### PR TITLE
feat(contracttesting): grade hook endpoints by declared delivery route

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -149,22 +149,22 @@ Before marking a ticket done, run the full suite — every layer must pass:
   rather than an exemption: the beacon makes the whole stale-port class
   INEXPRESSIBLE instead of fixing it once more — the dev daemon that left a
   user's real `~/.claude/settings.json` and `~/.codex/hooks.json` pointing at
-  three dead ports (#1449) could not have — so the mode asserts that the
-  property was actually obtained (the line varies with nothing and carries
-  nothing address-shaped) plus the failure the beacon NEWLY admits: an entry
-  naming a binary path that is no longer the running one, which must be
-  rewritten in place exactly as a stale port must. Only obligation 1 differs
-  between the modes; 2–4 are one implementation parameterised by the seed and
-  by the address check. Declaring the wrong mode cannot pass quietly — the two
-  first obligations are contradictory assertions about the same two strings
-  (URL requires them to DIFFER across bind addresses, address-free requires
-  them IDENTICAL), so a beacon adapter that forgets the field and a URL adapter
-  that sets it both go red. No adapter ships beacon delivery yet, so the
-  address-free call site is the reference wiring in
-  `hook_endpoint_addressfree_test.go`, which is also the shape to copy: it
-  resolves the binary path ONCE through `hookbeacon.InstalledCommand`, keeping
-  its config builder infallible rather than paying the +12 lines of error
-  branching a per-config resolve measured for copilot.
+  three dead ports (#1449) could not have — so the address-free route asserts
+  that the property was actually obtained (the line varies with nothing and
+  carries nothing address-shaped) plus the failure the beacon NEWLY admits: an
+  entry naming a binary path that is no longer the running one, which must be
+  rewritten in place exactly as a stale port must. Declaring the wrong route
+  cannot pass quietly, which is why this is a declaration and not an exemption:
+  the two routes' first obligations are contradictory assertions about the same
+  two strings (URL requires them to DIFFER across bind addresses, address-free
+  requires them IDENTICAL), so a beacon adapter that forgets the field and a URL
+  adapter that sets it both go red. The reasoning, and which obligations each
+  route runs, is on `deliveryRules` in that file rather than restated here.
+  Whichever adapter adopts beacon delivery first replaces
+  `hook_endpoint_addressfree_test.go`, the reference wiring the route is
+  currently exercised by — and that file is also the shape to copy, down to
+  resolving the binary path once through `hookbeacon.InstalledCommand` so the
+  config builder stays infallible.
 - Hook disclosure: `contracttesting.AssertHookDisclosureMatchesInstalled`
   (`core/internal/contracttesting/hook_disclosure.go`) binds a hooks
   permission's consent copy to what the installer actually writes — the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,7 +137,34 @@ Before marking a ticket done, run the full suite — every layer must pass:
   an install writes the resolved port not `:7837`, an entry left by a daemon
   on another port is rewritten in place rather than duplicated, and uninstall
   is not port-scoped (#1178). A new hook-installing adapter wires one call
-  (see `claudecode`/`codex` `hookport_test.go`) instead of porting a test file.
+  (see `claudecode`/`codex`/`copilot` `hookport_test.go`) instead of porting a
+  test file. It grades against the delivery route the adapter DECLARES
+  (`HookInstaller.Delivery`, #1453), because there are two ways to satisfy it
+  and the second makes the first unsatisfiable. `DeliveryURL` — the zero value,
+  and all three adapters above — is an entry that CARRIES the daemon's address.
+  `DeliveryAddressFree` is an entry that carries none, because it names the
+  `irrlichd hook-post` beacon (`core/pkg/hookbeacon`, #1373), which reads the
+  addr file at fire time; three of the four port obligations then fail by
+  construction, measured against a working beacon. That is the good outcome
+  rather than an exemption: the beacon makes the whole stale-port class
+  INEXPRESSIBLE instead of fixing it once more — the dev daemon that left a
+  user's real `~/.claude/settings.json` and `~/.codex/hooks.json` pointing at
+  three dead ports (#1449) could not have — so the mode asserts that the
+  property was actually obtained (the line varies with nothing and carries
+  nothing address-shaped) plus the failure the beacon NEWLY admits: an entry
+  naming a binary path that is no longer the running one, which must be
+  rewritten in place exactly as a stale port must. Only obligation 1 differs
+  between the modes; 2–4 are one implementation parameterised by the seed and
+  by the address check. Declaring the wrong mode cannot pass quietly — the two
+  first obligations are contradictory assertions about the same two strings
+  (URL requires them to DIFFER across bind addresses, address-free requires
+  them IDENTICAL), so a beacon adapter that forgets the field and a URL adapter
+  that sets it both go red. No adapter ships beacon delivery yet, so the
+  address-free call site is the reference wiring in
+  `hook_endpoint_addressfree_test.go`, which is also the shape to copy: it
+  resolves the binary path ONCE through `hookbeacon.InstalledCommand`, keeping
+  its config builder infallible rather than paying the +12 lines of error
+  branching a per-config resolve measured for copilot.
 - Hook disclosure: `contracttesting.AssertHookDisclosureMatchesInstalled`
   (`core/internal/contracttesting/hook_disclosure.go`) binds a hooks
   permission's consent copy to what the installer actually writes — the
@@ -380,8 +407,9 @@ Before marking a ticket done, run the full suite — every layer must pass:
   `spawn-record-daemon.sh`, immediately beside the `snapshot_managed_files`
   call that earns the entitlement. **`ir:test-mac`'s separate mode therefore no
   longer installs hooks** — that was the damage, not a regression.
-  All seven contract families pass by construction against a correct adapter, so
-  their whole value is that they *can* fail: a new or reworked contract
+  All seven contract families pass by construction against a correct adapter —
+  or, for a delivery route no adapter has adopted yet, against its reference
+  wiring — so their whole value is that they *can* fail: a new or reworked contract
   assertion lands with the deliberate mutation that was seen red for each
   obligation recorded in its PR — the same bar the red-first rule above sets
   for defect tests.

--- a/core/internal/contracttesting/hook_endpoint.go
+++ b/core/internal/contracttesting/hook_endpoint.go
@@ -78,16 +78,17 @@ const (
 )
 
 // HookInstaller wires one adapter's hook installer into
-// AssertHookEndpointFollowsBindAddr. Every field is required. Between them they
-// cover the only three things that genuinely differ per adapter: where the
+// AssertHookEndpointFollowsBindAddr. Every field is required except Delivery,
+// whose zero value is a route, and ForeignInstall, which only the address-free
+// route uses. Between them they cover the only three things that genuinely
+// differ per adapter: where the
 // config file lives and which env var relocates it (SettingsPath), the
 // install/uninstall entry points, and how an installed entry's endpoint is read
 // back (EndpointOf) — Claude Code writes a native `type: http` entry whose
 // endpoint is its `url`, Codex a `type: command` curl string that embeds it.
 type HookInstaller struct {
-	// Delivery declares how the adapter delivers, and therefore which
-	// obligations apply. The zero value, DeliveryURL, is every adapter wired
-	// before #1453.
+	// Delivery declares the adapter's delivery route, and therefore which
+	// obligations apply. See DeliveryURL / DeliveryAddressFree.
 	Delivery DeliveryMode
 
 	// SettingsPath points the installer at a temp config home — by t.Setenv of
@@ -148,57 +149,112 @@ type HookInstaller struct {
 }
 
 // AssertHookEndpointFollowsBindAddr runs the issue #1178 contract against h, in
-// whichever of the two delivery modes h declares.
+// whichever of the two delivery routes h declares.
 //
-// In DeliveryURL mode, three obligations, each of which a new hook-installing
-// adapter can fail independently:
+// Four sub-tests run in both routes. Only the FIRST differs:
 //
-//  1. an install writes the RESOLVED port, not the default one;
-//  2. an entry left by a daemon on a DIFFERENT port is still recognized as ours
-//     (the sentinel is port-independent) and rewritten IN PLACE, with no
-//     duplicate matcher group appended;
-//  3. uninstall is NOT port-scoped, or `irrlichd --uninstall-hooks` run from a
-//     daemon on one port leaves another port's entries behind.
+//  1. DeliveryURL — the delivery tracks the bind address and carries the
+//     resolved port. DeliveryAddressFree — it does not vary with the bind
+//     address at all and carries nothing address-shaped.
+//  2. an install writes what the adapter would install now, and is idempotent.
+//  3. an entry left by a differently-situated daemon (another port; another
+//     irrlichd binary) is still recognized as ours — the sentinel names neither
+//     — and rewritten IN PLACE, with no duplicate matcher group appended.
+//  4. uninstall is not scoped to the installing daemon, or `irrlichd
+//     --uninstall-hooks` run from one leaves another's entries behind.
 //
-// It assumes the installed endpoint is a URL with a path, since it looks for
-// the ":<port>/" fragment — true of every hook endpoint the daemon serves.
-//
-// In DeliveryAddressFree mode the same three, with the address obligation
-// inverted and the drift re-pointed at the binary path:
-//
-//  1. the delivery does not vary with the bind address AT ALL, and carries
-//     nothing address-shaped — no scheme, no host, no port;
-//  2. an entry naming a DIFFERENT irrlichd binary is still recognized as ours
-//     (the sentinel names neither the path nor the address) and rewritten IN
-//     PLACE, with no duplicate matcher group appended;
-//  3. uninstall is not scoped to the installing binary either.
-//
-// What it deliberately does NOT assert in that mode is that the beacon resolves
-// a live daemon's address at fire time. That is the beacon's own obligation and
-// is covered where the beacon lives, by
+// What it deliberately does NOT assert in address-free mode is that the beacon
+// resolves a live daemon's address at fire time. That is the beacon's own
+// obligation and is covered where the beacon lives, by
 // hookbeacon.TestPostResolvesTheDaemonAddressAtFireTime; this family grades the
 // ADAPTER, and an adapter cannot get it wrong or right.
 func AssertHookEndpointFollowsBindAddr(t *testing.T, h HookInstaller) {
 	t.Helper()
+	r := rulesFor(t, h)
+	t.Run(r.firstName, func(t *testing.T) { r.first(t, h) })
+	t.Run(r.installName, func(t *testing.T) { assertInstallWritesCanonicalDelivery(t, h, r) })
+	t.Run(r.upgradeName, func(t *testing.T) { assertUpgradedInPlace(t, h, r) })
+	t.Run(r.uninstallName, func(t *testing.T) { assertUninstallIsNotForeignScoped(t, h, r) })
+}
+
+// deliveryRules is everything that differs between the two routes, selected
+// ONCE from h.Delivery.
+//
+// It replaced a mode field re-consulted in four separate functions. Three of
+// those needed a defensive `default:` arm that could never actually run —
+// t.Fatalf is runtime.Goexit, so an unrecognized mode terminates the parent
+// before any sub-test is created — so the guards read as safety while being
+// dead. Selecting once makes "only the first sub-test differs" a fact about the
+// code rather than a promise four switches have to keep, and leaves exactly one
+// place a third route has to be taught.
+type deliveryRules struct {
+	// firstName and first are the one obligation that genuinely differs.
+	firstName string
+	first     func(t *testing.T, h HookInstaller)
+
+	// The remaining three sub-tests are the same functions in both routes and
+	// differ only in what they are called.
+	installName, upgradeName, uninstallName string
+
+	// assertAddress is the route's address obligation, applied per event.
+	assertAddress func(t *testing.T, what, delivery string)
+
+	// seed leaves behind what a differently-situated daemon installed, and
+	// foreign names it for the failure messages of the two obligations built
+	// on it.
+	seed    func(t *testing.T, h HookInstaller)
+	foreign string
+}
+
+func rulesFor(t *testing.T, h HookInstaller) deliveryRules {
+	t.Helper()
 	switch h.Delivery {
 	case DeliveryURL:
-		t.Run("endpoint_follows_bind_addr", func(t *testing.T) { assertEndpointFollowsBindAddr(t, h) })
-		t.Run("install_writes_resolved_port", func(t *testing.T) { assertInstallWritesCanonicalDelivery(t, h) })
-		t.Run("default_port_install_upgraded_in_place", func(t *testing.T) { assertUpgradedInPlace(t, h) })
-		t.Run("uninstall_is_not_port_scoped", func(t *testing.T) { assertUninstallIsNotForeignScoped(t, h) })
+		return deliveryRules{
+			firstName:     "endpoint_follows_bind_addr",
+			first:         assertEndpointFollowsBindAddr,
+			installName:   "install_writes_resolved_port",
+			upgradeName:   "default_port_install_upgraded_in_place",
+			uninstallName: "uninstall_is_not_port_scoped",
+			assertAddress: assertResolvedPort,
+			seed:          seedDefaultPortInstall,
+			foreign:       "a default-port install",
+		}
 	case DeliveryAddressFree:
 		if h.ForeignInstall == nil {
 			t.Fatal("DeliveryAddressFree requires ForeignInstall — there is no bind address the contract can vary to produce a drifted install for it")
 		}
-		t.Run("delivery_carries_no_address", func(t *testing.T) { assertDeliveryCarriesNoAddress(t, h) })
-		t.Run("install_writes_address_free_delivery", func(t *testing.T) { assertInstallWritesCanonicalDelivery(t, h) })
-		t.Run("foreign_binary_install_upgraded_in_place", func(t *testing.T) { assertUpgradedInPlace(t, h) })
-		t.Run("uninstall_is_not_binary_scoped", func(t *testing.T) { assertUninstallIsNotForeignScoped(t, h) })
+		return deliveryRules{
+			firstName:     "delivery_carries_no_address",
+			first:         assertDeliveryCarriesNoAddress,
+			installName:   "install_writes_address_free_delivery",
+			upgradeName:   "foreign_binary_install_upgraded_in_place",
+			uninstallName: "uninstall_is_not_binary_scoped",
+			assertAddress: assertNoAddress,
+			seed:          seedForeignBinaryInstall,
+			foreign:       "an install naming a different irrlichd binary",
+		}
 	default:
-		// A mode added to the enum but not wired here would otherwise run no
-		// obligations at all and report a pass.
-		t.Fatalf("unhandled DeliveryMode %d — every mode must name the obligations it runs", h.Delivery)
+		t.Fatalf("unhandled DeliveryMode %d — every route must name the obligations it runs", h.Delivery)
+		return deliveryRules{}
 	}
+}
+
+// deliveriesOnBothAddrs returns what the adapter would install on the default
+// and on the alternate bind address. The two obligation-1 bodies differ only in
+// how they compare the pair.
+//
+// It relocates the config home even though it writes nothing: an Entry() that
+// reads anything home-relative must never be evaluated against the developer's
+// real agent config. And it confirms EndpointOf read something at all before
+// either body compares — see assertDeliveryIsOurs.
+func deliveriesOnBothAddrs(t *testing.T, h HookInstaller) (onDefault, onAlt string) {
+	t.Helper()
+	h.SettingsPath(t)
+	onDefault = deliveryOn(t, h, "")
+	onAlt = deliveryOn(t, h, AltBindAddr)
+	assertDeliveryIsOurs(t, h, "delivery on the default bind address", onDefault)
+	return onDefault, onAlt
 }
 
 // assertDeliveryCarriesNoAddress is DeliveryAddressFree's obligation 1, and the
@@ -211,35 +267,21 @@ func AssertHookEndpointFollowsBindAddr(t *testing.T, h HookInstaller) {
 // reason and so could still be written differently by two daemons.
 func assertDeliveryCarriesNoAddress(t *testing.T, h HookInstaller) {
 	t.Helper()
-	// Relocate the config home even though this sub-test writes nothing: an
-	// Entry() that reads anything home-relative must never be evaluated against
-	// the developer's real agent config.
-	h.SettingsPath(t)
-
-	onDefault := deliveryOn(t, h, "")
-	onAlt := deliveryOn(t, h, AltBindAddr)
+	onDefault, onAlt := deliveriesOnBothAddrs(t, h)
 	if onDefault != onAlt {
-		t.Fatalf("delivery differs between the default and %s bind addresses (%q vs %q) — an address-free install must not vary with %s, or a daemon on another port writes a different line and the whole point of the mode is lost",
+		t.Fatalf("delivery differs between the default and %s bind addresses (%q vs %q) — an address-free install must not vary with %s, or a daemon on another port writes a different line and the whole point of the route is lost",
 			AltBindAddr, onDefault, onAlt, daemonaddr.EnvBindAddr)
 	}
-	assertDeliveryIsOurs(t, h, "delivery on the default bind address", onDefault)
-	assertNoAddress(t, "delivery on the default bind address", onDefault)
-	assertNoAddress(t, "delivery on "+AltBindAddr, onAlt)
+	// onDefault and onAlt are equal past the Fatalf, so one check covers both.
+	assertNoAddress(t, "delivery on both bind addresses", onDefault)
 }
 
-// assertEndpointFollowsBindAddr is obligation 1 at the source: the endpoint the
-// adapter would install is a function of the bind address at all. An installer
-// that hardcodes the port fails here first, and most legibly.
+// assertEndpointFollowsBindAddr is DeliveryURL's obligation 1 at the source:
+// the endpoint the adapter would install is a function of the bind address at
+// all. An installer that hardcodes the port fails here first, and most legibly.
 func assertEndpointFollowsBindAddr(t *testing.T, h HookInstaller) {
 	t.Helper()
-	// Relocate the config home even though this sub-test writes nothing: an
-	// Entry() that reads anything home-relative must never be evaluated against
-	// the developer's real agent config.
-	h.SettingsPath(t)
-
-	onDefault := deliveryOn(t, h, "")
-	onAlt := deliveryOn(t, h, AltBindAddr)
-	assertDeliveryIsOurs(t, h, "delivery on the default bind address", onDefault)
+	onDefault, onAlt := deliveriesOnBothAddrs(t, h)
 	if onDefault == onAlt {
 		t.Fatalf("delivery is identical on the default and %s bind addresses (%q) — the endpoint does not follow %s",
 			AltBindAddr, onDefault, daemonaddr.EnvBindAddr)
@@ -247,11 +289,10 @@ func assertEndpointFollowsBindAddr(t *testing.T, h HookInstaller) {
 	assertResolvedPort(t, "delivery on "+AltBindAddr, onAlt)
 }
 
-// assertInstallWritesCanonicalDelivery is obligation 1 end to end: what
-// actually lands in the settings file, plus idempotency on an unchanged bind
-// address. Shared by both modes — only the per-delivery address check inside
-// assertEveryEventDelivers differs.
-func assertInstallWritesCanonicalDelivery(t *testing.T, h HookInstaller) {
+// assertInstallWritesCanonicalDelivery is obligation 2: what actually lands in
+// the settings file, plus idempotency on an unchanged bind address. Shared by
+// both routes — only r.assertAddress differs.
+func assertInstallWritesCanonicalDelivery(t *testing.T, h HookInstaller, r deliveryRules) {
 	t.Helper()
 	path := h.SettingsPath(t)
 	want := deliveryOn(t, h, AltBindAddr)
@@ -259,7 +300,7 @@ func assertInstallWritesCanonicalDelivery(t *testing.T, h HookInstaller) {
 	if _, err := h.EnsureInstalled(); err != nil {
 		t.Fatalf("EnsureInstalled: %v", err)
 	}
-	assertEveryEventDelivers(t, h, path, want)
+	assertEveryEventDelivers(t, h, r, path, want)
 
 	modified, err := h.EnsureInstalled()
 	if err != nil {
@@ -270,14 +311,13 @@ func assertInstallWritesCanonicalDelivery(t *testing.T, h HookInstaller) {
 	}
 }
 
-// assertUpgradedInPlace is obligation 2: an install left by a differently
+// assertUpgradedInPlace is obligation 3: an install left by a differently
 // situated daemon is recognized as ours and repointed, not orphaned beside a
-// duplicate group. What "differently situated" means is the mode's — another
-// port, or another irrlichd binary — and it is the whole of the difference.
-func assertUpgradedInPlace(t *testing.T, h HookInstaller) {
+// duplicate group. What "differently situated" means is r.seed's business.
+func assertUpgradedInPlace(t *testing.T, h HookInstaller, r deliveryRules) {
 	t.Helper()
 	path := h.SettingsPath(t)
-	seedForeignInstall(t, h, path)
+	seedForeignInstall(t, h, r, path)
 	want := deliveryOn(t, h, AltBindAddr)
 
 	modified, err := h.EnsureInstalled()
@@ -285,23 +325,23 @@ func assertUpgradedInPlace(t *testing.T, h HookInstaller) {
 		t.Fatalf("EnsureInstalled: %v", err)
 	}
 	if !modified {
-		t.Fatalf("expected modified=true when repointing %s — an install left unrepaired here reports healthy while delivering nothing, and no later daemon start converges on it", h.foreignDescription())
+		t.Fatalf("expected modified=true when repointing %s — an install left unrepaired here reports healthy while delivering nothing, and no later daemon start converges on it", r.foreign)
 	}
 	// assertEveryEventDelivers fails on a second matcher group, which is the
 	// "upgraded in place, not duplicated" half of this obligation.
-	assertEveryEventDelivers(t, h, path, want)
+	assertEveryEventDelivers(t, h, r, path, want)
 }
 
-// assertUninstallIsNotForeignScoped is obligation 3: a daemon cleans up entries
+// assertUninstallIsNotForeignScoped is obligation 4: a daemon cleans up entries
 // a differently-situated daemon installed. In DeliveryURL mode that is another
 // port; in DeliveryAddressFree mode another binary path, where it additionally
 // means Uninstall must not depend on resolving a binary path at all —
 // `site/install.sh --uninstall` removes the binary without calling
 // --uninstall-hooks, so the entry commonly outlives the path it names.
-func assertUninstallIsNotForeignScoped(t *testing.T, h HookInstaller) {
+func assertUninstallIsNotForeignScoped(t *testing.T, h HookInstaller, r deliveryRules) {
 	t.Helper()
 	path := h.SettingsPath(t)
-	seedForeignInstall(t, h, path)
+	seedForeignInstall(t, h, r, path)
 	t.Setenv(daemonaddr.EnvBindAddr, AltBindAddr)
 
 	modified, err := h.Uninstall()
@@ -309,12 +349,12 @@ func assertUninstallIsNotForeignScoped(t *testing.T, h HookInstaller) {
 		t.Fatalf("Uninstall: %v", err)
 	}
 	if !modified {
-		t.Fatalf("expected modified=true removing %s from a daemon on %s", h.foreignDescription(), AltBindAddr)
+		t.Fatalf("expected modified=true removing %s from a daemon on %s", r.foreign, AltBindAddr)
 	}
 	hooksMap := readHooksMap(t, path)
 	for _, event := range h.Events {
 		if hookjson.HasOurHook(hooksMap, event, h.Sentinel) {
-			t.Errorf("event %s: %s survived uninstall", event, h.foreignDescription())
+			t.Errorf("event %s: %s survived uninstall", event, r.foreign)
 		}
 	}
 }
@@ -330,11 +370,11 @@ func deliveryOn(t *testing.T, h HookInstaller, bindAddr string) string {
 }
 
 // assertEveryEventDelivers checks each event's installed entry against want and
-// against the mode's address obligation. Both matter: equality catches an
+// against the route's address obligation. Both matter: equality catches an
 // installer writing a stale shape, the address check catches the case want
 // itself is wrong — because the endpoint stopped following the bind address, or
 // because an "address-free" delivery grew an address.
-func assertEveryEventDelivers(t *testing.T, h HookInstaller, path, want string) {
+func assertEveryEventDelivers(t *testing.T, h HookInstaller, r deliveryRules, path, want string) {
 	t.Helper()
 	hooksMap := readHooksMap(t, path)
 	for _, event := range h.Events {
@@ -343,7 +383,7 @@ func assertEveryEventDelivers(t *testing.T, h HookInstaller, path, want string) 
 		if got != want {
 			t.Errorf("event %s: installed delivery = %q, want %q", event, got, want)
 		}
-		assertAddressShape(t, h, "event "+event, got)
+		r.assertAddress(t, "event "+event, got)
 	}
 }
 
@@ -371,35 +411,30 @@ func assertDeliveryIsOurs(t *testing.T, h HookInstaller, what, delivery string) 
 	}
 }
 
-// assertAddressShape applies whichever address obligation h's mode carries to
-// one delivery string. It is the single place the two modes diverge below the
-// first sub-test, which is what keeps the other three one implementation.
-func assertAddressShape(t *testing.T, h HookInstaller, what, delivery string) {
-	t.Helper()
-	switch h.Delivery {
-	case DeliveryURL:
-		assertResolvedPort(t, what, delivery)
-	case DeliveryAddressFree:
-		assertNoAddress(t, what, delivery)
-	default:
-		// The switch in AssertHookEndpointFollowsBindAddr forces a new mode to
-		// name its obligations; without this one, it would silently inherit the
-		// URL address check down here and be told to carry a port.
-		t.Fatalf("unhandled DeliveryMode %d in assertAddressShape", h.Delivery)
-	}
-}
+// hookRoutePrefix is the path every hook receiver the daemon serves is
+// registered under. An address-free delivery must not contain it: an adapter
+// that embeds the daemon's HTTP route is delivering by URL whatever it declares.
+const hookRoutePrefix = "/api/v1/"
 
-// addressShaped matches anything that could pin a delivery to one daemon: a
-// scheme, a loopback host, a port-shaped `:<digits>`, or a port passed as a
-// flag argument. It is deliberately broader than the ":<port>/" fragment
-// assertResolvedPort looks for, because the failure it guards is an adapter
-// reintroducing an address in SOME spelling — including one no daemon of ours
-// currently uses.
+// addressShaped matches anything that could pin a delivery to one daemon — a
+// scheme, a loopback host, a port-shaped `:<digits>`, a port passed as a flag
+// argument, either concrete daemon port as a bare word, or the hook route.
 //
-// The colon-less `port 7837` branch is not decoration. A hardcoded port is
-// invariant across bind addresses, so it slips past the equality half of the
-// first sub-test as well, and `--port 7837` would then have satisfied BOTH
+// It is deliberately broader than the ":<port>/" fragment assertResolvedPort
+// looks for, because the failure it guards is an adapter reintroducing an
+// address in SOME spelling — including one no daemon of ours currently uses.
+//
+// Two of the branches are not decoration. A HARDCODED port is invariant across
+// bind addresses, so it slips past the equality half of obligation 1 as well:
+// `--port 7837` and a bare `7837` would each otherwise have satisfied BOTH
 // halves while writing exactly the #1178 defect into the user's config.
+//
+// This is the superset of hookbeacon's own TestCommandCarriesNoAddress, which
+// states the same rule as a substring list ("7837", "7838", "http://",
+// "https://", "localhost", "127.0.0.1", "/api/v1/") over the rendered command.
+// Two spellings of one rule can disagree, so this one is built to contain that
+// list rather than to parallel it — the ports are taken from daemonaddr instead
+// of retyped, so they cannot drift at all.
 //
 // It is applied to the WHOLE delivery, which for a beacon begins with a
 // shell-quoted absolute path, so it is fail-closed on two known false
@@ -409,7 +444,17 @@ func assertAddressShape(t *testing.T, h HookInstaller, what, delivery string) {
 // the whole delivery, so the cause is legible — and no layout we ship trips it
 // (`/Applications/Irrlicht.app/...`, `/opt/homebrew/bin/...`, `~/.local/bin/...`
 // and go's `/var/folders/.../go-build.../b001/...` test paths are all clean).
-var addressShaped = regexp.MustCompile(`(?i)https?://|\b(?:localhost|127\.0\.0\.1|0\.0\.0\.0)\b|\[::1\]|:\d{2,5}(?:\b|/)|\bports?\b[\s=:]*\d{2,5}\b`)
+// The bare-port branch is word-bounded for that reason: a go-build directory
+// like `go-build17837293` contains "7837" but is not it.
+var addressShaped = regexp.MustCompile(
+	`(?i)https?://` +
+		`|\b(?:localhost|127\.0\.0\.1|0\.0\.0\.0)\b` +
+		`|\[::1\]` +
+		`|:\d{2,5}(?:\b|/)` +
+		`|\bports?\b[\s=:]*\d{2,5}\b` +
+		`|` + regexp.QuoteMeta(hookRoutePrefix) +
+		fmt.Sprintf(`|\b(?:%d|%d)\b`, daemonaddr.PortOf(""), daemonaddr.PortOf(AltBindAddr)),
+)
 
 // assertNoAddress fails when delivery carries anything address-shaped. This is
 // the DeliveryAddressFree counterpart of assertResolvedPort, and it is what
@@ -440,54 +485,45 @@ func portMarker(bindAddr string) string {
 	return fmt.Sprintf(":%d/", daemonaddr.PortOf(bindAddr))
 }
 
-// foreignDescription names what seedForeignInstall arranged, for the failure
-// messages of the two obligations built on it.
-func (h HookInstaller) foreignDescription() string {
-	switch h.Delivery {
-	case DeliveryURL:
-		return "a default-port install"
-	case DeliveryAddressFree:
-		return "an install naming a different irrlichd binary"
-	default:
-		return fmt.Sprintf("a foreign install (unhandled DeliveryMode %d)", h.Delivery)
+// seedDefaultPortInstall is DeliveryURL's seed: the adapter's own installer run
+// under a default-port environment.
+func seedDefaultPortInstall(t *testing.T, h HookInstaller) {
+	t.Helper()
+	t.Setenv(daemonaddr.EnvBindAddr, "")
+	if _, err := h.EnsureInstalled(); err != nil {
+		t.Fatalf("seeding a default-port install: %v", err)
 	}
 }
 
-// seedForeignInstall leaves behind exactly what a differently-situated daemon
-// would have. In DeliveryURL mode that is the adapter's own installer run under
-// a default-port environment; in DeliveryAddressFree mode it is the adapter's
-// ForeignInstall, because no environment variable makes an installer name a
-// different binary.
+// seedForeignBinaryInstall is DeliveryAddressFree's seed. It has to be
+// adapter-supplied because no environment variable makes an installer name a
+// different binary, where the bind address is one the contract can set itself.
+func seedForeignBinaryInstall(t *testing.T, h HookInstaller) {
+	t.Helper()
+	if _, err := h.ForeignInstall(); err != nil {
+		t.Fatalf("seeding an install naming a different irrlichd binary: %v", err)
+	}
+}
+
+// seedForeignInstall runs the route's seed and then cross-checks it.
 //
-// Both go through a real installer. Synthesizing the matcher groups by hand
-// instead would be a second implementation of what hookjson.EnsureInstalled
+// Both seeds go through a real installer. Synthesizing the matcher groups by
+// hand instead would be a second implementation of what hookjson.EnsureInstalled
 // already does, and one that could drift from the shape the adapter actually
 // writes.
-func seedForeignInstall(t *testing.T, h HookInstaller, path string) {
+func seedForeignInstall(t *testing.T, h HookInstaller, r deliveryRules, path string) {
 	t.Helper()
-	switch h.Delivery {
-	case DeliveryURL:
-		t.Setenv(daemonaddr.EnvBindAddr, "")
-		if _, err := h.EnsureInstalled(); err != nil {
-			t.Fatalf("seeding %s: %v", h.foreignDescription(), err)
-		}
-	case DeliveryAddressFree:
-		if _, err := h.ForeignInstall(); err != nil {
-			t.Fatalf("seeding %s: %v", h.foreignDescription(), err)
-		}
-	default:
-		t.Fatalf("unhandled DeliveryMode %d in seedForeignInstall", h.Delivery)
-	}
+	r.seed(t, h)
 
 	// Sentinel is the one field nothing else cross-checks, and a wrong value
 	// makes the uninstall-survival assertion pass vacuously — HasOurHook would
-	// simply find nothing, for the wrong reason. Confirming the adapter's own
-	// install is matched by the declared sentinel turns that silent hole into a
-	// wiring error.
+	// simply find nothing, for the wrong reason. Confirming the seeded install
+	// is matched by the declared sentinel turns that silent hole into a wiring
+	// error.
 	seeded := readHooksMap(t, path)
 	for _, event := range h.Events {
 		if !hookjson.HasOurHook(seeded, event, h.Sentinel) {
-			t.Fatalf("event %s: %s is not matched by Sentinel %q — the contract is wired wrong", event, h.foreignDescription(), h.Sentinel)
+			t.Fatalf("event %s: %s is not matched by Sentinel %q — the contract is wired wrong", event, r.foreign, h.Sentinel)
 		}
 	}
 }

--- a/core/internal/contracttesting/hook_endpoint.go
+++ b/core/internal/contracttesting/hook_endpoint.go
@@ -25,10 +25,10 @@
 // really was obtained (the line varies with nothing and carries nothing
 // address-shaped) and that the failure the beacon NEWLY admits is policed: an
 // entry naming a binary path that is no longer the running one must be
-// rewritten in place, exactly as a stale port must be. Only obligation 1
-// differs between the modes; obligations 2-4 are the same code, parameterised
-// by which seed stands in for "what a differently-situated daemon left behind"
-// and which address assertion applies.
+// rewritten in place, exactly as a stale port must be. Only the FIRST of the
+// four sub-tests differs between the modes; the other three are the same code,
+// parameterised by which seed stands in for "what a differently-situated daemon
+// left behind" and which address assertion applies.
 //
 // Declaring the WRONG mode cannot pass quietly, which is the objection
 // hook_receipt.go raises against flag-shaped options ("a wiring that silently
@@ -222,6 +222,7 @@ func assertDeliveryCarriesNoAddress(t *testing.T, h HookInstaller) {
 		t.Fatalf("delivery differs between the default and %s bind addresses (%q vs %q) — an address-free install must not vary with %s, or a daemon on another port writes a different line and the whole point of the mode is lost",
 			AltBindAddr, onDefault, onAlt, daemonaddr.EnvBindAddr)
 	}
+	assertDeliveryIsOurs(t, h, "delivery on the default bind address", onDefault)
 	assertNoAddress(t, "delivery on the default bind address", onDefault)
 	assertNoAddress(t, "delivery on "+AltBindAddr, onAlt)
 }
@@ -238,6 +239,7 @@ func assertEndpointFollowsBindAddr(t *testing.T, h HookInstaller) {
 
 	onDefault := deliveryOn(t, h, "")
 	onAlt := deliveryOn(t, h, AltBindAddr)
+	assertDeliveryIsOurs(t, h, "delivery on the default bind address", onDefault)
 	if onDefault == onAlt {
 		t.Fatalf("delivery is identical on the default and %s bind addresses (%q) — the endpoint does not follow %s",
 			AltBindAddr, onDefault, daemonaddr.EnvBindAddr)
@@ -312,7 +314,7 @@ func assertUninstallIsNotForeignScoped(t *testing.T, h HookInstaller) {
 	hooksMap := readHooksMap(t, path)
 	for _, event := range h.Events {
 		if hookjson.HasOurHook(hooksMap, event, h.Sentinel) {
-			t.Errorf("event %s: a default-port entry survived uninstall", event)
+			t.Errorf("event %s: %s survived uninstall", event, h.foreignDescription())
 		}
 	}
 }
@@ -337,6 +339,7 @@ func assertEveryEventDelivers(t *testing.T, h HookInstaller, path, want string) 
 	hooksMap := readHooksMap(t, path)
 	for _, event := range h.Events {
 		got := h.EndpointOf(onlyEntry(t, hooksMap, event))
+		assertDeliveryIsOurs(t, h, "event "+event, got)
 		if got != want {
 			t.Errorf("event %s: installed delivery = %q, want %q", event, got, want)
 		}
@@ -344,24 +347,69 @@ func assertEveryEventDelivers(t *testing.T, h HookInstaller, path, want string) 
 	}
 }
 
+// assertDeliveryIsOurs fails unless the delivery string carries the sentinel.
+//
+// It is the vacuity guard for EndpointOf, and it is load-bearing in
+// DeliveryAddressFree mode specifically. Inverting obligation 1 from "the two
+// deliveries must DIFFER" to "must be IDENTICAL" removed the only assertion
+// that proved EndpointOf observed anything at all: an EndpointOf reading a key
+// the entry does not carry returns "" for both, and "" is invariant, carries no
+// address, and equals the "" that the next sub-test compares against — so the
+// whole mode passes 4/4 while asserting nothing. That is not a hypothetical
+// slip; the key is the one field that genuinely differs between the wirings
+// already in the tree (claudecode and copilot read `url`, codex reads
+// `command`).
+//
+// The sentinel is the right probe because hookjson identifies OUR entries by
+// finding it in exactly the field EndpointOf is supposed to be reading, so a
+// delivery that does not contain it is either not ours or not being read.
+func assertDeliveryIsOurs(t *testing.T, h HookInstaller, what, delivery string) {
+	t.Helper()
+	if !strings.Contains(delivery, h.Sentinel) {
+		t.Fatalf("%s: %q does not carry Sentinel %q — EndpointOf is not reading the field the installer writes, so every obligation below it is graded against the wrong string",
+			what, delivery, h.Sentinel)
+	}
+}
+
 // assertAddressShape applies whichever address obligation h's mode carries to
-// one delivery string. It is the single place the two modes diverge below
-// obligation 1, which is what keeps obligations 2-4 one implementation.
+// one delivery string. It is the single place the two modes diverge below the
+// first sub-test, which is what keeps the other three one implementation.
 func assertAddressShape(t *testing.T, h HookInstaller, what, delivery string) {
 	t.Helper()
-	if h.Delivery == DeliveryAddressFree {
+	switch h.Delivery {
+	case DeliveryURL:
+		assertResolvedPort(t, what, delivery)
+	case DeliveryAddressFree:
 		assertNoAddress(t, what, delivery)
-		return
+	default:
+		// The switch in AssertHookEndpointFollowsBindAddr forces a new mode to
+		// name its obligations; without this one, it would silently inherit the
+		// URL address check down here and be told to carry a port.
+		t.Fatalf("unhandled DeliveryMode %d in assertAddressShape", h.Delivery)
 	}
-	assertResolvedPort(t, what, delivery)
 }
 
 // addressShaped matches anything that could pin a delivery to one daemon: a
-// scheme, a loopback host, or a port-shaped `:<digits>`. It is deliberately
-// broader than the ":<port>/" fragment assertResolvedPort looks for, because
-// the failure it guards is an adapter reintroducing an address in SOME spelling
-// — including one no daemon of ours currently uses.
-var addressShaped = regexp.MustCompile(`(?i)https?://|\b(?:localhost|127\.0\.0\.1|0\.0\.0\.0)\b|\[::1\]|:\d{2,5}(?:\b|/)`)
+// scheme, a loopback host, a port-shaped `:<digits>`, or a port passed as a
+// flag argument. It is deliberately broader than the ":<port>/" fragment
+// assertResolvedPort looks for, because the failure it guards is an adapter
+// reintroducing an address in SOME spelling — including one no daemon of ours
+// currently uses.
+//
+// The colon-less `port 7837` branch is not decoration. A hardcoded port is
+// invariant across bind addresses, so it slips past the equality half of the
+// first sub-test as well, and `--port 7837` would then have satisfied BOTH
+// halves while writing exactly the #1178 defect into the user's config.
+//
+// It is applied to the WHOLE delivery, which for a beacon begins with a
+// shell-quoted absolute path, so it is fail-closed on two known false
+// positives: a binary path containing `:<digits>` or the literal `localhost`
+// (`/home/localhost-dev/bin/irrlichd`) reads as address-shaped. That is the
+// deliberate direction — the failure message prints the matched fragment and
+// the whole delivery, so the cause is legible — and no layout we ship trips it
+// (`/Applications/Irrlicht.app/...`, `/opt/homebrew/bin/...`, `~/.local/bin/...`
+// and go's `/var/folders/.../go-build.../b001/...` test paths are all clean).
+var addressShaped = regexp.MustCompile(`(?i)https?://|\b(?:localhost|127\.0\.0\.1|0\.0\.0\.0)\b|\[::1\]|:\d{2,5}(?:\b|/)|\bports?\b[\s=:]*\d{2,5}\b`)
 
 // assertNoAddress fails when delivery carries anything address-shaped. This is
 // the DeliveryAddressFree counterpart of assertResolvedPort, and it is what
@@ -395,10 +443,14 @@ func portMarker(bindAddr string) string {
 // foreignDescription names what seedForeignInstall arranged, for the failure
 // messages of the two obligations built on it.
 func (h HookInstaller) foreignDescription() string {
-	if h.Delivery == DeliveryAddressFree {
+	switch h.Delivery {
+	case DeliveryURL:
+		return "a default-port install"
+	case DeliveryAddressFree:
 		return "an install naming a different irrlichd binary"
+	default:
+		return fmt.Sprintf("a foreign install (unhandled DeliveryMode %d)", h.Delivery)
 	}
-	return "a default-port install"
 }
 
 // seedForeignInstall leaves behind exactly what a differently-situated daemon
@@ -413,15 +465,18 @@ func (h HookInstaller) foreignDescription() string {
 // writes.
 func seedForeignInstall(t *testing.T, h HookInstaller, path string) {
 	t.Helper()
-	if h.Delivery == DeliveryAddressFree {
-		if _, err := h.ForeignInstall(); err != nil {
-			t.Fatalf("seeding %s: %v", h.foreignDescription(), err)
-		}
-	} else {
+	switch h.Delivery {
+	case DeliveryURL:
 		t.Setenv(daemonaddr.EnvBindAddr, "")
 		if _, err := h.EnsureInstalled(); err != nil {
 			t.Fatalf("seeding %s: %v", h.foreignDescription(), err)
 		}
+	case DeliveryAddressFree:
+		if _, err := h.ForeignInstall(); err != nil {
+			t.Fatalf("seeding %s: %v", h.foreignDescription(), err)
+		}
+	default:
+		t.Fatalf("unhandled DeliveryMode %d in seedForeignInstall", h.Delivery)
 	}
 
 	// Sentinel is the one field nothing else cross-checks, and a wrong value

--- a/core/internal/contracttesting/hook_endpoint.go
+++ b/core/internal/contracttesting/hook_endpoint.go
@@ -1,14 +1,49 @@
 // hook_endpoint.go holds the issue #1178 contract every hook-installing agent
-// adapter must satisfy: the endpoint it writes into the user's agent config
-// follows the daemon's own bind address. Like AssertPermissionGated it exists
-// because the obligation is a runtime choice an adapter has to opt into — a
-// static check cannot see whether an installer baked ":7837" in — and because
-// the alternative is a third adapter copying a test file, or (issue #1216, more
+// adapter must satisfy: what it writes into the user's agent config cannot go
+// stale when the daemon moves. Like AssertPermissionGated it exists because the
+// obligation is a runtime choice an adapter has to opt into — a static check
+// cannot see whether an installer baked ":7837" in — and because the
+// alternative is a third adapter copying a test file, or (issue #1216, more
 // likely) not copying it and silently shipping a hardcoded port.
+//
+// There are two ways to satisfy that, and the contract holds an adapter to
+// whichever one it declares in HookInstaller.Delivery (issue #1453):
+//
+//   - DeliveryURL — the installed entry CARRIES the daemon's address, so the
+//     address it carries has to be the resolved one and a daemon on another
+//     port has to rewrite it in place. This is claudecode, codex and copilot.
+//   - DeliveryAddressFree — the installed entry carries NO address, because it
+//     names the `irrlichd hook-post` beacon (core/pkg/hookbeacon) which reads
+//     the daemon's address from the addr file at fire time. This is the route
+//     an agent whose hooks only support `command` delivery must take.
+//
+// The second mode is not an exemption from the first. Address-free delivery
+// makes the #1178 stale-port class INEXPRESSIBLE rather than merely fixing it
+// again — there is no port in the config to go stale — so the port obligations
+// become unsatisfiable by construction, and three of the four measurably fail
+// against a working beacon. What the mode asserts instead is that the property
+// really was obtained (the line varies with nothing and carries nothing
+// address-shaped) and that the failure the beacon NEWLY admits is policed: an
+// entry naming a binary path that is no longer the running one must be
+// rewritten in place, exactly as a stale port must be. Only obligation 1
+// differs between the modes; obligations 2-4 are the same code, parameterised
+// by which seed stands in for "what a differently-situated daemon left behind"
+// and which address assertion applies.
+//
+// Declaring the WRONG mode cannot pass quietly, which is the objection
+// hook_receipt.go raises against flag-shaped options ("a wiring that silently
+// ignored a flag would pass it by accident") and the reason this one is safe:
+// the two modes' first obligation are mutually exclusive assertions about the
+// same two strings — DeliveryURL requires the delivery to DIFFER between two
+// bind addresses, DeliveryAddressFree requires it to be IDENTICAL. A beacon
+// adapter that forgets the field is held to the URL obligations and fails; a
+// URL adapter that sets it is held to the address-free ones and fails. There is
+// no value of Delivery an adapter can be graded under vacuously.
 package contracttesting
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -22,6 +57,26 @@ import (
 // default; the specific value keeps failure messages recognizable.
 const AltBindAddr = "127.0.0.1:7838"
 
+// DeliveryMode selects which half of the contract an adapter is held to. See
+// the file comment for why a mode field rather than a second family: only
+// obligation 1 differs, and no value of it grades an adapter vacuously.
+type DeliveryMode int
+
+const (
+	// DeliveryURL is the zero value: the installed entry carries the daemon's
+	// address, whether as an http entry's `url` or embedded in a curl
+	// command. Every adapter wired before #1453 is this, and stays this
+	// without touching its call site.
+	DeliveryURL DeliveryMode = iota
+
+	// DeliveryAddressFree is beacon delivery: the installed entry names the
+	// irrlichd binary and an adapter segment, and the address is resolved in
+	// the beacon process at fire time. Requires ForeignInstall, because the
+	// drift such an install can suffer is a binary path rather than a port
+	// and the contract has no environment variable that produces it.
+	DeliveryAddressFree
+)
+
 // HookInstaller wires one adapter's hook installer into
 // AssertHookEndpointFollowsBindAddr. Every field is required. Between them they
 // cover the only three things that genuinely differ per adapter: where the
@@ -30,6 +85,11 @@ const AltBindAddr = "127.0.0.1:7838"
 // back (EndpointOf) — Claude Code writes a native `type: http` entry whose
 // endpoint is its `url`, Codex a `type: command` curl string that embeds it.
 type HookInstaller struct {
+	// Delivery declares how the adapter delivers, and therefore which
+	// obligations apply. The zero value, DeliveryURL, is every adapter wired
+	// before #1453.
+	Delivery DeliveryMode
+
 	// SettingsPath points the installer at a temp config home — by t.Setenv of
 	// whatever env var relocates it ($HOME, $CODEX_HOME) — and returns the
 	// absolute path of the settings file the installer will write.
@@ -65,11 +125,33 @@ type HookInstaller struct {
 	// EnsureInstalled and Uninstall are the adapter's exported entry points.
 	EnsureInstalled func() (bool, error)
 	Uninstall       func() (bool, error)
+
+	// ForeignInstall leaves behind what a DIFFERENTLY-SITUATED daemon would
+	// have installed — the state obligations 3 and 4 both start from. It is
+	// required in DeliveryAddressFree mode and ignored in DeliveryURL, where
+	// the contract produces the same thing itself by pinning the default bind
+	// address and calling EnsureInstalled.
+	//
+	// For a beacon adapter that means installing against a DIFFERENT irrlichd
+	// binary path — hookbeacon.Command takes one explicitly for this reason.
+	// Prefer a path that does not exist: an absolute path that has stopped
+	// existing is the drift the beacon newly admits (#1373), and it needs no
+	// second executable to arrange.
+	//
+	// Neither way of getting it wrong passes: an entry that is already
+	// canonical leaves obligation 3 with modified=false, and one that does not
+	// carry Sentinel is not recognized as ours, so EnsureInstalled appends a
+	// second matcher group and onlyEntry fails on the group count. The seed is
+	// additionally cross-checked against Sentinel before either obligation
+	// runs.
+	ForeignInstall func() (bool, error)
 }
 
-// AssertHookEndpointFollowsBindAddr runs the issue #1178 contract against h.
-// Three obligations, each of which a new hook-installing adapter can fail
-// independently:
+// AssertHookEndpointFollowsBindAddr runs the issue #1178 contract against h, in
+// whichever of the two delivery modes h declares.
+//
+// In DeliveryURL mode, three obligations, each of which a new hook-installing
+// adapter can fail independently:
 //
 //  1. an install writes the RESOLVED port, not the default one;
 //  2. an entry left by a daemon on a DIFFERENT port is still recognized as ours
@@ -80,12 +162,68 @@ type HookInstaller struct {
 //
 // It assumes the installed endpoint is a URL with a path, since it looks for
 // the ":<port>/" fragment — true of every hook endpoint the daemon serves.
+//
+// In DeliveryAddressFree mode the same three, with the address obligation
+// inverted and the drift re-pointed at the binary path:
+//
+//  1. the delivery does not vary with the bind address AT ALL, and carries
+//     nothing address-shaped — no scheme, no host, no port;
+//  2. an entry naming a DIFFERENT irrlichd binary is still recognized as ours
+//     (the sentinel names neither the path nor the address) and rewritten IN
+//     PLACE, with no duplicate matcher group appended;
+//  3. uninstall is not scoped to the installing binary either.
+//
+// What it deliberately does NOT assert in that mode is that the beacon resolves
+// a live daemon's address at fire time. That is the beacon's own obligation and
+// is covered where the beacon lives, by
+// hookbeacon.TestPostResolvesTheDaemonAddressAtFireTime; this family grades the
+// ADAPTER, and an adapter cannot get it wrong or right.
 func AssertHookEndpointFollowsBindAddr(t *testing.T, h HookInstaller) {
 	t.Helper()
-	t.Run("endpoint_follows_bind_addr", func(t *testing.T) { assertEndpointFollowsBindAddr(t, h) })
-	t.Run("install_writes_resolved_port", func(t *testing.T) { assertInstallWritesResolvedPort(t, h) })
-	t.Run("default_port_install_upgraded_in_place", func(t *testing.T) { assertUpgradedInPlace(t, h) })
-	t.Run("uninstall_is_not_port_scoped", func(t *testing.T) { assertUninstallIsNotPortScoped(t, h) })
+	switch h.Delivery {
+	case DeliveryURL:
+		t.Run("endpoint_follows_bind_addr", func(t *testing.T) { assertEndpointFollowsBindAddr(t, h) })
+		t.Run("install_writes_resolved_port", func(t *testing.T) { assertInstallWritesCanonicalDelivery(t, h) })
+		t.Run("default_port_install_upgraded_in_place", func(t *testing.T) { assertUpgradedInPlace(t, h) })
+		t.Run("uninstall_is_not_port_scoped", func(t *testing.T) { assertUninstallIsNotForeignScoped(t, h) })
+	case DeliveryAddressFree:
+		if h.ForeignInstall == nil {
+			t.Fatal("DeliveryAddressFree requires ForeignInstall — there is no bind address the contract can vary to produce a drifted install for it")
+		}
+		t.Run("delivery_carries_no_address", func(t *testing.T) { assertDeliveryCarriesNoAddress(t, h) })
+		t.Run("install_writes_address_free_delivery", func(t *testing.T) { assertInstallWritesCanonicalDelivery(t, h) })
+		t.Run("foreign_binary_install_upgraded_in_place", func(t *testing.T) { assertUpgradedInPlace(t, h) })
+		t.Run("uninstall_is_not_binary_scoped", func(t *testing.T) { assertUninstallIsNotForeignScoped(t, h) })
+	default:
+		// A mode added to the enum but not wired here would otherwise run no
+		// obligations at all and report a pass.
+		t.Fatalf("unhandled DeliveryMode %d — every mode must name the obligations it runs", h.Delivery)
+	}
+}
+
+// assertDeliveryCarriesNoAddress is DeliveryAddressFree's obligation 1, and the
+// exact inverse of assertEndpointFollowsBindAddr: rather than checking that the
+// delivery TRACKS the bind address, it checks that it is independent of it and
+// carries no address at all. Both halves are needed. Equality alone would pass
+// for an installer that hardcoded "http://localhost:7837/..." — the original
+// #1178 defect, which is address-bearing and equally invariant — and the
+// no-address check alone would pass for a line that varied for some other
+// reason and so could still be written differently by two daemons.
+func assertDeliveryCarriesNoAddress(t *testing.T, h HookInstaller) {
+	t.Helper()
+	// Relocate the config home even though this sub-test writes nothing: an
+	// Entry() that reads anything home-relative must never be evaluated against
+	// the developer's real agent config.
+	h.SettingsPath(t)
+
+	onDefault := deliveryOn(t, h, "")
+	onAlt := deliveryOn(t, h, AltBindAddr)
+	if onDefault != onAlt {
+		t.Fatalf("delivery differs between the default and %s bind addresses (%q vs %q) — an address-free install must not vary with %s, or a daemon on another port writes a different line and the whole point of the mode is lost",
+			AltBindAddr, onDefault, onAlt, daemonaddr.EnvBindAddr)
+	}
+	assertNoAddress(t, "delivery on the default bind address", onDefault)
+	assertNoAddress(t, "delivery on "+AltBindAddr, onAlt)
 }
 
 // assertEndpointFollowsBindAddr is obligation 1 at the source: the endpoint the
@@ -107,9 +245,11 @@ func assertEndpointFollowsBindAddr(t *testing.T, h HookInstaller) {
 	assertResolvedPort(t, "delivery on "+AltBindAddr, onAlt)
 }
 
-// assertInstallWritesResolvedPort is obligation 1 end to end: what actually
-// lands in the settings file, plus idempotency on an unchanged bind address.
-func assertInstallWritesResolvedPort(t *testing.T, h HookInstaller) {
+// assertInstallWritesCanonicalDelivery is obligation 1 end to end: what
+// actually lands in the settings file, plus idempotency on an unchanged bind
+// address. Shared by both modes — only the per-delivery address check inside
+// assertEveryEventDelivers differs.
+func assertInstallWritesCanonicalDelivery(t *testing.T, h HookInstaller) {
 	t.Helper()
 	path := h.SettingsPath(t)
 	want := deliveryOn(t, h, AltBindAddr)
@@ -128,12 +268,14 @@ func assertInstallWritesResolvedPort(t *testing.T, h HookInstaller) {
 	}
 }
 
-// assertUpgradedInPlace is obligation 2: a default-port install is recognized
-// as ours and repointed, not orphaned beside a duplicate group.
+// assertUpgradedInPlace is obligation 2: an install left by a differently
+// situated daemon is recognized as ours and repointed, not orphaned beside a
+// duplicate group. What "differently situated" means is the mode's — another
+// port, or another irrlichd binary — and it is the whole of the difference.
 func assertUpgradedInPlace(t *testing.T, h HookInstaller) {
 	t.Helper()
 	path := h.SettingsPath(t)
-	seedDefaultPortInstall(t, h, path)
+	seedForeignInstall(t, h, path)
 	want := deliveryOn(t, h, AltBindAddr)
 
 	modified, err := h.EnsureInstalled()
@@ -141,19 +283,23 @@ func assertUpgradedInPlace(t *testing.T, h HookInstaller) {
 		t.Fatalf("EnsureInstalled: %v", err)
 	}
 	if !modified {
-		t.Fatal("expected modified=true when repointing a default-port install at the resolved port")
+		t.Fatalf("expected modified=true when repointing %s — an install left unrepaired here reports healthy while delivering nothing, and no later daemon start converges on it", h.foreignDescription())
 	}
 	// assertEveryEventDelivers fails on a second matcher group, which is the
 	// "upgraded in place, not duplicated" half of this obligation.
 	assertEveryEventDelivers(t, h, path, want)
 }
 
-// assertUninstallIsNotPortScoped is obligation 3: a daemon on one port cleans
-// up entries another port's daemon installed.
-func assertUninstallIsNotPortScoped(t *testing.T, h HookInstaller) {
+// assertUninstallIsNotForeignScoped is obligation 3: a daemon cleans up entries
+// a differently-situated daemon installed. In DeliveryURL mode that is another
+// port; in DeliveryAddressFree mode another binary path, where it additionally
+// means Uninstall must not depend on resolving a binary path at all —
+// `site/install.sh --uninstall` removes the binary without calling
+// --uninstall-hooks, so the entry commonly outlives the path it names.
+func assertUninstallIsNotForeignScoped(t *testing.T, h HookInstaller) {
 	t.Helper()
 	path := h.SettingsPath(t)
-	seedDefaultPortInstall(t, h, path)
+	seedForeignInstall(t, h, path)
 	t.Setenv(daemonaddr.EnvBindAddr, AltBindAddr)
 
 	modified, err := h.Uninstall()
@@ -161,7 +307,7 @@ func assertUninstallIsNotPortScoped(t *testing.T, h HookInstaller) {
 		t.Fatalf("Uninstall: %v", err)
 	}
 	if !modified {
-		t.Fatalf("expected modified=true removing a default-port install from a daemon on %s", AltBindAddr)
+		t.Fatalf("expected modified=true removing %s from a daemon on %s", h.foreignDescription(), AltBindAddr)
 	}
 	hooksMap := readHooksMap(t, path)
 	for _, event := range h.Events {
@@ -182,9 +328,10 @@ func deliveryOn(t *testing.T, h HookInstaller, bindAddr string) string {
 }
 
 // assertEveryEventDelivers checks each event's installed entry against want and
-// against the resolved port. Both matter: equality catches an installer writing
-// a stale shape, the port check catches the case want itself is wrong because
-// the endpoint stopped following the bind address.
+// against the mode's address obligation. Both matter: equality catches an
+// installer writing a stale shape, the address check catches the case want
+// itself is wrong — because the endpoint stopped following the bind address, or
+// because an "address-free" delivery grew an address.
 func assertEveryEventDelivers(t *testing.T, h HookInstaller, path, want string) {
 	t.Helper()
 	hooksMap := readHooksMap(t, path)
@@ -193,7 +340,37 @@ func assertEveryEventDelivers(t *testing.T, h HookInstaller, path, want string) 
 		if got != want {
 			t.Errorf("event %s: installed delivery = %q, want %q", event, got, want)
 		}
-		assertResolvedPort(t, "event "+event, got)
+		assertAddressShape(t, h, "event "+event, got)
+	}
+}
+
+// assertAddressShape applies whichever address obligation h's mode carries to
+// one delivery string. It is the single place the two modes diverge below
+// obligation 1, which is what keeps obligations 2-4 one implementation.
+func assertAddressShape(t *testing.T, h HookInstaller, what, delivery string) {
+	t.Helper()
+	if h.Delivery == DeliveryAddressFree {
+		assertNoAddress(t, what, delivery)
+		return
+	}
+	assertResolvedPort(t, what, delivery)
+}
+
+// addressShaped matches anything that could pin a delivery to one daemon: a
+// scheme, a loopback host, or a port-shaped `:<digits>`. It is deliberately
+// broader than the ":<port>/" fragment assertResolvedPort looks for, because
+// the failure it guards is an adapter reintroducing an address in SOME spelling
+// — including one no daemon of ours currently uses.
+var addressShaped = regexp.MustCompile(`(?i)https?://|\b(?:localhost|127\.0\.0\.1|0\.0\.0\.0)\b|\[::1\]|:\d{2,5}(?:\b|/)`)
+
+// assertNoAddress fails when delivery carries anything address-shaped. This is
+// the DeliveryAddressFree counterpart of assertResolvedPort, and it is what
+// turns "the beacon happens not to embed a port" into a property the next
+// beacon adapter cannot quietly lose.
+func assertNoAddress(t *testing.T, what, delivery string) {
+	t.Helper()
+	if m := addressShaped.FindString(delivery); m != "" {
+		t.Errorf("%s: %q carries the address-shaped fragment %q — an address-free delivery must resolve the daemon at fire time, or it is a stale-port install (#1178) wearing a command entry's clothes", what, delivery, m)
 	}
 }
 
@@ -215,16 +392,36 @@ func portMarker(bindAddr string) string {
 	return fmt.Sprintf(":%d/", daemonaddr.PortOf(bindAddr))
 }
 
-// seedDefaultPortInstall leaves behind exactly what a daemon on the DEFAULT
-// port would have: the adapter's own installer, run under a default-port
-// environment. Synthesizing the matcher groups by hand instead would be a
-// second implementation of what hookjson.EnsureInstalled already does, and one
-// that could drift from the shape the adapter actually writes.
-func seedDefaultPortInstall(t *testing.T, h HookInstaller, path string) {
+// foreignDescription names what seedForeignInstall arranged, for the failure
+// messages of the two obligations built on it.
+func (h HookInstaller) foreignDescription() string {
+	if h.Delivery == DeliveryAddressFree {
+		return "an install naming a different irrlichd binary"
+	}
+	return "a default-port install"
+}
+
+// seedForeignInstall leaves behind exactly what a differently-situated daemon
+// would have. In DeliveryURL mode that is the adapter's own installer run under
+// a default-port environment; in DeliveryAddressFree mode it is the adapter's
+// ForeignInstall, because no environment variable makes an installer name a
+// different binary.
+//
+// Both go through a real installer. Synthesizing the matcher groups by hand
+// instead would be a second implementation of what hookjson.EnsureInstalled
+// already does, and one that could drift from the shape the adapter actually
+// writes.
+func seedForeignInstall(t *testing.T, h HookInstaller, path string) {
 	t.Helper()
-	t.Setenv(daemonaddr.EnvBindAddr, "")
-	if _, err := h.EnsureInstalled(); err != nil {
-		t.Fatalf("seeding a default-port install: %v", err)
+	if h.Delivery == DeliveryAddressFree {
+		if _, err := h.ForeignInstall(); err != nil {
+			t.Fatalf("seeding %s: %v", h.foreignDescription(), err)
+		}
+	} else {
+		t.Setenv(daemonaddr.EnvBindAddr, "")
+		if _, err := h.EnsureInstalled(); err != nil {
+			t.Fatalf("seeding %s: %v", h.foreignDescription(), err)
+		}
 	}
 
 	// Sentinel is the one field nothing else cross-checks, and a wrong value
@@ -235,7 +432,7 @@ func seedDefaultPortInstall(t *testing.T, h HookInstaller, path string) {
 	seeded := readHooksMap(t, path)
 	for _, event := range h.Events {
 		if !hookjson.HasOurHook(seeded, event, h.Sentinel) {
-			t.Fatalf("event %s: the adapter's own default-port install is not matched by Sentinel %q — the contract is wired wrong", event, h.Sentinel)
+			t.Fatalf("event %s: %s is not matched by Sentinel %q — the contract is wired wrong", event, h.foreignDescription(), h.Sentinel)
 		}
 	}
 }

--- a/core/internal/contracttesting/hook_endpoint_addressfree_test.go
+++ b/core/internal/contracttesting/hook_endpoint_addressfree_test.go
@@ -1,0 +1,136 @@
+// hook_endpoint_addressfree_test.go exercises AssertHookEndpointFollowsBindAddr's
+// DeliveryAddressFree mode against a reference beacon installer, and is the
+// wiring the first beacon-delivered adapter copies (#1453).
+//
+// It lives here rather than in an adapter because no adapter installs the beacon
+// yet: #1373 built the mechanism and adoption is a separate change per adapter,
+// so a mode with no call site would be a branch nothing ever runs — which is
+// precisely the "exemption with no test behind it" the contract-family
+// convention exists to prevent. It is the same split tools/lib's linter suites
+// draw: assertions are pinned against a purpose-built fixture, so they do not
+// move when a real adapter is edited.
+//
+// The installer below is deliberately the SHAPE an adapter should have rather
+// than the smallest thing that passes. Note in particular that
+// referenceBeaconConfig returns a hookjson.Config and not a (Config, error):
+// the binary path is resolved ONCE, at install time, so the config builder and
+// its four callers stay infallible. Resolving it per-config instead is what
+// measured +12 lines of error branching when copilot evaluated beacon delivery.
+package contracttesting
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"irrlicht/core/adapters/inbound/agents/hookjson"
+	"irrlicht/core/pkg/hookbeacon"
+)
+
+// referenceBeaconAdapter is the route segment the beacon posts to. A real
+// adapter exports this as one constant shared with registerHookRoutes.
+const referenceBeaconAdapter = "reference-beacon"
+
+// referenceBeaconHomeEnv relocates the reference installer's config file, the
+// way CODEX_HOME and COPILOT_HOME relocate the real ones.
+const referenceBeaconHomeEnv = "IRRLICHT_TEST_REFERENCE_BEACON_HOME"
+
+// referenceForeignBinary is the irrlichd a differently-situated daemon would
+// have named. It is absolute (Command refuses a relative path) and does not
+// exist, which is the drift the beacon newly admits: an absolute path that has
+// stopped existing fails exactly as quietly as a curl that was never on PATH.
+const referenceForeignBinary = "/nonexistent-irrlicht-1453/bin/irrlichd"
+
+var referenceBeaconEvents = []string{"BeforeTool", "Stop"}
+
+// referenceBeaconCommand is resolved once, at package init, standing in for an
+// adapter resolving it once at install time. The error is kept beside it rather
+// than swallowed so the contract test can fail on it explicitly instead of
+// silently grading an empty command.
+var referenceBeaconCommand, referenceBeaconCommandErr = hookbeacon.InstalledCommand(referenceBeaconAdapter)
+
+func referenceBeaconSettingsPath() string {
+	return filepath.Join(os.Getenv(referenceBeaconHomeEnv), "hooks.json")
+}
+
+// referenceBeaconEntry is the inner hook object. The timeout is milliseconds,
+// which is gemini-cli's unit and the one upstream's own `hooks migrate` gets
+// wrong by 1000x.
+func referenceBeaconEntry(command string) map[string]interface{} {
+	return map[string]interface{}{
+		"type":    "command",
+		"command": command,
+		"timeout": 2000,
+	}
+}
+
+// referenceBeaconConfig returns a Config, not a (Config, error) — see the file
+// comment. command is empty only on the uninstall path, which never needs it.
+func referenceBeaconConfig(command string) hookjson.Config {
+	return hookjson.Config{
+		Path:       referenceBeaconSettingsPath(),
+		Sentinel:   hookbeacon.Sentinel(referenceBeaconAdapter),
+		Events:     referenceBeaconEvents,
+		MatcherFor: func(string) string { return "" },
+		Entry:      func() map[string]interface{} { return referenceBeaconEntry(command) },
+		IsCanonical: func(hook map[string]interface{}) bool {
+			c, _ := hook["command"].(string)
+			return hookbeacon.IsCanonical(c, referenceBeaconAdapter)
+		},
+		WriteFile: func(path string, data []byte) error {
+			if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+				return err
+			}
+			return os.WriteFile(path, data, 0o600)
+		},
+	}
+}
+
+func referenceBeaconEnsureInstalled() (bool, error) {
+	return hookjson.EnsureInstalled(referenceBeaconConfig(referenceBeaconCommand))
+}
+
+// referenceBeaconUninstall passes no command on purpose: our entries are
+// identified by Sentinel, which names neither the binary path nor an address,
+// so removal must not depend on resolving a binary that `site/install.sh
+// --uninstall` has already deleted.
+func referenceBeaconUninstall() (bool, error) {
+	return hookjson.Uninstall(referenceBeaconConfig(""))
+}
+
+// referenceBeaconForeignInstall is the address-free counterpart of seeding a
+// default-port install: the same installer, situated on a different irrlichd.
+func referenceBeaconForeignInstall() (bool, error) {
+	command, err := hookbeacon.Command(referenceForeignBinary, referenceBeaconAdapter)
+	if err != nil {
+		return false, err
+	}
+	return hookjson.EnsureInstalled(referenceBeaconConfig(command))
+}
+
+func TestAddressFreeDeliveryContract(t *testing.T) {
+	if referenceBeaconCommandErr != nil {
+		t.Fatalf("resolving the beacon command: %v", referenceBeaconCommandErr)
+	}
+	AssertHookEndpointFollowsBindAddr(t, HookInstaller{
+		Delivery: DeliveryAddressFree,
+		SettingsPath: func(t *testing.T) string {
+			home := t.TempDir()
+			t.Setenv(referenceBeaconHomeEnv, home)
+			return referenceBeaconSettingsPath()
+		},
+		Sentinel: hookbeacon.Sentinel(referenceBeaconAdapter),
+		Events:   referenceBeaconEvents,
+		Entry:    func() map[string]interface{} { return referenceBeaconEntry(referenceBeaconCommand) },
+		// Beacon delivery is a `type: command` entry, so the delivery string is
+		// the whole command — there is no url field and nothing address-shaped
+		// inside it.
+		EndpointOf: func(hook map[string]interface{}) string {
+			c, _ := hook["command"].(string)
+			return c
+		},
+		EnsureInstalled: referenceBeaconEnsureInstalled,
+		Uninstall:       referenceBeaconUninstall,
+		ForeignInstall:  referenceBeaconForeignInstall,
+	})
+}

--- a/core/internal/contracttesting/hook_endpoint_addressfree_test.go
+++ b/core/internal/contracttesting/hook_endpoint_addressfree_test.go
@@ -1,14 +1,18 @@
 // hook_endpoint_addressfree_test.go exercises AssertHookEndpointFollowsBindAddr's
-// DeliveryAddressFree mode against a reference beacon installer, and is the
+// DeliveryAddressFree route against a reference beacon installer, and is the
 // wiring the first beacon-delivered adapter copies (#1453).
 //
 // It lives here rather than in an adapter because no adapter installs the beacon
 // yet: #1373 built the mechanism and adoption is a separate change per adapter,
-// so a mode with no call site would be a branch nothing ever runs — which is
-// precisely the "exemption with no test behind it" the contract-family
-// convention exists to prevent. It is the same split tools/lib's linter suites
-// draw: assertions are pinned against a purpose-built fixture, so they do not
-// move when a real adapter is edited.
+// so a route with no call site would be a branch nothing ever runs — precisely
+// the "exemption with no test behind it" the contract-family convention exists
+// to prevent. It is the same split tools/lib's linter suites draw: assertions
+// are pinned against a purpose-built fixture, so they do not move when a real
+// adapter is edited.
+//
+// It is scaffolding, and it says so: once an adapter declares this route, that
+// adapter's wiring becomes the honest coverage and this file should be reduced
+// to whatever it still uniquely proves, or deleted.
 //
 // The installer below is deliberately the SHAPE an adapter should have rather
 // than the smallest thing that passes, and that shape is copilot's: hookConfig
@@ -16,17 +20,22 @@
 // hookjson.Config, NOT a (Config, error), so each exported entry point owns its
 // own resolution. copilot parameterises on the settings path; a beacon adapter
 // parameterises on the path AND the rendered command, which is why
-// hookbeacon.InstalledCommand exists and is called once. Resolving the binary
-// per-config instead is what measured +12 lines of error branching when copilot
-// evaluated beacon delivery.
+// hookbeacon.InstalledCommand exists and is called once per entry point.
+// Resolving the binary per-config instead is what measured +12 lines of error
+// branching when copilot evaluated beacon delivery.
+//
+// One field is NOT the shape to copy: WriteFile. Every real installer passes an
+// atomic temp-file+rename writer (claudecode, codex, copilot each have one);
+// this one is a plain write, because hookjson deliberately leaves WriteFile
+// adapter-supplied and there is no shared writer to call.
 package contracttesting
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
 
+	"irrlicht/core/adapters/inbound/agents/agentpaths"
 	"irrlicht/core/adapters/inbound/agents/hookjson"
 	"irrlicht/core/pkg/hookbeacon"
 )
@@ -35,8 +44,8 @@ import (
 // adapter exports this as one constant shared with registerHookRoutes.
 const referenceBeaconAdapter = "reference-beacon"
 
-// referenceBeaconHomeEnv relocates the reference installer's config file, the
-// way CODEX_HOME and COPILOT_HOME relocate the real ones.
+// referenceBeaconHomeEnv relocates the fixture's config home, the way
+// CODEX_HOME and COPILOT_HOME relocate the real ones.
 const referenceBeaconHomeEnv = "IRRLICHT_TEST_REFERENCE_BEACON_HOME"
 
 // referenceForeignBinary is the irrlichd a differently-situated daemon would
@@ -47,33 +56,41 @@ const referenceForeignBinary = "/nonexistent-irrlicht-1453/bin/irrlichd"
 
 var referenceBeaconEvents = []string{"BeforeTool", "Stop"}
 
-// referenceBeaconCommand is resolved once, at package init, standing in for an
-// adapter resolving it once at install time. The error is kept beside it rather
-// than swallowed so the contract test can fail on it explicitly instead of
-// silently grading an empty command.
-var referenceBeaconCommand, referenceBeaconCommandErr = hookbeacon.InstalledCommand(referenceBeaconAdapter)
+// referenceBeaconHome composes agentpaths rather than re-deciding how an agent
+// home override is read — the same composition copilotHome uses, and for the
+// reason its doc records: the hand-rolled version silently dropped a RELATIVE
+// override, so the watcher warned while the installer wrote somewhere else.
+//
+// The default dir is deliberately EMPTY, which is the one place this fixture
+// must NOT copy a real adapter. A real adapter passes a $HOME-relative default;
+// AbsRoot refuses an empty root, so here an unset override fails loudly instead
+// of resolving into the developer's own agent config. A fixture must never be
+// one missing env var away from writing to a real $HOME.
+func referenceBeaconHome() (string, error) {
+	return agentpaths.AbsRoot(agentpaths.FromEnv(referenceBeaconAdapter, referenceBeaconHomeEnv, ""))
+}
 
-// referenceBeaconHooksPath resolves the settings file, and reports an error
-// rather than a relative path when the home is unset — the shape every real
-// adapter's resolver has (copilotHooksPath, codexHooksPath). filepath.Join on
-// an empty home would yield a bare "hooks.json", i.e. the process CWD.
 func referenceBeaconHooksPath() (string, error) {
-	home := os.Getenv(referenceBeaconHomeEnv)
-	if home == "" {
-		return "", fmt.Errorf("contracttesting: %s is not set", referenceBeaconHomeEnv)
+	home, err := referenceBeaconHome()
+	if err != nil {
+		return "", err
 	}
 	return filepath.Join(home, "hooks.json"), nil
 }
 
-// referenceBeaconEntry is the inner hook object. The timeout is milliseconds,
-// which is gemini-cli's unit and the one upstream's own `hooks migrate` gets
-// wrong by 1000x.
 func referenceBeaconEntry(command string) map[string]interface{} {
 	return map[string]interface{}{
 		"type":    "command",
 		"command": command,
-		"timeout": 2000,
 	}
+}
+
+// referenceBeaconEntryNow is the contract's Entry: the inner hook object the
+// adapter would install right now. A resolution failure yields an empty
+// command, which assertDeliveryIsOurs reports rather than grading silently.
+func referenceBeaconEntryNow() map[string]interface{} {
+	command, _ := hookbeacon.InstalledCommand(referenceBeaconAdapter)
+	return referenceBeaconEntry(command)
 }
 
 // referenceBeaconConfig returns a Config, not a (Config, error) — see the file
@@ -98,12 +115,22 @@ func referenceBeaconConfig(path, command string) hookjson.Config {
 	}
 }
 
-func referenceBeaconEnsureInstalled() (bool, error) {
+// referenceBeaconRun resolves the settings path and hands the built config to
+// op, so the three entry points below state that branch once between them.
+func referenceBeaconRun(command string, op func(hookjson.Config) (bool, error)) (bool, error) {
 	path, err := referenceBeaconHooksPath()
 	if err != nil {
 		return false, err
 	}
-	return hookjson.EnsureInstalled(referenceBeaconConfig(path, referenceBeaconCommand))
+	return op(referenceBeaconConfig(path, command))
+}
+
+func referenceBeaconEnsureInstalled() (bool, error) {
+	command, err := hookbeacon.InstalledCommand(referenceBeaconAdapter)
+	if err != nil {
+		return false, err
+	}
+	return referenceBeaconRun(command, hookjson.EnsureInstalled)
 }
 
 // referenceBeaconUninstall removes our entries whatever binary they name. It
@@ -113,30 +140,28 @@ func referenceBeaconEnsureInstalled() (bool, error) {
 // binary without calling --uninstall-hooks. uninstall_is_not_binary_scoped is
 // what holds that property, rather than this comment.
 func referenceBeaconUninstall() (bool, error) {
-	path, err := referenceBeaconHooksPath()
+	command, err := hookbeacon.InstalledCommand(referenceBeaconAdapter)
 	if err != nil {
 		return false, err
 	}
-	return hookjson.Uninstall(referenceBeaconConfig(path, referenceBeaconCommand))
+	return referenceBeaconRun(command, hookjson.Uninstall)
 }
 
 // referenceBeaconForeignInstall is the address-free counterpart of seeding a
 // default-port install: the same installer, situated on a different irrlichd.
 func referenceBeaconForeignInstall() (bool, error) {
-	path, err := referenceBeaconHooksPath()
-	if err != nil {
-		return false, err
-	}
 	command, err := hookbeacon.Command(referenceForeignBinary, referenceBeaconAdapter)
 	if err != nil {
 		return false, err
 	}
-	return hookjson.EnsureInstalled(referenceBeaconConfig(path, command))
+	return referenceBeaconRun(command, hookjson.EnsureInstalled)
 }
 
 func TestAddressFreeDeliveryContract(t *testing.T) {
-	if referenceBeaconCommandErr != nil {
-		t.Fatalf("resolving the beacon command: %v", referenceBeaconCommandErr)
+	// Checked up front so a resolution failure reads as itself rather than as
+	// the empty-delivery wiring error assertDeliveryIsOurs would report.
+	if _, err := hookbeacon.InstalledCommand(referenceBeaconAdapter); err != nil {
+		t.Fatalf("resolving the beacon command: %v", err)
 	}
 	AssertHookEndpointFollowsBindAddr(t, HookInstaller{
 		Delivery: DeliveryAddressFree,
@@ -150,7 +175,7 @@ func TestAddressFreeDeliveryContract(t *testing.T) {
 		},
 		Sentinel: hookbeacon.Sentinel(referenceBeaconAdapter),
 		Events:   referenceBeaconEvents,
-		Entry:    func() map[string]interface{} { return referenceBeaconEntry(referenceBeaconCommand) },
+		Entry:    referenceBeaconEntryNow,
 		// Beacon delivery is a `type: command` entry, so the delivery string is
 		// the whole command — there is no url field and nothing address-shaped
 		// inside it.

--- a/core/internal/contracttesting/hook_endpoint_addressfree_test.go
+++ b/core/internal/contracttesting/hook_endpoint_addressfree_test.go
@@ -11,14 +11,18 @@
 // move when a real adapter is edited.
 //
 // The installer below is deliberately the SHAPE an adapter should have rather
-// than the smallest thing that passes. Note in particular that
-// referenceBeaconConfig returns a hookjson.Config and not a (Config, error):
-// the binary path is resolved ONCE, at install time, so the config builder and
-// its four callers stay infallible. Resolving it per-config instead is what
-// measured +12 lines of error branching when copilot evaluated beacon delivery.
+// than the smallest thing that passes, and that shape is copilot's: hookConfig
+// takes the already-resolved fallible inputs as parameters and returns a
+// hookjson.Config, NOT a (Config, error), so each exported entry point owns its
+// own resolution. copilot parameterises on the settings path; a beacon adapter
+// parameterises on the path AND the rendered command, which is why
+// hookbeacon.InstalledCommand exists and is called once. Resolving the binary
+// per-config instead is what measured +12 lines of error branching when copilot
+// evaluated beacon delivery.
 package contracttesting
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -49,8 +53,16 @@ var referenceBeaconEvents = []string{"BeforeTool", "Stop"}
 // silently grading an empty command.
 var referenceBeaconCommand, referenceBeaconCommandErr = hookbeacon.InstalledCommand(referenceBeaconAdapter)
 
-func referenceBeaconSettingsPath() string {
-	return filepath.Join(os.Getenv(referenceBeaconHomeEnv), "hooks.json")
+// referenceBeaconHooksPath resolves the settings file, and reports an error
+// rather than a relative path when the home is unset — the shape every real
+// adapter's resolver has (copilotHooksPath, codexHooksPath). filepath.Join on
+// an empty home would yield a bare "hooks.json", i.e. the process CWD.
+func referenceBeaconHooksPath() (string, error) {
+	home := os.Getenv(referenceBeaconHomeEnv)
+	if home == "" {
+		return "", fmt.Errorf("contracttesting: %s is not set", referenceBeaconHomeEnv)
+	}
+	return filepath.Join(home, "hooks.json"), nil
 }
 
 // referenceBeaconEntry is the inner hook object. The timeout is milliseconds,
@@ -65,10 +77,10 @@ func referenceBeaconEntry(command string) map[string]interface{} {
 }
 
 // referenceBeaconConfig returns a Config, not a (Config, error) — see the file
-// comment. command is empty only on the uninstall path, which never needs it.
-func referenceBeaconConfig(command string) hookjson.Config {
+// comment.
+func referenceBeaconConfig(path, command string) hookjson.Config {
 	return hookjson.Config{
-		Path:       referenceBeaconSettingsPath(),
+		Path:       path,
 		Sentinel:   hookbeacon.Sentinel(referenceBeaconAdapter),
 		Events:     referenceBeaconEvents,
 		MatcherFor: func(string) string { return "" },
@@ -87,25 +99,39 @@ func referenceBeaconConfig(command string) hookjson.Config {
 }
 
 func referenceBeaconEnsureInstalled() (bool, error) {
-	return hookjson.EnsureInstalled(referenceBeaconConfig(referenceBeaconCommand))
+	path, err := referenceBeaconHooksPath()
+	if err != nil {
+		return false, err
+	}
+	return hookjson.EnsureInstalled(referenceBeaconConfig(path, referenceBeaconCommand))
 }
 
-// referenceBeaconUninstall passes no command on purpose: our entries are
-// identified by Sentinel, which names neither the binary path nor an address,
-// so removal must not depend on resolving a binary that `site/install.sh
-// --uninstall` has already deleted.
+// referenceBeaconUninstall removes our entries whatever binary they name. It
+// needs no special casing to do that: Sentinel names neither the binary path
+// nor an address, so an entry installed by a since-deleted irrlichd is still
+// matched — which matters because `site/install.sh --uninstall` removes the
+// binary without calling --uninstall-hooks. uninstall_is_not_binary_scoped is
+// what holds that property, rather than this comment.
 func referenceBeaconUninstall() (bool, error) {
-	return hookjson.Uninstall(referenceBeaconConfig(""))
+	path, err := referenceBeaconHooksPath()
+	if err != nil {
+		return false, err
+	}
+	return hookjson.Uninstall(referenceBeaconConfig(path, referenceBeaconCommand))
 }
 
 // referenceBeaconForeignInstall is the address-free counterpart of seeding a
 // default-port install: the same installer, situated on a different irrlichd.
 func referenceBeaconForeignInstall() (bool, error) {
+	path, err := referenceBeaconHooksPath()
+	if err != nil {
+		return false, err
+	}
 	command, err := hookbeacon.Command(referenceForeignBinary, referenceBeaconAdapter)
 	if err != nil {
 		return false, err
 	}
-	return hookjson.EnsureInstalled(referenceBeaconConfig(command))
+	return hookjson.EnsureInstalled(referenceBeaconConfig(path, command))
 }
 
 func TestAddressFreeDeliveryContract(t *testing.T) {
@@ -115,9 +141,12 @@ func TestAddressFreeDeliveryContract(t *testing.T) {
 	AssertHookEndpointFollowsBindAddr(t, HookInstaller{
 		Delivery: DeliveryAddressFree,
 		SettingsPath: func(t *testing.T) string {
-			home := t.TempDir()
-			t.Setenv(referenceBeaconHomeEnv, home)
-			return referenceBeaconSettingsPath()
+			t.Setenv(referenceBeaconHomeEnv, t.TempDir())
+			path, err := referenceBeaconHooksPath()
+			if err != nil {
+				t.Fatalf("resolving the reference hooks path: %v", err)
+			}
+			return path
 		},
 		Sentinel: hookbeacon.Sentinel(referenceBeaconAdapter),
 		Events:   referenceBeaconEvents,

--- a/core/pkg/hookbeacon/install.go
+++ b/core/pkg/hookbeacon/install.go
@@ -172,6 +172,36 @@ func BinaryPath() (string, error) {
 	return filepath.Abs(exe)
 }
 
+// InstalledCommand renders the line to install for adapter against the irrlichd
+// that is running now, resolving the binary path itself.
+//
+// It exists so an adopting adapter has ONE fallible step rather than two.
+// Command and BinaryPath are only ever called together in production, and
+// splitting them pushes two error branches into whatever builds the
+// hookjson.Config — which turns hookConfig into a (Config, error) and adds a
+// branch to each of Ensure/Verify/Uninstall/IsCanonical that calls it, measured
+// at +12 lines when copilot evaluated beacon delivery (#1453).
+//
+// The intended shape is to call this ONCE, at install time, and keep the
+// resolved string: the config builder then stays infallible, and Uninstall —
+// which identifies our entries by Sentinel and never needs the binary path —
+// keeps working when the binary it names has been removed. That case is not
+// hypothetical: `site/install.sh --uninstall` deletes the binary without
+// calling --uninstall-hooks, so the entry outlives every daemon that could
+// reconcile it. core/internal/contracttesting's address-free reference wiring
+// is written that way and is the shape to copy.
+//
+// Command stays exported and keeps taking an explicit path: that is what
+// renders the line a DIFFERENTLY-situated daemon would have installed, which is
+// how the contract seeds binary-path drift.
+func InstalledCommand(adapter string) (string, error) {
+	binaryPath, err := BinaryPath()
+	if err != nil {
+		return "", fmt.Errorf("hookbeacon: resolving the running binary: %w", err)
+	}
+	return Command(binaryPath, adapter)
+}
+
 // Drift names why an installed entry is not the one we would write now. It is
 // the beacon's equivalent of the port comparison inside claudecode's
 // hookEntryIsCanonical, generalized to the failure this mechanism newly admits:

--- a/core/pkg/hookbeacon/install_test.go
+++ b/core/pkg/hookbeacon/install_test.go
@@ -298,3 +298,38 @@ func TestSentinelIsNotAPrefixOfAnother(t *testing.T) {
 		t.Error("the sentinel no longer matches its own rendered command")
 	}
 }
+
+// TestInstalledCommandMatchesTheRunningBinary pins InstalledCommand as exactly
+// Command(BinaryPath(), adapter) — the composition an adapter would otherwise
+// write itself, with the two error branches it would otherwise carry (#1453).
+// The equality is the assertion: a helper that resolved a DIFFERENT path than
+// Inspect and IsCanonical judge against would report drift against itself and
+// rewrite the user's config on every daemon start without converging.
+func TestInstalledCommandMatchesTheRunningBinary(t *testing.T) {
+	got, err := InstalledCommand("gemini-cli")
+	if err != nil {
+		t.Fatalf("InstalledCommand: %v", err)
+	}
+
+	live, err := BinaryPath()
+	if err != nil {
+		t.Fatalf("BinaryPath: %v", err)
+	}
+	if want := mustCommand(t, live, "gemini-cli"); got != want {
+		t.Errorf("InstalledCommand = %q, want %q", got, want)
+	}
+	if !IsCanonical(got, "gemini-cli") {
+		t.Error("the line InstalledCommand renders is not the line IsCanonical accepts — an install would be rewritten on every daemon start")
+	}
+}
+
+// TestInstalledCommandRejectsAnUnsafeAdapter confirms the validation Command
+// does is not lost by the convenience wrapper: the rendered text is written
+// into a user's config and executed by a shell.
+func TestInstalledCommandRejectsAnUnsafeAdapter(t *testing.T) {
+	for _, adapter := range []string{"", "../../etc/passwd", "gemini cli", "Gemini-CLI"} {
+		if _, err := InstalledCommand(adapter); err == nil {
+			t.Errorf("InstalledCommand(%q) returned no error", adapter)
+		}
+	}
+}

--- a/core/pkg/hookbeacon/install_test.go
+++ b/core/pkg/hookbeacon/install_test.go
@@ -302,34 +302,33 @@ func TestSentinelIsNotAPrefixOfAnother(t *testing.T) {
 // TestInstalledCommandMatchesTheRunningBinary pins InstalledCommand as exactly
 // Command(BinaryPath(), adapter) — the composition an adapter would otherwise
 // write itself, with the two error branches it would otherwise carry (#1453).
-// The equality is the assertion: a helper that resolved a DIFFERENT path than
-// Inspect and IsCanonical judge against would report drift against itself and
-// rewrite the user's config on every daemon start without converging.
+//
+// The equality is the whole assertion, and it is the one that matters: a helper
+// resolving a DIFFERENT path than Inspect and IsCanonical judge against would
+// report drift against itself and rewrite the user's config on every daemon
+// start without ever converging. Deliberately NOT re-asserted here via
+// IsCanonical(got) — canonicalAgainst recomputes want from the same
+// deterministic BinaryPath and returns early on command == want, so that arm
+// cannot fail once this equality holds. TestIsCanonicalAcceptsTheLiveCommand is
+// where that property is actually locked.
 func TestInstalledCommandMatchesTheRunningBinary(t *testing.T) {
 	got, err := InstalledCommand("gemini-cli")
 	if err != nil {
 		t.Fatalf("InstalledCommand: %v", err)
 	}
-
-	live, err := BinaryPath()
-	if err != nil {
-		t.Fatalf("BinaryPath: %v", err)
-	}
-	if want := mustCommand(t, live, "gemini-cli"); got != want {
+	if want := mustCommand(t, liveBinary(t), "gemini-cli"); got != want {
 		t.Errorf("InstalledCommand = %q, want %q", got, want)
-	}
-	if !IsCanonical(got, "gemini-cli") {
-		t.Error("the line InstalledCommand renders is not the line IsCanonical accepts — an install would be rewritten on every daemon start")
 	}
 }
 
-// TestInstalledCommandRejectsAnUnsafeAdapter confirms the validation Command
-// does is not lost by the convenience wrapper: the rendered text is written
-// into a user's config and executed by a shell.
-func TestInstalledCommandRejectsAnUnsafeAdapter(t *testing.T) {
-	for _, adapter := range []string{"", "../../etc/passwd", "gemini cli", "Gemini-CLI"} {
-		if _, err := InstalledCommand(adapter); err == nil {
-			t.Errorf("InstalledCommand(%q) returned no error", adapter)
-		}
+// TestInstalledCommandForwardsAdapterValidation confirms the wrapper does not
+// lose the refusal Command performs — the rendered text is written into a
+// user's config and executed by a shell. One case is enough: InstalledCommand
+// only forwards, and the segment grammar itself is pinned by
+// TestAdapterSegmentRejectsUnsafeValues (beacon_test.go) and its wrapper-level
+// cases by TestCommandRejectsUnsafeArguments above.
+func TestInstalledCommandForwardsAdapterValidation(t *testing.T) {
+	if got, err := InstalledCommand("../../etc/passwd"); err == nil {
+		t.Errorf("InstalledCommand = %q with no error, want a refusal for a path traversal in the adapter", got)
 	}
 }


### PR DESCRIPTION
Closes #1453.

## The decision

`AssertHookEndpointFollowsBindAddr` assumed the installed entry **carries a resolved address**. A beacon-delivered adapter (`irrlichd hook-post`, #1373 / PR #1412) carries none — it reads the addr file at fire time — so three of its four obligations fail by construction, as the issue measured against a working prototype.

That is the property the contract was invented to police, *obtained* rather than lost: with no port in the config there is nothing to go stale, and the state #1449 hit — a dev daemon leaving the user's real `~/.claude/settings.json` and `~/.codex/hooks.json` pointing at three dead ports — becomes unwritable. But "unsatisfiable because the defect is gone" and "silently dropped because it did not fit" look identical in a diff, which is why the issue asked for a decision.

**Option 1, as recommended.** The contract grades against the delivery route the adapter declares:

| | `DeliveryURL` (zero value) | `DeliveryAddressFree` |
|---|---|---|
| 1 | `endpoint_follows_bind_addr` — delivery **differs** across bind addresses, carries the resolved port | `delivery_carries_no_address` — delivery is **identical** across bind addresses **and** carries nothing address-shaped |
| 2 | `install_writes_resolved_port` | `install_writes_address_free_delivery` |
| 3 | `default_port_install_upgraded_in_place` | `foreign_binary_install_upgraded_in_place` |
| 4 | `uninstall_is_not_port_scoped` | `uninstall_is_not_binary_scoped` |

Only sub-test 1 genuinely differs. 2–4 are **one implementation**, parameterised by which seed stands in for "what a differently-situated daemon left behind" (another port / another irrlichd binary) and which address assertion applies. That is the concrete argument for one family over option 2's second family: splitting duplicates that machinery and still leaves an author picking the right family, which is option 3's untested-exemption risk relocated rather than removed.

After the simplify round that parameterisation is literal: a single `deliveryRules` value is selected once by `rulesFor`, and nothing below it asks which route is in play.

**All three existing call sites are untouched** — `DeliveryURL` is the zero value, and claudecode/codex/copilot still run the same four sub-test names.

### Why declaring a route is safe, when `hook_receipt.go` rejects flag-shaped options

`hook_receipt.go` avoids a flag because *"a wiring that silently ignored a flag would pass it by accident."* That does not apply here, and the reason is checkable rather than asserted: the two routes' first obligations are **contradictory assertions about the same two strings** — URL requires them to DIFFER, address-free requires them IDENTICAL. There is no value of `Delivery` under which an adapter is graded vacuously, and mutations M5a/M5b/M5c prove all three mis-wirings go red.

### What the address-free route deliberately does *not* assert

That the beacon resolves a live daemon at fire time. That is the beacon's own obligation, covered by `hookbeacon.TestPostResolvesTheDaemonAddressAtFireTime`; this family grades the **adapter**, which cannot get that right or wrong.

## Red-first evidence — 14 deliberate mutations, each seen red

No adapter delivers by beacon yet, so the route's call site is a reference wiring in `core/internal/contracttesting/hook_endpoint_addressfree_test.go` — a branch with no call site is exactly the untested exemption this contract family exists to prevent. Each mutation was applied, run, recorded and reverted; the tree is clean.

| # | Mutation | Caught by |
|---|---|---|
| M1a | address-bearing but **invariant** delivery (a hardcoded `http://localhost:7837/...` line — the #1178 defect wearing a command entry's clothes) | `delivery_carries_no_address` |
| M1b | delivery **varies** with the bind address | `delivery_carries_no_address` |
| M2 | installer writes a line other than the canonical one | `install_writes_address_free_delivery` |
| **M3a** | **`IsCanonical` never checks the binary path** — an adapter that recognises its entry by sentinel and forgets to wire `hookbeacon.IsCanonical` | `foreign_binary_install_upgraded_in_place` |
| M3b | sentinel includes the binary path, so a foreign entry is **duplicated** rather than rewritten | `… expected exactly 1 matcher group …, got 2` |
| M4 | `Uninstall` scoped to the running binary | `uninstall_is_not_binary_scoped` |
| M5a | a beacon adapter that **forgets** `Delivery` (zero value ⇒ URL route) | `endpoint_follows_bind_addr` |
| M5b | a URL adapter (copilot) that **wrongly declares** `DeliveryAddressFree` | `delivery_carries_no_address` |
| M5c | address-free declared with **no `ForeignInstall`** seed | `DeliveryAddressFree requires ForeignInstall` |
| **M6a** | **`EndpointOf` reads a key the entry does not carry** — address-free route | `"" does not carry Sentinel "hook-post reference-beacon "` |
| M6b | the same, URL route (copilot) | `"" does not carry Sentinel "/api/v1/hooks/copilot"` |
| M7 | colon-less hardcoded port `--port 7837` | `carries the address-shaped fragment "port 7837"` |
| M8 | the daemon port as a **bare word**, no colon and no flag | `delivery_carries_no_address` |
| M9 | the daemon's **hook route** (`/api/v1/…`) embedded in the line | `delivery_carries_no_address` |

**M3a is the load-bearing one**: it is the exact difference between a beacon-correct and a beacon-incorrect install. The defect it catches — an entry naming a binary that has moved or been deleted, left unrepaired — reports `granted` and healthy while delivering nothing, and no later daemon start converges on it. It is #1373's scope point 5 ("path drift is the trap"), now policed by the contract rather than by whoever remembers.

**M6a and M7 came from the review round and were verified green before the fix**, which is the evidence they add distinguishing power rather than restating a check that already existed:

- **M6a was a clean 4/4 pass.** Inverting obligation 1 from "the two deliveries must DIFFER" to "must be IDENTICAL" removed the only assertion that proved `EndpointOf` observed anything: an `EndpointOf` reading the wrong key returns `""` for both, and `""` is invariant, carries no address, and equals the `""` the next sub-test compares against — so the entire route passed while asserting nothing. Not hypothetical: the key is the one field that genuinely differs between the wirings already in the tree (claudecode and copilot read `url`, codex reads `command`), and this file is advertised as the one to copy. Fixed by `assertDeliveryIsOurs`, run in **both** routes — M6b shows it sharpens the URL diagnosis too.
- **M7's responsible obligation passed it.** With `--port 7837` present, `delivery_carries_no_address` was **green** pre-fix (the matcher only recognised a *colon*-prefixed port). The run failed incidentally elsewhere, and only because `hookbeacon.IsCanonical` happens to reject the mutated line — an adapter rendering `--port` as part of its *canonical* form would have had no such incidental catch.

M8 and M9 came from the simplify round (see below).

## Second finding folded in: `hookbeacon.InstalledCommand`

`Command` and `BinaryPath` are only ever called together in production, and splitting them pushes two error branches into whatever builds the `hookjson.Config` — turning `hookConfig` into a `(Config, error)` and adding a branch to each of Ensure/Verify/Uninstall/IsCanonical, measured at **+12 lines** when copilot evaluated the beacon.

`InstalledCommand(adapter)` is that composition in one fallible step. The intended shape is copilot's, which the reference wiring now matches exactly: `hookConfig` takes the already-resolved fallible inputs as parameters and returns a `hookjson.Config`, **not** a `(Config, error)`, so each exported entry point owns its own resolution. `Command` stays exported taking an explicit path, because that is what renders the line a differently-situated daemon would have installed — which is how the contract seeds binary-path drift.

## Third finding: confirmed, no change needed

The issue's claim that the beacon's `IsCanonical` reconciliation already works against a per-file hook config is **confirmed by execution, not inspection**: `foreign_binary_install_upgraded_in_place` drives `hookbeacon.IsCanonical` through a real `hookjson.EnsureInstalled` against a real per-adapter settings file and proves the in-place rewrite, and M3a proves that assertion is not vacuous. No change to `hookbeacon`'s reconciliation.

## Review round

A `high`-effort review subagent returned 8 findings. Two were real holes in the new obligations, fixed with the mutation evidence above (M6a, M7). Four more fixed: the uninstall-survival message still said "a default-port entry" in a route that has no ports; three helpers fell back to URL behaviour on an unrecognised route; and the header said "obligations 2-4" while the file numbers 1..3 over four sub-tests.

Two were fixed differently from the suggestion, after checking what the adapters actually do:

- The reference `Uninstall` passed an empty command, relying on `hookjson.Uninstall` never calling `Entry` — true today, but `hookjson.Config` documents "every field is required". Rather than amend that doc, the reference now passes the resolved command, and the property the empty string gestured at (removal works whatever binary the entry names, because `Sentinel` names neither path nor address) is held by `uninstall_is_not_binary_scoped` instead of by a comment.
- The reviewer flagged the reference's path resolver returning a CWD-relative `hooks.json` when its home env var was unset, and proposed making it fallible — which would undo the infallible config builder the change exists to demonstrate. `copilot.hookConfig` already resolves this: `hookConfig(path string) Config` is infallible, parameterised on the fallible input. The reference now matches that exactly.

## Simplify round

Four cleanup agents (reuse / simplification / efficiency / altitude). Efficiency came back clean. The other three **independently converged on the same finding** — and so did CodeScene, which flagged `seedForeignInstall` for "Bumpy Road Ahead":

- **One selection point instead of four.** The route was re-consulted in four functions, three of which carried a defensive `default:` arm that **could never run** — `t.Fatalf` is `runtime.Goexit`, so an unrecognised route terminates the parent before any sub-test is created. Those guards read as safety while being dead. Replaced by a `deliveryRules` value selected once by `rulesFor`; "only the first sub-test differs" is now a fact about the code rather than a promise four switches keep, and a third route has exactly one place to be taught.
- **A real coverage gap in the address matcher** (reuse). `hookbeacon.TestCommandCarriesNoAddress` states the same "carries no address" rule as a substring list, and **neither spelling subsumed the other** — measured: a bare `7837` and a `/api/v1/hooks/…` route both passed my matcher. The matcher is now built to contain that list, with the ports taken from `daemonaddr` rather than retyped so they cannot drift. M8 and M9 are those two spellings, seen red.
- **Deduplication**: a verbatim 3-line comment and a 4-line preamble shared by the two obligation-1 bodies (now `deliveriesOnBothAddrs`); a second `assertNoAddress` call on a string already proven identical; an inlined `BinaryPath` + `t.Fatalf` where `liveBinary(t)` exists and is strictly stronger; a `IsCanonical` assertion that cannot fail once the equality above it passes; and adapter-validation cases already pinned by `TestAdapterSegmentRejectsUnsafeValues`.
- **Reference wiring**: resolution moved off package init into the entry points (so it models the error handling an adapter actually owes), the gemini-cli-specific `timeout` dropped (this fixture is not gemini-cli), three identical error branches collapsed to one, and the file now states its own retirement condition.
- `referenceBeaconHome` now composes `agentpaths` — the repo-owned rule copilot's doc says the hand-rolled version got wrong — but with a deliberately **empty** default dir, because `AbsRoot` refuses an empty root. A real adapter passes a `$HOME`-relative default; a fixture must never be one missing env var away from writing into the developer's real agent config. That deviation is stated in the file.

### Not taken — flagged for your call

The **altitude** agent argued for an "option 1.5" the issue didn't offer: keep one private implementation but export **two** entry points (`AssertHookEndpointFollowsBindAddr` + `AssertHookDeliveryIsAddressFree`) instead of one with a route field. Its strongest points are real — the exported name currently reads "assert the endpoint follows the bind address" while being configured to assert that it doesn't, and a required-only-in-one-route `ForeignInstall` would become a compile-time parameter instead of a runtime nil check.

I did not take it, because you asked for option 1 unless it *doesn't work*, and it does — the mis-wiring mutations show the declaration cannot be ignored silently. It also changes the exported surface and would make `grep -c "^func Assert"` report **8**, so AGENTS.md's count sentence and its per-family bullet list would disagree unless the family list is restructured too. That is a call worth making deliberately rather than as a side effect of a simplify pass. Happy to do it as a follow-up if you prefer it.

Two smaller follow-ups I'd also leave for a separate change: `hookbeacon` could hold the resolved binary in a value type (`Resolve(adapter) (Install, error)`) so the once-ness is structural rather than advised — worth doing while the package has zero adopters; and no contract family currently has a **negative** test proving its own assertions can fail, which is why all this mutation evidence lives in PR descriptions rather than in the tree.

## AGENTS.md

The count sentence stays **seven** — option 1 adds no `Assert*` function. Verified before writing the number, as #1453 asked:

```
$ grep -h "^func Assert" core/internal/contracttesting/*.go | wc -l
7
```

Edits: the hook-endpoints bullet now describes both delivery routes and why the second is coverage rather than an exemption (and names `copilot`, which wires the family but was missing); and "against a correct adapter" gains "— or, for a delivery route no adapter has adopted yet, against its reference wiring". Per the simplify round the bullet points at `deliveryRules` for the details rather than restating them, and carries no "no adapter yet" claim that would silently rot.

## Verification

`tools/preflight.sh` run chunked in the foreground, re-run after the review and simplify rounds:

| Gate | Result |
|---|---|
| `--only go` (gofmt, core tests, onboarding-factory, replaydata validate, recording-rig smoke, replay fixtures, starhistory) | **PASS** |
| `--only arch` | **PASS** — ARS composite 7.94416 → 7.94430, no category regression |
| `--only tools` | **PASS** |
| `--only skills` | **PASS** (23 files, 0 errors, 0 warnings) |
| `--only posix` | **PASS** |

Not run, with reasons: `--only web` (no `web/` tree touched), `--only security` (no dependency or lockfile change; the pre-push hook ran it anyway and it passed), `--only linux` (needs Docker; nothing Linux-specific here).

Rebased onto current `main` after #1474 landed; the overlap probe and the deletion tripwire were both empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
