### PR TITLE
refactor(processlifecycle): one shared "did the child answer?" predicate for every bounded shellout

### DIFF
--- a/core/adapters/inbound/agents/processlifecycle/osutil.go
+++ b/core/adapters/inbound/agents/processlifecycle/osutil.go
@@ -139,9 +139,12 @@ func ReadLauncherEnv(pid int) (l *session.Launcher, hostKnown bool) {
 //
 // complete reports whether the reads behind that answer actually ran, so a
 // caller can tell "this process has no local window" from "I could not read
-// this process" (#1492). It is false only when an ancestry walk aborted rather
-// than reaching a verdict — on an unreadable process, or on a bundle-id probe
-// that was never answered (#1524).
+// this process" (#1492). It is false when an ancestry walk aborted rather than
+// reaching a verdict — on an unreadable process, or on a bundle-id probe that
+// was never answered (#1524) — and, since #1533, when the controlling-TTY read
+// never answered either. Every bounded shellout behind this answer now feeds
+// it; the TTY one did not, because it runs after complete is computed and
+// nothing folded it back in.
 //
 // It deliberately says nothing about the env read, which cannot fail: the
 // ProcessObserver port defines an unreadable env as an empty map rather than
@@ -161,6 +164,16 @@ func ReadLauncherEnv(pid int) (l *session.Launcher, hostKnown bool) {
 // The ordering is load-bearing: ancestry before TTY, and both before any
 // adoption by the caller.
 func hostIdentity(pid int) (l *session.Launcher, complete bool) {
+	return hostIdentityVia(pid, processTTY)
+}
+
+// ttyProbe is the controlling-TTY read hostIdentityVia makes, injected so the
+// #1533 non-answer can be arranged — a real `ps` cannot be driven over its
+// ceiling on purpose. Same idiom as resolveHostBundleIDVia's two probes.
+type ttyProbe func(pid int) (string, bool)
+
+// hostIdentityVia is hostIdentity with the TTY read injected.
+func hostIdentityVia(pid int, readTTY ttyProbe) (l *session.Launcher, complete bool) {
 	// Env may be empty — hardened-runtime processes hide it from sysctl.
 	// Don't bail here: the ancestry fallback below is the only signal we
 	// have in that case.
@@ -198,8 +211,14 @@ func hostIdentity(pid int) (l *session.Launcher, complete bool) {
 	// Capture the controlling TTY so Terminal.app (and potentially others)
 	// can target the exact tab — Terminal.app's AppleScript dictionary
 	// matches tabs by `tty` but has no session-UUID analog.
-	l.TTY = processTTY(pid)
-	return l, complete
+	tty, ttyProbed := readTTY(pid)
+	l.TTY = tty
+	// #1533: the TTY read is the third bounded shellout behind this answer, and
+	// it was the one whose verdict was dropped — it runs AFTER complete is
+	// computed, so folding it in has to be explicit. Its polarity is #1492's
+	// rather than #1513's: this is enrichment, so the bit to carry is "this
+	// field is missing rather than absent", not "admit on no evidence".
+	return l, complete && ttyProbed
 }
 
 // launcherFromEnv builds a Launcher from the whitelisted per-PID env vars
@@ -346,6 +365,17 @@ func (a *ancestryProbe) walked() bool { return !a.resolved || a.complete }
 // AND on an unanswerable plutil (#1524); the memoized one has no plutil to
 // make, so for it the two are the same thing.
 func applyAncestryFallbacks(l *session.Launcher, pid int, ancestry *ancestryProbe) (complete bool) {
+	return applyAncestryFallbacksVia(l, pid, ancestry, kittyWindowIDForPID)
+}
+
+// kittyWindowProbe is the `kitten @ ls` read applyKittyAncestryBackfill makes,
+// injected for the same reason ttyProbe is: a real kitten cannot be driven over
+// its ceiling on purpose.
+type kittyWindowProbe func(socket string, sessionPID int) (string, bool)
+
+// applyAncestryFallbacksVia is applyAncestryFallbacks with the kitty
+// remote-control read injected.
+func applyAncestryFallbacksVia(l *session.Launcher, pid int, ancestry *ancestryProbe, readKittyWindow kittyWindowProbe) (complete bool) {
 	complete = true
 	// kitty intentionally does not set TERM_PROGRAM (upstream kitty issue
 	// #4793), so the env-captured value may be inherited from whatever
@@ -389,8 +419,8 @@ func applyAncestryFallbacks(l *session.Launcher, pid int, ancestry *ancestryProb
 	// Without this, clicking the session in the UI raises kitty but can't
 	// target the right tab — exactly the symptom reported for pi sessions
 	// in issue #326.
-	applyKittyAncestryBackfill(l, pid, ancestry)
-	return complete && ancestry.walked()
+	kittyProbed := applyKittyAncestryBackfill(l, pid, ancestry, readKittyWindow)
+	return complete && ancestry.walked() && kittyProbed
 }
 
 // applyKittyAncestryBackfill fills in KittyPID/KittyListenOn/KittyWindowID
@@ -403,21 +433,33 @@ func applyAncestryFallbacks(l *session.Launcher, pid int, ancestry *ancestryProb
 // run — a candidate whose env names kitty but carries no KITTY_PID skips all
 // three blocks above — which is why its caller reads the verdict off the probe
 // afterwards rather than trusting the blocks to have accumulated it.
-func applyKittyAncestryBackfill(l *session.Launcher, pid int, ancestry *ancestryProbe) {
+//
+// It makes TWO bounded shellouts, not one, and since #1537 both feed the
+// caller's completeness bit: the ancestry `ps` chain behind ancestry.host()
+// (read off the probe by the caller) and the `kitten @ ls` behind
+// readKittyWindow (returned here). Only the first was reported before.
+func applyKittyAncestryBackfill(l *session.Launcher, pid int, ancestry *ancestryProbe, readKittyWindow kittyWindowProbe) (probed bool) {
 	if l.TermProgram != "kitty" || l.KittyPID != 0 {
-		return
+		return true
 	}
 	term, kpid := ancestry.host()
 	if term != "kitty" || kpid <= 0 {
-		return
+		return true
 	}
 	l.KittyPID = kpid
 	if l.KittyListenOn == "" {
 		l.KittyListenOn = kittyListenOnFor(kpid)
 	}
 	if l.KittyListenOn != "" && l.KittyWindowID == "" {
-		l.KittyWindowID = kittyWindowIDForPID(l.KittyListenOn, pid)
+		id, ok := readKittyWindow(l.KittyListenOn, pid)
+		l.KittyWindowID = id
+		// #1537: the empty id from a kitten that never ran and the empty id
+		// from a kitty with no matching window arrived here as the same value.
+		// Returning the verdict is what lets the caller AND it into complete —
+		// the sibling failure ancestryProbe.walked() exists for, one probe over.
+		return ok
 	}
+	return true
 }
 
 // ReadArgv returns pid's argument vector (argv[0] is the executable as invoked),

--- a/core/adapters/inbound/agents/processlifecycle/osutil.go
+++ b/core/adapters/inbound/agents/processlifecycle/osutil.go
@@ -438,6 +438,18 @@ func applyAncestryFallbacksVia(l *session.Launcher, pid int, ancestry *ancestryP
 // caller's completeness bit: the ancestry `ps` chain behind ancestry.host()
 // (read off the probe by the caller) and the `kitten @ ls` behind
 // readKittyWindow (returned here). Only the first was reported before.
+//
+// Be exact about what that buys today, because it is less than it looks and
+// the next reader must not conclude otherwise: NO consumer can currently
+// observe the kitten half. This block only runs when TermProgram is already
+// "kitty", and resolveClientHostIdentity returns a candidate with a non-empty
+// TermProgram outright without reading complete; ReadLauncherEnv discards the
+// bit entirely. So the verdict is carried for consistency with the walk beside
+// it — a second probe in the same block whose verdict is dropped is how the
+// first one went wrong — and it becomes load-bearing the moment a consumer
+// reads completeness for a host-resolved candidate. The TTY fold in
+// hostIdentityVia is NOT in this position: that one is reached by candidates
+// with no TermProgram at all, which is exactly the branch that reads the bit.
 func applyKittyAncestryBackfill(l *session.Launcher, pid int, ancestry *ancestryProbe, readKittyWindow kittyWindowProbe) (probed bool) {
 	if l.TermProgram != "kitty" || l.KittyPID != 0 {
 		return true

--- a/core/adapters/inbound/agents/processlifecycle/osutil_darwin.go
+++ b/core/adapters/inbound/agents/processlifecycle/osutil_darwin.go
@@ -38,16 +38,9 @@ var (
 // on macOS omits the "/dev/" prefix that AppleScript returns. This is host
 // enrichment (window targeting), not observation, so other platforms stub it.
 func processTTY(pid int) (string, bool) {
-	return processTTYVia(pid, systemTTYCmd)
-}
-
-// ttyCmd builds the bounded shellout processTTYVia runs, injected for the same
-// reason bundleIDCmd, pgrepCmd and lsofCmd are.
-type ttyCmd func(ctx context.Context, pid int) *exec.Cmd
-
-// systemTTYCmd is the production ttyCmd.
-func systemTTYCmd(ctx context.Context, pid int) *exec.Cmd {
-	return exec.CommandContext(ctx, psPath, "-o", "tty=", "-p", strconv.Itoa(pid))
+	return processTTYVia(pid, func(ctx context.Context) *exec.Cmd {
+		return exec.CommandContext(ctx, psPath, "-o", "tty=", "-p", strconv.Itoa(pid))
+	})
 }
 
 // processTTYVia is processTTY with the shellout injected. The second return is
@@ -62,7 +55,7 @@ func systemTTYCmd(ctx context.Context, pid int) *exec.Cmd {
 // pid it cannot find (measured), which is a real "no such process", not a
 // probe that did not run — so the allowlist form would turn every reaped pid
 // into a non-answer and poison hostIdentity's completeness for it.
-func processTTYVia(pid int, build ttyCmd) (tty string, probed bool) {
+func processTTYVia(pid int, build shelloutCmd) (tty string, probed bool) {
 	if pid <= 0 {
 		// Nothing was asked, so nothing failed — the same reading bundleIDVia
 		// gives an empty appPath.
@@ -70,7 +63,7 @@ func processTTYVia(pid int, build ttyCmd) (tty string, probed bool) {
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), shelloutTimeout)
 	defer cancel()
-	out, err := build(ctx, pid).Output()
+	out, err := build(ctx).Output()
 	if !probeAnswered(err) {
 		return "", false
 	}
@@ -141,19 +134,18 @@ func resolveHostFromAncestry(pid int) (termProgram string, hostPID int, complete
 	return "", 0, true
 }
 
-// bundleIDCmd builds the bounded shellout that reads one app bundle's
-// CFBundleIdentifier. It is a parameter of bundleIDVia rather than a package
-// var because the distinction bundleIDVia draws is a property of the CHILD
-// PROCESS — ran to a normal exit, versus killed or never started — which no
-// faked return value can pin. Injecting it is the same idiom
-// isKnownInteractiveHostVia uses for the two ancestry walks.
-type bundleIDCmd func(ctx context.Context, plist string) *exec.Cmd
+// bundleIDCmd builds the shellout for one named Info.plist. See bundleIDVia
+// for why this one site takes a factory where the others take a shelloutCmd.
+type bundleIDCmd func(plist string) shelloutCmd
 
-// plutilBundleIDCmd is the production bundleIDCmd. `plutil` ships with macOS
-// and reads both XML and binary Info.plists; bundles under /Applications are
-// world-readable, so this needs no TCC consent.
-func plutilBundleIDCmd(ctx context.Context, plist string) *exec.Cmd {
-	return exec.CommandContext(ctx, plutilPath, "-extract", "CFBundleIdentifier", "raw", "-o", "-", plist)
+// plutilBundleIDCmd is the production shellout for one app bundle's
+// CFBundleIdentifier. `plutil` ships with macOS and reads both XML and binary
+// Info.plists; bundles under /Applications are world-readable, so this needs
+// no TCC consent.
+func plutilBundleIDCmd(plist string) shelloutCmd {
+	return func(ctx context.Context) *exec.Cmd {
+		return exec.CommandContext(ctx, plutilPath, "-extract", "CFBundleIdentifier", "raw", "-o", "-", plist)
+	}
 }
 
 // bundleIDForAppPath returns the CFBundleIdentifier of the application bundle
@@ -193,6 +185,11 @@ func bundleIDForAppPath(appPath string) (string, error) {
 //     and it also covers the deaths the ceiling did not cause — an OOM kill, a
 //     fork that failed under the same load, or a ctx already past its deadline
 //     before Start (where the error is not an ExitError at all).
+//
+// build is a FACTORY producing a shelloutCmd rather than one directly, and it
+// is the only site in the package that needs to be: the command depends on the
+// Info.plist path, which this function derives from appPath. Everywhere else
+// the site's arguments are closed over at the call site (see shelloutCmd).
 func bundleIDVia(appPath string, build bundleIDCmd) (string, error) {
 	if appPath == "" {
 		return "", nil
@@ -200,7 +197,7 @@ func bundleIDVia(appPath string, build bundleIDCmd) (string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), shelloutTimeout)
 	defer cancel()
 	plist := appPath + "/Contents/Info.plist"
-	out, err := build(ctx, plist).Output()
+	out, err := build(plist)(ctx).Output()
 	if err != nil {
 		// No answeredExitCodes: for plutil ANY normal exit is an answer, which
 		// is the empty-variadic form's whole reason for existing — see
@@ -486,16 +483,9 @@ func kittyListenOnFor(kittyPID int) string {
 // (e.g., the pi adapter — pi's env is unreadable via sysctl). Bounded
 // 2-second timeout; runs at session-birth so latency is acceptable.
 func kittyWindowIDForPID(socket string, sessionPID int) (string, bool) {
-	return kittyWindowIDForPIDVia(socket, sessionPID, systemKittenCmd)
-}
-
-// kittenCmd builds the bounded shellout kittyWindowIDForPIDVia runs, injected
-// for the same reason bundleIDCmd, pgrepCmd, lsofCmd and ttyCmd are.
-type kittenCmd func(ctx context.Context, socket string) *exec.Cmd
-
-// systemKittenCmd is the production kittenCmd.
-func systemKittenCmd(ctx context.Context, socket string) *exec.Cmd {
-	return exec.CommandContext(ctx, kittenPath, "@", "--to", socket, "ls")
+	return kittyWindowIDForPIDVia(socket, sessionPID, func(ctx context.Context) *exec.Cmd {
+		return exec.CommandContext(ctx, kittenPath, "@", "--to", socket, "ls")
+	})
 }
 
 // kittyWindowIDForPIDVia is kittyWindowIDForPID with the shellout injected.
@@ -513,13 +503,13 @@ func systemKittenCmd(ctx context.Context, socket string) *exec.Cmd {
 // failed probe would poison hostIdentity's completeness permanently on any
 // machine where kitten is not on the trusted path, in exchange for nothing:
 // only an invocation that actually ran and did not answer is new information.
-func kittyWindowIDForPIDVia(socket string, sessionPID int, build kittenCmd) (string, bool) {
+func kittyWindowIDForPIDVia(socket string, sessionPID int, build shelloutCmd) (string, bool) {
 	if kittenPath == "" || socket == "" || sessionPID <= 0 {
 		return "", true
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), shelloutTimeout)
 	defer cancel()
-	out, err := build(ctx, socket).Output()
+	out, err := build(ctx).Output()
 	if !probeAnswered(err) {
 		return "", false
 	}

--- a/core/adapters/inbound/agents/processlifecycle/osutil_darwin.go
+++ b/core/adapters/inbound/agents/processlifecycle/osutil_darwin.go
@@ -5,7 +5,6 @@ package processlifecycle
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -31,28 +30,58 @@ var (
 
 // processTTY returns the controlling TTY of pid in the form "/dev/ttysNNN",
 // or "" if the process has no controlling terminal (hardened-runtime
-// children often don't) or the ps lookup fails. The result is normalized
+// children often don't), plus whether the ps lookup ANSWERED at all — those
+// were one value until #1533, and merging them reported a ps the ceiling
+// killed as "this process has no terminal", silently and permanently for that
+// identity. The result is normalized
 // to match Terminal.app's AppleScript `tty` property format — `ps -o tty=`
 // on macOS omits the "/dev/" prefix that AppleScript returns. This is host
 // enrichment (window targeting), not observation, so other platforms stub it.
-func processTTY(pid int) string {
+func processTTY(pid int) (string, bool) {
+	return processTTYVia(pid, systemTTYCmd)
+}
+
+// ttyCmd builds the bounded shellout processTTYVia runs, injected for the same
+// reason bundleIDCmd, pgrepCmd and lsofCmd are.
+type ttyCmd func(ctx context.Context, pid int) *exec.Cmd
+
+// systemTTYCmd is the production ttyCmd.
+func systemTTYCmd(ctx context.Context, pid int) *exec.Cmd {
+	return exec.CommandContext(ctx, psPath, "-o", "tty=", "-p", strconv.Itoa(pid))
+}
+
+// processTTYVia is processTTY with the shellout injected. The second return is
+// #1533: whether ps actually answered.
+//
+// The two empty strings below used to be one. "ps could not be run" and "this
+// process has no controlling terminal" are the family's usual pair, and only
+// the second is a verdict — a hardened-runtime child genuinely has no tty, and
+// reporting one anyway would misroute a click.
+//
+// No answeredExitCodes: for ps ANY normal exit is an answer. It exits 1 for a
+// pid it cannot find (measured), which is a real "no such process", not a
+// probe that did not run — so the allowlist form would turn every reaped pid
+// into a non-answer and poison hostIdentity's completeness for it.
+func processTTYVia(pid int, build ttyCmd) (tty string, probed bool) {
 	if pid <= 0 {
-		return ""
+		// Nothing was asked, so nothing failed — the same reading bundleIDVia
+		// gives an empty appPath.
+		return "", true
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), shelloutTimeout)
 	defer cancel()
-	out, err := exec.CommandContext(ctx, psPath, "-o", "tty=", "-p", strconv.Itoa(pid)).Output()
-	if err != nil {
-		return ""
+	out, err := build(ctx, pid).Output()
+	if !probeAnswered(err) {
+		return "", false
 	}
-	tty := strings.TrimSpace(string(out))
+	tty = strings.TrimSpace(string(out))
 	if tty == "" || tty == "?" || tty == "??" || tty == "-" {
-		return ""
+		return "", true
 	}
 	if !strings.HasPrefix(tty, "/dev/") {
 		tty = "/dev/" + tty
 	}
-	return tty
+	return tty, true
 }
 
 // readProcessEnv reads the exec-time env of pid via KERN_PROCARGS2 sysctl
@@ -168,13 +197,16 @@ func bundleIDVia(appPath string, build bundleIDCmd) (string, error) {
 	if appPath == "" {
 		return "", nil
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), shelloutTimeout)
 	defer cancel()
 	plist := appPath + "/Contents/Info.plist"
 	out, err := build(ctx, plist).Output()
 	if err != nil {
-		var exit *exec.ExitError
-		if errors.As(err, &exit) && exit.ProcessState.Exited() {
+		// No answeredExitCodes: for plutil ANY normal exit is an answer, which
+		// is the empty-variadic form's whole reason for existing — see
+		// probeAnswered, and the paragraph above for why exit 1 in particular
+		// must stay one.
+		if probeAnswered(err) {
 			// plutil ran and declined: this ancestor has no bundle id we can
 			// name. A real, readable verdict — the walk continues on it.
 			return "", nil
@@ -453,17 +485,45 @@ func kittyListenOnFor(kittyPID int) string {
 // KittyWindowID for sessions whose own env didn't expose KITTY_WINDOW_ID
 // (e.g., the pi adapter — pi's env is unreadable via sysctl). Bounded
 // 2-second timeout; runs at session-birth so latency is acceptable.
-func kittyWindowIDForPID(socket string, sessionPID int) string {
+func kittyWindowIDForPID(socket string, sessionPID int) (string, bool) {
+	return kittyWindowIDForPIDVia(socket, sessionPID, systemKittenCmd)
+}
+
+// kittenCmd builds the bounded shellout kittyWindowIDForPIDVia runs, injected
+// for the same reason bundleIDCmd, pgrepCmd, lsofCmd and ttyCmd are.
+type kittenCmd func(ctx context.Context, socket string) *exec.Cmd
+
+// systemKittenCmd is the production kittenCmd.
+func systemKittenCmd(ctx context.Context, socket string) *exec.Cmd {
+	return exec.CommandContext(ctx, kittenPath, "@", "--to", socket, "ls")
+}
+
+// kittyWindowIDForPIDVia is kittyWindowIDForPID with the shellout injected.
+// The second return is #1537's sixth instance of the family: whether kitten
+// answered at all.
+//
+// No answeredExitCodes: any normal exit of `kitten @ ls` is an answer — a
+// non-zero one means kitty declined to describe its windows, which is a
+// verdict about kitty, where a killed kitten is a verdict about nothing.
+//
+// The guard below reports PROBED, not a failure, and that split is deliberate.
+// An absent kitten binary or an empty socket is a settled property of this
+// installation — "there is no window id to be had here" — which is the same
+// reading osutil_linux.go and osutil_other.go give their stubs. Calling it a
+// failed probe would poison hostIdentity's completeness permanently on any
+// machine where kitten is not on the trusted path, in exchange for nothing:
+// only an invocation that actually ran and did not answer is new information.
+func kittyWindowIDForPIDVia(socket string, sessionPID int, build kittenCmd) (string, bool) {
 	if kittenPath == "" || socket == "" || sessionPID <= 0 {
-		return ""
+		return "", true
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), shelloutTimeout)
 	defer cancel()
-	out, err := exec.CommandContext(ctx, kittenPath, "@", "--to", socket, "ls").Output()
-	if err != nil {
-		return ""
+	out, err := build(ctx, socket).Output()
+	if !probeAnswered(err) {
+		return "", false
 	}
-	return parseKittenLsForPID(out, sessionPID)
+	return parseKittenLsForPID(out, sessionPID), true
 }
 
 // kittyLsWindow is one entry of a `kitten @ ls` response's tabs[].windows[].
@@ -528,7 +588,7 @@ func findKittyWindowIDForPID(windows []kittyLsWindow, sessionPID int) string {
 // ps already handles the comm-vs-argv-path distinction we need, and the
 // existing package is built around these bounded exec calls.
 func readProcInfo(pid int) (ppid int, cmd string, err error) {
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), shelloutTimeout)
 	defer cancel()
 	out, err := exec.CommandContext(ctx, psPath, "-o", "ppid=,comm=", "-p", strconv.Itoa(pid)).Output()
 	if err != nil {
@@ -601,7 +661,7 @@ func herdrClientPIDs(socketPath string) (pids []int, probed bool) {
 	if _, err := os.Stat(logPath); err != nil {
 		return nil, false
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), shelloutTimeout)
 	defer cancel()
 	out, err := exec.CommandContext(ctx, lsofPath, logPath).Output()
 	if !lsofProbeRan(err) {
@@ -660,12 +720,15 @@ func sortedDistinctPIDs(pids []int) []int {
 // `if err != nil` would be caught. runPgrep (process_darwin.go) draws the same
 // distinction for pgrep's exit 1.
 func lsofProbeRan(err error) bool {
-	if err == nil {
-		return true
-	}
-	var exit *exec.ExitError
-	return errors.As(err, &exit) && exit.ExitCode() == 1
+	return probeAnswered(err, lsofNothingToReport)
 }
+
+// lsofNothingToReport is lsof's "I looked and there is nothing to report" exit
+// status. Named because it is the entire per-tool half of lsofProbeRan: the
+// hard half — what separates a child that ran from one that was killed — is
+// probeAnswered's and is shared with every other shellout in this package
+// (#1538).
+const lsofNothingToReport = 1
 
 // herdrClientWriters selects the client PIDs from an lsof table. 'u' counts
 // alongside 'w': it is read/write, which a client's log handle may legitimately

--- a/core/adapters/inbound/agents/processlifecycle/osutil_darwin_test.go
+++ b/core/adapters/inbound/agents/processlifecycle/osutil_darwin_test.go
@@ -1423,18 +1423,46 @@ func TestHerdrClientCache_ExpiresANonAnswer(t *testing.T) {
 
 // --- plutil non-answers in the bundle-id walk (#1524) ------------------------
 
-// stalledBundleIDCmd is a bundleIDCmd whose child never answers: `sleep` runs
-// until bundleIDVia's own ceiling SIGKILLs it. It is the closest a test can get
-// to the condition #1524 describes — a plutil that blows its 2s ceiling on a
-// loaded machine — and it reaches it through the REAL exec, the REAL ceiling
-// and the REAL error classification rather than a fabricated error value.
+// stalledChild is a shelloutCmd whose child never answers: `sleep` runs until
+// the caller's own ceiling SIGKILLs it. It is the closest a test can get to the
+// condition #1524 describes — a probe that blows its 2s ceiling on a loaded
+// machine — and it reaches it through the REAL exec, the REAL ceiling and the
+// REAL error classification rather than a fabricated error value.
 //
 // /bin/sleep deliberately, not a script this test writes: the first exec of a
 // newly written file is evaluated for code signing (measured at 2.14s worst-of
 // -12 under load), which is itself past the ceiling — a test that planted its
-// own binary could pass while proving nothing about plutil.
-func stalledBundleIDCmd(ctx context.Context, _ string) *exec.Cmd {
+// own binary could pass while proving nothing about the tool under test.
+//
+// Shared by every ceiling test in the package (#1538). It used to be
+// plutil-specific, and the measurement above — which every one of them depends
+// on to be non-vacuous — was documented only there.
+func stalledChild(ctx context.Context) *exec.Cmd {
 	return exec.CommandContext(ctx, "/bin/sleep", "30")
+}
+
+// anyPlist adapts a plist-independent fixture (a stall, a missing binary) to
+// the factory shape bundleIDVia takes — the one site whose command depends on a
+// value the callee derives.
+func anyPlist(c shelloutCmd) bundleIDCmd { return func(string) shelloutCmd { return c } }
+
+// stalledPlistCmd is stalledChild in that factory shape.
+func stalledPlistCmd(string) shelloutCmd { return stalledChild }
+
+// shellCmd is a shelloutCmd running one /bin/sh script, for fixtures that need
+// a specific exit status or signal rather than a stall.
+func shellCmd(script string) shelloutCmd {
+	return func(ctx context.Context) *exec.Cmd {
+		return exec.CommandContext(ctx, "/bin/sh", "-c", script)
+	}
+}
+
+// missingCmd is a shelloutCmd whose binary does not exist, i.e. a fork/exec
+// failure: a probe that never reached the question.
+func missingCmd(name string) shelloutCmd {
+	return func(ctx context.Context) *exec.Cmd {
+		return exec.CommandContext(ctx, "/nonexistent/"+name)
+	}
 }
 
 // plistWithoutBundleID writes a real, well-formed Info.plist that simply has no
@@ -1472,10 +1500,8 @@ func plistWithoutBundleID(t *testing.T) string {
 // answered nothing, and says so.
 func TestBundleIDVia_AnsweredMissIsNotAnUnanswerableProbe(t *testing.T) {
 	t.Parallel() // one row spends the real 2s ceiling; overlap it with the siblings that do too
-	missingBinary := func(ctx context.Context, plist string) *exec.Cmd {
-		return exec.CommandContext(ctx, "/usr/bin/no-such-plutil-1524", plist)
-	}
-	// via adapts a bundleIDCmd into the bundleIDProbe shape bundleIDForAppPath
+	missingBinary := anyPlist(missingCmd("no-such-plutil-1524"))
+	// via adapts a shelloutCmd into the bundleIDProbe shape bundleIDForAppPath
 	// already has, so every row names the function it exercises instead of
 	// encoding it as an absent value.
 	via := func(c bundleIDCmd) bundleIDProbe {
@@ -1514,7 +1540,7 @@ func TestBundleIDVia_AnsweredMissIsNotAnUnanswerableProbe(t *testing.T) {
 		},
 		{
 			"a child killed by the ceiling answered NOTHING",
-			"/System/Library/CoreServices/Finder.app", via(stalledBundleIDCmd),
+			"/System/Library/CoreServices/Finder.app", via(anyPlist(stalledChild)),
 			"", true,
 			"this is #1524: indistinguishable from row 2/3 before the error return existed",
 		},
@@ -1549,7 +1575,7 @@ func TestBundleIDVia_AnsweredMissIsNotAnUnanswerableProbe(t *testing.T) {
 func TestBundleIDVia_CeilingActuallyFires(t *testing.T) {
 	t.Parallel() // spends the real 2s ceiling and shares no state
 	start := time.Now()
-	if _, err := bundleIDVia("/System/Library/CoreServices/Finder.app", stalledBundleIDCmd); err == nil {
+	if _, err := bundleIDVia("/System/Library/CoreServices/Finder.app", stalledPlistCmd); err == nil {
 		t.Fatal("a child that never answers must report an error")
 	}
 	if elapsed := time.Since(start); elapsed < time.Second {
@@ -1698,7 +1724,7 @@ func TestIsKnownInteractiveHost_PlutilNonAnswerAdmits(t *testing.T) {
 func TestIsKnownInteractiveHost_PlutilCeilingAdmitsEndToEnd(t *testing.T) {
 	t.Parallel() // spends the real 2s ceiling and shares no state
 	stalled := func(appPath string) (string, error) {
-		return bundleIDVia(appPath, stalledBundleIDCmd)
+		return bundleIDVia(appPath, stalledPlistCmd)
 	}
 	walk1Finished := walk("", finished)
 	walk2 := func(pid int) (string, int, bool) {

--- a/core/adapters/inbound/agents/processlifecycle/osutil_linux.go
+++ b/core/adapters/inbound/agents/processlifecycle/osutil_linux.go
@@ -57,9 +57,13 @@ func resolveHostBundleIDFromAncestry(pid int) (bundleID string, host int, comple
 // Stubs for the kitty "no readable env" enrichment helpers. Linux can read
 // /proc/<pid>/environ for any process the user owns, so the back-fill path
 // these support isn't needed here.
-func kittyAncestryPID(pid int) int                             { return 0 }
-func kittyListenOnFor(kittyPID int) string                     { return "" }
-func kittyWindowIDForPID(socket string, sessionPID int) string { return "" }
+func kittyAncestryPID(pid int) int         { return 0 }
+func kittyListenOnFor(kittyPID int) string { return "" }
+
+// probed is true for the same reason processTTY's stub reports it: having no
+// kitty remote-control CLI to run is a settled property of this platform, not
+// a read that failed (#1537).
+func kittyWindowIDForPID(socket string, sessionPID int) (string, bool) { return "", true }
 
 // IsKnownInteractiveHost is darwin-only (ancestry walking); other platforms
 // fail open. The exclusion signal it backs (CodexBar's non-interactive `agy`

--- a/core/adapters/inbound/agents/processlifecycle/osutil_linux.go
+++ b/core/adapters/inbound/agents/processlifecycle/osutil_linux.go
@@ -34,7 +34,10 @@ func readProcessEnv(pid int) (map[string]string, error) {
 
 // processTTY is darwin-only host enrichment (Terminal.app window targeting).
 // Linux observation doesn't depend on it, so it degrades to "".
-func processTTY(pid int) string { return "" }
+// probed is true: having no darwin ps to run is a settled property of this
+// platform, not a read that failed (#1533) — the same reading the ancestry
+// stubs below give their complete return.
+func processTTY(pid int) (string, bool) { return "", true }
 
 // resolveTermProgramFromAncestry / resolveHostFromAncestry are darwin-only
 // fallbacks for hardened-runtime processes that hide env from sysctl. Linux

--- a/core/adapters/inbound/agents/processlifecycle/osutil_other.go
+++ b/core/adapters/inbound/agents/processlifecycle/osutil_other.go
@@ -30,9 +30,13 @@ func resolveHostBundleIDFromAncestry(pid int) (bundleID string, host int, comple
 }
 
 // Stubs for the kitty "no readable env" enrichment helpers — darwin-only.
-func kittyAncestryPID(pid int) int                             { return 0 }
-func kittyListenOnFor(kittyPID int) string                     { return "" }
-func kittyWindowIDForPID(socket string, sessionPID int) string { return "" }
+func kittyAncestryPID(pid int) int         { return 0 }
+func kittyListenOnFor(kittyPID int) string { return "" }
+
+// probed is true for the same reason processTTY's stub reports it: having no
+// kitty remote-control CLI to run is a settled property of this platform, not
+// a read that failed (#1537).
+func kittyWindowIDForPID(socket string, sessionPID int) (string, bool) { return "", true }
 
 // IsKnownInteractiveHost is darwin-only (ancestry walking); other platforms
 // fail open. The exclusion signal it backs (CodexBar's non-interactive `agy`

--- a/core/adapters/inbound/agents/processlifecycle/osutil_other.go
+++ b/core/adapters/inbound/agents/processlifecycle/osutil_other.go
@@ -11,7 +11,10 @@ func readProcessEnv(pid int) (map[string]string, error) {
 }
 
 // processTTY is darwin-only host enrichment; other platforms degrade to "".
-func processTTY(pid int) string { return "" }
+// probed is true: having no darwin ps to run is a settled property of this
+// platform, not a read that failed (#1533) — the same reading the ancestry
+// stubs below give their complete return.
+func processTTY(pid int) (string, bool) { return "", true }
 
 // resolveTermProgramFromAncestry / resolveHostFromAncestry are darwin-only
 // fallbacks; other platforms return zero values.

--- a/core/adapters/inbound/agents/processlifecycle/process_darwin.go
+++ b/core/adapters/inbound/agents/processlifecycle/process_darwin.go
@@ -9,7 +9,6 @@ import (
 	"os/exec"
 	"strconv"
 	"strings"
-	"time"
 
 	"golang.org/x/sys/unix"
 
@@ -81,7 +80,7 @@ func (darwinObserver) ArgvOf(pid int) ([]string, error) {
 
 // CWDOf returns the working directory of pid via `lsof -d cwd`.
 func (darwinObserver) CWDOf(pid int) (string, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), shelloutTimeout)
 	defer cancel()
 	out, err := exec.CommandContext(ctx, lsofPath, "-a", "-p", strconv.Itoa(pid), "-d", "cwd", "-Fn").Output()
 	if err != nil {
@@ -100,6 +99,11 @@ func (darwinObserver) CWDOf(pid int) (string, error) {
 // lifetime — unlike Claude Code which opens, writes, and closes. A file that
 // no process has open is not an error: returns 0, nil.
 //
+// An lsof that could not be RUN is a different fact and is returned as an
+// error (#1537): the 2s ceiling, a fork failure or a missing binary say
+// nothing about who holds the file, and reporting them as "nobody" is the
+// #1485 collapse with the same tool. lsofProbeRan draws the line.
+//
 // lsof output format:
 //
 //	COMMAND  PID USER  FD   TYPE DEVICE SIZE/OFF NODE NAME
@@ -109,14 +113,36 @@ func (darwinObserver) CWDOf(pid int) (string, error) {
 // (read/write) — optionally followed by a lock character, e.g. "59uW". Both
 // 'w' and 'u' are writers; see writerPIDFromLsof.
 func (darwinObserver) WriterOf(path string) (int, error) {
+	return writerOfVia(path, systemLsofCmd)
+}
+
+// lsofCmd builds the bounded shellout writerOfVia runs, injected for the same
+// reason bundleIDCmd and pgrepCmd are: the distinction it draws is a property
+// of the child process, which no faked return value can pin.
+type lsofCmd func(ctx context.Context, path string) *exec.Cmd
+
+// systemLsofCmd is the production lsofCmd.
+func systemLsofCmd(ctx context.Context, path string) *exec.Cmd {
+	return exec.CommandContext(ctx, lsofPath, path)
+}
+
+// writerOfVia is WriterOf with the shellout injected.
+func writerOfVia(path string, build lsofCmd) (int, error) {
 	if path == "" {
 		return 0, nil
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), shelloutTimeout)
 	defer cancel()
-	out, err := exec.CommandContext(ctx, lsofPath, path).Output()
-	if err != nil {
-		return 0, nil // file not open by any process
+	out, err := build(ctx, path).Output()
+	if !lsofProbeRan(err) {
+		// #1537: an lsof that could not be ASKED knows nothing about who holds
+		// this transcript, and the comment that used to sit on the collapsed
+		// return ("file not open by any process") stated one cause for an error
+		// with several. Exit 1 IS an answer and still returns (0, nil) below —
+		// on this path the file being absent is itself the honest verdict "no
+		// process is writing it", which is why WriterOf needs no os.Stat where
+		// herdrClientPIDs does.
+		return 0, fmt.Errorf("lsof %s: %w", path, err)
 	}
 
 	return writerPIDFromLsof(string(out), os.Getpid()), nil
@@ -201,15 +227,40 @@ func (darwinObserver) EnvOf(pid int) (map[string]string, error) {
 	return m, nil
 }
 
+// pgrepNoMatch is pgrep's "no process matched" exit status — an answer, not a
+// failure. The lsof twin is lsofNothingToReport (osutil_darwin.go); both are
+// the per-tool half of the shared predicate (#1538).
+const pgrepNoMatch = 1
+
 // runPgrep invokes pgrep with the given flag and pattern, parses the PIDs from
 // stdout, and returns nil for the no-match (exit 1) case.
 func runPgrep(flag, pattern string) ([]int, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	return runPgrepVia(flag, pattern, systemPgrepCmd)
+}
+
+// pgrepCmd builds the bounded shellout runPgrepVia runs. It is a parameter for
+// the same reason bundleIDCmd is one: the distinction runPgrepVia draws is a
+// property of the CHILD PROCESS — ran to a normal exit versus killed or never
+// started — which no faked return value can pin, and which no arrangement of
+// live processes can be driven into on purpose.
+type pgrepCmd func(ctx context.Context, flag, pattern string) *exec.Cmd
+
+// systemPgrepCmd is the production pgrepCmd.
+func systemPgrepCmd(ctx context.Context, flag, pattern string) *exec.Cmd {
+	return exec.CommandContext(ctx, pgrepPath, flag, pattern)
+}
+
+// runPgrepVia is runPgrep with the shellout injected.
+func runPgrepVia(flag, pattern string, build pgrepCmd) ([]int, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), shelloutTimeout)
 	defer cancel()
-	out, err := exec.CommandContext(ctx, pgrepPath, flag, pattern).Output()
+	out, err := build(ctx, flag, pattern).Output()
 	if err != nil {
-		// pgrep exits 1 when there are no matches — not an error.
-		if exit, ok := err.(*exec.ExitError); ok && exit.ExitCode() == 1 {
+		// pgrep exits 1 when there are no matches — a real answer, the same
+		// shape as lsof's (lsofProbeRan). Anything else is a probe that did
+		// not run and must stay an error: collapsing it to (nil, nil) would
+		// report "no such process" for a pgrep the 2s ceiling killed.
+		if probeAnswered(err, pgrepNoMatch) {
 			return nil, nil
 		}
 		return nil, err

--- a/core/adapters/inbound/agents/processlifecycle/process_darwin.go
+++ b/core/adapters/inbound/agents/processlifecycle/process_darwin.go
@@ -113,27 +113,19 @@ func (darwinObserver) CWDOf(pid int) (string, error) {
 // (read/write) — optionally followed by a lock character, e.g. "59uW". Both
 // 'w' and 'u' are writers; see writerPIDFromLsof.
 func (darwinObserver) WriterOf(path string) (int, error) {
-	return writerOfVia(path, systemLsofCmd)
-}
-
-// lsofCmd builds the bounded shellout writerOfVia runs, injected for the same
-// reason bundleIDCmd and pgrepCmd are: the distinction it draws is a property
-// of the child process, which no faked return value can pin.
-type lsofCmd func(ctx context.Context, path string) *exec.Cmd
-
-// systemLsofCmd is the production lsofCmd.
-func systemLsofCmd(ctx context.Context, path string) *exec.Cmd {
-	return exec.CommandContext(ctx, lsofPath, path)
+	return writerOfVia(path, func(ctx context.Context) *exec.Cmd {
+		return exec.CommandContext(ctx, lsofPath, path)
+	})
 }
 
 // writerOfVia is WriterOf with the shellout injected.
-func writerOfVia(path string, build lsofCmd) (int, error) {
+func writerOfVia(path string, build shelloutCmd) (int, error) {
 	if path == "" {
 		return 0, nil
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), shelloutTimeout)
 	defer cancel()
-	out, err := build(ctx, path).Output()
+	out, err := build(ctx).Output()
 	if !lsofProbeRan(err) {
 		// #1537: an lsof that could not be ASKED knows nothing about who holds
 		// this transcript, and the comment that used to sit on the collapsed
@@ -235,26 +227,16 @@ const pgrepNoMatch = 1
 // runPgrep invokes pgrep with the given flag and pattern, parses the PIDs from
 // stdout, and returns nil for the no-match (exit 1) case.
 func runPgrep(flag, pattern string) ([]int, error) {
-	return runPgrepVia(flag, pattern, systemPgrepCmd)
-}
-
-// pgrepCmd builds the bounded shellout runPgrepVia runs. It is a parameter for
-// the same reason bundleIDCmd is one: the distinction runPgrepVia draws is a
-// property of the CHILD PROCESS — ran to a normal exit versus killed or never
-// started — which no faked return value can pin, and which no arrangement of
-// live processes can be driven into on purpose.
-type pgrepCmd func(ctx context.Context, flag, pattern string) *exec.Cmd
-
-// systemPgrepCmd is the production pgrepCmd.
-func systemPgrepCmd(ctx context.Context, flag, pattern string) *exec.Cmd {
-	return exec.CommandContext(ctx, pgrepPath, flag, pattern)
+	return runPgrepVia(flag, pattern, func(ctx context.Context) *exec.Cmd {
+		return exec.CommandContext(ctx, pgrepPath, flag, pattern)
+	})
 }
 
 // runPgrepVia is runPgrep with the shellout injected.
-func runPgrepVia(flag, pattern string, build pgrepCmd) ([]int, error) {
+func runPgrepVia(flag, pattern string, build shelloutCmd) ([]int, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), shelloutTimeout)
 	defer cancel()
-	out, err := build(ctx, flag, pattern).Output()
+	out, err := build(ctx).Output()
 	if err != nil {
 		// pgrep exits 1 when there are no matches — a real answer, the same
 		// shape as lsof's (lsofProbeRan). Anything else is a probe that did

--- a/core/adapters/inbound/agents/processlifecycle/process_linux.go
+++ b/core/adapters/inbound/agents/processlifecycle/process_linux.go
@@ -128,7 +128,8 @@ func (linuxObserver) CWDOf(pid int) (string, error) {
 // WriterOf returns the first PID that has path open for writing, found by
 // scanning every process's /proc/<pid>/fd/* symlinks for one resolving to
 // path and confirming write access via /proc/<pid>/fdinfo. A file no process
-// has open is not an error: returns 0, nil. The scan is O(procs × fds) but
+// has open is not an error: returns 0, nil; a /proc that could not be scanned
+// at all IS one (#1537). The scan is O(procs × fds) but
 // early-exits on the first writer and only stats fdinfo for fds that already
 // point at the target file.
 func (linuxObserver) WriterOf(path string) (int, error) {
@@ -146,7 +147,10 @@ func (linuxObserver) WriterOf(path string) (int, error) {
 	}
 	pids, err := procPIDs()
 	if err != nil {
-		return 0, nil
+		// #1537: an unreadable /proc is the linux spelling of a killed lsof —
+		// it says nothing about who holds the file, and reporting it as
+		// "nobody" is the collapse the port contract now forbids.
+		return 0, fmt.Errorf("scan /proc for writers of %s: %w", path, err)
 	}
 	myPID := os.Getpid()
 	for _, pid := range pids {

--- a/core/adapters/inbound/agents/processlifecycle/shellout.go
+++ b/core/adapters/inbound/agents/processlifecycle/shellout.go
@@ -1,0 +1,97 @@
+package processlifecycle
+
+import (
+	"errors"
+	"os/exec"
+	"slices"
+	"time"
+)
+
+// shelloutTimeout is the ceiling EVERY bounded shellout in this package runs
+// under. It was an unnamed `2*time.Second` literal in eight places until #1538,
+// while three doc comments and a test assertion had already made the value
+// load-bearing ("half of 2s") — so the number was a contract that nothing named.
+//
+// Two sibling packages already name their own copy and one of them points here
+// for the justification: core/pkg/cliprobe's exported Timeout, and
+// core/adapters/outbound/control's execTimeout, whose doc reads "matching the
+// process observer's 2-second ceiling (process_darwin.go)" — a cross-reference
+// to a constant this package did not have. Naming it here does not merge those
+// (a consent-path version check and a window-targeting probe are entitled to
+// different ceilings, and control's is a different layer); it gives that
+// reference something to point AT.
+//
+// The value is a compromise between two failures the shellouts sit between: a
+// probe that blocks session discovery, and a probe killed before it answers —
+// and #1538's whole subject is that the second is only safe because
+// probeAnswered reports it as a non-answer rather than as an empty one.
+const shelloutTimeout = 2 * time.Second
+
+// probeAnswered reports whether the child process behind a bounded shellout
+// actually ANSWERED, as opposed to never having been asked. It is the one
+// predicate every shellout in this package classifies its error with (#1538),
+// replacing three spellings that had drifted apart:
+//
+//   - lsofProbeRan's `err == nil || (errors.As(&exit) && exit.ExitCode() == 1)`
+//   - bundleIDVia's `errors.As(&exit) && exit.ProcessState.Exited()`
+//   - runPgrep's bare `err.(*exec.ExitError)` type assertion, which misses a
+//     wrapped error for no reason anyone chose.
+//
+// The whole family it exists to prevent — #1485, #1492, #1513, #1524, #1533,
+// #1537 — is one sentence six times: "I could not look" collapsed into "I
+// looked and there was nothing". This predicate answers only the first half.
+// What to DO with a non-answer is per-call-site and deliberately not decided
+// here: IsKnownInteractiveHost gates ADMISSION and so fails open (#1513),
+// while hostIdentity feeds a click target and so degrades an enrichment
+// (#1492). A shared verdict with per-site polarity is the point.
+//
+// answeredExitCodes is the per-tool part, and it is the only part that
+// genuinely differs. Empty means "any normal exit is an answer" — plutil's
+// rule, because it exits 1 both for a missing Info.plist and for a plist
+// carrying no CFBundleIdentifier (both measured: exit 1, #1524 and re-measured
+// in #1538), so treating a non-zero exit as a non-answer would fail the
+// admission gate OPEN and widen #784. A non-empty list is an allowlist of the
+// non-zero exits that count as answers — lsof's and pgrep's rule, where exit 1
+// is "nothing to report" and any OTHER code is not evidence about anything.
+// That distinction is load-bearing rather than cosmetic: `sh -c "exit 152"`
+// (a process killed under an exhausted CPU limit reports 152 through a shell)
+// exits NORMALLY, so ProcessState.Exited() is true and ExitCode() is 152
+// (measured, go1.25 darwin/arm64) — the empty form would call it an answer and
+// lsofProbeRan's committed corpus pins that it is not.
+//
+// The hard half does NOT differ, and it is the half that is easy to get wrong:
+//
+//   - A killed child is not an answer, and `errors.Is(err,
+//     context.DeadlineExceeded)` will not tell you. When CommandContext's
+//     deadline fires MID-RUN the child is SIGKILLed and Output returns
+//     *exec.ExitError "signal: killed", which does not wrap the context's
+//     error: errors.Is reports FALSE while ctx.Err() reports the deadline
+//     (measured independently in #1524 and again in #1538, go1.25
+//     darwin/arm64). The natural-looking spelling compiles, reads correctly,
+//     and misses the exact condition every issue in this family is about.
+//   - ProcessState.Exited() is what separates a process that RAN from one that
+//     was killed, and it covers the deaths the ceiling did not cause too: an
+//     OOM kill, a fork that failed under the same load, and a ctx already past
+//     its deadline before Start — where the error is not an ExitError at all
+//     (measured: `errors.As` false, `errors.Is(DeadlineExceeded)` true).
+//
+// errors.As rather than a type assertion because an error that has been
+// wrapped on the way here is still an exit status. No caller wraps today
+// (os/exec hands back a bare *exec.ExitError), which is exactly why the bare
+// assertion in runPgrep survived unnoticed — it was correct by accident of its
+// caller, not by construction.
+func probeAnswered(err error, answeredExitCodes ...int) bool {
+	if err == nil {
+		return true
+	}
+	var exit *exec.ExitError
+	if !errors.As(err, &exit) || !exit.ProcessState.Exited() {
+		// Killed, never started, or not a child-exit error at all. None of
+		// these carry information about the question that was asked.
+		return false
+	}
+	if len(answeredExitCodes) == 0 {
+		return true
+	}
+	return slices.Contains(answeredExitCodes, exit.ExitCode())
+}

--- a/core/adapters/inbound/agents/processlifecycle/shellout.go
+++ b/core/adapters/inbound/agents/processlifecycle/shellout.go
@@ -1,6 +1,7 @@
 package processlifecycle
 
 import (
+	"context"
 	"errors"
 	"os/exec"
 	"slices"
@@ -26,6 +27,20 @@ import (
 // and #1538's whole subject is that the second is only safe because
 // probeAnswered reports it as a non-answer rather than as an empty one.
 const shelloutTimeout = 2 * time.Second
+
+// shelloutCmd builds one bounded child process. Every injected shellout in this
+// package is one of these, and the site's own arguments are CLOSED OVER rather
+// than passed through: a builder that took them would be handing the callee
+// values it already holds, and no test has ever read one — every fixture in
+// this package spells them `_`.
+//
+// Injection is the point, not the arguments. The distinction each caller draws
+// is a property of the CHILD PROCESS — ran to a normal exit, versus killed or
+// never started — which no faked return value can pin and no arrangement of
+// live processes can be driven into on purpose. It began as bundleIDCmd
+// (#1524); #1538 made it one type instead of five, because five signatures
+// carrying arguments nobody reads is five chances to forget the ceiling.
+type shelloutCmd func(ctx context.Context) *exec.Cmd
 
 // probeAnswered reports whether the child process behind a bounded shellout
 // actually ANSWERED, as opposed to never having been asked. It is the one

--- a/core/adapters/inbound/agents/processlifecycle/shellout_guard_corpus_test.go
+++ b/core/adapters/inbound/agents/processlifecycle/shellout_guard_corpus_test.go
@@ -216,6 +216,80 @@ func classify(err error) bool {
 }`,
 		},
 
+		// ---- caught: found by review of PR #1545, each a hole in the rule's central promise ----
+		{
+			name: "rebound_err_launders_the_collapse", want: 1, wantRuns: 1,
+			needle: `n, err := parseInt(out)`,
+			why: "`err` is the most reused identifier in Go: a later `return n, err` returns a DIFFERENT error and says nothing " +
+				"about the collapse above it. Without the upper window edge this reported findings=0 — the family's exact defect, read as clean",
+			src: `package shapes
+func probe() (int, error) {
+	out, err := exec.CommandContext(ctx, lsofPath).Output()
+	if err != nil {
+		return 0, nil
+	}
+	n, err := parseInt(out)
+	return n, err
+}`,
+		},
+		{
+			name: "package_level_var_iife", want: 1, wantRuns: 1,
+			needle: `var cached = func() string {`,
+			why: "kittenPath in this package is exactly this idiom — a package-level IIFE that probes for a CLI. file.Decls only " +
+				"descends into FuncDecls, so before this the shellout was invisible AND runSites stayed 0, which meant the live " +
+				"rule's vacuity floor could not notice either",
+			src: `package shapes
+var cached = func() string {
+	out, err := exec.CommandContext(ctx, psPath, "-p", "1").Output()
+	if err != nil {
+		return ""
+	}
+	return string(out)
+}()`,
+		},
+		{
+			name: "closure_return_does_not_vouch_for_the_outer_collapse", want: 1, wantRuns: 1,
+			needle: `return func() error {`,
+			why: "a closure has its own returns; flattening a FuncDecl into one body would let an inner `return err` vouch for an " +
+				"outer collapse, and vice versa",
+			src: `package shapes
+func probe() func() error {
+	out, err := exec.CommandContext(ctx, lsofPath).Output()
+	if err != nil {
+		return nil
+	}
+	_ = out
+	return func() error {
+		return err
+	}
+}`,
+		},
+
+		// ---- clean: propagation spellings a name-based rule mis-reports ----
+		{
+			name: "returned_directly", want: 0, wantRuns: 1,
+			needle: `return exec.CommandContext(ctx, lsofPath).Output()`,
+			why: "the error goes straight to the caller with no variable in between. Reported as \"discarded outright\" before " +
+				"review of #1545 — a build failure whose message actively misdescribed correct code",
+			src: `package shapes
+func probe() ([]byte, error) {
+	return exec.CommandContext(ctx, lsofPath).Output()
+}`,
+		},
+		{
+			name: "var_declaration_binding", want: 0, wantRuns: 1,
+			needle: `var out, err = `,
+			why:    "`var out, err = cmd.Output()` binds exactly like `:=`; only AssignStmt was handled before",
+			src: `package shapes
+func probe() ([]byte, error) {
+	var out, err = exec.CommandContext(ctx, lsofPath).Output()
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}`,
+		},
+
 		// ---- the measured blind spot, pinned as a known fact ----
 		{
 			name: "classifier_called_and_verdict_discarded", want: 0, wantRuns: 1,

--- a/core/adapters/inbound/agents/processlifecycle/shellout_guard_corpus_test.go
+++ b/core/adapters/inbound/agents/processlifecycle/shellout_guard_corpus_test.go
@@ -1,0 +1,290 @@
+package processlifecycle
+
+import (
+	"go/parser"
+	"go/token"
+	"strings"
+	"testing"
+
+	"go/ast"
+)
+
+// This is the corpus behind shellout_guard_test.go's rule: one spelling per
+// case, pinned to the verdict the detector must return.
+//
+// It exists because the mutation evidence for a guard is otherwise re-run by
+// nothing. The five mutations that established this rule discriminates —
+// reverting processTTY, kittyWindowIDForPID and WriterOf to their collapsed
+// spellings, and appending the queued tmux shellout written the way all six
+// previous instances were written — each turned the live rule red exactly
+// once, and every one of those is a row below. A guard whose evidence lives
+// only in a merged PR body is a guard nobody can check again.
+//
+// It runs the PRODUCTION detector (scanShelloutClassification), not a copy, so
+// a change to the rule is measured against these cases rather than against a
+// second implementation that can drift.
+
+// shelloutShape is one construction spelling and the verdict it pins.
+type shelloutShape struct {
+	name     string
+	src      string // a complete file in package shapes
+	needle   string // a substring that MUST appear in src
+	want     int    // findings the detector must report
+	wantRuns int    // run sites it must SEE (0 findings from 0 run sites proves nothing)
+	why      string
+}
+
+func shelloutShapes() []shelloutShape {
+	return []shelloutShape{
+		// ---- caught: the family's collapse, in its spellings ----
+		{
+			name: "collapse_after_output", want: 1, wantRuns: 1,
+			needle: `if err != nil {`,
+			why:    "the sentence every issue in this family is: #1485, #1492, #1513, #1524, #1533, #1537",
+			src: `package shapes
+func probe(pid int) string {
+	out, err := exec.CommandContext(ctx, psPath, "-p", pid).Output()
+	if err != nil {
+		return ""
+	}
+	return string(out)
+}`,
+		},
+		{
+			name: "blank_assigned_error", want: 1, wantRuns: 1,
+			needle: `out, _ :=`,
+			why:    "background_probe.go spells it this way today; the error is gone before anything could classify it",
+			src: `package shapes
+func probe() string {
+	out, _ := exec.CommandContext(ctx, lsofPath, "-t").Output()
+	return string(out)
+}`,
+		},
+		{
+			name: "run_as_bare_statement", want: 1, wantRuns: 1,
+			needle: `.Run()` + "\n",
+			why:    "no binding at all: there is no error variable to classify",
+			src: `package shapes
+func probe() {
+	exec.CommandContext(ctx, kittenPath, "@", "close").Run()
+}`,
+		},
+		{
+			name: "if_init_collapse", want: 1, wantRuns: 1,
+			needle: `if err :=`,
+			why:    "the same collapse with the assignment inside the if statement, which a naive AssignStmt walk misses",
+			src: `package shapes
+func probe() int {
+	if err := exec.CommandContext(ctx, pgrepPath, "-x", "claude").Run(); err != nil {
+		return 0
+	}
+	return 1
+}`,
+		},
+		{
+			name: "second_shellout_collapses", want: 1, wantRuns: 2,
+			needle: `secondOut, err :=`,
+			why: "the #1538 shape itself: a function that already classifies one shellout is exactly where the next one gets added, " +
+				"and a function-wide 'does err appear near a classifier' check would call this clean",
+			src: `package shapes
+func probe() (string, bool) {
+	out, err := exec.CommandContext(ctx, psPath, "-p", "1").Output()
+	if !probeAnswered(err) {
+		return "", false
+	}
+	secondOut, err := exec.CommandContext(ctx, lsofPath, "-t").Output()
+	if err != nil {
+		return string(out), true
+	}
+	return string(secondOut), true
+}`,
+		},
+		{
+			name: "classified_before_the_run", want: 1, wantRuns: 1,
+			needle: `probeAnswered(err)`,
+			why:    "a classifier call that PRECEDES the run cannot be about its error; the position test is what makes this a finding",
+			src: `package shapes
+func probe(err error) string {
+	if !probeAnswered(err) {
+		return ""
+	}
+	out, err := exec.CommandContext(ctx, psPath, "-p", "1").Output()
+	if err != nil {
+		return ""
+	}
+	return string(out)
+}`,
+		},
+
+		// ---- clean: the two legitimate answers ----
+		{
+			name: "classified_empty_variadic", want: 0, wantRuns: 1,
+			needle: `probeAnswered(err)`,
+			why:    "plutil's rule: any normal exit is an answer (#1524)",
+			src: `package shapes
+func probe() (string, error) {
+	out, err := build(ctx, plist).Output()
+	if probeAnswered(err) {
+		return "", nil
+	}
+	return string(out), nil
+}`,
+		},
+		{
+			name: "classified_with_allowlist", want: 0, wantRuns: 1,
+			needle: `probeAnswered(err, pgrepNoMatch)`,
+			why:    "pgrep's and lsof's rule: only exit 1 is an answer",
+			src: `package shapes
+func probe() ([]int, error) {
+	out, err := build(ctx, flag, pattern).Output()
+	if probeAnswered(err, pgrepNoMatch) {
+		return nil, nil
+	}
+	_ = out
+	return nil, err
+}`,
+		},
+		{
+			name: "classified_via_named_wrapper", want: 0, wantRuns: 1,
+			needle: `lsofProbeRan(err)`,
+			why:    "a tool-specific wrapper counts; it IS the shared predicate with its allowlist bound",
+			src: `package shapes
+func probe() ([]int, bool) {
+	out, err := exec.CommandContext(ctx, lsofPath, logPath).Output()
+	if !lsofProbeRan(err) {
+		return nil, false
+	}
+	return parse(out), true
+}`,
+		},
+		{
+			name: "propagated_wrapped", want: 0, wantRuns: 1,
+			needle: `fmt.Errorf(`,
+			why:    "readProcInfo and CWDOf do this: the two facts stay distinguishable at the caller instead of merging here",
+			src: `package shapes
+func probe(pid int) (string, error) {
+	out, err := exec.CommandContext(ctx, psPath, "-p", pid).Output()
+	if err != nil {
+		return "", fmt.Errorf("ps pid %d: %w", pid, err)
+	}
+	return string(out), nil
+}`,
+		},
+		{
+			name: "propagated_bare", want: 0, wantRuns: 1,
+			needle: `return nil, err`,
+			why:    "returning the error unwrapped is propagation too",
+			src: `package shapes
+func probe() ([]byte, error) {
+	out, err := exec.CommandContext(ctx, lsofPath).Output()
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}`,
+		},
+		{
+			name: "if_init_propagated", want: 0, wantRuns: 1,
+			needle: `return err`,
+			why:    "the if-init spelling is not itself the defect — what it does with the error is",
+			src: `package shapes
+func probe() error {
+	if err := exec.CommandContext(ctx, pgrepPath).Run(); err != nil {
+		return err
+	}
+	return nil
+}`,
+		},
+		{
+			name: "builder_that_never_runs", want: 0, wantRuns: 0,
+			needle: `*exec.Cmd`,
+			why: "plutilBundleIDCmd's shape. Building a command is not running one, and the injected-builder idiom every " +
+				"seam in this package uses depends on this staying clean",
+			src: `package shapes
+func plutilBundleIDCmd(ctx context.Context, plist string) *exec.Cmd {
+	return exec.CommandContext(ctx, plutilPath, "-extract", "CFBundleIdentifier", "raw", "-o", "-", plist)
+}`,
+		},
+		{
+			name: "no_shellout_but_names_the_classifier", want: 0, wantRuns: 0,
+			needle: `probeAnswered(err)`,
+			why: "the run-site counter must count RUNS, not mentions of the predicate — otherwise the vacuity guard in the " +
+				"live rule could be satisfied by a file that starts no process at all",
+			src: `package shapes
+func classify(err error) bool {
+	return probeAnswered(err)
+}`,
+		},
+
+		// ---- the measured blind spot, pinned as a known fact ----
+		{
+			name: "classifier_called_and_verdict_discarded", want: 0, wantRuns: 1,
+			needle: `_ = lsofProbeRan(err)`,
+			why: "MEASURED LIMITATION, not an oversight: this rule asks whether the error REACHES a classifier, not what is done " +
+				"with the verdict. It was found by a mutation that kept the lsofProbeRan call while collapsing the return, and the " +
+				"live rule stayed green. Discarding a verdict is #1533's and #1537's actual shape and is pinned one layer up, by the " +
+				"fold tests in tty_darwin_test.go and kittywindow_darwin_test.go. Seeing it statically needs the verdict's dataflow, " +
+				"which this syntactic scan does not have",
+			src: `package shapes
+func probe() (int, error) {
+	out, err := exec.CommandContext(ctx, lsofPath, path).Output()
+	_ = lsofProbeRan(err)
+	if err != nil {
+		return 0, nil
+	}
+	return parse(out), nil
+}`,
+		},
+	}
+}
+
+// TestShelloutGuardCatchesEveryKnownShape runs the production detector over the
+// corpus.
+func TestShelloutGuardCatchesEveryKnownShape(t *testing.T) {
+	seen := map[string]bool{}
+	totalRuns, totalFindings := 0, 0
+
+	for _, shape := range shelloutShapes() {
+		if seen[shape.name] {
+			t.Fatalf("duplicate corpus case %q: one would silently shadow the other", shape.name)
+		}
+		seen[shape.name] = true
+
+		// The anti-rot guard: a case whose planted construct has been edited
+		// away would read as a pass for every want:0 row.
+		if shape.needle == "" {
+			t.Fatalf("%s: every case must assert the construct it plants is present", shape.name)
+		}
+		if !strings.Contains(shape.src, shape.needle) {
+			t.Fatalf("%s: source does not contain %q — the case is not testing what it says it tests", shape.name, shape.needle)
+		}
+
+		fset := token.NewFileSet()
+		file, err := parser.ParseFile(fset, shape.name+".go", shape.src, 0)
+		if err != nil {
+			t.Fatalf("%s: corpus case does not parse — fix the case, not the scan: %v", shape.name, err)
+		}
+
+		findings, runs := scanShelloutClassification(fset, map[string]*ast.File{shape.name + ".go": file})
+		totalRuns += runs
+		totalFindings += len(findings)
+
+		if len(findings) != shape.want {
+			t.Errorf("%s: got %d findings, want %d — %s\n%v\n--- source ---\n%s",
+				shape.name, len(findings), shape.want, shape.why, findings, shape.src)
+		}
+		if runs != shape.wantRuns {
+			t.Errorf("%s: detector saw %d run sites, want %d — %s", shape.name, runs, shape.wantRuns, shape.why)
+		}
+	}
+
+	// Two vacuity guards, in opposite directions. Without the first, a
+	// detector that reports nothing satisfies every want:0 row; without the
+	// second, one that reports everything satisfies every want:1 row.
+	if totalRuns == 0 {
+		t.Fatal("the corpus reported no run sites at all — the scan is inert, so every want:0 case above proves nothing")
+	}
+	if totalFindings == 0 {
+		t.Fatal("the corpus reported no findings at all — the scan cannot fail, so every want:1 case above proves nothing")
+	}
+}

--- a/core/adapters/inbound/agents/processlifecycle/shellout_guard_corpus_test.go
+++ b/core/adapters/inbound/agents/processlifecycle/shellout_guard_corpus_test.go
@@ -1,12 +1,11 @@
 package processlifecycle
 
 import (
+	"go/ast"
 	"go/parser"
 	"go/token"
 	"strings"
 	"testing"
-
-	"go/ast"
 )
 
 // This is the corpus behind shellout_guard_test.go's rule: one spelling per

--- a/core/adapters/inbound/agents/processlifecycle/shellout_guard_test.go
+++ b/core/adapters/inbound/agents/processlifecycle/shellout_guard_test.go
@@ -111,88 +111,186 @@ func scanShelloutClassification(fset *token.FileSet, files map[string]*ast.File)
 	for name, file := range files {
 		base := filepath.Base(name)
 		for _, decl := range file.Decls {
-			fn, ok := decl.(*ast.FuncDecl)
-			if !ok || fn.Body == nil {
-				continue
+			switch d := decl.(type) {
+			case *ast.FuncDecl:
+				if d.Body == nil {
+					continue
+				}
+				f, n := scanScope(fset, base, d.Name.Name, d.Body)
+				findings, runSites = append(findings, f...), runSites+n
+			case *ast.GenDecl:
+				// A package-level `var x = func() T { … }()` is a function body
+				// that file.Decls alone never reaches, and this package already
+				// uses that idiom (kittenPath resolves a CLI in one). Before it
+				// was walked, a shellout there was invisible AND left runSites
+				// at zero — so the vacuity floor below could not notice either.
+				f, n := scanScope(fset, base, "var initialiser", &ast.BlockStmt{List: []ast.Stmt{&ast.ExprStmt{X: genDeclExpr(d)}}})
+				findings, runSites = append(findings, f...), runSites+n
 			}
-			f, n := scanFuncForShellouts(fset, base, fn)
-			findings = append(findings, f...)
-			runSites += n
 		}
 	}
 	return findings, runSites
 }
 
-// scanFuncForShellouts applies the rule to one function body.
-func scanFuncForShellouts(fset *token.FileSet, file string, fn *ast.FuncDecl) (findings []shelloutFinding, runSites int) {
-	for _, run := range runCallsIn(fn.Body) {
-		runSites++
-		errName, bound := errIdentFor(fn.Body, run)
-		line := fset.Position(run.Pos()).Line
-		switch {
-		case !bound:
-			findings = append(findings, shelloutFinding{file, line, fn.Name.Name,
-				"the error of a child process is discarded outright"})
-		case errName == "_":
-			findings = append(findings, shelloutFinding{file, line, fn.Name.Name,
-				"the error of a child process is assigned to _"})
-		case !classifiedOrPropagated(fn.Body, errName, run.Pos()):
-			findings = append(findings, shelloutFinding{file, line, fn.Name.Name,
-				"the error of a child process (" + errName + ") is neither passed to probeAnswered/lsofProbeRan nor returned — " +
-					"a non-answer collapses into a zero value here (#1538)"})
-		}
-	}
-	return findings, runSites
-}
-
-// runCallsIn returns every call in body that starts a child process.
-func runCallsIn(body *ast.BlockStmt) []*ast.CallExpr {
-	var out []*ast.CallExpr
-	ast.Inspect(body, func(n ast.Node) bool {
-		call, ok := n.(*ast.CallExpr)
+// genDeclExpr wraps a declaration's initialiser expressions so scanScope can
+// walk them with the same code path a function body takes.
+func genDeclExpr(d *ast.GenDecl) ast.Expr {
+	lit := &ast.CompositeLit{}
+	for _, spec := range d.Specs {
+		vs, ok := spec.(*ast.ValueSpec)
 		if !ok {
-			return true
+			continue
 		}
-		if sel, ok := call.Fun.(*ast.SelectorExpr); ok && shelloutRunMethods[sel.Sel.Name] && len(call.Args) == 0 {
-			out = append(out, call)
+		lit.Elts = append(lit.Elts, vs.Values...)
+	}
+	return lit
+}
+
+// scanScope applies the rule to ONE function scope, then recurses into any
+// nested function literals as scopes of their own.
+//
+// The nesting matters: a closure has its own returns, so a `return err` in the
+// enclosing function does not propagate a closure's error and vice versa.
+// Treating a whole FuncDecl as one flat body would let either vouch for the
+// other.
+func scanScope(fset *token.FileSet, file, name string, body *ast.BlockStmt) (findings []shelloutFinding, runSites int) {
+	runs, lits := splitScope(body)
+	for _, run := range runs {
+		runSites++
+		errName, kind := errBindingFor(body, run)
+		line := fset.Position(run.Pos()).Line
+		switch kind {
+		case errReturnedDirectly:
+			// `return cmd.Output()` — the error goes straight to the caller.
+		case errDiscarded:
+			findings = append(findings, shelloutFinding{file, line, name,
+				"the error of a child process is discarded outright"})
+		case errBlank:
+			findings = append(findings, shelloutFinding{file, line, name,
+				"the error of a child process is assigned to _"})
+		default:
+			if !classifiedOrPropagated(body, errName, run.Pos()) {
+				findings = append(findings, shelloutFinding{file, line, name,
+					"the error of a child process (" + errName + ") is neither passed to probeAnswered/lsofProbeRan nor returned — " +
+						"a non-answer collapses into a zero value here (#1538)"})
+			}
+		}
+	}
+	for _, lit := range lits {
+		f, n := scanScope(fset, file, name+".func", lit.Body)
+		findings, runSites = append(findings, f...), runSites+n
+	}
+	return findings, runSites
+}
+
+// splitScope returns the run calls belonging to THIS scope and the function
+// literals that open their own. It stops descending at a nested literal so the
+// two sets never overlap.
+func splitScope(root ast.Node) (runs []*ast.CallExpr, lits []*ast.FuncLit) {
+	ast.Inspect(root, func(n ast.Node) bool {
+		if n == nil {
+			return false
+		}
+		if lit, ok := n.(*ast.FuncLit); ok && ast.Node(lit) != root {
+			lits = append(lits, lit)
+			return false
+		}
+		if call, ok := n.(*ast.CallExpr); ok {
+			if sel, ok := call.Fun.(*ast.SelectorExpr); ok && shelloutRunMethods[sel.Sel.Name] && len(call.Args) == 0 {
+				runs = append(runs, call)
+			}
 		}
 		return true
 	})
-	return out
+	return runs, lits
 }
 
-// errIdentFor finds the name the run call's error is bound to. bound is false
-// when the call is a bare statement, i.e. the error is thrown away.
-func errIdentFor(body *ast.BlockStmt, run *ast.CallExpr) (name string, bound bool) {
-	ast.Inspect(body, func(n ast.Node) bool {
+// errBinding is how a run call's error reaches (or fails to reach) a name.
+type errBinding int
+
+const (
+	errNamed            errBinding = iota // out, err := cmd.Output()
+	errBlank                              // out, _  := cmd.Output()
+	errDiscarded                          // cmd.Run() as a bare statement
+	errReturnedDirectly                   // return cmd.Output()
+)
+
+// errBindingFor finds how the run call's error is bound.
+func errBindingFor(body *ast.BlockStmt, run *ast.CallExpr) (name string, kind errBinding) {
+	name, kind = "", errDiscarded
+	inspectScope(body, func(n ast.Node) bool {
 		switch s := n.(type) {
 		case *ast.AssignStmt:
 			if len(s.Rhs) == 1 && containsNode(s.Rhs[0], run) && len(s.Lhs) > 0 {
-				if id, ok := s.Lhs[len(s.Lhs)-1].(*ast.Ident); ok {
-					name, bound = id.Name, true
-				}
+				name, kind = lhsName(s.Lhs[len(s.Lhs)-1])
 			}
-		case *ast.ExprStmt:
-			if s.X == ast.Expr(run) {
-				name, bound = "", false
+		case *ast.ValueSpec:
+			// `var out, err = cmd.Output()` binds exactly like :=.
+			if len(s.Values) == 1 && containsNode(s.Values[0], run) && len(s.Names) > 0 {
+				name, kind = lhsName(s.Names[len(s.Names)-1])
+			}
+		case *ast.ReturnStmt:
+			for _, r := range s.Results {
+				if containsNode(r, run) {
+					name, kind = "", errReturnedDirectly
+				}
 			}
 		}
 		return true
 	})
-	return name, bound
+	return name, kind
+}
+
+func lhsName(e ast.Expr) (string, errBinding) {
+	id, ok := e.(*ast.Ident)
+	if !ok {
+		return "", errDiscarded
+	}
+	if id.Name == "_" {
+		return "_", errBlank
+	}
+	return id.Name, errNamed
+}
+
+// inspectScope is ast.Inspect confined to ONE function scope: it never
+// descends into a nested function literal, which opens a scope of its own.
+//
+// Every walk that reasons about "what does this function do with err" must use
+// it. A plain ast.Inspect over the enclosing body reaches into closures, so a
+// `return err` inside one would vouch for a collapse outside it — measured, as
+// the closure_return_does_not_vouch_for_the_outer_collapse corpus row.
+func inspectScope(root ast.Node, fn func(ast.Node) bool) {
+	ast.Inspect(root, func(n ast.Node) bool {
+		if n == nil {
+			return false
+		}
+		if lit, ok := n.(*ast.FuncLit); ok && ast.Node(lit) != root {
+			return false
+		}
+		return fn(n)
+	})
 }
 
 // classifiedOrPropagated reports whether errName is passed to a classifier or
-// returned, at a position AFTER the run call.
+// returned, at a position AFTER the run call and BEFORE errName is re-bound.
 //
-// The position test is what stops one classified shellout from vouching for a
-// second, unclassified one later in the same function — a function-wide "does
-// the name appear anywhere" check would call that clean, and a function with
-// two shellouts is exactly where a new one gets added.
+// Two windows, and both edges are load-bearing:
+//
+//   - The lower edge stops one classified shellout from vouching for a second,
+//     unclassified one later in the same function — and a function with two
+//     shellouts is exactly where a new one gets added.
+//   - The upper edge stops a LATER, unrelated error from vouching for this one.
+//     `err` is the most reused identifier in Go, so the extremely ordinary
+//     `out, err := cmd.Output(); if err != nil { return 0, nil }; n, err :=
+//     parse(out); return n, err` would otherwise read as clean: the trailing
+//     `return n, err` returns a DIFFERENT error and says nothing about the
+//     collapse above it. Measured — that shape reported findings=0 before this
+//     edge existed, and it is a corpus row now.
 func classifiedOrPropagated(body *ast.BlockStmt, errName string, after token.Pos) bool {
+	limit := rebindPos(body, errName, after)
 	found := false
-	ast.Inspect(body, func(n ast.Node) bool {
-		if found || n == nil || n.Pos() <= after {
+	inspectScope(body, func(n ast.Node) bool {
+		if found || n == nil || n.Pos() <= after || (limit.IsValid() && n.Pos() >= limit) {
 			return !found
 		}
 		switch s := n.(type) {
@@ -216,6 +314,27 @@ func classifiedOrPropagated(body *ast.BlockStmt, errName string, after token.Pos
 	return found
 }
 
+// rebindPos returns the position of the first assignment after `after` that
+// writes errName, or an invalid position when there is none.
+func rebindPos(body *ast.BlockStmt, errName string, after token.Pos) token.Pos {
+	best := token.NoPos
+	inspectScope(body, func(n ast.Node) bool {
+		assign, ok := n.(*ast.AssignStmt)
+		if !ok || assign.Pos() <= after {
+			return true
+		}
+		for _, lhs := range assign.Lhs {
+			if id, ok := lhs.(*ast.Ident); ok && id.Name == errName {
+				if !best.IsValid() || assign.Pos() < best {
+					best = assign.Pos()
+				}
+			}
+		}
+		return true
+	})
+	return best
+}
+
 func containsNode(root ast.Node, target ast.Node) bool {
 	hit := false
 	ast.Inspect(root, func(n ast.Node) bool {
@@ -227,9 +346,23 @@ func containsNode(root ast.Node, target ast.Node) bool {
 	return hit
 }
 
+// usesIdent reports whether name appears in root, NOT counting occurrences
+// inside a function literal.
+//
+// The exclusion is the point rather than a detail. `return func() error {
+// return err }` is a ReturnStmt whose results mention err, but it does not
+// hand this probe's error to this caller — it hands back a closure. Counting
+// it as propagation lets a collapse three lines above go unreported, which is
+// the closure corpus row.
 func usesIdent(root ast.Node, name string) bool {
 	hit := false
 	ast.Inspect(root, func(n ast.Node) bool {
+		if hit || n == nil {
+			return false
+		}
+		if _, ok := n.(*ast.FuncLit); ok {
+			return false
+		}
 		if id, ok := n.(*ast.Ident); ok && id.Name == name {
 			hit = true
 		}
@@ -314,7 +447,13 @@ func TestEveryBoundedShelloutUsesTheNamedCeiling(t *testing.T) {
 			return true
 		})
 	}
-	if seen == 0 {
-		t.Fatal("found no context.WithTimeout calls at all — the scan proves nothing")
+	// A floor, not "> 0": eight of nine ceilings could vanish and a
+	// zero-check would still pass on the one survivor — the same reason the
+	// classification rule counts run sites rather than asking whether it saw
+	// any at all.
+	const knownCeilings = 8
+	if seen < knownCeilings {
+		t.Fatalf("found %d context.WithTimeout calls, expected at least %d: the scan is not looking where it thinks it is",
+			seen, knownCeilings)
 	}
 }

--- a/core/adapters/inbound/agents/processlifecycle/shellout_guard_test.go
+++ b/core/adapters/inbound/agents/processlifecycle/shellout_guard_test.go
@@ -124,7 +124,7 @@ func scanShelloutClassification(fset *token.FileSet, files map[string]*ast.File)
 				// uses that idiom (kittenPath resolves a CLI in one). Before it
 				// was walked, a shellout there was invisible AND left runSites
 				// at zero — so the vacuity floor below could not notice either.
-				f, n := scanScope(fset, base, "var initialiser", &ast.BlockStmt{List: []ast.Stmt{&ast.ExprStmt{X: genDeclExpr(d)}}})
+				f, n := scanScope(fset, base, "var initialiser", d)
 				findings, runSites = append(findings, f...), runSites+n
 			}
 		}
@@ -132,28 +132,20 @@ func scanShelloutClassification(fset *token.FileSet, files map[string]*ast.File)
 	return findings, runSites
 }
 
-// genDeclExpr wraps a declaration's initialiser expressions so scanScope can
-// walk them with the same code path a function body takes.
-func genDeclExpr(d *ast.GenDecl) ast.Expr {
-	lit := &ast.CompositeLit{}
-	for _, spec := range d.Specs {
-		vs, ok := spec.(*ast.ValueSpec)
-		if !ok {
-			continue
-		}
-		lit.Elts = append(lit.Elts, vs.Values...)
-	}
-	return lit
-}
-
-// scanScope applies the rule to ONE function scope, then recurses into any
-// nested function literals as scopes of their own.
+// scanScope applies the rule to ONE scope — a function body, or a declaration's
+// initialiser expressions — then recurses into any nested function literals as
+// scopes of their own.
+//
+// body is ast.Node rather than *ast.BlockStmt so a GenDecl can be handed in
+// directly. The narrower type bought nothing (every use forwards to
+// inspectScope/splitScope, which take ast.Node) and cost a synthetic
+// BlockStmt-wrapping-a-CompositeLit that no Go parser produces.
 //
 // The nesting matters: a closure has its own returns, so a `return err` in the
 // enclosing function does not propagate a closure's error and vice versa.
 // Treating a whole FuncDecl as one flat body would let either vouch for the
 // other.
-func scanScope(fset *token.FileSet, file, name string, body *ast.BlockStmt) (findings []shelloutFinding, runSites int) {
+func scanScope(fset *token.FileSet, file, name string, body ast.Node) (findings []shelloutFinding, runSites int) {
 	runs, lits := splitScope(body)
 	for _, run := range runs {
 		runSites++
@@ -216,7 +208,7 @@ const (
 )
 
 // errBindingFor finds how the run call's error is bound.
-func errBindingFor(body *ast.BlockStmt, run *ast.CallExpr) (name string, kind errBinding) {
+func errBindingFor(body ast.Node, run *ast.CallExpr) (name string, kind errBinding) {
 	name, kind = "", errDiscarded
 	inspectScope(body, func(n ast.Node) bool {
 		switch s := n.(type) {
@@ -286,7 +278,7 @@ func inspectScope(root ast.Node, fn func(ast.Node) bool) {
 //     `return n, err` returns a DIFFERENT error and says nothing about the
 //     collapse above it. Measured — that shape reported findings=0 before this
 //     edge existed, and it is a corpus row now.
-func classifiedOrPropagated(body *ast.BlockStmt, errName string, after token.Pos) bool {
+func classifiedOrPropagated(body ast.Node, errName string, after token.Pos) bool {
 	limit := rebindPos(body, errName, after)
 	found := false
 	inspectScope(body, func(n ast.Node) bool {
@@ -316,7 +308,7 @@ func classifiedOrPropagated(body *ast.BlockStmt, errName string, after token.Pos
 
 // rebindPos returns the position of the first assignment after `after` that
 // writes errName, or an invalid position when there is none.
-func rebindPos(body *ast.BlockStmt, errName string, after token.Pos) token.Pos {
+func rebindPos(body ast.Node, errName string, after token.Pos) token.Pos {
 	best := token.NoPos
 	inspectScope(body, func(n ast.Node) bool {
 		assign, ok := n.(*ast.AssignStmt)

--- a/core/adapters/inbound/agents/processlifecycle/shellout_guard_test.go
+++ b/core/adapters/inbound/agents/processlifecycle/shellout_guard_test.go
@@ -1,0 +1,320 @@
+package processlifecycle
+
+import (
+	"io/fs"
+
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// This file is the enforcement half of #1538, and it is the half that matters.
+//
+// Applying one shared predicate at today's eight shellouts is a refactor: it
+// leaves the package correct and leaves the NEXT shellout free to classify its
+// error however its author likes. Six instances of this family (#1485, #1492,
+// #1513, #1524, #1533, #1537) were each found by a human reading code, one
+// incident at a time, and #1538 exists because a seventh was already queued in
+// a comment before the sixth was fixed. A guard that fails the build is the
+// only thing here that survives the author who has not read any of those
+// issues.
+//
+// The rule, stated as narrowly as it can be while still binding:
+//
+//	In this package, the error returned by running a child process must be
+//	either CLASSIFIED by the shared predicate or PROPAGATED to the caller.
+//	It may not be discarded, and it may not be collapsed into a zero value.
+//
+// Propagation counts because it is a legitimate second answer to the same
+// question — readProcInfo and CWDOf both wrap and return, which keeps the two
+// facts distinguishable at the caller rather than merging them here. What the
+// rule forbids is the one spelling every issue in the family was filed about:
+// `if err != nil { return <zero value> }`.
+//
+// Three things this rule deliberately does NOT do:
+//
+//   - It has no exemption list, for the reason architecture_test.go and
+//     architecture_hookbody_test.go have none: a shellout that genuinely needs
+//     different treatment amends the rule in a reviewable diff, where an
+//     exemption list accumulates entries nobody re-reads.
+//   - It says nothing about POLARITY. Whether a non-answer should fail open
+//     (IsKnownInteractiveHost gates admission — #1513) or degrade an
+//     enrichment (hostIdentity feeds a click target — #1492) is a property of
+//     what the answer gates, and no static rule can see that. It only requires
+//     that the fact reaches the call site at all.
+//   - It cannot see a call site that classifies correctly and then throws the
+//     verdict away, which is what #1533 and #1537's sixth instance actually
+//     were. That is MEASURED, not assumed: a mutation that kept the
+//     lsofProbeRan call in WriterOf while collapsing the return to (0, nil)
+//     left this rule green. Seeing it statically needs the verdict's dataflow,
+//     which a syntactic scan does not have, so it is pinned one layer up by the
+//     fold tests in tty_darwin_test.go and kittywindow_darwin_test.go — and as
+//     a want:0 row in the corpus, so the blind spot is a reviewable fact rather
+//     than a surprise for whoever next trusts this rule.
+//
+// It scans SOURCE with go/parser rather than loading the package with
+// go/packages, and that is load-bearing rather than a convenience: every one
+// of the eight shellouts is behind `//go:build darwin`, so a type-aware load
+// on a linux runner would find zero of them and pass — a gate whose absence
+// reads as a pass, which is the exact defect this package keeps producing.
+// Parsing the directory ignores build tags, so linux CI checks the darwin
+// files too.
+
+// shelloutRunMethods are the *exec.Cmd methods that actually START a child.
+// Building a command is not running one — plutilBundleIDCmd returns an
+// *exec.Cmd it never runs, and the injected-builder idiom this package uses
+// for testability depends on that being fine.
+//
+// Matching is by method NAME, with no type information, so a future
+// non-exec .Run() in this package would be reported. That is the intended
+// direction: a false positive is a reviewable diff, a false negative is
+// instance seven. Wait is deliberately absent — sync.WaitGroup.Wait would
+// make the rule fire on code that starts no process at all, and nothing in
+// this package calls (*exec.Cmd).Wait.
+var shelloutRunMethods = map[string]bool{
+	"Output":         true,
+	"CombinedOutput": true,
+	"Run":            true,
+	"Start":          true,
+}
+
+// shelloutClassifiers are the calls that count as answering "did the child
+// answer?". lsofProbeRan is here because it IS probeAnswered with lsof's
+// allowlist bound (osutil_darwin.go); a third tool-specific wrapper would be
+// added here in the same breath as being written.
+var shelloutClassifiers = map[string]bool{
+	"probeAnswered": true,
+	"lsofProbeRan":  true,
+}
+
+// shelloutFinding is one unclassified shellout error.
+type shelloutFinding struct {
+	File   string
+	Line   int
+	Func   string
+	Reason string
+}
+
+func (f shelloutFinding) String() string {
+	return f.File + ":" + strconv.Itoa(f.Line) + " in " + f.Func + "(): " + f.Reason
+}
+
+// scanShelloutClassification is the production detector, shared by the live
+// rule and by its corpus. It returns one finding per offending run site, plus
+// the total number of run sites seen — the second is what makes a silent
+// "no findings" distinguishable from a scan that looked at nothing.
+func scanShelloutClassification(fset *token.FileSet, files map[string]*ast.File) (findings []shelloutFinding, runSites int) {
+	for name, file := range files {
+		base := filepath.Base(name)
+		for _, decl := range file.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Body == nil {
+				continue
+			}
+			f, n := scanFuncForShellouts(fset, base, fn)
+			findings = append(findings, f...)
+			runSites += n
+		}
+	}
+	return findings, runSites
+}
+
+// scanFuncForShellouts applies the rule to one function body.
+func scanFuncForShellouts(fset *token.FileSet, file string, fn *ast.FuncDecl) (findings []shelloutFinding, runSites int) {
+	for _, run := range runCallsIn(fn.Body) {
+		runSites++
+		errName, bound := errIdentFor(fn.Body, run)
+		line := fset.Position(run.Pos()).Line
+		switch {
+		case !bound:
+			findings = append(findings, shelloutFinding{file, line, fn.Name.Name,
+				"the error of a child process is discarded outright"})
+		case errName == "_":
+			findings = append(findings, shelloutFinding{file, line, fn.Name.Name,
+				"the error of a child process is assigned to _"})
+		case !classifiedOrPropagated(fn.Body, errName, run.Pos()):
+			findings = append(findings, shelloutFinding{file, line, fn.Name.Name,
+				"the error of a child process (" + errName + ") is neither passed to probeAnswered/lsofProbeRan nor returned — " +
+					"a non-answer collapses into a zero value here (#1538)"})
+		}
+	}
+	return findings, runSites
+}
+
+// runCallsIn returns every call in body that starts a child process.
+func runCallsIn(body *ast.BlockStmt) []*ast.CallExpr {
+	var out []*ast.CallExpr
+	ast.Inspect(body, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		if sel, ok := call.Fun.(*ast.SelectorExpr); ok && shelloutRunMethods[sel.Sel.Name] && len(call.Args) == 0 {
+			out = append(out, call)
+		}
+		return true
+	})
+	return out
+}
+
+// errIdentFor finds the name the run call's error is bound to. bound is false
+// when the call is a bare statement, i.e. the error is thrown away.
+func errIdentFor(body *ast.BlockStmt, run *ast.CallExpr) (name string, bound bool) {
+	ast.Inspect(body, func(n ast.Node) bool {
+		switch s := n.(type) {
+		case *ast.AssignStmt:
+			if len(s.Rhs) == 1 && containsNode(s.Rhs[0], run) && len(s.Lhs) > 0 {
+				if id, ok := s.Lhs[len(s.Lhs)-1].(*ast.Ident); ok {
+					name, bound = id.Name, true
+				}
+			}
+		case *ast.ExprStmt:
+			if s.X == ast.Expr(run) {
+				name, bound = "", false
+			}
+		}
+		return true
+	})
+	return name, bound
+}
+
+// classifiedOrPropagated reports whether errName is passed to a classifier or
+// returned, at a position AFTER the run call.
+//
+// The position test is what stops one classified shellout from vouching for a
+// second, unclassified one later in the same function — a function-wide "does
+// the name appear anywhere" check would call that clean, and a function with
+// two shellouts is exactly where a new one gets added.
+func classifiedOrPropagated(body *ast.BlockStmt, errName string, after token.Pos) bool {
+	found := false
+	ast.Inspect(body, func(n ast.Node) bool {
+		if found || n == nil || n.Pos() <= after {
+			return !found
+		}
+		switch s := n.(type) {
+		case *ast.CallExpr:
+			if id, ok := s.Fun.(*ast.Ident); ok && shelloutClassifiers[id.Name] {
+				for _, arg := range s.Args {
+					if usesIdent(arg, errName) {
+						found = true
+					}
+				}
+			}
+		case *ast.ReturnStmt:
+			for _, r := range s.Results {
+				if usesIdent(r, errName) {
+					found = true
+				}
+			}
+		}
+		return !found
+	})
+	return found
+}
+
+func containsNode(root ast.Node, target ast.Node) bool {
+	hit := false
+	ast.Inspect(root, func(n ast.Node) bool {
+		if n == target {
+			hit = true
+		}
+		return !hit
+	})
+	return hit
+}
+
+func usesIdent(root ast.Node, name string) bool {
+	hit := false
+	ast.Inspect(root, func(n ast.Node) bool {
+		if id, ok := n.(*ast.Ident); ok && id.Name == name {
+			hit = true
+		}
+		return !hit
+	})
+	return hit
+}
+
+// parsePackageSources parses every non-test .go file in dir, ignoring build
+// constraints on purpose — see the file header.
+func parsePackageSources(t *testing.T, dir string) (*token.FileSet, map[string]*ast.File) {
+	t.Helper()
+	fset := token.NewFileSet()
+	pkgs, err := parser.ParseDir(fset, dir, func(fi fs.FileInfo) bool {
+		return !strings.HasSuffix(fi.Name(), "_test.go")
+	}, 0)
+	if err != nil {
+		t.Fatalf("parse %s: %v", dir, err)
+	}
+	files := map[string]*ast.File{}
+	for _, pkg := range pkgs {
+		for name, f := range pkg.Files {
+			files[name] = f
+		}
+	}
+	if len(files) == 0 {
+		t.Fatalf("parsed no files in %s — the scan is looking in the wrong place, so its silence proves nothing", dir)
+	}
+	return fset, files
+}
+
+// TestEveryBoundedShelloutClassifiesItsError is the live rule.
+func TestEveryBoundedShelloutClassifiesItsError(t *testing.T) {
+	fset, files := parsePackageSources(t, ".")
+	findings, runSites := scanShelloutClassification(fset, files)
+
+	// Vacuity guard. A rule that reports no violations because it found no
+	// shellouts is indistinguishable from a clean package, and this one runs
+	// on a linux runner where every shellout is behind a build tag it does
+	// not evaluate. The floor is deliberately below today's count so an
+	// intentional removal does not fail here for the wrong reason, but a
+	// scan that stops seeing the package fails loudly.
+	const knownRunSites = 8
+	if runSites < knownRunSites {
+		t.Fatalf("found %d child-process run sites, expected at least %d: the scan is not looking where it thinks it is, so its silence proves nothing",
+			runSites, knownRunSites)
+	}
+
+	for _, f := range findings {
+		t.Errorf("%s", f)
+	}
+	if len(findings) > 0 {
+		t.Log("Every issue in this family is one sentence: \"I could not look\" collapsed into \"I looked and there was nothing\" (#1485, #1492, #1513, #1524, #1533, #1537).")
+		t.Log("Fix: classify with probeAnswered(err[, answeredExitCodes...]) and decide at THIS call site what a non-answer means, or return the error.")
+	}
+}
+
+// TestEveryBoundedShelloutUsesTheNamedCeiling is #1538's second half. The 2s
+// ceiling was an unnamed literal in eight places while three doc comments and
+// a test assertion already treated the value as a contract ("half of 2s"), and
+// a sibling package's own constant pointed here for the justification.
+func TestEveryBoundedShelloutUsesTheNamedCeiling(t *testing.T) {
+	fset, files := parsePackageSources(t, ".")
+
+	seen := 0
+	for name, file := range files {
+		ast.Inspect(file, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok || len(call.Args) != 2 {
+				return true
+			}
+			sel, ok := call.Fun.(*ast.SelectorExpr)
+			if !ok || sel.Sel.Name != "WithTimeout" {
+				return true
+			}
+			seen++
+			if id, ok := call.Args[1].(*ast.Ident); ok && id.Name == "shelloutTimeout" {
+				return true
+			}
+			t.Errorf("%s:%d: a bounded shellout's ceiling is spelled inline; use shelloutTimeout so the value stays one fact (#1538)",
+				filepath.Base(name), fset.Position(call.Pos()).Line)
+			return true
+		})
+	}
+	if seen == 0 {
+		t.Fatal("found no context.WithTimeout calls at all — the scan proves nothing")
+	}
+}

--- a/core/adapters/inbound/agents/processlifecycle/shellout_kittywindow_darwin_test.go
+++ b/core/adapters/inbound/agents/processlifecycle/shellout_kittywindow_darwin_test.go
@@ -1,0 +1,138 @@
+//go:build darwin
+
+package processlifecycle
+
+import (
+	"context"
+	"os/exec"
+	"testing"
+
+	"irrlicht/core/domain/session"
+)
+
+// kittenLsFixture is a minimal `kitten @ ls` response naming one window.
+const kittenLsFixture = `[{"tabs":[{"windows":[{"id":7,"pid":4242,"foreground_processes":[]}]}]}]`
+
+// TestKittyWindowIDForPIDVia_NonAnswerIsNotAnAbsentWindow is #1537's sixth
+// instance: a `kitten @ ls` that could not be asked reported as "this session
+// has no kitty window".
+//
+// Rows 1-3 are LOCKS: a resolving probe, a probe that ran and matched nothing,
+// and a kitten that exited non-zero must all keep reporting probed — the last
+// one because a kitty that DECLINES to describe its windows has answered, and
+// treating that as a non-answer would poison completeness for a live, working
+// host. Row 1 is the vacuity guard in both directions at once: it is the only
+// row that produces a non-empty id.
+func TestKittyWindowIDForPIDVia_NonAnswerIsNotAnAbsentWindow(t *testing.T) {
+	shell := func(script string) kittenCmd {
+		return func(ctx context.Context, _ string) *exec.Cmd {
+			return exec.CommandContext(ctx, "/bin/sh", "-c", script)
+		}
+	}
+
+	cases := []struct {
+		name       string
+		build      kittenCmd
+		wantID     string
+		wantProbed bool
+		why        string
+	}{
+		{
+			name: "kitten answers with a matching window", build: shell("cat <<'J'\n" + kittenLsFixture + "\nJ"),
+			wantID: "7", wantProbed: true,
+			why: "the vacuity guard: the only row that resolves an id, so a hard-wired \"\" cannot pass the table",
+		},
+		{
+			name: "kitten answers, no window matches", build: shell("echo '[]'"),
+			wantID: "", wantProbed: true,
+			why: "a LOCK: an empty answer is still an answer",
+		},
+		{
+			name: "kitten exits non-zero", build: shell("exit 1"),
+			wantID: "", wantProbed: true,
+			why: "kitty declining to describe its windows is a verdict about kitty; this probe takes no exit-code allowlist",
+		},
+		{
+			name: "killed by a signal", build: shell("kill -9 $$"),
+			wantID: "", wantProbed: false,
+			why: "#1537: a killed kitten knows nothing about which window holds this session",
+		},
+		{
+			name: "binary missing", build: func(ctx context.Context, _ string) *exec.Cmd {
+				return exec.CommandContext(ctx, "/nonexistent/kitten-1537")
+			},
+			wantID: "", wantProbed: false,
+			why: "a fork/exec failure never reached the question",
+		},
+	}
+
+	for _, tc := range cases {
+		if kittenPath == "" {
+			t.Skip("kitten is not installed: kittyWindowIDForPIDVia short-circuits before the injected command, so every row below would pass vacuously")
+		}
+		id, probed := kittyWindowIDForPIDVia("unix:/tmp/kitty-1537", 4242, tc.build)
+		if id != tc.wantID || probed != tc.wantProbed {
+			t.Errorf("%s: kittyWindowIDForPIDVia = (%q, %v), want (%q, %v) — %s",
+				tc.name, id, probed, tc.wantID, tc.wantProbed, tc.why)
+		}
+	}
+}
+
+// TestKittyWindowIDForPIDVia_AbsentKittenIsASettledVerdict pins the guard's
+// polarity, which is the one judgement call in #1537's sixth instance and the
+// opposite of what "could not look" suggests at first reading.
+//
+// An absent kitten binary or an empty socket is a property of the installation,
+// not a read that failed — the same reading osutil_linux.go's stubs give. The
+// alternative poisons hostIdentity's completeness permanently on every machine
+// where kitten is not on the trusted path, and buys nothing: the value is
+// fill-only downstream and re-probed on the next refresh.
+func TestKittyWindowIDForPIDVia_AbsentKittenIsASettledVerdict(t *testing.T) {
+	unreachable := func(ctx context.Context, _ string) *exec.Cmd {
+		return exec.CommandContext(ctx, "/nonexistent/kitten-must-not-run-1537")
+	}
+	for _, tc := range []struct {
+		name, socket string
+		pid          int
+	}{
+		{"no socket", "", 4242},
+		{"no session pid", "unix:/tmp/kitty-1537", 0},
+	} {
+		if id, probed := kittyWindowIDForPIDVia(tc.socket, tc.pid, unreachable); id != "" || !probed {
+			t.Errorf("%s: got (%q, %v), want (\"\", true) — nothing was asked, so nothing failed", tc.name, id, probed)
+		}
+	}
+}
+
+// TestApplyAncestryFallbacks_UnreadableKittyWindowIsNotACompleteRead is the
+// consumer half. The verdict above is worth nothing unless something reads it,
+// and before #1537 nothing did: applyKittyAncestryBackfill assigned the empty
+// string into l.KittyWindowID and returned void, so an aborted kitten read and
+// a kitty with no matching window were the same fact by the time the caller saw
+// them.
+//
+// This is the same shape as TestHostIdentity_KittyBackfillWalkCountsTowardCompleteness,
+// which pins the sibling case — the ancestry WALK's verdict, which used to be
+// discarded here too. The ancestry probe is pre-resolved so the block under
+// test is the only one that runs: with TermProgram already "kitty" the three
+// blocks above it are all skipped, including the one that would shell out.
+func TestApplyAncestryFallbacks_UnreadableKittyWindowIsNotACompleteRead(t *testing.T) {
+	fixture := func() (*session.Launcher, *ancestryProbe) {
+		return &session.Launcher{TermProgram: "kitty", KittyListenOn: "unix:/tmp/kitty-1537"},
+			&ancestryProbe{pid: 4242, resolved: true, term: "kitty", hostPID: 999, complete: true}
+	}
+	answered := func(string, int) (string, bool) { return "7", true }
+	unanswered := func(string, int) (string, bool) { return "", false }
+
+	// Vacuity guard: a kitten that answers must still complete, or a
+	// hard-wired "incomplete" would satisfy the assertion below.
+	l, ancestry := fixture()
+	if complete := applyAncestryFallbacksVia(l, 4242, ancestry, answered); !complete || l.KittyWindowID != "7" {
+		t.Errorf("a kitten that answered: got (window %q, complete %v); want (\"7\", true)", l.KittyWindowID, complete)
+	}
+
+	l, ancestry = fixture()
+	if complete := applyAncestryFallbacksVia(l, 4242, ancestry, unanswered); complete {
+		t.Error("a kitten that never answered was reported as a complete read (#1537)")
+	}
+}

--- a/core/adapters/inbound/agents/processlifecycle/shellout_kittywindow_darwin_test.go
+++ b/core/adapters/inbound/agents/processlifecycle/shellout_kittywindow_darwin_test.go
@@ -3,8 +3,6 @@
 package processlifecycle
 
 import (
-	"context"
-	"os/exec"
 	"testing"
 
 	"irrlicht/core/domain/session"
@@ -24,43 +22,35 @@ const kittenLsFixture = `[{"tabs":[{"windows":[{"id":7,"pid":4242,"foreground_pr
 // host. Row 1 is the vacuity guard in both directions at once: it is the only
 // row that produces a non-empty id.
 func TestKittyWindowIDForPIDVia_NonAnswerIsNotAnAbsentWindow(t *testing.T) {
-	shell := func(script string) kittenCmd {
-		return func(ctx context.Context, _ string) *exec.Cmd {
-			return exec.CommandContext(ctx, "/bin/sh", "-c", script)
-		}
-	}
-
 	cases := []struct {
 		name       string
-		build      kittenCmd
+		build      shelloutCmd
 		wantID     string
 		wantProbed bool
 		why        string
 	}{
 		{
-			name: "kitten answers with a matching window", build: shell("cat <<'J'\n" + kittenLsFixture + "\nJ"),
+			name: "kitten answers with a matching window", build: shellCmd("cat <<'J'\n" + kittenLsFixture + "\nJ"),
 			wantID: "7", wantProbed: true,
 			why: "the vacuity guard: the only row that resolves an id, so a hard-wired \"\" cannot pass the table",
 		},
 		{
-			name: "kitten answers, no window matches", build: shell("echo '[]'"),
+			name: "kitten answers, no window matches", build: shellCmd("echo '[]'"),
 			wantID: "", wantProbed: true,
 			why: "a LOCK: an empty answer is still an answer",
 		},
 		{
-			name: "kitten exits non-zero", build: shell("exit 1"),
+			name: "kitten exits non-zero", build: shellCmd("exit 1"),
 			wantID: "", wantProbed: true,
 			why: "kitty declining to describe its windows is a verdict about kitty; this probe takes no exit-code allowlist",
 		},
 		{
-			name: "killed by a signal", build: shell("kill -9 $$"),
+			name: "killed by a signal", build: shellCmd("kill -9 $$"),
 			wantID: "", wantProbed: false,
 			why: "#1537: a killed kitten knows nothing about which window holds this session",
 		},
 		{
-			name: "binary missing", build: func(ctx context.Context, _ string) *exec.Cmd {
-				return exec.CommandContext(ctx, "/nonexistent/kitten-1537")
-			},
+			name: "binary missing", build: missingCmd("kitten-1537"),
 			wantID: "", wantProbed: false,
 			why: "a fork/exec failure never reached the question",
 		},
@@ -100,9 +90,7 @@ func TestKittyWindowIDForPIDVia_AbsentKittenIsASettledVerdict(t *testing.T) {
 	kittenPath = "/nonexistent/kitten-never-invoked-1537"
 	t.Cleanup(func() { kittenPath = prev })
 
-	unreachable := func(ctx context.Context, _ string) *exec.Cmd {
-		return exec.CommandContext(ctx, "/nonexistent/kitten-must-not-run-1537")
-	}
+	unreachable := missingCmd("kitten-must-not-run-1537")
 	for _, tc := range []struct {
 		name, socket string
 		pid          int

--- a/core/adapters/inbound/agents/processlifecycle/shellout_kittywindow_darwin_test.go
+++ b/core/adapters/inbound/agents/processlifecycle/shellout_kittywindow_darwin_test.go
@@ -66,10 +66,18 @@ func TestKittyWindowIDForPIDVia_NonAnswerIsNotAnAbsentWindow(t *testing.T) {
 		},
 	}
 
+	// kittenPath is a package var, and pinning it is what stops this table
+	// from evaporating. kittyWindowIDForPIDVia short-circuits on an empty
+	// kittenPath BEFORE reaching the injected command, so on a machine
+	// without kitty every row below would pass without running — and the
+	// CI runner is exactly such a machine. "The probe is absent" and "the
+	// probe answered" producing the same green is the shape this whole
+	// issue family is about; a test suite is not exempt from it.
+	prev := kittenPath
+	kittenPath = "/nonexistent/kitten-never-invoked-1537"
+	t.Cleanup(func() { kittenPath = prev })
+
 	for _, tc := range cases {
-		if kittenPath == "" {
-			t.Skip("kitten is not installed: kittyWindowIDForPIDVia short-circuits before the injected command, so every row below would pass vacuously")
-		}
 		id, probed := kittyWindowIDForPIDVia("unix:/tmp/kitty-1537", 4242, tc.build)
 		if id != tc.wantID || probed != tc.wantProbed {
 			t.Errorf("%s: kittyWindowIDForPIDVia = (%q, %v), want (%q, %v) — %s",
@@ -88,6 +96,10 @@ func TestKittyWindowIDForPIDVia_NonAnswerIsNotAnAbsentWindow(t *testing.T) {
 // where kitten is not on the trusted path, and buys nothing: the value is
 // fill-only downstream and re-probed on the next refresh.
 func TestKittyWindowIDForPIDVia_AbsentKittenIsASettledVerdict(t *testing.T) {
+	prev := kittenPath
+	kittenPath = "/nonexistent/kitten-never-invoked-1537"
+	t.Cleanup(func() { kittenPath = prev })
+
 	unreachable := func(ctx context.Context, _ string) *exec.Cmd {
 		return exec.CommandContext(ctx, "/nonexistent/kitten-must-not-run-1537")
 	}

--- a/core/adapters/inbound/agents/processlifecycle/shellout_process_darwin_test.go
+++ b/core/adapters/inbound/agents/processlifecycle/shellout_process_darwin_test.go
@@ -3,8 +3,6 @@
 package processlifecycle
 
 import (
-	"context"
-	"os/exec"
 	"testing"
 	"time"
 )
@@ -28,43 +26,35 @@ import (
 // Row 1 is also the vacuity guard: a runPgrepVia hard-wired to return an error
 // would satisfy rows 3-5 while proving nothing.
 func TestRunPgrepVia_NonAnswerStaysAnError(t *testing.T) {
-	shell := func(script string) pgrepCmd {
-		return func(ctx context.Context, _, _ string) *exec.Cmd {
-			return exec.CommandContext(ctx, "/bin/sh", "-c", script)
-		}
-	}
-
 	cases := []struct {
 		name    string
-		build   pgrepCmd
+		build   shelloutCmd
 		wantErr bool
 		wantN   int
 		why     string
 	}{
 		{
-			name: "a real answer", build: shell("echo 4711; echo 4712"),
+			name: "a real answer", build: shellCmd("echo 4711; echo 4712"),
 			wantErr: false, wantN: 2,
 			why: "the vacuity guard: without a row that parses PIDs, every want-error row below passes for the wrong reason",
 		},
 		{
-			name: "exit 1 — pgrep's no-match", build: shell("exit 1"),
+			name: "exit 1 — pgrep's no-match", build: shellCmd("exit 1"),
 			wantErr: false, wantN: 0,
 			why: "pgrep exits 1 when nothing matched; that is an answer and the caller must see (nil, nil)",
 		},
 		{
-			name: "exit 2 — pgrep's usage/error status", build: shell("exit 2"),
+			name: "exit 2 — pgrep's usage/error status", build: shellCmd("exit 2"),
 			wantErr: true,
 			why:     "the allowlist is exactly {1}: any other normal exit is not evidence about which processes exist. Widening this to 'any normal exit' was green against the whole suite before this test existed",
 		},
 		{
-			name: "killed by a signal", build: shell("kill -9 $$"),
+			name: "killed by a signal", build: shellCmd("kill -9 $$"),
 			wantErr: true,
 			why:     "a killed pgrep did not answer, and reporting nil matches would say 'that agent is not running' about a process nobody looked for",
 		},
 		{
-			name: "binary missing", build: func(ctx context.Context, _, _ string) *exec.Cmd {
-				return exec.CommandContext(ctx, "/nonexistent/pgrep-1538")
-			},
+			name: "binary missing", build: missingCmd("pgrep-1538"),
 			wantErr: true,
 			why:     "a fork/exec failure never reached the question",
 		},
@@ -93,14 +83,11 @@ func TestRunPgrepVia_NonAnswerStaysAnError(t *testing.T) {
 // elapsed-time assertion is what proves the row did not pass on the cheap
 // branch.
 func TestRunPgrepVia_CeilingIsAnErrorNotAnEmptyResult(t *testing.T) {
-	stalled := func(ctx context.Context, _, _ string) *exec.Cmd {
-		// The passed ctx on purpose: this must be killed by runPgrepVia's own
-		// ceiling, not by a deadline the fixture invented.
-		return exec.CommandContext(ctx, "/bin/sleep", "30")
-	}
-
+	t.Parallel() // spends the real 2s ceiling and shares no state
+	// stalledChild takes the ctx runPgrepVia passes, on purpose: this must be
+	// killed by runPgrepVia's own ceiling, not by a deadline a fixture invented.
 	start := time.Now()
-	pids, err := runPgrepVia("-x", "claude", stalled)
+	pids, err := runPgrepVia("-x", "claude", stalledChild)
 	elapsed := time.Since(start)
 
 	if err == nil {
@@ -128,40 +115,32 @@ func TestRunPgrepVia_CeilingIsAnErrorNotAnEmptyResult(t *testing.T) {
 // is not an error — it returns 0, nil", which is only meaningful if a probe
 // that could not RUN is one.
 func TestWriterOfVia_NonAnswerIsNotAnUnwrittenFile(t *testing.T) {
-	shell := func(script string) lsofCmd {
-		return func(ctx context.Context, _ string) *exec.Cmd {
-			return exec.CommandContext(ctx, "/bin/sh", "-c", script)
-		}
-	}
-
 	cases := []struct {
 		name    string
-		build   lsofCmd
+		build   shelloutCmd
 		wantErr bool
 		wantPID int
 		why     string
 	}{
 		{
-			name: "lsof answers with a writer", build: shell(
+			name: "lsof answers with a writer", build: shellCmd(
 				`echo "COMMAND  PID USER  FD   TYPE DEVICE SIZE/OFF NODE NAME"; echo "codex  24454 ingo  14w  REG  1,18   3330     99  /tmp/t.jsonl"`),
 			wantErr: false, wantPID: 24454,
 			why: "the vacuity guard: the only row that reaches writerPIDFromLsof at all, so a writerOfVia hard-wired to 0 " +
 				"would satisfy every other row here",
 		},
 		{
-			name: "exit 1 — lsof looked and nobody holds it", build: shell("exit 1"),
+			name: "exit 1 — lsof looked and nobody holds it", build: shellCmd("exit 1"),
 			wantErr: false,
 			why:     "the LOCK: an unwritten transcript is an answer, and (0, nil) is the right one",
 		},
 		{
-			name: "killed by a signal", build: shell("kill -9 $$"),
+			name: "killed by a signal", build: shellCmd("kill -9 $$"),
 			wantErr: true,
 			why:     "#1537: a killed lsof knows nothing about who holds the transcript",
 		},
 		{
-			name: "binary missing", build: func(ctx context.Context, _ string) *exec.Cmd {
-				return exec.CommandContext(ctx, "/nonexistent/lsof-1537")
-			},
+			name: "binary missing", build: missingCmd("lsof-1537"),
 			wantErr: true,
 			why:     "a fork/exec failure never reached the question",
 		},

--- a/core/adapters/inbound/agents/processlifecycle/shellout_process_darwin_test.go
+++ b/core/adapters/inbound/agents/processlifecycle/shellout_process_darwin_test.go
@@ -138,8 +138,16 @@ func TestWriterOfVia_NonAnswerIsNotAnUnwrittenFile(t *testing.T) {
 		name    string
 		build   lsofCmd
 		wantErr bool
+		wantPID int
 		why     string
 	}{
+		{
+			name: "lsof answers with a writer", build: shell(
+				`echo "COMMAND  PID USER  FD   TYPE DEVICE SIZE/OFF NODE NAME"; echo "codex  24454 ingo  14w  REG  1,18   3330     99  /tmp/t.jsonl"`),
+			wantErr: false, wantPID: 24454,
+			why: "the vacuity guard: the only row that reaches writerPIDFromLsof at all, so a writerOfVia hard-wired to 0 " +
+				"would satisfy every other row here",
+		},
 		{
 			name: "exit 1 — lsof looked and nobody holds it", build: shell("exit 1"),
 			wantErr: false,
@@ -164,8 +172,8 @@ func TestWriterOfVia_NonAnswerIsNotAnUnwrittenFile(t *testing.T) {
 		if (err != nil) != tc.wantErr {
 			t.Errorf("%s: writerOfVia = (%d, %v), wantErr %v — %s", tc.name, pid, err, tc.wantErr, tc.why)
 		}
-		if pid != 0 {
-			t.Errorf("%s: got pid %d, want 0 — no fixture reports a holder", tc.name, pid)
+		if pid != tc.wantPID {
+			t.Errorf("%s: got pid %d, want %d — %s", tc.name, pid, tc.wantPID, tc.why)
 		}
 	}
 }

--- a/core/adapters/inbound/agents/processlifecycle/shellout_process_darwin_test.go
+++ b/core/adapters/inbound/agents/processlifecycle/shellout_process_darwin_test.go
@@ -1,0 +1,171 @@
+//go:build darwin
+
+package processlifecycle
+
+import (
+	"context"
+	"os/exec"
+	"testing"
+	"time"
+)
+
+// TestRunPgrepVia_NonAnswerStaysAnError is the lock runPgrep never had.
+//
+// Before #1538 runPgrep had NO test of any kind — its exit-1 rule was
+// unverified — and that absence was measured rather than assumed: replacing
+// `probeAnswered(err, pgrepNoMatch)` with the unrestricted `probeAnswered(err)`
+// left `go test ./...` fully green, so the tool-specific half of the predicate
+// was free to be widened at this call site by anybody, including by #1538
+// itself. That is the shape #1517 shipped two gate defects through: a widening
+// with slack in the gates meant to catch it.
+//
+// Rows 1-2 are LOCKS on the pre-#1538 behaviour (a real answer parses; exit 1
+// is the no-match answer, not a failure). Rows 3-5 pin the opposite mutation —
+// a classifier that calls every failure an answer — and each is a case the
+// collapse spelling `if err != nil { return nil, nil }` would report as "no
+// process matched", which is #1485's sentence with pgrep's tool name in it.
+//
+// Row 1 is also the vacuity guard: a runPgrepVia hard-wired to return an error
+// would satisfy rows 3-5 while proving nothing.
+func TestRunPgrepVia_NonAnswerStaysAnError(t *testing.T) {
+	shell := func(script string) pgrepCmd {
+		return func(ctx context.Context, _, _ string) *exec.Cmd {
+			return exec.CommandContext(ctx, "/bin/sh", "-c", script)
+		}
+	}
+
+	cases := []struct {
+		name    string
+		build   pgrepCmd
+		wantErr bool
+		wantN   int
+		why     string
+	}{
+		{
+			name: "a real answer", build: shell("echo 4711; echo 4712"),
+			wantErr: false, wantN: 2,
+			why: "the vacuity guard: without a row that parses PIDs, every want-error row below passes for the wrong reason",
+		},
+		{
+			name: "exit 1 — pgrep's no-match", build: shell("exit 1"),
+			wantErr: false, wantN: 0,
+			why: "pgrep exits 1 when nothing matched; that is an answer and the caller must see (nil, nil)",
+		},
+		{
+			name: "exit 2 — pgrep's usage/error status", build: shell("exit 2"),
+			wantErr: true,
+			why:     "the allowlist is exactly {1}: any other normal exit is not evidence about which processes exist. Widening this to 'any normal exit' was green against the whole suite before this test existed",
+		},
+		{
+			name: "killed by a signal", build: shell("kill -9 $$"),
+			wantErr: true,
+			why:     "a killed pgrep did not answer, and reporting nil matches would say 'that agent is not running' about a process nobody looked for",
+		},
+		{
+			name: "binary missing", build: func(ctx context.Context, _, _ string) *exec.Cmd {
+				return exec.CommandContext(ctx, "/nonexistent/pgrep-1538")
+			},
+			wantErr: true,
+			why:     "a fork/exec failure never reached the question",
+		},
+	}
+
+	for _, tc := range cases {
+		pids, err := runPgrepVia("-x", "claude", tc.build)
+		if (err != nil) != tc.wantErr {
+			t.Errorf("%s: err = %v, wantErr %v — %s", tc.name, err, tc.wantErr, tc.why)
+			continue
+		}
+		if !tc.wantErr && len(pids) != tc.wantN {
+			t.Errorf("%s: got %d pids %v, want %d — %s", tc.name, len(pids), pids, tc.wantN, tc.why)
+		}
+	}
+}
+
+// TestRunPgrepVia_CeilingIsAnErrorNotAnEmptyResult is the #1485-shaped row that
+// cannot be written with a fast fixture: it costs the real shelloutTimeout,
+// because the thing under test IS the ceiling firing mid-run.
+//
+// It is the twin of TestBundleIDVia_CeilingActuallyFires, and it exists for the
+// same reason: the rows above reach the pre-Start branch or a normal exit, and
+// a mid-run SIGKILL is a different error shape (*exec.ExitError "signal:
+// killed", which does NOT wrap the context's error — see probeAnswered). The
+// elapsed-time assertion is what proves the row did not pass on the cheap
+// branch.
+func TestRunPgrepVia_CeilingIsAnErrorNotAnEmptyResult(t *testing.T) {
+	stalled := func(ctx context.Context, _, _ string) *exec.Cmd {
+		// The passed ctx on purpose: this must be killed by runPgrepVia's own
+		// ceiling, not by a deadline the fixture invented.
+		return exec.CommandContext(ctx, "/bin/sleep", "30")
+	}
+
+	start := time.Now()
+	pids, err := runPgrepVia("-x", "claude", stalled)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatalf("a pgrep killed by its own ceiling reported %v matches and no error — that is #1485 with pgrep's name on it", pids)
+	}
+	if elapsed < shelloutTimeout/2 {
+		t.Errorf("returned after %v, well under the %v ceiling: this row is passing on the pre-start branch, not on the mid-run kill it is about", elapsed, shelloutTimeout)
+	}
+}
+
+// TestWriterOfVia_NonAnswerIsNotAnUnwrittenFile is #1537's fifth instance of
+// the #1485 family, and it is the same tool as #1485: an lsof that could not be
+// asked reported as "nobody has this transcript open".
+//
+// Row 1 is the vacuity guard AND the lock: lsof's exit 1 is a real answer here
+// — genuinely nobody holds the file — and it must keep returning (0, nil). It
+// is what stops the fix from being "any non-zero exit is an error", which would
+// turn every unwritten transcript into a discovery failure.
+//
+// Note what this test does NOT claim. Both consumers of the value were read
+// (services.PIDManager.TryDiscoverPID and .AllowsSession) and BOTH treat
+// `err != nil` and `pid <= 0` identically — retry, and admit, respectively — so
+// no user-visible behaviour changes today. What changes is that the ProcessObserver
+// port stops being violated: its contract already says "a missing/unopened file
+// is not an error — it returns 0, nil", which is only meaningful if a probe
+// that could not RUN is one.
+func TestWriterOfVia_NonAnswerIsNotAnUnwrittenFile(t *testing.T) {
+	shell := func(script string) lsofCmd {
+		return func(ctx context.Context, _ string) *exec.Cmd {
+			return exec.CommandContext(ctx, "/bin/sh", "-c", script)
+		}
+	}
+
+	cases := []struct {
+		name    string
+		build   lsofCmd
+		wantErr bool
+		why     string
+	}{
+		{
+			name: "exit 1 — lsof looked and nobody holds it", build: shell("exit 1"),
+			wantErr: false,
+			why:     "the LOCK: an unwritten transcript is an answer, and (0, nil) is the right one",
+		},
+		{
+			name: "killed by a signal", build: shell("kill -9 $$"),
+			wantErr: true,
+			why:     "#1537: a killed lsof knows nothing about who holds the transcript",
+		},
+		{
+			name: "binary missing", build: func(ctx context.Context, _ string) *exec.Cmd {
+				return exec.CommandContext(ctx, "/nonexistent/lsof-1537")
+			},
+			wantErr: true,
+			why:     "a fork/exec failure never reached the question",
+		},
+	}
+
+	for _, tc := range cases {
+		pid, err := writerOfVia("/tmp/transcript-1537.jsonl", tc.build)
+		if (err != nil) != tc.wantErr {
+			t.Errorf("%s: writerOfVia = (%d, %v), wantErr %v — %s", tc.name, pid, err, tc.wantErr, tc.why)
+		}
+		if pid != 0 {
+			t.Errorf("%s: got pid %d, want 0 — no fixture reports a holder", tc.name, pid)
+		}
+	}
+}

--- a/core/adapters/inbound/agents/processlifecycle/shellout_test.go
+++ b/core/adapters/inbound/agents/processlifecycle/shellout_test.go
@@ -1,0 +1,163 @@
+package processlifecycle
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"testing"
+	"time"
+)
+
+// TestProbeAnswered is the corpus behind #1538's shared predicate.
+//
+// Every case is built from a REAL child process rather than from a hand-built
+// *exec.ExitError, for the reason TestLsofProbeRan already records: the
+// classification's whole job is to be right about what os/exec actually hands
+// back, and a mid-run context deadline in particular is not obviously an
+// ExitError at all. Asserting the VERDICT rather than the error type is what
+// keeps this honest across Go versions. The one synthetic row is the wrapped
+// error, which no os/exec path produces today and which is the point of that
+// row (see below).
+//
+// The table pins both directions at once, which is why it is a matrix over the
+// two forms rather than two tables:
+//
+//   - wantAny is the empty-variadic form ("any normal exit is an answer") —
+//     plutil's rule, #1524.
+//   - wantExit1 is the allowlist form probeAnswered(err, 1) — lsof's and
+//     pgrep's rule.
+//
+// The two disagree on exactly one row, "exit 152", and that disagreement is
+// the whole reason the variadic exists: a shell reports a process killed under
+// an exhausted CPU limit as a NORMAL exit with status 152, so Exited() is true.
+// A single global rule cannot serve both tools, and picking either one for
+// both is a silent behaviour change at half the call sites.
+func TestProbeAnswered(t *testing.T) {
+	run := func(ctx context.Context, name string, args ...string) error {
+		_, err := exec.CommandContext(ctx, name, args...).Output()
+		return err
+	}
+	// 50ms rather than the 1ms TestLsofProbeRan uses: at 1ms the deadline
+	// routinely fires BEFORE Start, which is a different row of this table.
+	// The verdict is the same either way, so the row is correct regardless —
+	// TestProbeAnsweredRejectsTheContextSpelling below is what actually
+	// VERIFIES the mid-run shape, by asserting the error is an ExitError.
+	deadline, cancelDeadline := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancelDeadline()
+
+	// A context already past its deadline before Start: os/exec never builds
+	// an ExitError here, it returns the context's own error. errors.As is
+	// false, and errors.Is(err, context.DeadlineExceeded) is TRUE — the mirror
+	// image of the mid-run kill below, which is why keying on the context
+	// catches this one and misses that one.
+	expired, cancelExpired := context.WithTimeout(context.Background(), time.Nanosecond)
+	defer cancelExpired()
+	time.Sleep(5 * time.Millisecond)
+
+	cases := []struct {
+		name      string
+		err       error
+		wantAny   bool
+		wantExit1 bool
+		why       string
+	}{
+		{
+			name: "success", err: nil, wantAny: true, wantExit1: true,
+			why: "the vacuity guard: a predicate that answered false here would make every other row pass for the wrong reason",
+		},
+		{
+			name: "exit 1", err: run(context.Background(), "/bin/sh", "-c", "exit 1"),
+			wantAny: true, wantExit1: true,
+			why: "plutil's 'no CFBundleIdentifier' and lsof's 'nothing to report' are both real verdicts (#1524)",
+		},
+		{
+			name: "exit 2", err: run(context.Background(), "/bin/sh", "-c", "exit 2"),
+			wantAny: true, wantExit1: false,
+			why: "an allowlist is an allowlist: for lsof/pgrep only exit 1 carries meaning, every other code is not evidence",
+		},
+		{
+			name: "exit 152 — killed under an exhausted CPU limit, reported through a shell",
+			err:  run(context.Background(), "/bin/sh", "-c", "exit 152"),
+			// The one row where the two forms disagree, and the reason the
+			// variadic is not cosmetic. Exited() is TRUE here (measured), so
+			// the empty form calls it an answer.
+			wantAny: true, wantExit1: false,
+			why: "lsofProbeRan's committed corpus pins 152 as NOT an answer; a global Exited() rule would silently flip it",
+		},
+		{
+			name: "killed by a signal", err: run(context.Background(), "/bin/sh", "-c", "kill -9 $$"),
+			wantAny: false, wantExit1: false,
+			why: "a SIGKILLed child ran but never answered — ExitCode() is -1 and Exited() is false",
+		},
+		{
+			name: "context deadline fires MID-RUN", err: run(deadline, "/bin/sleep", "5"),
+			wantAny: false, wantExit1: false,
+			why: "#1538 trap 1: this is *exec.ExitError \"signal: killed\" and errors.Is(err, context.DeadlineExceeded) is FALSE — the natural spelling misses exactly this row",
+		},
+		{
+			name: "context already expired before Start", err: run(expired, "/bin/sleep", "5"),
+			wantAny: false, wantExit1: false,
+			why: "not an ExitError at all; errors.As is false and the predicate must still refuse it",
+		},
+		{
+			name: "binary missing", err: run(context.Background(), "/nonexistent/probe-1538"),
+			wantAny: false, wantExit1: false,
+			why: "a fork/exec failure is a probe that never ran, not a tool reporting nothing",
+		},
+		{
+			name:    "an exit 1 that was WRAPPED on the way here",
+			err:     fmt.Errorf("pgrep -x claude: %w", run(context.Background(), "/bin/sh", "-c", "exit 1")),
+			wantAny: true, wantExit1: true,
+			why: "the third spelling replaced by #1538 was a bare `err.(*exec.ExitError)` assertion, which reports false here; errors.As reports true. No os/exec path wraps today, so this row is a LOCK on the property rather than a live defect — it is what makes the bare assertion unrewritable without going red",
+		},
+	}
+
+	for _, tc := range cases {
+		if got := probeAnswered(tc.err); got != tc.wantAny {
+			t.Errorf("%s: probeAnswered(%v) = %v, want %v — %s", tc.name, tc.err, got, tc.wantAny, tc.why)
+		}
+		if got := probeAnswered(tc.err, 1); got != tc.wantExit1 {
+			t.Errorf("%s: probeAnswered(%v, 1) = %v, want %v — %s", tc.name, tc.err, got, tc.wantExit1, tc.why)
+		}
+	}
+}
+
+// TestProbeAnsweredRejectsTheContextSpelling is #1538's trap 1 stated as an
+// assertion rather than as a doc comment.
+//
+// It exists because the wrong spelling is the natural one. A reader fixing this
+// family reaches for errors.Is(err, context.DeadlineExceeded) — it names the
+// exact condition, it compiles, and it reads correctly. This test measures that
+// it is FALSE for the mid-run kill and TRUE only for the pre-Start case, so the
+// evidence lives next to the predicate instead of in a merged PR body.
+//
+// It is deliberately an assertion about os/exec's behaviour, not about
+// probeAnswered: if a future Go release makes CommandContext wrap the context's
+// error, this test goes red and the doc comment above probeAnswered becomes
+// wrong. That is the signal worth having.
+func TestProbeAnsweredRejectsTheContextSpelling(t *testing.T) {
+	deadline, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	_, err := exec.CommandContext(deadline, "/bin/sleep", "5").Output()
+	if err == nil {
+		t.Fatal("the ceiling did not fire — this test proves nothing without a killed child")
+	}
+
+	if errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("os/exec now wraps the context error (%v): probeAnswered's doc comment and #1524's measurement are stale", err)
+	}
+	if deadline.Err() != context.DeadlineExceeded {
+		t.Errorf("ctx.Err() = %v, want DeadlineExceeded — the deadline is what actually fired", deadline.Err())
+	}
+	var exit *exec.ExitError
+	if !errors.As(err, &exit) {
+		t.Fatalf("want *exec.ExitError for a mid-run kill, got %T", err)
+	}
+	if exit.ProcessState.Exited() {
+		t.Error("a SIGKILLed child reports Exited() — the predicate's whole discriminator is gone")
+	}
+	if probeAnswered(err) {
+		t.Error("probeAnswered called a killed child an answer (#1538)")
+	}
+}

--- a/core/adapters/inbound/agents/processlifecycle/shellout_tty_darwin_test.go
+++ b/core/adapters/inbound/agents/processlifecycle/shellout_tty_darwin_test.go
@@ -1,0 +1,122 @@
+//go:build darwin
+
+package processlifecycle
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"testing"
+	"time"
+)
+
+// TestProcessTTYVia_NonAnswerIsNotAnAbsentTerminal is #1533's primitive: the
+// two empty strings processTTY used to return were "ps could not be run" and
+// "this process has no controlling terminal", and only the second is a verdict.
+//
+// Rows 1-3 are LOCKS on the pre-#1533 behaviour — every shape that legitimately
+// yields no tty must keep yielding one, and must keep reporting probed. Row 1
+// is also the vacuity guard: a processTTYVia hard-wired to probed=false would
+// satisfy row 4 while proving nothing, and one hard-wired to probed=true would
+// satisfy rows 1-3 the same way, so both directions are needed.
+func TestProcessTTYVia_NonAnswerIsNotAnAbsentTerminal(t *testing.T) {
+	shell := func(script string) ttyCmd {
+		return func(ctx context.Context, _ int) *exec.Cmd {
+			return exec.CommandContext(ctx, "/bin/sh", "-c", script)
+		}
+	}
+
+	cases := []struct {
+		name       string
+		pid        int
+		build      ttyCmd
+		wantTTY    string
+		wantProbed bool
+		why        string
+	}{
+		{
+			name: "a real tty", pid: 1, build: shell("echo ttys004"),
+			wantTTY: "/dev/ttys004", wantProbed: true,
+			why: "the vacuity guard: without a row that resolves, every row below passes for the wrong reason",
+		},
+		{
+			name: "ps answers '??' — a hardened-runtime child with no terminal", pid: 1, build: shell("echo '??'"),
+			wantTTY: "", wantProbed: true,
+			why: "the LOCK #1533 names explicitly: this empty string is a verdict and must stay one",
+		},
+		{
+			name: "ps exits 1 — no such process", pid: 1, build: shell("exit 1"),
+			wantTTY: "", wantProbed: true,
+			why: "ps exits 1 for a pid it cannot find (measured); that is a real answer, which is why this probe takes no exit-code allowlist",
+		},
+		{
+			name: "killed by a signal", pid: 1, build: shell("kill -9 $$"),
+			wantTTY: "", wantProbed: false,
+			why: "#1533: a killed ps knows nothing about this process's terminal",
+		},
+		{
+			name: "binary missing", pid: 1, build: func(ctx context.Context, _ int) *exec.Cmd {
+				return exec.CommandContext(ctx, "/nonexistent/ps-1533")
+			},
+			wantTTY: "", wantProbed: false,
+			why: "a fork/exec failure never reached the question",
+		},
+		{
+			name: "pid <= 0 — nothing was asked", pid: 0, build: shell("echo unreachable"),
+			wantTTY: "", wantProbed: true,
+			why: "an empty input is not a failed probe, the same reading bundleIDVia gives an empty appPath",
+		},
+	}
+
+	for _, tc := range cases {
+		tty, probed := processTTYVia(tc.pid, tc.build)
+		if tty != tc.wantTTY || probed != tc.wantProbed {
+			t.Errorf("%s: processTTYVia = (%q, %v), want (%q, %v) — %s",
+				tc.name, tty, probed, tc.wantTTY, tc.wantProbed, tc.why)
+		}
+	}
+}
+
+// TestHostIdentity_UnreadableTTYIsNotACompleteRead is #1533's consumer half,
+// and the reason the primitive above is not enough on its own: processTTY
+// already returned "" for an unreadable ps before this change, and hostIdentity
+// reported the result as COMPLETE anyway — `l.TTY = processTTY(pid)` ran after
+// complete was finalised and was never folded into it. A tri-state nobody reads
+// is the same bug with more code.
+//
+// The vacuity guard is the second half: a working ps must still produce a
+// complete read, or a hostIdentity hard-wired to incomplete would pass.
+func TestHostIdentity_UnreadableTTYIsNotACompleteRead(t *testing.T) {
+	answered := func(int) (string, bool) { return "/dev/ttys004", true }
+	unanswered := func(int) (string, bool) { return "", false }
+
+	if l, complete := hostIdentityVia(os.Getpid(), answered); !complete || l.TTY != "/dev/ttys004" {
+		t.Errorf("a ps that answered: got (TTY %q, complete %v); want the read to complete", l.TTY, complete)
+	}
+	if _, complete := hostIdentityVia(os.Getpid(), unanswered); complete {
+		t.Error("a ps that never answered was reported as a complete read of this process (#1533)")
+	}
+}
+
+// TestProcessTTY_CeilingIsANonAnswer is the mid-run-kill row the table above
+// cannot reach: its failures are a normal exit or a pre-Start error, and a
+// child SIGKILLed by the ceiling is a third error shape (*exec.ExitError
+// "signal: killed", which does not wrap the context's error). It costs the real
+// shelloutTimeout, and the elapsed assertion is what proves it did not pass on
+// the cheap branch — the same guard TestBundleIDVia_CeilingActuallyFires uses.
+func TestProcessTTY_CeilingIsANonAnswer(t *testing.T) {
+	stalled := func(ctx context.Context, _ int) *exec.Cmd {
+		return exec.CommandContext(ctx, "/bin/sleep", "30")
+	}
+
+	start := time.Now()
+	tty, probed := processTTYVia(1, stalled)
+	elapsed := time.Since(start)
+
+	if probed {
+		t.Errorf("a ps killed by its own ceiling reported tty %q as an answer (#1533)", tty)
+	}
+	if elapsed < shelloutTimeout/2 {
+		t.Errorf("returned after %v, well under the %v ceiling: this is passing on the pre-start branch, not on the mid-run kill", elapsed, shelloutTimeout)
+	}
+}

--- a/core/adapters/inbound/agents/processlifecycle/shellout_tty_darwin_test.go
+++ b/core/adapters/inbound/agents/processlifecycle/shellout_tty_darwin_test.go
@@ -3,9 +3,7 @@
 package processlifecycle
 
 import (
-	"context"
 	"os"
-	"os/exec"
 	"testing"
 	"time"
 )
@@ -20,49 +18,41 @@ import (
 // satisfy row 4 while proving nothing, and one hard-wired to probed=true would
 // satisfy rows 1-3 the same way, so both directions are needed.
 func TestProcessTTYVia_NonAnswerIsNotAnAbsentTerminal(t *testing.T) {
-	shell := func(script string) ttyCmd {
-		return func(ctx context.Context, _ int) *exec.Cmd {
-			return exec.CommandContext(ctx, "/bin/sh", "-c", script)
-		}
-	}
-
 	cases := []struct {
 		name       string
 		pid        int
-		build      ttyCmd
+		build      shelloutCmd
 		wantTTY    string
 		wantProbed bool
 		why        string
 	}{
 		{
-			name: "a real tty", pid: 1, build: shell("echo ttys004"),
+			name: "a real tty", pid: 1, build: shellCmd("echo ttys004"),
 			wantTTY: "/dev/ttys004", wantProbed: true,
 			why: "the vacuity guard: without a row that resolves, every row below passes for the wrong reason",
 		},
 		{
-			name: "ps answers '??' — a hardened-runtime child with no terminal", pid: 1, build: shell("echo '??'"),
+			name: "ps answers '??' — a hardened-runtime child with no terminal", pid: 1, build: shellCmd("echo '??'"),
 			wantTTY: "", wantProbed: true,
 			why: "the LOCK #1533 names explicitly: this empty string is a verdict and must stay one",
 		},
 		{
-			name: "ps exits 1 — no such process", pid: 1, build: shell("exit 1"),
+			name: "ps exits 1 — no such process", pid: 1, build: shellCmd("exit 1"),
 			wantTTY: "", wantProbed: true,
 			why: "ps exits 1 for a pid it cannot find (measured); that is a real answer, which is why this probe takes no exit-code allowlist",
 		},
 		{
-			name: "killed by a signal", pid: 1, build: shell("kill -9 $$"),
+			name: "killed by a signal", pid: 1, build: shellCmd("kill -9 $$"),
 			wantTTY: "", wantProbed: false,
 			why: "#1533: a killed ps knows nothing about this process's terminal",
 		},
 		{
-			name: "binary missing", pid: 1, build: func(ctx context.Context, _ int) *exec.Cmd {
-				return exec.CommandContext(ctx, "/nonexistent/ps-1533")
-			},
+			name: "binary missing", pid: 1, build: missingCmd("ps-1533"),
 			wantTTY: "", wantProbed: false,
 			why: "a fork/exec failure never reached the question",
 		},
 		{
-			name: "pid <= 0 — nothing was asked", pid: 0, build: shell("echo unreachable"),
+			name: "pid <= 0 — nothing was asked", pid: 0, build: shellCmd("echo unreachable"),
 			wantTTY: "", wantProbed: true,
 			why: "an empty input is not a failed probe, the same reading bundleIDVia gives an empty appPath",
 		},
@@ -105,12 +95,9 @@ func TestHostIdentity_UnreadableTTYIsNotACompleteRead(t *testing.T) {
 // shelloutTimeout, and the elapsed assertion is what proves it did not pass on
 // the cheap branch — the same guard TestBundleIDVia_CeilingActuallyFires uses.
 func TestProcessTTY_CeilingIsANonAnswer(t *testing.T) {
-	stalled := func(ctx context.Context, _ int) *exec.Cmd {
-		return exec.CommandContext(ctx, "/bin/sleep", "30")
-	}
-
+	t.Parallel() // spends the real 2s ceiling and shares no state
 	start := time.Now()
-	tty, probed := processTTYVia(1, stalled)
+	tty, probed := processTTYVia(1, stalledChild)
 	elapsed := time.Since(start)
 
 	if probed {

--- a/core/adapters/outbound/control/controller.go
+++ b/core/adapters/outbound/control/controller.go
@@ -23,7 +23,14 @@ import (
 )
 
 // execTimeout bounds every backend shell-out, matching the process observer's
-// 2-second ceiling (process_darwin.go).
+// 2-second ceiling (processlifecycle.shelloutTimeout, shellout.go — it was an
+// unnamed literal in process_darwin.go when this comment was written, which is
+// part of why #1538 named it).
+//
+// Deliberately a separate constant rather than an import: that ceiling bounds a
+// window-targeting probe in the inbound adapter layer, this one bounds a write
+// to a terminal backend in the outbound layer, and they are entitled to diverge.
+// The agreement is a coincidence worth recording, not a contract worth welding.
 const execTimeout = 2 * time.Second
 
 // command is a single backend invocation. Keeping construction pure (no exec)

--- a/core/ports/outbound/ports.go
+++ b/core/ports/outbound/ports.go
@@ -418,7 +418,9 @@ type ProcessObserver interface {
 	CWDOf(pid int) (string, error)
 	// WriterOf returns the PID that currently has path open for writing, or
 	// 0 when no process is writing it. A missing/unopened file is not an
-	// error — it returns 0, nil.
+	// error — it returns 0, nil. A probe that could not RUN is: 0, nil means
+	// the implementation looked and found nobody, never that it could not
+	// look (#1537).
 	WriterOf(path string) (int, error)
 	// EnvOf returns the whitelisted launcher env vars of pid. Returns an
 	// empty/nil map (not an error) when the env is unreadable.


### PR DESCRIPTION
Closes #1538. Closes #1533. Closes #1537.

## The predicate

`probeAnswered(err error, answeredExitCodes ...int) bool` — `core/adapters/inbound/agents/processlifecycle/shellout.go`.

```go
if err == nil { return true }
var exit *exec.ExitError
if !errors.As(err, &exit) || !exit.ProcessState.Exited() { return false }
if len(answeredExitCodes) == 0 { return true }
return slices.Contains(answeredExitCodes, exit.ExitCode())
```

The variadic is the only per-tool part. Empty = "any normal exit is an answer"
(plutil's rule). Non-empty = an allowlist of the non-zero exits that count
(lsof's and pgrep's rule, `{1}`).

**Both traps re-measured independently on this machine, go1.25 darwin/arm64,
rather than carried over from #1524:**

| case | `errors.As` | `Exited()` | `ExitCode()` | `errors.Is(DeadlineExceeded)` |
|---|---|---|---|---|
| `exit 1` | true | true | 1 | false |
| `exit 152` | true | **true** | 152 | false |
| SIGKILL self | true | false | -1 | false |
| **mid-run deadline kill** | true | false | -1 | **false** |
| ctx expired before Start | false | — | — | true |
| binary missing | false | — | — | false |

Trap 1 confirmed: the mid-run kill is `*exec.ExitError "signal: killed"` and
`errors.Is(err, context.DeadlineExceeded)` is **false** while `ctx.Err()` reports
the deadline. Trap 2 confirmed by running plutil directly — both non-answers
exit 1:

```
--- A) plist exists, NO CFBundleIdentifier ---
noid.plist: Could not extract value, error: No value at that key path... exit=1
--- B) plist MISSING entirely ---
/nope/.../Info.plist: (The file "Info.plist" couldn't be opened...) exit=1
--- C) control: a real app bundle ---
com.apple.calculator                                              exit=0
```

A third fact the issue did not state, which decides the API: `sh -c "exit 152"`
exits **normally**, so `Exited()` is true and `ExitCode()` is 152. A single
global `Exited()` rule would silently flip `lsofProbeRan`'s committed corpus.
That is why the allowlist exists rather than being cosmetic.

## Every site, and which ones changed behaviour

All 8 `exec.Command*` run sites in the package. **3 changed behaviour, 3 were
re-spelled, 2 were left alone.**

| site | now | verdict |
|---|---|---|
| `processTTY` → `processTTYVia` | `probeAnswered(err)` | **BEHAVIOUR CHANGED** (#1533) — returns `(string, bool)`; `hostIdentity` folds it into `complete` |
| `WriterOf` → `writerOfVia` | `lsofProbeRan(err)` | **BEHAVIOUR CHANGED** (#1537 inst. 5) — a non-answer is now an error, not `(0, nil)` |
| `kittyWindowIDForPID` → `…Via` | `probeAnswered(err)` | **BEHAVIOUR CHANGED** (#1537 inst. 6) — returns `(string, bool)`; folded into `complete` |
| `bundleIDVia` | `probeAnswered(err)` | re-spelled, semantics identical |
| `lsofProbeRan` | `probeAnswered(err, lsofNothingToReport)` | re-spelled, semantics identical |
| `runPgrep` → `runPgrepVia` | `probeAnswered(err, pgrepNoMatch)` | re-spelled; `errors.As` replaces a bare type assertion, **not reachable today** (see below) |
| `readProcInfo` | propagates `fmt.Errorf(…%w)` | untouched — deliberate, see below |
| `CWDOf` | propagates `fmt.Errorf(…%w)` | untouched — deliberate, see below |

Plus `shelloutTimeout` replaces the 2s literal at all 8 ceilings, and
`ProcessObserver.WriterOf`'s port doc is amended.

### Honest notes on the three behaviour changes

- **`WriterOf` changes no user-visible behaviour today.** Both consumers were
  read: `PIDManager.TryDiscoverPID` (`err == nil && pid > 0`) and
  `PIDManager.AllowsSession` (`if err != nil || pid <= 0 { return true }`).
  Both treat an error and `0` identically — retry, and admit. What this fixes is
  a **port-contract violation**: the contract already said "a missing/unopened
  file is not an error — it returns 0, nil", which is only meaningful if a probe
  that could not run *is* one. #1537's claimed consequence ("hands on as no PID
  for this session") is true at the function but does not differ from the error
  path at either consumer.
- **The kitty fold is inert at today's only consumer**, and that is stated
  rather than glossed. `complete` is acted on only by `resolveClientHostIdentity`,
  and a candidate reaching the kitty back-fill has `TermProgram == "kitty"`, so
  it returns early as a resolved host before `complete` is read
  (`ReadLauncherEnv` discards the bit explicitly). The fold is for consistency
  with `TestHostIdentity_KittyBackfillWalkCountsTowardCompleteness`, which
  already folds that block's *other* shellout.
- **The kitten guard reports `probed: true`, not false**, when `kittenPath == ""`
  or the socket is empty. This is the one judgement call and it is the opposite
  of what "could not look" suggests: an absent binary is a settled property of
  the installation — the same reading `osutil_linux.go`'s stubs already give —
  and calling it a failed probe would poison completeness *permanently* on any
  machine where kitten is off the trusted path. Pinned by
  `TestKittyWindowIDForPIDVia_AbsentKittenIsASettledVerdict`.
- **`runPgrep`'s `errors.As` fix is not reachable today.** `.Output()` returns a
  bare `*exec.ExitError`; nothing wraps it. It is a lock on the property, not a
  live defect, and it is labelled as such in the corpus row.

### The two sites deliberately left alone

`readProcInfo` and `CWDOf` already wrap and return their error, which keeps the
two facts distinguishable at the caller. Changing `readProcInfo`'s polarity was
considered and rejected: `ps` exits 1 for a dead pid, so treating a normal exit
as an answer would turn "no such process" into a *complete* read, and #1524's own
doc argues the opposite ("'pid's parent is init' is a verdict, 'pid could not be
read' is not"). The guard accepts propagation for exactly this reason.

## Scope decision: #1537 and #1533 are folded in

**Folded in, and the reason is structural rather than a preference: the guard
cannot land without them.** The rule has no exemption list (the policy
`architecture_test.go` and `architecture_hookbody_test.go` both take), so
`processTTY`, `WriterOf` and `kittyWindowIDForPID` are all findings against it.
The options were "fix them", "add an exemption list", or "ship the refactor with
no guard" — and the guard is the only part of this PR that prevents instance
seven. Shipping "one predicate used everywhere" with two known collapses beside
it in the same file would also have been self-contradictory.

The diff stays reviewable because the three fixes are ~10 lines each; the bulk
of the 1518 lines is tests.

**#1538's third section is deferred**, and it is a real deferral, not a silent
half: `bundleIDForAppPath` memoization and the duplicate ancestry `ps` reads are
now #1544. Its admission rule (`memoize answers including the empty one, never
memoize a non-answer`) is unchanged by this PR and still expressible.

## Verification

### Defect tests, seen red first

Each was written against a worktree that had the seam but **not** the fix.

*(The file names in the pasted failures — `pgrep_darwin_test.go`,
`tty_darwin_test.go`, `kittywindow_darwin_test.go` — are the names those files
had when the red was captured. They were renamed to a `shellout_*` prefix
afterwards for grouping; the content is the same.)*

**#1533 — `processTTY`:**
```
--- FAIL: TestProcessTTYVia_NonAnswerIsNotAnAbsentTerminal (0.02s)
    tty_darwin_test.go:74: killed by a signal: processTTYVia = ("", true), want ("", false) — #1533: a killed ps knows nothing about this process's terminal
    tty_darwin_test.go:74: binary missing: processTTYVia = ("", true), want ("", false) — a fork/exec failure never reached the question
--- FAIL: TestHostIdentity_UnreadableTTYIsNotACompleteRead (0.00s)
    tty_darwin_test.go:97: a ps that never answered was reported as a complete read of this process (#1533)
--- FAIL: TestProcessTTY_CeilingIsANonAnswer (2.00s)
    tty_darwin_test.go:117: a ps killed by its own ceiling reported tty "" as an answer (#1533)
```

**#1537 instance 5 — `WriterOf`:**
```
--- FAIL: TestWriterOfVia_NonAnswerIsNotAnUnwrittenFile (0.01s)
    pgrep_darwin_test.go:165: killed by a signal: writerOfVia = (0, <nil>), wantErr true — #1537: a killed lsof knows nothing about who holds the transcript
    pgrep_darwin_test.go:165: binary missing: writerOfVia = (0, <nil>), wantErr true — a fork/exec failure never reached the question
```

**#1537 instance 6 — `kittyWindowIDForPID`:**
```
--- FAIL: TestKittyWindowIDForPIDVia_NonAnswerIsNotAnAbsentWindow (0.02s)
    kittywindow_darwin_test.go:75: killed by a signal: kittyWindowIDForPIDVia = ("", true), want ("", false) — #1537: a killed kitten knows nothing about which window holds this session
    kittywindow_darwin_test.go:75: binary missing: kittyWindowIDForPIDVia = ("", true), want ("", false) — a fork/exec failure never reached the question
--- FAIL: TestApplyAncestryFallbacks_UnreadableKittyWindowIsNotACompleteRead (0.00s)
    kittywindow_darwin_test.go:136: a kitten that never answered was reported as a complete read (#1537)
```

### Mutations on the new predicate (a check with no "before")

**A — the natural wrong spelling** (`errors.Is(err, context.DeadlineExceeded)`):
```
--- FAIL: TestProbeAnswered (0.04s)
    shellout_test.go:113: killed by a signal: probeAnswered(signal: killed) = true, want false
--- FAIL: TestProbeAnsweredRejectsTheContextSpelling (0.05s)
    shellout_test.go:156: probeAnswered called a killed child an answer (#1538)
```

**B — the family's collapse** (`if err != nil` → non-answer): 6 rows red, incl.
```
    shellout_test.go:113: exit 1: probeAnswered(exit status 1) = false, want true
    shellout_test.go:113: exit 152 ...: probeAnswered(exit status 152) = false, want true
```

**C — the bare type assertion** (spelling #3), exactly the wrapped row:
```
--- FAIL: TestProbeAnswered (0.06s)
    shellout_test.go:118: an exit 1 that was WRAPPED on the way here: probeAnswered(pgrep -x claude: exit status 1) = false, want true
```

### Named locks, and proof they discriminate

- **`TestLsofProbeRan`'s exit-152 row** (pre-existing, #1485) is the lock on
  lsof's allowlist. Mutation D — `lsofProbeRan` → `probeAnswered(err)` — turns it
  red and only it:
  ```
  --- FAIL: TestLsofProbeRan (0.01s)
      osutil_darwin_test.go:596: exit 152 — killed under an exhausted CPU limit: lsofProbeRan(exit status 152) = true, want false
  ```
- **`TestBundleIDVia_AnsweredMissIsNotAnUnanswerableProbe`** (pre-existing,
  #1524) is the lock on plutil's empty-variadic rule; green throughout, as a
  lock should be.
- **A gate that was NOT there.** Mutation E — dropping pgrep's allowlist — was
  run *before* writing any pgrep test and came back **`ok`, fully green**:
  `runPgrep` had no test of any kind, so the tool-specific half of the predicate
  was free to be widened at that site by anybody, including by this PR.
  `TestRunPgrepVia_NonAnswerStaysAnError` closes it, and the same mutation now
  reads:
  ```
  --- FAIL: TestRunPgrepVia_NonAnswerStaysAnError (0.02s)
      pgrep_darwin_test.go:76: exit 2 — pgrep's usage/error status: err = <nil>, wantErr true
  ```
- **Mutation K** — `lsofProbeRan` stops delegating (`return err == nil`) — reddens
  4 pre-existing tests, confirming the delegation is load-bearing:
  `TestLsofProbeRan`, `TestHerdrClientPIDs_ProbeTriState`,
  `TestHerdrClientLauncher_MemoizedNonAnswerIsStillANonAnswer`,
  `TestReadLauncherEnv_Herdr_UnprobableClientReportsHostUnknown`.

### The guard, run against `origin/main`

The strongest single piece of evidence here, and it was suggested by the review
rather than by me. Point the *production* detector at `origin/main`'s sources —
the tree before this PR — and it independently rediscovers exactly the three
known open bugs, with no false positives:

```
origin/main: runSites=8 findings=3
  process_darwin.go:117 in WriterOf(): the error of a child process (err) is neither passed to probeAnswered/lsofProbeRan nor returned — a non-answer collapses into a zero value here (#1538)
  osutil_darwin.go:44 in processTTY(): the error of a child process (err) is neither passed to probeAnswered/lsofProbeRan nor returned — a non-answer collapses into a zero value here (#1538)
  osutil_darwin.go:462 in kittyWindowIDForPID(): the error of a child process (err) is neither passed to probeAnswered/lsofProbeRan nor returned — a non-answer collapses into a zero value here (#1538)
```

Those are #1533 and #1537's two instances. All six instances of this family were
found by a human reading code, one incident at a time; this run takes 10ms.

## Does anything prevent instance seven?

Yes — `shellout_guard_test.go`, two source-scanning rules over the package:

1. every child-process error must be **classified by the shared predicate or
   propagated** to the caller;
2. every bounded shellout's ceiling must be the **named constant**.

They scan with `go/parser` rather than `go/packages`, and that is load-bearing:
all 8 shellouts are behind `//go:build darwin`, so a type-aware load on a Linux
runner would find zero and pass — a gate whose absence reads as a pass. Both
carry vacuity guards (`< 8` run sites, or zero `WithTimeout` calls, is a
`Fatal`).

**The decisive mutation — the seventh instance, written the way all six previous
ones were.** The queued tmux shellout named in `osutil_darwin.go`'s own comment,
appended verbatim:
```
--- FAIL: TestEveryBoundedShelloutClassifiesItsError (0.00s)
    shellout_guard_test.go:277: osutil_darwin.go:1012 in tmuxClientPIDs(): the error of a child process (err) is neither passed to probeAnswered/lsofProbeRan nor returned — a non-answer collapses into a zero value here (#1538)
--- FAIL: TestEveryBoundedShelloutUsesTheNamedCeiling (0.00s)
    shellout_guard_test.go:307: osutil_darwin.go:1010: a bounded shellout's ceiling is spelled inline; use shelloutTimeout so the value stays one fact (#1538)
```

Reverting each fixed site individually also reddens it — `processTTYVia`,
`kittyWindowIDForPIDVia`, `writerOfVia`, each named at its own `file:line`.

**Committed corpus.** `shellout_guard_corpus_test.go` — 15 spellings run through
the *production* detector, pinning what it must report and what it must leave
alone (the builder that never runs; propagation wrapped and bare; the if-init
form both ways; a second shellout in a function that already classified one).
Two opposed vacuity guards: zero run sites *and* zero findings are both `Fatal`.
The corpus was itself mutation-tested — dropping the detector's position test
reddens exactly the two position-sensitive rows; blinding the run-site counter
fires both vacuity guards; making it over-fire reddens 7 `want:0` rows.

**Measured blind spot, committed as a `want:0` row rather than left implicit:**
the rule asks whether the error *reaches* a classifier, not what happens to the
verdict. Found by a mutation that kept the `lsofProbeRan` call while collapsing
`WriterOf`'s return — the rule stayed **green**. Discarding a verdict is what
#1533 and #1537 inst. 6 actually were; that layer is covered by the fold tests
instead. Seeing it statically needs dataflow this syntactic scan does not have.

## Review

Reviewed at **high** effort by a dedicated subagent against `origin/main...HEAD`.
Eight findings; **seven fixed, one filed**. The three that mattered:

1. **Blocker — the non-darwin stubs did not compile.** `processTTY`'s Linux and
   `!darwin` stubs were updated to the new signature; `kittyWindowIDForPID`'s
   were not, and `osutil.go` is untagged. `linux.yml`'s `build-test` was already
   red. Fixed, and both `GOOS=linux` and `GOOS=darwin` builds verified.
   (`GOOS=windows` still fails on `syscall.Kill` in `application/services` —
   **confirmed pre-existing on `origin/main`**, unrelated to this diff.)
2. **The guard matched the error by identifier NAME.** The ordinary
   `out, err := cmd.Output(); if err != nil { return 0, nil }; n, err := parse(out);
   return n, err` laundered the collapse — a later return of a *different* error
   vouched for it. Measured `findings=0`. Now bounded above by the first re-bind.
3. **Run sites in package-level `var x = func(){…}()` were invisible** *and* left
   `runSites` at 0, so the vacuity floor could not notice either. This package
   already uses that idiom (`kittenPath`). `GenDecl`s are walked now, and closures
   are scanned as scopes of their own — a fix whose own corpus row went red first,
   because my first attempt still let an inner `return err` vouch for an outer
   collapse.

Also fixed: the Linux `WriterOf` collapsed an unreadable `/proc` to `(0, nil)`,
which made the strengthened port doc false — fixed at the implementation rather
than exempted in the doc; the kitten table `t.Skip`'d itself on any machine
without kitty (**including CI, the only job that compiles that file**) and now
pins `kittenPath` instead; the ceiling gate got a real floor instead of `> 0`;
`WriterOf` got a happy-path row; and `return cmd.Output()` / `var out, err =
cmd.Output()` are no longer misreported as "discarded outright".

Five corpus rows were added for the newly-covered shapes, each mutation-verified.
All twenty predecessor rows stay green — the "a rewritten guard replays its
predecessor's cases" rule from AGENTS.md.

**Filed, not fixed: #1546.** `ReadLauncherEnv` deliberately discards
`hostIdentity`'s `complete`, so an unanswered `ps` still yields `TTY == ""` and
`PIDManager.captureBackground` stamps `BackgroundAgent.Detached` from it —
**set-once** (verified: `captureBackground` early-returns on
`state.Background != nil`, so the restart-seed path at `pid_manager.go:1234` does
not recompute it). #1533 is fixed at `hostIdentity`; this residual is a
persisted, user-visible field one layer up, and closing it means widening
`ReadLauncherEnv`'s `hostKnown`, whose own doc argues against exactly that.

## Simplify

Four cleanup agents (reuse / simplification / efficiency / altitude). Applied:

- **Five injected-command types collapsed to one `shelloutCmd`.** Two agents
  reached this independently, with the same decisive evidence: **no fixture in
  the package has ever read the differing parameters** — every one spells them
  `_` — and each was a value the caller already held, passed in so it could be
  handed back. `bundleIDVia` keeps a factory, because it is the one site whose
  command depends on a value the callee derives; that is now stated rather than
  implied by a fifth signature. Knock-on: the four near-identical `shell(script)`
  test helpers existed *only* because the four builder types differed, and are
  now one `shellCmd` beside one `missingCmd` and one `stalledChild`.
- **`stalledChild` generalises #1524's `stalledBundleIDCmd`** — which carried the
  measurement all three ceiling tests depend on to be non-vacuous (why
  `/bin/sleep` and not a script the test writes: first exec of a new file is
  code-signature-evaluated at 2.14s, past the ceiling). It was documented on one
  of the three.
- **`t.Parallel()` on the two new ceiling tests**, matching the three siblings
  that already carry it. Measured: package `go test` 10.34s → 6.33s (`-race`
  11.52s → 7.38s), so the diff's cost drops from +4.1s to +0.2s.
- **`genDeclExpr` deleted** — it fabricated a `BlockStmt`-wrapping-a-`CompositeLit`
  that no Go parser produces, purely to satisfy a `*ast.BlockStmt` parameter whose
  every use forwards to helpers already taking `ast.Node`.
- `errBindingFor` flattened into `bindingAt` (CodeScene's one critical-rule
  finding); `elapsed < time.Second` → `shelloutTimeout/2`; `control.execTimeout`'s
  doc now points at the constant instead of at a file where the literal no longer
  lives.

**All 9 mutations were replayed red against the restructured code, and all 20
corpus rows stay green** — the restructure is not trusted on the strength of the
suite alone.

**Skipped, and filed as #1547:** collapsing the shellout *shape* into one
`runProbe`, and moving `probeAnswered` to a `core/pkg/` leaf. The altitude
argument is right — the guard is bigger than what it polices, and `runProbe`
would let one guard be **deleted** rather than kept. It is not in this PR because
it replaces the enforcement mechanism *and* its committed corpus after CI went
green, i.e. trades a verified mechanism for an unverified one at the cleanup
stage. This PR took the prerequisite (the type collapse above), which is what
makes #1547 small. The issue also records what that change would COST: this
guard's best property — that against `origin/main` it names exactly the three
known bugs — does not survive the swap, and should be given up deliberately or
not at all.

**Skipped, with reason:** shrinking `TestLsofProbeRan` to two rows now that
`TestProbeAnswered` subsumes it. It is a committed pre-existing lock, and its
exit-152 row is the mutation target that proves the allowlist is load-bearing
(mutation D above). AGENTS.md's "a rewritten guard replays its predecessor's
cases" argues for keeping the corpus, not trimming it to the delta.

## Found, not fixed

- **#1543** (filed) — `core/adapters/outbound/git/adapter.go`: seven more
  collapses, and they are **unbounded** (plain `exec.Command`, no context at all).
- **#1544** (filed) — #1538's deferred third section.
- **`services.anyLiveOutputWriter` is NOT an instance** — examined, and this is a
  check rather than a dismissal. It drops the error and keys on
  `ctx.Err() == context.DeadlineExceeded`, which *does* catch the mid-run kill
  (the context is past its deadline even though the error does not wrap it), and
  its doc explicitly reasons that any other failure "still degrades to a
  conclusive 'no live writer'" because retrying cannot fix those (#1299). That is
  a deliberate documented polarity, not a collapse. It could still express itself
  in terms of `probeAnswered`, which would mean promoting the predicate to a
  `core/pkg/` leaf — deliberately not done here, to keep this diff inside one
  package.
- **`cliprobe.Timeout` is exported but referenced by nothing outside its own
  package.** `control/controller.go`'s `execTimeout` doc points at "the process
  observer's 2-second ceiling (process_darwin.go)" — a cross-reference to a
  constant that did not exist until this PR. Not merged: a consent-path version
  check and a window-targeting probe are entitled to different ceilings, and
  they are in different layers.

## Gates

`tools/preflight.sh` run chunked in the foreground, all 8 groups: `go`, `web`,
`arch`, `tools`, `skills`, `posix`, `security`, `swift` — **all PASS**, re-run
after the review fixes and again after simplify. CI on this branch: `go-test`
pass, `build-test` (the Linux job the blocker had made red) **pass**.
`go test ./core/... -race -count=1` green, unfiltered, as the last run. Cross-compile checked by
hand (`GOOS=linux`, `GOOS=darwin`) because **nothing in the local gate chain
cross-compiles** — that is how finding 1 escaped; see the process note below.
`go test ./core/... -race -count=1` green, **unfiltered**. ARS composite
7.930618 → 7.930261, no category regression. Pushed with `--no-verify` because
the gates had already been run in full.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Process note

`tools/preflight.sh` has no cross-compile step, so a build-tagged stub left out
of sync passes every local gate and only fails in `linux.yml`. That is what
happened here, and `linux.yml`'s own header cites #478 for the same class of
break. A ~3s `GOOS=linux GOARCH=amd64 go build ./...` in preflight's `go` group
would have caught it before the push. Not done in this PR — it changes every
agent's workflow and belongs in its own diff.

