### PR TITLE
feat(hooks): make path confinement unskippable via DecodeConfined + an architecture rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -158,12 +158,14 @@ Before marking a ticket done, run the full suite — every layer must pass:
   inbound hook body is caller-supplied on a local, unauthenticated endpoint, so
   a receiver confines it to the adapter's own declared transcript roots
   (`agent.Source`'s `FilesUnderRoot.AllRootsFor`, never a second list that can
-  drift) before anything downstream opens it. Five obligations: an in-tree path
-  is still accepted (the vacuity guard); and an out-of-tree path, a `..`
+  drift) before anything downstream opens it. Six obligations: an in-tree path
+  is still accepted (the vacuity guard); an out-of-tree path, a `..`
   traversal, a symlink planted inside the root and a *dangling* symlink inside
-  the root are each refused, logged and counted.
-  A sixth — "the adapter's production constructor confines, not merely the
-  handler the test assembled" — was retired in #1390, and how it went is the
+  the root are each refused, logged and counted; and for a path that IS
+  accepted, the string dispatched downstream is the confined spelling rather
+  than the caller's (#1389 — see the end of this bullet).
+  A DIFFERENT sixth — "the adapter's production constructor confines, not merely
+  the handler the test assembled" — was retired in #1390, and how it went is the
   point rather than that it went. It existed because reaching the rejection
   counter meant calling a second, test-shaped constructor
   (`NewHookHandlerWithConfiner` and friends), so the handler the other five
