### PR TITLE
docs(agents): generalize the red-first rule beyond defect tests

### DIFF
--- a/.claude/skills/ir:code-review/SKILL.md
+++ b/.claude/skills/ir:code-review/SKILL.md
@@ -90,7 +90,14 @@ Defects first — this skill hunts bugs. Quality cleanups are secondary here
 - **Test coverage** — does a test actually reach the changed behaviour? A
   defect fix needs a test that was **seen red** before the fix existed; a test
   that passes on `main` either doesn't reach the defect or the diagnosis is
-  wrong. Flag a green-that-was-never-red as a finding.
+  wrong. Flag a green-that-was-never-red as a finding. A check the diff *adds*
+  — a guard, a static rule, a linter or tripwire, a derived count, a schema
+  constraint, a migration, a contract assertion — has no "before" to run
+  against and owes the equivalent: a deliberate mutation of what it protects,
+  seen red. Ask for that evidence; its absence is the same finding. (This
+  review pass is where three of the four incidents behind that rule were
+  caught, each time by a mutation nobody had asked for — AGENTS.md's Testing
+  section has the rule and the categories.)
 - **Efficiency** — needless O(n²) over a hot path, repeated work in a loop,
   redundant I/O or process scans.
 - **Simplification / altitude** — only when the diff reimplements something

--- a/.claude/skills/ir:exec/SKILL.md
+++ b/.claude/skills/ir:exec/SKILL.md
@@ -439,15 +439,15 @@ Nobody is gating on the plan, so skip the HTML artifact and the wait entirely:
     daemon and asserts once its addr file exists can pass against a broken
     binary if the file is published before the behavior under test (e.g.
     consent effects) runs — the process is killed mid-startup and the
-    assertion never observes the code path it exists to cover. That is the
-    same shape as a linter that fails to run and returns empty, which then
-    reads as clean, or a mutation harness that silently stops mutating: **a
-    verification mechanism must fail loudly when it cannot run** — untested is
-    the most expensive way to fail, because its output is indistinguishable
-    from success. When an e2e test's "ready" signal and the behavior it means
-    to exercise are not obviously the same event, wait on the narrower one (a
-    dedicated readiness marker, or a bespoke poll for the specific side
-    effect) rather than the broad one. (Real incident, #1382/#1449: a daemon
+    assertion never observes the code path it exists to cover. This is the e2e
+    form of AGENTS.md's **"a verification mechanism must fail loudly when it
+    cannot run"** — that section carries the rule, why it is stated at all, and
+    its other instances (a linter that fails to run and returns empty, a
+    mutation harness that silently stops mutating). The local recipe: when an
+    e2e test's "ready" signal and the behavior it means to exercise are not
+    obviously the same event, wait on the narrower one (a dedicated readiness
+    marker, or a bespoke poll for the specific side effect) rather than the
+    broad one. (Real incident, #1382/#1449: a daemon
     e2e test came back green against a deliberately-broken binary this way —
     the addr file publishes before consent effects run, so SIGTERM landed
     mid-startup and the test never observed the code path under test.)
@@ -475,11 +475,13 @@ Nobody is gating on the plan, so skip the HTML artifact and the wait entirely:
     protects, confirm it goes red, and paste that failure to the same bar as
     above. Nothing going red means the check does not reach what it claims to
     cover — **STOP and report**, exactly as for a defect test that passes on
-    `main`. AGENTS.md's Testing section carries the full rule, the categories, why
-    committing the mutation as a fixture beats describing it in a PR body, and the
-    property-test convention for anything that computes an edit and writes bytes
-    (a config rewriter, a patcher, a migrator), where hand-written cases encode
-    the author's blind spot and cannot substitute. (Real incident, #1382/#1366: a
+    `main`. Where the mutation can live as a committed fixture (a corpus row, a
+    `testdata/` file), commit it rather than only describing it: evidence that
+    exists only in a merged PR body is re-run by nothing. AGENTS.md's Testing
+    section carries the full rule, the categories, and the property-test
+    convention for anything that computes an edit and writes bytes (a config
+    rewriter, a patcher, a migrator), where hand-written cases encode the
+    author's blind spot and cannot substitute. (Real incident, #1382/#1366: a
     run's two worst findings were both untested *guards* added alongside the fix,
     caught only because the review subagent ran a mutation battery on its own
     initiative — this step said nothing about them.)

