### PR TITLE
fix(processlifecycle): tell an unreadable herdr client from one with no window

### DIFF
--- a/core/adapters/inbound/agents/processlifecycle/osutil.go
+++ b/core/adapters/inbound/agents/processlifecycle/osutil.go
@@ -87,7 +87,14 @@ func ReadLauncherEnv(pid int) (l *session.Launcher, hostKnown bool) {
 	if pid <= 0 {
 		return nil, false
 	}
-	l = hostIdentity(pid)
+	// The agent's own identity deliberately ignores hostIdentity's second
+	// return. hostKnown here is about the herdr CLIENT indirection below; a
+	// direct session whose ancestry walk timed out is a different question
+	// with different consumers (captureLauncher, launcherBackfillNeedsFor),
+	// and widening it here would change behaviour for every non-herdr session
+	// on a signal #1492 has no evidence about. See resolveClientHostIdentity
+	// for the read that DOES act on it.
+	l, _ = hostIdentity(pid)
 	hostKnown = true
 
 	// A herdr pane's window belongs to the attached client, so its host
@@ -122,15 +129,30 @@ func ReadLauncherEnv(pid int) (l *session.Launcher, hostKnown bool) {
 // (osutil_darwin.go). Keeping it in one function is what stops the two from
 // drifting when a step is added.
 //
+// complete reports whether the reads behind that answer actually ran, so a
+// caller can tell "this process has no local window" from "I could not read
+// this process" (#1492). It is false only when an ancestry walk aborted on an
+// unreadable process rather than reaching a verdict.
+//
+// It deliberately says nothing about the env read, which cannot fail: the
+// ProcessObserver port defines an unreadable env as an empty map rather than
+// an error, and all three implementations discard it (process_darwin.go,
+// process_linux.go, process_other.go). Widening the port would buy nothing
+// here either, because an env that yields no host is exactly the condition
+// that makes the ancestry fallbacks run — so a false "no local window" always
+// passes through an ancestry walk, and the walk is where the distinction has
+// to be drawn.
+//
 // The ordering is load-bearing: ancestry before TTY, and both before any
 // adoption by the caller.
-func hostIdentity(pid int) *session.Launcher {
+func hostIdentity(pid int) (l *session.Launcher, complete bool) {
 	// Env may be empty — hardened-runtime processes hide it from sysctl.
 	// Don't bail here: the ancestry fallback below is the only signal we
 	// have in that case.
 	env, _ := osProc.EnvOf(pid)
 
-	l := launcherFromEnv(env)
+	l = launcherFromEnv(env)
+	complete = true
 
 	// The ancestry fallbacks resolve the *host application* of the process
 	// tree, so they are skipped for a herdr pane: that tree leads to the herdr
@@ -155,14 +177,14 @@ func hostIdentity(pid int) *session.Launcher {
 	// none of its own (kitty), whose fields the suppression above drops. So
 	// skipping it would buy no correctness and cost exactly that case.
 	if l.HerdrPaneID == "" {
-		applyAncestryFallbacks(l, pid, memoizedAncestry(pid))
+		complete = applyAncestryFallbacks(l, pid, memoizedAncestry(pid))
 	}
 
 	// Capture the controlling TTY so Terminal.app (and potentially others)
 	// can target the exact tab — Terminal.app's AppleScript dictionary
 	// matches tabs by `tty` but has no session-UUID analog.
 	l.TTY = processTTY(pid)
-	return l
+	return l, complete
 }
 
 // launcherFromEnv builds a Launcher from the whitelisted per-PID env vars
@@ -266,21 +288,27 @@ func tmuxSocketFromEnv(tmux string) string {
 	return tmux
 }
 
+// ancestryFn is a memoized process-ancestry lookup. complete carries
+// resolveHostFromAncestry's meaning unchanged: false says the walk aborted on
+// an unreadable process, so an empty term is not evidence of anything (#1492).
+type ancestryFn func() (term string, hostPID int, complete bool)
+
 // memoizedAncestry returns a closure resolving pid's process ancestry via
 // resolveHostFromAncestry at most once, caching the result for repeat calls.
 // ReadLauncherEnv's ancestry-dependent fallbacks may all need the same walk;
 // this keeps it bounded to a single `ps` shellout chain instead of up to
 // three.
-func memoizedAncestry(pid int) func() (term string, hostPID int) {
+func memoizedAncestry(pid int) ancestryFn {
 	var ancestryTerm string
 	var ancestryHostPID int
+	var ancestryComplete bool
 	ancestryResolved := false
-	return func() (string, int) {
+	return func() (string, int, bool) {
 		if !ancestryResolved {
-			ancestryTerm, ancestryHostPID = resolveHostFromAncestry(pid)
+			ancestryTerm, ancestryHostPID, ancestryComplete = resolveHostFromAncestry(pid)
 			ancestryResolved = true
 		}
-		return ancestryTerm, ancestryHostPID
+		return ancestryTerm, ancestryHostPID, ancestryComplete
 	}
 }
 
@@ -290,7 +318,13 @@ func memoizedAncestry(pid int) func() (term string, hostPID int) {
 // generic top-level-.app host fallback, and kitty field back-fill for
 // Apple-signed agents. ancestry is expected to be memoized by the caller so
 // this can call it from multiple guarded blocks at no extra cost.
-func applyAncestryFallbacks(l *session.Launcher, pid int, ancestry func() (term string, hostPID int)) {
+//
+// The return is the AND of every walk that actually ran: false means at least
+// one of them aborted on an unreadable process, so the fields it would have
+// filled are missing rather than absent (#1492). A run in which no walk was
+// needed is complete by definition.
+func applyAncestryFallbacks(l *session.Launcher, pid int, ancestry ancestryFn) (complete bool) {
+	complete = true
 	// kitty intentionally does not set TERM_PROGRAM (upstream kitty issue
 	// #4793), so the env-captured value may be inherited from whatever
 	// process launched kitty.app (e.g. a VS Code integrated terminal). When
@@ -298,7 +332,9 @@ func applyAncestryFallbacks(l *session.Launcher, pid int, ancestry func() (term 
 	// we still verify via process ancestry to rule out the reverse case
 	// (KITTY_WINDOW_ID leaked from a kitty shell that spawned VS Code).
 	if l.KittyWindowID != "" && l.TermProgram != "kitty" {
-		if term, _ := ancestry(); term == "kitty" {
+		term, _, ok := ancestry()
+		complete = complete && ok
+		if term == "kitty" {
 			l.TermProgram = "kitty"
 		}
 	}
@@ -307,7 +343,9 @@ func applyAncestryFallbacks(l *session.Launcher, pid int, ancestry func() (term 
 	// can at least bring the host app to the front. Darwin-only; other
 	// platforms return "" and this is a no-op.
 	if l.TermProgram == "" {
-		l.TermProgram, _ = ancestry()
+		term, _, ok := ancestry()
+		complete = complete && ok
+		l.TermProgram = term
 	}
 	// Generic host fallback: when no curated host matched (TermProgram still
 	// empty), resolve the first top-level `.app` ancestor's bundle id so the
@@ -316,7 +354,9 @@ func applyAncestryFallbacks(l *session.Launcher, pid int, ancestry func() (term 
 	// on a map miss, so every curated host keeps its exact behavior. Darwin-
 	// only; other platforms return "" and this is a no-op.
 	if l.TermProgram == "" {
-		l.HostBundleID, _ = resolveHostBundleIDFromAncestry(pid)
+		bundleID, _, ok := resolveHostBundleIDFromAncestry(pid)
+		complete = complete && ok
+		l.HostBundleID = bundleID
 	}
 	// Back-fill kitty fields for sessions whose own env is unreadable
 	// (Apple-signed agents like `pi`, hardened-runtime binaries). If kitty
@@ -326,6 +366,7 @@ func applyAncestryFallbacks(l *session.Launcher, pid int, ancestry func() (term 
 	// target the right tab — exactly the symptom reported for pi sessions
 	// in issue #326.
 	applyKittyAncestryBackfill(l, pid, ancestry)
+	return complete
 }
 
 // applyKittyAncestryBackfill fills in KittyPID/KittyListenOn/KittyWindowID
@@ -333,11 +374,11 @@ func applyAncestryFallbacks(l *session.Launcher, pid int, ancestry func() (term 
 // kitty is the host (Apple-signed agents like `pi`, hardened-runtime
 // binaries) — split out of applyAncestryFallbacks so its nested guards don't
 // compound that function's cognitive complexity (go:S3776).
-func applyKittyAncestryBackfill(l *session.Launcher, pid int, ancestry func() (term string, hostPID int)) {
+func applyKittyAncestryBackfill(l *session.Launcher, pid int, ancestry ancestryFn) {
 	if l.TermProgram != "kitty" || l.KittyPID != 0 {
 		return
 	}
-	term, kpid := ancestry()
+	term, kpid, _ := ancestry()
 	if term != "kitty" || kpid <= 0 {
 		return
 	}

--- a/core/adapters/inbound/agents/processlifecycle/osutil.go
+++ b/core/adapters/inbound/agents/processlifecycle/osutil.go
@@ -365,8 +365,7 @@ func applyAncestryFallbacks(l *session.Launcher, pid int, ancestry ancestryFn) (
 	// Without this, clicking the session in the UI raises kitty but can't
 	// target the right tab — exactly the symptom reported for pi sessions
 	// in issue #326.
-	applyKittyAncestryBackfill(l, pid, ancestry)
-	return complete
+	return complete && applyKittyAncestryBackfill(l, pid, ancestry)
 }
 
 // applyKittyAncestryBackfill fills in KittyPID/KittyListenOn/KittyWindowID
@@ -374,13 +373,20 @@ func applyAncestryFallbacks(l *session.Launcher, pid int, ancestry ancestryFn) (
 // kitty is the host (Apple-signed agents like `pi`, hardened-runtime
 // binaries) — split out of applyAncestryFallbacks so its nested guards don't
 // compound that function's cognitive complexity (go:S3776).
-func applyKittyAncestryBackfill(l *session.Launcher, pid int, ancestry ancestryFn) {
+//
+// It returns the same completeness verdict its caller accumulates. This is the
+// one block that can be the ONLY caller of ancestry() in a run — a candidate
+// whose env names kitty but carries no KITTY_PID skips all three blocks above —
+// so discarding the bit here would let an aborted walk be reported as a
+// complete one, and the caller's "AND of every walk that actually ran" would be
+// a claim its own code contradicts.
+func applyKittyAncestryBackfill(l *session.Launcher, pid int, ancestry ancestryFn) (complete bool) {
 	if l.TermProgram != "kitty" || l.KittyPID != 0 {
-		return
+		return true // no walk ran, so nothing was left unread
 	}
-	term, kpid, _ := ancestry()
+	term, kpid, complete := ancestry()
 	if term != "kitty" || kpid <= 0 {
-		return
+		return complete
 	}
 	l.KittyPID = kpid
 	if l.KittyListenOn == "" {
@@ -389,6 +395,7 @@ func applyKittyAncestryBackfill(l *session.Launcher, pid int, ancestry ancestryF
 	if l.KittyListenOn != "" && l.KittyWindowID == "" {
 		l.KittyWindowID = kittyWindowIDForPID(l.KittyListenOn, pid)
 	}
+	return complete
 }
 
 // ReadArgv returns pid's argument vector (argv[0] is the executable as invoked),

--- a/core/adapters/inbound/agents/processlifecycle/osutil.go
+++ b/core/adapters/inbound/agents/processlifecycle/osutil.go
@@ -137,11 +137,17 @@ func ReadLauncherEnv(pid int) (l *session.Launcher, hostKnown bool) {
 // It deliberately says nothing about the env read, which cannot fail: the
 // ProcessObserver port defines an unreadable env as an empty map rather than
 // an error, and all three implementations discard it (process_darwin.go,
-// process_linux.go, process_other.go). Widening the port would buy nothing
-// here either, because an env that yields no host is exactly the condition
-// that makes the ancestry fallbacks run — so a false "no local window" always
-// passes through an ancestry walk, and the walk is where the distinction has
-// to be drawn.
+// process_linux.go, process_other.go).
+//
+// On darwin that costs nothing, because an env yielding no host is exactly the
+// condition that makes the ancestry fallbacks run — so a false "no local
+// window" always passes through a walk, and the walk is where the distinction
+// can be drawn. **That argument does not carry to linux or other**, where both
+// ancestry helpers are stubs reporting complete: there the env IS the only host
+// source, so a failed `/proc/<pid>/environ` read reports complete here. It is
+// inert only because herdrClientLauncher — the sole consumer of this bit — is
+// itself a stub off darwin. A second consumer on another platform needs the
+// port widened first, and must not read this comment as saying otherwise.
 //
 // The ordering is load-bearing: ancestry before TTY, and both before any
 // adoption by the caller.
@@ -177,7 +183,7 @@ func hostIdentity(pid int) (l *session.Launcher, complete bool) {
 	// none of its own (kitty), whose fields the suppression above drops. So
 	// skipping it would buy no correctness and cost exactly that case.
 	if l.HerdrPaneID == "" {
-		complete = applyAncestryFallbacks(l, pid, memoizedAncestry(pid))
+		complete = applyAncestryFallbacks(l, pid, &ancestryProbe{pid: pid})
 	}
 
 	// Capture the controlling TTY so Terminal.app (and potentially others)
@@ -288,29 +294,33 @@ func tmuxSocketFromEnv(tmux string) string {
 	return tmux
 }
 
-// ancestryFn is a memoized process-ancestry lookup. complete carries
-// resolveHostFromAncestry's meaning unchanged: false says the walk aborted on
-// an unreadable process, so an empty term is not evidence of anything (#1492).
-type ancestryFn func() (term string, hostPID int, complete bool)
-
-// memoizedAncestry returns a closure resolving pid's process ancestry via
-// resolveHostFromAncestry at most once, caching the result for repeat calls.
-// ReadLauncherEnv's ancestry-dependent fallbacks may all need the same walk;
-// this keeps it bounded to a single `ps` shellout chain instead of up to
-// three.
-func memoizedAncestry(pid int) ancestryFn {
-	var ancestryTerm string
-	var ancestryHostPID int
-	var ancestryComplete bool
-	ancestryResolved := false
-	return func() (string, int, bool) {
-		if !ancestryResolved {
-			ancestryTerm, ancestryHostPID, ancestryComplete = resolveHostFromAncestry(pid)
-			ancestryResolved = true
-		}
-		return ancestryTerm, ancestryHostPID, ancestryComplete
-	}
+// ancestryProbe resolves pid's process ancestry via resolveHostFromAncestry at
+// most once, caching the result for repeat calls. ReadLauncherEnv's
+// ancestry-dependent fallbacks may all need the same walk; this keeps it
+// bounded to a single `ps` shellout chain instead of up to three.
+type ancestryProbe struct {
+	pid      int
+	resolved bool
+	term     string
+	hostPID  int
+	complete bool
 }
+
+func (a *ancestryProbe) host() (term string, hostPID int) {
+	if !a.resolved {
+		a.term, a.hostPID, a.complete = resolveHostFromAncestry(a.pid)
+		a.resolved = true
+	}
+	return a.term, a.hostPID
+}
+
+// walked reports whether this probe left nothing unread: either no walk was
+// ever needed, or the one that ran reached a verdict rather than aborting on
+// an unreadable process (#1492). Keeping the bit on the memo — rather than
+// ANDing it at each of the guarded blocks that call host() — is what stops a
+// block that forgets to accumulate from silently reporting an aborted walk as
+// a complete one.
+func (a *ancestryProbe) walked() bool { return !a.resolved || a.complete }
 
 // applyAncestryFallbacks fills in Launcher fields that require walking pid's
 // process ancestry — cases the env alone can't resolve: kitty's missing
@@ -319,11 +329,12 @@ func memoizedAncestry(pid int) ancestryFn {
 // Apple-signed agents. ancestry is expected to be memoized by the caller so
 // this can call it from multiple guarded blocks at no extra cost.
 //
-// The return is the AND of every walk that actually ran: false means at least
-// one of them aborted on an unreadable process, so the fields it would have
-// filled are missing rather than absent (#1492). A run in which no walk was
-// needed is complete by definition.
-func applyAncestryFallbacks(l *session.Launcher, pid int, ancestry ancestryFn) (complete bool) {
+// The return is the AND of both walks it can run — the memoized ancestry probe
+// and the separate bundle-id walk: false means one of them aborted on an
+// unreadable process, so the fields it would have filled are missing rather
+// than absent (#1492). A run in which neither was needed is complete by
+// definition.
+func applyAncestryFallbacks(l *session.Launcher, pid int, ancestry *ancestryProbe) (complete bool) {
 	complete = true
 	// kitty intentionally does not set TERM_PROGRAM (upstream kitty issue
 	// #4793), so the env-captured value may be inherited from whatever
@@ -332,9 +343,7 @@ func applyAncestryFallbacks(l *session.Launcher, pid int, ancestry ancestryFn) (
 	// we still verify via process ancestry to rule out the reverse case
 	// (KITTY_WINDOW_ID leaked from a kitty shell that spawned VS Code).
 	if l.KittyWindowID != "" && l.TermProgram != "kitty" {
-		term, _, ok := ancestry()
-		complete = complete && ok
-		if term == "kitty" {
+		if term, _ := ancestry.host(); term == "kitty" {
 			l.TermProgram = "kitty"
 		}
 	}
@@ -343,9 +352,7 @@ func applyAncestryFallbacks(l *session.Launcher, pid int, ancestry ancestryFn) (
 	// can at least bring the host app to the front. Darwin-only; other
 	// platforms return "" and this is a no-op.
 	if l.TermProgram == "" {
-		term, _, ok := ancestry()
-		complete = complete && ok
-		l.TermProgram = term
+		l.TermProgram, _ = ancestry.host()
 	}
 	// Generic host fallback: when no curated host matched (TermProgram still
 	// empty), resolve the first top-level `.app` ancestor's bundle id so the
@@ -355,7 +362,7 @@ func applyAncestryFallbacks(l *session.Launcher, pid int, ancestry ancestryFn) (
 	// only; other platforms return "" and this is a no-op.
 	if l.TermProgram == "" {
 		bundleID, _, ok := resolveHostBundleIDFromAncestry(pid)
-		complete = complete && ok
+		complete = ok
 		l.HostBundleID = bundleID
 	}
 	// Back-fill kitty fields for sessions whose own env is unreadable
@@ -365,7 +372,8 @@ func applyAncestryFallbacks(l *session.Launcher, pid int, ancestry ancestryFn) (
 	// Without this, clicking the session in the UI raises kitty but can't
 	// target the right tab — exactly the symptom reported for pi sessions
 	// in issue #326.
-	return complete && applyKittyAncestryBackfill(l, pid, ancestry)
+	applyKittyAncestryBackfill(l, pid, ancestry)
+	return complete && ancestry.walked()
 }
 
 // applyKittyAncestryBackfill fills in KittyPID/KittyListenOn/KittyWindowID
@@ -374,19 +382,17 @@ func applyAncestryFallbacks(l *session.Launcher, pid int, ancestry ancestryFn) (
 // binaries) — split out of applyAncestryFallbacks so its nested guards don't
 // compound that function's cognitive complexity (go:S3776).
 //
-// It returns the same completeness verdict its caller accumulates. This is the
-// one block that can be the ONLY caller of ancestry() in a run — a candidate
-// whose env names kitty but carries no KITTY_PID skips all three blocks above —
-// so discarding the bit here would let an aborted walk be reported as a
-// complete one, and the caller's "AND of every walk that actually ran" would be
-// a claim its own code contradicts.
-func applyKittyAncestryBackfill(l *session.Launcher, pid int, ancestry ancestryFn) (complete bool) {
+// It is the one block that can be the ONLY caller of the ancestry probe in a
+// run — a candidate whose env names kitty but carries no KITTY_PID skips all
+// three blocks above — which is why its caller reads the verdict off the probe
+// afterwards rather than trusting the blocks to have accumulated it.
+func applyKittyAncestryBackfill(l *session.Launcher, pid int, ancestry *ancestryProbe) {
 	if l.TermProgram != "kitty" || l.KittyPID != 0 {
-		return true // no walk ran, so nothing was left unread
+		return
 	}
-	term, kpid, complete := ancestry()
+	term, kpid := ancestry.host()
 	if term != "kitty" || kpid <= 0 {
-		return complete
+		return
 	}
 	l.KittyPID = kpid
 	if l.KittyListenOn == "" {
@@ -395,7 +401,6 @@ func applyKittyAncestryBackfill(l *session.Launcher, pid int, ancestry ancestryF
 	if l.KittyListenOn != "" && l.KittyWindowID == "" {
 		l.KittyWindowID = kittyWindowIDForPID(l.KittyListenOn, pid)
 	}
-	return complete
 }
 
 // ReadArgv returns pid's argument vector (argv[0] is the executable as invoked),

--- a/core/adapters/inbound/agents/processlifecycle/osutil_darwin.go
+++ b/core/adapters/inbound/agents/processlifecycle/osutil_darwin.go
@@ -186,6 +186,11 @@ func resolveHostBundleIDFromAncestry(pid int) (bundleID string, hostPID int, com
 // useful), this is a real allow-list: an ancestor that is a legitimate `.app`
 // but isn't a curated terminal/IDE and isn't in knownEmbeddedHostBundleIDs
 // returns false — which is exactly what excludes CodexBar.
+//
+// It discards the completeness bit resolveHostFromAncestry reports (#1492): a
+// `ps` that blows its ceiling here returns false, which REJECTS a session
+// rather than degrading a click target. Tracked separately — changing an
+// admission gate's failure direction is its own decision — as #1511.
 func IsKnownInteractiveHost(pid int) bool {
 	// Short-circuit before the second ancestry walk: resolveHostFromAncestry
 	// and resolveHostBundleIDFromAncestry each independently re-walk the same
@@ -523,17 +528,35 @@ const maxClientCandidates = 4
 // every candidate, and one that could not be read cannot be vouched for by the
 // others. A candidate that DOES resolve still wins outright, because a found
 // host is evidence regardless of what the rest of the list did.
+//
+// The maxClientCandidates truncation poisons it too, and for the same reason: a
+// candidate dropped by the cap is one we declined to look at. It is a weaker
+// case — herdrClientPIDs sorts newest-attach first, so the dropped candidates
+// are the stale ones — but "every attached client was read" is exactly the
+// claim the cap makes false, and answering it anyway is #1492 arriving through
+// the cap instead of through a timeout.
+//
+// Two residual false negatives survive, both of them "the walk reached a
+// verdict" cases rather than aborts, so the bit above cannot express them:
+// a candidate inside a tmux pane walks to the reparented tmux server and
+// terminates honestly at PID 1 while a local window exists (that indirection is
+// #1501, the tmux twin of #1350), and a chain deeper than maxAncestry is
+// declared a miss on the same terms.
 func resolveClientHostIdentity(pids []int) (*session.Launcher, bool) {
-	if len(pids) > maxClientCandidates {
+	truncated := len(pids) > maxClientCandidates
+	if truncated {
 		pids = pids[:maxClientCandidates]
 	}
-	unreadable := false
+	unreadable := truncated
 	for _, pid := range pids {
 		host, complete := hostIdentity(pid)
 		if host.HerdrPaneID != "" {
 			// A candidate that is itself a multiplexer pane has no window of
 			// its own — its host is one more indirection away. Don't recurse;
-			// try the next candidate.
+			// try the next candidate. Unlike the cap above, declining here does
+			// NOT poison the answer: refusing to recurse is a standing policy
+			// rather than a failed read, and treating it as "unknown" would mean
+			// a nested setup's stale host could never be cleared at all.
 			continue
 		}
 		if host.TermProgram == "" && host.HostBundleID == "" {
@@ -591,6 +614,14 @@ func herdrClientLauncher(socketPath string) (*session.Launcher, bool) {
 		// spread a single failed probe across every session that shares this
 		// socket for the next 5 seconds, which is the opposite of what the
 		// tri-state buys.
+		//
+		// #1492 widened what reaches this branch, and with it the cost: an
+		// unreadable candidate used to answer (nil, true) and be cached once
+		// per socket, and now re-probes per pane — under exactly the load that
+		// produces it. That is a deliberate trade of cost for correctness, not
+		// an oversight; re-deciding the rule reverses #1485's and is tracked as
+		// #1512, together with refreshHerdrHosts' affordability note, which
+		// assumes one lsof scan per socket per sweep.
 		return nil, false
 	}
 	herdrClientCachePut(socketPath, resolved)

--- a/core/adapters/inbound/agents/processlifecycle/osutil_darwin.go
+++ b/core/adapters/inbound/agents/processlifecycle/osutil_darwin.go
@@ -190,7 +190,7 @@ func resolveHostBundleIDFromAncestry(pid int) (bundleID string, hostPID int, com
 // It discards the completeness bit resolveHostFromAncestry reports (#1492): a
 // `ps` that blows its ceiling here returns false, which REJECTS a session
 // rather than degrading a click target. Tracked separately — changing an
-// admission gate's failure direction is its own decision — as #1511.
+// admission gate's failure direction is its own decision — as #1513.
 func IsKnownInteractiveHost(pid int) bool {
 	// Short-circuit before the second ancestry walk: resolveHostFromAncestry
 	// and resolveHostBundleIDFromAncestry each independently re-walk the same
@@ -620,7 +620,7 @@ func herdrClientLauncher(socketPath string) (*session.Launcher, bool) {
 		// per socket, and now re-probes per pane — under exactly the load that
 		// produces it. That is a deliberate trade of cost for correctness, not
 		// an oversight; re-deciding the rule reverses #1485's and is tracked as
-		// #1512, together with refreshHerdrHosts' affordability note, which
+		// #1514, together with refreshHerdrHosts' affordability note, which
 		// assumes one lsof scan per socket per sweep.
 		return nil, false
 	}

--- a/core/adapters/inbound/agents/processlifecycle/osutil_darwin.go
+++ b/core/adapters/inbound/agents/processlifecycle/osutil_darwin.go
@@ -543,11 +543,10 @@ const maxClientCandidates = 4
 // #1501, the tmux twin of #1350), and a chain deeper than maxAncestry is
 // declared a miss on the same terms.
 func resolveClientHostIdentity(pids []int) (*session.Launcher, bool) {
-	truncated := len(pids) > maxClientCandidates
-	if truncated {
+	readAll := len(pids) <= maxClientCandidates
+	if !readAll {
 		pids = pids[:maxClientCandidates]
 	}
-	unreadable := truncated
 	for _, pid := range pids {
 		host, complete := hostIdentity(pid)
 		if host.HerdrPaneID != "" {
@@ -560,12 +559,12 @@ func resolveClientHostIdentity(pids []int) (*session.Launcher, bool) {
 			continue
 		}
 		if host.TermProgram == "" && host.HostBundleID == "" {
-			unreadable = unreadable || !complete
+			readAll = readAll && complete
 			continue
 		}
 		return host, true
 	}
-	return nil, !unreadable
+	return nil, readAll
 }
 
 // herdrClientLauncher resolves the host-window identity of the herdr session
@@ -578,17 +577,8 @@ func resolveClientHostIdentity(pids []int) (*session.Launcher, bool) {
 // (#1485) or a candidate's own identity could not be read (#1492).
 //
 // "Was read and has no host" rather than "reported no host" is the whole of
-// #1492, and the two are not the same claim. hostIdentity swallows its env
-// read's failure by design — the ProcessObserver port defines an unreadable env
-// as an empty map, and the ancestry fallback is the only signal a
-// hardened-runtime process has — so the distinction is drawn where it can be:
-// resolveHostFromAncestry and resolveHostBundleIDFromAncestry now report
-// whether their walk reached a verdict or aborted on a readProcInfo failure,
-// hostIdentity carries that out as its second return, and
-// resolveClientHostIdentity refuses to call the negative an answer when any
-// candidate could not be read. Before that, a client attached from kitty (which
-// sets no TERM_PROGRAM upstream, so ancestry is its only source) yielded no host
-// on a loaded machine and was indistinguishable here from an SSH client.
+// #1492; resolveClientHostIdentity's doc carries the argument, and this
+// function only passes its verdict through.
 //
 // Only ever called with a socket path the daemon captured from the pane's own
 // $HERDR_SOCKET_PATH, so a resolved identity always accompanies a complete

--- a/core/adapters/inbound/agents/processlifecycle/osutil_darwin.go
+++ b/core/adapters/inbound/agents/processlifecycle/osutil_darwin.go
@@ -81,26 +81,35 @@ const maxAncestry = 10
 // which it was found. Returns ("", 0) when no supported host appears within
 // maxAncestry levels.
 //
+// complete reports whether the walk reached that verdict on its own terms —
+// it found a host, ran out of chain, or ran out of depth — rather than
+// aborting because a `ps` could not be answered. Those two produce the same
+// ("", 0) and are different facts: the first is evidence that this process has
+// no local window, the second is no evidence at all. Every abort is a
+// readProcInfo failure, which on a loaded machine is that helper's 2s ceiling
+// (#1492); the caller that acts on the distinction is
+// resolveClientHostIdentity.
+//
 // Intentionally ignores tmux: tmux's env vars (TMUX, TMUX_PANE) come from
 // the regular env-capture path when readable, and a tmux-only ancestor
 // (without a known host terminal above it) can't be brought to the front
 // by NSWorkspace.
-func resolveHostFromAncestry(pid int) (termProgram string, hostPID int) {
+func resolveHostFromAncestry(pid int) (termProgram string, hostPID int, complete bool) {
 	cur := pid
 	for i := 0; i < maxAncestry && cur > 1; i++ {
 		ppid, cmd, err := readProcInfo(cur)
 		if err != nil {
-			return "", 0
+			return "", 0, false
 		}
 		if term := termProgramForAppPath(cmd); term != "" {
-			return term, cur
+			return term, cur, true
 		}
 		if ppid == cur || ppid <= 1 {
-			return "", 0
+			return "", 0, true
 		}
 		cur = ppid
 	}
-	return "", 0
+	return "", 0, true
 }
 
 // bundleIDForAppPath returns the CFBundleIdentifier of the application bundle
@@ -124,7 +133,10 @@ func bundleIDForAppPath(appPath string) string {
 
 // resolveHostBundleIDFromAncestry walks the parent-process chain of pid and
 // returns the CFBundleIdentifier of the first top-level application bundle it
-// finds, plus that app's PID. It is the generic fallback used when the curated
+// finds, plus that app's PID. complete carries the same meaning as
+// resolveHostFromAncestry's, and the first read is split out of the `ppid <= 1`
+// guard for exactly that reason: "pid's parent is init" is a verdict, "pid
+// could not be read" is not. It is the generic fallback used when the curated
 // termProgramByAppName map matches no ancestor — it lets the UI bring an
 // embedded-terminal GUI host (e.g. Obsidian) to the front without a per-app
 // registry entry. Returns ("", 0) when no top-level app appears within
@@ -133,28 +145,31 @@ func bundleIDForAppPath(appPath string) string {
 // The walk starts at pid's *parent*: the agent runs inside the host and is
 // never the host itself, and an agent whose own binary lives in a top-level
 // bundle (e.g. ClaudeCode.app) must not be mistaken for it.
-func resolveHostBundleIDFromAncestry(pid int) (bundleID string, hostPID int) {
+func resolveHostBundleIDFromAncestry(pid int) (bundleID string, hostPID int, complete bool) {
 	ppid, _, err := readProcInfo(pid)
-	if err != nil || ppid <= 1 {
-		return "", 0
+	if err != nil {
+		return "", 0, false
+	}
+	if ppid <= 1 {
+		return "", 0, true
 	}
 	cur := ppid
 	for i := 0; i < maxAncestry && cur > 1; i++ {
 		pp, cmd, err := readProcInfo(cur)
 		if err != nil {
-			return "", 0
+			return "", 0, false
 		}
 		if appPath := topLevelAppPath(cmd); appPath != "" {
 			if bid := bundleIDForAppPath(appPath); bid != "" {
-				return bid, cur
+				return bid, cur, true
 			}
 		}
 		if pp == cur || pp <= 1 {
-			return "", 0
+			return "", 0, true
 		}
 		cur = pp
 	}
-	return "", 0
+	return "", 0, true
 }
 
 // IsKnownInteractiveHost reports whether pid's process ancestry traces back to
@@ -176,11 +191,11 @@ func IsKnownInteractiveHost(pid int) bool {
 	// and resolveHostBundleIDFromAncestry each independently re-walk the same
 	// parent chain via their own ps shellouts, so skip the bundle-ID walk
 	// entirely once the curated map already matched.
-	term, _ := resolveHostFromAncestry(pid)
+	term, _, _ := resolveHostFromAncestry(pid)
 	if term != "" {
 		return true
 	}
-	bundleID, _ := resolveHostBundleIDFromAncestry(pid)
+	bundleID, _, _ := resolveHostBundleIDFromAncestry(pid)
 	return isKnownInteractiveHostFrom(term, bundleID)
 }
 
@@ -196,7 +211,7 @@ func isKnownInteractiveHostFrom(termProgram, bundleID string) bool {
 // other host) appears in the chain; callers that also need the host PID
 // should use resolveHostFromAncestry directly to avoid a second walk.
 func resolveTermProgramFromAncestry(pid int) string {
-	term, _ := resolveHostFromAncestry(pid)
+	term, _, _ := resolveHostFromAncestry(pid)
 	return term
 }
 
@@ -208,7 +223,7 @@ func resolveTermProgramFromAncestry(pid int) string {
 // into the env-derived launcher. Ancestry walking still works because we
 // only read ppid + comm, not env.
 func kittyAncestryPID(pid int) int {
-	term, hostPID := resolveHostFromAncestry(pid)
+	term, hostPID, _ := resolveHostFromAncestry(pid)
 	if term != "kitty" {
 		return 0
 	}
@@ -489,12 +504,32 @@ const maxClientCandidates = 4
 // down: true means the answer is evidence, false means the candidates could
 // not be read and the caller must not treat an absent host as a host that is
 // gone.
+//
+// #1492 is the whole of that second return. "This candidate has no local GUI
+// window" and "this candidate's identity could not be READ" arrive at the same
+// place — an empty TermProgram and an empty HostBundleID — and only the first
+// is evidence. The first is real and must stay an answer: an SSH client has a
+// real tty and no local window, and reporting one anyway is the misroute #1348
+// removed. The second is not: kitty sets no TERM_PROGRAM (upstream kitty
+// #4793), so for a client attached from kitty the ancestry walk is the ONLY
+// source of a host, and that walk is a `ps` chain under a 2s ceiling. On a
+// loaded machine it times out, the candidate reports nothing, and answering
+// "detached" makes AdoptHostIdentity clear TermProgram / HostBundleID /
+// ITermSessionID / the kitty selectors from a session whose client is attached
+// right now.
+//
+// So an unreadable candidate poisons the negative answer rather than
+// contributing to it: "no attached client has a local window" is a claim about
+// every candidate, and one that could not be read cannot be vouched for by the
+// others. A candidate that DOES resolve still wins outright, because a found
+// host is evidence regardless of what the rest of the list did.
 func resolveClientHostIdentity(pids []int) (*session.Launcher, bool) {
 	if len(pids) > maxClientCandidates {
 		pids = pids[:maxClientCandidates]
 	}
+	unreadable := false
 	for _, pid := range pids {
-		host := hostIdentity(pid)
+		host, complete := hostIdentity(pid)
 		if host.HerdrPaneID != "" {
 			// A candidate that is itself a multiplexer pane has no window of
 			// its own — its host is one more indirection away. Don't recurse;
@@ -502,31 +537,35 @@ func resolveClientHostIdentity(pids []int) (*session.Launcher, bool) {
 			continue
 		}
 		if host.TermProgram == "" && host.HostBundleID == "" {
+			unreadable = unreadable || !complete
 			continue
 		}
 		return host, true
 	}
-	return nil, true
+	return nil, !unreadable
 }
 
 // herdrClientLauncher resolves the host-window identity of the herdr session
 // addressed by socketPath, by reading it from the attached client exactly the
 // way it would be read from any directly-hosted agent (hostIdentity). Returns
-// (nil, true) when nothing is attached, or when no attached client REPORTED a
-// local GUI host — an SSH client has a real tty but no local window, and
-// reporting one anyway is the misroute #1348 removed. (nil, false) is the
-// third state, "the probe did not run" (#1485).
+// (nil, true) when nothing is attached, or when every attached client was read
+// and none has a local GUI host — an SSH client has a real tty but no local
+// window, and reporting one anyway is the misroute #1348 removed. (nil, false)
+// is the third state, "I could not look": either the lsof probe did not run
+// (#1485) or a candidate's own identity could not be read (#1492).
 //
-// "Reported" rather than "resolves to" is deliberate and is the known residual
-// of #1485: a candidate whose own identity could not be READ is counted as one
-// that has no host. hostIdentity swallows both of its failure modes — EnvOf's
-// error is discarded, and resolveHostFromAncestry returns ("", 0) for a
-// readProcInfo timeout as well as for a genuine miss — so a client attached
-// from kitty (which sets no TERM_PROGRAM upstream, so ancestry is its only
-// source) yields no host on a loaded machine and is indistinguishable here
-// from an SSH client. That is the same conflation one layer up, and closing it
-// needs hostIdentity to report whether its reads ran, which this fix does not
-// do. Tracked as #1492; do not read the tri-state below as covering it.
+// "Was read and has no host" rather than "reported no host" is the whole of
+// #1492, and the two are not the same claim. hostIdentity swallows its env
+// read's failure by design — the ProcessObserver port defines an unreadable env
+// as an empty map, and the ancestry fallback is the only signal a
+// hardened-runtime process has — so the distinction is drawn where it can be:
+// resolveHostFromAncestry and resolveHostBundleIDFromAncestry now report
+// whether their walk reached a verdict or aborted on a readProcInfo failure,
+// hostIdentity carries that out as its second return, and
+// resolveClientHostIdentity refuses to call the negative an answer when any
+// candidate could not be read. Before that, a client attached from kitty (which
+// sets no TERM_PROGRAM upstream, so ancestry is its only source) yielded no host
+// on a loaded machine and was indistinguishable here from an SSH client.
 //
 // Only ever called with a socket path the daemon captured from the pane's own
 // $HERDR_SOCKET_PATH, so a resolved identity always accompanies a complete

--- a/core/adapters/inbound/agents/processlifecycle/osutil_darwin.go
+++ b/core/adapters/inbound/agents/processlifecycle/osutil_darwin.go
@@ -473,11 +473,41 @@ func herdrClientWriters(out string, self int) []int {
 	return pids
 }
 
-// maxHerdrClientCandidates bounds how many attached clients are probed for a
+// maxClientCandidates bounds how many attached clients are probed for a
 // resolvable host. Each candidate costs an env read plus an ancestry walk, and
 // attaching more than a handful of clients to one session is not a real
 // workflow, so the cap keeps that work proportionate.
-const maxHerdrClientCandidates = 4
+const maxClientCandidates = 4
+
+// resolveClientHostIdentity picks the host-window identity of the first
+// candidate in pids that reports one. It is the shared "which window is this
+// multiplexer session displayed in" loop: herdr feeds it the writers of the
+// session's client log (resolveHerdrClientLauncher), and #1501's tmux path is
+// queued to feed it `tmux list-clients -F '#{client_pid}'`.
+//
+// The second return is the same tri-state herdrClientPIDs draws one layer
+// down: true means the answer is evidence, false means the candidates could
+// not be read and the caller must not treat an absent host as a host that is
+// gone.
+func resolveClientHostIdentity(pids []int) (*session.Launcher, bool) {
+	if len(pids) > maxClientCandidates {
+		pids = pids[:maxClientCandidates]
+	}
+	for _, pid := range pids {
+		host := hostIdentity(pid)
+		if host.HerdrPaneID != "" {
+			// A candidate that is itself a multiplexer pane has no window of
+			// its own — its host is one more indirection away. Don't recurse;
+			// try the next candidate.
+			continue
+		}
+		if host.TermProgram == "" && host.HostBundleID == "" {
+			continue
+		}
+		return host, true
+	}
+	return nil, true
+}
 
 // herdrClientLauncher resolves the host-window identity of the herdr session
 // addressed by socketPath, by reading it from the attached client exactly the
@@ -533,22 +563,7 @@ func resolveHerdrClientLauncher(socketPath string) (*session.Launcher, bool) {
 	if !probed {
 		return nil, false
 	}
-	if len(pids) > maxHerdrClientCandidates {
-		pids = pids[:maxHerdrClientCandidates]
-	}
-	for _, pid := range pids {
-		host := hostIdentity(pid)
-		if host.HerdrPaneID != "" {
-			// herdr nested in herdr: this client's own window is another
-			// indirection away. Don't recurse — try the next candidate.
-			continue
-		}
-		if host.TermProgram == "" && host.HostBundleID == "" {
-			continue
-		}
-		return host, true
-	}
-	return nil, true
+	return resolveClientHostIdentity(pids)
 }
 
 // herdrClientCacheTTL is short enough that attaching a client is picked up by

--- a/core/adapters/inbound/agents/processlifecycle/osutil_darwin_test.go
+++ b/core/adapters/inbound/agents/processlifecycle/osutil_darwin_test.go
@@ -4,7 +4,6 @@ package processlifecycle
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -681,31 +680,25 @@ func TestReadLauncherEnv_Herdr_UnprobableClientReportsHostUnknown(t *testing.T) 
 
 // --- client-candidate resolution (#1492) ------------------------------------
 
-// exitedPID returns the PID of a process that has run to completion and been
-// reaped. Every identity read of it then fails the way a herdr client that
-// exits between the lsof scan and the identity read does — and, more to the
-// point of #1492, it takes the *same* `if err != nil` branch inside
-// resolveHostFromAncestry / resolveHostBundleIDFromAncestry that a `ps` which
-// blows its 2s ceiling on a loaded machine takes. The timeout is the cause the
-// issue is about; a reaped PID is the one cause of that class that a test can
-// arrange deterministically.
+// exitedPID is deadPIDForScannerTest (scanner_test.go, same package and same
+// test binary) with the recycle policy the #1492 family needs. Every identity
+// read of a reaped PID fails the way a herdr client that exits between the lsof
+// scan and the identity read does — and, more to the point, it takes the *same*
+// `if err != nil` branch inside resolveHostFromAncestry /
+// resolveHostBundleIDFromAncestry that a `ps` which blows its 2s ceiling on a
+// loaded machine takes. The timeout is the cause the issue is about; a reaped
+// PID is the one cause of that class a test can arrange deterministically.
 //
-// PID reuse is asserted away rather than tolerated: macOS allocates PIDs
-// ascending and wraps at 99999, so a reuse inside this window would need tens
-// of thousands of intervening spawns, and treating it as a skip would let the
-// whole family of assertions below pass vacuously.
+// The policy difference is the reason this wrapper exists rather than a second
+// spawn-and-reap: its caller skips on a recycled PID, which for these tests
+// would let the whole family pass vacuously. macOS allocates PIDs ascending and
+// wraps at 99999, so a reuse inside this window needs tens of thousands of
+// intervening spawns — rare enough to assert away, not rare enough to hide.
 func exitedPID(t *testing.T) int {
 	t.Helper()
-	cmd := exec.Command("/usr/bin/true")
-	if err := cmd.Start(); err != nil {
-		t.Fatalf("spawn: %v", err)
-	}
-	pid := cmd.Process.Pid
-	if err := cmd.Wait(); err != nil {
-		t.Fatalf("wait: %v", err)
-	}
-	if err := syscall.Kill(pid, 0); !errors.Is(err, syscall.ESRCH) {
-		t.Fatalf("pid %d is still addressable after being reaped (kill(0) = %v) — PID reuse would make every assertion below vacuous", pid, err)
+	pid := deadPIDForScannerTest(t)
+	if IsAlive(pid) {
+		t.Fatalf("pid %d is alive after being reaped — PID reuse would make every assertion below vacuous", pid)
 	}
 	return pid
 }
@@ -909,11 +902,14 @@ func TestResolveClientHostIdentity_HostlessCandidateStaysDetached(t *testing.T) 
 func TestResolveClientHostIdentity_OneUnreadableCandidatePoisonsTheAnswer(t *testing.T) {
 	dead := exitedPID(t)
 
-	// launchd first: a readable, genuinely hostless candidate. If the loop
-	// only remembered the last verdict it would answer "detached" here.
+	// launchd first, so a loop that only remembered the FIRST candidate's
+	// verdict would answer "detached" here.
 	if _, hostKnown := resolveClientHostIdentity([]int{1, dead}); hostKnown {
 		t.Error("one unreadable candidate makes 'no client has a window' unsupported (#1492)")
 	}
+	// launchd last, so a loop that only remembered the LAST verdict would
+	// answer "detached" here. Between them the two arms pin both spellings of
+	// "the accumulator was dropped".
 	if _, hostKnown := resolveClientHostIdentity([]int{dead, 1}); hostKnown {
 		t.Error("order must not change the verdict")
 	}
@@ -936,5 +932,13 @@ func TestResolveClientHostIdentity_ResolvableCandidateStillWins(t *testing.T) {
 	}
 	if host == nil || host.TermProgram != "iTerm.app" || host.ITermSessionID != "w0t0p0-CLIENT" {
 		t.Fatalf("want the candidate's own host identity, got %+v", host)
+	}
+
+	// The asymmetry the doc claims: a found host is evidence regardless of what
+	// the rest of the list did, so an unreadable candidate ahead of it must not
+	// poison a POSITIVE answer — only a negative one.
+	host, hostKnown = resolveClientHostIdentity([]int{exitedPID(t), client})
+	if !hostKnown || host == nil || host.TermProgram != "iTerm.app" {
+		t.Errorf("a resolving candidate wins outright past an unreadable one: got (%+v, %v)", host, hostKnown)
 	}
 }

--- a/core/adapters/inbound/agents/processlifecycle/osutil_darwin_test.go
+++ b/core/adapters/inbound/agents/processlifecycle/osutil_darwin_test.go
@@ -4,11 +4,13 @@ package processlifecycle
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"syscall"
 	"testing"
@@ -296,11 +298,12 @@ func TestTopLevelAppPath(t *testing.T) {
 // logic is covered by TestTopLevelAppPath.
 func TestResolveHostBundleIDFromAncestry_Self(t *testing.T) {
 	bid, hostPID, complete := resolveHostBundleIDFromAncestry(os.Getpid())
-	// The running test binary is alive by definition, so every readProcInfo in
-	// its chain answers and the walk reaches a verdict. This arm is
-	// environment-independent even though the verdict itself is not.
+	// The running test binary is alive, so every readProcInfo in its chain has
+	// something to answer with — barring a `ps` slow enough to blow its own 2s
+	// ceiling, which is the condition #1492 is about and which this assertion
+	// would report as a failure rather than hide.
 	if !complete {
-		t.Error("the walk over a live process aborted — every ps in its own ancestry must answer")
+		t.Error("the walk over a live process aborted — either a ps timed out, or the verdict is wrong")
 	}
 	if bid == "" {
 		return // no top-level .app ancestor (e.g. CI/tmux/ssh) — valid.
@@ -701,7 +704,7 @@ func exitedPID(t *testing.T) int {
 	if err := cmd.Wait(); err != nil {
 		t.Fatalf("wait: %v", err)
 	}
-	if err := syscall.Kill(pid, 0); err != syscall.ESRCH {
+	if err := syscall.Kill(pid, 0); !errors.Is(err, syscall.ESRCH) {
 		t.Fatalf("pid %d is still addressable after being reaped (kill(0) = %v) — PID reuse would make every assertion below vacuous", pid, err)
 	}
 	return pid
@@ -733,6 +736,115 @@ func TestResolveHostBundleIDFromAncestry_UnreadableProcessIsNotAMiss(t *testing.
 	}
 	if bid, hostPID, complete := resolveHostBundleIDFromAncestry(exitedPID(t)); bid != "" || hostPID != 0 || complete {
 		t.Errorf("reaped pid: got (%q, %d, %v); want an ABORTED walk", bid, hostPID, complete)
+	}
+}
+
+// envObserver is a ProcessObserver that answers EnvOf from a fixed map. It
+// exists to reach one block of applyAncestryFallbacks that no live process can
+// be arranged into: the kitty back-fill, which runs only when the env NAMES
+// kitty and carries no KITTY_PID, and which is then the ONLY caller of the
+// ancestry walk in that run.
+type envObserver struct {
+	fakeObserver
+	env map[string]string
+}
+
+func (o envObserver) EnvOf(int) (map[string]string, error) { return o.env, nil }
+
+// TestHostIdentity_KittyBackfillWalkCountsTowardCompleteness pins the one
+// ancestry walk that applyAncestryFallbacks used to run and then ignore.
+//
+// A candidate whose env says TERM_PROGRAM=kitty with no KITTY_PID skips all
+// three blocks above the back-fill (block 1 needs KITTY_WINDOW_ID, blocks 2 and
+// 3 need an empty TermProgram), so the back-fill's walk is the only one that
+// runs — and discarding its verdict reported an aborted walk as a complete one.
+// Reaching it needs the env and the process to disagree, which only the osProc
+// seam can arrange: a reaped PID whose env still reads as kitty's.
+func TestHostIdentity_KittyBackfillWalkCountsTowardCompleteness(t *testing.T) {
+	prev := osProc
+	osProc = envObserver{env: map[string]string{"TERM_PROGRAM": "kitty"}}
+	t.Cleanup(func() { osProc = prev })
+
+	// Vacuity guard: with a LIVE pid the same block runs and completes, so a
+	// hostIdentity hard-wired to "incomplete" would not satisfy this test.
+	if l, complete := hostIdentity(os.Getpid()); !complete || l.TermProgram != "kitty" {
+		t.Errorf("live pid: got (%+v, %v); want the back-fill to run and complete", l, complete)
+	}
+
+	l, complete := hostIdentity(exitedPID(t))
+	if l.TermProgram != "kitty" {
+		t.Fatalf("the env still names the host, so it must survive: %+v", l)
+	}
+	if complete {
+		t.Error("the back-fill's walk aborted and it was the only walk in this run — that is not a complete read")
+	}
+}
+
+// orphanPID returns the PID of a live process whose parent has exited, so it
+// has been reparented to launchd. Its ancestry walk therefore enters the loop
+// and leaves it through the `ppid <= 1` verdict — the branch PID 1 itself never
+// reaches, because the loop's `cur > 1` guard skips it entirely.
+//
+// It is also the shape hostIdentity's own comment leans on for tmux: a tmux
+// server daemonizes and is reparented to PID 1, so a pane's walk terminates
+// there having found nothing. That premise is a comment everywhere else in this
+// package; here it is an assertion.
+func orphanPID(t *testing.T) int {
+	t.Helper()
+	out, err := exec.Command("/bin/sh", "-c", "sleep 30 >/dev/null 2>&1 & echo $!").Output()
+	if err != nil {
+		t.Fatalf("spawn orphan: %v", err)
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(out)))
+	if err != nil {
+		t.Fatalf("parse orphan pid %q: %v", out, err)
+	}
+	t.Cleanup(func() { _ = syscall.Kill(pid, syscall.SIGKILL) })
+	// The `sh` has exited (Output waits for it); wait for launchd to actually
+	// re-parent before asserting on the chain.
+	for i := 0; i < 100; i++ {
+		if ppid, _, err := readProcInfo(pid); err == nil && ppid <= 1 {
+			return pid
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("orphan %d was never reparented to launchd", pid)
+	return 0
+}
+
+// TestResolveHostFromAncestry_ChainEndingAtInitIsAVerdict covers the arm PID 1
+// cannot reach. Both of the other tests' "complete" rows use launchd, whose
+// walk never enters the loop at all — so the in-loop verdict, which is the one
+// every reparented client (and every tmux-hosted candidate) leaves through, was
+// asserted by nothing. A walk that ends at init found no host and says so;
+// calling that an abort would mean a genuinely detached session's stale host
+// could never be cleared, which is the #1348 misroute by a third route.
+func TestResolveHostFromAncestry_ChainEndingAtInitIsAVerdict(t *testing.T) {
+	orphan := orphanPID(t)
+
+	if term, hostPID, complete := resolveHostFromAncestry(orphan); term != "" || hostPID != 0 || !complete {
+		t.Errorf("orphan: got (%q, %d, %v); want a completed in-loop walk that found nothing", term, hostPID, complete)
+	}
+	if _, hostKnown := resolveClientHostIdentity([]int{orphan}); !hostKnown {
+		t.Error("a reparented candidate WAS read and has no window — that is an answer")
+	}
+}
+
+// TestResolveClientHostIdentity_TruncatedCandidatesArePoisonToo: the cap is a
+// decision not to look, and answering "every attached client was read" over it
+// is the same conflation the rest of this file removes, arriving through the
+// cap instead of through a timeout. launchd repeated is a readable, genuinely
+// hostless candidate, so nothing but the truncation can move the verdict.
+func TestResolveClientHostIdentity_TruncatedCandidatesArePoisonToo(t *testing.T) {
+	full := make([]int, maxClientCandidates)
+	for i := range full {
+		full[i] = 1
+	}
+	if _, hostKnown := resolveClientHostIdentity(full); !hostKnown {
+		t.Fatalf("exactly maxClientCandidates readable candidates is a complete look: %d", len(full))
+	}
+	if _, hostKnown := resolveClientHostIdentity(append(full, 1)); hostKnown {
+		t.Error("one candidate past the cap was never probed, so 'no client has a window' is unsupported")
 	}
 }
 

--- a/core/adapters/inbound/agents/processlifecycle/osutil_darwin_test.go
+++ b/core/adapters/inbound/agents/processlifecycle/osutil_darwin_test.go
@@ -669,3 +669,113 @@ func TestReadLauncherEnv_Herdr_UnprobableClientReportsHostUnknown(t *testing.T) 
 		t.Error("a detached session's host is known to be absent")
 	}
 }
+
+// --- client-candidate resolution (#1492) ------------------------------------
+
+// exitedPID returns the PID of a process that has run to completion and been
+// reaped. Every identity read of it then fails the way a herdr client that
+// exits between the lsof scan and the identity read does — and, more to the
+// point of #1492, it takes the *same* `if err != nil` branch inside
+// resolveHostFromAncestry / resolveHostBundleIDFromAncestry that a `ps` which
+// blows its 2s ceiling on a loaded machine takes. The timeout is the cause the
+// issue is about; a reaped PID is the one cause of that class that a test can
+// arrange deterministically.
+//
+// PID reuse is asserted away rather than tolerated: macOS allocates PIDs
+// ascending and wraps at 99999, so a reuse inside this window would need tens
+// of thousands of intervening spawns, and treating it as a skip would let the
+// whole family of assertions below pass vacuously.
+func exitedPID(t *testing.T) int {
+	t.Helper()
+	cmd := exec.Command("/usr/bin/true")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("spawn: %v", err)
+	}
+	pid := cmd.Process.Pid
+	if err := cmd.Wait(); err != nil {
+		t.Fatalf("wait: %v", err)
+	}
+	if err := syscall.Kill(pid, 0); err != syscall.ESRCH {
+		t.Fatalf("pid %d is still addressable after being reaped (kill(0) = %v) — PID reuse would make every assertion below vacuous", pid, err)
+	}
+	return pid
+}
+
+// TestResolveClientHostIdentity_UnreadableCandidateIsNotDetached is #1492.
+//
+// The loop's `continue` meant two things at once: "this candidate genuinely has
+// no local GUI window" (an SSH client — reporting one anyway is the #1348
+// misroute) and "this candidate's identity could not be READ". Answering the
+// second with (nil, true) is an authoritative "detached", and AdoptHostIdentity
+// acts on it by clearing TermProgram / HostBundleID / ITermSessionID / the kitty
+// selectors from a session whose client is attached the whole time.
+//
+// A candidate that cannot be read must therefore come back as the third state —
+// "I could not look" — exactly as herdrClientPIDs already reports it one layer
+// down (#1485).
+func TestResolveClientHostIdentity_UnreadableCandidateIsNotDetached(t *testing.T) {
+	dead := exitedPID(t)
+
+	host, hostKnown := resolveClientHostIdentity([]int{dead})
+
+	if host != nil {
+		t.Errorf("an unreadable candidate must not produce a host: %+v", host)
+	}
+	if hostKnown {
+		t.Error("the candidate's identity could not be read, so the host is unknown — not absent (#1492)")
+	}
+}
+
+// TestResolveClientHostIdentity_HostlessCandidateStaysDetached is the lock the
+// fix must not break, and it passes on main by construction: #1348 removed the
+// misroute where a session with no local window was reported as living in the
+// terminal the user had left. launchd stands in for that candidate — its
+// ancestry walk terminates immediately and honestly (PID 1 has no parent), so
+// "no local window" here is evidence, and the answer stays an answer.
+func TestResolveClientHostIdentity_HostlessCandidateStaysDetached(t *testing.T) {
+	host, hostKnown := resolveClientHostIdentity([]int{1})
+
+	if host != nil {
+		t.Errorf("launchd has no window; reporting one is the #1348 misroute: %+v", host)
+	}
+	if !hostKnown {
+		t.Error("the candidate WAS read and genuinely has no local window — that is an answer, not a failed probe")
+	}
+}
+
+// TestResolveClientHostIdentity_OneUnreadableCandidatePoisonsTheAnswer covers
+// the mixed list. "No attached client has a local window" is a claim about
+// every candidate, so a single one that could not be read is enough to make it
+// unsupported — the readable ones cannot vouch for it.
+func TestResolveClientHostIdentity_OneUnreadableCandidatePoisonsTheAnswer(t *testing.T) {
+	dead := exitedPID(t)
+
+	// launchd first: a readable, genuinely hostless candidate. If the loop
+	// only remembered the last verdict it would answer "detached" here.
+	if _, hostKnown := resolveClientHostIdentity([]int{1, dead}); hostKnown {
+		t.Error("one unreadable candidate makes 'no client has a window' unsupported (#1492)")
+	}
+	if _, hostKnown := resolveClientHostIdentity([]int{dead, 1}); hostKnown {
+		t.Error("order must not change the verdict")
+	}
+}
+
+// TestResolveClientHostIdentity_ResolvableCandidateStillWins is the vacuity
+// guard for the three above: a loop that answered "unknown" for everything
+// would satisfy the #1492 assertions while resolving no session at all.
+func TestResolveClientHostIdentity_ResolvableCandidateStillWins(t *testing.T) {
+	client := spawnSleeperWithEnv(t, []string{
+		"PATH=/usr/bin:/bin",
+		"TERM_PROGRAM=iTerm.app",
+		"ITERM_SESSION_ID=w0t0p0-CLIENT",
+	})
+
+	host, hostKnown := resolveClientHostIdentity([]int{client})
+
+	if !hostKnown {
+		t.Fatal("a candidate whose own env names its host is readable by definition")
+	}
+	if host == nil || host.TermProgram != "iTerm.app" || host.ITermSessionID != "w0t0p0-CLIENT" {
+		t.Fatalf("want the candidate's own host identity, got %+v", host)
+	}
+}

--- a/core/adapters/inbound/agents/processlifecycle/osutil_darwin_test.go
+++ b/core/adapters/inbound/agents/processlifecycle/osutil_darwin_test.go
@@ -295,7 +295,13 @@ func TestTopLevelAppPath(t *testing.T) {
 // contains a dot) or "" — never errors or panics. The deterministic path
 // logic is covered by TestTopLevelAppPath.
 func TestResolveHostBundleIDFromAncestry_Self(t *testing.T) {
-	bid, hostPID := resolveHostBundleIDFromAncestry(os.Getpid())
+	bid, hostPID, complete := resolveHostBundleIDFromAncestry(os.Getpid())
+	// The running test binary is alive by definition, so every readProcInfo in
+	// its chain answers and the walk reaches a verdict. This arm is
+	// environment-independent even though the verdict itself is not.
+	if !complete {
+		t.Error("the walk over a live process aborted — every ps in its own ancestry must answer")
+	}
 	if bid == "" {
 		return // no top-level .app ancestor (e.g. CI/tmux/ssh) — valid.
 	}
@@ -699,6 +705,47 @@ func exitedPID(t *testing.T) int {
 		t.Fatalf("pid %d is still addressable after being reaped (kill(0) = %v) — PID reuse would make every assertion below vacuous", pid, err)
 	}
 	return pid
+}
+
+// TestResolveHostFromAncestry_UnreadableProcessIsNotAMiss covers the primitive
+// #1492 turns on. Both rows return ("", 0) — the walk found no supported host
+// either way — and the third value is the only thing that separates them:
+// launchd's chain ends honestly at PID 1, while a reaped PID's first
+// readProcInfo fails, which is the same branch a `ps` that blows its 2s ceiling
+// takes.
+func TestResolveHostFromAncestry_UnreadableProcessIsNotAMiss(t *testing.T) {
+	if term, hostPID, complete := resolveHostFromAncestry(1); term != "" || hostPID != 0 || !complete {
+		t.Errorf("launchd: got (%q, %d, %v); want a completed walk that found nothing", term, hostPID, complete)
+	}
+	if term, hostPID, complete := resolveHostFromAncestry(exitedPID(t)); term != "" || hostPID != 0 || complete {
+		t.Errorf("reaped pid: got (%q, %d, %v); want an ABORTED walk — an unreadable process is not a miss", term, hostPID, complete)
+	}
+}
+
+// TestResolveHostBundleIDFromAncestry_UnreadableProcessIsNotAMiss is the same
+// distinction for the generic top-level-.app walk, and pins the split of what
+// was one condition: `if err != nil || ppid <= 1`. "pid's parent is init" is a
+// verdict (launchd, row 1); "pid could not be read" is not (row 2). Merging
+// them is #1492 in miniature.
+func TestResolveHostBundleIDFromAncestry_UnreadableProcessIsNotAMiss(t *testing.T) {
+	if bid, hostPID, complete := resolveHostBundleIDFromAncestry(1); bid != "" || hostPID != 0 || !complete {
+		t.Errorf("launchd: got (%q, %d, %v); want a completed walk that found nothing", bid, hostPID, complete)
+	}
+	if bid, hostPID, complete := resolveHostBundleIDFromAncestry(exitedPID(t)); bid != "" || hostPID != 0 || complete {
+		t.Errorf("reaped pid: got (%q, %d, %v); want an ABORTED walk", bid, hostPID, complete)
+	}
+}
+
+// TestHostIdentity_CarriesTheAncestryVerdict is the link between the two
+// primitives above and the loop below: hostIdentity is where a caller reads
+// them, and #1501's tmux client path is queued to read it the same way.
+func TestHostIdentity_CarriesTheAncestryVerdict(t *testing.T) {
+	if l, complete := hostIdentity(1); !complete || l == nil {
+		t.Errorf("launchd is readable and hostless: got (%+v, %v)", l, complete)
+	}
+	if l, complete := hostIdentity(exitedPID(t)); complete {
+		t.Errorf("a reaped pid cannot be read, so its empty identity is not evidence: got (%+v, %v)", l, complete)
+	}
 }
 
 // TestResolveClientHostIdentity_UnreadableCandidateIsNotDetached is #1492.

--- a/core/adapters/inbound/agents/processlifecycle/osutil_linux.go
+++ b/core/adapters/inbound/agents/processlifecycle/osutil_linux.go
@@ -39,9 +39,17 @@ func processTTY(pid int) string { return "" }
 // resolveTermProgramFromAncestry / resolveHostFromAncestry are darwin-only
 // fallbacks for hardened-runtime processes that hide env from sysctl. Linux
 // reads /proc/<pid>/environ directly, so these stubs are unused.
-func resolveTermProgramFromAncestry(pid int) string                       { return "" }
-func resolveHostFromAncestry(pid int) (term string, host int)             { return "", 0 }
-func resolveHostBundleIDFromAncestry(pid int) (bundleID string, host int) { return "", 0 }
+//
+// complete is true: declining to walk is a settled verdict about this
+// platform, not a read that failed. It is false only where a walk was
+// attempted and could not be answered (#1492), which is darwin-only.
+func resolveTermProgramFromAncestry(pid int) string { return "" }
+func resolveHostFromAncestry(pid int) (term string, host int, complete bool) {
+	return "", 0, true
+}
+func resolveHostBundleIDFromAncestry(pid int) (bundleID string, host int, complete bool) {
+	return "", 0, true
+}
 
 // Stubs for the kitty "no readable env" enrichment helpers. Linux can read
 // /proc/<pid>/environ for any process the user owns, so the back-fill path

--- a/core/adapters/inbound/agents/processlifecycle/osutil_other.go
+++ b/core/adapters/inbound/agents/processlifecycle/osutil_other.go
@@ -15,9 +15,16 @@ func processTTY(pid int) string { return "" }
 
 // resolveTermProgramFromAncestry / resolveHostFromAncestry are darwin-only
 // fallbacks; other platforms return zero values.
-func resolveTermProgramFromAncestry(pid int) string                       { return "" }
-func resolveHostFromAncestry(pid int) (term string, host int)             { return "", 0 }
-func resolveHostBundleIDFromAncestry(pid int) (bundleID string, host int) { return "", 0 }
+//
+// complete is true: declining to walk is a settled verdict about this
+// platform, not a read that failed (#1492).
+func resolveTermProgramFromAncestry(pid int) string { return "" }
+func resolveHostFromAncestry(pid int) (term string, host int, complete bool) {
+	return "", 0, true
+}
+func resolveHostBundleIDFromAncestry(pid int) (bundleID string, host int, complete bool) {
+	return "", 0, true
+}
 
 // Stubs for the kitty "no readable env" enrichment helpers — darwin-only.
 func kittyAncestryPID(pid int) int                             { return 0 }


### PR DESCRIPTION
`resolveHerdrClientLauncher`'s `continue` meant two different things — "this
candidate genuinely has no local GUI window" and "this candidate's identity
could not be **read**" — and then answered `(nil, true)`, an authoritative
*detached*. `AdoptHostIdentity` acts on that by clearing `TermProgram` /
`HostBundleID` / `ITermSessionID` / the kitty selectors from a session whose
client is attached the whole time. That is #1485's symptom through a different
door, and #1405's re-resolution makes it recur rather than being a one-time
capture miss.

Closes #1492.

## Where the bit had to go, and where it deliberately did not

The issue names two swallowed failure modes. Only one of them can carry the
distinction, and saying which is half the change:

- **`osProc.EnvOf`'s discarded error is not fixable here, and fixing it would
  buy nothing.** The `ProcessObserver` port *defines* an unreadable env as an
  empty map rather than an error ("Returns an empty/nil map (not an error) when
  the env is unreadable", `core/ports/outbound/ports.go`), and all three
  implementations discard it (`process_darwin.go`, `process_linux.go`,
  `process_other.go`) — so there is no error at that call site to thread. Nor
  would widening the port help: an env that yields no host is *exactly* the
  condition that makes the ancestry fallbacks run, so a false "no local window"
  always passes through an ancestry walk. The walk is where the distinction has
  to be drawn. (This also matches the measured behaviour of `KERN_PROCARGS2` on
  signed platform binaries: no environment, **no error** — "expected empty",
  not "could not read".)
- **`resolveHostFromAncestry`'s `if err != nil { return "", 0 }` is the real
  one**, and `resolveHostBundleIDFromAncestry` has the same shape. Both now
  report whether they reached a verdict (found a host / ran out of chain / ran
  out of depth) or **aborted** on a `readProcInfo` failure — which on a loaded
  machine is that helper's 2s `ps` ceiling.

The bit lives on the ancestry memo itself (`ancestryProbe.walked()`), so a
guarded block that calls the walk cannot forget to accumulate it;
`applyAncestryFallbacks` ANDs it with the separate bundle-id walk,
`hostIdentity` returns it, and `resolveClientHostIdentity` acts on it.

`resolveHostBundleIDFromAncestry`'s `if err != nil || ppid <= 1` is split for
the same reason in miniature: "pid's parent is init" is a verdict, "pid could
not be read" is not.

**`ReadLauncherEnv`'s own call deliberately ignores the new bit** (`l, _ =
hostIdentity(pid)`). Its `hostKnown` is about the herdr *client* indirection; a
direct session whose ancestry walk timed out is a different question with
different consumers (`captureLauncher`, `launcherBackfillNeedsFor`), and
widening it there would change behaviour for every non-herdr session on a
signal this issue has no evidence about. Stated in the code, not just here.

## Neither rejected option

The issue rejected two cheap fixes and I am not re-proposing either. Returning
`(nil, false)` whenever candidates existed but none resolved recreates the
#1348 SSH misroute — and `TestResolveClientHostIdentity_HostlessCandidateStaysDetached`
is the committed lock against it (mutation **M5** below is exactly that
regression, and it goes red). Retrying the ancestry walk distinguishes nothing;
nothing here retries.

## The seam, and how #1501 should call it

The conflation lived in the **loop**, not in `hostIdentity` — so if #1501 wrote
its own loop it would rewrite the bug. The loop is therefore now shared:

```go
// osutil_darwin.go
func resolveClientHostIdentity(pids []int) (*session.Launcher, bool)
```

It takes client-candidate PIDs newest-first, caps them at `maxClientCandidates`
(was `maxHerdrClientCandidates`), and returns the same tri-state
`herdrClientPIDs` draws one layer down: a resolved host with `true`, `(nil,
true)` when every candidate was read and none has a local window, and `(nil,
false)` when any candidate could not be read.

herdr is now a five-line caller:

```go
func resolveHerdrClientLauncher(socketPath string) (*session.Launcher, bool) {
	pids, probed := herdrClientPIDs(socketPath)
	if !probed {
		return nil, false
	}
	return resolveClientHostIdentity(pids)
}
```

**#1501 should call it identically** — substitute `tmux -S <socket>
list-clients -F '#{client_pid}'` for `herdrClientPIDs`, keep the same
`(pids, probed)` shape so a `list-clients` that fails to run is `(nil, false)`
rather than "no client attached", and hand the PIDs straight to
`resolveClientHostIdentity`. It needs **no predicate parameter**: the
"candidate is itself a multiplexer pane" skip is generic, and a tmux-nested
candidate is handled correctly without one (its launcher carries only
`{TmuxPane, TmuxSocket}`, so the no-host test catches it, and its ancestry walk
terminates honestly at the reparented tmux server → `(nil, true)`, unchanged
from today). Two things #1501 still owns on its own: `TmuxPane`/`TmuxSocket`
joining `AdoptHostIdentity`'s closed put-back set, and the `refreshHerdrHosts`
twin. It inherits the #1492 semantics and the candidate cap for free.

It is in `osutil_darwin.go` rather than shared `osutil.go` on purpose: the
identity it produces depends on the darwin-only ancestry walk, so on linux/other
it would be dead code.

## Red first

`resolveClientHostIdentity` is an extraction, so the sequence is: commit 1
extracts the loop **verbatim** (behaviour-preserving — every pre-existing test
in the package stays green) and adds the tests; commit 2 fixes it. Verbatim
output of the four new tests against the still-buggy loop:

```
=== RUN   TestResolveClientHostIdentity_UnreadableCandidateIsNotDetached
    osutil_darwin_test.go:725: the candidate's identity could not be read, so the host is unknown — not absent (#1492)
--- FAIL: TestResolveClientHostIdentity_UnreadableCandidateIsNotDetached (0.01s)
=== RUN   TestResolveClientHostIdentity_HostlessCandidateStaysDetached
--- PASS: TestResolveClientHostIdentity_HostlessCandidateStaysDetached (0.01s)
=== RUN   TestResolveClientHostIdentity_OneUnreadableCandidatePoisonsTheAnswer
    osutil_darwin_test.go:756: one unreadable candidate makes 'no client has a window' unsupported (#1492)
    osutil_darwin_test.go:759: order must not change the verdict
--- FAIL: TestResolveClientHostIdentity_OneUnreadableCandidatePoisonsTheAnswer (0.03s)
=== RUN   TestResolveClientHostIdentity_ResolvableCandidateStillWins
--- PASS: TestResolveClientHostIdentity_ResolvableCandidateStillWins (0.06s)
FAIL
FAIL	irrlicht/core/adapters/inbound/agents/processlifecycle	0.381s
FAIL
```

The two greens are load-bearing and are labelled as such rather than counted as
proof: `HostlessCandidateStaysDetached` is a **lock** (the #1348 misroute must
stay removed — it passes on `main` by construction) and
`ResolvableCandidateStillWins` is the **vacuity guard** (a loop that answered
"unknown" for everything would satisfy every #1492 assertion while resolving no
session at all).

### What the red test actually reaches, and what it does not

`exitedPID` gives a PID that has run and been reaped, so `readProcInfo` fails on
it — **the same `if err != nil` branch** a `ps` that blows its 2s ceiling takes.
The timeout is the cause the issue describes; a reaped PID is the one cause of
that class a test can arrange deterministically. PID reuse is asserted away
(`kill(pid, 0)` must be `ESRCH`) rather than tolerated, because tolerating it
would let the whole family pass vacuously.

**Not verified live:** the issue's own scenario end-to-end — a kitty-hosted herdr
client plus a `ps` slow enough to hit the ceiling. The issue was marked
*Unverified* and this PR does not change that for the *trigger*; what it does
convert is the **mechanism**, which is now reproduced by a deterministic test at
every layer (primitive → `hostIdentity` → loop). The kitty premise
(`TERM_PROGRAM` unset upstream, so ancestry is the only source) is read from
`applyAncestryFallbacks`'s own comment and from `launcherFromEnv`, not measured
here.

`launchd` (PID 1) stands in for the readable-but-hostless candidate: its
ancestry terminates immediately and honestly, which makes the lock
environment-independent rather than dependent on whatever launched `go test`.

## Mutations (for what this PR *adds*)

Harness asserts the expected match count per site and refuses to draw a
conclusion at 0; it reverts in-memory (no `git checkout`/`restore`/`stash`) and
verifies `git status --porcelain` is empty afterwards. Baseline was confirmed
all-green before each run.

| # | Mutation | Went red |
|---|---|---|
| M1 | `resolveHostFromAncestry`: an aborted walk claims it completed | `…HostFromAncestry_UnreadableProcessIsNotAMiss` |
| M2 | `resolveHostBundleIDFromAncestry`: re-merge `err` with `ppid <= 1` | `…HostBundleIDFromAncestry_UnreadableProcessIsNotAMiss` |
| M3 | the loop: go back to answering "detached" unconditionally | `…UnreadableCandidateIsNotDetached`, `…OneUnreadableCandidatePoisonsTheAnswer` |
| M4 | `applyAncestryFallbacks`: drop the AND, always report complete | `…CarriesTheAncestryVerdict`, `…UnreadableCandidateIsNotDetached`, `…OneUnreadableCandidatePoisonsTheAnswer` |
| M5 | **over-broad:** the loop always answers "could not read" | `…ChainEndingAtInitIsAVerdict`, `…HostlessCandidateStaysDetached`, `…TruncatedCandidatesArePoisonToo` |
| M6 | **over-broad:** `hostIdentity` always reports incomplete | 5 tests |
| M7 | the cap: truncating no longer poisons the answer | `…TruncatedCandidatesArePoisonToo` |
| M8 | `resolveHostFromAncestry`: a chain ending at init reads as an abort | `…ChainEndingAtInitIsAVerdict` |
| M9 | the memo's verdict is discarded, so the back-fill's walk is invisible | `…KittyBackfillWalkCountsTowardCompleteness` |
| M10 | a found host is poisoned by an earlier unreadable candidate | `…ResolvableCandidateStillWins` |

M5/M6 are the ones that matter for the #1348 rejection: they show the fix is not
"always say unknown", and that the lock is what stops it becoming that.

The harness twice **refused to draw a conclusion** when a target matched 0 sites
(after the Finding-4 fix moved one line, and after the `readAll` rename) — that
refusal is the part worth having; each time the target was corrected and re-run
rather than the green being read as evidence.

M1 and M2 each turn **only their own primitive test** red, and that is the
finding that justifies those tests existing. The two ancestry walks are
independent and `applyAncestryFallbacks` ANDs them, so with M1 applied the
bundle-ID walk still reports the abort and the loop tests stay green — the loop
tests alone would not have covered M1.

## Review and simplify

The `ir:code-review` subagent returned 5 findings; all 5 are addressed. Two were
code fixes with their own tests and mutations:

- **The `maxClientCandidates` truncation answered "every client was read" about
  candidates it never probed** — the same conflation arriving through the cap
  instead of through a timeout, and it made this PR's own doc comment false.
  Fixed (`readAll`), test `…TruncatedCandidatesArePoisonToo`, mutation M7.
- **`applyKittyAncestryBackfill` could be the only caller of the ancestry walk
  in a run** (env names kitty, no `KITTY_PID` — all three blocks above it are
  skipped) **and its verdict was discarded.** Fixed by moving the bit onto the
  memo, test `…KittyBackfillWalkCountsTowardCompleteness` (reached via the
  existing `osProc` seam), mutation M9. The first cut of this fix spelled it
  `return complete && applyKittyAncestryBackfill(...)`, which silently made a
  false `complete` *skip* the back-fill — inert today, removed anyway.

One was a coverage hole: the in-loop "chain terminates at init" verdict was
asserted by nothing, because both `complete == true` rows used PID 1, whose walk
never enters the loop. That branch is what every reparented client — and every
tmux-hosted candidate, the premise `hostIdentity`'s own comment leans on — leaves
through. `orphanPID` + `…ChainEndingAtInitIsAVerdict`, mutation M8.

`/simplify` (4 agents) then found the completeness bit was being ANDed at four
sites that mostly re-read the same memoized value; it now lives on the memo
(`ancestryProbe.walked()`), which removed ~25 lines and the short-circuit above.
`exitedPID` was folded onto the package's existing `deadPIDForScannerTest`,
keeping the fatal-on-recycle policy these tests need (a skip would let the whole
family pass vacuously).

**Reported, not applied** (each with its reason, per AGENTS.md's dismissal bar):
a shared `walkAncestry` for the two near-identical ancestry loops, and a single
`//go:build !darwin` file for the byte-identical stubs — both restructure
pre-existing code well outside this diff. A `Launcher.HasHostWindow()` in
`core/domain/session` instead of the adapter's inline two-field test: genuinely
the right altitude (the domain's own comment argues the host set grows), but it
edits a shared domain type on the control path and the predicate is moved
verbatim from pre-existing code, so it is a recommendation for #1501 rather than
a change here. `herdrClientWriters` does not de-duplicate lsof FD rows, so one
client holding two write FDs would count twice against the cap — **unobserved**
(herdr 0.8.0 is one row per client, per `herdrClientPIDs`' own live note) and in
#1485's function, so reported rather than changed.

## Verification

- `go test ./core/... -race -count=1` — green (via `preflight.sh --only go`),
  re-run after each of the three rounds of fixes.
- `tools/preflight.sh --only go | arch | tools | skills | posix | security` —
  all PASS, each a separate foreground run. `web` skipped: no `web/` tree
  touched.
- ARS: composite 7.9373 → 7.9337, `composite_regressed: false`, no category
  regressions. Gate passed.
- CI on this head: `go-test`, `ars-gate`, `build-test` and both `web-test` trees
  green; CodeQL green. CodeScene and SonarCloud report red — both advisory, not
  merge gates, per AGENTS.md.
- Builds on all three build-tag paths: darwin, `GOOS=linux`, and the
  `!darwin && !linux` stub path (`GOOS=windows go build` of this package). The
  `GOOS=windows` failure in `core/application/services` + `claudecode`
  (`undefined: syscall.Kill`) is **pre-existing** — verified present at the
  branch point, 8 occurrences in `pid_manager.go` at `89f7c16`.

## Found, not fixed — both filed

- **#1513** — `IsKnownInteractiveHost` discards the same completeness bit, and it
  **gates session admission** (#784, the CodexBar exclusion), so a `ps` timeout
  silently declines to admit a legitimate antigravity session rather than
  degrading a click target. Note the direction is the opposite of the repo's
  usual choice: `cliversion` fails open, and this function's own linux/other
  stubs `return true` for exactly that reason. Left untouched because changing an
  admission gate's failure direction is its own decision, and this PR has no
  evidence about how often it fires.
- **#1514** — a non-answer is never memoized (#1485's deliberate, test-locked
  rule), and this PR widened what reaches that branch, so N panes of one herdr
  server now re-pay the probe where one used to. A cost regression this PR
  causes, named rather than hidden; closing it reverses another ticket's locked
  decision, which is not a call to make inside this one. `refreshHerdrHosts`'
  affordability note assumes the old behaviour and is named there too.

Residual false negatives that survive by design, recorded in
`resolveClientHostIdentity`'s doc: a candidate inside a tmux pane walks to the
reparented tmux server and terminates *honestly* at PID 1 while a local window
exists (that indirection is exactly #1501), and a chain deeper than
`maxAncestry` is declared a miss on the same terms. Neither is an aborted read,
so the bit this PR adds cannot express them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
