### PR TITLE
fix(daemon): re-derive BackgroundAgent.Detached when the launcher TTY is repaired

### DIFF
--- a/core/application/services/pid_manager.go
+++ b/core/application/services/pid_manager.go
@@ -341,9 +341,12 @@ func detachedFromLauncher(l *session.Launcher) bool {
 // process genuinely has no controlling terminal, or the `ps` behind
 // processTTY was killed by its 2s ceiling and never answered. Nothing that
 // reaches this layer distinguishes them — ReadLauncherEnv discards
-// hostIdentity's completeness verdict for the agent's own read, deliberately
-// and for reasons that have nothing to do with the tty (see its doc comment)
-// — so captureBackground's first stamp can be a claim made on no evidence.
+// hostIdentity's completeness verdict for the agent's own read — so
+// captureBackground's first stamp can be a claim made on no evidence. Read
+// that discard carefully before building on it: its stated reasons (see
+// ReadLauncherEnv's doc comment) are about the ANCESTRY walk and predate
+// #1533 folding the tty probe into the same bit, so the verdict being dropped
+// now carries tty information its rationale does not cover.
 //
 // The rest of the codebase already handles that correctly by treating an empty
 // TTY as MISSING rather than absent: launcherBackfillNeedsFor returns
@@ -1429,8 +1432,13 @@ func (pm *PIDManager) refreshHerdrHosts(snaps []livenessSnapshot) {
 		if state == nil {
 			continue
 		}
+		// Not "host re-resolved": since #1546 this pass reports a change when
+		// the host moved, when the background badge was re-derived from a
+		// repaired tty, or both — and in the badge-only case all three values
+		// printed here are identical to the ones printed last time, so the
+		// older wording named the one thing that provably had NOT happened.
 		pm.log.LogInfo(logComponentSessionDetector, state.SessionID,
-			fmt.Sprintf("herdr host re-resolved: term_program=%q host_bundle_id=%q tty=%q",
+			fmt.Sprintf("herdr session refreshed: term_program=%q host_bundle_id=%q tty=%q",
 				state.Launcher.TermProgram, state.Launcher.HostBundleID, state.Launcher.TTY))
 		pm.broadcast(outbound.PushTypeUpdated, state)
 	}

--- a/core/application/services/pid_manager.go
+++ b/core/application/services/pid_manager.go
@@ -304,9 +304,14 @@ func (pm *PIDManager) captureLauncher(state *session.SessionState, pid int) {
 
 // captureBackground flags state as a background agent when the reader recognizes
 // its PID, stamping Detached from the captured Launcher TTY. Must run AFTER
-// captureLauncher so the controlling TTY is known. Set-once: a no-op once
-// Background is already set, when no reader is installed, or for an unrecognized
-// PID. Returns true when it set Background so callers can persist (#744).
+// captureLauncher so the controlling TTY is known. Returns true when it set
+// Background so callers can persist (#744).
+//
+// Set-once, but only the IDENTIFICATION half: this is a no-op once Background
+// is already set, when no reader is installed, or for an unrecognized PID.
+// Detached is not an identification, it is derived from a field that is
+// explicitly repairable, so it is re-derived by refreshBackgroundDetached on
+// the paths that repair it (#1546).
 func (pm *PIDManager) captureBackground(state *session.SessionState, pid int) bool {
 	if pm.background == nil || state == nil || state.Background != nil || pid <= 0 {
 		return false
@@ -315,9 +320,57 @@ func (pm *PIDManager) captureBackground(state *session.SessionState, pid int) bo
 	if bg == nil {
 		return false
 	}
-	// No controlling terminal ⇒ no window/tab owns it — the "detached" signature.
-	bg.Detached = state.Launcher == nil || state.Launcher.TTY == ""
+	bg.Detached = detachedFromLauncher(state.Launcher)
 	state.Background = bg
+	return true
+}
+
+// detachedFromLauncher derives BackgroundAgent.Detached from the launcher a
+// session currently holds: no controlling terminal ⇒ no window/tab owns it,
+// which is the "detached" signature (#744). One function so the first stamp
+// and every later re-derivation cannot drift apart on what the badge means.
+func detachedFromLauncher(l *session.Launcher) bool {
+	return l == nil || l.TTY == ""
+}
+
+// refreshBackgroundDetached re-derives Detached for a session that already
+// carries a background badge, and reports whether the value moved so the
+// caller can persist and push only on a real change. It is #1546.
+//
+// Launcher.TTY has two ways of being empty and they are not the same fact: the
+// process genuinely has no controlling terminal, or the `ps` behind
+// processTTY was killed by its 2s ceiling and never answered. Nothing that
+// reaches this layer distinguishes them — ReadLauncherEnv discards
+// hostIdentity's completeness verdict for the agent's own read, deliberately
+// and for reasons that have nothing to do with the tty (see its doc comment)
+// — so captureBackground's first stamp can be a claim made on no evidence.
+//
+// The rest of the codebase already handles that correctly by treating an empty
+// TTY as MISSING rather than absent: launcherBackfillNeedsFor returns
+// `tty: l.TTY == ""`, and both refresh paths re-read it until one answers. What
+// was missing is the second half — the badge derived from that field never
+// followed it, because captureBackground is set-once and a record carrying a
+// wrong badge is by definition one that already has a Background. So the
+// repair ran and its result was discarded, and since SessionState is persisted
+// whole the badge outlived the daemon that wrote it: a permanent amber "no open
+// window; runs in the daemon pool" on a session with a perfectly good terminal.
+//
+// This can only ever move the badge true → false, which is why it is a repair
+// and not a new way to be wrong: applyLauncherBackfill copies a fresh TTY only
+// when it is non-empty, AdoptHostIdentity refuses to move a client's tty onto a
+// pane that has none, and no path ever nils a stored Launcher — so the field
+// this reads is monotone once set. Correcting a stale FALSE (an agent whose
+// window closed after capture) would need the stored TTY to be invalidated,
+// which nothing does today; that is a separate gap, not one this closes.
+func refreshBackgroundDetached(state *session.SessionState) bool {
+	if state == nil || state.Background == nil {
+		return false
+	}
+	want := detachedFromLauncher(state.Launcher)
+	if state.Background.Detached == want {
+		return false
+	}
+	state.Background.Detached = want
 	return true
 }
 
@@ -1232,7 +1285,15 @@ func (pm *PIDManager) handleAlivePIDState(state *session.SessionState) bool {
 	// Re-attach the background-agent badge to sessions persisted before the
 	// field existed, or restored after a daemon restart (#744). Runs after
 	// backfillLauncher so Detached reflects the refreshed TTY.
-	if pm.captureBackground(state, state.PID) {
+	stamped := pm.captureBackground(state, state.PID)
+	// ...and for a session restored WITH a badge, captureBackground is a
+	// set-once no-op, so the refreshed TTY reaches Detached only through this
+	// second call. That is the whole of #1546: a record already carrying the
+	// wrong badge is precisely the one the line above cannot correct. Both
+	// calls are evaluated — no short-circuit — because a just-stamped badge is
+	// already consistent and the refresh then reports no change anyway.
+	refreshed := refreshBackgroundDetached(state)
+	if stamped || refreshed {
 		state.UpdatedAt = time.Now().Unix()
 		_ = pm.repo.Save(state)
 	}
@@ -1437,7 +1498,19 @@ func (pm *PIDManager) applyHerdrHostRefresh(sessionID string, fresh *session.Lau
 		if fresh.HerdrPaneID != state.Launcher.HerdrPaneID {
 			return
 		}
-		if applyLauncherBackfill(state.Launcher, needs, fresh, hostKnown) {
+		changed := applyLauncherBackfill(state.Launcher, needs, fresh, hostKnown)
+		// The tty this sweep may just have acquired is what
+		// BackgroundAgent.Detached is derived from — launcherBackfillNeedsFor's
+		// doc gives that derivation as the whole reason the tty need survives
+		// the client adoption for a herdr pane. For such a session this is the
+		// only repair that runs inside a daemon's lifetime; everything else
+		// waits for a restart (#1546). It does not disturb the affordability
+		// argument above: once badge and tty agree this reports no change, so
+		// the steady state still writes nothing.
+		if refreshBackgroundDetached(state) {
+			changed = true
+		}
+		if changed {
 			pm.touchAndSave(state)
 			updated = state
 		}

--- a/core/application/services/pid_manager_background_test.go
+++ b/core/application/services/pid_manager_background_test.go
@@ -1,6 +1,7 @@
 package services_test
 
 import (
+	"os"
 	"testing"
 	"time"
 
@@ -95,4 +96,138 @@ func assertNoBackground(t *testing.T, repo *mockRepo, sessionID, msg string) {
 	if repo.states[sessionID].Background != nil {
 		t.Error(msg)
 	}
+}
+
+// TestSeedPIDs_BackgroundDetachedFollowsTheRefreshedTTY is #1546.
+//
+// Launcher.TTY has two ways of being empty and they are not the same fact: the
+// process genuinely has no controlling terminal, or the `ps` behind
+// processTTY was killed by its 2s ceiling and never answered. captureBackground
+// reads only the field, so it stamps Detached from the second as confidently as
+// from the first.
+//
+// That would be self-correcting, because the codebase already treats an empty
+// TTY as *missing* rather than absent: launcherBackfillNeedsFor returns
+// `tty: l.TTY == ""` and backfillLauncher re-reads it on every seed, and
+// handleAlivePIDState calls captureBackground straight afterwards saying, in a
+// comment, that it does so "so Detached reflects the refreshed TTY". But
+// captureBackground early-returns on `state.Background != nil`, and a record
+// carrying a wrong badge is by definition one that already has a Background —
+// so the machinery that repairs the input runs, and its output is discarded.
+// SessionState is persisted whole, so the badge outlives the daemon that wrote
+// it: amber "no open window; runs in the daemon pool" on a session with a
+// perfectly good terminal, for the life of the record.
+//
+// The first arm is the defect. The other two are LOCKS on behaviour that must
+// not change and pass by construction.
+func TestSeedPIDs_BackgroundDetachedFollowsTheRefreshedTTY(t *testing.T) {
+	// bgSession is a live background-agent session whose stored launcher and
+	// badge are whatever the caller says they were at capture time.
+	bgSession := func(l *session.Launcher, bg *session.BackgroundAgent) *session.SessionState {
+		return &session.SessionState{
+			SessionID:  "s",
+			State:      session.StateWorking,
+			PID:        os.Getpid(), // alive: handleAlivePIDState's ESRCH probe must pass
+			UpdatedAt:  time.Now().Unix(),
+			Launcher:   l,
+			Background: bg,
+		}
+	}
+	// answeringReader is the read that succeeds where the capture-time one
+	// timed out.
+	answeringReader := func(int) (*session.Launcher, bool) {
+		return &session.Launcher{TermProgram: "iTerm.app", TTY: "/dev/ttys004"}, true
+	}
+
+	t.Run("a stamp made without evidence is corrected once the tty arrives", func(t *testing.T) {
+		repo := newMockRepo()
+		// Captured while the tty `ps` was timing out: a real host, no tty...
+		repo.states["s"] = bgSession(
+			&session.Launcher{TermProgram: "iTerm.app"},
+			// ...and badged detached from that absence.
+			&session.BackgroundAgent{Name: "nightly refactor", Detached: true},
+		)
+		pm := newPIDManagerForTest(repo)
+		pm.SetLauncherEnvReader(answeringReader)
+		pm.SetBackgroundReader(func(int) *session.BackgroundAgent {
+			return &session.BackgroundAgent{Name: "nightly refactor"}
+		})
+
+		pm.SeedPIDs([]*session.SessionState{repo.states["s"]})
+
+		got := repo.states["s"]
+		// Vacuity guard. Without it, a run that reached neither the backfill
+		// nor the re-derivation is indistinguishable from one that reached
+		// both and found nothing to fix.
+		if got.Launcher.TTY != "/dev/ttys004" {
+			t.Fatalf("backfillLauncher never repaired the tty (TTY = %q), so this "+
+				"run's verdict on Detached says nothing about #1546", got.Launcher.TTY)
+		}
+		if got.Background == nil {
+			t.Fatal("the seed path dropped Background entirely")
+		}
+		if got.Background.Detached {
+			t.Error("Detached: got true, want false — the session holds /dev/ttys004, " +
+				"but the badge did not follow the repaired tty")
+		}
+		// The identification half stays set-once: only the derived field moves.
+		if got.Background.Name != "nightly refactor" {
+			t.Errorf("Name: got %q, want %q", got.Background.Name, "nightly refactor")
+		}
+	})
+
+	// LOCK: passes on main by construction. A session that really has no
+	// terminal must keep its detached badge — the re-derivation reads the same
+	// stored TTY, which applyLauncherBackfill never clears (it copies only a
+	// non-empty fresh value), so the badge can only ever move true → false.
+	t.Run("a genuinely detached record keeps its badge", func(t *testing.T) {
+		repo := newMockRepo()
+		repo.states["s"] = bgSession(
+			&session.Launcher{TermProgram: "iTerm.app"},
+			&session.BackgroundAgent{Name: "nightly refactor", Detached: true},
+		)
+		pm := newPIDManagerForTest(repo)
+		// The `ps` answers, and the answer is "no controlling terminal".
+		pm.SetLauncherEnvReader(func(int) (*session.Launcher, bool) {
+			return &session.Launcher{TermProgram: "iTerm.app"}, true
+		})
+		pm.SetBackgroundReader(func(int) *session.BackgroundAgent {
+			return &session.BackgroundAgent{Name: "nightly refactor"}
+		})
+
+		pm.SeedPIDs([]*session.SessionState{repo.states["s"]})
+
+		if bg := repo.states["s"].Background; bg == nil || !bg.Detached {
+			t.Errorf("Detached: got %v, want true (still no controlling terminal)", bg)
+		}
+	})
+
+	// LOCK: passes on main by construction. Re-deriving a field of an existing
+	// badge must never conjure the badge itself — with no BackgroundReader
+	// installed there is nothing that could have recognized this PID.
+	//
+	// It asserts on the seeded struct as well as on the repository, and the
+	// first assertion is the load-bearing one. A conjured badge derives
+	// Detached=false, which equals the zero value it was just given, so the
+	// re-derivation reports "no change" and never saves — and the only write
+	// this session takes is backfillLauncher's, which lands BEFORE the
+	// re-derivation runs. Checking the persisted copy alone therefore reads a
+	// snapshot taken before the thing under test happened: measured, by
+	// mutating refreshBackgroundDetached to allocate a Background when it finds
+	// none, which this arm passed until it also looked at the struct the seed
+	// path mutates in place.
+	t.Run("a session with no background badge is not given one", func(t *testing.T) {
+		repo := newMockRepo()
+		seeded := bgSession(&session.Launcher{TermProgram: "iTerm.app"}, nil)
+		repo.states["s"] = seeded
+		pm := newPIDManagerForTest(repo)
+		pm.SetLauncherEnvReader(answeringReader)
+
+		pm.SeedPIDs([]*session.SessionState{seeded})
+
+		if seeded.Background != nil {
+			t.Errorf("the seed path conjured a Background out of a re-derivation: %+v", seeded.Background)
+		}
+		assertNoBackground(t, repo, "s", "a conjured Background was persisted")
+	})
 }

--- a/core/application/services/pid_manager_background_test.go
+++ b/core/application/services/pid_manager_background_test.go
@@ -149,8 +149,12 @@ func TestSeedPIDs_BackgroundDetachedFollowsTheRefreshedTTY(t *testing.T) {
 		)
 		pm := newPIDManagerForTest(repo)
 		pm.SetLauncherEnvReader(answeringReader)
+		// Deliberately NOT the stored name. captureBackground is set-once, so
+		// nothing this reader returns may reach the record — and a reader that
+		// echoed the stored name would make the Name assertion below pass
+		// whether the identification half was re-stamped or not.
 		pm.SetBackgroundReader(func(int) *session.BackgroundAgent {
-			return &session.BackgroundAgent{Name: "nightly refactor"}
+			return &session.BackgroundAgent{Name: "RE-READ AT SEED"}
 		})
 
 		pm.SeedPIDs([]*session.SessionState{repo.states["s"]})
@@ -171,8 +175,11 @@ func TestSeedPIDs_BackgroundDetachedFollowsTheRefreshedTTY(t *testing.T) {
 				"but the badge did not follow the repaired tty")
 		}
 		// The identification half stays set-once: only the derived field moves.
+		// This is also the seed path's only set-once lock — the reader-call-count
+		// assertion in the #744 test above covers HandlePIDAssigned, not this path.
 		if got.Background.Name != "nightly refactor" {
-			t.Errorf("Name: got %q, want %q", got.Background.Name, "nightly refactor")
+			t.Errorf("Name: got %q, want %q — captureBackground re-stamped a record "+
+				"that already had a Background", got.Background.Name, "nightly refactor")
 		}
 	})
 

--- a/core/application/services/pid_manager_herdr_refresh_test.go
+++ b/core/application/services/pid_manager_herdr_refresh_test.go
@@ -343,3 +343,52 @@ func TestCheckPIDLiveness_HerdrHostSurvivesAnUnrunnableProbe(t *testing.T) {
 		t.Errorf("a non-answer churned the repo and pushed: %d saves", repo.saves-before)
 	}
 }
+
+// TestCheckPIDLiveness_HerdrBackgroundDetachedFollowsAnAcquiredTTY is the
+// sweep half of #1546.
+//
+// TestCheckPIDLiveness_HerdrAcquiresAMissingTTY above pins that a herdr pane
+// stored without a tty acquires one here, and launcherBackfillNeedsFor's doc
+// gives BackgroundAgent.Detached as the reason that need survives the client
+// adoption at all. This is the assertion that reason was never backed by: the
+// tty arrives, and the badge derived from it does not move. For a herdr
+// session this sweep is the only repair that runs inside a daemon's lifetime —
+// everything else waits for a restart.
+func TestCheckPIDLiveness_HerdrBackgroundDetachedFollowsAnAcquiredTTY(t *testing.T) {
+	repo := newMockRepo()
+	s := herdrSession(&session.Launcher{
+		HerdrPaneID:     "w1:p1",
+		HerdrSocketPath: "/cfg/herdr/herdr.sock",
+		TermProgram:     "iTerm.app",
+	})
+	s.Background = &session.BackgroundAgent{Name: "nightly refactor", Detached: true}
+	repo.states["s"] = s
+
+	pm := newPIDManagerForTest(repo)
+	pm.SetLauncherEnvReader(func(int) (*session.Launcher, bool) {
+		return &session.Launcher{
+			HerdrPaneID:     "w1:p1",
+			HerdrSocketPath: "/cfg/herdr/herdr.sock",
+			TermProgram:     "iTerm.app",
+			ITermSessionID:  "w0t0p0",
+			TTY:             "/dev/ttys077",
+		}, true
+	})
+
+	pm.CheckPIDLiveness()
+
+	got := repo.states["s"]
+	// Vacuity guard, as in the seed-path twin: no tty acquired means the sweep
+	// never got as far as the thing under test.
+	if got.Launcher.TTY != "/dev/ttys077" {
+		t.Fatalf("the sweep never backfilled the tty (TTY = %q), so its verdict "+
+			"on Detached says nothing about #1546", got.Launcher.TTY)
+	}
+	if got.Background == nil {
+		t.Fatal("the sweep dropped Background entirely")
+	}
+	if got.Background.Detached {
+		t.Error("Detached: got true, want false — the pane acquired /dev/ttys077, " +
+			"but the badge did not follow it")
+	}
+}

--- a/core/application/services/pid_manager_herdr_refresh_test.go
+++ b/core/application/services/pid_manager_herdr_refresh_test.go
@@ -161,7 +161,14 @@ func TestCheckPIDLiveness_HerdrSteadyStateDoesNotChurn(t *testing.T) {
 		TermProgram:     "ghostty",
 		TTY:             "/dev/ttys077",
 	}
-	repo.states["s"] = herdrSession(stored)
+	steady := herdrSession(stored)
+	// Carrying a background badge that already AGREES with the stored tty. A
+	// session without one returns at refreshBackgroundDetached's nil guard
+	// before reaching the change-detection, so it cannot see a refresh that
+	// started reporting a change on every call — which is exactly the shape
+	// that would rewrite every badged herdr session every 5 seconds forever.
+	steady.Background = &session.BackgroundAgent{Name: "nightly refactor", Detached: false}
+	repo.states["s"] = steady
 
 	calls := 0
 	pm := newPIDManagerForTest(repo)
@@ -390,5 +397,49 @@ func TestCheckPIDLiveness_HerdrBackgroundDetachedFollowsAnAcquiredTTY(t *testing
 	if got.Background.Detached {
 		t.Error("Detached: got true, want false — the pane acquired /dev/ttys077, " +
 			"but the badge did not follow it")
+	}
+}
+
+// TestCheckPIDLiveness_HerdrBadgeOnlyRepairIsPersisted pins the half of the
+// sweep wiring its sibling above cannot reach.
+//
+// In that test the reader also moves ITermSessionID and the tty, so
+// applyLauncherBackfill reports a change on its own and the save happens
+// whether or not the badge repair is folded into the change-detection. The two
+// are only distinguishable when the badge is the SOLE thing that moved: the
+// reader hands back the stored launcher unchanged, so a repair computed in
+// memory and not folded in is discarded when WithSessionStateLock returns —
+// the fix silently not fixing, with every test still green (#1546).
+//
+// This is the shape a record left over from before the fix has: an already
+// repaired tty, and a badge still stamped from the read that never answered.
+func TestCheckPIDLiveness_HerdrBadgeOnlyRepairIsPersisted(t *testing.T) {
+	repo := newMockRepo()
+	stored := &session.Launcher{
+		HerdrPaneID:     "w1:p1",
+		HerdrSocketPath: "/cfg/herdr/herdr.sock",
+		TermProgram:     "ghostty",
+		TTY:             "/dev/ttys077",
+	}
+	s := herdrSession(stored)
+	s.Background = &session.BackgroundAgent{Name: "nightly refactor", Detached: true}
+	repo.states["s"] = s
+
+	pm := newPIDManagerForTest(repo)
+	// Byte-identical to the stored launcher: nothing for applyLauncherBackfill
+	// to report, so the badge repair is the only reason to write.
+	pm.SetLauncherEnvReader(func(int) (*session.Launcher, bool) {
+		cp := *stored
+		return &cp, true
+	})
+
+	before := repo.saves
+	pm.CheckPIDLiveness()
+
+	if repo.saves == before {
+		t.Errorf("a badge-only repair was never persisted: %d saves", repo.saves-before)
+	}
+	if bg := repo.states["s"].Background; bg == nil || bg.Detached {
+		t.Errorf("Detached: got %+v, want false — the pane holds /dev/ttys077", bg)
 	}
 }

--- a/core/domain/session/session.go
+++ b/core/domain/session/session.go
@@ -155,7 +155,11 @@ type BackgroundAgent struct {
 	// (e.g. "Add guiding colors to quest cards"); may be empty.
 	Name string `json:"name,omitempty"`
 	// Detached is true when the agent has no controlling terminal — i.e. no
-	// window/tab owns it. Computed by the daemon from the captured Launcher TTY.
+	// window/tab owns it. Derived by the daemon from the captured Launcher TTY,
+	// and RE-derived whenever that TTY is repaired: an empty TTY is as often a
+	// `ps` that never answered as a process with genuinely no terminal, so the
+	// first derivation can be a claim made on no evidence, and freezing it made
+	// that claim permanent and persisted (#1546). Name is set once; this is not.
 	Detached bool `json:"detached,omitempty"`
 }
 

--- a/core/domain/session/session.go
+++ b/core/domain/session/session.go
@@ -156,10 +156,12 @@ type BackgroundAgent struct {
 	Name string `json:"name,omitempty"`
 	// Detached is true when the agent has no controlling terminal — i.e. no
 	// window/tab owns it. Derived by the daemon from the captured Launcher TTY,
-	// and RE-derived whenever that TTY is repaired: an empty TTY is as often a
-	// `ps` that never answered as a process with genuinely no terminal, so the
-	// first derivation can be a claim made on no evidence, and freezing it made
-	// that claim permanent and persisted (#1546). Name is set once; this is not.
+	// and RE-derived whenever that TTY is repaired: an empty TTY may equally
+	// mean the `ps` behind it never answered as that the process has no
+	// terminal, so the first derivation can be a claim made on no evidence, and
+	// freezing it made that claim permanent and persisted (#1546). The relative
+	// frequency of the two is unmeasured — no such mis-stamp has been observed
+	// in the wild. Name is set once; this is not.
 	Detached bool `json:"detached,omitempty"`
 }
 


### PR DESCRIPTION
Closes #1546.

> **Body corrected after merge.** The body originally published here was the
> one drafted by the concurrent agent working on #1543 — it described that
> issue's git-adapter shellouts and not this change at all. Root cause: concurrent `ir:exec` agents share one scratchpad
> directory and both wrote a generically-named `pr-body.md`; the second
> `Write` reported "updated successfully" rather than colliding. See #1382.
> The squash-merge commit message on `main` (102bcf82) was always correct and
> is reproduced below; nothing in git history was affected.

Launcher.TTY has two ways of being empty and they are not the same fact: the
process genuinely has no controlling terminal, or the `ps` behind processTTY
was killed by its 2s ceiling and never answered. captureBackground reads only
the field, so it stamps Detached from the second as confidently as from the
first — and, being set-once, made that claim permanent and persisted.

The rest of the codebase already treats an empty TTY as MISSING rather than
absent (launcherBackfillNeedsFor returns `tty: l.TTY == ""`, and both refresh
paths re-read it until one answers). What was missing is the second half: the
badge derived from that field never followed it, because a record carrying a
wrong badge is by definition one that already has a Background and so takes
captureBackground's early return. The repair ran and its result was discarded.

Extract the derivation (detachedFromLauncher) and re-derive it wherever the
stored TTY is repaired: handleAlivePIDState — where a comment already claimed
this happened — and applyHerdrHostRefresh, the only repair that runs inside a
daemon's lifetime. The identification half stays set-once; only the derived
field moves, and it can only ever move true -> false.

Refs #1546

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

* test(daemon): close three vacuous locks the review battery found, and two doc claims

Review of PR #1550 found three assertions that could not fail, each the same
shape as the M3 gap already recorded in the PR body: a fixture that cannot
express the state which discriminates. All three are now measured red under a
mutation.

- The sweep's "steady state writes nothing" affordability claim was asserted by
  nothing: TestCheckPIDLiveness_HerdrSteadyStateDoesNotChurn built a session
  with no Background, so the new refresh returned at its nil guard before
  reaching the change-detection. Give it a badge that agrees with its tty.
  Red under: refresh reports a change on every call.

- The sweep's `changed = true` fold-in was unlocked — the only test on that
  path already had applyLauncherBackfill returning true, so a repair computed
  and then discarded was indistinguishable from one that persisted. Add
  TestCheckPIDLiveness_HerdrBadgeOnlyRepairIsPersisted, where the badge is the
  sole change. Red under: compute the repair, don't fold it in.

- The seed path's "identification stays set-once" assertion echoed the stored
  name back through the injected reader, so it passed whether captureBackground
  no-opped or re-stamped. Make the reader return a name that must never land.
  Red under: drop captureBackground's `state.Background != nil` guard. This is
  also the seed path's only set-once lock; the pre-existing one covers
  HandlePIDAssigned.

Two doc corrections:

- The domain doc hardened a hedge into a rate ("as often as"), a frequency this
  PR explicitly marks unmeasured. Say unmeasured.
- "reasons that have nothing to do with the tty" was true of ReadLauncherEnv's
  stated reasons but not of the bit: since #1533 the discarded verdict is
  `complete && ttyProbed`, so it does carry tty information its rationale
  predates.

And the sweep's log line no longer says "herdr host re-resolved" on a pass
where only the badge moved and all three printed values are unchanged.

Refs #1546

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

---------

Co-authored-by: Test <test@example.com>
Co-authored-by: Claude Opus 5 (1M context) <noreply@anthropic.com>