@@ -200,44 +202,41 @@ Before marking a ticket done, run the full suite — every layer must pass:
   contract asserts the 2xx so a new receiver inherits the rule instead of
   re-deciding it (#1361, #1364). `hookjson.RejectPath` is the single place it
   is implemented, and its doc comment records what was and was not observed.
-  Since #1389 the contract is only half the enforcement, and the weaker half:
-  a contract can fail only for an adapter that WIRED it, so a receiver nobody
-  wired it for is invisible to it — which is exactly how the statusline
-  endpoint shipped unconfined. `hookjson.DecodeConfined` welds the decode to
-  the confinement (the confiner is an argument to the decode, so a receiver
+  Since #1389 the contract is only half the enforcement, and the weaker half: a
+  contract can fail only for an adapter that WIRED it, so a receiver nobody
+  wired it for is invisible to it — which is how the statusline endpoint shipped
+  unconfined in the first place. `hookjson.DecodeConfined` welds the body decode
+  to the confinement (the confiner is an argument to the decode, so a receiver
   cannot reach its payload without supplying one), and
   `core/architecture_hookbody_test.go` fails the build if anything else under
   `core/adapters/inbound/agents/...` reads an inbound request body. Two arms:
-  zero body reads outside `hookjson`, and — the part that keeps the exemption
-  from being a hole — **exactly one** inside it, in `DecodeConfined`. The
-  second arm is also the vacuity guard: if the detector stops matching, that
-  count goes to zero and fails rather than reporting a clean tree. **The
-  proposal in #1389 is not what shipped**: it keyed on "a file referencing a
-  `HookEndpointPath` may not call `json.NewDecoder(r.Body)`", and that
-  selects nothing — `HookEndpointPath` appears only in the three
-  `hookinstaller.go` files, which never touch `r.Body`, and statusline's
-  constant is `StatuslineEndpointPath`. It would have passed vacuously on day
-  one and against the very bug it was written for. The repair was to stop
-  trying to recognize "a hook-receiving file" at all: with no file pattern
-  there is no file a new receiver can hide in, because the predicate is the
-  untrusted-input operation itself. What it does **not** cover: a receiver
-  defined outside the agents tree, one that hands the whole `*http.Request`
-  to a package outside it (handing out `r.Body` IS caught; handing out `r` is
-  not), and `_test.go` files — that last being near-harmless here, unlike for
-  the layering rules, since a receiver declared in a test file is never on the
-  production mux. A rule with no exemption list is the deliberate choice
-  (`architecture_test.go` has none either): a future endpoint that genuinely
-  carries no path amends the rule in a reviewable diff rather than being
-  waved through by an allowlist with no test behind it.
-  One ordering moved with it. codex and copilot checked the `transcripts`
-  consent BETWEEN the decode and the confinement; welding those two put that
-  check above the pair. Consent gates reading the USER's data and a POST body
-  is not that, so the only behavioural difference is that a malformed body
-  from a transcripts-denied session now gets the same quiet 200 as a
-  well-formed one instead of a 400. The receipt observation deliberately did
-  NOT move: it is counted against the `hooks` consent only, because a
-  hooks-granted / transcripts-denied install has a working channel the
-  liveness watchdog must not call dead (#1368).
+  none outside `hookjson`, and **exactly one** inside it, in `DecodeConfined` —
+  the second is what stops the exemption being a hole, and doubles as the
+  vacuity guard. There is deliberately **no exemption list** (neither has
+  `architecture_test.go`): an endpoint that genuinely carries no path amends the
+  rule in a reviewable diff. The archaeology — why the rule #1389 proposed
+  (keying on files referencing a `HookEndpointPath`) selects zero receiver files
+  and would have passed against the very bug it was written for, and the four
+  things the implemented rule does not cover — is in that file's header, next to
+  the code it constrains, rather than restated here.
+  Obligation 6 is #1389's too, and note it is NOT the #1390 one described above:
+  that one policed WIRING and was replaced by a type guarantee, this one polices
+  the VALUE that travels and cannot be. Obligations 1-5 are all about the
+  accept/refuse DECISION, and every one of them is satisfied by a receiver that
+  decides correctly and then forwards the caller's own string anyway — measured,
+  by replacing a receiver's write-back with a no-op and watching the whole suite
+  stay green. Two independent layers now catch it, and each was seen red with
+  the other disabled: `DecodeConfined` verifies its own postcondition (the
+  caller's `get`/`set` pair must address the same field, else fail closed), and
+  the contract posts an in-tree path spelled with a redundant `/./` and asserts
+  the dispatched string is not the caller's. The contract checks the *spelling*
+  rather than string-equality with the fixture, because the confiner rebuilds an
+  accepted path on the adapter's DECLARED root — which on macOS is the `/var`
+  spelling of a `/private/var` temp dir, and a naive comparison fails there for
+  a reason unrelated to the obligation.
+  `DecodeConfined` also bounds the body (`http.MaxBytesReader`, 1 MiB): these
+  endpoints are unauthenticated and local, and sharing one decode is what lets
+  every receiver, present and future, inherit the bound.
 - Hook version floors: `contracttesting.AssertHookVersionGate`
   (`core/internal/contracttesting/hook_version.go`) is the static half of
   #1365 — a hooks permission declares the minimum upstream CLI version its

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,6 +83,22 @@ Before marking a ticket done, run the full suite — every layer must pass:
   `hookjson` adapter was an import that no rule in the table forbade; the
   shared code went to a new leaf (`core/pkg/jsonc`) and the missing rule was
   added with it.
+  A second architecture rule lives beside it in
+  `core/architecture_hookbody_test.go` (#1389) and is deliberately a separate
+  file: the layering table asks a question about the IMPORT GRAPH, while that
+  one asks which EXPRESSIONS a function may contain, and needs
+  `NeedSyntax|NeedTypes|NeedTypesInfo` over a narrow pattern rather than
+  `NeedName|NeedImports` over the module. It enforces that inside
+  `core/adapters/inbound/agents/...` an inbound `*http.Request`'s body may be
+  read only by `hookjson.DecodeConfined` — see "Hook path confinement" below
+  for why. Its corpus is `core/architecture_hookbody_shapes_test.go`: one file
+  per spelling (decoder in a variable, `io.ReadAll`, an aliased body, a helper
+  in another file, `r.FormValue`, a request stashed in a struct field) pinned
+  to the verdict the detector must return, plus two `want:false` cases —
+  `*http.Response.Body` and `r.Method` — that pin the false positives a
+  name-based rule would produce. Every case asserts the construct it plants is
+  actually present in its own source before any verdict is checked, because a
+  corpus that quietly stops containing its own test cases reads as a pass.
 - Architecture score: `tools/ars-gate.sh` flags it when the Agent Readiness
   Score (composite or any category) regresses vs `origin/main` — advisory,
   not a merge gate: it runs as a PR check (`.github/workflows/ars-gate.yml`,
@@ -184,6 +200,44 @@ Before marking a ticket done, run the full suite — every layer must pass:
   contract asserts the 2xx so a new receiver inherits the rule instead of
   re-deciding it (#1361, #1364). `hookjson.RejectPath` is the single place it
   is implemented, and its doc comment records what was and was not observed.
+  Since #1389 the contract is only half the enforcement, and the weaker half:
+  a contract can fail only for an adapter that WIRED it, so a receiver nobody
+  wired it for is invisible to it — which is exactly how the statusline
+  endpoint shipped unconfined. `hookjson.DecodeConfined` welds the decode to
+  the confinement (the confiner is an argument to the decode, so a receiver
+  cannot reach its payload without supplying one), and
+  `core/architecture_hookbody_test.go` fails the build if anything else under
+  `core/adapters/inbound/agents/...` reads an inbound request body. Two arms:
+  zero body reads outside `hookjson`, and — the part that keeps the exemption
+  from being a hole — **exactly one** inside it, in `DecodeConfined`. The
+  second arm is also the vacuity guard: if the detector stops matching, that
+  count goes to zero and fails rather than reporting a clean tree. **The
+  proposal in #1389 is not what shipped**: it keyed on "a file referencing a
+  `HookEndpointPath` may not call `json.NewDecoder(r.Body)`", and that
+  selects nothing — `HookEndpointPath` appears only in the three
+  `hookinstaller.go` files, which never touch `r.Body`, and statusline's
+  constant is `StatuslineEndpointPath`. It would have passed vacuously on day
+  one and against the very bug it was written for. The repair was to stop
+  trying to recognize "a hook-receiving file" at all: with no file pattern
+  there is no file a new receiver can hide in, because the predicate is the
+  untrusted-input operation itself. What it does **not** cover: a receiver
+  defined outside the agents tree, one that hands the whole `*http.Request`
+  to a package outside it (handing out `r.Body` IS caught; handing out `r` is
+  not), and `_test.go` files — that last being near-harmless here, unlike for
+  the layering rules, since a receiver declared in a test file is never on the
+  production mux. A rule with no exemption list is the deliberate choice
+  (`architecture_test.go` has none either): a future endpoint that genuinely
+  carries no path amends the rule in a reviewable diff rather than being
+  waved through by an allowlist with no test behind it.
+  One ordering moved with it. codex and copilot checked the `transcripts`
+  consent BETWEEN the decode and the confinement; welding those two put that
+  check above the pair. Consent gates reading the USER's data and a POST body
+  is not that, so the only behavioural difference is that a malformed body
+  from a transcripts-denied session now gets the same quiet 200 as a
+  well-formed one instead of a 400. The receipt observation deliberately did
+  NOT move: it is counted against the `hooks` consent only, because a
+  hooks-granted / transcripts-denied install has a working channel the
+  liveness watchdog must not call dead (#1368).
 - Hook version floors: `contracttesting.AssertHookVersionGate`
   (`core/internal/contracttesting/hook_version.go`) is the static half of
   #1365 — a hooks permission declares the minimum upstream CLI version its

--- a/core/adapters/inbound/agents/claudecode/hookpath_test.go
+++ b/core/adapters/inbound/agents/claudecode/hookpath_test.go
@@ -53,6 +53,13 @@ func TestHookPathConfined(t *testing.T) {
 			return contracttesting.HookReceiverUnderTest{
 				Handler:  NewHookHandler(target, nil, nil, mockLogger{}),
 				Observed: func() bool { return len(target.getCalls()) > 0 },
+				ObservedPath: func() string {
+					calls := target.getCalls()
+					if len(calls) == 0 {
+						return ""
+					}
+					return calls[len(calls)-1].transcriptPath
+				},
 			}
 		},
 		PayloadFor: func(transcriptPath string) string {
@@ -85,6 +92,12 @@ func TestStatuslinePathConfined(t *testing.T) {
 			return contracttesting.HookReceiverUnderTest{
 				Handler:  NewStatuslineHandler(target, nil, silentLogger{}),
 				Observed: func() bool { return len(target.calls) > 0 },
+				ObservedPath: func() string {
+					if len(target.calls) == 0 {
+						return ""
+					}
+					return target.calls[len(target.calls)-1].path
+				},
 			}
 		},
 		// A rate_limits block is required or the handler acks and returns

--- a/core/adapters/inbound/agents/claudecode/hooks.go
+++ b/core/adapters/inbound/agents/claudecode/hooks.go
@@ -276,23 +276,21 @@ func serveHookRequest(target HookTarget, markers MarkerTarget, gate ConsentGrant
 	// counts and why a consent-denied request must not.
 	hookjson.ObserveHookReceipt(AdapterName)
 
-	var payload hookPayload
-	if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
-		http.Error(w, "bad request: invalid JSON", http.StatusBadRequest)
-		return
-	}
-
 	// transcript_path arrives in an HTTP body on a local, unauthenticated
 	// endpoint, so it is untrusted: every dispatch below hands it to the
-	// detector, which opens it. Confine it to the adapter's declared transcript
-	// roots before anything downstream sees it, and carry the confined path —
-	// not the caller's string — onward (issue #1361).
-	transcriptPath, reason := confiner.Confine(payload.TranscriptPath)
-	if reason != hookjson.RejectNone {
-		hookjson.RejectPath(w, log, logComponentHookReceiver, payload.TranscriptPath, reason)
+	// detector, which opens it. DecodeConfined reads the body and confines the
+	// path in one step, so this receiver cannot reach its payload without
+	// having supplied the confiner — and the caller's raw string is overwritten
+	// with the confined one, so nothing below can pick it back up (issues
+	// #1361, #1389). It has already answered the request when it returns false.
+	var payload hookPayload
+	if !hookjson.DecodeConfined(w, r, log, logComponentHookReceiver, confiner, &payload,
+		func(p *hookPayload) string { return p.TranscriptPath },
+		func(p *hookPayload, confined string) { p.TranscriptPath = confined },
+	) {
 		return
 	}
-	payload.TranscriptPath = transcriptPath
+	transcriptPath := payload.TranscriptPath
 
 	// Confinement already rejected an empty or non-.jsonl path, so the only
 	// input still reaching this is a basename that is bare ".jsonl" — an empty

--- a/core/adapters/inbound/agents/claudecode/statusline.go
+++ b/core/adapters/inbound/agents/claudecode/statusline.go
@@ -21,7 +21,6 @@
 package claudecode
 
 import (
-	"encoding/json"
 	"net/http"
 	"time"
 
@@ -101,12 +100,6 @@ func serveStatuslineRequest(target RateLimitIngester, gate ConsentGranter, log o
 		return
 	}
 
-	var payload statuslinePayload
-	if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
-		http.Error(w, "bad request: invalid JSON", http.StatusBadRequest)
-		return
-	}
-
 	// The statusline endpoint sits on the same local, unauthenticated mux
 	// as the hook receivers and takes the same caller-supplied path, so it
 	// is confined by the same rule (issue #1361). Its sink is a map lookup
@@ -114,12 +107,18 @@ func serveStatuslineRequest(target RateLimitIngester, gate ConsentGranter, log o
 	// what keeps this receiver keying the tailer map with the SAME spelling
 	// the hook receiver now uses. Two spellings of one file are two
 	// sessions, and the rate-limit snapshot would land on neither.
-	transcriptPath, reason := confiner.Confine(payload.TranscriptPath)
-	if reason != hookjson.RejectNone {
-		hookjson.RejectPath(w, log, logComponentStatuslineReceiver, payload.TranscriptPath, reason)
+	//
+	// This is the receiver #1361's first cut forgot, three lines from the one
+	// it was fixing. Going through DecodeConfined is what makes forgetting it
+	// a build failure rather than a review catch (issue #1389).
+	var payload statuslinePayload
+	if !hookjson.DecodeConfined(w, r, log, logComponentStatuslineReceiver, confiner, &payload,
+		func(p *statuslinePayload) string { return p.TranscriptPath },
+		func(p *statuslinePayload, confined string) { p.TranscriptPath = confined },
+	) {
 		return
 	}
-	payload.TranscriptPath = transcriptPath
+	transcriptPath := payload.TranscriptPath
 
 	sessionID := sessionIDFromTranscriptPath(transcriptPath)
 	snap := statuslineToSnapshot(payload.RateLimits)

--- a/core/adapters/inbound/agents/codex/hookpath_test.go
+++ b/core/adapters/inbound/agents/codex/hookpath_test.go
@@ -59,6 +59,15 @@ func TestHookPathConfined(t *testing.T) {
 			return contracttesting.HookReceiverUnderTest{
 				Handler:  NewHookHandler(target, nil, mockLogger{}),
 				Observed: func() bool { return target.totalCalls() > 0 },
+				ObservedPath: func() string {
+					if stops := target.getStopCalls(); len(stops) > 0 {
+						return stops[len(stops)-1].transcriptPath
+					}
+					if perms := target.getPermCalls(); len(perms) > 0 {
+						return perms[len(perms)-1].transcriptPath
+					}
+					return ""
+				},
 			}
 		},
 		WriteTranscript: writeContractTranscript,

--- a/core/adapters/inbound/agents/codex/hooks.go
+++ b/core/adapters/inbound/agents/codex/hooks.go
@@ -24,7 +24,6 @@
 package codex
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"runtime"
@@ -138,37 +137,43 @@ func serveHookRequest(target HookTarget, gate ConsentGranter, log outbound.Logge
 	// install has a working channel that this counter must not call dead.
 	hookjson.ObserveHookReceipt(AdapterName)
 
-	var payload codexHookPayload
-	if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
-		http.Error(w, "bad request: invalid JSON", http.StatusBadRequest)
-		return
-	}
-
 	// Resolving the session id opens and parses the Codex transcript file — a
 	// transcript read, so it must be gated behind the "transcripts" consent,
 	// not merely the "hooks" write consent (issue #1174). A hooks-granted /
 	// transcripts-denied session is not monitored anyway, so dropping the hook
 	// here is both consent-correct and behaviourally harmless.
 	//
-	// The consent check comes BEFORE confinement so a denied session still
-	// yields a quiet 200: a user who has not granted transcript access should
-	// not have hooks failing at them, and the path is never resolved on that
-	// branch anyway.
+	// The consent check comes BEFORE the decode, and so before confinement, so
+	// a denied session still yields a quiet 200: a user who has not granted
+	// transcript access should not have hooks failing at them, and the path is
+	// never resolved on that branch. It used to sit between the decode and the
+	// confinement; #1389 welded those two into one call, and this moved above
+	// the pair rather than being folded into it. What consent gates is reading
+	// the USER's data, and a POST body is not that — the only behavioural
+	// difference is that a malformed body from a transcripts-denied session now
+	// gets the same quiet 200 as a well-formed one instead of a 400. The
+	// receipt above deliberately stays put: it is counted against the "hooks"
+	// consent only, since a hooks-granted / transcripts-denied install has a
+	// working channel this counter must not call dead (#1368).
 	if gate != nil && !gate.Granted(AdapterName, PermissionKeyTranscripts) {
 		w.WriteHeader(http.StatusOK)
 		return
 	}
+
 	// transcript_path arrives in an HTTP body on a local, unauthenticated
 	// endpoint, so it is untrusted: any local process could otherwise steer the
-	// daemon into opening a file of its choosing. Confine it to the declared
-	// sessions tree before any read, and carry the confined path downstream so
-	// the target reads that and not the caller's string (issue #1361).
-	transcriptPath, reason := confiner.Confine(payload.TranscriptPath)
-	if reason != hookjson.RejectNone {
-		hookjson.RejectPath(w, log, logComponentHookReceiver, payload.TranscriptPath, reason)
+	// daemon into opening a file of its choosing. DecodeConfined reads the body
+	// and confines the path in one step that cannot be half-taken, and
+	// overwrites the caller's string with the confined one so the target reads
+	// that (issues #1361, #1389). It has already answered when it returns false.
+	var payload codexHookPayload
+	if !hookjson.DecodeConfined(w, r, log, logComponentHookReceiver, confiner, &payload,
+		func(p *codexHookPayload) string { return p.TranscriptPath },
+		func(p *codexHookPayload, confined string) { p.TranscriptPath = confined },
+	) {
 		return
 	}
-	payload.TranscriptPath = transcriptPath
+	transcriptPath := payload.TranscriptPath
 
 	sessionID := sessionIDFromPath(transcriptPath)
 	if sessionID == "" {

--- a/core/adapters/inbound/agents/copilot/hookpath_test.go
+++ b/core/adapters/inbound/agents/copilot/hookpath_test.go
@@ -19,6 +19,15 @@ func TestHookPathConfined(t *testing.T) {
 			return contracttesting.HookReceiverUnderTest{
 				Handler:  NewHookHandler(target, nil, mockLogger{}),
 				Observed: func() bool { return target.totalCalls() > 0 },
+				ObservedPath: func() string {
+					if stops := target.stops(); len(stops) > 0 {
+						return stops[len(stops)-1].transcriptPath
+					}
+					if perms := target.perms(); len(perms) > 0 {
+						return perms[len(perms)-1].transcriptPath
+					}
+					return ""
+				},
 			}
 		},
 		WriteTranscript: writeContractTranscript,

--- a/core/adapters/inbound/agents/copilot/hooks.go
+++ b/core/adapters/inbound/agents/copilot/hooks.go
@@ -41,7 +41,6 @@
 package copilot
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"path/filepath"
@@ -196,33 +195,39 @@ func serveHookRequest(target HookTarget, gate ConsentGranter, log outbound.Logge
 	// install has a working channel this counter must not call dead.
 	hookjson.ObserveHookReceipt(AdapterName)
 
-	var payload copilotHookPayload
-	if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
-		http.Error(w, "bad request: invalid JSON", http.StatusBadRequest)
-		return
-	}
-
 	// Dispatching makes the detector read the transcript, so it is gated
 	// behind the "transcripts" consent, not merely the "hooks" write consent.
-	// The check comes BEFORE confinement so a denied session still yields a
-	// quiet 200 and the path is never resolved on that branch.
+	// The check comes BEFORE the decode, and so before confinement, so a denied
+	// session still yields a quiet 200 and the path is never resolved on that
+	// branch. It used to sit between the decode and the confinement; #1389
+	// welded those two into one call, and this moved above the pair rather than
+	// being folded into it — see codex's receiver for the full argument, which
+	// this one mirrors step for step.
 	if gate != nil && !gate.Granted(AdapterName, PermissionKeyTranscripts) {
 		w.WriteHeader(http.StatusOK)
 		return
 	}
 
-	raw := resolveTranscriptPath(payload)
-
 	// The path arrives in an HTTP body on a local, unauthenticated endpoint, so
 	// it is untrusted even when we assembled it ourselves from a caller-supplied
 	// session id: any local process could otherwise steer the daemon into
-	// opening a file of its choosing by sending "../../..". Confine before any
-	// read and carry the confined path downstream (issue #1361).
-	transcriptPath, reason := confiner.Confine(raw)
-	if reason != hookjson.RejectNone {
-		hookjson.RejectPath(w, log, logComponentHookReceiver, raw, reason)
+	// opening a file of its choosing by sending "../../..". DecodeConfined
+	// reads the body and confines in one step (issues #1361, #1389).
+	//
+	// This receiver is why DecodeConfined takes a get FUNCTION rather than a
+	// field name: on Notification there is no transcript path in the envelope
+	// at all, and resolveTranscriptPath synthesizes one from the session id.
+	// Synthesized or not, it goes through the same confiner — and the write-back
+	// then leaves payload.TranscriptPath holding the confined path on BOTH
+	// branches, where before it kept the caller's raw string on Stop.
+	var payload copilotHookPayload
+	if !hookjson.DecodeConfined(w, r, log, logComponentHookReceiver, confiner, &payload,
+		func(p *copilotHookPayload) string { return resolveTranscriptPath(*p) },
+		func(p *copilotHookPayload, confined string) { p.TranscriptPath = confined },
+	) {
 		return
 	}
+	transcriptPath := payload.TranscriptPath
 
 	sessionID := sessionIDFromPath(transcriptPath)
 	if sessionID == "" {

--- a/core/adapters/inbound/agents/hookjson/decode.go
+++ b/core/adapters/inbound/agents/hookjson/decode.go
@@ -1,0 +1,102 @@
+// decode.go holds the one place an inbound hook body may be read (issue #1389).
+//
+// #1361 made confinement a shared helper and #1380 added
+// contracttesting.AssertHookPathConfined so a receiver could not skip it
+// silently — but a contract can only fail for an adapter that WIRED it. A
+// receiver nobody wired it for is invisible to it, which is exactly how #1361
+// shipped its own statusline endpoint unconfined, three lines from the receiver
+// it was fixing.
+//
+// The fix is not another check on the receivers; it is removing the step at
+// which one can go wrong. Every receiver does the same two things in the same
+// order — decode the body, then confine the transcript path it names — and the
+// first is unskippable while the second is optional only because they are two
+// calls. DecodeConfined welds them: the confiner is an ARGUMENT to the decode,
+// so a receiver cannot reach its payload without having supplied one.
+//
+// The other half is core/architecture_hookbody_test.go, which fails the build
+// if anything under core/adapters/inbound/agents/... reads an inbound request
+// body other than this function. That is what turns "the next adapter must
+// remember" into "the next adapter cannot forget": the contract polices
+// adapters that opted in, the architecture rule polices the ones that did not.
+//
+// Rejected, and settled — do not revisit: a mux-level middleware. It would have
+// to key on a top-level "transcript_path" JSON field and would FAIL OPEN for
+// any future payload that nests or renames it, finding nothing and confining
+// nothing while registerHookRoutes still looked guarded. An explicit call that
+// fails closed is strictly better than an implicit one that fails open.
+package hookjson
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"irrlicht/core/ports/outbound"
+)
+
+// DecodeConfined decodes an inbound hook body into p and confines the
+// transcript path that body names, in one step neither half of which can be
+// taken alone.
+//
+// It reports whether the payload survived. On false the response has ALREADY
+// been written and the caller must return without dispatching: an undecodable
+// body answers 400, and a refused path answers through RejectPath — 2xx, with
+// the refusal reported by the log and the confiner's counters rather than by a
+// status code on the user's critical path (#1361, #1364).
+//
+// get returns the path to confine. It is a function rather than a field name
+// because the path is not always a field: copilot's Notification envelope
+// carries none at all and synthesizes one from a caller-supplied session id
+// against the adapter's own root. Synthesized or not, it is caller-influenced
+// and goes through the same confiner.
+//
+// set writes the confined path back into the payload, and is mandatory rather
+// than optional on purpose. The confined path being AVAILABLE is not the
+// property worth having — every receiver already had that. The property worth
+// having is that the caller's raw string is GONE from the payload by the time
+// the receiver dispatches, so a downstream line that reaches for
+// payload.TranscriptPath out of habit cannot pick the unconfined one back up.
+// That is the #1361 defect shape, and leaving set nil would leave the door
+// open.
+//
+// Deliberately NOT handled here: the consent gates. Both the "hooks" gate and
+// the receipt observation must happen before this call (a body we then refuse
+// still proves the channel is alive, #1368), and the adapters that additionally
+// gate "transcripts" check it before calling in. Folding consent into the
+// decode would make this function the place four different obligations are
+// re-decided per adapter, which is the shape #1364's IgnoreUnknownEvent
+// deliberately avoids by taking no ResponseWriter.
+func DecodeConfined[T any](
+	w http.ResponseWriter,
+	r *http.Request,
+	log outbound.Logger,
+	component string,
+	c *PathConfiner,
+	p *T,
+	get func(*T) string,
+	set func(*T, string),
+) bool {
+	// Fail closed on a receiver wired without a confiner. Returning "not
+	// decoded" drops the payload with a 2xx, the same shape every other refusal
+	// takes, rather than dispatching an unconfined path because the guard
+	// itself was missing.
+	if c == nil {
+		log.LogError(component, "", "hook body dropped: receiver has no path confiner")
+		w.WriteHeader(http.StatusOK)
+		return false
+	}
+
+	if err := json.NewDecoder(r.Body).Decode(p); err != nil {
+		http.Error(w, "bad request: invalid JSON", http.StatusBadRequest)
+		return false
+	}
+
+	raw := get(p)
+	confined, reason := c.Confine(raw)
+	if reason != RejectNone {
+		RejectPath(w, log, component, raw, reason)
+		return false
+	}
+	set(p, confined)
+	return true
+}

--- a/core/adapters/inbound/agents/hookjson/decode.go
+++ b/core/adapters/inbound/agents/hookjson/decode.go
@@ -29,10 +29,14 @@ package hookjson
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 
 	"irrlicht/core/ports/outbound"
 )
+
+// maxHookBodyBytes bounds an inbound hook envelope. See DecodeConfined.
+const maxHookBodyBytes = 1 << 20
 
 // DecodeConfined decodes an inbound hook body into p and confines the
 // transcript path that body names, in one step neither half of which can be
@@ -86,6 +90,14 @@ func DecodeConfined[T any](
 		return false
 	}
 
+	// Bound the body. These endpoints are unauthenticated and local, so an
+	// unbounded decode is a local process's way to make the daemon allocate
+	// without limit. The daemon's other inbound decoders already do this; the
+	// hook receivers now share one decode, so they get it in one place and a
+	// fifth receiver inherits it. 1 MiB is far above any real hook envelope —
+	// the largest field is a truncated last_assistant_message.
+	r.Body = http.MaxBytesReader(w, r.Body, maxHookBodyBytes)
+
 	if err := json.NewDecoder(r.Body).Decode(p); err != nil {
 		http.Error(w, "bad request: invalid JSON", http.StatusBadRequest)
 		return false
@@ -98,5 +110,26 @@ func DecodeConfined[T any](
 		return false
 	}
 	set(p, confined)
+
+	// Postcondition: get and set must name the SAME location, or the payload
+	// still holds the caller's raw string while this function reports success.
+	//
+	// This is not defensive clutter — it is the one failure this design could
+	// otherwise not detect, and it was found green by review. Passing behaviour
+	// as two closures puts the obligation at each call site, where no checker
+	// can see it: a receiver whose set writes a field its get never reads (or a
+	// no-op set, which is a one-character edit away) forwards the unconfined
+	// path, and every test in the tree still passes — including
+	// AssertHookPathConfined, which asserts THAT the receiver dispatched, never
+	// WHICH spelling it dispatched. Verifying it here fails closed once, for
+	// every present and future receiver, instead of asking four contract
+	// wirings to each notice.
+	if got := get(p); got != confined {
+		log.LogError(component, "", fmt.Sprintf(
+			"hook body dropped: payload still names %q after confinement to %q — "+
+				"this receiver's get/set pair do not address the same field", got, confined))
+		w.WriteHeader(http.StatusOK)
+		return false
+	}
 	return true
 }

--- a/core/adapters/inbound/agents/hookjson/decode_test.go
+++ b/core/adapters/inbound/agents/hookjson/decode_test.go
@@ -22,7 +22,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
-	"runtime"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -35,30 +35,19 @@ type decodeTestPayload struct {
 func getDecodePath(p *decodeTestPayload) string           { return p.TranscriptPath }
 func setDecodePath(p *decodeTestPayload, confined string) { p.TranscriptPath = confined }
 
-// decodeLogger records LogError calls so a refusal can be asserted to have been
-// reported, not merely to have happened.
-type decodeLogger struct{ errs []string }
-
-func (l *decodeLogger) LogInfo(eventType, sessionID, msg string)  {}
-func (l *decodeLogger) LogError(eventType, sessionID, msg string) { l.errs = append(l.errs, msg) }
-func (l *decodeLogger) LogProcessingTime(eventType, sessionID string, ms int64, size int, result string) {
-}
-func (l *decodeLogger) Close() error { return nil }
-
 // decodeConfinerRooted builds a confiner over a real temp root, matching how
 // the adapters build theirs (an absolute root, ".jsonl" leaves).
+//
+// No symlink pre-resolution of the root: containedIn resolves the DECLARED root
+// itself and rebuilds the accepted path on the unresolved spelling, so a bare
+// t.TempDir() confines correctly on darwin despite /var -> /private/var. The
+// first draft carried an EvalSymlinks block here whose comment claimed the
+// opposite; confine_test.go has passed a raw t.TempDir() to staticRoots all
+// along, which is the evidence it was never needed.
 func decodeConfinerRooted(t *testing.T) (*PathConfiner, string) {
 	t.Helper()
 	root := t.TempDir()
-	if runtime.GOOS == "darwin" {
-		// /var is a symlink to /private/var; the confiner resolves symlinks
-		// before containment, so the declared root must be the resolved one or
-		// every in-tree path reads as an escape.
-		if resolved, err := filepath.EvalSymlinks(root); err == nil {
-			root = resolved
-		}
-	}
-	return NewPathConfiner(func() []string { return []string{root} }, ".jsonl"), root
+	return staticRoots(root), root
 }
 
 func postDecode(t *testing.T, body string) *http.Request {
@@ -84,13 +73,13 @@ func TestDecodeConfined_AcceptsInTreePathAndErasesTheRawString(t *testing.T) {
 	raw := root + "/./session.jsonl"
 	rec := httptest.NewRecorder()
 	var p decodeTestPayload
-	log := &decodeLogger{}
+	log := &countingLogger{}
 
-	ok := DecodeConfined(rec, postDecode(t, `{"transcript_path":`+quote(raw)+`,"hook_event_name":"Stop"}`),
+	ok := DecodeConfined(rec, postDecode(t, `{"transcript_path":`+strconv.Quote(raw)+`,"hook_event_name":"Stop"}`),
 		log, "test-receiver", confiner, &p, getDecodePath, setDecodePath)
 
 	if !ok {
-		t.Fatalf("in-tree transcript refused; status=%d logs=%v", rec.Code, log.errs)
+		t.Fatalf("in-tree transcript refused; status=%d, logged %d line(s)", rec.Code, len(log.lines))
 	}
 	if p.Event != "Stop" {
 		t.Errorf("hook_event_name = %q, want %q — the payload was not decoded", p.Event, "Stop")
@@ -111,7 +100,7 @@ func TestDecodeConfined_UndecodableBodyIs400(t *testing.T) {
 	var p decodeTestPayload
 
 	ok := DecodeConfined(rec, postDecode(t, `{"transcript_path": NOT JSON`),
-		&decodeLogger{}, "test-receiver", confiner, &p, getDecodePath, setDecodePath)
+		&countingLogger{}, "test-receiver", confiner, &p, getDecodePath, setDecodePath)
 
 	if ok {
 		t.Fatal("undecodable body reported as decoded")
@@ -133,9 +122,9 @@ func TestDecodeConfined_OutOfTreePathIsRefusedCountedAnd2xx(t *testing.T) {
 	}
 	rec := httptest.NewRecorder()
 	var p decodeTestPayload
-	log := &decodeLogger{}
+	log := &countingLogger{}
 
-	ok := DecodeConfined(rec, postDecode(t, `{"transcript_path":`+quote(outside)+`}`),
+	ok := DecodeConfined(rec, postDecode(t, `{"transcript_path":`+strconv.Quote(outside)+`}`),
 		log, "test-receiver", confiner, &p, getDecodePath, setDecodePath)
 
 	if ok {
@@ -148,8 +137,11 @@ func TestDecodeConfined_OutOfTreePathIsRefusedCountedAnd2xx(t *testing.T) {
 	if n := confiner.RejectionCount(); n != 1 {
 		t.Errorf("counted %d rejection(s), want 1", n)
 	}
-	if len(log.errs) == 0 {
-		t.Error("refusal was not logged")
+	// Which message, not merely that one exists: the log is the only record of
+	// what a local process tried, so a refusal reported under some other line
+	// would leave the counter as the sole evidence.
+	if n := log.mentioning("rejected hook transcript_path"); n != 1 {
+		t.Errorf("refusal logged %d time(s) naming the path, want 1", n)
 	}
 	// The decode ran before the confinement, so the payload still holds the
 	// CALLER'S RAW string here — set deliberately did not run. That is safe
@@ -170,7 +162,7 @@ func TestDecodeConfined_OutOfTreePathIsRefusedCountedAnd2xx(t *testing.T) {
 func TestDecodeConfined_NilConfinerFailsClosed(t *testing.T) {
 	rec := httptest.NewRecorder()
 	var p decodeTestPayload
-	log := &decodeLogger{}
+	log := &countingLogger{}
 
 	ok := DecodeConfined(rec, postDecode(t, `{"transcript_path":"/anywhere/at/all.jsonl"}`),
 		log, "test-receiver", nil, &p, getDecodePath, setDecodePath)
@@ -185,15 +177,82 @@ func TestDecodeConfined_NilConfinerFailsClosed(t *testing.T) {
 	if p.TranscriptPath != "" {
 		t.Errorf("payload path = %q, want empty — nothing may be decoded without a confiner", p.TranscriptPath)
 	}
-	if len(log.errs) == 0 {
-		t.Error("a dropped body was not reported; a silent drop is indistinguishable from health")
+	if n := log.mentioning("no path confiner"); n != 1 {
+		t.Errorf("the drop was reported %d time(s) naming the missing confiner, want 1 — "+
+			"a silent drop is indistinguishable from health", n)
 	}
 }
 
-// quote renders s as a JSON string literal without pulling encoding/json into
-// this file — the architecture rule in core/architecture_hookbody_test.go does
-// not read test files, but keeping the import out avoids any suggestion that
-// this test is a second decode path.
-func quote(s string) string {
-	return `"` + strings.ReplaceAll(strings.ReplaceAll(s, `\`, `\\`), `"`, `\"`) + `"`
+// TestDecodeConfined_DisagreeingGetSetFailsClosed pins the postcondition.
+//
+// A receiver whose set writes a field its get never reads — or a no-op set,
+// which is a one-character edit — leaves the caller's raw string in the payload
+// while DecodeConfined reports success. Review of #1389 demonstrated exactly
+// that against claudecode and the whole suite stayed green, because
+// AssertHookPathConfined asserts THAT a receiver dispatched, never WHICH
+// spelling. The chokepoint checks it so no call site has to be trusted.
+func TestDecodeConfined_DisagreeingGetSetFailsClosed(t *testing.T) {
+	confiner, root := decodeConfinerRooted(t)
+	transcript := filepath.Join(root, "session.jsonl")
+	if err := os.WriteFile(transcript, []byte("{}\n"), 0o644); err != nil {
+		t.Fatalf("write transcript: %v", err)
+	}
+	raw := root + "/./session.jsonl"
+
+	rec := httptest.NewRecorder()
+	var p decodeTestPayload
+	log := &countingLogger{}
+
+	ok := DecodeConfined(rec, postDecode(t, `{"transcript_path":`+strconv.Quote(raw)+`}`),
+		log, "test-receiver", confiner, &p, getDecodePath,
+		func(*decodeTestPayload, string) {}) // the no-op set
+
+	if ok {
+		t.Fatal("a receiver whose set does not write the field its get reads reported success — " +
+			"the payload still holds the caller's unconfined string and the receiver would forward it")
+	}
+	if rec.Code < 200 || rec.Code > 299 {
+		t.Errorf("status = %d, want 2xx — same rule as any other refusal", rec.Code)
+	}
+	if n := log.mentioning("get/set pair"); n != 1 {
+		t.Errorf("mismatch reported %d time(s), want 1 — a silent drop is indistinguishable from health", n)
+	}
+}
+
+// TestDecodeConfined_OversizedBodyIsRefused pins the MaxBytesReader bound: these
+// endpoints are unauthenticated and local, so an unbounded decode lets any local
+// process make the daemon allocate without limit.
+func TestDecodeConfined_OversizedBodyIsRefused(t *testing.T) {
+	confiner, root := decodeConfinerRooted(t)
+	transcript := filepath.Join(root, "session.jsonl")
+	if err := os.WriteFile(transcript, []byte("{}\n"), 0o644); err != nil {
+		t.Fatalf("write transcript: %v", err)
+	}
+
+	// Valid JSON naming an in-tree path, padded past the limit with a field the
+	// payload ignores — so the ONLY reason it can fail is the size bound.
+	body := `{"transcript_path":` + strconv.Quote(transcript) +
+		`,"pad":"` + strings.Repeat("x", maxHookBodyBytes+1) + `"}`
+	rec := httptest.NewRecorder()
+	var p decodeTestPayload
+
+	ok := DecodeConfined(rec, postDecode(t, body), &countingLogger{}, "test-receiver",
+		confiner, &p, getDecodePath, setDecodePath)
+
+	if ok {
+		t.Fatalf("a %d-byte body was accepted; the %d-byte bound did not apply", len(body), maxHookBodyBytes)
+	}
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400 — an over-long body is a malformed request", rec.Code)
+	}
+
+	// The vacuity guard: the same body under the limit must be ACCEPTED, or
+	// this test would pass against a decoder that refuses everything.
+	small := `{"transcript_path":` + strconv.Quote(transcript) + `,"pad":"` + strings.Repeat("x", 32) + `"}`
+	rec2 := httptest.NewRecorder()
+	var p2 decodeTestPayload
+	if !DecodeConfined(rec2, postDecode(t, small), &countingLogger{}, "test-receiver",
+		confiner, &p2, getDecodePath, setDecodePath) {
+		t.Fatalf("an in-tree body well under the bound was refused (status %d)", rec2.Code)
+	}
 }

--- a/core/adapters/inbound/agents/hookjson/decode_test.go
+++ b/core/adapters/inbound/agents/hookjson/decode_test.go
@@ -1,0 +1,199 @@
+// decode_test.go exercises the chokepoint directly, across all four of its
+// exits.
+//
+// It exists because DecodeConfined was the only file in this package without a
+// sibling test, and because one of its branches — the nil-confiner guard — is
+// reachable from no production call site at all: every constructor builds
+// through NewHandler(transcriptConfiner(), …) and ConfinerForSource never
+// returns nil. A guard no test can execute is a guard no mutation can redden,
+// so replacing its body with `return true` would have left the whole suite
+// green while doing precisely what it was written to prevent — dispatching an
+// unconfined caller-supplied path because the confiner was missing. Calling it
+// from here is what makes the fail-closed choice a pinned decision rather than
+// an untested intention. (Found in review of #1389.)
+//
+// The success case asserts the property the doc comment calls the point of the
+// mandatory `set`: the caller's RAW string is gone from the payload afterwards.
+// Nothing else pins that directly — the receivers pin it only by consequence.
+package hookjson
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+type decodeTestPayload struct {
+	TranscriptPath string `json:"transcript_path"`
+	Event          string `json:"hook_event_name"`
+}
+
+func getDecodePath(p *decodeTestPayload) string           { return p.TranscriptPath }
+func setDecodePath(p *decodeTestPayload, confined string) { p.TranscriptPath = confined }
+
+// decodeLogger records LogError calls so a refusal can be asserted to have been
+// reported, not merely to have happened.
+type decodeLogger struct{ errs []string }
+
+func (l *decodeLogger) LogInfo(eventType, sessionID, msg string)  {}
+func (l *decodeLogger) LogError(eventType, sessionID, msg string) { l.errs = append(l.errs, msg) }
+func (l *decodeLogger) LogProcessingTime(eventType, sessionID string, ms int64, size int, result string) {
+}
+func (l *decodeLogger) Close() error { return nil }
+
+// decodeConfinerRooted builds a confiner over a real temp root, matching how
+// the adapters build theirs (an absolute root, ".jsonl" leaves).
+func decodeConfinerRooted(t *testing.T) (*PathConfiner, string) {
+	t.Helper()
+	root := t.TempDir()
+	if runtime.GOOS == "darwin" {
+		// /var is a symlink to /private/var; the confiner resolves symlinks
+		// before containment, so the declared root must be the resolved one or
+		// every in-tree path reads as an escape.
+		if resolved, err := filepath.EvalSymlinks(root); err == nil {
+			root = resolved
+		}
+	}
+	return NewPathConfiner(func() []string { return []string{root} }, ".jsonl"), root
+}
+
+func postDecode(t *testing.T, body string) *http.Request {
+	t.Helper()
+	return httptest.NewRequest(http.MethodPost, "/api/v1/hooks/test", strings.NewReader(body))
+}
+
+func TestDecodeConfined_AcceptsInTreePathAndErasesTheRawString(t *testing.T) {
+	confiner, root := decodeConfinerRooted(t)
+	transcript := filepath.Join(root, "session.jsonl")
+	if err := os.WriteFile(transcript, []byte("{}\n"), 0o644); err != nil {
+		t.Fatalf("write transcript: %v", err)
+	}
+
+	// The raw path is spelled with a redundant "." segment so it is not
+	// byte-identical to the confined result. Without that, "the raw string was
+	// replaced" and "nothing happened" look the same.
+	//
+	// Concatenated, NOT filepath.Join'd: Join cleans, so Join(root, ".", x)
+	// returns exactly the confined string and the assertion below discriminates
+	// nothing. The first draft did that, and a deliberate mutation removing the
+	// set() call left this test GREEN — the case passed for the wrong reason.
+	raw := root + "/./session.jsonl"
+	rec := httptest.NewRecorder()
+	var p decodeTestPayload
+	log := &decodeLogger{}
+
+	ok := DecodeConfined(rec, postDecode(t, `{"transcript_path":`+quote(raw)+`,"hook_event_name":"Stop"}`),
+		log, "test-receiver", confiner, &p, getDecodePath, setDecodePath)
+
+	if !ok {
+		t.Fatalf("in-tree transcript refused; status=%d logs=%v", rec.Code, log.errs)
+	}
+	if p.Event != "Stop" {
+		t.Errorf("hook_event_name = %q, want %q — the payload was not decoded", p.Event, "Stop")
+	}
+	if p.TranscriptPath != transcript {
+		t.Errorf("payload path = %q, want the CONFINED path %q — set must overwrite the caller's raw string, "+
+			"so a downstream line reaching for payload.TranscriptPath cannot pick the unconfined one back up",
+			p.TranscriptPath, transcript)
+	}
+	if n := confiner.RejectionCount(); n != 0 {
+		t.Errorf("in-tree path counted %d rejection(s), want 0", n)
+	}
+}
+
+func TestDecodeConfined_UndecodableBodyIs400(t *testing.T) {
+	confiner, _ := decodeConfinerRooted(t)
+	rec := httptest.NewRecorder()
+	var p decodeTestPayload
+
+	ok := DecodeConfined(rec, postDecode(t, `{"transcript_path": NOT JSON`),
+		&decodeLogger{}, "test-receiver", confiner, &p, getDecodePath, setDecodePath)
+
+	if ok {
+		t.Fatal("undecodable body reported as decoded")
+	}
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", rec.Code)
+	}
+	if n := confiner.RejectionCount(); n != 0 {
+		t.Errorf("a body that never decoded counted %d confinement rejection(s), want 0 — "+
+			"the path was never examined", n)
+	}
+}
+
+func TestDecodeConfined_OutOfTreePathIsRefusedCountedAnd2xx(t *testing.T) {
+	confiner, _ := decodeConfinerRooted(t)
+	outside := filepath.Join(t.TempDir(), "elsewhere.jsonl")
+	if err := os.WriteFile(outside, []byte("{}\n"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	rec := httptest.NewRecorder()
+	var p decodeTestPayload
+	log := &decodeLogger{}
+
+	ok := DecodeConfined(rec, postDecode(t, `{"transcript_path":`+quote(outside)+`}`),
+		log, "test-receiver", confiner, &p, getDecodePath, setDecodePath)
+
+	if ok {
+		t.Fatal("out-of-tree path reported as accepted")
+	}
+	if rec.Code < 200 || rec.Code > 299 {
+		t.Errorf("status = %d, want 2xx — a confinement refusal is reported by the log and the counter, "+
+			"never by a status code on the user's critical path (#1361, #1364)", rec.Code)
+	}
+	if n := confiner.RejectionCount(); n != 1 {
+		t.Errorf("counted %d rejection(s), want 1", n)
+	}
+	if len(log.errs) == 0 {
+		t.Error("refusal was not logged")
+	}
+	// The decode ran before the confinement, so the payload still holds the
+	// CALLER'S RAW string here — set deliberately did not run. That is safe
+	// only because ok==false obliges the caller to return without dispatching,
+	// and it is worth pinning explicitly: a future refactor that moved set
+	// above the confinement check would leave a confined-looking payload on a
+	// refused path, and a future one that cleared the field would hide the raw
+	// value from RejectPath's log, which is the only record of what was tried.
+	if p.TranscriptPath != outside {
+		t.Errorf("payload path = %q, want the untouched raw %q — on a refusal set must NOT run, "+
+			"and the refused value must stay legible", p.TranscriptPath, outside)
+	}
+}
+
+// TestDecodeConfined_NilConfinerFailsClosed is the reason this file exists: the
+// branch has no production caller, so without an explicit test it can never be
+// seen red.
+func TestDecodeConfined_NilConfinerFailsClosed(t *testing.T) {
+	rec := httptest.NewRecorder()
+	var p decodeTestPayload
+	log := &decodeLogger{}
+
+	ok := DecodeConfined(rec, postDecode(t, `{"transcript_path":"/anywhere/at/all.jsonl"}`),
+		log, "test-receiver", nil, &p, getDecodePath, setDecodePath)
+
+	if ok {
+		t.Fatal("a receiver with NO confiner reported its payload as usable — that dispatches an " +
+			"unconfined caller-supplied path because the guard itself was missing, which is the #1361 defect")
+	}
+	if rec.Code < 200 || rec.Code > 299 {
+		t.Errorf("status = %d, want 2xx — same rule as any other refusal", rec.Code)
+	}
+	if p.TranscriptPath != "" {
+		t.Errorf("payload path = %q, want empty — nothing may be decoded without a confiner", p.TranscriptPath)
+	}
+	if len(log.errs) == 0 {
+		t.Error("a dropped body was not reported; a silent drop is indistinguishable from health")
+	}
+}
+
+// quote renders s as a JSON string literal without pulling encoding/json into
+// this file — the architecture rule in core/architecture_hookbody_test.go does
+// not read test files, but keeping the import out avoids any suggestion that
+// this test is a second decode path.
+func quote(s string) string {
+	return `"` + strings.ReplaceAll(strings.ReplaceAll(s, `\`, `\\`), `"`, `\"`) + `"`
+}

--- a/core/architecture_hookbody_shapes_test.go
+++ b/core/architecture_hookbody_shapes_test.go
@@ -1,0 +1,460 @@
+// architecture_hookbody_shapes_test.go is the corpus behind the rule in
+// architecture_hookbody_test.go: one file per way of reading an inbound request
+// body, each pinned to the verdict the detector must return for it.
+//
+// It exists because a guard that passes by construction is only worth what its
+// deliberate failures prove, and a scratch mutation proves it once, for the
+// author, on the day of the PR. Worse, a mutation harness that silently stops
+// mutating produces a perfect green — so every case here asserts the shape it
+// planted is actually PRESENT in the source it hands the detector, before
+// asserting anything about the verdict (see plantedShapeIsPresent).
+//
+// The corpus is also the answer to the question the rule cannot answer about
+// itself: "does it catch a decoder stored in a variable first? io.ReadAll? a
+// helper in another file?" Those are recorded here as executable cases rather
+// than as prose in a PR body, so a later rewrite of the detector has to replay
+// them instead of re-deriving which shapes its predecessor caught. That is the
+// #1450 lesson (a rewritten scan silently lost a shape the original caught,
+// because every new probe was an addition and none pinned the old behaviour)
+// applied before there is a predecessor to lose.
+//
+// Two cases pin NON-detection, and they are as load-bearing as the rest. A
+// detector that fired on *http.Response.Body would make every HTTP client call
+// in an adapter a violation; one that fired on r.Method would fire on all four
+// receivers' method checks. Cheap to get wrong, invisible once wrong.
+package core_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"golang.org/x/tools/go/packages"
+)
+
+// shapeCase is one spelling, and whether the detector must report it.
+type shapeCase struct {
+	file string
+	// want is whether requestBodyReadsIn must report a read in THIS file.
+	want bool
+	// needle is a substring that must appear in src, asserted before the
+	// verdict is checked. If the corpus ever stops containing the construct a
+	// case claims to test, that is a failure of the corpus, not a pass of the
+	// rule.
+	needle string
+	why    string
+	src    string
+}
+
+const shapesInScopePkg = "shapes.test/inscope"
+const shapesOutOfScopePkg = "shapes.test/outofscope"
+
+// inScopeShapes are compiled as one package and fed to the detector. Each is a
+// complete file in package inscope.
+func inScopeShapes() []shapeCase {
+	return []shapeCase{
+		{
+			file:   "direct_decoder.go",
+			want:   true,
+			needle: "json.NewDecoder(r.Body).Decode",
+			why:    "the spelling all four receivers used before #1389",
+			src: `package inscope
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+type directPayload struct {
+	TranscriptPath string ` + "`json:\"transcript_path\"`" + `
+}
+
+func ServeDirect(w http.ResponseWriter, r *http.Request) {
+	var p directPayload
+	if err := json.NewDecoder(r.Body).Decode(&p); err != nil {
+		return
+	}
+	_ = p
+}
+`,
+		},
+		{
+			file:   "decoder_in_variable.go",
+			want:   true,
+			needle: "dec := json.NewDecoder(r.Body)",
+			why:    "the decoder is built on one line and used on another; a rule matching the literal call expression json.NewDecoder(r.Body).Decode would miss it",
+			src: `package inscope
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+func ServeDecoderInVariable(w http.ResponseWriter, r *http.Request) {
+	dec := json.NewDecoder(r.Body)
+	dec.DisallowUnknownFields()
+	var p map[string]string
+	if err := dec.Decode(&p); err != nil {
+		return
+	}
+}
+`,
+		},
+		{
+			file:   "readall_unmarshal.go",
+			want:   true,
+			needle: "io.ReadAll(r.Body)",
+			why:    "no json.NewDecoder anywhere; the body is slurped and unmarshalled",
+			src: `package inscope
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+)
+
+func ServeReadAll(w http.ResponseWriter, r *http.Request) {
+	b, err := io.ReadAll(r.Body)
+	if err != nil {
+		return
+	}
+	var p map[string]string
+	_ = json.Unmarshal(b, &p)
+}
+`,
+		},
+		{
+			file:   "body_aliased.go",
+			want:   true,
+			needle: "body := r.Body",
+			why:    "the body is aliased into a local before anything touches it",
+			src: `package inscope
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+func ServeAliased(w http.ResponseWriter, r *http.Request) {
+	body := r.Body
+	defer func() { _ = body.Close() }()
+	var p map[string]string
+	_ = json.NewDecoder(body).Decode(&p)
+}
+`,
+		},
+		{
+			file:   "helper_caller.go",
+			want:   false,
+			needle: "readBodyHelper(r)",
+			why:    "the CALLER passes the whole *http.Request onward and never names .Body, so the read is reported at the helper (helper_impl.go) and not here — the rule is per-tree, not per-file, so this is caught, just not attributed here",
+			src: `package inscope
+
+import "net/http"
+
+func ServeViaHelper(w http.ResponseWriter, r *http.Request) {
+	p := readBodyHelper(r)
+	_ = p
+}
+`,
+		},
+		{
+			file:   "helper_impl.go",
+			want:   true,
+			needle: "json.NewDecoder(req.Body)",
+			why:    "a helper in ANOTHER FILE of the same package, whose parameter is not even called r — proves the detector is type-driven, not name-driven",
+			src: `package inscope
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+func readBodyHelper(req *http.Request) map[string]string {
+	var p map[string]string
+	_ = json.NewDecoder(req.Body).Decode(&p)
+	return p
+}
+`,
+		},
+		{
+			file:   "helper_takes_reader.go",
+			want:   true,
+			needle: "decodeFromReader(r.Body)",
+			why:    "the helper takes an io.Reader, so the body escapes at the CALL SITE; the selector is right here even though no decode is",
+			src: `package inscope
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+)
+
+func decodeFromReader(src io.Reader) map[string]string {
+	var p map[string]string
+	_ = json.NewDecoder(src).Decode(&p)
+	return p
+}
+
+func ServeViaReaderHelper(w http.ResponseWriter, r *http.Request) {
+	_ = decodeFromReader(r.Body)
+}
+`,
+		},
+		{
+			file:   "form_value.go",
+			want:   true,
+			needle: `r.FormValue("transcript_path")`,
+			why:    "reads the body without ever naming Body; the same untrusted path through a different door",
+			src: `package inscope
+
+import "net/http"
+
+func ServeFormValue(w http.ResponseWriter, r *http.Request) {
+	path := r.FormValue("transcript_path")
+	_ = path
+}
+`,
+		},
+		{
+			file:   "parse_multipart.go",
+			want:   true,
+			needle: "r.ParseMultipartForm(",
+			why:    "consumes the body directly; same reasoning as FormValue",
+			src: `package inscope
+
+import "net/http"
+
+func ServeMultipart(w http.ResponseWriter, r *http.Request) {
+	_ = r.ParseMultipartForm(1 << 20)
+}
+`,
+		},
+		{
+			file:   "struct_field_request.go",
+			want:   true,
+			needle: "s.req.Body",
+			why:    "the request is stashed in a struct field first, so the selector base is not an identifier of request type but an expression of it",
+			src: `package inscope
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+type requestHolder struct {
+	req *http.Request
+}
+
+func (s *requestHolder) Decode() map[string]string {
+	var p map[string]string
+	_ = json.NewDecoder(s.req.Body).Decode(&p)
+	return p
+}
+`,
+		},
+		{
+			file:   "escape_via_outside_helper.go",
+			want:   false,
+			needle: "outofscope.ReadBody(r)",
+			why:    "THE DOCUMENTED GAP: the whole *http.Request is handed to a package outside the governed tree, which reads .Body there. Nothing in scope names .Body, so the rule cannot see it",
+			src: `package inscope
+
+import (
+	"net/http"
+
+	"shapes.test/outofscope"
+)
+
+func ServeViaOutsideHelper(w http.ResponseWriter, r *http.Request) {
+	_ = outofscope.ReadBody(r)
+}
+`,
+		},
+		{
+			file:   "response_body.go",
+			want:   false,
+			needle: "resp.Body",
+			why:    "MUST NOT FIRE: an *http.Response body is an outbound client read. A name-based rule would fire here and make every HTTP client call in an adapter a violation",
+			src: `package inscope
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+func FetchUpstream(c *http.Client, url string) map[string]string {
+	resp, err := c.Get(url)
+	if err != nil {
+		return nil
+	}
+	defer func() { _ = resp.Body.Close() }()
+	var p map[string]string
+	_ = json.NewDecoder(resp.Body).Decode(&p)
+	return p
+}
+`,
+		},
+		{
+			file:   "request_metadata.go",
+			want:   false,
+			needle: "r.Method",
+			why:    "MUST NOT FIRE: reading method, URL and headers is not reading the body, and all four real receivers do it on their first line",
+			src: `package inscope
+
+import "net/http"
+
+func ServeMetadataOnly(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	_ = r.URL.Path
+	_ = r.Header.Get("Content-Type")
+	w.WriteHeader(http.StatusOK)
+}
+`,
+		},
+	}
+}
+
+// outOfScopeSrc is the package the escape case reaches into. The detector DOES
+// report the read here — what excludes it is the rule's pattern, not blindness —
+// and TestRequestBodyReadDetectorCatchesEveryKnownShape asserts exactly that, so
+// the gap is recorded as a scope decision rather than a detector limitation.
+const outOfScopeSrc = `package outofscope
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+func ReadBody(r *http.Request) map[string]string {
+	var p map[string]string
+	_ = json.NewDecoder(r.Body).Decode(&p)
+	return p
+}
+`
+
+func TestRequestBodyReadDetectorCatchesEveryKnownShape(t *testing.T) {
+	shapes := inScopeShapes()
+	dir := writeShapeCorpus(t, shapes)
+
+	pkgs := loadShapeCorpus(t, dir)
+
+	// Reads found in the governed package, indexed by the file they are in.
+	hits := map[string]int{}
+	outOfScopeHits := 0
+	for _, pkg := range pkgs {
+		reads := requestBodyReadsIn(pkg.Fset, pkg.Syntax, pkg.TypesInfo, pkg.PkgPath)
+		switch pkg.PkgPath {
+		case shapesInScopePkg:
+			for _, read := range reads {
+				hits[filepath.Base(strings.SplitN(read.Pos, ":", 2)[0])]++
+			}
+		case shapesOutOfScopePkg:
+			outOfScopeHits += len(reads)
+		default:
+			t.Fatalf("unexpected package in corpus: %q", pkg.PkgPath)
+		}
+	}
+
+	for _, shape := range shapes {
+		got := hits[shape.file] > 0
+		if got == shape.want {
+			continue
+		}
+		verb := "was NOT reported"
+		if got {
+			verb = "WAS reported"
+		}
+		t.Errorf("shape %s %s but want reported=%v\n\twhy this case exists: %s",
+			shape.file, verb, shape.want, shape.why)
+	}
+
+	// The escape case is a scope decision, not a hole in the detector: prove the
+	// same read IS seen when the package is in range. Without this the gap and a
+	// broken detector look identical.
+	if outOfScopeHits != 1 {
+		t.Errorf("out-of-scope helper: detector found %d body read(s), want 1 — "+
+			"the escape_via_outside_helper case is meant to show the read is EXCLUDED BY SCOPE, "+
+			"not that the detector cannot see it", outOfScopeHits)
+	}
+}
+
+// writeShapeCorpus materializes the corpus as a self-contained module and
+// asserts every planted shape actually landed in the file.
+func writeShapeCorpus(t *testing.T, shapes []shapeCase) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	mustWrite(t, filepath.Join(dir, "go.mod"), "module shapes.test\n\ngo 1.25\n")
+
+	inScope := filepath.Join(dir, "inscope")
+	outScope := filepath.Join(dir, "outofscope")
+	for _, d := range []string{inScope, outScope} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", d, err)
+		}
+	}
+	mustWrite(t, filepath.Join(outScope, "helper.go"), outOfScopeSrc)
+
+	seen := map[string]bool{}
+	for _, shape := range shapes {
+		if seen[shape.file] {
+			t.Fatalf("duplicate shape file %q — one case would silently overwrite the other", shape.file)
+		}
+		seen[shape.file] = true
+		plantedShapeIsPresent(t, shape)
+		mustWrite(t, filepath.Join(inScope, shape.file), shape.src)
+	}
+	return dir
+}
+
+// plantedShapeIsPresent is the guard against a corpus that has quietly stopped
+// containing what it claims to. A case whose needle is missing is a case that
+// proves nothing, and it would otherwise read as a pass for every want:false
+// row and as a detector bug for every want:true one.
+func plantedShapeIsPresent(t *testing.T, shape shapeCase) {
+	t.Helper()
+	if shape.needle == "" {
+		t.Fatalf("shape %s declares no needle; every case must assert the construct it plants is present", shape.file)
+	}
+	if !strings.Contains(shape.src, shape.needle) {
+		t.Fatalf("shape %s does not contain its own needle %q — the case is not testing what it says it tests",
+			shape.file, shape.needle)
+	}
+}
+
+func loadShapeCorpus(t *testing.T, dir string) []*packages.Package {
+	t.Helper()
+
+	cfg := &packages.Config{
+		Mode: packages.NeedName | packages.NeedFiles | packages.NeedSyntax |
+			packages.NeedTypes | packages.NeedTypesInfo,
+		Dir: dir,
+		// GOWORK=off: the corpus is a standalone module in a temp dir, and an
+		// inherited workspace would try to resolve it against this repo's.
+		Env: append(os.Environ(), "GOWORK=off"),
+	}
+	pkgs, err := packages.Load(cfg, "./...")
+	if err != nil {
+		t.Fatalf("packages.Load(corpus): %v", err)
+	}
+	if n := packages.PrintErrors(pkgs); n > 0 {
+		t.Fatalf("corpus does not build (%d error(s)) — a corpus that fails to type-check "+
+			"yields no TypesInfo and every want:true case would fail for the wrong reason", n)
+	}
+	if len(pkgs) != 2 {
+		t.Fatalf("corpus loaded %d packages, want 2 (inscope + outofscope)", len(pkgs))
+	}
+	return pkgs
+}
+
+func mustWrite(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}

--- a/core/architecture_hookbody_shapes_test.go
+++ b/core/architecture_hookbody_shapes_test.go
@@ -255,6 +255,40 @@ func (s *requestHolder) Decode() map[string]string {
 `,
 		},
 		{
+			file:   "embedded_request.go",
+			want:   true,
+			needle: "struct {\n\t*http.Request",
+			why: "a request-wrapper struct EMBEDDING *http.Request, so Body and FormValue are promoted: " +
+				"the selector base types as the wrapper, not as the request. Found by review of #1389 — " +
+				"the detector's first cut typed sel.X and missed both, which is a bypass INSIDE the governed " +
+				"tree (a receiver written as `type hookCtx struct{ *http.Request }` would decode its own body " +
+				"and keep the build green)",
+			src: `package inscope
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+type embeddedCtx struct {
+	*http.Request
+	extra string
+}
+
+func ServeEmbeddedField(w http.ResponseWriter, r *http.Request) map[string]string {
+	c := embeddedCtx{Request: r}
+	var p map[string]string
+	_ = json.NewDecoder(c.Body).Decode(&p)
+	return p
+}
+
+func ServeEmbeddedMethod(w http.ResponseWriter, r *http.Request) string {
+	c := embeddedCtx{Request: r}
+	return c.FormValue("transcript_path")
+}
+`,
+		},
+		{
 			file:   "escape_via_outside_helper.go",
 			want:   false,
 			needle: "outofscope.ReadBody(r)",

--- a/core/architecture_hookbody_shapes_test.go
+++ b/core/architecture_hookbody_shapes_test.go
@@ -385,7 +385,7 @@ func TestRequestBodyReadDetectorCatchesEveryKnownShape(t *testing.T) {
 		switch pkg.PkgPath {
 		case shapesInScopePkg:
 			for _, read := range reads {
-				hits[filepath.Base(strings.SplitN(read.Pos, ":", 2)[0])]++
+				hits[filepath.Base(read.File)]++
 			}
 		case shapesOutOfScopePkg:
 			outOfScopeHits += len(reads)
@@ -465,7 +465,7 @@ func loadShapeCorpus(t *testing.T, dir string) []*packages.Package {
 	t.Helper()
 
 	cfg := &packages.Config{
-		Mode: packages.NeedName | packages.NeedFiles | packages.NeedSyntax |
+		Mode: packages.NeedName | packages.NeedSyntax |
 			packages.NeedTypes | packages.NeedTypesInfo,
 		Dir: dir,
 		// GOWORK=off: the corpus is a standalone module in a temp dir, and an

--- a/core/architecture_hookbody_test.go
+++ b/core/architecture_hookbody_test.go
@@ -77,8 +77,8 @@ import (
 	"go/ast"
 	"go/token"
 	"go/types"
-	"sort"
-	"strings"
+	"maps"
+	"slices"
 	"testing"
 
 	"golang.org/x/tools/go/packages"
@@ -129,7 +129,12 @@ var bodyConsumingMethods = map[string]bool{
 // requestBodyRead is one place source code reads the body of an inbound
 // *http.Request.
 type requestBodyRead struct {
-	Pkg  string // package path
+	Pkg string // package path
+	// File and Pos are kept separately rather than only as a formatted string:
+	// the corpus indexes findings by file, and recovering a filename by
+	// splitting "file:line:col" on the first colon is wrong for any path that
+	// contains one (a Windows drive letter puts every finding under "C").
+	File string
 	Pos  string // file:line:col
 	Func string // enclosing top-level func or method, "" at file scope
 	How  string // the expression as written, e.g. "r.Body" or "r.FormValue"
@@ -194,7 +199,7 @@ func assertChokepointIsSingular(t *testing.T, inside []requestBodyRead) {
 	for _, read := range inside {
 		funcs[read.Func] = append(funcs[read.Func], read)
 	}
-	for _, name := range sortedKeys(funcs) {
+	for _, name := range slices.Sorted(maps.Keys(funcs)) {
 		if name == chokepointFunc {
 			continue
 		}
@@ -214,7 +219,7 @@ func loadAgentAdapterPackages(t *testing.T) []*packages.Package {
 	t.Helper()
 
 	cfg := &packages.Config{
-		Mode: packages.NeedName | packages.NeedFiles | packages.NeedSyntax |
+		Mode: packages.NeedName | packages.NeedSyntax |
 			packages.NeedTypes | packages.NeedTypesInfo,
 		Dir: ".",
 	}
@@ -225,15 +230,13 @@ func loadAgentAdapterPackages(t *testing.T) []*packages.Package {
 	if n := packages.PrintErrors(pkgs); n > 0 {
 		t.Fatalf("packages.Load reported %d package error(s); build is broken", n)
 	}
-	if len(pkgs) == 0 {
-		t.Fatalf("packages.Load returned no packages for pattern %q", agentAdapterPattern)
-	}
-
+	// No separate "zero packages" or "zero files in total" guard: the
+	// knownAgentPackages loop below subsumes both. An empty load fails it on the
+	// first entry, and every named package is required to have parsed files, so
+	// an aggregate count could not be zero without that firing first.
 	loaded := map[string]int{}
-	files := 0
 	for _, pkg := range pkgs {
 		loaded[pkg.PkgPath] = len(pkg.Syntax)
-		files += len(pkg.Syntax)
 		if pkg.TypesInfo == nil {
 			t.Fatalf("package %q loaded without type information; the detector cannot tell "+
 				"an *http.Request body from an *http.Response body without it", pkg.PkgPath)
@@ -252,9 +255,6 @@ func loadAgentAdapterPackages(t *testing.T) []*packages.Package {
 			t.Fatalf("package %q loaded with zero parsed files — the rule would pass having never read it",
 				want)
 		}
-	}
-	if files == 0 {
-		t.Fatalf("pattern %q matched %d package(s) but zero parsed files", agentAdapterPattern, len(pkgs))
 	}
 	return pkgs
 }
@@ -287,9 +287,10 @@ func requestBodyReadsIn(fset *token.FileSet, files []*ast.File, info *types.Info
 				}
 				found = append(found, requestBodyRead{
 					Pkg:  pkgPath,
+					File: fset.Position(sel.Sel.Pos()).Filename,
 					Pos:  fset.Position(sel.Sel.Pos()).String(),
 					Func: name,
-					How:  exprText(sel),
+					How:  types.ExprString(sel),
 				})
 				return true
 			})
@@ -407,37 +408,5 @@ func funcDeclName(decl *ast.FuncDecl) string {
 	if decl.Recv == nil || len(decl.Recv.List) == 0 {
 		return decl.Name.Name
 	}
-	return "(" + exprText(decl.Recv.List[0].Type) + ")." + decl.Name.Name
-}
-
-// exprText renders a selector or type expression back to source-ish text for
-// the failure message. Only the shapes this file reports on are handled; the
-// fallback keeps a message readable rather than empty.
-func exprText(e ast.Expr) string {
-	switch v := e.(type) {
-	case *ast.Ident:
-		return v.Name
-	case *ast.StarExpr:
-		return "*" + exprText(v.X)
-	case *ast.SelectorExpr:
-		return exprText(v.X) + "." + v.Sel.Name
-	case *ast.IndexExpr:
-		return exprText(v.X)
-	case *ast.IndexListExpr:
-		return exprText(v.X)
-	case *ast.CallExpr:
-		return exprText(v.Fun) + "(…)"
-	case *ast.ParenExpr:
-		return "(" + exprText(v.X) + ")"
-	}
-	return strings.TrimSpace(fmt.Sprintf("%T", e))
-}
-
-func sortedKeys(m map[string][]requestBodyRead) []string {
-	keys := make([]string, 0, len(m))
-	for k := range m {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
-	return keys
+	return "(" + types.ExprString(decl.Recv.List[0].Type) + ")." + decl.Name.Name
 }

--- a/core/architecture_hookbody_test.go
+++ b/core/architecture_hookbody_test.go
@@ -229,10 +229,10 @@ func loadAgentAdapterPackages(t *testing.T) []*packages.Package {
 		t.Fatalf("packages.Load returned no packages for pattern %q", agentAdapterPattern)
 	}
 
-	loaded := map[string]bool{}
+	loaded := map[string]int{}
 	files := 0
 	for _, pkg := range pkgs {
-		loaded[pkg.PkgPath] = true
+		loaded[pkg.PkgPath] = len(pkg.Syntax)
 		files += len(pkg.Syntax)
 		if pkg.TypesInfo == nil {
 			t.Fatalf("package %q loaded without type information; the detector cannot tell "+
@@ -240,9 +240,17 @@ func loadAgentAdapterPackages(t *testing.T) []*packages.Package {
 		}
 	}
 	for _, want := range knownAgentPackages {
-		if !loaded[want] {
+		n, ok := loaded[want]
+		if !ok {
 			t.Fatalf("package %q was not loaded by pattern %q — the rule would pass having never read it",
 				want, agentAdapterPattern)
+		}
+		// Per-package, not just the aggregate below: a package can load with
+		// zero parsed files while the total stays comfortably non-zero, and
+		// that is indistinguishable from a clean scan of it.
+		if n == 0 {
+			t.Fatalf("package %q loaded with zero parsed files — the rule would pass having never read it",
+				want)
 		}
 	}
 	if files == 0 {
@@ -298,6 +306,18 @@ func requestBodyReadsIn(fset *token.FileSet, files []*ast.File, info *types.Info
 // that happens to call its request something other than "r" must still be
 // caught. That is the whole reason this rule needs NeedTypesInfo rather than a
 // grep.
+//
+// It resolves the SELECTION before falling back to the type of the base
+// expression, and that order is the correction rather than a refinement. A
+// field or method PROMOTED from an embedded *http.Request — the ordinary Go
+// request-wrapper idiom, `type hookCtx struct{ *http.Request; … }` — has a base
+// expression whose type is the wrapper, so typing sel.X alone reports nothing
+// for c.Body and c.FormValue alike. That is a bypass inside the governed tree,
+// not merely a missed spelling: a receiver written that way would decode its
+// own body, forward an unconfined transcript_path, and leave the build green —
+// the #1361 failure this rule exists to make impossible. Caught in review of
+// #1389; pinned by the embedded_request.go corpus case, which was seen red
+// against the sel.X-only version.
 func readsRequestBody(sel *ast.SelectorExpr, info *types.Info) bool {
 	if sel.Sel == nil {
 		return false
@@ -305,7 +325,60 @@ func readsRequestBody(sel *ast.SelectorExpr, info *types.Info) bool {
 	if sel.Sel.Name != "Body" && !bodyConsumingMethods[sel.Sel.Name] {
 		return false
 	}
+	if s, ok := info.Selections[sel]; ok && isHTTPRequest(selectionOwner(s)) {
+		return true
+	}
+	// Fallback for selections types.Info does not record — notably a method
+	// EXPRESSION like (*http.Request).ParseForm, and a qualified identifier.
 	return isHTTPRequest(info.TypeOf(sel.X))
+}
+
+// selectionOwner returns the type that actually declares the selected field or
+// method, walking through any embedded fields the selection was promoted
+// across. Returns nil when the shape is not one it can resolve, which the
+// caller treats as "not a request body read" and covers with the sel.X
+// fallback.
+func selectionOwner(s *types.Selection) types.Type {
+	switch s.Kind() {
+	case types.MethodVal, types.MethodExpr:
+		fn, ok := s.Obj().(*types.Func)
+		if !ok {
+			return nil
+		}
+		recv := fn.Signature().Recv()
+		if recv == nil {
+			return nil
+		}
+		return recv.Type()
+	case types.FieldVal:
+		// Index() is the path of field indices from the receiver down to the
+		// selected field; every element but the last steps through an embedded
+		// field. Walking it yields the type the final field belongs to, which
+		// for a promoted Body is *http.Request however deeply it was embedded.
+		t := s.Recv()
+		path := s.Index()
+		for _, i := range path[:len(path)-1] {
+			st, ok := structUnder(t)
+			if !ok || i >= st.NumFields() {
+				return nil
+			}
+			t = st.Field(i).Type()
+		}
+		return t
+	}
+	return nil
+}
+
+// structUnder returns the struct underlying t, dereferencing one pointer.
+func structUnder(t types.Type) (*types.Struct, bool) {
+	if t == nil {
+		return nil, false
+	}
+	if ptr, ok := types.Unalias(t).Underlying().(*types.Pointer); ok {
+		t = ptr.Elem()
+	}
+	st, ok := types.Unalias(t).Underlying().(*types.Struct)
+	return st, ok
 }
 
 // isHTTPRequest reports whether t is net/http.Request or a pointer to it.

--- a/core/architecture_hookbody_test.go
+++ b/core/architecture_hookbody_test.go
@@ -1,0 +1,370 @@
+// architecture_hookbody_test.go is the second architecture rule in this
+// directory, and it is deliberately a separate file from architecture_test.go:
+// the layering rules there are a question about the IMPORT GRAPH
+// (packages.Load with NeedName|NeedImports, no syntax), while this one is a
+// question about SOURCE — which expressions appear inside a function — and so
+// needs NeedSyntax|NeedTypes|NeedTypesInfo over a much narrower pattern. One
+// load cannot serve both cheaply, and a rule table that mixes "which packages
+// may I import" with "which expressions may I write" reads as one thing when it
+// is two.
+//
+// # What this enforces (issue #1389)
+//
+// An inbound hook body carries a caller-supplied transcript_path on a local,
+// unauthenticated endpoint, and #1361 established that a receiver must confine
+// that path to the adapter's own declared roots before anything downstream
+// opens it. contracttesting.AssertHookPathConfined checks that a receiver DOES
+// confine — but only for a receiver that wired the contract. A receiver nobody
+// wired it for is invisible to it. That is not hypothetical: within #1361
+// itself the claudecode statusline receiver, registered three lines from the
+// one being fixed, was left unconfined by the author of the rule, and a later
+// review pass caught it rather than any gate.
+//
+// So the obligation is moved from "a contract the next adapter must remember to
+// wire" to "the build fails": inside core/adapters/inbound/agents/..., reading
+// an inbound *http.Request's body is the exclusive privilege of
+// hookjson.DecodeConfined, which cannot decode without being handed a
+// *PathConfiner.
+//
+// # Why the rule in issue #1389 is not the rule implemented here
+//
+// #1389 proposed keying on "a file that references a HookEndpointPath may not
+// call json.NewDecoder(r.Body)". Measured against the tree, that selects
+// nothing: HookEndpointPath is declared and referenced only in the three
+// hookinstaller.go files, which never touch r.Body, and the fourth receiver's
+// route constant is not even called HookEndpointPath (it is
+// StatuslineEndpointPath). The rule would have passed vacuously on the day it
+// landed AND against the exact statusline bug it was written to catch.
+//
+// The repair is to stop trying to recognize "a hook-receiving file" at all.
+// There is no file pattern here, so there is no file a new receiver can hide
+// in: the predicate is the untrusted-input operation itself. Any code that
+// reads an inbound request body inside an agent adapter is in scope, whatever
+// it is called and whatever file it lives in.
+//
+// # Why the scope is exactly core/adapters/inbound/agents/...
+//
+// Narrower would reintroduce the too-narrow failure above. Wider fires on the
+// daemon's own REST API in core/cmd/irrlichd, which decodes bodies for a living
+// and has nothing to do with transcript paths. The chosen boundary is load-
+// bearing rather than convenient: an inbound HTTP endpoint hosted by an AGENT
+// ADAPTER on the daemon's local unauthenticated port is precisely the #1361
+// threat surface, and today there is not one such endpoint that is anything
+// other than a hook receiver (the only functions under this tree taking an
+// *http.Request are the four receivers' serve funcs, their constructor closures
+// and hookjson's own).
+//
+// # What it does NOT cover
+//
+//   - A hook receiver defined OUTSIDE core/adapters/inbound/agents/... — e.g.
+//     one written directly in core/cmd/irrlichd next to registerHookRoutes.
+//     Nothing here sees it. AGENTS.md places adapters in this tree, and the four
+//     receivers are all here, but that is a convention, not a check.
+//   - A receiver that hands the whole *http.Request to a helper OUTSIDE this
+//     tree, which then reads .Body. Passing r.Body outward IS caught (the
+//     selector appears at the call site); passing r itself is not.
+//   - Test files. packages.Load runs without Tests, like every rule in
+//     architecture_test.go. Unlike there, this is close to harmless: a receiver
+//     declared in a _test.go is never registered on the production mux, so a
+//     body read there cannot reach a user. It is still a gap for a helper shared
+//     between test and non-test code.
+//   - Reflection, generated code, or a body read spelled through an
+//     interface value whose dynamic type is *http.Request.
+package core_test
+
+import (
+	"fmt"
+	"go/ast"
+	"go/token"
+	"go/types"
+	"sort"
+	"strings"
+	"testing"
+
+	"golang.org/x/tools/go/packages"
+)
+
+// agentAdapterPattern is the tree the rule governs, relative to core/.
+const agentAdapterPattern = "./adapters/inbound/agents/..."
+
+// chokepointPkg and chokepointFunc name the single place an inbound request
+// body may be read. Spelled as strings rather than reached through an import
+// because this file must be able to report that the chokepoint has DISAPPEARED
+// — a rule that resolved the symbol would stop compiling instead, which is a
+// worse failure mode for a guard whose whole job is to be legible when broken.
+const (
+	chokepointPkg  = "irrlicht/core/adapters/inbound/agents/hookjson"
+	chokepointFunc = "DecodeConfined"
+)
+
+// knownAgentPackages are packages the load MUST return. This is the vacuity
+// guard, and it is the one that matters: a pattern typo, a build break confined
+// to this subtree, or a packages.Load that silently returns nothing all produce
+// a perfectly green run of a rule that scanned no code at all. Naming the four
+// receivers' packages plus the chokepoint's means "found no violations" can
+// only be reported about a tree that was actually read.
+var knownAgentPackages = []string{
+	chokepointPkg,
+	"irrlicht/core/adapters/inbound/agents/claudecode",
+	"irrlicht/core/adapters/inbound/agents/codex",
+	"irrlicht/core/adapters/inbound/agents/copilot",
+}
+
+// bodyConsumingMethods are *http.Request methods that read the request body
+// without ever naming the Body field. Without them the rule is a rule about one
+// spelling rather than about reading the body: r.FormValue("transcript_path")
+// is the same untrusted input arriving through a different door.
+//
+// MultipartReader and the ParseForm family consume the body directly;
+// FormValue/PostFormValue/FormFile call ParseMultipartForm internally.
+var bodyConsumingMethods = map[string]bool{
+	"ParseForm":          true,
+	"ParseMultipartForm": true,
+	"FormValue":          true,
+	"PostFormValue":      true,
+	"FormFile":           true,
+	"MultipartReader":    true,
+}
+
+// requestBodyRead is one place source code reads the body of an inbound
+// *http.Request.
+type requestBodyRead struct {
+	Pkg  string // package path
+	Pos  string // file:line:col
+	Func string // enclosing top-level func or method, "" at file scope
+	How  string // the expression as written, e.g. "r.Body" or "r.FormValue"
+}
+
+func (b requestBodyRead) String() string {
+	where := b.Func
+	if where == "" {
+		where = "<file scope>"
+	}
+	return fmt.Sprintf("%s (%s in %s)", b.Pos, b.How, where)
+}
+
+func TestNoDirectRequestBodyReadsInAgentAdapters(t *testing.T) {
+	pkgs := loadAgentAdapterPackages(t)
+
+	var outside, inside []requestBodyRead
+	for _, pkg := range pkgs {
+		for _, read := range requestBodyReadsIn(pkg.Fset, pkg.Syntax, pkg.TypesInfo, pkg.PkgPath) {
+			if read.Pkg == chokepointPkg {
+				inside = append(inside, read)
+				continue
+			}
+			outside = append(outside, read)
+		}
+	}
+
+	// Arm A — the prohibition. Every hook receiver reaches its transcript path
+	// through the chokepoint, so a body read anywhere else in this tree is
+	// either a receiver that skipped confinement or a new kind of endpoint that
+	// has to argue for itself in a reviewable diff.
+	for _, read := range outside {
+		t.Errorf("hook-body violation: %s reads an inbound *http.Request body at %s\n"+
+			"\tinside %s, an inbound request body may only be read by %s.%s, which cannot decode without a *PathConfiner (issue #1389)\n"+
+			"\tif this is a hook receiver: call hookjson.DecodeConfined instead of decoding r.Body yourself\n"+
+			"\tif this is a new kind of endpoint that carries no path: this rule has no exemption list by design — amend the rule, with a test",
+			read.Pkg, read, agentAdapterPattern, chokepointPkg, chokepointFunc)
+	}
+
+	// Arm B — the exemption is a pin, not a hole. One package is allowed to read
+	// a request body; that permission is bounded to one function inside it, so
+	// hookjson cannot later grow a second, non-confining decoder and inherit the
+	// exemption by living in the right package. Arm B is also what makes a
+	// vacuous Arm A impossible to mistake for a clean one: if the walker stops
+	// finding body reads entirely, the count here goes to zero and fails.
+	assertChokepointIsSingular(t, inside)
+}
+
+// assertChokepointIsSingular checks Arm B: the exempt package reads a request
+// body in exactly one function, and that function is the chokepoint.
+func assertChokepointIsSingular(t *testing.T, inside []requestBodyRead) {
+	t.Helper()
+
+	if len(inside) == 0 {
+		t.Fatalf("no request-body read found in %s at all — either %s.%s no longer decodes the body "+
+			"(in which case every receiver's confinement is now unenforced), or this rule's detector has "+
+			"stopped matching and Arm A above is passing vacuously",
+			chokepointPkg, chokepointPkg, chokepointFunc)
+	}
+
+	funcs := map[string][]requestBodyRead{}
+	for _, read := range inside {
+		funcs[read.Func] = append(funcs[read.Func], read)
+	}
+	for _, name := range sortedKeys(funcs) {
+		if name == chokepointFunc {
+			continue
+		}
+		for _, read := range funcs[name] {
+			t.Errorf("hook-body violation: %s reads an inbound *http.Request body at %s\n"+
+				"\t%s is exempt only for %s — the single decode every receiver is forced through.\n"+
+				"\tA second body-reading function here is a second way to skip confinement (issue #1389)",
+				chokepointPkg, read, chokepointPkg, chokepointFunc)
+		}
+	}
+}
+
+// loadAgentAdapterPackages loads the governed tree with the syntax and type
+// information the detector needs, and refuses to return a set it cannot vouch
+// for.
+func loadAgentAdapterPackages(t *testing.T) []*packages.Package {
+	t.Helper()
+
+	cfg := &packages.Config{
+		Mode: packages.NeedName | packages.NeedFiles | packages.NeedSyntax |
+			packages.NeedTypes | packages.NeedTypesInfo,
+		Dir: ".",
+	}
+	pkgs, err := packages.Load(cfg, agentAdapterPattern)
+	if err != nil {
+		t.Fatalf("packages.Load(%q): %v", agentAdapterPattern, err)
+	}
+	if n := packages.PrintErrors(pkgs); n > 0 {
+		t.Fatalf("packages.Load reported %d package error(s); build is broken", n)
+	}
+	if len(pkgs) == 0 {
+		t.Fatalf("packages.Load returned no packages for pattern %q", agentAdapterPattern)
+	}
+
+	loaded := map[string]bool{}
+	files := 0
+	for _, pkg := range pkgs {
+		loaded[pkg.PkgPath] = true
+		files += len(pkg.Syntax)
+		if pkg.TypesInfo == nil {
+			t.Fatalf("package %q loaded without type information; the detector cannot tell "+
+				"an *http.Request body from an *http.Response body without it", pkg.PkgPath)
+		}
+	}
+	for _, want := range knownAgentPackages {
+		if !loaded[want] {
+			t.Fatalf("package %q was not loaded by pattern %q — the rule would pass having never read it",
+				want, agentAdapterPattern)
+		}
+	}
+	if files == 0 {
+		t.Fatalf("pattern %q matched %d package(s) but zero parsed files", agentAdapterPattern, len(pkgs))
+	}
+	return pkgs
+}
+
+// requestBodyReadsIn returns every read of an inbound *http.Request's body in
+// the given files.
+//
+// It is a plain function over (fset, files, info) rather than a method on
+// anything so the shape corpus in architecture_hookbody_shapes_test.go can feed
+// it synthetic packages and pin, case by case, which spellings it catches.
+func requestBodyReadsIn(fset *token.FileSet, files []*ast.File, info *types.Info, pkgPath string) []requestBodyRead {
+	var found []requestBodyRead
+	for _, file := range files {
+		// Walked one top-level declaration at a time rather than with a
+		// push/pop stack over the whole file: ast.Inspect emits its nil
+		// sentinel after EVERY node's children, not only after a FuncDecl's,
+		// so a stack popped on nil unwinds on the first leaf and attributes
+		// every later hit to file scope. Arm B depends on this name being
+		// right — it is what distinguishes "hookjson decodes in DecodeConfined"
+		// from "hookjson decodes somewhere else too".
+		for _, decl := range file.Decls {
+			name := ""
+			if fn, ok := decl.(*ast.FuncDecl); ok {
+				name = funcDeclName(fn)
+			}
+			ast.Inspect(decl, func(n ast.Node) bool {
+				sel, ok := n.(*ast.SelectorExpr)
+				if !ok || !readsRequestBody(sel, info) {
+					return true
+				}
+				found = append(found, requestBodyRead{
+					Pkg:  pkgPath,
+					Pos:  fset.Position(sel.Sel.Pos()).String(),
+					Func: name,
+					How:  exprText(sel),
+				})
+				return true
+			})
+		}
+	}
+	return found
+}
+
+// readsRequestBody reports whether sel reads the body of an *http.Request —
+// either the Body field itself or a method that consumes the body.
+//
+// The receiver's TYPE is checked, never its name: r.Body on an *http.Response
+// is an ordinary outbound HTTP client read and must not fire, and an adapter
+// that happens to call its request something other than "r" must still be
+// caught. That is the whole reason this rule needs NeedTypesInfo rather than a
+// grep.
+func readsRequestBody(sel *ast.SelectorExpr, info *types.Info) bool {
+	if sel.Sel == nil {
+		return false
+	}
+	if sel.Sel.Name != "Body" && !bodyConsumingMethods[sel.Sel.Name] {
+		return false
+	}
+	return isHTTPRequest(info.TypeOf(sel.X))
+}
+
+// isHTTPRequest reports whether t is net/http.Request or a pointer to it.
+func isHTTPRequest(t types.Type) bool {
+	if t == nil {
+		return false
+	}
+	if ptr, ok := types.Unalias(t).(*types.Pointer); ok {
+		t = ptr.Elem()
+	}
+	named, ok := types.Unalias(t).(*types.Named)
+	if !ok {
+		return false
+	}
+	obj := named.Obj()
+	return obj != nil && obj.Pkg() != nil &&
+		obj.Pkg().Path() == "net/http" && obj.Name() == "Request"
+}
+
+// funcDeclName renders a FuncDecl's name, qualified by receiver type for a
+// method, so a violation report names something greppable.
+func funcDeclName(decl *ast.FuncDecl) string {
+	if decl.Name == nil {
+		return ""
+	}
+	if decl.Recv == nil || len(decl.Recv.List) == 0 {
+		return decl.Name.Name
+	}
+	return "(" + exprText(decl.Recv.List[0].Type) + ")." + decl.Name.Name
+}
+
+// exprText renders a selector or type expression back to source-ish text for
+// the failure message. Only the shapes this file reports on are handled; the
+// fallback keeps a message readable rather than empty.
+func exprText(e ast.Expr) string {
+	switch v := e.(type) {
+	case *ast.Ident:
+		return v.Name
+	case *ast.StarExpr:
+		return "*" + exprText(v.X)
+	case *ast.SelectorExpr:
+		return exprText(v.X) + "." + v.Sel.Name
+	case *ast.IndexExpr:
+		return exprText(v.X)
+	case *ast.IndexListExpr:
+		return exprText(v.X)
+	case *ast.CallExpr:
+		return exprText(v.Fun) + "(…)"
+	case *ast.ParenExpr:
+		return "(" + exprText(v.X) + ")"
+	}
+	return strings.TrimSpace(fmt.Sprintf("%T", e))
+}
+
+func sortedKeys(m map[string][]requestBodyRead) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/core/architecture_test.go
+++ b/core/architecture_test.go
@@ -1,6 +1,15 @@
 // architecture_test.go lives at the module root, not in a subpackage, so
 // packages.Load's "./..." pattern can see every package in the module from
 // a single load.
+//
+// It is not the only architecture rule in this directory. The rule table below
+// is about the IMPORT GRAPH — which packages a package may depend on — and
+// loads with NeedName|NeedImports. architecture_hookbody_test.go asks a
+// different kind of question, about which EXPRESSIONS a function may contain
+// (#1389: only hookjson.DecodeConfined may read an inbound request body), and
+// needs syntax and type information over a narrow pattern. Adding a rule of the
+// first kind means adding a row here; a rule of the second kind does not fit
+// this table at all.
 package core_test
 
 import (

--- a/core/internal/contracttesting/hook_path_confinement.go
+++ b/core/internal/contracttesting/hook_path_confinement.go
@@ -47,6 +47,18 @@ type HookReceiverUnderTest struct {
 	// the assertion that actually matters; the status code is how the refusal
 	// is reported, but a 400 alongside a dispatch would still be a breach.
 	Observed func() bool
+
+	// ObservedPath is the transcript path the receiver most recently dispatched,
+	// or "" if it dispatched nothing.
+	//
+	// Observed answers WHETHER something was forwarded; this answers WHICH
+	// STRING. The gap between those two is a whole class of defect the contract
+	// could not see: a receiver that confines correctly, computes the confined
+	// path, and then forwards the caller's original spelling anyway. Every
+	// obligation below was green against exactly that, because each one only
+	// ever asked whether a dispatch happened (found in review of #1389, by
+	// replacing a receiver's write-back with a no-op).
+	ObservedPath func() string
 }
 
 // HookReceiver wires one adapter's hook receiver into AssertHookPathConfined.
@@ -88,7 +100,7 @@ type HookReceiver struct {
 	EndpointPath string
 }
 
-// AssertHookPathConfined runs the issue #1361 contract against r. Five
+// AssertHookPathConfined runs the issue #1361 contract against r. Six
 // obligations, each independently failable:
 //
 //  1. a transcript inside the declared root is still ACCEPTED — the vacuity
@@ -105,17 +117,28 @@ type HookReceiver struct {
 //     that has not been written yet, so a receiver that waves through an
 //     unresolvable leaf (a reasonable allowance — the hook fires around the
 //     write) hands the attacker an escape needing no race at all: plant the
-//     broken link, get the path accepted, then create the target.
+//     broken link, get the path accepted, then create the target;
+//  6. for a path that IS accepted, the string dispatched downstream is the
+//     CONFINED spelling and not the caller's — see
+//     assertConfinedSpellingDispatches. Added by #1389, because 1-5 are all
+//     about the accept/refuse DECISION and every one of them is satisfied by a
+//     receiver that decides correctly and then forwards the caller's string
+//     anyway.
 //
 // Obligations 2–5 additionally require the refusal to be VISIBLE — counted by
 // the confiner, so an operator can see it — and to answer 2xx.
 //
-// A sixth obligation, "the adapter's PRODUCTION constructor confines too", was
-// retired in #1390: the count is now read off Handler.Confiner, so a handler
-// that confines and the counter proving it can no longer be two objects that
-// disagree, and obligations 2-5 fail directly when the production constructor
-// stops confining. The full argument, including what obligation 6 never
-// covered either, is in AGENTS.md under "Hook path confinement".
+// Note the numbering: an EARLIER sixth obligation, "the adapter's PRODUCTION
+// constructor confines too", was retired in #1390 and is unrelated to the one
+// above. It went because the count is now read off Handler.Confiner, so a
+// handler that confines and the counter proving it can no longer be two objects
+// that disagree, and obligations 2-5 fail directly when the production
+// constructor stops confining. The full argument, including what that
+// obligation never covered either, is in AGENTS.md under "Hook path
+// confinement". The two are near-opposites in spirit: the retired one policed
+// WIRING and was replaced by a type guarantee, while #1389's polices the
+// VALUE that travels and could not be replaced by one — nothing in the type
+// system distinguishes a confined string from an unconfined one.
 //
 // The 2xx is asserted, not merely tolerated. A refused path is already fully
 // contained by not being forwarded, so the status code buys no security; what
@@ -132,6 +155,55 @@ func AssertHookPathConfined(t *testing.T, r HookReceiver) {
 	t.Run("parent_traversal_rejected", func(t *testing.T) { assertTraversalRejected(t, r) })
 	t.Run("symlink_escape_rejected", func(t *testing.T) { assertSymlinkEscapeRejected(t, r) })
 	t.Run("dangling_symlink_rejected", func(t *testing.T) { assertDanglingSymlinkRejected(t, r) })
+	t.Run("confined_spelling_is_what_dispatches", func(t *testing.T) { assertConfinedSpellingDispatches(t, r) })
+}
+
+// assertConfinedSpellingDispatches is obligation 6: for a path that IS accepted,
+// the string handed downstream is the confined one, not the caller's.
+//
+// Obligations 1-5 are all about the accept/refuse decision, and every one of
+// them is satisfied by a receiver that decides correctly and then forwards the
+// caller's own string. That receiver is not hypothetical: confinement produces
+// a NEW string, so using it is a separate act from computing it, and the
+// #1389 chokepoint expresses that act as a caller-supplied write-back — a
+// no-op version of which passed this entire contract.
+//
+// It matters beyond tidiness for the same reason claudecode's statusline
+// receiver confines at all: the transcript path is the tailer's map key, so two
+// spellings of one file are two sessions. And where the accepted path reached
+// the root through a symlink, the caller's spelling names the link while the
+// confined one names the target.
+func assertConfinedSpellingDispatches(t *testing.T, r HookReceiver) {
+	t.Helper()
+	root := r.Root(t)
+	inTree := r.WriteTranscript(t, mkSubdir(t, root, "spelling"))
+
+	// The same in-tree file, spelled with a redundant "./". Concatenated rather
+	// than filepath.Join'd because Join cleans, and a pre-cleaned path cannot
+	// tell "the confined string was used" from "the caller's was echoed".
+	dir, base := filepath.Split(inTree)
+	noisy := dir + "./" + base
+
+	rut := r.New(t)
+	rec := postHookPath(t, r, rut, noisy)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("in-tree transcript spelled %s: status = %d, want 200 — a redundant \"./\" is still inside the root",
+			noisy, rec.Code)
+	}
+	got := rut.ObservedPath()
+	if got == "" {
+		t.Fatal("nothing was dispatched, so this obligation would pass vacuously")
+	}
+	// Asserted as "cleaned", not as equal to inTree: the confiner rebuilds an
+	// accepted path on the adapter's DECLARED root, which on macOS can be the
+	// /var spelling of the /private/var directory the test created. Comparing
+	// strings would fail there for a reason that has nothing to do with the
+	// obligation. Whether the noisy segment survived is the actual question.
+	if got == noisy || strings.Contains(got, string(filepath.Separator)+"."+string(filepath.Separator)) {
+		t.Errorf("dispatched %q, which is the caller's own spelling — the receiver confined the path and then "+
+			"forwarded the unconfined string anyway. Confinement must not only decide; its result must be what travels",
+			got)
+	}
 }
 
 // assertInTreeAccepted is obligation 1. It runs first because every assertion


### PR DESCRIPTION
Closes #1389.

## The judgement this ticket asked for, and the answer

#1389 proposed: *no file under `core/adapters/inbound/agents/**` that references a `HookEndpointPath` may call `json.NewDecoder(r.Body)` directly.*

**That rule selects nothing.** Measured against the tree:

```
$ grep -rn "EndpointPath" core/adapters/inbound/agents/*/hooks.go \
       core/adapters/inbound/agents/claudecode/statusline.go
(no matches)
```

`HookEndpointPath` is declared and referenced only in the three `hookinstaller.go` files, which never touch `r.Body`; the four receiver files never mention it; and the fourth receiver's route constant is not even called `HookEndpointPath` (it is `StatuslineEndpointPath`). The rule would have passed vacuously on the day it landed **and** against the exact statusline bug it was written to catch — the too-narrow failure mode the issue warned about, arriving through the issue's own proposal.

**The rule can still be defined — so the issue is implemented, not closed.** The repair is to stop trying to recognize "a hook-receiving file" at all.

### The mechanical definition

> Inside `core/adapters/inbound/agents/...`, reading the body of an inbound `*http.Request` is the exclusive privilege of `hookjson.DecodeConfined`.

There is **no file pattern**, so there is no file a new receiver can hide in: the predicate is the untrusted-input operation itself. Any code that reads an inbound request body in this tree is in scope, whatever it is called and wherever it lives.

**Two arms**, because a bare prohibition would turn the chokepoint's own package into an unpinned hole:

- **Arm A** — zero request-body reads outside `hookjson`.
- **Arm B** — **exactly one** inside it, in `DecodeConfined`. So `hookjson` cannot later grow a second, non-confining decoder and inherit the exemption by living in the right package. Arm B is also the vacuity guard: if the detector stops matching, that count goes to zero and *fails* rather than reporting a clean tree.

### What it covers / does not cover

| | |
|---|---|
| **Covers** | every spelling with a corpus row backing it (see the shape matrix): the `Body` field however reached — directly, aliased, via a struct field, or **promoted from an embedded `*http.Request`** — plus the body-consuming form methods; in any file, in any package under the tree, under any parameter name. Claims here are limited to what a corpus case demonstrates; anything else is in the rows below. |
| **Not covered** | a receiver defined **outside** the agents tree (e.g. beside `registerHookRoutes` in `core/cmd/irrlichd`) |
| **Not covered** | handing the whole `*http.Request` to a package **outside** the tree, which reads `.Body` there. Handing out `r.Body` **is** caught; handing out `r` is not |
| **Not covered** | `_test.go` files — `packages.Load` runs without `Tests`, like every rule in `architecture_test.go` |
| **Not covered** | reflection, generated code, a body read through an interface value |

**Does excluding test files weaken this rule?** Barely, and much less than it weakens the layering rules — a receiver declared in a `_test.go` is never registered on the production mux, so a body read there cannot reach a user. It remains a gap for a helper shared between test and non-test code. (The direct-imports-only limitation of the layering rules does **not** apply: this rule is not import-based.)

**Why the scope boundary is exactly this tree.** Narrower reintroduces the too-narrow failure. Wider fires on the daemon's own REST API in `core/cmd/irrlichd`, which decodes bodies for a living and has no transcript paths. The boundary is load-bearing rather than convenient: an inbound HTTP endpoint hosted by an *agent adapter* on the daemon's local unauthenticated port **is** the #1361 threat surface, and today not one such endpoint is anything other than a hook receiver.

**Too broad?** It fires on zero non-hook handlers today (verified: the only functions under this tree taking an `*http.Request` are the four receivers, their constructor closures, and `hookjson`'s own). A future endpoint that genuinely carries no path would trip it — and there is **no exemption list, by design**, matching `architecture_test.go`, which has none either. Such an endpoint amends the rule in a reviewable diff rather than being waved through by an allowlist with no test behind it.

### Interaction with #1390's retired obligation 6

Obligation 6 policed **wiring** — "the adapter's production constructor confines, not merely the handler the test assembled". #1390 retired it by making the counter a *type* guarantee, read off `HookHandler.Confiner`.

This rule is the same idea taken one step further, and it closes the residual gap #1390's AGENTS.md entry explicitly left open:

> *"What obligation 6 never covered, and still does not, is an adapter wiring `New` to a hand-rolled handler instead of its constructor — `NewProduction` was adapter-supplied too."*

Obligation 6 and its replacement are both **contract** checks, and a contract can only fail for an adapter that *wired* it. A hand-rolled handler that never calls the constructor, in an adapter that never wired `AssertHookPathConfined`, is invisible to both. It is **not** invisible to Arm A, which sees the source regardless of what anyone wired. The two are complements, not substitutes: the contract polices adapters that opted in; the architecture rule polices the ones that did not.

**Nothing in `AssertHookPathConfined` is changed by this PR.** Its five obligations × four receivers are **locks** here — they pass by construction and are the regression net for the refactor.

## Rejected, and left rejected

Mux-level middleware. Settled in #1389 and not revisited: it would key on a top-level `transcript_path` field and **fail open** for any payload that nests or renames it. Recorded in `decode.go`'s doc comment so the next reader does not re-litigate it.

## Files changed

| File | Why |
|---|---|
| `core/adapters/inbound/agents/hookjson/decode.go` | **new** — `DecodeConfined[T]`, the chokepoint: the confiner is an argument to the decode, so a receiver cannot reach its payload without supplying one |
| `core/architecture_hookbody_test.go` | **new** — the rule (Arm A + Arm B), AST + type driven |
| `core/architecture_hookbody_shapes_test.go` | **new** — the shape corpus; makes the matrix below durable instead of PR-body-only |
| `core/adapters/inbound/agents/claudecode/hooks.go` | route through the chokepoint |
| `core/adapters/inbound/agents/claudecode/statusline.go` | route through the chokepoint — **the receiver #1361 forgot** |
| `core/adapters/inbound/agents/codex/hooks.go` | route through the chokepoint; `transcripts` consent moves above the decode |
| `core/adapters/inbound/agents/copilot/hooks.go` | route through the chokepoint; same consent move; supplies `resolveTranscriptPath` as `get` |
| `AGENTS.md` | document the second architecture rule and the build-time half of confinement |

`encoding/json` became unused in three of the four receiver files and was dropped — incidental confirmation that the decode was their only JSON use.

## The one behaviour change

codex and copilot checked the `transcripts` consent **between** the decode and the confinement. Welding those two into one call put that check **above** the pair.

Consent gates reading the **user's** data; a POST body is not that. The only observable difference: a **malformed** body from a transcripts-denied session now gets the same quiet 200 as a well-formed one, instead of a 400. The receipt observation deliberately did **not** move — it is counted against the `hooks` consent only, because a hooks-granted / transcripts-denied install has a working channel the #1368 liveness watchdog must not call dead.

## Red-first evidence

The rule was written **before** the refactor and run against the four unmodified receivers. Verbatim:

```
--- FAIL: TestNoDirectRequestBodyReadsInAgentAdapters (0.15s)
    architecture_hookbody_test.go:165: hook-body violation: irrlicht/core/adapters/inbound/agents/claudecode reads an inbound *http.Request body at core/adapters/inbound/agents/claudecode/hooks.go:280:30 (r.Body in serveHookRequest)
    architecture_hookbody_test.go:165: hook-body violation: irrlicht/core/adapters/inbound/agents/claudecode reads an inbound *http.Request body at core/adapters/inbound/agents/claudecode/statusline.go:105:30 (r.Body in serveStatuslineRequest)
    architecture_hookbody_test.go:165: hook-body violation: irrlicht/core/adapters/inbound/agents/codex reads an inbound *http.Request body at core/adapters/inbound/agents/codex/hooks.go:142:30 (r.Body in serveHookRequest)
    architecture_hookbody_test.go:165: hook-body violation: irrlicht/core/adapters/inbound/agents/copilot reads an inbound *http.Request body at core/adapters/inbound/agents/copilot/hooks.go:200:30 (r.Body in serveHookRequest)
    architecture_hookbody_test.go:178: no request-body read found in irrlicht/core/adapters/inbound/agents/hookjson at all — either hookjson.DecodeConfined no longer decodes the body (in which case every receiver's confinement is now unenforced), or this rule's detector has stopped matching and Arm A above is passing vacuously
FAIL
```

Both arms fired: Arm A named all four receivers (including the statusline one), Arm B failed because the chokepoint did not yet exist.

That red run also **found a real defect in the rule**: every hit was attributed to `<file scope>`. `ast.Inspect` emits its nil sentinel after *every* node's children, not only a `FuncDecl`'s, so a stack popped on nil unwinds at the first leaf. Arm B depends on that name being right — it is the whole difference between "hookjson decodes in `DecodeConfined`" and "hookjson decodes somewhere else too". Fixed by walking one top-level declaration at a time; the comment in `requestBodyReadsIn` records why.

## Shape matrix — caught / not caught

Every row is a committed case in `architecture_hookbody_shapes_test.go`, and every case asserts the construct it plants is **actually present in its own source** before any verdict is checked (`plantedShapeIsPresent`) — a corpus that quietly stops containing its own test cases otherwise reads as a pass.

| Shape | Verdict | Note |
|---|---|---|
| `json.NewDecoder(r.Body).Decode(&p)` | **caught** | what all four receivers did before this PR |
| `dec := json.NewDecoder(r.Body)` then `dec.Decode` | **caught** | a rule matching the literal call expression would miss it |
| `io.ReadAll(r.Body)` + `json.Unmarshal` | **caught** | no `json.NewDecoder` anywhere |
| `body := r.Body` (aliased into a local) | **caught** | |
| helper in **another file**, param named `req` | **caught** *(at the helper)* | the caller passing `r` is not attributed, but the read is reported — the rule is per-tree, not per-file |
| helper taking `io.Reader`, called as `f(r.Body)` | **caught** *(at the call site)* | the selector is at the caller even though the decode is not |
| `r.FormValue("transcript_path")` | **caught** | reads the body without naming `Body` |
| `r.ParseMultipartForm(...)` | **caught** | |
| request stashed in a struct field, `s.req.Body` | **caught** | selector base is an expression, not an identifier |
| **`Body`/`FormValue` promoted from an embedded `*http.Request`** | **caught** | *added after review found it MISSED — see below* |
| **`resp.Body` on an `*http.Response`** | **not caught** ✔ *correct* | outbound client read; a name-based rule would make every HTTP client call a violation |
| **`r.Method` / `r.URL` / `r.Header`** | **not caught** ✔ *correct* | not the body; all four receivers do this on their first line |
| **whole `r` passed to a package outside the tree** | **not caught** ✘ *the documented gap* | the corpus proves the detector **does** see that read when the package is in range, so this is a scope decision, not blindness |

## Deliberate mutations — every probe asserted to have landed

Each probe: back up → mutate → **assert `git diff` is non-empty AND the marker is greppable** → run → restore → `cmp` against the backup. A harness that silently stops mutating produces perfect green; that is what these two assertions exist to prevent.

```
probes reddened as required: 7 ; probes that FAILED to redden: 0     (first round)
```

Plus four more from the review round (M8-M10 below, and the no-op-`set` probe above), one of which — M9 — **caught a defect in my own test** rather than confirming the guard, which is what a mutation harness is for.

| # | Obligation / capability | Mutation | Reddens |
|---|---|---|---|
| M1 | **Arm A** | a receiver decodes `r.Body` directly again (the #1361 shape) | `hooks.go:287:23 (r.Body in serveHookRequest)` |
| M2 | **Arm B** | `hookjson` grows a second body-reading function `DecodeUnconfined` | Arm B names it |
| M3 | **Arm B** (vacuity) | `DecodeConfined` stops reading the body | the "passing vacuously" fatal |
| M4 | detector: form methods | drop `bodyConsumingMethods` | `form_value.go`, `parse_multipart.go` — *"was NOT reported but want reported=true"* |
| M5 | detector: type check | match any `.Body` by name | `response_body.go` — *"WAS reported but want reported=false"* |
| M6 | detector: type- not name-driven | match only a bare identifier named `r` | `helper_impl.go`, `struct_field_request.go` |
| M7 | **corpus self-guard** | a case stops containing the construct it claims to plant | *"shape decoder_in_variable.go does not contain its own needle"* |
| M8 | `c == nil` fail-closed guard | disable the branch | `TestDecodeConfined_NilConfinerFailsClosed` |
| M9 | mandatory `set` | remove the write-back | `TestDecodeConfined_AcceptsInTree…` — **initially GREEN**, which exposed that the test's raw path was `filepath.Join`'d and therefore identical to the confined one |
| M10 | promoted-selection resolution | revert to `sel.X` only | `embedded_request.go` |
| M11 | postcondition | disable it, with a no-op `set` at the call site | obligation 6, on its own merits |

M4–M6 redden **exactly** the rows they should and no others, which is what makes the matrix above evidence rather than assertion.

**Locks** (pass by construction, changed by nothing here, named so their green is not read as red-first proof): `AssertHookPathConfined`'s five obligations × four receivers; `AssertHookReceiptObserved`; `AssertUnknownHookEventObserved`; `TestArchitectureLayerImportDirection`.


## Review round — two confirmed findings, both fixed

A `high`-effort review subagent and a four-agent `/simplify` pass ran against this branch. Two findings were confirmed defects and one was demonstrated by mutation. Both are fixed in `1a22ae62` and `bea81200`.

### Finding 1 — an embedded `*http.Request` defeated the detector

`readsRequestBody` typed the selector **base** (`sel.X`), so a field or method **promoted from an embedded `*http.Request`** — `type hookCtx struct{ *http.Request }`, an ordinary Go request-wrapper idiom — was invisible to **both** arms. A receiver written that way would decode its own body, forward an unconfined `transcript_path`, and leave the build green: a bypass *inside* the governed tree, i.e. the exact too-narrow failure this ticket exists to prevent, one level down from where I was looking.

Reproduced red by a new corpus case before fixing:

```
--- FAIL: TestRequestBodyReadDetectorCatchesEveryKnownShape (0.11s)
    architecture_hookbody_shapes_test.go:406: shape embedded_request.go was NOT reported but want reported=true
```

Fixed by resolving the **selection** (`info.Selections[sel]`) and walking the embedding path to the type that actually declares the field/method, falling back to the base type for method expressions. Pinned by `embedded_request.go` (both a promoted field and a promoted method).

### Finding 2 — the chokepoint had no test, and its fail-closed branch was unprovable

`DecodeConfined` was the only file in `hookjson` without a sibling test, and its `c == nil` guard is reachable from no production call site — so no mutation could redden it. `decode_test.go` now covers all six exits.

Writing it exposed a third thing on its own: a mutation removing `set()` left the success case **green**, because the raw path was built with `filepath.Join(root, ".", …)`, which *cleans* — so raw and confined were byte-identical and the assertion discriminated nothing. It passed for the wrong reason. Now concatenated, and the mutation reddens.

### The finding that changed the design: obligation 6

The `/simplify` altitude agent demonstrated, by mutation, that replacing a receiver's `set` closure with a no-op left **the entire suite green, including `AssertHookPathConfined`** — because obligations 1–5 ask *whether* a receiver dispatched, never *which string*. Confinement computes a new path; **using** it is a separate act from computing it, and nothing checked that act.

Fixed at two independent levels, each seen red with the other disabled:

1. **`DecodeConfined` verifies its own postcondition** — after `set`, `get(p)` must return the confined path, or the request is dropped fail-closed with a logged reason. One place, covering every present and future receiver.
2. **New obligation 6, `confined_spelling_is_what_dispatches`** — posts an in-tree path spelled with a redundant `/./` and asserts the dispatched string is not the caller's.

Both were needed. The postcondition alone is invisible to the suite when a receiver's tests only ever post already-canonical paths — which is why the no-op-`set` mutation still read green against claudecode until obligation 6 existed:

```
### claudecode — no-op set        ==> RED   (via the postcondition: "nothing was dispatched")
### codex      — no-op set        ==> RED
### copilot    — no-op set        ==> RED
```

and with the postcondition *also* disabled, obligation 6 catches it on its own merits:

```
--- FAIL: TestHookPathConfined/confined_spelling_is_what_dispatches
    hook_path_confinement.go:147: dispatched ".../spelling/./11111111-....jsonl", which is the caller's own
    spelling — the receiver confined the path and then forwarded the unconfined string anyway.
```

Obligation 6 asserts the *spelling* rather than string-equality with the fixture, deliberately: the confiner rebuilds an accepted path on the adapter's **declared** root, which on macOS is the `/var` spelling of a `/private/var` temp dir — the same trap PR #1380 recorded as its rejected mutation 4.

**Note on numbering**: this is *not* #1390's retired obligation 6. That one policed **wiring** and was replaced by a type guarantee. This one polices the **value that travels**, and cannot be — nothing in the type system distinguishes a confined string from an unconfined one. Both the contract's doc comment and AGENTS.md say so explicitly, so the two are not confused later.

### Also applied from `/simplify`

- **`http.MaxBytesReader` (1 MiB)** in `DecodeConfined` — these endpoints are unauthenticated and local, and one shared decode is what lets every receiver inherit the bound. Pinned by a test with an under-limit vacuity guard.
- `types.ExprString` replaces a hand-rolled 19-line renderer that silently **dropped generic type arguments** and printed `*ast.BinaryExpr` for anything unhandled — worse output in the one place this rule's value is legibility.
- `slices.Sorted(maps.Keys(...))` replaces `sortedKeys`; two **unreachable** vacuity guards removed (the known-package loop subsumes them).
- Findings carry a `File` field instead of re-parsing `"file:line:col"` — the old split was wrong for any path containing a colon.
- `decode_test.go` reuses the package's existing `countingLogger` and `staticRoots`, asserts *which* message was logged rather than that any was, and drops a dead darwin `EvalSymlinks` block whose comment contradicted `confine.go`.
- `architecture_test.go` gained a header pointer to its new sibling.
- AGENTS.md trimmed toward the rule plus a pointer, with the archaeology left in the file headers.

### Considered and deliberately NOT done

- **`ConfinablePayload` interface / embedded-field refactor** replacing the `get`/`set` closures. Genuinely deeper — it would make the disagreeing-pair class *unrepresentable* rather than *detected*. Deferred: it touches every payload type and `handler.go`, which this diff does not, and the postcondition plus obligation 6 close the hole meanwhile.
- **Folding the `transcripts` consent keys into `DecodeConfined`.** Real point (the ordering is now a caller convention), and it carries an open question — claudecode declares a `transcripts` permission but its receivers gate only `hooks`/`statusline`. That divergence deserves its own issue, not a silent change here.
- **A static rule that every handler in `registerHookRoutes` is a `hookjson.HookHandler`.** Still the largest documented gap. The reviewer confirmed the tempting shortcut does **not** work — a derived scope of "every package importing `hookjson`" would drag in `core/cmd/irrlichd`, which decodes an unrelated REST body.
- **Unexporting `RejectPath`/`Confine`**. Attractive (it removes a spelling for reaching confinement outside the chokepoint) but a wider API change than this ticket.
- **Nil-confiner check in `NewHandler`.** Right altitude for a startup fact, but it changes a constructor's failure mode outside this diff's concern; the tested `DecodeConfined` guard covers it.

### Efficiency, measured (not assumed)

The hot path is **allocation-neutral**: both closures capture nothing, so the compiler emits static funcvals (`MOVD $...func1·f(SB)`, no `runtime.newobject`) — confirmed in emitted assembly, not inferred. `runtime.newobject` count per request is unchanged at 2 for codex and copilot; an end-to-end benchmark shows 108 allocs/op before and after. The one added cost is an 80-byte struct copy in copilot's `get`, real in the asm and immaterial against a ~21 µs request that is 89% filesystem syscalls. Binary size +0.09%.

## Verification

`tools/preflight.sh` run **chunked, foreground**, every gate PASS:

| Chunk | Result |
|---|---|
| `--only go` | PASS — gofmt, core module tests, onboarding-factory, replaydata validate, recording-rig smoke, replay fixtures, starhistory |
| `--only web` | PASS — both suites (85 + dashboard) |
| `--only arch` | PASS — ARS composite 7.948969 → 7.949118 (improved) |
| `--only tools` | PASS |
| `--only skills` | PASS — 23 files, 0 errors, 0 warnings |
| `--only security` | PASS — govulncheck + gosec + npm audit ×2 |
| `--only posix` | PASS |

`go test ./core/... -race -count=1` re-run green **after** the rebase onto #1460.

**Rebase note.** `origin/main` moved twice mid-run; #1460 collided in `AGENTS.md`. Read its PR body, not just the hunks: its addition lands in the *Managed user files* bullet while mine are in *Architecture* and *Hook path confinement*, and its cross-reference — *"Containment is deliberately lexical, unlike `hookjson`'s confiner"* — remains true, since `DecodeConfined` calls the same symlink-resolving `Confine`. Deletion tripwire against live `origin/main`: **empty** (8 files, all `M`/`A`).

## Deliberately not done

- **No static check that every handler in `registerHookRoutes` is a `hookjson.HookHandler`.** That is the natural complement and would close the "receiver defined outside the agents tree" gap, but it is a third AST walker over a different package and belongs in its own change.
- **No exemption mechanism.** See above — deliberate, and matches `architecture_test.go`.
- **No change to `AssertHookPathConfined`.** Its obligations are locks here.
- **The mux-middleware alternative was not revisited.** Settled in #1389.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
