### PR TITLE
feat(hookjson): fold the consent keys into the decode chokepoint (#1488)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -209,6 +209,61 @@ Before marking a ticket done, run the full suite — every layer must pass:
   kitty remote-control (install-type `Apply`/`Remove`), and `InputService`'s
   backchannel forwarding (the shared "control" gate) for the three call-site
   shapes it covers.
+  For a **hook receiver** the key set is no longer the wiring's to name. Since
+  #1488 a receiver declares its permissions to `hookjson.NewHandler` (via
+  `hookjson.RequireConsent`, whose first key is positional — a keyless receiver
+  does not compile), the handler publishes them as `HookHandler.Consent`, and
+  `contracttesting.AssertHookReceiverPermissionGated` derives one arm per
+  declared key. A receiver that later honours a third permission is graded on it
+  by existing rather than by someone remembering — which is what #1475 could
+  assert but not enforce, copilot's receiver having reached #1475 with no wiring
+  at all. Three things to know before touching it:
+  - `DecodeConfined` re-checks the whole declared set and fails closed, so a
+    receiver that declares a permission and never checks it drops the payload
+    instead of dispatching. That is #1466's shape, removed rather than detected.
+    It refuses **before** reading the body and before the confine, so a denied
+    request costs no decode, no path resolution and no confiner counter —
+    asserted by `TestDecodeConfined_RefusesBeforeReadingAnything`, because
+    deleting that guard and merely *moving* it are different mutations and only
+    the first reddens the others.
+  - **The backstop quietens every per-adapter consent mutation that graded
+    DISPATCH, so what those tests assert had to move to the one thing it does
+    NOT reproduce: silence.** Deleting a receiver's own `transcripts` gate used
+    to fail `…/transcripts/gated_on_the_named_key` plus that adapter's #1466
+    defect test; after #1488 the chokepoint drops the same payload, so every
+    dispatch-shaped assertion stays green (measured on all four receivers —
+    claudecode's hooks and statusline, codex, copilot). It is not silent about
+    it: reaching the backstop means a receiver skipped a check or consent was
+    revoked mid-request, so it logs an error, where a receiver's own gate
+    answers a quiet 200. That difference is both the surviving discriminator
+    and a real user-facing property — an ordinary denied session must not
+    collect an error line per tool call — so each of the four receivers' hand-
+    written consent tests now asserts **no error was logged**, and each was
+    seen red again with its gate deleted. Statusline is the receiver to watch
+    here: it declares ONE permission and keeps no second gate, so that
+    assertion is the whole of its live per-adapter proof.
+  - Beside those four, the coverage is one shared proof plus one lock per
+    adapter: `hookjson/consent_test.go`'s committed `forgetfulReceiver`
+    (declares two keys, checks one) grades the backstop for every receiver at
+    once, and `AssertDeclaredPermissions` / each adapter's
+    `Test…DeclaresItsPermissions` replays the key list its wiring used to spell
+    out, so the predecessor's cases are not deleted along with it (#1450).
+    Declaring the WRONG set reddens both.
+  - What did not move is the ORDER — but note exactly how much of it is held.
+    The channel key must stay ahead of `hookjson.ObserveHookReceipt`, and that
+    half IS enforced: deleting the `hooks` check, or hoisting the receipt above
+    it, reddens `AssertHookReceiptObserved`'s
+    `consent_denied_request_is_not_counted` (measured both ways). The other
+    half — the transcript key staying BEHIND the receipt, so a hooks-granted /
+    transcripts-denied install is not reported dead by #1368's watchdog — is
+    held by nothing: hoisting that check above the receipt is green here and
+    was green before #1488 too, so it is a standing gap rather than a
+    regression, and it is stated here rather than left implied by the sentence
+    above it.
+  `HookReceiverGate.Foreign` exists for the one receiver declaring a SINGLE
+  permission — claudecode's statusline — where the derived set leaves nothing to
+  hold open and the driver refuses rather than running a #1475 isolation arm
+  that proves nothing.
   A wiring names the permission under test (`Key`) and at least one the call
   site must NOT be gated on (`OtherKeys`), and `SetState` takes the key it is
   driving — because until #1475 it did not, and every live-gate wiring supplied
@@ -228,12 +283,15 @@ Before marking a ticket done, run the full suite — every layer must pass:
   whose wiring supplies the fake is a contract whose wiring can supply a
   key-blind one. The static `keyedGate` map literals in the adapter test
   packages are a different thing and stay: they pin a fixed two-permission
-  combination in one-off tests and were never key-blind. A receiver gated on
+  combination in one-off tests and were never key-blind. A call site gated on
   more than one permission wires `AssertPermissionGatedOnEachKey` rather than a
   hand-written table pairing each key with "the other one" — it names its key
   set once and the pairing is derived, because such a table can silently list
   only one direction and the direction that already works is
-  indistinguishable from covering both. Install-type wirings use
+  indistinguishable from covering both. A hook receiver is the exception and
+  names no set at all: since #1488 it wires
+  `AssertHookReceiverPermissionGated`, which derives the set from the
+  receiver's own declaration (the bullet above). Install-type wirings use
   `contracttesting.OnlyKey` instead of re-deciding per adapter that a foreign
   key is a no-op. The arm is
   load-bearing only for live per-request gates; for an install-type permission
@@ -526,11 +584,15 @@ Before marking a ticket done, run the full suite — every layer must pass:
   or, for a delivery route no adapter has adopted yet, against its reference
   wiring — so their whole value is that they *can* fail. Seven is a count of
   *obligations*, not of exported `Assert…` functions: `grep -c "^func Assert"`
-  over the package currently returns eight, because
-  `AssertPermissionGatedOnEachKey` is a driver that runs the permission-gate
-  family once per key, not a family of its own. Check what a function asserts
-  before moving this number (and before re-counting with `git grep`, whose
-  pathspec `*` crosses directory boundaries and returns nine). A new or reworked
+  over the package currently returns ten, because three of those are not
+  families. `AssertPermissionGatedOnEachKey` and
+  `AssertHookReceiverPermissionGated` are **drivers** running the
+  permission-gate family once per key — the first over a set the wiring names,
+  the second over one derived from the receiver itself (#1488) — and
+  `AssertDeclaredPermissions` is a one-line **lock** on that derivation rather
+  than an obligation of its own. Check what a function asserts before moving
+  this number (and before re-counting with `git grep`, whose pathspec `*`
+  crosses directory boundaries and returns one more). A new or reworked
   contract assertion is therefore the mutation rule at the top of this section
   in its most literal form: it lands with the deliberate mutation seen red for
   each obligation — and since #1479 that mutation is **committed beside the
@@ -565,7 +627,16 @@ Before marking a ticket done, run the full suite — every layer must pass:
   self-tests (permission gate, hook endpoint, hook disclosure, hook version);
   the three receiver-shaped ones, and a source walk that would make a fifth
   family covered by existing rather than by remembering, are #1497 — queued
-  behind #1488, which changes the fake receiver all three would share.
+  behind #1488, which changed the fake receiver all three would share. It made
+  that fixture cheaper rather than dearer, but did not build it:
+  `hookjson.NewHandler` now takes the consent alongside the confiner, so one
+  `RequireConsent` line replaces the ad-hoc gate each of the three would have
+  wired separately, and `hook_receiver_gate_test.go`'s `gatedFakeReceiver`
+  shows the constructor shape. What that fixture still lacks is most of what
+  #1497 specifies — it passes a nil confiner and never reaches
+  `DecodeConfined`, so it carries no declared roots, no rejection counters and
+  no receipt. The consent third is done; the roots-and-counters two thirds are
+  still #1497's to write.
 - Guarded construction: not a contract family — a package-local pair of guards,
   `core/application/services/construction_test.go`. A service whose fields
   include maps, channels, or anything else whose zero value is unusable is

--- a/core/adapters/inbound/agents/claudecode/hooks.go
+++ b/core/adapters/inbound/agents/claudecode/hooks.go
@@ -241,8 +241,9 @@ func sessionIDFromTranscriptPath(p string) string {
 // gate means no gating — used by tests.
 func NewHookHandler(target HookTarget, markers MarkerTarget, gate ConsentGranter, log outbound.Logger) hookjson.HookHandler {
 	return hookjson.NewHandler(transcriptConfiner(),
-		func(c *hookjson.PathConfiner, w http.ResponseWriter, r *http.Request) {
-			serveHookRequest(target, markers, gate, log, c, w, r)
+		hookjson.RequireConsent(gate, AdapterName, PermissionKeyHooks, PermissionKeyTranscripts),
+		func(consent hookjson.Consent, c *hookjson.PathConfiner, w http.ResponseWriter, r *http.Request) {
+			serveHookRequest(target, markers, consent, log, c, w, r)
 		})
 }
 
@@ -282,15 +283,21 @@ func transcriptConfiner() *hookjson.PathConfiner {
 // transcript the user had denied (issue #1466). A hooks-granted /
 // transcripts-denied session is not monitored anyway, so dropping the hook
 // here is both consent-correct and behaviourally harmless.
-func admitHookRequest(gate ConsentGranter, w http.ResponseWriter) bool {
-	if gate != nil && !gate.Granted(AdapterName, PermissionKeyHooks) {
+//
+// Both keys are asked of the receiver's OWN hookjson.Consent (issue #1488), so
+// the pair this order is written for is the pair the handler publishes and the
+// contract derives — not a second list that could drift from it. A key this
+// receiver did not declare answers false, so the drift fails closed rather than
+// silently gating on nothing.
+func admitHookRequest(consent hookjson.Consent, w http.ResponseWriter) bool {
+	if !consent.Granted(PermissionKeyHooks) {
 		w.WriteHeader(http.StatusOK)
 		return false
 	}
 
 	hookjson.ObserveHookReceipt(AdapterName)
 
-	if gate != nil && !gate.Granted(AdapterName, PermissionKeyTranscripts) {
+	if !consent.Granted(PermissionKeyTranscripts) {
 		w.WriteHeader(http.StatusOK)
 		return false
 	}
@@ -301,13 +308,13 @@ func admitHookRequest(gate ConsentGranter, w http.ResponseWriter) bool {
 // returned closure so its branching isn't counted at the closure's extra
 // nesting depth (go:S3776 — this dropped the reported complexity from 31 to
 // within the 15-point budget without changing any behavior).
-func serveHookRequest(target HookTarget, markers MarkerTarget, gate ConsentGranter, log outbound.Logger, confiner *hookjson.PathConfiner, w http.ResponseWriter, r *http.Request) {
+func serveHookRequest(target HookTarget, markers MarkerTarget, consent hookjson.Consent, log outbound.Logger, confiner *hookjson.PathConfiner, w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
 
-	if !admitHookRequest(gate, w) {
+	if !admitHookRequest(consent, w) {
 		return
 	}
 
@@ -319,7 +326,7 @@ func serveHookRequest(target HookTarget, markers MarkerTarget, gate ConsentGrant
 	// with the confined one, so nothing below can pick it back up (issues
 	// #1361, #1389). It has already answered the request when it returns false.
 	var payload hookPayload
-	if !hookjson.DecodeConfined(w, r, log, logComponentHookReceiver, confiner, &payload,
+	if !hookjson.DecodeConfined(w, r, log, logComponentHookReceiver, consent, confiner, &payload,
 		func(p *hookPayload) string { return p.TranscriptPath },
 		func(p *hookPayload, confined string) { p.TranscriptPath = confined },
 	) {

--- a/core/adapters/inbound/agents/claudecode/hooks_test.go
+++ b/core/adapters/inbound/agents/claudecode/hooks_test.go
@@ -784,13 +784,16 @@ func TestHookHandler_PreToolUse_UserInputToolStillDispatchesWithMarkerScan(t *te
 // granted (issue #1475). A single wiring over a key-blind gate is what let
 // this receiver dispatch with "transcripts" denied for the whole of its life
 // (issue #1466) while this very test was green.
+//
+// Since #1488 the wiring no longer NAMES that pair: the receiver declares it to
+// hookjson.NewHandler, the handler publishes it, and the driver derives one arm
+// per declared permission. A third permission here would be graded without
+// anyone editing this test. TestHookHandler_DeclaresItsPermissions below is the
+// lock on what that derivation currently yields.
 func TestHookHandler_PermissionGateContract(t *testing.T) {
-	keys := []string{PermissionKeyHooks, PermissionKeyTranscripts}
-
-	contracttesting.AssertPermissionGatedOnEachKey(t, keys,
-		func(key string, others []string) contracttesting.PermissionGate {
+	contracttesting.AssertHookReceiverPermissionGated(t, contracttesting.HookReceiverGate{
+		Build: func(t *testing.T, gate *contracttesting.ConsentGate) contracttesting.GatedHookReceiver {
 			target := &mockTarget{}
-			gate := contracttesting.NewConsentGate()
 			handler := NewHookHandler(target, nil, gate, mockLogger{})
 			payload := hookPayload{
 				TranscriptPath: inTreeTranscript(t, "sess-gate"),
@@ -798,17 +801,26 @@ func TestHookHandler_PermissionGateContract(t *testing.T) {
 				ToolName:       "Bash",
 			}
 
-			return contracttesting.PermissionGate{
-				Key:       key,
-				OtherKeys: others,
-				SetState:  gate.SetState,
+			return contracttesting.GatedHookReceiver{
+				Handler: handler,
 				Exercise: func() {
 					target.reset()
 					postHook(t, handler, payload)
 				},
 				Observe: func() bool { return len(target.getCalls()) > 0 },
 			}
-		})
+		},
+	})
+}
+
+// TestHookHandler_DeclaresItsPermissions is the LOCK on the key list the
+// wiring above used to spell out. Per #1450 a rewritten guard replays its
+// predecessor's cases or it is not known to be a superset — and a derivation
+// is the one thing that cannot assert what it derives.
+func TestHookHandler_DeclaresItsPermissions(t *testing.T) {
+	contracttesting.AssertDeclaredPermissions(t,
+		NewHookHandler(&mockTarget{}, nil, nil, mockLogger{}),
+		PermissionKeyHooks, PermissionKeyTranscripts)
 }
 
 // TestHookHandler_TranscriptsConsentGatesTheRead is the issue #1466 defect
@@ -832,15 +844,24 @@ func TestHookHandler_PermissionGateContract(t *testing.T) {
 // It stays as a LOCK now that the contract above is key-aware (issue #1475).
 // The contract's key-isolation arm covers the dispatch obligation generically
 // — and covers it for every adapter that wires it, which three hand-written
-// per-adapter tests never could. What it does not cover is the status code:
-// AssertPermissionGated's Exercise is opaque to it, so the 200 asserted below
-// is this test's own. Per #1450 a rewritten guard replays its predecessor's
-// cases or it is not known to be a superset; this one is not a superset, so
-// the predecessor stays.
+// per-adapter tests never could. Per #1450 a rewritten guard replays its
+// predecessor's cases or it is not known to be a superset; this one is not a
+// superset, so the predecessor stays.
+//
+// Two of its three assertions are now the ONLY live ones. Since #1488
+// DecodeConfined refuses this same request on the receiver's own declaration,
+// so deleting the gate below leaves the dispatch assertion — and the whole
+// permission-gate contract — green (measured). What the chokepoint does NOT
+// reproduce is the SILENCE: it logs an error, because reaching it means a
+// receiver skipped its check or consent was revoked mid-request. A
+// transcripts-denied user must not collect an error line per tool call, so
+// that is both a real user-facing property and the assertion that keeps this
+// receiver's own gate load-bearing.
 func TestHookHandler_TranscriptsConsentGatesTheRead(t *testing.T) {
 	target := &mockTarget{}
 	gate := keyedGate{PermissionKeyHooks: true, PermissionKeyTranscripts: false}
-	handler := NewHookHandler(target, nil, gate, mockLogger{})
+	log := &contracttesting.RecordingLogger{}
+	handler := NewHookHandler(target, nil, gate, log)
 
 	rec := postHook(t, handler, hookPayload{
 		TranscriptPath: inTreeTranscript(t, "sess-transcripts-gate"),
@@ -854,5 +875,10 @@ func TestHookHandler_TranscriptsConsentGatesTheRead(t *testing.T) {
 	if got := target.getCalls(); len(got) != 0 {
 		t.Errorf("dispatched %d call(s) without transcripts consent: %+v — "+
 			"the detector opens the transcript this path hands it", len(got), got)
+	}
+	if len(log.Errors()) != 0 {
+		t.Errorf("a transcripts-denied hook logged %d error(s): %v — an ordinary denied session "+
+			"must be refused by THIS receiver's own gate, quietly. Reaching DecodeConfined's "+
+			"backstop instead means one error line per tool call, forever", len(log.Errors()), log.Errors())
 	}
 }

--- a/core/adapters/inbound/agents/claudecode/statusline.go
+++ b/core/adapters/inbound/agents/claudecode/statusline.go
@@ -80,8 +80,9 @@ const logComponentStatuslineReceiver = "statusline-receiver"
 // used by tests.
 func NewStatuslineHandler(target RateLimitIngester, gate ConsentGranter, log outbound.Logger) hookjson.HookHandler {
 	return hookjson.NewHandler(transcriptConfiner(),
-		func(c *hookjson.PathConfiner, w http.ResponseWriter, r *http.Request) {
-			serveStatuslineRequest(target, gate, log, c, w, r)
+		hookjson.RequireConsent(gate, AdapterName, PermissionKeyStatusline),
+		func(consent hookjson.Consent, c *hookjson.PathConfiner, w http.ResponseWriter, r *http.Request) {
+			serveStatuslineRequest(target, consent, log, c, w, r)
 		})
 }
 
@@ -89,13 +90,19 @@ func NewStatuslineHandler(target RateLimitIngester, gate ConsentGranter, log out
 // the returned closure so the constructor reads like its two siblings in
 // hooks.go and the branching isn't counted at the closure's extra nesting
 // depth.
-func serveStatuslineRequest(target RateLimitIngester, gate ConsentGranter, log outbound.Logger, confiner *hookjson.PathConfiner, w http.ResponseWriter, r *http.Request) {
+func serveStatuslineRequest(target RateLimitIngester, consent hookjson.Consent, log outbound.Logger, confiner *hookjson.PathConfiner, w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
 
-	if gate != nil && !gate.Granted(AdapterName, PermissionKeyStatusline) {
+	// The ONE permission this receiver acts under, and the whole of what it
+	// declares (issue #1488). It owes no "transcripts" consent: the path it
+	// forwards is a map key for metrics.IngestRateLimit, never opened — #1466
+	// is about the READ, and there is none here. Because the set is published
+	// on the handler, that judgement is now stated in one place and the
+	// contract grades exactly it.
+	if !consent.Granted(PermissionKeyStatusline) {
 		w.WriteHeader(http.StatusOK)
 		return
 	}
@@ -112,7 +119,7 @@ func serveStatuslineRequest(target RateLimitIngester, gate ConsentGranter, log o
 	// it was fixing. Going through DecodeConfined is what makes forgetting it
 	// a build failure rather than a review catch (issue #1389).
 	var payload statuslinePayload
-	if !hookjson.DecodeConfined(w, r, log, logComponentStatuslineReceiver, confiner, &payload,
+	if !hookjson.DecodeConfined(w, r, log, logComponentStatuslineReceiver, consent, confiner, &payload,
 		func(p *statuslinePayload) string { return p.TranscriptPath },
 		func(p *statuslinePayload, confined string) { p.TranscriptPath = confined },
 	) {

--- a/core/adapters/inbound/agents/claudecode/statusline_test.go
+++ b/core/adapters/inbound/agents/claudecode/statusline_test.go
@@ -265,9 +265,17 @@ func TestChainStatuslineCommand_MigratesOldWrapsToV3(t *testing.T) {
 	}
 }
 
+// TestStatuslineHandler_ConsentGateDropsWhenNotGranted is this receiver's only
+// hand-written consent test, and since #1488 its silence assertion is the only
+// part of it that still discriminates: DecodeConfined refuses the same request
+// on the declared key, so deleting the gate in serveStatuslineRequest leaves
+// the drop assertion and three of the four contract arms green (measured).
+// This receiver declares ONE permission, so unlike the hook receivers it keeps
+// no second gate whose deletion would redden — the silence is what is left.
 func TestStatuslineHandler_ConsentGateDropsWhenNotGranted(t *testing.T) {
 	target := &fakeRateLimitIngester{}
-	h := NewStatuslineHandler(target, fakeGate(false), silentLogger{})
+	log := &contracttesting.RecordingLogger{}
+	h := NewStatuslineHandler(target, fakeGate(false), log)
 
 	body := `{
 		"session_id": "abc",
@@ -286,6 +294,11 @@ func TestStatuslineHandler_ConsentGateDropsWhenNotGranted(t *testing.T) {
 	if len(target.calls) != 0 {
 		t.Fatalf("ingested %d snapshots while permission not granted", len(target.calls))
 	}
+	if len(log.Errors()) != 0 {
+		t.Errorf("a statusline-denied tick logged %d error(s): %v — the statusline hook fires on "+
+			"every prompt render, so refusing it anywhere but this receiver's own gate floods the "+
+			"log of a user who declined the feature", len(log.Errors()), log.Errors())
+	}
 }
 
 // TestStatuslineHandler_PermissionGateContract generalizes
@@ -294,9 +307,6 @@ func TestStatuslineHandler_ConsentGateDropsWhenNotGranted(t *testing.T) {
 // pending or denied, ingested once granted, and dropped again once
 // revoked.
 func TestStatuslineHandler_PermissionGateContract(t *testing.T) {
-	target := &fakeRateLimitIngester{}
-	gate := contracttesting.NewConsentGate()
-	h := NewStatuslineHandler(target, gate, silentLogger{})
 	body := `{
 		"session_id": "abc",
 		"transcript_path": "` + inTreeTranscript(t, "abc") + `",
@@ -305,24 +315,44 @@ func TestStatuslineHandler_PermissionGateContract(t *testing.T) {
 		}
 	}`
 
-	contracttesting.AssertPermissionGated(t, contracttesting.PermissionGate{
-		Key: PermissionKeyStatusline,
+	contracttesting.AssertHookReceiverPermissionGated(t, contracttesting.HookReceiverGate{
 		// This endpoint is a hook receiver too, so the two permissions it must
 		// NOT be gated on are the ones a copy-paste from hooks.go would reach
 		// for. It owes no transcripts consent of its own: the transcript path
 		// it forwards is used as a map key by metrics.IngestRateLimit, never
 		// opened (issue #1466 is about the READ, and there is none here).
-		OtherKeys: []string{PermissionKeyHooks, PermissionKeyTranscripts},
-		SetState:  gate.SetState,
-		Exercise: func() {
-			target.reset()
-			req := httptest.NewRequest(http.MethodPost, "/api/v1/hooks/claudecode/statusline", strings.NewReader(body))
-			rec := httptest.NewRecorder()
-			h.ServeHTTP(rec, req)
-			if rec.Code != http.StatusOK {
-				t.Fatalf("status = %d, want 200", rec.Code)
+		//
+		// Foreign is non-empty here and empty at the three hook receivers, and
+		// the asymmetry is the whole reason the field exists: this is the one
+		// receiver declaring a SINGLE permission, so its derived set leaves
+		// nothing to hold open and the #1475 isolation arm would have no state
+		// to run in.
+		Foreign: []string{PermissionKeyHooks, PermissionKeyTranscripts},
+		Build: func(t *testing.T, gate *contracttesting.ConsentGate) contracttesting.GatedHookReceiver {
+			target := &fakeRateLimitIngester{}
+			h := NewStatuslineHandler(target, gate, silentLogger{})
+			return contracttesting.GatedHookReceiver{
+				Handler: h,
+				Exercise: func() {
+					target.reset()
+					req := httptest.NewRequest(http.MethodPost, "/api/v1/hooks/claudecode/statusline", strings.NewReader(body))
+					rec := httptest.NewRecorder()
+					h.ServeHTTP(rec, req)
+					if rec.Code != http.StatusOK {
+						t.Fatalf("status = %d, want 200", rec.Code)
+					}
+				},
+				Observe: func() bool { return len(target.calls) > 0 },
 			}
 		},
-		Observe: func() bool { return len(target.calls) > 0 },
 	})
+}
+
+// TestStatuslineHandler_DeclaresItsPermission is the LOCK on the single key the
+// wiring above used to name through Key (#1450). It is the load-bearing half of
+// this receiver's asymmetry: statusline, and NOT hooks or transcripts.
+func TestStatuslineHandler_DeclaresItsPermission(t *testing.T) {
+	contracttesting.AssertDeclaredPermissions(t,
+		NewStatuslineHandler(&fakeRateLimitIngester{}, nil, silentLogger{}),
+		PermissionKeyStatusline)
 }

--- a/core/adapters/inbound/agents/codex/hooks.go
+++ b/core/adapters/inbound/agents/codex/hooks.go
@@ -103,8 +103,9 @@ type ConsentGranter = hookjson.ConsentGranter
 // tests.
 func NewHookHandler(target HookTarget, gate ConsentGranter, log outbound.Logger) hookjson.HookHandler {
 	return hookjson.NewHandler(transcriptConfiner(),
-		func(c *hookjson.PathConfiner, w http.ResponseWriter, r *http.Request) {
-			serveHookRequest(target, gate, log, c, w, r)
+		hookjson.RequireConsent(gate, AdapterName, PermissionKeyHooks, PermissionKeyTranscripts),
+		func(consent hookjson.Consent, c *hookjson.PathConfiner, w http.ResponseWriter, r *http.Request) {
+			serveHookRequest(target, consent, log, c, w, r)
 		})
 }
 
@@ -120,13 +121,17 @@ func transcriptConfiner() *hookjson.PathConfiner {
 // serveHookRequest is NewHookHandler's request logic, pulled out of the
 // returned closure so its branching isn't counted at the closure's extra
 // nesting depth.
-func serveHookRequest(target HookTarget, gate ConsentGranter, log outbound.Logger, confiner *hookjson.PathConfiner, w http.ResponseWriter, r *http.Request) {
+func serveHookRequest(target HookTarget, consent hookjson.Consent, log outbound.Logger, confiner *hookjson.PathConfiner, w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
 
-	if gate != nil && !gate.Granted(AdapterName, PermissionKeyHooks) {
+	// Both keys come off the receiver's OWN hookjson.Consent (issue #1488), so
+	// the set this sequence is written for is the set the handler publishes and
+	// the contract derives. A key this receiver did not declare answers false,
+	// so a drift between the two fails closed.
+	if !consent.Granted(PermissionKeyHooks) {
 		w.WriteHeader(http.StatusOK)
 		return
 	}
@@ -155,7 +160,7 @@ func serveHookRequest(target HookTarget, gate ConsentGranter, log outbound.Logge
 	// receipt above deliberately stays put: it is counted against the "hooks"
 	// consent only, since a hooks-granted / transcripts-denied install has a
 	// working channel this counter must not call dead (#1368).
-	if gate != nil && !gate.Granted(AdapterName, PermissionKeyTranscripts) {
+	if !consent.Granted(PermissionKeyTranscripts) {
 		w.WriteHeader(http.StatusOK)
 		return
 	}
@@ -167,7 +172,7 @@ func serveHookRequest(target HookTarget, gate ConsentGranter, log outbound.Logge
 	// overwrites the caller's string with the confined one so the target reads
 	// that (issues #1361, #1389). It has already answered when it returns false.
 	var payload codexHookPayload
-	if !hookjson.DecodeConfined(w, r, log, logComponentHookReceiver, confiner, &payload,
+	if !hookjson.DecodeConfined(w, r, log, logComponentHookReceiver, consent, confiner, &payload,
 		func(p *codexHookPayload) string { return p.TranscriptPath },
 		func(p *codexHookPayload, confined string) { p.TranscriptPath = confined },
 	) {

--- a/core/adapters/inbound/agents/codex/hooks_test.go
+++ b/core/adapters/inbound/agents/codex/hooks_test.go
@@ -342,9 +342,15 @@ func TestHookHandler_TranscriptsConsentGatesTheRead(t *testing.T) {
 	// read must be gated behind the "transcripts" consent — not merely the
 	// "hooks" write consent. With hooks granted but transcripts denied, the
 	// hook is dropped and the target is never called (issue #1174 review).
+	//
+	// Since #1488 the dispatch half no longer discriminates: DecodeConfined
+	// refuses this same request on the receiver's declaration, so deleting the
+	// gate below leaves it green (measured). The silence assertion is what
+	// still holds the gate in place — see contracttesting.RecordingLogger.
 	target := &mockTarget{}
 	gate := keyedGate{PermissionKeyHooks: true, PermissionKeyTranscripts: false}
-	handler := NewHookHandler(target, gate, mockLogger{})
+	log := &contracttesting.RecordingLogger{}
+	handler := NewHookHandler(target, gate, log)
 
 	rec := postHook(t, handler, codexHookPayload{
 		TranscriptPath: writeSessionTranscript(t, "sess-1"),
@@ -355,6 +361,10 @@ func TestHookHandler_TranscriptsConsentGatesTheRead(t *testing.T) {
 	}
 	if target.totalCalls() != 0 {
 		t.Error("transcript read (and dispatch) happened without transcripts consent")
+	}
+	if len(log.Errors()) != 0 {
+		t.Errorf("a transcripts-denied hook logged %d error(s): %v — an ordinary denied session is "+
+			"this receiver's own gate to refuse, quietly", len(log.Errors()), log.Errors())
 	}
 }
 
@@ -379,25 +389,31 @@ func TestHookHandler_UnrecognizedEvent(t *testing.T) {
 // arm (issue #1475) holds one denied while the other is granted, which is the
 // only state that tells a receiver gated on the right permission from one gated
 // on the other.
+// Since #1488 the pair is derived from the receiver's own declaration rather
+// than named here; TestHookHandler_DeclaresItsPermissions locks what it yields.
 func TestHookHandler_PermissionGateContract(t *testing.T) {
-	keys := []string{PermissionKeyHooks, PermissionKeyTranscripts}
-
-	contracttesting.AssertPermissionGatedOnEachKey(t, keys,
-		func(key string, others []string) contracttesting.PermissionGate {
+	contracttesting.AssertHookReceiverPermissionGated(t, contracttesting.HookReceiverGate{
+		Build: func(t *testing.T, gate *contracttesting.ConsentGate) contracttesting.GatedHookReceiver {
 			target := &mockTarget{}
-			gate := contracttesting.NewConsentGate()
 			handler := NewHookHandler(target, gate, mockLogger{})
 			payload := codexHookPayload{
 				TranscriptPath: writeSessionTranscript(t, "sess-gate"),
 				HookEventName:  HookPermissionRequest,
 				ToolName:       "shell",
 			}
-			return contracttesting.PermissionGate{
-				Key:       key,
-				OtherKeys: others,
-				SetState:  gate.SetState,
-				Exercise:  func() { target.reset(); postHook(t, handler, payload) },
-				Observe:   func() bool { return target.totalCalls() > 0 },
+			return contracttesting.GatedHookReceiver{
+				Handler:  handler,
+				Exercise: func() { target.reset(); postHook(t, handler, payload) },
+				Observe:  func() bool { return target.totalCalls() > 0 },
 			}
-		})
+		},
+	})
+}
+
+// TestHookHandler_DeclaresItsPermissions is the LOCK on the key list the
+// wiring above used to spell out (#1450).
+func TestHookHandler_DeclaresItsPermissions(t *testing.T) {
+	contracttesting.AssertDeclaredPermissions(t,
+		NewHookHandler(&mockTarget{}, nil, mockLogger{}),
+		PermissionKeyHooks, PermissionKeyTranscripts)
 }

--- a/core/adapters/inbound/agents/copilot/hooks.go
+++ b/core/adapters/inbound/agents/copilot/hooks.go
@@ -160,8 +160,9 @@ type ConsentGranter = hookjson.ConsentGranter
 // means no gating — used by tests.
 func NewHookHandler(target HookTarget, gate ConsentGranter, log outbound.Logger) hookjson.HookHandler {
 	return hookjson.NewHandler(transcriptConfiner(),
-		func(c *hookjson.PathConfiner, w http.ResponseWriter, r *http.Request) {
-			serveHookRequest(target, gate, log, c, w, r)
+		hookjson.RequireConsent(gate, AdapterName, PermissionKeyHooks, PermissionKeyTranscripts),
+		func(consent hookjson.Consent, c *hookjson.PathConfiner, w http.ResponseWriter, r *http.Request) {
+			serveHookRequest(target, consent, log, c, w, r)
 		})
 }
 
@@ -178,13 +179,17 @@ func transcriptConfiner() *hookjson.PathConfiner {
 // returned closure so its branching isn't counted at the closure's extra
 // nesting depth. The step order matches codex's receiver exactly and each step
 // is load-bearing — see the contract assertions in hook*_test.go.
-func serveHookRequest(target HookTarget, gate ConsentGranter, log outbound.Logger, confiner *hookjson.PathConfiner, w http.ResponseWriter, r *http.Request) {
+func serveHookRequest(target HookTarget, consent hookjson.Consent, log outbound.Logger, confiner *hookjson.PathConfiner, w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
 
-	if gate != nil && !gate.Granted(AdapterName, PermissionKeyHooks) {
+	// Both keys come off the receiver's OWN hookjson.Consent (issue #1488), so
+	// the set this sequence is written for is the set the handler publishes and
+	// the contract derives. A key this receiver did not declare answers false,
+	// so a drift between the two fails closed.
+	if !consent.Granted(PermissionKeyHooks) {
 		w.WriteHeader(http.StatusOK)
 		return
 	}
@@ -203,7 +208,7 @@ func serveHookRequest(target HookTarget, gate ConsentGranter, log outbound.Logge
 	// welded those two into one call, and this moved above the pair rather than
 	// being folded into it — see codex's receiver for the full argument, which
 	// this one mirrors step for step.
-	if gate != nil && !gate.Granted(AdapterName, PermissionKeyTranscripts) {
+	if !consent.Granted(PermissionKeyTranscripts) {
 		w.WriteHeader(http.StatusOK)
 		return
 	}
@@ -221,7 +226,7 @@ func serveHookRequest(target HookTarget, gate ConsentGranter, log outbound.Logge
 	// then leaves payload.TranscriptPath holding the confined path on BOTH
 	// branches, where before it kept the caller's raw string on Stop.
 	var payload copilotHookPayload
-	if !hookjson.DecodeConfined(w, r, log, logComponentHookReceiver, confiner, &payload,
+	if !hookjson.DecodeConfined(w, r, log, logComponentHookReceiver, consent, confiner, &payload,
 		func(p *copilotHookPayload) string { return resolveTranscriptPath(*p) },
 		func(p *copilotHookPayload, confined string) { p.TranscriptPath = confined },
 	) {

--- a/core/adapters/inbound/agents/copilot/hooks_test.go
+++ b/core/adapters/inbound/agents/copilot/hooks_test.go
@@ -346,11 +346,18 @@ func TestHookReceiver_DeniedHooksConsentDropsQuietly(t *testing.T) {
 // TestHookReceiver_DeniedTranscriptsConsentDropsQuietly pins the second gate:
 // dispatching makes the detector read the transcript, so a transcripts-denied
 // session must not dispatch even though the hooks consent is granted.
+//
+// "Quietly" was decoration when this test was written and is now the load-
+// bearing half. Since #1488 DecodeConfined refuses the same request on the
+// receiver's declaration, so the dispatch assertion survives deleting the gate
+// below (measured); the silence does not, because the backstop logs an error
+// where this receiver's own gate says nothing. See contracttesting.RecordingLogger.
 func TestHookReceiver_DeniedTranscriptsConsentDropsQuietly(t *testing.T) {
 	root := copilotSessionRoot(t)
 	tp := writeSessionTranscript(t, root, "sess-stop")
 	target := &mockTarget{}
-	h := NewHookHandler(target, keyedGate{PermissionKeyHooks: true}, mockLogger{})
+	log := &contracttesting.RecordingLogger{}
+	h := NewHookHandler(target, keyedGate{PermissionKeyHooks: true}, log)
 
 	rec := post(t, h, contractPayload(tp, HookStop))
 
@@ -359,6 +366,10 @@ func TestHookReceiver_DeniedTranscriptsConsentDropsQuietly(t *testing.T) {
 	}
 	if n := target.totalCalls(); n != 0 {
 		t.Fatalf("dispatched %d times while transcripts consent was denied, want 0", n)
+	}
+	if len(log.Errors()) != 0 {
+		t.Errorf("a transcripts-denied hook logged %d error(s): %v — the whole point of the word "+
+			"in this test's name", len(log.Errors()), log.Errors())
 	}
 }
 
@@ -372,29 +383,36 @@ func TestHookReceiver_DeniedTranscriptsConsentDropsQuietly(t *testing.T) {
 // separates a receiver gated on the right permission from one gated on the
 // other, and it is the state claudecode sat in undetected for its whole life
 // (issue #1466).
+// Since #1488 the pair is derived from the receiver's own declaration rather
+// than named here — which also means this receiver could no longer have reached
+// #1475 with no wiring at all, the state it was found in.
 func TestHookReceiver_PermissionGateContract(t *testing.T) {
-	keys := []string{PermissionKeyHooks, PermissionKeyTranscripts}
-
-	contracttesting.AssertPermissionGatedOnEachKey(t, keys,
-		func(key string, others []string) contracttesting.PermissionGate {
+	contracttesting.AssertHookReceiverPermissionGated(t, contracttesting.HookReceiverGate{
+		Build: func(t *testing.T, gate *contracttesting.ConsentGate) contracttesting.GatedHookReceiver {
 			root := copilotSessionRoot(t)
 			body := contractPayload(writeSessionTranscript(t, root, "sess-gate"), HookStop)
 			target := &mockTarget{}
-			gate := contracttesting.NewConsentGate()
 			h := NewHookHandler(target, gate, mockLogger{})
 
 			before := 0
-			return contracttesting.PermissionGate{
-				Key:       key,
-				OtherKeys: others,
-				SetState:  gate.SetState,
+			return contracttesting.GatedHookReceiver{
+				Handler: h,
 				Exercise: func() {
 					before = target.totalCalls()
 					post(t, h, body)
 				},
 				Observe: func() bool { return target.totalCalls() > before },
 			}
-		})
+		},
+	})
+}
+
+// TestHookReceiver_DeclaresItsPermissions is the LOCK on the key list the
+// wiring above used to spell out (#1450).
+func TestHookReceiver_DeclaresItsPermissions(t *testing.T) {
+	contracttesting.AssertDeclaredPermissions(t,
+		NewHookHandler(&mockTarget{}, nil, mockLogger{}),
+		PermissionKeyHooks, PermissionKeyTranscripts)
 }
 
 // TestHookReceiver_NonPostRejected is a LOCK on the shared receiver shape.

--- a/core/adapters/inbound/agents/hookjson/consent.go
+++ b/core/adapters/inbound/agents/hookjson/consent.go
@@ -1,10 +1,12 @@
-// consent.go holds the one receiver-side type the JSON-hook adapters share
-// verbatim. Their HookTarget interfaces and payload structs deliberately stay
+// consent.go holds the receiver-side consent types the JSON-hook adapters
+// share. Their HookTarget interfaces and payload structs deliberately stay
 // per-adapter — those differ in shape and in intent (Codex, for instance, does
 // not decode session_id at all, because a Codex session shares its id with
 // every child) and merging them would couple the adapters to each other's
 // event sets rather than to a common contract.
 package hookjson
+
+import "slices"
 
 // ConsentGranter reports whether the user has granted a permission (issue
 // #570). Satisfied by *services.PermissionService. Hooks installed by a
@@ -12,4 +14,132 @@ package hookjson
 // receiver drops payloads while its permission is pending or denied.
 type ConsentGranter interface {
 	Granted(agentName, key string) bool
+}
+
+// Consent is the set of permissions ONE hook receiver acts under, bound to the
+// granter that answers for them and to the adapter they belong to.
+//
+// # Why this type exists at all
+//
+// #1361 made a receiver confine caller-supplied paths, #1389 welded the
+// confinement to the decode so it could not be skipped, and #1390 published the
+// confiner on the handler so the contract graded the object the daemon builds.
+// Consent is the same three moves for the OTHER thing a receiver owes: the #570
+// permission its work happens under.
+//
+// #1475 made contracttesting.AssertPermissionGated key-aware, so "gated on the
+// RIGHT permission" became assertable. It did not make it unforgettable: a
+// receiver must be wired once per permission it honours, and nothing failed if
+// an author wired only one arm — copilot's receiver reached #1475 with no
+// contract wiring at all, correct by its author's care rather than by anything
+// that would have caught its absence (issue #1488).
+//
+// Naming the keys HERE removes both acts of memory at once, because the set
+// becomes a property of the receiver rather than of the test that grades it:
+//
+//   - NewHandler takes a Consent, so a receiver that names no permission does
+//     not compile. That is a type guarantee and needs no tripwire policing it,
+//     the same trade #1390 made for the confiner and #1479 for armT.fixtures.
+//   - HookHandler publishes it, so a contract wiring DERIVES the keys instead
+//     of listing them. A receiver that later honours a third permission grows a
+//     third contract arm by existing, not by being remembered.
+//   - DecodeConfined refuses to decode while any DECLARED key is ungranted, so
+//     a receiver that declares a permission and then forgets to check it drops
+//     the payload rather than dispatching. That is the #1466 shape, and it is
+//     the one direction a declaration alone would leave open.
+//
+// # What it deliberately does NOT do
+//
+// It does not run the checks for the receiver, and it does not know their
+// ORDER. That order is the contract (see claudecode's admitHookRequest) and it
+// is load-bearing in two directions at once: the channel key has to be checked
+// BEFORE ObserveHookReceipt so a consent-denied request counts no receipt,
+// and the transcript key AFTER it so a hooks-granted / transcripts-denied
+// install is not falsely reported dead by #1368's liveness watchdog. Folding
+// the sequence in here would put those two obligations — plus the receipt, plus
+// the response code — in a function whose callers cannot see them, which is the
+// shape #1364's IgnoreUnknownEvent avoids by taking no ResponseWriter. The
+// receiver keeps writing the sequence; this type only makes the SET
+// unforgettable and re-checks it at the chokepoint.
+//
+// # Zero value, and why it is a value type rather than a pointer
+//
+// The zero Consent declares nothing and grants nothing: DecodeConfined fails
+// closed on it, loudly, and consent_test.go commits that mutation. It is a
+// value rather than a pointer because it has no mutable state to share — unlike
+// PathConfiner, whose per-instance rejection counters are the whole reason the
+// handler must publish the same instance the request path uses. A value also
+// leaves exactly ONE degenerate spelling to guard (Consent{}) instead of two
+// (nil and the zero struct).
+type Consent struct {
+	granter ConsentGranter
+	agent   string
+	keys    []string
+}
+
+// RequireConsent declares the permissions a receiver acts under.
+//
+// key is positional and more is variadic, so "at least one permission" is
+// enforced by the signature rather than by a check: RequireConsent(g, name) is
+// a compile error, and there is no spelling of a keyless receiver that builds.
+//
+// A nil granter answers granted for every DECLARED key. That is the existing
+// test-only ungated shape every receiver constructor documents (`a nil gate
+// means no gating`), preserved verbatim rather than changed here — production
+// wiring in registerHookRoutes always passes the PermissionService. Note what
+// it is not: it is not a way to reach an UNDECLARED key, which stays false
+// however the granter answers.
+func RequireConsent(granter ConsentGranter, agentName, key string, more ...string) Consent {
+	keys := make([]string, 0, 1+len(more))
+	keys = append(keys, key)
+	keys = append(keys, more...)
+	return Consent{granter: granter, agent: agentName, keys: keys}
+}
+
+// Keys returns the permissions this receiver declared, in declaration order.
+//
+// This is what a contract wiring reads instead of restating the list: the set
+// under test is then taken off the receiver the daemon builds, so it cannot
+// drift from what production actually honours (issue #1488). The copy is
+// deliberate — a caller that sorted or truncated the returned slice would edit
+// the receiver's own declaration.
+func (c Consent) Keys() []string {
+	return slices.Clone(c.keys)
+}
+
+// Granted reports whether one DECLARED permission is currently granted.
+//
+// An undeclared key is false, always, and that is the load-bearing half. A
+// receiver that checks a permission it never declared would otherwise gate
+// itself on something the published set does not mention — so the contract
+// would derive one set while the request path consulted another, which is the
+// two-objects-that-disagree failure #1390 removed for the confiner. Answering
+// false makes such a receiver drop everything, which is loud on its first test
+// rather than silent for its whole life.
+func (c Consent) Granted(key string) bool {
+	if !c.declares(key) {
+		return false
+	}
+	if c.granter == nil {
+		return true
+	}
+	return c.granter.Granted(c.agent, key)
+}
+
+// declares reports whether key is in the declared set.
+func (c Consent) declares(key string) bool {
+	return slices.Contains(c.keys, key)
+}
+
+// ungranted returns the first declared permission that is not currently
+// granted, and whether there was one. DecodeConfined uses it as the backstop:
+// see this file's header for why the receiver still runs its own checks in its
+// own order, and decode.go for what the backstop catches that they cannot.
+func (c Consent) ungranted() (string, bool) {
+	for _, k := range c.keys {
+		if !c.Granted(k) {
+			return k, true
+		}
+	}
+	return "", false
 }

--- a/core/adapters/inbound/agents/hookjson/consent_test.go
+++ b/core/adapters/inbound/agents/hookjson/consent_test.go
@@ -1,0 +1,275 @@
+// consent_test.go is the committed mutation evidence for issue #1488.
+//
+// Consent's whole claim is that a receiver cannot act on an inbound body
+// without naming the permissions it acts under. Half of that claim is a type
+// guarantee and needs no test — NewHandler takes a Consent and RequireConsent
+// takes its first key positionally, so a keyless receiver does not compile, in
+// any spelling, and AGENTS.md's rule is that a type needs no proof where a
+// guard would.
+//
+// The other half CAN silently stop discriminating, so it is mutated here:
+//
+//   - the zero Consent, the one degenerate value the type still admits;
+//   - a receiver that DECLARES a permission and never checks it — #1466's exact
+//     shape, committed below as forgetfulReceiver rather than described, since
+//     a paragraph in a merged PR body is re-run by nothing;
+//   - the vacuity guard beside each, because an arm that refused
+//     unconditionally would satisfy both mutations and read as coverage.
+package hookjson
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"irrlicht/core/ports/outbound"
+)
+
+// keyedGranter answers per key, so one permission can be held denied while the
+// others are granted — the state that separates a receiver gated on the right
+// permission from one gated on any permission at all (issue #1475).
+type keyedGranter map[string]bool
+
+func (g keyedGranter) Granted(_ string, key string) bool { return g[key] }
+
+func TestRequireConsent_DeclaresEveryKeyInOrder(t *testing.T) {
+	c := RequireConsent(keyedGranter{}, "agent-x", "hooks", "transcripts", "statusline")
+
+	if got, want := strings.Join(c.Keys(), ","), "hooks,transcripts,statusline"; got != want {
+		t.Fatalf("Keys() = %q, want %q — a contract wiring derives its arms from this order", got, want)
+	}
+}
+
+// TestConsentKeys_ReturnsACopy pins the copy in Keys(). Without it a contract
+// wiring that sorted or truncated the returned slice would edit the receiver's
+// own declaration, and the request path would then consult a set nobody
+// declared.
+func TestConsentKeys_ReturnsACopy(t *testing.T) {
+	c := RequireConsent(keyedGranter{"hooks": true}, "agent-x", "hooks", "transcripts")
+
+	keys := c.Keys()
+	keys[0] = "clobbered"
+
+	if got := c.Keys()[0]; got != "hooks" {
+		t.Fatalf("mutating the returned slice changed the declaration: Keys()[0] = %q, want %q", got, "hooks")
+	}
+}
+
+// TestConsentGranted_AnUndeclaredKeyIsAlwaysFalse is the load-bearing arm of
+// Granted. A receiver checking a permission it never declared would gate itself
+// on something the published set does not mention, so the contract would derive
+// one set while the request path consulted another — the two-objects-that-
+// disagree failure #1390 removed for the confiner. The granter here answers
+// TRUE for that key, so only the declaration check can produce the false.
+func TestConsentGranted_AnUndeclaredKeyIsAlwaysFalse(t *testing.T) {
+	c := RequireConsent(keyedGranter{"hooks": true, "transcripts": true}, "agent-x", "hooks")
+
+	if !c.Granted("hooks") {
+		t.Fatal("a declared, granted key answered false — the vacuity guard for the arm below")
+	}
+	if c.Granted("transcripts") {
+		t.Fatal("an UNDECLARED key answered true because the granter said so — a receiver could " +
+			"then gate on a permission its published set never names, and the contract would " +
+			"grade a different set than the request path consults (issue #1488)")
+	}
+}
+
+// TestConsentGranted_NilGranterIsUngatedForDeclaredKeysOnly pins the test-only
+// ungated shape every receiver constructor documents, and pins its bound: a nil
+// granter is not a way to reach a permission that was never declared.
+func TestConsentGranted_NilGranterIsUngatedForDeclaredKeysOnly(t *testing.T) {
+	c := RequireConsent(nil, "agent-x", "hooks")
+
+	if !c.Granted("hooks") {
+		t.Error("a nil granter denied a declared key — every receiver constructor documents " +
+			"`a nil gate means no gating`, and dozens of tests build handlers that way")
+	}
+	if c.Granted("transcripts") {
+		t.Error("a nil granter granted an UNDECLARED key")
+	}
+}
+
+// --- the chokepoint backstop, and the committed receiver that needs it ---
+
+// forgetfulReceiver is issue #1466 reduced to a fixture and kept in the tree.
+//
+// It declares BOTH permissions and then checks only the first, which is exactly
+// what claudecode's hook receiver did for the whole of its life: "hooks" was
+// consulted, "transcripts" was declared by the adapter and never asked about,
+// and every test in the tree was green. Before #1488 nothing below the
+// receiver could tell it apart from a correct one — DecodeConfined took no
+// keys, so it had nothing to compare against.
+//
+// It is committed rather than described because that is the difference between
+// evidence that is re-run on every build and a paragraph in a merged PR body.
+func forgetfulReceiver(confiner *PathConfiner, consent Consent, log outbound.Logger) HookHandler {
+	return NewHandler(confiner, consent,
+		func(c Consent, pc *PathConfiner, w http.ResponseWriter, r *http.Request) {
+			// Checks the FIRST declared key only. The second is declared and
+			// never asked about — the mutation.
+			if !c.Granted(c.Keys()[0]) {
+				w.WriteHeader(http.StatusOK)
+				return
+			}
+			var p decodeTestPayload
+			if !DecodeConfined(w, r, log, "forgetful-receiver", c, pc, &p, getDecodePath, setDecodePath) {
+				return
+			}
+			// Dispatch: the effect a consent gate exists to prevent.
+			w.WriteHeader(http.StatusTeapot)
+		})
+}
+
+// postTo drives a handler with an in-tree transcript path and reports the
+// status. 418 means the receiver dispatched.
+func postTo(t *testing.T, h HookHandler, transcript string) int {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, postDecode(t, `{"transcript_path":`+strconv.Quote(transcript)+`}`))
+	return rec.Code
+}
+
+// TestDecodeConfined_RefusesADeclaredPermissionThatWasNeverChecked drives the
+// committed broken receiver above. With every declared key granted it must
+// still dispatch (the vacuity guard — a backstop that refused unconditionally
+// would satisfy the mutation below while discriminating nothing); with the
+// declared-but-unchecked key denied it must not.
+func TestDecodeConfined_RefusesADeclaredPermissionThatWasNeverChecked(t *testing.T) {
+	confiner, root := decodeConfinerRooted(t)
+	// An in-tree transcript, so the confiner's resolve step has a real leaf to
+	// accept — these cases are about consent, and a path rejection would fail
+	// them for the wrong reason.
+	transcript := writeFile(t, filepath.Join(root, "session.jsonl"))
+
+	t.Run("vacuity_guard_all_granted_still_dispatches", func(t *testing.T) {
+		granter := keyedGranter{"hooks": true, "transcripts": true}
+		h := forgetfulReceiver(confiner, RequireConsent(granter, "agent-x", "hooks", "transcripts"), &countingLogger{})
+
+		if got := postTo(t, h, transcript); got != http.StatusTeapot {
+			t.Fatalf("status = %d, want 418 — a receiver whose every declared permission is "+
+				"granted must still dispatch, or this file's mutation proves nothing", got)
+		}
+	})
+
+	t.Run("declared_but_unchecked_key_denied_drops_the_payload", func(t *testing.T) {
+		granter := keyedGranter{"hooks": true, "transcripts": false}
+		log := &countingLogger{}
+		h := forgetfulReceiver(confiner, RequireConsent(granter, "agent-x", "hooks", "transcripts"), log)
+
+		got := postTo(t, h, transcript)
+		if got == http.StatusTeapot {
+			t.Fatal("a receiver that DECLARES \"transcripts\" and never checks it dispatched with " +
+				"\"transcripts\" denied — that is issue #1466 verbatim, and the whole point of " +
+				"carrying the key set into the decode (issue #1488)")
+		}
+		if got < 200 || got > 299 {
+			t.Errorf("status = %d, want 2xx — a consent refusal is reported by the log, never by a "+
+				"status code on the user's critical path (#1361, #1364)", got)
+		}
+		if len(log.lines) == 0 {
+			t.Error("the refusal was silent — the log is the only surface a dropped hook has")
+		}
+	})
+}
+
+// TestDecodeConfined_RefusesBeforeReadingAnything is the arm the guard's own
+// doc sentence needs and the delete-mutation cannot supply: the refusal must
+// come BEFORE the body read and the confine, not merely before the dispatch.
+//
+// Review of PR #1506 moved the ungranted() check verbatim to just after
+// set(p, confined) and every package stayed green — so nothing held it in
+// place. What that permits is #570 broken inside the function added to enforce
+// it: a receiver whose declared key is denied would still allocate and decode
+// up to 1 MiB of caller-supplied body, run PathConfiner.Confine (a real
+// symlink resolution and stat of a path the user denied us), and move the
+// confiner's rejection counters, which AssertHookPathConfined and the
+// diagnostics bundle both read.
+//
+// Both observations are needed. The untouched payload catches a guard moved
+// below the decode; the untouched counters catch one moved below the confine,
+// which the payload alone cannot see for an out-of-tree path.
+func TestDecodeConfined_RefusesBeforeReadingAnything(t *testing.T) {
+	confiner, _ := decodeConfinerRooted(t)
+
+	granter := keyedGranter{"hooks": true, "transcripts": false}
+	consent := RequireConsent(granter, "agent-x", "hooks", "transcripts")
+
+	before := confiner.RejectionCount()
+	rec := httptest.NewRecorder()
+	p := decodeTestPayload{TranscriptPath: "untouched"}
+
+	// An OUT-OF-TREE path: were the guard below the confine, this would be
+	// refused there and bump a counter. Consent must refuse it first.
+	if DecodeConfined(rec, postDecode(t, `{"transcript_path":"/nowhere/at/all.jsonl","hook_event_name":"Stop"}`),
+		&countingLogger{}, "test-receiver", consent, confiner, &p, getDecodePath, setDecodePath) {
+		t.Fatal("a request with a declared permission denied was accepted")
+	}
+
+	if p.TranscriptPath != "untouched" || p.Event != "" {
+		t.Errorf("the body was DECODED for a consent-denied request (payload = %+v) — a receiver "+
+			"whose permission is withheld must not allocate and parse up to %d bytes on its "+
+			"behalf (#570: nothing is exercised while pending or denied)", p, maxHookBodyBytes)
+	}
+	if got := confiner.RejectionCount(); got != before {
+		t.Errorf("the confiner ran for a consent-denied request (rejections %d -> %d) — that "+
+			"resolves and stats a path the user denied us, and moves counters the path-confinement "+
+			"contract and the diagnostics bundle read", before, got)
+	}
+}
+
+// TestDecodeConfined_ZeroConsentFailsClosed covers the one degenerate value the
+// type still admits. RequireConsent cannot produce it (its first key is
+// positional), so this is reachable only by writing Consent{} — and a guard no
+// test executes is a guard no mutation can redden, which is the argument
+// decode_test.go's header makes for the nil-confiner arm.
+func TestDecodeConfined_ZeroConsentFailsClosed(t *testing.T) {
+	confiner, root := decodeConfinerRooted(t)
+	transcript := writeFile(t, filepath.Join(root, "session.jsonl"))
+
+	rec := httptest.NewRecorder()
+	log := &countingLogger{}
+	var p decodeTestPayload
+
+	ok := DecodeConfined(rec, postDecode(t, `{"transcript_path":`+strconv.Quote(transcript)+`}`),
+		log, "test-receiver", Consent{}, confiner, &p, getDecodePath, setDecodePath)
+
+	if ok {
+		t.Fatal("a receiver that named NO permission reached its payload — every hook receiver " +
+			"acts under at least one (#570), and an empty declaration must not read a body")
+	}
+	if rec.Code < 200 || rec.Code > 299 {
+		t.Errorf("status = %d, want 2xx — same rule as any other refusal", rec.Code)
+	}
+	if len(log.lines) == 0 {
+		t.Error("the refusal was silent")
+	}
+}
+
+// TestNewHandler_PublishesTheConsentTheRequestPathUses is the #1390 property
+// restated for consent: a contract wiring derives its arms from
+// HookHandler.Consent, so that value has to be the one the serve func is handed
+// rather than a second one built beside it.
+func TestNewHandler_PublishesTheConsentTheRequestPathUses(t *testing.T) {
+	confiner, _ := decodeConfinerRooted(t)
+	declared := RequireConsent(keyedGranter{"hooks": true}, "agent-x", "hooks", "transcripts")
+
+	var served Consent
+	h := NewHandler(confiner, declared, func(c Consent, _ *PathConfiner, w http.ResponseWriter, _ *http.Request) {
+		served = c
+		w.WriteHeader(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/hooks/test", strings.NewReader(`{}`))
+	h.ServeHTTP(httptest.NewRecorder(), req)
+
+	if got, want := strings.Join(served.Keys(), ","), strings.Join(h.Consent.Keys(), ","); got != want {
+		t.Fatalf("the request path saw %q but the handler publishes %q — a contract would grade "+
+			"a set the receiver does not use", got, want)
+	}
+	if got := strings.Join(h.Consent.Keys(), ","); got != "hooks,transcripts" {
+		t.Fatalf("HookHandler.Consent.Keys() = %q, want %q", got, "hooks,transcripts")
+	}
+}

--- a/core/adapters/inbound/agents/hookjson/decode.go
+++ b/core/adapters/inbound/agents/hookjson/decode.go
@@ -20,6 +20,16 @@
 // remember" into "the next adapter cannot forget": the contract polices
 // adapters that opted in, the architecture rule polices the ones that did not.
 //
+// #1488 hangs a second obligation on the same chokepoint, for the same reason
+// and by the same route. A receiver's #570 consent had exactly the shape
+// confinement had before #1389: assertable once wired, invisible when nobody
+// wired it. So the permissions a receiver acts under are now an ARGUMENT to the
+// decode too — declared once at NewHandler, published on the handler so a
+// contract derives them rather than restating them, and re-checked here so a
+// declaration that is never checked drops the payload instead of dispatching.
+// See consent.go for what this deliberately does not take over: the ORDER of
+// the receiver'"'"'s own gates, which no single call can express.
+//
 // Rejected, and settled — do not revisit: a mux-level middleware. It would have
 // to key on a top-level "transcript_path" JSON field and would FAIL OPEN for
 // any future payload that nests or renames it, finding nothing and confining
@@ -63,23 +73,67 @@ const maxHookBodyBytes = 1 << 20
 // That is the #1361 defect shape, and leaving set nil would leave the door
 // open.
 //
-// Deliberately NOT handled here: the consent gates. Both the "hooks" gate and
-// the receipt observation must happen before this call (a body we then refuse
-// still proves the channel is alive, #1368), and the adapters that additionally
-// gate "transcripts" check it before calling in. Folding consent into the
-// decode would make this function the place four different obligations are
-// re-decided per adapter, which is the shape #1364's IgnoreUnknownEvent
-// deliberately avoids by taking no ResponseWriter.
+// consent names the permissions this receiver acts under, and every one of them
+// must be granted before the body is read. This is a BACKSTOP, not the
+// receiver's gate: the receiver still runs its own checks, in its own order,
+// because that order is load-bearing in two directions this function cannot see
+// (the channel key ahead of ObserveHookReceipt so a consent-denied request
+// counts no receipt, the transcript key behind it so a hooks-granted /
+// transcripts-denied install is not reported dead by #1368's watchdog). What
+// the backstop adds is the case those checks cannot cover: a receiver that
+// DECLARES a permission and then never checks it. That is #1466 exactly —
+// claudecode read transcripts with "transcripts" denied for the whole of its
+// life — and it is why the keys travel with the decode rather than only with
+// the contract that grades it (issue #1488). It also closes the window where
+// consent is revoked between the receiver's check and this read.
+//
+// A zero Consent declares nothing and is refused, so a receiver cannot reach a
+// payload by passing an empty one; NewHandler and RequireConsent between them
+// make the honest spelling the only short one, and the keyless spelling does
+// not compile at all.
 func DecodeConfined[T any](
 	w http.ResponseWriter,
 	r *http.Request,
 	log outbound.Logger,
 	component string,
+	consent Consent,
 	c *PathConfiner,
 	p *T,
 	get func(*T) string,
 	set func(*T, string),
 ) bool {
+	// Fail closed on a receiver that named no permission. Every hook receiver
+	// acts under at least one (#570), so an empty declaration is a wiring that
+	// went through Consent{} rather than RequireConsent — it cannot be typed
+	// away, and it must not read a body.
+	if len(consent.keys) == 0 {
+		log.LogError(component, "", "hook body dropped: receiver declared no permission to act under")
+		w.WriteHeader(http.StatusOK)
+		return false
+	}
+
+	// A declared permission that is not granted. Answering 2xx is the same
+	// choice every other refusal on this path makes: the refusal is reported by
+	// the log, never by a status code on the user's critical path (#1361,
+	// #1364).
+	//
+	// This logs where a receiver's OWN gate is silent, and the asymmetry is
+	// deliberate rather than an oversight. Reaching here means one of two
+	// things, and both are worth a line: the receiver skipped a check it
+	// declared, or consent was revoked in the window between its check and this
+	// read. The ordinary denied path never reaches here at all — the receiver
+	// answers it quietly, which is what keeps a transcripts-denied user from
+	// collecting an error per tool call, and what each adapter's
+	// consent-drops-quietly test now pins.
+	if key, missing := consent.ungranted(); missing {
+		log.LogError(component, "", fmt.Sprintf(
+			"hook body dropped: permission %q is not granted at the decode — either this "+
+				"receiver skipped the check it declares, or consent was revoked mid-request "+
+				"(issue #1488)", key))
+		w.WriteHeader(http.StatusOK)
+		return false
+	}
+
 	// Fail closed on a receiver wired without a confiner. Returning "not
 	// decoded" drops the payload with a 2xx, the same shape every other refusal
 	// takes, rather than dispatching an unconfined path because the guard

--- a/core/adapters/inbound/agents/hookjson/decode_test.go
+++ b/core/adapters/inbound/agents/hookjson/decode_test.go
@@ -50,6 +50,18 @@ func decodeConfinerRooted(t *testing.T) (*PathConfiner, string) {
 	return staticRoots(root), root
 }
 
+// decodeConsent is the consent a CORRECT receiver hands the chokepoint: one
+// declared key, granted. Every existing case below passes it, which keeps them
+// asserting what they always asserted; the #1488 cases override exactly one
+// thing about it.
+//
+// A nil ConsentGranter would answer the same (RequireConsent documents it as
+// the ungated test shape) — keyedGranter is used so the cases below travel the
+// same code path production does.
+func decodeConsent() Consent {
+	return RequireConsent(keyedGranter{"hooks": true}, "decode-test", "hooks")
+}
+
 func postDecode(t *testing.T, body string) *http.Request {
 	t.Helper()
 	return httptest.NewRequest(http.MethodPost, "/api/v1/hooks/test", strings.NewReader(body))
@@ -76,7 +88,7 @@ func TestDecodeConfined_AcceptsInTreePathAndErasesTheRawString(t *testing.T) {
 	log := &countingLogger{}
 
 	ok := DecodeConfined(rec, postDecode(t, `{"transcript_path":`+strconv.Quote(raw)+`,"hook_event_name":"Stop"}`),
-		log, "test-receiver", confiner, &p, getDecodePath, setDecodePath)
+		log, "test-receiver", decodeConsent(), confiner, &p, getDecodePath, setDecodePath)
 
 	if !ok {
 		t.Fatalf("in-tree transcript refused; status=%d, logged %d line(s)", rec.Code, len(log.lines))
@@ -100,7 +112,7 @@ func TestDecodeConfined_UndecodableBodyIs400(t *testing.T) {
 	var p decodeTestPayload
 
 	ok := DecodeConfined(rec, postDecode(t, `{"transcript_path": NOT JSON`),
-		&countingLogger{}, "test-receiver", confiner, &p, getDecodePath, setDecodePath)
+		&countingLogger{}, "test-receiver", decodeConsent(), confiner, &p, getDecodePath, setDecodePath)
 
 	if ok {
 		t.Fatal("undecodable body reported as decoded")
@@ -125,7 +137,7 @@ func TestDecodeConfined_OutOfTreePathIsRefusedCountedAnd2xx(t *testing.T) {
 	log := &countingLogger{}
 
 	ok := DecodeConfined(rec, postDecode(t, `{"transcript_path":`+strconv.Quote(outside)+`}`),
-		log, "test-receiver", confiner, &p, getDecodePath, setDecodePath)
+		log, "test-receiver", decodeConsent(), confiner, &p, getDecodePath, setDecodePath)
 
 	if ok {
 		t.Fatal("out-of-tree path reported as accepted")
@@ -165,7 +177,7 @@ func TestDecodeConfined_NilConfinerFailsClosed(t *testing.T) {
 	log := &countingLogger{}
 
 	ok := DecodeConfined(rec, postDecode(t, `{"transcript_path":"/anywhere/at/all.jsonl"}`),
-		log, "test-receiver", nil, &p, getDecodePath, setDecodePath)
+		log, "test-receiver", decodeConsent(), nil, &p, getDecodePath, setDecodePath)
 
 	if ok {
 		t.Fatal("a receiver with NO confiner reported its payload as usable — that dispatches an " +
@@ -204,7 +216,7 @@ func TestDecodeConfined_DisagreeingGetSetFailsClosed(t *testing.T) {
 	log := &countingLogger{}
 
 	ok := DecodeConfined(rec, postDecode(t, `{"transcript_path":`+strconv.Quote(raw)+`}`),
-		log, "test-receiver", confiner, &p, getDecodePath,
+		log, "test-receiver", decodeConsent(), confiner, &p, getDecodePath,
 		func(*decodeTestPayload, string) {}) // the no-op set
 
 	if ok {
@@ -237,7 +249,7 @@ func TestDecodeConfined_OversizedBodyIsRefused(t *testing.T) {
 	var p decodeTestPayload
 
 	ok := DecodeConfined(rec, postDecode(t, body), &countingLogger{}, "test-receiver",
-		confiner, &p, getDecodePath, setDecodePath)
+		decodeConsent(), confiner, &p, getDecodePath, setDecodePath)
 
 	if ok {
 		t.Fatalf("a %d-byte body was accepted; the %d-byte bound did not apply", len(body), maxHookBodyBytes)
@@ -252,7 +264,7 @@ func TestDecodeConfined_OversizedBodyIsRefused(t *testing.T) {
 	rec2 := httptest.NewRecorder()
 	var p2 decodeTestPayload
 	if !DecodeConfined(rec2, postDecode(t, small), &countingLogger{}, "test-receiver",
-		confiner, &p2, getDecodePath, setDecodePath) {
+		decodeConsent(), confiner, &p2, getDecodePath, setDecodePath) {
 		t.Fatalf("an in-tree body well under the bound was refused (status %d)", rec2.Code)
 	}
 }

--- a/core/adapters/inbound/agents/hookjson/handler.go
+++ b/core/adapters/inbound/agents/hookjson/handler.go
@@ -1,7 +1,8 @@
 // handler.go holds the shape every hook-receiving adapter's constructor
-// returns: the handler itself, plus the confiner it guards caller-supplied
-// transcript paths with. The confiner is part of what a receiver IS, not a
-// detail of how one is built (issue #1390).
+// returns: the handler itself, plus the two things it guards a request with —
+// the confiner for caller-supplied transcript paths (issue #1390) and the
+// consent it acts under (issue #1488). Both are part of what a receiver IS,
+// not details of how one is built.
 //
 // Why there is no longer a NewHookHandlerWithConfiner, and why the #1361
 // contract lost an obligation along with it: see AGENTS.md, "Hook path
@@ -10,16 +11,18 @@
 // The sibling counters in this package need nothing like this type:
 // IgnoreUnknownEvent (#1364) and ObserveHookReceipt (#1368) keep package-level
 // counts, so their contracts read package accessors and hold no handle on a
-// handler. PathConfiner is per-instance because its roots are per-adapter, so
-// it is the one that needs a way out — which is why HookHandler carries exactly
-// one field and is not a bag of receiver internals.
+// handler. PathConfiner is per-instance because its roots are per-adapter, and
+// Consent because its key set is; those are the two that need a way out, which
+// is why HookHandler carries exactly those two fields and is not a bag of
+// receiver internals.
 package hookjson
 
 import "net/http"
 
 // HookHandler is a hook receiver: an http.Handler (and, via the embedded
 // HandlerFunc, an ordinary func) together with the PathConfiner it enforces
-// issue #1361 confinement with. Build one with NewHandler.
+// issue #1361 confinement with and the Consent it acts under. Build one with
+// NewHandler.
 //
 // The embedding keeps it a drop-in for a bare http.HandlerFunc — ServeHTTP is
 // promoted, so a HookHandler satisfies http.Handler and goes straight into
@@ -33,19 +36,32 @@ type HookHandler struct {
 	// (RejectPath logs and counts; the response is an ordinary 2xx), which is
 	// why the contract reads them rather than trusting the status code.
 	Confiner *PathConfiner
+
+	// Consent is the set of permissions this handler acts under — again the
+	// same value the request path consults. A contract wiring reads its Keys()
+	// rather than restating them, so a receiver that honours a further
+	// permission is covered by the existing wiring instead of by someone
+	// remembering to add an arm (issue #1488).
+	Consent Consent
 }
 
-// NewHandler builds a receiver that serves through serve, handing it confiner
-// on every request and publishing that same instance as Confiner.
+// NewHandler builds a receiver that serves through serve, handing it consent
+// and confiner on every request and publishing those same values.
 //
-// Constructing the pair here rather than at each adapter is the point: the
+// Constructing the triple here rather than at each adapter is the point: the
 // property #1390 buys is that Confiner IS the confiner the request path uses,
-// and three hand-written struct literals asserted that by convention. serve
-// takes the confiner as a parameter rather than capturing one, so the correct
-// wiring is also the shortest one and a fourth receiver inherits it.
-func NewHandler(confiner *PathConfiner, serve func(*PathConfiner, http.ResponseWriter, *http.Request)) HookHandler {
+// and #1488 extends it to Consent. Three hand-written struct literals asserted
+// the first by convention. serve takes both as parameters rather than
+// capturing them, so the correct wiring is also the shortest one and a fifth
+// receiver inherits it.
+//
+// What this still does not stop — the same residue #1390 recorded — is a serve
+// func that ignores what it is handed and builds its own. It cannot be typed
+// away, and it is longer to write than the correct version.
+func NewHandler(confiner *PathConfiner, consent Consent, serve func(Consent, *PathConfiner, http.ResponseWriter, *http.Request)) HookHandler {
 	return HookHandler{
-		HandlerFunc: func(w http.ResponseWriter, r *http.Request) { serve(confiner, w, r) },
+		HandlerFunc: func(w http.ResponseWriter, r *http.Request) { serve(consent, confiner, w, r) },
 		Confiner:    confiner,
+		Consent:     consent,
 	}
 }

--- a/core/internal/contracttesting/hook_receiver_gate.go
+++ b/core/internal/contracttesting/hook_receiver_gate.go
@@ -1,0 +1,284 @@
+// hook_receiver_gate.go is the issue #1488 half of the permission-gate family:
+// the driver that reads a hook receiver's permissions off the RECEIVER instead
+// of taking them from the wiring.
+//
+// AssertPermissionGatedOnEachKey (#1475) already removes one hand-written
+// table — the wiring names its key set once and the "other" key of each pair is
+// derived. What it cannot remove is the key set itself. An author who wires
+// only "hooks" gets a green contract, a green suite, and a receiver that reads
+// transcripts with "transcripts" denied; that is issue #1466, and copilot's
+// receiver reached #1475 with no wiring at all.
+//
+// Since #1488 a receiver DECLARES its permissions to hookjson.NewHandler and
+// the handler publishes them, so the set is a property of the object the daemon
+// builds. This driver takes it from there. Two consequences, and the second is
+// the point:
+//
+//   - A receiver that later honours a third permission grows a third contract
+//     arm by existing, not by someone remembering — the same "covered by
+//     existing rather than by remembering" shape TestEveryHookInstallDeclares-
+//     AVersionFloor has for the registry.
+//   - A wiring can no longer name a set the receiver does not use, because it
+//     names no set at all. The two-objects-that-could-disagree failure #1390
+//     removed for the confiner is removed here for consent.
+//
+// It also owns the ConsentGate rather than accepting one. PermissionGate.
+// SetState carries a warning that a key-blind fake is exactly what hid #1466;
+// a driver that constructs the granter itself makes that unsupplyable.
+package contracttesting
+
+import (
+	"fmt"
+	"slices"
+	"sync"
+	"testing"
+
+	"irrlicht/core/adapters/inbound/agents/hookjson"
+)
+
+// GatedHookReceiver is one freshly built receiver: the handler whose declared
+// permissions the driver reads, plus the way to drive and observe it.
+//
+// Handler is the concrete hookjson.HookHandler rather than an http.Handler for
+// the same reason HookReceiverUnderTest.Handler is: the property under test is
+// carried by a field on it (Consent here, Confiner there), and an interface
+// would force the wiring to declare that property separately — which is the
+// declaration this driver exists to delete.
+type GatedHookReceiver struct {
+	// Handler is the receiver under test, built through the adapter's own
+	// production constructor.
+	Handler hookjson.HookHandler
+
+	// Exercise posts a request the receiver would act on when every permission
+	// is granted.
+	Exercise func()
+
+	// Observe reports whether the gated effect is currently present.
+	Observe func() bool
+}
+
+// HookReceiverGate wires one hook receiver into
+// AssertHookReceiverPermissionGated.
+type HookReceiverGate struct {
+	// Build returns a FRESH receiver bound to gate. It is called once per
+	// declared permission plus once to read the declaration, and the fixtures
+	// must not be shared between calls, or state left behind by one run decides
+	// the next.
+	//
+	// It is handed the testing.TB of the arm it is building for, and that is
+	// what makes "fresh" structural rather than incidental. A wiring closing
+	// over the enclosing *testing.T instead would hang every arm's t.TempDir()
+	// and t.Setenv() off the PARENT — copilot's relocation of COPILOT_HOME is
+	// exactly that shape — so the fixtures would be correct only because each
+	// arm happens to be built immediately before it runs, and their cleanup
+	// would not land until the whole family finished. A t.Fatalf from inside
+	// Exercise would likewise be attributed to the parent rather than to the
+	// arm that failed.
+	//
+	// It takes *testing.T rather than this package's reporter seam on purpose.
+	// Build is wiring supplied by the adapter, not an obligation that decides a
+	// verdict, and what it needs is fixture machinery — t.TempDir(), t.Setenv()
+	// — which fixtureT deliberately does not carry and a recorder must not
+	// fake. It is the same split armT draws, landing on the fixture side.
+	Build func(t *testing.T, gate *ConsentGate) GatedHookReceiver
+
+	// Foreign names permissions the ADAPTER declares that this receiver must
+	// not be gated on. It is needed only for a receiver declaring a single
+	// permission, where the derived set leaves nothing to hold open and the
+	// key-isolation arm cannot run (issue #1475) — claudecode's statusline
+	// endpoint is the one such receiver today, and the two keys it names are
+	// exactly the ones a copy-paste from hooks.go would have reached for.
+	//
+	// For a receiver declaring two or more it is empty: the other declared
+	// permissions already supply the isolation state, and listing more would
+	// re-introduce the hand-written table this driver removes.
+	Foreign []string
+}
+
+// AssertHookReceiverPermissionGated runs the permission-gate contract once per
+// permission the receiver DECLARES, deriving that set from the handler.
+//
+// It fails rather than skipping on every shape it cannot grade — an empty
+// declaration, a Build that returns differently-declared receivers, a derived
+// set with nothing to hold open. A family that quietly ran fewer arms would
+// read as coverage, which is the shape this package exists to remove.
+func AssertHookReceiverPermissionGated(t *testing.T, g HookReceiverGate) {
+	t.Helper()
+	if g.Build == nil {
+		t.Fatal("HookReceiverGate needs Build")
+	}
+
+	probe := g.Build(t, NewConsentGate())
+	if reason := malformedReceiverReason(probe); reason != "" {
+		t.Fatal(reason)
+	}
+	declared := probe.Handler.Consent.Keys()
+
+	arms, reason := hookGateArms(declared, g.Foreign)
+	if reason != "" {
+		t.Fatal(reason)
+	}
+
+	for _, arm := range arms {
+		t.Run(arm.Key, func(t *testing.T) {
+			gate := NewConsentGate()
+			r := g.Build(t, gate)
+			if why := sameDeclarationReason(declared, r.Handler.Consent.Keys()); why != "" {
+				t.Fatal(why)
+			}
+
+			AssertPermissionGated(t, PermissionGate{
+				Key:       arm.Key,
+				OtherKeys: arm.Others,
+				SetState:  gate.SetState,
+				Exercise:  r.Exercise,
+				Observe:   r.Observe,
+			})
+		})
+	}
+}
+
+// hookGateArm is one derived run: the declared permission under test, and the
+// permissions held open while it is denied.
+type hookGateArm struct {
+	Key    string
+	Others []string
+}
+
+// hookGateArms derives one arm per declared permission, holding the rest of the
+// declared set plus foreign open in each.
+//
+// It returns a reason instead of failing so the shapes it rejects are
+// themselves testable — the same choice malformedGateReason makes, and for the
+// same reason: a guard nobody can drive is the kind of unverifiable check this
+// package exists to remove.
+func hookGateArms(declared, foreign []string) ([]hookGateArm, string) {
+	for _, f := range foreign {
+		if slices.Contains(declared, f) {
+			return nil, fmt.Sprintf("Foreign names %q, which this receiver DECLARES — Foreign is for "+
+				"permissions the receiver must NOT be gated on, and the declared ones are already "+
+				"held open by the derivation. Listing one here re-introduces the hand-written table "+
+				"this driver removes, and on that key's own arm it would grant and deny the same "+
+				"permission.", f)
+		}
+	}
+
+	// Loop-invariant, so it is decided once: every arm holds the same
+	// len(declared)-1+len(foreign) permissions open, and only a lone
+	// declaration with no Foreign leaves that empty.
+	if len(declared) == 1 && len(foreign) == 0 {
+		return nil, fmt.Sprintf("the receiver declares only %q and the wiring names no Foreign "+
+			"permissions — the key-isolation arm cannot run, so %q would only be shown to be "+
+			"gated on something rather than on %q (issue #1475). Name at least one permission "+
+			"this receiver must NOT be gated on.", declared[0], declared[0], declared[0])
+	}
+
+	arms := make([]hookGateArm, 0, len(declared))
+	for i, key := range declared {
+		arms = append(arms, hookGateArm{Key: key, Others: slices.Concat(declared[:i], declared[i+1:], foreign)})
+	}
+	return arms, ""
+}
+
+// malformedReceiverReason reports why the probe receiver cannot be graded, or
+// "" when it can.
+//
+// A receiver that declares nothing cannot be built through
+// hookjson.RequireConsent — its first key is positional — so an empty set here
+// means a wiring that assembled a handler some other way, and it must not pass
+// silently: a driver that ran zero arms is indistinguishable from one that ran
+// them all.
+func malformedReceiverReason(r GatedHookReceiver) string {
+	if r.Exercise == nil || r.Observe == nil {
+		return "GatedHookReceiver needs Exercise and Observe"
+	}
+	if len(r.Handler.Consent.Keys()) == 0 {
+		return "the receiver under test declares no permission — nothing would be graded, and a " +
+			"contract that runs zero arms reads exactly like one that runs them all (issue #1488)"
+	}
+	return ""
+}
+
+// sameDeclarationReason reports why a receiver Build returned declares
+// something other than the set the arms were derived from, or "" when they
+// agree.
+//
+// Build is called once to read the declaration and once per arm. A Build that
+// returned a differently-configured receiver on later calls would have the
+// contract grading a set the receiver under test does not use — the failure
+// #1390 removed by publishing the confiner, arriving here through the wiring
+// instead of through the constructor.
+func sameDeclarationReason(want, got []string) string {
+	if slices.Equal(want, got) {
+		return ""
+	}
+	return fmt.Sprintf("Build returned a receiver declaring %v, but the arms were derived from %v — "+
+		"the contract would grade a set this receiver does not use", got, want)
+}
+
+// AssertDeclaredPermissions is the per-adapter LOCK companion: it pins the
+// exact key set a receiver declares, so the list each wiring used to write out
+// by hand survives as an assertion rather than being deleted along with the
+// wiring.
+//
+// Per #1450 a rewritten guard replays its predecessor's cases or it is not
+// known to be a superset. AssertHookReceiverPermissionGated derives what those
+// wirings declared, which makes it a superset only if the derived set is the
+// same set — and that is exactly what a derivation cannot assert about itself.
+func AssertDeclaredPermissions(t *testing.T, h hookjson.HookHandler, want ...string) {
+	t.Helper()
+	declaredPermissionsMismatch(t, h, want...)
+}
+
+// declaredPermissionsMismatch is the arm behind AssertDeclaredPermissions. It
+// takes reporter rather than *testing.T so a negative self-test can drive it —
+// a lock that could not itself be shown to fail is a lock nobody has checked.
+func declaredPermissionsMismatch(t reporter, h hookjson.HookHandler, want ...string) {
+	t.Helper()
+	if got := h.Consent.Keys(); !slices.Equal(got, want) {
+		t.Fatalf("receiver declares %v, want %v — this list is the one the pre-#1488 contract "+
+			"wiring named by hand, kept as a lock (#1450)", got, want)
+	}
+}
+
+// RecordingLogger is an outbound.Logger that keeps what was logged at ERROR.
+//
+// It exists for one assertion, made by every hook receiver's hand-written
+// consent test since #1488: that an ordinary consent-denied request is refused
+// SILENTLY. That matters twice over. It is a user-facing property — a hook
+// fires per tool call, and a statusline hook per prompt render, so a user who
+// declined a permission must not collect an error line at that rate. And it is
+// the last thing those tests still discriminate: DecodeConfined's backstop
+// drops the same payload on the receiver's own declaration, so every
+// dispatch-shaped assertion survives deleting a receiver's gate, while the
+// silence does not — the backstop logs, because reaching it means a check was
+// skipped or consent was revoked mid-request.
+//
+// It lives here rather than in each adapter for the reason ConsentGate does:
+// three packages had grown the same ten lines, and "what a refusal may log" is
+// a decision about the contract rather than about an adapter.
+type RecordingLogger struct {
+	mu     sync.Mutex
+	errors []string
+}
+
+// LogError records. The other methods are deliberately inert: only the error
+// channel carries the obligation above.
+func (l *RecordingLogger) LogError(_, _, msg string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.errors = append(l.errors, msg)
+}
+
+func (l *RecordingLogger) LogInfo(string, string, string) {}
+
+func (l *RecordingLogger) LogProcessingTime(string, string, int64, int, string) {}
+
+func (l *RecordingLogger) Close() error { return nil }
+
+// Errors returns what was logged at ERROR, newest last.
+func (l *RecordingLogger) Errors() []string {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return slices.Clone(l.errors)
+}

--- a/core/internal/contracttesting/hook_receiver_gate_test.go
+++ b/core/internal/contracttesting/hook_receiver_gate_test.go
@@ -1,0 +1,249 @@
+package contracttesting
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"irrlicht/core/adapters/inbound/agents/hookjson"
+)
+
+// This file is the committed mutation evidence for the #1488 driver, in the
+// same shape permission_gate_test.go carries it for #1475's arm.
+//
+// What is new here is not an obligation — the four arms are still
+// AssertPermissionGated's — it is the DERIVATION: which arms run at all, and
+// where their key set comes from. Three things can silently stop working, and
+// each would look exactly like health:
+//
+//   - the derivation could pair a key with the wrong "others";
+//   - the driver could read a set that is not the receiver's;
+//   - a receiver declaring one permission could run an isolation arm with
+//     nothing held open, which is #1475's original blind spot restored.
+//
+// Each is driven below through a reason-returning helper rather than through a
+// *testing.T, which is what makes them gradeable at all — the choice
+// malformedGateReason already made in this package.
+
+// gatedFakeReceiver builds a real hookjson receiver that declares keys and
+// dispatches only when every key in gatedOn is granted. It goes through
+// hookjson.NewHandler so the Consent the driver reads is the one the request
+// path uses, exactly as an adapter's constructor does.
+func gatedFakeReceiver(gate *ConsentGate, declared, gatedOn []string) (hookjson.HookHandler, *bool) {
+	dispatched := new(bool)
+	consent := hookjson.RequireConsent(gate, "test-agent", declared[0], declared[1:]...)
+	h := hookjson.NewHandler(nil, consent,
+		func(c hookjson.Consent, _ *hookjson.PathConfiner, w http.ResponseWriter, _ *http.Request) {
+			for _, k := range gatedOn {
+				if !c.Granted(k) {
+					w.WriteHeader(http.StatusOK)
+					return
+				}
+			}
+			*dispatched = true
+			w.WriteHeader(http.StatusOK)
+		})
+	return h, dispatched
+}
+
+// receiverGateOver wires gatedFakeReceiver into the driver. The receiver never
+// reaches DecodeConfined (its serve func dispatches directly), so a nil
+// confiner is fine and the fixture stays about consent alone.
+func receiverGateOver(declared, gatedOn, foreign []string) HookReceiverGate {
+	return HookReceiverGate{
+		Foreign: foreign,
+		Build: func(_ *testing.T, gate *ConsentGate) GatedHookReceiver {
+			h, dispatched := gatedFakeReceiver(gate, declared, gatedOn)
+			return GatedHookReceiver{
+				Handler: h,
+				Exercise: func() {
+					*dispatched = false
+					req := httptest.NewRequest(http.MethodPost, "/api/v1/hooks/test", strings.NewReader(`{}`))
+					h.ServeHTTP(httptest.NewRecorder(), req)
+				},
+				Observe: func() bool { return *dispatched },
+			}
+		},
+	}
+}
+
+// TestAssertHookReceiverPermissionGated_PassesACorrectReceiver is the vacuity
+// guard. Without it, a driver that derived no arms at all — or one whose arms
+// reported unconditionally — would satisfy every case below and read as
+// coverage.
+func TestAssertHookReceiverPermissionGated_PassesACorrectReceiver(t *testing.T) {
+	keys := []string{selfTestHooks, selfTestTranscripts}
+	AssertHookReceiverPermissionGated(t, receiverGateOver(keys, keys, nil))
+}
+
+// TestAssertHookReceiverPermissionGated_DerivesOneArmPerDeclaredKey is the
+// property the whole ticket rests on: the number of arms follows the
+// RECEIVER's declaration, not the wiring's. A receiver that grows a third
+// permission is graded on it without anyone editing its test.
+//
+// Build is called once to read the declaration plus once per arm, so four
+// calls for three keys — and a driver that silently derived nothing would show
+// one.
+func TestAssertHookReceiverPermissionGated_DerivesOneArmPerDeclaredKey(t *testing.T) {
+	keys := []string{"a", "b", "c"}
+	base := receiverGateOver(keys, keys, nil)
+
+	builds := 0
+	counted := HookReceiverGate{Build: func(tb *testing.T, gate *ConsentGate) GatedHookReceiver {
+		builds++
+		return base.Build(tb, gate)
+	}}
+
+	AssertHookReceiverPermissionGated(t, counted)
+
+	if want := len(keys) + 1; builds != want {
+		t.Fatalf("Build called %d time(s), want %d (one probe + one per declared permission) — "+
+			"an arm count that does not follow the declaration is the act of memory #1488 removes", builds, want)
+	}
+}
+
+// TestHookGateArms_DerivesTheOthers pins the pairing directly. Three keys,
+// because with two "the others" and "the other one" are the same answer, so a
+// two-key case cannot tell a correct derivation from one returning the last
+// key — the argument TestAssertPermissionGatedOnEachKey_DerivesTheOthers makes.
+func TestHookGateArms_DerivesTheOthers(t *testing.T) {
+	arms, reason := hookGateArms([]string{"a", "b", "c"}, nil)
+	if reason != "" {
+		t.Fatalf("a three-key declaration was refused: %s", reason)
+	}
+
+	want := map[string]string{"a": "b,c", "b": "a,c", "c": "a,b"}
+	if len(arms) != len(want) {
+		t.Fatalf("derived %d arm(s), want %d — every declared permission must get a turn under test", len(arms), len(want))
+	}
+	for _, arm := range arms {
+		if got := strings.Join(arm.Others, ","); got != want[arm.Key] {
+			t.Errorf("key %q held open %q, want %q", arm.Key, got, want[arm.Key])
+		}
+	}
+}
+
+// TestHookGateArms_AppendsForeignToEveryArm covers the single-permission
+// receiver — claudecode's statusline endpoint, the one case where the derived
+// set alone leaves nothing to hold open.
+func TestHookGateArms_AppendsForeignToEveryArm(t *testing.T) {
+	arms, reason := hookGateArms([]string{"statusline"}, []string{"hooks", "transcripts"})
+	if reason != "" {
+		t.Fatalf("a one-key declaration with Foreign was refused: %s", reason)
+	}
+	if len(arms) != 1 {
+		t.Fatalf("derived %d arm(s), want 1", len(arms))
+	}
+	if got := strings.Join(arms[0].Others, ","); got != "hooks,transcripts" {
+		t.Fatalf("held open %q, want %q — without them the isolation arm proves only that the "+
+			"receiver is gated on something", got, "hooks,transcripts")
+	}
+}
+
+// TestHookGateArms_RefusesASoloDeclarationWithNoForeign is #1475's blind spot,
+// which the derivation could otherwise restore by accident: with one declared
+// permission and no Foreign there is nothing to hold open, and the isolation
+// arm would pass having proved nothing.
+func TestHookGateArms_RefusesASoloDeclarationWithNoForeign(t *testing.T) {
+	arms, reason := hookGateArms([]string{"statusline"}, nil)
+	if reason == "" {
+		t.Fatal("a receiver declaring ONE permission with no Foreign was accepted — the " +
+			"key-isolation arm then runs with nothing granted beside the denied key, which is " +
+			"exactly the state that cannot tell a correctly gated receiver from an ungated one")
+	}
+	if arms != nil {
+		t.Error("arms were returned alongside a refusal")
+	}
+	if !strings.Contains(reason, "statusline") {
+		t.Errorf("the refusal does not name the key it is about: %s", reason)
+	}
+}
+
+// TestHookGateArms_RefusesAForeignKeyTheReceiverDeclares covers the other
+// direction of Foreign's contract. Its doc says a multi-key receiver leaves it
+// empty because the declared keys already supply the isolation state — but
+// nothing stopped a wiring listing one anyway, which is the hand-written table
+// this driver exists to delete, growing back. It is also incoherent on the
+// named key's own arm, where the same permission would be denied and granted.
+func TestHookGateArms_RefusesAForeignKeyTheReceiverDeclares(t *testing.T) {
+	arms, reason := hookGateArms([]string{"hooks", "transcripts"}, []string{"transcripts"})
+	if reason == "" {
+		t.Fatal("Foreign named a permission the receiver DECLARES and was accepted — on that " +
+			"key's own arm the driver would grant and deny the same permission, and the " +
+			"hand-written key table this driver removes would be back")
+	}
+	if arms != nil {
+		t.Error("arms were returned alongside a refusal")
+	}
+	if !strings.Contains(reason, "transcripts") {
+		t.Errorf("the refusal does not name the offending key: %s", reason)
+	}
+
+	// The vacuity guard: a genuinely foreign key is still accepted, or the
+	// check above would refuse every statusline-shaped wiring too.
+	if _, reason := hookGateArms([]string{"statusline"}, []string{"hooks"}); reason != "" {
+		t.Fatalf("a genuinely foreign key was refused: %s", reason)
+	}
+}
+
+// TestMalformedReceiverReason_RefusesADeclarationlessReceiver covers the
+// handler a wiring assembled without going through hookjson.RequireConsent.
+// Zero arms and every arm passing look identical from outside.
+func TestMalformedReceiverReason_RefusesADeclarationlessReceiver(t *testing.T) {
+	empty := GatedHookReceiver{
+		Handler:  hookjson.HookHandler{},
+		Exercise: func() {},
+		Observe:  func() bool { return false },
+	}
+	if malformedReceiverReason(empty) == "" {
+		t.Fatal("a receiver declaring NO permission was accepted — the driver would run zero " +
+			"arms and report success, which reads exactly like running them all")
+	}
+
+	ok := GatedHookReceiver{
+		Handler:  mustDeclare("hooks", "transcripts"),
+		Exercise: func() {},
+		Observe:  func() bool { return false },
+	}
+	if reason := malformedReceiverReason(ok); reason != "" {
+		t.Fatalf("a well-formed receiver was refused (%s) — the vacuity guard for the case above", reason)
+	}
+}
+
+// TestSameDeclarationReason_CatchesABuildThatDrifts covers a Build returning a
+// differently-declared receiver on a later call, where the arms would grade a
+// set the receiver under test does not use.
+func TestSameDeclarationReason_CatchesABuildThatDrifts(t *testing.T) {
+	if reason := sameDeclarationReason([]string{"hooks", "transcripts"}, []string{"hooks", "transcripts"}); reason != "" {
+		t.Fatalf("an unchanged declaration was reported as drift: %s — the vacuity guard here", reason)
+	}
+	if sameDeclarationReason([]string{"hooks", "transcripts"}, []string{"hooks"}) == "" {
+		t.Error("a receiver that dropped a permission between builds was accepted")
+	}
+	if sameDeclarationReason([]string{"hooks", "transcripts"}, []string{"transcripts", "hooks"}) == "" {
+		t.Error("a reordered declaration was accepted — the arms are derived positionally, so " +
+			"order is part of what must not drift")
+	}
+}
+
+// TestAssertDeclaredPermissions_IsTheLockItClaimsToBe grades the lock helper
+// itself: it has to fail for a set that differs, or the four per-adapter locks
+// replay nothing.
+func TestAssertDeclaredPermissions_IsTheLockItClaimsToBe(t *testing.T) {
+	h := mustDeclare("hooks", "transcripts")
+
+	if got := h.Consent.Keys(); strings.Join(got, ",") != "hooks,transcripts" {
+		t.Fatalf("fixture declares %v", got)
+	}
+	rec := observe(t, func(at armT) { declaredPermissionsMismatch(at, h, "hooks") })
+	mustReport(t, rec, "receiver declares",
+		"a lock naming FEWER permissions than the receiver declares — the shape that would let a "+
+			"newly honoured permission slip past the lock unnoticed")
+}
+
+func mustDeclare(keys ...string) hookjson.HookHandler {
+	return hookjson.NewHandler(nil,
+		hookjson.RequireConsent(nil, "test-agent", keys[0], keys[1:]...),
+		func(hookjson.Consent, *hookjson.PathConfiner, http.ResponseWriter, *http.Request) {})
+}

--- a/core/internal/contracttesting/permission_gate.go
+++ b/core/internal/contracttesting/permission_gate.go
@@ -77,12 +77,14 @@ type PermissionGate struct {
 // let an install-type wiring skip it is a flag a live-gate wiring could also
 // reach for, and that is the one place it must not be skippable.
 //
-// What this still does not do is make the obligation unforgettable: a receiver
+// What this still does not do is make the obligation unforgettable: a call site
 // must be wired once per permission it must honour, and nothing fails if an
-// author wires only one of them. Issue #1488 is the chokepoint move that would
-// remove that last act of memory — folding the consent key into
+// author wires only one of them. Issue #1488 removed that last act of memory
+// for hook receivers — the consent keys are folded into
 // hookjson.DecodeConfined, which core/architecture_hookbody_test.go already
-// forces every hook receiver through.
+// forces every hook receiver through, and published on the handler so
+// AssertHookReceiverPermissionGated derives the set instead of being told it.
+// Every other kind of call site still names its own keys here.
 func AssertPermissionGated(t *testing.T, g PermissionGate) {
 	t.Helper()
 	if reason := malformedGateReason(g); reason != "" {


### PR DESCRIPTION
Closes #1488.

## The shape

`hookjson.Consent` names the permissions **one receiver acts under**, bound to its granter and adapter name. It rides the chokepoint the same way the confiner does:

| | #1390 (confiner) | #1488 (consent) |
|---|---|---|
| required by | `NewHandler` | `NewHandler` |
| published on | `HookHandler.Confiner` | `HookHandler.Consent` |
| enforced by | `DecodeConfined` | `DecodeConfined` |
| read by the contract | `AssertHookPathConfined` | `AssertHookReceiverPermissionGated` |

`RequireConsent(granter, agent, key string, more ...string)` takes its first key **positionally**, so a keyless receiver does not compile, in any spelling. That is a type guarantee and carries no tripwire — the trade `reporter.go` records for `fixtureT`, and AGENTS.md's "a type needs no such proof". The one degenerate value Go still admits, `Consent{}`, fails closed in `DecodeConfined` and has a committed mutation.

## claudecode's two-permission receiver

The set is a **list**, not a scalar, so two permissions needed no special case: `RequireConsent(gate, AdapterName, PermissionKeyHooks, PermissionKeyTranscripts)`. Statusline — one key, no receipt — is the same call with one key. `HookReceiverGate.Foreign` exists for exactly that receiver: with a single declared permission the derived set leaves nothing to hold open, so the driver **refuses** rather than running a #1475 isolation arm that proves nothing. Naming a `Foreign` key the receiver already declares is refused too.

## The ordering is untouched

`admitHookRequest`'s order is load-bearing in two directions and has not moved. The receiver still writes `hooks` → `ObserveHookReceipt` → `transcripts` → decode; `Consent` deliberately does **not** know the order, and `DecodeConfined`'s check is a **backstop below** the sequence. Its doc says why folding the sequence in would put four obligations behind one call — the shape `IgnoreUnknownEvent` avoids by taking no `ResponseWriter`.

## Static or runtime

**Both, split on purpose.**

- **Static / does-not-compile:** naming ≥1 permission. `NewHandler` requires a `Consent`; `RequireConsent` requires a key positionally.
- **Runtime, fail-closed:** the set being *honoured*. `DecodeConfined` refuses while any declared key is ungranted — **before** the body read and the confine, so a denied request costs no decode, no path resolution and no confiner counter.

`core/architecture_hookbody_test.go` is **not** extended. It already forces every receiver through `DecodeConfined`, which is what makes the new argument unavoidable; an AST arm policing `NewHandler(c, Consent{}, …)` would be "a contract that grows a sub-test to police an API the same PR invented", which #1390 records as the signal to prefer a type.

## The existing wirings: replaced, with their key lists kept as locks

All four receiver wirings go through the derived driver and **name no keys**. Per #1450 a rewritten guard replays its predecessor's cases, so each adapter gained a `Test…DeclaresItsPermissions` lock pinning the exact list its wiring used to spell out.

**The interesting consequence, found by review and now fixed rather than merely documented.** The backstop refuses the same request a receiver's own gate would, so every *dispatch-shaped* per-adapter mutation went quiet: deleting the `transcripts` gate from claudecode/codex/copilot — and deleting statusline's *only* gate — all left the suite green. What the backstop does **not** reproduce is silence: it logs an error, because reaching it means a receiver skipped a check or consent was revoked mid-request. That difference is a real user-facing property (a denied session must not collect an error line per tool call), so each of the four receivers' hand-written consent tests now asserts **no error was logged** — and all four were seen red again with their gate deleted. Statusline is the one to watch: it declares one permission and keeps no second gate, so that assertion is the whole of its live per-adapter proof.

## Mutation evidence — 20 mutations, all committed, all seen red

Re-run after the simplify pass. Chokepoint (7): delete the backstop; **move** it below the read (the review's own mutation — this is why placement has its own arm); delete the zero-`Consent` guard; `ungranted()` always reports (the vacuity guard); `Granted` ignores the declaration; `Keys()` stops copying; `NewHandler` publishes a decoy. Driver (8): `Foreign` not appended; solo-declaration refusal removed; `others` drops the tail; derives only the first key; empty-declaration check removed; `sameDeclarationReason` always agrees; the lock stops reporting; the Foreign-duplicates-declared refusal removed. Receivers (5): each of the four gates deleted, plus the `hooks` gate deleted (which reddens `AssertHookReceiptObserved`'s `consent_denied_request_is_not_counted`) and copilot under-declaring.

`forgetfulReceiver` is #1466 reduced to a committed fixture — declares both keys, checks one.

## What is *not* held (stated rather than implied)

AGENTS.md's new bullet says so directly: the `hooks`-key-ahead-of-the-receipt half of the ordering is enforced, but the `transcripts`-key-behind-it half is held by nothing — hoisting it above the receipt is green here **and was green before this change**. A standing gap, not a regression, recorded rather than left to the reader.

## Effect on #1497

**Cheaper, but not built.** `NewHandler` now takes the consent alongside the confiner, so one `RequireConsent` line replaces the ad-hoc gate each of the three families would have wired separately, and `gatedFakeReceiver` shows the constructor shape. It still passes a nil confiner and never reaches `DecodeConfined`, so it carries no declared roots, no rejection counters and no receipt — the consent third is done, the roots-and-counters two thirds remain #1497's.

## Known limitation (deliberate)

`RequireConsent(nil, …)` still answers granted for declared keys — the `a nil gate means no gating` affordance every receiver constructor documents and ~40 tests rely on. Preserved verbatim; it is now at least confined to *declared* keys. Unreachable from production (`registerHookRoutes` always passes `permService`).

## Verification

`tools/preflight.sh` chunked, all gates PASS: `go`, `arch`, `tools`, `skills`, `posix`, `security`, `web`. Plus `go test ./core/... -race -count=1` clean. All required PR checks green on `e8c2f54b`: `go-test`, `build-test`, `ars-gate`, both web entries, CodeQL, SonarCloud.

### The two advisory checks

SonarCloud first failed on **duplication in new code** (4.2% vs 3% — every rating still best-grade, no new issues). The cause was mine: three adapter test packages had each grown the same ten-line error-recording logger. It now lives once, as `contracttesting.RecordingLogger`, for the reason `ConsentGate` lives there — "what a refusal may log" is a decision about the contract, not about an adapter. SonarCloud is green.

That move flipped **CodeScene** to fail, on one advisory rule: *Excess Number of Function Arguments*, for `LogProcessingTime(string, string, int64, int, string)`. That signature is imposed by the `outbound.Logger` interface the type must implement, and is identical to every other `Logger` implementation in the repo; the rule fires now only because the code moved from a `_test.go` file into `contracttesting`, which is a non-test package by necessity. It is not actionable without ceasing to implement the interface. Per AGENTS.md both checks are advisory and neither is required by branch protection — flagged here rather than suppressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