--- a/.claude/skills/ir:exec/SKILL.md
+++ b/.claude/skills/ir:exec/SKILL.md
@@ -468,6 +468,22 @@ Nobody is gating on the plan, so skip the HTML artifact and the wait entirely:
     construction. Say which tests those are explicitly, rather than letting their
     green read as a red-first proof.
 
+    **A check the change *adds* has no "before" to run against — mutate instead.**
+    A new guard, a static architecture rule, a linter or tripwire, a derived count
+    or score, a schema constraint, a migration, a config rewriter, a contract
+    assertion: each passes the moment it is written, so break the thing it
+    protects, confirm it goes red, and paste that failure to the same bar as
+    above. Nothing going red means the check does not reach what it claims to
+    cover — **STOP and report**, exactly as for a defect test that passes on
+    `main`. AGENTS.md's Testing section carries the full rule, the categories, why
+    committing the mutation as a fixture beats describing it in a PR body, and the
+    property-test convention for anything that computes an edit and writes bytes
+    (a config rewriter, a patcher, a migrator), where hand-written cases encode
+    the author's blind spot and cannot substitute. (Real incident, #1382/#1366: a
+    run's two worst findings were both untested *guards* added alongside the fix,
+    caught only because the review subagent ran a mutation battery on its own
+    initiative — this step said nothing about them.)
+
     This applies to test code the *issue itself* pasted. A code block in an issue
     is a proposal, not evidence: `/ir:triage` marks such a test **unproven** on
     its Verifiability axis, and an untriaged one owes you the same run. (Real
@@ -1006,6 +1022,10 @@ Phase 6.
 - A defect test proves nothing until it has been seen red (Phase 4 step 11a). This
   binds regardless of where the test came from — the issue, `/ir:triage`, or your
   own diagnosis; a green that was never red is the failure mode, not the author.
+  The same bar binds a check the change *adds* — a guard, a static rule, a derived
+  number, a migration, a contract assertion — where the equivalent of running it
+  before the fix is mutating what it protects (same step; AGENTS.md's Testing
+  section has the categories).
 - **Verification is `tools/preflight.sh`, chunked by `--only` group in the
   foreground — never the unscoped run backgrounded** (Phase 4 step 11). The
   unscoped run reliably exceeds an automated caller's 600s command budget;

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,12 +58,82 @@ Use `./.build` for build artifacts.
 
 ## Testing
 
+**A test earns its place by having been seen fail.** A green that was never red is a
+claim, not evidence. How you obtain that red depends on what the test is for.
+
 **A defect test proves nothing until it has been seen red.** Run it before the fix
 exists, confirm it fails, paste the failure. A test that passes on `main` means either
 the diagnosis is wrong or the test doesn't reach the defect (a stub blind to the
 asserted field is the classic) — stop and report rather than shipping the green. Locks
 — tests pinning behavior that must *not* change — pass by construction; say which ones
 those are. `ir:exec` enforces this at Phase 4 step 11a; it binds outside `ir:exec` too.
