### PR TITLE
fix(processlifecycle): tell a failed herdr client probe from a detached one

### DIFF
--- a/core/adapters/inbound/agents/processlifecycle/osutil.go
+++ b/core/adapters/inbound/agents/processlifecycle/osutil.go
@@ -69,13 +69,15 @@ func herdrClientLogPath(socketPath string) string {
 // of pid. Returns nil if env cannot be read or no interesting vars are present.
 //
 // hostKnown reports whether the host window could be *determined*, which is
-// not the same as being found. It is false only for a herdr pane whose client
-// probe did not run (#1485) — every other read either resolves the host from
-// the process itself or establishes that it has none. A caller merging this
-// read into a launcher it already holds must not clear host fields when
-// hostKnown is false: their absence means "not looked up", not "gone". A
-// caller capturing a session's first launcher may ignore it, because there is
-// nothing to clear and dropping the read would cost the pane its herdr address.
+// not the same as being found. It is false whenever this read established
+// nothing: a herdr pane whose client probe did not run (#1485), a pid that
+// cannot be looked at at all (pid <= 0, or a process whose env, ancestry and
+// tty all came back empty), and — at the wiring in cmd/irrlichd — a revoked
+// launcher consent. A caller merging this read into a launcher it already
+// holds must not clear host fields when hostKnown is false: their absence
+// means "not looked up", not "gone". A caller capturing a session's first
+// launcher may ignore it, because there is nothing to clear and dropping the
+// read would cost the pane its herdr address.
 //
 // Never blocks longer than 2 seconds. Never prompts the user — on macOS we use
 // `sysctl(kern.procargs2)` (no TCC prompt; `ps e` stopped exposing env on
@@ -101,7 +103,14 @@ func ReadLauncherEnv(pid int) (l *session.Launcher, hostKnown bool) {
 	}
 
 	if l.IsEmpty() {
-		return nil, hostKnown
+		// Nothing was determined, so say so rather than passing hostKnown
+		// through: an empty read is "env, ancestry and tty all came back
+		// blank", which is a hardened-runtime process or one that has already
+		// exited as often as it is a process with genuinely no terminal. Every
+		// consumer today bails on the nil before reading the flag, so this
+		// costs nothing — but a future consumer that reads the flag first
+		// would otherwise be told an unreadable process HAS no host.
+		return nil, false
 	}
 	return l, hostKnown
 }

