### PR TITLE
fix(processlifecycle): stop capturing a tmux server's frozen host identity

### DIFF
--- a/core/adapters/inbound/agents/processlifecycle/osutil.go
+++ b/core/adapters/inbound/agents/processlifecycle/osutil.go
@@ -145,7 +145,14 @@ func hostIdentity(pid int) *session.Launcher {
 	// kitty field back-fill). Walking the ppid chain once instead of up to
 	// three times keeps this bounded — each readProcInfo is a `ps` shellout
 	// with a 2s ceiling.
-	if l.HerdrPaneID == "" {
+	//
+	// A tmux pane is skipped for the same reason, and the reason is not merely
+	// that the walk is futile: tmux's server is reparented to PID 1, so the
+	// chain from a pane can only ever rediscover the terminal the *server* was
+	// launched from — which is precisely the stale host launcherFromEnv just
+	// suppressed. Running the fallbacks here would undo that suppression by
+	// another route, exactly as it would for herdr.
+	if l.HerdrPaneID == "" && l.TmuxPane == "" {
 		applyAncestryFallbacks(l, pid, memoizedAncestry(pid))
 	}
 
@@ -173,6 +180,18 @@ func launcherFromEnv(env map[string]string) *session.Launcher {
 			HerdrSocketPath: env["HERDR_SOCKET_PATH"],
 		}
 	}
+	// A tmux pane is the same shape as a herdr pane and for the same reason,
+	// so it keeps only its own address too — see session.Launcher's Tmux*
+	// fields. Checked *after* herdr on purpose: a herdr server started from a
+	// tmux pane hands every pane a $TMUX_PANE as well, and that one is the
+	// server's, not the agent's (#1348). herdrPaneEnv in the tests is exactly
+	// that env, and TestLauncherFromEnv_HerdrCapture locks the ordering.
+	if pane := env["TMUX_PANE"]; pane != "" {
+		return &session.Launcher{
+			TmuxPane:   pane,
+			TmuxSocket: tmuxSocketFromEnv(env["TMUX"]),
+		}
+	}
 	l := &session.Launcher{
 		TermProgram:    env["TERM_PROGRAM"],
 		ITermSessionID: env["ITERM_SESSION_ID"],
@@ -181,14 +200,7 @@ func launcherFromEnv(env map[string]string) *session.Launcher {
 		KittyListenOn:  env["KITTY_LISTEN_ON"],
 		KittyWindowID:  env["KITTY_WINDOW_ID"],
 	}
-	if tmux := env["TMUX"]; tmux != "" {
-		// $TMUX is "/path/to/socket,pid,session" — first field is the socket.
-		if i := strings.Index(tmux, ","); i > 0 {
-			l.TmuxSocket = tmux[:i]
-		} else {
-			l.TmuxSocket = tmux
-		}
-	}
+	l.TmuxSocket = tmuxSocketFromEnv(env["TMUX"])
 	if v := env["VSCODE_PID"]; v != "" {
 		if n, err := strconv.Atoi(v); err == nil {
 			l.VSCodePID = n
@@ -212,6 +224,22 @@ func launcherFromEnv(env map[string]string) *session.Launcher {
 		l.TermProgram = "jetbrains"
 	}
 	return l
+}
+
+// tmuxSocketFromEnv extracts the server socket from $TMUX, whose value is
+// "/path/to/socket,pid,session". Returns "" for an empty $TMUX so a launcher
+// with no tmux server keeps a zero socket rather than an empty-but-set one.
+// Shared by both branches of launcherFromEnv: a tmux pane's address is the one
+// thing it keeps, so the parse must not live only on the path that no longer
+// runs for it.
+func tmuxSocketFromEnv(tmux string) string {
+	if tmux == "" {
+		return ""
+	}
+	if i := strings.Index(tmux, ","); i > 0 {
+		return tmux[:i]
+	}
+	return tmux
 }
 
 // memoizedAncestry returns a closure resolving pid's process ancestry via

--- a/core/adapters/inbound/agents/processlifecycle/osutil.go
+++ b/core/adapters/inbound/agents/processlifecycle/osutil.go
@@ -146,13 +146,15 @@ func hostIdentity(pid int) *session.Launcher {
 	// three times keeps this bounded — each readProcInfo is a `ps` shellout
 	// with a 2s ceiling.
 	//
-	// A tmux pane is skipped for the same reason, and the reason is not merely
-	// that the walk is futile: tmux's server is reparented to PID 1, so the
-	// chain from a pane can only ever rediscover the terminal the *server* was
-	// launched from — which is precisely the stale host launcherFromEnv just
-	// suppressed. Running the fallbacks here would undo that suppression by
-	// another route, exactly as it would for herdr.
-	if l.HerdrPaneID == "" && l.TmuxPane == "" {
+	// A tmux pane is deliberately NOT skipped here, though the same argument
+	// looks like it should apply. It does not: tmux's server is reparented to
+	// PID 1, so the walk from a genuine pane terminates there having found
+	// nothing — it is inert, not dangerous, and cannot put back what
+	// launcherFromEnv suppressed. Meanwhile it is the only thing that recovers
+	// a host for a process launched from a pane by a terminal that reports
+	// none of its own (kitty), whose fields the suppression above drops. So
+	// skipping it would buy no correctness and cost exactly that case.
+	if l.HerdrPaneID == "" {
 		applyAncestryFallbacks(l, pid, memoizedAncestry(pid))
 	}
 
@@ -182,11 +184,25 @@ func launcherFromEnv(env map[string]string) *session.Launcher {
 	}
 	// A tmux pane is the same shape as a herdr pane and for the same reason,
 	// so it keeps only its own address too — see session.Launcher's Tmux*
-	// fields. Checked *after* herdr on purpose: a herdr server started from a
-	// tmux pane hands every pane a $TMUX_PANE as well, and that one is the
+	// fields.
+	//
+	// The condition is $TMUX_PANE *and* tmux's own TERM_PROGRAM marker, never
+	// $TMUX_PANE alone. $TMUX_PANE is not self-describing: every descendant of
+	// a pane inherits it, including a GUI terminal or IDE launched from inside
+	// one (`code .`, `kitty`), and such a process carries the stale pane
+	// address alongside a correct host identity it reported itself. Keying on
+	// the address alone discards that host and turns a working click-to-focus
+	// into a silent no-op. tmux stamps TERM_PROGRAM=tmux onto the panes it
+	// spawns, so a process claiming any other host claimed it for itself and
+	// is left alone; one claiming no host of its own (kitty sets none —
+	// upstream kitty#4793) is suppressed here and recovered by the ancestry
+	// fallbacks, which is why hostIdentity must not skip them for tmux.
+	//
+	// Checked *after* herdr on purpose: a herdr server started from a tmux
+	// pane hands every pane a $TMUX_PANE as well, and that one is the
 	// server's, not the agent's (#1348). herdrPaneEnv in the tests is exactly
 	// that env, and TestLauncherFromEnv_HerdrCapture locks the ordering.
-	if pane := env["TMUX_PANE"]; pane != "" {
+	if pane := env["TMUX_PANE"]; pane != "" && env["TERM_PROGRAM"] == tmuxTermProgram {
 		return &session.Launcher{
 			TmuxPane:   pane,
 			TmuxSocket: tmuxSocketFromEnv(env["TMUX"]),
@@ -199,8 +215,8 @@ func launcherFromEnv(env map[string]string) *session.Launcher {
 		TmuxPane:       env["TMUX_PANE"],
 		KittyListenOn:  env["KITTY_LISTEN_ON"],
 		KittyWindowID:  env["KITTY_WINDOW_ID"],
+		TmuxSocket:     tmuxSocketFromEnv(env["TMUX"]),
 	}
-	l.TmuxSocket = tmuxSocketFromEnv(env["TMUX"])
 	if v := env["VSCODE_PID"]; v != "" {
 		if n, err := strconv.Atoi(v); err == nil {
 			l.VSCodePID = n
@@ -225,6 +241,14 @@ func launcherFromEnv(env map[string]string) *session.Launcher {
 	}
 	return l
 }
+
+// tmuxTermProgram is the value tmux writes into $TERM_PROGRAM for the panes it
+// spawns (measured on 3.6a, alongside TERM_PROGRAM_VERSION=3.6a). It is not a
+// host — it names a multiplexer, matches no entry in the macOS activator
+// registry, and being non-empty it suppresses the TermProgram=="" guards that
+// reach the ancestry fallbacks — so it is used only as evidence that tmux, and
+// not something launched from within it, spawned this process.
+const tmuxTermProgram = "tmux"
 
 // tmuxSocketFromEnv extracts the server socket from $TMUX, whose value is
 // "/path/to/socket,pid,session". Returns "" for an empty $TMUX so a launcher

--- a/core/adapters/inbound/agents/processlifecycle/osutil_test.go
+++ b/core/adapters/inbound/agents/processlifecycle/osutil_test.go
@@ -404,6 +404,134 @@ func TestReadLauncherEnv_Subprocess_Herdr(t *testing.T) {
 	}
 }
 
+// tmuxPaneEnv is the env a process sees inside a tmux pane whose server was
+// started from an iTerm2 window — iTerm session "w0t0p0:ALPHA-UUID" — that the
+// user has since detached from. Values match a live capture on tmux 3.6a
+// (#1486), and the shape is herdrPaneEnv's above for the same reason: tmux's
+// server daemonizes at first use, is reparented to PID 1, outlives every
+// client, and hands its own launch-time environment to every pane it will ever
+// spawn.
+//
+// Two measured details drive the assertions below.
+//
+// First, TERM_PROGRAM is NOT a stale host name: tmux overwrites it with its own
+// name ("tmux", alongside TERM_PROGRAM_VERSION=3.6a). That refutes #1486's
+// stated hypothesis, but it is not a reprieve — "tmux" matches no entry in the
+// macOS activator registry, and being non-empty it also suppresses the
+// TermProgram=="" guards that would otherwise reach the ancestry fallbacks. So
+// it is a value that can only mask, never resolve.
+//
+// Second, every *other* terminal-identity var IS handed through frozen. This
+// was measured on a pane created minutes after the ALPHA terminal was gone,
+// while a completely different client (Apple_Terminal, "w9t9p9:BRAVO-UUID")
+// was the only one attached — so unlike #1405's herdr staleness, it is wrong
+// from the very first click rather than only after a re-attach.
+var tmuxPaneEnv = map[string]string{
+	"TERM_PROGRAM":      "tmux",
+	"TMUX":              "/private/tmp/tmux-501/default,69323,0",
+	"TMUX_PANE":         "%4",
+	"ITERM_SESSION_ID":  "w0t0p0:ALPHA-UUID",
+	"TERM_SESSION_ID":   "ALPHA_TERMSESS",
+	"KITTY_LISTEN_ON":   "unix:/tmp/kitty-ALPHA/sock",
+	"KITTY_WINDOW_ID":   "77",
+	"KITTY_PID":         "555",
+	"VSCODE_PID":        "4242",
+	"TERMINAL_EMULATOR": "JetBrains-JediTerm",
+}
+
+// TestLauncherFromEnv_TmuxSuppressesInheritedIdentity pins the defect. Each
+// field here describes the terminal the tmux *server* was started in, not the
+// one displaying the pane, and none of them is refreshed when the user
+// re-attaches somewhere else.
+func TestLauncherFromEnv_TmuxSuppressesInheritedIdentity(t *testing.T) {
+	l := launcherFromEnv(tmuxPaneEnv)
+	if l.TermProgram != "" {
+		t.Errorf("TermProgram: tmux's own name is not a host, got %q", l.TermProgram)
+	}
+	if l.ITermSessionID != "" || l.TermSessionID != "" {
+		t.Errorf("iTerm/Terminal.app session identity must not survive, got iterm=%q term=%q",
+			l.ITermSessionID, l.TermSessionID)
+	}
+	if l.KittyListenOn != "" || l.KittyWindowID != "" || l.KittyPID != 0 {
+		t.Errorf("kitty identity must not survive, got listen=%q window=%q pid=%d",
+			l.KittyListenOn, l.KittyWindowID, l.KittyPID)
+	}
+	if l.VSCodePID != 0 {
+		t.Errorf("VSCodePID: inherited value must not survive, got %d", l.VSCodePID)
+	}
+}
+
+// TestLauncherFromEnv_TmuxCapture covers the other half: the pane's own
+// address, which is the only thing in that env that actually describes it and
+// which the backchannel routes on (resolveBackend picks backendTmux from
+// TmuxPane alone, before it ever looks at TermProgram). Keeping these two is
+// what makes the suppression above a click-to-focus change and not a control
+// regression.
+func TestLauncherFromEnv_TmuxCapture(t *testing.T) {
+	l := launcherFromEnv(tmuxPaneEnv)
+	if l.TmuxPane != "%4" {
+		t.Errorf("TmuxPane: want %%4, got %q", l.TmuxPane)
+	}
+	if l.TmuxSocket != "/private/tmp/tmux-501/default" {
+		t.Errorf("TmuxSocket: got %q", l.TmuxSocket)
+	}
+	if l.IsEmpty() {
+		t.Error("a tmux-only launcher must not be reported empty")
+	}
+}
+
+// TestLauncherFromEnv_TmuxSuppressionIsScoped guards the blast radius: the
+// suppression must key off an actual tmux pane and leave an ordinary terminal
+// session alone. A lock — it passes before the change and must keep passing
+// after.
+func TestLauncherFromEnv_TmuxSuppressionIsScoped(t *testing.T) {
+	l := launcherFromEnv(map[string]string{
+		"TERM_PROGRAM":     "iTerm.app",
+		"ITERM_SESSION_ID": "w0t0p0:REAL-UUID",
+		"KITTY_WINDOW_ID":  "3",
+	})
+	if l.TermProgram != "iTerm.app" || l.ITermSessionID != "w0t0p0:REAL-UUID" {
+		t.Errorf("a non-tmux session must keep its own identity, got %+v", l)
+	}
+	if l.KittyWindowID != "3" {
+		t.Errorf("KittyWindowID: want 3, got %q", l.KittyWindowID)
+	}
+}
+
+// TestReadLauncherEnv_Subprocess_TmuxSkipsAncestry is the tmux twin of
+// TestReadLauncherEnv_Subprocess_Herdr: it exercises the real sysctl / /proc
+// read path, and pins that the ancestry fallbacks do not put a host identity
+// back by another route. The walk from a tmux pane leads to the tmux server,
+// which is reparented to PID 1 — so it can only ever rediscover the terminal
+// the server was launched from, which is the value being suppressed. (This
+// test process is itself hosted by some terminal, so without the skip
+// TermProgram/HostBundleID would be populated here.)
+func TestReadLauncherEnv_Subprocess_TmuxSkipsAncestry(t *testing.T) {
+	if runtime.GOOS != "darwin" && runtime.GOOS != "linux" {
+		t.Skip()
+	}
+	pid := spawnSleeperWithEnv(t, []string{
+		"PATH=/usr/bin:/bin",
+		"TERM_PROGRAM=tmux",
+		"TMUX=/private/tmp/tmux-501/default,69323,0",
+		"TMUX_PANE=%4",
+		"ITERM_SESSION_ID=w0t0p0:ALPHA-UUID",
+	})
+	l, _ := ReadLauncherEnv(pid)
+	if l == nil {
+		t.Fatal("expected non-nil launcher")
+	}
+	if l.TmuxPane != "%4" || l.TmuxSocket != "/private/tmp/tmux-501/default" {
+		t.Errorf("the pane's own address must survive the real read path: %+v", l)
+	}
+	if l.ITermSessionID != "" {
+		t.Errorf("inherited iTerm identity survived the real read path: %+v", l)
+	}
+	if l.TermProgram != "" || l.HostBundleID != "" {
+		t.Errorf("ancestry identity must not be merged into a tmux launcher: %+v", l)
+	}
+}
+
 // TestReadLauncherEnv_Subprocess_KittyOverridesInheritedTermProgram covers
 // the case where kitty was launched from a process whose env contained
 // TERM_PROGRAM=vscode (e.g. a VS Code integrated terminal). kitty itself

--- a/core/adapters/inbound/agents/processlifecycle/osutil_test.go
+++ b/core/adapters/inbound/agents/processlifecycle/osutil_test.go
@@ -498,15 +498,57 @@ func TestLauncherFromEnv_TmuxSuppressionIsScoped(t *testing.T) {
 	}
 }
 
-// TestReadLauncherEnv_Subprocess_TmuxSkipsAncestry is the tmux twin of
-// TestReadLauncherEnv_Subprocess_Herdr: it exercises the real sysctl / /proc
-// read path, and pins that the ancestry fallbacks do not put a host identity
-// back by another route. The walk from a tmux pane leads to the tmux server,
-// which is reparented to PID 1 — so it can only ever rediscover the terminal
-// the server was launched from, which is the value being suppressed. (This
-// test process is itself hosted by some terminal, so without the skip
-// TermProgram/HostBundleID would be populated here.)
-func TestReadLauncherEnv_Subprocess_TmuxSkipsAncestry(t *testing.T) {
+// TestLauncherFromEnv_TmuxSuppressionSparesADescendantsOwnHost is the other
+// half of the blast-radius guard, and the one that is easy to get wrong.
+// $TMUX_PANE is not self-describing: it is inherited by *every* descendant of a
+// pane, including a GUI terminal or IDE launched from inside one (`code .`,
+// `kitty`). Such a process carries the stale pane address AND a correct,
+// self-reported host identity — so keying the suppression on $TMUX_PANE alone
+// throws away a host that click-to-focus could actually have used, turning
+// "raises the right window" into a silent no-op.
+//
+// The discriminator is tmux's own marker: tmux stamps TERM_PROGRAM=tmux onto
+// the panes it spawns, and a descendant that reports a different host reported
+// it itself. A descendant that reports no host of its own (kitty sets no
+// TERM_PROGRAM, upstream #4793) is still suppressed here, and is recovered by
+// the ancestry fallbacks instead — which is why hostIdentity must NOT skip
+// them for tmux. TestReadLauncherEnv_Subprocess_TmuxSkipsAncestry pins the
+// genuine-pane end of that.
+func TestLauncherFromEnv_TmuxSuppressionSparesADescendantsOwnHost(t *testing.T) {
+	l := launcherFromEnv(map[string]string{
+		"TERM_PROGRAM": "vscode",
+		"VSCODE_PID":   "4242",
+		// Inherited from the pane VS Code was launched from — stale, but not a
+		// reason to discard VS Code's own identity below.
+		"TMUX":      "/private/tmp/tmux-501/default,69323,0",
+		"TMUX_PANE": "%4",
+	})
+	if l.TermProgram != "vscode" {
+		t.Errorf("a descendant's own TERM_PROGRAM must survive, got %q", l.TermProgram)
+	}
+	if l.VSCodePID != 4242 {
+		t.Errorf("VSCodePID: want 4242, got %d", l.VSCodePID)
+	}
+}
+
+// TestReadLauncherEnv_Subprocess_TmuxSuppressesInheritedIdentity is the tmux
+// twin of TestReadLauncherEnv_Subprocess_Herdr: it exercises the real sysctl /
+// proc read path rather than launcherFromEnv in isolation.
+//
+// It deliberately does NOT assert TermProgram == "", the way the herdr twin
+// does. The herdr twin can, because hostIdentity skips the ancestry fallbacks
+// for a herdr pane; for tmux they run on purpose (see hostIdentity). In
+// production that walk is inert — a genuine pane's chain reaches the tmux
+// server, which is reparented to PID 1, and terminates there. Here it is not:
+// the subprocess is a child of the test binary, which really is hosted by a
+// terminal, so ancestry legitimately repopulates TermProgram. That is the same
+// recovery path a kitty window launched from a pane depends on, so asserting
+// its absence would pin the bug rather than the fix.
+//
+// What must hold either way is that nothing inherited from the tmux server's
+// launch environment survives, and that tmux's own marker is never kept as if
+// it were a host.
+func TestReadLauncherEnv_Subprocess_TmuxSuppressesInheritedIdentity(t *testing.T) {
 	if runtime.GOOS != "darwin" && runtime.GOOS != "linux" {
 		t.Skip()
 	}
@@ -516,6 +558,7 @@ func TestReadLauncherEnv_Subprocess_TmuxSkipsAncestry(t *testing.T) {
 		"TMUX=/private/tmp/tmux-501/default,69323,0",
 		"TMUX_PANE=%4",
 		"ITERM_SESSION_ID=w0t0p0:ALPHA-UUID",
+		"TERM_SESSION_ID=ALPHA_TERMSESS",
 	})
 	l, _ := ReadLauncherEnv(pid)
 	if l == nil {
@@ -524,11 +567,11 @@ func TestReadLauncherEnv_Subprocess_TmuxSkipsAncestry(t *testing.T) {
 	if l.TmuxPane != "%4" || l.TmuxSocket != "/private/tmp/tmux-501/default" {
 		t.Errorf("the pane's own address must survive the real read path: %+v", l)
 	}
-	if l.ITermSessionID != "" {
-		t.Errorf("inherited iTerm identity survived the real read path: %+v", l)
+	if l.ITermSessionID != "" || l.TermSessionID != "" {
+		t.Errorf("inherited terminal identity survived the real read path: %+v", l)
 	}
-	if l.TermProgram != "" || l.HostBundleID != "" {
-		t.Errorf("ancestry identity must not be merged into a tmux launcher: %+v", l)
+	if l.TermProgram == "tmux" {
+		t.Errorf("tmux's own marker must never be kept as a host: %+v", l)
 	}
 }
 

--- a/core/domain/session/session.go
+++ b/core/domain/session/session.go
@@ -85,6 +85,32 @@ func (s *subagentSummary) Equal(o *subagentSummary) bool {
 // resolve to tmux and type into a foreign pane in a different window. This is
 // the rationale the capture and control paths refer back to (#1348).
 //
+// The Tmux* fields are the same case, established by live measurement on tmux
+// 3.6a (#1486): tmux's server daemonizes at first use, is reparented to PID 1,
+// outlives every client, and hands its own launch-time environment to every
+// pane it will ever spawn. A pane created minutes after the launching terminal
+// was gone still carried that terminal's $ITERM_SESSION_ID and
+// $TERM_SESSION_ID, while a different client was the only one attached — so a
+// tmux pane keeps only TmuxPane/TmuxSocket, exactly as a herdr pane keeps only
+// its address.
+//
+// Note what tmux itself does to $TERM_PROGRAM, because it is the opposite of
+// what the herdr paragraph above would lead you to expect: tmux overwrites it
+// with the literal "tmux" rather than leaking the launching terminal's value.
+// That does not make it usable. "tmux" names a multiplexer, not a window;
+// it matches no entry in the macOS activator registry; and being non-empty it
+// suppresses the TermProgram=="" guards that would otherwise reach the
+// ancestry fallbacks. It is a value that can only mask, never resolve, which
+// is why it is dropped rather than kept as a label.
+//
+// The consequence is that a tmux session currently resolves to no host at all
+// — click-to-focus does nothing rather than raising the wrong window, which is
+// the same honest degradation a herdr session with no attached client gets.
+// Resolving the real host means asking tmux which client is attached
+// (`tmux -S <socket> list-clients -F '#{client_pid}'`, then reading that
+// process's identity the way a herdr client's is read). That is #1350's
+// counterpart for tmux and is deliberately not built here.
+//
 // The host fields on a herdr launcher are therefore populated from a different
 // process: the attached herdr *client*, which is what actually owns a window
 // (#1350). Provenance is the whole distinction — the same TmuxPane that is a
@@ -96,7 +122,7 @@ type Launcher struct {
 	TermProgram    string `json:"term_program,omitempty"`     // $TERM_PROGRAM (e.g. iTerm.app, Apple_Terminal, vscode, cursor, ghostty, WezTerm, Hyper)
 	ITermSessionID string `json:"iterm_session_id,omitempty"` // $ITERM_SESSION_ID
 	TermSessionID  string `json:"term_session_id,omitempty"`  // $TERM_SESSION_ID (Terminal.app)
-	TmuxPane       string `json:"tmux_pane,omitempty"`        // $TMUX_PANE
+	TmuxPane       string `json:"tmux_pane,omitempty"`        // $TMUX_PANE — the pane's own address, and the only host-independent thing its env carries (#1486)
 	TmuxSocket     string `json:"tmux_socket,omitempty"`      // first `,`-field of $TMUX
 	VSCodePID      int    `json:"vscode_pid,omitempty"`       // $VSCODE_PID (vscode/cursor/windsurf)
 	TTY            string `json:"tty,omitempty"`              // controlling TTY, e.g. "/dev/ttys021" — Terminal.app AppleScript matches tabs by this. The agent process's own, except on a herdr session with a client attached, where it is the client's: that is the tab actually displaying the pane (#1350)

--- a/core/domain/session/session.go
+++ b/core/domain/session/session.go
@@ -94,6 +94,14 @@ func (s *subagentSummary) Equal(o *subagentSummary) bool {
 // tmux pane keeps only TmuxPane/TmuxSocket, exactly as a herdr pane keeps only
 // its address.
 //
+// Unlike a herdr pane, though, the address alone does not identify one: every
+// descendant of a pane inherits $TMUX_PANE, so a GUI terminal or IDE launched
+// from inside one carries a stale pane address next to a perfectly good host
+// identity of its own. The capture keys the suppression on tmux's own
+// TERM_PROGRAM marker for that reason, and leaves the ancestry fallbacks
+// enabled so a descendant reporting no host itself is still resolved — see
+// processlifecycle.launcherFromEnv.
+//
 // Note what tmux itself does to $TERM_PROGRAM, because it is the opposite of
 // what the herdr paragraph above would lead you to expect: tmux overwrites it
 // with the literal "tmux" rather than leaking the launching terminal's value.
@@ -103,7 +111,8 @@ func (s *subagentSummary) Equal(o *subagentSummary) bool {
 // ancestry fallbacks. It is a value that can only mask, never resolve, which
 // is why it is dropped rather than kept as a label.
 //
-// The consequence is that a tmux session currently resolves to no host at all
+// The consequence is that a genuine tmux pane currently resolves to no host at
+// all
 // — click-to-focus does nothing rather than raising the wrong window, which is
 // the same honest degradation a herdr session with no attached client gets.
 // Resolving the real host means asking tmux which client is attached
@@ -122,7 +131,7 @@ type Launcher struct {
 	TermProgram    string `json:"term_program,omitempty"`     // $TERM_PROGRAM (e.g. iTerm.app, Apple_Terminal, vscode, cursor, ghostty, WezTerm, Hyper)
 	ITermSessionID string `json:"iterm_session_id,omitempty"` // $ITERM_SESSION_ID
 	TermSessionID  string `json:"term_session_id,omitempty"`  // $TERM_SESSION_ID (Terminal.app)
-	TmuxPane       string `json:"tmux_pane,omitempty"`        // $TMUX_PANE — the pane's own address, and the only host-independent thing its env carries (#1486)
+	TmuxPane       string `json:"tmux_pane,omitempty"`        // $TMUX_PANE — this process's pane when tmux spawned it; inherited, and then a foreign pane's, in any descendant of one (#1486)
 	TmuxSocket     string `json:"tmux_socket,omitempty"`      // first `,`-field of $TMUX
 	VSCodePID      int    `json:"vscode_pid,omitempty"`       // $VSCODE_PID (vscode/cursor/windsurf)
 	TTY            string `json:"tty,omitempty"`              // controlling TTY, e.g. "/dev/ttys021" — Terminal.app AppleScript matches tabs by this. The agent process's own, except on a herdr session with a client attached, where it is the client's: that is the tab actually displaying the pane (#1350)

--- a/platforms/macos/Irrlicht/Managers/SessionLauncher.swift
+++ b/platforms/macos/Irrlicht/Managers/SessionLauncher.swift
@@ -64,11 +64,19 @@ enum SessionLauncher {
     /// terminal has no registry entry, lands here too, and pointing that at a
     /// missing client would send whoever debugs it looking for the wrong thing.
     ///
+    /// `tmuxPane` counts as evidence of a resolved client for that same reason.
+    /// A herdr pane's own environment never contributes one — the capture
+    /// suppresses it (#1348) — so a tmux address on a herdr launcher can only
+    /// have been adopted from a client, and since #1486 a client running inside
+    /// tmux contributes *only* that address, with no `termProgram` to speak for
+    /// it.
+    ///
     /// Exposed for tests, which is the only way either wording is checked.
     static func herdrDiagnostic(for launcher: Launcher?) -> String {
         guard let pane = launcher?.herdrPaneID else { return "herdr_pane=nil" }
         let unresolved = (launcher?.termProgram ?? "").isEmpty
             && (launcher?.hostBundleID ?? "").isEmpty
+            && (launcher?.tmuxPane ?? "").isEmpty
         let why = unresolved ? "no attached client" : "client resolved but its host has no activator"
         return "herdr_pane=\(pane), \(why)"
     }

--- a/platforms/macos/Tests/SessionManagerTests.swift
+++ b/platforms/macos/Tests/SessionManagerTests.swift
@@ -492,6 +492,14 @@ final class SessionManagerTests: XCTestCase {
         XCTAssertEqual(SessionLauncher.herdrDiagnostic(for: unregisteredHost),
                        "herdr_pane=w1:p1, client resolved but its host has no activator")
 
+        // A client running inside tmux contributes only a tmux address since
+        // #1486 — its own $TERM_PROGRAM is tmux's marker and is dropped. The
+        // client was still found, so this must not read as "no attached
+        // client".
+        let clientInTmux = try launcher(#"{"herdr_pane_id":"w1:p1","tmux_pane":"%3"}"#)
+        XCTAssertEqual(SessionLauncher.herdrDiagnostic(for: clientInTmux),
+                       "herdr_pane=w1:p1, client resolved but its host has no activator")
+
         XCTAssertEqual(SessionLauncher.herdrDiagnostic(for: nil), "herdr_pane=nil")
     }
 


### PR DESCRIPTION
Closes #1486.

#1486 was filed from code reading and explicitly marked UNVERIFIED, with an
inconclusive live probe. So the first job was establishing whether the defect is
real. It is — but **not by the mechanism the issue proposed**, and the difference
matters enough to state up front.

## What was measured

tmux 3.6a, pristine (`-f /dev/null`, no user config — this machine has none), a
throwaway server on a private socket started with synthetic identity vars, and a
second client attached from a *different* synthetic terminal. Launchers read
through the daemon's own `processlifecycle.ReadLauncherEnv`.

| launcher field | server started with | pane got | frozen leak? |
|---|---|---|---|
| `TERM_PROGRAM` | `iTerm.app` | **`tmux`** | **no** — tmux overwrites it |
| `ITERM_SESSION_ID` | `w0t0p0:ALPHA-UUID` | `w0t0p0:ALPHA-UUID` | **yes** |
| `TERM_SESSION_ID` | `ALPHA_TERMSESS` | `ALPHA_TERMSESS` | **yes** |
| `VSCODE_PID` | `4242` | `4242` | **yes** |
| `KITTY_LISTEN_ON` / `KITTY_WINDOW_ID` / `KITTY_PID` | ALPHA values | ALPHA values | **yes** |
| `TERMINAL_EMULATOR` | `JetBrains-JediTerm` | same | **yes** |
| `TMUX` / `TMUX_PANE` | — | the pane's own | correct |

**The issue's central claim is refuted.** `TermProgram` does not name the terminal
the server was started in: tmux overwrites `$TERM_PROGRAM` with the literal `tmux`
(plus `TERM_PROGRAM_VERSION=3.6a`). The repo already held this evidence without it
being connected — `herdrPaneEnv`, the live #1348 capture, carries
`"TERM_PROGRAM": "tmux"` for a herdr server started inside tmux.

**The issue's concern is confirmed, and its "wrong from the first click" framing is
right.** The other seven vars are handed through frozen. Measured on a pane created
minutes after the ALPHA terminal was gone, while an `Apple_Terminal` client
(`w9t9p9:BRAVO-UUID`) was the only one attached — that pane still reported
`iterm_session_id=w0t0p0:ALPHA-UUID`. Detaching and re-attaching never updated it
(byte-identical launcher before and after).

`update-environment` is why: its default set is `DISPLAY KRB5CCNAME MSYSTEM
SSH_ASKPASS SSH_AUTH_SOCK SSH_AGENT_PID SSH_CONNECTION WINDOWID XAUTHORITY` — no
terminal-identity var, so attaching never refreshes one.

### Why the issue's own probe came back empty

Reproduced, then explained. `KERN_PROCARGS2` returns **no env at all** for Apple's
signed platform binaries, which is what the original probe used:

```
applesleep  (/bin/sleep)       rawlen=35    envish=0   launcher={"tty":"/dev/ttys025"}
applezsh    (/bin/zsh)         rawlen=32    envish=0   launcher={"tty":"/dev/ttys026"}
gobin       (unsigned Go bin)  rawlen=6428  envish=84  launcher={"term_program":"tmux",...}
```

It is a property of the *binary*, not of tmux — the same hardened-runtime path
`readProcessEnv`'s doc comment already describes. Probing with a non-platform
binary makes the env fully readable.

### The user-visible consequence (worse than the issue supposed)

`term_program: "tmux"` matches no entry in the macOS activator registry
(`SessionLauncher.swift`), and being **non-empty** it also suppresses the
`TermProgram == ""` guards that would otherwise reach the ancestry fallbacks — so
`HostBundleID` is never resolved either. `resolveActivator` returns nil and
**click-to-focus is a silent no-op for every tmux session**, with `TmuxActivator`'s
`select-pane` never running because it is a decorator over a nil base.

## The fix

Apply #1348's herdr treatment to tmux, which is the same architecture for the same
reason (server daemonizes, reparented to PID 1, outlives every client) and which
that rationale already named `$TMUX`/`$TMUX_PANE` explicitly — but keyed carefully,
because the first cut of this PR was too broad and review caught it (see below):

- `launcherFromEnv` early-returns a tmux pane's **own address only**, gated on
  `$TMUX_PANE` **and** tmux's own `TERM_PROGRAM=tmux` marker. Placed *after* the
  herdr check — a herdr server started from a tmux pane hands every pane a
  `$TMUX_PANE` too, and that one is the server's.
  `TestLauncherFromEnv_HerdrCapture` locks the ordering.
- `hostIdentity` **keeps** the ancestry fallbacks enabled for tmux. For a genuine
  pane the walk is inert (the chain reaches the reparented server and terminates),
  and for a descendant that reports no host of its own it is the only thing that
  recovers one.
- `tmuxSocketFromEnv` extracts the shared `$TMUX` parse so the address the pane
  *keeps* is not parsed only on the path that no longer runs for it.
- `SessionLauncher.herdrDiagnostic` counts an adopted `tmuxPane` as evidence a
  herdr client *was* resolved. A herdr pane's own env never contributes one
  (#1348 suppresses it), so it can only have been adopted — and after this change
  a client living in tmux contributes nothing else.

### Why not `$TMUX_PANE` alone

`$TMUX_PANE` is **not self-describing**: every descendant of a pane inherits it,
including a GUI terminal or IDE launched from inside one (`code .`, `kitty`). Such
a process carries the stale pane address *next to a correct host identity it
reported itself*. Suppressing on the address alone discarded that host and turned
a working click-to-focus into a silent no-op — a regression, not a fix. tmux stamps
`TERM_PROGRAM=tmux` on the panes it spawns, so a process claiming any other host
claimed it for itself and is left alone; one claiming no host of its own (kitty
sets none, upstream kitty#4793) is suppressed and then recovered by the ancestry
walk, which is why that walk must stay enabled.

Result, measured live on real tmux panes:

```
before: {"term_program":"tmux","iterm_session_id":"w0t0p0:ALPHA-UUID","term_session_id":"ALPHA_TERMSESS","tmux_pane":"%4","tmux_socket":"...","tty":"/dev/ttys026"}
after:  {"tmux_pane":"%4","tmux_socket":"...","tty":"/dev/ttys026"}
```

**Control is unaffected**, as the issue predicted: `resolveBackend` picks
`backendTmux` from `TmuxPane` alone, before it ever reads `TermProgram`.

**Cost profile: nothing added.** No new probe, no new shellout, no sweep-time work,
no extra process walk — the ancestry fallbacks run exactly where they ran before.
Zero tmux sessions costs exactly what it did before.

## Red-first

Every assertion here was seen failing before its fix existed.

**The leak** (against unmodified `main`, production files reverted to the branch
point with the tests at HEAD):

```
--- FAIL: TestLauncherFromEnv_TmuxSuppressesInheritedIdentity
    TermProgram: tmux's own name is not a host, got "tmux"
    iTerm/Terminal.app session identity must not survive, got iterm="w0t0p0:ALPHA-UUID" term="ALPHA_TERMSESS"
    kitty identity must not survive, got listen="unix:/tmp/kitty-ALPHA/sock" window="77" pid=555
    VSCodePID: inherited value must not survive, got 4242
--- FAIL: TestReadLauncherEnv_Subprocess_TmuxSuppressesInheritedIdentity
    inherited terminal identity survived the real read path: &{TermProgram:tmux ITermSessionID:w0t0p0:ALPHA-UUID ...}
    tmux's own marker must never be kept as a host: &{TermProgram:tmux ...}
```

**The over-broad first cut** (`TestLauncherFromEnv_TmuxSuppressionSparesADescendantsOwnHost`,
red against this PR's own first commit — this is the review finding):

```
--- FAIL: TestLauncherFromEnv_TmuxSuppressionSparesADescendantsOwnHost
    a descendant's own TERM_PROGRAM must survive, got ""
    VSCodePID: want 4242, got 0
```

**The herdr diagnostic** (Swift, `swift test` — not CI-gated, run locally):

```
SessionManagerTests.swift:500: error: XCTAssertEqual failed:
  ("herdr_pane=w1:p1, no attached client") is not equal to
  ("herdr_pane=w1:p1, client resolved but its host has no activator")
```

`TestLauncherFromEnv_TmuxCapture` and `TestLauncherFromEnv_TmuxSuppressionIsScoped`
are **locks** — they pass by construction before and after, and pin the blast
radius (the pane's address survives; an ordinary iTerm session is untouched).

Note what `TestReadLauncherEnv_Subprocess_TmuxSuppressesInheritedIdentity`
deliberately does *not* assert, unlike its herdr twin: `TermProgram == ""`. In a
test the spawned subprocess is a child of the test binary, which really is hosted
by a terminal, so ancestry legitimately repopulates it — the same recovery path a
kitty-from-pane window depends on. Asserting its absence would pin the bug.

## Deliberately NOT built

Making click-to-focus actually *work* for tmux needs #1350's counterpart: resolve
the attached client (`tmux -S <socket> list-clients -F '#{client_pid}'`, then read
that process's identity as a herdr client's is read). That is materially larger
than #1405 — `AdoptHostIdentity`'s deliberately-closed "put back" set would have to
grow to cover the tmux address or the pane loses its backchannel selector, and it
needs a refresh hook symmetric to `refreshHerdrHosts`. Flagged rather than
smuggled in; until then a tmux session honestly resolves to no host, which is the
same degradation a herdr session with no attached client already gets.

## Review

One `medium` review subagent. It confirmed four findings; all four are applied.
The first — the inherited-`$TMUX_PANE` regression above — was a real defect in
this PR's first cut, found by launching kitty from a tmux pane and measuring,
not by reading the diff. It also disproved the first cut's stated rationale for
skipping the ancestry walk (the walk is inert because the server is reparented,
not because it would rediscover the suppressed host), and that correction is now
in the code comments rather than only in this description.

## Scope note

No throwaway tmux session outlived the investigation; the user's own `default`
socket was never touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
