### PR TITLE
fix(tooling): bound the pre-push run so a slow gate is named, not silently killed from outside

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1096,10 +1096,16 @@ Before marking a ticket done, run the full suite — every layer must pass:
 
 `tools/preflight.sh` runs every PR-gating check (test.yml + web-test.yml +
 ars-gate.yml + linux.yml's replay-fixtures step natively, plus the full Linux
-build+test gate via Docker under `--linux`) locally, in CI's order, and prints
-a pass/fail summary
-instead of stopping at the first failure — so before opening a PR, run it
-once instead of round-tripping through GitHub Actions per fix:
+build+test gate via Docker under `--linux`) locally and prints a pass/fail
+summary instead of stopping at the first failure — so before opening a PR, run
+it once instead of round-tripping through GitHub Actions per fix. Gates run
+**cheapest first**, in two phases, not in "CI's order": there is no single CI
+order to mirror, since those are separate workflows GitHub runs concurrently,
+and the order is load-bearing under `--budget` (below) because it decides which
+gates survive a squeeze. `skill-file lint` and `POSIX sh lint` are the only
+coverage their file families have and cost a fraction of a second each, so they
+run before four minutes of `go test` — which is the argument test.yml already
+makes in-file for running the skill lint before `setup-go`.
 
 ```
 tools/preflight.sh                # everything except the Linux Docker gate
@@ -1108,6 +1114,7 @@ tools/preflight.sh --only go      # just the test.yml-equivalent gates
 tools/preflight.sh --only arch    # just the ARS architecture gate
 tools/preflight.sh --only skills  # just the .claude/skills/**/*.md linter
 tools/preflight.sh --only swift   # just the macOS Swift build + test suite
+tools/preflight.sh --budget 540   # bound the whole run; see "The budget" below
 ```
 
 **For an automated caller (an agent), `--only` chunking is the recipe, not a
