### PR TITLE
feat(daemon): resolve a tmux pane's host from the client tmux itself names

### DIFF
--- a/core/adapters/inbound/agents/processlifecycle/clienthostbudget_darwin_test.go
+++ b/core/adapters/inbound/agents/processlifecycle/clienthostbudget_darwin_test.go
@@ -11,10 +11,15 @@ import (
 	"irrlicht/core/domain/session"
 )
 
-// This file is #1529's behavioural half: what the herdr client loop does when
-// the ONE aggregate deadline covering it runs out. The value half — that the
-// deadline is small enough to be worth having — is
-// TestHerdrReadFitsTheLivenessSweepTick, platform-neutral beside the constant.
+// This file is #1529's behavioural half: what the attached-client loop does
+// when the ONE aggregate deadline covering it runs out. The value half — that
+// the deadline is small enough to be worth having — is
+// TestClientHostReadFitsTheLivenessSweepTick, platform-neutral beside the
+// constant.
+//
+// The loop is shared by both producers since #1501, so every assertion here is
+// a lock on tmux's indirection as much as on herdr's; only the last test, which
+// pins the DERIVATION of the budget, has to be stated once per producer.
 //
 // Every assertion here turns on the BUDGET rather than on a wall clock, which
 // is what the issue asked for and what keeps these tests instant: the loop
@@ -169,11 +174,47 @@ func TestResolveHerdrClientLauncher_DerivesOneBudgetOverScanAndCandidates(t *tes
 	}
 	if !scanDeadline.Equal(candidateDeadline) {
 		t.Errorf("the scan and the candidate loop ran under different deadlines (%v apart): "+
-			"one deadline per stage sums to twice herdrClientBudget and is not the aggregate this fix states (#1529)",
+			"one deadline per stage sums to twice clientHostBudget and is not the aggregate this fix states (#1529)",
 			candidateDeadline.Sub(scanDeadline))
 	}
-	if scanDeadline.After(after.Add(herdrClientBudget)) || !scanDeadline.After(before) {
-		t.Errorf("the derived deadline is %v from the call, want a positive span no longer than herdrClientBudget (%v)",
-			scanDeadline.Sub(before), herdrClientBudget)
+	if scanDeadline.After(after.Add(clientHostBudget)) || !scanDeadline.After(before) {
+		t.Errorf("the derived deadline is %v from the call, want a positive span no longer than clientHostBudget (%v)",
+			scanDeadline.Sub(before), clientHostBudget)
+	}
+}
+
+// TestResolveTmuxClientLauncher_DerivesOneBudgetOverScanAndCandidates is the
+// #1501 twin of the test above, and it is duplicated rather than shared for the
+// one reason the two resolves are not merged: what it pins is that THIS
+// producer derives the budget itself. A table over both would be driven by a
+// helper that derives it once, which is precisely the thing that must be
+// asserted separately at each entry point.
+func TestResolveTmuxClientLauncher_DerivesOneBudgetOverScanAndCandidates(t *testing.T) {
+	var scanDeadline, candidateDeadline time.Time
+	var scanBounded, candidateBounded bool
+
+	before := time.Now()
+	scan := func(ctx context.Context, _ string) ([]int, bool) {
+		scanDeadline, scanBounded = ctx.Deadline()
+		return []int{11}, true
+	}
+	identify := func(ctx context.Context, _ int) (*session.Launcher, bool) {
+		candidateDeadline, candidateBounded = ctx.Deadline()
+		return readableHostlessCandidate()
+	}
+	_, _ = resolveTmuxClientLauncherVia("/private/tmp/tmux-501/default", scan, identify)
+	after := time.Now()
+
+	if !scanBounded || !candidateBounded {
+		t.Fatal("the tmux client indirection ran unbounded: `list-clients` is cheap, but the candidate " +
+			"loop behind it is the same two ancestry walks per candidate herdr pays (#1529)")
+	}
+	if !scanDeadline.Equal(candidateDeadline) {
+		t.Errorf("the scan and the candidate loop ran under different deadlines (%v apart): "+
+			"one deadline per stage sums to twice clientHostBudget", candidateDeadline.Sub(scanDeadline))
+	}
+	if scanDeadline.After(after.Add(clientHostBudget)) || !scanDeadline.After(before) {
+		t.Errorf("the derived deadline is %v from the call, want a positive span no longer than clientHostBudget (%v)",
+			scanDeadline.Sub(before), clientHostBudget)
 	}
 }

--- a/core/adapters/inbound/agents/processlifecycle/clienthostbudget_test.go
+++ b/core/adapters/inbound/agents/processlifecycle/clienthostbudget_test.go
@@ -17,17 +17,33 @@ const sweepBaseIntervalSource = "../../../../application/services/pid_manager.go
 // but reading the source can produce it.
 var sweepBaseIntervalDecl = regexp.MustCompile(`const baseInterval = (\d+) \* time\.(Second|Millisecond|Minute)`)
 
-// TestHerdrReadFitsTheLivenessSweepTick is what makes herdrClientBudget's value
+// TestClientHostReadFitsTheLivenessSweepTick is what makes clientHostBudget's value
 // a decision rather than a preference, and it is the reason #1529 was filed as
 // a bug rather than as a doc fix.
 //
-// refreshHerdrHosts runs SYNCHRONOUSLY inside the SweepDeadPIDs ticker handler
-// (CheckPIDLiveness → refreshHerdrHosts), and Go's Ticker drops ticks it
+// It covers BOTH producers, because since #1501 there is one budget rather
+// than one per multiplexer (see clientHostBudget for that decision) — so one
+// assertion over one constant is the whole coverage, and a second constant
+// would be the thing that could drift past this tick unobserved.
+//
+// What it does NOT cover, stated because a reader would otherwise assume the
+// arithmetic is exhaustive: a tmux pane's DIRECT read is not shelloutTimeout.
+// hostIdentity skips the ancestry fallbacks for a herdr pane and deliberately
+// runs them for a tmux one (a kitty launched from a pane has no other source of
+// a host), so a tmux session pays the ordinary non-herdr direct read — two
+// walks bounded by a COUNT, which is what noAggregateBudget names and what
+// #1529 deliberately did not move. In practice that walk terminates at the
+// reparented tmux server in two or three hops; in the worst case it is the
+// standing cost noAggregateBudget's doc records for every non-herdr session,
+// and #1501 neither adds to it nor fixes it.
+//
+// refreshMultiplexerHosts runs SYNCHRONOUSLY inside the SweepDeadPIDs ticker handler
+// (CheckPIDLiveness → refreshMultiplexerHosts), and Go's Ticker drops ticks it
 // overruns. So a herdr read that can outlast one tick delays dead-PID reaping
 // for every session behind it — which is what the old bound, a COUNT over up to
 // maxClientCandidates candidates each spending several 2s ceilings, allowed.
 // The whole read is shelloutTimeout (the pane's own controlling-tty `ps`, the
-// only child the direct read starts for a herdr pane) plus herdrClientBudget
+// only child the direct read starts for a herdr pane) plus clientHostBudget
 // (the entire client indirection), so that sum is what has to fit.
 //
 // The cadence is READ OUT OF THE SERVICES SOURCE rather than copied here. A
