### PR TITLE
test(contracttesting): negative self-tests for the three receiver-shaped families

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -623,20 +623,99 @@ Before marking a ticket done, run the full suite — every layer must pass:
   and its obligation silently leaves the covered set. `armT.fixtures` is typed
   `fixtureT`, which carries `Setenv` and nothing that can decide a verdict, so
   reporting through it does not compile; that is a type guarantee rather than a
-  guard, the same trade #1390 made for path confinement. Four families carry
-  self-tests (permission gate, hook endpoint, hook disclosure, hook version);
-  the three receiver-shaped ones, and a source walk that would make a fifth
-  family covered by existing rather than by remembering, are #1497 — queued
-  behind #1488, which changed the fake receiver all three would share. It made
-  that fixture cheaper rather than dearer, but did not build it:
-  `hookjson.NewHandler` now takes the consent alongside the confiner, so one
-  `RequireConsent` line replaces the ad-hoc gate each of the three would have
-  wired separately, and `hook_receiver_gate_test.go`'s `gatedFakeReceiver`
-  shows the constructor shape. What that fixture still lacks is most of what
-  #1497 specifies — it passes a nil confiner and never reaches
-  `DecodeConfined`, so it carries no declared roots, no rejection counters and
-  no receipt. The consent third is done; the roots-and-counters two thirds are
-  still #1497's to write.
+  guard, the same trade #1390 made for path confinement. Since #1497 **every**
+  family carries self-tests. The three receiver-shaped ones share one fixture,
+  `receiver_fixture_test.go`: a receiver built through `hookjson.NewHandler`
+  over a real `PathConfiner` and a real `RequireConsent`, decoding through
+  `DecodeConfined`, whose `receiverBreak` struct has one field per committed
+  mutation and whose ZERO VALUE is a correct receiver — so a case names what it
+  broke and nothing else. Three things there are worth knowing before writing a
+  fourth family's fixture. **A verdict a self-test cannot reach is stated, not
+  faked**: obligations 2-5 of the confinement family grade a decision
+  `hookjson.PathConfiner` makes, and #1380/#1446 recorded their mutations as
+  edits to `confine.go`, which a test in this package cannot make — so the
+  fixture consults the real confiner and second-guesses its answer in the
+  direction each recorded mutation produced, and the file says that is what the
+  evidence supports. **The counter is only reachable through `Confine`** —
+  `RejectPath` logs and answers 2xx but counts nothing — so a fixture that
+  skipped it would fail every arm with "counted 0 rejection(s)" for a reason
+  unrelated to the mutation under test. And a mutated receiver that cannot use
+  `DecodeConfined` differs from a correct one in TWO ways, the verdict and the
+  decode, so a hand-rolled-but-faithful baseline is run through every arm first
+  to prove the decode is not what was reported.
+  Each case also names the obligations it must leave **silent**, which is half
+  the evidence: without it, six mutations against six obligations are equally
+  satisfied by six arms that all report on everything. Those silences reproduce
+  the recorded #1446 matrix — M1 red on obligation 1 alone, M4 (containment
+  before symlink resolution) red on 4 and 5 while 1-3 stay green, M6 red on 5
+  alone. Two rows are reproduced with a deliberately NARROWER blast radius than
+  the recorded one, because the recorded mutation edited `confine.go` and a
+  reproduction in this package cannot; both say so where they live, and the M3
+  row's narrowing is the point rather than a compromise — its reproduction
+  leaves obligation 2 green, which is exactly what separates the traversal
+  obligation from the out-of-tree one.
+  Two mutation sets could not simply be transcribed, and both gaps are worth
+  knowing about. #1403 recorded obligations 1 and 2 of the unrecognized-event
+  family as **locks** with no mutation at all; deriving them found that
+  obligation 1 carries two independent claims (a recognized event still
+  DISPATCHES, and it is counted as unrecognized by NOBODY), which a receiver
+  can fail one at a time. And #1413's receipt mutation covers obligations 1-3
+  **jointly** — removing `ObserveHookReceipt` entirely — which proves neither
+  PLACEMENT those obligations exist to pin; the two placements that isolate
+  them (`receiptOnlyWhenRecognized`, `receiptAfterConfinement`) are #1497's and
+  are recorded nowhere else.
+  What makes the seam structural rather than remembered is
+  `seam_walk_test.go`, an AST walk over the package's own sources with two
+  rules. **Rule 1**: a function in a non-test file whose FIRST parameter is
+  `*testing.T` must be an exported `Assert…` entry point, `realT`, or named in
+  `deferredToTheSeam` with its reason — keyed on the parameter TYPE and
+  POSITION, never on a name convention, since a naming rule is satisfied by
+  renaming — and `testing.TB`, `*testing.B` and `*testing.M` count as the same
+  type for it, because TB carries `Errorf`/`Fatalf` AND an unexported method, so
+  no recorder can implement it and a TB-first arm is exactly as unswappable as a
+  `*testing.T`-first one. The exemption map admits two KINDS of function, stated
+  as two rather than generalized because the generalization is false and a false
+  one there reads as "you don't need to look": fixture machinery (the line
+  `fixtureT` draws — a fixture that cannot be BUILT must fail loudly rather than
+  be recorded as an obligation firing), and one helper that does decide a
+  verdict but has no family to self-test (`CompareGolden`).
+  **Rule 2**: every arm (first parameter `reporter` or `armT`) must be
+  reachable, along a chain that does **not** pass through an exported entry
+  point, from a reference in a `_test.go` **that also calls `mustReport`**.
+  All three clauses matter — reference-based rather than filename-based, because
+  the permission-gate family's self-tests live in `permission_gate_test.go`;
+  not-through-an-entry-point, because a family's vacuity guard CALLS its entry
+  point and would otherwise mark every arm of a self-test-less family as driven;
+  and the `mustReport` clause, which came from review, because seeded from every
+  test file an arm counted as driven merely by being NAMED — deleting a family's
+  four negative self-tests and leaving the now-uncalled table that listed them
+  passed the rule in full. `mustReport` is the one call every negative self-test
+  makes and no positive test does. Its corpus is `seam_walk_corpus_test.go`: one
+  row per parameter spelling pinned to the verdict the detector must return,
+  plus one per call graph pinning the propagation (no count is stated here,
+  because nothing would keep one honest). The `want:false` rows carry the value,
+  per #1450 — a `*testing.T` in second position, one inside a struct FIELD type,
+  one inside a parameter's own func type, a function literal assigned to a
+  package var, and an aliased `testing` import. The first three are false
+  positives a text-based rule produces; the last two are declared LIMITS of an
+  `ast.FuncDecl` walk over syntactic types, pinned so they are learned from a
+  test rather than from an incident. A `want:false` row is also how this
+  corpus's own worst defect shipped and was caught in review: `testing.TB` sat
+  in the must-NOT-flag block, so the rule's biggest hole came with an approved
+  spelling.
+  One further cost is worth knowing before writing a fifth family:
+  `hookjson`'s distinct-name table retains `MaxUnknownEventNames` `(adapter,
+  name)` pairs for the life of the process and never resets, so an obligation
+  needing a globally FRESH name (only #1364's fourth) spends a slot per run.
+  Keeping the delta-measuring obligations on an adapter-stable name, and driving
+  the fresh-name one only where it is the subject, is what buys the headroom —
+  measured at `go test -count=12` when this was written, against roughly eight
+  before. Trust neither number: nothing produces either, which is precisely the
+  drift "Replay's measured figures" below is about. What IS load-bearing is that
+  `assertNameTableHadRoom` reports a saturated table as a limit of the TEST
+  BINARY — quoting the bound it reads from `hookjson` rather than a copy of it —
+  instead of letting it become the false accusation ("counted 0") it otherwise
+  is.
 - Guarded construction: not a contract family — a package-local pair of guards,
   `core/application/services/construction_test.go`. A service whose fields
   include maps, channels, or anything else whose zero value is unusable is

--- a/core/adapters/inbound/agents/hookjson/unknown.go
+++ b/core/adapters/inbound/agents/hookjson/unknown.go
@@ -48,9 +48,15 @@ import (
 // of the process. Real event names are short PascalCase identifiers, so both
 // are far past anything an upstream rename produces.
 const (
-	// maxUnknownEventNames bounds how many distinct (adapter, event) pairs are
+	// MaxUnknownEventNames bounds how many distinct (adapter, event) pairs are
 	// retained.
-	maxUnknownEventNames = 64
+	//
+	// Exported because a saturated table is indistinguishable from "this name
+	// was never counted" at every reader, so anything explaining that to a
+	// human has to state the bound — and a copy of the number restated
+	// elsewhere goes stale silently while its advice stays confident. Its one
+	// caller is contracttesting.assertNameTableHadRoom (#1497).
+	MaxUnknownEventNames = 64
 
 	// maxUnknownEventNameLen bounds the retained length of one name, in bytes.
 	maxUnknownEventNameLen = 64
@@ -137,7 +143,7 @@ func IgnoreUnknownEvent(log outbound.Logger, component, adapter, sessionID, even
 	case unknownTableFullFirst:
 		log.LogError(component, sessionID, fmt.Sprintf(
 			"unrecognized hook event %q from %s: ignored, and NOT counted by name — the distinct-name table is full at %d entries, so no further name from this adapter can be attributed. Later sightings are totalled per adapter in hooks.json's unknown_event_names_dropped_by_adapter.",
-			name, adapter, maxUnknownEventNames))
+			name, adapter, MaxUnknownEventNames))
 	case unknownRepeat, unknownTableFullRepeat:
 		// Counted. Deliberately silent: these are the flooding cases.
 	}
@@ -158,7 +164,7 @@ func observeUnknownEvent(adapter, event string) (unknownOutcome, string) {
 	unknownMu.RLock()
 	counter := unknownCounts[key]
 	var dropped *atomic.Uint64
-	if counter == nil && len(unknownCounts) >= maxUnknownEventNames {
+	if counter == nil && len(unknownCounts) >= MaxUnknownEventNames {
 		// Post-saturation fast path: read the adapter's drop counter under the
 		// SAME read lock the map lookup above already needs, so a flood of
 		// unretainable names never reaches the exclusive lock.
@@ -181,7 +187,7 @@ func observeUnknownEvent(adapter, event string) (unknownOutcome, string) {
 		counter.Add(1)
 		return unknownRepeat, key.Event
 	}
-	if len(unknownCounts) >= maxUnknownEventNames {
+	if len(unknownCounts) >= MaxUnknownEventNames {
 		if dropped := unknownDropped[adapter]; dropped != nil {
 			dropped.Add(1)
 			return unknownTableFullRepeat, key.Event

--- a/core/adapters/inbound/agents/hookjson/unknown_test.go
+++ b/core/adapters/inbound/agents/hookjson/unknown_test.go
@@ -162,15 +162,15 @@ func TestUnknownEventTableSaturates(t *testing.T) {
 	log := &countingLogger{}
 
 	// Fill the table with junk aimed at one adapter.
-	for i := 0; i < maxUnknownEventNames+8; i++ {
+	for i := 0; i < MaxUnknownEventNames+8; i++ {
 		IgnoreUnknownEvent(log, "comp", "adapter-junk", "sess", fmt.Sprintf("Sat%03d", i))
 	}
-	if n := len(UnknownEvents()); n > maxUnknownEventNames {
-		t.Errorf("retained %d distinct names, want at most %d", n, maxUnknownEventNames)
+	if n := len(UnknownEvents()); n > MaxUnknownEventNames {
+		t.Errorf("retained %d distinct names, want at most %d", n, MaxUnknownEventNames)
 	}
 	if droppedTotal() == 0 {
 		t.Fatalf("posting %d distinct names past a cap of %d dropped none — the table is unbounded",
-			maxUnknownEventNames+8, maxUnknownEventNames)
+			MaxUnknownEventNames+8, MaxUnknownEventNames)
 	}
 
 	// Now a real rename at a DIFFERENT adapter, arriving on every tool call.
@@ -190,8 +190,8 @@ func TestUnknownEventTableSaturates(t *testing.T) {
 		t.Errorf("saturation was announced %d time(s), want exactly 2 — once per adapter, so a second adapter's rename is not silenced by the first adapter's junk, and not once per event either", n)
 	}
 	// The total still accounts for every event that arrived, named or not.
-	if total := UnknownEventTotal(); total < 500+uint64(maxUnknownEventNames) {
-		t.Errorf("total = %d, want at least %d — dropped sightings must still be totalled", total, 500+maxUnknownEventNames)
+	if total := UnknownEventTotal(); total < 500+uint64(MaxUnknownEventNames) {
+		t.Errorf("total = %d, want at least %d — dropped sightings must still be totalled", total, 500+MaxUnknownEventNames)
 	}
 }
 

--- a/core/internal/contracttesting/hook_path_confinement.go
+++ b/core/internal/contracttesting/hook_path_confinement.go
@@ -150,12 +150,88 @@ type HookReceiver struct {
 // rule rather than leaving each adapter to rediscover it (issues #1361, #1364).
 func AssertHookPathConfined(t *testing.T, r HookReceiver) {
 	t.Helper()
-	t.Run("in_tree_path_accepted", func(t *testing.T) { assertInTreeAccepted(t, r) })
-	t.Run("out_of_tree_path_rejected", func(t *testing.T) { assertOutOfTreeRejected(t, r) })
-	t.Run("parent_traversal_rejected", func(t *testing.T) { assertTraversalRejected(t, r) })
-	t.Run("symlink_escape_rejected", func(t *testing.T) { assertSymlinkEscapeRejected(t, r) })
-	t.Run("dangling_symlink_rejected", func(t *testing.T) { assertDanglingSymlinkRejected(t, r) })
-	t.Run("confined_spelling_is_what_dispatches", func(t *testing.T) { assertConfinedSpellingDispatches(t, r) })
+	// Every wiring closure — Root, WriteTranscript, New — is called HERE, on
+	// the sub-test's real *testing.T, rather than inside an arm. That is the
+	// split AssertHookEndpointFollowsBindAddr already draws, and it is what
+	// lets the arms report through the seam: relocating a root, writing a
+	// transcript, planting a symlink and building a receiver are fixture
+	// machinery that reports its own failures, and a fixture that cannot be
+	// BUILT must fail the run loudly rather than be recorded as the obligation
+	// under test firing (#1479). The arms below take resolved values and do
+	// nothing but grade them, so a negative self-test can drive one against a
+	// deliberately wrong receiver and read back what it said (#1497).
+	t.Run("in_tree_path_accepted", func(t *testing.T) {
+		root := r.Root(t)
+		inTree := r.WriteTranscript(t, mkSubdir(t, root, "in-tree"))
+		rut := r.New(t)
+		assertInTreeAccepted(realT(t), r, rut, inTree)
+	})
+	t.Run("out_of_tree_path_rejected", func(t *testing.T) {
+		r.Root(t)
+		outside := r.WriteTranscript(t, t.TempDir())
+		assertRefused(realT(t), r, r.New(t), outside, whatOutOfTree)
+	})
+	t.Run("parent_traversal_rejected", func(t *testing.T) {
+		root := r.Root(t)
+		outside := r.WriteTranscript(t, t.TempDir())
+		// Concatenated, not filepath.Join'd: Join cleans, and an already-cleaned
+		// path is not the input under test. Enough ".." to bottom out at "/",
+		// where further ones are absorbed.
+		traversal := root + strings.Repeat("/..", 32) + outside
+		assertRefused(realT(t), r, r.New(t), traversal, whatTraversal)
+	})
+	t.Run("symlink_escape_rejected", func(t *testing.T) {
+		root := r.Root(t)
+		outside := r.WriteTranscript(t, t.TempDir())
+		link := filepath.Join(mkSubdir(t, root, "linked"), filepath.Base(outside))
+		if err := os.Symlink(outside, link); err != nil {
+			t.Fatalf("symlink %s -> %s: %v", link, outside, err)
+		}
+		assertRefused(realT(t), r, r.New(t), link, whatSymlinkEscape)
+	})
+	t.Run("dangling_symlink_rejected", func(t *testing.T) {
+		root := r.Root(t)
+		// A path in a directory the receiver has no claim on. Deliberately NOT
+		// created: the whole point is that it does not exist at confinement time.
+		target := filepath.Join(t.TempDir(), "planted"+r.TranscriptExt)
+		link := filepath.Join(mkSubdir(t, root, "dangling"), filepath.Base(target))
+		if err := os.Symlink(target, link); err != nil {
+			t.Fatalf("symlink %s -> %s: %v", link, target, err)
+		}
+		assertRefused(realT(t), r, r.New(t), link, whatDangling)
+	})
+	t.Run("confined_spelling_is_what_dispatches", func(t *testing.T) {
+		root := r.Root(t)
+		inTree := r.WriteTranscript(t, mkSubdir(t, root, "spelling"))
+		assertConfinedSpellingDispatches(realT(t), r, r.New(t), noisySpellingOf(inTree))
+	})
+}
+
+// The four refusal inputs, named once. Obligations 2-5 share ONE arm
+// (assertRefused) and differ only in the path they post, so `what` is the only
+// thing that tells their failures apart — which makes it the fragment a
+// negative self-test has to match on. Naming them here rather than at the call
+// site is #1498's own lesson applied: that PR graded an arm on an interpolated
+// value a NEIGHBOURING obligation's message also contained, so an arm reporting
+// the wrong prose for the right condition was graded green. A fragment retyped
+// in a self-test is the same defect with an extra step.
+const (
+	whatOutOfTree     = "a well-formed transcript outside every declared root"
+	whatTraversal     = "a path rooted in the declared tree that climbs out of it"
+	whatSymlinkEscape = "a symlink inside the declared root pointing out of it (symlinks must be resolved BEFORE the containment check)"
+	whatDangling      = "a dangling symlink inside the declared root (an unresolvable leaf must not be assumed to be an unflushed write)"
+)
+
+// noisySpellingOf returns path with a redundant "./" before its last component
+// — the same file, spelled the way a caller would if it wanted to find out
+// whether its own string is what travels.
+//
+// Concatenated rather than filepath.Join'd because Join cleans, and a
+// pre-cleaned path cannot tell "the confined string was used" from "the
+// caller's was echoed".
+func noisySpellingOf(path string) string {
+	dir, base := filepath.Split(path)
+	return dir + "./" + base
 }
 
 // assertConfinedSpellingDispatches is obligation 6: for a path that IS accepted,
@@ -173,18 +249,8 @@ func AssertHookPathConfined(t *testing.T, r HookReceiver) {
 // spellings of one file are two sessions. And where the accepted path reached
 // the root through a symlink, the caller's spelling names the link while the
 // confined one names the target.
-func assertConfinedSpellingDispatches(t *testing.T, r HookReceiver) {
+func assertConfinedSpellingDispatches(t reporter, r HookReceiver, rut HookReceiverUnderTest, noisy string) {
 	t.Helper()
-	root := r.Root(t)
-	inTree := r.WriteTranscript(t, mkSubdir(t, root, "spelling"))
-
-	// The same in-tree file, spelled with a redundant "./". Concatenated rather
-	// than filepath.Join'd because Join cleans, and a pre-cleaned path cannot
-	// tell "the confined string was used" from "the caller's was echoed".
-	dir, base := filepath.Split(inTree)
-	noisy := dir + "./" + base
-
-	rut := r.New(t)
 	rec := postHookPath(t, r, rut, noisy)
 	if rec.Code != http.StatusOK {
 		t.Fatalf("in-tree transcript spelled %s: status = %d, want 200 — a redundant \"./\" is still inside the root",
@@ -194,11 +260,12 @@ func assertConfinedSpellingDispatches(t *testing.T, r HookReceiver) {
 	if got == "" {
 		t.Fatal("nothing was dispatched, so this obligation would pass vacuously")
 	}
-	// Asserted as "cleaned", not as equal to inTree: the confiner rebuilds an
-	// accepted path on the adapter's DECLARED root, which on macOS can be the
-	// /var spelling of the /private/var directory the test created. Comparing
-	// strings would fail there for a reason that has nothing to do with the
-	// obligation. Whether the noisy segment survived is the actual question.
+	// Asserted as "cleaned", not as equal to the fixture path: the confiner
+	// rebuilds an accepted path on the adapter's DECLARED root, which on macOS
+	// can be the /var spelling of the /private/var directory the test created.
+	// Comparing strings would fail there for a reason that has nothing to do
+	// with the obligation. Whether the noisy segment survived is the actual
+	// question.
 	if got == noisy || strings.Contains(got, string(filepath.Separator)+"."+string(filepath.Separator)) {
 		t.Errorf("dispatched %q, which is the caller's own spelling — the receiver confined the path and then "+
 			"forwarded the unconfined string anyway. Confinement must not only decide; its result must be what travels",
@@ -209,12 +276,8 @@ func assertConfinedSpellingDispatches(t *testing.T, r HookReceiver) {
 // assertInTreeAccepted is obligation 1. It runs first because every assertion
 // below it is a negative one, and a receiver that has stopped working at all
 // satisfies negative assertions perfectly.
-func assertInTreeAccepted(t *testing.T, r HookReceiver) {
+func assertInTreeAccepted(t reporter, r HookReceiver, rut HookReceiverUnderTest, inTree string) {
 	t.Helper()
-	root := r.Root(t)
-	inTree := r.WriteTranscript(t, mkSubdir(t, root, "in-tree"))
-	rut := r.New(t)
-
 	rec := postHookPath(t, r, rut, inTree)
 	if rec.Code != http.StatusOK {
 		t.Fatalf("in-tree transcript %s: status = %d, want 200 — confinement is refusing the adapter's own tree", inTree, rec.Code)
@@ -227,65 +290,14 @@ func assertInTreeAccepted(t *testing.T, r HookReceiver) {
 	}
 }
 
-// assertOutOfTreeRejected is obligation 2: a plain absolute path elsewhere.
-func assertOutOfTreeRejected(t *testing.T, r HookReceiver) {
-	t.Helper()
-	r.Root(t)
-	outside := r.WriteTranscript(t, t.TempDir())
-	assertRefused(t, r, outside, "a well-formed transcript outside every declared root")
-}
-
-// assertTraversalRejected is obligation 3: lexically inside, really outside.
-func assertTraversalRejected(t *testing.T, r HookReceiver) {
-	t.Helper()
-	root := r.Root(t)
-	outside := r.WriteTranscript(t, t.TempDir())
-	// Concatenated, not filepath.Join'd: Join cleans, and an already-cleaned
-	// path is not the input under test. Enough ".." to bottom out at "/",
-	// where further ones are absorbed.
-	traversal := root + strings.Repeat("/..", 32) + outside
-	assertRefused(t, r, traversal, "a path rooted in the declared tree that climbs out of it")
-}
-
-// assertSymlinkEscapeRejected is obligation 4 — the ordering obligation. The
-// submitted path is lexically inside the declared root and passes any
-// containment check applied to the raw string; only resolving it first reveals
-// that it leaves the tree.
-func assertSymlinkEscapeRejected(t *testing.T, r HookReceiver) {
-	t.Helper()
-	root := r.Root(t)
-	outside := r.WriteTranscript(t, t.TempDir())
-	link := filepath.Join(mkSubdir(t, root, "linked"), filepath.Base(outside))
-	if err := os.Symlink(outside, link); err != nil {
-		t.Fatalf("symlink %s -> %s: %v", link, outside, err)
-	}
-	assertRefused(t, r, link, "a symlink inside the declared root pointing out of it (symlinks must be resolved BEFORE the containment check)")
-}
-
-// assertDanglingSymlinkRejected is obligation 5. The link is inside the root
-// and its target does not exist yet, so a guard that treats "cannot resolve" as
-// "not written yet" accepts it — and the attacker then creates the target.
-func assertDanglingSymlinkRejected(t *testing.T, r HookReceiver) {
-	t.Helper()
-	root := r.Root(t)
-	// A path in a directory the receiver has no claim on. Deliberately NOT
-	// created: the whole point is that it does not exist at confinement time.
-	target := filepath.Join(t.TempDir(), "planted"+r.TranscriptExt)
-	link := filepath.Join(mkSubdir(t, root, "dangling"), filepath.Base(target))
-	if err := os.Symlink(target, link); err != nil {
-		t.Fatalf("symlink %s -> %s: %v", link, target, err)
-	}
-	assertRefused(t, r, link, "a dangling symlink inside the declared root (an unresolvable leaf must not be assumed to be an unflushed write)")
-}
-
 // --- helpers ---
 
-// assertRefused drives one escape attempt against a fresh receiver and checks
-// all three properties a refusal owes: nothing dispatched, a loud status, and a
-// counted reason.
-func assertRefused(t *testing.T, r HookReceiver, path, what string) {
+// assertRefused is obligations 2-5. It drives one escape attempt against a
+// fresh receiver and checks all three properties a refusal owes: nothing
+// dispatched, a loud-in-the-daemon-but-quiet-on-the-wire status, and a counted
+// reason. Which obligation is speaking is carried entirely by `what`.
+func assertRefused(t reporter, r HookReceiver, rut HookReceiverUnderTest, path, what string) {
 	t.Helper()
-	rut := r.New(t)
 	rec := postHookPath(t, r, rut, path)
 	if rut.Observed() {
 		t.Errorf("%s was dispatched downstream: %s", what, path)
@@ -297,7 +309,7 @@ func assertRefused(t *testing.T, r HookReceiver, path, what string) {
 }
 
 // postHookPath POSTs the adapter's hook body for path and returns the response.
-func postHookPath(t *testing.T, r HookReceiver, rut HookReceiverUnderTest, path string) *httptest.ResponseRecorder {
+func postHookPath(t reporter, r HookReceiver, rut HookReceiverUnderTest, path string) *httptest.ResponseRecorder {
 	t.Helper()
 	return postHookBody(t, rut.Handler, r.EndpointPath, r.PayloadFor(path))
 }

--- a/core/internal/contracttesting/hook_path_confinement_selftest_test.go
+++ b/core/internal/contracttesting/hook_path_confinement_selftest_test.go
@@ -1,0 +1,334 @@
+// hook_path_confinement_selftest_test.go is the committed mutation evidence for
+// AssertHookPathConfined (#1361, #1389, #1390), turning what #1380 and #1446
+// recorded in merged PR bodies into a lock that runs on every build (#1479,
+// #1497).
+//
+// The mutations are transcribed, not invented. #1446 carries an 8x5 matrix — the
+// best-documented in the repo — and its verdict pattern is what each case below
+// reproduces:
+//
+//	M1 confiner rejects everything            RED on 1 only
+//	M2 confiner accepts everything            RED on 2,3,4,5
+//	M3 the ".." guard dropped                 RED on 2,3,4
+//	M4 purely lexical containment             RED on 4,5 only   <- the ordering obligation
+//	M6 the dangling-link guard disabled       RED on 5 only
+//	   a no-op `set` closure (#1465)          RED on 6 only
+//
+// # What each case can and cannot claim
+//
+// Read receiver_fixture_test.go's header first: obligations 1 and 2 are driven
+// by a receiver that is wrong in a way an ADAPTER can be wrong, running the
+// whole production path. Obligations 3, 4 and 5 grade a verdict
+// hookjson.PathConfiner reaches, so their recorded mutations edited confine.go
+// and this file cannot; the fixture reproduces each recorded verdict pattern by
+// second-guessing the confiner instead. The claim is therefore about the ARM —
+// it reports when the receiver reaches the wrong verdict on that input — and
+// not about confine.go, which has its own tests.
+//
+// # The isolation cases are half the evidence
+//
+// Every mutation here also names the obligations it must leave SILENT. Without
+// that, six mutations against six obligations would be satisfied by six arms
+// that all report on everything — which is #1453's failure wearing a bigger
+// hat. The silence cases are what make "the obligation that owns this wrongness
+// is the one that reported it" a checked claim rather than a hopeful one, and
+// they are exactly where the recorded matrix's per-row PASS cells live.
+package contracttesting
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// confinementArmBuilders mirrors AssertHookPathConfined's own t.Run bodies, in
+// its order and with its inputs.
+//
+// It restates that entry point rather than sharing it, which is the same trade
+// every <family>_selftest_test.go in this package makes. The vacuity guard is
+// what keeps the restatement honest: a construction that drifted into something
+// an arm legitimately rejects turns TestConfinementArms_PassACorrectReceiver
+// red, not green.
+func confinementArmBuilders() []armBuilder {
+	return []armBuilder{
+		{"in_tree_path_accepted", func(t *testing.T, brk receiverBreak) func(armT) {
+			r := fakePathReceiver(brk)
+			inTree := r.WriteTranscript(t, mkSubdir(t, r.Root(t), "in-tree"))
+			rut := r.New(t)
+			return func(at armT) { assertInTreeAccepted(at, r, rut, inTree) }
+		}},
+		{"out_of_tree_path_rejected", func(t *testing.T, brk receiverBreak) func(armT) {
+			r := fakePathReceiver(brk)
+			r.Root(t)
+			outside := r.WriteTranscript(t, t.TempDir())
+			rut := r.New(t)
+			return func(at armT) { assertRefused(at, r, rut, outside, whatOutOfTree) }
+		}},
+		{"parent_traversal_rejected", func(t *testing.T, brk receiverBreak) func(armT) {
+			r := fakePathReceiver(brk)
+			root := r.Root(t)
+			outside := r.WriteTranscript(t, t.TempDir())
+			traversal := root + strings.Repeat("/..", 32) + outside
+			rut := r.New(t)
+			return func(at armT) { assertRefused(at, r, rut, traversal, whatTraversal) }
+		}},
+		{"symlink_escape_rejected", func(t *testing.T, brk receiverBreak) func(armT) {
+			r := fakePathReceiver(brk)
+			root := r.Root(t)
+			outside := r.WriteTranscript(t, t.TempDir())
+			link := filepath.Join(mkSubdir(t, root, "linked"), filepath.Base(outside))
+			if err := os.Symlink(outside, link); err != nil {
+				t.Fatalf("symlink %s -> %s: %v", link, outside, err)
+			}
+			rut := r.New(t)
+			return func(at armT) { assertRefused(at, r, rut, link, whatSymlinkEscape) }
+		}},
+		{"dangling_symlink_rejected", func(t *testing.T, brk receiverBreak) func(armT) {
+			r := fakePathReceiver(brk)
+			root := r.Root(t)
+			// Deliberately NOT created: the whole point is that it does not
+			// exist at confinement time.
+			target := filepath.Join(t.TempDir(), "planted"+r.TranscriptExt)
+			link := filepath.Join(mkSubdir(t, root, "dangling"), filepath.Base(target))
+			if err := os.Symlink(target, link); err != nil {
+				t.Fatalf("symlink %s -> %s: %v", link, target, err)
+			}
+			rut := r.New(t)
+			return func(at armT) { assertRefused(at, r, rut, link, whatDangling) }
+		}},
+		{"confined_spelling_is_what_dispatches", func(t *testing.T, brk receiverBreak) func(armT) {
+			r := fakePathReceiver(brk)
+			spelled := r.WriteTranscript(t, mkSubdir(t, r.Root(t), "spelling"))
+			rut := r.New(t)
+			noisy := noisySpellingOf(spelled)
+			return func(at armT) { assertConfinedSpellingDispatches(at, r, rut, noisy) }
+		}},
+	}
+}
+
+// confinementFamily is the obligation table this file's cases drive through
+// receiverFamily's shared drive/silence pair.
+var confinementFamily = receiverFamily{
+	entryPoint: "AssertHookPathConfined",
+	builders:   confinementArmBuilders,
+}
+
+// TestConfinementArms_PassACorrectReceiver is the family's vacuity guard.
+// Without it, an arm that reported unconditionally would satisfy every mutation
+// below and read as excellent coverage.
+//
+// The receiver is built the production way — hookjson.NewHandler over a real
+// PathConfiner, decoding through hookjson.DecodeConfined — so a silence here is
+// a silence against production code rather than against a stand-in.
+func TestConfinementArms_PassACorrectReceiver(t *testing.T) {
+	confinementFamily.mustPassACorrectReceiver(t, receiverBreak{}, "a correct hook receiver")
+}
+
+// TestConfinementArms_PassAHandRolledButFaithfulReceiver is the baseline the
+// three verdict-override cases below are measured against.
+//
+// Those three cannot decode through DecodeConfined, because DecodeConfined
+// offers no way to reach a wrong verdict. Without this test each of them would
+// differ from a correct receiver in TWO ways — the verdict and the decode — and
+// could not say which one the arm reported. With it, the decode is proved
+// neutral and the verdict is the only variable left.
+func TestConfinementArms_PassAHandRolledButFaithfulReceiver(t *testing.T) {
+	confinementFamily.mustPassACorrectReceiver(t, receiverBreak{handRolledDecode: true},
+		"a receiver that hand-rolls the decode but keeps the confiner's verdict")
+}
+
+// TestConfinementObligation1_InTreeAccepted is #1446's M1: a confiner that
+// refuses everything. Here it arrives the way an adapter would actually reach
+// it — by declaring no transcript root at all, which ConfinerForSource's doc
+// comment warns about by name ("refuses everything with RejectNoRoots rather
+// than waving paths through").
+//
+// It is the vacuity obligation, and the matrix says so: M1 is RED on 1 and
+// green on every other row, because a receiver that refuses everything satisfies
+// four negative assertions perfectly.
+func TestConfinementObligation1_InTreeAccepted(t *testing.T) {
+	brk := receiverBreak{roots: func() []string { return nil }}
+
+	rec := confinementFamily.drive(t, brk, "in_tree_path_accepted")
+	mustReport(t, rec, "in-tree transcript was not dispatched",
+		"a receiver that declares no transcript root, so confinement refuses its own tree")
+
+	confinementFamily.mustBeSilentOn(t, brk, "a receiver that refuses everything",
+		"out_of_tree_path_rejected", "parent_traversal_rejected",
+		"symlink_escape_rejected", "dangling_symlink_rejected")
+}
+
+// TestConfinementObligation2_OutOfTreeRejected is #1446's M2 — a confiner that
+// accepts everything — reached the way an adapter reaches it: by declaring a
+// root so broad it swallows the decoy. The whole production path runs,
+// DecodeConfined included; only the declaration is wrong.
+func TestConfinementObligation2_OutOfTreeRejected(t *testing.T) {
+	brk := receiverBreak{roots: func() []string { return []string{os.TempDir()} }}
+
+	rec := confinementFamily.drive(t, brk, "out_of_tree_path_rejected")
+	mustReport(t, rec, whatOutOfTree+" was dispatched downstream",
+		"a receiver whose declared root is broad enough to contain the out-of-tree decoy")
+
+	// Obligation 1 stays silent, which is what separates this from M1: an
+	// over-broad root still accepts the adapter's own tree.
+	confinementFamily.mustBeSilentOn(t, brk, "a receiver with an over-broad declared root", "in_tree_path_accepted")
+}
+
+// TestConfinementObligation3_ParentTraversalRejected is #1446's M3, the ".."
+// guard dropped: containment by lexical prefix on the CALLER'S string.
+//
+// The matrix records M3 as RED on 2, 3 and 4 — so the isolation that matters
+// here is against obligation 2, which stays green because a path in another
+// temp directory does not start with the declared root either way. That is what
+// makes the traversal obligation a separate obligation rather than a second
+// spelling of the out-of-tree one.
+func TestConfinementObligation3_ParentTraversalRejected(t *testing.T) {
+	brk := receiverBreak{confine: confineRawPrefix}
+
+	rec := confinementFamily.drive(t, brk, "parent_traversal_rejected")
+	mustReport(t, rec, whatTraversal+" was dispatched downstream",
+		"a receiver that checks containment by lexical prefix on the caller's uncleaned string")
+
+	confinementFamily.mustBeSilentOn(t, brk, "a receiver whose containment check is a raw lexical prefix",
+		"in_tree_path_accepted", "out_of_tree_path_rejected")
+}
+
+// TestConfinementObligation4_SymlinkEscapeRejected is #1446's M4 and #1361's
+// headline warning: containment checked BEFORE symlinks are resolved. A guard
+// in that order passes the in-tree, out-of-tree AND traversal obligations and
+// confines nothing.
+//
+// The matrix records M4 as RED on 4 and 5 only. Obligation 3 staying green is
+// the decisive cell — it is what proves the ordering obligation is not covered
+// by the traversal one, which was #1361's entire point.
+func TestConfinementObligation4_SymlinkEscapeRejected(t *testing.T) {
+	brk := receiverBreak{confine: confineCleanedPrefix}
+
+	rec := confinementFamily.drive(t, brk, "symlink_escape_rejected")
+	mustReport(t, rec, whatSymlinkEscape+" was dispatched downstream",
+		"a receiver that cleans the path and checks containment without ever resolving symlinks")
+
+	// The matrix records M4 as red on 4 AND 5 — #1380 called that "strictly
+	// stronger" than its first result — so obligation 5 is ASSERTED here rather
+	// than described. A matrix cell claimed in prose and checked by nothing is
+	// the shape this file exists to replace (review of PR #1512).
+	t.Run("also_red_on_dangling_symlink_rejected", func(t *testing.T) {
+		mustReport(t, confinementFamily.drive(t, brk, "dangling_symlink_rejected"),
+			whatDangling+" was dispatched downstream",
+			"a receiver that checks containment before resolution — a dangling link inside the "+
+				"root survives purely lexical containment too")
+	})
+
+	confinementFamily.mustBeSilentOn(t, brk, "a receiver that checks containment before resolution",
+		"in_tree_path_accepted", "out_of_tree_path_rejected", "parent_traversal_rejected")
+}
+
+// TestConfinementObligation5_DanglingSymlinkRejected is #1446's M6: the
+// dangling-link guard disabled, red on obligation 5 and nothing else.
+//
+// The receiver here is correct in every other respect — it resolves before it
+// contains, and it refuses a resolvable escape — and wrong only in treating
+// "cannot resolve" as "not written yet". That allowance is reasonable-looking,
+// which is why it needs an obligation: resolution reports the same error for a
+// broken link as for a file that has not landed, so an attacker plants the
+// broken link, has the path accepted, and then creates the target.
+func TestConfinementObligation5_DanglingSymlinkRejected(t *testing.T) {
+	brk := receiverBreak{confine: confineAcceptUnresolvable}
+
+	rec := confinementFamily.drive(t, brk, "dangling_symlink_rejected")
+	mustReport(t, rec, whatDangling+" was dispatched downstream",
+		"a receiver that waves through a leaf it cannot resolve, on the assumption the write has not landed yet")
+
+	confinementFamily.mustBeSilentOn(t, brk, "a receiver that accepts an unresolvable leaf",
+		"in_tree_path_accepted", "out_of_tree_path_rejected",
+		"parent_traversal_rejected", "symlink_escape_rejected")
+}
+
+// TestConfinementObligation6_ConfinedSpellingDispatches is #1465's no-op `set`:
+// a receiver that decides correctly and then forwards the caller's own string.
+//
+// The silences are the entire reason this obligation exists. #1465 found the
+// whole contract green against exactly this receiver, because obligations 1-5
+// ask WHETHER a receiver dispatched and never WHICH STRING — measured by
+// replacing a receiver's write-back with a no-op and watching the suite stay
+// green. Re-running that measurement here is what stops the fifth obligation
+// from quietly growing to cover the sixth's ground and leaving nobody to notice
+// when it stops.
+func TestConfinementObligation6_ConfinedSpellingDispatches(t *testing.T) {
+	brk := receiverBreak{forwardCallersSpelling: true}
+
+	rec := confinementFamily.drive(t, brk, "confined_spelling_is_what_dispatches")
+	mustReport(t, rec, "which is the caller's own spelling",
+		"a receiver that confines correctly and then dispatches the caller's unconfined string")
+
+	confinementFamily.mustBeSilentOn(t, brk, "a receiver that forwards the caller's spelling",
+		"in_tree_path_accepted", "out_of_tree_path_rejected", "parent_traversal_rejected",
+		"symlink_escape_rejected", "dangling_symlink_rejected")
+}
+
+// refusalObligations are the four inputs that share assertRefused, paired with
+// the `what` each one prints. Named once and ranged over by both cases below,
+// so a fifth refusal obligation cannot be added to one table and forgotten in
+// the other.
+var refusalObligations = []struct{ name, what string }{
+	{"out_of_tree_path_rejected", whatOutOfTree},
+	{"parent_traversal_rejected", whatTraversal},
+	{"symlink_escape_rejected", whatSymlinkEscape},
+	{"dangling_symlink_rejected", whatDangling},
+}
+
+// TestConfinementObligations2to5_RefusalIsCounted covers the half of those four
+// obligations the escape mutations above leave untouched: a receiver can reach
+// the right VERDICT and still leave no evidence it did.
+//
+// The mutation is #1446's M7a — the handler publishes one PathConfiner and its
+// request path uses another — which the matrix records as red on obligations
+// 2-5, and which has no analogue in #1380 because the pre-#1390 shape could not
+// express it. RejectPath logs and answers 2xx but counts NOTHING; only
+// Confine counts. So a receiver that confines through an instance the handler
+// does not publish refuses correctly, silently, and forever.
+//
+// Obligation 1 stays silent: the in-tree path is accepted by both instances,
+// and its assertion is that the count is ZERO — which a counter nobody
+// increments satisfies perfectly. That is the cell worth reading twice.
+func TestConfinementObligations2to5_RefusalIsCounted(t *testing.T) {
+	brk := receiverBreak{privateConfiner: true}
+
+	for _, ob := range refusalObligations {
+		t.Run(ob.name, func(t *testing.T) {
+			mustReport(t, confinementFamily.drive(t, brk, ob.name),
+				ob.what+": counted 0 rejection(s), want 1",
+				"a receiver whose published confiner is not the one its request path uses")
+		})
+	}
+
+	confinementFamily.mustBeSilentOn(t, brk, "a receiver confining through a second, unpublished instance",
+		"in_tree_path_accepted")
+}
+
+// TestConfinementObligations2to5_RefusalAnswers2xx is the other shared half: a
+// refusal is reported by the log and the counter, never by a status code on the
+// user's critical path.
+//
+// It is asserted rather than tolerated because the status buys no security —
+// the path is already contained by not being forwarded — while a non-2xx is an
+// untested interaction with the agent CLI. Claude Code documents that a non-2xx
+// from a `type: http` hook "can't block actions" but not whether it surfaces an
+// error, and gemini-cli's pre-tool hooks and Copilot's preToolUse are known to
+// fail CLOSED on an error result (#1361, #1364). assertHookStatus2xx is the one
+// place that rule lives, so this is also the negative test for the two other
+// receiving-side families that depend on it.
+func TestConfinementObligations2to5_RefusalAnswers2xx(t *testing.T) {
+	brk := receiverBreak{refusesPathWith4xx: true}
+
+	for _, ob := range refusalObligations {
+		t.Run(ob.name, func(t *testing.T) {
+			mustReport(t, confinementFamily.drive(t, brk, ob.name),
+				ob.what+": status = 400, want 2xx",
+				"a receiver that reports a confinement refusal through the status code")
+		})
+	}
+
+	confinementFamily.mustBeSilentOn(t, brk, "a receiver that answers 4xx on a refusal", "in_tree_path_accepted")
+}

--- a/core/internal/contracttesting/hook_receipt.go
+++ b/core/internal/contracttesting/hook_receipt.go
@@ -100,19 +100,46 @@ type HookReceiptReceiver struct {
 // invocations, share a test binary without interfering.
 func AssertHookReceiptObserved(t *testing.T, r HookReceiptReceiver) {
 	t.Helper()
-	t.Run("recognized_event_counts_one", func(t *testing.T) { assertReceiptCounted(t, r, r.KnownEvent) })
-	t.Run("unrecognized_event_counts_too", func(t *testing.T) { assertReceiptCounted(t, r, "IrrReceiptUnknownEvent") })
-	t.Run("confinement_rejected_request_counts_too", func(t *testing.T) { assertReceiptCountedOutOfTree(t, r) })
-	t.Run("consent_denied_request_is_not_counted", func(t *testing.T) { assertDeniedNotCounted(t, r) })
+	// Root, WriteTranscript and New/NewDenied are called HERE, on the
+	// sub-test's real *testing.T, for the reason the other two receiving-side
+	// families give: they are fixture machinery reporting their own failures,
+	// and a fixture that cannot be BUILT has to fail the run loudly instead of
+	// being recorded as the obligation firing (#1479). The arms grade, and
+	// nothing else, so a negative self-test can drive one (#1497).
+	t.Run("recognized_event_counts_one", func(t *testing.T) {
+		transcript := receiptTranscript(t, r, "in-tree")
+		assertReceiptCounted(realT(t), r, r.New(t, &recordingLogger{}), transcript, r.KnownEvent)
+	})
+	t.Run("unrecognized_event_counts_too", func(t *testing.T) {
+		transcript := receiptTranscript(t, r, "in-tree")
+		assertReceiptCounted(realT(t), r, r.New(t, &recordingLogger{}), transcript, receiptUnknownEvent)
+	})
+	t.Run("confinement_rejected_request_counts_too", func(t *testing.T) {
+		// Relocate the root first so the receiver is confined to it, then write
+		// the transcript somewhere else entirely — the request is well-formed
+		// and the channel plainly delivered it; only the path is refused.
+		r.Root(t)
+		outside := r.WriteTranscript(t, mkSubdir(t, t.TempDir(), "out-of-tree"))
+		assertReceiptCountedOutOfTree(realT(t), r, r.New(t, &recordingLogger{}), outside)
+	})
+	t.Run("consent_denied_request_is_not_counted", func(t *testing.T) {
+		transcript := receiptTranscript(t, r, "in-tree")
+		assertDeniedNotCounted(realT(t), r, r.NewDenied(t, &recordingLogger{}), transcript)
+	})
 }
+
+// receiptUnknownEvent is the name obligation 2 posts. It is a constant rather
+// than a literal at the call site so a negative self-test matches the fragment
+// the arm will actually print instead of retyping it — obligations 1 and 2
+// share one arm and one message, and the EVENT NAME is the only thing that
+// tells their failures apart (#1498's own defect was grading an arm on an
+// interpolated value a neighbouring obligation also carried).
+const receiptUnknownEvent = "IrrReceiptUnknownEvent"
 
 // assertReceiptCounted is obligations 1 and 2: a request the receiver was
 // allowed to see adds exactly one receipt, whether or not it understood it.
-func assertReceiptCounted(t *testing.T, r HookReceiptReceiver, event string) {
+func assertReceiptCounted(t reporter, r HookReceiptReceiver, handler http.Handler, transcript, event string) {
 	t.Helper()
-	transcript := receiptTranscript(t, r, "in-tree")
-	handler := r.New(t, &recordingLogger{})
-
 	before := hookjson.HookReceipts()[r.Adapter]
 	rec := postHookBody(t, handler, r.EndpointPath, r.PayloadFor(transcript, event))
 
@@ -124,15 +151,8 @@ func assertReceiptCounted(t *testing.T, r HookReceiptReceiver, event string) {
 }
 
 // assertReceiptCountedOutOfTree is obligation 3.
-func assertReceiptCountedOutOfTree(t *testing.T, r HookReceiptReceiver) {
+func assertReceiptCountedOutOfTree(t reporter, r HookReceiptReceiver, handler http.Handler, outside string) {
 	t.Helper()
-	// Relocate the root first so the receiver is confined to it, then write the
-	// transcript somewhere else entirely — the request is well-formed and the
-	// channel plainly delivered it; only the path is refused.
-	r.Root(t)
-	outside := r.WriteTranscript(t, mkSubdir(t, t.TempDir(), "out-of-tree"))
-	handler := r.New(t, &recordingLogger{})
-
 	before := hookjson.HookReceipts()[r.Adapter]
 	rec := postHookBody(t, handler, r.EndpointPath, r.PayloadFor(outside, r.KnownEvent))
 
@@ -144,11 +164,8 @@ func assertReceiptCountedOutOfTree(t *testing.T, r HookReceiptReceiver) {
 }
 
 // assertDeniedNotCounted is obligation 4.
-func assertDeniedNotCounted(t *testing.T, r HookReceiptReceiver) {
+func assertDeniedNotCounted(t reporter, r HookReceiptReceiver, handler http.Handler, transcript string) {
 	t.Helper()
-	transcript := receiptTranscript(t, r, "in-tree")
-	handler := r.NewDenied(t, &recordingLogger{})
-
 	before := hookjson.HookReceipts()[r.Adapter]
 	rec := postHookBody(t, handler, r.EndpointPath, r.PayloadFor(transcript, r.KnownEvent))
 

--- a/core/internal/contracttesting/hook_receipt_selftest_test.go
+++ b/core/internal/contracttesting/hook_receipt_selftest_test.go
@@ -1,0 +1,175 @@
+// hook_receipt_selftest_test.go is the committed mutation evidence for
+// AssertHookReceiptObserved (#1368), and it is the family where the recorded
+// evidence had to be SPLIT rather than transcribed or derived (#1479, #1497).
+//
+// PR #1413's mutations live in a PR comment rather than its body, and they are
+// two:
+//
+//	obligations 1-3 : both receivers stop calling hookjson.ObserveHookReceipt
+//	obligation 4    : the count moved ABOVE the consent gate
+//
+// The first is JOINT, and joint is not good enough here. Obligations 2 and 3
+// exist to pin WHERE the call sits — before the unrecognized-event switch, and
+// before the confinement refusal — and removing the call entirely proves
+// neither placement: a receiver that counts only what it dispatches, or only
+// what it understands, passes obligation 1 and reddens nothing that names it.
+// So this file adds the two placements #1413 never recorded, and each isolates
+// the obligation that owns it.
+//
+// # Why a false green here is worse than elsewhere
+//
+// This is the only receiving-side contract whose failure is a false ACCUSATION
+// rather than a silence. The liveness watchdog demotes a channel that produces
+// no receipts across N completed turns and releases the holds it placed, so a
+// receiver that forgets to count is reported DEAD while working perfectly — and
+// the watchdog cannot tell that apart from a real outage. An arm that stopped
+// discriminating would let that ship.
+package contracttesting
+
+import "testing"
+
+// receiptArmBuilders mirrors AssertHookReceiptObserved's own t.Run bodies. A
+// builder rather than a pre-built arm, for the reason armBuilder's doc gives:
+// a drive constructs only the obligation it is about.
+func receiptArmBuilders() []armBuilder {
+	return []armBuilder{
+		{"recognized_event_counts_one", func(t *testing.T, brk receiverBreak) func(armT) {
+			r := fakeReceiptReceiver(brk)
+			transcript := receiptTranscript(t, r, "in-tree")
+			h := r.New(t, &recordingLogger{})
+			return func(at armT) { assertReceiptCounted(at, r, h, transcript, r.KnownEvent) }
+		}},
+		{"unrecognized_event_counts_too", func(t *testing.T, brk receiverBreak) func(armT) {
+			r := fakeReceiptReceiver(brk)
+			transcript := receiptTranscript(t, r, "in-tree")
+			h := r.New(t, &recordingLogger{})
+			return func(at armT) { assertReceiptCounted(at, r, h, transcript, receiptUnknownEvent) }
+		}},
+		{"confinement_rejected_request_counts_too", func(t *testing.T, brk receiverBreak) func(armT) {
+			r := fakeReceiptReceiver(brk)
+			// Relocate the root first so the receiver is confined to it, then
+			// write the transcript somewhere else entirely — the request is
+			// well-formed and the channel plainly delivered it; only the path
+			// is refused.
+			r.Root(t)
+			outside := r.WriteTranscript(t, mkSubdir(t, t.TempDir(), "out-of-tree"))
+			h := r.New(t, &recordingLogger{})
+			return func(at armT) { assertReceiptCountedOutOfTree(at, r, h, outside) }
+		}},
+		{"consent_denied_request_is_not_counted", func(t *testing.T, brk receiverBreak) func(armT) {
+			r := fakeReceiptReceiver(brk)
+			transcript := receiptTranscript(t, r, "in-tree")
+			h := r.NewDenied(t, &recordingLogger{})
+			return func(at armT) { assertDeniedNotCounted(at, r, h, transcript) }
+		}},
+	}
+}
+
+// receiptFamily is the obligation table this file's cases drive through
+// receiverFamily's shared drive/silence pair.
+var receiptFamily = receiverFamily{
+	entryPoint: "AssertHookReceiptObserved",
+	builders:   receiptArmBuilders,
+}
+
+// TestReceiptArms_PassACorrectReceiver is the family's vacuity guard. The
+// receiver counts its receipt exactly where every shipped one does: after the
+// channel consent gate and before everything else.
+func TestReceiptArms_PassACorrectReceiver(t *testing.T) {
+	receiptFamily.mustPassACorrectReceiver(t, receiverBreak{}, "a correct hook receiver")
+}
+
+// TestReceiptObligation1_RecognizedEventCountsOne is #1413's recorded mutation,
+// narrowed to the one obligation it is evidence for: a receiver that never
+// calls hookjson.ObserveHookReceipt at all.
+//
+// The recorded failure, verbatim from that PR's comment:
+//
+//	event "PermissionRequest" added 0 receipts for adapter "claude-code", want
+//	exactly 1 — a receiver that does not count its own traffic is reported as a
+//	DEAD channel by the liveness watchdog and demoted while working perfectly
+//
+// Obligation 4 stays silent, and that is not a technicality: a receiver that
+// counts NOTHING satisfies "a consent-denied request counts nothing" perfectly.
+// It is the same shape as #1446's M1 — the degenerate receiver passes every
+// obligation phrased as an absence.
+func TestReceiptObligation1_RecognizedEventCountsOne(t *testing.T) {
+	brk := receiverBreak{receipt: receiptNever}
+
+	mustReport(t, receiptFamily.drive(t, brk, "recognized_event_counts_one"),
+		"added 0 receipts for adapter",
+		"a receiver that never calls hookjson.ObserveHookReceipt")
+
+	receiptFamily.mustBeSilentOn(t, brk, "a receiver that counts no receipts at all",
+		"consent_denied_request_is_not_counted")
+}
+
+// TestReceiptObligation2_UnrecognizedEventCountsToo is the first of the two
+// splits #1413 never recorded: a receiver that counts only the event names it
+// HANDLES.
+//
+// That is the shape hook_receipt.go's own header names, and it is the one the
+// joint mutation cannot reach — such a receiver passes obligation 1 with full
+// marks. Its diagnosis is the damaging part: an upstream event rename would be
+// reported as a channel that stopped delivering, sending the reader to #1368's
+// file and #1368's fix when the actual problem is #1364's.
+//
+// The isolation is asymmetric on purpose, and the asymmetry is the finding.
+// This receiver also reddens obligation 3, because a request refused at
+// confinement never reaches the switch either — so it is obligation 3's
+// mutation, below, that separates the two, not this one.
+func TestReceiptObligation2_UnrecognizedEventCountsToo(t *testing.T) {
+	brk := receiverBreak{receipt: receiptOnlyWhenRecognized}
+
+	mustReport(t, receiptFamily.drive(t, brk, "unrecognized_event_counts_too"),
+		"event \""+receiptUnknownEvent+"\" added 0 receipts for adapter",
+		"a receiver that counts a receipt only for event names it recognizes")
+
+	receiptFamily.mustBeSilentOn(t, brk, "a receiver that counts only recognized events",
+		"recognized_event_counts_one", "consent_denied_request_is_not_counted")
+}
+
+// TestReceiptObligation3_ConfinementRejectedRequestCountsToo is the second
+// split: a receiver that counts only what survives path confinement.
+//
+// It isolates obligation 3 exactly — obligations 1, 2 and 4 all stay silent —
+// which is what makes it, and not obligation 2's mutation, the evidence that
+// obligations 2 and 3 are two obligations rather than one written twice. Its
+// diagnosis is a misconfigured transcript root (#1361) reported as a dead
+// channel (#1368): again the right symptom filed under the wrong issue.
+func TestReceiptObligation3_ConfinementRejectedRequestCountsToo(t *testing.T) {
+	brk := receiverBreak{receipt: receiptAfterConfinement}
+
+	mustReport(t, receiptFamily.drive(t, brk, "confinement_rejected_request_counts_too"),
+		"a path-refused request added 0 receipts for adapter",
+		"a receiver that counts a receipt only once the path has survived confinement")
+
+	receiptFamily.mustBeSilentOn(t, brk, "a receiver that counts only what it dispatches",
+		"recognized_event_counts_one", "unrecognized_event_counts_too",
+		"consent_denied_request_is_not_counted")
+}
+
+// TestReceiptObligation4_ConsentDeniedRequestIsNotCounted is #1413's second
+// recorded mutation: the count moved ABOVE the consent gate. Its failure,
+// verbatim from that PR's comment:
+//
+//	a consent-denied request added 1 receipts for adapter "claude-code", want 0
+//	— noting that a POST arrived is an observation, and every observation an
+//	adapter makes is gated
+//
+// The ordering it pins is the one consent.go documents as load-bearing in two
+// directions at once: the channel key BEFORE the receipt so a denied request
+// counts none, and the transcript key AFTER it so a hooks-granted /
+// transcripts-denied install is not falsely reported dead. This mutation moves
+// the receipt past the first of those, and nothing but obligation 4 notices.
+func TestReceiptObligation4_ConsentDeniedRequestIsNotCounted(t *testing.T) {
+	brk := receiverBreak{receipt: receiptBeforeChannelConsent}
+
+	mustReport(t, receiptFamily.drive(t, brk, "consent_denied_request_is_not_counted"),
+		"a consent-denied request added 1 receipts for adapter",
+		"a receiver that counts the receipt before the consent gate it is meant to sit behind")
+
+	receiptFamily.mustBeSilentOn(t, brk, "a receiver that counts before consent",
+		"recognized_event_counts_one", "unrecognized_event_counts_too",
+		"confinement_rejected_request_counts_too")
+}

--- a/core/internal/contracttesting/hook_receiver.go
+++ b/core/internal/contracttesting/hook_receiver.go
@@ -7,6 +7,14 @@
 // through a status code on the user's critical path" is one rule (#1361,
 // #1364), and a rule stated in three places is a rule that can disagree with
 // itself.
+//
+// Note which of the three take a reporter and which keeps a *testing.T. The
+// first two are graded — assertHookStatus2xx decides a verdict and postHookBody
+// only marks itself a helper — so both go through the seam and can be driven by
+// a negative self-test (#1479, #1497). mkSubdir cannot: a directory that will
+// not be created is a fixture that could not be BUILT, and recording that as
+// "the obligation fired" is the failure reporter.go's fixtureT split exists to
+// prevent. It is named in deferredToTheSeam for exactly that reason.
 package contracttesting
 
 import (
@@ -19,7 +27,7 @@ import (
 )
 
 // postHookBody POSTs body to handler at endpoint and returns the response.
-func postHookBody(t *testing.T, handler http.Handler, endpoint, body string) *httptest.ResponseRecorder {
+func postHookBody(t reporter, handler http.Handler, endpoint, body string) *httptest.ResponseRecorder {
 	t.Helper()
 	req := httptest.NewRequest(http.MethodPost, endpoint, strings.NewReader(body))
 	rec := httptest.NewRecorder()
@@ -29,7 +37,7 @@ func postHookBody(t *testing.T, handler http.Handler, endpoint, body string) *ht
 
 // assertHookStatus2xx checks the one status rule every hook receiver owes.
 // what names the input, so the failure says which case broke it.
-func assertHookStatus2xx(t *testing.T, rec *httptest.ResponseRecorder, what string) {
+func assertHookStatus2xx(t reporter, rec *httptest.ResponseRecorder, what string) {
 	t.Helper()
 	if rec.Code < 200 || rec.Code > 299 {
 		t.Errorf("%s: status = %d, want 2xx — a hook receiver reports a refusal through its log and its counters, never through a status code on the user's critical path", what, rec.Code)

--- a/core/internal/contracttesting/receiver_fixture_test.go
+++ b/core/internal/contracttesting/receiver_fixture_test.go
@@ -1,0 +1,614 @@
+// receiver_fixture_test.go is the one hook receiver the three receiving-side
+// families' negative self-tests are driven against, and the knobs that make it
+// wrong in exactly one way at a time.
+//
+// # Why one fixture rather than three
+//
+// AssertHookPathConfined, AssertUnknownHookEventObserved and
+// AssertHookReceiptObserved all grade a hook RECEIVER, and a receiver is not a
+// small object: it needs declared transcript roots, a consent gate, a live
+// hookjson.PathConfiner whose rejection counters the contract reads back off
+// the handler, and the process-global unknown-event and receipt counters. Built
+// three times it is three chances to drift; built once it is the shape every
+// adapter's constructor actually produces (issue #1497).
+//
+// # It is built the production way
+//
+// newFakeHookReceiver goes through hookjson.NewHandler with a real
+// PathConfiner and a real Consent from hookjson.RequireConsent, and its default
+// request path is hookjson.DecodeConfined — the same chokepoint every shipped
+// receiver decodes through since #1389/#1488. That matters for the vacuity
+// guards above all: an arm proved silent against this receiver is proved silent
+// against production code, not against a hand-written stand-in.
+//
+// Since #1390 a receiver has exactly ONE exported constructor returning a
+// hookjson.HookHandler, so "this handler confines" and "the counter proving it"
+// cannot be two objects that disagree. This fixture preserves that: there is no
+// second, test-shaped constructor, and HookReceiverUnderTest.Handler is the
+// value NewHandler returned.
+//
+// # What a mutation may and may not touch
+//
+// A negative self-test grades an ARM. It may therefore build a wrong RECEIVER;
+// it may not reach into hookjson. That line is not cosmetic — it is the honest
+// limit of what this file can prove, and it lands differently per family:
+//
+//   - Obligations 1 and 2 of the confinement family are reached by declaring
+//     the wrong ROOTS (none at all; one so broad it swallows the decoy). Those
+//     receivers run the entire production path, DecodeConfined included, and
+//     are ordinary adapter defects — ConfinerForSource's doc comment warns
+//     about the first by name.
+//   - Obligations 3, 4 and 5 grade a VERDICT that hookjson.PathConfiner
+//     reaches. #1380 and #1446 recorded their mutations as edits to confine.go
+//     itself, which a self-test in this package cannot make. So the fixture
+//     reproduces each recorded verdict pattern instead: it consults the real
+//     confiner — which is also the only way to reach the rejection counter the
+//     arms read — and then second-guesses its answer in exactly the direction
+//     that mutation produced. The claim the self-test then supports is stated
+//     precisely: the arm reports when the receiver reaches the WRONG VERDICT on
+//     that input. That is the obligation. It is not a claim about confine.go,
+//     which has its own tests.
+//   - Obligation 6 needs no override at all. It grades which STRING travels
+//     after a correct verdict, and forwarding the caller's own spelling is a
+//     one-line receiver defect — the exact one #1465 found green.
+//
+// One limit of the hand-rolled path is worth stating rather than leaving to be
+// discovered. It is a SECOND implementation of the chokepoint, and the baseline
+// test proves it faithful only with respect to what the six arms look at:
+// DecodeConfined's 1 MiB MaxBytesReader bound and its get/set postcondition are
+// exercised by no arm here, so a hand-rolled decode that dropped them would
+// still read as faithful. Both are covered where they live, in hookjson's own
+// tests (review of PR #1512).
+package contracttesting
+
+import (
+	"encoding/json"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"irrlicht/core/adapters/inbound/agents/hookjson"
+	"irrlicht/core/domain/permission"
+	"irrlicht/core/ports/outbound"
+)
+
+const (
+	// fakeAdapterName is the name the process-global unknown-event and receipt
+	// counters are keyed by. Every contract reads them as a DELTA, so one
+	// constant shared by every self-test in the package is safe and keeps the
+	// "counted under the right adapter" assertions meaningful.
+	fakeAdapterName = "contracttesting-selftest"
+
+	fakeEndpointPath  = "/api/v1/hooks/selftest"
+	fakeTranscriptExt = ".jsonl"
+	fakeKnownEvent    = "Stop"
+	fakeLogComponent  = "selftest-hook-receiver"
+)
+
+// fakeHookPayload is the hook envelope this receiver speaks. Two fields,
+// because two fields are what all three families exercise: the caller-supplied
+// path that must be confined, and the event name that may not be recognized.
+type fakeHookPayload struct {
+	TranscriptPath string `json:"transcript_path"`
+	HookEventName  string `json:"hook_event_name"`
+}
+
+// --- the knobs ---
+
+// confineOverride names how the receiver second-guesses the shared confiner.
+// The zero value overrides nothing, which is why it is also the correct value:
+// a fixture whose CORRECT setting has to be spelled out is a fixture that can
+// be wrong by omission.
+type confineOverride int
+
+const (
+	// confineFaithful takes hookjson.PathConfiner's verdict unchanged, through
+	// hookjson.DecodeConfined — the production path, end to end.
+	confineFaithful confineOverride = iota
+
+	// confineRawPrefix accepts anything whose CALLER-SUPPLIED string starts
+	// with the declared root: containment by lexical prefix, uncleaned and
+	// unresolved. Reproduces #1380's mutation 3 ("the .. guard dropped"), which
+	// the #1446 matrix records as red on obligations 2, 3 and 4.
+	confineRawPrefix
+
+	// confineCleanedPrefix cleans the path and then checks the prefix, but
+	// never resolves symlinks — the CONTAINMENT-BEFORE-RESOLUTION inversion
+	// #1361 was filed about, and #1380's mutation 4. A guard in this order
+	// passes every lexical traversal test and confines nothing. The #1446
+	// matrix records it as red on obligations 4 and 5 alone, which is what
+	// makes it the ordering obligation's own mutation.
+	confineCleanedPrefix
+
+	// confineAcceptUnresolvable waves through a leaf that will not resolve,
+	// treating "cannot resolve" as "not written yet" — a reasonable-looking
+	// allowance, since the hook fires around the write. It is #1380's mutation
+	// 6, red on obligation 5 and nothing else.
+	confineAcceptUnresolvable
+)
+
+// receiptPlacement names where in the request the receiver counts its #1368
+// receipt. The zero value is the correct placement.
+type receiptPlacement int
+
+const (
+	// receiptAfterChannelConsent is immediately after the "hooks" gate and
+	// before everything else — what every shipped receiver does.
+	receiptAfterChannelConsent receiptPlacement = iota
+
+	// receiptNever is the receiver that forgets entirely. #1413's recorded
+	// mutation, which reddened obligations 1, 2 and 3 jointly.
+	receiptNever
+
+	// receiptBeforeChannelConsent counts a request the user never consented to
+	// the daemon observing. #1413's obligation-4 mutation.
+	receiptBeforeChannelConsent
+
+	// receiptAfterConfinement counts only what survived path confinement — the
+	// receiver that "counts what it dispatches". Not recorded anywhere; it is
+	// the split #1497 asks for, isolating obligation 3.
+	receiptAfterConfinement
+
+	// receiptOnlyWhenRecognized counts only event names it handles. Also not
+	// recorded; it is the other half of that split, and the shape hook_receipt.go's
+	// own header names ("a receiver that counts only names it handles").
+	receiptOnlyWhenRecognized
+)
+
+// receiverBreak is the deliberate wrongness, one field per mutation. Its zero
+// value is a CORRECT receiver, so a self-test names exactly what it broke and
+// nothing else — which is what lets mustBeSilent and mustReport disagree for a
+// reason the reader can see.
+type receiverBreak struct {
+	// --- path confinement (#1361, #1389, #1390) ---
+
+	// roots replaces the declared transcript roots. nil means "the root the
+	// wiring relocated to", i.e. correct. It has hookjson.NewPathConfiner's own
+	// signature, so a mutation supplies exactly what production supplies.
+	roots func() []string
+
+	confine confineOverride
+
+	// forwardCallersSpelling dispatches the string the caller sent instead of
+	// the confined one — #1465's no-op `set`, which obligations 1-5 are all
+	// green against.
+	forwardCallersSpelling bool
+
+	// handRolledDecode takes this file's own decode while keeping the
+	// confiner's verdict unchanged. It is not a mutation: it is the BASELINE
+	// for the verdict overrides, which cannot use DecodeConfined because
+	// DecodeConfined offers no way to be wrong. Without it, a self-test for
+	// obligation 3/4/5 would differ from a correct receiver in TWO ways — the
+	// verdict AND the decode — and could not say which one the arm reported.
+	handRolledDecode bool
+
+	// privateConfiner reaches every verdict correctly, but through a SECOND
+	// PathConfiner built alongside the published one. #1446's M7a: the field
+	// says one instance, the request path uses another, so every refusal lands
+	// on a counter nobody reads. It is the only way a receiver can be right
+	// about the decision and wrong about the evidence, which is the half of
+	// obligations 2-5 the escape mutations leave untouched.
+	privateConfiner bool
+
+	// refusesPathWith4xx answers a confinement refusal with a status code. The
+	// rule it breaks is shared — assertHookStatus2xx grades it for three
+	// families — and it is not decoration: gemini-cli's pre-tool hooks and
+	// Copilot's preToolUse fail CLOSED on an error result, so a receiver added
+	// for one of those must not answer 4xx (RejectPath's doc records what was
+	// and was not observed).
+	refusesPathWith4xx bool
+
+	// --- unrecognized events (#1364) ---
+
+	// countsEveryEvent counts a RECOGNIZED event as unrecognized as well.
+	countsEveryEvent bool
+
+	// ignoresKnownEvent recognizes nothing: every event, including the one this
+	// adapter handles, goes down the unrecognized branch and dispatches
+	// nowhere. It is the unknown-event family's analogue of #1446's M1, and the
+	// reason obligation 1 exists — a receiver that has stopped working at all
+	// satisfies obligations 2 through 4 perfectly.
+	ignoresKnownEvent bool
+
+	// dispatchesUnknown guesses a handler for an unfamiliar name.
+	dispatchesUnknown bool
+
+	// refusesUnknownWith4xx answers an unfamiliar name with a status code
+	// instead of a log line — the fail-closed hazard RejectPath's doc records.
+	refusesUnknownWith4xx bool
+
+	// collapsesEventNames counts every unrecognized name under one key, which
+	// is the single scalar that cannot tell a rename from a stray POST.
+	collapsesEventNames bool
+
+	// logsEveryUnknown reports each arrival rather than each distinct name —
+	// literally what both receivers did before #1364.
+	logsEveryUnknown bool
+
+	// --- receipts (#1368) ---
+
+	receipt receiptPlacement
+}
+
+// --- the receiver ---
+
+type fakeHookReceiver struct {
+	root    string
+	brk     receiverBreak
+	log     outbound.Logger
+	handler hookjson.HookHandler
+
+	dispatched     bool
+	dispatchedPath string
+}
+
+// newFakeHookReceiver builds one receiver rooted at root. There is exactly one
+// constructor, and it returns the handler together with the confiner and the
+// consent it actually uses — #1390's and #1488's property, preserved rather
+// than re-litigated.
+func newFakeHookReceiver(root string, brk receiverBreak, gate hookjson.ConsentGranter, log outbound.Logger) *fakeHookReceiver {
+	f := &fakeHookReceiver{root: root, brk: brk, log: log}
+	roots := func() []string { return []string{root} }
+	if brk.roots != nil {
+		roots = brk.roots
+	}
+	f.handler = hookjson.NewHandler(
+		hookjson.NewPathConfiner(roots, fakeTranscriptExt),
+		hookjson.RequireConsent(gate, fakeAdapterName, selfTestHooks, selfTestTranscripts),
+		f.serve)
+	return f
+}
+
+// serve is the request sequence every shipped receiver writes, in the order
+// consent.go documents as load-bearing: the channel key BEFORE the receipt so a
+// consent-denied request counts none, and the transcript key AFTER it so a
+// hooks-granted / transcripts-denied install is not reported dead.
+func (f *fakeHookReceiver) serve(consent hookjson.Consent, c *hookjson.PathConfiner, w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if f.brk.receipt == receiptBeforeChannelConsent {
+		hookjson.ObserveHookReceipt(fakeAdapterName)
+	}
+	if !consent.Granted(selfTestHooks) {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+	if f.brk.receipt == receiptAfterChannelConsent {
+		hookjson.ObserveHookReceipt(fakeAdapterName)
+	}
+	if !consent.Granted(selfTestTranscripts) {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
+	payload, ok := f.decode(consent, c, w, r)
+	if !ok {
+		return
+	}
+	if f.brk.receipt == receiptAfterConfinement {
+		hookjson.ObserveHookReceipt(fakeAdapterName)
+	}
+	f.dispatch(w, payload)
+}
+
+// decode reads the body and confines the path it names.
+//
+// confineFaithful is the whole of the production path — DecodeConfined, which
+// owns the body bound, the consent backstop and the get/set postcondition.
+// Every other setting has to hand-roll it, because DecodeConfined offers no way
+// to reach a wrong verdict; confineHandRolledFaithful exists so that difference
+// is never the only difference between a correct fixture and a mutated one.
+func (f *fakeHookReceiver) decode(consent hookjson.Consent, c *hookjson.PathConfiner, w http.ResponseWriter, r *http.Request) (fakeHookPayload, bool) {
+	var p fakeHookPayload
+	if f.brk.usesProductionDecode() {
+		ok := hookjson.DecodeConfined(w, r, f.log, fakeLogComponent, consent, c, &p,
+			func(p *fakeHookPayload) string { return p.TranscriptPath },
+			func(p *fakeHookPayload, confined string) { p.TranscriptPath = confined })
+		return p, ok
+	}
+
+	if err := json.NewDecoder(r.Body).Decode(&p); err != nil {
+		http.Error(w, "bad request: invalid JSON", http.StatusBadRequest)
+		return p, false
+	}
+	raw := p.TranscriptPath
+
+	// The real confiner is consulted first in EVERY setting. Two reasons, and
+	// the second is not optional: its verdict is what the overrides below
+	// second-guess, and its counters are the only evidence a refusal happened
+	// at all — RejectPath logs and answers 2xx but counts nothing, so a fixture
+	// that skipped Confine would leave RejectionCount at 0 and make every arm
+	// report "counted 0 rejection(s)" for a reason that has nothing to do with
+	// the mutation under test.
+	deciding := c
+	if f.brk.privateConfiner {
+		deciding = hookjson.NewPathConfiner(func() []string { return []string{f.root} }, fakeTranscriptExt)
+	}
+	confined, reason := deciding.Confine(raw)
+	confined, reason = f.override(raw, confined, reason)
+	if reason != hookjson.RejectNone {
+		if f.brk.refusesPathWith4xx {
+			// INSTEAD of RejectPath, not after it: RejectPath writes the 200
+			// itself, and a second WriteHeader is a no-op, so a fixture that
+			// tried to "add" a 4xx would not be wrong at all. mustReport caught
+			// exactly that while this file was being written, which is the
+			// difference between a negative self-test and a hopeful one.
+			f.log.LogError(fakeLogComponent, "", "rejected hook transcript_path "+strconv.Quote(raw))
+			http.Error(w, "refused: transcript_path outside the declared roots", http.StatusBadRequest)
+			return p, false
+		}
+		hookjson.RejectPath(w, f.log, fakeLogComponent, raw, reason)
+		return p, false
+	}
+	p.TranscriptPath = confined
+	if f.brk.forwardCallersSpelling {
+		p.TranscriptPath = raw
+	}
+	return p, true
+}
+
+// override applies the one deliberate verdict error. It only ever turns a
+// REFUSAL into an acceptance: every recorded mutation in #1380 and #1446 that
+// this file reproduces is an escape, and a fixture that could also refuse what
+// the confiner accepted would be able to fail obligation 1 for reasons no
+// obligation owns.
+func (f *fakeHookReceiver) override(raw, confined string, reason hookjson.RejectReason) (string, hookjson.RejectReason) {
+	if reason == hookjson.RejectNone {
+		return confined, reason
+	}
+	switch f.brk.confine {
+	case confineRawPrefix:
+		if strings.HasPrefix(raw, f.root) {
+			return filepath.Clean(raw), hookjson.RejectNone
+		}
+	case confineCleanedPrefix:
+		if cleaned := filepath.Clean(raw); strings.HasPrefix(cleaned, f.root+string(filepath.Separator)) {
+			return cleaned, hookjson.RejectNone
+		}
+	case confineAcceptUnresolvable:
+		if reason == hookjson.RejectUnresolvable {
+			return filepath.Clean(raw), hookjson.RejectNone
+		}
+	}
+	return confined, reason
+}
+
+// usesProductionDecode reports whether this receiver can decode through
+// hookjson.DecodeConfined — the production path, end to end.
+//
+// It is the ONE expression of the fork, and it is derived rather than declared.
+// The first draft made "hand-rolled" a value of the confine enum, which
+// conflated two independent axes (WHICH DECODE PATH, and WHICH VERDICT ERROR)
+// and forced obligation 6's mutation to set two fields — quietly breaking this
+// struct's own stated rule that a self-test names exactly one (review of
+// PR #1512). Every knob below needs something DecodeConfined does not offer, so
+// each one implies the hand-rolled path on its own.
+func (b receiverBreak) usesProductionDecode() bool {
+	return !b.handRolledDecode && b.confine == confineFaithful &&
+		!b.forwardCallersSpelling && !b.privateConfiner && !b.refusesPathWith4xx
+}
+
+// dispatch is the event switch, and the second place a receipt can be counted
+// wrongly.
+func (f *fakeHookReceiver) dispatch(w http.ResponseWriter, p fakeHookPayload) {
+	if p.HookEventName == fakeKnownEvent && !f.brk.ignoresKnownEvent {
+		if f.brk.countsEveryEvent {
+			hookjson.IgnoreUnknownEvent(f.log, fakeLogComponent, fakeAdapterName, "", p.HookEventName)
+		}
+		if f.brk.receipt == receiptOnlyWhenRecognized {
+			hookjson.ObserveHookReceipt(fakeAdapterName)
+		}
+		f.dispatched = true
+		f.dispatchedPath = p.TranscriptPath
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
+	if f.brk.dispatchesUnknown {
+		f.dispatched = true
+		f.dispatchedPath = p.TranscriptPath
+	}
+	if f.brk.logsEveryUnknown {
+		f.log.LogInfo(fakeLogComponent, "", "ignored unrecognized hook event "+strconv.Quote(p.HookEventName))
+	}
+	name := p.HookEventName
+	if f.brk.collapsesEventNames {
+		name = "unknown"
+	}
+	hookjson.IgnoreUnknownEvent(f.log, fakeLogComponent, fakeAdapterName, "", name)
+	if f.brk.refusesUnknownWith4xx {
+		http.Error(w, "unrecognized hook event", http.StatusBadRequest)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+}
+
+// --- wiring the fixture into each family ---
+
+// grantingGate is a ConsentGate with both declared permissions granted, which
+// is the state every obligation except the receipt family's fourth runs under.
+func grantingGate() *ConsentGate {
+	g := NewConsentGate()
+	g.SetState(selfTestHooks, permission.StateGranted)
+	g.SetState(selfTestTranscripts, permission.StateGranted)
+	return g
+}
+
+// writeFakeTranscript writes a well-formed transcript into dir. The out-of-tree
+// decoy is written by this same function, so a refusal can never be confused
+// with "the file was unreadable".
+func writeFakeTranscript(t *testing.T, dir string) string {
+	t.Helper()
+	path := filepath.Join(dir, "11111111-2222-3333-4444-555555555555"+fakeTranscriptExt)
+	if err := os.WriteFile(path, []byte("{}\n"), 0o600); err != nil {
+		t.Fatalf("write transcript %s: %v", path, err)
+	}
+	return path
+}
+
+// fakePayloadFor renders the hook body this receiver speaks.
+//
+// Marshalled from fakeHookPayload rather than formatted by hand, so the encoder
+// and the decoder cannot disagree: a renamed json tag would otherwise leave the
+// fixture posting the old key, the receiver decoding an empty transcript_path,
+// and every arm failing for a reason unrelated to the mutation under test —
+// the "failed, but NOT on the obligation" mode this package exists to remove.
+func fakePayloadFor(transcriptPath, event string) string {
+	body, err := json.Marshal(fakeHookPayload{TranscriptPath: transcriptPath, HookEventName: event})
+	if err != nil {
+		// Two strings into a two-field struct cannot fail to marshal. Panicking
+		// keeps this callable from the wiring closures, which hold no reporter.
+		panic("marshal fake hook payload: " + err.Error())
+	}
+	return string(body)
+}
+
+// fakePathReceiver wires the fixture into AssertHookPathConfined. root is
+// captured so New builds a confiner over the directory Root just relocated to —
+// the ordering the HookReceiver contract requires.
+func fakePathReceiver(brk receiverBreak) HookReceiver {
+	var built *fakeHookReceiver
+	var root string
+	return HookReceiver{
+		Root: func(t *testing.T) string { root = t.TempDir(); return root },
+		New: func(t *testing.T) HookReceiverUnderTest {
+			t.Helper()
+			built = newFakeHookReceiver(root, brk, grantingGate(), &recordingLogger{})
+			return HookReceiverUnderTest{
+				Handler:      built.handler,
+				Observed:     func() bool { return built.dispatched },
+				ObservedPath: func() string { return built.dispatchedPath },
+			}
+		},
+		WriteTranscript: writeFakeTranscript,
+		TranscriptExt:   fakeTranscriptExt,
+		PayloadFor:      func(p string) string { return fakePayloadFor(p, fakeKnownEvent) },
+		EndpointPath:    fakeEndpointPath,
+	}
+}
+
+// fakeUnknownEventReceiver wires the fixture into
+// AssertUnknownHookEventObserved.
+func fakeUnknownEventReceiver(brk receiverBreak) UnknownEventReceiver {
+	var built *fakeHookReceiver
+	var root string
+	return UnknownEventReceiver{
+		Adapter: fakeAdapterName,
+		Root:    func(t *testing.T) string { root = t.TempDir(); return root },
+		New: func(t *testing.T, log outbound.Logger) UnknownEventReceiverUnderTest {
+			t.Helper()
+			built = newFakeHookReceiver(root, brk, grantingGate(), log)
+			return UnknownEventReceiverUnderTest{
+				Handler:  built.handler,
+				Observed: func() bool { return built.dispatched },
+			}
+		},
+		WriteTranscript: writeFakeTranscript,
+		PayloadFor:      fakePayloadFor,
+		KnownEvent:      fakeKnownEvent,
+		EndpointPath:    fakeEndpointPath,
+	}
+}
+
+// fakeReceiptReceiver wires the fixture into AssertHookReceiptObserved. New and
+// NewDenied differ only in the consent gate, which is the point of the contract
+// keeping them separate: a wiring that ignored the distinction would pass
+// obligation 4 by accident.
+func fakeReceiptReceiver(brk receiverBreak) HookReceiptReceiver {
+	var root string
+	build := func(t *testing.T, log outbound.Logger, gate hookjson.ConsentGranter) http.Handler {
+		t.Helper()
+		return newFakeHookReceiver(root, brk, gate, log).handler
+	}
+	return HookReceiptReceiver{
+		Adapter: fakeAdapterName,
+		Root:    func(t *testing.T) string { root = t.TempDir(); return root },
+		New: func(t *testing.T, log outbound.Logger) http.Handler {
+			return build(t, log, grantingGate())
+		},
+		NewDenied: func(t *testing.T, log outbound.Logger) http.Handler {
+			g := NewConsentGate()
+			g.SetState(selfTestHooks, permission.StateDenied)
+			g.SetState(selfTestTranscripts, permission.StateDenied)
+			return build(t, log, g)
+		},
+		WriteTranscript: writeFakeTranscript,
+		PayloadFor:      fakePayloadFor,
+		KnownEvent:      fakeKnownEvent,
+		EndpointPath:    fakeEndpointPath,
+	}
+}
+
+// --- driving one obligation of a receiver-shaped family ---
+
+// armBuilder is one obligation's fixture-plus-arm, built on demand.
+//
+// A BUILDER rather than a pre-built arm because a drive must construct only the
+// obligation it is about — building every obligation's fixture per drive and
+// discarding all but one multiplied the process-global name slots the
+// unrecognized-event family spends (review of PR #1512). Building outside
+// observe is equally deliberate: observe runs the arm on its own goroutine
+// (Fatal is runtime.Goexit), and t.Fatalf from a non-test goroutine is not
+// something a fixture failure should ever depend on.
+type armBuilder struct {
+	name  string
+	build func(*testing.T, receiverBreak) func(armT)
+}
+
+// receiverFamily is one contract family's obligation table, plus the entry
+// point's name for the drift message.
+//
+// The three families' drive-and-silence helpers were byte-identical apart from
+// the table and that one string, so they are one pair here (review of
+// PR #1512). It lives beside receiverBreak rather than in selftest_test.go on
+// purpose: the harness serves seven families and four of them have no
+// receiverBreak, so teaching it about this one would be shared infrastructure
+// learning a special case.
+type receiverFamily struct {
+	entryPoint string
+	builders   func() []armBuilder
+}
+
+// drive builds and runs ONE named obligation against a receiver broken by brk,
+// looked up BY NAME from the same table the vacuity guard walks — so a case
+// cannot silently grade a different obligation than the one it claims to.
+func (f receiverFamily) drive(t *testing.T, brk receiverBreak, obligation string) *recordingT {
+	t.Helper()
+	for _, b := range f.builders() {
+		if b.name == obligation {
+			return observe(t, b.build(t, brk))
+		}
+	}
+	t.Fatalf("no obligation named %q — the mutation table and %s have drifted apart", obligation, f.entryPoint)
+	return nil
+}
+
+// mustBeSilentOn drives every obligation in others against brk and asserts none
+// of them reports. This is the half of the evidence that says WHICH obligation
+// owns a wrongness, rather than merely that some obligation noticed it.
+func (f receiverFamily) mustBeSilentOn(t *testing.T, brk receiverBreak, what string, others ...string) {
+	t.Helper()
+	for _, name := range others {
+		t.Run("silent_on_"+name, func(t *testing.T) {
+			mustBeSilent(t, f.drive(t, brk, name), what)
+		})
+	}
+}
+
+// mustPassACorrectReceiver runs every obligation against brk and asserts all of
+// them stay silent — each family's vacuity guard. Without one, an arm that
+// reported unconditionally would satisfy every mutation and read as excellent
+// coverage.
+func (f receiverFamily) mustPassACorrectReceiver(t *testing.T, brk receiverBreak, what string) {
+	t.Helper()
+	for _, b := range f.builders() {
+		t.Run(b.name, func(t *testing.T) {
+			mustBeSilent(t, observe(t, b.build(t, brk)), what)
+		})
+	}
+}

--- a/core/internal/contracttesting/seam_walk_corpus_test.go
+++ b/core/internal/contracttesting/seam_walk_corpus_test.go
@@ -1,0 +1,257 @@
+// seam_walk_corpus_test.go is the committed corpus for seam_walk_test.go's two
+// rules: source spellings and call graphs pinned to the verdict each detector
+// must return, INCLUDING the verdicts it must NOT return.
+//
+// It exists because of #1450. There, a rewritten guard silently dropped a case
+// its predecessor caught while eighteen hand-planted probes all passed — every
+// one of them an addition to coverage, none a lock on what already worked. A
+// guard is worth only what its deliberate failures prove, and a guard with no
+// corpus proves whatever its author happened to try that afternoon.
+//
+// The want:false rows are the more valuable half. Rule 1 is the kind of rule
+// that is tempting to write as `grep 't \*testing\.T'`, and four rows below are
+// exactly what that grep gets wrong: a *testing.T in second position, a
+// *testing.T inside a struct FIELD type, a *testing.T inside a PARAMETER's func
+// type, and a function literal assigned to a var. The first three are real
+// false positives a name- or text-based rule produces. The last, together with
+// the aliased-import row, is a deliberate LIMIT rather than a claim of safety —
+// an ast.FuncDecl walk over syntactic types cannot see either — and pinning
+// them here is how the next reader learns that from a test rather than from an
+// incident.
+//
+// A want:false row is also how this corpus's own worst defect shipped and was
+// caught: `testing.TB` sat in the must-NOT-flag block, so the rule's biggest
+// hole came with an approved spelling. It is now in the must-flag block with
+// the reason attached (review of PR #1512).
+package contracttesting
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"testing"
+)
+
+// TestSeamWalkCorpus pins firstParamType — the whole of rule 1's decision — over
+// every spelling a parameter list can take.
+func TestSeamWalkCorpus(t *testing.T) {
+	cases := []struct {
+		name string
+		src  string
+		// fn is the function the case is about, or "" when the source
+		// deliberately declares none.
+		fn   string
+		want string
+		// role is the verdict rule 1 and rule 2 actually consume. Pinning it
+		// beside the type render is what gives the CASE LIST coverage: an
+		// earlier draft pinned the render alone, so testing.TB missing from the
+		// list was invisible to every row here (review of PR #1512).
+		role string
+	}{
+		// --- the shapes rule 1 must FLAG (want "*testing.T") ---
+		{"plain", "func arm(t *testing.T) {}", "arm", "*testing.T", roleTestingT},
+		{"with trailing params", "func arm(t *testing.T, s string) {}", "arm", "*testing.T", roleTestingT},
+		{"method with a receiver", "func (r *rec) arm(t *testing.T) {}", "arm", "*testing.T", roleTestingT},
+		{"variadic tail", "func arm(t *testing.T, xs ...string) {}", "arm", "*testing.T", roleTestingT},
+		{"two names sharing one type", "func arm(t, u *testing.T) {}", "arm", "*testing.T", roleTestingT},
+		{"exported but not an Assert entry point", "func Helper(t *testing.T) {}", "Helper", "*testing.T", roleTestingT},
+		{"an Assert entry point is still detected, and exempted by NAME not by type",
+			"func AssertThing(t *testing.T) {}", "AssertThing", "*testing.T", roleTestingT},
+
+		// testing.TB is FLAGGED, and the reason is worth reading: TB carries
+		// Errorf/Fatalf/Helper and an unexported method, so no recorder can
+		// implement it in any spelling. A TB-first arm is exactly as
+		// unswappable as a *testing.T-first one. An earlier draft of this
+		// corpus filed it under "must NOT flag", which made the hole an
+		// APPROVED spelling — found in review of PR #1512. *testing.B and
+		// *testing.M are flagged on the same argument.
+		{"the TB interface — unswappable, so rule 1 owns it too",
+			"func arm(tb testing.TB) {}", "arm", "testing.TB", roleTestingT},
+		{"a benchmark", "func arm(b *testing.B) {}", "arm", "*testing.B", roleTestingT},
+		{"a TestMain", "func arm(m *testing.M) {}", "arm", "*testing.M", roleTestingT},
+
+		// --- the shapes rule 1 must NOT flag ---
+		{"*testing.T in SECOND position", "func arm(s string, t *testing.T) {}", "arm", "string", roleNeither},
+		{"pointer to pointer", "func arm(t **testing.T) {}", "arm", "**testing.T", roleNeither},
+		{"no parameters at all", "func arm() {}", "arm", "", roleNeither},
+		{"a reporter — rule 2's subject, not rule 1's", "func arm(t reporter) {}", "arm", "reporter", roleArm},
+		{"an armT — likewise", "func arm(t armT) {}", "arm", "armT", roleArm},
+		{"*testing.T inside a PARAMETER's func type",
+			"func arm(build func(t *testing.T) string) {}", "arm", "func(t *testing.T) string", roleNeither},
+		// A declared LIMIT, not an approval: the walk renders the type as
+		// written, so an aliased testing import hides the seam type from rule
+		// 1. Nothing in this repo aliases it and no rule forbids doing so, and
+		// pinning the limit here is how the next reader learns it from a test
+		// rather than from an incident — the same treatment the func-literal
+		// row gets (review of PR #1512).
+		{"an ALIASED testing import — a declared limit of a syntactic type render",
+			"func arm(t *tst.T) {}", "arm", "*tst.T", roleNeither},
+
+		// --- shapes that declare no function at all ---
+		{"*testing.T inside a struct FIELD type",
+			"type S struct{ Root func(t *testing.T) string }", "", "", roleNeither},
+		{"a function LITERAL assigned to a package var — a known LIMIT of an ast.FuncDecl walk, " +
+			"pinned so it is discovered here and not in an incident",
+			"var arm = func(t *testing.T) {}", "", "", roleNeither},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			fset := token.NewFileSet()
+			file, err := parser.ParseFile(fset, "corpus.go", "package p\nimport \"testing\"\nimport tst \"testing\"\nvar _ = testing.Short\nvar _ = tst.Short\ntype rec struct{}\n"+c.src+"\n", 0)
+			if err != nil {
+				t.Fatalf("the corpus row does not parse, so it pins nothing: %v", err)
+			}
+			var got, gotRole string
+			var found bool
+			for _, decl := range file.Decls {
+				fn, ok := decl.(*ast.FuncDecl)
+				if !ok || fn.Name.Name != c.fn {
+					continue
+				}
+				found, got, gotRole = true, firstParamType(fn), seamRole(fn)
+			}
+			if c.fn == "" {
+				// Every row asserts the construct it plants is actually there,
+				// because a corpus that quietly stops containing its own cases
+				// reads as a pass (core/architecture_hookbody_shapes_test.go).
+				if found {
+					t.Fatalf("this row is about a source that declares no function, but one was found")
+				}
+				if !declaresSomething(file) {
+					t.Fatal("the row planted nothing at all")
+				}
+				return
+			}
+			if !found {
+				t.Fatalf("the corpus row no longer declares %q — it pins nothing", c.fn)
+			}
+			if got != c.want {
+				t.Errorf("firstParamType = %q, want %q", got, c.want)
+			}
+			if gotRole != c.role {
+				t.Errorf("seamRole = %q, want %q — this is the verdict rule 1 and rule 2 consume, "+
+					"and pinning only the type render above is what hid testing.TB's absence from the case list",
+					gotRole, c.role)
+			}
+		})
+	}
+}
+
+// declaresSomething confirms a no-function row still carries a declaration, so
+// an empty or mistyped source cannot pass as "declares no function".
+func declaresSomething(file *ast.File) bool {
+	// The preamble alone contributes two imports, two vars and a type, so a row
+	// that planted nothing still has five. Requiring more is what makes this a
+	// check rather than a formality.
+	return len(file.Decls) > 5
+}
+
+// TestSeamWalkCoverageCorpus pins rule 2's propagation, which is the half a
+// spelling corpus cannot reach.
+//
+// The last two rows are the ones the rule exists for: an arm reachable ONLY
+// through an exported entry point is NOT covered, because a family's vacuity
+// guard calls the entry point and would otherwise mark every arm of a
+// self-test-less family as driven.
+func TestSeamWalkCoverageCorpus(t *testing.T) {
+	cases := []struct {
+		name  string
+		facts seamFacts
+		want  map[string]bool
+	}{
+		{
+			name: "an arm a test references directly is covered",
+			facts: seamFacts{
+				arms:              map[string]string{"armA": "x.go:1"},
+				refs:              map[string]map[string]bool{},
+				entryPoints:       map[string]bool{},
+				referencedInTests: map[string]bool{"armA": true},
+			},
+			want: map[string]bool{"armA": true},
+		},
+		{
+			name: "an arm reached through a covered helper is covered",
+			facts: seamFacts{
+				arms:              map[string]string{"armA": "x.go:1", "helper": "x.go:2"},
+				refs:              map[string]map[string]bool{"helper": {"armA": true}},
+				entryPoints:       map[string]bool{},
+				referencedInTests: map[string]bool{"helper": true},
+			},
+			want: map[string]bool{"armA": true, "helper": true},
+		},
+		{
+			name: "coverage propagates transitively, two hops",
+			facts: seamFacts{
+				arms: map[string]string{"armA": "x.go:1", "mid": "x.go:2", "top": "x.go:3"},
+				refs: map[string]map[string]bool{
+					"top": {"mid": true},
+					"mid": {"armA": true},
+				},
+				entryPoints:       map[string]bool{},
+				referencedInTests: map[string]bool{"top": true},
+			},
+			want: map[string]bool{"armA": true, "mid": true, "top": true},
+		},
+		{
+			// The mustReport CLAUSE — "named by a positive-test file is not
+			// driven" — is not reachable from this table: coveredArms is handed
+			// facts, and the clause lives in how parseSeamFacts BUILDS them. A
+			// row asserting it here would be byte-identical to this one and
+			// could never fail independently, which is this package's own
+			// thesis turned on its corpus. It is pinned by
+			// TestParseSeamFactsSeedsOnlyFromDrivingTestFiles instead.
+			name: "an arm nothing references is NOT covered",
+			facts: seamFacts{
+				arms:              map[string]string{"armA": "x.go:1"},
+				refs:              map[string]map[string]bool{},
+				entryPoints:       map[string]bool{},
+				referencedInTests: map[string]bool{},
+			},
+			want: map[string]bool{},
+		},
+		{
+			name: "an arm reached only through an UNCOVERED helper is NOT covered",
+			facts: seamFacts{
+				arms:              map[string]string{"armA": "x.go:1"},
+				refs:              map[string]map[string]bool{"helper": {"armA": true}},
+				entryPoints:       map[string]bool{},
+				referencedInTests: map[string]bool{},
+			},
+			want: map[string]bool{},
+		},
+		{
+			name: "an arm reached ONLY through an exported entry point is NOT covered — " +
+				"a family with a vacuity guard and no negative self-test",
+			facts: seamFacts{
+				arms:              map[string]string{"armA": "x.go:1"},
+				refs:              map[string]map[string]bool{"AssertFamily": {"armA": true}},
+				entryPoints:       map[string]bool{"AssertFamily": true},
+				referencedInTests: map[string]bool{"AssertFamily": true},
+			},
+			want: map[string]bool{},
+		},
+		{
+			name: "the same arm becomes covered as soon as a test drives it directly — " +
+				"the vacuity guard for the entry-point row above",
+			facts: seamFacts{
+				arms:              map[string]string{"armA": "x.go:1"},
+				refs:              map[string]map[string]bool{"AssertFamily": {"armA": true}},
+				entryPoints:       map[string]bool{"AssertFamily": true},
+				referencedInTests: map[string]bool{"AssertFamily": true, "armA": true},
+			},
+			want: map[string]bool{"armA": true},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := coveredArms(c.facts)
+			for name := range c.facts.arms {
+				if got[name] != c.want[name] {
+					t.Errorf("arm %q covered = %v, want %v", name, got[name], c.want[name])
+				}
+			}
+		})
+	}
+}

--- a/core/internal/contracttesting/seam_walk_test.go
+++ b/core/internal/contracttesting/seam_walk_test.go
@@ -1,0 +1,446 @@
+// seam_walk_test.go makes #1479's reporter seam STRUCTURAL.
+//
+// #1479 applied the seam per-arm, by hand. Nothing failed if a new arm took
+// *testing.T, and nothing failed if a whole family had no self-test at all —
+// that this was deliberate rather than an oversight was recorded only in prose,
+// which is the exact failure mode this package exists to remove (#1497).
+//
+// Two rules, over one parse of the package's own sources.
+//
+// # Rule 1 — who may hold a *testing.T
+//
+// A function in a non-test file whose FIRST parameter is *testing.T can decide
+// a verdict through a channel no negative self-test can swap. That is allowed
+// for exactly three kinds of function, and everything else is a violation:
+//
+//   - an exported Assert… entry point, which is where a real *testing.T
+//     legitimately enters the package;
+//   - realT, which is the adapter between the two halves;
+//   - anything named in deferredToTheSeam, with its reason and its issue — the
+//     applyWritesNoUserFile shape from core/cmd/irrlichd/managedfiles_test.go.
+//
+// It keys on the parameter TYPE AND POSITION, never on a name convention. A
+// naming rule is satisfied by renaming, which is not a fix.
+//
+// testing.TB counts as the same type for this rule, and that is not pedantry:
+// TB carries Errorf/Fatalf/Helper AND an unexported method, so it cannot be
+// implemented outside the testing package — no recorder can satisfy it in any
+// spelling, which makes a TB-first arm exactly as unswappable as a
+// *testing.T-first one. An earlier draft treated TB as "not the seam type" and
+// its corpus filed that spelling under "must NOT flag", so the hole came with
+// an approved spelling (review of PR #1512). *testing.B and *testing.M are
+// included on the same argument and at no cost, rather than left as a judgement
+// call for the next reader.
+//
+// # Rule 2 — every arm is actually driven
+//
+// An ARM is a function whose first parameter is reporter or armT: the seam
+// exists for it, so something must go through it. Rule 2 requires every arm to
+// be reachable from a reference in some _test.go of this package, along a chain
+// that does NOT pass through an exported Assert… entry point.
+//
+// Both halves of that sentence are load-bearing:
+//
+//   - Reference-based, not filename-based. The permission-gate family's
+//     self-tests live in permission_gate_test.go, so a
+//     <family>_selftest_test.go rule would need a special case on day one.
+//   - Not through an entry point, because a family's VACUITY GUARD calls the
+//     entry point (TestAssertHookReceiverPermissionGated_PassesACorrectReceiver
+//     does exactly that) and would otherwise mark every arm of a self-test-less
+//     family as covered. A positive test proves an arm passes a correct
+//     fixture; it proves nothing about whether the arm can fail, which is the
+//     only thing this rule is about.
+//
+// # What it does not cover
+//
+// The edge set is identifier REFERENCES inside a function body, not resolved
+// call targets — arms are assigned to struct fields as values here
+// (deliveryRules.first), and a call-expression-only walk would report those as
+// uncalled. That over-approximates: it can only make rule 2 miss a violation,
+// never fabricate one. And neither rule sees a function literal assigned to a
+// package var, since that is not a FuncDecl; TestSeamWalkCorpus pins that as a
+// known limit rather than leaving it to be discovered.
+package contracttesting
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"go/types"
+	"maps"
+	"os"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// deferredToTheSeam names every function in a non-test file of this package
+// that still takes a *testing.T first and is NOT an entry point, with the
+// reason it is allowed to.
+//
+// The admission rule is "this function must be able to FAIL THE RUN, and no
+// obligation owns that failure". Two different kinds of function satisfy it,
+// and they are listed as two kinds rather than generalized because the
+// generalization is false — and a false one here reads as "you don't need to
+// look" (review of PR #1512, against an earlier draft that claimed every entry
+// was fixture machinery):
+//
+//   - FIXTURE MACHINERY — mkSubdir, receiptTranscript, unknownEventTranscript,
+//     unknownEventName. This is the line reporter.go's fixtureT draws: a
+//     fixture that cannot be BUILT is a real failure and has to be loud, and
+//     recording it as "the obligation fired" is #1479's second instance in
+//     miniature.
+//   - A HELPER WITH NO FAMILY — CompareGolden. It does decide a verdict, which
+//     is exactly what breaks the generalization, but it grades golden files for
+//     adapter tests and has no obligations to drive, so there is no self-test
+//     for the seam to serve.
+//
+// The map is deliberately not empty. #1497 chose to write it here rather than
+// in #1479 so it would list what is genuinely still deferred instead of being
+// written and immediately emptied.
+var deferredToTheSeam = map[string]string{
+	"CompareGolden": "not a contract family at all — a golden-file comparison used by adapter tests. " +
+		"It has no obligations to drive and no family to self-test (#1497).",
+	"mkSubdir": "fixture construction: a directory that cannot be created is a failure of the test " +
+		"environment, not of the receiver under test, and must be loud (#1479).",
+	"receiptTranscript": "fixture construction: relocates the adapter's root and writes a transcript " +
+		"into it, reporting its own failures (#1479).",
+	"unknownEventTranscript": "fixture construction, same shape as receiptTranscript (#1479).",
+	"unknownEventName": "derives a per-sub-test, per-invocation event name from t.Name(), which no " +
+		"reporter carries. It decides no verdict; a name it cannot derive is a fixture failure (#1364, #1479).",
+	"unknownEventHash": "the t.Name() half the two name functions share, so they cannot drift onto " +
+		"different derivations. It decides no verdict (#1512 review).",
+}
+
+// --- the walk ---
+
+// seamFacts is everything both rules need, from one parse.
+type seamFacts struct {
+	// testingTFirst maps a non-test function's name to the file:line it is
+	// declared at, for every function whose first parameter is *testing.T.
+	testingTFirst map[string]string
+
+	// arms is the same, for every function whose first parameter is reporter or
+	// armT.
+	arms map[string]string
+
+	// refs maps a non-test function's name to the identifiers its body
+	// mentions.
+	refs map[string]map[string]bool
+
+	// entryPoints is the set of exported Assert… functions.
+	entryPoints map[string]bool
+
+	// declaredInTests is every function DECLARED by a _test.go, driving or not.
+	// It exists so a probe can confirm it still names something real before
+	// grading it (TestParseSeamFactsSeedsOnlyFromDrivingTestFiles) out of the
+	// parse this walk already performs, rather than out of a second one that
+	// could disagree with it about which files it read.
+	declaredInTests map[string]bool
+
+	// referencedInTests is every identifier mentioned in a _test.go that also
+	// mentions mustReport.
+	//
+	// The mustReport condition is what makes this a claim about being DRIVEN
+	// rather than about being NAMED. Seeding from every test file meant an arm
+	// listed in a table literal counted as covered: deleting a family's four
+	// negative self-tests outright, leaving only the now-uncalled table that
+	// named them, passed rule 2 in full — measured in review of PR #1512, and
+	// that is precisely the regression this rule exists to catch. mustReport is
+	// the one call every negative self-test in this package makes and no
+	// positive test does, so requiring it in the same FILE separates the two
+	// without keying on a filename — which matters, because
+	// permission_gate_test.go holds both.
+	referencedInTests map[string]bool
+}
+
+func parseSeamFacts(t *testing.T, dir string) seamFacts {
+	t.Helper()
+	f := seamFacts{
+		testingTFirst:     map[string]string{},
+		arms:              map[string]string{},
+		refs:              map[string]map[string]bool{},
+		entryPoints:       map[string]bool{},
+		declaredInTests:   map[string]bool{},
+		referencedInTests: map[string]bool{},
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read %s: %v", dir, err)
+	}
+	fset := token.NewFileSet()
+	var sawTest, sawNonTest bool
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasSuffix(name, ".go") {
+			continue
+		}
+		file, err := parser.ParseFile(fset, filepath.Join(dir, name), nil, 0)
+		if err != nil {
+			t.Fatalf("parse %s: %v", name, err)
+		}
+		if strings.HasSuffix(name, "_test.go") {
+			sawTest = true
+			f.absorbTestFile(file)
+			continue
+		}
+		sawNonTest = true
+		f.absorbNonTestFile(fset, name, file)
+	}
+	// A walk that read nothing passes both rules perfectly. Refusing here is
+	// the same "a verification mechanism must fail loudly when it cannot run"
+	// rule the package header states (#1423, #1446).
+	if !sawNonTest || !sawTest {
+		t.Fatalf("the walk read %v non-test and %v test files — a parse that finds nothing satisfies every rule below", sawNonTest, sawTest)
+	}
+	return f
+}
+
+// absorbTestFile records what one _test.go declares and, if it drives
+// obligations, what it references.
+//
+// The declaration half is unconditional and the reference half is gated on
+// mustReport: a probe needs to know a symbol still EXISTS wherever it lives,
+// while coverage may only be seeded by a file that actually drives an arm.
+func (f seamFacts) absorbTestFile(file *ast.File) {
+	idents := identsIn(file)
+	for _, decl := range file.Decls {
+		if fn, ok := decl.(*ast.FuncDecl); ok {
+			f.declaredInTests[fn.Name.Name] = true
+		}
+	}
+	if !idents["mustReport"] {
+		return
+	}
+	for id := range idents {
+		f.referencedInTests[id] = true
+	}
+}
+
+// absorbNonTestFile records every function one non-test file declares: the role
+// each rule keys on, whether it is an entry point, and the identifiers its body
+// mentions (rule 2's edge set).
+func (f seamFacts) absorbNonTestFile(fset *token.FileSet, name string, file *ast.File) {
+	for _, decl := range file.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok {
+			continue
+		}
+		where := name + ":" + strconv.Itoa(fset.Position(fn.Pos()).Line)
+		switch seamRole(fn) {
+		case roleTestingT:
+			f.testingTFirst[fn.Name.Name] = where
+		case roleArm:
+			f.arms[fn.Name.Name] = where
+		}
+		if fn.Name.IsExported() && strings.HasPrefix(fn.Name.Name, "Assert") {
+			f.entryPoints[fn.Name.Name] = true
+		}
+		f.refs[fn.Name.Name] = identsIn(fn)
+	}
+}
+
+// identsIn is every identifier appearing anywhere under n.
+//
+// Rule 2's edges are identifier REFERENCES rather than resolved call targets,
+// because arms are assigned to struct fields as values here
+// (deliveryRules.first) and a call-expression walk would report those as
+// uncalled. That over-approximates in the safe direction: it can make rule 2
+// miss a violation, never fabricate one.
+func identsIn(n ast.Node) map[string]bool {
+	out := map[string]bool{}
+	ast.Inspect(n, func(n ast.Node) bool {
+		if id, ok := n.(*ast.Ident); ok {
+			out[id.Name] = true
+		}
+		return true
+	})
+	return out
+}
+
+// seamRole classifies one function by the only thing either rule looks at: the
+// type of its FIRST parameter.
+//
+// It is a named function rather than a switch inside parseSeamFacts so the
+// corpus can pin the DECISION and not merely the type render. That distinction
+// is not cosmetic: the corpus originally pinned firstParamType alone, so the
+// case list — which is where testing.TB was missing — had no committed coverage
+// at all, and the hole was found by review rather than by a test (PR #1512).
+func seamRole(fn *ast.FuncDecl) string {
+	switch firstParamType(fn) {
+	case "*testing.T", "testing.TB", "*testing.B", "*testing.M":
+		return roleTestingT
+	case "reporter", "armT":
+		return roleArm
+	}
+	return roleNeither
+}
+
+const (
+	// roleTestingT: reports through a channel no self-test can swap, so rule 1
+	// owns it.
+	roleTestingT = "testing-T"
+	// roleArm: reports through the seam, so rule 2 owns it.
+	roleArm = "arm"
+	// roleNeither: outside both rules.
+	roleNeither = ""
+)
+
+// firstParamType renders the first parameter's type, or "" when there is none.
+//
+// It renders through go/types.ExprString, which is what this repo's other AST
+// guard already uses for exactly this job (core/architecture_hookbody_test.go).
+// The first draft hand-rolled a renderer that collapsed every unlisted
+// expression into one placeholder, so a corpus row could pin only the
+// placeholder rather than the real spelling. ExprString is purely syntactic and
+// needs no type information, so it is a drop-in.
+func firstParamType(fn *ast.FuncDecl) string {
+	if fn.Type.Params == nil || len(fn.Type.Params.List) == 0 {
+		return ""
+	}
+	return types.ExprString(fn.Type.Params.List[0].Type)
+}
+
+// --- rule 1 ---
+
+// TestEveryTestingTHolderIsAnEntryPointOrDeferred is rule 1.
+func TestEveryTestingTHolderIsAnEntryPointOrDeferred(t *testing.T) {
+	f := parseSeamFacts(t, ".")
+	if len(f.testingTFirst) == 0 {
+		t.Fatal("no function in this package takes a *testing.T first — the entry points do, so the walk is not reading what it thinks it is")
+	}
+
+	for _, name := range sortedKeys(f.testingTFirst) {
+		if f.entryPoints[name] || name == "realT" {
+			continue
+		}
+		if reason, ok := deferredToTheSeam[name]; ok {
+			if reason == "" {
+				t.Errorf("%s (%s) is deferred with no reason — an exemption whose justification is blank is an exemption nobody can review",
+					name, f.testingTFirst[name])
+			}
+			continue
+		}
+		t.Errorf("%s (%s) takes a *testing.T as its first parameter, so it reports through a channel no negative self-test can swap. "+
+			"Take a reporter (or armT, if it also builds fixture state), or name it in deferredToTheSeam with the reason it cannot",
+			name, f.testingTFirst[name])
+	}
+
+	// An exemption that stopped naming a real function is a silent no-op, and
+	// this map's whole job is to be reviewable — the same reasoning
+	// construction_test.go's existence-checked exemption maps carry.
+	for _, name := range sortedKeys(deferredToTheSeam) {
+		if _, ok := f.testingTFirst[name]; !ok {
+			t.Errorf("deferredToTheSeam names %q, which no longer takes a *testing.T first (or no longer exists) — "+
+				"remove the entry rather than leaving an exemption that exempts nothing", name)
+		}
+	}
+}
+
+// --- rule 2 ---
+
+// TestParseSeamFactsSeedsOnlyFromDrivingTestFiles pins rule 2's mustReport
+// clause, which is the one part of the seeding no corpus row over coveredArms
+// can reach — those rows are handed synthetic facts, and this is about how the
+// facts are BUILT.
+//
+// The clause exists because an arm counted as driven merely by being NAMED:
+// deleting a family's negative self-tests and leaving the now-uncalled table
+// that listed them passed rule 2 in full (review of PR #1512).
+func TestParseSeamFactsSeedsOnlyFromDrivingTestFiles(t *testing.T) {
+	f := parseSeamFacts(t, ".")
+
+	// The vacuity half: a symbol declared in a file that DOES drive obligations
+	// must be seeded, or the rule below could never cover anything.
+	if !f.referencedInTests["mustReport"] {
+		t.Fatal("mustReport itself is not in the seeded set — parseSeamFacts read no driving test file, " +
+			"so rule 2 would report every arm as undriven for a reason unrelated to any family")
+	}
+
+	// The discriminating half. This symbol is declared in
+	// hook_endpoint_addressfree_test.go, which drives the hook-endpoint family
+	// through its exported entry point and calls mustReport nowhere — exactly
+	// the positive-test shape the clause must not treat as coverage.
+	const namedOnlyByAPositiveTest = "referenceBeaconHome"
+
+	// Confirm the probe still names something real BEFORE grading it. A symbol
+	// that has been renamed away is absent from the seeded set for a reason
+	// that has nothing to do with the clause, and the assertion below would
+	// then pass while checking nothing — which is how the first draft of this
+	// test shipped, naming a symbol that never existed.
+	if !f.declaredInTests[namedOnlyByAPositiveTest] {
+		t.Fatalf("the probe symbol %q is no longer declared in any _test.go — pick another symbol that "+
+			"a positive-test file declares, or this assertion checks nothing", namedOnlyByAPositiveTest)
+	}
+	if f.referencedInTests[namedOnlyByAPositiveTest] {
+		t.Errorf("%q was seeded from a test file that never calls mustReport — being NAMED by a positive "+
+			"test is not being DRIVEN by a negative one, and treating it as such is what let a family's "+
+			"deleted self-tests pass rule 2", namedOnlyByAPositiveTest)
+	}
+}
+
+// TestEveryArmIsDrivenByATest is rule 2.
+func TestEveryArmIsDrivenByATest(t *testing.T) {
+	f := parseSeamFacts(t, ".")
+	if len(f.arms) == 0 {
+		t.Fatal("this package declares no arm taking a reporter — either the seam is gone or the walk is not reading the package")
+	}
+
+	covered := coveredArms(f)
+
+	for _, name := range sortedKeys(f.arms) {
+		if covered[name] {
+			continue
+		}
+		t.Errorf("arm %s (%s) is reached by no _test.go in this package except through an exported Assert… entry point. "+
+			"Its family has a vacuity guard but no negative self-test, so nothing anywhere demonstrates the obligation can fail (#1453, #1479)",
+			name, f.arms[name])
+	}
+}
+
+// coveredArms computes rule 2's fixed point: an arm is covered when a _test.go
+// references it, or when something covered (and not an entry point) mentions
+// it.
+//
+// It is a separate function so TestSeamWalkCoverageCorpus can pin its verdicts
+// on synthetic graphs. A propagation rule that quietly started covering
+// everything would otherwise look exactly like a package with no violations.
+func coveredArms(f seamFacts) map[string]bool {
+	covered := map[string]bool{}
+	for name := range f.arms {
+		if f.referencedInTests[name] {
+			covered[name] = true
+		}
+	}
+	// Propagate backwards along "is mentioned by a covered function", skipping
+	// exported entry points: a family's vacuity guard calls the entry point,
+	// and a positive test says nothing about whether an arm can fail.
+	for changed := true; changed; {
+		changed = false
+		for caller, body := range f.refs {
+			if f.entryPoints[caller] || !isCovered(caller, covered, f) {
+				continue
+			}
+			for callee := range body {
+				if _, isArm := f.arms[callee]; isArm && !covered[callee] {
+					covered[callee] = true
+					changed = true
+				}
+			}
+		}
+	}
+	return covered
+}
+
+// isCovered reports whether caller may propagate coverage. A non-arm helper
+// that a test references directly counts, which is what lets coverage flow
+// through a chain like assertFloorCoversEveryEvent -> assertFloorCoversEvent.
+func isCovered(caller string, covered map[string]bool, f seamFacts) bool {
+	return covered[caller] || f.referencedInTests[caller]
+}
+
+func sortedKeys[V any](m map[string]V) []string {
+	return slices.Sorted(maps.Keys(m))
+}

--- a/core/internal/contracttesting/unknown_hook_event.go
+++ b/core/internal/contracttesting/unknown_hook_event.go
@@ -111,19 +111,40 @@ type UnknownEventReceiver struct {
 // adapters, or two invocations, can share a test binary without interfering.
 func AssertUnknownHookEventObserved(t *testing.T, r UnknownEventReceiver) {
 	t.Helper()
-	t.Run("known_event_still_dispatched", func(t *testing.T) { assertKnownEventUncounted(t, r) })
-	t.Run("unknown_event_answered_2xx_not_dispatched", func(t *testing.T) { assertUnknownIgnored(t, r) })
-	t.Run("counted_per_adapter_and_name", func(t *testing.T) { assertUnknownCounted(t, r) })
-	t.Run("reported_once_per_distinct_name", func(t *testing.T) { assertUnknownReportedOnce(t, r) })
+	// Root, WriteTranscript and New are called HERE, on the sub-test's real
+	// *testing.T, rather than inside an arm — the split
+	// AssertHookEndpointFollowsBindAddr draws and AssertHookPathConfined
+	// repeats. So is unknownEventName, which reads t.Name(). All four are
+	// fixture machinery that reports its own failures, and a fixture that
+	// cannot be BUILT has to fail the run loudly instead of being recorded as
+	// the obligation firing (#1479). The arms take resolved values and only
+	// grade them, so a negative self-test can drive one against a deliberately
+	// wrong receiver (#1497).
+	t.Run("known_event_still_dispatched", func(t *testing.T) {
+		transcript := unknownEventTranscript(t, r)
+		log := &recordingLogger{}
+		assertKnownEventUncounted(realT(t), r, r.New(t, log), log, transcript)
+	})
+	t.Run("unknown_event_answered_2xx_not_dispatched", func(t *testing.T) {
+		transcript := unknownEventTranscript(t, r)
+		assertUnknownIgnored(realT(t), r, r.New(t, &recordingLogger{}), transcript, reusableEventName(r.Adapter))
+	})
+	t.Run("counted_per_adapter_and_name", func(t *testing.T) {
+		transcript := unknownEventTranscript(t, r)
+		renamed, stray := reusableEventName(r.Adapter)+"Renamed", reusableEventName(r.Adapter)+"Stray"
+		assertUnknownCounted(realT(t), r, r.New(t, &recordingLogger{}), transcript, renamed, stray)
+	})
+	t.Run("reported_once_per_distinct_name", func(t *testing.T) {
+		transcript := unknownEventTranscript(t, r)
+		log := &recordingLogger{}
+		flooding, second := unknownEventName(t)+"Flood", unknownEventName(t)+"Second"
+		assertUnknownReportedOnce(realT(t), r, r.New(t, log), log, transcript, flooding, second)
+	})
 }
 
 // assertKnownEventUncounted is obligation 1.
-func assertKnownEventUncounted(t *testing.T, r UnknownEventReceiver) {
+func assertKnownEventUncounted(t reporter, r UnknownEventReceiver, rut UnknownEventReceiverUnderTest, log *recordingLogger, transcript string) {
 	t.Helper()
-	transcript := unknownEventTranscript(t, r)
-	log := &recordingLogger{}
-	rut := r.New(t, log)
-
 	before := unknownTotalFor(r.Adapter)
 	rec := postUnknownEvent(t, r, rut, transcript, r.KnownEvent)
 
@@ -140,12 +161,8 @@ func assertKnownEventUncounted(t *testing.T, r UnknownEventReceiver) {
 }
 
 // assertUnknownIgnored is obligation 2.
-func assertUnknownIgnored(t *testing.T, r UnknownEventReceiver) {
+func assertUnknownIgnored(t reporter, r UnknownEventReceiver, rut UnknownEventReceiverUnderTest, transcript, event string) {
 	t.Helper()
-	transcript := unknownEventTranscript(t, r)
-	rut := r.New(t, &recordingLogger{})
-
-	event := unknownEventName(t)
 	rec := postUnknownEvent(t, r, rut, transcript, event)
 
 	assertHookStatus2xx(t, rec, fmt.Sprintf("unrecognized event %q", event))
@@ -155,18 +172,16 @@ func assertUnknownIgnored(t *testing.T, r UnknownEventReceiver) {
 }
 
 // assertUnknownCounted is obligation 3: the count is keyed by adapter AND name.
-func assertUnknownCounted(t *testing.T, r UnknownEventReceiver) {
+func assertUnknownCounted(t reporter, r UnknownEventReceiver, rut UnknownEventReceiverUnderTest, transcript, renamed, stray string) {
 	t.Helper()
-	transcript := unknownEventTranscript(t, r)
-	rut := r.New(t, &recordingLogger{})
-
-	renamed, stray := unknownEventName(t)+"Renamed", unknownEventName(t)+"Stray"
 	beforeRenamed, beforeStray := unknownCountFor(r.Adapter, renamed), unknownCountFor(r.Adapter, stray)
+	beforeDropped := unknownNamesDroppedFor(r.Adapter)
 
 	for i := 0; i < 3; i++ {
 		postUnknownEvent(t, r, rut, transcript, renamed)
 	}
 	postUnknownEvent(t, r, rut, transcript, stray)
+	assertNameTableHadRoom(t, r.Adapter, beforeDropped)
 
 	if got := unknownCountFor(r.Adapter, renamed) - beforeRenamed; got != 3 {
 		t.Errorf("event %q arrived 3 times, counted %d for adapter %q — an event that keeps arriving is the signature of an upstream rename and has to be countable as such",
@@ -179,17 +194,14 @@ func assertUnknownCounted(t *testing.T, r UnknownEventReceiver) {
 }
 
 // assertUnknownReportedOnce is obligation 4.
-func assertUnknownReportedOnce(t *testing.T, r UnknownEventReceiver) {
+func assertUnknownReportedOnce(t reporter, r UnknownEventReceiver, rut UnknownEventReceiverUnderTest, log *recordingLogger, transcript, flooding, second string) {
 	t.Helper()
-	transcript := unknownEventTranscript(t, r)
-	log := &recordingLogger{}
-	rut := r.New(t, log)
-
-	flooding, second := unknownEventName(t)+"Flood", unknownEventName(t)+"Second"
+	beforeDropped := unknownNamesDroppedFor(r.Adapter)
 	for i := 0; i < 5; i++ {
 		postUnknownEvent(t, r, rut, transcript, flooding)
 	}
 	postUnknownEvent(t, r, rut, transcript, second)
+	assertNameTableHadRoom(t, r.Adapter, beforeDropped)
 
 	if n := log.CountMentioning(flooding); n != 1 {
 		t.Errorf("event %q arrived 5 times and produced %d log line(s), want exactly 1 — a renamed event fires on every tool call, and one line per call buries the evidence it is meant to surface\nlines:\n%s",
@@ -211,7 +223,28 @@ func unknownEventTranscript(t *testing.T, r UnknownEventReceiver) string {
 	return r.WriteTranscript(t, mkSubdir(t, r.Root(t), "in-tree"))
 }
 
-// unknownEventName derives a name unique to the running sub-test. The counters
+// reusableEventName derives a name that is stable for one adapter, for the
+// obligations that measure a DELTA rather than a first sighting.
+//
+// hookjson retains at most 64 distinct (adapter, name) pairs for the life of
+// the process and NEVER resets, so every distinct name a contract mints is a
+// slot spent forever and every globally-FRESH one is a slot spent per run.
+// Obligations 2 and 3 need neither: they read a before/after difference, which
+// is correct however many times that name has been seen before. Only obligation
+// 4 depends on first-sighting state, and it is the only caller of
+// unknownEventName left.
+//
+// Keyed by ADAPTER rather than by sub-test on purpose. Per sub-test was the
+// first draft, for traceability, and it spent one permanent slot per sub-test
+// path — about twenty across this package. Per adapter keeps the failure
+// traceable to the CLI it is about, which is the axis that matters when reading
+// one, and costs three slots per adapter forever (review of PR #1512).
+func reusableEventName(adapter string) string {
+	return "IrrUnk" + hash8(adapter)
+}
+
+// unknownEventName derives a name unique to the running sub-test AND to this
+// invocation of it. The counters
 // are process-global and never reset, so a fixed literal would make two
 // invocations in one test binary — two adapters, or a receiver wired twice —
 // silently share a key and a first-sighting.
@@ -231,13 +264,55 @@ func unknownEventTranscript(t *testing.T, r UnknownEventReceiver) string {
 // hash keeps failures traceable to a test; the counter keeps them independent.
 func unknownEventName(t *testing.T) string {
 	t.Helper()
+	return fmt.Sprintf("IrrUnk%s%02d", unknownEventHash(t), unknownEventSeq.Add(1))
+}
+
+// unknownEventHash is the sub-test-derived half both name functions share, so
+// they cannot drift onto different derivations.
+func unknownEventHash(t *testing.T) string {
+	t.Helper()
+	return hash8(t.Name())
+}
+
+// hash8 is the derivation every event name in this file goes through, so the
+// two name functions cannot drift onto different ones — which they had, since
+// reusableEventName takes an adapter name and unknownEventHash a *testing.T, so
+// a shared helper over *testing.T could not serve both (review of PR #1512).
+func hash8(s string) string {
 	h := fnv.New32a()
-	_, _ = h.Write([]byte(t.Name()))
-	return fmt.Sprintf("IrrUnk%08x%02d", h.Sum32(), unknownEventSeq.Add(1))
+	_, _ = h.Write([]byte(s))
+	return fmt.Sprintf("%08x", h.Sum32())
 }
 
 // unknownEventSeq makes every unknownEventName call unique within the process.
 var unknownEventSeq atomic.Uint64
+
+// assertNameTableHadRoom stops a saturated process-global name table from being
+// reported as a receiver defect.
+//
+// hookjson retains at most 64 distinct (adapter, name) pairs for the life of the
+// process. Past that, a genuinely-new name is counted only in a per-adapter drop
+// total and never gets a row — so unknownCountFor returns 0 and the arms above
+// say "arrived 3 times, counted 0", which is a FALSE ACCUSATION against a
+// receiver doing exactly the right thing. That is precisely the failure shape
+// this package exists to remove, so it is refused loudly here instead: "a
+// verification mechanism must fail loudly when it cannot run" (AGENTS.md,
+// #1423). It is a Fatalf rather than an Errorf because every assertion below it
+// is graded on the state this guard just declared unreadable.
+func assertNameTableHadRoom(t reporter, adapter string, before uint64) {
+	t.Helper()
+	if got := unknownNamesDroppedFor(adapter) - before; got > 0 {
+		t.Fatalf("hookjson's process-global distinct-name table saturated during this obligation (%d name(s) dropped for adapter %q) — "+
+			"this is a limit of the TEST BINARY, not a defect in the receiver: past %d distinct (adapter, name) pairs a new name is never given a row, "+
+			"so every count below reads 0. Run with a lower -count, or spend fewer globally-fresh names (see reusableEventName)",
+			got, adapter, hookjson.MaxUnknownEventNames)
+	}
+}
+
+// unknownNamesDroppedFor reads one adapter's dropped-name total.
+func unknownNamesDroppedFor(adapter string) uint64 {
+	return hookjson.UnknownEventNamesDropped()[adapter]
+}
 
 // unknownCountFor reads one (adapter, event) counter out of the snapshot.
 func unknownCountFor(adapter, event string) uint64 {
@@ -264,7 +339,7 @@ func unknownTotalFor(adapter string) uint64 {
 
 // postUnknownEvent POSTs the adapter's hook body for event and returns the
 // response.
-func postUnknownEvent(t *testing.T, r UnknownEventReceiver, rut UnknownEventReceiverUnderTest, transcriptPath, event string) *httptest.ResponseRecorder {
+func postUnknownEvent(t reporter, r UnknownEventReceiver, rut UnknownEventReceiverUnderTest, transcriptPath, event string) *httptest.ResponseRecorder {
 	t.Helper()
 	return postHookBody(t, rut.Handler, r.EndpointPath, r.PayloadFor(transcriptPath, event))
 }

--- a/core/internal/contracttesting/unknown_hook_event_selftest_test.go
+++ b/core/internal/contracttesting/unknown_hook_event_selftest_test.go
@@ -1,0 +1,215 @@
+// unknown_hook_event_selftest_test.go is the committed mutation evidence for
+// AssertUnknownHookEventObserved (#1364), and it is the family where half of it
+// had to be RE-DERIVED rather than transcribed (#1479, #1497).
+//
+// PR #1403's evidence is a PRE-FIX RUN, not a mutation table: the contract and
+// both adapter wirings were written first, with the two `default:` branches
+// untouched, so obligations 3 and 4 reddened together against main's
+// log-at-Info-and-200 behaviour. That is real red-first evidence and it is
+// transcribed below. Obligations 1 and 2 have none — the PR names them
+// explicitly as LOCKS ("passed pre-fix ... their green says nothing about the
+// defect") — so their mutations are derived here for the first time, from what
+// the arms' own doc comments say they are for.
+//
+// Deriving them was worth doing rather than skipping. Obligation 1 turns out to
+// carry two independent claims that the single recorded phrase "the vacuity
+// guard" hides: that a recognized event still DISPATCHES, and that it is
+// counted as unrecognized by NOBODY. A receiver can fail either without the
+// other, so each gets its own mutation below.
+// # A note on why obligation 4 is absent from every silence list
+//
+// It is the only obligation that must spend a GLOBALLY-FRESH event name (it
+// grades first-sighting behaviour), and hookjson retains at most 64 distinct
+// (adapter, name) pairs for the life of the process, never resetting. Naming it
+// in four silence lists cost four extra drives — eight permanent slots — per
+// run, which took this package from passing `go test -count=5` to failing
+// `-count=3` (review of PR #1512). Its own case and the vacuity guard still
+// drive it; what is given up is the weakest evidence in the file, since none of
+// the four mutations touches the reporting path obligation 4 grades.
+//
+// The residual limit is real and bounded rather than hidden:
+// assertNameTableHadRoom turns a saturated table into an explicit "this is a
+// limit of the TEST BINARY, not a defect in the receiver" failure instead of
+// the false accusation ("counted 0") it used to produce.
+package contracttesting
+
+import "testing"
+
+// unknownArmBuilders is one builder per obligation, mirroring
+// AssertUnknownHookEventObserved's own t.Run bodies — the same restatement,
+// kept honest by the same vacuity guard, that confinementArmBuilders makes.
+//
+// Builders rather than pre-built arms because a drive must construct ONLY the
+// obligation it is about. An earlier draft built all four and discarded three,
+// which quadrupled the globally-fresh event names this file spends against
+// hookjson's 64-pair, never-reset table and took the package from passing
+// -count=5 to failing -count=3 (review of PR #1512). Only obligation 4 needs a
+// fresh name at all; 2 and 3 measure deltas and use reusableEventName.
+func unknownArmBuilders() []armBuilder {
+	return []armBuilder{
+		{"known_event_still_dispatched", func(t *testing.T, brk receiverBreak) func(armT) {
+			r := fakeUnknownEventReceiver(brk)
+			log := &recordingLogger{}
+			transcript := unknownEventTranscript(t, r)
+			rut := r.New(t, log)
+			return func(at armT) { assertKnownEventUncounted(at, r, rut, log, transcript) }
+		}},
+		{"unknown_event_answered_2xx_not_dispatched", func(t *testing.T, brk receiverBreak) func(armT) {
+			r := fakeUnknownEventReceiver(brk)
+			transcript := unknownEventTranscript(t, r)
+			rut := r.New(t, &recordingLogger{})
+			event := reusableEventName(r.Adapter)
+			return func(at armT) { assertUnknownIgnored(at, r, rut, transcript, event) }
+		}},
+		{"counted_per_adapter_and_name", func(t *testing.T, brk receiverBreak) func(armT) {
+			r := fakeUnknownEventReceiver(brk)
+			transcript := unknownEventTranscript(t, r)
+			rut := r.New(t, &recordingLogger{})
+			renamed, stray := reusableEventName(r.Adapter)+"Renamed", reusableEventName(r.Adapter)+"Stray"
+			return func(at armT) { assertUnknownCounted(at, r, rut, transcript, renamed, stray) }
+		}},
+		{"reported_once_per_distinct_name", func(t *testing.T, brk receiverBreak) func(armT) {
+			r := fakeUnknownEventReceiver(brk)
+			log := &recordingLogger{}
+			transcript := unknownEventTranscript(t, r)
+			rut := r.New(t, log)
+			flooding, second := unknownEventName(t)+"Flood", unknownEventName(t)+"Second"
+			return func(at armT) { assertUnknownReportedOnce(at, r, rut, log, transcript, flooding, second) }
+		}},
+	}
+}
+
+// unknownEventFamily is the obligation table this file's cases drive through
+// receiverFamily's shared drive/silence pair.
+var unknownEventFamily = receiverFamily{
+	entryPoint: "AssertUnknownHookEventObserved",
+	builders:   unknownArmBuilders,
+}
+
+// TestUnknownEventArms_PassACorrectReceiver is the family's vacuity guard,
+// against a receiver built the production way — hookjson.NewHandler, decoding
+// through hookjson.DecodeConfined, counting through hookjson.IgnoreUnknownEvent.
+func TestUnknownEventArms_PassACorrectReceiver(t *testing.T) {
+	unknownEventFamily.mustPassACorrectReceiver(t, receiverBreak{}, "a correct hook receiver")
+}
+
+// TestUnknownEventObligation1_RecognizedEventStillDispatches is the first of
+// obligation 1's two derived mutations: a receiver that recognizes nothing.
+//
+// This is the shape the arm's Fatal exists for, and #1403 recorded no mutation
+// for it because on main it was true by construction. It is the same argument
+// #1446's M1 makes for the confinement family: obligations 2-4 are all
+// assertions about what an unrecognized event must NOT do, and a receiver that
+// treats every event as unrecognized satisfies all three while being broken.
+func TestUnknownEventObligation1_RecognizedEventStillDispatches(t *testing.T) {
+	brk := receiverBreak{ignoresKnownEvent: true}
+
+	mustReport(t, unknownEventFamily.drive(t, brk, "known_event_still_dispatched"),
+		"was not dispatched — every obligation below it would pass vacuously",
+		"a receiver that recognizes no event at all, so every name goes down the unrecognized branch")
+
+	unknownEventFamily.mustBeSilentOn(t, brk, "a receiver that recognizes nothing",
+		"unknown_event_answered_2xx_not_dispatched", "counted_per_adapter_and_name")
+}
+
+// TestUnknownEventObligation1_RecognizedEventIsCountedByNobody is obligation
+// 1's second derived mutation, and the one the arm's doc comment names: a
+// receiver that counts EVERYTHING.
+//
+// It matters because such a receiver is indistinguishable from a correct one on
+// obligations 2, 3 and 4 — all three of which are about unrecognized names —
+// while reporting an upstream rename that never happened, on every tool call,
+// forever. The diagnostic value of the counter is exactly its silence on
+// healthy traffic.
+func TestUnknownEventObligation1_RecognizedEventIsCountedByNobody(t *testing.T) {
+	brk := receiverBreak{countsEveryEvent: true}
+
+	mustReport(t, unknownEventFamily.drive(t, brk, "known_event_still_dispatched"),
+		"to the unrecognized-event counters, want 0",
+		"a receiver that counts a recognized event as unrecognized as well")
+
+	unknownEventFamily.mustBeSilentOn(t, brk, "a receiver that counts every event",
+		"unknown_event_answered_2xx_not_dispatched", "counted_per_adapter_and_name")
+}
+
+// TestUnknownEventObligation2_UnknownEventIsNotDispatched is obligation 2's
+// derived mutation: the receiver guesses a handler for a name it does not know.
+//
+// #1403 recorded none, because before the fix both receivers already ignored
+// the payload — the defect that issue was about was the SILENCE, not a wrong
+// dispatch. The obligation is still the one that has to fail here: an
+// unfamiliar name reaching a handler chosen by fallback is worse than one
+// ignored, and nothing else in the family would notice.
+func TestUnknownEventObligation2_UnknownEventIsNotDispatched(t *testing.T) {
+	brk := receiverBreak{dispatchesUnknown: true}
+
+	mustReport(t, unknownEventFamily.drive(t, brk, "unknown_event_answered_2xx_not_dispatched"),
+		"was dispatched downstream — an unfamiliar name must not be guessed into a handler",
+		"a receiver that guesses a handler for an event name it does not recognize")
+
+	unknownEventFamily.mustBeSilentOn(t, brk, "a receiver that dispatches unrecognized events",
+		"known_event_still_dispatched", "counted_per_adapter_and_name")
+}
+
+// TestUnknownEventObligation2_UnknownEventAnswers2xx is the other half of
+// obligation 2's statement. The rule is shared — assertHookStatus2xx grades it
+// for three families — and it is pinned here as well as in the confinement
+// family because this is the branch where a receiver is most tempted to answer
+// 4xx: it genuinely does not understand the request. gemini-cli's pre-tool
+// hooks and Copilot's preToolUse fail CLOSED on an error result, so for those
+// adapters a 400 on an unrecognized name would block the user's tool call.
+func TestUnknownEventObligation2_UnknownEventAnswers2xx(t *testing.T) {
+	brk := receiverBreak{refusesUnknownWith4xx: true}
+
+	mustReport(t, unknownEventFamily.drive(t, brk, "unknown_event_answered_2xx_not_dispatched"),
+		"status = 400, want 2xx",
+		"a receiver that answers an unrecognized event with a status code")
+
+	unknownEventFamily.mustBeSilentOn(t, brk, "a receiver that answers 4xx on an unrecognized event",
+		"known_event_still_dispatched", "counted_per_adapter_and_name")
+}
+
+// TestUnknownEventObligation3_CountedPerAdapterAndName transcribes #1403's
+// pre-fix run, reproduced here as a receiver that files every unrecognized name
+// under one key.
+//
+// The recorded failure is the same in shape and in prose:
+//
+//	event "...Renamed" arrived 3 times, counted 0 for adapter "claude-code" —
+//	an event that keeps arriving is the signature of an upstream rename and has
+//	to be countable as such
+//
+// A single scalar cannot tell an upstream rename, which fires on every tool
+// call forever, from one stray POST — and telling those apart is the whole
+// diagnostic value.
+func TestUnknownEventObligation3_CountedPerAdapterAndName(t *testing.T) {
+	brk := receiverBreak{collapsesEventNames: true}
+
+	mustReport(t, unknownEventFamily.drive(t, brk, "counted_per_adapter_and_name"),
+		"arrived 3 times, counted 0 for adapter",
+		"a receiver that counts every unrecognized name under one collapsed key")
+
+	unknownEventFamily.mustBeSilentOn(t, brk, "a receiver that collapses every unrecognized name into one key",
+		"known_event_still_dispatched", "unknown_event_answered_2xx_not_dispatched")
+}
+
+// TestUnknownEventObligation4_ReportedOncePerDistinctName transcribes the other
+// half of #1403's pre-fix run — literally what both receivers did before the
+// fix: an Info log per arrival.
+//
+// The recorded failure named five lines for five arrivals; this fixture keeps
+// hookjson.IgnoreUnknownEvent's own once-per-name line as well, so the count is
+// six. That difference is deliberate. It isolates the REPORTING axis: the
+// counters stay correct, so obligation 3 remains green and the only thing wrong
+// is that the evidence is buried under one line per tool call.
+func TestUnknownEventObligation4_ReportedOncePerDistinctName(t *testing.T) {
+	brk := receiverBreak{logsEveryUnknown: true}
+
+	mustReport(t, unknownEventFamily.drive(t, brk, "reported_once_per_distinct_name"),
+		"arrived 5 times and produced 6 log line(s), want exactly 1",
+		"a receiver that reports every arrival of an unrecognized name rather than every distinct name")
+
+	unknownEventFamily.mustBeSilentOn(t, brk, "a receiver that logs one line per unrecognized arrival",
+		"known_event_still_dispatched", "unknown_event_answered_2xx_not_dispatched",
+		"counted_per_adapter_and_name")
+}


### PR DESCRIPTION
Closes #1497. Follow-up to #1479, which built the negative-self-test harness and covered four of the seven `contracttesting` families. This is the remaining three, plus the structural seam walk #1479 deferred.

## What lands

**All 14 obligations of the three receiver-shaped families now have a negative self-test**, each driving one fixture wrong in exactly one way and asserting *the obligation that owns that wrongness* is the one that reports it — `mustReport` with a fragment of that obligation's own message.

- `hook_path_confinement_selftest_test.go` — 6 obligations, plus the two shared halves of obligations 2-5 (a refusal must be **counted**, and must answer **2xx**).
- `unknown_hook_event_selftest_test.go` — 4 obligations. #1403 declared obligations 1-2 **locks with no recorded mutation**; deriving them found obligation 1 carries *two* independent claims, so it gets two cases.
- `hook_receipt_selftest_test.go` — 4 obligations. #1413's recorded mutation covers 1-3 **jointly**; the two placements that split them are new here.
- `receiver_fixture_test.go` — the one fixture all three share, built through `hookjson.NewHandler` over a real `PathConfiner` and a real `RequireConsent`, decoding through `DecodeConfined`. `receiverBreak`'s zero value is a **correct** receiver, so each case names what it broke and nothing else. No second, test-shaped constructor — #1390's property is preserved.
- `seam_walk_test.go` + `seam_walk_corpus_test.go` — the structural seam (below).
- The three families' arms now take `reporter`/`armT`, with fixture construction hoisted into the exported entry points — the split `AssertHookEndpointFollowsBindAddr` already draws. **No exported signature changed**; all four real receivers (claudecode hook + statusline, codex, copilot) stay green.

## The isolation cases are half the evidence

Every mutation also names the obligations it must leave **silent**. Without that, six mutations against six obligations are equally satisfied by six arms that all report on everything — #1453's failure wearing a bigger hat. Those silences reproduce #1446's recorded 8x5 matrix:

| Mutation | 1 | 2 | 3 | 4 | 5 | 6 |
|---|---|---|---|---|---|---|
| M1 no declared root (refuses everything) | **RED** | pass | pass | pass | pass | - |
| M2 over-broad declared root (accepts the decoy) | pass | **RED** | - | - | - | - |
| M3 raw lexical prefix (`..` guard dropped) | pass | pass | **RED** | - | - | - |
| M4 cleaned prefix, no symlink resolution | pass | pass | pass | **RED** | **RED** | - |
| M6 unresolvable leaf waved through | pass | pass | pass | pass | **RED** | - |
| no-op `set` (caller's spelling forwarded) | pass | pass | pass | pass | pass | **RED** |
| M7a published `.Confiner` != the one in use | pass | *count* | *count* | *count* | *count* | - |

M4 leaving obligation 3 green is the decisive cell — it proves the ordering obligation (**symlinks resolved BEFORE containment**, #1361's headline) is not covered by the traversal one. Two rows are reproduced with a deliberately **narrower** blast radius than the recorded one, because the recorded mutation edited `confine.go` and a test in `contracttesting` cannot; both say so where they live.

## What the fixture can and cannot claim — stated, not papered over

Obligations 2-5 grade a verdict `hookjson.PathConfiner` reaches, and #1380/#1446 recorded their mutations as edits to `confine.go`. The fixture therefore **consults the real confiner and second-guesses its answer** in the direction each recorded mutation produced. The claim a case supports is stated precisely: *the arm reports when the receiver reaches the wrong verdict on that input*. That is the obligation. It is not a claim about `confine.go`.

Obligations 1 and 2 need no override — they are reached by declaring the wrong **roots**, an ordinary adapter defect (`ConfinerForSource`'s doc warns about the first by name) that runs the entire production path.

Four things bit while writing it, all now recorded in the code:

- **The counter is only reachable through `Confine`.** `RejectPath` logs and answers 2xx but counts nothing, so a fixture that skipped `Confine` would fail every arm with "counted 0 rejection(s)" for a reason unrelated to the mutation.
- **A mutated receiver that cannot use `DecodeConfined` differs from a correct one in two ways** — the verdict *and* the decode. `TestConfinementArms_PassAHandRolledButFaithfulReceiver` runs the hand-rolled baseline through every arm first, so the decode is proved neutral. Its honest limit is recorded too: `MaxBytesReader` and the get/set postcondition are exercised by no arm here.
- **`mustReport` caught a fixture that was not actually wrong.** The first 4xx mutation called `http.Error` *after* `RejectPath` had written 200; a second `WriteHeader` is a no-op, so the receiver was correct and the obligation rightly said nothing.
- **The name budget is finite.** `hookjson` retains 64 `(adapter, name)` pairs for the life of the process and never resets. The first draft spent a globally-fresh name per drive and took the package from passing `-count=5` to failing `-count=3`, with the symptom being a *false accusation* against the receiver ("counted 0"). Delta-measuring obligations now use an adapter-stable name, only the first-sighting obligation spends a fresh one, and `assertNameTableHadRoom` reports saturation as a limit of the test binary. **`-count=12` now passes** (main's headroom was ~8).

## The seam is now structural

`seam_walk_test.go` is an AST walk over the package's own sources, keyed on parameter **TYPE and POSITION**, never on a name convention (a naming rule is satisfied by renaming).

- **Rule 1** — a function in a non-test file whose first parameter is `*testing.T` (or `testing.TB`/`*testing.B`/`*testing.M`, which carry an unexported method and so are equally unswappable) must be an exported `Assert...` entry point, `realT`, or named in `deferredToTheSeam` with its reason. Stale entries fail too.
- **Rule 2** — every arm (first parameter `reporter` or `armT`) must be reachable, along a chain that does **not** pass through an exported entry point, from a reference in a `_test.go` **that also calls `mustReport`**. Reference-based, not filename-based (permission-gate's self-tests live in `permission_gate_test.go`); not-through-an-entry-point because a family's vacuity guard calls its entry point; and the `mustReport` clause because being NAMED is not being DRIVEN.

Per #1450 it lands with a corpus rather than probes: one row per parameter spelling pinned to the verdict the detector must return (`seamRole`, not just the type render — the case list is where `testing.TB` was missing), plus one per call graph pinning the propagation. The `want:false` rows carry the value.

## Mutation evidence — verbatim

**24 mutations, all RED**, applied by a harness that asserts the edit landed (`git diff --quiet`), refuses to conclude anything at 0 sites, and refuses an untracked file. Both refusals fired during this run: #1446's harness incident reproduced (a stale anchor after the simplify pass), and five edits once left stuck in a file `git diff` could not see.

### The three families — the ARM stops asserting, its self-test must go red

```
### ARM ob1: assertInTreeAccepted stops checking that the in-tree path dispatched
### mutated 1 site(s) in core/internal/contracttesting/hook_path_confinement.go  ==> RED
--- FAIL: TestConfinementObligation1_InTreeAccepted (0.00s)
    hook_path_confinement_selftest_test.go:154: mutation "a receiver that declares no transcript root, so confinement refuses its own tree": the arm failed, but NOT on the obligation under test: wanted a message containing "in-tree transcript was not dispatched", got: in-tree transcript counted 1 rejection(s), want 0
