### PR TITLE
test(contracttesting): assert the two statements of each obligation's fixture agree

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -703,6 +703,51 @@ Before marking a ticket done, run the full suite — every layer must pass:
   corpus's own worst defect shipped and was caught in review: `testing.TB` sat
   in the must-NOT-flag block, so the rule's biggest hole came with an approved
   spelling.
+  Beside the seam walk sits `fixture_drift_test.go` (#1520), which closes the
+  direction the vacuity guards cannot see. Each obligation of a receiver-shaped
+  family states its fixture TWICE — once in the entry point's `t.Run` body,
+  which is what an adapter runs, and once in the self-test's `armBuilder`
+  table — and only the SELF-TEST side's drift was caught: a self-test that stops
+  posting the input its obligation grades goes silent against a
+  deliberately-wrong fixture and fails, while an ENTRY POINT that changes an
+  input leaves every self-test green, still certifying an input production no
+  longer posts. Measured, not argued: renaming the entry point's `in-tree`
+  subdirectory left the whole package green. Folding the two statements into one
+  source was rejected in #1512 and again in #1520 — those `t.Run` bodies are
+  what an adapter author reads to learn what their adapter owes — so the
+  duplication stays and an assertion removes the silence. Two rules over one
+  parse, both in the seam walk's shape. The **first** compares, per obligation,
+  the multiset of BASIC LITERALS the two bodies contain, which is where "a
+  different path spelling" actually lives and which an identifier-only rule
+  cannot see (`32` becoming `2` shortens the traversal below the point where it
+  bottoms out at `/`); the set of package-level identifiers declared in
+  NON-test files that each side references — the arm, the `what` constant its
+  failure prints, the fixture helper — where a self-test's own
+  `fakePathReceiver` and `receiverBreak` are test-declared and drop out by
+  construction rather than by an exemption list; and the obligation NAMES in
+  ORDER, which catches the one drift no input comparison can, a seventh
+  obligation reusing an existing arm, invisible to the seam walk's rule 2
+  because it introduces no new arm. The family list is derived from the
+  package-level `receiverFamily` vars, so a fourth receiver-shaped family is
+  graded by existing. Names the body BINDS are subtracted before the comparison
+  (the two sides legitimately call one path `inTree` and `spelled`), and the
+  declared limit is EXPRESSION STRUCTURE — two bodies holding the same pieces in
+  a different arrangement agree — pinned by a `want:false` corpus row. AST
+  equality was tried first and abandoned: the two sides already differ in ways
+  nobody should have to mirror, so it would have been red on arrival. The
+  **second** rule is #1520's smaller sibling: every `receiverBreak` knob must
+  still be SPENT by a negative self-test and HONOURED by the fixture, over a
+  knob set derived from the struct's fields plus the constants of every enum a
+  field is declared with — `confine` and `receipt` are single fields carrying
+  three and four distinct mutations, so a field-level rule would report
+  `confine` as spent while `confineAcceptUnresolvable` rotted. All 22 knobs were
+  spent when it was written; one, `receiptNever`, is honoured by matching NO
+  placement guard and is named in `knobsHonouredByAbsence` rather than left to
+  be inferred from the absence of a branch. Both rules' mutation evidence is
+  committed in `fixture_drift_corpus_test.go`, and it does NOT reach the four
+  non-receiver families: their entry points construct no per-obligation input
+  (`assertFloorParses(t, gate.Min)` grades a value the WIRING carries), so there
+  is no second statement to drift from.
   One further cost is worth knowing before writing a fifth family:
   `hookjson`'s distinct-name table retains `MaxUnknownEventNames` `(adapter,
   name)` pairs for the life of the process and never resets, so an obligation

--- a/core/internal/contracttesting/fixture_drift_corpus_test.go
+++ b/core/internal/contracttesting/fixture_drift_corpus_test.go
@@ -1,0 +1,572 @@
+// fixture_drift_corpus_test.go is fixture_drift_test.go's committed mutation
+// evidence, in the shape AGENTS.md asks for: one deliberately-wrong case per
+// thing the two rules claim to catch, kept in the tree rather than described in
+// a merged PR body that nothing re-runs.
+//
+// Both rules pass by construction against a package that has not drifted, which
+// is exactly the condition the mutation rule exists for — so their whole value
+// is that they CAN fail, and this file is where that is demonstrated.
+//
+// The must-NOT-report rows carry as much of the value as the must-report ones,
+// per #1450. A comparator that reported unconditionally would satisfy every
+// mutation below and read as thorough coverage, so every table here has a
+// vacuity row; and three rows pin DECLARED LIMITS rather than successes — the
+// reporter seam's two spellings, a self-test's own test-only scaffolding, and
+// (the one that matters) two bodies holding the same literals and the same
+// shared references in a different arrangement, which rule 1 cannot tell apart.
+// Pinning a limit is how it gets learned from a test instead of from an
+// incident.
+package contracttesting
+
+import (
+	"go/parser"
+	"go/token"
+	"strings"
+	"testing"
+)
+
+// --- building facts from synthetic sources ---
+
+// factsFromSources runs the real absorb over sources held as strings, so the
+// corpus grades the walk the package actually uses rather than a second reader
+// written to agree with it.
+//
+// Nothing is type-checked, only parsed: a corpus row references receiverBreak
+// and fakeReceiver without declaring them precisely because that is what a real
+// self-test does — those live in _test.go files and must drop out of the shared
+// vocabulary on their own.
+func factsFromSources(t *testing.T, sources map[string]string) fixtureFacts {
+	t.Helper()
+	f := newFixtureFacts()
+	fset := token.NewFileSet()
+	// Iterated in map order on purpose: absorb's result does not depend on which
+	// file it reaches first, which is exactly why resolveEnumKnobs runs after the
+	// whole walk rather than during it. A corpus that had to fix an order would
+	// be hiding that property instead of exercising it.
+	for name, src := range sources {
+		file, err := parser.ParseFile(fset, name, src, 0)
+		if err != nil {
+			t.Fatalf("parse corpus source %s: %v\n%s", name, err, src)
+		}
+		f.absorb(fset, name, strings.HasSuffix(name, "_test.go"), file)
+	}
+	f.resolveEnumKnobs()
+	return *f
+}
+
+// --- rule 1's corpus: extraction and comparison, end to end ---
+
+// corpusSharedDecls is the corpus's NON-test file, so everything it declares is
+// "shared" — the vocabulary both sides of an obligation must agree on. It mirrors
+// the real package's shape: an arm, a fixture helper, the `what` constants an
+// arm's failure prints, and the entry-point half of the reporter seam.
+const corpusSharedDecls = `package p
+
+type armT struct{}
+
+func realT(t *testing.T) armT { return armT{} }
+
+func assertRefused(t reporter, path, what string) {}
+
+func mkSubdir(t *testing.T, root, name string) string { return "" }
+
+const (
+	whatOutOfTree = "a well-formed transcript outside every declared root"
+	whatTraversal = "a path rooted in the declared tree that climbs out of it"
+
+	// inTree collides on purpose with a name the obligation bodies below bind
+	// as a LOCAL. Without it the row pinning that locals are subtracted would
+	// pass while proving nothing, because an identifier no non-test file
+	// declares drops out of both statements anyway.
+	inTree = "a package-level declaration the bodies below shadow"
+)
+`
+
+// statementRow is one corpus case: the entry point's t.Run bodies and the
+// self-test's armBuilder rows, verbatim, plus what the comparator must say.
+type statementRow struct {
+	name string
+
+	// entry is spliced into an AssertCorpus function body.
+	entry string
+
+	// self is spliced into the []armBuilder literal corpusArmBuilders returns.
+	self string
+
+	// want is a fragment of the message the comparator must report. Empty means
+	// it must stay SILENT — the vacuity and declared-limit rows.
+	want string
+
+	// why records what the row is evidence for, and appears in its failure.
+	why string
+}
+
+// corpusSources splices one row into the two files the walk reads.
+func corpusSources(row statementRow) map[string]string {
+	return map[string]string{
+		"shared.go": corpusSharedDecls,
+		"family_test.go": "package p\n\nfunc AssertCorpus(t *testing.T) {\n" + row.entry +
+			"}\n\nfunc corpusArmBuilders() []armBuilder {\n\treturn []armBuilder{\n" + row.self +
+			"\t}\n}\n\nvar corpusFamily = receiverFamily{entryPoint: \"AssertCorpus\", builders: corpusArmBuilders}\n",
+	}
+}
+
+// The obligation both sides state correctly, in the two spellings the real
+// package uses: the entry point binds the root and posts through realT, the
+// builder inlines the root, hoists the receiver and posts through armT.
+const (
+	corpusEntryInTree = `	t.Run("in_tree_path_accepted", func(t *testing.T) {
+		root := r.Root(t)
+		inTree := r.WriteTranscript(t, mkSubdir(t, root, "in-tree"))
+		assertRefused(realT(t), inTree, whatTraversal)
+	})
+`
+	corpusSelfInTree = `		{"in_tree_path_accepted", func(t *testing.T, brk receiverBreak) func(armT) {
+			r := fakeReceiver(brk)
+			inTree := r.WriteTranscript(t, mkSubdir(t, r.Root(t), "in-tree"))
+			return func(at armT) { assertRefused(at, inTree, whatTraversal) }
+		}},
+`
+	corpusEntryTraversal = `	t.Run("parent_traversal_rejected", func(t *testing.T) {
+		root := r.Root(t)
+		traversal := root + strings.Repeat("/..", 32)
+		assertRefused(realT(t), traversal, whatOutOfTree)
+	})
+`
+	corpusSelfTraversal = `		{"parent_traversal_rejected", func(t *testing.T, brk receiverBreak) func(armT) {
+			r := fakeReceiver(brk)
+			traversal := r.Root(t) + strings.Repeat("/..", 32)
+			return func(at armT) { assertRefused(at, traversal, whatOutOfTree) }
+		}},
+`
+)
+
+func statementRows() []statementRow {
+	return []statementRow{
+		{
+			name:  "an_undrifted_pair_is_passed",
+			entry: corpusEntryInTree + corpusEntryTraversal,
+			self:  corpusSelfInTree + corpusSelfTraversal,
+			why: "the vacuity guard. A comparator that reported unconditionally would satisfy every row below " +
+				"and read as excellent coverage. It also pins two DECLARED LIMITS at once, because the two sides " +
+				"here already differ: the entry point binds `root :=` where the builder inlines r.Root(t), and " +
+				"the builder names receiverBreak and fakeReceiver, which no entry point may reference",
+		},
+		{
+			name: "a_string_literal_changed_on_the_entry_side",
+			entry: `	t.Run("in_tree_path_accepted", func(t *testing.T) {
+		root := r.Root(t)
+		inTree := r.WriteTranscript(t, mkSubdir(t, root, "somewhere-else"))
+		assertRefused(realT(t), inTree, whatTraversal)
+	})
+`,
+			self: corpusSelfInTree,
+			want: "post different literals",
+			why: "#1520's headline failure, in its most literal form: the contract posts a path the self-tests " +
+				"stopped posting, and both stay green while the committed evidence attests to an input production " +
+				"no longer produces",
+		},
+		{
+			name: "an_int_literal_changed_on_the_entry_side",
+			entry: `	t.Run("parent_traversal_rejected", func(t *testing.T) {
+		root := r.Root(t)
+		traversal := root + strings.Repeat("/..", 2)
+		assertRefused(realT(t), traversal, whatOutOfTree)
+	})
+`,
+			self: corpusSelfTraversal,
+			want: "post different literals",
+			why: "a traversal shortened from 32 segments to 2 no longer bottoms out at \"/\", so the obligation " +
+				"grades a different input than the one the self-test's mutation was measured against. An " +
+				"identifier-only comparison would miss it entirely",
+		},
+		{
+			name: "a_shared_constant_swapped_on_the_entry_side",
+			entry: `	t.Run("parent_traversal_rejected", func(t *testing.T) {
+		root := r.Root(t)
+		traversal := root + strings.Repeat("/..", 32)
+		assertRefused(realT(t), traversal, whatTraversal)
+	})
+`,
+			self: corpusSelfTraversal,
+			want: "reference different shared declarations",
+			why: "the four refusal obligations share ONE arm and differ only in the `what` they print, which is " +
+				"the fragment a negative self-test matches on. An entry point that prints a neighbour's `what` " +
+				"leaves every self-test matching a message the contract no longer emits",
+		},
+		{
+			name: "a_shared_helper_dropped_on_the_entry_side",
+			entry: `	t.Run("in_tree_path_accepted", func(t *testing.T) {
+		root := r.Root(t)
+		inTree := r.WriteTranscript(t, root+"/"+"in-tree")
+		assertRefused(realT(t), inTree, whatTraversal)
+	})
+`,
+			self: corpusSelfInTree,
+			want: "reference different shared declarations",
+			why: "the entry point stops building through the shared fixture helper and hand-rolls the same thing. " +
+				"The two constructions may agree today and diverge on the next edit to the helper, which is the " +
+				"duplication this rule exists to keep honest",
+		},
+		{
+			name:  "an_obligation_only_the_entry_point_runs",
+			entry: corpusEntryInTree + corpusEntryTraversal,
+			self:  corpusSelfInTree,
+			want:  "states different obligations",
+			why: "the drift no per-input comparison can see: a seventh obligation added to a contract with no " +
+				"self-test driving it. The seam walk's rule 2 stays green because reusing an existing arm " +
+				"introduces no new arm for it to notice",
+		},
+		{
+			name: "an_obligation_renamed_on_one_side",
+			entry: `	t.Run("in_tree_path_still_accepted", func(t *testing.T) {
+		root := r.Root(t)
+		inTree := r.WriteTranscript(t, mkSubdir(t, root, "in-tree"))
+		assertRefused(realT(t), inTree, whatTraversal)
+	})
+`,
+			self: corpusSelfInTree,
+			want: "states different obligations",
+			why: "receiverFamily.drive looks an obligation up BY NAME and fatals when it misses, so a rename on " +
+				"the entry-point side would be found — but only for a name some self-test still asks for. A " +
+				"rename that nothing drives is silent without this",
+		},
+		{
+			name:  "two_obligations_swapped_in_order",
+			entry: corpusEntryTraversal + corpusEntryInTree,
+			self:  corpusSelfInTree + corpusSelfTraversal,
+			want:  "states different obligations",
+			why: "order is part of the statement: the confinement family's obligation 1 runs first precisely " +
+				"because everything below it is a negative assertion, and a receiver that has stopped working " +
+				"satisfies negative assertions perfectly",
+		},
+		{
+			name:  "a_keyed_builder_row_is_still_read",
+			entry: corpusEntryInTree,
+			self: `		{name: "in_tree_path_accepted", build: func(t *testing.T, brk receiverBreak) func(armT) {
+			r := fakeReceiver(brk)
+			inTree := r.WriteTranscript(t, mkSubdir(t, r.Root(t), "in-tree"))
+			return func(at armT) { assertRefused(at, inTree, whatTraversal) }
+		}},
+`,
+			why: "a DECLARED LIMIT avoided rather than accepted: builderRow reads the keyed spelling as well as " +
+				"the positional one, because a rule that quietly stopped matching when a table was rewritten in " +
+				"the other style would report \"no obligations\" for a reason unrelated to any drift",
+		},
+		{
+			name:  "the_two_sides_name_their_locals_differently",
+			entry: corpusEntryInTree,
+			self: `		{"in_tree_path_accepted", func(t *testing.T, brk receiverBreak) func(armT) {
+			r := fakeReceiver(brk)
+			spelled := r.WriteTranscript(t, mkSubdir(t, r.Root(t), "in-tree"))
+			return func(at armT) { assertRefused(at, spelled, whatTraversal) }
+		}},
+`,
+			why: "a false report this rule must not make. The real obligation 6 calls the same path inTree on one " +
+				"side and spelled on the other, and the corpus's shared file declares an inTree of its own so the " +
+				"collision is real rather than assumed — a name the body BINDS is a local, not a shared reference, " +
+				"and a rule that reported on it would be reporting a variable name as a fixture drift",
+		},
+		{
+			name: "the_same_literals_in_a_different_arrangement",
+			entry: `	t.Run("in_tree_path_accepted", func(t *testing.T) {
+		first := mkSubdir(t, r.Root(t), "linked")
+		second := mkSubdir(t, r.Root(t), "dangling")
+		assertRefused(realT(t), first+second, whatTraversal)
+	})
+`,
+			self: `		{"in_tree_path_accepted", func(t *testing.T, brk receiverBreak) func(armT) {
+			r := fakeReceiver(brk)
+			first := mkSubdir(t, r.Root(t), "dangling")
+			second := mkSubdir(t, r.Root(t), "linked")
+			return func(at armT) { assertRefused(at, first+second, whatTraversal) }
+		}},
+`,
+			why: "THE declared limit, pinned rather than left to be discovered. Rule 1 compares a multiset of " +
+				"literals and a set of shared references, not expression structure, so two bodies that use the " +
+				"same pieces differently agree as far as it is concerned. Structural comparison was tried and " +
+				"abandoned: the two sides legitimately differ in arrangement (see the vacuity row), so an " +
+				"AST-equality rule would have been red on arrival",
+		},
+		{
+			name: "an_entry_point_that_loops_over_its_obligations",
+			entry: `	for _, name := range []string{"in_tree_path_accepted"} {
+		t.Run(name, func(t *testing.T) {
+			root := r.Root(t)
+			inTree := r.WriteTranscript(t, mkSubdir(t, root, "in-tree"))
+			assertRefused(realT(t), inTree, whatTraversal)
+		})
+	}
+`,
+			self: corpusSelfInTree,
+			want: "states different obligations",
+			why: "extraction reads TOP-LEVEL t.Run calls only, so a looped entry point yields nothing. It is " +
+				"reported here as an empty obligation list; in the real rule the extraction guard fatals first, " +
+				"which is the loud failure a walk that cannot read its input owes (AGENTS.md)",
+		},
+	}
+}
+
+// TestStatementComparisonCatchesEveryKnownDrift is rule 1's committed mutation
+// evidence: one deliberately-drifted pair per shape it claims to catch, plus the
+// rows it must leave alone.
+func TestStatementComparisonCatchesEveryKnownDrift(t *testing.T) {
+	rows := statementRows()
+	if len(rows) == 0 {
+		t.Fatal("the corpus is empty, which grades nothing")
+	}
+	var reported, silent int
+	for _, row := range rows {
+		t.Run(row.name, func(t *testing.T) {
+			f := factsFromSources(t, corpusSources(row))
+			if len(f.families) != 1 {
+				t.Fatalf("the corpus source declares %d receiverFamily vars, want exactly 1 — the row would then grade nothing", len(f.families))
+			}
+			fam := f.families[0]
+			entry := obligationsOfEntryPoint(f.funcs[fam.entryPoint], f.shared)
+			self := obligationsOfBuilderTable(f.funcs[fam.builders], f.shared)
+			got := strings.Join(compareStatements(fam.varName, entry, self), "\n")
+
+			if row.want == "" {
+				if got != "" {
+					t.Fatalf("the comparator reported against a pair it must pass:\n%s\n\nthis row is evidence for: %s", got, row.why)
+				}
+				return
+			}
+			if got == "" {
+				t.Fatalf("the comparator said nothing about a pair that has drifted — this row is evidence for: %s", row.why)
+			}
+			if !strings.Contains(got, row.want) {
+				t.Fatalf("the comparator reported, but NOT on the drift under test: wanted a message containing %q, got:\n%s\n\nthis row is evidence for: %s",
+					row.want, got, row.why)
+			}
+		})
+		if row.want == "" {
+			silent++
+		} else {
+			reported++
+		}
+	}
+	// Both populations have to be non-empty. A corpus of only-reporting rows
+	// certifies a comparator that fires on everything; one of only-silent rows
+	// certifies one that fires on nothing.
+	if reported == 0 || silent == 0 {
+		t.Fatalf("the corpus has %d must-report and %d must-stay-silent rows — it needs both, or it grades a comparator that is constant", reported, silent)
+	}
+}
+
+// --- rule 2's corpus: knob extraction ---
+
+// TestKnobExtractionReadsEveryKnobAndNothingElse pins what a receiverBreak knob
+// IS, which is the half of rule 2 no violation table can reach: the rule grades
+// the knobs it was handed, and a walk that stopped collecting the enum constants
+// would hand it a short list and pass.
+//
+// The must-NOT-collect rows carry the value here. A field declared with a
+// builtin type contributes no enum — treating `bool` as one would make every
+// `true` in the package a knob — and a const block of a type no receiverBreak
+// field mentions is not a knob set at all.
+func TestKnobExtractionReadsEveryKnobAndNothingElse(t *testing.T) {
+	const source = `package p
+
+type confineOverride int
+
+const (
+	confineFaithful confineOverride = iota
+	confineRawPrefix
+	confineCleanedPrefix
+)
+
+type unrelatedEnum int
+
+const (
+	unrelatedZero unrelatedEnum = iota
+	unrelatedOne
+)
+
+type receiverBreak struct {
+	forwardCallersSpelling bool
+	confine                confineOverride
+	receipt                receiptPlacement
+}
+
+type receiptPlacement int
+
+const (
+	receiptAfterChannelConsent receiptPlacement = iota
+	receiptNever
+)
+`
+	f := factsFromSources(t, map[string]string{"fixture_test.go": source})
+
+	// The enum whose constants follow receiverBreak in the source is the point
+	// of resolving after the whole walk rather than during it: a field and its
+	// enum are declared in no guaranteed order.
+	want := map[string]bool{
+		"forwardCallersSpelling":     false,
+		"confine":                    false,
+		"receipt":                    false,
+		"confineFaithful":            true,
+		"confineRawPrefix":           false,
+		"confineCleanedPrefix":       false,
+		"receiptAfterChannelConsent": true,
+		"receiptNever":               false,
+	}
+	for name, correct := range want {
+		k, ok := f.knobs[name]
+		if !ok {
+			t.Errorf("%s was not collected as a knob — rule 2 would grade a short list and pass", name)
+			continue
+		}
+		if k.correct != correct {
+			t.Errorf("%s: collected with correct=%v, want %v — the FIRST constant of an enum is its zero value, "+
+				"i.e. the correct setting, and is the one knob no negative self-test may be required to name", name, k.correct, correct)
+		}
+	}
+	for _, name := range []string{"unrelatedZero", "unrelatedOne"} {
+		if _, ok := f.knobs[name]; ok {
+			t.Errorf("%s was collected as a knob, but no receiverBreak field is declared with its type — a rule that "+
+				"collects every typed constant in the package would demand a self-test for constants that are not mutations at all", name)
+		}
+	}
+	if f.knobEnums["bool"] {
+		t.Error("`bool` was collected as a knob enum — a receiverBreak field may be declared with a builtin type, " +
+			"and treating one as an enum would make every predeclared constant a knob")
+	}
+	if len(f.knobs) != len(want) {
+		t.Errorf("collected %d knobs from a source declaring %d, so something outside the table above was picked up: %v",
+			len(f.knobs), len(want), sortedKeys(f.knobs))
+	}
+}
+
+// --- rule 2's corpus: the violation table ---
+
+// knobRow is one synthetic knob-facts case.
+type knobRow struct {
+	name   string
+	facts  fixtureFacts
+	exempt knobExemptions
+	want   string
+	why    string
+}
+
+// knobFactsFor builds a fact set with one knob in a named state, so each row
+// below varies exactly one thing.
+func knobFactsFor(k knob, honoured, spent bool) fixtureFacts {
+	f := *newFixtureFacts()
+	f.knobs["probe"] = k
+	if honoured {
+		f.honoured["probe"] = true
+	}
+	if spent {
+		f.spent["probe"] = true
+	}
+	return f
+}
+
+func knobRows() []knobRow {
+	field := knob{where: "receiver_fixture_test.go:1", what: "field"}
+	setting := knob{where: "receiver_fixture_test.go:2", what: "setting of confineOverride"}
+	correct := knob{where: "receiver_fixture_test.go:3", what: "setting of confineOverride", correct: true}
+
+	return []knobRow{
+		{
+			name:  "a_knob_that_is_honoured_and_spent_is_passed",
+			facts: knobFactsFor(field, true, true),
+			why:   "the vacuity guard: a rule that reported unconditionally would satisfy every row below",
+		},
+		{
+			name:  "a_knob_no_self_test_spends_is_reported",
+			facts: knobFactsFor(field, true, false),
+			want:  "spent by no negative self-test",
+			why:   "#1520's smaller sibling: a committed mutation with no failure attached is evidence for nothing",
+		},
+		{
+			name:  "a_knob_no_fixture_honours_is_reported",
+			facts: knobFactsFor(field, false, true),
+			want:  "read by no fixture",
+			why: "the other end of the same death. A knob the fixture ignores builds a CORRECT receiver, so the " +
+				"case setting it goes through every motion and grades nothing",
+		},
+		{
+			name:  "an_enum_setting_no_self_test_spends_is_reported",
+			facts: knobFactsFor(setting, true, false),
+			want:  "spent by no negative self-test",
+			why: "the half a field-level rule misses: `confine` and `receipt` are single fields carrying three and " +
+				"four distinct mutations, so a field-level rule calls `confine` spent while one of its settings rots",
+		},
+		{
+			name:  "the_correct_setting_need_not_be_spent",
+			facts: knobFactsFor(correct, true, false),
+			why: "the zero value is what receiverBreak{} MEANS. Every family's vacuity guard spends it and no " +
+				"negative self-test names it, so requiring it would be requiring the correct setting to be a mutation",
+		},
+		{
+			name:  "the_correct_setting_must_still_be_honoured",
+			facts: knobFactsFor(correct, false, false),
+			want:  "read by no fixture",
+			why: "what stops the exemption above from being a silent skip: the zero value is exempt from being " +
+				"SPENT, not from naming a behaviour the receiver implements",
+		},
+		{
+			name:   "an_exempted_knob_is_passed",
+			facts:  knobFactsFor(field, true, false),
+			exempt: knobExemptions{unspent: map[string]string{"probe": "a reason"}},
+			why:    "an exemption with a reason is the reviewable escape hatch, the shape deferredToTheSeam uses",
+		},
+		{
+			name:   "an_exemption_with_a_blank_reason_is_reported",
+			facts:  knobFactsFor(field, true, false),
+			exempt: knobExemptions{unspent: map[string]string{"probe": ""}},
+			want:   "with no reason",
+			why:    "an exemption whose justification is blank is one nobody can review",
+		},
+		{
+			name:   "a_knob_honoured_by_absence_is_passed",
+			facts:  knobFactsFor(field, false, true),
+			exempt: knobExemptions{byAbsence: map[string]string{"probe": "a reason"}},
+			why: "receiptNever's shape: the fixture implements it by matching none of its placement guards, so no " +
+				"branch names it and a walk looking for the name cannot see it",
+		},
+		{
+			name:   "an_exemption_that_names_no_knob_is_reported",
+			facts:  knobFactsFor(field, true, true),
+			exempt: knobExemptions{unspent: map[string]string{"gone": "a reason"}},
+			want:   "which is no longer a receiverBreak knob",
+			why:    "an exemption that exempts nothing is a silent no-op, and these maps exist to be reviewed",
+		},
+	}
+}
+
+// TestKnobViolationsCatchesEveryKnownShape is rule 2's committed mutation
+// evidence.
+func TestKnobViolationsCatchesEveryKnownShape(t *testing.T) {
+	rows := knobRows()
+	var reported, silent int
+	for _, row := range rows {
+		t.Run(row.name, func(t *testing.T) {
+			got := strings.Join(knobViolations(row.facts, row.exempt), "\n")
+			if row.want == "" {
+				if got != "" {
+					t.Fatalf("the rule reported against a knob set it must pass:\n%s\n\nthis row is evidence for: %s", got, row.why)
+				}
+				return
+			}
+			if got == "" {
+				t.Fatalf("the rule said nothing about a dead knob — this row is evidence for: %s", row.why)
+			}
+			if !strings.Contains(got, row.want) {
+				t.Fatalf("the rule reported, but NOT on the shape under test: wanted a message containing %q, got:\n%s\n\nthis row is evidence for: %s",
+					row.want, got, row.why)
+			}
+		})
+		if row.want == "" {
+			silent++
+		} else {
+			reported++
+		}
+	}
+	if reported == 0 || silent == 0 {
+		t.Fatalf("the corpus has %d must-report and %d must-stay-silent rows — it needs both, or it grades a rule that is constant", reported, silent)
+	}
+}

--- a/core/internal/contracttesting/fixture_drift_test.go
+++ b/core/internal/contracttesting/fixture_drift_test.go
@@ -1,0 +1,779 @@
+// fixture_drift_test.go closes the direction the vacuity guards cannot see.
+//
+// Each obligation of a receiver-shaped family states its fixture TWICE: once in
+// the contract's own t.Run body, which is what a real adapter runs, and once in
+// the self-test's armBuilder table, which is what the negative self-tests drive.
+// The restatement is deliberate — those t.Run bodies are what an adapter author
+// reads to learn what their adapter owes, and #1512 declined to fold them into a
+// shared table for exactly that reason — but only ONE direction of drift is
+// caught today. A SELF-TEST that stops posting the input its obligation grades
+// goes silent against a deliberately-wrong fixture, and its own case fails. An
+// ENTRY POINT that changes an input does not: the contract goes on grading
+// adapters against the new input while the self-tests go on proving something
+// about the old one, both stay green, and the committed mutation evidence
+// quietly attests to an input production no longer posts (#1520).
+//
+// That is worse than a stale number — #1503's species, an artefact that
+// documents behaviour without being produced by it — because these self-tests
+// ARE the evidence the contracts can fail at all. Evidence that has detached
+// from what it certifies is indistinguishable from evidence that still holds.
+//
+// Two rules, over one parse of the package's own sources. Both follow
+// seam_walk_test.go's shape rather than inventing a second one: derive the
+// subject list from the code, keep the decision procedure in a pure function so
+// a committed corpus can pin its verdicts, and let an exemption carry a reason.
+//
+// # Rule 1 — the two statements agree, obligation by obligation
+//
+// TestTheEntryPointAndItsSelfTestsStateTheSameFixture takes the duplication as
+// given (acceptance option 2 of #1520) and removes the silence instead. For each
+// receiver-shaped family it compares, per obligation:
+//
+//   - the multiset of BASIC LITERALS the two bodies contain — the subdirectory
+//     name, the ".." repeat count, the event-name suffix, the symlink error
+//     format. This is where "a different path spelling, a different event name"
+//     actually lives;
+//   - the set of SHARED IDENTIFIERS each body references, where "shared" means
+//     declared at package level in a NON-test file: the arm it drives, the
+//     `what` constant its failure will print, the fixture helper it builds
+//     through, the logger type it hands over. Everything a self-test
+//     legitimately adds — fakePathReceiver, receiverBreak, its own locals — is
+//     declared in a _test.go and drops out by construction rather than by an
+//     exemption list;
+//   - the obligation NAMES, in order. That half catches the drift no per-input
+//     comparison can: an obligation added to the entry point that no self-test
+//     drives. Nothing else would notice, because the seam walk's rule 2 fires
+//     only when a new obligation also introduces a new ARM, and a seventh
+//     confinement obligation reusing assertRefused introduces none.
+//
+// The one legitimate asymmetry is the reporter seam itself — production passes
+// realT(t), a self-test passes the armT it was handed — and it is named in
+// seamAdapters rather than absorbed into a looser comparison.
+//
+// What it does NOT compare is expression STRUCTURE. Two bodies holding the same
+// literals and the same shared references in a different arrangement agree as
+// far as this rule is concerned; that limit is pinned by a want:false corpus row
+// rather than left to be discovered. Structural comparison was tried first and
+// abandoned: the two sides already differ in ways nobody should have to mirror —
+// the entry point binds `root := r.Root(t)` where the builder inlines it, and
+// obligation 6 calls the same path `inTree` on one side and `spelled` on the
+// other — so an AST-equality rule would have been red on arrival and could only
+// be made green by mandating a mirroring the code does not owe.
+//
+// # Rule 2 — every receiverBreak knob is still spent
+//
+// The smaller sibling from the same issue: a knob no self-test uses is dead
+// evidence with no failure attached, and nothing checked it. Two obligations per
+// knob, because a knob can die at either end. The fixture can stop HONOURING it
+// — the receiver ignores the field, so setting it yields a correct receiver and
+// the negative self-test that sets it grades nothing while still going through
+// the motions. Or a self-test can stop SPENDING it, which is the committed
+// mutation nothing runs.
+//
+// The knob set is derived, never listed: every field of receiverBreak, plus
+// every constant of every enum type a receiverBreak field is declared with. The
+// second half matters more than it looks — `confine` and `receipt` are single
+// fields carrying three and four distinct mutations, so a field-level rule would
+// report `confine` as spent while confineAcceptUnresolvable rotted.
+package contracttesting
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// unspentKnobs names any receiverBreak knob deliberately not driven by a
+// negative self-test, with the reason it is not.
+//
+// Deliberately empty, and it has to stay reviewable when it is not: an entry is
+// a claim that a committed mutation is worth keeping while nothing runs it,
+// which is the shape #1479 exists to refuse. Its keys are existence-checked
+// below, the same way deferredToTheSeam's are, so an entry that stopped naming a
+// real knob fails rather than exempting nothing.
+var unspentKnobs = map[string]string{}
+
+// knobsHonouredByAbsence names every knob the fixture implements by matching
+// NOTHING, so a walk looking for the knob's own name cannot see it.
+//
+// One entry, and it is worth reading rather than skipping: receiptNever is the
+// receiver that forgets to count entirely, and the fixture expresses that by
+// having serve and dispatch each guard their placement with an `if` that this
+// setting matches none of. Naming it here is the same trade deferredToTheSeam
+// makes — the knowledge a walk cannot derive is written down and
+// existence-checked, rather than being inferred by the next reader from the
+// absence of a branch.
+var knobsHonouredByAbsence = map[string]string{
+	"receiptNever": "the receiver that forgets entirely — it is honoured by matching none of serve's " +
+		"and dispatch's placement guards, so no branch names it (#1413, #1497).",
+}
+
+// seamAdapters are the two spellings of the reporter seam, and the ONE
+// legitimate asymmetry between an entry point's statement of a fixture and a
+// self-test's. Production wires an arm with realT(t); a self-test hands it the
+// armT it was given. Neither says anything about the fixture, so both are
+// dropped before the statements are compared.
+//
+// Named here rather than absorbed into a looser comparison, because the whole
+// value of rule 1 is that everything else has to match.
+var seamAdapters = map[string]bool{"realT": true, "armT": true}
+
+// --- the walk ---
+
+// fixtureFacts is everything both rules need, from one parse.
+type fixtureFacts struct {
+	// knobs maps every receiverBreak knob to what is known about it. Populated
+	// in two passes: the fields during the walk, the enum constants afterwards,
+	// because a field and its enum are declared in no guaranteed order.
+	knobs map[string]knob
+
+	// knobEnums is every named, non-builtin type a receiverBreak field is
+	// declared with.
+	knobEnums map[string]bool
+
+	// enumConsts is every typed constant in the package, in declaration order,
+	// filtered against knobEnums once the walk is done.
+	enumConsts []enumConst
+
+	// honoured is every identifier appearing in a function BODY of a _test.go
+	// that does NOT drive obligations — the fixture and the wirings. A knob the
+	// fixture never reads is a knob whose mutation produces a correct receiver.
+	//
+	// Bodies rather than whole files, because a struct field's declaration and a
+	// const spec are not bodies: a knob that is merely declared would otherwise
+	// count as honoured by its own definition, which is the vacuity this rule
+	// exists to refuse.
+	honoured map[string]bool
+
+	// spent is every identifier mentioned in a _test.go that also mentions
+	// mustReport — the same seeding rule seam_walk_test.go's rule 2 uses, and it
+	// carries the same property: being NAMED by a positive test is not being
+	// DRIVEN by a negative one.
+	spent map[string]bool
+
+	// shared is every name declared at package level in a NON-test file: the
+	// vocabulary an entry point and a self-test must agree on. Test-file
+	// declarations are excluded on purpose, because that is exactly the set a
+	// self-test may legitimately reference and an entry point may not.
+	shared map[string]bool
+
+	// families is one row per package-level receiverFamily var, so a fourth
+	// receiver-shaped family is graded by existing rather than by being added to
+	// a table here.
+	families []familyStatement
+
+	// funcs maps a function name to its declaration, across every file.
+	funcs map[string]*ast.FuncDecl
+}
+
+// knob is one committed receiverBreak mutation knob.
+type knob struct {
+	// where is the file:line it is declared at.
+	where string
+
+	// what names the knob's kind for a failure message.
+	what string
+
+	// correct marks the zero value of an enum knob — the CORRECT setting, spent
+	// by every family's vacuity guard through receiverBreak{} and therefore
+	// never named by a negative self-test.
+	correct bool
+}
+
+// enumConst is one typed constant, before it is known whether its type is a
+// receiverBreak knob enum.
+type enumConst struct {
+	name  string
+	typ   string
+	where string
+}
+
+// familyStatement is one receiverFamily var: the entry point it names and the
+// builder table it drives.
+type familyStatement struct {
+	varName    string
+	entryPoint string
+	builders   string
+}
+
+// newFixtureFacts allocates every map absorb writes into. It exists so the
+// corpus can build facts from synthetic sources through the same absorb the real
+// walk uses, rather than through a second reader that could disagree with it.
+func newFixtureFacts() *fixtureFacts {
+	return &fixtureFacts{
+		knobs:     map[string]knob{},
+		knobEnums: map[string]bool{},
+		honoured:  map[string]bool{},
+		spent:     map[string]bool{},
+		shared:    map[string]bool{},
+		funcs:     map[string]*ast.FuncDecl{},
+	}
+}
+
+func parseFixtureFacts(t *testing.T, dir string) fixtureFacts {
+	t.Helper()
+	f := newFixtureFacts()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read %s: %v", dir, err)
+	}
+	fset := token.NewFileSet()
+	var sawTest, sawNonTest bool
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasSuffix(name, ".go") {
+			continue
+		}
+		file, err := parser.ParseFile(fset, filepath.Join(dir, name), nil, 0)
+		if err != nil {
+			t.Fatalf("parse %s: %v", name, err)
+		}
+		isTest := strings.HasSuffix(name, "_test.go")
+		sawTest = sawTest || isTest
+		sawNonTest = sawNonTest || !isTest
+		f.absorb(fset, name, isTest, file)
+	}
+	// A walk that read nothing satisfies both rules perfectly — the same refusal
+	// parseSeamFacts makes, for the same reason (AGENTS.md: a verification
+	// mechanism must fail loudly when it cannot run).
+	if !sawNonTest || !sawTest {
+		t.Fatalf("the walk read %v non-test and %v test files — a parse that finds nothing satisfies every rule below", sawNonTest, sawTest)
+	}
+	f.resolveEnumKnobs()
+	return *f
+}
+
+// absorb records everything one file contributes.
+func (f *fixtureFacts) absorb(fset *token.FileSet, name string, isTest bool, file *ast.File) {
+	driving := identsIn(file)["mustReport"]
+	for _, decl := range file.Decls {
+		switch d := decl.(type) {
+		case *ast.FuncDecl:
+			f.funcs[d.Name.Name] = d
+			if !isTest && d.Recv == nil {
+				f.shared[d.Name.Name] = true
+			}
+			if isTest && !driving && d.Body != nil {
+				for id := range identsIn(d.Body) {
+					f.honoured[id] = true
+				}
+			}
+		case *ast.GenDecl:
+			f.absorbGenDecl(fset, name, isTest, d)
+		}
+	}
+	if isTest && driving {
+		for id := range identsIn(file) {
+			f.spent[id] = true
+		}
+	}
+}
+
+// absorbGenDecl records one file's type, const and var declarations: the shared
+// vocabulary, receiverBreak's fields and enums, and the receiverFamily rows.
+func (f *fixtureFacts) absorbGenDecl(fset *token.FileSet, file string, isTest bool, d *ast.GenDecl) {
+	// inherited is per-block state: inside one const block a spec with no type
+	// of its own inherits the last one named, which is how an iota enum is
+	// spelled and the reason a constant's type cannot be read off its own spec.
+	var inherited string
+	for _, spec := range d.Specs {
+		switch s := spec.(type) {
+		case *ast.TypeSpec:
+			if !isTest {
+				f.shared[s.Name.Name] = true
+			}
+			if st, ok := s.Type.(*ast.StructType); ok && s.Name.Name == "receiverBreak" {
+				f.absorbKnobFields(fset, file, st)
+			}
+		case *ast.ValueSpec:
+			if s.Type != nil {
+				inherited = ""
+				if id, ok := s.Type.(*ast.Ident); ok {
+					inherited = id.Name
+				}
+			}
+			for _, n := range s.Names {
+				if !isTest {
+					f.shared[n.Name] = true
+				}
+			}
+			if d.Tok == token.CONST && inherited != "" {
+				for _, n := range s.Names {
+					f.enumConsts = append(f.enumConsts, enumConst{name: n.Name, typ: inherited, where: where(fset, file, n.Pos())})
+				}
+			}
+			if d.Tok == token.VAR {
+				f.absorbFamily(s)
+			}
+		}
+	}
+}
+
+// absorbKnobFields records receiverBreak's fields, and the enum types its fields
+// are declared with so their constants can be collected as knobs too.
+func (f *fixtureFacts) absorbKnobFields(fset *token.FileSet, file string, st *ast.StructType) {
+	for _, field := range st.Fields.List {
+		for _, n := range field.Names {
+			f.knobs[n.Name] = knob{where: where(fset, file, n.Pos()), what: "field"}
+		}
+		if id, ok := field.Type.(*ast.Ident); ok && !isBuiltinType(id.Name) {
+			f.knobEnums[id.Name] = true
+		}
+	}
+}
+
+// resolveEnumKnobs turns the collected typed constants into knobs, keeping only
+// those whose type a receiverBreak field is declared with. The FIRST constant of
+// each such type is the zero value, i.e. the correct setting.
+func (f *fixtureFacts) resolveEnumKnobs() {
+	seen := map[string]bool{}
+	for _, c := range f.enumConsts {
+		if !f.knobEnums[c.typ] {
+			continue
+		}
+		f.knobs[c.name] = knob{where: c.where, what: "setting of " + c.typ, correct: !seen[c.typ]}
+		seen[c.typ] = true
+	}
+}
+
+// absorbFamily records one package-level receiverFamily var.
+func (f *fixtureFacts) absorbFamily(s *ast.ValueSpec) {
+	for i, v := range s.Values {
+		lit, ok := v.(*ast.CompositeLit)
+		if !ok || i >= len(s.Names) {
+			continue
+		}
+		if id, ok := lit.Type.(*ast.Ident); !ok || id.Name != "receiverFamily" {
+			continue
+		}
+		row := familyStatement{varName: s.Names[i].Name}
+		for _, elt := range lit.Elts {
+			kv, ok := elt.(*ast.KeyValueExpr)
+			if !ok {
+				continue
+			}
+			key, ok := kv.Key.(*ast.Ident)
+			if !ok {
+				continue
+			}
+			switch key.Name {
+			case "entryPoint":
+				row.entryPoint = stringLit(kv.Value)
+			case "builders":
+				if id, ok := kv.Value.(*ast.Ident); ok {
+					row.builders = id.Name
+				}
+			}
+		}
+		f.families = append(f.families, row)
+	}
+}
+
+func where(fset *token.FileSet, file string, pos token.Pos) string {
+	return file + ":" + strconv.Itoa(fset.Position(pos).Line)
+}
+
+// isBuiltinType reports whether name is a predeclared type. A receiverBreak
+// field declared with one carries no constants to collect, and treating `bool`
+// as an enum would make every `true` in the package a knob.
+func isBuiltinType(name string) bool {
+	switch name {
+	case "bool", "string", "int", "int8", "int16", "int32", "int64",
+		"uint", "uint8", "uint16", "uint32", "uint64", "uintptr",
+		"float32", "float64", "complex64", "complex128",
+		"byte", "rune", "error", "any":
+		return true
+	}
+	return false
+}
+
+// stringLit unquotes a string literal expression, or returns "".
+func stringLit(e ast.Expr) string {
+	lit, ok := e.(*ast.BasicLit)
+	if !ok || lit.Kind != token.STRING {
+		return ""
+	}
+	s, err := strconv.Unquote(lit.Value)
+	if err != nil {
+		return ""
+	}
+	return s
+}
+
+// --- rule 1: the two statements agree ---
+
+// obligation is one obligation's fixture statement, as ONE side states it.
+type obligation struct {
+	name string
+
+	// literals is the multiset of basic literals the body contains, sorted. A
+	// multiset rather than a set because "posted twice" and "posted once" are
+	// different statements.
+	literals []string
+
+	// shared is the set of package-level, non-test identifiers the body
+	// references, sorted.
+	shared []string
+}
+
+// statementOf reads one obligation's fixture statement out of a body.
+func statementOf(name string, body ast.Node, shared map[string]bool) obligation {
+	ob := obligation{name: name}
+	local := localsIn(body)
+	set := map[string]bool{}
+	ast.Inspect(body, func(n ast.Node) bool {
+		switch n := n.(type) {
+		case *ast.BasicLit:
+			// The kind is part of the key so the string "32" and the integer 32
+			// are not the same statement.
+			ob.literals = append(ob.literals, n.Kind.String()+" "+n.Value)
+		case *ast.Ident:
+			if shared[n.Name] && !seamAdapters[n.Name] && !local[n.Name] {
+				set[n.Name] = true
+			}
+		}
+		return true
+	})
+	slices.Sort(ob.literals)
+	ob.shared = sortedKeys(set)
+	return ob
+}
+
+// localsIn is every name the body binds itself: `x :=`, a var/const spec, a
+// parameter, a range variable.
+//
+// They are subtracted because the two sides legitimately name their locals
+// differently — obligation 6 calls the same path inTree on one side and spelled
+// on the other — so a local that happens to collide with a package-level
+// declaration would otherwise appear in one statement and not the other, and
+// rule 1 would report a drift that is only a variable name. That is the one
+// direction a false report is expensive in: this package's whole subject is
+// evidence you can trust.
+func localsIn(body ast.Node) map[string]bool {
+	out := map[string]bool{}
+	add := func(exprs []ast.Expr) {
+		for _, e := range exprs {
+			if id, ok := e.(*ast.Ident); ok {
+				out[id.Name] = true
+			}
+		}
+	}
+	ast.Inspect(body, func(n ast.Node) bool {
+		switch n := n.(type) {
+		case *ast.AssignStmt:
+			if n.Tok == token.DEFINE {
+				add(n.Lhs)
+			}
+		case *ast.ValueSpec:
+			for _, id := range n.Names {
+				out[id.Name] = true
+			}
+		case *ast.RangeStmt:
+			add([]ast.Expr{n.Key, n.Value})
+		case *ast.FuncLit:
+			for _, p := range n.Type.Params.List {
+				for _, id := range p.Names {
+					out[id.Name] = true
+				}
+			}
+		}
+		return true
+	})
+	return out
+}
+
+// obligationsOfEntryPoint reads the entry point's statement: one obligation per
+// top-level t.Run("name", func…) in its body.
+//
+// TOP-LEVEL statements only, rather than an ast.Inspect over the whole function.
+// A nested t.Run belongs to the obligation that opened it, not to the family,
+// and folding it in would silently invent an obligation the builder table has no
+// row for. An entry point that moved its t.Run calls into a loop yields nothing
+// here and trips the extraction guard rather than passing quietly.
+func obligationsOfEntryPoint(fn *ast.FuncDecl, shared map[string]bool) []obligation {
+	var out []obligation
+	if fn == nil || fn.Body == nil {
+		return nil
+	}
+	for _, stmt := range fn.Body.List {
+		expr, ok := stmt.(*ast.ExprStmt)
+		if !ok {
+			continue
+		}
+		call, ok := expr.X.(*ast.CallExpr)
+		if !ok || len(call.Args) != 2 {
+			continue
+		}
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok || sel.Sel.Name != "Run" {
+			continue
+		}
+		name := stringLit(call.Args[0])
+		lit, ok := call.Args[1].(*ast.FuncLit)
+		if !ok || name == "" {
+			continue
+		}
+		out = append(out, statementOf(name, lit.Body, shared))
+	}
+	return out
+}
+
+// obligationsOfBuilderTable reads the self-test's statement: one obligation per
+// armBuilder element of the slice the builders function returns.
+func obligationsOfBuilderTable(fn *ast.FuncDecl, shared map[string]bool) []obligation {
+	var out []obligation
+	if fn == nil || fn.Body == nil {
+		return nil
+	}
+	ast.Inspect(fn.Body, func(n ast.Node) bool {
+		lit, ok := n.(*ast.CompositeLit)
+		if !ok {
+			return true
+		}
+		arr, ok := lit.Type.(*ast.ArrayType)
+		if !ok {
+			return true
+		}
+		if id, ok := arr.Elt.(*ast.Ident); !ok || id.Name != "armBuilder" {
+			return true
+		}
+		for _, elt := range lit.Elts {
+			row, ok := elt.(*ast.CompositeLit)
+			if !ok {
+				continue
+			}
+			name, body := builderRow(row)
+			if name == "" || body == nil {
+				continue
+			}
+			out = append(out, statementOf(name, body, shared))
+		}
+		return false
+	})
+	return out
+}
+
+// builderRow reads one armBuilder element, keyed or positional. Both spellings
+// are read rather than one being mandated: a rule that quietly stops matching
+// when a table is rewritten in the other style reports "no obligations" for a
+// reason unrelated to any drift.
+func builderRow(row *ast.CompositeLit) (string, ast.Node) {
+	var name string
+	var body ast.Node
+	for i, elt := range row.Elts {
+		value := elt
+		field := ""
+		if kv, ok := elt.(*ast.KeyValueExpr); ok {
+			value = kv.Value
+			if id, ok := kv.Key.(*ast.Ident); ok {
+				field = id.Name
+			}
+		} else if i == 0 {
+			field = "name"
+		} else if i == 1 {
+			field = "build"
+		}
+		switch field {
+		case "name":
+			name = stringLit(value)
+		case "build":
+			if lit, ok := value.(*ast.FuncLit); ok {
+				body = lit.Body
+			}
+		}
+	}
+	return name, body
+}
+
+// compareStatements reports every way the two statements of one family's
+// obligations disagree, or nil when they agree.
+//
+// It is a pure function over the extracted statements so a committed corpus can
+// pin its verdicts — including the ones it must NOT return. A comparator that
+// reported unconditionally would satisfy every mutation and read as thorough.
+func compareStatements(family string, entry, self []obligation) []string {
+	var out []string
+	entryNames, selfNames := obligationNames(entry), obligationNames(self)
+	if !slices.Equal(entryNames, selfNames) {
+		return []string{fmt.Sprintf("%s states different obligations on its two sides:\n  the entry point: %v\n  the self-tests:  %v\n"+
+			"An obligation the entry point runs and no self-test drives has no evidence it can fail; one a self-test drives and the "+
+			"entry point no longer runs is evidence for nothing (#1520)", family, entryNames, selfNames)}
+	}
+	for i := range entry {
+		e, s := entry[i], self[i]
+		if !slices.Equal(e.literals, s.literals) {
+			out = append(out, fmt.Sprintf("%s/%s: the two sides post different literals:\n  the entry point: %v\n  the self-tests:  %v\n"+
+				"The self-tests' committed mutation evidence is about an input the contract no longer posts",
+				family, e.name, e.literals, s.literals))
+		}
+		if !slices.Equal(e.shared, s.shared) {
+			out = append(out, fmt.Sprintf("%s/%s: the two sides reference different shared declarations:\n  the entry point: %v\n  the self-tests:  %v\n"+
+				"Both sides must drive the same arm, through the same fixture helpers, against the same message constants",
+				family, e.name, e.shared, s.shared))
+		}
+	}
+	return out
+}
+
+func obligationNames(obs []obligation) []string {
+	out := make([]string, 0, len(obs))
+	for _, ob := range obs {
+		out = append(out, ob.name)
+	}
+	return out
+}
+
+// TestTheEntryPointAndItsSelfTestsStateTheSameFixture is rule 1.
+func TestTheEntryPointAndItsSelfTestsStateTheSameFixture(t *testing.T) {
+	f := parseFixtureFacts(t, ".")
+	if len(f.families) == 0 {
+		t.Fatal("no package-level receiverFamily var was found — either the receiver-shaped families are gone or the walk is not reading the package")
+	}
+
+	for _, fam := range f.families {
+		t.Run(fam.varName, func(t *testing.T) {
+			entryFn, ok := f.funcs[fam.entryPoint]
+			if !ok {
+				t.Fatalf("%s names entry point %q, which this package does not declare", fam.varName, fam.entryPoint)
+			}
+			buildersFn, ok := f.funcs[fam.builders]
+			if !ok {
+				t.Fatalf("%s names builder table %q, which this package does not declare", fam.varName, fam.builders)
+			}
+
+			entry := obligationsOfEntryPoint(entryFn, f.shared)
+			self := obligationsOfBuilderTable(buildersFn, f.shared)
+			// Extraction guards first. "The two sides agree" is trivially true of
+			// two empty statements, and an extractor that stopped matching would
+			// report exactly that (AGENTS.md: a verification mechanism must fail
+			// loudly when it cannot run).
+			if len(entry) == 0 {
+				t.Fatalf("no t.Run obligation was extracted from %s — the rule below would pass by finding nothing", fam.entryPoint)
+			}
+			if len(self) == 0 {
+				t.Fatalf("no armBuilder row was extracted from %s — the rule below would pass by finding nothing", fam.builders)
+			}
+			if !slices.ContainsFunc(entry, func(ob obligation) bool { return len(ob.literals) > 0 }) {
+				t.Fatalf("not one obligation of %s carries a literal — every input this rule exists to compare has vanished from the extraction, "+
+					"which is indistinguishable from two sides that agree", fam.entryPoint)
+			}
+
+			for _, msg := range compareStatements(fam.varName, entry, self) {
+				t.Error(msg)
+			}
+		})
+	}
+}
+
+// --- rule 2: every receiverBreak knob is still spent ---
+
+// knobExemptions carries the two exemption maps rule 2 consults, so the corpus
+// can drive the rule against a set of its own.
+type knobExemptions struct {
+	unspent   map[string]string
+	byAbsence map[string]string
+}
+
+// knobViolations reports every way f's knob set has gone dead, or nil when every
+// knob is both honoured and spent.
+//
+// Pure over the extracted facts, for the reason compareStatements is: the corpus
+// drives it against synthetic fact sets, including ones it must pass.
+//
+// The two obligations are not redundant, and it is worth saying why the SPENT
+// half does not subsume the HONOURED half. `spent` is reference-based — any
+// mention of the knob in a file that drives obligations, the same
+// over-approximation seam_walk_test.go's rule 2 makes and for the same reason —
+// so a knob left behind in a table or a comment-adjacent expression counts as
+// spent while nothing sets it. `honoured` grades the other end: a knob no
+// fixture reads is one whose mutation builds a CORRECT receiver, so the case
+// spending it goes through every motion and grades nothing.
+func knobViolations(f fixtureFacts, exempt knobExemptions) []string {
+	var out []string
+	for _, name := range sortedKeys(f.knobs) {
+		out = append(out, knobViolation(f, exempt, name)...)
+	}
+	out = append(out, danglingExemptions(f, "unspentKnobs", exempt.unspent)...)
+	out = append(out, danglingExemptions(f, "knobsHonouredByAbsence", exempt.byAbsence)...)
+	return out
+}
+
+// knobViolation grades one knob against both obligations.
+func knobViolation(f fixtureFacts, exempt knobExemptions, name string) []string {
+	var out []string
+	k := f.knobs[name]
+	if !f.honoured[name] {
+		if reason, ok := exempt.byAbsence[name]; !ok {
+			out = append(out, fmt.Sprintf("receiverBreak knob %s (%s, %s) is read by no fixture — a mutation that sets it builds a CORRECT "+
+				"receiver, so the case spending it goes through every motion and grades nothing. Honour it in the fixture, delete it, or "+
+				"name it in knobsHonouredByAbsence with the reason (#1520)", name, k.what, k.where))
+		} else if reason == "" {
+			out = append(out, blankExemption("knobsHonouredByAbsence", name))
+		}
+	}
+	if k.correct {
+		// The zero value is what receiverBreak{} MEANS, so every family's
+		// vacuity guard spends it and no negative self-test ever names it.
+		// Requiring it below would be requiring the correct setting to be a
+		// mutation.
+		return out
+	}
+	if f.spent[name] {
+		return out
+	}
+	if reason, ok := exempt.unspent[name]; ok {
+		if reason == "" {
+			out = append(out, blankExemption("unspentKnobs", name))
+		}
+		return out
+	}
+	return append(out, fmt.Sprintf("receiverBreak knob %s (%s, %s) is spent by no negative self-test — it is a committed mutation with no "+
+		"failure attached, which is evidence for nothing. Drive it from a <family>_selftest_test.go, delete it, or name it in unspentKnobs "+
+		"with the reason (#1520)", name, k.what, k.where))
+}
+
+func blankExemption(mapName, knobName string) string {
+	return fmt.Sprintf("%s exempts %q with no reason — an exemption whose justification is blank is one nobody can review", mapName, knobName)
+}
+
+// danglingExemptions reports an entry that stopped naming a real knob. An
+// exemption that exempts nothing is a silent no-op, and these maps exist to be
+// reviewed — the same reasoning deferredToTheSeam and construction_test.go's
+// exemption maps carry.
+func danglingExemptions(f fixtureFacts, mapName string, exempt map[string]string) []string {
+	var out []string
+	for _, name := range sortedKeys(exempt) {
+		if _, ok := f.knobs[name]; !ok {
+			out = append(out, fmt.Sprintf("%s names %q, which is no longer a receiverBreak knob — remove the entry rather than "+
+				"leaving an exemption that exempts nothing", mapName, name))
+		}
+	}
+	return out
+}
+
+// TestEveryReceiverBreakKnobIsHonouredAndSpent is rule 2.
+func TestEveryReceiverBreakKnobIsHonouredAndSpent(t *testing.T) {
+	f := parseFixtureFacts(t, ".")
+	if len(f.knobs) == 0 {
+		t.Fatal("receiverBreak has no knobs — either the fixture is gone or the walk is not reading the package")
+	}
+	if len(f.knobEnums) == 0 {
+		t.Fatal("no receiverBreak field is declared with an enum type — the constants carrying most of the committed mutations would then " +
+			"be invisible to this rule while its field half went on passing")
+	}
+	if !f.spent["mustReport"] {
+		t.Fatal("mustReport is not in the spent set — parseFixtureFacts read no driving test file, so every knob would be reported as " +
+			"unspent for a reason unrelated to any of them")
+	}
+
+	for _, msg := range knobViolations(f, knobExemptions{unspent: unspentKnobs, byAbsence: knobsHonouredByAbsence}) {
+		t.Error(msg)
+	}
+}


### PR DESCRIPTION
Closes #1520

## The failure, measured

Each obligation of a receiver-shaped family states its fixture **twice**: once in the entry point's `t.Run` body (what a real adapter runs), once in the self-test's `armBuilder` table (what the negative self-tests drive). Only the self-test side's drift was caught.

The entry-point side's drift is silent, and this is the measurement rather than the argument. With `AssertHookPathConfined`'s `mkSubdir(t, root, "in-tree")` renamed to `"in-tree-2"` on the entry-point side alone, the entire pre-existing package suite is green:

```
===== M1 again: EVERYTHING EXCEPT the new rules, with the drift in place =====
ok  	irrlicht/core/internal/contracttesting	0.438s
```

The committed mutation evidence for obligation 1 then certifies an input the contract no longer posts, which is #1503's species landing on a *test* instead of a figure — and worse, because these self-tests are the evidence the contracts can fail at all.

## Which shape, and why

**Acceptance option 2** — keep the duplication, assert the two statements agree.

Option 1 (one source, both sides derive) was rejected in #1512 because it degrades the `t.Run` bodies for adapter authors, who are `contracttesting`'s primary audience. That judgement holds and the rule here costs those bodies nothing: **not one line of any entry point changed.** A surgical variant of option 1 — naming each obligation's input derivation once and calling it from both sides — was considered and rejected for a second reason: under it the issue's required mutation ("change an input on the entry-point side alone") becomes unexpressible, so the change would have shipped with no red to show. Sharing removes the duplication; it does not remove the *silence* about a side that stops sharing.

Structural (AST-equality) comparison was tried first and abandoned. The two sides already differ in ways nobody should have to mirror — the entry point binds `root := r.Root(t)` where the builder inlines it, and confinement obligation 6 calls the same path `inTree` on one side and `spelled` on the other — so an AST-equality rule would have been red on arrival and could only be made green by mandating a mirroring the code does not owe.

## What landed

`core/internal/contracttesting/fixture_drift_test.go` — two rules over one parse, both in `seam_walk_test.go`'s shape (derive the subject list from the code, keep the decision procedure pure so a corpus can pin its verdicts, let an exemption carry a reason).

**Rule 1 — `TestTheEntryPointAndItsSelfTestsStateTheSameFixture`.** Per obligation it compares:

- the multiset of **basic literals** each body contains. This is where "a different path spelling" actually lives, and an identifier-only rule cannot see it: `strings.Repeat("/..", 32)` becoming `2` no longer bottoms out at `/`.
- the set of **shared identifiers** each body references, where shared means *declared at package level in a non-test file* — the arm, the `what` constant its failure prints, the fixture helper, the logger type. A self-test's own `fakePathReceiver` and `receiverBreak` are test-declared and drop out **by construction**, not by an exemption list. Names the body *binds* are subtracted, because the two sides legitimately name their locals differently.
- the obligation **names, in order**. That half catches the one drift no input comparison can: a seventh obligation added to a contract with no self-test driving it. The seam walk's rule 2 stays green there, because reusing an existing arm introduces no new arm for it to notice.

The family list is derived from the package-level `receiverFamily` vars, so a fourth receiver-shaped family is graded by existing rather than by being added to a table. The one legitimate asymmetry — `realT` on the entry side, `armT` on the self-test side — is named in `seamAdapters` rather than absorbed into a looser comparison.

**Rule 2 — `TestEveryReceiverBreakKnobIsHonouredAndSpent`.** The issue's smaller sibling. Every `receiverBreak` knob must be **spent** by a negative self-test and **honoured** by the fixture. The knob set is derived, never listed: the struct's fields plus the constants of every enum a field is declared with. The second half is the load-bearing one — `confine` and `receipt` are single fields carrying three and four distinct mutations, so a field-level rule would report `confine` as spent while `confineAcceptUnresolvable` rotted.

**No unspent knobs.** Machine-produced census: 22 knobs (13 fields + 9 enum settings), 2 of which are the enums' zero values, `unspent=0`. One knob, `receiptNever`, is **honoured by absence** — the fixture implements "the receiver that forgets entirely" by having `serve` and `dispatch` guard each placement with an `if` this setting matches none of — and is named in `knobsHonouredByAbsence` with that reason rather than left to be inferred from a missing branch. It is the one thing rule 2 surfaced that a reader would not have known.

## Scope, stated rather than implied

The rule covers the **three receiver-shaped families** and not the other four, because the other four have no second statement to drift from: their entry-point `t.Run` bodies construct nothing (`assertFloorParses(t, gate.Min)`, `assertModifyKind(t, d.PermissionKey, perm.Kind)` — the input is carried by the wiring, which the adapter and the self-test each supply once). Read from `hook_version.go:47-70`, `hook_disclosure.go:100-129`, `permission_gate.go:88-97`, `hook_endpoint.go:171-188`.

## Mutation evidence

Committed, per #1479, in `fixture_drift_corpus_test.go`: synthetic entry-point/builder pairs drifted in exactly one way each, plus the rows that must stay silent — a vacuity row, the reporter seam's two spellings, a self-test's own test-only scaffolding, differing local names, and the declared limit (same literals and shared references in a different arrangement). Both tables refuse a corpus that is all-reporting or all-silent.

Run against the real tree, entry-point side only:

**M1 — a string literal changed on the entry side**

```
--- FAIL: TestTheEntryPointAndItsSelfTestsStateTheSameFixture/confinementFamily
    confinementFamily/in_tree_path_accepted: the two sides post different literals:
      the entry point: [STRING "in-tree-2"]
      the self-tests:  [STRING "in-tree"]
    The self-tests' committed mutation evidence is about an input the contract no longer posts