@@ -1122,20 +1129,69 @@ invocations it takes. **Do not background the unscoped run to make it fit**:
 a subagent is not woken by its own background job, so the run stalls silently
 with the work committed but never pushed
 (`.claude/skills/ir:exec/SKILL.md` Phase 4 step 11 has the incident and the
-same recipe).
+same recipe). Chunking is still the recipe for a *manual* unscoped run;
+`--budget` is what covers the `--changed` run the hook performs, and the two
+compose — `--only <group> --budget <n>` bounds one group.
+
+Also read a push's exit status directly, never through a pipe: `git push … |
+tail` reports `tail`'s status, so a push the hook refused looks like a success
+to the caller. Use `PIPESTATUS`, or assert afterwards that `git status -sb`
+shows a tracking branch — this is a plausible cause of the "committed but never
+pushed" incident recorded in `ir:exec` Phase 4 (#1570).
 
 `tools/install-git-hooks.sh` (run once per clone; worktrees share the parent
 repo's hooks automatically) wires `tools/preflight.sh`'s fast gates as a
 pre-push hook, so a push that would fail CI is rejected locally instead. The
-hook runs `tools/preflight.sh --changed`, which scopes every gate to the
-packages and web trees the push's diff actually touches (vs `origin/main`), so
-a typical push finishes in seconds rather than re-running the whole suite —
-important for automated callers, whose bounded command timeout the full run
-routinely blew past, killing the push after the commit had already landed. A
-large or cross-cutting diff (or a `go.mod`/`go.sum` change, which falls back to
-the full core suite) can still take a few minutes. Skip once with `git push
---no-verify`; run `tools/preflight.sh` manually (no `--changed`) for the
-unscoped full gate.
+hook runs `tools/preflight.sh --changed --budget 540`, which scopes every gate
+to the packages and web trees the push's diff actually touches (vs
+`origin/main`), so a typical push finishes in seconds rather than re-running
+the whole suite. A large or cross-cutting diff (or a `go.mod`/`go.sum` change,
+which falls back to the full core suite) can still take a few minutes. Skip
+once with `git push --no-verify`; run `tools/preflight.sh` manually (no
+`--changed`) for the unscoped full gate.
+
+**The budget is the part not to remove** (#1570). Scoping alone did not make
+the hook fit: on a one-file diff under `core/adapters/inbound/agents/` the run
+measured **621s** — go 250s, arch 16s, security 355s — against an automated
+caller's 600s command budget, so the *caller* killed the tool call. That is the
+worst available failure: no summary, no gate name, no exit code, the commit
+already made and the push not sent, and the documented recovery (`--no-verify`)
+then skips the sub-second gates nobody ran. Six of thirteen PRs in one day went
+out that way. `--budget <seconds>` makes the run bound itself: each gate is
+given whatever is left, a gate that outlives it is **killed and reported
+`TIMEOUT` by name**, every gate behind it is reported **`NOT RUN`**, and both
+exit non-zero. Neither is a `SKIP` — `SKIP` means "this diff cannot break it",
+which is a finished answer; these two are the absence of one, and the closing
+block lists them again after the summary. `PREPUSH_BUDGET` overrides the hook's
+540s (`0` = unbounded, exactly the old behaviour); an unflagged
+`tools/preflight.sh` is unbounded and unchanged. The bounded runner is
+`tools/lib/gate-budget.sh` — pure bash 3.2, because `timeout(1)` is not on a
+stock macOS and a gate that stops being bounded on the machines missing an
+optional dependency is the same defect wearing a different hat. Its unit tests
+plus the end-to-end mutation (a copy of `preflight.sh` with one gate replaced
+by a `sleep`) are `tools/lib/gate-budget_test.sh`, in the `tools` gate.
+
+Two things the budget makes visible that were previously invisible, both
+measured while #1570 was being fixed:
+- **`gosec` was running twice per module.** `-severity`/`-confidence` filter
+  the *report*, not the analysis, so `security-scan.sh`'s informational pass
+  and its gate pass were the same 172s scan of the same 263 files, twice. One
+  `-fmt=json` run now answers both (`tools/lib/gosec-report.sh`), which took
+  the security gate from **355s to 186s** with identical coverage and verdict.
+  Nothing was narrowed — deduplicating a scan is not scanning less, which is
+  why gosec was *not* scoped to changed packages instead. A report that will
+  not parse, or whose own `.Stats.files` is 0, is refused rather than read as
+  clean: a scan that read nothing produces "no High/High findings" too.
+- **The `swift` gate can consume the whole budget on its own.** Its trigger
+  includes `tools/preflight.sh` itself, and `SWIFT_SUITE_TIMEOUT` defaults to
+  600s — equal to an automated caller's entire command budget, so the gate's
+  own careful HUNG diagnosis could never print before the caller killed
+  everything. Measured on this machine at `origin/main`, the suite reaches
+  `SessionRowSnapshotTests.testRelayCloudOnline` and stops there (twice, at the
+  identical point; that test passes in 0.157s in isolation) — #1523/#1530
+  territory. Under `--budget` the outer bound fires first and names the gate,
+  and the tree kill reaches through `script -q`'s separate session, leaving no
+  orphaned `xctest` (measured at `--budget 45`).
 
 The security gate is scoped twice over: its trigger regex decides whether the
 scan runs at all, and `tools/security-scan.sh --changed` then picks which Go

--- a/tools/git-hooks/pre-push
+++ b/tools/git-hooks/pre-push
@@ -33,10 +33,29 @@ set -uo pipefail
 # Unset them so preflight's git-touching tests see a clean environment.
 unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE
 
-echo "pre-push: running tools/preflight.sh --changed"
-echo "pre-push: gates are scoped to this push's diff vs origin/main — usually"
-echo "pre-push: seconds, but a large or cross-cutting diff (or a go.mod/go.sum"
-echo "pre-push: change) can still take a few minutes. Skip with"
+# The whole run is bounded, so it cannot be killed from OUTSIDE with no output
+# (#1570). An automated caller gives a foreground command 600s; a one-file
+# core/ diff measured 621s here, so the caller killed the tool call, the hook
+# died mid-gate with no summary and no exit code, and the push did not land
+# with the commit already made. Six of thirteen PRs in one day then went out
+# with --no-verify, which skips the sub-second gates too. 540s leaves that
+# caller ~60s of headroom; a gate that outlives what is left is reported
+# TIMEOUT by name and the push is refused with that named, which is a louder
+# outcome than today's, not a quieter one.
+#
+# PREPUSH_BUDGET=0 restores the old unbounded behaviour exactly; raise it
+# (PREPUSH_BUDGET=1800 git push) when a genuinely large diff needs the room.
+BUDGET="${PREPUSH_BUDGET:-540}"
+
+echo "pre-push: running tools/preflight.sh --changed --budget $BUDGET"
+echo "pre-push: gates are scoped to this push's diff vs origin/main and run"
+echo "pre-push: cheapest-first — usually seconds, but a large or cross-cutting"
+echo "pre-push: diff (or a go.mod/go.sum change) can still take minutes."
+echo "pre-push: The run is bounded to ${BUDGET}s in total: a gate that outruns"
+echo "pre-push: what is left is killed and reported TIMEOUT, and gates after it"
+echo "pre-push: are reported NOT RUN. Neither is a pass. Raise the bound with"
+echo "pre-push: 'PREPUSH_BUDGET=1800 git push', or remove it with"
+echo "pre-push: 'PREPUSH_BUDGET=0 git push'. Skip every gate with"
 echo "pre-push: 'git push --no-verify' (run tools/preflight.sh manually for the"
 echo "pre-push: full unscoped gate)."
-./tools/preflight.sh --changed
+./tools/preflight.sh --changed --budget "$BUDGET"

--- a/tools/lib/changed-files_test.sh
+++ b/tools/lib/changed-files_test.sh
@@ -172,10 +172,30 @@ for script in security-scan.sh preflight.sh; do
     *)                args=(--changed) ;;
   esac
   cp "$REPO_ROOT_FOR_TEST/tools/$script" "$NOLIB/$script"
+
+  # Case 1: no lib/ directory at all. Both scripts source more than one lib
+  # now (#1570 added gate-budget.sh to preflight.sh and gosec-report.sh to
+  # security-scan.sh), so whichever they reach first is the one they name —
+  # this case pins the REFUSAL, not which file it happens to be about.
+  rm -rf "$NOLIB/lib"
   out=$( cd "$REPO_ROOT_FOR_TEST" && bash "$NOLIB/$script" "${args[@]}" 2>&1 )
   rc=$?
-  assert_eq "$script --changed with no lib/ → exit 2, not a silent pass" "2" "$rc"
-  assert_contains "$script names the missing lib in its error" "changed-files.sh" "$out"
+  assert_eq "$script --changed with no lib/ at all → exit 2, not a silent pass" "2" "$rc"
+  assert_contains "$script refuses rather than running blind" "refusing" "$out"
+
+  # Case 2: every lib present EXCEPT this one. That is the assertion this block
+  # was written for — that a missing changed-files.sh specifically is fatal and
+  # named — and case 1 stopped reaching it the moment a second lib was sourced
+  # ahead of it. Deleting one file rather than the whole directory is what
+  # keeps the original case alive instead of quietly replacing it.
+  mkdir -p "$NOLIB/lib"
+  cp "$REPO_ROOT_FOR_TEST/tools/lib/"*.sh "$NOLIB/lib/"
+  rm -f "$NOLIB/lib/changed-files.sh"
+  out=$( cd "$REPO_ROOT_FOR_TEST" && bash "$NOLIB/$script" "${args[@]}" 2>&1 )
+  rc=$?
+  assert_eq "$script --changed with only changed-files.sh missing → exit 2" "2" "$rc"
+  assert_contains "$script names changed-files.sh in its error" "changed-files.sh" "$out"
+  rm -rf "$NOLIB/lib"
 done
 
 echo ""

--- a/tools/lib/gate-budget.sh
+++ b/tools/lib/gate-budget.sh
@@ -1,0 +1,215 @@
+#!/usr/bin/env bash
+# gate-budget.sh — a wall-clock budget for a run of gates, plus the bounded
+# runner that enforces it. Sourced by tools/preflight.sh; this file is never
+# executed directly.
+#
+#   . "$SCRIPT_DIR/lib/gate-budget.sh"
+#   budget_open 540 || exit 2
+#   budget_exhausted && ...            # nothing left — do not start a gate
+#   budget_run "$(budget_remaining)" go test ./...
+#
+# ---------------------------------------------------------------------------
+# Why this exists (#1570)
+#
+# The pre-push hook runs tools/preflight.sh --changed. On a diff touching one
+# package under core/ that run measured 621s — go 250s, arch 16s, security
+# 355s — against an automated caller's 600s command budget. The caller kills
+# the tool call from OUTSIDE, so the hook dies with no summary, no gate name
+# and no exit code anyone reads: the push does not land, the commit already
+# has, and the documented recovery is `git push --no-verify`, which disables
+# every gate rather than the slow one. Six of thirteen PRs in a single day
+# went out that way.
+#
+# That is AGENTS.md's "a verification mechanism must fail loudly when it
+# cannot run" violated in its purest form — the mechanism fails SILENTLY, from
+# the outside, and the silence is indistinguishable from a hook that was never
+# installed. A budget the run enforces itself converts that into a named,
+# non-zero refusal: this gate TIMED OUT after N seconds, these gates NEVER RAN,
+# and neither is a pass.
+#
+# ---------------------------------------------------------------------------
+# Why not `timeout(1)`
+#
+# GNU coreutils' `timeout` is not on a stock macOS — it arrives with
+# `brew install coreutils`, which is exactly the kind of optional dependency
+# that turns a gate into a skip on the machines that do not have it. The
+# bounded runner below is pure bash 3.2 (what /bin/bash is on macOS: no
+# `wait -n`, no associative arrays, no `mapfile`), so it cannot be the reason
+# a budget silently stops being enforced.
+
+# Exit status budget_run reports for a command it killed. 124 matches
+# timeout(1) so the number is familiar, but callers should test
+# BUDGET_LAST_TIMED_OUT instead — see below.
+BUDGET_TIMEOUT_RC=124
+
+# Set to 1 by budget_run when, and only when, it killed the command for
+# exceeding its bound; 0 otherwise. This is the signal callers classify on,
+# NOT the 124 exit status: a real gate is free to exit 124 on its own, and a
+# scanner that happened to pick that number would otherwise be reported as a
+# timeout and send the reader looking for time they did not spend.
+BUDGET_LAST_TIMED_OUT=0
+
+# How long budget_run polls between checks, and how long it waits after
+# SIGTERM before SIGKILL. Overridable so the unit tests can run in
+# milliseconds instead of seconds.
+: "${BUDGET_POLL_SECONDS:=0.2}"
+: "${BUDGET_TERM_GRACE_SECONDS:=5}"
+
+# Total budget, in seconds, for everything after budget_open. 0 means
+# unbounded, which is what an unflagged `tools/preflight.sh` run gets — the
+# manual full run must stay byte-for-byte what it was.
+BUDGET_TOTAL_SECONDS=0
+_BUDGET_STARTED_AT=0
+
+# budget_open <seconds> — start the clock. 0 (or no call at all) leaves the
+# run unbounded. A non-numeric value is refused with status 2 rather than
+# coerced: `--budget 10m` silently meaning "unbounded" would be a bound that
+# quietly is not one, which is the failure this file exists to remove.
+budget_open() {
+  local secs="${1:-}"
+  case "$secs" in
+    '' | *[!0-9]*)
+      echo "gate-budget: budget must be a non-negative whole number of seconds, got '$secs'" >&2
+      return 2
+      ;;
+  esac
+  BUDGET_TOTAL_SECONDS="$secs"
+  # bash's own second counter, so the poll loop below costs no fork per tick.
+  _BUDGET_STARTED_AT=$SECONDS
+  return 0
+}
+
+# budget_is_bounded — true when a budget is in force.
+budget_is_bounded() {
+  [[ "$BUDGET_TOTAL_SECONDS" -gt 0 ]]
+}
+
+# budget_remaining — whole seconds left, floored at 0. An unbounded run prints
+# 0, which is also what budget_run reads as "no bound" — so the two compose
+# without the caller special-casing. That collision is safe ONLY because an
+# exhausted budget is distinguished by budget_exhausted, never by this value.
+budget_remaining() {
+  if ! budget_is_bounded; then
+    echo 0
+    return 0
+  fi
+  local left=$((BUDGET_TOTAL_SECONDS - (SECONDS - _BUDGET_STARTED_AT)))
+  [[ "$left" -lt 0 ]] && left=0
+  echo "$left"
+  return 0
+}
+
+# budget_exhausted — true when a budget is in force and has run out. Callers
+# check this BEFORE starting a gate, so a gate with nothing left is reported
+# as "did not run" rather than started and instantly killed.
+budget_exhausted() {
+  budget_is_bounded && [[ "$(budget_remaining)" -le 0 ]]
+}
+
+# _budget_kill_tree <signal> <pid> — signal a process and every descendant.
+#
+# Killing only the direct child is not enough: `go test` forks a compiler and
+# a test binary per package, `npm` forks node, and gosec forks nothing but
+# holds the terminal — leaving those alive after the hook returns is how a
+# "bounded" run keeps burning the machine. Descendants are signalled first so
+# a shell that would exit on its own does not orphan them mid-walk.
+#
+# pgrep is on both macOS and Linux. If it is somehow absent the walk degrades
+# to the direct child, which still ends the wait and still reports TIMEOUT —
+# the verdict stays correct, only the cleanup is weaker.
+#
+# lib/swift-suite.sh has the same recursion (`_swift_suite_descendants`) and
+# they stay separate deliberately. That one exists to kill a tree that
+# `script -q` has moved into another SESSION and other process groups, so it
+# collects the pids first and signals them as a flat list with its own grace
+# period, inside a `{ … } 2>/dev/null` that hides the shell's job notice at the
+# one moment the gate is explaining itself. This one signals depth-first as it
+# walks and lets that notice through, because here it lands beside a named
+# TIMEOUT block rather than in place of one. Folding them together would mean
+# one of the two gets the wrong half. They are, however, verified to compose:
+# the swift gate under `--budget 45` kills the whole pty-wrapped tree and
+# leaves no xctest process behind (measured, #1570).
+_budget_kill_tree() {
+  local sig="$1" pid="$2" child
+  for child in $(pgrep -P "$pid" 2>/dev/null); do
+    _budget_kill_tree "$sig" "$child"
+  done
+  kill "-$sig" "$pid" 2>/dev/null
+  return 0
+}
+
+# budget_run <seconds> <cmd...> — run <cmd...> bounded to <seconds> of wall
+# clock. Returns the command's own status, or BUDGET_TIMEOUT_RC with
+# BUDGET_LAST_TIMED_OUT=1 when the bound expired. <seconds> of 0 runs the
+# command directly, with no wrapper process and no polling at all.
+budget_run() {
+  local secs="${1:-}"
+  shift || true
+  BUDGET_LAST_TIMED_OUT=0
+  case "$secs" in
+    '' | *[!0-9]*)
+      echo "gate-budget: budget_run needs a non-negative whole number of seconds, got '$secs'" >&2
+      return 2
+      ;;
+  esac
+  if [[ $# -eq 0 ]]; then
+    echo "gate-budget: budget_run needs a command to run" >&2
+    return 2
+  fi
+  if [[ "$secs" -eq 0 ]]; then
+    "$@"
+    return $?
+  fi
+
+  # The child writes its own exit status here as its last act, and that file —
+  # not `kill -0 $pid` — is the "it finished" signal. A background child bash
+  # has already reaped still answers `kill -0` successfully while it is a
+  # zombie, so a pid-only poll can spin until the deadline on a command that
+  # exited normally seconds earlier, turning every fast gate into a TIMEOUT.
+  # The status is written to a sibling and renamed, so a reader can never
+  # observe a half-written file (rename within a directory is atomic).
+  local statusfile
+  statusfile=$(mktemp -t irrlicht-gate-budget) || return 2
+
+  { "$@"; echo "$?" >"$statusfile.part" && mv -f "$statusfile.part" "$statusfile"; } &
+  local pid=$!
+
+  local started=$SECONDS rc
+  while :; do
+    if [[ -s "$statusfile" ]]; then
+      rc=$(cat "$statusfile")
+      rm -f "$statusfile" "$statusfile.part"
+      wait "$pid" 2>/dev/null
+      return "$rc"
+    fi
+    if [[ $((SECONDS - started)) -ge "$secs" ]]; then
+      # One last look before killing. The deadline and the child's final write
+      # can land in the same poll interval, and reporting TIMEOUT for a command
+      # that finished is a false accusation of the exact kind this file is
+      # supposed to replace.
+      if [[ -s "$statusfile" ]]; then
+        rc=$(cat "$statusfile")
+        rm -f "$statusfile" "$statusfile.part"
+        wait "$pid" 2>/dev/null
+        return "$rc"
+      fi
+      # bash prints its own "…Terminated: 15" job notice on stderr when it
+      # reaps a signalled background job. It is left alone deliberately: it
+      # lands immediately beside the caller's named TIMEOUT block, so it reads
+      # as corroboration, and silencing shell diagnostics wholesale to tidy one
+      # line would hide the next one nobody predicted.
+      _budget_kill_tree TERM "$pid"
+      local hard=$SECONDS
+      while [[ $((SECONDS - hard)) -lt "$BUDGET_TERM_GRACE_SECONDS" ]] && kill -0 "$pid" 2>/dev/null; do
+        sleep "$BUDGET_POLL_SECONDS"
+      done
+      _budget_kill_tree KILL "$pid"
+      wait "$pid" 2>/dev/null
+      rm -f "$statusfile" "$statusfile.part"
+      # shellcheck disable=SC2034  # read by the caller (tools/preflight.sh), not here
+      BUDGET_LAST_TIMED_OUT=1
+      return "$BUDGET_TIMEOUT_RC"
+    fi
+    sleep "$BUDGET_POLL_SECONDS"
+  done
+}

--- a/tools/lib/gate-budget_test.sh
+++ b/tools/lib/gate-budget_test.sh
@@ -1,0 +1,242 @@
+#!/usr/bin/env bash
+# gate-budget_test.sh — unit tests for lib/gate-budget.sh plus one end-to-end
+# check that tools/preflight.sh actually wires it. Plain bash, no framework,
+# matching tools/lib/changed-files_test.sh. Run directly, or via
+# tools/preflight.sh's `tools` gate.
+#
+# Covers #1570. The bug being fixed is a SILENCE — the pre-push hook exceeding
+# an automated caller's 600s command budget and being killed from outside with
+# no gate name, no summary and no exit code — so the tests that matter are the
+# ones asserting the run says which gate ran out of time and which never
+# started. A budget that expired without naming anything would reproduce the
+# defect inside its own fix.
+#
+# The end-to-end block at the bottom is the mutation evidence, and it is a
+# mutation of a COPY: preflight.sh is duplicated to a scratch name inside
+# tools/ (so its own `dirname $0/..` root resolution still lands on the repo)
+# with one gate's command replaced by a sleep. Nothing tracked is written, so
+# an interrupted run cannot leave the tree broken. The substitution is asserted
+# to have applied — #1390's lesson: a mutation harness whose mutation silently
+# no-ops reports the unmutated result as evidence.
+
+set -uo pipefail   # NOT -e: assertions capture non-zero return codes
+
+DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$DIR/../.." && pwd)"
+# shellcheck source=gate-budget.sh
+source "$DIR/gate-budget.sh"
+
+# Keep the suite in seconds rather than tens of seconds. The grace period is
+# how long budget_run waits between SIGTERM and SIGKILL; 1s is plenty for the
+# `sleep` processes below and does not change what is being tested.
+# shellcheck disable=SC2034  # both are read by gate-budget.sh, sourced above
+BUDGET_TERM_GRACE_SECONDS=1
+# shellcheck disable=SC2034
+BUDGET_POLL_SECONDS=0.05
+
+fails=0
+pass() { echo "  PASS: $1"; return 0; }
+fail() { echo "  FAIL: $1 — expected [$2] got [$3]"; fails=$((fails + 1)); return 0; }
+assert_eq() {
+  [[ "$2" == "$3" ]] && pass "$1" || fail "$1" "$2" "$3"
+  return 0
+}
+assert_contains() {
+  case "$3" in
+    *"$2"*) pass "$1" ;;
+    *) fail "$1" "output containing: $2" "$3" ;;
+  esac
+  return 0
+}
+# assert_le <label> <ceiling> <actual>
+assert_le() {
+  [[ "$3" -le "$2" ]] && pass "$1 ($3 <= $2)" || fail "$1" "<= $2" "$3"
+  return 0
+}
+
+echo "== budget_open refuses anything that is not a whole number of seconds =="
+# A bound that quietly is not one is worse than no bound: the caller stops
+# watching for the outcome it believes it is protected from.
+for bad in "10m" "-5" "1.5" "abc" ""; do
+  budget_open "$bad" >/dev/null 2>&1
+  assert_eq "budget_open '$bad' → 2" "2" "$?"
+done
+budget_open 0 >/dev/null 2>&1
+assert_eq "budget_open 0 → 0 (unbounded is legal)" "0" "$?"
+
+echo ""
+echo "== an unbounded budget is never bounded and never exhausted =="
+budget_open 0
+if budget_is_bounded; then bounded=yes; else bounded=no; fi
+assert_eq "budget_open 0 → not bounded" "no" "$bounded"
+if budget_exhausted; then ex=yes; else ex=no; fi
+assert_eq "budget_open 0 → not exhausted" "no" "$ex"
+assert_eq "budget_remaining under an unbounded run is 0 (== 'no bound')" "0" "$(budget_remaining)"
+
+budget_open 30
+if budget_is_bounded; then bounded=yes; else bounded=no; fi
+assert_eq "budget_open 30 → bounded" "yes" "$bounded"
+if budget_exhausted; then ex=yes; else ex=no; fi
+assert_eq "budget_open 30 → not yet exhausted" "no" "$ex"
+rem=$(budget_remaining)
+assert_le "budget_remaining is at most the budget" "30" "$rem"
+[[ "$rem" -ge 28 ]] && pass "budget_remaining is ~the budget right after opening ($rem)" \
+                    || fail "budget_remaining right after opening" ">= 28" "$rem"
+
+echo ""
+echo "== an exhausted budget reports itself, and never as 'unbounded' =="
+# The one collision in the API: budget_remaining prints 0 both for "no bound"
+# and for "nothing left". If budget_exhausted did not tell them apart, an
+# expired budget would silently become an unbounded run — the exact outcome
+# --budget exists to prevent.
+budget_open 1
+sleep 1.3
+if budget_exhausted; then ex=yes; else ex=no; fi
+assert_eq "a spent budget is exhausted" "yes" "$ex"
+if budget_is_bounded; then bounded=yes; else bounded=no; fi
+assert_eq "a spent budget is still BOUNDED (not silently unbounded)" "yes" "$bounded"
+assert_eq "a spent budget has 0 remaining" "0" "$(budget_remaining)"
+
+echo ""
+echo "== budget_run 0 is a plain passthrough =="
+budget_open 0
+budget_run 0 true
+assert_eq "budget_run 0 true → 0" "0" "$?"
+budget_run 0 bash -c 'exit 7'
+assert_eq "budget_run 0 passes the command's own status through" "7" "$?"
+assert_eq "budget_run 0 sets no timeout flag" "0" "$BUDGET_LAST_TIMED_OUT"
+
+echo ""
+echo "== a fast command under a bound is unaffected =="
+# The other half of the timeout evidence. A wrapper that reported TIMEOUT for
+# everything would satisfy every negative case below and read as working.
+start=$SECONDS
+budget_run 30 bash -c 'exit 3'
+rc=$?
+elapsed=$((SECONDS - start))
+assert_eq "a fast command keeps its own exit status under a bound" "3" "$rc"
+assert_eq "a fast command sets no timeout flag" "0" "$BUDGET_LAST_TIMED_OUT"
+assert_le "a fast command returns immediately, it does not wait out the bound" "3" "$elapsed"
+
+start=$SECONDS
+budget_run 30 true
+rc=$?
+elapsed=$((SECONDS - start))
+assert_eq "a fast success under a bound → 0" "0" "$rc"
+assert_le "and returns immediately" "3" "$elapsed"
+
+echo ""
+echo "== a command that exits 124 on its own is NOT reported as a timeout =="
+# 124 is the status budget_run reports for a kill, so a caller classifying on
+# the number alone would send the reader hunting for time nobody spent.
+budget_run 30 bash -c "exit $BUDGET_TIMEOUT_RC"
+assert_eq "a self-inflicted 124 is passed through" "$BUDGET_TIMEOUT_RC" "$?"
+assert_eq "...and the timeout flag stays clear" "0" "$BUDGET_LAST_TIMED_OUT"
+
+echo ""
+echo "== a command that outlives its bound is killed and reported =="
+start=$SECONDS
+budget_run 1 sleep 60
+rc=$?
+elapsed=$((SECONDS - start))
+assert_eq "an over-budget command → BUDGET_TIMEOUT_RC" "$BUDGET_TIMEOUT_RC" "$rc"
+assert_eq "...and sets the timeout flag" "1" "$BUDGET_LAST_TIMED_OUT"
+assert_le "...and does not wait out the command (1s bound, not 60s)" "8" "$elapsed"
+
+echo ""
+echo "== the whole process tree dies, not just the direct child =="
+# `go test` forks a compiler and a test binary per package and npm forks node,
+# so a bound that only kills the shell leaves the expensive part running after
+# the hook has returned — a "bounded" run that keeps burning the machine.
+marker=$(mktemp -t irrlicht-gate-budget-marker)
+rm -f "$marker"
+budget_run 1 bash -c "bash -c 'sleep 30; echo grandchild-survived >\"$marker\"' & wait"
+assert_eq "the wrapper still reports a timeout" "1" "$BUDGET_LAST_TIMED_OUT"
+# Give a survivor time to prove it survived: without the tree kill the
+# grandchild would still be sleeping here and would write the marker at t+30.
+sleep 2
+survivors=$(pgrep -f 'sleep 30; echo grandchild-survived' | wc -l | tr -d ' ')
+assert_eq "no descendant of the killed command is still running" "0" "$survivors"
+[[ -e "$marker" ]] && fail "the grandchild must not outlive the bound" "no marker file" "marker written"
+[[ -e "$marker" ]] || pass "the grandchild did not outlive the bound"
+rm -f "$marker"
+
+echo ""
+echo "== end to end: tools/preflight.sh names the gate that ran out of time =="
+# One mutated COPY of preflight.sh, with the gofmt gate's command replaced by a
+# sleep. gofmt is the first gate of the go group, so `--only go --budget 3`
+# produces both verdicts in one run: gofmt TIMEOUT, then every gate behind it
+# NOT RUN. No --changed, so this does not depend on the branch's diff.
+probe="$ROOT/tools/.preflight-budget-probe-$$.sh"
+trap 'rm -f "$probe"' EXIT
+python3 - "$ROOT/tools/preflight.sh" "$probe" <<'PY'
+import sys
+src, dst = sys.argv[1], sys.argv[2]
+s = open(src).read()
+old = 'unformatted=$(gofmt -l core/ tools/)'
+# #1390: assert the mutation applied. A harness whose substitution silently
+# no-ops reports the UNMUTATED run as evidence, which is the failure this whole
+# file is about, reproduced inside its own test.
+assert s.count(old) == 1, f"MUTATION DID NOT APPLY: expected exactly one {old!r}, found {s.count(old)}"
+open(dst, 'w').write(s.replace(old, 'unformatted=$(sleep 45)'))
+PY
+mutated=$?
+assert_eq "the probe's mutation applied" "0" "$mutated"
+
+if [[ "$mutated" -eq 0 ]]; then
+  start=$SECONDS
+  out=$(bash "$probe" --only go --budget 3 2>&1)
+  rc=$?
+  elapsed=$((SECONDS - start))
+  assert_eq "an over-budget gate refuses the run" "1" "$rc"
+  assert_contains "the timed-out gate is named" "gofmt" "$out"
+  assert_contains "and its verdict is TIMEOUT" "TIMEOUT" "$out"
+  # Read the verdict out of the summary row rather than grepping the whole
+  # output for the word: the budget banner at the top of every bounded run
+  # contains "TIMEOUT" as prose, so a whole-output grep passes for a gate that
+  # was never graded at all.
+  assert_eq "the summary row for gofmt reads TIMEOUT" "TIMEOUT" \
+    "$(echo "$out" | awk '/^  gofmt {2,}/ {print $NF}')"
+  assert_contains "the gates behind it are NOT RUN, not PASS" "NOT RUN" "$out"
+  assert_contains "NOT RUN is distinguished from SKIP in words" "not a SKIP and not a pass" "$out"
+  assert_contains "the closing verdict names the unfinished gates" "did not finish inside the 3s budget" "$out"
+  assert_contains "and says how to run them" "--only go" "$out"
+  assert_le "the bounded run really is bounded (3s budget, 45s gate)" "20" "$elapsed"
+
+  # The vacuity half: the same mutated copy, on a group the mutation does not
+  # touch, still passes. Without this, a probe that failed for any reason at
+  # all would satisfy every assertion above.
+  out=$(bash "$probe" --only skills --budget 120 2>&1)
+  rc=$?
+  assert_eq "an untouched, fast gate under a generous budget still passes" "0" "$rc"
+  assert_eq "...and its summary row reads PASS, not TIMEOUT" "PASS" \
+    "$(echo "$out" | awk '/^  skill-file lint {2,}/ {print $NF}')"
+  case "$out" in
+    *"did not finish inside"*) fail "a fast gate must not be listed as unfinished" "no unfinished list" "unfinished list present" ;;
+    *) pass "a fast gate is not listed among the unfinished" ;;
+  esac
+
+  # And unbounded: --budget 0 must leave the run exactly as it was, so the
+  # manual `tools/preflight.sh` full run is unchanged by any of this.
+  out=$(bash "$probe" --only skills --budget 0 2>&1)
+  rc=$?
+  assert_eq "--budget 0 runs unbounded and still passes" "0" "$rc"
+  case "$out" in
+    *"budget: this run is bounded"*) fail "--budget 0 must not announce a bound" "no bound banner" "bound banner present" ;;
+    *) pass "--budget 0 announces no bound" ;;
+  esac
+fi
+
+echo ""
+echo "== preflight.sh rejects a malformed --budget, as it does an unknown --only =="
+out=$("$ROOT/tools/preflight.sh" --budget 10m 2>&1); rc=$?
+assert_eq "tools/preflight.sh --budget 10m → 2" "2" "$rc"
+assert_contains "...and says what it wanted" "whole number of seconds" "$out"
+
+echo ""
+if [[ "$fails" -eq 0 ]]; then
+  echo "gate-budget_test: ALL PASS"
+else
+  echo "gate-budget_test: $fails FAILED" >&2
+  exit 1
+fi

--- a/tools/lib/gosec-report.sh
+++ b/tools/lib/gosec-report.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# gosec-report.sh — read ONE gosec JSON report and answer both questions
+# tools/security-scan.sh asks of it: what did it find (informational, every
+# severity), and does anything in it block the gate (High severity AND High
+# confidence). Sourced, never executed.
+#
+#   . "$SCRIPT_DIR/lib/gosec-report.sh"
+#   gosec -no-fail -quiet -fmt=json -out="$json" ./...
+#   gosec_report_check "$json" "core"
+#
+# ---------------------------------------------------------------------------
+# Why this exists (#1570)
+#
+# security-scan.sh used to run gosec TWICE per module over the same tree:
+#
+#     gosec -no-fail -quiet ./...                          # informational
+#     gosec -quiet -severity high -confidence high ./...   # the gate
+#
+# gosec's -severity/-confidence are report filters applied after the analysis,
+# not analysis switches, so the second run re-derived a strict subset of the
+# first at full price. Measured on the core module (263 files, 66,534 lines):
+# 172s + 172s. The whole security gate on a one-file core/ diff was 355s, of
+# which 344s was gosec analysing the same code twice.
+#
+# One `-fmt=json` run costs 174s and carries both answers — .Stats for the
+# informational summary, .Issues[].severity/.confidence for the gate. Nothing
+# is scanned less: the module still gets `./...`, unfiltered. This is the
+# reason the security gate was NOT narrowed to changed packages instead, which
+# would have been a real reduction in what gets scanned; halving a duplicate
+# is not.
+#
+# ---------------------------------------------------------------------------
+# Why an unreadable report is a hard failure, and why an EMPTY one is too
+#
+# security-scan.sh's header: "A silently-skipped scan is indistinguishable
+# from a clean one." A report that will not parse, and a report whose own
+# .Stats says it read zero files, both produce "no High/High findings" if you
+# only count matching issues — a perfect clean bill of health from a scan that
+# never looked at anything. Both are refused here with status 2.
+
+# gosec_report_check <json-file> [label] — classify one report and print its
+# findings. Returns:
+#   0 — readable, covered at least one file, no High/High finding
+#   1 — readable, and at least one High/High finding (listed on stderr)
+#   2 — unreadable, or covered no file at all (the scan did not happen)
+gosec_report_check() {
+  local json="${1:-}" label="${2:-gosec}"
+
+  if [[ -z "$json" || ! -s "$json" ]]; then
+    echo "gosec-report: $label — no report at '${json:-<none>}' (gosec produced nothing to read)" >&2
+    return 2
+  fi
+  if ! jq -e . "$json" >/dev/null 2>&1; then
+    echo "gosec-report: $label — report at '$json' is not valid JSON (gosec did not finish)" >&2
+    return 2
+  fi
+
+  local files lines found
+  files=$(jq -r '.Stats.files // "null"' "$json" 2>/dev/null)
+  lines=$(jq -r '.Stats.lines // 0' "$json" 2>/dev/null)
+  found=$(jq -r '.Stats.found // 0' "$json" 2>/dev/null)
+  case "$files" in
+    '' | null | *[!0-9]*)
+      echo "gosec-report: $label — report at '$json' carries no .Stats.files count; refusing to read it as a clean scan" >&2
+      return 2
+      ;;
+  esac
+  if [[ "$files" -eq 0 ]]; then
+    echo "gosec-report: $label — the scan covered 0 files. A scan that read nothing is not a clean scan." >&2
+    return 2
+  fi
+
+  echo "   scanned $files file(s) / $lines line(s); $found issue(s) at all severities"
+  # The whole finding list, one line each. The two-run version printed gosec's
+  # own text report — every issue plus three lines of surrounding code — so
+  # this is the same information an order of magnitude shorter, not less of it.
+  jq -r '(.Issues // [])[] | "   \(.severity)/\(.confidence) \(.rule_id) \(.file):\(.line) — \(.details)"' "$json"
+
+  local blocking
+  blocking=$(jq -r '[(.Issues // [])[] | select(.severity == "HIGH" and .confidence == "HIGH")] | length' "$json" 2>/dev/null)
+  case "$blocking" in
+    '' | *[!0-9]*)
+      echo "gosec-report: $label — could not count High/High findings in '$json'" >&2
+      return 2
+      ;;
+  esac
+  if [[ "$blocking" -gt 0 ]]; then
+    jq -r '(.Issues // [])[] | select(.severity == "HIGH" and .confidence == "HIGH") | "  - \(.rule_id) \(.file):\(.line) — \(.details)"' "$json" >&2
+    return 1
+  fi
+  return 0
+}

--- a/tools/lib/gosec-report_test.sh
+++ b/tools/lib/gosec-report_test.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+# gosec-report_test.sh — unit tests for lib/gosec-report.sh, the classifier
+# tools/security-scan.sh reads a gosec JSON report through. Plain bash, no
+# framework, matching tools/lib/changed-files_test.sh. Run directly, or via
+# tools/preflight.sh's `tools` gate.
+#
+# Covers #1570: security-scan.sh used to run gosec TWICE per module — an
+# unfiltered informational pass and a `-severity high -confidence high` gate
+# pass — for 172s + 172s on the core module, 344s of the security gate's
+# measured 355s. Those flags filter the REPORT, not the analysis, so the second
+# run re-derived a strict subset of the first at full price. One JSON run now
+# answers both, and these tests are what stands in for the second run's exit
+# code.
+#
+# The fixtures under testdata/gosec-report/ are committed rather than generated
+# here, the same choice testdata/posix-lint/ makes: the mutation evidence has
+# to outlive the PR that added it, and a real 174s gosec run is not something a
+# unit test can perform. They are trimmed from an actual report of this repo's
+# core module (Stats: 263 files / 66,534 lines) so the shapes are the ones
+# gosec really emits, `"Issues": null` included.
+#
+# The load-bearing case is near-miss.json. It carries HIGH/MEDIUM and
+# MEDIUM/HIGH and nothing else, so it is the ONE fixture that tells
+# `severity == HIGH and confidence == HIGH` apart from `... or ...`: every
+# other fixture passes both spellings. clean.json is the vacuity guard — a
+# classifier that blocked unconditionally would satisfy every negative case
+# here and read as excellent coverage.
+
+set -uo pipefail   # NOT -e: assertions capture non-zero return codes
+
+DIR="$(cd "$(dirname "$0")" && pwd)"
+DATA="$DIR/testdata/gosec-report"
+# shellcheck source=gosec-report.sh
+source "$DIR/gosec-report.sh"
+
+fails=0
+pass() { echo "  PASS: $1"; return 0; }
+fail() { echo "  FAIL: $1 — expected [$2] got [$3]"; fails=$((fails + 1)); return 0; }
+assert_eq() {
+  [[ "$2" == "$3" ]] && pass "$1" || fail "$1" "$2" "$3"
+  return 0
+}
+assert_contains() {
+  case "$3" in
+    *"$2"*) pass "$1" ;;
+    *) fail "$1" "output containing: $2" "$3" ;;
+  esac
+  return 0
+}
+assert_not_contains() {
+  case "$3" in
+    *"$2"*) fail "$1" "output NOT containing: $2" "$3" ;;
+    *) pass "$1" ;;
+  esac
+  return 0
+}
+
+# run_check <fixture-basename> — captures stdout+stderr and the status.
+OUT=""
+RC=0
+run_check() {
+  OUT=$(gosec_report_check "$DATA/$1" "testmod" 2>&1)
+  RC=$?
+  return 0
+}
+
+echo "== the fixtures are what the tests think they are =="
+# Without this, a fixture edited into a different shape would silently retarget
+# every assertion below it — the corpus quietly stopping to contain its own
+# test cases, which reads as a pass.
+assert_eq "near-miss.json really carries no HIGH/HIGH issue" \
+  "0" "$(jq '[.Issues[] | select(.severity=="HIGH" and .confidence=="HIGH")] | length' "$DATA/near-miss.json")"
+assert_eq "near-miss.json really carries a HIGH severity issue" \
+  "2" "$(jq '[.Issues[] | select(.severity=="HIGH")] | length' "$DATA/near-miss.json")"
+assert_eq "near-miss.json really carries a HIGH confidence issue" \
+  "1" "$(jq '[.Issues[] | select(.confidence=="HIGH")] | length' "$DATA/near-miss.json")"
+assert_eq "high-high.json really carries exactly one HIGH/HIGH issue" \
+  "1" "$(jq '[.Issues[] | select(.severity=="HIGH" and .confidence=="HIGH")] | length' "$DATA/high-high.json")"
+assert_eq "empty-scan.json really reports zero files" \
+  "0" "$(jq '.Stats.files' "$DATA/empty-scan.json")"
+# jq answers a parse error with 5, not 1, so this asserts "non-zero" rather
+# than pinning a number that is not the one jq actually returns.
+assert_eq "truncated.json really is unparseable" \
+  "unparseable" "$(jq -e . "$DATA/truncated.json" >/dev/null 2>&1 && echo parseable || echo unparseable)"
+
+echo ""
+echo "== a readable report with no High/High passes (the vacuity guard) =="
+run_check clean.json
+assert_eq "clean.json → 0" "0" "$RC"
+assert_contains "clean.json names the coverage it had" "scanned 263 file(s)" "$OUT"
+assert_contains "clean.json still lists its non-blocking findings" "G304" "$OUT"
+
+run_check null-issues.json
+assert_eq "null-issues.json (gosec's empty-result shape) → 0" "0" "$RC"
+assert_contains "null-issues.json still names its coverage" "scanned 263 file(s)" "$OUT"
+
+echo ""
+echo "== High severity OR High confidence alone does not block =="
+# The whole point of this fixture: swap the `and` in gosec_report_check for an
+# `or` and this is the only case in the file that goes red.
+run_check near-miss.json
+assert_eq "near-miss.json → 0 (HIGH/MEDIUM and MEDIUM/HIGH are not blocking)" "0" "$RC"
+assert_contains "near-miss.json still lists the HIGH/MEDIUM finding" "G115" "$OUT"
+
+echo ""
+echo "== one High/High finding blocks, and is named =="
+run_check high-high.json
+assert_eq "high-high.json → 1" "1" "$RC"
+assert_contains "high-high.json names the blocking rule" "G402" "$OUT"
+assert_contains "high-high.json names the blocking file:line" "client.go:27" "$OUT"
+
+echo ""
+echo "== a scan that could not run is NOT a clean scan =="
+# security-scan.sh's own header: "A silently-skipped scan is indistinguishable
+# from a clean one." Each of these produces "no High/High findings" under a
+# classifier that only counts matching issues.
+run_check empty-scan.json
+assert_eq "empty-scan.json (0 files) → 2, not 0" "2" "$RC"
+assert_contains "empty-scan.json says why" "covered 0 files" "$OUT"
+assert_not_contains "empty-scan.json does not read as a finding count" "scanned 0 file(s)" "$OUT"
+
+run_check truncated.json
+assert_eq "truncated.json (unparseable) → 2" "2" "$RC"
+assert_contains "truncated.json says it is not valid JSON" "not valid JSON" "$OUT"
+
+run_check no-stats.json
+assert_eq "no-stats.json (parses, no .Stats) → 2" "2" "$RC"
+assert_contains "no-stats.json refuses to read it as clean" "refusing to read it as a clean scan" "$OUT"
+
+run_check empty-file.json
+assert_eq "empty-file.json (gosec wrote nothing) → 2" "2" "$RC"
+assert_contains "empty-file.json says gosec produced nothing" "produced nothing to read" "$OUT"
+
+OUT=$(gosec_report_check "$DATA/does-not-exist.json" "testmod" 2>&1); RC=$?
+assert_eq "a missing report → 2" "2" "$RC"
+
+OUT=$(gosec_report_check "" "testmod" 2>&1); RC=$?
+assert_eq "no report path at all → 2" "2" "$RC"
+assert_contains "an empty path is named as such" "<none>" "$OUT"
+
+echo ""
+echo "== every failure names the module, so a six-module sweep is readable =="
+for f in empty-scan.json truncated.json no-stats.json empty-file.json; do
+  run_check "$f"
+  assert_contains "$f names the module in its refusal" "testmod" "$OUT"
+done
+
+echo ""
+if [[ "$fails" -eq 0 ]]; then
+  echo "gosec-report_test: ALL PASS"
+else
+  echo "gosec-report_test: $fails FAILED" >&2
+  exit 1
+fi

--- a/tools/lib/testdata/gosec-report/clean.json
+++ b/tools/lib/testdata/gosec-report/clean.json
@@ -1,0 +1,9 @@
+{
+  "Golang errors": {},
+  "Issues": [
+    {"severity":"MEDIUM","confidence":"HIGH","cwe":{"id":"22","url":"https://cwe.mitre.org/data/definitions/22.html"},"rule_id":"G304","details":"Potential file inclusion via variable","file":"/repo/core/pkg/tailer/tailer.go","code":"41: f, err := os.Open(path)\n","line":"41","column":"12","nosec":false,"suppressions":null},
+    {"severity":"LOW","confidence":"HIGH","cwe":{"id":"703","url":"https://cwe.mitre.org/data/definitions/703.html"},"rule_id":"G104","details":"Errors unhandled","file":"/repo/core/domain/session/state.go","code":"88: defer f.Close()\n","line":"88","column":"2","nosec":false,"suppressions":null}
+  ],
+  "Stats": {"files":263,"lines":66534,"nosec":0,"found":2},
+  "GosecVersion":"dev"
+}

--- a/tools/lib/testdata/gosec-report/empty-scan.json
+++ b/tools/lib/testdata/gosec-report/empty-scan.json
@@ -1,0 +1,1 @@
+{"Golang errors": {}, "Issues": [], "Stats": {"files":0,"lines":0,"nosec":0,"found":0}, "GosecVersion":"dev"}

--- a/tools/lib/testdata/gosec-report/high-high.json
+++ b/tools/lib/testdata/gosec-report/high-high.json
@@ -1,0 +1,9 @@
+{
+  "Golang errors": {},
+  "Issues": [
+    {"severity":"HIGH","confidence":"MEDIUM","cwe":{"id":"190","url":"https://cwe.mitre.org/data/definitions/190.html"},"rule_id":"G115","details":"integer overflow conversion uint64 -> int64","file":"/repo/core/adapters/inbound/agents/antigravity/dbmetrics.go","code":"165: out = int64(num)\n","line":"165","column":"15","nosec":false,"suppressions":null},
+    {"severity":"HIGH","confidence":"HIGH","cwe":{"id":"295","url":"https://cwe.mitre.org/data/definitions/295.html"},"rule_id":"G402","details":"TLS InsecureSkipVerify set true.","file":"/repo/core/adapters/outbound/relay/client.go","code":"27: tls.Config{InsecureSkipVerify: true}\n","line":"27","column":"10","nosec":false,"suppressions":null}
+  ],
+  "Stats": {"files":263,"lines":66534,"nosec":0,"found":2},
+  "GosecVersion":"dev"
+}

--- a/tools/lib/testdata/gosec-report/near-miss.json
+++ b/tools/lib/testdata/gosec-report/near-miss.json
@@ -1,0 +1,10 @@
+{
+  "Golang errors": {},
+  "Issues": [
+    {"severity":"HIGH","confidence":"MEDIUM","cwe":{"id":"190","url":"https://cwe.mitre.org/data/definitions/190.html"},"rule_id":"G115","details":"integer overflow conversion uint64 -> int64","file":"/repo/core/adapters/inbound/agents/antigravity/dbmetrics.go","code":"165: out = int64(num)\n","line":"165","column":"15","nosec":false,"suppressions":null},
+    {"severity":"MEDIUM","confidence":"HIGH","cwe":{"id":"22","url":"https://cwe.mitre.org/data/definitions/22.html"},"rule_id":"G304","details":"Potential file inclusion via variable","file":"/repo/core/pkg/tailer/tailer.go","code":"41: f, err := os.Open(path)\n","line":"41","column":"12","nosec":false,"suppressions":null},
+    {"severity":"HIGH","confidence":"LOW","cwe":{"id":"798","url":"https://cwe.mitre.org/data/definitions/798.html"},"rule_id":"G101","details":"Potential hardcoded credentials","file":"/repo/core/adapters/outbound/store/dsn.go","code":"12: const tokenKey = \"token\"\n","line":"12","column":"7","nosec":false,"suppressions":null}
+  ],
+  "Stats": {"files":263,"lines":66534,"nosec":0,"found":3},
+  "GosecVersion":"dev"
+}

--- a/tools/lib/testdata/gosec-report/no-stats.json
+++ b/tools/lib/testdata/gosec-report/no-stats.json
@@ -1,0 +1,1 @@
+{"Golang errors": {}, "Issues": [], "GosecVersion":"dev"}

--- a/tools/lib/testdata/gosec-report/null-issues.json
+++ b/tools/lib/testdata/gosec-report/null-issues.json
@@ -1,0 +1,1 @@
+{"Golang errors": {}, "Issues": null, "Stats": {"files":263,"lines":66534,"nosec":0,"found":0}, "GosecVersion":"dev"}

--- a/tools/lib/testdata/gosec-report/truncated.json
+++ b/tools/lib/testdata/gosec-report/truncated.json
@@ -1,0 +1,1 @@
+{"Golang errors": {}, "Issues": [{"severity":"HIGH","confidence":"HI

--- a/tools/preflight.sh
+++ b/tools/preflight.sh
@@ -1,10 +1,16 @@
 #!/usr/bin/env bash
-# preflight.sh — run every PR-gating CI check locally, in the same order CI
-# runs them, so a failure surfaces on your machine in minutes instead of on
-# GitHub Actions after a push. Exit code mirrors CI: 0 only if every gate
-# that ran passed. All gates run regardless of an earlier failure, and a
-# pass/fail summary prints at the end — so one invocation surfaces every
-# problem instead of forcing one push per failure.
+# preflight.sh — run every PR-gating CI check locally, so a failure surfaces on
+# your machine in minutes instead of on GitHub Actions after a push. Exit code
+# mirrors CI: 0 only if every gate that ran passed. All gates run regardless of
+# an earlier failure, and a pass/fail summary prints at the end — so one
+# invocation surfaces every problem instead of forcing one push per failure.
+#
+# Gates run CHEAPEST FIRST, in two phases, rather than in the order CI happens
+# to (#1570) — there is no single CI order to mirror anyway, since test.yml,
+# web-test.yml, ars-gate.yml, macos-swift.yml and linux.yml are separate
+# workflows GitHub runs concurrently. See the "PHASE 1"/"PHASE 2" banners below
+# for why the order is load-bearing under --budget, and why cheap-first moves
+# this script towards test.yml rather than away from it.
 #
 # Mirrors:
 #   .github/workflows/test.yml      — gofmt, core + onboarding-factory tests,
@@ -72,6 +78,24 @@
 #                                        runs, then security-scan.sh --changed
 #                                        picks which Go modules / web trees to
 #                                        scan (issue #1213).
+#   tools/preflight.sh --budget 540    # bound the WHOLE run to 540s of wall
+#                                        clock. Each gate gets whatever is
+#                                        left; one that outlives it is killed
+#                                        and reported TIMEOUT by name, and
+#                                        every gate after it is reported
+#                                        NOT RUN. Both exit non-zero — neither
+#                                        is a pass, and neither is a SKIP.
+#                                        0 (the default) is unbounded, which is
+#                                        what a manual run gets: the full run
+#                                        is byte-for-byte what it was.
+#
+# --budget exists because the pre-push hook's failure mode was the one thing
+# AGENTS.md rules out (#1570): on a one-file core/ diff the run measured 621s
+# against an automated caller's 600s command budget, so the CALLER killed it
+# from outside — no summary, no gate name, no exit code, the commit already
+# made and the push not sent. The documented recovery, `git push --no-verify`,
+# then disables every gate including the sub-second ones nobody ran. A budget
+# the run enforces itself turns that silence into a named refusal.
 #
 # PLATFORMS overrides the Linux gate's docker --platform (default: linux/amd64,
 # matching linux.yml's ubuntu-latest runner — QEMU-emulated on Apple Silicon,
@@ -85,11 +109,13 @@ cd "$ROOT_DIR"
 RUN_LINUX=0
 ONLY=""
 CHANGED=0
+BUDGET=0
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --linux) RUN_LINUX=1; shift ;;
     --only)  ONLY="${2:-}"; shift 2 ;;
     --changed) CHANGED=1; shift ;;
+    --budget) BUDGET="${2:-}"; shift 2 ;;
     # Print the whole leading comment block — including the Usage section,
     # which the previous fixed line range had already drifted past.
     -h|--help) awk 'NR>1 && /^#/ {print; next} NR>1 {exit}' "$0"; exit 0 ;;
@@ -115,6 +141,25 @@ if [[ -n "$ONLY" ]]; then
 fi
 
 [[ "$ONLY" == "linux" ]] && RUN_LINUX=1
+
+# ---- wall-clock budget (#1570) -------------------------------------------
+# Sourced unconditionally, and fatally: without it every gate would run
+# unbounded, which is precisely the behaviour --budget was passed to prevent.
+# A bound that silently is not one is worse than no bound, because the caller
+# stops watching for the outcome it was promised protection from.
+# shellcheck source=lib/gate-budget.sh
+. "$SCRIPT_DIR/lib/gate-budget.sh" || {
+  echo "cannot load $SCRIPT_DIR/lib/gate-budget.sh — refusing to run a budgeted gate set with no budget" >&2
+  exit 2
+}
+budget_open "$BUDGET" || exit 2
+if budget_is_bounded; then
+  echo "budget: this run is bounded to ${BUDGET}s of wall clock in total."
+  echo "budget: a gate that outlives what is left is KILLED and reported TIMEOUT;"
+  echo "budget: gates after it are reported NOT RUN. Neither is a pass, and both"
+  echo "budget: exit non-zero. Re-run any of them unbounded with"
+  echo "budget:   tools/preflight.sh --changed --only <group>"
+fi
 
 want() {
   local group="$1"
@@ -162,13 +207,50 @@ RESULTS=()
 overall=0
 SEPARATOR="=============================================================="
 
+# The group whose gates are currently being run, so a TIMEOUT can name the
+# exact `--only` value that re-runs it unbounded. Set by each `if want …`
+# block below; the advice is useless without it.
+CURRENT_GROUP=""
+
 run_gate() {
   local name="$1"; shift
+  # Checked BEFORE the banner: a gate with nothing left is one that did not
+  # run, which is a different claim from one that ran and was killed, and the
+  # reader has to be able to tell them apart. Both refuse the push.
+  if budget_exhausted; then
+    echo
+    echo "$SEPARATOR"
+    echo "  $name  — NOT RUN (the ${BUDGET_TOTAL_SECONDS}s budget was already spent)"
+    echo "$SEPARATOR"
+    # One line, not a paragraph: every gate behind the one that overran prints
+    # this, and six copies of the same explanation bury the TIMEOUT above them.
+    # The reasoning is stated once, in the closing block after the summary.
+    echo "  Never started — that is not a SKIP and not a pass."
+    echo "  Run it:  tools/preflight.sh --changed --only ${CURRENT_GROUP:-<group>}"
+    NAMES+=("$name"); RESULTS+=("NOT RUN")
+    overall=1
+    return 0
+  fi
   echo
   echo "$SEPARATOR"
   echo "  $name"
   echo "$SEPARATOR"
-  if "$@"; then
+  local allowed rc
+  allowed=$(budget_remaining)   # 0 when unbounded — budget_run reads that as "no bound"
+  budget_run "$allowed" "$@"
+  rc=$?
+  # BUDGET_LAST_TIMED_OUT, not `rc == 124`: a gate is free to exit 124 on its
+  # own, and reporting that as a timeout would send the reader hunting for
+  # time nobody spent.
+  if [[ "$BUDGET_LAST_TIMED_OUT" -eq 1 ]]; then
+    echo
+    echo "  $name — TIMEOUT."
+    echo "  Killed after ${allowed}s: all that was left of this run's ${BUDGET_TOTAL_SECONDS}s budget."
+    echo "  It did NOT finish, so nothing it covers is known to pass."
+    echo "  Run it unbounded:  tools/preflight.sh --changed --only ${CURRENT_GROUP:-<group>}"
+    NAMES+=("$name"); RESULTS+=("TIMEOUT")
+    overall=1
+  elif [[ "$rc" -eq 0 ]]; then
     NAMES+=("$name"); RESULTS+=("PASS")
   else
     NAMES+=("$name"); RESULTS+=("FAIL")
@@ -195,7 +277,24 @@ run_gate_scoped() {
   run_gate "$@"
 }
 
-# ---- go group (mirrors test.yml) ----------------------------------------
+# ---- gate implementations -------------------------------------------------
+# Each group's helper is defined here; the two PHASES below decide the order
+# the gates run in. Phase 1 is the cheap, deterministic set — seconds at most,
+# no test binaries, no network — and Phase 2 is everything that costs real
+# time.
+#
+# That split is load-bearing, not cosmetic (#1570). Under --budget a run can
+# end before it reaches its last gate, so the order decides WHICH gates survive
+# a squeeze — and the cheap ones have to be the survivors. `skill-file lint`
+# and `POSIX sh lint` are the only coverage their file families have anywhere,
+# and each costs a fraction of a second; paying for them behind four minutes of
+# `go test` is backwards. test.yml already makes this argument for this gate,
+# in these words: "Runs first, before setup-go: it needs no toolchain and takes
+# a fraction of a second, and behind the Go suites a `go test` failure would
+# abort the job and leave a skills-only PR with no skill feedback at all." So
+# ordering cheap-first moves preflight TOWARDS the workflow it mirrors.
+
+# -- go ---------------------------------------------------------------------
 gofmt_check() {
   local unformatted
   unformatted=$(gofmt -l core/ tools/)
@@ -237,8 +336,114 @@ core_module_tests() {
   go test $pkgs -race -count=1
 }
 
+# -- web (mirrors web-test.yml) ---------------------------------------------
+web_tree() {
+  local dir="$1"
+  # --ignore-scripts mirrors web-test.yml: no dependency lifecycle script runs
+  # at install time. Keep the two in step, or preflight stops being CI parity.
+  ( cd "$dir" && npm ci --ignore-scripts && npm test )
+  return $?
+}
+
+# -- tools (mirrors test.yml's "Test the shared shell libs" step) ------------
+shell_lib_tests() {
+  local rc=0 t
+  for t in tools/lib/*_test.sh; do
+    [[ -e "$t" ]] || continue
+    bash "$t" || rc=1
+  done
+  return "$rc"
+}
+
+# ===========================================================================
+#  PHASE 1 — the cheap, deterministic gates. Sub-second to ~16s each.
+# ===========================================================================
+
+# ---- posix group (mirrors linux.yml's "Lint POSIX sh scripts" step) --------
+# The #!/bin/sh corpus is two files today (site/install.sh and
+# tools/linux-replay-entrypoint.sh) and the gate re-lints all of them whenever
+# it fires — it is a fraction of a second, and the trigger cannot enumerate
+# them anyway, because a NEW POSIX script is exactly the file the gate most
+# needs to see on the push that adds it. So the regex is deliberately loose:
+# any *.sh, any extensionless file under tools/ or site/, plus the linter and
+# its own corpus. Over-firing costs milliseconds; under-firing is #1209's
+# silent-skip shape again.
+#
+# Unlike the CI step this gate can legitimately be unrunnable on a developer
+# machine that has neither checkbashisms nor shellcheck. It still FAILS rather
+# than skipping in that case — the script says what to `brew install`. A gate
+# whose absence looks like a pass is the defect #1423 was filed about, and
+# preflight is not the place to reintroduce it.
+#
+# The extensionless alternatives are not decoration: `tools/git-hooks/pre-push`
+# is already a tracked script with no suffix, and a `#!/bin/sh` file called
+# `site/install` would match nothing in a `\.sh$`-only trigger — skipping the
+# gate on precisely the push that introduces the script it exists to check.
+if want posix; then
+  CURRENT_GROUP=posix
+  run_gate_scoped '\.sh$|^(tools|site)/[^/]*$|^tools/git-hooks/|^tools/lib/testdata/posix-lint/' \
+                  "POSIX sh lint (#!/bin/sh bashisms)" tools/posix-lint.sh
+fi
+
+# ---- skills group (mirrors test.yml's "Lint skill files" step) ------------
+# Scoped to skill markdown plus the linter, so editing a check re-lints the
+# corpus it governs. `SKILL.md` matches at any path because skills are not all
+# under .claude/skills/ — tools/irrlicht-design-system/ holds one. The whole
+# corpus is linted whenever the gate fires rather than just the changed files:
+# it is ~23 small files and a fraction of a second, and a finding a
+# *neighbouring* file already carries is worth surfacing on the push that
+# finally reads it.
+if want skills; then
+  CURRENT_GROUP=skills
+  run_gate_scoped '^\.claude/skills/.*\.md$|(^|/)SKILL\.md$|^tools/skill-lint\.sh$' \
+                  "skill-file lint" tools/skill-lint.sh
+fi
+
+# ---- tools group (mirrors test.yml's "Test the shared shell libs" step) ----
+# Scoped to tools/lib/ plus every top-level tools/*.sh rather than naming the
+# two current callers: a third script sourcing the lib would otherwise stop
+# running these tests without anyone noticing.
+if want tools; then
+  CURRENT_GROUP=tools
+  # go.work and .github/dependabot.yml are in scope because module-list_test.sh
+  # asserts they agree — and a commit touching only one of those two is exactly
+  # the commit that breaks the invariant, so leaving them out would skip the
+  # test precisely when it matters (#1291).
+  # site/install.sh is in the trigger set because tools/lib/install-uninstall_test.sh
+  # tests it (#1416). Without it a push touching only the installer would SKIP
+  # the one gate that covers the installer.
+  run_gate_scoped '^tools/lib/|^tools/[^/]*\.sh$|^go\.work$|^\.github/dependabot\.yml$|^site/install\.sh$' \
+                  "tools/lib shell-lib tests" shell_lib_tests
+fi
+
+# ---- go group, cheap half (mirrors test.yml's gofmt step) ------------------
+# gofmt is a second of work and is the single most common way a push fails, so
+# it runs before anything expensive. Unscoped, exactly as in CI: it reads the
+# whole tree, not the diff.
 if want go; then