@@ -41,14 +57,14 @@ var sweepBaseIntervalDecl = regexp.MustCompile(`const baseInterval = (\d+) \* ti
 // It refuses rather than skips when it cannot find that declaration: a gate
 // whose inability to look is indistinguishable from a pass is the failure mode
 // this repo's guards exist to remove.
-func TestHerdrReadFitsTheLivenessSweepTick(t *testing.T) {
+func TestClientHostReadFitsTheLivenessSweepTick(t *testing.T) {
 	tick := sweepBaseInterval(t)
 
-	if read := shelloutTimeout + herdrClientBudget; read >= tick {
-		t.Errorf("a herdr ReadLauncherEnv can take shelloutTimeout+herdrClientBudget = %v, "+
+	if read := shelloutTimeout + clientHostBudget; read >= tick {
+		t.Errorf("a pane's ReadLauncherEnv can take shelloutTimeout+clientHostBudget = %v, "+
 			"which does not fit inside the liveness sweep's fastest tick (%v, PIDManager.SweepDeadPIDs). "+
-			"That sweep calls refreshHerdrHosts synchronously and Go's Ticker drops ticks it overruns, "+
-			"so one herdr resolve would again delay dead-PID reaping for every session behind it — #1529 "+
+			"That sweep calls refreshMultiplexerHosts synchronously and Go's Ticker drops ticks it overruns, "+
+			"so one client resolve would again delay dead-PID reaping for every session behind it — #1529 "+
 			"exactly, with a duration bound instead of a count", read, tick)
 	}
 }
@@ -66,13 +82,13 @@ func sweepBaseInterval(t *testing.T) time.Duration {
 	}
 	if !regexp.MustCompile(`func \(pm \*PIDManager\) SweepDeadPIDs\(`).Match(src) {
 		t.Fatalf("%s no longer declares PIDManager.SweepDeadPIDs: the cadence this test reads may no "+
-			"longer be the one refreshHerdrHosts runs under, so re-point it rather than trusting it",
+			"longer be the one refreshMultiplexerHosts runs under, so re-point it rather than trusting it",
 			sweepBaseIntervalSource)
 	}
 	m := sweepBaseIntervalDecl.FindSubmatch(src)
 	if m == nil {
 		t.Fatalf("%s no longer declares `const baseInterval = N * time.Unit`: the liveness sweep's "+
-			"cadence is what bounds herdrClientBudget, and a test that cannot read it must say so "+
+			"cadence is what bounds clientHostBudget, and a test that cannot read it must say so "+
 			"rather than pass", sweepBaseIntervalSource)
 	}
 	n, err := strconv.Atoi(string(m[1]))

--- a/core/adapters/inbound/agents/processlifecycle/osutil.go
+++ b/core/adapters/inbound/agents/processlifecycle/osutil.go
@@ -19,9 +19,10 @@ import (
 	"irrlicht/core/domain/session"
 )
 
-// herdrClientBudget is the ONE aggregate deadline covering the entire herdr
-// client indirection: the lsof scan that finds the attached clients and every
-// candidate probed behind it (resolveHerdrClientLauncherVia, osutil_darwin.go).
+// clientHostBudget is the ONE aggregate deadline covering an entire attached-
+// client indirection: the scan that finds the attached clients and every
+// candidate probed behind it (resolveHerdrClientLauncherVia and
+// resolveTmuxClientLauncherVia, osutil_darwin.go).
 //
 // It exists because every individual shellout on that path was bounded and the
 // path was not (#1529). resolveClientHostIdentity loops over up to
@@ -30,13 +31,31 @@ import (
 // maxAncestry — so the bound was a COUNT, and one resolve could run to tens of
 // seconds.
 //
+// ONE constant for BOTH producers, which #1501 decided rather than inherited.
+// The two scans differ by more than an order of magnitude — `tmux -S <sock>
+// list-clients` measured at 14ms/call against an `lsof` of a herdr client log
+// at roughly 0.3s — so a per-producer budget was the obvious alternative. It is
+// not taken, for three reasons:
+//
+//   - What the budget bounds is the CANDIDATE LOOP, and that is literally the
+//     same function for both (resolveClientHostIdentityVia). The scan is the
+//     cheap stage in both spellings; the ancestry walks behind it are what can
+//     run to tens of seconds, and they do not know which producer found the pid.
+//   - A cheaper scan does not want a smaller aggregate, it wants the same one:
+//     it leaves MORE of the budget for the candidates, which is exactly the
+//     trade resolveHerdrClientLauncherVia's doc says lsof loses.
+//   - The sum this bounds has to fit inside one liveness-sweep tick, and that
+//     assertion is over ONE number. Two constants would let one drift past the
+//     tick while the test still passed on the other — a second number with no
+//     second piece of evidence behind it.
+//
 // The value is set by what it has to fit inside rather than by what the probes
-// cost: PIDManager.SweepDeadPIDs calls refreshHerdrHosts synchronously on its
-// ticker, and Go's Ticker drops ticks it overruns, so a single herdr resolve
-// delays dead-PID reaping for every session behind it.
-// TestHerdrReadFitsTheLivenessSweepTick reads that cadence out of the services
-// source and pins the sum against it, so the relation is measured rather than
-// restated.
+// cost: PIDManager.SweepDeadPIDs calls refreshMultiplexerHosts synchronously on
+// its ticker, and Go's Ticker drops ticks it overruns, so a single client
+// resolve delays dead-PID reaping for every session behind it.
+// TestClientHostReadFitsTheLivenessSweepTick reads that cadence out of the
+// services source and pins the sum against it, so the relation is measured
+// rather than restated.
 //
 // Abandoning candidates is safe by construction and that is what makes the
 // budget cheap: an abandoned candidate is a NON-answer (#1492), not a detach,
@@ -50,11 +69,11 @@ import (
 // together the two ARE the decision about which host reads get an aggregate and
 // which deliberately do not, and splitting that across a build tag hides half
 // of it.
-const herdrClientBudget = 2 * time.Second
+const clientHostBudget = 2 * time.Second
 
 // noAggregateBudget is the context every host read that deliberately has NO
 // aggregate deadline runs under. Naming it is the whole point: #1529 bounded
-// the herdr client indirection (herdrClientBudget above) and left these
+// the herdr client indirection (clientHostBudget above) and left these
 // unbounded, and a named helper makes that a reviewable absence rather than a
 // context.Background() whose meaning the next reader has to infer.
 //
@@ -139,14 +158,23 @@ func herdrClientLogPath(socketPath string) string {
 //
 // hostKnown reports whether the host window could be *determined*, which is
 // not the same as being found. It is false whenever this read established
-// nothing: a herdr pane whose client probe did not run (#1485), a pid that
-// cannot be looked at at all (pid <= 0, or a process whose env, ancestry and
-// tty all came back empty), and — at the wiring in cmd/irrlichd — a revoked
-// launcher consent. A caller merging this read into a launcher it already
-// holds must not clear host fields when hostKnown is false: their absence
-// means "not looked up", not "gone". A caller capturing a session's first
-// launcher may ignore it, because there is nothing to clear and dropping the
-// read would cost the pane its herdr address.
+// nothing: a pane whose client probe did not run (#1485 for herdr, #1501 for
+// tmux), a pid that cannot be looked at at all (pid <= 0, or a process whose
+// env, ancestry and tty all came back empty), and — at the wiring in
+// cmd/irrlichd — a revoked launcher consent. A caller merging this read into a
+// launcher it already holds must not clear host fields when hostKnown is false:
+// their absence means "not looked up", not "gone". A caller capturing a
+// session's first launcher may ignore it, because there is nothing to clear and
+// dropping the read would cost the pane its address.
+//
+// Read it as "the host of the PANE this launcher addresses was determined",
+// which is what the merging contract above actually needs, and which #1501
+// separated from "a host was determined". A process that merely INHERITED a
+// $TMUX_PANE has a host of its own and no claim on that pane's — so the answer
+// for it is false, and the merge leaves its own identity alone instead of
+// overwriting it with a fresh read that could be one timed-out probe short.
+// For a launcher addressing no pane at all the two readings coincide and it is
+// true, exactly as before.
 //
 // Never prompts the user — on macOS we use
 // `sysctl(kern.procargs2)` (no TCC prompt; `ps e` stopped exposing env on
@@ -154,15 +182,15 @@ func herdrClientLogPath(socketPath string) string {
 // nil.
 //
 // On the herdr path this function is bounded at shelloutTimeout +
-// herdrClientBudget. One shelloutTimeout is the pane's own controlling-TTY
+// clientHostBudget. One shelloutTimeout is the pane's own controlling-TTY
 // `ps`, which is the ONLY child process the direct read starts for a herdr
 // pane: launcherFromEnv returns early with HerdrPaneID set, hostIdentityVia
 // skips the ancestry fallbacks for exactly that case, and the env read is a
-// sysctl rather than a shellout. herdrClientBudget is one aggregate deadline
+// sysctl rather than a shellout. clientHostBudget is one aggregate deadline
 // covering the entire client indirection below — the lsof scan and every
 // candidate behind it. The sum is not restated here as a number, because a
 // number a doc carries and nothing produces drifts: it is
-// TestHerdrReadFitsTheLivenessSweepTick that measures it, against the sweep
+// TestClientHostReadFitsTheLivenessSweepTick that measures it, against the sweep
 // cadence that has to accommodate it.
 //
 // It used to say "never blocks longer than 2 seconds", and then, honestly,
@@ -197,15 +225,14 @@ func ReadLauncherEnv(pid int) (l *session.Launcher, hostKnown bool) {
 	l, _ = hostIdentity(noAggregateBudget(), pid)
 	hostKnown = true
 
-	// A herdr pane's window belongs to the attached client, so its host
+	// A multiplexer pane's window belongs to the attached client, so its host
 	// identity is resolved from that process instead — one indirection past
-	// the ancestry walk hostIdentity skipped (#1350). Runs after the TTY
+	// the ancestry walk (#1350 for herdr, #1501 for tmux). Runs after the TTY
 	// capture so the pane keeps its own pty when nothing is attached, and is
 	// overridden by the client's when something is: AdoptHostIdentity owns
 	// that rule.
-	if l.HerdrPaneID != "" {
-		var client *session.Launcher
-		client, hostKnown = herdrClientLauncher(l.HerdrSocketPath)
+	if client, probed, addressesAPane := clientHostFor(l); addressesAPane {
+		hostKnown = probed
 		l.AdoptHostIdentity(client)
 	}
 
@@ -220,6 +247,75 @@ func ReadLauncherEnv(pid int) (l *session.Launcher, hostKnown bool) {
 		return nil, false
 	}
 	return l, hostKnown
+}
+
+// clientHostFor resolves the identity of the client displaying l's pane, for
+// the one multiplexer l's session lives in.
+//
+// Three-valued on purpose, and the third value is the one worth reading twice.
+// addressesAPane says l carries a pane address at all; probed is the
+// #1485/#1492 tri-state for that pane's host. They come apart in exactly one
+// case and it is the case #1499 was filed about: a launcher that carries a
+// $TMUX_PANE it INHERITED — a GUI terminal or IDE launched from inside a pane —
+// addresses a pane whose host it must not adopt, because its own host is real
+// and the pane's belongs to a different process. So that case answers
+// (nil, false, true): "this addresses a pane, and the pane's host was not
+// looked up", which is precisely the shape ReadLauncherEnv's hostKnown contract
+// tells a merging caller not to clear fields on.
+//
+// It is the dispatcher, and having one is the point: the two producers differ
+// only in how they enumerate clients (osutil_darwin.go), and the ORDER they are
+// tried in is #1348's — herdr first, because a herdr server started from inside
+// a tmux pane hands every pane it spawns a $TMUX_PANE that is the server's.
+// session.Launcher.pane applies the same precedence for the adoption's
+// put-back, and the two must not disagree.
+func clientHostFor(l *session.Launcher) (client *session.Launcher, probed, addressesAPane bool) {
+	switch {
+	case l.HerdrPaneID != "":
+		client, probed = herdrClientLauncher(l.HerdrSocketPath)
+		return client, probed, true
+	case l.TmuxPane == "":
+		return nil, false, false
+	case !tmuxPaneAwaitsItsClient(l):
+		return nil, false, true
+	default:
+		client, probed = tmuxClientLauncher(l.TmuxSocket)
+		return client, probed, true
+	}
+}
+
+// tmuxPaneAwaitsItsClient reports whether l is a tmux pane whose host can only
+// come from the attached client.
+//
+// It is deliberately NARROWER than "$TMUX_PANE is set", and the difference is
+// the whole reason #1499 keyed its suppression on tmux's own TERM_PROGRAM
+// marker rather than on the pane address. $TMUX_PANE is not self-describing:
+// every descendant of a pane inherits it, so a GUI terminal or IDE launched
+// from inside one (`code .`, `kitty`) carries a stale pane address next to a
+// perfectly good host identity of its own. Resolving THAT session's tmux client
+// and adopting it would replace a correct host with the window displaying a
+// pane the session is not in — the #1348 misroute, arriving through the fix for
+// it.
+//
+// The three-term test is what tells those apart, and each term is doing work:
+//
+//   - TmuxPane non-empty: there is a pane address to resolve a client for.
+//   - TermProgram and HostBundleID both empty: nothing has claimed a host for
+//     this process. A descendant that reports its own $TERM_PROGRAM never had
+//     it suppressed (launcherFromEnv), and one that reports none of its own —
+//     kitty, upstream kitty#4793 — has just had it recovered by the ancestry
+//     fallbacks, which hostIdentity deliberately runs for tmux for exactly that
+//     reason. Either way the host is the process's own and is not the client's
+//     to overwrite.
+//
+// A genuine pane passes all three, because its ancestry terminates at the
+// reparented tmux server: the walk is inert there (hostIdentityVia says so),
+// which is what leaves the two host fields empty for it and for nothing else.
+// So this is the same "no local window" test resolveClientHostIdentityVia
+// applies to a CANDIDATE, applied one level up to decide whether to look for
+// candidates at all.
+func tmuxPaneAwaitsItsClient(l *session.Launcher) bool {
+	return l.TmuxPane != "" && l.TermProgram == "" && l.HostBundleID == ""
 }
 
 // hostIdentity resolves the window-owning identity of pid: its whitelisted

--- a/core/adapters/inbound/agents/processlifecycle/osutil_darwin.go
+++ b/core/adapters/inbound/agents/processlifecycle/osutil_darwin.go
@@ -199,12 +199,12 @@ func bundleIDUncached(ctx context.Context, appPath string) (string, error) {
 //     near ancestryReads, whose subject — the process table — changes by the
 //     second.
 //   - Process-global therefore means shared between goroutines: PID discovery
-//     and the liveness sweep both reach it (see refreshHerdrHosts' own comment
+//     and the liveness sweep both reach it (see refreshMultiplexerHosts' own comment
 //     on running outside assignMu). It is synchronised with an RWMutex, the
-//     same idiom herdrClientCache uses one file down.
+//     same idiom clientHostMemo uses one file down.
 //
 // It carries no TTL and no eviction, and both are deliberate. No TTL because
-// the entry describes something immutable — herdrClientCache's 5s exists
+// the entry describes something immutable — clientHostMemo's 5s exists
 // precisely because ITS subject (who is attached to a herdr socket) is not.
 // No eviction because the key space is the set of top-level `.app` bundles in
 // one machine's process ancestry: a handful, bounded by what is installed and
@@ -276,7 +276,7 @@ func (m *bundleIDMemo) record(appPath, id string) {
 //     verdict that REJECTS at the #784 admission gate and that SessionDetector
 //     then caches in hostGateRejected and never evicts.
 //
-// #1514 reached the OPPOSITE conclusion for herdrClientCache — it memoizes
+// #1514 reached the OPPOSITE conclusion for clientHostMemo — it memoizes
 // non-answers on purpose — and the two must not be read as a contradiction,
 // because they turn on a property this cache does not have. #1514's rule is
 // that a non-answer may be cached only when every consumer sees it AS a
@@ -973,13 +973,132 @@ func herdrClientWriters(out string, self int) []int {
 	return pids
 }
 
+// tmuxPath is the tmux CLI, resolved once at package init.
+//
+// Resolved with pathutil.Resolve rather than MustResolve, unlike psPath and
+// plutilPath at the top of this file, and the difference is deliberate. Those
+// two are macOS platform binaries under /usr/bin, so a miss there means
+// something is deeply wrong and falling back to the bare name costs nothing.
+// tmux is a third-party install that is routinely absent — and MustResolve's
+// fallback is the bare name, which hands the lookup to exec.Command's PATH
+// search. The daemon runs under launchd with a minimal PATH, so on a machine
+// where tmux lives outside the trusted directories that fallback does not find
+// it either; it just pays a fork per sweep to be told so. An empty string here
+// is checked once instead (tmuxClientPIDs).
+//
+// pathutil's trusted set covers /opt/homebrew/bin and /usr/local/bin, which is
+// where Homebrew puts tmux on Apple Silicon and Intel respectively — the two
+// installs this actually has to find (measured: /opt/homebrew/bin/tmux on this
+// machine, a symlink into the Cellar, which Stat follows).
+var tmuxPath = func() string {
+	p, err := pathutil.Resolve("tmux")
+	if err != nil {
+		return ""
+	}
+	return p
+}()
+
+// tmuxClientPIDFormat asks list-clients for one client PID per line and
+// nothing else. tmux's own format language, so the parse below has no columns
+// to get wrong — the contrast with herdrClientPIDs, which has to select the
+// write handles out of an lsof table, is the whole of what makes this the
+// cheaper half of #1350's shape.
+const tmuxClientPIDFormat = "#{client_pid}"
+
+// tmuxClientPIDs asks the tmux server at socketPath which clients are attached,
+// newest-attach-first.
+//
+// The second return is the same tri-state herdrClientPIDs draws: true means the
+// list is evidence, false means the question did not reach the server and a
+// caller must not read the absence of clients as a detach.
+//
+// A missing tmux binary is (nil, false) — "I could not look" — and NOT the
+// settled-property reading kittyWindowIDForPIDVia gives its absent kitten. The
+// two look alike and are not: kitten's absence means this installation has no
+// kitty to describe windows, which is a fact about the machine, whereas a
+// session in a tmux pane is standing proof that tmux exists here and only our
+// lookup failed. Reporting "no client attached" on that would be a claim that
+// nothing is displaying a session that plainly is displayed. The cost of the
+// honest answer is bounded: a permanent non-answer clears no stored host
+// (#1485/#1492) and adopts none, which is exactly the state such a machine was
+// in before this existed.
+func tmuxClientPIDs(ctx context.Context, socketPath string) (pids []int, probed bool) {
+	if tmuxPath == "" || socketPath == "" {
+		return nil, false
+	}
+	return tmuxClientPIDsVia(ctx, func(ctx context.Context) *exec.Cmd {
+		return exec.CommandContext(ctx, tmuxPath, "-S", socketPath, "list-clients", "-F", tmuxClientPIDFormat)
+	})
+}
+
+// tmuxClientPIDsVia is tmuxClientPIDs with the shellout injected.
+func tmuxClientPIDsVia(ctx context.Context, build shelloutCmd) (pids []int, probed bool) {
+	out, err := runProbe(ctx, probeTmuxClients, build)
+	if !tmuxListedClients(err) {
+		return nil, false
+	}
+	// Sorted and deduped through the shared helper, which is where
+	// resolveClientHostIdentityVia's "producers must feed it DISTINCT pids"
+	// obligation is discharged. tmux emits one line per client, so the dedup is
+	// inert here — reusing the helper rather than asserting that in a comment is
+	// what keeps it inert if tmux ever grows a second row per client.
+	return sortedDistinctPIDs(tmuxClientPIDsFrom(string(out))), true
+}
+
+// tmuxListedClients reports whether a `tmux list-clients` that returned err
+// answered the question it was asked.
+//
+// It is the strictest classifier in this package, and the strictness is
+// measured rather than assumed (tmux 3.6a, this machine):
+//
+//	live server, no client attached   exit 0, empty stdout
+//	no server at that path            exit 1, "no server running on <path>"
+//	path is not a socket              exit 1, "error connecting to <path> …"
+//	path does not exist               exit 1, "error connecting to <path> …"
+//
+// So tmux has NO "nothing to report" status: the detach case, which is lsof's
+// exit 1 and pgrep's exit 1, is tmux's exit ZERO. An allowlist modelled on
+// lsofProbeRan would therefore turn every socket we cannot reach into an
+// authoritative "nobody is displaying this session" — #1485's defect with a
+// different tool, and on the one path where it clears a resolved host.
+//
+// probeAnswered still decides the harder half, and it is called rather than
+// folded away even though `err == nil` implies it. Two facts are being
+// separated, they are measured separately, and only one of them is tmux's: a
+// child killed by the ceiling or one that never started is a non-answer
+// everywhere in this package (#1538), and a reader who saw only a nil check
+// would learn neither that nor why the allowlist is empty.
+func tmuxListedClients(err error) bool {
+	if !probeAnswered(err) {
+		return false
+	}
+	return err == nil
+}
+
+// tmuxClientPIDsFrom parses tmuxClientPIDFormat output: one PID per line.
+// Unparseable lines are skipped rather than failing the read — tmux writes
+// nothing else to stdout under -F, so a line that is not a number is a format
+// change we do not understand, and dropping the read entirely would report a
+// working server as unreachable.
+func tmuxClientPIDsFrom(out string) []int {
+	var pids []int
+	for _, line := range strings.Split(out, "\n") {
+		pid, err := strconv.Atoi(strings.TrimSpace(line))
+		if err != nil || pid <= 0 {
+			continue
+		}
+		pids = append(pids, pid)
+	}
+	return pids
+}
+
 // maxClientCandidates bounds how many attached clients are probed for a
 // resolvable host. Each candidate costs an env read plus an ancestry walk, and
 // attaching more than a handful of clients to one session is not a real
 // workflow, so the cap keeps that work proportionate.
 //
 // Since #1529 it is a SANITY cap and no longer the de-facto time bound it had
-// been: herdrClientBudget bounds the loop by duration, so a machine slow enough
+// been: clientHostBudget bounds the loop by duration, so a machine slow enough
 // for four candidates to matter now stops on the clock instead of on the count.
 // The cap still poisons the answer when it truncates (see
 // resolveClientHostIdentity), because "we declined to look at the rest" is the
@@ -1143,7 +1262,7 @@ func resolveClientHostIdentityVia(ctx context.Context, pids []int, identify host
 // #1492; resolveClientHostIdentity's doc carries the argument, and this
 // function only passes its verdict through.
 //
-// A miss costs at most herdrClientBudget, and that is a real ceiling rather
+// A miss costs at most clientHostBudget, and that is a real ceiling rather
 // than a sum of per-child ones (#1529): resolveHerdrClientLauncherVia derives
 // ONE deadline covering the lsof scan and every candidate behind it. Before
 // that the cost here was bounded by a COUNT — up to maxClientCandidates
@@ -1176,19 +1295,19 @@ func resolveClientHostIdentityVia(ctx context.Context, pids []int, identify host
 //     memoized non-answer keeps that exactly, because it is stored AS a
 //     non-answer and every consumer of the bit sees the identical (nil, false)
 //     pair either way: captureLauncher ignores it outright, and backfillLauncher
-//     and refreshHerdrHosts both route it through applyHerdrHostBackfill, which
+//     and refreshMultiplexerHosts both route it through applyMultiplexerHostBackfill, which
 //     returns before touching the stored launcher. The one thing a cached
 //     unknown costs is deferring a RECOVERY — a probe that would have
 //     answered. Note the honest bound on that deferral is a SWEEP, not a TTL:
 //     the entry expires one TTL after the probe that wrote it, but nothing
 //     reads it in between, so what a user observes is quantized to
-//     refreshHerdrHosts' cadence. See the TTL note below.
+//     refreshMultiplexerHosts' cadence. See the TTL note below.
 //   - The failure the reason describes is no longer the failure that arrives
 //     here. #1485 was written when the only non-answer was a failed lsof probe,
 //     which fails fast, so re-paying it per pane was nearly free and the spread
 //     was the only cost worth naming. #1492 routed the most EXPENSIVE outcome in
 //     this function to the same branch: every candidate probed and none
-//     readable, which is the whole herdrClientBudget spent before an answer
+//     readable, which is the whole clientHostBudget spent before an answer
 //     arrives. Re-paying now dominates, and the trade the rule was making
 //     inverted. (Until #1529 that outcome had no ceiling at all — up to
 //     maxClientCandidates candidates, two independent ancestry walks each on
@@ -1213,22 +1332,73 @@ func resolveClientHostIdentityVia(ctx context.Context, pids []int, identify host
 // intervals, because entry.at is stamped when the probe FINISHES rather than
 // when the pass began, so an entry written late in a pass is not yet expired
 // when the next pass reaches it. It cannot slip further than that, because
-// herdrClientCacheGet does not restamp on a hit: a sweep served from the memo
+// clientHostMemo.get does not restamp on a hit: a sweep served from the memo
 // costs nothing and so cannot keep pushing the expiry ahead of itself.
 func herdrClientLauncher(socketPath string) (*session.Launcher, bool) {
-	if socketPath == "" {
-		return nil, false
-	}
-	if cached, hit := herdrClientCacheGet(socketPath); hit {
-		return cached.launcher, cached.probed
-	}
-	resolved, probed := resolveHerdrClientLauncher(socketPath)
-	herdrClientCachePut(socketPath, resolved, probed)
-	return resolved, probed
+	return herdrClientHosts.resolve(socketPath, resolveHerdrClientLauncher)
 }
 
 func resolveHerdrClientLauncher(socketPath string) (*session.Launcher, bool) {
 	return resolveHerdrClientLauncherVia(socketPath, herdrClientPIDs, hostIdentity)
+}
+
+// tmuxClientLauncher resolves the host-window identity of the tmux session
+// displayed in socketPath's server, by reading it from an attached client
+// exactly the way a herdr pane's is read (#1501, #1350's counterpart).
+//
+// It is #1350 one step cheaper, and the step it saves is the whole reason this
+// was worth doing separately: herdr has to be asked WHO holds its per-session
+// client log open, with an `lsof` scan, while tmux answers the question itself
+// in one line of output. Everything downstream — the candidate cap, the
+// aggregate budget, the tri-state, the #1492 poisoning rule — is the same code
+// (resolveClientHostIdentityVia).
+//
+// Process ancestry cannot substitute for it, which is why the indirection is
+// needed at all rather than being a cheaper alternative to a walk: the tmux
+// server daemonizes at first use and is reparented to PID 1 (measured, tmux
+// 3.6a — a pane's shell has the server as its parent and the server has init),
+// so the walk from a pane terminates at init having found nothing. That is
+// exactly what left a genuine tmux pane with no host at all after #1499, and
+// therefore with a click that did nothing.
+//
+// The same memoization argument as herdr's applies and is stronger: every pane
+// of one tmux server shares a socket, and a user with eight panes open is
+// ordinary. Every outcome is memoized, non-answers included — clientHostMemo
+// carries #1514's rule and its argument.
+//
+// Only ever called with a socket path the daemon parsed from the pane's own
+// $TMUX, so a resolved identity always accompanies the pane address it belongs
+// to; AdoptHostIdentity puts that address back over the client's own (the
+// client is a GUI terminal and carries none), which is what keeps control and
+// the macOS TmuxActivator addressing the pane rather than the window.
+func tmuxClientLauncher(socketPath string) (*session.Launcher, bool) {
+	return tmuxClientHosts.resolve(socketPath, resolveTmuxClientLauncher)
+}
+
+func resolveTmuxClientLauncher(socketPath string) (*session.Launcher, bool) {
+	return resolveTmuxClientLauncherVia(socketPath, tmuxClientPIDs, hostIdentity)
+}
+
+// resolveTmuxClientLauncherVia is resolveTmuxClientLauncher with both probes
+// injected. It derives the aggregate deadline rather than taking one, for the
+// reason resolveHerdrClientLauncherVia's doc gives: a test driving it exercises
+// clientHostBudget itself rather than a budget the test supplied.
+//
+// The two functions are deliberately NOT merged into one parameterised by its
+// scan. They would differ only in the probe, and the probe is already a
+// parameter — but the budget derivation is the thing under test in both, and a
+// single shared body reached through two one-line wrappers is what
+// resolveHerdrClientLauncherVia already is. What is shared is the part that can
+// drift (the loop, the budget, the tri-state); what is duplicated is two lines
+// naming this producer's own probes.
+func resolveTmuxClientLauncherVia(socketPath string, scan clientPIDProbe, identify hostIdentityProbe) (*session.Launcher, bool) {
+	ctx, cancel := context.WithTimeout(context.Background(), clientHostBudget)
+	defer cancel()
+	pids, probed := scan(ctx, socketPath)
+	if !probed {
+		return nil, false
+	}
+	return resolveClientHostIdentityVia(ctx, pids, identify)
 }
 
 // clientPIDProbe is the attached-client scan resolveHerdrClientLauncherVia
@@ -1238,7 +1408,7 @@ type clientPIDProbe func(ctx context.Context, socketPath string) (pids []int, pr
 
 // resolveHerdrClientLauncherVia is resolveHerdrClientLauncher with both probes
 // injected. It DERIVES the aggregate deadline rather than taking one, so a test
-// driving it exercises herdrClientBudget itself rather than a budget the test
+// driving it exercises clientHostBudget itself rather than a budget the test
 // supplied — the same reason #1390 collapsed a receiver's two constructors into
 // the one the daemon builds.
 //
@@ -1248,7 +1418,7 @@ type clientPIDProbe func(ctx context.Context, socketPath string) (pids []int, pr
 //
 // What sharing COSTS, stated rather than argued away. The two stages compete
 // for one budget and the scan goes first, so an lsof that runs to nearly
-// herdrClientBudget and still SUCCEEDS leaves the loop nothing: every candidate
+// clientHostBudget and still SUCCEEDS leaves the loop nothing: every candidate
 // is abandoned and the answer is (nil, false). On a machine where lsof is
 // chronically slow-but-answering, a herdr host would then never resolve, where
 // before #1529 it resolved slowly. Three things bound that, and none of them
@@ -1269,7 +1439,7 @@ type clientPIDProbe func(ctx context.Context, socketPath string) (pids []int, pr
 // the git adapter — an unbounded call that answered slowly becomes a bounded
 // one that does not answer at all — and it is written down for the same reason.
 func resolveHerdrClientLauncherVia(socketPath string, scan clientPIDProbe, identify hostIdentityProbe) (*session.Launcher, bool) {
-	ctx, cancel := context.WithTimeout(context.Background(), herdrClientBudget)
+	ctx, cancel := context.WithTimeout(context.Background(), clientHostBudget)
 	defer cancel()
 	pids, probed := scan(ctx, socketPath)
 	if !probed {
@@ -1278,15 +1448,15 @@ func resolveHerdrClientLauncherVia(socketPath string, scan clientPIDProbe, ident
 	return resolveClientHostIdentityVia(ctx, pids, identify)
 }
 
-// herdrClientCacheTTL is short enough that attaching a client is picked up by
+// clientHostCacheTTL is short enough that attaching a client is picked up by
 // the next session bound after it, and long enough to collapse one startup
 // seed's worth of repeats into a single scan.
-const herdrClientCacheTTL = 5 * time.Second
+const clientHostCacheTTL = 5 * time.Second
 
-type herdrClientCacheEntry struct {
+type clientHostEntry struct {
 	launcher *session.Launcher
-	// probed carries herdrClientLauncher's second return through the memo. It
-	// is what makes caching a non-answer safe: without it a cached nil is
+	// probed carries the resolver's second return through the memo. It is what
+	// makes caching a non-answer safe: without it a cached nil is
 	// indistinguishable from a cached detach, and the next pane to read this
 	// socket would be told its client is gone on the strength of a probe that
 	// never ran — #1485's defect, re-entered through the cache.
@@ -1294,58 +1464,78 @@ type herdrClientCacheEntry struct {
 	at     time.Time
 }
 
+// clientHostMemo is the per-socket memo in front of one attached-client
+// resolver. #1544's rule decides its LIFETIME and it is the opposite end of
+// that pairing from bundleIDMemo: who is attached to a multiplexer socket
+// changes by the second — detach-here-reattach-there is the entire point of a
+// persistent multiplexer — so this one carries a TTL and bundleIDMemo, whose
+// subject is immutable, carries none.
+//
+// One type, two instances (below), because #1514's admission rule is subtle
+// enough that a second hand-written copy is a second chance to get the
+// non-answer semantics wrong — which is the defect this memo exists to avoid
+// re-introducing, not a style preference. The instances are separate rather
+// than one shared map because a herdr socket path and a tmux socket path are
+// different namespaces that happen to share a key type, and one map would let
+// a collision serve a herdr answer to a tmux pane.
+type clientHostMemo struct {
+	mu      sync.Mutex
+	entries map[string]clientHostEntry
+}
+
 var (
-	herdrClientCacheMu sync.Mutex
-	herdrClientCache   = map[string]herdrClientCacheEntry{}
+	// herdrClientHosts memoizes herdr's lsof-based client scan (#1350/#1514).
+	herdrClientHosts = &clientHostMemo{entries: map[string]clientHostEntry{}}
+	// tmuxClientHosts memoizes tmux's `list-clients` scan (#1501).
+	tmuxClientHosts = &clientHostMemo{entries: map[string]clientHostEntry{}}
 )
 
-// herdrClientCacheGet reports what the last probe of socketPath determined.
-// The entry rather than its fields, because launcher and probed are the same
-// tri-state herdrClientLauncher returns — a cached "nothing attached" is
-// (nil, probed) while a cached non-answer is (nil, !probed), and two adjacent
-// bools in a return list is the one shape a future call site can transpose
-// silently. Collapsing those two states would be #1485.
+// get reports what the last probe of socketPath determined. The entry rather
+// than its fields, because launcher and probed are the same tri-state the
+// resolver returns — a cached "nothing attached" is (nil, probed) while a
+// cached non-answer is (nil, !probed), and two adjacent bools in a return list
+// is the one shape a future call site can transpose silently. Collapsing those
+// two states would be #1485.
 //
 // A hit deliberately does NOT restamp entry.at. Refreshing on read would let a
 // socket busy enough to be read every sweep hold a stale entry — in particular
 // a stale non-answer — indefinitely; leaving the stamp alone bounds any entry
 // to one TTL from the probe that produced it, however often it is read.
-func herdrClientCacheGet(socketPath string) (herdrClientCacheEntry, bool) {
-	herdrClientCacheMu.Lock()
-	defer herdrClientCacheMu.Unlock()
-	return herdrClientCacheLive(socketPath)
+func (m *clientHostMemo) get(socketPath string) (clientHostEntry, bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.live(socketPath)
 }
 
-// herdrClientCacheLive returns socketPath's entry when it has not expired, and
-// drops it when it has — so sockets that stop being used don't accumulate.
-// Callers hold herdrClientCacheMu.
+// live returns socketPath's entry when it has not expired, and drops it when it
+// has — so sockets that stop being used don't accumulate. Callers hold m.mu.
 //
 // Split out so the expiry rule has exactly one spelling. Both readers need it
 // and they need it with opposite polarity, which is precisely the pair that
 // drifts.
-func herdrClientCacheLive(socketPath string) (herdrClientCacheEntry, bool) {
-	entry, ok := herdrClientCache[socketPath]
+func (m *clientHostMemo) live(socketPath string) (clientHostEntry, bool) {
+	entry, ok := m.entries[socketPath]
 	if !ok {
-		return herdrClientCacheEntry{}, false
+		return clientHostEntry{}, false
 	}
-	if time.Since(entry.at) > herdrClientCacheTTL {
-		delete(herdrClientCache, socketPath)
-		return herdrClientCacheEntry{}, false
+	if time.Since(entry.at) > clientHostCacheTTL {
+		delete(m.entries, socketPath)
+		return clientHostEntry{}, false
 	}
 	return entry, true
 }
 
-// herdrClientCachePut records what a probe of socketPath determined. A
-// non-answer never displaces a live answer.
+// put records what a probe of socketPath determined. A non-answer never
+// displaces a live answer.
 //
 // That guard is new with the memo and is the one hazard memoizing non-answers
 // introduces: before #1514 a non-answer was never written, so it could not
 // overwrite anything. Two goroutines can miss the memo for one socket and
-// probe concurrently — refreshHerdrHosts reads outside assignMu, on the sweep
-// goroutine, while PID discovery reaches captureLauncher/backfillLauncher on
-// its own — and a non-answer is still by far the SLOWER outcome to produce: it
-// is the one that can spend the whole herdrClientBudget, where an answer stops
-// at the first candidate that resolves.
+// probe concurrently — refreshMultiplexerHosts reads outside assignMu, on the
+// sweep goroutine, while PID discovery reaches captureLauncher/backfillLauncher
+// on its own — and a non-answer is still by far the SLOWER outcome to produce:
+// it is the one that can spend the whole clientHostBudget, where an answer
+// stops at the first candidate that resolves.
 // So the loser of that race is systematically the one carrying no
 // information, and last-writer-wins would let it both erase a resolved host
 // and restamp the entry fresh, extending the deferral by another full TTL.
@@ -1354,13 +1544,29 @@ func herdrClientCacheLive(socketPath string) (herdrClientCacheEntry, bool) {
 // still expires on the schedule the probe that produced it set. The reverse
 // direction needs no guard — an answer displacing a non-answer is strictly
 // more information, which is the whole point of re-probing.
-func herdrClientCachePut(socketPath string, l *session.Launcher, probed bool) {
-	herdrClientCacheMu.Lock()
-	defer herdrClientCacheMu.Unlock()
+func (m *clientHostMemo) put(socketPath string, l *session.Launcher, probed bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	if !probed {
-		if prev, live := herdrClientCacheLive(socketPath); live && prev.probed {
+		if prev, live := m.live(socketPath); live && prev.probed {
 			return
 		}
 	}
-	herdrClientCache[socketPath] = herdrClientCacheEntry{launcher: l, probed: probed, at: time.Now()}
+	m.entries[socketPath] = clientHostEntry{launcher: l, probed: probed, at: time.Now()}
+}
+
+// resolve answers from the memo or runs probe, recording whatever it
+// determined. It is the shape every consumer of a client indirection goes
+// through, so the memo cannot be bypassed by one producer and honoured by the
+// other.
+func (m *clientHostMemo) resolve(socketPath string, probe func(string) (*session.Launcher, bool)) (*session.Launcher, bool) {
+	if socketPath == "" {
+		return nil, false
+	}
+	if cached, hit := m.get(socketPath); hit {
+		return cached.launcher, cached.probed
+	}
+	resolved, probed := probe(socketPath)
+	m.put(socketPath, resolved, probed)
+	return resolved, probed
 }

--- a/core/adapters/inbound/agents/processlifecycle/osutil_darwin_test.go
+++ b/core/adapters/inbound/agents/processlifecycle/osutil_darwin_test.go
@@ -667,11 +667,11 @@ func TestHerdrClientPIDs_ProbeTriState(t *testing.T) {
 // The third case is the vacuity guard: a cache that reported probed=false for
 // everything would satisfy the first two and destroy the tri-state.
 func TestHerdrClientLauncher_MemoizedNonAnswerIsStillANonAnswer(t *testing.T) {
-	memoized := func(t *testing.T, socketPath string) herdrClientCacheEntry {
+	memoized := func(t *testing.T, socketPath string) clientHostEntry {
 		t.Helper()
-		herdrClientCacheMu.Lock()
-		defer herdrClientCacheMu.Unlock()
-		entry, ok := herdrClientCache[socketPath]
+		herdrClientHosts.mu.Lock()
+		defer herdrClientHosts.mu.Unlock()
+		entry, ok := herdrClientHosts.entries[socketPath]
 		if !ok {
 			t.Fatal("nothing was memoized: every pane sharing this socket re-pays the probe (#1514)")
 		}
@@ -712,13 +712,13 @@ func TestHerdrClientLauncher_MemoizedNonAnswerIsStillANonAnswer(t *testing.T) {
 	t.Run("a hit returns what was memoized", func(t *testing.T) {
 		// Without this the whole family is satisfiable by a cache that returns
 		// the right tri-state and drops the launcher — measured: making
-		// herdrClientCacheGet return a nil launcher leaves every other test in
+		// clientHostMemo.get return a nil launcher leaves every other test in
 		// the package green, while panes 2..N of a herdr server silently lose
 		// their host. The socket has no client log, so a read that reached the
 		// prober instead of the memo would answer probed=false and fail here.
 		socketPath := newHerdrSessionDir(t)
 		want := &session.Launcher{TermProgram: "iTerm.app", HostBundleID: "com.googlecode.iterm2"}
-		herdrClientCachePut(socketPath, want, true)
+		herdrClientHosts.put(socketPath, want, true)
 		t.Cleanup(func() { forgetHerdrClientMemo(socketPath) })
 
 		got, probed := herdrClientLauncher(socketPath)
@@ -748,7 +748,7 @@ func TestHerdrClientLauncher_MemoizedNonAnswerIsStillANonAnswer(t *testing.T) {
 
 // TestReadLauncherEnv_Herdr_UnprobableClientReportsHostUnknown is #1485 at the
 // port boundary: the reader has to carry the distinction all the way out, or
-// the sweep that consumes it (refreshHerdrHosts) cannot act on it. The pane's
+// the sweep that consumes it (refreshMultiplexerHosts) cannot act on it. The pane's
 // own identity is unaffected either way — only the second return value moves.
 func TestReadLauncherEnv_Herdr_UnprobableClientReportsHostUnknown(t *testing.T) {
 	socketPath := newHerdrSessionDir(t) // no client log
@@ -1172,9 +1172,9 @@ func TestResolveClientHostIdentity_ResolvableCandidateStillWins(t *testing.T) {
 // than a copy per test. One caller uses it mid-test, standing in for the TTL
 // elapsing; the rest wire it through t.Cleanup.
 func forgetHerdrClientMemo(socketPath string) {
-	herdrClientCacheMu.Lock()
-	defer herdrClientCacheMu.Unlock()
-	delete(herdrClientCache, socketPath)
+	herdrClientHosts.mu.Lock()
+	defer herdrClientHosts.mu.Unlock()
+	delete(herdrClientHosts.entries, socketPath)
 }
 
 // countingLsof makes the herdr client log at logPath answer as an lsof table,
@@ -1345,7 +1345,7 @@ func TestHerdrClientPIDs_DedupesFDRowsOfOneClient(t *testing.T) {
 // TestHerdrClientCachePut_NonAnswerDoesNotDisplaceALiveAnswer locks the one
 // hazard memoizing non-answers introduces. Before #1514 a non-answer was never
 // written, so it could not overwrite anything; now two goroutines can miss the
-// memo for one socket and probe concurrently (refreshHerdrHosts reads outside
+// memo for one socket and probe concurrently (refreshMultiplexerHosts reads outside
 // assignMu on the sweep goroutine, PID discovery reaches captureLauncher on its
 // own), and the non-answer is systematically the slower of the two to produce.
 // Last-writer-wins would let the one carrying no information erase a resolved
@@ -1360,8 +1360,8 @@ func TestHerdrClientCachePut_NonAnswerDoesNotDisplaceALiveAnswer(t *testing.T) {
 		want := &session.Launcher{TermProgram: "iTerm.app"}
 		t.Cleanup(func() { forgetHerdrClientMemo(socketPath) })
 
-		herdrClientCachePut(socketPath, want, true)
-		herdrClientCachePut(socketPath, nil, false) // the slow loser lands second
+		herdrClientHosts.put(socketPath, want, true)
+		herdrClientHosts.put(socketPath, nil, false) // the slow loser lands second
 
 		got, probed := herdrClientLauncher(socketPath)
 		if !probed || got != want {
@@ -1374,8 +1374,8 @@ func TestHerdrClientCachePut_NonAnswerDoesNotDisplaceALiveAnswer(t *testing.T) {
 		want := &session.Launcher{TermProgram: "iTerm.app"}
 		t.Cleanup(func() { forgetHerdrClientMemo(socketPath) })
 
-		herdrClientCachePut(socketPath, nil, false)
-		herdrClientCachePut(socketPath, want, true)
+		herdrClientHosts.put(socketPath, nil, false)
+		herdrClientHosts.put(socketPath, want, true)
 
 		got, probed := herdrClientLauncher(socketPath)
 		if !probed || got != want {
@@ -1385,7 +1385,7 @@ func TestHerdrClientCachePut_NonAnswerDoesNotDisplaceALiveAnswer(t *testing.T) {
 }
 
 // TestHerdrClientCache_ExpiresANonAnswer is the load-bearing half of #1514's
-// argument, and it was missing: deleting herdrClientCacheLive's expiry check
+// argument, and it was missing: deleting clientHostMemo.live's expiry check
 // entirely left every other test in the package green (measured).
 //
 // The case for reversing #1485 is that a memoized non-answer costs only a
@@ -1407,11 +1407,11 @@ func TestHerdrClientCache_ExpiresANonAnswer(t *testing.T) {
 		t.Fatalf("first read cost %d scans, want 1", got)
 	}
 
-	herdrClientCacheMu.Lock()
-	entry := herdrClientCache[socketPath]
-	entry.at = time.Now().Add(-herdrClientCacheTTL - time.Second)
-	herdrClientCache[socketPath] = entry
-	herdrClientCacheMu.Unlock()
+	herdrClientHosts.mu.Lock()
+	entry := herdrClientHosts.entries[socketPath]
+	entry.at = time.Now().Add(-clientHostCacheTTL - time.Second)
+	herdrClientHosts.entries[socketPath] = entry
+	herdrClientHosts.mu.Unlock()
 
 	if _, probed := herdrClientLauncher(socketPath); probed {
 		t.Fatal("the re-probe finds the same unreadable candidate")

--- a/core/adapters/inbound/agents/processlifecycle/osutil_linux.go
+++ b/core/adapters/inbound/agents/processlifecycle/osutil_linux.go
@@ -111,3 +111,11 @@ func hostGateFor(pid int) hostGateOutcome { return observeHostGate(hostGateNotEv
 // platform never looks, and a caller merging the read into a stored launcher
 // must not read that silence as a client having detached.
 func herdrClientLauncher(socketPath string) (*session.Launcher, bool) { return nil, false }
+
+// tmuxClientLauncher resolves a tmux pane's window through the attached client
+// (#1501). Darwin-only for the same reason herdrClientLauncher is: the identity
+// it produces is only consumed by the macOS click-to-focus path, and resolving
+// it needs the same ancestry walk the stubs above already decline to do.
+//
+// So the answer here is "not probed" (#1485), not "nothing attached".
+func tmuxClientLauncher(socketPath string) (*session.Launcher, bool) { return nil, false }

--- a/core/adapters/inbound/agents/processlifecycle/osutil_other.go
+++ b/core/adapters/inbound/agents/processlifecycle/osutil_other.go
@@ -77,3 +77,11 @@ func hostGateFor(pid int) hostGateOutcome { return observeHostGate(hostGateNotEv
 // platform never looks, and a caller merging the read into a stored launcher
 // must not read that silence as a client having detached.
 func herdrClientLauncher(socketPath string) (*session.Launcher, bool) { return nil, false }
+
+// tmuxClientLauncher resolves a tmux pane's window through the attached client
+// (#1501). Darwin-only for the same reason herdrClientLauncher is: the identity
+// it produces is only consumed by the macOS click-to-focus path, and resolving
+// it needs the same ancestry walk the stubs above already decline to do.
+//
+// So the answer here is "not probed" (#1485), not "nothing attached".
+func tmuxClientLauncher(socketPath string) (*session.Launcher, bool) { return nil, false }

--- a/core/adapters/inbound/agents/processlifecycle/probecount.go
+++ b/core/adapters/inbound/agents/processlifecycle/probecount.go
@@ -73,6 +73,12 @@ const (
 	probePgrepDiscover probeKind = "pgrep.discover"
 	// probeKittenWindow is kittyWindowIDForPID's `kitten @ ls` (#1537).
 	probeKittenWindow probeKind = "kitten.window"
+	// probeTmuxClients is tmuxClientPIDs' `tmux -S <sock> list-clients` (#1501)
+	// — the tmux twin of probeLsofHerdrClients, and its own row for the reason
+	// this file keys per call site: the two answer the same QUESTION ("who is
+	// displaying this pane") with different tools, so one bucket could not say
+	// which multiplexer stopped resolving.
+	probeTmuxClients probeKind = "tmux.list_clients"
 )
 
 // allProbeKinds is every declared kind. It is the set
@@ -88,6 +94,7 @@ var allProbeKinds = []probeKind{
 	probeLsofHerdrClients,
 	probePgrepDiscover,
 	probeKittenWindow,
+	probeTmuxClients,
 }
 
 // probeTally is one kind's three counters.
@@ -191,7 +198,7 @@ func observeProbeMemoHit(kind probeKind) {
 
 // herdrCandidates counts the two ways resolveClientHostIdentityVia's loop can
 // end for a candidate: it probed one, or it abandoned the rest on the aggregate
-// budget (#1529's herdrClientBudget).
+// budget (#1529's clientHostBudget).
 //
 // This is #1558, and it is counted HERE rather than deferred because that issue
 // says so in its own words: "#1534 is that nothing counts probe non-answers,
@@ -274,7 +281,7 @@ type HerdrCandidateCounts struct {
 	// Probed is how many attached-client candidates the loop asked about.
 	Probed uint64
 	// AbandonedOnBudget is how many times the loop stopped early because
-	// herdrClientBudget was already spent — one per event, not per candidate.
+	// clientHostBudget was already spent — one per event, not per candidate.
 	AbandonedOnBudget uint64
 }
 

--- a/core/adapters/inbound/agents/processlifecycle/shellout.go
+++ b/core/adapters/inbound/agents/processlifecycle/shellout.go
@@ -30,7 +30,7 @@ import (
 // Since #1529 every site derives this ceiling FROM the caller's context rather
 // than from context.Background(), so a child is killed at whichever comes
 // first: its own ceiling, or an aggregate deadline the caller imposed across a
-// whole sequence of them (herdrClientBudget is the one such aggregate today;
+// whole sequence of them (clientHostBudget is the one such aggregate today;
 // noAggregateBudget names the reads that deliberately have none). Nothing about
 // the per-child value changed — what changed is that a caller can now cap the
 // SUM, which this constant never could.

--- a/core/adapters/inbound/agents/processlifecycle/shellout_guard_test.go
+++ b/core/adapters/inbound/agents/processlifecycle/shellout_guard_test.go
@@ -118,11 +118,15 @@ const runProbeName = "runProbe"
 
 // shelloutClassifiers are the UNQUALIFIED calls that count as answering "did
 // the child answer?". lsofProbeRan is here because it IS probeAnswered with
-// lsof's allowlist bound (osutil_darwin.go); a third tool-specific wrapper
-// would be added here in the same breath as being written.
+// lsof's allowlist bound (osutil_darwin.go), and #1501's tmuxListedClients is
+// the third: it is probeAnswered with an EMPTY allowlist and a further exit-0
+// requirement, because tmux has no "nothing to report" status at all. A fourth
+// tool-specific wrapper is added here in the same breath as being written —
+// that instruction has now been followed once, which is the evidence it works.
 var shelloutClassifiers = map[string]bool{
-	"probeAnswered": true,
-	"lsofProbeRan":  true,
+	"probeAnswered":     true,
+	"lsofProbeRan":      true,
+	"tmuxListedClients": true,
 }
 
 // shelloutPkgClassifiers are the QUALIFIED spellings, keyed by the source text
@@ -612,15 +616,15 @@ func TestEveryChildProcessRunsThroughRunProbe(t *testing.T) {
 //
 //   - shelloutTimeout bounds ONE child process. Every shellout in this package
 //     derives it, and #1538's whole point is that the value stays one fact.
-//   - herdrClientBudget bounds a SEQUENCE of them — the lsof scan plus every
+//   - clientHostBudget bounds a SEQUENCE of them — the lsof scan plus every
 //     herdr client candidate behind it — which is a bound shelloutTimeout
 //     cannot express, and its absence is exactly what #1529 was filed about.
 //
 // A third entry is a reviewable diff, which is the property an "any named
 // identifier" rule would have thrown away.
 var namedCeilings = map[string]bool{
-	"shelloutTimeout":   true,
-	"herdrClientBudget": true,
+	"shelloutTimeout":  true,
+	"clientHostBudget": true,
 }
 
 // TestEveryBoundedShelloutUsesTheNamedCeiling is #1538's second half. The 2s
@@ -633,7 +637,7 @@ var namedCeilings = map[string]bool{
 // expressible". Re-derived against the tree as it actually is, that argument
 // does not hold, and it fails twice over:
 //
-//   - There are TWO WithTimeout sites after runProbe, not one. herdrClientBudget
+//   - There are TWO WithTimeout sites after runProbe, not one. clientHostBudget
 //     bounds a SEQUENCE of children (#1529) and so is not a child shellout and
 //     does not live inside runProbe. A second aggregate is foreseeable —
 //     noAggregateBudget's own doc names IsKnownInteractiveHost's ancestry walk
@@ -672,7 +676,7 @@ func TestEveryBoundedShelloutUsesTheNamedCeiling(t *testing.T) {
 	// A floor, not "> 0", for the same reason the classification rule counts
 	// run sites rather than asking whether it saw any at all. Since #1547 it
 	// equals the population rather than sitting below it: there is exactly one
-	// child ceiling (runProbe's) and one aggregate (herdrClientBudget's), and
+	// child ceiling (runProbe's) and one aggregate (clientHostBudget's), and
 	// either disappearing means the scan is looking somewhere else — a third
 	// entry raises this number in the same reviewable diff that adds it.
 	const knownCeilings = 2

--- a/core/adapters/inbound/agents/processlifecycle/tmuxclient_darwin_test.go
+++ b/core/adapters/inbound/agents/processlifecycle/tmuxclient_darwin_test.go
@@ -1,0 +1,532 @@
+//go:build darwin
+
+package processlifecycle
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"irrlicht/core/domain/session"
+)
+
+// This file covers #1501: a tmux pane's host resolved from the client tmux
+// itself names, rather than from a process-ancestry walk that terminates at
+// the reparented server.
+//
+// The live half is deliberately NOT committed here. Driving a real tmux server
+// needs a tmux on the machine, a short-enough socket path (sun_path is capped
+// at 104 bytes, which t.TempDir() under /var/folders exceeds) and a pty for the
+// client — none of which a CI runner has, and a test that SKIPS on all three is
+// a gate whose absence reads as a pass. What the live run measured is recorded
+// where the code depends on it instead: tmuxListedClients' exit-status table
+// and tmuxClientLauncher's reparenting note.
+
+// fakeTmux writes an executable stand-in for the tmux CLI that prints stdout
+// and exits with code, and points tmuxPath at it for the duration of the test.
+// It is how the whole chain — scan, candidate loop, adoption — is driven
+// without a tmux server.
+func fakeTmux(t *testing.T, stdout string, code int) {
+	t.Helper()
+	script := filepath.Join(t.TempDir(), "tmux")
+	// A script rather than a Go fake, because tmuxClientPIDs closes its
+	// arguments over an exec.CommandContext on tmuxPath — the seam being
+	// exercised is that var, so the fake has to be an executable.
+	body := "#!/bin/sh\nprintf '%s' \"" + stdout + "\"\nexit " + strconv.Itoa(code) + "\n"
+	if err := os.WriteFile(script, []byte(body), 0o700); err != nil {
+		t.Fatalf("write fake tmux: %v", err)
+	}
+	prev := tmuxPath
+	tmuxPath = script
+	t.Cleanup(func() { tmuxPath = prev })
+}
+
+// forgetTmuxClientMemo drops socketPath's memo entry. Every socket a test
+// touches leaves one behind — non-answers included — so this is the single
+// spelling of the locking protocol, mirroring forgetHerdrClientMemo.
+func forgetTmuxClientMemo(socketPath string) {
+	tmuxClientHosts.mu.Lock()
+	defer tmuxClientHosts.mu.Unlock()
+	delete(tmuxClientHosts.entries, socketPath)
+}
+
+func TestTmuxClientPIDsFrom(t *testing.T) {
+	cases := map[string]struct {
+		out  string
+		want []int
+	}{
+		"one client":                                  {"38291\n", []int{38291}},
+		"two clients":                                 {"24980\n25162\n", []int{24980, 25162}},
+		"no trailing newline":                         {"7", []int{7}},
+		"detached: exit 0, no rows":                   {"", nil},
+		"blank lines are skipped":                     {"\n\n41\n\n", []int{41}},
+		"a row we cannot parse is skipped, not fatal": {"nonsense\n41\n", []int{41}},
+		"a nonsense pid is skipped":                   {"0\n-3\n41\n", []int{41}},
+	}
+	for name, tc := range cases {
+		if got := tmuxClientPIDsFrom(tc.out); !reflect.DeepEqual(got, tc.want) {
+			t.Errorf("%s: tmuxClientPIDsFrom(%q) = %v, want %v", name, tc.out, got, tc.want)
+		}
+	}
+}
+
+// TestTmuxListedClients is the classification #1501 could most easily have got
+// wrong by copying lsofProbeRan. tmux has no "nothing to report" status: the
+// detach case is exit ZERO with empty output, so every non-zero exit is a
+// failure to reach the server and carries no verdict about who is attached.
+//
+// Getting it wrong is not a cosmetic difference — it is #1485 in a new tool. A
+// socket we cannot reach would be reported as an authoritative detach, and the
+// sweep would clear a resolved host on it.
+func TestTmuxListedClients(t *testing.T) {
+	if !tmuxListedClients(nil) {
+		t.Error("exit 0 is the only answer tmux gives, and it must be one")
+	}
+	// The discriminator against lsof's reading, spelled as a comparison so the
+	// two classifiers cannot silently converge.
+	exit1 := runFakeExit(t, 1)
+	if tmuxListedClients(exit1) {
+		t.Error("tmux exit 1 is 'no server running' / 'error connecting' — not a detach")
+	}
+	if !lsofProbeRan(exit1) {
+		t.Error("lsof's exit 1 IS an answer; if this ever changes the contrast above stops being the point")
+	}
+	if tmuxListedClients(runFakeExit(t, 2)) {
+		t.Error("no non-zero exit is allowlisted for tmux")
+	}
+	if _, err := runProbe(context.Background(), probeTmuxClients, missingBinaryCmd()); tmuxListedClients(err) {
+		t.Error("a child that never started answered nothing (#1538)")
+	}
+}
+
+// runFakeExit produces the error a child that ran to a normal exit with code
+// returns — the shape probeAnswered classifies, obtained from a real child
+// rather than a hand-built *exec.ExitError.
+func runFakeExit(t *testing.T, code int) error {
+	t.Helper()
+	_, err := runProbe(context.Background(), probeTmuxClients, answeringCmd(strconv.Itoa(code)))
+	if code != 0 && err == nil {
+		t.Fatalf("exit %d must produce an error", code)
+	}
+	return err
+}
+
+func TestTmuxClientPIDsVia(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("a live server reports its clients newest-attach-first", func(t *testing.T) {
+		pids, probed := tmuxClientPIDsVia(ctx, answeringStdout("24980\n25162\n"))
+		if !probed {
+			t.Fatal("exit 0 answered")
+		}
+		// Descending PID: pids are allocated ascending, so the newest attach is
+		// the window the user most recently chose. Same rule as herdr's.
+		if !reflect.DeepEqual(pids, []int{25162, 24980}) {
+			t.Errorf("got %v, want newest-first [25162 24980]", pids)
+		}
+	})
+
+	t.Run("a live server with nothing attached is an ANSWER", func(t *testing.T) {
+		pids, probed := tmuxClientPIDsVia(ctx, answeringStdout(""))
+		if !probed {
+			t.Fatal("exit 0 with no rows is 'nothing is displaying this pane', not a failed probe")
+		}
+		if len(pids) != 0 {
+			t.Errorf("got %v, want none", pids)
+		}
+	})
+
+	t.Run("an unreachable server is NOT a detach", func(t *testing.T) {
+		if _, probed := tmuxClientPIDsVia(ctx, answeringCmd("1")); probed {
+			t.Error("exit 1 must poison the answer, or a stale socket clears a live host (#1485)")
+		}
+	})
+
+	t.Run("a child that never started is not a detach either", func(t *testing.T) {
+		if _, probed := tmuxClientPIDsVia(ctx, missingBinaryCmd()); probed {
+			t.Error("a probe that did not run says nothing about who is attached")
+		}
+	})
+}
+
+// answeringStdout builds a child that prints out on stdout and exits 0 — the
+// shape `tmux list-clients -F` answers in.
+func answeringStdout(out string) shelloutCmd {
+	return func(ctx context.Context) *exec.Cmd {
+		return exec.CommandContext(ctx, "/bin/sh", "-c", "printf '%s' \"$0\"", out)
+	}
+}
+
+// TestTmuxClientPIDs_NoBinaryIsNotADetach pins the reading tmuxClientPIDs
+// deliberately does NOT share with kittyWindowIDForPIDVia's absent kitten. A
+// session in a tmux pane is standing proof that tmux exists on this machine, so
+// failing to find the binary is our lookup failing, not a fact about the
+// installation — and answering "nothing attached" would clear a host on it.
+func TestTmuxClientPIDs_NoBinaryIsNotADetach(t *testing.T) {
+	prev := tmuxPath
+	tmuxPath = ""
+	t.Cleanup(func() { tmuxPath = prev })
+	if _, probed := tmuxClientPIDs(context.Background(), "/tmp/whatever"); probed {
+		t.Error("no tmux binary is 'I could not look', not 'nobody is attached'")
+	}
+	tmuxPath = prev
+	if _, probed := tmuxClientPIDs(context.Background(), ""); probed {
+		t.Error("no socket path is no address to ask about")
+	}
+}
+
+// TestTmuxClientPIDsIsCountedUnderItsOwnKind is #1534's runtime half for the
+// ninth probe: the site reaches the counter, under tmux.list_clients and
+// nothing else. TestEveryProbeSiteDeclaresItsOwnKind grades the declaration
+// statically; this grades the wiring.
+func TestTmuxClientPIDsIsCountedUnderItsOwnKind(t *testing.T) {
+	before := readProbeLedger()
+	if _, probed := tmuxClientPIDsVia(context.Background(), answeringStdout("41\n")); !probed {
+		t.Fatal("exit 0 answered")
+	}
+	assertProbesMoved(t, before, map[string]ProbeCount{
+		"tmux.list_clients": {Probe: "tmux.list_clients", Answered: 1},
+	}, "tmuxClientPIDsVia's shellout is the tmux.list_clients probe")
+
+	before = readProbeLedger()
+	if _, probed := tmuxClientPIDsVia(context.Background(), missingBinaryCmd()); probed {
+		t.Fatal("a tmux that never started must report probed=false")
+	}
+	assertProbesMoved(t, before, map[string]ProbeCount{
+		"tmux.list_clients": {Probe: "tmux.list_clients", Unanswered: 1},
+	}, "the non-answer is the one that must not read as a detach")
+}
+
+// TestResolveTmuxClientLauncherVia covers the tri-state the whole indirection
+// hands its caller. The loop, the cap and the budget behind it are
+// resolveClientHostIdentityVia's and are covered by the #1492/#1529 tests; what
+// is new here is that tmux's scan feeds it with the same (pids, probed) shape
+// herdr's does.
+func TestResolveTmuxClientLauncherVia(t *testing.T) {
+	iterm := func(context.Context, int) (*session.Launcher, bool) {
+		return &session.Launcher{TermProgram: "iTerm.app", TTY: "/dev/ttys012"}, true
+	}
+
+	t.Run("a scan that did not run answers nothing", func(t *testing.T) {
+		scan := func(context.Context, string) ([]int, bool) { return nil, false }
+		if host, probed := resolveTmuxClientLauncherVia("/s", scan, iterm); host != nil || probed {
+			t.Errorf("got (%+v, %v), want (nil, false)", host, probed)
+		}
+	})
+
+	t.Run("no client attached is an answer, and it is 'no host'", func(t *testing.T) {
+		scan := func(context.Context, string) ([]int, bool) { return nil, true }
+		host, probed := resolveTmuxClientLauncherVia("/s", scan, iterm)
+		if host != nil {
+			t.Errorf("nothing is displaying this pane: %+v", host)
+		}
+		if !probed {
+			t.Error("every candidate (none) was read, so this is evidence")
+		}
+	})
+
+	t.Run("an attached client's identity is the pane's host", func(t *testing.T) {
+		scan := func(context.Context, string) ([]int, bool) { return []int{4242}, true }
+		host, probed := resolveTmuxClientLauncherVia("/s", scan, iterm)
+		if !probed || host == nil || host.TermProgram != "iTerm.app" {
+			t.Fatalf("got (%+v, %v), want the client's identity", host, probed)
+		}
+	})
+
+	t.Run("a candidate that could not be read poisons the negative answer", func(t *testing.T) {
+		scan := func(context.Context, string) ([]int, bool) { return []int{4242}, true }
+		unreadable := func(context.Context, int) (*session.Launcher, bool) {
+			return &session.Launcher{}, false
+		}
+		if host, probed := resolveTmuxClientLauncherVia("/s", scan, unreadable); host != nil || probed {
+			t.Errorf("got (%+v, %v), want (nil, false) — #1492 inherited for free", host, probed)
+		}
+	})
+}
+
+// TestTmuxClientHostMemoCollapsesRepeats is #1501's cost profile in the form
+// that actually matters: every pane of one tmux server shares a socket, and a
+// user with eight panes open is ordinary. Without the memo the startup seed and
+// every liveness sweep would pay one scan per pane.
+func TestTmuxClientHostMemoCollapsesRepeats(t *testing.T) {
+	socket := filepath.Join(t.TempDir(), "tmux-sock")
+	t.Cleanup(func() { forgetTmuxClientMemo(socket) })
+
+	scans := 0
+	probe := func(string) (*session.Launcher, bool) {
+		scans++
+		return &session.Launcher{TermProgram: "ghostty"}, true
+	}
+	for i := 0; i < 8; i++ {
+		if host, probed := tmuxClientHosts.resolve(socket, probe); !probed || host.TermProgram != "ghostty" {
+			t.Fatalf("resolve %d: got (%+v, %v)", i, host, probed)
+		}
+	}
+	if scans != 1 {
+		t.Errorf("eight panes of one server cost %d scans, want 1", scans)
+	}
+}
+
+// TestTmuxAndHerdrMemosDoNotShareEntries pins the reason clientHostMemo is a
+// TYPE with two instances rather than one map keyed by socket path: the two
+// namespaces are unrelated, and a collision would serve one multiplexer's
+// answer to the other's pane.
+func TestTmuxAndHerdrMemosDoNotShareEntries(t *testing.T) {
+	socket := filepath.Join(t.TempDir(), "same-path")
+	t.Cleanup(func() { forgetTmuxClientMemo(socket); forgetHerdrClientMemo(socket) })
+
+	tmuxClientHosts.put(socket, &session.Launcher{TermProgram: "ghostty"}, true)
+	if _, hit := herdrClientHosts.get(socket); hit {
+		t.Error("a tmux answer must not be served to a herdr pane on the same path")
+	}
+}
+
+// spawnClientSleeperWithEnv starts a stand-in for an attached client that
+// outlives the whole test.
+//
+// spawnSleeperWithEnv's helper exits after 3s, and under a loaded
+// `go test ./core/... -race` run these cases reached ReadLauncherEnv after it
+// had gone — so hostIdentity read a dead pid, answered complete=false, and the
+// case failed on the fixture rather than on the code. Measured: one such flake
+// in a full-suite run. GO_WANT_LAUNCHER_HELPER_HOLD is TestHelperProcess's
+// existing 30s path, added for the herdr tests for the same reason.
+func spawnClientSleeperWithEnv(t *testing.T, env []string) int {
+	t.Helper()
+	return spawnSleeperWithEnv(t, append(env,
+		"GO_WANT_LAUNCHER_HELPER_HOLD="+filepath.Join(t.TempDir(), "held")))
+}
+
+// spawnPaneSleeperWithEnv starts a helper whose PARENT IS INIT, which is what
+// makes it a faithful stand-in for a process inside a tmux pane.
+//
+// spawnSleeperWithEnv's helper is a child of the test binary, so its ancestry
+// walk climbs `go test` → the shell → the terminal and resolves a host — and
+// that host is precisely what tmuxPaneAwaitsItsClient reads as "this process
+// reported a host of its own, leave it alone". A real pane cannot do that: the
+// tmux server daemonizes and is reparented to PID 1 (measured, tmux 3.6a), so
+// the walk from a pane terminates at init having found nothing, which is what
+// leaves the two host fields empty for a genuine pane and for nothing else.
+//
+// Backgrounding from a shell that then exits reproduces exactly that
+// reparenting, and it is the difference between this file testing the gate and
+// testing the harness: without it these cases fail on the fixture's ancestry
+// rather than on anything the code did.
+func spawnPaneSleeperWithEnv(t *testing.T, env []string) int {
+	t.Helper()
+	cmd := exec.Command("/bin/sh", "-c",
+		os.Args[0]+" -test.run='^TestHelperProcess$' -test.count=1 >/dev/null 2>&1 & echo $!")
+	cmd.Env = append([]string{
+		"GO_WANT_LAUNCHER_HELPER=1",
+		// Outlives the test for the reason spawnClientSleeperWithEnv gives.
+		"GO_WANT_LAUNCHER_HELPER_HOLD=" + filepath.Join(t.TempDir(), "held"),
+	}, env...)
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("spawn orphaned helper: %v", err)
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(out)))
+	if err != nil {
+		t.Fatalf("helper pid %q: %v", out, err)
+	}
+	t.Cleanup(func() { _ = syscall.Kill(pid, syscall.SIGKILL) })
+	// Give the kernel a beat to publish the exec'd env to sysctl, and the
+	// shell a beat to exit so the reparenting has actually happened.
+	time.Sleep(120 * time.Millisecond)
+	if ppid, _, err := readProcInfo(context.Background(), pid); err != nil || ppid != 1 {
+		t.Fatalf("helper %d has ppid %d (err %v), want 1: this fixture only stands in for a "+
+			"tmux pane while its ancestry terminates at init", pid, ppid, err)
+	}
+	return pid
+}
+
+// --- end to end, through ReadLauncherEnv ------------------------------------
+//
+// These drive the whole chain against real processes whose env sysctl can
+// actually read (spawnSleeperWithEnv self-execs the unsigned test binary),
+// with only the tmux CLI faked. That is the seam worth faking: everything
+// below it — the env whitelist, launcherFromEnv's suppression, the ancestry
+// fallbacks, hostIdentity of the client, AdoptHostIdentity's put-back — is the
+// production code.
+
+// TestReadLauncherEnv_Tmux_AttachedClientIsTheHost is the green half of
+// #1501's defect. Measured live before the fix, against a real tmux 3.6a
+// server with a client attached: the pane resolved to
+// {TmuxPane, TmuxSocket, TTY} and nothing else, so
+// SessionLauncher.resolveActivator returned nil and clicking the session did
+// nothing.
+func TestReadLauncherEnv_Tmux_AttachedClientIsTheHost(t *testing.T) {
+	clientPID := spawnClientSleeperWithEnv(t, []string{
+		"PATH=/usr/bin:/bin",
+		"TERM_PROGRAM=iTerm.app",
+		"ITERM_SESSION_ID=w0t0p0-CLIENT",
+	})
+	fakeTmux(t, strconv.Itoa(clientPID)+"\n", 0)
+
+	socket := "/tmp/tmux-501/e2e-attached"
+	t.Cleanup(func() { forgetTmuxClientMemo(socket) })
+	agentPID := spawnPaneSleeperWithEnv(t, []string{
+		"PATH=/usr/bin:/bin",
+		"TERM_PROGRAM=tmux",
+		"TMUX=" + socket + ",1234,0",
+		"TMUX_PANE=%17",
+	})
+
+	l, hostKnown := ReadLauncherEnv(agentPID)
+	if l == nil {
+		t.Fatal("expected non-nil launcher")
+	}
+	if !hostKnown {
+		t.Error("the scan ran and answered, so the host was determined")
+	}
+	if l.TermProgram != "iTerm.app" || l.ITermSessionID != "w0t0p0-CLIENT" {
+		t.Errorf("the attached client's window was not adopted: %+v", l)
+	}
+	if l.TmuxPane != "%17" || l.TmuxSocket != socket {
+		t.Errorf("the pane lost the address control and TmuxActivator route on: %+v", l)
+	}
+}
+
+// TestReadLauncherEnv_Tmux_DetachedResolvesNoHost is the honest-failure half,
+// and the exact counterpart of the herdr one: a tmux server with no client
+// attached answers exit 0 with no rows, which is evidence that nothing is
+// displaying this pane rather than a probe that failed.
+func TestReadLauncherEnv_Tmux_DetachedResolvesNoHost(t *testing.T) {
+	fakeTmux(t, "", 0)
+
+	socket := "/tmp/tmux-501/e2e-detached"
+	t.Cleanup(func() { forgetTmuxClientMemo(socket) })
+	agentPID := spawnPaneSleeperWithEnv(t, []string{
+		"PATH=/usr/bin:/bin",
+		"TERM_PROGRAM=tmux",
+		"TMUX=" + socket + ",1234,0",
+		"TMUX_PANE=%17",
+		// Inherited from whatever terminal started the server, and wrong:
+		// #1499's suppression is what keeps these out, and this asserts the
+		// client indirection does not put them back by another route.
+		"ITERM_SESSION_ID=w0t0p0-STALE",
+		"KITTY_WINDOW_ID=42",
+	})
+
+	l, hostKnown := ReadLauncherEnv(agentPID)
+	if l == nil {
+		t.Fatal("expected non-nil launcher (the pane address is still identity)")
+	}
+	if !hostKnown {
+		t.Error("an empty client list is an ANSWER: the server was reached")
+	}
+	if l.TermProgram != "" || l.HostBundleID != "" {
+		t.Errorf("no client is attached, so no host may be reported: %+v", l)
+	}
+	if l.ITermSessionID != "" || l.KittyWindowID != "" {
+		t.Errorf("inherited identity must stay suppressed: %+v", l)
+	}
+	if l.TmuxPane != "%17" {
+		t.Errorf("TmuxPane: got %q", l.TmuxPane)
+	}
+}
+
+// TestReadLauncherEnv_Tmux_UnreachableServerKeepsNothingAndKnowsNothing is the
+// third state. An exit-1 tmux says nothing about who is attached, so hostKnown
+// must be false — that bit is the only thing standing between a stale socket
+// and the sweep clearing a resolved host on it (#1485/#1492).
+func TestReadLauncherEnv_Tmux_UnreachableServerKeepsNothingAndKnowsNothing(t *testing.T) {
+	fakeTmux(t, "no server running on /tmp/x\n", 1)
+
+	socket := "/tmp/tmux-501/e2e-unreachable"
+	t.Cleanup(func() { forgetTmuxClientMemo(socket) })
+	agentPID := spawnPaneSleeperWithEnv(t, []string{
+		"PATH=/usr/bin:/bin",
+		"TERM_PROGRAM=tmux",
+		"TMUX=" + socket + ",1234,0",
+		"TMUX_PANE=%17",
+	})
+
+	l, hostKnown := ReadLauncherEnv(agentPID)
+	if l == nil {
+		t.Fatal("expected non-nil launcher")
+	}
+	if hostKnown {
+		t.Error("a tmux we could not reach determined nothing; reporting otherwise clears a live host on the next sweep")
+	}
+	if l.TmuxPane != "%17" {
+		t.Errorf("TmuxPane: got %q", l.TmuxPane)
+	}
+}
+
+// TestReadLauncherEnv_Tmux_InheritedPaneKeepsItsOwnHost is the guard that stops
+// #1501 from re-opening #1499. A GUI terminal or IDE launched from inside a
+// pane inherits $TMUX_PANE while reporting a perfectly good host of its own.
+// Resolving THAT pane's client and adopting it would replace a correct host
+// with the window displaying a pane the session is not in.
+//
+// Two claims, and the second is the one a naive gate fails: the identity
+// survives, AND tmux is never consulted at all — asserted by pointing tmuxPath
+// at a fake that would resolve a different host if it ran.
+func TestReadLauncherEnv_Tmux_InheritedPaneKeepsItsOwnHost(t *testing.T) {
+	otherClientPID := spawnClientSleeperWithEnv(t, []string{
+		"PATH=/usr/bin:/bin",
+		"TERM_PROGRAM=ghostty",
+	})
+	fakeTmux(t, strconv.Itoa(otherClientPID)+"\n", 0)
+
+	socket := "/tmp/tmux-501/e2e-inherited"
+	t.Cleanup(func() { forgetTmuxClientMemo(socket) })
+	agentPID := spawnClientSleeperWithEnv(t, []string{
+		"PATH=/usr/bin:/bin",
+		// Its own, reported by itself — so launcherFromEnv never suppressed it.
+		"TERM_PROGRAM=iTerm.app",
+		"ITERM_SESSION_ID=w0t0p0-OWN",
+		// Inherited from the pane the terminal was launched from.
+		"TMUX=" + socket + ",1234,0",
+		"TMUX_PANE=%17",
+	})
+
+	l, hostKnown := ReadLauncherEnv(agentPID)
+	if l == nil {
+		t.Fatal("expected non-nil launcher")
+	}
+	if l.TermProgram != "iTerm.app" || l.ITermSessionID != "w0t0p0-OWN" {
+		t.Errorf("a session that reported its own host must keep it: %+v", l)
+	}
+	if hostKnown {
+		t.Error("the pane this launcher ADDRESSES had its host looked up, which it must not have been: " +
+			"hostKnown=false is what stops the sweep adopting a fresh read over this session's own identity")
+	}
+}
+
+// TestReadLauncherEnv_Tmux_KittyLaunchedFromAPaneKeepsTheAncestryHost is the
+// harder version of the same guard, and the one the three-term gate exists for.
+// kitty sets no $TERM_PROGRAM of its own (upstream kitty#4793), so a kitty
+// launched from a tmux pane inherits TERM_PROGRAM=tmux along with $TMUX_PANE —
+// launcherFromEnv DOES suppress it, and the ancestry fallbacks are what
+// recover the real host. Keying the indirection on the pane address alone
+// would overwrite that recovery with the pane's client.
+//
+// The ancestry host is stood in for here by a HostBundleID: this test binary's
+// real ancestry is `go test`, not a terminal, so the fallbacks resolve nothing
+// on their own. What is being pinned is the gate's reading of the field, which
+// is why the assertion is that tmux was not consulted.
+func TestReadLauncherEnv_Tmux_KittyLaunchedFromAPaneKeepsTheAncestryHost(t *testing.T) {
+	l := &session.Launcher{
+		TmuxPane:     "%17",
+		TmuxSocket:   "/tmp/tmux-501/x",
+		HostBundleID: "net.kovidgoyal.kitty",
+	}
+	if tmuxPaneAwaitsItsClient(l) {
+		t.Error("a host recovered by the ancestry walk is this process's own; the pane's client must not replace it")
+	}
+	_, probed, addressesAPane := clientHostFor(l)
+	if !addressesAPane {
+		t.Error("it does carry a pane address — the sweep has to be told that, or it cannot tell this apart from a plain session")
+	}
+	if probed {
+		t.Error("that pane's host was not looked up, and saying otherwise lets a fresh read overwrite this identity")
+	}
+}

--- a/core/application/services/launcher_backfill_internal_test.go
+++ b/core/application/services/launcher_backfill_internal_test.go
@@ -16,7 +16,7 @@ import (
 // was never re-checked, so a session detached in one terminal and re-attached
 // in another kept naming the first one for the rest of its life. Eligibility is
 // now unconditional for a herdr pane, which is what lets the liveness sweep
-// re-resolve it (refreshHerdrHosts).
+// re-resolve it (refreshMultiplexerHosts).
 func TestLauncherBackfillNeedsFor_HerdrHost(t *testing.T) {
 	tests := map[string]struct {
 		launcher *session.Launcher
@@ -40,8 +40,8 @@ func TestLauncherBackfillNeedsFor_HerdrHost(t *testing.T) {
 		},
 	}
 	for name, tc := range tests {
-		if got := launcherBackfillNeedsFor(tc.launcher).herdrHost; got != tc.want {
-			t.Errorf("%s: herdrHost = %v, want %v", name, got, tc.want)
+		if got := launcherBackfillNeedsFor(tc.launcher).multiplexerHost; got != tc.want {
+			t.Errorf("%s: multiplexerHost = %v, want %v", name, got, tc.want)
 		}
 	}
 }
@@ -65,13 +65,13 @@ func TestLauncherBackfillNeedsFor_HerdrClientInKitty(t *testing.T) {
 		HerdrPaneID: "w1:p1",
 		TermProgram: "kitty", // the attached client's, adopted at capture
 	}
-	if want := (launcherBackfillNeeds{herdrHost: true, tty: true}); launcherBackfillNeedsFor(kittyClient) != want {
+	if want := (launcherBackfillNeeds{multiplexerHost: true, tty: true}); launcherBackfillNeedsFor(kittyClient) != want {
 		t.Errorf("no kitty need may fire for a herdr pane: got %+v, want %+v",
 			launcherBackfillNeedsFor(kittyClient), want)
 	}
 
 	kittyClient.TTY = "/dev/ttys077"
-	if want := (launcherBackfillNeeds{herdrHost: true}); launcherBackfillNeedsFor(kittyClient) != want {
+	if want := (launcherBackfillNeeds{multiplexerHost: true}); launcherBackfillNeedsFor(kittyClient) != want {
 		t.Errorf("a herdr pane with a tty needs only the host: got %+v, want %+v",
 			launcherBackfillNeedsFor(kittyClient), want)
 	}

--- a/core/application/services/pid_manager.go
+++ b/core/application/services/pid_manager.go
@@ -883,8 +883,8 @@ func (pm *PIDManager) DiscoverPIDWithRetry(sessionID, cwd, transcriptPath, adapt
 // are found for several consecutive sweeps.
 func (pm *PIDManager) SweepDeadPIDs(ctx context.Context) {
 	// baseInterval is read out of this source, by name and in this spelling, by
-	// processlifecycle's TestHerdrReadFitsTheLivenessSweepTick: this handler
-	// calls refreshHerdrHosts synchronously, so the herdr launcher read has to
+	// processlifecycle's TestClientHostReadFitsTheLivenessSweepTick: this handler
+	// calls refreshMultiplexerHosts synchronously, so the herdr launcher read has to
 	// fit inside one tick, and an adapter can neither import this package nor a
 	// function-local const. Renaming or moving it fails that test loudly rather
 	// than silently unpinning the bound — which is the intended behaviour, not a
@@ -941,10 +941,37 @@ type livenessSnapshot struct {
 	parentSessionID string
 	transcriptPath  string
 	adapter         string
-	// herdrPane marks a session hosted in a herdr pane — the one Launcher
-	// whose host identity is not static for the process's lifetime, and so
-	// the only one the sweep re-resolves (#1405, refreshHerdrHosts).
-	herdrPane bool
+	// multiplexerPane marks a session hosted in a herdr or tmux pane — the
+	// Launchers whose host identity is not static for the process's lifetime,
+	// and so the only ones the sweep re-resolves (#1405 for herdr, #1501 for
+	// tmux; refreshMultiplexerHosts).
+	multiplexerPane bool
+}
+
+// hostedInAMultiplexerPane reports whether l's host belongs to an attached
+// client rather than to l's own process — the gate that decides which sessions
+// the periodic refresh pays a read for.
+//
+// It is deliberately CHEAPER and wider than the test the reader itself applies
+// (processlifecycle.tmuxPaneAwaitsItsClient): this runs under assignMu for
+// every session on every sweep, so it may only look at fields, and the stored
+// launcher cannot distinguish a genuine tmux pane whose host was ADOPTED from
+// one whose $TMUX_PANE was merely inherited by a GUI terminal launched from a
+// pane — both end up with a pane address and a host, and nothing records which
+// process the host came from.
+//
+// What that costs is a read per sweep for such a session, and what it does NOT
+// cost is correctness: the reader re-derives the narrow test from the live env
+// every time, so an inherited-$TMUX_PANE session resolves to its OWN identity,
+// which is what it already stored, and the merge reports no change and writes
+// nothing. The wide gate spends work on it; it cannot corrupt it.
+//
+// (Removing even that cost means not storing a foreign pane address in the
+// first place — #1582, the pre-existing inherited-$TMUX_PANE bug, filed
+// separately because it is also what makes the backchannel address a foreign
+// pane, and that is the half worth fixing first.)
+func hostedInAMultiplexerPane(l *session.Launcher) bool {
+	return l != nil && (l.HerdrPaneID != "" || l.TmuxPane != "")
 }
 
 // snapshotLivenessStates reads every session's liveness-relevant fields under
@@ -968,7 +995,7 @@ func (pm *PIDManager) snapshotLivenessStates() []livenessSnapshot {
 			parentSessionID: state.ParentSessionID,
 			transcriptPath:  state.TranscriptPath,
 			adapter:         state.Adapter,
-			herdrPane:       state.Launcher != nil && state.Launcher.HerdrPaneID != "",
+			multiplexerPane: hostedInAMultiplexerPane(state.Launcher),
 		})
 	}
 	return snaps
@@ -1010,7 +1037,7 @@ func (pm *PIDManager) CheckPIDLiveness() bool {
 	// Last, so a session reaped above is already gone by the time its refresh
 	// tries to load it — and gets nothing back — rather than being written
 	// out again.
-	pm.refreshHerdrHosts(snaps)
+	pm.refreshMultiplexerHosts(snaps)
 	return foundDead
 }
 
@@ -1341,7 +1368,7 @@ func (pm *PIDManager) handleAlivePIDState(state *session.SessionState) bool {
 //     is the path by which one attached since then is picked up at startup.
 //     It is no longer the *only* such path: because a herdr pane's host is the
 //     one Launcher field that is not static for the process's lifetime, it is
-//     also re-resolved on every periodic liveness sweep (refreshHerdrHosts,
+//     also re-resolved on every periodic liveness sweep (refreshMultiplexerHosts,
 //     #1405). Both share launcherBackfillNeedsFor/applyLauncherBackfill, so
 //     the seed and the sweep cannot drift apart on what a refresh means.
 func (pm *PIDManager) backfillLauncher(state *session.SessionState) {
@@ -1375,7 +1402,7 @@ func (pm *PIDManager) touchAndSave(state *session.SessionState) {
 	_ = pm.repo.Save(state)
 }
 
-// refreshHerdrHosts re-resolves the host window of every herdr-hosted session,
+// refreshMultiplexerHosts re-resolves the host window of every herdr-hosted session,
 // on the periodic liveness sweep. Called from CheckPIDLiveness.
 //
 // Why the sweep and not capture time: every other Launcher field describes
@@ -1411,7 +1438,7 @@ func (pm *PIDManager) touchAndSave(state *session.SessionState) {
 //     probe per socket per TTL rather than N — "per sweep" while a pass runs
 //     inside one TTL, which is the normal case and is now also the case under
 //     the load that produces a non-answer, because #1529 capped what one such
-//     probe can cost (herdrClientBudget) rather than only how often it is
+//     probe can cost (clientHostBudget) rather than only how often it is
 //     paid. That now holds for every outcome,
 //     including the ones that determine nothing, and it did not always:
 //     #1492 routed an unreadable candidate to the same "could not look"
@@ -1431,10 +1458,10 @@ func (pm *PIDManager) touchAndSave(state *session.SessionState) {
 // The read runs outside assignMu deliberately: ReadLauncherEnv may block, and
 // assignMu serializes PID discovery for every session. Only the merge is taken
 // under the lock. What it may block FOR, on this path, is
-// processlifecycle.shelloutTimeout + herdrClientBudget: the pane's own
+// processlifecycle.shelloutTimeout + clientHostBudget: the pane's own
 // controlling-tty `ps` plus one aggregate deadline over the whole herdr client
 // indirection. That sum is asserted to fit inside baseInterval below, by
-// processlifecycle's TestHerdrReadFitsTheLivenessSweepTick, which reads this
+// processlifecycle's TestClientHostReadFitsTheLivenessSweepTick, which reads this
 // function's own cadence out of this file rather than restating it.
 //
 // This said "for up to two seconds", and it was wrong in the same way the
@@ -1443,7 +1470,7 @@ func (pm *PIDManager) touchAndSave(state *session.SessionState) {
 // this ticker — which drops ticks it overruns. #1529 gave that loop the
 // aggregate deadline; the memo above makes the cost rarer, and this is what
 // makes it short.
-func (pm *PIDManager) refreshHerdrHosts(snaps []livenessSnapshot) {
+func (pm *PIDManager) refreshMultiplexerHosts(snaps []livenessSnapshot) {
 	if pm.launcherEnv == nil {
 		return
 	}
@@ -1453,14 +1480,14 @@ func (pm *PIDManager) refreshHerdrHosts(snaps []livenessSnapshot) {
 	// every one of them a `ps` shellout for the controlling tty.
 	read := memoizedLauncherEnv(pm.launcherEnv)
 	for _, snap := range snaps {
-		if !snap.herdrPane || snap.pid <= 0 {
+		if !snap.multiplexerPane || snap.pid <= 0 {
 			continue
 		}
 		fresh, hostKnown := read(snap.pid)
 		if fresh == nil {
 			continue
 		}
-		state := pm.applyHerdrHostRefresh(snap.state.SessionID, fresh, hostKnown)
+		state := pm.applyMultiplexerHostRefresh(snap.state.SessionID, fresh, hostKnown)
 		if state == nil {
 			continue
 		}
@@ -1496,7 +1523,7 @@ func memoizedLauncherEnv(read LauncherEnvReader) LauncherEnvReader {
 	}
 }
 
-// applyHerdrHostRefresh merges fresh into sessionID's stored launcher and
+// applyMultiplexerHostRefresh merges fresh into sessionID's stored launcher and
 // persists it, returning the updated state when something actually changed and
 // nil otherwise — so the caller pushes only on a real move.
 //
@@ -1506,7 +1533,7 @@ func memoizedLauncherEnv(read LauncherEnvReader) LauncherEnvReader {
 // the one assignPIDLocked takes around its own load-modify-save of the same
 // session, which is what keeps a concurrent PID discovery from being clobbered
 // by this one.
-func (pm *PIDManager) applyHerdrHostRefresh(sessionID string, fresh *session.Launcher, hostKnown bool) *session.SessionState {
+func (pm *PIDManager) applyMultiplexerHostRefresh(sessionID string, fresh *session.Launcher, hostKnown bool) *session.SessionState {
 	var updated *session.SessionState
 	pm.WithSessionStateLock(func() {
 		// Gone: reaped between the snapshot and here — possibly earlier in this
@@ -1522,7 +1549,7 @@ func (pm *PIDManager) applyHerdrHostRefresh(sessionID string, fresh *session.Lau
 			return
 		}
 		needs := launcherBackfillNeedsFor(state.Launcher)
-		if !needs.herdrHost {
+		if !needs.multiplexerHost {
 			return
 		}
 		// The fresh read has to still be the same pane. It may not be: a PID
@@ -1535,7 +1562,14 @@ func (pm *PIDManager) applyHerdrHostRefresh(sessionID string, fresh *session.Lau
 		// wholesale — re-introducing the #1348 misroute on a timer, which is
 		// the opposite of what this refresh exists to do. A genuinely detached
 		// pane still carries its own address, so the honest clear survives.
-		if fresh.HerdrPaneID != state.Launcher.HerdrPaneID {
+		//
+		// SamePaneAs rather than a field comparison, because the question is
+		// about the session's OWN pane and which multiplexer that is now has
+		// two answers (#1501). Comparing both addresses would be wrong in the
+		// direction that matters: a herdr client running inside tmux
+		// contributes a TmuxPane of its own, and requiring THAT to be stable
+		// would freeze the refresh for exactly the sessions whose client moved.
+		if !state.Launcher.SamePaneAs(fresh) {
 			return
 		}
 		changed := applyLauncherBackfill(state.Launcher, needs, fresh, hostKnown)
@@ -1561,7 +1595,7 @@ func (pm *PIDManager) applyHerdrHostRefresh(sessionID string, fresh *session.Lau
 // launcherBackfillNeeds tracks which Launcher fields are missing and should
 // be refreshed from a fresh env read.
 type launcherBackfillNeeds struct {
-	tty, kittyPID, kittyListen, kittyWindow, herdrHost bool
+	tty, kittyPID, kittyListen, kittyWindow, multiplexerHost bool
 }
 
 // any reports whether anything needs refreshing. Compares against the zero
@@ -1575,8 +1609,8 @@ func (n launcherBackfillNeeds) any() bool {
 // eligible for backfill. The three Kitty-specific fields only ever need
 // backfilling for a kitty launcher.
 //
-// A herdr pane returns exactly one need, and it is unconditional. Both halves
-// of that matter:
+// A pane — herdr since #1350, tmux since #1501 — returns exactly one need, and
+// it is unconditional. Both halves of that matter:
 //
 //   - None of the kitty ones, because a pane owns no kitty field — they are
 //     adopted wholesale from the attached client (AdoptHostIdentity). Under
@@ -1590,7 +1624,7 @@ func (n launcherBackfillNeeds) any() bool {
 //   - The tty need stays, and it is the one host-ish field that is NOT covered
 //     by the adoption: AdoptHostIdentity deliberately refuses to move the
 //     client's tty onto a pane that has none, because BackgroundAgent.Detached
-//     is derived from it (#744). So a herdr launcher stored without a tty —
+//     is derived from it (#744). So a pane launcher stored without a tty —
 //     processTTY's `ps` timed out at capture, say — has no other route to
 //     acquiring one, and dropping this need would stall Terminal.app's
 //     tab-level targeting for that session permanently.
@@ -1600,9 +1634,23 @@ func (n launcherBackfillNeeds) any() bool {
 //     whole point of a persistent multiplexer, and gating on *no* host ever
 //     being recorded meant a session that moved terminals kept naming the one
 //     the user left (#1405).
+//
+// A TMUX pane ADDS the host need to the ordinary set instead of replacing it,
+// which is the one place the two multiplexers are not symmetric. The herdr
+// branch can replace, because $HERDR_PANE_ID is injected per pane and so always
+// describes THIS pane; $TMUX_PANE is inherited by every descendant, so this
+// branch is also reached by sessions whose host is their own and whose pane
+// address is stale. Suppressing their kitty needs would take a working
+// per-field backfill away from them in exchange for an adoption that
+// ReadLauncherEnv correctly refuses to make (its hostKnown is false for exactly
+// that shape), leaving them with neither.
+//
+// The wide gate is deliberate — hostedInAMultiplexerPane cannot tell an adopted
+// host from an inherited pane address, and that function says why the cost is
+// real and the risk is not.
 func launcherBackfillNeedsFor(l *session.Launcher) launcherBackfillNeeds {
 	if l.HerdrPaneID != "" {
-		return launcherBackfillNeeds{tty: l.TTY == "", herdrHost: true}
+		return launcherBackfillNeeds{tty: l.TTY == "", multiplexerHost: true}
 	}
 	isKitty := l.TermProgram == "kitty"
 	return launcherBackfillNeeds{
@@ -1610,6 +1658,10 @@ func launcherBackfillNeedsFor(l *session.Launcher) launcherBackfillNeeds {
 		kittyPID:    isKitty && l.KittyPID == 0,
 		kittyListen: isKitty && l.KittyListenOn == "",
 		kittyWindow: isKitty && l.KittyWindowID == "",
+		// Equivalent to hostedInAMultiplexerPane here — the herdr disjunct is
+		// already spent by the early return above — and spelled as the field so
+		// the two gates stay one set.
+		multiplexerHost: l.TmuxPane != "",
 	}
 }
 
@@ -1629,21 +1681,26 @@ func applyLauncherBackfill(l *session.Launcher, needs launcherBackfillNeeds, fre
 	if applyKittyLauncherBackfill(l, needs, fresh) {
 		updated = true
 	}
-	if applyHerdrHostBackfill(l, needs, fresh, hostKnown) {
+	if applyMultiplexerHostBackfill(l, needs, fresh, hostKnown) {
 		updated = true
 	}
 	return updated
 }
 
-// applyHerdrHostBackfill adopts the host identity a fresh read resolved from
-// the attached herdr client. Split out for the same reason
+// applyMultiplexerHostBackfill adopts the host identity a fresh read resolved
+// from the attached client. Split out for the same reason
 // applyKittyLauncherBackfill is — applyLauncherBackfill stays one branch per
 // *kind* of backfill — and because the two conditions it ANDs are unrelated
 // facts about different things, which is worth a line each rather than a
 // three-term conditional.
 //
-// needs.herdrHost comes from the STORED launcher: is this a herdr pane at all.
-// hostKnown comes from the FRESH read: did it determine a host. fresh was
+// needs.multiplexerHost comes from the STORED launcher: does this address a
+// pane at all.
+// hostKnown comes from the FRESH read: did it determine that pane's host — and
+// since #1501 those are genuinely two questions rather than one asked twice,
+// because a stored $TMUX_PANE can be inherited. Such a session satisfies the
+// need and fails hostKnown, and the AND below is what leaves its own identity
+// alone. fresh was
 // produced by the same reader, so its host fields are already the attached
 // client's, and a still-detached session yields none — AdoptHostIdentity then
 // reports no change rather than writing empties over empties.
@@ -1653,8 +1710,8 @@ func applyLauncherBackfill(l *session.Launcher, needs launcherBackfillNeeds, fre
 // resolved host on a probe that never ran (#1485). The stored host stays until
 // a probe actually answers; a genuine detach still clears it on the first
 // sweep whose probe runs.
-func applyHerdrHostBackfill(l *session.Launcher, needs launcherBackfillNeeds, fresh *session.Launcher, hostKnown bool) bool {
-	if !needs.herdrHost || !hostKnown {
+func applyMultiplexerHostBackfill(l *session.Launcher, needs launcherBackfillNeeds, fresh *session.Launcher, hostKnown bool) bool {
+	if !needs.multiplexerHost || !hostKnown {
 		return false
 	}
 	return l.AdoptHostIdentity(fresh)

--- a/core/application/services/pid_manager_tmux_refresh_test.go
+++ b/core/application/services/pid_manager_tmux_refresh_test.go
@@ -1,0 +1,234 @@
+package services_test
+
+import (
+	"testing"
+
+	"irrlicht/core/domain/session"
+)
+
+// This file is #1501's half of the periodic host refresh #1405 built for herdr.
+// A tmux pane's host is exactly as dynamic — detach here, re-attach there is
+// what a persistent multiplexer is FOR, and tmux re-attaches are at least as
+// common as herdr's — so a host resolved once and never revisited goes on
+// naming the terminal the user walked away from.
+//
+// The sweep is shared with herdr rather than duplicated: one snapshot flag, one
+// need, one identity check. pid_manager_herdr_refresh_test.go carries the herdr
+// side, and every assertion there is now also a lock on the generalization.
+
+// tmuxSession builds a live tmux-hosted session, reusing herdrSession's shape
+// (own PID for the liveness probe, fresh UpdatedAt to stay out of the readyTTL
+// reap) so the only thing these tests observe is the launcher.
+func tmuxSession(host *session.Launcher) *session.SessionState {
+	return herdrSession(host)
+}
+
+// TestCheckPIDLiveness_TmuxHostRefreshedOnReattach is the defect: the same one
+// #1405 fixed for herdr, arriving through the multiplexer this repo's users
+// are far more likely to be running.
+func TestCheckPIDLiveness_TmuxHostRefreshedOnReattach(t *testing.T) {
+	repo := newMockRepo()
+	repo.states["s"] = tmuxSession(&session.Launcher{
+		TmuxPane:       "%17",
+		TmuxSocket:     "/private/tmp/tmux-501/default",
+		TermProgram:    "iTerm.app",
+		ITermSessionID: "w0t0p0-OLD",
+		TTY:            "/dev/ttys012",
+	})
+
+	pm := newPIDManagerForTest(repo)
+	// A fresh read now resolves the client the user re-attached in. The pane
+	// address survives because AdoptHostIdentity puts it back — which is what
+	// makes the identity check below expressible at all.
+	pm.SetLauncherEnvReader(func(int) (*session.Launcher, bool) {
+		return &session.Launcher{
+			TmuxPane:    "%17",
+			TmuxSocket:  "/private/tmp/tmux-501/default",
+			TermProgram: "ghostty",
+			TTY:         "/dev/ttys077",
+		}, true
+	})
+
+	pm.CheckPIDLiveness()
+
+	got := repo.states["s"].Launcher
+	if got == nil {
+		t.Fatal("launcher went nil")
+	}
+	if got.TermProgram != "ghostty" {
+		t.Errorf("host not refreshed on the sweep: TermProgram = %q, want ghostty", got.TermProgram)
+	}
+	if got.ITermSessionID != "" {
+		t.Errorf("the previous client's iTerm selector survived the re-attach: %+v", got)
+	}
+	if got.TmuxPane != "%17" || got.TmuxSocket != "/private/tmp/tmux-501/default" {
+		t.Errorf("the pane address must survive: %+v", got)
+	}
+}
+
+// TestCheckPIDLiveness_TmuxHostClearedOnDetach is the other half. Nothing is
+// displaying the session, and a stale host is worse than none: the app raises
+// some unrelated window instead of doing nothing.
+func TestCheckPIDLiveness_TmuxHostClearedOnDetach(t *testing.T) {
+	repo := newMockRepo()
+	repo.states["s"] = tmuxSession(&session.Launcher{
+		TmuxPane:       "%17",
+		TmuxSocket:     "/private/tmp/tmux-501/default",
+		TermProgram:    "iTerm.app",
+		ITermSessionID: "w0t0p0-OLD",
+		TTY:            "/dev/ttys012",
+	})
+
+	pm := newPIDManagerForTest(repo)
+	pm.SetLauncherEnvReader(func(int) (*session.Launcher, bool) {
+		return &session.Launcher{
+			TmuxPane:   "%17",
+			TmuxSocket: "/private/tmp/tmux-501/default",
+			TTY:        "/dev/ttys012",
+		}, true
+	})
+
+	pm.CheckPIDLiveness()
+
+	got := repo.states["s"].Launcher
+	if got.TermProgram != "" || got.ITermSessionID != "" {
+		t.Errorf("no client is attached, so no host may be reported: %+v", got)
+	}
+	if got.TmuxPane != "%17" {
+		t.Errorf("the pane address must survive a detach: %+v", got)
+	}
+}
+
+// TestCheckPIDLiveness_TmuxHostSurvivesAnUnrunnableProbe is the polarity that
+// matters most, and the one a `tmux list-clients` makes easy to get wrong: exit
+// 1 means "no server running" / "error connecting", which says nothing about
+// who is attached. hostKnown=false has to leave the stored host alone
+// (#1485/#1492); adopting the empties would clear a live host on a probe that
+// never reached the server.
+func TestCheckPIDLiveness_TmuxHostSurvivesAnUnrunnableProbe(t *testing.T) {
+	repo := newMockRepo()
+	repo.states["s"] = tmuxSession(&session.Launcher{
+		TmuxPane:       "%17",
+		TmuxSocket:     "/private/tmp/tmux-501/default",
+		TermProgram:    "iTerm.app",
+		ITermSessionID: "w0t0p0-LIVE",
+		TTY:            "/dev/ttys012",
+	})
+
+	pm := newPIDManagerForTest(repo)
+	pm.SetLauncherEnvReader(func(int) (*session.Launcher, bool) {
+		return &session.Launcher{TmuxPane: "%17", TmuxSocket: "/private/tmp/tmux-501/default"}, false
+	})
+
+	pm.CheckPIDLiveness()
+
+	got := repo.states["s"].Launcher
+	if got.TermProgram != "iTerm.app" || got.ITermSessionID != "w0t0p0-LIVE" {
+		t.Errorf("a probe that did not run cleared a live host: %+v", got)
+	}
+}
+
+// TestCheckPIDLiveness_TmuxIgnoresAReadThatIsNoLongerThePane is the PID-reuse
+// guard. A PID can be recycled, and assignPIDLocked re-binds a session to a new
+// PID while its Launcher is set-once — so a fresh read can describe a
+// completely different process. Adopting it wholesale would put a stranger's
+// window on this session, on a timer.
+func TestCheckPIDLiveness_TmuxIgnoresAReadThatIsNoLongerThePane(t *testing.T) {
+	stored := &session.Launcher{
+		TmuxPane:       "%17",
+		TmuxSocket:     "/private/tmp/tmux-501/default",
+		TermProgram:    "iTerm.app",
+		ITermSessionID: "w0t0p0-LIVE",
+	}
+	for name, fresh := range map[string]*session.Launcher{
+		"the pid is in a different pane now": {TmuxPane: "%99", TermProgram: "ghostty"},
+		"the pid is in no pane at all now":   {TermProgram: "ghostty", ITermSessionID: "STRANGER"},
+		"the pid is in a herdr pane now":     {HerdrPaneID: "w1:p1", TermProgram: "ghostty"},
+	} {
+		repo := newMockRepo()
+		snapshot := *stored
+		repo.states["s"] = tmuxSession(&snapshot)
+
+		pm := newPIDManagerForTest(repo)
+		pm.SetLauncherEnvReader(func(int) (*session.Launcher, bool) { return fresh, true })
+		pm.CheckPIDLiveness()
+
+		if got := repo.states["s"].Launcher; *got != *stored {
+			t.Errorf("%s: a read of a different pane was adopted: %+v", name, got)
+		}
+	}
+}
+
+// TestCheckPIDLiveness_TmuxSteadyStateDoesNotChurn is the cost half of #1501's
+// third item: a client that has not moved must produce no Save, no UpdatedAt
+// bump and no push, however often the 5s sweep runs.
+//
+// It also asserts the session was actually VISITED, because "refreshed and
+// correctly declined to write" and "never looked at" are otherwise
+// indistinguishable and only the first is what this claims.
+func TestCheckPIDLiveness_TmuxSteadyStateDoesNotChurn(t *testing.T) {
+	repo := newMockRepo()
+	stored := &session.Launcher{
+		TmuxPane:    "%17",
+		TmuxSocket:  "/private/tmp/tmux-501/default",
+		TermProgram: "ghostty",
+		TTY:         "/dev/ttys077",
+	}
+	repo.states["s"] = tmuxSession(stored)
+
+	reads := 0
+	pm := newPIDManagerForTest(repo)
+	pm.SetLauncherEnvReader(func(int) (*session.Launcher, bool) {
+		reads++
+		copied := *stored
+		return &copied, true
+	})
+
+	before := repo.saves
+	pm.CheckPIDLiveness()
+	pm.CheckPIDLiveness()
+
+	if reads == 0 {
+		t.Fatal("the sweep never read this session, so it pins nothing about churn")
+	}
+	if repo.saves != before {
+		t.Errorf("an unmoved client was written back %d times", repo.saves-before)
+	}
+}
+
+// TestCheckPIDLiveness_InheritedTmuxPaneKeepsItsOwnHost is the guard that stops
+// the sweep from re-opening #1499. The snapshot gate is deliberately WIDE — a
+// stored launcher cannot tell an adopted host from an inherited pane address —
+// so a GUI terminal launched from inside a pane IS read every sweep. What must
+// not happen is its own identity being replaced by a fresh read that resolved
+// less: the reader answers hostKnown=false for that shape, and this pins that
+// the sweep honours it.
+func TestCheckPIDLiveness_InheritedTmuxPaneKeepsItsOwnHost(t *testing.T) {
+	repo := newMockRepo()
+	repo.states["s"] = tmuxSession(&session.Launcher{
+		TmuxPane:       "%17",
+		TmuxSocket:     "/private/tmp/tmux-501/default",
+		TermProgram:    "iTerm.app",
+		ITermSessionID: "w0t0p0-OWN",
+		TTY:            "/dev/ttys012",
+	})
+
+	pm := newPIDManagerForTest(repo)
+	// What ReadLauncherEnv returns for an inherited pane address whose own
+	// ancestry probe came back short: the identity is there but the PANE's host
+	// was never looked up.
+	pm.SetLauncherEnvReader(func(int) (*session.Launcher, bool) {
+		return &session.Launcher{
+			TmuxPane:   "%17",
+			TmuxSocket: "/private/tmp/tmux-501/default",
+			TTY:        "/dev/ttys012",
+		}, false
+	})
+
+	pm.CheckPIDLiveness()
+
+	got := repo.states["s"].Launcher
+	if got.TermProgram != "iTerm.app" || got.ITermSessionID != "w0t0p0-OWN" {
+		t.Errorf("a session that reported its own host had it cleared by the sweep: %+v", got)
+	}
+}

--- a/core/domain/session/session.go
+++ b/core/domain/session/session.go
@@ -111,15 +111,6 @@ func (s *subagentSummary) Equal(o *subagentSummary) bool {
 // ancestry fallbacks. It is a value that can only mask, never resolve, which
 // is why it is dropped rather than kept as a label.
 //
-// The consequence is that a genuine tmux pane currently resolves to no host at
-// all
-// — click-to-focus does nothing rather than raising the wrong window, which is
-// the same honest degradation a herdr session with no attached client gets.
-// Resolving the real host means asking tmux which client is attached
-// (`tmux -S <socket> list-clients -F '#{client_pid}'`, then reading that
-// process's identity the way a herdr client's is read). That is #1350's
-// counterpart for tmux and is deliberately not built here.
-//
 // The host fields on a herdr launcher are therefore populated from a different
 // process: the attached herdr *client*, which is what actually owns a window
 // (#1350). Provenance is the whole distinction — the same TmuxPane that is a
@@ -127,6 +118,14 @@ func (s *subagentSummary) Equal(o *subagentSummary) bool {
 // client's own, because then the client really is running in that tmux pane.
 // A session with no attached client keeps the two Herdr* fields alone, which
 // is the honest answer: nothing is displaying it anywhere.
+//
+// Since #1501 a tmux pane's host fields come from the same indirection, one
+// step cheaper: tmux is asked which clients are attached
+// (`tmux -S <socket> list-clients -F '#{client_pid}'`) instead of the socket
+// directory being scanned for them, and each client PID is then read exactly as
+// a herdr client's is. A pane with no client attached keeps TmuxPane/TmuxSocket
+// alone — nothing is displaying it — which is why a click on such a session
+// still does nothing rather than raising a stale window.
 type Launcher struct {
 	TermProgram    string `json:"term_program,omitempty"`     // $TERM_PROGRAM (e.g. iTerm.app, Apple_Terminal, vscode, cursor, ghostty, WezTerm, Hyper)
 	ITermSessionID string `json:"iterm_session_id,omitempty"` // $ITERM_SESSION_ID
@@ -176,27 +175,89 @@ func (l *Launcher) IsEmpty() bool {
 		l.HostBundleID == "" && l.HerdrPaneID == "" && l.HerdrSocketPath == "")
 }
 
+// paneKind names which multiplexer a launcher's session lives in, as decided
+// by (*Launcher).pane below.
+type paneKind string
+
+const (
+	paneKindNone  paneKind = ""
+	paneKindHerdr paneKind = "herdr"
+	paneKindTmux  paneKind = "tmux"
+)
+
+// ownPane is the multiplexer pane a launcher's session lives IN — the address
+// that is the PANE's rather than the displaying window's.
+type ownPane struct {
+	kind paneKind
+	id   string
+}
+
+// pane reports which multiplexer pane this launcher's session lives in.
+//
+// The precedence is herdr-then-tmux, and it is not a preference: it is the
+// SAME precedence processlifecycle.launcherFromEnv applies when it captures
+// these fields, and the reason is #1348 — a herdr server started from inside a
+// tmux pane hands every pane it will ever spawn a $TMUX_PANE that is the
+// server's, not the agent's. A launcher carrying both addresses is therefore a
+// herdr pane whose tmux address is inherited, never a tmux pane that also
+// happens to be a herdr one. Deciding it here rather than at each call site is
+// what stops the capture and the adoption from drifting to opposite answers.
+//
+// A launcher in NEITHER — a plain terminal session — reports paneKindNone, and
+// callers must treat that as "this is not a pane" rather than as a default.
+func (l *Launcher) pane() ownPane {
+	switch {
+	case l == nil:
+		return ownPane{}
+	case l.HerdrPaneID != "":
+		return ownPane{kind: paneKindHerdr, id: l.HerdrPaneID}
+	case l.TmuxPane != "":
+		return ownPane{kind: paneKindTmux, id: l.TmuxPane}
+	}
+	return ownPane{}
+}
+
+// SamePaneAs reports whether other describes the same multiplexer pane as l.
+//
+// It exists for the one check that stands between a periodic host refresh and
+// a PID-reuse misroute: a PID can be recycled by an unrelated process, and a
+// fresh read of it describes whatever that process is in. Comparing the pane
+// address — kind AND id, so a pane that changed multiplexer is not "the same
+// pane with a new address" — is what tells a client that MOVED (the thing the
+// refresh exists to observe) from a session that is no longer there at all.
+//
+// Two launchers in no pane at all are not "the same pane": paneKindNone is an
+// absence, and answering true for it would let a refresh adopt a stranger's
+// identity onto a session whose own address had gone.
+func (l *Launcher) SamePaneAs(other *Launcher) bool {
+	mine := l.pane()
+	if mine.kind == paneKindNone {
+		return false
+	}
+	return mine == other.pane()
+}
+
 // AdoptHostIdentity copies every host-window field of from onto l, leaving
-// l's own herdr address untouched, and reports whether anything changed. It is
-// how a herdr pane acquires the identity of the client that displays it: the
-// pane supplies the address to focus, the client supplies the window to raise.
+// l's own pane address untouched, and reports whether anything changed. It is
+// how a multiplexer pane acquires the identity of the client that displays it:
+// the pane supplies the address to focus, the client supplies the window to
+// raise.
 //
 // A nil or empty from is a no-op, so "no client attached" degrades to the
-// herdr-only launcher rather than to a half-populated one. Callers must only
+// address-only launcher rather than to a half-populated one. Callers must only
 // pass a launcher they resolved from the attached client — the point of #1348
 // is that the pane's own environment is not that.
 func (l *Launcher) AdoptHostIdentity(from *Launcher) bool {
 	if l == nil || from.IsEmpty() {
 		return false
 	}
-	// Copy wholesale and put back the two fields that are the *pane's*, rather
-	// than listing the host fields one by one. The host set grows (it has
-	// eleven members and gains one per terminal integration) while the herdr
-	// address is closed at two, so enumerating the closed set is what keeps a
-	// newly added host field from being silently left behind here.
+	// Copy wholesale and put back the pane's own address, rather than listing
+	// the host fields one by one. The host set grows (it has eleven members and
+	// gains one per terminal integration) while a pane address is closed at two
+	// fields, so enumerating the closed set is what keeps a newly added host
+	// field from being silently left behind here.
 	merged := *from
-	merged.HerdrPaneID = l.HerdrPaneID
-	merged.HerdrSocketPath = l.HerdrSocketPath
+	l.putBackOwnPaneAddress(&merged)
 	// TTY needs both sides, and the guard is symmetric on purpose:
 	// BackgroundAgent.Detached is computed from this field (#744), so a client
 	// resolved without a controlling tty must not erase the pane's own — and,
@@ -213,6 +274,42 @@ func (l *Launcher) AdoptHostIdentity(from *Launcher) bool {
 	}
 	*l = merged
 	return true
+}
+
+// putBackOwnPaneAddress restores onto merged the address that is l's PANE's
+// rather than the displaying window's — the closed set AdoptHostIdentity's
+// wholesale copy is allowed to overwrite and must not.
+//
+// WHICH closed set is l.pane()'s answer, and #1501 is why that is a question at
+// all. Until then the only pane that adopted anything was a herdr one, so the
+// put-back could name Herdr* unconditionally. A tmux pane adopts too now, and
+// its address has to survive the copy for exactly the same reason:
+// TmuxPane/TmuxSocket are what the backchannel routes on
+// (control.resolveBackend) and what the macOS TmuxActivator selects with, and
+// the attached client carries neither — it is a GUI terminal, not a pane.
+// Leaving them behind would resolve the window and lose the pane inside it,
+// which is a worse outcome than the nil it replaced: a click would raise the
+// right window and select nothing, and control would fall through to a backend
+// addressing a different process.
+//
+// Only the pane's OWN address is put back. A herdr client that is itself
+// running inside tmux contributes real TmuxPane/TmuxSocket fields — the client
+// really is in that pane — and those must pass through, which is what
+// control.resolveBackend's herdr-before-tmux ordering depends on.
+func (l *Launcher) putBackOwnPaneAddress(merged *Launcher) {
+	switch l.pane().kind {
+	case paneKindHerdr:
+		merged.HerdrPaneID = l.HerdrPaneID
+		merged.HerdrSocketPath = l.HerdrSocketPath
+	case paneKindTmux:
+		merged.TmuxPane = l.TmuxPane
+		merged.TmuxSocket = l.TmuxSocket
+	case paneKindNone:
+		// Not reachable from either production call site — both resolve a
+		// client only for a launcher that IS a pane — and pinned as a lock
+		// rather than left to be inferred. There is no own address to keep, so
+		// from stands whole.
+	}
 }
 
 // SessionState represents the current state of a Claude Code or Copilot session.

--- a/core/domain/session/session_test.go
+++ b/core/domain/session/session_test.go
@@ -187,3 +187,120 @@ func TestLauncher_AdoptHostIdentity_TTYlessAgentStaysTTYless(t *testing.T) {
 		t.Errorf("TermProgram: want iTerm.app, got %q", detachedAgent.TermProgram)
 	}
 }
+
+// TestLauncher_AdoptHostIdentity_TmuxPaneKeepsItsAddress is #1501's defect
+// test, and the riskiest line of that change: AdoptHostIdentity's "put back"
+// set was closed at the two Herdr* fields, so a tmux pane adopting its
+// client's identity would have been handed a launcher with the client's window
+// and NO pane address — the client is a GUI terminal and carries none.
+//
+// Losing it is worse than the nil it replaced. TmuxPane/TmuxSocket are what
+// control.resolveBackend routes the backchannel on and what the macOS
+// TmuxActivator selects with, so the result would be a click that raises the
+// right window and selects nothing, and a control path that falls through to
+// whatever backend the remaining fields happen to match.
+//
+// Seen RED against origin/main, where the put-back names only the herdr
+// address.
+func TestLauncher_AdoptHostIdentity_TmuxPaneKeepsItsAddress(t *testing.T) {
+	pane := &Launcher{
+		TmuxPane:   "%17",
+		TmuxSocket: "/private/tmp/tmux-501/default",
+		TTY:        "/dev/ttys900", // the pane's own pty
+	}
+	client := &Launcher{
+		TermProgram:    "iTerm.app",
+		ITermSessionID: "w0t0p0-CLIENT",
+		TTY:            "/dev/ttys012",
+		HostBundleID:   "com.googlecode.iterm2",
+	}
+	if !pane.AdoptHostIdentity(client) {
+		t.Fatal("adopting a populated client identity must report a change")
+	}
+	if pane.TermProgram != "iTerm.app" || pane.ITermSessionID != "w0t0p0-CLIENT" {
+		t.Errorf("host identity not adopted: %+v", pane)
+	}
+	if pane.TmuxPane != "%17" || pane.TmuxSocket != "/private/tmp/tmux-501/default" {
+		t.Errorf("the pane lost the address the backchannel routes on: %+v", pane)
+	}
+	if pane.TTY != "/dev/ttys012" {
+		t.Errorf("TTY: want the client's tab, got %q", pane.TTY)
+	}
+}
+
+// TestLauncher_AdoptHostIdentity_HerdrPaneKeepsTheClientsTmuxAddress is the
+// lock the #1501 put-back had to not break. A herdr client can itself be
+// running inside a tmux pane, in which case its TmuxPane/TmuxSocket are its
+// OWN and describe the window displaying the herdr pane —
+// control.resolveBackend's herdr-before-tmux ordering exists precisely because
+// both addresses can be present and mean different things.
+//
+// So the put-back is the pane's own address only, chosen by the same
+// herdr-then-tmux precedence processlifecycle.launcherFromEnv captures with. A
+// put-back that unconditionally cleared both address pairs would erase this.
+func TestLauncher_AdoptHostIdentity_HerdrPaneKeepsTheClientsTmuxAddress(t *testing.T) {
+	pane := &Launcher{HerdrPaneID: "w1:p2", HerdrSocketPath: "/cfg/herdr/herdr.sock"}
+	pane.AdoptHostIdentity(&Launcher{
+		TermProgram: "iTerm.app",
+		TmuxPane:    "%4",
+		TmuxSocket:  "/private/tmp/tmux-501/default",
+		TTY:         "/dev/ttys012",
+	})
+	if pane.HerdrPaneID != "w1:p2" || pane.HerdrSocketPath != "/cfg/herdr/herdr.sock" {
+		t.Errorf("the herdr pane's own address must survive: %+v", pane)
+	}
+	if pane.TmuxPane != "%4" || pane.TmuxSocket != "/private/tmp/tmux-501/default" {
+		t.Errorf("the client's own tmux address must pass through: %+v", pane)
+	}
+}
+
+// TestLauncher_AdoptHostIdentity_NoPaneKeepsNothing pins the third branch.
+// A launcher in no pane at all has no own address to put back, so from stands
+// whole. Unreachable from either production call site — both resolve a client
+// only for a launcher that IS a pane — and pinned rather than left to be
+// inferred from the absence of a branch.
+func TestLauncher_AdoptHostIdentity_NoPaneKeepsNothing(t *testing.T) {
+	plain := &Launcher{TermProgram: "ghostty"}
+	plain.AdoptHostIdentity(&Launcher{TermProgram: "iTerm.app", TmuxPane: "%9", HerdrPaneID: "w1:p1"})
+	if plain.TmuxPane != "%9" || plain.HerdrPaneID != "w1:p1" {
+		t.Errorf("with no own pane address there is nothing to put back: %+v", plain)
+	}
+}
+
+// TestLauncher_SamePaneAs is what stands between the periodic host refresh and
+// a PID-reuse misroute (services.applyMultiplexerHostRefresh).
+func TestLauncher_SamePaneAs(t *testing.T) {
+	cases := map[string]struct {
+		stored, fresh *Launcher
+		want          bool
+	}{
+		"same herdr pane": {
+			&Launcher{HerdrPaneID: "w1:p1"}, &Launcher{HerdrPaneID: "w1:p1"}, true,
+		},
+		"same tmux pane": {
+			&Launcher{TmuxPane: "%17"}, &Launcher{TmuxPane: "%17"}, true,
+		},
+		"a herdr pane whose client moved into tmux is still the same pane": {
+			&Launcher{HerdrPaneID: "w1:p1", TmuxPane: "%4"},
+			&Launcher{HerdrPaneID: "w1:p1", TmuxPane: "%9"},
+			true,
+		},
+		"tmux pane rebound to another pane": {
+			&Launcher{TmuxPane: "%17"}, &Launcher{TmuxPane: "%18"}, false,
+		},
+		"the pid is no longer in any pane": {
+			&Launcher{TmuxPane: "%17"}, &Launcher{TermProgram: "ghostty"}, false,
+		},
+		"the pid moved from tmux into herdr": {
+			&Launcher{TmuxPane: "%17"}, &Launcher{HerdrPaneID: "w1:p1"}, false,
+		},
+		"neither is in a pane": {
+			&Launcher{TermProgram: "ghostty"}, &Launcher{TermProgram: "ghostty"}, false,
+		},
+	}
+	for name, tc := range cases {
+		if got := tc.stored.SamePaneAs(tc.fresh); got != tc.want {
+			t.Errorf("%s: SamePaneAs = %v, want %v", name, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
Resolves a tmux pane's host window from the client tmux itself names, so
clicking a tmux-hosted session raises the window displaying it.

Closes #1501.

## The state this starts from

#1486 / PR #1499 established by live measurement that a tmux pane's captured
host identity is the tmux server's launch environment, frozen and handed to
every pane it will ever spawn, and removed it. That was right, and it left a
genuine pane resolving to `{tmux_pane, tmux_socket, tty}` and nothing else —
so `SessionLauncher.resolveActivator` returns nil, `TmuxActivator` is a
decorator over a nil base, and clicking such a session does nothing.

Process ancestry cannot recover it: the tmux server daemonizes and is
reparented to PID 1. Measured again here on tmux 3.6a — a pane's process has
the server as its parent and the server has init.

## What this does

herdr's #1350 with a cheaper first stage. Instead of scanning for who holds a
per-session client log open, tmux is asked:

```
tmux -S <socket> list-clients -F '#{client_pid}'
```

and each client PID goes through `hostIdentity`, into
`resolveClientHostIdentityVia` — the loop #1510 shared for exactly this queued
second producer, so the candidate cap, the aggregate deadline, the #1492
"unreadable candidate poisons the negative answer" rule and #1529's budget
abandonment all come along unchanged.

### The three decisions #1501 named

**1. `AdoptHostIdentity`'s put-back set.** It was the closed pair
`HerdrPaneID` + `HerdrSocketPath`. It is now *the pane's own address*, chosen
by the herdr-then-tmux precedence `launcherFromEnv` already captures with
(`Launcher.pane`), and lives in `putBackOwnPaneAddress` so `AdoptHostIdentity`
states one rule per paragraph. Without this a tmux pane adopts the client's window and
loses `TmuxPane`/`TmuxSocket` — the address `control.resolveBackend` routes
the backchannel on and the macOS `TmuxActivator` selects with. That is worse
than the nil it replaces: the click raises the right window and selects
nothing, and control falls through to a backend addressing a different
process. Only the pane's OWN address is put back, so a herdr client that is
itself running inside tmux still contributes real `Tmux*` fields — which
`resolveBackend`'s herdr-before-tmux ordering depends on, and which a
put-back that cleared both pairs would have erased.

**2. The refresh hook.** The liveness sweep re-resolves tmux panes as it does
herdr ones. Generalised rather than duplicated: `snap.multiplexerPane`,
`needs.multiplexerHost`, and one identity check that is now
`Launcher.SamePaneAs` — asking about the session's own pane rather than about
one named field, because for a herdr pane whose client moved into a different
tmux pane, requiring `TmuxPane` stability would freeze the refresh for exactly
the sessions it exists to observe. `refreshHerdrHosts` →
`refreshMultiplexerHosts` and friends follow.

**3. Cost.** `clientHostBudget` (was `herdrClientBudget`) is shared, and that
is the decision: what it bounds is the candidate loop, which is literally the
same function for both producers, and the sweep-tick assertion is over ONE
number — two constants would let one drift past the tick while the test passed
on the other. The scans differ by more than an order of magnitude (measured:
`list-clients` 14ms/call against `lsof` at roughly 0.3s), and a cheaper scan
wants the same aggregate, not a smaller one — it leaves more of it for the
candidates. The memo is `clientHostMemo`, one type with two instances
(`herdrClientHosts`, `tmuxClientHosts`), so #1514's rule that a non-answer
never displaces a live answer has one implementation rather than two; a list
of attached clients is mutable, so it keeps the TTL, which is the opposite end
of #1544's pairing from `bundleIDMemo`.

Zero tmux sessions still cost literally nothing: the sweep gate is one bool
per session read off the stored launcher.

### tmux's exit statuses are the opposite of lsof's

Measured, tmux 3.6a:

| situation | exit | stdout |
|---|---|---|
| live server, no client attached | 0 | empty |
| no server at that path | 1 | `no server running on <path>` |
| path is not a socket | 1 | `error connecting to <path> …` |
| path does not exist | 1 | `error connecting to <path> …` |

So the detach case — lsof's exit 1, pgrep's exit 1 — is tmux's exit **zero**.
`tmuxListedClients` allowlists nothing: copying `lsofProbeRan` would report
every socket we cannot reach as an authoritative "nobody is displaying this
session", which is #1485's defect in a new tool and on the one path that
clears a resolved host.

### Composed with, not around

- **#1547** — the `list-clients` shellout goes through `runProbe`; nothing
  else in the package starts a child.
- **#1534** — a new kind, `tmux.list_clients`. Its own row rather than
  herdr's, because the two answer the same question with different tools and
  one bucket could not say which multiplexer stopped resolving.
- **#1529** — shared budget, one context across scan and candidates, derived
  by the resolve rather than taken from a caller.
- **#1544** — TTL'd per-socket memo (mutable subject), not the process-global
  shape.
- **#1525** — the host gate is **unaffected**, and that is a claim I checked
  rather than assumed: `IsKnownInteractiveHost` walks the AGENT's ancestry
  (`hostGateOutcomeVia(ctx, pid, …)`), never the launcher, and this change
  touches no ancestry input. A tmux-resolved host changes nothing the gate
  sees.

## Evidence

### The defect, live, before the fix

A real tmux 3.6a server on a private socket, a real attached client, the
production `ReadLauncherEnv` — with the production files restored to
`origin/main` by copy-aside/copy-back:

```
attached client pids: "37996"
pane pid=37993 agent pid=37993
LAUNCHER: {TermProgram: ITermSessionID: TermSessionID: TmuxPane:%0
  TmuxSocket:/tmp/ir1501756541103/s VSCodePID:0 TTY:/dev/ttys027 KittyListenOn:
  KittyWindowID: KittyPID:0 HostBundleID: HerdrPaneID: HerdrSocketPath:}  hostKnown=true
a client is attached RIGHT NOW and no host resolved: resolveActivator would
  return nil and clicking this session does nothing (#1501)
--- FAIL: TestLiveTmuxPaneResolvesItsHost (1.62s)
```

The same run against this branch:

```
attached client pids: "38291"
LAUNCHER: {TermProgram:vscode … TmuxPane:%0 TmuxSocket:/tmp/ir15013991202934/s
  … TTY:/dev/ttys028 …}  hostKnown=true
--- PASS: TestLiveTmuxPaneResolvesItsHost (1.63s)
```

`vscode` is the client's own identity, and the pane kept its address.

That live driver is **not committed**, deliberately: it needs a tmux on the
machine, a socket path short enough for `sun_path`'s 104 bytes (`t.TempDir()`
under `/var/folders` exceeds it) and a pty for the client, and a test that
skips on all three is a gate whose absence reads as a pass. What it measured is
recorded where the code depends on it — `tmuxListedClients`' status table and
`tmuxClientLauncher`'s reparenting note — and the committed suite drives the
same chain with only the tmux CLI faked.

### The riskiest line, red on `origin/main`

```
--- FAIL: TestLauncher_AdoptHostIdentity_TmuxPaneKeepsItsAddress
    session_test.go:224: the pane lost the address the backchannel routes on:
      &{TermProgram:iTerm.app ITermSessionID:w0t0p0-CLIENT … TmuxPane: TmuxSocket: …}
```

The explicit mutation (deleting the `paneKindTmux` arm from the put-back)
reproduces it exactly, and notably reddens **only** that test — the
services-layer refresh tests stay green, because there `fresh` is a full
re-read that already carries the pane address. The domain test is the only
thing that catches it.

### Deliberate mutations, each seen red

| # | mutation | red |
|---|---|---|
| M1 | drop the `paneKindTmux` put-back | `TmuxPaneKeepsItsAddress`: "the pane lost the address the backchannel routes on" |
| M2 | delete the tmux branch in `clientHostFor` | 4 tests, incl. "the attached client's window was not adopted" |
| M3 | `tmuxListedClients` copies lsof's allowlist | `TestTmuxListedClients`, `TestTmuxClientPIDsVia`, and the unreachable-server E2E |
| M4 | refresh gate back to herdr-only | "host not refreshed on the sweep: TermProgram = \"iTerm.app\", want ghostty" — the stale host surviving |
| M5 | `SamePaneAs` returns true | the new table AND the pre-existing `HerdrIgnoresAReadThatIsNoLongerThePane` |
| M6 | tmux probe shares herdr's kind | `TestEveryProbeSiteDeclaresItsOwnKind`: "passed by 2 call sites … they share one bucket" |
| M7 | bypass the memo | `TmuxClientHostMemoCollapsesRepeats` AND four pre-existing herdr memo tests |
| M8 | inherited pane reports its host as known | the two inherited-`$TMUX_PANE` guards |

M5 and M7 reddening pre-existing herdr tests is the point of generalising
rather than duplicating: the predecessor's cases became locks on the shared
code.

Two of the new domain tests are **locks that pass by construction**, and say
so: `HerdrPaneKeepsTheClientsTmuxAddress` (green on `origin/main` too — it
pins what the put-back change must not break) and the vacuity halves of the
budget tests.

### Verification

`go build ./core/...`, `GOOS=linux go build ./core/...`,
`go test ./core/... -race -count=1`, the processlifecycle package at
`-race -count=4`, `tools/preflight.sh --only go` and `--only arch` — all pass.
ARS composite 7.9339 → 7.9292, no category regression.

One flake was found and fixed rather than reported: under a loaded full-suite
run the E2E fixtures' 3s helper processes had exited before `ReadLauncherEnv`
read them, so `hostIdentity` read a dead pid. They now use
`TestHelperProcess`'s existing 30s hold path.

### CodeScene

Advisory, and still red — on **test files only**, which is where it was left
deliberately.

The first run also failed "Prevent hotspot decline" on `session.go`:
`AdoptHostIdentity` regressed 9.69 → 8.99 for the branch this adds. That one
was acted on rather than suppressed, because it is the riskiest function in the
change — the put-back moved to `putBackOwnPaneAddress`, and the mutation was
re-run afterwards to confirm the extraction did not move the assertion off what
it grades (deleting the tmux arm still reddens `TmuxPaneKeepsItsAddress` with
the same message). That gate now passes and `session.go` is off the list.

What remains is `tmuxclient_darwin_test.go` (Complex Method, on the
four-subtest tri-state table), `pid_manager_tmux_refresh_test.go` (Code
Duplication, against the herdr refresh tests it mirrors) and `session_test.go`
(Overall Code Complexity). The duplication is the point rather than debt: those
tests mirror the herdr ones case for case, which is what makes them locks on
the generalisation — mutations M5 and M7 redden the herdr tests too.

## Deliberately not fixed here

**#1582** (filed): a GUI terminal or IDE launched from inside a pane inherits
`$TMUX_PANE`, and `control.resolveBackend` picks the tmux backend from that
field alone — so the backchannel can `send-keys` into a foreign pane. The same
class #1348 fixed for herdr, pre-existing, and untouched by this. The CAPTURE
side is guarded here (`tmuxPaneAwaitsItsClient` refuses to resolve a client for
such a session, and reports its host as not-looked-up so the sweep leaves its
own identity alone); the CONTROL side is that issue's, because refusing an
inherited address there makes a session that is controllable today
uncontrollable and wants its own decision.

That issue is also what would remove a cost this change accepts: a stored
launcher cannot distinguish an *adopted* host from an *inherited* pane
address, so the sweep gate is wide and re-reads such sessions every sweep for
no benefit. It cannot corrupt them — the reader re-derives the narrow test
from the live env, resolves them to their own identity, and reports no change
— it just spends work. `services.hostedInAMultiplexerPane` carries that
argument.

**Old tmux** (out of scope per the ticket): a tmux too old to set
`TERM_PROGRAM=tmux` leaks the launching terminal's value, so #1499's
suppression never fires and those sessions keep the original stale-host
behaviour. Nothing here measures how far back that goes and this does not
change it.

Also stated rather than implied: a tmux pane's DIRECT read is not
`shelloutTimeout`. `hostIdentity` deliberately runs the ancestry fallbacks for
a tmux pane (a kitty launched from a pane has no other source of a host), so
such a session pays the ordinary non-herdr direct read — two walks bounded by
a COUNT, which is what `noAggregateBudget` names and what #1529 deliberately
did not move. In practice that walk terminates at the reparented server in two
or three hops. The sweep-tick test says so where the arithmetic lives, rather
than leaving it to be assumed exhaustive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