FAIL
FAIL	irrlicht/core/internal/contracttesting	0.435s
FAIL

### ARM ob2-5 (escape): assertRefused stops checking that nothing was dispatched
### mutated 1 site(s) in core/internal/contracttesting/hook_path_confinement.go  ==> RED
--- FAIL: TestConfinementObligation2_OutOfTreeRejected (0.00s)
    hook_path_confinement_selftest_test.go:170: mutation "a receiver whose declared root is broad enough to contain the out-of-tree decoy": the arm failed, but NOT on the obligation under test: wanted a message containing "a well-formed transcript outside every declared root was dispatched downstream", got: a well-formed transcript outside every declared root: counted 0 rejection(s), want 1 — a refusal has to be countable, not just returned
--- FAIL: TestConfinementObligation3_ParentTraversalRejected (0.00s)
    hook_path_confinement_selftest_test.go:190: mutation "a receiver that checks containment by lexical prefix on the caller's uncleaned string": the obligation reported nothing against a fixture that is wrong for it — either the fixture is no longer wrong, or the obligation has stopped discriminating (expected a message containing "a path rooted in the declared tree that climbs out of it was dispatched downstream")
--- FAIL: TestConfinementObligation4_SymlinkEscapeRejected (0.00s)
    hook_path_confinement_selftest_test.go:209: mutation "a receiver that cleans the path and checks containment without ever resolving symlinks": the obligation reported nothing against a fixture that is wrong for it — either the fixture is no longer wrong, or the obligation has stopped discriminating (expected a message containing "a symlink inside the declared root pointing out of it (symlinks must be resolved BEFORE the containment check) was dispatched downstream")
