### PR TITLE
test(contracttesting): make AssertPermissionGated key-aware

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -209,27 +209,34 @@ Before marking a ticket done, run the full suite — every layer must pass:
   shapes it covers.
   A wiring names the permission under test (`Key`) and at least one the call
   site must NOT be gated on (`OtherKeys`), and `SetState` takes the key it is
-  driving — because until #1475 it did not, and every adapter supplied a gate
-  shaped `func(_, _ string) bool` that discarded the key. One permission moved
-  through three states says only that a call site is gated on *something*: a
-  receiver gated on the WRONG permission answers identically, and that is not
-  hypothetical — claudecode's hook receiver read transcripts with
-  `transcripts` denied for the whole of its life (#1466) while this contract
-  was wired at that receiver and green. The fourth arm holds `Key` denied while
-  `OtherKeys` are granted, the one state that tells those apart, and it denies
-  `Key` **first**: a wiring that still ignored its key would end up holding
-  everything granted and fail, where the reverse order would let it settle at
-  "denied" and pass. Use `contracttesting.ConsentGate` for a live per-request
-  gate rather than a local fake — three adapters had re-invented the same
-  `map[string]bool` after #1466, and a contract whose wiring supplies the fake
-  is a contract whose wiring can supply a key-blind one. The arm is
+  driving — because until #1475 it did not, and every live-gate wiring supplied
+  a `Granted(_, _ string) bool` fake that discarded the key. One permission
+  moved through three states says only that a call site is gated on
+  *something*: a receiver gated on the WRONG permission answers identically,
+  and that is not hypothetical — claudecode's hook receiver read transcripts
+  with `transcripts` denied for the whole of its life (#1466) while this
+  contract was wired at that receiver and green. The fourth arm holds `Key`
+  denied while `OtherKeys` are granted, the one state that tells those apart,
+  and it denies `Key` **first**: a wiring that still ignored its key would end
+  up holding everything granted and fail, where the reverse order would let it
+  settle at "denied" and pass. Use `contracttesting.ConsentGate` for a live
+  per-request gate rather than a local fake — it replaces the three key-blind
+  mutable fakes those wirings had each grown (claudecode's and codex's
+  `mutableGate`, the services layer's `mutableConsent`), because a contract
+  whose wiring supplies the fake is a contract whose wiring can supply a
+  key-blind one. The static `keyedGate` map literals in the adapter test
+  packages are a different thing and stay: they pin a fixed two-permission
+  combination in one-off tests and were never key-blind. The arm is
   load-bearing only for live per-request gates; for an install-type permission
   the wiring holds that permission's own closures, so a wrong key is not
-  representable and the arm is weak by construction — documented in the doc
-  comment rather than made an opt-out a live-gate adapter could also reach for.
-  It makes the obligation *assertable*, not unforgettable: a receiver still has
-  to be wired once per permission it must honour (#1488 is the chokepoint move
-  that would remove that remaining act of memory).
+  representable and the arm is weak by construction — and where the other key
+  has no closure at all (an observe-kind sibling, a single-permission
+  declaration) it is inert and repeats the revoked arm, which those three call
+  sites say out loud. It is kept uniform with no opt-out anyway, because a flag
+  an install-type wiring could take is one a live-gate wiring could take too.
+  All of which makes the obligation *assertable*, not unforgettable: a receiver
+  still has to be wired once per permission it must honour (#1488 is the
+  chokepoint move that would remove that remaining act of memory).
 - Hook endpoints: `contracttesting.AssertHookEndpointFollowsBindAddr`
   (`core/internal/contracttesting/hook_endpoint.go`) is the same kind of
   runtime obligation for adapters that install hooks into a JSON config —

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -522,7 +522,12 @@ Before marking a ticket done, run the full suite — every layer must pass:
   longer installs hooks** — that was the damage, not a regression.
   All seven contract families pass by construction against a correct adapter —
   or, for a delivery route no adapter has adopted yet, against its reference
-  wiring — so their whole value is that they *can* fail. A new or reworked
+  wiring — so their whole value is that they *can* fail. Seven is a count of
+  *obligations*, not of exported `Assert…` functions: `grep -c "^func Assert"`
+  over the package currently returns eight, because
+  `AssertPermissionGatedOnEachKey` is a driver that runs the permission-gate
+  family once per key, not a family of its own. Check what a function asserts
+  before moving this number. A new or reworked
   contract assertion is therefore the mutation rule at the top of this section
   in its most literal form: it lands with the deliberate mutation seen red for
   each obligation. That evidence currently lives in the PR body, where nothing

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -207,6 +207,29 @@ Before marking a ticket done, run the full suite — every layer must pass:
   kitty remote-control (install-type `Apply`/`Remove`), and `InputService`'s
   backchannel forwarding (the shared "control" gate) for the three call-site
   shapes it covers.
+  A wiring names the permission under test (`Key`) and at least one the call
+  site must NOT be gated on (`OtherKeys`), and `SetState` takes the key it is
+  driving — because until #1475 it did not, and every adapter supplied a gate
+  shaped `func(_, _ string) bool` that discarded the key. One permission moved
+  through three states says only that a call site is gated on *something*: a
+  receiver gated on the WRONG permission answers identically, and that is not
+  hypothetical — claudecode's hook receiver read transcripts with
+  `transcripts` denied for the whole of its life (#1466) while this contract
+  was wired at that receiver and green. The fourth arm holds `Key` denied while
+  `OtherKeys` are granted, the one state that tells those apart, and it denies
+  `Key` **first**: a wiring that still ignored its key would end up holding
+  everything granted and fail, where the reverse order would let it settle at
+  "denied" and pass. Use `contracttesting.ConsentGate` for a live per-request
+  gate rather than a local fake — three adapters had re-invented the same
+  `map[string]bool` after #1466, and a contract whose wiring supplies the fake
+  is a contract whose wiring can supply a key-blind one. The arm is
+  load-bearing only for live per-request gates; for an install-type permission
+  the wiring holds that permission's own closures, so a wrong key is not
+  representable and the arm is weak by construction — documented in the doc
+  comment rather than made an opt-out a live-gate adapter could also reach for.
+  It makes the obligation *assertable*, not unforgettable: a receiver still has
+  to be wired once per permission it must honour (#1488 is the chokepoint move
+  that would remove that remaining act of memory).
 - Hook endpoints: `contracttesting.AssertHookEndpointFollowsBindAddr`
   (`core/internal/contracttesting/hook_endpoint.go`) is the same kind of
   runtime obligation for adapters that install hooks into a JSON config —

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -226,7 +226,14 @@ Before marking a ticket done, run the full suite — every layer must pass:
   whose wiring supplies the fake is a contract whose wiring can supply a
   key-blind one. The static `keyedGate` map literals in the adapter test
   packages are a different thing and stay: they pin a fixed two-permission
-  combination in one-off tests and were never key-blind. The arm is
+  combination in one-off tests and were never key-blind. A receiver gated on
+  more than one permission wires `AssertPermissionGatedOnEachKey` rather than a
+  hand-written table pairing each key with "the other one" — it names its key
+  set once and the pairing is derived, because such a table can silently list
+  only one direction and the direction that already works is
+  indistinguishable from covering both. Install-type wirings use
+  `contracttesting.OnlyKey` instead of re-deciding per adapter that a foreign
+  key is a no-op. The arm is
   load-bearing only for live per-request gates; for an install-type permission
   the wiring holds that permission's own closures, so a wrong key is not
   representable and the arm is weak by construction — and where the other key

--- a/core/adapters/inbound/agents/claudecode/hooks_test.go
+++ b/core/adapters/inbound/agents/claudecode/hooks_test.go
@@ -8,7 +8,6 @@ import (
 	"sync"
 	"testing"
 
-	"irrlicht/core/domain/permission"
 	"irrlicht/core/domain/session"
 	"irrlicht/core/internal/contracttesting"
 )
@@ -542,26 +541,6 @@ type fakeGate bool
 
 func (g fakeGate) Granted(_, _ string) bool { return bool(g) }
 
-// mutableGate is a ConsentGranter whose answer can change between calls —
-// needed to drive a single handler instance through all three consent
-// states for contracttesting.AssertPermissionGated.
-type mutableGate struct {
-	mu      sync.Mutex
-	granted bool
-}
-
-func (g *mutableGate) Granted(_, _ string) bool {
-	g.mu.Lock()
-	defer g.mu.Unlock()
-	return g.granted
-}
-
-func (g *mutableGate) setGranted(v bool) {
-	g.mu.Lock()
-	g.granted = v
-	g.mu.Unlock()
-}
-
 // keyedGate is a ConsentGranter that answers per permission key, so a test can
 // grant one of this adapter's permissions while denying another. The gates
 // above deliberately ignore the key, which is why neither of them can tell a
@@ -786,31 +765,48 @@ func TestHookHandler_PreToolUse_UserInputToolStillDispatchesWithMarkerScan(t *te
 	}
 }
 
-// TestHookHandler_PermissionGateContract wires the hooks permission's live
-// per-request ConsentGranter check into the shared issue #797 contract: while
-// PermissionKeyHooks is pending or denied, an inbound hook payload must
+// TestHookHandler_PermissionGateContract wires this receiver's live
+// per-request ConsentGranter checks into the shared issue #797 contract: while
+// the permission under test is pending or denied, an inbound hook payload must
 // dispatch to nothing; granted, it must dispatch; revoked, dispatch must
 // stop again. TestHookHandler_ConsentGateDropsWhenNotGranted /
 // ConsentGatePassesWhenGranted above cover the same call site by hand —
 // this is the generalized, three-state version.
+//
+// It runs once per permission this receiver must honour. Both are needed and
+// neither subsumes the other: "hooks" authorises writing our entries into
+// settings.json, "transcripts" authorises reading the file those entries point
+// at, and the contract's key-isolation arm holds one denied while the other is
+// granted (issue #1475). A single wiring over a key-blind gate is what let
+// this receiver dispatch with "transcripts" denied for the whole of its life
+// (issue #1466) while this very test was green.
 func TestHookHandler_PermissionGateContract(t *testing.T) {
-	target := &mockTarget{}
-	gate := &mutableGate{}
-	handler := NewHookHandler(target, nil, gate, mockLogger{})
-	payload := hookPayload{
-		TranscriptPath: inTreeTranscript(t, "sess-gate"),
-		HookEventName:  "PermissionRequest",
-		ToolName:       "Bash",
-	}
+	for _, tc := range []struct{ key, other string }{
+		{PermissionKeyHooks, PermissionKeyTranscripts},
+		{PermissionKeyTranscripts, PermissionKeyHooks},
+	} {
+		t.Run(tc.key, func(t *testing.T) {
+			target := &mockTarget{}
+			gate := contracttesting.NewConsentGate()
+			handler := NewHookHandler(target, nil, gate, mockLogger{})
+			payload := hookPayload{
+				TranscriptPath: inTreeTranscript(t, "sess-gate"),
+				HookEventName:  "PermissionRequest",
+				ToolName:       "Bash",
+			}
 
-	contracttesting.AssertPermissionGated(t, contracttesting.PermissionGate{
-		SetState: func(state permission.State) { gate.setGranted(state == permission.StateGranted) },
-		Exercise: func() {
-			target.reset()
-			postHook(t, handler, payload)
-		},
-		Observe: func() bool { return len(target.getCalls()) > 0 },
-	})
+			contracttesting.AssertPermissionGated(t, contracttesting.PermissionGate{
+				Key:       tc.key,
+				OtherKeys: []string{tc.other},
+				SetState:  gate.SetState,
+				Exercise: func() {
+					target.reset()
+					postHook(t, handler, payload)
+				},
+				Observe: func() bool { return len(target.getCalls()) > 0 },
+			})
+		})
+	}
 }
 
 // TestHookHandler_TranscriptsConsentGatesTheRead is the issue #1466 defect
@@ -831,10 +827,14 @@ func TestHookHandler_PermissionGateContract(t *testing.T) {
 // user should not have hooks failing at them. The dispatch assertion is what
 // carries this test.
 //
-// It cannot be folded into TestHookHandler_PermissionGateContract above:
-// that contract drives ONE permission through three states via mutableGate,
-// which ignores the key it is passed and so answers identically for both.
-// Two permissions held at opposite states is exactly what it cannot express.
+// It stays as a LOCK now that the contract above is key-aware (issue #1475).
+// The contract's key-isolation arm covers the dispatch obligation generically
+// — and covers it for every adapter that wires it, which three hand-written
+// per-adapter tests never could. What it does not cover is the status code:
+// AssertPermissionGated's Exercise is opaque to it, so the 200 asserted below
+// is this test's own. Per #1450 a rewritten guard replays its predecessor's
+// cases or it is not known to be a superset; this one is not a superset, so
+// the predecessor stays.
 func TestHookHandler_TranscriptsConsentGatesTheRead(t *testing.T) {
 	target := &mockTarget{}
 	gate := keyedGate{PermissionKeyHooks: true, PermissionKeyTranscripts: false}

--- a/core/adapters/inbound/agents/claudecode/hooks_test.go
+++ b/core/adapters/inbound/agents/claudecode/hooks_test.go
@@ -542,9 +542,13 @@ type fakeGate bool
 func (g fakeGate) Granted(_, _ string) bool { return bool(g) }
 
 // keyedGate is a ConsentGranter that answers per permission key, so a test can
-// grant one of this adapter's permissions while denying another. The gates
-// above deliberately ignore the key, which is why neither of them can tell a
-// receiver gated on "hooks" from one gated on "transcripts" (issue #1466).
+// grant one of this adapter's permissions while denying another. fakeGate
+// above deliberately ignores the key, which is why it cannot tell a receiver
+// gated on "hooks" from one gated on "transcripts" (issue #1466).
+//
+// For a MUTABLE keyed gate — one driven through states by the shared contract
+// — use contracttesting.ConsentGate instead. This type is for pinning a fixed
+// combination in a one-off test, which is all it has ever been used for.
 type keyedGate map[string]bool
 
 func (g keyedGate) Granted(_, key string) bool { return g[key] }
@@ -781,11 +785,10 @@ func TestHookHandler_PreToolUse_UserInputToolStillDispatchesWithMarkerScan(t *te
 // this receiver dispatch with "transcripts" denied for the whole of its life
 // (issue #1466) while this very test was green.
 func TestHookHandler_PermissionGateContract(t *testing.T) {
-	for _, tc := range []struct{ key, other string }{
-		{PermissionKeyHooks, PermissionKeyTranscripts},
-		{PermissionKeyTranscripts, PermissionKeyHooks},
-	} {
-		t.Run(tc.key, func(t *testing.T) {
+	keys := []string{PermissionKeyHooks, PermissionKeyTranscripts}
+
+	contracttesting.AssertPermissionGatedOnEachKey(t, keys,
+		func(key string, others []string) contracttesting.PermissionGate {
 			target := &mockTarget{}
 			gate := contracttesting.NewConsentGate()
 			handler := NewHookHandler(target, nil, gate, mockLogger{})
@@ -795,18 +798,17 @@ func TestHookHandler_PermissionGateContract(t *testing.T) {
 				ToolName:       "Bash",
 			}
 
-			contracttesting.AssertPermissionGated(t, contracttesting.PermissionGate{
-				Key:       tc.key,
-				OtherKeys: []string{tc.other},
+			return contracttesting.PermissionGate{
+				Key:       key,
+				OtherKeys: others,
 				SetState:  gate.SetState,
 				Exercise: func() {
 					target.reset()
 					postHook(t, handler, payload)
 				},
 				Observe: func() bool { return len(target.getCalls()) > 0 },
-			})
+			}
 		})
-	}
 }
 
 // TestHookHandler_TranscriptsConsentGatesTheRead is the issue #1466 defect

--- a/core/adapters/inbound/agents/claudecode/instructioninstaller_test.go
+++ b/core/adapters/inbound/agents/claudecode/instructioninstaller_test.go
@@ -548,18 +548,26 @@ func findPermission(t *testing.T, a agent.Agent, key string) agent.Permission {
 func TestInstructionsPermission_GateContract(t *testing.T) {
 	home := withTempHome(t)
 	path := memoryPathFor(home)
-	decl := findPermission(t, Agent(), PermissionKeyInstructions)
 
 	contracttesting.AssertPermissionGated(t, contracttesting.PermissionGate{
-		SetState: func(state permission.State) {
+		Key: PermissionKeyInstructions,
+		// The hooks permission writes a different user file (settings.json)
+		// from the same adapter, so the key-isolation arm grants it while
+		// instructions is denied and confirms CLAUDE.md stays untouched.
+		OtherKeys: []string{PermissionKeyHooks},
+		SetState: func(key string, state permission.State) {
+			// Dispatch through the declaration rather than closing over one
+			// permission's closures: an arm that hands this a key it ignored
+			// would be the key-blind wiring issue #1475 exists to reject.
+			decl := findPermission(t, Agent(), key)
 			switch state {
 			case permission.StateGranted:
 				if err := decl.Apply(); err != nil {
-					t.Fatalf("Apply: %v", err)
+					t.Fatalf("Apply %s: %v", key, err)
 				}
 			case permission.StateDenied:
 				if err := decl.Remove(); err != nil {
-					t.Fatalf("Remove: %v", err)
+					t.Fatalf("Remove %s: %v", key, err)
 				}
 			}
 			// Pending: PermissionService never invokes Apply/Remove until

--- a/core/adapters/inbound/agents/claudecode/instructioninstaller_test.go
+++ b/core/adapters/inbound/agents/claudecode/instructioninstaller_test.go
@@ -1,6 +1,7 @@
 package claudecode
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -525,17 +526,27 @@ func TestRemoveInstructionBlocks_RoundTripsToOriginal(t *testing.T) {
 	}
 }
 
+// lookupPermission returns the declared permission matching key. Separate from
+// findPermission because a caller running inside a subtest cannot use the
+// latter's t.Fatalf — see TestInstructionsPermission_GateContract.
+func lookupPermission(a agent.Agent, key string) (agent.Permission, bool) {
+	for _, p := range a.Permissions {
+		if p.Key == key {
+			return p, true
+		}
+	}
+	return agent.Permission{}, false
+}
+
 // findPermission returns the declared permission matching key, failing the
 // test if the adapter dropped or renamed it.
 func findPermission(t *testing.T, a agent.Agent, key string) agent.Permission {
 	t.Helper()
-	for _, p := range a.Permissions {
-		if p.Key == key {
-			return p
-		}
+	p, ok := lookupPermission(a, key)
+	if !ok {
+		t.Fatalf("no permission %q declared by %s", key, a.Identity.Name)
 	}
-	t.Fatalf("no permission %q declared by %s", key, a.Identity.Name)
-	return agent.Permission{}
+	return p
 }
 
 // TestInstructionsPermission_GateContract drives the real Apply/Remove
@@ -549,6 +560,11 @@ func TestInstructionsPermission_GateContract(t *testing.T) {
 	home := withTempHome(t)
 	path := memoryPathFor(home)
 
+	// SetState runs inside the contract's arm subtests, so a t.Fatalf there
+	// would call FailNow on a parent test from a child goroutine — go test
+	// reports that panic instead of the real reason. Capture and assert after.
+	var driveErr error
+
 	contracttesting.AssertPermissionGated(t, contracttesting.PermissionGate{
 		Key: PermissionKeyInstructions,
 		// The hooks permission writes a different user file (settings.json)
@@ -559,15 +575,19 @@ func TestInstructionsPermission_GateContract(t *testing.T) {
 			// Dispatch through the declaration rather than closing over one
 			// permission's closures: an arm that hands this a key it ignored
 			// would be the key-blind wiring issue #1475 exists to reject.
-			decl := findPermission(t, Agent(), key)
+			decl, ok := lookupPermission(Agent(), key)
+			if !ok {
+				driveErr = fmt.Errorf("no permission %q declared by %s", key, AdapterName)
+				return
+			}
 			switch state {
 			case permission.StateGranted:
 				if err := decl.Apply(); err != nil {
-					t.Fatalf("Apply %s: %v", key, err)
+					driveErr = fmt.Errorf("Apply %s: %w", key, err)
 				}
 			case permission.StateDenied:
 				if err := decl.Remove(); err != nil {
-					t.Fatalf("Remove %s: %v", key, err)
+					driveErr = fmt.Errorf("Remove %s: %w", key, err)
 				}
 			}
 			// Pending: PermissionService never invokes Apply/Remove until
@@ -582,4 +602,8 @@ func TestInstructionsPermission_GateContract(t *testing.T) {
 			return strings.Contains(string(data), taskEtaBeginSentinel)
 		},
 	})
+
+	if driveErr != nil {
+		t.Fatalf("driving a permission to a state failed: %v", driveErr)
+	}
 }

--- a/core/adapters/inbound/agents/claudecode/instructioninstaller_test.go
+++ b/core/adapters/inbound/agents/claudecode/instructioninstaller_test.go
@@ -1,7 +1,6 @@
 package claudecode
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -526,27 +525,17 @@ func TestRemoveInstructionBlocks_RoundTripsToOriginal(t *testing.T) {
 	}
 }
 
-// lookupPermission returns the declared permission matching key. Separate from
-// findPermission because a caller running inside a subtest cannot use the
-// latter's t.Fatalf — see TestInstructionsPermission_GateContract.
-func lookupPermission(a agent.Agent, key string) (agent.Permission, bool) {
-	for _, p := range a.Permissions {
-		if p.Key == key {
-			return p, true
-		}
-	}
-	return agent.Permission{}, false
-}
-
 // findPermission returns the declared permission matching key, failing the
 // test if the adapter dropped or renamed it.
 func findPermission(t *testing.T, a agent.Agent, key string) agent.Permission {
 	t.Helper()
-	p, ok := lookupPermission(a, key)
-	if !ok {
-		t.Fatalf("no permission %q declared by %s", key, a.Identity.Name)
+	for _, p := range a.Permissions {
+		if p.Key == key {
+			return p
+		}
 	}
-	return p
+	t.Fatalf("no permission %q declared by %s", key, a.Identity.Name)
+	return agent.Permission{}
 }
 
 // TestInstructionsPermission_GateContract drives the real Apply/Remove
@@ -560,10 +549,15 @@ func TestInstructionsPermission_GateContract(t *testing.T) {
 	home := withTempHome(t)
 	path := memoryPathFor(home)
 
-	// SetState runs inside the contract's arm subtests, so a t.Fatalf there
-	// would call FailNow on a parent test from a child goroutine — go test
-	// reports that panic instead of the real reason. Capture and assert after.
-	var driveErr error
+	// Resolved out here, on the main goroutine, because findPermission fails
+	// with t.Fatalf and SetState below runs inside the contract's arm
+	// subtests — a FailNow from there is a FailNow on a parent test from a
+	// child goroutine, which go test reports as a panic instead of the real
+	// reason. Inside SetState only t.Errorf is used, which is goroutine-safe.
+	decls := map[string]agent.Permission{
+		PermissionKeyInstructions: findPermission(t, Agent(), PermissionKeyInstructions),
+		PermissionKeyHooks:        findPermission(t, Agent(), PermissionKeyHooks),
+	}
 
 	contracttesting.AssertPermissionGated(t, contracttesting.PermissionGate{
 		Key: PermissionKeyInstructions,
@@ -573,21 +567,21 @@ func TestInstructionsPermission_GateContract(t *testing.T) {
 		OtherKeys: []string{PermissionKeyHooks},
 		SetState: func(key string, state permission.State) {
 			// Dispatch through the declaration rather than closing over one
-			// permission's closures: an arm that hands this a key it ignored
-			// would be the key-blind wiring issue #1475 exists to reject.
-			decl, ok := lookupPermission(Agent(), key)
+			// permission's closures: a wiring that ignored the key it is
+			// handed is what issue #1475 exists to reject.
+			decl, ok := decls[key]
 			if !ok {
-				driveErr = fmt.Errorf("no permission %q declared by %s", key, AdapterName)
+				t.Errorf("contract drove an unexpected key %q", key)
 				return
 			}
 			switch state {
 			case permission.StateGranted:
 				if err := decl.Apply(); err != nil {
-					driveErr = fmt.Errorf("Apply %s: %w", key, err)
+					t.Errorf("Apply %s: %v", key, err)
 				}
 			case permission.StateDenied:
 				if err := decl.Remove(); err != nil {
-					driveErr = fmt.Errorf("Remove %s: %w", key, err)
+					t.Errorf("Remove %s: %v", key, err)
 				}
 			}
 			// Pending: PermissionService never invokes Apply/Remove until
@@ -602,8 +596,4 @@ func TestInstructionsPermission_GateContract(t *testing.T) {
 			return strings.Contains(string(data), taskEtaBeginSentinel)
 		},
 	})
-
-	if driveErr != nil {
-		t.Fatalf("driving a permission to a state failed: %v", driveErr)
-	}
 }

--- a/core/adapters/inbound/agents/claudecode/statusline_test.go
+++ b/core/adapters/inbound/agents/claudecode/statusline_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 	"time"
 
-	"irrlicht/core/domain/permission"
 	"irrlicht/core/domain/session"
 	"irrlicht/core/internal/contracttesting"
 )
@@ -296,7 +295,7 @@ func TestStatuslineHandler_ConsentGateDropsWhenNotGranted(t *testing.T) {
 // revoked.
 func TestStatuslineHandler_PermissionGateContract(t *testing.T) {
 	target := &fakeRateLimitIngester{}
-	gate := &mutableGate{}
+	gate := contracttesting.NewConsentGate()
 	h := NewStatuslineHandler(target, gate, silentLogger{})
 	body := `{
 		"session_id": "abc",
@@ -307,7 +306,14 @@ func TestStatuslineHandler_PermissionGateContract(t *testing.T) {
 	}`
 
 	contracttesting.AssertPermissionGated(t, contracttesting.PermissionGate{
-		SetState: func(state permission.State) { gate.setGranted(state == permission.StateGranted) },
+		Key: PermissionKeyStatusline,
+		// This endpoint is a hook receiver too, so the two permissions it must
+		// NOT be gated on are the ones a copy-paste from hooks.go would reach
+		// for. It owes no transcripts consent of its own: the transcript path
+		// it forwards is used as a map key by metrics.IngestRateLimit, never
+		// opened (issue #1466 is about the READ, and there is none here).
+		OtherKeys: []string{PermissionKeyHooks, PermissionKeyTranscripts},
+		SetState:  gate.SetState,
 		Exercise: func() {
 			target.reset()
 			req := httptest.NewRequest(http.MethodPost, "/api/v1/hooks/claudecode/statusline", strings.NewReader(body))

--- a/core/adapters/inbound/agents/codex/hookinstaller_test.go
+++ b/core/adapters/inbound/agents/codex/hookinstaller_test.go
@@ -173,9 +173,12 @@ func TestHooksPermission_InstallGateContract(t *testing.T) {
 
 	contracttesting.AssertPermissionGated(t, contracttesting.PermissionGate{
 		Key: PermissionKeyHooks,
-		// transcripts is the adapter's other declared permission and is
-		// observe-kind — it carries no Apply/Remove, so granting it must leave
-		// hooks.json untouched while hooks itself is denied.
+		// transcripts is the adapter's only other declared permission and is
+		// observe-kind, so it has no closure to drive: the key-isolation arm is
+		// INERT here and repeats the revoked arm exactly. Install-type wirings
+		// hold their own permission's closures, so a wrong key is not
+		// representable — the arm is load-bearing at the live receiver
+		// (hooks_test.go), not here.
 		OtherKeys: []string{PermissionKeyTranscripts},
 		SetState: func(key string, state permission.State) {
 			if key != PermissionKeyHooks {

--- a/core/adapters/inbound/agents/codex/hookinstaller_test.go
+++ b/core/adapters/inbound/agents/codex/hookinstaller_test.go
@@ -172,7 +172,15 @@ func TestHooksPermission_InstallGateContract(t *testing.T) {
 	t.Setenv(codexHomeEnvVar, home)
 
 	contracttesting.AssertPermissionGated(t, contracttesting.PermissionGate{
-		SetState: func(state permission.State) {
+		Key: PermissionKeyHooks,
+		// transcripts is the adapter's other declared permission and is
+		// observe-kind — it carries no Apply/Remove, so granting it must leave
+		// hooks.json untouched while hooks itself is denied.
+		OtherKeys: []string{PermissionKeyTranscripts},
+		SetState: func(key string, state permission.State) {
+			if key != PermissionKeyHooks {
+				return // no install effect of its own to drive
+			}
 			var err error
 			if state == permission.StateGranted {
 				_, err = EnsureHooksInstalled()

--- a/core/adapters/inbound/agents/codex/hookinstaller_test.go
+++ b/core/adapters/inbound/agents/codex/hookinstaller_test.go
@@ -180,10 +180,7 @@ func TestHooksPermission_InstallGateContract(t *testing.T) {
 		// representable — the arm is load-bearing at the live receiver
 		// (hooks_test.go), not here.
 		OtherKeys: []string{PermissionKeyTranscripts},
-		SetState: func(key string, state permission.State) {
-			if key != PermissionKeyHooks {
-				return // no install effect of its own to drive
-			}
+		SetState: contracttesting.OnlyKey(PermissionKeyHooks, func(state permission.State) {
 			var err error
 			if state == permission.StateGranted {
 				_, err = EnsureHooksInstalled()
@@ -191,9 +188,9 @@ func TestHooksPermission_InstallGateContract(t *testing.T) {
 				_, err = UninstallHooks()
 			}
 			if err != nil {
-				t.Fatalf("drive permission to %v: %v", state, err)
+				t.Errorf("drive permission to %v: %v", state, err)
 			}
-		},
+		}),
 		Exercise: func() {},
 		Observe: func() bool {
 			return eventHasSentinel(readHooks(t, home), HookStop)

--- a/core/adapters/inbound/agents/codex/hooks_test.go
+++ b/core/adapters/inbound/agents/codex/hooks_test.go
@@ -68,7 +68,9 @@ func (m *mockTarget) reset() {
 }
 
 // keyedGate grants exactly the permission keys in its set — used to exercise
-// the hooks-granted / transcripts-denied combination.
+// the hooks-granted / transcripts-denied combination. For a MUTABLE keyed gate
+// driven through states by the shared contract, use
+// contracttesting.ConsentGate instead.
 type keyedGate map[string]bool
 
 func (g keyedGate) Granted(_, key string) bool { return g[key] }
@@ -378,11 +380,10 @@ func TestHookHandler_UnrecognizedEvent(t *testing.T) {
 // only state that tells a receiver gated on the right permission from one gated
 // on the other.
 func TestHookHandler_PermissionGateContract(t *testing.T) {
-	for _, tc := range []struct{ key, other string }{
-		{PermissionKeyHooks, PermissionKeyTranscripts},
-		{PermissionKeyTranscripts, PermissionKeyHooks},
-	} {
-		t.Run(tc.key, func(t *testing.T) {
+	keys := []string{PermissionKeyHooks, PermissionKeyTranscripts}
+
+	contracttesting.AssertPermissionGatedOnEachKey(t, keys,
+		func(key string, others []string) contracttesting.PermissionGate {
 			target := &mockTarget{}
 			gate := contracttesting.NewConsentGate()
 			handler := NewHookHandler(target, gate, mockLogger{})
@@ -391,13 +392,12 @@ func TestHookHandler_PermissionGateContract(t *testing.T) {
 				HookEventName:  HookPermissionRequest,
 				ToolName:       "shell",
 			}
-			contracttesting.AssertPermissionGated(t, contracttesting.PermissionGate{
-				Key:       tc.key,
-				OtherKeys: []string{tc.other},
+			return contracttesting.PermissionGate{
+				Key:       key,
+				OtherKeys: others,
 				SetState:  gate.SetState,
 				Exercise:  func() { target.reset(); postHook(t, handler, payload) },
 				Observe:   func() bool { return target.totalCalls() > 0 },
-			})
+			}
 		})
-	}
 }

--- a/core/adapters/inbound/agents/codex/hooks_test.go
+++ b/core/adapters/inbound/agents/codex/hooks_test.go
@@ -10,7 +10,6 @@ import (
 	"sync"
 	"testing"
 
-	"irrlicht/core/domain/permission"
 	"irrlicht/core/internal/contracttesting"
 )
 
@@ -66,26 +65,6 @@ func (m *mockTarget) reset() {
 	defer m.mu.Unlock()
 	m.permCalls = nil
 	m.stopCalls = nil
-}
-
-// mutableGate is a ConsentGranter whose grant state can be flipped between
-// permission states for the AssertPermissionGated contract. It grants (or
-// denies) every key uniformly.
-type mutableGate struct {
-	mu      sync.Mutex
-	granted bool
-}
-
-func (g *mutableGate) Granted(string, string) bool {
-	g.mu.Lock()
-	defer g.mu.Unlock()
-	return g.granted
-}
-
-func (g *mutableGate) setGranted(v bool) {
-	g.mu.Lock()
-	defer g.mu.Unlock()
-	g.granted = v
 }
 
 // keyedGate grants exactly the permission keys in its set — used to exercise
@@ -392,18 +371,33 @@ func TestHookHandler_UnrecognizedEvent(t *testing.T) {
 	}
 }
 
+// TestHookHandler_PermissionGateContract runs the shared #797 contract once per
+// permission this receiver must honour: "hooks" for accepting the POST at all,
+// "transcripts" for the read the dispatch below it performs. The key-isolation
+// arm (issue #1475) holds one denied while the other is granted, which is the
+// only state that tells a receiver gated on the right permission from one gated
+// on the other.
 func TestHookHandler_PermissionGateContract(t *testing.T) {
-	target := &mockTarget{}
-	gate := &mutableGate{}
-	handler := NewHookHandler(target, gate, mockLogger{})
-	payload := codexHookPayload{
-		TranscriptPath: writeSessionTranscript(t, "sess-gate"),
-		HookEventName:  HookPermissionRequest,
-		ToolName:       "shell",
+	for _, tc := range []struct{ key, other string }{
+		{PermissionKeyHooks, PermissionKeyTranscripts},
+		{PermissionKeyTranscripts, PermissionKeyHooks},
+	} {
+		t.Run(tc.key, func(t *testing.T) {
+			target := &mockTarget{}
+			gate := contracttesting.NewConsentGate()
+			handler := NewHookHandler(target, gate, mockLogger{})
+			payload := codexHookPayload{
+				TranscriptPath: writeSessionTranscript(t, "sess-gate"),
+				HookEventName:  HookPermissionRequest,
+				ToolName:       "shell",
+			}
+			contracttesting.AssertPermissionGated(t, contracttesting.PermissionGate{
+				Key:       tc.key,
+				OtherKeys: []string{tc.other},
+				SetState:  gate.SetState,
+				Exercise:  func() { target.reset(); postHook(t, handler, payload) },
+				Observe:   func() bool { return target.totalCalls() > 0 },
+			})
+		})
 	}
-	contracttesting.AssertPermissionGated(t, contracttesting.PermissionGate{
-		SetState: func(state permission.State) { gate.setGranted(state == permission.StateGranted) },
-		Exercise: func() { target.reset(); postHook(t, handler, payload) },
-		Observe:  func() bool { return target.totalCalls() > 0 },
-	})
 }

--- a/core/adapters/inbound/agents/copilot/hookinstaller_test.go
+++ b/core/adapters/inbound/agents/copilot/hookinstaller_test.go
@@ -76,12 +76,7 @@ func TestHooksPermission_IsGated(t *testing.T) {
 		// representable — the arm is load-bearing at the live receiver
 		// (hooks_test.go), not here.
 		OtherKeys: []string{PermissionKeyTranscripts},
-		SetState: func(key string, s permission.State) {
-			if key != PermissionKeyHooks {
-				return // no install effect of its own to drive
-			}
-			state = s
-		},
+		SetState:  contracttesting.OnlyKey(PermissionKeyHooks, func(s permission.State) { state = s }),
 		Exercise: func() {
 			switch state {
 			case permission.StateGranted:

--- a/core/adapters/inbound/agents/copilot/hookinstaller_test.go
+++ b/core/adapters/inbound/agents/copilot/hookinstaller_test.go
@@ -69,9 +69,12 @@ func TestHooksPermission_IsGated(t *testing.T) {
 	state := permission.StatePending
 	contracttesting.AssertPermissionGated(t, contracttesting.PermissionGate{
 		Key: PermissionKeyHooks,
-		// transcripts is the adapter's other declared permission and is
-		// observe-kind — it carries no Apply/Remove, so granting it must leave
-		// the hooks file untouched while hooks itself is denied.
+		// transcripts is the adapter's only other declared permission and is
+		// observe-kind, so it has no closure to drive: the key-isolation arm is
+		// INERT here and repeats the revoked arm exactly. Install-type wirings
+		// hold their own permission's closures, so a wrong key is not
+		// representable — the arm is load-bearing at the live receiver
+		// (hooks_test.go), not here.
 		OtherKeys: []string{PermissionKeyTranscripts},
 		SetState: func(key string, s permission.State) {
 			if key != PermissionKeyHooks {

--- a/core/adapters/inbound/agents/copilot/hookinstaller_test.go
+++ b/core/adapters/inbound/agents/copilot/hookinstaller_test.go
@@ -68,7 +68,17 @@ func TestHooksPermission_IsGated(t *testing.T) {
 
 	state := permission.StatePending
 	contracttesting.AssertPermissionGated(t, contracttesting.PermissionGate{
-		SetState: func(s permission.State) { state = s },
+		Key: PermissionKeyHooks,
+		// transcripts is the adapter's other declared permission and is
+		// observe-kind — it carries no Apply/Remove, so granting it must leave
+		// the hooks file untouched while hooks itself is denied.
+		OtherKeys: []string{PermissionKeyTranscripts},
+		SetState: func(key string, s permission.State) {
+			if key != PermissionKeyHooks {
+				return // no install effect of its own to drive
+			}
+			state = s
+		},
 		Exercise: func() {
 			switch state {
 			case permission.StateGranted:

--- a/core/adapters/inbound/agents/copilot/hooks_test.go
+++ b/core/adapters/inbound/agents/copilot/hooks_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"irrlicht/core/domain/session"
+	"irrlicht/core/internal/contracttesting"
 )
 
 // --- test doubles, shared by this file and the contract wirings ---
@@ -355,6 +356,43 @@ func TestHookReceiver_DeniedTranscriptsConsentDropsQuietly(t *testing.T) {
 	}
 	if n := target.totalCalls(); n != 0 {
 		t.Fatalf("dispatched %d times while transcripts consent was denied, want 0", n)
+	}
+}
+
+// TestHookReceiver_PermissionGateContract runs the shared #797 contract once
+// per permission this receiver must honour. The two tests above pin the same
+// two gates by hand and stay as LOCKS — they additionally assert the 200 that
+// a consent refusal answers with, which the contract's opaque Exercise cannot
+// see. What the contract adds is that the obligation is no longer this
+// adapter's to remember: its key-isolation arm (issue #1475) holds one
+// permission denied while the other is granted, which is the state that
+// separates a receiver gated on the right permission from one gated on the
+// other, and it is the state claudecode sat in undetected for its whole life
+// (issue #1466).
+func TestHookReceiver_PermissionGateContract(t *testing.T) {
+	for _, tc := range []struct{ key, other string }{
+		{PermissionKeyHooks, PermissionKeyTranscripts},
+		{PermissionKeyTranscripts, PermissionKeyHooks},
+	} {
+		t.Run(tc.key, func(t *testing.T) {
+			root := copilotSessionRoot(t)
+			body := contractPayload(writeSessionTranscript(t, root, "sess-gate"), HookStop)
+			target := &mockTarget{}
+			gate := contracttesting.NewConsentGate()
+			h := NewHookHandler(target, gate, mockLogger{})
+
+			before := 0
+			contracttesting.AssertPermissionGated(t, contracttesting.PermissionGate{
+				Key:       tc.key,
+				OtherKeys: []string{tc.other},
+				SetState:  gate.SetState,
+				Exercise: func() {
+					before = target.totalCalls()
+					post(t, h, body)
+				},
+				Observe: func() bool { return target.totalCalls() > before },
+			})
+		})
 	}
 }
 

--- a/core/adapters/inbound/agents/copilot/hooks_test.go
+++ b/core/adapters/inbound/agents/copilot/hooks_test.go
@@ -61,6 +61,9 @@ func (m *mockTarget) stops() []stopCall {
 	return append([]stopCall(nil), m.stopCalls...)
 }
 
+// keyedGate pins a fixed permission combination for a one-off test. For a
+// MUTABLE keyed gate driven through states by the shared contract, use
+// contracttesting.ConsentGate instead.
 type keyedGate map[string]bool
 
 func (g keyedGate) Granted(_, key string) bool { return g[key] }
@@ -370,11 +373,10 @@ func TestHookReceiver_DeniedTranscriptsConsentDropsQuietly(t *testing.T) {
 // other, and it is the state claudecode sat in undetected for its whole life
 // (issue #1466).
 func TestHookReceiver_PermissionGateContract(t *testing.T) {
-	for _, tc := range []struct{ key, other string }{
-		{PermissionKeyHooks, PermissionKeyTranscripts},
-		{PermissionKeyTranscripts, PermissionKeyHooks},
-	} {
-		t.Run(tc.key, func(t *testing.T) {
+	keys := []string{PermissionKeyHooks, PermissionKeyTranscripts}
+
+	contracttesting.AssertPermissionGatedOnEachKey(t, keys,
+		func(key string, others []string) contracttesting.PermissionGate {
 			root := copilotSessionRoot(t)
 			body := contractPayload(writeSessionTranscript(t, root, "sess-gate"), HookStop)
 			target := &mockTarget{}
@@ -382,18 +384,17 @@ func TestHookReceiver_PermissionGateContract(t *testing.T) {
 			h := NewHookHandler(target, gate, mockLogger{})
 
 			before := 0
-			contracttesting.AssertPermissionGated(t, contracttesting.PermissionGate{
-				Key:       tc.key,
-				OtherKeys: []string{tc.other},
+			return contracttesting.PermissionGate{
+				Key:       key,
+				OtherKeys: others,
 				SetState:  gate.SetState,
 				Exercise: func() {
 					before = target.totalCalls()
 					post(t, h, body)
 				},
 				Observe: func() bool { return target.totalCalls() > before },
-			})
+			}
 		})
-	}
 }
 
 // TestHookReceiver_NonPostRejected is a LOCK on the shared receiver shape.

--- a/core/adapters/inbound/agents/processlifecycle/kitty_permission_test.go
+++ b/core/adapters/inbound/agents/processlifecycle/kitty_permission_test.go
@@ -299,8 +299,11 @@ func TestKittyPermission_GateContract(t *testing.T) {
 	contracttesting.AssertPermissionGated(t, contracttesting.PermissionGate{
 		Key: PermissionKeyKittyConfig,
 		// This declaration exports exactly one permission, so the key held open
-		// beside it is a foreign one: answering some OTHER permission granted
-		// must not patch kitty.conf.
+		// beside it is a foreign one with no closure here to drive: the
+		// key-isolation arm is INERT and repeats the revoked arm exactly. It is
+		// wired anyway because the contract admits no opt-out — a flag an
+		// install-type wiring could take is one a live-gate wiring could take
+		// too, and there it is the whole point.
 		OtherKeys: []string{agent.HooksPermissionKey},
 		SetState: func(key string, state permission.State) {
 			if key != PermissionKeyKittyConfig {

--- a/core/adapters/inbound/agents/processlifecycle/kitty_permission_test.go
+++ b/core/adapters/inbound/agents/processlifecycle/kitty_permission_test.go
@@ -297,7 +297,15 @@ func TestKittyPermission_GateContract(t *testing.T) {
 	decl := findKittyPermission(t, PermissionKeyKittyConfig)
 
 	contracttesting.AssertPermissionGated(t, contracttesting.PermissionGate{
-		SetState: func(state permission.State) {
+		Key: PermissionKeyKittyConfig,
+		// This declaration exports exactly one permission, so the key held open
+		// beside it is a foreign one: answering some OTHER permission granted
+		// must not patch kitty.conf.
+		OtherKeys: []string{agent.HooksPermissionKey},
+		SetState: func(key string, state permission.State) {
+			if key != PermissionKeyKittyConfig {
+				return // not this declaration's permission
+			}
 			switch state {
 			case permission.StateGranted:
 				if err := decl.Apply(); err != nil {

--- a/core/adapters/inbound/agents/processlifecycle/kitty_permission_test.go
+++ b/core/adapters/inbound/agents/processlifecycle/kitty_permission_test.go
@@ -305,21 +305,18 @@ func TestKittyPermission_GateContract(t *testing.T) {
 		// install-type wiring could take is one a live-gate wiring could take
 		// too, and there it is the whole point.
 		OtherKeys: []string{agent.HooksPermissionKey},
-		SetState: func(key string, state permission.State) {
-			if key != PermissionKeyKittyConfig {
-				return // not this declaration's permission
-			}
+		SetState: contracttesting.OnlyKey(PermissionKeyKittyConfig, func(state permission.State) {
 			switch state {
 			case permission.StateGranted:
 				if err := decl.Apply(); err != nil {
-					t.Fatalf("Apply: %v", err)
+					t.Errorf("Apply: %v", err)
 				}
 			case permission.StateDenied:
 				if err := decl.Remove(); err != nil {
-					t.Fatalf("Remove: %v", err)
+					t.Errorf("Remove: %v", err)
 				}
 			}
-		},
+		}),
 		Exercise: func() {}, // the effect IS the Apply/Remove call above
 		Observe: func() bool {
 			data, err := os.ReadFile(path)

--- a/core/application/services/input_service_test.go
+++ b/core/application/services/input_service_test.go
@@ -137,11 +137,14 @@ func TestSendInput_PermissionGateContract(t *testing.T) {
 
 	contracttesting.AssertPermissionGated(t, contracttesting.PermissionGate{
 		Key: agent.ControlPermissionKey,
-		// Forwarding must ride on "control" and on nothing else. The two keys
-		// held open beside it are the ones an adapter's own receiver checks —
-		// a gate that answered for any of them would forward input on the
-		// strength of a consent that authorises reading, not writing.
-		OtherKeys: []string{agent.HooksPermissionKey, "transcripts"},
+		// Forwarding must ride on "control" and on nothing else. The keys held
+		// open beside it are other permissions the same wizard grants — a gate
+		// that answered for any of them would forward input on the strength of
+		// a consent that authorises writing a config file, not typing into a
+		// session. Both are domain constants rather than literals: an adapter's
+		// own "transcripts" spelling is package-local, and a key nothing
+		// declares would make this arm a no-op that still reads green.
+		OtherKeys: []string{agent.HooksPermissionKey, agent.InstructionsPermissionKey},
 		SetState:  consent.SetState,
 		Exercise: func() {
 			ctrl.sentData = nil

--- a/core/application/services/input_service_test.go
+++ b/core/application/services/input_service_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"irrlicht/core/application/services"
-	"irrlicht/core/domain/permission"
+	"irrlicht/core/domain/agent"
 	"irrlicht/core/domain/session"
 	"irrlicht/core/internal/contracttesting"
 )
@@ -33,13 +33,6 @@ func (f *fakeController) Controllable(_ string) bool { return f.controllable }
 type fakeConsent struct{ granted bool }
 
 func (f fakeConsent) Granted(_, _ string) bool { return f.granted }
-
-// mutableConsent is a consentGranter whose answer can change between calls —
-// needed to drive a single InputService instance through all three
-// consent states for contracttesting.AssertPermissionGated.
-type mutableConsent struct{ granted bool }
-
-func (c *mutableConsent) Granted(_, _ string) bool { return c.granted }
 
 func controllableSession() *session.SessionState {
 	return &session.SessionState{SessionID: "abc", Adapter: "claude-code"}
@@ -138,12 +131,18 @@ func TestControllable_ReflectsGate(t *testing.T) {
 // permission is pending or denied, must delegate to the controller once
 // granted, and must stop again once revoked.
 func TestSendInput_PermissionGateContract(t *testing.T) {
-	consent := &mutableConsent{}
+	consent := contracttesting.NewConsentGate()
 	ctrl := &fakeController{controllable: true}
 	svc := services.NewInputService(&stubRepo{state: controllableSession()}, ctrl, consent, func() bool { return true }, stubLog{})
 
 	contracttesting.AssertPermissionGated(t, contracttesting.PermissionGate{
-		SetState: func(state permission.State) { consent.granted = state == permission.StateGranted },
+		Key: agent.ControlPermissionKey,
+		// Forwarding must ride on "control" and on nothing else. The two keys
+		// held open beside it are the ones an adapter's own receiver checks —
+		// a gate that answered for any of them would forward input on the
+		// strength of a consent that authorises reading, not writing.
+		OtherKeys: []string{agent.HooksPermissionKey, "transcripts"},
+		SetState:  consent.SetState,
 		Exercise: func() {
 			ctrl.sentData = nil
 			_ = svc.SendInput("abc", []byte("x"))

--- a/core/internal/contracttesting/permission_gate.go
+++ b/core/internal/contracttesting/permission_gate.go
@@ -1,23 +1,65 @@
 package contracttesting
 
 import (
+	"fmt"
+	"sync"
 	"testing"
 
 	"irrlicht/core/domain/permission"
 )
 
 // PermissionGate wires one declared permission's consent-gated call site
-// into AssertPermissionGated. SetState drives the permission to the given
-// state through whatever mechanism the call site actually checks — a
-// mutable fake ConsentGranter for a live per-request check (an HTTP handler,
-// input forwarding), or the permission's real Apply/Remove closures for an
-// install-type permission (a hook file, a config block). Exercise performs
-// the action the permission is supposed to gate. Observe reports whether
-// the gated effect is currently present.
+// into AssertPermissionGated.
+//
+// Key names the permission under test — the one this call site must honour.
+// OtherKeys names permissions it must NOT be gated on; the contract holds
+// them open while Key is denied, which is the only condition under which a
+// mis-gated call site looks different from a correct one.
+//
+// SetState drives ONE key to one state through whatever mechanism the call
+// site actually checks — a keyed fake ConsentGranter for a live per-request
+// check (an HTTP handler, input forwarding), or the permission's real
+// Apply/Remove closures for an install-type permission (a hook file, a
+// config block). Exercise performs the action the permission is supposed to
+// gate. Observe reports whether the gated effect is currently present.
+//
+// Use ConsentGate for the live-per-request flavour rather than hand-rolling a
+// keyed fake: SetState is then satisfied by a method that cannot ignore the
+// key it is handed.
 type PermissionGate struct {
-	SetState func(state permission.State)
+	// Key is the permission key whose consent this call site must honour.
+	Key string
+
+	// OtherKeys are permissions this call site must not be gated on —
+	// typically the rest of what the same adapter declares. At least one is
+	// required: with nothing to hold open, "denied" is indistinguishable
+	// from "denied along with everything else", which is precisely the
+	// blind spot this contract had (issue #1475).
+	OtherKeys []string
+
+	// SetState drives one key to one state. It MUST honour the key it is
+	// passed — a fake that answers identically for every key is what let a
+	// receiver read transcripts with "transcripts" denied for the whole of
+	// its life (issue #1466), and the key-isolation arm below is written so
+	// that such a fake fails rather than passes.
+	SetState func(key string, state permission.State)
+
+	// Exercise performs the action the permission gates.
 	Exercise func()
-	Observe  func() bool
+
+	// Observe reports whether the gated effect is currently present.
+	Observe func() bool
+}
+
+// gateReporter is the slice of *testing.T the individual arms use. Taking an
+// interface rather than *testing.T is what lets this file's own tests drive an
+// arm against a deliberately mis-gated call site and assert it goes red —
+// a contract assertion passes by construction against a correct adapter, so
+// its whole value is that it can fail, and nothing re-runs evidence that
+// exists only in a merged PR body.
+type gateReporter interface {
+	Helper()
+	Errorf(format string, args ...any)
 }
 
 // AssertPermissionGated runs the issue #797 contract against g: no
@@ -27,27 +69,163 @@ type PermissionGate struct {
 // site that forgot to check consent is caught even when the underlying
 // resource (a hook entry, a config block) was left behind by an earlier
 // grant.
+//
+// A fourth arm (issue #1475) covers what the first three cannot: they move
+// every key in lockstep, so they answer identically whether the call site
+// reads g.Key or some other permission entirely. Holding g.Key denied while
+// OtherKeys are granted is the one state that tells those apart.
+//
+// The arm is load-bearing for a LIVE per-request gate — a handler that reads
+// a key from a ConsentGranter on every request, which is where #1466 lived.
+// For an install-type permission it is weak by construction: the wiring holds
+// that permission's own Apply/Remove closures, so "gated on the wrong key" is
+// not representable there, and the arm degenerates to asserting that another
+// permission's effects do not produce this one's. That is worth little, but it
+// is not nothing, and a uniform contract with no opt-out is worth more than a
+// flag a live-gate adapter could also reach for.
+//
+// What this still does not do is make the obligation unforgettable: a receiver
+// must be wired once per permission it must honour, and nothing fails if an
+// author wires only one of them. Issue #1488 is the chokepoint move that would
+// remove that last act of memory — folding the consent key into
+// hookjson.DecodeConfined, which core/architecture_hookbody_test.go already
+// forces every hook receiver through.
 func AssertPermissionGated(t *testing.T, g PermissionGate) {
 	t.Helper()
-	t.Run("pending_no_effect", func(t *testing.T) {
-		g.SetState(permission.StatePending)
-		g.Exercise()
-		if g.Observe() {
-			t.Error("effect observed while permission is pending — call site is not consent-gated")
+	if reason := malformedGateReason(g); reason != "" {
+		t.Fatal(reason)
+	}
+
+	t.Run("pending_no_effect", func(t *testing.T) { assertPendingNoEffect(t, g) })
+	t.Run("granted_effect_observable", func(t *testing.T) { assertGrantedEffectObservable(t, g) })
+	t.Run("revoked_effect_undone", func(t *testing.T) { assertRevokedEffectUndone(t, g) })
+	t.Run("gated_on_the_named_key", func(t *testing.T) { assertGatedOnTheNamedKey(t, g) })
+}
+
+// malformedGateReason reports why the contract cannot actually exercise g, or
+// "" when it can. It returns a reason instead of failing so that the shapes it
+// rejects are themselves testable — a guard nobody can drive is the same kind
+// of unverifiable check as the one this file exists to remove. The caller
+// fails loudly on a non-empty reason rather than running a reduced set of arms
+// that reads as a pass.
+func malformedGateReason(g PermissionGate) string {
+	if g.SetState == nil || g.Exercise == nil || g.Observe == nil {
+		return "PermissionGate needs SetState, Exercise and Observe"
+	}
+	if g.Key == "" {
+		return "PermissionGate.Key is empty — name the permission this call site must be gated on"
+	}
+	if len(g.OtherKeys) == 0 {
+		return fmt.Sprintf("PermissionGate.OtherKeys is empty — the key-isolation arm cannot run, so %q "+
+			"would only be shown to be gated on something rather than on %q (issue #1475). "+
+			"Name at least one permission this call site must NOT be gated on.", g.Key, g.Key)
+	}
+	for _, k := range g.OtherKeys {
+		if k == g.Key {
+			return fmt.Sprintf("PermissionGate.OtherKeys repeats the key under test (%q) — "+
+				"the key-isolation arm would grant and deny the same permission", g.Key)
 		}
-	})
-	t.Run("granted_effect_observable", func(t *testing.T) {
-		g.SetState(permission.StateGranted)
-		g.Exercise()
-		if !g.Observe() {
-			t.Error("effect not observed after granting permission")
-		}
-	})
-	t.Run("revoked_effect_undone", func(t *testing.T) {
-		g.SetState(permission.StateDenied)
-		g.Exercise()
-		if g.Observe() {
-			t.Error("effect still observed after revoking a previously granted permission")
-		}
-	})
+	}
+	return ""
+}
+
+// setEveryKey drives the key under test and every other key to state. The
+// first three arms move them in lockstep on purpose: a call site legitimately
+// gated on several permissions (a hook receiver needs both "hooks" and
+// "transcripts") must see all of them open before its effect can appear.
+func setEveryKey(g PermissionGate, state permission.State) {
+	g.SetState(g.Key, state)
+	for _, k := range g.OtherKeys {
+		g.SetState(k, state)
+	}
+}
+
+func assertPendingNoEffect(t gateReporter, g PermissionGate) {
+	t.Helper()
+	setEveryKey(g, permission.StatePending)
+	g.Exercise()
+	if g.Observe() {
+		t.Errorf("effect observed while permission %q is pending — call site is not consent-gated", g.Key)
+	}
+}
+
+func assertGrantedEffectObservable(t gateReporter, g PermissionGate) {
+	t.Helper()
+	setEveryKey(g, permission.StateGranted)
+	g.Exercise()
+	if !g.Observe() {
+		t.Errorf("effect not observed after granting permission %q", g.Key)
+	}
+}
+
+func assertRevokedEffectUndone(t gateReporter, g PermissionGate) {
+	t.Helper()
+	setEveryKey(g, permission.StateDenied)
+	g.Exercise()
+	if g.Observe() {
+		t.Errorf("effect still observed after revoking a previously granted permission %q", g.Key)
+	}
+}
+
+// assertGatedOnTheNamedKey is the issue #1475 arm: the effect must be absent
+// while g.Key is denied even though every other permission is granted.
+//
+// The write order is load-bearing and is the reason this arm also rejects a
+// key-blind SetState. g.Key is denied FIRST and the other keys are opened
+// AFTER, so a wiring that ignores the key it is handed ends up holding
+// everything granted, dispatches, and fails here. Opening the other keys
+// first would leave such a wiring sitting at "denied" — it would pass, and
+// the contract would once again be satisfiable by exactly the fake that
+// hid #1466.
+func assertGatedOnTheNamedKey(t gateReporter, g PermissionGate) {
+	t.Helper()
+	g.SetState(g.Key, permission.StateDenied)
+	for _, k := range g.OtherKeys {
+		g.SetState(k, permission.StateGranted)
+	}
+	g.Exercise()
+	if g.Observe() {
+		t.Errorf("effect observed while %q is denied and %v granted — the call site is gated on "+
+			"some OTHER permission (or on none), not on %q (issue #1475)", g.Key, g.OtherKeys, g.Key)
+	}
+}
+
+// ConsentGate is a keyed, mutable ConsentGranter fake: it answers per
+// permission key, so a test can hold one of an adapter's permissions denied
+// while every other is granted. It satisfies hookjson.ConsentGranter (and the
+// identical private interfaces the services layer declares) structurally.
+//
+// It lives here rather than in each adapter's test package because three of
+// them had already re-invented the same map[string]bool after #1466, and
+// because a contract whose wiring supplies the fake is a contract whose wiring
+// can supply a key-blind one. SetState has exactly PermissionGate.SetState's
+// signature, so the usual wiring is one line: SetState: gate.SetState.
+//
+// A key never set reads as pending, matching permission.Set.Get.
+type ConsentGate struct {
+	mu     sync.Mutex
+	states map[string]permission.State
+}
+
+// NewConsentGate returns a ConsentGate with every key pending.
+func NewConsentGate() *ConsentGate {
+	return &ConsentGate{states: make(map[string]permission.State)}
+}
+
+// SetState drives one permission key to state.
+func (g *ConsentGate) SetState(key string, state permission.State) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if g.states == nil {
+		g.states = make(map[string]permission.State)
+	}
+	g.states[key] = state
+}
+
+// Granted implements the receiver-side consent check. The agent name is
+// ignored: a ConsentGate stands in for one adapter's consent at a time.
+func (g *ConsentGate) Granted(_ string, key string) bool {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return g.states[key] == permission.StateGranted
 }

--- a/core/internal/contracttesting/permission_gate.go
+++ b/core/internal/contracttesting/permission_gate.go
@@ -106,6 +106,52 @@ func AssertPermissionGated(t *testing.T, g PermissionGate) {
 	t.Run("gated_on_the_named_key", func(t *testing.T) { assertGatedOnTheNamedKey(t, g) })
 }
 
+// AssertPermissionGatedOnEachKey runs the contract once per key in keys, each
+// time holding the REST of the set open — the shape every receiver gated on
+// more than one permission needs, since a receiver must be shown to honour
+// each of them separately.
+//
+// It exists because the alternative is what three adapters had started doing
+// independently: a hand-written table pairing each key with "the other one".
+// Such a table can silently list only one direction, and listing only the
+// direction that already works is indistinguishable from covering both. Here a
+// wiring names its key set once and the pairing is derived.
+//
+// build receives the key under test and the others, and returns a gate with a
+// FRESH call site — the fixtures must not be shared between keys, or a state
+// left behind by one run decides the next.
+func AssertPermissionGatedOnEachKey(t *testing.T, keys []string, build func(key string, others []string) PermissionGate) {
+	t.Helper()
+	if len(keys) < 2 {
+		t.Fatalf("AssertPermissionGatedOnEachKey needs at least two keys, got %d — "+
+			"with fewer there is nothing to hold open and the key-isolation arm cannot run", len(keys))
+	}
+	for i, key := range keys {
+		others := append(append([]string{}, keys[:i]...), keys[i+1:]...)
+		t.Run(key, func(t *testing.T) { AssertPermissionGated(t, build(key, others)) })
+	}
+}
+
+// OnlyKey adapts a single permission's state-driver to PermissionGate.SetState
+// by ignoring every other key. It is the install-type counterpart to
+// ConsentGate: those wirings hold one permission's own Apply/Remove closures,
+// so a key that is not theirs has nothing to drive.
+//
+// It is here rather than written out at each install wiring for the same
+// reason ConsentGate is: three of them had each hand-rolled the filter, and
+// "a foreign key is a no-op" is a decision about the contract, not about an
+// adapter. Note what it means for the key-isolation arm — with nothing to
+// drive for the other key, that arm repeats the revoked arm exactly. See
+// AssertPermissionGated's doc for why it is kept uniform anyway.
+func OnlyKey(key string, drive func(permission.State)) func(string, permission.State) {
+	return func(k string, state permission.State) {
+		if k != key {
+			return
+		}
+		drive(state)
+	}
+}
+
 // malformedGateReason reports why the contract cannot actually exercise g, or
 // "" when it can. It returns a reason instead of failing so that the shapes it
 // rejects are themselves testable — a guard nobody can drive is the same kind
@@ -217,31 +263,38 @@ func assertGatedOnTheNamedKey(t gateReporter, g PermissionGate) {
 // those were never the problem. SetState has exactly PermissionGate.SetState's
 // signature, so the usual wiring is one line: SetState: gate.SetState.
 //
-// A key never set reads as pending, matching permission.Set.Get.
+// It is backed by permission.Set rather than a bare map so the "never answered
+// reads as pending" rule is INHERITED from the domain instead of restated
+// here. A fake that hand-maintains its own copy of that default would keep
+// answering the old way if the domain ever changed it, and the contract would
+// go on asserting against a consent model production no longer uses.
 type ConsentGate struct {
-	mu     sync.Mutex
-	states map[string]permission.State
+	mu  sync.Mutex
+	set permission.Set
 }
+
+// consentGateAgent is the single agent name a ConsentGate records under. The
+// fake stands in for one adapter's consent at a time, so the agent axis of
+// permission.Set is deliberately collapsed — see Granted.
+const consentGateAgent = "contracttesting"
 
 // NewConsentGate returns a ConsentGate with every key pending.
 func NewConsentGate() *ConsentGate {
-	return &ConsentGate{states: make(map[string]permission.State)}
+	return &ConsentGate{set: permission.Set{}}
 }
 
 // SetState drives one permission key to state.
 func (g *ConsentGate) SetState(key string, state permission.State) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if g.states == nil {
-		g.states = make(map[string]permission.State)
-	}
-	g.states[key] = state
+	g.set.Put(consentGateAgent, key, state)
 }
 
-// Granted implements the receiver-side consent check. The agent name is
-// ignored: a ConsentGate stands in for one adapter's consent at a time.
+// Granted implements the receiver-side consent check. The agent name a call
+// site passes is ignored: a ConsentGate stands in for one adapter at a time,
+// so every question it is asked is about that adapter.
 func (g *ConsentGate) Granted(_ string, key string) bool {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	return g.states[key] == permission.StateGranted
+	return g.set.Get(consentGateAgent, key) == permission.StateGranted
 }

--- a/core/internal/contracttesting/permission_gate.go
+++ b/core/internal/contracttesting/permission_gate.go
@@ -80,9 +80,13 @@ type gateReporter interface {
 // For an install-type permission it is weak by construction: the wiring holds
 // that permission's own Apply/Remove closures, so "gated on the wrong key" is
 // not representable there, and the arm degenerates to asserting that another
-// permission's effects do not produce this one's. That is worth little, but it
-// is not nothing, and a uniform contract with no opt-out is worth more than a
-// flag a live-gate adapter could also reach for.
+// permission's effects do not produce this one's — and where that other
+// permission has no closures to run at all (an observe-kind sibling, or a
+// declaration exporting a single permission) it degenerates one step further
+// still, to a repeat of the revoked arm. Those wirings say so at the call
+// site. The arm is kept uniform anyway, with no opt-out, because a flag that
+// let an install-type wiring skip it is a flag a live-gate wiring could also
+// reach for, and that is the one place it must not be skippable.
 //
 // What this still does not do is make the obligation unforgettable: a receiver
 // must be wired once per permission it must honour, and nothing fails if an
@@ -121,6 +125,15 @@ func malformedGateReason(g PermissionGate) string {
 			"Name at least one permission this call site must NOT be gated on.", g.Key, g.Key)
 	}
 	for _, k := range g.OtherKeys {
+		if k == "" {
+			// g.Key is non-empty by the check above, so the k == g.Key test
+			// below can never catch this. An unfilled constant or a struct
+			// typo would otherwise grant a permission no call site can be
+			// checking, and the isolation arm would pass having proved
+			// nothing — the exact inert-but-green shape this guard exists for.
+			return "PermissionGate.OtherKeys contains an empty key — name a real permission " +
+				"this call site must NOT be gated on"
+		}
 		if k == g.Key {
 			return fmt.Sprintf("PermissionGate.OtherKeys repeats the key under test (%q) — "+
 				"the key-isolation arm would grant and deny the same permission", g.Key)
@@ -195,10 +208,13 @@ func assertGatedOnTheNamedKey(t gateReporter, g PermissionGate) {
 // while every other is granted. It satisfies hookjson.ConsentGranter (and the
 // identical private interfaces the services layer declares) structurally.
 //
-// It lives here rather than in each adapter's test package because three of
-// them had already re-invented the same map[string]bool after #1466, and
-// because a contract whose wiring supplies the fake is a contract whose wiring
-// can supply a key-blind one. SetState has exactly PermissionGate.SetState's
+// It replaces the three key-blind mutable fakes the live-gate wirings each
+// grew for this contract (claudecode's and codex's mutableGate, the services
+// layer's mutableConsent), and it lives here rather than in an adapter because
+// a contract whose wiring supplies the fake is a contract whose wiring can
+// supply a key-blind one. Adapters keep their own static keyedGate map
+// literals for one-off tests that pin a fixed two-permission combination —
+// those were never the problem. SetState has exactly PermissionGate.SetState's
 // signature, so the usual wiring is one line: SetState: gate.SetState.
 //
 // A key never set reads as pending, matching permission.Set.Get.

--- a/core/internal/contracttesting/permission_gate.go
+++ b/core/internal/contracttesting/permission_gate.go
@@ -165,24 +165,35 @@ func malformedGateReason(g PermissionGate) string {
 	if g.Key == "" {
 		return "PermissionGate.Key is empty — name the permission this call site must be gated on"
 	}
-	if len(g.OtherKeys) == 0 {
+	return malformedOtherKeysReason(g.Key, g.OtherKeys)
+}
+
+// malformedOtherKeysReason reports why the keys meant to be held open beside
+// key cannot serve that purpose, or "" when they can. Split from the shape
+// checks above because it answers a different question: those ask whether a
+// gate was filled in at all, this asks whether the key set it names can
+// actually produce the isolation arm's state.
+//
+// key is assumed non-empty — its caller has already rejected that.
+func malformedOtherKeysReason(key string, others []string) string {
+	if len(others) == 0 {
 		return fmt.Sprintf("PermissionGate.OtherKeys is empty — the key-isolation arm cannot run, so %q "+
 			"would only be shown to be gated on something rather than on %q (issue #1475). "+
-			"Name at least one permission this call site must NOT be gated on.", g.Key, g.Key)
+			"Name at least one permission this call site must NOT be gated on.", key, key)
 	}
-	for _, k := range g.OtherKeys {
+	for _, k := range others {
 		if k == "" {
-			// g.Key is non-empty by the check above, so the k == g.Key test
-			// below can never catch this. An unfilled constant or a struct
-			// typo would otherwise grant a permission no call site can be
-			// checking, and the isolation arm would pass having proved
-			// nothing — the exact inert-but-green shape this guard exists for.
+			// key is non-empty, so the k == key test below can never catch
+			// this. An unfilled constant or a struct typo would otherwise
+			// grant a permission no call site can be checking, and the
+			// isolation arm would pass having proved nothing — the exact
+			// inert-but-green shape this guard exists for.
 			return "PermissionGate.OtherKeys contains an empty key — name a real permission " +
 				"this call site must NOT be gated on"
 		}
-		if k == g.Key {
+		if k == key {
 			return fmt.Sprintf("PermissionGate.OtherKeys repeats the key under test (%q) — "+
-				"the key-isolation arm would grant and deny the same permission", g.Key)
+				"the key-isolation arm would grant and deny the same permission", key)
 		}
 	}
 	return ""

--- a/core/internal/contracttesting/permission_gate_test.go
+++ b/core/internal/contracttesting/permission_gate_test.go
@@ -91,17 +91,41 @@ func (g *keyBlindGate) Granted(_, _ string) bool { return g.state == permission.
 // hook receiver: "hooks" authorises writing our entries, "transcripts"
 // authorises reading the file those entries point at.
 func TestAssertPermissionGated_PassesAgainstACorrectlyGatedReceiver(t *testing.T) {
-	for _, tc := range []struct{ key, other string }{
-		{selfTestTranscripts, selfTestHooks},
-		{selfTestHooks, selfTestTranscripts},
-	} {
-		t.Run(tc.key, func(t *testing.T) {
-			r := &fakeReceiver{
-				gate:    NewConsentGate(),
-				gatedOn: []string{selfTestHooks, selfTestTranscripts},
-			}
-			AssertPermissionGated(t, r.gateFor(tc.key, tc.other))
-		})
+	keys := []string{selfTestHooks, selfTestTranscripts}
+
+	AssertPermissionGatedOnEachKey(t, keys, func(key string, others []string) PermissionGate {
+		r := &fakeReceiver{gate: NewConsentGate(), gatedOn: keys}
+		return r.gateFor(key, others...)
+	})
+}
+
+// TestAssertPermissionGatedOnEachKey_DerivesTheOthers pins the pairing the
+// helper exists to stop adapters hand-maintaining. Three keys, because every
+// wiring in the tree today has exactly two — and with two, "the others" and
+// "the other one" are the same answer, so a two-key case cannot tell a correct
+// derivation from one that just returns the last key.
+func TestAssertPermissionGatedOnEachKey_DerivesTheOthers(t *testing.T) {
+	keys := []string{"a", "b", "c"}
+	got := map[string][]string{}
+
+	AssertPermissionGatedOnEachKey(t, keys, func(key string, others []string) PermissionGate {
+		got[key] = others
+		r := &fakeReceiver{gate: NewConsentGate(), gatedOn: keys}
+		return r.gateFor(key, others...)
+	})
+
+	want := map[string][]string{
+		"a": {"b", "c"},
+		"b": {"a", "c"},
+		"c": {"a", "b"},
+	}
+	if len(got) != len(want) {
+		t.Fatalf("ran for %d keys, want %d — every key must get a turn under test", len(got), len(want))
+	}
+	for key, wantOthers := range want {
+		if strings.Join(got[key], ",") != strings.Join(wantOthers, ",") {
+			t.Errorf("key %q held open %v, want %v", key, got[key], wantOthers)
+		}
 	}
 }
 

--- a/core/internal/contracttesting/permission_gate_test.go
+++ b/core/internal/contracttesting/permission_gate_test.go
@@ -1,0 +1,248 @@
+package contracttesting
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"irrlicht/core/domain/permission"
+)
+
+// This file is the deliberate mutation for the key-isolation arm added in
+// issue #1475, committed rather than described. A contract assertion passes by
+// construction against a correct adapter, so its whole value is that it can
+// fail — and #1466 is the standing proof that this one could not: claudecode's
+// hook receiver read transcripts with "transcripts" denied for the whole of
+// its life while AssertPermissionGated was wired at that receiver and green.
+//
+// Every case below drives a call site whose gating is known-wrong through the
+// arms and asserts what each one reports, so the evidence is re-run on every
+// build instead of living in a merged PR body.
+
+const (
+	selfTestHooks       = "hooks"
+	selfTestTranscripts = "transcripts"
+)
+
+// recordingReporter captures what an arm reports instead of failing the
+// enclosing test.
+type recordingReporter struct{ errs []string }
+
+func (r *recordingReporter) Helper() {}
+
+func (r *recordingReporter) Errorf(format string, args ...any) {
+	r.errs = append(r.errs, fmt.Sprintf(format, args...))
+}
+
+func (r *recordingReporter) failed() bool { return len(r.errs) > 0 }
+
+func (r *recordingReporter) report() string { return strings.Join(r.errs, "; ") }
+
+// fakeReceiver stands in for a hook receiver: it dispatches only once the
+// consent gate answers granted for every key in gatedOn. gatedOn is the
+// mutation knob — naming the wrong key, or none, reproduces the two shapes
+// this contract has to tell apart from a correct receiver.
+type fakeReceiver struct {
+	gate       consentSetter
+	gatedOn    []string
+	dispatched bool
+}
+
+// consentSetter is what a fakeReceiver needs of a gate: drive a key, and
+// answer a consent check. *ConsentGate satisfies it; so does keyBlindGate,
+// which is the point of the interface.
+type consentSetter interface {
+	SetState(key string, state permission.State)
+	Granted(agentName, key string) bool
+}
+
+func (f *fakeReceiver) exercise() {
+	f.dispatched = false
+	for _, k := range f.gatedOn {
+		if !f.gate.Granted("test-agent", k) {
+			return
+		}
+	}
+	f.dispatched = true
+}
+
+func (f *fakeReceiver) gateFor(key string, others ...string) PermissionGate {
+	return PermissionGate{
+		Key:       key,
+		OtherKeys: others,
+		SetState:  f.gate.SetState,
+		Exercise:  f.exercise,
+		Observe:   func() bool { return f.dispatched },
+	}
+}
+
+// keyBlindGate is the fake every adapter supplied before #1475: its answer
+// does not depend on the key it is handed.
+type keyBlindGate struct{ state permission.State }
+
+func (g *keyBlindGate) SetState(_ string, state permission.State) { g.state = state }
+
+func (g *keyBlindGate) Granted(_, _ string) bool { return g.state == permission.StateGranted }
+
+// TestAssertPermissionGated_PassesAgainstACorrectlyGatedReceiver is the
+// vacuity guard. Without it, an arm that reported a failure unconditionally
+// would satisfy every mutation case below and look like excellent coverage.
+// The receiver here honours both permissions, which is the real shape of a
+// hook receiver: "hooks" authorises writing our entries, "transcripts"
+// authorises reading the file those entries point at.
+func TestAssertPermissionGated_PassesAgainstACorrectlyGatedReceiver(t *testing.T) {
+	for _, tc := range []struct{ key, other string }{
+		{selfTestTranscripts, selfTestHooks},
+		{selfTestHooks, selfTestTranscripts},
+	} {
+		t.Run(tc.key, func(t *testing.T) {
+			r := &fakeReceiver{
+				gate:    NewConsentGate(),
+				gatedOn: []string{selfTestHooks, selfTestTranscripts},
+			}
+			AssertPermissionGated(t, r.gateFor(tc.key, tc.other))
+		})
+	}
+}
+
+// TestKeyIsolationArm_FailsAReceiverGatedOnTheWrongPermission is #1466 itself,
+// reduced to a fixture: a receiver that checks only "hooks" while the effect
+// it produces is a transcript read. Denying "transcripts" with "hooks" held
+// open is the one state that separates it from a correct receiver, and the
+// arm must report it.
+func TestKeyIsolationArm_FailsAReceiverGatedOnTheWrongPermission(t *testing.T) {
+	r := &fakeReceiver{gate: NewConsentGate(), gatedOn: []string{selfTestHooks}}
+
+	rec := &recordingReporter{}
+	assertGatedOnTheNamedKey(rec, r.gateFor(selfTestTranscripts, selfTestHooks))
+
+	if !rec.failed() {
+		t.Fatal("key-isolation arm passed a receiver gated on \"hooks\" while the key under test " +
+			"was \"transcripts\" — this is exactly the #1466 defect the arm exists to catch")
+	}
+	if !strings.Contains(rec.report(), selfTestTranscripts) {
+		t.Errorf("failure message does not name the key under test: %s", rec.report())
+	}
+}
+
+// TestKeyIsolationArm_FailsAnUngatedReceiver covers the other mis-gating: no
+// consent check at all. The lockstep arms already catch this one; the arm must
+// not have become narrower than they are on its way to catching the wrong-key
+// case.
+func TestKeyIsolationArm_FailsAnUngatedReceiver(t *testing.T) {
+	r := &fakeReceiver{gate: NewConsentGate(), gatedOn: nil}
+
+	rec := &recordingReporter{}
+	assertGatedOnTheNamedKey(rec, r.gateFor(selfTestTranscripts, selfTestHooks))
+
+	if !rec.failed() {
+		t.Fatal("key-isolation arm passed a receiver with no consent check at all")
+	}
+}
+
+// TestKeyIsolationArm_FailsAKeyBlindWiring pins the arm's write order, which
+// is load-bearing and not obvious. The key under test is denied FIRST and the
+// other keys opened AFTER, so a SetState that ignores the key it is handed
+// ends up holding everything granted, dispatches, and fails here. Reverse the
+// two loops and this test goes green: such a wiring would settle at "denied",
+// pass, and the contract would once again be satisfiable by precisely the fake
+// that hid #1466.
+func TestKeyIsolationArm_FailsAKeyBlindWiring(t *testing.T) {
+	// The receiver itself is gated correctly — only the wiring is blind.
+	r := &fakeReceiver{
+		gate:    &keyBlindGate{},
+		gatedOn: []string{selfTestHooks, selfTestTranscripts},
+	}
+
+	rec := &recordingReporter{}
+	assertGatedOnTheNamedKey(rec, r.gateFor(selfTestTranscripts, selfTestHooks))
+
+	if !rec.failed() {
+		t.Fatal("key-isolation arm passed a SetState that ignores the key it is handed — " +
+			"the arm must deny the key under test before opening the others")
+	}
+}
+
+// TestTheLockstepArmsCannotSeeAWrongKeyGate is the measured blind spot: the
+// three original arms move every key together, so they answer identically for
+// a receiver gated on "hooks" and one gated on "transcripts". It is why the
+// fourth arm exists, and why #1466 survived a contract wired straight at the
+// defective receiver.
+//
+// If a future change makes one of these arms catch a wrong-key gate on its
+// own, RETIRE this test rather than patching it — its subject is a limitation,
+// not a behaviour worth preserving.
+func TestTheLockstepArmsCannotSeeAWrongKeyGate(t *testing.T) {
+	misGated := func() PermissionGate {
+		r := &fakeReceiver{gate: NewConsentGate(), gatedOn: []string{selfTestHooks}}
+		return r.gateFor(selfTestTranscripts, selfTestHooks)
+	}
+
+	for name, arm := range map[string]func(gateReporter, PermissionGate){
+		"pending_no_effect":         assertPendingNoEffect,
+		"granted_effect_observable": assertGrantedEffectObservable,
+		"revoked_effect_undone":     assertRevokedEffectUndone,
+	} {
+		t.Run(name, func(t *testing.T) {
+			rec := &recordingReporter{}
+			arm(rec, misGated())
+			if rec.failed() {
+				t.Fatalf("this arm now catches a wrong-key gate (%s) — retire this test, "+
+					"it documents a limitation that no longer holds", rec.report())
+			}
+		})
+	}
+}
+
+// TestMalformedGateReason covers the precondition guard. A wiring the contract
+// cannot exercise must be refused out loud: silently running three of four
+// arms is indistinguishable from a pass, which is the failure mode the whole
+// change is about.
+func TestMalformedGateReason(t *testing.T) {
+	wellFormed := func() PermissionGate {
+		r := &fakeReceiver{gate: NewConsentGate(), gatedOn: []string{selfTestHooks}}
+		return r.gateFor(selfTestHooks, selfTestTranscripts)
+	}
+
+	if reason := malformedGateReason(wellFormed()); reason != "" {
+		t.Fatalf("well-formed gate rejected: %s", reason)
+	}
+
+	for name, mutate := range map[string]func(*PermissionGate){
+		"no_key":              func(g *PermissionGate) { g.Key = "" },
+		"no_other_keys":       func(g *PermissionGate) { g.OtherKeys = nil },
+		"other_key_is_theKey": func(g *PermissionGate) { g.OtherKeys = []string{g.Key} },
+		"no_set_state":        func(g *PermissionGate) { g.SetState = nil },
+		"no_exercise":         func(g *PermissionGate) { g.Exercise = nil },
+		"no_observe":          func(g *PermissionGate) { g.Observe = nil },
+	} {
+		t.Run(name, func(t *testing.T) {
+			g := wellFormed()
+			mutate(&g)
+			if reason := malformedGateReason(g); reason == "" {
+				t.Error("malformed gate accepted — the contract would run a reduced set of arms silently")
+			}
+		})
+	}
+}
+
+// TestConsentGate_AnswersPerKey pins the fake the contract now owns. Three
+// adapters had re-invented this after #1466; the value of moving it here is
+// entirely that a wiring can no longer supply a key-blind one by accident.
+func TestConsentGate_AnswersPerKey(t *testing.T) {
+	g := NewConsentGate()
+
+	if g.Granted("any", selfTestHooks) {
+		t.Error("an unanswered key must read as pending, not granted")
+	}
+
+	g.SetState(selfTestHooks, permission.StateGranted)
+	g.SetState(selfTestTranscripts, permission.StateDenied)
+
+	if !g.Granted("any", selfTestHooks) {
+		t.Error("granted key reads as not granted")
+	}
+	if g.Granted("any", selfTestTranscripts) {
+		t.Error("denied key reads as granted — the gate is answering key-blind")
+	}
+}

--- a/core/internal/contracttesting/permission_gate_test.go
+++ b/core/internal/contracttesting/permission_gate_test.go
@@ -105,16 +105,22 @@ func TestAssertPermissionGated_PassesAgainstACorrectlyGatedReceiver(t *testing.T
 	}
 }
 
-// TestKeyIsolationArm_FailsAReceiverGatedOnTheWrongPermission is #1466 itself,
-// reduced to a fixture: a receiver that checks only "hooks" while the effect
-// it produces is a transcript read. Denying "transcripts" with "hooks" held
-// open is the one state that separates it from a correct receiver, and the
-// arm must report it.
-func TestKeyIsolationArm_FailsAReceiverGatedOnTheWrongPermission(t *testing.T) {
+// misGatedReceiver is #1466 itself, reduced to a fixture: a receiver that
+// checks only "hooks" while the effect it produces is a transcript read, wired
+// with "transcripts" as the key under test. One constructor shared by the two
+// tests below, so neither can drift onto a different subject than the other.
+func misGatedReceiver() PermissionGate {
 	r := &fakeReceiver{gate: NewConsentGate(), gatedOn: []string{selfTestHooks}}
+	return r.gateFor(selfTestTranscripts, selfTestHooks)
+}
 
+// TestKeyIsolationArm_FailsAReceiverGatedOnTheWrongPermission drives that
+// fixture through the new arm. Denying "transcripts" with "hooks" held open is
+// the one state that separates it from a correct receiver, and the arm must
+// report it.
+func TestKeyIsolationArm_FailsAReceiverGatedOnTheWrongPermission(t *testing.T) {
 	rec := &recordingReporter{}
-	assertGatedOnTheNamedKey(rec, r.gateFor(selfTestTranscripts, selfTestHooks))
+	assertGatedOnTheNamedKey(rec, misGatedReceiver())
 
 	if !rec.failed() {
 		t.Fatal("key-isolation arm passed a receiver gated on \"hooks\" while the key under test " +
@@ -173,9 +179,16 @@ func TestKeyIsolationArm_FailsAKeyBlindWiring(t *testing.T) {
 // own, RETIRE this test rather than patching it — its subject is a limitation,
 // not a behaviour worth preserving.
 func TestTheLockstepArmsCannotSeeAWrongKeyGate(t *testing.T) {
-	misGated := func() PermissionGate {
-		r := &fakeReceiver{gate: NewConsentGate(), gatedOn: []string{selfTestHooks}}
-		return r.gateFor(selfTestTranscripts, selfTestHooks)
+	// Anchor the fixture before asserting anything about it. This is the only
+	// test in the file that asserts a NEGATIVE, so it is the only one that can
+	// go quietly vacuous: a misGatedReceiver that drifted to correct gating
+	// would satisfy every assertion below while the limitation it documents
+	// went unexamined, and the "retire me" instruction above would never fire.
+	anchor := &recordingReporter{}
+	assertGatedOnTheNamedKey(anchor, misGatedReceiver())
+	if !anchor.failed() {
+		t.Fatal("the fixture is no longer mis-gated — this test would assert nothing about the " +
+			"lockstep arms; fix misGatedReceiver rather than the assertions below")
 	}
 
 	for name, arm := range map[string]func(gateReporter, PermissionGate){
@@ -185,7 +198,7 @@ func TestTheLockstepArmsCannotSeeAWrongKeyGate(t *testing.T) {
 	} {
 		t.Run(name, func(t *testing.T) {
 			rec := &recordingReporter{}
-			arm(rec, misGated())
+			arm(rec, misGatedReceiver())
 			if rec.failed() {
 				t.Fatalf("this arm now catches a wrong-key gate (%s) — retire this test, "+
 					"it documents a limitation that no longer holds", rec.report())
@@ -212,6 +225,7 @@ func TestMalformedGateReason(t *testing.T) {
 		"no_key":              func(g *PermissionGate) { g.Key = "" },
 		"no_other_keys":       func(g *PermissionGate) { g.OtherKeys = nil },
 		"other_key_is_theKey": func(g *PermissionGate) { g.OtherKeys = []string{g.Key} },
+		"other_key_is_empty":  func(g *PermissionGate) { g.OtherKeys = []string{""} },
 		"no_set_state":        func(g *PermissionGate) { g.SetState = nil },
 		"no_exercise":         func(g *PermissionGate) { g.Exercise = nil },
 		"no_observe":          func(g *PermissionGate) { g.Observe = nil },


### PR DESCRIPTION
Closes #1475.

## The blind spot

`AssertPermissionGated` drove ONE permission through three states, and every adapter supplied a gate shaped `func(_, _ string) bool` that **discards the key**. It therefore answered identically for every permission an adapter declares: a receiver gated on the WRONG permission was indistinguishable from a correct one, because *two permissions held at opposite states* is exactly what the contract could not express.

That is why #1466's live #570 violation survived. `claudecode`'s hook receiver read transcripts with `transcripts` **denied**, for the adapter's whole life, while `AssertPermissionGated` was wired at that receiver (`hooks_test.go:806`) and green throughout.

## Direction taken: 1 only

`PermissionGate` now names the permission under test (`Key`) plus at least one the call site must **not** be gated on (`OtherKeys`), and `SetState` takes the key it is driving. That is a **signature change**, deliberately: it is a compile error at all eight wirings, so none can silently stay key-blind.

A fourth arm, `gated_on_the_named_key`, holds `Key` denied while `OtherKeys` are granted — the one state that tells a correctly-gated call site from a mis-gated one.

**The write order is load-bearing.** `Key` is denied **first** and the other keys opened **after**, so a wiring that still ignored its key ends up holding everything granted, dispatches, and fails. Reverse the loops and such a wiring settles at "denied", passes, and the contract is once again satisfiable by precisely the fake that hid #1466. There is a test that fails on exactly that inversion.

The contract now owns the keyed fake (`contracttesting.ConsentGate`). Three adapters had each re-invented the same `map[string]bool` after #1466, and a contract whose *wiring* supplies the fake is a contract whose wiring can supply a key-blind one.

**Direction 2 is filed as #1488, not taken on here** — see "On direction 2" below.

## Mutation evidence, seen red

Per AGENTS.md's Testing section as generalized by #1482: a check a change *adds* has no "before" to run against and owes a deliberate mutation instead.

**1. The real defect, in the real adapter.** Reinstating #1466 — deleting the `transcripts` gate from `claudecode/hooks.go`'s `admitHookRequest`:

```
--- FAIL: TestHookHandler_PermissionGateContract (0.00s)
    --- FAIL: TestHookHandler_PermissionGateContract/transcripts (0.00s)
        --- FAIL: TestHookHandler_PermissionGateContract/transcripts/gated_on_the_named_key (0.00s)
            permission_gate.go:95: effect observed while "transcripts" is denied and [hooks] granted —
            the call site is gated on some OTHER permission (or on none), not on "transcripts" (issue #1475)
```

Note **which** arms failed: only the new one. `pending_no_effect`, `granted_effect_observable` and `revoked_effect_undone` all stayed green under the live defect — that is the blind spot, measured.

The same mutation on the other two receivers:

| receiver | arm that fails |
|---|---|
| `codex/hooks.go` | `TestHookHandler_PermissionGateContract/transcripts/gated_on_the_named_key` |
| `copilot/hooks.go` | `TestHookReceiver_PermissionGateContract/transcripts/gated_on_the_named_key` |

All three restored and green afterwards.

**2. Mutating the arm itself.** Neutering its detection (`if false && g.Observe()`) fails all three `TestKeyIsolationArm_*` cases; inverting the write order fails `TestKeyIsolationArm_FailsAKeyBlindWiring` and *only* that one, so the ordering test is targeted rather than incidental.

**3. Committed, not just described.** #1482 prefers a mutation that lives as a fixture over one that lives in a PR body, because a merged PR body is re-run by nothing. `core/internal/contracttesting/permission_gate_test.go` is that fixture:

- `TestAssertPermissionGated_PassesAgainstACorrectlyGatedReceiver` — the **vacuity guard**. Without it, an arm that failed unconditionally would satisfy every case below and look like excellent coverage.
- `TestKeyIsolationArm_FailsAReceiverGatedOnTheWrongPermission` — #1466 reduced to a fixture.
- `TestKeyIsolationArm_FailsAnUngatedReceiver` — the arm did not get narrower than the lockstep arms on its way to catching the wrong-key case.
- `TestKeyIsolationArm_FailsAKeyBlindWiring` — pins the write order.
- `TestTheLockstepArmsCannotSeeAWrongKeyGate` — the blind spot itself, asserted. It carries an instruction to **retire** it, not patch it, if an earlier arm ever gets stronger; its subject is a limitation, not a behaviour worth preserving.
- `TestMalformedGateReason` — the precondition guard. `malformedGateReason` returns a reason rather than calling `t.Fatal` precisely so the shapes it rejects are themselves testable; a guard nobody can drive is the same unverifiable check this PR exists to remove.
- `TestAssertPermissionGatedOnEachKey_DerivesTheOthers` — pins the derived pairing over **three** keys, because every wiring in the tree has two, and with two "the others" and "the other one" are the same answer. Dropping the prefix in the derivation fails it (verified).

## The three per-adapter transcripts tests: they STAY, as locks

The issue asks for this to be explicit. `claudecode`'s `TestHookHandler_TranscriptsConsentGatesTheRead` (via #1474), `codex`'s namesake, and `copilot`'s `TestHookReceiver_DeniedTranscriptsConsentDropsQuietly` all **stay**.

Per #1450, a rewritten guard replays its predecessor's cases or it is not known to be a superset — and this one is **not** a superset. Each of the three additionally asserts the **200** a consent refusal answers with, and `AssertPermissionGated`'s `Exercise` is opaque to it: the contract observes dispatch, never the status code. They are relabelled as locks in their doc comments, saying what they carry that the contract does not.

What the contract adds is that the obligation stops being each adapter's to remember.

## Also: copilot's receiver had no contract wiring at all

Found while migrating: `copilot` had only the two hand-written tests, no `AssertPermissionGated`. It was correct — by the author's care, not by anything that would have caught its absence. That is the issue's "a fourth receiver forgetting is caught by nothing", already in the tree. This PR wires it (for both keys).

## On direction 2 — judged, argued, filed as #1488

I think it is right, and doing direction 1 is what produced the evidence:

1. **Direction 1 makes the obligation assertable, not unforgettable.** A receiver must still be wired once per permission it must honour; nothing fails if an author wires only the `hooks` arm and never thinks about `transcripts`. That is #1466's own class of omission, moved one level up.
2. **The `copilot` finding above is that omission, observed.**
3. **The chokepoint already exists and is already enforced.** `core/architecture_hookbody_test.go` (#1389) statically requires that inside `core/adapters/inbound/agents/...` an inbound request body be read **only** by `hookjson.DecodeConfined`. Every receiver provably passes through one function.
4. **`DecodeConfined` already takes the confiner.** Taking the permission it acts under is symmetric: the function that confines the path becomes the function that requires consent to read it.

It is a different, larger diff with real ordering constraints (the `hooks` check must stay ahead of `ObserveHookReceipt` and the `transcripts` check behind it, per `AssertHookReceiptObserved`'s fourth obligation), so per this repo's "no speculative future-proofing" it is #1488 rather than scope here.

## Verification

`tools/preflight.sh` chunked, all foreground:

| gate | result |
|---|---|
| `--only go` (gofmt, core, onboarding-factory, `of validate`, rig smoke, replay fixtures, starhistory) | **PASS** |
| `--only arch` (ARS, composite 7.9439 → 7.9436, no category regression) | **PASS** |
| `--only tools` | **PASS** |
| `--only skills` (23 files, 0 errors, 0 warnings) | **PASS** |
| `--only posix` | **PASS** |

`--only web` and `--only security` not run: the diff touches no `web/` tree and no dependency manifest. The push used `--no-verify` because the pre-push hook re-runs gates already run unscoped above (AGENTS.md sanctions exactly this).

`grep -c "^func Assert" core/internal/contracttesting/*.go` still totals **seven** — this adds an arm, not a family — so AGENTS.md's "All seven contract families" sentence stays correct.

## Review round (5 findings, all applied)

The review subagent independently reproduced the mutation at all five live-gate call sites — including two I had not: `claudecode/statusline.go:98` (statusline→hooks) and `services/input_service.go:118` (control→hooks). All five go red only on the new arm.

| # | finding | fix |
|---|---|---|
| 1 | `TestTheLockstepArmsCannotSeeAWrongKeyGate` asserts a **negative** with nothing anchoring its fixture to a mis-gated receiver — a fixture that drifted to correct gating left it green while asserting nothing, and its own "retire me" instruction would never fire | drives the isolation arm first and fails if the fixture is no longer mis-gated; one `misGatedReceiver` constructor shared with the wrong-permission test so the two cannot drift apart. Verified red on the reviewer's exact repro |
| 2 | the three install-type wirings early-return for every non-`Key` key, so the isolation arm there is **inert** — byte-identical to the revoked arm — while their comments claimed it proved something | comments and the package doc now say what the code does |
| 3 | AGENTS.md claimed "every adapter" supplied a key-blind gate (only the live-gate wirings did) and that `ConsentGate` replaced three `map[string]bool` re-inventions (it replaced three key-blind **boolean** fakes; the `keyedGate` literals are still live and deliberately kept) | corrected |
| 4 | `malformedGateReason` accepted `OtherKeys: []string{""}` — `Key` is non-empty by an earlier check, so `k == g.Key` could never catch it, and the arm would grant a permission no call site checks and pass having proved nothing | rejected, with a table case |
| 5 | `instructioninstaller`'s `SetState` called `t.Fatalf` from inside an arm subtest → `"subtest may have called FailNow on a parent test"` instead of the real reason | errors reported with `t.Errorf` (goroutine-safe) and declarations resolved once on the main goroutine. Verified: the real reason now prints alone |

## Simplify round (4 agents, converged findings applied)

- **`ConsentGate` is backed by `permission.Set`** instead of a bare map. Its doc previously restated the domain's "never answered reads as pending" rule in prose — a hand-maintained copy of an invariant that would silently keep the old answer if the domain changed it.
- **`AssertPermissionGatedOnEachKey`** replaces the `{key, other}` pair table that had been copy-pasted at three receivers *and* in the contract's own self-test. A wiring names its key set once and the pairing is derived; a hand-written table can list only one direction, and the direction that already works is indistinguishable from covering both.
- **`contracttesting.OnlyKey`** replaces the `if key != X { return }` filter the three install-type wirings had each hand-rolled — the install-side counterpart to `ConsentGate`, which the live-gate flavour already had.
- The instructions wiring **drops `lookupPermission` and the `driveErr` capture** (finding 5's fix, done more simply): only the `FailNow` family is goroutine-restricted.
- `input_service_test.go` no longer spells an `OtherKey` as the bare literal `"transcripts"` — a key nothing declares would make that arm a no-op that still reads green.
- The three surviving `keyedGate` types carry a line pointing at `ConsentGate`.

**Skipped, with reasons:** exporting `contracttesting.findPermission` (pre-existing duplication across four packages; this diff no longer *adds* a copy, so it is out of scope); splitting the contract into separate live-gate and install-gate assertions (a defensible alternative design — the reviewer argued a *type* expresses the distinction better than a flag, and that is fair — but the uniform contract with no opt-out is the deliberate choice here, and swapping designs late is not a defect fix); the fourth arm's measured suite cost (**+8.8 ms**, **+21.5 ms** under `-race`, ~0.03% of a ~30 s package set — below the suite's own ±0.8 s noise floor).

## Verification (re-run after both rounds)

| gate | result |
|---|---|
| `--only go` (gofmt, core, onboarding-factory, `of validate`, rig smoke, replay fixtures, starhistory) | **PASS** |
| `--only arch` (ARS, composite 7.94388 → 7.94365, no category regression) | **PASS** |
| `--only tools` | **PASS** |
| `--only skills` (23 files, 0 errors, 0 warnings) | **PASS** |
| `--only posix` | **PASS** |

## CI

Every merge-gating check passes on head `df35e52a`: `go-test`, `build-test`, `ars-gate`, and both `test (…)` web entries (plus CodeQL, SonarCloud). `guard` is correctly absent — it dispatches only on `replaydata/**`.

**CodeScene is red, and it is advisory** (AGENTS.md: "neither branch protection nor the 'Protect Main' ruleset requires it to pass"). Looked at rather than waved through: it flagged `malformedGateReason` for Complex Method + Complex Conditional (`permission_gate.go` 10.00 → 9.39). The Complex Method half was a fair complaint with a real seam — the shape checks ask whether a gate was filled in at all, the `OtherKeys` loop asks whether the key set it names can produce the isolation arm's state — so that split landed and the file went 9.39 → **9.69**, 2 advisory rules → 1. The remainder is the three-clause `SetState == nil || Exercise == nil || Observe == nil` guard, which is the clearest form of what it does; splitting it further would buy a number, not a reader. (CodeScene also records `input_service_test.go` improving 9.69 → **10.00**.)

## Note on the contract-family count

`AssertPermissionGatedOnEachKey` makes `grep -c "^func Assert"` over `contracttesting` return **eight** while the number of distinct obligations is still **seven** — it is a driver that runs the permission-gate family once per key, not a family of its own. AGENTS.md's sentence now says what it counts, because the naive grep is exactly how that number has been set wrong after a rebase before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
