### PR TITLE
fix(claudecode): gate hook dispatch behind the transcripts consent

### DIFF
--- a/core/adapters/inbound/agents/claudecode/hooks.go
+++ b/core/adapters/inbound/agents/claudecode/hooks.go
@@ -254,6 +254,49 @@ func transcriptConfiner() *hookjson.PathConfiner {
 	return hookjson.ConfinerForSource(Source, runtime.GOOS, transcriptExt)
 }
 
+// admitHookRequest applies both consents this receiver needs and records the
+// channel receipt between them. It answers the request itself on refusal and
+// returns false; a true means the caller may proceed to read the body.
+//
+// All three steps live here together because their ORDER is the contract, and
+// each boundary is load-bearing in a different direction:
+//
+//   - The "hooks" consent comes first. It authorizes WRITING our entries into
+//     the user's settings.json — which is what makes a POST arrive at all.
+//   - The receipt is counted between them, so a hooks-granted /
+//     transcripts-denied install still reads as a LIVE channel. #1368's
+//     liveness watchdog demotes a channel that produces no receipts and
+//     releases the holds it placed; counting only fully-granted requests would
+//     have it falsely accuse a working install of being dead. See receipt.go
+//     for why each later rejection still counts and why a consent-denied
+//     request must not.
+//   - The "transcripts" consent comes last, and still BEFORE the decode and so
+//     before confinement, so a denied session yields a quiet 200 and the path
+//     is never resolved on that branch. Dispatching makes the detector open
+//     the transcript, so that read needs its own consent: granting "hooks" is
+//     not a licence to read the file those entries point at.
+//
+// codex and copilot have carried the transcripts gate since #1174 and mirror
+// each other step for step; claudecode — the receiver the other two were
+// modelled on — never got it, so a hook POST reached the detector's open on a
+// transcript the user had denied (issue #1466). A hooks-granted /
+// transcripts-denied session is not monitored anyway, so dropping the hook
+// here is both consent-correct and behaviourally harmless.
+func admitHookRequest(gate ConsentGranter, w http.ResponseWriter) bool {
+	if gate != nil && !gate.Granted(AdapterName, PermissionKeyHooks) {
+		w.WriteHeader(http.StatusOK)
+		return false
+	}
+
+	hookjson.ObserveHookReceipt(AdapterName)
+
+	if gate != nil && !gate.Granted(AdapterName, PermissionKeyTranscripts) {
+		w.WriteHeader(http.StatusOK)
+		return false
+	}
+	return true
+}
+
 // serveHookRequest is NewHookHandler's request logic, pulled out of the
 // returned closure so its branching isn't counted at the closure's extra
 // nesting depth (go:S3776 — this dropped the reported complexity from 31 to
@@ -264,34 +307,7 @@ func serveHookRequest(target HookTarget, markers MarkerTarget, gate ConsentGrant
 		return
 	}
 
