### PR TITLE
fix(git): bound and classify the git adapter's seven shellouts

### DIFF
--- a/core/adapters/inbound/agents/processlifecycle/shellout.go
+++ b/core/adapters/inbound/agents/processlifecycle/shellout.go
@@ -49,14 +49,18 @@ type shelloutCmd func(ctx context.Context) *exec.Cmd
 // wrap context.DeadlineExceeded, and why ProcessState.Exited() rather than
 // errors.Is is the ran-vs-killed discriminator — live there.
 //
-// It stays a local name because the knowledge splits in three, one level per
-// name: shellout.Answered knows what is true of any child process,
-// probeAnswered is where this package's sites agree on the empty-variadic form
-// ("for ps and plutil, any normal exit is an answer"), and lsofProbeRan binds
-// the one per-tool allowlist below that. #1543 moved the bottom of that stack
-// into pkg/ so an OUTBOUND adapter could reach it; it did not merge the three,
-// and shellout_guard_test.go recognises BOTH spellings so a future site here
-// may call shellout.Answered directly without being reported.
+// It is a pure alias — same signature, same semantics, binding nothing — and
+// saying so is better than the tidier story that it is "this package's binding
+// of the empty-variadic form". That story is false: process_darwin.go calls
+// probeAnswered(err, pgrepNoMatch), so the variadic is forwarded, not bound.
+// lsofProbeRan is the only real binding in this package.
+//
+// The honest reason it survives #1543's promotion is churn: five call sites, a
+// guard classifier table and a committed corpus all spell it this way, and
+// #1547 argues that verified enforcement machinery is worth not disturbing for
+// a rename. Deleting it — or narrowing it to a non-variadic form so it binds
+// what its name suggests — is a reasonable follow-up; shellout_guard_test.go
+// already recognises the qualified spelling, so nothing mechanical blocks it.
 func probeAnswered(err error, answeredExitCodes ...int) bool {
 	return shellout.Answered(err, answeredExitCodes...)
 }

--- a/core/adapters/inbound/agents/processlifecycle/shellout.go
+++ b/core/adapters/inbound/agents/processlifecycle/shellout.go
@@ -2,10 +2,10 @@ package processlifecycle
 
 import (
 	"context"
-	"errors"
 	"os/exec"
-	"slices"
 	"time"
+
+	"irrlicht/core/pkg/shellout"
 )
 
 // shelloutTimeout is the ceiling EVERY bounded shellout in this package runs
@@ -42,71 +42,21 @@ const shelloutTimeout = 2 * time.Second
 // carrying arguments nobody reads is five chances to forget the ceiling.
 type shelloutCmd func(ctx context.Context) *exec.Cmd
 
-// probeAnswered reports whether the child process behind a bounded shellout
-// actually ANSWERED, as opposed to never having been asked. It is the one
-// predicate every shellout in this package classifies its error with (#1538),
-// replacing three spellings that had drifted apart:
+// probeAnswered is this package's binding of the shared predicate
+// core/pkg/shellout.Answered, which every bounded child process in the repo
+// classifies its error with (#1538). The implementation, and the measurements
+// behind it — why a mid-run deadline kill is an *exec.ExitError that does NOT
+// wrap context.DeadlineExceeded, and why ProcessState.Exited() rather than
+// errors.Is is the ran-vs-killed discriminator — live there.
 //
-//   - lsofProbeRan's `err == nil || (errors.As(&exit) && exit.ExitCode() == 1)`
-//   - bundleIDVia's `errors.As(&exit) && exit.ProcessState.Exited()`
-//   - runPgrep's bare `err.(*exec.ExitError)` type assertion, which misses a
-//     wrapped error for no reason anyone chose.
-//
-// The whole family it exists to prevent — #1485, #1492, #1513, #1524, #1533,
-// #1537 — is one sentence six times: "I could not look" collapsed into "I
-// looked and there was nothing". This predicate answers only the first half.
-// What to DO with a non-answer is per-call-site and deliberately not decided
-// here: IsKnownInteractiveHost gates ADMISSION and so fails open (#1513),
-// while hostIdentity feeds a click target and so degrades an enrichment
-// (#1492). A shared verdict with per-site polarity is the point.
-//
-// answeredExitCodes is the per-tool part, and it is the only part that
-// genuinely differs. Empty means "any normal exit is an answer" — plutil's
-// rule, because it exits 1 both for a missing Info.plist and for a plist
-// carrying no CFBundleIdentifier (both measured: exit 1, #1524 and re-measured
-// in #1538), so treating a non-zero exit as a non-answer would fail the
-// admission gate OPEN and widen #784. A non-empty list is an allowlist of the
-// non-zero exits that count as answers — lsof's and pgrep's rule, where exit 1
-// is "nothing to report" and any OTHER code is not evidence about anything.
-// That distinction is load-bearing rather than cosmetic: `sh -c "exit 152"`
-// (a process killed under an exhausted CPU limit reports 152 through a shell)
-// exits NORMALLY, so ProcessState.Exited() is true and ExitCode() is 152
-// (measured, go1.25 darwin/arm64) — the empty form would call it an answer and
-// lsofProbeRan's committed corpus pins that it is not.
-//
-// The hard half does NOT differ, and it is the half that is easy to get wrong:
-//
-//   - A killed child is not an answer, and `errors.Is(err,
-//     context.DeadlineExceeded)` will not tell you. When CommandContext's
-//     deadline fires MID-RUN the child is SIGKILLed and Output returns
-//     *exec.ExitError "signal: killed", which does not wrap the context's
-//     error: errors.Is reports FALSE while ctx.Err() reports the deadline
-//     (measured independently in #1524 and again in #1538, go1.25
-//     darwin/arm64). The natural-looking spelling compiles, reads correctly,
-//     and misses the exact condition every issue in this family is about.
-//   - ProcessState.Exited() is what separates a process that RAN from one that
-//     was killed, and it covers the deaths the ceiling did not cause too: an
-//     OOM kill, a fork that failed under the same load, and a ctx already past
-//     its deadline before Start — where the error is not an ExitError at all
-//     (measured: `errors.As` false, `errors.Is(DeadlineExceeded)` true).
-//
-// errors.As rather than a type assertion because an error that has been
-// wrapped on the way here is still an exit status. No caller wraps today
-// (os/exec hands back a bare *exec.ExitError), which is exactly why the bare
-// assertion in runPgrep survived unnoticed — it was correct by accident of its
-// caller, not by construction.
+// It stays a local name because the knowledge splits in three, one level per
+// name: shellout.Answered knows what is true of any child process,
+// probeAnswered is where this package's sites agree on the empty-variadic form
+// ("for ps and plutil, any normal exit is an answer"), and lsofProbeRan binds
+// the one per-tool allowlist below that. #1543 moved the bottom of that stack
+// into pkg/ so an OUTBOUND adapter could reach it; it did not merge the three,
+// and shellout_guard_test.go recognises BOTH spellings so a future site here
+// may call shellout.Answered directly without being reported.
 func probeAnswered(err error, answeredExitCodes ...int) bool {
-	if err == nil {
-		return true
-	}
-	var exit *exec.ExitError
-	if !errors.As(err, &exit) || !exit.ProcessState.Exited() {
-		// Killed, never started, or not a child-exit error at all. None of
-		// these carry information about the question that was asked.
-		return false
-	}
-	if len(answeredExitCodes) == 0 {
-		return true
-	}
-	return slices.Contains(answeredExitCodes, exit.ExitCode())
+	return shellout.Answered(err, answeredExitCodes...)
 }

