### PR TITLE
fix(processlifecycle): admit a session whose ancestry walk could not be read

### DIFF
--- a/core/adapters/inbound/agents/processlifecycle/osutil_darwin.go
+++ b/core/adapters/inbound/agents/processlifecycle/osutil_darwin.go
@@ -190,8 +190,7 @@ func resolveHostBundleIDFromAncestry(pid int) (bundleID string, hostPID int, com
 // It honours the completeness bit both walks report (#1492) and fails OPEN on a
 // walk that could not be completed (#1513). An aborted walk and a genuine miss
 // both resolve to "", and they are different facts: the second is the #784
-// evidence itself, the first is no evidence at all — every abort is a
-// readProcInfo failure, which on a loaded machine is that helper's 2s ceiling.
+// evidence itself, the first is no evidence at all.
 //
 // The direction is the opposite of #1492's for the same bit, because this call
 // site is an ADMISSION gate rather than a click target: a false answer here does
@@ -206,17 +205,49 @@ func resolveHostBundleIDFromAncestry(pid int) (bundleID string, hostPID int, com
 //
 // A COMPLETED walk that found no allow-listed host still rejects: that is #784
 // and it is unchanged.
+//
+// "Complete" is exactly "no readProcInfo call failed", which is narrower than
+// "every probe in the walk was answered": resolveHostBundleIDFromAncestry also
+// shells out to plutil via bundleIDForAppPath, and a plutil that blows its own
+// 2s ceiling yields an empty bundle id indistinguishable from an ancestor that
+// is not an app at all. That residue is #1524, not something this bit reports.
 func IsKnownInteractiveHost(pid int) bool {
-	// Short-circuit before the second ancestry walk: resolveHostFromAncestry
-	// and resolveHostBundleIDFromAncestry each independently re-walk the same
-	// parent chain via their own ps shellouts, so skip the bundle-ID walk
-	// entirely once the curated map already matched — and equally once the
-	// first walk aborted, since the second re-walks that same unreadable chain
-	// and cannot reach a verdict the first could not.
-	term, _, complete := resolveHostFromAncestry(pid)
+	return isKnownInteractiveHostVia(pid, resolveHostFromAncestry, resolveHostBundleIDFromAncestry)
+}
+
+// ancestryWalk is the shape resolveHostFromAncestry and
+// resolveHostBundleIDFromAncestry share: a host string, the PID it was found
+// at, and whether the walk reached its verdict rather than aborting.
+type ancestryWalk func(pid int) (host string, hostPID int, complete bool)
+
+// isKnownInteractiveHostVia is IsKnownInteractiveHost with both walks injected,
+// so the ORDER between them is testable — the pure isKnownInteractiveHostFrom
+// below cannot see it, and no arrangement of live processes can drive the two
+// walks to different verdicts on purpose.
+//
+// The `complete` half of the short-circuit is load-bearing, not an
+// optimization, and the asymmetry between the two allow-lists is why: walk 1
+// recognizes every curated terminal and IDE by app name (termProgramByAppName),
+// while walk 2 recognizes exactly the hosts in knownEmbeddedHostBundleIDs —
+// today one entry, md.obsidian. So walk 2 can CONFIRM an embedded host and can
+// never rule out a curated one. Letting it answer alone after walk 1 aborted
+// would reject every iTerm, VS Code, kitty and JetBrains session whose first
+// walk timed out — #1513 again, one walk over, and the very sessions this gate
+// exists to admit.
+//
+// The consequence, stated plainly because it is the trade and not an accident:
+// a walk 1 that aborts TRANSIENTLY (its ps over the 2s ceiling, rather than an
+// unreadable process) admits without re-probing, where a second walk might have
+// completed and found CodexBar. That is the deliberate polarity — a re-probe
+// could only move the answer toward rejection, on evidence this gate has
+// already decided not to trust.
+func isKnownInteractiveHostVia(pid int, walkTerm, walkBundle ancestryWalk) bool {
+	term, _, complete := walkTerm(pid)
 	bundleID := ""
 	if term == "" && complete {
-		bundleID, _, complete = resolveHostBundleIDFromAncestry(pid)
+		// Only reached when walk 1 ran to a verdict, so this also skips the
+		// duplicate ps shellouts whenever the curated map already matched.
+		bundleID, _, complete = walkBundle(pid)
 	}
 	return isKnownInteractiveHostFrom(term, bundleID, complete)
 }

--- a/core/adapters/inbound/agents/processlifecycle/osutil_darwin.go
+++ b/core/adapters/inbound/agents/processlifecycle/osutil_darwin.go
@@ -187,27 +187,51 @@ func resolveHostBundleIDFromAncestry(pid int) (bundleID string, hostPID int, com
 // but isn't a curated terminal/IDE and isn't in knownEmbeddedHostBundleIDs
 // returns false — which is exactly what excludes CodexBar.
 //
-// It discards the completeness bit resolveHostFromAncestry reports (#1492): a
-// `ps` that blows its ceiling here returns false, which REJECTS a session
-// rather than degrading a click target. Tracked separately — changing an
-// admission gate's failure direction is its own decision — as #1513.
+// It honours the completeness bit both walks report (#1492) and fails OPEN on a
+// walk that could not be completed (#1513). An aborted walk and a genuine miss
+// both resolve to "", and they are different facts: the second is the #784
+// evidence itself, the first is no evidence at all — every abort is a
+// readProcInfo failure, which on a loaded machine is that helper's 2s ceiling.
+//
+// The direction is the opposite of #1492's for the same bit, because this call
+// site is an ADMISSION gate rather than a click target: a false answer here does
+// not degrade an enrichment, it declines a legitimate session outright. It
+// declines it permanently, too — SessionDetector caches the rejection in
+// hostGateRejected, checks that cache ahead of the gate, and never evicts from
+// it — so one slow `ps` cost the user a session for the lifetime of the daemon.
+// Failing open is what core/pkg/cliversion already does for a CLI version it
+// cannot read, what PIDManager.AllowsSession (this function's only caller)
+// already does for a PID it cannot discover, and what this function's own
+// linux/other stubs already do unconditionally.
+//
+// A COMPLETED walk that found no allow-listed host still rejects: that is #784
+// and it is unchanged.
 func IsKnownInteractiveHost(pid int) bool {
 	// Short-circuit before the second ancestry walk: resolveHostFromAncestry
 	// and resolveHostBundleIDFromAncestry each independently re-walk the same
 	// parent chain via their own ps shellouts, so skip the bundle-ID walk
-	// entirely once the curated map already matched.
-	term, _, _ := resolveHostFromAncestry(pid)
-	if term != "" {
-		return true
+	// entirely once the curated map already matched — and equally once the
+	// first walk aborted, since the second re-walks that same unreadable chain
+	// and cannot reach a verdict the first could not.
+	term, _, complete := resolveHostFromAncestry(pid)
+	bundleID := ""
+	if term == "" && complete {
+		bundleID, _, complete = resolveHostBundleIDFromAncestry(pid)
 	}
-	bundleID, _, _ := resolveHostBundleIDFromAncestry(pid)
-	return isKnownInteractiveHostFrom(term, bundleID)
+	return isKnownInteractiveHostFrom(term, bundleID, complete)
 }
 
 // isKnownInteractiveHostFrom is the pure decision behind IsKnownInteractiveHost,
 // split out so the allow-list logic can be tested with synthetic ancestry
 // results instead of depending on whatever launched the test binary.
-func isKnownInteractiveHostFrom(termProgram, bundleID string) bool {
+//
+// complete is checked first and on its own: when the walk aborted, termProgram
+// and bundleID are "" for a reason that says nothing about the host, so reading
+// the allow-list at all would be reading a value that was never observed.
+func isKnownInteractiveHostFrom(termProgram, bundleID string, complete bool) bool {
+	if !complete {
+		return true
+	}
 	return termProgram != "" || knownEmbeddedHostBundleIDs[bundleID]
 }
 

--- a/core/adapters/inbound/agents/processlifecycle/osutil_darwin_test.go
+++ b/core/adapters/inbound/agents/processlifecycle/osutil_darwin_test.go
@@ -759,6 +759,64 @@ func TestIsKnownInteractiveHost_AbortedWalkAdmits(t *testing.T) {
 	}
 }
 
+// TestIsKnownInteractiveHostVia_AbortedFirstWalkDoesNotDeferToTheSecond pins
+// the ORDER between the two walks, which neither the pure decision nor any
+// arrangement of live processes can reach: driving the two walks to DIFFERENT
+// verdicts on purpose needs them injected, because in a live chain a `ps` that
+// fails for one walk fails for the other.
+//
+// It exists because the `&& complete` clause looks like an optimization and is
+// not. The two allow-lists are asymmetric — walk 1 knows 27 curated terminals
+// and IDEs by app name, walk 2 knows whatever is in knownEmbeddedHostBundleIDs
+// (today: md.obsidian alone) — so walk 2 can confirm an embedded host and can
+// never rule out a curated one. Row 1 is the case that costs: walk 1 aborted
+// and walk 2 completed on an iTerm ancestor, and iTerm's BUNDLE id is not in
+// walk 2's list because walk 1 is what recognizes iTerm. Deferring to walk 2
+// there rejects a legitimate iTerm session — #1513 arriving through the
+// second walk.
+func TestIsKnownInteractiveHostVia_AbortedFirstWalkDoesNotDeferToTheSecond(t *testing.T) {
+	walk := func(host string, complete bool) ancestryWalk {
+		return func(int) (string, int, bool) { return host, 0, complete }
+	}
+	const (
+		aborted  = false
+		finished = true
+	)
+	tests := []struct {
+		name            string
+		term, bundle    ancestryWalk
+		wantInteractive bool
+	}{
+		{
+			"walk 1 aborted, walk 2 saw iTerm — whose bundle only walk 1 can vouch for",
+			walk("", aborted), walk("com.googlecode.iterm2", finished), true,
+		},
+		{
+			"walk 1 aborted, walk 2 saw CodexBar — a re-probe could only reject, and that is evidence we declined to trust",
+			walk("", aborted), walk("com.steipete.codexbar", finished), true,
+		},
+		{
+			"walk 1 finished and missed, walk 2 saw CodexBar — #784, and the vacuity guard",
+			walk("", finished), walk("com.steipete.codexbar", finished), false,
+		},
+		{
+			"walk 1 finished and missed, walk 2 saw Obsidian — the one host walk 2 does vouch for",
+			walk("", finished), walk("md.obsidian", finished), true,
+		},
+		{
+			"walk 1 matched, so walk 2 is never consulted",
+			walk("iTerm.app", finished), walk("com.steipete.codexbar", finished), true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isKnownInteractiveHostVia(4242, tc.term, tc.bundle); got != tc.wantInteractive {
+				t.Errorf("isKnownInteractiveHostVia = %v, want %v", got, tc.wantInteractive)
+			}
+		})
+	}
+}
+
 // TestIsKnownInteractiveHost_ReadVerdictStillExcludes is the #784 LOCK, and it
 // is what stops the fix above from being spelled `return true`. A walk that RAN
 // and found no curated terminal and no allow-listed embedded host — the shape

--- a/core/adapters/inbound/agents/processlifecycle/osutil_darwin_test.go
+++ b/core/adapters/inbound/agents/processlifecycle/osutil_darwin_test.go
@@ -329,23 +329,31 @@ func TestResolveTermProgramFromAncestry_Self(t *testing.T) {
 // synthetic ancestry results — no live process chain needed — so the CodexBar
 // exclusion (#784) and the Obsidian carve-out (#728) are both deterministic,
 // not dependent on whatever happens to have launched `go test`.
+//
+// The last two rows are the same pair of facts as the two live-process tests
+// further down, restated at the pure layer: the empty ancestry means "read, and
+// nothing there" when complete and "not read" when not, and only the second
+// admits (#1513). Every other row carries complete=true, which is what keeps
+// the fail-open arm from swallowing the allow-list.
 func TestIsKnownInteractiveHostFrom(t *testing.T) {
 	tests := []struct {
 		name                 string
 		termProgram          string
 		bundleID             string
+		complete             bool
 		wantKnownInteractive bool
 	}{
-		{"curated terminal", "iTerm.app", "", true},
-		{"curated IDE", "vscode", "", true},
-		{"obsidian via generic top-level-app fallback", "", "md.obsidian", true},
-		{"codexbar is a real .app but not allow-listed", "", "com.steipete.codexbar", false},
-		{"no ancestry resolved at all", "", "", false},
+		{"curated terminal", "iTerm.app", "", true, true},
+		{"curated IDE", "vscode", "", true, true},
+		{"obsidian via generic top-level-app fallback", "", "md.obsidian", true, true},
+		{"codexbar is a real .app but not allow-listed", "", "com.steipete.codexbar", true, false},
+		{"no ancestry resolved at all", "", "", true, false},
+		{"aborted walk resolved nothing and proves nothing", "", "", false, true},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := isKnownInteractiveHostFrom(tc.termProgram, tc.bundleID); got != tc.wantKnownInteractive {
-				t.Errorf("isKnownInteractiveHostFrom(%q, %q) = %v, want %v", tc.termProgram, tc.bundleID, got, tc.wantKnownInteractive)
+			if got := isKnownInteractiveHostFrom(tc.termProgram, tc.bundleID, tc.complete); got != tc.wantKnownInteractive {
+				t.Errorf("isKnownInteractiveHostFrom(%q, %q, complete=%v) = %v, want %v", tc.termProgram, tc.bundleID, tc.complete, got, tc.wantKnownInteractive)
 			}
 		})
 	}

--- a/core/adapters/inbound/agents/processlifecycle/osutil_darwin_test.go
+++ b/core/adapters/inbound/agents/processlifecycle/osutil_darwin_test.go
@@ -732,6 +732,45 @@ func TestResolveHostBundleIDFromAncestry_UnreadableProcessIsNotAMiss(t *testing.
 	}
 }
 
+// TestIsKnownInteractiveHost_AbortedWalkAdmits is #1513's defect test, and it
+// is the two tests above carried up to the caller that acts on their verdict.
+// Both rows resolve no host at all; the completeness bit is the only thing
+// separating them.
+//
+// A reaped PID's first readProcInfo fails, which is the branch a `ps` that
+// blows its 2s ceiling under load takes. Before #1513 that returned false, and
+// because this function gates session ADMISSION (#784) the result was that a
+// legitimate agent session was silently declined — not, as in #1492, that a
+// click target degraded. An unreadable probe is no evidence either way, so it
+// fails OPEN: the direction core/pkg/cliversion already takes for a CLI version
+// it cannot read, and the direction this very function's linux/other stubs
+// already take by returning true unconditionally.
+func TestIsKnownInteractiveHost_AbortedWalkAdmits(t *testing.T) {
+	if !IsKnownInteractiveHost(exitedPID(t)) {
+		t.Error("a walk that could not be completed is not evidence of a non-interactive host — it must not reject the session")
+	}
+}
+
+// TestIsKnownInteractiveHost_ReadVerdictStillExcludes is the #784 LOCK, and it
+// is what stops the fix above from being spelled `return true`. A walk that RAN
+// and found no curated terminal and no allow-listed embedded host — the shape
+// CodexBar's background `agy` process presents — is a real answer, and must
+// still exclude.
+//
+// The two rows leave the walk by different exits, so neither can stand in for
+// the other: launchd never enters the loop at all (`cur > 1` is false
+// immediately), while a reparented orphan enters it and leaves through the
+// `ppid <= 1` verdict — the arm every reparented and every tmux-hosted
+// candidate takes.
+func TestIsKnownInteractiveHost_ReadVerdictStillExcludes(t *testing.T) {
+	if IsKnownInteractiveHost(1) {
+		t.Error("launchd is readable and is not an interactive host — a completed walk that found nothing must still exclude (#784)")
+	}
+	if orphan := orphanPID(t); IsKnownInteractiveHost(orphan) {
+		t.Errorf("orphan %d was read and has no host ancestor — a completed in-loop walk must still exclude (#784)", orphan)
+	}
+}
+
 // envObserver is a ProcessObserver that answers EnvOf from a fixed map. It
 // exists to reach one block of applyAncestryFallbacks that no live process can
 // be arranged into: the kitty back-fill, which runs only when the env NAMES


### PR DESCRIPTION
Closes #1513.

`IsKnownInteractiveHost` discarded the completeness bit both ancestry walks
report since #1492 (PR #1510), **while gating session admission**. An aborted
walk and a completed walk that found nothing both resolve to `""`, so a `ps`
over its 2s ceiling on a loaded machine answered `false` — and `false` here does
not degrade a click target, it declines a legitimate session.

## The direction is the whole decision, and it is the opposite of #1492's

#1492 stopped an unreadable client producing an authoritative *"detached"* — a
false **negative** about a host. Here an unreadable ancestry produced a
**rejection**, so it fails **open** instead.

**darwin really was the outlier — checked, not assumed.** Three independent
precedents already fail open on a probe that could not run, and darwin
disagreed with all three:

1. **`core/pkg/cliversion`** — AGENTS.md: "an unknown or unparseable version
   fails open … only a version successfully read AND parsed AND found below the
   floor blocks an install."
2. **This function's own non-darwin stubs**, verbatim in both
   `osutil_linux.go:61` and `osutil_other.go:34`: *"other platforms fail open …
   failing closed here would reject every antigravity CLI session on this
   platform instead."*
3. **Its only production caller.** `PIDManager.AllowsSession`
   (`core/application/services/pid_manager.go:270`) is the sole call site
   (`core/cmd/irrlichd/startup.go:808` wires it), and it already fails open three
   times over for "I could not look" — no discoverer, no PID found, no gate
   installed. Its own doc says so: *"No PID found yet fails open — discovery is
   best-effort … a rare timing race must not block a legitimate session
   forever."* The darwin implementation was the one link in that chain that
   answered "I could not look" with "reject".

## The blast radius is worse than the issue states (verified while investigating)

The rejection is **permanent, not per-sweep**. `SessionDetector.admitHost`
caches it in `hostGateRejected` (`session_detector_activity.go:221`),
`admitNewSession` checks that cache **unconditionally, ahead of the gate**
(`:135`), and **nothing anywhere deletes from it** (`grep -rn
"delete(d.hostGateRejected" core/` → no matches). So one slow `ps` cost the user
that session for the lifetime of the daemon, with no retry.

## The fix

The bit was already available; only the call site discarded it.

```go
term, _, complete := walkTerm(pid)
bundleID := ""
if term == "" && complete {
	bundleID, _, complete = walkBundle(pid)
}
return isKnownInteractiveHostFrom(term, bundleID, complete)
```

with `complete` checked first and alone in the pure decision, because when the
walk aborted the other two arguments are `""` for a reason that says nothing
about the host. **A completed walk that finds no allow-listed host still
rejects — #784 is unchanged.**

Scope held to the call site named in the issue. `ReadLauncherEnv` /
`captureLauncher` still ignore the bit deliberately, for the reason recorded at
`pid_manager.go:293` (a first capture has no stored host to protect); untouched.

### The `&& complete` clause is load-bearing, and the first version of this PR said otherwise

Worth reading even though it ends in a small diff, because the first version of
this PR shipped the wrong reason for it and disclosed a green mutation as
acceptable.

The original comment claimed walk 2 "cannot reach a verdict the first could
not", so the clause was pure efficiency. **That is false**, and the review
caught it: the two walks are independent `ps` shellouts issued at different
moments, so a *transient* timeout — precisely this PR's failure mode — can abort
walk 1 while walk 2 completes.

Chasing that down showed the clause matters in the **opposite** direction to
both the original comment and the review's own reading. The two allow-lists are
asymmetric:

| | recognizes | how many |
|---|---|---|
| walk 1 `resolveHostFromAncestry` | `termProgramByAppName`, by app name | **27** — iTerm, Terminal, VS Code, Cursor, Ghostty, kitty, Zed, every JetBrains IDE, … |
| walk 2 `resolveHostBundleIDFromAncestry` | `knownEmbeddedHostBundleIDs`, by bundle id | **1** — `md.obsidian` |

So walk 2 can *confirm* an embedded host and can never *rule out* a curated one.
Deferring to it after walk 1 aborted rejects every iTerm / VS Code / kitty /
JetBrains session whose first walk timed out — #1513 again, one walk over, hitting
the exact sessions this gate exists to admit.

Both walks are now injected (`isKnownInteractiveHostVia`) so the **order** is
testable, which no arrangement of live processes can be: in a real chain, a `ps`
that fails for one walk fails for the other. The comment now states the real
trade instead of a false one — a re-probe could only move the answer toward
rejection, on evidence this gate has already decided not to trust.

## Red-first evidence (verbatim)

`TestIsKnownInteractiveHost_AbortedWalkAdmits`, run at `911c256e` — test
present, fix absent:

```
=== RUN   TestIsKnownInteractiveHost_AbortedWalkAdmits
    osutil_darwin_test.go:750: a walk that could not be completed is not evidence of a non-interactive host — it must not reject the session
--- FAIL: TestIsKnownInteractiveHost_AbortedWalkAdmits (0.01s)
=== RUN   TestIsKnownInteractiveHost_ReadVerdictStillExcludes
--- PASS: TestIsKnownInteractiveHost_ReadVerdictStillExcludes (0.02s)
FAIL
FAIL	irrlicht/core/adapters/inbound/agents/processlifecycle	0.752s
FAIL
```

The `-run` filter was confirmed to select exactly those two tests (two `=== RUN`
lines, both named) before the result was read as evidence.

`TestIsKnownInteractiveHost_ReadVerdictStillExcludes` is a **LOCK**, not a
red-first proof: it pins #784 and passes on `main` by construction. Its green
above is expected and proves nothing on its own — which is what the mutations
are for.

## Mutations seen red

Each applied at exactly one site (the harness refuses at 0 sites), reverted by
file copy, `git status --porcelain` empty after each.

**M1 — spell the fix `return true` (defeat #784 entirely).** The lock fires:

```
--- FAIL: TestIsKnownInteractiveHostFrom (0.00s)
    --- FAIL: TestIsKnownInteractiveHostFrom/codexbar_is_a_real_.app_but_not_allow-listed (0.00s)
    --- FAIL: TestIsKnownInteractiveHostFrom/no_ancestry_resolved_at_all (0.00s)
--- FAIL: TestIsKnownInteractiveHost_ReadVerdictStillExcludes (0.02s)
FAIL
```

**M2 — flip the new arm back to fail-closed (`!complete → false`).**

```
--- FAIL: TestIsKnownInteractiveHostFrom (0.00s)
    --- FAIL: TestIsKnownInteractiveHostFrom/aborted_walk_resolved_nothing_and_proves_nothing (0.00s)
--- FAIL: TestIsKnownInteractiveHost_AbortedWalkAdmits (0.01s)
FAIL
```

**M3 — keep the pure function correct but discard the bit at the CALL SITE**
(the literal pre-#1513 wiring, passing `true`). This proves the wiring is
covered and not merely the pure function:

```
--- FAIL: TestIsKnownInteractiveHost_AbortedWalkAdmits (0.01s)
FAIL
```

**M4 — drop `&& complete` so walk 2 always runs.** This is the one that was
**GREEN in the first version of this PR** and was disclosed as an acceptable
"unobservable optimization". It is not; see above. After the seam and its test:

```
--- FAIL: TestIsKnownInteractiveHostVia_AbortedFirstWalkDoesNotDeferToTheSecond (0.00s)
    --- FAIL: .../walk_1_aborted,_walk_2_saw_iTerm_—_whose_bundle_only_walk_1_can_vouch_for (0.00s)
    --- FAIL: .../walk_1_aborted,_walk_2_saw_CodexBar_—_a_re-probe_could_only_reject,_and_that_is_evidence_we_declined_to_trust (0.00s)
FAIL
```

**M5 — swap the two walks at the production call site.** Still **GREEN**, and
reported rather than papered over:

```
ok  	irrlicht/core/adapters/inbound/agents/processlifecycle	0.464s
```

A swap would be a real regression (the pure decision would read the bundle id as
if it were a `TERM_PROGRAM`, admitting *any* top-level app and defeating #784).
No test catches it. It is **not a hole this PR introduces**: the pre-#1513 code
inlined the same two calls and a swap there was equally invisible. Left as-is
deliberately rather than grown a type-level guard — Go's assignability makes
distinct named func types no help here, and a keyword-struct wiring would make
the mistake harder to write without making the mutation red.

## Review findings and how each was resolved

The review subagent (medium effort) returned three findings; all three are
addressed.

1. **`bundleIDForAppPath`'s `plutil` timeout is reported as a completed miss.**
   Confirmed by tracing: `bid == ""` falls through indistinguishably from "this
   ancestor is not an app", so the walk returns `("", 0, true)` — the verdict
   that rejects. Pre-existing (it comes from #1492, not this diff) and one-sided
   (it only costs on the Obsidian path, the one place a bundle id admits).
   **Filed as #1524**; the doc comment here no longer claims the bit covers it.
2. **The `&& complete` rationale was factually wrong.** Confirmed, and the
   investigation it prompted found the clause is load-bearing in the opposite
   direction. Comment rewritten, seam added, M4 now red — see above.
3. **"Filed separately" was unsupported — no such issue existed.** Correct, and
   exactly the AGENTS.md failure mode ("dismissals carry evidence"). Both
   follow-ups are now actually filed: **#1524** and **#1525**.

The review also independently reproduced M2, M3 and M4, and confirmed no
attacker-reachable path to induce an aborted walk: `complete=false` needs a
`readProcInfo` failure, and a CodexBar-hosted `agy` chain (`agy` → CodexBar →
launchd) is readable and stable. The one mundane path — the process exits
between the scanner's snapshot and the walk — is already admitted today by
`AllowsSession`'s `pid <= 0` arm, so it is not a new hole.

## Verification

`tools/preflight.sh` chunked in the foreground, all seven gates green: `go`
(incl. `core/...` + replay fixtures), `web`, `arch` (ARS composite
7.9326 → 7.9320, no category regression), `tools`, `skills`, `posix`,
`security`. The `go`, `arch` and `security` gates were re-run after the review
fixes. Plus `go build ./core/...` under both native and `GOOS=linux` (the stubs
compile against the unchanged exported signature), and
`go test ./core/adapters/inbound/agents/processlifecycle/
./core/application/services/ -race -count=1`.

No `TestFSWatcher_EmitsEventsForTranscriptCreateAndModify` flake was observed in
any run.

## Not fixed here

- **#1524** — `plutil` timeouts still read as completed misses.
- **#1525** — the gate remains unobservable in both directions, so the issue's
  own "**Unverified:** nothing measures how often the ancestry walk actually
  times out" is still unmeasured. Both this PR and #1524 are reasoned from
  source, not from measurement; that is stated as an assumption, not a check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
