### PR TITLE
fix(launcher): refresh a herdr session's host on the liveness sweep

### DIFF
--- a/core/application/services/launcher_backfill_internal_test.go
+++ b/core/application/services/launcher_backfill_internal_test.go
@@ -46,23 +46,34 @@ func TestLauncherBackfillNeedsFor_HerdrHost(t *testing.T) {
 	}
 }
 
-// TestLauncherBackfillNeedsFor_HerdrClientInKittyIsHerdrOnly pins the
-// exclusivity that used to be a coincidence. The kitty needs and the herdr need
-// could never both fire while the herdr one required TermProgram == "" and the
-// kitty ones required TermProgram == "kitty". Dropping that precondition
-// (#1405) removes the coincidence, and a herdr pane whose *client* runs in
-// kitty is exactly the shape that would satisfy both — so the herdr branch now
-// returns before the kitty ones are computed. It has to: a pane owns none of
-// those fields, they are adopted wholesale from the client, and letting the
-// per-field kitty copies run first would report an update for a client that
-// never moved.
-func TestLauncherBackfillNeedsFor_HerdrClientInKittyIsHerdrOnly(t *testing.T) {
-	needs := launcherBackfillNeedsFor(&session.Launcher{
+// TestLauncherBackfillNeedsFor_HerdrClientInKitty pins the exclusivity that
+// used to be a coincidence. The kitty needs and the herdr need could never both
+// fire while the herdr one required TermProgram == "" and the kitty ones
+// required TermProgram == "kitty". Dropping that precondition (#1405) removes
+// the coincidence, and a herdr pane whose *client* runs in kitty is exactly the
+// shape that would satisfy both — so the herdr branch now returns before the
+// kitty ones are computed. It has to: a pane owns no kitty field, they are
+// adopted wholesale from the client, and letting the per-field kitty copies run
+// first would report an update for a client that never moved.
+//
+// The tty need is the deliberate exception and is asserted here rather than
+// left implicit: AdoptHostIdentity refuses to move the client's tty onto a pane
+// that has none (#744), so it is the one field the adoption cannot supply and
+// the only one a herdr launcher still backfills per-field.
+func TestLauncherBackfillNeedsFor_HerdrClientInKitty(t *testing.T) {
+	kittyClient := &session.Launcher{
 		HerdrPaneID: "w1:p1",
 		TermProgram: "kitty", // the attached client's, adopted at capture
-	})
-	if want := (launcherBackfillNeeds{herdrHost: true}); needs != want {
-		t.Errorf("herdr pane must have exactly the herdr need: got %+v, want %+v", needs, want)
+	}
+	if want := (launcherBackfillNeeds{herdrHost: true, tty: true}); launcherBackfillNeedsFor(kittyClient) != want {
+		t.Errorf("no kitty need may fire for a herdr pane: got %+v, want %+v",
+			launcherBackfillNeedsFor(kittyClient), want)
+	}
+
+	kittyClient.TTY = "/dev/ttys077"
+	if want := (launcherBackfillNeeds{herdrHost: true}); launcherBackfillNeedsFor(kittyClient) != want {
+		t.Errorf("a herdr pane with a tty needs only the host: got %+v, want %+v",
+			launcherBackfillNeedsFor(kittyClient), want)
 	}
 }
 

--- a/core/application/services/launcher_backfill_internal_test.go
+++ b/core/application/services/launcher_backfill_internal_test.go
@@ -8,8 +8,15 @@ import (
 
 // TestLauncherBackfillNeedsFor_HerdrHost covers the gap #1350 leaves open at
 // capture time: a herdr session whose PID was bound while nothing was attached
-// has no host to record, so the seed-time backfill has to be the path that
-// picks up a client attached since then.
+// has no host to record, so a later re-read has to be the path that picks up a
+// client attached since then.
+//
+// The two "already resolved" cases below wanted false until #1405 and now want
+// true. That was the second half of the same defect: a host that did resolve
+// was never re-checked, so a session detached in one terminal and re-attached
+// in another kept naming the first one for the rest of its life. Eligibility is
+// now unconditional for a herdr pane, which is what lets the liveness sweep
+// re-resolve it (refreshHerdrHosts).
 func TestLauncherBackfillNeedsFor_HerdrHost(t *testing.T) {
 	tests := map[string]struct {
 		launcher *session.Launcher
@@ -21,11 +28,11 @@ func TestLauncherBackfillNeedsFor_HerdrHost(t *testing.T) {
 		},
 		"herdr pane whose client already resolved": {
 			launcher: &session.Launcher{HerdrPaneID: "w1:p1", TermProgram: "ghostty"},
-			want:     false,
+			want:     true,
 		},
 		"herdr pane resolved only to a bundle id": {
 			launcher: &session.Launcher{HerdrPaneID: "w1:p1", HostBundleID: "md.obsidian"},
-			want:     false,
+			want:     true,
 		},
 		"a non-herdr session is never eligible": {
 			launcher: &session.Launcher{TTY: "/dev/ttys012"},
@@ -36,6 +43,26 @@ func TestLauncherBackfillNeedsFor_HerdrHost(t *testing.T) {
 		if got := launcherBackfillNeedsFor(tc.launcher).herdrHost; got != tc.want {
 			t.Errorf("%s: herdrHost = %v, want %v", name, got, tc.want)
 		}
+	}
+}
+
+// TestLauncherBackfillNeedsFor_HerdrClientInKittyIsHerdrOnly pins the
+// exclusivity that used to be a coincidence. The kitty needs and the herdr need
+// could never both fire while the herdr one required TermProgram == "" and the
+// kitty ones required TermProgram == "kitty". Dropping that precondition
+// (#1405) removes the coincidence, and a herdr pane whose *client* runs in
+// kitty is exactly the shape that would satisfy both — so the herdr branch now
+// returns before the kitty ones are computed. It has to: a pane owns none of
+// those fields, they are adopted wholesale from the client, and letting the
+// per-field kitty copies run first would report an update for a client that
+// never moved.
+func TestLauncherBackfillNeedsFor_HerdrClientInKittyIsHerdrOnly(t *testing.T) {
+	needs := launcherBackfillNeedsFor(&session.Launcher{
+		HerdrPaneID: "w1:p1",
+		TermProgram: "kitty", // the attached client's, adopted at capture
+	})
+	if want := (launcherBackfillNeeds{herdrHost: true}); needs != want {
+		t.Errorf("herdr pane must have exactly the herdr need: got %+v, want %+v", needs, want)
 	}
 }
 

--- a/core/application/services/pid_manager.go
+++ b/core/application/services/pid_manager.go
@@ -1372,11 +1372,16 @@ func memoizedLauncherEnv(read LauncherEnvReader) LauncherEnvReader {
 func (pm *PIDManager) applyHerdrHostRefresh(sessionID string, fresh *session.Launcher) *session.SessionState {
 	var updated *session.SessionState
 	pm.WithSessionStateLock(func() {
+		// Gone: reaped between the snapshot and here — possibly earlier in this
+		// very sweep. Returning rather than saving is what stops a deleted
+		// session being written back out.
 		state, err := pm.repo.Load(sessionID)
-		// Gone, or no longer a herdr pane: reaped or re-bound between the
-		// snapshot and here. Returning early rather than saving is what stops
-		// a session deleted earlier in this same sweep being written back out.
-		if err != nil || state == nil || state.Launcher == nil {
+		if err != nil || state == nil {
+			return
+		}
+		// Present but no longer launcher-bearing: a separate concern from
+		// existing, and the guard launcherBackfillNeedsFor's deref relies on.
+		if state.Launcher == nil {
 			return
 		}
 		needs := launcherBackfillNeedsFor(state.Launcher)

--- a/core/application/services/pid_manager.go
+++ b/core/application/services/pid_manager.go
@@ -1308,9 +1308,9 @@ func (pm *PIDManager) touchAndSave(state *session.SessionState) {
 //     one scan per sweep rather than N.
 //   - applyLauncherBackfill reports no change when the client has not moved,
 //     so the steady state writes nothing: no Save, no UpdatedAt bump, no push.
-//     The bump matters beyond churn — UpdatedAt drives the readyTTL reap, so a
-//     refresh that touched it every tick would keep idle sessions alive
-//     forever.
+//     The UpdatedAt bump is churn only, not a lifetime hazard: this runs solely
+//     for pid > 0 sessions, and sweepStaleSnapshot exempts any session with a
+//     live PID from the readyTTL reap before UpdatedAt is ever consulted.
 //
 // The read runs outside assignMu deliberately: ReadLauncherEnv is allowed to
 // block for up to two seconds, and assignMu serializes PID discovery for every

--- a/core/application/services/pid_manager.go
+++ b/core/application/services/pid_manager.go
@@ -847,6 +847,10 @@ type livenessSnapshot struct {
 	parentSessionID string
 	transcriptPath  string
 	adapter         string
+	// herdrPane marks a session hosted in a herdr pane — the one Launcher
+	// whose host identity is not static for the process's lifetime, and so
+	// the only one the sweep re-resolves (#1405, refreshHerdrHosts).
+	herdrPane bool
 }
 
 // snapshotLivenessStates reads every session's liveness-relevant fields under
@@ -870,6 +874,7 @@ func (pm *PIDManager) snapshotLivenessStates() []livenessSnapshot {
 			parentSessionID: state.ParentSessionID,
 			transcriptPath:  state.TranscriptPath,
 			adapter:         state.Adapter,
+			herdrPane:       state.Launcher != nil && state.Launcher.HerdrPaneID != "",
 		})
 	}
 	return snaps
@@ -907,6 +912,11 @@ func (pm *PIDManager) CheckPIDLiveness() bool {
 			pm.sweepStaleSnapshot(snap)
 		}
 	}
+
+	// Last, so a session reaped above is already gone by the time its refresh
+	// tries to load it — and gets nothing back — rather than being written
+	// out again.
+	pm.refreshHerdrHosts(snaps)
 	return foundDead
 }
 
@@ -1226,14 +1236,12 @@ func (pm *PIDManager) handleAlivePIDState(state *session.SessionState) bool {
 //   - The host identity of a herdr pane (issue #1350), which is resolved from
 //     the attached herdr client rather than from the pane itself. A session
 //     that was detached when its PID was bound has no host to record, so this
-//     is the path by which one attached since then is picked up. Two limits
-//     follow from where this runs, and both are deliberate for now: capture is
-//     once-per-PID-bind and this runs only at seed, so re-attaching a session
-//     to a *different* terminal is not noticed until the daemon restarts; and
-//     because the need is gated on *no* host being recorded, a host that did
-//     resolve is never re-checked afterwards. Refreshing it from the periodic
-//     liveness sweep instead would fix both — the daemon pushes launcher
-//     updates to clients, so nothing on the click path would have to change.
+//     is the path by which one attached since then is picked up at startup.
+//     It is no longer the *only* such path: because a herdr pane's host is the
+//     one Launcher field that is not static for the process's lifetime, it is
+//     also re-resolved on every periodic liveness sweep (refreshHerdrHosts,
+//     #1405). Both share launcherBackfillNeedsFor/applyLauncherBackfill, so
+//     the seed and the sweep cannot drift apart on what a refresh means.
 func (pm *PIDManager) backfillLauncher(state *session.SessionState) {
 	if state.Launcher == nil {
 		pm.captureLauncher(state, state.PID)
@@ -1265,6 +1273,101 @@ func (pm *PIDManager) touchAndSave(state *session.SessionState) {
 	_ = pm.repo.Save(state)
 }
 
+// refreshHerdrHosts re-resolves the host window of every herdr-hosted session,
+// on the periodic liveness sweep. Called from CheckPIDLiveness.
+//
+// Why the sweep and not capture time: every other Launcher field describes
+// something fixed for the life of the process, so capturing it once is
+// correct. A herdr pane's host is not — it belongs to whichever client is
+// attached right now, and detaching in one terminal to re-attach in another is
+// the entire point of a persistent multiplexer. Resolved once and never
+// revisited, the session goes on naming the terminal the user walked away
+// from, and a click raises that window: the misroute class #1348 was opened to
+// remove, arriving by a slower route (#1405). The sweep is the only thing that
+// runs while a session sits idle, which is exactly when a user re-attaches.
+//
+// Why not at focus time instead: the macOS row tap (SessionRowView →
+// SessionLauncher.jump) reads the session state the app already holds and
+// never round-trips to the daemon, so resolving there would route the
+// most-used interaction in the app through the daemon. Refreshing here needs
+// no click-path change — the corrected launcher rides the ordinary
+// session_updated push.
+//
+// Why this is affordable on a 5s timer:
+//
+//   - It is gated on the *stored* launcher already being a herdr pane, so a
+//     machine running no herdr sessions pays one bool per session per sweep
+//     and never calls the reader at all.
+//   - A herdr pane skips the process-ancestry walk by construction (see
+//     hostIdentity), which is the `ps` shellout chain the non-herdr path
+//     memoizes precisely because it is the expensive part.
+//   - The one genuinely costly step, the lsof scan that finds the attached
+//     client, is memoized per socket path, so N panes of one herdr server cost
+//     one scan per sweep rather than N.
+//   - applyLauncherBackfill reports no change when the client has not moved,
+//     so the steady state writes nothing: no Save, no UpdatedAt bump, no push.
+//     The bump matters beyond churn — UpdatedAt drives the readyTTL reap, so a
+//     refresh that touched it every tick would keep idle sessions alive
+//     forever.
+//
+// The read runs outside assignMu deliberately: ReadLauncherEnv is allowed to
+// block for up to two seconds, and assignMu serializes PID discovery for every
+// session. Only the merge is taken under the lock.
+func (pm *PIDManager) refreshHerdrHosts(snaps []livenessSnapshot) {
+	if pm.launcherEnv == nil {
+		return
+	}
+	for _, snap := range snaps {
+		if !snap.herdrPane || snap.pid <= 0 {
+			continue
+		}
+		fresh := pm.launcherEnv(snap.pid)
+		if fresh == nil {
+			continue
+		}
+		state := pm.applyHerdrHostRefresh(snap.state.SessionID, fresh)
+		if state == nil {
+			continue
+		}
+		pm.log.LogInfo(logComponentSessionDetector, state.SessionID,
+			fmt.Sprintf("herdr host re-resolved: term_program=%q host_bundle_id=%q tty=%q",
+				state.Launcher.TermProgram, state.Launcher.HostBundleID, state.Launcher.TTY))
+		pm.broadcast(outbound.PushTypeUpdated, state)
+	}
+}
+
+// applyHerdrHostRefresh merges fresh into sessionID's stored launcher and
+// persists it, returning the updated state when something actually changed and
+// nil otherwise — so the caller pushes only on a real move.
+//
+// The load-modify-save under WithSessionStateLock is not ceremony. The sweep's
+// snapshot holds a deep copy (the repository hands those out so callers can
+// mutate freely), so writing through it would persist nothing; and the lock is
+// the one assignPIDLocked takes around its own load-modify-save of the same
+// session, which is what keeps a concurrent PID discovery from being clobbered
+// by this one.
+func (pm *PIDManager) applyHerdrHostRefresh(sessionID string, fresh *session.Launcher) *session.SessionState {
+	var updated *session.SessionState
+	pm.WithSessionStateLock(func() {
+		state, err := pm.repo.Load(sessionID)
+		// Gone, or no longer a herdr pane: reaped or re-bound between the
+		// snapshot and here. Returning early rather than saving is what stops
+		// a session deleted earlier in this same sweep being written back out.
+		if err != nil || state == nil || state.Launcher == nil {
+			return
+		}
+		needs := launcherBackfillNeedsFor(state.Launcher)
+		if !needs.herdrHost {
+			return
+		}
+		if applyLauncherBackfill(state.Launcher, needs, fresh) {
+			pm.touchAndSave(state)
+			updated = state
+		}
+	})
+	return updated
+}
+
 // launcherBackfillNeeds tracks which Launcher fields are missing and should
 // be refreshed from a fresh env read.
 type launcherBackfillNeeds struct {
@@ -1281,17 +1384,34 @@ func (n launcherBackfillNeeds) any() bool {
 // launcherBackfillNeedsFor computes which fields of l are missing and
 // eligible for backfill. The three Kitty-specific fields only ever need
 // backfilling for a kitty launcher.
+//
+// A herdr pane returns exactly one need, and it is unconditional. Both halves
+// of that matter:
+//
+//   - Exactly one, because a pane owns none of the host fields — they are
+//     adopted wholesale from the attached client (AdoptHostIdentity), which
+//     already carries the kitty fields and the tty. Under the earlier rule the
+//     kitty needs happened to be mutually exclusive with the herdr one, since
+//     they all required TermProgram == "kitty" and the herdr need required it
+//     to be empty. Dropping that precondition would have made a herdr pane
+//     whose client runs *in* kitty satisfy both, so the exclusivity is now by
+//     construction rather than by coincidence.
+//   - Unconditional, because "a host was already resolved" is not a reason to
+//     stop looking. Every other Launcher field is static for a process's
+//     lifetime; the attached client is not — detach-here-reattach-there is the
+//     whole point of a persistent multiplexer, and gating on *no* host ever
+//     being recorded meant a session that moved terminals kept naming the one
+//     the user left (#1405).
 func launcherBackfillNeedsFor(l *session.Launcher) launcherBackfillNeeds {
+	if l.HerdrPaneID != "" {
+		return launcherBackfillNeeds{herdrHost: true}
+	}
 	isKitty := l.TermProgram == "kitty"
 	return launcherBackfillNeeds{
 		tty:         l.TTY == "",
 		kittyPID:    isKitty && l.KittyPID == 0,
 		kittyListen: isKitty && l.KittyListenOn == "",
 		kittyWindow: isKitty && l.KittyWindowID == "",
-		// A herdr pane with no host recorded had no client attached when it
-		// was captured. Mutually exclusive with the kitty needs above, which
-		// all require TermProgram == "kitty".
-		herdrHost: l.HerdrPaneID != "" && l.TermProgram == "" && l.HostBundleID == "",
 	}
 }
 

--- a/core/application/services/pid_manager.go
+++ b/core/application/services/pid_manager.go
@@ -1300,7 +1300,9 @@ func (pm *PIDManager) touchAndSave(state *session.SessionState) {
 //     and never calls the reader at all.
 //   - A herdr pane skips the process-ancestry walk by construction (see
 //     hostIdentity), which is the `ps` shellout chain the non-herdr path
-//     memoizes precisely because it is the expensive part.
+//     memoizes precisely because it is the expensive part. It still pays one
+//     `ps` for its controlling tty (~2ms measured), which is why the read is
+//     memoized per PID across the pass.
 //   - The one genuinely costly step, the lsof scan that finds the attached
 //     client, is memoized per socket path, so N panes of one herdr server cost
 //     one scan per sweep rather than N.
@@ -1317,11 +1319,16 @@ func (pm *PIDManager) refreshHerdrHosts(snaps []livenessSnapshot) {
 	if pm.launcherEnv == nil {
 		return
 	}
+	// Memoized for the duration of one pass because subagent sessions share
+	// their parent's PID and each carries its own herdr launcher: a parent
+	// with five subagents in one pane would otherwise pay six identical reads,
+	// every one of them a `ps` shellout for the controlling tty.
+	read := memoizedLauncherEnv(pm.launcherEnv)
 	for _, snap := range snaps {
 		if !snap.herdrPane || snap.pid <= 0 {
 			continue
 		}
-		fresh := pm.launcherEnv(snap.pid)
+		fresh := read(snap.pid)
 		if fresh == nil {
 			continue
 		}
@@ -1333,6 +1340,22 @@ func (pm *PIDManager) refreshHerdrHosts(snaps []livenessSnapshot) {
 			fmt.Sprintf("herdr host re-resolved: term_program=%q host_bundle_id=%q tty=%q",
 				state.Launcher.TermProgram, state.Launcher.HostBundleID, state.Launcher.TTY))
 		pm.broadcast(outbound.PushTypeUpdated, state)
+	}
+}
+
+// memoizedLauncherEnv wraps read so repeated calls for the same PID within one
+// pass resolve it once. Deliberately per-pass and not a field: the whole point
+// of the refresh is to observe a change between sweeps, so nothing here may
+// outlive the sweep that created it.
+func memoizedLauncherEnv(read LauncherEnvReader) LauncherEnvReader {
+	seen := map[int]*session.Launcher{}
+	return func(pid int) *session.Launcher {
+		if l, ok := seen[pid]; ok {
+			return l
+		}
+		l := read(pid)
+		seen[pid] = l
+		return l
 	}
 }
 
@@ -1358,6 +1381,19 @@ func (pm *PIDManager) applyHerdrHostRefresh(sessionID string, fresh *session.Lau
 		}
 		needs := launcherBackfillNeedsFor(state.Launcher)
 		if !needs.herdrHost {
+			return
+		}
+		// The fresh read has to still be the same pane. It may not be: a PID
+		// can be reused by an unrelated process, and assignPIDLocked re-binds a
+		// session to a new PID while captureLauncher — set-once — keeps the old
+		// Launcher (the --bg-spare pool re-bind of #727). Either way the reader
+		// sees no HERDR_PANE_ID, so launcherFromEnv skips its herdr
+		// early-return, hostIdentity runs the ancestry fallbacks that resolve
+		// the herdr *server's* terminal, and AdoptHostIdentity would copy that
+		// wholesale — re-introducing the #1348 misroute on a timer, which is
+		// the opposite of what this refresh exists to do. A genuinely detached
+		// pane still carries its own address, so the honest clear survives.
+		if fresh.HerdrPaneID != state.Launcher.HerdrPaneID {
 			return
 		}
 		if applyLauncherBackfill(state.Launcher, needs, fresh) {
@@ -1388,14 +1424,22 @@ func (n launcherBackfillNeeds) any() bool {
 // A herdr pane returns exactly one need, and it is unconditional. Both halves
 // of that matter:
 //
-//   - Exactly one, because a pane owns none of the host fields — they are
-//     adopted wholesale from the attached client (AdoptHostIdentity), which
-//     already carries the kitty fields and the tty. Under the earlier rule the
-//     kitty needs happened to be mutually exclusive with the herdr one, since
-//     they all required TermProgram == "kitty" and the herdr need required it
-//     to be empty. Dropping that precondition would have made a herdr pane
-//     whose client runs *in* kitty satisfy both, so the exclusivity is now by
-//     construction rather than by coincidence.
+//   - None of the kitty ones, because a pane owns no kitty field — they are
+//     adopted wholesale from the attached client (AdoptHostIdentity). Under
+//     the earlier rule the kitty needs happened to be mutually exclusive with
+//     the herdr one, since they all required TermProgram == "kitty" and the
+//     herdr need required it to be empty. Dropping that precondition removes
+//     the coincidence, and a herdr pane whose *client* runs in kitty is exactly
+//     the shape that would satisfy both — so the exclusivity is now by
+//     construction. Letting the per-field kitty copies run first would report
+//     an update for a client that never moved.
+//   - The tty need stays, and it is the one host-ish field that is NOT covered
+//     by the adoption: AdoptHostIdentity deliberately refuses to move the
+//     client's tty onto a pane that has none, because BackgroundAgent.Detached
+//     is derived from it (#744). So a herdr launcher stored without a tty —
+//     processTTY's `ps` timed out at capture, say — has no other route to
+//     acquiring one, and dropping this need would stall Terminal.app's
+//     tab-level targeting for that session permanently.
 //   - Unconditional, because "a host was already resolved" is not a reason to
 //     stop looking. Every other Launcher field is static for a process's
 //     lifetime; the attached client is not — detach-here-reattach-there is the
@@ -1404,7 +1448,7 @@ func (n launcherBackfillNeeds) any() bool {
 //     the user left (#1405).
 func launcherBackfillNeedsFor(l *session.Launcher) launcherBackfillNeeds {
 	if l.HerdrPaneID != "" {
-		return launcherBackfillNeeds{herdrHost: true}
+		return launcherBackfillNeeds{tty: l.TTY == "", herdrHost: true}
 	}
 	isKitty := l.TermProgram == "kitty"
 	return launcherBackfillNeeds{

--- a/core/application/services/pid_manager_herdr_refresh_test.go
+++ b/core/application/services/pid_manager_herdr_refresh_test.go
@@ -146,8 +146,13 @@ func TestCheckPIDLiveness_NonHerdrLauncherNotRefreshed(t *testing.T) {
 // TestCheckPIDLiveness_HerdrSteadyStateDoesNotChurn pins the other half of the
 // cost argument: a session whose client has not moved must produce no Save and
 // therefore no UpdatedAt bump and no websocket push, however often the sweep
-// runs. Without this, a 5s timer would rewrite every herdr session forever —
-// and a bumped UpdatedAt on a `ready` session also defers its own TTL reap.
+// runs. Without this, a 5s timer would rewrite every herdr session forever.
+//
+// A LOCK, not a defect test — the no-save half passes on main by construction,
+// since the sweep reads no launchers there. So it also asserts the session was
+// actually *visited*: "refreshed and correctly declined to write" and "never
+// looked at" are otherwise indistinguishable, and only the first is what this
+// claims to pin.
 func TestCheckPIDLiveness_HerdrSteadyStateDoesNotChurn(t *testing.T) {
 	repo := newMockRepo()
 	stored := &session.Launcher{
@@ -158,8 +163,10 @@ func TestCheckPIDLiveness_HerdrSteadyStateDoesNotChurn(t *testing.T) {
 	}
 	repo.states["s"] = herdrSession(stored)
 
+	calls := 0
 	pm := newPIDManagerForTest(repo)
 	pm.SetLauncherEnvReader(func(int) *session.Launcher {
+		calls++
 		cp := *stored
 		return &cp
 	})
@@ -170,5 +177,111 @@ func TestCheckPIDLiveness_HerdrSteadyStateDoesNotChurn(t *testing.T) {
 
 	if repo.saves != before {
 		t.Errorf("unchanged host still churned the repo: %d saves", repo.saves-before)
+	}
+	if calls != 2 {
+		t.Errorf("the session must be re-read once per sweep: %d reads over 2 sweeps", calls)
+	}
+}
+
+// TestCheckPIDLiveness_HerdrIgnoresAReadThatIsNoLongerThePane guards the way
+// this refresh could re-create the very misroute it removes. It decides "herdr
+// pane" from the *stored* launcher, but the PID it then reads may no longer be
+// that pane: a PID can be reused by an unrelated process, and assignPIDLocked
+// re-binds a session to a new PID while captureLauncher — set-once — keeps the
+// old Launcher (the --bg-spare re-bind of #727). Such a read carries no
+// HERDR_PANE_ID, so hostIdentity runs the ancestry fallbacks and resolves the
+// herdr *server's* terminal; adopting it wholesale would point every sweep at
+// the wrong window (#1348).
+func TestCheckPIDLiveness_HerdrIgnoresAReadThatIsNoLongerThePane(t *testing.T) {
+	repo := newMockRepo()
+	repo.states["s"] = herdrSession(&session.Launcher{
+		HerdrPaneID:     "w1:p1",
+		HerdrSocketPath: "/cfg/herdr/herdr.sock",
+		TermProgram:     "ghostty",
+		TTY:             "/dev/ttys077",
+	})
+
+	pm := newPIDManagerForTest(repo)
+	// What the reader returns for a PID that is no longer the pane: the
+	// ancestry walk resolved the herdr server's own terminal.
+	pm.SetLauncherEnvReader(func(int) *session.Launcher {
+		return &session.Launcher{TermProgram: "kitty", KittyPID: 42, TTY: "/dev/ttys001"}
+	})
+
+	pm.CheckPIDLiveness()
+
+	got := repo.states["s"].Launcher
+	if got.TermProgram != "ghostty" || got.KittyPID != 0 || got.TTY != "/dev/ttys077" {
+		t.Errorf("a read that is not this pane was adopted anyway: %+v", got)
+	}
+}
+
+// TestCheckPIDLiveness_HerdrAcquiresAMissingTTY covers the one host-ish field
+// the client adoption does NOT carry. AdoptHostIdentity deliberately refuses to
+// move the client's tty onto a pane that has none, because
+// BackgroundAgent.Detached is derived from it (#744) — so a herdr launcher
+// stored without a tty (processTTY's `ps` timed out at capture) has no other
+// route to acquiring one, and Terminal.app's tab-level targeting stays broken
+// for that session until it does.
+func TestCheckPIDLiveness_HerdrAcquiresAMissingTTY(t *testing.T) {
+	repo := newMockRepo()
+	repo.states["s"] = herdrSession(&session.Launcher{
+		HerdrPaneID:     "w1:p1",
+		HerdrSocketPath: "/cfg/herdr/herdr.sock",
+		TermProgram:     "iTerm.app",
+	})
+
+	pm := newPIDManagerForTest(repo)
+	pm.SetLauncherEnvReader(func(int) *session.Launcher {
+		return &session.Launcher{
+			HerdrPaneID:     "w1:p1",
+			HerdrSocketPath: "/cfg/herdr/herdr.sock",
+			TermProgram:     "iTerm.app",
+			ITermSessionID:  "w0t0p0",
+			TTY:             "/dev/ttys077",
+		}
+	})
+
+	pm.CheckPIDLiveness()
+
+	if got := repo.states["s"].Launcher.TTY; got != "/dev/ttys077" {
+		t.Errorf("a missing tty was never backfilled: TTY = %q", got)
+	}
+}
+
+// TestCheckPIDLiveness_HerdrSubagentsShareOneRead pins the cost fix for the
+// multiplier the per-socket memo does not cover: subagent sessions share their
+// parent's PID and each carries its own herdr launcher, so without a per-PID
+// memo a parent with subagents pays one identical `ps`-backed read per session,
+// every sweep, forever.
+func TestCheckPIDLiveness_HerdrSubagentsShareOneRead(t *testing.T) {
+	repo := newMockRepo()
+	pane := &session.Launcher{
+		HerdrPaneID:     "w1:p1",
+		HerdrSocketPath: "/cfg/herdr/herdr.sock",
+		TermProgram:     "ghostty",
+		TTY:             "/dev/ttys077",
+	}
+	parent := herdrSession(pane)
+	repo.states["s"] = parent
+	for _, id := range []string{"c1", "c2", "c3"} {
+		child := herdrSession(pane)
+		child.SessionID = id
+		child.ParentSessionID = "s"
+		repo.states[id] = child
+	}
+
+	calls := 0
+	pm := newPIDManagerForTest(repo)
+	pm.SetLauncherEnvReader(func(int) *session.Launcher {
+		calls++
+		cp := *pane
+		return &cp
+	})
+
+	pm.CheckPIDLiveness()
+
+	if calls != 1 {
+		t.Errorf("4 sessions on one PID cost %d reads, want 1", calls)
 	}
 }

--- a/core/application/services/pid_manager_herdr_refresh_test.go
+++ b/core/application/services/pid_manager_herdr_refresh_test.go
@@ -1,0 +1,174 @@
+package services_test
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"irrlicht/core/domain/session"
+)
+
+// herdrSession builds a live herdr-hosted session whose stored launcher
+// carries the host resolved from whichever client was attached at capture
+// time. os.Getpid() keeps the liveness sweep's ESRCH probe satisfied, and a
+// fresh UpdatedAt keeps it out of the readyTTL reap, so the only thing these
+// tests observe is the launcher.
+func herdrSession(host *session.Launcher) *session.SessionState {
+	return &session.SessionState{
+		SessionID: "s",
+		Adapter:   "claude-code",
+		State:     session.StateWorking,
+		PID:       os.Getpid(),
+		UpdatedAt: time.Now().Unix(),
+		Launcher:  host,
+	}
+}
+
+// TestCheckPIDLiveness_HerdrHostRefreshedOnReattach is the #1405 defect: a
+// herdr session's host is a *dynamic* property (detach-here-reattach-there is
+// the whole point of a persistent multiplexer), but #1350 stores it as a
+// capture-time snapshot. Attach in iTerm → bind the session → detach →
+// re-attach in Ghostty, and the session keeps pointing at iTerm for the rest
+// of its life, across daemon restarts: clicking it raises the wrong window,
+// which is the misroute class #1348 was opened to remove.
+//
+// The periodic liveness sweep is the only thing that runs while a session is
+// idle, so it is where the re-resolution has to happen.
+func TestCheckPIDLiveness_HerdrHostRefreshedOnReattach(t *testing.T) {
+	repo := newMockRepo()
+	repo.states["s"] = herdrSession(&session.Launcher{
+		HerdrPaneID:     "w1:p1",
+		HerdrSocketPath: "/cfg/herdr/herdr.sock",
+		TermProgram:     "iTerm.app",
+		ITermSessionID:  "w0t0p0-OLD",
+		TTY:             "/dev/ttys012",
+	})
+
+	pm := newPIDManagerForTest(repo)
+	// A fresh read now resolves the client the user re-attached in.
+	pm.SetLauncherEnvReader(func(int) *session.Launcher {
+		return &session.Launcher{
+			HerdrPaneID:     "w1:p1",
+			HerdrSocketPath: "/cfg/herdr/herdr.sock",
+			TermProgram:     "ghostty",
+			TTY:             "/dev/ttys077",
+		}
+	})
+
+	pm.CheckPIDLiveness()
+
+	got := repo.states["s"].Launcher
+	if got == nil {
+		t.Fatal("launcher went nil")
+	}
+	if got.TermProgram != "ghostty" {
+		t.Errorf("host not refreshed on the sweep: TermProgram = %q, want ghostty", got.TermProgram)
+	}
+	if got.ITermSessionID != "" {
+		t.Errorf("the previous client's iTerm selector survived the re-attach: %+v", got)
+	}
+	if got.TTY != "/dev/ttys077" {
+		t.Errorf("TTY still names the old client's tab: %q", got.TTY)
+	}
+	if got.HerdrPaneID != "w1:p1" || got.HerdrSocketPath != "/cfg/herdr/herdr.sock" {
+		t.Errorf("the pane address must survive: %+v", got)
+	}
+}
+
+// TestCheckPIDLiveness_HerdrHostClearedOnDetach is the other half of the same
+// defect. Detaching leaves no client, so no window displays the session — and
+// #1350's rule is that this is reported honestly rather than by leaving the
+// last known host in place. A stale host is worse than none: the app raises
+// some unrelated window instead of logging "no attached client".
+func TestCheckPIDLiveness_HerdrHostClearedOnDetach(t *testing.T) {
+	repo := newMockRepo()
+	repo.states["s"] = herdrSession(&session.Launcher{
+		HerdrPaneID:     "w1:p1",
+		HerdrSocketPath: "/cfg/herdr/herdr.sock",
+		TermProgram:     "iTerm.app",
+		ITermSessionID:  "w0t0p0-OLD",
+		TTY:             "/dev/ttys012",
+	})
+
+	pm := newPIDManagerForTest(repo)
+	// Nothing attached: the reader resolves no client, so it returns the pane's
+	// own address and its own pty and nothing else (ReadLauncherEnv's herdr
+	// early-return in launcherFromEnv).
+	pm.SetLauncherEnvReader(func(int) *session.Launcher {
+		return &session.Launcher{
+			HerdrPaneID:     "w1:p1",
+			HerdrSocketPath: "/cfg/herdr/herdr.sock",
+			TTY:             "/dev/ttys900",
+		}
+	})
+
+	pm.CheckPIDLiveness()
+
+	got := repo.states["s"].Launcher
+	if got.TermProgram != "" || got.ITermSessionID != "" {
+		t.Errorf("a detached session must report no host, not the last one: %+v", got)
+	}
+	if got.HerdrPaneID != "w1:p1" {
+		t.Errorf("the pane address must survive: %+v", got)
+	}
+}
+
+// TestCheckPIDLiveness_NonHerdrLauncherNotRefreshed is a LOCK, not a defect
+// test — it passes on main by construction, because the sweep reads no
+// launchers at all there. It pins the cost argument: every other Launcher
+// field is static for a process's lifetime, so only a herdr session may pay
+// the sweep's env read. A regression that widened this to all sessions would
+// put a sysctl + `ps` shellout per session on a 5s timer.
+func TestCheckPIDLiveness_NonHerdrLauncherNotRefreshed(t *testing.T) {
+	repo := newMockRepo()
+	repo.states["s"] = herdrSession(&session.Launcher{
+		TermProgram: "iTerm.app",
+		TTY:         "/dev/ttys012",
+	})
+
+	calls := 0
+	pm := newPIDManagerForTest(repo)
+	pm.SetLauncherEnvReader(func(int) *session.Launcher {
+		calls++
+		return &session.Launcher{TermProgram: "ghostty"}
+	})
+
+	pm.CheckPIDLiveness()
+
+	if calls != 0 {
+		t.Errorf("a non-herdr session must not be re-read by the sweep: %d reads", calls)
+	}
+	if repo.states["s"].Launcher.TermProgram != "iTerm.app" {
+		t.Errorf("non-herdr launcher was rewritten: %+v", repo.states["s"].Launcher)
+	}
+}
+
+// TestCheckPIDLiveness_HerdrSteadyStateDoesNotChurn pins the other half of the
+// cost argument: a session whose client has not moved must produce no Save and
+// therefore no UpdatedAt bump and no websocket push, however often the sweep
+// runs. Without this, a 5s timer would rewrite every herdr session forever —
+// and a bumped UpdatedAt on a `ready` session also defers its own TTL reap.
+func TestCheckPIDLiveness_HerdrSteadyStateDoesNotChurn(t *testing.T) {
+	repo := newMockRepo()
+	stored := &session.Launcher{
+		HerdrPaneID:     "w1:p1",
+		HerdrSocketPath: "/cfg/herdr/herdr.sock",
+		TermProgram:     "ghostty",
+		TTY:             "/dev/ttys077",
+	}
+	repo.states["s"] = herdrSession(stored)
+
+	pm := newPIDManagerForTest(repo)
+	pm.SetLauncherEnvReader(func(int) *session.Launcher {
+		cp := *stored
+		return &cp
+	})
+
+	before := repo.saves
+	pm.CheckPIDLiveness()
+	pm.CheckPIDLiveness()
+
+	if repo.saves != before {
+		t.Errorf("unchanged host still churned the repo: %d saves", repo.saves-before)
+	}
+}

--- a/core/application/services/pid_manager_herdr_refresh_test.go
+++ b/core/application/services/pid_manager_herdr_refresh_test.go
@@ -210,9 +210,18 @@ func TestCheckPIDLiveness_HerdrIgnoresAReadThatIsNoLongerThePane(t *testing.T) {
 
 	pm.CheckPIDLiveness()
 
+	// Asserted per field rather than as one disjunction: which field moved says
+	// which half of the adoption leaked (the term program, a kitty selector the
+	// pane never had, or the tab).
 	got := repo.states["s"].Launcher
-	if got.TermProgram != "ghostty" || got.KittyPID != 0 || got.TTY != "/dev/ttys077" {
-		t.Errorf("a read that is not this pane was adopted anyway: %+v", got)
+	if got.TermProgram != "ghostty" {
+		t.Errorf("the server's terminal was adopted: TermProgram = %q", got.TermProgram)
+	}
+	if got.KittyPID != 0 {
+		t.Errorf("a kitty selector the pane never had leaked in: KittyPID = %d", got.KittyPID)
+	}
+	if got.TTY != "/dev/ttys077" {
+		t.Errorf("the pane's tab was overwritten: TTY = %q", got.TTY)
 	}
 }
 


### PR DESCRIPTION
Closes #1405. Follow-up to #1350 (PR #1399).

## Root cause

Every other `session.Launcher` field describes something fixed for the life of
the agent process, so capturing it once when the PID is bound is correct. A
herdr pane's host is not — it belongs to whichever client is attached *right
now*, and detach-here-reattach-there is the entire point of a persistent
multiplexer.

#1350 stored that dynamic property as a capture-time snapshot. Two independent
gates each froze it:

| Gate | Where | Effect |
|---|---|---|
| `captureLauncher` is set-once (`state.Launcher != nil` → no-op) | `pid_manager.go:280` | a session bound while detached never picks up a client that attached later, except at seed |
| `launcherBackfillNeedsFor` required `TermProgram == "" && HostBundleID == ""` | `pid_manager.go:1294` | a host that *did* resolve was never re-checked, ever |

and `backfillLauncher` — the only thing that re-reads a launcher at all — runs
only from `SeedPIDs`, i.e. at daemon startup.

So: attach in iTerm → start the agent → detach → re-attach in Ghostty, and the
session names iTerm for the rest of its life, **across daemon restarts** (the
seed-time backfill's own precondition rejects it, because a host *is*
recorded). Clicking it raises the wrong window — the misroute class #1348 was
opened to remove, arriving by a slower route.

Both limits were already written down in `backfillLauncher`'s doc comment as
"deliberate for now". This replaces "documented" with "handled".

## Red first

Written before the fix existed, run against `main`:

```
$ go test ./core/application/services/ -run 'TestCheckPIDLiveness_Herdr|TestCheckPIDLiveness_NonHerdr' -count=1
--- FAIL: TestCheckPIDLiveness_HerdrHostRefreshedOnReattach (0.00s)
    pid_manager_herdr_refresh_test.go:65: host not refreshed on the sweep: TermProgram = "iTerm.app", want ghostty
    pid_manager_herdr_refresh_test.go:68: the previous client's iTerm selector survived the re-attach: &{TermProgram:iTerm.app ITermSessionID:w0t0p0-OLD TermSessionID: TmuxPane: TmuxSocket: VSCodePID:0 TTY:/dev/ttys012 KittyListenOn: KittyWindowID: KittyPID:0 HostBundleID: HerdrPaneID:w1:p1 HerdrSocketPath:/cfg/herdr/herdr.sock}
    pid_manager_herdr_refresh_test.go:71: TTY still names the old client's tab: "/dev/ttys012"
--- FAIL: TestCheckPIDLiveness_HerdrHostClearedOnDetach (0.00s)
    pid_manager_herdr_refresh_test.go:109: a detached session must report no host, not the last one: &{TermProgram:iTerm.app ITermSessionID:w0t0p0-OLD TermSessionID: TmuxPane: TmuxSocket: VSCodePID:0 TTY:/dev/ttys012 KittyListenOn: KittyWindowID: KittyPID:0 HostBundleID: HerdrPaneID:w1:p1 HerdrSocketPath:/cfg/herdr/herdr.sock}
FAIL
FAIL	irrlicht/core/application/services	0.405s
```

Both defect tests fail on `main` and pass with the fix.

### Mutation evidence for the checks this PR *adds*

#1482 landed on `main` mid-run and generalized the red-first rule: a check a
change **adds** has no "before the fix" to run against and owes a deliberate
mutation instead — explicitly including a lock the change itself adds, since
"passes by construction" is the reason the mutation is needed rather than an
exemption from it. Rebased onto it, and satisfied for all four:

| Test (added by this PR) | Mutation applied | Result |
|---|---|---|
| `TestCheckPIDLiveness_NonHerdrLauncherNotRefreshed` | dropped the `!snap.herdrPane` gate in `refreshHerdrHosts` | `a non-herdr session must not be re-read by the sweep: 1 reads` |
| `TestCheckPIDLiveness_HerdrSteadyStateDoesNotChurn` | made the herdr adoption always report a change | `unchanged host still churned the repo: 2 saves` |
| `TestLauncherBackfillNeedsFor_HerdrClientInKitty` | dropped the herdr early-return in `launcherBackfillNeedsFor` | `no kitty need may fire for a herdr pane: got {tty:true kittyPID:true kittyListen:true kittyWindow:true herdrHost:false}` |
| `TestCheckPIDLiveness_HerdrSubagentsShareOneRead` | dropped `memoizedLauncherEnv` | `4 sessions on one PID cost 4 reads, want 1` |

The rule prefers committing the mutation to describing it. There is no fixture
form available here: all four mutations perturb *production control flow*
(`pid_manager.go`), not an input a corpus could hold, so the evidence is a
transcript rather than a `testdata/` entry. Flagging that explicitly rather
than letting it read as an oversight.

**The two defect tests are red-first proper**, not mutations — they fail on
`main` as pasted above.

**Locks over pre-existing behavior** (no mutation owed — nothing new to prove
reaches anything): none in this PR; every lock here is one the change adds,
which is why all four are in the table.

## The fix

1. **`launcherBackfillNeedsFor` returns exactly one need for a herdr pane, and
   it is unconditional.** Both halves are load-bearing:
   - *Exactly one*, because a pane owns none of the host fields — they are
     adopted wholesale by `AdoptHostIdentity`, which already carries the kitty
     fields and the tty. Under the old rule the kitty needs and the herdr need
     were mutually exclusive **by coincidence** (`TermProgram` had to be both
     `""` and `"kitty"`). Dropping the precondition removes the coincidence,
     and a herdr pane whose *client* runs in kitty is exactly the shape that
     would then satisfy both — so the herdr branch returns before the kitty
     ones are computed. Otherwise the per-field kitty copies would run first
     and report an update for a client that never moved.
   - *Unconditional*, because "a host was already resolved" is not a reason to
     stop looking. That is the defect.
2. **`CheckPIDLiveness` ends with `refreshHerdrHosts(snaps)`**, gated on the
   *stored* launcher already being a herdr pane (a new `herdrPane bool` on
   `livenessSnapshot`, frozen under `assignMu` like every other snapshot
   field).
3. **A real change is pushed as `session_updated`.** `PIDManager` only ever
   broadcast `PushTypeDeleted` before. Without this the corrected host would
   reach a connected client only on the next *unrelated* activity push — and a
   session sitting idle in `ready`/`waiting` is precisely the one a user
   clicks, so it might never arrive.

**Placement, deliberately.** Resolving at focus time instead is the wrong
shape, as the issue argues: the macOS row tap (`SessionRowView` →
`SessionLauncher.jump`) reads state the app already holds and never
round-trips to the daemon. The sweep needs no click-path change at all.

**Concurrency.** The env read runs *outside* `assignMu` — `ReadLauncherEnv` is
documented to block up to 2s, and that lock serializes PID discovery for every
session. Only the merge is taken under `WithSessionStateLock`, as a
load-modify-save: the sweep's `livenessSnapshot.state` is a **deep copy**
(`cachedSessionRepository.ListAll` → `deepCopySessions`, "so callers can safely
mutate"), so writing through it would persist nothing. That is the same shape
`assignPIDLocked` already uses around its own load-modify-save, which is what
keeps a concurrent PID discovery from being clobbered. `refreshHerdrHosts` runs
**last** in the sweep, so a session reaped earlier in the same tick is already
gone and its `repo.Load` fails harmlessly rather than being written back out.

## Cost

The sweep is on a 5s ticker that backs off to 15s after three clean sweeps, so
this had to be measured rather than waved through. On this machine, under load
average 4.09:

| Probe | Cost | How often |
|---|---|---|
| `lsof <client log>` (find the attached client) | **178.9 ms** | once per herdr **socket** per sweep — memoized 5s per socket path, so N panes of one server cost one scan, not N |
| `ps -o tty= -p <pid>` (`processTTY`) | **2.1 ms** | once per herdr **PID** per sweep — memoized per pass, so a parent and its subagents (which share a PID) cost one read, not one each |
| `sysctl(kern.procargs2)` env read | µs, in-process | once per herdr session per sweep |
| process-ancestry walk (the `ps` shellout chain) | — | **never** for a herdr pane: `hostIdentity` skips it by construction when `HerdrPaneID != ""`. This is the expensive part of the non-herdr path. |

One herdr server with eight panes ≈ `179 + 8×2.1` ≈ **200 ms per sweep**:
~4% of one core at the 5s interval, ~1.3% at the 15s backoff — and idle is
exactly when it backs off, which is also exactly when a user re-attaches.

**A machine running no herdr sessions adds nothing at all.** The gate is a bool
already on the snapshot; `pm.launcherEnv` is never called. That is the
important number, since herdr users are the rare case.

**No steady-state churn.** `applyLauncherBackfill` reports no change when the
client has not moved, so an unmoved session produces no `Save`, no `UpdatedAt`
bump and no push — pinned by
`TestCheckPIDLiveness_HerdrSteadyStateDoesNotChurn`. The `UpdatedAt` half
matters beyond noise: `UpdatedAt` drives the `readyTTL` reap, so a refresh that
touched it every tick would keep idle sessions alive forever.

**Cheaper triggers considered and rejected.** "Only re-resolve when the
previously-resolved client is gone" needs the client's PID, which is not stored
(`AdoptHostIdentity` copies host *fields*, not the process it read them from) —
so establishing "is it gone" costs the same `lsof` as just re-resolving. A
minimum re-resolve interval independent of the ticker would add per-session
timestamp state for a saving the 15s backoff already delivers; disproportionate
for a `Priority-Low` ticket.

## Review round

One `medium`-effort review subagent (`ir:code-review`). Five findings; four
acted on, one filed rather than fixed, one escalation refuted with evidence.

**Fixed, each seen red before its fix** (second commit — the failure output is
in that commit message):

1. **A read that is no longer the pane was adopted anyway.** The refresh decides
   "herdr pane" from the *stored* launcher, but the PID it reads may not be that
   pane: PID reuse, or `assignPIDLocked` re-binding a session to a new PID while
   set-once `captureLauncher` keeps the old `Launcher` (the `--bg-spare` re-bind
   of #727). Such a read has no `HERDR_PANE_ID`, so `hostIdentity` runs the
   ancestry fallbacks, resolves the herdr *server's* terminal, and
   `AdoptHostIdentity` copies it wholesale — re-creating the #1348 misroute **on
   a timer**. Now requires `fresh.HerdrPaneID == state.Launcher.HerdrPaneID`.
   This was the most valuable finding: the PR as first written made the misroute
   recurrent rather than one-shot.
2. **The `tty` need must stay for a herdr launcher.** My comment claimed the
   adoption "already carries the kitty fields and the tty". Not the tty —
   `AdoptHostIdentity` deliberately refuses to move the client's tty onto a pane
   that has none (`BackgroundAgent.Detached` derives from it, #744). A herdr
   launcher stored without a tty had no remaining route to acquiring one.
3. **One read per PID per sweep.** Subagents share the parent's PID and each
   carries its own herdr launcher, so a parent with three subagents paid four
   identical `ps`-backed reads every sweep. `memoizedLauncherEnv` is per-pass
   and deliberately not a field — the refresh exists to observe change *between*
   sweeps.
4. `HerdrSteadyStateDoesNotChurn` asserted only "no Save", which "never visited
   the session" satisfies as well as "visited and declined to write". It now
   counts reads too, and says out loud that it is a lock.

**Filed, not fixed → #1485.** `herdrClientPIDs` cannot tell "nothing attached"
from "the probe failed" — it returns `nil` on any `exec` error, though only
lsof's exit 1 means "ran, found nothing" (measured: no-openers → 1, nonexistent
→ 1, killed → 152, deadline → not an `ExitError`). Before this PR a failed probe
was a harmless no-op, because the host was write-once-if-empty; now it *clears*
a good host for one sweep. The clean fix needs a tri-state propagated up to
`ReadLauncherEnv`, whose only "unknown" spelling without widening the
`LauncherEnvReader` port is `nil` — and `nil` at *capture* time loses the herdr
address, and with it backchannel routing, until the next daemon restart. That
is worse than the 5–15s window it removes, so it is a design decision, not a
guard. Harm as it stands: click-to-focus reports "no attached client" for up to
one sweep interval, then self-heals; two extra pushes.

**Escalation refuted.** The review argued the same flap would defeat the
`readyTTL` reap by bumping `UpdatedAt` faster than the 30m TTL, keeping idle
herdr sessions alive forever. It cannot: `sweepStaleSnapshot` returns at
`if snap.pid > 0 && syscall.Kill(snap.pid, 0) == nil`, and `refreshHerdrHosts`
only touches `snap.pid > 0` sessions — which `reapDeadOrInfraPID` has already
cleared of dead PIDs earlier in the same sweep. A live-PID session is exempt
from the TTL reap regardless of `UpdatedAt`, so there is no reap to defer. (The
`UpdatedAt`-churn argument in `refreshHerdrHosts`' own doc comment was
correspondingly overstated and has been trimmed to what holds.)

**Cleared by the reviewer, worth recording:** consent gating (the reader is
per-call gated at `startup.go:773`, so a pending/revoked launcher permission
short-circuits the refresh via `fresh == nil` and can never destroy a stored
host); hexagonal layering; the "runs last" ordering claim; `BackgroundAgent.Detached`
cannot go stale (`AdoptHostIdentity` can never move `TTY` between empty and
non-empty).

**Declined:** raising `herdrClientCacheTTL` from 5s to the 15s backed-off sweep
interval. It would save one lsof per sweep but the TTL is what bounds
re-attach detection latency — the thing this PR exists to shorten. Trading the
feature's responsiveness for ~180ms per 15s is the wrong direction.

## Verification

`tools/preflight.sh`, chunked, all green: `go` (core suite incl. `-race`,
onboarding-factory, replaydata validate, recording-rig smoke, replay fixtures,
starhistory), `arch` (ARS 7.9441 → 7.9440, no category regression), `tools`,
`skills`, `posix`, `security`. `--only web` skipped: zero web files touched;
`web-test.yml` covers it here.

`go test ./core/... -race -count=1` → all 58 packages `ok`, no failures. The
pre-push hook's `tools/preflight.sh --changed` is green on the final head.

**Not done: the live detach/re-attach cycle against herdr 0.8.0** that the
issue's Verification section asks for. herdr is not installed in this
environment and the click-to-focus half is macOS-GUI-observable only. The unit
half of that ask — "a herdr launcher with a stale host is refreshed while a
non-herdr one is still left alone" — is `TestCheckPIDLiveness_HerdrHostRefreshedOnReattach`
plus `TestCheckPIDLiveness_NonHerdrLauncherNotRefreshed`. The live cycle is
worth running before merge by someone with herdr to hand.

## Follow-up: the same shape, unfixed, for tmux → #1486

Reported rather than fixed, per this repo's no-scope-creep convention.

`launcherFromEnv` early-returns for `HERDR_PANE_ID` — a herdr pane keeps *only*
its own address, because everything else in that environment describes the
herdr server's launch environment. **tmux gets no such treatment**: a tmux
pane's `TERM_PROGRAM` is read straight from the pane's own env alongside
`TMUX_PANE`, and tmux's server has the same architecture herdr's does —
detached, outliving its clients, handing every pane the environment it was
started in. `session.Launcher`'s own doc names `$TMUX` and `$TMUX_PANE` in the
list of vars that are "frozen at that moment and handed to every pane it will
ever spawn". Control is unaffected (`send-keys` routes by `TmuxPane`, which is
stable); focus is not.

⚠ **This is reasoned from code, not live-verified.** I attempted a live probe
(tmux 3.6a, a server started with a synthetic `TERM_PROGRAM`, re-attached from
a second client with a different one, reading the pane process through the
daemon's own `ReadLauncherEnv`) and it came back **inconclusive**: the sysctl
env read returned empty for the tmux pane process on this machine, so the
frozen value could not be observed directly. Treat #1486 as a
hypothesis to verify, not an established defect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