-  run_gate        "gofmt"                    gofmt_check
+  CURRENT_GROUP=go
+  run_gate "gofmt" gofmt_check
+fi
+
+# ---- arch group (mirrors ars-gate.yml) -----------------------------------
+# ars-gate.sh scans core/, so an ARS regression can only come from a core/
+# change. ~16s, which is the boundary of "cheap" — it is the last gate in
+# phase 1 for that reason.
+if want arch; then
+  CURRENT_GROUP=arch
+  run_gate_scoped '^core/' "ARS architecture gate" tools/ars-gate.sh
+fi
+
+# ===========================================================================
+#  PHASE 2 — the gates that cost real time. Measured on a one-file diff under
+#  core/adapters/inbound/agents/: core module tests + replay fixtures 250s,
+#  security scan 185s. These are the gates a --budget squeeze drops first, and
+#  each is reported by name when it does.
+# ===========================================================================
+
+# ---- go group, expensive half (mirrors test.yml) --------------------------
+if want go; then
+  CURRENT_GROUP=go
   run_gate_scoped '^core/.*\.go$|^core/go\.(mod|sum)$' \
                   "core module tests"        core_module_tests
   run_gate_scoped '^tools/onboarding-factory/.*\.go$' \
@@ -264,95 +469,19 @@ if want go; then
 fi
 
 # ---- web group (mirrors web-test.yml) -----------------------------------