-	if gate != nil && !gate.Granted(AdapterName, PermissionKeyHooks) {
-		w.WriteHeader(http.StatusOK)
-		return
-	}
-
-	// The channel delivered (issue #1368). Counted here — after the consent
-	// gate, before anything can reject the payload — because the question this
-	// answers is "are hooks arriving at all", and a body we then refuse still
-	// proves they are. See receipt.go for why each rejection below still
-	// counts and why a consent-denied request must not.
-	hookjson.ObserveHookReceipt(AdapterName)
-
-	// Dispatching makes the detector read the transcript — the comment below
-	// says so in as many words — so it is gated behind the "transcripts"
-	// consent, not merely the "hooks" write consent. Granting "hooks"
-	// authorizes WRITING our entries into settings.json; it is not a licence to
-	// read the file those entries point at. The check comes BEFORE the decode,
-	// and so before confinement, so a denied session still yields a quiet 200
-	// and the path is never resolved on that branch.
-	//
-	// codex and copilot have carried this since #1174 and mirror each other
-	// step for step; claudecode — the receiver the other two were modelled on —
-	// never got it, so a hook POST reached the detector's open on a transcript
-	// the user had denied (issue #1466). A hooks-granted / transcripts-denied
-	// session is not monitored anyway, so dropping the hook here is both
-	// consent-correct and behaviourally harmless.
-	if gate != nil && !gate.Granted(AdapterName, PermissionKeyTranscripts) {
-		w.WriteHeader(http.StatusOK)
+	if !admitHookRequest(gate, w) {
 		return
 	}
 

--- a/core/adapters/inbound/agents/claudecode/hooks.go
+++ b/core/adapters/inbound/agents/claudecode/hooks.go
@@ -276,6 +276,25 @@ func serveHookRequest(target HookTarget, markers MarkerTarget, gate ConsentGrant
 	// counts and why a consent-denied request must not.
 	hookjson.ObserveHookReceipt(AdapterName)
 
+	// Dispatching makes the detector read the transcript — the comment below
+	// says so in as many words — so it is gated behind the "transcripts"
+	// consent, not merely the "hooks" write consent. Granting "hooks"
+	// authorizes WRITING our entries into settings.json; it is not a licence to
+	// read the file those entries point at. The check comes BEFORE the decode,
+	// and so before confinement, so a denied session still yields a quiet 200
+	// and the path is never resolved on that branch.
+	//
+	// codex and copilot have carried this since #1174 and mirror each other
+	// step for step; claudecode — the receiver the other two were modelled on —
+	// never got it, so a hook POST reached the detector's open on a transcript
+	// the user had denied (issue #1466). A hooks-granted / transcripts-denied
+	// session is not monitored anyway, so dropping the hook here is both
+	// consent-correct and behaviourally harmless.
+	if gate != nil && !gate.Granted(AdapterName, PermissionKeyTranscripts) {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
 	// transcript_path arrives in an HTTP body on a local, unauthenticated
 	// endpoint, so it is untrusted: every dispatch below hands it to the
 	// detector, which opens it. DecodeConfined reads the body and confines the

--- a/core/adapters/inbound/agents/claudecode/hooks_test.go
+++ b/core/adapters/inbound/agents/claudecode/hooks_test.go
@@ -562,6 +562,14 @@ func (g *mutableGate) setGranted(v bool) {
 	g.mu.Unlock()
 }
 
+// keyedGate is a ConsentGranter that answers per permission key, so a test can
+// grant one of this adapter's permissions while denying another. The gates
+// above deliberately ignore the key, which is why neither of them can tell a
+// receiver gated on "hooks" from one gated on "transcripts" (issue #1466).
+type keyedGate map[string]bool
+
+func (g keyedGate) Granted(_, key string) bool { return g[key] }
+
 func TestHookHandler_ConsentGateDropsWhenNotGranted(t *testing.T) {
 	target := &mockTarget{}
 	handler := NewHookHandler(target, nil, fakeGate(false), mockLogger{})
@@ -803,4 +811,46 @@ func TestHookHandler_PermissionGateContract(t *testing.T) {
 		},
 		Observe: func() bool { return len(target.getCalls()) > 0 },
 	})
+}
+
+// TestHookHandler_TranscriptsConsentGatesTheRead is the issue #1466 defect
+// test. Every dispatch below the gate hands the transcript path to the
+// detector, which opens it (hooks.go says so in as many words) — so accepting
+// a hook POST authorizes a READ of the user's transcript, and that read is
+// what the observe-kind "transcripts" permission covers. The "hooks" consent
+// authorizes WRITING our entries into settings.json; it is not a licence to
+// read the file those entries point at.
+//
+// With hooks granted and transcripts denied the payload must be dropped and
+// the target never called. codex (hooks.go:158) and copilot (hooks.go:206)
+// have carried this second gate since #1174; claudecode never got one, so a
+// hook POST reached os.Open on a transcript the user had not consented to.
+//
+// The status stays 200 for the same reason a confinement refusal does: a
+// refusal is reported by the log, never on the wire, and a transcripts-denied
+// user should not have hooks failing at them. The dispatch assertion is what
+// carries this test.
+//
+// It cannot be folded into TestHookHandler_PermissionGateContract above:
+// that contract drives ONE permission through three states via mutableGate,
+// which ignores the key it is passed and so answers identically for both.
+// Two permissions held at opposite states is exactly what it cannot express.
+func TestHookHandler_TranscriptsConsentGatesTheRead(t *testing.T) {
+	target := &mockTarget{}
+	gate := keyedGate{PermissionKeyHooks: true, PermissionKeyTranscripts: false}
+	handler := NewHookHandler(target, nil, gate, mockLogger{})
+
+	rec := postHook(t, handler, hookPayload{
+		TranscriptPath: inTreeTranscript(t, "sess-transcripts-gate"),
+		HookEventName:  HookPermissionRequest,
+		ToolName:       "Bash",
+	})
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200 (a consent refusal is not reported on the wire)", rec.Code)
+	}
+	if got := target.getCalls(); len(got) != 0 {
+		t.Errorf("dispatched %d call(s) without transcripts consent: %+v — "+
+			"the detector opens the transcript this path hands it", len(got), got)
+	}
 }


### PR DESCRIPTION
Closes #1466.

## The finding: reading 3, the live one

The issue offered three readings and asked which. It is **reading 3** — the receiver dispatches a transcript read that no permission covers.

`claudecode`'s hook receiver gated only on `hooks`. Every dispatch below that gate hands the transcript path to the detector, which opens it — and the file's **own comment three lines further down already said so**:

