### PR TITLE
fix(git): give the two history walks their own ceiling (#1553)

### DIFF
--- a/core/adapters/outbound/git/adapter.go
+++ b/core/adapters/outbound/git/adapter.go
@@ -36,47 +36,139 @@ var gitPath = pathutil.MustResolve("git")
 // and GetGitRoot to resolve refs, commits, and repo-relative paths.
 const gitRevParseCmd = "rev-parse"
 
-// gitTimeout is the ceiling EVERY shellout in this adapter runs under. Until
-// #1543 there was none at all: seven plain exec.Command calls with no context,
-// inside a long-lived daemon, on directories that can be network mounts or
-// repos holding a lock.
+// gitTimeout is the ceiling for every shellout in this adapter whose cost does
+// NOT grow with the number of commits in the repository. gitHistoryTimeout
+// below is the other profile, and the reason there are two is #1553. Until
+// #1543 there was no ceiling at all: seven plain exec.Command calls with no
+// context, inside a long-lived daemon, on directories that can be network
+// mounts or repos holding a lock.
 //
 // The value is this adapter's own rather than a copy of the 2s next door
 // (processlifecycle's shelloutTimeout), because the workloads are not
-// comparable — a `ps` answers about one PID, `git log --all --grep` walks
-// every commit a user has ever reachable. Measured on this repo (3192 commits,
-// 265 MiB pack, git 2.50.1 / Apple Git-155, darwin/arm64, warm cache):
-// `log --all --grep` 0.05s, `for-each-ref refs/tags` 0.01s,
-// `tag --contains` 0.01s, `rev-parse` 0.01s. 5s is ~100x the heaviest of
-// those, and ~500x the three on the session-enrichment path, which are all
-// rev-parse.
+// comparable — a `ps` answers about one PID, `git tag --contains` walks a
+// commit graph. Measured on this repo (3209 commits across all refs, 325 MiB
+// .git, git 2.50.1 / Apple Git-155, darwin/arm64, warm cache, ~7ms of each
+// figure being process start): `rev-parse` 33ms, `for-each-ref refs/tags`
+// 38ms, `tag --contains` 39ms. 5s is ~130x the heaviest of those.
 //
-// Two consequences are stated rather than left implied. The ceiling is a
-// SINGLE value across two profiles: the enrichment reads (GetBranch,
-// GetHeadCommit, GetGitRoot) run inside the detector loop where 5s of stall is
-// bad but bounded, while the DORA reads run on a request a user is already
-// waiting on. And a repo large enough to legitimately exceed 5s now reports a
-// non-answer where it previously returned a correct-but-slow result — which is
-// the trade this whole family makes, and is safe only because a non-answer is
-// now propagated as "unknown" rather than as "there was nothing" (#1492's
-// polarity; nothing here gates admission). UNVERIFIED: the scaling to a very
-// large repo is extrapolation from the numbers above (~810 bytes and ~16us of
-// `log` per commit), not a measurement on such a repo.
+// `tag --contains` is the one whose membership in this profile is a judgement
+// rather than a fact, and #1553's own table had it backwards: it does not
+// scale with the TAG count, it walks the commit graph, so it scales with
+// history. Measured on a synthetic 1,000,000-commit repo carrying 40 tags:
+// 1.04s for a commit near the root (the worst case — every tag contains it)
+// against 38ms for a recent one. That is ~1us/commit where the two `log` walks
+// below cost ~22, because it reads the commit GRAPH rather than every commit
+// MESSAGE, so 5s covers roughly 5M commits. It stays in this profile rather
+// than moving to the longer ceiling because it is also the call
+// ComputeDoraMetrics makes most often — once per revert candidate — so a
+// longer ceiling multiplies worst there (#1563).
 //
-// It bounds ONE CALL, not one operation, and callers stack it: adoptGitMetadata
-// makes 2, RefreshOnActivity up to 3, and ComputeDoraMetrics
-// 1 + len(tags) + len(revertCandidates) — on a server whose WriteTimeout is
-// deliberately 0 (core/cmd/irrlichd/startup.go). A per-operation budget is a
-// larger change than #1543 and is not attempted here; what is fixed is that the
-// unbounded case is gone.
+// The consequence worth stating: these reads sit inside the detector loop,
+// where 5s of stall is bad but bounded. That is what the value is chosen
+// against, and it is why the history walks could not simply take it with them.
+// It also bounds ONE CALL, not one operation, and callers stack it —
+// adoptGitMetadata makes 2, RefreshOnActivity up to 3, ComputeDoraMetrics
+// 1 + len(in-window tags) + len(revertCandidates) — which is #1563.
 const gitTimeout = 5 * time.Second
 
-// gitMaxOutput caps how much of git's stdout is held in memory. gitTimeout
-// bounds how long git runs, not how much it writes in that time, and this runs
-// inside a long-lived daemon: `git log --pretty=format:...%B` over full history
-// measured 2.59 MB on this repo's 3192 commits (~810 bytes/commit), so a
-// 100k-commit repo is ~81 MB and a 1M-commit one ~810 MB, all buffered by
+// gitHistoryTimeout is the ceiling for the two shellouts that read every commit
+// MESSAGE in their range: RevertedCommits (`log --all --grep`) and
+// CommitsInRange (`log --pretty=%B`). They are the only two whose cost grows
+// with the size of the history, and #1553 is that one 5s ceiling covered both
+// profiles — so a repository big enough to exceed it got a permanent NON-answer
+// where before #1543 it got a correct-but-slow one, the DORA panel reading
+// "could not read this project's git history" forever and the yield sweep
+// logging an unread root every 30 minutes.
+//
+// MEASURED, on synthetic `git fast-import` repositories (one branch, ~60-byte
+// commit messages, packed, warm cache, same machine and git as above):
+//
+//	commits              log --all --grep   log --pretty=%B
+//	    3,209 (this repo)           0.15s   0.08s (over the 1,386 from HEAD)
+//	  100,000                       1.89s   2.24s
+//	1,000,000                      22.5s   30.5s
+//
+// Two things follow, and the first corrects #1553's own headline figure. 5s is
+// NOT reached at 100k commits — that costs 1.9s, comfortably inside it; the
+// wall is nearer 250k for the grep walk (19us/commit at 100k, 22us at 1M) and
+// ~200k for the body walk. And 30s covers the largest history measured here,
+// 1M commits — Linux-kernel scale — with ~25% headroom on the grep walk.
+//
+// The caveats belong to the measurement rather than to the constant: a
+// synthetic repo's commit objects are far smaller than a real one's (this repo
+// averages ~1.9 KB of message per commit against the synthetic's ~60 bytes), it
+// carries ONE ref where `--all` on a real large repo iterates thousands, and
+// the cache was warm. Read 1M commits as the shape of the curve, not as a
+// guarantee for any particular repository.
+//
+// Why 30s and not 60. It bounds one CALL, and ComputeDoraMetrics stacks
+// 1 + len(in-window tags) + len(revertCandidates) of them on a request served
+// by a server whose WriteTimeout is deliberately 0 (#1563 is that aggregate).
+// Every second here is multiplied by that count, so the value is chosen against
+// the stack rather than against the largest repository imaginable.
+//
+// And it is a TIME bound rather than a work bound, which #1553 asked to have
+// argued rather than assumed. Both work bounds that issue proposed were
+// measured and rejected:
+//
+//   - `--max-count` does not bound the work of a `--grep` scan at all. It caps
+//     the commits OUTPUT, after filtering, so git still walks everything
+//     looking for matches it never finds. Measured at 100k commits with no
+//     matching commit: 1921.8ms with `--max-count=10` against 1923.5ms without.
+//     "This repo has no reverts" is the ordinary case, so the option leaves
+//     precisely the worst case untouched.
+//   - `--since` derived from the DORA window changes the NUMBER, not only its
+//     cost. LeadTime is the median of (release time - commit author time) over
+//     a release's commits, so dropping the commits authored before the window
+//     start drops the LONGEST lead times first: the median moves down and is
+//     still published as Available:true. That is the biased-sample failure
+//     gitMaxOutput's doc argues must never happen, arriving through a third
+//     door.
+//
+// What DOES bound the work is the one bound that costs no semantics, and it is
+// #1553's other half: ComputeDoraMetrics no longer asks for the commits of tags
+// outside its window, because nothing reads them — the domain filters both
+// LeadTime and DetectReverts through filterRange.
+const gitHistoryTimeout = 30 * time.Second
+
+// costProfile names which of the two ceilings above a shellout runs under. It
+// is a REQUIRED argument of run() rather than a default the call sites can
+// inherit by omission, because picking wrong is silent in both directions: a
+// history walk on the short ceiling is #1553 reintroduced, and an enrichment
+// read on the long one stalls the detector loop for 30s. Deriving the profile
+// from the subcommand was the alternative and was rejected — `git log -1
+// --format=%s` is an entirely plausible future enrichment read, and it would
+// inherit the history ceiling from its argv with nobody deciding that.
+type costProfile int
+
+const (
+	// fixedCost is a shellout whose cost does not grow with the number of
+	// commits — or, for `tag --contains`, grows ~20x more slowly than the two
+	// history walks because it reads the commit graph rather than every commit
+	// message (see gitTimeout, which carries that measurement).
+	fixedCost costProfile = iota
+	// historyCost is a shellout that reads every commit MESSAGE in its range.
+	// There are exactly two and both are `git log`.
+	historyCost
+)
+
+// gitMaxOutput caps how much of git's stdout is held in memory. The ceilings
+// above bound how long git runs, not how much it writes in that time, and this
+// runs inside a long-lived daemon: `git log --pretty=format:...%B` over full
+// history measured 2,611,982 bytes on this repo — over the 1,386 commits
+// reachable from HEAD, which is the population that command actually walks, so
+// ~1.9 KB per commit. (It said "~810 bytes/commit" until #1553, which divided
+// that same byte count by the 3,192-commit ALL-REFS population: two different
+// populations, and every extrapolation from it was ~2.3x low.) So a
+// 100k-commit repo is ~190 MB and a 1M-commit one ~1.9 GB, all buffered by
 // cmd.Output() before #1543 with nothing to stop it.
+//
+// Which of the two bounds actually binds for CommitsInRange at scale is worth
+// knowing before reading #1553 as more than it is: 64 MiB is reached at
+// ~36,000 commits in a single range at that rate, while the 30s ceiling is not
+// reached until ~1M. Raising the ceiling therefore restores RevertedCommits,
+// whose output is only the MATCHING bodies, and leaves CommitsInRange's real
+// wall where it was — #1564.
 //
 // run() reports overflow as a NON-ANSWER rather than truncating, which is the
 // opposite of cliprobe's choice and deliberately so: a truncated version banner
@@ -96,14 +188,15 @@ type gitCmd func(ctx context.Context, dir string, args ...string) *exec.Cmd
 // Adapter implements ports/outbound.GitResolver using local git commands and
 // transcript file inspection.
 //
-// Its three fields are the adapter's three test seams, and they share ONE
-// shape rather than three: each is read through an accessor that falls back to
-// the production value, so the zero value of the struct is the production
-// adapter and no seam can be left in a state the daemon would never build.
-// #1554 is why that uniformity is worth stating — the binary was the one of
-// the three with no field, so the only way to drive the production builder at
-// a stub was to mutate the package var `gitPath`, which every parallel test in
-// the package shares.
+// Its four fields are the adapter's four test seams, and they share ONE shape
+// rather than four: each is read through an accessor that falls back to the
+// production value, so the zero value of the struct is the production adapter
+// and no seam can be left in a state the daemon would never build. #1554 is
+// why that uniformity is worth stating — the binary was the one field-less
+// seam, so the only way to drive the production builder at a stub was to
+// mutate the package var `gitPath`, which every parallel test in the package
+// shares. #1553's second ceiling took the same shape rather than inventing a
+// fifth.
 type Adapter struct {
 	// cmd is execGitCmd unless a test injected a fake child. Injected so a
 	// test can arrange the one distinction no faked return value can pin: a
@@ -115,6 +208,16 @@ type Adapter struct {
 	// TestProductionAdapterIsBounded deliberately does NOT use this seam: it
 	// goes through New(), so the real constant stays proven.
 	timeout time.Duration
+	// historyTimeout is gitHistoryTimeout unless a test lowered it — #1553's
+	// second ceiling. It is its own field rather than a multiple of timeout
+	// because the only way to observe that a history walk is NOT bounded by
+	// the enrichment ceiling is to drive the two at different values in one
+	// adapter (TestTheTwoCeilingsAreIndependentAtRuntime), and a multiple
+	// cannot express that. Waiting out the real 30s is not a cost this suite
+	// can pay, so the production wiring is proven by the DEADLINE the
+	// production adapter sets rather than by outliving it
+	// (TestEachShelloutRunsUnderTheCeilingForItsCostProfile).
+	historyTimeout time.Duration
 	// path is gitPath unless a test injected another executable — the seam
 	// #1554 added, and the reason it exists is the one the other two already
 	// had: TestProductionAdapterIsBounded must point the PRODUCTION builder at
@@ -127,14 +230,14 @@ type Adapter struct {
 
 // New returns a new git Adapter.
 //
-// It names the two production values it can name even though the accessors
+// It names the three production values it can name even though the accessors
 // below would supply the same ones from the zero value, so what the daemon
 // runs stays readable here rather than only assembled from fallbacks. The
 // builder is the exception and is left to builder(): naming it would mean
 // storing a method value bound to this very Adapter (`a.cmd = a.execGitCmd`),
 // and a copy of that struct would then keep running the ORIGINAL's binary.
 func New() *Adapter {
-	return &Adapter{timeout: gitTimeout, path: gitPath}
+	return &Adapter{timeout: gitTimeout, historyTimeout: gitHistoryTimeout, path: gitPath}
 }
 
 // execGitCmd is the production builder: git, resolved through pathutil rather
@@ -161,7 +264,7 @@ func (a *Adapter) builder() gitCmd {
 	return a.execGitCmd
 }
 
-// ceiling is the adapter's timeout, defaulting to gitTimeout so a
+// ceiling is the adapter's fixed-cost timeout, defaulting to gitTimeout so a
 // zero-valued Adapter (a struct literal in a test) is still bounded rather
 // than unbounded — the failure mode #1543 is about.
 func (a *Adapter) ceiling() time.Duration {
@@ -169,6 +272,30 @@ func (a *Adapter) ceiling() time.Duration {
 		return a.timeout
 	}
 	return gitTimeout
+}
+
+// historyCeiling is the adapter's timeout for the two history walks,
+// defaulting to gitHistoryTimeout exactly as ceiling() defaults to gitTimeout.
+// The fallback matters more here than the symmetry does: every helper in this
+// package's tests predates #1553 and sets only `timeout`, so without it a
+// history walk in any of them would run under a ZERO ceiling — a
+// context.WithTimeout that fires immediately, i.e. every history read a
+// non-answer for a reason that has nothing to do with git.
+func (a *Adapter) historyCeiling() time.Duration {
+	if a.historyTimeout > 0 {
+		return a.historyTimeout
+	}
+	return gitHistoryTimeout
+}
+
+// ceilingFor is the single place a cost profile chooses a ceiling, so the two
+// accessors above stay one-per-field and the mapping stays one expression
+// rather than one per call site.
+func (a *Adapter) ceilingFor(cost costProfile) time.Duration {
+	if cost == historyCost {
+		return a.historyCeiling()
+	}
+	return a.ceiling()
 }
 
 // binary is the git executable this adapter runs, defaulting to gitPath
@@ -182,8 +309,8 @@ func (a *Adapter) binary() string {
 	return gitPath
 }
 
-// run executes `git args...` in dir under gitTimeout and reports whether git
-// ANSWERED — as opposed to never having been asked.
+// run executes `git args...` in dir under the ceiling cost names, and reports
+// whether git ANSWERED — as opposed to never having been asked.
 //
 // answered is false for exactly three things: the ceiling killed the child,
 // the child never started (git missing, fork failure), or its output exceeded
@@ -212,7 +339,7 @@ func (a *Adapter) binary() string {
 // `fatal:`), and it is the pre-existing behaviour; the distinction #1543 is
 // about is "git could not be RUN" versus "git ran and said no", and that is
 // the line drawn here.
-func (a *Adapter) run(dir string, args ...string) (out []byte, answered bool) {
+func (a *Adapter) run(cost costProfile, dir string, args ...string) (out []byte, answered bool) {
 	if dir == "" {
 		// Nothing was asked, so nothing failed — the reading processTTYVia
 		// gives a non-positive pid. Deciding it here rather than at each
@@ -220,7 +347,7 @@ func (a *Adapter) run(dir string, args ...string) (out []byte, answered bool) {
 		// of any particular git subcommand.
 		return nil, true
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), a.ceiling())
+	ctx, cancel := context.WithTimeout(context.Background(), a.ceilingFor(cost))
 	defer cancel()
 
 	cmd := a.builder()(ctx, dir, args...)
@@ -274,7 +401,7 @@ func (a *Adapter) run(dir string, args ...string) (out []byte, answered bool) {
 // unborn. Callers must not overwrite a branch they already hold on a
 // non-answer — an empty string there carries no information (#1485/#1543).
 func (a *Adapter) GetBranch(dir string) (string, bool) {
-	out, answered := a.run(dir, gitRevParseCmd, "--abbrev-ref", "HEAD")
+	out, answered := a.run(fixedCost, dir, gitRevParseCmd, "--abbrev-ref", "HEAD")
 	if !answered {
 		return "", false
 	}
@@ -293,7 +420,7 @@ func (a *Adapter) GetBranch(dir string) (string, bool) {
 // answered=false means git could not be run, which is not evidence about
 // either.
 func (a *Adapter) GetHeadCommit(dir string) (string, bool) {
-	out, answered := a.run(dir, gitRevParseCmd, "HEAD")
+	out, answered := a.run(fixedCost, dir, gitRevParseCmd, "HEAD")
 	if !answered {
 		return "", false
 	}
@@ -312,7 +439,7 @@ func (a *Adapter) GetHeadCommit(dir string) (string, bool) {
 // not happen, which is NOT "no reverts" — treating it as such is what makes a
 // yield sweep report "nothing flipped" for a repo it never read (#1543).
 func (a *Adapter) RevertedCommits(dir string) ([]string, bool) {
-	out, answered := a.run(dir, "log", "--all", "--grep", "^This reverts commit ", "--pretty=format:%b")
+	out, answered := a.run(historyCost, dir, "log", "--all", "--grep", "^This reverts commit ", "--pretty=format:%b")
 	if !answered {
 		return nil, false
 	}
@@ -333,7 +460,7 @@ func (a *Adapter) RevertedCommits(dir string) ([]string, bool) {
 // answered=false means git could not be run, and reporting that as "no
 // releases found for this project" is the false claim #1543 removes.
 func (a *Adapter) ListReleaseTags(dir string) ([]dora.TagInfo, bool) {
-	out, answered := a.run(dir, "for-each-ref", "--sort=creatordate", "--format=%(refname:short)%09%(creatordate:unix)", "refs/tags")
+	out, answered := a.run(fixedCost, dir, "for-each-ref", "--sort=creatordate", "--format=%(refname:short)%09%(creatordate:unix)", "refs/tags")
 	if !answered {
 		return nil, false
 	}
@@ -372,7 +499,7 @@ func (a *Adapter) CommitsInRange(dir, fromRef, toRef string) ([]dora.CommitInfo,
 	// \x01/\x02 are ASCII control bytes used as record/field separators —
 	// they won't collide with real commit message content, so a multi-line
 	// %B body can be parsed without spawning a process per commit.
-	out, answered := a.run(dir, "log", "--pretty=format:%x01%H%x02%at%x02%B", rangeSpec)
+	out, answered := a.run(historyCost, dir, "log", "--pretty=format:%x01%H%x02%at%x02%B", rangeSpec)
 	if !answered {
 		return nil, false
 	}
@@ -410,7 +537,7 @@ func (a *Adapter) TagContaining(dir, hash string) (string, bool) {
 	if hash == "" {
 		return "", true
 	}
-	out, answered := a.run(dir, "tag", "--contains", hash, "--sort=creatordate")
+	out, answered := a.run(fixedCost, dir, "tag", "--contains", hash, "--sort=creatordate")
 	if !answered {
 		return "", false
 	}
@@ -441,7 +568,7 @@ func (a *Adapter) GetGitRoot(dir string) (string, bool) {
 		return "", true
 	}
 	dir = nearestExistingDir(dir)
-	out, answered := a.run(dir, gitRevParseCmd, "--path-format=absolute", "--git-common-dir")
+	out, answered := a.run(fixedCost, dir, gitRevParseCmd, "--path-format=absolute", "--git-common-dir")
 	if !answered {
 		return "", false
 	}

--- a/core/adapters/outbound/git/shellout_test.go
+++ b/core/adapters/outbound/git/shellout_test.go
@@ -74,18 +74,36 @@ func floodingGit(ctx context.Context, _ string, _ ...string) *exec.Cmd {
 	return exec.CommandContext(ctx, "/bin/sh", "-c", "head -c "+over+" /dev/zero")
 }
 
-// withCmd returns an adapter whose git is build, under the production ceiling.
-// Every method routes through Adapter.run, so one seam covers all seven
-// shellouts.
-func withCmd(build gitCmd) *Adapter { return &Adapter{cmd: build, timeout: gitTimeout} }
+// withCmd returns an adapter whose git is build, under the production
+// ceilings. Every method routes through Adapter.run, so one seam covers all
+// seven shellouts.
+func withCmd(build gitCmd) *Adapter {
+	return &Adapter{cmd: build, timeout: gitTimeout, historyTimeout: gitHistoryTimeout}
+}
 
 // withCeiling is withCmd under a SHORT ceiling, for the tests whose subject is
 // the ceiling firing rather than its value. Waiting out the real 5s twice is
 // the package's slowest and most load-sensitive cost, and neither test learns
-// anything from the extra 4.9s. The real constant stays proven by
-// TestProductionAdapterIsBounded, which runs the adapter New() builds.
+// anything from the extra 4.9s. The real constants stay proven by
+// TestProductionAdapterIsBounded and
+// TestEachShelloutRunsUnderTheCeilingForItsCostProfile, which run the adapter
+// New() builds.
+//
+// It sets BOTH ceilings, which matters since #1553 gave the adapter two: the
+// callers whose subject is "the ceiling fired" (the flooding one drives
+// RevertedCommits) want a short one whichever profile they happen to reach,
+// and one left at the production 30s would make that test wait 30s to prove
+// something about the cap. withCeilings below is for the one test that needs
+// them to DIFFER.
 func withCeiling(build gitCmd, d time.Duration) *Adapter {
-	return &Adapter{cmd: build, timeout: d}
+	return &Adapter{cmd: build, timeout: d, historyTimeout: d}
+}
+
+// withCeilings is withCeiling with the two ceilings driven independently —
+// the only shape that can observe a history walk outliving the enrichment
+// ceiling, which is #1553's whole subject.
+func withCeilings(build gitCmd, fixed, history time.Duration) *Adapter {
+	return &Adapter{cmd: build, timeout: fixed, historyTimeout: history}
 }
 
 // withBinary is the adapter New() returns, running binary instead of git —
@@ -416,7 +434,7 @@ func TestUnderTheCapIsStillAnAnswer(t *testing.T) {
 	// A gitMaxOutput-1 row would cost a second 64 MiB pipe copy to assert what
 	// TestCappedBufferStopsAtItsLimit already pins at Limit: 8.
 	for _, n := range []int{1 << 10, gitMaxOutput} {
-		out, answered := withCmd(build(n)).run("/tmp", "irrelevant")
+		out, answered := withCmd(build(n)).run(fixedCost, "/tmp", "irrelevant")
 		if !answered {
 			t.Errorf("%d bytes, under the %d-byte cap, was reported as a non-answer", n, gitMaxOutput)
 		}
@@ -606,6 +624,15 @@ func TestZeroValuedAdapterIsStillBounded(t *testing.T) {
 		t.Errorf("ceiling() = %v on a zero-valued Adapter, want the %v default; a zero ceiling "+
 			"means context.WithTimeout fires immediately and a negative one means never", got, gitTimeout)
 	}
+	// #1553's second ceiling needs the same fallback, and needs it MORE: every
+	// helper in this file predates it and sets only `timeout`, so a missing
+	// fallback would run every history walk under a zero ceiling — a
+	// context.WithTimeout that has already expired, i.e. RevertedCommits and
+	// CommitsInRange reporting a non-answer instantly, for a reason that has
+	// nothing to do with git.
+	if got := a.historyCeiling(); got != gitHistoryTimeout {
+		t.Errorf("historyCeiling() = %v on a zero-valued Adapter, want the %v default", got, gitHistoryTimeout)
+	}
 
 	start := time.Now()
 	_, answered := a.GetBranch("/tmp")
@@ -658,6 +685,17 @@ func TestEverySeamDefaultsToProduction(t *testing.T) {
 		t.Fatal("builder() = nil on a zero-valued Adapter; run() would panic on the call " +
 			"rather than shelling out to the production git")
 	}
+	// ceilingFor is the whole of the profile→ceiling mapping, and it is one
+	// expression, so pinning both directions costs two lines. Without the
+	// second, a ceilingFor that returned the history ceiling for EVERYTHING
+	// would satisfy the first — and that is the mutation that puts the
+	// detector loop on a 30s stall.
+	if got := zero.ceilingFor(historyCost); got != gitHistoryTimeout {
+		t.Errorf("ceilingFor(historyCost) = %v, want %v", got, gitHistoryTimeout)
+	}
+	if got := zero.ceilingFor(fixedCost); got != gitTimeout {
+		t.Errorf("ceilingFor(fixedCost) = %v, want %v", got, gitTimeout)
+	}
 
 	const stub = "/nonexistent/irrlicht-1554-stub"
 	cmd := withBinary(stub).builder()(context.Background(), "/tmp", gitRevParseCmd, "HEAD")
@@ -705,5 +743,173 @@ func TestGitPathIsResolvedNotInherited(t *testing.T) {
 	}
 	if strings.Contains(resolved, "..") {
 		t.Errorf("New() runs %q, which contains a traversal", resolved)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// The two cost profiles (#1553)
+// ---------------------------------------------------------------------------
+
+// TestEachShelloutRunsUnderTheCeilingForItsCostProfile is the wiring arm for
+// #1553, and it is the test the mutation "put the history walks back on the
+// short ceiling" has to fail. It reads the DEADLINE the adapter puts on the
+// context it hands the builder, rather than outliving it: waiting out
+// gitHistoryTimeout would cost 30s per run, which -count=4 turns into two
+// minutes for a fact a deadline states exactly.
+//
+// It drives the adapter New() builds, with only the builder substituted, so
+// what it pins is the PRODUCTION mapping of both constants — not a pair of
+// values a helper chose. TestProductionAdapterIsBounded remains the arm that
+// proves a real child actually dies at a real ceiling; this one proves which
+// ceiling each of the eight methods asks for.
+//
+// MUTATION EVIDENCE is recorded on TestTheTwoCeilingsAreIndependentAtRuntime
+// below, which the same mutations also redden.
+func TestEachShelloutRunsUnderTheCeilingForItsCostProfile(t *testing.T) {
+	t.Parallel()
+
+	// Vacuity guard, and it is not decorative: every row below asserts
+	// "budget == the constant this profile names", so if the two constants
+	// were equal the whole table would pass against an adapter that had never
+	// heard of a second profile. The 6x gap is the only reason the assertions
+	// discriminate.
+	if gitHistoryTimeout <= gitTimeout {
+		t.Fatalf("gitHistoryTimeout (%v) is not longer than gitTimeout (%v); with one value "+
+			"this test cannot tell the two profiles apart and #1553 is not fixed",
+			gitHistoryTimeout, gitTimeout)
+	}
+
+	dir := realPath(t, t.TempDir())
+
+	var budget time.Duration
+	var built bool
+	a := New()
+	a.cmd = func(ctx context.Context, _ string, _ ...string) *exec.Cmd {
+		if deadline, ok := ctx.Deadline(); ok {
+			budget = time.Until(deadline)
+		}
+		built = true
+		// A child that exits at once: what is under test is the deadline the
+		// adapter set, not what the child does with it.
+		return exec.CommandContext(ctx, "/bin/sh", "-c", "exit 0")
+	}
+
+	cases := []struct {
+		name string
+		want time.Duration
+		call func()
+	}{
+		{"GetBranch", gitTimeout, func() { a.GetBranch(dir) }},
+		{"GetHeadCommit", gitTimeout, func() { a.GetHeadCommit(dir) }},
+		{"GetGitRoot", gitTimeout, func() { a.GetGitRoot(dir) }},
+		{"GetProjectName", gitTimeout, func() { a.GetProjectName(dir) }},
+		{"ListReleaseTags", gitTimeout, func() { a.ListReleaseTags(dir) }},
+		{"TagContaining", gitTimeout, func() { a.TagContaining(dir, "deadbeef") }},
+		{"RevertedCommits", gitHistoryTimeout, func() { a.RevertedCommits(dir) }},
+		{"CommitsInRange", gitHistoryTimeout, func() { a.CommitsInRange(dir, "", "HEAD") }},
+	}
+
+	const tolerance = 2 * time.Second // the read happens microseconds after the deadline is set
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			budget, built = 0, false
+			tc.call()
+			// Fail loudly rather than silently: a method that started no child
+			// records no budget, and a zero budget would otherwise be reported
+			// as "ran under a 0s ceiling" — a finding about a call that never
+			// happened.
+			if !built {
+				t.Fatal("no child was built, so nothing was measured; this row is not exercising " +
+					"the shellout it names")
+			}
+			if budget <= 0 {
+				t.Fatalf("the context carried no deadline; #1543's whole subject is that every " +
+					"child here runs under one")
+			}
+			if diff := tc.want - budget; diff < 0 || diff > tolerance {
+				t.Errorf("ran under a %v budget, want ~%v. The other profile's ceiling is %v — a "+
+					"history walk on the short one is #1553 reintroduced (a big repository gets a "+
+					"permanent non-answer), and an enrichment read on the long one stalls the "+
+					"detector loop for %v",
+					budget, tc.want, otherCeiling(tc.want), gitHistoryTimeout)
+			}
+		})
+	}
+}
+
+// otherCeiling names the ceiling a row did NOT want, so the failure message
+// above can say which mistake it is looking at rather than only which number
+// disagreed.
+func otherCeiling(want time.Duration) time.Duration {
+	if want == gitHistoryTimeout {
+		return gitTimeout
+	}
+	return gitHistoryTimeout
+}
+
+// TestTheTwoCeilingsAreIndependentAtRuntime is the behavioural half: the
+// deadline test above reads what the adapter INTENDS, this one watches a real
+// child outlive the shorter ceiling. Together they are the two claims #1553
+// makes — that the mapping is right, and that the longer ceiling is a ceiling
+// rather than a number nothing consults.
+//
+// The two values are driven independently through the seams (short=100ms,
+// long=2s) rather than at their production values, because the property is the
+// INDEPENDENCE and waiting out 30s to observe it buys nothing. The gap is wide
+// enough that shellout.WaitDelay (500ms) cannot close it: a history walk that
+// had run under the short ceiling returns in at most ~600ms, well under the 1s
+// this asserts it must exceed.
+//
+// MUTATION EVIDENCE (both run, both red — see the PR body for the output):
+//
+//   - RevertedCommits and CommitsInRange changed back to run(fixedCost, …):
+//     this test fails with "RevertedCommits returned after ~100ms against a 2s
+//     history ceiling", and
+//     TestEachShelloutRunsUnderTheCeilingForItsCostProfile fails on both of its
+//     history rows with "ran under a 5s budget, want ~30s".
+//   - ceilingFor() reduced to `return a.historyCeiling()` — i.e. one ceiling
+//     again, the other direction: this test fails on the GetBranch arm, and the
+//     deadline test fails on all six fixed-cost rows.
+func TestTheTwoCeilingsAreIndependentAtRuntime(t *testing.T) {
+	t.Parallel()
+
+	const short = 100 * time.Millisecond
+	const long = 2 * time.Second
+
+	a := withCeilings(stalledGit, short, long)
+
+	start := time.Now()
+	_, answered := a.GetBranch("/tmp")
+	fixedElapsed := time.Since(start)
+	if answered {
+		t.Error("GetBranch: a child killed by the ceiling was reported as an answer")
+	}
+
+	start = time.Now()
+	_, answered = a.RevertedCommits("/tmp")
+	historyElapsed := time.Since(start)
+	if answered {
+		t.Error("RevertedCommits: a child killed by the ceiling was reported as an answer")
+	}
+
+	if historyElapsed < long/2 {
+		t.Errorf("RevertedCommits returned after %v against a %v history ceiling — it is running "+
+			"under the %v enrichment ceiling instead, which is #1553: the history walk a large "+
+			"repository needs is cut off at the short one and the yield sweep reports that root "+
+			"unread forever", historyElapsed, long, short)
+	}
+	if fixedElapsed > long/2 {
+		t.Errorf("GetBranch returned after %v against a %v enrichment ceiling — it is running "+
+			"under the %v history ceiling instead, which puts a %v stall inside the detector loop",
+			fixedElapsed, short, long, gitHistoryTimeout)
+	}
+	// Upper bounds, so a ceiling that fired for the wrong reason (or not at
+	// all) is not read as success.
+	if limit := long + shellout.WaitDelay + 5*time.Second; historyElapsed > limit {
+		t.Errorf("RevertedCommits took %v against a %v ceiling; the bound did not fire",
+			historyElapsed, long)
+	}
+	if limit := short + shellout.WaitDelay + 5*time.Second; fixedElapsed > limit {
+		t.Errorf("GetBranch took %v against a %v ceiling; the bound did not fire", fixedElapsed, short)
 	}
 }

--- a/core/application/services/dora_metrics.go
+++ b/core/application/services/dora_metrics.go
@@ -101,6 +101,32 @@ func ComputeDoraMetrics(git doraGitProbe, sessions doraSessionLister, project st
 	// left for a follow-up rather than smuggled in here.
 	commitsByTag := make(map[string][]dora.CommitInfo, len(tags))
 	for i, tag := range tags {
+		// Skip the tags no metric will read. LeadTime and DetectReverts are
+		// the only two consumers of commitsByTag and both index it through
+		// dora.filterRange, so an out-of-window tag's commits are fetched,
+		// parsed, held in memory and then never looked at — and until #1553
+		// every release in the repository's history was fetched on every
+		// request, however narrow the window. The oldest tag is the expensive
+		// one: its range starts at the repo root, so on a project that adopted
+		// tags late it is a full-history walk paid for a chart that spans a
+		// week. dora.InWindow rather than a local comparison, so this and
+		// filterRange cannot disagree about which tags those are.
+		//
+		// This is a WORK bound, not a time bound, and it is the only one of
+		// the three #1553 weighed that costs no semantics: nothing reads what
+		// is no longer fetched. (`--max-count` was measured not to bound the
+		// work of a `--grep` scan at all, and `--since` biases LeadTime's
+		// median downward — both recorded on gitHistoryTimeout.)
+		//
+		// One user-visible consequence, stated rather than left implied: a
+		// repository whose out-of-window history cannot be read no longer
+		// blanks the panel. Before this, one unreadable ancient range made
+		// every window unavailable; now the panel is blank only when a read
+		// the metrics actually needed failed. That is the same polarity as the
+		// rest of #1543 — claim nothing about history nobody asked about.
+		if !dora.InWindow(tag.Epoch, start, end) {
+			continue
+		}
 		from := ""
 		if i > 0 {
 			from = tags[i-1].Name

--- a/core/application/services/dora_metrics_test.go
+++ b/core/application/services/dora_metrics_test.go
@@ -4,11 +4,13 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 
 	"irrlicht/core/adapters/outbound/git"
 	"irrlicht/core/application/services"
+	"irrlicht/core/domain/dora"
 	"irrlicht/core/domain/session"
 )
 
@@ -176,5 +178,87 @@ func TestComputeDoraMetrics_EndToEnd(t *testing.T) {
 	wantHours := float64(29 * 24)
 	if result.MTTR.Value != wantHours {
 		t.Fatalf("MTTR.Value = %v, want %v (29 days)", result.MTTR.Value, wantHours)
+	}
+}
+
+// doraRecordingProbe is a doraGitProbe that serves a fixed tag list and
+// records every commit-range it is asked for. It is a fake rather than a real
+// repo because what is under test is which git calls are MADE, and a real repo
+// answers the same either way.
+type doraRecordingProbe struct {
+	root    string
+	tags    []dora.TagInfo
+	commits map[string][]dora.CommitInfo
+	asked   []string // "<fromRef>..<toRef>" per CommitsInRange call, in order
+}
+
+func (p *doraRecordingProbe) GetGitRoot(string) (string, bool) { return p.root, true }
+
+func (p *doraRecordingProbe) ListReleaseTags(string) ([]dora.TagInfo, bool) { return p.tags, true }
+
+func (p *doraRecordingProbe) CommitsInRange(_, fromRef, toRef string) ([]dora.CommitInfo, bool) {
+	p.asked = append(p.asked, fromRef+".."+toRef)
+	return p.commits[toRef], true
+}
+
+func (p *doraRecordingProbe) TagContaining(string, string) (string, bool) { return "", true }
+
+// TestComputeDoraMetrics_SkipsCommitRangesNoMetricReads is #1553's work bound.
+// ComputeDoraMetrics used to walk the commits of EVERY release tag in the
+// repository on every request, however narrow the window — and the oldest
+// tag's range starts at the repo root, so on a project that adopted tags late
+// that one call is a full-history walk paid for a chart spanning a week.
+// Nothing read those commits: LeadTime and DetectReverts index commitsByTag
+// through the domain's window filter (locked by
+// TestNoMetricReadsAnOutOfWindowTagsCommits).
+//
+// MUTATION EVIDENCE: deleting the `if !dora.InWindow(...) { continue }` guard
+// from ComputeDoraMetrics makes this fail, reporting the four ranges it walked
+// against the two it needed.
+func TestComputeDoraMetrics_SkipsCommitRangesNoMetricReads(t *testing.T) {
+	const day = int64(86400)
+	probe := &doraRecordingProbe{
+		root: "/repo",
+		tags: []dora.TagInfo{
+			{Name: "v1.0", Epoch: 10 * day}, // before the window
+			{Name: "v2.0", Epoch: 20 * day}, // before the window
+			{Name: "v3.0", Epoch: 40 * day}, // in
+			{Name: "v4.0", Epoch: 45 * day}, // in
+			{Name: "v5.0", Epoch: 90 * day}, // after
+		},
+		commits: map[string][]dora.CommitInfo{
+			"v3.0": {{Hash: "ccc", AuthorEpoch: 39 * day, Body: "work\n"}},
+			"v4.0": {{Hash: "ddd", AuthorEpoch: 44 * day, Body: "more work\n"}},
+		},
+	}
+	sessions := &doraFakeSessions{states: []*session.SessionState{
+		{SessionID: "s1", ProjectName: "proj", CWD: "/repo/sub"},
+	}}
+
+	result, err := services.ComputeDoraMetrics(probe, sessions, "proj", 30*day, 50*day)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// The vacuity guard, and it is the important half: a service that fetched
+	// NOTHING would satisfy the call-list assertion below while publishing
+	// metrics over an empty sample.
+	if !result.Available {
+		t.Fatalf("expected Available=true, got %+v", result)
+	}
+	if result.LeadTime.SampleSize != 2 {
+		t.Errorf("LeadTime.SampleSize = %d, want 2 — the in-window releases' commits were not read",
+			result.LeadTime.SampleSize)
+	}
+
+	// The predecessor ref of an in-window tag is still used as the range's
+	// START even when that predecessor is itself out of window: the range is
+	// what shipped in v3.0, and that is bounded by v2.0 whether or not v2.0's
+	// own commits are read.
+	want := []string{"v2.0..v3.0", "v3.0..v4.0"}
+	if !slices.Equal(probe.asked, want) {
+		t.Errorf("walked %v, want %v — a commit range was fetched for a tag no metric reads "+
+			"(the oldest one is a full-history walk), or an in-window range was skipped",
+			probe.asked, want)
 	}
 }

--- a/core/domain/dora/dora.go
+++ b/core/domain/dora/dora.go
@@ -73,11 +73,23 @@ var (
 	revertTrailerPattern = regexp.MustCompile(`(?m)^This reverts commit ([0-9a-f]{7,40})`)
 )
 
+// InWindow reports whether an epoch falls inside the [from, to] window every
+// metric below is computed over.
+//
+// It is exported for ONE caller and for one reason: since #1553 the
+// application service decides, before walking git, which tags the metrics
+// below will actually read, and skips the commit-range call for the rest. That
+// decision has to use this comparison rather than a copy of it — a second
+// spelling that drifted would not produce a slower answer, it would produce a
+// metric computed over commits the service never fetched, which is a silently
+// wrong number rather than a visible failure.
+func InWindow(epoch, from, to int64) bool { return epoch >= from && epoch <= to }
+
 // filterRange returns the tags whose Epoch falls within [from, to].
 func filterRange(tags []TagInfo, from, to int64) []TagInfo {
 	var out []TagInfo
 	for _, t := range tags {
-		if t.Epoch >= from && t.Epoch <= to {
+		if InWindow(t.Epoch, from, to) {
 			out = append(out, t)
 		}
 	}

--- a/core/domain/dora/dora_test.go
+++ b/core/domain/dora/dora_test.go
@@ -269,3 +269,108 @@ func TestMTTR(t *testing.T) {
 		}
 	})
 }
+
+// TestNoMetricReadsAnOutOfWindowTagsCommits is the lock #1553's work bound
+// stands on. ComputeDoraMetrics now skips the git call for tags outside
+// [from, to], which is safe only because nothing here reads their entry in
+// commitsByTag — LeadTime and DetectReverts are its only two consumers and
+// both index it through filterRange.
+//
+// If either grew a read of an out-of-window tag, the service would not get a
+// slower answer: it would get a metric computed over commits it never
+// fetched, which is a wrong number reported as Available. So this asserts the
+// property directly, by computing each metric with the out-of-window entries
+// present and absent and requiring the two to agree.
+//
+// MUTATION EVIDENCE: replacing `filterRange(tags, from, to)` with `tags` in
+// DetectReverts's loop makes the DetectReverts arm fail on the unresolved
+// count; the same replacement in LeadTime's loop makes the LeadTime arm fail
+// on the sample size.
+//
+// The LeadTime half is why the fixture below looks the way it does, and the
+// first draft of it did NOT redden: LeadTime filters COMMITS by author epoch
+// as well as TAGS by window, so an out-of-window tag carrying out-of-window
+// commits is excluded twice over and the mutation changes nothing. A fixture
+// that cannot express the distinguishing state grades a filter that is not the
+// one under test — the shape #1475 records. What distinguishes them is a
+// release made AFTER the window that ships commits authored DURING it, which
+// is an ordinary thing for a repository to contain.
+func TestNoMetricReadsAnOutOfWindowTagsCommits(t *testing.T) {
+	const day = int64(86400)
+	tags := []TagInfo{
+		{Name: "v1.0", Epoch: 10 * day}, // before the window
+		{Name: "v2.0", Epoch: 40 * day}, // inside it
+		{Name: "v3.0", Epoch: 90 * day}, // after it
+	}
+	from, to := 30*day, 50*day
+
+	// Each out-of-window release carries the shape one consumer looks for:
+	// v1.0 a revert (DetectReverts), v3.0 a commit authored inside the window
+	// (LeadTime — see the note above about why an out-of-window author epoch
+	// there would prove nothing).
+	full := map[string][]CommitInfo{
+		"v1.0": {
+			{Hash: "aaa", AuthorEpoch: 9 * day, Body: "old work\n"},
+			{Hash: "bbb", AuthorEpoch: 9 * day, Body: "Revert \"old work\"\n\nThis reverts commit aaa.\n"},
+		},
+		"v2.0": {
+			{Hash: "ccc", AuthorEpoch: 39 * day, Body: "new work\n"},
+		},
+		"v3.0": {
+			{Hash: "ddd", AuthorEpoch: 45 * day, Body: "work shipped after the window\n"},
+		},
+	}
+	pruned := map[string][]CommitInfo{"v2.0": full["v2.0"]}
+
+	// Vacuity guard: without an in-window commit both sides would agree at
+	// "nothing", and a filterRange that dropped everything would pass.
+	if got := LeadTime(tags, pruned, from, to); !got.Available || got.SampleSize != 1 {
+		t.Fatalf("LeadTime over the pruned map = %+v, want one in-window commit; this test is "+
+			"not exercising anything", got)
+	}
+
+	if withAll, withPruned := LeadTime(tags, full, from, to), LeadTime(tags, pruned, from, to); withAll != withPruned {
+		t.Errorf("LeadTime read an out-of-window tag's commits: %+v with them, %+v without. "+
+			"ComputeDoraMetrics no longer fetches those (#1553), so this metric would be "+
+			"computed over commits that were never read", withAll, withPruned)
+	}
+
+	allCand, allUnres := DetectReverts(tags, full, from, to)
+	prunedCand, prunedUnres := DetectReverts(tags, pruned, from, to)
+	if len(allCand) != len(prunedCand) || allUnres != prunedUnres {
+		t.Errorf("DetectReverts read an out-of-window tag's commits: %d candidate(s)/%d unresolved "+
+			"with them, %d/%d without", len(allCand), allUnres, len(prunedCand), prunedUnres)
+	}
+}
+
+// TestInWindowIsTheOneDefinitionFilterRangeUses pins the export #1553 added.
+// The service's skip and filterRange must agree on every boundary, and the
+// boundary cases are where a second spelling would drift: both ends are
+// INCLUSIVE.
+func TestInWindowIsTheOneDefinitionFilterRangeUses(t *testing.T) {
+	tags := []TagInfo{
+		{Name: "before", Epoch: 99},
+		{Name: "lower-edge", Epoch: 100},
+		{Name: "middle", Epoch: 150},
+		{Name: "upper-edge", Epoch: 200},
+		{Name: "after", Epoch: 201},
+	}
+	kept := filterRange(tags, 100, 200)
+	if len(kept) != 3 {
+		t.Fatalf("filterRange kept %d tags, want 3 (both ends inclusive)", len(kept))
+	}
+	for _, tag := range tags {
+		want := false
+		for _, k := range kept {
+			if k.Name == tag.Name {
+				want = true
+			}
+		}
+		if got := InWindow(tag.Epoch, 100, 200); got != want {
+			t.Errorf("InWindow(%d) = %v but filterRange %s it; the service skips git calls on "+
+				"InWindow and the metrics read filterRange, so a disagreement is a metric "+
+				"computed over commits nobody fetched",
+				tag.Epoch, got, map[bool]string{true: "keeps", false: "drops"}[want])
+		}
+	}
+}


### PR DESCRIPTION
Closes #1553.

`core/adapters/outbound/git`'s single 5s ceiling covered two cost profiles that
differ by orders of magnitude. A repository large enough to exceed it got a
permanent NON-answer where before #1543 it got a correct-but-slow one — the
DORA panel reading "could not read this project's git history" forever and the
yield sweep logging an unread root every 30 minutes. Honest, but a capability
regression for exactly the users with the most history.

## What this does — option 3, but not the option-2 the issue proposed

**Time bound.** `gitHistoryTimeout` (30s) is now the ceiling for the two
shellouts that read every commit MESSAGE in their range — `RevertedCommits`
(`log --all --grep`) and `CommitsInRange` (`log --pretty=%B`). `gitTimeout`
(5s) keeps the five that do not, which are the ones sitting inside the detector
loop. `run()` takes the profile as a **required** argument rather than
defaulting to one, because picking wrong is silent in both directions (a history
walk on the short ceiling is this issue reintroduced; an enrichment read on the
long one is a 30s detector stall) and an eighth shellout should have to decide
rather than inherit. Deriving the profile from the subcommand was the
alternative and is rejected in the doc: `git log -1 --format=%s` is a plausible
future enrichment read that would silently inherit the history ceiling from its
argv.

The seam is the package's existing one rather than a fourth shape — a field read
through an accessor that falls back to the production value, exactly as #1554
left `cmd`/`timeout`/`path`.

**Work bound.** `ComputeDoraMetrics` no longer fetches the commits of tags
outside its window. `LeadTime` and `DetectReverts` are `commitsByTag`'s only two
consumers and both index it through the domain's window filter, so those commits
were fetched, parsed, held in memory and never read. The oldest tag is the
expensive one: its range starts at the repo root, so on a project that adopted
tags late it is a full-history walk paid for a chart spanning a week. `dora.InWindow`
is exported so the skip and the filter cannot drift into disagreeing about which
tags those are.

## Why not the work bounds the issue proposed — both measured, both rejected

- **`--max-count` does not bound the work of a `--grep` scan at all.** It caps
  the commits *output*, after filtering, so git still walks everything looking
  for matches it never finds. Measured at 100k commits with no matching commit:
  **1921.8 ms with `--max-count=10` against 1923.5 ms without.** "This repo has
  no reverts" is the ordinary case, so the option leaves precisely the worst case
  untouched. (With matches it helps only incidentally — 88.8 ms vs 154.1 ms on
  this repo, because the newest revert is recent.)
- **`--since` changes the number, not only its cost.** `LeadTime` is the median
  of (release time − commit author time) over a release's commits, so dropping
  the commits authored before the window start drops the **longest** lead times
  first: the median moves down and is still published as `Available: true`.
  That is the biased-sample failure `gitMaxOutput`'s doc argues must never
  happen, arriving through a third door.

So the work bound that carries weight is the one that costs no semantics:
*don't make the call at all for a tag nothing reads.*

## Semantics changes, stated plainly

1. **The ceiling change has none.** The same commands, the same output, a longer
   maximum wait for two of the seven.
2. **The DORA skip changes one user-visible behaviour, in the honest direction.**
   A repository whose *out-of-window* history cannot be read no longer blanks the
   panel. Before this, one unreadable ancient range made every window
   unavailable; now the panel is blank only when a read the metrics actually
   needed failed. Same polarity as the rest of #1543 — claim nothing about
   history nobody asked about. Nothing else moves: the pruning removes only map
   entries no metric indexes, locked by `TestNoMetricReadsAnOutOfWindowTagsCommits`.
3. **No result is ever "capped".** Nothing truncates a scan, so there is no third
   outcome between "answered" and "could not look" and the #1543 classification is
   unchanged.

## Measurements — what was actually measured, and what remains unverified

Synthetic repositories built with `git fast-import` (one branch, ~60-byte commit
messages, 50 files, packed, warm cache), git 2.50.1 / Apple Git-155,
darwin/arm64:

| commits | `log --all --grep` | `log --pretty=%B` |
|---|---|---|
| 3,209 (this repo, all refs) | 0.15 s | 0.08 s (over the 1,386 from HEAD) |
| 100,000 | 1.89 s | 2.24 s |
| 1,000,000 | 22.5 s | 30.5 s |

**The issue's headline figure was wrong, in the safe direction.** 100k commits is
*not* at the 5s ceiling — it costs 1.9 s. Interpolating the per-commit cost
(18.9 µs at 100k, 22.5 µs at 1M) puts the wall nearer **250k** commits for the
grep walk and ~200k for the body walk. 30s covers the largest history measured
here, 1M commits (Linux-kernel scale), with ~25% headroom.

**The issue's `TagContaining` row was also wrong**, in the other direction: it
does not scale with the tag count, it walks the commit graph. Measured on a
1M-commit repo with 40 tags: **1.04 s** for a commit near the root (every tag
contains it) against 38 ms for a recent one — ~1 µs/commit, ~20x cheaper than
`log` because it reads the graph rather than every commit message. It stays on
the 5s ceiling (5s ≈ 5M commits there) because `ComputeDoraMetrics` calls it once
per revert candidate, so a longer ceiling multiplies worst there.

**Why 30s and not 60**: the ceiling bounds one CALL and the callers stack them
(#1563), on a server whose `WriteTimeout` is deliberately 0. Every second is
multiplied by that count, so the value is chosen against the stack rather than
against the largest repository imaginable.

**Still unverified**, and marked as such in the constant's doc: the synthetic
repos have far smaller commit objects than real ones (this repo averages ~1.9 KB
of message per commit against the synthetic's ~60 bytes), carry ONE ref where
`--all` on a real large repo iterates thousands, and were measured warm. Read 1M
commits as the shape of the curve, not as a guarantee for any particular
repository. No measurement was taken on a real large repository.

**Drive-by correction**: `gitMaxOutput`'s doc said "~810 bytes/commit", which
divided a HEAD-only byte count (2.59 MB) by an all-refs commit count (3,192) —
two different populations. Measured consistently it is ~1,884 B/commit
(2,611,982 bytes over 1,386 commits from HEAD), so every extrapolation resting on
it was ~2.3x low.

## Mutation evidence — seven mutations, seven reds

Every one applied by copy-aside, run, copy-back, with `git status --porcelain`
empty afterwards. No `git stash`, no `checkout --`, no `reset --hard`.

**M1 — the two history walks back onto the short ceiling** (`historyCost` →
`fixedCost` at both call sites):

```
--- FAIL: TestEachShelloutRunsUnderTheCeilingForItsCostProfile/RevertedCommits
    ran under a 4.999991791s budget, want ~30s. ...
--- FAIL: TestEachShelloutRunsUnderTheCeilingForItsCostProfile/CommitsInRange
    ran under a 4.999990459s budget, want ~30s. ...
--- FAIL: TestTheTwoCeilingsAreIndependentAtRuntime
    RevertedCommits returned after 101.472334ms against a 2s history ceiling — it is
    running under the 100ms enrichment ceiling instead, which is #1553 ...
```

**M2 — `ceilingFor` collapsed back to one ceiling, the other direction**
(`return a.historyCeiling()` for everything):

```
--- FAIL: TestEverySeamDefaultsToProduction
    ceilingFor(fixedCost) = 30s, want 5s
--- FAIL: TestEachShelloutRunsUnderTheCeilingForItsCostProfile/GetBranch
    ran under a 29.999992959s budget, want ~5s ...          (and the other 5 fixed-cost rows)
--- FAIL: TestTheTwoCeilingsAreIndependentAtRuntime
    GetBranch returned after 2.00097175s against a 100ms enrichment ceiling ...
```

**M3 — `historyCeiling()` loses its production fallback** (`return a.historyTimeout`):

```
--- FAIL: TestEverySeamDefaultsToProduction
    ceilingFor(historyCost) = 0s, want 30s
--- FAIL: TestZeroValuedAdapterIsStillBounded
    historyCeiling() = 0s on a zero-valued Adapter, want the 30s default
```

**M4 — `gitHistoryTimeout` collapsed onto `gitTimeout`** (one value again). This
is the vacuity guard: without it the whole table would pass against an adapter
that had never heard of a second profile.

```
--- FAIL: TestEachShelloutRunsUnderTheCeilingForItsCostProfile
    gitHistoryTimeout (5s) is not longer than gitTimeout (5s); with one value this
    test cannot tell the two profiles apart and #1553 is not fixed
```

**M5 — the work bound removed** (`if !dora.InWindow(...) { continue }` deleted):

```
--- FAIL: TestComputeDoraMetrics_SkipsCommitRangesNoMetricReads
    walked [..v1.0 v1.0..v2.0 v2.0..v3.0 v3.0..v4.0 v4.0..v5.0], want [v2.0..v3.0 v3.0..v4.0]
    — a commit range was fetched for a tag no metric reads (the oldest one is a
    full-history walk), or an in-window range was skipped
```

**M6 — a metric reads an out-of-window tag's commits** (`filterRange(...)` →
`tags` in each consumer's loop), which is the invariant the skip stands on:

```
--- FAIL: TestNoMetricReadsAnOutOfWindowTagsCommits          (DetectReverts)
    DetectReverts read an out-of-window tag's commits: 0 candidate(s)/1 unresolved
    with them, 0/0 without
--- FAIL: TestNoMetricReadsAnOutOfWindowTagsCommits          (LeadTime)
    LeadTime read an out-of-window tag's commits: {Value:552 ... SampleSize:2 ...}
    with them, {Value:24 ... SampleSize:1 ...} without ...
```

**The LeadTime half is the one worth reading, because its first draft came back
GREEN.** `LeadTime` filters COMMITS by author epoch as well as TAGS by window, so
an out-of-window tag carrying out-of-window commits is excluded twice over and
the mutation changed nothing — a fixture that cannot express the distinguishing
state grading a filter that is not the one under test, the #1475 shape. The
fixture now carries a release made *after* the window shipping commits authored
*during* it, which is the ordinary thing that separates the two filters; the
mutation then reports a 552-hour median against the true 24. That reasoning is
committed on the test rather than left in this PR body.

**M7 — `filterRange` re-inlines its own comparison and drifts from `InWindow`**
(exclusive upper bound):

```
--- FAIL: TestInWindowIsTheOneDefinitionFilterRangeUses
    filterRange kept 2 tags, want 3 (both ends inclusive)
```

## Filed, not built

- **#1563** — the issue's last paragraph: the ceiling bounds ONE CALL, not one
  operation, and `ComputeDoraMetrics` / the yield sweep stack them on a server
  whose `WriteTimeout` is 0. Same aggregate-vs-per-child shape #1529 fixed for the
  herdr path, including how an abandoned sub-call must be reported. Raising the
  per-call ceiling makes that aggregate larger, which is exactly why 30s and not
  60s.
- **#1564** — found while measuring: for `CommitsInRange` at scale, `gitMaxOutput`
  binds long before either ceiling does. 64 MiB is reached at ~36,000 commits in a
  single range at this repo's ~1.9 KB/commit, where the 30s ceiling is not reached
  until ~1M. So this PR restores `RevertedCommits` (whose output is only the
  matching bodies) decisively and leaves `CommitsInRange`'s real wall where it was.
  Stated in `gitMaxOutput`'s doc so nobody reads this fix as more than it is.

## Verification

`go build ./core/...`; `go test ./core/adapters/outbound/git/... -race` at
`-count=1` (10.7s) and `-count=4` (39.1s, the load-sensitive suite);
`go test ./core/... -race -count=1`; `tools/preflight.sh --only go` (all 7 gates
PASS) and `--only arch` (composite 7.93053 → 7.93039, no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
