### PR TITLE
fix(daemon): require a tmux socket before addressing a pane from the backchannel

### DIFF
--- a/core/adapters/inbound/agents/processlifecycle/osutil.go
+++ b/core/adapters/inbound/agents/processlifecycle/osutil.go
@@ -346,14 +346,17 @@ func tmuxPaneAwaitsItsClient(l *session.Launcher) bool {
 // pane address belonging to a different process in a different window. #1499
 // already keeps such a session's own host identity — its suppression keys on
 // tmux's own TERM_PROGRAM marker — and copied the pane address alongside it.
-// control.resolveBackend picks the tmux backend from that field alone, so the
+// control.resolveBackend routed to the tmux backend on that address, so the
 // backchannel ran `tmux -S <inherited socket> send-keys -t %17 -l -- <text>`
 // into a stranger's pane, and interrupt and capture addressed the same one
 // (#1582). That is the failure #1348 removed for herdr, reached through the
-// one field #1499 deliberately left populated for a descendant.
+// one field #1499 deliberately left populated for a descendant. (resolveBackend
+// has since grown a socket requirement of its own, #1593 — an independent rule
+// that would not have caught this one, because $TMUX is inherited beside
+// $TMUX_PANE and a descendant carries both.)
 //
 // The CAPTURE is the only place this can be decided, which is why the fix is
-// here and resolveBackend is untouched. A stored launcher cannot tell the two
+// here and resolveBackend was untouched by it. A stored launcher cannot tell the two
 // apart: a genuine pane that adopted its client's identity (#1501) and a
 // descendant that reported its own end up with the same fields —
 // {TermProgram: iTerm.app, ITermSessionID, TmuxPane, TmuxSocket} — and nothing

--- a/core/adapters/inbound/agents/processlifecycle/osutil_test.go
+++ b/core/adapters/inbound/agents/processlifecycle/osutil_test.go
@@ -491,10 +491,10 @@ func TestLauncherFromEnv_TmuxSuppressesInheritedIdentity(t *testing.T) {
 
 // TestLauncherFromEnv_TmuxCapture covers the other half: the pane's own
 // address, which is the only thing in that env that actually describes it and
-// which the backchannel routes on (resolveBackend picks backendTmux from
-// TmuxPane alone, before it ever looks at TermProgram). Keeping these two is
-// what makes the suppression above a click-to-focus change and not a control
-// regression.
+// which the backchannel routes on (resolveBackend reaches backendTmux from
+// these two fields, before it ever looks at TermProgram — and since #1593 it
+// needs BOTH of them). Keeping them is what makes the suppression above a
+// click-to-focus change and not a control regression.
 func TestLauncherFromEnv_TmuxCapture(t *testing.T) {
 	l := launcherFromEnv(tmuxPaneEnv)
 	if l.TmuxPane != "%4" {
@@ -505,6 +505,43 @@ func TestLauncherFromEnv_TmuxCapture(t *testing.T) {
 	}
 	if l.IsEmpty() {
 		t.Error("a tmux-only launcher must not be reported empty")
+	}
+}
+
+// TestLauncherFromEnv_TmuxPaneSurvivesAClearedTmux is the reachability half of
+// #1593, and a LOCK: it passes before that fix and after, because the shape it
+// pins is an input to the router rather than a decision the router makes.
+//
+// $TMUX carries the socket and $TMUX_PANE the address, and they are separate
+// variables. `unset TMUX` is the documented way to run tmux inside tmux, and
+// some shell configs do it — which leaves a genuine pane reporting its own
+// address with no server to address it against. #1582's drop does not close
+// this: it clears the two fields TOGETHER, but only for an address the process
+// inherited, and this process's address is its own (nothing else claimed a host
+// for it), so the drop deliberately keeps it.
+//
+// So `{TmuxPane: "%4", TmuxSocket: ""}` reaches control.resolveBackend, which
+// is why TestResolveBackend_TmuxPaneWithoutSocketIsNotAddressable is a defect
+// test rather than a lock over an unreachable state.
+func TestLauncherFromEnv_TmuxPaneSurvivesAClearedTmux(t *testing.T) {
+	env := map[string]string{}
+	for k, v := range tmuxPaneEnv {
+		env[k] = v
+	}
+	delete(env, "TMUX")
+
+	l := launcherFromEnv(env)
+	if l.TmuxPane != "%4" {
+		t.Errorf("TmuxPane: want %%4, got %q", l.TmuxPane)
+	}
+	if l.TmuxSocket != "" {
+		t.Errorf("TmuxSocket: want empty with $TMUX cleared, got %q", l.TmuxSocket)
+	}
+	// And #1582's drop leaves it alone, because it is this process's own.
+	dropInheritedTmuxPane(l)
+	if l.TmuxPane != "%4" || l.TmuxSocket != "" {
+		t.Errorf("after dropInheritedTmuxPane: pane=%q socket=%q, want %%4 and empty",
+			l.TmuxPane, l.TmuxSocket)
 	}
 }
 
@@ -589,6 +626,11 @@ func TestDropInheritedTmuxPane(t *testing.T) {
 		// server having found nothing. That is a genuine pane, and dropping its
 		// address would cost it click-to-focus and the backchannel.
 		{"genuine pane", session.Launcher{TmuxPane: pane, TmuxSocket: socket}, true},
+		// The same pane with $TMUX cleared (`unset TMUX`, the documented way to
+		// nest tmux). Still this process's own address, so still kept — which
+		// is what leaves a socket-less pane reaching control.resolveBackend and
+		// makes #1593 a live defect rather than a state #1582 closed off.
+		{"genuine pane whose $TMUX was cleared", session.Launcher{TmuxPane: pane}, true},
 		// The shape the issue was filed about: `open -a iTerm` from a pane.
 		{"descendant reporting its own TERM_PROGRAM",
 			session.Launcher{TermProgram: "iTerm.app", ITermSessionID: "w0t0p0-OWN", TmuxPane: pane, TmuxSocket: socket}, false},

--- a/core/adapters/outbound/control/controller.go
+++ b/core/adapters/outbound/control/controller.go
@@ -209,19 +209,36 @@ var cliBackends = map[backend]cliBackend{
 // checks reintroduces it. TestResolveBackend_HerdrWinsOverClientTmux is the
 // lock.
 //
-// The tmux check is `TmuxPane != ""` and cannot usefully be more than that,
-// which is worth stating because the herdr line below is stricter and the
-// asymmetry reads as an oversight. What made it one — a $TMUX_PANE inherited by
-// a GUI terminal or IDE launched from inside a pane, addressed here as if the
-// session were in it (#1582) — is not visible from these fields: a genuine pane
-// that adopted its client's identity and a descendant that reported its own are
-// the same struct, so there is nothing here to require. Requiring the socket as
-// well would not have discriminated either, because $TMUX is inherited beside
-// $TMUX_PANE. That decision is made once, at capture
-// (processlifecycle.dropInheritedTmuxPane), and what reaches here is a pane the
-// session is in. The socket half of the asymmetry is a real and separate gap —
-// a pane id with no socket is addressed against whatever server the daemon's
-// own environment points at — and is #1593.
+// The tmux check requires both fields, for the reason the herdr comment below
+// gives and by the same argument: a pane id alone is addressed against whatever
+// server the daemon's own environment points at — under launchd, the default
+// socket — and ids like "%17" exist on every server, so `send-keys -t %17` does
+// not degrade to "the default session", it lands in a stranger's pane. That
+// shape is producible rather than theoretical: $TMUX and $TMUX_PANE are
+// separate variables and `unset TMUX` is the documented way to nest tmux, so a
+// pane can report its own address with no server to address it against
+// (processlifecycle.launcherFromEnv;
+// TestLauncherFromEnv_TmuxPaneSurvivesAClearedTmux pins it, #1593).
+//
+// What this check deliberately does NOT ask is whether the pane is the
+// session's own. A $TMUX_PANE inherited by a GUI terminal or IDE launched from
+// inside a pane was addressed here as if the session were in it (#1582), and
+// that is invisible from these fields: a genuine pane that adopted its client's
+// identity (#1501) and a descendant that reported its own are the same struct.
+// Requiring the socket does not discriminate there either, because $TMUX is
+// inherited beside $TMUX_PANE — the two rules are independent, this one asking
+// whether the address is COMPLETE and that one whether it is OURS. Provenance
+// is decided once, at capture (processlifecycle.dropInheritedTmuxPane), and
+// what reaches here is a pane the session is in.
+//
+// A refusal falls THROUGH to the checks below rather than resolving to
+// backendNone directly, exactly as herdr's and kitty's do. In practice every
+// producible socket-less pane ends at backendNone anyway: the #1501 adoption
+// that could give such a launcher a window identity is itself skipped on an
+// empty socket (processlifecycle.tmuxClientPIDs), so no later branch matches.
+// What that session loses is control and read-back — the trade #1582 already
+// made here, a pane we cannot address safely being better reported
+// uncontrollable than typed into blind.
 func resolveBackend(l *session.Launcher) backend {
 	if l == nil {
 		return backendNone
@@ -235,7 +252,7 @@ func resolveBackend(l *session.Launcher) backend {
 	if l.HerdrPaneID != "" && l.HerdrSocketPath != "" {
 		return backendHerdr
 	}
-	if l.TmuxPane != "" {
+	if l.TmuxPane != "" && l.TmuxSocket != "" {
 		return backendTmux
 	}
 	if l.KittyListenOn != "" && l.KittyWindowID != "" {
@@ -275,13 +292,19 @@ func tmuxInterrupt(l *session.Launcher) command {
 	return command{name: "tmux", args: args}
 }
 
-// tmuxBase prepends `-S <socket>` when the session's tmux server socket is
-// known, so we target the right server even with multiple tmux instances.
+// tmuxBase names the server every tmux command is addressed to, so we target
+// the right one even with several tmux instances running.
+//
+// It is unconditional, and that is #1593's other half. resolveBackend refuses a
+// launcher with no socket, so the field is non-empty on every path that reaches
+// here — but a builder able to omit `-S` can silently address whatever server
+// the daemon's own environment points at, and a loaded gun is worth unloading
+// even when no caller currently reaches it. An empty socket that somehow
+// arrived now produces `tmux -S ""`, which tmux refuses ("error connecting to
+// ...") and captureRunnerExec surfaces with that stderr — a diagnosable failure
+// instead of a successful write into a stranger's pane.
 func tmuxBase(l *session.Launcher) []string {
-	if l.TmuxSocket != "" {
-		return []string{"-S", l.TmuxSocket}
-	}
-	return nil
+	return []string{"-S", l.TmuxSocket}
 }
 
 // kittyInput builds the send-text command targeting the session's window over

--- a/core/adapters/outbound/control/controller_test.go
+++ b/core/adapters/outbound/control/controller_test.go
@@ -50,7 +50,14 @@ func TestResolveBackend(t *testing.T) {
 		// the tmux identity would be the herdr server's, pointing at a
 		// different window entirely.
 		{"herdr wins over inherited tmux", &session.Launcher{HerdrPaneID: "w1:p1", HerdrSocketPath: "/tmp/h.sock", TmuxPane: "%0", TmuxSocket: "/tmp/other"}, backendHerdr},
-		{"tmux pane", &session.Launcher{TmuxPane: "%3"}, backendTmux},
+		{"tmux pane", &session.Launcher{TmuxPane: "%3", TmuxSocket: "/tmp/tmux-501/default"}, backendTmux},
+		// Both fields, for the reason the herdr rows above give: a pane id is
+		// per-server and exists on every server, so a missing socket would be
+		// resolved against the daemon's own default rather than the session's
+		// (#1593). TestResolveBackend_TmuxPaneWithoutSocketIsNotAddressable
+		// carries the argument and the fall-through half.
+		{"tmux missing socket", &session.Launcher{TmuxPane: "%3"}, backendNone},
+		{"tmux missing pane", &session.Launcher{TmuxSocket: "/tmp/tmux-501/default"}, backendNone},
 		// A LOCK, green before #1582 and after, and the reason that fix is a
 		// capture-side one: a genuine pane that adopted its client's window
 		// (#1501) is field-for-field the shape an inherited $TMUX_PANE used to
@@ -59,7 +66,8 @@ func TestResolveBackend(t *testing.T) {
 		// says which window displays it.
 		{"tmux pane whose host was adopted from its client",
 			&session.Launcher{TmuxPane: "%3", TmuxSocket: "/tmp/tmux-501/default", TermProgram: "iTerm.app", ITermSessionID: "w0t0p0:UUID"}, backendTmux},
-		{"tmux wins over kitty", &session.Launcher{TmuxPane: "%3", KittyListenOn: "unix:/x", KittyWindowID: "12"}, backendTmux},
+		{"tmux wins over kitty",
+			&session.Launcher{TmuxPane: "%3", TmuxSocket: "/tmp/tmux-501/default", KittyListenOn: "unix:/x", KittyWindowID: "12"}, backendTmux},
 		{"kitty both fields", &session.Launcher{KittyListenOn: "unix:/x", KittyWindowID: "12"}, backendKitty},
 		{"kitty missing window", &session.Launcher{KittyListenOn: "unix:/x"}, backendNone},
 		{"iterm session", &session.Launcher{TermProgram: "iTerm.app", ITermSessionID: "w0t0p0:UUID"}, backendAppleScript},
@@ -105,9 +113,63 @@ func TestResolveBackend_HerdrWinsOverClientTmux(t *testing.T) {
 	}
 }
 
+// TestResolveBackend_TmuxPaneWithoutSocketIsNotAddressable is #1593's defect
+// test. A pane id is per-server and exists on every server, so routing on it
+// alone addresses it against whatever server the daemon's own environment
+// points at — under launchd, the default socket. `send-keys -t %17` then lands
+// in an unrelated pane on a server the session is not in. That is the argument
+// resolveBackend already made for herdr, and the reason kitty requires both of
+// its fields too.
+//
+// The shape is producible after #1582/#1594, which is why this is a defect test
+// and not a lock: that fix clears TmuxPane and TmuxSocket *together*, but only
+// for a pane address the process INHERITED. A pane whose $TMUX was cleared
+// while $TMUX_PANE survived (`unset TMUX`, the documented way to nest tmux) is
+// judged genuine and kept — with no socket.
+// TestLauncherFromEnv_TmuxPaneSurvivesAClearedTmux pins that end.
+//
+// The second half is the blast radius in the other direction: refusing here is
+// a fall-through, exactly as herdr's and kitty's refusals are, not a dead end.
+// A launcher that also carries a usable address further down the chain is still
+// controllable through it.
+func TestResolveBackend_TmuxPaneWithoutSocketIsNotAddressable(t *testing.T) {
+	paneOnly := &session.Launcher{TmuxPane: "%17"}
+	if got := resolveBackend(paneOnly); got != backendNone {
+		t.Errorf("pane with no socket: resolveBackend = %v, want backendNone", got)
+	}
+
+	alsoKitty := &session.Launcher{TmuxPane: "%17", KittyListenOn: "unix:/x", KittyWindowID: "12"}
+	if got := resolveBackend(alsoKitty); got != backendKitty {
+		t.Errorf("pane with no socket, kitty available: resolveBackend = %v, want backendKitty", got)
+	}
+}
+
+// TestTmuxCommandsAlwaysNameTheServer covers the other half of #1593: with the
+// routing guard above in place, tmuxBase's `-S`-less form is unreachable from
+// production, and a builder that can silently address the default server is a
+// loaded gun whether or not a caller reaches it today. Every tmux argv names a
+// server, so a socket that somehow arrived empty produces a command tmux itself
+// refuses ("error connecting to ...") — surfaced through captureRunnerExec's
+// stderr — rather than one that succeeds against a stranger.
+func TestTmuxCommandsAlwaysNameTheServer(t *testing.T) {
+	noSock := &session.Launcher{TmuxPane: "%17"}
+	cases := []struct {
+		name string
+		got  command
+	}{
+		{"input", tmuxInput(noSock, []byte("hi"))},
+		{"interrupt", tmuxInterrupt(noSock)},
+		{"capture", tmuxCapture(noSock)},
+	}
+	for _, c := range cases {
+		if len(c.got.args) < 2 || c.got.args[0] != "-S" {
+			t.Errorf("tmux %s: argv %q does not name a server", c.name, c.got.args)
+		}
+	}
+}
+
 func TestCommandBuilders(t *testing.T) {
 	tmuxL := &session.Launcher{TmuxPane: "%3", TmuxSocket: "/tmp/tmux-501/default"}
-	tmuxNoSock := &session.Launcher{TmuxPane: "%7"}
 	kittyL := &session.Launcher{KittyListenOn: "unix:/tmp/mykitty", KittyWindowID: "12"}
 	herdrL := &session.Launcher{HerdrPaneID: "w1:p1", HerdrSocketPath: "/tmp/herdr/h.sock"}
 	// wantHerdr keeps the repeated {name, env} boilerplate out of the table.
@@ -124,11 +186,6 @@ func TestCommandBuilders(t *testing.T) {
 			"tmux input with socket",
 			tmuxInput(tmuxL, []byte("hello\r")),
 			command{name: "tmux", args: []string{"-S", "/tmp/tmux-501/default", "send-keys", "-t", "%3", "-l", "--", "hello\r"}},
-		},
-		{
-			"tmux input no socket",
-			tmuxInput(tmuxNoSock, []byte("hi")),
-			command{name: "tmux", args: []string{"send-keys", "-t", "%7", "-l", "--", "hi"}},
 		},
 		{
 			"tmux interrupt",
@@ -187,7 +244,7 @@ func TestCommandBuilders(t *testing.T) {
 func TestControllerDelegatesToBackend(t *testing.T) {
 	repo := &fakeRepo{state: &session.SessionState{
 		SessionID: "abc",
-		Launcher:  &session.Launcher{TmuxPane: "%3"},
+		Launcher:  &session.Launcher{TmuxPane: "%3", TmuxSocket: "/tmp/tmux-501/default"},
 	}}
 	c := NewController(repo, &fakePush{}, nopLog{})
 	var ran command
@@ -290,7 +347,7 @@ func TestControllerSendCommandSubmits(t *testing.T) {
 
 func verifySendCommandTmuxAppendsCR(t *testing.T) {
 	repo := &fakeRepo{state: &session.SessionState{
-		SessionID: "abc", Launcher: &session.Launcher{TmuxPane: "%3"},
+		SessionID: "abc", Launcher: &session.Launcher{TmuxPane: "%3", TmuxSocket: "/tmp/tmux-501/default"},
 	}}
 	c := NewController(repo, &fakePush{}, nopLog{})
 	var ran command

--- a/core/adapters/outbound/control/reader_test.go
+++ b/core/adapters/outbound/control/reader_test.go
@@ -12,7 +12,6 @@ import (
 
 func TestCaptureCommandBuilders(t *testing.T) {
 	tmuxL := &session.Launcher{TmuxPane: "%3", TmuxSocket: "/tmp/tmux-501/default"}
-	tmuxNoSock := &session.Launcher{TmuxPane: "%7"}
 	kittyL := &session.Launcher{KittyListenOn: "unix:/tmp/mykitty", KittyWindowID: "12"}
 
 	cases := []struct {
@@ -24,11 +23,6 @@ func TestCaptureCommandBuilders(t *testing.T) {
 			"tmux capture with socket",
 			tmuxCapture(tmuxL),
 			command{name: "tmux", args: []string{"-S", "/tmp/tmux-501/default", "capture-pane", "-t", "%3", "-p"}},
-		},
-		{
-			"tmux capture without socket",
-			tmuxCapture(tmuxNoSock),
-			command{name: "tmux", args: []string{"capture-pane", "-t", "%7", "-p"}},
 		},
 		{
 			"kitty capture",
@@ -60,7 +54,7 @@ func TestCaptureScreenDispatch(t *testing.T) {
 		wantErrIs error
 	}{
 		{"herdr", &session.Launcher{HerdrPaneID: "w1:p1", HerdrSocketPath: "/tmp/h.sock"}, "herdr", nil},
-		{"tmux", &session.Launcher{TmuxPane: "%1"}, "tmux", nil},
+		{"tmux", &session.Launcher{TmuxPane: "%1", TmuxSocket: "/tmp/tmux-501/default"}, "tmux", nil},
 		{"kitty", &session.Launcher{KittyListenOn: "unix:/x", KittyWindowID: "9"}, "kitten", nil},
 		{"applescript not readable", &session.Launcher{TermProgram: "iTerm.app", ITermSessionID: "w0t0p0:U"}, "", outbound.ErrNotReadable},
 		{"no backend not readable", &session.Launcher{TermProgram: "vscode"}, "", outbound.ErrNotReadable},


### PR DESCRIPTION
Closes #1593.

`control.resolveBackend` routed to the tmux backend on `TmuxPane != ""` alone,
and `tmuxBase` omitted `-S` when `TmuxSocket` was empty. A pane id is
per-server and exists on every server, so such a launcher was addressed against
whatever server the daemon's own environment points at — under launchd, the
default socket — and `send-keys -t %17` landed in an unrelated pane on a server
the session is not in. herdr and kitty already required both of their fields,
and `resolveBackend`'s own doc already stated the argument for herdr. tmux was
the one that did not.

## Still reachable after PR #1594

Yes — re-confirmed against `origin/main` at `b15fa84f` (source read, plus a
committed lock).

`processlifecycle.launcherFromEnv` fills `TmuxSocket` from `$TMUX` and
`TmuxPane` from `$TMUX_PANE`, which are **separate variables**; `unset TMUX` is
the documented way to nest tmux. PR #1594 clears the two fields *together*, but
only for an address the process **inherited** — `dropInheritedTmuxPane` returns
early when `tmuxPaneAwaitsItsClient(l)`, which is true for a genuine pane, so a
pane whose own `$TMUX` was cleared is kept with no socket.
`TestLauncherFromEnv_TmuxPaneSurvivesAClearedTmux` pins both halves and is a
**lock** — green on `origin/main` before this change.

Limits of the evidence, unchanged from the issue: **verified from source and
unit tests only.** Nobody has driven a live `send-keys` with an empty
`TmuxSocket` and watched where it landed, and the reachability remains narrow
and unmeasured — it needs a pane whose `$TMUX` was cleared while `$TMUX_PANE`
survived *and* a server on a non-default socket.

## The red

A real defect red, not a lock. Both new assertions were run on the unmodified
`origin/main` tree before the fix existed:

```
=== RUN   TestResolveBackend_TmuxPaneWithoutSocketIsNotAddressable
    controller_test.go:130: pane with no socket: resolveBackend = 2, want backendNone
    controller_test.go:135: pane with no socket, kitty available: resolveBackend = 2, want backendKitty
--- FAIL: TestResolveBackend_TmuxPaneWithoutSocketIsNotAddressable (0.00s)
=== RUN   TestTmuxCommandsAlwaysNameTheServer
    controller_test.go:158: tmux input: argv ["send-keys" "-t" "%17" "-l" "--" "hi"] does not name a server
    controller_test.go:158: tmux interrupt: argv ["send-keys" "-t" "%17" "C-c"] does not name a server
    controller_test.go:158: tmux capture: argv ["capture-pane" "-t" "%17" "-p"] does not name a server
--- FAIL: TestTmuxCommandsAlwaysNameTheServer (0.00s)
```

That is the defect in one line: backend 2 is `backendTmux`, and the argv carries
no `-S`.

The end-to-end red — env in, `send-keys` out — is not obtainable in one test:
`launcherFromEnv` is an inbound adapter and `resolveBackend` an outbound one,
with nothing wiring the two in-process. The two ends are pinned separately (the
lock above, and these two).

## What a pane with no socket does now

It **falls through** to the checks below, exactly as herdr's and kitty's
refusals do — matched to the established behaviour rather than a third one. In
practice every producible socket-less pane still ends at `backendNone`: the
#1501 client adoption that could give such a launcher an AppleScript window
identity is itself skipped on an empty socket
(`processlifecycle.tmuxClientPIDs` returns `(nil, false)` for `socketPath ==
""`), so no later branch matches. What that session loses is control and
read-back — the trade #1582 already made here, a pane we cannot address safely
being better reported uncontrollable than typed into blind. The fall-through is
asserted rather than assumed: the second arm posts a launcher carrying kitty
fields and requires `backendKitty`.

## `tmuxBase`'s `-S`-less form is removed

`tmuxBase` now always emits `-S <socket>`. Every production path into
`tmuxInput`/`tmuxInterrupt`/`tmuxCapture` goes through
`cliBackends[resolveBackend(l)]`, so with the routing guard in place the old
branch was unreachable — but a builder able to omit `-S` can silently address
the default server, which is worth unloading even with no caller. **The cost:**
an empty socket that somehow arrived now produces `tmux -S ""`, which tmux
refuses (`error connecting to ...`) and `captureRunnerExec` surfaces with that
stderr. A diagnosable failure replaces a successful write into a stranger's
pane. Two test cases that used the `-S`-less argv as their subject are gone,
replaced by `TestTmuxCommandsAlwaysNameTheServer`.

## Mutation evidence

The fix's own red is above. The two **locks this change adds** owe a deliberate
mutation, and both were seen red (applied to `osutil.go`, reverted by
copy-aside/copy-back with a `git status --porcelain` assertion — never `git
stash`, which is shared across worktrees here):

**M1** — `dropInheritedTmuxPane` also drops a pane whose socket is empty:

```
--- FAIL: TestLauncherFromEnv_TmuxPaneSurvivesAClearedTmux (0.00s)
    osutil_test.go:543: after dropInheritedTmuxPane: pane="" socket="", want %4 and empty
--- FAIL: TestDropInheritedTmuxPane (0.00s)
    --- FAIL: TestDropInheritedTmuxPane/genuine_pane_whose_$TMUX_was_cleared (0.00s)
        osutil_test.go:666: pane="" socket="", want pane="%17" socket=""
```

**M2** — `tmuxSocketFromEnv` fabricates a default socket when `$TMUX` is absent:

```
--- FAIL: TestLauncherFromEnv_TmuxPaneSurvivesAClearedTmux (0.00s)
    osutil_test.go:538: TmuxSocket: want empty with $TMUX cleared, got "/tmp/tmux-501/default"
    osutil_test.go:543: after dropInheritedTmuxPane: pane="%4" socket="/tmp/tmux-501/default", want %4 and empty
```

Both reverted; `git status --porcelain` matched its pre-mutation baseline and no
`MUTATION` marker survives in the tree.

## Blast radius on existing tests

Five fixtures used a socket-less launcher as shorthand for "a tmux session" and
now carry a socket (`TestResolveBackend`'s `tmux pane` and `tmux wins over
kitty` rows, `TestControllerDelegatesToBackend`,
`verifySendCommandTmuxAppendsCR`, `TestCaptureScreenDispatch`). Two comments
that stated the old routing rule — `dropInheritedTmuxPane`'s doc and
`TestLauncherFromEnv_TmuxCapture`'s — were corrected in place; both now say the
two rules are independent, since requiring the socket would **not** have caught
#1582 (`$TMUX` is inherited beside `$TMUX_PANE`).

## Not fixed

Nothing found and left. One adjacent observation, stated as a non-finding with
its evidence: `tmuxClientPIDs` already refuses an empty socket path
(`osutil_darwin.go:1124`), so the #1501 adoption path never queries the default
server — it is not a second instance of this bug.

## Verification

- `go build ./core/...`, `GOOS=linux go build ./core/...`, `go vet` on both
  touched packages — pass.
- `go test ./core/adapters/outbound/control/...
  ./core/adapters/inbound/agents/processlifecycle/... ./core/domain/session/...
  -race -count=1` — pass.
- `go test ./core/... -race -count=1` — pass.
- `tools/preflight.sh --only go` — all 7 gates PASS.
- `tools/preflight.sh --only arch` — PASS (composite 7.92885 -> 7.92871, no
  regression).

No live tmux server was driven for this change; none was needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
