### PR TITLE
fix(processlifecycle): memoize a herdr client non-answer as a non-answer

### DIFF
--- a/core/adapters/inbound/agents/processlifecycle/osutil.go
+++ b/core/adapters/inbound/agents/processlifecycle/osutil.go
@@ -79,10 +79,18 @@ func herdrClientLogPath(socketPath string) string {
 // launcher may ignore it, because there is nothing to clear and dropping the
 // read would cost the pane its herdr address.
 //
-// Never blocks longer than 2 seconds. Never prompts the user — on macOS we use
+// Never prompts the user — on macOS we use
 // `sysctl(kern.procargs2)` (no TCC prompt; `ps e` stopped exposing env on
 // modern macOS). On Linux we read /proc/<pid>/environ. Other platforms return
 // nil.
+//
+// It used to say "never blocks longer than 2 seconds" here. Every individual
+// shellout is bounded at 2s, but this function is not, and has not been since
+// the herdr indirection below: resolveClientHostIdentity loops over up to
+// maxClientCandidates candidates and each costs two ancestry walks plus a tty
+// `ps`, with the bundle-id walk paying a `plutil` per hop. The bound is a
+// COUNT, not a duration. Giving the loop one aggregate deadline is #1529;
+// until then no caller may assume a wall-clock ceiling here.
 func ReadLauncherEnv(pid int) (l *session.Launcher, hostKnown bool) {
 	if pid <= 0 {
 		return nil, false

--- a/core/adapters/inbound/agents/processlifecycle/osutil_darwin.go
+++ b/core/adapters/inbound/agents/processlifecycle/osutil_darwin.go
@@ -508,9 +508,35 @@ func herdrClientPIDs(socketPath string) (pids []int, probed bool) {
 	if !lsofProbeRan(err) {
 		return nil, false
 	}
-	pids = herdrClientWriters(string(out), os.Getpid())
+	return sortedDistinctPIDs(herdrClientWriters(string(out), os.Getpid())), true
+}
+
+// sortedDistinctPIDs sorts pids newest-attach-first and collapses repeats.
+//
+// The sort answers open question 3 of #1350; the dedup is what makes the
+// result a list of CLIENTS rather than of file descriptors. parseLsofFDs emits
+// one entry per FD row by design, so a client holding the client log on two
+// write handles is reported twice — and every consumer downstream treats the
+// list as one entry per client: resolveClientHostIdentity would run the same
+// two ancestry walks twice for it, and maxClientCandidates, whose doc says it
+// "bounds how many attached clients are probed", would count it twice against
+// the cap and so reach its truncation at three clients instead of five.
+//
+// Unobserved on herdr 0.8.0 — herdrClientPIDs' own doc records a live check
+// where two attached clients produced exactly two writers — so this is a
+// latent dependency on herdr's FD layout being one handle per client, not a
+// defect today. It is closed here rather than left standing because the cap's
+// truncation is one of the two triggers of #1514, and a duplicate is a way to
+// reach it that has nothing to do with how many clients are attached.
+func sortedDistinctPIDs(pids []int) []int {
 	sort.Sort(sort.Reverse(sort.IntSlice(pids)))
-	return pids, true
+	distinct := pids[:0]
+	for i, pid := range pids {
+		if i == 0 || pid != pids[i-1] {
+			distinct = append(distinct, pid)
+		}
+	}
+	return distinct
 }
 
 // lsofProbeRan reports whether an lsof invocation that returned err
@@ -641,36 +667,59 @@ func resolveClientHostIdentity(pids []int) (*session.Launcher, bool) {
 // Herdr fields and tests them first) rather than to any tmux/kitty identity
 // adopted from the client.
 //
-// Results are memoized briefly because every pane of one herdr server shares a
-// socket, and the startup seed resolves them back to back, synchronously: an
-// lsof scan costs ~0.3s on a quiet machine, so eight panes would otherwise pay
-// eight identical scans before the daemon starts serving.
+// Every outcome is memoized briefly, non-answers included, because every pane
+// of one herdr server shares a socket and both the startup seed and the
+// liveness sweep resolve them one after another, synchronously: an lsof scan
+// costs ~0.3s on a quiet machine, so eight panes would otherwise pay eight
+// identical scans before the daemon starts serving.
+//
+// Memoizing the non-answer REVERSES #1485's rule, which was "never memoize a
+// non-answer" on the grounds that "caching 'unknown' would spread a single
+// failed probe across every session that shares this socket for the next 5
+// seconds, which is the opposite of what the tri-state buys". Both halves of
+// that reason stopped holding, and the replacement rule is below (#1514):
+//
+//   - Spreading an unknown is INERT, so it is not the opposite of what the
+//     tri-state buys. What the tri-state buys is that a probe which did not run
+//     is never mistaken for a detach and never clears a stored host — and a
+//     memoized non-answer keeps that exactly, because it is stored AS a
+//     non-answer and every consumer of the bit sees the identical (nil, false)
+//     pair either way: captureLauncher ignores it outright, and backfillLauncher
+//     and refreshHerdrHosts both route it through applyHerdrHostBackfill, which
+//     returns before touching the stored launcher. The one thing a cached
+//     unknown costs is deferring a RECOVERY — a probe that would have answered
+//     — by at most one TTL.
+//   - The failure the reason describes is no longer the failure that arrives
+//     here. #1485 was written when the only non-answer was a failed lsof probe,
+//     which fails fast, so re-paying it per pane was nearly free and the spread
+//     was the only cost worth naming. #1492 routed the most EXPENSIVE outcome in
+//     this function to the same branch: every candidate probed and none
+//     readable, which is up to maxClientCandidates candidates, each costing two
+//     independent ancestry walks on readProcInfo's 2s ceiling. Re-paying now
+//     dominates, and the trade the rule was making inverted.
+//
+// The new rule: the memo holds what ONE probe of this socket determined, for
+// one TTL — an answer or the absence of one. A non-answer keeps probed=false on
+// the way out, so nothing downstream can tell a cached one from a fresh one.
+//
+// The unknown deliberately shares the answer's TTL rather than getting a
+// shorter one of its own. A shorter TTL does not survive the interleaving: the
+// sweep iterates sessions, not sockets, so two panes of one herdr server need
+// not be adjacent, and any TTL shorter than a whole sweep pass can expire
+// between them. Sharing it is bounded in the other direction too, because
+// herdrClientCacheGet does not restamp on a hit: with the TTL and the sweep
+// interval both 5s an entry survives at most into the following sweep, never
+// past it.
 func herdrClientLauncher(socketPath string) (*session.Launcher, bool) {
 	if socketPath == "" {
 		return nil, false
 	}
-	if cached, ok := herdrClientCacheGet(socketPath); ok {
-		return cached, true
+	if cached, probed, hit := herdrClientCacheGet(socketPath); hit {
+		return cached, probed
 	}
 	resolved, probed := resolveHerdrClientLauncher(socketPath)
-	if !probed {
-		// Never memoize a non-answer. The cache exists to collapse one startup
-		// seed's worth of identical scans; caching "unknown" would instead
-		// spread a single failed probe across every session that shares this
-		// socket for the next 5 seconds, which is the opposite of what the
-		// tri-state buys.
-		//
-		// #1492 widened what reaches this branch, and with it the cost: an
-		// unreadable candidate used to answer (nil, true) and be cached once
-		// per socket, and now re-probes per pane — under exactly the load that
-		// produces it. That is a deliberate trade of cost for correctness, not
-		// an oversight; re-deciding the rule reverses #1485's and is tracked as
-		// #1514, together with refreshHerdrHosts' affordability note, which
-		// assumes one lsof scan per socket per sweep.
-		return nil, false
-	}
-	herdrClientCachePut(socketPath, resolved)
-	return resolved, true
+	herdrClientCachePut(socketPath, resolved, probed)
+	return resolved, probed
 }
 
 func resolveHerdrClientLauncher(socketPath string) (*session.Launcher, bool) {
@@ -688,7 +737,13 @@ const herdrClientCacheTTL = 5 * time.Second
 
 type herdrClientCacheEntry struct {
 	launcher *session.Launcher
-	at       time.Time
+	// probed carries herdrClientLauncher's second return through the memo. It
+	// is what makes caching a non-answer safe: without it a cached nil is
+	// indistinguishable from a cached detach, and the next pane to read this
+	// socket would be told its client is gone on the strength of a probe that
+	// never ran — #1485's defect, re-entered through the cache.
+	probed bool
+	at     time.Time
 }
 
 var (
@@ -696,26 +751,34 @@ var (
 	herdrClientCache   = map[string]herdrClientCacheEntry{}
 )
 
-// herdrClientCacheGet reports the cached identity for socketPath. A cached
-// "nothing attached" is a real answer and returns (nil, true); ok is false only
-// when there is no live entry. Expired entries are dropped on the way past, so
-// sockets that stop being used don't accumulate.
-func herdrClientCacheGet(socketPath string) (*session.Launcher, bool) {
+// herdrClientCacheGet reports what the last probe of socketPath determined.
+// The three returns are deliberately not two: hit answers "is there a live
+// entry", and (launcher, probed) is the same tri-state herdrClientLauncher
+// returns — a cached "nothing attached" is (nil, true, true) while a cached
+// non-answer is (nil, false, true), and collapsing those two would be #1485.
+// Expired entries are dropped on the way past, so sockets that stop being used
+// don't accumulate.
+//
+// A hit deliberately does NOT restamp entry.at. Refreshing on read would let a
+// socket busy enough to be read every sweep hold a stale entry — in particular
+// a stale non-answer — indefinitely; leaving the stamp alone bounds any entry
+// to one TTL from the probe that produced it, however often it is read.
+func herdrClientCacheGet(socketPath string) (l *session.Launcher, probed, hit bool) {
 	herdrClientCacheMu.Lock()
 	defer herdrClientCacheMu.Unlock()
 	entry, ok := herdrClientCache[socketPath]
 	if !ok {
-		return nil, false
+		return nil, false, false
 	}
 	if time.Since(entry.at) > herdrClientCacheTTL {
 		delete(herdrClientCache, socketPath)
-		return nil, false
+		return nil, false, false
 	}
-	return entry.launcher, true
+	return entry.launcher, entry.probed, true
 }
 
-func herdrClientCachePut(socketPath string, l *session.Launcher) {
+func herdrClientCachePut(socketPath string, l *session.Launcher, probed bool) {
 	herdrClientCacheMu.Lock()
 	defer herdrClientCacheMu.Unlock()
-	herdrClientCache[socketPath] = herdrClientCacheEntry{launcher: l, at: time.Now()}
+	herdrClientCache[socketPath] = herdrClientCacheEntry{launcher: l, probed: probed, at: time.Now()}
 }

--- a/core/adapters/inbound/agents/processlifecycle/osutil_darwin.go
+++ b/core/adapters/inbound/agents/processlifecycle/osutil_darwin.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -512,10 +512,10 @@ func herdrClientPIDs(socketPath string) (pids []int, probed bool) {
 }
 
 // sortedDistinctPIDs sorts pids newest-attach-first and collapses repeats.
-// It sorts in place and reuses the argument's backing array, so the result
-// aliases pids and pids is not left as the caller passed it. Both are fine for
-// the single production caller, which passes a slice herdrClientWriters just
-// built and does not look at it again.
+// Sorts in place and reuses the argument's backing array — slices.Compact's
+// documented contract — so the result aliases pids. Fine for the single
+// production caller, which passes a slice herdrClientWriters just built and
+// does not look at it again.
 //
 // The sort answers open question 3 of #1350; the dedup is what makes the
 // result a list of CLIENTS rather than of file descriptors. parseLsofFDs emits
@@ -541,14 +541,10 @@ func herdrClientPIDs(socketPath string) (pids []int, probed bool) {
 // not that. Removing it removes a false claim of incompleteness, it does not
 // weaken #1492 — a candidate genuinely dropped by the cap still poisons.
 func sortedDistinctPIDs(pids []int) []int {
-	sort.Sort(sort.Reverse(sort.IntSlice(pids)))
-	distinct := pids[:0]
-	for i, pid := range pids {
-		if i == 0 || pid != pids[i-1] {
-			distinct = append(distinct, pid)
-		}
-	}
-	return distinct
+	slices.Sort(pids)
+	pids = slices.Compact(pids)
+	slices.Reverse(pids)
+	return pids
 }
 
 // lsofProbeRan reports whether an lsof invocation that returned err
@@ -635,6 +631,12 @@ const maxClientCandidates = 4
 // terminates honestly at PID 1 while a local window exists (that indirection is
 // #1501, the tmux twin of #1350), and a chain deeper than maxAncestry is
 // declared a miss on the same terms.
+// Producers must feed it DISTINCT pids. maxClientCandidates is a bound on
+// clients, and the truncation below poisons the answer, so a repeated pid both
+// burns a slot and costs a second identical hostIdentity. herdr's producer
+// dedups (sortedDistinctPIDs) because lsof emits a row per FD; a `tmux
+// list-clients` producer is naturally distinct, but the obligation is stated
+// here, next to the constant that depends on it, rather than only there.
 func resolveClientHostIdentity(pids []int) (*session.Launcher, bool) {
 	readAll := len(pids) <= maxClientCandidates
 	if !readAll {
@@ -737,8 +739,8 @@ func herdrClientLauncher(socketPath string) (*session.Launcher, bool) {
 	if socketPath == "" {
 		return nil, false
 	}
-	if cached, probed, hit := herdrClientCacheGet(socketPath); hit {
-		return cached, probed
+	if cached, hit := herdrClientCacheGet(socketPath); hit {
+		return cached.launcher, cached.probed
 	}
 	resolved, probed := resolveHerdrClientLauncher(socketPath)
 	herdrClientCachePut(socketPath, resolved, probed)
@@ -775,29 +777,39 @@ var (
 )
 
 // herdrClientCacheGet reports what the last probe of socketPath determined.
-// The three returns are deliberately not two: hit answers "is there a live
-// entry", and (launcher, probed) is the same tri-state herdrClientLauncher
-// returns — a cached "nothing attached" is (nil, true, true) while a cached
-// non-answer is (nil, false, true), and collapsing those two would be #1485.
-// Expired entries are dropped on the way past, so sockets that stop being used
-// don't accumulate.
+// The entry rather than its fields, because launcher and probed are the same
+// tri-state herdrClientLauncher returns — a cached "nothing attached" is
+// (nil, probed) while a cached non-answer is (nil, !probed), and two adjacent
+// bools in a return list is the one shape a future call site can transpose
+// silently. Collapsing those two states would be #1485.
 //
 // A hit deliberately does NOT restamp entry.at. Refreshing on read would let a
 // socket busy enough to be read every sweep hold a stale entry — in particular
 // a stale non-answer — indefinitely; leaving the stamp alone bounds any entry
 // to one TTL from the probe that produced it, however often it is read.
-func herdrClientCacheGet(socketPath string) (l *session.Launcher, probed, hit bool) {
+func herdrClientCacheGet(socketPath string) (herdrClientCacheEntry, bool) {
 	herdrClientCacheMu.Lock()
 	defer herdrClientCacheMu.Unlock()
+	return herdrClientCacheLive(socketPath)
+}
+
+// herdrClientCacheLive returns socketPath's entry when it has not expired, and
+// drops it when it has — so sockets that stop being used don't accumulate.
+// Callers hold herdrClientCacheMu.
+//
+// Split out so the expiry rule has exactly one spelling. Both readers need it
+// and they need it with opposite polarity, which is precisely the pair that
+// drifts.
+func herdrClientCacheLive(socketPath string) (herdrClientCacheEntry, bool) {
 	entry, ok := herdrClientCache[socketPath]
 	if !ok {
-		return nil, false, false
+		return herdrClientCacheEntry{}, false
 	}
 	if time.Since(entry.at) > herdrClientCacheTTL {
 		delete(herdrClientCache, socketPath)
-		return nil, false, false
+		return herdrClientCacheEntry{}, false
 	}
-	return entry.launcher, entry.probed, true
+	return entry, true
 }
 
 // herdrClientCachePut records what a probe of socketPath determined. A
@@ -822,7 +834,7 @@ func herdrClientCachePut(socketPath string, l *session.Launcher, probed bool) {
 	herdrClientCacheMu.Lock()
 	defer herdrClientCacheMu.Unlock()
 	if !probed {
-		if prev, ok := herdrClientCache[socketPath]; ok && prev.probed && time.Since(prev.at) <= herdrClientCacheTTL {
+		if prev, live := herdrClientCacheLive(socketPath); live && prev.probed {
 			return
 		}
 	}

--- a/core/adapters/inbound/agents/processlifecycle/osutil_darwin.go
+++ b/core/adapters/inbound/agents/processlifecycle/osutil_darwin.go
@@ -512,6 +512,10 @@ func herdrClientPIDs(socketPath string) (pids []int, probed bool) {
 }
 
 // sortedDistinctPIDs sorts pids newest-attach-first and collapses repeats.
+// It sorts in place and reuses the argument's backing array, so the result
+// aliases pids and pids is not left as the caller passed it. Both are fine for
+// the single production caller, which passes a slice herdrClientWriters just
+// built and does not look at it again.
 //
 // The sort answers open question 3 of #1350; the dedup is what makes the
 // result a list of CLIENTS rather than of file descriptors. parseLsofFDs emits
@@ -528,6 +532,14 @@ func herdrClientPIDs(socketPath string) (pids []int, probed bool) {
 // defect today. It is closed here rather than left standing because the cap's
 // truncation is one of the two triggers of #1514, and a duplicate is a way to
 // reach it that has nothing to do with how many clients are attached.
+//
+// Deduping BEFORE the cap therefore also moves resolveClientHostIdentity's
+// readAll from false to true in those cases, which is a change in the
+// host-CLEARING direction and so deserves saying out loud. It is the honest
+// direction: the cap poisons the answer because a dropped candidate is one we
+// declined to look at, and a second FD row for a candidate we DID look at is
+// not that. Removing it removes a false claim of incompleteness, it does not
+// weaken #1492 — a candidate genuinely dropped by the cap still poisons.
 func sortedDistinctPIDs(pids []int) []int {
 	sort.Sort(sort.Reverse(sort.IntSlice(pids)))
 	distinct := pids[:0]
@@ -687,8 +699,11 @@ func resolveClientHostIdentity(pids []int) (*session.Launcher, bool) {
 //     pair either way: captureLauncher ignores it outright, and backfillLauncher
 //     and refreshHerdrHosts both route it through applyHerdrHostBackfill, which
 //     returns before touching the stored launcher. The one thing a cached
-//     unknown costs is deferring a RECOVERY — a probe that would have answered
-//     — by at most one TTL.
+//     unknown costs is deferring a RECOVERY — a probe that would have
+//     answered. Note the honest bound on that deferral is a SWEEP, not a TTL:
+//     the entry expires one TTL after the probe that wrote it, but nothing
+//     reads it in between, so what a user observes is quantized to
+//     refreshHerdrHosts' cadence. See the TTL note below.
 //   - The failure the reason describes is no longer the failure that arrives
 //     here. #1485 was written when the only non-answer was a failed lsof probe,
 //     which fails fast, so re-paying it per pane was nearly free and the spread
@@ -706,10 +721,18 @@ func resolveClientHostIdentity(pids []int) (*session.Launcher, bool) {
 // shorter one of its own. A shorter TTL does not survive the interleaving: the
 // sweep iterates sessions, not sockets, so two panes of one herdr server need
 // not be adjacent, and any TTL shorter than a whole sweep pass can expire
-// between them. Sharing it is bounded in the other direction too, because
-// herdrClientCacheGet does not restamp on a hit: with the TTL and the sweep
-// interval both 5s an entry survives at most into the following sweep, never
-// past it.
+// between them.
+//
+// What a deferred recovery actually costs, stated honestly rather than as one
+// TTL: the reader is the liveness sweep, so recovery lands on the next sweep
+// whose probe runs. SweepDeadPIDs (pid_manager.go) ticks at 5s and backs off
+// to 15s after three clean sweeps — the idle steady state — so the worst case
+// is about one 15s interval. At the 5s cadence it can instead take two
+// intervals, because entry.at is stamped when the probe FINISHES rather than
+// when the pass began, so an entry written late in a pass is not yet expired
+// when the next pass reaches it. It cannot slip further than that, because
+// herdrClientCacheGet does not restamp on a hit: a sweep served from the memo
+// costs nothing and so cannot keep pushing the expiry ahead of itself.
 func herdrClientLauncher(socketPath string) (*session.Launcher, bool) {
 	if socketPath == "" {
 		return nil, false
@@ -777,8 +800,31 @@ func herdrClientCacheGet(socketPath string) (l *session.Launcher, probed, hit bo
 	return entry.launcher, entry.probed, true
 }
 
+// herdrClientCachePut records what a probe of socketPath determined. A
+// non-answer never displaces a live answer.
+//
+// That guard is new with the memo and is the one hazard memoizing non-answers
+// introduces: before #1514 a non-answer was never written, so it could not
+// overwrite anything. Two goroutines can miss the memo for one socket and
+// probe concurrently — refreshHerdrHosts reads outside assignMu, on the sweep
+// goroutine, while PID discovery reaches captureLauncher/backfillLauncher on
+// its own — and a non-answer is by far the SLOWER outcome to produce (up to
+// maxClientCandidates candidates, two ancestry walks each on a 2s ceiling).
+// So the loser of that race is systematically the one carrying no
+// information, and last-writer-wins would let it both erase a resolved host
+// and restamp the entry fresh, extending the deferral by another full TTL.
+//
+// Keeping the incumbent cannot pin anything: its own at is left alone, so it
+// still expires on the schedule the probe that produced it set. The reverse
+// direction needs no guard — an answer displacing a non-answer is strictly
+// more information, which is the whole point of re-probing.
 func herdrClientCachePut(socketPath string, l *session.Launcher, probed bool) {
 	herdrClientCacheMu.Lock()
 	defer herdrClientCacheMu.Unlock()
+	if !probed {
+		if prev, ok := herdrClientCache[socketPath]; ok && prev.probed && time.Since(prev.at) <= herdrClientCacheTTL {
+			return
+		}
+	}
 	herdrClientCache[socketPath] = herdrClientCacheEntry{launcher: l, probed: probed, at: time.Now()}
 }

--- a/core/adapters/inbound/agents/processlifecycle/osutil_darwin_test.go
+++ b/core/adapters/inbound/agents/processlifecycle/osutil_darwin_test.go
@@ -14,6 +14,8 @@ import (
 	"syscall"
 	"testing"
 	"time"
+
+	"irrlicht/core/domain/session"
 )
 
 func TestKittyAncestryPID_Self(t *testing.T) {
@@ -694,6 +696,27 @@ func TestHerdrClientLauncher_MemoizedNonAnswerIsStillANonAnswer(t *testing.T) {
 		}
 	})
 
+	t.Run("a hit returns what was memoized", func(t *testing.T) {
+		// Without this the whole family is satisfiable by a cache that returns
+		// the right tri-state and drops the launcher — measured: making
+		// herdrClientCacheGet return a nil launcher leaves every other test in
+		// the package green, while panes 2..N of a herdr server silently lose
+		// their host. The socket has no client log, so a read that reached the
+		// prober instead of the memo would answer probed=false and fail here.
+		socketPath := newHerdrSessionDir(t)
+		want := &session.Launcher{TermProgram: "iTerm.app", HostBundleID: "com.googlecode.iterm2"}
+		herdrClientCachePut(socketPath, want, true)
+		t.Cleanup(func() { forget(socketPath) })
+
+		got, probed := herdrClientLauncher(socketPath)
+		if !probed {
+			t.Fatal("a memoized answer must read back as an answer")
+		}
+		if got != want {
+			t.Errorf("got %+v, want the memoized launcher %+v", got, want)
+		}
+	})
+
 	t.Run("detach is still an answer", func(t *testing.T) {
 		socketPath := newHerdrSessionDir(t)
 		if err := os.WriteFile(herdrClientLogPath(socketPath), []byte("detached\n"), 0o600); err != nil {
@@ -716,6 +739,14 @@ func TestHerdrClientLauncher_MemoizedNonAnswerIsStillANonAnswer(t *testing.T) {
 // own identity is unaffected either way — only the second return value moves.
 func TestReadLauncherEnv_Herdr_UnprobableClientReportsHostUnknown(t *testing.T) {
 	socketPath := newHerdrSessionDir(t) // no client log
+	// This test reads the socket three times and the last read re-memoizes, so
+	// it is the one place in the family that would otherwise leave residue in
+	// the package-global memo.
+	t.Cleanup(func() {
+		herdrClientCacheMu.Lock()
+		delete(herdrClientCache, socketPath)
+		herdrClientCacheMu.Unlock()
+	})
 	agentPID := spawnSleeperWithEnv(t, []string{
 		"PATH=/usr/bin:/bin",
 		"HERDR_PANE_ID=w1:p1",
@@ -735,8 +766,10 @@ func TestReadLauncherEnv_Herdr_UnprobableClientReportsHostUnknown(t *testing.T) 
 	// non-answer above is memoized, so the recovery is deferred until that
 	// entry expires. This assertion is the price of that reversal, pinned
 	// rather than left to be rediscovered: a cached unknown clears nothing and
-	// is inert at every consumer, and deferring a recovery by at most one TTL
-	// is the ONLY behaviour it changes.
+	// is inert at every consumer, and deferring a recovery is the ONLY
+	// behaviour it changes. The deferral is bounded by a SWEEP rather than by
+	// the TTL — nothing reads the memo between sweeps — which herdrClientLauncher's
+	// doc works out against SweepDeadPIDs' 5s/15s cadence.
 	if err := os.WriteFile(herdrClientLogPath(socketPath), []byte("detached\n"), 0o600); err != nil {
 		t.Fatalf("seed client log: %v", err)
 	}
@@ -1248,4 +1281,89 @@ func TestSortedDistinctPIDs_DuplicateDoesNotConsumeACandidateSlot(t *testing.T) 
 	if len(got) != 3 {
 		t.Errorf("got %v, want one entry per client", got)
 	}
+}
+
+// TestHerdrClientPIDs_DedupesFDRowsOfOneClient is the end-to-end half of the
+// dedup, and it is the one that matters: TestSortedDistinctPIDs calls the
+// helper directly, so nothing there pins that herdrClientPIDs — the helper's
+// only production caller — actually routes through it. Measured: unwiring the
+// call while keeping the sort leaves the whole package green.
+//
+// TestHerdrClientPIDs_MultipleClientsAreOrderedNewestFirst cannot cover this,
+// because real herdr clients hold one write handle each — which is exactly the
+// case the dedup is not about.
+func TestHerdrClientPIDs_DedupesFDRowsOfOneClient(t *testing.T) {
+	socketPath := newHerdrSessionDir(t)
+	logPath := herdrClientLogPath(socketPath)
+	if err := os.WriteFile(logPath, []byte("attached\n"), 0o600); err != nil {
+		t.Fatalf("seed client log: %v", err)
+	}
+	// One client on two write handles, plus a second client. lsof emits a row
+	// per FD, so this is three rows for two clients.
+	table := "COMMAND     PID USER   FD   TYPE DEVICE SIZE/OFF   NODE NAME\n" +
+		"herdr     26932 ingo    3w   REG   1,18      372 136170 " + logPath + "\n" +
+		"herdr     26932 ingo    4w   REG   1,18      372 136170 " + logPath + "\n" +
+		"herdr     26940 ingo    5u   REG   1,18      372 136170 " + logPath
+	countingLsof(t, table)
+
+	pids, probed := herdrClientPIDs(socketPath)
+	if !probed {
+		t.Fatal("the stub exits 0, so the probe ran")
+	}
+	want := []int{26940, 26932}
+	if len(pids) != len(want) {
+		t.Fatalf("got %v, want one entry per client %v — the cap counts candidates, so a duplicate consumes a slot", pids, want)
+	}
+	for i := range want {
+		if pids[i] != want[i] {
+			t.Fatalf("got %v, want %v (newest attach first)", pids, want)
+		}
+	}
+}
+
+// TestHerdrClientCachePut_NonAnswerDoesNotDisplaceALiveAnswer locks the one
+// hazard memoizing non-answers introduces. Before #1514 a non-answer was never
+// written, so it could not overwrite anything; now two goroutines can miss the
+// memo for one socket and probe concurrently (refreshHerdrHosts reads outside
+// assignMu on the sweep goroutine, PID discovery reaches captureLauncher on its
+// own), and the non-answer is systematically the slower of the two to produce.
+// Last-writer-wins would let the one carrying no information erase a resolved
+// host AND restamp the entry fresh.
+//
+// The second case is the vacuity guard: a put that simply refused every
+// overwrite would satisfy the first and freeze the memo forever.
+func TestHerdrClientCachePut_NonAnswerDoesNotDisplaceALiveAnswer(t *testing.T) {
+	forget := func(socketPath string) {
+		herdrClientCacheMu.Lock()
+		delete(herdrClientCache, socketPath)
+		herdrClientCacheMu.Unlock()
+	}
+
+	t.Run("non-answer loses to a live answer", func(t *testing.T) {
+		socketPath := newHerdrSessionDir(t)
+		want := &session.Launcher{TermProgram: "iTerm.app"}
+		t.Cleanup(func() { forget(socketPath) })
+
+		herdrClientCachePut(socketPath, want, true)
+		herdrClientCachePut(socketPath, nil, false) // the slow loser lands second
+
+		got, probed := herdrClientLauncher(socketPath)
+		if !probed || got != want {
+			t.Errorf("got (%+v, %v), want the resolved host to survive — a probe that determined nothing erased one that did", got, probed)
+		}
+	})
+
+	t.Run("answer still wins over a non-answer", func(t *testing.T) {
+		socketPath := newHerdrSessionDir(t)
+		want := &session.Launcher{TermProgram: "iTerm.app"}
+		t.Cleanup(func() { forget(socketPath) })
+
+		herdrClientCachePut(socketPath, nil, false)
+		herdrClientCachePut(socketPath, want, true)
+
+		got, probed := herdrClientLauncher(socketPath)
+		if !probed || got != want {
+			t.Errorf("got (%+v, %v), want the answer to replace the non-answer — re-probing is pointless otherwise", got, probed)
+		}
+	})
 }

--- a/core/adapters/inbound/agents/processlifecycle/osutil_darwin_test.go
+++ b/core/adapters/inbound/agents/processlifecycle/osutil_darwin_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"syscall"
@@ -649,11 +650,6 @@ func TestHerdrClientPIDs_ProbeTriState(t *testing.T) {
 // The third case is the vacuity guard: a cache that reported probed=false for
 // everything would satisfy the first two and destroy the tri-state.
 func TestHerdrClientLauncher_MemoizedNonAnswerIsStillANonAnswer(t *testing.T) {
-	forget := func(socketPath string) {
-		herdrClientCacheMu.Lock()
-		delete(herdrClientCache, socketPath)
-		herdrClientCacheMu.Unlock()
-	}
 	memoized := func(t *testing.T, socketPath string) herdrClientCacheEntry {
 		t.Helper()
 		herdrClientCacheMu.Lock()
@@ -667,7 +663,7 @@ func TestHerdrClientLauncher_MemoizedNonAnswerIsStillANonAnswer(t *testing.T) {
 
 	t.Run("probe could not run", func(t *testing.T) {
 		socketPath := newHerdrSessionDir(t) // no client log: the probe cannot run
-		t.Cleanup(func() { forget(socketPath) })
+		t.Cleanup(func() { forgetHerdrClientMemo(socketPath) })
 
 		if _, probed := herdrClientLauncher(socketPath); probed {
 			t.Fatal("want a non-answer for a socket whose client log is absent")
@@ -706,7 +702,7 @@ func TestHerdrClientLauncher_MemoizedNonAnswerIsStillANonAnswer(t *testing.T) {
 		socketPath := newHerdrSessionDir(t)
 		want := &session.Launcher{TermProgram: "iTerm.app", HostBundleID: "com.googlecode.iterm2"}
 		herdrClientCachePut(socketPath, want, true)
-		t.Cleanup(func() { forget(socketPath) })
+		t.Cleanup(func() { forgetHerdrClientMemo(socketPath) })
 
 		got, probed := herdrClientLauncher(socketPath)
 		if !probed {
@@ -722,7 +718,7 @@ func TestHerdrClientLauncher_MemoizedNonAnswerIsStillANonAnswer(t *testing.T) {
 		if err := os.WriteFile(herdrClientLogPath(socketPath), []byte("detached\n"), 0o600); err != nil {
 			t.Fatalf("seed client log: %v", err)
 		}
-		t.Cleanup(func() { forget(socketPath) })
+		t.Cleanup(func() { forgetHerdrClientMemo(socketPath) })
 
 		if _, probed := herdrClientLauncher(socketPath); !probed {
 			t.Fatal("a detach is an answer")
@@ -743,9 +739,7 @@ func TestReadLauncherEnv_Herdr_UnprobableClientReportsHostUnknown(t *testing.T) 
 	// it is the one place in the family that would otherwise leave residue in
 	// the package-global memo.
 	t.Cleanup(func() {
-		herdrClientCacheMu.Lock()
-		delete(herdrClientCache, socketPath)
-		herdrClientCacheMu.Unlock()
+		forgetHerdrClientMemo(socketPath)
 	})
 	agentPID := spawnSleeperWithEnv(t, []string{
 		"PATH=/usr/bin:/bin",
@@ -780,9 +774,7 @@ func TestReadLauncherEnv_Herdr_UnprobableClientReportsHostUnknown(t *testing.T) 
 	// Dropping the entry stands in for the TTL elapsing — waiting out five real
 	// seconds would buy nothing but a slower suite. Once it is gone the detach
 	// is visible, which is what bounds the deferral at one TTL.
-	herdrClientCacheMu.Lock()
-	delete(herdrClientCache, socketPath)
-	herdrClientCacheMu.Unlock()
+	forgetHerdrClientMemo(socketPath)
 	if _, hostKnown := ReadLauncherEnv(agentPID); !hostKnown {
 		t.Error("a detached session's host is known to be absent")
 	}
@@ -1152,6 +1144,17 @@ func TestResolveClientHostIdentity_ResolvableCandidateStillWins(t *testing.T) {
 
 // --- non-answer memoization (#1514) -----------------------------------------
 
+// forgetHerdrClientMemo drops socketPath's entry from the process-global memo.
+// Since #1514 every socket a test touches leaves one behind — non-answers are
+// memoized too — so this is the single spelling of the locking protocol rather
+// than a copy per test. One caller uses it mid-test, standing in for the TTL
+// elapsing; the rest wire it through t.Cleanup.
+func forgetHerdrClientMemo(socketPath string) {
+	herdrClientCacheMu.Lock()
+	defer herdrClientCacheMu.Unlock()
+	delete(herdrClientCache, socketPath)
+}
+
 // countingLsof points lsofPath at a stub that records one line per invocation
 // and prints table for every call, and returns a func reporting how many times
 // it ran. It is how the cost claims below are asserted as a COUNT of probes
@@ -1203,9 +1206,7 @@ func unreadableClientSocket(t *testing.T) (string, func() int) {
 		"herdr     " + strconv.Itoa(exitedPID(t)) + " ingo    3w   REG   1,18      372 136170 " + logPath
 	scans := countingLsof(t, table)
 	t.Cleanup(func() {
-		herdrClientCacheMu.Lock()
-		delete(herdrClientCache, socketPath)
-		herdrClientCacheMu.Unlock()
+		forgetHerdrClientMemo(socketPath)
 	})
 	return socketPath, scans
 }
@@ -1251,16 +1252,8 @@ func TestSortedDistinctPIDs(t *testing.T) {
 		"empty":                   {nil, nil},
 	}
 	for name, tc := range cases {
-		got := sortedDistinctPIDs(append([]int(nil), tc.in...))
-		if len(got) != len(tc.want) {
+		if got := sortedDistinctPIDs(slices.Clone(tc.in)); !slices.Equal(got, tc.want) {
 			t.Errorf("%s: got %v, want %v", name, got, tc.want)
-			continue
-		}
-		for i := range got {
-			if got[i] != tc.want[i] {
-				t.Errorf("%s: got %v, want %v", name, got, tc.want)
-				break
-			}
 		}
 	}
 }
@@ -1273,7 +1266,7 @@ func TestSortedDistinctPIDs(t *testing.T) {
 func TestSortedDistinctPIDs_DuplicateDoesNotConsumeACandidateSlot(t *testing.T) {
 	// Three clients, one of them holding two write handles: five FD rows.
 	rows := []int{100, 100, 200, 300, 300}
-	got := sortedDistinctPIDs(append([]int(nil), rows...))
+	got := sortedDistinctPIDs(slices.Clone(rows))
 	if len(got) > maxClientCandidates {
 		t.Fatalf("%d FD rows for 3 clients still exceed the %d-candidate cap: %v",
 			len(rows), maxClientCandidates, got)
@@ -1310,14 +1303,8 @@ func TestHerdrClientPIDs_DedupesFDRowsOfOneClient(t *testing.T) {
 	if !probed {
 		t.Fatal("the stub exits 0, so the probe ran")
 	}
-	want := []int{26940, 26932}
-	if len(pids) != len(want) {
-		t.Fatalf("got %v, want one entry per client %v — the cap counts candidates, so a duplicate consumes a slot", pids, want)
-	}
-	for i := range want {
-		if pids[i] != want[i] {
-			t.Fatalf("got %v, want %v (newest attach first)", pids, want)
-		}
+	if want := []int{26940, 26932}; !slices.Equal(pids, want) {
+		t.Fatalf("got %v, want one entry per client, newest attach first %v — the cap counts candidates, so a duplicate consumes a slot", pids, want)
 	}
 }
 
@@ -1333,16 +1320,11 @@ func TestHerdrClientPIDs_DedupesFDRowsOfOneClient(t *testing.T) {
 // The second case is the vacuity guard: a put that simply refused every
 // overwrite would satisfy the first and freeze the memo forever.
 func TestHerdrClientCachePut_NonAnswerDoesNotDisplaceALiveAnswer(t *testing.T) {
-	forget := func(socketPath string) {
-		herdrClientCacheMu.Lock()
-		delete(herdrClientCache, socketPath)
-		herdrClientCacheMu.Unlock()
-	}
 
 	t.Run("non-answer loses to a live answer", func(t *testing.T) {
 		socketPath := newHerdrSessionDir(t)
 		want := &session.Launcher{TermProgram: "iTerm.app"}
-		t.Cleanup(func() { forget(socketPath) })
+		t.Cleanup(func() { forgetHerdrClientMemo(socketPath) })
 
 		herdrClientCachePut(socketPath, want, true)
 		herdrClientCachePut(socketPath, nil, false) // the slow loser lands second
@@ -1356,7 +1338,7 @@ func TestHerdrClientCachePut_NonAnswerDoesNotDisplaceALiveAnswer(t *testing.T) {
 	t.Run("answer still wins over a non-answer", func(t *testing.T) {
 		socketPath := newHerdrSessionDir(t)
 		want := &session.Launcher{TermProgram: "iTerm.app"}
-		t.Cleanup(func() { forget(socketPath) })
+		t.Cleanup(func() { forgetHerdrClientMemo(socketPath) })
 
 		herdrClientCachePut(socketPath, nil, false)
 		herdrClientCachePut(socketPath, want, true)
@@ -1366,4 +1348,41 @@ func TestHerdrClientCachePut_NonAnswerDoesNotDisplaceALiveAnswer(t *testing.T) {
 			t.Errorf("got (%+v, %v), want the answer to replace the non-answer — re-probing is pointless otherwise", got, probed)
 		}
 	})
+}
+
+// TestHerdrClientCache_ExpiresANonAnswer is the load-bearing half of #1514's
+// argument, and it was missing: deleting herdrClientCacheLive's expiry check
+// entirely left every other test in the package green (measured).
+//
+// The case for reversing #1485 is that a memoized non-answer costs only a
+// DEFERRED recovery. That sentence is true only because the entry expires. An
+// unknown that never expired would pin every pane of a herdr server to "host
+// unknown" for the life of the daemon — strictly worse than the per-pane
+// re-probe #1514 removes, and arrived at through the fix for it.
+//
+// Backdating the stamp stands in for five real seconds; asserting the SCAN
+// COUNT rather than the return value is what makes it discriminating, since a
+// non-answer reads identically whether it was re-probed or served stale.
+func TestHerdrClientCache_ExpiresANonAnswer(t *testing.T) {
+	socketPath, scans := unreadableClientSocket(t)
+
+	if _, probed := herdrClientLauncher(socketPath); probed {
+		t.Fatal("want a non-answer for a socket whose only candidate is unreadable")
+	}
+	if got := scans(); got != 1 {
+		t.Fatalf("first read cost %d scans, want 1", got)
+	}
+
+	herdrClientCacheMu.Lock()
+	entry := herdrClientCache[socketPath]
+	entry.at = time.Now().Add(-herdrClientCacheTTL - time.Second)
+	herdrClientCache[socketPath] = entry
+	herdrClientCacheMu.Unlock()
+
+	if _, probed := herdrClientLauncher(socketPath); probed {
+		t.Fatal("the re-probe finds the same unreadable candidate")
+	}
+	if got := scans(); got != 2 {
+		t.Errorf("an expired non-answer was served from the memo (%d scans, want 2): a cached unknown that never lapses pins every pane on this socket forever", got)
+	}
 }

--- a/core/adapters/inbound/agents/processlifecycle/osutil_darwin_test.go
+++ b/core/adapters/inbound/agents/processlifecycle/osutil_darwin_test.go
@@ -1155,28 +1155,43 @@ func forgetHerdrClientMemo(socketPath string) {
 	delete(herdrClientCache, socketPath)
 }
 
-// countingLsof points lsofPath at a stub that records one line per invocation
-// and prints table for every call, and returns a func reporting how many times
-// it ran. It is how the cost claims below are asserted as a COUNT of probes
-// rather than as a wall-clock time: the whole regression is "N panes pay N
-// scans instead of 1", and a timing assertion for that is a flake generator on
-// a loaded machine — which is, awkwardly, the exact machine state the defect
+// countingLsof makes the herdr client log at logPath answer as an lsof table,
+// records one line per invocation, and returns a func reporting how many times
+// the probe ran. It is how the cost claims below are asserted as a COUNT of
+// probes rather than as a wall-clock time: the whole regression is "N panes pay
+// N scans instead of 1", and a timing assertion for that is a flake generator
+// on a loaded machine — which is, awkwardly, the exact machine state the defect
 // needs.
 //
-// lsofPath is a package var (process_darwin.go) rather than a seam invented
-// for this test, and no test in this package calls t.Parallel, so swapping it
-// under t.Cleanup is safe.
-func countingLsof(t *testing.T, table string) func() int {
+// The shape is odd and the reason is macOS, not taste. The obvious stub — write
+// a #!/bin/sh script somewhere, point lsofPath at it — spawns in ~6ms idle and
+// **2.1s under load**, because the first exec of a newly written file is
+// evaluated for code signing; a copied /bin/cat was outright `signal: killed`
+// on every one of 12 attempts. herdrClientPIDs gives lsof a 2s ceiling, so that
+// stub does not merely run slowly, it times out and the probe reports "could
+// not run" — the exact state these tests are trying to tell apart from the one
+// under test. Measured worst-of-N under a concurrent `go test ./core/... -race`:
+// /usr/bin/true 3.6ms, written script 2.14s, script-as-data below 6.1ms.
+//
+// So nothing new is ever EXEC'd: lsofPath becomes /bin/sh — a warm, signed
+// system binary — and the script it runs is DATA. herdrClientPIDs passes the
+// client-log path as lsof's only argument, so the client log is necessarily
+// where that script has to live. Production never reads the log's bytes (it
+// stats the path and hands it to lsofPath), so the substitution is invisible to
+// the code under test.
+//
+// lsofPath is a package var (process_darwin.go) rather than a seam invented for
+// this test, and no test in this package calls t.Parallel, so swapping it under
+// t.Cleanup is safe.
+func countingLsof(t *testing.T, logPath, table string) func() int {
 	t.Helper()
-	dir := t.TempDir()
-	counter := filepath.Join(dir, "calls")
-	stub := filepath.Join(dir, "lsof")
-	script := "#!/bin/sh\necho x >> " + counter + "\ncat <<'TABLE'\n" + table + "\nTABLE\n"
-	if err := os.WriteFile(stub, []byte(script), 0o700); err != nil {
-		t.Fatalf("write lsof stub: %v", err)
+	counter := filepath.Join(t.TempDir(), "calls")
+	script := "echo x >> '" + counter + "'\ncat <<'TABLE'\n" + table + "\nTABLE\n"
+	if err := os.WriteFile(logPath, []byte(script), 0o600); err != nil {
+		t.Fatalf("write client log: %v", err)
 	}
 	saved := lsofPath
-	lsofPath = stub
+	lsofPath = "/bin/sh"
 	t.Cleanup(func() { lsofPath = saved })
 	return func() int {
 		b, err := os.ReadFile(counter)
@@ -1199,12 +1214,9 @@ func unreadableClientSocket(t *testing.T) (string, func() int) {
 	t.Helper()
 	socketPath := newHerdrSessionDir(t)
 	logPath := herdrClientLogPath(socketPath)
-	if err := os.WriteFile(logPath, []byte("attached\n"), 0o600); err != nil {
-		t.Fatalf("seed client log: %v", err)
-	}
 	table := "COMMAND     PID USER   FD   TYPE DEVICE SIZE/OFF   NODE NAME\n" +
 		"herdr     " + strconv.Itoa(exitedPID(t)) + " ingo    3w   REG   1,18      372 136170 " + logPath
-	scans := countingLsof(t, table)
+	scans := countingLsof(t, logPath, table)
 	t.Cleanup(func() {
 		forgetHerdrClientMemo(socketPath)
 	})
@@ -1288,16 +1300,13 @@ func TestSortedDistinctPIDs_DuplicateDoesNotConsumeACandidateSlot(t *testing.T) 
 func TestHerdrClientPIDs_DedupesFDRowsOfOneClient(t *testing.T) {
 	socketPath := newHerdrSessionDir(t)
 	logPath := herdrClientLogPath(socketPath)
-	if err := os.WriteFile(logPath, []byte("attached\n"), 0o600); err != nil {
-		t.Fatalf("seed client log: %v", err)
-	}
 	// One client on two write handles, plus a second client. lsof emits a row
 	// per FD, so this is three rows for two clients.
 	table := "COMMAND     PID USER   FD   TYPE DEVICE SIZE/OFF   NODE NAME\n" +
 		"herdr     26932 ingo    3w   REG   1,18      372 136170 " + logPath + "\n" +
 		"herdr     26932 ingo    4w   REG   1,18      372 136170 " + logPath + "\n" +
 		"herdr     26940 ingo    5u   REG   1,18      372 136170 " + logPath
-	countingLsof(t, table)
+	countingLsof(t, logPath, table)
 
 	pids, probed := herdrClientPIDs(socketPath)
 	if !probed {

--- a/core/adapters/inbound/agents/processlifecycle/osutil_darwin_test.go
+++ b/core/adapters/inbound/agents/processlifecycle/osutil_darwin_test.go
@@ -630,30 +630,84 @@ func TestHerdrClientPIDs_ProbeTriState(t *testing.T) {
 	})
 }
 
-// TestHerdrClientLauncher_DoesNotCacheANonAnswer covers step 2 of #1485's
-// suggested shape. The memo exists to collapse one startup seed's worth of
-// identical scans; caching a probe that did not run would instead spread a
-// single failure across every session sharing that socket for the next 5
-// seconds — turning the one thing the tri-state buys back into a wider window.
-func TestHerdrClientLauncher_DoesNotCacheANonAnswer(t *testing.T) {
-	socketPath := newHerdrSessionDir(t) // no client log: the probe cannot run
-	// Defensive, and it is the regression this test exists to catch that would
-	// make it necessary: nothing should ever be inserted under this key.
-	t.Cleanup(func() {
+// TestHerdrClientLauncher_MemoizedNonAnswerIsStillANonAnswer REPLACES
+// TestHerdrClientLauncher_DoesNotCacheANonAnswer, which locked #1485's rule
+// that a non-answer must never be memoized. #1514 reversed that rule; this is
+// the lock on what replaced it, and it is a strictly stronger claim than the
+// one it retires.
+//
+// The retired lock said "do not cache". This one says "cache, and the cached
+// thing must not be mistaken for an answer" — which is what actually protects
+// #1485's invariant. #1485's defect was never the caching; it was a probe that
+// did not run being read as a detach and clearing a resolved host. A cached
+// nil with no probed bit beside it would re-enter that defect through the
+// memo, and would do it silently, since every consumer reads the bool and not
+// the nil.
+//
+// The third case is the vacuity guard: a cache that reported probed=false for
+// everything would satisfy the first two and destroy the tri-state.
+func TestHerdrClientLauncher_MemoizedNonAnswerIsStillANonAnswer(t *testing.T) {
+	forget := func(socketPath string) {
 		herdrClientCacheMu.Lock()
 		delete(herdrClientCache, socketPath)
 		herdrClientCacheMu.Unlock()
+	}
+	memoized := func(t *testing.T, socketPath string) herdrClientCacheEntry {
+		t.Helper()
+		herdrClientCacheMu.Lock()
+		defer herdrClientCacheMu.Unlock()
+		entry, ok := herdrClientCache[socketPath]
+		if !ok {
+			t.Fatal("nothing was memoized: every pane sharing this socket re-pays the probe (#1514)")
+		}
+		return entry
+	}
+
+	t.Run("probe could not run", func(t *testing.T) {
+		socketPath := newHerdrSessionDir(t) // no client log: the probe cannot run
+		t.Cleanup(func() { forget(socketPath) })
+
+		if _, probed := herdrClientLauncher(socketPath); probed {
+			t.Fatal("want a non-answer for a socket whose client log is absent")
+		}
+		if entry := memoized(t, socketPath); entry.probed {
+			t.Error("the memo calls a probe that never ran an answer — #1485 re-entered through the cache")
+		}
+		if _, probed := herdrClientLauncher(socketPath); probed {
+			t.Error("the second reader was handed a detach built from a probe that did not run")
+		}
 	})
 
-	if _, probed := herdrClientLauncher(socketPath); probed {
-		t.Fatal("want a non-answer for a socket whose client log is absent")
-	}
-	herdrClientCacheMu.Lock()
-	_, cached := herdrClientCache[socketPath]
-	herdrClientCacheMu.Unlock()
-	if cached {
-		t.Error("a non-answer was memoized: the next 5s of reads inherit one failed probe")
-	}
+	t.Run("candidate could not be read", func(t *testing.T) {
+		// The branch #1492 widened, and the one that made the re-probe
+		// expensive rather than merely repeated.
+		socketPath, _ := unreadableClientSocket(t)
+
+		if _, probed := herdrClientLauncher(socketPath); probed {
+			t.Fatal("want a non-answer for a socket whose only candidate is unreadable")
+		}
+		if entry := memoized(t, socketPath); entry.probed {
+			t.Error("an unreadable candidate was memoized as an answer: AdoptHostIdentity would clear a live host")
+		}
+		if _, probed := herdrClientLauncher(socketPath); probed {
+			t.Error("the second pane was told its attached client is gone")
+		}
+	})
+
+	t.Run("detach is still an answer", func(t *testing.T) {
+		socketPath := newHerdrSessionDir(t)
+		if err := os.WriteFile(herdrClientLogPath(socketPath), []byte("detached\n"), 0o600); err != nil {
+			t.Fatalf("seed client log: %v", err)
+		}
+		t.Cleanup(func() { forget(socketPath) })
+
+		if _, probed := herdrClientLauncher(socketPath); !probed {
+			t.Fatal("a detach is an answer")
+		}
+		if entry := memoized(t, socketPath); !entry.probed {
+			t.Error("a real detach was memoized as a non-answer: the stored host can now never be cleared")
+		}
+	})
 }
 
 // TestReadLauncherEnv_Herdr_UnprobableClientReportsHostUnknown is #1485 at the
@@ -676,11 +730,26 @@ func TestReadLauncherEnv_Herdr_UnprobableClientReportsHostUnknown(t *testing.T) 
 		t.Fatalf("the pane's own address must survive an unresolved host: %+v", l)
 	}
 
-	// The same pane once the log exists and nobody holds it open: now the
-	// emptiness is an answer, and the sweep is allowed to act on it.
+	// The same pane once the log exists and nobody holds it open: the
+	// emptiness is now an answer — but not yet a visible one. Since #1514 the
+	// non-answer above is memoized, so the recovery is deferred until that
+	// entry expires. This assertion is the price of that reversal, pinned
+	// rather than left to be rediscovered: a cached unknown clears nothing and
+	// is inert at every consumer, and deferring a recovery by at most one TTL
+	// is the ONLY behaviour it changes.
 	if err := os.WriteFile(herdrClientLogPath(socketPath), []byte("detached\n"), 0o600); err != nil {
 		t.Fatalf("seed client log: %v", err)
 	}
+	if _, hostKnown := ReadLauncherEnv(agentPID); hostKnown {
+		t.Error("the memoized non-answer was bypassed: every pane on this socket is re-paying the probe (#1514)")
+	}
+
+	// Dropping the entry stands in for the TTL elapsing — waiting out five real
+	// seconds would buy nothing but a slower suite. Once it is gone the detach
+	// is visible, which is what bounds the deferral at one TTL.
+	herdrClientCacheMu.Lock()
+	delete(herdrClientCache, socketPath)
+	herdrClientCacheMu.Unlock()
 	if _, hostKnown := ReadLauncherEnv(agentPID); !hostKnown {
 		t.Error("a detached session's host is known to be absent")
 	}
@@ -1045,5 +1114,138 @@ func TestResolveClientHostIdentity_ResolvableCandidateStillWins(t *testing.T) {
 	host, hostKnown = resolveClientHostIdentity([]int{exitedPID(t), client})
 	if !hostKnown || host == nil || host.TermProgram != "iTerm.app" {
 		t.Errorf("a resolving candidate wins outright past an unreadable one: got (%+v, %v)", host, hostKnown)
+	}
+}
+
+// --- non-answer memoization (#1514) -----------------------------------------
+
+// countingLsof points lsofPath at a stub that records one line per invocation
+// and prints table for every call, and returns a func reporting how many times
+// it ran. It is how the cost claims below are asserted as a COUNT of probes
+// rather than as a wall-clock time: the whole regression is "N panes pay N
+// scans instead of 1", and a timing assertion for that is a flake generator on
+// a loaded machine — which is, awkwardly, the exact machine state the defect
+// needs.
+//
+// lsofPath is a package var (process_darwin.go) rather than a seam invented
+// for this test, and no test in this package calls t.Parallel, so swapping it
+// under t.Cleanup is safe.
+func countingLsof(t *testing.T, table string) func() int {
+	t.Helper()
+	dir := t.TempDir()
+	counter := filepath.Join(dir, "calls")
+	stub := filepath.Join(dir, "lsof")
+	script := "#!/bin/sh\necho x >> " + counter + "\ncat <<'TABLE'\n" + table + "\nTABLE\n"
+	if err := os.WriteFile(stub, []byte(script), 0o700); err != nil {
+		t.Fatalf("write lsof stub: %v", err)
+	}
+	saved := lsofPath
+	lsofPath = stub
+	t.Cleanup(func() { lsofPath = saved })
+	return func() int {
+		b, err := os.ReadFile(counter)
+		if os.IsNotExist(err) {
+			return 0
+		}
+		if err != nil {
+			t.Fatalf("read lsof counter: %v", err)
+		}
+		return strings.Count(string(b), "\n")
+	}
+}
+
+// unreadableClientSocket builds a herdr session whose client log exists and
+// whose only attached "client" is a reaped PID — so the lsof probe answers,
+// every candidate is unreadable, and resolveClientHostIdentity returns the
+// (nil, false) non-answer #1492 introduced. Returns the socket path and the
+// scan counter.
+func unreadableClientSocket(t *testing.T) (string, func() int) {
+	t.Helper()
+	socketPath := newHerdrSessionDir(t)
+	logPath := herdrClientLogPath(socketPath)
+	if err := os.WriteFile(logPath, []byte("attached\n"), 0o600); err != nil {
+		t.Fatalf("seed client log: %v", err)
+	}
+	table := "COMMAND     PID USER   FD   TYPE DEVICE SIZE/OFF   NODE NAME\n" +
+		"herdr     " + strconv.Itoa(exitedPID(t)) + " ingo    3w   REG   1,18      372 136170 " + logPath
+	scans := countingLsof(t, table)
+	t.Cleanup(func() {
+		herdrClientCacheMu.Lock()
+		delete(herdrClientCache, socketPath)
+		herdrClientCacheMu.Unlock()
+	})
+	return socketPath, scans
+}
+
+// TestHerdrClientLauncher_UnreadableCandidateIsProbedOncePerSocket is #1514.
+// Every pane of one herdr server shares a socket, and the sweep resolves them
+// one after another, so the memo is the only thing standing between "one probe
+// per socket" and "one probe per pane". Before #1492 an unreadable candidate
+// answered (nil, true) and was memoized; after it, it answers (nil, false) and
+// — under #1485's rule — was not, so all eight panes re-paid the scan plus four
+// candidate probes, each of which is two ancestry walks on a 2s ceiling.
+//
+// Eight is the count herdrClientLauncher's own doc uses.
+func TestHerdrClientLauncher_UnreadableCandidateIsProbedOncePerSocket(t *testing.T) {
+	socketPath, scans := unreadableClientSocket(t)
+
+	const panes = 8
+	for i := 0; i < panes; i++ {
+		if _, probed := herdrClientLauncher(socketPath); probed {
+			t.Fatalf("pane %d: an unreadable candidate is not an answer", i)
+		}
+	}
+	if got := scans(); got != 1 {
+		t.Errorf("%d panes of one herdr server cost %d lsof scans, want 1 — each also drags %d candidate probes behind it",
+			panes, got, maxClientCandidates)
+	}
+}
+
+// TestSortedDistinctPIDs pins both halves of what herdrClientPIDs hands to
+// resolveClientHostIdentity. The ordering half is #1350's open question 3; the
+// distinctness half is what makes maxClientCandidates count clients rather than
+// file descriptors, since parseLsofFDs emits one entry per FD row by design.
+//
+// The dedup is latent rather than a live fix — herdr 0.8.0 gives one write
+// handle per client — so the rows below are constructed, and the "two handles"
+// case is the shape that would otherwise consume two of the four candidate
+// slots for one client.
+func TestSortedDistinctPIDs(t *testing.T) {
+	cases := map[string]struct{ in, want []int }{
+		"newest first":            {[]int{26932, 26941, 26940}, []int{26941, 26940, 26932}},
+		"two handles, one client": {[]int{26932, 26932}, []int{26932}},
+		"repeats collapse":        {[]int{7, 9, 7, 9, 9}, []int{9, 7}},
+		"empty":                   {nil, nil},
+	}
+	for name, tc := range cases {
+		got := sortedDistinctPIDs(append([]int(nil), tc.in...))
+		if len(got) != len(tc.want) {
+			t.Errorf("%s: got %v, want %v", name, got, tc.want)
+			continue
+		}
+		for i := range got {
+			if got[i] != tc.want[i] {
+				t.Errorf("%s: got %v, want %v", name, got, tc.want)
+				break
+			}
+		}
+	}
+}
+
+// TestSortedDistinctPIDs_DuplicateDoesNotConsumeACandidateSlot is the reason
+// the dedup is in this PR rather than filed for later: a duplicated PID is a
+// way to reach maxClientCandidates' truncation that has nothing to do with how
+// many clients are attached, and that truncation is one of the two triggers of
+// #1514's permanent non-answer.
+func TestSortedDistinctPIDs_DuplicateDoesNotConsumeACandidateSlot(t *testing.T) {
+	// Three clients, one of them holding two write handles: five FD rows.
+	rows := []int{100, 100, 200, 300, 300}
+	got := sortedDistinctPIDs(append([]int(nil), rows...))
+	if len(got) > maxClientCandidates {
+		t.Fatalf("%d FD rows for 3 clients still exceed the %d-candidate cap: %v",
+			len(rows), maxClientCandidates, got)
+	}
+	if len(got) != 3 {
+		t.Errorf("got %v, want one entry per client", got)
 	}
 }

--- a/core/application/services/pid_manager.go
+++ b/core/application/services/pid_manager.go
@@ -1319,9 +1319,19 @@ func (pm *PIDManager) touchAndSave(state *session.SessionState) {
 //     memoizes precisely because it is the expensive part. It still pays one
 //     `ps` for its controlling tty (~2ms measured), which is why the read is
 //     memoized per PID across the pass.
-//   - The one genuinely costly step, the lsof scan that finds the attached
-//     client, is memoized per socket path, so N panes of one herdr server cost
-//     one scan per sweep rather than N.
+//   - The one genuinely costly step — the lsof scan that finds the
+//     attached client, and the per-candidate identity probes behind it —
+//     is memoized per socket path, so N panes of one herdr server cost one
+//     probe per sweep rather than N. That now holds for every outcome,
+//     including the ones that determine nothing, and it did not always:
+//     #1492 routed an unreadable candidate to the same "could not look"
+//     answer as a failed scan, and #1485's rule was that such an answer is
+//     never memoized — so from #1492 until #1514 this bullet was false in
+//     exactly the case that costs the most: N panes each re-paid a scan
+//     plus up to four candidates, every candidate two ancestry walks on a
+//     2s ceiling, under precisely the load that made the candidate
+//     unreadable. herdrClientLauncher carries the reversal and its
+//     argument.
 //   - applyLauncherBackfill reports no change when the client has not moved,
 //     so the steady state writes nothing: no Save, no UpdatedAt bump, no push.
 //     The UpdatedAt bump is churn only, not a lifetime hazard: this runs solely

--- a/core/application/services/pid_manager.go
+++ b/core/application/services/pid_manager.go
@@ -1322,7 +1322,9 @@ func (pm *PIDManager) touchAndSave(state *session.SessionState) {
 //   - The one genuinely costly step — the lsof scan that finds the
 //     attached client, and the per-candidate identity probes behind it —
 //     is memoized per socket path, so N panes of one herdr server cost one
-//     probe per sweep rather than N. That now holds for every outcome,
+//     probe per socket per TTL rather than N — "per sweep" while a pass runs
+//     inside one TTL, which is the normal case but not guaranteed under the
+//     load that produces a non-answer (#1529). That now holds for every outcome,
 //     including the ones that determine nothing, and it did not always:
 //     #1492 routed an unreadable candidate to the same "could not look"
 //     answer as a failed scan, and #1485's rule was that such an answer is
@@ -1338,9 +1340,13 @@ func (pm *PIDManager) touchAndSave(state *session.SessionState) {
 //     for pid > 0 sessions, and sweepStaleSnapshot exempts any session with a
 //     live PID from the readyTTL reap before UpdatedAt is ever consulted.
 //
-// The read runs outside assignMu deliberately: ReadLauncherEnv is allowed to
-// block for up to two seconds, and assignMu serializes PID discovery for every
-// session. Only the merge is taken under the lock.
+// The read runs outside assignMu deliberately: ReadLauncherEnv may block, and
+// assignMu serializes PID discovery for every session. Only the merge is taken
+// under the lock. "For up to two seconds" is what this said, and it was wrong
+// in the same way the bullet above was: each shellout is bounded at 2s, the
+// herdr path's candidate loop is bounded by a COUNT rather than by time, so
+// one resolve can outlast this ticker. That is #1529, not something the memo
+// above fixes — the memo makes it rarer, not shorter.
 func (pm *PIDManager) refreshHerdrHosts(snaps []livenessSnapshot) {
 	if pm.launcherEnv == nil {
 		return


### PR DESCRIPTION
Closes #1514.

## What was wrong

`herdrClientLauncher` returned a non-answer without memoizing it. Every pane of one herdr
server shares a socket, and both callers (the startup seed and `refreshHerdrHosts`) resolve
panes one after another, serially — so the memo is the only thing standing between "one
probe per socket" and "one probe per pane".

#1492 (PR #1510) routed the **most expensive** outcome in that function to the un-memoized
branch: every candidate probed, none readable. Eight panes each re-paid an `lsof` scan plus
up to four candidate probes, each candidate two independent ancestry walks on
`readProcInfo`'s 2s ceiling — on the 5s `CheckPIDLiveness` ticker, under exactly the load
that makes a candidate unreadable.

Two triggers, not one:

- **Load-induced** (the issue as filed): a `ps` blows its ceiling. Self-clears.
- **Deterministic** (found by #1510's `/simplify` pass): a socket with more than
  `maxClientCandidates` candidates, none of whose first four resolve, can only ever return
  `(host, true)` or `(nil, false)` — never `(nil, true)`. It takes the no-cache branch
  permanently, in steady state, with nothing to clear it. It also *inverts the cap's own
  justification*: above the cap, the cap costs N−1 extra scans per sweep to save probing
  candidates 5..N once.

## The locked decision this reverses

#1485's rule was **"never memoize a non-answer"**, locked by
`TestHerdrClientLauncher_DoesNotCacheANonAnswer`. Its stated reason:

> caching "unknown" would spread a single failed probe across every session that shares
> this socket for the next 5 seconds, which is the opposite of what the tri-state buys.

**That rule is reversed here.** Both halves of its reason stopped holding:

1. **"Spreading an unknown" is inert — it is not the opposite of what the tri-state buys.**
   What the tri-state buys is that a probe which did not run is never mistaken for a detach
   and never clears a stored host. A memoized non-answer keeps that exactly, *provided it
   is stored as a non-answer*. The only thing it costs is deferring a **recovery**.
2. **The failure the reason describes is no longer the failure that arrives there.** #1485
   was written when the only non-answer was a failed `lsof` probe, which fails fast — so
   re-paying it per pane was nearly free and the "spread" was the only cost worth naming.
   #1492 made the dominant cost arrive at the same branch. The trade inverted.

**The new rule:** the memo holds what *one* probe of this socket determined, for one TTL —
an answer or the absence of one. `herdrClientCacheEntry` gains a `probed` field so the
non-answer travels as a non-answer, and nothing downstream can tell a cached one from a
fresh one.

**The lock was replaced, not deleted.** `TestHerdrClientLauncher_MemoizedNonAnswerIsStillANonAnswer`
pins the new rule and is a strictly stronger claim than the one it retires: the old lock
said *"do not cache"*; the new one says *"cache, and the cached thing must not be mistaken
for an answer"* — which is what actually protects #1485's invariant. #1485's defect was
never the caching; it was a probe that did not run being read as a detach. A cached `nil`
with no `probed` bit beside it would re-enter that defect *through the memo*, silently,
since every consumer reads the bool and not the nil. Its third sub-test is the vacuity
guard: a cache reporting `probed=false` for everything would satisfy the first two and
destroy the tri-state.

## The "behaviourally identical" claim — verified, not assumed

The issue asserts a cached `(nil,false)` and a fresh failed probe are identical to every
consumer. Enumerated rather than trusted:

- `herdrClientLauncher` has exactly **one** production caller — `ReadLauncherEnv`
  (`osutil.go`) — which uses the launcher only via `AdoptHostIdentity` (a no-op on nil) and
  passes the bool straight out.
- `hostKnown` has exactly **three** production consumers: `captureLauncher` ignores it
  outright; `backfillLauncher` and `refreshHerdrHosts` both route it through
  `applyHerdrHostBackfill`, which returns `false` before touching the stored launcher.
- The cache map is read nowhere outside its own accessors.
- Consent revocation short-circuits *above* `ReadLauncherEnv` (`startup.go`), so a revoked
  grant can never be served from the memo. No #570 interaction.

So the claim reduces to "the cached path returns the identical `(launcher, probed)` pair",
which the replacement lock asserts directly. **Confirmed.**

**But the issue understates the one cost it concedes, and so did the first draft of this
PR.** "At most one TTL" is wrong: the reader is the liveness sweep, so a recovery lands on
the next sweep whose probe actually runs. `SweepDeadPIDs` ticks at 5s and **backs off to
15s after three clean sweeps** — the idle steady state — so the honest worst case is about
one 15s interval, and at the 5s cadence it can take two intervals because `entry.at` is
stamped when the probe *finishes*. It cannot slip further, because `herdrClientCacheGet`
does not restamp on a hit. Stated that way in the code.

### A correction to the issue's own reasoning

The issue argues a shorter TTL for the unknown is not a workable compromise because "if the
probe itself takes ~4s, a 1s TTL expires before the next pane reaches the cache". That
mechanism is **wrong**: `herdrClientCachePut` stamps `at` when the probe *returns*, so
back-to-back panes on one socket hit at age ≈ 0 and even a 1s TTL would collapse that
burst. The conclusion still holds for a different, checkable reason: `refreshHerdrHosts`
iterates **sessions, not sockets**, so two panes of one server need not be adjacent — any
TTL shorter than a whole sweep pass can expire between them.

## Also in this PR

- **A non-answer never displaces a live answer** in the memo. This hazard is *new with the
  memo*: before it, a non-answer was never written. Two goroutines can miss for one socket
  and probe concurrently (`refreshHerdrHosts` reads outside `assignMu` on the sweep
  goroutine; PID discovery reaches `captureLauncher` on its own), and the non-answer is
  systematically the *slower* to produce — so last-writer-wins would let the outcome
  carrying no information erase a resolved host and restamp the entry fresh.
- **The FD-dedup interaction** the issue names as latent (`sortedDistinctPIDs`).
  `parseLsofFDs` emits one entry per FD row by design, so a client holding the client log on
  two write handles counts twice against `maxClientCandidates` — whose doc says it bounds
  *clients*. Still **unobserved on herdr 0.8.0** (`herdrClientPIDs`' doc records a live check
  where two attached clients produced exactly two writers), so this is a latent dependency on
  herdr's FD layout, not a defect today. Closed here because a duplicate is a way to reach
  the cap's truncation — one of the two triggers above — unrelated to how many clients are
  attached. Note this moves `readAll` from false to true in those cases, a change in the
  host-*clearing* direction: it is the honest direction (a second FD row for a candidate we
  did read is not a candidate we declined to look at) and a candidate genuinely dropped by
  the cap still poisons.
- **Three false claims corrected**, all of the same kind the ticket named:
  - `refreshHerdrHosts`' affordability bullet claimed one lsof scan per socket per sweep.
    Now true, and annotated with the window in which it was false.
  - `ReadLauncherEnv`'s contract said *"Never blocks longer than 2 seconds"* and
    `refreshHerdrHosts` repeated it. **Both false on the herdr path** and have been since
    #1350/#1492 — every individual shellout is bounded, the candidate loop is bounded by a
    **count**, not by time. Corrected; the fix (one aggregate deadline) is filed as **#1529**
    and deliberately not done here.

## Verification

### Defect test, seen RED first

`TestHerdrClientLauncher_UnreadableCandidateIsProbedOncePerSocket` asserts a **count of
probes** for 8 panes sharing a socket, not a wall-clock time. Run with the memoization
removed (i.e. #1485's rule restored), against the fixture as it ships:

```
=== RUN   TestHerdrClientLauncher_UnreadableCandidateIsProbedOncePerSocket
    osutil_darwin_test.go:1245: 8 panes of one herdr server cost 8 lsof scans, want 1 — each also drags 4 candidate probes behind it
--- FAIL: TestHerdrClientLauncher_UnreadableCandidateIsProbedOncePerSocket (0.10s)
FAIL
FAIL	irrlicht/core/adapters/inbound/agents/processlifecycle	0.321s
FAIL
```

`=== RUN` count was 1, so the `-run` filter matched exactly the intended test.

### Mutations — 9 of 9 seen RED

Every added check owes one. Each asserted **exactly 1 site** before running; each run's
`=== RUN` count checked non-zero; reverted by file copy with `git status --porcelain`
confirmed clean afterwards. Re-run in full against the final code after the simplify pass
and again after the fixture rewrite, because evidence against a superseded revision is not
evidence.

| # | Mutation | Caught by |
|---|---|---|
| M1 | memoize the non-answer AS an answer | `..._MemoizedNonAnswerIsStillANonAnswer` (4 assertions), `..._UnreadableCandidateIsProbedOncePerSocket` |
| M2 | restore #1485's rule (do not memoize) | the three above + `TestReadLauncherEnv_Herdr_UnprobableClientReportsHostUnknown` |
| M3 | memoize EVERYTHING as a non-answer | `..._MemoizedNonAnswerIsStillANonAnswer` (vacuity guard) |
| M4 | drop the dedup inside `sortedDistinctPIDs` | `TestSortedDistinctPIDs*`, `TestHerdrClientPIDs_DedupesFDRowsOfOneClient` |
| M5 | unwire `sortedDistinctPIDs` at its only caller | `TestHerdrClientPIDs_DedupesFDRowsOfOneClient` |
| M6 | a cache hit drops the memoized launcher | `..._MemoizedNonAnswerIsStillANonAnswer`, `..._NonAnswerDoesNotDisplaceALiveAnswer` |
| M7 | let a non-answer displace a live answer | `..._NonAnswerDoesNotDisplaceALiveAnswer` |
| M8 | refuse EVERY overwrite | same (vacuity guard for M7's fix) |
| M9 | never expire an entry | `TestHerdrClientCache_ExpiresANonAnswer` |

**M9 initially survived** — nothing pinned that the memo expires at all, and the entire case
for reversing #1485 rests on the cached non-answer being temporary. An unknown that never
lapsed would pin every pane of a herdr server to "host unknown" for the daemon's life, which
is worse than the bug being fixed, and arrived at through the fix for it. That test exists
because the mutation found its absence.

### Which tests are locks vs. proved

- **Proved red-first against unmodified code:** `..._UnreadableCandidateIsProbedOncePerSocket`.
- **Proved by mutation:** `..._MemoizedNonAnswerIsStillANonAnswer` (M1/M3/M6), the deferral
  arm of `TestReadLauncherEnv_Herdr_UnprobableClientReportsHostUnknown` (M2),
  `..._NonAnswerDoesNotDisplaceALiveAnswer` (M6/M7/M8), `TestSortedDistinctPIDs*` +
  `TestHerdrClientPIDs_DedupesFDRowsOfOneClient` (M4/M5), `..._ExpiresANonAnswer` (M9).
- **Locks that pass by construction and were NOT mutated** — pre-existing, pinning behaviour
  that must not change; regression cover, not evidence: `TestHerdrClientPIDs_ProbeTriState`,
  the `TestResolveClientHostIdentity_*` #1492 family, `TestHerdrClientWriters*`,
  `TestLsofProbeRan`.

### A test-infrastructure finding worth keeping

The probe counter was first a `#!/bin/sh` script written to a temp dir. Three tests then
failed inside `go test ./core/...` while passing when the package ran alone. The cause is
not flakiness in the usual sense: **on macOS the first exec of a newly written file is
evaluated for code signing**, and under a concurrent race-enabled build that took **2.14s
worst-of-12** — past the 2s ceiling `herdrClientPIDs` gives lsof. The probe then reported
"could not run", which is the exact state these tests exist to distinguish. A copied
`/bin/cat` was `signal: killed` on all 12 attempts.

Measured worst-of-N under that load: `/usr/bin/true` **3.6ms**, written script **2.14s**,
script-as-data **6.1ms**. So nothing new is exec'd any more — `lsofPath` becomes `/bin/sh`
(warm, signed) and the script it runs is *data*. Since `herdrClientPIDs` passes the
client-log path as lsof's only argument, the client log is necessarily where that script
lives; production only stats the path, so the substitution is invisible to the code under
test. Verified with three consecutive passes at load average ~7.

### Suites

`tools/preflight.sh` chunked in the foreground — `go`, `arch`, `tools`, `skills`, `posix`,
`security`: **all PASS** (ARS composite 7.93204 → 7.93192, not a regression). `--only web`
skipped deliberately: the diff is Go-only and touches no `web/` tree. Affected packages also
under `-race -count=1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