--- FAIL: TestConfinementObligation5_DanglingSymlinkRejected (0.00s)
    hook_path_confinement_selftest_test.go:240: mutation "a receiver that waves through a leaf it cannot resolve, on the assumption the write has not landed yet": the obligation reported nothing against a fixture that is wrong for it — either the fixture is no longer wrong, or the obligation has stopped discriminating (expected a message containing "a dangling symlink inside the declared root (an unresolvable leaf must not be assumed to be an unflushed write) was dispatched downstream")
FAIL
FAIL	irrlicht/core/internal/contracttesting	0.405s
FAIL

### ARM ob2-5 (countability): assertRefused stops checking the rejection counter
### mutated 1 site(s) in core/internal/contracttesting/hook_path_confinement.go  ==> RED
--- FAIL: TestConfinementObligations2to5_RefusalIsCounted (0.01s)
    --- FAIL: TestConfinementObligations2to5_RefusalIsCounted/out_of_tree_path_rejected (0.00s)
        hook_path_confinement_selftest_test.go:300: mutation "a receiver whose published confiner is not the one its request path uses": the obligation reported nothing against a fixture that is wrong for it — either the fixture is no longer wrong, or the obligation has stopped discriminating (expected a message containing "a well-formed transcript outside every declared root: counted 0 rejection(s), want 1")
    --- FAIL: TestConfinementObligations2to5_RefusalIsCounted/parent_traversal_rejected (0.00s)
        hook_path_confinement_selftest_test.go:300: mutation "a receiver whose published confiner is not the one its request path uses": the obligation reported nothing against a fixture that is wrong for it — either the fixture is no longer wrong, or the obligation has stopped discriminating (expected a message containing "a path rooted in the declared tree that climbs out of it: counted 0 rejection(s), want 1")
    --- FAIL: TestConfinementObligations2to5_RefusalIsCounted/symlink_escape_rejected (0.00s)
        hook_path_confinement_selftest_test.go:300: mutation "a receiver whose published confiner is not the one its request path uses": the obligation reported nothing against a fixture that is wrong for it — either the fixture is no longer wrong, or the obligation has stopped discriminating (expected a message containing "a symlink inside the declared root pointing out of it (symlinks must be resolved BEFORE the containment check): counted 0 rejection(s), want 1")
    --- FAIL: TestConfinementObligations2to5_RefusalIsCounted/dangling_symlink_rejected (0.00s)
        hook_path_confinement_selftest_test.go:300: mutation "a receiver whose published confiner is not the one its request path uses": the obligation reported nothing against a fixture that is wrong for it — either the fixture is no longer wrong, or the obligation has stopped discriminating (expected a message containing "a dangling symlink inside the declared root (an unresolvable leaf must not be assumed to be an unflushed write): counted 0 rejection(s), want 1")