```

**M2 — the traversal shortened from 32 segments to 2**

```
    confinementFamily/parent_traversal_rejected: the two sides post different literals:
      the entry point: [INT 2 STRING "/.."]
      the self-tests:  [INT 32 STRING "/.."]
```

**M3 — the entry point prints a neighbouring obligation's `what`**

```
    confinementFamily/dangling_symlink_rejected: the two sides reference different shared declarations:
      the entry point: [assertRefused mkSubdir whatSymlinkEscape]
      the self-tests:  [assertRefused mkSubdir whatDangling]
```

**M4 — a seventh obligation added to the contract, reusing an existing arm**

```
    confinementFamily states different obligations on its two sides:
      the entry point: [... dangling_symlink_rejected absolute_symlink_chain_rejected confined_spelling_is_what_dispatches]
      the self-tests:  [... dangling_symlink_rejected confined_spelling_is_what_dispatches]
    An obligation the entry point runs and no self-test drives has no evidence it can fail
```

**M5 — the only self-test spending `confineAcceptUnresolvable` stops spending it**

```
--- FAIL: TestEveryReceiverBreakKnobIsHonouredAndSpent
    receiverBreak knob confineAcceptUnresolvable (setting of confineOverride, receiver_fixture_test.go:130)
    is spent by no negative self-test — it is a committed mutation with no failure attached, which is
    evidence for nothing.
