### PR TITLE
fix(daemon): give the herdr client indirection one aggregate deadline (#1529)

### DIFF
--- a/core/adapters/inbound/agents/processlifecycle/herdrbudget_darwin_test.go
+++ b/core/adapters/inbound/agents/processlifecycle/herdrbudget_darwin_test.go
@@ -1,0 +1,179 @@
+//go:build darwin
+
+package processlifecycle
+
+import (
+	"context"
+	"slices"
+	"testing"
+	"time"
+
+	"irrlicht/core/domain/session"
+)
+
+// This file is #1529's behavioural half: what the herdr client loop does when
+// the ONE aggregate deadline covering it runs out. The value half — that the
+// deadline is small enough to be worth having — is
+// TestHerdrReadFitsTheLivenessSweepTick, platform-neutral beside the constant.
+//
+// Every assertion here turns on the BUDGET rather than on a wall clock, which
+// is what the issue asked for and what keeps these tests instant: the loop
+// consults ctx.Err(), so a test that cancels the context at a chosen candidate
+// drives the exact state a loaded machine would take seconds to reach. Nothing
+// here sleeps.
+//
+// The probes are injected because no arrangement of live processes can be made
+// to exhaust a shared budget at candidate 2 of 4 on purpose — the same reason
+// ttyProbe, kittyWindowProbe and resolveHostBundleIDVia's pair are injected.
+
+// readableHostlessCandidate is the answer a candidate gives when it WAS read
+// and genuinely has no local GUI window: a real pty, no TermProgram, no
+// HostBundleID, and complete=true. It is the one candidate shape that leaves
+// readAll alone, so it is the only fixture with which an abandonment is the
+// sole thing that can move the verdict — an unreadable candidate would poison
+// readAll by itself (#1492) and hide what these tests are about.
+func readableHostlessCandidate() (*session.Launcher, bool) {
+	return &session.Launcher{TTY: "/dev/ttys001"}, true
+}
+
+// exhaustAt returns a hostIdentityProbe that records every candidate it is
+// asked about and spends the whole remaining budget on the nth one. Cancelling
+// the context is how "this candidate consumed the budget" is expressed without
+// waiting for it: the loop reads ctx.Err(), which cancellation and a fired
+// deadline set alike.
+//
+// n <= 0 never exhausts anything, which is how each test below gets its vacuity
+// guard from the same fixture it makes its claim with.
+func exhaustAt(n int, cancel context.CancelFunc, probed *[]int) hostIdentityProbe {
+	return func(_ context.Context, pid int) (*session.Launcher, bool) {
+		*probed = append(*probed, pid)
+		if n > 0 && len(*probed) == n {
+			cancel()
+		}
+		return readableHostlessCandidate()
+	}
+}
+
+// TestResolveClientHostIdentity_ChecksTheBudgetBeforeEachCandidate is #1529's
+// point 2, and the reason the loop tests ctx.Err() itself instead of letting
+// the children inherit the deadline.
+//
+// Inheriting alone is not nothing — an expired context does kill every child —
+// but it produces the WRONG FACT. Each remaining candidate still runs its two
+// ancestry walks and its tty `ps`, each returns "I could not be read", and the
+// loop then reports "I looked at all four and none was readable" where the
+// truth is "I stopped looking after two". Detecting exhaustion is also the only
+// way the aggregate becomes a bound a caller can observe rather than an
+// accident of the children's own ceilings.
+func TestResolveClientHostIdentity_ChecksTheBudgetBeforeEachCandidate(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var probed []int
+	_, _ = resolveClientHostIdentityVia(ctx, []int{11, 12, 13, 14}, exhaustAt(2, cancel, &probed))
+
+	if want := []int{11, 12}; !slices.Equal(probed, want) {
+		t.Errorf("the budget ran out at candidate 2 and the loop went on to probe %v, want %v: "+
+			"an aggregate deadline that is only INHERITED by the children is not detected by the loop, "+
+			"so every remaining candidate is still probed and reported as unreadable (#1529)", probed, want)
+	}
+
+	// Vacuity guard: the same fixture with nothing exhausting the budget must
+	// reach every candidate, or the assertion above would pass for a loop that
+	// simply stops early.
+	probed = nil
+	stillLive, cancelLive := context.WithCancel(context.Background())
+	defer cancelLive()
+	_, _ = resolveClientHostIdentityVia(stillLive, []int{11, 12, 13, 14}, exhaustAt(0, cancelLive, &probed))
+	if want := []int{11, 12, 13, 14}; !slices.Equal(probed, want) {
+		t.Errorf("with budget to spare the loop probed %v, want %v — the test above proves nothing "+
+			"if the loop truncates regardless", probed, want)
+	}
+}
+
+// TestResolveClientHostIdentity_AbandonedCandidateIsANonAnswer is #1529's point
+// 1, and the composition with #1492 that the whole fix rests on.
+//
+// A candidate abandoned because the budget ran out is a candidate we DECLINED
+// TO LOOK AT — the maxClientCandidates truncation's case, not the detach case.
+// So it must poison readAll and the caller must be told (nil, false) = "I could
+// not look". Getting this backwards is not a missing nicety: (nil, true) means
+// "every attached client was read and none has a local window", which is
+// exactly what makes AdoptHostIdentity clear TermProgram / HostBundleID /
+// ITermSessionID / the kitty selectors from a session whose client is attached
+// right now — the misroute #1348 was opened to remove and #1492 narrowed. A fix
+// for a latency bug that reintroduced it would be a bad trade.
+//
+// The fixture is deliberately one readable, genuinely hostless candidate ahead
+// of the exhaustion, so readAll is TRUE at the moment the budget runs out and
+// the abandonment is the only thing that can move it.
+func TestResolveClientHostIdentity_AbandonedCandidateIsANonAnswer(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var probed []int
+	host, hostKnown := resolveClientHostIdentityVia(ctx, []int{11, 12}, exhaustAt(1, cancel, &probed))
+
+	if host != nil {
+		t.Errorf("an abandoned run named a host %+v; no candidate resolved one", host)
+	}
+	if hostKnown {
+		t.Error("candidate 12 was never looked at because the aggregate budget ran out, and the loop " +
+			"still answered (nil, true) = 'every attached client was read and none has a local window'. " +
+			"That answer clears a stored host (AdoptHostIdentity), so a budget that abandons without " +
+			"poisoning turns #1529's latency fix into the #1348/#1492 misroute (#1529)")
+	}
+
+	// Vacuity guard: the identical candidates read within budget ARE a complete
+	// look, and must still answer "nobody has a window" — otherwise the
+	// assertion above would hold for a loop that never reports a complete read.
+	probed = nil
+	stillLive, cancelLive := context.WithCancel(context.Background())
+	defer cancelLive()
+	if _, hostKnown := resolveClientHostIdentityVia(stillLive, []int{11, 12}, exhaustAt(0, cancelLive, &probed)); !hostKnown {
+		t.Error("two readable, genuinely hostless candidates read within budget is an ANSWER — " +
+			"if this fails, the assertion above passes for a loop that never says 'I looked'")
+	}
+}
+
+// TestResolveHerdrClientLauncher_DerivesOneBudgetOverScanAndCandidates pins the
+// two structural claims the loop tests above cannot make, because those supply
+// their own context: that the production resolve derives a bounded one at all,
+// and that the SAME one spans both stages.
+//
+// One context rather than one per stage is the decision, not an implementation
+// detail: two deadlines would read as a bound while summing to twice the
+// budget, and the lsof scan running long is precisely the case in which the
+// candidate loop needs less. What the herdr indirection costs is one number.
+func TestResolveHerdrClientLauncher_DerivesOneBudgetOverScanAndCandidates(t *testing.T) {
+	var scanDeadline, candidateDeadline time.Time
+	var scanBounded, candidateBounded bool
+
+	before := time.Now()
+	scan := func(ctx context.Context, _ string) ([]int, bool) {
+		scanDeadline, scanBounded = ctx.Deadline()
+		return []int{11}, true
+	}
+	identify := func(ctx context.Context, _ int) (*session.Launcher, bool) {
+		candidateDeadline, candidateBounded = ctx.Deadline()
+		return readableHostlessCandidate()
+	}
+	_, _ = resolveHerdrClientLauncherVia("/tmp/irrlicht-1529/herdr.sock", scan, identify)
+	after := time.Now()
+
+	if !scanBounded {
+		t.Fatal("the lsof scan ran under a context with no deadline: the herdr indirection is unbounded again (#1529)")
+	}
+	if !candidateBounded {
+		t.Fatal("the candidate loop ran under a context with no deadline: the herdr indirection is unbounded again (#1529)")
+	}
+	if !scanDeadline.Equal(candidateDeadline) {
+		t.Errorf("the scan and the candidate loop ran under different deadlines (%v apart): "+
+			"one deadline per stage sums to twice herdrClientBudget and is not the aggregate this fix states (#1529)",
+			candidateDeadline.Sub(scanDeadline))
+	}
+	if scanDeadline.After(after.Add(herdrClientBudget)) || !scanDeadline.After(before) {
+		t.Errorf("the derived deadline is %v from the call, want a positive span no longer than herdrClientBudget (%v)",
+			scanDeadline.Sub(before), herdrClientBudget)
+	}
+}

--- a/core/adapters/inbound/agents/processlifecycle/herdrbudget_test.go
+++ b/core/adapters/inbound/agents/processlifecycle/herdrbudget_test.go
@@ -1,0 +1,92 @@
+package processlifecycle
+
+import (
+	"os"
+	"regexp"
+	"strconv"
+	"testing"
+	"time"
+)
+
+// sweepBaseIntervalSource is the file the liveness sweep's cadence is declared
+// in. Relative to this package's directory, which is where `go test` runs.
+const sweepBaseIntervalSource = "../../../../application/services/pid_manager.go"
+
+// sweepBaseIntervalDecl matches the fastest cadence PIDManager.SweepDeadPIDs
+// ticks at. It is a function-local const, so nothing can import it and nothing
+// but reading the source can produce it.
+var sweepBaseIntervalDecl = regexp.MustCompile(`const baseInterval = (\d+) \* time\.(Second|Millisecond|Minute)`)
+
+// TestHerdrReadFitsTheLivenessSweepTick is what makes herdrClientBudget's value
+// a decision rather than a preference, and it is the reason #1529 was filed as
+// a bug rather than as a doc fix.
+//
+// refreshHerdrHosts runs SYNCHRONOUSLY inside the SweepDeadPIDs ticker handler
+// (CheckPIDLiveness → refreshHerdrHosts), and Go's Ticker drops ticks it
+// overruns. So a herdr read that can outlast one tick delays dead-PID reaping
+// for every session behind it — which is what the old bound, a COUNT over up to
+// maxClientCandidates candidates each spending several 2s ceilings, allowed.
+// The whole read is shelloutTimeout (the pane's own controlling-tty `ps`, the
+// only child the direct read starts for a herdr pane) plus herdrClientBudget
+// (the entire client indirection), so that sum is what has to fit.
+//
+// The cadence is READ OUT OF THE SERVICES SOURCE rather than copied here. A
+// number a test carries and nothing produces is the drift this repo has been
+// bitten by more than once, and the coupling is real in both directions: this
+// fails if the budget is widened past the tick, and equally if the tick is
+// shortened below the budget. An adapter may not import the application layer,
+// and `baseInterval` is a function-local const that could not be imported even
+// if it could — so the source is the only place the number exists.
+//
+// It refuses rather than skips when it cannot find that declaration: a gate
+// whose inability to look is indistinguishable from a pass is the failure mode
+// this repo's guards exist to remove.
+func TestHerdrReadFitsTheLivenessSweepTick(t *testing.T) {
+	tick := sweepBaseInterval(t)
+
+	if read := shelloutTimeout + herdrClientBudget; read >= tick {
+		t.Errorf("a herdr ReadLauncherEnv can take shelloutTimeout+herdrClientBudget = %v, "+
+			"which does not fit inside the liveness sweep's fastest tick (%v, PIDManager.SweepDeadPIDs). "+
+			"That sweep calls refreshHerdrHosts synchronously and Go's Ticker drops ticks it overruns, "+
+			"so one herdr resolve would again delay dead-PID reaping for every session behind it — #1529 "+
+			"exactly, with a duration bound instead of a count", read, tick)
+	}
+}
+
+// sweepBaseInterval extracts the sweep's fastest cadence from the services
+// source, failing loudly if the file, the function or the declaration has moved
+// — in which case this test's coupling needs re-pointing, and reporting "no
+// finding" would be a lie.
+func sweepBaseInterval(t *testing.T) time.Duration {
+	t.Helper()
+	src, err := os.ReadFile(sweepBaseIntervalSource)
+	if err != nil {
+		t.Fatalf("read %s: %v — this test measures the sweep cadence rather than restating it, "+
+			"so it cannot run at all without that file", sweepBaseIntervalSource, err)
+	}
+	if !regexp.MustCompile(`func \(pm \*PIDManager\) SweepDeadPIDs\(`).Match(src) {
+		t.Fatalf("%s no longer declares PIDManager.SweepDeadPIDs: the cadence this test reads may no "+
+			"longer be the one refreshHerdrHosts runs under, so re-point it rather than trusting it",
+			sweepBaseIntervalSource)
+	}
+	m := sweepBaseIntervalDecl.FindSubmatch(src)
+	if m == nil {
+		t.Fatalf("%s no longer declares `const baseInterval = N * time.Unit`: the liveness sweep's "+
+			"cadence is what bounds herdrClientBudget, and a test that cannot read it must say so "+
+			"rather than pass", sweepBaseIntervalSource)
+	}
+	n, err := strconv.Atoi(string(m[1]))
+	if err != nil || n <= 0 {
+		t.Fatalf("parsed a nonsensical sweep interval %q from %s", m[1], sweepBaseIntervalSource)
+	}
+	units := map[string]time.Duration{
+		"Millisecond": time.Millisecond,
+		"Second":      time.Second,
+		"Minute":      time.Minute,
+	}
+	unit, ok := units[string(m[2])]
+	if !ok {
+		t.Fatalf("unrecognised time unit %q in %s", m[2], sweepBaseIntervalSource)
+	}
+	return time.Duration(n) * unit
+}

--- a/core/adapters/inbound/agents/processlifecycle/osutil.go
+++ b/core/adapters/inbound/agents/processlifecycle/osutil.go
@@ -9,13 +9,82 @@
 package processlifecycle
 
 import (
+	"context"
 	"encoding/binary"
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 
 	"irrlicht/core/domain/session"
 )
+
+// herdrClientBudget is the ONE aggregate deadline covering the entire herdr
+// client indirection: the lsof scan that finds the attached clients and every
+// candidate probed behind it (resolveHerdrClientLauncherVia, osutil_darwin.go).
+//
+// It exists because every individual shellout on that path was bounded and the
+// path was not (#1529). resolveClientHostIdentity loops over up to
+// maxClientCandidates candidates; each costs two independent ancestry walks
+// plus a tty `ps`, and the bundle-id walk pays a `plutil` per hop up to
+// maxAncestry — so the bound was a COUNT, and one resolve could run to tens of
+// seconds.
+//
+// The value is set by what it has to fit inside rather than by what the probes
+// cost: PIDManager.SweepDeadPIDs calls refreshHerdrHosts synchronously on its
+// ticker, and Go's Ticker drops ticks it overruns, so a single herdr resolve
+// delays dead-PID reaping for every session behind it.
+// TestHerdrReadFitsTheLivenessSweepTick reads that cadence out of the services
+// source and pins the sum against it, so the relation is measured rather than
+// restated.
+//
+// Abandoning candidates is safe by construction and that is what makes the
+// budget cheap: an abandoned candidate is a NON-answer (#1492), not a detach,
+// so the caller is told "I could not look" and nothing clears a stored host.
+//
+// It lives here, platform-neutral, although the loop it bounds is darwin-only.
+// The contract it defines is stated in ReadLauncherEnv's doc, which compiles on
+// every platform, so a constant behind //go:build darwin would leave that doc
+// naming a symbol a linux reader cannot look up, and would put the arithmetic
+// that matters behind the same tag. It also belongs beside noAggregateBudget:
+// together the two ARE the decision about which host reads get an aggregate and
+// which deliberately do not, and splitting that across a build tag hides half
+// of it.
+const herdrClientBudget = 2 * time.Second
+
+// noAggregateBudget is the context every host read that deliberately has NO
+// aggregate deadline runs under. Naming it is the whole point: #1529 bounded
+// the herdr client indirection (herdrClientBudget above) and left these
+// unbounded, and a named helper makes that a reviewable absence rather than a
+// context.Background() whose meaning the next reader has to infer.
+//
+// Its two production call sites are the direct (non-herdr) launcher read in
+// ReadLauncherEnv and the interactive-host admission gate
+// (IsKnownInteractiveHost). Both keep exactly the aggregate they had before
+// #1529 — a COUNT — and their reasons are OPPOSITE polarities rather than one
+// shared argument, which is why they are stated separately instead of as
+// "bounding either would change an answer":
+//
+//   - ReadLauncherEnv discards hostIdentity's completeness for the direct read
+//     (see the call site), so an abandoned walk there arrives at consumers as a
+//     determined "this process has no host" with hostKnown TRUE. Bounding it
+//     would move answers in the host-CLEARING direction — the misroute #1348
+//     opened and #1492 narrowed.
+//   - IsKnownInteractiveHost fails OPEN on an incomplete walk (#1513), so
+//     bounding it would move answers the other way: the #784 exclusion would
+//     quietly stop excluding. Nothing counts how often either of its walks
+//     fails to be answered (#1534), so that degradation would be invisible.
+//     The standing cost is that this gate — reached synchronously from PID
+//     discovery — is still bounded only by a COUNT: two walks of up to
+//     maxAncestry hops, each hop a `ps` and possibly a `plutil`, every one of
+//     them at shelloutTimeout. #1529 gathered no evidence about that path and
+//     deliberately did not move it.
+//
+// This is NOT the bare context.Background() core/architecture_shellout_test.go
+// forbids: nothing passes it to exec.CommandContext. Every shellout downstream
+// still derives its own shelloutTimeout from it, so each CHILD keeps a
+// ceiling. What is absent is only the ceiling ACROSS children.
+func noAggregateBudget() context.Context { return context.Background() }
 
 // CWDToProjectDir converts a working directory path to the directory name used
 // by Claude Code under ~/.claude/projects/. Claude Code replaces both "/" and
@@ -84,13 +153,36 @@ func herdrClientLogPath(socketPath string) string {
 // modern macOS). On Linux we read /proc/<pid>/environ. Other platforms return
 // nil.
 //
-// It used to say "never blocks longer than 2 seconds" here. Every individual
-// shellout is bounded at 2s, but this function is not, and has not been since
-// the herdr indirection below: resolveClientHostIdentity loops over up to
-// maxClientCandidates candidates and each costs two ancestry walks plus a tty
-// `ps`, with the bundle-id walk paying a `plutil` per hop. The bound is a
-// COUNT, not a duration. Giving the loop one aggregate deadline is #1529;
-// until then no caller may assume a wall-clock ceiling here.
+// On the herdr path this function is bounded at shelloutTimeout +
+// herdrClientBudget. One shelloutTimeout is the pane's own controlling-TTY
+// `ps`, which is the ONLY child process the direct read starts for a herdr
+// pane: launcherFromEnv returns early with HerdrPaneID set, hostIdentityVia
+// skips the ancestry fallbacks for exactly that case, and the env read is a
+// sysctl rather than a shellout. herdrClientBudget is one aggregate deadline
+// covering the entire client indirection below — the lsof scan and every
+// candidate behind it. The sum is not restated here as a number, because a
+// number a doc carries and nothing produces drifts: it is
+// TestHerdrReadFitsTheLivenessSweepTick that measures it, against the sweep
+// cadence that has to accommodate it.
+//
+// It used to say "never blocks longer than 2 seconds", and then, honestly,
+// that it said nothing at all. Every individual shellout was bounded at 2s and
+// the function was not: resolveClientHostIdentity looped over up to
+// maxClientCandidates candidates, each independently spending two ancestry
+// walks plus a tty `ps`, with the bundle-id walk paying a `plutil` per hop.
+// The bound was a COUNT, not a duration. #1529 gave that loop one aggregate
+// deadline, so the arithmetic above is a real ceiling rather than a hope.
+//
+// The DIRECT path is deliberately still a count, and saying so is the point of
+// scoping the sentence above to herdr. A non-herdr pid walks its ancestry
+// under per-shellout ceilings only, up to maxAncestry hops on each of two
+// walks. Bounding it would be a behaviour change in the host-CLEARING
+// direction on a path #1529 has no evidence about: an abandoned direct walk
+// returns an empty host with hostKnown TRUE — this function discards
+// hostIdentity's completeness for the direct read, see below — which is
+// exactly the shape the contract above tells callers they may act on. So the
+// budget stops at the herdr indirection, and noAggregateBudget names what the
+// direct read runs under instead.
 func ReadLauncherEnv(pid int) (l *session.Launcher, hostKnown bool) {
 	if pid <= 0 {
 		return nil, false
@@ -102,7 +194,7 @@ func ReadLauncherEnv(pid int) (l *session.Launcher, hostKnown bool) {
 	// and widening it here would change behaviour for every non-herdr session
 	// on a signal #1492 has no evidence about. See resolveClientHostIdentity
 	// for the read that DOES act on it.
-	l, _ = hostIdentity(pid)
+	l, _ = hostIdentity(noAggregateBudget(), pid)
 	hostKnown = true
 
 	// A herdr pane's window belongs to the attached client, so its host
@@ -163,17 +255,26 @@ func ReadLauncherEnv(pid int) (l *session.Launcher, hostKnown bool) {
 //
 // The ordering is load-bearing: ancestry before TTY, and both before any
 // adoption by the caller.
-func hostIdentity(pid int) (l *session.Launcher, complete bool) {
-	return hostIdentityVia(pid, processTTY)
+//
+// ctx carries the caller's aggregate budget, and every bounded shellout below
+// derives its own shelloutTimeout from it — so a child is killed at whichever
+// comes first, its own ceiling or the budget. That composition is what makes
+// #1529's aggregate deadline real rather than advisory: this function is
+// applied once per herdr candidate, and a candidate cut short by the shared
+// budget reports complete=false, which is already the "could not be read"
+// non-answer #1492 gave it. Callers with no aggregate to impose pass
+// noAggregateBudget().
+func hostIdentity(ctx context.Context, pid int) (l *session.Launcher, complete bool) {
+	return hostIdentityVia(ctx, pid, processTTY)
 }
 
 // ttyProbe is the controlling-TTY read hostIdentityVia makes, injected so the
 // #1533 non-answer can be arranged — a real `ps` cannot be driven over its
 // ceiling on purpose. Same idiom as resolveHostBundleIDVia's two probes.
-type ttyProbe func(pid int) (string, bool)
+type ttyProbe func(ctx context.Context, pid int) (string, bool)
 
 // hostIdentityVia is hostIdentity with the TTY read injected.
-func hostIdentityVia(pid int, readTTY ttyProbe) (l *session.Launcher, complete bool) {
+func hostIdentityVia(ctx context.Context, pid int, readTTY ttyProbe) (l *session.Launcher, complete bool) {
 	// Env may be empty — hardened-runtime processes hide it from sysctl.
 	// Don't bail here: the ancestry fallback below is the only signal we
 	// have in that case.
@@ -205,13 +306,13 @@ func hostIdentityVia(pid int, readTTY ttyProbe) (l *session.Launcher, complete b
 	// none of its own (kitty), whose fields the suppression above drops. So
 	// skipping it would buy no correctness and cost exactly that case.
 	if l.HerdrPaneID == "" {
-		complete = applyAncestryFallbacks(l, pid, &ancestryProbe{pid: pid})
+		complete = applyAncestryFallbacks(ctx, l, pid, &ancestryProbe{pid: pid})
 	}
 
 	// Capture the controlling TTY so Terminal.app (and potentially others)
 	// can target the exact tab — Terminal.app's AppleScript dictionary
 	// matches tabs by `tty` but has no session-UUID analog.
-	tty, ttyProbed := readTTY(pid)
+	tty, ttyProbed := readTTY(ctx, pid)
 	l.TTY = tty
 	// #1533: the TTY read is the third bounded shellout behind this answer, and
 	// it was the one whose verdict was dropped — it runs AFTER complete is
@@ -334,9 +435,13 @@ type ancestryProbe struct {
 	complete bool
 }
 
-func (a *ancestryProbe) host() (term string, hostPID int) {
+// host walks the ancestry once and memoizes the result. ctx is a parameter
+// rather than a field of the memo on purpose: a context stored in a struct
+// outlives the call it was scoped to, and this memo is passed between three
+// guarded blocks that each already hold the caller's budget.
+func (a *ancestryProbe) host(ctx context.Context) (term string, hostPID int) {
 	if !a.resolved {
-		a.term, a.hostPID, a.complete = resolveHostFromAncestry(a.pid)
+		a.term, a.hostPID, a.complete = resolveHostFromAncestry(ctx, a.pid)
 		a.resolved = true
 	}
 	return a.term, a.hostPID
@@ -364,18 +469,18 @@ func (a *ancestryProbe) walked() bool { return !a.resolved || a.complete }
 // complete by definition. The bundle-id walk aborts on an unreadable process
 // AND on an unanswerable plutil (#1524); the memoized one has no plutil to
 // make, so for it the two are the same thing.
-func applyAncestryFallbacks(l *session.Launcher, pid int, ancestry *ancestryProbe) (complete bool) {
-	return applyAncestryFallbacksVia(l, pid, ancestry, kittyWindowIDForPID)
+func applyAncestryFallbacks(ctx context.Context, l *session.Launcher, pid int, ancestry *ancestryProbe) (complete bool) {
+	return applyAncestryFallbacksVia(ctx, l, pid, ancestry, kittyWindowIDForPID)
 }
 
 // kittyWindowProbe is the `kitten @ ls` read applyKittyAncestryBackfill makes,
 // injected for the same reason ttyProbe is: a real kitten cannot be driven over
 // its ceiling on purpose.
-type kittyWindowProbe func(socket string, sessionPID int) (string, bool)
+type kittyWindowProbe func(ctx context.Context, socket string, sessionPID int) (string, bool)
 
 // applyAncestryFallbacksVia is applyAncestryFallbacks with the kitty
 // remote-control read injected.
-func applyAncestryFallbacksVia(l *session.Launcher, pid int, ancestry *ancestryProbe, readKittyWindow kittyWindowProbe) (complete bool) {
+func applyAncestryFallbacksVia(ctx context.Context, l *session.Launcher, pid int, ancestry *ancestryProbe, readKittyWindow kittyWindowProbe) (complete bool) {
 	complete = true
 	// kitty intentionally does not set TERM_PROGRAM (upstream kitty issue
 	// #4793), so the env-captured value may be inherited from whatever
@@ -384,7 +489,7 @@ func applyAncestryFallbacksVia(l *session.Launcher, pid int, ancestry *ancestryP
 	// we still verify via process ancestry to rule out the reverse case
 	// (KITTY_WINDOW_ID leaked from a kitty shell that spawned VS Code).
 	if l.KittyWindowID != "" && l.TermProgram != "kitty" {
-		if term, _ := ancestry.host(); term == "kitty" {
+		if term, _ := ancestry.host(ctx); term == "kitty" {
 			l.TermProgram = "kitty"
 		}
 	}
@@ -393,7 +498,7 @@ func applyAncestryFallbacksVia(l *session.Launcher, pid int, ancestry *ancestryP
 	// can at least bring the host app to the front. Darwin-only; other
 	// platforms return "" and this is a no-op.
 	if l.TermProgram == "" {
-		l.TermProgram, _ = ancestry.host()
+		l.TermProgram, _ = ancestry.host(ctx)
 	}
 	// Generic host fallback: when no curated host matched (TermProgram still
 	// empty), resolve the first top-level `.app` ancestor's bundle id so the
@@ -402,7 +507,7 @@ func applyAncestryFallbacksVia(l *session.Launcher, pid int, ancestry *ancestryP
 	// on a map miss, so every curated host keeps its exact behavior. Darwin-
 	// only; other platforms return "" and this is a no-op.
 	if l.TermProgram == "" {
-		bundleID, _, ok := resolveHostBundleIDFromAncestry(pid)
+		bundleID, _, ok := resolveHostBundleIDFromAncestry(ctx, pid)
 		// AND, not assign: this bit is hand-accumulated three guarded blocks
 		// down, and a block inserted above that also writes it would otherwise
 		// be silently overwritten here — the failure ancestryProbe.walked()'s
@@ -419,7 +524,7 @@ func applyAncestryFallbacksVia(l *session.Launcher, pid int, ancestry *ancestryP
 	// Without this, clicking the session in the UI raises kitty but can't
 	// target the right tab — exactly the symptom reported for pi sessions
 	// in issue #326.
-	kittyProbed := applyKittyAncestryBackfill(l, pid, ancestry, readKittyWindow)
+	kittyProbed := applyKittyAncestryBackfill(ctx, l, pid, ancestry, readKittyWindow)
 	return complete && ancestry.walked() && kittyProbed
 }
 
@@ -450,11 +555,11 @@ func applyAncestryFallbacksVia(l *session.Launcher, pid int, ancestry *ancestryP
 // reads completeness for a host-resolved candidate. The TTY fold in
 // hostIdentityVia is NOT in this position: that one is reached by candidates
 // with no TermProgram at all, which is exactly the branch that reads the bit.
-func applyKittyAncestryBackfill(l *session.Launcher, pid int, ancestry *ancestryProbe, readKittyWindow kittyWindowProbe) (probed bool) {
+func applyKittyAncestryBackfill(ctx context.Context, l *session.Launcher, pid int, ancestry *ancestryProbe, readKittyWindow kittyWindowProbe) (probed bool) {
 	if l.TermProgram != "kitty" || l.KittyPID != 0 {
 		return true
 	}
-	term, kpid := ancestry.host()
+	term, kpid := ancestry.host(ctx)
 	if term != "kitty" || kpid <= 0 {
 		return true
 	}
@@ -463,7 +568,7 @@ func applyKittyAncestryBackfill(l *session.Launcher, pid int, ancestry *ancestry
 		l.KittyListenOn = kittyListenOnFor(kpid)
 	}
 	if l.KittyListenOn != "" && l.KittyWindowID == "" {
-		id, ok := readKittyWindow(l.KittyListenOn, pid)
+		id, ok := readKittyWindow(ctx, l.KittyListenOn, pid)
 		l.KittyWindowID = id
 		// #1537: the empty id from a kitten that never ran and the empty id
 		// from a kitty with no matching window arrived here as the same value.

--- a/core/adapters/inbound/agents/processlifecycle/osutil_darwin.go
+++ b/core/adapters/inbound/agents/processlifecycle/osutil_darwin.go
@@ -37,8 +37,8 @@ var (
 // to match Terminal.app's AppleScript `tty` property format — `ps -o tty=`
 // on macOS omits the "/dev/" prefix that AppleScript returns. This is host
 // enrichment (window targeting), not observation, so other platforms stub it.
-func processTTY(pid int) (string, bool) {
-	return processTTYVia(pid, func(ctx context.Context) *exec.Cmd {
+func processTTY(ctx context.Context, pid int) (string, bool) {
+	return processTTYVia(ctx, pid, func(ctx context.Context) *exec.Cmd {
 		return exec.CommandContext(ctx, psPath, "-o", "tty=", "-p", strconv.Itoa(pid))
 	})
 }
@@ -55,13 +55,13 @@ func processTTY(pid int) (string, bool) {
 // pid it cannot find (measured), which is a real "no such process", not a
 // probe that did not run — so the allowlist form would turn every reaped pid
 // into a non-answer and poison hostIdentity's completeness for it.
-func processTTYVia(pid int, build shelloutCmd) (tty string, probed bool) {
+func processTTYVia(ctx context.Context, pid int, build shelloutCmd) (tty string, probed bool) {
 	if pid <= 0 {
 		// Nothing was asked, so nothing failed — the same reading bundleIDVia
 		// gives an empty appPath.
 		return "", true
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), shelloutTimeout)
+	ctx, cancel := context.WithTimeout(ctx, shelloutTimeout)
 	defer cancel()
 	out, err := build(ctx).Output()
 	if !probeAnswered(err) {
@@ -109,17 +109,18 @@ const maxAncestry = 10
 // ("", 0) and are different facts: the first is evidence that this process has
 // no local window, the second is no evidence at all. Every abort is a
 // readProcInfo failure, which on a loaded machine is that helper's 2s ceiling
-// (#1492); the caller that acts on the distinction is
-// resolveClientHostIdentity.
+// (#1492) — or, since #1529, ctx's aggregate budget expiring first, which
+// produces the same non-answer for the same reason. The caller that acts on the
+// distinction is resolveClientHostIdentity.
 //
 // Intentionally ignores tmux: tmux's env vars (TMUX, TMUX_PANE) come from
 // the regular env-capture path when readable, and a tmux-only ancestor
 // (without a known host terminal above it) can't be brought to the front
 // by NSWorkspace.
-func resolveHostFromAncestry(pid int) (termProgram string, hostPID int, complete bool) {
+func resolveHostFromAncestry(ctx context.Context, pid int) (termProgram string, hostPID int, complete bool) {
 	cur := pid
 	for i := 0; i < maxAncestry && cur > 1; i++ {
-		ppid, cmd, err := readProcInfo(cur)
+		ppid, cmd, err := readProcInfo(ctx, cur)
 		if err != nil {
 			return "", 0, false
 		}
@@ -155,8 +156,8 @@ func plutilBundleIDCmd(plist string) shelloutCmd {
 // The error is non-nil ONLY when plutil could not be ASKED, never when it
 // answered — see bundleIDVia for why those are different facts and where the
 // line between them falls (#1524).
-func bundleIDForAppPath(appPath string) (string, error) {
-	return bundleIDVia(appPath, plutilBundleIDCmd)
+func bundleIDForAppPath(ctx context.Context, appPath string) (string, error) {
+	return bundleIDVia(ctx, appPath, plutilBundleIDCmd)
 }
 
 // bundleIDVia is bundleIDForAppPath with the shellout injected.
@@ -190,11 +191,11 @@ func bundleIDForAppPath(appPath string) (string, error) {
 // is the only site in the package that needs to be: the command depends on the
 // Info.plist path, which this function derives from appPath. Everywhere else
 // the site's arguments are closed over at the call site (see shelloutCmd).
-func bundleIDVia(appPath string, build bundleIDCmd) (string, error) {
+func bundleIDVia(ctx context.Context, appPath string, build bundleIDCmd) (string, error) {
 	if appPath == "" {
 		return "", nil
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), shelloutTimeout)
+	ctx, cancel := context.WithTimeout(ctx, shelloutTimeout)
 	defer cancel()
 	plist := appPath + "/Contents/Info.plist"
 	out, err := build(plist)(ctx).Output()
@@ -244,8 +245,8 @@ func bundleIDVia(appPath string, build bundleIDCmd) (string, error) {
 // The walk starts at pid's *parent*: the agent runs inside the host and is
 // never the host itself, and an agent whose own binary lives in a top-level
 // bundle (e.g. ClaudeCode.app) must not be mistaken for it.
-func resolveHostBundleIDFromAncestry(pid int) (bundleID string, hostPID int, complete bool) {
-	return resolveHostBundleIDVia(pid, readProcInfo, bundleIDForAppPath)
+func resolveHostBundleIDFromAncestry(ctx context.Context, pid int) (bundleID string, hostPID int, complete bool) {
+	return resolveHostBundleIDVia(ctx, pid, readProcInfo, bundleIDForAppPath)
 }
 
 // procInfoProbe and bundleIDProbe are the two bounded shellouts
@@ -253,14 +254,14 @@ func resolveHostBundleIDFromAncestry(pid int) (bundleID string, hostPID int, com
 // reason isKnownInteractiveHostVia injects its two walks: no arrangement of
 // live processes can drive either into a chosen failure on purpose.
 type (
-	procInfoProbe func(pid int) (ppid int, cmd string, err error)
-	bundleIDProbe func(appPath string) (string, error)
+	procInfoProbe func(ctx context.Context, pid int) (ppid int, cmd string, err error)
+	bundleIDProbe func(ctx context.Context, appPath string) (string, error)
 )
 
 // resolveHostBundleIDVia is resolveHostBundleIDFromAncestry with both probes
 // injected.
-func resolveHostBundleIDVia(pid int, procInfo procInfoProbe, bundleID bundleIDProbe) (bundleIDOut string, hostPID int, complete bool) {
-	ppid, _, err := procInfo(pid)
+func resolveHostBundleIDVia(ctx context.Context, pid int, procInfo procInfoProbe, bundleID bundleIDProbe) (bundleIDOut string, hostPID int, complete bool) {
+	ppid, _, err := procInfo(ctx, pid)
 	if err != nil {
 		return "", 0, false
 	}
@@ -269,12 +270,12 @@ func resolveHostBundleIDVia(pid int, procInfo procInfoProbe, bundleID bundleIDPr
 	}
 	cur := ppid
 	for i := 0; i < maxAncestry && cur > 1; i++ {
-		pp, cmd, err := procInfo(cur)
+		pp, cmd, err := procInfo(ctx, cur)
 		if err != nil {
 			return "", 0, false
 		}
 		if appPath := topLevelAppPath(cmd); appPath != "" {
-			bid, err := bundleID(appPath)
+			bid, err := bundleID(ctx, appPath)
 			if err != nil {
 				// #1524: the probe was never answered, so "" here says nothing
 				// about this ancestor. Falling through would walk on and report
@@ -335,18 +336,28 @@ func resolveHostBundleIDVia(pid int, procInfo procInfoProbe, bundleID bundleIDPr
 // even at 12x CPU oversubscription, so whatever triggers a real non-answer is
 // not CPU pressure and is still unidentified.
 //
+// That is also why #1529 bounded the herdr client indirection and left THIS
+// call site running under noAggregateBudget(): here an aggregate deadline would
+// manufacture the very non-answer the gate fails open on, so it would move
+// answers toward admitting — invisibly, per the paragraph above. The walks
+// therefore remain bounded by a COUNT (two of them, up to maxAncestry hops
+// each, every hop a `ps` and possibly a `plutil` at shelloutTimeout), which is
+// a real standing hazard on the discovery path and is stated rather than
+// implied. noAggregateBudget carries the polarity argument for both call sites
+// side by side.
+//
 // "Complete" means every probe in the walk was ANSWERED, which is wider than
 // "no readProcInfo call failed" — the walk also shells out to plutil (#1524).
 // resolveHostBundleIDFromAncestry says why that mattered; bundleIDVia is where
 // the line between an answer and a non-answer is drawn.
 func IsKnownInteractiveHost(pid int) bool {
-	return isKnownInteractiveHostVia(pid, resolveHostFromAncestry, resolveHostBundleIDFromAncestry)
+	return isKnownInteractiveHostVia(noAggregateBudget(), pid, resolveHostFromAncestry, resolveHostBundleIDFromAncestry)
 }
 
 // ancestryWalk is the shape resolveHostFromAncestry and
 // resolveHostBundleIDFromAncestry share: a host string, the PID it was found
 // at, and whether the walk reached its verdict rather than aborting.
-type ancestryWalk func(pid int) (host string, hostPID int, complete bool)
+type ancestryWalk func(ctx context.Context, pid int) (host string, hostPID int, complete bool)
 
 // isKnownInteractiveHostVia is IsKnownInteractiveHost with both walks injected,
 // so the ORDER between them is testable — the pure isKnownInteractiveHostFrom
@@ -369,13 +380,13 @@ type ancestryWalk func(pid int) (host string, hostPID int, complete bool)
 // completed and found CodexBar. That is the deliberate polarity — a re-probe
 // could only move the answer toward rejection, on evidence this gate has
 // already decided not to trust.
-func isKnownInteractiveHostVia(pid int, walkTerm, walkBundle ancestryWalk) bool {
-	term, _, complete := walkTerm(pid)
+func isKnownInteractiveHostVia(ctx context.Context, pid int, walkTerm, walkBundle ancestryWalk) bool {
+	term, _, complete := walkTerm(ctx, pid)
 	bundleID := ""
 	if term == "" && complete {
 		// Only reached when walk 1 ran to a verdict, so this also skips the
 		// duplicate ps shellouts whenever the curated map already matched.
-		bundleID, _, complete = walkBundle(pid)
+		bundleID, _, complete = walkBundle(ctx, pid)
 	}
 	return isKnownInteractiveHostFrom(term, bundleID, complete)
 }
@@ -398,8 +409,8 @@ func isKnownInteractiveHostFrom(termProgram, bundleID string, complete bool) boo
 // PID. Kept for the existing call site that only cares whether kitty (or any
 // other host) appears in the chain; callers that also need the host PID
 // should use resolveHostFromAncestry directly to avoid a second walk.
-func resolveTermProgramFromAncestry(pid int) string {
-	term, _, _ := resolveHostFromAncestry(pid)
+func resolveTermProgramFromAncestry(ctx context.Context, pid int) string {
+	term, _, _ := resolveHostFromAncestry(ctx, pid)
 	return term
 }
 
@@ -410,8 +421,8 @@ func resolveTermProgramFromAncestry(pid int) string {
 // their env even from non-TCC sysctl reads, so KITTY_PID never makes it
 // into the env-derived launcher. Ancestry walking still works because we
 // only read ppid + comm, not env.
-func kittyAncestryPID(pid int) int {
-	term, hostPID, _ := resolveHostFromAncestry(pid)
+func kittyAncestryPID(ctx context.Context, pid int) int {
+	term, hostPID, _ := resolveHostFromAncestry(ctx, pid)
 	if term != "kitty" {
 		return 0
 	}
@@ -482,8 +493,8 @@ func kittyListenOnFor(kittyPID int) string {
 // KittyWindowID for sessions whose own env didn't expose KITTY_WINDOW_ID
 // (e.g., the pi adapter — pi's env is unreadable via sysctl). Bounded
 // 2-second timeout; runs at session-birth so latency is acceptable.
-func kittyWindowIDForPID(socket string, sessionPID int) (string, bool) {
-	return kittyWindowIDForPIDVia(socket, sessionPID, func(ctx context.Context) *exec.Cmd {
+func kittyWindowIDForPID(ctx context.Context, socket string, sessionPID int) (string, bool) {
+	return kittyWindowIDForPIDVia(ctx, socket, sessionPID, func(ctx context.Context) *exec.Cmd {
 		return exec.CommandContext(ctx, kittenPath, "@", "--to", socket, "ls")
 	})
 }
@@ -503,11 +514,11 @@ func kittyWindowIDForPID(socket string, sessionPID int) (string, bool) {
 // failed probe would poison hostIdentity's completeness permanently on any
 // machine where kitten is not on the trusted path, in exchange for nothing:
 // only an invocation that actually ran and did not answer is new information.
-func kittyWindowIDForPIDVia(socket string, sessionPID int, build shelloutCmd) (string, bool) {
+func kittyWindowIDForPIDVia(ctx context.Context, socket string, sessionPID int, build shelloutCmd) (string, bool) {
 	if kittenPath == "" || socket == "" || sessionPID <= 0 {
 		return "", true
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), shelloutTimeout)
+	ctx, cancel := context.WithTimeout(ctx, shelloutTimeout)
 	defer cancel()
 	out, err := build(ctx).Output()
 	if !probeAnswered(err) {
@@ -577,8 +588,8 @@ func findKittyWindowIDForPID(windows []kittyLsWindow, sessionPID int) string {
 // helpers. We shell out rather than parse `kinfo_proc` from sysctl because
 // ps already handles the comm-vs-argv-path distinction we need, and the
 // existing package is built around these bounded exec calls.
-func readProcInfo(pid int) (ppid int, cmd string, err error) {
-	ctx, cancel := context.WithTimeout(context.Background(), shelloutTimeout)
+func readProcInfo(ctx context.Context, pid int) (ppid int, cmd string, err error) {
+	ctx, cancel := context.WithTimeout(ctx, shelloutTimeout)
 	defer cancel()
 	out, err := exec.CommandContext(ctx, psPath, "-o", "ppid=,comm=", "-p", strconv.Itoa(pid)).Output()
 	if err != nil {
@@ -628,7 +639,7 @@ func readProcInfo(pid int) (ppid int, cmd string, err error) {
 // are allocated ascending, so descending PID is "newest first". lsof matches
 // by device and inode rather than by string, so a symlinked path (a macOS
 // t.TempDir() lives under /var -> /private/var) needs no canonicalisation here.
-func herdrClientPIDs(socketPath string) (pids []int, probed bool) {
+func herdrClientPIDs(ctx context.Context, socketPath string) (pids []int, probed bool) {
 	logPath := herdrClientLogPath(socketPath)
 	if logPath == "" {
 		return nil, false
@@ -651,7 +662,7 @@ func herdrClientPIDs(socketPath string) (pids []int, probed bool) {
 	if _, err := os.Stat(logPath); err != nil {
 		return nil, false
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), shelloutTimeout)
+	ctx, cancel := context.WithTimeout(ctx, shelloutTimeout)
 	defer cancel()
 	out, err := exec.CommandContext(ctx, lsofPath, logPath).Output()
 	if !lsofProbeRan(err) {
@@ -738,6 +749,13 @@ func herdrClientWriters(out string, self int) []int {
 // resolvable host. Each candidate costs an env read plus an ancestry walk, and
 // attaching more than a handful of clients to one session is not a real
 // workflow, so the cap keeps that work proportionate.
+//
+// Since #1529 it is a SANITY cap and no longer the de-facto time bound it had
+// been: herdrClientBudget bounds the loop by duration, so a machine slow enough
+// for four candidates to matter now stops on the clock instead of on the count.
+// The cap still poisons the answer when it truncates (see
+// resolveClientHostIdentity), because "we declined to look at the rest" is the
+// same non-answer whichever bound produced it.
 const maxClientCandidates = 4
 
 // resolveClientHostIdentity picks the host-window identity of the first
@@ -777,6 +795,29 @@ const maxClientCandidates = 4
 // claim the cap makes false, and answering it anyway is #1492 arriving through
 // the cap instead of through a timeout.
 //
+// #1529's aggregate budget arrives at the SAME conclusion by a third route, and
+// getting its polarity backwards would have made this fix cause the misroute
+// #1348/#1492 removed. ctx carries one deadline shared by the lsof scan and
+// every candidate behind it, and a candidate abandoned on it is a candidate we
+// declined to look at — so it poisons readAll exactly as an unreadable one
+// does, and the caller is told (nil, false) = "I could not look". Two ways in,
+// both covered:
+//
+//   - A candidate ABANDONED before it starts: the check below is why the loop
+//     tests the budget itself rather than relying on the children to inherit
+//     it. An expired ctx still lets every remaining candidate run three
+//     shellouts that fail instantly, and — worse for correctness than for cost —
+//     an aggregate that is only ever inherited is one no caller can observe as
+//     a bound.
+//   - A candidate CUT SHORT mid-flight: its own shellouts die on the shared
+//     deadline, hostIdentity reports complete=false, and the existing #1492
+//     line below poisons on it with no new code. That composition is the whole
+//     reason the tri-state needed no fourth state.
+//
+// A candidate that resolved a host BEFORE the budget ran out still wins
+// outright, on the same grounds as an unreadable-siblings answer: a found host
+// is evidence regardless of what the rest of the list did.
+//
 // Two residual false negatives survive, both of them "the walk reached a
 // verdict" cases rather than aborts, so the bit above cannot express them:
 // a candidate inside a tmux pane walks to the reparented tmux server and
@@ -789,13 +830,51 @@ const maxClientCandidates = 4
 // dedups (sortedDistinctPIDs) because lsof emits a row per FD; a `tmux
 // list-clients` producer is naturally distinct, but the obligation is stated
 // here, next to the constant that depends on it, rather than only there.
-func resolveClientHostIdentity(pids []int) (*session.Launcher, bool) {
+//
+// This wrapper is the loop paired with the PRODUCTION identity read, and it is
+// the name the rest of this file's prose refers to. Say plainly what it is
+// today rather than let a reader infer: nothing in production calls it —
+// resolveHerdrClientLauncher reaches the Via form so it can name both probes at
+// one wiring — and its callers are the #1492 tests, which drive real PIDs
+// through the real hostIdentity and would otherwise have to name that probe
+// themselves. So the production probe is named twice, one line apart, which is
+// a drift worth knowing about and too small to be worth a seam.
+func resolveClientHostIdentity(ctx context.Context, pids []int) (*session.Launcher, bool) {
+	return resolveClientHostIdentityVia(ctx, pids, hostIdentity)
+}
+
+// hostIdentityProbe is the per-candidate identity read
+// resolveClientHostIdentityVia makes. Injected for the reason ttyProbe,
+// kittyWindowProbe and resolveHostBundleIDVia's two probes are: no arrangement
+// of live processes can be driven to consume a shared budget at a chosen
+// candidate, and #1529's whole subject is what the loop does when it has.
+//
+// It returns a NON-NIL launcher, as hostIdentity does for every input: the loop
+// reads fields off it before deciding anything, and a probe that returned nil
+// would panic rather than report a non-answer. "Nothing was determined" is the
+// second return, never a nil first.
+type hostIdentityProbe func(ctx context.Context, pid int) (*session.Launcher, bool)
+
+// resolveClientHostIdentityVia is resolveClientHostIdentity with the
+// per-candidate identity read injected.
+func resolveClientHostIdentityVia(ctx context.Context, pids []int, identify hostIdentityProbe) (*session.Launcher, bool) {
 	readAll := len(pids) <= maxClientCandidates
 	if !readAll {
 		pids = pids[:maxClientCandidates]
 	}
 	for _, pid := range pids {
-		host, complete := hostIdentity(pid)
+		if ctx.Err() != nil {
+			// #1529: the aggregate budget is gone and candidates are left. They
+			// are candidates we declined to look at, which is the cap's case
+			// rather than the detach case — so poison and stop, exactly as a
+			// truncation does. Checked HERE rather than left to the children:
+			// an expired deadline reaches them anyway, but only this check
+			// turns "every probe failed" into "we stopped looking", and only
+			// this check makes the aggregate a bound a caller can observe.
+			readAll = false
+			break
+		}
+		host, complete := identify(ctx, pid)
 		if host.HerdrPaneID != "" {
 			// A candidate that is itself a multiplexer pane has no window of
 			// its own — its host is one more indirection away. Don't recurse;
@@ -826,6 +905,15 @@ func resolveClientHostIdentity(pids []int) (*session.Launcher, bool) {
 // "Was read and has no host" rather than "reported no host" is the whole of
 // #1492; resolveClientHostIdentity's doc carries the argument, and this
 // function only passes its verdict through.
+//
+// A miss costs at most herdrClientBudget, and that is a real ceiling rather
+// than a sum of per-child ones (#1529): resolveHerdrClientLauncherVia derives
+// ONE deadline covering the lsof scan and every candidate behind it. Before
+// that the cost here was bounded by a COUNT — up to maxClientCandidates
+// candidates, each two independent ancestry walks plus a tty `ps`, the
+// bundle-id walk paying a `plutil` per hop up to maxAncestry — so one resolve
+// could run to tens of seconds inside a 5s liveness-sweep tick. A cache HIT is
+// free either way and is the common case; the budget bounds the miss.
 //
 // Only ever called with a socket path the daemon captured from the pane's own
 // $HERDR_SOCKET_PATH, so a resolved identity always accompanies a complete
@@ -863,9 +951,12 @@ func resolveClientHostIdentity(pids []int) (*session.Launcher, bool) {
 //     which fails fast, so re-paying it per pane was nearly free and the spread
 //     was the only cost worth naming. #1492 routed the most EXPENSIVE outcome in
 //     this function to the same branch: every candidate probed and none
-//     readable, which is up to maxClientCandidates candidates, each costing two
-//     independent ancestry walks on readProcInfo's 2s ceiling. Re-paying now
-//     dominates, and the trade the rule was making inverted.
+//     readable, which is the whole herdrClientBudget spent before an answer
+//     arrives. Re-paying now dominates, and the trade the rule was making
+//     inverted. (Until #1529 that outcome had no ceiling at all — up to
+//     maxClientCandidates candidates, two independent ancestry walks each on
+//     readProcInfo's 2s ceiling, with a `plutil` per hop — which is why #1514's
+//     memo made it rarer without making it shorter.)
 //
 // The new rule: the memo holds what ONE probe of this socket determined, for
 // one TTL — an answer or the absence of one. A non-answer keeps probed=false on
@@ -900,11 +991,33 @@ func herdrClientLauncher(socketPath string) (*session.Launcher, bool) {
 }
 
 func resolveHerdrClientLauncher(socketPath string) (*session.Launcher, bool) {
-	pids, probed := herdrClientPIDs(socketPath)
+	return resolveHerdrClientLauncherVia(socketPath, herdrClientPIDs, hostIdentity)
+}
+
+// clientPIDProbe is the attached-client scan resolveHerdrClientLauncherVia
+// makes — the lsof half of the budget, injected so a test can drive the loop
+// behind it without a live herdr server.
+type clientPIDProbe func(ctx context.Context, socketPath string) (pids []int, probed bool)
+
+// resolveHerdrClientLauncherVia is resolveHerdrClientLauncher with both probes
+// injected. It DERIVES the aggregate deadline rather than taking one, so a test
+// driving it exercises herdrClientBudget itself rather than a budget the test
+// supplied — the same reason #1390 collapsed a receiver's two constructors into
+// the one the daemon builds.
+//
+// One context spans both stages on purpose. Two deadlines, one per stage, would
+// read as a bound and add up to twice the budget; and the lsof scan is the
+// cheap half of a pair whose expensive half is the loop, so the scan running
+// long is precisely when the loop needs less. What the herdr indirection costs
+// is one number, so it is one context.
+func resolveHerdrClientLauncherVia(socketPath string, scan clientPIDProbe, identify hostIdentityProbe) (*session.Launcher, bool) {
+	ctx, cancel := context.WithTimeout(context.Background(), herdrClientBudget)
+	defer cancel()
+	pids, probed := scan(ctx, socketPath)
 	if !probed {
 		return nil, false
 	}
-	return resolveClientHostIdentity(pids)
+	return resolveClientHostIdentityVia(ctx, pids, identify)
 }
 
 // herdrClientCacheTTL is short enough that attaching a client is picked up by
@@ -972,8 +1085,9 @@ func herdrClientCacheLive(socketPath string) (herdrClientCacheEntry, bool) {
 // overwrite anything. Two goroutines can miss the memo for one socket and
 // probe concurrently — refreshHerdrHosts reads outside assignMu, on the sweep
 // goroutine, while PID discovery reaches captureLauncher/backfillLauncher on
-// its own — and a non-answer is by far the SLOWER outcome to produce (up to
-// maxClientCandidates candidates, two ancestry walks each on a 2s ceiling).
+// its own — and a non-answer is still by far the SLOWER outcome to produce: it
+// is the one that can spend the whole herdrClientBudget, where an answer stops
+// at the first candidate that resolves.
 // So the loser of that race is systematically the one carrying no
 // information, and last-writer-wins would let it both erase a resolved host
 // and restamp the entry fresh, extending the deferral by another full TTL.

--- a/core/adapters/inbound/agents/processlifecycle/osutil_darwin.go
+++ b/core/adapters/inbound/agents/processlifecycle/osutil_darwin.go
@@ -1005,11 +1005,32 @@ type clientPIDProbe func(ctx context.Context, socketPath string) (pids []int, pr
 // supplied — the same reason #1390 collapsed a receiver's two constructors into
 // the one the daemon builds.
 //
-// One context spans both stages on purpose. Two deadlines, one per stage, would
-// read as a bound and add up to twice the budget; and the lsof scan is the
-// cheap half of a pair whose expensive half is the loop, so the scan running
-// long is precisely when the loop needs less. What the herdr indirection costs
-// is one number, so it is one context.
+// One context spans both stages on purpose: two deadlines, one per stage, would
+// read as a bound while summing to twice the budget, and what the herdr
+// indirection costs is one number, so it is one context.
+//
+// What sharing COSTS, stated rather than argued away. The two stages compete
+// for one budget and the scan goes first, so an lsof that runs to nearly
+// herdrClientBudget and still SUCCEEDS leaves the loop nothing: every candidate
+// is abandoned and the answer is (nil, false). On a machine where lsof is
+// chronically slow-but-answering, a herdr host would then never resolve, where
+// before #1529 it resolved slowly. Three things bound that, and none of them
+// makes it go away:
+//
+//   - It fails to the SAFE side. A non-answer clears no stored host (#1492) and
+//     the memo re-probes on the next sweep, so the cost is a deferred recovery
+//     rather than a wrong answer.
+//   - The band is narrow. An lsof at its own shelloutTimeout is normally KILLED
+//     rather than slow, and a killed one is already (nil, false) via
+//     lsofProbeRan — so only the slow-and-successful window is new.
+//   - Nobody would see it. #1534 is that nothing counts probe non-answers, and
+//     that now covers budget abandonment too.
+//
+// Splitting the budget between the stages is the obvious alternative and is
+// deliberately NOT taken here: it needs evidence about the real distribution of
+// scan times, which #1529 has none of. This is the same trade #1553 records for
+// the git adapter — an unbounded call that answered slowly becomes a bounded
+// one that does not answer at all — and it is written down for the same reason.
 func resolveHerdrClientLauncherVia(socketPath string, scan clientPIDProbe, identify hostIdentityProbe) (*session.Launcher, bool) {
 	ctx, cancel := context.WithTimeout(context.Background(), herdrClientBudget)
 	defer cancel()

--- a/core/adapters/inbound/agents/processlifecycle/osutil_darwin_test.go
+++ b/core/adapters/inbound/agents/processlifecycle/osutil_darwin_test.go
@@ -24,7 +24,7 @@ func TestKittyAncestryPID_Self(t *testing.T) {
 	// app launched `go test`, so we only assert the helper returns cleanly.
 	// When it returns non-zero, the result must point at a real kitty.app
 	// process (or one that's since exited — the lookup is best-effort).
-	got := kittyAncestryPID(os.Getpid())
+	got := kittyAncestryPID(noAggregateBudget(), os.Getpid())
 	if got == 0 {
 		return // legitimate when no kitty in ancestry
 	}
@@ -299,7 +299,7 @@ func TestTopLevelAppPath(t *testing.T) {
 // contains a dot) or "" — never errors or panics. The deterministic path
 // logic is covered by TestTopLevelAppPath.
 func TestResolveHostBundleIDFromAncestry_Self(t *testing.T) {
-	bid, hostPID, complete := resolveHostBundleIDFromAncestry(os.Getpid())
+	bid, hostPID, complete := resolveHostBundleIDFromAncestry(noAggregateBudget(), os.Getpid())
 	// The running test binary is alive, so every readProcInfo in its chain has
 	// something to answer with — barring a `ps` slow enough to blow its own 2s
 	// ceiling, which is the condition #1492 is about and which this assertion
@@ -318,8 +318,8 @@ func TestResolveHostBundleIDFromAncestry_Self(t *testing.T) {
 		// only the bundle probe to one that always answers. A non-empty sentinel
 		// means the walk DID reach a top-level app, so the production pair had
 		// something to name and came back empty.
-		sentinel, _, _ := resolveHostBundleIDVia(os.Getpid(), readProcInfo,
-			func(string) (string, error) { return "sentinel.app", nil })
+		sentinel, _, _ := resolveHostBundleIDVia(noAggregateBudget(), os.Getpid(), readProcInfo,
+			func(context.Context, string) (string, error) { return "sentinel.app", nil })
 		if sentinel != "" {
 			t.Error("the walk reached a top-level .app ancestor but resolveHostBundleIDFromAncestry " +
 				"named nothing — either its production probe pair no longer reaches plutil, or every " +
@@ -337,7 +337,7 @@ func TestResolveHostBundleIDFromAncestry_Self(t *testing.T) {
 // invocation, so we only assert that the helper either finds a supported host
 // (non-empty) or returns "" cleanly — never errors or panics.
 func TestResolveTermProgramFromAncestry_Self(t *testing.T) {
-	got := resolveTermProgramFromAncestry(os.Getpid())
+	got := resolveTermProgramFromAncestry(noAggregateBudget(), os.Getpid())
 	if got != "" {
 		if _, known := termProgramByAppName[reverseLookup(got)]; !known {
 			t.Errorf("resolveTermProgramFromAncestry returned unknown TermProgram %q", got)
@@ -412,7 +412,7 @@ func spawnHerdrClient(t *testing.T, socketPath string, env ...string) int {
 	}, env...))
 	deadline := time.Now().Add(5 * time.Second)
 	for time.Now().Before(deadline) {
-		pids, _ := herdrClientPIDs(socketPath)
+		pids, _ := herdrClientPIDs(noAggregateBudget(), socketPath)
 		for _, got := range pids {
 			if got == pid {
 				return pid
@@ -481,7 +481,7 @@ func TestHerdrClientPIDs_MultipleClientsAreOrderedNewestFirst(t *testing.T) {
 	first := spawnHerdrClient(t, socketPath)
 	second := spawnHerdrClient(t, socketPath)
 
-	pids, _ := herdrClientPIDs(socketPath)
+	pids, _ := herdrClientPIDs(noAggregateBudget(), socketPath)
 	if len(pids) < 2 {
 		t.Fatalf("want both attached clients, got %v (first=%d second=%d)", pids, first, second)
 	}
@@ -607,7 +607,7 @@ func TestHerdrClientPIDs_ProbeTriState(t *testing.T) {
 	t.Run("attached", func(t *testing.T) {
 		socketPath := newHerdrSessionDir(t)
 		client := spawnHerdrClient(t, socketPath)
-		pids, probed := herdrClientPIDs(socketPath)
+		pids, probed := herdrClientPIDs(noAggregateBudget(), socketPath)
 		if !probed {
 			t.Fatal("a successful lsof must report a probe that ran")
 		}
@@ -622,7 +622,7 @@ func TestHerdrClientPIDs_ProbeTriState(t *testing.T) {
 		if err := os.WriteFile(herdrClientLogPath(socketPath), []byte("detached\n"), 0o600); err != nil {
 			t.Fatalf("seed client log: %v", err)
 		}
-		pids, probed := herdrClientPIDs(socketPath)
+		pids, probed := herdrClientPIDs(noAggregateBudget(), socketPath)
 		if !probed {
 			t.Fatal("a detach is an answer, not a failure — reporting it as unknown would freeze the last host forever")
 		}
@@ -638,13 +638,13 @@ func TestHerdrClientPIDs_ProbeTriState(t *testing.T) {
 		// self-consistent "nobody is attached". A socket path addressing
 		// another *real* session is NOT covered — that log exists, so the
 		// stat passes; see herdrClientPIDs.
-		if _, probed := herdrClientPIDs(newHerdrSessionDir(t)); probed {
+		if _, probed := herdrClientPIDs(noAggregateBudget(), newHerdrSessionDir(t)); probed {
 			t.Error("a client log that does not exist is not evidence of a detach")
 		}
 	})
 
 	t.Run("no socket path", func(t *testing.T) {
-		if _, probed := herdrClientPIDs(""); probed {
+		if _, probed := herdrClientPIDs(noAggregateBudget(), ""); probed {
 			t.Error("no address means nothing was probed")
 		}
 	})
@@ -829,10 +829,10 @@ func exitedPID(t *testing.T) int {
 // readProcInfo fails, which is the same branch a `ps` that blows its 2s ceiling
 // takes.
 func TestResolveHostFromAncestry_UnreadableProcessIsNotAMiss(t *testing.T) {
-	if term, hostPID, complete := resolveHostFromAncestry(1); term != "" || hostPID != 0 || !complete {
+	if term, hostPID, complete := resolveHostFromAncestry(noAggregateBudget(), 1); term != "" || hostPID != 0 || !complete {
 		t.Errorf("launchd: got (%q, %d, %v); want a completed walk that found nothing", term, hostPID, complete)
 	}
-	if term, hostPID, complete := resolveHostFromAncestry(exitedPID(t)); term != "" || hostPID != 0 || complete {
+	if term, hostPID, complete := resolveHostFromAncestry(noAggregateBudget(), exitedPID(t)); term != "" || hostPID != 0 || complete {
 		t.Errorf("reaped pid: got (%q, %d, %v); want an ABORTED walk — an unreadable process is not a miss", term, hostPID, complete)
 	}
 }
@@ -843,10 +843,10 @@ func TestResolveHostFromAncestry_UnreadableProcessIsNotAMiss(t *testing.T) {
 // verdict (launchd, row 1); "pid could not be read" is not (row 2). Merging
 // them is #1492 in miniature.
 func TestResolveHostBundleIDFromAncestry_UnreadableProcessIsNotAMiss(t *testing.T) {
-	if bid, hostPID, complete := resolveHostBundleIDFromAncestry(1); bid != "" || hostPID != 0 || !complete {
+	if bid, hostPID, complete := resolveHostBundleIDFromAncestry(noAggregateBudget(), 1); bid != "" || hostPID != 0 || !complete {
 		t.Errorf("launchd: got (%q, %d, %v); want a completed walk that found nothing", bid, hostPID, complete)
 	}
-	if bid, hostPID, complete := resolveHostBundleIDFromAncestry(exitedPID(t)); bid != "" || hostPID != 0 || complete {
+	if bid, hostPID, complete := resolveHostBundleIDFromAncestry(noAggregateBudget(), exitedPID(t)); bid != "" || hostPID != 0 || complete {
 		t.Errorf("reaped pid: got (%q, %d, %v); want an ABORTED walk", bid, hostPID, complete)
 	}
 }
@@ -874,7 +874,7 @@ func TestIsKnownInteractiveHost_AbortedWalkAdmits(t *testing.T) {
 // value at the call site — every test of this seam turns on which of the two a
 // walk returned, and a bare `true` there reads as "found a host".
 func walk(host string, complete bool) ancestryWalk {
-	return func(int) (string, int, bool) { return host, 0, complete }
+	return func(context.Context, int) (string, int, bool) { return host, 0, complete }
 }
 
 const (
@@ -926,7 +926,7 @@ func TestIsKnownInteractiveHostVia_AbortedFirstWalkDoesNotDeferToTheSecond(t *te
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := isKnownInteractiveHostVia(4242, tc.term, tc.bundle); got != tc.wantInteractive {
+			if got := isKnownInteractiveHostVia(noAggregateBudget(), 4242, tc.term, tc.bundle); got != tc.wantInteractive {
 				t.Errorf("isKnownInteractiveHostVia = %v, want %v", got, tc.wantInteractive)
 			}
 		})
@@ -981,11 +981,11 @@ func TestHostIdentity_KittyBackfillWalkCountsTowardCompleteness(t *testing.T) {
 
 	// Vacuity guard: with a LIVE pid the same block runs and completes, so a
 	// hostIdentity hard-wired to "incomplete" would not satisfy this test.
-	if l, complete := hostIdentity(os.Getpid()); !complete || l.TermProgram != "kitty" {
+	if l, complete := hostIdentity(noAggregateBudget(), os.Getpid()); !complete || l.TermProgram != "kitty" {
 		t.Errorf("live pid: got (%+v, %v); want the back-fill to run and complete", l, complete)
 	}
 
-	l, complete := hostIdentity(exitedPID(t))
+	l, complete := hostIdentity(noAggregateBudget(), exitedPID(t))
 	if l.TermProgram != "kitty" {
 		t.Fatalf("the env still names the host, so it must survive: %+v", l)
 	}
@@ -1017,7 +1017,7 @@ func orphanPID(t *testing.T) int {
 	// The `sh` has exited (Output waits for it); wait for launchd to actually
 	// re-parent before asserting on the chain.
 	for i := 0; i < 100; i++ {
-		if ppid, _, err := readProcInfo(pid); err == nil && ppid <= 1 {
+		if ppid, _, err := readProcInfo(noAggregateBudget(), pid); err == nil && ppid <= 1 {
 			return pid
 		}
 		time.Sleep(20 * time.Millisecond)
@@ -1036,10 +1036,10 @@ func orphanPID(t *testing.T) int {
 func TestResolveHostFromAncestry_ChainEndingAtInitIsAVerdict(t *testing.T) {
 	orphan := orphanPID(t)
 
-	if term, hostPID, complete := resolveHostFromAncestry(orphan); term != "" || hostPID != 0 || !complete {
+	if term, hostPID, complete := resolveHostFromAncestry(noAggregateBudget(), orphan); term != "" || hostPID != 0 || !complete {
 		t.Errorf("orphan: got (%q, %d, %v); want a completed in-loop walk that found nothing", term, hostPID, complete)
 	}
-	if _, hostKnown := resolveClientHostIdentity([]int{orphan}); !hostKnown {
+	if _, hostKnown := resolveClientHostIdentity(noAggregateBudget(), []int{orphan}); !hostKnown {
 		t.Error("a reparented candidate WAS read and has no window — that is an answer")
 	}
 }
@@ -1054,10 +1054,10 @@ func TestResolveClientHostIdentity_TruncatedCandidatesArePoisonToo(t *testing.T)
 	for i := range full {
 		full[i] = 1
 	}
-	if _, hostKnown := resolveClientHostIdentity(full); !hostKnown {
+	if _, hostKnown := resolveClientHostIdentity(noAggregateBudget(), full); !hostKnown {
 		t.Fatalf("exactly maxClientCandidates readable candidates is a complete look: %d", len(full))
 	}
-	if _, hostKnown := resolveClientHostIdentity(append(full, 1)); hostKnown {
+	if _, hostKnown := resolveClientHostIdentity(noAggregateBudget(), append(full, 1)); hostKnown {
 		t.Error("one candidate past the cap was never probed, so 'no client has a window' is unsupported")
 	}
 }
@@ -1066,10 +1066,10 @@ func TestResolveClientHostIdentity_TruncatedCandidatesArePoisonToo(t *testing.T)
 // primitives above and the loop below: hostIdentity is where a caller reads
 // them, and #1501's tmux client path is queued to read it the same way.
 func TestHostIdentity_CarriesTheAncestryVerdict(t *testing.T) {
-	if l, complete := hostIdentity(1); !complete || l == nil {
+	if l, complete := hostIdentity(noAggregateBudget(), 1); !complete || l == nil {
 		t.Errorf("launchd is readable and hostless: got (%+v, %v)", l, complete)
 	}
-	if l, complete := hostIdentity(exitedPID(t)); complete {
+	if l, complete := hostIdentity(noAggregateBudget(), exitedPID(t)); complete {
 		t.Errorf("a reaped pid cannot be read, so its empty identity is not evidence: got (%+v, %v)", l, complete)
 	}
 }
@@ -1089,7 +1089,7 @@ func TestHostIdentity_CarriesTheAncestryVerdict(t *testing.T) {
 func TestResolveClientHostIdentity_UnreadableCandidateIsNotDetached(t *testing.T) {
 	dead := exitedPID(t)
 
-	host, hostKnown := resolveClientHostIdentity([]int{dead})
+	host, hostKnown := resolveClientHostIdentity(noAggregateBudget(), []int{dead})
 
 	if host != nil {
 		t.Errorf("an unreadable candidate must not produce a host: %+v", host)
@@ -1106,7 +1106,7 @@ func TestResolveClientHostIdentity_UnreadableCandidateIsNotDetached(t *testing.T
 // ancestry walk terminates immediately and honestly (PID 1 has no parent), so
 // "no local window" here is evidence, and the answer stays an answer.
 func TestResolveClientHostIdentity_HostlessCandidateStaysDetached(t *testing.T) {
-	host, hostKnown := resolveClientHostIdentity([]int{1})
+	host, hostKnown := resolveClientHostIdentity(noAggregateBudget(), []int{1})
 
 	if host != nil {
 		t.Errorf("launchd has no window; reporting one is the #1348 misroute: %+v", host)
@@ -1125,13 +1125,13 @@ func TestResolveClientHostIdentity_OneUnreadableCandidatePoisonsTheAnswer(t *tes
 
 	// launchd first, so a loop that only remembered the FIRST candidate's
 	// verdict would answer "detached" here.
-	if _, hostKnown := resolveClientHostIdentity([]int{1, dead}); hostKnown {
+	if _, hostKnown := resolveClientHostIdentity(noAggregateBudget(), []int{1, dead}); hostKnown {
 		t.Error("one unreadable candidate makes 'no client has a window' unsupported (#1492)")
 	}
 	// launchd last, so a loop that only remembered the LAST verdict would
 	// answer "detached" here. Between them the two arms pin both spellings of
 	// "the accumulator was dropped".
-	if _, hostKnown := resolveClientHostIdentity([]int{dead, 1}); hostKnown {
+	if _, hostKnown := resolveClientHostIdentity(noAggregateBudget(), []int{dead, 1}); hostKnown {
 		t.Error("order must not change the verdict")
 	}
 }
@@ -1146,7 +1146,7 @@ func TestResolveClientHostIdentity_ResolvableCandidateStillWins(t *testing.T) {
 		"ITERM_SESSION_ID=w0t0p0-CLIENT",
 	})
 
-	host, hostKnown := resolveClientHostIdentity([]int{client})
+	host, hostKnown := resolveClientHostIdentity(noAggregateBudget(), []int{client})
 
 	if !hostKnown {
 		t.Fatal("a candidate whose own env names its host is readable by definition")
@@ -1158,7 +1158,7 @@ func TestResolveClientHostIdentity_ResolvableCandidateStillWins(t *testing.T) {
 	// The asymmetry the doc claims: a found host is evidence regardless of what
 	// the rest of the list did, so an unreadable candidate ahead of it must not
 	// poison a POSITIVE answer — only a negative one.
-	host, hostKnown = resolveClientHostIdentity([]int{exitedPID(t), client})
+	host, hostKnown = resolveClientHostIdentity(noAggregateBudget(), []int{exitedPID(t), client})
 	if !hostKnown || host == nil || host.TermProgram != "iTerm.app" {
 		t.Errorf("a resolving candidate wins outright past an unreadable one: got (%+v, %v)", host, hostKnown)
 	}
@@ -1333,7 +1333,7 @@ func TestHerdrClientPIDs_DedupesFDRowsOfOneClient(t *testing.T) {
 		"herdr     26940 ingo    5u   REG   1,18      372 136170 " + logPath
 	countingLsof(t, logPath, table)
 
-	pids, probed := herdrClientPIDs(socketPath)
+	pids, probed := herdrClientPIDs(noAggregateBudget(), socketPath)
 	if !probed {
 		t.Fatal("the stub exits 0, so the probe ran")
 	}
@@ -1505,7 +1505,7 @@ func TestBundleIDVia_AnsweredMissIsNotAnUnanswerableProbe(t *testing.T) {
 	// already has, so every row names the function it exercises instead of
 	// encoding it as an absent value.
 	via := func(c bundleIDCmd) bundleIDProbe {
-		return func(appPath string) (string, error) { return bundleIDVia(appPath, c) }
+		return func(ctx context.Context, appPath string) (string, error) { return bundleIDVia(ctx, appPath, c) }
 	}
 	tests := []struct {
 		name    string
@@ -1554,7 +1554,7 @@ func TestBundleIDVia_AnsweredMissIsNotAnUnanswerableProbe(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			id, err := tc.probe(tc.appPath)
+			id, err := tc.probe(noAggregateBudget(), tc.appPath)
 			if id != tc.wantID {
 				t.Errorf("id = %q, want %q — %s", id, tc.wantID, tc.wantWhy)
 			}
@@ -1575,7 +1575,7 @@ func TestBundleIDVia_AnsweredMissIsNotAnUnanswerableProbe(t *testing.T) {
 func TestBundleIDVia_CeilingActuallyFires(t *testing.T) {
 	t.Parallel() // spends the real 2s ceiling and shares no state
 	start := time.Now()
-	if _, err := bundleIDVia("/System/Library/CoreServices/Finder.app", stalledPlistCmd); err == nil {
+	if _, err := bundleIDVia(noAggregateBudget(), "/System/Library/CoreServices/Finder.app", stalledPlistCmd); err == nil {
 		t.Fatal("a child that never answers must report an error")
 	}
 	if elapsed := time.Since(start); elapsed < time.Second {
@@ -1600,7 +1600,7 @@ func obsidianChain() procInfoProbe {
 		300: {400, "/Applications/Obsidian.app/Contents/Frameworks/Obsidian Helper (Renderer).app/Contents/MacOS/Obsidian Helper (Renderer)"},
 		400: {1, "/Applications/Obsidian.app/Contents/MacOS/Obsidian"},
 	}
-	return func(pid int) (int, string, error) {
+	return func(_ context.Context, pid int) (int, string, error) {
 		l, ok := links[pid]
 		if !ok {
 			return 0, "", fmt.Errorf("no process info for pid %d", pid)
@@ -1613,11 +1613,11 @@ func obsidianChain() procInfoProbe {
 // unanswerable returns one that never answers. The pair is the whole #1524
 // distinction in two lines.
 func answering(id string) bundleIDProbe {
-	return func(string) (string, error) { return id, nil }
+	return func(context.Context, string) (string, error) { return id, nil }
 }
 
 func unanswerable() bundleIDProbe {
-	return func(string) (string, error) { return "", fmt.Errorf("plutil: signal: killed") }
+	return func(context.Context, string) (string, error) { return "", fmt.Errorf("plutil: signal: killed") }
 }
 
 // TestResolveHostBundleIDVia_UnanswerableBundleProbeIsNotAMiss is #1524's
@@ -1658,7 +1658,7 @@ func TestResolveHostBundleIDVia_UnanswerableBundleProbeIsNotAMiss(t *testing.T) 
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			id, hostPID, complete := resolveHostBundleIDVia(100, obsidianChain(), tc.probe)
+			id, hostPID, complete := resolveHostBundleIDVia(noAggregateBudget(), 100, obsidianChain(), tc.probe)
 			if got := (verdict{id, hostPID, complete}); got != tc.want {
 				t.Errorf("resolveHostBundleIDVia = %+v; want %+v", got, tc.want)
 			}
@@ -1680,8 +1680,8 @@ func TestResolveHostBundleIDVia_UnanswerableBundleProbeIsNotAMiss(t *testing.T) 
 func TestIsKnownInteractiveHost_PlutilNonAnswerAdmits(t *testing.T) {
 	walk1Finished := walk("", finished)
 	walk2 := func(probe bundleIDProbe) ancestryWalk {
-		return func(pid int) (string, int, bool) {
-			return resolveHostBundleIDVia(pid, obsidianChain(), probe)
+		return func(ctx context.Context, pid int) (string, int, bool) {
+			return resolveHostBundleIDVia(ctx, pid, obsidianChain(), probe)
 		}
 	}
 	tests := []struct {
@@ -1708,7 +1708,7 @@ func TestIsKnownInteractiveHost_PlutilNonAnswerAdmits(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := isKnownInteractiveHostVia(100, walk1Finished, walk2(tc.probe)); got != tc.want {
+			if got := isKnownInteractiveHostVia(noAggregateBudget(), 100, walk1Finished, walk2(tc.probe)); got != tc.want {
 				t.Errorf("isKnownInteractiveHostVia = %v, want %v — %s", got, tc.want, tc.why)
 			}
 		})
@@ -1723,14 +1723,14 @@ func TestIsKnownInteractiveHost_PlutilNonAnswerAdmits(t *testing.T) {
 // classifies a REAL kill the way resolveHostBundleIDVia expects.
 func TestIsKnownInteractiveHost_PlutilCeilingAdmitsEndToEnd(t *testing.T) {
 	t.Parallel() // spends the real 2s ceiling and shares no state
-	stalled := func(appPath string) (string, error) {
-		return bundleIDVia(appPath, stalledPlistCmd)
+	stalled := func(ctx context.Context, appPath string) (string, error) {
+		return bundleIDVia(ctx, appPath, stalledPlistCmd)
 	}
 	walk1Finished := walk("", finished)
-	walk2 := func(pid int) (string, int, bool) {
-		return resolveHostBundleIDVia(pid, obsidianChain(), stalled)
+	walk2 := func(ctx context.Context, pid int) (string, int, bool) {
+		return resolveHostBundleIDVia(ctx, pid, obsidianChain(), stalled)
 	}
-	if !isKnownInteractiveHostVia(100, walk1Finished, walk2) {
+	if !isKnownInteractiveHostVia(noAggregateBudget(), 100, walk1Finished, walk2) {
 		t.Error("a plutil that blew its own ceiling declined a legitimate Obsidian-hosted session (#1524)")
 	}
 }

--- a/core/adapters/inbound/agents/processlifecycle/osutil_linux.go
+++ b/core/adapters/inbound/agents/processlifecycle/osutil_linux.go
@@ -3,6 +3,7 @@
 package processlifecycle
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"strings"
@@ -37,7 +38,7 @@ func readProcessEnv(pid int) (map[string]string, error) {
 // probed is true: having no darwin ps to run is a settled property of this
 // platform, not a read that failed (#1533) — the same reading the ancestry
 // stubs below give their complete return.
-func processTTY(pid int) (string, bool) { return "", true }
+func processTTY(ctx context.Context, pid int) (string, bool) { return "", true }
 
 // resolveTermProgramFromAncestry / resolveHostFromAncestry are darwin-only
 // fallbacks for hardened-runtime processes that hide env from sysctl. Linux
@@ -46,24 +47,26 @@ func processTTY(pid int) (string, bool) { return "", true }
 // complete is true: declining to walk is a settled verdict about this
 // platform, not a read that failed. It is false only where a walk was
 // attempted and could not be answered (#1492), which is darwin-only.
-func resolveTermProgramFromAncestry(pid int) string { return "" }
-func resolveHostFromAncestry(pid int) (term string, host int, complete bool) {
+func resolveTermProgramFromAncestry(ctx context.Context, pid int) string { return "" }
+func resolveHostFromAncestry(ctx context.Context, pid int) (term string, host int, complete bool) {
 	return "", 0, true
 }
-func resolveHostBundleIDFromAncestry(pid int) (bundleID string, host int, complete bool) {
+func resolveHostBundleIDFromAncestry(ctx context.Context, pid int) (bundleID string, host int, complete bool) {
 	return "", 0, true
 }
 
 // Stubs for the kitty "no readable env" enrichment helpers. Linux can read
 // /proc/<pid>/environ for any process the user owns, so the back-fill path
 // these support isn't needed here.
-func kittyAncestryPID(pid int) int         { return 0 }
-func kittyListenOnFor(kittyPID int) string { return "" }
+func kittyAncestryPID(ctx context.Context, pid int) int { return 0 }
+func kittyListenOnFor(kittyPID int) string              { return "" }
 
 // probed is true for the same reason processTTY's stub reports it: having no
 // kitty remote-control CLI to run is a settled property of this platform, not
 // a read that failed (#1537).
-func kittyWindowIDForPID(socket string, sessionPID int) (string, bool) { return "", true }
+func kittyWindowIDForPID(ctx context.Context, socket string, sessionPID int) (string, bool) {
+	return "", true
+}
 
 // IsKnownInteractiveHost is darwin-only (ancestry walking); other platforms
 // fail open. The exclusion signal it backs (CodexBar's non-interactive `agy`

--- a/core/adapters/inbound/agents/processlifecycle/osutil_other.go
+++ b/core/adapters/inbound/agents/processlifecycle/osutil_other.go
@@ -2,7 +2,11 @@
 
 package processlifecycle
 
-import "irrlicht/core/domain/session"
+import (
+	"context"
+
+	"irrlicht/core/domain/session"
+)
 
 // readProcessEnv is not implemented on this platform — launcher capture
 // is disabled and the menu-bar app falls back to Finder-reveal of cwd.
@@ -14,29 +18,31 @@ func readProcessEnv(pid int) (map[string]string, error) {
 // probed is true: having no darwin ps to run is a settled property of this
 // platform, not a read that failed (#1533) — the same reading the ancestry
 // stubs below give their complete return.
-func processTTY(pid int) (string, bool) { return "", true }
+func processTTY(ctx context.Context, pid int) (string, bool) { return "", true }
 
 // resolveTermProgramFromAncestry / resolveHostFromAncestry are darwin-only
 // fallbacks; other platforms return zero values.
 //
 // complete is true: declining to walk is a settled verdict about this
 // platform, not a read that failed (#1492).
-func resolveTermProgramFromAncestry(pid int) string { return "" }
-func resolveHostFromAncestry(pid int) (term string, host int, complete bool) {
+func resolveTermProgramFromAncestry(ctx context.Context, pid int) string { return "" }
+func resolveHostFromAncestry(ctx context.Context, pid int) (term string, host int, complete bool) {
 	return "", 0, true
 }
-func resolveHostBundleIDFromAncestry(pid int) (bundleID string, host int, complete bool) {
+func resolveHostBundleIDFromAncestry(ctx context.Context, pid int) (bundleID string, host int, complete bool) {
 	return "", 0, true
 }
 
 // Stubs for the kitty "no readable env" enrichment helpers — darwin-only.
-func kittyAncestryPID(pid int) int         { return 0 }
-func kittyListenOnFor(kittyPID int) string { return "" }
+func kittyAncestryPID(ctx context.Context, pid int) int { return 0 }
+func kittyListenOnFor(kittyPID int) string              { return "" }
 
 // probed is true for the same reason processTTY's stub reports it: having no
 // kitty remote-control CLI to run is a settled property of this platform, not
 // a read that failed (#1537).
-func kittyWindowIDForPID(socket string, sessionPID int) (string, bool) { return "", true }
+func kittyWindowIDForPID(ctx context.Context, socket string, sessionPID int) (string, bool) {
+	return "", true
+}
 
 // IsKnownInteractiveHost is darwin-only (ancestry walking); other platforms
 // fail open. The exclusion signal it backs (CodexBar's non-interactive `agy`

--- a/core/adapters/inbound/agents/processlifecycle/osutil_test.go
+++ b/core/adapters/inbound/agents/processlifecycle/osutil_test.go
@@ -608,7 +608,7 @@ func TestReadLauncherEnv_Subprocess_KittyOverridesInheritedTermProgram(t *testin
 		t.Errorf("KittyPID: want 4242, got %d", l.KittyPID)
 	}
 	// Resolve ancestry of the spawned subprocess to decide which branch we're in.
-	ancestry := resolveTermProgramFromAncestry(pid)
+	ancestry := resolveTermProgramFromAncestry(noAggregateBudget(), pid)
 	if ancestry == "kitty" {
 		if l.TermProgram != "kitty" {
 			t.Errorf("kitty in ancestry: expected TermProgram override to 'kitty', got %q", l.TermProgram)

--- a/core/adapters/inbound/agents/processlifecycle/shellout.go
+++ b/core/adapters/inbound/agents/processlifecycle/shellout.go
@@ -26,6 +26,14 @@ import (
 // probe that blocks session discovery, and a probe killed before it answers —
 // and #1538's whole subject is that the second is only safe because
 // probeAnswered reports it as a non-answer rather than as an empty one.
+//
+// Since #1529 every site derives this ceiling FROM the caller's context rather
+// than from context.Background(), so a child is killed at whichever comes
+// first: its own ceiling, or an aggregate deadline the caller imposed across a
+// whole sequence of them (herdrClientBudget is the one such aggregate today;
+// noAggregateBudget names the reads that deliberately have none). Nothing about
+// the per-child value changed — what changed is that a caller can now cap the
+// SUM, which this constant never could.
 const shelloutTimeout = 2 * time.Second
 
 // shelloutCmd builds one bounded child process. Every injected shellout in this

--- a/core/adapters/inbound/agents/processlifecycle/shellout_guard_test.go
+++ b/core/adapters/inbound/agents/processlifecycle/shellout_guard_test.go
@@ -7,6 +7,7 @@ import (
 	"go/parser"
 	"go/token"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"testing"
@@ -460,6 +461,28 @@ func TestEveryBoundedShelloutClassifiesItsError(t *testing.T) {
 	}
 }
 
+// namedCeilings are the durations a context.WithTimeout in this package may be
+// given. Both are package-level constants, and the rule is still that the
+// argument is a NAMED one — an inline literal, or a local whose value nothing
+// names, fails whichever site writes it.
+//
+// #1529 added the second entry rather than widening the rule to "any
+// identifier", because the two are different KINDS of ceiling and a rule that
+// could not tell them apart would be the weaker one:
+//
+//   - shelloutTimeout bounds ONE child process. Every shellout in this package
+//     derives it, and #1538's whole point is that the value stays one fact.
+//   - herdrClientBudget bounds a SEQUENCE of them — the lsof scan plus every
+//     herdr client candidate behind it — which is a bound shelloutTimeout
+//     cannot express, and its absence is exactly what #1529 was filed about.
+//
+// A third entry is a reviewable diff, which is the property an "any named
+// identifier" rule would have thrown away.
+var namedCeilings = map[string]bool{
+	"shelloutTimeout":   true,
+	"herdrClientBudget": true,
+}
+
 // TestEveryBoundedShelloutUsesTheNamedCeiling is #1538's second half. The 2s
 // ceiling was an unnamed literal in eight places while three doc comments and
 // a test assertion already treated the value as a contract ("half of 2s"), and
@@ -479,11 +502,11 @@ func TestEveryBoundedShelloutUsesTheNamedCeiling(t *testing.T) {
 				return true
 			}
 			seen++
-			if id, ok := call.Args[1].(*ast.Ident); ok && id.Name == "shelloutTimeout" {
+			if id, ok := call.Args[1].(*ast.Ident); ok && namedCeilings[id.Name] {
 				return true
 			}
-			t.Errorf("%s:%d: a bounded shellout's ceiling is spelled inline; use shelloutTimeout so the value stays one fact (#1538)",
-				filepath.Base(name), fset.Position(call.Pos()).Line)
+			t.Errorf("%s:%d: a context ceiling here is spelled inline or names something outside %v; use one of those so each value stays one fact (#1538, #1529)",
+				filepath.Base(name), fset.Position(call.Pos()).Line, sortedNames(namedCeilings))
 			return true
 		})
 	}
@@ -496,4 +519,70 @@ func TestEveryBoundedShelloutUsesTheNamedCeiling(t *testing.T) {
 		t.Fatalf("found %d context.WithTimeout calls, expected at least %d: the scan is not looking where it thinks it is",
 			seen, knownCeilings)
 	}
+}
+
+// TestNoAggregateBudgetNeverReachesAChildProcess enforces the one claim
+// noAggregateBudget's own doc makes about itself — that nothing hands it to
+// exec.CommandContext — which until #1529 was a sentence nothing checked.
+//
+// It matters because that helper is a NAMED spelling of context.Background(),
+// and core/architecture_shellout_test.go's repo-wide rule matches the LITERAL
+// spelling only ("a variable that happens to hold one is invisible here", its
+// own declared limit). So `exec.CommandContext(noAggregateBudget(), …)` would
+// be exec.Command wearing two disguises instead of one: unbounded, and passing
+// both the repo rule and a reviewer skimming for a blessed helper name. The
+// helper exists to name an absent AGGREGATE, never an absent child ceiling —
+// every site derives shelloutTimeout from it, and this is what keeps that true.
+func TestNoAggregateBudgetNeverReachesAChildProcess(t *testing.T) {
+	fset, files := parsePackageSources(t, ".")
+
+	sites := 0
+	for name, file := range files {
+		ast.Inspect(file, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok || len(call.Args) == 0 {
+				return true
+			}
+			sel, ok := call.Fun.(*ast.SelectorExpr)
+			if !ok || sel.Sel.Name != "CommandContext" {
+				return true
+			}
+			if pkg, ok := sel.X.(*ast.Ident); !ok || pkg.Name != "exec" {
+				return true
+			}
+			sites++
+			inner, ok := call.Args[0].(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			if id, ok := inner.Fun.(*ast.Ident); ok && id.Name == "noAggregateBudget" {
+				t.Errorf("%s:%d: exec.CommandContext given noAggregateBudget() — that is a NAMED "+
+					"context.Background(), so this child has no ceiling at all, and the repo-wide rule "+
+					"in core/architecture_shellout_test.go matches only the literal spelling and cannot "+
+					"see it. Derive shelloutTimeout from the caller's context instead (#1529, #1543)",
+					filepath.Base(name), fset.Position(call.Pos()).Line)
+			}
+			return true
+		})
+	}
+
+	// A floor for the same reason the two rules above carry one: a scan that
+	// stopped seeing this package's shellouts would report nothing and read
+	// exactly like a clean one.
+	const knownCommandSites = 4
+	if sites < knownCommandSites {
+		t.Fatalf("found %d exec.CommandContext sites, expected at least %d: the scan is not looking where it thinks it is",
+			sites, knownCommandSites)
+	}
+}
+
+// sortedNames renders a name set deterministically, so a failure message does
+// not vary run to run with Go's map iteration order.
+func sortedNames(set map[string]bool) []string {
+	out := make([]string, 0, len(set))
+	for name := range set {
+		out = append(out, name)
+	}
+	sort.Strings(out)
+	return out
 }

--- a/core/adapters/inbound/agents/processlifecycle/shellout_kittywindow_darwin_test.go
+++ b/core/adapters/inbound/agents/processlifecycle/shellout_kittywindow_darwin_test.go
@@ -3,6 +3,7 @@
 package processlifecycle
 
 import (
+	"context"
 	"testing"
 
 	"irrlicht/core/domain/session"
@@ -68,7 +69,7 @@ func TestKittyWindowIDForPIDVia_NonAnswerIsNotAnAbsentWindow(t *testing.T) {
 	t.Cleanup(func() { kittenPath = prev })
 
 	for _, tc := range cases {
-		id, probed := kittyWindowIDForPIDVia("unix:/tmp/kitty-1537", 4242, tc.build)
+		id, probed := kittyWindowIDForPIDVia(noAggregateBudget(), "unix:/tmp/kitty-1537", 4242, tc.build)
 		if id != tc.wantID || probed != tc.wantProbed {
 			t.Errorf("%s: kittyWindowIDForPIDVia = (%q, %v), want (%q, %v) — %s",
 				tc.name, id, probed, tc.wantID, tc.wantProbed, tc.why)
@@ -98,7 +99,7 @@ func TestKittyWindowIDForPIDVia_AbsentKittenIsASettledVerdict(t *testing.T) {
 		{"no socket", "", 4242},
 		{"no session pid", "unix:/tmp/kitty-1537", 0},
 	} {
-		if id, probed := kittyWindowIDForPIDVia(tc.socket, tc.pid, unreachable); id != "" || !probed {
+		if id, probed := kittyWindowIDForPIDVia(noAggregateBudget(), tc.socket, tc.pid, unreachable); id != "" || !probed {
 			t.Errorf("%s: got (%q, %v), want (\"\", true) — nothing was asked, so nothing failed", tc.name, id, probed)
 		}
 	}
@@ -121,18 +122,18 @@ func TestApplyAncestryFallbacks_UnreadableKittyWindowIsNotACompleteRead(t *testi
 		return &session.Launcher{TermProgram: "kitty", KittyListenOn: "unix:/tmp/kitty-1537"},
 			&ancestryProbe{pid: 4242, resolved: true, term: "kitty", hostPID: 999, complete: true}
 	}
-	answered := func(string, int) (string, bool) { return "7", true }
-	unanswered := func(string, int) (string, bool) { return "", false }
+	answered := func(context.Context, string, int) (string, bool) { return "7", true }
+	unanswered := func(context.Context, string, int) (string, bool) { return "", false }
 
 	// Vacuity guard: a kitten that answers must still complete, or a
 	// hard-wired "incomplete" would satisfy the assertion below.
 	l, ancestry := fixture()
-	if complete := applyAncestryFallbacksVia(l, 4242, ancestry, answered); !complete || l.KittyWindowID != "7" {
+	if complete := applyAncestryFallbacksVia(noAggregateBudget(), l, 4242, ancestry, answered); !complete || l.KittyWindowID != "7" {
 		t.Errorf("a kitten that answered: got (window %q, complete %v); want (\"7\", true)", l.KittyWindowID, complete)
 	}
 
 	l, ancestry = fixture()
-	if complete := applyAncestryFallbacksVia(l, 4242, ancestry, unanswered); complete {
+	if complete := applyAncestryFallbacksVia(noAggregateBudget(), l, 4242, ancestry, unanswered); complete {
 		t.Error("a kitten that never answered was reported as a complete read (#1537)")
 	}
 }

--- a/core/adapters/inbound/agents/processlifecycle/shellout_tty_darwin_test.go
+++ b/core/adapters/inbound/agents/processlifecycle/shellout_tty_darwin_test.go
@@ -3,6 +3,7 @@
 package processlifecycle
 
 import (
+	"context"
 	"os"
 	"testing"
 	"time"
@@ -59,7 +60,7 @@ func TestProcessTTYVia_NonAnswerIsNotAnAbsentTerminal(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tty, probed := processTTYVia(tc.pid, tc.build)
+		tty, probed := processTTYVia(noAggregateBudget(), tc.pid, tc.build)
 		if tty != tc.wantTTY || probed != tc.wantProbed {
 			t.Errorf("%s: processTTYVia = (%q, %v), want (%q, %v) — %s",
 				tc.name, tty, probed, tc.wantTTY, tc.wantProbed, tc.why)
@@ -77,13 +78,13 @@ func TestProcessTTYVia_NonAnswerIsNotAnAbsentTerminal(t *testing.T) {
 // The vacuity guard is the second half: a working ps must still produce a
 // complete read, or a hostIdentity hard-wired to incomplete would pass.
 func TestHostIdentity_UnreadableTTYIsNotACompleteRead(t *testing.T) {
-	answered := func(int) (string, bool) { return "/dev/ttys004", true }
-	unanswered := func(int) (string, bool) { return "", false }
+	answered := func(context.Context, int) (string, bool) { return "/dev/ttys004", true }
+	unanswered := func(context.Context, int) (string, bool) { return "", false }
 
-	if l, complete := hostIdentityVia(os.Getpid(), answered); !complete || l.TTY != "/dev/ttys004" {
+	if l, complete := hostIdentityVia(noAggregateBudget(), os.Getpid(), answered); !complete || l.TTY != "/dev/ttys004" {
 		t.Errorf("a ps that answered: got (TTY %q, complete %v); want the read to complete", l.TTY, complete)
 	}
-	if _, complete := hostIdentityVia(os.Getpid(), unanswered); complete {
+	if _, complete := hostIdentityVia(noAggregateBudget(), os.Getpid(), unanswered); complete {
 		t.Error("a ps that never answered was reported as a complete read of this process (#1533)")
 	}
 }
@@ -97,7 +98,7 @@ func TestHostIdentity_UnreadableTTYIsNotACompleteRead(t *testing.T) {
 func TestProcessTTY_CeilingIsANonAnswer(t *testing.T) {
 	t.Parallel() // spends the real 2s ceiling and shares no state
 	start := time.Now()
-	tty, probed := processTTYVia(1, stalledChild)
+	tty, probed := processTTYVia(noAggregateBudget(), 1, stalledChild)
 	elapsed := time.Since(start)
 
 	if probed {

--- a/core/application/services/pid_manager.go
+++ b/core/application/services/pid_manager.go
@@ -868,6 +868,14 @@ func (pm *PIDManager) DiscoverPIDWithRetry(sessionID, cwd, transcriptPath, adapt
 // cancelled. The sweep interval backs off from 5s to 15s when no dead PIDs
 // are found for several consecutive sweeps.
 func (pm *PIDManager) SweepDeadPIDs(ctx context.Context) {
+	// baseInterval is read out of this source, by name and in this spelling, by
+	// processlifecycle's TestHerdrReadFitsTheLivenessSweepTick: this handler
+	// calls refreshHerdrHosts synchronously, so the herdr launcher read has to
+	// fit inside one tick, and an adapter can neither import this package nor a
+	// function-local const. Renaming or moving it fails that test loudly rather
+	// than silently unpinning the bound — which is the intended behaviour, not a
+	// nuisance: it means re-pointing the test, or noticing that the coupling has
+	// changed.
 	const baseInterval = 5 * time.Second
 	const backoffInterval = 15 * time.Second
 	const cleanThreshold = 3
@@ -1387,8 +1395,10 @@ func (pm *PIDManager) touchAndSave(state *session.SessionState) {
 //     attached client, and the per-candidate identity probes behind it —
 //     is memoized per socket path, so N panes of one herdr server cost one
 //     probe per socket per TTL rather than N — "per sweep" while a pass runs
-//     inside one TTL, which is the normal case but not guaranteed under the
-//     load that produces a non-answer (#1529). That now holds for every outcome,
+//     inside one TTL, which is the normal case and is now also the case under
+//     the load that produces a non-answer, because #1529 capped what one such
+//     probe can cost (herdrClientBudget) rather than only how often it is
+//     paid. That now holds for every outcome,
 //     including the ones that determine nothing, and it did not always:
 //     #1492 routed an unreadable candidate to the same "could not look"
 //     answer as a failed scan, and #1485's rule was that such an answer is
@@ -1406,11 +1416,19 @@ func (pm *PIDManager) touchAndSave(state *session.SessionState) {
 //
 // The read runs outside assignMu deliberately: ReadLauncherEnv may block, and
 // assignMu serializes PID discovery for every session. Only the merge is taken
-// under the lock. "For up to two seconds" is what this said, and it was wrong
-// in the same way the bullet above was: each shellout is bounded at 2s, the
-// herdr path's candidate loop is bounded by a COUNT rather than by time, so
-// one resolve can outlast this ticker. That is #1529, not something the memo
-// above fixes — the memo makes it rarer, not shorter.
+// under the lock. What it may block FOR, on this path, is
+// processlifecycle.shelloutTimeout + herdrClientBudget: the pane's own
+// controlling-tty `ps` plus one aggregate deadline over the whole herdr client
+// indirection. That sum is asserted to fit inside baseInterval below, by
+// processlifecycle's TestHerdrReadFitsTheLivenessSweepTick, which reads this
+// function's own cadence out of this file rather than restating it.
+//
+// This said "for up to two seconds", and it was wrong in the same way the
+// bullet above was: each shellout was bounded at 2s and the herdr candidate
+// loop was bounded by a COUNT rather than by time, so one resolve could outlast
+// this ticker — which drops ticks it overruns. #1529 gave that loop the
+// aggregate deadline; the memo above makes the cost rarer, and this is what
+// makes it short.
 func (pm *PIDManager) refreshHerdrHosts(snaps []livenessSnapshot) {
 	if pm.launcherEnv == nil {
 		return


### PR DESCRIPTION
Closes #1529

`ReadLauncherEnv`'s contract said *"never blocks longer than 2 seconds"* and did not
hold it. Every individual shellout on the herdr path was bounded at `shelloutTimeout`;
**the path was not.** `resolveClientHostIdentity` looped over up to
`maxClientCandidates` (4) candidates, each costing two independent ancestry walks plus
a tty `ps`, with the bundle-id walk paying a `plutil` per hop up to `maxAncestry` (10) —
a **COUNT, not a duration**. `refreshHerdrHosts` runs synchronously inside the
`SweepDeadPIDs` ticker handler, and Go's `Ticker` drops ticks it overruns, so one slow
resolve delayed dead-PID reaping for every session behind it.

## The fix

`herdrClientBudget` (2s, `osutil.go`) is that duration.
`resolveHerdrClientLauncherVia` derives **one** deadline covering the lsof scan *and*
every candidate behind it; `ctx` is threaded through `hostIdentity` and every bounded
shellout under it, each still deriving its own `shelloutTimeout` from it — so a child
dies at whichever comes first, its own ceiling or the budget.

The whole herdr read is therefore `shelloutTimeout + herdrClientBudget`. The first
term is the pane's own controlling-tty `ps`, which is the **only** child the direct
read starts for a herdr pane — `launcherFromEnv` returns early with `HerdrPaneID` set,
`hostIdentityVia` skips the ancestry fallbacks for exactly that case, and the env read
is a `sysctl` rather than a shellout. (The wip checkpoint asserted that premise; it is
true, and is now stated with the three things that make it true rather than as a
parenthetical.)

### An abandoned candidate is a NON-ANSWER, not a detach

This is the composition with #1492 and the part that would have been worth failing on.
A candidate skipped or cut short because the budget ran out is a candidate we
*declined to look at* — the `maxClientCandidates` truncation's case, not the detach
case. It poisons `readAll`, so the caller gets `(nil, false)` = "I could not look" and
nothing clears a stored host. `(nil, true)` would mean "every attached client was read
and none has a local window", which is exactly what makes `AdoptHostIdentity` clear the
host of a session whose client is attached right now — the #1348 misroute, caused by
the fix for a latency bug.

Two ways in, both covered: a candidate **abandoned before it starts** (the loop checks
`ctx.Err()` itself — an aggregate that is only *inherited* by the children still probes
every remaining candidate and reports "all four were unreadable" where the truth is "I
stopped after two"), and a candidate **cut short mid-flight** (its shellouts die on the
shared deadline, `hostIdentity` reports `complete=false`, and #1492's existing line
poisons on it with no new code). The tri-state needed no fourth state.

### The two reads that deliberately keep a COUNT bound

`noAggregateBudget()` names them. The wip checkpoint claimed one shared reason and had
the second polarity **backwards**; they are opposites and are now stated separately:

- `ReadLauncherEnv`'s direct read discards `hostIdentity`'s completeness, so an
  abandoned walk arrives as a determined "no host" with `hostKnown=true` — bounding it
  moves answers toward **CLEARING** a host.
- `IsKnownInteractiveHost` fails **OPEN** on an incomplete walk (#1513), so bounding it
  would make the #784 exclusion quietly stop excluding — and #1534 means invisibly.

That gate is still bounded only by a count (two walks × up to 10 hops × `ps` + `plutil`)
on the synchronous discovery path. #1529 gathered no evidence about it and deliberately
did not move it; it is written down rather than left implied.

### Where the constant lives

`osutil.go`, platform-neutral, although the loop it bounds is darwin-only: the contract
is stated in `ReadLauncherEnv`'s doc, which compiles everywhere, so a constant behind
`//go:build darwin` would leave that doc naming a symbol a linux reader cannot look up
and put the arithmetic behind the same tag. It also belongs beside `noAggregateBudget`
— together the two *are* the decision about which host reads get an aggregate.

## Doc sync (acceptance criterion 3)

`ReadLauncherEnv`, `herdrClientLauncher` (three passages) and `refreshHerdrHosts` now
agree, and `maxClientCandidates` is demoted from a de-facto time bound to a sanity cap
in its own doc. **No prose carries a hand-typed total.**
`TestHerdrReadFitsTheLivenessSweepTick` measures
`shelloutTimeout + herdrClientBudget` against the sweep cadence, which it **reads out
of `pid_manager.go`'s source** — an adapter may not import the application layer, and
`baseInterval` is a function-local const that could not be imported anyway. It refuses
loudly if the file, the function or the declaration has moved, rather than reporting
"no finding". A note beside `baseInterval` says so, so whoever changes the tick knows
what is coupled to it.

## Mutation evidence

This change **adds** a bound, so there is no "before the fix" red. Six deliberate
mutations, each seen red with its own distinct failure message, each reverted by
copy-aside/copy-back (never `git stash`, `git restore` or `git checkout --`):

| # | Mutation | Test that went red |
|---|---|---|
| 1 | delete the loop's `ctx.Err()` check | `ChecksTheBudgetBeforeEachCandidate` — *"went on to probe [11 12 13 14], want [11 12]"* |
| 2 | abandon without setting `readAll = false` | `AbandonedCandidateIsANonAnswer` — *"still answered (nil, true)"*; mutation 1's test stays **green**, so the two are independent |
| 3 | `herdrClientBudget = 10 * time.Minute` | `HerdrReadFitsTheLivenessSweepTick` — *"10m2s … does not fit inside the liveness sweep's fastest tick (5s)"* |
| 4 | drop the `WithTimeout` in the production resolve | `DerivesOneBudgetOverScanAndCandidates` — *"ran under a context with no deadline"* |
| 4b | one deadline **per stage** instead of one aggregate | same test — *"ran under different deadlines (4.875µs apart)"* |
| 5 | `exec.CommandContext(noAggregateBudget(), …)` | the new `TestNoAggregateBudgetNeverReachesAChildProcess`, while the repo-wide #1543 rule stayed **green** — measured, which is why that guard is not redundant |
| 6 | the aggregate ceiling as an inline literal | the widened `TestEveryBoundedShelloutUsesTheNamedCeiling` |

Every budget assertion turns on the **budget** (`ctx.Err()`), not on a wall clock, as
the issue asked: the tests cancel the shared context at a chosen candidate, so they are
instant and nothing sleeps.

### Two guards this touches

- `TestEveryBoundedShelloutUsesTheNamedCeiling` now admits `herdrClientBudget`
  alongside `shelloutTimeout` — a two-entry allowlist, **not** "any identifier": the
  two are different KINDS of ceiling (one child vs. a sequence of them), and an inline
  literal or an unrecognised name still fails (mutation 6).
- `TestNoAggregateBudgetNeverReachesAChildProcess` is new. `noAggregateBudget()` is a
  *named* `context.Background()`, and `core/architecture_shellout_test.go` matches the
  **literal** spelling only (its own declared limit), so
  `exec.CommandContext(noAggregateBudget(), …)` would be `exec.Command` wearing two
  disguises. The helper's doc claimed nothing does that; now something checks it.

## Standing gaps, not fixed here

- **`IsKnownInteractiveHost` is still unbounded in aggregate** — two ancestry walks ×
  up to `maxAncestry` hops × (`ps` + `plutil`) at `shelloutTimeout` each, on the
  synchronous PID-discovery path. Bounding it moves answers in the fail-open direction
  (see above), so it needs evidence #1529 does not have. Documented at the call site.
- **Nothing counts budget abandonments.** #1534's gap applies here too: a machine on
  which every herdr resolve is abandoned is indistinguishable from one where none is.
- `resolveClientHostIdentity` (the non-`Via` wrapper) has no production caller — it is
  the loop paired with the production `hostIdentity`, driven by the #1492 tests, and
  it names that probe one line away from where `resolveHerdrClientLauncher` names it.
  Kept because it is the name the file's prose refers to; the duplication is stated in
  its doc rather than left to be discovered.

## Verification

`go build ./core/...` (darwin, linux, and freebsd for the `osutil_other.go` stubs —
windows fails on a pre-existing `syscall.Kill` in `claudecode/pid.go`, untouched here),
`go test ./core/... -race -count=1`, `tools/preflight.sh --only go` (all 7 gates PASS)
and `tools/preflight.sh --only arch` (composite 7.9301 → 7.9303, no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Independent review pass

Reviewed by a second pass that did not write this change.

**Verified independently rather than taken from the report:**

- Mutation 2 reproduced from scratch (drop `readAll = false` from the abandonment branch): `AbandonedCandidateIsANonAnswer` red with the stated message, `ChecksTheBudgetBeforeEachCandidate` still green — so the two obligations really are independent. Reverted by copy-aside/copy-back, `git status --porcelain` empty.
- The `shelloutTimeout + herdrClientBudget` premise: `EnvOf` is `unix.SysctlRaw("kern.procargs2", …)` (no child), `hostIdentityVia` skips both ancestry walks when `HerdrPaneID != ""`, and `kittyListenOnFor` is `os.Stat` only. The controlling-tty `ps` really is the only child the direct read starts for a herdr pane.
- All five shellouts in `osutil_darwin.go` derive their ceiling from the passed `ctx`; none is left on `context.Background()`.
- `noAggregateBudget()` has exactly the two production call sites its doc claims.

**One finding, fixed in this PR** (`638466e1`, doc only): `resolveHerdrClientLauncherVia`'s doc justified the single shared context with *"the lsof scan is the cheap half of a pair whose expensive half is the loop, so the scan running long is precisely when the loop needs less."* That is a non-sequitur doing dismissal work — the loop does not *need* less when the scan ran long, it *gets* less — and it hid a real consequence: a scan that runs to nearly the budget and still succeeds leaves the loop nothing, so a machine with chronically slow-but-answering `lsof` never resolves a herdr host, where before #1529 it resolved slowly. Now stated, with the three things that bound it and why splitting the budget is not taken here.

**Filed as follow-ups rather than fixed here:**

- #1558 — the budget-allocation trade above (scan starves loop). Same shape as #1553 for the git adapter; the honest first step is counting it (#1534), not tuning it.
- #1559 — `core/architecture_shellout_test.go` is blind to a root context returned by a helper: `exec.CommandContext(noAggregateBudget(), …)` leaves the repo-wide rule green. Confirmed by reading `isBareRootContext` (it requires an `*ast.SelectorExpr`) as well as by this PR's own measurement. The new `TestNoAggregateBudgetNeverReachesAChildProcess` is the right guard for *this* package and not the general answer.