FAIL
FAIL	irrlicht/core/internal/contracttesting	0.453s
FAIL

### ARM ob2-5 (2xx): assertHookStatus2xx stops grading the status code
### mutated 1 site(s) in core/internal/contracttesting/hook_receiver.go  ==> RED
--- FAIL: TestConfinementObligations2to5_RefusalAnswers2xx (0.01s)
    --- FAIL: TestConfinementObligations2to5_RefusalAnswers2xx/out_of_tree_path_rejected (0.00s)
        hook_path_confinement_selftest_test.go:327: mutation "a receiver that reports a confinement refusal through the status code": the obligation reported nothing against a fixture that is wrong for it — either the fixture is no longer wrong, or the obligation has stopped discriminating (expected a message containing "a well-formed transcript outside every declared root: status = 400, want 2xx")
    --- FAIL: TestConfinementObligations2to5_RefusalAnswers2xx/parent_traversal_rejected (0.00s)
        hook_path_confinement_selftest_test.go:327: mutation "a receiver that reports a confinement refusal through the status code": the obligation reported nothing against a fixture that is wrong for it — either the fixture is no longer wrong, or the obligation has stopped discriminating (expected a message containing "a path rooted in the declared tree that climbs out of it: status = 400, want 2xx")
    --- FAIL: TestConfinementObligations2to5_RefusalAnswers2xx/symlink_escape_rejected (0.00s)
        hook_path_confinement_selftest_test.go:327: mutation "a receiver that reports a confinement refusal through the status code": the obligation reported nothing against a fixture that is wrong for it — either the fixture is no longer wrong, or the obligation has stopped discriminating (expected a message containing "a symlink inside the declared root pointing out of it (symlinks must be resolved BEFORE the containment check): status = 400, want 2xx")
    --- FAIL: TestConfinementObligations2to5_RefusalAnswers2xx/dangling_symlink_rejected (0.00s)
        hook_path_confinement_selftest_test.go:327: mutation "a receiver that reports a confinement refusal through the status code": the obligation reported nothing against a fixture that is wrong for it — either the fixture is no longer wrong, or the obligation has stopped discriminating (expected a message containing "a dangling symlink inside the declared root (an unresolvable leaf must not be assumed to be an unflushed write): status = 400, want 2xx")
