### PR TITLE
fix(architecture): make the shellout rule see a root context that came from a helper

### DIFF
--- a/core/adapters/inbound/agents/processlifecycle/osutil.go
+++ b/core/adapters/inbound/agents/processlifecycle/osutil.go
@@ -100,10 +100,13 @@ const clientHostBudget = 2 * time.Second
 //     them at shelloutTimeout. #1529 gathered no evidence about that path and
 //     deliberately did not move it.
 //
-// This is NOT the bare context.Background() core/architecture_shellout_test.go
-// forbids: nothing passes it to exec.CommandContext. Every shellout downstream
-// still derives its own shelloutTimeout from it, so each CHILD keeps a
-// ceiling. What is absent is only the ceiling ACROSS children.
+// It does not violate core/architecture_shellout_test.go, and note the reason
+// is what is DONE with it rather than what it is: since #1559 that rule
+// resolves this helper and would report it exactly like a literal
+// context.Background(), so what keeps it legal is that nothing passes it to
+// exec.CommandContext. Every shellout downstream still derives its own
+// shelloutTimeout from it, so each CHILD keeps a ceiling. What is absent is
+// only the ceiling ACROSS children.
 func noAggregateBudget() context.Context { return context.Background() }
 
 // CWDToProjectDir converts a working directory path to the directory name used

