### PR TITLE
fix(state): stop birthing sessions `working` on metrics that observed nothing

### DIFF
--- a/core/application/services/session_detector_activity.go
+++ b/core/application/services/session_detector_activity.go
@@ -337,12 +337,30 @@ func (d *SessionDetector) buildNewSessionState(id agent.Identity, ev agent.Event
 	// The #1256 copilot case is untouched: its events.jsonl already holds a
 	// real user message at discovery, so LastEventType is set and the open
 	// turn is still caught here.
-	if state.Metrics != nil && (state.ParentSessionID != "" || state.Metrics.LastEventType != "") {
+	if shouldClassifyAtBirth(state) {
 		if newState, _ := ClassifyState(state.State, state.Metrics); newState != state.State {
 			state.State = newState
 		}
 	}
 	return state
+}
+
+// shouldClassifyAtBirth reports whether a just-built session should be run
+// through ClassifyState instead of keeping its bootstrap `ready`.
+//
+// Two independent reasons to say yes, spelled out separately because they are
+// answering different questions — see the commentary in buildNewSessionState
+// for why each exists:
+//
+//   - it is a CHILD, which must be born `working` so hasActiveChildren counts
+//     it and the stale-session sweep cannot release its parent (#889); or
+//   - something substantive has actually been parsed off the transcript, so
+//     the ladder has evidence to reason from rather than defaulting (#1447).
+func shouldClassifyAtBirth(state *session.SessionState) bool {
+	if state.Metrics == nil {
+		return false
+	}
+	return state.ParentSessionID != "" || state.Metrics.LastEventType != ""
 }
 
 // finalizeNewSession persists a freshly built session, records its creation

--- a/core/application/services/session_detector_activity.go
+++ b/core/application/services/session_detector_activity.go
@@ -283,10 +283,51 @@ func (d *SessionDetector) buildNewSessionState(id agent.Identity, ev agent.Event
 	// produced the correct ready->working, which is what identified it as a
 	// live-path-only gap rather than a parser one (#1256).
 	//
-	// Sessions with nothing to classify are unaffected: ClassifyState against
-	// nil/empty metrics returns ready, which is where they already start.
-	if newState, _ := ClassifyState(state.State, state.Metrics); newState != state.State {
-		state.State = newState
+	// Sessions with nothing to classify are unaffected — but "nothing to
+	// classify" has TWO shapes and only one of them is nil.
+	//
+	// ClassifyState short-circuits on a nil *SessionMetrics, so an adapter
+	// whose transcript does not exist or is empty at discovery is safe. An
+	// adapter whose transcript exists and was PARSED, but whose every line so
+	// far carries no observable signal, gets non-nil metrics that describe
+	// nothing — and non-nil metrics enter the rule ladder, which is
+	// deliberately total: its last rung (`transcript_activity`) has a nil
+	// `when` and always fires, returning `working`. So the insubstantial case
+	// was decided as "generating" on zero evidence.
+	//
+	// Codex hit this on every session (#1447). It is header-linked (#1055),
+	// so the fswatcher parks the zero-byte create and emits EventNewSession
+	// only once the first line is readable — its birth event therefore ALWAYS
+	// carries a parseable file. The two lines present at that moment,
+	// `session_meta` and `event_msg`/`task_started`, are both Skip=true in its
+	// parser. Result: every codex session was born `working` and stayed there
+	// until its first real turn boundary.
+	//
+	// The guard is LastEventType, not NoSubstantiveActivity. Both describe
+	// "nothing happened", but they answer different questions and only one of
+	// them is the question being asked here:
+	//
+	//   - NoSubstantiveActivity is PER-PASS (`linesParsed > 0 && !substantive`).
+	//     An EMPTY pass — zero lines read, e.g. a birth event re-emitted by the
+	//     fswatcher's reconcile sweep (#1286) for a file already tailed — leaves
+	//     it FALSE, which would wave the insubstantial session straight through
+	//     this guard and back to `working`. It is the right flag for the
+	//     activity path below, which asks "did THIS pass change anything".
+	//   - LastEventType is CUMULATIVE: non-empty exactly when at least one
+	//     substantive event has ever been parsed off this transcript. That is
+	//     the birth question — "is there anything at all to classify" — and it
+	//     is the same bail forceReadyToWorkingIfActive already uses.
+	//
+	// With no substantive event on record, every rule in the ladder is
+	// reasoning from absence, so the bootstrap `ready` stands.
+	//
+	// The #1256 copilot case is untouched: its events.jsonl already holds a
+	// real user message at discovery, so LastEventType is set and the open
+	// turn is still caught here.
+	if state.Metrics != nil && state.Metrics.LastEventType != "" {
+		if newState, _ := ClassifyState(state.State, state.Metrics); newState != state.State {
+			state.State = newState
+		}
 	}
 	return state
 }

--- a/core/application/services/session_detector_activity.go
+++ b/core/application/services/session_detector_activity.go
@@ -321,10 +321,23 @@ func (d *SessionDetector) buildNewSessionState(id agent.Identity, ev agent.Event
 	// With no substantive event on record, every rule in the ladder is
 	// reasoning from absence, so the bootstrap `ready` stands.
 	//
+	// CHILDREN ARE EXEMPT, which is why this is an `||` and not one condition.
+	// The child arm above is not about evidence — it is about a child being
+	// COUNTED. A child born `ready` does not count in hasActiveChildren, so a
+	// parent whose own turn-done metrics are unchanged has nothing holding it
+	// and the stale-session sweep flips it back to `ready` while the subagent
+	// is still running (#889). Zero-byte-create parking is gated on
+	// header-linkage and codex is the only adapter that declares it, so a
+	// Claude Code subagent transcript really does emit its birth event at size
+	// zero — exactly the population #889 is about, and exactly the one an
+	// evidence-only guard would drop. Applying the guard to children too was
+	// this fix's own first draft; it silently re-opened #889 and is what the
+	// child case in session_detector_bornready_test.go now pins.
+	//
 	// The #1256 copilot case is untouched: its events.jsonl already holds a
 	// real user message at discovery, so LastEventType is set and the open
 	// turn is still caught here.
-	if state.Metrics != nil && state.Metrics.LastEventType != "" {
+	if state.Metrics != nil && (state.ParentSessionID != "" || state.Metrics.LastEventType != "") {
 		if newState, _ := ClassifyState(state.State, state.Metrics); newState != state.State {
 			state.State = newState
 		}

--- a/core/application/services/session_detector_bornready_test.go
+++ b/core/application/services/session_detector_bornready_test.go
@@ -133,11 +133,22 @@ func TestNewTopLevelSession_StaysReadyWhenNothingToClassify(t *testing.T) {
 // `event_msg`/`task_started`, are explicitly `Skip = true` in its parser, so
 // the metrics that reach the ladder describe nothing at all.
 //
-// The other three classification sites all guard on exactly this flag —
-// session_detector_activity.go's activity path and PID path, and
-// replayengine/engine.go — which is why replaying the same transcript offline
-// still produces the correct `ready` while the live daemon says `working`.
-// The birth path was the only one without the guard.
+// Replaying the same transcript offline still produces the correct `ready`
+// while the live daemon says `working`, because the replay engine bails on
+// insubstantial metrics and the birth path did not.
+//
+// The guard this fix uses is deliberately NOT the one those other sites use,
+// and the asymmetry is the point rather than an oversight. The activity path's
+// skipClassification and replayengine.Engine both gate on
+// NoSubstantiveActivity, a PER-PASS flag (`linesParsed > 0 && !substantive`),
+// so an EMPTY pass leaves it false. The only pre-existing `LastEventType != ""`
+// bails are forceReadyToWorkingIfActive and the replay engine's force-bounce,
+// and birth follows those: the question at birth is cumulative ("has anything
+// ever been parsed off this transcript") rather than per-pass, and
+// applySkippedEvent can mark a pass substantive without ever setting
+// LastEventType. Do not "restore consistency" by switching this to
+// NoSubstantiveActivity — TestSession_BornReadyOnAZeroByteTranscript in
+// core/e2e is the lock that fails when you do.
 func TestNewTopLevelSession_StaysReadyWhenParsedLinesAreAllInsubstantial(t *testing.T) {
 	d := NewSessionDetector(nil, SessionDetectorDeps{
 		Log:     bornLog{},
@@ -155,5 +166,52 @@ func TestNewTopLevelSession_StaysReadyWhenParsedLinesAreAllInsubstantial(t *test
 		t.Errorf("State = %q, want %q — every parsed line was insubstantial, so there is no "+
 			"evidence of an open turn; birthing `working` reports an idle agent as generating",
 			state.State, session.StateReady)
+	}
+}
+
+// TestNewChildSession_StillBornWorkingOnInsubstantialMetrics is a LOCK, not a
+// defect test: it passes on main by construction, because on main every
+// session is classified at birth. It exists because the #1447 fix's first
+// draft broke it, and nothing else in the suite noticed.
+//
+// A child is classified at birth for a reason that has nothing to do with
+// evidence — it is about being COUNTED. hasActiveChildren ignores a child
+// sitting in `ready`, so a parent whose own turn-done metrics are unchanged
+// has nothing holding it, and RunStaleSessionRefresh flips it back to `ready`
+// while the subagent is still running. That is #889 verbatim, and
+// holdParentWorkingForNewChild does not cover it: that hold only moves the
+// parent in memory for an instant, and it is the child's PERSISTED `working`
+// that survives the sweep.
+//
+// The existing #889 tests cannot catch this, which is the whole reason this
+// one is here: workflowChildMetrics hands its child LastEventType "tool_use",
+// so an evidence-based guard passes and they stay green. The population at
+// risk is the child whose transcript is empty or all-skip at discovery — and
+// that is the common case, because the fswatcher parks a zero-byte create only
+// for header-linked adapters and codex is the only one, so a Claude Code
+// subagent transcript emits its birth event at size zero.
+func TestNewChildSession_StillBornWorkingOnInsubstantialMetrics(t *testing.T) {
+	d := NewSessionDetector(nil, SessionDetectorDeps{
+		Log:     bornLog{},
+		Git:     bornGit{},
+		Metrics: insubstantialMetrics{},
+	})
+
+	state := d.buildNewSessionState(
+		agent.Identity{Name: "claude-code"},
+		agent.Event{
+			SessionID:       "child1",
+			ParentSessionID: "parent1",
+			TranscriptPath:  "/tmp/w/child.jsonl",
+			CWD:             "/tmp/w",
+		},
+		1000,
+	)
+
+	if state.State != session.StateWorking {
+		t.Errorf("State = %q, want %q — a child born `ready` does not count in "+
+			"hasActiveChildren, so the stale-session sweep releases its parent while the "+
+			"subagent is still running (#889)",
+			state.State, session.StateWorking)
 	}
 }

--- a/core/application/services/session_detector_bornready_test.go
+++ b/core/application/services/session_detector_bornready_test.go
@@ -37,6 +37,21 @@ func (emptyMetrics) ComputeMetrics(_, _ string) (*session.SessionMetrics, error)
 	return nil, nil
 }
 
+// insubstantialMetrics is what the collector actually returns for an agent
+// whose transcript exists and has been parsed at discovery but whose every
+// line so far carries no observable signal — the tailer's own
+// NoSubstantiveActivity verdict (`linesParsed > 0 && !substantive`).
+//
+// This is NOT the same as emptyMetrics above, and the difference is the whole
+// of issue #1447: emptyMetrics returns a nil pointer, which ClassifyState
+// short-circuits on, so it can never reach the rule ladder. Non-nil metrics
+// always reach the ladder, and the ladder is total.
+type insubstantialMetrics struct{ outbound.MetricsCollector }
+
+func (insubstantialMetrics) ComputeMetrics(_, _ string) (*session.SessionMetrics, error) {
+	return &session.SessionMetrics{NoSubstantiveActivity: true}, nil
+}
+
 // TestNewTopLevelSession_ClassifiedAgainstItsOwnMetrics pins the "born ready"
 // bug found by recording GitHub Copilot's session-end cell (#1256).
 //
@@ -93,6 +108,52 @@ func TestNewTopLevelSession_StaysReadyWhenNothingToClassify(t *testing.T) {
 
 	if state.State != session.StateReady {
 		t.Errorf("State = %q, want %q — a session with no metrics to classify must stay ready",
+			state.State, session.StateReady)
+	}
+}
+
+// TestNewTopLevelSession_StaysReadyWhenParsedLinesAreAllInsubstantial is the
+// defect test for issue #1447: codex sessions became born `working`.
+//
+// The sibling lock above passes only because its collector returns a NIL
+// pointer, and ClassifyState short-circuits on nil (state_classifier.go:
+// `if metrics == nil { return currentState }`). That leaves the
+// non-nil-but-insubstantial case — the one every header-linked adapter
+// actually produces — completely uncovered, and it does not behave the same
+// way at all: non-nil metrics enter the rule ladder, the ladder is
+// deliberately TOTAL (its last rung `transcript_activity` has a nil `when`
+// and always fires), so the verdict is `working` no matter how little
+// evidence there is.
+//
+// Codex hits this on every single session. It is a header-linked adapter
+// (#1055), so the fswatcher parks the zero-byte create and emits
+// EventNewSession only once the rollout's first line is readable — which
+// guarantees the birth event always carries a parseable file and therefore
+// non-nil metrics. Both lines codex has written by then, `session_meta` and
+// `event_msg`/`task_started`, are explicitly `Skip = true` in its parser, so
+// the metrics that reach the ladder describe nothing at all.
+//
+// The other three classification sites all guard on exactly this flag —
+// session_detector_activity.go's activity path and PID path, and
+// replayengine/engine.go — which is why replaying the same transcript offline
+// still produces the correct `ready` while the live daemon says `working`.
+// The birth path was the only one without the guard.
+func TestNewTopLevelSession_StaysReadyWhenParsedLinesAreAllInsubstantial(t *testing.T) {
+	d := NewSessionDetector(nil, SessionDetectorDeps{
+		Log:     bornLog{},
+		Git:     bornGit{},
+		Metrics: insubstantialMetrics{},
+	})
+
+	state := d.buildNewSessionState(
+		agent.Identity{Name: "codex"},
+		agent.Event{SessionID: "s3", TranscriptPath: "/tmp/z/rollout.jsonl", CWD: "/tmp/z"},
+		1000,
+	)
+
+	if state.State != session.StateReady {
+		t.Errorf("State = %q, want %q — every parsed line was insubstantial, so there is no "+
+			"evidence of an open turn; birthing `working` reports an idle agent as generating",
 			state.State, session.StateReady)
 	}
 }

--- a/core/e2e/codex_birth_test.go
+++ b/core/e2e/codex_birth_test.go
@@ -20,17 +20,31 @@ import (
 // the daemon first sees the file, transcribed from recordings of two codex
 // releases fourteen weeks apart.
 //
-// They are here as a PAIR on purpose. Issue #1447 offered two candidate
-// causes for codex sessions being born `working`: upstream drift (codex 0.147
-// materialising its rollout differently than 0.130 did) or a daemon
-// regression. Pinning both versions through the same assertion is what
-// separates them — if the verdict tracked the CLI version, these two subtests
-// would disagree.
+// They are here as a PAIR to pin both shapes, but be precise about what that
+// does and does not prove. Issue #1447 offered two candidate causes for codex
+// sessions being born `working`: upstream drift (codex 0.147 materialising its
+// rollout differently than 0.130 did) or a daemon regression.
 //
-// Shapes verified against:
-//   - 0.130.0: replaydata/agents/codex/scenarios/2-13_turn-end-terminal-text/
-//     recordings/2026-05-23-21-44-53_irrlichd-0.4.7+f83dc27/transcript.jsonl
-//   - 0.147.0: the 2026-08-10 staged re-record of the same cell (#1388)
+// These two subtests CANNOT discriminate between them on their own, and the
+// earlier version of this comment wrongly claimed they could. The only field
+// that differs between the heads is payload.cli_version, which codex's parser
+// turns into ev.AgentVersion on a Skip=true session_meta — and no rule in
+// stateRules reads AgentVersion. The two subtests are therefore incapable of
+// disagreeing. The discrimination happened when these bytes were transcribed
+// and compared, not here.
+//
+// What they DO pin is that both shapes are insubstantial at birth, so a future
+// parser change that starts finding signal in either one is caught.
+//
+// Provenance, which is asymmetric and worth knowing before trusting them:
+//   - 0.130.0 is verifiable from this repo, field-by-field against
+//     replaydata/agents/codex/scenarios/2-13_turn-end-terminal-text/
+//     recordings/2026-05-23-21-44-53_irrlichd-0.4.7+f83dc27/transcript.jsonl.
+//   - 0.147.0 is NOT in the repo. It was transcribed from the 2026-08-10
+//     staged re-record of the same cell, which lives under .build/ in #1388's
+//     worktree and is unpromotable (it was recorded by the very daemon this
+//     fix repairs). A reader cannot check it here. When #1388 lands a
+//     re-recorded fixture, read the head off disk and delete this constant.
 //
 // Both emit session_meta, then event_msg/task_started, 1-3ms apart. The
 // payloads are trimmed to the fields codex's parser dispatches on — it keys
@@ -44,6 +58,46 @@ const (
 {"timestamp":"2026-08-10T00:51:56.769Z","type":"event_msg","payload":{"type":"task_started"}}
 `
 )
+
+// bornState drives one EventNewSession through a real SessionDetector wired
+// to the PRODUCTION metrics adapter, and returns the session as it was first
+// persisted. Both tests below assert on nothing but its State, so the wiring
+// is factored out here rather than repeated around each assertion.
+//
+// The production adapter is the point: the birth path trusts whatever the
+// real collector hands back, and a stub returning nil is exactly what hid
+// #1447 for as long as it hid.
+func bornState(t *testing.T, adapterName, sessionID, transcriptPath, cwd string) *session.SessionState {
+	t.Helper()
+
+	repo := newMemRepo()
+	deps := defaultSessionDetectorDeps(repo)
+	deps.Metrics = realCodexMetrics()
+
+	w := newMockWatcher(1)
+	w.identity = agent.Identity{Name: adapterName}
+	detector := services.NewSessionDetector([]inbound.Watcher{w}, deps)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	go detector.Run(ctx)
+
+	w.ch <- agent.Event{
+		Type:           agent.EventNewSession,
+		SessionID:      sessionID,
+		TranscriptPath: transcriptPath,
+		CWD:            cwd,
+	}
+
+	if !waitForSession(repo, sessionID, 5*time.Second) {
+		t.Fatalf("session %s never reached the repo", sessionID)
+	}
+	got, err := repo.Load(sessionID)
+	if err != nil {
+		t.Fatalf("load session %s: %v", sessionID, err)
+	}
+	return got
+}
 
 // realCodexMetrics builds the production metrics adapter over the real
 // adapter registry, so ComputeMetrics runs codex's own parser rather than a
@@ -123,35 +177,7 @@ func TestCodexSession_BornReadyOnAnInsubstantialRolloutHead(t *testing.T) {
 					m.LastEventType)
 			}
 
-			mc := realCodexMetrics()
-
-			repo := newMemRepo()
-			deps := defaultSessionDetectorDeps(repo)
-			deps.Metrics = mc
-
-			w := newMockWatcher(1)
-			w.identity = agent.Identity{Name: "codex"}
-			detector := services.NewSessionDetector([]inbound.Watcher{w}, deps)
-
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
-			go detector.Run(ctx)
-
-			const sessionID = "019fe927-889e-73d1-98c8-4f1ed0c064a5"
-			w.ch <- agent.Event{
-				Type:           agent.EventNewSession,
-				SessionID:      sessionID,
-				TranscriptPath: rollout,
-				CWD:            dir,
-			}
-
-			if !waitForSession(repo, sessionID, 5*time.Second) {
-				t.Fatalf("session %s never reached the repo", sessionID)
-			}
-			got, err := repo.Load(sessionID)
-			if err != nil {
-				t.Fatalf("load session: %v", err)
-			}
+			got := bornState(t, "codex", "019fe927-889e-73d1-98c8-4f1ed0c064a5", rollout, dir)
 			if got.State != session.StateReady {
 				t.Errorf("born %q, want %q — the rollout head holds only session_meta and "+
 					"task_started, both of which codex's own parser skips, so nothing "+
@@ -195,37 +221,18 @@ func TestSession_BornReadyOnAZeroByteTranscript(t *testing.T) {
 	if m, err := realCodexMetrics().ComputeMetrics(probe, "claude-code"); err != nil {
 		t.Fatalf("ComputeMetrics: %v", err)
 	} else if m == nil {
-		t.Skipf("a zero-byte transcript now yields nil metrics — this arm of #1447 " +
-			"is no longer reachable and this test would pass vacuously")
+		// Fatal, not Skip. This test is the ONLY lock on the
+		// LastEventType-vs-NoSubstantiveActivity choice: mutate the guard to
+		// NoSubstantiveActivity and every other test in this PR stays green
+		// while this one fails. A skip reads as a pass, which would retire
+		// that lock silently — the same reasoning AGENTS.md applies to
+		// posix-lint.sh's three refusals.
+		t.Fatalf("a zero-byte transcript now yields nil metrics — this arm of #1447 is no " +
+			"longer reachable, so this test would pass vacuously and stop locking the " +
+			"guard choice; re-derive it rather than deleting it")
 	}
 
-	repo := newMemRepo()
-	deps := defaultSessionDetectorDeps(repo)
-	deps.Metrics = realCodexMetrics()
-
-	w := newMockWatcher(1)
-	w.identity = agent.Identity{Name: "claude-code"}
-	detector := services.NewSessionDetector([]inbound.Watcher{w}, deps)
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	go detector.Run(ctx)
-
-	const sessionID = "zero-byte-session"
-	w.ch <- agent.Event{
-		Type:           agent.EventNewSession,
-		SessionID:      sessionID,
-		TranscriptPath: transcript,
-		CWD:            dir,
-	}
-
-	if !waitForSession(repo, sessionID, 5*time.Second) {
-		t.Fatalf("session %s never reached the repo", sessionID)
-	}
-	got, err := repo.Load(sessionID)
-	if err != nil {
-		t.Fatalf("load session: %v", err)
-	}
+	got := bornState(t, "claude-code", "zero-byte-session", transcript, dir)
 	if got.State != session.StateReady {
 		t.Errorf("born %q, want %q — the transcript is zero bytes, so no event has been "+
 			"observed at all; only an ABSENT file yields nil metrics, and it is that gap "+

--- a/core/e2e/codex_birth_test.go
+++ b/core/e2e/codex_birth_test.go
@@ -62,12 +62,14 @@ const (
 // bornState drives one EventNewSession through a real SessionDetector wired
 // to the PRODUCTION metrics adapter, and returns the session as it was first
 // persisted. Both tests below assert on nothing but its State, so the wiring
-// is factored out here rather than repeated around each assertion.
+// is factored out here rather than repeated around each assertion. The
+// session's CWD is derived from the transcript's own directory — what both
+// callers want, and one fewer argument for them to keep in sync.
 //
 // The production adapter is the point: the birth path trusts whatever the
 // real collector hands back, and a stub returning nil is exactly what hid
 // #1447 for as long as it hid.
-func bornState(t *testing.T, adapterName, sessionID, transcriptPath, cwd string) *session.SessionState {
+func bornState(t *testing.T, adapterName, sessionID, transcriptPath string) *session.SessionState {
 	t.Helper()
 
 	repo := newMemRepo()
@@ -86,7 +88,7 @@ func bornState(t *testing.T, adapterName, sessionID, transcriptPath, cwd string)
 		Type:           agent.EventNewSession,
 		SessionID:      sessionID,
 		TranscriptPath: transcriptPath,
-		CWD:            cwd,
+		CWD:            filepath.Dir(transcriptPath),
 	}
 
 	if !waitForSession(repo, sessionID, 5*time.Second) {
@@ -177,7 +179,7 @@ func TestCodexSession_BornReadyOnAnInsubstantialRolloutHead(t *testing.T) {
 					m.LastEventType)
 			}
 
-			got := bornState(t, "codex", "019fe927-889e-73d1-98c8-4f1ed0c064a5", rollout, dir)
+			got := bornState(t, "codex", "019fe927-889e-73d1-98c8-4f1ed0c064a5", rollout)
 			if got.State != session.StateReady {
 				t.Errorf("born %q, want %q — the rollout head holds only session_meta and "+
 					"task_started, both of which codex's own parser skips, so nothing "+
@@ -232,7 +234,7 @@ func TestSession_BornReadyOnAZeroByteTranscript(t *testing.T) {
 			"guard choice; re-derive it rather than deleting it")
 	}
 
-	got := bornState(t, "claude-code", "zero-byte-session", transcript, dir)
+	got := bornState(t, "claude-code", "zero-byte-session", transcript)
 	if got.State != session.StateReady {
 		t.Errorf("born %q, want %q — the transcript is zero bytes, so no event has been "+
 			"observed at all; only an ABSENT file yields nil metrics, and it is that gap "+

--- a/core/e2e/codex_birth_test.go
+++ b/core/e2e/codex_birth_test.go
@@ -1,0 +1,235 @@
+// Package e2e — birth-state coverage for header-linked adapters (issue #1447).
+package e2e_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"irrlicht/core/adapters/inbound/agents"
+	"irrlicht/core/adapters/outbound/metrics"
+	"irrlicht/core/application/services"
+	"irrlicht/core/domain/agent"
+	"irrlicht/core/domain/session"
+	"irrlicht/core/ports/inbound"
+)
+
+// Real codex rollout heads — the two lines that exist on disk at the instant
+// the daemon first sees the file, transcribed from recordings of two codex
+// releases fourteen weeks apart.
+//
+// They are here as a PAIR on purpose. Issue #1447 offered two candidate
+// causes for codex sessions being born `working`: upstream drift (codex 0.147
+// materialising its rollout differently than 0.130 did) or a daemon
+// regression. Pinning both versions through the same assertion is what
+// separates them — if the verdict tracked the CLI version, these two subtests
+// would disagree.
+//
+// Shapes verified against:
+//   - 0.130.0: replaydata/agents/codex/scenarios/2-13_turn-end-terminal-text/
+//     recordings/2026-05-23-21-44-53_irrlichd-0.4.7+f83dc27/transcript.jsonl
+//   - 0.147.0: the 2026-08-10 staged re-record of the same cell (#1388)
+//
+// Both emit session_meta, then event_msg/task_started, 1-3ms apart. The
+// payloads are trimmed to the fields codex's parser dispatches on — it keys
+// off the top-level "type" and, for event_msg, payload.type; everything else
+// in the real ~19KB header is data this code path never reads.
+const (
+	codexHead0130 = `{"timestamp":"2026-05-23T19:45:09.665Z","type":"session_meta","payload":{"id":"019e565e-7c1d-7ce3-ad6f-7f422672d7c7","cwd":"/tmp/cwd","originator":"codex-tui","cli_version":"0.130.0","source":"cli"}}
+{"timestamp":"2026-05-23T19:45:09.668Z","type":"event_msg","payload":{"type":"task_started"}}
+`
+	codexHead0147 = `{"timestamp":"2026-08-10T00:51:56.768Z","type":"session_meta","payload":{"id":"019fe927-889e-73d1-98c8-4f1ed0c064a5","cwd":"/tmp/cwd","originator":"codex-tui","cli_version":"0.147.0","source":"cli"}}
+{"timestamp":"2026-08-10T00:51:56.769Z","type":"event_msg","payload":{"type":"task_started"}}
+`
+)
+
+// realCodexMetrics builds the production metrics adapter over the real
+// adapter registry, so ComputeMetrics runs codex's own parser rather than a
+// double. That is the point of putting this test in e2e: the defect is that
+// the birth path trusts whatever the real collector hands back, and a stub
+// returning nil is exactly what hid it.
+func realCodexMetrics() *metrics.Adapter {
+	all := agents.All()
+	return metrics.New(metrics.Registry{
+		Parsers:          agents.Parsers(all),
+		SubagentCounters: agents.SubagentCounters(all),
+		MetricsProviders: agents.MetricsProviders(all),
+		FallbackName:     "claude-code",
+	})
+}
+
+// TestCodexSession_BornReadyOnAnInsubstantialRolloutHead is the end-to-end
+// half of issue #1447's defect test; the unit half is
+// TestNewTopLevelSession_StaysReadyWhenParsedLinesAreAllInsubstantial in
+// core/application/services.
+//
+// Codex is header-linked (#1055): the fswatcher parks the zero-byte create
+// and emits EventNewSession only once the rollout's first line is readable.
+// So unlike Claude Code, codex's birth event ALWAYS carries a parseable file,
+// and ComputeMetrics therefore always returns non-nil metrics. Both lines
+// present at that moment are Skip=true in codex's parser, so those metrics
+// describe no activity whatsoever — but they are not nil, and ClassifyState
+// only short-circuits on nil. The rule ladder is total, so the session was
+// birthed `working` on zero evidence.
+//
+// The user-visible damage is that every codex session appears to be
+// generating from the moment it is discovered until its first real turn
+// boundary, and 34 fixture cells assert the opposite.
+func TestCodexSession_BornReadyOnAnInsubstantialRolloutHead(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		head string
+	}{
+		{"codex 0.130.0 (May 2026 recording)", codexHead0130},
+		{"codex 0.147.0 (Aug 2026 re-record)", codexHead0147},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := realTempDir(t)
+			rollout := filepath.Join(dir, "rollout-2026-01-01T00-00-00-test.jsonl")
+			if err := os.WriteFile(rollout, []byte(tc.head), 0o644); err != nil {
+				t.Fatalf("write rollout: %v", err)
+			}
+
+			// Vacuity guard. If codex's parser ever starts treating either of
+			// these lines as substantive, or ComputeMetrics starts returning
+			// nil for them, the assertion below would pass without exercising
+			// the defect at all — the "stub blind to the asserted field"
+			// failure. Fail loudly instead of reporting a green that proves
+			// nothing.
+			//
+			// Run against a SEPARATE copy of the bytes, through a separate
+			// adapter instance. Tailers are stateful and cached per transcript
+			// path: probing the detector's own file here would consume its
+			// lines, so the detector's pass would read zero new ones and the
+			// test would measure the empty-pass case instead of the
+			// insubstantial-pass case it is about.
+			probeFile := filepath.Join(dir, "probe.jsonl")
+			if err := os.WriteFile(probeFile, []byte(tc.head), 0o644); err != nil {
+				t.Fatalf("write probe: %v", err)
+			}
+			m, err := realCodexMetrics().ComputeMetrics(probeFile, "codex")
+			if err != nil {
+				t.Fatalf("ComputeMetrics: %v", err)
+			}
+			if m == nil {
+				t.Fatalf("ComputeMetrics returned nil metrics — this test no longer reaches " +
+					"the #1447 defect, which is specifically the NON-nil-but-insubstantial case")
+			}
+			if m.LastEventType != "" {
+				t.Fatalf("LastEventType = %q, want empty — codex's parser now finds signal in "+
+					"session_meta/task_started, so this head no longer reproduces #1447",
+					m.LastEventType)
+			}
+
+			mc := realCodexMetrics()
+
+			repo := newMemRepo()
+			deps := defaultSessionDetectorDeps(repo)
+			deps.Metrics = mc
+
+			w := newMockWatcher(1)
+			w.identity = agent.Identity{Name: "codex"}
+			detector := services.NewSessionDetector([]inbound.Watcher{w}, deps)
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			go detector.Run(ctx)
+
+			const sessionID = "019fe927-889e-73d1-98c8-4f1ed0c064a5"
+			w.ch <- agent.Event{
+				Type:           agent.EventNewSession,
+				SessionID:      sessionID,
+				TranscriptPath: rollout,
+				CWD:            dir,
+			}
+
+			if !waitForSession(repo, sessionID, 5*time.Second) {
+				t.Fatalf("session %s never reached the repo", sessionID)
+			}
+			got, err := repo.Load(sessionID)
+			if err != nil {
+				t.Fatalf("load session: %v", err)
+			}
+			if got.State != session.StateReady {
+				t.Errorf("born %q, want %q — the rollout head holds only session_meta and "+
+					"task_started, both of which codex's own parser skips, so nothing "+
+					"observed says the agent is generating",
+					got.State, session.StateReady)
+			}
+		})
+	}
+}
+
+// TestSession_BornReadyOnAZeroByteTranscript covers the second, wider arm of
+// #1447 — and it is the one that makes this a whole-daemon defect rather than
+// a codex quirk.
+//
+// #1256 reasoned that non-header-linked adapters were safe because "there is
+// genuinely nothing to classify at discovery" for an agent that creates its
+// transcript and writes to it later. That is true of the FILE and false of
+// the METRICS. ComputeMetrics returns nil only when the transcript is ABSENT;
+// an existing zero-byte one is opened, tailed, and yields a non-nil metrics
+// struct with nothing in it — which then reaches the total rule ladder and
+// comes back `working`, exactly like codex's insubstantial head.
+//
+// The fswatcher parks the zero-byte create only for header-linked adapters
+// (codex is the only one), so for every OTHER adapter the birth event is free
+// to fire in the window between create and first write. That makes this arm a
+// race rather than a certainty — which is precisely why it went unnoticed:
+// it produces an intermittently wrong opening state instead of a reproducible
+// one.
+func TestSession_BornReadyOnAZeroByteTranscript(t *testing.T) {
+	dir := realTempDir(t)
+	transcript := filepath.Join(dir, "session.jsonl")
+	if err := os.WriteFile(transcript, nil, 0o644); err != nil {
+		t.Fatalf("write empty transcript: %v", err)
+	}
+
+	// Vacuity guard: the whole point is that this is NOT the nil case.
+	probe := filepath.Join(dir, "probe.jsonl")
+	if err := os.WriteFile(probe, nil, 0o644); err != nil {
+		t.Fatalf("write probe: %v", err)
+	}
+	if m, err := realCodexMetrics().ComputeMetrics(probe, "claude-code"); err != nil {
+		t.Fatalf("ComputeMetrics: %v", err)
+	} else if m == nil {
+		t.Skipf("a zero-byte transcript now yields nil metrics — this arm of #1447 " +
+			"is no longer reachable and this test would pass vacuously")
+	}
+
+	repo := newMemRepo()
+	deps := defaultSessionDetectorDeps(repo)
+	deps.Metrics = realCodexMetrics()
+
+	w := newMockWatcher(1)
+	w.identity = agent.Identity{Name: "claude-code"}
+	detector := services.NewSessionDetector([]inbound.Watcher{w}, deps)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go detector.Run(ctx)
+
+	const sessionID = "zero-byte-session"
+	w.ch <- agent.Event{
+		Type:           agent.EventNewSession,
+		SessionID:      sessionID,
+		TranscriptPath: transcript,
+		CWD:            dir,
+	}
+
+	if !waitForSession(repo, sessionID, 5*time.Second) {
+		t.Fatalf("session %s never reached the repo", sessionID)
+	}
+	got, err := repo.Load(sessionID)
+	if err != nil {
+		t.Fatalf("load session: %v", err)
+	}
+	if got.State != session.StateReady {
+		t.Errorf("born %q, want %q — the transcript is zero bytes, so no event has been "+
+			"observed at all; only an ABSENT file yields nil metrics, and it is that gap "+
+			"between absent and empty that this asserts",
+			got.State, session.StateReady)
+	}
+}

--- a/core/e2e/e2e_helpers_test.go
+++ b/core/e2e/e2e_helpers_test.go
@@ -13,11 +13,38 @@ import (
 	"time"
 
 	"irrlicht/core/adapters/inbound/agents/processlifecycle"
+	"irrlicht/core/adapters/outbound/metrics"
 	"irrlicht/core/application/services"
 	"irrlicht/core/domain/agent"
 	"irrlicht/core/domain/session"
 	"irrlicht/core/ports/outbound"
 )
+
+// TestMain redirects the metrics ledger away from the developer's real
+// ~/.local/share/irrlicht/sessions before any test runs.
+//
+// Every ComputeMetrics pass calls saveLedger, and ledgerPath falls back to
+// $HOME unless SetLedgerDir was called — which only the daemon does, in
+// cmd/irrlichd/paths.go. This package's tests hash t.TempDir() names into
+// those filenames, so each run left orphaned ledgers behind that nothing ever
+// reads again (measured: 493 -> 499 across one run of codex_birth_test.go
+// alone, and 510 accumulated before this was added).
+//
+// It has to be TestMain rather than a per-test helper: ensureLedgerDir is a
+// sync.Once, so the override must land before the FIRST ledger operation
+// anywhere in the package. Tests that use stubMetrics never reach it, but any
+// future test wiring the production metrics adapter — codex_birth_test.go is
+// the first — silently would.
+func TestMain(m *testing.M) {
+	dir, err := os.MkdirTemp("", "irrlicht-e2e-ledger-")
+	if err != nil {
+		panic("e2e TestMain: cannot create temp ledger dir: " + err.Error())
+	}
+	metrics.SetLedgerDir(dir)
+	code := m.Run()
+	_ = os.RemoveAll(dir)
+	os.Exit(code)
+}
 
 // defaultSessionDetectorDeps returns the SessionDetectorDeps every e2e test in
 // this package builds identically (nopLogger/stubGit/stubMetrics, no


### PR DESCRIPTION
Closes #1447.

## Verdict: cause 2 — a daemon regression. Not upstream drift.

#1447 offered two candidate causes for codex sessions being born `working`.
The evidence is decisive, and it is archaeological rather than rhetorical.

**1. The May 2026 daemon could not have produced anything but `ready`.**
`f83dc27` — the build that recorded the promoted cell 2-13 fixture — had **no
birth-time classification at all**: `onNewSession` set
`State: session.StateReady` and never called `ClassifyState`. So the specs'
born-`ready` was recording a property of the *daemon*, not of codex. No
upstream change could have produced it, and none is needed to lose it.

**2. Birth-time classification was extended to every session on 2026-08-05.**
`1ee9b18e` (#1332) removed the `if state.ParentSessionID != ""` gate that had
confined it to children since `6714a84d` (#893).

**3. Codex's rollout head did not change across the version in question.**
0.130.0 and 0.147.0 both emit `session_meta`, then `event_msg`/`task_started`,
1–3 ms apart — verified field-by-field against the May recording and the
2026-08-10 staged re-record. Both lines are `Skip = true` in codex's parser,
so the daemon is not detecting a genuinely open turn; it is defaulting with
zero evidence.

**4. The timing moved the *opposite* way to cause 1's prediction.** The Aug
rollout appeared **6.5 s after launch vs May's 16.3 s** — earlier, not later.

**5. Both recorded heads fail identically on unfixed `main`:**

```
--- FAIL: TestCodexSession_BornReadyOnAnInsubstantialRolloutHead
    --- FAIL: .../codex_0.130.0_(May_2026_recording)   born "working", want "ready"
    --- FAIL: .../codex_0.147.0_(Aug_2026_re-record)   born "working", want "ready"
```

One precision, added after review: that subtest **pair cannot by itself
discriminate** the two causes, because the only field differing between the
heads is `cli_version`, which becomes `AgentVersion` on a `Skip=true` line and
is read by no rule in `stateRules`. The discrimination is points 1–4; the pair
pins both shapes so a future parser change is caught. The test comment now
says exactly this rather than overclaiming.

## The defect

`ClassifyState` short-circuits only on a **nil** `*SessionMetrics`. Anything
non-nil enters the rule ladder, and the ladder is deliberately **total** — its
last rung `transcript_activity` has a nil `when` and always fires, returning
`working`. A session whose metrics existed but described nothing was decided
"generating" on zero evidence.

## Blast radius: measured, and wider than inferred

The issue says two cells confirmed and the rest inferred. Measured:

| | count |
|---|---|
| codex cells asserting a session-birth state | **34 cells / 39 assertion lines**, all `ready` |
| confirmed by an actual re-recording | 2 (2-13, 2-19) — the only codex cells with an Aug re-record |
| cells asserting session-birth across **all 11 adapters** | 321 cells / 346 lines |
| adapters structurally affected | **all of them** |

`presession_birth` assertions are **not** affected — the `proc-<PID>` row is
still born `ready` in today's recordings (verified in the staged Aug
`events.jsonl`).

**The defect was never codex-only, and this was not suspected.**
`ComputeMetrics` returns nil only for an **absent** transcript; an existing
**zero-byte** one is tailed and yields a non-nil, empty struct (measured
directly). Codex is the only header-linked adapter (#1055), so it is the only
one that hits this *deterministically* — the fswatcher parks its zero-byte
create and emits `EventNewSession` only once the first line is readable. For
the other ten the birth event is free to fire between create and first write,
making it a **race**: an intermittently wrong opening state, which is why it
read as flakiness. #1256's own comment — that these adapters have "genuinely
nothing to classify at discovery" — is true of the *file* and false of the
*metrics*.

## The fix

One predicate, `shouldClassifyAtBirth`. Two independent reasons to classify:

```go
if state.Metrics == nil { return false }
return state.ParentSessionID != "" || state.Metrics.LastEventType != ""
```

**Why `LastEventType` and not `NoSubstantiveActivity`.** The latter is
**per-pass** (`linesParsed > 0 && !substantive`), so an **empty** pass — a
birth event re-emitted by the reconcile sweep (#1286) over an already-tailed
file — leaves it `false` and waves the session through. I hit this for real:
the first draft used it and the e2e test stayed red, because the test's own
probe had consumed the tailer's lines. `LastEventType` is **cumulative**, and
it is the same bail `forceReadyToWorkingIfActive` already uses. Reviewer
independently confirmed the choice by reading every rung of `stateRules`, and
found the deciding argument: `applySkippedEvent` can mark a pass substantive
without ever setting `LastEventType`.

**Why children are exempt.** Review caught that the first draft re-opened
**#889**. A child is classified at birth not for evidence but to be *counted*:
a child in `ready` does not register in `hasActiveChildren`, so a parent held
up only by its children is released by the stale-session sweep while the
subagent is still running. `holdParentWorkingForNewChild` does not cover it —
that hold moves the parent in memory for one instant; it is the child's
*persisted* `working` that survives. The at-risk population is the common one,
since zero-byte parking applies only to codex.

## No spec was weakened

**No `expected.jsonl` was edited, no `replaydata/` file was touched, and no
replay golden moved** (`git diff --name-only origin/main...HEAD -- replaydata/`
is empty; 0 golden files in the diff). The 34 codex cells asserting
born-`ready` were right; the daemon was wrong. `replay fixtures` and
`replaydata validate` pass untouched — expected, since the replay path already
carried a guard, which is also why replaying a codex transcript offline gave
the right answer while the live daemon did not.

## What this does NOT do — #1388 stays open

`of coverage --hooks` still reports codex `GAP`, and this PR does not change
that:

```
codex   yes   44   36   0   GAP — declares hooks, zero hook-bearing recordings
```

The staged Aug recordings **still cannot be promoted**, because they were
produced by the buggy daemon — their `events.jsonl` literally contains
`state_transition … new_state:"working" reason:"new session created"` (seq 117
of the 2-13 run). Promoting them would bake the defect into the fixtures.
Codex must be **re-recorded against a daemon carrying this fix**; that is
#1388's job and is now unblocked. I deliberately did not drive codex live
here — re-recording plus fixture promotion riding on an unreviewed daemon fix
is a far larger and riskier change than the one this PR is reviewed as.

## Tests

| test | kind | seen red before fix |
|---|---|---|
| `TestNewTopLevelSession_StaysReadyWhenParsedLinesAreAllInsubstantial` | defect | yes — `State = "working", want "ready"` |
| `TestCodexSession_BornReadyOnAnInsubstantialRolloutHead` (0.130.0 + 0.147.0) | defect | yes — both subtests |
| `TestSession_BornReadyOnAZeroByteTranscript` | defect | yes |
| `TestNewChildSession_StillBornWorkingOnInsubstantialMetrics` | **lock** (#889) | no — passes on `main` by construction; it exists because this fix's own first draft broke it |
| `TestNewTopLevelSession_ClassifiedAgainstItsOwnMetrics` | **lock** (#1256 copilot) | no — passes by construction |
| `TestNewTopLevelSession_StaysReadyWhenNothingToClassify` | **lock** | no — passes by construction |

**Mutation-verified**, since three of these are locks and a lock is only worth
what it catches:

- drop the child arm → `TestNewChildSession_…` fails.
- swap to `NoSubstantiveActivity` → every other test stays **green**; only
  `TestSession_BornReadyOnAZeroByteTranscript` fails. It is the sole lock on
  the guard choice, which is why its vacuity guard is `Fatalf` and not `Skipf`.

Both e2e defect tests carry vacuity guards that fail loudly if the parser ever
starts finding signal in these heads.

## Review findings, all applied

1. **Child regression (#889)** — described above.
2. **Ledger leak** — `realCodexMetrics` builds the production metrics adapter,
   whose every pass calls `saveLedger`; `ledgerPath` falls back to `$HOME`
   unless `SetLedgerDir` was called, and only the daemon calls it. `core/e2e`
   had no `TestMain`, so runs orphaned ledgers into the developer's real
   `~/.local/share/irrlicht/sessions` (measured 493 → 499 in one run; 510
   accumulated). Added a `TestMain`; verified the real dir is unchanged across
   a full package run.
3. **A comment that was factually untrue** about where the other guards live —
   it inverted this PR's own rationale, so a reader trusting it would "restore
   consistency" by switching to `NoSubstantiveActivity`. Rewritten.
4. **An overstated test claim** — the two-version pair, corrected above; the
   0.147.0 head's provenance (outside the repo, unpromotable) is now recorded.
5. **`Skipf` → `Fatalf`** on the zero-byte vacuity guard.

CodeScene's two findings were both on code this PR introduced, and both were
fixed rather than suppressed: the complex conditional became
`shouldClassifyAtBirth`, and `bornState` derives `cwd` instead of taking it.

## Verification

Preflight, chunked and foreground, all 7 gates: `go` PASS (gofmt, core tests,
onboarding-factory, replaydata validate, recording-rig smoke, replay fixtures,
starhistory) · `arch` PASS · `tools` PASS · `skills` PASS · `posix` PASS ·
`web` PASS (both trees) · `security` PASS.

Deletion tripwire against live `origin/main`: **empty**.

`go-test` failed once on this head for an infrastructure reason — the runner
could not resolve `codeload.github.com` while downloading `actions/setup-go`,
failing in "Set up job" before any code ran. Re-run: pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)