FAIL
FAIL	irrlicht/core/internal/contracttesting	0.407s
FAIL

### ARM ob6: assertConfinedSpellingDispatches stops checking WHICH string travelled
### mutated 1 site(s) in core/internal/contracttesting/hook_path_confinement.go  ==> RED
--- FAIL: TestConfinementObligation6_ConfinedSpellingDispatches (0.00s)
    hook_path_confinement_selftest_test.go:262: mutation "a receiver that confines correctly and then dispatches the caller's unconfined string": the obligation reported nothing against a fixture that is wrong for it — either the fixture is no longer wrong, or the obligation has stopped discriminating (expected a message containing "which is the caller's own spelling")
FAIL
FAIL	irrlicht/core/internal/contracttesting	0.385s
FAIL

=== SUMMARY ===
RED                    ARM ob1: assertInTreeAccepted stops checking that the in-tree path dispatched
RED                    ARM ob2-5 (escape): assertRefused stops checking that nothing was dispatched
RED                    ARM ob2-5 (countability): assertRefused stops checking the rejection counter
RED                    ARM ob2-5 (2xx): assertHookStatus2xx stops grading the status code
RED                    ARM ob6: assertConfinedSpellingDispatches stops checking WHICH string travelled
```

```
### ARM unknown ob1 (dispatch): assertKnownEventUncounted stops checking the recognized event dispatched
### mutated 1 site(s) in core/internal/contracttesting/unknown_hook_event.go  ==> RED
--- FAIL: TestUnknownEventObligation1_RecognizedEventStillDispatches (0.00s)
    unknown_hook_event_selftest_test.go:107: mutation "a receiver that recognizes no event at all, so every name goes down the unrecognized branch": the arm failed, but NOT on the obligation under test: wanted a message containing "was not dispatched — every obligation below it would pass vacuously", got: recognized event "Stop" added 1 to the unrecognized-event counters, want 0 — a receiver that counts everything reports a rename that never happened; recognized event "Stop" was reported as unrecognized: [error] selftest-hook-receiver : unrecognized hook event "Stop" from contracttesting-selftest: ignored, answered 2xx. Further occurrences of this name are counted, not logged — an upstream event rename looks exactly like this, so check the count in the diagnostics bundle's hooks.json before dismissing it.
