### PR TITLE
fix(daemon): stop the backchannel typing into a tmux pane the session only inherited

### DIFF
--- a/core/adapters/inbound/agents/processlifecycle/osutil.go
+++ b/core/adapters/inbound/agents/processlifecycle/osutil.go
@@ -170,12 +170,18 @@ func herdrClientLogPath(socketPath string) string {
 //
 // Read it as "the host of the PANE this launcher addresses was determined",
 // which is what the merging contract above actually needs, and which #1501
-// separated from "a host was determined". A process that merely INHERITED a
-// $TMUX_PANE has a host of its own and no claim on that pane's — so the answer
-// for it is false, and the merge leaves its own identity alone instead of
-// overwriting it with a fresh read that could be one timed-out probe short.
-// For a launcher addressing no pane at all the two readings coincide and it is
-// true, exactly as before.
+// separated from "a host was determined". For a launcher addressing no pane at
+// all the two readings coincide and it is true, exactly as before.
+//
+// A process that merely INHERITED a $TMUX_PANE used to be the case that made
+// the distinction bite: it has a host of its own and no claim on that pane's,
+// so the answer for it was false and the merge left its own identity alone.
+// Since #1582 it no longer carries the pane address at all
+// (dropInheritedTmuxPane), so it is an ordinary launcher addressing no pane and
+// the answer for it is true — which is also what stops the liveness sweep
+// paying a re-read per tick for a session whose identity was never the pane's
+// to change (services.hostedInAMultiplexerPane). The distinction itself stays:
+// it is what a genuine pane whose client probe did not run still needs.
 //
 // Never prompts the user — on macOS we use
 // `sysctl(kern.procargs2)` (no TCC prompt; `ps e` stopped exposing env on
@@ -264,6 +270,13 @@ func ReadLauncherEnv(pid int) (l *session.Launcher, hostKnown bool) {
 // looked up", which is precisely the shape ReadLauncherEnv's hostKnown contract
 // tells a merging caller not to clear fields on.
 //
+// Since #1582 that case no longer arrives from ReadLauncherEnv, which drops the
+// inherited address one step earlier (dropInheritedTmuxPane), so the branch is
+// reached only by tests today. It is kept rather than deleted because it guards
+// a DIFFERENT failure from the one that drop fixes — adopting a stranger's
+// window onto a session that has its own, which is #1499 rather than #1582 —
+// and the two are not one edit apart.
+//
 // It is the dispatcher, and having one is the point: the two producers differ
 // only in how they enumerate clients (osutil_darwin.go), and the ORDER they are
 // tried in is #1348's — herdr first, because a herdr server started from inside
@@ -315,8 +328,63 @@ func clientHostFor(l *session.Launcher) (client *session.Launcher, probed, addre
 // So this is the same "no local window" test resolveClientHostIdentityVia
 // applies to a CANDIDATE, applied one level up to decide whether to look for
 // candidates at all.
+//
+// Since #1582 the same three terms answer a second question — whether the pane
+// address is worth RECORDING at all — and dropInheritedTmuxPane below asks it
+// through this function rather than restating the terms. The two questions are
+// the same one: an address that is not this process's own is neither a pane
+// whose client we may adopt nor a pane we may address.
 func tmuxPaneAwaitsItsClient(l *session.Launcher) bool {
 	return l.TmuxPane != "" && l.TermProgram == "" && l.HostBundleID == ""
+}
+
+// dropInheritedTmuxPane clears l's tmux address when that address is not the
+// process it was read from's own.
+//
+// $TMUX_PANE is inherited by every descendant of a pane, so a GUI terminal or
+// IDE launched from inside one (`code .`, `kitty`, `open -a iTerm`) carries a
+// pane address belonging to a different process in a different window. #1499
+// already keeps such a session's own host identity — its suppression keys on
+// tmux's own TERM_PROGRAM marker — and copied the pane address alongside it.
+// control.resolveBackend picks the tmux backend from that field alone, so the
+// backchannel ran `tmux -S <inherited socket> send-keys -t %17 -l -- <text>`
+// into a stranger's pane, and interrupt and capture addressed the same one
+// (#1582). That is the failure #1348 removed for herdr, reached through the
+// one field #1499 deliberately left populated for a descendant.
+//
+// The CAPTURE is the only place this can be decided, which is why the fix is
+// here and resolveBackend is untouched. A stored launcher cannot tell the two
+// apart: a genuine pane that adopted its client's identity (#1501) and a
+// descendant that reported its own end up with the same fields —
+// {TermProgram: iTerm.app, ITermSessionID, TmuxPane, TmuxSocket} — and nothing
+// records which process the host came from. Requiring BOTH tmux fields the way
+// resolveBackend requires both herdr ones does not discriminate either: $TMUX
+// is inherited beside $TMUX_PANE, so a descendant carries the socket too.
+//
+// It runs AFTER the ancestry fallbacks, and not inside launcherFromEnv, because
+// the env alone does not answer the question. tmux stamps TERM_PROGRAM=tmux
+// onto the panes it spawns, and a kitty window launched from a pane inherits
+// exactly that (kitty sets no TERM_PROGRAM of its own, upstream kitty#4793) —
+// so at env time a genuine pane and a kitty descendant are the same map, and an
+// env-only check would leave that descendant addressing the pane kitty was
+// launched from while its own kitty backend sat one branch further down
+// resolveBackend. The walk is what separates them: from a genuine pane it
+// terminates at the reparented tmux server having found nothing, and from a
+// descendant it finds the host app.
+//
+// It fails towards DROPPING. An address wrongly dropped costs click-to-focus
+// and the backchannel for that one session, which keeps its own host and stays
+// visible; an address wrongly kept types the user's text into a terminal they
+// were not looking at, and no amount of it being rare makes that the better
+// error. The residual is a descendant whose host cannot be resolved at all (no
+// $TERM_PROGRAM of its own, no `.app` in its ancestry): it is indistinguishable
+// from a genuine pane here and keeps the address, which is the same residual
+// #1499's suppression already accepted.
+func dropInheritedTmuxPane(l *session.Launcher) {
+	if l.TmuxPane == "" || tmuxPaneAwaitsItsClient(l) {
+		return
+	}
+	l.TmuxPane, l.TmuxSocket = "", ""
 }
 
 // hostIdentity resolves the window-owning identity of pid: its whitelisted
@@ -406,6 +474,10 @@ func hostIdentityVia(ctx context.Context, pid int, readTTY ttyProbe) (l *session
 		complete = applyAncestryFallbacks(ctx, l, pid, &ancestryProbe{pid: pid, reads: newAncestryReads()})
 	}
 
+	// Here rather than in launcherFromEnv, because the answer needs the walk
+	// above: see dropInheritedTmuxPane.
+	dropInheritedTmuxPane(l)
+
 	// Capture the controlling TTY so Terminal.app (and potentially others)
 	// can target the exact tab — Terminal.app's AppleScript dictionary
 	// matches tabs by `tty` but has no session-UUID analog.
@@ -452,6 +524,12 @@ func launcherFromEnv(env map[string]string) *session.Launcher {
 	// upstream kitty#4793) is suppressed here and recovered by the ancestry
 	// fallbacks, which is why hostIdentity must not skip them for tmux.
 	//
+	// What this branch decides is which HOST fields survive, never whether the
+	// pane ADDRESS is the process's own — both shapes above carry one and only
+	// one of them is in that pane, and this map cannot tell them apart. That is
+	// dropInheritedTmuxPane's question, asked once the ancestry walk has run
+	// (#1582).
+	//
 	// Checked *after* herdr on purpose: a herdr server started from a tmux
 	// pane hands every pane a $TMUX_PANE as well, and that one is the
 	// server's, not the agent's (#1348). herdrPaneEnv in the tests is exactly
@@ -466,7 +544,7 @@ func launcherFromEnv(env map[string]string) *session.Launcher {
 		TermProgram:    env["TERM_PROGRAM"],
 		ITermSessionID: env["ITERM_SESSION_ID"],
 		TermSessionID:  env["TERM_SESSION_ID"],
-		TmuxPane:       env["TMUX_PANE"],
+		TmuxPane:       env["TMUX_PANE"], // provisional; see dropInheritedTmuxPane (#1582)
 		KittyListenOn:  env["KITTY_LISTEN_ON"],
 		KittyWindowID:  env["KITTY_WINDOW_ID"],
 		TmuxSocket:     tmuxSocketFromEnv(env["TMUX"]),

--- a/core/adapters/inbound/agents/processlifecycle/osutil_test.go
+++ b/core/adapters/inbound/agents/processlifecycle/osutil_test.go
@@ -7,6 +7,8 @@ import (
 	"runtime"
 	"testing"
 	"time"
+
+	"irrlicht/core/domain/session"
 )
 
 // TestHelperProcess is a sleeper used by the subprocess env-capture tests.
@@ -285,11 +287,37 @@ func TestReadLauncherEnv_Subprocess_Tmux(t *testing.T) {
 	if l == nil {
 		t.Fatal("expected non-nil launcher")
 	}
-	if l.TmuxSocket != "/private/tmp/tmux-501/default" {
-		t.Errorf("TmuxSocket: got %q", l.TmuxSocket)
+	assertPaneAddressFollowsProvenance(t, l, "%17", "/private/tmp/tmux-501/default")
+}
+
+// assertPaneAddressFollowsProvenance asserts #1582's rule against a launcher
+// read through the real sysctl / /proc path: the tmux address survives exactly
+// when nothing claimed a host for the process, and is dropped otherwise.
+//
+// A biconditional rather than a fixed expectation, because the fixture the two
+// callers use cannot model a pane faithfully on every platform.
+// spawnSleeperWithEnv's helper is a CHILD of the test binary, so on darwin its
+// ancestry walk climbs `go test` → the shell → the terminal and resolves a host
+// (measured while #1582 was written: TermProgram=vscode) — which is precisely
+// the descendant shape dropInheritedTmuxPane refuses to record an address for.
+// On linux the ancestry helpers are stubs, nothing claims a host, and the
+// address survives. Pinning either single outcome would pin the RIG rather than
+// the rule, and would fail on one platform for a reason unrelated to the code.
+//
+// The fixture that IS faithful is spawnPaneSleeperWithEnv, which reparents the
+// helper to init exactly as tmux's server is; the cases in
+// tmuxclient_darwin_test.go use it and do assert the address outright.
+func assertPaneAddressFollowsProvenance(t *testing.T, l *session.Launcher, pane, socket string) {
+	t.Helper()
+	if l.TermProgram == "" && l.HostBundleID == "" {
+		if l.TmuxPane != pane || l.TmuxSocket != socket {
+			t.Errorf("nothing claimed a host, so this is a pane and keeps its address: %+v", l)
+		}
+		return
 	}
-	if l.TmuxPane != "%17" {
-		t.Errorf("TmuxPane: got %q", l.TmuxPane)
+	if l.TmuxPane != "" || l.TmuxSocket != "" {
+		t.Errorf("a host was claimed (%q/%q), so the pane address is inherited and must not be recorded (#1582): %+v",
+			l.TermProgram, l.HostBundleID, l)
 	}
 }
 
@@ -529,6 +557,83 @@ func TestLauncherFromEnv_TmuxSuppressionSparesADescendantsOwnHost(t *testing.T) 
 	if l.VSCodePID != 4242 {
 		t.Errorf("VSCodePID: want 4242, got %d", l.VSCodePID)
 	}
+	// #1582: keeping that identity is only half the answer. The pane address
+	// beside it belongs to the pane VS Code was launched FROM, and
+	// dropInheritedTmuxPane is what stops it being stored — see the table
+	// below, and TestReadLauncherEnv_Tmux_InheritedPaneKeepsItsOwnHost for the
+	// same case through the real read path.
+}
+
+// TestDropInheritedTmuxPane is #1582's rule at the one place it is decided: a
+// $TMUX_PANE is recorded only when it is the reading process's own, which is
+// exactly when nothing else has claimed a host for that process.
+//
+// The end-to-end proof against a live process is
+// TestReadLauncherEnv_Tmux_InheritedPaneKeepsItsOwnHost (darwin, and the case
+// seen red before the fix). This table is the cross-platform half, and it is
+// the only coverage of two rows that fixture cannot express: the descendant
+// whose host came from the ANCESTRY walk rather than from its own env, and the
+// blast radius — the drop may move those two fields and nothing else.
+func TestDropInheritedTmuxPane(t *testing.T) {
+	const (
+		pane   = "%17"
+		socket = "/private/tmp/tmux-501/default"
+	)
+	cases := []struct {
+		name string
+		in   session.Launcher
+		keep bool
+	}{
+		// Nothing claimed a host: launcherFromEnv suppressed the inherited
+		// identity and the ancestry walk terminated at the reparented tmux
+		// server having found nothing. That is a genuine pane, and dropping its
+		// address would cost it click-to-focus and the backchannel.
+		{"genuine pane", session.Launcher{TmuxPane: pane, TmuxSocket: socket}, true},
+		// The shape the issue was filed about: `open -a iTerm` from a pane.
+		{"descendant reporting its own TERM_PROGRAM",
+			session.Launcher{TermProgram: "iTerm.app", ITermSessionID: "w0t0p0-OWN", TmuxPane: pane, TmuxSocket: socket}, false},
+		// `code .` from a pane. VSCODE_PID implies the host, so this is the
+		// same row through launcherFromEnv's inference rather than $TERM_PROGRAM.
+		{"descendant reporting a vscode host",
+			session.Launcher{TermProgram: "vscode", VSCodePID: 4242, TmuxPane: pane, TmuxSocket: socket}, false},
+		// The row an env-only check cannot see, and the reason this runs after
+		// the ancestry walk: kitty sets no $TERM_PROGRAM (upstream kitty#4793),
+		// so a kitty window launched from a pane inherits tmux's own marker and
+		// is indistinguishable from a pane until the walk finds kitty.app.
+		{"descendant whose host came from the ancestry walk",
+			session.Launcher{HostBundleID: "net.kovidgoyal.kitty", TmuxPane: pane, TmuxSocket: socket}, false},
+		// Same descendant once the kitty back-fill has run. Dropping the pane
+		// is what lets control.resolveBackend reach the kitty branch, which is
+		// the backend that actually addresses this session's window.
+		{"descendant with its own kitty backend",
+			session.Launcher{TermProgram: "kitty", KittyListenOn: "unix:/tmp/kitty/sock", KittyWindowID: "42", TmuxPane: pane, TmuxSocket: socket}, false},
+		// Vacuity guards: neither row has an address to decide about, and a
+		// drop that fired on them would be clearing fields it was never given.
+		{"no pane address at all", session.Launcher{TermProgram: "iTerm.app", ITermSessionID: "w0t0p0-OWN"}, true},
+		{"herdr pane", session.Launcher{HerdrPaneID: "w1:p1", HerdrSocketPath: "/tmp/h.sock"}, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := c.in
+			dropInheritedTmuxPane(&got)
+			wantPane, wantSocket := "", ""
+			if c.keep {
+				wantPane, wantSocket = c.in.TmuxPane, c.in.TmuxSocket
+			}
+			if got.TmuxPane != wantPane || got.TmuxSocket != wantSocket {
+				t.Errorf("pane=%q socket=%q, want pane=%q socket=%q", got.TmuxPane, got.TmuxSocket, wantPane, wantSocket)
+			}
+			// The address is the whole of the decision: a drop that also took
+			// the host with it would turn a descendant into a session nothing
+			// can focus, which is the outcome #1499 exists to prevent.
+			gotRest, wantRest := got, c.in
+			gotRest.TmuxPane, gotRest.TmuxSocket = "", ""
+			wantRest.TmuxPane, wantRest.TmuxSocket = "", ""
+			if gotRest != wantRest {
+				t.Errorf("only the pane address may change: got %+v, want %+v", gotRest, wantRest)
+			}
+		})
+	}
 }
 
 // TestReadLauncherEnv_Subprocess_TmuxSuppressesInheritedIdentity is the tmux
@@ -564,9 +669,7 @@ func TestReadLauncherEnv_Subprocess_TmuxSuppressesInheritedIdentity(t *testing.T
 	if l == nil {
 		t.Fatal("expected non-nil launcher")
 	}
-	if l.TmuxPane != "%4" || l.TmuxSocket != "/private/tmp/tmux-501/default" {
-		t.Errorf("the pane's own address must survive the real read path: %+v", l)
-	}
+	assertPaneAddressFollowsProvenance(t, l, "%4", "/private/tmp/tmux-501/default")
 	if l.ITermSessionID != "" || l.TermSessionID != "" {
 		t.Errorf("inherited terminal identity survived the real read path: %+v", l)
 	}

--- a/core/adapters/inbound/agents/processlifecycle/tmuxclient_darwin_test.go
+++ b/core/adapters/inbound/agents/processlifecycle/tmuxclient_darwin_test.go
@@ -474,6 +474,20 @@ func TestReadLauncherEnv_Tmux_UnreachableServerKeepsNothingAndKnowsNothing(t *te
 // Two claims, and the second is the one a naive gate fails: the identity
 // survives, AND tmux is never consulted at all — asserted by pointing tmuxPath
 // at a fake that would resolve a different host if it ran.
+//
+// Since #1582 it carries a third, which is the one that was seen RED: the
+// inherited address is not recorded either. Until then the launcher kept it
+// beside the correct host, control.resolveBackend picked the tmux backend from
+// that field alone, and the backchannel typed into a pane in a window the user
+// was not looking at.
+//
+// That third claim is why the hostKnown assertion below reads the other way
+// round from #1501's. The tri-state answers "was the host of the pane this
+// launcher ADDRESSES determined", and this launcher now addresses no pane at
+// all — so true is not a claim about the foreign pane's client, it is the
+// ordinary answer for an ordinary launcher, and it is what keeps this session
+// out of the liveness sweep's per-tick re-read (services.hostedInAMultiplexerPane).
+// The state it used to protect against is gone with the address.
 func TestReadLauncherEnv_Tmux_InheritedPaneKeepsItsOwnHost(t *testing.T) {
 	otherClientPID := spawnClientSleeperWithEnv(t, []string{
 		"PATH=/usr/bin:/bin",
@@ -500,9 +514,14 @@ func TestReadLauncherEnv_Tmux_InheritedPaneKeepsItsOwnHost(t *testing.T) {
 	if l.TermProgram != "iTerm.app" || l.ITermSessionID != "w0t0p0-OWN" {
 		t.Errorf("a session that reported its own host must keep it: %+v", l)
 	}
-	if hostKnown {
-		t.Error("the pane this launcher ADDRESSES had its host looked up, which it must not have been: " +
-			"hostKnown=false is what stops the sweep adopting a fresh read over this session's own identity")
+	if l.TmuxPane != "" || l.TmuxSocket != "" {
+		t.Errorf("an inherited pane address must not be recorded — control.resolveBackend routes on it "+
+			"and would send-keys into a pane in someone else's window (#1582): pane=%q socket=%q",
+			l.TmuxPane, l.TmuxSocket)
+	}
+	if !hostKnown {
+		t.Error("this launcher addresses no pane, so there is no pane host left unlooked-up to report: " +
+			"answering false would put a plain session back into the sweep's per-tick re-read")
 	}
 }
 

--- a/core/adapters/outbound/control/controller.go
+++ b/core/adapters/outbound/control/controller.go
@@ -208,6 +208,20 @@ var cliBackends = map[backend]cliBackend{
 // the #1348 misroute, arriving by a different route. Reordering these two
 // checks reintroduces it. TestResolveBackend_HerdrWinsOverClientTmux is the
 // lock.
+//
+// The tmux check is `TmuxPane != ""` and cannot usefully be more than that,
+// which is worth stating because the herdr line below is stricter and the
+// asymmetry reads as an oversight. What made it one — a $TMUX_PANE inherited by
+// a GUI terminal or IDE launched from inside a pane, addressed here as if the
+// session were in it (#1582) — is not visible from these fields: a genuine pane
+// that adopted its client's identity and a descendant that reported its own are
+// the same struct, so there is nothing here to require. Requiring the socket as
+// well would not have discriminated either, because $TMUX is inherited beside
+// $TMUX_PANE. That decision is made once, at capture
+// (processlifecycle.dropInheritedTmuxPane), and what reaches here is a pane the
+// session is in. The socket half of the asymmetry is a real and separate gap —
+// a pane id with no socket is addressed against whatever server the daemon's
+// own environment points at — and is #1593.
 func resolveBackend(l *session.Launcher) backend {
 	if l == nil {
 		return backendNone

--- a/core/adapters/outbound/control/controller_test.go
+++ b/core/adapters/outbound/control/controller_test.go
@@ -51,6 +51,14 @@ func TestResolveBackend(t *testing.T) {
 		// different window entirely.
 		{"herdr wins over inherited tmux", &session.Launcher{HerdrPaneID: "w1:p1", HerdrSocketPath: "/tmp/h.sock", TmuxPane: "%0", TmuxSocket: "/tmp/other"}, backendHerdr},
 		{"tmux pane", &session.Launcher{TmuxPane: "%3"}, backendTmux},
+		// A LOCK, green before #1582 and after, and the reason that fix is a
+		// capture-side one: a genuine pane that adopted its client's window
+		// (#1501) is field-for-field the shape an inherited $TMUX_PANE used to
+		// produce, so there is nothing here to discriminate on. This must keep
+		// resolving to tmux — the agent is in the pane; the iTerm identity only
+		// says which window displays it.
+		{"tmux pane whose host was adopted from its client",
+			&session.Launcher{TmuxPane: "%3", TmuxSocket: "/tmp/tmux-501/default", TermProgram: "iTerm.app", ITermSessionID: "w0t0p0:UUID"}, backendTmux},
 		{"tmux wins over kitty", &session.Launcher{TmuxPane: "%3", KittyListenOn: "unix:/x", KittyWindowID: "12"}, backendTmux},
 		{"kitty both fields", &session.Launcher{KittyListenOn: "unix:/x", KittyWindowID: "12"}, backendKitty},
 		{"kitty missing window", &session.Launcher{KittyListenOn: "unix:/x"}, backendNone},

--- a/core/application/services/pid_manager.go
+++ b/core/application/services/pid_manager.go
@@ -952,24 +952,27 @@ type livenessSnapshot struct {
 // client rather than to l's own process — the gate that decides which sessions
 // the periodic refresh pays a read for.
 //
-// It is deliberately CHEAPER and wider than the test the reader itself applies
+// It is deliberately CHEAPER than the test the reader itself applies
 // (processlifecycle.tmuxPaneAwaitsItsClient): this runs under assignMu for
-// every session on every sweep, so it may only look at fields, and the stored
-// launcher cannot distinguish a genuine tmux pane whose host was ADOPTED from
-// one whose $TMUX_PANE was merely inherited by a GUI terminal launched from a
-// pane — both end up with a pane address and a host, and nothing records which
-// process the host came from.
+// every session on every sweep, so it may only look at fields.
 //
-// What that costs is a read per sweep for such a session, and what it does NOT
-// cost is correctness: the reader re-derives the narrow test from the live env
-// every time, so an inherited-$TMUX_PANE session resolves to its OWN identity,
-// which is what it already stored, and the merge reports no change and writes
-// nothing. The wide gate spends work on it; it cannot corrupt it.
+// It used to be WIDER as well, because the stored launcher could not
+// distinguish a genuine tmux pane whose host was ADOPTED from one whose
+// $TMUX_PANE was merely inherited by a GUI terminal launched from a pane — both
+// ended up with a pane address and a host, and nothing recorded which process
+// the host came from. #1582 removed the shape rather than the ambiguity: the
+// capture no longer stores an inherited address at all
+// (processlifecycle.dropInheritedTmuxPane), so a TmuxPane reaching this gate is
+// the pane its process is in.
 //
-// (Removing even that cost means not storing a foreign pane address in the
-// first place — #1582, the pre-existing inherited-$TMUX_PANE bug, filed
-// separately because it is also what makes the backchannel address a foreign
-// pane, and that is the half worth fixing first.)
+// One case survives that, and it is why the cost argument stays here rather
+// than being deleted with the shape: a session whose Launcher was captured by a
+// daemon older than #1582 keeps its inherited address in the persisted state,
+// and this gate pays a read per sweep for it. What that does NOT cost is
+// correctness — the reader re-derives the narrow test from the live env every
+// time, so such a session resolves to its OWN identity, which is what it
+// already stored, and the merge reports no change and writes nothing. The wide
+// gate spends work on it; it cannot corrupt it.
 func hostedInAMultiplexerPane(l *session.Launcher) bool {
 	return l != nil && (l.HerdrPaneID != "" || l.TmuxPane != "")
 }
@@ -1639,15 +1642,15 @@ func (n launcherBackfillNeeds) any() bool {
 // which is the one place the two multiplexers are not symmetric. The herdr
 // branch can replace, because $HERDR_PANE_ID is injected per pane and so always
 // describes THIS pane; $TMUX_PANE is inherited by every descendant, so this
-// branch is also reached by sessions whose host is their own and whose pane
+// branch was also reached by sessions whose host is their own and whose pane
 // address is stale. Suppressing their kitty needs would take a working
 // per-field backfill away from them in exchange for an adoption that
-// ReadLauncherEnv correctly refuses to make (its hostKnown is false for exactly
-// that shape), leaving them with neither.
+// ReadLauncherEnv correctly refuses to make, leaving them with neither.
 //
-// The wide gate is deliberate — hostedInAMultiplexerPane cannot tell an adopted
-// host from an inherited pane address, and that function says why the cost is
-// real and the risk is not.
+// Since #1582 the capture no longer stores such an address, so the only
+// launchers still carrying one were captured by an older daemon — see
+// hostedInAMultiplexerPane. The asymmetry is kept because it is conservative
+// for exactly those, not because it is load-bearing for a fresh capture.
 func launcherBackfillNeedsFor(l *session.Launcher) launcherBackfillNeeds {
 	if l.HerdrPaneID != "" {
 		return launcherBackfillNeeds{tty: l.TTY == "", multiplexerHost: true}

--- a/core/domain/session/session.go
+++ b/core/domain/session/session.go
@@ -102,6 +102,16 @@ func (s *subagentSummary) Equal(o *subagentSummary) bool {
 // enabled so a descendant reporting no host itself is still resolved — see
 // processlifecycle.launcherFromEnv.
 //
+// Such a descendant's pane ADDRESS is dropped rather than stored, which is a
+// separate decision from the suppression above and was made later (#1582): the
+// two fields are what control.resolveBackend routes on, so keeping them sent
+// the user's input into a stranger's pane, in a window they were not looking
+// at, and interrupt and read-back went to the same one. It has to be
+// decided at capture, because these fields cannot carry their own provenance —
+// a genuine pane that adopted its client's identity and a descendant that
+// reported its own are the same struct. So a TmuxPane that reaches this type is
+// the pane its process is IN, and every consumer may treat it as one.
+//
 // Note what tmux itself does to $TERM_PROGRAM, because it is the opposite of
 // what the herdr paragraph above would lead you to expect: tmux overwrites it
 // with the literal "tmux" rather than leaking the launching terminal's value.
@@ -130,7 +140,7 @@ type Launcher struct {
 	TermProgram    string `json:"term_program,omitempty"`     // $TERM_PROGRAM (e.g. iTerm.app, Apple_Terminal, vscode, cursor, ghostty, WezTerm, Hyper)
 	ITermSessionID string `json:"iterm_session_id,omitempty"` // $ITERM_SESSION_ID
 	TermSessionID  string `json:"term_session_id,omitempty"`  // $TERM_SESSION_ID (Terminal.app)
-	TmuxPane       string `json:"tmux_pane,omitempty"`        // $TMUX_PANE — this process's pane when tmux spawned it; inherited, and then a foreign pane's, in any descendant of one (#1486)
+	TmuxPane       string `json:"tmux_pane,omitempty"`        // $TMUX_PANE — the pane this process is IN. Every descendant of a pane inherits the variable (#1486), so an inherited one is dropped at capture instead of stored (#1582)
 	TmuxSocket     string `json:"tmux_socket,omitempty"`      // first `,`-field of $TMUX
 	VSCodePID      int    `json:"vscode_pid,omitempty"`       // $VSCODE_PID (vscode/cursor/windsurf)
 	TTY            string `json:"tty,omitempty"`              // controlling TTY, e.g. "/dev/ttys021" — Terminal.app AppleScript matches tabs by this. The agent process's own, except on a herdr session with a client attached, where it is the client's: that is the tab actually displaying the pane (#1350)


### PR DESCRIPTION
## The bug

`$TMUX_PANE` is inherited by **every descendant of a pane**, including a GUI
terminal or IDE launched from inside one (`code .`, `kitty`, `open -a iTerm`).
Such a process reports a perfectly good host identity of its own, so
`processlifecycle.launcherFromEnv` correctly declined to suppress it — and
copied the inherited pane address alongside. `control.resolveBackend` picks the
tmux backend from `TmuxPane != ""` **alone**, so the backchannel ran

```
tmux -S <inherited socket> send-keys -t %17 -l -- <text>
```

into a pane belonging to a different process in a different window. Interrupt
(`send-keys -t %17 C-c`) and read-back (`capture-pane -t %17 -p`) addressed the
same foreign pane. Same failure #1348 removed for herdr, reached through the one
field #1499 deliberately left populated for a descendant.

Re-confirmed on `origin/main` (`37948e64`) before changing anything: all three
call sites still read as the issue quotes them, and the executing test still
pinned the shape.

**Not verified live** — nobody has driven a real `send-keys` into a foreign pane
and watched text land. Only the last hop is unverified; the launcher shape and
the backend selection are both read off executing code. **Reachability is
unmeasured**, as the issue says.

## Red first

The defect assertion, added to `TestReadLauncherEnv_Tmux_InheritedPaneKeepsItsOwnHost`
(an end-to-end case over a real process carrying `TERM_PROGRAM=iTerm.app` plus an
inherited `TMUX_PANE=%17`), against unmodified `origin/main` production code:

```
$ git log --oneline -1
37948e64 fix(tooling): bound the pre-push run so a slow gate is named, not silently killed from outside (#1590)
$ go test ./core/adapters/inbound/agents/processlifecycle/ -run 'TestReadLauncherEnv_Tmux_InheritedPaneKeepsItsOwnHost' -count=1 -v
=== RUN   TestReadLauncherEnv_Tmux_InheritedPaneKeepsItsOwnHost
    tmuxclient_darwin_test.go:504: an inherited pane address must not be recorded — control.resolveBackend routes on it and would send-keys into a pane in someone else's window (#1582): pane="%17" socket="/tmp/tmux-501/e2e-inherited"
--- FAIL: TestReadLauncherEnv_Tmux_InheritedPaneKeepsItsOwnHost (0.12s)
FAIL	irrlicht/core/adapters/inbound/agents/processlifecycle	0.598s
```

## Where the discrimination went, and why

**At capture, not at routing.** `resolveBackend` is untouched, because a stored
launcher cannot carry the distinction: a genuine pane that adopted its client's
identity (#1501) and a descendant that reported its own end up field-for-field
identical — `{TermProgram: iTerm.app, ITermSessionID, TmuxPane, TmuxSocket}` —
and nothing records which process the host came from. The herdr asymmetry
(`HerdrPaneID != "" && HerdrSocketPath != ""`) does not transfer either:
`$TMUX` is inherited beside `$TMUX_PANE`, so a descendant carries the socket
too, and requiring both would have routed to the foreign pane exactly as before.
A lock case in `TestResolveBackend` pins the shape that must keep resolving to
tmux, so the reasoning is re-run rather than only written down.

**After the ancestry fallbacks, not inside `launcherFromEnv`.** The env alone
cannot answer it. tmux stamps `TERM_PROGRAM=tmux` onto the panes it spawns, and
a kitty window launched from a pane inherits exactly that (kitty sets none of its
own, upstream kitty#4793) — so at env time a genuine pane and a kitty descendant
are the same map, and an env-only check (the issue's own sketch) would have left
that descendant addressing the pane kitty was launched from while its own kitty
backend sat one branch further down `resolveBackend`. The walk is what separates
them: from a genuine pane it terminates at the reparented tmux server having
found nothing; from a descendant it finds the host app. That second shape now
reaches `backendKitty`, which is the backend that actually addresses its window.

`dropInheritedTmuxPane` asks the question through the existing
`tmuxPaneAwaitsItsClient` rather than restating its three terms — the two
questions are the same one, and one definition is what keeps them from drifting.

**Direction of failure: towards dropping.** An address wrongly dropped costs
click-to-focus and the backchannel for one session, which keeps its own host and
stays visible. An address wrongly kept types the user's input into a terminal
they were not looking at. Those are not symmetric, and no amount of rarity makes
the second the better error. The residual is stated in the code: a descendant
whose host cannot be resolved at all (no `$TERM_PROGRAM` of its own, no `.app`
in its ancestry) is indistinguishable from a genuine pane and keeps the address
— the same residual #1499's suppression already accepted.

Known limits, stated rather than implied:

- A session whose `Launcher` was captured by an **older daemon** keeps its
  inherited address in the persisted state; the fix is capture-side, so it takes
  effect for launchers captured from here on. `hostedInAMultiplexerPane`'s doc
  now names that as the one surviving case for its wide gate.
- **tmux < 3.2** does not set `TERM_PROGRAM` at all, so a genuine pane there
  looks like a descendant and loses its address. That is #1499's existing
  premise, not a new decision; this change inherits it.

## What the change does to `TestReadLauncherEnv_Tmux_InheritedPaneKeepsItsOwnHost`

Kept, not deleted, and it keeps its purpose (a descendant keeps its own host and
tmux is never consulted). It gains the assertion above, and its `hostKnown`
expectation **flips from false to true** — with the reason written into the test:
the tri-state answers "was the host of the pane this launcher ADDRESSES
determined", and this launcher now addresses no pane at all, so `true` is the
ordinary answer for an ordinary launcher rather than a claim about a foreign
pane's client. That is also what stops the liveness sweep paying a re-read per
tick for it, which is the cost `hostedInAMultiplexerPane`'s doc predicted this
would remove.

Two cross-platform subprocess cases (`TestReadLauncherEnv_Subprocess_Tmux`,
`..._TmuxSuppressesInheritedIdentity`) now assert the **rule** via
`assertPaneAddressFollowsProvenance` instead of a fixed address. Their fixture is
a child of the test binary, so on darwin its ancestry resolves the terminal
hosting `go test` (measured: `TermProgram=vscode`) — i.e. the rig models a
descendant, not a pane — while on linux the ancestry helpers are stubs and it
models a pane. Pinning either outcome would pin the rig. The faithful fixture is
`spawnPaneSleeperWithEnv` (reparented to init, as tmux's server is), and the
darwin e2e cases that use it still assert the address outright.

## Mutation evidence (for what the change adds)

All three run against the committed tests, restored by copy-aside/copy-back with
a `git status --porcelain` assertion afterwards.

**M1 — the drop never fires** (body replaced with a no-op): 5 cases red across
three files.

```
--- FAIL: TestReadLauncherEnv_Subprocess_Tmux (0.13s)
    osutil_test.go:290: a host was claimed ("vscode"/""), so the pane address is inherited and must not be recorded (#1582): &{TermProgram:vscode ... TmuxPane:%17 TmuxSocket:/private/tmp/tmux-501/default ...}
--- FAIL: TestDropInheritedTmuxPane/descendant_reporting_its_own_TERM_PROGRAM (0.00s)
        osutil_test.go:624: pane="%17" socket="/private/tmp/tmux-501/default", want pane="" socket=""
    --- FAIL: TestDropInheritedTmuxPane/descendant_reporting_a_vscode_host
    --- FAIL: TestDropInheritedTmuxPane/descendant_whose_host_came_from_the_ancestry_walk
    --- FAIL: TestDropInheritedTmuxPane/descendant_with_its_own_kitty_backend
--- FAIL: TestReadLauncherEnv_Subprocess_TmuxSuppressesInheritedIdentity (0.12s)
--- FAIL: TestReadLauncherEnv_Tmux_InheritedPaneKeepsItsOwnHost (0.12s)
    tmuxclient_darwin_test.go:518: an inherited pane address must not be recorded ...
    tmuxclient_darwin_test.go:523: this launcher addresses no pane, so there is no pane host left unlooked-up to report ...
```

**M2 — the provenance guard removed, so every address is dropped**: the
fail-direction guard fires, including the three reparented-fixture e2e cases,
which show the concrete cost (the launcher becomes empty and `ReadLauncherEnv`
returns nil).

```
--- FAIL: TestDropInheritedTmuxPane/genuine_pane (0.00s)
        osutil_test.go:624: pane="" socket="", want pane="%17" socket="/private/tmp/tmux-501/default"
--- FAIL: TestReadLauncherEnv_Tmux_AttachedClientIsTheHost (0.10s)
    tmuxclient_darwin_test.go:388: expected non-nil launcher
--- FAIL: TestReadLauncherEnv_Tmux_DetachedResolvesNoHost (0.04s)
    tmuxclient_darwin_test.go:424: expected non-nil launcher (the pane address is still identity)
--- FAIL: TestReadLauncherEnv_Tmux_UnreachableServerKeepsNothingAndKnowsNothing (0.04s)
    tmuxclient_darwin_test.go:458: expected non-nil launcher
```

**M3 — the drop takes the process's own host with it** (`TermProgram` cleared
too): the blast-radius assertion fires, which is the half that keeps this from
becoming the #1499 regression.

```
--- FAIL: TestDropInheritedTmuxPane/descendant_reporting_its_own_TERM_PROGRAM (0.00s)
        osutil_test.go:633: only the pane address may change: got {TermProgram: ITermSessionID:w0t0p0-OWN ...}, want {TermProgram:iTerm.app ITermSessionID:w0t0p0-OWN ...}
    --- FAIL: TestDropInheritedTmuxPane/descendant_reporting_a_vscode_host
    --- FAIL: TestDropInheritedTmuxPane/descendant_with_its_own_kitty_backend
--- FAIL: TestReadLauncherEnv_Tmux_InheritedPaneKeepsItsOwnHost (0.12s)
    tmuxclient_darwin_test.go:515: a session that reported its own host must keep it: &{TermProgram: ITermSessionID:w0t0p0-OWN ...}
```

The `TestResolveBackend` row added here is a **lock** — green before and after —
and is labelled as one in the table.

## Verification

- `go build ./core/...` and `GOOS=linux go build ./core/...`
- `go test ./core/adapters/inbound/agents/processlifecycle/... ./core/adapters/outbound/control/... ./core/domain/session/... -race -count=1` — pass
- `go test ./core/... -race -count=1` — pass
- `tools/preflight.sh --only go` — all 7 gates PASS
- `tools/preflight.sh --only arch` — PASS (composite 7.9293 → 7.9288, not a regression)
- pre-push hook: every applicable gate PASS, none `TIMEOUT`

No tmux server was driven; the tests fake the `tmux` CLI and use self-exec'd
helper processes.

## Found, not folded in

`resolveBackend` routes a `TmuxPane` with an **empty `TmuxSocket`** to
`tmux send-keys` without `-S`, i.e. against whatever server the daemon's own
environment points at — the exact failure the herdr and kitty branches both
refuse. Different discriminator, different blast radius, so it is filed as
issue #1593 rather than folded in here, and `resolveBackend`'s doc names it.

Closes #1582