+
+**Anything a change *adds* has no "before the fix" to run against, and owes a
+deliberate mutation instead.** A new guard, a static `architecture_test.go` rule, a
+linter or registry tripwire, a derived count or score, a schema constraint, a data
+migration, a config rewriter, a contract assertion — every one of them passes the
+moment it is written, which is exactly the condition the red-first rule exists to
+prevent. So break the thing being protected — violate the invariant, perturb the
+derived number, corrupt a migrated value — and confirm the new check goes red. If
+nothing does, it does not reach what it claims to cover, and that is the same
+stop-and-report as a defect test that passes on `main`. Four agents in one fleet run
+arrived at this gap from four directions — a new guard (#1366), derived numbers
+(#1363), a data migration (#1367), a layering rule (#1391) — each because a reviewer
+ran a mutation nobody had asked for. **Prefer committing the mutation to describing
+it**: `tools/lib/testdata/posix-lint/`'s deliberately-broken fixtures are the shape
+("committed rather than improvised so the mutation evidence outlives the PR"), and
+`TestSourceScanCatchesEveryKnownShape`
+(`core/application/services/construction_test.go`) is the same idea as a corpus.
+Evidence living only in a merged PR body is re-run by nothing, which for the
+`contracttesting` families is #1479. A guard that *rewrites* an existing one owes its
+predecessor's cases as locks on top of its own — "Guarded construction" below carries
+that rule and the incident that earned it.
+
+**A verification mechanism must fail loudly when it cannot run.** Absence of a finding
+and inability to look must never produce the same output: "the thing under test never
+executed" is the most expensive way to fail, because it is indistinguishable from
+success. Wherever a check greps, matches, mutates, shells out or waits on a readiness
+signal, assert that the operation actually happened — not merely that it reported
+nothing. The guard is one line each time, and each one caught something real
+immediately after being added: `posix-lint.sh` refusing rather than skipping when it
+finds no POSIX shell, no static linter, or no files (below); the architecture corpus
+asserting every case still contains the construct it plants (below); a mutation
+harness asserting its mutation changed the file, which then caught two more stale
+mutations (#1390) — and the next harness built on that from the start, carrying a
+deliberate no-match row that must report `STALE`, so its integrity check is provably
+not vacuous (#1450); and an e2e test waiting on a signal narrower than "the daemon
+published its addr file", which fires *before* the consent effects under test run, so
+a deliberately-broken binary came back green (#1449; `ir:exec` Phase 4 step 11 carries
+the recipe).
+
+**A validator that cannot parse its input checks MORE, never less.** An input it
+cannot read with confidence is neither a quiet pass nor a skip: it is the case where
+the validator has the least idea what it is looking at, so it is the last place to
+drop checks. `skill-lint.sh`'s fence and frontmatter checks exist for exactly that
+reason (below) — skipping is how it tells "documents a marker" from "has one", and an
+unbalanced delimiter would otherwise silence every check after it.
+
+**Code that emits bytes from a structural diff gets a property test.** Anything that
+computes an edit and writes the result — config rewriters, formatting-preserving
+serializers, patchers, migrators — is tested by generating random inputs and random
+mutations and asserting the output round-trips, not only by hand-written cases, which
+encode what the author already thought of and are therefore the same set they got
+right. `hookjson`'s splicer shipped with seven green round-trip tests and a defect
+writing `,,` into ~11% of randomly shaped documents, because all seven removed the
+*tail* of a container — the one position where the arithmetic was correct.
+`TestSplice_PropertyRandomMutations`
+(`core/adapters/inbound/agents/hookjson/jsonc_test.go`) is the shape to copy: a fixed
+seed so a failure reproduces, the document *and* the mutation printed in the failure
+message, and a committed iteration count small enough to stay in the suite (2000,
+0.07s) with a much larger sweep across several seeds run locally before landing. Two
+things the PR says out loud. **Which structural axes the generator varies** — one
+that varies only the axis you thought of is the same vacuous green wearing a
+different hat: that test's first draft mutated only object members, so it never
+produced a removal run longer than one item and never touched an array, which is
+precisely what the production uninstall path does, and a fourth defect survived until
+the generator was widened. And **which properties survive which mutation** — "every
+comment is preserved" is false for a deletion, since the deleted subtree's comments
+go with it, and asserting it anyway produces false failures that erode the test.
 
 Before marking a ticket done, run the full suite — every layer must pass:
 
@@ -348,7 +418,7 @@ Before marking a ticket done, run the full suite — every layer must pass:
 - Managed user files: every `modify`-kind permission with an `Apply` closure
   declares the shared, user-owned file that closure writes
   (`agent.Permission.Writes`, an `agent.ManagedUserFile` carrying `Path` +
-  `Uninstall`). Two projections read it, and they read deliberately different
+  `Uninstall`). Three projections read it, and they read deliberately different
   slices: `agents.ManagedUserFiles` returns everything — what
   `irrlichd --print-managed-files` prints and the onboarding recorder backs up
   before spawning a `grant-all` daemon against the user's real `$HOME` — while
@@ -373,7 +443,7 @@ Before marking a ticket done, run the full suite — every layer must pass:
   (`TestUninstallTaskEtaReadsOnlyTheInstructionsSlice`), because a
   single-sided narrowing check cannot see the one failure that matters most —
   two commands revoking each other's capability.
-  Both project the **full consent catalog** (`consentCatalog` in
+  All three project the **full consent catalog** (`consentCatalog` in
   `core/cmd/irrlichd`), not `agents.All()`: three daemon-wide declarations —
   gastown, launcher, kitty — are appended outside the adapter registry, and
   projecting only the registry is exactly how the kitty config patch was
@@ -409,10 +479,11 @@ Before marking a ticket done, run the full suite — every layer must pass:
   longer installs hooks** — that was the damage, not a regression.
   All seven contract families pass by construction against a correct adapter —
   or, for a delivery route no adapter has adopted yet, against its reference
-  wiring — so their whole value is that they *can* fail: a new or reworked contract
-  assertion lands with the deliberate mutation that was seen red for each
-  obligation recorded in its PR — the same bar the red-first rule above sets
-  for defect tests.
+  wiring — so their whole value is that they *can* fail. A new or reworked
+  contract assertion is therefore the mutation rule at the top of this section
+  in its most literal form: it lands with the deliberate mutation seen red for
+  each obligation. That evidence currently lives in the PR body, where nothing
+  re-runs it — #1479.
 - Guarded construction: not a contract family — a package-local pair of guards,
   `core/application/services/construction_test.go`. A service whose fields
   include maps, channels, or anything else whose zero value is unusable is
@@ -457,8 +528,8 @@ Before marking a ticket done, run the full suite — every layer must pass:
   promotes them, which is how one gets hardened). The fence and frontmatter
   checks exist because skipping is how the linter tells "documents a marker"
   from "has one" — so an unbalanced delimiter would otherwise silence the rest
-  of the file, and the rule is that when a file cannot be parsed with
-  confidence the linter degrades toward *more* checking, never less. Runs as
+  of the file. That is the parse-failure rule at the top of this section in its
+  local form. Runs as
   its own `skill-file lint` gate in `tools/preflight.sh` (scoped to skill
   markdown plus the linter itself) and unscoped as test.yml's "Lint skill
   files" step — first in the job, before `setup-go`. Its own tests are

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,35 +76,40 @@ moment it is written, which is exactly the condition the red-first rule exists t
 prevent. So break the thing being protected — violate the invariant, perturb the
 derived number, corrupt a migrated value — and confirm the new check goes red. If
 nothing does, it does not reach what it claims to cover, and that is the same
-stop-and-report as a defect test that passes on `main`. Four agents in one fleet run
-arrived at this gap from four directions — a new guard (#1366), derived numbers
-(#1363), a data migration (#1367), a layering rule (#1391) — each because a reviewer
-ran a mutation nobody had asked for. **Prefer committing the mutation to describing
-it**: `tools/lib/testdata/posix-lint/`'s deliberately-broken fixtures are the shape
-("committed rather than improvised so the mutation evidence outlives the PR"), and
-`TestSourceScanCatchesEveryKnownShape`
+stop-and-report as a defect test that passes on `main`. This includes a **lock the
+change itself adds**: "passes by construction" is the reason the mutation is needed,
+not an exemption from it — the Locks sentence above is about locks over behavior that
+predates the change, where there is nothing new to prove reaches anything. Four agents
+in one fleet run arrived at this gap from four directions — a new guard (#1366),
+derived numbers (#1363), a data migration (#1367), a layering rule (#1391) — each
+because a reviewer, or the agent itself, ran a mutation nobody had asked for.
+
+**Prefer committing that mutation to describing it.** `tools/lib/testdata/posix-lint/`'s
+deliberately-broken fixtures are the shape ("committed rather than improvised so the
+mutation evidence outlives the PR"), and `TestSourceScanCatchesEveryKnownShape`
 (`core/application/services/construction_test.go`) is the same idea as a corpus.
 Evidence living only in a merged PR body is re-run by nothing, which for the
-`contracttesting` families is #1479. A guard that *rewrites* an existing one owes its
-predecessor's cases as locks on top of its own — "Guarded construction" below carries
-that rule and the incident that earned it.
+`contracttesting` families is #1479. And a guard that *rewrites* an existing one owes
+its predecessor's cases as locks on top of its own — "Guarded construction" below
+carries that rule and the incident that earned it.
 
 **A verification mechanism must fail loudly when it cannot run.** Absence of a finding
 and inability to look must never produce the same output: "the thing under test never
 executed" is the most expensive way to fail, because it is indistinguishable from
 success. Wherever a check greps, matches, mutates, shells out or waits on a readiness
 signal, assert that the operation actually happened — not merely that it reported
-nothing. The guard is one line each time, and each one caught something real
-immediately after being added: `posix-lint.sh` refusing rather than skipping when it
-finds no POSIX shell, no static linter, or no files (below); the architecture corpus
-asserting every case still contains the construct it plants (below); a mutation
-harness asserting its mutation changed the file, which then caught two more stale
-mutations (#1390) — and the next harness built on that from the start, carrying a
-deliberate no-match row that must report `STALE`, so its integrity check is provably
-not vacuous (#1450); and an e2e test waiting on a signal narrower than "the daemon
-published its addr file", which fires *before* the consent effects under test run, so
-a deliberately-broken binary came back green (#1449; `ir:exec` Phase 4 step 11 carries
-the recipe).
+nothing. The guard is one line each time. Three of them caught something real the
+moment they were added: `posix-lint.sh` refusing rather than skipping when it finds no
+POSIX shell, no static linter, or no files, after its first draft printed `ALL PASS`
+over an installer carrying a deliberate `[[ ]]` (below); a mutation harness asserting
+its mutation changed the file, which then caught two more stale mutations (#1390); and
+an e2e test waiting on a signal narrower than "the daemon published its addr file",
+which fires *before* the consent effects under test run, so a deliberately-broken
+binary came back green (#1449; `ir:exec` Phase 4 step 11 carries the recipe). Two more
+were added before they could catch anything and carry the weaker evidence that they
+*can* fire: the architecture corpus asserting every case still contains the construct
+it plants (below), and the harness built on #1390's lesson from the start, carrying a
+deliberate no-match row that must report `STALE` (#1450).
 
 **A validator that cannot parse its input checks MORE, never less.** An input it
 cannot read with confidence is neither a quiet pass nor a skip: it is the case where
@@ -125,13 +130,14 @@ writing `,,` into ~11% of randomly shaped documents, because all seven removed t
 (`core/adapters/inbound/agents/hookjson/jsonc_test.go`) is the shape to copy: a fixed
 seed so a failure reproduces, the document *and* the mutation printed in the failure
 message, and a committed iteration count small enough to stay in the suite (2000,
-0.07s) with a much larger sweep across several seeds run locally before landing. Two
-things the PR says out loud. **Which structural axes the generator varies** — one
-that varies only the axis you thought of is the same vacuous green wearing a
-different hat: that test's first draft mutated only object members, so it never
-produced a removal run longer than one item and never touched an array, which is
-precisely what the production uninstall path does, and a fourth defect survived until
-the generator was widened. And **which properties survive which mutation** — "every
+0.07s) with a much larger sweep across several seeds run locally before landing. Such
+a PR says two things out loud. **Which structural axes the generator varies** — one
+that varies only the axis you thought of is the same vacuous green wearing a different
+hat: that test's first draft mutated only object members, so it never produced a
+removal run longer than one item and never touched an array, while multi-item removals
+inside an array are exactly what the production uninstall path performs
+(`hooks[event]`, seven events removed in one pass). A fourth defect survived until the
+generator was widened. And **which properties survive which mutation** — "every
 comment is preserved" is false for a deletion, since the deleted subtree's comments
 go with it, and asserting it anyway produces false failures that erode the test.
 
@@ -447,7 +453,7 @@ Before marking a ticket done, run the full suite — every layer must pass:
   `core/cmd/irrlichd`), not `agents.All()`: three daemon-wide declarations —
   gastown, launcher, kitty — are appended outside the adapter registry, and
   projecting only the registry is exactly how the kitty config patch was
-  offered by the wizard while being invisible to both lists (#1383). The
+  offered by the wizard while being invisible to every one of them (#1383). The
   catalog-wide tripwire is
   `TestEveryModifyPermissionDeclaresTheFileItWrites`
   (`core/cmd/irrlichd/managedfiles_test.go`); a new modify permission is


### PR DESCRIPTION
Closes #1392.

## The gap

AGENTS.md's red-first rule is written for **defect** tests — *"Run it before the
fix exists, confirm it fails."* By its own terms it does not bind on anything a
change *adds*: a new guard, a static `architecture_test.go` rule, a linter or
tripwire, a derived count or score, a schema constraint, a data migration, a
config rewriter, a contract assertion. Every one of those **passes the moment it
is written**, which is exactly the condition the red-first rule exists to
prevent. The repo has accumulated ~10 independent instances of that hole, which
is what this issue was held open to absorb in one pass.

## What the Testing preamble now says

One ordered rule set at the top of the section, so a reader gets the whole
obligation before the gate list:

1. **A test earns its place by having been seen fail.** (lead-in)
2. **A defect test proves nothing until it has been seen red.** — unchanged,
   byte-for-byte. Every downstream reference to it (`ir:code-review`,
   `ir:triage`, `ir:exec` step 11a, CHANGELOG) still resolves.
3. **Anything a change *adds* has no "before the fix" to run against, and owes a
   deliberate mutation instead.** Names the categories, states the
   stop-and-report, and prefers *committing* the mutation as a fixture over
   describing it in a PR body.
4. **A verification mechanism must fail loudly when it cannot run.** Promoted
   out of `ir:exec` Phase 4 step 11, where it was the only general statement of
   it anywhere.
5. **A validator that cannot parse its input checks MORE, never less.** Promoted
   out of the `skill-lint.sh` bullet, where nothing suggested it generalized.
6. **Code that emits bytes from a structural diff gets a property test.** The
   seed case, with `TestSplice_PropertyRandomMutations` named as the shape to
   copy and both corollaries (say which structural axes the generator varies;
   be precise about which properties survive which mutation).

## Consolidated rather than duplicated

- **Contract families** (`Managed user files` bullet) restated the mutation bar
  in its own words — *"the same bar the red-first rule above sets for defect
  tests"*. It now names itself as the promoted rule's most literal instance and
  adds where that evidence currently lives (#1479).
- **`skill-lint.sh` bullet** restated the parse-failure rule inline — *"the rule
  is that when a file cannot be parsed with confidence the linter degrades
  toward *more* checking, never less"*. It now keeps the local mechanics and
  points up.

## Judged already covered — not restated

- **A rewritten guard replays its predecessor's cases** (#1450 vs #1444) is
  already in the tree verbatim, in the `Guarded construction` bullet next to the
  incident that earned it: *"A rewritten guard replays its predecessor's cases
  or it is not known to be a superset."* The new preamble adds a **pointer**, not
  a second statement.
- **`posix-lint.sh`'s three refusals** (#1423) already carry the fail-loudly
  consequence in situ — *"Three ways out are hard failures, not skips … because
  a gate whose absence reads as a pass is the exact defect it was built to
  remove"* — and the architecture corpus already carries its own — *"a corpus
  that quietly stops containing its own test cases reads as a pass"*. Both are
  now cited from the promoted rule as its instances; neither was reworded.
- **The #1453 contract obligation that passed its own mutation** is already
  covered at length in the `Hook endpoints` bullet, including the vacuity guard
  (*"asserts that the property was actually obtained"*) and why the two delivery
  routes' first obligations are contradictory so neither can pass quietly.
- **#1475 and #1479 are open**; this PR does not preempt their fixes. #1479 is
  cited as the named weakness of PR-body-only mutation evidence.

## Skill files

`ir:exec` was read fresh from the worktree (#1468 landed a large update to it
days ago), and `ir:code-review` was added in the review round — see below.

## `ir:exec` skill

Read fresh from the worktree (#1468 landed a large update to it days ago).
Step 11a gains one paragraph — the added-check half of red-first, pointing at
AGENTS.md for the categories rather than restating them — and the Notes entry
gains the matching clause. Nothing else in the skill changed.

## `ir:code-review` skill (added in the review round)

The step 13 reviewer flagged that `/ir:code-review`'s **Test coverage**
dimension was still scoped to defect tests only — *"a defect fix needs a test
that was **seen red** … Flag a green-that-was-never-red"* — and that this review
pass is the surface where **three of the four cited incidents were actually
caught**, each by a mutation nobody had asked for. A rule the reviewer is never
told to ask for is a rule that depends on the reviewer's initiative, which is
precisely how these were found. One added clause now asks for mutation evidence
on a check the diff *adds*, and makes its absence the same finding.

## Review round (step 13, `medium`, one subagent)

Seven findings, all applied in `9e834b93`:

1. **MEDIUM** — the untouched Locks sentence read as an *exemption* covering
   most of the categories the new rule enumerates (a static rule, a tripwire, a
   schema constraint, a contract assertion are all "locks"). An agent could have
   cited AGENTS.md while shipping the exact vacuous green this closes. The new
   text now says a lock the change *itself adds* is why the mutation is needed,
   not an exemption from it.
2. *"each one caught something real immediately after being added"* was
   universally quantified and **false for one member** — the architecture corpus
   arrived with can-fire evidence only (PR #1465 row M7), not a real catch. Split
   into the three that caught something and the two proven able to fire. This is
   the same failure class the PR documents, so it is worth the fix rather than
   the softening.
3. *"each because a reviewer ran a mutation nobody had asked for"* misattributed
   two of four — #1392's comment says *"a reviewer **or the agent itself**"*, and
   #1391/#1363 both supplied their own evidence unprompted. Restored; the
   distinction matters because the audience is the implementing agent.
4. *"invisible to both lists (#1383)"* was a **third** stale count in the same
   bullet, three lines below the two just corrected.
5. The fail-loudly rule was now stated in full, near-verbatim, in **both**
   AGENTS.md and `ir:exec` step 11, with a one-way pointer that would drift.
   `ir:exec` keeps its local e2e recipe and defers for the rule.
6. Step 11a said *"paste that failure"* two lines from citing the rationale for
   preferring a committed fixture. It now says both, in order.
7. Two clarity fixes in the property-test paragraph (obligation vs description;
   a relative clause that could be read as its own inverse).

The reviewer independently verified every symbol, test name, seed, iteration
count, fixture directory and issue number cited in the new prose against this
tree and against the primary-source PRs, and confirmed the `#1390` / `#1450`
split below is faithful to PR #1446 and PR #1459.

## Corrections found while checking claims against the tree

Per AGENTS.md's own evidence bar, two claims in the ticket's synthesis did not
survive contact with the tree and are **not** written down as stated:

- The brief listed #1450 as a *second, independent* mutation harness that
  silently stopped mutating. PR #1459 (which closed #1450) says the opposite:
  its harness carries the guard **from the start** — *"Every probe asserts it
  actually landed … a mutation must change the target's sha256"* — plus a
  deliberate no-match row `Z1` that must report `STALE`. So the text records
  #1390 as the failure and #1450 as the adoption that proves the guard isn't
  vacuous.
- **Drive-by, out of scope, flagged rather than silent:** PR #1459's own review
  noted a stale count in the `Managed user files` bullet, pre-existing on `main`
  and deliberately left there — the bullet opened *"Two projections read it"*,
  then *"Since #1437 there is a third"*, then *"Both project the full consent
  catalog"*. Verified against `core/adapters/inbound/agents/managedfiles.go`
  (three exported projections) and `core/cmd/irrlichd/main.go` (all three called
  with `declaredConsentCatalog()`); corrected to "Three" and "All three". Happy
  to drop this hunk if you'd rather it rode its own PR.

## Verification

Documentation only, so there is no red-first obligation on the change itself —
and no test was added that could carry one. What was checked instead: every
symbol, file path, test name, fixture directory and issue number cited in the
new text was verified to exist in this tree or in the cited issue/PR before
being written down.

- `tools/skill-lint.sh` — 23 files, 0 errors, 0 warnings.
- `tools/preflight.sh --only skills` — PASS.
- `tools/preflight.sh --changed` — gofmt PASS, skill-file lint PASS, rest
  correctly SKIP (docs-only diff).
- `TestSplice_PropertyRandomMutations` run to confirm the timing claim in the
  new text: **0.07s** for 2000 iterations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
