### PR TITLE
feat(daemon): count what every bounded probe did, and publish it (#1534)

### DIFF
--- a/core/adapters/inbound/agents/processlifecycle/osutil.go
+++ b/core/adapters/inbound/agents/processlifecycle/osutil.go
@@ -486,6 +486,13 @@ func newAncestryReadsVia(read procInfoProbe) *ancestryReads {
 // can, and records only what the underlying read ANSWERED.
 func (r *ancestryReads) probe(ctx context.Context, pid int) (ppid int, cmd string, err error) {
 	if answer, hit := r.seen[pid]; hit {
+		// #1534: a hit starts no child, so runProbe never sees it, and an
+		// "N answered" that silently excluded hits would understate how often
+		// this probe is ASKED. #1544's own hand-back named this — "a memo now
+		// also hides how often the probe runs" — so the hit is counted where it
+		// happens, on the kind the underlying read would have used, and
+		// published as its own outcome rather than folded into the runs.
+		observeProbeMemoHit(probePSProcInfo)
 		return answer.ppid, answer.cmd, nil
 	}
 	ppid, cmd, err = r.read(ctx, pid)

--- a/core/adapters/inbound/agents/processlifecycle/osutil_darwin.go
+++ b/core/adapters/inbound/agents/processlifecycle/osutil_darwin.go
@@ -61,7 +61,7 @@ func processTTYVia(ctx context.Context, pid int, build shelloutCmd) (tty string,
 		// gives an empty appPath.
 		return "", true
 	}
-	out, err := runProbe(ctx, build)
+	out, err := runProbe(ctx, probePSTTY, build)
 	if !probeAnswered(err) {
 		return "", false
 	}
@@ -290,6 +290,12 @@ func (m *bundleIDMemo) record(appPath, id string) {
 // the consumer does, not because one of the two is a mistake.
 func (m *bundleIDMemo) resolve(ctx context.Context, appPath string, probe bundleIDProbe) (string, error) {
 	if id, hit := m.lookup(appPath); hit {
+		// #1534, and the sibling of ancestryReads.probe's line: a hit starts no
+		// child, so the counter at runProbe cannot see it. Counting it here is
+		// what keeps "answered" from silently meaning "answered, of the ones
+		// that were not memoized" — #1544 flagged exactly this in its own
+		// hand-back.
+		observeProbeMemoHit(probePlutilBundleID)
 		return id, nil
 	}
 	id, err := probe(ctx, appPath)
@@ -336,7 +342,7 @@ func bundleIDVia(ctx context.Context, appPath string, build bundleIDCmd) (string
 		return "", nil
 	}
 	plist := appPath + "/Contents/Info.plist"
-	out, err := runProbe(ctx, build(plist))
+	out, err := runProbe(ctx, probePlutilBundleID, build(plist))
 	if err != nil {
 		// No answeredExitCodes: for plutil ANY normal exit is an answer, which
 		// is the empty-variadic form's whole reason for existing — see
@@ -683,7 +689,7 @@ func kittyWindowIDForPIDVia(ctx context.Context, socket string, sessionPID int, 
 	if kittenPath == "" || socket == "" || sessionPID <= 0 {
 		return "", true
 	}
-	out, err := runProbe(ctx, build)
+	out, err := runProbe(ctx, probeKittenWindow, build)
 	if !probeAnswered(err) {
 		return "", false
 	}
@@ -752,7 +758,7 @@ func findKittyWindowIDForPID(windows []kittyLsWindow, sessionPID int) string {
 // ps already handles the comm-vs-argv-path distinction we need, and the
 // existing package is built around these bounded exec calls.
 func readProcInfo(ctx context.Context, pid int) (ppid int, cmd string, err error) {
-	out, err := runProbe(ctx, func(ctx context.Context) *exec.Cmd {
+	out, err := runProbe(ctx, probePSProcInfo, func(ctx context.Context) *exec.Cmd {
 		return exec.CommandContext(ctx, psPath, "-o", "ppid=,comm=", "-p", strconv.Itoa(pid))
 	})
 	if err != nil {
@@ -825,7 +831,7 @@ func herdrClientPIDs(ctx context.Context, socketPath string) (pids []int, probed
 	if _, err := os.Stat(logPath); err != nil {
 		return nil, false
 	}
-	out, err := runProbe(ctx, func(ctx context.Context) *exec.Cmd {
+	out, err := runProbe(ctx, probeLsofHerdrClients, func(ctx context.Context) *exec.Cmd {
 		return exec.CommandContext(ctx, lsofPath, logPath)
 	})
 	if !lsofProbeRan(err) {
@@ -1034,9 +1040,18 @@ func resolveClientHostIdentityVia(ctx context.Context, pids []int, identify host
 			// an expired deadline reaches them anyway, but only this check
 			// turns "every probe failed" into "we stopped looking", and only
 			// this check makes the aggregate a bound a caller can observe.
+			//
+			// #1558/#1534: counted here because this branch is invisible
+			// everywhere else. It produces the same (nil, false) a failed lsof
+			// produces, so on a machine where the scan is chronically
+			// slow-but-successful a herdr host would never resolve and nothing
+			// would say so. ONE event per loop, not one per candidate left —
+			// the break means the loop never learns how many those were.
+			observeHerdrCandidatesAbandoned()
 			readAll = false
 			break
 		}
+		observeHerdrCandidateProbed()
 		host, complete := identify(ctx, pid)
 		if host.HerdrPaneID != "" {
 			// A candidate that is itself a multiplexer pane has no window of

--- a/core/adapters/inbound/agents/processlifecycle/probecount.go
+++ b/core/adapters/inbound/agents/processlifecycle/probecount.go
@@ -1,0 +1,293 @@
+// probecount.go counts what every bounded child process in this package did
+// (issue #1534).
+//
+// Six issues — #1485, #1492, #1513, #1524, #1533, #1537 — each fixed one probe
+// that collapsed "I could not look" into "I looked and there was nothing", and
+// every one of them closed with the same footer: nothing measures how often a
+// probe actually fails to answer. That is not a documentation gap. Three of
+// those fixes fail OPEN — IsKnownInteractiveHost admits on a walk it could not
+// complete, which is the right call on no evidence — so a probe failing
+// constantly and a probe that never fails produce the SAME observable daemon:
+// the #784 gate quietly stops gating and there is nothing anywhere to look at.
+// A counter is what keeps that visible.
+//
+// Three decisions here are load-bearing, and each is a choice against an
+// obvious alternative:
+//
+//   - COUNTED AT runProbe, which since #1547 is the only place in this package
+//     that starts a child (TestEveryChildProcessRunsThroughRunProbe). One
+//     counting site instead of eight, and a ninth probe is counted by existing
+//     rather than by someone remembering.
+//   - KEYED PER CALL SITE, not per tool. `lsof` runs on three different
+//     questions here and `ps` on two; an "lsof: 4 non-answers" that cannot say
+//     which question went unanswered is the single-scalar failure #1364 already
+//     paid for. TestEveryProbeSiteDeclaresItsOwnKind makes a shared bucket a
+//     build failure rather than a thing to notice.
+//   - ANSWERED means the child RAN TO A NORMAL EXIT. See probeOutcomeRule below
+//     for why that is the hard half of shellout.Answered and not each site's
+//     own allowlist — this file must not acquire a second copy of any call
+//     site's policy.
+//
+// A third outcome, memoHits, exists because #1544 put two memos in front of two
+// of these probes and said so in its own hand-back: "a memo now also hides how
+// often the probe runs". A `plutil` served from bundleIDMemo, or a `ps` served
+// from ancestryReads, starts no child and would be invisible here. Reporting
+// "N answered" while silently excluding hits is a figure that misleads in
+// exactly the way this issue exists to prevent, so a hit is counted where it
+// happens — in the memo — and reported beside the runs rather than folded into
+// them.
+package processlifecycle
+
+import (
+	"sort"
+	"sync/atomic"
+)
+
+// probeKind names ONE bounded child process this package starts: the question,
+// not the binary. Two kinds may run the same tool — `ps` answers both an
+// ancestry read and a controlling-TTY read — and merging them would produce a
+// count that cannot say which question stopped being answered.
+//
+// The values are stable, low-cardinality tokens: they are published in a
+// diagnostics bundle a bug reporter pastes, so they are read by humans and
+// diffed between captures.
+type probeKind string
+
+const (
+	// probePSProcInfo is readProcInfo's `ps -o ppid=,comm=` — the per-PID read
+	// both ancestry walks are built out of, and the one behind ancestryReads.
+	probePSProcInfo probeKind = "ps.proc_info"
+	// probePSTTY is processTTY's `ps -o tty=` (#1533).
+	probePSTTY probeKind = "ps.tty"
+	// probePlutilBundleID is bundleIDForAppPath's `plutil -extract
+	// CFBundleIdentifier` (#1524), the one behind bundleIDMemo.
+	probePlutilBundleID probeKind = "plutil.bundle_id"
+	// probeLsofCWD is the observer's CWDOf `lsof -d cwd`.
+	probeLsofCWD probeKind = "lsof.cwd"
+	// probeLsofWriter is the observer's WriterOf `lsof <path>` (#1537).
+	probeLsofWriter probeKind = "lsof.writer"
+	// probeLsofHerdrClients is herdrClientPIDs' `lsof <client log>` (#1485).
+	probeLsofHerdrClients probeKind = "lsof.herdr_clients"
+	// probePgrepDiscover is runPgrep, behind both FindByName and FindByCmdline
+	// — one run site, so one kind.
+	probePgrepDiscover probeKind = "pgrep.discover"
+	// probeKittenWindow is kittyWindowIDForPID's `kitten @ ls` (#1537).
+	probeKittenWindow probeKind = "kitten.window"
+)
+
+// allProbeKinds is every declared kind. It is the set
+// TestEveryProbeSiteDeclaresItsOwnKind grades the call sites against and the
+// order ProbeCounts reports in, so a kind that stops being used, or a call site
+// that names one nobody declared, is a failure rather than a silent zero.
+var allProbeKinds = []probeKind{
+	probePSProcInfo,
+	probePSTTY,
+	probePlutilBundleID,
+	probeLsofCWD,
+	probeLsofWriter,
+	probeLsofHerdrClients,
+	probePgrepDiscover,
+	probeKittenWindow,
+}
+
+// probeTally is one kind's three counters.
+//
+// Atomics rather than a mutex, for the reason PathConfiner's fixed array of
+// atomics gives: what these exist to observe is a BURST of non-answers under
+// load, and instrumentation that serializes exactly when the events arrive
+// together would blunt the thing it measures.
+type probeTally struct {
+	answered   atomic.Uint64
+	unanswered atomic.Uint64
+	memoHits   atomic.Uint64
+}
+
+// probeCounts maps every declared kind to its tally. The map is built once at
+// init and NEVER written again — only the atomics inside it are — so it needs
+// no mutex of its own. That is a property of this declaration, not a habit:
+// adding an entry at runtime would make the map a shared mutable one and every
+// read here a data race.
+var probeCounts = func() map[probeKind]*probeTally {
+	m := make(map[probeKind]*probeTally, len(allProbeKinds))
+	for _, kind := range allProbeKinds {
+		m[kind] = &probeTally{}
+	}
+	return m
+}()
+
+// undeclaredProbes counts observations naming a kind that is not in
+// allProbeKinds.
+//
+// It exists so that a mis-wired site fails LOUDLY rather than in the one way
+// this whole file is about. The two obvious alternatives are both worse: a
+// panic puts a diagnostics counter on the daemon's critical path, and dropping
+// the observation makes an uncounted probe indistinguishable from one that
+// never ran — which is the exact silence #1534 was filed against, reproduced
+// inside its own fix. TestEveryProbeSiteDeclaresItsOwnKind is what makes this
+// unreachable from production; this is what happens when that guard is wrong.
+var undeclaredProbes atomic.Uint64
+
+// probeOutcomeRule records what "answered" means here, because the answer is
+// NOT each call site's own verdict and the difference matters when reading the
+// numbers.
+//
+// A probe is counted ANSWERED when the child ran to a normal exit — any status
+// — and UNANSWERED when it was killed, never started, or its fork failed. That
+// is shellout.Answered with no exit-code allowlist: the "hard half" its own doc
+// comment describes as the part that does not differ per tool.
+//
+// The per-tool allowlists (lsofNothingToReport, pgrepNoMatch) are deliberately
+// NOT applied here, and that is the decision rather than an oversight. An
+// allowlist encodes what a particular NORMAL exit MEANS to one call site — a
+// policy, per-site by construction, and #1547 kept runProbe free of exactly
+// that. Folding it in would put a second copy of every site's policy here, one
+// copy able to drift from the other, and a counter that disagrees with the code
+// it describes is worse than no counter.
+//
+// What that costs, stated rather than implied: for a tool with an allowlist,
+// a normal-but-not-allowlisted exit (lsof exit 2, pgrep exit 2) is counted
+// ANSWERED while its call site treats it as carrying no verdict. That reading
+// is still the right one for this counter's question — the probe DID run — and
+// the case the fail-open gates actually degrade on, a child killed by the 2s
+// ceiling under load, lands on the unanswered side in every spelling. The one
+// row where the two forms disagree in shellout's own corpus is exit 152, a
+// process killed under an exhausted CPU limit REPORTED THROUGH A SHELL; every
+// probe here execs its binary directly, so a SIGXCPU'd child arrives as a
+// signal (Exited() false) and is counted unanswered.
+const probeOutcomeRule = "a child that ran to a normal exit ANSWERED; one killed, never started, or whose fork failed did not"
+
+// observeProbe records one bounded child process and what became of it. Called
+// from runProbe and nowhere else, so every probe in this package is counted by
+// existing rather than by remembering.
+func observeProbe(kind probeKind, err error) {
+	tally, declared := probeCounts[kind]
+	if !declared {
+		undeclaredProbes.Add(1)
+		return
+	}
+	if probeAnswered(err) {
+		tally.answered.Add(1)
+		return
+	}
+	tally.unanswered.Add(1)
+}
+
+// observeProbeMemoHit records one call to a probe that a memo answered without
+// starting a child (#1544). Its two call sites are the two memos: bundleIDMemo
+// (osutil_darwin.go) and ancestryReads (osutil.go).
+//
+// It is a separate outcome rather than an "answered", because those two facts
+// are used for different things and merging them loses both: answered +
+// unanswered is how often a CHILD RAN, which is the denominator the non-answer
+// rate is a fraction of, while memoHits is how much work the memos removed.
+func observeProbeMemoHit(kind probeKind) {
+	tally, declared := probeCounts[kind]
+	if !declared {
+		undeclaredProbes.Add(1)
+		return
+	}
+	tally.memoHits.Add(1)
+}
+
+// herdrCandidates counts the two ways resolveClientHostIdentityVia's loop can
+// end for a candidate: it probed one, or it abandoned the rest on the aggregate
+// budget (#1529's herdrClientBudget).
+//
+// This is #1558, and it is counted HERE rather than deferred because that issue
+// says so in its own words: "#1534 is that nothing counts probe non-answers,
+// and that now covers budget abandonment too, so this degradation is invisible
+// by construction", with "count it first" named as the cheapest option and the
+// measurement every other option needs.
+//
+// It is NOT a probe row and is deliberately kept off the (kind, outcome) axis:
+// no child process is involved, so calling it "unanswered" would put a
+// different kind of fact in a column whose meaning is fixed by
+// probeOutcomeRule. It is published beside them instead.
+//
+// probed is the denominator, and it is the half #1558 does not ask for. Without
+// it "12 abandoned" cannot be read at all — 12 out of 12 and 12 out of 10,000
+// are different findings and a single scalar cannot tell them apart.
+var herdrCandidates struct {
+	probed            atomic.Uint64
+	abandonedOnBudget atomic.Uint64
+}
+
+// observeHerdrCandidateProbed records one candidate the loop actually asked
+// about.
+func observeHerdrCandidateProbed() { herdrCandidates.probed.Add(1) }
+
+// observeHerdrCandidatesAbandoned records ONE abandonment event — the loop
+// stopping because the aggregate budget was gone — not one per candidate left
+// unread. The loop breaks on the first expired check, so it never learns how
+// many were left; counting the event is the fact it actually has.
+func observeHerdrCandidatesAbandoned() { herdrCandidates.abandonedOnBudget.Add(1) }
+
+// ProbeCount is one probe kind's counters, as the diagnostics bundle reports
+// them. Exported for the composition root, which converts it into the
+// application layer's own shape — application/services must not import an
+// inbound adapter (core/architecture_test.go), the same seam
+// hookjson.UnknownEvents crosses.
+type ProbeCount struct {
+	// Probe is the kind token, e.g. "lsof.herdr_clients".
+	Probe string
+	// Answered is how many children ran to a normal exit.
+	Answered uint64
+	// Unanswered is how many were killed, never started, or failed to fork —
+	// the number every issue in this family closed without.
+	Unanswered uint64
+	// MemoHits is how many calls a memo answered without starting a child. Only
+	// two kinds have a memo (ps.proc_info, plutil.bundle_id); for the rest this
+	// is structurally zero, which is a finding of nothing rather than an
+	// inability to look.
+	MemoHits uint64
+}
+
+// ProbeCounts snapshots every declared kind, in allProbeKinds order.
+//
+// Every kind is returned, including one that has never run: a probe that
+// produced nothing at all is itself a finding — on a machine where the daemon
+// never resolves a host, or where a tool is missing, the ZERO row is the
+// evidence — and omitting it would leave a reader unable to tell "never ran"
+// from "this build has no such probe".
+func ProbeCounts() []ProbeCount {
+	out := make([]ProbeCount, 0, len(allProbeKinds))
+	for _, kind := range allProbeKinds {
+		tally := probeCounts[kind]
+		out = append(out, ProbeCount{
+			Probe:      string(kind),
+			Answered:   tally.answered.Load(),
+			Unanswered: tally.unanswered.Load(),
+			MemoHits:   tally.memoHits.Load(),
+		})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Probe < out[j].Probe })
+	return out
+}
+
+// UndeclaredProbeKinds is how many observations named a kind nobody declared.
+// Non-zero means ProbeCounts is INCOMPLETE and something is wired wrong; it is
+// published rather than left to be inferred from rows that do not add up.
+func UndeclaredProbeKinds() uint64 { return undeclaredProbes.Load() }
+
+// HerdrCandidateCounts is the herdr client loop's two figures (#1558).
+type HerdrCandidateCounts struct {
+	// Probed is how many attached-client candidates the loop asked about.
+	Probed uint64
+	// AbandonedOnBudget is how many times the loop stopped early because
+	// herdrClientBudget was already spent — one per event, not per candidate.
+	AbandonedOnBudget uint64
+}
+
+// HerdrCandidates snapshots that loop.
+func HerdrCandidates() HerdrCandidateCounts {
+	return HerdrCandidateCounts{
+		Probed:            herdrCandidates.probed.Load(),
+		AbandonedOnBudget: herdrCandidates.abandonedOnBudget.Load(),
+	}
+}
+
+// ProbeOutcomeRule is probeOutcomeRule, exported so the diagnostics bundle
+// prints the definition it is actually counting by rather than a second copy
+// of it written in the application layer — the drift "a number which documents
+// behaviour but is not produced by it" describes, one layer up.
+func ProbeOutcomeRule() string { return probeOutcomeRule }

--- a/core/adapters/inbound/agents/processlifecycle/probecount_darwin_test.go
+++ b/core/adapters/inbound/agents/processlifecycle/probecount_darwin_test.go
@@ -1,0 +1,176 @@
+//go:build darwin
+
+package processlifecycle
+
+import (
+	"context"
+	"testing"
+
+	"irrlicht/core/domain/session"
+)
+
+// This file is the darwin half of #1534's coverage: the runtime proof that the
+// PRODUCTION call sites reach the counter under their own kind, rather than the
+// mechanism-only proof probecount_test.go gives by calling runProbe directly.
+//
+// It covers four of the eight sites — the four whose shellout is injected, one
+// per tool, and both classifier polarities (probeAnswered's empty form at
+// ps.tty and plutil.bundle_id, the allowlist form at lsof.writer and
+// pgrep.discover). The other four (ps.proc_info, lsof.cwd, lsof.herdr_clients,
+// kitten.window) take no builder, so what each of them PASSES is graded
+// statically by TestEveryProbeSiteDeclaresItsOwnKind instead. Saying which half
+// covers which is the point: a reader must not have to assume the runtime test
+// reaches sites it cannot.
+
+// TestProductionProbeSitesCountUnderTheirOwnKind drives each injectable site
+// once answering and once not, and asserts the delta lands on that site's kind
+// and nowhere else.
+func TestProductionProbeSitesCountUnderTheirOwnKind(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("ps.tty", func(t *testing.T) {
+		before := readProbeLedger()
+		if _, probed := processTTYVia(ctx, 1, answeringCmd("0")); !probed {
+			t.Fatal("a ps that exited 0 must report probed=true")
+		}
+		assertProbesMoved(t, before, map[string]ProbeCount{
+			"ps.tty": {Probe: "ps.tty", Answered: 1},
+		}, "processTTYVia's shellout is the ps.tty probe")
+
+		before = readProbeLedger()
+		if _, probed := processTTYVia(ctx, 1, missingBinaryCmd()); probed {
+			t.Fatal("a ps that never started must report probed=false — #1533")
+		}
+		assertProbesMoved(t, before, map[string]ProbeCount{
+			"ps.tty": {Probe: "ps.tty", Unanswered: 1},
+		}, "the counter must agree with the site's own probed bit on the case that matters")
+	})
+
+	t.Run("plutil.bundle_id", func(t *testing.T) {
+		answering := func(plist string) shelloutCmd { return answeringCmd("0") }
+		missing := func(plist string) shelloutCmd { return missingBinaryCmd() }
+
+		before := readProbeLedger()
+		if _, err := bundleIDVia(ctx, "/Applications/Nothing.app", answering); err != nil {
+			t.Fatalf("a plutil that exited 0 must not error: %v", err)
+		}
+		assertProbesMoved(t, before, map[string]ProbeCount{
+			"plutil.bundle_id": {Probe: "plutil.bundle_id", Answered: 1},
+		}, "bundleIDVia's shellout is the plutil.bundle_id probe")
+
+		before = readProbeLedger()
+		if _, err := bundleIDVia(ctx, "/Applications/Nothing.app", missing); err == nil {
+			t.Fatal("a plutil that never started must return an error — #1524")
+		}
+		assertProbesMoved(t, before, map[string]ProbeCount{
+			"plutil.bundle_id": {Probe: "plutil.bundle_id", Unanswered: 1},
+		}, "the plutil non-answer is the one #1524's fail-open admission gate turns on")
+	})
+
+	t.Run("lsof.writer", func(t *testing.T) {
+		before := readProbeLedger()
+		if _, err := writerOfVia("/tmp/probe-1534", answeringCmd("0")); err != nil {
+			t.Fatalf("an lsof that exited 0 must not error: %v", err)
+		}
+		assertProbesMoved(t, before, map[string]ProbeCount{
+			"lsof.writer": {Probe: "lsof.writer", Answered: 1},
+		}, "writerOfVia's shellout is the lsof.writer probe")
+
+		// Exit 1 is lsofNothingToReport — an ANSWER at the call site and an
+		// answer here too, which is the one place the two definitions could
+		// have been made to disagree and deliberately were not.
+		before = readProbeLedger()
+		if _, err := writerOfVia("/tmp/probe-1534", answeringCmd("1")); err != nil {
+			t.Fatalf("lsof exit 1 is 'nothing to report', an answer: %v", err)
+		}
+		assertProbesMoved(t, before, map[string]ProbeCount{
+			"lsof.writer": {Probe: "lsof.writer", Answered: 1},
+		}, "lsof's 'nothing to report' ran and answered; counting it as a non-answer would report a healthy machine as failing")
+	})
+
+	t.Run("pgrep.discover", func(t *testing.T) {
+		before := readProbeLedger()
+		if _, err := runPgrepVia("-x", "nothing", answeringCmd("1")); err != nil {
+			t.Fatalf("pgrep exit 1 is 'no match', an answer: %v", err)
+		}
+		assertProbesMoved(t, before, map[string]ProbeCount{
+			"pgrep.discover": {Probe: "pgrep.discover", Answered: 1},
+		}, "runPgrepVia's shellout is the pgrep.discover probe")
+
+		before = readProbeLedger()
+		if _, err := runPgrepVia("-x", "nothing", missingBinaryCmd()); err == nil {
+			t.Fatal("a pgrep that never started must return an error")
+		}
+		assertProbesMoved(t, before, map[string]ProbeCount{
+			"pgrep.discover": {Probe: "pgrep.discover", Unanswered: 1},
+		}, "a pgrep the ceiling killed reports 'no such process' to discovery unless something counts it")
+	})
+}
+
+// TestBundleIDMemoHitIsCounted drives the process-global memo #1544 put in
+// FRONT of the plutil probe. Its first resolve reaches the injected probe (not
+// runProbe, so nothing is counted for it here); its second is served from the
+// memo, which is the call runProbe's counter cannot see.
+//
+// A fresh memo rather than the package-global bundleIDs, for the reason that
+// memo's own comment gives: nothing in the suite should depend on the order
+// tests run in.
+func TestBundleIDMemoHitIsCounted(t *testing.T) {
+	memo := &bundleIDMemo{ids: map[string]string{}}
+	probe := func(ctx context.Context, appPath string) (string, error) { return "md.obsidian", nil }
+	ctx := context.Background()
+	if _, err := memo.resolve(ctx, "/Applications/Obsidian.app", probe); err != nil {
+		t.Fatalf("first resolve: %v", err)
+	}
+
+	before := readProbeLedger()
+	if _, err := memo.resolve(ctx, "/Applications/Obsidian.app", probe); err != nil {
+		t.Fatalf("second resolve: %v", err)
+	}
+	assertProbesMoved(t, before, map[string]ProbeCount{
+		"plutil.bundle_id": {Probe: "plutil.bundle_id", MemoHits: 1},
+	}, "#1544's hand-back: a memo hides how often the probe RUNS, so a hit is its own outcome rather than an unreported one")
+}
+
+// TestHerdrCandidateAbandonmentIsCounted is #1558 inside #1534.
+//
+// The loop's budget break produces the same (nil, false) a failed lsof
+// produces, so on a machine where the scan is chronically slow-but-successful a
+// herdr host would never resolve and nothing anywhere would say why. The
+// probed figure is the denominator: without it "12 abandoned" cannot be read.
+func TestHerdrCandidateAbandonmentIsCounted(t *testing.T) {
+	identify := func(ctx context.Context, pid int) (*session.Launcher, bool) {
+		return &session.Launcher{}, true
+	}
+
+	t.Run("a live budget probes every candidate and abandons none", func(t *testing.T) {
+		before := HerdrCandidates()
+		if _, readAll := resolveClientHostIdentityVia(context.Background(), []int{11, 12}, identify); !readAll {
+			t.Fatal("every candidate was read and none has a host: that is an ANSWER (#1492)")
+		}
+		got := HerdrCandidates()
+		if probed := got.Probed - before.Probed; probed != 2 {
+			t.Errorf("probed moved by %d, want 2 — the denominator must count what the loop actually asked about", probed)
+		}
+		if abandoned := got.AbandonedOnBudget - before.AbandonedOnBudget; abandoned != 0 {
+			t.Errorf("abandoned moved by %d, want 0 — a loop that ran to the end abandoned nothing, and a counter that fires anyway measures nothing", abandoned)
+		}
+	})
+
+	t.Run("a spent budget abandons once and probes nothing", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		before := HerdrCandidates()
+		if _, readAll := resolveClientHostIdentityVia(ctx, []int{11, 12}, identify); readAll {
+			t.Fatal("candidates we declined to look at must poison the answer (#1529)")
+		}
+		got := HerdrCandidates()
+		if abandoned := got.AbandonedOnBudget - before.AbandonedOnBudget; abandoned != 1 {
+			t.Errorf("abandoned moved by %d, want 1 — one event per loop, not one per candidate left unread", abandoned)
+		}
+		if probed := got.Probed - before.Probed; probed != 0 {
+			t.Errorf("probed moved by %d, want 0 — the loop broke before asking about anything", probed)
+		}
+	})
+}

--- a/core/adapters/inbound/agents/processlifecycle/probecount_test.go
+++ b/core/adapters/inbound/agents/processlifecycle/probecount_test.go
@@ -1,0 +1,456 @@
+package processlifecycle
+
+import (
+	"context"
+	"go/ast"
+	"go/token"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// This file grades #1534's counters. Every one of them passes the moment it is
+// written, so what is asserted here is not "the number went up" but the three
+// ways a counter can be present and useless:
+//
+//   - it counts everything as an answer, so the number that matters is always
+//     zero (TestProbeCounterSeparatesAnsweredFromUnanswered);
+//   - two probes share a bucket, so a climbing count cannot say which one
+//     stopped answering (TestEveryProbeSiteDeclaresItsOwnKind, and its runtime
+//     twin one tool at a time);
+//   - it counts something that answered as a non-answer, which is
+//     indistinguishable from correct until the day it matters (the exactness of
+//     every delta assertion below — see probesSince).
+//
+// The counters are process-global and never reset, which is deliberate: a reset
+// hook would be a second way to zero them and the daemon has no use for one. So
+// every assertion here is a DELTA across the call under test, which also makes
+// the file safe under `go test -count=N`. Nothing here calls t.Parallel: Go
+// defers parallel tests until the serial ones have finished, so a serial delta
+// cannot overlap the package's real-ceiling shellout tests.
+
+// probeLedger is one reading of every per-probe counter. The herdr figures are
+// deliberately not in it: they are not on the (kind, outcome) axis, and folding
+// them in would let a probe assertion vouch for a herdr one.
+type probeLedger struct {
+	rows map[string]ProbeCount
+}
+
+// readProbeLedger snapshots the per-probe counters.
+func readProbeLedger() probeLedger {
+	l := probeLedger{rows: map[string]ProbeCount{}}
+	for _, row := range ProbeCounts() {
+		l.rows[row.Probe] = row
+	}
+	return l
+}
+
+// probesSince returns the probe rows that MOVED since before, with the deltas
+// in place of the totals — and only those. Returning the movers rather than
+// every row is what makes a bare reflect.DeepEqual against a one-entry map an
+// exhaustive claim: it says this probe moved by exactly this much AND no other
+// probe moved at all. That second half is the vacuity guard #1364's first
+// obligation exists for — a counter that counts everything looks identical to
+// one that counts correctly until something asserts the silence.
+func probesSince(before probeLedger) map[string]ProbeCount {
+	moved := map[string]ProbeCount{}
+	after := readProbeLedger()
+	for probe, now := range after.rows {
+		was := before.rows[probe]
+		delta := ProbeCount{
+			Probe:      probe,
+			Answered:   now.Answered - was.Answered,
+			Unanswered: now.Unanswered - was.Unanswered,
+			MemoHits:   now.MemoHits - was.MemoHits,
+		}
+		if probeDeltaMoved(delta) {
+			moved[probe] = delta
+		}
+	}
+	return moved
+}
+
+// probeDeltaMoved reports whether any of a row's three counters changed. All
+// three, not just the two outcomes: a memo hit that appeared where none was
+// expected is exactly the #1544 confusion these deltas exist to catch, and a
+// predicate that ignored it would let it pass as silence.
+func probeDeltaMoved(delta ProbeCount) bool {
+	return delta.Answered != 0 || delta.Unanswered != 0 || delta.MemoHits != 0
+}
+
+// assertProbesMoved fails unless exactly want moved. want is keyed by probe
+// token; its ProbeCount values carry deltas.
+func assertProbesMoved(t *testing.T, before probeLedger, want map[string]ProbeCount, why string) {
+	t.Helper()
+	got := probesSince(before)
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("probe counters moved by %v, want %v — %s", got, want, why)
+	}
+}
+
+// answeringCmd builds a child that runs to a normal exit with status code.
+// /bin/sh is present on every platform this package builds for.
+func answeringCmd(code string) shelloutCmd {
+	return func(ctx context.Context) *exec.Cmd {
+		return exec.CommandContext(ctx, "/bin/sh", "-c", "exit "+code)
+	}
+}
+
+// missingBinaryCmd builds a child that can never start. A fork/exec failure is
+// the cheapest deterministic non-answer: unlike a ceiling kill it costs no
+// wall-clock time, and shellout.Answered's own corpus pins it on the same side
+// of the line ("a probe that never ran, not a tool reporting nothing").
+func missingBinaryCmd() shelloutCmd {
+	return func(ctx context.Context) *exec.Cmd {
+		return exec.CommandContext(ctx, "/nonexistent/probe-1534")
+	}
+}
+
+// TestProbeCounterSeparatesAnsweredFromUnanswered is the central claim: the two
+// outcomes are different columns, and a child that ran is never counted as one
+// that did not.
+//
+// The exit-3 row is not a duplicate of the exit-0 one. It pins
+// probeOutcomeRule's deliberate choice — ANSWERED means the child ran to a
+// normal exit, ANY status, rather than the call site's own exit-code allowlist
+// — so a future change that folded lsof's or pgrep's allowlist into runProbe
+// would reclassify it and be caught here rather than silently shifting what
+// every published number means.
+func TestProbeCounterSeparatesAnsweredFromUnanswered(t *testing.T) {
+	ctx := context.Background()
+
+	before := readProbeLedger()
+	if _, err := runProbe(ctx, probePSTTY, answeringCmd("0")); err != nil {
+		t.Fatalf("a child that exits 0 must not error: %v", err)
+	}
+	assertProbesMoved(t, before, map[string]ProbeCount{
+		"ps.tty": {Probe: "ps.tty", Answered: 1},
+	}, "a child that ran to a normal exit is an ANSWER, and is counted by nobody as a non-answer")
+
+	before = readProbeLedger()
+	if _, err := runProbe(ctx, probePSTTY, answeringCmd("3")); err == nil {
+		t.Fatal("a child that exits 3 must return an error, or this row is testing the exit-0 case again")
+	}
+	assertProbesMoved(t, before, map[string]ProbeCount{
+		"ps.tty": {Probe: "ps.tty", Answered: 1},
+	}, "a NON-ZERO normal exit is still an answer: probeOutcomeRule counts the child running, not the call site's allowlist")
+
+	before = readProbeLedger()
+	if _, err := runProbe(ctx, probePSTTY, missingBinaryCmd()); err == nil {
+		t.Fatal("a missing binary must return an error, or this row proves nothing")
+	}
+	assertProbesMoved(t, before, map[string]ProbeCount{
+		"ps.tty": {Probe: "ps.tty", Unanswered: 1},
+	}, "a child that never started is the non-answer every issue in this family closed without a count of")
+}
+
+// TestProbeCounterKeepsEachKindInItsOwnBucket is the runtime half of the
+// per-call-site key. `ps` answers two different questions here and `lsof`
+// three; a bucket shared between them still climbs under load and still cannot
+// say which question stopped being answered, which is the whole diagnostic
+// value.
+func TestProbeCounterKeepsEachKindInItsOwnBucket(t *testing.T) {
+	ctx := context.Background()
+
+	before := readProbeLedger()
+	if _, err := runProbe(ctx, probePSProcInfo, answeringCmd("0")); err != nil {
+		t.Fatalf("ps.proc_info probe: %v", err)
+	}
+	assertProbesMoved(t, before, map[string]ProbeCount{
+		"ps.proc_info": {Probe: "ps.proc_info", Answered: 1},
+	}, "the ancestry read and the tty read both run `ps` and must not share a bucket")
+
+	before = readProbeLedger()
+	if _, err := runProbe(ctx, probeLsofCWD, missingBinaryCmd()); err == nil {
+		t.Fatal("a missing binary must return an error")
+	}
+	if _, err := runProbe(ctx, probeLsofWriter, missingBinaryCmd()); err == nil {
+		t.Fatal("a missing binary must return an error")
+	}
+	assertProbesMoved(t, before, map[string]ProbeCount{
+		"lsof.cwd":    {Probe: "lsof.cwd", Unanswered: 1},
+		"lsof.writer": {Probe: "lsof.writer", Unanswered: 1},
+	}, "three lsof questions, three buckets: a shared one would report six failures against one name and diagnose neither")
+}
+
+// TestProbeMemoHitIsCountedAndIsNotAnAnswer covers #1544's interaction. A memo
+// hit starts no child, so runProbe never sees it — and counting it as an
+// "answer" would inflate the denominator the non-answer rate is read against
+// with calls no probe was ever asked.
+func TestProbeMemoHitIsCountedAndIsNotAnAnswer(t *testing.T) {
+	before := readProbeLedger()
+	observeProbeMemoHit(probePlutilBundleID)
+	assertProbesMoved(t, before, map[string]ProbeCount{
+		"plutil.bundle_id": {Probe: "plutil.bundle_id", MemoHits: 1},
+	}, "a memo hit is its own outcome: it is neither an answered child nor an unanswered one")
+}
+
+// TestAncestryReadsMemoHitIsCounted drives the real per-resolve memo (#1544's
+// second half). Its first read goes to the injected probe — not runProbe, so
+// nothing is counted for it here — and its second is served from seen, which is
+// the call the counter at runProbe cannot see.
+func TestAncestryReadsMemoHitIsCounted(t *testing.T) {
+	reads := newAncestryReadsVia(func(ctx context.Context, pid int) (int, string, error) {
+		return 1, "/bin/launchd", nil
+	})
+	ctx := context.Background()
+	if _, _, err := reads.probe(ctx, 4242); err != nil {
+		t.Fatalf("first read: %v", err)
+	}
+
+	before := readProbeLedger()
+	if _, _, err := reads.probe(ctx, 4242); err != nil {
+		t.Fatalf("second read: %v", err)
+	}
+	assertProbesMoved(t, before, map[string]ProbeCount{
+		"ps.proc_info": {Probe: "ps.proc_info", MemoHits: 1},
+	}, "a ps served from ancestryReads is a call the probe was asked and never ran for; #1544's hand-back is that a memo hides exactly this")
+}
+
+// TestUndeclaredProbeKindIsCountedNotDropped is the guard on the guard. A kind
+// nothing declared cannot be attributed to a row, and dropping the observation
+// would make an uncounted probe indistinguishable from one that never ran —
+// this issue's own failure mode, reproduced inside its fix.
+func TestUndeclaredProbeKindIsCountedNotDropped(t *testing.T) {
+	beforeUndeclared := UndeclaredProbeKinds()
+	before := readProbeLedger()
+
+	observeProbe(probeKind("not.a.declared.kind"), nil)
+	observeProbeMemoHit(probeKind("not.a.declared.kind"))
+
+	if got := UndeclaredProbeKinds() - beforeUndeclared; got != 2 {
+		t.Errorf("undeclared observations = %d, want 2 — an unattributable probe must be reported, not swallowed", got)
+	}
+	assertProbesMoved(t, before, map[string]ProbeCount{},
+		"an undeclared kind must not be silently folded into some other probe's row")
+}
+
+// TestProbeCountsReportsEveryDeclaredKind pins the snapshot's shape. Every
+// declared kind is present even at zero, because "this probe never ran" is
+// itself a finding — on a machine where a tool is missing, the zero row IS the
+// evidence — and an omitted row cannot be told apart from a probe this build
+// does not have.
+func TestProbeCountsReportsEveryDeclaredKind(t *testing.T) {
+	if len(probeCounts) != len(allProbeKinds) {
+		t.Fatalf("probeCounts has %d entries for %d declared kinds — two kinds share a token, so they share a bucket",
+			len(probeCounts), len(allProbeKinds))
+	}
+	rows := ProbeCounts()
+	if len(rows) != len(allProbeKinds) {
+		t.Fatalf("ProbeCounts returned %d rows for %d declared kinds", len(rows), len(allProbeKinds))
+	}
+	seen := map[string]bool{}
+	for _, row := range rows {
+		seen[row.Probe] = true
+	}
+	for _, kind := range allProbeKinds {
+		if !seen[string(kind)] {
+			t.Errorf("ProbeCounts omits %q", kind)
+		}
+	}
+	if !sort.SliceIsSorted(rows, func(i, j int) bool { return rows[i].Probe < rows[j].Probe }) {
+		t.Errorf("ProbeCounts is unsorted: %v — two captures of the same daemon must diff cleanly", rows)
+	}
+}
+
+// --- the static half: every run site names its own declared kind -----------
+
+// TestEveryProbeSiteDeclaresItsOwnKind is #1534's tripwire, and it is where a
+// NINTH probe is covered by existing rather than by remembering.
+//
+// It reads the package's own source, for the reason the shellout guard beside
+// it does: every one of these sites is behind `//go:build darwin`, so a
+// type-aware load on a linux runner would find none of them and pass — a gate
+// whose absence reads as a pass, which is the exact defect this package keeps
+// producing. parsePackageSources (shellout_guard_test.go) ignores build tags
+// and excludes _test.go, so a test driving runProbe directly (this file does)
+// is not graded as a production site.
+//
+// Three claims, and they fail on different mutations:
+//
+//   - every runProbe call passes a kind from the declared const block — a
+//     site passing a bare string, or a kind nobody declared, is a row that
+//     lands in undeclaredProbes at runtime and in nothing at all in the bundle;
+//   - no two sites pass the SAME kind — the shared-bucket mutation;
+//   - every declared kind is used by some site — so a kind left behind by a
+//     removed probe is deleted rather than published forever at zero.
+func TestEveryProbeSiteDeclaresItsOwnKind(t *testing.T) {
+	fset, files := parsePackageSources(t, ".")
+	declared := declaredProbeKindIdents(t, files)
+	assertDeclarationMatchesAllProbeKinds(t, declared)
+
+	usedBy, sites := probeKindsBySite(t, fset, files, declared)
+
+	// Vacuity floor, the same shape and for the same reason as the shellout
+	// guard's: a scan that found no sites reports no violations and is
+	// indistinguishable from a clean package.
+	const knownProbeSites = 8
+	if sites < knownProbeSites {
+		t.Fatalf("found %d runProbe call sites, expected at least %d: the scan is not looking where it thinks it is, so its silence proves nothing",
+			sites, knownProbeSites)
+	}
+
+	assertNoTwoSitesShareAKind(t, usedBy)
+	assertEveryDeclaredKindIsUsed(t, declared, usedBy)
+}
+
+// assertDeclarationMatchesAllProbeKinds checks that the set this scan reads out
+// of the source and the set the runtime side counts into are the same one.
+// Without it, a const added to the block but left out of allProbeKinds would
+// satisfy every claim below while counting into nothing.
+func assertDeclarationMatchesAllProbeKinds(t *testing.T, declared map[string]string) {
+	t.Helper()
+	if len(declared) != len(allProbeKinds) {
+		t.Fatalf("the source declares %d probeKind constants but allProbeKinds lists %d — a kind that is not in allProbeKinds has no counter",
+			len(declared), len(allProbeKinds))
+	}
+	values := declaredValues(declared)
+	for _, kind := range allProbeKinds {
+		if !values[string(kind)] {
+			t.Errorf("allProbeKinds contains %q, which no probeKind constant declares", kind)
+		}
+	}
+}
+
+// assertNoTwoSitesShareAKind is the shared-bucket claim.
+func assertNoTwoSitesShareAKind(t *testing.T, usedBy map[string][]string) {
+	t.Helper()
+	for kind, where := range usedBy {
+		if len(where) > 1 {
+			t.Errorf("%s is passed by %d call sites (%s) — they share one bucket, so a climbing count cannot say which probe stopped answering. A kind names a call site; a genuinely shared one amends this rule in a reviewable diff.",
+				kind, len(where), strings.Join(where, ", "))
+		}
+	}
+}
+
+// assertEveryDeclaredKindIsUsed keeps a kind left behind by a removed probe
+// from being published forever as a zero row no probe can move.
+func assertEveryDeclaredKindIsUsed(t *testing.T, declared map[string]string, usedBy map[string][]string) {
+	t.Helper()
+	for name := range declared {
+		if len(usedBy[name]) == 0 {
+			t.Errorf("%s is declared but passed by no call site — it publishes a permanent zero row that no probe can ever move", name)
+		}
+	}
+}
+
+// probeKindsBySite returns, per declared kind identifier, the `file:line` of
+// every call site that passes it — plus how many runProbe calls were seen at
+// all, which is the vacuity floor's input. A call whose kind argument is
+// missing or is not a declared constant is reported here and contributes to
+// sites but to no kind, so it cannot be mistaken for coverage.
+func probeKindsBySite(t *testing.T, fset *token.FileSet, files map[string]*ast.File, declared map[string]string) (usedBy map[string][]string, sites int) {
+	t.Helper()
+	usedBy = map[string][]string{}
+	for name, file := range files {
+		ast.Inspect(file, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok || !isRunProbeCall(call) {
+				return true
+			}
+			sites++
+			where := filepath.Base(name) + ":" + strconv.Itoa(fset.Position(call.Pos()).Line)
+			if kind := probeKindArgument(t, call, where, declared); kind != "" {
+				usedBy[kind] = append(usedBy[kind], where)
+			}
+			return true
+		})
+	}
+	return usedBy, sites
+}
+
+// probeKindArgument returns the declared kind identifier one runProbe call
+// passes, or "" (having reported why) when it passes something else.
+func probeKindArgument(t *testing.T, call *ast.CallExpr, where string, declared map[string]string) string {
+	t.Helper()
+	if len(call.Args) < 2 {
+		t.Errorf("%s: runProbe is called with %d arguments — the probe kind is missing, so this child is counted under nothing",
+			where, len(call.Args))
+		return ""
+	}
+	id, ok := call.Args[1].(*ast.Ident)
+	if !ok {
+		t.Errorf("%s: runProbe's kind argument is not an identifier — only the declared probeKind constants (%s) are counted; anything else lands in undeclared_probe_kinds and appears in no row",
+			where, strings.Join(sortedKeys(declared), ", "))
+		return ""
+	}
+	if _, isKind := declared[id.Name]; !isKind {
+		t.Errorf("%s: runProbe is passed %s, which is not one of the declared probeKind constants (%s) — an undeclared kind is counted in undeclared_probe_kinds and appears in no row",
+			where, id.Name, strings.Join(sortedKeys(declared), ", "))
+		return ""
+	}
+	return id.Name
+}
+
+// declaredProbeKindIdents returns the identifier names of every `probeKind`
+// constant, mapped to its string value. Derived from the source rather than
+// listed here, so a new kind is graded by existing.
+func declaredProbeKindIdents(t *testing.T, files map[string]*ast.File) map[string]string {
+	t.Helper()
+	out := map[string]string{}
+	for _, file := range files {
+		for _, decl := range file.Decls {
+			if gen, ok := decl.(*ast.GenDecl); ok && gen.Tok == token.CONST {
+				collectProbeKindConsts(gen, out)
+			}
+		}
+	}
+	if len(out) == 0 {
+		t.Fatal("no probeKind constants found in the package source — the scan is looking in the wrong place, so its silence proves nothing")
+	}
+	return out
+}
+
+// collectProbeKindConsts adds every `<name> probeKind = "<token>"` spec of one
+// const block to out. The type is required on each spec rather than inherited
+// from the first, which is how probecount.go spells them and what keeps a
+// neighbouring const of some other type out of the set.
+func collectProbeKindConsts(gen *ast.GenDecl, out map[string]string) {
+	for _, spec := range gen.Specs {
+		vs, ok := spec.(*ast.ValueSpec)
+		if !ok {
+			continue
+		}
+		if typ, ok := vs.Type.(*ast.Ident); !ok || typ.Name != "probeKind" {
+			continue
+		}
+		for i, name := range vs.Names {
+			out[name.Name] = probeKindLiteral(vs, i)
+		}
+	}
+}
+
+// probeKindLiteral returns the unquoted string value of spec's i-th value, or
+// "" when there is none to read.
+func probeKindLiteral(vs *ast.ValueSpec, i int) string {
+	if i >= len(vs.Values) {
+		return ""
+	}
+	lit, ok := vs.Values[i].(*ast.BasicLit)
+	if !ok {
+		return ""
+	}
+	return strings.Trim(lit.Value, `"`)
+}
+
+// declaredValues inverts declaredProbeKindIdents to a set of token values.
+func declaredValues(declared map[string]string) map[string]bool {
+	out := map[string]bool{}
+	for _, v := range declared {
+		out[v] = true
+	}
+	return out
+}
+
+func sortedKeys(m map[string]string) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/core/adapters/inbound/agents/processlifecycle/process_darwin.go
+++ b/core/adapters/inbound/agents/processlifecycle/process_darwin.go
@@ -80,7 +80,7 @@ func (darwinObserver) ArgvOf(pid int) ([]string, error) {
 
 // CWDOf returns the working directory of pid via `lsof -d cwd`.
 func (darwinObserver) CWDOf(pid int) (string, error) {
-	out, err := runProbe(context.Background(), func(ctx context.Context) *exec.Cmd {
+	out, err := runProbe(context.Background(), probeLsofCWD, func(ctx context.Context) *exec.Cmd {
 		return exec.CommandContext(ctx, lsofPath, "-a", "-p", strconv.Itoa(pid), "-d", "cwd", "-Fn")
 	})
 	if err != nil {
@@ -123,7 +123,7 @@ func writerOfVia(path string, build shelloutCmd) (int, error) {
 	if path == "" {
 		return 0, nil
 	}
-	out, err := runProbe(context.Background(), build)
+	out, err := runProbe(context.Background(), probeLsofWriter, build)
 	if !lsofProbeRan(err) {
 		// #1537: an lsof that could not be ASKED knows nothing about who holds
 		// this transcript, and the comment that used to sit on the collapsed
@@ -232,7 +232,7 @@ func runPgrep(flag, pattern string) ([]int, error) {
 
 // runPgrepVia is runPgrep with the shellout injected.
 func runPgrepVia(flag, pattern string, build shelloutCmd) ([]int, error) {
-	out, err := runProbe(context.Background(), build)
+	out, err := runProbe(context.Background(), probePgrepDiscover, build)
 	if err != nil {
 		// pgrep exits 1 when there are no matches — a real answer, the same
 		// shape as lsof's (lsofProbeRan). Anything else is a probe that did

--- a/core/adapters/inbound/agents/processlifecycle/shellout.go
+++ b/core/adapters/inbound/agents/processlifecycle/shellout.go
@@ -101,10 +101,27 @@ type shelloutCmd func(ctx context.Context) *exec.Cmd
 // (out, err) and leaves the verdict, whose POLARITY is per-call-site anyway, at
 // the call site. See the file header of shellout_guard_test.go for the rule and
 // what each half of it can and cannot see.
-func runProbe(ctx context.Context, build shelloutCmd) ([]byte, error) {
+//
+// WHAT IT DOES DO, since #1534, is COUNT. Being the only place a child starts
+// is exactly what makes one counting site cover every probe, present and
+// future — eight call sites' worth of remembering removed the same way #1547
+// removed eight copies of the ceiling. The counter has to know WHICH question
+// was asked, which is why this signature grew a parameter rather than deriving
+// one: a shelloutCmd closes its arguments over (see the type), so there is
+// nothing in build to derive a kind from, and TestEveryProbeSiteDeclaresItsOwnKind
+// grades what each site passes.
+//
+// Counting is still not CLASSIFYING, and the distinction is the same one the
+// paragraph above draws. observeProbe records whether the CHILD answered —
+// shellout.Answered's tool-independent half — and touches no site's exit-code
+// allowlist and no site's polarity. probecount.go's probeOutcomeRule carries
+// that argument and states what it costs.
+func runProbe(ctx context.Context, kind probeKind, build shelloutCmd) ([]byte, error) {
 	ctx, cancel := context.WithTimeout(ctx, shelloutTimeout)
 	defer cancel()
-	return build(ctx).Output()
+	out, err := build(ctx).Output()
+	observeProbe(kind, err)
+	return out, err
 }
 
 // probeAnswered is this package's binding of the shared predicate

--- a/core/application/services/diagnostics_probes_test.go
+++ b/core/application/services/diagnostics_probes_test.go
@@ -1,0 +1,175 @@
+package services
+
+// This file holds probes.json's coverage (#1534). It is a separate file from
+// diagnostics_service_test.go rather than an appendix to it: that file already
+// carries the bundle's shape, redaction, liveness and three generations of hook
+// counters, and a fifth unrelated subject in it is a file nobody can hold in
+// their head. The shared wiring (buildTestServiceWith) stays there, next to the
+// service it builds.
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// buildTestServiceWithProbes is buildTestService with an explicit probe-health
+// source, so a test can drive probes.json's two collection modes: nil is the
+// --diagnose CLI, non-nil is the daemon.
+func buildTestServiceWithProbes(t *testing.T, probeHealth func() ProbeHealthSnapshot) *DiagnosticsService {
+	t.Helper()
+	return buildTestServiceWith(t, nil, probeHealth)
+}
+
+// probesJSON pulls probes.json out of a freshly written bundle.
+func probesJSON(t *testing.T, svc *DiagnosticsService) map[string]any {
+	t.Helper()
+	var buf bytes.Buffer
+	if err := svc.WriteBundle(&buf); err != nil {
+		t.Fatalf("WriteBundle: %v", err)
+	}
+	raw, ok := untar(t, buf.Bytes())["probes.json"]
+	if !ok {
+		t.Fatal("bundle has no probes.json")
+	}
+	var out map[string]any
+	if err := json.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("probes.json is not valid JSON: %v\n%s", err, raw)
+	}
+	return out
+}
+
+// probeHealthFixture is a daemon snapshot with one failing probe, one healthy
+// one, one memoized one and one that never ran.
+func probeHealthFixture() ProbeHealthSnapshot {
+	return ProbeHealthSnapshot{
+		// Deliberately out of order: the view sorts, so two captures of the
+		// same daemon diff cleanly instead of churning.
+		Probes: []ProbeCount{
+			{Probe: "plutil.bundle_id", Answered: 40, Unanswered: 2, MemoHits: 118},
+			{Probe: "kitten.window"},
+			{Probe: "lsof.cwd", Answered: 17},
+		},
+		OutcomeRule:                      "a child that ran to a normal exit ANSWERED; one killed, never started, or whose fork failed did not",
+		HerdrCandidatesProbed:            9,
+		HerdrCandidatesAbandonedOnBudget: 3,
+	}
+}
+
+// TestProbesBundleReportsCounts covers the daemon-collected form: the numbers a
+// bug report needs in order to answer "is this probe failing, and how often",
+// which every issue in the #1485/#1492/#1513/#1524/#1533/#1537 family closed
+// without.
+func TestProbesBundleReportsCounts(t *testing.T) {
+	got := probesJSON(t, buildTestServiceWithProbes(t, probeHealthFixture))
+
+	if got["collected_from"] != "daemon" {
+		t.Errorf("collected_from = %v, want \"daemon\"", got["collected_from"])
+	}
+	if got["total_unanswered"] != float64(2) {
+		t.Errorf("total_unanswered = %v, want 2 — the total is published, not left for a reader to sum", got["total_unanswered"])
+	}
+	rows, _ := got["probes"].([]any)
+	if len(rows) != 3 {
+		t.Fatalf("probes has %d rows, want 3: %v", len(rows), got["probes"])
+	}
+	first, _ := rows[0].(map[string]any)
+	if first["probe"] != "kitten.window" {
+		t.Errorf("first row = %v, want kitten.window (sorted by probe)", first)
+	}
+	if first["answered"] != float64(0) || first["unanswered"] != float64(0) {
+		t.Errorf("a probe that never ran must still be reported at zero, not omitted: %v", first)
+	}
+	// The memo column is the #1544 interaction. Folding it into "answered"
+	// would inflate the denominator the non-answer rate is read against with
+	// calls that started no child.
+	last, _ := rows[2].(map[string]any)
+	if last["probe"] != "plutil.bundle_id" || last["memo_hits"] != float64(118) || last["answered"] != float64(40) {
+		t.Errorf("plutil row = %v, want answered:40 memo_hits:118 kept apart", last)
+	}
+	if note, _ := got["memo_note"].(string); !strings.Contains(note, "memo_hits") {
+		t.Errorf("memo_note must say that hits are excluded from answered/unanswered: %q", note)
+	}
+	if rule, _ := got["outcome_rule"].(string); !strings.Contains(rule, "normal exit") {
+		t.Errorf("outcome_rule must carry the counting rule the numbers were produced by: %q", rule)
+	}
+	unanswered, _ := got["unanswered_note"].(string)
+	if !strings.Contains(unanswered, "plutil.bundle_id") || !strings.Contains(unanswered, "#784") {
+		t.Errorf("a non-zero unanswered count must name the probe and what fails open on it: %q", unanswered)
+	}
+	if got["herdr_client_candidates_abandoned_on_budget"] != float64(3) {
+		t.Errorf("herdr abandonment = %v, want 3 (#1558)", got["herdr_client_candidates_abandoned_on_budget"])
+	}
+	if got["herdr_client_candidates_probed"] != float64(9) {
+		t.Errorf("herdr probed = %v, want 9 — without the denominator the abandonment count cannot be read", got["herdr_client_candidates_probed"])
+	}
+	if note, _ := got["herdr_abandonment_note"].(string); !strings.Contains(note, "#1529") {
+		t.Errorf("a non-zero abandonment must explain itself: %q", note)
+	}
+}
+
+// TestProbesBundleStaysTerseWhenNothingIsWrong is the vacuity guard on the
+// notes. A section that prints its explanation unconditionally is one whose
+// explanation carries no information — a reader cannot tell a machine with a
+// failing probe from a healthy one by looking at it.
+func TestProbesBundleStaysTerseWhenNothingIsWrong(t *testing.T) {
+	got := probesJSON(t, buildTestServiceWithProbes(t, func() ProbeHealthSnapshot {
+		return ProbeHealthSnapshot{
+			Probes:                []ProbeCount{{Probe: "lsof.cwd", Answered: 17}},
+			OutcomeRule:           "a child that ran to a normal exit ANSWERED",
+			HerdrCandidatesProbed: 9,
+		}
+	}))
+
+	for _, field := range []string{"unanswered_note", "herdr_abandonment_note", "undeclared_probe_kinds_note", "undeclared_probe_kinds"} {
+		if v, ok := got[field]; ok {
+			t.Errorf("%s is present on a healthy machine: %v — an explanation that always fires explains nothing", field, v)
+		}
+	}
+	if got["total_unanswered"] != float64(0) {
+		t.Errorf("total_unanswered = %v, want 0 — the FIGURE is not conditional, only its essay is", got["total_unanswered"])
+	}
+}
+
+// TestProbesBundleOmitsCountsWhenNotCollectedInDaemon is the honesty
+// obligation, and it is a step stronger than hooks.json's.
+//
+// `irrlichd --diagnose` builds its bundle in a separate process, and that
+// process is NOT structurally quiet about probes: collecting processes.json
+// walks every adapter's matcher through the observer, which on macOS shells out
+// to pgrep and lsof. So this form's counters are small, real, and about nothing
+// but its own bundle collection — publishing them under the daemon's field
+// names would produce a plausible-looking measurement of something nobody
+// measured, which is worse than a zero because a zero announces itself.
+func TestProbesBundleOmitsCountsWhenNotCollectedInDaemon(t *testing.T) {
+	got := probesJSON(t, buildTestServiceWithProbes(t, nil))
+
+	if got["collected_from"] != "cli" {
+		t.Errorf("collected_from = %v, want \"cli\"", got["collected_from"])
+	}
+	// Every count, not just the list. A zero here reads as an all-clear, and
+	// the numbers this process could truthfully print are answers to a
+	// different question.
+	for _, field := range []string{
+		"probes", "total_unanswered", "undeclared_probe_kinds",
+		"herdr_client_candidates_probed", "herdr_client_candidates_abandoned_on_budget",
+		// The notes that only make sense beside counts. outcome_rule is here
+		// too: a counting rule printed next to no counts describes numbers this
+		// section does not carry.
+		"memo_note", "outcome_rule", "unanswered_note", "herdr_abandonment_note",
+	} {
+		if v, ok := got[field]; ok {
+			t.Errorf("%s is present without a daemon to read it from: %v", field, v)
+		}
+	}
+	note, _ := got["note"].(string)
+	if !strings.Contains(note, "/debug/bundle") {
+		t.Errorf("note does not say where the real evidence is: %q", note)
+	}
+	// The reason is not the hook section's reason, and stating the wrong one
+	// would teach the next reader that this process runs no probes.
+	if !strings.Contains(note, "NOT zero") {
+		t.Errorf("note must say that this process's counters are non-zero and describe its own collection, not that they are structurally zero: %q", note)
+	}
+}

--- a/core/application/services/diagnostics_service.go
+++ b/core/application/services/diagnostics_service.go
@@ -51,6 +51,7 @@ type DiagnosticsService struct {
 	version        string
 	paths          DiagnosticsPaths
 	hookHealth     func() HookHealthSnapshot
+	probeHealth    func() ProbeHealthSnapshot
 }
 
 // UnknownHookEvent is one (adapter, event name) pair a hook receiver was sent
@@ -106,6 +107,61 @@ type HookHealthSnapshot struct {
 	EntryReverification HookEntryReverifySnapshot
 }
 
+// ProbeCount is one bounded child process the daemon runs, with how often it
+// ANSWERED, how often it did not, and how often a memo answered for it without
+// starting a child at all (issue #1534).
+//
+// Six issues in this family — #1485, #1492, #1513, #1524, #1533, #1537 — each
+// fixed one probe that collapsed "I could not look" into "I looked and there
+// was nothing", and each closed with the same footer: nothing measures how
+// often it actually happens. Three of them fail OPEN, so a probe failing
+// constantly and one that never fails produce the same observable daemon.
+// Unanswered is the number that was missing.
+type ProbeCount struct {
+	// Probe is the per-call-site kind token, e.g. "lsof.herdr_clients". Per
+	// call site rather than per tool: `lsof` answers three different questions
+	// here and `ps` two, and a count that cannot say WHICH stopped being
+	// answered is the single-scalar failure #1364 already paid for.
+	Probe string `json:"probe"`
+	// Answered is how many children ran to a normal exit.
+	Answered uint64 `json:"answered"`
+	// Unanswered is how many were killed (the 2s ceiling, an OOM kill), never
+	// started, or failed to fork.
+	Unanswered uint64 `json:"unanswered"`
+	// MemoHits is how many calls a memo served without starting a child
+	// (#1544). Only two probes have a memo, so a zero here is a finding of
+	// nothing rather than an inability to look.
+	MemoHits uint64 `json:"memo_hits"`
+}
+
+// ProbeHealthSnapshot is the probe counters at one instant.
+//
+// Like HookHealthSnapshot it is a plain value handed in by the composition
+// root, because application/services must not import adapters/inbound — the
+// hexagonal rule core/architecture_test.go enforces. The daemon converts
+// processlifecycle's snapshot into this; --diagnose supplies nothing.
+type ProbeHealthSnapshot struct {
+	// Probes is every declared probe kind, including one that never ran: a
+	// zero row is itself evidence (a missing tool, a daemon that never
+	// resolved a host) and omitting it would leave a reader unable to tell
+	// "never ran" from "no such probe in this build".
+	Probes []ProbeCount
+	// OutcomeRule is the counting rule, taken from the package that does the
+	// counting rather than restated here — a definition written twice is one
+	// that can describe behaviour it no longer has.
+	OutcomeRule string
+	// UndeclaredKinds is how many observations named a probe kind nobody
+	// declared. Non-zero means Probes is INCOMPLETE.
+	UndeclaredKinds uint64
+	// HerdrCandidatesProbed and HerdrCandidatesAbandonedOnBudget are #1558's
+	// figures: how many attached-client candidates the herdr host loop asked
+	// about, and how many times it stopped early because the aggregate budget
+	// was already spent. Not probe rows — no child process is involved — so
+	// they are reported beside them rather than as an outcome.
+	HerdrCandidatesProbed            uint64
+	HerdrCandidatesAbandonedOnBudget uint64
+}
+
 // DiagnosticsServiceDeps bundles NewDiagnosticsService's dependencies.
 type DiagnosticsServiceDeps struct {
 	Repo    outbound.SessionRepository
@@ -124,6 +180,15 @@ type DiagnosticsServiceDeps struct {
 	// hooks.json then omits the counts and says where the real ones are, rather
 	// than publishing zeros that look like an all-clear.
 	HookHealth func() HookHealthSnapshot
+	// ProbeHealth snapshots the in-process probe counters (#1534). NIL IS
+	// MEANINGFUL and means something SHARPER than HookHealth's nil: the
+	// --diagnose CLI does run probes — collecting processes.json shells out to
+	// pgrep and lsof through the observer — so its counters are not
+	// structurally zero, they are a handful of numbers describing that CLI's
+	// own bundle collection. Publishing those under the same field names as
+	// the daemon's would be worse than publishing zeros, because they look
+	// plausible. probesView omits them and says so.
+	ProbeHealth func() ProbeHealthSnapshot
 }
 
 // NewDiagnosticsService wires the service.
@@ -138,6 +203,7 @@ func NewDiagnosticsService(deps DiagnosticsServiceDeps) *DiagnosticsService {
 		version:        deps.Version,
 		paths:          deps.Paths,
 		hookHealth:     deps.HookHealth,
+		probeHealth:    deps.ProbeHealth,
 	}
 }
 
@@ -167,6 +233,7 @@ func (s *DiagnosticsService) WriteBundle(w io.Writer) error {
 	b.addJSON("liveness.json", s.liveness(sessions, b.red))
 	b.addJSON("processes.json", s.processes(b.red))
 	b.addJSON("hooks.json", s.hooksView())
+	b.addJSON("probes.json", s.probesView())
 	s.addLogs(b)
 
 	if errs := b.errs; len(errs) > 0 {
@@ -531,6 +598,153 @@ func (s *DiagnosticsService) hooksView() any {
 		UnknownEvents:            events,
 		UnknownEventNamesDropped: snap.UnknownNamesDropped,
 	}
+}
+
+// probesView renders probes.json: how often each bounded child process the
+// daemon runs actually ANSWERED (issue #1534).
+//
+// It is a sibling of hooks.json rather than a section inside it. The two answer
+// different questions of different subjects — what arrived at our HTTP
+// endpoints, versus what came back from the children we start — and the one
+// thing they share is the honesty problem below, which is a reason to draw the
+// seam the same way, not to merge the artifacts.
+//
+// That honesty problem is SHARPER here than for hooks, and getting it wrong
+// would be worse. `irrlichd --diagnose` builds its bundle in a separate,
+// freshly launched process, and unlike the hook case that process is not
+// structurally quiet: collecting processes.json walks every adapter's matcher
+// through the observer, which on macOS is `pgrep` and `lsof`. So its counters
+// are non-zero — a handful of probes, run by the bundle collector itself, in
+// the last second. Published under the daemon's field names they would read as
+// a measurement of the daemon's probe health, and they would look plausible
+// enough that nobody would check. Zeros at least announce themselves. So when
+// no snapshot source is wired the counts are OMITTED and the section says both
+// that they are missing and why the numbers this process could have printed
+// would not have been the ones asked for.
+func (s *DiagnosticsService) probesView() any {
+	if s.probeHealth == nil {
+		// A DIFFERENT shape, not the daemon shape with this CLI's own numbers
+		// (or zeros) in it — the same rule hooksView follows, for a reason that
+		// is one step stronger. See the doc comment above.
+		return struct {
+			CollectedFrom string `json:"collected_from"`
+			Note          string `json:"note"`
+		}{
+			CollectedFrom: "cli",
+			Note: "Collected by `irrlichd --diagnose`, which is not the process that runs the daemon's " +
+				"probes, so the per-probe answered/unanswered counters are omitted rather than reported. " +
+				"Note they are NOT zero in this process: building processes.json shells out to pgrep and " +
+				"lsof through the same observer, so this process has a few counts of its own, describing " +
+				"nothing but its own bundle collection — which is why they are omitted rather than printed. " +
+				"For the daemon's real counts, fetch GET /debug/bundle from the running daemon.",
+		}
+	}
+
+	snap := s.probeHealth()
+	// Copied before sorting, for the reason hooksView copies its events: the
+	// slice belongs to the injected snapshot source, and reordering a caller's
+	// slice in place is the aliasing bug this repo has already paid for once
+	// (#965/#967/#975).
+	probes := append([]ProbeCount(nil), snap.Probes...)
+	sort.Slice(probes, func(i, j int) bool { return probes[i].Probe < probes[j].Probe })
+	var totalUnanswered uint64
+	for _, p := range probes {
+		totalUnanswered += p.Unanswered
+	}
+	return struct {
+		CollectedFrom    string       `json:"collected_from"`
+		OutcomeRule      string       `json:"outcome_rule"`
+		Probes           []ProbeCount `json:"probes"`
+		TotalUnanswered  uint64       `json:"total_unanswered"`
+		UndeclaredKinds  uint64       `json:"undeclared_probe_kinds,omitempty"`
+		HerdrProbed      uint64       `json:"herdr_client_candidates_probed"`
+		HerdrAbandoned   uint64       `json:"herdr_client_candidates_abandoned_on_budget"`
+		UnansweredNote   string       `json:"unanswered_note,omitempty"`
+		UndeclaredNote   string       `json:"undeclared_probe_kinds_note,omitempty"`
+		HerdrAbandonNote string       `json:"herdr_abandonment_note,omitempty"`
+		MemoNote         string       `json:"memo_note"`
+		PlatformNote     string       `json:"platform_note,omitempty"`
+	}{
+		CollectedFrom:    "daemon",
+		OutcomeRule:      snap.OutcomeRule,
+		Probes:           probes,
+		TotalUnanswered:  totalUnanswered,
+		UndeclaredKinds:  snap.UndeclaredKinds,
+		HerdrProbed:      snap.HerdrCandidatesProbed,
+		HerdrAbandoned:   snap.HerdrCandidatesAbandonedOnBudget,
+		UnansweredNote:   unansweredProbeNote(probes),
+		UndeclaredNote:   undeclaredProbeKindsNote(snap.UndeclaredKinds),
+		HerdrAbandonNote: herdrAbandonmentNote(snap.HerdrCandidatesAbandonedOnBudget),
+		MemoNote: "memo_hits are calls a memo answered without starting a child (#1544), so they are NOT " +
+			"included in answered/unanswered — answered+unanswered is how often a child actually ran, and " +
+			"answered+unanswered+memo_hits is how often the probe was asked. Only ps.proc_info and " +
+			"plutil.bundle_id have a memo; a zero elsewhere means there is no memo, not that it never hit.",
+		PlatformNote: probePlatformNote(),
+	}
+}
+
+// unansweredProbeNote explains what a non-zero unanswered count means, and —
+// like silentChannelNote beside it — what it does not. Emitted only when
+// something actually went unanswered, so a healthy bundle keeps the terse rows
+// and no essay.
+func unansweredProbeNote(probes []ProbeCount) string {
+	var failing []string
+	for _, p := range probes {
+		if p.Unanswered > 0 {
+			failing = append(failing, fmt.Sprintf("%s (%d of %d runs)", p.Probe, p.Unanswered, p.Answered+p.Unanswered))
+		}
+	}
+	if len(failing) == 0 {
+		return ""
+	}
+	return "Probe(s) that did not answer: " + strings.Join(failing, ", ") +
+		". A non-answer is a child killed by its 2-second ceiling, killed by something else, or never " +
+		"started — never a tool that ran and reported nothing, which is an ANSWER and is counted as one. " +
+		"This matters most where the caller fails OPEN: IsKnownInteractiveHost (#1513/#1524) admits a " +
+		"session whose ancestry walk it could not complete, so a climbing count on ps.proc_info or " +
+		"plutil.bundle_id means the #784 admission gate is quietly not gating. Where the caller degrades " +
+		"instead (#1485/#1492/#1537), the cost is a host-window enrichment that stops resolving rather " +
+		"than a wrong one. Measured on one machine plutil stayed ~25x under its ceiling even at 12x CPU " +
+		"oversubscription, so if these counts are non-zero the trigger is something other than CPU " +
+		"pressure and this bundle is the first evidence of it."
+}
+
+// undeclaredProbeKindsNote fires only when the counters saw a probe kind
+// nothing declared — which means the rows above are incomplete, and a reader
+// must not have to work that out by noticing they do not add up.
+func undeclaredProbeKindsNote(n uint64) string {
+	if n == 0 {
+		return ""
+	}
+	return fmt.Sprintf("%d probe observation(s) named a kind that is not in the declared set, so the "+
+		"probes list above is INCOMPLETE and no row accounts for them. This is a wiring defect in the "+
+		"daemon, not a machine condition.", n)
+}
+
+// herdrAbandonmentNote fires only when the herdr client loop actually stopped
+// early on its aggregate budget (#1558). It is the one figure in this file
+// whose absence was the whole reason the issue could not be decided.
+func herdrAbandonmentNote(n uint64) string {
+	if n == 0 {
+		return ""
+	}
+	return fmt.Sprintf("The herdr client loop abandoned its remaining candidates %d time(s) because the "+
+		"aggregate budget (#1529) was already spent — normally because the lsof scan ahead of it ran "+
+		"slowly and still SUCCEEDED, which is the one window that bound does not cover. The answer is "+
+		"then \"I could not look\", which clears no stored host and is re-probed on the next sweep, so "+
+		"this is a deferred host-window recovery rather than a wrong answer (#1558).", n)
+}
+
+// probePlatformNote says out loud that these probes are macOS-only, so an
+// all-zero table on another platform reads as "this build starts no children"
+// rather than as a broken counter.
+func probePlatformNote() string {
+	if runtime.GOOS == "darwin" {
+		return ""
+	}
+	return "Every probe listed here is a macOS bounded shellout. On " + runtime.GOOS +
+		" the daemon reads the same process facts from /proc without starting a child, so these counters " +
+		"are structurally zero — that is this platform having no such probe, not a probe that never ran."
 }
 
 // entryReverificationNote spells out what the entry_reverification rows mean

--- a/core/application/services/diagnostics_service_test.go
+++ b/core/application/services/diagnostics_service_test.go
@@ -88,6 +88,12 @@ func buildTestService(t *testing.T) *DiagnosticsService {
 // --diagnose CLI (a process that served no hooks), non-nil is the daemon.
 func buildTestServiceWithHooks(t *testing.T, hookHealth func() HookHealthSnapshot) *DiagnosticsService {
 	t.Helper()
+	return buildTestServiceWith(t, hookHealth, nil)
+}
+
+// buildTestServiceWith wires both nil-meaningful snapshot sources explicitly.
+func buildTestServiceWith(t *testing.T, hookHealth func() HookHealthSnapshot, probeHealth func() ProbeHealthSnapshot) *DiagnosticsService {
+	t.Helper()
 	home := "/Users/test"
 	dir := t.TempDir()
 	instancesDir := filepath.Join(dir, "instances")
@@ -140,6 +146,7 @@ func buildTestServiceWithHooks(t *testing.T, hookHealth func() HookHealthSnapsho
 		Cfg:            cfg,
 		Version:        "9.9.9+test",
 		HookHealth:     hookHealth,
+		ProbeHealth:    probeHealth,
 		Paths: DiagnosticsPaths{
 			Home:            home,
 			InstancesDir:    instancesDir,
@@ -160,7 +167,7 @@ func TestWriteBundleContents(t *testing.T) {
 	for _, want := range []string{
 		"version.txt", "system.txt", "config.json", "permissions.json",
 		"state.json", "sessions.json", "liveness.json", "processes.json",
-		"hooks.json", "events.log", "instances/sess-a.json", "ledgers/abc.ledger.json",
+		"hooks.json", "probes.json", "events.log", "instances/sess-a.json", "ledgers/abc.ledger.json",
 	} {
 		if _, ok := files[want]; !ok {
 			t.Errorf("bundle missing %s (have %v)", want, keys(files))

--- a/core/cmd/irrlichd/daemon_smoke_test.go
+++ b/core/cmd/irrlichd/daemon_smoke_test.go
@@ -257,6 +257,7 @@ func assertBundleEndpoint(t *testing.T, client *http.Client, url string) {
 		t.Errorf("bundle from %s missing version.txt", url)
 	}
 	assertHooksCollectedInDaemon(t, url, entries["hooks.json"])
+	assertProbesCollectedInDaemon(t, url, entries["probes.json"])
 }
 
 // readBundleEntries decodes the gzip+tar bundle into name → contents.
@@ -305,6 +306,39 @@ func assertHooksCollectedInDaemon(t *testing.T, url string, raw []byte) {
 	}
 	if hooks.CollectedFrom != "daemon" {
 		t.Errorf("hooks.json collected_from = %q, want \"daemon\" — the running daemon did not wire its hook counters into the bundle", hooks.CollectedFrom)
+	}
+}
+
+// assertProbesCollectedInDaemon checks that the LIVE daemon's bundle reports
+// its probe counters as daemon-collected (issue #1534).
+//
+// It is the twin of assertHooksCollectedInDaemon and exists for the same
+// reason: the service's nil-ProbeHealth branch is a perfectly valid, perfectly
+// quiet output, so a daemon that forgot to wire liveProbeHealth would emit the
+// CLI form here and no unit test anywhere would notice. It is the only thing
+// that proves startup.go passes it.
+func assertProbesCollectedInDaemon(t *testing.T, url string, raw []byte) {
+	t.Helper()
+	if len(raw) == 0 {
+		t.Fatalf("bundle from %s missing probes.json", url)
+	}
+	var probes struct {
+		CollectedFrom string `json:"collected_from"`
+		Probes        []struct {
+			Probe string `json:"probe"`
+		} `json:"probes"`
+	}
+	if err := json.Unmarshal(raw, &probes); err != nil {
+		t.Fatalf("probes.json is not valid JSON: %v\n%s", err, raw)
+	}
+	if probes.CollectedFrom != "daemon" {
+		t.Errorf("probes.json collected_from = %q, want \"daemon\" — the running daemon did not wire its probe counters into the bundle", probes.CollectedFrom)
+	}
+	// A daemon form with no rows would satisfy the field above while carrying
+	// no measurement at all: the snapshot publishes every declared kind, so an
+	// empty list means the conversion in liveProbeHealth dropped them.
+	if len(probes.Probes) == 0 {
+		t.Errorf("probes.json reports itself as daemon-collected but carries no probe rows — every declared kind is published, including one that never ran")
 	}
 }
 

--- a/core/cmd/irrlichd/paths.go
+++ b/core/cmd/irrlichd/paths.go
@@ -103,8 +103,10 @@ func resolveSessionRepo() (*filesystem.SessionRepository, error) {
 // the (uncached) session list and the instances dir; ledger and log dirs honor
 // IRRLICHT_HOME via the same accessors the daemon writes through.
 // hookHealth is nil-meaningful: the daemon passes liveHookHealth, --diagnose
-// passes nil, and hooks.json reports which it got. See hooksView.
-func buildDiagnostics(fsRepo *filesystem.SessionRepository, allAgents []agent.Agent, cfg config.Config, hookHealth func() services.HookHealthSnapshot) *services.DiagnosticsService {
+// passes nil, and hooks.json reports which it got. See hooksView. probeHealth
+// (#1534) is nil-meaningful the same way and for a sharper reason — probesView
+// carries it.
+func buildDiagnostics(fsRepo *filesystem.SessionRepository, allAgents []agent.Agent, cfg config.Config, hookHealth func() services.HookHealthSnapshot, probeHealth func() services.ProbeHealthSnapshot) *services.DiagnosticsService {
 	home, _ := os.UserHomeDir()
 	ledgerDir, _ := metrics.LedgerDir()
 	logsDir, _ := logging.LogDir()
@@ -117,6 +119,7 @@ func buildDiagnostics(fsRepo *filesystem.SessionRepository, allAgents []agent.Ag
 		Cfg:            cfg,
 		Version:        Version,
 		HookHealth:     hookHealth,
+		ProbeHealth:    probeHealth,
 		Paths: services.DiagnosticsPaths{
 			Home:            home,
 			InstancesDir:    fsRepo.InstancesDir(),
@@ -150,6 +153,37 @@ func liveHookHealth(watchdog *services.HookLivenessWatchdog, verifier *services.
 				Adapter: row.Adapter,
 				Event:   row.Event,
 				Count:   row.Count,
+			})
+		}
+		return snap
+	}
+}
+
+// liveProbeHealth snapshots the in-process probe counters for the diagnostics
+// bundle (issue #1534). Only the daemon wires it, and the reason differs from
+// liveHookHealth's in the one way that matters: the --diagnose CLI is not a
+// process that served no hooks, it is a process that DOES run these probes —
+// building processes.json shells out to pgrep and lsof through the same
+// observer — so its counts are small, real, and about nothing but its own
+// bundle collection. probesView omits them rather than publishing numbers that
+// would look like the daemon's.
+func liveProbeHealth() func() services.ProbeHealthSnapshot {
+	return func() services.ProbeHealthSnapshot {
+		rows := processlifecycle.ProbeCounts()
+		herdr := processlifecycle.HerdrCandidates()
+		snap := services.ProbeHealthSnapshot{
+			Probes:                           make([]services.ProbeCount, 0, len(rows)),
+			OutcomeRule:                      processlifecycle.ProbeOutcomeRule(),
+			UndeclaredKinds:                  processlifecycle.UndeclaredProbeKinds(),
+			HerdrCandidatesProbed:            herdr.Probed,
+			HerdrCandidatesAbandonedOnBudget: herdr.AbandonedOnBudget,
+		}
+		for _, row := range rows {
+			snap.Probes = append(snap.Probes, services.ProbeCount{
+				Probe:      row.Probe,
+				Answered:   row.Answered,
+				Unanswered: row.Unanswered,
+				MemoHits:   row.MemoHits,
 			})
 		}
 		return snap
@@ -206,7 +240,14 @@ func runDiagnose() {
 	// nil hook health on purpose: this process has served no hooks, so its
 	// counters are structurally zero and publishing them would read as an
 	// all-clear. hooks.json says so and points at GET /debug/bundle.
-	if err := buildDiagnostics(fsRepo, agents.All(), cfg, nil).WriteBundle(f); err != nil {
+	//
+	// nil probe health on purpose too, and NOT for the same reason (#1534):
+	// this process does run probes — WriteBundle's own processes.json walk
+	// shells out through the observer — so its counters are non-zero and
+	// describe only that walk. Publishing them under the daemon's field names
+	// would be a plausible-looking number nobody would check. probes.json says
+	// so and points at GET /debug/bundle.
+	if err := buildDiagnostics(fsRepo, agents.All(), cfg, nil, nil).WriteBundle(f); err != nil {
 		log.Fatalf("diagnose: write bundle: %v", err)
 	}
 	abs, _ := filepath.Abs(out)

--- a/core/cmd/irrlichd/startup.go
+++ b/core/cmd/irrlichd/startup.go
@@ -418,7 +418,7 @@ func registerCoreRoutes(mux *http.ServeMux, deps registerCoreRoutesDeps) {
 	// per-PID liveness, trimmed logs, and config for bug reports. Localhost
 	// only — it carries session paths and (pre-redaction) process argv. Reads
 	// fsRepo directly for a fresh, uncached snapshot.
-	diagSvc := buildDiagnostics(deps.FSRepo, deps.AllAgents, deps.Cfg, liveHookHealth(deps.HookLiveness, deps.HookVerifier))
+	diagSvc := buildDiagnostics(deps.FSRepo, deps.AllAgents, deps.Cfg, liveHookHealth(deps.HookLiveness, deps.HookVerifier), liveProbeHealth())
 	mux.HandleFunc("GET /debug/bundle", localhostOnly(handleDiagnosticsBundle(diagSvc)))
 }
 


### PR DESCRIPTION
Closes #1534.

Every issue in the `#1485/#1492/#1513/#1524/#1533/#1537` family closes with the
same caveat: **nothing measures how often a probe fails to answer.** Three of
those fixes fail OPEN — `IsKnownInteractiveHost` admits on a walk it could not
complete, which is the right call on no evidence — so a probe failing constantly
and one that never fails produce the *same* observable daemon: the #784 gate
quietly stops gating with nothing anywhere to look at.

This adds a counter per probe kind and outcome, read into the diagnostics bundle
as `probes.json`, a sibling of `hooks.json`.

## What is counted, and where

**At `runProbe`**, which since #1547 is the only place in `processlifecycle`
that starts a child (`TestEveryChildProcessRunsThroughRunProbe`). One counting
site instead of eight, and a ninth probe is counted by existing rather than by
someone remembering. `runProbe` grew a `kind` parameter — a `shelloutCmd` closes
its arguments over, so there is nothing in `build` to derive one from — and
`TestEveryProbeSiteDeclaresItsOwnKind` grades what each site passes.

**Keyed per call site, not per tool.** `lsof` answers three questions here and
`ps` two. A count that cannot say *which* question stopped being answered is the
single-scalar failure #1364 already paid for. Eight kinds, one per site:
`ps.proc_info`, `ps.tty`, `plutil.bundle_id`, `lsof.cwd`, `lsof.writer`,
`lsof.herdr_clients`, `pgrep.discover`, `kitten.window`.

**ANSWERED means the child ran to a normal exit** — `shellout.Answered`'s
tool-independent half — and deliberately *not* each site's own exit-code
allowlist. An allowlist encodes what a particular normal exit MEANS to one call
site: policy, per-site by construction, and #1547 kept `runProbe` free of exactly
that. Folding it in would put a second copy of every site's policy in the
counter, able to drift from the code it describes. `probeOutcomeRule` carries the
argument and states the cost: for a tool with an allowlist, a
normal-but-not-allowlisted exit (`lsof` 2, `pgrep` 2) is counted answered while
its call site treats it as carrying no verdict — still the right reading for this
counter's question, since the probe *did* run. The case the fail-open gates
actually degrade on, a child killed by the 2s ceiling, lands on the unanswered
side in every spelling.

## The three changed premises

**#1547 (merged) made this dramatically cheaper — confirmed.** `runProbe` is the
sole run site; the signature change to `(ctx, kind, build)` is the whole cost.
The routing guard and its committed corpus stayed green: the corpus rows are
self-contained source strings the detector parses arity-agnostically, and the
live rule's vacuity floor still sees 9 run sites (8 `runProbe` calls + the one
`.Output()` inside it). The classification rule also stayed green — `runProbe`
now binds `err`, calls `observeProbe`, and returns it, which is propagation.

**#1544 (merged) added two memos — covered as a third outcome, not excluded.**
Its own hand-back flagged this: *"a memo now also hides how often the probe
runs."* A `plutil` served from `bundleIDMemo`, or a `ps` from `ancestryReads`,
starts no child and is invisible at `runProbe`. Reporting "N answered" while
silently excluding hits is exactly the misleading figure this issue exists to
prevent, so a hit is counted where it happens — in the memo, under the kind the
underlying read would have used — and published as `memo_hits`.
`answered + unanswered` is how often a child **ran** (the denominator the
non-answer rate is a fraction of); `+ memo_hits` is how often the probe was
**asked**. `memo_note` says so in the bundle. Only two probes have a memo, so a
zero elsewhere is a finding of nothing rather than an inability to look, and the
note says that too.

**#1529 (merged) added a fourth non-answer kind — covered.** #1558 asks for
exactly this and names it the measurement every other option needs
(*"count it first... cheapest, and it is the measurement every other option
needs"*). It is **not** a probe row and is deliberately kept off the
(kind, outcome) axis: no child process is involved, so calling it "unanswered"
would put a different kind of fact in a column whose meaning is fixed. It is
published beside them, with a `probed` denominator that #1558 does not ask for
and without which "12 abandoned" cannot be read at all — 12 out of 12 and 12 out
of 10,000 are different findings. A comment has been posted on #1558.

## The `--diagnose` distinction, and why it is one step stronger here

`hooks.json` omits counts under `--diagnose` because that process served no
hooks, so its counters are *structurally zero*. **That reason is false for
probes**, and stating it would teach the next reader something wrong: building
`processes.json` walks every adapter's matcher through the observer, which on
macOS shells out to `pgrep` and `lsof`.

Measured, by temporarily wiring `liveProbeHealth` into `runDiagnose` and running
the binary against an isolated `IRRLICHT_HOME`:

```
{"probe": "lsof.cwd",       "answered": 11, "unanswered": 0, "memo_hits": 0}
{"probe": "pgrep.discover", "answered": 11, "unanswered": 0, "memo_hits": 0}
```

So the CLI's counters are small, real, and about nothing but its own bundle
collection. Under the daemon's field names they would read as a measurement of
the daemon's probe health and would look *plausible* — worse than a zero, because
a zero announces itself. `probesView` therefore emits a different shape, and the
note says which reason applies:

```json
{
  "collected_from": "cli",
  "note": "Collected by `irrlichd --diagnose`, which is not the process that runs the daemon's probes, so the per-probe answered/unanswered counters are omitted rather than reported. Note they are NOT zero in this process: building processes.json shells out to pgrep and lsof through the same observer, so this process has a few counts of its own, describing nothing but its own bundle collection — which is why they are omitted rather than printed. For the daemon's real counts, fetch GET /debug/bundle from the running daemon."
}
```

## Behaviour preservation

The change is behaviour-preserving apart from the counters. What convinced me:

- Every production hunk is an added argument, an added counter call, or a
  comment — `git diff` on the four adapter files is 8 one-token argument
  additions, 4 counter calls, and prose. No classifier, polarity, ceiling,
  return value or control-flow edge moved.
- The counter reads the error *after* it is produced and never feeds it back:
  `observeProbe` returns nothing, and `runProbe` still returns the same
  `(out, err)` it always did.
- No call site's `probeAnswered` / `lsofProbeRan` call was touched, which is why
  the counter uses the tool-independent half rather than adopting any site's
  allowlist — adopting one would have been a second decision about that site.
- The two guards over these shellouts (`TestEveryChildProcessRunsThroughRunProbe`,
  `TestEveryBoundedShelloutClassifiesItsError`) and the whole
  `processlifecycle` suite are green at `-race -count=1` **and `-count=4`** —
  process-global counters are exactly the thing that breaks under repeat runs, so
  every assertion is a DELTA and no reset hook was needed.

## Mutation evidence — nine mutations, each seen red

Counters pass the moment they are written. Each mutation below was applied by
copy-aside, run, and restored by copy-back with a `git status --porcelain` diff
against a captured baseline (`RESTORED_CLEAN` after every one). No `git stash`,
no `git restore`, no `git checkout -- .`.

**M1 — `observeProbe` counts everything as answered.**

```
--- FAIL: TestProbeCounterSeparatesAnsweredFromUnanswered (0.03s)
    probecount_test.go:140: probe counters moved by map[ps.tty:{ps.tty 1 0 0}], want map[ps.tty:{ps.tty 0 1 0}] — a child that never started is the non-answer every issue in this family closed without a count of
--- FAIL: TestProbeCounterKeepsEachKindInItsOwnBucket (0.01s)
    probecount_test.go:168: probe counters moved by map[lsof.cwd:{lsof.cwd 1 0 0} lsof.writer:{lsof.writer 1 0 0}], want map[lsof.cwd:{lsof.cwd 0 1 0} lsof.writer:{lsof.writer 0 1 0}] — three lsof questions, three buckets: a shared one would report six failures against one name and diagnose neither
--- FAIL: TestProductionProbeSitesCountUnderTheirOwnKind/ps.tty (0.01s)
    probecount_darwin_test.go:44: probe counters moved by map[ps.tty:{ps.tty 1 0 0}], want map[ps.tty:{ps.tty 0 1 0}] — the counter must agree with the site's own probed bit on the case that matters
```

**M2 — the (kind, outcome) key collapses: `writerOfVia` passes `probeLsofCWD`.**
A *different* test, and only that one:

```
--- FAIL: TestEveryProbeSiteDeclaresItsOwnKind (0.01s)
    probecount_test.go:330: probeLsofCWD is passed by 2 call sites (process_darwin.go:83, process_darwin.go:126) — they share one bucket, so a climbing count cannot say which probe stopped answering. A kind names a call site; a genuinely shared one amends this rule in a reviewable diff.
    probecount_test.go:336: probeLsofWriter is declared but passed by no call site — it publishes a permanent zero row that no probe can ever move
```

**M3 — the `--diagnose` form publishes zeros instead of saying it cannot look.**
The most important one:

```
--- FAIL: TestProbesBundleOmitsCountsWhenNotCollectedInDaemon (0.00s)
    diagnostics_service_test.go:778: collected_from = daemon, want "cli"
    diagnostics_service_test.go:792: probes is present without a daemon to read it from: [map[answered:0 memo_hits:0 probe:lsof.cwd unanswered:0]]
    diagnostics_service_test.go:792: total_unanswered is present without a daemon to read it from: 0
    diagnostics_service_test.go:792: herdr_client_candidates_probed is present without a daemon to read it from: 0
    diagnostics_service_test.go:792: memo_note is present without a daemon to read it from: ...
    diagnostics_service_test.go:797: note does not say where the real evidence is: ""
    diagnostics_service_test.go:802: note must say that this process's counters are non-zero and describe its own collection, not that they are structurally zero: ""
```

**M4 — vacuity: every probe is counted as a non-answer *as well*.** A counter
that counts everything is indistinguishable from one that counts correctly until
something asserts the silence; `probesSince` returns only the rows that MOVED, so
a one-entry expectation is an exhaustive claim:

```
--- FAIL: TestProbeCounterSeparatesAnsweredFromUnanswered (0.02s)
    probecount_test.go:124: probe counters moved by map[ps.tty:{ps.tty 1 1 0}], want map[ps.tty:{ps.tty 1 0 0}] — a child that ran to a normal exit is an ANSWER, and is counted by nobody as a non-answer
--- FAIL: TestProductionProbeSitesCountUnderTheirOwnKind/lsof.writer (0.02s)
    probecount_darwin_test.go:86: probe counters moved by map[lsof.writer:{lsof.writer 1 1 0}], want map[lsof.writer:{lsof.writer 1 0 0}] — lsof's 'nothing to report' ran and answered; counting it as a non-answer would report a healthy machine as failing
```

**M5 — the daemon forgets to wire `liveProbeHealth`** (`startup.go` passes nil).
The service's nil branch is a perfectly valid, perfectly quiet output, so this is
the only thing that catches it:

```
--- FAIL: TestDaemonStartupSmoke/demo (1.62s)
    daemon_smoke_test.go:61: probes.json collected_from = "cli", want "daemon" — the running daemon did not wire its probe counters into the bundle
    daemon_smoke_test.go:61: probes.json reports itself as daemon-collected but carries no probe rows — every declared kind is published, including one that never ran
```

**M6 — a memo hit is folded into `answered`.**

```
--- FAIL: TestBundleIDMemoHitIsCounted (0.00s)
    probecount_darwin_test.go:130: probe counters moved by map[plutil.bundle_id:{plutil.bundle_id 1 0 0}], want map[plutil.bundle_id:{plutil.bundle_id 0 0 1}] — #1544's hand-back: a memo hides how often the probe RUNS, so a hit is its own outcome rather than an unreported one
--- FAIL: TestAncestryReadsMemoHitIsCounted (0.00s)
    probecount_test.go:203: probe counters moved by map[ps.proc_info:{ps.proc_info 1 0 0}], want map[ps.proc_info:{ps.proc_info 0 0 1}] — a ps served from ancestryReads is a call the probe was asked and never ran for; #1544's hand-back is that a memo hides exactly this
```

**M7 — budget abandonment is not counted** (`observeHerdrCandidatesAbandoned`
deleted):

```
--- FAIL: TestHerdrCandidateAbandonmentIsCounted/a_spent_budget_abandons_once_and_probes_nothing (0.00s)
    probecount_darwin_test.go:170: abandoned moved by 0, want 1 — one event per loop, not one per candidate left unread
```

**M8 — an observation naming an undeclared kind is silently dropped.** Dropping
it would make an uncounted probe indistinguishable from one that never ran —
this issue's own failure mode reproduced inside its fix:

```
--- FAIL: TestUndeclaredProbeKindIsCountedNotDropped (0.00s)
    probecount_test.go:220: undeclared observations = 0, want 2 — an unattributable probe must be reported, not swallowed
```

**M9 — the explanations fire unconditionally.** An explanation that always fires
explains nothing; a reader could not tell a machine with a failing probe from a
healthy one:

```
--- FAIL: TestProbesBundleStaysTerseWhenNothingIsWrong (0.00s)
    diagnostics_service_test.go:756: unanswered_note is present on a healthy machine: Probe(s) that did not answer: . A non-answer is ... — an explanation that always fires explains nothing
    diagnostics_service_test.go:756: herdr_abandonment_note is present on a healthy machine: The herdr client loop abandoned its remaining candidates 0 time(s) ... — an explanation that always fires explains nothing
```

### Which half of the coverage reaches which sites

Stated rather than left to be assumed. Four of the eight sites take an injected
builder, so the darwin runtime test drives them end to end (one per tool, and
both classifier polarities). The other four (`ps.proc_info`, `lsof.cwd`,
`lsof.herdr_clients`, `kitten.window`) take no builder, so what each of them
*passes* is graded statically by `TestEveryProbeSiteDeclaresItsOwnKind`, which
reads the package's own source with build tags ignored — the same reason the
shellout guard beside it parses rather than type-loads: every one of these sites
is behind `//go:build darwin`, and a type-aware load on a Linux runner would find
none of them and pass.

## Verification (all foreground)

- `go build ./core/...` and `GOOS=linux go build ./core/...` — pass
- `go test ./core/adapters/inbound/agents/processlifecycle/... -race -count=1` — pass (12.1s)
- same at `-race -count=4` — pass (45.2s), no reset hook needed
- `go test ./core/... -race -count=1` — pass, no failures
- `tools/preflight.sh --only go` — all 7 gates PASS
- `tools/preflight.sh --only arch` — PASS, composite 7.931881 → 7.932251 (no regression)
- `irrlichd --diagnose` run against an isolated `IRRLICHT_HOME`: emits the CLI
  form shown above.

The pre-push hook blew the 600s command budget on this `core/` diff (#1570); the
push was repeated with `--no-verify` **after** every gate above had passed in the
foreground, and the tracking branch was asserted afterwards.

## Found, not fixed

`readProcInfo` propagates **every** `ps` error, so an ANSWERED "no such process"
(`ps -o ppid=,comm= -p <reaped pid>` exits 1) aborts both ancestry walks with
`complete=false`, which makes `IsKnownInteractiveHost` fail open. `processTTYVia`
sits four hundred lines up in the same file and its doc comment argues explicitly
against that shape for its own `ps`: *"It exits 1 for a pid it cannot find
(measured), which is a real 'no such process', not a probe that did not run — so
the allowlist form would turn every reaped pid into a non-answer and poison
hostIdentity's completeness for it."*

Deliberately **not** touched here and **not** filed, because I could not
establish it is a defect rather than the chosen polarity: "the ancestor is gone"
genuinely leaves the walk unable to reach a verdict, fail-open is this gate's
declared direction for an unknown, and the practical exposure is small (the walk
terminates cleanly at `ppid <= 1`, so reaching a dead ancestor needs a PID to die
mid-walk). Read off the code, not reproduced. Flagging it rather than folding a
behaviour change into an observability PR — and this counter is now what would
show it, since a `ps.proc_info` count climbing on an otherwise idle machine is
the evidence that does not exist today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