-web_tree() {
-  local dir="$1"
-  # --ignore-scripts mirrors web-test.yml: no dependency lifecycle script runs
-  # at install time. Keep the two in step, or preflight stops being CI parity.
-  ( cd "$dir" && npm ci --ignore-scripts && npm test )
-  return $?
-}
-
 if want web; then
+  CURRENT_GROUP=web
   run_gate_scoped '^platforms/web/' \
                   "web: platforms/web"             web_tree platforms/web
   run_gate_scoped '^tools/onboarding-factory/internal/viewer/web/' \
                   "web: onboarding-factory viewer" web_tree tools/onboarding-factory/internal/viewer/web
 fi
 
-# ---- arch group (mirrors ars-gate.yml) -----------------------------------
-# ars-gate.sh scans core/, so an ARS regression can only come from a core/
-# change.
-if want arch; then
-  run_gate_scoped '^core/' "ARS architecture gate" tools/ars-gate.sh
-fi
-
-# ---- tools group (mirrors test.yml's "Test the shared shell libs" step) ----
-# Scoped to tools/lib/ plus every top-level tools/*.sh rather than naming the
-# two current callers: a third script sourcing the lib would otherwise stop
-# running these tests without anyone noticing.
-shell_lib_tests() {
-  local rc=0 t
-  for t in tools/lib/*_test.sh; do
-    [[ -e "$t" ]] || continue
-    bash "$t" || rc=1
-  done
-  return "$rc"
-}
-
-if want tools; then
-  # go.work and .github/dependabot.yml are in scope because module-list_test.sh
-  # asserts they agree — and a commit touching only one of those two is exactly
-  # the commit that breaks the invariant, so leaving them out would skip the
-  # test precisely when it matters (#1291).
-  # site/install.sh is in the trigger set because tools/lib/install-uninstall_test.sh
-  # tests it (#1416). Without it a push touching only the installer would SKIP
-  # the one gate that covers the installer.
-  run_gate_scoped '^tools/lib/|^tools/[^/]*\.sh$|^go\.work$|^\.github/dependabot\.yml$|^site/install\.sh$' \
-                  "tools/lib shell-lib tests" shell_lib_tests
-fi
-
-# ---- skills group (mirrors test.yml's "Lint skill files" step) ------------
-# Scoped to skill markdown plus the linter, so editing a check re-lints the
-# corpus it governs. `SKILL.md` matches at any path because skills are not all
-# under .claude/skills/ — tools/irrlicht-design-system/ holds one. The whole
-# corpus is linted whenever the gate fires rather than just the changed files:
-# it is ~23 small files and a fraction of a second, and a finding a
-# *neighbouring* file already carries is worth surfacing on the push that
-# finally reads it.
-if want skills; then
-  run_gate_scoped '^\.claude/skills/.*\.md$|(^|/)SKILL\.md$|^tools/skill-lint\.sh$' \
-                  "skill-file lint" tools/skill-lint.sh
-fi
-
-# ---- posix group (mirrors linux.yml's "Lint POSIX sh scripts" step) --------
-# The #!/bin/sh corpus is two files today (site/install.sh and
-# tools/linux-replay-entrypoint.sh) and the gate re-lints all of them whenever
-# it fires — it is a fraction of a second, and the trigger cannot enumerate
-# them anyway, because a NEW POSIX script is exactly the file the gate most
-# needs to see on the push that adds it. So the regex is deliberately loose:
-# any *.sh, any extensionless file under tools/ or site/, plus the linter and
-# its own corpus. Over-firing costs milliseconds; under-firing is #1209's
-# silent-skip shape again.
-#
-# Unlike the CI step this gate can legitimately be unrunnable on a developer
-# machine that has neither checkbashisms nor shellcheck. It still FAILS rather
-# than skipping in that case — the script says what to `brew install`. A gate
-# whose absence looks like a pass is the defect #1423 was filed about, and
-# preflight is not the place to reintroduce it.
-#
-# The extensionless alternatives are not decoration: `tools/git-hooks/pre-push`
-# is already a tracked script with no suffix, and a `#!/bin/sh` file called
-# `site/install` would match nothing in a `\.sh$`-only trigger — skipping the
-# gate on precisely the push that introduces the script it exists to check.
-if want posix; then
-  run_gate_scoped '\.sh$|^(tools|site)/[^/]*$|^tools/git-hooks/|^tools/lib/testdata/posix-lint/' \
-                  "POSIX sh lint (#!/bin/sh bashisms)" tools/posix-lint.sh
-fi
-
 # ---- security group (mirrors tools/security-scan.sh's local mode; the same
 # script's full mode, with GitHub Dependabot/CodeQL alert checks, runs at
 # release time from ir:release's Step 5.5, not here) ------------------------
 if want security; then
+  CURRENT_GROUP=security
   # In --changed mode the gate's trigger regex only decides whether the scan
   # runs at all; --changed then narrows *which* modules and trees it scans, so
   # a diff that trips the trigger via one tree's lockfile doesn't also audit
@@ -435,6 +564,7 @@ swift_suite() {
 }
 
 if want swift; then
+  CURRENT_GROUP=swift
   # macOS-only, and skipped rather than failed elsewhere. The gate mirrors a
   # workflow that is itself `runs-on: macos-latest`, so on Linux it is out of
   # scope, not unmet — without this guard a Linux contributor's plain
@@ -471,6 +601,7 @@ linux_parity() {
 }
 
 if [[ "$RUN_LINUX" == 1 ]]; then
+  CURRENT_GROUP=linux
   run_gate "linux parity (build + go test ./... -race + replay-fixtures)" linux_parity
 fi
 
@@ -487,5 +618,24 @@ fi
 for i in "${!NAMES[@]}"; do
   printf "  %-58s %s\n" "${NAMES[$i]}" "${RESULTS[$i]}"
 done
+
+# Name the unfinished gates once more, after the table (#1570). The table is
+# the first thing scrolled past; the sentence that decides whether to push is
+# the last thing printed. SKIP is deliberately absent from this list — "this
+# diff cannot break it" is a finished answer, where TIMEOUT and NOT RUN are the
+# absence of one.
+unfinished=()
+for i in "${!NAMES[@]}"; do
+  case "${RESULTS[$i]}" in
+    TIMEOUT|"NOT RUN") unfinished+=("${NAMES[$i]} (${RESULTS[$i]})") ;;
+  esac
+done
+if [[ ${#unfinished[@]} -gt 0 ]]; then
+  echo
+  echo "  ${#unfinished[@]} gate(s) did not finish inside the ${BUDGET_TOTAL_SECONDS}s budget:"
+  printf '    - %s\n' "${unfinished[@]}"
+  echo "  They are NOT passes. Run them unbounded before pushing, or push with a"
+  echo "  larger budget:  PREPUSH_BUDGET=1800 git push"
+fi
 
 exit "$overall"

--- a/tools/security-scan.sh
+++ b/tools/security-scan.sh
@@ -36,7 +36,10 @@
 #     `stdlib` is a Go-toolchain patch-level issue, not a code change here —
 #     logged prominently as an upgrade recommendation, not blocking.
 #   - gosec: High-severity + High-confidence findings fail the gate.
-#     Everything else is logged for visibility, not blocking.
+#     Everything else is logged for visibility, not blocking. Both answers
+#     come out of ONE `-fmt=json` run per module (#1570) — see the gosec
+#     block below and lib/gosec-report.sh for why there used to be two, and
+#     what "the scan covered 0 files" is refused for.
 #   - npm audit: gate on the High+Critical count in the JSON report's
 #     `.metadata.vulnerabilities` block. A non-zero exit alone is ambiguous —
 #     npm exits non-zero both when it finds advisories and when the audit
@@ -58,6 +61,16 @@ set -uo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT=$(git rev-parse --show-toplevel)
 cd "$REPO_ROOT"
+
+# Sourced unconditionally and fatally, the same shape as the --changed lib
+# below: without it gosec_report_check is undefined, `case $?` would take the
+# catch-all arm, and every module would be reported as a failed scan. Loud
+# either way — but "cannot load the classifier" is the accurate sentence.
+# shellcheck source=lib/gosec-report.sh
+. "$SCRIPT_DIR/lib/gosec-report.sh" || {
+  echo "FAIL: cannot load $SCRIPT_DIR/lib/gosec-report.sh — refusing to classify a gosec report blind" >&2
+  exit 2
+}
 
 LOCAL_ONLY=0
 CHANGED=0
@@ -240,18 +253,33 @@ done
 # Same placement, and for a sharper reason: "gosec not found" is a hard
 # failure, so hoisting it out of the loop would reject a push that had no Go
 # module to scan — again #1213's shape.
+#
+# ONE run per module, not two (#1570). This used to be an unfiltered
+# informational pass followed by a `-severity high -confidence high` gate
+# pass — but those flags filter the REPORT, not the analysis, so the second
+# run re-derived a strict subset of the first at full price: 172s + 172s on
+# the core module, 344s of the security gate's measured 355s. The single JSON
+# report carries both answers and lib/gosec-report.sh reads them out. Nothing
+# is scanned less: still `./...`, still unfiltered.
 
 for mod in "${GO_MODULES[@]+"${GO_MODULES[@]}"}"; do
   command -v gosec >/dev/null 2>&1 || { fail "gosec not found — install: go install github.com/securego/gosec/v2/cmd/gosec@latest"; continue; }
-  echo "-- gosec: $mod (informational, all severities) --"
-  ( cd "$mod" && gosec -no-fail -quiet ./... ) || true
-
-  echo "-- gosec: $mod (gate: High severity + High confidence) --"
-  if ( cd "$mod" && gosec -quiet -severity high -confidence high ./... ); then
-    ok "gosec: $mod — no High/High findings"
-  else
-    fail "gosec: $mod — High-severity/High-confidence finding(s) — see output above"
-  fi
+  echo "-- gosec: $mod (one pass; informational listing + High/High gate) --"
+  gs_json=$(mktemp)
+  gs_err=$(mktemp)
+  # -no-fail so the exit status carries no verdict: the verdict is the report,
+  # and a gosec that exits non-zero merely because it found a LOW issue must
+  # not be confused with one that could not run. "Could not run" is caught by
+  # gosec_report_check, which refuses an unparseable or zero-file report
+  # rather than reading it as clean.
+  ( cd "$mod" && gosec -no-fail -quiet -fmt=json -out="$gs_json" ./... ) >/dev/null 2>"$gs_err"
+  gosec_report_check "$gs_json" "$mod"
+  case $? in
+    0) ok "gosec: $mod — no High/High findings" ;;
+    1) fail "gosec: $mod — High-severity/High-confidence finding(s) — listed above" ;;
+    *) fail "gosec: $mod — the scan did not produce a readable report; this is NOT a clean result: $(tr '\n' ' ' <"$gs_err" | sed 's/  */ /g' | cut -c1-400)" ;;
+  esac
+  rm -f "$gs_json" "$gs_err"
 done
 
 # ---- npm audit (all modes) -------------------------------------------------


### PR DESCRIPTION
Closes #1570

The pre-push hook ran `tools/preflight.sh --changed` unbounded, so when it
outlived an automated caller's 600s command budget the **caller** killed it:
no summary, no gate name, no exit code, the commit already made and the push
not sent. The documented recovery — `git push --no-verify` — then also skips
the gates that are *fast* and that nobody ran, turning "one gate is too slow"
into "no gates ran".

Three changes. Everything below is measured on this machine, not estimated.

## Where the time actually goes

One-file diff under `core/adapters/inbound/agents/`, each group timed as its
own `tools/preflight.sh --changed --only <g>` run:

| group | before | after |
|---|---|---|
| `go` (gofmt + scoped core tests + replay fixtures) | 250s | 250s |
| `arch` | 16s | 16s |
| `security` | **355s** | **186s** |
| `posix` / `skills` / `tools` / `web` / `swift` | SKIP | SKIP |
| **total** | **621s** | **452s** |

621s against a 600s budget is the reported incident, reproduced exactly.

Inside the security gate, the cost was not `govulncheck` (11.9s) and not the
`npm audit`s (already scoped out of a Go-only diff by #1213 — 7 of 9 scans
reported SKIP). It was `gosec`, **running the identical scan twice**:

```
( cd "$mod" && gosec -no-fail -quiet ./... )                          # 2:52.82
( cd "$mod" && gosec -quiet -severity high -confidence high ./... )   # 2:51.33
```

`-severity`/`-confidence` are *report* filters applied after the analysis, so
the second run re-derived a strict subset of the first at full price.

## 1. One gosec pass per module

`gosec -no-fail -quiet -fmt=json -out=<file> ./...` runs once and
`tools/lib/gosec-report.sh` reads both answers out of it: `.Stats` for the
informational summary, `.Issues[].severity`/`.confidence` for the gate.

- **Nothing is scanned less.** Still `./...`, still unfiltered, same 263 files
  / 66,534 lines / 161 issues / same verdict. This is why gosec was *not*
  scoped to changed packages instead, which the issue floated — that would be
  a real reduction in coverage; halving a duplicate is not.
- **A scan that could not run is not a clean scan.** An unparseable report, a
  report with no `.Stats`, an empty file, and a report whose own
  `.Stats.files` is `0` are each refused (status 2) rather than counted as
  "no High/High findings", which is what all four produce if you only count
  matching issues.

## 2. `--budget <seconds>`

`tools/lib/gate-budget.sh`, wired by the hook at 540s and overridable with
`PREPUSH_BUDGET` (`0` = unbounded, exactly the old behaviour). An unflagged
`tools/preflight.sh` is unbounded and byte-for-byte unchanged.

Each gate is given whatever is left. A gate that outlives it is killed and
reported **`TIMEOUT` by name**; every gate behind it is reported **`NOT RUN`**;
both exit non-zero, and the closing block lists them again after the summary.
Neither is a `SKIP` — `SKIP` means "this diff cannot break it", which is a
finished answer, where these two are the absence of one.

Two implementation notes that are load-bearing:

- **Pure bash 3.2, not `timeout(1)`.** `timeout` needs `brew install
  coreutils`; a bound that stops being enforced on the machines missing an
  optional dependency is the same defect wearing a different hat. `/bin/bash`
  on macOS is 3.2, so no `wait -n`, no `mapfile`.
- **Classification is on `BUDGET_LAST_TIMED_OUT`, not on the 124 exit
  status.** A gate is free to exit 124 on its own, and reporting that as a
  timeout sends the reader hunting for time nobody spent. Pinned by a test.
- **The whole process tree is killed**, verified against the hardest case in
  the repo: the `swift` gate wraps `swift test` in `script -q`, which calls
  `login_tty` and moves the children into a different session and process
  groups. Under `--budget 45` the gate is killed at 45.087s and leaves **zero**
  `xctest` processes behind.

## 3. Cheapest-first gate order

Under a budget the order decides which gates survive a squeeze, so the cheap
ones have to be the survivors: `skill-file lint` and `POSIX sh lint` are the
only coverage their file families have anywhere, at a fraction of a second
each, and they were running behind four minutes of `go test`. `test.yml`
already makes exactly this argument in-file for running the skill lint before
`setup-go`, so this moves preflight *towards* the workflow it mirrors. There
is no single "CI order" to preserve — those are separate workflows GitHub runs
concurrently.

**The reported "gofmt runs last in the `go` group" is not real** — it is the
first gate of the group and the first gate of the whole run, both on `main`
and here. Evidence: `tools/preflight.sh:241` on `main`, and the first banner of a
recorded `--only go` run. The real version of that complaint was the *group*
order, which is what changed.

## Mutation evidence — each seen red

Budget (`tools/lib/gate-budget_test.sh`, 49 assertions, 11s):

| mutation | red |
|---|---|
| deadline check → `if false` | 7 assertions; the 3s-bounded probe takes 45s |
| descendant walk removed from the tree kill | the grandchild outlives its bound; 2 red |
| `BUDGET_LAST_TIMED_OUT=1` deleted | summary row reads `FAIL`, not `TIMEOUT` |
| `budget_exhausted` check removed from `run_gate` | `NOT RUN` never printed, and the run takes **332s** instead of ≤20s — the exhausted budget silently became an unbounded one |

gosec classifier (`tools/lib/gosec-report_test.sh`, 34 assertions):

| mutation | red |
|---|---|
| blocking predicate `and` → `or` | `near-miss.json` + `clean.json` |
| zero-files guard deleted | `empty-scan.json` — a scan that read nothing reads as clean |
| unparseable report returns 0 | `truncated.json` |

And end to end, against the real scanner rather than a fixture: a genuine
`G402` (`tls.Config{InsecureSkipVerify: true}`, HIGH/HIGH) planted in a new
`core/` package. The single-pass gate **FAILs** and names it —

```
   HIGH/HIGH G402 …/core/pkg/gosecprobe/probe.go:10 — TLS InsecureSkipVerify set true.
  - G402 …/core/pkg/gosecprobe/probe.go:10 — TLS InsecureSkipVerify set true.
FAIL: gosec: core — High-severity/High-confidence finding(s) — listed above
  security scan (govulncheck + gosec + npm audit)            FAIL
```

— so the dedup did not make it blind. The probe was removed before commit.

The fixtures are committed under `tools/lib/testdata/gosec-report/`, following
`testdata/posix-lint/`: the mutation evidence has to outlive this PR, and a
174s gosec run is not something a unit test can perform. `near-miss.json` is
the load-bearing one — HIGH/MEDIUM and MEDIUM/HIGH only, the single shape that
tells `and` from `or`. `clean.json` is the vacuity guard.

## Verification

All foreground, all green:

```
tools/preflight.sh --only tools      PASS   43s   (8 suites, incl. both new ones)
tools/preflight.sh --only posix      PASS    7s
tools/preflight.sh --only skills     PASS    1s
tools/preflight.sh --only security   PASS  4:48   (full unscoped sweep:
                                                   6 Go modules + both web trees,
                                                   every module reporting a
                                                   non-zero file count)
```

No Go source is touched, so `go test ./core/...` is not in scope for this diff.

### The hook, end to end

**Old hook, real `git push`:** ran unbounded, hit the `swift` gate, and was
killed by the caller at 600s. The push did not land — `git status -sb` showed
`[ahead 1]` against `origin/main` and `git ls-remote` showed no branch, with
the commit already made. #1570 reproduced live, in the session that fixed it.
(The hook that ran was the *main checkout's* copy: `.git/hooks/pre-push` is a
symlink into the main worktree, so a hook edit in a worktree does not apply to
that worktree's own push. See "found but not fixed".)

**New hook, same diff, `PREPUSH_BUDGET=180`:** finished in **3:00.44** —
bounded to the second — with the cheap gates run first and green, and the one
gate that could not finish named:

```
  POSIX sh lint (#!/bin/sh bashisms)                         PASS
  skill-file lint                                            SKIP
  tools/lib shell-lib tests                                  PASS
  gofmt                                                      PASS
  ...
  macOS Swift build + test                                   TIMEOUT

  1 gate(s) did not finish inside the 180s budget:
    - macOS Swift build + test (TIMEOUT)
  They are NOT passes. Run them unbounded before pushing, or push with a
  larger budget:  PREPUSH_BUDGET=1800 git push
```

Zero orphaned processes afterwards.

### Why this branch was pushed with `--no-verify`

The `swift` gate cannot complete on this machine, for reasons that predate and
are independent of this diff: the suite reaches
`SessionRowSnapshotTests.testRelayCloudOnline` and stops there — reproduced
twice, at the identical point — while that test passes in 0.157s in isolation.
`platforms/macos/` and `tools/lib/swift-suite.sh` are byte-identical to
`origin/main` in this worktree (`git diff --stat origin/main -- platforms/macos
tools/lib/swift-suite.sh` is empty), so this is #1530's already-recorded hang,
not something introduced here. Every other gate this diff triggers was run
individually in the foreground and passed (above).

Worth noting for #1530: `SWIFT_SUITE_TIMEOUT` defaults to **600s**, which is
exactly an automated caller's whole command budget — so the gate's own careful
`swift test HUNG` diagnosis can never print before the caller kills everything.
The outer budget added here fires first and names the gate, which is what made
the hang legible in the first place.

## Also in this diff

`tools/lib/changed-files_test.sh`'s "names the missing lib in its error" case
stopped reaching what it was written for the moment a second lib was sourced
ahead of `changed-files.sh` — it deleted the whole `lib/` directory, so the
script now died on the *first* missing lib and named that one instead. It now
deletes only `changed-files.sh` and keeps the whole-directory case beside it,
so the predecessor's assertion survives rather than being quietly replaced.