FAIL
FAIL	irrlicht/core/internal/contracttesting	0.385s
FAIL

### ARM unknown ob1 (counter): assertKnownEventUncounted stops checking the recognized event was counted by nobody
### mutated 1 site(s) in core/internal/contracttesting/unknown_hook_event.go  ==> RED
--- FAIL: TestUnknownEventObligation1_RecognizedEventIsCountedByNobody (0.00s)
    unknown_hook_event_selftest_test.go:127: mutation "a receiver that counts a recognized event as unrecognized as well": the arm failed, but NOT on the obligation under test: wanted a message containing "to the unrecognized-event counters, want 0", got: recognized event "Stop" was reported as unrecognized: [error] selftest-hook-receiver : unrecognized hook event "Stop" from contracttesting-selftest: ignored, answered 2xx. Further occurrences of this name are counted, not logged — an upstream event rename looks exactly like this, so check the count in the diagnostics bundle's hooks.json before dismissing it.
FAIL
FAIL	irrlicht/core/internal/contracttesting	0.488s
FAIL

### ARM unknown ob2 (dispatch): assertUnknownIgnored stops checking that nothing was dispatched
### mutated 1 site(s) in core/internal/contracttesting/unknown_hook_event.go  ==> RED
--- FAIL: TestUnknownEventObligation2_UnknownEventIsNotDispatched (0.00s)
    unknown_hook_event_selftest_test.go:146: mutation "a receiver that guesses a handler for an event name it does not recognize": the obligation reported nothing against a fixture that is wrong for it — either the fixture is no longer wrong, or the obligation has stopped discriminating (expected a message containing "was dispatched downstream — an unfamiliar name must not be guessed into a handler")
