### PR TITLE
fix(replay): pair transcript.md so the Go gates walk the catalog the sweep walks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -827,7 +827,7 @@ Before marking a ticket done, run the full suite — every layer must pass:
   transition, and until #1480 **nothing compared it to anything** — the
   goldens pin it only against their own previous value, `compareOrdered` walks
   `prev_state`/`new_state` index-by-index and never reads the time, and the
-  "N of 309 recordings diverge" headline every replay PR quotes is counts and
+  "N of M recordings diverge" headline every replay PR quotes is counts and
   kinds only (that headline is `extendedCheck.Diverges` counted over the
   catalog — see the next bullet for why it has exactly one definition). So a transition reproduced at the right position in the ORDER but
   31 seconds from when the daemon made it was a full pass, and the golden then
@@ -844,10 +844,10 @@ Before marking a ticket done, run the full suite — every layer must pass:
   twice. The reporting side (`timing_drift.go`) buckets and ranks those deltas;
   it reuses `core/domain/stats.Percentile` rather than carrying its own.
   It is a **ratchet, not a tolerance gate**, and that is the deliberate
-  shape: 24.3% of the catalog's 826 kind-matched pairs are still more than 1s
-  from their daemon, so a gate failing on all of them would protect nothing.
-  `TestSidecarReplayTransitionTimesMatchTheDaemonsOwnLog` walks all 309
-  sidecar-driven recordings, prints the distribution, and fails when a
+  shape: roughly a quarter of the catalog's kind-matched pairs are still more
+  than 1s from their daemon, so a gate failing on all of them would protect
+  nothing. `TestSidecarReplayTransitionTimesMatchTheDaemonsOwnLog` walks every
+  sidecar-driven recording, prints the distribution, and fails when a
   recording NEWLY drifts, when a pinned entry stops drifting and is left to rot,
   or when the aggregate counts grow — the same idiom `knownZeroTransition`
   uses. The 1s threshold is read off the measured distribution rather than

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -880,7 +880,7 @@ Before marking a ticket done, run the full suite — every layer must pass:
   `.Fabricates` — and every counter derives from it, including `main.go`'s exit
   code, which had its own wider spelling (`ordered || missing kinds || extra
   kinds`); those disjuncts are structurally unreachable and the census asserts
-  the two spellings agree on all 309 recordings rather than trusting that
+  the two spellings agree on every recording it walks rather than trusting that
   argument. `Diverges` is `len(OrderedMismatches) > 0`, and the near-misses are
   the point: "the counts or the kind sets differ" reads as a restatement and is
   one low, because one committed recording replays the same two kinds and the
@@ -899,29 +899,22 @@ Before marking a ticket done, run the full suite — every layer must pass:
   stops a diff which reports everything from looking correct.
   Three of the census's figures are not defect counts, and each exists because
   a prose sentence was carrying the number. `DivergentByCountsAndKinds` is the
-  near-miss spelling itself (139 against `Divergent`'s 140), so "they differ by
+  near-miss spelling itself, carried beside `Divergent` so that "they differ by
   exactly one recording" is re-derived every run instead of being true once.
   `UnpairedSidecars` and `PairedButUngraded` are the denominator's honesty:
-  `forEachSidecarRecording` pairs a sidecar with a sibling `transcript.jsonl`,
-  while `tools/replay-fixtures.sh` walks `transcript.md` too — so the sweep
-  replays 31 aider recordings the Go gates never see, and reported **142**
-  divergent against the census's **140** (measured; the two extra were both
-  `aider/4-2_multiple-agents-same-workspace`). A further 56 recordings are
-  paired but produce no extended check at all, chiefly the
-  process-owned-store adapters. Together the three account for every sidecar on
-  disk.
-  There is a standing coverage note in that: `knownZeroTransition`,
-  `knownFabricated` and #1480's ratchets are catalog-wide over the catalog
-  *that walk can see*, and have never been evaluated against any aider
-  recording. Widening the pairing is deferred as a **scope** call, and the
-  reason is stated that way because the tempting blast-radius reason is
-  measurably false — pairing `transcript.md` when no `transcript.jsonl` exists
-  adds exactly **2** gradeable recordings, both merely divergent, and moves
-  `knownZeroTransition`, `knownFabricated` and `knownFirstTransitionDrift` by
-  **nothing**. It would make the census agree with the sweep exactly. A
-  dismissal in this repo carries the same evidentiary bar as the claim it
-  supports, and this one was measured rather than assumed — the first draft of
-  this bullet asserted the opposite and a review caught it.
+  every sidecar on disk is either graded, unpairable, or paired-but-ungradeable,
+  and the three figures sum to the catalog. Nothing is unpairable today — the
+  Go walk and `tools/replay-fixtures.sh` pair the same two transcript names
+  through one rule (`pairedTranscript`, `cmd/replay/issue1517_pairing_test.go`),
+  so both walk the same set. The figure stays in the census at zero because it
+  is what would report the blindness returning: before #1517 it counted every
+  aider recording — graded by the sweep, by no Go gate, so
+  `knownZeroTransition`, `knownFabricated` and #1480's ratchets described the
+  catalog *that walk could see* rather than the catalog, and #1342's stated
+  goal of catalog-wide coverage was silently false for a whole adapter. The
+  remaining `PairedButUngraded` recordings produce no extended check at all —
+  the process-owned-store adapters, plus the aider recordings whose sidecar
+  names no real session and is not drivable.
 - Replay read boundary: the sidecar records `file_size` from the fswatcher's
   stat at fire time but stamps `ts` at the daemon's **dequeue** time, and the
   watcher's stat time is not a field of `lifecycle.Event` at all — so "where

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -904,9 +904,12 @@ Before marking a ticket done, run the full suite — every layer must pass:
   `UnpairedSidecars` and `PairedButUngraded` are the denominator's honesty:
   every sidecar on disk is either graded, unpairable, or paired-but-ungradeable,
   and the three figures sum to the catalog. Nothing is unpairable today — the
-  Go walk and `tools/replay-fixtures.sh` pair the same two transcript names
-  through one rule (`pairedTranscript`, `cmd/replay/issue1517_pairing_test.go`),
-  so both walk the same set. The figure stays in the census at zero because it
+  Go walk and `tools/replay-fixtures.sh` select recordings by the same two
+  transcript names, from the one declaration `replay.TranscriptNames`, with
+  `TestSweepAndGatesWalkTheSameTranscriptNames` pinning the shell's own `find`
+  list to it. They do not walk one identical *set* — the sweep enumerates
+  transcripts, the gates enumerate sidecars — and the NAMES are what had
+  drifted. The figure stays in the census at zero because it
   is what would report the blindness returning: before #1517 it counted every
   aider recording — graded by the sweep, by no Go gate, so
   `knownZeroTransition`, `knownFabricated` and #1480's ratchets described the