```

**M6 — the fixture stops honouring `logsEveryUnknown`**

```
    receiverBreak knob logsEveryUnknown (field, receiver_fixture_test.go:229) is read by no fixture —
    a mutation that sets it builds a CORRECT receiver, so the case spending it goes through every
    motion and grades nothing.
```

**M7 — the locals subtraction neutered**, so its `want:false` corpus row is red-first evidence rather than a row that never could have failed:

```
--- FAIL: TestStatementComparisonCatchesEveryKnownDrift/the_two_sides_name_their_locals_differently
    the comparator reported against a pair it must pass:
    corpusFamily/in_tree_path_accepted: the two sides reference different shared declarations:
      the entry point: [assertRefused inTree mkSubdir whatTraversal]
      the self-tests:  [assertRefused mkSubdir whatTraversal]
```

**Vacuity**: both rules are silent against the undrifted tree, and `TestTheEntryPointAndItsSelfTestsStateTheSameFixture` was green on all three families before any production line was touched — the whole point being that it can fail. Every mutation was reverted by copy-aside/copy-back with `git status --porcelain` asserted clean afterwards; no `git stash` was used.

## Limits

- **Expression structure is not compared.** Two bodies holding the same literals and the same shared references in a different arrangement agree. Pinned as a `want:false` corpus row so it is learned from a test rather than from an incident, with the reason AST equality was rejected recorded beside it.
- **Extraction reads top-level `t.Run` calls only.** An entry point that loops over its obligations yields nothing, which the extraction guard fatals on rather than passing quietly — the "a verification mechanism must fail loudly when it cannot run" rule applied to this walk. A corpus row pins that shape.
- `spent` is reference-based (any mention in a file that also calls `mustReport`), the same over-approximation the seam walk's rule 2 makes, which is why the `honoured` half exists to grade the other end.

## Verification

- `go build ./core/...` — PASS
- `go test ./core/internal/contracttesting/... -race -count=1` — PASS
- `go test ./core/... -race -count=1` — PASS after re-running `core/e2e`'s `TestFSWatcher_EmitsEventsForTranscriptCreateAndModify`, the known load-flake (#1432); the whole `core/e2e` package is green on re-run
- `tools/preflight.sh --only go` — all 7 gates PASS
- `tools/preflight.sh --only arch` — PASS, composite 7.9332 → 7.9339

🤖 Generated with [Claude Code](https://claude.com/claude-code)
