### PR TITLE
feat(replay): measure transition timing against the recording's own events.jsonl

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -597,6 +597,43 @@ Before marking a ticket done, run the full suite — every layer must pass:
   surfaces without Docker. Takes ~3 minutes unscoped; under `--changed` it
   runs only when the diff touches `replaydata/`, the factory, or the
   `core/` parsers and tailer a golden is derived from.
+- Replay transition timing: a golden records a `virtual_time` on every
+  transition, and until #1480 **nothing compared it to anything** — the
+  goldens pin it only against their own previous value, `compareOrdered` walks
+  `prev_state`/`new_state` index-by-index and never reads the time, and the
+  "N of 309 recordings diverge" headline every replay PR quotes is counts and
+  kinds only. So a transition reproduced at the right position in the ORDER but
+  31 seconds from when the daemon made it was a full pass, and the golden then
+  pinned it as correct. `transitionTimeDeltas`
+  (`tools/onboarding-factory/cmd/replay/timing_drift.go`) measures each
+  reproduced transition against the `ts` the recording's own `events.jsonl`
+  carries, riding `compareOrdered`'s exact pairing so the two figures describe
+  the same transitions; a pairing change in one is a change owed to the other.
+  Only KIND-MATCHED pairs are measured — where `compareOrdered` reports
+  `state_differs` the two sides are not the same transition, so their timestamp
+  difference means nothing and counting it would report one sequence divergence
+  twice.
+  It is a **ratchet, not a tolerance gate**, and that is the deliberate
+  shape: 28.7% of the catalog's 818 kind-matched pairs are already more than 1s
+  from their daemon, so a gate failing on all of them would protect nothing.
+  `TestSidecarReplayTransitionTimesMatchTheDaemonsOwnLog` walks all 309
+  sidecar-driven recordings, prints the distribution, and fails when a
+  recording NEWLY drifts, when a pinned entry stops drifting and is left to rot,
+  or when the aggregate counts grow — the same idiom `knownZeroTransition`
+  uses. The 1s threshold is read off the measured distribution rather than
+  picked: |delta| is sharply bimodal (70.0% under 100ms, 28.7% over 1s) with a
+  near-empty decade between, so the cut lands where ~1% of the population
+  lives; `driftThreshold`'s doc comment carries the histogram. The 20 goldens
+  #1476 documented as its accepted cost are enumerated by name in
+  `knownFirstTransitionDrift` rather than living in a paragraph of a doc
+  comment, which is what #1480 was filed about. Its mutation evidence is
+  committed, not described: `cmd/replay/testdata/timing/` holds one file per
+  timing shape, carrying both verdicts on purpose — a detector that flags
+  everything and one that flags correctly are indistinguishable without the
+  cases that must stay silent. `tools/replay-fixtures.sh` reports the same
+  figure beside the divergence figure, because a `go test` that passes prints
+  nothing without `-v` and an unread measurement is the failure mode this
+  closes.
 - Replay goldens (when a recording or replay-output change is in play):
   regenerate with `UPDATE_REPLAY_GOLDENS=1 go test
   ./tools/onboarding-factory/cmd/replay/... -count=1` (the `-count=1`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -604,15 +604,18 @@ Before marking a ticket done, run the full suite — every layer must pass:
   "N of 309 recordings diverge" headline every replay PR quotes is counts and
   kinds only. So a transition reproduced at the right position in the ORDER but
   31 seconds from when the daemon made it was a full pass, and the golden then
-  pinned it as correct. `transitionTimeDeltas`
-  (`tools/onboarding-factory/cmd/replay/timing_drift.go`) measures each
-  reproduced transition against the `ts` the recording's own `events.jsonl`
-  carries, riding `compareOrdered`'s exact pairing so the two figures describe
-  the same transitions; a pairing change in one is a change owed to the other.
-  Only KIND-MATCHED pairs are measured — where `compareOrdered` reports
+  pinned it as correct. `compareOrdered`
+  (`tools/onboarding-factory/cmd/replay/extended_check.go`) now returns the
+  MATCHED pairs rather than a count of them, each carrying how far apart in time
+  the two sides fired — so the ordered-divergence figure and the timing figure
+  are one traversal and cannot describe different transitions. The first draft
+  had a second, identical loop plus three comments and a runtime assertion
+  saying the two must agree; one loop makes that structural instead.
+  Only KIND-MATCHED pairs carry a delta — where `compareOrdered` reports
   `state_differs` the two sides are not the same transition, so their timestamp
   difference means nothing and counting it would report one sequence divergence
-  twice.
+  twice. The reporting side (`timing_drift.go`) buckets and ranks those deltas;
+  it reuses `core/domain/stats.Percentile` rather than carrying its own.
   It is a **ratchet, not a tolerance gate**, and that is the deliberate
   shape: 28.7% of the catalog's 818 kind-matched pairs are already more than 1s
   from their daemon, so a gate failing on all of them would protect nothing.

--- a/tools/onboarding-factory/cmd/replay/extended_check.go
+++ b/tools/onboarding-factory/cmd/replay/extended_check.go
@@ -23,10 +23,8 @@ func runExtendedCheck(sidecarPath string, replayed []transition) (*extendedCheck
 		RecordedCount: len(recorded),
 		ReplayedCount: len(replayedReal),
 	}
-	check.OrderedMatches, check.OrderedMismatches = compareOrdered(recorded, replayedReal)
-	// Same two slices, same index-by-index pairing — see transitionTimeDeltas
-	// for why that identity is a requirement and not just tidiness (#1480).
-	check.TimeDeltas = transitionTimeDeltas(recorded, replayedReal)
+	check.TimeDeltas, check.OrderedMismatches = compareOrdered(recorded, replayedReal)
+	check.OrderedMatches = len(check.TimeDeltas)
 
 	recordedKinds := uniqueTransitionKinds(recorded, func(e lifecycle.Event) (string, string) { return e.PrevState, e.NewState })
 	replayedKinds := uniqueTransitionKinds(replayedReal, func(t transition) (string, string) { return t.PrevState, t.NewState })
@@ -54,18 +52,31 @@ func dropInitTransitions(replayed []transition) []transition {
 // the shorter slice's length, then reports the longer slice's tail as
 // missing/extra.
 //
-// It reads prev_state/new_state and NEVER the time. That is by design and is
-// now stated rather than merely true: transitionTimeDeltas is the timing
-// counterpart, riding this exact pairing, so the two figures describe the same
-// set of transitions (#1480). A change to the pairing here must be made there
-// too, or the ordered-divergence figure and the timing figure start disagreeing
-// about which transitions they are talking about.
-func compareOrdered(recorded []lifecycle.Event, replayedReal []transition) (matches int, mismatches []transitionMismatch) {
+// It returns the MATCHED pairs rather than a count of them, each carrying how
+// far apart in time the two sides fired (#1480). The count callers used to get
+// is len(matched). Those were two functions until the timing measurement's
+// first draft, which rode this pairing from a second, identical loop and
+// documented the coupling in three prose comments plus a runtime assertion that
+// len(TimeDeltas) == OrderedMatches. One loop makes that equality hold by
+// construction, so there is nothing left to remember or to assert: a pairing
+// change cannot move the ordered figure and the timing figure apart, because
+// they are now the same traversal.
+//
+// The timing of an UNMATCHED pair is deliberately not reported. The two sides
+// are not the same transition there — that is what state_differs means — so
+// subtracting their timestamps yields a number with no meaning, and counting it
+// would report one sequence divergence twice.
+func compareOrdered(recorded []lifecycle.Event, replayedReal []transition) (matched []timeDelta, mismatches []transitionMismatch) {
 	n := min(len(recorded), len(replayedReal))
+	matched = make([]timeDelta, 0, n)
 	for i := 0; i < n; i++ {
 		r, p := recorded[i], replayedReal[i]
 		if r.PrevState == p.PrevState && r.NewState == p.NewState {
-			matches++
+			matched = append(matched, timeDelta{
+				Index: i,
+				Kind:  r.PrevState + "→" + r.NewState,
+				Delta: p.VirtualTime.Sub(r.Timestamp),
+			})
 			continue
 		}
 		mismatches = append(mismatches, transitionMismatch{
@@ -91,7 +102,7 @@ func compareOrdered(recorded []lifecycle.Event, replayedReal []transition) (matc
 			Replayed: p.PrevState + "→" + p.NewState,
 		})
 	}
-	return matches, mismatches
+	return matched, mismatches
 }
 
 // diffKinds returns the "prev→new" kind strings present in recordedKinds but

--- a/tools/onboarding-factory/cmd/replay/extended_check.go
+++ b/tools/onboarding-factory/cmd/replay/extended_check.go
@@ -24,6 +24,9 @@ func runExtendedCheck(sidecarPath string, replayed []transition) (*extendedCheck
 		ReplayedCount: len(replayedReal),
 	}
 	check.OrderedMatches, check.OrderedMismatches = compareOrdered(recorded, replayedReal)
+	// Same two slices, same index-by-index pairing — see transitionTimeDeltas
+	// for why that identity is a requirement and not just tidiness (#1480).
+	check.TimeDeltas = transitionTimeDeltas(recorded, replayedReal)
 
 	recordedKinds := uniqueTransitionKinds(recorded, func(e lifecycle.Event) (string, string) { return e.PrevState, e.NewState })
 	replayedKinds := uniqueTransitionKinds(replayedReal, func(t transition) (string, string) { return t.PrevState, t.NewState })
@@ -50,6 +53,13 @@ func dropInitTransitions(replayed []transition) []transition {
 // compareOrdered walks recorded and replayed transitions index-by-index up to
 // the shorter slice's length, then reports the longer slice's tail as
 // missing/extra.
+//
+// It reads prev_state/new_state and NEVER the time. That is by design and is
+// now stated rather than merely true: transitionTimeDeltas is the timing
+// counterpart, riding this exact pairing, so the two figures describe the same
+// set of transitions (#1480). A change to the pairing here must be made there
+// too, or the ordered-divergence figure and the timing figure start disagreeing
+// about which transitions they are talking about.
 func compareOrdered(recorded []lifecycle.Event, replayedReal []transition) (matches int, mismatches []transitionMismatch) {
 	n := min(len(recorded), len(replayedReal))
 	for i := 0; i < n; i++ {

--- a/tools/onboarding-factory/cmd/replay/issue1342_debounce_test.go
+++ b/tools/onboarding-factory/cmd/replay/issue1342_debounce_test.go
@@ -164,27 +164,27 @@ var knownFabricated = map[string]string{
 	"copilot/scenarios/2-19_tool-gate-permission-prompt/recordings/2026-08-03-18-02-54_irrlichd-0.5.9+c55d3a0/transcript.jsonl": "pre-existing on main, unrelated to #1342",
 }
 
-// TestSidecarReplayAgreesWithTheDaemonsOwnLog walks the whole catalog and holds
-// every sidecar-driven recording to its own recording in both directions: it
-// must not reproduce ZERO transitions where the daemon logged some, and it must
-// not invent transitions where the daemon logged none.
+// forEachSidecarRecording replays every sidecar-driven recording in the catalog
+// and hands each one's extended check to visit, keyed by its catalog-relative
+// transcript path. It returns how many were visited.
 //
-// Catalog-wide rather than a list of paths, so a newly recorded fixture is
-// covered by existing rather than by somebody remembering to add it.
+// Shared because two catalog gates now ask the same question of the same
+// population and only differ in the verdict they draw — this one and #1480's
+// timing measurement. The walk is mechanism (what counts as a sidecar-driven
+// recording, how a transcript pairs with its sidecar, which recordings
+// legitimately have no extended check); the verdicts are policy and stay in
+// each caller's callback with its own known-lists and messages. Keeping the two
+// replay runs separate is deliberate — sharing the walk costs ~2.8s of re-run
+// and buys full independence between the gates, which is the right trade.
 //
-// Scope note: this asserts only the two absolute failures, not
-// replayed >= recorded generally. 145 of 309 sidecar-driven recordings still
-// show milder extended-check divergence (dominant kind: a missing terminal
-// working→ready); that is a separate population #1342 does not claim to fix,
-// and asserting on it here would fail for reasons this ticket is not about.
-func TestSidecarReplayAgreesWithTheDaemonsOwnLog(t *testing.T) {
+// The zero-recordings vacuity guard lives here rather than in each caller: it
+// is exactly the check that must not be forgotten by the third one, and it was
+// already written twice with two different wordings.
+func forEachSidecarRecording(t *testing.T, visit func(name string, ec *extendedCheck)) int {
+	t.Helper()
 	root := replaydataRoot(t)
 
 	var checked int
-	seenZero := map[string]bool{}
-	seenFabricated := map[string]bool{}
-	var newZero, newFabricated []string
-
 	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
@@ -208,12 +208,41 @@ func TestSidecarReplayAgreesWithTheDaemonsOwnLog(t *testing.T) {
 		// A process-owned-store adapter records no fswatcher fires and
 		// legitimately degrades to transcript-only, so it has no extended
 		// check to compare.
-		ec := report.ExtendedCheck
-		if ec == nil {
+		if report.ExtendedCheck == nil {
 			return nil
 		}
 		checked++
-		name := rel(root, transcript)
+		visit(rel(root, transcript), report.ExtendedCheck)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk replaydata/agents: %v", err)
+	}
+	if checked == 0 {
+		t.Fatal("no sidecar-driven recording found under replaydata/agents — the check is vacuous")
+	}
+	return checked
+}
+
+// TestSidecarReplayAgreesWithTheDaemonsOwnLog walks the whole catalog and holds
+// every sidecar-driven recording to its own recording in both directions: it
+// must not reproduce ZERO transitions where the daemon logged some, and it must
+// not invent transitions where the daemon logged none.
+//
+// Catalog-wide rather than a list of paths, so a newly recorded fixture is
+// covered by existing rather than by somebody remembering to add it.
+//
+// Scope note: this asserts only the two absolute failures, not
+// replayed >= recorded generally. 145 of 309 sidecar-driven recordings still
+// show milder extended-check divergence (dominant kind: a missing terminal
+// working→ready); that is a separate population #1342 does not claim to fix,
+// and asserting on it here would fail for reasons this ticket is not about.
+func TestSidecarReplayAgreesWithTheDaemonsOwnLog(t *testing.T) {
+	seenZero := map[string]bool{}
+	seenFabricated := map[string]bool{}
+	var newZero, newFabricated []string
+
+	checked := forEachSidecarRecording(t, func(name string, ec *extendedCheck) {
 		switch {
 		case ec.RecordedCount > 0 && ec.ReplayedCount == 0:
 			seenZero[name] = true
@@ -228,14 +257,7 @@ func TestSidecarReplayAgreesWithTheDaemonsOwnLog(t *testing.T) {
 					name, ec.ReplayedCount))
 			}
 		}
-		return nil
 	})
-	if err != nil {
-		t.Fatalf("walk replaydata/agents: %v", err)
-	}
-	if checked == 0 {
-		t.Fatal("no sidecar-driven recording found under replaydata/agents — the check is vacuous")
-	}
 
 	report := func(label string, items []string) {
 		if len(items) == 0 {

--- a/tools/onboarding-factory/cmd/replay/issue1480_timing_test.go
+++ b/tools/onboarding-factory/cmd/replay/issue1480_timing_test.go
@@ -3,7 +3,6 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"io/fs"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -31,15 +30,22 @@ import (
 // 1. The detector itself, over a committed corpus.
 // ---------------------------------------------------------------------------
 
+// wantPair is one expected (index, kind, delta) triple. One array of these
+// rather than three parallel want_* arrays: the parallel form needs a
+// hand-written same-length guard because the representation permits an
+// inconsistency, and the comparison fans out into three branches.
+type wantPair struct {
+	Index   int    `json:"index"`
+	Kind    string `json:"kind"`
+	DeltaNs int64  `json:"delta_ns"`
+}
+
 type timingCase struct {
-	Description  string            `json:"description"`
-	Recorded     []lifecycle.Event `json:"recorded"`
-	Replayed     []transition      `json:"replayed"`
-	WantDeltasNs []int64           `json:"want_deltas_ns"`
-	WantIndices  []int             `json:"want_indices"`
-	WantKinds    []string          `json:"want_kinds"`
-	WantFirstNs  *int64            `json:"want_first_drift"`
-	WantWorstNs  *int64            `json:"want_worst_ns"`
+	Description string            `json:"description"`
+	Recorded    []lifecycle.Event `json:"recorded"`
+	Replayed    []transition      `json:"replayed"`
+	Want        []wantPair        `json:"want"`
+	WantFirstNs *int64            `json:"want_first_drift"`
 }
 
 // TestTransitionTimeDeltas_Corpus is #1480's mutation evidence. Every case is a
@@ -85,41 +91,28 @@ func TestTransitionTimeDeltas_Corpus(t *testing.T) {
 			// guard below. A probe with kind-mismatched sides and no want_*
 			// fields at all passed and incremented sawClean before this check
 			// existed, which would have satisfied that guard on its own.
-			if len(tc.WantDeltasNs) == 0 {
+			if len(tc.Want) == 0 {
 				t.Fatalf("%s expects no measured pairs — a corpus row must pin at least one "+
-					"delta, or it passes without asserting anything", name)
-			}
-			if len(tc.WantIndices) != len(tc.WantDeltasNs) || len(tc.WantKinds) != len(tc.WantDeltasNs) {
-				t.Fatalf("%s: want_indices (%d) and want_kinds (%d) must both match want_deltas_ns (%d)",
-					name, len(tc.WantIndices), len(tc.WantKinds), len(tc.WantDeltasNs))
+					"pair, or it passes without asserting anything", name)
 			}
 
-			got := transitionTimeDeltas(tc.Recorded, tc.Replayed)
+			// compareOrdered is the production pairing, and since #1480 it is
+			// the only one — the corpus therefore exercises the function the
+			// daemon-comparison actually runs, not a parallel copy of it.
+			got, _ := compareOrdered(tc.Recorded, tc.Replayed)
 
-			if len(got) != len(tc.WantDeltasNs) {
-				t.Fatalf("%s: got %d deltas, want %d\n  got:  %v\n  want: %v",
-					tc.Description, len(got), len(tc.WantDeltasNs), durations(got), tc.WantDeltasNs)
+			want := make([]timeDelta, 0, len(tc.Want))
+			for _, w := range tc.Want {
+				want = append(want, timeDelta{Index: w.Index, Kind: w.Kind, Delta: time.Duration(w.DeltaNs)})
 			}
-			for i, d := range got {
-				if int64(d.Delta) != tc.WantDeltasNs[i] {
-					t.Errorf("%s: delta[%d] = %v (%d ns), want %v (%d ns)",
-						tc.Description, i, d.Delta, int64(d.Delta),
-						time.Duration(tc.WantDeltasNs[i]), tc.WantDeltasNs[i])
-				}
-				// Index is the INPUT pair position, not the output slot, and
-				// the two differ exactly where a pair was excluded — which is
-				// the case kind-mismatch-excluded.json exists to pin. Every
-				// "at pair N" in the 65-entry enumeration is this number, so a
-				// regression writing the output slot there would leave the
-				// deltas green and every reported position wrong.
-				if d.Index != tc.WantIndices[i] {
-					t.Errorf("%s: delta[%d].Index = %d, want %d",
-						tc.Description, i, d.Index, tc.WantIndices[i])
-				}
-				if d.Kind != tc.WantKinds[i] {
-					t.Errorf("%s: delta[%d].Kind = %q, want %q",
-						tc.Description, i, d.Kind, tc.WantKinds[i])
-				}
+			// Index is the INPUT pair position, not the output slot, and the
+			// two differ exactly where a pair was excluded — which is what
+			// kind-mismatch-excluded.json pins. Every "at pair N" in the
+			// 65-entry enumeration is that number, so a regression writing the
+			// output slot there would leave the deltas right and every
+			// reported position wrong.
+			if !reflect.DeepEqual(got, want) {
+				t.Fatalf("%s:\n  got  %v\n  want %v", tc.Description, got, want)
 			}
 
 			first, ok := firstDrift(got)
@@ -133,16 +126,6 @@ func TestTransitionTimeDeltas_Corpus(t *testing.T) {
 			case tc.WantFirstNs != nil && int64(first.Delta) != *tc.WantFirstNs:
 				t.Errorf("%s: first drift = %v, want %v",
 					tc.Description, first.Delta, time.Duration(*tc.WantFirstNs))
-			}
-
-			if tc.WantWorstNs != nil {
-				worst, found := worstDrift(got)
-				if !found {
-					t.Errorf("%s: no worst pair, want %v", tc.Description, time.Duration(*tc.WantWorstNs))
-				} else if int64(worst.Delta) != *tc.WantWorstNs {
-					t.Errorf("%s: worst = %v, want %v",
-						tc.Description, worst.Delta, time.Duration(*tc.WantWorstNs))
-				}
 			}
 
 			if tc.WantFirstNs != nil {
@@ -164,14 +147,6 @@ func TestTransitionTimeDeltas_Corpus(t *testing.T) {
 		t.Error("no corpus case expects a clean result — nothing here proves the measurement can stay silent")
 	}
 	t.Logf("corpus: %d cases (%d expect drift, %d expect clean)", ran, sawDrift, sawClean)
-}
-
-func durations(ds []timeDelta) []time.Duration {
-	out := make([]time.Duration, 0, len(ds))
-	for _, d := range ds {
-		out = append(out, d.Delta)
-	}
-	return out
 }
 
 // ---------------------------------------------------------------------------
@@ -322,61 +297,16 @@ const (
 // their daemon, and a gate that failed on all of them would be reverted within
 // the day and would protect nothing.
 func TestSidecarReplayTransitionTimesMatchTheDaemonsOwnLog(t *testing.T) {
-	root := replaydataRoot(t)
-
-	var checked int
 	var allDeltas []timeDelta
 	drifted := map[string]timeDelta{}
 	unmeasured := map[string]bool{}
-	measured := 0
 	overThreshold, over5s := 0, 0
 
-	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-		if d.IsDir() || filepath.Base(path) != eventsSidecarName {
-			return nil
-		}
-		transcript := filepath.Join(filepath.Dir(path), "transcript.jsonl")
-		if _, statErr := os.Stat(transcript); statErr != nil {
-			return nil
-		}
-		tp, sp, useSidecar := resolveInputPaths(transcript)
-		if !useSidecar {
-			return nil
-		}
-		report, runErr := runReplay(tp, sp, useSidecar, replaySettingsForTest(t, tp))
-		if runErr != nil {
-			t.Errorf("runReplay(%s): %v", rel(root, transcript), runErr)
-			return nil
-		}
-		ec := report.ExtendedCheck
-		if ec == nil {
-			return nil
-		}
-		checked++
-
-		name := rel(root, transcript)
+	checked := forEachSidecarRecording(t, func(name string, ec *extendedCheck) {
 		allDeltas = append(allDeltas, ec.TimeDeltas...)
 		if len(ec.TimeDeltas) == 0 {
 			unmeasured[name] = true
-		} else {
-			measured++
 		}
-		// compareOrdered counts a match on exactly the complement of the
-		// condition transitionTimeDeltas skips on, over the same
-		// min(len,len) loop — so "the same pairing" is not a matter of
-		// intent, it is the equality below, and it holds for all 309
-		// recordings today. Asserting it is what stops the two drifting
-		// apart behind three prose comments that a future editor can leave
-		// stale.
-		if len(ec.TimeDeltas) != ec.OrderedMatches {
-			t.Errorf("%s: %d timing pairs but %d ordered matches — transitionTimeDeltas "+
-				"and compareOrdered have stopped pairing identically",
-				name, len(ec.TimeDeltas), ec.OrderedMatches)
-		}
-
 		if first, ok := firstDrift(ec.TimeDeltas); ok {
 			drifted[name] = first
 		}
@@ -395,14 +325,8 @@ func TestSidecarReplayTransitionTimesMatchTheDaemonsOwnLog(t *testing.T) {
 		if anyOver5 {
 			over5s++
 		}
-		return nil
 	})
-	if err != nil {
-		t.Fatalf("walk replaydata/agents: %v", err)
-	}
-	if checked == 0 {
-		t.Fatal("no sidecar-driven recording found under replaydata/agents — the measurement is vacuous")
-	}
+	measured := checked - len(unmeasured)
 	// The measurement's own fail-loudly guard (AGENTS.md): a run that reached
 	// every recording but produced no comparable pair is not a clean result,
 	// it is a broken one, and without this it reads as a pass.

--- a/tools/onboarding-factory/cmd/replay/issue1480_timing_test.go
+++ b/tools/onboarding-factory/cmd/replay/issue1480_timing_test.go
@@ -6,6 +6,8 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"reflect"
+	"regexp"
 	"sort"
 	"strings"
 	"testing"
@@ -34,6 +36,8 @@ type timingCase struct {
 	Recorded     []lifecycle.Event `json:"recorded"`
 	Replayed     []transition      `json:"replayed"`
 	WantDeltasNs []int64           `json:"want_deltas_ns"`
+	WantIndices  []int             `json:"want_indices"`
+	WantKinds    []string          `json:"want_kinds"`
 	WantFirstNs  *int64            `json:"want_first_drift"`
 	WantWorstNs  *int64            `json:"want_worst_ns"`
 }
@@ -76,6 +80,19 @@ func TestTransitionTimeDeltas_Corpus(t *testing.T) {
 				t.Fatalf("%s supplies %d recorded / %d replayed — an empty side pins nothing",
 					name, len(tc.Recorded), len(tc.Replayed))
 			}
+			// And a case that expects no pairs asserts nothing either, while
+			// still passing and still counting toward the drift/clean balance
+			// guard below. A probe with kind-mismatched sides and no want_*
+			// fields at all passed and incremented sawClean before this check
+			// existed, which would have satisfied that guard on its own.
+			if len(tc.WantDeltasNs) == 0 {
+				t.Fatalf("%s expects no measured pairs — a corpus row must pin at least one "+
+					"delta, or it passes without asserting anything", name)
+			}
+			if len(tc.WantIndices) != len(tc.WantDeltasNs) || len(tc.WantKinds) != len(tc.WantDeltasNs) {
+				t.Fatalf("%s: want_indices (%d) and want_kinds (%d) must both match want_deltas_ns (%d)",
+					name, len(tc.WantIndices), len(tc.WantKinds), len(tc.WantDeltasNs))
+			}
 
 			got := transitionTimeDeltas(tc.Recorded, tc.Replayed)
 
@@ -88,6 +105,20 @@ func TestTransitionTimeDeltas_Corpus(t *testing.T) {
 					t.Errorf("%s: delta[%d] = %v (%d ns), want %v (%d ns)",
 						tc.Description, i, d.Delta, int64(d.Delta),
 						time.Duration(tc.WantDeltasNs[i]), tc.WantDeltasNs[i])
+				}
+				// Index is the INPUT pair position, not the output slot, and
+				// the two differ exactly where a pair was excluded — which is
+				// the case kind-mismatch-excluded.json exists to pin. Every
+				// "at pair N" in the 65-entry enumeration is this number, so a
+				// regression writing the output slot there would leave the
+				// deltas green and every reported position wrong.
+				if d.Index != tc.WantIndices[i] {
+					t.Errorf("%s: delta[%d].Index = %d, want %d",
+						tc.Description, i, d.Index, tc.WantIndices[i])
+				}
+				if d.Kind != tc.WantKinds[i] {
+					t.Errorf("%s: delta[%d].Kind = %q, want %q",
+						tc.Description, i, d.Kind, tc.WantKinds[i])
 				}
 			}
 
@@ -259,6 +290,23 @@ const (
 	maxRecordingsDriftingOver5s        = 50
 )
 
+// Lower bounds on HOW MUCH is measured. Every ratchet above is an upper bound,
+// and upper bounds alone are satisfied by a measurement that shrinks: a
+// classifier change that shifts replay transitions one position turns
+// kind-matched pairs into state_differs, which are excluded, so the drift
+// counts FALL and every assertion above passes while the population quietly
+// drains. Regenerating goldens then erases the only other trace, since
+// ordered_matches is the serialized field that would have moved.
+//
+// 39 of the 309 recordings already produce zero kind-matched pairs, so
+// "this recording measures nothing" is the current state of an eighth of the
+// catalog rather than a hypothetical — which is exactly why the floor is a
+// number and not merely a non-zero check.
+const (
+	minKindMatchedPairs   = 818
+	minMeasuredRecordings = 270
+)
+
 // TestSidecarReplayTransitionTimesMatchTheDaemonsOwnLog is #1480's mechanical
 // report: it walks every sidecar-driven recording in the catalog, measures each
 // reproduced transition against the ts the recording's own daemon logged, and
@@ -270,7 +318,7 @@ const (
 //
 // It is a RATCHET, not a tolerance gate. A transition drifting 900ms is not
 // asserted to be correct; it is asserted not to be NEW. The distinction matters
-// because 24.5% of the committed catalog's transitions are already over 1s from
+// because 28.7% of the committed catalog's transitions are already over 1s from
 // their daemon, and a gate that failed on all of them would be reverted within
 // the day and would protect nothing.
 func TestSidecarReplayTransitionTimesMatchTheDaemonsOwnLog(t *testing.T) {
@@ -279,6 +327,8 @@ func TestSidecarReplayTransitionTimesMatchTheDaemonsOwnLog(t *testing.T) {
 	var checked int
 	var allDeltas []timeDelta
 	drifted := map[string]timeDelta{}
+	unmeasured := map[string]bool{}
+	measured := 0
 	overThreshold, over5s := 0, 0
 
 	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
@@ -309,6 +359,23 @@ func TestSidecarReplayTransitionTimesMatchTheDaemonsOwnLog(t *testing.T) {
 
 		name := rel(root, transcript)
 		allDeltas = append(allDeltas, ec.TimeDeltas...)
+		if len(ec.TimeDeltas) == 0 {
+			unmeasured[name] = true
+		} else {
+			measured++
+		}
+		// compareOrdered counts a match on exactly the complement of the
+		// condition transitionTimeDeltas skips on, over the same
+		// min(len,len) loop — so "the same pairing" is not a matter of
+		// intent, it is the equality below, and it holds for all 309
+		// recordings today. Asserting it is what stops the two drifting
+		// apart behind three prose comments that a future editor can leave
+		// stale.
+		if len(ec.TimeDeltas) != ec.OrderedMatches {
+			t.Errorf("%s: %d timing pairs but %d ordered matches — transitionTimeDeltas "+
+				"and compareOrdered have stopped pairing identically",
+				name, len(ec.TimeDeltas), ec.OrderedMatches)
+		}
 
 		if first, ok := firstDrift(ec.TimeDeltas); ok {
 			drifted[name] = first
@@ -385,11 +452,34 @@ func TestSidecarReplayTransitionTimesMatchTheDaemonsOwnLog(t *testing.T) {
 	}
 	// Stale entries rot the list into a permanent excuse.
 	for n := range knownFirstTransitionDrift {
-		if _, still := drifted[n]; !still {
-			t.Errorf("knownFirstTransitionDrift entry %q no longer drifts — delete it", n)
+		if _, still := drifted[n]; still {
+			continue
 		}
+		// firstDrift returns false for two opposite reasons, and reporting
+		// them the same way tells a developer to DELETE COVERAGE in response
+		// to a regression: the drift genuinely shrank, or the recording
+		// stopped producing kind-matched pairs at all, which means replay no
+		// longer reproduces that transition and the entry is the last thing
+		// that should be removed.
+		if unmeasured[n] {
+			t.Errorf("knownFirstTransitionDrift entry %q stopped producing kind-matched pairs — "+
+				"replay no longer reproduces its transitions at all. Do NOT delete the entry; "+
+				"this is a regression, not a fix", n)
+			continue
+		}
+		t.Errorf("knownFirstTransitionDrift entry %q no longer drifts — delete it", n)
 	}
 
+	if len(allDeltas) < minKindMatchedPairs {
+		t.Errorf("only %d kind-matched pairs measured (floor: %d) — the measurement SHRANK. "+
+			"Every other assertion here is an upper bound and passes when it does, so this is "+
+			"the one that catches a pairing shift draining the population",
+			len(allDeltas), minKindMatchedPairs)
+	}
+	if measured < minMeasuredRecordings {
+		t.Errorf("only %d of %d recordings produced any kind-matched pair (floor: %d)",
+			measured, checked, minMeasuredRecordings)
+	}
 	if overThreshold > maxRecordingsDriftingOverThreshold {
 		t.Errorf("%d recordings have at least one transition drifting >%v (ratchet: %d) — "+
 			"the named list above keys on the FIRST transition only, so this is what catches a "+
@@ -399,6 +489,166 @@ func TestSidecarReplayTransitionTimesMatchTheDaemonsOwnLog(t *testing.T) {
 		t.Errorf("%d recordings have at least one transition drifting >5s (ratchet: %d)",
 			over5s, maxRecordingsDriftingOver5s)
 	}
-	t.Logf("aggregate: %d/%d recordings drift >%v somewhere, %d >5s",
-		overThreshold, checked, driftThreshold, over5s)
+	t.Logf("aggregate: %d/%d recordings drift >%v somewhere, %d >5s; "+
+		"%d pairs measured across %d recordings (%d produced none)",
+		overThreshold, checked, driftThreshold, over5s,
+		len(allDeltas), measured, len(unmeasured))
+}
+
+// ---------------------------------------------------------------------------
+// 3. The reporting helpers.
+// ---------------------------------------------------------------------------
+
+// TestDriftDistribution_BucketsAndPercentiles pins the code that produces the
+// histogram, because that histogram IS the stated justification for
+// driftThreshold — it is pasted verbatim into that constant's doc comment and
+// into AGENTS.md. Untested, a bucketing or interpolation bug would silently
+// rewrite the rationale for the constant rather than fail anything.
+func TestDriftDistribution_BucketsAndPercentiles(t *testing.T) {
+	mk := func(ds ...time.Duration) []timeDelta {
+		out := make([]timeDelta, 0, len(ds))
+		for i, d := range ds {
+			out = append(out, timeDelta{Index: i, Kind: "ready→working", Delta: d})
+		}
+		return out
+	}
+
+	t.Run("one delta per bucket lands in its own bucket", func(t *testing.T) {
+		// Deliberately one value strictly inside each of the nine buckets,
+		// plus the two edge values that decide the open/closed question.
+		dist := newDriftDistribution(mk(
+			500*time.Microsecond, // <1ms
+			5*time.Millisecond,   // 1-10ms
+			50*time.Millisecond,  // 10-100ms
+			500*time.Millisecond, // 0.1-1s
+			2*time.Second,        // 1-5s
+			7*time.Second,        // 5-10s
+			20*time.Second,       // 10-30s
+			45*time.Second,       // 30-60s
+			2*time.Minute,        // >60s
+		))
+		if dist.N != 9 {
+			t.Fatalf("N = %d, want 9", dist.N)
+		}
+		for i, label := range driftBucketLabels {
+			if dist.BucketCount[i] != 1 {
+				t.Errorf("bucket %q = %d, want 1 (buckets: %v)", label, dist.BucketCount[i], dist.BucketCount)
+			}
+		}
+	})
+
+	t.Run("bucket edges are upper-exclusive", func(t *testing.T) {
+		// Exactly 1s belongs to "1-5s", not "0.1-1s". This is the one place
+		// the histogram and driftThreshold deliberately disagree — a delta of
+		// exactly 1s is counted above the line here but is NOT drifted by
+		// firstDrift, which compares with >. The disagreement is one
+		// nanosecond wide and is pinned so it stays deliberate.
+		dist := newDriftDistribution(mk(time.Second))
+		if got := dist.BucketCount[bucketIndex(time.Second)]; got != 1 {
+			t.Fatalf("bucket count for exactly 1s = %d, want 1", got)
+		}
+		if driftBucketLabels[bucketIndex(time.Second)] != "1-5s" {
+			t.Errorf("exactly 1s bucketed as %q, want \"1-5s\"", driftBucketLabels[bucketIndex(time.Second)])
+		}
+		if _, drifted := firstDrift(mk(time.Second)); drifted {
+			t.Error("exactly 1s reported as drifted; firstDrift must compare with >, not >=")
+		}
+	})
+
+	t.Run("sign is ignored — buckets are taken over magnitude", func(t *testing.T) {
+		neg := newDriftDistribution(mk(-30 * time.Second))
+		pos := newDriftDistribution(mk(30 * time.Second))
+		if !reflect.DeepEqual(neg.BucketCount, pos.BucketCount) {
+			t.Errorf("negative and positive deltas of equal magnitude bucketed differently: %v vs %v",
+				neg.BucketCount, pos.BucketCount)
+		}
+	})
+
+	t.Run("percentiles", func(t *testing.T) {
+		// 1..10 seconds: p50 interpolates between the 5th and 6th value.
+		var ds []time.Duration
+		for i := 1; i <= 10; i++ {
+			ds = append(ds, time.Duration(i)*time.Second)
+		}
+		dist := newDriftDistribution(mk(ds...))
+		for _, tc := range []struct {
+			p    int
+			want time.Duration
+		}{
+			{50, 5500 * time.Millisecond},
+			{100, 10 * time.Second},
+		} {
+			if got := dist.Percentiles[tc.p]; got != tc.want {
+				t.Errorf("p%d = %v, want %v", tc.p, got, tc.want)
+			}
+		}
+	})
+
+	t.Run("degenerate inputs do not panic", func(t *testing.T) {
+		if got := newDriftDistribution(nil); got.N != 0 {
+			t.Errorf("empty input: N = %d, want 0", got.N)
+		}
+		if got := newDriftDistribution(nil).String(); !strings.Contains(got, "vacuous") {
+			t.Errorf("empty distribution must say so, got %q", got)
+		}
+		single := newDriftDistribution(mk(7 * time.Second))
+		if single.Percentiles[50] != 7*time.Second || single.Percentiles[100] != 7*time.Second {
+			t.Errorf("single-element percentiles = %v", single.Percentiles)
+		}
+	})
+}
+
+// TestDriftSummary_FormatIsTheShellContract pins the exact string
+// tools/replay-fixtures.sh parses out of the replay binary's stderr.
+//
+// Without this, the two sides are coupled by nothing: the sweep's sed would
+// silently stop matching, its counter would stay 0, its reporting block would
+// never print, and the sweep would exit 0 — which is precisely the dead-counter
+// failure this PR is fixing one level up, reintroduced at the new layer. The
+// regexp below is the one in replay-fixtures.sh; if this test is updated, that
+// script must be updated in the same commit.
+func TestDriftSummary_FormatIsTheShellContract(t *testing.T) {
+	sweepRE := regexp.MustCompile(`timing ([0-9]+) pairs worst ([+-][0-9.]+)s@([0-9]+)`)
+
+	t.Run("the sweep's regexp matches, with the right captures", func(t *testing.T) {
+		got := driftSummary([]timeDelta{
+			{Index: 0, Kind: "ready→working", Delta: -30976480 * time.Microsecond},
+			{Index: 1, Kind: "working→ready", Delta: 12 * time.Millisecond},
+		})
+		m := sweepRE.FindStringSubmatch(got)
+		if m == nil {
+			t.Fatalf("replay-fixtures.sh would not parse %q — the sweep's timing report goes silent", got)
+		}
+		if m[1] != "2" || m[2] != "-30.976" || m[3] != "0" {
+			t.Errorf("captures = pairs %q, worst %q, index %q; want \"2\", \"-30.976\", \"0\"", m[1], m[2], m[3])
+		}
+	})
+
+	t.Run("a positive delta keeps its explicit + sign", func(t *testing.T) {
+		// The sweep's character class requires a leading sign, so dropping
+		// the %+ verb would make every late-firing recording unparseable
+		// while every early-firing one still matched.
+		got := driftSummary([]timeDelta{{Index: 3, Delta: 2004 * time.Millisecond}})
+		if !sweepRE.MatchString(got) {
+			t.Fatalf("positive delta unparseable by the sweep: %q", got)
+		}
+		if !strings.Contains(got, "+2.004") {
+			t.Errorf("got %q, want a +2.004 figure", got)
+		}
+	})
+
+	t.Run("no pairs reports n/a rather than a zero figure", func(t *testing.T) {
+		// 39 of the catalog's 309 recordings produce no kind-matched pair, so
+		// this is the common case, not an edge one. Reporting "worst +0.000s"
+		// would make "nothing was measured" indistinguishable from "measured,
+		// and perfect" — in the sweep's output and in the counter.
+		got := driftSummary(nil)
+		if sweepRE.MatchString(got) {
+			t.Errorf("empty input produced a parseable timing figure %q — "+
+				"unmeasured must not read as measured-and-zero", got)
+		}
+		if got != "timing n/a" {
+			t.Errorf("got %q, want \"timing n/a\"", got)
+		}
+	})
 }

--- a/tools/onboarding-factory/cmd/replay/issue1480_timing_test.go
+++ b/tools/onboarding-factory/cmd/replay/issue1480_timing_test.go
@@ -282,6 +282,35 @@ const (
 	minMeasuredRecordings = 270
 )
 
+// reportDriftEnumeration prints the drifted set — the deliverable of #1480,
+// printed whether or not any ratchet trips — as the map literal to paste into
+// knownFirstTransitionDrift when the set legitimately moves. That literal is
+// why the list is machine-generated rather than hand-maintained. Returns the
+// names sorted, which the caller's two ratchets then walk.
+func reportDriftEnumeration(t *testing.T, drifted map[string]timeDelta) []string {
+	t.Helper()
+	names := make([]string, 0, len(drifted))
+	for n := range drifted {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+
+	var literal strings.Builder
+	for _, n := range names {
+		fmt.Fprintf(&literal, "\t%q: %q,\n", n, describeDrift(drifted[n]))
+	}
+	t.Logf("%d recordings drift >%v on their first kind-matched transition:\n%s",
+		len(drifted), driftThreshold, literal.String())
+	return names
+}
+
+// describeDrift is the one spelling of a drift figure, shared by the pasteable
+// literal and the newly-drifted error so a reader comparing the two is looking
+// at the same rendering.
+func describeDrift(d timeDelta) string {
+	return fmt.Sprintf("%+.3fs at pair %d (%s)", d.Delta.Seconds(), d.Index, d.Kind)
+}
+
 // TestSidecarReplayTransitionTimesMatchTheDaemonsOwnLog is #1480's mechanical
 // report: it walks every sidecar-driven recording in the catalog, measures each
 // reproduced transition against the ts the recording's own daemon logged, and
@@ -338,20 +367,7 @@ func TestSidecarReplayTransitionTimesMatchTheDaemonsOwnLog(t *testing.T) {
 	dist := newDriftDistribution(allDeltas)
 	t.Logf("#1480 transition-timing drift, %d sidecar-driven recordings\n%s", checked, dist)
 
-	// The enumeration is the deliverable, so print it whether or not the
-	// ratchet trips — with the map literal to paste when it legitimately moves.
-	names := make([]string, 0, len(drifted))
-	for n := range drifted {
-		names = append(names, n)
-	}
-	sort.Strings(names)
-	var literal strings.Builder
-	for _, n := range names {
-		fmt.Fprintf(&literal, "\t%q: %q,\n", n, fmt.Sprintf("%+.3fs at pair %d (%s)",
-			drifted[n].Delta.Seconds(), drifted[n].Index, drifted[n].Kind))
-	}
-	t.Logf("%d recordings drift >%v on their first kind-matched transition:\n%s",
-		len(drifted), driftThreshold, literal.String())
+	names := reportDriftEnumeration(t, drifted)
 
 	// A catalog where nothing drifts means the comparison stopped comparing —
 	// 20 recordings are known-drifted by #1476's own measurement, and this
@@ -363,8 +379,7 @@ func TestSidecarReplayTransitionTimesMatchTheDaemonsOwnLog(t *testing.T) {
 	var appeared []string
 	for _, n := range names {
 		if _, known := knownFirstTransitionDrift[n]; !known {
-			appeared = append(appeared, fmt.Sprintf("%s (%+.3fs at pair %d, %s)",
-				n, drifted[n].Delta.Seconds(), drifted[n].Index, drifted[n].Kind))
+			appeared = append(appeared, fmt.Sprintf("%s (%s)", n, describeDrift(drifted[n])))
 		}
 	}
 	if len(appeared) > 0 {

--- a/tools/onboarding-factory/cmd/replay/issue1480_timing_test.go
+++ b/tools/onboarding-factory/cmd/replay/issue1480_timing_test.go
@@ -1,0 +1,404 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"irrlicht/core/domain/lifecycle"
+)
+
+// Issue #1480: replay goldens pin a virtual_time on every transition and
+// nothing compared it to anything, so a transition reproduced at the right
+// position in the ORDER but 31 seconds from when the daemon made it passed
+// every gate in this package and the golden then pinned it as correct.
+//
+// These two tests are the measurement. The first proves the measurement can
+// fail — it has no "before the fix" to run against, so per AGENTS.md it owes a
+// deliberate mutation, and that mutation is committed under testdata/timing/
+// rather than described in a PR body. The second runs it over the whole
+// catalog and enumerates what drifts today.
+
+// ---------------------------------------------------------------------------
+// 1. The detector itself, over a committed corpus.
+// ---------------------------------------------------------------------------
+
+type timingCase struct {
+	Description  string            `json:"description"`
+	Recorded     []lifecycle.Event `json:"recorded"`
+	Replayed     []transition      `json:"replayed"`
+	WantDeltasNs []int64           `json:"want_deltas_ns"`
+	WantFirstNs  *int64            `json:"want_first_drift"`
+	WantWorstNs  *int64            `json:"want_worst_ns"`
+}
+
+// TestTransitionTimeDeltas_Corpus is #1480's mutation evidence. Every case is a
+// timing shape the measurement must classify correctly, and the corpus carries
+// both verdicts on purpose: first-transition-31s-early.json must be reported,
+// aligned.json and sub-second-justified.json must not. A detector that flags
+// everything and one that flags correctly are indistinguishable without the
+// second kind, which is why the balance is asserted below rather than left to
+// whoever adds the next case.
+func TestTransitionTimeDeltas_Corpus(t *testing.T) {
+	dir := filepath.Join("testdata", "timing")
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read corpus dir: %v", err)
+	}
+
+	var ran, sawDrift, sawClean int
+	for _, e := range entries {
+		if e.IsDir() || filepath.Ext(e.Name()) != ".json" {
+			continue
+		}
+		name := e.Name()
+		t.Run(strings.TrimSuffix(name, ".json"), func(t *testing.T) {
+			raw, err := os.ReadFile(filepath.Join(dir, name))
+			if err != nil {
+				t.Fatalf("read %s: %v", name, err)
+			}
+			var tc timingCase
+			if err := json.Unmarshal(raw, &tc); err != nil {
+				t.Fatalf("parse %s: %v", name, err)
+			}
+			if tc.Description == "" {
+				t.Fatalf("%s has no description — a corpus row states what it pins", name)
+			}
+			// A case that supplies no transitions asserts nothing; the corpus
+			// would still look populated. Refuse rather than skip.
+			if len(tc.Recorded) == 0 || len(tc.Replayed) == 0 {
+				t.Fatalf("%s supplies %d recorded / %d replayed — an empty side pins nothing",
+					name, len(tc.Recorded), len(tc.Replayed))
+			}
+
+			got := transitionTimeDeltas(tc.Recorded, tc.Replayed)
+
+			if len(got) != len(tc.WantDeltasNs) {
+				t.Fatalf("%s: got %d deltas, want %d\n  got:  %v\n  want: %v",
+					tc.Description, len(got), len(tc.WantDeltasNs), durations(got), tc.WantDeltasNs)
+			}
+			for i, d := range got {
+				if int64(d.Delta) != tc.WantDeltasNs[i] {
+					t.Errorf("%s: delta[%d] = %v (%d ns), want %v (%d ns)",
+						tc.Description, i, d.Delta, int64(d.Delta),
+						time.Duration(tc.WantDeltasNs[i]), tc.WantDeltasNs[i])
+				}
+			}
+
+			first, ok := firstDrift(got)
+			switch {
+			case tc.WantFirstNs == nil && ok:
+				t.Errorf("%s: reported first drift %v, want none (threshold %v)",
+					tc.Description, first.Delta, driftThreshold)
+			case tc.WantFirstNs != nil && !ok:
+				t.Errorf("%s: reported NO first drift, want %v — the measurement stopped measuring",
+					tc.Description, time.Duration(*tc.WantFirstNs))
+			case tc.WantFirstNs != nil && int64(first.Delta) != *tc.WantFirstNs:
+				t.Errorf("%s: first drift = %v, want %v",
+					tc.Description, first.Delta, time.Duration(*tc.WantFirstNs))
+			}
+
+			if tc.WantWorstNs != nil {
+				worst, found := worstDrift(got)
+				if !found {
+					t.Errorf("%s: no worst pair, want %v", tc.Description, time.Duration(*tc.WantWorstNs))
+				} else if int64(worst.Delta) != *tc.WantWorstNs {
+					t.Errorf("%s: worst = %v, want %v",
+						tc.Description, worst.Delta, time.Duration(*tc.WantWorstNs))
+				}
+			}
+
+			if tc.WantFirstNs != nil {
+				sawDrift++
+			} else {
+				sawClean++
+			}
+			ran++
+		})
+	}
+
+	if ran == 0 {
+		t.Fatal("no corpus case ran — testdata/timing/ is empty or unreadable, and an empty corpus reads exactly like a passing one")
+	}
+	if sawDrift == 0 {
+		t.Error("no corpus case expects drift — nothing here proves the measurement can fire")
+	}
+	if sawClean == 0 {
+		t.Error("no corpus case expects a clean result — nothing here proves the measurement can stay silent")
+	}
+	t.Logf("corpus: %d cases (%d expect drift, %d expect clean)", ran, sawDrift, sawClean)
+}
+
+func durations(ds []timeDelta) []time.Duration {
+	out := make([]time.Duration, 0, len(ds))
+	for _, d := range ds {
+		out = append(out, d.Delta)
+	}
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// 2. The catalog measurement.
+// ---------------------------------------------------------------------------
+
+// knownFirstTransitionDrift enumerates every sidecar-driven recording whose
+// FIRST kind-matched transition is reproduced more than driftThreshold (1s)
+// from the timestamp the daemon logged for it.
+//
+// This list is the answer to #1480's acceptance criterion, and it is machine-
+// generated: TestSidecarReplayTransitionTimesMatchTheDaemonsOwnLog prints the
+// exact map literal to paste when the set legitimately changes. It is not
+// maintained by hand and must not be.
+//
+// The 20 entries marked "#1476" are that PR's documented, ACCEPTED cost, not a
+// backlog. readBoundaryFor's doc comment carries the full argument and the
+// rejected alternative: bounding the widening by elapsed time collapses these
+// six worst cases (-30.976s -> -0.022s) but breaks 35 gemini-cli recordings
+// that reproduce exactly today, because the sidecar cannot distinguish "the gap
+// is idle time AFTER a write the daemon absorbed" from "the gap is before the
+// write happened". Net across the catalog the widening still moves times TOWARD
+// the daemon. They are listed here so the cost is enumerated rather than living
+// in a paragraph of a doc comment — which is precisely what #1480 was filed
+// about.
+//
+// Everything unmarked PRE-DATES #1476 and is untouched by it. Two families
+// dominate:
+//
+//   - copilot and antigravity recordings whose first turn opens with a long
+//     tool call: the daemon classified on a read that reached content the
+//     replay's clamped boundary does not, so the replay fires at the debounce
+//     deadline instead.
+//   - pi and gemini-cli recordings sitting at almost exactly +2.00s: a
+//     synthesized debounce-deadline stamp, one full window after the last
+//     coalesced fs event, where the daemon's own timer had fired earlier.
+//
+// Neither is #1480's to fix. #1480 is the measurement; what to do about the
+// populations it reveals is argued in the PR with this list in hand.
+var knownFirstTransitionDrift = map[string]string{
+	"antigravity/scenarios/1-1_session-start/recordings/2026-06-20-12-33-40_irrlichd-0.5.2+be45695/transcript.jsonl":                   "pre-dates #1476: -6.609s at pair 0 (ready→working)",
+	"antigravity/scenarios/1-2_session-end/recordings/2026-06-20-12-36-01_irrlichd-0.5.2+a00b826/transcript.jsonl":                     "pre-dates #1476: -4.304s at pair 0 (ready→working)",
+	"antigravity/scenarios/1-3_long-idle-live-session/recordings/2026-06-20-17-58-44_irrlichd-0.5.2+1fcae3a/transcript.jsonl":          "pre-dates #1476: -3.937s at pair 0 (ready→working)",
+	"antigravity/scenarios/1-4_session-resume/recordings/2026-06-20-12-43-04_irrlichd-0.5.2+bb79f4c/transcript.jsonl":                  "pre-dates #1476: -3.771s at pair 0 (ready→working)",
+	"antigravity/scenarios/2-11_auto-classified-permission/recordings/2026-06-20-13-41-55_irrlichd-0.5.2+b756a52/transcript.jsonl":     "pre-dates #1476: -5.774s at pair 0 (ready→working)",
+	"antigravity/scenarios/2-12_context-compaction/recordings/2026-06-20-13-46-30_irrlichd-0.5.2+77308b9/transcript.jsonl":             "pre-dates #1476: -3.809s at pair 0 (ready→working)",
+	"antigravity/scenarios/2-13_turn-end-terminal-text/recordings/2026-06-20-02-50-41_irrlichd-0.5.2+2900672/transcript.jsonl":         "pre-dates #1476: -3.522s at pair 0 (ready→working)",
+	"antigravity/scenarios/2-15_shell-escape-command/recordings/2026-06-20-13-49-04_irrlichd-0.5.2+349bafc/transcript.jsonl":           "pre-dates #1476: -4.067s at pair 0 (ready→working)",
+	"antigravity/scenarios/2-16_oversized-transcript-line/recordings/2026-06-20-13-18-38_irrlichd-0.5.2+76d805a/transcript.jsonl":      "pre-dates #1476: -67.369s at pair 0 (ready→working)",
+	"antigravity/scenarios/2-1_basic-turn/recordings/2026-06-20-02-48-55_irrlichd-0.5.2+daeb6e1/transcript.jsonl":                      "pre-dates #1476: -3.199s at pair 0 (ready→working)",
+	"antigravity/scenarios/2-21_streaming-partial-writes/recordings/2026-06-20-13-21-01_irrlichd-0.5.2+c7f1c6d/transcript.jsonl":       "pre-dates #1476: -5.111s at pair 0 (ready→working)",
+	"antigravity/scenarios/2-4_self-correction-iteration/recordings/2026-06-20-13-14-32_irrlichd-0.5.2+a489d47/transcript.jsonl":       "pre-dates #1476: -4.859s at pair 0 (ready→working)",
+	"antigravity/scenarios/2-5_synchronous-slash-command/recordings/2026-06-20-13-38-51_irrlichd-0.5.2+7a48e0d/transcript.jsonl":       "pre-dates #1476: -3.726s at pair 0 (ready→working)",
+	"antigravity/scenarios/2-7_autonomous-loop/recordings/2026-06-20-14-00-16_irrlichd-0.5.2+250cd02/transcript.jsonl":                 "pre-dates #1476: -4.521s at pair 0 (ready→working)",
+	"antigravity/scenarios/2-8_autonomous-loop-iteration-limit/recordings/2026-06-20-14-02-53_irrlichd-0.5.2+2de7ce6/transcript.jsonl": "pre-dates #1476: -5.681s at pair 0 (ready→working)",
+	"antigravity/scenarios/3-1_foreground-subagent/recordings/2026-06-20-18-04-13_irrlichd-0.5.2+09e9cf9/transcript.jsonl":             "pre-dates #1476: -6.595s at pair 0 (ready→working)",
+	"antigravity/scenarios/3-2_background-subagent/recordings/2026-06-20-18-15-41_irrlichd-0.5.2+b305884/transcript.jsonl":             "pre-dates #1476: -4.468s at pair 0 (ready→working)",
+	"antigravity/scenarios/4-2_multiple-agents-same-workspace/recordings/2026-06-20-16-53-31_irrlichd-0.5.2+2eb84fb/transcript.jsonl":  "pre-dates #1476: -5.079s at pair 0 (ready→working)",
+	"antigravity/scenarios/5-1_token-accounting/recordings/2026-06-28-11-54-27_irrlichd-0.5.3+7f52a76/transcript.jsonl":                "pre-dates #1476: -3.343s at pair 0 (ready→working)",
+	"claudecode/scenarios/2-7_autonomous-loop/recordings/2026-05-18-22-47-11_irrlichd-0.4.5+8499138/transcript.jsonl":                  "#1476 accepted: -5.075s at pair 0 (ready→working)",
+	"claudecode/scenarios/2-7_autonomous-loop/recordings/2026-05-18-22-52-38_irrlichd-0.4.5+8499138/transcript.jsonl":                  "#1476 accepted: -4.561s at pair 0 (ready→working)",
+	"claudecode/scenarios/2-8_autonomous-loop-iteration-limit/recordings/2026-05-18-22-56-34_irrlichd-0.4.5+6898561/transcript.jsonl":  "#1476 accepted: -9.012s at pair 0 (ready→working)",
+	"claudecode/scenarios/5-8_task-estimate-marker/recordings/2026-06-03-21-50-21_irrlichd-0.4.8+defb4d8/transcript.jsonl":             "pre-dates #1476: -1.167s at pair 0 (ready→working)",
+	"codex/regressions/fork-conversation/recordings/2026-05-23-19-39-41_irrlichd-0.4.7+3c6427c/transcript.jsonl":                       "#1476 accepted: -3.759s at pair 0 (ready→working)",
+	"codex/scenarios/1-4_session-resume/recordings/2026-05-23-20-30-54_irrlichd-0.4.7+c461eef/transcript.jsonl":                        "#1476 accepted: -4.007s at pair 0 (ready→working)",
+	"codex/scenarios/1-5_session-reset/recordings/2026-05-25-00-26-42_irrlichd-0.4.7+9d1ef56.dirty/transcript.jsonl":                   "#1476 accepted: -3.673s at pair 0 (ready→working)",
+	"codex/scenarios/2-13_turn-end-terminal-text/recordings/2026-05-23-21-44-53_irrlichd-0.4.7+f83dc27/transcript.jsonl":               "#1476 accepted: -2.246s at pair 0 (ready→working)",
+	"codex/scenarios/2-15_shell-escape-command/recordings/2026-05-23-22-23-45_irrlichd-0.4.7+7075bff/transcript.jsonl":                 "#1476 accepted: -2.032s at pair 0 (ready→working)",
+	"codex/scenarios/2-18_user-blocking-plan-mode-approval/recordings/2026-05-23-23-48-22_irrlichd-0.4.7+eb984db/transcript.jsonl":     "#1476 accepted: -5.670s at pair 0 (ready→working)",
+	"codex/scenarios/2-1_basic-turn/recordings/2026-05-23-20-36-20_irrlichd-0.4.7+723609a/transcript.jsonl":                            "#1476 accepted: -3.691s at pair 0 (ready→working)",
+	"codex/scenarios/2-20_interrupted-turn/recordings/2026-05-14-23-36-59_irrlichd-dev/transcript.jsonl":                               "pre-dates #1476: +2.187s at pair 0 (ready→working)",
+	"codex/scenarios/2-20_interrupted-turn/recordings/2026-05-16-22-53-47_irrlichd-0.3.13+4662be4/transcript.jsonl":                    "pre-dates #1476: +2.214s at pair 0 (ready→working)",
+	"codex/scenarios/2-20_interrupted-turn/recordings/2026-05-16-22-56-57_irrlichd-0.3.13+4662be4/transcript.jsonl":                    "pre-dates #1476: +2.652s at pair 0 (ready→working)",
+	"codex/scenarios/2-2_auto-executed-tool-call/recordings/2026-05-23-22-48-46_irrlichd-0.4.7+14e1e7a/transcript.jsonl":               "#1476 accepted: -2.234s at pair 0 (ready→working)",
+	"codex/scenarios/2-5_synchronous-slash-command/recordings/2026-05-23-21-53-28_irrlichd-0.4.7+6934b22/transcript.jsonl":             "#1476 accepted: -3.615s at pair 0 (ready→working)",
+	"codex/scenarios/2-6_long-agentic-session-stress/recordings/2026-05-23-23-03-45_irrlichd-0.4.7+ccb564c/transcript.jsonl":           "#1476 accepted: -2.230s at pair 0 (ready→working)",
+	"codex/scenarios/2-7_autonomous-loop/recordings/2026-05-23-23-15-25_irrlichd-0.4.7+774c575/transcript.jsonl":                       "#1476 accepted: -2.287s at pair 0 (ready→working)",
+	"codex/scenarios/2-8_autonomous-loop-iteration-limit/recordings/2026-05-23-23-20-25_irrlichd-0.4.7+6a1a098/transcript.jsonl":       "#1476 accepted: -6.782s at pair 0 (ready→working)",
+	"codex/scenarios/4-1_multiple-sessions-same-cwd/recordings/2026-05-24-21-42-19_irrlichd-0.4.7+83509be.dirty/transcript.jsonl":      "#1476 accepted: -3.775s at pair 0 (ready→working)",
+	"codex/scenarios/5-3_model-switch-midsession/recordings/2026-05-23-21-34-12_irrlichd-0.4.7+b8b1cfc/transcript.jsonl":               "#1476 accepted: -4.079s at pair 0 (ready→working)",
+	"copilot/scenarios/1-1_session-start/recordings/2026-08-03-12-06-21_irrlichd-0.5.9+4c1b2e4/transcript.jsonl":                       "pre-dates #1476: -3.842s at pair 0 (ready→working)",
+	"copilot/scenarios/1-2_session-end/recordings/2026-08-03-12-07-28_irrlichd-0.5.9+57d59de/transcript.jsonl":                         "pre-dates #1476: -10.828s at pair 0 (ready→working)",
+	"copilot/scenarios/1-4_session-resume/recordings/2026-08-05-19-02-01_irrlichd-0.5.9+4b58365/transcript.jsonl":                      "pre-dates #1476: -18.621s at pair 1 (working→ready)",
+	"copilot/scenarios/2-13_turn-end-terminal-text/recordings/2026-08-03-12-16-12_irrlichd-0.5.9+ced85ef/transcript.jsonl":             "pre-dates #1476: -4.190s at pair 0 (ready→working)",
+	"gemini-cli/scenarios/2-12_context-compaction/recordings/2026-06-12-10-36-37_irrlichd-0.5.1+93db11a/transcript.jsonl":              "pre-dates #1476: +2.001s at pair 0 (ready→working)",
+	"mistral-vibe/scenarios/2-12_context-compaction/recordings/2026-07-07-17-22-57_irrlichd-0.5.5+bc77a37.dirty/transcript.jsonl":      "#1476 accepted: -30.976s at pair 0 (ready→working)",
+	"mistral-vibe/scenarios/2-15_shell-escape-command/recordings/2026-07-07-17-41-58_irrlichd-0.5.5+22a01d2.dirty/transcript.jsonl":    "#1476 accepted: -8.599s at pair 0 (ready→working)",
+	"mistral-vibe/scenarios/6-1_backchannel-control/recordings/2026-07-08-09-15-24_irrlichd-0.5.5+35c4012.dirty/transcript.jsonl":      "#1476 accepted: -27.522s at pair 0 (ready→working)",
+	"pi/regressions/model-switch/recordings/2026-05-25-04-09-10_irrlichd-0.4.7+2a46388/transcript.jsonl":                               "pre-dates #1476: +2.003s at pair 0 (ready→working)",
+	"pi/regressions/multi-turn-conversation/recordings/2026-04-26-12-27-56_irrlichd-unknown/transcript.jsonl":                          "pre-dates #1476: +2.045s at pair 0 (ready→working)",
+	"pi/scenarios/1-2_session-end/recordings/2026-05-25-05-48-26_irrlichd-0.4.7+597f655/transcript.jsonl":                              "pre-dates #1476: +2.003s at pair 0 (ready→working)",
+	"pi/scenarios/1-3_long-idle-live-session/recordings/2026-05-23-11-12-58_irrlichd-0.4.7+d30518a.dirty/transcript.jsonl":             "pre-dates #1476: +2.002s at pair 0 (ready→working)",
+	"pi/scenarios/1-5_session-reset/recordings/2026-05-27-23-52-56_irrlichd-0.4.7+b4e2076-2/transcript.jsonl":                          "pre-dates #1476: +2.004s at pair 0 (ready→working)",
+	"pi/scenarios/1-5_session-reset/recordings/2026-05-27-23-52-56_irrlichd-0.4.7+b4e2076/transcript.jsonl":                            "pre-dates #1476: +2.004s at pair 0 (ready→working)",
+	"pi/scenarios/1-8_model-context-display/recordings/2026-06-05-10-58-09_irrlichd-0.4.8+1f22f6f/transcript.jsonl":                    "pre-dates #1476: +2.005s at pair 0 (ready→working)",
+	"pi/scenarios/2-10_mid-turn-message-queued/recordings/2026-05-25-03-03-21_irrlichd-0.4.7+2f5b484-2/transcript.jsonl":               "pre-dates #1476: +2.002s at pair 0 (ready→working)",
+	"pi/scenarios/2-10_mid-turn-message-queued/recordings/2026-05-25-03-03-21_irrlichd-0.4.7+2f5b484/transcript.jsonl":                 "pre-dates #1476: +2.002s at pair 0 (ready→working)",
+	"pi/scenarios/2-12_context-compaction/recordings/2026-05-25-04-43-02_irrlichd-0.4.7+ac2dcc1/transcript.jsonl":                      "pre-dates #1476: +2.004s at pair 0 (ready→working)",
+	"pi/scenarios/2-13_turn-end-terminal-text/recordings/2026-05-25-02-11-57_irrlichd-0.4.7+327fbc2/transcript.jsonl":                  "pre-dates #1476: +2.003s at pair 0 (ready→working)",
+	"pi/scenarios/2-15_shell-escape-command/recordings/2026-05-25-02-51-25_irrlichd-0.4.7+021b5b0/transcript.jsonl":                    "pre-dates #1476: +2.003s at pair 0 (ready→working)",
+	"pi/scenarios/2-17_agent-question-pending/recordings/2026-05-25-05-28-25_irrlichd-0.4.7+730a676/transcript.jsonl":                  "pre-dates #1476: +2.003s at pair 0 (ready→working)",
+	"pi/scenarios/2-5_synchronous-slash-command/recordings/2026-05-25-02-43-00_irrlichd-0.4.7+3810f2e/transcript.jsonl":                "pre-dates #1476: +2.003s at pair 0 (ready→working)",
+	"pi/scenarios/5-1_token-accounting/recordings/2026-05-25-02-16-07_irrlichd-0.4.7+ec7acf6/transcript.jsonl":                         "pre-dates #1476: +2.006s at pair 0 (ready→working)",
+	"pi/scenarios/5-2_model-identification/recordings/2026-05-25-02-20-47_irrlichd-0.4.7+d379043/transcript.jsonl":                     "pre-dates #1476: +2.004s at pair 0 (ready→working)",
+	"pi/scenarios/5-3_model-switch-midsession/recordings/2026-05-25-04-02-05_irrlichd-0.4.7+4de276d/transcript.jsonl":                  "pre-dates #1476: +2.003s at pair 0 (ready→working)",
+}
+
+// aggregate ratchets. The named list above keys on the FIRST kind-matched pair,
+// which is the figure a read-boundary model moves and the one #1476 reported.
+// A classifier change that moved only a LATER transition would slip past it
+// entirely, so the two scalars below hold the whole population — every
+// kind-matched pair in every recording — without a second list of names to
+// maintain.
+const (
+	maxRecordingsDriftingOverThreshold = 119
+	maxRecordingsDriftingOver5s        = 50
+)
+
+// TestSidecarReplayTransitionTimesMatchTheDaemonsOwnLog is #1480's mechanical
+// report: it walks every sidecar-driven recording in the catalog, measures each
+// reproduced transition against the ts the recording's own daemon logged, and
+// prints the distribution.
+//
+// Catalog-wide rather than a list of paths, so a newly recorded fixture is
+// covered by existing rather than by somebody remembering to add it — the same
+// reason TestSidecarReplayAgreesWithTheDaemonsOwnLog walks instead of listing.
+//
+// It is a RATCHET, not a tolerance gate. A transition drifting 900ms is not
+// asserted to be correct; it is asserted not to be NEW. The distinction matters
+// because 24.5% of the committed catalog's transitions are already over 1s from
+// their daemon, and a gate that failed on all of them would be reverted within
+// the day and would protect nothing.
+func TestSidecarReplayTransitionTimesMatchTheDaemonsOwnLog(t *testing.T) {
+	root := replaydataRoot(t)
+
+	var checked int
+	var allDeltas []timeDelta
+	drifted := map[string]timeDelta{}
+	overThreshold, over5s := 0, 0
+
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || filepath.Base(path) != eventsSidecarName {
+			return nil
+		}
+		transcript := filepath.Join(filepath.Dir(path), "transcript.jsonl")
+		if _, statErr := os.Stat(transcript); statErr != nil {
+			return nil
+		}
+		tp, sp, useSidecar := resolveInputPaths(transcript)
+		if !useSidecar {
+			return nil
+		}
+		report, runErr := runReplay(tp, sp, useSidecar, replaySettingsForTest(t, tp))
+		if runErr != nil {
+			t.Errorf("runReplay(%s): %v", rel(root, transcript), runErr)
+			return nil
+		}
+		ec := report.ExtendedCheck
+		if ec == nil {
+			return nil
+		}
+		checked++
+
+		name := rel(root, transcript)
+		allDeltas = append(allDeltas, ec.TimeDeltas...)
+
+		if first, ok := firstDrift(ec.TimeDeltas); ok {
+			drifted[name] = first
+		}
+		var anyOver, anyOver5 bool
+		for _, dd := range ec.TimeDeltas {
+			if dd.Abs() > driftThreshold {
+				anyOver = true
+			}
+			if dd.Abs() > 5*time.Second {
+				anyOver5 = true
+			}
+		}
+		if anyOver {
+			overThreshold++
+		}
+		if anyOver5 {
+			over5s++
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk replaydata/agents: %v", err)
+	}
+	if checked == 0 {
+		t.Fatal("no sidecar-driven recording found under replaydata/agents — the measurement is vacuous")
+	}
+	// The measurement's own fail-loudly guard (AGENTS.md): a run that reached
+	// every recording but produced no comparable pair is not a clean result,
+	// it is a broken one, and without this it reads as a pass.
+	if len(allDeltas) == 0 {
+		t.Fatalf("walked %d sidecar-driven recordings and produced ZERO kind-matched pairs — "+
+			"nothing was compared, which is the exact failure #1480 exists to close", checked)
+	}
+
+	dist := newDriftDistribution(allDeltas)
+	t.Logf("#1480 transition-timing drift, %d sidecar-driven recordings\n%s", checked, dist)
+
+	// The enumeration is the deliverable, so print it whether or not the
+	// ratchet trips — with the map literal to paste when it legitimately moves.
+	names := make([]string, 0, len(drifted))
+	for n := range drifted {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	var literal strings.Builder
+	for _, n := range names {
+		fmt.Fprintf(&literal, "\t%q: %q,\n", n, fmt.Sprintf("%+.3fs at pair %d (%s)",
+			drifted[n].Delta.Seconds(), drifted[n].Index, drifted[n].Kind))
+	}
+	t.Logf("%d recordings drift >%v on their first kind-matched transition:\n%s",
+		len(drifted), driftThreshold, literal.String())
+
+	// A catalog where nothing drifts means the comparison stopped comparing —
+	// 20 recordings are known-drifted by #1476's own measurement, and this
+	// check exists because reporting zero is the failure mode, not the goal.
+	if len(drifted) == 0 {
+		t.Fatal("no recording drifts at all — #1476 documents 20 that do, so the measurement is not reaching them")
+	}
+
+	var appeared []string
+	for _, n := range names {
+		if _, known := knownFirstTransitionDrift[n]; !known {
+			appeared = append(appeared, fmt.Sprintf("%s (%+.3fs at pair %d, %s)",
+				n, drifted[n].Delta.Seconds(), drifted[n].Index, drifted[n].Kind))
+		}
+	}
+	if len(appeared) > 0 {
+		t.Errorf("%d recording(s) newly drift >%v on their first transition — a classifier or "+
+			"read-boundary change moved WHEN a transition fires, which is exactly what nothing "+
+			"could see before #1480:\n  %s\nPaste the printed literal into "+
+			"knownFirstTransitionDrift only with a reason per entry.",
+			len(appeared), driftThreshold, strings.Join(appeared, "\n  "))
+	}
+	// Stale entries rot the list into a permanent excuse.
+	for n := range knownFirstTransitionDrift {
+		if _, still := drifted[n]; !still {
+			t.Errorf("knownFirstTransitionDrift entry %q no longer drifts — delete it", n)
+		}
+	}
+
+	if overThreshold > maxRecordingsDriftingOverThreshold {
+		t.Errorf("%d recordings have at least one transition drifting >%v (ratchet: %d) — "+
+			"the named list above keys on the FIRST transition only, so this is what catches a "+
+			"change that moved a later one", overThreshold, driftThreshold, maxRecordingsDriftingOverThreshold)
+	}
+	if over5s > maxRecordingsDriftingOver5s {
+		t.Errorf("%d recordings have at least one transition drifting >5s (ratchet: %d)",
+			over5s, maxRecordingsDriftingOver5s)
+	}
+	t.Logf("aggregate: %d/%d recordings drift >%v somewhere, %d >5s",
+		overThreshold, checked, driftThreshold, over5s)
+}

--- a/tools/onboarding-factory/cmd/replay/main.go
+++ b/tools/onboarding-factory/cmd/replay/main.go
@@ -397,8 +397,8 @@ func printSummary(report *replayReport) {
 		if len(c.OrderedMismatches) > 0 {
 			orderMark = "FAIL"
 		}
-		fmt.Fprintf(os.Stderr, " [extended-check: kinds %s ordered %d/%d %s]",
-			kindsMark, c.OrderedMatches, c.RecordedCount, orderMark)
+		fmt.Fprintf(os.Stderr, " [extended-check: kinds %s ordered %d/%d %s %s]",
+			kindsMark, c.OrderedMatches, c.RecordedCount, orderMark, driftSummary(c.TimeDeltas))
 	}
 	fmt.Fprintln(os.Stderr)
 }

--- a/tools/onboarding-factory/cmd/replay/testdata/timing/README.md
+++ b/tools/onboarding-factory/cmd/replay/testdata/timing/README.md
@@ -1,0 +1,19 @@
+# `transitionTimeDeltas` corpus (#1480)
+
+One file per timing shape the measurement must get right, committed rather than
+improvised so the evidence outlives the PR that added it (AGENTS.md: "Prefer
+committing that mutation to describing it").
+
+Each case supplies the two slices `transitionTimeDeltas` takes — already
+filtered, exactly as `runExtendedCheck` hands them over: `recorded` has passed
+`filterStateTransitions` (primary session, non-empty `prev_state`) and
+`replayed` has passed `dropInitTransitions` (no synthetic init row).
+
+`want_deltas_ns` is the full expected result, in order. A case whose
+`want_first_drift` is `null` asserts that nothing exceeded `driftThreshold` —
+those are the vacuity guards, and without them a detector that flagged
+everything would look identical to one that flagged correctly.
+
+The numbers in `first-transition-31s-early.json` are the real ones from
+`mistral-vibe/scenarios/2-12_context-compaction`, the worst case #1476
+documented. It is the case that must go red if the measurement stops measuring.

--- a/tools/onboarding-factory/cmd/replay/testdata/timing/README.md
+++ b/tools/onboarding-factory/cmd/replay/testdata/timing/README.md
@@ -1,10 +1,10 @@
-# `transitionTimeDeltas` corpus (#1480)
+# Transition-timing corpus (#1480)
 
 One file per timing shape the measurement must get right, committed rather than
 improvised so the evidence outlives the PR that added it (AGENTS.md: "Prefer
 committing that mutation to describing it").
 
-Each case supplies the two slices `transitionTimeDeltas` takes — already
+Each case supplies the two slices `compareOrdered` takes — already
 filtered, exactly as `runExtendedCheck` hands them over: `recorded` has passed
 `filterStateTransitions` (primary session, non-empty `prev_state`) and
 `replayed` has passed `dropInitTransitions` (no synthetic init row).

--- a/tools/onboarding-factory/cmd/replay/testdata/timing/aligned.json
+++ b/tools/onboarding-factory/cmd/replay/testdata/timing/aligned.json
@@ -1,0 +1,16 @@
+{
+  "description": "replay reproduces every transition at the daemon's own time (sub-millisecond) — the vacuity guard: a detector that flags this flags everything",
+  "recorded": [
+    {"seq": 1, "ts": "2026-05-23T20:36:41.131713+02:00", "kind": "state_transition", "session_id": "s", "prev_state": "ready", "new_state": "working"},
+    {"seq": 2, "ts": "2026-05-23T20:36:41.132557+02:00", "kind": "state_transition", "session_id": "s", "prev_state": "working", "new_state": "waiting"},
+    {"seq": 3, "ts": "2026-05-23T20:36:44.492741+02:00", "kind": "state_transition", "session_id": "s", "prev_state": "waiting", "new_state": "ready"}
+  ],
+  "replayed": [
+    {"virtual_time": "2026-05-23T20:36:41.131713+02:00", "prev_state": "ready", "new_state": "working"},
+    {"virtual_time": "2026-05-23T20:36:41.133557+02:00", "prev_state": "working", "new_state": "waiting"},
+    {"virtual_time": "2026-05-23T20:36:44.490741+02:00", "prev_state": "waiting", "new_state": "ready"}
+  ],
+  "want_deltas_ns": [0, 1000000, -2000000],
+  "want_first_drift": null,
+  "want_worst_ns": -2000000
+}

--- a/tools/onboarding-factory/cmd/replay/testdata/timing/aligned.json
+++ b/tools/onboarding-factory/cmd/replay/testdata/timing/aligned.json
@@ -43,21 +43,22 @@
       "new_state": "ready"
     }
   ],
-  "want_deltas_ns": [
-    0,
-    1000000,
-    -2000000
+  "want": [
+    {
+      "index": 0,
+      "kind": "ready→working",
+      "delta_ns": 0
+    },
+    {
+      "index": 1,
+      "kind": "working→waiting",
+      "delta_ns": 1000000
+    },
+    {
+      "index": 2,
+      "kind": "waiting→ready",
+      "delta_ns": -2000000
+    }
   ],
-  "want_indices": [
-    0,
-    1,
-    2
-  ],
-  "want_kinds": [
-    "ready→working",
-    "working→waiting",
-    "waiting→ready"
-  ],
-  "want_first_drift": null,
-  "want_worst_ns": -2000000
+  "want_first_drift": null
 }

--- a/tools/onboarding-factory/cmd/replay/testdata/timing/aligned.json
+++ b/tools/onboarding-factory/cmd/replay/testdata/timing/aligned.json
@@ -1,16 +1,63 @@
 {
   "description": "replay reproduces every transition at the daemon's own time (sub-millisecond) — the vacuity guard: a detector that flags this flags everything",
   "recorded": [
-    {"seq": 1, "ts": "2026-05-23T20:36:41.131713+02:00", "kind": "state_transition", "session_id": "s", "prev_state": "ready", "new_state": "working"},
-    {"seq": 2, "ts": "2026-05-23T20:36:41.132557+02:00", "kind": "state_transition", "session_id": "s", "prev_state": "working", "new_state": "waiting"},
-    {"seq": 3, "ts": "2026-05-23T20:36:44.492741+02:00", "kind": "state_transition", "session_id": "s", "prev_state": "waiting", "new_state": "ready"}
+    {
+      "seq": 1,
+      "ts": "2026-05-23T20:36:41.131713+02:00",
+      "kind": "state_transition",
+      "session_id": "s",
+      "prev_state": "ready",
+      "new_state": "working"
+    },
+    {
+      "seq": 2,
+      "ts": "2026-05-23T20:36:41.132557+02:00",
+      "kind": "state_transition",
+      "session_id": "s",
+      "prev_state": "working",
+      "new_state": "waiting"
+    },
+    {
+      "seq": 3,
+      "ts": "2026-05-23T20:36:44.492741+02:00",
+      "kind": "state_transition",
+      "session_id": "s",
+      "prev_state": "waiting",
+      "new_state": "ready"
+    }
   ],
   "replayed": [
-    {"virtual_time": "2026-05-23T20:36:41.131713+02:00", "prev_state": "ready", "new_state": "working"},
-    {"virtual_time": "2026-05-23T20:36:41.133557+02:00", "prev_state": "working", "new_state": "waiting"},
-    {"virtual_time": "2026-05-23T20:36:44.490741+02:00", "prev_state": "waiting", "new_state": "ready"}
+    {
+      "virtual_time": "2026-05-23T20:36:41.131713+02:00",
+      "prev_state": "ready",
+      "new_state": "working"
+    },
+    {
+      "virtual_time": "2026-05-23T20:36:41.133557+02:00",
+      "prev_state": "working",
+      "new_state": "waiting"
+    },
+    {
+      "virtual_time": "2026-05-23T20:36:44.490741+02:00",
+      "prev_state": "waiting",
+      "new_state": "ready"
+    }
   ],
-  "want_deltas_ns": [0, 1000000, -2000000],
+  "want_deltas_ns": [
+    0,
+    1000000,
+    -2000000
+  ],
+  "want_indices": [
+    0,
+    1,
+    2
+  ],
+  "want_kinds": [
+    "ready→working",
+    "working→waiting",
+    "waiting→ready"
+  ],
   "want_first_drift": null,
   "want_worst_ns": -2000000
 }

--- a/tools/onboarding-factory/cmd/replay/testdata/timing/debounce-deadline-2s-late.json
+++ b/tools/onboarding-factory/cmd/replay/testdata/timing/debounce-deadline-2s-late.json
@@ -1,12 +1,31 @@
 {
   "description": "the other sign: a synthesized debounce-deadline stamp fires one whole 2s window after the daemon's own timer did. Drift is measured on |delta| precisely so this is not silently treated as healthy",
   "recorded": [
-    {"seq": 10, "ts": "2026-05-25T02:16:05.000000+02:00", "kind": "state_transition", "session_id": "s", "prev_state": "ready", "new_state": "working"}
+    {
+      "seq": 10,
+      "ts": "2026-05-25T02:16:05.000000+02:00",
+      "kind": "state_transition",
+      "session_id": "s",
+      "prev_state": "ready",
+      "new_state": "working"
+    }
   ],
   "replayed": [
-    {"virtual_time": "2026-05-25T02:16:07.004000+02:00", "prev_state": "ready", "new_state": "working"}
+    {
+      "virtual_time": "2026-05-25T02:16:07.004000+02:00",
+      "prev_state": "ready",
+      "new_state": "working"
+    }
   ],
-  "want_deltas_ns": [2004000000],
+  "want_deltas_ns": [
+    2004000000
+  ],
+  "want_indices": [
+    0
+  ],
+  "want_kinds": [
+    "ready→working"
+  ],
   "want_first_drift": 2004000000,
   "want_worst_ns": 2004000000
 }

--- a/tools/onboarding-factory/cmd/replay/testdata/timing/debounce-deadline-2s-late.json
+++ b/tools/onboarding-factory/cmd/replay/testdata/timing/debounce-deadline-2s-late.json
@@ -17,15 +17,12 @@
       "new_state": "working"
     }
   ],
-  "want_deltas_ns": [
-    2004000000
+  "want": [
+    {
+      "index": 0,
+      "kind": "ready→working",
+      "delta_ns": 2004000000
+    }
   ],
-  "want_indices": [
-    0
-  ],
-  "want_kinds": [
-    "ready→working"
-  ],
-  "want_first_drift": 2004000000,
-  "want_worst_ns": 2004000000
+  "want_first_drift": 2004000000
 }

--- a/tools/onboarding-factory/cmd/replay/testdata/timing/debounce-deadline-2s-late.json
+++ b/tools/onboarding-factory/cmd/replay/testdata/timing/debounce-deadline-2s-late.json
@@ -1,0 +1,12 @@
+{
+  "description": "the other sign: a synthesized debounce-deadline stamp fires one whole 2s window after the daemon's own timer did. Drift is measured on |delta| precisely so this is not silently treated as healthy",
+  "recorded": [
+    {"seq": 10, "ts": "2026-05-25T02:16:05.000000+02:00", "kind": "state_transition", "session_id": "s", "prev_state": "ready", "new_state": "working"}
+  ],
+  "replayed": [
+    {"virtual_time": "2026-05-25T02:16:07.004000+02:00", "prev_state": "ready", "new_state": "working"}
+  ],
+  "want_deltas_ns": [2004000000],
+  "want_first_drift": 2004000000,
+  "want_worst_ns": 2004000000
+}

--- a/tools/onboarding-factory/cmd/replay/testdata/timing/first-transition-31s-early.json
+++ b/tools/onboarding-factory/cmd/replay/testdata/timing/first-transition-31s-early.json
@@ -1,0 +1,14 @@
+{
+  "description": "#1476's worst documented cost, verbatim: mistral-vibe/2-12_context-compaction pins ready→working at 17:23:08.571829 while the daemon logged it at 17:23:39.548309 — 30.976s EARLY, and a full pass on every other gate in this package",
+  "recorded": [
+    {"seq": 21989, "ts": "2026-07-07T17:23:39.548309+02:00", "kind": "state_transition", "session_id": "s", "prev_state": "ready", "new_state": "working"},
+    {"seq": 21990, "ts": "2026-07-07T17:23:39.549021+02:00", "kind": "state_transition", "session_id": "s", "prev_state": "working", "new_state": "ready"}
+  ],
+  "replayed": [
+    {"virtual_time": "2026-07-07T17:23:08.571829+02:00", "prev_state": "ready", "new_state": "working"},
+    {"virtual_time": "2026-07-07T17:23:41.561939+02:00", "prev_state": "working", "new_state": "ready"}
+  ],
+  "want_deltas_ns": [-30976480000, 2012918000],
+  "want_first_drift": -30976480000,
+  "want_worst_ns": -30976480000
+}

--- a/tools/onboarding-factory/cmd/replay/testdata/timing/first-transition-31s-early.json
+++ b/tools/onboarding-factory/cmd/replay/testdata/timing/first-transition-31s-early.json
@@ -1,14 +1,47 @@
 {
   "description": "#1476's worst documented cost, verbatim: mistral-vibe/2-12_context-compaction pins ready→working at 17:23:08.571829 while the daemon logged it at 17:23:39.548309 — 30.976s EARLY, and a full pass on every other gate in this package",
   "recorded": [
-    {"seq": 21989, "ts": "2026-07-07T17:23:39.548309+02:00", "kind": "state_transition", "session_id": "s", "prev_state": "ready", "new_state": "working"},
-    {"seq": 21990, "ts": "2026-07-07T17:23:39.549021+02:00", "kind": "state_transition", "session_id": "s", "prev_state": "working", "new_state": "ready"}
+    {
+      "seq": 21989,
+      "ts": "2026-07-07T17:23:39.548309+02:00",
+      "kind": "state_transition",
+      "session_id": "s",
+      "prev_state": "ready",
+      "new_state": "working"
+    },
+    {
+      "seq": 21990,
+      "ts": "2026-07-07T17:23:39.549021+02:00",
+      "kind": "state_transition",
+      "session_id": "s",
+      "prev_state": "working",
+      "new_state": "ready"
+    }
   ],
   "replayed": [
-    {"virtual_time": "2026-07-07T17:23:08.571829+02:00", "prev_state": "ready", "new_state": "working"},
-    {"virtual_time": "2026-07-07T17:23:41.561939+02:00", "prev_state": "working", "new_state": "ready"}
+    {
+      "virtual_time": "2026-07-07T17:23:08.571829+02:00",
+      "prev_state": "ready",
+      "new_state": "working"
+    },
+    {
+      "virtual_time": "2026-07-07T17:23:41.561939+02:00",
+      "prev_state": "working",
+      "new_state": "ready"
+    }
   ],
-  "want_deltas_ns": [-30976480000, 2012918000],
+  "want_deltas_ns": [
+    -30976480000,
+    2012918000
+  ],
+  "want_indices": [
+    0,
+    1
+  ],
+  "want_kinds": [
+    "ready→working",
+    "working→ready"
+  ],
   "want_first_drift": -30976480000,
   "want_worst_ns": -30976480000
 }

--- a/tools/onboarding-factory/cmd/replay/testdata/timing/first-transition-31s-early.json
+++ b/tools/onboarding-factory/cmd/replay/testdata/timing/first-transition-31s-early.json
@@ -30,18 +30,17 @@
       "new_state": "ready"
     }
   ],
-  "want_deltas_ns": [
-    -30976480000,
-    2012918000
+  "want": [
+    {
+      "index": 0,
+      "kind": "ready→working",
+      "delta_ns": -30976480000
+    },
+    {
+      "index": 1,
+      "kind": "working→ready",
+      "delta_ns": 2012918000
+    }
   ],
-  "want_indices": [
-    0,
-    1
-  ],
-  "want_kinds": [
-    "ready→working",
-    "working→ready"
-  ],
-  "want_first_drift": -30976480000,
-  "want_worst_ns": -30976480000
+  "want_first_drift": -30976480000
 }

--- a/tools/onboarding-factory/cmd/replay/testdata/timing/kind-mismatch-excluded.json
+++ b/tools/onboarding-factory/cmd/replay/testdata/timing/kind-mismatch-excluded.json
@@ -43,18 +43,17 @@
       "new_state": "ready"
     }
   ],
-  "want_deltas_ns": [
-    5000000,
-    7000000
+  "want": [
+    {
+      "index": 0,
+      "kind": "ready→working",
+      "delta_ns": 5000000
+    },
+    {
+      "index": 2,
+      "kind": "waiting→ready",
+      "delta_ns": 7000000
+    }
   ],
-  "want_indices": [
-    0,
-    2
-  ],
-  "want_kinds": [
-    "ready→working",
-    "waiting→ready"
-  ],
-  "want_first_drift": null,
-  "want_worst_ns": 7000000
+  "want_first_drift": null
 }

--- a/tools/onboarding-factory/cmd/replay/testdata/timing/kind-mismatch-excluded.json
+++ b/tools/onboarding-factory/cmd/replay/testdata/timing/kind-mismatch-excluded.json
@@ -1,0 +1,16 @@
+{
+  "description": "index 1 pairs working→waiting against working→ready — compareOrdered already reports that as state_differs, so subtracting their timestamps would double-count one sequence divergence as a 900s timing divergence. The pair is excluded, and the pairs either side of it are still measured",
+  "recorded": [
+    {"seq": 1, "ts": "2026-04-11T10:00:00.000000Z", "kind": "state_transition", "session_id": "s", "prev_state": "ready", "new_state": "working"},
+    {"seq": 2, "ts": "2026-04-11T10:00:01.000000Z", "kind": "state_transition", "session_id": "s", "prev_state": "working", "new_state": "waiting"},
+    {"seq": 3, "ts": "2026-04-11T10:00:02.000000Z", "kind": "state_transition", "session_id": "s", "prev_state": "waiting", "new_state": "ready"}
+  ],
+  "replayed": [
+    {"virtual_time": "2026-04-11T10:00:00.005000Z", "prev_state": "ready", "new_state": "working"},
+    {"virtual_time": "2026-04-11T10:15:01.000000Z", "prev_state": "working", "new_state": "ready"},
+    {"virtual_time": "2026-04-11T10:00:02.007000Z", "prev_state": "waiting", "new_state": "ready"}
+  ],
+  "want_deltas_ns": [5000000, 7000000],
+  "want_first_drift": null,
+  "want_worst_ns": 7000000
+}

--- a/tools/onboarding-factory/cmd/replay/testdata/timing/kind-mismatch-excluded.json
+++ b/tools/onboarding-factory/cmd/replay/testdata/timing/kind-mismatch-excluded.json
@@ -1,16 +1,60 @@
 {
   "description": "index 1 pairs working→waiting against working→ready — compareOrdered already reports that as state_differs, so subtracting their timestamps would double-count one sequence divergence as a 900s timing divergence. The pair is excluded, and the pairs either side of it are still measured",
   "recorded": [
-    {"seq": 1, "ts": "2026-04-11T10:00:00.000000Z", "kind": "state_transition", "session_id": "s", "prev_state": "ready", "new_state": "working"},
-    {"seq": 2, "ts": "2026-04-11T10:00:01.000000Z", "kind": "state_transition", "session_id": "s", "prev_state": "working", "new_state": "waiting"},
-    {"seq": 3, "ts": "2026-04-11T10:00:02.000000Z", "kind": "state_transition", "session_id": "s", "prev_state": "waiting", "new_state": "ready"}
+    {
+      "seq": 1,
+      "ts": "2026-04-11T10:00:00.000000Z",
+      "kind": "state_transition",
+      "session_id": "s",
+      "prev_state": "ready",
+      "new_state": "working"
+    },
+    {
+      "seq": 2,
+      "ts": "2026-04-11T10:00:01.000000Z",
+      "kind": "state_transition",
+      "session_id": "s",
+      "prev_state": "working",
+      "new_state": "waiting"
+    },
+    {
+      "seq": 3,
+      "ts": "2026-04-11T10:00:02.000000Z",
+      "kind": "state_transition",
+      "session_id": "s",
+      "prev_state": "waiting",
+      "new_state": "ready"
+    }
   ],
   "replayed": [
-    {"virtual_time": "2026-04-11T10:00:00.005000Z", "prev_state": "ready", "new_state": "working"},
-    {"virtual_time": "2026-04-11T10:15:01.000000Z", "prev_state": "working", "new_state": "ready"},
-    {"virtual_time": "2026-04-11T10:00:02.007000Z", "prev_state": "waiting", "new_state": "ready"}
+    {
+      "virtual_time": "2026-04-11T10:00:00.005000Z",
+      "prev_state": "ready",
+      "new_state": "working"
+    },
+    {
+      "virtual_time": "2026-04-11T10:15:01.000000Z",
+      "prev_state": "working",
+      "new_state": "ready"
+    },
+    {
+      "virtual_time": "2026-04-11T10:00:02.007000Z",
+      "prev_state": "waiting",
+      "new_state": "ready"
+    }
   ],
-  "want_deltas_ns": [5000000, 7000000],
+  "want_deltas_ns": [
+    5000000,
+    7000000
+  ],
+  "want_indices": [
+    0,
+    2
+  ],
+  "want_kinds": [
+    "ready→working",
+    "waiting→ready"
+  ],
   "want_first_drift": null,
   "want_worst_ns": 7000000
 }

--- a/tools/onboarding-factory/cmd/replay/testdata/timing/replay-shorter-than-recorded.json
+++ b/tools/onboarding-factory/cmd/replay/testdata/timing/replay-shorter-than-recorded.json
@@ -33,15 +33,12 @@
       "new_state": "working"
     }
   ],
-  "want_deltas_ns": [
-    12500000000
+  "want": [
+    {
+      "index": 0,
+      "kind": "ready→working",
+      "delta_ns": 12500000000
+    }
   ],
-  "want_indices": [
-    0
-  ],
-  "want_kinds": [
-    "ready→working"
-  ],
-  "want_first_drift": 12500000000,
-  "want_worst_ns": 12500000000
+  "want_first_drift": 12500000000
 }

--- a/tools/onboarding-factory/cmd/replay/testdata/timing/replay-shorter-than-recorded.json
+++ b/tools/onboarding-factory/cmd/replay/testdata/timing/replay-shorter-than-recorded.json
@@ -1,14 +1,47 @@
 {
   "description": "replay reproduced 1 of the daemon's 3 transitions — only the overlap is measured, exactly as compareOrdered pairs it. The missing tail is ordered_mismatches' business, not timing's",
   "recorded": [
-    {"seq": 1, "ts": "2026-04-11T10:00:00.000000Z", "kind": "state_transition", "session_id": "s", "prev_state": "ready", "new_state": "working"},
-    {"seq": 2, "ts": "2026-04-11T10:00:01.000000Z", "kind": "state_transition", "session_id": "s", "prev_state": "working", "new_state": "waiting"},
-    {"seq": 3, "ts": "2026-04-11T10:00:02.000000Z", "kind": "state_transition", "session_id": "s", "prev_state": "waiting", "new_state": "ready"}
+    {
+      "seq": 1,
+      "ts": "2026-04-11T10:00:00.000000Z",
+      "kind": "state_transition",
+      "session_id": "s",
+      "prev_state": "ready",
+      "new_state": "working"
+    },
+    {
+      "seq": 2,
+      "ts": "2026-04-11T10:00:01.000000Z",
+      "kind": "state_transition",
+      "session_id": "s",
+      "prev_state": "working",
+      "new_state": "waiting"
+    },
+    {
+      "seq": 3,
+      "ts": "2026-04-11T10:00:02.000000Z",
+      "kind": "state_transition",
+      "session_id": "s",
+      "prev_state": "waiting",
+      "new_state": "ready"
+    }
   ],
   "replayed": [
-    {"virtual_time": "2026-04-11T10:00:12.500000Z", "prev_state": "ready", "new_state": "working"}
+    {
+      "virtual_time": "2026-04-11T10:00:12.500000Z",
+      "prev_state": "ready",
+      "new_state": "working"
+    }
   ],
-  "want_deltas_ns": [12500000000],
+  "want_deltas_ns": [
+    12500000000
+  ],
+  "want_indices": [
+    0
+  ],
+  "want_kinds": [
+    "ready→working"
+  ],
   "want_first_drift": 12500000000,
   "want_worst_ns": 12500000000
 }

--- a/tools/onboarding-factory/cmd/replay/testdata/timing/replay-shorter-than-recorded.json
+++ b/tools/onboarding-factory/cmd/replay/testdata/timing/replay-shorter-than-recorded.json
@@ -1,0 +1,14 @@
+{
+  "description": "replay reproduced 1 of the daemon's 3 transitions — only the overlap is measured, exactly as compareOrdered pairs it. The missing tail is ordered_mismatches' business, not timing's",
+  "recorded": [
+    {"seq": 1, "ts": "2026-04-11T10:00:00.000000Z", "kind": "state_transition", "session_id": "s", "prev_state": "ready", "new_state": "working"},
+    {"seq": 2, "ts": "2026-04-11T10:00:01.000000Z", "kind": "state_transition", "session_id": "s", "prev_state": "working", "new_state": "waiting"},
+    {"seq": 3, "ts": "2026-04-11T10:00:02.000000Z", "kind": "state_transition", "session_id": "s", "prev_state": "waiting", "new_state": "ready"}
+  ],
+  "replayed": [
+    {"virtual_time": "2026-04-11T10:00:12.500000Z", "prev_state": "ready", "new_state": "working"}
+  ],
+  "want_deltas_ns": [12500000000],
+  "want_first_drift": 12500000000,
+  "want_worst_ns": 12500000000
+}

--- a/tools/onboarding-factory/cmd/replay/testdata/timing/sub-second-justified.json
+++ b/tools/onboarding-factory/cmd/replay/testdata/timing/sub-second-justified.json
@@ -1,0 +1,14 @@
+{
+  "description": "readBoundaryFor's justified regime — a 42ms gap, its own measured p50. Must NOT be reported as drift, or the measurement cannot tell the widening's win from its cost",
+  "recorded": [
+    {"seq": 1, "ts": "2026-04-11T10:00:00.000000Z", "kind": "state_transition", "session_id": "s", "prev_state": "ready", "new_state": "working"},
+    {"seq": 2, "ts": "2026-04-11T10:00:01.000000Z", "kind": "state_transition", "session_id": "s", "prev_state": "working", "new_state": "ready"}
+  ],
+  "replayed": [
+    {"virtual_time": "2026-04-11T10:00:00.042000Z", "prev_state": "ready", "new_state": "working"},
+    {"virtual_time": "2026-04-11T10:00:01.999000Z", "prev_state": "working", "new_state": "ready"}
+  ],
+  "want_deltas_ns": [42000000, 999000000],
+  "want_first_drift": null,
+  "want_worst_ns": 999000000
+}

--- a/tools/onboarding-factory/cmd/replay/testdata/timing/sub-second-justified.json
+++ b/tools/onboarding-factory/cmd/replay/testdata/timing/sub-second-justified.json
@@ -1,14 +1,47 @@
 {
   "description": "readBoundaryFor's justified regime — a 42ms gap, its own measured p50. Must NOT be reported as drift, or the measurement cannot tell the widening's win from its cost",
   "recorded": [
-    {"seq": 1, "ts": "2026-04-11T10:00:00.000000Z", "kind": "state_transition", "session_id": "s", "prev_state": "ready", "new_state": "working"},
-    {"seq": 2, "ts": "2026-04-11T10:00:01.000000Z", "kind": "state_transition", "session_id": "s", "prev_state": "working", "new_state": "ready"}
+    {
+      "seq": 1,
+      "ts": "2026-04-11T10:00:00.000000Z",
+      "kind": "state_transition",
+      "session_id": "s",
+      "prev_state": "ready",
+      "new_state": "working"
+    },
+    {
+      "seq": 2,
+      "ts": "2026-04-11T10:00:01.000000Z",
+      "kind": "state_transition",
+      "session_id": "s",
+      "prev_state": "working",
+      "new_state": "ready"
+    }
   ],
   "replayed": [
-    {"virtual_time": "2026-04-11T10:00:00.042000Z", "prev_state": "ready", "new_state": "working"},
-    {"virtual_time": "2026-04-11T10:00:01.999000Z", "prev_state": "working", "new_state": "ready"}
+    {
+      "virtual_time": "2026-04-11T10:00:00.042000Z",
+      "prev_state": "ready",
+      "new_state": "working"
+    },
+    {
+      "virtual_time": "2026-04-11T10:00:01.999000Z",
+      "prev_state": "working",
+      "new_state": "ready"
+    }
   ],
-  "want_deltas_ns": [42000000, 999000000],
+  "want_deltas_ns": [
+    42000000,
+    999000000
+  ],
+  "want_indices": [
+    0,
+    1
+  ],
+  "want_kinds": [
+    "ready→working",
+    "working→ready"
+  ],
   "want_first_drift": null,
   "want_worst_ns": 999000000
 }

--- a/tools/onboarding-factory/cmd/replay/testdata/timing/sub-second-justified.json
+++ b/tools/onboarding-factory/cmd/replay/testdata/timing/sub-second-justified.json
@@ -30,18 +30,17 @@
       "new_state": "ready"
     }
   ],
-  "want_deltas_ns": [
-    42000000,
-    999000000
+  "want": [
+    {
+      "index": 0,
+      "kind": "ready→working",
+      "delta_ns": 42000000
+    },
+    {
+      "index": 1,
+      "kind": "working→ready",
+      "delta_ns": 999000000
+    }
   ],
-  "want_indices": [
-    0,
-    1
-  ],
-  "want_kinds": [
-    "ready→working",
-    "working→ready"
-  ],
-  "want_first_drift": null,
-  "want_worst_ns": 999000000
+  "want_first_drift": null
 }

--- a/tools/onboarding-factory/cmd/replay/testdata/timing/threshold-exactly-1s.json
+++ b/tools/onboarding-factory/cmd/replay/testdata/timing/threshold-exactly-1s.json
@@ -1,14 +1,28 @@
 {
   "description": "the threshold boundary from below: a delta of EXACTLY driftThreshold is not drifted, because firstDrift compares with > and not >=. Unpinned, the > / >= choice is free to flip and nothing in the catalog sits close enough to notice",
   "recorded": [
-    {"seq": 1, "ts": "2026-04-11T10:00:00.000000Z", "kind": "state_transition", "session_id": "s", "prev_state": "ready", "new_state": "working"}
+    {
+      "seq": 1,
+      "ts": "2026-04-11T10:00:00.000000Z",
+      "kind": "state_transition",
+      "session_id": "s",
+      "prev_state": "ready",
+      "new_state": "working"
+    }
   ],
   "replayed": [
-    {"virtual_time": "2026-04-11T10:00:01.000000Z", "prev_state": "ready", "new_state": "working"}
+    {
+      "virtual_time": "2026-04-11T10:00:01.000000Z",
+      "prev_state": "ready",
+      "new_state": "working"
+    }
   ],
-  "want_deltas_ns": [1000000000],
-  "want_indices": [0],
-  "want_kinds": ["ready→working"],
-  "want_first_drift": null,
-  "want_worst_ns": 1000000000
+  "want": [
+    {
+      "index": 0,
+      "kind": "ready→working",
+      "delta_ns": 1000000000
+    }
+  ],
+  "want_first_drift": null
 }

--- a/tools/onboarding-factory/cmd/replay/testdata/timing/threshold-exactly-1s.json
+++ b/tools/onboarding-factory/cmd/replay/testdata/timing/threshold-exactly-1s.json
@@ -1,0 +1,14 @@
+{
+  "description": "the threshold boundary from below: a delta of EXACTLY driftThreshold is not drifted, because firstDrift compares with > and not >=. Unpinned, the > / >= choice is free to flip and nothing in the catalog sits close enough to notice",
+  "recorded": [
+    {"seq": 1, "ts": "2026-04-11T10:00:00.000000Z", "kind": "state_transition", "session_id": "s", "prev_state": "ready", "new_state": "working"}
+  ],
+  "replayed": [
+    {"virtual_time": "2026-04-11T10:00:01.000000Z", "prev_state": "ready", "new_state": "working"}
+  ],
+  "want_deltas_ns": [1000000000],
+  "want_indices": [0],
+  "want_kinds": ["ready→working"],
+  "want_first_drift": null,
+  "want_worst_ns": 1000000000
+}

--- a/tools/onboarding-factory/cmd/replay/testdata/timing/threshold-one-ns-over.json
+++ b/tools/onboarding-factory/cmd/replay/testdata/timing/threshold-one-ns-over.json
@@ -1,0 +1,14 @@
+{
+  "description": "the threshold boundary from above: one nanosecond past driftThreshold IS drifted. Paired with threshold-exactly-1s.json this pins the comparison to the exact boundary rather than to a value comfortably either side of it",
+  "recorded": [
+    {"seq": 1, "ts": "2026-04-11T10:00:00.000000000Z", "kind": "state_transition", "session_id": "s", "prev_state": "ready", "new_state": "working"}
+  ],
+  "replayed": [
+    {"virtual_time": "2026-04-11T10:00:01.000000001Z", "prev_state": "ready", "new_state": "working"}
+  ],
+  "want_deltas_ns": [1000000001],
+  "want_indices": [0],
+  "want_kinds": ["ready→working"],
+  "want_first_drift": 1000000001,
+  "want_worst_ns": 1000000001
+}

--- a/tools/onboarding-factory/cmd/replay/testdata/timing/threshold-one-ns-over.json
+++ b/tools/onboarding-factory/cmd/replay/testdata/timing/threshold-one-ns-over.json
@@ -1,14 +1,28 @@
 {
   "description": "the threshold boundary from above: one nanosecond past driftThreshold IS drifted. Paired with threshold-exactly-1s.json this pins the comparison to the exact boundary rather than to a value comfortably either side of it",
   "recorded": [
-    {"seq": 1, "ts": "2026-04-11T10:00:00.000000000Z", "kind": "state_transition", "session_id": "s", "prev_state": "ready", "new_state": "working"}
+    {
+      "seq": 1,
+      "ts": "2026-04-11T10:00:00.000000000Z",
+      "kind": "state_transition",
+      "session_id": "s",
+      "prev_state": "ready",
+      "new_state": "working"
+    }
   ],
   "replayed": [
-    {"virtual_time": "2026-04-11T10:00:01.000000001Z", "prev_state": "ready", "new_state": "working"}
+    {
+      "virtual_time": "2026-04-11T10:00:01.000000001Z",
+      "prev_state": "ready",
+      "new_state": "working"
+    }
   ],
-  "want_deltas_ns": [1000000001],
-  "want_indices": [0],
-  "want_kinds": ["ready→working"],
-  "want_first_drift": 1000000001,
-  "want_worst_ns": 1000000001
+  "want": [
+    {
+      "index": 0,
+      "kind": "ready→working",
+      "delta_ns": 1000000001
+    }
+  ],
+  "want_first_drift": 1000000001
 }

--- a/tools/onboarding-factory/cmd/replay/timing_drift.go
+++ b/tools/onboarding-factory/cmd/replay/timing_drift.go
@@ -1,0 +1,272 @@
+package main
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"irrlicht/core/domain/lifecycle"
+)
+
+// Issue #1480: replay goldens record a virtual_time on every transition and
+// nothing compared it to anything. compareOrdered walks prev_state/new_state
+// index-by-index and never reads the time; assertReproducesRecordedTransitions
+// checks counts and kind-sets; the "N of 309 recordings diverge" headline every
+// replay PR quotes is counts and kinds only. So a transition reproduced at the
+// right position in the ORDER but 31 seconds from when the daemon made it was a
+// full pass on every gate in this package, and the golden then pinned it as
+// correct.
+//
+// This file is the measurement. It is deliberately NOT a tolerance gate — see
+// driftThreshold below for why the distribution had to be printed first.
+
+// timeDelta is one paired transition's timing divergence: how far the replay's
+// virtual_time sits from the ts the daemon logged for the SAME transition.
+//
+// The sign is load-bearing and is stated here once so no caller has to
+// rediscover it: NEGATIVE means the replay fired EARLY — ahead of the daemon —
+// which is the direction readBoundaryFor's known cost pushes (it widens the
+// read boundary by the next stat's SIZE, never its TIME, so it classifies
+// against bytes that did not exist yet). POSITIVE means the replay fired LATE,
+// which is what a synthesized debounce-deadline stamp does when the daemon's
+// real timer fired earlier than the replay's reconstruction of it.
+type timeDelta struct {
+	Index int
+	Kind  string
+	Delta time.Duration
+}
+
+// Abs is |Delta|, the quantity every bucket and percentile below is taken over.
+// Magnitude rather than signed value because the two directions have different
+// causes but the same cost: a golden pinning a time the daemon never produced.
+func (d timeDelta) Abs() time.Duration {
+	if d.Delta < 0 {
+		return -d.Delta
+	}
+	return d.Delta
+}
+
+// driftThreshold is the boundary this package calls "drifted".
+//
+// It is chosen from the measured distribution rather than picked, because the
+// issue is explicit that a tolerance cannot be chosen for a distribution nobody
+// has printed. Measured over all 818 kind-matched paired transitions in the
+// committed catalog, |delta| is sharply bimodal, and the two modes are
+// separated by a near-empty decade:
+//
+//	<1ms       162   19.8%   ┐
+//	1-10ms     324   39.6%   ├ 70.0% under 100ms — the daemon's own read latency
+//	10-100ms    87   10.6%   ┘
+//	0.1-1s      10    1.2%   ← the trough: ONE HUNDREDTH of the population
+//	1-5s       119   14.5%   ┐
+//	5-10s       39    4.8%   │
+//	10-30s      58    7.1%   ├ 28.7% above 1s — a different phenomenon entirely
+//	30-60s      13    1.6%   │
+//	>60s         6    0.7%   ┘
+//
+// p50 3.2ms, p75 2.0s, p90 8.8s, p95 20.5s, p99 43.3s, max 1m54.9s. The p75
+// sitting at almost exactly 2s is not a coincidence and is worth knowing
+// before reading any of the above: it is one debounce window, the synthesized
+// deadline stamp a coalesced flush carries.
+//
+// 1s sits in that trough. It is not a claim that 999ms is acceptable — it is
+// the observation that essentially nothing lands between 100ms and 1s, so any
+// cut in that decade partitions the same two populations and the exact value
+// cannot change the verdict for more than ~1% of transitions. A threshold
+// anywhere inside the dense regions WOULD be a guess; this one is not.
+const driftThreshold = time.Second
+
+// driftBucketEdges/driftBucketLabels are the histogram the report prints. The
+// edges are decade-ish rather than uniform because the population spans five
+// orders of magnitude (sub-millisecond to ~15 minutes) and a linear histogram
+// over that range is a single spike with a flat tail — which is exactly the
+// shape that let this cost stay invisible.
+var driftBucketEdges = []time.Duration{
+	time.Millisecond,
+	10 * time.Millisecond,
+	100 * time.Millisecond,
+	time.Second,
+	5 * time.Second,
+	10 * time.Second,
+	30 * time.Second,
+	time.Minute,
+}
+
+var driftBucketLabels = []string{
+	"<1ms", "1-10ms", "10-100ms", "0.1-1s", "1-5s", "5-10s", "10-30s", "30-60s", ">60s",
+}
+
+// transitionTimeDeltas measures, per paired transition, how far the replay's
+// virtual_time sits from the timestamp the daemon logged for it.
+//
+// It pairs EXACTLY as compareOrdered does — index by index, up to the shorter
+// slice — and that is a requirement rather than a convenience. A timing figure
+// computed over a different pairing would describe a different set of
+// transitions than the ordered-divergence figure it is reported beside, and the
+// two would disagree in ways no reader could attribute. If compareOrdered's
+// pairing ever changes, this must change with it.
+//
+// Only KIND-MATCHED pairs are measured, and the exclusion is the substantive
+// decision in this function. Where compareOrdered reports state_differs, the
+// two sides are not the same transition — subtracting their timestamps yields a
+// number with no meaning, and counting it as timing drift would report one
+// sequence divergence twice, once in ordered_mismatches and again here. The
+// catalog measurement was run both ways while this was written: including
+// unmatched pairs adds 80 of 898 pairs (8.9%) and leaves the #1476 enumeration
+// below bit-for-bit identical, so the choice costs nothing and buys a figure
+// that means one thing.
+//
+// The recorded side must already be filtered by filterStateTransitions (primary
+// session, non-empty prev_state) and the replayed side by dropInitTransitions,
+// same as compareOrdered's inputs — the synthetic init row has no counterpart
+// in the daemon's log and would pair index 0 against the wrong transition.
+func transitionTimeDeltas(recorded []lifecycle.Event, replayedReal []transition) []timeDelta {
+	n := min(len(recorded), len(replayedReal))
+	out := make([]timeDelta, 0, n)
+	for i := 0; i < n; i++ {
+		r, p := recorded[i], replayedReal[i]
+		if r.PrevState != p.PrevState || r.NewState != p.NewState {
+			continue
+		}
+		out = append(out, timeDelta{
+			Index: i,
+			Kind:  r.PrevState + "→" + r.NewState,
+			Delta: p.VirtualTime.Sub(r.Timestamp),
+		})
+	}
+	return out
+}
+
+// firstDrift reports whether the FIRST kind-matched pair — pair 0, the first
+// transition the replay and the daemon agree happened — is further than
+// driftThreshold from the daemon's own timestamp.
+//
+// It tests pair 0 and nothing else, which is the whole point and is easy to get
+// wrong: scanning for "the first pair that drifts" is a different predicate
+// (it answers "does ANY pair drift", just wearing the word first) and measures
+// 119 recordings where this one measures 65. Both quantities are useful and the
+// catalog test carries both — this one as the named enumeration, the other as
+// the aggregate ratchet — but conflating them costs the named list its meaning.
+//
+// Pair 0 specifically, because that is the transition a READ BOUNDARY decides:
+// it is the figure readBoundaryFor moves, and the figure #1476 reported when it
+// wrote "20 goldens now pin a FIRST transition more than 1s ahead of their own
+// events.jsonl". Checking this predicate against the goldens as they stood at
+// #1476's parent commit reproduces that PR's 20 exactly, worst case included
+// (mistral-vibe/2-12_context-compaction, -30.976s), which is the evidence that
+// this is the predicate #1476 meant.
+func firstDrift(deltas []timeDelta) (timeDelta, bool) {
+	if len(deltas) == 0 {
+		return timeDelta{}, false
+	}
+	if deltas[0].Abs() <= driftThreshold {
+		return timeDelta{}, false
+	}
+	return deltas[0], true
+}
+
+// worstDrift returns the pair with the largest |delta|, or false when there are
+// no kind-matched pairs at all.
+func worstDrift(deltas []timeDelta) (timeDelta, bool) {
+	var worst timeDelta
+	var found bool
+	for _, d := range deltas {
+		if !found || d.Abs() > worst.Abs() {
+			worst, found = d, true
+		}
+	}
+	return worst, found
+}
+
+// driftDistribution is the aggregate printed by the catalog measurement.
+type driftDistribution struct {
+	N           int
+	BucketCount []int
+	Percentiles map[int]time.Duration
+}
+
+// newDriftDistribution buckets and ranks |delta| over every kind-matched pair
+// handed to it.
+func newDriftDistribution(deltas []timeDelta) driftDistribution {
+	abs := make([]time.Duration, 0, len(deltas))
+	for _, d := range deltas {
+		abs = append(abs, d.Abs())
+	}
+	sort.Slice(abs, func(i, j int) bool { return abs[i] < abs[j] })
+
+	dist := driftDistribution{
+		N:           len(abs),
+		BucketCount: make([]int, len(driftBucketLabels)),
+		Percentiles: map[int]time.Duration{},
+	}
+	for _, a := range abs {
+		dist.BucketCount[bucketIndex(a)]++
+	}
+	for _, p := range []int{50, 75, 90, 95, 99, 100} {
+		dist.Percentiles[p] = percentile(abs, p)
+	}
+	return dist
+}
+
+// bucketIndex maps a magnitude onto driftBucketLabels. Edges are upper-
+// exclusive, so a delta of exactly 1s lands in "1-5s" rather than "0.1-1s" —
+// consistent with driftThreshold, which treats "drifted" as strictly greater.
+func bucketIndex(d time.Duration) int {
+	for i, edge := range driftBucketEdges {
+		if d < edge {
+			return i
+		}
+	}
+	return len(driftBucketLabels) - 1
+}
+
+// percentile returns the p-th percentile of a pre-sorted ascending slice by
+// linear interpolation between ranks. Returns 0 for an empty slice rather than
+// panicking: a catalog with no kind-matched pairs is a vacuity failure the
+// caller reports with a far better message than an index-out-of-range.
+func percentile(sorted []time.Duration, p int) time.Duration {
+	if len(sorted) == 0 {
+		return 0
+	}
+	if len(sorted) == 1 {
+		return sorted[0]
+	}
+	pos := float64(len(sorted)-1) * float64(p) / 100.0
+	lo := int(pos)
+	hi := lo + 1
+	if hi >= len(sorted) {
+		return sorted[len(sorted)-1]
+	}
+	frac := pos - float64(lo)
+	return sorted[lo] + time.Duration(float64(sorted[hi]-sorted[lo])*frac)
+}
+
+// String renders the distribution as the block the catalog measurement prints.
+func (d driftDistribution) String() string {
+	if d.N == 0 {
+		return "no kind-matched transition pairs — the measurement is vacuous"
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "|delta| over %d kind-matched paired transitions\n", d.N)
+	for _, p := range []int{50, 75, 90, 95, 99, 100} {
+		fmt.Fprintf(&b, "  p%-3d %12s\n", p, d.Percentiles[p])
+	}
+	b.WriteString("  ---- histogram ----\n")
+	for i, label := range driftBucketLabels {
+		c := d.BucketCount[i]
+		fmt.Fprintf(&b, "  %-9s %5d  %5.1f%%\n", label, c, 100*float64(c)/float64(d.N))
+	}
+	return b.String()
+}
+
+// driftSummary is the one-line per-recording figure printSummary appends to the
+// existing [extended-check: ...] line, so the sweep reports timing beside the
+// divergence figure it already reports.
+func driftSummary(deltas []timeDelta) string {
+	if len(deltas) == 0 {
+		return "timing n/a"
+	}
+	worst, _ := worstDrift(deltas)
+	return fmt.Sprintf("timing %d pairs worst %+.3fs@%d", len(deltas), worst.Delta.Seconds(), worst.Index)
+}

--- a/tools/onboarding-factory/cmd/replay/timing_drift.go
+++ b/tools/onboarding-factory/cmd/replay/timing_drift.go
@@ -2,11 +2,10 @@ package main
 
 import (
 	"fmt"
-	"sort"
 	"strings"
 	"time"
 
-	"irrlicht/core/domain/lifecycle"
+	"irrlicht/core/domain/stats"
 )
 
 // Issue #1480: replay goldens record a virtual_time on every transition and
@@ -40,12 +39,7 @@ type timeDelta struct {
 // Abs is |Delta|, the quantity every bucket and percentile below is taken over.
 // Magnitude rather than signed value because the two directions have different
 // causes but the same cost: a golden pinning a time the daemon never produced.
-func (d timeDelta) Abs() time.Duration {
-	if d.Delta < 0 {
-		return -d.Delta
-	}
-	return d.Delta
-}
+func (d timeDelta) Abs() time.Duration { return d.Delta.Abs() }
 
 // driftThreshold is the boundary this package calls "drifted".
 //
@@ -97,46 +91,11 @@ var driftBucketLabels = []string{
 	"<1ms", "1-10ms", "10-100ms", "0.1-1s", "1-5s", "5-10s", "10-30s", "30-60s", ">60s",
 }
 
-// transitionTimeDeltas measures, per paired transition, how far the replay's
-// virtual_time sits from the timestamp the daemon logged for it.
-//
-// It pairs EXACTLY as compareOrdered does — index by index, up to the shorter
-// slice — and that is a requirement rather than a convenience. A timing figure
-// computed over a different pairing would describe a different set of
-// transitions than the ordered-divergence figure it is reported beside, and the
-// two would disagree in ways no reader could attribute. If compareOrdered's
-// pairing ever changes, this must change with it.
-//
-// Only KIND-MATCHED pairs are measured, and the exclusion is the substantive
-// decision in this function. Where compareOrdered reports state_differs, the
-// two sides are not the same transition — subtracting their timestamps yields a
-// number with no meaning, and counting it as timing drift would report one
-// sequence divergence twice, once in ordered_mismatches and again here. The
-// catalog measurement was run both ways while this was written: including
-// unmatched pairs adds 80 of 898 pairs (8.9%) and leaves the #1476 enumeration
-// below bit-for-bit identical, so the choice costs nothing and buys a figure
-// that means one thing.
-//
-// The recorded side must already be filtered by filterStateTransitions (primary
-// session, non-empty prev_state) and the replayed side by dropInitTransitions,
-// same as compareOrdered's inputs — the synthetic init row has no counterpart
-// in the daemon's log and would pair index 0 against the wrong transition.
-func transitionTimeDeltas(recorded []lifecycle.Event, replayedReal []transition) []timeDelta {
-	n := min(len(recorded), len(replayedReal))
-	out := make([]timeDelta, 0, n)
-	for i := 0; i < n; i++ {
-		r, p := recorded[i], replayedReal[i]
-		if r.PrevState != p.PrevState || r.NewState != p.NewState {
-			continue
-		}
-		out = append(out, timeDelta{
-			Index: i,
-			Kind:  r.PrevState + "→" + r.NewState,
-			Delta: p.VirtualTime.Sub(r.Timestamp),
-		})
-	}
-	return out
-}
+// driftPercentiles is ranged over by both the computation and the rendering.
+// Written twice, the two drift silently: adding one only to the compute side
+// means String never shows it, and only to the print side means it prints 0s
+// from a missing map key.
+var driftPercentiles = []int{50, 75, 90, 95, 99, 100}
 
 // firstDrift reports whether the FIRST kind-matched pair — pair 0, the first
 // transition the replay and the daemon agree happened — is further than
@@ -166,17 +125,22 @@ func firstDrift(deltas []timeDelta) (timeDelta, bool) {
 	return deltas[0], true
 }
 
-// worstDrift returns the pair with the largest |delta|, or false when there are
-// no kind-matched pairs at all.
-func worstDrift(deltas []timeDelta) (timeDelta, bool) {
+// worstDrift returns the pair with the largest |delta|, or the zero timeDelta
+// when there are no kind-matched pairs — the same convention percentile uses,
+// and enough for both callers, which each already branch on len(deltas) first.
+//
+// It stays separate from newDriftDistribution because the distribution keeps
+// magnitudes only, while this needs the SIGNED delta and the pair index: the
+// direction is the diagnosis (early means a read boundary reached bytes that
+// did not exist yet; late means a synthesized debounce deadline).
+func worstDrift(deltas []timeDelta) timeDelta {
 	var worst timeDelta
-	var found bool
 	for _, d := range deltas {
-		if !found || d.Abs() > worst.Abs() {
-			worst, found = d, true
+		if d.Abs() > worst.Abs() {
+			worst = d
 		}
 	}
-	return worst, found
+	return worst
 }
 
 // driftDistribution is the aggregate printed by the catalog measurement.
@@ -189,22 +153,26 @@ type driftDistribution struct {
 // newDriftDistribution buckets and ranks |delta| over every kind-matched pair
 // handed to it.
 func newDriftDistribution(deltas []timeDelta) driftDistribution {
-	abs := make([]time.Duration, 0, len(deltas))
-	for _, d := range deltas {
-		abs = append(abs, d.Abs())
-	}
-	sort.Slice(abs, func(i, j int) bool { return abs[i] < abs[j] })
-
+	abs := make([]float64, 0, len(deltas))
 	dist := driftDistribution{
-		N:           len(abs),
+		N:           len(deltas),
 		BucketCount: make([]int, len(driftBucketLabels)),
 		Percentiles: map[int]time.Duration{},
 	}
-	for _, a := range abs {
+	for _, d := range deltas {
+		a := d.Abs()
+		abs = append(abs, float64(a))
 		dist.BucketCount[bucketIndex(a)]++
 	}
-	for _, p := range []int{50, 75, 90, 95, 99, 100} {
-		dist.Percentiles[p] = percentile(abs, p)
+	// stats.Percentile sorts a copy and is total (it reports false on empty),
+	// so no pre-sort is needed here and an empty population cannot produce a
+	// silently wrong number the way a pre-sort contract can.
+	for _, p := range driftPercentiles {
+		v, ok := stats.Percentile(abs, float64(p)/100)
+		if !ok {
+			continue
+		}
+		dist.Percentiles[p] = time.Duration(v)
 	}
 	return dist
 }
@@ -228,27 +196,6 @@ func bucketIndex(d time.Duration) int {
 	return len(driftBucketLabels) - 1
 }
 
-// percentile returns the p-th percentile of a pre-sorted ascending slice by
-// linear interpolation between ranks. Returns 0 for an empty slice rather than
-// panicking: a catalog with no kind-matched pairs is a vacuity failure the
-// caller reports with a far better message than an index-out-of-range.
-func percentile(sorted []time.Duration, p int) time.Duration {
-	if len(sorted) == 0 {
-		return 0
-	}
-	if len(sorted) == 1 {
-		return sorted[0]
-	}
-	pos := float64(len(sorted)-1) * float64(p) / 100.0
-	lo := int(pos)
-	hi := lo + 1
-	if hi >= len(sorted) {
-		return sorted[len(sorted)-1]
-	}
-	frac := pos - float64(lo)
-	return sorted[lo] + time.Duration(float64(sorted[hi]-sorted[lo])*frac)
-}
-
 // String renders the distribution as the block the catalog measurement prints.
 func (d driftDistribution) String() string {
 	if d.N == 0 {
@@ -256,7 +203,7 @@ func (d driftDistribution) String() string {
 	}
 	var b strings.Builder
 	fmt.Fprintf(&b, "|delta| over %d kind-matched paired transitions\n", d.N)
-	for _, p := range []int{50, 75, 90, 95, 99, 100} {
+	for _, p := range driftPercentiles {
 		fmt.Fprintf(&b, "  p%-3d %12s\n", p, d.Percentiles[p])
 	}
 	b.WriteString("  ---- histogram ----\n")
@@ -274,6 +221,6 @@ func driftSummary(deltas []timeDelta) string {
 	if len(deltas) == 0 {
 		return "timing n/a"
 	}
-	worst, _ := worstDrift(deltas)
+	worst := worstDrift(deltas)
 	return fmt.Sprintf("timing %d pairs worst %+.3fs@%d", len(deltas), worst.Delta.Seconds(), worst.Index)
 }

--- a/tools/onboarding-factory/cmd/replay/timing_drift.go
+++ b/tools/onboarding-factory/cmd/replay/timing_drift.go
@@ -210,8 +210,15 @@ func newDriftDistribution(deltas []timeDelta) driftDistribution {
 }
 
 // bucketIndex maps a magnitude onto driftBucketLabels. Edges are upper-
-// exclusive, so a delta of exactly 1s lands in "1-5s" rather than "0.1-1s" —
-// consistent with driftThreshold, which treats "drifted" as strictly greater.
+// exclusive, so a delta of exactly 1s lands in "1-5s" rather than "0.1-1s".
+//
+// That is one nanosecond out of step with driftThreshold on purpose: firstDrift
+// treats "drifted" as strictly greater, so a delta of exactly 1s is counted in
+// the histogram's above-the-line population while NOT being reported as drift.
+// The window is a single nanosecond and no recording sits in it, but the
+// disagreement is real, so it is pinned by
+// TestDriftDistribution_BucketsAndPercentiles rather than left to be
+// rediscovered as a bug.
 func bucketIndex(d time.Duration) int {
 	for i, edge := range driftBucketEdges {
 		if d < edge {

--- a/tools/onboarding-factory/cmd/replay/types.go
+++ b/tools/onboarding-factory/cmd/replay/types.go
@@ -108,6 +108,20 @@ type extendedCheck struct {
 	ReplayedUniqueKinds []string             `json:"replayed_unique_kinds"`
 	MissingKinds        []string             `json:"missing_kinds,omitempty"`
 	ExtraKinds          []string             `json:"extra_kinds,omitempty"`
+
+	// TimeDeltas is #1480's measurement: per kind-matched pair, how far the
+	// replay's virtual_time sits from the ts the daemon logged for the same
+	// transition. See timing_drift.go.
+	//
+	// `json:"-"` is deliberate and is the whole reason this lands as a
+	// measurement rather than a golden change. Goldens ARE this struct (only
+	// SidecarPath, GeneratedAt and SourceTranscript are zeroed before
+	// encoding), so serializing a duration here would rewrite all 399 of them
+	// in the same commit that introduces the thing they would be rewritten to
+	// assert — the reviewer could not tell a correct baseline from a wrong one.
+	// Goldening the delta is the issue's option 3 and is argued, with this
+	// measurement in hand, in the PR rather than assumed here.
+	TimeDeltas []timeDelta `json:"-"`
 }
 
 // transitionMismatch is a single divergence between replayed and recorded

--- a/tools/replay-fixtures.sh
+++ b/tools/replay-fixtures.sh
@@ -76,16 +76,9 @@ extended_divergence_count=0
 # the failure mode #1480 is about.
 timing_drifts=""
 timing_drift_count=0
-# How many recordings yielded a PARSEABLE timing figure, and how many printed an
-# extended-check line at all. The pair exists so this block cannot fail the way
-# the one above it did: if driftSummary's format ever changes, the sed below
-# matches nothing, timing_drift_count stays 0, the report never prints and the
-# sweep still exits 0 — absence of drift and inability to parse producing byte-
-# identical output. The check at the end of this script refuses that. The Go
-# side pins the same contract from the other direction
-# (TestDriftSummary_FormatIsTheShellContract).
-timing_parsed_count=0
-extcheck_seen_count=0
+# The format the summary line must carry. Kept in a variable because bash 3.2
+# needs an unquoted variable on the right of =~ for a regex with groups.
+timing_re='timing ([0-9]+) pairs worst ([+-][0-9.]+)s@([0-9]+)'
 while IFS= read -r fix; do
   [[ -z "$fix" ]] && continue
   [[ "$fix" == */subagents/* ]] && continue
@@ -141,35 +134,50 @@ while IFS= read -r fix; do
   # the sweep's live output is what it always was.
   replay_err="$("./$BIN" --out "$json" --debounce "$DEBOUNCE" "$fix" 2>&1 >/dev/null || true)"
   [[ -n "$replay_err" ]] && printf '%s\n' "$replay_err" >&2
-  # Tally the ordered/kind divergence. These two counters were added with the
-  # reporting block at the end of this script but nothing ever incremented
-  # them, so that block could not print and the "N of 309 diverge" figure it
-  # exists to show had to be recomputed by hand every time (#1480).
-  if printf '%s' "$replay_err" | grep -q 'extended-check:'; then
-    extcheck_seen_count=$((extcheck_seen_count + 1))
-  fi
-  if printf '%s' "$replay_err" | grep -q 'extended-check:.*FAIL'; then
-    extended_divergences="${extended_divergences}   ${adapter}/${kind}/${name}/${recname}
+  # printSummary emits exactly one summary line, last, after any malformed-line
+  # warnings — so the last line is the one to read, and matching against the
+  # whole capture could pick up a FAIL from unrelated stderr.
+  summary_line="${replay_err##*$'\n'}"
+  if [[ "$summary_line" == *"extended-check:"* ]]; then
+    # Tally the ordered/kind divergence. These two counters were added with the
+    # reporting block at the end of this script but nothing ever incremented
+    # them, so that block could not print and the "N of 309 diverge" figure it
+    # exists to show had to be recomputed by hand every time (#1480).
+    if [[ "$summary_line" == *FAIL* ]]; then
+      extended_divergences="${extended_divergences}   ${adapter}/${kind}/${name}/${recname}
 "
-    extended_divergence_count=$((extended_divergence_count + 1))
-  fi
-  # Tally the timing drift. The 1s cut matches driftThreshold in
-  # cmd/replay/timing_drift.go, chosen from the measured distribution (a
-  # near-empty decade between 100ms and 1s) rather than picked. Note this cut is
-  # taken on the %+.3f-ROUNDED figure, so a delta of 1.0004s reads as 1.000 and
-  # is omitted here while the Go gate counts it. That only decides which rows
-  # this informational listing prints; the gate is the Go test.
-  timing_worst="$(printf '%s' "$replay_err" | sed -n 's/.*timing \([0-9][0-9]*\) pairs worst \([+-][0-9.][0-9.]*\)s@\([0-9][0-9]*\).*/\1 \2 \3/p' | tail -1)"
-  if [[ -n "$timing_worst" ]]; then
-    timing_parsed_count=$((timing_parsed_count + 1))
-    tw_pairs="${timing_worst%% *}"
-    tw_rest="${timing_worst#* }"
-    tw_delta="${tw_rest%% *}"
-    tw_index="${tw_rest##* }"
-    if awk "BEGIN{d=$tw_delta; if (d<0) d=-d; exit !(d > 1.0)}"; then
-      timing_drifts="${timing_drifts}   ${adapter}/${kind}/${name}/${recname}: worst ${tw_delta}s at pair ${tw_index} of ${tw_pairs}
+      extended_divergence_count=$((extended_divergence_count + 1))
+    fi
+    # Tally the timing drift. The 1s cut matches driftThreshold in
+    # cmd/replay/timing_drift.go, chosen from the measured distribution (a
+    # near-empty decade between 100ms and 1s) rather than picked. Note the cut
+    # is taken on the %+.3f-ROUNDED figure, so a delta of 1.0004s reads as 1.000
+    # and is omitted from this listing while the Go gate counts it. That only
+    # decides which rows print here; the gate is the Go test.
+    if [[ "$summary_line" =~ $timing_re ]]; then
+      tw_delta="${BASH_REMATCH[2]}"
+      if awk "BEGIN{d=$tw_delta; if (d<0) d=-d; exit !(d > 1.0)}"; then
+        timing_drifts="${timing_drifts}   ${adapter}/${kind}/${name}/${recname}: worst ${tw_delta}s at pair ${BASH_REMATCH[3]} of ${BASH_REMATCH[1]}
 "
-      timing_drift_count=$((timing_drift_count + 1))
+        timing_drift_count=$((timing_drift_count + 1))
+      fi
+    elif [[ "$summary_line" != *"timing n/a"* ]]; then
+      # A verification mechanism must fail loudly when it cannot run
+      # (AGENTS.md). Every extended-check line carries a timing figure — a
+      # parseable one, or the literal "timing n/a" for a recording with no
+      # kind-matched pair. Neither means driftSummary's format and this parser
+      # have diverged, and without this the report would simply go silent and
+      # the sweep would still exit 0. Checked per recording rather than tallied
+      # to the end, so it fails on the first one and cannot be masked by the 39
+      # recordings that legitimately report n/a. The Go side pins the same
+      # contract from the other direction
+      # (TestDriftSummary_FormatIsTheShellContract).
+      echo "timing report is broken: ${adapter}/${kind}/${name}/${recname} printed an" >&2
+      echo "  extended-check line carrying neither a parseable timing figure nor 'timing n/a':" >&2
+      echo "    $summary_line" >&2
+      echo "  driftSummary's format and this script's parser have diverged — see" >&2
+      echo "  cmd/replay/timing_drift.go and TestDriftSummary_FormatIsTheShellContract (#1480)." >&2
+      exit 1
     fi
   fi
   if [[ ! -s "$json" ]]; then
@@ -387,19 +395,6 @@ if [[ "$timing_drift_count" -gt 0 ]]; then
   echo "   the daemon. These do not fail the build here; the gate is" >&2
   echo "   TestSidecarReplayTransitionTimesMatchTheDaemonsOwnLog, which ratchets the set (#1480)." >&2
   echo >&2
-fi
-
-# A verification mechanism must fail loudly when it cannot run (AGENTS.md). If
-# recordings produced extended-check lines but NONE of them yielded a timing
-# figure, the format contract between driftSummary and the sed above has broken
-# and this script's timing report has gone silent — which is indistinguishable
-# from "nothing drifted" without this check.
-if [[ "$extcheck_seen_count" -gt 0 && "$timing_parsed_count" -eq 0 ]]; then
-  echo "timing report is broken: $extcheck_seen_count recording(s) printed an extended-check line" >&2
-  echo "  but none yielded a parseable 'timing N pairs worst ±X.XXXs@I' figure. driftSummary's" >&2
-  echo "  format and this script's parser have diverged — see cmd/replay/timing_drift.go and" >&2
-  echo "  TestDriftSummary_FormatIsTheShellContract (#1480)." >&2
-  exit 1
 fi
 
 echo "done. reports in $REPORTS_DIR/" >&2

--- a/tools/replay-fixtures.sh
+++ b/tools/replay-fixtures.sh
@@ -62,6 +62,20 @@ found_any=0
 # variable error.
 extended_divergences=""
 extended_divergence_count=0
+# #1480: transition-timing drift — how far each reproduced transition sits from
+# the ts the recording's own daemon logged for it. Reported beside the
+# divergence figure above because they are the two halves of one question:
+# that one asks whether the replay produced the same transitions, this one
+# whether it produced them at the same TIME. Nothing asked the second until
+# #1480, so a transition reproduced 31s early was a full pass.
+#
+# The authoritative implementation is Go (cmd/replay/timing_drift.go, gated by
+# TestSidecarReplayTransitionTimesMatchTheDaemonsOwnLog). This block only
+# surfaces the per-recording figure the replay binary already prints, because a
+# `go test` that passes prints nothing without -v, and an unread measurement is
+# the failure mode #1480 is about.
+timing_drifts=""
+timing_drift_count=0
 while IFS= read -r fix; do
   [[ -z "$fix" ]] && continue
   [[ "$fix" == */subagents/* ]] && continue
@@ -112,7 +126,35 @@ while IFS= read -r fix; do
   # `preflight.sh` coexist with a red CI on a fresh checkout, inverting the
   # local-CI-parity contract this script provides.
   rm -f "$json"
-  "./$BIN" --out "$json" --debounce "$DEBOUNCE" "$fix" || true
+  # stderr is captured rather than passed straight through so the per-recording
+  # extended-check line can be tallied; it is echoed on unchanged afterwards, so
+  # the sweep's live output is what it always was.
+  replay_err="$("./$BIN" --out "$json" --debounce "$DEBOUNCE" "$fix" 2>&1 >/dev/null || true)"
+  [[ -n "$replay_err" ]] && printf '%s\n' "$replay_err" >&2
+  # Tally the ordered/kind divergence. These two counters were added with the
+  # reporting block at the end of this script but nothing ever incremented
+  # them, so that block could not print and the "N of 309 diverge" figure it
+  # exists to show had to be recomputed by hand every time (#1480).
+  if printf '%s' "$replay_err" | grep -q 'extended-check:.*FAIL'; then
+    extended_divergences="${extended_divergences}   ${adapter}/${kind}/${name}/${recname}
+"
+    extended_divergence_count=$((extended_divergence_count + 1))
+  fi
+  # Tally the timing drift. The threshold matches driftThreshold in
+  # cmd/replay/timing_drift.go, which is chosen from the measured distribution
+  # (a near-empty decade between 100ms and 1s) rather than picked.
+  timing_worst="$(printf '%s' "$replay_err" | sed -n 's/.*timing \([0-9][0-9]*\) pairs worst \([+-][0-9.][0-9.]*\)s@\([0-9][0-9]*\).*/\1 \2 \3/p' | tail -1)"
+  if [[ -n "$timing_worst" ]]; then
+    tw_pairs="${timing_worst%% *}"
+    tw_rest="${timing_worst#* }"
+    tw_delta="${tw_rest%% *}"
+    tw_index="${tw_rest##* }"
+    if awk "BEGIN{d=$tw_delta; if (d<0) d=-d; exit !(d > 1.0)}"; then
+      timing_drifts="${timing_drifts}   ${adapter}/${kind}/${name}/${recname}: worst ${tw_delta}s at pair ${tw_index} of ${tw_pairs}
+"
+      timing_drift_count=$((timing_drift_count + 1))
+    fi
+  fi
   if [[ ! -s "$json" ]]; then
     echo "replay failed (no report written) for $fix" >&2
     exit 1
@@ -318,6 +360,15 @@ if [[ "$extended_divergence_count" -gt 0 ]]; then
   echo "== extended-check divergences (informational: replay vs the daemon that made the recording) ==" >&2
   printf '%s' "$extended_divergences" >&2
   echo "   $extended_divergence_count recording(s); these do not fail the build — the byte-identity goldens are the gate." >&2
+  echo >&2
+fi
+
+if [[ "$timing_drift_count" -gt 0 ]]; then
+  echo "== transition-timing drift >1s (informational: replay's virtual_time vs the daemon's own ts) ==" >&2
+  printf '%s' "$timing_drifts" >&2
+  echo "   $timing_drift_count recording(s). A NEGATIVE delta means the replay fired EARLY — ahead of" >&2
+  echo "   the daemon. These do not fail the build here; the gate is" >&2
+  echo "   TestSidecarReplayTransitionTimesMatchTheDaemonsOwnLog, which ratchets the set (#1480)." >&2
   echo >&2
 fi
 

--- a/tools/replay-fixtures.sh
+++ b/tools/replay-fixtures.sh
@@ -76,6 +76,16 @@ extended_divergence_count=0
 # the failure mode #1480 is about.
 timing_drifts=""
 timing_drift_count=0
+# How many recordings yielded a PARSEABLE timing figure, and how many printed an
+# extended-check line at all. The pair exists so this block cannot fail the way
+# the one above it did: if driftSummary's format ever changes, the sed below
+# matches nothing, timing_drift_count stays 0, the report never prints and the
+# sweep still exits 0 — absence of drift and inability to parse producing byte-
+# identical output. The check at the end of this script refuses that. The Go
+# side pins the same contract from the other direction
+# (TestDriftSummary_FormatIsTheShellContract).
+timing_parsed_count=0
+extcheck_seen_count=0
 while IFS= read -r fix; do
   [[ -z "$fix" ]] && continue
   [[ "$fix" == */subagents/* ]] && continue
@@ -135,16 +145,23 @@ while IFS= read -r fix; do
   # reporting block at the end of this script but nothing ever incremented
   # them, so that block could not print and the "N of 309 diverge" figure it
   # exists to show had to be recomputed by hand every time (#1480).
+  if printf '%s' "$replay_err" | grep -q 'extended-check:'; then
+    extcheck_seen_count=$((extcheck_seen_count + 1))
+  fi
   if printf '%s' "$replay_err" | grep -q 'extended-check:.*FAIL'; then
     extended_divergences="${extended_divergences}   ${adapter}/${kind}/${name}/${recname}
 "
     extended_divergence_count=$((extended_divergence_count + 1))
   fi
-  # Tally the timing drift. The threshold matches driftThreshold in
-  # cmd/replay/timing_drift.go, which is chosen from the measured distribution
-  # (a near-empty decade between 100ms and 1s) rather than picked.
+  # Tally the timing drift. The 1s cut matches driftThreshold in
+  # cmd/replay/timing_drift.go, chosen from the measured distribution (a
+  # near-empty decade between 100ms and 1s) rather than picked. Note this cut is
+  # taken on the %+.3f-ROUNDED figure, so a delta of 1.0004s reads as 1.000 and
+  # is omitted here while the Go gate counts it. That only decides which rows
+  # this informational listing prints; the gate is the Go test.
   timing_worst="$(printf '%s' "$replay_err" | sed -n 's/.*timing \([0-9][0-9]*\) pairs worst \([+-][0-9.][0-9.]*\)s@\([0-9][0-9]*\).*/\1 \2 \3/p' | tail -1)"
   if [[ -n "$timing_worst" ]]; then
+    timing_parsed_count=$((timing_parsed_count + 1))
     tw_pairs="${timing_worst%% *}"
     tw_rest="${timing_worst#* }"
     tw_delta="${tw_rest%% *}"
@@ -370,6 +387,19 @@ if [[ "$timing_drift_count" -gt 0 ]]; then
   echo "   the daemon. These do not fail the build here; the gate is" >&2
   echo "   TestSidecarReplayTransitionTimesMatchTheDaemonsOwnLog, which ratchets the set (#1480)." >&2
   echo >&2
+fi
+
+# A verification mechanism must fail loudly when it cannot run (AGENTS.md). If
+# recordings produced extended-check lines but NONE of them yielded a timing
+# figure, the format contract between driftSummary and the sed above has broken
+# and this script's timing report has gone silent — which is indistinguishable
+# from "nothing drifted" without this check.
+if [[ "$extcheck_seen_count" -gt 0 && "$timing_parsed_count" -eq 0 ]]; then
+  echo "timing report is broken: $extcheck_seen_count recording(s) printed an extended-check line" >&2
+  echo "  but none yielded a parseable 'timing N pairs worst ±X.XXXs@I' figure. driftSummary's" >&2
+  echo "  format and this script's parser have diverged — see cmd/replay/timing_drift.go and" >&2
+  echo "  TestDriftSummary_FormatIsTheShellContract (#1480)." >&2
+  exit 1
 fi
 
 echo "done. reports in $REPORTS_DIR/" >&2


### PR DESCRIPTION
Closes #1480.

Replay goldens pin a `virtual_time` on every transition and **nothing compared it to anything**. This adds the measurement — the issue's option 1 — and deliberately stops there: options 2 and 3 are argued below against the printed distribution rather than assumed.

## The measured distribution

Over all **818 kind-matched paired transitions** in the 309 sidecar-driven recordings. This is the thing that did not exist before, and the reason a threshold could not be chosen until now:

```
|delta| over 818 kind-matched paired transitions
  p50          3.246ms
  p75        2.0020505s
  p90       8.781336799s
  p95      20.454595649s
  p99       43.34475694s
  p100      1m54.901443s
  ---- histogram ----
  <1ms        162   19.8%   ┐
  1-10ms      324   39.6%   ├ 70.0% under 100ms
  10-100ms     87   10.6%   ┘
  0.1-1s       10    1.2%   ← the trough: ~1% of the population
  1-5s        119   14.5%   ┐
  5-10s        39    4.8%   │
  10-30s       58    7.1%   ├ 28.7% above 1s
  30-60s       13    1.6%   │
  >60s          6    0.7%   ┘
```

The issue predicted bimodality from `readBoundaryFor`'s own 114-firing sample. The full population confirms it **and quantifies the gap**: the 0.1–1s decade holds 10 of 818 pairs. That trough is why `driftThreshold = 1s` is read off the data rather than picked — any cut inside it partitions the same two populations, and the exact value cannot move the verdict for more than ~1% of transitions. A threshold inside either dense region would have been a guess.

The `p75` sitting at almost exactly **2.002s** is worth calling out: that is one debounce window, the synthesized deadline stamp a coalesced flush carries. A whole mode of this distribution is the replayer reconstructing a timer rather than reading a timestamp.

Aggregate: **119 of 309** recordings have at least one transition >1s from their daemon, **50** >5s; **65** drift on their *first* transition.

## The 20 from #1476 are enumerated mechanically

`knownFirstTransitionDrift` lists 65 recordings by name, each tagged `#1476 accepted` or `pre-dates #1476`. The attribution was **measured, not asserted** — I replayed the goldens as they stood at `7f8fd900^` (#1476's parent) and diffed the first-transition delta:

```
goldens whose FIRST transition time CHANGED at #1476 and is now >1s early: 20
  old=-0.022s new=-30.976s  mistral-vibe/scenarios/2-12_context-compaction/...
  old=-0.021s new=-27.522s  mistral-vibe/scenarios/6-1_backchannel-control/...
  ...
  old=-0.002s new=-2.032s  codex/scenarios/2-15_shell-escape-command/...
```

Exactly 20, worst case `-30.976s` on `mistral-vibe/2-12_context-compaction` — #1476's own figures, reproduced independently.

## Red-first evidence — mutations, not description

Per AGENTS.md, a check a change *adds* has no "before" and owes a deliberate mutation. Both were run and seen red.

**Mutation A — force every delta to `0`** (the measurement stops measuring). Every corpus case goes red, and the catalog vacuity guard fires:

```
--- FAIL: TestTransitionTimeDeltas_Corpus/first-transition-31s-early
      got  [{0 ready→working 0s} {1 working→ready 0s}]
      want [{0 ready→working -30.97648s} {1 working→ready 2.012918s}]
--- FAIL: TestSidecarReplayTransitionTimesMatchTheDaemonsOwnLog
    issue1480_timing_test.go:360: no recording drifts at all — #1476 documents 20 that do,
        so the measurement is not reaching them
```

**Mutation B — disable `readBoundaryFor`** (revert #1476's widening). The check names **exactly 20** entries as no longer drifting, and they are precisely the 20 tagged `#1476 accepted`:

```
$ go test -run TestSidecarReplayTransitionTimes... | grep -c 'no longer drifts'
20
    knownFirstTransitionDrift entry "mistral-vibe/scenarios/2-12_context-compaction/..." no longer drifts
    knownFirstTransitionDrift entry "codex/scenarios/1-4_session-resume/..." no longer drifts
    ...
```

That is the acceptance criterion satisfied mechanically: the tool identifies #1476's 20 without being told which they are.

Mutation B also **independently confirms #1476's net-win claim** — with the widening disabled, 45 recordings *newly* drift and the aggregate worsens (119 → 131 over 1s, 50 → 67 over 5s).

The mutation for A is **committed**, not just described: `cmd/replay/testdata/timing/` holds one file per timing shape, carrying both verdicts on purpose. A detector that flags everything and one that flags correctly are indistinguishable without the cases that must stay *silent*, so `aligned.json` and `sub-second-justified.json` are load-bearing, and the test refuses a corpus that has lost either kind.

## Accepted, not fixed — stated explicitly

The 20 are an **accepted, documented limitation**, as #1476 argues with evidence. Its rejected alternative stands: a 200ms gap bound collapses the worst drifts but breaks 35 gemini-cli recordings that reproduce exactly today, because the sidecar cannot distinguish "the gap is idle time *after* a write the daemon absorbed" from "the gap is *before* the write happened". The list now says so per entry rather than leaving it in a doc-comment paragraph — which is what #1480 was filed about.

## Design notes

- **No golden is rewritten.** `extendedCheck.TimeDeltas` is `json:"-"`. Goldens *are* this struct, so serializing a duration would rewrite all 399 in the same commit that introduces the thing they'd be rewritten to assert — a reviewer could not tell a correct baseline from a wrong one. Measured: 0 goldens in the diff.
- **Ratchet, not tolerance gate.** 28.7% of pairs already exceed 1s; a gate failing on all of them would be reverted within the day. It fails on *new* drift, on a stale entry, or on the aggregate growing — `knownZeroTransition`'s idiom.
- **One traversal, not two.** `compareOrdered` returns the matched pairs, each carrying its delta, instead of a count. The first draft had a second identical loop with the identity `len(TimeDeltas) == OrderedMatches` held by three prose comments and a runtime assertion; folding them makes it structural, and the assertion is deleted rather than kept.
- **Kind-matched pairs only.** Where `compareOrdered` reports `state_differs` the two sides are not the same transition, so their timestamp difference is meaningless and counting it would report one sequence divergence twice. Run both ways: including unmatched pairs adds 80 of 898 (8.9%) and leaves the #1476 enumeration bit-for-bit identical.
- **`firstDrift` tests pair 0 and nothing else.** Scanning for "the first pair that drifts" is a different predicate wearing the word *first* — it measures 119 where this measures 65. The first draft had that bug; it is now named in the doc comment.
- **Floors as well as ceilings.** Every ratchet is an upper bound, so a pairing shift that turns kind-matched pairs into `state_differs` makes the drift counts *fall* and everything pass. `minKindMatchedPairs`/`minMeasuredRecordings` pin the size of the measured population (818 pairs, 270 recordings — 39 already measure nothing, so this is a live state).

## Drive-by fix: the sweep's divergence reporter was dead

`tools/replay-fixtures.sh` initialized `extended_divergences`/`extended_divergence_count` (:63-64) and printed them (:317-320), but **nothing ever incremented them** — verified by grep, only those four lines mention the variables. The "N of 309 diverge" figure that block exists to show could never print and has been recomputed by hand in every replay PR since. Both counters are now wired, alongside the new timing block. Informational only, exactly as its comment says.

## Review

A `high`-effort review subagent returned 8 findings; all were applied (commit 2). Four were variants of one shape — the check going quiet without saying so — including one the reviewer demonstrated with a probe: a corpus row asserting nothing passed *and* counted toward the drift/clean balance guard.

A `/simplify` pass (4 agents) converged on two structural findings, both taken (commit 3): fold the duplicate pairing loop into `compareOrdered`, and share the byte-identical catalog walk between the two gates. Plus `core/domain/stats.Percentile` reuse (percentiles come out bit-identical), `time.Duration.Abs()`, and replacing ~1500 `grep`/`sed` subprocesses in the sweep with bash-native matching.

Three suggestions were **not** taken, with reasons:

- **Memoizing the shared catalog walk** across the two gates (~1.7s CPU, and measured to cost *zero* wall-clock on the gate, whose tail is `internal/matrix`). Two reviewers disagreed on this; keeping two independent replay runs is deliberate, so a fault on one path cannot mask the other.
- **Replacing the sweep's last `awk` fork** with `[[ "${d%%.*}" -ge 1 ]]`. Not equivalent: integer truncation makes a delta of exactly `1.000` compare true where `awk`'s `> 1.0` is false. 1.3s on a 200s sweep is not worth a boundary change.
- **Pre-sorting before the six `stats.Percentile` calls.** Real redundancy (6 sorts where 1 would do), but measured at 140µs *once per test run*; a comment explaining it would be longer than the saving.

## Verification

- `tools/preflight.sh --only go` — all 7 gates PASS (core suite, onboarding-factory, replaydata validate, recording-rig smoke, **replay fixtures**, starhistory)
- `--only arch` PASS (ARS composite unchanged, 7.9439 → 7.9439) · `--only tools` PASS · `--only skills` PASS · `--only security` PASS
- Deletion tripwire empty; 0 goldens touched
- The sweep's new block reports **119** recordings, matching the Go test's aggregate exactly — independent cross-check between the shell and Go implementations
- The revived divergence counter reports **147** recordings; that block could never print before
- Shell matching verified under the real macOS system `bash 3.2.57` the script targets, including the multi-line, `timing n/a`, and broken-format cases

## Note for #1478

#1478 says any time-aware read-boundary model "should be validated against the recorded transition timestamps rather than only against the counts". That validation now exists and is catalog-wide, so #1478 can be evaluated on the axis it asked for. Two figures it should be held to: its four recordings must not enter `knownFirstTransitionDrift`, and neither aggregate scalar may grow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
