### PR TITLE
refactor(hooks): collapse the two hook-handler constructors per adapter

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -156,7 +156,10 @@ Before marking a ticket done, run the full suite — every layer must pass:
   — the handler together with the confiner it actually uses — so the counter
   the contract reads is taken off the handler under test, and "this handler
   confines" and "the counter proving it" stop being two objects that could
-  disagree. A contract that grows a sub-test to police an API the same PR
+  disagree. `HookReceiverUnderTest.Handler` is typed as that concrete struct
+  rather than `http.Handler`, and the count is derived from it rather than
+  declared beside it, so the wiring cannot name two different confiners even
+  by accident. A contract that grows a sub-test to police an API the same PR
   invented is a signal to remove the API, not to test it. What obligation 6
   never covered, and still does not, is an adapter wiring `New` to a hand-rolled
   handler instead of its constructor — `NewProduction` was adapter-supplied too.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -142,11 +142,24 @@ Before marking a ticket done, run the full suite — every layer must pass:
   inbound hook body is caller-supplied on a local, unauthenticated endpoint, so
   a receiver confines it to the adapter's own declared transcript roots
   (`agent.Source`'s `FilesUnderRoot.AllRootsFor`, never a second list that can
-  drift) before anything downstream opens it. Six obligations: an in-tree path
-  is still accepted (the vacuity guard); an out-of-tree path, a `..` traversal,
-  a symlink planted inside the root and a *dangling* symlink inside the root
-  are each refused, logged and counted; and the adapter's production
-  constructor confines, not merely the handler the test assembled.
+  drift) before anything downstream opens it. Five obligations: an in-tree path
+  is still accepted (the vacuity guard); and an out-of-tree path, a `..`
+  traversal, a symlink planted inside the root and a *dangling* symlink inside
+  the root are each refused, logged and counted.
+  A sixth — "the adapter's production constructor confines, not merely the
+  handler the test assembled" — was retired in #1390, and how it went is the
+  point rather than that it went. It existed because reaching the rejection
+  counter meant calling a second, test-shaped constructor
+  (`NewHookHandlerWithConfiner` and friends), so the handler the other five
+  obligations ran against was not provably the one the daemon builds. Each
+  receiver now has ONE exported constructor returning a `hookjson.HookHandler`
+  — the handler together with the confiner it actually uses — so the counter
+  the contract reads is taken off the handler under test, and "this handler
+  confines" and "the counter proving it" stop being two objects that could
+  disagree. A contract that grows a sub-test to police an API the same PR
+  invented is a signal to remove the API, not to test it. What obligation 6
+  never covered, and still does not, is an adapter wiring `New` to a hand-rolled
+  handler instead of its constructor — `NewProduction` was adapter-supplied too.
   Two are load-bearing and neither is obvious. **Symlinks are resolved BEFORE
   the containment check** — a guard with that order reversed passes every
   lexical traversal test and confines nothing (#1361, where claudecode

--- a/core/adapters/inbound/agents/claudecode/hookpath_test.go
+++ b/core/adapters/inbound/agents/claudecode/hookpath_test.go
@@ -50,19 +50,11 @@ func TestHookPathConfined(t *testing.T) {
 		New: func(t *testing.T) contracttesting.HookReceiverUnderTest {
 			t.Helper()
 			target := &mockTarget{}
-			confiner := TranscriptConfiner()
+			h := NewHookHandler(target, nil, nil, mockLogger{})
 			return contracttesting.HookReceiverUnderTest{
-				Handler:    NewHookHandlerWithConfiner(target, nil, nil, mockLogger{}, confiner),
+				Handler:    h,
 				Observed:   func() bool { return len(target.getCalls()) > 0 },
-				Rejections: confiner.RejectionCount,
-			}
-		},
-		NewProduction: func(t *testing.T) contracttesting.HookReceiverUnderTest {
-			t.Helper()
-			target := &mockTarget{}
-			return contracttesting.HookReceiverUnderTest{
-				Handler:  NewHookHandler(target, nil, nil, mockLogger{}),
-				Observed: func() bool { return len(target.getCalls()) > 0 },
+				Rejections: h.Confiner.RejectionCount,
 			}
 		},
 		PayloadFor: func(transcriptPath string) string {
@@ -92,19 +84,11 @@ func TestStatuslinePathConfined(t *testing.T) {
 		New: func(t *testing.T) contracttesting.HookReceiverUnderTest {
 			t.Helper()
 			target := &fakeRateLimitIngester{}
-			confiner := TranscriptConfiner()
+			h := NewStatuslineHandler(target, nil, silentLogger{})
 			return contracttesting.HookReceiverUnderTest{
-				Handler:    NewStatuslineHandlerWithConfiner(target, nil, silentLogger{}, confiner),
+				Handler:    h,
 				Observed:   func() bool { return len(target.calls) > 0 },
-				Rejections: confiner.RejectionCount,
-			}
-		},
-		NewProduction: func(t *testing.T) contracttesting.HookReceiverUnderTest {
-			t.Helper()
-			target := &fakeRateLimitIngester{}
-			return contracttesting.HookReceiverUnderTest{
-				Handler:  NewStatuslineHandler(target, nil, silentLogger{}),
-				Observed: func() bool { return len(target.calls) > 0 },
+				Rejections: h.Confiner.RejectionCount,
 			}
 		},
 		// A rate_limits block is required or the handler acks and returns

--- a/core/adapters/inbound/agents/claudecode/hookpath_test.go
+++ b/core/adapters/inbound/agents/claudecode/hookpath_test.go
@@ -50,9 +50,8 @@ func TestHookPathConfined(t *testing.T) {
 		New: func(t *testing.T) contracttesting.HookReceiverUnderTest {
 			t.Helper()
 			target := &mockTarget{}
-			h := NewHookHandler(target, nil, nil, mockLogger{})
 			return contracttesting.HookReceiverUnderTest{
-				Handler:  h,
+				Handler:  NewHookHandler(target, nil, nil, mockLogger{}),
 				Observed: func() bool { return len(target.getCalls()) > 0 },
 			}
 		},
@@ -83,9 +82,8 @@ func TestStatuslinePathConfined(t *testing.T) {
 		New: func(t *testing.T) contracttesting.HookReceiverUnderTest {
 			t.Helper()
 			target := &fakeRateLimitIngester{}
-			h := NewStatuslineHandler(target, nil, silentLogger{})
 			return contracttesting.HookReceiverUnderTest{
-				Handler:  h,
+				Handler:  NewStatuslineHandler(target, nil, silentLogger{}),
 				Observed: func() bool { return len(target.calls) > 0 },
 			}
 		},

--- a/core/adapters/inbound/agents/claudecode/hookpath_test.go
+++ b/core/adapters/inbound/agents/claudecode/hookpath_test.go
@@ -52,9 +52,8 @@ func TestHookPathConfined(t *testing.T) {
 			target := &mockTarget{}
 			h := NewHookHandler(target, nil, nil, mockLogger{})
 			return contracttesting.HookReceiverUnderTest{
-				Handler:    h,
-				Observed:   func() bool { return len(target.getCalls()) > 0 },
-				Rejections: h.Confiner.RejectionCount,
+				Handler:  h,
+				Observed: func() bool { return len(target.getCalls()) > 0 },
 			}
 		},
 		PayloadFor: func(transcriptPath string) string {
@@ -86,9 +85,8 @@ func TestStatuslinePathConfined(t *testing.T) {
 			target := &fakeRateLimitIngester{}
 			h := NewStatuslineHandler(target, nil, silentLogger{})
 			return contracttesting.HookReceiverUnderTest{
-				Handler:    h,
-				Observed:   func() bool { return len(target.calls) > 0 },
-				Rejections: h.Confiner.RejectionCount,
+				Handler:  h,
+				Observed: func() bool { return len(target.calls) > 0 },
 			}
 		},
 		// A rate_limits block is required or the handler acks and returns

--- a/core/adapters/inbound/agents/claudecode/hookreceipt_test.go
+++ b/core/adapters/inbound/agents/claudecode/hookreceipt_test.go
@@ -23,11 +23,11 @@ func TestHookReceiptObserved(t *testing.T) {
 		WriteTranscript: writeContractTranscript,
 		New: func(t *testing.T, log outbound.Logger) http.Handler {
 			t.Helper()
-			return NewHookHandlerWithConfiner(&mockTarget{}, nil, fakeGate(true), log, TranscriptConfiner())
+			return NewHookHandler(&mockTarget{}, nil, fakeGate(true), log)
 		},
 		NewDenied: func(t *testing.T, log outbound.Logger) http.Handler {
 			t.Helper()
-			return NewHookHandlerWithConfiner(&mockTarget{}, nil, fakeGate(false), log, TranscriptConfiner())
+			return NewHookHandler(&mockTarget{}, nil, fakeGate(false), log)
 		},
 		PayloadFor:   contractPayload,
 		KnownEvent:   HookPermissionRequest,

--- a/core/adapters/inbound/agents/claudecode/hooks.go
+++ b/core/adapters/inbound/agents/claudecode/hooks.go
@@ -240,7 +240,7 @@ func sessionIDFromTranscriptPath(p string) string {
 // the payload is dropped with 200 (so the curl hook stays quiet). A nil
 // gate means no gating — used by tests.
 func NewHookHandler(target HookTarget, markers MarkerTarget, gate ConsentGranter, log outbound.Logger) hookjson.HookHandler {
-	confiner := TranscriptConfiner()
+	confiner := transcriptConfiner()
 	return hookjson.HookHandler{
 		HandlerFunc: func(w http.ResponseWriter, r *http.Request) {
 			serveHookRequest(target, markers, gate, log, confiner, w, r)
@@ -249,11 +249,11 @@ func NewHookHandler(target HookTarget, markers MarkerTarget, gate ConsentGranter
 	}
 }
 
-// TranscriptConfiner returns the confiner this adapter's hook receiver guards
+// transcriptConfiner returns the confiner this adapter's hook receiver guards
 // caller-supplied transcript paths with, rooted in the adapter's own
 // agent.Source declaration so it cannot drift from the tree the daemon watches
 // (issue #1361).
-func TranscriptConfiner() *hookjson.PathConfiner {
+func transcriptConfiner() *hookjson.PathConfiner {
 	return hookjson.ConfinerForSource(Source, runtime.GOOS, transcriptExt)
 }
 

--- a/core/adapters/inbound/agents/claudecode/hooks.go
+++ b/core/adapters/inbound/agents/claudecode/hooks.go
@@ -221,9 +221,10 @@ func sessionIDFromTranscriptPath(p string) string {
 	return strings.TrimSuffix(filepath.Base(p), transcriptExt)
 }
 
-// NewHookHandler returns an http.HandlerFunc that receives Claude Code
-// hook events (PermissionRequest, PostToolUse, PostToolUseFailure) and
-// dispatches them to the target.
+// NewHookHandler returns the hook receiver for Claude Code hook events
+// (PermissionRequest, PostToolUse, PostToolUseFailure), which dispatches them
+// to the target. The returned hookjson.HookHandler is an http.Handler carrying
+// the confiner it guards caller-supplied transcript paths with (issue #1390).
 //
 // The handler returns 200 with an empty body for recognized events. For
 // PermissionRequest, an empty response means Claude Code shows its normal
@@ -238,8 +239,14 @@ func sessionIDFromTranscriptPath(p string) string {
 // gate is the consent check for the "hooks" permission; while not granted
 // the payload is dropped with 200 (so the curl hook stays quiet). A nil
 // gate means no gating — used by tests.
-func NewHookHandler(target HookTarget, markers MarkerTarget, gate ConsentGranter, log outbound.Logger) http.HandlerFunc {
-	return NewHookHandlerWithConfiner(target, markers, gate, log, TranscriptConfiner())
+func NewHookHandler(target HookTarget, markers MarkerTarget, gate ConsentGranter, log outbound.Logger) hookjson.HookHandler {
+	confiner := TranscriptConfiner()
+	return hookjson.HookHandler{
+		HandlerFunc: func(w http.ResponseWriter, r *http.Request) {
+			serveHookRequest(target, markers, gate, log, confiner, w, r)
+		},
+		Confiner: confiner,
+	}
 }
 
 // TranscriptConfiner returns the confiner this adapter's hook receiver guards
@@ -248,15 +255,6 @@ func NewHookHandler(target HookTarget, markers MarkerTarget, gate ConsentGranter
 // (issue #1361).
 func TranscriptConfiner() *hookjson.PathConfiner {
 	return hookjson.ConfinerForSource(Source, runtime.GOOS, transcriptExt)
-}
-
-// NewHookHandlerWithConfiner is NewHookHandler with an explicit confiner, for
-// tests that need to drive a receiver rooted somewhere other than the real
-// transcript tree and to read back what it refused.
-func NewHookHandlerWithConfiner(target HookTarget, markers MarkerTarget, gate ConsentGranter, log outbound.Logger, confiner *hookjson.PathConfiner) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		serveHookRequest(target, markers, gate, log, confiner, w, r)
-	}
 }
 
 // serveHookRequest is NewHookHandler's request logic, pulled out of the

--- a/core/adapters/inbound/agents/claudecode/hooks.go
+++ b/core/adapters/inbound/agents/claudecode/hooks.go
@@ -240,13 +240,10 @@ func sessionIDFromTranscriptPath(p string) string {
 // the payload is dropped with 200 (so the curl hook stays quiet). A nil
 // gate means no gating — used by tests.
 func NewHookHandler(target HookTarget, markers MarkerTarget, gate ConsentGranter, log outbound.Logger) hookjson.HookHandler {
-	confiner := transcriptConfiner()
-	return hookjson.HookHandler{
-		HandlerFunc: func(w http.ResponseWriter, r *http.Request) {
-			serveHookRequest(target, markers, gate, log, confiner, w, r)
-		},
-		Confiner: confiner,
-	}
+	return hookjson.NewHandler(transcriptConfiner(),
+		func(c *hookjson.PathConfiner, w http.ResponseWriter, r *http.Request) {
+			serveHookRequest(target, markers, gate, log, c, w, r)
+		})
 }
 
 // transcriptConfiner returns the confiner this adapter's hook receiver guards

--- a/core/adapters/inbound/agents/claudecode/hooks_test.go
+++ b/core/adapters/inbound/agents/claudecode/hooks_test.go
@@ -136,7 +136,7 @@ func TestHookHandler_PermissionRequest(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/hooks/claudecode", bytes.NewReader(body))
 	rec := httptest.NewRecorder()
-	handler(rec, req)
+	handler.ServeHTTP(rec, req)
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
@@ -168,7 +168,7 @@ func TestHookHandler_PostToolUse(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/hooks/claudecode", bytes.NewReader(body))
 	rec := httptest.NewRecorder()
-	handler(rec, req)
+	handler.ServeHTTP(rec, req)
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
@@ -193,7 +193,7 @@ func TestHookHandler_PreToolUse(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/hooks/claudecode", bytes.NewReader(body))
 	rec := httptest.NewRecorder()
-	handler(rec, req)
+	handler.ServeHTTP(rec, req)
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
@@ -228,7 +228,7 @@ func TestHookHandler_PreToolUse_RejectsUnexpectedTool(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/hooks/claudecode", bytes.NewReader(body))
 	rec := httptest.NewRecorder()
-	handler(rec, req)
+	handler.ServeHTTP(rec, req)
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d, want %d (handler should accept but ignore)", rec.Code, http.StatusOK)
@@ -254,7 +254,7 @@ func TestHookHandler_PreCompactManual(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/hooks/claudecode", bytes.NewReader(body))
 	rec := httptest.NewRecorder()
-	handler(rec, req)
+	handler.ServeHTTP(rec, req)
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
@@ -290,7 +290,7 @@ func TestHookHandler_PreCompactAuto(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/hooks/claudecode", bytes.NewReader(body))
 	rec := httptest.NewRecorder()
-	handler(rec, req)
+	handler.ServeHTTP(rec, req)
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d, want %d (accept but ignore)", rec.Code, http.StatusOK)
@@ -317,7 +317,7 @@ func TestHookHandler_Stop(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/hooks/claudecode", bytes.NewReader(body))
 	rec := httptest.NewRecorder()
-	handler(rec, req)
+	handler.ServeHTTP(rec, req)
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
@@ -357,7 +357,7 @@ func TestHookHandler_StopEndingInQuestion(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/hooks/claudecode", bytes.NewReader(body))
 	rec := httptest.NewRecorder()
-	handler(rec, req)
+	handler.ServeHTTP(rec, req)
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
@@ -458,7 +458,7 @@ func TestHookHandler_PostToolUseFailure(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/hooks/claudecode", bytes.NewReader(body))
 	rec := httptest.NewRecorder()
-	handler(rec, req)
+	handler.ServeHTTP(rec, req)
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
@@ -482,7 +482,7 @@ func TestHookHandler_UnrecognizedEvent(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/hooks/claudecode", bytes.NewReader(body))
 	rec := httptest.NewRecorder()
-	handler(rec, req)
+	handler.ServeHTTP(rec, req)
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
@@ -504,7 +504,7 @@ func TestHookHandler_MissingTranscriptPath(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/hooks/claudecode", bytes.NewReader(body))
 	rec := httptest.NewRecorder()
-	handler(rec, req)
+	handler.ServeHTTP(rec, req)
 
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("status = %d, want %d", rec.Code, http.StatusBadRequest)
@@ -517,7 +517,7 @@ func TestHookHandler_WrongMethod(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/hooks/claudecode", nil)
 	rec := httptest.NewRecorder()
-	handler(rec, req)
+	handler.ServeHTTP(rec, req)
 
 	if rec.Code != http.StatusMethodNotAllowed {
 		t.Fatalf("status = %d, want %d", rec.Code, http.StatusMethodNotAllowed)
@@ -530,7 +530,7 @@ func TestHookHandler_MalformedJSON(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/hooks/claudecode", bytes.NewReader([]byte("not json")))
 	rec := httptest.NewRecorder()
-	handler(rec, req)
+	handler.ServeHTTP(rec, req)
 
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("status = %d, want %d", rec.Code, http.StatusBadRequest)
@@ -574,7 +574,7 @@ func TestHookHandler_ConsentGateDropsWhenNotGranted(t *testing.T) {
 	body, _ := json.Marshal(payload)
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/hooks/claudecode", bytes.NewReader(body))
 	rec := httptest.NewRecorder()
-	handler(rec, req)
+	handler.ServeHTTP(rec, req)
 
 	// 200 keeps the curl hook quiet, but nothing is dispatched.
 	if rec.Code != http.StatusOK {
@@ -597,7 +597,7 @@ func TestHookHandler_ConsentGatePassesWhenGranted(t *testing.T) {
 	body, _ := json.Marshal(payload)
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/hooks/claudecode", bytes.NewReader(body))
 	rec := httptest.NewRecorder()
-	handler(rec, req)
+	handler.ServeHTTP(rec, req)
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d, want 200", rec.Code)
@@ -650,12 +650,12 @@ func (m *mockMarkerTarget) getSummaries() []summaryCall {
 	return append([]summaryCall{}, m.summaries...)
 }
 
-func postHook(t *testing.T, handler http.HandlerFunc, payload hookPayload) *httptest.ResponseRecorder {
+func postHook(t *testing.T, handler http.Handler, payload hookPayload) *httptest.ResponseRecorder {
 	t.Helper()
 	body, _ := json.Marshal(payload)
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/hooks/claudecode", bytes.NewReader(body))
 	rec := httptest.NewRecorder()
-	handler(rec, req)
+	handler.ServeHTTP(rec, req)
 	return rec
 }
 

--- a/core/adapters/inbound/agents/claudecode/hookunknown_test.go
+++ b/core/adapters/inbound/agents/claudecode/hookunknown_test.go
@@ -20,7 +20,7 @@ func TestUnknownHookEventObserved(t *testing.T) {
 			t.Helper()
 			target := &mockTarget{}
 			return contracttesting.UnknownEventReceiverUnderTest{
-				Handler:  NewHookHandlerWithConfiner(target, nil, nil, log, TranscriptConfiner()),
+				Handler:  NewHookHandler(target, nil, nil, log),
 				Observed: func() bool { return len(target.getCalls()) > 0 },
 			}
 		},

--- a/core/adapters/inbound/agents/claudecode/statusline.go
+++ b/core/adapters/inbound/agents/claudecode/statusline.go
@@ -76,14 +76,11 @@ const logComponentStatuslineReceiver = "statusline-receiver"
 // gate is the consent check for the "statusline" permission; while not
 // granted the payload is dropped with 200. A nil gate means no gating —
 // used by tests.
-func NewStatuslineHandler(target RateLimitIngester, gate ConsentGranter, log outbound.Logger) http.HandlerFunc {
-	return NewStatuslineHandlerWithConfiner(target, gate, log, TranscriptConfiner())
-}
-
-// NewStatuslineHandlerWithConfiner is NewStatuslineHandler with an explicit
-// confiner, for tests that drive the receiver against a temp root.
-func NewStatuslineHandlerWithConfiner(target RateLimitIngester, gate ConsentGranter, log outbound.Logger, confiner *hookjson.PathConfiner) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
+// The returned hookjson.HookHandler is an http.Handler carrying the confiner it
+// guards caller-supplied transcript paths with (issue #1390).
+func NewStatuslineHandler(target RateLimitIngester, gate ConsentGranter, log outbound.Logger) hookjson.HookHandler {
+	confiner := TranscriptConfiner()
+	return hookjson.HookHandler{Confiner: confiner, HandlerFunc: func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 			return
@@ -126,7 +123,7 @@ func NewStatuslineHandlerWithConfiner(target RateLimitIngester, gate ConsentGran
 		target.IngestRateLimit(payload.TranscriptPath, snap)
 		log.LogInfo(logComponentStatuslineReceiver, sessionID, "ingested rate-limit snapshot")
 		w.WriteHeader(http.StatusOK)
-	}
+	}}
 }
 
 // statuslineToSnapshot converts Claude Code's two-window statusline payload

--- a/core/adapters/inbound/agents/claudecode/statusline.go
+++ b/core/adapters/inbound/agents/claudecode/statusline.go
@@ -73,57 +73,69 @@ const logComponentStatuslineReceiver = "statusline-receiver"
 // the appropriate 4xx. It never blocks: target.IngestRateLimit is a no-op
 // when the session hasn't been seen yet, so the handler returns immediately.
 //
+// The returned hookjson.HookHandler is an http.Handler carrying the confiner it
+// guards caller-supplied transcript paths with (issue #1390).
+//
 // gate is the consent check for the "statusline" permission; while not
 // granted the payload is dropped with 200. A nil gate means no gating —
 // used by tests.
-// The returned hookjson.HookHandler is an http.Handler carrying the confiner it
-// guards caller-supplied transcript paths with (issue #1390).
 func NewStatuslineHandler(target RateLimitIngester, gate ConsentGranter, log outbound.Logger) hookjson.HookHandler {
-	confiner := TranscriptConfiner()
-	return hookjson.HookHandler{Confiner: confiner, HandlerFunc: func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodPost {
-			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
-			return
-		}
+	confiner := transcriptConfiner()
+	return hookjson.HookHandler{
+		HandlerFunc: func(w http.ResponseWriter, r *http.Request) {
+			serveStatuslineRequest(target, gate, log, confiner, w, r)
+		},
+		Confiner: confiner,
+	}
+}
 
-		if gate != nil && !gate.Granted(AdapterName, PermissionKeyStatusline) {
-			w.WriteHeader(http.StatusOK)
-			return
-		}
+// serveStatuslineRequest is NewStatuslineHandler's request logic, pulled out of
+// the returned closure so the constructor reads like its two siblings in
+// hooks.go and the branching isn't counted at the closure's extra nesting
+// depth.
+func serveStatuslineRequest(target RateLimitIngester, gate ConsentGranter, log outbound.Logger, confiner *hookjson.PathConfiner, w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
 
-		var payload statuslinePayload
-		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
-			http.Error(w, "bad request: invalid JSON", http.StatusBadRequest)
-			return
-		}
-
-		// The statusline endpoint sits on the same local, unauthenticated mux
-		// as the hook receivers and takes the same caller-supplied path, so it
-		// is confined by the same rule (issue #1361). Its sink is a map lookup
-		// rather than an open, so this is not an arbitrary-read guard — it is
-		// what keeps this receiver keying the tailer map with the SAME spelling
-		// the hook receiver now uses. Two spellings of one file are two
-		// sessions, and the rate-limit snapshot would land on neither.
-		transcriptPath, reason := confiner.Confine(payload.TranscriptPath)
-		if reason != hookjson.RejectNone {
-			hookjson.RejectPath(w, log, logComponentStatuslineReceiver, payload.TranscriptPath, reason)
-			return
-		}
-		payload.TranscriptPath = transcriptPath
-
-		sessionID := sessionIDFromTranscriptPath(transcriptPath)
-		snap := statuslineToSnapshot(payload.RateLimits)
-		if snap == nil {
-			// API-key / Bedrock / Vertex users — nothing to record. Ack and move on.
-			log.LogInfo(logComponentStatuslineReceiver, sessionID, "received statusline tick with no rate_limits block")
-			w.WriteHeader(http.StatusOK)
-			return
-		}
-
-		target.IngestRateLimit(payload.TranscriptPath, snap)
-		log.LogInfo(logComponentStatuslineReceiver, sessionID, "ingested rate-limit snapshot")
+	if gate != nil && !gate.Granted(AdapterName, PermissionKeyStatusline) {
 		w.WriteHeader(http.StatusOK)
-	}}
+		return
+	}
+
+	var payload statuslinePayload
+	if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+		http.Error(w, "bad request: invalid JSON", http.StatusBadRequest)
+		return
+	}
+
+	// The statusline endpoint sits on the same local, unauthenticated mux
+	// as the hook receivers and takes the same caller-supplied path, so it
+	// is confined by the same rule (issue #1361). Its sink is a map lookup
+	// rather than an open, so this is not an arbitrary-read guard — it is
+	// what keeps this receiver keying the tailer map with the SAME spelling
+	// the hook receiver now uses. Two spellings of one file are two
+	// sessions, and the rate-limit snapshot would land on neither.
+	transcriptPath, reason := confiner.Confine(payload.TranscriptPath)
+	if reason != hookjson.RejectNone {
+		hookjson.RejectPath(w, log, logComponentStatuslineReceiver, payload.TranscriptPath, reason)
+		return
+	}
+	payload.TranscriptPath = transcriptPath
+
+	sessionID := sessionIDFromTranscriptPath(transcriptPath)
+	snap := statuslineToSnapshot(payload.RateLimits)
+	if snap == nil {
+		// API-key / Bedrock / Vertex users — nothing to record. Ack and move on.
+		log.LogInfo(logComponentStatuslineReceiver, sessionID, "received statusline tick with no rate_limits block")
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
+	target.IngestRateLimit(payload.TranscriptPath, snap)
+	log.LogInfo(logComponentStatuslineReceiver, sessionID, "ingested rate-limit snapshot")
+	w.WriteHeader(http.StatusOK)
 }
 
 // statuslineToSnapshot converts Claude Code's two-window statusline payload

--- a/core/adapters/inbound/agents/claudecode/statusline.go
+++ b/core/adapters/inbound/agents/claudecode/statusline.go
@@ -80,13 +80,10 @@ const logComponentStatuslineReceiver = "statusline-receiver"
 // granted the payload is dropped with 200. A nil gate means no gating —
 // used by tests.
 func NewStatuslineHandler(target RateLimitIngester, gate ConsentGranter, log outbound.Logger) hookjson.HookHandler {
-	confiner := transcriptConfiner()
-	return hookjson.HookHandler{
-		HandlerFunc: func(w http.ResponseWriter, r *http.Request) {
-			serveStatuslineRequest(target, gate, log, confiner, w, r)
-		},
-		Confiner: confiner,
-	}
+	return hookjson.NewHandler(transcriptConfiner(),
+		func(c *hookjson.PathConfiner, w http.ResponseWriter, r *http.Request) {
+			serveStatuslineRequest(target, gate, log, c, w, r)
+		})
 }
 
 // serveStatuslineRequest is NewStatuslineHandler's request logic, pulled out of

--- a/core/adapters/inbound/agents/claudecode/statusline_test.go
+++ b/core/adapters/inbound/agents/claudecode/statusline_test.go
@@ -53,7 +53,7 @@ func TestStatuslineHandler_IngestsRateLimits(t *testing.T) {
 	}`
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/api/v1/hooks/claudecode/statusline", bytes.NewBufferString(body))
 	rr := httptest.NewRecorder()
-	h(rr, req)
+	h.ServeHTTP(rr, req)
 
 	if rr.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d (%s)", rr.Code, rr.Body.String())
@@ -83,7 +83,7 @@ func TestStatuslineHandler_NoRateLimitsBlockIsOk(t *testing.T) {
 	body := `{"session_id":"abc","transcript_path":"` + inTreeTranscript(t, "abc") + `"}`
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/x", bytes.NewBufferString(body))
 	rr := httptest.NewRecorder()
-	h(rr, req)
+	h.ServeHTTP(rr, req)
 
 	if rr.Code != http.StatusOK {
 		t.Fatalf("expected 200 for API-key path (no rate_limits), got %d", rr.Code)
@@ -98,7 +98,7 @@ func TestStatuslineHandler_RejectsMissingTranscriptPath(t *testing.T) {
 	body := `{"session_id":"abc"}`
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/x", bytes.NewBufferString(body))
 	rr := httptest.NewRecorder()
-	h(rr, req)
+	h.ServeHTTP(rr, req)
 	if rr.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400, got %d", rr.Code)
 	}
@@ -108,7 +108,7 @@ func TestStatuslineHandler_RejectsNonPost(t *testing.T) {
 	h := NewStatuslineHandler(&fakeRateLimitIngester{}, nil, silentLogger{})
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/x", nil)
 	rr := httptest.NewRecorder()
-	h(rr, req)
+	h.ServeHTTP(rr, req)
 	if rr.Code != http.StatusMethodNotAllowed {
 		t.Fatalf("expected 405, got %d", rr.Code)
 	}
@@ -125,7 +125,7 @@ func TestStatuslineHandler_SampledAtUsesClock(t *testing.T) {
 	body := `{"transcript_path":"` + inTreeTranscript(t, "x") + `","rate_limits":{"five_hour":{"used_percentage":1,"resets_at":2}}}`
 	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/x", bytes.NewBufferString(body))
 	rr := httptest.NewRecorder()
-	h(rr, req)
+	h.ServeHTTP(rr, req)
 
 	if rr.Code != http.StatusOK {
 		t.Fatal(rr.Body.String())
@@ -279,7 +279,7 @@ func TestStatuslineHandler_ConsentGateDropsWhenNotGranted(t *testing.T) {
 	}`
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/hooks/claudecode/statusline", strings.NewReader(body))
 	rec := httptest.NewRecorder()
-	h(rec, req)
+	h.ServeHTTP(rec, req)
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d, want 200", rec.Code)
@@ -312,7 +312,7 @@ func TestStatuslineHandler_PermissionGateContract(t *testing.T) {
 			target.reset()
 			req := httptest.NewRequest(http.MethodPost, "/api/v1/hooks/claudecode/statusline", strings.NewReader(body))
 			rec := httptest.NewRecorder()
-			h(rec, req)
+			h.ServeHTTP(rec, req)
 			if rec.Code != http.StatusOK {
 				t.Fatalf("status = %d, want 200", rec.Code)
 			}

--- a/core/adapters/inbound/agents/codex/hookpath_test.go
+++ b/core/adapters/inbound/agents/codex/hookpath_test.go
@@ -56,19 +56,11 @@ func TestHookPathConfined(t *testing.T) {
 		New: func(t *testing.T) contracttesting.HookReceiverUnderTest {
 			t.Helper()
 			target := &mockTarget{}
-			confiner := TranscriptConfiner()
+			h := NewHookHandler(target, nil, mockLogger{})
 			return contracttesting.HookReceiverUnderTest{
-				Handler:    NewHookHandlerWithConfiner(target, nil, mockLogger{}, confiner),
+				Handler:    h,
 				Observed:   func() bool { return target.totalCalls() > 0 },
-				Rejections: confiner.RejectionCount,
-			}
-		},
-		NewProduction: func(t *testing.T) contracttesting.HookReceiverUnderTest {
-			t.Helper()
-			target := &mockTarget{}
-			return contracttesting.HookReceiverUnderTest{
-				Handler:  NewHookHandler(target, nil, mockLogger{}),
-				Observed: func() bool { return target.totalCalls() > 0 },
+				Rejections: h.Confiner.RejectionCount,
 			}
 		},
 		WriteTranscript: writeContractTranscript,

--- a/core/adapters/inbound/agents/codex/hookpath_test.go
+++ b/core/adapters/inbound/agents/codex/hookpath_test.go
@@ -56,9 +56,8 @@ func TestHookPathConfined(t *testing.T) {
 		New: func(t *testing.T) contracttesting.HookReceiverUnderTest {
 			t.Helper()
 			target := &mockTarget{}
-			h := NewHookHandler(target, nil, mockLogger{})
 			return contracttesting.HookReceiverUnderTest{
-				Handler:  h,
+				Handler:  NewHookHandler(target, nil, mockLogger{}),
 				Observed: func() bool { return target.totalCalls() > 0 },
 			}
 		},

--- a/core/adapters/inbound/agents/codex/hookpath_test.go
+++ b/core/adapters/inbound/agents/codex/hookpath_test.go
@@ -58,9 +58,8 @@ func TestHookPathConfined(t *testing.T) {
 			target := &mockTarget{}
 			h := NewHookHandler(target, nil, mockLogger{})
 			return contracttesting.HookReceiverUnderTest{
-				Handler:    h,
-				Observed:   func() bool { return target.totalCalls() > 0 },
-				Rejections: h.Confiner.RejectionCount,
+				Handler:  h,
+				Observed: func() bool { return target.totalCalls() > 0 },
 			}
 		},
 		WriteTranscript: writeContractTranscript,

--- a/core/adapters/inbound/agents/codex/hookreceipt_test.go
+++ b/core/adapters/inbound/agents/codex/hookreceipt_test.go
@@ -25,12 +25,12 @@ func TestHookReceiptObserved(t *testing.T) {
 		WriteTranscript: writeContractTranscript,
 		New: func(t *testing.T, log outbound.Logger) http.Handler {
 			t.Helper()
-			return NewHookHandlerWithConfiner(&mockTarget{},
-				keyedGate{PermissionKeyHooks: true, PermissionKeyTranscripts: true}, log, TranscriptConfiner())
+			return NewHookHandler(&mockTarget{},
+				keyedGate{PermissionKeyHooks: true, PermissionKeyTranscripts: true}, log)
 		},
 		NewDenied: func(t *testing.T, log outbound.Logger) http.Handler {
 			t.Helper()
-			return NewHookHandlerWithConfiner(&mockTarget{}, keyedGate{}, log, TranscriptConfiner())
+			return NewHookHandler(&mockTarget{}, keyedGate{}, log)
 		},
 		PayloadFor:   contractPayload,
 		KnownEvent:   HookPermissionRequest,

--- a/core/adapters/inbound/agents/codex/hooks.go
+++ b/core/adapters/inbound/agents/codex/hooks.go
@@ -100,8 +100,16 @@ type ConsentGranter = hookjson.ConsentGranter
 // the session id reads the transcript file, so that read is additionally gated
 // behind the "transcripts" permission. A nil gate means no gating — used by
 // tests.
-func NewHookHandler(target HookTarget, gate ConsentGranter, log outbound.Logger) http.HandlerFunc {
-	return NewHookHandlerWithConfiner(target, gate, log, TranscriptConfiner())
+// The returned hookjson.HookHandler is an http.Handler carrying the confiner it
+// guards caller-supplied transcript paths with (issue #1390).
+func NewHookHandler(target HookTarget, gate ConsentGranter, log outbound.Logger) hookjson.HookHandler {
+	confiner := TranscriptConfiner()
+	return hookjson.HookHandler{
+		HandlerFunc: func(w http.ResponseWriter, r *http.Request) {
+			serveHookRequest(target, gate, log, confiner, w, r)
+		},
+		Confiner: confiner,
+	}
 }
 
 // TranscriptConfiner returns the confiner this adapter's hook receiver guards
@@ -111,15 +119,6 @@ func NewHookHandler(target HookTarget, gate ConsentGranter, log outbound.Logger)
 // constants and so could guard a different tree than the one being watched.
 func TranscriptConfiner() *hookjson.PathConfiner {
 	return hookjson.ConfinerForSource(Source, runtime.GOOS, transcriptExt)
-}
-
-// NewHookHandlerWithConfiner is NewHookHandler with an explicit confiner, for
-// tests that need to drive a receiver rooted somewhere other than the real
-// sessions tree and to read back what it refused.
-func NewHookHandlerWithConfiner(target HookTarget, gate ConsentGranter, log outbound.Logger, confiner *hookjson.PathConfiner) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		serveHookRequest(target, gate, log, confiner, w, r)
-	}
 }
 
 // serveHookRequest is NewHookHandler's request logic, pulled out of the

--- a/core/adapters/inbound/agents/codex/hooks.go
+++ b/core/adapters/inbound/agents/codex/hooks.go
@@ -88,8 +88,10 @@ type HookTarget interface {
 // shared the same way.
 type ConsentGranter = hookjson.ConsentGranter
 
-// NewHookHandler returns an http.HandlerFunc that receives Codex hook events
-// (PermissionRequest, PostToolUse, Stop) and dispatches them to the target.
+// NewHookHandler returns the hook receiver for Codex hook events
+// (PermissionRequest, PostToolUse, Stop), which dispatches them to the target.
+// The returned hookjson.HookHandler is an http.Handler carrying the confiner it
+// guards caller-supplied transcript paths with (issue #1390).
 //
 // The handler returns 200 with an empty body for recognized events. For
 // PermissionRequest, an empty response means Codex shows its normal approval
@@ -100,10 +102,8 @@ type ConsentGranter = hookjson.ConsentGranter
 // the session id reads the transcript file, so that read is additionally gated
 // behind the "transcripts" permission. A nil gate means no gating — used by
 // tests.
-// The returned hookjson.HookHandler is an http.Handler carrying the confiner it
-// guards caller-supplied transcript paths with (issue #1390).
 func NewHookHandler(target HookTarget, gate ConsentGranter, log outbound.Logger) hookjson.HookHandler {
-	confiner := TranscriptConfiner()
+	confiner := transcriptConfiner()
 	return hookjson.HookHandler{
 		HandlerFunc: func(w http.ResponseWriter, r *http.Request) {
 			serveHookRequest(target, gate, log, confiner, w, r)
@@ -112,12 +112,12 @@ func NewHookHandler(target HookTarget, gate ConsentGranter, log outbound.Logger)
 	}
 }
 
-// TranscriptConfiner returns the confiner this adapter's hook receiver guards
+// transcriptConfiner returns the confiner this adapter's hook receiver guards
 // caller-supplied transcript paths with, rooted in the adapter's own
 // agent.Source declaration (issue #1361). It replaces the adapter-local
 // confineToSessionsDir, which re-derived $CODEX_HOME/sessions from its own
 // constants and so could guard a different tree than the one being watched.
-func TranscriptConfiner() *hookjson.PathConfiner {
+func transcriptConfiner() *hookjson.PathConfiner {
 	return hookjson.ConfinerForSource(Source, runtime.GOOS, transcriptExt)
 }
 

--- a/core/adapters/inbound/agents/codex/hooks.go
+++ b/core/adapters/inbound/agents/codex/hooks.go
@@ -103,13 +103,10 @@ type ConsentGranter = hookjson.ConsentGranter
 // behind the "transcripts" permission. A nil gate means no gating — used by
 // tests.
 func NewHookHandler(target HookTarget, gate ConsentGranter, log outbound.Logger) hookjson.HookHandler {
-	confiner := transcriptConfiner()
-	return hookjson.HookHandler{
-		HandlerFunc: func(w http.ResponseWriter, r *http.Request) {
-			serveHookRequest(target, gate, log, confiner, w, r)
-		},
-		Confiner: confiner,
-	}
+	return hookjson.NewHandler(transcriptConfiner(),
+		func(c *hookjson.PathConfiner, w http.ResponseWriter, r *http.Request) {
+			serveHookRequest(target, gate, log, c, w, r)
+		})
 }
 
 // transcriptConfiner returns the confiner this adapter's hook receiver guards

--- a/core/adapters/inbound/agents/codex/hooks_test.go
+++ b/core/adapters/inbound/agents/codex/hooks_test.go
@@ -139,7 +139,7 @@ func writeRolloutInto(t *testing.T, dir, id string) string {
 	return path
 }
 
-func postHook(t *testing.T, handler http.HandlerFunc, payload codexHookPayload) *httptest.ResponseRecorder {
+func postHook(t *testing.T, handler http.Handler, payload codexHookPayload) *httptest.ResponseRecorder {
 	t.Helper()
 	body, err := json.Marshal(payload)
 	if err != nil {
@@ -147,7 +147,7 @@ func postHook(t *testing.T, handler http.HandlerFunc, payload codexHookPayload) 
 	}
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/hooks/codex", bytes.NewReader(body))
 	rec := httptest.NewRecorder()
-	handler(rec, req)
+	handler.ServeHTTP(rec, req)
 	return rec
 }
 
@@ -262,7 +262,7 @@ func TestHookHandler_MethodNotAllowed(t *testing.T) {
 	handler := NewHookHandler(&mockTarget{}, nil, mockLogger{})
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/hooks/codex", nil)
 	rec := httptest.NewRecorder()
-	handler(rec, req)
+	handler.ServeHTTP(rec, req)
 	if rec.Code != http.StatusMethodNotAllowed {
 		t.Errorf("status: got %d, want 405", rec.Code)
 	}
@@ -273,7 +273,7 @@ func TestHookHandler_BadJSON(t *testing.T) {
 	handler := NewHookHandler(target, nil, mockLogger{})
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/hooks/codex", bytes.NewReader([]byte("{not json")))
 	rec := httptest.NewRecorder()
-	handler(rec, req)
+	handler.ServeHTTP(rec, req)
 	if rec.Code != http.StatusBadRequest {
 		t.Errorf("status: got %d, want 400", rec.Code)
 	}

--- a/core/adapters/inbound/agents/codex/hookunknown_test.go
+++ b/core/adapters/inbound/agents/codex/hookunknown_test.go
@@ -20,7 +20,7 @@ func TestUnknownHookEventObserved(t *testing.T) {
 			t.Helper()
 			target := &mockTarget{}
 			return contracttesting.UnknownEventReceiverUnderTest{
-				Handler:  NewHookHandlerWithConfiner(target, nil, log, TranscriptConfiner()),
+				Handler:  NewHookHandler(target, nil, log),
 				Observed: func() bool { return target.totalCalls() > 0 },
 			}
 		},

--- a/core/adapters/inbound/agents/copilot/hookdefaulthome_test.go
+++ b/core/adapters/inbound/agents/copilot/hookdefaulthome_test.go
@@ -32,9 +32,8 @@ func TestNotification_DispatchesWithDefaultHome(t *testing.T) {
 	want := writeSessionTranscript(t, root, "sess-default")
 
 	target := &mockTarget{}
-	confiner := TranscriptConfiner()
-	h := NewHookHandlerWithConfiner(target,
-		keyedGate{PermissionKeyHooks: true, PermissionKeyTranscripts: true}, mockLogger{}, confiner)
+	h := NewHookHandler(target,
+		keyedGate{PermissionKeyHooks: true, PermissionKeyTranscripts: true}, mockLogger{})
 
 	rec := post(t, h, notificationBody("sess-default", "permission_prompt"))
 	if rec.Code != http.StatusOK {
@@ -46,15 +45,15 @@ func TestNotification_DispatchesWithDefaultHome(t *testing.T) {
 		t.Fatalf("got %d permission dispatches with COPILOT_HOME unset, want 1 "+
 			"(confiner rejections: %v) — the reconstructed path must be absolute, or the "+
 			"permission-prompt half of the channel is dead for every default install",
-			len(perms), confiner.Rejections())
+			len(perms), h.Confiner.Rejections())
 	}
 	if perms[0].transcriptPath != want {
 		t.Errorf("transcriptPath = %q, want %q", perms[0].transcriptPath, want)
 	}
-	if n := confiner.RejectionCount(); n != 0 {
+	if n := h.Confiner.RejectionCount(); n != 0 {
 		t.Errorf("confiner counted %d rejection(s) for a legitimate prompt (%v) — this "+
 			"pollutes the counter whose purpose is to signal local probing",
-			n, confiner.Rejections())
+			n, h.Confiner.Rejections())
 	}
 }
 
@@ -73,8 +72,8 @@ func TestStop_DispatchesWithDefaultHome(t *testing.T) {
 	tp := writeSessionTranscript(t, root, "sess-default")
 
 	target := &mockTarget{}
-	h := NewHookHandlerWithConfiner(target,
-		keyedGate{PermissionKeyHooks: true, PermissionKeyTranscripts: true}, mockLogger{}, TranscriptConfiner())
+	h := NewHookHandler(target,
+		keyedGate{PermissionKeyHooks: true, PermissionKeyTranscripts: true}, mockLogger{})
 
 	post(t, h, contractPayload(tp, HookStop))
 	if n := len(target.stops()); n != 1 {

--- a/core/adapters/inbound/agents/copilot/hookpath_test.go
+++ b/core/adapters/inbound/agents/copilot/hookpath_test.go
@@ -16,16 +16,6 @@ func TestHookPathConfined(t *testing.T) {
 		New: func(t *testing.T) contracttesting.HookReceiverUnderTest {
 			t.Helper()
 			target := &mockTarget{}
-			confiner := TranscriptConfiner()
-			return contracttesting.HookReceiverUnderTest{
-				Handler:    NewHookHandlerWithConfiner(target, nil, mockLogger{}, confiner),
-				Observed:   func() bool { return target.totalCalls() > 0 },
-				Rejections: confiner.RejectionCount,
-			}
-		},
-		NewProduction: func(t *testing.T) contracttesting.HookReceiverUnderTest {
-			t.Helper()
-			target := &mockTarget{}
 			return contracttesting.HookReceiverUnderTest{
 				Handler:  NewHookHandler(target, nil, mockLogger{}),
 				Observed: func() bool { return target.totalCalls() > 0 },

--- a/core/adapters/inbound/agents/copilot/hookreceipt_test.go
+++ b/core/adapters/inbound/agents/copilot/hookreceipt_test.go
@@ -24,12 +24,12 @@ func TestHookReceiptObserved(t *testing.T) {
 		WriteTranscript: writeContractTranscript,
 		New: func(t *testing.T, log outbound.Logger) http.Handler {
 			t.Helper()
-			return NewHookHandlerWithConfiner(&mockTarget{},
-				keyedGate{PermissionKeyHooks: true, PermissionKeyTranscripts: true}, log, TranscriptConfiner())
+			return NewHookHandler(&mockTarget{},
+				keyedGate{PermissionKeyHooks: true, PermissionKeyTranscripts: true}, log)
 		},
 		NewDenied: func(t *testing.T, log outbound.Logger) http.Handler {
 			t.Helper()
-			return NewHookHandlerWithConfiner(&mockTarget{}, keyedGate{}, log, TranscriptConfiner())
+			return NewHookHandler(&mockTarget{}, keyedGate{}, log)
 		},
 		PayloadFor:   contractPayload,
 		KnownEvent:   HookStop,

--- a/core/adapters/inbound/agents/copilot/hooks.go
+++ b/core/adapters/inbound/agents/copilot/hooks.go
@@ -152,31 +152,27 @@ type HookTarget interface {
 type ConsentGranter = hookjson.ConsentGranter
 
 // NewHookHandler returns an http.HandlerFunc that receives Copilot hook events
-// and dispatches them to the target.
+// and dispatches them to the target. The returned hookjson.HookHandler is an
+// http.Handler carrying the confiner it guards caller-supplied transcript paths
+// with (issue #1390).
 //
 // gate is the consent check; while the "hooks" permission is not granted the
 // payload is dropped with 200, so the installed hook stays quiet. A nil gate
 // means no gating — used by tests.
-func NewHookHandler(target HookTarget, gate ConsentGranter, log outbound.Logger) http.HandlerFunc {
-	return NewHookHandlerWithConfiner(target, gate, log, TranscriptConfiner())
+func NewHookHandler(target HookTarget, gate ConsentGranter, log outbound.Logger) hookjson.HookHandler {
+	return hookjson.NewHandler(transcriptConfiner(),
+		func(c *hookjson.PathConfiner, w http.ResponseWriter, r *http.Request) {
+			serveHookRequest(target, gate, log, c, w, r)
+		})
 }
 
-// TranscriptConfiner returns the confiner this adapter's hook receiver guards
+// transcriptConfiner returns the confiner this adapter's hook receiver guards
 // caller-supplied transcript paths with, rooted in the adapter's own
 // agent.Source declaration (issue #1361) rather than re-derived from the
 // adapter's constants — so the tree the receiver confines to cannot drift from
 // the one the daemon watches.
-func TranscriptConfiner() *hookjson.PathConfiner {
+func transcriptConfiner() *hookjson.PathConfiner {
 	return hookjson.ConfinerForSource(Source, runtime.GOOS, transcriptExt)
-}
-
-// NewHookHandlerWithConfiner is NewHookHandler with an explicit confiner, for
-// tests that need to drive a receiver rooted somewhere other than the real
-// session-state tree and to read back what it refused.
-func NewHookHandlerWithConfiner(target HookTarget, gate ConsentGranter, log outbound.Logger, confiner *hookjson.PathConfiner) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		serveHookRequest(target, gate, log, confiner, w, r)
-	}
 }
 
 // serveHookRequest is NewHookHandler's request logic, pulled out of the

--- a/core/adapters/inbound/agents/copilot/hooks_test.go
+++ b/core/adapters/inbound/agents/copilot/hooks_test.go
@@ -141,7 +141,7 @@ func newReceiver(t *testing.T) (http.Handler, *mockTarget) {
 	t.Helper()
 	target := &mockTarget{}
 	gate := keyedGate{PermissionKeyHooks: true, PermissionKeyTranscripts: true}
-	return NewHookHandlerWithConfiner(target, gate, mockLogger{}, TranscriptConfiner()), target
+	return NewHookHandler(target, gate, mockLogger{}), target
 }
 
 // --- behaviour ---
@@ -327,7 +327,7 @@ func TestHookReceiver_DeniedHooksConsentDropsQuietly(t *testing.T) {
 	root := copilotSessionRoot(t)
 	tp := writeSessionTranscript(t, root, "sess-stop")
 	target := &mockTarget{}
-	h := NewHookHandlerWithConfiner(target, keyedGate{}, mockLogger{}, TranscriptConfiner())
+	h := NewHookHandler(target, keyedGate{}, mockLogger{})
 
 	rec := post(t, h, contractPayload(tp, HookStop))
 
@@ -346,7 +346,7 @@ func TestHookReceiver_DeniedTranscriptsConsentDropsQuietly(t *testing.T) {
 	root := copilotSessionRoot(t)
 	tp := writeSessionTranscript(t, root, "sess-stop")
 	target := &mockTarget{}
-	h := NewHookHandlerWithConfiner(target, keyedGate{PermissionKeyHooks: true}, mockLogger{}, TranscriptConfiner())
+	h := NewHookHandler(target, keyedGate{PermissionKeyHooks: true}, mockLogger{})
 
 	rec := post(t, h, contractPayload(tp, HookStop))
 

--- a/core/adapters/inbound/agents/copilot/hookunknown_test.go
+++ b/core/adapters/inbound/agents/copilot/hookunknown_test.go
@@ -19,7 +19,7 @@ func TestUnknownHookEventObserved(t *testing.T) {
 			t.Helper()
 			target := &mockTarget{}
 			return contracttesting.UnknownEventReceiverUnderTest{
-				Handler:  NewHookHandlerWithConfiner(target, nil, log, TranscriptConfiner()),
+				Handler:  NewHookHandler(target, nil, log),
 				Observed: func() bool { return target.totalCalls() > 0 },
 			}
 		},

--- a/core/adapters/inbound/agents/hookjson/handler.go
+++ b/core/adapters/inbound/agents/hookjson/handler.go
@@ -1,0 +1,48 @@
+// handler.go holds the shape every hook-receiving adapter's constructor
+// returns: the handler itself, plus the confiner it guards caller-supplied
+// transcript paths with.
+//
+// The confiner is part of what a receiver IS, not a detail of how one is built
+// (issue #1390). Before this type each adapter exported a second, test-shaped
+// constructor — NewHookHandlerWithConfiner and friends — for the single reason
+// that the #1361 contract has to read RejectionCount() off the instance the
+// handler actually closed over, and a closure hides it. Three receivers carried
+// that seam, and the contract then grew a sixth obligation whose whole job was
+// policing the API the same PR had introduced: proving that the DEFAULT
+// constructor confines too, since the test had been exercising the other one.
+//
+// Returning the confiner alongside the handler dissolves that. There is one
+// exported constructor per receiver, and the counter the contract reads is
+// obtained FROM the handler under test — so "this handler confines" and "the
+// counter I am reading belongs to this handler" stop being two facts that could
+// disagree. That is what retired obligation 6, rather than the split merely
+// being gone.
+//
+// Note the sibling counters in this package need nothing like it:
+// IgnoreUnknownEvent (#1364) and ObserveHookReceipt (#1368) keep package-level
+// counts, so their contracts read package accessors and hold no handle on a
+// handler. PathConfiner is per-instance because its roots are per-adapter, so
+// it is the one that needs a way out. That asymmetry is the reason this type
+// carries exactly one field and is not a bag of receiver internals.
+package hookjson
+
+import "net/http"
+
+// HookHandler is a hook receiver: an http.Handler (and, via the embedded
+// HandlerFunc, an ordinary func) together with the PathConfiner it enforces
+// issue #1361 confinement with.
+//
+// The embedding is what keeps this a drop-in for the bare http.HandlerFunc the
+// constructors used to return — ServeHTTP is promoted, so a HookHandler
+// satisfies http.Handler and goes straight into mux.Handle, and h.HandlerFunc
+// is still callable directly where a raw func is genuinely wanted.
+type HookHandler struct {
+	http.HandlerFunc
+
+	// Confiner is the confiner this handler guards transcript_path with — the
+	// same instance the request path uses, never a second one built alongside
+	// it. Its counters are the only evidence a refusal happened at all
+	// (RejectPath logs and counts; the response is an ordinary 2xx), which is
+	// why the contract reads them rather than trusting the status code.
+	Confiner *PathConfiner
+}

--- a/core/adapters/inbound/agents/hookjson/handler.go
+++ b/core/adapters/inbound/agents/hookjson/handler.go
@@ -1,41 +1,29 @@
 // handler.go holds the shape every hook-receiving adapter's constructor
 // returns: the handler itself, plus the confiner it guards caller-supplied
-// transcript paths with.
+// transcript paths with. The confiner is part of what a receiver IS, not a
+// detail of how one is built (issue #1390).
 //
-// The confiner is part of what a receiver IS, not a detail of how one is built
-// (issue #1390). Before this type each adapter exported a second, test-shaped
-// constructor — NewHookHandlerWithConfiner and friends — for the single reason
-// that the #1361 contract has to read RejectionCount() off the instance the
-// handler actually closed over, and a closure hides it. Three receivers carried
-// that seam, and the contract then grew a sixth obligation whose whole job was
-// policing the API the same PR had introduced: proving that the DEFAULT
-// constructor confines too, since the test had been exercising the other one.
+// Why there is no longer a NewHookHandlerWithConfiner, and why the #1361
+// contract lost an obligation along with it: see AGENTS.md, "Hook path
+// confinement".
 //
-// Returning the confiner alongside the handler dissolves that. There is one
-// exported constructor per receiver, and the counter the contract reads is
-// obtained FROM the handler under test — so "this handler confines" and "the
-// counter I am reading belongs to this handler" stop being two facts that could
-// disagree. That is what retired obligation 6, rather than the split merely
-// being gone.
-//
-// Note the sibling counters in this package need nothing like it:
+// The sibling counters in this package need nothing like this type:
 // IgnoreUnknownEvent (#1364) and ObserveHookReceipt (#1368) keep package-level
 // counts, so their contracts read package accessors and hold no handle on a
 // handler. PathConfiner is per-instance because its roots are per-adapter, so
-// it is the one that needs a way out. That asymmetry is the reason this type
-// carries exactly one field and is not a bag of receiver internals.
+// it is the one that needs a way out — which is why HookHandler carries exactly
+// one field and is not a bag of receiver internals.
 package hookjson
 
 import "net/http"
 
 // HookHandler is a hook receiver: an http.Handler (and, via the embedded
 // HandlerFunc, an ordinary func) together with the PathConfiner it enforces
-// issue #1361 confinement with.
+// issue #1361 confinement with. Build one with NewHandler.
 //
-// The embedding is what keeps this a drop-in for the bare http.HandlerFunc the
-// constructors used to return — ServeHTTP is promoted, so a HookHandler
-// satisfies http.Handler and goes straight into mux.Handle, and h.HandlerFunc
-// is still callable directly where a raw func is genuinely wanted.
+// The embedding keeps it a drop-in for a bare http.HandlerFunc — ServeHTTP is
+// promoted, so a HookHandler satisfies http.Handler and goes straight into
+// mux.Handle.
 type HookHandler struct {
 	http.HandlerFunc
 
@@ -45,4 +33,19 @@ type HookHandler struct {
 	// (RejectPath logs and counts; the response is an ordinary 2xx), which is
 	// why the contract reads them rather than trusting the status code.
 	Confiner *PathConfiner
+}
+
+// NewHandler builds a receiver that serves through serve, handing it confiner
+// on every request and publishing that same instance as Confiner.
+//
+// Constructing the pair here rather than at each adapter is the point: the
+// property #1390 buys is that Confiner IS the confiner the request path uses,
+// and three hand-written struct literals asserted that by convention. serve
+// takes the confiner as a parameter rather than capturing one, so the correct
+// wiring is also the shortest one and a fourth receiver inherits it.
+func NewHandler(confiner *PathConfiner, serve func(*PathConfiner, http.ResponseWriter, *http.Request)) HookHandler {
+	return HookHandler{
+		HandlerFunc: func(w http.ResponseWriter, r *http.Request) { serve(confiner, w, r) },
+		Confiner:    confiner,
+	}
 }

--- a/core/cmd/irrlichd/startup.go
+++ b/core/cmd/irrlichd/startup.go
@@ -920,11 +920,14 @@ func setupBackchannel(mux *http.ServeMux, deps setupBackchannelDeps) (*services.
 // pre-consent daemon keep firing until the wizard is answered, so payloads are
 // dropped while pending.
 func registerHookRoutes(mux *http.ServeMux, detector *services.SessionDetector, metricsCollector outbound.MetricsCollector, permService *services.PermissionService, logger outbound.Logger) {
-	mux.HandleFunc("POST "+claudecode.HookEndpointPath,
+	// mux.Handle, not HandleFunc: each constructor returns a hookjson.HookHandler
+	// — the handler together with the confiner it enforces #1361 with — which
+	// satisfies http.Handler through its embedded HandlerFunc (issue #1390).
+	mux.Handle("POST "+claudecode.HookEndpointPath,
 		claudecode.NewHookHandler(detector, metricsCollector, permService, logger))
-	mux.HandleFunc("POST "+claudecode.StatuslineEndpointPath,
+	mux.Handle("POST "+claudecode.StatuslineEndpointPath,
 		claudecode.NewStatuslineHandler(metricsCollector, permService, logger))
-	mux.HandleFunc("POST "+codex.HookEndpointPath,
+	mux.Handle("POST "+codex.HookEndpointPath,
 		codex.NewHookHandler(detector, permService, logger))
 	mux.HandleFunc("POST "+copilot.HookEndpointPath,
 		copilot.NewHookHandler(detector, permService, logger))

--- a/core/cmd/irrlichd/startup.go
+++ b/core/cmd/irrlichd/startup.go
@@ -929,7 +929,7 @@ func registerHookRoutes(mux *http.ServeMux, detector *services.SessionDetector, 
 		claudecode.NewStatuslineHandler(metricsCollector, permService, logger))
 	mux.Handle("POST "+codex.HookEndpointPath,
 		codex.NewHookHandler(detector, permService, logger))
-	mux.HandleFunc("POST "+copilot.HookEndpointPath,
+	mux.Handle("POST "+copilot.HookEndpointPath,
 		copilot.NewHookHandler(detector, permService, logger))
 }
 

--- a/core/internal/contracttesting/hook_path_confinement.go
+++ b/core/internal/contracttesting/hook_path_confinement.go
@@ -35,14 +35,11 @@ import (
 type HookReceiverUnderTest struct {
 	// Handler is the adapter's hook receiver, as its constructor returns it.
 	//
-	// Typed as the concrete hookjson.HookHandler rather than http.Handler on
-	// purpose: it carries the confiner the handler itself uses, so the contract
-	// reads the rejection count off THIS value (see rejections) instead of
-	// taking it as a second, adapter-supplied func that could be bound to a
-	// different instance. That is what makes "rejected and counted" evidence
-	// about the handler under test rather than about whatever the wiring
-	// happened to hand over, and it is the type-level residue of retired
-	// obligation 6 — see AssertHookPathConfined.
+	// Typed as the concrete hookjson.HookHandler rather than http.Handler so the
+	// rejection count can be read off THIS value — Handler.Confiner — instead of
+	// arriving as a second, separately-supplied func that could name a different
+	// instance. That is what makes "rejected and counted" evidence about the
+	// handler under test.
 	Handler hookjson.HookHandler
 
 	// Observed reports whether the receiver dispatched anything downstream —
@@ -50,14 +47,6 @@ type HookReceiverUnderTest struct {
 	// the assertion that actually matters; the status code is how the refusal
 	// is reported, but a 400 alongside a dispatch would still be a breach.
 	Observed func() bool
-}
-
-// rejections is the receiver's confinement rejection count, so "rejected and
-// counted" is checked rather than assumed. A receiver that refuses without
-// counting fails on it. Derived from the handler rather than declared beside
-// it, so the two cannot name different confiners.
-func (rut HookReceiverUnderTest) rejections() uint64 {
-	return rut.Handler.Confiner.RejectionCount()
 }
 
 // HookReceiver wires one adapter's hook receiver into AssertHookPathConfined.
@@ -74,13 +63,8 @@ type HookReceiver struct {
 	// the rejection count starts at zero and Observed cannot carry over.
 	//
 	// There is nothing else to call: since #1390 each receiver has exactly one
-	// exported constructor, returning a hookjson.HookHandler that carries the
-	// confiner the handler itself uses. So the rejection count is read OFF the
-	// handler under test rather than off an instance the test built alongside
-	// it, and every obligation here binds the production path by construction.
-	// A separate NewProduction obligation existed until #1390 to re-anchor
-	// exactly that, back when reaching the counter meant calling a second,
-	// test-only constructor that could confine differently from the real one.
+	// exported constructor, so every obligation here binds the production path
+	// rather than a handler the test assembled.
 	New func(t *testing.T) HookReceiverUnderTest
 
 	// WriteTranscript writes a transcript the adapter would dispatch on into
@@ -126,20 +110,12 @@ type HookReceiver struct {
 // Obligations 2–5 additionally require the refusal to be VISIBLE — counted by
 // the confiner, so an operator can see it — and to answer 2xx.
 //
-// A sixth obligation, "the adapter's PRODUCTION constructor confines too",
-// was retired in #1390 and is not merely dropped. It existed because reaching
-// the rejection counter meant calling a second, test-only constructor, so the
-// handler these five obligations ran against was not provably the one the
-// daemon builds. Each receiver now has ONE exported constructor, returning a
-// hookjson.HookHandler that carries its own confiner — so the count is read off
-// Handler.Confiner, i.e. obtained FROM the handler under test. Typing Handler as
-// that concrete struct rather than http.Handler is what stops the two from
-// being separately supplied. A handler that confines
-// and a counter that proves it can no longer be two different objects, which
-// is the property obligation 6 was checking. What it never covered, and still
-// does not, is an adapter wiring New to a hand-rolled handler instead of its
-// constructor: NewProduction was adapter-supplied too, so that gap is
-// unchanged rather than newly opened.
+// A sixth obligation, "the adapter's PRODUCTION constructor confines too", was
+// retired in #1390: the count is now read off Handler.Confiner, so a handler
+// that confines and the counter proving it can no longer be two objects that
+// disagree, and obligations 2-5 fail directly when the production constructor
+// stops confining. The full argument, including what obligation 6 never
+// covered either, is in AGENTS.md under "Hook path confinement".
 //
 // The 2xx is asserted, not merely tolerated. A refused path is already fully
 // contained by not being forwarded, so the status code buys no security; what
@@ -174,7 +150,7 @@ func assertInTreeAccepted(t *testing.T, r HookReceiver) {
 	if !rut.Observed() {
 		t.Fatal("in-tree transcript was not dispatched — the rejection assertions below would pass vacuously")
 	}
-	if n := rut.rejections(); n != 0 {
+	if n := rut.Handler.Confiner.RejectionCount(); n != 0 {
 		t.Errorf("in-tree transcript counted %d rejection(s), want 0", n)
 	}
 }
@@ -243,7 +219,7 @@ func assertRefused(t *testing.T, r HookReceiver, path, what string) {
 		t.Errorf("%s was dispatched downstream: %s", what, path)
 	}
 	assertHookStatus2xx(t, rec, what)
-	if n := rut.rejections(); n != 1 {
+	if n := rut.Handler.Confiner.RejectionCount(); n != 1 {
 		t.Errorf("%s: counted %d rejection(s), want 1 — a refusal has to be countable, not just returned", what, n)
 	}
 }

--- a/core/internal/contracttesting/hook_path_confinement.go
+++ b/core/internal/contracttesting/hook_path_confinement.go
@@ -25,28 +25,39 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"irrlicht/core/adapters/inbound/agents/hookjson"
 )
 
 // HookReceiverUnderTest is one freshly built hook receiver plus the two things
 // the contract must be able to see from outside it: whether a payload was
 // dispatched, and what the receiver refused.
 type HookReceiverUnderTest struct {
-	// Handler is the adapter's hook HTTP handler.
-	Handler http.Handler
+	// Handler is the adapter's hook receiver, as its constructor returns it.
+	//
+	// Typed as the concrete hookjson.HookHandler rather than http.Handler on
+	// purpose: it carries the confiner the handler itself uses, so the contract
+	// reads the rejection count off THIS value (see rejections) instead of
+	// taking it as a second, adapter-supplied func that could be bound to a
+	// different instance. That is what makes "rejected and counted" evidence
+	// about the handler under test rather than about whatever the wiring
+	// happened to hand over, and it is the type-level residue of retired
+	// obligation 6 — see AssertHookPathConfined.
+	Handler hookjson.HookHandler
 
 	// Observed reports whether the receiver dispatched anything downstream —
 	// i.e. whether the supplied transcript_path escaped the receiver. This is
 	// the assertion that actually matters; the status code is how the refusal
 	// is reported, but a 400 alongside a dispatch would still be a breach.
 	Observed func() bool
+}
 
-	// Rejections is the receiver's confinement rejection count, so "rejected
-	// and counted" is checked rather than assumed. A receiver that returns 400
-	// without counting fails here. Required — take it off the Confiner the
-	// constructor handed back with Handler (h.Confiner.RejectionCount), never
-	// off a confiner built separately, or the count stops being evidence about
-	// this handler.
-	Rejections func() uint64
+// rejections is the receiver's confinement rejection count, so "rejected and
+// counted" is checked rather than assumed. A receiver that refuses without
+// counting fails on it. Derived from the handler rather than declared beside
+// it, so the two cannot name different confiners.
+func (rut HookReceiverUnderTest) rejections() uint64 {
+	return rut.Handler.Confiner.RejectionCount()
 }
 
 // HookReceiver wires one adapter's hook receiver into AssertHookPathConfined.
@@ -64,7 +75,7 @@ type HookReceiver struct {
 	//
 	// There is nothing else to call: since #1390 each receiver has exactly one
 	// exported constructor, returning a hookjson.HookHandler that carries the
-	// confiner the handler itself uses. So Rejections below is read OFF the
+	// confiner the handler itself uses. So the rejection count is read OFF the
 	// handler under test rather than off an instance the test built alongside
 	// it, and every obligation here binds the production path by construction.
 	// A separate NewProduction obligation existed until #1390 to re-anchor
@@ -120,8 +131,10 @@ type HookReceiver struct {
 // the rejection counter meant calling a second, test-only constructor, so the
 // handler these five obligations ran against was not provably the one the
 // daemon builds. Each receiver now has ONE exported constructor, returning a
-// hookjson.HookHandler that carries its own confiner — so the counter read by
-// Rejections is obtained FROM the handler under test. A handler that confines
+// hookjson.HookHandler that carries its own confiner — so the count is read off
+// Handler.Confiner, i.e. obtained FROM the handler under test. Typing Handler as
+// that concrete struct rather than http.Handler is what stops the two from
+// being separately supplied. A handler that confines
 // and a counter that proves it can no longer be two different objects, which
 // is the property obligation 6 was checking. What it never covered, and still
 // does not, is an adapter wiring New to a hand-rolled handler instead of its
@@ -161,7 +174,7 @@ func assertInTreeAccepted(t *testing.T, r HookReceiver) {
 	if !rut.Observed() {
 		t.Fatal("in-tree transcript was not dispatched — the rejection assertions below would pass vacuously")
 	}
-	if n := rut.Rejections(); n != 0 {
+	if n := rut.rejections(); n != 0 {
 		t.Errorf("in-tree transcript counted %d rejection(s), want 0", n)
 	}
 }
@@ -230,7 +243,7 @@ func assertRefused(t *testing.T, r HookReceiver, path, what string) {
 		t.Errorf("%s was dispatched downstream: %s", what, path)
 	}
 	assertHookStatus2xx(t, rec, what)
-	if n := rut.Rejections(); n != 1 {
+	if n := rut.rejections(); n != 1 {
 		t.Errorf("%s: counted %d rejection(s), want 1 — a refusal has to be countable, not just returned", what, n)
 	}
 }

--- a/core/internal/contracttesting/hook_path_confinement.go
+++ b/core/internal/contracttesting/hook_path_confinement.go
@@ -42,7 +42,10 @@ type HookReceiverUnderTest struct {
 
 	// Rejections is the receiver's confinement rejection count, so "rejected
 	// and counted" is checked rather than assumed. A receiver that returns 400
-	// without counting fails here.
+	// without counting fails here. Required — take it off the Confiner the
+	// constructor handed back with Handler (h.Confiner.RejectionCount), never
+	// off a confiner built separately, or the count stops being evidence about
+	// this handler.
 	Rejections func() uint64
 }
 
@@ -55,20 +58,19 @@ type HookReceiver struct {
 	// FIRST in every sub-test, before New.
 	Root func(t *testing.T) string
 
-	// New builds a fresh receiver, after Root has run. Fresh per sub-test so
+	// New builds a fresh receiver, after Root has run, THROUGH THE ADAPTER'S
+	// PRODUCTION CONSTRUCTOR — the one the daemon calls. Fresh per sub-test so
 	// the rejection count starts at zero and Observed cannot carry over.
-	New func(t *testing.T) HookReceiverUnderTest
-
-	// NewProduction builds the receiver through the adapter's DEFAULT exported
-	// constructor — the one the daemon actually calls — rather than any
-	// test-only variant New may use to reach the rejection counter.
 	//
-	// Without it the contract only ever inspects a handler the test assembled,
-	// so an adapter could satisfy every obligation with a correctly wired test
-	// handler while its real constructor confines nothing: the #1361 hole,
-	// shipped past a green contract. Rejections may be nil here; the
-	// obligation this field serves is about reachability, not counting.
-	NewProduction func(t *testing.T) HookReceiverUnderTest
+	// There is nothing else to call: since #1390 each receiver has exactly one
+	// exported constructor, returning a hookjson.HookHandler that carries the
+	// confiner the handler itself uses. So Rejections below is read OFF the
+	// handler under test rather than off an instance the test built alongside
+	// it, and every obligation here binds the production path by construction.
+	// A separate NewProduction obligation existed until #1390 to re-anchor
+	// exactly that, back when reaching the counter meant calling a second,
+	// test-only constructor that could confine differently from the real one.
+	New func(t *testing.T) HookReceiverUnderTest
 
 	// WriteTranscript writes a transcript the adapter would dispatch on into
 	// dir, and returns its absolute path. The contract uses it for the in-tree
@@ -91,7 +93,7 @@ type HookReceiver struct {
 	EndpointPath string
 }
 
-// AssertHookPathConfined runs the issue #1361 contract against r. Four
+// AssertHookPathConfined runs the issue #1361 contract against r. Five
 // obligations, each independently failable:
 //
 //  1. a transcript inside the declared root is still ACCEPTED — the vacuity
@@ -108,12 +110,23 @@ type HookReceiver struct {
 //     that has not been written yet, so a receiver that waves through an
 //     unresolvable leaf (a reasonable allowance — the hook fires around the
 //     write) hands the attacker an escape needing no race at all: plant the
-//     broken link, get the path accepted, then create the target;
-//  6. the adapter's PRODUCTION constructor confines too, not merely whatever
-//     handler the test assembled.
+//     broken link, get the path accepted, then create the target.
 //
 // Obligations 2–5 additionally require the refusal to be VISIBLE — counted by
 // the confiner, so an operator can see it — and to answer 2xx.
+//
+// A sixth obligation, "the adapter's PRODUCTION constructor confines too",
+// was retired in #1390 and is not merely dropped. It existed because reaching
+// the rejection counter meant calling a second, test-only constructor, so the
+// handler these five obligations ran against was not provably the one the
+// daemon builds. Each receiver now has ONE exported constructor, returning a
+// hookjson.HookHandler that carries its own confiner — so the counter read by
+// Rejections is obtained FROM the handler under test. A handler that confines
+// and a counter that proves it can no longer be two different objects, which
+// is the property obligation 6 was checking. What it never covered, and still
+// does not, is an adapter wiring New to a hand-rolled handler instead of its
+// constructor: NewProduction was adapter-supplied too, so that gap is
+// unchanged rather than newly opened.
 //
 // The 2xx is asserted, not merely tolerated. A refused path is already fully
 // contained by not being forwarded, so the status code buys no security; what
@@ -130,7 +143,6 @@ func AssertHookPathConfined(t *testing.T, r HookReceiver) {
 	t.Run("parent_traversal_rejected", func(t *testing.T) { assertTraversalRejected(t, r) })
 	t.Run("symlink_escape_rejected", func(t *testing.T) { assertSymlinkEscapeRejected(t, r) })
 	t.Run("dangling_symlink_rejected", func(t *testing.T) { assertDanglingSymlinkRejected(t, r) })
-	t.Run("production_constructor_confines", func(t *testing.T) { assertProductionConfines(t, r) })
 }
 
 // assertInTreeAccepted is obligation 1. It runs first because every assertion
@@ -205,18 +217,6 @@ func assertDanglingSymlinkRejected(t *testing.T, r HookReceiver) {
 	assertRefused(t, r, link, "a dangling symlink inside the declared root (an unresolvable leaf must not be assumed to be an unflushed write)")
 }
 
-// assertProductionConfines is obligation 6: the confinement is reachable
-// through the constructor the daemon calls, not only the one the test wires.
-func assertProductionConfines(t *testing.T, r HookReceiver) {
-	t.Helper()
-	r.Root(t)
-	outside := r.WriteTranscript(t, t.TempDir())
-	rut := r.NewProduction(t)
-
-	assertRefusedBy(t, r, rut, outside,
-		"an out-of-tree transcript at the adapter's PRODUCTION constructor (confinement must be wired into the handler the daemon builds, not only the one the test assembles)")
-}
-
 // --- helpers ---
 
 // assertRefused drives one escape attempt against a fresh receiver and checks
@@ -224,22 +224,12 @@ func assertProductionConfines(t *testing.T, r HookReceiver) {
 // counted reason.
 func assertRefused(t *testing.T, r HookReceiver, path, what string) {
 	t.Helper()
-	assertRefusedBy(t, r, r.New(t), path, what)
-}
-
-// assertRefusedBy is assertRefused against an already-built receiver. The count
-// check is skipped when Rejections is nil, which is how NewProduction is
-// allowed to supply a receiver with no handle on the confiner.
-func assertRefusedBy(t *testing.T, r HookReceiver, rut HookReceiverUnderTest, path, what string) {
-	t.Helper()
+	rut := r.New(t)
 	rec := postHookPath(t, r, rut, path)
 	if rut.Observed() {
 		t.Errorf("%s was dispatched downstream: %s", what, path)
 	}
 	assertHookStatus2xx(t, rec, what)
-	if rut.Rejections == nil {
-		return
-	}
 	if n := rut.Rejections(); n != 1 {
 		t.Errorf("%s: counted %d rejection(s), want 1 — a refusal has to be countable, not just returned", what, n)
 	}


### PR DESCRIPTION
Closes #1390

## The proposal was evaluated, not just executed

#1390 is a pure refactor of working, tested code, so the first question was whether it is still worth doing. Since #1361 landed, that surface grew to seven contract families, and the issue's premise — "a struct with the confiner collapses both constructors and obligation 6" — had to be re-checked against what is there now rather than what was there in #1380.

**What decided it: the three receiver-side counter families in `hookjson` are not shaped alike, and only one of them needs a seam.**

| Counter | Storage | How its contract reads it | In the diagnostics bundle? |
|---|---|---|---|
| Unknown events (#1364) | package-level globals | `hookjson.UnknownEvents()`, delta-measured | yes |
| Hook receipts (#1368) | package-level global map | `hookjson.HookReceipts()`, delta-measured | yes |
| **Path confinement (#1361)** | **per-`*PathConfiner` instance** | **a method value on an instance the test built** | **no** |

Neither of the other two contracts holds any handle on a handler — `AssertHookReceiptObserved` does not even define an `…UnderTest` struct. So the "one struct becomes a grab-bag" risk is not real here: exactly one contract wants exactly one thing, and nothing else is queuing up to be added.

The split was also smaller than it looked. Of the nine `*WithConfiner` call sites, only **three** — one per receiver, all in `hookpath_test.go` — actually needed the seam. The other six (`hookreceipt_test.go`, `hookunknown_test.go`) passed `TranscriptConfiner()`, making them byte-for-byte equivalent to the plain constructor. Three exported production constructors existed to serve three test call sites.

**Decision: proceed**, with one deliberate change from the issue's sketch — the type lives in `hookjson` (shared, beside `PathConfiner`) rather than being duplicated per adapter, so the third hook adapter inherits it instead of copying it.

## What changed

| File | Why |
|---|---|
| `core/adapters/inbound/agents/hookjson/handler.go` **(new)** | `HookHandler{http.HandlerFunc; Confiner *PathConfiner}` — the handler together with the confiner it enforces #1361 with. Embedding keeps it a drop-in: `ServeHTTP` is promoted, so it satisfies `http.Handler`. Plus `NewHandler(confiner, serve)`, which builds the pair so the "same instance" invariant is not hand-asserted per adapter. |
| `core/adapters/inbound/agents/claudecode/hooks.go` | `NewHookHandler` returns `hookjson.HookHandler`; `NewHookHandlerWithConfiner` deleted. |
| `core/adapters/inbound/agents/claudecode/statusline.go` | Same for `NewStatuslineHandler`; `NewStatuslineHandlerWithConfiner` deleted. |
| `core/adapters/inbound/agents/codex/hooks.go` | Same for `NewHookHandler`; `NewHookHandlerWithConfiner` deleted. |
| `core/adapters/inbound/agents/copilot/hooks.go` + its 5 hook tests | Same again — copilot landed on `main` as a **fourth** receiver mid-run (#1436) with the identical split. See "The fourth receiver" below. |
| `core/cmd/irrlichd/startup.go` | `mux.HandleFunc` → `mux.Handle` for the three hook routes. |
| `core/internal/contracttesting/hook_path_confinement.go` | `NewProduction` field and `assertProductionConfines` removed; obligation 6 retired; `assertRefusedBy` folded back into `assertRefused`. `HookReceiverUnderTest.Handler` is typed `hookjson.HookHandler` and the `Rejections` field is **deleted** — the count is read off `Handler.Confiner`, so the wiring cannot name two different confiners. |
| `{claudecode,codex}/hookpath_test.go` | Wire through the one constructor; the `NewProduction` blocks and the separate `Rejections` wiring are gone. |
| `{claudecode,codex}/hook{receipt,unknown}_test.go` | The six gratuitous `*WithConfiner` calls become the plain constructor. |
| `{claudecode,codex}/hooks_test.go`, `claudecode/statusline_test.go` | `postHook` widened to `http.Handler`; 26 direct `handler(rec, req)` invocations become `handler.ServeHTTP(rec, req)`. |
| `claudecode/statusline.go` | `serveStatuslineRequest` extracted so the constructor reads like its two siblings (review finding). |
| `AGENTS.md` | Six obligations → five, and **why** the sixth went. This is the canonical account; the code sites carry a pointer rather than a fourth and fifth retelling. |

## What happened to obligation 6 — and the evidence that nothing weakened

Obligation 6 policed a real gap: reaching the rejection counter meant calling a *second* constructor, so the handler obligations 2–5 ran against was not provably the one the daemon builds. #1380's mutation 7 proved that precisely — breaking the production constructor reddened obligation 6 **and nothing else**.

It is not being dropped because "the split is gone". It is retired because the property it checked is now carried by obligations 2–5 themselves: the counter they read is obtained **from** the handler under test (`h.Confiner`), so "this handler confines" and "the counter proving it" can no longer be two objects that disagree.

That claim is tested, not asserted. Two mutations replace #1380's mutation 7:

- **M7b — the production constructor built without confinement** (claudecode's `NewHookHandler` handed a permissive confiner). Under the old design this was invisible to obligations 2–5. Now it reddens `out_of_tree`, `parent_traversal` and `symlink_escape` on the claudecode hook receiver, leaving statusline and codex green — so the blast radius is right, and coverage of this fault went from one subtest to three.
- **M7a — `HookHandler.Confiner` diverges from the confiner the handler actually uses** (the field publishes one instance, the request path uses another). This is the *new* design's own invariant, and it reddens obligations 2–5 on the count. It has no analogue in #1380 because the old shape could not express it.

What obligation 6 never covered, and still does not: an adapter wiring `New` to a hand-rolled handler instead of its constructor. `NewProduction` was adapter-supplied too, so that gap is unchanged rather than newly opened. Stated rather than glossed.

## The fourth receiver arrived mid-run — which is the ticket's own argument

`copilot` merged to `main` (#1436) while this branch was in flight, adding a
fourth hook receiver that had copied the two-constructor shape verbatim:
`NewHookHandlerWithConfiner`, an exported `TranscriptConfiner`, and a
`hookpath_test.go` wiring both `Rejections` and `NewProduction`. Local tests
passed and CI failed, because CI compiles the *merge*.

That is the concrete cost the issue predicted ("the next hook adapter inherits
it"), observed rather than argued: the pattern replicated itself once more in
the days between #1361 and this PR. Copilot is ported here, so the count of
receivers carrying the split goes 4 → 0, and the mutation matrix below runs
against all four.

One detail worth noting: copilot's `hookdefaulthome_test.go` kept a local
`confiner` variable purely to print `Rejections()` in two failure messages. It
now reads `h.Confiner` — the same instance by construction, rather than because
the test remembered to pass the same one in.

## Re-run mutation matrix — `AssertHookPathConfined`

All mutations applied to the **final** (post-review, post-simplify, post-copilot) code, run against all **four** receivers (claudecode hook, claudecode statusline, codex hook, copilot hook), then reverted. `1` = in-tree accepted, `2` = out-of-tree, `3` = traversal, `4` = symlink escape, `5` = dangling symlink.

| Mutation | 1 | 2 | 3 | 4 | 5 | Matches #1380? |
|---|---|---|---|---|---|---|
| *baseline* | PASS | PASS | PASS | PASS | PASS | — |
| **M1** confiner rejects everything | **RED** | pass | pass | pass | pass | yes |
| **M2** confiner accepts everything | pass | **RED** | **RED** | **RED** | **RED** | yes |
| **M3** `..` guard dropped in `containedIn` | pass | **RED** | **RED** | **RED** | pass | yes |
| **M4** purely lexical containment (ordering inversion) | pass | pass | pass | **RED** | **RED** | yes — incl. #1380's "strictly stronger" 4+5 |
| **M5** rejection returned but not counted | pass | **RED** | **RED** | **RED** | **RED** | yes |
| **M6** dangling-link guard disabled | pass | pass | pass | pass | **RED** | yes |
| **M7b** production constructor without confinement | pass | **RED** | **RED** | **RED** | pass | replaces M7; was obligation-6-only |
| **M7a** published `.Confiner` ≠ confiner in use | pass | **RED** | **RED** | **RED** | **RED** | new — no old-shape analogue |

Every obligation still reddens under at least one mutation, and each mutation's failure set is unchanged from #1380 where the shape is unchanged. M1 is the vacuity guard; M4 is the ordering obligation (#1361's headline warning) and still isolates it. M7b leaves `dangling_symlink` green because a permissive confiner rooted at `/` still refuses an unresolvable leaf via `RejectUnresolvable` — the rejection arrives by a different reason, not by confinement.

The five obligations are **locks**, not defect tests: they pin behaviour that must not change and pass by construction on `main`. There is no red-first defect test in this PR because there is no defect — the mutation matrix above is the evidence standard that applies to a reworked contract assertion.

## Zero behaviour change

The wire behaviour is untouched: same routes, same statuses, same confinement, same counters. `mux.Handle` and `mux.HandleFunc` register the identical pattern; the only difference is which interface the value satisfies.

## Verification

Rebased onto `origin/main` mid-run (main moved 6 commits, two into files this branch touches — #1429 into `startup.go`, #1435 into `AGENTS.md`). Both re-read semantically: #1429 edited `setupPermissionService`, not `registerHookRoutes`; #1435 edited the *architecture* bullet, not the confinement bullet, and the "All seven contract families" line stays correct because an obligation was removed, not a family. Deletion tripwire against live `origin/main`: empty.

`tools/preflight.sh` run chunked in the foreground, all gates PASS (`go` and `arch` re-run after each code change; the rest re-run only where their inputs moved):

```
  gofmt / core module tests / onboarding-factory tests            PASS
  replaydata validate / recording-rig smoke / replay fixtures     PASS
  starhistory tests                                               PASS
  ARS architecture gate                     PASS (7.9542 -> 7.9546, no regression)
  tools/lib shell-lib tests                 PASS
  skill-file lint                           PASS (23 files, 0 errors, 0 warnings)
  POSIX sh lint                             PASS
  web: platforms/web + onboarding viewer    PASS
  security scan                             PASS
```

### The two advisory checks, with evidence rather than a wave

Both are advisory per AGENTS.md (neither branch protection nor the "Protect Main" ruleset requires them), but a dismissal owes evidence:

- **CodeScene — red, and not caused by this PR.** It is red on every recent PR I checked: #1445, #1444 and #1436 all report `fail` on "CodeScene Code Health Review (main)". Pre-existing.
- **SonarCloud — red on exactly one condition, and it is this refactor's goal showing up as a metric.** The quality gate reports `new_reliability_rating` OK, `new_security_rating` OK, `new_maintainability_rating` OK, `new_security_hotspots_reviewed` OK, and `new_duplicated_lines_density` **17.1%** against a 3% threshold. The duplication is the four adapters' contract wirings: codex's and copilot's `New` closures are now byte-identical and claudecode's differs only in constructor arity, because the lines that used to distinguish them — `confiner := TranscriptConfiner()`, `Rejections:`, and the entire `NewProduction` block — are exactly what this PR deletes. Sonar also failed on #1436, which added the fourth copy of that wiring; same cause, opposite direction. Collapsing the wirings into a shared helper would defeat the contract's purpose, which is that each adapter names its own constructor and its own target.

`replay fixtures` green with **no golden movement** (`git status --porcelain` empty after the run).

## Review and simplify

A `high`-effort review subagent returned **no correctness defects** and three low findings, all applied: codex's `NewHookHandler` doc still advertised `http.HandlerFunc`; `TranscriptConfiner` had no callers outside its own package once the `*WithConfiner` constructors went (unexported in both adapters); and `NewStatuslineHandler` inlined a 43-line closure in a shape neither sibling used. It also identified — and deliberately did not file — the strengthening this PR then took: typing `Handler` as the concrete `hookjson.HookHandler` and deriving the count from it, which turns "the counter comes off the handler" from a doc-comment convention into a type guarantee.

`/simplify` then ran, and both cleanup agents independently produced the same top finding: the invariant #1390 exists to establish was still asserted by hand in three identical struct literals, so a fourth receiver could write `Confiner: transcriptConfiner()` and publish a counter that never moves. `hookjson.NewHandler` now builds the pair, handing `serve` the confiner rather than letting it capture one. They also flagged that the obligation-6 rationale was narrated five times (~90 lines); it is now told once, in AGENTS.md, with pointers from the code.

Skipped, with reasons: extracting the shared method/consent/decode preamble of the three receivers into `hookjson` (a genuine duplication, but it touches request-handling code well outside this refactor — worth its own issue); and inlining codex's one-caller `transcriptConfiner`, because the symmetry with claudecode's two-caller namesake is worth more than the line, and its doc carries #1361 history.

## A note on the mutation harness itself

Worth recording because it nearly produced a false green. The harness applies each mutation by pattern-matching the source. When this PR unexported `TranscriptConfiner`, the M7a/M7b patterns silently stopped matching — the mutation became a **no-op**, every test passed, and the matrix read "all green" for the two mutations that matter most to this change. A mutation that fails to apply is indistinguishable from a mutation the tests caught, unless you check.

The harness now asserts that each mutation actually changed the file (`git diff --quiet`) and says `MUTATION DID NOT APPLY` otherwise. It caught two further stalings during this run, both real. This is the same failure shape as the `posix-lint.sh` incident recorded in AGENTS.md — a checker whose failure to run reads as a pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