FAIL
FAIL	irrlicht/core/internal/contracttesting	0.418s
FAIL

### ARM unknown ob2 (2xx): assertHookStatus2xx stops grading the status code
### mutated 1 site(s) in core/internal/contracttesting/hook_receiver.go  ==> RED
--- FAIL: TestUnknownEventObligation2_UnknownEventAnswers2xx (0.00s)
    unknown_hook_event_selftest_test.go:164: mutation "a receiver that answers an unrecognized event with a status code": the obligation reported nothing against a fixture that is wrong for it — either the fixture is no longer wrong, or the obligation has stopped discriminating (expected a message containing "status = 400, want 2xx")
FAIL
FAIL	irrlicht/core/internal/contracttesting	0.289s
FAIL

### ARM unknown ob3: assertUnknownCounted stops checking the per-name count
### mutated 1 site(s) in core/internal/contracttesting/unknown_hook_event.go  ==> RED
--- FAIL: TestUnknownEventObligation3_CountedPerAdapterAndName (0.00s)
    unknown_hook_event_selftest_test.go:188: mutation "a receiver that counts every unrecognized name under one collapsed key": the arm failed, but NOT on the obligation under test: wanted a message containing "arrived 3 times, counted 0 for adapter", got: event "IrrUnk571dd6feStray" arrived once, counted 0 for adapter "contracttesting-selftest" — a second name must get its own key, or a rename is indistinguishable from a stray event