--- a/core/adapters/inbound/agents/processlifecycle/shellout_guard_corpus_test.go
+++ b/core/adapters/inbound/agents/processlifecycle/shellout_guard_corpus_test.go
@@ -157,6 +157,71 @@ func probe() ([]int, bool) {
 }`,
 		},
 		{
+			name: "classified_via_the_qualified_shared_predicate", want: 0, wantRuns: 1,
+			needle: `shellout.Answered(err)`,
+			why:    "#1543 promoted the predicate to core/pkg/shellout; before shelloutPkgClassifiers existed this row reported a FALSE POSITIVE against correctly-classified code (measured against processTTYVia)",
+			src: `package shapes
+func probe() (string, bool) {
+	out, err := exec.CommandContext(ctx, psPath, "-p", pid).Output()
+	if !shellout.Answered(err) {
+		return "", false
+	}
+	return string(out), true
+}`,
+		},
+		{
+			name: "classified_via_the_qualified_predicate_with_an_allowlist", want: 0, wantRuns: 1,
+			needle: `shellout.Answered(err, lsofNothingToReport)`,
+			why:    "the variadic form must be recognised too; matching is on the callee, not on the argument count",
+			src: `package shapes
+func probe() (int, bool) {
+	out, err := exec.CommandContext(ctx, lsofPath, path).Output()
+	if !shellout.Answered(err, lsofNothingToReport) {
+		return 0, false
+	}
+	return parse(out), true
+}`,
+		},
+		{
+			name: "a_different_packages_Answered_does_not_vouch", want: 1, wantRuns: 1,
+			needle: `notourpkg.Answered(err)`,
+			why:    "matching is keyed on the package identifier: an unrelated Answered is not this repo's predicate, and accepting it would make the rule satisfiable by naming",
+			src: `package shapes
+func probe() (string, bool) {
+	out, err := exec.CommandContext(ctx, psPath, "-p", pid).Output()
+	if !notourpkg.Answered(err) {
+		return "", false
+	}
+	return string(out), true
+}`,
+		},
+		{
+			name: "an_aliased_import_of_the_shared_predicate_is_NOT_recognised", want: 1, wantRuns: 1,
+			needle: `sh.Answered(err)`,
+			why:    "a DECLARED LIMIT, pinned so it is learned from a test rather than an incident: the scan has no type information, so `import sh \"irrlicht/core/pkg/shellout\"` reads as an unknown package. The failure is a false positive, which is the loud direction",
+			src: `package shapes
+func probe() (string, bool) {
+	out, err := exec.CommandContext(ctx, psPath, "-p", pid).Output()
+	if !sh.Answered(err) {
+		return "", false
+	}
+	return string(out), true
+}`,
+		},
+		{
+			name: "a_method_named_Answered_on_a_receiver", want: 1, wantRuns: 1,
+			needle: `probe.Answered(err)`,
+			why:    "the SelectorExpr match must not be satisfied by any value with an Answered method; only the known package identifiers count",
+			src: `package shapes
+func run(probe classifier) (string, bool) {
+	out, err := exec.CommandContext(ctx, psPath, "-p", pid).Output()
+	if !probe.Answered(err) {
+		return "", false
+	}
+	return string(out), true
+}`,
+		},
+		{
 			name: "propagated_wrapped", want: 0, wantRuns: 1,
 			needle: `fmt.Errorf(`,
 			why:    "readProcInfo and CWDOf do this: the two facts stay distinguishable at the caller instead of merging here",

--- a/core/adapters/inbound/agents/processlifecycle/shellout_guard_test.go
+++ b/core/adapters/inbound/agents/processlifecycle/shellout_guard_test.go
@@ -82,13 +82,61 @@ var shelloutRunMethods = map[string]bool{
 	"Start":          true,
 }
 
-// shelloutClassifiers are the calls that count as answering "did the child
-// answer?". lsofProbeRan is here because it IS probeAnswered with lsof's
-// allowlist bound (osutil_darwin.go); a third tool-specific wrapper would be
-// added here in the same breath as being written.
+// shelloutClassifiers are the UNQUALIFIED calls that count as answering "did
+// the child answer?". lsofProbeRan is here because it IS probeAnswered with
+// lsof's allowlist bound (osutil_darwin.go); a third tool-specific wrapper
+// would be added here in the same breath as being written.
 var shelloutClassifiers = map[string]bool{
 	"probeAnswered": true,
 	"lsofProbeRan":  true,
+}
+
+// shelloutPkgClassifiers are the QUALIFIED spellings, keyed by package
+// identifier then function name.
+//
+// #1543 promoted probeAnswered's implementation to core/pkg/shellout.Answered
+// so an outbound adapter one hexagon layer away could reach it. This package
+// still calls the local probeAnswered — which now forwards — so nothing here
+// changed spelling, and that is exactly why this entry is needed rather than
+// obviously needed: the moment a site here writes shellout.Answered(err)
+// directly, which is a completely reasonable thing to write, an *ast.Ident
+// match stops recognising it.
+//
+// MEASURED before this entry existed, by rewriting processTTYVia's classifier
+// call to the qualified spelling: the guard reported
+//
+//	osutil_darwin.go:67 in processTTYVia(): the error of a child process (err)
+//	is neither passed to probeAnswered/lsofProbeRan nor returned
+//
+// i.e. a FALSE POSITIVE against correctly-classified code, not a false
+// negative. That is the loud direction and the guard's own doc argues for
+// preferring it — but a rule that fails the build on the sanctioned fix
+// teaches the next author to spell it the way the rule expects rather than the
+// way that is right, so it is fixed rather than left as a known quirk.
+//
+// Matching is on the package IDENTIFIER, not an import path: this scan has no
+// type information (see the file header on why it parses source). An aliased
+// import of core/pkg/shellout would therefore not be recognised, which is the
+// same class of limit the run-method table already accepts and is pinned as a
+// corpus row rather than left to be discovered.
+var shelloutPkgClassifiers = map[string]map[string]bool{
+	"shellout": {"Answered": true},
+}
+
+// isShelloutClassifier reports whether fun names a call that classifies a
+// child-process error, in either spelling.
+func isShelloutClassifier(fun ast.Expr) bool {
+	switch f := fun.(type) {
+	case *ast.Ident:
+		return shelloutClassifiers[f.Name]
+	case *ast.SelectorExpr:
+		pkg, ok := f.X.(*ast.Ident)
+		if !ok {
+			return false
+		}
+		return shelloutPkgClassifiers[pkg.Name][f.Sel.Name]
+	}
+	return false
 }
 
 // shelloutFinding is one unclassified shellout error.
@@ -163,7 +211,7 @@ func scanScope(fset *token.FileSet, file, name string, body ast.Node) (findings 
 		default:
 			if !classifiedOrPropagated(body, errName, run.Pos()) {
 				findings = append(findings, shelloutFinding{file, line, name,
-					"the error of a child process (" + errName + ") is neither passed to probeAnswered/lsofProbeRan nor returned — " +
+					"the error of a child process (" + errName + ") is neither passed to probeAnswered/lsofProbeRan/shellout.Answered nor returned — " +
 						"a non-answer collapses into a zero value here (#1538)"})
 			}
 		}
@@ -287,7 +335,7 @@ func classifiedOrPropagated(body ast.Node, errName string, after token.Pos) bool
 		}
 		switch s := n.(type) {
 		case *ast.CallExpr:
-			if id, ok := s.Fun.(*ast.Ident); ok && shelloutClassifiers[id.Name] {
+			if isShelloutClassifier(s.Fun) {
 				for _, arg := range s.Args {
 					if usesIdent(arg, errName) {
 						found = true
@@ -408,7 +456,7 @@ func TestEveryBoundedShelloutClassifiesItsError(t *testing.T) {
 	}
 	if len(findings) > 0 {
 		t.Log("Every issue in this family is one sentence: \"I could not look\" collapsed into \"I looked and there was nothing\" (#1485, #1492, #1513, #1524, #1533, #1537).")
-		t.Log("Fix: classify with probeAnswered(err[, answeredExitCodes...]) and decide at THIS call site what a non-answer means, or return the error.")
+		t.Log("Fix: classify with probeAnswered(err[, answeredExitCodes...]) — or shellout.Answered, the shared predicate it forwards to (#1543) — and decide at THIS call site what a non-answer means, or return the error.")
 	}
 }
 

--- a/core/adapters/inbound/agents/processlifecycle/shellout_guard_test.go
+++ b/core/adapters/inbound/agents/processlifecycle/shellout_guard_test.go
@@ -91,8 +91,8 @@ var shelloutClassifiers = map[string]bool{
 	"lsofProbeRan":  true,
 }
 
-// shelloutPkgClassifiers are the QUALIFIED spellings, keyed by package
-// identifier then function name.
+// shelloutPkgClassifiers are the QUALIFIED spellings, keyed by the source text
+// "<package identifier>.<function>".
 //
 // #1543 promoted probeAnswered's implementation to core/pkg/shellout.Answered
 // so an outbound adapter one hexagon layer away could reach it. This package
@@ -119,8 +119,8 @@ var shelloutClassifiers = map[string]bool{
 // import of core/pkg/shellout would therefore not be recognised, which is the
 // same class of limit the run-method table already accepts and is pinned as a
 // corpus row rather than left to be discovered.
-var shelloutPkgClassifiers = map[string]map[string]bool{
-	"shellout": {"Answered": true},
+var shelloutPkgClassifiers = map[string]bool{
+	"shellout.Answered": true,
 }
 
 // isShelloutClassifier reports whether fun names a call that classifies a
@@ -134,7 +134,7 @@ func isShelloutClassifier(fun ast.Expr) bool {
 		if !ok {
 			return false
 		}
-		return shelloutPkgClassifiers[pkg.Name][f.Sel.Name]
+		return shelloutPkgClassifiers[pkg.Name+"."+f.Sel.Name]
 	}
 	return false
 }

--- a/core/adapters/inbound/agents/processlifecycle/shellout_test.go
+++ b/core/adapters/inbound/agents/processlifecycle/shellout_test.go
@@ -1,163 +1,34 @@
 package processlifecycle
 
 import (
-	"context"
-	"errors"
-	"fmt"
 	"os/exec"
 	"testing"
-	"time"
+
+	"irrlicht/core/pkg/shellout"
 )
 
-// TestProbeAnswered is the corpus behind #1538's shared predicate.
-//
-// Every case is built from a REAL child process rather than from a hand-built
-// *exec.ExitError, for the reason TestLsofProbeRan already records: the
-// classification's whole job is to be right about what os/exec actually hands
-// back, and a mid-run context deadline in particular is not obviously an
-// ExitError at all. Asserting the VERDICT rather than the error type is what
-// keeps this honest across Go versions. The one synthetic row is the wrapped
-// error, which no os/exec path produces today and which is the point of that
-// row (see below).
-//
-// The table pins both directions at once, which is why it is a matrix over the
-// two forms rather than two tables:
-//
-//   - wantAny is the empty-variadic form ("any normal exit is an answer") —
-//     plutil's rule, #1524.
-//   - wantExit1 is the allowlist form probeAnswered(err, 1) — lsof's and
-//     pgrep's rule.
-//
-// The two disagree on exactly one row, "exit 152", and that disagreement is
-// the whole reason the variadic exists: a shell reports a process killed under
-// an exhausted CPU limit as a NORMAL exit with status 152, so Exited() is true.
-// A single global rule cannot serve both tools, and picking either one for
-// both is a silent behaviour change at half the call sites.
-func TestProbeAnswered(t *testing.T) {
-	run := func(ctx context.Context, name string, args ...string) error {
-		_, err := exec.CommandContext(ctx, name, args...).Output()
-		return err
-	}
-	// 50ms rather than the 1ms TestLsofProbeRan uses: at 1ms the deadline
-	// routinely fires BEFORE Start, which is a different row of this table.
-	// The verdict is the same either way, so the row is correct regardless —
-	// TestProbeAnsweredRejectsTheContextSpelling below is what actually
-	// VERIFIES the mid-run shape, by asserting the error is an ExitError.
-	deadline, cancelDeadline := context.WithTimeout(context.Background(), 50*time.Millisecond)
-	defer cancelDeadline()
-
-	// A context already past its deadline before Start: os/exec never builds
-	// an ExitError here, it returns the context's own error. errors.As is
-	// false, and errors.Is(err, context.DeadlineExceeded) is TRUE — the mirror
-	// image of the mid-run kill below, which is why keying on the context
-	// catches this one and misses that one.
-	expired, cancelExpired := context.WithTimeout(context.Background(), time.Nanosecond)
-	defer cancelExpired()
-	time.Sleep(5 * time.Millisecond)
-
+// TestProbeAnsweredForwardsToTheSharedPredicate is a LOCK, and a thin one on
+// purpose: #1543 moved the corpus that grades this behaviour to
+// core/pkg/shellout, where the implementation now lives. What stays here is
+// the one claim that is local — that this package's spelling still reaches
+// that implementation, in both the empty and the allowlist form — so a
+// forwarder quietly rewritten to its own logic fails here rather than nowhere.
+func TestProbeAnsweredForwardsToTheSharedPredicate(t *testing.T) {
 	cases := []struct {
-		name      string
-		err       error
-		wantAny   bool
-		wantExit1 bool
-		why       string
+		name  string
+		err   error
+		codes []int
 	}{
-		{
-			name: "success", err: nil, wantAny: true, wantExit1: true,
-			why: "the vacuity guard: a predicate that answered false here would make every other row pass for the wrong reason",
-		},
-		{
-			name: "exit 1", err: run(context.Background(), "/bin/sh", "-c", "exit 1"),
-			wantAny: true, wantExit1: true,
-			why: "plutil's 'no CFBundleIdentifier' and lsof's 'nothing to report' are both real verdicts (#1524)",
-		},
-		{
-			name: "exit 2", err: run(context.Background(), "/bin/sh", "-c", "exit 2"),
-			wantAny: true, wantExit1: false,
-			why: "an allowlist is an allowlist: for lsof/pgrep only exit 1 carries meaning, every other code is not evidence",
-		},
-		{
-			name: "exit 152 — killed under an exhausted CPU limit, reported through a shell",
-			err:  run(context.Background(), "/bin/sh", "-c", "exit 152"),
-			// The one row where the two forms disagree, and the reason the
-			// variadic is not cosmetic. Exited() is TRUE here (measured), so
-			// the empty form calls it an answer.
-			wantAny: true, wantExit1: false,
-			why: "lsofProbeRan's committed corpus pins 152 as NOT an answer; a global Exited() rule would silently flip it",
-		},
-		{
-			name: "killed by a signal", err: run(context.Background(), "/bin/sh", "-c", "kill -9 $$"),
-			wantAny: false, wantExit1: false,
-			why: "a SIGKILLed child ran but never answered — ExitCode() is -1 and Exited() is false",
-		},
-		{
-			name: "context deadline fires MID-RUN", err: run(deadline, "/bin/sleep", "5"),
-			wantAny: false, wantExit1: false,
-			why: "#1538 trap 1: this is *exec.ExitError \"signal: killed\" and errors.Is(err, context.DeadlineExceeded) is FALSE — the natural spelling misses exactly this row",
-		},
-		{
-			name: "context already expired before Start", err: run(expired, "/bin/sleep", "5"),
-			wantAny: false, wantExit1: false,
-			why: "not an ExitError at all; errors.As is false and the predicate must still refuse it",
-		},
-		{
-			name: "binary missing", err: run(context.Background(), "/nonexistent/probe-1538"),
-			wantAny: false, wantExit1: false,
-			why: "a fork/exec failure is a probe that never ran, not a tool reporting nothing",
-		},
-		{
-			name:    "an exit 1 that was WRAPPED on the way here",
-			err:     fmt.Errorf("pgrep -x claude: %w", run(context.Background(), "/bin/sh", "-c", "exit 1")),
-			wantAny: true, wantExit1: true,
-			why: "the third spelling replaced by #1538 was a bare `err.(*exec.ExitError)` assertion, which reports false here; errors.As reports true. No os/exec path wraps today, so this row is a LOCK on the property rather than a live defect — it is what makes the bare assertion unrewritable without going red",
-		},
+		{name: "nil"},
+		{name: "exit 1", err: exec.Command("/bin/sh", "-c", "exit 1").Run()},
+		{name: "exit 1, allowlisted", err: exec.Command("/bin/sh", "-c", "exit 1").Run(), codes: []int{1}},
+		{name: "exit 152 against an allowlist of 1", err: exec.Command("/bin/sh", "-c", "exit 152").Run(), codes: []int{1}},
+		{name: "binary missing", err: exec.Command("/nonexistent/irrlicht-1543").Run()},
 	}
-
 	for _, tc := range cases {
-		if got := probeAnswered(tc.err); got != tc.wantAny {
-			t.Errorf("%s: probeAnswered(%v) = %v, want %v — %s", tc.name, tc.err, got, tc.wantAny, tc.why)
+		if got, want := probeAnswered(tc.err, tc.codes...), shellout.Answered(tc.err, tc.codes...); got != want {
+			t.Errorf("%s: probeAnswered = %v, shellout.Answered = %v — the local spelling no longer "+
+				"forwards to the shared predicate", tc.name, got, want)
 		}
-		if got := probeAnswered(tc.err, 1); got != tc.wantExit1 {
-			t.Errorf("%s: probeAnswered(%v, 1) = %v, want %v — %s", tc.name, tc.err, got, tc.wantExit1, tc.why)
-		}
-	}
-}
-
-// TestProbeAnsweredRejectsTheContextSpelling is #1538's trap 1 stated as an
-// assertion rather than as a doc comment.
-//
-// It exists because the wrong spelling is the natural one. A reader fixing this
-// family reaches for errors.Is(err, context.DeadlineExceeded) — it names the
-// exact condition, it compiles, and it reads correctly. This test measures that
-// it is FALSE for the mid-run kill and TRUE only for the pre-Start case, so the
-// evidence lives next to the predicate instead of in a merged PR body.
-//
-// It is deliberately an assertion about os/exec's behaviour, not about
-// probeAnswered: if a future Go release makes CommandContext wrap the context's
-// error, this test goes red and the doc comment above probeAnswered becomes
-// wrong. That is the signal worth having.
-func TestProbeAnsweredRejectsTheContextSpelling(t *testing.T) {
-	deadline, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
-	defer cancel()
-	_, err := exec.CommandContext(deadline, "/bin/sleep", "5").Output()
-	if err == nil {
-		t.Fatal("the ceiling did not fire — this test proves nothing without a killed child")
-	}
-
-	if errors.Is(err, context.DeadlineExceeded) {
-		t.Errorf("os/exec now wraps the context error (%v): probeAnswered's doc comment and #1524's measurement are stale", err)
-	}
-	if deadline.Err() != context.DeadlineExceeded {
-		t.Errorf("ctx.Err() = %v, want DeadlineExceeded — the deadline is what actually fired", deadline.Err())
-	}
-	var exit *exec.ExitError
-	if !errors.As(err, &exit) {
-		t.Fatalf("want *exec.ExitError for a mid-run kill, got %T", err)
-	}
-	if exit.ProcessState.Exited() {
-		t.Error("a SIGKILLed child reports Exited() — the predicate's whole discriminator is gone")
-	}
-	if probeAnswered(err) {
-		t.Error("probeAnswered called a killed child an answer (#1538)")
 	}
 }

--- a/core/adapters/outbound/filesystem/concurrency_tracker.go
+++ b/core/adapters/outbound/filesystem/concurrency_tracker.go
@@ -144,8 +144,8 @@ func (t *ConcurrencyTracker) resolveProject(cwd string) string {
 	}
 	t.resolveMu.Lock()
 	defer t.resolveMu.Unlock()
-	if p, ok := t.resolveCache[cwd]; ok {
-		return p
+	if cached, ok := t.resolveCache[cwd]; ok {
+		return cached
 	}
 	p := filepath.Base(cwd)
 	if t.git != nil {

--- a/core/adapters/outbound/filesystem/concurrency_tracker.go
+++ b/core/adapters/outbound/filesystem/concurrency_tracker.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"time"
 
 	"irrlicht/core/domain/lifecycle"
 	"irrlicht/core/domain/session"
@@ -43,7 +44,37 @@ type ConcurrencyTracker struct {
 	// instance is shared across every request.
 	resolveMu    sync.Mutex
 	resolveCache map[string]string // raw CWD -> resolved project name
+
+	// unresolvedUntil is the NEGATIVE cache: raw CWD -> when its non-answer
+	// stops being reused. It is separate from resolveCache because the two
+	// have opposite lifetimes, and that asymmetry is the whole point.
+	//
+	// A resolved project is effectively permanent (#1049) — a historical
+	// session's working directory does not change repos after the fact — so
+	// resolveCache never expires. A NON-answer is the opposite: it says
+	// nothing about the directory, only that one probe did not run, so
+	// caching it forever would make a transient git failure permanent.
+	//
+	// Caching it for NOTHING is just as wrong, and that is the version #1543
+	// shipped first. resolveProject is called once per recording EVENT, not
+	// once per distinct cwd, and loadTimelines re-scans every recording file
+	// on every request — so skipping the cache entirely costs one `git
+	// rev-parse` per event, each up to the git adapter's 5s ceiling, while
+	// holding resolveMu, on an endpoint the dashboard polls. #1049's comment
+	// measured the uncached pathology at "~20s+ … for every distinct
+	// historical CWD"; per event it is that multiplied again.
+	unresolvedUntil map[string]time.Time
+
+	// clock is nil in production; a test replaces it to drive unresolvedTTL
+	// without sleeping.
+	clock func() time.Time
 }
+
+// unresolvedTTL bounds how long a non-answer is reused before the probe is
+// retried. Short enough that a git outage self-heals within one dashboard poll
+// cycle, long enough that one unreadable repo costs one probe per request
+// rather than one per event.
+const unresolvedTTL = 30 * time.Second
 
 // NewConcurrencyTrackerWithDir returns a reader rooted at the given recordings
 // directory. The daemon passes the same dir the recorder writes to (see
@@ -52,9 +83,10 @@ type ConcurrencyTracker struct {
 // fall back to a bare filepath.Base(cwd).
 func NewConcurrencyTrackerWithDir(dir string, git concurrencyProjectResolver) *ConcurrencyTracker {
 	return &ConcurrencyTracker{
-		dir:          dir,
-		git:          git,
-		resolveCache: make(map[string]string),
+		dir:             dir,
+		git:             git,
+		resolveCache:    make(map[string]string),
+		unresolvedUntil: make(map[string]time.Time),
 	}
 }
 
@@ -117,14 +149,23 @@ func (t *ConcurrencyTracker) resolveProject(cwd string) string {
 	}
 	p := filepath.Base(cwd)
 	if t.git != nil {
+		// A recent non-answer is reused rather than re-probed — see
+		// unresolvedUntil for why this is neither permanent nor absent.
+		if until, ok := t.unresolvedUntil[cwd]; ok {
+			if t.now().Before(until) {
+				return p
+			}
+			delete(t.unresolvedUntil, cwd)
+		}
 		resolved, answered := t.git.GetProjectName(cwd)
 		if !answered {
-			// #1543: the cache below is for the daemon's LIFETIME, on the
+			// #1543: resolveCache is for the daemon's LIFETIME, on the
 			// reasoning that a historical cwd's repo does not change after the
-			// fact. That reasoning holds for a resolution; it does not hold
-			// for a git that never ran, whose basename fallback is a guess —
-			// and for a worktree cwd it is the guess #1046 exists to prevent.
-			// Return it for this request and re-ask on the next.
+			// fact. That holds for a resolution; it does not hold for a git
+			// that never ran, whose basename fallback is a guess — and for a
+			// worktree cwd it is the guess #1046 exists to prevent. So it goes
+			// in the negative cache, not this one.
+			t.unresolvedUntil[cwd] = t.now().Add(unresolvedTTL)
 			return p
 		}
 		if resolved != "" {
@@ -133,6 +174,15 @@ func (t *ConcurrencyTracker) resolveProject(cwd string) string {
 	}
 	t.resolveCache[cwd] = p
 	return p
+}
+
+// now is time.Now unless a test replaced it, so the TTL above can be driven
+// without sleeping.
+func (t *ConcurrencyTracker) now() time.Time {
+	if t.clock != nil {
+		return t.clock()
+	}
+	return time.Now()
 }
 
 // AgentsSeries reconstructs a per-project concurrent-agents time series over

--- a/core/adapters/outbound/filesystem/concurrency_tracker.go
+++ b/core/adapters/outbound/filesystem/concurrency_tracker.go
@@ -23,7 +23,7 @@ import (
 // to a bare basename, i.e. pre-#1046 behavior) so every recordings-dir-only
 // test fixture can omit it.
 type concurrencyProjectResolver interface {
-	GetProjectName(dir string) string
+	GetProjectName(dir string) (name string, answered bool)
 }
 
 // ConcurrencyTracker reconstructs concurrent-agent counts over time from the
@@ -117,7 +117,17 @@ func (t *ConcurrencyTracker) resolveProject(cwd string) string {
 	}
 	p := filepath.Base(cwd)
 	if t.git != nil {
-		if resolved := t.git.GetProjectName(cwd); resolved != "" {
+		resolved, answered := t.git.GetProjectName(cwd)
+		if !answered {
+			// #1543: the cache below is for the daemon's LIFETIME, on the
+			// reasoning that a historical cwd's repo does not change after the
+			// fact. That reasoning holds for a resolution; it does not hold
+			// for a git that never ran, whose basename fallback is a guess —
+			// and for a worktree cwd it is the guess #1046 exists to prevent.
+			// Return it for this request and re-ask on the next.
+			return p
+		}
+		if resolved != "" {
 			p = resolved
 		}
 	}

--- a/core/adapters/outbound/filesystem/concurrency_tracker_nonanswer_test.go
+++ b/core/adapters/outbound/filesystem/concurrency_tracker_nonanswer_test.go
@@ -1,0 +1,119 @@
+package filesystem
+
+import (
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+)
+
+// #1551 review findings 5 and 6: resolveProject's non-answer branch had no
+// coverage at all — neutralising it (`if false && !answered`) left the package
+// green, because the only double in it never reported a non-answer.
+//
+// What the branch must do is narrow: not poison the permanent cache with a
+// guess (#1046/#1049), and not re-probe per recording EVENT either, which is
+// what the first draft did.
+
+type answerControlledResolver struct {
+	mu       sync.Mutex
+	calls    map[string]int
+	answered bool
+}
+
+func (r *answerControlledResolver) GetProjectName(dir string) (string, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.calls == nil {
+		r.calls = map[string]int{}
+	}
+	r.calls[dir]++
+	if !r.answered {
+		return "", false
+	}
+	return "resolved-" + filepath.Base(dir), true
+}
+
+func (r *answerControlledResolver) count(dir string) int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.calls[dir]
+}
+
+// TestResolveProjectDoesNotCacheANonAnswerPermanently pins both halves.
+//
+// RED-FIRST, measured by reverting each half separately:
+//
+//   - Writing the guess into resolveCache (the pre-#1543 behaviour): the
+//     "re-probed after the TTL" arm fails with 1 call, because the permanent
+//     cache answers forever and a worktree cwd keeps #1046's wrong name.
+//   - Dropping the negative cache entirely (#1543's first draft): the "not
+//     re-probed within the TTL" arm fails with 3 calls — one per event, each
+//     up to the git adapter's 5s ceiling, under a held mutex.
+func TestResolveProjectDoesNotCacheANonAnswerPermanently(t *testing.T) {
+	now := time.Now()
+	git := &answerControlledResolver{answered: false}
+	tr := NewConcurrencyTrackerWithDir(t.TempDir(), git)
+	tr.clock = func() time.Time { return now }
+
+	const cwd = "/repo/.claude/worktrees/1543-slug"
+
+	// Three events for the same cwd inside one request.
+	for i := 0; i < 3; i++ {
+		if got := tr.resolveProject(cwd); got != "1543-slug" {
+			t.Fatalf("resolveProject = %q, want the basename fallback", got)
+		}
+	}
+	if n := git.count(cwd); n != 1 {
+		t.Errorf("probed %d times for 3 events on one cwd; a non-answer must be reused within "+
+			"the TTL, or every recording line costs a bounded-but-real git shellout under a "+
+			"held mutex (#1551 finding 5)", n)
+	}
+
+	// The guess must NOT have entered the permanent cache.
+	tr.resolveMu.Lock()
+	_, cached := tr.resolveCache[cwd]
+	tr.resolveMu.Unlock()
+	if cached {
+		t.Error("a basename guess from a git that never ran was written to the lifetime cache; " +
+			"for a worktree cwd that is exactly the name #1046 exists to prevent")
+	}
+
+	// Past the TTL, the probe is retried and a now-working git wins.
+	now = now.Add(unresolvedTTL + time.Second)
+	git.mu.Lock()
+	git.answered = true
+	git.mu.Unlock()
+
+	if got := tr.resolveProject(cwd); got != "resolved-1543-slug" {
+		t.Errorf("after the TTL, resolveProject = %q — the non-answer was cached permanently", got)
+	}
+	if n := git.count(cwd); n != 2 {
+		t.Errorf("probed %d times, want 2 (once inside the TTL, once after)", n)
+	}
+}
+
+// TestResolveProjectStillCachesAnAnswerForever is the vacuity guard: without
+// it, a tracker that cached nothing at all would pass every arm above, and
+// #1049's whole point — one shellout per distinct cwd, not per event — would
+// be silently undone.
+func TestResolveProjectStillCachesAnAnswerForever(t *testing.T) {
+	now := time.Now()
+	git := &answerControlledResolver{answered: true}
+	tr := NewConcurrencyTrackerWithDir(t.TempDir(), git)
+	tr.clock = func() time.Time { return now }
+
+	const cwd = "/repo/sub"
+	for i := 0; i < 3; i++ {
+		if got := tr.resolveProject(cwd); got != "resolved-sub" {
+			t.Fatalf("resolveProject = %q", got)
+		}
+	}
+	now = now.Add(10 * unresolvedTTL)
+	if got := tr.resolveProject(cwd); got != "resolved-sub" {
+		t.Fatalf("after a long wait, resolveProject = %q", got)
+	}
+	if n := git.count(cwd); n != 1 {
+		t.Errorf("probed %d times for a cwd that resolved; a resolution is permanent (#1049)", n)
+	}
+}

--- a/core/adapters/outbound/filesystem/concurrency_tracker_nonanswer_test.go
+++ b/core/adapters/outbound/filesystem/concurrency_tracker_nonanswer_test.go
@@ -1,8 +1,6 @@
 package filesystem
 
 import (
-	"path/filepath"
-	"sync"
 	"testing"
 	"time"
 )
@@ -13,32 +11,8 @@ import (
 //
 // What the branch must do is narrow: not poison the permanent cache with a
 // guess (#1046/#1049), and not re-probe per recording EVENT either, which is
-// what the first draft did.
-
-type answerControlledResolver struct {
-	mu       sync.Mutex
-	calls    map[string]int
-	answered bool
-}
-
-func (r *answerControlledResolver) GetProjectName(dir string) (string, bool) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	if r.calls == nil {
-		r.calls = map[string]int{}
-	}
-	r.calls[dir]++
-	if !r.answered {
-		return "", false
-	}
-	return "resolved-" + filepath.Base(dir), true
-}
-
-func (r *answerControlledResolver) count(dir string) int {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	return r.calls[dir]
-}
+// what #1543's first draft did. The doubles are this package's existing
+// countingResolver, which grew one `unread` knob rather than a second type.
 
 // TestResolveProjectDoesNotCacheANonAnswerPermanently pins both halves.
 //
@@ -48,11 +22,11 @@ func (r *answerControlledResolver) count(dir string) int {
 //     "re-probed after the TTL" arm fails with 1 call, because the permanent
 //     cache answers forever and a worktree cwd keeps #1046's wrong name.
 //   - Dropping the negative cache entirely (#1543's first draft): the "not
-//     re-probed within the TTL" arm fails with 3 calls — one per event, each
-//     up to the git adapter's 5s ceiling, under a held mutex.
+//     re-probed within the TTL" arm fails with 3 calls — one per recording
+//     event, each up to the git adapter's 5s ceiling, under a held mutex.
 func TestResolveProjectDoesNotCacheANonAnswerPermanently(t *testing.T) {
 	now := time.Now()
-	git := &answerControlledResolver{answered: false}
+	git := &countingResolver{unread: true}
 	tr := NewConcurrencyTrackerWithDir(t.TempDir(), git)
 	tr.clock = func() time.Time { return now }
 
@@ -64,7 +38,7 @@ func TestResolveProjectDoesNotCacheANonAnswerPermanently(t *testing.T) {
 			t.Fatalf("resolveProject = %q, want the basename fallback", got)
 		}
 	}
-	if n := git.count(cwd); n != 1 {
+	if n := git.Calls(cwd); n != 1 {
 		t.Errorf("probed %d times for 3 events on one cwd; a non-answer must be reused within "+
 			"the TTL, or every recording line costs a bounded-but-real git shellout under a "+
 			"held mutex (#1551 finding 5)", n)
@@ -79,17 +53,25 @@ func TestResolveProjectDoesNotCacheANonAnswerPermanently(t *testing.T) {
 			"for a worktree cwd that is exactly the name #1046 exists to prevent")
 	}
 
-	// Past the TTL, the probe is retried and a now-working git wins.
+	// Past the TTL the probe is retried, and a now-working git wins.
 	now = now.Add(unresolvedTTL + time.Second)
 	git.mu.Lock()
-	git.answered = true
+	git.unread = false
 	git.mu.Unlock()
 
-	if got := tr.resolveProject(cwd); got != "resolved-1543-slug" {
-		t.Errorf("after the TTL, resolveProject = %q — the non-answer was cached permanently", got)
+	if got := tr.resolveProject(cwd); got != "1543-slug" {
+		t.Errorf("after the TTL, resolveProject = %q", got)
 	}
-	if n := git.count(cwd); n != 2 {
-		t.Errorf("probed %d times, want 2 (once inside the TTL, once after)", n)
+	if n := git.Calls(cwd); n != 2 {
+		t.Errorf("probed %d times, want 2 (once inside the TTL, once after) — the non-answer "+
+			"was cached permanently", n)
+	}
+	// And now that it answered, it is permanent.
+	tr.resolveMu.Lock()
+	_, cached = tr.resolveCache[cwd]
+	tr.resolveMu.Unlock()
+	if !cached {
+		t.Error("a resolution that finally answered was not written to the lifetime cache")
 	}
 }
 
@@ -99,21 +81,21 @@ func TestResolveProjectDoesNotCacheANonAnswerPermanently(t *testing.T) {
 // be silently undone.
 func TestResolveProjectStillCachesAnAnswerForever(t *testing.T) {
 	now := time.Now()
-	git := &answerControlledResolver{answered: true}
+	git := &countingResolver{}
 	tr := NewConcurrencyTrackerWithDir(t.TempDir(), git)
 	tr.clock = func() time.Time { return now }
 
 	const cwd = "/repo/sub"
 	for i := 0; i < 3; i++ {
-		if got := tr.resolveProject(cwd); got != "resolved-sub" {
+		if got := tr.resolveProject(cwd); got != "sub" {
 			t.Fatalf("resolveProject = %q", got)
 		}
 	}
 	now = now.Add(10 * unresolvedTTL)
-	if got := tr.resolveProject(cwd); got != "resolved-sub" {
+	if got := tr.resolveProject(cwd); got != "sub" {
 		t.Fatalf("after a long wait, resolveProject = %q", got)
 	}
-	if n := git.count(cwd); n != 1 {
+	if n := git.Calls(cwd); n != 1 {
 		t.Errorf("probed %d times for a cwd that resolved; a resolution is permanent (#1049)", n)
 	}
 }

--- a/core/adapters/outbound/filesystem/concurrency_tracker_test.go
+++ b/core/adapters/outbound/filesystem/concurrency_tracker_test.go
@@ -733,9 +733,12 @@ type countingResolver struct {
 	mu    sync.Mutex
 	calls map[string]int
 	delay time.Duration
+	// unread makes this double report a NON-ANSWER — git could not be run —
+	// rather than a resolved name (#1543).
+	unread bool
 }
 
-func (r *countingResolver) GetProjectName(dir string) string {
+func (r *countingResolver) GetProjectName(dir string) (string, bool) {
 	r.mu.Lock()
 	if r.calls == nil {
 		r.calls = map[string]int{}
@@ -746,7 +749,7 @@ func (r *countingResolver) GetProjectName(dir string) string {
 	if delay > 0 {
 		time.Sleep(delay)
 	}
-	return filepath.Base(dir)
+	return filepath.Base(dir), !r.unread
 }
 
 func (r *countingResolver) Calls(dir string) int {

--- a/core/adapters/outbound/filesystem/concurrency_tracker_test.go
+++ b/core/adapters/outbound/filesystem/concurrency_tracker_test.go
@@ -733,9 +733,6 @@ type countingResolver struct {
 	mu    sync.Mutex
 	calls map[string]int
 	delay time.Duration
-	// unread makes this double report a NON-ANSWER — git could not be run —
-	// rather than a resolved name (#1543).
-	unread bool
 }
 
 func (r *countingResolver) GetProjectName(dir string) (string, bool) {
@@ -749,7 +746,7 @@ func (r *countingResolver) GetProjectName(dir string) (string, bool) {
 	if delay > 0 {
 		time.Sleep(delay)
 	}
-	return filepath.Base(dir), !r.unread
+	return filepath.Base(dir), true
 }
 
 func (r *countingResolver) Calls(dir string) int {

--- a/core/adapters/outbound/filesystem/concurrency_tracker_test.go
+++ b/core/adapters/outbound/filesystem/concurrency_tracker_test.go
@@ -733,6 +733,10 @@ type countingResolver struct {
 	mu    sync.Mutex
 	calls map[string]int
 	delay time.Duration
+	// unread makes the double report a NON-ANSWER — git could not be run —
+	// rather than a resolved name (#1543). The zero value answers, so every
+	// pre-existing use is unchanged.
+	unread bool
 }
 
 func (r *countingResolver) GetProjectName(dir string) (string, bool) {
@@ -745,6 +749,9 @@ func (r *countingResolver) GetProjectName(dir string) (string, bool) {
 	r.mu.Unlock()
 	if delay > 0 {
 		time.Sleep(delay)
+	}
+	if r.unread {
+		return "", false
 	}
 	return filepath.Base(dir), true
 }

--- a/core/adapters/outbound/git/adapter.go
+++ b/core/adapters/outbound/git/adapter.go
@@ -71,22 +71,14 @@ const gitRevParseCmd = "rev-parse"
 // unbounded case is gone.
 const gitTimeout = 5 * time.Second
 
-// gitWaitDelay bounds the extra time a run waits for the child's output pipe
-// to close after its context expires. Killing git is not enough on its own:
-// exec waits for stdout to reach EOF, and a grandchild that inherited the pipe
-// — a credential helper, a `core.fsmonitor` daemon, a pager some global config
-// forced on — holds it open after its parent dies. Same reasoning, same value,
-// as core/pkg/cliprobe's waitDelay.
-const gitWaitDelay = 500 * time.Millisecond
-
 // gitMaxOutput caps how much of git's stdout is held in memory. gitTimeout
 // bounds how long git runs, not how much it writes in that time, and this runs
 // inside a long-lived daemon: `git log --pretty=format:...%B` over full history
 // measured 2.59 MB on this repo's 3192 commits (~810 bytes/commit), so a
 // 100k-commit repo is ~81 MB and a 1M-commit one ~810 MB, all buffered by
-// cmd.Output() today with nothing to stop it.
+// cmd.Output() before #1543 with nothing to stop it.
 //
-// Overflow is reported as a NON-ANSWER rather than truncated, which is the
+// run() reports overflow as a NON-ANSWER rather than truncating, which is the
 // opposite of cliprobe's choice and deliberately so: a truncated version banner
 // still contains the version, whereas a truncated commit list silently drops
 // releases and reverts, and DORA would then publish a smaller sample as though
@@ -105,10 +97,16 @@ type gitCmd func(ctx context.Context, dir string, args ...string) *exec.Cmd
 // transcript file inspection.
 type Adapter struct {
 	cmd gitCmd
+	// timeout is gitTimeout unless a test lowered it. Injected for the same
+	// reason cmd is — driving the ceiling means waiting it out, and two tests
+	// waiting out 5s each is both slow and the most load-sensitive thing in
+	// the package. TestProductionAdapterIsBounded deliberately does NOT use
+	// this seam: it goes through New(), so the real constant stays proven.
+	timeout time.Duration
 }
 
 // New returns a new git Adapter.
-func New() *Adapter { return &Adapter{cmd: execGitCmd} }
+func New() *Adapter { return &Adapter{cmd: execGitCmd, timeout: gitTimeout} }
 
 // execGitCmd is the production builder: git, resolved through pathutil rather
 // than the inherited PATH (go:S4036), run in dir.
@@ -138,19 +136,35 @@ func execGitCmd(ctx context.Context, dir string, args ...string) *exec.Cmd {
 // `fatal:`), and it is the pre-existing behaviour; the distinction #1543 is
 // about is "git could not be RUN" versus "git ran and said no", and that is
 // the line drawn here.
+// ceiling is the adapter's timeout, defaulting to gitTimeout so a
+// zero-valued Adapter (a struct literal in a test) is still bounded rather
+// than unbounded — the failure mode this whole issue is about.
+func (a *Adapter) ceiling() time.Duration {
+	if a.timeout > 0 {
+		return a.timeout
+	}
+	return gitTimeout
+}
+
 func (a *Adapter) run(dir string, args ...string) (out []byte, answered bool) {
-	ctx, cancel := context.WithTimeout(context.Background(), gitTimeout)
+	if dir == "" {
+		// Nothing was asked, so nothing failed — the reading processTTYVia
+		// gives a non-positive pid. Deciding it here rather than at each
+		// method keeps it one fact: it is a property of starting a child, not
+		// of any particular git subcommand.
+		return nil, true
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), a.ceiling())
 	defer cancel()
 
 	cmd := a.cmd(ctx, dir, args...)
-	cmd.WaitDelay = gitWaitDelay
+	cmd.WaitDelay = shellout.WaitDelay
 	// Explicit rather than load-bearing: a nil Stdin is already /dev/null, so
 	// os/exec never hands the daemon's own stdin to the child. Spelled out so
 	// a later edit does not "helpfully" wire one up — a git that decided to
 	// prompt (a credential helper, a hook) would then block until the ceiling.
 	cmd.Stdin = nil
-	var buf cappedBuffer
-	buf.limit = gitMaxOutput
+	buf := shellout.CappedBuffer{Limit: gitMaxOutput}
 	cmd.Stdout = &buf
 	// stderr is left nil (i.e. /dev/null) rather than captured: nothing here
 	// reads it, and a pipe nobody drains is a way to block.
@@ -159,7 +173,7 @@ func (a *Adapter) run(dir string, args ...string) (out []byte, answered bool) {
 	if !shellout.Answered(err) {
 		return nil, false
 	}
-	if buf.overflowed {
+	if buf.Overflowed() {
 		return nil, false
 	}
 	if err != nil {
@@ -183,38 +197,7 @@ func (a *Adapter) run(dir string, args ...string) (out []byte, answered bool) {
 		// could not express.
 		return nil, true
 	}
-	return buf.buf, true
-}
-
-// cappedBuffer collects at most limit bytes and records whether anything was
-// DROPPED. It never returns an error: exec's output-copying goroutine treats a
-// write error as fatal to the command, which would turn an overflow into a
-// second, less specific failure. run() reads overflowed instead.
-//
-// seen counts every byte offered, not every byte kept, because those are the
-// same number until the cap is reached and only the first distinguishes "the
-// output is exactly the cap" from "the output was truncated". Keying on
-// len(buf) >= limit instead conflates them and turns a complete read of exactly
-// gitMaxOutput bytes into a false non-answer.
-type cappedBuffer struct {
-	limit      int
-	buf        []byte
-	seen       int
-	overflowed bool
-}
-
-func (w *cappedBuffer) Write(p []byte) (int, error) {
-	if room := w.limit - len(w.buf); room > 0 {
-		if len(p) < room {
-			room = len(p)
-		}
-		w.buf = append(w.buf, p[:room]...)
-	}
-	w.seen += len(p)
-	if w.seen > w.limit {
-		w.overflowed = true
-	}
-	return len(p), nil
+	return buf.Bytes(), true
 }
 
 // GetBranch returns the current git branch for the given working directory.
@@ -225,11 +208,6 @@ func (w *cappedBuffer) Write(p []byte) (int, error) {
 // unborn. Callers must not overwrite a branch they already hold on a
 // non-answer — an empty string there carries no information (#1485/#1543).
 func (a *Adapter) GetBranch(dir string) (string, bool) {
-	if dir == "" {
-		// Nothing was asked, so nothing failed — the reading processTTYVia
-		// gives a non-positive pid.
-		return "", true
-	}
 	out, answered := a.run(dir, gitRevParseCmd, "--abbrev-ref", "HEAD")
 	if !answered {
 		return "", false
@@ -249,9 +227,6 @@ func (a *Adapter) GetBranch(dir string) (string, bool) {
 // answered=false means git could not be run, which is not evidence about
 // either.
 func (a *Adapter) GetHeadCommit(dir string) (string, bool) {
-	if dir == "" {
-		return "", true
-	}
 	out, answered := a.run(dir, gitRevParseCmd, "HEAD")
 	if !answered {
 		return "", false
@@ -271,9 +246,6 @@ func (a *Adapter) GetHeadCommit(dir string) (string, bool) {
 // not happen, which is NOT "no reverts" — treating it as such is what makes a
 // yield sweep report "nothing flipped" for a repo it never read (#1543).
 func (a *Adapter) RevertedCommits(dir string) ([]string, bool) {
-	if dir == "" {
-		return nil, true
-	}
 	out, answered := a.run(dir, "log", "--all", "--grep", "^This reverts commit ", "--pretty=format:%b")
 	if !answered {
 		return nil, false
@@ -295,9 +267,6 @@ func (a *Adapter) RevertedCommits(dir string) ([]string, bool) {
 // answered=false means git could not be run, and reporting that as "no
 // releases found for this project" is the false claim #1543 removes.
 func (a *Adapter) ListReleaseTags(dir string) ([]dora.TagInfo, bool) {
-	if dir == "" {
-		return nil, true
-	}
 	out, answered := a.run(dir, "for-each-ref", "--sort=creatordate", "--format=%(refname:short)%09%(creatordate:unix)", "refs/tags")
 	if !answered {
 		return nil, false
@@ -325,7 +294,9 @@ func (a *Adapter) ListReleaseTags(dir string) ([]dora.TagInfo, bool) {
 // worse than a total one, because a median lead time computed over the tags
 // that happened to succeed is a biased number reported as Available:true.
 func (a *Adapter) CommitsInRange(dir, fromRef, toRef string) ([]dora.CommitInfo, bool) {
-	if dir == "" || toRef == "" {
+	// toRef, unlike dir, is still guarded HERE: an empty one would become an
+	// empty argv entry rather than no call at all. run() handles the dir case.
+	if toRef == "" {
 		return nil, true
 	}
 	rangeSpec := toRef
@@ -368,7 +339,9 @@ func (a *Adapter) CommitsInRange(dir, fromRef, toRef string) ([]dora.CommitInfo,
 // list, which makes Change Failure Rate read BETTER than reality — the one
 // path in this adapter where the collapse flatters the number (#1543).
 func (a *Adapter) TagContaining(dir, hash string) (string, bool) {
-	if dir == "" || hash == "" {
+	// hash, unlike dir, is still guarded HERE — an empty one would become an
+	// empty argv entry. run() handles the dir case.
+	if hash == "" {
 		return "", true
 	}
 	out, answered := a.run(dir, "tag", "--contains", hash, "--sort=creatordate")
@@ -394,13 +367,14 @@ func (a *Adapter) TagContaining(dir, hash string) (string, bool) {
 // a user as "project not found or not a git repository" is a second false
 // claim #1543 removes.
 func (a *Adapter) GetGitRoot(dir string) (string, bool) {
+	// This guard must stay, and it is NOT the one run() absorbed:
+	// nearestExistingDir("") walks Dir("") == "." and Stat(".") succeeds, so
+	// without it an empty dir would resolve to the DAEMON'S OWN working
+	// directory and report that repo's root.
 	if dir == "" {
 		return "", true
 	}
 	dir = nearestExistingDir(dir)
-	if dir == "" {
-		return "", true
-	}
 	out, answered := a.run(dir, gitRevParseCmd, "--path-format=absolute", "--git-common-dir")
 	if !answered {
 		return "", false

--- a/core/adapters/outbound/git/adapter.go
+++ b/core/adapters/outbound/git/adapter.go
@@ -116,6 +116,16 @@ func execGitCmd(ctx context.Context, dir string, args ...string) *exec.Cmd {
 	return cmd
 }
 
+// ceiling is the adapter's timeout, defaulting to gitTimeout so a
+// zero-valued Adapter (a struct literal in a test) is still bounded rather
+// than unbounded — the failure mode this whole issue is about.
+func (a *Adapter) ceiling() time.Duration {
+	if a.timeout > 0 {
+		return a.timeout
+	}
+	return gitTimeout
+}
+
 // run executes `git args...` in dir under gitTimeout and reports whether git
 // ANSWERED — as opposed to never having been asked.
 //
@@ -130,22 +140,22 @@ func execGitCmd(ctx context.Context, dir string, args ...string) *exec.Cmd {
 // why shellout.Answered is called in its EMPTY-variadic form here — the same
 // form, for the same reason, that plutil uses (#1524).
 //
+// One non-answer is PERMANENT rather than transient, and callers must not
+// reason as if retrying fixes it: when dir no longer exists, os/exec fails at
+// chdir BEFORE the child is started, so there is no exit status and this
+// reports answered=false forever. Cleaned-up worktrees are the ordinary case
+// here — GetGitRoot and GetProjectName survive it because they walk up to the
+// nearest existing ancestor first (nearestExistingDir), and the other six
+// deliberately do not, because walking up would answer about a DIFFERENT
+// directory's branch or history. Measured across all eight methods in #1551's
+// QA.
+//
 // The limit that reading buys: a repo whose objects are corrupt, or whose
 // .git is on a filesystem returning EIO, also exits 128, so this reports it as
 // "git answered: not a repo". That is the reading git itself gives (it prints
 // `fatal:`), and it is the pre-existing behaviour; the distinction #1543 is
 // about is "git could not be RUN" versus "git ran and said no", and that is
 // the line drawn here.
-// ceiling is the adapter's timeout, defaulting to gitTimeout so a
-// zero-valued Adapter (a struct literal in a test) is still bounded rather
-// than unbounded — the failure mode this whole issue is about.
-func (a *Adapter) ceiling() time.Duration {
-	if a.timeout > 0 {
-		return a.timeout
-	}
-	return gitTimeout
-}
-
 func (a *Adapter) run(dir string, args ...string) (out []byte, answered bool) {
 	if dir == "" {
 		// Nothing was asked, so nothing failed — the reading processTTYVia

--- a/core/adapters/outbound/git/adapter.go
+++ b/core/adapters/outbound/git/adapter.go
@@ -3,6 +3,7 @@ package git
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"encoding/json"
 	"os"
 	"os/exec"
@@ -10,9 +11,11 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 
 	"irrlicht/core/domain/dora"
 	"irrlicht/core/pkg/pathutil"
+	"irrlicht/core/pkg/shellout"
 	"irrlicht/core/pkg/transcript"
 )
 
@@ -33,90 +36,233 @@ var gitPath = pathutil.MustResolve("git")
 // and GetGitRoot to resolve refs, commits, and repo-relative paths.
 const gitRevParseCmd = "rev-parse"
 
+// gitTimeout is the ceiling EVERY shellout in this adapter runs under. Until
+// #1543 there was none at all: seven plain exec.Command calls with no context,
+// inside a long-lived daemon, on directories that can be network mounts or
+// repos holding a lock.
+//
+// The value is this adapter's own rather than a copy of the 2s next door
+// (processlifecycle's shelloutTimeout), because the workloads are not
+// comparable — a `ps` answers about one PID, `git log --all --grep` walks
+// every commit a user has ever reachable. Measured on this repo (3192 commits,
+// 265 MiB pack, git 2.50.1 / Apple Git-155, darwin/arm64, warm cache):
+// `log --all --grep` 0.05s, `for-each-ref refs/tags` 0.01s,
+// `tag --contains` 0.01s, `rev-parse` 0.01s. 5s is ~100x the heaviest of
+// those, and ~500x the three on the session-enrichment path, which are all
+// rev-parse.
+//
+// Two consequences are stated rather than left implied. The ceiling is a
+// SINGLE value across two profiles: the enrichment reads (GetBranch,
+// GetHeadCommit, GetGitRoot) run inside the detector loop where 5s of stall is
+// bad but bounded, while the DORA reads run on a request a user is already
+// waiting on. And a repo large enough to legitimately exceed 5s now reports a
+// non-answer where it previously returned a correct-but-slow result — which is
+// the trade this whole family makes, and is safe only because a non-answer is
+// now propagated as "unknown" rather than as "there was nothing" (#1492's
+// polarity; nothing here gates admission). UNVERIFIED: the scaling to a very
+// large repo is extrapolation from the numbers above (~810 bytes and ~16us of
+// `log` per commit), not a measurement on such a repo.
+const gitTimeout = 5 * time.Second
+
+// gitWaitDelay bounds the extra time a run waits for the child's output pipe
+// to close after its context expires. Killing git is not enough on its own:
+// exec waits for stdout to reach EOF, and a grandchild that inherited the pipe
+// — a credential helper, a `core.fsmonitor` daemon, a pager some global config
+// forced on — holds it open after its parent dies. Same reasoning, same value,
+// as core/pkg/cliprobe's waitDelay.
+const gitWaitDelay = 500 * time.Millisecond
+
+// gitMaxOutput caps how much of git's stdout is held in memory. gitTimeout
+// bounds how long git runs, not how much it writes in that time, and this runs
+// inside a long-lived daemon: `git log --pretty=format:...%B` over full history
+// measured 2.59 MB on this repo's 3192 commits (~810 bytes/commit), so a
+// 100k-commit repo is ~81 MB and a 1M-commit one ~810 MB, all buffered by
+// cmd.Output() today with nothing to stop it.
+//
+// Overflow is reported as a NON-ANSWER rather than truncated, which is the
+// opposite of cliprobe's choice and deliberately so: a truncated version banner
+// still contains the version, whereas a truncated commit list silently drops
+// releases and reverts, and DORA would then publish a smaller sample as though
+// it were the whole one. "I could not read it all" is a fact; a biased median
+// presented as Available:true is not.
+const gitMaxOutput = 64 << 20
+
+// gitCmd builds one bounded git child process. Injected so a test can arrange
+// the one distinction that matters here and that no faked return value can
+// pin: a child that RAN to a normal exit versus one killed or never started.
+// The shape is processlifecycle's shelloutCmd (#1524/#1538) with the two
+// arguments every git call varies.
+type gitCmd func(ctx context.Context, dir string, args ...string) *exec.Cmd
+
 // Adapter implements ports/outbound.GitResolver using local git commands and
 // transcript file inspection.
-type Adapter struct{}
+type Adapter struct {
+	cmd gitCmd
+}
 
 // New returns a new git Adapter.
-func New() *Adapter { return &Adapter{} }
+func New() *Adapter { return &Adapter{cmd: execGitCmd} }
+
+// execGitCmd is the production builder: git, resolved through pathutil rather
+// than the inherited PATH (go:S4036), run in dir.
+func execGitCmd(ctx context.Context, dir string, args ...string) *exec.Cmd {
+	cmd := exec.CommandContext(ctx, gitPath, args...)
+	cmd.Dir = dir
+	return cmd
+}
+
+// run executes `git args...` in dir under gitTimeout and reports whether git
+// ANSWERED — as opposed to never having been asked.
+//
+// answered is false for exactly three things: the ceiling killed the child,
+// the child never started (git missing, fork failure), or its output exceeded
+// gitMaxOutput. It is TRUE for every non-zero exit git produces on its own,
+// because git has no exit status meaning "I could not look": measured on git
+// 2.50.1 / Apple Git-155 (darwin/arm64), not-a-repo is 128 for all six
+// subcommands this adapter runs, an unborn branch's rev-parse is 128, a range
+// naming an unknown ref is 128, `tag --contains` with an unresolvable object
+// name is 129, and "no tags" / "no reverts" are 0 with empty stdout. That is
+// why shellout.Answered is called in its EMPTY-variadic form here — the same
+// form, for the same reason, that plutil uses (#1524).
+//
+// The limit that reading buys: a repo whose objects are corrupt, or whose
+// .git is on a filesystem returning EIO, also exits 128, so this reports it as
+// "git answered: not a repo". That is the reading git itself gives (it prints
+// `fatal:`), and it is the pre-existing behaviour; the distinction #1543 is
+// about is "git could not be RUN" versus "git ran and said no", and that is
+// the line drawn here.
+func (a *Adapter) run(dir string, args ...string) (out []byte, answered bool) {
+	ctx, cancel := context.WithTimeout(context.Background(), gitTimeout)
+	defer cancel()
+
+	cmd := a.cmd(ctx, dir, args...)
+	cmd.WaitDelay = gitWaitDelay
+	// Never inherit the daemon's stdin: a git that decided to prompt (a
+	// credential helper, a hook) would otherwise block until the ceiling.
+	cmd.Stdin = nil
+	var buf cappedBuffer
+	buf.limit = gitMaxOutput
+	cmd.Stdout = &buf
+	// stderr is left nil (i.e. /dev/null) rather than captured: nothing here
+	// reads it, and a pipe nobody drains is a way to block.
+	err := cmd.Run()
+
+	if !shellout.Answered(err) {
+		return nil, false
+	}
+	if buf.overflowed {
+		return nil, false
+	}
+	return buf.buf, true
+}
+
+// cappedBuffer collects at most limit bytes and records that it stopped. It
+// never returns an error: exec's output-copying goroutine treats a write error
+// as fatal to the command, which would turn an overflow into a second, less
+// specific failure. run() reads overflowed instead.
+type cappedBuffer struct {
+	limit      int
+	buf        []byte
+	overflowed bool
+}
+
+func (w *cappedBuffer) Write(p []byte) (int, error) {
+	if room := w.limit - len(w.buf); room > 0 {
+		if len(p) < room {
+			room = len(p)
+		}
+		w.buf = append(w.buf, p[:room]...)
+	}
+	if len(w.buf) >= w.limit {
+		w.overflowed = true
+	}
+	return len(p), nil
+}
 
 // GetBranch returns the current git branch for the given working directory.
-// Returns "" if git is unavailable or the directory is not a git repo.
-func (a *Adapter) GetBranch(dir string) string {
+//
+// answered is false when git could not be RUN at all (see run). It is TRUE
+// with an empty branch for every case where git answered and there is no
+// branch to report: dir is not a repo, HEAD is detached, or the branch is
+// unborn. Callers must not overwrite a branch they already hold on a
+// non-answer — an empty string there carries no information (#1485/#1543).
+func (a *Adapter) GetBranch(dir string) (string, bool) {
 	if dir == "" {
-		return ""
+		// Nothing was asked, so nothing failed — the reading processTTYVia
+		// gives a non-positive pid.
+		return "", true
 	}
-	cmd := exec.Command(gitPath, gitRevParseCmd, "--abbrev-ref", "HEAD")
-	cmd.Dir = dir
-	out, err := cmd.Output()
-	if err != nil {
-		return ""
+	out, answered := a.run(dir, gitRevParseCmd, "--abbrev-ref", "HEAD")
+	if !answered {
+		return "", false
 	}
 	branch := strings.TrimSpace(string(out))
 	if branch == "" || branch == "HEAD" {
-		return ""
+		return "", true
 	}
 	// Claude Code worktree branches are named "worktree-<slug>" — strip the prefix.
 	branch = strings.TrimPrefix(branch, "worktree-")
-	return branch
+	return branch, true
 }
 
 // GetHeadCommit returns the full SHA of the current HEAD commit for the given
-// working directory. Returns "" if git is unavailable or the directory is not
-// a git repo (e.g. an unborn branch with no commits yet). See issue #373.
-func (a *Adapter) GetHeadCommit(dir string) string {
+// working directory. An empty SHA with answered=true means git ran and there
+// is no HEAD — not a git repo, or an unborn branch with no commits yet (#373).
+// answered=false means git could not be run, which is not evidence about
+// either.
+func (a *Adapter) GetHeadCommit(dir string) (string, bool) {
 	if dir == "" {
-		return ""
+		return "", true
 	}
-	cmd := exec.Command(gitPath, gitRevParseCmd, "HEAD")
-	cmd.Dir = dir
-	out, err := cmd.Output()
-	if err != nil {
-		return ""
+	out, answered := a.run(dir, gitRevParseCmd, "HEAD")
+	if !answered {
+		return "", false
 	}
-	return strings.TrimSpace(string(out))
+	return strings.TrimSpace(string(out)), true
 }
 
 // RevertedCommits returns the full SHAs reverted in the repo containing dir,
 // parsed from the "This reverts commit <sha>." trailer that `git revert`
 // writes. It scans all reachable history (`--all`), so a revert on any branch
-// counts — the documented v1 behavior (#373). Returns nil if dir is not a git
-// repo or has no reverts. Errors are swallowed: a sweep over many projects must
-// tolerate non-git, permission-denied, and missing directories without failing.
-func (a *Adapter) RevertedCommits(dir string) []string {
+// counts — the documented v1 behavior (#373).
+//
+// A nil slice with answered=true means git ran and this repo has no reverts
+// (or is not a repo at all): a sweep over many projects must tolerate non-git,
+// permission-denied and missing directories without failing, and git reports
+// all of those as ordinary non-zero exits. answered=false means the scan did
+// not happen, which is NOT "no reverts" — treating it as such is what makes a
+// yield sweep report "nothing flipped" for a repo it never read (#1543).
+func (a *Adapter) RevertedCommits(dir string) ([]string, bool) {
 	if dir == "" {
-		return nil
+		return nil, true
 	}
-	cmd := exec.Command(gitPath, "log", "--all", "--grep", "^This reverts commit ", "--pretty=format:%b")
-	cmd.Dir = dir
-	out, err := cmd.Output()
-	if err != nil {
-		return nil
+	out, answered := a.run(dir, "log", "--all", "--grep", "^This reverts commit ", "--pretty=format:%b")
+	if !answered {
+		return nil, false
 	}
 	matches := revertTrailer.FindAllSubmatch(out, -1)
 	if len(matches) == 0 {
-		return nil
+		return nil, true
 	}
 	shas := make([]string, 0, len(matches))
 	for _, m := range matches {
 		shas = append(shas, string(m[1]))
 	}
-	return shas
+	return shas, true
 }
 
 // ListReleaseTags returns every release tag in the repo containing dir,
-// oldest-first by creation date (#951). Returns nil if dir is not a git
-// repo or has no release tags. Errors are swallowed, matching this
-// adapter's other read methods.
-func (a *Adapter) ListReleaseTags(dir string) []dora.TagInfo {
+// oldest-first by creation date (#951). A nil slice with answered=true means
+// git ran and there are no release tags (or dir is not a repo);
+// answered=false means git could not be run, and reporting that as "no
+// releases found for this project" is the false claim #1543 removes.
+func (a *Adapter) ListReleaseTags(dir string) ([]dora.TagInfo, bool) {
 	if dir == "" {
-		return nil
+		return nil, true
 	}
-	cmd := exec.Command(gitPath, "for-each-ref", "--sort=creatordate", "--format=%(refname:short)%09%(creatordate:unix)", "refs/tags")
-	cmd.Dir = dir
-	out, err := cmd.Output()
-	if err != nil {
-		return nil
+	out, answered := a.run(dir, "for-each-ref", "--sort=creatordate", "--format=%(refname:short)%09%(creatordate:unix)", "refs/tags")
+	if !answered {
+		return nil, false
 	}
 	var tags []dora.TagInfo
 	for _, line := range strings.Split(string(out), "\n") {
@@ -130,16 +276,19 @@ func (a *Adapter) ListReleaseTags(dir string) []dora.TagInfo {
 		}
 		tags = append(tags, dora.TagInfo{Name: name, Epoch: epoch})
 	}
-	return tags
+	return tags, true
 }
 
 // CommitsInRange returns the commits reachable from toRef but not fromRef
 // (fromRef empty walks toRef's entire history — for the oldest release
-// tag, which has no predecessor) (#951). Returns nil if dir is not a git
-// repo, toRef is empty, or the range is empty.
-func (a *Adapter) CommitsInRange(dir, fromRef, toRef string) []dora.CommitInfo {
+// tag, which has no predecessor) (#951).
+//
+// answered=false is the case DORA must not average over: a partial failure is
+// worse than a total one, because a median lead time computed over the tags
+// that happened to succeed is a biased number reported as Available:true.
+func (a *Adapter) CommitsInRange(dir, fromRef, toRef string) ([]dora.CommitInfo, bool) {
 	if dir == "" || toRef == "" {
-		return nil
+		return nil, true
 	}
 	rangeSpec := toRef
 	if fromRef != "" {
@@ -148,11 +297,9 @@ func (a *Adapter) CommitsInRange(dir, fromRef, toRef string) []dora.CommitInfo {
 	// \x01/\x02 are ASCII control bytes used as record/field separators —
 	// they won't collide with real commit message content, so a multi-line
 	// %B body can be parsed without spawning a process per commit.
-	cmd := exec.Command(gitPath, "log", "--pretty=format:%x01%H%x02%at%x02%B", rangeSpec)
-	cmd.Dir = dir
-	out, err := cmd.Output()
-	if err != nil {
-		return nil
+	out, answered := a.run(dir, "log", "--pretty=format:%x01%H%x02%at%x02%B", rangeSpec)
+	if !answered {
+		return nil, false
 	}
 	var commits []dora.CommitInfo
 	for _, record := range bytes.Split(out, []byte{0x01}) {
@@ -169,61 +316,67 @@ func (a *Adapter) CommitsInRange(dir, fromRef, toRef string) []dora.CommitInfo {
 		}
 		commits = append(commits, dora.CommitInfo{Hash: string(parts[0]), AuthorEpoch: epoch, Body: string(parts[2])})
 	}
-	return commits
+	return commits, true
 }
 
 // TagContaining returns the earliest release tag (by creation date) that
-// contains hash, or "" if none does — either the commit was never
-// released, or dir is not a git repo (#951). Used to resolve which release
-// shipped the original commit a revert commit targets.
-func (a *Adapter) TagContaining(dir, hash string) string {
+// contains hash (#951). Used to resolve which release shipped the original
+// commit a revert commit targets.
+//
+// An empty tag with answered=true means git ran and no release contains it —
+// the commit was never released, dir is not a repo, or the object name does
+// not resolve (measured: exit 129). answered=false means git could not be run,
+// and treating that as "never released" DROPS the revert from the failure
+// list, which makes Change Failure Rate read BETTER than reality — the one
+// path in this adapter where the collapse flatters the number (#1543).
+func (a *Adapter) TagContaining(dir, hash string) (string, bool) {
 	if dir == "" || hash == "" {
-		return ""
+		return "", true
 	}
-	cmd := exec.Command(gitPath, "tag", "--contains", hash, "--sort=creatordate")
-	cmd.Dir = dir
-	out, err := cmd.Output()
-	if err != nil {
-		return ""
+	out, answered := a.run(dir, "tag", "--contains", hash, "--sort=creatordate")
+	if !answered {
+		return "", false
 	}
 	for _, line := range strings.Split(string(out), "\n") {
 		line = strings.TrimSpace(line)
 		if releaseTagPattern.MatchString(line) {
-			return line
+			return line, true
 		}
 	}
-	return ""
+	return "", true
 }
 
 // GetGitRoot returns the absolute path of the git repo root for the given
-// directory, or "" if the directory is not inside a git repository.
-// For worktrees it returns the main repo root (not the worktree path).
-// If dir has been deleted (e.g. a cleaned-up worktree), it walks up to the
-// nearest existing ancestor so the repo can still be resolved.
-func (a *Adapter) GetGitRoot(dir string) string {
+// directory. For worktrees it returns the main repo root (not the worktree
+// path). If dir has been deleted (e.g. a cleaned-up worktree), it walks up to
+// the nearest existing ancestor so the repo can still be resolved.
+//
+// An empty root with answered=true means git ran and dir is not inside a
+// repository; answered=false means git could not be run, and reporting that to
+// a user as "project not found or not a git repository" is a second false
+// claim #1543 removes.
+func (a *Adapter) GetGitRoot(dir string) (string, bool) {
 	if dir == "" {
-		return ""
+		return "", true
 	}
 	dir = nearestExistingDir(dir)
 	if dir == "" {
-		return ""
+		return "", true
 	}
-	cmd := exec.Command(gitPath, gitRevParseCmd, "--path-format=absolute", "--git-common-dir")
-	cmd.Dir = dir
-	out, err := cmd.Output()
-	if err != nil {
-		return ""
+	out, answered := a.run(dir, gitRevParseCmd, "--path-format=absolute", "--git-common-dir")
+	if !answered {
+		return "", false
 	}
 	gitDir := strings.TrimSpace(string(out))
 	if gitDir == "" {
-		return ""
+		return "", true
 	}
 	// gitDir is e.g. "/Users/x/projects/irrlicht/.git"
 	root := filepath.Dir(gitDir)
 	if root == "" || root == "." || root == "/" {
-		return ""
+		return "", true
 	}
-	return root
+	return root, true
 }
 
 // nearestExistingDir returns dir if it exists, otherwise walks up to the
@@ -245,19 +398,28 @@ func nearestExistingDir(dir string) string {
 // It uses the git repo root directory name so that sessions in subdirectories
 // of the same repo share the same project name.
 // Falls back to filepath.Base(dir) if not inside a git repo.
-func (a *Adapter) GetProjectName(dir string) string {
-	if root := a.GetGitRoot(dir); root != "" {
-		return filepath.Base(root)
+//
+// It runs no child process of its own — the second return is GetGitRoot's,
+// forwarded. That forwarding is the point rather than bookkeeping: on a
+// non-answer the returned name is the directory basename, which for a worktree
+// is the WORKTREE's name rather than the repo's, and the one consumer that
+// caches this (filesystem.ConcurrencyTracker) memoises for the daemon's
+// lifetime. A guess cached forever as though it were resolved is the same
+// defect one layer up (#1528's "memoize a non-answer as a non-answer").
+func (a *Adapter) GetProjectName(dir string) (string, bool) {
+	root, answered := a.GetGitRoot(dir)
+	if root != "" {
+		return filepath.Base(root), answered
 	}
 	// Fallback for non-git directories.
 	if dir == "" {
-		return ""
+		return "", answered
 	}
 	name := filepath.Base(dir)
 	if name == "." || name == "/" || name == "" {
-		return ""
+		return "", answered
 	}
-	return name
+	return name, answered
 }
 
 // GetCWDFromTranscript extracts the working directory from a transcript file.

--- a/core/adapters/outbound/git/adapter.go
+++ b/core/adapters/outbound/git/adapter.go
@@ -62,6 +62,13 @@ const gitRevParseCmd = "rev-parse"
 // polarity; nothing here gates admission). UNVERIFIED: the scaling to a very
 // large repo is extrapolation from the numbers above (~810 bytes and ~16us of
 // `log` per commit), not a measurement on such a repo.
+//
+// It bounds ONE CALL, not one operation, and callers stack it: adoptGitMetadata
+// makes 2, RefreshOnActivity up to 3, and ComputeDoraMetrics
+// 1 + len(tags) + len(revertCandidates) — on a server whose WriteTimeout is
+// deliberately 0 (core/cmd/irrlichd/startup.go). A per-operation budget is a
+// larger change than #1543 and is not attempted here; what is fixed is that the
+// unbounded case is gone.
 const gitTimeout = 5 * time.Second
 
 // gitWaitDelay bounds the extra time a run waits for the child's output pipe
@@ -137,8 +144,10 @@ func (a *Adapter) run(dir string, args ...string) (out []byte, answered bool) {
 
 	cmd := a.cmd(ctx, dir, args...)
 	cmd.WaitDelay = gitWaitDelay
-	// Never inherit the daemon's stdin: a git that decided to prompt (a
-	// credential helper, a hook) would otherwise block until the ceiling.
+	// Explicit rather than load-bearing: a nil Stdin is already /dev/null, so
+	// os/exec never hands the daemon's own stdin to the child. Spelled out so
+	// a later edit does not "helpfully" wire one up — a git that decided to
+	// prompt (a credential helper, a hook) would then block until the ceiling.
 	cmd.Stdin = nil
 	var buf cappedBuffer
 	buf.limit = gitMaxOutput
@@ -153,16 +162,44 @@ func (a *Adapter) run(dir string, args ...string) (out []byte, answered bool) {
 	if buf.overflowed {
 		return nil, false
 	}
+	if err != nil {
+		// git RAN and reported a failure. That is an answer — "not a repo",
+		// "no such ref" — but its stdout is NOT the answer's content, and
+		// returning it is a defect in both directions:
+		//
+		//   - `git rev-parse HEAD` on an unborn branch exits 128 and writes
+		//     the literal string "HEAD" to STDOUT (measured, git 2.50.1 /
+		//     Apple Git-155, darwin/arm64). Forwarding that made
+		//     GetHeadCommit report "HEAD" as a commit SHA, which
+		//     CaptureYieldOnReady then persisted as YieldProductive.
+		//   - A `git log` that streams commits and then hits a fatal (a
+		//     corrupt object) exits 128 having already written a PREFIX of
+		//     the history. Forwarding it hands DORA a silently truncated
+		//     commit list — the exact harm gitMaxOutput's doc argues must
+		//     never happen, arriving through a different door.
+		//
+		// Discarding it restores what .Output()'s `if err != nil` arm did
+		// before #1543, while keeping the non-answer distinction that arm
+		// could not express.
+		return nil, true
+	}
 	return buf.buf, true
 }
 
-// cappedBuffer collects at most limit bytes and records that it stopped. It
-// never returns an error: exec's output-copying goroutine treats a write error
-// as fatal to the command, which would turn an overflow into a second, less
-// specific failure. run() reads overflowed instead.
+// cappedBuffer collects at most limit bytes and records whether anything was
+// DROPPED. It never returns an error: exec's output-copying goroutine treats a
+// write error as fatal to the command, which would turn an overflow into a
+// second, less specific failure. run() reads overflowed instead.
+//
+// seen counts every byte offered, not every byte kept, because those are the
+// same number until the cap is reached and only the first distinguishes "the
+// output is exactly the cap" from "the output was truncated". Keying on
+// len(buf) >= limit instead conflates them and turns a complete read of exactly
+// gitMaxOutput bytes into a false non-answer.
 type cappedBuffer struct {
 	limit      int
 	buf        []byte
+	seen       int
 	overflowed bool
 }
 
@@ -173,7 +210,8 @@ func (w *cappedBuffer) Write(p []byte) (int, error) {
 		}
 		w.buf = append(w.buf, p[:room]...)
 	}
-	if len(w.buf) >= w.limit {
+	w.seen += len(p)
+	if w.seen > w.limit {
 		w.overflowed = true
 	}
 	return len(p), nil

--- a/core/adapters/outbound/git/adapter_test.go
+++ b/core/adapters/outbound/git/adapter_test.go
@@ -46,14 +46,20 @@ func TestGetGitRoot_DeletedSubdir(t *testing.T) {
 	a := New()
 
 	// Existing dir works as before.
-	got := a.GetGitRoot(dir)
+	got, answered := a.GetGitRoot(dir)
+	if !answered {
+		t.Fatal("existing dir: git did not answer")
+	}
 	if got != dir {
 		t.Errorf("existing dir: got %q, want %q", got, dir)
 	}
 
 	// Deleted subdir resolves to the same repo root.
 	deleted := filepath.Join(dir, "nonexistent", "child")
-	got = a.GetGitRoot(deleted)
+	got, answered = a.GetGitRoot(deleted)
+	if !answered {
+		t.Fatal("deleted subdir: git did not answer")
+	}
 	if got != dir {
 		t.Errorf("deleted subdir: got %q, want %q", got, dir)
 	}
@@ -62,7 +68,10 @@ func TestGetGitRoot_DeletedSubdir(t *testing.T) {
 func TestGetGitRoot_NotARepo(t *testing.T) {
 	dir := t.TempDir()
 	a := New()
-	got := a.GetGitRoot(dir)
+	got, answered := a.GetGitRoot(dir)
+	if !answered {
+		t.Fatal("a non-repo dir is an ANSWER — git ran and reported exit 128 (#1543)")
+	}
 	if got != "" {
 		t.Errorf("non-repo dir: got %q, want empty", got)
 	}
@@ -92,7 +101,10 @@ func TestGetProjectName_DeletedWorktree(t *testing.T) {
 
 	a := New()
 	deleted := filepath.Join(repoDir, ".claude", "worktrees", "62")
-	got := a.GetProjectName(deleted)
+	got, answered := a.GetProjectName(deleted)
+	if !answered {
+		t.Fatal("git did not answer")
+	}
 	if got != "myproject" {
 		t.Errorf("got %q, want %q", got, "myproject")
 	}
@@ -133,13 +145,13 @@ func commitFileForTest(t *testing.T, dir, name, content string) string {
 
 func TestGetHeadCommit(t *testing.T) {
 	a := New()
-	if got := a.GetHeadCommit(t.TempDir()); got != "" {
-		t.Errorf("non-repo dir: got %q, want empty", got)
+	if got, answered := a.GetHeadCommit(t.TempDir()); got != "" || !answered {
+		t.Errorf("non-repo dir: got (%q, %v), want (\"\", true)", got, answered)
 	}
 	dir := gitInitForTest(t)
 	sha := commitFileForTest(t, dir, "a.txt", "hello")
-	if got := a.GetHeadCommit(dir); got != sha {
-		t.Errorf("got %q, want %q", got, sha)
+	if got, answered := a.GetHeadCommit(dir); got != sha || !answered {
+		t.Errorf("got (%q, %v), want (%q, true)", got, answered, sha)
 	}
 }
 
@@ -149,12 +161,15 @@ func TestRevertedCommits(t *testing.T) {
 	shaA := commitFileForTest(t, dir, "a.txt", "A")
 	commitFileForTest(t, dir, "b.txt", "B")
 
-	if got := a.RevertedCommits(dir); len(got) != 0 {
-		t.Fatalf("no reverts yet: got %v", got)
+	if got, answered := a.RevertedCommits(dir); len(got) != 0 || !answered {
+		t.Fatalf("no reverts yet: got (%v, %v)", got, answered)
 	}
 
 	runGitForTest(t, dir, "revert", "--no-edit", shaA)
-	got := a.RevertedCommits(dir)
+	got, answered := a.RevertedCommits(dir)
+	if !answered {
+		t.Fatal("git did not answer")
+	}
 	found := false
 	for _, s := range got {
 		if s == shaA {
@@ -165,8 +180,8 @@ func TestRevertedCommits(t *testing.T) {
 		t.Errorf("expected revert of %s in %v", shaA, got)
 	}
 
-	if r := a.RevertedCommits(t.TempDir()); r != nil {
-		t.Errorf("non-repo dir: want nil, got %v", r)
+	if r, answered := a.RevertedCommits(t.TempDir()); r != nil || !answered {
+		t.Errorf("non-repo dir: want (nil, true), got (%v, %v)", r, answered)
 	}
 }
 
@@ -217,14 +232,14 @@ func TestGetCWDFromTranscript_WrappedCodex(t *testing.T) {
 func TestListReleaseTags(t *testing.T) {
 	a := New()
 
-	if got := a.ListReleaseTags(t.TempDir()); got != nil {
-		t.Errorf("non-repo dir: want nil, got %v", got)
+	if got, answered := a.ListReleaseTags(t.TempDir()); got != nil || !answered {
+		t.Errorf("non-repo dir: want (nil, true), got (%v, %v)", got, answered)
 	}
 
 	dir := gitInitForTest(t)
 	commitFileForTest(t, dir, "a.txt", "A")
-	if got := a.ListReleaseTags(dir); got != nil {
-		t.Fatalf("no tags yet: want nil, got %v", got)
+	if got, answered := a.ListReleaseTags(dir); got != nil || !answered {
+		t.Fatalf("no tags yet: want (nil, true), got (%v, %v)", got, answered)
 	}
 
 	runGitForTest(t, dir, "tag", "v0.1.0")
@@ -232,7 +247,10 @@ func TestListReleaseTags(t *testing.T) {
 	commitFileForTest(t, dir, "b.txt", "B")
 	runGitForTest(t, dir, "tag", "v0.2.0")
 
-	got := a.ListReleaseTags(dir)
+	got, answered := a.ListReleaseTags(dir)
+	if !answered {
+		t.Fatal("git did not answer")
+	}
 	if len(got) != 2 {
 		t.Fatalf("got %d tags, want 2 (non-release tag must be filtered): %+v", len(got), got)
 	}
@@ -247,8 +265,8 @@ func TestListReleaseTags(t *testing.T) {
 func TestCommitsInRange(t *testing.T) {
 	a := New()
 
-	if got := a.CommitsInRange(t.TempDir(), "", "HEAD"); got != nil {
-		t.Errorf("non-repo dir: want nil, got %v", got)
+	if got, answered := a.CommitsInRange(t.TempDir(), "", "HEAD"); got != nil || !answered {
+		t.Errorf("non-repo dir: want (nil, true), got (%v, %v)", got, answered)
 	}
 
 	dir := gitInitForTest(t)
@@ -265,12 +283,18 @@ func TestCommitsInRange(t *testing.T) {
 	shaB := runGitForTest(t, dir, "rev-parse", "HEAD")
 	runGitForTest(t, dir, "tag", "v0.2.0")
 
-	oldest := a.CommitsInRange(dir, "", "v0.1.0")
+	oldest, answered := a.CommitsInRange(dir, "", "v0.1.0")
+	if !answered {
+		t.Fatal("git did not answer for the oldest tag")
+	}
 	if len(oldest) != 1 || oldest[0].Hash != shaA {
 		t.Fatalf("oldest tag (no predecessor): got %+v, want just %s", oldest, shaA)
 	}
 
-	between := a.CommitsInRange(dir, "v0.1.0", "v0.2.0")
+	between, answered := a.CommitsInRange(dir, "v0.1.0", "v0.2.0")
+	if !answered {
+		t.Fatal("git did not answer for the range")
+	}
 	if len(between) != 1 || between[0].Hash != shaB {
 		t.Fatalf("v0.1.0..v0.2.0: got %+v, want just %s", between, shaB)
 	}
@@ -278,16 +302,16 @@ func TestCommitsInRange(t *testing.T) {
 		t.Fatalf("multi-line body not preserved: %q", between[0].Body)
 	}
 
-	if got := a.CommitsInRange(dir, "v0.2.0", "v0.2.0"); got != nil {
-		t.Fatalf("empty range: want nil, got %v", got)
+	if got, answered := a.CommitsInRange(dir, "v0.2.0", "v0.2.0"); got != nil || !answered {
+		t.Fatalf("empty range: want (nil, true), got (%v, %v)", got, answered)
 	}
 }
 
 func TestTagContaining(t *testing.T) {
 	a := New()
 
-	if got := a.TagContaining(t.TempDir(), "deadbeef"); got != "" {
-		t.Errorf("non-repo dir: want empty, got %q", got)
+	if got, answered := a.TagContaining(t.TempDir(), "deadbeef"); got != "" || !answered {
+		t.Errorf("non-repo dir: want (\"\", true), got (%q, %v)", got, answered)
 	}
 
 	dir := gitInitForTest(t)
@@ -296,10 +320,12 @@ func TestTagContaining(t *testing.T) {
 	commitFileForTest(t, dir, "b.txt", "B")
 	runGitForTest(t, dir, "tag", "v0.2.0")
 
-	if got := a.TagContaining(dir, shaA); got != "v0.1.0" {
-		t.Errorf("got %q, want v0.1.0 (earliest tag containing the first commit)", got)
+	if got, answered := a.TagContaining(dir, shaA); got != "v0.1.0" || !answered {
+		t.Errorf("got (%q, %v), want (v0.1.0, true) — earliest tag containing the first commit", got, answered)
 	}
-	if got := a.TagContaining(dir, "0000000000000000000000000000000000000000"); got != "" {
-		t.Errorf("unknown hash: want empty, got %q", got)
+	// An object name git cannot resolve exits 129 (measured, git 2.50.1) —
+	// still an ANSWER: git ran and told us no release contains it.
+	if got, answered := a.TagContaining(dir, "0000000000000000000000000000000000000000"); got != "" || !answered {
+		t.Errorf("unknown hash: want (\"\", true), got (%q, %v)", got, answered)
 	}
 }

--- a/core/adapters/outbound/git/shellout_test.go
+++ b/core/adapters/outbound/git/shellout_test.go
@@ -1,0 +1,476 @@
+package git
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+// This file covers the two halves of #1543, and they need different evidence.
+//
+// The COLLAPSE is a pre-existing defect: before the fix, "git could not be run"
+// and "this directory is not a repo" both arrived as "". Its test was seen red
+// against the unmodified adapter — the failure is in the PR body.
+//
+// The BOUND is new, so there is no "before the fix" to run it against. Its
+// tests owe a deliberate mutation instead: removing the ceiling, or widening it
+// past the fixture's stall, and confirming they go red. Both mutations were
+// run; what each reported is recorded on the test it breaks.
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+// stalledGit is a child that runs past the ceiling without ever answering.
+//
+// /bin/sleep rather than a script the test writes, for the reason
+// processlifecycle's stalledChild records: the first exec of a newly created
+// file is code-signature-evaluated on macOS (measured at 2.14s there), which
+// would make a bound test slow for a reason unrelated to the bound.
+func stalledGit(ctx context.Context, _ string, _ ...string) *exec.Cmd {
+	return exec.CommandContext(ctx, "/bin/sleep", "30")
+}
+
+// orphanHoldingStdout exits promptly but leaves a background child holding the
+// stdout pipe. This is what WaitDelay exists for, and the ceiling does NOT
+// cover it: the deadline never fires because the process the context knows
+// about has already exited.
+//
+// Measured on this machine (go1.25 darwin/arm64, 2s ceiling) — the numbers the
+// mutation evidence on TestOrphanHoldingStdoutIsANonAnswer refers to:
+//
+//	with WaitDelay:     500ms, err = "exec: WaitDelay expired before I/O complete"
+//	without WaitDelay:  30.01s, err = NIL
+//
+// The second row is why this fixture is here rather than only a hang test. A
+// nil error is an ANSWER, so without WaitDelay the adapter does not merely
+// block for the orphan's whole lifetime — it then reports whatever partial
+// output it collected as a complete, successful read.
+func orphanHoldingStdout(ctx context.Context, _ string, _ ...string) *exec.Cmd {
+	return exec.CommandContext(ctx, "/bin/sh", "-c", "sleep 30 & echo hi")
+}
+
+// missingGit is a binary that does not exist: the child never starts, so there
+// is no exit status at all. shellout.Answered reports it as a non-answer
+// because the error is not an *exec.ExitError.
+func missingGit(ctx context.Context, _ string, _ ...string) *exec.Cmd {
+	return exec.CommandContext(ctx, "/nonexistent/irrlicht-no-such-git-1543")
+}
+
+// floodingGit writes past gitMaxOutput and exits 0 — an answer by exit status
+// whose output cannot be held. It writes a bounded amount and exits rather
+// than streaming forever (`yes`), so the test costs one pipe copy instead of
+// the whole ceiling; what is under test is the cap, not the ceiling.
+func floodingGit(ctx context.Context, _ string, _ ...string) *exec.Cmd {
+	over := strconv.Itoa(gitMaxOutput + 1<<20)
+	return exec.CommandContext(ctx, "/bin/sh", "-c", "head -c "+over+" /dev/zero")
+}
+
+// withCmd returns an adapter whose git is build. Every method routes through
+// Adapter.run, so one seam covers all seven shellouts.
+func withCmd(build gitCmd) *Adapter { return &Adapter{cmd: build} }
+
+// ---------------------------------------------------------------------------
+// The collapse (#1543 defect 1)
+// ---------------------------------------------------------------------------
+
+// TestNonAnswerIsDistinguishableFromAGenuineMiss is the defect test, in the
+// form it takes now that the adapter can express the distinction. Its pre-fix
+// form asserted the only thing a single-return API allowed — that the two
+// situations must not produce the same value — and failed:
+//
+//	GetBranch: a git that could not be RUN ("") is indistinguishable from a
+//	directory that genuinely is not a repo ("") — #1543
+//
+// A real repo is used for the non-answer arm on purpose: the branch IS
+// resolvable, so an empty result cannot be excused as "there was nothing".
+func TestNonAnswerIsDistinguishableFromAGenuineMiss(t *testing.T) {
+	realRepo := gitInitForTest(t)
+	commitFileForTest(t, realRepo, "a.txt", "A")
+	notARepo := t.TempDir()
+
+	// A genuine miss: git runs fine and reports that this is not a repo.
+	branch, answered := New().GetBranch(notARepo)
+	if !answered {
+		t.Fatal("a directory that is not a repo is an ANSWER — git exits 128 and has said so")
+	}
+	if branch != "" {
+		t.Errorf("non-repo: got branch %q, want empty", branch)
+	}
+
+	// A non-answer: git cannot be run at all.
+	branch, answered = withCmd(missingGit).GetBranch(realRepo)
+	if answered {
+		t.Error("a git that never started was reported as an answer; \"\" would then " +
+			"mean \"this repo has no branch\", which is #1543")
+	}
+	if branch != "" {
+		t.Errorf("non-answer: got branch %q, want empty", branch)
+	}
+}
+
+// TestEveryShelloutReportsANonAnswer walks all seven. The vacuity guard is the
+// second half of each row: the same call against a real repo must ANSWER, or a
+// method that reported false unconditionally would pass the first half.
+func TestEveryShelloutReportsANonAnswer(t *testing.T) {
+	repo := gitInitForTest(t)
+	sha := commitFileForTest(t, repo, "a.txt", "A")
+	runGitForTest(t, repo, "tag", "v0.1.0")
+
+	broken, working := withCmd(missingGit), New()
+
+	cases := []struct {
+		name    string
+		unread  func(*Adapter) bool // reports the adapter's answered bit
+		wantVal string              // description of what the zero value would have meant
+	}{
+		{"GetBranch", func(a *Adapter) bool { _, ok := a.GetBranch(repo); return ok },
+			"detached HEAD"},
+		{"GetHeadCommit", func(a *Adapter) bool { _, ok := a.GetHeadCommit(repo); return ok },
+			"not a git repo (persisted as YieldUnknown)"},
+		{"RevertedCommits", func(a *Adapter) bool { _, ok := a.RevertedCommits(repo); return ok },
+			"this repo has no reverts"},
+		{"ListReleaseTags", func(a *Adapter) bool { _, ok := a.ListReleaseTags(repo); return ok },
+			"no releases found for this project"},
+		{"CommitsInRange", func(a *Adapter) bool { _, ok := a.CommitsInRange(repo, "", "v0.1.0"); return ok },
+			"this release shipped no commits"},
+		{"TagContaining", func(a *Adapter) bool { _, ok := a.TagContaining(repo, sha); return ok },
+			"this commit was never released (which LOWERS change failure rate)"},
+		{"GetGitRoot", func(a *Adapter) bool { _, ok := a.GetGitRoot(repo); return ok },
+			"project not found or not a git repository"},
+		{"GetProjectName", func(a *Adapter) bool { _, ok := a.GetProjectName(repo); return ok },
+			"the directory basename, cached for the daemon's lifetime"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.unread(broken) {
+				t.Errorf("a git that never started was reported as an answer; its zero value "+
+					"would then mean %q", tc.wantVal)
+			}
+			// Vacuity guard: without this, a method hard-coded to report
+			// "never answered" passes the arm above.
+			if !tc.unread(working) {
+				t.Error("a real git against a real repo was reported as a non-answer")
+			}
+		})
+	}
+}
+
+// TestNotARepoIsAnAnswer is the other direction, and it is the arm that keeps
+// the fix from being "report a non-answer whenever anything is empty". Every
+// exit status git produces on its own is an answer: measured on git 2.50.1
+// (Apple Git-155, darwin/arm64), not-a-repo is 128, an unborn branch's
+// rev-parse is 128, a range naming an unknown ref is 128, and `tag --contains`
+// with an unresolvable object name is 129.
+func TestNotARepoIsAnAnswer(t *testing.T) {
+	notARepo := t.TempDir()
+	unborn := realPath(t, t.TempDir())
+	runGitForTest(t, unborn, "init")
+	repo := gitInitForTest(t)
+	commitFileForTest(t, repo, "a.txt", "A")
+
+	a := New()
+	cases := []struct {
+		name string
+		ok   func() bool
+	}{
+		{"not a repo/GetBranch", func() bool { _, ok := a.GetBranch(notARepo); return ok }},
+		{"not a repo/GetHeadCommit", func() bool { _, ok := a.GetHeadCommit(notARepo); return ok }},
+		{"not a repo/RevertedCommits", func() bool { _, ok := a.RevertedCommits(notARepo); return ok }},
+		{"not a repo/ListReleaseTags", func() bool { _, ok := a.ListReleaseTags(notARepo); return ok }},
+		{"not a repo/TagContaining", func() bool { _, ok := a.TagContaining(notARepo, "deadbeef"); return ok }},
+		{"not a repo/GetGitRoot", func() bool { _, ok := a.GetGitRoot(notARepo); return ok }},
+		{"unborn branch/GetHeadCommit", func() bool { _, ok := a.GetHeadCommit(unborn); return ok }},
+		{"unborn branch/RevertedCommits", func() bool { _, ok := a.RevertedCommits(unborn); return ok }},
+		{"unresolvable object/TagContaining", func() bool { _, ok := a.TagContaining(repo, "deadbeef"); return ok }},
+		{"unknown ref range/CommitsInRange", func() bool { _, ok := a.CommitsInRange(repo, "v9.9.9", "v9.9.8"); return ok }},
+	}
+	for _, tc := range cases {
+		if !tc.ok() {
+			t.Errorf("%s: reported as a non-answer, but git RAN and said so — reporting it "+
+				"as unread would blank a chart that should read \"not a git repository\"", tc.name)
+		}
+	}
+}
+
+// TestNothingAskedIsNotANonAnswer pins the early-return guards. An empty dir
+// starts no child, so nothing failed — the reading processTTYVia gives a
+// non-positive pid.
+func TestNothingAskedIsNotANonAnswer(t *testing.T) {
+	a := withCmd(func(context.Context, string, ...string) *exec.Cmd {
+		t.Fatal("no child process should be started when there is nothing to ask about")
+		return nil
+	})
+	checks := []struct {
+		name string
+		ok   bool
+	}{
+		{"GetBranch", second(a.GetBranch(""))},
+		{"GetHeadCommit", second(a.GetHeadCommit(""))},
+		{"GetGitRoot", second(a.GetGitRoot(""))},
+		{"GetProjectName", second(a.GetProjectName(""))},
+		{"TagContaining/no hash", second(a.TagContaining("/tmp", ""))},
+	}
+	for _, c := range checks {
+		if !c.ok {
+			t.Errorf("%s: an unasked question was reported as a non-answer", c.name)
+		}
+	}
+	if _, ok := a.RevertedCommits(""); !ok {
+		t.Error("RevertedCommits: an unasked question was reported as a non-answer")
+	}
+	if _, ok := a.ListReleaseTags(""); !ok {
+		t.Error("ListReleaseTags: an unasked question was reported as a non-answer")
+	}
+	if _, ok := a.CommitsInRange("", "", ""); !ok {
+		t.Error("CommitsInRange: an unasked question was reported as a non-answer")
+	}
+}
+
+func second(_ string, ok bool) bool { return ok }
+
+// ---------------------------------------------------------------------------
+// The bound (#1543 defect 2)
+// ---------------------------------------------------------------------------
+
+// TestRunCeilingActuallyFires is the bound's own test, and it is the one that
+// owes a mutation rather than a red-first run — before this change there was no
+// ceiling to test.
+//
+// MUTATION EVIDENCE (both run, both red):
+//
+//   - Replacing context.WithTimeout(…, gitTimeout) in Adapter.run with
+//     context.Background(): this test does not fail, it HANGS — the run never
+//     returns, and `go test` kills the package at its own 10-minute timeout
+//     with `panic: test timed out after 10m0s`. That is the unbounded adapter,
+//     reproduced.
+//   - Widening gitTimeout to 60s: fails on the elapsed assertion, reporting
+//     ~30s against a half-ceiling of 30s.
+//
+// The elapsed bound is gitTimeout+gitWaitDelay+slack rather than exactly
+// gitTimeout: the child is SIGKILLed at the deadline and exec then waits up to
+// WaitDelay for the output pipe.
+func TestRunCeilingActuallyFires(t *testing.T) {
+	t.Parallel()
+
+	start := time.Now()
+	_, answered := withCmd(stalledGit).GetBranch("/tmp")
+	elapsed := time.Since(start)
+
+	if answered {
+		t.Error("a child killed by the ceiling was reported as an answer — the empty branch " +
+			"would then mean \"detached HEAD\"")
+	}
+	if elapsed < gitTimeout/2 {
+		t.Errorf("returned after %v, well under the %v ceiling: the child cannot have been "+
+			"the 30s sleep this test arranges, so the ceiling is not what stopped it", elapsed, gitTimeout)
+	}
+	if limit := gitTimeout + gitWaitDelay + 2*time.Second; elapsed > limit {
+		t.Errorf("took %v against a %v ceiling (+%v WaitDelay); the bound did not fire",
+			elapsed, gitTimeout, gitWaitDelay)
+	}
+}
+
+// TestOrphanHoldingStdoutIsANonAnswer is WaitDelay's own arm, and it covers a
+// failure the ceiling cannot: the child exits promptly, so the deadline never
+// fires, but a grandchild that inherited the stdout pipe holds it open and
+// exec keeps waiting for an EOF that does not come. git spawns such children
+// routinely — a credential helper, an fsmonitor daemon, a pager forced on by
+// global config.
+//
+// MUTATION EVIDENCE: deleting `cmd.WaitDelay = gitWaitDelay` from Adapter.run
+// makes this fail on BOTH assertions, and the first is the one worth having.
+// Measured directly (go1.25 darwin/arm64): without WaitDelay the call returns
+// after 30.01s with err == NIL — so the adapter does not just block, it then
+// reports the orphan's partial output as a complete successful read. With
+// WaitDelay it returns in 500ms with "exec: WaitDelay expired before I/O
+// complete", which is not an *exec.ExitError and so is correctly a non-answer.
+func TestOrphanHoldingStdoutIsANonAnswer(t *testing.T) {
+	t.Parallel()
+
+	start := time.Now()
+	_, answered := withCmd(orphanHoldingStdout).GetHeadCommit("/tmp")
+	elapsed := time.Since(start)
+
+	if answered {
+		t.Error("a read that never saw EOF was reported as an answer; whatever partial " +
+			"output it collected would be published as the whole of it")
+	}
+	if limit := gitWaitDelay + 2*time.Second; elapsed > limit {
+		t.Errorf("took %v; WaitDelay (%v) is supposed to bound exactly this, and the "+
+			"ceiling cannot — the process the context knows about exited immediately",
+			elapsed, gitWaitDelay)
+	}
+}
+
+// TestMissingBinaryFailsImmediately pins the most common real-world
+// non-answer, and pins that it costs nothing: the daemon runs under launchd
+// with a minimal PATH, and pathutil.MustResolve falls back to the bare name
+// when git is not in a trusted directory. That must fail before anything is
+// spawned rather than waiting out gitTimeout.
+func TestMissingBinaryFailsImmediately(t *testing.T) {
+	t.Parallel()
+
+	start := time.Now()
+	_, answered := withCmd(missingGit).GetGitRoot("/tmp")
+	elapsed := time.Since(start)
+
+	if answered {
+		t.Error("a binary that does not exist was reported as an answer")
+	}
+	if elapsed > gitTimeout/2 {
+		t.Errorf("took %v for a missing binary; the PATH lookup should fail before anything "+
+			"is spawned, well inside the %v budget", elapsed, gitTimeout)
+	}
+}
+
+// TestFloodingChildIsBoundedAndReportsANonAnswer covers gitMaxOutput, and the
+// polarity is the point. cliprobe TRUNCATES on overflow, because a truncated
+// version banner still contains the version. Here truncation would silently
+// drop commits and releases, and DORA would publish the surviving subset as
+// Available:true — a biased median is harder to notice than a blank chart.
+//
+// MUTATION EVIDENCE (both run, both red):
+//
+//   - Dropping the `if buf.overflowed { return nil, false }` arm from
+//     Adapter.run: fails with "a truncated read was reported as an answer".
+//   - Removing the cap itself (cappedBuffer replaced by a plain bytes.Buffer):
+//     fails the same assertion, because the whole 65 MiB is then accepted as
+//     an answer. That is the mutation that matters for memory — the fixture
+//     writes a bounded amount so the test stays cheap, but production has no
+//     such courtesy and a 1M-commit `git log` is measured below at ~810 MB.
+func TestFloodingChildIsBoundedAndReportsANonAnswer(t *testing.T) {
+	t.Parallel()
+
+	start := time.Now()
+	_, answered := withCmd(floodingGit).RevertedCommits("/tmp")
+	elapsed := time.Since(start)
+
+	if answered {
+		t.Error("a truncated read was reported as an answer; the surviving commits would " +
+			"then be published as if they were all of them")
+	}
+	if limit := gitTimeout + gitWaitDelay + 2*time.Second; elapsed > limit {
+		t.Errorf("took %v against a %v ceiling; the flood was not bounded", elapsed, gitTimeout)
+	}
+}
+
+// TestUnderTheCapIsStillAnAnswer is the cap's vacuity guard: without it, a run
+// that reported every read as truncated would satisfy the arm above. It also
+// pins that the boundary is not off by one in the direction that blinds the
+// adapter — a read of exactly the cap is not an overflow of it.
+func TestUnderTheCapIsStillAnAnswer(t *testing.T) {
+	t.Parallel()
+
+	build := func(n int) gitCmd {
+		return func(ctx context.Context, _ string, _ ...string) *exec.Cmd {
+			return exec.CommandContext(ctx, "/bin/sh", "-c", "head -c "+strconv.Itoa(n)+" /dev/zero")
+		}
+	}
+	for _, n := range []int{1 << 10, gitMaxOutput - 1} {
+		out, answered := withCmd(build(n)).run("/tmp", "irrelevant")
+		if !answered {
+			t.Errorf("%d bytes, under the %d-byte cap, was reported as a non-answer", n, gitMaxOutput)
+		}
+		if len(out) != n {
+			t.Errorf("%d bytes written, %d kept", n, len(out))
+		}
+	}
+}
+
+// TestCappedBufferStopsAtItsLimit is the unit half of the arm above, so a
+// change to gitMaxOutput's enforcement is caught without spawning `yes`.
+func TestCappedBufferStopsAtItsLimit(t *testing.T) {
+	var w cappedBuffer
+	w.limit = 8
+
+	if n, err := w.Write([]byte("abc")); n != 3 || err != nil {
+		t.Fatalf("Write = (%d, %v), want (3, nil)", n, err)
+	}
+	if w.overflowed {
+		t.Error("3 bytes into a limit of 8 reported an overflow")
+	}
+	// Reports the full length even past the limit: returning short would make
+	// exec's copier treat it as a write error and fail the command for the
+	// wrong reason.
+	if n, err := w.Write([]byte("defghijkl")); n != 9 || err != nil {
+		t.Fatalf("Write past the limit = (%d, %v), want (9, nil)", n, err)
+	}
+	if !w.overflowed {
+		t.Error("writing past the limit did not record an overflow")
+	}
+	if len(w.buf) != 8 {
+		t.Errorf("kept %d bytes, want the limit of 8", len(w.buf))
+	}
+	if string(w.buf) != "abcdefgh" {
+		t.Errorf("kept %q, want the FIRST 8 bytes", w.buf)
+	}
+}
+
+// TestProductionAdapterIsBounded is the wiring arm. Every test above builds an
+// Adapter with an injected command, so none of them proves the adapter New()
+// returns has a ceiling — which is the shape #1390 removed from the path
+// confinement contract for the same reason. gitPath is a package var, so the
+// production builder can be pointed at a real stalling binary without an
+// injected gitCmd.
+func TestProductionAdapterIsBounded(t *testing.T) {
+	t.Parallel()
+
+	// A script rather than /bin/sleep directly: the adapter's argv is git's
+	// ("rev-parse", "HEAD"), which sleep rejects as a duration and exits on
+	// immediately. The script ignores its arguments and stalls, which is what
+	// this needs to observe.
+	stub := filepath.Join(t.TempDir(), "git")
+	if err := os.WriteFile(stub, []byte("#!/bin/sh\nexec sleep 30\n"), 0o755); err != nil {
+		t.Fatalf("write stub: %v", err)
+	}
+	// Pay macOS's first-exec code-signature evaluation (measured at 2.14s in
+	// #1524) OUTSIDE the measurement, so it cannot be mistaken for the
+	// ceiling, and so it cannot push a legitimate run past the assertion.
+	warm := exec.Command(stub)
+	_ = warm.Start()
+	if warm.Process != nil {
+		_ = warm.Process.Kill()
+		_ = warm.Wait()
+	}
+
+	saved := gitPath
+	gitPath = stub
+	t.Cleanup(func() { gitPath = saved })
+
+	start := time.Now()
+	_, answered := New().GetHeadCommit(t.TempDir())
+	elapsed := time.Since(start)
+
+	if answered {
+		t.Error("the production adapter reported an answer from a child it had to kill")
+	}
+	if elapsed < gitTimeout/2 {
+		t.Errorf("returned after %v, far under the %v ceiling — the stub cannot have run, "+
+			"so this proves nothing about the production path", elapsed, gitTimeout)
+	}
+	if limit := gitTimeout + gitWaitDelay + 3*time.Second; elapsed > limit {
+		t.Errorf("the production adapter took %v; New() is not running under gitTimeout", elapsed)
+	}
+}
+
+// TestGitPathIsResolvedNotInherited pins go:S4036 — the adapter must not run
+// whatever "git" the inherited PATH happens to resolve to.
+func TestGitPathIsResolvedNotInherited(t *testing.T) {
+	if gitPath == "git" {
+		t.Skip("git is not under a trusted directory on this machine; pathutil fell back " +
+			"to a PATH lookup, which is MustResolve's documented degradation")
+	}
+	if !filepath.IsAbs(gitPath) {
+		t.Errorf("gitPath = %q, want an absolute path under a trusted directory", gitPath)
+	}
+	if strings.Contains(gitPath, "..") {
+		t.Errorf("gitPath = %q contains a traversal", gitPath)
+	}
+}

--- a/core/adapters/outbound/git/shellout_test.go
+++ b/core/adapters/outbound/git/shellout_test.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"irrlicht/core/pkg/shellout"
 )
 
 // This file covers the two halves of #1543, and they need different evidence.
@@ -71,9 +73,23 @@ func floodingGit(ctx context.Context, _ string, _ ...string) *exec.Cmd {
 	return exec.CommandContext(ctx, "/bin/sh", "-c", "head -c "+over+" /dev/zero")
 }
 
-// withCmd returns an adapter whose git is build. Every method routes through
-// Adapter.run, so one seam covers all seven shellouts.
-func withCmd(build gitCmd) *Adapter { return &Adapter{cmd: build} }
+// withCmd returns an adapter whose git is build, under the production ceiling.
+// Every method routes through Adapter.run, so one seam covers all seven
+// shellouts.
+func withCmd(build gitCmd) *Adapter { return &Adapter{cmd: build, timeout: gitTimeout} }
+
+// withCeiling is withCmd under a SHORT ceiling, for the tests whose subject is
+// the ceiling firing rather than its value. Waiting out the real 5s twice is
+// the package's slowest and most load-sensitive cost, and neither test learns
+// anything from the extra 4.9s. The real constant stays proven by
+// TestProductionAdapterIsBounded, which goes through New().
+func withCeiling(build gitCmd, d time.Duration) *Adapter {
+	return &Adapter{cmd: build, timeout: d}
+}
+
+// testCeiling is short enough to keep the suite fast and long enough that a
+// loaded machine still starts the child before it fires.
+const testCeiling = 300 * time.Millisecond
 
 // ---------------------------------------------------------------------------
 // The collapse (#1543 defect 1)
@@ -255,27 +271,27 @@ func second(_ string, ok bool) bool { return ok }
 //   - Widening gitTimeout to 60s: fails on the elapsed assertion, reporting
 //     ~30s against a half-ceiling of 30s.
 //
-// The elapsed bound is gitTimeout+gitWaitDelay+slack rather than exactly
+// The elapsed bound is gitTimeout+shellout.WaitDelay+slack rather than exactly
 // gitTimeout: the child is SIGKILLed at the deadline and exec then waits up to
 // WaitDelay for the output pipe.
 func TestRunCeilingActuallyFires(t *testing.T) {
 	t.Parallel()
 
 	start := time.Now()
-	_, answered := withCmd(stalledGit).GetBranch("/tmp")
+	_, answered := withCeiling(stalledGit, testCeiling).GetBranch("/tmp")
 	elapsed := time.Since(start)
 
 	if answered {
 		t.Error("a child killed by the ceiling was reported as an answer — the empty branch " +
 			"would then mean \"detached HEAD\"")
 	}
-	if elapsed < gitTimeout/2 {
+	if elapsed < testCeiling/2 {
 		t.Errorf("returned after %v, well under the %v ceiling: the child cannot have been "+
-			"the 30s sleep this test arranges, so the ceiling is not what stopped it", elapsed, gitTimeout)
+			"the 30s sleep this test arranges, so the ceiling is not what stopped it", elapsed, testCeiling)
 	}
-	if limit := gitTimeout + gitWaitDelay + 2*time.Second; elapsed > limit {
+	if limit := testCeiling + shellout.WaitDelay + 5*time.Second; elapsed > limit {
 		t.Errorf("took %v against a %v ceiling (+%v WaitDelay); the bound did not fire",
-			elapsed, gitTimeout, gitWaitDelay)
+			elapsed, testCeiling, shellout.WaitDelay)
 	}
 }
 
@@ -286,7 +302,7 @@ func TestRunCeilingActuallyFires(t *testing.T) {
 // routinely — a credential helper, an fsmonitor daemon, a pager forced on by
 // global config.
 //
-// MUTATION EVIDENCE: deleting `cmd.WaitDelay = gitWaitDelay` from Adapter.run
+// MUTATION EVIDENCE: deleting `cmd.WaitDelay = shellout.WaitDelay` from Adapter.run
 // makes this fail on BOTH assertions, and the first is the one worth having.
 // Measured directly (go1.25 darwin/arm64): without WaitDelay the call returns
 // after 30.01s with err == NIL — so the adapter does not just block, it then
@@ -297,17 +313,17 @@ func TestOrphanHoldingStdoutIsANonAnswer(t *testing.T) {
 	t.Parallel()
 
 	start := time.Now()
-	_, answered := withCmd(orphanHoldingStdout).GetHeadCommit("/tmp")
+	_, answered := withCeiling(orphanHoldingStdout, testCeiling).GetHeadCommit("/tmp")
 	elapsed := time.Since(start)
 
 	if answered {
 		t.Error("a read that never saw EOF was reported as an answer; whatever partial " +
 			"output it collected would be published as the whole of it")
 	}
-	if limit := gitWaitDelay + 2*time.Second; elapsed > limit {
+	if limit := shellout.WaitDelay + 2*time.Second; elapsed > limit {
 		t.Errorf("took %v; WaitDelay (%v) is supposed to bound exactly this, and the "+
 			"ceiling cannot — the process the context knows about exited immediately",
-			elapsed, gitWaitDelay)
+			elapsed, shellout.WaitDelay)
 	}
 }
 
@@ -320,15 +336,15 @@ func TestMissingBinaryFailsImmediately(t *testing.T) {
 	t.Parallel()
 
 	start := time.Now()
-	_, answered := withCmd(missingGit).GetGitRoot("/tmp")
+	_, answered := withCeiling(missingGit, testCeiling).GetGitRoot("/tmp")
 	elapsed := time.Since(start)
 
 	if answered {
 		t.Error("a binary that does not exist was reported as an answer")
 	}
-	if elapsed > gitTimeout/2 {
+	if elapsed > testCeiling/2 {
 		t.Errorf("took %v for a missing binary; the PATH lookup should fail before anything "+
-			"is spawned, well inside the %v budget", elapsed, gitTimeout)
+			"is spawned, well inside the %v budget", elapsed, testCeiling)
 	}
 }
 
@@ -351,15 +367,15 @@ func TestFloodingChildIsBoundedAndReportsANonAnswer(t *testing.T) {
 	t.Parallel()
 
 	start := time.Now()
-	_, answered := withCmd(floodingGit).RevertedCommits("/tmp")
+	_, answered := withCeiling(floodingGit, testCeiling).RevertedCommits("/tmp")
 	elapsed := time.Since(start)
 
 	if answered {
 		t.Error("a truncated read was reported as an answer; the surviving commits would " +
 			"then be published as if they were all of them")
 	}
-	if limit := gitTimeout + gitWaitDelay + 2*time.Second; elapsed > limit {
-		t.Errorf("took %v against a %v ceiling; the flood was not bounded", elapsed, gitTimeout)
+	if limit := testCeiling + shellout.WaitDelay + 5*time.Second; elapsed > limit {
+		t.Errorf("took %v against a %v ceiling; the flood was not bounded", elapsed, testCeiling)
 	}
 }
 
@@ -375,12 +391,12 @@ func TestUnderTheCapIsStillAnAnswer(t *testing.T) {
 			return exec.CommandContext(ctx, "/bin/sh", "-c", "head -c "+strconv.Itoa(n)+" /dev/zero")
 		}
 	}
-	// gitMaxOutput itself is the row that matters: the previous spelling
-	// (len(buf) >= limit) fired when the buffer merely REACHED the cap with
-	// nothing dropped, so a complete read of exactly gitMaxOutput bytes was a
-	// false non-answer. The table used to stop at gitMaxOutput-1 while its
-	// comment claimed to pin the boundary.
-	for _, n := range []int{1 << 10, gitMaxOutput - 1, gitMaxOutput} {
+	// gitMaxOutput itself is the row that matters, and it is the one this
+	// test adds over shellout.CappedBuffer's unit tests: it pins that run()
+	// wires the REAL constant, not just that the buffer's arithmetic is right.
+	// A gitMaxOutput-1 row would cost a second 64 MiB pipe copy to assert what
+	// TestCappedBufferStopsAtItsLimit already pins at Limit: 8.
+	for _, n := range []int{1 << 10, gitMaxOutput} {
 		out, answered := withCmd(build(n)).run("/tmp", "irrelevant")
 		if !answered {
 			t.Errorf("%d bytes, under the %d-byte cap, was reported as a non-answer", n, gitMaxOutput)
@@ -486,47 +502,6 @@ func TestASuccessfulGitStillReturnsItsOutput(t *testing.T) {
 	}
 }
 
-// TestCappedBufferStopsAtItsLimit is the unit half of the arm above, so a
-// change to gitMaxOutput's enforcement is caught without spawning `yes`.
-func TestCappedBufferStopsAtItsLimit(t *testing.T) {
-	var w cappedBuffer
-	w.limit = 8
-
-	if n, err := w.Write([]byte("abc")); n != 3 || err != nil {
-		t.Fatalf("Write = (%d, %v), want (3, nil)", n, err)
-	}
-	if w.overflowed {
-		t.Error("3 bytes into a limit of 8 reported an overflow")
-	}
-	// Exactly the limit is NOT an overflow: nothing was dropped. The previous
-	// spelling keyed on len(buf) >= limit and reported one here.
-	if n, err := w.Write([]byte("defgh")); n != 5 || err != nil {
-		t.Fatalf("Write to exactly the limit = (%d, %v), want (5, nil)", n, err)
-	}
-	if w.overflowed {
-		t.Error("a complete read of exactly the limit was reported as truncated — that is a " +
-			"false non-answer, and it blanks a chart the daemon read successfully")
-	}
-	if string(w.buf) != "abcdefgh" {
-		t.Fatalf("kept %q, want abcdefgh", w.buf)
-	}
-	// Reports the full length even past the limit: returning short would make
-	// exec's copier treat it as a write error and fail the command for the
-	// wrong reason.
-	if n, err := w.Write([]byte("i")); n != 1 || err != nil {
-		t.Fatalf("Write past the limit = (%d, %v), want (1, nil)", n, err)
-	}
-	if !w.overflowed {
-		t.Error("writing past the limit did not record an overflow")
-	}
-	if len(w.buf) != 8 {
-		t.Errorf("kept %d bytes, want the limit of 8", len(w.buf))
-	}
-	if string(w.buf) != "abcdefgh" {
-		t.Errorf("kept %q, want the FIRST 8 bytes", w.buf)
-	}
-}
-
 // TestProductionAdapterIsBounded is the wiring arm. Every test above builds an
 // Adapter with an injected command, so none of them proves the adapter New()
 // returns has a ceiling — which is the shape #1390 removed from the path
@@ -569,8 +544,45 @@ func TestProductionAdapterIsBounded(t *testing.T) {
 		t.Errorf("returned after %v, far under the %v ceiling — the stub cannot have run, "+
 			"so this proves nothing about the production path", elapsed, gitTimeout)
 	}
-	if limit := gitTimeout + gitWaitDelay + 3*time.Second; elapsed > limit {
+	if limit := gitTimeout + shellout.WaitDelay + 3*time.Second; elapsed > limit {
 		t.Errorf("the production adapter took %v; New() is not running under gitTimeout", elapsed)
+	}
+}
+
+// TestZeroValuedAdapterIsStillBounded covers ceiling()'s fallback, which
+// nothing else reaches: every other test builds its Adapter through New() or
+// one of the helpers above, all of which set timeout.
+//
+// It exists because the timeout field is a TEST seam, and a test seam whose
+// zero value is "no ceiling" reintroduces #1543 the first time someone writes
+// &Adapter{cmd: ...} — an entirely reasonable thing to write, and exactly the
+// literal the helpers above are. The fallback makes unbounded unrepresentable
+// rather than merely discouraged.
+//
+// MUTATION EVIDENCE: replacing ceiling()'s body with `return a.timeout` left
+// the whole package GREEN before this test existed, which is why it is here —
+// the fallback was uncovered, so nothing would have noticed it being deleted.
+// With this test the same mutation fails on both assertions below.
+func TestZeroValuedAdapterIsStillBounded(t *testing.T) {
+	t.Parallel()
+
+	a := &Adapter{cmd: stalledGit} // no timeout set — the shape that must not be unbounded
+
+	if got := a.ceiling(); got != gitTimeout {
+		t.Errorf("ceiling() = %v on a zero-valued Adapter, want the %v default; a zero ceiling "+
+			"means context.WithTimeout fires immediately and a negative one means never", got, gitTimeout)
+	}
+
+	start := time.Now()
+	_, answered := a.GetBranch("/tmp")
+	elapsed := time.Since(start)
+
+	if answered {
+		t.Error("a child killed by the default ceiling was reported as an answer")
+	}
+	if limit := gitTimeout + shellout.WaitDelay + 5*time.Second; elapsed > limit {
+		t.Errorf("took %v; a zero-valued Adapter is not bounded, which is #1543 reintroduced "+
+			"through the test seam that was added to make it faster", elapsed)
 	}
 }
 

--- a/core/adapters/outbound/git/shellout_test.go
+++ b/core/adapters/outbound/git/shellout_test.go
@@ -562,7 +562,16 @@ func TestProductionAdapterIsBounded(t *testing.T) {
 // MUTATION EVIDENCE: replacing ceiling()'s body with `return a.timeout` left
 // the whole package GREEN before this test existed, which is why it is here —
 // the fallback was uncovered, so nothing would have noticed it being deleted.
-// With this test the same mutation fails on both assertions below.
+// With this test the same mutation fails, reporting `ceiling() = 0s ... want
+// the 5s default`.
+//
+// Only the FIRST assertion fires under that mutation, and saying so is the
+// point (#1551 QA, B5): a zero ceiling makes context.WithTimeout expire
+// immediately, so the run returns in microseconds and the elapsed arms below
+// are satisfied for the wrong reason. They are kept because they cover the
+// OTHER direction — a negative or absurdly large fallback, which a zero-check
+// alone would wave through — and the ceiling() assertion is what actually
+// discriminates the deletion.
 func TestZeroValuedAdapterIsStillBounded(t *testing.T) {
 	t.Parallel()
 

--- a/core/adapters/outbound/git/shellout_test.go
+++ b/core/adapters/outbound/git/shellout_test.go
@@ -204,6 +204,10 @@ func TestNotARepoIsAnAnswer(t *testing.T) {
 		{"not a repo/ListReleaseTags", func() bool { _, ok := a.ListReleaseTags(notARepo); return ok }},
 		{"not a repo/TagContaining", func() bool { _, ok := a.TagContaining(notARepo, "deadbeef"); return ok }},
 		{"not a repo/GetGitRoot", func() bool { _, ok := a.GetGitRoot(notARepo); return ok }},
+		// The seventh method. It was the one row missing from this table
+		// (#1551 QA), which mattered because CommitsInRange is the method
+		// whose non-answer biases a DORA median rather than blanking a field.
+		{"not a repo/CommitsInRange", func() bool { _, ok := a.CommitsInRange(notARepo, "", "HEAD"); return ok }},
 		{"unborn branch/GetHeadCommit", func() bool { _, ok := a.GetHeadCommit(unborn); return ok }},
 		{"unborn branch/RevertedCommits", func() bool { _, ok := a.RevertedCommits(unborn); return ok }},
 		{"unresolvable object/TagContaining", func() bool { _, ok := a.TagContaining(repo, "deadbeef"); return ok }},

--- a/core/adapters/outbound/git/shellout_test.go
+++ b/core/adapters/outbound/git/shellout_test.go
@@ -114,7 +114,9 @@ func TestNonAnswerIsDistinguishableFromAGenuineMiss(t *testing.T) {
 	}
 }
 
-// TestEveryShelloutReportsANonAnswer walks all seven. The vacuity guard is the
+// TestEveryShelloutReportsANonAnswer walks the seven shellouts plus
+// GetProjectName, which starts no child of its own but forwards GetGitRoot's
+// verdict. The vacuity guard is the
 // second half of each row: the same call against a real repo must ANSWER, or a
 // method that reported false unconditionally would pass the first half.
 func TestEveryShelloutReportsANonAnswer(t *testing.T) {
@@ -363,8 +365,8 @@ func TestFloodingChildIsBoundedAndReportsANonAnswer(t *testing.T) {
 
 // TestUnderTheCapIsStillAnAnswer is the cap's vacuity guard: without it, a run
 // that reported every read as truncated would satisfy the arm above. It also
-// pins that the boundary is not off by one in the direction that blinds the
-// adapter — a read of exactly the cap is not an overflow of it.
+// pins the boundary in the direction that blinds the adapter — a read of
+// exactly the cap is not an overflow of it, because nothing was dropped.
 func TestUnderTheCapIsStillAnAnswer(t *testing.T) {
 	t.Parallel()
 
@@ -373,7 +375,12 @@ func TestUnderTheCapIsStillAnAnswer(t *testing.T) {
 			return exec.CommandContext(ctx, "/bin/sh", "-c", "head -c "+strconv.Itoa(n)+" /dev/zero")
 		}
 	}
-	for _, n := range []int{1 << 10, gitMaxOutput - 1} {
+	// gitMaxOutput itself is the row that matters: the previous spelling
+	// (len(buf) >= limit) fired when the buffer merely REACHED the cap with
+	// nothing dropped, so a complete read of exactly gitMaxOutput bytes was a
+	// false non-answer. The table used to stop at gitMaxOutput-1 while its
+	// comment claimed to pin the boundary.
+	for _, n := range []int{1 << 10, gitMaxOutput - 1, gitMaxOutput} {
 		out, answered := withCmd(build(n)).run("/tmp", "irrelevant")
 		if !answered {
 			t.Errorf("%d bytes, under the %d-byte cap, was reported as a non-answer", n, gitMaxOutput)
@@ -381,6 +388,101 @@ func TestUnderTheCapIsStillAnAnswer(t *testing.T) {
 		if len(out) != n {
 			t.Errorf("%d bytes written, %d kept", n, len(out))
 		}
+	}
+}
+
+// TestFailingGitDoesNotPublishItsStdoutAsData is findings 1 and 2 of PR #1551's
+// review, and the regression it pins was INTRODUCED by #1543's first draft
+// rather than being pre-existing: .Output()'s `if err != nil { return "" }`
+// discarded stdout on any failure, and routing everything through
+// shellout.Answered's empty-variadic form started forwarding it, because a
+// non-zero NORMAL exit is an answer.
+//
+// It is an answer. Its stdout is not the answer's content.
+//
+// Measured (git 2.50.1 / Apple Git-155, darwin/arm64): on an unborn branch
+// `git rev-parse HEAD` exits 128 and writes the literal string "HEAD" to
+// STDOUT, not just to stderr. The first draft returned ("HEAD", true), which
+// CaptureYieldOnReady persisted as a commit SHA with YieldState productive.
+//
+// RED-FIRST: run against the first draft this reports
+//
+//	GetHeadCommit(unborn) = "HEAD" — a failing git's stdout was published as a commit SHA
+func TestFailingGitDoesNotPublishItsStdoutAsData(t *testing.T) {
+	unborn := realPath(t, t.TempDir())
+	runGitForTest(t, unborn, "init")
+
+	a := New()
+
+	head, answered := a.GetHeadCommit(unborn)
+	if !answered {
+		t.Fatal("an unborn branch is an ANSWER — git ran and exited 128")
+	}
+	if head != "" {
+		t.Errorf("GetHeadCommit(unborn) = %q — a failing git's stdout was published as a "+
+			"commit SHA; #373 says an unborn branch is YieldUnknown, and a session indexed "+
+			"under the fake SHA %q is one the yield sweeper can never correlate", head, head)
+	}
+
+	branch, answered := a.GetBranch(unborn)
+	if !answered {
+		t.Fatal("an unborn branch is an ANSWER for GetBranch too")
+	}
+	if branch != "" {
+		t.Errorf("GetBranch(unborn) = %q, want empty", branch)
+	}
+}
+
+// TestPartialOutputBeforeAFatalIsNotACompleteAnswer is the other half of the
+// same root cause, and the one with DORA-shaped blast radius: a `git log` that
+// streams commits and then hits a fatal exits 128 having already written a
+// prefix of the history. Publishing that prefix is a silently truncated commit
+// list presented as Available:true — exactly what gitMaxOutput's doc argues
+// must never happen, reached through a different door.
+//
+// The fixture writes two records and then exits non-zero, which is the shape
+// without needing to corrupt a real object store.
+//
+// RED-FIRST: against the first draft, both arms report the truncated data.
+func TestPartialOutputBeforeAFatalIsNotACompleteAnswer(t *testing.T) {
+	t.Parallel()
+
+	partial := func(ctx context.Context, _ string, _ ...string) *exec.Cmd {
+		// Two well-formed \x01-delimited records, then a non-zero exit.
+		return exec.CommandContext(ctx, "/bin/sh", "-c",
+			`printf '\001aaa\002100\002first\001bbb\002200\002second'; exit 128`)
+	}
+	a := withCmd(partial)
+
+	commits, answered := a.CommitsInRange("/tmp", "", "HEAD")
+	if !answered {
+		t.Fatal("a git that exited 128 ANSWERED; only a killed or unstarted child has not")
+	}
+	if len(commits) != 0 {
+		t.Errorf("CommitsInRange returned %d commit(s) from a git that died mid-stream; DORA "+
+			"would publish a median lead time over a silently truncated history as Available:true",
+			len(commits))
+	}
+
+	shas, answered := a.RevertedCommits("/tmp")
+	if !answered {
+		t.Fatal("same for RevertedCommits")
+	}
+	if len(shas) != 0 {
+		t.Errorf("RevertedCommits returned %d SHA(s) from a partial read", len(shas))
+	}
+}
+
+// TestASuccessfulGitStillReturnsItsOutput is the vacuity guard for the two
+// tests above. Discarding stdout whenever err != nil is only correct if
+// err == nil still delivers it — without this, an adapter that returned nil
+// unconditionally would pass both.
+func TestASuccessfulGitStillReturnsItsOutput(t *testing.T) {
+	repo := gitInitForTest(t)
+	sha := commitFileForTest(t, repo, "a.txt", "A")
+
+	if got, answered := New().GetHeadCommit(repo); got != sha || !answered {
+		t.Errorf("GetHeadCommit = (%q, %v), want (%q, true)", got, answered, sha)
 	}
 }
 
@@ -396,11 +498,23 @@ func TestCappedBufferStopsAtItsLimit(t *testing.T) {
 	if w.overflowed {
 		t.Error("3 bytes into a limit of 8 reported an overflow")
 	}
+	// Exactly the limit is NOT an overflow: nothing was dropped. The previous
+	// spelling keyed on len(buf) >= limit and reported one here.
+	if n, err := w.Write([]byte("defgh")); n != 5 || err != nil {
+		t.Fatalf("Write to exactly the limit = (%d, %v), want (5, nil)", n, err)
+	}
+	if w.overflowed {
+		t.Error("a complete read of exactly the limit was reported as truncated — that is a " +
+			"false non-answer, and it blanks a chart the daemon read successfully")
+	}
+	if string(w.buf) != "abcdefgh" {
+		t.Fatalf("kept %q, want abcdefgh", w.buf)
+	}
 	// Reports the full length even past the limit: returning short would make
 	// exec's copier treat it as a write error and fail the command for the
 	// wrong reason.
-	if n, err := w.Write([]byte("defghijkl")); n != 9 || err != nil {
-		t.Fatalf("Write past the limit = (%d, %v), want (9, nil)", n, err)
+	if n, err := w.Write([]byte("i")); n != 1 || err != nil {
+		t.Fatalf("Write past the limit = (%d, %v), want (1, nil)", n, err)
 	}
 	if !w.overflowed {
 		t.Error("writing past the limit did not record an overflow")

--- a/core/application/services/dora_metrics.go
+++ b/core/application/services/dora_metrics.go
@@ -83,13 +83,22 @@ func ComputeDoraMetrics(git doraGitProbe, sessions doraSessionLister, project st
 		return DoraResult{Available: false, Message: "no releases found for this project"}, nil
 	}
 
-	// Every read below is all-or-nothing, and that is the point rather than
-	// caution. A PARTIAL failure is worse than a total one here: dropping one
-	// tag's commits still yields a median lead time, and dropping one revert's
-	// containing tag still yields a Change Failure Rate — each computed over
-	// whatever happened to succeed and published as Available:true. A number
-	// that is quietly biased is harder to notice than a chart that says it
+	// Every read below is all-or-nothing. The load-bearing half of that is
+	// never publishing a number computed over "whatever happened to succeed":
+	// dropping one tag's commits still yields a median lead time, and dropping
+	// one revert's containing tag still yields a Change Failure Rate, each
+	// quietly biased and therefore harder to notice than a chart that says it
 	// could not be drawn (#1543).
+	//
+	// Blanking ALL FOUR metrics is the conservative part, not the principled
+	// part, and it is stated that way rather than defended. dora.Metric already
+	// carries its own Available/Message and the handler, the dashboard and the
+	// CSV builder all honour it, so a per-metric version is expressible today:
+	// a TagContaining non-answer biases ChangeFailureRate and MTTR while
+	// DeploymentFrequency (computed from tags alone) was fully read. That is a
+	// user-visible behaviour change beyond #1543's scope — a blank panel is
+	// conservative but honest, which is what this issue is about — so it is
+	// left for a follow-up rather than smuggled in here.
 	commitsByTag := make(map[string][]dora.CommitInfo, len(tags))
 	for i, tag := range tags {
 		from := ""
@@ -149,12 +158,11 @@ func resolveDoraProjectRoot(git doraGitProbe, sessions doraSessionLister, projec
 	if err != nil {
 		return "", true, err
 	}
-	asked, unread := 0, 0
+	unread := 0
 	for _, st := range all {
 		if st == nil || st.ProjectName != project || st.CWD == "" {
 			continue
 		}
-		asked++
 		root, answered := git.GetGitRoot(st.CWD)
 		if !answered {
 			unread++

--- a/core/application/services/dora_metrics.go
+++ b/core/application/services/dora_metrics.go
@@ -17,10 +17,10 @@ const doraHotfixWindowHours = 24
 // the yieldGitProbe/historySessionLister convention of small per-consumer
 // interfaces rather than a shared, ever-growing one.
 type doraGitProbe interface {
-	GetGitRoot(dir string) string
-	ListReleaseTags(dir string) []dora.TagInfo
-	CommitsInRange(dir, fromRef, toRef string) []dora.CommitInfo
-	TagContaining(dir, hash string) string
+	GetGitRoot(dir string) (root string, answered bool)
+	ListReleaseTags(dir string) (tags []dora.TagInfo, answered bool)
+	CommitsInRange(dir, fromRef, toRef string) (commits []dora.CommitInfo, answered bool)
+	TagContaining(dir, hash string) (tag string, answered bool)
 }
 
 // doraSessionLister is the narrow read ComputeDoraMetrics needs over the
@@ -30,10 +30,19 @@ type doraSessionLister interface {
 	ListAll() ([]*session.SessionState, error)
 }
 
+// doraGitUnreadable is the Message for every outcome where git could not be
+// RUN. It is one string on purpose: until #1543 each of those outcomes wore
+// the message of the ANSWER it was collapsed into — a timed-out for-each-ref
+// reached the user as "no releases found for this project", and an unreadable
+// repo root as "project not found or not a git repository". Both are claims
+// about the repository made by a probe that never reached it.
+const doraGitUnreadable = "could not read this project's git history"
+
 // DoraResult is the outcome of ComputeDoraMetrics, ready for the HTTP
 // handler to serialize. Available is false when project didn't resolve to
-// a git repo, or that repo has no release tags — Message explains why, and
-// the four metrics are zero values that should not be rendered.
+// a git repo, that repo has no release tags, or git could not be read at all
+// — Message explains which, and the four metrics are zero values that should
+// not be rendered.
 type DoraResult struct {
 	Available           bool
 	Message             string
@@ -55,26 +64,43 @@ func ComputeDoraMetrics(git doraGitProbe, sessions doraSessionLister, project st
 		return DoraResult{Available: false, Message: "git or session data unavailable"}, nil
 	}
 
-	root, err := resolveDoraProjectRoot(git, sessions, project)
+	root, rootAnswered, err := resolveDoraProjectRoot(git, sessions, project)
 	if err != nil {
 		return DoraResult{}, err
+	}
+	if !rootAnswered {
+		return DoraResult{Available: false, Message: doraGitUnreadable}, nil
 	}
 	if root == "" {
 		return DoraResult{Available: false, Message: "project not found or not a git repository"}, nil
 	}
 
-	tags := git.ListReleaseTags(root)
+	tags, answered := git.ListReleaseTags(root)
+	if !answered {
+		return DoraResult{Available: false, Message: doraGitUnreadable}, nil
+	}
 	if len(tags) == 0 {
 		return DoraResult{Available: false, Message: "no releases found for this project"}, nil
 	}
 
+	// Every read below is all-or-nothing, and that is the point rather than
+	// caution. A PARTIAL failure is worse than a total one here: dropping one
+	// tag's commits still yields a median lead time, and dropping one revert's
+	// containing tag still yields a Change Failure Rate — each computed over
+	// whatever happened to succeed and published as Available:true. A number
+	// that is quietly biased is harder to notice than a chart that says it
+	// could not be drawn (#1543).
 	commitsByTag := make(map[string][]dora.CommitInfo, len(tags))
 	for i, tag := range tags {
 		from := ""
 		if i > 0 {
 			from = tags[i-1].Name
 		}
-		commitsByTag[tag.Name] = git.CommitsInRange(root, from, tag.Name)
+		commits, answered := git.CommitsInRange(root, from, tag.Name)
+		if !answered {
+			return DoraResult{Available: false, Message: doraGitUnreadable}, nil
+		}
+		commitsByTag[tag.Name] = commits
 	}
 
 	hotfixes := dora.DetectHotfixes(tags, doraHotfixWindowHours, start, end)
@@ -83,7 +109,13 @@ func ComputeDoraMetrics(git doraGitProbe, sessions doraSessionLister, project st
 	failures := make([]dora.ResolvedFailure, 0, len(hotfixes)+len(candidates))
 	failures = append(failures, hotfixes...)
 	for _, c := range candidates {
-		originalTag := git.TagContaining(root, c.OriginalHash)
+		originalTag, answered := git.TagContaining(root, c.OriginalHash)
+		if !answered {
+			// Silently dropping this candidate would make Change Failure Rate
+			// read BETTER than reality — the one collapse in this adapter
+			// that flatters the number rather than blanking it.
+			return DoraResult{Available: false, Message: doraGitUnreadable}, nil
+		}
 		if resolved, ok := dora.ResolveRevert(tags, c, originalTag); ok {
 			failures = append(failures, resolved)
 		}
@@ -100,20 +132,34 @@ func ComputeDoraMetrics(git doraGitProbe, sessions doraSessionLister, project st
 
 // resolveDoraProjectRoot finds the git repo root for project by scanning
 // sessions for a representative CWD, mirroring YieldSweeper.recordRootDir.
-// Returns "" (not an error) when no session matches or none resolves to a
-// git repo — that's a normal "nothing to compute" outcome, not a failure.
-func resolveDoraProjectRoot(git doraGitProbe, sessions doraSessionLister, project string) (string, error) {
+// Returns "" with answered=true (not an error) when no session matches or none
+// resolves to a git repo — that's a normal "nothing to compute" outcome, not a
+// failure.
+//
+// answered is false only when EVERY candidate cwd went unread, which is the
+// case that must not reach the user as "not a git repository". A single cwd
+// that resolves is enough to answer the question being asked, so one unread
+// candidate among several is not a failure — it is why the flag is computed
+// over the loop rather than returned from inside it.
+func resolveDoraProjectRoot(git doraGitProbe, sessions doraSessionLister, project string) (string, bool, error) {
 	all, err := sessions.ListAll()
 	if err != nil {
-		return "", err
+		return "", true, err
 	}
+	asked, unread := 0, 0
 	for _, st := range all {
 		if st == nil || st.ProjectName != project || st.CWD == "" {
 			continue
 		}
-		if root := git.GetGitRoot(st.CWD); root != "" {
-			return root, nil
+		asked++
+		root, answered := git.GetGitRoot(st.CWD)
+		if !answered {
+			unread++
+			continue
+		}
+		if root != "" {
+			return root, true, nil
 		}
 	}
-	return "", nil
+	return "", asked == 0 || unread < asked, nil
 }

--- a/core/application/services/dora_metrics.go
+++ b/core/application/services/dora_metrics.go
@@ -136,11 +136,14 @@ func ComputeDoraMetrics(git doraGitProbe, sessions doraSessionLister, project st
 // resolves to a git repo — that's a normal "nothing to compute" outcome, not a
 // failure.
 //
-// answered is false only when EVERY candidate cwd went unread, which is the
-// case that must not reach the user as "not a git repository". A single cwd
-// that resolves is enough to answer the question being asked, so one unread
-// candidate among several is not a failure — it is why the flag is computed
-// over the loop rather than returned from inside it.
+// A single cwd that RESOLVES is enough to answer the question being asked, and
+// that case returns from inside the loop. answered therefore only ever reports
+// on the remaining case: no candidate produced a root. There, every candidate
+// that answered answered NEGATIVELY, so one unread candidate is enough to make
+// "project not found or not a git repository" a claim this daemon cannot
+// support — which is the class of claim #1543 removes everywhere else. Hence
+// `unread == 0` rather than a majority test; it subsumes the no-candidates case,
+// where unread is 0 and "nothing to compute" is the honest answer.
 func resolveDoraProjectRoot(git doraGitProbe, sessions doraSessionLister, project string) (string, bool, error) {
 	all, err := sessions.ListAll()
 	if err != nil {
@@ -161,5 +164,5 @@ func resolveDoraProjectRoot(git doraGitProbe, sessions doraSessionLister, projec
 			return root, true, nil
 		}
 	}
-	return "", asked == 0 || unread < asked, nil
+	return "", unread == 0, nil
 }

--- a/core/application/services/git_nonanswer_test.go
+++ b/core/application/services/git_nonanswer_test.go
@@ -6,6 +6,7 @@ import (
 
 	"irrlicht/core/domain/dora"
 	"irrlicht/core/domain/session"
+	"irrlicht/core/ports/outbound"
 )
 
 // #1543's collapse did not stop at the adapter — the whole harm was what the
@@ -216,6 +217,37 @@ func TestResolveDoraProjectRootAnswersWhenAnyCandidateDid(t *testing.T) {
 		}
 	})
 
+	// #1551 review finding 7. The old expression was `asked == 0 || unread <
+	// asked`, which let ONE negative candidate outvote N-1 unread ones: with
+	// asked=3, unread=2, the user got the confident "project not found or not
+	// a git repository" on the strength of a single cwd.
+	//
+	// RED-FIRST: against `unread < asked` this reports
+	//	2 of 3 candidates went unread, but the result was reported as an answer
+	t.Run("a mix of unread and negative candidates is not an answer", func(t *testing.T) {
+		seen := 0
+		mixed := &countingRootGit{fn: func(string) (string, bool) {
+			seen++
+			if seen == 3 {
+				return "", true // genuinely not a repo
+			}
+			return "", false // unread
+		}}
+		three := oneSession{states: []*session.SessionState{
+			{SessionID: "a", ProjectName: "proj", CWD: "/one", State: session.StateReady},
+			{SessionID: "b", ProjectName: "proj", CWD: "/two", State: session.StateReady},
+			{SessionID: "c", ProjectName: "proj", CWD: "/three", State: session.StateReady},
+		}}
+		_, answered, err := resolveDoraProjectRoot(mixed, three, "proj")
+		if err != nil {
+			t.Fatalf("resolveDoraProjectRoot: %v", err)
+		}
+		if answered {
+			t.Error("2 of 3 candidates went unread, but the result was reported as an answer; " +
+				"one negative cwd cannot support \"not a git repository\" for the project")
+		}
+	})
+
 	t.Run("no candidate at all is an answer", func(t *testing.T) {
 		none := &countingRootGit{fn: func(string) (string, bool) { return "", true }}
 		_, answered, err := resolveDoraProjectRoot(none, oneSession{}, "proj")
@@ -240,17 +272,31 @@ type enricherGit struct {
 	branchAnswered bool
 	nameAnswered   bool
 	headAnswered   bool
+	rootAnswered   bool
 	branch         string
 	name           string
 	head           string
+	root           string
 }
 
 func (g *enricherGit) GetBranch(string) (string, bool)       { return g.branch, g.branchAnswered }
 func (g *enricherGit) GetProjectName(string) (string, bool)  { return g.name, g.nameAnswered }
-func (g *enricherGit) GetGitRoot(string) (string, bool)      { return "", true }
+func (g *enricherGit) GetGitRoot(string) (string, bool)      { return g.root, g.rootAnswered }
 func (g *enricherGit) GetHeadCommit(string) (string, bool)   { return g.head, g.headAnswered }
 func (g *enricherGit) GetBranchFromTranscript(string) string { return "" }
-func (g *enricherGit) GetCWDFromTranscript(string) string    { return "" }
+
+// GetCWDFromTranscript reports a MOVE: RefreshOnActivity only reaches the
+// branch/project block when the transcript's cwd differs from the state's.
+func (g *enricherGit) GetCWDFromTranscript(string) string { return "/new/repo" }
+
+// noopMetrics is the MetricsCollector RefreshOnActivity needs. It embeds the
+// port so only the methods actually exercised need bodies and an unexpected
+// call panics loudly rather than silently returning a zero value — the idiom
+// session_detector_bornready_test.go's doubles use. ComputeMetrics returns no
+// metrics, so the cwd comes from GetCWDFromTranscript above.
+type noopMetrics struct{ outbound.MetricsCollector }
+
+func (noopMetrics) ComputeMetrics(string, string) (*session.SessionMetrics, error) { return nil, nil }
 
 // TestBackfillDoesNotMarkASessionDoneOnANonAnswer is the permanence bug, and it
 // is the sharpest of the four: backfillOne returns early when ProjectName is
@@ -262,7 +308,7 @@ func (g *enricherGit) GetCWDFromTranscript(string) string    { return "" }
 // assignment): "a non-answer marked the session updated; it will never be
 // retried". Measured by reverting the arm.
 func TestBackfillDoesNotMarkASessionDoneOnANonAnswer(t *testing.T) {
-	e := newMetadataEnricher(&enricherGit{name: "guess", branch: "guess"}, nil)
+	e := newMetadataEnricher(&enricherGit{name: "guess", branch: "guess", rootAnswered: true}, nil)
 	st := &session.SessionState{SessionID: "s", CWD: "/repo/sub"}
 
 	if e.backfillOne(st) {
@@ -280,7 +326,7 @@ func TestBackfillDoesNotMarkASessionDoneOnANonAnswer(t *testing.T) {
 	// nothing at all would pass the arm above.
 	answering := newMetadataEnricher(&enricherGit{
 		nameAnswered: true, name: "proj",
-		branchAnswered: true, branch: "main",
+		branchAnswered: true, branch: "main", rootAnswered: true,
 	}, nil)
 	fresh := &session.SessionState{SessionID: "s", CWD: "/repo/sub"}
 	if !answering.backfillOne(fresh) {
@@ -288,6 +334,58 @@ func TestBackfillDoesNotMarkASessionDoneOnANonAnswer(t *testing.T) {
 	}
 	if fresh.ProjectName != "proj" || fresh.GitBranch != "main" {
 		t.Errorf("got (%q, %q), want (proj, main)", fresh.ProjectName, fresh.GitBranch)
+	}
+}
+
+// TestRefreshOnActivityNeverReportsAnotherDirectorysBranch is #1551 review
+// finding 3, and it is a defect the FIRST DRAFT of #1543 introduced rather
+// than a pre-existing one: applying "never overwrite what you already hold"
+// to a session that has MOVED keeps values describing the OLD directory.
+//
+// A blank branch is a missing fact. Another repo's branch is a false one — and
+// it was permanent, because backfillOne returns early while ProjectName is set
+// and RefreshOnActivity skips the whole block once cwd == state.CWD.
+//
+// RED-FIRST: against the first draft this reports
+//
+//	GitBranch = "old-branch" after moving to /new/repo
+func TestRefreshOnActivityNeverReportsAnotherDirectorysBranch(t *testing.T) {
+	git := &enricherGit{} // every probe reports a non-answer
+	e := newMetadataEnricher(git, &noopMetrics{})
+	st := &session.SessionState{
+		SessionID:   "s",
+		CWD:         "/old/repo",
+		GitBranch:   "old-branch",
+		ProjectName: "old-project",
+	}
+
+	e.RefreshOnActivity(st, "/transcripts/s.jsonl")
+
+	if st.CWD != "/new/repo" {
+		t.Fatalf("CWD = %q, want /new/repo — the fixture is not exercising a move", st.CWD)
+	}
+	if st.GitBranch == "old-branch" {
+		t.Error("the session moved to /new/repo but still reports /old/repo's branch; that is a " +
+			"claim about the new directory the daemon never established")
+	}
+	if st.ProjectName == "old-project" {
+		t.Error("same for ProjectName — and while it is set, backfillOne returns early, so the " +
+			"stale value is permanent")
+	}
+
+	// Vacuity guard: a git that ANSWERS must still update both, or an enricher
+	// that blanked everything unconditionally would pass the arms above.
+	answering := newMetadataEnricher(&enricherGit{
+		branchAnswered: true, branch: "new-branch",
+		rootAnswered: true, root: "/new/new-project",
+	}, &noopMetrics{})
+	st2 := &session.SessionState{SessionID: "s", CWD: "/old/repo", GitBranch: "old-branch", ProjectName: "old-project"}
+	answering.RefreshOnActivity(st2, "/transcripts/s.jsonl")
+	if st2.GitBranch != "new-branch" {
+		t.Errorf("GitBranch = %q, want new-branch", st2.GitBranch)
+	}
+	if st2.ProjectName != "new-project" {
+		t.Errorf("ProjectName = %q, want new-project", st2.ProjectName)
 	}
 }
 
@@ -299,7 +397,7 @@ func TestBackfillDoesNotMarkASessionDoneOnANonAnswer(t *testing.T) {
 // RED-FIRST (with the `!answered` arm removed): "a non-answer was persisted as
 // the verdict YieldUnknown".
 func TestCaptureYieldOnReadyDoesNotRecordAVerdictItDidNotReach(t *testing.T) {
-	e := newMetadataEnricher(&enricherGit{}, nil)
+	e := newMetadataEnricher(&enricherGit{rootAnswered: true}, nil)
 	st := &session.SessionState{SessionID: "s", CWD: "/repo", YieldState: session.YieldProductive, HeadCommit: "abc"}
 
 	e.CaptureYieldOnReady(st)
@@ -313,7 +411,7 @@ func TestCaptureYieldOnReadyDoesNotRecordAVerdictItDidNotReach(t *testing.T) {
 
 	// Vacuity guard: a git that ANSWERS with no HEAD is a genuine
 	// not-a-git-repo verdict and must still be recorded.
-	genuine := newMetadataEnricher(&enricherGit{headAnswered: true, head: ""}, nil)
+	genuine := newMetadataEnricher(&enricherGit{headAnswered: true, head: "", rootAnswered: true}, nil)
 	st2 := &session.SessionState{SessionID: "s", CWD: "/repo", YieldState: session.YieldProductive}
 	genuine.CaptureYieldOnReady(st2)
 	if st2.YieldState != session.YieldUnknown {
@@ -386,6 +484,51 @@ func (l *recordingLogger) LogError(eventType, sessionID, msg string) {
 }
 func (l *recordingLogger) LogProcessingTime(_, _ string, _ int64, _ int, _ string) {}
 func (l *recordingLogger) Close() error                                            { return nil }
+
+// TestYieldSweepReportsRootsItCouldNotResolve is #1551 review finding 4: a cwd
+// whose GetGitRoot never answered never entered rootDirs, so
+// collectRevertedSHAs — which walks that map — could not report it, and the
+// sweep went completely silent for history it never read.
+//
+// RED-FIRST: against the previous code this reports
+//
+//	a cwd whose repo root never resolved was not reported; logged: []
+func TestYieldSweepReportsRootsItCouldNotResolve(t *testing.T) {
+	log := &recordingLogger{}
+	s := NewYieldSweeper(&noopYieldStore{}, &unresolvableRootGit{}, log, 0)
+
+	s.indexByCommit([]*session.SessionState{
+		{SessionID: "a", HeadCommit: "abc", CWD: "/repo/one"},
+		{SessionID: "b", HeadCommit: "def", CWD: "/repo/two"},
+	})
+
+	found := false
+	for _, e := range log.errs {
+		if strings.Contains(e, "could not resolve a repo root") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("a cwd whose repo root never resolved was not reported; logged: %v\n"+
+			"collectRevertedSHAs cannot report it — the cwd never reaches rootDirs at all", log.errs)
+	}
+
+	// Vacuity guard: a sweep that resolved every root must log nothing.
+	quiet := &recordingLogger{}
+	NewYieldSweeper(&noopYieldStore{}, &unreadRevertGit{root: "/repo"}, quiet, 0).
+		indexByCommit([]*session.SessionState{{SessionID: "a", HeadCommit: "abc", CWD: "/repo/one"}})
+	for _, e := range quiet.errs {
+		if strings.Contains(e, "could not resolve a repo root") {
+			t.Errorf("a fully resolvable sweep logged an unresolved-roots error: %q", e)
+		}
+	}
+}
+
+// unresolvableRootGit reports a non-answer for the repo-root probe.
+type unresolvableRootGit struct{}
+
+func (unresolvableRootGit) GetGitRoot(string) (string, bool)        { return "", false }
+func (unresolvableRootGit) RevertedCommits(string) ([]string, bool) { return nil, true }
 
 type noopYieldStore struct{}
 

--- a/core/application/services/git_nonanswer_test.go
+++ b/core/application/services/git_nonanswer_test.go
@@ -1,12 +1,10 @@
 package services
 
 import (
-	"strings"
 	"testing"
 
 	"irrlicht/core/domain/dora"
 	"irrlicht/core/domain/session"
-	"irrlicht/core/ports/outbound"
 )
 
 // #1543's collapse did not stop at the adapter — the whole harm was what the
@@ -26,8 +24,7 @@ type unreadGit struct {
 	root      string
 	tags      []dora.TagInfo
 	commits   map[string][]dora.CommitInfo
-	tagFor    string
-	unreadFor map[string]bool // "root" | "tags" | "commits" | "tagcontaining" | "branch" | "name"
+	unreadFor map[string]bool // "root" | "tags" | "commits" | "tagcontaining"
 }
 
 func (g *unreadGit) answered(probe string) bool { return !g.unreadFor[probe] }
@@ -57,7 +54,7 @@ func (g *unreadGit) TagContaining(string, string) (string, bool) {
 	if !g.answered("tagcontaining") {
 		return "", false
 	}
-	return g.tagFor, true
+	return "", true
 }
 
 type oneSession struct{ states []*session.SessionState }
@@ -289,15 +286,6 @@ func (g *enricherGit) GetBranchFromTranscript(string) string { return "" }
 // branch/project block when the transcript's cwd differs from the state's.
 func (g *enricherGit) GetCWDFromTranscript(string) string { return "/new/repo" }
 
-// noopMetrics is the MetricsCollector RefreshOnActivity needs. It embeds the
-// port so only the methods actually exercised need bodies and an unexpected
-// call panics loudly rather than silently returning a zero value — the idiom
-// session_detector_bornready_test.go's doubles use. ComputeMetrics returns no
-// metrics, so the cwd comes from GetCWDFromTranscript above.
-type noopMetrics struct{ outbound.MetricsCollector }
-
-func (noopMetrics) ComputeMetrics(string, string) (*session.SessionMetrics, error) { return nil, nil }
-
 // TestBackfillDoesNotMarkASessionDoneOnANonAnswer is the permanence bug, and it
 // is the sharpest of the four: backfillOne returns early when ProjectName is
 // already set, so a session that stored a value from a git which never ran was
@@ -351,7 +339,7 @@ func TestBackfillDoesNotMarkASessionDoneOnANonAnswer(t *testing.T) {
 //	GitBranch = "old-branch" after moving to /new/repo
 func TestRefreshOnActivityNeverReportsAnotherDirectorysBranch(t *testing.T) {
 	git := &enricherGit{} // every probe reports a non-answer
-	e := newMetadataEnricher(git, &noopMetrics{})
+	e := newMetadataEnricher(git, emptyMetrics{})
 	st := &session.SessionState{
 		SessionID:   "s",
 		CWD:         "/old/repo",
@@ -378,7 +366,7 @@ func TestRefreshOnActivityNeverReportsAnotherDirectorysBranch(t *testing.T) {
 	answering := newMetadataEnricher(&enricherGit{
 		branchAnswered: true, branch: "new-branch",
 		rootAnswered: true, root: "/new/new-project",
-	}, &noopMetrics{})
+	}, emptyMetrics{})
 	st2 := &session.SessionState{SessionID: "s", CWD: "/old/repo", GitBranch: "old-branch", ProjectName: "old-project"}
 	answering.RefreshOnActivity(st2, "/transcripts/s.jsonl")
 	if st2.GitBranch != "new-branch" {
@@ -426,33 +414,24 @@ func TestCaptureYieldOnReadyDoesNotRecordAVerdictItDidNotReach(t *testing.T) {
 // RED-FIRST (with collectRevertedSHAs's `!answered` arm removed): no error was
 // logged and the sweep reported a clean pass.
 func TestYieldSweepReportsRootsItCouldNotScan(t *testing.T) {
-	log := &recordingLogger{}
+	log := &gateLog{}
 	git := &unreadRevertGit{root: "/repo", unread: true}
-	s := NewYieldSweeper(&noopYieldStore{}, git, log, 0)
+	s := NewYieldSweeper(&diagFakeRepo{}, git, log, 0)
 
 	s.collectRevertedSHAs(map[string]string{"/repo": "/repo/sub"})
 
-	errs := log.errs
-	found := false
-	for _, e := range errs {
-		if strings.Contains(e, "could not read git history") {
-			found = true
-		}
-	}
-	if !found {
+	if !log.errorMentioning("could not read git history") {
 		t.Errorf("a root whose revert scan never ran was not reported; logged: %v\n"+
-			"Silence here means the sweep reports \"nothing flipped\" for history it never read", errs)
+			"Silence here means the sweep reports \"nothing flipped\" for history it never read", log.errors)
 	}
 
 	// Vacuity guard: a sweep that read everything must log nothing, or a
 	// sweeper that always complained would pass the arm above.
-	quiet := &recordingLogger{}
-	NewYieldSweeper(&noopYieldStore{}, &unreadRevertGit{root: "/repo"}, quiet, 0).
+	quiet := &gateLog{}
+	NewYieldSweeper(&diagFakeRepo{}, &unreadRevertGit{root: "/repo"}, quiet, 0).
 		collectRevertedSHAs(map[string]string{"/repo": "/repo/sub"})
-	for _, e := range quiet.errs {
-		if strings.Contains(e, "could not read git history") {
-			t.Errorf("a fully readable sweep logged an unread-roots error: %q", e)
-		}
+	if quiet.errorMentioning("could not read git history") {
+		t.Errorf("a fully readable sweep logged an unread-roots error: %v", quiet.errors)
 	}
 }
 
@@ -461,29 +440,26 @@ func TestYieldSweepReportsRootsItCouldNotScan(t *testing.T) {
 // because that one lives in the EXTERNAL services_test package and these tests
 // need the unexported collectRevertedSHAs.
 type unreadRevertGit struct {
-	root   string
-	unread bool
+	root string
+	// unread / rootUnread pick WHICH probe reports the non-answer; the two
+	// sweeper tests need different ones, and one type with two knobs beats two
+	// types differing by a line.
+	unread     bool
+	rootUnread bool
 }
 
-func (g *unreadRevertGit) GetGitRoot(string) (string, bool) { return g.root, true }
+func (g *unreadRevertGit) GetGitRoot(string) (string, bool) {
+	if g.rootUnread {
+		return "", false
+	}
+	return g.root, true
+}
 func (g *unreadRevertGit) RevertedCommits(string) ([]string, bool) {
 	if g.unread {
 		return nil, false
 	}
 	return nil, true
 }
-
-// recordingLogger keeps the error lines the sweeper writes. The sweep's whole
-// report of an unscanned root is a log line, so a test that could not read them
-// would be asserting on nothing.
-type recordingLogger struct{ errs []string }
-
-func (l *recordingLogger) LogInfo(_, _, _ string) {}
-func (l *recordingLogger) LogError(eventType, sessionID, msg string) {
-	l.errs = append(l.errs, eventType+" "+sessionID+" "+msg)
-}
-func (l *recordingLogger) LogProcessingTime(_, _ string, _ int64, _ int, _ string) {}
-func (l *recordingLogger) Close() error                                            { return nil }
 
 // TestYieldSweepReportsRootsItCouldNotResolve is #1551 review finding 4: a cwd
 // whose GetGitRoot never answered never entered rootDirs, so
@@ -494,44 +470,24 @@ func (l *recordingLogger) Close() error                                         
 //
 //	a cwd whose repo root never resolved was not reported; logged: []
 func TestYieldSweepReportsRootsItCouldNotResolve(t *testing.T) {
-	log := &recordingLogger{}
-	s := NewYieldSweeper(&noopYieldStore{}, &unresolvableRootGit{}, log, 0)
+	log := &gateLog{}
+	s := NewYieldSweeper(&diagFakeRepo{}, &unreadRevertGit{rootUnread: true}, log, 0)
 
 	s.indexByCommit([]*session.SessionState{
 		{SessionID: "a", HeadCommit: "abc", CWD: "/repo/one"},
 		{SessionID: "b", HeadCommit: "def", CWD: "/repo/two"},
 	})
 
-	found := false
-	for _, e := range log.errs {
-		if strings.Contains(e, "could not resolve a repo root") {
-			found = true
-		}
-	}
-	if !found {
+	if !log.errorMentioning("could not resolve a repo root") {
 		t.Errorf("a cwd whose repo root never resolved was not reported; logged: %v\n"+
-			"collectRevertedSHAs cannot report it — the cwd never reaches rootDirs at all", log.errs)
+			"collectRevertedSHAs cannot report it — the cwd never reaches rootDirs at all", log.errors)
 	}
 
 	// Vacuity guard: a sweep that resolved every root must log nothing.
-	quiet := &recordingLogger{}
-	NewYieldSweeper(&noopYieldStore{}, &unreadRevertGit{root: "/repo"}, quiet, 0).
+	quiet := &gateLog{}
+	NewYieldSweeper(&diagFakeRepo{}, &unreadRevertGit{root: "/repo"}, quiet, 0).
 		indexByCommit([]*session.SessionState{{SessionID: "a", HeadCommit: "abc", CWD: "/repo/one"}})
-	for _, e := range quiet.errs {
-		if strings.Contains(e, "could not resolve a repo root") {
-			t.Errorf("a fully resolvable sweep logged an unresolved-roots error: %q", e)
-		}
+	if quiet.errorMentioning("could not resolve a repo root") {
+		t.Errorf("a fully resolvable sweep logged an unresolved-roots error: %v", quiet.errors)
 	}
 }
-
-// unresolvableRootGit reports a non-answer for the repo-root probe.
-type unresolvableRootGit struct{}
-
-func (unresolvableRootGit) GetGitRoot(string) (string, bool)        { return "", false }
-func (unresolvableRootGit) RevertedCommits(string) ([]string, bool) { return nil, true }
-
-type noopYieldStore struct{}
-
-func (noopYieldStore) ListAll() ([]*session.SessionState, error)  { return nil, nil }
-func (noopYieldStore) Load(string) (*session.SessionState, error) { return nil, nil }
-func (noopYieldStore) Save(*session.SessionState) error           { return nil }

--- a/core/application/services/git_nonanswer_test.go
+++ b/core/application/services/git_nonanswer_test.go
@@ -1,0 +1,394 @@
+package services
+
+import (
+	"strings"
+	"testing"
+
+	"irrlicht/core/domain/dora"
+	"irrlicht/core/domain/session"
+)
+
+// #1543's collapse did not stop at the adapter — the whole harm was what the
+// zero value MEANT once it arrived. These pin the four consumer decisions, and
+// each is a claim the daemon made to a user on evidence it did not have.
+//
+// Red-first: each was run against the consumer arm reverted (the `!answered`
+// branch removed, so a non-answer takes the old empty-answer path). What each
+// reported is recorded on the test. That is the same evidence shape as the
+// adapter's defect test — the consumer code is new, but the BEHAVIOUR each one
+// asserts is the pre-existing defect, so reverting the arm reproduces it.
+
+// unreadGit reports a non-answer for whichever probes it is told to fail, and a
+// normal answer for the rest. The two are separable so a test can pin which
+// probe's non-answer produced which message.
+type unreadGit struct {
+	root      string
+	tags      []dora.TagInfo
+	commits   map[string][]dora.CommitInfo
+	tagFor    string
+	unreadFor map[string]bool // "root" | "tags" | "commits" | "tagcontaining" | "branch" | "name"
+}
+
+func (g *unreadGit) answered(probe string) bool { return !g.unreadFor[probe] }
+
+func (g *unreadGit) GetGitRoot(string) (string, bool) {
+	if !g.answered("root") {
+		return "", false
+	}
+	return g.root, true
+}
+
+func (g *unreadGit) ListReleaseTags(string) ([]dora.TagInfo, bool) {
+	if !g.answered("tags") {
+		return nil, false
+	}
+	return g.tags, true
+}
+
+func (g *unreadGit) CommitsInRange(_, _, toRef string) ([]dora.CommitInfo, bool) {
+	if !g.answered("commits") {
+		return nil, false
+	}
+	return g.commits[toRef], true
+}
+
+func (g *unreadGit) TagContaining(string, string) (string, bool) {
+	if !g.answered("tagcontaining") {
+		return "", false
+	}
+	return g.tagFor, true
+}
+
+type oneSession struct{ states []*session.SessionState }
+
+func (s oneSession) ListAll() ([]*session.SessionState, error) { return s.states, nil }
+
+func doraSessions(project, cwd string) oneSession {
+	return oneSession{states: []*session.SessionState{
+		{SessionID: "s1", ProjectName: project, CWD: cwd, State: session.StateReady},
+	}}
+}
+
+// TestDoraReportsUnreadableGitRatherThanAFalseVerdict is the user-visible half
+// of #1543. Three different non-answers each used to reach the user as a
+// confident statement about their repository.
+//
+// RED-FIRST (each arm, with its `!answered` branch reverted to the old path):
+//
+//	unreadable root    -> Message = "project not found or not a git repository"
+//	unreadable tags    -> Message = "no releases found for this project"
+//	unreadable commits -> Available = true, with a lead time computed over the
+//	                      tags that happened to succeed
+func TestDoraReportsUnreadableGitRatherThanAFalseVerdict(t *testing.T) {
+	tags := []dora.TagInfo{{Name: "v0.1.0", Epoch: 1000}, {Name: "v0.2.0", Epoch: 2000}}
+	// v0.2.0 carries a REVERT commit, so DetectReverts produces a candidate and
+	// TagContaining is actually reached. Without it that arm asserts on a probe
+	// the code never calls, which is a green that proves nothing.
+	commits := map[string][]dora.CommitInfo{
+		"v0.1.0": {{Hash: "a", AuthorEpoch: 900}},
+		"v0.2.0": {{
+			Hash:        "b",
+			AuthorEpoch: 1900,
+			Body:        "Revert \"add a\"\n\nThis reverts commit aaaaaaa.\n",
+		}},
+	}
+
+	cases := []struct {
+		name   string
+		unread string
+		wasSay string // what the collapse used to claim
+	}{
+		{"repo root unread", "root", "project not found or not a git repository"},
+		{"release tags unread", "tags", "no releases found for this project"},
+		{"a release's commits unread", "commits", "a lead time over the tags that happened to succeed"},
+		{"the tag containing a revert unread", "tagcontaining", "a change failure rate missing that revert"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			git := &unreadGit{
+				root:      "/repo",
+				tags:      tags,
+				commits:   commits,
+				unreadFor: map[string]bool{tc.unread: true},
+			}
+			got, err := ComputeDoraMetrics(git, doraSessions("proj", "/repo/sub"), "proj", 0, 9999)
+			if err != nil {
+				t.Fatalf("ComputeDoraMetrics: %v", err)
+			}
+			if got.Available {
+				t.Errorf("reported Available:true on a git it could not read; it used to publish %s", tc.wasSay)
+			}
+			if got.Message != doraGitUnreadable {
+				t.Errorf("Message = %q, want %q — the old message (%q) is a claim about the "+
+					"repository made by a probe that never reached it", got.Message, doraGitUnreadable, tc.wasSay)
+			}
+		})
+	}
+}
+
+// TestDoraStillReportsItsGenuineVerdicts is the vacuity guard for the test
+// above. Without it, a ComputeDoraMetrics that answered "could not read git"
+// unconditionally would pass every arm — and the two genuine verdicts below are
+// the ones the collapse was hiding behind, so losing them would be a regression
+// wearing the fix's clothes.
+func TestDoraStillReportsItsGenuineVerdicts(t *testing.T) {
+	t.Run("no session resolves to a repo", func(t *testing.T) {
+		git := &unreadGit{root: ""}
+		got, err := ComputeDoraMetrics(git, doraSessions("proj", "/nowhere"), "proj", 0, 9999)
+		if err != nil {
+			t.Fatalf("ComputeDoraMetrics: %v", err)
+		}
+		if got.Available || got.Message != "project not found or not a git repository" {
+			t.Errorf("got (%v, %q), want a genuine not-a-repo verdict", got.Available, got.Message)
+		}
+	})
+
+	t.Run("a repo with no release tags", func(t *testing.T) {
+		git := &unreadGit{root: "/repo", tags: nil}
+		got, err := ComputeDoraMetrics(git, doraSessions("proj", "/repo/sub"), "proj", 0, 9999)
+		if err != nil {
+			t.Fatalf("ComputeDoraMetrics: %v", err)
+		}
+		if got.Available || got.Message != "no releases found for this project" {
+			t.Errorf("got (%v, %q), want a genuine no-releases verdict", got.Available, got.Message)
+		}
+	})
+
+	t.Run("a healthy repo still computes", func(t *testing.T) {
+		git := &unreadGit{
+			root: "/repo",
+			tags: []dora.TagInfo{{Name: "v0.1.0", Epoch: 1000}, {Name: "v0.2.0", Epoch: 2000}},
+			commits: map[string][]dora.CommitInfo{
+				"v0.1.0": {{Hash: "a", AuthorEpoch: 900}},
+				"v0.2.0": {{Hash: "b", AuthorEpoch: 1900}},
+			},
+		}
+		got, err := ComputeDoraMetrics(git, doraSessions("proj", "/repo/sub"), "proj", 0, 9999)
+		if err != nil {
+			t.Fatalf("ComputeDoraMetrics: %v", err)
+		}
+		if !got.Available {
+			t.Errorf("a fully readable repo reported Available:false (%q)", got.Message)
+		}
+	})
+}
+
+// TestResolveDoraProjectRootAnswersWhenAnyCandidateDid pins the one place the
+// non-answer must NOT propagate. The question is "where is this project's repo
+// root", and one candidate cwd resolving answers it — so a second candidate
+// that went unread is not a failure. Reporting unreadable there would blank a
+// chart the daemon has everything it needs to draw.
+func TestResolveDoraProjectRootAnswersWhenAnyCandidateDid(t *testing.T) {
+	// A git that fails the FIRST cwd and resolves the second.
+	seen := 0
+	git := &countingRootGit{fn: func(cwd string) (string, bool) {
+		seen++
+		if seen == 1 {
+			return "", false
+		}
+		return "/repo", true
+	}}
+	sessions := oneSession{states: []*session.SessionState{
+		{SessionID: "a", ProjectName: "proj", CWD: "/one", State: session.StateReady},
+		{SessionID: "b", ProjectName: "proj", CWD: "/two", State: session.StateReady},
+	}}
+
+	root, answered, err := resolveDoraProjectRoot(git, sessions, "proj")
+	if err != nil {
+		t.Fatalf("resolveDoraProjectRoot: %v", err)
+	}
+	if !answered {
+		t.Error("reported unreadable although a later candidate resolved the root")
+	}
+	if root != "/repo" {
+		t.Errorf("root = %q, want /repo", root)
+	}
+
+	t.Run("every candidate unread is unreadable", func(t *testing.T) {
+		all := &countingRootGit{fn: func(string) (string, bool) { return "", false }}
+		_, answered, err := resolveDoraProjectRoot(all, sessions, "proj")
+		if err != nil {
+			t.Fatalf("resolveDoraProjectRoot: %v", err)
+		}
+		if answered {
+			t.Error("every candidate went unread, but the result was reported as an answer")
+		}
+	})
+
+	t.Run("no candidate at all is an answer", func(t *testing.T) {
+		none := &countingRootGit{fn: func(string) (string, bool) { return "", true }}
+		_, answered, err := resolveDoraProjectRoot(none, oneSession{}, "proj")
+		if err != nil {
+			t.Fatalf("resolveDoraProjectRoot: %v", err)
+		}
+		if !answered {
+			t.Error("a project with no sessions is a normal nothing-to-compute outcome, not an unreadable git")
+		}
+	})
+}
+
+type countingRootGit struct {
+	fn func(string) (string, bool)
+	unreadGit
+}
+
+func (g *countingRootGit) GetGitRoot(cwd string) (string, bool) { return g.fn(cwd) }
+
+// enricherGit is a GitResolver whose branch/name probes report a non-answer.
+type enricherGit struct {
+	branchAnswered bool
+	nameAnswered   bool
+	headAnswered   bool
+	branch         string
+	name           string
+	head           string
+}
+
+func (g *enricherGit) GetBranch(string) (string, bool)       { return g.branch, g.branchAnswered }
+func (g *enricherGit) GetProjectName(string) (string, bool)  { return g.name, g.nameAnswered }
+func (g *enricherGit) GetGitRoot(string) (string, bool)      { return "", true }
+func (g *enricherGit) GetHeadCommit(string) (string, bool)   { return g.head, g.headAnswered }
+func (g *enricherGit) GetBranchFromTranscript(string) string { return "" }
+func (g *enricherGit) GetCWDFromTranscript(string) string    { return "" }
+
+// TestBackfillDoesNotMarkASessionDoneOnANonAnswer is the permanence bug, and it
+// is the sharpest of the four: backfillOne returns early when ProjectName is
+// already set, so a session that stored a value from a git which never ran was
+// never revisited. One transient failure at first enrichment left a session
+// with no project and no branch for the rest of its life.
+//
+// RED-FIRST (with the adoptIfAnswered calls reverted to unconditional
+// assignment): "a non-answer marked the session updated; it will never be
+// retried". Measured by reverting the arm.
+func TestBackfillDoesNotMarkASessionDoneOnANonAnswer(t *testing.T) {
+	e := newMetadataEnricher(&enricherGit{name: "guess", branch: "guess"}, nil)
+	st := &session.SessionState{SessionID: "s", CWD: "/repo/sub"}
+
+	if e.backfillOne(st) {
+		t.Error("a non-answer marked the session updated; because backfillOne returns early once " +
+			"ProjectName is set, that verdict would never be revisited")
+	}
+	if st.ProjectName != "" {
+		t.Errorf("ProjectName = %q — a guess from a git that never ran was stored as resolved", st.ProjectName)
+	}
+	if st.GitBranch != "" {
+		t.Errorf("GitBranch = %q — same", st.GitBranch)
+	}
+
+	// Vacuity guard: an answer must still backfill, or a backfillOne that did
+	// nothing at all would pass the arm above.
+	answering := newMetadataEnricher(&enricherGit{
+		nameAnswered: true, name: "proj",
+		branchAnswered: true, branch: "main",
+	}, nil)
+	fresh := &session.SessionState{SessionID: "s", CWD: "/repo/sub"}
+	if !answering.backfillOne(fresh) {
+		t.Fatal("a git that answered did not backfill")
+	}
+	if fresh.ProjectName != "proj" || fresh.GitBranch != "main" {
+		t.Errorf("got (%q, %q), want (proj, main)", fresh.ProjectName, fresh.GitBranch)
+	}
+}
+
+// TestCaptureYieldOnReadyDoesNotRecordAVerdictItDidNotReach pins the yield
+// path. "unknown" is not a neutral placeholder here — it is what
+// aggregateYieldBySession buckets a session's dollars into, and it is
+// persisted. A git that could not be run has not established it.
+//
+// RED-FIRST (with the `!answered` arm removed): "a non-answer was persisted as
+// the verdict YieldUnknown".
+func TestCaptureYieldOnReadyDoesNotRecordAVerdictItDidNotReach(t *testing.T) {
+	e := newMetadataEnricher(&enricherGit{}, nil)
+	st := &session.SessionState{SessionID: "s", CWD: "/repo", YieldState: session.YieldProductive, HeadCommit: "abc"}
+
+	e.CaptureYieldOnReady(st)
+
+	if st.YieldState != session.YieldProductive {
+		t.Errorf("YieldState = %q — a git that could not be run overwrote a verdict it did not reach", st.YieldState)
+	}
+	if st.HeadCommit != "abc" {
+		t.Errorf("HeadCommit = %q — a non-answer cleared a resolved commit", st.HeadCommit)
+	}
+
+	// Vacuity guard: a git that ANSWERS with no HEAD is a genuine
+	// not-a-git-repo verdict and must still be recorded.
+	genuine := newMetadataEnricher(&enricherGit{headAnswered: true, head: ""}, nil)
+	st2 := &session.SessionState{SessionID: "s", CWD: "/repo", YieldState: session.YieldProductive}
+	genuine.CaptureYieldOnReady(st2)
+	if st2.YieldState != session.YieldUnknown {
+		t.Errorf("YieldState = %q, want unknown — an answered empty HEAD IS the not-a-repo verdict", st2.YieldState)
+	}
+}
+
+// TestYieldSweepReportsRootsItCouldNotScan pins the sweeper. A revert scan that
+// never ran is not "this repo has no reverts": the sweep would report "nothing
+// flipped" for history it never read, with no log and nothing to look at.
+//
+// RED-FIRST (with collectRevertedSHAs's `!answered` arm removed): no error was
+// logged and the sweep reported a clean pass.
+func TestYieldSweepReportsRootsItCouldNotScan(t *testing.T) {
+	log := &recordingLogger{}
+	git := &unreadRevertGit{root: "/repo", unread: true}
+	s := NewYieldSweeper(&noopYieldStore{}, git, log, 0)
+
+	s.collectRevertedSHAs(map[string]string{"/repo": "/repo/sub"})
+
+	errs := log.errs
+	found := false
+	for _, e := range errs {
+		if strings.Contains(e, "could not read git history") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("a root whose revert scan never ran was not reported; logged: %v\n"+
+			"Silence here means the sweep reports \"nothing flipped\" for history it never read", errs)
+	}
+
+	// Vacuity guard: a sweep that read everything must log nothing, or a
+	// sweeper that always complained would pass the arm above.
+	quiet := &recordingLogger{}
+	NewYieldSweeper(&noopYieldStore{}, &unreadRevertGit{root: "/repo"}, quiet, 0).
+		collectRevertedSHAs(map[string]string{"/repo": "/repo/sub"})
+	for _, e := range quiet.errs {
+		if strings.Contains(e, "could not read git history") {
+			t.Errorf("a fully readable sweep logged an unread-roots error: %q", e)
+		}
+	}
+}
+
+// unreadRevertGit is a yieldGitProbe whose revert scan reports a non-answer.
+// Local to this file rather than reusing yield_sweeper_test.go's fakeYieldGit,
+// because that one lives in the EXTERNAL services_test package and these tests
+// need the unexported collectRevertedSHAs.
+type unreadRevertGit struct {
+	root   string
+	unread bool
+}
+
+func (g *unreadRevertGit) GetGitRoot(string) (string, bool) { return g.root, true }
+func (g *unreadRevertGit) RevertedCommits(string) ([]string, bool) {
+	if g.unread {
+		return nil, false
+	}
+	return nil, true
+}
+
+// recordingLogger keeps the error lines the sweeper writes. The sweep's whole
+// report of an unscanned root is a log line, so a test that could not read them
+// would be asserting on nothing.
+type recordingLogger struct{ errs []string }
+
+func (l *recordingLogger) LogInfo(_, _, _ string) {}
+func (l *recordingLogger) LogError(eventType, sessionID, msg string) {
+	l.errs = append(l.errs, eventType+" "+sessionID+" "+msg)
+}
+func (l *recordingLogger) LogProcessingTime(_, _ string, _ int64, _ int, _ string) {}
+func (l *recordingLogger) Close() error                                            { return nil }
+
+type noopYieldStore struct{}
+
+func (noopYieldStore) ListAll() ([]*session.SessionState, error)  { return nil, nil }
+func (noopYieldStore) Load(string) (*session.SessionState, error) { return nil, nil }
+func (noopYieldStore) Save(*session.SessionState) error           { return nil }

--- a/core/application/services/git_nonanswer_test.go
+++ b/core/application/services/git_nonanswer_test.go
@@ -356,9 +356,15 @@ func TestRefreshOnActivityNeverReportsAnotherDirectorysBranch(t *testing.T) {
 		t.Error("the session moved to /new/repo but still reports /old/repo's branch; that is a " +
 			"claim about the new directory the daemon never established")
 	}
-	if st.ProjectName == "old-project" {
-		t.Error("same for ProjectName — and while it is set, backfillOne returns early, so the " +
-			"stale value is permanent")
+	// ProjectName is the opposite obligation, and #1551's QA (B1) is where the
+	// first draft had it backwards: blanking it is DESTRUCTIVE, because an
+	// empty project name is bucketed as "unknown" by aggregateYieldBySession
+	// and is invisible to DORA. main kept it here, #1543's polarity says a
+	// non-answer leaves what we hold alone, and the only repair path is
+	// bounded and idle-only.
+	if st.ProjectName != "old-project" {
+		t.Errorf("ProjectName = %q — a git that could not be run destroyed a resolved project "+
+			"name, which costs the session its yield spend and its DORA membership", st.ProjectName)
 	}
 
 	// Vacuity guard: a git that ANSWERS must still update both, or an enricher
@@ -397,6 +403,18 @@ func TestCaptureYieldOnReadyDoesNotRecordAVerdictItDidNotReach(t *testing.T) {
 		t.Errorf("HeadCommit = %q — a non-answer cleared a resolved commit", st.HeadCommit)
 	}
 
+	// #1551 QA, B2: a session with NO verdict yet must not be left empty.
+	// aggregateYieldBySession skips YieldState == "" entirely, so an empty
+	// state removes the session's spend from the chart, where main put it in
+	// the unknown bucket. Unknown is the honest bucket for a non-answer.
+	fresh := &session.SessionState{SessionID: "s2", CWD: "/gone"}
+	e.CaptureYieldOnReady(fresh)
+	if fresh.YieldState != session.YieldUnknown {
+		t.Errorf("YieldState = %q for a first-ever non-answer, want unknown — an empty state is "+
+			"skipped by aggregateYieldBySession, so the session's spend leaves the yield chart "+
+			"altogether. A cleaned-up worktree makes this permanent, not transient.", fresh.YieldState)
+	}
+
 	// Vacuity guard: a git that ANSWERS with no HEAD is a genuine
 	// not-a-git-repo verdict and must still be recorded.
 	genuine := newMetadataEnricher(&enricherGit{headAnswered: true, head: "", rootAnswered: true}, nil)
@@ -432,6 +450,30 @@ func TestYieldSweepReportsRootsItCouldNotScan(t *testing.T) {
 		collectRevertedSHAs(map[string]string{"/repo": "/repo/sub"})
 	if quiet.errorMentioning("could not read git history") {
 		t.Errorf("a fully readable sweep logged an unread-roots error: %v", quiet.errors)
+	}
+}
+
+// TestYieldSweepScansTheRootNotAPossiblyDeletedCWD is #1551 QA finding B2's
+// second half. GetGitRoot walks up to the nearest existing ancestor, so it
+// answers for a cleaned-up worktree — but the cwd it resolved FROM may be gone,
+// and running the revert scan there fails at chdir before exec, which is a
+// permanent non-answer. Recording the cwd left that repo unscanned forever and,
+// once this PR added the report, logging it every 30 minutes.
+//
+// RED-FIRST: with `rootDirs[root] = cwd` this reports
+//
+//	scan dir = "/repo/worktrees/gone", want the resolved root "/repo"
+func TestYieldSweepScansTheRootNotAPossiblyDeletedCWD(t *testing.T) {
+	git := &unreadRevertGit{root: "/repo"}
+	s := NewYieldSweeper(&diagFakeRepo{}, git, &gateLog{}, 0)
+
+	rootDirs := map[string]string{}
+	if !s.recordRootDir(rootDirs, "/repo/worktrees/gone") {
+		t.Fatal("a resolvable root was reported as unresolved")
+	}
+	if got := rootDirs["/repo"]; got != "/repo" {
+		t.Errorf("scan dir = %q, want the resolved root %q — the cwd it was resolved from may "+
+			"no longer exist, and a deleted directory is a PERMANENT non-answer", got, "/repo")
 	}
 }
 

--- a/core/application/services/metadata_enricher.go
+++ b/core/application/services/metadata_enricher.go
@@ -19,6 +19,21 @@ type metadataEnricher struct {
 	metrics outbound.MetricsCollector
 }
 
+// baseNameOf is the non-git project-name fallback: the directory's own name,
+// or "" for the degenerate roots that are not a name. It mirrors the tail of
+// the git adapter's GetProjectName, which is the only other place this
+// fallback is spelled.
+func baseNameOf(dir string) string {
+	if dir == "" {
+		return ""
+	}
+	name := filepath.Base(dir)
+	if name == "." || name == "/" {
+		return ""
+	}
+	return name
+}
+
 // adoptIfAnswered writes v into *dst only when the git probe that produced it
 // actually RAN, and reports whether it did.
 //
@@ -171,8 +186,15 @@ func (e *metadataEnricher) RefreshOnActivity(state *session.SessionState, transc
 		case gitRoot != "":
 			state.ProjectName = filepath.Base(gitRoot)
 		case state.ProjectName == "":
-			name, nameAnswered := e.git.GetProjectName(cwd)
-			adoptIfAnswered(&state.ProjectName, name, nameAnswered)
+			// The basename is inlined rather than asked of GetProjectName,
+			// which would spend a SECOND bounded shellout to learn what this
+			// arm already knows: it is reachable only when the root probe
+			// answered and reported no repo, and GetProjectName's first act is
+			// to re-run exactly that probe. On main the empty root was
+			// ambiguous (error or not-a-repo) so re-asking was at least
+			// arguable; #1543 removed the ambiguity, which is what makes the
+			// second call provably dead rather than merely redundant.
+			state.ProjectName = baseNameOf(cwd)
 		}
 	}
 }

--- a/core/application/services/metadata_enricher.go
+++ b/core/application/services/metadata_enricher.go
@@ -19,6 +19,23 @@ type metadataEnricher struct {
 	metrics outbound.MetricsCollector
 }
 
+// adoptIfAnswered writes v into *dst only when the git probe that produced it
+// actually RAN, and reports whether it did.
+//
+// Every git read on this enricher's paths returns ("", false) when git could
+// not be run at all (outbound.GitResolver, #1543), and that empty string is
+// not evidence: assigning it clears a branch or project name the session
+// already resolved, which is #1485's shape one adapter over. Declining also
+// leaves backfillOne's retry open — see the note there, which is the half of
+// this that made a transient failure PERMANENT.
+func adoptIfAnswered(dst *string, v string, answered bool) bool {
+	if !answered {
+		return false
+	}
+	*dst = v
+	return true
+}
+
 // newMetadataEnricher creates a metadataEnricher with the given dependencies.
 func newMetadataEnricher(git outbound.GitResolver, metrics outbound.MetricsCollector) *metadataEnricher {
 	return &metadataEnricher{git: git, metrics: metrics}
@@ -34,7 +51,15 @@ func (e *metadataEnricher) CaptureYieldOnReady(state *session.SessionState) {
 	if state == nil || state.YieldState == session.YieldReverted {
 		return
 	}
-	head := e.git.GetHeadCommit(state.CWD)
+	head, answered := e.git.GetHeadCommit(state.CWD)
+	if !answered {
+		// "unknown" is a VERDICT here — it is what the yield ratio buckets a
+		// session's dollars into, and it is persisted. A git that could not be
+		// run has not established it (#1543). Leaving the state untouched is
+		// safe because this runs on every ready transition, so the next one
+		// re-asks.
+		return
+	}
 	if head == "" {
 		state.YieldState = session.YieldUnknown
 		return
@@ -58,13 +83,11 @@ func (e *metadataEnricher) EnrichNewSession(state *session.SessionState, ev agen
 	// Resolve git metadata.
 	if ev.CWD != "" {
 		state.CWD = ev.CWD
-		state.GitBranch = e.git.GetBranch(ev.CWD)
-		state.ProjectName = e.git.GetProjectName(ev.CWD)
+		e.adoptGitMetadata(state, ev.CWD)
 	} else if ev.TranscriptPath != "" {
 		if cwd := e.git.GetCWDFromTranscript(ev.TranscriptPath); cwd != "" {
 			state.CWD = cwd
-			state.GitBranch = e.git.GetBranch(cwd)
-			state.ProjectName = e.git.GetProjectName(cwd)
+			e.adoptGitMetadata(state, cwd)
 		} else if b := e.git.GetBranchFromTranscript(ev.TranscriptPath); b != "" {
 			state.GitBranch = b
 		}
@@ -84,10 +107,19 @@ func (e *metadataEnricher) EnrichNewSession(state *session.SessionState, ev agen
 		// an already-resolved cwd above wins.
 		if state.CWD == "" && m.LastCWD != "" {
 			state.CWD = m.LastCWD
-			state.GitBranch = e.git.GetBranch(m.LastCWD)
-			state.ProjectName = e.git.GetProjectName(m.LastCWD)
+			e.adoptGitMetadata(state, m.LastCWD)
 		}
 	}
+}
+
+// adoptGitMetadata fills branch and project name from cwd, leaving either
+// untouched when git could not be run for it. Leaving them empty is what keeps
+// backfillOne willing to try again later.
+func (e *metadataEnricher) adoptGitMetadata(state *session.SessionState, cwd string) {
+	branch, branchAnswered := e.git.GetBranch(cwd)
+	adoptIfAnswered(&state.GitBranch, branch, branchAnswered)
+	name, nameAnswered := e.git.GetProjectName(cwd)
+	adoptIfAnswered(&state.ProjectName, name, nameAnswered)
 }
 
 // RefreshOnActivity refreshes CWD/branch/project from the latest transcript
@@ -110,16 +142,26 @@ func (e *metadataEnricher) RefreshOnActivity(state *session.SessionState, transc
 	}
 	if cwd != "" && cwd != state.CWD {
 		state.CWD = cwd
-		state.GitBranch = e.git.GetBranch(cwd)
+		branch, branchAnswered := e.git.GetBranch(cwd)
+		// A non-answer must not clear the branch this session already
+		// resolved — an empty string from a git that never ran says nothing
+		// about which branch the worktree is on (#1543).
+		adoptIfAnswered(&state.GitBranch, branch, branchAnswered)
 		// Only update ProjectName when the new CWD is inside a git repo.
 		// For non-git directories, keep the original project name set at
 		// session creation to avoid subdirectory names overriding it.
 		// However, if ProjectName was never set (initial enrichment failed
 		// because the transcript was too new), use the full fallback chain.
-		if gitRoot := e.git.GetGitRoot(cwd); gitRoot != "" {
+		gitRoot, rootAnswered := e.git.GetGitRoot(cwd)
+		switch {
+		case !rootAnswered:
+			// Neither branch of the original applies: "not inside a repo" is
+			// exactly what was not established.
+		case gitRoot != "":
 			state.ProjectName = filepath.Base(gitRoot)
-		} else if state.ProjectName == "" {
-			state.ProjectName = e.git.GetProjectName(cwd)
+		case state.ProjectName == "":
+			name, nameAnswered := e.git.GetProjectName(cwd)
+			adoptIfAnswered(&state.ProjectName, name, nameAnswered)
 		}
 	}
 }
@@ -166,13 +208,19 @@ func (e *metadataEnricher) backfillOne(state *session.SessionState) bool {
 	if state.CWD == "" {
 		return updated
 	}
+	// updated is set only when git ANSWERED, and that is load-bearing rather
+	// than tidy. This function returns early above when ProjectName is
+	// already set, so a run that stored a value from a git which never ran
+	// would never be revisited: one transient failure at first enrichment
+	// left a session with no project and no branch for the rest of its life
+	// (#1543). Declining to store keeps the next sweep willing to ask again.
 	if state.ProjectName == "" {
-		state.ProjectName = e.git.GetProjectName(state.CWD)
-		updated = true
+		name, answered := e.git.GetProjectName(state.CWD)
+		updated = adoptIfAnswered(&state.ProjectName, name, answered) || updated
 	}
 	if state.GitBranch == "" {
-		state.GitBranch = e.git.GetBranch(state.CWD)
-		updated = true
+		branch, answered := e.git.GetBranch(state.CWD)
+		updated = adoptIfAnswered(&state.GitBranch, branch, answered) || updated
 	}
 	return updated
 }

--- a/core/application/services/metadata_enricher.go
+++ b/core/application/services/metadata_enricher.go
@@ -143,10 +143,22 @@ func (e *metadataEnricher) RefreshOnActivity(state *session.SessionState, transc
 	if cwd != "" && cwd != state.CWD {
 		state.CWD = cwd
 		branch, branchAnswered := e.git.GetBranch(cwd)
-		// A non-answer must not clear the branch this session already
-		// resolved — an empty string from a git that never ran says nothing
-		// about which branch the worktree is on (#1543).
-		adoptIfAnswered(&state.GitBranch, branch, branchAnswered)
+		// The session has MOVED, so #1485's "never overwrite what you already
+		// hold" does not apply: what is held describes the OLD directory.
+		// Keeping it would report another repo's branch — a false claim, where
+		// an empty one is only a missing one. So on a non-answer the stale
+		// values are dropped rather than kept, and dropping ProjectName is
+		// what reopens backfillOne, which returns early while it is set.
+		//
+		// state.CWD still advances: it comes from the transcript, not from
+		// git, so it is not the thing that went unread, and PID discovery
+		// needs it. What must stay consistent is the TRIPLE — cwd, branch and
+		// project all describing the same directory.
+		if !branchAnswered {
+			state.GitBranch = ""
+		} else {
+			state.GitBranch = branch
+		}
 		// Only update ProjectName when the new CWD is inside a git repo.
 		// For non-git directories, keep the original project name set at
 		// session creation to avoid subdirectory names overriding it.
@@ -155,8 +167,7 @@ func (e *metadataEnricher) RefreshOnActivity(state *session.SessionState, transc
 		gitRoot, rootAnswered := e.git.GetGitRoot(cwd)
 		switch {
 		case !rootAnswered:
-			// Neither branch of the original applies: "not inside a repo" is
-			// exactly what was not established.
+			state.ProjectName = ""
 		case gitRoot != "":
 			state.ProjectName = filepath.Base(gitRoot)
 		case state.ProjectName == "":

--- a/core/application/services/metadata_enricher.go
+++ b/core/application/services/metadata_enricher.go
@@ -68,11 +68,27 @@ func (e *metadataEnricher) CaptureYieldOnReady(state *session.SessionState) {
 	}
 	head, answered := e.git.GetHeadCommit(state.CWD)
 	if !answered {
-		// "unknown" is a VERDICT here — it is what the yield ratio buckets a
-		// session's dollars into, and it is persisted. A git that could not be
-		// run has not established it (#1543). Leaving the state untouched is
-		// safe because this runs on every ready transition, so the next one
-		// re-asks.
+		// A git that could not be run must not overwrite a verdict already
+		// reached — that is #1543's polarity, and it is why an existing
+		// productive/reverted state is left alone here.
+		//
+		// But leaving state.YieldState EMPTY is not neutral, and #1551's QA
+		// (B2) is where that surfaced: aggregateYieldBySession skips every
+		// session with YieldState == "" outright, so the session's spend
+		// vanishes from the yield chart rather than landing in the unknown
+		// bucket — where main put it, since main read "" from a failed
+		// GetHeadCommit and wrote YieldUnknown. Unknown is not a false claim
+		// here; it is the honest bucket for "we cannot attribute this", which
+		// is exactly what a non-answer means.
+		//
+		// This is reachable and not hypothetical: a cleaned-up worktree is a
+		// PERMANENT non-answer for GetHeadCommit (cmd.Dir fails at chdir before
+		// exec, so there is no exit status at all), so "the next ready
+		// transition re-asks" — which the first draft of this comment relied on
+		// — is true only for transient failures.
+		if state.YieldState == "" {
+			state.YieldState = session.YieldUnknown
+		}
 		return
 	}
 	if head == "" {
@@ -158,17 +174,16 @@ func (e *metadataEnricher) RefreshOnActivity(state *session.SessionState, transc
 	if cwd != "" && cwd != state.CWD {
 		state.CWD = cwd
 		branch, branchAnswered := e.git.GetBranch(cwd)
-		// The session has MOVED, so #1485's "never overwrite what you already
-		// hold" does not apply: what is held describes the OLD directory.
-		// Keeping it would report another repo's branch — a false claim, where
-		// an empty one is only a missing one. So on a non-answer the stale
-		// values are dropped rather than kept, and dropping ProjectName is
-		// what reopens backfillOne, which returns early while it is set.
+		// The session has MOVED, so what is held describes the OLD directory
+		// and #1485's "never overwrite what you already hold" does not protect
+		// it. Reporting another repo's branch is a false claim where an empty
+		// one is only a missing one, so the branch is dropped — which is also
+		// exactly what main did here (`state.GitBranch = e.git.GetBranch(cwd)`
+		// stored "" on failure), so this is not a behaviour change.
 		//
 		// state.CWD still advances: it comes from the transcript, not from
 		// git, so it is not the thing that went unread, and PID discovery
-		// needs it. What must stay consistent is the TRIPLE — cwd, branch and
-		// project all describing the same directory.
+		// needs it.
 		if !branchAnswered {
 			state.GitBranch = ""
 		} else {
@@ -179,10 +194,28 @@ func (e *metadataEnricher) RefreshOnActivity(state *session.SessionState, transc
 		// session creation to avoid subdirectory names overriding it.
 		// However, if ProjectName was never set (initial enrichment failed
 		// because the transcript was too new), use the full fallback chain.
+		// ProjectName is deliberately NOT dropped on a non-answer, and it is
+		// the one field where that asymmetry with GitBranch above is correct
+		// rather than an oversight (#1551 QA, B1).
+		//
+		// Blanking it is destructive in a way blanking a branch is not: an
+		// empty ProjectName is bucketed as literally "unknown" by
+		// aggregateYieldBySession and is invisible to DORA, whose
+		// resolveDoraProjectRoot filters on `st.ProjectName != project`. So a
+		// git that merely failed to run costs the session its yield spend and
+		// its DORA membership.
+		//
+		// It is also what main did — `else if state.ProjectName == ""` is
+		// false for an already-named session, so main kept it — and it is what
+		// #1543's own polarity requires: a non-answer leaves what we already
+		// hold alone. The repair path is real but BOUNDED and idle-only
+		// (retryIdleProjectResolution, capped by
+		// maxIdleProjectResolveAttempts), so it cannot be relied on to undo a
+		// blanking; that is why nothing here claims a sweep will fix it.
 		gitRoot, rootAnswered := e.git.GetGitRoot(cwd)
 		switch {
 		case !rootAnswered:
-			state.ProjectName = ""
+			// Leave ProjectName exactly as it is.
 		case gitRoot != "":
 			state.ProjectName = filepath.Base(gitRoot)
 		case state.ProjectName == "":
@@ -242,11 +275,19 @@ func (e *metadataEnricher) backfillOne(state *session.SessionState) bool {
 		return updated
 	}
 	// updated is set only when git ANSWERED, and that is load-bearing rather
-	// than tidy. This function returns early above when ProjectName is
-	// already set, so a run that stored a value from a git which never ran
-	// would never be revisited: one transient failure at first enrichment
-	// left a session with no project and no branch for the rest of its life
-	// (#1543). Declining to store keeps the next sweep willing to ask again.
+	// than tidy. This function returns early above when ProjectName is already
+	// set, so a run that stored a value from a git which never ran would not be
+	// revisited here: one transient failure at first enrichment left a session
+	// with no project and no branch (#1543).
+	//
+	// What re-asks is NOT a sweep — there is no periodic backfill, and saying
+	// so precisely matters because the first draft of this comment claimed one
+	// (#1551 QA, B1). BackfillMetadata runs once, from seedBackfillMetadata at
+	// daemon start. The only other caller is retryIdleProjectResolution, which
+	// fires for an IDLE session whose ProjectName is still empty and is capped
+	// at maxIdleProjectResolveAttempts. So declining to store keeps that
+	// bounded retry open; it does not promise the value will eventually
+	// arrive.
 	if state.ProjectName == "" {
 		name, answered := e.git.GetProjectName(state.CWD)
 		updated = adoptIfAnswered(&state.ProjectName, name, answered) || updated

--- a/core/application/services/session_detector_bornready_test.go
+++ b/core/application/services/session_detector_bornready_test.go
@@ -13,8 +13,8 @@ import (
 // unexpected call panics loudly rather than silently returning a zero value.
 type bornGit struct{ outbound.GitResolver }
 
-func (bornGit) GetBranch(string) string      { return "main" }
-func (bornGit) GetProjectName(string) string { return "project" }
+func (bornGit) GetBranch(string) (string, bool)      { return "main", true }
+func (bornGit) GetProjectName(string) (string, bool) { return "project", true }
 
 type bornLog struct{ outbound.Logger }
 

--- a/core/application/services/testhelpers_test.go
+++ b/core/application/services/testhelpers_test.go
@@ -312,15 +312,15 @@ func (l *mockLogger) errorSnapshot() []string {
 
 type mockGit struct{}
 
-func (g *mockGit) GetBranch(dir string) string { return "main" }
-func (g *mockGit) GetProjectName(dir string) string {
+func (g *mockGit) GetBranch(dir string) (string, bool) { return "main", true }
+func (g *mockGit) GetProjectName(dir string) (string, bool) {
 	if dir == "" {
-		return ""
+		return "", true
 	}
-	return "project"
+	return "project", true
 }
-func (g *mockGit) GetGitRoot(dir string) string               { return "" }
-func (g *mockGit) GetHeadCommit(dir string) string            { return "" }
+func (g *mockGit) GetGitRoot(dir string) (string, bool)       { return "", true }
+func (g *mockGit) GetHeadCommit(dir string) (string, bool)    { return "", true }
 func (g *mockGit) GetBranchFromTranscript(path string) string { return "" }
 func (g *mockGit) GetCWDFromTranscript(path string) string    { return "" }
 

--- a/core/application/services/yield_sweeper.go
+++ b/core/application/services/yield_sweeper.go
@@ -101,7 +101,9 @@ func (s *YieldSweeper) indexByCommit(sessions []*session.SessionState) (map[stri
 			continue
 		}
 		byCommit[st.HeadCommit] = append(byCommit[st.HeadCommit], st)
-		s.recordRootDir(rootDirs, st.CWD, &unresolved)
+		if !s.recordRootDir(rootDirs, st.CWD) {
+			unresolved++
+		}
 	}
 	if unresolved > 0 {
 		s.logError("yield sweep could not resolve a repo root",
@@ -112,12 +114,14 @@ func (s *YieldSweeper) indexByCommit(sessions []*session.SessionState) (map[stri
 
 // recordRootDir resolves cwd's git root and, if no representative directory
 // is recorded for that root yet, records cwd as its sample directory for the
-// revert scan. A no-op for a non-git or empty cwd. unresolved counts the cwds
-// whose root probe never ANSWERED, which is a different fact from "not a repo"
-// and is reported rather than dropped.
-func (s *YieldSweeper) recordRootDir(rootDirs map[string]string, cwd string, unresolved *int) {
+// revert scan. A no-op for a non-git or empty cwd.
+//
+// resolved is false only when the root probe never ANSWERED — a different fact
+// from "not a repo", and the one the caller counts and reports rather than
+// dropping.
+func (s *YieldSweeper) recordRootDir(rootDirs map[string]string, cwd string) (resolved bool) {
 	if cwd == "" {
-		return
+		return true
 	}
 	root, answered := s.git.GetGitRoot(cwd)
 	if !answered {
@@ -126,15 +130,15 @@ func (s *YieldSweeper) recordRootDir(rootDirs map[string]string, cwd string, unr
 		// counted here instead and folded into the same single log line, or
 		// the sweep goes completely silent for history it never read, one step
 		// UPSTREAM of where #1543 fixed exactly that (#1551 review finding 4).
-		*unresolved++
-		return
+		return false
 	}
 	if root == "" {
-		return
+		return true
 	}
 	if _, seen := rootDirs[root]; !seen {
 		rootDirs[root] = cwd
 	}
+	return true
 }
 
 // collectRevertedSHAs gathers every reverted commit SHA across the deduped

--- a/core/application/services/yield_sweeper.go
+++ b/core/application/services/yield_sweeper.go
@@ -112,9 +112,9 @@ func (s *YieldSweeper) indexByCommit(sessions []*session.SessionState) (map[stri
 	return byCommit, rootDirs
 }
 
-// recordRootDir resolves cwd's git root and, if no representative directory
-// is recorded for that root yet, records cwd as its sample directory for the
-// revert scan. A no-op for a non-git or empty cwd.
+// recordRootDir resolves cwd's git root and, if that root is not recorded yet,
+// records it as the directory the revert scan will run in. A no-op for a
+// non-git or empty cwd.
 //
 // resolved is false only when the root probe never ANSWERED — a different fact
 // from "not a repo", and the one the caller counts and reports rather than
@@ -136,7 +136,15 @@ func (s *YieldSweeper) recordRootDir(rootDirs map[string]string, cwd string) (re
 		return true
 	}
 	if _, seen := rootDirs[root]; !seen {
-		rootDirs[root] = cwd
+		// The ROOT is the scan directory, not the cwd it was resolved from
+		// (#1551 QA, B2). GetGitRoot walks up to the nearest existing ancestor
+		// before asking git, so it answers for a cleaned-up worktree — but the
+		// cwd itself may no longer exist, and running the revert scan there
+		// fails at chdir before exec, which is a PERMANENT non-answer. That
+		// left the repo unscanned forever and, once this PR added the report,
+		// logging that it was unscanned every 30 minutes. root is guaranteed to
+		// exist: git just read its .git directory to produce it.
+		rootDirs[root] = root
 	}
 	return true
 }

--- a/core/application/services/yield_sweeper.go
+++ b/core/application/services/yield_sweeper.go
@@ -95,28 +95,41 @@ func (s *YieldSweeper) Sweep() int {
 func (s *YieldSweeper) indexByCommit(sessions []*session.SessionState) (map[string][]*session.SessionState, map[string]string) {
 	byCommit := make(map[string][]*session.SessionState)
 	rootDirs := make(map[string]string)
+	unresolved := 0
 	for _, st := range sessions {
 		if st == nil || st.HeadCommit == "" || st.YieldState == session.YieldReverted {
 			continue
 		}
 		byCommit[st.HeadCommit] = append(byCommit[st.HeadCommit], st)
-		s.recordRootDir(rootDirs, st.CWD)
+		s.recordRootDir(rootDirs, st.CWD, &unresolved)
+	}
+	if unresolved > 0 {
+		s.logError("yield sweep could not resolve a repo root",
+			fmt.Errorf("%d session cwd(s) unread: git did not answer, so their project was not scanned", unresolved))
 	}
 	return byCommit, rootDirs
 }
 
 // recordRootDir resolves cwd's git root and, if no representative directory
 // is recorded for that root yet, records cwd as its sample directory for the
-// revert scan. A no-op for a non-git or empty cwd.
-func (s *YieldSweeper) recordRootDir(rootDirs map[string]string, cwd string) {
+// revert scan. A no-op for a non-git or empty cwd. unresolved counts the cwds
+// whose root probe never ANSWERED, which is a different fact from "not a repo"
+// and is reported rather than dropped.
+func (s *YieldSweeper) recordRootDir(rootDirs map[string]string, cwd string, unresolved *int) {
 	if cwd == "" {
 		return
 	}
 	root, answered := s.git.GetGitRoot(cwd)
-	if !answered || root == "" {
-		// A non-answer drops this cwd from the scan exactly as a non-repo
-		// does, and collectRevertedSHAs is where that is reported — one line
-		// per sweep at most, rather than one per session.
+	if !answered {
+		// A cwd whose root never resolved never enters rootDirs, so
+		// collectRevertedSHAs — which walks that map — cannot report it. It is
+		// counted here instead and folded into the same single log line, or
+		// the sweep goes completely silent for history it never read, one step
+		// UPSTREAM of where #1543 fixed exactly that (#1551 review finding 4).
+		*unresolved++
+		return
+	}
+	if root == "" {
 		return
 	}
 	if _, seen := rootDirs[root]; !seen {

--- a/core/application/services/yield_sweeper.go
+++ b/core/application/services/yield_sweeper.go
@@ -25,8 +25,8 @@ type yieldSessionStore interface {
 // yieldGitProbe is the narrow git surface the sweeper needs: resolve a repo
 // root (to dedupe projects) and list the commits a repo has reverted.
 type yieldGitProbe interface {
-	GetGitRoot(dir string) string
-	RevertedCommits(dir string) []string
+	GetGitRoot(dir string) (root string, answered bool)
+	RevertedCommits(dir string) (shas []string, answered bool)
 }
 
 // YieldSweeper periodically correlates `git revert` commits back to the
@@ -112,8 +112,11 @@ func (s *YieldSweeper) recordRootDir(rootDirs map[string]string, cwd string) {
 	if cwd == "" {
 		return
 	}
-	root := s.git.GetGitRoot(cwd)
-	if root == "" {
+	root, answered := s.git.GetGitRoot(cwd)
+	if !answered || root == "" {
+		// A non-answer drops this cwd from the scan exactly as a non-repo
+		// does, and collectRevertedSHAs is where that is reported — one line
+		// per sweep at most, rather than one per session.
 		return
 	}
 	if _, seen := rootDirs[root]; !seen {
@@ -125,10 +128,26 @@ func (s *YieldSweeper) recordRootDir(rootDirs map[string]string, cwd string) {
 // project roots.
 func (s *YieldSweeper) collectRevertedSHAs(rootDirs map[string]string) map[string]bool {
 	reverted := make(map[string]bool)
+	unread := 0
 	for _, dir := range rootDirs {
-		for _, sha := range s.git.RevertedCommits(dir) {
+		shas, answered := s.git.RevertedCommits(dir)
+		if !answered {
+			// #1543: "git could not be run" is not "this repo has no
+			// reverts". The sweep is idempotent and re-runs every interval, so
+			// the correct response is to skip this root and say so — not to
+			// let an unscanned repo count as a scanned one with no findings,
+			// which is how a sweep reports "nothing flipped" for history it
+			// never read.
+			unread++
+			continue
+		}
+		for _, sha := range shas {
 			reverted[sha] = true
 		}
+	}
+	if unread > 0 {
+		s.logError("yield sweep could not read git history",
+			fmt.Errorf("%d of %d project root(s) unscanned: git did not answer", unread, len(rootDirs)))
 	}
 	return reverted
 }

--- a/core/application/services/yield_sweeper_test.go
+++ b/core/application/services/yield_sweeper_test.go
@@ -153,14 +153,13 @@ func TestYieldSweeper_Idempotent(t *testing.T) {
 type fakeYieldGit struct {
 	root     string
 	reverted []string
-	// rootUnread / revertsUnread make this double report a NON-ANSWER — git
-	// could not be run — rather than an empty answer (#1543).
-	rootUnread    bool
-	revertsUnread bool
 }
 
-func (f *fakeYieldGit) GetGitRoot(string) (string, bool)        { return f.root, !f.rootUnread }
-func (f *fakeYieldGit) RevertedCommits(string) ([]string, bool) { return f.reverted, !f.revertsUnread }
+// Always answers. The non-answer cases live in git_nonanswer_test.go, which is
+// in the INTERNAL services package because they need collectRevertedSHAs and
+// indexByCommit; a knob here would be scaffolding no test in this file sets.
+func (f *fakeYieldGit) GetGitRoot(string) (string, bool)        { return f.root, true }
+func (f *fakeYieldGit) RevertedCommits(string) ([]string, bool) { return f.reverted, true }
 
 // 1K sessions correlated against 10K reverted SHAs must complete well under the
 // 2s DoD bar. This measures the daemon's matching cost; the `git log` scan over

--- a/core/application/services/yield_sweeper_test.go
+++ b/core/application/services/yield_sweeper_test.go
@@ -153,10 +153,14 @@ func TestYieldSweeper_Idempotent(t *testing.T) {
 type fakeYieldGit struct {
 	root     string
 	reverted []string
+	// rootUnread / revertsUnread make this double report a NON-ANSWER — git
+	// could not be run — rather than an empty answer (#1543).
+	rootUnread    bool
+	revertsUnread bool
 }
 
-func (f *fakeYieldGit) GetGitRoot(string) string        { return f.root }
-func (f *fakeYieldGit) RevertedCommits(string) []string { return f.reverted }
+func (f *fakeYieldGit) GetGitRoot(string) (string, bool)        { return f.root, !f.rootUnread }
+func (f *fakeYieldGit) RevertedCommits(string) ([]string, bool) { return f.reverted, !f.revertsUnread }
 
 // 1K sessions correlated against 10K reverted SHAs must complete well under the
 // 2s DoD bar. This measures the daemon's matching cost; the `git log` scan over

--- a/core/architecture_hookbody_shapes_test.go
+++ b/core/architecture_hookbody_shapes_test.go
@@ -452,12 +452,23 @@ func writeShapeCorpus(t *testing.T, shapes []shapeCase) string {
 // row and as a detector bug for every want:true one.
 func plantedShapeIsPresent(t *testing.T, shape shapeCase) {
 	t.Helper()
-	if shape.needle == "" {
-		t.Fatalf("shape %s declares no needle; every case must assert the construct it plants is present", shape.file)
+	assertPlantedShapePresent(t, shape.file, shape.src, shape.needle)
+}
+
+// assertPlantedShapePresent is the corpus-agnostic half, shared with
+// architecture_shellout_shapes_test.go (#1543). Both corpora are in package
+// core_test, so this is one fact rather than two — and the shellout corpus's
+// first draft re-inlined only the "contains" half, so a row that declared no
+// needle at all passed silently, which is the failure this guard exists to
+// prevent happening inside the guard.
+func assertPlantedShapePresent(t *testing.T, id, src, needle string) {
+	t.Helper()
+	if needle == "" {
+		t.Fatalf("shape %s declares no needle; every case must assert the construct it plants is present", id)
 	}
-	if !strings.Contains(shape.src, shape.needle) {
+	if !strings.Contains(src, needle) {
 		t.Fatalf("shape %s does not contain its own needle %q — the case is not testing what it says it tests",
-			shape.file, shape.needle)
+			id, needle)
 	}
 }
 

--- a/core/architecture_shellout_shapes_test.go
+++ b/core/architecture_shellout_shapes_test.go
@@ -1,0 +1,259 @@
+package core_test
+
+import (
+	"go/parser"
+	"go/token"
+	"strings"
+	"testing"
+)
+
+// This is the committed mutation evidence for architecture_shellout_test.go's
+// rule, in the shape architecture_hookbody_shapes_test.go uses: one row per
+// spelling, pinned to the verdict the detector must return.
+//
+// It is committed rather than described because a mutation recorded only in a
+// merged PR body is re-run by nothing, and a detector that silently stops
+// discriminating looks exactly like a clean tree (AGENTS.md, Testing).
+//
+// The `want: 0` rows carry as much of the value as the `want: 1` rows. A
+// detector that flags everything and one that flags correctly are
+// indistinguishable without cases that must stay SILENT — and three of the
+// silent rows below are false positives a text-based `grep exec.Command` rule
+// produces, which is the rule anyone would reach for first.
+type shelloutShape struct {
+	name        string
+	src         string // a complete file in package shapes
+	needle      string // a substring that MUST still appear in src
+	want        int    // findings the detector must report
+	wantBounded int    // boundable sites it must SEE (0 findings from 0 sites proves nothing)
+	why         string
+}
+
+func shelloutShapes() []shelloutShape {
+	return []shelloutShape{
+		// ---- caught ----
+		{
+			name:   "plain_exec_command",
+			needle: `exec.Command(`,
+			want:   1, wantBounded: 0,
+			why: "#1543's exact shape: seven of these in the git adapter, no context, no ceiling.",
+			src: `package shapes
+
+import "os/exec"
+
+func f() ([]byte, error) {
+	cmd := exec.Command("git", "rev-parse", "HEAD")
+	return cmd.Output()
+}
+`,
+		},
+		{
+			name:   "exec_command_chained_without_a_variable",
+			needle: `exec.Command("git", "status").Output()`,
+			want:   1, wantBounded: 0,
+			why: "The call is an operand rather than an assignment RHS; a rule keyed on assignment misses it.",
+			src: `package shapes
+
+import "os/exec"
+
+func f() ([]byte, error) { return exec.Command("git", "status").Output() }
+`,
+		},
+		{
+			name:   "exec_command_inside_a_closure",
+			needle: `exec.Command(`,
+			want:   1, wantBounded: 0,
+			why: "A nested function literal is still core/ source; #1538's guard had to grow closure walking for the same reason.",
+			src: `package shapes
+
+import "os/exec"
+
+var build = func() error { return exec.Command("git", "gc").Run() }
+`,
+		},
+		{
+			name:   "commandcontext_with_bare_background",
+			needle: `context.Background()`,
+			want:   1, wantBounded: 0,
+			why: "exec.Command wearing a context: it reads as bounded to anyone skimming for CommandContext, and nothing can ever cancel it.",
+			src: `package shapes
+
+import (
+	"context"
+	"os/exec"
+)
+
+func f() error { return exec.CommandContext(context.Background(), "git", "fsck").Run() }
+`,
+		},
+		{
+			name:   "commandcontext_with_bare_todo",
+			needle: `context.TODO()`,
+			want:   1, wantBounded: 0,
+			why: "context.TODO() is the same hole as Background() and is what a half-finished refactor leaves behind.",
+			src: `package shapes
+
+import (
+	"context"
+	"os/exec"
+)
+
+func f() error { return exec.CommandContext(context.TODO(), "git", "fsck").Run() }
+`,
+		},
+		{
+			name:   "two_sites_one_bounded_one_not",
+			needle: `exec.CommandContext(ctx`,
+			want:   1, wantBounded: 1,
+			why: "A function with one correct shellout is exactly where a second, unbounded one gets added; the correct one must not vouch for it.",
+			src: `package shapes
+
+import (
+	"context"
+	"os/exec"
+)
+
+func f(ctx context.Context) {
+	_ = exec.CommandContext(ctx, "git", "status").Run()
+	_ = exec.Command("git", "gc").Run()
+}
+`,
+		},
+
+		// ---- clean ----
+		{
+			name:   "commandcontext_with_a_derived_context",
+			needle: `exec.CommandContext(ctx`,
+			want:   0, wantBounded: 1,
+			why: "The vacuity guard for every row above: the sanctioned spelling must be silent, or a detector that flags everything would satisfy them all.",
+			src: `package shapes
+
+import (
+	"context"
+	"os/exec"
+	"time"
+)
+
+func f() error {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	return exec.CommandContext(ctx, "git", "status").Run()
+}
+`,
+		},
+		{
+			name:   "commandcontext_with_a_caller_supplied_context",
+			needle: `func f(ctx context.Context)`,
+			want:   0, wantBounded: 1,
+			why: "A DECLARED LIMIT, pinned so it is learned from a test rather than an incident: this rule cannot see whether ctx carries a deadline, only that one can reach the child.",
+			src: `package shapes
+
+import (
+	"context"
+	"os/exec"
+)
+
+func f(ctx context.Context) error { return exec.CommandContext(ctx, "git", "status").Run() }
+`,
+		},
+		{
+			name:   "a_different_package_named_exec",
+			needle: `myexec.Command(`,
+			want:   0, wantBounded: 0,
+			why: "A false positive a text grep for 'exec.Command(' produces. Matching requires the selector's own package identifier to be exec.",
+			src: `package shapes
+
+import myexec "example.com/notos/exec"
+
+func f() { myexec.Command("anything") }
+`,
+		},
+		{
+			name:   "a_method_named_Command_on_a_local_value",
+			needle: `runner.Command(`,
+			want:   0, wantBounded: 0,
+			why: "Second text-grep false positive: a receiver that happens to be spelled with a Command method starts no child process.",
+			src: `package shapes
+
+type shell struct{}
+
+func (shell) Command(string) error { return nil }
+
+func f(runner shell) error { return runner.Command("git") }
+`,
+		},
+		{
+			name:   "the_word_exec_Command_in_a_comment_or_string",
+			needle: `"never use exec.Command here"`,
+			want:   0, wantBounded: 0,
+			why: "Third text-grep false positive, and the one most likely to appear for real — a doc comment naming the banned spelling, exactly as this repo's own comments do.",
+			src: `package shapes
+
+// f must never use exec.Command; see #1543.
+const advice = "never use exec.Command here"
+`,
+		},
+		{
+			name:   "a_bare_Command_call_with_no_package_qualifier",
+			needle: `= Command(`,
+			want:   0, wantBounded: 0,
+			why: "A DECLARED LIMIT: a dot-import of os/exec would make this a real child process and the rule would miss it. Nothing in core/ dot-imports, and pinning it here means the gap is a known fact rather than a surprise.",
+			src: `package shapes
+
+func Command(string) error { return nil }
+
+var err = Command("git")
+`,
+		},
+	}
+}
+
+// TestShelloutBoundScanCatchesEveryKnownShape drives the PRODUCTION detector
+// (scanShelloutBounds), not a copy of it — a corpus grading a reimplementation
+// grades the wrong thing.
+func TestShelloutBoundScanCatchesEveryKnownShape(t *testing.T) {
+	seen := map[string]bool{}
+	totalFindings, totalBounded := 0, 0
+
+	for _, sh := range shelloutShapes() {
+		if seen[sh.name] {
+			t.Fatalf("duplicate shape name %q — one row is silently shadowing another", sh.name)
+		}
+		seen[sh.name] = true
+
+		t.Run(sh.name, func(t *testing.T) {
+			// Anti-rot: a row whose source stopped containing the construct it
+			// plants would pass on a detector that reports nothing, which is
+			// the "verification mechanism that cannot run" failure inside the
+			// mechanism meant to catch it (AGENTS.md).
+			if !strings.Contains(sh.src, sh.needle) {
+				t.Fatalf("shape %q no longer contains %q — it is not testing what it claims", sh.name, sh.needle)
+			}
+
+			fset := token.NewFileSet()
+			f, err := parser.ParseFile(fset, sh.name+".go", sh.src, parser.ParseComments)
+			if err != nil {
+				t.Fatalf("parse: %v", err)
+			}
+			findings, bounded := scanShelloutBounds(fset, f, sh.name+".go")
+
+			if len(findings) != sh.want {
+				t.Errorf("got %d finding(s), want %d — %s\nfindings: %v", len(findings), sh.want, sh.why, findings)
+			}
+			if bounded != sh.wantBounded {
+				t.Errorf("saw %d boundable site(s), want %d — %s", bounded, sh.wantBounded, sh.why)
+			}
+			totalFindings += len(findings)
+			totalBounded += bounded
+		})
+	}
+
+	// Two opposite vacuity guards over the corpus as a whole, because each
+	// alone is satisfied by a detector stuck in one direction.
+	if totalFindings == 0 {
+		t.Fatal("the whole corpus produced no findings — the detector reports nothing, so every want:0 row above is meaningless")
+	}
+	if totalBounded == 0 {
+		t.Fatal("the whole corpus saw no boundable sites — the live rule's floor could not notice a scan that stopped looking")
+	}
+}

--- a/core/architecture_shellout_shapes_test.go
+++ b/core/architecture_shellout_shapes_test.go
@@ -3,7 +3,6 @@ package core_test
 import (
 	"go/parser"
 	"go/token"
-	"strings"
 	"testing"
 )
 
@@ -251,10 +250,10 @@ func TestShelloutBoundScanCatchesEveryKnownShape(t *testing.T) {
 			// Anti-rot: a row whose source stopped containing the construct it
 			// plants would pass on a detector that reports nothing, which is
 			// the "verification mechanism that cannot run" failure inside the
-			// mechanism meant to catch it (AGENTS.md).
-			if !strings.Contains(sh.src, sh.needle) {
-				t.Fatalf("shape %q no longer contains %q — it is not testing what it claims", sh.name, sh.needle)
-			}
+			// mechanism meant to catch it (AGENTS.md). Shared with the
+			// hookbody corpus, which also refuses a row declaring NO needle —
+			// the case this file's first draft let through silently.
+			assertPlantedShapePresent(t, sh.name, sh.src, sh.needle)
 
 			fset := token.NewFileSet()
 			f, err := parser.ParseFile(fset, sh.name+".go", sh.src, parser.ParseComments)

--- a/core/architecture_shellout_shapes_test.go
+++ b/core/architecture_shellout_shapes_test.go
@@ -194,6 +194,32 @@ const advice = "never use exec.Command here"
 `,
 		},
 		{
+			name:   "an_aliased_import_of_os_exec_is_NOT_caught",
+			needle: `xexec.Command(`,
+			want:   0, wantBounded: 0,
+			why: "a DECLARED LIMIT (#1551 review finding 9), pinned so it is learned from a test rather than an incident: matching is on the selector's package identifier, and this scan has no type information. The sibling guard in processlifecycle pins the same limit for the same reason.",
+			src: `package shapes
+
+import xexec "os/exec"
+
+func f() error { return xexec.Command("git", "gc").Run() }
+`,
+		},
+		{
+			name:   "os_StartProcess_is_NOT_caught",
+			needle: `os.StartProcess(`,
+			want:   0, wantBounded: 0,
+			why: "a DECLARED LIMIT: a child can be started without os/exec at all. Nothing in core/ does, and widening the rule to os.StartProcess would need the same type information the alias case does.",
+			src: `package shapes
+
+import "os"
+
+func f() (*os.Process, error) {
+	return os.StartProcess("/usr/bin/git", []string{"git", "gc"}, &os.ProcAttr{})
+}
+`,
+		},
+		{
 			name:   "a_bare_Command_call_with_no_package_qualifier",
 			needle: `= Command(`,
 			want:   0, wantBounded: 0,

--- a/core/architecture_shellout_shapes_test.go
+++ b/core/architecture_shellout_shapes_test.go
@@ -193,6 +193,47 @@ const advice = "never use exec.Command here"
 `,
 		},
 		{
+			name:   "exec_Cmd_built_as_a_struct_literal",
+			needle: `&exec.Cmd{`,
+			want:   1, wantBounded: 0,
+			why: "#1551 QA, S1: the natural thing to reach for once exec.Command is banned, and the WORST of the three — exec.Cmd has no exported context field, so this is unbounded by construction rather than by omission.",
+			src: `package shapes
+
+import "os/exec"
+
+func f() error {
+	cmd := &exec.Cmd{Path: "/usr/bin/git", Args: []string{"git", "gc"}}
+	return cmd.Run()
+}
+`,
+		},
+		{
+			name:   "a_package_level_var_holding_exec_Command_is_NOT_caught",
+			needle: `var run = exec.Command`,
+			want:   0, wantBounded: 0,
+			why: "a DECLARED LIMIT (#1551 QA, S1), measured: the rule matches the CALLEE, and `run(...)` names an Ident whose value is only knowable with type information.",
+			src: `package shapes
+
+import "os/exec"
+
+var run = exec.Command
+
+func f() error { return run("git", "gc").Run() }
+`,
+		},
+		{
+			name:   "a_child_started_through_a_value_built_elsewhere_is_NOT_caught",
+			needle: `builder.build("git", "gc").Run()`,
+			want:   0, wantBounded: 0,
+			why: "a DECLARED LIMIT (#1551 QA, S1): with no exec.* selector in the file there is nothing syntactic to match. Note the sibling shape WITH the builder in the same file IS caught, via the exec.Command inside it — the gap is cross-file, not the method value itself.",
+			src: `package shapes
+
+type cmdBuilder interface{ build(string, ...string) interface{ Run() error } }
+
+func f(builder cmdBuilder) error { return builder.build("git", "gc").Run() }
+`,
+		},
+		{
 			name:   "an_aliased_import_of_os_exec_is_NOT_caught",
 			needle: `xexec.Command(`,
 			want:   0, wantBounded: 0,

--- a/core/architecture_shellout_test.go
+++ b/core/architecture_shellout_test.go
@@ -1,0 +1,220 @@
+// architecture_shellout_test.go is the third architecture rule in this
+// directory, and like architecture_hookbody_test.go it is deliberately a
+// separate file from architecture_test.go's layering table.
+//
+// The layering table asks a question about the IMPORT GRAPH. This one asks
+// which EXPRESSIONS may appear anywhere under core/:
+//
+//	A child process started from core/ must be built with
+//	exec.CommandContext, and the context it is given must not be a bare
+//	context.Background()/TODO() written at the call site.
+//
+// WHY IT EXISTS. Six issues (#1485, #1492, #1513, #1524, #1533, #1537) fixed
+// one sentence six times — "I could not look" collapsed into "I looked and
+// there was nothing" — and #1538 gave processlifecycle a shared predicate plus
+// a package-local AST guard so a seventh instance there would fail the build.
+// That guard scans `parsePackageSources(t, ".")`: its own directory. #1543 was
+// found in core/adapters/outbound/git, one hexagon layer away and completely
+// invisible to it — seven plain exec.Command calls with no context and no
+// timeout at all, inside a long-lived daemon.
+//
+// So the enforcement gap was not "processlifecycle might regress"; it was that
+// nothing anywhere asked the question of the rest of core/. This rule is the
+// repo-wide half, and it is deliberately the WEAKER, cheaper question:
+// processlifecycle's guard reasons per-site about what each call does with its
+// error, which is the strong property but needs per-package knowledge of the
+// classifiers in scope. This one asks only whether a bound can reach the child
+// at all — a question with the same answer in every package, and one an author
+// cannot satisfy by accident.
+//
+// WHAT IT DOES NOT COVER, stated because a rule whose limits are implied reads
+// as stronger than it is:
+//
+//   - It does not check that the context carries a DEADLINE. `ctx` derived
+//     from a caller-supplied context satisfies this rule whether or not
+//     anything ever called WithTimeout on it. Catching that needs dataflow the
+//     syntactic scan does not have; what stops it in practice is that the
+//     ceiling is then a named constant per package, which is a reviewable
+//     absence rather than an invisible one.
+//   - It says nothing about CLASSIFICATION — whether a non-answer is
+//     distinguishable from an empty answer at the call site. That is
+//     processlifecycle's guard, and core/pkg/shellout.Answered is the shared
+//     predicate #1543 promoted so a second package could reach it.
+//   - It is scoped to core/. tools/ is a separate module of developer tooling
+//     that is not a long-lived daemon.
+//
+// There is deliberately NO EXEMPTION LIST, for the reason architecture_test.go
+// and architecture_hookbody_test.go have none: a call site that genuinely
+// needs an unbounded child amends the rule in a reviewable diff, where an
+// exemption list accumulates entries nobody re-reads.
+//
+// Like #1538's guard it parses SOURCE with go/parser rather than loading with
+// go/packages, and that is load-bearing rather than a convenience: eight of the
+// repo's shellouts are behind `//go:build darwin`, so a type-aware load on a
+// linux runner would find zero of them and pass — a gate whose absence reads as
+// a pass, which is the exact defect this family keeps producing.
+package core_test
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// shelloutBoundFinding is one child process that cannot be bounded.
+type shelloutBoundFinding struct {
+	File   string
+	Line   int
+	Reason string
+}
+
+func (f shelloutBoundFinding) String() string {
+	return f.File + ":" + strconv.Itoa(f.Line) + ": " + f.Reason
+}
+
+// scanShelloutBounds is the production detector, shared by the live rule and by
+// its corpus (architecture_shellout_shapes_test.go).
+//
+// It returns one finding per offending site, plus the number of BOUNDABLE sites
+// it saw. The second is what makes a silent "no findings" distinguishable from
+// a scan that looked at nothing — the same floor #1538's guard carries, and the
+// reason it is a count rather than a bool is that most of the tree could stop
+// being scanned while one survivor kept a `> 0` check green.
+func scanShelloutBounds(fset *token.FileSet, file *ast.File, name string) (findings []shelloutBoundFinding, bounded int) {
+	ast.Inspect(file, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+		pkg, ok := sel.X.(*ast.Ident)
+		if !ok || pkg.Name != "exec" {
+			return true
+		}
+		line := fset.Position(call.Pos()).Line
+		switch sel.Sel.Name {
+		case "Command":
+			findings = append(findings, shelloutBoundFinding{name, line,
+				"exec.Command starts a child no context can reach: it has no ceiling, and " +
+					"cmd.WaitDelay does nothing without one (measured — see " +
+					"core/adapters/outbound/git's TestOrphanHoldingStdoutIsANonAnswer). " +
+					"Use exec.CommandContext under a named per-package timeout (#1543)"})
+		case "CommandContext":
+			if len(call.Args) > 0 && isBareRootContext(call.Args[0]) {
+				findings = append(findings, shelloutBoundFinding{name, line,
+					"exec.CommandContext given a bare context.Background()/TODO() is exec.Command " +
+						"wearing a context: nothing can ever cancel it. Derive a bounded context " +
+						"first (#1543)"})
+				return true
+			}
+			bounded++
+		}
+		return true
+	})
+	return findings, bounded
+}
+
+// isBareRootContext reports whether e is literally context.Background() or
+// context.TODO() written at the call site.
+//
+// Only the LITERAL spelling: a variable that happens to hold one is invisible
+// here, and that is the declared limit rather than an oversight — the point is
+// that `exec.CommandContext(context.Background(), …)` reads as bounded to a
+// reviewer skimming for "CommandContext" while being exactly as unbounded as
+// exec.Command.
+func isBareRootContext(e ast.Expr) bool {
+	call, ok := e.(*ast.CallExpr)
+	if !ok || len(call.Args) != 0 {
+		return false
+	}
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok {
+		return false
+	}
+	pkg, ok := sel.X.(*ast.Ident)
+	if !ok || pkg.Name != "context" {
+		return false
+	}
+	return sel.Sel.Name == "Background" || sel.Sel.Name == "TODO"
+}
+
+// parseCoreSources parses every non-test .go file under core/, ignoring build
+// constraints on purpose — see the file header.
+func parseCoreSources(t *testing.T) (*token.FileSet, map[string]*ast.File) {
+	t.Helper()
+	fset := token.NewFileSet()
+	files := map[string]*ast.File{}
+	err := filepath.WalkDir(".", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			// testdata holds deliberately odd fixtures, and bin/ holds build
+			// output; neither is code this rule constrains.
+			if d.Name() == "testdata" || d.Name() == "bin" || d.Name() == "node_modules" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		f, perr := parser.ParseFile(fset, path, nil, 0)
+		if perr != nil {
+			return perr
+		}
+		files[path] = f
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk core/: %v", err)
+	}
+	if len(files) == 0 {
+		t.Fatalf("parsed no files under core/ — the scan is looking in the wrong place, so its silence proves nothing")
+	}
+	return fset, files
+}
+
+// TestEveryChildProcessInCoreCanBeBounded is the live rule.
+func TestEveryChildProcessInCoreCanBeBounded(t *testing.T) {
+	fset, files := parseCoreSources(t)
+
+	var findings []shelloutBoundFinding
+	total := 0
+	for name, f := range files {
+		got, bounded := scanShelloutBounds(fset, f, name)
+		findings = append(findings, got...)
+		total += bounded
+	}
+
+	// Vacuity guard. A rule reporting no violations because it found no
+	// shellouts is indistinguishable from a clean tree, and this one runs on a
+	// linux runner where most of them are behind a build tag it does not
+	// evaluate. The floor is deliberately below today's count (13, measured
+	// across 7 files) so an intentional removal does not fail here for the
+	// wrong reason, but a scan that stops seeing the tree fails loudly.
+	const knownBoundedSites = 10
+	if total < knownBoundedSites {
+		t.Fatalf("found %d boundable child-process sites under core/, expected at least %d: "+
+			"the scan is not looking where it thinks it is, so its silence proves nothing",
+			total, knownBoundedSites)
+	}
+
+	for _, f := range findings {
+		t.Errorf("%s", f)
+	}
+	if len(findings) > 0 {
+		t.Log("A child process this daemon cannot bound is one it can wait on forever: #1543's git adapter " +
+			"had seven, on directories that can be network mounts or repos holding a lock.")
+		t.Log("Fix: exec.CommandContext under a per-package named ceiling, and classify the result with " +
+			"core/pkg/shellout.Answered so a non-answer stays distinguishable from an empty answer.")
+	}
+}

--- a/core/architecture_shellout_test.go
+++ b/core/architecture_shellout_test.go
@@ -50,6 +50,17 @@
 //     limit that is pinned is learned from a test. Fixing them needs type
 //     information, which this scan deliberately does not have (see the last
 //     paragraph).
+//   - It matches the CALLEE syntactically, so a child started through a value
+//     rather than a direct call is invisible: a package-level `var run =
+//     exec.Command` used as `run(…).Run()`, or a method value / interface
+//     whose implementation lives in another file. Both are measured
+//     (findings=0) and pinned as want:0 corpus rows. Seeing them needs type
+//     information, which this scan deliberately does not have.
+//   - It reads NON-TEST files only, and does not skip vendor/ (the repo has
+//     none). Test code starting an unbounded child is out of scope on purpose:
+//     the hazard this rule exists for is a long-lived daemon waiting forever,
+//     and every fixture in core/adapters/outbound/git's own suite deliberately
+//     builds stalling children.
 //   - It is scoped to core/. tools/ is a separate module of developer tooling
 //     that is not a long-lived daemon.
 //
@@ -97,6 +108,24 @@ func (f shelloutBoundFinding) String() string {
 // being scanned while one survivor kept a `> 0` check green.
 func scanShelloutBounds(fset *token.FileSet, file *ast.File, name string) (findings []shelloutBoundFinding, bounded int) {
 	ast.Inspect(file, func(n ast.Node) bool {
+		// A composite literal is the one spelling that cannot be fixed by
+		// passing a context, because exec.Cmd has no exported context field —
+		// CommandContext sets an unexported one. So `&exec.Cmd{Path: …}`
+		// followed by .Run() is unbounded BY CONSTRUCTION, and it is the
+		// natural thing to reach for once exec.Command is banned. Flagged
+		// rather than merely declared, because unlike the two limits in the
+		// header this one needs no type information to see.
+		if lit, ok := n.(*ast.CompositeLit); ok {
+			if sel, ok := lit.Type.(*ast.SelectorExpr); ok {
+				if pkg, ok := sel.X.(*ast.Ident); ok && pkg.Name == "exec" && sel.Sel.Name == "Cmd" {
+					findings = append(findings, shelloutBoundFinding{name, fset.Position(lit.Pos()).Line,
+						"an exec.Cmd built as a struct literal has no context field at all — " +
+							"exec.CommandContext sets an unexported one, so nothing can ever cancel " +
+							"this child. Build it with exec.CommandContext (#1543)"})
+				}
+			}
+			return true
+		}
 		call, ok := n.(*ast.CallExpr)
 		if !ok {
 			return true

--- a/core/architecture_shellout_test.go
+++ b/core/architecture_shellout_test.go
@@ -40,6 +40,16 @@
 //     distinguishable from an empty answer at the call site. That is
 //     processlifecycle's guard, and core/pkg/shellout.Answered is the shared
 //     predicate #1543 promoted so a second package could reach it.
+//   - It matches on the SELECTOR's package identifier, so `import xexec
+//     "os/exec"` followed by xexec.Command(…) is invisible to it — measured
+//     against the detector, findings=0. So is a dot-import, and so is
+//     os.StartProcess, which starts a child without going through os/exec at
+//     all. All three are pinned as want:0 corpus rows, the same way the
+//     sibling guard in processlifecycle pins its own aliased-import limit,
+//     because a limit that is merely true is learned from an incident while a
+//     limit that is pinned is learned from a test. Fixing them needs type
+//     information, which this scan deliberately does not have (see the last
+//     paragraph).
 //   - It is scoped to core/. tools/ is a separate module of developer tooling
 //     that is not a long-lived daemon.
 //

--- a/core/cmd/irrlichd/handlers.go
+++ b/core/cmd/irrlichd/handlers.go
@@ -442,10 +442,10 @@ func toDoraMetric(m dora.Metric) doraMetric {
 // historyGitReader is the narrow git surface chart=dora needs, matching the
 // historySessionLister convention of small per-consumer interfaces.
 type historyGitReader interface {
-	GetGitRoot(dir string) string
-	ListReleaseTags(dir string) []dora.TagInfo
-	CommitsInRange(dir, fromRef, toRef string) []dora.CommitInfo
-	TagContaining(dir, hash string) string
+	GetGitRoot(dir string) (root string, answered bool)
+	ListReleaseTags(dir string) (tags []dora.TagInfo, answered bool)
+	CommitsInRange(dir, fromRef, toRef string) (commits []dora.CommitInfo, answered bool)
+	TagContaining(dir, hash string) (tag string, answered bool)
 }
 
 // serveHistoryDoraChart serves chart=dora (#951): requires exactly one

--- a/core/cmd/irrlichd/history_dora_endpoint_test.go
+++ b/core/cmd/irrlichd/history_dora_endpoint_test.go
@@ -19,17 +19,17 @@ type fakeDoraGit struct {
 	commitsByTag map[string][]dora.CommitInfo
 }
 
-func (f fakeDoraGit) GetGitRoot(dir string) string { return dir }
-func (f fakeDoraGit) ListReleaseTags(dir string) []dora.TagInfo {
+func (f fakeDoraGit) GetGitRoot(dir string) (string, bool) { return dir, true }
+func (f fakeDoraGit) ListReleaseTags(dir string) ([]dora.TagInfo, bool) {
 	if dir == "" {
-		return nil
+		return nil, true
 	}
-	return f.tags
+	return f.tags, true
 }
-func (f fakeDoraGit) CommitsInRange(dir, fromRef, toRef string) []dora.CommitInfo {
-	return f.commitsByTag[toRef]
+func (f fakeDoraGit) CommitsInRange(dir, fromRef, toRef string) ([]dora.CommitInfo, bool) {
+	return f.commitsByTag[toRef], true
 }
-func (f fakeDoraGit) TagContaining(dir, hash string) string { return "" }
+func (f fakeDoraGit) TagContaining(dir, hash string) (string, bool) { return "", true }
 
 func doraSession(id, project, cwd string) *session.SessionState {
 	return &session.SessionState{SessionID: id, State: session.StateReady, ProjectName: project, CWD: cwd}

--- a/core/e2e/e2e_helpers_test.go
+++ b/core/e2e/e2e_helpers_test.go
@@ -251,12 +251,12 @@ func (l *nopLogger) Close() error                                            { r
 
 type stubGit struct{}
 
-func (g *stubGit) GetBranch(_ string) string               { return "main" }
-func (g *stubGit) GetProjectName(dir string) string        { return filepath.Base(dir) }
-func (g *stubGit) GetGitRoot(_ string) string              { return "" }
-func (g *stubGit) GetHeadCommit(_ string) string           { return "" }
-func (g *stubGit) GetBranchFromTranscript(_ string) string { return "" }
-func (g *stubGit) GetCWDFromTranscript(_ string) string    { return "" }
+func (g *stubGit) GetBranch(_ string) (string, bool)        { return "main", true }
+func (g *stubGit) GetProjectName(dir string) (string, bool) { return filepath.Base(dir), true }
+func (g *stubGit) GetGitRoot(_ string) (string, bool)       { return "", true }
+func (g *stubGit) GetHeadCommit(_ string) (string, bool)    { return "", true }
+func (g *stubGit) GetBranchFromTranscript(_ string) string  { return "" }
+func (g *stubGit) GetCWDFromTranscript(_ string) string     { return "" }
 
 type stubMetrics struct{}
 

--- a/core/pkg/cliprobe/cliprobe.go
+++ b/core/pkg/cliprobe/cliprobe.go
@@ -17,6 +17,7 @@ import (
 
 	"irrlicht/core/pkg/cliversion"
 	"irrlicht/core/pkg/pathutil"
+	"irrlicht/core/pkg/shellout"
 )
 
 // Timeout bounds how long a version probe may take. A version check runs on
@@ -24,18 +25,15 @@ import (
 // CLI that hangs must lose quickly rather than wedge the grant.
 const Timeout = 2 * time.Second
 
-// waitDelay bounds the extra time Probe waits for the child's output pipes to
-// close after its context expires. Killing the process is not enough on its
-// own: exec waits for stdout to reach EOF, and a grandchild that inherited the
-// pipe holds it open after its parent dies, so a plain CommandContext kill can
-// still block indefinitely. This is the difference between "fails fast" as an
-// intention and as a guarantee.
-const waitDelay = 500 * time.Millisecond
-
 // maxOutput caps how much of the child's stdout is read. Timeout bounds how
 // long a misbehaving CLI gets, not how much it can write in that time — a
 // process streaming to a pipe moves gigabytes in two seconds, and this runs
 // inside a long-lived daemon. A version banner is a few hundred bytes.
+//
+// Overflow is TRUNCATED rather than reported: a version banner followed by
+// noise still contains the version. shellout.CappedBuffer's doc carries the
+// contrast with the git adapter, which treats the same overflow as a
+// non-answer for the opposite reason.
 const maxOutput = 64 << 10
 
 // Probe runs argv and returns the first version triple it prints on stdout.
@@ -46,8 +44,8 @@ const maxOutput = 64 << 10
 //
 //   - Missing binary: the lookup fails before anything is spawned, so this
 //     returns immediately rather than after Timeout.
-//   - Hung binary: bounded by Timeout, and by waitDelay against a grandchild
-//     holding the output pipe open past the kill.
+//   - Hung binary: bounded by Timeout, and by shellout.WaitDelay against a
+//     grandchild holding the output pipe open past the kill.
 //   - Flooding binary: bounded by maxOutput.
 //   - Unintelligible output: reported as an error here, unknown by Parse.
 //
@@ -66,13 +64,12 @@ func Probe(ctx context.Context, argv []string) (string, error) {
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx, pathutil.MustResolve(argv[0]), argv[1:]...)
-	cmd.WaitDelay = waitDelay
+	cmd.WaitDelay = shellout.WaitDelay
 	// A version probe must never block on a prompt or inherit the daemon's
 	// stdin, and stderr is discarded so a chatty CLI cannot buffer through it.
 	cmd.Stdin = nil
 
-	var out cappedWriter
-	out.limit = maxOutput
+	out := shellout.CappedBuffer{Limit: maxOutput}
 	cmd.Stdout = &out
 
 	runErr := cmd.Run()
@@ -92,25 +89,3 @@ func Probe(ctx context.Context, argv []string) (string, error) {
 	}
 	return version.String(), nil
 }
-
-// cappedWriter keeps at most limit bytes and silently discards the rest. It
-// never returns an error: exec's output-copying goroutine treats a write error
-// as fatal to the command, and a CLI whose banner happens to be followed by
-// noise has still told us its version. Bounding memory is the whole job here —
-// the process itself is bounded by Timeout.
-type cappedWriter struct {
-	limit int
-	buf   []byte
-}
-
-func (w *cappedWriter) Write(p []byte) (int, error) {
-	if room := w.limit - len(w.buf); room > 0 {
-		if len(p) < room {
-			room = len(p)
-		}
-		w.buf = append(w.buf, p[:room]...)
-	}
-	return len(p), nil
-}
-
-func (w *cappedWriter) String() string { return string(w.buf) }

--- a/core/pkg/shellout/answered_test.go
+++ b/core/pkg/shellout/answered_test.go
@@ -1,0 +1,172 @@
+package shellout
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"testing"
+	"time"
+)
+
+// TestAnswered is the corpus behind #1538's shared predicate.
+//
+// It moved here from core/adapters/inbound/agents/processlifecycle in #1543,
+// which promoted the implementation to this leaf so an OUTBOUND adapter could
+// reach it. Nothing in it was rewritten — the rows, the measurements and the
+// reasoning are #1538's — but it now runs where the code lives rather than
+// through one importer. That distinction is the whole reason for the move: a
+// package whose only coverage arrives through an importer stops being covered
+// the moment that importer stops importing it, and "no test files" is what a
+// reviewer sees in the meantime.
+//
+// Every case is built from a REAL child process rather than from a hand-built
+// *exec.ExitError, for the reason TestLsofProbeRan already records: the
+// classification's whole job is to be right about what os/exec actually hands
+// back, and a mid-run context deadline in particular is not obviously an
+// ExitError at all. Asserting the VERDICT rather than the error type is what
+// keeps this honest across Go versions. The one synthetic row is the wrapped
+// error, which no os/exec path produces today and which is the point of that
+// row (see below).
+//
+// The table pins both directions at once, which is why it is a matrix over the
+// two forms rather than two tables:
+//
+//   - wantAny is the empty-variadic form ("any normal exit is an answer") —
+//     plutil's rule, #1524.
+//   - wantExit1 is the allowlist form Answered(err, 1) — lsof's and
+//     pgrep's rule.
+//
+// The two disagree on exactly one row, "exit 152", and that disagreement is
+// the whole reason the variadic exists: a shell reports a process killed under
+// an exhausted CPU limit as a NORMAL exit with status 152, so Exited() is true.
+// A single global rule cannot serve both tools, and picking either one for
+// both is a silent behaviour change at half the call sites.
+func TestAnswered(t *testing.T) {
+	run := func(ctx context.Context, name string, args ...string) error {
+		_, err := exec.CommandContext(ctx, name, args...).Output()
+		return err
+	}
+	// 50ms rather than the 1ms TestLsofProbeRan uses: at 1ms the deadline
+	// routinely fires BEFORE Start, which is a different row of this table.
+	// The verdict is the same either way, so the row is correct regardless —
+	// TestAnsweredRejectsTheContextSpelling below is what actually
+	// VERIFIES the mid-run shape, by asserting the error is an ExitError.
+	deadline, cancelDeadline := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancelDeadline()
+
+	// A context already past its deadline before Start: os/exec never builds
+	// an ExitError here, it returns the context's own error. errors.As is
+	// false, and errors.Is(err, context.DeadlineExceeded) is TRUE — the mirror
+	// image of the mid-run kill below, which is why keying on the context
+	// catches this one and misses that one.
+	expired, cancelExpired := context.WithTimeout(context.Background(), time.Nanosecond)
+	defer cancelExpired()
+	time.Sleep(5 * time.Millisecond)
+
+	cases := []struct {
+		name      string
+		err       error
+		wantAny   bool
+		wantExit1 bool
+		why       string
+	}{
+		{
+			name: "success", err: nil, wantAny: true, wantExit1: true,
+			why: "the vacuity guard: a predicate that answered false here would make every other row pass for the wrong reason",
+		},
+		{
+			name: "exit 1", err: run(context.Background(), "/bin/sh", "-c", "exit 1"),
+			wantAny: true, wantExit1: true,
+			why: "plutil's 'no CFBundleIdentifier' and lsof's 'nothing to report' are both real verdicts (#1524)",
+		},
+		{
+			name: "exit 2", err: run(context.Background(), "/bin/sh", "-c", "exit 2"),
+			wantAny: true, wantExit1: false,
+			why: "an allowlist is an allowlist: for lsof/pgrep only exit 1 carries meaning, every other code is not evidence",
+		},
+		{
+			name: "exit 152 — killed under an exhausted CPU limit, reported through a shell",
+			err:  run(context.Background(), "/bin/sh", "-c", "exit 152"),
+			// The one row where the two forms disagree, and the reason the
+			// variadic is not cosmetic. Exited() is TRUE here (measured), so
+			// the empty form calls it an answer.
+			wantAny: true, wantExit1: false,
+			why: "lsofProbeRan's committed corpus pins 152 as NOT an answer; a global Exited() rule would silently flip it",
+		},
+		{
+			name: "killed by a signal", err: run(context.Background(), "/bin/sh", "-c", "kill -9 $$"),
+			wantAny: false, wantExit1: false,
+			why: "a SIGKILLed child ran but never answered — ExitCode() is -1 and Exited() is false",
+		},
+		{
+			name: "context deadline fires MID-RUN", err: run(deadline, "/bin/sleep", "5"),
+			wantAny: false, wantExit1: false,
+			why: "#1538 trap 1: this is *exec.ExitError \"signal: killed\" and errors.Is(err, context.DeadlineExceeded) is FALSE — the natural spelling misses exactly this row",
+		},
+		{
+			name: "context already expired before Start", err: run(expired, "/bin/sleep", "5"),
+			wantAny: false, wantExit1: false,
+			why: "not an ExitError at all; errors.As is false and the predicate must still refuse it",
+		},
+		{
+			name: "binary missing", err: run(context.Background(), "/nonexistent/probe-1538"),
+			wantAny: false, wantExit1: false,
+			why: "a fork/exec failure is a probe that never ran, not a tool reporting nothing",
+		},
+		{
+			name:    "an exit 1 that was WRAPPED on the way here",
+			err:     fmt.Errorf("pgrep -x claude: %w", run(context.Background(), "/bin/sh", "-c", "exit 1")),
+			wantAny: true, wantExit1: true,
+			why: "the third spelling replaced by #1538 was a bare `err.(*exec.ExitError)` assertion, which reports false here; errors.As reports true. No os/exec path wraps today, so this row is a LOCK on the property rather than a live defect — it is what makes the bare assertion unrewritable without going red",
+		},
+	}
+
+	for _, tc := range cases {
+		if got := Answered(tc.err); got != tc.wantAny {
+			t.Errorf("%s: Answered(%v) = %v, want %v — %s", tc.name, tc.err, got, tc.wantAny, tc.why)
+		}
+		if got := Answered(tc.err, 1); got != tc.wantExit1 {
+			t.Errorf("%s: Answered(%v, 1) = %v, want %v — %s", tc.name, tc.err, got, tc.wantExit1, tc.why)
+		}
+	}
+}
+
+// TestAnsweredRejectsTheContextSpelling is #1538's trap 1 stated as an
+// assertion rather than as a doc comment.
+//
+// It exists because the wrong spelling is the natural one. A reader fixing this
+// family reaches for errors.Is(err, context.DeadlineExceeded) — it names the
+// exact condition, it compiles, and it reads correctly. This test measures that
+// it is FALSE for the mid-run kill and TRUE only for the pre-Start case, so the
+// evidence lives next to the predicate instead of in a merged PR body.
+//
+// It is deliberately an assertion about os/exec's behaviour, not about
+// Answered: if a future Go release makes CommandContext wrap the context's
+// error, this test goes red and the doc comment above Answered becomes
+// wrong. That is the signal worth having.
+func TestAnsweredRejectsTheContextSpelling(t *testing.T) {
+	deadline, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	_, err := exec.CommandContext(deadline, "/bin/sleep", "5").Output()
+	if err == nil {
+		t.Fatal("the ceiling did not fire — this test proves nothing without a killed child")
+	}
+
+	if errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("os/exec now wraps the context error (%v): Answered's doc comment and #1524's measurement are stale", err)
+	}
+	if deadline.Err() != context.DeadlineExceeded {
+		t.Errorf("ctx.Err() = %v, want DeadlineExceeded — the deadline is what actually fired", deadline.Err())
+	}
+	var exit *exec.ExitError
+	if !errors.As(err, &exit) {
+		t.Fatalf("want *exec.ExitError for a mid-run kill, got %T", err)
+	}
+	if exit.ProcessState.Exited() {
+		t.Error("a SIGKILLed child reports Exited() — the predicate's whole discriminator is gone")
+	}
+	if Answered(err) {
+		t.Error("Answered called a killed child an answer (#1538)")
+	}
+}

--- a/core/pkg/shellout/buffer.go
+++ b/core/pkg/shellout/buffer.go
@@ -1,0 +1,93 @@
+package shellout
+
+import "time"
+
+// WaitDelay bounds the extra time a bounded shellout waits for its child's
+// output pipes to close after the context expires.
+//
+// Killing the process is not enough on its own: exec waits for stdout to reach
+// EOF, and a grandchild that inherited the pipe — a credential helper, a
+// core.fsmonitor daemon, a pager some global config forced on — holds it open
+// after its parent dies. This is the difference between "fails fast" as an
+// intention and as a guarantee.
+//
+// Unlike the CEILING, which is per-package and argued for as such on Answered
+// (a consent-path version check and a `git log --all` are entitled to
+// different budgets), this value is a property of os/exec's pipe handling
+// rather than of the workload, so there is one. It is shared rather than
+// copied because the copies had already started naming each other: #1543's
+// first draft carried a `gitWaitDelay` whose doc comment ended "Same
+// reasoning, same value, as core/pkg/cliprobe's waitDelay", and a comment that
+// names its own duplicate is the drift signal, not the documentation.
+//
+// A measured consequence worth knowing before changing it: WaitDelay does
+// NOTHING for a command built with exec.Command rather than exec.CommandContext
+// — with no context there is nothing to expire, so the call blocks for the
+// child's whole life. Measured, go1.25 darwin/arm64, against a child that exits
+// promptly while a grandchild holds stdout: with WaitDelay the call returns in
+// 500ms with "exec: WaitDelay expired before I/O complete", which Answered
+// correctly reports as a NON-answer; without it the call returns after 30s with
+// err == nil, which Answered correctly reports as an ANSWER — so the absence is
+// not merely a hang, it publishes whatever partial output was collected as a
+// complete successful read.
+const WaitDelay = 500 * time.Millisecond
+
+// CappedBuffer collects at most Limit bytes of a child's output and records
+// whether anything was DROPPED.
+//
+// It exists because a ceiling bounds how long a misbehaving child runs, not how
+// much it writes in that time — a process streaming to a pipe moves gigabytes
+// in a few seconds, and these run inside a long-lived daemon.
+//
+// It never returns an error. exec's output-copying goroutine treats a write
+// error as fatal to the command, which would turn "the output was too big" into
+// a second, less specific failure; and returning short would make io.Copy report
+// ErrShortWrite for a buffer that is behaving exactly as designed. Callers read
+// Overflowed instead.
+//
+// **What to DO about an overflow is per-call-site and deliberately not decided
+// here**, the same split Answered draws. core/pkg/cliprobe ignores Overflowed
+// and keeps the prefix, because a truncated version banner still contains the
+// version. core/adapters/outbound/git treats it as a NON-ANSWER, because a
+// truncated commit list silently drops releases and reverts and DORA would then
+// publish a smaller sample as though it were the whole one.
+type CappedBuffer struct {
+	// Limit is the maximum number of bytes retained. Set it before the first
+	// Write; a zero Limit keeps nothing and reports every non-empty write as
+	// an overflow.
+	Limit int
+
+	buf        []byte
+	overflowed bool
+}
+
+// Write keeps as much of p as Limit allows and reports the full length so the
+// caller's copy loop is never told it under-wrote.
+//
+// overflowed is set when bytes are DROPPED, which is the condition callers
+// care about — not when the buffer merely REACHES Limit. Those are different:
+// a complete read of exactly Limit bytes lost nothing, and reporting it as
+// truncated is a false non-answer that blanks a chart the daemon read
+// successfully. Keying on `len(buf) >= Limit` conflates them, and #1543's first
+// draft did; keying on the write that actually drops is what makes the two
+// inexpressible as one.
+func (w *CappedBuffer) Write(p []byte) (int, error) {
+	if room := w.Limit - len(w.buf); len(p) > room {
+		if room > 0 {
+			w.buf = append(w.buf, p[:room]...)
+		}
+		w.overflowed = true
+	} else {
+		w.buf = append(w.buf, p...)
+	}
+	return len(p), nil
+}
+
+// Bytes returns the retained prefix. It is not a copy.
+func (w *CappedBuffer) Bytes() []byte { return w.buf }
+
+// String returns the retained prefix as a string.
+func (w *CappedBuffer) String() string { return string(w.buf) }
+
+// Overflowed reports whether any byte was dropped.
+func (w *CappedBuffer) Overflowed() bool { return w.overflowed }

--- a/core/pkg/shellout/buffer_test.go
+++ b/core/pkg/shellout/buffer_test.go
@@ -1,0 +1,103 @@
+package shellout
+
+import "testing"
+
+// TestCappedBufferStopsAtItsLimit is the unit half of the cap, so a change to
+// its enforcement is caught without spawning a flooding child.
+//
+// It lives here rather than beside either consumer because the two consumers
+// want OPPOSITE things from the same overflow — core/pkg/cliprobe truncates and
+// keeps reading, core/adapters/outbound/git reports a non-answer — and the
+// arithmetic they share is what this pins.
+//
+// MUTATION EVIDENCE, both run and both red:
+//
+//   - Keying the overflow on `len(w.buf) >= w.Limit` (the spelling #1543's
+//     first draft shipped): fails "a complete read of exactly the limit was
+//     reported as truncated", because the buffer merely REACHING the cap is
+//     not the same as bytes being dropped.
+//   - Returning `len(w.buf)` instead of `len(p)` from Write: fails
+//     "Write past the limit"; io.Copy would report ErrShortWrite for a buffer
+//     behaving exactly as designed, and exec treats that as fatal to the
+//     command.
+func TestCappedBufferStopsAtItsLimit(t *testing.T) {
+	var w CappedBuffer
+	w.Limit = 8
+
+	if n, err := w.Write([]byte("abc")); n != 3 || err != nil {
+		t.Fatalf("Write = (%d, %v), want (3, nil)", n, err)
+	}
+	if w.Overflowed() {
+		t.Error("3 bytes into a limit of 8 reported an overflow")
+	}
+
+	// Exactly the limit is NOT an overflow: nothing was dropped. This is the
+	// boundary, and the direction that matters — a false overflow blanks a
+	// read that completed successfully.
+	if n, err := w.Write([]byte("defgh")); n != 5 || err != nil {
+		t.Fatalf("Write to exactly the limit = (%d, %v), want (5, nil)", n, err)
+	}
+	if w.Overflowed() {
+		t.Error("a complete read of exactly the limit was reported as truncated")
+	}
+	if w.String() != "abcdefgh" {
+		t.Fatalf("kept %q, want abcdefgh", w.String())
+	}
+
+	// One byte past drops it, and reports the FULL length anyway: returning
+	// short would make exec's copier treat it as a write error and fail the
+	// command for the wrong reason.
+	if n, err := w.Write([]byte("i")); n != 1 || err != nil {
+		t.Fatalf("Write past the limit = (%d, %v), want (1, nil)", n, err)
+	}
+	if !w.Overflowed() {
+		t.Error("writing past the limit did not record an overflow")
+	}
+	if string(w.Bytes()) != "abcdefgh" {
+		t.Errorf("kept %q, want the FIRST 8 bytes", w.Bytes())
+	}
+}
+
+// TestCappedBufferOverflowsOnASingleOversizeWrite covers the other arithmetic
+// path: one write larger than the whole limit, rather than an accumulation
+// that crosses it. A guard keyed on the ACCUMULATED length handles the second
+// and can miss the first.
+func TestCappedBufferOverflowsOnASingleOversizeWrite(t *testing.T) {
+	var w CappedBuffer
+	w.Limit = 4
+
+	if n, err := w.Write([]byte("abcdefgh")); n != 8 || err != nil {
+		t.Fatalf("Write = (%d, %v), want (8, nil)", n, err)
+	}
+	if !w.Overflowed() {
+		t.Error("a single write of 8 bytes into a limit of 4 did not report an overflow")
+	}
+	if w.String() != "abcd" {
+		t.Errorf("kept %q, want abcd", w.String())
+	}
+}
+
+// TestCappedBufferZeroLimitKeepsNothing pins the degenerate case rather than
+// leaving it to be discovered: a zero Limit is a buffer that retains nothing
+// and calls every non-empty write an overflow. No caller sets one today, and
+// the doc says so — this is what makes that statement checkable.
+func TestCappedBufferZeroLimitKeepsNothing(t *testing.T) {
+	var w CappedBuffer
+	if n, err := w.Write([]byte("x")); n != 1 || err != nil {
+		t.Fatalf("Write = (%d, %v), want (1, nil)", n, err)
+	}
+	if !w.Overflowed() {
+		t.Error("a zero limit did not report an overflow")
+	}
+	if len(w.Bytes()) != 0 {
+		t.Errorf("kept %q, want nothing", w.Bytes())
+	}
+	// An empty write drops nothing, so it is not an overflow even here.
+	var empty CappedBuffer
+	if _, err := empty.Write(nil); err != nil {
+		t.Fatalf("Write(nil): %v", err)
+	}
+	if empty.Overflowed() {
+		t.Error("an empty write reported an overflow")
+	}
+}

--- a/core/pkg/shellout/shellout.go
+++ b/core/pkg/shellout/shellout.go
@@ -1,0 +1,97 @@
+// Package shellout holds the one predicate every bounded child process in this
+// repo classifies its error with: did the child ANSWER, or was it never asked?
+//
+// It is a leaf on purpose. The family this exists to prevent — #1485, #1492,
+// #1513, #1524, #1533, #1537, #1543 — is one sentence seven times: "I could not
+// look" collapsed into "I looked and there was nothing". #1538 gave that
+// sentence a single implementation, but only inside
+// core/adapters/inbound/agents/processlifecycle, so the eighth instance
+// (#1543's git adapter, in an OUTBOUND adapter) could not reuse it without
+// copying it. A pkg/ leaf is the smallest thing that makes it reachable from
+// both directions of the hexagon; core/architecture_test.go's rule for pkg/ is
+// "must not import adapters or application", and this package imports stdlib
+// only.
+//
+// What it deliberately does NOT hold is a ceiling. A consent-path version
+// check, a window-targeting probe and a `git log --all` over a user's whole
+// history are entitled to different budgets, and each package names its own
+// (core/pkg/cliprobe's Timeout, processlifecycle's shelloutTimeout,
+// core/adapters/outbound/git's gitTimeout, control's execTimeout). Merging them
+// would be picking one number by proximity, which is the unexamined copy this
+// whole family is about.
+package shellout
+
+import (
+	"errors"
+	"os/exec"
+	"slices"
+)
+
+// Answered reports whether the child process behind a bounded shellout actually
+// ANSWERED, as opposed to never having been asked.
+//
+// It answers only that half. What to DO with a non-answer is per-call-site and
+// deliberately not decided here: processlifecycle's IsKnownInteractiveHost
+// gates ADMISSION and so fails open (#1513), while hostIdentity and the git
+// adapter feed enrichment and so degrade to "unknown" (#1492, #1543). A shared
+// verdict with per-site polarity is the point.
+//
+// answeredExitCodes is the per-tool part, and it is the only part that
+// genuinely differs.
+//
+// Empty means "any normal exit is an answer". That is plutil's rule — it exits
+// 1 both for a missing Info.plist and for a plist carrying no
+// CFBundleIdentifier (both measured, #1524 and re-measured in #1538) — and it
+// is git's rule too: every failure git reports as a real verdict exits
+// non-zero but NORMALLY (measured on git 2.50.1 / Apple Git-155, darwin/arm64:
+// not-a-repo 128 for all six of the adapter's subcommands, unborn-branch
+// rev-parse 128, a range naming an unknown ref 128, `tag --contains` with an
+// unresolvable object name 129, and "no tags"/"no reverts" 0 with empty
+// stdout). git has no exit status that means "I could not look", so for git the
+// non-answers are exactly: killed by the ceiling, never started, fork failed.
+//
+// A non-empty list is an allowlist of the non-zero exits that count as answers
+// — lsof's and pgrep's rule, where exit 1 is "nothing to report" and any OTHER
+// code is not evidence about anything. That distinction is load-bearing rather
+// than cosmetic: `sh -c "exit 152"` (a process killed under an exhausted CPU
+// limit reports 152 through a shell) exits NORMALLY, so ProcessState.Exited()
+// is true and ExitCode() is 152 (measured, go1.25 darwin/arm64) — the empty
+// form would call it an answer and lsofProbeRan's committed corpus pins that it
+// is not.
+//
+// The hard half does NOT differ, and it is the half that is easy to get wrong:
+//
+//   - A killed child is not an answer, and `errors.Is(err,
+//     context.DeadlineExceeded)` will not tell you. When CommandContext's
+//     deadline fires MID-RUN the child is SIGKILLed and Output returns
+//     *exec.ExitError "signal: killed", which does not wrap the context's
+//     error: errors.Is reports FALSE while ctx.Err() reports the deadline
+//     (measured independently in #1524 and again in #1538, go1.25
+//     darwin/arm64). The natural-looking spelling compiles, reads correctly,
+//     and misses the exact condition every issue in this family is about.
+//   - ProcessState.Exited() is what separates a process that RAN from one that
+//     was killed, and it covers the deaths the ceiling did not cause too: an
+//     OOM kill, a fork that failed under the same load, and a ctx already past
+//     its deadline before Start — where the error is not an ExitError at all
+//     (measured: `errors.As` false, `errors.Is(DeadlineExceeded)` true).
+//
+// errors.As rather than a type assertion because an error that has been wrapped
+// on the way here is still an exit status. No caller wraps today (os/exec hands
+// back a bare *exec.ExitError), which is exactly why a bare assertion in
+// runPgrep survived unnoticed until #1538 — it was correct by accident of its
+// caller, not by construction.
+func Answered(err error, answeredExitCodes ...int) bool {
+	if err == nil {
+		return true
+	}
+	var exit *exec.ExitError
+	if !errors.As(err, &exit) || !exit.ProcessState.Exited() {
+		// Killed, never started, or not a child-exit error at all. None of
+		// these carry information about the question that was asked.
+		return false
+	}
+	if len(answeredExitCodes) == 0 {
+		return true
+	}
+	return slices.Contains(answeredExitCodes, exit.ExitCode())
+}

--- a/core/pkg/shellout/shellout_test.go
+++ b/core/pkg/shellout/shellout_test.go
@@ -1,0 +1,179 @@
+package shellout
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"testing"
+	"time"
+)
+
+// These are LOCKS, and saying so is the point rather than a disclaimer: #1543
+// moved this implementation out of processlifecycle without changing a line of
+// it, so there is no "before the fix" for them to have been red against.
+// processlifecycle's TestProbeAnswered — an 8-row matrix over both variadic
+// forms, every case built from a real child process, and carrying no build tag
+// so it runs on Linux CI too — still grades this code through the forwarder.
+//
+// What these add is that the leaf is graded AT ITS OWN LOCATION. A package
+// whose only coverage arrives through two importers stops being covered the
+// moment either stops importing it, and "no test files" is what a reviewer sees
+// in the meantime.
+//
+// Every case is built from a real child process on purpose. The distinction
+// under test — ran to a normal exit, versus killed or never started — is a
+// property of the process, and a hand-constructed error cannot pin it: an
+// *exec.ExitError's ProcessState is not something a test can forge.
+
+func TestAnswered_RealChildProcesses(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name  string
+		build func(t *testing.T) error
+		codes []int
+		want  bool
+		why   string
+	}{
+		{
+			name:  "clean exit is an answer",
+			build: func(*testing.T) error { return exec.Command("/bin/sh", "-c", "exit 0").Run() },
+			want:  true,
+		},
+		{
+			name:  "exit 1, empty variadic",
+			build: func(*testing.T) error { return exec.Command("/bin/sh", "-c", "exit 1").Run() },
+			want:  true,
+			why:   "plutil's and git's rule: any NORMAL exit is an answer, however unhappy",
+		},
+		{
+			name:  "exit 1, allowlisted",
+			build: func(*testing.T) error { return exec.Command("/bin/sh", "-c", "exit 1").Run() },
+			codes: []int{1},
+			want:  true,
+			why:   "lsof's and pgrep's rule: 1 means 'nothing to report'",
+		},
+		{
+			name:  "exit 152, allowlist of {1}",
+			build: func(*testing.T) error { return exec.Command("/bin/sh", "-c", "exit 152").Run() },
+			codes: []int{1},
+			want:  false,
+			why: "152 is what a process killed under an exhausted CPU limit reports through a shell. " +
+				"It EXITS NORMALLY, so Exited() is true and a global Exited()-only rule would call it " +
+				"an answer — which is the whole reason the allowlist exists rather than being cosmetic",
+		},
+		{
+			name:  "exit 152, empty variadic",
+			build: func(*testing.T) error { return exec.Command("/bin/sh", "-c", "exit 152").Run() },
+			want:  true,
+			why:   "the other side of the row above: with no allowlist, 152 IS an answer",
+		},
+		{
+			name: "killed mid-run by the context deadline",
+			build: func(*testing.T) error {
+				ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+				defer cancel()
+				return exec.CommandContext(ctx, "/bin/sleep", "30").Run()
+			},
+			want: false,
+			why:  "the case every issue in this family is about",
+		},
+		{
+			name: "context already expired before Start",
+			build: func(*testing.T) error {
+				ctx, cancel := context.WithTimeout(context.Background(), time.Nanosecond)
+				defer cancel()
+				time.Sleep(time.Millisecond)
+				return exec.CommandContext(ctx, "/bin/sh", "-c", "exit 0").Run()
+			},
+			want: false,
+			why:  "not an ExitError at all — errors.As is false, so the first guard is what catches it",
+		},
+		{
+			name:  "binary does not exist",
+			build: func(*testing.T) error { return exec.Command("/nonexistent/irrlicht-1543").Run() },
+			want:  false,
+			why:   "nothing started, so there is no exit status to read",
+		},
+		{
+			name:  "nil error",
+			build: func(*testing.T) error { return nil },
+			want:  true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := tc.build(t)
+			if got := Answered(err, tc.codes...); got != tc.want {
+				t.Errorf("Answered(%v, %v) = %v, want %v — %s", err, tc.codes, got, tc.want, tc.why)
+			}
+		})
+	}
+}
+
+// TestAnswered_RejectsTheContextSpelling pins the trap that makes the natural
+// implementation wrong: a child SIGKILLed when CommandContext's deadline fires
+// returns an *exec.ExitError that does NOT wrap the context's error, so
+// errors.Is(err, context.DeadlineExceeded) is FALSE while ctx.Err() reports the
+// deadline.
+//
+// A predicate written as `!errors.Is(err, context.DeadlineExceeded)` compiles,
+// reads correctly, and misses exactly the condition this package exists for.
+// Measured independently in #1524, again in #1538, and re-run here.
+func TestAnswered_RejectsTheContextSpelling(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	err := exec.CommandContext(ctx, "/bin/sleep", "30").Run()
+
+	if err == nil {
+		t.Fatal("the sleep was not killed; this machine did not reproduce the case under test")
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		t.Error("the mid-run kill DOES wrap context.DeadlineExceeded on this toolchain — the " +
+			"doc comment's justification for ProcessState.Exited() no longer holds and must be re-measured")
+	}
+	if ctx.Err() == nil {
+		t.Error("the context did not expire; the fixture is not arranging the case under test")
+	}
+	var exit *exec.ExitError
+	if !errors.As(err, &exit) {
+		t.Fatalf("expected an *exec.ExitError, got %T", err)
+	}
+	if exit.ProcessState.Exited() {
+		t.Error("a SIGKILLed child reported Exited()==true; Exited() is the discriminator this " +
+			"package relies on")
+	}
+	if Answered(err) {
+		t.Error("a child killed by the deadline was reported as having answered")
+	}
+}
+
+// TestAnswered_UnwrapsAWrappedExitStatus pins errors.As over a type assertion.
+// Nothing in the repo wraps today — os/exec hands back a bare *exec.ExitError —
+// which is precisely why a bare assertion survived unnoticed in runPgrep until
+// #1538: it was correct by accident of its caller, not by construction.
+func TestAnswered_UnwrapsAWrappedExitStatus(t *testing.T) {
+	t.Parallel()
+
+	raw := exec.Command("/bin/sh", "-c", "exit 1").Run()
+	if raw == nil {
+		t.Fatal("expected a non-nil error from exit 1")
+	}
+	wrapped := fmt.Errorf("running the probe: %w", raw)
+
+	if !Answered(wrapped) {
+		t.Error("a wrapped exit status was not recognised; an error wrapped on the way here is " +
+			"still an exit status")
+	}
+	if Answered(wrapped, 2) && !Answered(raw, 2) {
+		t.Error("the wrapped and unwrapped forms disagreed about the allowlist")
+	}
+	if Answered(wrapped, 2) {
+		t.Error("exit 1 was accepted against an allowlist of {2}")
+	}
+}

--- a/core/ports/outbound/ports.go
+++ b/core/ports/outbound/ports.go
@@ -124,12 +124,19 @@ type Logger interface {
 // GitResolver resolves git metadata from a working directory.
 //
 // Four methods here return a second value, answered, which is false when git
-// could not be RUN at all — killed by the adapter's ceiling, never started, or
-// output past its cap. Three of them shell out directly; GetProjectName starts
-// no child of its own and forwards GetGitRoot's verdict, which matters because
-// its one caching consumer must not memoise a guess. It is TRUE, with a zero
-// first value, for every case where git ran and reported nothing to give:
-// not a repo, a detached or unborn HEAD, no release tags.
+// could not be RUN at all — killed by the adapter's ceiling, never started
+// (including a dir that no longer exists, which fails at chdir and is therefore
+// PERMANENT, not transient), or output past its cap. Three of them shell out
+// directly; GetProjectName starts no child of its own and forwards GetGitRoot's
+// verdict, which matters because its one caching consumer must not memoise a
+// guess.
+//
+// answered is TRUE for every case where git RAN, whatever it found. For three
+// of the four that also means a zero first value when there was nothing to give
+// — not a repo, a detached or unborn HEAD. GetProjectName is the exception and
+// the sentence has to say so: it answers with a non-empty directory-basename
+// fallback for a perfectly ordinary non-repo directory, so "answered" there
+// means "this name is a resolution, not a guess", never "the name is empty".
 //
 // The distinction is the whole of #1543, and it has the polarity of #1492
 // rather than #1513: nothing behind this port gates admission, so a non-answer

--- a/core/ports/outbound/ports.go
+++ b/core/ports/outbound/ports.go
@@ -123,9 +123,11 @@ type Logger interface {
 
 // GitResolver resolves git metadata from a working directory.
 //
-// The four methods that shell out to git return a second value, answered,
-// which is false when git could not be RUN at all — killed by the adapter's
-// ceiling, never started, or output past its cap. It is TRUE, with a zero
+// Four methods here return a second value, answered, which is false when git
+// could not be RUN at all — killed by the adapter's ceiling, never started, or
+// output past its cap. Three of them shell out directly; GetProjectName starts
+// no child of its own and forwards GetGitRoot's verdict, which matters because
+// its one caching consumer must not memoise a guess. It is TRUE, with a zero
 // first value, for every case where git ran and reported nothing to give:
 // not a repo, a detached or unborn HEAD, no release tags.
 //

--- a/core/ports/outbound/ports.go
+++ b/core/ports/outbound/ports.go
@@ -122,15 +122,27 @@ type Logger interface {
 }
 
 // GitResolver resolves git metadata from a working directory.
+//
+// The four methods that shell out to git return a second value, answered,
+// which is false when git could not be RUN at all — killed by the adapter's
+// ceiling, never started, or output past its cap. It is TRUE, with a zero
+// first value, for every case where git ran and reported nothing to give:
+// not a repo, a detached or unborn HEAD, no release tags.
+//
+// The distinction is the whole of #1543, and it has the polarity of #1492
+// rather than #1513: nothing behind this port gates admission, so a non-answer
+// degrades an enrichment to "unknown" and must never be written over a value
+// the caller already holds. The two transcript readers carry no such value —
+// they read files, they start no child process.
 type GitResolver interface {
-	GetBranch(dir string) string
-	GetProjectName(dir string) string
+	GetBranch(dir string) (branch string, answered bool)
+	GetProjectName(dir string) (name string, answered bool)
 	// GetGitRoot returns the absolute path of the git repo root for the given
 	// directory, or "" if the directory is not inside a git repository.
-	GetGitRoot(dir string) string
+	GetGitRoot(dir string) (root string, answered bool)
 	// GetHeadCommit returns the full SHA of the current HEAD commit for the
 	// given directory, or "" if it is not inside a git repository (#373).
-	GetHeadCommit(dir string) string
+	GetHeadCommit(dir string) (sha string, answered bool)
 	GetBranchFromTranscript(transcriptPath string) string
 	// GetCWDFromTranscript extracts the working directory from a transcript
 	// file by scanning the first few lines for a "cwd" field.


### PR DESCRIPTION
Closes #1543.

Two defects in `core/adapters/outbound/git/adapter.go`, needing two different
kinds of evidence. Both are below, with what was run and what it reported.

## 1. The collapse (pre-existing defect — seen RED first)

"git could not be run" and "this directory is not a repo / has no such tag"
both arrived as `""` or `nil`. Run against the **unmodified** adapter, asking
the only question a single-return API allows — that the two situations must not
produce the same value:

```
=== RUN   TestNonAnswerIsDistinguishableFromAGenuineMiss
    redfirst_probe_test.go:39: GetBranch: a git that could not be RUN ("") is
    indistinguishable from a directory that genuinely is not a repo ("") — #1543
--- FAIL: TestNonAnswerIsDistinguishableFromAGenuineMiss (0.10s)
FAIL	irrlicht/core/adapters/outbound/git	0.274s
```

**The harm was downstream, and that is where the fix has to be judged.** Seven
consumer arms were each run with their `!answered` branch reverted, so the
non-answer takes the old empty-answer path. Two of them reproduce the exact
string a user saw:

| # | reverted arm | what it reported |
|---|---|---|
| C1 | `ListReleaseTags` | `Message = "no releases found for this project"` |
| C2 | `GetGitRoot` | `Message = "project not found or not a git repository"` |
| C3 | `CommitsInRange` | `Available:true` — a median lead time over the tags that happened to succeed |
| C4 | `TagContaining` | `Available:true` — a change failure rate **missing that revert**, i.e. reading better than reality |
| C5 | `backfillOne` | "a non-answer marked the session updated" + `ProjectName = "guess"` — and because `backfillOne` returns early once ProjectName is set, that verdict is never revisited |
| C6 | `CaptureYieldOnReady` | `YieldState = "unknown"` persisted as a verdict, which is what the yield ratio buckets a session's dollars into |
| C7 | `collectRevertedSHAs` | nothing logged; the sweep reports a clean pass for history it never read |

## 2. The bound (added — owes a MUTATION, all seen red)

Plain `exec.Command`, no context, no timeout, in a long-lived daemon.

| # | mutation | reported |
|---|---|---|
| M1 | ceiling → `context.WithCancel(Background())` | 30.00s elapsed; *"a child killed by the ceiling was reported as an answer"* — and the production-wiring arm failed identically at 30.10s |
| M2 | `gitTimeout` → 60s | same first assertion at 30s |
| M3 | delete `cmd.WaitDelay` | 30.01s; *"a read that never saw EOF was reported as an answer"* |
| M4 | drop the `buf.overflowed` arm | *"a truncated read was reported as an answer"* |
| M5 | remove the output cap | same |
| M6 | collapse a non-answer back to a zero value | the #1543 defect test plus the eight-method table, while `TestNotARepoIsAnAnswer` correctly stayed **green** |

**M3 is worth reading twice.** `WaitDelay`'s absence is not a hang, it is a
*wrong answer*. Measured directly (go1.25 darwin/arm64) against a child that
exits promptly while a grandchild holds the stdout pipe:

```
with WaitDelay:     500ms, err = "exec: WaitDelay expired before I/O complete"
without WaitDelay:  30.01s, err = NIL
```

A nil error is an *answer*, so without `WaitDelay` the adapter would publish
whatever partial output it collected as a complete successful read.

## The polarity, and why the empty variadic is git's rule

These feed DORA and branch display — enrichment. So this is #1492's polarity (a
non-answer is "unknown", propagated as such), **not** #1513's fail-open. Nothing
here gates admission. The seven methods, plus `GetProjectName` (which consumes
`GetGitRoot` and whose one caching consumer memoised a basename guess for the
daemon's lifetime), return `(T, bool)`.

Measured on git 2.50.1 / Apple Git-155, darwin/arm64:

| case | exit |
|---|---|
| not a repo — all six subcommands | 128 |
| unborn branch, `rev-parse HEAD` | 128 |
| range naming an unknown ref | 128 |
| `tag --contains <unresolvable>` | 129 |
| no tags / no reverts | 0, empty stdout |

Every one is a git that RAN and answered. git has no exit status meaning "I
could not look", so the non-answers are exactly: killed, never started, output
past the cap — which is `shellout.Answered`'s **empty-variadic** form, the same
form and the same reason as plutil (#1524). `TestNotARepoIsAnAnswer` pins all
ten of those rows so the fix cannot drift into "report a non-answer whenever
anything is empty".

## The ceiling is chosen, not copied

`gitTimeout = 5s`, deliberately not the 2s next door (#1547 argues the ceiling
should stay per-package, and #1545's own doc argues it). Measured on this repo
(3192 commits, 265 MiB pack, warm cache): `log --all --grep` 0.05s,
`for-each-ref` / `tag --contains` / `rev-parse` 0.01s. 5s is ~100x the heaviest,
~500x the three on the enrichment hot path.

Two costs stated rather than implied, and both are in the constant's doc:
it is ONE value across two profiles (a detector-loop read and a request a user
waits on), and a repo large enough to legitimately exceed 5s now reports a
non-answer where it previously returned a correct-but-slow result — safe only
because a non-answer is now propagated as unknown. **UNVERIFIED:** the scaling
to a very large repo is extrapolation (~810 bytes and ~16us of `log` per commit
on this repo), not a measurement on such a repo.

`gitMaxOutput = 64 MiB` treats overflow as a **non-answer**, not a truncation —
the opposite of `cliprobe`'s choice, because a truncated version banner still
contains the version whereas a truncated commit list silently biases DORA.

## The predicate moved; #1545's guard was blind to it, and that is measured

`probeAnswered` is promoted to `core/pkg/shellout.Answered`. `core/pkg/` may not
import `adapters/` or `application/` (`core/architecture_test.go`); this leaf
imports `errors`, `os/exec`, `slices`. `processlifecycle.probeAnswered` stays as
that package's own binding and forwards, so #1545's five call sites, its guard
and its committed corpus are untouched — #1547 argues that verified mechanism is
worth protecting.

The guard matches classifier calls as `*ast.Ident`. Rewriting `processTTYVia` to
the qualified spelling made it report:

```
osutil_darwin.go:67 in processTTYVia(): the error of a child process (err) is
neither passed to probeAnswered/lsofProbeRan nor returned
```

i.e. a **false positive** against correctly-classified code — the loud
direction, but a rule that fails the build on the sanctioned fix teaches the
next author to spell it the way the rule expects. Fixed, with five committed
corpus rows, mutated both ways:

- **M9** (revert to Ident-only): the two qualified-spelling rows go red.
- **M10** (widen to any `.Answered` selector): the three negative rows go red —
  a different package's `Answered`, an aliased import, and a method named
  `Answered` on a receiver.

## New: a repo-wide rule, because a package-local guard is why #1543 existed

`core/architecture_shellout_test.go` — no child process started under `core/`
may be built with `exec.Command`, or with a bare `context.Background()`/`TODO()`
at the call site. #1538's guard scans `parsePackageSources(t, ".")`, its own
directory, which is exactly why the git adapter was invisible to it. The census:
after this fix there are **zero** `exec.Command` sites in non-test `core/` code
and 13 `CommandContext` sites, so the rule lands with no exemption list — the
policy `architecture_test.go` and `architecture_hookbody_test.go` both take.

Mutations: **M7** planting one `exec.Command` back into the git adapter → the
live rule names it by `file:line`; **M8** making the walk see nothing → *"parsed
no files under core/ — the scan is looking in the wrong place, so its silence
proves nothing"*.

Its corpus (`core/architecture_shellout_shapes_test.go`) is committed rather
than described, 12 rows. The six `want:0` rows carry as much value as the
`want:1` rows — three are false positives a text grep for `exec.Command(`
produces (an aliased import of another package named `exec`, a method named
`Command`, and the phrase inside a doc comment), and two are **declared limits**
pinned so they are learned from a test rather than an incident (this rule cannot
see whether a context carries a deadline; a dot-import of `os/exec` would evade
it).

## What I deliberately did NOT do

- **#1547's `runProbe`.** Out of scope, and it swaps a verified enforcement
  mechanism for an unverified one.
- **The three other family members #1547 names** —
  `background_probe.go:79`, `control/controller.go:27`, `cliprobe.go:25`. All
  three already bound their children and are unaffected by this diff; they
  reach the new `shellout.Answered` only if someone imports it, and none does.
- **Lifting #1538's classification guard into a shared package.** Its rule needs
  per-package knowledge of the classifiers in scope, and moving 450 lines of
  test code plus its corpus is exactly the trade #1547 declined. The repo-wide
  rule above asks the weaker, cheaper question instead — one whose answer is the
  same in every package.

## Verification

`tools/preflight.sh` chunked, all PASS: `go` (core + onboarding-factory +
replay fixtures + validate + rig smoke), `arch` (ARS 7.9316 → 7.9308, no
category regression), `tools`, `skills`, `posix`, `security`. `web` and `swift`
not run — neither tree is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Review pass (`high` effort) — 9 findings, all applied

**Three were regressions this PR's own first draft introduced**, and none of its
~1400 lines of new tests could see them. That is the most useful thing in this
PR to check.

1+2 (one root cause) Routing every read through `shellout.Answered`'s
empty-variadic form started **forwarding stdout on a non-zero normal exit**,
which `.Output()`'s `if err != nil { return "" }` had discarded. Measured: `git
rev-parse HEAD` on an unborn branch exits 128 **and writes the literal `HEAD` to
stdout**, so `GetHeadCommit` returned `("HEAD", true)` and `CaptureYieldOnReady`
persisted it as a commit SHA with `YieldProductive`. Same shape, worse blast
radius, for a `git log` that streams commits then hits a fatal — DORA would
publish a truncated history as `Available:true`.
3. `RefreshOnActivity` applied "never overwrite what you already hold" to a
session that had **moved**, so it reported the OLD directory's branch — a false
claim where `main` left a blank, and permanent.
4. A cwd whose `GetGitRoot` never answered never entered `rootDirs`, so the
sweep went silent one step *upstream* of where this PR fixed exactly that.
5+6. `resolveProject` runs once per recording **event**, so declining to cache a
non-answer cost one 5s-ceilinged shellout per event under a held mutex.
7. `asked == 0 || unread < asked` let one negative candidate outvote N−1 unread.
8. `cappedBuffer` keyed overflow on `len(buf) >= limit`, so a complete read of
exactly the cap was a false non-answer — and the test whose comment claimed to
pin that boundary stopped one byte short of it.
9. The new repo-wide rule is evaded by an aliased `os/exec` import and by
`os.StartProcess`; both are now **declared limits** with `want:0` corpus rows.

Every fix carries its own red-first or mutation evidence.

# `/simplify` pass — 4 agents, converging on one thing

They all found the same shape: **this PR created `core/pkg/shellout` and then
shipped three more `cliprobe`-shaped copies outside it.** So `CappedBuffer` and
`WaitDelay` moved into the leaf and `cliprobe` collapsed onto them, and #1538's
predicate corpus moved there too.

**Two findings were refused, and the refusals matter more than the fixes:**

- Moving the probe outside `resolveMu` **broke
  `TestConcurrencyProject_MemoizesConcurrentRequests`**, which pins single-flight
  resolution as deliberate. Reverted — the lock did its job.
- `ceiling()`'s zero-value fallback was **uncovered**: deleting it left the
  package green. Per AGENTS.md that is stop-and-fix, not ship-the-green, so
  `TestZeroValuedAdapterIsStillBounded` now covers it and the mutation was
  replayed red.

All 11 recorded mutations were replayed against the restructured code; the two
ceiling ones now land on `TestProductionAdapterIsBounded`, which goes through
`New()` and so still proves the real constant.

# Deliberately NOT done (each is a real finding, deferred with a reason)

- **A shared `shellout.Runner`** (altitude F1). `WaitDelay` and an output cap are
  absent at 11 of the repo's 13 shellout sites, including all 8 in
  `processlifecycle`. Restructuring those is #1547's territory and this PR
  already touches enough.
- **Making the classification rule repo-wide** (altitude F3). It would force
  rewriting `background_probe.go:80`, whose `out, _ :=` is deliberate and
  `//nolint`-annotated.
- **Per-metric DORA availability** (altitude F6). `dora.Metric` already carries
  `Available`/`Message` end to end, so a `TagContaining` non-answer blanks a
  `DeploymentFrequency` that was fully read. That is a user-visible behaviour
  change beyond this issue; the overclaiming comment that said all-or-nothing
  "is the point" has been corrected to say it is the conservative choice.
- **Giving `git.Adapter` a Logger** (altitude F5). Three distinct non-answers
  (ceiling / never started / overflow) collapse to one bit, so no operator can
  tell them apart. Additive observability, needs a constructor change.
- **`ReadFrom` on `CappedBuffer`** (efficiency F7) — 32 KiB per shellout, and
  getting the drain semantics wrong is worse than the win.

# Unverified / worth a second look

- The 5s ceiling's adequacy for a **very large repo** is extrapolation
  (~810 bytes and ~16µs of `log` per commit here), not a measurement.
- One `tools/preflight.sh --only go` run reported `core module tests FAIL` with
  an unchanged tree, between two green runs. **I could not reproduce it** across
  three subsequent full runs (`go test ./core/... -race` twice, exit 0, 59
  packages; `--only go` twice, exit 0). Most plausible cause is one of the two
  5s timing tests under load, which is part of why the ceiling is now injectable
  — but that is reasoning, not a diagnosis.
- CodeScene is red. It is advisory per AGENTS.md, and the findings are almost
  all table-driven test files (the same shape the existing
  `shellout_guard_corpus_test.go` already carries). `metadata_enricher.go`
  **improved** 8.99 → 9.39. Only `adapter.go` regressed, 8.03 → 7.79, on
  "Primitive Obsession" — which is the `(T, bool)` idiom #1485/#1533 established,
  and chasing it would be metric-driven design.


---

# Adversarial QA round — 6 findings, 5 applied, 3 filed

Two more regressions against `main`, neither of which my own `high` review round
caught.

**B1 — `RefreshOnActivity` blanked `ProjectName` on a non-answer, and the comment
justifying it promised a sweep that does not exist.** `main` kept it here, so
this was a regression, and a costly one: an empty `ProjectName` is bucketed as
literally `"unknown"` by `aggregateYieldBySession` and is invisible to DORA
(`resolveDoraProjectRoot` filters `st.ProjectName != project`). It was also my
own polarity rule pointing the wrong way. Now left untouched. The "sweep" is not
real — `BackfillMetadata` runs **once**, from `seedBackfillMetadata` at daemon
start; the only other caller, `retryIdleProjectResolution`, fires only for an
*idle* session with an empty `ProjectName` and is capped by
`maxIdleProjectResolveAttempts`. Both comments now say that. `GitBranch` keeps
its blanking — the session has *moved*, `main` blanked it too, and a stale
branch is the false claim round 1 flagged.

**B2 — a deleted CWD is a PERMANENT non-answer, and two call sites reasoned as
if non-answers were transient.** `cmd.Dir` fails at `chdir` before exec, so
there is no exit status. Measured across all eight methods: **six** report
`answered=false`; `GetGitRoot`/`GetProjectName` survive because they walk up
first, and the other six deliberately must not.
- `CaptureYieldOnReady` left `YieldState` empty, which `aggregateYieldBySession`
  **skips outright** — the session's spend left the yield chart, where `main`
  put it in the unknown bucket. A first-ever non-answer now records
  `YieldUnknown`; an existing verdict is still never overwritten.
- `recordRootDir` stored the raw cwd although it had just resolved a root that
  is guaranteed to exist, leaving that repo permanently unscanned and — new in
  this PR — logging it every 30 minutes forever.

**B4 — `run()`'s entire 21-line contract had ended up above `ceiling()`**, which
the `/simplify` commit inserted between the comment and its function. `run()`
had no doc at all. Reattached.

**B5 — the port contract was false for `GetProjectName`**, which answers with a
non-empty basename fallback for an ordinary non-repo directory; four consumers
read that sentence. And the `ceiling()` mutation note claimed both assertions
fire — replayed, only the first does.

**S1 — the architecture rule had three evasions its header did not declare.**
`&exec.Cmd{Path: …}` is now **caught** rather than declared: it is the natural
thing to reach for once `exec.Command` is banned, and `exec.Cmd` has no exported
context field, so it is unbounded *by construction*. The other two need type
information and are pinned as `want:0` rows. One correction to the report: the
method-value seam **is** caught when the builder is in the same file — the gap is
cross-file, and the row says so.

Filed rather than done: **#1553** (the 5s ceiling covers two cost profiles;
`RevertedCommits` extrapolates to the ceiling around 100k commits) and **#1554**
(`TestProductionAdapterIsBounded` mutates the package var `gitPath` under
`t.Parallel()` — latent, not live). The third follow-up was a single missing
table row in `TestNotARepoIsAnAnswer` and is included here instead.

All **15** mutations were re-run against the changed code — every one red on its
own assertion, every file restored byte-identical. One harness row correctly
reported `STALE` rather than proving nothing, and was re-run with a unique
pattern.