```go
// transcript_path arrives in an HTTP body on a local, unauthenticated
// endpoint, so it is untrusted: every dispatch below hands it to the
// detector, which opens it.
```

So a hook POST caused irrlicht to read a transcript the user had explicitly **denied**. Granting `hooks` authorizes WRITING our entries into `settings.json`; it is not a licence to read the file those entries point at. That is a live #570 violation — the guarantee is that nothing is exercised while a permission is pending or denied.

## Seen red

On the rebased tree, before the fix:

```
--- FAIL: TestHookHandler_TranscriptsConsentGatesTheRead (0.00s)
    hooks_test.go:853: dispatched 1 call(s) without transcripts consent:
    [{sessionID:sess-transcripts-gate
      transcriptPath:/var/folders/.../sess-transcripts-gate.jsonl
      hookEventName:PermissionRequest}] — the detector opens the transcript this path hands it
```

Green after. `go test ./core/... -race -count=1` passes.

## All four receivers, by grep and by mutation

The issue asked for each to be reported explicitly, since a gap in one and not the others is itself informative. It is:

| receiver | `hooks` gate | `transcripts` gate | verdict |
|---|---|---|---|
| `claudecode/hooks.go` | :267 | **none** | **GAP — fixed here** |
| `claudecode/statusline.go` | `statusline` :98 | none | **benign** — see below |
| `codex/hooks.go` | :129 | :158 | present |
| `copilot/hooks.go` | :187 | :206 | present |

**The statusline dismissal carries evidence** (per AGENTS.md). Its sink is `target.IngestRateLimit(path, snap)` — a map lookup keyed by path, not an open. Its own comment already states this and it is still true on current `main`: *"Its sink is a map lookup rather than an open, so this is not an arbitrary-read guard."* Nothing there reads a transcript, so `transcripts` is not the permission it needs, and its `statusline` gate is the right one.

**codex and copilot are genuinely covered, not merely present.** I deleted each one's transcripts gate and ran its suite:

```
codex:   FAIL  irrlicht/core/adapters/inbound/agents/codex
copilot: hooks_test.go:357: dispatched 1 times while transcripts consent was denied, want 0
         FAIL  irrlicht/core/adapters/inbound/agents/copilot
```

So claudecode was the **sole outlier in both respects** — missing the gate *and* missing the test. It is also the receiver the other two were explicitly modelled on: copilot's comment says it *"mirrors codex step for step"*, and codex has carried the gate since #1174.

## Why the existing contract passed while the gap was live

This is the part worth reading. `contracttesting.AssertPermissionGated` drives **one** permission through three states via `mutableGate`:

```go
func (g *mutableGate) Granted(_, _ string) bool { ... }
```

It **discards the key**. So it answers identically for `hooks` and `transcripts`, and a receiver gated on *either* passes the contract identically. The contract cannot express two permissions held at opposite states — which is exactly the condition the defect lives in. `claudecode` wires it (`hooks_test.go:806`) and it was green throughout.

The new test supplies a `keyedGate` that answers per key, which is what makes the assertion reachable at all.

## The fix, and why the placement is load-bearing

The same block codex and copilot carry, in the same place — after `ObserveHookReceipt`, before `DecodeConfined`. Both boundaries matter and both match the other two receivers:

- **AFTER the receipt counter**, so a hooks-granted / transcripts-denied install still counts as a **live channel**. #1368's liveness watchdog demotes a channel producing no receipts and releases the holds it placed; counting only fully-granted requests would have it falsely accuse a working install of being dead.
- **BEFORE the decode**, and so before confinement, so a denied session yields a quiet 200 and the path is never resolved on that branch. A user who has not granted transcript access should not have hooks failing at them.

## Scope: what I deliberately did not do

The issue floated folding the consent key into the `DecodeConfined` chokepoint so a receiver cannot dispatch without naming the permission it acts under — the same move #1389 made for path confinement — and flagged it as a design change to be argued on its merits rather than assumed. I did not take it on here: the correct fix for the reported defect is genuinely this one block, and the mutation results above show the other two receivers are already covered, so nothing is left half-finished by leaving it out.

What the mutation evidence *does* argue for is filing it, because the residual risk is precise and unaddressed: **three receivers now carry three bespoke tests, and a fourth receiver forgetting is caught by nothing.** That is the shape this repo normally answers with a registry tripwire (`TestEveryHookInstallDeclaresAVersionFloor`) or a key-aware contract, not with a fourth hand-written test. Filed as a follow-up rather than done inline.

## Verification

- `go test ./core/... -race -count=1` — pass
- `tools/preflight.sh --only go` — gofmt, core, factory, replaydata validate, rig smoke, replay fixtures, starhistory: all PASS
- `tools/preflight.sh --only arch` — ARS gate PASS (composite 7.9444 → 7.9440, no category regression)
- pre-push hook (`--changed`) — PASS