--- a/core/adapters/inbound/agents/processlifecycle/shellout_guard_test.go
+++ b/core/adapters/inbound/agents/processlifecycle/shellout_guard_test.go
@@ -691,13 +691,27 @@ func TestEveryBoundedShelloutUsesTheNamedCeiling(t *testing.T) {
 // exec.CommandContext — which until #1529 was a sentence nothing checked.
 //
 // It matters because that helper is a NAMED spelling of context.Background(),
-// and core/architecture_shellout_test.go's repo-wide rule matches the LITERAL
-// spelling only ("a variable that happens to hold one is invisible here", its
-// own declared limit). So `exec.CommandContext(noAggregateBudget(), …)` would
-// be exec.Command wearing two disguises instead of one: unbounded, and passing
-// both the repo rule and a reviewer skimming for a blessed helper name. The
-// helper exists to name an absent AGGREGATE, never an absent child ceiling —
-// every site derives shelloutTimeout from it, and this is what keeps that true.
+// so `exec.CommandContext(noAggregateBudget(), …)` is exec.Command wearing two
+// disguises instead of one: unbounded, and passing a reviewer skimming for a
+// blessed helper name. The helper exists to name an absent AGGREGATE, never an
+// absent child ceiling — every site derives shelloutTimeout from it, and this
+// is what keeps that true.
+//
+// Until #1559 it was also the ONLY thing that did: the repo-wide rule matched
+// the literal spelling only, so this package-local guard was the general
+// question's answer in one package, and the next package to name its own root
+// context would have inherited nothing. That is fixed there rather than here —
+// core/architecture_shellout_test.go now resolves a package-local helper whose
+// body returns a root context, and catches this call site too (measured, by
+// planting exactly that line at osutil_darwin.go:42).
+//
+// This guard is KEPT anyway, and not as ceremony: the two key on different
+// things and fail in OPPOSITE directions. The repo rule reads the helper's
+// BODY, so it follows a rename for free but stops seeing this one the moment
+// the body grows a second statement (`c := context.Background(); return c` — a
+// declared limit there, pinned by a want:0 row). This one reads the NAME, so it
+// survives any body shape but not a rename. Cheap belt-and-braces over a helper
+// whose whole reason to exist is that it is easy to reach for by name.
 func TestNoAggregateBudgetNeverReachesAChildProcess(t *testing.T) {
 	fset, files := parsePackageSources(t, ".")
 
@@ -722,9 +736,10 @@ func TestNoAggregateBudgetNeverReachesAChildProcess(t *testing.T) {
 			}
 			if id, ok := inner.Fun.(*ast.Ident); ok && id.Name == "noAggregateBudget" {
 				t.Errorf("%s:%d: exec.CommandContext given noAggregateBudget() — that is a NAMED "+
-					"context.Background(), so this child has no ceiling at all, and the repo-wide rule "+
-					"in core/architecture_shellout_test.go matches only the literal spelling and cannot "+
-					"see it. Derive shelloutTimeout from the caller's context instead (#1529, #1543)",
+					"context.Background(), so this child has no ceiling at all. The repo-wide rule in "+
+					"core/architecture_shellout_test.go reports it too (#1559); this guard adds the "+
+					"half that keys on the NAME rather than the body. Derive shelloutTimeout from the "+
+					"caller's context instead (#1529, #1543)",
 					filepath.Base(name), fset.Position(call.Pos()).Line)
 			}
 			return true

--- a/core/architecture_shellout_shapes_test.go
+++ b/core/architecture_shellout_shapes_test.go
@@ -1,6 +1,7 @@
 package core_test
 
 import (
+	"go/ast"
 	"go/parser"
 	"go/token"
 	"testing"
@@ -20,12 +21,20 @@ import (
 // silent rows below are false positives a text-based `grep exec.Command` rule
 // produces, which is the rule anyone would reach for first.
 type shelloutShape struct {
-	name        string
-	src         string // a complete file in package shapes
-	needle      string // a substring that MUST still appear in src
-	want        int    // findings the detector must report
-	wantBounded int    // boundable sites it must SEE (0 findings from 0 sites proves nothing)
-	why         string
+	name   string
+	src    string // a complete file in package shapes
+	needle string // a substring that MUST still appear in src
+	// sibling is a SECOND file of the same package, empty for most rows. It
+	// exists because #1559's shape spans two files — processlifecycle declares
+	// noAggregateBudget in osutil.go and every shellout that could be handed it
+	// lives in osutil_darwin.go — so a corpus that could only express one file
+	// per row would have graded the detector on the one arrangement the defect
+	// does not take.
+	sibling       string
+	siblingNeedle string // asserted the same way as needle when sibling is set
+	want          int    // findings the detector must report
+	wantBounded   int    // boundable sites it must SEE (0 findings from 0 sites proves nothing)
+	why           string
 }
 
 func shelloutShapes() []shelloutShape {
@@ -101,6 +110,78 @@ func f() error { return exec.CommandContext(context.TODO(), "git", "fsck").Run()
 `,
 		},
 		{
+			name:   "commandcontext_with_a_package_local_root_helper",
+			needle: `exec.CommandContext(noAggregateBudget()`,
+			want:   1, wantBounded: 0,
+			why: "#1559: the same site as the two rows above with a name in front of it. Naming an absent AGGREGATE is fine; handing that name to a CHILD is the thing this rule forbids, and it read as bounded to both the rule and a reviewer.",
+			src: `package shapes
+
+import (
+	"context"
+	"os/exec"
+)
+
+func noAggregateBudget() context.Context { return context.Background() }
+
+func f() error { return exec.CommandContext(noAggregateBudget(), "git", "fsck").Run() }
+`,
+		},
+		{
+			name:          "a_root_helper_declared_in_ANOTHER_FILE_of_the_same_package",
+			needle:        `exec.CommandContext(noAggregateBudget()`,
+			siblingNeedle: `return context.Background()`,
+			want:          1, wantBounded: 0,
+			why: "The arrangement #1559 actually occurs in, and the one a file-local collection would miss: processlifecycle declares the helper in osutil.go and every shellout that could take it is in osutil_darwin.go.",
+			src: `package shapes
+
+import "os/exec"
+
+func f() error { return exec.CommandContext(noAggregateBudget(), "git", "fsck").Run() }
+`,
+			sibling: `package shapes
+
+import "context"
+
+func noAggregateBudget() context.Context { return context.Background() }
+`,
+		},
+		{
+			name:   "a_helper_that_returns_another_root_helper",
+			needle: `func alias() context.Context { return root() }`,
+			want:   1, wantBounded: 0,
+			why: "One indirection is the same unbounded child with one more hop; the collection is a fixpoint so a single rename-and-wrap does not defeat it.",
+			src: `package shapes
+
+import (
+	"context"
+	"os/exec"
+)
+
+func root() context.Context { return context.Background() }
+
+func alias() context.Context { return root() }
+
+func f() error { return exec.CommandContext(alias(), "git", "fsck").Run() }
+`,
+		},
+		{
+			name:   "a_root_helper_that_takes_an_argument",
+			needle: `func rootFor(pid int) context.Context`,
+			want:   1, wantBounded: 0,
+			why: "Pins a deliberate asymmetry: the LITERAL form must take no arguments (context.Background does not), but a helper is free to take a pid and return the root anyway, and it is no more bounded for that.",
+			src: `package shapes
+
+import (
+	"context"
+	"os/exec"
+)
+
+func rootFor(pid int) context.Context { return context.Background() }
+
+func f(pid int) error { return exec.CommandContext(rootFor(pid), "git", "fsck").Run() }
+`,
+		},
+		{
 			name:   "two_sites_one_bounded_one_not",
 			needle: `exec.CommandContext(ctx`,
 			want:   1, wantBounded: 1,
@@ -153,6 +234,119 @@ import (
 )
 
 func f(ctx context.Context) error { return exec.CommandContext(ctx, "git", "status").Run() }
+`,
+		},
+		{
+			name:   "a_helper_that_returns_its_callers_context",
+			needle: `func fromParent(parent context.Context) context.Context { return parent }`,
+			want:   0, wantBounded: 1,
+			why: "#1559's anti-greedy row, and the sharpest one: identical in SHAPE to the caught helper rows — one statement, one result, an Ident call in argument 0 — differing only in what the body returns. A collection keyed on the shape rather than the body flags it.",
+			src: `package shapes
+
+import (
+	"context"
+	"os/exec"
+)
+
+func fromParent(parent context.Context) context.Context { return parent }
+
+func f(parent context.Context) error {
+	return exec.CommandContext(fromParent(parent), "git", "status").Run()
+}
+`,
+		},
+		{
+			name:   "a_helper_that_derives_from_its_callers_context",
+			needle: `return context.WithValue(parent`,
+			want:   0, wantBounded: 1,
+			why: "The other half of the same guard: a body that IS a context.* call, so a collection keyed on the package identifier rather than on Background/TODO flags it. Also the shape a per-package context decorator really takes.",
+			src: `package shapes
+
+import (
+	"context"
+	"os/exec"
+)
+
+type key struct{}
+
+func tagged(parent context.Context) context.Context { return context.WithValue(parent, key{}, "git") }
+
+func f(parent context.Context) error {
+	return exec.CommandContext(tagged(parent), "git", "status").Run()
+}
+`,
+		},
+		{
+			name:   "a_METHOD_returning_a_root_context_is_NOT_caught",
+			needle: `func (reads) noBudget() context.Context { return context.Background() }`,
+			want:   0, wantBounded: 1,
+			why: "a DECLARED LIMIT (#1559): a receiver makes the call site r.noBudget() a selector, and knowing what r is needs the type information this scan deliberately does not have — the same wall the aliased-import row hits.",
+			src: `package shapes
+
+import (
+	"context"
+	"os/exec"
+)
+
+type reads struct{}
+
+func (reads) noBudget() context.Context { return context.Background() }
+
+func f(r reads) error { return exec.CommandContext(r.noBudget(), "git", "gc").Run() }
+`,
+		},
+		{
+			name:   "a_root_helper_in_ANOTHER_PACKAGE_is_NOT_caught",
+			needle: `other.NoBudget()`,
+			want:   0, wantBounded: 1,
+			why: "a DECLARED LIMIT (#1559): the collection is per package, so a cross-package helper is a selector whose target is unresolvable without types. The scope is where the shape occurs — a root context is named for one package's reasons.",
+			src: `package shapes
+
+import (
+	"os/exec"
+
+	"example.com/other"
+)
+
+func f() error { return exec.CommandContext(other.NoBudget(), "git", "gc").Run() }
+`,
+		},
+		{
+			name:   "a_root_helper_with_more_than_one_statement_is_NOT_caught",
+			needle: `c := context.Background()`,
+			want:   0, wantBounded: 1,
+			why: "a DECLARED LIMIT (#1559): resolving this needs intra-function dataflow, which is the same thing the variable row below needs and the reason both stop here rather than at a different place.",
+			src: `package shapes
+
+import (
+	"context"
+	"os/exec"
+)
+
+func noBudget() context.Context {
+	c := context.Background()
+	return c
+}
+
+func f() error { return exec.CommandContext(noBudget(), "git", "gc").Run() }
+`,
+		},
+		{
+			name:   "a_VARIABLE_holding_a_root_context_is_NOT_caught",
+			needle: `ctx := context.Background()`,
+			want:   0, wantBounded: 1,
+			why: "a DECLARED LIMIT stated on isBareRootContext since #1543 and pinned only by #1559 — the case where a limit was merely true for two issues. It is the cheapest evasion of the whole rule, so it is the one most worth learning from a test rather than an incident.",
+			src: `package shapes
+
+import (
+	"context"
+	"os/exec"
+)
+
+func f() error {
+	ctx := context.Background()
+	return exec.CommandContext(ctx, "git", "gc").Run()
+}
 `,
 		},
 		{
@@ -295,13 +489,40 @@ func TestShelloutBoundScanCatchesEveryKnownShape(t *testing.T) {
 			// hookbody corpus, which also refuses a row declaring NO needle —
 			// the case this file's first draft let through silently.
 			assertPlantedShapePresent(t, sh.name, sh.src, sh.needle)
+			if sh.sibling != "" {
+				// A two-file row is two plantings, and the second is the half
+				// that carries the case — a sibling that stopped declaring the
+				// helper would leave the row grading the single-file shape
+				// under a two-file name.
+				assertPlantedShapePresent(t, sh.name+" (sibling)", sh.sibling, sh.siblingNeedle)
+			}
 
 			fset := token.NewFileSet()
-			f, err := parser.ParseFile(fset, sh.name+".go", sh.src, parser.ParseComments)
-			if err != nil {
-				t.Fatalf("parse: %v", err)
+			pkg := map[string]*ast.File{}
+			parse := func(file, src string) {
+				f, err := parser.ParseFile(fset, file, src, parser.ParseComments)
+				if err != nil {
+					t.Fatalf("parse %s: %v", file, err)
+				}
+				pkg[file] = f
 			}
-			findings, bounded := scanShelloutBounds(fset, f, sh.name+".go")
+			parse(sh.name+".go", sh.src)
+			if sh.sibling != "" {
+				parse(sh.name+"_sibling.go", sh.sibling)
+			}
+
+			// The production pipeline in the order the live rule runs it:
+			// collect the PACKAGE's root-context helpers first, then scan each
+			// file against that one set. Doing it per file here would grade a
+			// weaker detector than the one that ships.
+			helpers := rootContextHelpers(pkg)
+			var findings []shelloutBoundFinding
+			bounded := 0
+			for file, f := range pkg {
+				got, b := scanShelloutBounds(fset, f, file, helpers)
+				findings = append(findings, got...)
+				bounded += b
+			}
 
 			if len(findings) != sh.want {
 				t.Errorf("got %d finding(s), want %d — %s\nfindings: %v", len(findings), sh.want, sh.why, findings)

--- a/core/architecture_shellout_test.go
+++ b/core/architecture_shellout_test.go
@@ -7,7 +7,8 @@
 //
 //	A child process started from core/ must be built with
 //	exec.CommandContext, and the context it is given must not be a bare
-//	context.Background()/TODO() written at the call site.
+//	context.Background()/TODO() — written at the call site, or returned by a
+//	package-local helper whose whole body is one of those two (#1559).
 //
 // WHY IT EXISTS. Six issues (#1485, #1492, #1513, #1524, #1533, #1537) fixed
 // one sentence six times — "I could not look" collapsed into "I looked and
@@ -36,10 +37,36 @@
 //     syntactic scan does not have; what stops it in practice is that the
 //     ceiling is then a named constant per package, which is a reviewable
 //     absence rather than an invisible one.
+//
+//     #1559 removed the ONE case where that mitigation was inert rather than
+//     weak. A helper whose body is `return context.Background()` is not a
+//     caller-supplied context that might lack a ceiling — it is provably the
+//     root, and the named constant the limit falls back on is precisely what
+//     does not exist there, so the fallback had nothing to say about it. That
+//     spelling is now CAUGHT (see isBareRootContext), and what is left under
+//     this limit is only its original subject: a context that came from
+//     somewhere and may or may not have been bounded on the way.
+//
+//   - Resolving that named spelling is deliberately the CHEAPEST thing that
+//     reaches the shape which occurs, so four narrower ones stay out of scope
+//     and are pinned as want:0 corpus rows rather than merely stated. A helper
+//     in ANOTHER package (`other.NoBudget()`) and a METHOD (`s.rootCtx()`) are
+//     both selector calls whose target this scan cannot resolve without type
+//     information — the same wall the aliased-import limit hits. A helper whose
+//     body is more than one statement (`c := context.Background(); return c`)
+//     needs intra-function dataflow. And a plain VARIABLE holding a root
+//     context is invisible for the same reason, which was already stated on
+//     isBareRootContext and had no row until #1559 gave it one. Widening to any
+//     of the four is a reviewable diff here plus a row there; what makes the
+//     stopping point defensible is that the first three all require the type
+//     information the last paragraph of this header explains this rule cannot
+//     have.
+//
 //   - It says nothing about CLASSIFICATION — whether a non-answer is
 //     distinguishable from an empty answer at the call site. That is
 //     processlifecycle's guard, and core/pkg/shellout.Answered is the shared
 //     predicate #1543 promoted so a second package could reach it.
+//
 //   - It matches on the SELECTOR's package identifier, so `import xexec
 //     "os/exec"` followed by xexec.Command(…) is invisible to it — measured
 //     against the detector, findings=0. So is a dot-import, and so is
@@ -50,17 +77,20 @@
 //     limit that is pinned is learned from a test. Fixing them needs type
 //     information, which this scan deliberately does not have (see the last
 //     paragraph).
+//
 //   - It matches the CALLEE syntactically, so a child started through a value
 //     rather than a direct call is invisible: a package-level `var run =
 //     exec.Command` used as `run(…).Run()`, or a method value / interface
 //     whose implementation lives in another file. Both are measured
 //     (findings=0) and pinned as want:0 corpus rows. Seeing them needs type
 //     information, which this scan deliberately does not have.
+//
 //   - It reads NON-TEST files only, and does not skip vendor/ (the repo has
 //     none). Test code starting an unbounded child is out of scope on purpose:
 //     the hazard this rule exists for is a long-lived daemon waiting forever,
 //     and every fixture in core/adapters/outbound/git's own suite deliberately
 //     builds stalling children.
+//
 //   - It is scoped to core/. tools/ is a separate module of developer tooling
 //     that is not a long-lived daemon.
 //
@@ -106,7 +136,13 @@ func (f shelloutBoundFinding) String() string {
 // a scan that looked at nothing — the same floor #1538's guard carries, and the
 // reason it is a count rather than a bool is that most of the tree could stop
 // being scanned while one survivor kept a `> 0` check green.
-func scanShelloutBounds(fset *token.FileSet, file *ast.File, name string) (findings []shelloutBoundFinding, bounded int) {
+//
+// helpers is the package's root-context helper set (rootContextHelpers). It is
+// a parameter rather than something derived per file because the shape #1559
+// found occurs ACROSS files: processlifecycle declares noAggregateBudget in
+// osutil.go and every one of its shellouts lives in osutil_darwin.go, so a
+// file-local collection would have resolved nothing and passed.
+func scanShelloutBounds(fset *token.FileSet, file *ast.File, name string, helpers map[string]bool) (findings []shelloutBoundFinding, bounded int) {
 	ast.Inspect(file, func(n ast.Node) bool {
 		// A composite literal is the one spelling that cannot be fixed by
 		// passing a context, because exec.Cmd has no exported context field —
@@ -147,9 +183,10 @@ func scanShelloutBounds(fset *token.FileSet, file *ast.File, name string) (findi
 					"core/adapters/outbound/git's TestOrphanHoldingStdoutIsANonAnswer). " +
 					"Use exec.CommandContext under a named per-package timeout (#1543)"})
 		case "CommandContext":
-			if len(call.Args) > 0 && isBareRootContext(call.Args[0]) {
+			if len(call.Args) > 0 && isBareRootContext(call.Args[0], helpers) {
 				findings = append(findings, shelloutBoundFinding{name, line,
-					"exec.CommandContext given a bare context.Background()/TODO() is exec.Command " +
+					"exec.CommandContext given a bare context.Background()/TODO() — literally, or " +
+						"through a package-local helper that returns one (#1559) — is exec.Command " +
 						"wearing a context: nothing can ever cancel it. Derive a bounded context " +
 						"first (#1543)"})
 				return true
@@ -161,28 +198,95 @@ func scanShelloutBounds(fset *token.FileSet, file *ast.File, name string) (findi
 	return findings, bounded
 }
 
-// isBareRootContext reports whether e is literally context.Background() or
-// context.TODO() written at the call site.
+// isBareRootContext reports whether e is context.Background() or context.TODO()
+// — written at the call site, or reached through a package-local helper in
+// helpers whose whole body returns one of them.
 //
-// Only the LITERAL spelling: a variable that happens to hold one is invisible
-// here, and that is the declared limit rather than an oversight — the point is
-// that `exec.CommandContext(context.Background(), …)` reads as bounded to a
-// reviewer skimming for "CommandContext" while being exactly as unbounded as
-// exec.Command.
-func isBareRootContext(e ast.Expr) bool {
+// The literal half is why the rule exists: `exec.CommandContext(
+// context.Background(), …)` reads as bounded to a reviewer skimming for
+// "CommandContext" while being exactly as unbounded as exec.Command.
+//
+// The named half is #1559, and the naming is what made it invisible rather than
+// what made it safe. `exec.CommandContext(noAggregateBudget(), …)` is that same
+// site wearing a second disguise: it passes a reviewer skimming for a blessed
+// helper name too, and until #1559 it passed this rule, because a call to an
+// Ident is not the *ast.SelectorExpr the literal half matches. Naming an absent
+// AGGREGATE is a good practice this rule has no quarrel with (see that helper's
+// doc); handing that name to a CHILD is the thing it forbids, and the two are
+// one keystroke apart.
+//
+// A variable holding a root context is still invisible, and so is a helper
+// spelled as a method or living in another package — declared limits, pinned as
+// want:0 corpus rows so they are learned from a test rather than an incident
+// (#1450). The header says what each would cost to close.
+func isBareRootContext(e ast.Expr, helpers map[string]bool) bool {
 	call, ok := e.(*ast.CallExpr)
-	if !ok || len(call.Args) != 0 {
-		return false
-	}
-	sel, ok := call.Fun.(*ast.SelectorExpr)
 	if !ok {
 		return false
 	}
-	pkg, ok := sel.X.(*ast.Ident)
-	if !ok || pkg.Name != "context" {
-		return false
+	if sel, ok := call.Fun.(*ast.SelectorExpr); ok {
+		pkg, ok := sel.X.(*ast.Ident)
+		if !ok || pkg.Name != "context" || len(call.Args) != 0 {
+			return false
+		}
+		return sel.Sel.Name == "Background" || sel.Sel.Name == "TODO"
 	}
-	return sel.Sel.Name == "Background" || sel.Sel.Name == "TODO"
+	// Arguments are deliberately not constrained here, unlike the literal form
+	// above: context.Background takes none, but a helper is free to take a pid
+	// or a name and return the root anyway, and that spelling is no more
+	// bounded for having an argument.
+	id, ok := call.Fun.(*ast.Ident)
+	return ok && helpers[id.Name]
+}
+
+// rootContextHelpers collects, from one PACKAGE's files, the names of functions
+// whose whole body is `return <a bare root context>` — the named spelling of
+// context.Background() that #1559 found the rule blind to.
+//
+// It is a fixpoint rather than a single pass so that one indirection does not
+// defeat it: `func a() context.Context { return b() }` over a root-returning b
+// is the same unbounded child with one more hop, and closing it costs the loop
+// below rather than a second mechanism. Everything it takes is syntactic, so
+// the header's argument for parsing source rather than loading types still
+// holds — a helper declared behind //go:build darwin is collected on a linux
+// runner exactly like every other declaration this file reads.
+//
+// What it deliberately does not collect: methods (a receiver makes the call a
+// selector this scan cannot resolve), and any body of more than one statement.
+// Both are pinned as want:0 rows.
+func rootContextHelpers(files map[string]*ast.File) map[string]bool {
+	returned := map[string]ast.Expr{}
+	for _, file := range files {
+		for _, decl := range file.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Recv != nil || fn.Body == nil || len(fn.Body.List) != 1 {
+				continue
+			}
+			if fn.Type.Results == nil || len(fn.Type.Results.List) != 1 {
+				continue
+			}
+			ret, ok := fn.Body.List[0].(*ast.ReturnStmt)
+			if !ok || len(ret.Results) != 1 {
+				continue
+			}
+			returned[fn.Name.Name] = ret.Results[0]
+		}
+	}
+
+	helpers := map[string]bool{}
+	for changed := true; changed; {
+		changed = false
+		for name, result := range returned {
+			if helpers[name] {
+				continue
+			}
+			if isBareRootContext(result, helpers) {
+				helpers[name] = true
+				changed = true
+			}
+		}
+	}
+	return helpers
 }
 
 // parseCoreSources parses every non-test .go file under core/, ignoring build
@@ -226,12 +330,31 @@ func parseCoreSources(t *testing.T) (*token.FileSet, map[string]*ast.File) {
 func TestEveryChildProcessInCoreCanBeBounded(t *testing.T) {
 	fset, files := parseCoreSources(t)
 
+	// Grouped by directory, because the root-context helper set is a PACKAGE
+	// fact and the shape #1559 found spans two files of one (noAggregateBudget
+	// is declared in processlifecycle/osutil.go; every shellout that could take
+	// it lives in osutil_darwin.go). Directory rather than the package clause:
+	// build-tagged files of the same package are read here regardless of tag,
+	// which is the point of parsing rather than loading, and the directory is
+	// what holds them together without evaluating one.
+	byPackage := map[string]map[string]*ast.File{}
+	for name, f := range files {
+		dir := filepath.Dir(name)
+		if byPackage[dir] == nil {
+			byPackage[dir] = map[string]*ast.File{}
+		}
+		byPackage[dir][name] = f
+	}
+
 	var findings []shelloutBoundFinding
 	total := 0
-	for name, f := range files {
-		got, bounded := scanShelloutBounds(fset, f, name)
-		findings = append(findings, got...)
-		total += bounded
+	for _, pkg := range byPackage {
+		helpers := rootContextHelpers(pkg)
+		for name, f := range pkg {
+			got, bounded := scanShelloutBounds(fset, f, name, helpers)
+			findings = append(findings, got...)
+			total += bounded
+		}
 	}
 
 	// Vacuity guard. A rule reporting no violations because it found no
@@ -246,6 +369,17 @@ func TestEveryChildProcessInCoreCanBeBounded(t *testing.T) {
 			"the scan is not looking where it thinks it is, so its silence proves nothing",
 			total, knownBoundedSites)
 	}
+
+	// There is deliberately NO matching floor on the helper set, and the reason
+	// is worth stating because every other mechanism in this family carries
+	// one. A count here would assert that core/ contains at least N named
+	// root-context helpers — i.e. it would require a smell to keep existing,
+	// and would go red the day noAggregateBudget (today's only one) is
+	// legitimately deleted. The floor that a broken collection needs lives in
+	// the corpus instead, where it cannot be moved by the tree changing: the
+	// helper rows in architecture_shellout_shapes_test.go are want:1, so a
+	// rootContextHelpers that quietly collected nothing reddens there rather
+	// than reading as a clean tree here.
 
 	for _, f := range findings {
 		t.Errorf("%s", f)


### PR DESCRIPTION
Closes #1559

## The hole

`core/architecture_shellout_test.go`'s repo-wide rule decided "bare root
context" by requiring an `*ast.SelectorExpr` whose package identifier is
`context` and whose selector is `Background`/`TODO`. A root context returned by
a **helper** is not a `SelectorExpr` at all, so the rule never looked at it:

```go
func noAggregateBudget() context.Context { return context.Background() }
exec.CommandContext(noAggregateBudget(), psPath, ...)   // rule stayed GREEN
```

Reproduced in this branch, not assumed — see "Mutation evidence" below: the
pre-change rule passes on exactly that line planted in a real production file.

This was not covered by the rule's first declared limit ("does not check that
the context carries a DEADLINE"), whose stated mitigation is that "the ceiling
is then a named constant per package, which is a reviewable absence rather than
an invisible one". That mitigation is inert here: `noAggregateBudget()` is
provably a root context, and the named constant it falls back on is exactly
what does not exist.

## Premises re-checked before deciding

- `noAggregateBudget()` still exists, unchanged in shape, at
  `core/adapters/inbound/agents/processlifecycle/osutil.go:107` — a
  single-expression helper. Its two production call sites (`ReadLauncherEnv`'s
  direct launcher read, `hostGateFor`) pass it to package-internal walks, never
  to `exec.CommandContext`.
- #1547's `runProbe` (`processlifecycle/shellout.go:119`) is the only place in
  that package that starts a child; the ten `exec.CommandContext` calls under
  it live inside `shelloutCmd` closures and take the closure's own `ctx`, which
  `runProbe` derives via `context.WithTimeout(ctx, shelloutTimeout)`. So
  processlifecycle has no site the defect currently occurs at — it has ten
  sites one keystroke away from it.
- `TestNoAggregateBudgetNeverReachesAChildProcess`
  (`processlifecycle/shellout_guard_test.go`) still exists and still covers
  exactly one package.
- Across all of non-test `core/`, `noAggregateBudget` is the only
  single-expression root-context helper. `PermissionService.effectContext()`
  (`permission_service.go:978`) is the near miss — a method, multi-statement,
  and not passed to a child.

## Option taken: (1), widened `isBareRootContext`

`isBareRootContext` now accepts, besides the literal spelling, a call to a
package-local helper collected by a new `rootContextHelpers` — a function with
no receiver, one result, and a body of exactly `return <a bare root context>`.

Three things about the shape are load-bearing:

- **Collection is per PACKAGE, not per file.** The shape occurs across files:
  processlifecycle declares the helper in `osutil.go` and every shellout that
  could be handed it is in `osutil_darwin.go`. A file-local collection resolves
  nothing and passes — measured (mutation E below).
- **It is a fixpoint**, so `func a() context.Context { return b() }` over a
  root-returning `b` is caught too. One rename-and-wrap is not an escape.
- **Everything stays syntactic.** No `go/packages` load, so the header's
  argument for parsing source stands: eight of the repo's shellouts are behind
  `//go:build darwin` and a type-aware load on a Linux runner would find zero of
  them and pass.

Options 2 and 3 were rejected for stated reasons:

- **Option 2 (invert: require a parameter or a `With*` result)** is the
  strongest, and it needs an exemption story this rule deliberately does not
  have. Deciding whether an identifier is a parameter or a `With*` result is
  reachable syntactically, but every other provenance — a struct field, a range
  variable, a channel receive, a value returned by any helper at all — arrives
  as "unknown", and the only way to ship that is an exemption list. The header
  says why there is none (`architecture_test.go` and
  `architecture_hookbody_test.go` have none either): a call site that genuinely
  needs an unbounded child amends the rule in a reviewable diff, where a list
  accretes entries nobody re-reads.
- **Option 3 (declare a sixth limit, pin it, leave it)** was the fallback if
  option 1 turned out not to be cheap. It was cheap: ~60 lines of detector plus
  a `sibling` field on the corpus row. Option 3's deliverable is folded in
  anyway — the four spellings that remain out of scope after this change are
  each pinned by a `want:0` row rather than merely stated.

## What happens to the package-local guard

`TestNoAggregateBudgetNeverReachesAChildProcess` is **kept**, and not as
ceremony. The two key on different things and fail in opposite directions:

| | keys on | survives | lost to |
|---|---|---|---|
| repo-wide rule | the helper's **body** | a rename | the body growing a second statement (a declared limit, pinned by a `want:0` row) |
| package guard | the helper's **name** | any body shape | a rename |

Its doc comment and failure message both claimed the repo-wide rule "matches
only the literal spelling and cannot see it", which this PR makes false; both
are rewritten. The same sentence in `noAggregateBudget`'s own doc
(`osutil.go`) is corrected too — what keeps that helper legal is now what is
*done* with it, not what it is.

## Corpus

`core/architecture_shellout_shapes_test.go` keeps every predecessor row and adds
ten. Four `want:1`:

- `commandcontext_with_a_package_local_root_helper` — #1559's shape, same file
- `a_root_helper_declared_in_ANOTHER_FILE_of_the_same_package` — the
  arrangement it actually occurs in
- `a_helper_that_returns_another_root_helper` — one indirection
- `a_root_helper_that_takes_an_argument` — pins the deliberate asymmetry (the
  literal form must take no arguments; a helper need not)

Six `want:0`, which is where the value is. Two are anti-greedy rows built to be
identical in *shape* to the caught ones and to differ only in what the body
returns (`a_helper_that_returns_its_callers_context`,
`a_helper_that_derives_from_its_callers_context`). Four are declared limits
after this change: a **method**, a helper in **another package**, a
**multi-statement** helper, and a plain **variable** holding a root context —
that last one stated on `isBareRootContext` since #1543 and pinned by nothing
until now.

## Mutation evidence

Every mutation was applied to the working tree, run, and reverted by
copy-aside/copy-back with a `git status --porcelain` assertion. No `git stash`,
no `git checkout --`, no `git restore`.

### 1. The new spelling is caught (real tree)

Planted at `processlifecycle/osutil_darwin.go:42`, replacing the closure's `ctx`
with `noAggregateBudget()`. With the widened rule:

```
--- FAIL: TestEveryChildProcessInCoreCanBeBounded (0.12s)
    architecture_shellout_test.go:385: adapters/inbound/agents/processlifecycle/osutil_darwin.go:42: exec.CommandContext given a bare context.Background()/TODO() — literally, or through a package-local helper that returns one (#1559) — is exec.Command wearing a context: nothing can ever cancel it. Derive a bounded context first (#1543)
```

The **same planted line** against the pre-change rule restored from `HEAD` —
this is the blind spot the issue reports, reproduced here rather than taken on
trust:

```
=== PRE-CHANGE rule (HEAD) vs the SAME planted site ===
ok  	irrlicht/core	0.527s
=== package-local guard vs the same planted site ===
--- FAIL: TestNoAggregateBudgetNeverReachesAChildProcess (0.01s)
    shellout_guard_test.go:724: osutil_darwin.go:42: exec.CommandContext given noAggregateBudget() — that is a NAMED context.Background(), ...
```

i.e. before this PR the package-local guard was the **only** thing standing
between that line and `main`.

### 2. The per-package grouping is load-bearing (mutation E)

Same plant still in place, helper collection changed to per-file:

```
=== MUTATION E: helpers collected PER FILE — the plant is still in place ===
ok  	irrlicht/core	0.587s
```

The corpus row that grades this reddens on its own under the same mutation
applied to the harness, and it is the only row that does:

```
--- FAIL: TestShelloutBoundScanCatchesEveryKnownShape/a_root_helper_declared_in_ANOTHER_FILE_of_the_same_package
    got 0 finding(s), want 1
```

### 3. The widened detector does not fire on the `want:0` rows

Three greedy mutations, each reddening exactly the rows built to discriminate
it and nothing else.

**A — any `Ident` call in argument 0 is "bare"** (`return ok && helpers[...]`
→ `return ok`):

```
--- FAIL: .../a_helper_that_returns_its_callers_context             got 1 finding(s), want 0
--- FAIL: .../a_helper_that_derives_from_its_callers_context        got 1 finding(s), want 0
--- FAIL: .../a_root_helper_with_more_than_one_statement_is_NOT_caught  got 1 finding(s), want 0
```

**B — collect EVERY single-return function as a root helper**:

```
--- FAIL: .../a_helper_that_returns_its_callers_context             got 1 finding(s), want 0
--- FAIL: .../a_helper_that_derives_from_its_callers_context        got 1 finding(s), want 0
```

**C — any selector call in argument 0 is "bare"**:

```
--- FAIL: .../a_helper_that_derives_from_its_callers_context        got 1 finding(s), want 0
--- FAIL: .../a_METHOD_returning_a_root_context_is_NOT_caught       got 1 finding(s), want 0
--- FAIL: .../a_root_helper_in_ANOTHER_PACKAGE_is_NOT_caught        got 1 finding(s), want 0
```

**D — any plain identifier in argument 0 is "bare"** (the maximally greedy one,
reaching the pre-existing rows too):

```
--- FAIL: .../two_sites_one_bounded_one_not                         got 2 finding(s), want 1
--- FAIL: .../commandcontext_with_a_derived_context                 got 1 finding(s), want 0
--- FAIL: .../commandcontext_with_a_caller_supplied_context         got 1 finding(s), want 0
--- FAIL: .../a_helper_that_returns_its_callers_context             got 1 finding(s), want 0
--- FAIL: .../a_VARIABLE_holding_a_root_context_is_NOT_caught       got 1 finding(s), want 0
--- FAIL: TestEveryChildProcessInCoreCanBeBounded
```

One measured fact worth recording: mutation **B** leaves
`TestEveryChildProcessInCoreCanBeBounded` green. `core/` today has no
`exec.CommandContext` whose first argument is a call at all — every site passes
a plain `ctx`. So the live rule cannot be the evidence for the collection's
correctness, and the corpus is.

## Limits that remain declared-but-uncovered

Stated so they are not implied to be closed:

- The rule still does not check that a context carries a **deadline**. #1559
  removes only the case where that limit's mitigation was inert rather than
  weak; a caller-supplied `ctx` that nobody bounded is unchanged.
- The four narrower helper spellings above are pinned by `want:0` rows but not
  detected. Three of them need type information.
- **No floor on the helper set.** The live rule counts boundable sites but
  deliberately does not assert "core/ contains at least N root-context
  helpers" — that would require a smell to keep existing and would go red the
  day `noAggregateBudget` is legitimately deleted. The corpus carries that
  floor instead (its helper rows are `want:1`), which is stated in the code
  rather than left to be inferred.
- The pre-existing limits are untouched: aliased import, dot-import,
  `os.StartProcess`, a callee reached through a value, test files, `tools/`.

## Verification

All foreground.

- `go build ./core/...` and `GOOS=linux go build ./core/...` — both OK
- `go test ./core/... -race -count=1` — clean
- `tools/preflight.sh --only go` — all 7 gates PASS
- `tools/preflight.sh --only arch` — PASS (composite 7.928710701531242 →
  7.9287094211919396, no category regressions)
- pre-push hook: PASS on gofmt, ARS, core module tests, replay fixtures,
  security scan; no `TIMEOUT`, no `NOT RUN`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
