### PR TITLE
test(contracttesting): commit the mutation evidence beside the assertion (#1479)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,8 +89,9 @@ deliberately-broken fixtures are the shape ("committed rather than improvised so
 mutation evidence outlives the PR"), and `TestSourceScanCatchesEveryKnownShape`
 (`core/application/services/construction_test.go`) is the same idea as a corpus.
 Evidence living only in a merged PR body is re-run by nothing; for the
-`contracttesting` families #1479 committed it beside each assertion, and the
-"Permission gating" bullet below describes the shape. And a guard that *rewrites* an existing one owes
+`contracttesting` families #1479 committed it beside each assertion, in
+`core/internal/contracttesting/<family>_selftest_test.go` — the paragraph
+closing the contract-family bullets below carries the shape and its limits. And a guard that *rewrites* an existing one owes
 its predecessor's cases as locks on top of its own — "Guarded construction" below
 carries that rule and the incident that earned it.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,8 +88,9 @@ because a reviewer, or the agent itself, ran a mutation nobody had asked for.
 deliberately-broken fixtures are the shape ("committed rather than improvised so the
 mutation evidence outlives the PR"), and `TestSourceScanCatchesEveryKnownShape`
 (`core/application/services/construction_test.go`) is the same idea as a corpus.
-Evidence living only in a merged PR body is re-run by nothing, which for the
-`contracttesting` families is #1479. And a guard that *rewrites* an existing one owes
+Evidence living only in a merged PR body is re-run by nothing; for the
+`contracttesting` families #1479 committed it beside each assertion, and the
+"Permission gating" bullet below describes the shape. And a guard that *rewrites* an existing one owes
 its predecessor's cases as locks on top of its own — "Guarded construction" below
 carries that rule and the incident that earned it.
 
@@ -527,11 +528,8 @@ Before marking a ticket done, run the full suite — every layer must pass:
   over the package currently returns eight, because
   `AssertPermissionGatedOnEachKey` is a driver that runs the permission-gate
   family once per key, not a family of its own. Check what a function asserts
-  before moving this number, and note that the count is tool-sensitive: a `git
-  grep` over the pathspec `core/internal/contracttesting/*.go` returns NINE,
-  because a git pathspec `*` crosses directory boundaries where a shell glob
-  does not, and it picks up `AssertMatchesCanonical` in the `userblocking/`
-  subpackage. A new or reworked
+  before moving this number (and before re-counting with `git grep`, whose
+  pathspec `*` crosses directory boundaries and returns nine). A new or reworked
   contract assertion is therefore the mutation rule at the top of this section
   in its most literal form: it lands with the deliberate mutation seen red for
   each obligation — and since #1479 that mutation is **committed beside the
@@ -557,10 +555,16 @@ Before marking a ticket done, run the full suite — every layer must pass:
   arms all passed correctly for what they asserted and the gap was that the
   FIXTURE could not express the distinguishing state — a negative self-test
   grades an obligation against the wrong receiver it can build, never against
-  the one nobody thought to build. Four families carry them today (permission
-  gate, hook endpoint, hook disclosure, hook version); the three
-  receiver-shaped ones are #1497, queued behind #1488 because they share one
-  fake receiver and #1488 changes the constructor that builds it.
+  the one nobody thought to build. **A new arm takes `reporter`, or `armT` when
+  it also builds fixtures — never `*testing.T`**, or it cannot be driven at all
+  and its obligation silently leaves the covered set. `armT.fixtures` is typed
+  `fixtureT`, which carries `Setenv` and nothing that can decide a verdict, so
+  reporting through it does not compile; that is a type guarantee rather than a
+  guard, the same trade #1390 made for path confinement. Four families carry
+  self-tests (permission gate, hook endpoint, hook disclosure, hook version);
+  the three receiver-shaped ones, and a source walk that would make a fifth
+  family covered by existing rather than by remembering, are #1497 — queued
+  behind #1488, which changes the fake receiver all three would share.
 - Guarded construction: not a contract family — a package-local pair of guards,
   `core/application/services/construction_test.go`. A service whose fields
   include maps, channels, or anything else whose zero value is unusable is

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -527,11 +527,40 @@ Before marking a ticket done, run the full suite — every layer must pass:
   over the package currently returns eight, because
   `AssertPermissionGatedOnEachKey` is a driver that runs the permission-gate
   family once per key, not a family of its own. Check what a function asserts
-  before moving this number. A new or reworked
+  before moving this number, and note that the count is tool-sensitive: a `git
+  grep` over the pathspec `core/internal/contracttesting/*.go` returns NINE,
+  because a git pathspec `*` crosses directory boundaries where a shell glob
+  does not, and it picks up `AssertMatchesCanonical` in the `userblocking/`
+  subpackage. A new or reworked
   contract assertion is therefore the mutation rule at the top of this section
   in its most literal form: it lands with the deliberate mutation seen red for
-  each obligation. That evidence currently lives in the PR body, where nothing
-  re-runs it — #1479.
+  each obligation — and since #1479 that mutation is **committed beside the
+  assertion** rather than described in the PR that added it, because a
+  paragraph in a merged PR body is re-run by nothing and an assertion that
+  silently stops discriminating looks exactly like health.
+  `<family>_selftest_test.go` drives one obligation against a fixture that is
+  wrong in exactly ONE way and asserts that obligation reports it;
+  `selftest_test.go` holds the harness — a recording reporter behind the
+  `reporter` seam introduced by #1475/PR #1489, plus `verdictReported` and
+  `verdictSilent` — and the harness's OWN committed mutation, `deafRecorder`
+  and `criesWolfRecorder`, since a recorder that stopped observing would be
+  this failure reproduced inside its own fix. Two rules are load-bearing and
+  neither is obvious. A negative self-test names a fragment of the
+  obligation's own failure message and a bare failure is refused: "the arm
+  failed" and "THIS obligation failed" are different claims, and #1453's
+  second instance is the one where only the first was true (`--port 7837` left
+  `delivery_carries_no_address` green while the run failed incidentally
+  elsewhere). And every family carries a vacuity guard running each arm
+  against a CORRECT fixture, because an arm that reported unconditionally
+  would satisfy every mutation and read as excellent coverage. Note what this
+  does NOT close: #1475's key-blindness would have survived it, because those
+  arms all passed correctly for what they asserted and the gap was that the
+  FIXTURE could not express the distinguishing state — a negative self-test
+  grades an obligation against the wrong receiver it can build, never against
+  the one nobody thought to build. Four families carry them today (permission
+  gate, hook endpoint, hook disclosure, hook version); the three
+  receiver-shaped ones are #1497, queued behind #1488 because they share one
+  fake receiver and #1488 changes the constructor that builds it.
 - Guarded construction: not a contract family — a package-local pair of guards,
   `core/application/services/construction_test.go`. A service whose fields
   include maps, channels, or anything else whose zero value is unusable is

--- a/core/internal/contracttesting/hook_disclosure.go
+++ b/core/internal/contracttesting/hook_disclosure.go
@@ -107,7 +107,7 @@ func AssertHookDisclosureMatchesInstalled(t *testing.T, d HookDisclosure) {
 	t.Run("permission_is_modify_kind", func(t *testing.T) {
 		assertModifyKind(t, d.PermissionKey, perm.Kind)
 	})
-	disclosure := perm.Touches + "\n" + perm.Detail
+	disclosure := disclosureTextOf(perm)
 	// One tokenization serves both the "is this name present" and the "what
 	// event-shaped names are present" questions. Whole-word matching is what
 	// makes the first safe: "PostToolUse" occurs inside "PostToolUseFailure",
@@ -127,6 +127,16 @@ func AssertHookDisclosureMatchesInstalled(t *testing.T, d HookDisclosure) {
 	t.Run("states_the_version_floor", func(t *testing.T) {
 		assertStatesVersionFloor(t, perm, disclosure)
 	})
+}
+
+// disclosureTextOf is the copy the user actually reads before granting: the
+// wizard row shows Touches and the (i) expander shows Detail, and which of the
+// two carries a given fact is a presentation choice. It is a function rather
+// than an expression repeated at each reader so the self-tests grade exactly
+// the string the contract grades — a second spelling would keep passing while
+// the contract moved to a wider one.
+func disclosureTextOf(perm agent.Permission) string {
+	return perm.Touches + "\n" + perm.Detail
 }
 
 // disclosureUnderTest returns the permission the contract grades, or a reason

--- a/core/internal/contracttesting/hook_disclosure.go
+++ b/core/internal/contracttesting/hook_disclosure.go
@@ -14,6 +14,7 @@
 package contracttesting
 
 import (
+	"fmt"
 	"regexp"
 	"sort"
 	"strconv"
@@ -99,17 +100,13 @@ type HookDisclosure struct {
 func AssertHookDisclosureMatchesInstalled(t *testing.T, d HookDisclosure) {
 	t.Helper()
 
-	perm, ok := findPermission(d.Agent, d.PermissionKey)
-	if !ok {
-		t.Fatalf("agent %q declares no permission with key %q", d.Agent.Identity.Name, d.PermissionKey)
+	perm, reason := disclosureUnderTest(d)
+	if reason != "" {
+		t.Fatal(reason)
 	}
-	if perm.Kind != permission.KindModify {
-		t.Errorf("hooks permission %q is %v, want %v — installing hooks writes to the user's config",
-			d.PermissionKey, perm.Kind, permission.KindModify)
-	}
-	if len(d.Installed) == 0 {
-		t.Fatal("HookDisclosure.Installed is empty — pass the installer's event list")
-	}
+	t.Run("permission_is_modify_kind", func(t *testing.T) {
+		assertModifyKind(t, d.PermissionKey, perm.Kind)
+	})
 	disclosure := perm.Touches + "\n" + perm.Detail
 	// One tokenization serves both the "is this name present" and the "what
 	// event-shaped names are present" questions. Whole-word matching is what
@@ -132,6 +129,34 @@ func AssertHookDisclosureMatchesInstalled(t *testing.T, d HookDisclosure) {
 	})
 }
 
+// disclosureUnderTest returns the permission the contract grades, or a reason
+// it cannot grade one. It reports a reason rather than failing so the shapes it
+// rejects are themselves drivable from a negative self-test — the same split
+// malformedGateReason draws, and for the same reason: a guard nobody can
+// exercise is the unverifiable check this package exists to remove.
+func disclosureUnderTest(d HookDisclosure) (agent.Permission, string) {
+	perm, ok := findPermission(d.Agent, d.PermissionKey)
+	if !ok {
+		return agent.Permission{}, fmt.Sprintf("agent %q declares no permission with key %q",
+			d.Agent.Identity.Name, d.PermissionKey)
+	}
+	if len(d.Installed) == 0 {
+		return agent.Permission{}, "HookDisclosure.Installed is empty — pass the installer's event list"
+	}
+	return perm, ""
+}
+
+// assertModifyKind is the kind obligation, split out of the precondition block
+// because it is one: a permission whose Apply writes the user's config while
+// declaring itself observe-kind mislabels the wizard row the user consents at.
+func assertModifyKind(t reporter, key string, kind permission.Kind) {
+	t.Helper()
+	if kind != permission.KindModify {
+		t.Errorf("hooks permission %q is %v, want %v — installing hooks writes to the user's config",
+			key, kind, permission.KindModify)
+	}
+}
+
 // assertStatesVersionFloor extends the #1356 contract along the axis #1365
 // added. The other three arms bind the copy to WHICH entries get written; a
 // declared minimum upstream version makes it conditional whether ANY of them
@@ -148,7 +173,7 @@ func AssertHookDisclosureMatchesInstalled(t *testing.T, d HookDisclosure) {
 // Touches/Detail can keep stating one exact count and one exact list. A gate
 // that filtered events per version would make the count a range, which is the
 // hand-waving #1356 abolished.
-func assertStatesVersionFloor(t *testing.T, perm agent.Permission, disclosure string) {
+func assertStatesVersionFloor(t reporter, perm agent.Permission, disclosure string) {
 	t.Helper()
 	if perm.Writes == nil || perm.Writes.Version == nil || perm.Writes.Version.Min == "" {
 		return
@@ -163,7 +188,7 @@ func assertStatesVersionFloor(t *testing.T, perm agent.Permission, disclosure st
 
 // assertNamesEveryInstalledEvent is the consent-critical arm: an installed
 // event the copy never names is a write the user was not told about.
-func assertNamesEveryInstalledEvent(t *testing.T, installed []string, named map[string]bool) {
+func assertNamesEveryInstalledEvent(t reporter, installed []string, named map[string]bool) {
 	t.Helper()
 	for _, event := range installed {
 		if !named[event] {
@@ -176,7 +201,7 @@ func assertNamesEveryInstalledEvent(t *testing.T, installed []string, named map[
 // assertStatesInstalledCount checks every count the copy states, not just the
 // first: a permission that mentions its entry count twice must not have them
 // disagree.
-func assertStatesInstalledCount(t *testing.T, installed []string, disclosure string) {
+func assertStatesInstalledCount(t reporter, installed []string, disclosure string) {
 	t.Helper()
 	matches := entryCountPattern.FindAllStringSubmatch(disclosure, -1)
 	if len(matches) == 0 {
@@ -199,7 +224,7 @@ func assertStatesInstalledCount(t *testing.T, installed []string, disclosure str
 // sources overlap (every multi-word modelled name is in both), so they are
 // merged before reporting: one wrong name should produce one failure line, not
 // two. The contract's whole value is the message someone reads at 2am.
-func assertNamesNoUninstalledEvent(t *testing.T, d HookDisclosure, named map[string]bool) {
+func assertNamesNoUninstalledEvent(t reporter, d HookDisclosure, named map[string]bool) {
 	t.Helper()
 	exempt := make(map[string]bool, len(d.Installed)+len(d.NonEventTerms))
 	for _, event := range d.Installed {

--- a/core/internal/contracttesting/hook_disclosure_selftest_test.go
+++ b/core/internal/contracttesting/hook_disclosure_selftest_test.go
@@ -1,0 +1,261 @@
+// hook_disclosure_selftest_test.go is the committed mutation evidence for
+// AssertHookDisclosureMatchesInstalled (#1356, extended by #1393), transcribed
+// from PR #1370 and PR #1393 where it lived as prose (#1479).
+//
+// Each case builds a disclosure that is wrong in exactly ONE way and asserts
+// the obligation that owns that wrongness is the one that reports it. The
+// fixture is a purpose-built agent rather than a real adapter's, for the reason
+// tools/lib's linter suites give: assertions pinned against a real declaration
+// move whenever that adapter is edited, and then the evidence is about
+// something else.
+package contracttesting
+
+import (
+	"testing"
+
+	"irrlicht/core/adapters/inbound/agents/hookjson"
+	"irrlicht/core/domain/agent"
+	"irrlicht/core/domain/permission"
+)
+
+const (
+	selfTestDisclosureAgent = "selftest-disclosure"
+	selfTestCLIName         = "selftest-cli"
+	selfTestFloor           = "2.1.122"
+	selfTestConfigPath      = "~/.selftest/settings.json"
+)
+
+// selfTestInstalledEvents is the installer's event list. Three events, because
+// the count obligation and the naming obligation are different claims and a
+// one-event list makes them nearly the same one.
+var selfTestInstalledEvents = []string{"SessionStart", "PostToolUse", "Notification"}
+
+// correctDisclosure renders consent copy the way a correct adapter does: every
+// sentence derived from selfTestInstalledEvents rather than hand-restated, which
+// is the fix #1356 shipped. Each mutation below overrides exactly one part.
+func correctDisclosure() HookDisclosure {
+	return disclosureWith(
+		hookjson.EntriesTouched(selfTestConfigPath, selfTestInstalledEvents),
+		"Adds "+hookjson.EventList(selfTestInstalledEvents)+" entries. "+
+			hookjson.RequiresVersion(selfTestCLIName, selfTestFloor),
+	)
+}
+
+// disclosureWith builds the wiring around one Touches/Detail pair. The version
+// floor is declared on the permission (not just mentioned in the copy) because
+// the fourth obligation reads it off the declaration.
+func disclosureWith(touches, detail string) HookDisclosure {
+	return HookDisclosure{
+		Agent: agent.Agent{
+			Identity: agent.Identity{Name: selfTestDisclosureAgent},
+			Permissions: []agent.Permission{{
+				Key:     agent.HooksPermissionKey,
+				Kind:    permission.KindModify,
+				Touches: touches,
+				Detail:  detail,
+				Apply:   func() error { return nil },
+				Writes: &agent.ManagedUserFile{
+					Version: &agent.VersionGate{
+						Min:   selfTestFloor,
+						Probe: []string{selfTestCLIName, "--version"},
+					},
+				},
+			}},
+		},
+		PermissionKey: agent.HooksPermissionKey,
+		Installed:     selfTestInstalledEvents,
+	}
+}
+
+// disclosureArms names each obligation, the fragment of its own failure message
+// that proves IT fired rather than a neighbour, and how to drive it. Keeping the
+// four in one table is what makes the vacuity guard below cheap: every arm is
+// run against the correct fixture as well as against its own mutation.
+type disclosureArm struct {
+	want string
+	run  func(t armT, d HookDisclosure)
+}
+
+func disclosureArms() map[string]disclosureArm {
+	return map[string]disclosureArm{
+		"names_every_installed_event": {
+			want: "but the installer writes it",
+			run: func(t armT, d HookDisclosure) {
+				assertNamesEveryInstalledEvent(t, d.Installed, disclosureWords(d))
+			},
+		},
+		"states_the_installed_count": {
+			want: "consent copy declares",
+			run: func(t armT, d HookDisclosure) {
+				assertStatesInstalledCount(t, d.Installed, disclosureText(d))
+			},
+		},
+		"names_no_uninstalled_event": {
+			want: "which reads as a hook event but the installer",
+			run: func(t armT, d HookDisclosure) {
+				assertNamesNoUninstalledEvent(t, d, disclosureWords(d))
+			},
+		},
+		"states_the_version_floor": {
+			want: "never states the",
+			run: func(t armT, d HookDisclosure) {
+				perm, _ := disclosureUnderTest(d)
+				assertStatesVersionFloor(t, perm, disclosureText(d))
+			},
+		},
+	}
+}
+
+func disclosureText(d HookDisclosure) string {
+	perm, _ := disclosureUnderTest(d)
+	return perm.Touches + "\n" + perm.Detail
+}
+
+func disclosureWords(d HookDisclosure) map[string]bool { return wordsIn(disclosureText(d)) }
+
+// TestDisclosureArms_PassACorrectDisclosure is the family's vacuity guard. Every
+// arm is run against copy that is right in every respect: an arm that reported
+// unconditionally would satisfy all four mutations below and look like coverage.
+func TestDisclosureArms_PassACorrectDisclosure(t *testing.T) {
+	for name, arm := range disclosureArms() {
+		t.Run(name, func(t *testing.T) {
+			d := correctDisclosure()
+			mustBeSilent(t, observe(t, func(at armT) { arm.run(at, d) }), "a correct disclosure")
+		})
+	}
+}
+
+// TestDisclosureArm_NamesEveryInstalledEvent is #1356 itself, reduced to a
+// fixture: Claude Code's copy named six events for a seven-event install, so
+// the Notification hook was written to the user's settings.json undisclosed.
+// PR #1370's mutation was rendering Detail from installedHookEvents[:len-1];
+// this is that mutation.
+func TestDisclosureArm_NamesEveryInstalledEvent(t *testing.T) {
+	short := selfTestInstalledEvents[:len(selfTestInstalledEvents)-1]
+	d := disclosureWith(
+		hookjson.EntriesTouched(selfTestConfigPath, selfTestInstalledEvents),
+		"Adds "+hookjson.EventList(short)+" entries. "+
+			hookjson.RequiresVersion(selfTestCLIName, selfTestFloor),
+	)
+
+	rec := observe(t, func(at armT) {
+		assertNamesEveryInstalledEvent(at, d.Installed, disclosureWords(d))
+	})
+	mustReport(t, rec, "Notification",
+		"copy rendered from installed[:len-1] — the last event is installed but never named (#1356)")
+}
+
+// TestDisclosureArm_StatesTheInstalledCount pins the other half of the same
+// defect: PR #1370's M1 hand-restated the count as 6 against a seven-event
+// install. Here the count is one short of what is installed.
+func TestDisclosureArm_StatesTheInstalledCount(t *testing.T) {
+	t.Run("a_count_that_is_wrong", func(t *testing.T) {
+		d := disclosureWith(
+			hookjson.EntriesTouched(selfTestConfigPath, selfTestInstalledEvents[:1]),
+			"Adds "+hookjson.EventList(selfTestInstalledEvents)+" entries.",
+		)
+		rec := observe(t, func(at armT) {
+			assertStatesInstalledCount(at, d.Installed, disclosureText(d))
+		})
+		mustReport(t, rec, "consent copy declares 1 hook entries, installer writes 3",
+			"a hand-restated entry count, one the installer disagrees with (#1356 M1)")
+	})
+
+	// A count stated NOWHERE is a different failure from a count stated wrongly,
+	// and it is the one an adapter reaches by writing its own prose instead of
+	// calling EntriesTouched. Without this case the arm could be satisfied by
+	// only ever comparing numbers it found.
+	t.Run("no_count_stated_at_all", func(t *testing.T) {
+		d := disclosureWith("Writes to "+selfTestConfigPath,
+			"Adds "+hookjson.EventList(selfTestInstalledEvents)+" entries.")
+		rec := observe(t, func(at armT) {
+			assertStatesInstalledCount(at, d.Installed, disclosureText(d))
+		})
+		mustReport(t, rec, "consent copy states no entry count",
+			"copy that never states how many entries are written")
+	})
+}
+
+// TestDisclosureArm_NamesNoUninstalledEvent is PR #1370's M3: codex's Detail
+// also named PreCompact, which codex never installs. An over-promise does not
+// hide a write from the user, but it is still not the contract they agreed to.
+//
+// The second case is the review finding from the same PR — the arm originally
+// knew only names the DOMAIN models, so copy promising an upstream event
+// irrlicht has no constant for passed clean. It is covered here because it is
+// the half that is easy to lose in a refactor of eventShapedToken.
+func TestDisclosureArm_NamesNoUninstalledEvent(t *testing.T) {
+	for name, extra := range map[string]string{
+		"a_modelled_event_that_is_not_installed":    "PreCompact",
+		"an_event_shaped_name_the_domain_never_saw": "UserPromptSubmit",
+	} {
+		t.Run(name, func(t *testing.T) {
+			d := disclosureWith(
+				hookjson.EntriesTouched(selfTestConfigPath, selfTestInstalledEvents),
+				"Adds "+hookjson.EventList(selfTestInstalledEvents)+" entries, plus "+extra+".",
+			)
+			rec := observe(t, func(at armT) {
+				assertNamesNoUninstalledEvent(at, d, disclosureWords(d))
+			})
+			mustReport(t, rec, extra, "consent copy naming "+extra+", which the installer never writes")
+		})
+	}
+}
+
+// TestDisclosureArm_StatesTheVersionFloor is #1393's arm: the permission
+// declares a floor, so the copy has to say so — otherwise it describes an
+// install that may not happen on the user's machine. The mutation is copy that
+// is correct about every event and silent about the precondition.
+func TestDisclosureArm_StatesTheVersionFloor(t *testing.T) {
+	d := disclosureWith(
+		hookjson.EntriesTouched(selfTestConfigPath, selfTestInstalledEvents),
+		"Adds "+hookjson.EventList(selfTestInstalledEvents)+" entries.",
+	)
+
+	rec := observe(t, func(at armT) {
+		perm, _ := disclosureUnderTest(d)
+		assertStatesVersionFloor(at, perm, disclosureText(d))
+	})
+	mustReport(t, rec, selfTestFloor,
+		"a declared version floor the consent copy never mentions (#1393)")
+}
+
+// TestDisclosureArm_PermissionIsModifyKind covers the kind obligation, which is
+// the one that decides which wizard row the user consents at: a permission that
+// writes the user's config while declaring itself observe-kind is disclosed as
+// a read.
+func TestDisclosureArm_PermissionIsModifyKind(t *testing.T) {
+	rec := observe(t, func(at armT) {
+		assertModifyKind(at, agent.HooksPermissionKey, permission.KindObserve)
+	})
+	mustReport(t, rec, "installing hooks writes to the user's config",
+		"a hooks permission declaring itself observe-kind")
+
+	mustBeSilent(t, observe(t, func(at armT) {
+		assertModifyKind(at, agent.HooksPermissionKey, permission.KindModify)
+	}), "a modify-kind hooks permission")
+}
+
+// TestDisclosureUnderTest covers the preconditions. A wiring the contract cannot
+// grade must be refused out loud: silently running three of four arms is
+// indistinguishable from a pass, which is the failure mode this whole file is
+// about.
+func TestDisclosureUnderTest(t *testing.T) {
+	if _, reason := disclosureUnderTest(correctDisclosure()); reason != "" {
+		t.Fatalf("a well-formed disclosure was rejected: %s", reason)
+	}
+
+	for name, mutate := range map[string]func(*HookDisclosure){
+		"permission_key_names_nothing": func(d *HookDisclosure) { d.PermissionKey = "no-such-key" },
+		"installed_list_is_empty":      func(d *HookDisclosure) { d.Installed = nil },
+	} {
+		t.Run(name, func(t *testing.T) {
+			d := correctDisclosure()
+			mutate(&d)
+			if _, reason := disclosureUnderTest(d); reason == "" {
+				t.Error("a disclosure the contract cannot grade was accepted — it would run a " +
+					"reduced set of arms silently")
+			}
+		})
+	}
+}

--- a/core/internal/contracttesting/hook_disclosure_selftest_test.go
+++ b/core/internal/contracttesting/hook_disclosure_selftest_test.go
@@ -11,6 +11,7 @@
 package contracttesting
 
 import (
+	"strings"
 	"testing"
 
 	"irrlicht/core/adapters/inbound/agents/hookjson"
@@ -106,6 +107,33 @@ func disclosureArms() map[string]disclosureArm {
 	}
 }
 
+// wantOf returns the fragment of an obligation's OWN failure message that
+// proves IT fired. Taking it from the table rather than retyping it at the call
+// site is the review finding from PR #1498: three of these tests originally
+// passed the interpolated VALUE ("Notification", the floor string) as the
+// fragment, which a NEIGHBOURING obligation's message also contains — so an arm
+// that reported the wrong prose for the right condition was graded green. That
+// is #1453's second instance reproduced inside its own fix.
+func wantOf(t *testing.T, obligation string) string {
+	t.Helper()
+	arm, ok := disclosureArms()[obligation]
+	if !ok {
+		t.Fatalf("no obligation named %q — the table and these tests have drifted", obligation)
+	}
+	return arm.want
+}
+
+// mustAlsoName asserts the failure names the value the fixture was wrong about,
+// on top of naming the obligation. Both halves matter: the obligation fragment
+// says WHICH check fired, the value says the message is actionable.
+func mustAlsoName(t *testing.T, obs observation, value, what string) {
+	t.Helper()
+	if !strings.Contains(obs.report(), value) {
+		t.Errorf("%s: the failure never names %q, so a reader cannot act on it: %s",
+			what, value, obs.report())
+	}
+}
+
 func disclosureText(d HookDisclosure) string {
 	perm, _ := disclosureUnderTest(d)
 	return perm.Touches + "\n" + perm.Detail
@@ -141,8 +169,9 @@ func TestDisclosureArm_NamesEveryInstalledEvent(t *testing.T) {
 	rec := observe(t, func(at armT) {
 		assertNamesEveryInstalledEvent(at, d.Installed, disclosureWords(d))
 	})
-	mustReport(t, rec, "Notification",
-		"copy rendered from installed[:len-1] — the last event is installed but never named (#1356)")
+	const what = "copy rendered from installed[:len-1] — the last event is installed but never named (#1356)"
+	mustReport(t, rec, wantOf(t, "names_every_installed_event"), what)
+	mustAlsoName(t, rec, "Notification", what)
 }
 
 // TestDisclosureArm_StatesTheInstalledCount pins the other half of the same
@@ -157,8 +186,9 @@ func TestDisclosureArm_StatesTheInstalledCount(t *testing.T) {
 		rec := observe(t, func(at armT) {
 			assertStatesInstalledCount(at, d.Installed, disclosureText(d))
 		})
-		mustReport(t, rec, "consent copy declares 1 hook entries, installer writes 3",
-			"a hand-restated entry count, one the installer disagrees with (#1356 M1)")
+		const what = "a hand-restated entry count, one the installer disagrees with (#1356 M1)"
+		mustReport(t, rec, wantOf(t, "states_the_installed_count"), what)
+		mustAlsoName(t, rec, "declares 1 hook entries, installer writes 3", what)
 	})
 
 	// A count stated NOWHERE is a different failure from a count stated wrongly,
@@ -197,7 +227,9 @@ func TestDisclosureArm_NamesNoUninstalledEvent(t *testing.T) {
 			rec := observe(t, func(at armT) {
 				assertNamesNoUninstalledEvent(at, d, disclosureWords(d))
 			})
-			mustReport(t, rec, extra, "consent copy naming "+extra+", which the installer never writes")
+			what := "consent copy naming " + extra + ", which the installer never writes"
+			mustReport(t, rec, wantOf(t, "names_no_uninstalled_event"), what)
+			mustAlsoName(t, rec, extra, what)
 		})
 	}
 }
@@ -216,8 +248,9 @@ func TestDisclosureArm_StatesTheVersionFloor(t *testing.T) {
 		perm, _ := disclosureUnderTest(d)
 		assertStatesVersionFloor(at, perm, disclosureText(d))
 	})
-	mustReport(t, rec, selfTestFloor,
-		"a declared version floor the consent copy never mentions (#1393)")
+	const what = "a declared version floor the consent copy never mentions (#1393)"
+	mustReport(t, rec, wantOf(t, "states_the_version_floor"), what)
+	mustAlsoName(t, rec, selfTestFloor, what)
 }
 
 // TestDisclosureArm_PermissionIsModifyKind covers the kind obligation, which is

--- a/core/internal/contracttesting/hook_disclosure_selftest_test.go
+++ b/core/internal/contracttesting/hook_disclosure_selftest_test.go
@@ -55,12 +55,7 @@ func disclosureWith(touches, detail string) HookDisclosure {
 				Touches: touches,
 				Detail:  detail,
 				Apply:   func() error { return nil },
-				Writes: &agent.ManagedUserFile{
-					Version: &agent.VersionGate{
-						Min:   selfTestFloor,
-						Probe: []string{selfTestCLIName, "--version"},
-					},
-				},
+				Writes:  &agent.ManagedUserFile{Version: selfTestGate()},
 			}},
 		},
 		PermissionKey: agent.HooksPermissionKey,
@@ -104,6 +99,13 @@ func disclosureArms() map[string]disclosureArm {
 				assertStatesVersionFloor(t, perm, disclosureText(d))
 			},
 		},
+		"permission_is_modify_kind": {
+			want: "installing hooks writes to the user's config",
+			run: func(t armT, d HookDisclosure) {
+				perm, _ := disclosureUnderTest(d)
+				assertModifyKind(t, d.PermissionKey, perm.Kind)
+			},
+		},
 	}
 }
 
@@ -136,7 +138,7 @@ func mustAlsoName(t *testing.T, obs observation, value, what string) {
 
 func disclosureText(d HookDisclosure) string {
 	perm, _ := disclosureUnderTest(d)
-	return perm.Touches + "\n" + perm.Detail
+	return disclosureTextOf(perm)
 }
 
 func disclosureWords(d HookDisclosure) map[string]bool { return wordsIn(disclosureText(d)) }
@@ -261,12 +263,8 @@ func TestDisclosureArm_PermissionIsModifyKind(t *testing.T) {
 	rec := observe(t, func(at armT) {
 		assertModifyKind(at, agent.HooksPermissionKey, permission.KindObserve)
 	})
-	mustReport(t, rec, "installing hooks writes to the user's config",
+	mustReport(t, rec, wantOf(t, "permission_is_modify_kind"),
 		"a hooks permission declaring itself observe-kind")
-
-	mustBeSilent(t, observe(t, func(at armT) {
-		assertModifyKind(at, agent.HooksPermissionKey, permission.KindModify)
-	}), "a modify-kind hooks permission")
 }
 
 // TestDisclosureUnderTest covers the preconditions. A wiring the contract cannot

--- a/core/internal/contracttesting/hook_endpoint.go
+++ b/core/internal/contracttesting/hook_endpoint.go
@@ -171,10 +171,10 @@ type HookInstaller struct {
 func AssertHookEndpointFollowsBindAddr(t *testing.T, h HookInstaller) {
 	t.Helper()
 	r := rulesFor(t, h)
-	t.Run(r.firstName, func(t *testing.T) { r.first(t, h) })
-	t.Run(r.installName, func(t *testing.T) { assertInstallWritesCanonicalDelivery(t, h, r) })
-	t.Run(r.upgradeName, func(t *testing.T) { assertUpgradedInPlace(t, h, r) })
-	t.Run(r.uninstallName, func(t *testing.T) { assertUninstallIsNotForeignScoped(t, h, r) })
+	t.Run(r.firstName, func(t *testing.T) { r.first(realT(t), h) })
+	t.Run(r.installName, func(t *testing.T) { assertInstallWritesCanonicalDelivery(realT(t), h, r) })
+	t.Run(r.upgradeName, func(t *testing.T) { assertUpgradedInPlace(realT(t), h, r) })
+	t.Run(r.uninstallName, func(t *testing.T) { assertUninstallIsNotForeignScoped(realT(t), h, r) })
 }
 
 // deliveryRules is everything that differs between the two routes, selected
@@ -190,23 +190,23 @@ func AssertHookEndpointFollowsBindAddr(t *testing.T, h HookInstaller) {
 type deliveryRules struct {
 	// firstName and first are the one obligation that genuinely differs.
 	firstName string
-	first     func(t *testing.T, h HookInstaller)
+	first     func(t armT, h HookInstaller)
 
 	// The remaining three sub-tests are the same functions in both routes and
 	// differ only in what they are called.
 	installName, upgradeName, uninstallName string
 
 	// assertAddress is the route's address obligation, applied per event.
-	assertAddress func(t *testing.T, what, delivery string)
+	assertAddress func(t reporter, what, delivery string)
 
 	// seed leaves behind what a differently-situated daemon installed, and
 	// foreign names it for the failure messages of the two obligations built
 	// on it.
-	seed    func(t *testing.T, h HookInstaller)
+	seed    func(t armT, h HookInstaller)
 	foreign string
 }
 
-func rulesFor(t *testing.T, h HookInstaller) deliveryRules {
+func rulesFor(t reporter, h HookInstaller) deliveryRules {
 	t.Helper()
 	switch h.Delivery {
 	case DeliveryURL:
@@ -248,9 +248,9 @@ func rulesFor(t *testing.T, h HookInstaller) deliveryRules {
 // reads anything home-relative must never be evaluated against the developer's
 // real agent config. And it confirms EndpointOf read something at all before
 // either body compares — see assertDeliveryIsOurs.
-func deliveriesOnBothAddrs(t *testing.T, h HookInstaller) (onDefault, onAlt string) {
+func deliveriesOnBothAddrs(t armT, h HookInstaller) (onDefault, onAlt string) {
 	t.Helper()
-	h.SettingsPath(t)
+	h.SettingsPath(t.fixtures)
 	onDefault = deliveryOn(t, h, "")
 	onAlt = deliveryOn(t, h, AltBindAddr)
 	assertDeliveryIsOurs(t, h, "delivery on the default bind address", onDefault)
@@ -265,7 +265,7 @@ func deliveriesOnBothAddrs(t *testing.T, h HookInstaller) (onDefault, onAlt stri
 // #1178 defect, which is address-bearing and equally invariant — and the
 // no-address check alone would pass for a line that varied for some other
 // reason and so could still be written differently by two daemons.
-func assertDeliveryCarriesNoAddress(t *testing.T, h HookInstaller) {
+func assertDeliveryCarriesNoAddress(t armT, h HookInstaller) {
 	t.Helper()
 	onDefault, onAlt := deliveriesOnBothAddrs(t, h)
 	if onDefault != onAlt {
@@ -279,7 +279,7 @@ func assertDeliveryCarriesNoAddress(t *testing.T, h HookInstaller) {
 // assertEndpointFollowsBindAddr is DeliveryURL's obligation 1 at the source:
 // the endpoint the adapter would install is a function of the bind address at
 // all. An installer that hardcodes the port fails here first, and most legibly.
-func assertEndpointFollowsBindAddr(t *testing.T, h HookInstaller) {
+func assertEndpointFollowsBindAddr(t armT, h HookInstaller) {
 	t.Helper()
 	onDefault, onAlt := deliveriesOnBothAddrs(t, h)
 	if onDefault == onAlt {
@@ -292,9 +292,9 @@ func assertEndpointFollowsBindAddr(t *testing.T, h HookInstaller) {
 // assertInstallWritesCanonicalDelivery is obligation 2: what actually lands in
 // the settings file, plus idempotency on an unchanged bind address. Shared by
 // both routes — only r.assertAddress differs.
-func assertInstallWritesCanonicalDelivery(t *testing.T, h HookInstaller, r deliveryRules) {
+func assertInstallWritesCanonicalDelivery(t armT, h HookInstaller, r deliveryRules) {
 	t.Helper()
-	path := h.SettingsPath(t)
+	path := h.SettingsPath(t.fixtures)
 	want := deliveryOn(t, h, AltBindAddr)
 
 	if _, err := h.EnsureInstalled(); err != nil {
@@ -314,9 +314,9 @@ func assertInstallWritesCanonicalDelivery(t *testing.T, h HookInstaller, r deliv
 // assertUpgradedInPlace is obligation 3: an install left by a differently
 // situated daemon is recognized as ours and repointed, not orphaned beside a
 // duplicate group. What "differently situated" means is r.seed's business.
-func assertUpgradedInPlace(t *testing.T, h HookInstaller, r deliveryRules) {
+func assertUpgradedInPlace(t armT, h HookInstaller, r deliveryRules) {
 	t.Helper()
-	path := h.SettingsPath(t)
+	path := h.SettingsPath(t.fixtures)
 	seedForeignInstall(t, h, r, path)
 	want := deliveryOn(t, h, AltBindAddr)
 
@@ -338,11 +338,11 @@ func assertUpgradedInPlace(t *testing.T, h HookInstaller, r deliveryRules) {
 // means Uninstall must not depend on resolving a binary path at all —
 // `site/install.sh --uninstall` removes the binary without calling
 // --uninstall-hooks, so the entry commonly outlives the path it names.
-func assertUninstallIsNotForeignScoped(t *testing.T, h HookInstaller, r deliveryRules) {
+func assertUninstallIsNotForeignScoped(t armT, h HookInstaller, r deliveryRules) {
 	t.Helper()
-	path := h.SettingsPath(t)
+	path := h.SettingsPath(t.fixtures)
 	seedForeignInstall(t, h, r, path)
-	t.Setenv(daemonaddr.EnvBindAddr, AltBindAddr)
+	t.fixtures.Setenv(daemonaddr.EnvBindAddr, AltBindAddr)
 
 	modified, err := h.Uninstall()
 	if err != nil {
@@ -363,9 +363,9 @@ func assertUninstallIsNotForeignScoped(t *testing.T, h HookInstaller, r delivery
 
 // deliveryOn pins the daemon bind address to bindAddr for the rest of the
 // sub-test and returns the delivery string the adapter would install there.
-func deliveryOn(t *testing.T, h HookInstaller, bindAddr string) string {
+func deliveryOn(t armT, h HookInstaller, bindAddr string) string {
 	t.Helper()
-	t.Setenv(daemonaddr.EnvBindAddr, bindAddr)
+	t.fixtures.Setenv(daemonaddr.EnvBindAddr, bindAddr)
 	return h.EndpointOf(h.Entry())
 }
 
@@ -374,7 +374,7 @@ func deliveryOn(t *testing.T, h HookInstaller, bindAddr string) string {
 // installer writing a stale shape, the address check catches the case want
 // itself is wrong — because the endpoint stopped following the bind address, or
 // because an "address-free" delivery grew an address.
-func assertEveryEventDelivers(t *testing.T, h HookInstaller, r deliveryRules, path, want string) {
+func assertEveryEventDelivers(t armT, h HookInstaller, r deliveryRules, path, want string) {
 	t.Helper()
 	hooksMap := readHooksMap(t, path)
 	for _, event := range h.Events {
@@ -403,7 +403,7 @@ func assertEveryEventDelivers(t *testing.T, h HookInstaller, r deliveryRules, pa
 // The sentinel is the right probe because hookjson identifies OUR entries by
 // finding it in exactly the field EndpointOf is supposed to be reading, so a
 // delivery that does not contain it is either not ours or not being read.
-func assertDeliveryIsOurs(t *testing.T, h HookInstaller, what, delivery string) {
+func assertDeliveryIsOurs(t reporter, h HookInstaller, what, delivery string) {
 	t.Helper()
 	if !strings.Contains(delivery, h.Sentinel) {
 		t.Fatalf("%s: %q does not carry Sentinel %q — EndpointOf is not reading the field the installer writes, so every obligation below it is graded against the wrong string",
@@ -460,7 +460,7 @@ var addressShaped = regexp.MustCompile(
 // the DeliveryAddressFree counterpart of assertResolvedPort, and it is what
 // turns "the beacon happens not to embed a port" into a property the next
 // beacon adapter cannot quietly lose.
-func assertNoAddress(t *testing.T, what, delivery string) {
+func assertNoAddress(t reporter, what, delivery string) {
 	t.Helper()
 	if m := addressShaped.FindString(delivery); m != "" {
 		t.Errorf("%s: %q carries the address-shaped fragment %q — an address-free delivery must resolve the daemon at fire time, or it is a stale-port install (#1178) wearing a command entry's clothes", what, delivery, m)
@@ -469,7 +469,7 @@ func assertNoAddress(t *testing.T, what, delivery string) {
 
 // assertResolvedPort fails unless delivery carries the alternate port and no
 // longer carries the default one.
-func assertResolvedPort(t *testing.T, what, delivery string) {
+func assertResolvedPort(t reporter, what, delivery string) {
 	t.Helper()
 	if want := portMarker(AltBindAddr); !strings.Contains(delivery, want) {
 		t.Errorf("%s: %q does not carry the resolved port %q", what, delivery, want)
@@ -487,9 +487,9 @@ func portMarker(bindAddr string) string {
 
 // seedDefaultPortInstall is DeliveryURL's seed: the adapter's own installer run
 // under a default-port environment.
-func seedDefaultPortInstall(t *testing.T, h HookInstaller) {
+func seedDefaultPortInstall(t armT, h HookInstaller) {
 	t.Helper()
-	t.Setenv(daemonaddr.EnvBindAddr, "")
+	t.fixtures.Setenv(daemonaddr.EnvBindAddr, "")
 	if _, err := h.EnsureInstalled(); err != nil {
 		t.Fatalf("seeding a default-port install: %v", err)
 	}
@@ -498,7 +498,7 @@ func seedDefaultPortInstall(t *testing.T, h HookInstaller) {
 // seedForeignBinaryInstall is DeliveryAddressFree's seed. It has to be
 // adapter-supplied because no environment variable makes an installer name a
 // different binary, where the bind address is one the contract can set itself.
-func seedForeignBinaryInstall(t *testing.T, h HookInstaller) {
+func seedForeignBinaryInstall(t armT, h HookInstaller) {
 	t.Helper()
 	if _, err := h.ForeignInstall(); err != nil {
 		t.Fatalf("seeding an install naming a different irrlichd binary: %v", err)
@@ -511,7 +511,7 @@ func seedForeignBinaryInstall(t *testing.T, h HookInstaller) {
 // hand instead would be a second implementation of what hookjson.EnsureInstalled
 // already does, and one that could drift from the shape the adapter actually
 // writes.
-func seedForeignInstall(t *testing.T, h HookInstaller, r deliveryRules, path string) {
+func seedForeignInstall(t armT, h HookInstaller, r deliveryRules, path string) {
 	t.Helper()
 	r.seed(t, h)
 
@@ -532,7 +532,7 @@ func seedForeignInstall(t *testing.T, h HookInstaller, r deliveryRules, path str
 // failing on any other shape — which is the assertion, not incidental: an
 // upgrade that appends a second group instead of rewriting in place shows up
 // here as a group count of 2.
-func onlyEntry(t *testing.T, hooksMap map[string]interface{}, event string) map[string]interface{} {
+func onlyEntry(t reporter, hooksMap map[string]interface{}, event string) map[string]interface{} {
 	t.Helper()
 	groups, ok := hooksMap[event].([]interface{})
 	if !ok {
@@ -558,7 +558,7 @@ func onlyEntry(t *testing.T, hooksMap map[string]interface{}, event string) map[
 
 // readHooksMap reads the settings file through the same codec the installers
 // use and returns its top-level "hooks" object (nil when absent).
-func readHooksMap(t *testing.T, path string) map[string]interface{} {
+func readHooksMap(t reporter, path string) map[string]interface{} {
 	t.Helper()
 	settings, err := hookjson.ReadSettings(path)
 	if err != nil {

--- a/core/internal/contracttesting/hook_endpoint.go
+++ b/core/internal/contracttesting/hook_endpoint.go
@@ -171,10 +171,19 @@ type HookInstaller struct {
 func AssertHookEndpointFollowsBindAddr(t *testing.T, h HookInstaller) {
 	t.Helper()
 	r := rulesFor(t, h)
-	t.Run(r.firstName, func(t *testing.T) { r.first(realT(t), h) })
-	t.Run(r.installName, func(t *testing.T) { assertInstallWritesCanonicalDelivery(realT(t), h, r) })
-	t.Run(r.upgradeName, func(t *testing.T) { assertUpgradedInPlace(realT(t), h, r) })
-	t.Run(r.uninstallName, func(t *testing.T) { assertUninstallIsNotForeignScoped(realT(t), h, r) })
+	// SettingsPath is called HERE, on the sub-test's real *testing.T, rather
+	// than inside each arm. It relocates the adapter's config home and reports
+	// its own failures, which is fixture machinery: a home that cannot be
+	// relocated must fail the run loudly, never be recorded as the obligation
+	// under test firing. Arms take the resolved path.
+	t.Run(r.firstName, func(t *testing.T) { r.first(realT(t), h, h.SettingsPath(t)) })
+	t.Run(r.installName, func(t *testing.T) {
+		assertInstallWritesCanonicalDelivery(realT(t), h, r, h.SettingsPath(t))
+	})
+	t.Run(r.upgradeName, func(t *testing.T) { assertUpgradedInPlace(realT(t), h, r, h.SettingsPath(t)) })
+	t.Run(r.uninstallName, func(t *testing.T) {
+		assertUninstallIsNotForeignScoped(realT(t), h, r, h.SettingsPath(t))
+	})
 }
 
 // deliveryRules is everything that differs between the two routes, selected
@@ -190,7 +199,7 @@ func AssertHookEndpointFollowsBindAddr(t *testing.T, h HookInstaller) {
 type deliveryRules struct {
 	// firstName and first are the one obligation that genuinely differs.
 	firstName string
-	first     func(t armT, h HookInstaller)
+	first     func(t armT, h HookInstaller, path string)
 
 	// The remaining three sub-tests are the same functions in both routes and
 	// differ only in what they are called.
@@ -244,13 +253,13 @@ func rulesFor(t reporter, h HookInstaller) deliveryRules {
 // and on the alternate bind address. The two obligation-1 bodies differ only in
 // how they compare the pair.
 //
-// It relocates the config home even though it writes nothing: an Entry() that
-// reads anything home-relative must never be evaluated against the developer's
-// real agent config. And it confirms EndpointOf read something at all before
-// either body compares — see assertDeliveryIsOurs.
+// Its caller has already relocated the config home, which matters even though
+// this writes nothing: an Entry() that reads anything home-relative must never
+// be evaluated against the developer's real agent config. It confirms
+// EndpointOf read something at all before either body compares — see
+// assertDeliveryIsOurs.
 func deliveriesOnBothAddrs(t armT, h HookInstaller) (onDefault, onAlt string) {
 	t.Helper()
-	h.SettingsPath(t.fixtures)
 	onDefault = deliveryOn(t, h, "")
 	onAlt = deliveryOn(t, h, AltBindAddr)
 	assertDeliveryIsOurs(t, h, "delivery on the default bind address", onDefault)
@@ -265,7 +274,7 @@ func deliveriesOnBothAddrs(t armT, h HookInstaller) (onDefault, onAlt string) {
 // #1178 defect, which is address-bearing and equally invariant — and the
 // no-address check alone would pass for a line that varied for some other
 // reason and so could still be written differently by two daemons.
-func assertDeliveryCarriesNoAddress(t armT, h HookInstaller) {
+func assertDeliveryCarriesNoAddress(t armT, h HookInstaller, _ string) {
 	t.Helper()
 	onDefault, onAlt := deliveriesOnBothAddrs(t, h)
 	if onDefault != onAlt {
@@ -279,7 +288,7 @@ func assertDeliveryCarriesNoAddress(t armT, h HookInstaller) {
 // assertEndpointFollowsBindAddr is DeliveryURL's obligation 1 at the source:
 // the endpoint the adapter would install is a function of the bind address at
 // all. An installer that hardcodes the port fails here first, and most legibly.
-func assertEndpointFollowsBindAddr(t armT, h HookInstaller) {
+func assertEndpointFollowsBindAddr(t armT, h HookInstaller, _ string) {
 	t.Helper()
 	onDefault, onAlt := deliveriesOnBothAddrs(t, h)
 	if onDefault == onAlt {
@@ -292,9 +301,8 @@ func assertEndpointFollowsBindAddr(t armT, h HookInstaller) {
 // assertInstallWritesCanonicalDelivery is obligation 2: what actually lands in
 // the settings file, plus idempotency on an unchanged bind address. Shared by
 // both routes — only r.assertAddress differs.
-func assertInstallWritesCanonicalDelivery(t armT, h HookInstaller, r deliveryRules) {
+func assertInstallWritesCanonicalDelivery(t armT, h HookInstaller, r deliveryRules, path string) {
 	t.Helper()
-	path := h.SettingsPath(t.fixtures)
 	want := deliveryOn(t, h, AltBindAddr)
 
 	if _, err := h.EnsureInstalled(); err != nil {
@@ -314,9 +322,8 @@ func assertInstallWritesCanonicalDelivery(t armT, h HookInstaller, r deliveryRul
 // assertUpgradedInPlace is obligation 3: an install left by a differently
 // situated daemon is recognized as ours and repointed, not orphaned beside a
 // duplicate group. What "differently situated" means is r.seed's business.
-func assertUpgradedInPlace(t armT, h HookInstaller, r deliveryRules) {
+func assertUpgradedInPlace(t armT, h HookInstaller, r deliveryRules, path string) {
 	t.Helper()
-	path := h.SettingsPath(t.fixtures)
 	seedForeignInstall(t, h, r, path)
 	want := deliveryOn(t, h, AltBindAddr)
 
@@ -338,9 +345,8 @@ func assertUpgradedInPlace(t armT, h HookInstaller, r deliveryRules) {
 // means Uninstall must not depend on resolving a binary path at all —
 // `site/install.sh --uninstall` removes the binary without calling
 // --uninstall-hooks, so the entry commonly outlives the path it names.
-func assertUninstallIsNotForeignScoped(t armT, h HookInstaller, r deliveryRules) {
+func assertUninstallIsNotForeignScoped(t armT, h HookInstaller, r deliveryRules, path string) {
 	t.Helper()
-	path := h.SettingsPath(t.fixtures)
 	seedForeignInstall(t, h, r, path)
 	t.fixtures.Setenv(daemonaddr.EnvBindAddr, AltBindAddr)
 

--- a/core/internal/contracttesting/hook_endpoint_addressfree_test.go
+++ b/core/internal/contracttesting/hook_endpoint_addressfree_test.go
@@ -88,6 +88,14 @@ func referenceBeaconEntry(command string) map[string]interface{} {
 // referenceBeaconEntryNow is the contract's Entry: the inner hook object the
 // adapter would install right now. A resolution failure yields an empty
 // command, which assertDeliveryIsOurs reports rather than grading silently.
+// referenceBeaconEndpointOf is the contract's EndpointOf: beacon delivery is a
+// `type: command` entry, so the delivery string is the whole command — there is
+// no url field and nothing address-shaped inside it.
+func referenceBeaconEndpointOf(hook map[string]interface{}) string {
+	c, _ := hook["command"].(string)
+	return c
+}
+
 func referenceBeaconEntryNow() map[string]interface{} {
 	command, _ := hookbeacon.InstalledCommand(referenceBeaconAdapter)
 	return referenceBeaconEntry(command)
@@ -157,13 +165,14 @@ func referenceBeaconForeignInstall() (bool, error) {
 	return referenceBeaconRun(command, hookjson.EnsureInstalled)
 }
 
-func TestAddressFreeDeliveryContract(t *testing.T) {
-	// Checked up front so a resolution failure reads as itself rather than as
-	// the empty-delivery wiring error assertDeliveryIsOurs would report.
-	if _, err := hookbeacon.InstalledCommand(referenceBeaconAdapter); err != nil {
-		t.Fatalf("resolving the beacon command: %v", err)
-	}
-	AssertHookEndpointFollowsBindAddr(t, HookInstaller{
+// referenceBeaconInstaller is the whole wiring, as one value. An adapter copies
+// this shape; hook_endpoint_selftest_test.go drives obligations 2-4 through it
+// rather than retyping the literal, so the mutations there are graded against
+// exactly the installer this contract test uses. A second copy would let the
+// two drift, and the self-tests would then be evidence about a wiring nobody
+// runs.
+func referenceBeaconInstaller() HookInstaller {
+	return HookInstaller{
 		Delivery: DeliveryAddressFree,
 		SettingsPath: func(t *testing.T) string {
 			t.Setenv(referenceBeaconHomeEnv, t.TempDir())
@@ -173,18 +182,21 @@ func TestAddressFreeDeliveryContract(t *testing.T) {
 			}
 			return path
 		},
-		Sentinel: hookbeacon.Sentinel(referenceBeaconAdapter),
-		Events:   referenceBeaconEvents,
-		Entry:    referenceBeaconEntryNow,
-		// Beacon delivery is a `type: command` entry, so the delivery string is
-		// the whole command — there is no url field and nothing address-shaped
-		// inside it.
-		EndpointOf: func(hook map[string]interface{}) string {
-			c, _ := hook["command"].(string)
-			return c
-		},
+		Sentinel:        hookbeacon.Sentinel(referenceBeaconAdapter),
+		Events:          referenceBeaconEvents,
+		Entry:           referenceBeaconEntryNow,
+		EndpointOf:      referenceBeaconEndpointOf,
 		EnsureInstalled: referenceBeaconEnsureInstalled,
 		Uninstall:       referenceBeaconUninstall,
 		ForeignInstall:  referenceBeaconForeignInstall,
-	})
+	}
+}
+
+func TestAddressFreeDeliveryContract(t *testing.T) {
+	// Checked up front so a resolution failure reads as itself rather than as
+	// the empty-delivery wiring error assertDeliveryIsOurs would report.
+	if _, err := hookbeacon.InstalledCommand(referenceBeaconAdapter); err != nil {
+		t.Fatalf("resolving the beacon command: %v", err)
+	}
+	AssertHookEndpointFollowsBindAddr(t, referenceBeaconInstaller())
 }

--- a/core/internal/contracttesting/hook_endpoint_selftest_test.go
+++ b/core/internal/contracttesting/hook_endpoint_selftest_test.go
@@ -1,0 +1,408 @@
+// hook_endpoint_selftest_test.go is the committed mutation evidence for
+// AssertHookEndpointFollowsBindAddr (#1178/#1216, two-route since #1453),
+// transcribed from PR #1240 and PR #1473 where it lived as prose (#1479).
+//
+// This family is why #1479 was filed. PR #1473's obligation 1 for the
+// address-free route passed its own mutation 4 of 4: inverting it to "the two
+// deliveries must be IDENTICAL" destroyed the only assertion proving EndpointOf
+// had read anything, because an EndpointOf pointed at a key the entry does not
+// carry returns "" — and "" is invariant, carries no address, and equals the ""
+// the next sub-test compares against. The whole route passed while asserting
+// nothing. assertDeliveryIsOurs is the guard that closed it, and
+// TestEndpointGuard_DeliveryIsOurs is that mutation, now re-run on every build
+// instead of recorded in a merged PR body.
+//
+// Obligations 2-4 are the same code in both delivery routes (only the address
+// assertion and the seed differ — see deliveryRules), so they are driven once
+// here, through the reference beacon installer, and cover both.
+package contracttesting
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"irrlicht/core/adapters/inbound/agents/hookjson"
+	"irrlicht/core/pkg/daemonaddr"
+	"irrlicht/core/pkg/hookbeacon"
+)
+
+// --- fixtures for the address-only obligations ---
+
+// selfTestEndpointSentinel is the port-independent substring marking our
+// entries, as an adapter's hookjson.Config carries it.
+const selfTestEndpointSentinel = "/api/v1/hooks/selftest"
+
+// selfTestBeaconSentinel is the address-free route's marker. It deliberately
+// carries no route and no port: an adapter whose SENTINEL is address-shaped
+// cannot satisfy that route's obligation 1 no matter what its installer does,
+// which is a property of the sentinel rather than of the delivery.
+const selfTestBeaconSentinel = "hook-post selftest"
+
+// sentinelFor picks the marker the declared route can actually satisfy.
+func sentinelFor(mode DeliveryMode) string {
+	if mode == DeliveryAddressFree {
+		return selfTestBeaconSentinel
+	}
+	return selfTestEndpointSentinel
+}
+
+// entryInstaller is the smallest wiring the obligation-1 arms need: they never
+// touch the filesystem, they only ask what the adapter WOULD install at two
+// bind addresses. render is the mutation knob — one function from bind address
+// to delivery string, which is exactly the surface #1178 and #1453 are about.
+func entryInstaller(t *testing.T, mode DeliveryMode, render func(bindAddr string) string) HookInstaller {
+	return HookInstaller{
+		Delivery: mode,
+		SettingsPath: func(t *testing.T) string {
+			return filepath.Join(t.TempDir(), "settings.json")
+		},
+		Sentinel: sentinelFor(mode),
+		Events:   []string{"Stop"},
+		Entry: func() map[string]interface{} {
+			// daemonaddr is read at Entry time, exactly as a real adapter's
+			// builder reads it — the contract varies the env var, not this.
+			return map[string]interface{}{"url": render(os.Getenv(daemonaddr.EnvBindAddr))}
+		},
+		EndpointOf: func(hook map[string]interface{}) string {
+			u, _ := hook["url"].(string)
+			return u
+		},
+		EnsureInstalled: func() (bool, error) { return false, nil },
+		Uninstall:       func() (bool, error) { return false, nil },
+	}
+}
+
+// correctURLDelivery is what a URL-route adapter installs: an endpoint carrying
+// the RESOLVED bind address, so a daemon on another port writes a different
+// line and an old one is repointed rather than left stale (#1178).
+func correctURLDelivery(bindAddr string) string {
+	return fmt.Sprintf("http://127.0.0.1:%d%s", daemonaddr.PortOf(bindAddr), selfTestEndpointSentinel)
+}
+
+// TestEndpointArm_EndpointFollowsBindAddr is #1178 itself: an installer that
+// hardcodes the daemon's port. The delivery is then identical on both bind
+// addresses, which is the first and most legible way it shows up.
+func TestEndpointArm_EndpointFollowsBindAddr(t *testing.T) {
+	t.Run("a_hardcoded_port_does_not_vary", func(t *testing.T) {
+		h := entryInstaller(t, DeliveryURL, func(string) string {
+			return "http://localhost:7837" + selfTestEndpointSentinel // #1178, verbatim
+		})
+		rec := observe(t, func(at armT) { assertEndpointFollowsBindAddr(at, h) })
+		mustReport(t, rec, "delivery is identical on the default",
+			"an installer that hardcodes :7837 — the #1178 defect")
+	})
+
+	// A delivery that varies but keeps the stale port slips past the equality
+	// half, so the port half is asserted separately. Without this case an
+	// installer that appended the port as a query parameter while leaving the
+	// endpoint on 7837 would pass.
+	t.Run("varies_but_carries_the_stale_port", func(t *testing.T) {
+		h := entryInstaller(t, DeliveryURL, func(bindAddr string) string {
+			return "http://localhost:7837" + selfTestEndpointSentinel + "?on=" + bindAddr
+		})
+		rec := observe(t, func(at armT) { assertEndpointFollowsBindAddr(at, h) })
+		mustReport(t, rec, "still carries the default port",
+			"a delivery that varies with the bind address but still points at :7837")
+	})
+
+	t.Run("a_correct_url_installer_passes", func(t *testing.T) {
+		h := entryInstaller(t, DeliveryURL, correctURLDelivery)
+		mustBeSilent(t, observe(t, func(at armT) { assertEndpointFollowsBindAddr(at, h) }),
+			"an installer whose endpoint follows the bind address")
+	})
+}
+
+// TestEndpointArm_DeliveryCarriesNoAddress is the address-free route's
+// obligation 1, and it needs BOTH halves: equality alone passes for a
+// hardcoded address (invariant, and the original defect), while the
+// no-address check alone passes for a line that varies for some other reason.
+//
+// The last three cases are PR #1473's M7/M8/M9 — spellings of an address that
+// the first draft of the matcher did not recognise. M7 is the one worth
+// keeping: with `--port 7837` present, this obligation was GREEN and the run
+// failed only incidentally elsewhere.
+func TestEndpointArm_DeliveryCarriesNoAddress(t *testing.T) {
+	beaconish := "irrlichd hook-post selftest"
+
+	for name, c := range map[string]struct {
+		render func(string) string
+		want   string
+		what   string
+	}{
+		"an_address_bearing_but_invariant_delivery": {
+			render: func(string) string { return beaconish + " http://localhost:7837/x" },
+			want:   "carries the address-shaped fragment",
+			what:   "a hardcoded URL inside a command entry — #1178 wearing a command entry's clothes (M1a)",
+		},
+		"a_delivery_that_varies_with_the_bind_address": {
+			render: func(bindAddr string) string { return beaconish + " on=" + bindAddr },
+			want:   "delivery differs between the default",
+			what:   "an address-free delivery that is not actually independent of the bind address (M1b)",
+		},
+		"a_colon_less_port_flag": {
+			render: func(string) string { return beaconish + " --port 7837" },
+			want:   "carries the address-shaped fragment",
+			what:   "`--port 7837` — invariant and address-free by the naive reading, so it passed BOTH halves before the matcher was widened (M7)",
+		},
+		"the_daemon_port_as_a_bare_word": {
+			render: func(string) string { return beaconish + " 7837" },
+			want:   "carries the address-shaped fragment",
+			what:   "the daemon port with no colon and no flag (M8)",
+		},
+		"the_daemons_hook_route": {
+			render: func(string) string { return beaconish + " /api/v1/hooks/x" },
+			want:   "carries the address-shaped fragment",
+			what:   "the daemon's own HTTP route embedded in the line — delivering by URL whatever the adapter declares (M9)",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			// The sentinel has to survive every mutation, or assertDeliveryIsOurs
+			// fires first and this case would be graded on the wrong obligation.
+			h := entryInstaller(t, DeliveryAddressFree, func(bindAddr string) string {
+				return selfTestBeaconSentinel + " " + c.render(bindAddr)
+			})
+			mustReport(t, observe(t, func(at armT) { assertDeliveryCarriesNoAddress(at, h) }),
+				c.want, c.what)
+		})
+	}
+
+	t.Run("a_correct_address_free_installer_passes", func(t *testing.T) {
+		h := entryInstaller(t, DeliveryAddressFree, func(string) string {
+			return "/opt/homebrew/bin/irrlichd " + selfTestBeaconSentinel
+		})
+		mustBeSilent(t, observe(t, func(at armT) { assertDeliveryCarriesNoAddress(at, h) }),
+			"a delivery that varies with nothing and carries no address")
+	})
+}
+
+// TestEndpointGuard_DeliveryIsOurs is the #1453 instance itself: an EndpointOf
+// pointed at a key the installed entry does not carry. It returns "" for every
+// bind address, and "" satisfies both halves of the address-free obligation and
+// equals whatever the next sub-test compares it against.
+//
+// The two cases are PR #1473's M6a and M6b — the same wiring error graded under
+// each route. Both matter because the key is the one field that genuinely
+// differs between the wirings in the tree: claudecode and copilot read `url`,
+// codex reads `command`.
+func TestEndpointGuard_DeliveryIsOurs(t *testing.T) {
+	for name, mode := range map[string]DeliveryMode{
+		"address_free_route": DeliveryAddressFree,
+		"url_route":          DeliveryURL,
+	} {
+		t.Run(name, func(t *testing.T) {
+			h := entryInstaller(t, mode, correctURLDelivery)
+			// The mutation: read a key the entry does not carry. Everything
+			// else about this installer is correct.
+			h.EndpointOf = func(hook map[string]interface{}) string {
+				c, _ := hook["command"].(string)
+				return c
+			}
+
+			rec := observe(t, func(at armT) { deliveriesOnBothAddrs(at, h) })
+			mustReport(t, rec, "EndpointOf is not reading the field the installer writes",
+				"EndpointOf pointed at a key the entry does not carry — returns \"\", which is "+
+					"invariant, address-free, and equal to itself, so it satisfied every "+
+					"obligation while observing nothing (#1453)")
+		})
+	}
+}
+
+// TestEndpointAddressAssertions covers the two per-event address checks
+// directly, since they are pure string predicates and each guards a different
+// route. They are reached through obligations 1-3, but only for whichever route
+// the wiring declares, so a regression in the unused one would be invisible.
+func TestEndpointAddressAssertions(t *testing.T) {
+	alt := fmt.Sprintf(":%d/", daemonaddr.PortOf(AltBindAddr))
+
+	t.Run("assertNoAddress_reports_an_address", func(t *testing.T) {
+		mustReport(t, observe(t, func(at armT) {
+			assertNoAddress(at, "probe", "irrlichd hook-post http://localhost:7837/x")
+		}), "carries the address-shaped fragment", "an address inside an address-free delivery")
+	})
+	t.Run("assertNoAddress_passes_an_address_free_line", func(t *testing.T) {
+		mustBeSilent(t, observe(t, func(at armT) {
+			assertNoAddress(at, "probe", "/opt/homebrew/bin/irrlichd hook-post selftest")
+		}), "a beacon command carrying no address")
+	})
+	t.Run("assertResolvedPort_reports_a_missing_port", func(t *testing.T) {
+		mustReport(t, observe(t, func(at armT) {
+			assertResolvedPort(at, "probe", "http://localhost/x")
+		}), "does not carry the resolved port", "a delivery with no port at all")
+	})
+	t.Run("assertResolvedPort_reports_the_stale_port", func(t *testing.T) {
+		mustReport(t, observe(t, func(at armT) {
+			assertResolvedPort(at, "probe", "http://localhost"+alt+"x and :7837/y")
+		}), "still carries the default port", "a delivery still carrying :7837 alongside the resolved port")
+	})
+	t.Run("assertResolvedPort_passes_a_resolved_delivery", func(t *testing.T) {
+		mustBeSilent(t, observe(t, func(at armT) {
+			assertResolvedPort(at, "probe", "http://localhost"+alt+"x")
+		}), "a delivery carrying only the resolved port")
+	})
+}
+
+// --- fixtures for obligations 2-4, which do touch the filesystem ---
+
+// beaconInstaller wires the reference beacon adapter (see
+// hook_endpoint_addressfree_test.go) as a HookInstaller, with the three entry
+// points taken as parameters so each mutation below replaces exactly one.
+func beaconInstaller(ensure, uninstall, foreign func() (bool, error)) HookInstaller {
+	return HookInstaller{
+		Delivery: DeliveryAddressFree,
+		SettingsPath: func(t *testing.T) string {
+			t.Setenv(referenceBeaconHomeEnv, t.TempDir())
+			path, err := referenceBeaconHooksPath()
+			if err != nil {
+				t.Fatalf("resolving the reference hooks path: %v", err)
+			}
+			return path
+		},
+		Sentinel:        hookbeacon.Sentinel(referenceBeaconAdapter),
+		Events:          referenceBeaconEvents,
+		Entry:           referenceBeaconEntryNow,
+		EndpointOf:      func(hook map[string]interface{}) string { c, _ := hook["command"].(string); return c },
+		EnsureInstalled: ensure,
+		Uninstall:       uninstall,
+		ForeignInstall:  foreign,
+	}
+}
+
+func correctBeaconInstaller() HookInstaller {
+	return beaconInstaller(referenceBeaconEnsureInstalled, referenceBeaconUninstall, referenceBeaconForeignInstall)
+}
+
+// addressFreeRules is the route the mutations below are graded under. Taking it
+// from rulesFor rather than restating it keeps the self-tests bound to the same
+// seed and address assertion the contract actually uses.
+func addressFreeRules(t *testing.T, h HookInstaller) deliveryRules {
+	t.Helper()
+	return rulesFor(t, h)
+}
+
+// TestEndpointArm_InstallWritesCanonicalDelivery is obligation 2 (PR #1473 M2):
+// the installer writes a line other than the one Entry reports it would.
+func TestEndpointArm_InstallWritesCanonicalDelivery(t *testing.T) {
+	h := correctBeaconInstaller()
+	r := addressFreeRules(t, h)
+
+	t.Run("a_correct_installer_passes", func(t *testing.T) {
+		h := correctBeaconInstaller()
+		mustBeSilent(t, observe(t, func(at armT) { assertInstallWritesCanonicalDelivery(at, h, r) }),
+			"an installer that writes what it says it writes")
+	})
+
+	t.Run("installs_a_line_other_than_the_canonical_one", func(t *testing.T) {
+		mutated := correctBeaconInstaller()
+		mutated.EnsureInstalled = func() (bool, error) {
+			command, err := hookbeacon.Command(referenceForeignBinary, referenceBeaconAdapter)
+			if err != nil {
+				return false, err
+			}
+			return referenceBeaconRun(command, hookjson.EnsureInstalled)
+		}
+		rec := observe(t, func(at armT) { assertInstallWritesCanonicalDelivery(at, mutated, r) })
+		mustReport(t, rec, "installed delivery =",
+			"an installer whose install does not match what Entry reports it would install (M2)")
+	})
+}
+
+// TestEndpointArm_UpgradedInPlace is obligation 3 (PR #1473 M3a — the one that
+// PR called load-bearing): an entry left by a differently-situated daemon must
+// be recognized as ours and REPOINTED. An installer that already considers a
+// foreign entry canonical leaves it in place and reports modified=false, which
+// is the "reports healthy while delivering nothing" state #1178 is about.
+func TestEndpointArm_UpgradedInPlace(t *testing.T) {
+	h := correctBeaconInstaller()
+	r := addressFreeRules(t, h)
+
+	t.Run("a_correct_installer_passes", func(t *testing.T) {
+		h := correctBeaconInstaller()
+		mustBeSilent(t, observe(t, func(at armT) { assertUpgradedInPlace(at, h, r) }),
+			"an installer that repoints a foreign entry in place")
+	})
+
+	t.Run("a_foreign_entry_is_left_alone", func(t *testing.T) {
+		mutated := correctBeaconInstaller()
+		// IsCanonical never checks the binary path, so the seeded foreign
+		// install is already "ours and current" and EnsureInstalled does
+		// nothing.
+		mutated.EnsureInstalled = func() (bool, error) {
+			path, err := referenceBeaconHooksPath()
+			if err != nil {
+				return false, err
+			}
+			command, err := hookbeacon.InstalledCommand(referenceBeaconAdapter)
+			if err != nil {
+				return false, err
+			}
+			cfg := referenceBeaconConfig(path, command)
+			cfg.IsCanonical = func(map[string]interface{}) bool { return true }
+			return hookjson.EnsureInstalled(cfg)
+		}
+		rec := observe(t, func(at armT) { assertUpgradedInPlace(at, mutated, r) })
+		mustReport(t, rec, "expected modified=true when repointing",
+			"an IsCanonical that never checks the binary path, so an entry naming a since-deleted "+
+				"irrlichd is accepted as current (M3a)")
+	})
+}
+
+// TestEndpointArm_UninstallIsNotForeignScoped is obligation 4 (PR #1473 M4):
+// `irrlichd --uninstall-hooks` run from one daemon must remove another's
+// entries, or every daemon leaves its own behind. For the beacon route it
+// additionally means uninstall must not depend on resolving a binary path at
+// all — site/install.sh --uninstall removes the binary without calling
+// --uninstall-hooks, so the entry commonly outlives the path it names.
+func TestEndpointArm_UninstallIsNotForeignScoped(t *testing.T) {
+	h := correctBeaconInstaller()
+	r := addressFreeRules(t, h)
+
+	t.Run("a_correct_uninstall_passes", func(t *testing.T) {
+		h := correctBeaconInstaller()
+		mustBeSilent(t, observe(t, func(at armT) { assertUninstallIsNotForeignScoped(at, h, r) }),
+			"an uninstall matched by a binary-independent sentinel")
+	})
+
+	t.Run("uninstall_scoped_to_the_running_binary", func(t *testing.T) {
+		mutated := correctBeaconInstaller()
+		mutated.Uninstall = func() (bool, error) {
+			path, err := referenceBeaconHooksPath()
+			if err != nil {
+				return false, err
+			}
+			command, err := hookbeacon.InstalledCommand(referenceBeaconAdapter)
+			if err != nil {
+				return false, err
+			}
+			cfg := referenceBeaconConfig(path, command)
+			cfg.Sentinel = command // the whole command, so a foreign binary's entry no longer matches
+			return hookjson.Uninstall(cfg)
+		}
+		rec := observe(t, func(at armT) { assertUninstallIsNotForeignScoped(at, mutated, r) })
+		mustReport(t, rec, "expected modified=true removing",
+			"an Uninstall whose sentinel names the running binary, so another daemon's entries survive (M4)")
+	})
+}
+
+// TestEndpointRulesFor covers the route selection. A wiring that declares the
+// address-free route without a ForeignInstall seed has no way to produce the
+// drifted state obligations 3 and 4 both start from, and must be refused rather
+// than graded on two obligations that cannot run (PR #1473 M5c).
+func TestEndpointRulesFor(t *testing.T) {
+	t.Run("address_free_without_a_foreign_seed_is_refused", func(t *testing.T) {
+		h := entryInstaller(t, DeliveryAddressFree, correctURLDelivery)
+		h.ForeignInstall = nil
+		mustReport(t, observe(t, func(at armT) { rulesFor(at, h) }),
+			"DeliveryAddressFree requires ForeignInstall",
+			"an address-free wiring with no way to seed a drifted install (M5c)")
+	})
+
+	t.Run("an_unknown_route_is_refused", func(t *testing.T) {
+		h := entryInstaller(t, DeliveryMode(99), correctURLDelivery)
+		mustReport(t, observe(t, func(at armT) { rulesFor(at, h) }),
+			"unhandled DeliveryMode",
+			"a delivery mode naming no obligation set — a third route added without saying "+
+				"which obligations it runs")
+	})
+}

--- a/core/internal/contracttesting/hook_endpoint_selftest_test.go
+++ b/core/internal/contracttesting/hook_endpoint_selftest_test.go
@@ -61,7 +61,7 @@ func sentinelFor(mode DeliveryMode) string {
 // touch the filesystem, they only ask what the adapter WOULD install at two
 // bind addresses. render is the mutation knob — one function from bind address
 // to delivery string, which is exactly the surface #1178 and #1453 are about.
-func entryInstaller(t *testing.T, mode DeliveryMode, render func(bindAddr string) string) HookInstaller {
+func entryInstaller(mode DeliveryMode, render func(bindAddr string) string) HookInstaller {
 	return HookInstaller{
 		Delivery: mode,
 		SettingsPath: func(t *testing.T) string {
@@ -95,10 +95,10 @@ func correctURLDelivery(bindAddr string) string {
 // addresses, which is the first and most legible way it shows up.
 func TestEndpointArm_EndpointFollowsBindAddr(t *testing.T) {
 	t.Run("a_hardcoded_port_does_not_vary", func(t *testing.T) {
-		h := entryInstaller(t, DeliveryURL, func(string) string {
+		h := entryInstaller(DeliveryURL, func(string) string {
 			return "http://localhost:7837" + selfTestEndpointSentinel // #1178, verbatim
 		})
-		rec := observe(t, func(at armT) { assertEndpointFollowsBindAddr(at, h) })
+		rec := observe(t, func(at armT) { assertEndpointFollowsBindAddr(at, h, h.SettingsPath(t)) })
 		mustReport(t, rec, "delivery is identical on the default",
 			"an installer that hardcodes :7837 — the #1178 defect")
 	})
@@ -108,17 +108,17 @@ func TestEndpointArm_EndpointFollowsBindAddr(t *testing.T) {
 	// installer that appended the port as a query parameter while leaving the
 	// endpoint on 7837 would pass.
 	t.Run("varies_but_carries_the_stale_port", func(t *testing.T) {
-		h := entryInstaller(t, DeliveryURL, func(bindAddr string) string {
+		h := entryInstaller(DeliveryURL, func(bindAddr string) string {
 			return "http://localhost:7837" + selfTestEndpointSentinel + "?on=" + bindAddr
 		})
-		rec := observe(t, func(at armT) { assertEndpointFollowsBindAddr(at, h) })
+		rec := observe(t, func(at armT) { assertEndpointFollowsBindAddr(at, h, h.SettingsPath(t)) })
 		mustReport(t, rec, "still carries the default port",
 			"a delivery that varies with the bind address but still points at :7837")
 	})
 
 	t.Run("a_correct_url_installer_passes", func(t *testing.T) {
-		h := entryInstaller(t, DeliveryURL, correctURLDelivery)
-		mustBeSilent(t, observe(t, func(at armT) { assertEndpointFollowsBindAddr(at, h) }),
+		h := entryInstaller(DeliveryURL, correctURLDelivery)
+		mustBeSilent(t, observe(t, func(at armT) { assertEndpointFollowsBindAddr(at, h, h.SettingsPath(t)) }),
 			"an installer whose endpoint follows the bind address")
 	})
 }
@@ -169,19 +169,19 @@ func TestEndpointArm_DeliveryCarriesNoAddress(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			// The sentinel has to survive every mutation, or assertDeliveryIsOurs
 			// fires first and this case would be graded on the wrong obligation.
-			h := entryInstaller(t, DeliveryAddressFree, func(bindAddr string) string {
+			h := entryInstaller(DeliveryAddressFree, func(bindAddr string) string {
 				return selfTestBeaconSentinel + " " + c.render(bindAddr)
 			})
-			mustReport(t, observe(t, func(at armT) { assertDeliveryCarriesNoAddress(at, h) }),
+			mustReport(t, observe(t, func(at armT) { assertDeliveryCarriesNoAddress(at, h, h.SettingsPath(t)) }),
 				c.want, c.what)
 		})
 	}
 
 	t.Run("a_correct_address_free_installer_passes", func(t *testing.T) {
-		h := entryInstaller(t, DeliveryAddressFree, func(string) string {
+		h := entryInstaller(DeliveryAddressFree, func(string) string {
 			return "/opt/homebrew/bin/irrlichd " + selfTestBeaconSentinel
 		})
-		mustBeSilent(t, observe(t, func(at armT) { assertDeliveryCarriesNoAddress(at, h) }),
+		mustBeSilent(t, observe(t, func(at armT) { assertDeliveryCarriesNoAddress(at, h, h.SettingsPath(t)) }),
 			"a delivery that varies with nothing and carries no address")
 	})
 }
@@ -201,13 +201,10 @@ func TestEndpointGuard_DeliveryIsOurs(t *testing.T) {
 		"url_route":          DeliveryURL,
 	} {
 		t.Run(name, func(t *testing.T) {
-			h := entryInstaller(t, mode, correctURLDelivery)
+			h := entryInstaller(mode, correctURLDelivery)
 			// The mutation: read a key the entry does not carry. Everything
 			// else about this installer is correct.
-			h.EndpointOf = func(hook map[string]interface{}) string {
-				c, _ := hook["command"].(string)
-				return c
-			}
+			h.EndpointOf = referenceBeaconEndpointOf
 
 			rec := observe(t, func(at armT) { deliveriesOnBothAddrs(at, h) })
 			mustReport(t, rec, "EndpointOf is not reading the field the installer writes",
@@ -254,64 +251,47 @@ func TestEndpointAddressAssertions(t *testing.T) {
 
 // --- fixtures for obligations 2-4, which do touch the filesystem ---
 
-// beaconInstaller wires the reference beacon adapter (see
-// hook_endpoint_addressfree_test.go) as a HookInstaller, with the three entry
-// points taken as parameters so each mutation below replaces exactly one.
-func beaconInstaller(ensure, uninstall, foreign func() (bool, error)) HookInstaller {
-	return HookInstaller{
-		Delivery: DeliveryAddressFree,
-		SettingsPath: func(t *testing.T) string {
-			t.Setenv(referenceBeaconHomeEnv, t.TempDir())
-			path, err := referenceBeaconHooksPath()
-			if err != nil {
-				t.Fatalf("resolving the reference hooks path: %v", err)
-			}
-			return path
-		},
-		Sentinel:        hookbeacon.Sentinel(referenceBeaconAdapter),
-		Events:          referenceBeaconEvents,
-		Entry:           referenceBeaconEntryNow,
-		EndpointOf:      func(hook map[string]interface{}) string { c, _ := hook["command"].(string); return c },
-		EnsureInstalled: ensure,
-		Uninstall:       uninstall,
-		ForeignInstall:  foreign,
+// correctBeaconInstaller is the reference wiring from
+// hook_endpoint_addressfree_test.go, unchanged. Each mutation below takes a
+// fresh copy and replaces exactly one entry point, so the deviation is the only
+// difference from the installer the real contract test runs.
+func correctBeaconInstaller() HookInstaller { return referenceBeaconInstaller() }
+
+// TestEndpointArms_PassACorrectInstaller is this family's vacuity guard, the
+// counterpart of TestDisclosureArms_PassACorrectDisclosure and
+// TestVersionArms_PassACorrectDeclaration: every arm run against the reference
+// installer, which is correct in every respect. An arm that reported
+// unconditionally would satisfy every mutation in this file and read as
+// excellent coverage.
+func TestEndpointArms_PassACorrectInstaller(t *testing.T) {
+	h := correctBeaconInstaller()
+	r := rulesFor(t, h)
+
+	for name, arm := range map[string]func(armT, string){
+		r.firstName:     func(at armT, path string) { r.first(at, h, path) },
+		r.installName:   func(at armT, path string) { assertInstallWritesCanonicalDelivery(at, h, r, path) },
+		r.upgradeName:   func(at armT, path string) { assertUpgradedInPlace(at, h, r, path) },
+		r.uninstallName: func(at armT, path string) { assertUninstallIsNotForeignScoped(at, h, r, path) },
+	} {
+		t.Run(name, func(t *testing.T) {
+			// SettingsPath per sub-test, exactly as the contract calls it: a
+			// fresh temp home, so no arm inherits another's installed state.
+			path := h.SettingsPath(t)
+			mustBeSilent(t, observe(t, func(at armT) { arm(at, path) }), "the reference beacon installer")
+		})
 	}
-}
-
-func correctBeaconInstaller() HookInstaller {
-	return beaconInstaller(referenceBeaconEnsureInstalled, referenceBeaconUninstall, referenceBeaconForeignInstall)
-}
-
-// addressFreeRules is the route the mutations below are graded under. Taking it
-// from rulesFor rather than restating it keeps the self-tests bound to the same
-// seed and address assertion the contract actually uses.
-func addressFreeRules(t *testing.T, h HookInstaller) deliveryRules {
-	t.Helper()
-	return rulesFor(t, h)
 }
 
 // TestEndpointArm_InstallWritesCanonicalDelivery is obligation 2 (PR #1473 M2):
 // the installer writes a line other than the one Entry reports it would.
 func TestEndpointArm_InstallWritesCanonicalDelivery(t *testing.T) {
 	h := correctBeaconInstaller()
-	r := addressFreeRules(t, h)
-
-	t.Run("a_correct_installer_passes", func(t *testing.T) {
-		h := correctBeaconInstaller()
-		mustBeSilent(t, observe(t, func(at armT) { assertInstallWritesCanonicalDelivery(at, h, r) }),
-			"an installer that writes what it says it writes")
-	})
+	r := rulesFor(t, h)
 
 	t.Run("installs_a_line_other_than_the_canonical_one", func(t *testing.T) {
 		mutated := correctBeaconInstaller()
-		mutated.EnsureInstalled = func() (bool, error) {
-			command, err := hookbeacon.Command(referenceForeignBinary, referenceBeaconAdapter)
-			if err != nil {
-				return false, err
-			}
-			return referenceBeaconRun(command, hookjson.EnsureInstalled)
-		}
-		rec := observe(t, func(at armT) { assertInstallWritesCanonicalDelivery(at, mutated, r) })
+		mutated.EnsureInstalled = referenceBeaconForeignInstall
+		rec := observe(t, func(at armT) { assertInstallWritesCanonicalDelivery(at, mutated, r, mutated.SettingsPath(t)) })
 		mustReport(t, rec, "installed delivery =",
 			"an installer whose install does not match what Entry reports it would install (M2)")
 	})
@@ -324,13 +304,7 @@ func TestEndpointArm_InstallWritesCanonicalDelivery(t *testing.T) {
 // is the "reports healthy while delivering nothing" state #1178 is about.
 func TestEndpointArm_UpgradedInPlace(t *testing.T) {
 	h := correctBeaconInstaller()
-	r := addressFreeRules(t, h)
-
-	t.Run("a_correct_installer_passes", func(t *testing.T) {
-		h := correctBeaconInstaller()
-		mustBeSilent(t, observe(t, func(at armT) { assertUpgradedInPlace(at, h, r) }),
-			"an installer that repoints a foreign entry in place")
-	})
+	r := rulesFor(t, h)
 
 	t.Run("a_foreign_entry_is_left_alone", func(t *testing.T) {
 		mutated := correctBeaconInstaller()
@@ -342,7 +316,7 @@ func TestEndpointArm_UpgradedInPlace(t *testing.T) {
 				cfg.IsCanonical = func(map[string]interface{}) bool { return true }
 			}, hookjson.EnsureInstalled)
 		}
-		rec := observe(t, func(at armT) { assertUpgradedInPlace(at, mutated, r) })
+		rec := observe(t, func(at armT) { assertUpgradedInPlace(at, mutated, r, mutated.SettingsPath(t)) })
 		mustReport(t, rec, "expected modified=true when repointing",
 			"an IsCanonical that never checks the binary path, so an entry naming a since-deleted "+
 				"irrlichd is accepted as current (M3a)")
@@ -357,13 +331,7 @@ func TestEndpointArm_UpgradedInPlace(t *testing.T) {
 // --uninstall-hooks, so the entry commonly outlives the path it names.
 func TestEndpointArm_UninstallIsNotForeignScoped(t *testing.T) {
 	h := correctBeaconInstaller()
-	r := addressFreeRules(t, h)
-
-	t.Run("a_correct_uninstall_passes", func(t *testing.T) {
-		h := correctBeaconInstaller()
-		mustBeSilent(t, observe(t, func(at armT) { assertUninstallIsNotForeignScoped(at, h, r) }),
-			"an uninstall matched by a binary-independent sentinel")
-	})
+	r := rulesFor(t, h)
 
 	t.Run("uninstall_scoped_to_the_running_binary", func(t *testing.T) {
 		mutated := correctBeaconInstaller()
@@ -373,7 +341,7 @@ func TestEndpointArm_UninstallIsNotForeignScoped(t *testing.T) {
 				cfg.Sentinel = cfg.Entry()["command"].(string)
 			}, hookjson.Uninstall)
 		}
-		rec := observe(t, func(at armT) { assertUninstallIsNotForeignScoped(at, mutated, r) })
+		rec := observe(t, func(at armT) { assertUninstallIsNotForeignScoped(at, mutated, r, mutated.SettingsPath(t)) })
 		mustReport(t, rec, "expected modified=true removing",
 			"an Uninstall whose sentinel names the running binary, so another daemon's entries survive (M4)")
 	})
@@ -385,7 +353,7 @@ func TestEndpointArm_UninstallIsNotForeignScoped(t *testing.T) {
 // than graded on two obligations that cannot run (PR #1473 M5c).
 func TestEndpointRulesFor(t *testing.T) {
 	t.Run("address_free_without_a_foreign_seed_is_refused", func(t *testing.T) {
-		h := entryInstaller(t, DeliveryAddressFree, correctURLDelivery)
+		h := entryInstaller(DeliveryAddressFree, correctURLDelivery)
 		h.ForeignInstall = nil
 		mustReport(t, observe(t, func(at armT) { rulesFor(at, h) }),
 			"DeliveryAddressFree requires ForeignInstall",
@@ -393,7 +361,7 @@ func TestEndpointRulesFor(t *testing.T) {
 	})
 
 	t.Run("an_unknown_route_is_refused", func(t *testing.T) {
-		h := entryInstaller(t, DeliveryMode(99), correctURLDelivery)
+		h := entryInstaller(DeliveryMode(99), correctURLDelivery)
 		mustReport(t, observe(t, func(at armT) { rulesFor(at, h) }),
 			"unhandled DeliveryMode",
 			"a delivery mode naming no obligation set — a third route added without saying "+
@@ -412,7 +380,7 @@ func TestEndpointRulesFor(t *testing.T) {
 // "the run failed incidentally elsewhere" shape this file exists to refuse.
 func TestEndpointArm_SecondAssertions(t *testing.T) {
 	h := correctBeaconInstaller()
-	r := addressFreeRules(t, h)
+	r := rulesFor(t, h)
 
 	// Obligation 3's second claim: repointed IN PLACE, not appended beside the
 	// foreign entry. A sentinel that does not match what the seed wrote means
@@ -426,7 +394,7 @@ func TestEndpointArm_SecondAssertions(t *testing.T) {
 				cfg.Sentinel = "not-the-sentinel-the-seed-wrote"
 			}, hookjson.EnsureInstalled)
 		}
-		rec := observe(t, func(at armT) { assertUpgradedInPlace(at, mutated, r) })
+		rec := observe(t, func(at armT) { assertUpgradedInPlace(at, mutated, r, mutated.SettingsPath(t)) })
 		mustReport(t, rec, "expected exactly 1 matcher group",
 			"an install that appends a second group beside the foreign entry instead of "+
 				"repointing it (M3b)")
@@ -438,7 +406,7 @@ func TestEndpointArm_SecondAssertions(t *testing.T) {
 	t.Run("uninstall_reports_success_but_removes_nothing", func(t *testing.T) {
 		mutated := correctBeaconInstaller()
 		mutated.Uninstall = func() (bool, error) { return true, nil }
-		rec := observe(t, func(at armT) { assertUninstallIsNotForeignScoped(at, mutated, r) })
+		rec := observe(t, func(at armT) { assertUninstallIsNotForeignScoped(at, mutated, r, mutated.SettingsPath(t)) })
 		mustReport(t, rec, "survived uninstall",
 			"an Uninstall that reports modified=true and leaves every entry in place")
 	})
@@ -456,25 +424,23 @@ func TestEndpointArm_SecondAssertions(t *testing.T) {
 			}
 			return true, nil
 		}
-		rec := observe(t, func(at armT) { assertInstallWritesCanonicalDelivery(at, mutated, r) })
+		rec := observe(t, func(at armT) { assertInstallWritesCanonicalDelivery(at, mutated, r, mutated.SettingsPath(t)) })
 		mustReport(t, rec, "second install on the same bind address",
 			"an installer that reports modified=true every time it runs")
 	})
 }
 
-// beaconRunWith builds the reference beacon's config, applies one deliberate
-// deviation, and hands it to op — so each mutation above states its deviation
-// as one line rather than restating the whole config.
+// beaconRunWith is referenceBeaconRun with one deliberate deviation applied, so
+// each mutation states its deviation as a single line and inherits every other
+// field from the reference config — a new required hookjson.Config field then
+// reaches these mutations as well as the real contract test.
 func beaconRunWith(mutate func(*hookjson.Config), op func(hookjson.Config) (bool, error)) (bool, error) {
-	path, err := referenceBeaconHooksPath()
-	if err != nil {
-		return false, err
-	}
 	command, err := hookbeacon.InstalledCommand(referenceBeaconAdapter)
 	if err != nil {
 		return false, err
 	}
-	cfg := referenceBeaconConfig(path, command)
-	mutate(&cfg)
-	return op(cfg)
+	return referenceBeaconRun(command, func(cfg hookjson.Config) (bool, error) {
+		mutate(&cfg)
+		return op(cfg)
+	})
 }

--- a/core/internal/contracttesting/hook_endpoint_selftest_test.go
+++ b/core/internal/contracttesting/hook_endpoint_selftest_test.go
@@ -14,7 +14,16 @@
 //
 // Obligations 2-4 are the same code in both delivery routes (only the address
 // assertion and the seed differ — see deliveryRules), so they are driven once
-// here, through the reference beacon installer, and cover both.
+// here, through the reference beacon installer, and cover both. Each of those
+// three makes TWO claims, and the second of each is covered separately in
+// TestEndpointArm_SecondAssertions — an installer can satisfy "writes the
+// canonical line" while rewriting on every start, or "reports modified" while
+// removing nothing.
+//
+// A fixture here is wrong in one way, which is not the same as reddening one
+// assertion: a non-idempotent install also trips the delivery comparison. That
+// is what mustReport's required message fragment is for — it grades WHICH
+// assertion fired, not merely that something did.
 package contracttesting
 
 import (
@@ -329,17 +338,9 @@ func TestEndpointArm_UpgradedInPlace(t *testing.T) {
 		// install is already "ours and current" and EnsureInstalled does
 		// nothing.
 		mutated.EnsureInstalled = func() (bool, error) {
-			path, err := referenceBeaconHooksPath()
-			if err != nil {
-				return false, err
-			}
-			command, err := hookbeacon.InstalledCommand(referenceBeaconAdapter)
-			if err != nil {
-				return false, err
-			}
-			cfg := referenceBeaconConfig(path, command)
-			cfg.IsCanonical = func(map[string]interface{}) bool { return true }
-			return hookjson.EnsureInstalled(cfg)
+			return beaconRunWith(func(cfg *hookjson.Config) {
+				cfg.IsCanonical = func(map[string]interface{}) bool { return true }
+			}, hookjson.EnsureInstalled)
 		}
 		rec := observe(t, func(at armT) { assertUpgradedInPlace(at, mutated, r) })
 		mustReport(t, rec, "expected modified=true when repointing",
@@ -367,17 +368,10 @@ func TestEndpointArm_UninstallIsNotForeignScoped(t *testing.T) {
 	t.Run("uninstall_scoped_to_the_running_binary", func(t *testing.T) {
 		mutated := correctBeaconInstaller()
 		mutated.Uninstall = func() (bool, error) {
-			path, err := referenceBeaconHooksPath()
-			if err != nil {
-				return false, err
-			}
-			command, err := hookbeacon.InstalledCommand(referenceBeaconAdapter)
-			if err != nil {
-				return false, err
-			}
-			cfg := referenceBeaconConfig(path, command)
-			cfg.Sentinel = command // the whole command, so a foreign binary's entry no longer matches
-			return hookjson.Uninstall(cfg)
+			return beaconRunWith(func(cfg *hookjson.Config) {
+				// The whole command, so a foreign binary's entry no longer matches.
+				cfg.Sentinel = cfg.Entry()["command"].(string)
+			}, hookjson.Uninstall)
 		}
 		rec := observe(t, func(at armT) { assertUninstallIsNotForeignScoped(at, mutated, r) })
 		mustReport(t, rec, "expected modified=true removing",
@@ -405,4 +399,82 @@ func TestEndpointRulesFor(t *testing.T) {
 			"a delivery mode naming no obligation set — a third route added without saying "+
 				"which obligations it runs")
 	})
+}
+
+// TestEndpointArm_SecondAssertions covers the half of obligations 2, 3 and 4
+// that the mutations above leave untouched. Each of those obligations makes two
+// claims, and only the first was graded — measured in review of PR #1498, where
+// neutering each of these three left the whole suite green.
+//
+// They are grouped rather than folded into the tests above because each needs a
+// fixture that is CORRECT on the first claim and wrong only on the second;
+// mixing them into one installer would grade two things at once, which is the
+// "the run failed incidentally elsewhere" shape this file exists to refuse.
+func TestEndpointArm_SecondAssertions(t *testing.T) {
+	h := correctBeaconInstaller()
+	r := addressFreeRules(t, h)
+
+	// Obligation 3's second claim: repointed IN PLACE, not appended beside the
+	// foreign entry. A sentinel that does not match what the seed wrote means
+	// EnsureInstalled does not recognize the entry as ours, so it adds a second
+	// matcher group — reported modified=true, and the user's config now carries
+	// two of our hooks, one of them dead. This is #1178's actual damage shape.
+	t.Run("upgrade_appends_a_duplicate_group", func(t *testing.T) {
+		mutated := correctBeaconInstaller()
+		mutated.EnsureInstalled = func() (bool, error) {
+			return beaconRunWith(func(cfg *hookjson.Config) {
+				cfg.Sentinel = "not-the-sentinel-the-seed-wrote"
+			}, hookjson.EnsureInstalled)
+		}
+		rec := observe(t, func(at armT) { assertUpgradedInPlace(at, mutated, r) })
+		mustReport(t, rec, "expected exactly 1 matcher group",
+			"an install that appends a second group beside the foreign entry instead of "+
+				"repointing it (M3b)")
+	})
+
+	// Obligation 4's second claim: the entries are actually GONE. Reporting
+	// modified=true while removing nothing is the shape a caller cannot detect —
+	// `--uninstall-hooks` prints success over a config it did not change.
+	t.Run("uninstall_reports_success_but_removes_nothing", func(t *testing.T) {
+		mutated := correctBeaconInstaller()
+		mutated.Uninstall = func() (bool, error) { return true, nil }
+		rec := observe(t, func(at armT) { assertUninstallIsNotForeignScoped(at, mutated, r) })
+		mustReport(t, rec, "survived uninstall",
+			"an Uninstall that reports modified=true and leaves every entry in place")
+	})
+
+	// Obligation 2's second claim: idempotency. An install that rewrites on every
+	// daemon start churns the user's config forever and makes "modified" useless
+	// as a signal that anything actually changed.
+	t.Run("install_is_not_idempotent", func(t *testing.T) {
+		mutated := correctBeaconInstaller()
+		mutated.EnsureInstalled = func() (bool, error) {
+			// Writes the canonical delivery, so the first claim still holds and
+			// only idempotency is wrong.
+			if _, err := referenceBeaconEnsureInstalled(); err != nil {
+				return false, err
+			}
+			return true, nil
+		}
+		rec := observe(t, func(at armT) { assertInstallWritesCanonicalDelivery(at, mutated, r) })
+		mustReport(t, rec, "second install on the same bind address",
+			"an installer that reports modified=true every time it runs")
+	})
+}
+
+// beaconRunWith builds the reference beacon's config, applies one deliberate
+// deviation, and hands it to op — so each mutation above states its deviation
+// as one line rather than restating the whole config.
+func beaconRunWith(mutate func(*hookjson.Config), op func(hookjson.Config) (bool, error)) (bool, error) {
+	path, err := referenceBeaconHooksPath()
+	if err != nil {
+		return false, err
+	}
+	command, err := hookbeacon.InstalledCommand(referenceBeaconAdapter)
+	if err != nil {
+		return false, err
+	}
+	cfg := referenceBeaconConfig(path, command)
+	mutate(&cfg)
+	return op(cfg)
 }

--- a/core/internal/contracttesting/hook_version.go
+++ b/core/internal/contracttesting/hook_version.go
@@ -173,12 +173,24 @@ func assertFloorRefusesOlder(t reporter, gate *agent.VersionGate) {
 		t.Errorf("gate refuses its own floor %s — the comparison is exclusive where it "+
 			"should be inclusive", gate.Min)
 	}
+	// A floor with nothing below it exercises NOTHING: predecessors is empty,
+	// the loop never runs, and the arm passes having asserted only that the
+	// gate permits its own floor. Every other value of Min makes the loop run,
+	// so this is the one input under which the obligation silently stops
+	// discriminating — found by writing this family's negative self-tests
+	// (#1479), which could otherwise not make this arm fail at all.
+	below := predecessors(floor)
+	if len(below) == 0 {
+		t.Errorf("declared floor %s has no version below it, so this obligation asserts "+
+			"nothing — a floor of %s permits every CLI and is not a gate", gate.Min, gate.Min)
+		return
+	}
 	// Each field decremented independently rather than one synthetic
 	// predecessor: a single "just below" value like 0.99.99 exercises only the
 	// borrow path, so a comparison that is correct there and off by one at the
 	// major boundary would still pass. These are the three boundaries a
 	// field-wise comparison can get wrong.
-	for _, older := range predecessors(floor) {
+	for _, older := range below {
 		allowed, why := gate.Permits(older.String())
 		if allowed {
 			t.Errorf("gate permits %s, below the declared floor %s", older, gate.Min)

--- a/core/internal/contracttesting/hook_version.go
+++ b/core/internal/contracttesting/hook_version.go
@@ -16,6 +16,7 @@
 package contracttesting
 
 import (
+	"fmt"
 	"slices"
 	"strings"
 	"testing"
@@ -46,21 +47,10 @@ type HookVersionGate struct {
 func AssertHookVersionGate(t *testing.T, g HookVersionGate) {
 	t.Helper()
 
-	perm, ok := findPermission(g.Agent, g.PermissionKey)
-	if !ok {
-		t.Fatalf("agent %q declares no permission with key %q", g.Agent.Identity.Name, g.PermissionKey)
+	gate, reason := versionGateUnderTest(g)
+	if reason != "" {
+		t.Fatal(reason)
 	}
-	if perm.Writes == nil {
-		t.Fatalf("permission %q declares no agent.ManagedUserFile — a hooks permission must, "+
-			"so that --uninstall-hooks and the version gate can both see it", g.PermissionKey)
-	}
-	if perm.Writes.Version == nil || perm.Writes.Version.Min == "" {
-		t.Fatalf("hooks permission %q declares no minimum CLI version (#1365) — an adapter "+
-			"that installs into an agent's config at any version writes entries an older CLI "+
-			"may reject, and the user sees a granted permission whose channel never fires",
-			g.PermissionKey)
-	}
-	gate := perm.Writes.Version
 
 	t.Run("floor_is_parseable", func(t *testing.T) {
 		assertFloorParses(t, gate.Min)
@@ -75,19 +65,52 @@ func AssertHookVersionGate(t *testing.T, g HookVersionGate) {
 		assertUnknownFailsOpen(t, gate)
 	})
 	t.Run("version_source_is_declared", func(t *testing.T) {
-		if gate.Observed == nil && len(gate.Probe) == 0 {
-			t.Errorf("hooks permission %q declares a floor of %q but no way to learn the "+
-				"installed version — neither Observed nor Probe — so the gate can never "+
-				"refuse anything and reads as protection that isn't there",
-				g.PermissionKey, gate.Min)
-		}
+		assertVersionSourceDeclared(t, g.PermissionKey, gate)
 	})
+}
+
+// versionGateUnderTest returns the declared gate the contract grades, or a
+// reason it cannot grade one. It reports a reason rather than failing so the
+// shapes it rejects are themselves drivable from a negative self-test — the
+// same split malformedGateReason draws.
+func versionGateUnderTest(g HookVersionGate) (*agent.VersionGate, string) {
+	perm, ok := findPermission(g.Agent, g.PermissionKey)
+	if !ok {
+		return nil, fmt.Sprintf("agent %q declares no permission with key %q",
+			g.Agent.Identity.Name, g.PermissionKey)
+	}
+	if perm.Writes == nil {
+		return nil, fmt.Sprintf("permission %q declares no agent.ManagedUserFile — a hooks "+
+			"permission must, so that --uninstall-hooks and the version gate can both see it",
+			g.PermissionKey)
+	}
+	if perm.Writes.Version == nil || perm.Writes.Version.Min == "" {
+		return nil, fmt.Sprintf("hooks permission %q declares no minimum CLI version (#1365) — "+
+			"an adapter that installs into an agent's config at any version writes entries an "+
+			"older CLI may reject, and the user sees a granted permission whose channel never fires",
+			g.PermissionKey)
+	}
+	return perm.Writes.Version, ""
+}
+
+// assertVersionSourceDeclared is the arm that keeps a floor from being
+// decorative: claudecode's was probe-only, and the daemon runs under launchd
+// with a minimal PATH, so the probe always missed, unknown failed open, and no
+// version was ever checked.
+func assertVersionSourceDeclared(t reporter, key string, gate *agent.VersionGate) {
+	t.Helper()
+	if gate.Observed == nil && len(gate.Probe) == 0 {
+		t.Errorf("hooks permission %q declares a floor of %q but no way to learn the "+
+			"installed version — neither Observed nor Probe — so the gate can never "+
+			"refuse anything and reads as protection that isn't there",
+			key, gate.Min)
+	}
 }
 
 // assertFloorParses rejects a floor the comparison cannot read. An unparseable
 // floor fails open on every comparison, so the declaration would look like a
 // gate while gating nothing — the failure mode this whole family is about.
-func assertFloorParses(t *testing.T, min string) {
+func assertFloorParses(t reporter, min string) {
 	t.Helper()
 	if _, ok := cliversion.Parse(min); !ok {
 		t.Errorf("declared minimum version %q is not a major.minor.patch triple; "+
@@ -98,7 +121,7 @@ func assertFloorParses(t *testing.T, min string) {
 // assertFloorCoversEveryEvent is the scope-item-2 arm: the floor must dominate
 // every installed event's own introduction, so that at any version where the
 // adapter installs at all, every entry it writes names an event the CLI knows.
-func assertFloorCoversEveryEvent(t *testing.T, min string, installed []string, since map[string]string) {
+func assertFloorCoversEveryEvent(t reporter, min string, installed []string, since map[string]string) {
 	t.Helper()
 	if len(installed) == 0 {
 		t.Fatal("HookVersionGate.Installed is empty — pass the installer's event list")
@@ -118,7 +141,7 @@ func assertFloorCoversEveryEvent(t *testing.T, min string, installed []string, s
 // A missing or unparseable Since is reported rather than skipped: an event
 // with no stated version is one nobody checked, which is the position
 // claudecode's seven-event install was in before #1365.
-func assertFloorCoversEvent(t *testing.T, min, event, since string) {
+func assertFloorCoversEvent(t reporter, min, event, since string) {
 	t.Helper()
 	if since == "" {
 		t.Errorf("no Since entry for installed event %q — every event written into the "+
@@ -140,7 +163,7 @@ func assertFloorCoversEvent(t *testing.T, min, event, since string) {
 // assertFloorRefusesOlder proves the declaration actually blocks, rather than
 // merely being present. It walks one patch level below the floor, which is the
 // boundary an off-by-one in a comparison shows up at.
-func assertFloorRefusesOlder(t *testing.T, gate *agent.VersionGate) {
+func assertFloorRefusesOlder(t reporter, gate *agent.VersionGate) {
 	t.Helper()
 	floor, ok := cliversion.Parse(gate.Min)
 	if !ok {
@@ -199,7 +222,7 @@ func predecessors(v cliversion.Version) []cliversion.Version {
 // flipping the default to fail-closed — which would silently disable hooks for
 // every user whose binary the daemon's PATH cannot reach — cannot happen
 // quietly.
-func assertUnknownFailsOpen(t *testing.T, gate *agent.VersionGate) {
+func assertUnknownFailsOpen(t reporter, gate *agent.VersionGate) {
 	t.Helper()
 	for _, unknown := range []string{"", "not a version", "2.1"} {
 		if allowed, why := gate.Permits(unknown); !allowed {

--- a/core/internal/contracttesting/hook_version_selftest_test.go
+++ b/core/internal/contracttesting/hook_version_selftest_test.go
@@ -43,13 +43,21 @@ func selfTestSince() map[string]string {
 	}
 }
 
+// selfTestGate is the gate a correct adapter declares: a parseable floor and a
+// way to learn the installed version. Shared with the disclosure family's
+// fixture, so the floor those tests expect the consent copy to state is the
+// same value this family grades.
+func selfTestGate() *agent.VersionGate {
+	return &agent.VersionGate{
+		Min:   selfTestFloor,
+		Probe: []string{selfTestCLIName, "--version"},
+	}
+}
+
 // correctVersionGate is a wiring that satisfies all five obligations. Each
 // mutation below overrides exactly one thing.
 func correctVersionGate() HookVersionGate {
-	return versionGateWith(&agent.VersionGate{
-		Min:   selfTestFloor,
-		Probe: []string{selfTestCLIName, "--version"},
-	})
+	return versionGateWith(selfTestGate())
 }
 
 func versionGateWith(gate *agent.VersionGate) HookVersionGate {
@@ -196,7 +204,7 @@ func TestVersionArm_FloorRefusesAnOlderCLI(t *testing.T) {
 // only that the direction still holds, and says out loud that that is all it
 // asserts.
 func TestVersionArm_UnknownVersionFailsOpen_IsALock(t *testing.T) {
-	gate := &agent.VersionGate{Min: selfTestFloor, Probe: []string{selfTestCLIName, "--version"}}
+	gate := selfTestGate()
 	for _, unknown := range []string{"", "not a version", "2.1"} {
 		if allowed, why := gate.Permits(unknown); !allowed {
 			t.Fatalf("unknown version %q was refused (%s) — the fail-open direction has been "+

--- a/core/internal/contracttesting/hook_version_selftest_test.go
+++ b/core/internal/contracttesting/hook_version_selftest_test.go
@@ -1,0 +1,251 @@
+// hook_version_selftest_test.go is the committed mutation evidence for
+// AssertHookVersionGate (#1365), and it is the one family where most of it had
+// to be RE-DERIVED rather than transcribed: PR #1393 carries red-first defect
+// tests against the two live adapters but no per-obligation mutation table, so
+// four of the five arms had no recorded evidence that they can fail (#1479).
+//
+// Writing them found something. Two of this family's five obligations do not
+// grade the ADAPTER at all — they grade agent.VersionGate.Permits, which is
+// domain code every wiring shares — so no wrong wiring can make them fail:
+//
+//   - floor_refuses_an_older_cli was reachable only through Min, and for every
+//     parseable Min above 0.0.0 the domain answers correctly. At Min = "0.0.0"
+//     it answered nothing at all: predecessors() is empty, the loop that proves
+//     the gate blocks never ran, and the arm passed having asserted only that
+//     the gate permits its own floor. That is now a reported failure
+//     (assertFloorRefusesOlder), and TestVersionArm_FloorRefusesAnOlderCLI is
+//     the mutation for it.
+//   - unknown_version_fails_open is a LOCK by its own doc comment: it pins the
+//     direction chosen in cliversion.AtLeast and passes by construction. Its
+//     mutation is in the domain, not here — PR #1393's review made AtLeast fail
+//     CLOSED and the arm went red in both adapters — and AGENTS.md's Testing
+//     section is explicit that a lock's green is not evidence. It is named in
+//     TestVersionArm_UnknownVersionFailsOpen_IsALock rather than given a
+//     wiring mutation that does not exist.
+package contracttesting
+
+import (
+	"testing"
+
+	"irrlicht/core/domain/agent"
+	"irrlicht/core/domain/permission"
+)
+
+const selfTestVersionAgent = "selftest-version"
+
+// selfTestSince is the provenance map a correct adapter declares: every
+// installed event, at or below the floor.
+func selfTestSince() map[string]string {
+	return map[string]string{
+		"SessionStart": "2.1.0",
+		"PostToolUse":  "2.1.0",
+		"Notification": selfTestFloor,
+	}
+}
+
+// correctVersionGate is a wiring that satisfies all five obligations. Each
+// mutation below overrides exactly one thing.
+func correctVersionGate() HookVersionGate {
+	return versionGateWith(&agent.VersionGate{
+		Min:   selfTestFloor,
+		Probe: []string{selfTestCLIName, "--version"},
+	})
+}
+
+func versionGateWith(gate *agent.VersionGate) HookVersionGate {
+	return HookVersionGate{
+		Agent: agent.Agent{
+			Identity: agent.Identity{Name: selfTestVersionAgent},
+			Permissions: []agent.Permission{{
+				Key:    agent.HooksPermissionKey,
+				Kind:   permission.KindModify,
+				Apply:  func() error { return nil },
+				Writes: &agent.ManagedUserFile{Version: gate},
+			}},
+		},
+		PermissionKey: agent.HooksPermissionKey,
+		Installed:     selfTestInstalledEvents,
+		Since:         selfTestSince(),
+	}
+}
+
+// TestVersionArms_PassACorrectDeclaration is the family's vacuity guard: an arm
+// that reported unconditionally would satisfy every mutation below.
+func TestVersionArms_PassACorrectDeclaration(t *testing.T) {
+	g := correctVersionGate()
+	gate, reason := versionGateUnderTest(g)
+	if reason != "" {
+		t.Fatalf("a well-formed wiring was rejected: %s", reason)
+	}
+
+	for name, arm := range map[string]func(armT){
+		"floor_is_parseable": func(at armT) { assertFloorParses(at, gate.Min) },
+		"floor_covers_every_installed_event": func(at armT) {
+			assertFloorCoversEveryEvent(at, gate.Min, g.Installed, g.Since)
+		},
+		"floor_refuses_an_older_cli": func(at armT) { assertFloorRefusesOlder(at, gate) },
+		"unknown_version_fails_open": func(at armT) { assertUnknownFailsOpen(at, gate) },
+		"version_source_is_declared": func(at armT) {
+			assertVersionSourceDeclared(at, g.PermissionKey, gate)
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			mustBeSilent(t, observe(t, arm), "a correct version-gate declaration")
+		})
+	}
+}
+
+// TestVersionArm_FloorIsParseable: a floor the comparison cannot read fails
+// open on every comparison, so the declaration looks like a gate while gating
+// nothing — the failure mode the whole family is about.
+func TestVersionArm_FloorIsParseable(t *testing.T) {
+	for name, min := range map[string]string{
+		"two_field_version": "2.1",
+		"not_a_version":     "latest",
+	} {
+		t.Run(name, func(t *testing.T) {
+			rec := observe(t, func(at armT) { assertFloorParses(at, min) })
+			mustReport(t, rec, "is not a major.minor.patch triple",
+				"a declared floor of "+min+", which cliversion cannot parse")
+		})
+	}
+}
+
+// TestVersionArm_FloorCoversEveryInstalledEvent covers the four ways the floor
+// and the provenance map can disagree. The third is #1365's own shape: an event
+// written into the user's config at a version the CLI does not know it at.
+func TestVersionArm_FloorCoversEveryInstalledEvent(t *testing.T) {
+	cases := map[string]struct {
+		since map[string]string
+		want  string
+		what  string
+	}{
+		"an_installed_event_with_no_provenance": {
+			since: map[string]string{"SessionStart": "2.1.0", "PostToolUse": "2.1.0"},
+			want:  "no Since entry for installed event",
+			what:  "an installed event nobody stated a version for — the position claudecode's seven-event install was in",
+		},
+		"provenance_for_an_event_never_installed": {
+			since: withSince("PreCompact", "2.1.0"),
+			want:  "which is not installed",
+			what:  "a stale Since entry naming an event the installer dropped",
+		},
+		"floor_below_an_installed_events_own_version": {
+			since: withSince("Notification", "9.9.9"),
+			want:  "is below",
+			what:  "a floor lower than the version one installed event is known at (#1365)",
+		},
+		"unparseable_provenance": {
+			since: withSince("Notification", "two point one"),
+			want:  "is not a major.minor.patch triple",
+			what:  "a Since entry the comparison cannot read",
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			rec := observe(t, func(at armT) {
+				assertFloorCoversEveryEvent(at, selfTestFloor, selfTestInstalledEvents, c.since)
+			})
+			mustReport(t, rec, c.want, c.what)
+		})
+	}
+
+	// An empty Installed list is a wiring error, not a satisfied obligation:
+	// without this the arm would pass for an adapter that forgot to pass its
+	// event slice, which is the "nothing to check reads as clean" shape.
+	t.Run("no_installed_events_at_all", func(t *testing.T) {
+		rec := observe(t, func(at armT) {
+			assertFloorCoversEveryEvent(at, selfTestFloor, nil, selfTestSince())
+		})
+		mustReport(t, rec, "Installed is empty", "a wiring that passed no event list")
+	})
+}
+
+// withSince returns the correct provenance map with one entry overridden or
+// added, so each mutation differs from the correct fixture in exactly one key.
+func withSince(event, version string) map[string]string {
+	since := selfTestSince()
+	since[event] = version
+	return since
+}
+
+// TestVersionArm_FloorRefusesAnOlderCLI is the arm's only reachable mutation,
+// and it exists because writing this file found the arm vacuous at a zero
+// floor: predecessors("0.0.0") is empty, so the loop proving the gate blocks
+// never ran and the arm passed having asserted nothing. Every other parseable
+// Min grades agent.VersionGate.Permits — domain code no adapter can get wrong —
+// which is why there is one case here and not four.
+func TestVersionArm_FloorRefusesAnOlderCLI(t *testing.T) {
+	rec := observe(t, func(at armT) {
+		assertFloorRefusesOlder(at, &agent.VersionGate{Min: "0.0.0", Probe: []string{"x", "--version"}})
+	})
+	mustReport(t, rec, "has no version below it",
+		"a floor of 0.0.0 — nothing is below it, so the obligation exercised nothing and passed")
+}
+
+// TestVersionArm_UnknownVersionFailsOpen_IsALock records what this arm is,
+// since a green here would otherwise read as mutation evidence it is not.
+//
+// The arm pins a direction chosen in cliversion.AtLeast: an unknown or
+// unparseable version PERMITS the install, because the daemon runs under
+// launchd with a minimal PATH and routinely cannot probe the user's CLI. No
+// wiring can make it fail — Permits is domain code shared by every adapter —
+// so its mutation lives in the domain, and PR #1393's review ran it: making
+// AtLeast fail CLOSED reddened this arm in both adapters. This test asserts
+// only that the direction still holds, and says out loud that that is all it
+// asserts.
+func TestVersionArm_UnknownVersionFailsOpen_IsALock(t *testing.T) {
+	gate := &agent.VersionGate{Min: selfTestFloor, Probe: []string{selfTestCLIName, "--version"}}
+	for _, unknown := range []string{"", "not a version", "2.1"} {
+		if allowed, why := gate.Permits(unknown); !allowed {
+			t.Fatalf("unknown version %q was refused (%s) — the fail-open direction has been "+
+				"reversed, which disables hooks for every user whose CLI the daemon cannot probe",
+				unknown, why)
+		}
+	}
+}
+
+// TestVersionArm_VersionSourceIsDeclared: a floor with no way to learn the
+// installed version can never refuse anything. claudecode's was probe-only, and
+// under launchd's minimal PATH the probe always missed — protection that was
+// not there.
+func TestVersionArm_VersionSourceIsDeclared(t *testing.T) {
+	rec := observe(t, func(at armT) {
+		assertVersionSourceDeclared(at, agent.HooksPermissionKey, &agent.VersionGate{Min: selfTestFloor})
+	})
+	mustReport(t, rec, "reads as protection that isn't there",
+		"a declared floor with neither Observed nor Probe")
+}
+
+// TestVersionGateUnderTest covers the preconditions, which are the three ways a
+// hooks permission arrives with no floor to grade at all. #1365 was filed
+// because claudecode was in the third state and wrote seven entries at any
+// version.
+func TestVersionGateUnderTest(t *testing.T) {
+	if _, reason := versionGateUnderTest(correctVersionGate()); reason != "" {
+		t.Fatalf("a well-formed wiring was rejected: %s", reason)
+	}
+
+	for name, mutate := range map[string]func(*HookVersionGate){
+		"permission_key_names_nothing": func(g *HookVersionGate) { g.PermissionKey = "no-such-key" },
+		"no_managed_user_file": func(g *HookVersionGate) {
+			g.Agent.Permissions[0].Writes = nil
+		},
+		"no_version_gate": func(g *HookVersionGate) {
+			g.Agent.Permissions[0].Writes = &agent.ManagedUserFile{}
+		},
+		"empty_minimum_version": func(g *HookVersionGate) {
+			g.Agent.Permissions[0].Writes = &agent.ManagedUserFile{Version: &agent.VersionGate{}}
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			g := correctVersionGate()
+			mutate(&g)
+			if _, reason := versionGateUnderTest(g); reason == "" {
+				t.Error("a wiring the contract cannot grade was accepted — it would run five " +
+					"arms against a nil gate")
+			}
+		})
+	}
+}

--- a/core/internal/contracttesting/permission_gate.go
+++ b/core/internal/contracttesting/permission_gate.go
@@ -51,17 +51,6 @@ type PermissionGate struct {
 	Observe func() bool
 }
 
-// gateReporter is the slice of *testing.T the individual arms use. Taking an
-// interface rather than *testing.T is what lets this file's own tests drive an
-// arm against a deliberately mis-gated call site and assert it goes red —
-// a contract assertion passes by construction against a correct adapter, so
-// its whole value is that it can fail, and nothing re-runs evidence that
-// exists only in a merged PR body.
-type gateReporter interface {
-	Helper()
-	Errorf(format string, args ...any)
-}
-
 // AssertPermissionGated runs the issue #797 contract against g: no
 // observable effect while the permission is pending, the effect observable
 // once granted, and the effect undone after a subsequent revoke. Each
@@ -210,7 +199,7 @@ func setEveryKey(g PermissionGate, state permission.State) {
 	}
 }
 
-func assertPendingNoEffect(t gateReporter, g PermissionGate) {
+func assertPendingNoEffect(t reporter, g PermissionGate) {
 	t.Helper()
 	setEveryKey(g, permission.StatePending)
 	g.Exercise()
@@ -219,7 +208,7 @@ func assertPendingNoEffect(t gateReporter, g PermissionGate) {
 	}
 }
 
-func assertGrantedEffectObservable(t gateReporter, g PermissionGate) {
+func assertGrantedEffectObservable(t reporter, g PermissionGate) {
 	t.Helper()
 	setEveryKey(g, permission.StateGranted)
 	g.Exercise()
@@ -228,7 +217,7 @@ func assertGrantedEffectObservable(t gateReporter, g PermissionGate) {
 	}
 }
 
-func assertRevokedEffectUndone(t gateReporter, g PermissionGate) {
+func assertRevokedEffectUndone(t reporter, g PermissionGate) {
 	t.Helper()
 	setEveryKey(g, permission.StateDenied)
 	g.Exercise()
@@ -247,7 +236,7 @@ func assertRevokedEffectUndone(t gateReporter, g PermissionGate) {
 // first would leave such a wiring sitting at "denied" — it would pass, and
 // the contract would once again be satisfiable by exactly the fake that
 // hid #1466.
-func assertGatedOnTheNamedKey(t gateReporter, g PermissionGate) {
+func assertGatedOnTheNamedKey(t reporter, g PermissionGate) {
 	t.Helper()
 	g.SetState(g.Key, permission.StateDenied)
 	for _, k := range g.OtherKeys {

--- a/core/internal/contracttesting/permission_gate_test.go
+++ b/core/internal/contracttesting/permission_gate_test.go
@@ -260,3 +260,47 @@ func TestConsentGate_AnswersPerKey(t *testing.T) {
 		t.Error("denied key reads as granted — the gate is answering key-blind")
 	}
 }
+
+// TestTheLockstepArmsFailABrokenReceiver is the can-fail evidence for the three
+// arms #797/PR #817 shipped. Neither that PR nor #1489 recorded a mutation for
+// them: #1489 measured only that they CANNOT see a wrong-key gate (the test
+// above), and the vacuity guard measures that they pass a correct receiver.
+// Between those two, nothing asserted they can fire at all — which is precisely
+// the property #1479 exists to commit, so covering the fourth arm while leaving
+// the first three uncovered would have been the same gap one level down.
+//
+// Each case is the mis-gating that arm owns, and only that one.
+func TestTheLockstepArmsFailABrokenReceiver(t *testing.T) {
+	t.Run("pending_no_effect", func(t *testing.T) {
+		// No consent check at all: the effect appears while every permission
+		// is still pending, which is a fresh IRRLICHT_HOME on a user's machine.
+		r := &fakeReceiver{gate: NewConsentGate(), gatedOn: nil}
+		rec := observe(t, func(at armT) {
+			assertPendingNoEffect(at, r.gateFor(selfTestTranscripts, selfTestHooks))
+		})
+		mustReport(t, rec, "call site is not consent-gated",
+			"a receiver that dispatches with every permission pending")
+	})
+
+	t.Run("granted_effect_observable", func(t *testing.T) {
+		// Gated on a permission nothing ever grants — the effect never appears,
+		// so a granted permission buys the user nothing.
+		r := &fakeReceiver{gate: NewConsentGate(), gatedOn: []string{"never-granted"}}
+		rec := observe(t, func(at armT) {
+			assertGrantedEffectObservable(at, r.gateFor(selfTestTranscripts, selfTestHooks))
+		})
+		mustReport(t, rec, "effect not observed after granting",
+			"a receiver whose effect never appears however the permission is answered")
+	})
+
+	t.Run("revoked_effect_undone", func(t *testing.T) {
+		// The effect outlives the revoke. For an install-type permission that is
+		// a hook entry left in the user's config after they withdrew consent.
+		r := &fakeReceiver{gate: NewConsentGate(), gatedOn: []string{selfTestTranscripts}}
+		g := r.gateFor(selfTestTranscripts, selfTestHooks)
+		g.Observe = func() bool { return true }
+		rec := observe(t, func(at armT) { assertRevokedEffectUndone(at, g) })
+		mustReport(t, rec, "still observed after revoking",
+			"a receiver whose effect survives the revoke")
+	})
+}

--- a/core/internal/contracttesting/permission_gate_test.go
+++ b/core/internal/contracttesting/permission_gate_test.go
@@ -1,7 +1,6 @@
 package contracttesting
 
 import (
-	"fmt"
 	"strings"
 	"testing"
 
@@ -23,20 +22,6 @@ const (
 	selfTestHooks       = "hooks"
 	selfTestTranscripts = "transcripts"
 )
-
-// recordingReporter captures what an arm reports instead of failing the
-// enclosing test.
-type recordingReporter struct{ errs []string }
-
-func (r *recordingReporter) Helper() {}
-
-func (r *recordingReporter) Errorf(format string, args ...any) {
-	r.errs = append(r.errs, fmt.Sprintf(format, args...))
-}
-
-func (r *recordingReporter) failed() bool { return len(r.errs) > 0 }
-
-func (r *recordingReporter) report() string { return strings.Join(r.errs, "; ") }
 
 // fakeReceiver stands in for a hook receiver: it dispatches only once the
 // consent gate answers granted for every key in gatedOn. gatedOn is the
@@ -143,13 +128,10 @@ func misGatedReceiver() PermissionGate {
 // the one state that separates it from a correct receiver, and the arm must
 // report it.
 func TestKeyIsolationArm_FailsAReceiverGatedOnTheWrongPermission(t *testing.T) {
-	rec := &recordingReporter{}
-	assertGatedOnTheNamedKey(rec, misGatedReceiver())
+	rec := observe(t, func(at armT) { assertGatedOnTheNamedKey(at, misGatedReceiver()) })
 
-	if !rec.failed() {
-		t.Fatal("key-isolation arm passed a receiver gated on \"hooks\" while the key under test " +
-			"was \"transcripts\" — this is exactly the #1466 defect the arm exists to catch")
-	}
+	mustReport(t, rec, "is gated on some OTHER permission",
+		"a receiver gated on \"hooks\" while the key under test is \"transcripts\" — the #1466 defect itself")
 	if !strings.Contains(rec.report(), selfTestTranscripts) {
 		t.Errorf("failure message does not name the key under test: %s", rec.report())
 	}
@@ -162,12 +144,10 @@ func TestKeyIsolationArm_FailsAReceiverGatedOnTheWrongPermission(t *testing.T) {
 func TestKeyIsolationArm_FailsAnUngatedReceiver(t *testing.T) {
 	r := &fakeReceiver{gate: NewConsentGate(), gatedOn: nil}
 
-	rec := &recordingReporter{}
-	assertGatedOnTheNamedKey(rec, r.gateFor(selfTestTranscripts, selfTestHooks))
+	rec := observe(t, func(at armT) { assertGatedOnTheNamedKey(at, r.gateFor(selfTestTranscripts, selfTestHooks)) })
 
-	if !rec.failed() {
-		t.Fatal("key-isolation arm passed a receiver with no consent check at all")
-	}
+	mustReport(t, rec, "is gated on some OTHER permission",
+		"a receiver with no consent check at all")
 }
 
 // TestKeyIsolationArm_FailsAKeyBlindWiring pins the arm's write order, which
@@ -184,13 +164,11 @@ func TestKeyIsolationArm_FailsAKeyBlindWiring(t *testing.T) {
 		gatedOn: []string{selfTestHooks, selfTestTranscripts},
 	}
 
-	rec := &recordingReporter{}
-	assertGatedOnTheNamedKey(rec, r.gateFor(selfTestTranscripts, selfTestHooks))
+	rec := observe(t, func(at armT) { assertGatedOnTheNamedKey(at, r.gateFor(selfTestTranscripts, selfTestHooks)) })
 
-	if !rec.failed() {
-		t.Fatal("key-isolation arm passed a SetState that ignores the key it is handed — " +
-			"the arm must deny the key under test before opening the others")
-	}
+	mustReport(t, rec, "is gated on some OTHER permission",
+		"a SetState that ignores the key it is handed — the arm must deny the key under "+
+			"test BEFORE opening the others, or such a wiring settles at \"denied\" and passes")
 }
 
 // TestTheLockstepArmsCannotSeeAWrongKeyGate is the measured blind spot: the
@@ -208,22 +186,20 @@ func TestTheLockstepArmsCannotSeeAWrongKeyGate(t *testing.T) {
 	// go quietly vacuous: a misGatedReceiver that drifted to correct gating
 	// would satisfy every assertion below while the limitation it documents
 	// went unexamined, and the "retire me" instruction above would never fire.
-	anchor := &recordingReporter{}
-	assertGatedOnTheNamedKey(anchor, misGatedReceiver())
-	if !anchor.failed() {
+	anchor := observe(t, func(at armT) { assertGatedOnTheNamedKey(at, misGatedReceiver()) })
+	if !anchor.reported() {
 		t.Fatal("the fixture is no longer mis-gated — this test would assert nothing about the " +
 			"lockstep arms; fix misGatedReceiver rather than the assertions below")
 	}
 
-	for name, arm := range map[string]func(gateReporter, PermissionGate){
+	for name, arm := range map[string]func(reporter, PermissionGate){
 		"pending_no_effect":         assertPendingNoEffect,
 		"granted_effect_observable": assertGrantedEffectObservable,
 		"revoked_effect_undone":     assertRevokedEffectUndone,
 	} {
 		t.Run(name, func(t *testing.T) {
-			rec := &recordingReporter{}
-			arm(rec, misGatedReceiver())
-			if rec.failed() {
+			rec := observe(t, func(at armT) { arm(at, misGatedReceiver()) })
+			if rec.reported() {
 				t.Fatalf("this arm now catches a wrong-key gate (%s) — retire this test, "+
 					"it documents a limitation that no longer holds", rec.report())
 			}

--- a/core/internal/contracttesting/reporter.go
+++ b/core/internal/contracttesting/reporter.go
@@ -44,17 +44,33 @@ type reporter interface {
 	Fatalf(format string, args ...any)
 }
 
-// armT carries both halves an arm can need: where it REPORTS, which a self-test
-// swaps, and the *testing.T its FIXTURES are built against, which no self-test
-// ever swaps.
+// fixtureT is the slice of *testing.T an arm may use to BUILD state, and it is
+// deliberately reporting-free: it carries Setenv and nothing that can decide a
+// test's verdict.
 //
-// The split is the point. A negative self-test substitutes the reporting so an
-// obligation's failure can be observed instead of failing the run; it must NOT
-// substitute t.TempDir/t.Setenv/t.Cleanup, because a fixture that cannot be
-// built is a real failure of the self-test itself and has to be loud. Folding
-// both into one recorder would swallow setup breakage as if it were the
-// obligation firing — which is the second live instance issue #1479 records
-// (an obligation graded green while the run failed incidentally elsewhere).
+// That narrowing is the whole guarantee. armT has to hand an arm some real
+// *testing.T — env relocation is fixture machinery a recorder must not fake,
+// because a fixture that cannot be built is a real failure and has to be loud,
+// not recorded as the obligation firing (issue #1479's second instance, in
+// miniature). But a bare *testing.T field would also carry Errorf and Fatalf,
+// and an arm reporting through those bypasses the seam entirely: it could no
+// longer be driven by a negative self-test, and nothing would say so.
+//
+// The first draft policed that with an AST tripwire over the package's own
+// sources, including alias tracking for `ft := t.fixtures`. This replaces the
+// guard with a type: `t.fixtures.Fatalf(...)` does not compile, in any
+// spelling. It is the same move #1390 made for hook path confinement, where a
+// wiring obligation ("remember to confine") became a type guarantee
+// ("DecodeConfined cannot decode without a *PathConfiner") — and it is the
+// better half of that trade for the same reason, since a guard is worth only
+// what its deliberate failures prove and a type needs no such proof.
+type fixtureT interface {
+	Setenv(key, value string)
+}
+
+// armT carries both halves an arm can need: where it REPORTS, which a self-test
+// swaps, and the fixture machinery it builds state with, which no self-test
+// ever swaps.
 //
 // Only the hook_endpoint family needs this today; the other arms are pure and
 // take reporter.
@@ -63,10 +79,8 @@ type armT struct {
 	// it did when it held a *testing.T, and armT itself satisfies reporter.
 	reporter
 
-	// fixtures is the real *testing.T. Use it ONLY for fixture machinery.
-	// Reporting through it bypasses the seam and silently un-does this file;
-	// TestNoArmReportsThroughTheFixtureT is the tripwire that says so.
-	fixtures *testing.T
+	// fixtures is reporting-free by type — see fixtureT.
+	fixtures fixtureT
 }
 
 // realT wraps a *testing.T as the arm-facing pair used in production, where

--- a/core/internal/contracttesting/reporter.go
+++ b/core/internal/contracttesting/reporter.go
@@ -1,0 +1,76 @@
+// reporter.go holds the seam every contract family's obligations are driven
+// through, and it exists for the reason issue #1479 was filed: a contract
+// assertion passes by construction against a correct adapter, so its whole
+// value is that it CAN fail — and until this file, the evidence that it can was
+// a paragraph in a merged pull request, re-run by nothing.
+//
+// AGENTS.md requires a new or reworked contract assertion to land with the
+// deliberate mutation seen red for each obligation. That rule works; it caught
+// real vacuity twice in one run (#1453). But its product is prose, so an
+// assertion that silently stops discriminating — a refactor that makes a
+// comparison trivially true, a helper that starts returning the same value on
+// both sides — goes on passing and looks exactly like health. That is the same
+// shape as a linter that fails to run and returns empty (#1423), or a mutation
+// harness that silently stops mutating (#1390, #1450): a verification mechanism
+// must fail loudly when it cannot run.
+//
+// The fix is to let each obligation be driven against a deliberately-wrong
+// fixture and to assert what it reports, WITHOUT failing the enclosing test.
+// That needs one thing from the arms: they report through a narrow interface
+// rather than through *testing.T directly. The seam was introduced for
+// AssertPermissionGated by #1475/PR #1489 (as gateReporter) with exactly this
+// generalization in mind; this file is that generalization.
+//
+// Where the negative self-tests live: <family>_selftest_test.go, one per
+// family, plus selftest_test.go for the harness itself.
+package contracttesting
+
+import "testing"
+
+// reporter is the slice of *testing.T a contract-family arm uses to REPORT.
+//
+// *testing.T satisfies it directly, so a production call site passes t
+// unchanged and no family's exported entry point changes shape. A negative
+// self-test passes a recorder instead, and reads back what the arm said.
+//
+// It is deliberately reporting-only. An arm that needs fixture machinery
+// (t.TempDir, t.Setenv, a *testing.T-typed wiring field) takes armT below,
+// which keeps the two halves separate on purpose — see armT.
+type reporter interface {
+	Helper()
+	Error(args ...any)
+	Errorf(format string, args ...any)
+	Fatal(args ...any)
+	Fatalf(format string, args ...any)
+}
+
+// armT carries both halves an arm can need: where it REPORTS, which a self-test
+// swaps, and the *testing.T its FIXTURES are built against, which no self-test
+// ever swaps.
+//
+// The split is the point. A negative self-test substitutes the reporting so an
+// obligation's failure can be observed instead of failing the run; it must NOT
+// substitute t.TempDir/t.Setenv/t.Cleanup, because a fixture that cannot be
+// built is a real failure of the self-test itself and has to be loud. Folding
+// both into one recorder would swallow setup breakage as if it were the
+// obligation firing — which is the second live instance issue #1479 records
+// (an obligation graded green while the run failed incidentally elsewhere).
+//
+// Only the hook_endpoint family needs this today; the other arms are pure and
+// take reporter.
+type armT struct {
+	// reporter is embedded, so an arm calls t.Helper()/t.Fatalf() exactly as
+	// it did when it held a *testing.T, and armT itself satisfies reporter.
+	reporter
+
+	// fixtures is the real *testing.T. Use it ONLY for fixture machinery.
+	// Reporting through it bypasses the seam and silently un-does this file;
+	// TestNoArmReportsThroughTheFixtureT is the tripwire that says so.
+	fixtures *testing.T
+}
+
+// realT wraps a *testing.T as the arm-facing pair used in production, where
+// both halves are the same object.
+func realT(t *testing.T) armT {
+	return armT{reporter: t, fixtures: t}
+}

--- a/core/internal/contracttesting/selftest_test.go
+++ b/core/internal/contracttesting/selftest_test.go
@@ -18,6 +18,17 @@
 // mutation harness whose mutations silently stopped applying reported "all
 // green" for the two that mattered most.
 //
+// # Why there is no tripwire policing the fixture *testing.T
+//
+// An earlier draft of this file carried an AST walk asserting that no arm
+// reported through armT's fixture field, alias tracking included. It is gone,
+// and its absence is the point: fixtureT (reporter.go) narrows that field to a
+// reporting-free interface, so `t.fixtures.Fatalf(...)` no longer compiles in
+// any spelling. A guard is worth only what its deliberate failures prove, and
+// this one would have shipped without a committed corpus proving it could find
+// anything — in a package whose whole thesis is that such a guard is worth
+// nothing. A type needs no such proof.
+//
 // # Why the harness has a mutation of its own
 //
 // A recorder that stopped observing would be the failure being fixed,
@@ -32,10 +43,6 @@ package contracttesting
 
 import (
 	"fmt"
-	"go/ast"
-	"go/parser"
-	"go/token"
-	"io/fs"
 	"runtime"
 	"strings"
 	"sync"
@@ -48,21 +55,21 @@ import (
 // enclosing test. It is the swappable half of armT; the fixture half stays a
 // real *testing.T, so a fixture that cannot be built still fails loudly.
 type recordingT struct {
-	mu      sync.Mutex
-	errs    []string
-	fatal   bool
-	helpers int
+	mu     sync.Mutex
+	errs   []string
+	fatal  bool
+	marked bool
 }
 
 func newRecordingT() *recordingT { return &recordingT{} }
 
-// Helper is counted rather than ignored, so the tripwire test can confirm the
-// arms still mark themselves — a missing t.Helper() moves a failure's reported
-// line into this file and makes every contract failure point at the harness.
+// Helper is recorded rather than ignored, so the verdicts can confirm the arm
+// marked itself — a missing t.Helper() moves a failure's reported line into
+// this file and makes every contract failure point at the harness.
 func (r *recordingT) Helper() {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	r.helpers++
+	r.marked = true
 }
 
 func (r *recordingT) Error(args ...any) { r.record(fmt.Sprint(args...)) }
@@ -122,7 +129,7 @@ func (r *recordingT) aborted() bool {
 func (r *recordingT) markedHelper() bool {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	return r.helpers > 0
+	return r.marked
 }
 
 // --- driving an arm ---
@@ -150,27 +157,28 @@ func observe(t *testing.T, arm func(armT)) *recordingT {
 // observation is what a self-test reads back off a driven arm. It is an
 // interface so the committed broken recorders below can be substituted for the
 // real one, which is how the harness proves its own verdicts are not vacuous.
+// observation carries three axes, and markedHelper is on the interface rather
+// than probed for with a type assertion on purpose: an optional interface is
+// satisfied by NOT implementing it, so a future observation type would opt out
+// of the helper obligation by omission and nothing would say so. That is the
+// silent-skip shape this package exists to remove, and it must not appear in
+// the harness itself.
+//
+// markedHelper reports whether the arm called t.Helper(). Every contract arm
+// does, first thing, and it is not decoration — without it a failure is
+// attributed to the harness rather than to the wiring that supplied the wrong
+// fixture, so every contract failure in the tree would point here.
 type observation interface {
 	reported() bool
 	report() string
+	markedHelper() bool
 }
 
-// helperMarker is the optional half of an observation: whether the arm called
-// t.Helper(). Every contract arm does, first thing, and it is not decoration —
-// without it a failure is attributed to this file rather than to the wiring
-// that supplied the wrong fixture, so every contract failure in the tree would
-// point at the harness.
-//
-// It is optional because the committed broken recorders below are not arms and
-// have no helper to mark. Checking it in the verdicts rather than in one test
-// is what makes it cover every family at once (review of PR #1498).
-type helperMarker interface{ markedHelper() bool }
-
 // verdictHelperMarked reports why obs shows the arm did not identify itself, or
-// "" when it did or cannot say.
+// "" when it did. Checking it in the verdicts rather than in one test is what
+// makes it cover every family at once (review of PR #1498).
 func verdictHelperMarked(obs observation) string {
-	hm, ok := obs.(helperMarker)
-	if !ok || hm.markedHelper() {
+	if obs.markedHelper() {
 		return ""
 	}
 	return "the arm never called t.Helper() — its failures are attributed to the harness " +
@@ -246,7 +254,6 @@ func mustBeSilent(t *testing.T, obs observation, what string) {
 // itself. The two instances below are the only two ways a recorder can be
 // broken: it can fail to observe, or it can observe indiscriminately.
 type brokenRecorder struct {
-	name string
 	did  bool
 	text string
 }
@@ -255,24 +262,29 @@ func (b brokenRecorder) reported() bool { return b.did }
 
 func (b brokenRecorder) report() string { return b.text }
 
+// markedHelper is true for every fixture below: the helper axis is not what
+// they grade, and stating that explicitly is the point of putting the method on
+// observation rather than leaving it optional.
+func (b brokenRecorder) markedHelper() bool { return true }
+
 var (
 	// deafRecorder records nothing, whatever the arm reports. This is the
 	// failure #1479's acceptance criterion names: "a recording-T that records
 	// nothing would make every negative self-test pass". It does not, and
 	// TestTheVerdictsDependOnWhatTheRecorderSaw is why — but the claim has to
 	// be re-run, not believed.
-	deafRecorder = brokenRecorder{name: "deaf", did: false, text: ""}
+	deafRecorder = brokenRecorder{did: false, text: ""}
 
 	// criesWolfRecorder reports unconditionally, with text that names no
 	// obligation. It is the opposite break and the more dangerous one: it
 	// satisfies "something failed" for every mutation ever written, so a
 	// harness that only asked that question would grade every obligation as
 	// discriminating while none of them did.
-	criesWolfRecorder = brokenRecorder{name: "cries-wolf", did: true, text: "something went wrong"}
+	criesWolfRecorder = brokenRecorder{did: true, text: "something went wrong"}
 
 	// faithfulRecording is what a working recorder produces for the mutation
 	// the two above are graded against: the obligation's own message.
-	faithfulRecording = brokenRecorder{name: "faithful", did: true, text: harnessProbeMessage}
+	faithfulRecording = brokenRecorder{did: true, text: harnessProbeMessage}
 )
 
 // harnessProbeMessage stands in for an obligation's failure text. It is
@@ -397,135 +409,4 @@ func TestTheRecorderObservesWhatAnArmReports(t *testing.T) {
 				"would then be attributed to the harness instead of to the wiring")
 		}
 	})
-}
-
-// TestNoArmReportsThroughTheFixtureT is the tripwire for the one way this seam
-// can be silently un-done: armT carries the real *testing.T so an arm can build
-// fixtures with it, and reporting through that field instead of through the
-// embedded reporter bypasses the recorder entirely. Such an arm cannot be
-// driven by a negative self-test — it would fail the enclosing test — so the
-// mutation evidence would go back to being unrunnable without anything saying
-// so.
-//
-// It reads the package's own non-test sources, because a convention that lives
-// only in a doc comment is the thing this package exists to replace.
-//
-// ALIASES ARE TRACKED, and that is the review finding this shape exists for:
-// matching only the literal `t.fixtures.Fatalf(...)` chain catches the obvious
-// spelling and misses `ft := t.fixtures; ft.Fatalf(...)`, which bypasses the
-// seam exactly as completely. `core/architecture_hookbody_shapes_test.go` pins
-// "an aliased body" as its own corpus case for the same reason.
-func TestNoArmReportsThroughTheFixtureT(t *testing.T) {
-	fset := token.NewFileSet()
-	pkgs, err := parser.ParseDir(fset, ".", func(fi fs.FileInfo) bool {
-		return !strings.HasSuffix(fi.Name(), "_test.go")
-	}, 0)
-	if err != nil {
-		t.Fatalf("parsing the package: %v", err)
-	}
-	if len(pkgs) == 0 {
-		t.Fatal("parsed no packages — this tripwire would pass vacuously")
-	}
-
-	seenArmT := false
-	for _, pkg := range pkgs {
-		for _, file := range pkg.Files {
-			ast.Inspect(file, func(n ast.Node) bool {
-				if id, ok := n.(*ast.Ident); ok && id.Name == armTTypeName {
-					seenArmT = true
-				}
-				fn, ok := n.(*ast.FuncDecl)
-				if !ok || fn.Body == nil {
-					return true
-				}
-				for _, pos := range fixtureReportsIn(fn, aliasesOfFixturesIn(fn)) {
-					t.Errorf("%s: reports through the fixture *testing.T — that bypasses the "+
-						"reporter seam, so this obligation cannot be driven by a negative "+
-						"self-test; report through the embedded reporter and keep .%s for "+
-						"fixture machinery only", fset.Position(pos), fixtureFieldName)
-				}
-				return true
-			})
-		}
-	}
-	if !seenArmT {
-		t.Fatalf("the package no longer mentions %s — this tripwire is scanning for a shape "+
-			"that has been renamed, and would pass whatever the sources do", armTTypeName)
-	}
-}
-
-const (
-	fixtureFieldName = "fixtures"
-	armTTypeName     = "armT"
-)
-
-// reportingMethods are the *testing.T methods that decide a test's verdict. An
-// arm may reach the fixture T for t.TempDir/t.Setenv/t.Cleanup and for the
-// *testing.T-typed wiring fields; these are the ones it may not.
-var reportingMethods = map[string]bool{
-	"Error": true, "Errorf": true, "Fatal": true, "Fatalf": true, "Skip": true, "Skipf": true,
-}
-
-// aliasesOfFixturesIn returns the local names bound to something's .fixtures
-// field anywhere in fn — `ft := t.fixtures`, `var ft = at.fixtures`. Scope is
-// deliberately the whole function rather than the exact block: over-approximating
-// makes the tripwire refuse a shape it is not certain about, which is the
-// direction a check that cannot parse its input must degrade in.
-func aliasesOfFixturesIn(fn *ast.FuncDecl) map[string]bool {
-	aliases := map[string]bool{}
-	bind := func(lhs, rhs []ast.Expr) {
-		for i, r := range rhs {
-			if i >= len(lhs) || !isFixtureSelector(r) {
-				continue
-			}
-			if id, ok := lhs[i].(*ast.Ident); ok && id.Name != "_" {
-				aliases[id.Name] = true
-			}
-		}
-	}
-	ast.Inspect(fn.Body, func(n ast.Node) bool {
-		switch v := n.(type) {
-		case *ast.AssignStmt:
-			bind(v.Lhs, v.Rhs)
-		case *ast.ValueSpec:
-			names := make([]ast.Expr, len(v.Names))
-			for i, name := range v.Names {
-				names[i] = name
-			}
-			bind(names, v.Values)
-		}
-		return true
-	})
-	return aliases
-}
-
-// fixtureReportsIn returns the position of every reporting call in fn made
-// through the fixture T, whether spelled directly or through an alias.
-func fixtureReportsIn(fn *ast.FuncDecl, aliases map[string]bool) []token.Pos {
-	var found []token.Pos
-	ast.Inspect(fn.Body, func(n ast.Node) bool {
-		call, ok := n.(*ast.CallExpr)
-		if !ok {
-			return true
-		}
-		sel, ok := call.Fun.(*ast.SelectorExpr)
-		if !ok || !reportingMethods[sel.Sel.Name] {
-			return true
-		}
-		if isFixtureSelector(sel.X) {
-			found = append(found, call.Pos())
-			return true
-		}
-		if id, ok := sel.X.(*ast.Ident); ok && aliases[id.Name] {
-			found = append(found, call.Pos())
-		}
-		return true
-	})
-	return found
-}
-
-// isFixtureSelector reports whether e is a `<something>.fixtures` selection.
-func isFixtureSelector(e ast.Expr) bool {
-	sel, ok := e.(*ast.SelectorExpr)
-	return ok && sel.Sel.Name == fixtureFieldName
 }

--- a/core/internal/contracttesting/selftest_test.go
+++ b/core/internal/contracttesting/selftest_test.go
@@ -1,0 +1,412 @@
+// selftest_test.go is the harness every family's negative self-tests are
+// written against, plus the harness's own deliberate mutation.
+//
+// Each <family>_selftest_test.go drives one obligation against a fixture that
+// is WRONG in exactly one way and asserts the obligation reports it. That turns
+// the mutation evidence AGENTS.md requires — until now a paragraph in a merged
+// PR body, re-run by nothing — into a lock that runs on every build (#1479).
+//
+// # Why an obligation must be named, not merely "something failed"
+//
+// verdictReported takes a fragment of the obligation's OWN failure message and
+// will not accept a bare failure. That is not fussiness: it is the second live
+// instance #1479 records. In #1453, `--port 7837` left the obligation that was
+// supposed to catch it (delivery_carries_no_address) GREEN — the run failed
+// incidentally elsewhere, so that obligation's own power was never
+// demonstrated, and a self-test asserting only "the arm failed" would have
+// certified it. The same trap has a fixture-shaped twin, recorded in #1446: a
+// mutation harness whose mutations silently stopped applying reported "all
+// green" for the two that mattered most.
+//
+// # Why the harness has a mutation of its own
+//
+// A recorder that stopped observing would be the failure being fixed,
+// reproduced inside its own fix. Two broken recorders are therefore COMMITTED
+// below — deafRecorder and criesWolfRecorder — and driven through the same
+// verdict functions the real self-tests use, so the claim "these self-tests
+// depend on what was actually observed" is itself re-run rather than asserted
+// in prose. See TestTheVerdictsDependOnWhatTheRecorderSaw and
+// TestTheRecorderObservesWhatAnArmReports, which cover the two halves: the
+// decision procedure, and the recorder feeding it.
+package contracttesting
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// --- the recorder ---
+
+// recordingT captures what a contract arm reports instead of failing the
+// enclosing test. It is the swappable half of armT; the fixture half stays a
+// real *testing.T, so a fixture that cannot be built still fails loudly.
+type recordingT struct {
+	mu      sync.Mutex
+	errs    []string
+	fatal   bool
+	helpers int
+}
+
+func newRecordingT() *recordingT { return &recordingT{} }
+
+// Helper is counted rather than ignored, so the tripwire test can confirm the
+// arms still mark themselves — a missing t.Helper() moves a failure's reported
+// line into this file and makes every contract failure point at the harness.
+func (r *recordingT) Helper() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.helpers++
+}
+
+func (r *recordingT) Error(args ...any) { r.record(fmt.Sprint(args...)) }
+
+func (r *recordingT) Errorf(format string, args ...any) {
+	r.record(fmt.Sprintf(format, args...))
+}
+
+func (r *recordingT) Fatal(args ...any) {
+	r.record(fmt.Sprint(args...))
+	r.abort()
+}
+
+func (r *recordingT) Fatalf(format string, args ...any) {
+	r.record(fmt.Sprintf(format, args...))
+	r.abort()
+}
+
+func (r *recordingT) record(msg string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.errs = append(r.errs, msg)
+}
+
+// abort reproduces *testing.T's Fatal semantics. A recorder that merely noted
+// the failure and returned would let the arm keep running past a precondition
+// it just declared unmet — so an obligation whose Fatalf guards the assertions
+// below it would be graded on state its own guard rejected.
+func (r *recordingT) abort() {
+	r.mu.Lock()
+	r.fatal = true
+	r.mu.Unlock()
+	runtime.Goexit()
+}
+
+func (r *recordingT) reported() bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.errs) > 0
+}
+
+func (r *recordingT) report() string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return strings.Join(r.errs, "; ")
+}
+
+func (r *recordingT) aborted() bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.fatal
+}
+
+// --- driving an arm ---
+
+// observe runs arm against a recorder and returns what it reported.
+//
+// The goroutine is not incidental: Fatal and Fatalf end in runtime.Goexit, so
+// an arm that hits a fatal must terminate a goroutine that is not the test's.
+// The deferred close runs on that path too, which is what makes an aborted arm
+// observable rather than a hang.
+func observe(t *testing.T, arm func(armT)) *recordingT {
+	t.Helper()
+	rec := newRecordingT()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		arm(armT{reporter: rec, fixtures: t})
+	}()
+	<-done
+	return rec
+}
+
+// --- the verdicts every negative self-test goes through ---
+
+// observation is what a self-test reads back off a driven arm. It is an
+// interface so the committed broken recorders below can be substituted for the
+// real one, which is how the harness proves its own verdicts are not vacuous.
+type observation interface {
+	reported() bool
+	report() string
+}
+
+// verdictReported reports why obs fails to demonstrate that the obligation
+// under test fired, or "" when it does.
+//
+// want is a fragment of that obligation's own failure message. It is required,
+// because "the arm failed" and "this obligation failed" are different claims
+// and only the second is evidence — see the file comment.
+func verdictReported(obs observation, want string) string {
+	if want == "" {
+		return "no expected message fragment was named — a negative self-test that accepts any " +
+			"failure certifies an obligation that may not have run at all (#1453); pass a " +
+			"distinctive fragment of the obligation's own message"
+	}
+	if !obs.reported() {
+		return fmt.Sprintf("the obligation reported nothing against a fixture that is wrong for it — "+
+			"either the fixture is no longer wrong, or the obligation has stopped discriminating "+
+			"(expected a message containing %q)", want)
+	}
+	if !strings.Contains(obs.report(), want) {
+		return fmt.Sprintf("the arm failed, but NOT on the obligation under test: wanted a message "+
+			"containing %q, got: %s", want, obs.report())
+	}
+	return ""
+}
+
+// verdictSilent reports why obs fails to demonstrate that a CORRECT fixture is
+// passed, or "" when it does. Every family needs at least one: without it an
+// obligation that reported unconditionally would satisfy every negative case
+// and read as excellent coverage.
+func verdictSilent(obs observation) string {
+	if obs.reported() {
+		return "the obligation reported against a fixture that is CORRECT for it — an assertion " +
+			"that fires unconditionally satisfies every negative self-test while discriminating " +
+			"nothing: " + obs.report()
+	}
+	return ""
+}
+
+// mustReport fails the enclosing test unless the obligation named by want was
+// the one that fired. what names the mutation, so the failure says which
+// deliberate wrong fixture stopped being caught.
+func mustReport(t *testing.T, obs observation, want, what string) {
+	t.Helper()
+	if v := verdictReported(obs, want); v != "" {
+		t.Fatalf("mutation %q: %s", what, v)
+	}
+}
+
+// mustBeSilent fails the enclosing test unless the obligation passed the
+// correct fixture — the per-family vacuity guard.
+func mustBeSilent(t *testing.T, obs observation, what string) {
+	t.Helper()
+	if v := verdictSilent(obs); v != "" {
+		t.Fatalf("vacuity guard %q: %s", what, v)
+	}
+}
+
+// --- the harness's own deliberate mutation, committed ---
+
+// brokenRecorder is a recorder that does not work, kept in the tree rather than
+// described in a PR body — which is the whole point of #1479 applied to the fix
+// itself. The two instances below are the only two ways a recorder can be
+// broken: it can fail to observe, or it can observe indiscriminately.
+type brokenRecorder struct {
+	name string
+	did  bool
+	text string
+}
+
+func (b brokenRecorder) reported() bool { return b.did }
+
+func (b brokenRecorder) report() string { return b.text }
+
+var (
+	// deafRecorder records nothing, whatever the arm reports. This is the
+	// failure #1479's acceptance criterion names: "a recording-T that records
+	// nothing would make every negative self-test pass". It does not, and
+	// TestTheVerdictsDependOnWhatTheRecorderSaw is why — but the claim has to
+	// be re-run, not believed.
+	deafRecorder = brokenRecorder{name: "deaf", did: false, text: ""}
+
+	// criesWolfRecorder reports unconditionally, with text that names no
+	// obligation. It is the opposite break and the more dangerous one: it
+	// satisfies "something failed" for every mutation ever written, so a
+	// harness that only asked that question would grade every obligation as
+	// discriminating while none of them did.
+	criesWolfRecorder = brokenRecorder{name: "cries-wolf", did: true, text: "something went wrong"}
+
+	// faithfulRecording is what a working recorder produces for the mutation
+	// the two above are graded against: the obligation's own message.
+	faithfulRecording = brokenRecorder{name: "faithful", did: true, text: harnessProbeMessage}
+)
+
+// harnessProbeMessage stands in for an obligation's failure text. It is
+// deliberately not any real obligation's message: the harness is being graded
+// here, not a family.
+const harnessProbeMessage = "effect observed while permission is pending"
+
+// TestTheVerdictsDependOnWhatTheRecorderSaw is the first half of the harness's
+// own mutation proof: the decision procedure every negative self-test runs
+// through, driven against two committed broken recorders.
+//
+// Read the deaf row as the answer to #1479's acceptance criterion. A recorder
+// that stops recording does not make the self-tests pass — it makes
+// verdictReported non-empty, so every one of them goes RED and says the
+// obligation observed nothing. That direction is the safe one, and it is
+// asserted here rather than reasoned about.
+func TestTheVerdictsDependOnWhatTheRecorderSaw(t *testing.T) {
+	t.Run("a_faithful_recording_is_accepted", func(t *testing.T) {
+		if v := verdictReported(faithfulRecording, harnessProbeMessage); v != "" {
+			t.Fatalf("a recorder that saw the obligation's own message was rejected: %s", v)
+		}
+	})
+
+	t.Run("a_deaf_recorder_turns_a_negative_self_test_red", func(t *testing.T) {
+		if verdictReported(deafRecorder, harnessProbeMessage) == "" {
+			t.Fatal("a recorder that records NOTHING was accepted as evidence that an " +
+				"obligation fired — every negative self-test in this package would then pass " +
+				"while observing nothing, which is the failure #1479 exists to remove")
+		}
+	})
+
+	t.Run("a_cries_wolf_recorder_cannot_fake_an_obligation", func(t *testing.T) {
+		if verdictReported(criesWolfRecorder, harnessProbeMessage) == "" {
+			t.Fatal("a recorder that reports unconditionally was accepted as evidence that a " +
+				"SPECIFIC obligation fired — this is #1453's second instance, where a run " +
+				"failed incidentally elsewhere and the obligation was graded on it")
+		}
+	})
+
+	t.Run("a_cries_wolf_recorder_fails_the_vacuity_guard", func(t *testing.T) {
+		if verdictSilent(criesWolfRecorder) == "" {
+			t.Fatal("a recorder that reports unconditionally passed the vacuity guard — the " +
+				"guard is what stops an assertion that fires on everything from looking like " +
+				"coverage")
+		}
+		if verdictSilent(deafRecorder) != "" {
+			t.Fatal("the vacuity guard rejected a silent observation, so no correct fixture " +
+				"could ever pass it")
+		}
+	})
+
+	t.Run("an_unnamed_obligation_is_refused", func(t *testing.T) {
+		if verdictReported(faithfulRecording, "") == "" {
+			t.Fatal("a self-test that named no expected message was accepted — that is the " +
+				"\"any failure will do\" shape #1453's second instance slipped through")
+		}
+	})
+}
+
+// TestTheRecorderObservesWhatAnArmReports is the second half: the real
+// recordingT, driven by arms whose behaviour is known, so that neutering any of
+// its methods goes red here rather than quietly weakening every family.
+func TestTheRecorderObservesWhatAnArmReports(t *testing.T) {
+	t.Run("errorf_is_recorded_and_does_not_abort", func(t *testing.T) {
+		ran := false
+		rec := observe(t, func(at armT) {
+			at.Errorf("probe: %s", "one")
+			ran = true
+		})
+		if !rec.reported() {
+			t.Fatal("Errorf recorded nothing — the recorder is deaf, and every negative " +
+				"self-test in this package is being graded by it")
+		}
+		if !strings.Contains(rec.report(), "probe: one") {
+			t.Fatalf("Errorf lost the message it was handed: %s", rec.report())
+		}
+		if !ran {
+			t.Fatal("Errorf aborted the arm; only Fatal/Fatalf may")
+		}
+	})
+
+	t.Run("fatalf_is_recorded_and_aborts", func(t *testing.T) {
+		past := false
+		rec := observe(t, func(at armT) {
+			at.Fatalf("probe: %s", "fatal")
+			past = true
+		})
+		if !rec.reported() {
+			t.Fatal("Fatalf recorded nothing")
+		}
+		if past {
+			t.Fatal("Fatalf did not abort the arm — an obligation whose fatal guards the " +
+				"assertions below it would then be graded on state its own guard rejected")
+		}
+		if !rec.aborted() {
+			t.Fatal("an aborted arm was not reported as aborted")
+		}
+	})
+
+	t.Run("a_silent_arm_records_nothing", func(t *testing.T) {
+		rec := observe(t, func(armT) {})
+		if rec.reported() {
+			t.Fatalf("a silent arm was reported as failing (%s) — a recorder that reports "+
+				"unconditionally satisfies every mutation case in this package", rec.report())
+		}
+	})
+
+	t.Run("helper_is_still_called_by_arms", func(t *testing.T) {
+		rec := observe(t, func(at armT) { at.Helper() })
+		if rec.helpers == 0 {
+			t.Fatal("Helper was not recorded")
+		}
+	})
+}
+
+// TestNoArmReportsThroughTheFixtureT is the tripwire for the one way this seam
+// can be silently un-done: armT carries the real *testing.T so an arm can build
+// fixtures with it, and reporting through that field instead of through the
+// embedded reporter bypasses the recorder entirely. Such an arm cannot be
+// driven by a negative self-test — it would fail the enclosing test — so the
+// mutation evidence would go back to being unrunnable without anything saying
+// so.
+//
+// It reads the package's own non-test sources, because a convention that lives
+// only in a doc comment is the thing this package exists to replace.
+func TestNoArmReportsThroughTheFixtureT(t *testing.T) {
+	const field = "fixtures"
+	reportingMethods := map[string]bool{
+		"Error": true, "Errorf": true, "Fatal": true, "Fatalf": true, "Skip": true, "Skipf": true,
+	}
+
+	fset := token.NewFileSet()
+	pkgs, err := parser.ParseDir(fset, ".", func(fi fs.FileInfo) bool {
+		return !strings.HasSuffix(fi.Name(), "_test.go")
+	}, 0)
+	if err != nil {
+		t.Fatalf("parsing the package: %v", err)
+	}
+	if len(pkgs) == 0 {
+		t.Fatal("parsed no packages — this tripwire would pass vacuously")
+	}
+
+	seenArmT := false
+	for _, pkg := range pkgs {
+		for _, file := range pkg.Files {
+			ast.Inspect(file, func(n ast.Node) bool {
+				if id, ok := n.(*ast.Ident); ok && id.Name == "armT" {
+					seenArmT = true
+				}
+				call, ok := n.(*ast.CallExpr)
+				if !ok {
+					return true
+				}
+				outer, ok := call.Fun.(*ast.SelectorExpr)
+				if !ok || !reportingMethods[outer.Sel.Name] {
+					return true
+				}
+				inner, ok := outer.X.(*ast.SelectorExpr)
+				if !ok || inner.Sel.Name != field {
+					return true
+				}
+				t.Errorf("%s: reports through .%s.%s — that bypasses the reporter seam, so "+
+					"this obligation cannot be driven by a negative self-test; report through "+
+					"the embedded reporter and keep .%s for fixture machinery only",
+					fset.Position(call.Pos()), field, outer.Sel.Name, field)
+				return true
+			})
+		}
+	}
+	if !seenArmT {
+		t.Fatal("the package no longer mentions armT — this tripwire is scanning for a shape " +
+			"that has been renamed, and would pass whatever the sources do")
+	}
+}

--- a/core/internal/contracttesting/selftest_test.go
+++ b/core/internal/contracttesting/selftest_test.go
@@ -116,6 +116,15 @@ func (r *recordingT) aborted() bool {
 	return r.fatal
 }
 
+// markedHelper reports whether the arm identified itself as a helper. It is
+// read through the mutex like every other field, so the accessor exists rather
+// than the field being touched directly.
+func (r *recordingT) markedHelper() bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.helpers > 0
+}
+
 // --- driving an arm ---
 
 // observe runs arm against a recorder and returns what it reported.
@@ -146,6 +155,28 @@ type observation interface {
 	report() string
 }
 
+// helperMarker is the optional half of an observation: whether the arm called
+// t.Helper(). Every contract arm does, first thing, and it is not decoration —
+// without it a failure is attributed to this file rather than to the wiring
+// that supplied the wrong fixture, so every contract failure in the tree would
+// point at the harness.
+//
+// It is optional because the committed broken recorders below are not arms and
+// have no helper to mark. Checking it in the verdicts rather than in one test
+// is what makes it cover every family at once (review of PR #1498).
+type helperMarker interface{ markedHelper() bool }
+
+// verdictHelperMarked reports why obs shows the arm did not identify itself, or
+// "" when it did or cannot say.
+func verdictHelperMarked(obs observation) string {
+	hm, ok := obs.(helperMarker)
+	if !ok || hm.markedHelper() {
+		return ""
+	}
+	return "the arm never called t.Helper() — its failures are attributed to the harness " +
+		"rather than to the call site that wired the fixture"
+}
+
 // verdictReported reports why obs fails to demonstrate that the obligation
 // under test fired, or "" when it does.
 //
@@ -157,6 +188,9 @@ func verdictReported(obs observation, want string) string {
 		return "no expected message fragment was named — a negative self-test that accepts any " +
 			"failure certifies an obligation that may not have run at all (#1453); pass a " +
 			"distinctive fragment of the obligation's own message"
+	}
+	if v := verdictHelperMarked(obs); v != "" {
+		return v
 	}
 	if !obs.reported() {
 		return fmt.Sprintf("the obligation reported nothing against a fixture that is wrong for it — "+
@@ -175,6 +209,9 @@ func verdictReported(obs observation, want string) string {
 // obligation that reported unconditionally would satisfy every negative case
 // and read as excellent coverage.
 func verdictSilent(obs observation) string {
+	if v := verdictHelperMarked(obs); v != "" {
+		return v
+	}
 	if obs.reported() {
 		return "the obligation reported against a fixture that is CORRECT for it — an assertion " +
 			"that fires unconditionally satisfies every negative self-test while discriminating " +
@@ -343,10 +380,21 @@ func TestTheRecorderObservesWhatAnArmReports(t *testing.T) {
 		}
 	})
 
-	t.Run("helper_is_still_called_by_arms", func(t *testing.T) {
+	// This grades the RECORDER, not the arms: the lambda calls Helper itself.
+	// That arms still call it is graded by verdictHelperMarked, which every
+	// mustReport/mustBeSilent in every family goes through.
+	t.Run("helper_is_recorded", func(t *testing.T) {
 		rec := observe(t, func(at armT) { at.Helper() })
-		if rec.helpers == 0 {
+		if !rec.markedHelper() {
 			t.Fatal("Helper was not recorded")
+		}
+	})
+
+	t.Run("an_arm_that_never_marks_itself_is_reported", func(t *testing.T) {
+		rec := observe(t, func(at armT) { at.Errorf("probe") })
+		if verdictReported(rec, "probe") == "" {
+			t.Fatal("an arm that never called t.Helper() was accepted — every contract failure " +
+				"would then be attributed to the harness instead of to the wiring")
 		}
 	})
 }
@@ -361,12 +409,13 @@ func TestTheRecorderObservesWhatAnArmReports(t *testing.T) {
 //
 // It reads the package's own non-test sources, because a convention that lives
 // only in a doc comment is the thing this package exists to replace.
+//
+// ALIASES ARE TRACKED, and that is the review finding this shape exists for:
+// matching only the literal `t.fixtures.Fatalf(...)` chain catches the obvious
+// spelling and misses `ft := t.fixtures; ft.Fatalf(...)`, which bypasses the
+// seam exactly as completely. `core/architecture_hookbody_shapes_test.go` pins
+// "an aliased body" as its own corpus case for the same reason.
 func TestNoArmReportsThroughTheFixtureT(t *testing.T) {
-	const field = "fixtures"
-	reportingMethods := map[string]bool{
-		"Error": true, "Errorf": true, "Fatal": true, "Fatalf": true, "Skip": true, "Skipf": true,
-	}
-
 	fset := token.NewFileSet()
 	pkgs, err := parser.ParseDir(fset, ".", func(fi fs.FileInfo) bool {
 		return !strings.HasSuffix(fi.Name(), "_test.go")
@@ -382,31 +431,101 @@ func TestNoArmReportsThroughTheFixtureT(t *testing.T) {
 	for _, pkg := range pkgs {
 		for _, file := range pkg.Files {
 			ast.Inspect(file, func(n ast.Node) bool {
-				if id, ok := n.(*ast.Ident); ok && id.Name == "armT" {
+				if id, ok := n.(*ast.Ident); ok && id.Name == armTTypeName {
 					seenArmT = true
 				}
-				call, ok := n.(*ast.CallExpr)
-				if !ok {
+				fn, ok := n.(*ast.FuncDecl)
+				if !ok || fn.Body == nil {
 					return true
 				}
-				outer, ok := call.Fun.(*ast.SelectorExpr)
-				if !ok || !reportingMethods[outer.Sel.Name] {
-					return true
+				for _, pos := range fixtureReportsIn(fn, aliasesOfFixturesIn(fn)) {
+					t.Errorf("%s: reports through the fixture *testing.T — that bypasses the "+
+						"reporter seam, so this obligation cannot be driven by a negative "+
+						"self-test; report through the embedded reporter and keep .%s for "+
+						"fixture machinery only", fset.Position(pos), fixtureFieldName)
 				}
-				inner, ok := outer.X.(*ast.SelectorExpr)
-				if !ok || inner.Sel.Name != field {
-					return true
-				}
-				t.Errorf("%s: reports through .%s.%s — that bypasses the reporter seam, so "+
-					"this obligation cannot be driven by a negative self-test; report through "+
-					"the embedded reporter and keep .%s for fixture machinery only",
-					fset.Position(call.Pos()), field, outer.Sel.Name, field)
 				return true
 			})
 		}
 	}
 	if !seenArmT {
-		t.Fatal("the package no longer mentions armT — this tripwire is scanning for a shape " +
-			"that has been renamed, and would pass whatever the sources do")
+		t.Fatalf("the package no longer mentions %s — this tripwire is scanning for a shape "+
+			"that has been renamed, and would pass whatever the sources do", armTTypeName)
 	}
+}
+
+const (
+	fixtureFieldName = "fixtures"
+	armTTypeName     = "armT"
+)
+
+// reportingMethods are the *testing.T methods that decide a test's verdict. An
+// arm may reach the fixture T for t.TempDir/t.Setenv/t.Cleanup and for the
+// *testing.T-typed wiring fields; these are the ones it may not.
+var reportingMethods = map[string]bool{
+	"Error": true, "Errorf": true, "Fatal": true, "Fatalf": true, "Skip": true, "Skipf": true,
+}
+
+// aliasesOfFixturesIn returns the local names bound to something's .fixtures
+// field anywhere in fn — `ft := t.fixtures`, `var ft = at.fixtures`. Scope is
+// deliberately the whole function rather than the exact block: over-approximating
+// makes the tripwire refuse a shape it is not certain about, which is the
+// direction a check that cannot parse its input must degrade in.
+func aliasesOfFixturesIn(fn *ast.FuncDecl) map[string]bool {
+	aliases := map[string]bool{}
+	bind := func(lhs, rhs []ast.Expr) {
+		for i, r := range rhs {
+			if i >= len(lhs) || !isFixtureSelector(r) {
+				continue
+			}
+			if id, ok := lhs[i].(*ast.Ident); ok && id.Name != "_" {
+				aliases[id.Name] = true
+			}
+		}
+	}
+	ast.Inspect(fn.Body, func(n ast.Node) bool {
+		switch v := n.(type) {
+		case *ast.AssignStmt:
+			bind(v.Lhs, v.Rhs)
+		case *ast.ValueSpec:
+			names := make([]ast.Expr, len(v.Names))
+			for i, name := range v.Names {
+				names[i] = name
+			}
+			bind(names, v.Values)
+		}
+		return true
+	})
+	return aliases
+}
+
+// fixtureReportsIn returns the position of every reporting call in fn made
+// through the fixture T, whether spelled directly or through an alias.
+func fixtureReportsIn(fn *ast.FuncDecl, aliases map[string]bool) []token.Pos {
+	var found []token.Pos
+	ast.Inspect(fn.Body, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok || !reportingMethods[sel.Sel.Name] {
+			return true
+		}
+		if isFixtureSelector(sel.X) {
+			found = append(found, call.Pos())
+			return true
+		}
+		if id, ok := sel.X.(*ast.Ident); ok && aliases[id.Name] {
+			found = append(found, call.Pos())
+		}
+		return true
+	})
+	return found
+}
+
+// isFixtureSelector reports whether e is a `<something>.fixtures` selection.
+func isFixtureSelector(e ast.Expr) bool {
+	sel, ok := e.(*ast.SelectorExpr)
+	return ok && sel.Sel.Name == fixtureFieldName
 }


### PR DESCRIPTION
Closes #1479.

All seven `contracttesting` families run on every CI build. Until this PR, the evidence that each obligation **can fail** lived in a merged PR body and was re-run by nothing — so an assertion that silently stopped discriminating went on passing and looked exactly like health. This makes that evidence a lock.

## What ships

**The seam** (`core/internal/contracttesting/reporter.go`). A family's arms report through a narrow `reporter` interface (`*testing.T` satisfies it, so no exported entry point changed shape). Arms that also build state take `armT`, whose fixture half is typed `fixtureT` — an interface carrying `Setenv` and **nothing that can decide a verdict**. So `t.fixtures.Fatalf(...)` does not compile, in any spelling. This generalizes the `gateReporter` seam #1475/PR #1489 introduced with exactly this issue in mind.

**The harness** (`selftest_test.go`). `observe()` drives one arm against a recording reporter (on its own goroutine, because `Fatal` is `runtime.Goexit`), and two verdict functions grade what came back:

- `verdictReported(obs, want)` — requires a fragment of the obligation's **own** failure message. A bare failure is refused. This is #1453's second live instance made mechanical: `--port 7837` left `delivery_carries_no_address` green while the run failed incidentally elsewhere, so "the arm failed" was true and "this obligation failed" was not.
- `verdictSilent(obs)` — the per-family vacuity guard. Every arm is also run against a **correct** fixture, because an arm that reported unconditionally would satisfy every mutation below it.
- Both also require the arm to have called `t.Helper()`, so a failure is attributed to the wiring rather than to the harness.

**Four families covered**, one `<family>_selftest_test.go` each:

| Family | Coverage | Source of the mutations |
|---|---|---|
| `AssertPermissionGated` | 4 arms — #1489's key-isolation tests migrated onto the shared harness, plus new can-fail evidence for the three lockstep arms, which had none | PR #1489; lockstep arms **re-derived** |
| `AssertHookEndpointFollowsBindAddr` | 5 obligations + the sentinel guard + route selection; both claims of obligations 2/3/4 | transcribed from PR #1240, PR #1473 (M1a/M1b/M2/M3a/M3b/M4/M5c/M6a/M6b/M7/M8/M9) |
| `AssertHookDisclosureMatchesInstalled` | all 5 arms + preconditions | transcribed from PR #1370 (M1–M3), PR #1393 |
| `AssertHookVersionGate` | 5 obligations + preconditions | **re-derived** — PR #1393 has no per-obligation table |

## The acceptance criterion that mattered most: the harness proved non-vacuous

A recorder that stopped observing would be the failure being fixed, reproduced inside its own fix. So two broken recorders are **committed**, not described — `deafRecorder` (records nothing) and `criesWolfRecorder` (reports unconditionally, naming no obligation) — and driven through the same verdict functions every self-test uses.

Three transient mutations on top of that, each seen red and reverted:

```
MUTATION A: recordingT.record() drops the message      → 60 failures across all four families
MUTATION B: recordingT.reported() returns true always  → every vacuity guard red
MUTATION C: verdictReported accepts any failure        → the two harness self-tests red
```

Note the direction Mutation A establishes: a deaf recorder does **not** make the negative self-tests pass — it makes them all go red. That is the safe direction, and it is now asserted rather than reasoned about.

## The self-tests are themselves non-vacuous

Every obligation covered here was neutered individually and seen red — including, after the review, six assertions that were previously green under mutation:

```
D: assertDeliveryIsOurs neutered (the #1453 guard)  → TestEndpointGuard_DeliveryIsOurs, both routes
E: assertNoAddress stops matching                   → 5 cases
F: assertUpgradedInPlace drops modified=true        → TestEndpointArm_UpgradedInPlace
G: onlyEntry drops the group-count check            → upgrade_appends_a_duplicate_group
H: "survived uninstall" removed                     → uninstall_reports_success_but_removes_nothing
I: idempotency check removed                        → install_is_not_idempotent
J: each of the 3 lockstep permission-gate arms      → TestTheLockstepArmsFailABrokenReceiver
K: an arm reports the WRONG obligation's prose      → "failed, but NOT on the obligation under test"
```

K is the one worth reading: the disclosure tests originally graded on an interpolated **value** (`"Notification"`, the floor string), which a neighbouring obligation's message also contains — so an arm reporting the wrong prose for the right condition was graded green. That is this PR's own defect, inside its own fix, found by review. Fragments now come from the family's arm table (`wantOf`), never retyped at the call site.

## One live vacuity found, and fixed

Writing `AssertHookVersionGate`'s self-tests found that **`floor_refuses_an_older_cli` asserted nothing at a floor of `0.0.0`**: `predecessors("0.0.0")` is empty, so the loop that proves the gate blocks never ran and the arm passed having asserted only that the gate permits its own floor. `assertFloorRefusesOlder` now reports that. No adapter declares `0.0.0`, so no existing wiring's verdict changes.

## Two obligations that no wrong wiring can fail — said out loud rather than faked

`AssertHookVersionGate`'s `floor_refuses_an_older_cli` (past the zero-floor case) and `unknown_version_fails_open` grade `agent.VersionGate.Permits` — **domain code every adapter shares** — not the adapter. Their mutations live in the domain, and PR #1393's review already ran one. They are named as such in `TestVersionArm_UnknownVersionFailsOpen_IsALock` rather than given a wiring mutation that does not exist, per AGENTS.md's rule that a lock's green is not evidence.

## Known limit — this does not close every hole

**A negative self-test would not have caught #1475's key-blindness.** Those arms all passed *correctly* for what they asserted; the gap was that the fixture could not express the distinguishing state. A negative self-test grades an obligation against the wrong receiver someone thought to build — never against the one nobody thought of. `TestTheLockstepArmsCannotSeeAWrongKeyGate` (from PR #1489) is the in-tree record of that blind spot and is preserved unchanged.

Also not closed: nothing forces a **new** arm to take the seam, or a new family to have a self-test at all. That needs a package source walk with a named exception map (the `applyWritesNoUserFile` shape); it is scoped to #1497.

## Scoped out, tracked: #1497

The three receiver-shaped families — `AssertHookPathConfined` (6), `AssertUnknownHookEventObserved` (4), `AssertHookReceiptObserved` (4) — all need the same fixture: a live `hookjson.HookHandler` with declared roots, a consent gate and readable counters. **That fixture is exactly what #1488 changes** (folding the consent key into `DecodeConfined`), so writing it now means writing it twice. #1497 is deliberately queued behind #1488.

**Effect on #1488:** no collision — this PR touches no `hookjson` file and no receiver. It makes #1488 marginally easier: the seam and harness will already exist when #1497 follows it.

## Review and simplify

A `high`-effort review subagent ran 27 deliberate mutations (all red) and returned 6 findings; all 6 are fixed — the wrong-prose hole above, three uncovered second assertions, the three uncovered lockstep arms, an alias-bypassable tripwire, and an unguarded field read.

Four simplify agents followed. The load-bearing outcome: the alias-tracking AST tripwire that policed `armT.fixtures` (~110 lines) is **deleted**, replaced by the `fixtureT` type narrowing above — a guard is worth only what its deliberate failures prove, and that one would have shipped without a committed corpus, in a PR whose whole thesis says so. Same trade #1390 made for path confinement. Also: the reference beacon installer is now defined once and reused (it was duplicated), the disclosure arm table now holds all five of its family's arms (it held four while claiming to be complete), and the endpoint family gained the named vacuity guard the other two already had.

## Verification

`tools/preflight.sh` chunked, all seven groups **PASS**: `go`, `web`, `arch`, `tools`, `skills`, `posix`, `security`. `go test ./core/... -race -count=1` clean. Rebased onto `origin/main` after #1499/#1500/#1502/#1504 landed; #1500 also touched AGENTS.md, in the replay-drift section — no semantic overlap, and it independently states the same "committed mutation evidence" principle. Pushes used `--no-verify`, covered by the full unscoped preflight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)