--- a/core/adapters/inbound/agents/processlifecycle/osutil.go
+++ b/core/adapters/inbound/agents/processlifecycle/osutil.go
@@ -68,15 +68,25 @@ func herdrClientLogPath(socketPath string) string {
 // ReadLauncherEnv returns the launcher identity captured from the process env
 // of pid. Returns nil if env cannot be read or no interesting vars are present.
 //
+// hostKnown reports whether the host window could be *determined*, which is
+// not the same as being found. It is false only for a herdr pane whose client
+// probe did not run (#1485) — every other read either resolves the host from
+// the process itself or establishes that it has none. A caller merging this
+// read into a launcher it already holds must not clear host fields when
+// hostKnown is false: their absence means "not looked up", not "gone". A
+// caller capturing a session's first launcher may ignore it, because there is
+// nothing to clear and dropping the read would cost the pane its herdr address.
+//
 // Never blocks longer than 2 seconds. Never prompts the user — on macOS we use
 // `sysctl(kern.procargs2)` (no TCC prompt; `ps e` stopped exposing env on
 // modern macOS). On Linux we read /proc/<pid>/environ. Other platforms return
 // nil.
-func ReadLauncherEnv(pid int) *session.Launcher {
+func ReadLauncherEnv(pid int) (l *session.Launcher, hostKnown bool) {
 	if pid <= 0 {
-		return nil
+		return nil, false
 	}
-	l := hostIdentity(pid)
+	l = hostIdentity(pid)
+	hostKnown = true
 
 	// A herdr pane's window belongs to the attached client, so its host
 	// identity is resolved from that process instead — one indirection past
@@ -85,13 +95,15 @@ func ReadLauncherEnv(pid int) *session.Launcher {
 	// overridden by the client's when something is: AdoptHostIdentity owns
 	// that rule.
 	if l.HerdrPaneID != "" {
-		l.AdoptHostIdentity(herdrClientLauncher(l.HerdrSocketPath))
+		var client *session.Launcher
+		client, hostKnown = herdrClientLauncher(l.HerdrSocketPath)
+		l.AdoptHostIdentity(client)
 	}
 
 	if l.IsEmpty() {
-		return nil
+		return nil, hostKnown
 	}
-	return l
+	return l, hostKnown
 }
 
 // hostIdentity resolves the window-owning identity of pid: its whitelisted

--- a/core/adapters/inbound/agents/processlifecycle/osutil_darwin.go
+++ b/core/adapters/inbound/agents/processlifecycle/osutil_darwin.go
@@ -413,10 +413,17 @@ func herdrClientPIDs(socketPath string) (pids []int, probed bool) {
 	// exists and nobody holds it open" and "there is no such file" (measured,
 	// lsof 4.91: the second also writes a "status error on <path>" line to
 	// stderr, which .Output() discards). Only the first is a detach. Without
-	// this, a client log that is not where we looked — herdr moving it between
-	// releases, or a captured socket path that addresses a different session —
-	// reads as a permanent, self-consistent "nobody is attached" rather than
-	// as a probe that never reached the question.
+	// this, a client log that resolves to NOTHING — herdr moving or renaming
+	// it between releases — reads as a permanent, self-consistent "nobody is
+	// attached" rather than as a probe that never reached the question.
+	//
+	// It covers only that case, and deliberately not the neighbouring one: a
+	// socket path addressing a *different, real* herdr session resolves to a
+	// client log that exists, so the stat passes and lsof honestly reports no
+	// holders. Verified live against herdr 0.8.0 — a detached session keeps
+	// its client log (~/.config/herdr/sessions/factory/herdr-client.log, 505
+	// bytes, no holders), so file existence cannot separate "detached" from
+	// "probed somebody else's session". Only deriving the path correctly can.
 	if _, err := os.Stat(logPath); err != nil {
 		return nil, false
 	}
@@ -475,10 +482,21 @@ const maxHerdrClientCandidates = 4
 // herdrClientLauncher resolves the host-window identity of the herdr session
 // addressed by socketPath, by reading it from the attached client exactly the
 // way it would be read from any directly-hosted agent (hostIdentity). Returns
-// (nil, true) when nothing is attached, or when no attached client resolves to
-// a local GUI host — an SSH client has a real tty but no local window, and
-// reporting one anyway is the misroute #1348 removed. Both of those are real
-// answers; (nil, false) is the third state, "the probe did not run" (#1485).
+// (nil, true) when nothing is attached, or when no attached client REPORTED a
+// local GUI host — an SSH client has a real tty but no local window, and
+// reporting one anyway is the misroute #1348 removed. (nil, false) is the
+// third state, "the probe did not run" (#1485).
+//
+// "Reported" rather than "resolves to" is deliberate and is the known residual
+// of #1485: a candidate whose own identity could not be READ is counted as one
+// that has no host. hostIdentity swallows both of its failure modes — EnvOf's
+// error is discarded, and resolveHostFromAncestry returns ("", 0) for a
+// readProcInfo timeout as well as for a genuine miss — so a client attached
+// from kitty (which sets no TERM_PROGRAM upstream, so ancestry is its only
+// source) yields no host on a loaded machine and is indistinguishable here
+// from an SSH client. That is the same conflation one layer up, and closing it
+// needs hostIdentity to report whether its reads ran, which this fix does not
+// do. Tracked as #1492; do not read the tri-state below as covering it.
 //
 // Only ever called with a socket path the daemon captured from the pane's own
 // $HERDR_SOCKET_PATH, so a resolved identity always accompanies a complete

--- a/core/adapters/inbound/agents/processlifecycle/osutil_darwin.go
+++ b/core/adapters/inbound/agents/processlifecycle/osutil_darwin.go
@@ -5,6 +5,7 @@ package processlifecycle
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -378,10 +379,19 @@ func readProcInfo(pid int) (ppid int, cmd string, err error) {
 }
 
 // herdrClientPIDs returns the PIDs of every herdr client currently attached to
-// the session addressed by socketPath, newest attach first. A detached session
-// yields nil — verified live against herdr 0.8.0, where a session with no
-// client has no writer on its client log, and one with two clients attached
-// (herdr supports attaching from more than one place) has two.
+// the session addressed by socketPath, newest attach first, and whether the
+// probe actually ran. A detached session yields (nil, true) — verified live
+// against herdr 0.8.0, where a session with no client has no writer on its
+// client log, and one with two clients attached (herdr supports attaching from
+// more than one place) has two.
+//
+// The second return value is the whole of #1485. "Nobody is attached" and "I
+// could not look" are different facts, and a caller that merges this answer
+// into a host it already has must be able to tell them apart: the first is
+// evidence, the second is not. Collapsing them was harmless while the host was
+// resolved once and never revisited, and became a defect when #1405 made the
+// liveness sweep re-resolve it — a probe that fails to run then overwrites a
+// good host with nothing.
 //
 // Only writers count. "Holds the log open" is not the predicate: a `tail -f`
 // reader is not a client, and adopting its terminal as the host of every
@@ -394,22 +404,52 @@ func readProcInfo(pid int) (ppid int, cmd string, err error) {
 // are allocated ascending, so descending PID is "newest first". lsof matches
 // by device and inode rather than by string, so a symlinked path (a macOS
 // t.TempDir() lives under /var -> /private/var) needs no canonicalisation here.
-func herdrClientPIDs(socketPath string) []int {
+func herdrClientPIDs(socketPath string) (pids []int, probed bool) {
 	logPath := herdrClientLogPath(socketPath)
 	if logPath == "" {
-		return nil
+		return nil, false
+	}
+	// Stat before probing, because lsof answers exit 1 for BOTH "the file
+	// exists and nobody holds it open" and "there is no such file" (measured,
+	// lsof 4.91: the second also writes a "status error on <path>" line to
+	// stderr, which .Output() discards). Only the first is a detach. Without
+	// this, a client log that is not where we looked — herdr moving it between
+	// releases, or a captured socket path that addresses a different session —
+	// reads as a permanent, self-consistent "nobody is attached" rather than
+	// as a probe that never reached the question.
+	if _, err := os.Stat(logPath); err != nil {
+		return nil, false
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
-	// A non-zero exit means no process holds the file open — the detached
-	// case, not an error.
 	out, err := exec.CommandContext(ctx, lsofPath, logPath).Output()
-	if err != nil {
-		return nil
+	if !lsofProbeRan(err) {
+		return nil, false
 	}
-	pids := herdrClientWriters(string(out), os.Getpid())
+	pids = herdrClientWriters(string(out), os.Getpid())
 	sort.Sort(sort.Reverse(sort.IntSlice(pids)))
-	return pids
+	return pids, true
+}
+
+// lsofProbeRan reports whether an lsof invocation that returned err
+// nevertheless ran and answered. Exit 1 is lsof's "nothing to report", which —
+// on a path herdrClientPIDs has already confirmed exists — is the detached
+// case and not an error. Every other failure is a probe that did not run: the
+// 2s deadline above, a fork failure, a signal (a process killed under an
+// exhausted CPU limit exits 152, measured on this machine), a missing binary.
+// None of them carry information about who is attached, and returning them as
+// "detached" is #1485.
+//
+// Split out so the classification is testable without arranging a real lsof
+// failure — its table of committed cases is the evidence that a revert to
+// `if err != nil` would be caught. runPgrep (process_darwin.go) draws the same
+// distinction for pgrep's exit 1.
+func lsofProbeRan(err error) bool {
+	if err == nil {
+		return true
+	}
+	var exit *exec.ExitError
+	return errors.As(err, &exit) && exit.ExitCode() == 1
 }
 
 // herdrClientWriters selects the client PIDs from an lsof table. 'u' counts
@@ -435,9 +475,10 @@ const maxHerdrClientCandidates = 4
 // herdrClientLauncher resolves the host-window identity of the herdr session
 // addressed by socketPath, by reading it from the attached client exactly the
 // way it would be read from any directly-hosted agent (hostIdentity). Returns
-// nil when nothing is attached, or when no attached client resolves to a local
-// GUI host — an SSH client has a real tty but no local window, and reporting
-// one anyway is the misroute #1348 removed.
+// (nil, true) when nothing is attached, or when no attached client resolves to
+// a local GUI host — an SSH client has a real tty but no local window, and
+// reporting one anyway is the misroute #1348 removed. Both of those are real
+// answers; (nil, false) is the third state, "the probe did not run" (#1485).
 //
 // Only ever called with a socket path the daemon captured from the pane's own
 // $HERDR_SOCKET_PATH, so a resolved identity always accompanies a complete
@@ -449,20 +490,31 @@ const maxHerdrClientCandidates = 4
 // socket, and the startup seed resolves them back to back, synchronously: an
 // lsof scan costs ~0.3s on a quiet machine, so eight panes would otherwise pay
 // eight identical scans before the daemon starts serving.
-func herdrClientLauncher(socketPath string) *session.Launcher {
+func herdrClientLauncher(socketPath string) (*session.Launcher, bool) {
 	if socketPath == "" {
-		return nil
+		return nil, false
 	}
 	if cached, ok := herdrClientCacheGet(socketPath); ok {
-		return cached
+		return cached, true
 	}
-	resolved := resolveHerdrClientLauncher(socketPath)
+	resolved, probed := resolveHerdrClientLauncher(socketPath)
+	if !probed {
+		// Never memoize a non-answer. The cache exists to collapse one startup
+		// seed's worth of identical scans; caching "unknown" would instead
+		// spread a single failed probe across every session that shares this
+		// socket for the next 5 seconds, which is the opposite of what the
+		// tri-state buys.
+		return nil, false
+	}
 	herdrClientCachePut(socketPath, resolved)
-	return resolved
+	return resolved, true
 }
 
-func resolveHerdrClientLauncher(socketPath string) *session.Launcher {
-	pids := herdrClientPIDs(socketPath)
+func resolveHerdrClientLauncher(socketPath string) (*session.Launcher, bool) {
+	pids, probed := herdrClientPIDs(socketPath)
+	if !probed {
+		return nil, false
+	}
 	if len(pids) > maxHerdrClientCandidates {
 		pids = pids[:maxHerdrClientCandidates]
 	}
@@ -476,9 +528,9 @@ func resolveHerdrClientLauncher(socketPath string) *session.Launcher {
 		if host.TermProgram == "" && host.HostBundleID == "" {
 			continue
 		}
-		return host
+		return host, true
 	}
-	return nil
+	return nil, true
 }
 
 // herdrClientCacheTTL is short enough that attaching a client is picked up by

--- a/core/adapters/inbound/agents/processlifecycle/osutil_darwin_test.go
+++ b/core/adapters/inbound/agents/processlifecycle/osutil_darwin_test.go
@@ -517,10 +517,17 @@ func TestLsofFDMode(t *testing.T) {
 
 // TestLsofProbeRan is the committed corpus for the discrimination #1485 adds:
 // which lsof failures mean "ran and found nothing" and which mean "did not
-// run". Every row but the first two is a case the pre-#1485 `if err != nil {
-// return nil }` reported as a detached session, so a revert to that spelling
-// turns them red — which is why they are a table of real, executed failures
-// rather than a sentence in a PR body.
+// run".
+//
+// The two directions are caught by different rows, and it is worth being exact
+// about which, because the obvious summary is wrong. A revert to the pre-#1485
+// `if err != nil { return nil }` turns exactly ONE row red — "exit 1", which
+// that spelling misreports as a failure. Rows 3-6 stay green under it, because
+// it and this classifier agree that those are not answers; they pin the
+// opposite mutation, a classifier that calls every failure a completed probe,
+// and each is a case the pre-#1485 code reported as a detached session.
+// Together they bracket the behaviour, which is why they are a table of real,
+// executed failures rather than a sentence in a PR body.
 //
 // The cases are constructed from a real child process rather than from
 // hand-built *exec.ExitError values, because the classification's whole job is
@@ -591,8 +598,10 @@ func TestHerdrClientPIDs_ProbeTriState(t *testing.T) {
 	t.Run("client log is not where we looked", func(t *testing.T) {
 		// lsof exits 1 for this exactly as it does for a detached session, so
 		// the stat guard is the only thing separating them. Left conflated,
-		// herdr moving its client log — or a socket path addressing another
-		// session — is a permanent, self-consistent "nobody is attached".
+		// herdr moving or renaming its client log is a permanent,
+		// self-consistent "nobody is attached". A socket path addressing
+		// another *real* session is NOT covered — that log exists, so the
+		// stat passes; see herdrClientPIDs.
 		if _, probed := herdrClientPIDs(newHerdrSessionDir(t)); probed {
 			t.Error("a client log that does not exist is not evidence of a detach")
 		}
@@ -612,6 +621,8 @@ func TestHerdrClientPIDs_ProbeTriState(t *testing.T) {
 // seconds — turning the one thing the tri-state buys back into a wider window.
 func TestHerdrClientLauncher_DoesNotCacheANonAnswer(t *testing.T) {
 	socketPath := newHerdrSessionDir(t) // no client log: the probe cannot run
+	// Defensive, and it is the regression this test exists to catch that would
+	// make it necessary: nothing should ever be inserted under this key.
 	t.Cleanup(func() {
 		herdrClientCacheMu.Lock()
 		delete(herdrClientCache, socketPath)

--- a/core/adapters/inbound/agents/processlifecycle/osutil_darwin_test.go
+++ b/core/adapters/inbound/agents/processlifecycle/osutil_darwin_test.go
@@ -3,9 +3,11 @@
 package processlifecycle
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"syscall"
@@ -374,7 +376,8 @@ func spawnHerdrClient(t *testing.T, socketPath string, env ...string) int {
 	}, env...))
 	deadline := time.Now().Add(5 * time.Second)
 	for time.Now().Before(deadline) {
-		for _, got := range herdrClientPIDs(socketPath) {
+		pids, _ := herdrClientPIDs(socketPath)
+		for _, got := range pids {
 			if got == pid {
 				return pid
 			}
@@ -408,7 +411,7 @@ func TestReadLauncherEnv_Herdr_ResolvesHostFromAttachedClient(t *testing.T) {
 		"TMUX_PANE=%0",
 	})
 
-	l := ReadLauncherEnv(agentPID)
+	l, _ := ReadLauncherEnv(agentPID)
 	if l == nil {
 		t.Fatal("expected non-nil launcher")
 	}
@@ -442,7 +445,7 @@ func TestHerdrClientPIDs_MultipleClientsAreOrderedNewestFirst(t *testing.T) {
 	first := spawnHerdrClient(t, socketPath)
 	second := spawnHerdrClient(t, socketPath)
 
-	pids := herdrClientPIDs(socketPath)
+	pids, _ := herdrClientPIDs(socketPath)
 	if len(pids) < 2 {
 		t.Fatalf("want both attached clients, got %v (first=%d second=%d)", pids, first, second)
 	}
@@ -507,5 +510,151 @@ func TestLsofFDMode(t *testing.T) {
 		if got := (lsofFD{FD: fd}).Mode(); got != want {
 			t.Errorf("lsofFD{FD: %q}.Mode() = %q, want %q", fd, got, want)
 		}
+	}
+}
+
+// --- probe tri-state (#1485) -------------------------------------------------
+
+// TestLsofProbeRan is the committed corpus for the discrimination #1485 adds:
+// which lsof failures mean "ran and found nothing" and which mean "did not
+// run". Every row but the first two is a case the pre-#1485 `if err != nil {
+// return nil }` reported as a detached session, so a revert to that spelling
+// turns them red — which is why they are a table of real, executed failures
+// rather than a sentence in a PR body.
+//
+// The cases are constructed from a real child process rather than from
+// hand-built *exec.ExitError values, because the classification's whole job is
+// to be right about what os/exec actually hands back: a context deadline in
+// particular is not obviously an ExitError at all (it depends on whether the
+// kill or the deadline is observed first), and asserting the *verdict* rather
+// than the error type is what keeps this honest across Go versions.
+func TestLsofProbeRan(t *testing.T) {
+	run := func(ctx context.Context, name string, args ...string) error {
+		_, err := exec.CommandContext(ctx, name, args...).Output()
+		return err
+	}
+	deadline, cancelDeadline := context.WithTimeout(context.Background(), time.Millisecond)
+	defer cancelDeadline()
+
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"success", nil, true},
+		{"exit 1 — lsof's nothing-to-report", run(context.Background(), "/bin/sh", "-c", "exit 1"), true},
+		{"exit 152 — killed under an exhausted CPU limit", run(context.Background(), "/bin/sh", "-c", "exit 152"), false},
+		{"killed by a signal", run(context.Background(), "/bin/sh", "-c", "kill -9 $$"), false},
+		{"context deadline", run(deadline, "/bin/sleep", "5"), false},
+		{"binary missing", run(context.Background(), "/nonexistent/lsof-1485"), false},
+	}
+	for _, tc := range cases {
+		if got := lsofProbeRan(tc.err); got != tc.want {
+			t.Errorf("%s: lsofProbeRan(%v) = %v, want %v", tc.name, tc.err, got, tc.want)
+		}
+	}
+}
+
+// TestHerdrClientPIDs_ProbeTriState pins the three outcomes end to end,
+// through the real lsof. The detached row is the vacuity guard: a probe that
+// reported "did not run" for everything would satisfy the other two rows and
+// protect a stale host forever, so "the file exists and nobody holds it open"
+// must still come back as an authoritative empty answer.
+func TestHerdrClientPIDs_ProbeTriState(t *testing.T) {
+	t.Run("attached", func(t *testing.T) {
+		socketPath := newHerdrSessionDir(t)
+		client := spawnHerdrClient(t, socketPath)
+		pids, probed := herdrClientPIDs(socketPath)
+		if !probed {
+			t.Fatal("a successful lsof must report a probe that ran")
+		}
+		if len(pids) == 0 || pids[0] != client {
+			t.Errorf("attached client %d not reported: %v", client, pids)
+		}
+	})
+
+	t.Run("detached", func(t *testing.T) {
+		socketPath := newHerdrSessionDir(t)
+		// The session ran once, so the log is there; nobody holds it open.
+		if err := os.WriteFile(herdrClientLogPath(socketPath), []byte("detached\n"), 0o600); err != nil {
+			t.Fatalf("seed client log: %v", err)
+		}
+		pids, probed := herdrClientPIDs(socketPath)
+		if !probed {
+			t.Fatal("a detach is an answer, not a failure — reporting it as unknown would freeze the last host forever")
+		}
+		if len(pids) != 0 {
+			t.Errorf("nobody holds the log open: %v", pids)
+		}
+	})
+
+	t.Run("client log is not where we looked", func(t *testing.T) {
+		// lsof exits 1 for this exactly as it does for a detached session, so
+		// the stat guard is the only thing separating them. Left conflated,
+		// herdr moving its client log — or a socket path addressing another
+		// session — is a permanent, self-consistent "nobody is attached".
+		if _, probed := herdrClientPIDs(newHerdrSessionDir(t)); probed {
+			t.Error("a client log that does not exist is not evidence of a detach")
+		}
+	})
+
+	t.Run("no socket path", func(t *testing.T) {
+		if _, probed := herdrClientPIDs(""); probed {
+			t.Error("no address means nothing was probed")
+		}
+	})
+}
+
+// TestHerdrClientLauncher_DoesNotCacheANonAnswer covers step 2 of #1485's
+// suggested shape. The memo exists to collapse one startup seed's worth of
+// identical scans; caching a probe that did not run would instead spread a
+// single failure across every session sharing that socket for the next 5
+// seconds — turning the one thing the tri-state buys back into a wider window.
+func TestHerdrClientLauncher_DoesNotCacheANonAnswer(t *testing.T) {
+	socketPath := newHerdrSessionDir(t) // no client log: the probe cannot run
+	t.Cleanup(func() {
+		herdrClientCacheMu.Lock()
+		delete(herdrClientCache, socketPath)
+		herdrClientCacheMu.Unlock()
+	})
+
+	if _, probed := herdrClientLauncher(socketPath); probed {
+		t.Fatal("want a non-answer for a socket whose client log is absent")
+	}
+	herdrClientCacheMu.Lock()
+	_, cached := herdrClientCache[socketPath]
+	herdrClientCacheMu.Unlock()
+	if cached {
+		t.Error("a non-answer was memoized: the next 5s of reads inherit one failed probe")
+	}
+}
+
+// TestReadLauncherEnv_Herdr_UnprobableClientReportsHostUnknown is #1485 at the
+// port boundary: the reader has to carry the distinction all the way out, or
+// the sweep that consumes it (refreshHerdrHosts) cannot act on it. The pane's
+// own identity is unaffected either way — only the second return value moves.
+func TestReadLauncherEnv_Herdr_UnprobableClientReportsHostUnknown(t *testing.T) {
+	socketPath := newHerdrSessionDir(t) // no client log
+	agentPID := spawnSleeperWithEnv(t, []string{
+		"PATH=/usr/bin:/bin",
+		"HERDR_PANE_ID=w1:p1",
+		"HERDR_SOCKET_PATH=" + socketPath,
+	})
+
+	l, hostKnown := ReadLauncherEnv(agentPID)
+	if hostKnown {
+		t.Error("the client probe could not run, so the host is unknown — not absent")
+	}
+	if l == nil || l.HerdrPaneID != "w1:p1" {
+		t.Fatalf("the pane's own address must survive an unresolved host: %+v", l)
+	}
+
+	// The same pane once the log exists and nobody holds it open: now the
+	// emptiness is an answer, and the sweep is allowed to act on it.
+	if err := os.WriteFile(herdrClientLogPath(socketPath), []byte("detached\n"), 0o600); err != nil {
+		t.Fatalf("seed client log: %v", err)
+	}
+	if _, hostKnown := ReadLauncherEnv(agentPID); !hostKnown {
+		t.Error("a detached session's host is known to be absent")
 	}
 }

--- a/core/adapters/inbound/agents/processlifecycle/osutil_linux.go
+++ b/core/adapters/inbound/agents/processlifecycle/osutil_linux.go
@@ -60,4 +60,8 @@ func IsKnownInteractiveHost(pid int) bool { return true }
 // client (#1350). Darwin-only: the identity it produces is only consumed by the
 // macOS click-to-focus path, and resolving it needs the same ancestry walk the
 // stubs above already decline to do.
-func herdrClientLauncher(socketPath string) *session.Launcher { return nil }
+//
+// So the answer here is "not probed" (#1485), not "nothing attached": this
+// platform never looks, and a caller merging the read into a stored launcher
+// must not read that silence as a client having detached.
+func herdrClientLauncher(socketPath string) (*session.Launcher, bool) { return nil, false }

--- a/core/adapters/inbound/agents/processlifecycle/osutil_other.go
+++ b/core/adapters/inbound/agents/processlifecycle/osutil_other.go
@@ -34,4 +34,8 @@ func IsKnownInteractiveHost(pid int) bool { return true }
 // client (#1350). Darwin-only: the identity it produces is only consumed by the
 // macOS click-to-focus path, and resolving it needs the same ancestry walk the
 // stubs above already decline to do.
-func herdrClientLauncher(socketPath string) *session.Launcher { return nil }
+//
+// So the answer here is "not probed" (#1485), not "nothing attached": this
+// platform never looks, and a caller merging the read into a stored launcher
+// must not read that silence as a client having detached.
+func herdrClientLauncher(socketPath string) (*session.Launcher, bool) { return nil, false }

--- a/core/adapters/inbound/agents/processlifecycle/osutil_test.go
+++ b/core/adapters/inbound/agents/processlifecycle/osutil_test.go
@@ -181,10 +181,10 @@ func TestParseProcargs2Argv(t *testing.T) {
 }
 
 func TestReadLauncherEnv_InvalidPID(t *testing.T) {
-	if l := ReadLauncherEnv(0); l != nil {
+	if l, _ := ReadLauncherEnv(0); l != nil {
 		t.Errorf("pid 0: want nil, got %+v", l)
 	}
-	if l := ReadLauncherEnv(-1); l != nil {
+	if l, _ := ReadLauncherEnv(-1); l != nil {
 		t.Errorf("pid -1: want nil, got %+v", l)
 	}
 }
@@ -221,7 +221,7 @@ func TestReadLauncherEnv_Subprocess(t *testing.T) {
 		"TERM_PROGRAM=iTerm.app",
 		"ITERM_SESSION_ID=w0t0p0-test",
 	})
-	l := ReadLauncherEnv(pid)
+	l, _ := ReadLauncherEnv(pid)
 	if l == nil {
 		t.Fatal("expected non-nil launcher")
 	}
@@ -241,7 +241,7 @@ func TestReadLauncherEnv_Subprocess_VSCodePIDImpliesTermProgram(t *testing.T) {
 		"PATH=/usr/bin:/bin",
 		"VSCODE_PID=4242",
 	})
-	l := ReadLauncherEnv(pid)
+	l, _ := ReadLauncherEnv(pid)
 	if l == nil {
 		t.Fatal("expected non-nil launcher when VSCODE_PID present")
 	}
@@ -262,7 +262,7 @@ func TestReadLauncherEnv_Subprocess_NoRelevantEnv(t *testing.T) {
 	// nil — if the test process's host terminal/IDE is on the recognized
 	// list, we'll populate TermProgram from ppid walk. The invariant that
 	// still holds: env-derived fields must be empty (we only set PATH).
-	l := ReadLauncherEnv(pid)
+	l, _ := ReadLauncherEnv(pid)
 	if l == nil {
 		return // legitimate on unknown hosts
 	}
@@ -281,7 +281,7 @@ func TestReadLauncherEnv_Subprocess_Tmux(t *testing.T) {
 		"TMUX=/private/tmp/tmux-501/default,1234,0",
 		"TMUX_PANE=%17",
 	})
-	l := ReadLauncherEnv(pid)
+	l, _ := ReadLauncherEnv(pid)
 	if l == nil {
 		t.Fatal("expected non-nil launcher")
 	}
@@ -375,7 +375,7 @@ func TestReadLauncherEnv_Subprocess_Herdr(t *testing.T) {
 		"HERDR_PANE_ID=w1:p1",
 		"HERDR_SOCKET_PATH=/tmp/herdr-probe.sock",
 	})
-	l := ReadLauncherEnv(pid)
+	l, _ := ReadLauncherEnv(pid)
 	if l == nil {
 		t.Fatal("expected non-nil launcher")
 	}
@@ -426,7 +426,7 @@ func TestReadLauncherEnv_Subprocess_KittyOverridesInheritedTermProgram(t *testin
 		"KITTY_WINDOW_ID=42",
 		"KITTY_PID=4242",
 	})
-	l := ReadLauncherEnv(pid)
+	l, _ := ReadLauncherEnv(pid)
 	if l == nil {
 		t.Fatal("expected non-nil launcher when KITTY_WINDOW_ID present")
 	}
@@ -457,7 +457,7 @@ func TestReadLauncherEnv_Subprocess_JetBrainsImpliesTermProgram(t *testing.T) {
 		"PATH=/usr/bin:/bin",
 		"TERMINAL_EMULATOR=JetBrains-JediTerm",
 	})
-	l := ReadLauncherEnv(pid)
+	l, _ := ReadLauncherEnv(pid)
 	if l == nil {
 		t.Fatal("expected non-nil launcher when TERMINAL_EMULATOR=JetBrains-JediTerm")
 	}
@@ -500,7 +500,7 @@ func TestReadLauncherEnv_Herdr_DetachedSessionResolvesNoHost(t *testing.T) {
 		"TERM_PROGRAM=kitty",
 		"KITTY_WINDOW_ID=42",
 	})
-	l := ReadLauncherEnv(agentPID)
+	l, _ := ReadLauncherEnv(agentPID)
 	if l == nil {
 		t.Fatal("expected non-nil launcher (the herdr address is still identity)")
 	}

--- a/core/application/services/launcher_backfill_internal_test.go
+++ b/core/application/services/launcher_backfill_internal_test.go
@@ -90,7 +90,7 @@ func TestApplyLauncherBackfill_HerdrHost(t *testing.T) {
 
 	// Still detached: the re-read carries the herdr address and nothing else.
 	stillDetached := &session.Launcher{HerdrPaneID: "w1:p1", HerdrSocketPath: "/cfg/herdr/herdr.sock"}
-	if applyLauncherBackfill(stored, needs, stillDetached) {
+	if applyLauncherBackfill(stored, needs, stillDetached, true) {
 		t.Error("a still-detached session must report no update")
 	}
 	if stored.TermProgram != "" {
@@ -105,7 +105,7 @@ func TestApplyLauncherBackfill_HerdrHost(t *testing.T) {
 		ITermSessionID:  "w0t0p0-CLIENT",
 		TTY:             "/dev/ttys012",
 	}
-	if !applyLauncherBackfill(stored, needs, fresh) {
+	if !applyLauncherBackfill(stored, needs, fresh, true) {
 		t.Fatal("a newly attached client must report an update")
 	}
 	if stored.TermProgram != "iTerm.app" || stored.ITermSessionID != "w0t0p0-CLIENT" {

--- a/core/application/services/pid_manager.go
+++ b/core/application/services/pid_manager.go
@@ -33,7 +33,18 @@ type LiveCWDsFunc func(processName string) (map[string]struct{}, error)
 // Implementations must never block longer than a couple of seconds and must
 // never prompt the user (no TCC). The real implementation lives in the
 // processlifecycle adapter and is injected to preserve the hexagonal layering.
-type LauncherEnvReader func(pid int) *session.Launcher
+//
+// hostKnown distinguishes "this read established that there is no host window"
+// from "this read could not determine one" (#1485). Only the first is evidence.
+// The distinction exists because a herdr pane's host lives in a separate
+// process found by an external probe, and that probe has three outcomes rather
+// than two: attached, detached, or it never ran. Every caller that MERGES a
+// read into a launcher it already holds must decline to clear host fields on
+// hostKnown == false — their emptiness carries no information. Callers that
+// only CAPTURE a first launcher may ignore it (captureLauncher does, and says
+// why). An implementation that cannot look at all — a platform with no probe,
+// a revoked consent — returns false rather than true.
+type LauncherEnvReader func(pid int) (l *session.Launcher, hostKnown bool)
 
 // BackgroundReader reports adapter-specific background-agent metadata for a PID
 // (e.g. Claude Code's kind:"bg" registry entry for an Agent-View background
@@ -281,7 +292,12 @@ func (pm *PIDManager) captureLauncher(state *session.SessionState, pid int) {
 	if pm.launcherEnv == nil || state == nil || state.Launcher != nil || pid <= 0 {
 		return
 	}
-	if l := pm.launcherEnv(pid); l != nil {
+	// hostKnown is deliberately ignored: a first capture has no stored host to
+	// protect, and refusing the read over an unresolved one would leave the
+	// session with no Launcher at all — losing the herdr address, and with it
+	// backchannel routing, to buy nothing. The refresh paths, which do have
+	// something to lose, are where it is honoured (#1485).
+	if l, _ := pm.launcherEnv(pid); l != nil {
 		state.Launcher = l
 	}
 }
@@ -1257,11 +1273,11 @@ func (pm *PIDManager) backfillLauncher(state *session.SessionState) {
 	if !needs.any() {
 		return
 	}
-	fresh := pm.launcherEnv(state.PID)
+	fresh, hostKnown := pm.launcherEnv(state.PID)
 	if fresh == nil {
 		return
 	}
-	if applyLauncherBackfill(state.Launcher, needs, fresh) {
+	if applyLauncherBackfill(state.Launcher, needs, fresh, hostKnown) {
 		pm.touchAndSave(state)
 	}
 }
@@ -1328,11 +1344,11 @@ func (pm *PIDManager) refreshHerdrHosts(snaps []livenessSnapshot) {
 		if !snap.herdrPane || snap.pid <= 0 {
 			continue
 		}
-		fresh := read(snap.pid)
+		fresh, hostKnown := read(snap.pid)
 		if fresh == nil {
 			continue
 		}
-		state := pm.applyHerdrHostRefresh(snap.state.SessionID, fresh)
+		state := pm.applyHerdrHostRefresh(snap.state.SessionID, fresh, hostKnown)
 		if state == nil {
 			continue
 		}
@@ -1348,14 +1364,18 @@ func (pm *PIDManager) refreshHerdrHosts(snaps []livenessSnapshot) {
 // of the refresh is to observe a change between sweeps, so nothing here may
 // outlive the sweep that created it.
 func memoizedLauncherEnv(read LauncherEnvReader) LauncherEnvReader {
-	seen := map[int]*session.Launcher{}
-	return func(pid int) *session.Launcher {
-		if l, ok := seen[pid]; ok {
-			return l
+	type result struct {
+		launcher  *session.Launcher
+		hostKnown bool
+	}
+	seen := map[int]result{}
+	return func(pid int) (*session.Launcher, bool) {
+		if r, ok := seen[pid]; ok {
+			return r.launcher, r.hostKnown
 		}
-		l := read(pid)
-		seen[pid] = l
-		return l
+		l, hostKnown := read(pid)
+		seen[pid] = result{launcher: l, hostKnown: hostKnown}
+		return l, hostKnown
 	}
 }
 
@@ -1369,7 +1389,7 @@ func memoizedLauncherEnv(read LauncherEnvReader) LauncherEnvReader {
 // the one assignPIDLocked takes around its own load-modify-save of the same
 // session, which is what keeps a concurrent PID discovery from being clobbered
 // by this one.
-func (pm *PIDManager) applyHerdrHostRefresh(sessionID string, fresh *session.Launcher) *session.SessionState {
+func (pm *PIDManager) applyHerdrHostRefresh(sessionID string, fresh *session.Launcher, hostKnown bool) *session.SessionState {
 	var updated *session.SessionState
 	pm.WithSessionStateLock(func() {
 		// Gone: reaped between the snapshot and here — possibly earlier in this
@@ -1401,7 +1421,7 @@ func (pm *PIDManager) applyHerdrHostRefresh(sessionID string, fresh *session.Lau
 		if fresh.HerdrPaneID != state.Launcher.HerdrPaneID {
 			return
 		}
-		if applyLauncherBackfill(state.Launcher, needs, fresh) {
+		if applyLauncherBackfill(state.Launcher, needs, fresh, hostKnown) {
 			pm.touchAndSave(state)
 			updated = state
 		}
@@ -1466,7 +1486,12 @@ func launcherBackfillNeedsFor(l *session.Launcher) launcherBackfillNeeds {
 
 // applyLauncherBackfill copies each field fresh has that l is missing per
 // needs. Returns true when any field was updated.
-func applyLauncherBackfill(l *session.Launcher, needs launcherBackfillNeeds, fresh *session.Launcher) bool {
+//
+// hostKnown gates only the herdr host adoption, not the whole merge: the tty
+// and kitty fields are read from the process itself and are unaffected by a
+// client probe that did not run, so a pane still acquires a missing tty on a
+// sweep where the host is unknown.
+func applyLauncherBackfill(l *session.Launcher, needs launcherBackfillNeeds, fresh *session.Launcher, hostKnown bool) bool {
 	updated := false
 	if needs.tty && fresh.TTY != "" {
 		l.TTY = fresh.TTY
@@ -1478,7 +1503,13 @@ func applyLauncherBackfill(l *session.Launcher, needs launcherBackfillNeeds, fre
 	// fresh was produced by the same reader, so its host fields are already
 	// the attached client's. A still-detached session yields none and this
 	// reports no change rather than writing empties over empties.
-	if needs.herdrHost && l.AdoptHostIdentity(fresh) {
+	//
+	// Unless the reader could not determine the host at all, in which case
+	// those empties are not "detached" — they are "unknown", and adopting them
+	// clears a resolved host on a probe that never ran (#1485). The stored
+	// host stays until a probe actually answers; a genuine detach still clears
+	// it on the first sweep whose probe runs.
+	if needs.herdrHost && hostKnown && l.AdoptHostIdentity(fresh) {
 		updated = true
 	}
 	return updated

--- a/core/application/services/pid_manager.go
+++ b/core/application/services/pid_manager.go
@@ -1500,19 +1500,35 @@ func applyLauncherBackfill(l *session.Launcher, needs launcherBackfillNeeds, fre
 	if applyKittyLauncherBackfill(l, needs, fresh) {
 		updated = true
 	}
-	// fresh was produced by the same reader, so its host fields are already
-	// the attached client's. A still-detached session yields none and this
-	// reports no change rather than writing empties over empties.
-	//
-	// Unless the reader could not determine the host at all, in which case
-	// those empties are not "detached" — they are "unknown", and adopting them
-	// clears a resolved host on a probe that never ran (#1485). The stored
-	// host stays until a probe actually answers; a genuine detach still clears
-	// it on the first sweep whose probe runs.
-	if needs.herdrHost && hostKnown && l.AdoptHostIdentity(fresh) {
+	if applyHerdrHostBackfill(l, needs, fresh, hostKnown) {
 		updated = true
 	}
 	return updated
+}
+
+// applyHerdrHostBackfill adopts the host identity a fresh read resolved from
+// the attached herdr client. Split out for the same reason
+// applyKittyLauncherBackfill is — applyLauncherBackfill stays one branch per
+// *kind* of backfill — and because the two conditions it ANDs are unrelated
+// facts about different things, which is worth a line each rather than a
+// three-term conditional.
+//
+// needs.herdrHost comes from the STORED launcher: is this a herdr pane at all.
+// hostKnown comes from the FRESH read: did it determine a host. fresh was
+// produced by the same reader, so its host fields are already the attached
+// client's, and a still-detached session yields none — AdoptHostIdentity then
+// reports no change rather than writing empties over empties.
+//
+// Unless the reader could not determine the host at all, in which case those
+// empties are not "detached" — they are "unknown", and adopting them clears a
+// resolved host on a probe that never ran (#1485). The stored host stays until
+// a probe actually answers; a genuine detach still clears it on the first
+// sweep whose probe runs.
+func applyHerdrHostBackfill(l *session.Launcher, needs launcherBackfillNeeds, fresh *session.Launcher, hostKnown bool) bool {
+	if !needs.herdrHost || !hostKnown {
+		return false
+	}
+	return l.AdoptHostIdentity(fresh)
 }
 
 // applyKittyLauncherBackfill copies the three kitty fields fresh has that l is

--- a/core/application/services/pid_manager_background_test.go
+++ b/core/application/services/pid_manager_background_test.go
@@ -46,8 +46,8 @@ func TestHandlePIDAssigned_BackgroundCapture(t *testing.T) {
 		repo := newMockRepo()
 		repo.states["s"] = newReady()
 		pm := newPIDManagerForTest(repo)
-		pm.SetLauncherEnvReader(func(pid int) *session.Launcher {
-			return &session.Launcher{TTY: "/dev/ttys003"}
+		pm.SetLauncherEnvReader(func(pid int) (*session.Launcher, bool) {
+			return &session.Launcher{TTY: "/dev/ttys003"}, true
 		})
 		pm.SetBackgroundReader(func(pid int) *session.BackgroundAgent {
 			return &session.BackgroundAgent{Name: "bg job"}

--- a/core/application/services/pid_manager_herdr_refresh_test.go
+++ b/core/application/services/pid_manager_herdr_refresh_test.go
@@ -46,13 +46,13 @@ func TestCheckPIDLiveness_HerdrHostRefreshedOnReattach(t *testing.T) {
 
 	pm := newPIDManagerForTest(repo)
 	// A fresh read now resolves the client the user re-attached in.
-	pm.SetLauncherEnvReader(func(int) *session.Launcher {
+	pm.SetLauncherEnvReader(func(int) (*session.Launcher, bool) {
 		return &session.Launcher{
 			HerdrPaneID:     "w1:p1",
 			HerdrSocketPath: "/cfg/herdr/herdr.sock",
 			TermProgram:     "ghostty",
 			TTY:             "/dev/ttys077",
-		}
+		}, true
 	})
 
 	pm.CheckPIDLiveness()
@@ -94,12 +94,12 @@ func TestCheckPIDLiveness_HerdrHostClearedOnDetach(t *testing.T) {
 	// Nothing attached: the reader resolves no client, so it returns the pane's
 	// own address and its own pty and nothing else (ReadLauncherEnv's herdr
 	// early-return in launcherFromEnv).
-	pm.SetLauncherEnvReader(func(int) *session.Launcher {
+	pm.SetLauncherEnvReader(func(int) (*session.Launcher, bool) {
 		return &session.Launcher{
 			HerdrPaneID:     "w1:p1",
 			HerdrSocketPath: "/cfg/herdr/herdr.sock",
 			TTY:             "/dev/ttys900",
-		}
+		}, true
 	})
 
 	pm.CheckPIDLiveness()
@@ -128,9 +128,9 @@ func TestCheckPIDLiveness_NonHerdrLauncherNotRefreshed(t *testing.T) {
 
 	calls := 0
 	pm := newPIDManagerForTest(repo)
-	pm.SetLauncherEnvReader(func(int) *session.Launcher {
+	pm.SetLauncherEnvReader(func(int) (*session.Launcher, bool) {
 		calls++
-		return &session.Launcher{TermProgram: "ghostty"}
+		return &session.Launcher{TermProgram: "ghostty"}, true
 	})
 
 	pm.CheckPIDLiveness()
@@ -165,10 +165,10 @@ func TestCheckPIDLiveness_HerdrSteadyStateDoesNotChurn(t *testing.T) {
 
 	calls := 0
 	pm := newPIDManagerForTest(repo)
-	pm.SetLauncherEnvReader(func(int) *session.Launcher {
+	pm.SetLauncherEnvReader(func(int) (*session.Launcher, bool) {
 		calls++
 		cp := *stored
-		return &cp
+		return &cp, true
 	})
 
 	before := repo.saves
@@ -204,8 +204,8 @@ func TestCheckPIDLiveness_HerdrIgnoresAReadThatIsNoLongerThePane(t *testing.T) {
 	pm := newPIDManagerForTest(repo)
 	// What the reader returns for a PID that is no longer the pane: the
 	// ancestry walk resolved the herdr server's own terminal.
-	pm.SetLauncherEnvReader(func(int) *session.Launcher {
-		return &session.Launcher{TermProgram: "kitty", KittyPID: 42, TTY: "/dev/ttys001"}
+	pm.SetLauncherEnvReader(func(int) (*session.Launcher, bool) {
+		return &session.Launcher{TermProgram: "kitty", KittyPID: 42, TTY: "/dev/ttys001"}, true
 	})
 
 	pm.CheckPIDLiveness()
@@ -241,14 +241,14 @@ func TestCheckPIDLiveness_HerdrAcquiresAMissingTTY(t *testing.T) {
 	})
 
 	pm := newPIDManagerForTest(repo)
-	pm.SetLauncherEnvReader(func(int) *session.Launcher {
+	pm.SetLauncherEnvReader(func(int) (*session.Launcher, bool) {
 		return &session.Launcher{
 			HerdrPaneID:     "w1:p1",
 			HerdrSocketPath: "/cfg/herdr/herdr.sock",
 			TermProgram:     "iTerm.app",
 			ITermSessionID:  "w0t0p0",
 			TTY:             "/dev/ttys077",
-		}
+		}, true
 	})
 
 	pm.CheckPIDLiveness()
@@ -282,15 +282,64 @@ func TestCheckPIDLiveness_HerdrSubagentsShareOneRead(t *testing.T) {
 
 	calls := 0
 	pm := newPIDManagerForTest(repo)
-	pm.SetLauncherEnvReader(func(int) *session.Launcher {
+	pm.SetLauncherEnvReader(func(int) (*session.Launcher, bool) {
 		calls++
 		cp := *pane
-		return &cp
+		return &cp, true
 	})
 
 	pm.CheckPIDLiveness()
 
 	if calls != 1 {
 		t.Errorf("4 sessions on one PID cost %d reads, want 1", calls)
+	}
+}
+
+// TestCheckPIDLiveness_HerdrHostSurvivesAnUnrunnableProbe is #1485. The
+// detach test above pins the honest clear; this one pins the case that must
+// NOT clear, and the two are indistinguishable to the sweep unless the reader
+// says which it is.
+//
+// The reader's herdr host comes from an `lsof` probe of the client log, and
+// that probe has three outcomes, not two: a client is attached, no client is
+// attached, or the probe never ran (its 2s deadline, a fork failure, a signal,
+// a client log that is not where we looked). #1350 collapsed the last two,
+// which was harmless while the host was write-once-if-empty; #1405 made the
+// refresh re-resolve on every sweep, so a non-answer now overwrites a good
+// host with nothing.
+func TestCheckPIDLiveness_HerdrHostSurvivesAnUnrunnableProbe(t *testing.T) {
+	repo := newMockRepo()
+	repo.states["s"] = herdrSession(&session.Launcher{
+		HerdrPaneID:     "w1:p1",
+		HerdrSocketPath: "/cfg/herdr/herdr.sock",
+		TermProgram:     "iTerm.app",
+		ITermSessionID:  "w0t0p0-OLD",
+		TTY:             "/dev/ttys012",
+	})
+
+	pm := newPIDManagerForTest(repo)
+	// The launcher is byte-identical to the detach test's — that is the point.
+	// Only the second return value separates them, and without it the sweep
+	// has nothing to go on.
+	pm.SetLauncherEnvReader(func(int) (*session.Launcher, bool) {
+		return &session.Launcher{
+			HerdrPaneID:     "w1:p1",
+			HerdrSocketPath: "/cfg/herdr/herdr.sock",
+			TTY:             "/dev/ttys900",
+		}, false
+	})
+
+	before := repo.saves
+	pm.CheckPIDLiveness()
+
+	got := repo.states["s"].Launcher
+	if got.TermProgram != "iTerm.app" || got.ITermSessionID != "w0t0p0-OLD" {
+		t.Errorf("a probe that never ran cleared a resolved host: %+v", got)
+	}
+	if got.TTY != "/dev/ttys012" {
+		t.Errorf("the client's tab was cleared by a non-answer: TTY = %q", got.TTY)
+	}
+	if repo.saves != before {
+		t.Errorf("a non-answer churned the repo and pushed: %d saves", repo.saves-before)
 	}
 }

--- a/core/application/services/pid_manager_test.go
+++ b/core/application/services/pid_manager_test.go
@@ -753,9 +753,9 @@ func TestHandlePIDAssigned_LauncherCaptureIsIdempotent(t *testing.T) {
 
 	pm := newPIDManagerForTest(repo)
 	var calls int
-	pm.SetLauncherEnvReader(func(pid int) *session.Launcher {
+	pm.SetLauncherEnvReader(func(pid int) (*session.Launcher, bool) {
 		calls++
-		return &session.Launcher{TermProgram: "iTerm.app"}
+		return &session.Launcher{TermProgram: "iTerm.app"}, true
 	})
 
 	pm.HandlePIDAssigned(42, "s")
@@ -810,14 +810,14 @@ func TestBackfillLauncher_KittyFieldsMergedFromFreshEnv(t *testing.T) {
 	}
 
 	pm := newPIDManagerForTest(repo)
-	pm.SetLauncherEnvReader(func(pid int) *session.Launcher {
+	pm.SetLauncherEnvReader(func(pid int) (*session.Launcher, bool) {
 		return &session.Launcher{
 			TermProgram:   "kitty",
 			TTY:           "/dev/ttys999", // intentionally different — should NOT overwrite
 			KittyPID:      31155,
 			KittyListenOn: "unix:/tmp/kitty-31155",
 			KittyWindowID: "2",
-		}
+		}, true
 	})
 
 	pm.SeedPIDs([]*session.SessionState{repo.states["s"]})
@@ -871,9 +871,9 @@ func TestBackfillLauncher_NoChangeWhenNothingMissing(t *testing.T) {
 
 	pm := newPIDManagerForTest(repo)
 	var calls int
-	pm.SetLauncherEnvReader(func(pid int) *session.Launcher {
+	pm.SetLauncherEnvReader(func(pid int) (*session.Launcher, bool) {
 		calls++
-		return &session.Launcher{TermProgram: "iTerm.app"} // would corrupt if called
+		return &session.Launcher{TermProgram: "iTerm.app"}, true // would corrupt if called
 	})
 
 	pm.SeedPIDs([]*session.SessionState{repo.states["s"]})
@@ -907,12 +907,12 @@ func TestBackfillLauncher_NonKittyUnaffected(t *testing.T) {
 
 	pm := newPIDManagerForTest(repo)
 	var calls int
-	pm.SetLauncherEnvReader(func(pid int) *session.Launcher {
+	pm.SetLauncherEnvReader(func(pid int) (*session.Launcher, bool) {
 		calls++
 		// Even if a fresh read suggested kitty fields, the missing-checks
 		// gate `isKitty := TermProgram == "kitty"` — none of the
 		// missingKitty* flags will be true for an iTerm launcher.
-		return &session.Launcher{TermProgram: "iTerm.app", KittyPID: 9999}
+		return &session.Launcher{TermProgram: "iTerm.app", KittyPID: 9999}, true
 	})
 
 	pm.SeedPIDs([]*session.SessionState{repo.states["s"]})

--- a/core/application/services/session_detector_pid_test.go
+++ b/core/application/services/session_detector_pid_test.go
@@ -87,12 +87,12 @@ func TestSessionDetector_PIDAssigned_CapturesLauncher(t *testing.T) {
 
 	det := newDetector(tw, pw, repo)
 	var calledPID int
-	det.SetLauncherEnvReader(func(pid int) *session.Launcher {
+	det.SetLauncherEnvReader(func(pid int) (*session.Launcher, bool) {
 		calledPID = pid
 		return &session.Launcher{
 			TermProgram:    "iTerm.app",
 			ITermSessionID: "w0t0p0",
-		}
+		}, true
 	})
 
 	det.HandlePIDAssigned(4242, "s")

--- a/core/cmd/irrlichd/startup.go
+++ b/core/cmd/irrlichd/startup.go
@@ -770,9 +770,12 @@ func setupPermissionService(mux *http.ServeMux, deps setupPermissionServiceDeps)
 	// Consent-gated per capture (#570): checked on every call so a revoke
 	// takes effect immediately; without the grant, click-to-focus falls
 	// back to app-level activation.
-	detector.SetLauncherEnvReader(func(pid int) *session.Launcher {
+	detector.SetLauncherEnvReader(func(pid int) (*session.Launcher, bool) {
 		if !permService.Granted(processlifecycle.LauncherName, processlifecycle.PermissionKeyLauncherEnv) {
-			return nil
+			// Not "there is no host" — "we were not allowed to look". A revoke
+			// must not clear the hosts captured while the grant was live
+			// (#1485).
+			return nil, false
 		}
 		return processlifecycle.ReadLauncherEnv(pid)
 	})


### PR DESCRIPTION
Closes #1485.

`herdrClientPIDs` answered `nil` for both "no client is attached" and "the
probe did not run" — two-valued output over three real states. Harmless while
#1350 resolved a herdr pane's host once and never revisited it; a defect since
#1405 made the liveness sweep re-resolve it every pass, because a probe that
fails to run now returns a pane-only launcher, `AdoptHostIdentity` adopts it
wholesale, and a session whose client is attached the whole time loses
`TermProgram` / `HostBundleID` / `ITermSessionID`.

## Was the tri-state threadable? Yes — and the rejected fix stays rejected

#1485 records why #1405 declined to fix this inline: propagating "unknown" up
to `ReadLauncherEnv` has no spelling but `nil`, and `nil` at **capture** time
means `captureLauncher` records no launcher at all, losing the herdr address
and backchannel routing. That reasoning is correct and this PR does not
overturn it — it routes around it.

The bit rides on the port's **second** return value rather than on the pointer,
so the three consumers can read it differently, which turns out to be exactly
what they need:

| consumer | reads `hostKnown` as |
|---|---|
| `captureLauncher` | **ignored.** No stored host to protect; refusing the read would cost the pane its herdr address to buy nothing. This is the regression #1405 identified, avoided rather than traded. |
| `backfillLauncher` / `refreshHerdrHosts` | **skip the host adoption only** — not the whole merge. A pane still acquires a missing tty on a sweep whose probe failed, because the tty comes from the process itself. |
| the consent gate in `startup.go` | **"not probed", not "detached"** — revoking the launcher permission must not clear hosts captured while it was granted. |

Three cheaper options were considered and ruled out explicitly:

- **Caller-side "unknown ⇒ keep what I had" with no port change.** Ruled
  **out**: `fresh` is byte-identical in the detached and unknown cases (the new
  test says so in its comment), so the caller has nothing to branch on.
- **Adapter-side "return the last good answer on a failed probe."** Ruled
  **out**: it covers a transient failure *after* a success, but a cold daemon
  whose every probe fails — the durable case — has no last-good value, and
  clears every restored host on the first sweep.
- **"Clear only after two consecutive empty resolutions"** (#1485's own
  stopgap). Ruled **out**: absorbs transients, but a *permanently* wrong probe
  still clears, and it delays every honest detach by a sweep.

## What the probe now distinguishes

`lsof` exits **1** for both "the file exists and nobody holds it open" and
"there is no such file" (measured, lsof 4.91 — the second also writes a
`status error on <path>` line to stderr, which `.Output()` discards). So a
`os.Stat` precedes the scan: without it, herdr moving its client log between
releases reads as a permanent, self-consistent *"nobody is attached"* rather
than as a probe that never reached the question. Every other exec failure — the
2s deadline, a signal, exit 152, a missing binary — is classified by the new
`lsofProbeRan` instead of being swallowed by `if err != nil`, the same
distinction `runPgrep` already draws for pgrep. A non-answer is never memoized.

### One correction to the issue's live evidence

The issue's comment reports `~/.config/herdr/herdr-client.log` as a "same-named
decoy one directory up". Verified on this machine (herdr 0.8.0): that path sits
beside `herdr.sock`, `herdr-client.sock` and `session.json` at the same level,
which is the **default session's own directory** — the identical layout named
sessions get under `sessions/<name>/`. It is that session's real client log
correctly reporting no client, not a stray file. Confirmed live:

```
~/.config/herdr/herdr-client.log                    -> lsof exit 1 (default session, detached)
~/.config/herdr/sessions/irrlicht/herdr-client.log  -> herdr 26932 3w  (attached)
~/.config/herdr/sessions/factory/herdr-client.log   -> lsof exit 1 (detached, file present)
```

The consequence matters for what the fix buys: because a genuinely detached
session's log **still exists** (the `factory` row), `os.Stat` cannot separate
"detached" from "probed a session that isn't ours". A tri-state does not fix a
*mis-derived path that resolves to a real file* — both are successful probes.
What it does fix is the transient failures, and the durable case where the path
resolves to **nothing**, which is the shape a herdr layout change would take.

## Red-first

`TestCheckPIDLiveness_HerdrHostSurvivesAnUnrunnableProbe`, written in the
pre-fix spelling (the reader literal byte-identical to the existing detach
test's, which is the defect), run before the fix existed:

```
--- FAIL: TestCheckPIDLiveness_HerdrHostSurvivesAnUnrunnableProbe (0.00s)
    pid_manager_herdr_refresh_test.go:337: a probe that never ran cleared a resolved host: &{TermProgram: ITermSessionID: ... TTY:/dev/ttys900 ... HerdrPaneID:w1:p1 HerdrSocketPath:/cfg/herdr/herdr.sock}
    pid_manager_herdr_refresh_test.go:340: the client's tab was cleared by a non-answer: TTY = "/dev/ttys900"
    pid_manager_herdr_refresh_test.go:343: a non-answer churned the repo and pushed: 1 saves
```

The assertions are unchanged in the landed version; only the reader's second
return value moved from absent to `false`.

## Mutations for the checks this change *adds* (AGENTS.md Testing)

Six mutations, each run and seen red **on an assertion** — the first attempt at
M1/M2 produced a *build* failure (unused import), which proves nothing about
reach, so both were re-run with mutations that compile:

| # | mutation | red |
|---|---|---|
| M1 | `lsofProbeRan` → `errors.As(...) \|\| true` | `TestLsofProbeRan`: exit 152, signal, deadline, missing binary all misclassified |
| M2 | `lsofProbeRan` → `ExitCode() == 0` | `TestLsofProbeRan` exit-1 row **and** `ProbeTriState/detached` |
| M3 | `os.Stat` guard deleted | `ProbeTriState/client_log_is_not_where_we_looked`, `DoesNotCacheANonAnswer`, `UnprobableClientReportsHostUnknown` |
| M4 | memoize the non-answer | `DoesNotCacheANonAnswer` |
| M5 | drop `hostKnown &&` from the merge (the pre-fix state) | `HerdrHostSurvivesAnUnrunnableProbe`, all three assertions |
| M6 | vacuity: probe never claims to have run | `ProbeTriState/attached` + `/detached`, `ResolvesHostFromAttachedClient`, `UnprobableClientReportsHostUnknown` |

M6 is the vacuity guard the tri-state most needed: a probe that answered
"unknown" to everything would satisfy every new assertion and freeze the last
known host forever.

`TestLsofProbeRan`'s table is the **committed** form of M1/M2 — real, executed
child-process failures rather than hand-built `*exec.ExitError` values, so the
evidence outlives this PR body. Being exact about which row catches what, since
the obvious summary is wrong and the review caught it: a revert to the pre-#1485
`if err != nil` turns exactly **one** row red (`exit 1`). Rows 3-6 stay green
under that spelling — it and this classifier agree those are not answers — and
pin the opposite mutation (M1, a classifier that calls every failure a completed
probe). Together they bracket the behaviour; separately, neither would.

## Locks (pass by construction, not red-first proofs)

`TestCheckPIDLiveness_HerdrHostClearedOnDetach` (an honest detach must still
clear — the behaviour M6 would have destroyed), `HerdrSteadyStateDoesNotChurn`,
`HerdrIgnoresAReadThatIsNoLongerThePane`, `HerdrAcquiresAMissingTTY` (the one
that pins "skip the adoption, not the whole merge"),
`TestReadLauncherEnv_Herdr_DetachedSessionResolvesNoHost`.

## Verification

`tools/preflight.sh` chunked in the foreground: `go` PASS (one gofmt failure on
an import order, fixed and amended), `arch` PASS (ARS 7.9439 → 7.9432, no
category regression), `web`, `tools`, `skills`, `posix`, `security` all PASS.
Touched packages re-run under `-race`.

## Review outcome

One review subagent at **high** effort (the tier table's Medium row bumped one
row for the widened caller set — a port signature change reaches every
consumer). It re-ran the mutations independently, confirmed the honest detach
still clears against live herdr 0.8.0, and returned **five findings**. All five
are applied:

1. *(correctness, the real one)* `resolveHerdrClientLauncher` still returns
   `(nil, true)` when a candidate client's OWN identity cannot be read —
   `hostIdentity` discards `EnvOf`'s error and `resolveHostFromAncestry`
   returns `("", 0)` for a `readProcInfo` timeout as well as a genuine miss, so
   a kitty-hosted client (kitty sets no `TERM_PROGRAM` upstream, making ancestry
   its only source) on a loaded machine is indistinguishable from an SSH client.
   That is this bug one layer up. Fixing it needs `hostIdentity` to report
   whether its reads ran — a wider change, since its error-swallowing is
   load-bearing for hardened-runtime processes on the main capture path. **Filed
   as #1492 and named in the doc comment, rather than left asserted away** — the
   original comment claimed both cases were "real answers", which is the kind of
   dismissal AGENTS.md requires evidence for.
2. The `os.Stat` guard's comment claimed it also covers a socket path addressing
   a *different* session. It does not — verified live, a detached session keeps
   its client log, so that path exists and the stat passes. Narrowed.
3. `TestLsofProbeRan`'s doc had the mutation inference backwards (above).
4. `ReadLauncherEnv`'s "false only for a herdr pane" was contradicted by
   `pid <= 0` and the consent gate. Corrected.
5. The `IsEmpty()` path returned `(nil, true)` — asserting "no host exists" for
   a read that established nothing. Now `(nil, false)`; inert today (every
   consumer bails on the nil first), but it stops the next consumer being
   misled.

Explicitly checked and **not** filed by the reviewer: a cache hit returning
`(cached, true)` with a nil launcher is correct, because `herdrClientCachePut`
is only reachable on the `probed` branch; the cache is fully mutex-guarded and
both packages pass `-race`; `memoizedLauncherEnv` cannot cross values between
reads.

**Simplify** took the *Small* row where review took the higher one — the two
columns are read independently, and the substantive logic here is ~30 lines
threading one bool, with the rest comments and mechanical `, true` test churn.
Inline glance instead of the fan-out: no duplicated logic added; `lsofProbeRan`
deliberately not merged with `runPgrep`'s inline exit-1 idiom (different return
shapes, and `runPgrep` is untouched by this ticket — cross-referenced in the doc
instead); `hostKnown` deliberately NOT folded into `launcherBackfillNeeds`,
because `needs` is derived from the *stored* launcher and `hostKnown` from the
*fresh read*, and one name over two sources is how they drift; one extra
`os.Stat` per probe, well under the lsof scan it guards and memoized per socket
for 5s alongside it.

## Not in scope

#1486 asks whether tmux has the same shape. This change does not touch the tmux
path and does not settle it — see the handback note on that issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
