### PR TITLE
fix(git): inject the git binary through the adapter instead of the package var (#1554)

### DIFF
--- a/core/adapters/outbound/git/adapter.go
+++ b/core/adapters/outbound/git/adapter.go
@@ -95,35 +95,91 @@ type gitCmd func(ctx context.Context, dir string, args ...string) *exec.Cmd
 
 // Adapter implements ports/outbound.GitResolver using local git commands and
 // transcript file inspection.
+//
+// Its three fields are the adapter's three test seams, and they share ONE
+// shape rather than three: each is read through an accessor that falls back to
+// the production value, so the zero value of the struct is the production
+// adapter and no seam can be left in a state the daemon would never build.
+// #1554 is why that uniformity is worth stating — the binary was the one of
+// the three with no field, so the only way to drive the production builder at
+// a stub was to mutate the package var `gitPath`, which every parallel test in
+// the package shares.
 type Adapter struct {
+	// cmd is execGitCmd unless a test injected a fake child. Injected so a
+	// test can arrange the one distinction no faked return value can pin: a
+	// child that RAN to a normal exit versus one killed or never started.
 	cmd gitCmd
-	// timeout is gitTimeout unless a test lowered it. Injected for the same
-	// reason cmd is — driving the ceiling means waiting it out, and two tests
-	// waiting out 5s each is both slow and the most load-sensitive thing in
-	// the package. TestProductionAdapterIsBounded deliberately does NOT use
-	// this seam: it goes through New(), so the real constant stays proven.
+	// timeout is gitTimeout unless a test lowered it. Injected because driving
+	// the ceiling means waiting it out, and two tests waiting out 5s each is
+	// both slow and the most load-sensitive thing in the package.
+	// TestProductionAdapterIsBounded deliberately does NOT use this seam: it
+	// goes through New(), so the real constant stays proven.
 	timeout time.Duration
+	// path is gitPath unless a test injected another executable — the seam
+	// #1554 added, and the reason it exists is the one the other two already
+	// had: TestProductionAdapterIsBounded must point the PRODUCTION builder at
+	// a stalling stub, and the alternative it used to take was assigning to
+	// the package var while calling t.Parallel(). That was clean only for as
+	// long as no other parallel test called New(), an invariant nothing
+	// enforced.
+	path string
 }
 
 // New returns a new git Adapter.
-func New() *Adapter { return &Adapter{cmd: execGitCmd, timeout: gitTimeout} }
+//
+// It names the two production values it can name even though the accessors
+// below would supply the same ones from the zero value, so what the daemon
+// runs stays readable here rather than only assembled from fallbacks. The
+// builder is the exception and is left to builder(): naming it would mean
+// storing a method value bound to this very Adapter (`a.cmd = a.execGitCmd`),
+// and a copy of that struct would then keep running the ORIGINAL's binary.
+func New() *Adapter {
+	return &Adapter{timeout: gitTimeout, path: gitPath}
+}
 
 // execGitCmd is the production builder: git, resolved through pathutil rather
 // than the inherited PATH (go:S4036), run in dir.
-func execGitCmd(ctx context.Context, dir string, args ...string) *exec.Cmd {
-	cmd := exec.CommandContext(ctx, gitPath, args...)
+//
+// It is a METHOD rather than the package-level function it was until #1554,
+// because the executable it runs is now the adapter's own field. That is the
+// whole of the fix: a test injects into the value it built instead of into
+// state every other test in the package shares.
+func (a *Adapter) execGitCmd(ctx context.Context, dir string, args ...string) *exec.Cmd {
+	cmd := exec.CommandContext(ctx, a.binary(), args...)
 	cmd.Dir = dir
 	return cmd
 }
 
+// builder is the adapter's command builder, defaulting to the production one
+// so that an Adapter built by a struct literal shells out to real git rather
+// than panicking on a nil func — the same polarity ceiling() and binary()
+// take, and the reason New() can leave the field unset (see New()).
+func (a *Adapter) builder() gitCmd {
+	if a.cmd != nil {
+		return a.cmd
+	}
+	return a.execGitCmd
+}
+
 // ceiling is the adapter's timeout, defaulting to gitTimeout so a
 // zero-valued Adapter (a struct literal in a test) is still bounded rather
-// than unbounded — the failure mode this whole issue is about.
+// than unbounded — the failure mode #1543 is about.
 func (a *Adapter) ceiling() time.Duration {
 	if a.timeout > 0 {
 		return a.timeout
 	}
 	return gitTimeout
+}
+
+// binary is the git executable this adapter runs, defaulting to gitPath
+// exactly as ceiling() defaults to gitTimeout. An empty path would otherwise
+// reach exec.CommandContext as "", which fails with a non-answer on every
+// call — a zero-valued Adapter that silently resolves NOTHING.
+func (a *Adapter) binary() string {
+	if a.path != "" {
+		return a.path
+	}
+	return gitPath
 }
 
 // run executes `git args...` in dir under gitTimeout and reports whether git
@@ -167,7 +223,7 @@ func (a *Adapter) run(dir string, args ...string) (out []byte, answered bool) {
 	ctx, cancel := context.WithTimeout(context.Background(), a.ceiling())
 	defer cancel()
 
-	cmd := a.cmd(ctx, dir, args...)
+	cmd := a.builder()(ctx, dir, args...)
 	cmd.WaitDelay = shellout.WaitDelay
 	// Explicit rather than load-bearing: a nil Stdin is already /dev/null, so
 	// os/exec never hands the daemon's own stdin to the child. Spelled out so

--- a/core/adapters/outbound/git/gitpath_scan_test.go
+++ b/core/adapters/outbound/git/gitpath_scan_test.go
@@ -1,0 +1,265 @@
+package git
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// This file is the half of #1554 the seam cannot do.
+//
+// Adapter.path makes the safe spelling available; it does not stop the unsafe
+// one from coming back. The unsafe one is an assignment to the package var
+// gitPath, and its cost is entirely invisible at the site: the test that
+// writes it looks self-contained (it saves, assigns, and restores in
+// t.Cleanup), while what it actually does is hand every CONCURRENTLY running
+// test in this package a different git for the duration. What those tests then
+// report is a timeout or an empty result — a timing flake, not a fixture
+// collision — and the assignment is nowhere in the failure.
+//
+// It is a SOURCE scan rather than a behavioural one, for the reason
+// construction_test.go's scan is (#1400/#1450): the hazard is created by a
+// construct that no test needs to execute wrongly. Whether it bites depends on
+// which other test the scheduler happens to run at the same time, which is the
+// one thing about it that is not deterministic — so a runtime check would be
+// green on almost every run of a package that is already broken.
+//
+// It is deliberately narrow. It says nothing about t.Parallel(), because
+// "assign to a shared var only from a serial test" is a rule about the whole
+// package's future scheduling that no local read can check, and #1554's own
+// history is the argument: the mutation WAS legal under that rule for as long
+// as nobody wrote a second test, and the rule is what nobody was enforcing.
+// Forbidding the assignment outright is checkable, and the seam makes it free.
+
+// gitPathVar is the package var this file protects. Named once so the scan and
+// its corpus cannot drift onto different symbols.
+const gitPathVar = "gitPath"
+
+// assignmentsToGitPath returns one description per place in file that WRITES
+// the package var gitPath — a plain assignment, or taking its address, which
+// is the same write one indirection away.
+//
+// It has no type information, and two consequences follow that are stated
+// rather than left to be discovered:
+//
+//   - A local or parameter named gitPath is flagged even though it shadows the
+//     var rather than writing it. That is a false positive by the letter of
+//     what this checks, and it is kept: a shadow of this name is exactly what
+//     makes reviewing for the real thing impossible, and the corpus pins the
+//     behaviour so it is learned from a test rather than from a surprise.
+//   - A field or selector spelled `x.gitPath = y` is NOT flagged, because the
+//     LHS is a SelectorExpr, not the bare identifier. Adapter.path is
+//     deliberately named `path` and not `gitPath` for the neighbouring reason,
+//     but a future field of that name would be invisible here. Pinned as a
+//     must-not-flag row.
+//
+// The declaration itself (`var gitPath = pathutil.MustResolve("git")`) is a
+// ValueSpec, not an assignment, so it does not trip this.
+func assignmentsToGitPath(fset *token.FileSet, file *ast.File) []string {
+	var found []string
+	report := func(pos token.Pos, how string) {
+		found = append(found, fmt.Sprintf("%s (%s)", fset.Position(pos), how))
+	}
+
+	ast.Inspect(file, func(n ast.Node) bool {
+		switch v := n.(type) {
+		case *ast.AssignStmt:
+			for _, lhs := range v.Lhs {
+				if id, ok := lhs.(*ast.Ident); ok && id.Name == gitPathVar {
+					report(id.Pos(), "assignment")
+				}
+			}
+		case *ast.UnaryExpr:
+			if v.Op != token.AND {
+				return true
+			}
+			if id, ok := v.X.(*ast.Ident); ok && id.Name == gitPathVar {
+				report(id.Pos(), "address taken")
+			}
+		}
+		return true
+	})
+	return found
+}
+
+// declaresGitPath reports whether file contains gitPath's own var declaration.
+// It is the vacuity guard's input: a scan that has not seen the declaration is
+// not reading the package it thinks it is, and its silence would then mean
+// nothing at all.
+func declaresGitPath(file *ast.File) bool {
+	declared := false
+	ast.Inspect(file, func(n ast.Node) bool {
+		spec, ok := n.(*ast.ValueSpec)
+		if !ok {
+			return true
+		}
+		for _, name := range spec.Names {
+			if name.Name == gitPathVar {
+				declared = true
+			}
+		}
+		return true
+	})
+	return declared
+}
+
+// TestNothingAssignsToTheResolvedGitPath walks this package's own source —
+// production files and tests alike, since either could write the var — and
+// fails on any write to gitPath.
+//
+// MUTATION EVIDENCE (#1554), all three seen red:
+//   - Re-adding the assignment this issue is about
+//     (`saved := gitPath; gitPath = stub; t.Cleanup(...)`) inside
+//     TestProductionAdapterIsBounded fails it, naming both writes by file and
+//     line. The same shape is pinned without a live edit by the `#1554's own
+//     shape` row of the corpus below.
+//   - Renaming gitPathVar so no declaration matches fails the second vacuity
+//     guard (`scanned 4 file(s) and found no declaration of …`) rather than
+//     reporting a clean package.
+//   - Pointing the walk at ".." fails the first (`parsed no packages`).
+func TestNothingAssignsToTheResolvedGitPath(t *testing.T) {
+	t.Parallel()
+
+	fset := token.NewFileSet()
+	pkgs, err := parser.ParseDir(fset, ".", nil, 0)
+	if err != nil {
+		t.Fatalf("parsing this package's source: %v", err)
+	}
+	if len(pkgs) == 0 {
+		t.Fatal("parsed no packages — the scan would pass vacuously")
+	}
+
+	files := 0
+	sawDeclaration := false
+	var offenders []string
+	for _, pkg := range pkgs {
+		for _, file := range pkg.Files {
+			files++
+			sawDeclaration = sawDeclaration || declaresGitPath(file)
+			offenders = append(offenders, assignmentsToGitPath(fset, file)...)
+		}
+	}
+
+	// Two vacuity guards, because "found nothing" and "looked at nothing" must
+	// not produce the same output. The file count catches a walk pointed at
+	// the wrong directory; the declaration catches a rename, after which the
+	// scan would be looking for a symbol that no longer exists and reporting a
+	// clean package forever.
+	if files == 0 {
+		t.Fatal("parsed no files — the scan would pass vacuously")
+	}
+	if !sawDeclaration {
+		t.Fatalf("scanned %d file(s) and found no declaration of %s; the scan is not looking "+
+			"where it thinks it is, so its silence proves nothing", files, gitPathVar)
+	}
+
+	if len(offenders) > 0 {
+		sort.Strings(offenders)
+		t.Errorf("%s is assigned at %s.\n"+
+			"It is a package var shared by every test in this package, and the tests here "+
+			"run in parallel: a test that repoints it hands every concurrently running test "+
+			"a different git for the duration, which they report as a timing flake rather "+
+			"than as this. Inject through the adapter instead — withBinary(path), or an "+
+			"&Adapter{path: ...} literal (#1554).",
+			gitPathVar, strings.Join(offenders, ", "))
+	}
+}
+
+// TestGitPathAssignmentScanFlagsEverySpelling is the scan's committed mutation
+// evidence: one row per spelling, pinned to the verdict the detector must
+// return. The must-NOT-flag rows carry as much of the value as the others —
+// a detector that flagged every mention of gitPath would satisfy every
+// must-flag row and be useless, and two of them (the declaration, and the read
+// on an assignment's right-hand side) are what this package's own source
+// contains.
+func TestGitPathAssignmentScanFlagsEverySpelling(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		src  string
+		want bool
+	}{
+		{
+			name: "#1554's own shape: save, repoint, restore in Cleanup",
+			src: `func f(t *testing.T) {
+				saved := gitPath
+				gitPath = "/tmp/stub"
+				t.Cleanup(func() { gitPath = saved })
+			}`,
+			want: true,
+		},
+		{
+			name: "assignment inside a deferred closure",
+			src:  `func f() { defer func() { gitPath = "x" }() }`,
+			want: true,
+		},
+		{
+			name: "second position of a multi-assignment",
+			src:  `func f(a, b string) { a, gitPath = b, a }`,
+			want: true,
+		},
+		{
+			name: "address taken — the same write, one indirection away",
+			src:  `func f() { p := &gitPath; *p = "x" }`,
+			want: true,
+		},
+		{
+			name: "declared limit: a parameter shadowing the var is flagged too",
+			src:  `func f(gitPath string) { gitPath = "x" }`,
+			want: true,
+		},
+		{
+			name: "the declaration itself is not an assignment",
+			src:  `var gitPath = resolve("git")`,
+			want: false,
+		},
+		{
+			name: "a read in a comparison",
+			src:  `func f() bool { return gitPath == "git" }`,
+			want: false,
+		},
+		{
+			name: "a read on an assignment's right-hand side",
+			src:  `func f(a *Adapter) { a.path = gitPath }`,
+			want: false,
+		},
+		{
+			name: "a field of that name is a selector, not the var",
+			src:  `func f(x struct{ gitPath string }) { x.gitPath = "y" }`,
+			want: false,
+		},
+		{
+			name: "the blank identifier on the left, gitPath on the right",
+			src:  `func f() { _ = gitPath }`,
+			want: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			fset := token.NewFileSet()
+			file, err := parser.ParseFile(fset, "corpus.go", "package git\n\n"+tc.src, 0)
+			if err != nil {
+				t.Fatalf("parsing the case's own source: %v\n%s", err, tc.src)
+			}
+			// The case must still contain what it plants: a corpus that
+			// quietly stopped mentioning gitPath would read as a clean pass on
+			// every must-not-flag row.
+			if !strings.Contains(tc.src, gitPathVar) {
+				t.Fatalf("case source no longer mentions %s, so it pins nothing", gitPathVar)
+			}
+
+			got := assignmentsToGitPath(fset, file)
+			if (len(got) > 0) != tc.want {
+				t.Errorf("scan reported %v, want flagged=%v for:\n%s", got, tc.want, tc.src)
+			}
+		})
+	}
+}

--- a/core/adapters/outbound/git/shellout_test.go
+++ b/core/adapters/outbound/git/shellout_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"testing"
@@ -82,9 +83,23 @@ func withCmd(build gitCmd) *Adapter { return &Adapter{cmd: build, timeout: gitTi
 // the ceiling firing rather than its value. Waiting out the real 5s twice is
 // the package's slowest and most load-sensitive cost, and neither test learns
 // anything from the extra 4.9s. The real constant stays proven by
-// TestProductionAdapterIsBounded, which goes through New().
+// TestProductionAdapterIsBounded, which runs the adapter New() builds.
 func withCeiling(build gitCmd, d time.Duration) *Adapter {
 	return &Adapter{cmd: build, timeout: d}
+}
+
+// withBinary is the adapter New() returns, running binary instead of git —
+// the production builder and the production ceiling, with one substitution.
+//
+// It is built FROM New() rather than from a struct literal on purpose: what
+// TestProductionAdapterIsBounded has to prove is a property of the adapter the
+// daemon builds, so the injected binary must be the only thing that differs
+// from it. A literal would restate New()'s body and could then drift from it,
+// which is the shape #1390 removed from the path-confinement contract.
+func withBinary(binary string) *Adapter {
+	a := New()
+	a.path = binary
+	return a
 }
 
 // testCeiling is short enough to keep the suite fast and long enough that a
@@ -509,9 +524,19 @@ func TestASuccessfulGitStillReturnsItsOutput(t *testing.T) {
 // TestProductionAdapterIsBounded is the wiring arm. Every test above builds an
 // Adapter with an injected command, so none of them proves the adapter New()
 // returns has a ceiling — which is the shape #1390 removed from the path
-// confinement contract for the same reason. gitPath is a package var, so the
-// production builder can be pointed at a real stalling binary without an
-// injected gitCmd.
+// confinement contract for the same reason. It drives the PRODUCTION builder
+// (execGitCmd) under the PRODUCTION ceiling at a real stalling binary,
+// substituted through the adapter's own path field.
+//
+// Until #1554 that substitution was an assignment to the package var gitPath,
+// under t.Parallel(). It was clean only because every other parallel test in
+// the package built its adapter through the injected gitCmd seam, which never
+// reads gitPath — so the invariant was "no parallel test may call New()", and
+// nothing enforced it. The first one that did would have run
+// `/bin/sh -c 'exec sleep 30'` as git for the ~5s this test holds the stub in
+// place, and reported it as a timing flake rather than a fixture collision.
+// The seam removes the hazard rather than documenting it, so t.Parallel()
+// stays and no test in this package needs to know what any other is doing.
 func TestProductionAdapterIsBounded(t *testing.T) {
 	t.Parallel()
 
@@ -533,12 +558,8 @@ func TestProductionAdapterIsBounded(t *testing.T) {
 		_ = warm.Wait()
 	}
 
-	saved := gitPath
-	gitPath = stub
-	t.Cleanup(func() { gitPath = saved })
-
 	start := time.Now()
-	_, answered := New().GetHeadCommit(t.TempDir())
+	_, answered := withBinary(stub).GetHeadCommit(t.TempDir())
 	elapsed := time.Since(start)
 
 	if answered {
@@ -599,17 +620,90 @@ func TestZeroValuedAdapterIsStillBounded(t *testing.T) {
 	}
 }
 
+// TestEverySeamDefaultsToProduction covers the other two accessors the way
+// TestZeroValuedAdapterIsStillBounded covers ceiling(): an Adapter with a
+// field left at its zero value must run the PRODUCTION value for it, so no
+// seam can leave the adapter in a state the daemon would never build.
+//
+// binary() is #1554's new field and needs it most. An empty path reaches
+// exec.CommandContext as "", which fails to start on every call — so a
+// zero-valued Adapter without the fallback resolves NOTHING, quietly, and
+// every method reports a non-answer for a reason that has nothing to do with
+// git.
+//
+// The second half is a distinct claim from the first: binary() returning the
+// injected path and execGitCmd actually RUNNING it are two things, and an
+// execGitCmd left reading the package var satisfies the first while ignoring
+// the injection entirely — which is precisely the defect this issue's fix
+// would be if it were only half applied.
+//
+// MUTATION EVIDENCE (#1554):
+//   - `binary()` reduced to `return a.path` fails the first arm:
+//     `binary() = "" on a zero-valued Adapter`.
+//   - `execGitCmd` reading the package `gitPath` instead of `a.binary()` fails
+//     the last arm: `the production builder ran "/usr/bin/git", want the
+//     injected "/nonexistent/irrlicht-1554-stub"`.
+//   - `builder()` returning a nil gitCmd fails the second arm rather than
+//     panicking somewhere inside run().
+func TestEverySeamDefaultsToProduction(t *testing.T) {
+	t.Parallel()
+
+	zero := &Adapter{} // every seam at its zero value
+
+	if got := zero.binary(); got != gitPath {
+		t.Errorf("binary() = %q on a zero-valued Adapter, want the resolved %q; an empty "+
+			"path reaches exec as \"\", so every call becomes a non-answer", got, gitPath)
+	}
+	if zero.builder() == nil {
+		t.Fatal("builder() = nil on a zero-valued Adapter; run() would panic on the call " +
+			"rather than shelling out to the production git")
+	}
+
+	const stub = "/nonexistent/irrlicht-1554-stub"
+	cmd := withBinary(stub).builder()(context.Background(), "/tmp", gitRevParseCmd, "HEAD")
+	if cmd.Path != stub {
+		t.Errorf("the production builder ran %q, want the injected %q; the injected path "+
+			"is readable but not reaching the child", cmd.Path, stub)
+	}
+	if cmd.Dir != "/tmp" {
+		t.Errorf("cmd.Dir = %q, want /tmp — the builder is not running git in the "+
+			"directory it was asked about", cmd.Dir)
+	}
+	if want := []string{stub, gitRevParseCmd, "HEAD"}; !slices.Equal(cmd.Args, want) {
+		t.Errorf("cmd.Args = %q, want %q", cmd.Args, want)
+	}
+}
+
 // TestGitPathIsResolvedNotInherited pins go:S4036 — the adapter must not run
 // whatever "git" the inherited PATH happens to resolve to.
+//
+// It asserts on what New()'s adapter WILL RUN rather than on the package var
+// alone. Since #1554 those are two reads and only the first is the property:
+// an adapter whose path field were wired to something else would leave a
+// var-only assertion green while running that something else. The var is still
+// read for the skip and for the equality arm, which is what pins the wiring.
+//
+// t.Parallel() is safe here now and was not before, which is the point rather
+// than a tidy-up: gitPath is written once, at package initialisation, and
+// nothing assigns to it afterwards — TestNothingAssignsToTheResolvedGitPath
+// (gitpath_scan_test.go) is what keeps that true, so this unsynchronised read
+// cannot race a fixture.
 func TestGitPathIsResolvedNotInherited(t *testing.T) {
+	t.Parallel()
+
 	if gitPath == "git" {
 		t.Skip("git is not under a trusted directory on this machine; pathutil fell back " +
 			"to a PATH lookup, which is MustResolve's documented degradation")
 	}
-	if !filepath.IsAbs(gitPath) {
-		t.Errorf("gitPath = %q, want an absolute path under a trusted directory", gitPath)
+	resolved := New().binary()
+	if resolved != gitPath {
+		t.Errorf("New() runs %q, want the resolved %q; the constructor is not wiring "+
+			"the pathutil-resolved git into the adapter", resolved, gitPath)
 	}
-	if strings.Contains(gitPath, "..") {
-		t.Errorf("gitPath = %q contains a traversal", gitPath)
+	if !filepath.IsAbs(resolved) {
+		t.Errorf("New() runs %q, want an absolute path under a trusted directory", resolved)
+	}
+	if strings.Contains(resolved, "..") {
+		t.Errorf("New() runs %q, which contains a traversal", resolved)
 	}
 }


### PR DESCRIPTION
## What

`TestProductionAdapterIsBounded` (`core/adapters/outbound/git/shellout_test.go`)
mutated the package-level var `gitPath` — pointing it at a stalling stub for ~5s
— while calling `t.Parallel()`. It was clean **today** only because every other
parallel test in the package builds its adapter through the injected `gitCmd`
seam (`withCmd` / `withCeiling`), which never reads `gitPath`. The invariant was
therefore "no parallel test may call `New()`", enforced by nobody.

**Option 2** from the issue: the adapter gets a `path` field read through
`binary()`, exactly the way `timeout` is read through `ceiling()`. `execGitCmd`
becomes a method so the executable it runs is the adapter's own field, and the
test injects through `withBinary(stub)` — `New()`'s adapter with one field
substituted — instead of writing shared state. `t.Parallel()` stays.

`cmd` gains the same accessor shape (`builder()`), so all three seams are one
idiom and the zero-valued `Adapter` is the production adapter. That also lets
`New()` leave `cmd` unset rather than storing a method value bound to itself
(`a.cmd = a.execGitCmd`), which a copy of the struct would carry into running
the original's binary.

The seam removes the hazard; it does not stop the assignment from coming back,
and the assignment is silent — the test that writes it looks self-contained
while handing every concurrently running test a different git. So
`gitpath_scan_test.go` adds an AST scan over this package's own source that
fails on any write to `gitPath`.

## Confirmation the issue still described the code

Verified against `origin/main` (`e226cf84`) before starting: `gitPath` is a
package var (`adapter.go:33`), `execGitCmd` reads it, and
`TestProductionAdapterIsBounded` called `t.Parallel()` and then
`saved := gitPath; gitPath = stub; t.Cleanup(...)` at `shellout_test.go:515-538`.
`TestGitPathIsResolvedNotInherited` read the var unsynchronised and was not
parallel. All as written.

## Tests: what is a lock, what carries mutation evidence

The issue's own last line is "**Unverified:** no failure has been observed", so
nothing here is a defect test reproducing a live failure. Instead:

### The hazard is real — demonstrated, then removed

Not committed (it costs 8s and its whole point is that it cannot happen after
the fix), but run in both directions. On the **pre-fix** tree, the test #1554
predicts — a parallel test that builds its adapter through `New()` and asserts
the production adapter reads a real repo's HEAD:

```
WARNING: DATA RACE
Write at 0x0001051a5710 by goroutine 7:
  git.TestProductionAdapterIsBounded.func1()
      shellout_test.go:538
Previous read at 0x0001051a5710 by goroutine 8:
  git.execGitCmd()
      adapter.go:114
  git.(*Adapter).run()
  git.(*Adapter).GetHeadCommit()
  git.TestFutureParallelTestUsingNew()
      ztemp_future_parallel_test.go:23
...
--- FAIL: TestProductionAdapterIsBounded (5.01s)
--- FAIL: TestFutureParallelTestUsingNew (5.25s)
    GetHeadCommit = ("", false), want ("0120979c...", true) — the production
    adapter is not running git
FAIL
```

Note the shape of the victim's failure: a 5s stall and an empty non-answer,
which reads as a timing flake. The same test against the **post-fix** tree:
`ok irrlicht/core/adapters/outbound/git 9.695s`.

### Locks (pass by construction, pinning behaviour that must not change)

- `TestProductionAdapterIsBounded` — same assertions as before, reached through
  the seam instead of the global. Behaviour unchanged.
- `TestGitPathIsResolvedNotInherited` — the go:S4036 arms are unchanged; it now
  asserts them on `New().binary()` (what the adapter will run) rather than on
  the var alone, with one added arm pinning that `New()` wires the resolved path
  in. Now `t.Parallel()`, which is safe precisely because nothing writes the var
  any more.

### Added, with the mutation seen red

**`TestEverySeamDefaultsToProduction`** (the new accessors):

```
# binary() reduced to `return a.path`
--- FAIL: TestEverySeamDefaultsToProduction (0.00s)
    shellout_test.go:654: binary() = "" on a zero-valued Adapter, want the
    resolved "/usr/bin/git"; an empty path reaches exec as "", so every call
    becomes a non-answer

# execGitCmd reading the package gitPath instead of a.binary()
--- FAIL: TestEverySeamDefaultsToProduction (0.00s)
    shellout_test.go:665: the production builder ran "/usr/bin/git", want the
    injected "/nonexistent/irrlicht-1554-stub"; the injected path is readable
    but not reaching the child
    shellout_test.go:673: cmd.Args = ["/usr/bin/git" "rev-parse" "HEAD"], want
    ["/nonexistent/irrlicht-1554-stub" "rev-parse" "HEAD"]
--- FAIL: TestProductionAdapterIsBounded (0.03s)
    shellout_test.go:566: the production adapter reported an answer from a child
    it had to kill
    shellout_test.go:569: returned after 28.431792ms, far under the 5s ceiling —
    the stub cannot have run, so this proves nothing about the production path

# builder() reduced to `return a.cmd`
--- FAIL: TestEverySeamDefaultsToProduction (0.00s)
    shellout_test.go:658: builder() = nil on a zero-valued Adapter; run() would
    panic on the call rather than shelling out to the production git
```

The second and third arms are separate claims on purpose: `binary()` returning
the injected path and `execGitCmd` actually *running* it are two things, and a
half-applied fix satisfies the first.

**`TestNothingAssignsToTheResolvedGitPath`** (the source scan), mutated by
re-adding exactly the assignment this issue is about:

```
--- FAIL: TestNothingAssignsToTheResolvedGitPath (0.00s)
    gitPath is assigned at shellout_test.go:562:2 (assignment),
    shellout_test.go:563:21 (assignment).
    It is a package var shared by every test in this package, and the tests here
    run in parallel: a test that repoints it hands every concurrently running
    test a different git for the duration, which they report as a timing flake
    rather than as this. Inject through the adapter instead — withBinary(path),
    or an &Adapter{path: ...} literal (#1554).
```

Its two vacuity guards were also driven red, so "found nothing" and "looked at
nothing" cannot produce the same output:

```
# gitPathVar renamed so no declaration matches
    scanned 4 file(s) and found no declaration of gitPathAfterSomeRename; the
    scan is not looking where it thinks it is, so its silence proves nothing

# the walk pointed at ".."
    parsed no packages — the scan would pass vacuously
```

**`TestGitPathAssignmentScanFlagsEverySpelling`** is the scan's committed
mutation evidence (per AGENTS.md's "prefer committing that mutation to
describing it"): ten rows, five must-flag (including #1554's exact shape, an
assignment inside a deferred closure, the second position of a multi-assignment,
`&gitPath`, and the declared limit that a shadowing parameter is flagged too)
and five must-not-flag (the declaration, a comparison, a read on an assignment's
RHS, a same-named struct field, and `_ = gitPath`). Widening the detector to
flag every *mention* reddens all five must-not-flag rows:

```
--- FAIL: .../the_declaration_itself_is_not_an_assignment
--- FAIL: .../a_field_of_that_name_is_a_selector,_not_the_var
--- FAIL: .../a_read_on_an_assignment's_right-hand_side
--- FAIL: .../a_read_in_a_comparison
--- FAIL: .../the_blank_identifier_on_the_left,_gitPath_on_the_right
```

Every mutation was reverted by copy-aside/copy-back with a `git status
--porcelain` assertion after each (no `git stash`, no `checkout -- .`).

## Verification

- `go build ./core/...` — clean
- `go test ./core/adapters/outbound/git/... -race -count=1` — ok
- `go test ./core/adapters/outbound/git/... -race -count=4` — ok (40.4s), the
  repeat run being the point here
- `go test ./core/... -race -count=1` — all green
- `tools/preflight.sh --only go` — all 7 gates PASS
- `tools/preflight.sh --only arch` — PASS (composite 7.930282 → 7.930529)

## Not fixed

`TestGitPathIsResolvedNotInherited`'s unsynchronised read of `gitPath` is left
as a read, deliberately: the var is written once at package initialisation and
nothing assigns to it afterwards, which the new scan is what keeps true. That is
why the test could be made parallel rather than needing synchronisation.

The scan is name-based and has no type information, so a same-named field
(`x.gitPath = y`) is invisible to it and a shadowing local is flagged. Both are
pinned as corpus rows rather than left to be discovered.

Closes #1554

🤖 Generated with [Claude Code](https://claude.com/claude-code)