FAIL
FAIL	irrlicht/core/internal/contracttesting	0.425s
FAIL

### ARM unknown ob4: assertUnknownReportedOnce stops checking the once-per-name log
### mutated 1 site(s) in core/internal/contracttesting/unknown_hook_event.go  ==> RED
--- FAIL: TestUnknownEventObligation4_ReportedOncePerDistinctName (0.00s)
    unknown_hook_event_selftest_test.go:208: mutation "a receiver that reports every arrival of an unrecognized name rather than every distinct name": the arm failed, but NOT on the obligation under test: wanted a message containing "arrived 5 times and produced 6 log line(s), want exactly 1", got: event "IrrUnk68724f6c02Second" arrived once and produced 2 log line(s), want exactly 1 — every distinct name is reported, not only the first one ever seen
        lines:
        [info] selftest-hook-receiver : ignored unrecognized hook event "IrrUnk68724f6c01Flood"
        [error] selftest-hook-receiver : unrecognized hook event "IrrUnk68724f6c01Flood" from contracttesting-selftest: ignored, answered 2xx. Further occurrences of this name are counted, not logged — an upstream event rename looks exactly like this, so check the count in the diagnostics bundle's hooks.json before dismissing it.
        [info] selftest-hook-receiver : ignored unrecognized hook event "IrrUnk68724f6c01Flood"
        [info] selftest-hook-receiver : ignored unrecognized hook event "IrrUnk68724f6c01Flood"
        [info] selftest-hook-receiver : ignored unrecognized hook event "IrrUnk68724f6c01Flood"
        [info] selftest-hook-receiver : ignored unrecognized hook event "IrrUnk68724f6c01Flood"
        [info] selftest-hook-receiver : ignored unrecognized hook event "IrrUnk68724f6c02Second"
        [error] selftest-hook-receiver : unrecognized hook event "IrrUnk68724f6c02Second" from contracttesting-selftest: ignored, answered 2xx. Further occurrences of this name are counted, not logged — an upstream event rename looks exactly like this, so check the count in the diagnostics bundle's hooks.json before dismissing it.
FAIL
FAIL	irrlicht/core/internal/contracttesting	0.394s
FAIL

### ARM receipt ob1+ob2: assertReceiptCounted stops checking the receipt delta
### mutated 1 site(s) in core/internal/contracttesting/hook_receipt.go  ==> RED
--- FAIL: TestReceiptObligation1_RecognizedEventCountsOne (0.00s)
    hook_receipt_selftest_test.go:99: mutation "a receiver that never calls hookjson.ObserveHookReceipt": the obligation reported nothing against a fixture that is wrong for it — either the fixture is no longer wrong, or the obligation has stopped discriminating (expected a message containing "added 0 receipts for adapter")
--- FAIL: TestReceiptObligation2_UnrecognizedEventCountsToo (0.00s)
    hook_receipt_selftest_test.go:124: mutation "a receiver that counts a receipt only for event names it recognizes": the obligation reported nothing against a fixture that is wrong for it — either the fixture is no longer wrong, or the obligation has stopped discriminating (expected a message containing "event \"IrrReceiptUnknownEvent\" added 0 receipts for adapter")
FAIL
FAIL	irrlicht/core/internal/contracttesting	0.399s
FAIL

### ARM receipt ob3: assertReceiptCountedOutOfTree stops checking the refused-path receipt
### mutated 1 site(s) in core/internal/contracttesting/hook_receipt.go  ==> RED
--- FAIL: TestReceiptObligation3_ConfinementRejectedRequestCountsToo (0.00s)
    hook_receipt_selftest_test.go:143: mutation "a receiver that counts a receipt only once the path has survived confinement": the obligation reported nothing against a fixture that is wrong for it — either the fixture is no longer wrong, or the obligation has stopped discriminating (expected a message containing "a path-refused request added 0 receipts for adapter")
FAIL
FAIL	irrlicht/core/internal/contracttesting	0.373s
FAIL

### ARM receipt ob4: assertDeniedNotCounted stops checking that a denied request counts nothing
### mutated 1 site(s) in core/internal/contracttesting/hook_receipt.go  ==> RED
--- FAIL: TestReceiptObligation4_ConsentDeniedRequestIsNotCounted (0.00s)
    hook_receipt_selftest_test.go:168: mutation "a receiver that counts the receipt before the consent gate it is meant to sit behind": the obligation reported nothing against a fixture that is wrong for it — either the fixture is no longer wrong, or the obligation has stopped discriminating (expected a message containing "a consent-denied request added 1 receipts for adapter")
FAIL
FAIL	irrlicht/core/internal/contracttesting	4.113s
FAIL

=== SUMMARY ===
RED                    ARM unknown ob1 (dispatch): assertKnownEventUncounted stops checking the recognized event dispatched
RED                    ARM unknown ob1 (counter): assertKnownEventUncounted stops checking the recognized event was counted by nobody
RED                    ARM unknown ob2 (dispatch): assertUnknownIgnored stops checking that nothing was dispatched
RED                    ARM unknown ob2 (2xx): assertHookStatus2xx stops grading the status code
RED                    ARM unknown ob3: assertUnknownCounted stops checking the per-name count
RED                    ARM unknown ob4: assertUnknownReportedOnce stops checking the once-per-name log
RED                    ARM receipt ob1+ob2: assertReceiptCounted stops checking the receipt delta
RED                    ARM receipt ob3: assertReceiptCountedOutOfTree stops checking the refused-path receipt
RED                    ARM receipt ob4: assertDeniedNotCounted stops checking that a denied request counts nothing
```

### The seam walk

```
### SEAM rule 1: a new non-test function takes a *testing.T first
### mutated 1 site(s) in core/internal/contracttesting/hook_receiver.go  ==> RED
--- FAIL: TestEveryTestingTHolderIsAnEntryPointOrDeferred (0.01s)
    seam_walk_test.go:305: selfTestProbeUngatedArm (hook_receiver.go:47) takes a *testing.T as its first parameter, so it reports through a channel no negative self-test can swap. Take a reporter (or armT, if it also builds fixture state), or name it in deferredToTheSeam with the reason it cannot
FAIL
FAIL	irrlicht/core/internal/contracttesting	0.653s
FAIL

### SEAM rule 1: an exemption is dropped from deferredToTheSeam
### mutated 1 site(s) in core/internal/contracttesting/seam_walk_test.go  ==> RED
--- FAIL: TestEveryTestingTHolderIsAnEntryPointOrDeferred (0.01s)
    seam_walk_test.go:303: mkSubdir (hook_receiver.go:49) takes a *testing.T as its first parameter, so it reports through a channel no negative self-test can swap. Take a reporter (or armT, if it also builds fixture state), or name it in deferredToTheSeam with the reason it cannot
FAIL
FAIL	irrlicht/core/internal/contracttesting	0.274s
FAIL

### SEAM rule 1: an exemption stops naming a real function (stale entry)
### mutated 1 site(s) in core/internal/contracttesting/seam_walk_test.go  ==> RED
--- FAIL: TestEveryTestingTHolderIsAnEntryPointOrDeferred (0.01s)
    seam_walk_test.go:316: deferredToTheSeam names "aFunctionThatNoLongerExists", which no longer takes a *testing.T first (or no longer exists) — remove the entry rather than leaving an exemption that exempts nothing
FAIL
FAIL	irrlicht/core/internal/contracttesting	0.265s
FAIL

### SEAM rule 2: a new arm that no test drives
### mutated 1 site(s) in core/internal/contracttesting/hook_receiver.go  ==> RED
--- FAIL: TestEveryArmIsDrivenByATest (0.01s)
    seam_walk_test.go:376: arm selfTestProbeUndrivenArm (hook_receiver.go:47) is reached by no _test.go in this package except through an exported Assert… entry point. Its family has a vacuity guard but no negative self-test, so nothing anywhere demonstrates the obligation can fail (#1453, #1479)
FAIL
FAIL	irrlicht/core/internal/contracttesting	0.280s
FAIL

### SEAM rule 2: coverage stops skipping exported entry points (a vacuity guard would count as a self-test)
### mutated 1 site(s) in core/internal/contracttesting/seam_walk_test.go  ==> RED
--- FAIL: TestSeamWalkCoverageCorpus (0.00s)
    --- FAIL: TestSeamWalkCoverageCorpus/an_arm_reached_ONLY_through_an_exported_entry_point_is_NOT_covered_—_a_family_with_a_vacuity_guard_and_no_negative_self-test (0.00s)
        seam_walk_corpus_test.go:252: arm "armA" covered = true, want false
FAIL
FAIL	irrlicht/core/internal/contracttesting	0.260s
FAIL

### SEAM detector: firstParamType reads the LAST parameter instead of the first
### mutated 1 site(s) in core/internal/contracttesting/seam_walk_test.go  ==> RED
--- FAIL: TestSeamWalkCorpus (0.00s)
    --- FAIL: TestSeamWalkCorpus/with_trailing_params (0.00s)
        seam_walk_corpus_test.go:130: firstParamType = "string", want "*testing.T"
        seam_walk_corpus_test.go:133: seamRole = "", want "testing-T" — this is the verdict rule 1 and rule 2 consume, and pinning only the type render above is what hid testing.TB's absence from the case list
    --- FAIL: TestSeamWalkCorpus/variadic_tail (0.00s)
        seam_walk_corpus_test.go:130: firstParamType = "...string", want "*testing.T"
        seam_walk_corpus_test.go:133: seamRole = "", want "testing-T" — this is the verdict rule 1 and rule 2 consume, and pinning only the type render above is what hid testing.TB's absence from the case list
    --- FAIL: TestSeamWalkCorpus/*testing.T_in_SECOND_position (0.00s)
        seam_walk_corpus_test.go:130: firstParamType = "*testing.T", want "string"
        seam_walk_corpus_test.go:133: seamRole = "testing-T", want "" — this is the verdict rule 1 and rule 2 consume, and pinning only the type render above is what hid testing.TB's absence from the case list
FAIL
FAIL	irrlicht/core/internal/contracttesting	0.380s
FAIL

### SEAM: the walk reads no non-test files at all (a parse that finds nothing passes every rule)
### mutated 1 site(s) in core/internal/contracttesting/seam_walk_test.go  ==> RED
--- FAIL: TestEveryTestingTHolderIsAnEntryPointOrDeferred (0.01s)
    seam_walk_test.go:289: the walk read false non-test and true test files — a parse that finds nothing satisfies every rule below
--- FAIL: TestEveryArmIsDrivenByATest (0.01s)
    seam_walk_test.go:365: the walk read false non-test and true test files — a parse that finds nothing satisfies every rule below
FAIL
FAIL	irrlicht/core/internal/contracttesting	0.317s
FAIL

### SEAM rule 1: testing.TB dropped from the case list (a TB-first arm is equally unswappable)
### mutated 1 site(s) in core/internal/contracttesting/seam_walk_test.go  ==> RED
--- FAIL: TestSeamWalkCorpus (0.00s)
    --- FAIL: TestSeamWalkCorpus/the_TB_interface_—_unswappable,_so_rule_1_owns_it_too (0.00s)
        seam_walk_corpus_test.go:133: seamRole = "", want "testing-T" — this is the verdict rule 1 and rule 2 consume, and pinning only the type render above is what hid testing.TB's absence from the case list
FAIL
FAIL	irrlicht/core/internal/contracttesting	0.355s
FAIL

### SEAM rule 2: the mustReport clause dropped (being NAMED by a positive test counts as driven)
### mutated 1 site(s) in core/internal/contracttesting/seam_walk_test.go  ==> RED
--- FAIL: TestParseSeamFactsSeedsOnlyFromDrivingTestFiles (0.01s)
    seam_walk_test.go:354: "referenceBeaconHome" was seeded from a test file that never calls mustReport — being NAMED by a positive test is not being DRIVEN by a negative one, and treating it as such is what let a family's deleted self-tests pass rule 2
FAIL
FAIL	irrlicht/core/internal/contracttesting	0.271s
FAIL

### SEAM: the mustReport-clause probe names a symbol that does not exist (its own vacuity guard)
### mutated 1 site(s) in core/internal/contracttesting/seam_walk_test.go  ==> RED
--- FAIL: TestParseSeamFactsSeedsOnlyFromDrivingTestFiles (0.01s)
    seam_walk_test.go:353: the probe symbol "aSymbolNobodyDeclares" is no longer declared in any _test.go — pick another symbol that a positive-test file declares, or this assertion checks nothing
FAIL
FAIL	irrlicht/core/internal/contracttesting	0.288s
FAIL

=== SUMMARY ===
RED                    SEAM rule 1: a new non-test function takes a *testing.T first
RED                    SEAM rule 1: an exemption is dropped from deferredToTheSeam
RED                    SEAM rule 1: an exemption stops naming a real function (stale entry)
RED                    SEAM rule 2: a new arm that no test drives
RED                    SEAM rule 2: coverage stops skipping exported entry points (a vacuity guard would count as a self-test)
RED                    SEAM detector: firstParamType reads the LAST parameter instead of the first
RED                    SEAM: the walk reads no non-test files at all (a parse that finds nothing passes every rule)
RED                    SEAM rule 1: testing.TB dropped from the case list (a TB-first arm is equally unswappable)
RED                    SEAM rule 2: the mustReport clause dropped (being NAMED by a positive test counts as driven)
RED                    SEAM: the mustReport-clause probe names a symbol that does not exist (its own vacuity guard)
```

## Review + simplify

A `high`-effort review subagent returned 8 findings; **all 8 applied**, including two guard-strength ones it proved by mutation: rule 2 was satisfied by an arm merely being *named* (it deleted a family's four self-tests and the rule still passed), and `testing.TB` sat in the corpus's must-NOT-flag block, so the rule's biggest hole came with an approved spelling. A 4-agent `/simplify` pass followed; the reuse/simplification/altitude findings taken are folded in (shared `receiverFamily` drive/silence pair, `types.ExprString`, one parse instead of two, `json.Marshal` for the payload, exported `MaxUnknownEventNames`). The efficiency angle reported nothing actionable (+146 ms on a 39 s core suite).

**Found but not fixed** — recorded rather than silently dropped:
- Each obligation's *fixture construction* is stated twice: once in the contract's `t.Run` bodies, once in the self-test's builder table. The vacuity guard catches drift in one direction only. Sharing one obligation table between them would fix it but moves fixture construction into the production files and costs the contract's readability for adapter authors.
- Nothing checks that every committed `receiverBreak` knob is still spent — the symmetric hole to rule 2, one notch lower.
- The three family descriptor structs are 5/7 identical; an embedded base would touch every adapter's wiring, out of scope here.

## Locks (pass by construction — NOT red-first evidence)

- The four real receivers' existing wirings of all three families. Their green proves the arm refactor is behaviour-preserving, and that is all it proves.
- The other four families' self-tests, untouched by this PR.

## Verification

`tools/preflight.sh` chunked: `go`, `arch`, `tools`, `skills`, `posix`, `security` — all PASS. Plus `-race -count=1` and `-count=12` over the package. No `web/` tree is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