--- a/tools/onboarding-factory/cmd/replay/hook_fixture_test.go
+++ b/tools/onboarding-factory/cmd/replay/hook_fixture_test.go
@@ -272,16 +272,25 @@ func TestReplayWithSidecar_BlankLinesAreNotMalformed(t *testing.T) {
 
 // assertSidecarPairsWithTranscript checks one sidecar, reporting whether it was
 // in scope for the lock: it must carry a hook_received record and sit beside a
-// transcript.jsonl. A hook-carrying sidecar next to a transcript.md (aider) or
-// next to no transcript at all is skipped and reported as not checked, so the
-// caller's "the lock is vacuous" guard stays honest.
+// transcript pairedTranscript recognises. A hook-carrying sidecar next to no
+// transcript at all is skipped and reported as not checked, so the caller's
+// "the lock is vacuous" guard stays honest.
+//
+// It pairs through the shared helper rather than its own literal. Until #1517
+// this line read filepath.Join(..., "transcript.jsonl") and skipped every
+// transcript.md — the same blind spot the rest of that ticket closed, in the
+// one site that did not use the shared rule and so did not move with it. No
+// committed aider recording carries hooks today (measured: 17 hook-carrying
+// sidecars, all claudecode/copilot/hermes, every one beside a transcript.jsonl),
+// so this is a latent hole rather than a live one, which is exactly the kind
+// that reopens unnoticed.
 func assertSidecarPairsWithTranscript(t *testing.T, sidecar string) bool {
 	t.Helper()
 	if !sidecarHasHooks(t, sidecar) {
 		return false
 	}
-	transcript := filepath.Join(filepath.Dir(sidecar), "transcript.jsonl")
-	if _, err := os.Stat(transcript); err != nil {
+	transcript, paired := pairedTranscript(filepath.Dir(sidecar))
+	if !paired {
 		return false
 	}
 	if _, gotSidecar, useSidecar := resolveInputPaths(transcript); !useSidecar || gotSidecar != sidecar {

--- a/tools/onboarding-factory/cmd/replay/issue1342_debounce_test.go
+++ b/tools/onboarding-factory/cmd/replay/issue1342_debounce_test.go
@@ -200,6 +200,12 @@ var knownFabricated = map[string]string{
 // replay runs separate is deliberate — sharing the walk costs ~2.8s of re-run
 // and buys full independence between the gates, which is the right trade.
 //
+// The pairing itself is pairedTranscript, which accepts every name in
+// transcriptNames rather than transcript.jsonl alone. Narrowing it back is not
+// a cosmetic change: it is what made every aider recording invisible to this
+// gate, to #1480's and to the census, while tools/replay-fixtures.sh graded
+// them all along (#1517).
+//
 // The zero-recordings vacuity guard lives here rather than in each caller: it
 // is exactly the check that must not be forgotten by the third one, and it was
 // already written twice with two different wordings.
@@ -215,8 +221,8 @@ func forEachSidecarRecording(t *testing.T, visit func(name string, ec *extendedC
 		if d.IsDir() || filepath.Base(path) != eventsSidecarName {
 			return nil
 		}
-		transcript := filepath.Join(filepath.Dir(path), transcriptName)
-		if _, statErr := os.Stat(transcript); statErr != nil {
+		transcript, paired := pairedTranscript(filepath.Dir(path))
+		if !paired {
 			return nil
 		}
 		tp, sp, useSidecar := resolveInputPaths(transcript)

--- a/tools/onboarding-factory/cmd/replay/issue1480_timing_test.go
+++ b/tools/onboarding-factory/cmd/replay/issue1480_timing_test.go
@@ -266,13 +266,22 @@ const (
 // drains. Regenerating goldens then erases the only other trace, since
 // ordered_matches is the serialized field that would have moved.
 //
-// 36 of the 309 recordings already produce zero kind-matched pairs, so
-// "this recording measures nothing" is the current state of an eighth of the
-// catalog rather than a hypothetical — which is exactly why the floor is a
-// number and not merely a non-zero check.
+// 36 recordings already produce zero kind-matched pairs, so "this recording
+// measures nothing" is the current state of over a tenth of the catalog rather
+// than a hypothetical — which is exactly why the floor is a number and not
+// merely a non-zero check.
+//
+// Both floors are re-ratcheted whenever the population grows, and #1517 is why
+// that is spelled out rather than left to judgement. It widened the walk to
+// pair transcript.md, adding two recordings and two pairs; the floors were
+// sitting at exactly the old measured values, so they absorbed the growth as
+// slack and this gate stayed green under a mutation that narrowed the pairing
+// straight back. A floor whose stated job is catching a pairing shift that
+// drains the population has to be re-tightened onto the new measurement, or
+// the very next drain is free.
 const (
-	minKindMatchedPairs   = 826
-	minMeasuredRecordings = 273
+	minKindMatchedPairs   = 828
+	minMeasuredRecordings = 275
 )
 
 // reportDriftEnumeration prints the drifted set — the deliverable of #1480,

--- a/tools/onboarding-factory/cmd/replay/issue1503_census_test.go
+++ b/tools/onboarding-factory/cmd/replay/issue1503_census_test.go
@@ -2,8 +2,8 @@ package main
 
 import (
 	"fmt"
+	"go/format"
 	"io/fs"
-	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -26,14 +26,6 @@ import (
 // verification mechanism must fail loudly when it cannot run": a number that
 // DOCUMENTS behaviour but is not PRODUCED by it drifts silently, and is then
 // quoted with full confidence.
-
-// transcriptName is the transcript filename forEachSidecarRecording pairs a
-// sidecar with. It is a constant beside eventsSidecarName because the census
-// and the walk it audits must apply the SAME pairing rule — the whole meaning
-// of UnpairedSidecars is the difference between this rule and the wider one
-// tools/replay-fixtures.sh uses, and two bare string literals is how that
-// difference stops being deliberate.
-const transcriptName = "transcript.jsonl"
 
 // catalogCensus is the census of the committed catalog's populations, plus the
 // denominator they are quoted against ("N of 309").
@@ -67,36 +59,28 @@ type catalogCensus struct {
 	// rather than being a sentence that was true once. The recording making up
 	// the difference is pinned by name as divergenceWitness.
 	DivergentByCountsAndKinds int
-	// UnpairedSidecars counts recorded sidecars the walk cannot PAIR: it
-	// requires a sibling transcriptName, and these recordings carry a
-	// transcript.md instead — today, every aider recording.
+	// UnpairedSidecars counts recorded sidecars the walk cannot PAIR at all:
+	// no name in transcriptNames sits beside them. It is 0, and the walk is
+	// therefore not known to be blind to any recording on disk.
 	//
-	// It is in the census because leaving it out is how the same headline came
-	// to have two values: tools/replay-fixtures.sh walks `-name
-	// transcript.jsonl -o -name transcript.md`, so it replays these too and
-	// reports a higher divergence figure. Measured, not asserted — the sweep
-	// reported 142 against this census's 140 while this field was being added,
-	// and diffing the two sets named the two extra recordings exactly (both
-	// aider/4-2_multiple-agents-same-workspace).
-	//
-	// Also a standing coverage note: #1342's known-lists and #1480's ratchets
-	// have never been evaluated against any of these recordings, so
-	// "catalog-wide" is true of the catalog this walk can see rather than of
-	// the catalog.
-	//
-	// Why widening the pairing is deferred is a SCOPE call and is stated as
-	// one, because the natural blast-radius reason is measurably false:
-	// pairing transcript.md when no transcriptName exists adds exactly 2
-	// gradeable recordings, both merely divergent, and moves
-	// knownZeroTransition, knownFabricated and knownFirstTransitionDrift by
-	// nothing at all. It would make this census agree with the sweep exactly,
-	// at the cost of re-replaying the aider recordings that then produce no
-	// extended check.
+	// A zero figure is kept in the census rather than deleted because it is
+	// the one number that would report the blindness coming back. Until #1517
+	// this field counted 31 — every aider recording, paired by
+	// tools/replay-fixtures.sh and by no Go gate, so #1342's known-lists and
+	// #1480's ratchets described the catalog that walk could see rather than
+	// the catalog. A recording committed with its transcript in some third
+	// format would be invisible to every gate here and would land in exactly
+	// this figure. A zero that is measured every run is evidence; a zero that
+	// is assumed is the shape #1503 was filed about.
 	UnpairedSidecars int
 	// PairedButUngraded counts recordings the walk DID pair and still could not
 	// grade: resolveInputPaths declined the sidecar, or the replay produced no
-	// extended check at all — chiefly the process-owned-store adapters, which
-	// record no fswatcher fires and legitimately degrade to transcript-only.
+	// extended check at all. Two populations dominate, both legitimate — the
+	// process-owned-store adapters, which record no fswatcher fires and degrade
+	// to transcript-only, and the 29 aider recordings whose sidecar names no
+	// real session in a transcript_new event and is therefore not drivable
+	// (the benign half of the pair TestReplayWithSidecar_CorruptSidecarIsFatal
+	// separates).
 	//
 	// Derived as (all recorded sidecars) - UnpairedSidecars - Recordings, so
 	// the three account for every sidecar on disk. That identity holds by
@@ -125,13 +109,13 @@ type catalogCensus struct {
 // point is that it cannot move UNNOTICED, and that no doc comment anywhere
 // carries a second, hand-typed copy of it.
 var censusOfTheCommittedCatalog = catalogCensus{
-	Recordings:                309,
+	Recordings:                311,
 	Zero:                      1,
 	Fabricated:                1,
-	Divergent:                 140,
-	DivergentByCountsAndKinds: 139,
-	UnpairedSidecars:          31,
-	PairedButUngraded:         56,
+	Divergent:                 142,
+	DivergentByCountsAndKinds: 141,
+	UnpairedSidecars:          0,
+	PairedButUngraded:         85,
 }
 
 // literal renders the census as the Go source to paste over the declaration
@@ -340,8 +324,8 @@ func TestCatalogCensusMatchesTheCommittedFigures(t *testing.T) {
 }
 
 // countSidecars returns how many recorded sidecars exist under the catalog and
-// how many of them the walk cannot pair, because no sibling transcriptName sits
-// beside them.
+// how many of them the walk cannot pair, because no name in transcriptNames
+// sits beside them.
 //
 // It stats rather than replays, so it costs milliseconds and, more to the
 // point, it cannot be fooled by the very pairing it is measuring: asking the
@@ -357,7 +341,7 @@ func countSidecars(t *testing.T) (total, unpaired int) {
 			return nil
 		}
 		total++
-		if _, statErr := os.Stat(filepath.Join(filepath.Dir(path), transcriptName)); statErr != nil {
+		if _, ok := pairedTranscript(filepath.Dir(path)); !ok {
 			unpaired++
 		}
 		return nil
@@ -456,6 +440,25 @@ func TestCensusDiffNamesEveryStaleShape(t *testing.T) {
 		f(&c)
 		return c
 	}
+	// moved renders the verdict for one perturbed field, taking the MEASURED
+	// half from the live census rather than restating it.
+	//
+	// The rows below used to spell their expectations out in full — "Divergent:
+	// committed 139, measured 140" — which put a hand-typed copy of every
+	// census figure in the corpus that exists to remove hand-typed copies. It
+	// held only while the census stood still: #1517 widened the walk, the
+	// census legitimately moved, and seven of these rows failed for a reason
+	// none of them is about. What each row pins is the SHAPE of the verdict and
+	// the perturbation that provokes it; the figure is the census's business.
+	moved := func(field string, committed int) string {
+		for _, f := range current.fields() {
+			if f.name == field {
+				return fmt.Sprintf("%s: committed %d, measured %d", field, committed, f.value)
+			}
+		}
+		t.Fatalf("no census field named %q — the corpus names a figure that no longer exists", field)
+		return ""
+	}
 
 	for _, tc := range []struct {
 		name      string
@@ -472,75 +475,83 @@ func TestCensusDiffNamesEveryStaleShape(t *testing.T) {
 			// low, internally consistent, and invisible without re-measuring.
 			name:      "divergent one low — #1478's error",
 			committed: with(func(c *catalogCensus) { c.Divergent-- }),
-			want:      []string{"Divergent: committed 139, measured 140"},
+			want:      []string{moved("Divergent", current.Divergent-1)},
 		},
 		{
 			// The other direction. A count that only ever fails when it is too
 			// LOW blesses a regression that raises it.
 			name:      "divergent one high — a fidelity regression left uncounted",
 			committed: with(func(c *catalogCensus) { c.Divergent++ }),
-			want:      []string{"Divergent: committed 141, measured 140"},
+			want:      []string{moved("Divergent", current.Divergent+1)},
 		},
 		{
 			// The near-miss converging on Diverges means the catalog lost its
 			// only order-only witness — a coverage loss that looks like
 			// agreement.
 			name:      "the near-miss spelling stopped being a near miss",
-			committed: with(func(c *catalogCensus) { c.DivergentByCountsAndKinds = 140 }),
-			want:      []string{"DivergentByCountsAndKinds: committed 140, measured 139"},
+			committed: with(func(c *catalogCensus) { c.DivergentByCountsAndKinds = current.Divergent }),
+			want:      []string{moved("DivergentByCountsAndKinds", current.Divergent)},
 		},
 		{
 			// The shape #1342 and #1478 both moved: a zero-transition recording
 			// rescued, with the doc comments still claiming the old figure.
 			name:      "zero stale at its pre-#1478 value",
 			committed: with(func(c *catalogCensus) { c.Zero = 4 }),
-			want:      []string{"Zero: committed 4, measured 1"},
+			want:      []string{moved("Zero", 4)},
 		},
 		{
 			name:      "fabricated stale — the count that must never rise unnoticed",
 			committed: with(func(c *catalogCensus) { c.Fabricated = 3 }),
-			want:      []string{"Fabricated: committed 3, measured 1"},
+			want:      []string{moved("Fabricated", 3)},
 		},
 		{
-			// The gap between this census and tools/replay-fixtures.sh's own
-			// divergence figure is made of exactly this population, so a stale
-			// value here is a stale explanation of a live discrepancy.
+			// This population is what the Go walk cannot pair at all. It is 0,
+			// and a committed non-zero value would be claiming the gates are
+			// blind to recordings they now read — the state #1517 closed.
 			name:      "the unpaired-sidecar population moved",
 			committed: with(func(c *catalogCensus) { c.UnpairedSidecars = 29 }),
-			want:      []string{"UnpairedSidecars: committed 29, measured 31"},
+			want:      []string{moved("UnpairedSidecars", 29)},
 		},
 		{
 			// Moves when the walk's skip conditions change — a store adapter
 			// gaining an fswatcher trace, or a pairing rule quietly widening.
 			name:      "the ungraded population moved",
 			committed: with(func(c *catalogCensus) { c.PairedButUngraded = 54 }),
-			want:      []string{"PairedButUngraded: committed 54, measured 56"},
+			want:      []string{moved("PairedButUngraded", 54)},
 		},
 		{
 			// The denominator rots on its own schedule: every promotion or
 			// retirement moves it, and nothing else in the census need change.
 			name:      "the denominator alone went stale",
 			committed: with(func(c *catalogCensus) { c.Recordings = 300 }),
-			want:      []string{"Recordings: committed 300, measured 309"},
+			want:      []string{moved("Recordings", 300)},
 		},
 		{
 			// Everything at once, in declaration order — a census pasted from a
 			// different branch names every figure rather than the first one.
 			name: "every figure moved, and every one is named",
+			// Every field is perturbed by a distinct non-zero delta rather than
+			// set to fixed values: a constant that happens to equal the live
+			// figure silently drops its line from the expected verdict, which
+			// is how this row would stop testing "every one is named" without
+			// failing. UnpairedSidecars reached exactly that state at 0.
 			committed: with(func(c *catalogCensus) {
-				*c = catalogCensus{
-					Recordings: 300, Zero: 4, Fabricated: 3, Divergent: 145,
-					DivergentByCountsAndKinds: 144, UnpairedSidecars: 0, PairedButUngraded: 0,
-				}
+				c.Recordings -= 9
+				c.Zero += 3
+				c.Fabricated += 2
+				c.Divergent += 5
+				c.DivergentByCountsAndKinds += 5
+				c.UnpairedSidecars += 7
+				c.PairedButUngraded -= 4
 			}),
 			want: []string{
-				"Recordings: committed 300, measured 309",
-				"Zero: committed 4, measured 1",
-				"Fabricated: committed 3, measured 1",
-				"Divergent: committed 145, measured 140",
-				"DivergentByCountsAndKinds: committed 144, measured 139",
-				"UnpairedSidecars: committed 0, measured 31",
-				"PairedButUngraded: committed 0, measured 56",
+				moved("Recordings", current.Recordings-9),
+				moved("Zero", current.Zero+3),
+				moved("Fabricated", current.Fabricated+2),
+				moved("Divergent", current.Divergent+5),
+				moved("DivergentByCountsAndKinds", current.DivergentByCountsAndKinds+5),
+				moved("UnpairedSidecars", current.UnpairedSidecars+7),
+				moved("PairedButUngraded", current.PairedButUngraded-4),
 			},
 		},
 	} {
@@ -592,21 +603,33 @@ func TestCensusLiteralIsValidPasteableSource(t *testing.T) {
 		t.Errorf("literal() has %d lines, want %d (one per field plus both braces):\n%s",
 			got, want, lit)
 	}
-	// The alignment is pinned verbatim because gofmt is what the pasted block
-	// must survive: a literal that is correct but misaligned gets reformatted
-	// on the next gofmt run and stops being byte-identical to what the test
-	// prints, which is the property the idiom rests on.
-	for _, want := range []string{
-		"\tRecordings:                309,\n",
-		"\tZero:                      1,\n",
-		"\tFabricated:                1,\n",
-		"\tDivergent:                 140,\n",
-		"\tDivergentByCountsAndKinds: 139,\n",
-		"\tUnpairedSidecars:          31,\n",
-		"\tPairedButUngraded:         56,\n",
-	} {
-		if !strings.Contains(lit, want) {
-			t.Errorf("literal() is missing the gofmt-aligned line %q:\n%s", want, lit)
+	// The alignment is checked by running the block through gofmt itself and
+	// requiring it back unchanged, which IS the property the idiom rests on: a
+	// literal that is correct but misaligned is reformatted on the next gofmt
+	// run and stops being byte-identical to what this test prints.
+	//
+	// It used to be pinned as seven verbatim lines carrying the committed
+	// figures. That spelling asserted the alignment and the CENSUS at once, so
+	// it failed whenever a figure legitimately moved — #1517 widened the walk
+	// and it broke, having caught nothing about alignment. Round-tripping is
+	// also strictly stronger: the verbatim list could only confirm the widths
+	// someone typed, while gofmt is the authority those widths were guessing
+	// at. It is not tautological, because literal() derives the column itself
+	// rather than deferring to go/format.
+	if formatted, err := format.Source([]byte(lit)); err != nil {
+		t.Errorf("literal() is not valid Go source (%v):\n%s", err, lit)
+	} else if string(formatted) != lit {
+		t.Errorf("literal() is not gofmt-canonical, so the pasted block would be reformatted "+
+			"and stop matching what this test prints.\n got:\n%s\nwant:\n%s", lit, formatted)
+	}
+	// Each field still has to appear with its measured value, or a
+	// gofmt-canonical block that simply omitted one would pass above.
+	for _, f := range censusOfTheCommittedCatalog.fields() {
+		if !strings.Contains(lit, fmt.Sprintf("%s:", f.name)) {
+			t.Errorf("literal() omits the %s field:\n%s", f.name, lit)
+		}
+		if !strings.Contains(lit, fmt.Sprintf(" %d,\n", f.value)) {
+			t.Errorf("literal() does not carry %s's value %d:\n%s", f.name, f.value, lit)
 		}
 	}
 }

--- a/tools/onboarding-factory/cmd/replay/issue1503_census_test.go
+++ b/tools/onboarding-factory/cmd/replay/issue1503_census_test.go
@@ -154,10 +154,14 @@ func (c catalogCensus) literal() string {
 // both, stayed gofmt-canonical, kept the right line count, and shipped a census
 // of garbage past the whole package (measured, on review).
 //
-// The width is re-derived by the same rule literal() uses. That is not
-// tautological here: the round-trip through go/format in
-// TestCensusLiteralIsValidPasteableSource is what pins the width itself, and
-// this function pins the pairing the round-trip cannot see.
+// The width is re-derived by the same rule literal() uses. Do NOT "simplify"
+// that by having literal() call this function: the moment the renderer and the
+// expectation share one implementation, every assertion below is comparing a
+// string to itself and passes for any pairing whatsoever. The duplication IS
+// the test. It is not tautological as written, because the round-trip through
+// go/format in TestCensusLiteralIsValidPasteableSource is an independent
+// authority on the width, and this function pins the pairing that round-trip
+// cannot see.
 func (c catalogCensus) alignedFieldLine(f censusField) string {
 	width := 0
 	for _, other := range c.fields() {

--- a/tools/onboarding-factory/cmd/replay/issue1503_census_test.go
+++ b/tools/onboarding-factory/cmd/replay/issue1503_census_test.go
@@ -28,14 +28,14 @@ import (
 // quoted with full confidence.
 
 // catalogCensus is the census of the committed catalog's populations, plus the
-// denominator they are quoted against ("N of 309").
+// denominator they are quoted against ("N of <Recordings>").
 //
 // The denominator is a field rather than a constant because it is quoted just
 // as often and rots the same way: it moves whenever a recording is promoted or
 // retired, and a stale one silently rescales every ratio computed from it.
 type catalogCensus struct {
 	// Recordings is how many sidecar-driven recordings the walk reached — the
-	// denominator in "N of 309".
+	// denominator every population here is quoted against.
 	Recordings int
 	// Zero counts extendedCheck.ReproducesNothing: the daemon logged
 	// transitions, the replay reproduced none, so the golden asserts nothing.
@@ -141,6 +141,31 @@ func (c catalogCensus) literal() string {
 	}
 	b.WriteString("}\n")
 	return b.String()
+}
+
+// alignedFieldLine renders the one line literal() must contain for a field:
+// its name and ITS OWN value, bound together in one string.
+//
+// Bound rather than checked apart, because that is the property the pasted
+// block rests on and the one an independent pair of Contains calls cannot see.
+// #1517 replaced a hand-typed verbatim list here with two separate
+// substring checks — "the name appears" and "the value appears somewhere" — and
+// a literal() that paired every field with its NEIGHBOUR's value satisfied
+// both, stayed gofmt-canonical, kept the right line count, and shipped a census
+// of garbage past the whole package (measured, on review).
+//
+// The width is re-derived by the same rule literal() uses. That is not
+// tautological here: the round-trip through go/format in
+// TestCensusLiteralIsValidPasteableSource is what pins the width itself, and
+// this function pins the pairing the round-trip cannot see.
+func (c catalogCensus) alignedFieldLine(f censusField) string {
+	width := 0
+	for _, other := range c.fields() {
+		if n := len(other.name) + 1; n > width {
+			width = n
+		}
+	}
+	return fmt.Sprintf("\t%-*s %d,\n", width, f.name+":", f.value)
 }
 
 // censusField pairs a figure with the name it is declared and reported under,
@@ -569,12 +594,9 @@ func TestCensusDiffNamesEveryStaleShape(t *testing.T) {
 			}
 			lit := current.literal()
 			for _, f := range current.fields() {
-				if !strings.Contains(lit, fmt.Sprintf("%s:", f.name)) {
-					t.Errorf("literal() omits the %s field entirely:\n%s", f.name, lit)
-				}
-				if !strings.Contains(lit, fmt.Sprintf(" %d,\n", f.value)) {
-					t.Errorf("literal() does not carry the measured %s value %d:\n%s",
-						f.name, f.value, lit)
+				if want := current.alignedFieldLine(f); !strings.Contains(lit, want) {
+					t.Errorf("literal() does not carry %s beside its measured value; "+
+						"want the line %q:\n%s", f.name, want, lit)
 				}
 			}
 		})
@@ -622,14 +644,14 @@ func TestCensusLiteralIsValidPasteableSource(t *testing.T) {
 		t.Errorf("literal() is not gofmt-canonical, so the pasted block would be reformatted "+
 			"and stop matching what this test prints.\n got:\n%s\nwant:\n%s", lit, formatted)
 	}
-	// Each field still has to appear with its measured value, or a
-	// gofmt-canonical block that simply omitted one would pass above.
+	// Each field still has to appear beside ITS OWN value. Checking the name
+	// and the value as two independent substrings is satisfied by a literal
+	// that pairs every field with the wrong figure, which is worse than an
+	// omission: the pasted block would be gofmt-clean and wrong.
 	for _, f := range censusOfTheCommittedCatalog.fields() {
-		if !strings.Contains(lit, fmt.Sprintf("%s:", f.name)) {
-			t.Errorf("literal() omits the %s field:\n%s", f.name, lit)
-		}
-		if !strings.Contains(lit, fmt.Sprintf(" %d,\n", f.value)) {
-			t.Errorf("literal() does not carry %s's value %d:\n%s", f.name, f.value, lit)
+		if want := censusOfTheCommittedCatalog.alignedFieldLine(f); !strings.Contains(lit, want) {
+			t.Errorf("literal() is missing the gofmt-aligned line %q for %s:\n%s",
+				want, f.name, lit)
 		}
 	}
 }

--- a/tools/onboarding-factory/cmd/replay/issue1517_pairing_test.go
+++ b/tools/onboarding-factory/cmd/replay/issue1517_pairing_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"bufio"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -124,13 +123,6 @@ func TestTheCatalogWalkGradesMarkdownTranscripts(t *testing.T) {
 		len(markdown), checked, markdown)
 }
 
-// sweepScript is tools/replay-fixtures.sh, read as the other half of the
-// contract rather than described.
-func sweepScript(t *testing.T) string {
-	t.Helper()
-	return mustAbs(t, filepath.Join("..", "..", "..", "replay-fixtures.sh"))
-}
-
 // findNameRE picks the -name arguments out of the sweep's find invocation.
 var findNameRE = regexp.MustCompile(`-name\s+'([^']+)'`)
 
@@ -150,17 +142,15 @@ var findNameRE = regexp.MustCompile(`-name\s+'([^']+)'`)
 // TestDriftSummary_FormatIsTheShellContract hardcodes the sweep's pattern and
 // so pins the format while still allowing the two files to disagree about it.
 func TestSweepAndGatesWalkTheSameTranscriptNames(t *testing.T) {
-	f, err := os.Open(sweepScript(t))
+	sweep := mustAbs(t, filepath.Join("..", "..", "..", "replay-fixtures.sh"))
+	src, err := os.ReadFile(sweep)
 	if err != nil {
-		t.Fatalf("open the sweep: %v", err)
+		t.Fatalf("read the sweep: %v", err)
 	}
-	defer f.Close()
 
 	var names []string
 	var line string
-	scanner := bufio.NewScanner(f)
-	for scanner.Scan() {
-		l := scanner.Text()
+	for _, l := range strings.Split(string(src), "\n") {
 		if !strings.Contains(l, "find \"$FIXTURES_ROOT\"") {
 			continue
 		}
@@ -169,9 +159,6 @@ func TestSweepAndGatesWalkTheSameTranscriptNames(t *testing.T) {
 			names = append(names, m[1])
 		}
 		break
-	}
-	if err := scanner.Err(); err != nil {
-		t.Fatalf("read the sweep: %v", err)
 	}
 	// Both guards are the vacuity check this contract needs most: a rename in
 	// the script makes every assertion below pass over an empty list, which is

--- a/tools/onboarding-factory/cmd/replay/issue1517_pairing_test.go
+++ b/tools/onboarding-factory/cmd/replay/issue1517_pairing_test.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// Issue #1517: every aider recording was invisible to every Go replay gate.
+//
+// tools/replay-fixtures.sh has always walked `-name transcript.jsonl -o -name
+// transcript.md`, while the Go walk paired a sidecar with a sibling
+// transcript.jsonl and nothing else — so the sweep graded 31 aider recordings
+// that #1342's known-lists, #1480's ratchets and #1503's census never saw. The
+// two walks reported different counts for the same headline, which is how the
+// divergence became visible at all, but the counts were the symptom — and the
+// live ones are censusOfTheCommittedCatalog's, machine-generated, rather than
+// restated here. The gates' stated design goal is that they are catalog-wide "so a
+// newly recorded fixture is covered by existing coverage rather than by
+// somebody remembering" (#1342), and for one adapter that was simply false.
+//
+// This file holds the pairing rule itself and the lock on it. The rule is one
+// function so that widening or narrowing it is a single reviewable edit rather
+// than a filename repeated at each walk.
+
+// transcriptNames are the transcript filenames the catalog walks pair a sidecar
+// with, in preference order. They are ONE list because every walk over this
+// catalog must apply the same rule: tools/replay-fixtures.sh walks exactly
+// these two names, and a bare string literal at each Go site is how the two
+// came to disagree about which recordings exist at all.
+//
+// The ORDER is part of the rule rather than an accident of iteration:
+// internal/validate/expected.go treats a recording carrying both names as
+// ambiguous, so the walk must not let directory order decide. No committed
+// recording has both today — measured over the whole catalog: 396 sidecars,
+// 365 beside a transcript.jsonl, 31 beside a transcript.md, none with both and
+// none with neither — and TestPairedTranscriptPrefersJSONL pins the tie-break
+// so it stays decided if one ever does.
+var transcriptNames = []string{"transcript.jsonl", "transcript.md"}
+
+// pairedTranscript returns the transcript sitting beside a sidecar in dir, and
+// whether any exists at all.
+//
+// One function rather than a filename per call site. Before #1517 the rule was
+// spelled three times over — a const in issue1503_census_test.go used by two
+// walks, and a hardcoded "transcript.jsonl" in hook_fixture_test.go — so a
+// change to the const moved two of the three sites and left the third silently
+// narrower.
+func pairedTranscript(dir string) (string, bool) {
+	for _, name := range transcriptNames {
+		p := filepath.Join(dir, name)
+		if _, err := os.Stat(p); err == nil {
+			return p, true
+		}
+	}
+	return "", false
+}
+
+// TestPairedTranscriptPrefersJSONL pins the tie-break, the "no transcript at
+// all" answer, and — the arm that matters — that a markdown transcript pairs
+// when it is the only one present.
+//
+// Hermetic, so it keeps failing on a narrowed rule even if the catalog stops
+// carrying a markdown recording. That is the division of labour with the
+// catalog lock below: this one pins the RULE, that one proves the rule reaches
+// real committed recordings.
+func TestPairedTranscriptPrefersJSONL(t *testing.T) {
+	both := t.TempDir()
+	writeFile(t, filepath.Join(both, "transcript.jsonl"), "{}\n")
+	writeFile(t, filepath.Join(both, "transcript.md"), "# hello\n")
+	if got, ok := pairedTranscript(both); !ok || filepath.Base(got) != "transcript.jsonl" {
+		t.Errorf("a recording carrying BOTH names paired with (%q, %v), want transcript.jsonl — "+
+			"internal/validate/expected.go calls that shape ambiguous, so the tie-break must be "+
+			"the declared order and not the filesystem's", filepath.Base(got), ok)
+	}
+
+	mdOnly := t.TempDir()
+	writeFile(t, filepath.Join(mdOnly, "transcript.md"), "# hello\n")
+	if got, ok := pairedTranscript(mdOnly); !ok || filepath.Base(got) != "transcript.md" {
+		t.Errorf("a markdown-only recording paired with (%q, %v), want transcript.md — this is "+
+			"#1517 itself: every aider recording is this shape, and a rule that answers false "+
+			"here hides all 31 from every Go gate while tools/replay-fixtures.sh grades them",
+			filepath.Base(got), ok)
+	}
+
+	if got, ok := pairedTranscript(t.TempDir()); ok {
+		t.Errorf("an empty directory paired with %q — a walk that pairs a sidecar with a "+
+			"transcript that does not exist reports recordings it never read", got)
+	}
+}
+
+// TestTheCatalogWalkGradesMarkdownTranscripts is the catalog-wide half of the
+// lock: the shared walk must actually reach committed recordings whose
+// transcript is a transcript.md, not merely be capable of it.
+//
+// This is the assertion that goes red if the pairing is narrowed back to
+// transcript.jsonl alone, which is what the widening owes as its mutation
+// evidence. The census gate catches the same narrowing a second way — its
+// population would SHRINK from 311 to 309 and trip the fail-loudly guard ahead
+// of the paste-the-literal advice — but that one reports a moved NUMBER, while
+// this one names the property.
+func TestTheCatalogWalkGradesMarkdownTranscripts(t *testing.T) {
+	var markdown []string
+	checked := forEachSidecarRecording(t, func(name string, _ *extendedCheck) {
+		if filepath.Base(name) == "transcript.md" {
+			markdown = append(markdown, name)
+		}
+	})
+	if len(markdown) == 0 {
+		t.Fatalf("the walk graded %d recordings and not one of them has a transcript.md, so "+
+			"every aider recording in the catalog is invisible to this gate, to #1480's and to "+
+			"#1503's census — the exact state #1517 closed. Either pairedTranscript has been "+
+			"narrowed back to transcript.jsonl, or the catalog's markdown recordings stopped "+
+			"producing an extended check; the second is a replay regression and not a reason to "+
+			"delete this test", checked)
+	}
+	t.Logf("the walk grades %d markdown-transcript recording(s) of %d:\n  %v",
+		len(markdown), checked, markdown)
+}

--- a/tools/onboarding-factory/cmd/replay/issue1517_pairing_test.go
+++ b/tools/onboarding-factory/cmd/replay/issue1517_pairing_test.go
@@ -1,9 +1,15 @@
 package main
 
 import (
+	"bufio"
 	"os"
 	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
 	"testing"
+
+	internalreplay "irrlicht/tools/onboarding-factory/internal/replay"
 )
 
 // Issue #1517: every aider recording was invisible to every Go replay gate.
@@ -23,11 +29,11 @@ import (
 // function so that widening or narrowing it is a single reviewable edit rather
 // than a filename repeated at each walk.
 
-// transcriptNames are the transcript filenames the catalog walks pair a sidecar
-// with, in preference order. They are ONE list because every walk over this
-// catalog must apply the same rule: tools/replay-fixtures.sh walks exactly
-// these two names, and a bare string literal at each Go site is how the two
-// came to disagree about which recordings exist at all.
+// transcriptNames is the rule these walks pair by, and it is the PRODUCTION
+// declaration rather than a copy of it: internal/replay.TranscriptNames is what
+// SynthesizeEventsFromTranscript reads, so the gates cannot come to disagree
+// with the code they are grading. That disagreement is exactly #1517 — the
+// gates' copy said transcript.jsonl alone.
 //
 // The ORDER is part of the rule rather than an accident of iteration:
 // internal/validate/expected.go treats a recording carrying both names as
@@ -36,7 +42,7 @@ import (
 // 365 beside a transcript.jsonl, 31 beside a transcript.md, none with both and
 // none with neither — and TestPairedTranscriptPrefersJSONL pins the tie-break
 // so it stays decided if one ever does.
-var transcriptNames = []string{"transcript.jsonl", "transcript.md"}
+var transcriptNames = internalreplay.TranscriptNames
 
 // pairedTranscript returns the transcript sitting beside a sidecar in dir, and
 // whether any exists at all.
@@ -116,4 +122,79 @@ func TestTheCatalogWalkGradesMarkdownTranscripts(t *testing.T) {
 	}
 	t.Logf("the walk grades %d markdown-transcript recording(s) of %d:\n  %v",
 		len(markdown), checked, markdown)
+}
+
+// sweepScript is tools/replay-fixtures.sh, read as the other half of the
+// contract rather than described.
+func sweepScript(t *testing.T) string {
+	t.Helper()
+	return mustAbs(t, filepath.Join("..", "..", "..", "replay-fixtures.sh"))
+}
+
+// findNameRE picks the -name arguments out of the sweep's find invocation.
+var findNameRE = regexp.MustCompile(`-name\s+'([^']+)'`)
+
+// TestSweepAndGatesWalkTheSameTranscriptNames pins the one copy of the rule
+// that cannot be shared by reference: tools/replay-fixtures.sh selects
+// recordings with its own `find … -name` list, in shell.
+//
+// Without this the agreement is a sentence. #1517 was two hand-kept lists
+// drifting apart — the sweep grading 31 aider recordings that no Go gate could
+// see — and unifying the Go side into one variable does not stop the shell's
+// list from drifting tomorrow. Note which direction is dangerous: a name the
+// SWEEP gains and the gates do not is invisible to UnpairedSidecars, because
+// that figure counts sidecars no Go name can pair and a recording the gates
+// never look at does not move it.
+//
+// It reads the script rather than restating its regexp — the sibling contract
+// TestDriftSummary_FormatIsTheShellContract hardcodes the sweep's pattern and
+// so pins the format while still allowing the two files to disagree about it.
+func TestSweepAndGatesWalkTheSameTranscriptNames(t *testing.T) {
+	f, err := os.Open(sweepScript(t))
+	if err != nil {
+		t.Fatalf("open the sweep: %v", err)
+	}
+	defer f.Close()
+
+	var names []string
+	var line string
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		l := scanner.Text()
+		if !strings.Contains(l, "find \"$FIXTURES_ROOT\"") {
+			continue
+		}
+		line = l
+		for _, m := range findNameRE.FindAllStringSubmatch(l, -1) {
+			names = append(names, m[1])
+		}
+		break
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatalf("read the sweep: %v", err)
+	}
+	// Both guards are the vacuity check this contract needs most: a rename in
+	// the script makes every assertion below pass over an empty list, which is
+	// the reassuring spelling of "the two sides are no longer compared".
+	if line == "" {
+		t.Fatal("no `find \"$FIXTURES_ROOT\"` line in tools/replay-fixtures.sh — this contract " +
+			"is reading nothing. Find where the sweep selects recordings and re-anchor it, rather " +
+			"than deleting the test")
+	}
+	if len(names) == 0 {
+		t.Fatalf("the sweep's find line matched no -name argument, so this compares two empty "+
+			"sets:\n  %s", line)
+	}
+
+	got, want := append([]string(nil), names...), append([]string(nil), transcriptNames...)
+	sort.Strings(got)
+	sort.Strings(want)
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("tools/replay-fixtures.sh walks %v but the Go gates pair %v.\n"+
+			"The two must select the same recordings or one of them grades a population the "+
+			"other cannot see — #1517, where the sweep read every aider recording and no Go "+
+			"gate did. Update whichever side is wrong in the same commit.\n  sweep line: %s",
+			got, want, line)
+	}
+	t.Logf("the sweep and the gates both walk %v", want)
 }

--- a/tools/onboarding-factory/cmd/replay/replay_sidecar.go
+++ b/tools/onboarding-factory/cmd/replay/replay_sidecar.go
@@ -26,10 +26,15 @@ import (
 //
 // The sentinel is keyed on those symptoms, NOT on the adapter, and the
 // distinction is worth stating because the obvious reading is wrong. For most
-// of the 56 fallbacks the cause really is an adapter property: opencode (30)
-// and hermes (24) are agent.ProcessOwnedStore, with no transcript file for the
-// daemon to watch and so no fswatcher fire to record, and aider is
-// agent.FilesUnderCWD, with no session identifier of its own.
+// of these fallbacks the cause really is an adapter property: opencode and
+// hermes are agent.ProcessOwnedStore, with no transcript file for the daemon to
+// watch and so no fswatcher fire to record, and aider is agent.FilesUnderCWD,
+// with no session identifier of its own — which is why nearly every aider
+// recording lands here. The size of the population is
+// censusOfTheCommittedCatalog.PairedButUngraded, machine-generated, and is not
+// restated here: the count this sentence used to carry described the catalog
+// before #1517 widened the walk to pair transcript.md, and so silently stopped
+// including the aider recordings the very next clause names.
 //
 // The remaining two are recording-level, and they are the reason this comment
 // does not claim otherwise: mistral-vibe is agent.FilesUnderRoot
@@ -752,6 +757,13 @@ func (r *sidecarReplayer) classifyAt(fileSize int64, ctx transitionCtx) error {
 // low. Diverges' doc comment names the two near-misses and the single committed
 // recording that separates them.
 //
+// The table is #1478's calibration, measured over the catalog as it stood then
+// and kept as the evidence for the window that shipped. Its columns are counts
+// over that population, so they no longer equal the live gate's figures — #1517
+// widened the walk and the shipped row's divergent/pairs columns moved with it.
+// Read it as a comparison BETWEEN the rows, which is what it was built for, not
+// as a current measurement:
+//
 //	                          zero  fabricated  divergent  drift>1s  pairs
 //	#1476 as shipped             4           1        145       119    818
 //	+ 2ms cluster window         4           1        143       118    821
@@ -872,8 +884,10 @@ var readBoundaryClusterWindow = 10 * time.Millisecond
 // pass's own timestamp, and `at` is never reassigned — so the rule can never go
 // transitive across an idle period no matter how many events follow. The
 // `break` is therefore a pure early exit, valid because the fswatch stream is
-// Seq-sorted and its dequeue timestamps are monotonic (verified: 0 of 309
-// committed recordings have a non-monotonic fswatch timestamp in Seq order).
+// Seq-sorted and its dequeue timestamps are monotonic (re-verified for #1517's
+// widened walk: of the catalog's 396 committed sidecars, 393 carry a
+// transcript_activity stream and NONE has a non-monotonic timestamp in Seq
+// order — including the two recordings the widening newly reaches).
 // Do NOT "restore" a chained form by comparing j to j-1: that would silently
 // turn a bounded 10ms rule into an unbounded walk and invalidate the
 // calibration.

--- a/tools/onboarding-factory/cmd/replay/timing_drift.go
+++ b/tools/onboarding-factory/cmd/replay/timing_drift.go
@@ -11,7 +11,7 @@ import (
 // Issue #1480: replay goldens record a virtual_time on every transition and
 // nothing compared it to anything. compareOrdered walks prev_state/new_state
 // index-by-index and never reads the time; assertReproducesRecordedTransitions
-// checks counts and kind-sets; the "N of 309 recordings diverge" headline every
+// checks counts and kind-sets; the "N of M recordings diverge" headline every
 // replay PR quotes is counts and kinds only (that headline is
 // extendedCheck.Diverges counted over the catalog, and N is
 // censusOfTheCommittedCatalog.Divergent — neither is restated here, per #1503).
@@ -48,9 +48,12 @@ func (d timeDelta) Abs() time.Duration { return d.Delta.Abs() }
 //
 // It is chosen from the measured distribution rather than picked, because the
 // issue is explicit that a tolerance cannot be chosen for a distribution nobody
-// has printed. Measured over all 826 kind-matched paired transitions in the
-// committed catalog, |delta| is sharply bimodal, and the two modes are
-// separated by a near-empty decade:
+// has printed. The distribution below was measured for #1480, over the 826
+// kind-matched pairs the catalog held then; it is the evidence for the
+// threshold and is deliberately NOT refreshed as the catalog grows — the live
+// figures are printed by the gate on every run. It is quoted here as of that
+// measurement, not as a current count. |delta| is sharply bimodal, and the two
+// modes are separated by a near-empty decade:
 //
 //	<1ms       190   23.0%   ┐
 //	1-10ms     338   40.9%   ├ 74.4% under 100ms — the daemon's own read latency

--- a/tools/onboarding-factory/internal/replay/transcript_events.go
+++ b/tools/onboarding-factory/internal/replay/transcript_events.go
@@ -33,14 +33,26 @@ import (
 // the transcript parser. The aider markdown path keeps a coarse mtime
 // approximation because aider transcripts carry no per-line timestamps.
 //
+// TranscriptNames are the transcript filenames a recording may carry, in
+// PREFERENCE order: a recording carrying both is read as the jsonl one, because
+// internal/validate/expected.go treats that shape as ambiguous and the choice
+// must not fall to directory iteration order.
+//
+// Exported because it is the catalog's rule rather than this function's: the
+// replay gates' catalog walk pairs a sidecar with a transcript by exactly this
+// list (cmd/replay/issue1517_pairing_test.go), and tools/replay-fixtures.sh
+// walks it too, in a `find -name` its own test pins to this variable. Three
+// hand-kept copies of the list is what #1517 was: the Go gates' copy said
+// transcript.jsonl alone, so every aider recording was graded by the sweep and
+// by no gate.
+var TranscriptNames = []string{"transcript.jsonl", "transcript.md"}
+
 // Returns nil if no transcript is present at any expected name.
 func SynthesizeEventsFromTranscript(scenarioDir, adapter string) []lifecycle.Event {
 	if hasParentTraversal(scenarioDir) {
 		return nil
 	}
-	// Try common transcript filenames in order.
-	candidates := []string{"transcript.jsonl", "transcript.md"}
-	for _, name := range candidates {
+	for _, name := range TranscriptNames {
 		path := filepath.Join(scenarioDir, name)
 		if _, err := os.Stat(path); err != nil {
 			continue

--- a/tools/replay-fixtures.sh
+++ b/tools/replay-fixtures.sh
@@ -156,7 +156,7 @@ while IFS= read -r fix; do
   if [[ "$summary_line" == *"extended-check:"* ]]; then
     # Tally the ordered/kind divergence. These two counters were added with the
     # reporting block at the end of this script but nothing ever incremented
-    # them, so that block could not print and the "N of 309 diverge" figure it
+    # them, so that block could not print and the "N of M diverge" figure it
     # exists to show had to be recomputed by hand every time (#1480).
     if [[ "$summary_line" == *FAIL* ]]; then
       extended_divergences="${extended_divergences}   ${adapter}/${kind}/${name}/${recname}

--- a/tools/replay-fixtures.sh
+++ b/tools/replay-fixtures.sh
@@ -113,16 +113,15 @@ while IFS= read -r fix; do
   # line carried by hand said 198 long after the Go side had measured 140
   # (#1503).
   #
-  # This sweep's own count is legitimately HIGHER than that census, and the
-  # difference is a population, not a predicate: the find below walks
-  # transcript.md as well as transcript.jsonl, while the Go gates pair a
-  # sidecar only with a sibling transcript.jsonl and therefore skip every aider
-  # recording. That population is censusOfTheCommittedCatalog.UnpairedSidecars,
-  # also machine-generated. Measured while #1503 was written: this sweep
-  # reported 142 where the census reported 140, and the two extra recordings
-  # were both aider/4-2_multiple-agents-same-workspace. Making the two agree is
-  # a scope call rather than a risky one — see that field's doc comment, which
-  # carries the measurement.
+  # This sweep and that census count the same predicate over the same
+  # population: the find below walks transcript.md as well as transcript.jsonl,
+  # and since #1517 the Go walk pairs both names too, through the one rule in
+  # cmd/replay/issue1517_pairing_test.go. They used to disagree, because the Go
+  # side paired only transcript.jsonl and so skipped every aider recording —
+  # which meant a divergence figure quoted from one of them could be the
+  # other's. If they ever diverge again that is a pairing bug, not a rounding
+  # difference, and censusOfTheCommittedCatalog.UnpairedSidecars is the
+  # machine-generated figure that reports it.
   # The dominant kind is a missing terminal
   # working→ready: the sidecar replayer synthesises idle promotions for child
   # sessions (applyChildOrphan) but never for the primary one. That is a known


### PR DESCRIPTION
Closes #1517.

`forEachSidecarRecording` paired a sidecar only with a sibling `transcript.jsonl`, while `tools/replay-fixtures.sh` has always walked `transcript.md` too. Every aider recording carries `transcript.md` and none carries `transcript.jsonl`, so all 31 were graded by the sweep and by **no Go gate**. #1342's stated design goal — the gates are catalog-wide "so a newly recorded fixture is covered by existing coverage rather than by somebody remembering" — was silently false for a whole adapter.

## What changed

The ordered name list is now a single **production** declaration, `replay.TranscriptNames` in `internal/replay/transcript_events.go` — where `SynthesizeEventsFromTranscript` already had its own copy of it — and the gates alias that rather than keeping a fourth:

```go
// internal/replay
var TranscriptNames = []string{"transcript.jsonl", "transcript.md"}
// cmd/replay/issue1517_pairing_test.go
var transcriptNames = internalreplay.TranscriptNames
func pairedTranscript(dir string) (string, bool)
```

All three Go walks use it — `forEachSidecarRecording` (#1342/#1480/#1503), `countSidecars` (the census), and `assertSidecarPairsWithTranscript` (the hook lock). The third is worth calling out: it carried its **own hardcoded `"transcript.jsonl"`** rather than the shared const, so it never moved when the const did. No committed aider recording carries hooks today (measured: 17 hook-carrying sidecars, all claudecode/copilot/hermes, every one beside a `transcript.jsonl`), so that was a latent hole rather than a live one.

The order is part of the rule: `internal/validate/expected.go` treats a recording carrying **both** names as ambiguous, so the walk must not let directory iteration decide. `TestPairedTranscriptPrefersJSONL` pins the tie-break.

## Blast radius — re-measured here, not carried over

The issue's figures came from PR #1511's author and were wrong in that PR's first draft, so I measured them independently before changing anything, with a throwaway probe over the md-only population. **The claim holds.** Full accounting of the catalog, which neither the issue nor #1511 established:

| | count |
|---|---|
| `events.jsonl` sidecars on disk | 396 |
| beside a `transcript.jsonl` | 365 |
| beside a `transcript.md`, no `.jsonl` | 31 (all aider) |
| beside **both** | **0** |
| beside **neither** | **0** |

Because no recording has both and none has neither, widening cannot re-route an existing recording — it can only add. Of the 31:

- **2 become gradeable** — both `aider/scenarios/4-2_multiple-agents-same-workspace`, exactly the two the docs named. Each: daemon logged 2 transitions, replay reproduced 1.
- **29 pair but produce no extended check** — their sidecar names no real session in a `transcript_new` event, so replay takes the documented not-drivable fallback to transcript-only. This is the benign half of the pair `TestReplayWithSidecar_CorruptSidecarIsFatal` separates, not a new failure.
- **0** reproduce nothing, **0** fabricate, **0** drift >1s on their first transition.

So `knownZeroTransition` (1 entry), `knownFabricated` (1) and `knownFirstTransitionDrift` (48) are **unmoved** — the claim, confirmed.

**The issue did not mention #1480's four aggregate ratchets, and they were the real risk**: two are upper bounds sitting at *exactly* the measured value, with zero headroom. Measured, they also do not move:

| ratchet | kind | before | after |
|---|---|---|---|
| `maxRecordingsDriftingOverThreshold` (105) | upper | 105/309 | 105/311 |
| `maxRecordingsDriftingOver5s` (50) | upper | 50 | 50 |
| `minKindMatchedPairs` (826) | lower | 826 | 828 |
| `minMeasuredRecordings` (273) | lower | 273 | 275 |

Had either of the two new recordings drifted >1s anywhere, the upper bounds would have tripped on the spot.

## Census: the corrected literal

Machine-generated — pasted programmatically from the test's own output, never hand-typed:

```go
var censusOfTheCommittedCatalog = catalogCensus{
	Recordings:                311,
	Zero:                      1,
	Fabricated:                1,
	Divergent:                 142,
	DivergentByCountsAndKinds: 141,
	UnpairedSidecars:          0,
	PairedButUngraded:         85,
}
```

Reason per moved figure:

- **`Recordings` 309 → 311** — the two gradeable markdown recordings above.
- **`Divergent` 140 → 142** — both of them diverge. **This is the ticket:** 142 is exactly what `tools/replay-fixtures.sh` has reported all along, so the gap closes by the census rising to meet the sweep, not by the sweep falling.
- **`DivergentByCountsAndKinds` 139 → 141** — the same two; each replays 1 where the daemon logged 2, so the counts differ and the near-miss spelling catches them too. The one-recording gap between the two spellings is **preserved** (142 − 141 = 1), which is the property #1503 pinned by name.
- **`UnpairedSidecars` 31 → 0** — the 31 aider sidecars are now paired; nothing on disk is unpairable. Kept in the census at zero deliberately: it is the figure that would report the blindness returning if a recording ever lands with its transcript in a third format.
- **`PairedButUngraded` 56 → 85** — +29, the not-drivable aider sidecars above.
- **`Zero` and `Fabricated` unchanged at 1** — neither new recording is either shape.

The identity still closes exactly: 396 sidecars = 0 unpairable + 311 graded + 85 paired-but-ungraded.

## Mutation seen red

The widening is a *check being added*, so per AGENTS.md its evidence is a deliberate mutation. Narrowing the production `TranscriptNames` back to `{"transcript.jsonl"}` fails **five** gates:

```
--- FAIL: TestSidecarReplayTransitionTimesMatchTheDaemonsOwnLog
    issue1480_timing_test.go:415: only 826 kind-matched pairs measured (floor: 828) — the
    measurement SHRANK. Every other assertion here is an upper bound and passes when it
    does, so this is the one that catches a pairing shift draining the population
    issue1480_timing_test.go:421: only 273 of 309 recordings produced any kind-matched
    pair (floor: 275)

--- FAIL: TestCatalogCensusMatchesTheCommittedFigures
    issue1503_census_test.go:301: the walk reached 309 sidecar-driven recordings but the
    committed census was taken over 311 — the population SHRANK. Do not paste the new
    literal until you know a recording was genuinely retired: a walk that stopped pairing
    recordings with their sidecars reports exactly this, with every other figure quietly
    scaled down to match. Everything that moved: Recordings: committed 311, measured 309;
    Divergent: committed 142, measured 140; DivergentByCountsAndKinds: committed 141,
    measured 139; UnpairedSidecars: committed 0, measured 31; PairedButUngraded:
    committed 85, measured 56

--- FAIL: TestPairedTranscriptPrefersJSONL
    issue1517_pairing_test.go:80: a markdown-only recording paired with (".", false), want
    transcript.md — this is #1517 itself: every aider recording is this shape, and a rule
    that answers false here hides all 31 from every Go gate while tools/replay-fixtures.sh
    grades them

--- FAIL: TestTheCatalogWalkGradesMarkdownTranscripts
    issue1517_pairing_test.go:110: the walk graded 309 recordings and not one of them has a
    transcript.md, so every aider recording in the catalog is invisible to this gate, to
    #1480's and to #1503's census — the exact state #1517 closed.

--- FAIL: TestSweepAndGatesWalkTheSameTranscriptNames
    issue1517_pairing_test.go:193: tools/replay-fixtures.sh walks [transcript.jsonl
    transcript.md] but the Go gates pair [transcript.jsonl].
```

The census reaches its **fail-loudly shrink guard** — a `t.Fatalf` ahead of the paste-the-literal advice — rather than merely reporting staleness, which is exactly the case #1503 built that guard for.

**The timing gate was in this list only after review.** As first written this PR left #1480's two lower-bound ratchets at their pre-widening values, so the 2 recordings it added sat inside the floors as slack and that gate passed under this very mutation — the floor whose stated job is "catches a pairing shift draining the population" could not catch the pairing shift. See finding 1 below.

Each mutation was reverted by file copy, with `git status --porcelain` asserted empty afterwards.

The new shell-contract test was mutated separately (narrowing the sweep's `find -name` list instead), and goes red naming both sides.

## The 142-vs-140 discrepancy, and its four mentions

Gone, and verified from both sides in this branch: the sweep prints `142 recording(s)` and the census now measures `Divergent: 142`.

The four places #1503 documented it are **deleted, not updated**:

1. `AGENTS.md` — the "Replay's measured figures" bullet's 142-vs-140 paragraph and the "widening the pairing is deferred as a scope call" paragraph.
2. `tools/replay-fixtures.sh` — the "This sweep's own count is legitimately HIGHER" comment.
3. `issue1503_census_test.go` — the `transcriptName` const doc (the const itself is replaced by the shared rule).
4. `issue1503_census_test.go` — the `UnpairedSidecars` field doc carrying the measurement and the deferral argument.

Nothing that replaces them restates a figure: the surviving prose points at the machine-generated field instead. I also removed two figures elsewhere in that AGENTS.md bullet that **this change silently invalidated** — "the two spellings agree on all 309 recordings" and "(139 against `Divergent`'s 140)" — which is the same defect the bullet is about.

## Finding: #1503's own corpus carried hand-typed copies of the census

Not a rebase — reporting it as the acceptance criteria ask. `TestCensusDiffNamesEveryStaleShape` derives its *perturbations* from the live census (`with(...)`) but spelled its *expected verdicts* out in full — `"Divergent: committed 139, measured 140"` — and `TestCensusLiteralIsValidPasteableSource` pinned all seven gofmt-aligned lines with their figures. So when the census moved here, **8 subtests failed for a reason none of them is about**: the same defect #1503 exists to remove, one layer down. They were green on `main` only because the census had not moved since they were written.

Re-typing the numbers would have reproduced it, so both now derive:

- the corpus takes the measured half of each verdict from `current.fields()` via a `moved(field, committed)` helper;
- the pasteable-source test round-trips the literal through `go/format` and requires it back unchanged, which is the property the idiom actually rests on and is strictly stronger than a hand-typed width — it is not tautological, since `literal()` computes the column itself rather than deferring to `go/format`.

One row needed a real repair rather than a mechanical one: `"every figure moved, and every one is named"` set `UnpairedSidecars: 0` as a sentinel, which **now equals the live value**, so that field would have silently dropped out of the expected verdict and the row would have stopped testing what its name claims — without failing. It now perturbs every field by a distinct non-zero delta.

## Review findings, all fixed in this PR

A review pass raised five findings; three it proved by running a mutation, and two of those were defects this PR had introduced.

**1. #1480's two lower-bound ratchets were not re-tightened** (`issue1480_timing_test.go`). `minKindMatchedPairs = 826` / `minMeasuredRecordings = 273` were set at exactly the values measured on `main`. This PR raises the live measurement to 828/275, so the floors carried exactly 2 units of slack — and those 2 were the recordings the widening added. Under the narrowing mutation the timing gate therefore stayed **green**. Re-ratcheted to 828/275; it now fails with `only 826 kind-matched pairs measured (floor: 828)`.

**2. The "one rule / same set" claim was prose, not mechanism.** `tools/replay-fixtures.sh` keeps its own hardcoded `find … -name` list, and `UnpairedSidecars` cannot detect the dangerous direction: a name the **sweep** gains that the gates lack does not move it, because that figure counts sidecars no *Go* name can pair. New `TestSweepAndGatesWalkTheSameTranscriptNames` reads the `find` line out of the script and pins its `-name` set to `transcriptNames`, with two vacuity guards (no matching line; no `-name` matched) so a rename cannot make it compare two empty sets. The AGENTS.md wording that claimed the two walk "the same set" is corrected — they walk the same *names*; the sweep walks transcripts, the Go gates walk sidecars.

**3. `TestCensusLiteralIsValidPasteableSource` had lost the name↔value binding** — a defect this PR introduced when it replaced the verbatim figure list. Checking "the name appears" and "the value appears" as two independent `Contains` calls is satisfied by a `literal()` that pairs every field with its *neighbour's* value: gofmt-canonical, right line count, and a census of garbage. The reviewer demonstrated it green. Both sites now compare one bound, gofmt-aligned line per field via `alignedFieldLine`, and the mutation that demonstrated it now fails. The width duplication with `literal()` is deliberate and carries a comment saying so — sharing one implementation would make the assertion compare a string to itself.

**4. Roughly ten hand-typed figures elsewhere were silently invalidated by this change** — the `"N of 309"` denominators in the census, `timing_drift.go`, `AGENTS.md` and `replay-fixtures.sh`; the `826` pair count; and `replay_sidecar.go`'s explanation of the paired-but-ungraded population, which quoted `56` and broke it down as opencode + hermes while **omitting aider**, the adapter this PR just added to it. Fixed by re-pointing at the machine-generated fields rather than re-typing, and by stamping #1478's calibration table and #1480's distribution as the historical measurements they are rather than leaving them reading as current. `replay_sidecar.go`'s fswatch-monotonicity claim (`0 of 309`) was **re-verified rather than widened**: 393 of the 396 committed sidecars carry a `transcript_activity` stream and none is non-monotonic, the two newly-walked recordings included.

**5. A third copy of the ordered name list survived in production** (`internal/replay/transcript_events.go`). Hoisted to the single exported `replay.TranscriptNames` described above.

The reviewer also confirmed, by measurement, several things this PR asserts: `pairedTranscript` cannot mis-pair or move any existing recording; the three pinned lists genuinely do not move; the `go/format` round-trip is **not** tautological; the `moved(...)` helper is not circular; the "every figure moved" row's rewrite gained coverage; and the 29 not-drivable aider recordings really do have zero `transcript_new` events naming a real session.

## Verification

- `go test ./tools/onboarding-factory/... -race -count=1` — green (the full package, not a filter; the filtered run is what initially hid the two corpus failures above).
- `tools/replay-fixtures.sh` — exit 0, goldens byte-identical, no golden regenerated.
- `go run ./tools/onboarding-factory/cmd/of validate` — OK.
- `tools/preflight.sh --only go | arch | tools | skills | posix | security` — all PASS, re-run on the final tree after the review fixes. `web` skipped: the diff touches no web tree.

## CodeScene: red, advisory, and not read

`CodeScene Code Health Review` fails on this PR. Per AGENTS.md it is advisory — neither branch protection nor the Protect Main ruleset requires it — but "advisory" is not evidence, so: **I could not read the finding.** The delta report is login-gated and returned no findings to me. What follows is inference from my own measurement, not a check.

The most likely trigger is `TestCensusDiffNamesEveryStaleShape` in `issue1503_census_test.go`, which was **already** a large table-driven function on `main` (97 code lines) and which this PR grows to 106 (+9): the `moved(...)` helper, plus the "every figure moved" row expanding from a compact absolute literal to a per-field perturbation and a per-field expectation. `TestCensusLiteralIsValidPasteableSource` went *down* (27 → 26) and the new `alignedFieldLine` is 9 lines. No function in the new `issue1517_pairing_test.go` exceeds 45 code lines.

I did not chase it to green: the growth is in the corpus table, where the rows *are* the test, and extracting them to reduce a function-length metric would move the corpus away from the assertions it feeds. Worth a second opinion rather than a silent dismissal.

## Found, not fixed

- `cmd/replay/fixtures_test.go`'s `discoverReplayFixtures` selects on a `.jsonl` suffix, so the **byte-identity golden** gate still generates and checks no golden for any `transcript.md` recording. That is a different gate from the ones this ticket names, and closing it means committing 31 new goldens plus a change to `internal/validate/expected.go`, which requires a golden only "for a jsonl transcript". Out of scope here; worth its own issue.
- `tools/replay-fixtures.sh` retains one historical numeral ("said 198 long after the Go side had measured 140"), left deliberately: it is #1503's archaeology about a *different*, pre-existing discrepancy and is explicitly past-tense.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
