### PR TITLE
fix(git): bound a whole git OPERATION, not one call at a time

### DIFF
--- a/core/adapters/outbound/filesystem/concurrency_tracker.go
+++ b/core/adapters/outbound/filesystem/concurrency_tracker.go
@@ -2,6 +2,7 @@ package filesystem
 
 import (
 	"bufio"
+	"context"
 	"encoding/json"
 	"io"
 	"os"
@@ -24,8 +25,26 @@ import (
 // to a bare basename, i.e. pre-#1046 behavior) so every recordings-dir-only
 // test fixture can omit it.
 type concurrencyProjectResolver interface {
-	GetProjectName(dir string) (name string, answered bool)
+	GetProjectName(ctx context.Context, dir string) (name string, answered bool)
 }
+
+// noGitBudget is the context this tracker's one git read runs under: a
+// deliberately absent aggregate deadline, named so the absence is reviewable
+// rather than inferred (#1563, the shape #1529's noAggregateBudget established).
+//
+// It is the services twin's argument in its weakest and therefore easiest form:
+// there is nothing here to aggregate. resolveProject makes exactly ONE git call
+// per distinct CWD, memoised for the daemon's lifetime on success and behind a
+// TTL on a non-answer, so no sequence of calls exists for a budget to span. The
+// per-call ceiling the adapter derives from this (gitTimeout, 5s) is the whole
+// bound and is unchanged.
+//
+// It is spelled here rather than imported from application/services because
+// core/architecture_test.go forbids an adapter from importing that layer — and
+// because a package-local helper is what core/architecture_shellout_test.go can
+// resolve: a shared one in pkg/ would be invisible to that rule, so handing it
+// straight to exec.CommandContext would stop being caught.
+func noGitBudget() context.Context { return context.Background() }
 
 // ConcurrencyTracker reconstructs concurrent-agent counts over time from the
 // lifecycle recordings irrlichd writes under <dataDir>/recordings when started
@@ -157,7 +176,7 @@ func (t *ConcurrencyTracker) resolveProject(cwd string) string {
 			}
 			delete(t.unresolvedUntil, cwd)
 		}
-		resolved, answered := t.git.GetProjectName(cwd)
+		resolved, answered := t.git.GetProjectName(noGitBudget(), cwd)
 		if !answered {
 			// #1543: resolveCache is for the daemon's LIFETIME, on the
 			// reasoning that a historical cwd's repo does not change after the

--- a/core/adapters/outbound/filesystem/concurrency_tracker_test.go
+++ b/core/adapters/outbound/filesystem/concurrency_tracker_test.go
@@ -1,6 +1,7 @@
 package filesystem
 
 import (
+	"context"
 	"encoding/json"
 	"math"
 	"os"
@@ -739,7 +740,7 @@ type countingResolver struct {
 	unread bool
 }
 
-func (r *countingResolver) GetProjectName(dir string) (string, bool) {
+func (r *countingResolver) GetProjectName(_ context.Context, dir string) (string, bool) {
 	r.mu.Lock()
 	if r.calls == nil {
 		r.calls = map[string]int{}

--- a/core/adapters/outbound/git/adapter.go
+++ b/core/adapters/outbound/git/adapter.go
@@ -66,9 +66,16 @@ const gitRevParseCmd = "rev-parse"
 // The consequence worth stating: these reads sit inside the detector loop,
 // where 5s of stall is bad but bounded. That is what the value is chosen
 // against, and it is why the history walks could not simply take it with them.
-// It also bounds ONE CALL, not one operation, and callers stack it —
+//
+// It bounds ONE CALL, not one operation, and callers stack it —
 // adoptGitMetadata makes 2, RefreshOnActivity up to 3, ComputeDoraMetrics
-// 1 + len(in-window tags) + len(revertCandidates) — which is #1563.
+// 1 + len(in-window tags) + len(revertCandidates). That was #1563, and since
+// #1563 the SUM is the caller's to bound: every method here takes a
+// context.Context, so an operation that stacks calls derives one aggregate
+// deadline over the whole sequence and each call runs under whichever of the
+// two is shorter. What is NOT delegated is this ceiling — a caller with no
+// aggregate at all (services.noGitBudget) still gets it per call, which is the
+// property #1543 established and #1563 deliberately did not weaken.
 const gitTimeout = 5 * time.Second
 
 // gitHistoryTimeout is the ceiling for the two shellouts that read every commit
@@ -107,6 +114,13 @@ const gitTimeout = 5 * time.Second
 // Every second here is multiplied by that count, so the value is chosen against
 // the stack rather than against the largest repository imaginable.
 //
+// #1563 supplied the aggregate and did NOT revisit this number, which is worth
+// stating because the relation now runs the other way too: an operation budget
+// smaller than this ceiling would silently narrow it for every caller that
+// stacks, so services.doraGitBudget is derived from it rather than picked
+// beside it (the relation is pinned in core/cmd/irrlichd, the one package that
+// depends on both — see HistoryCeiling below).
+//
 // And it is a TIME bound rather than a work bound, which #1553 asked to have
 // argued rather than assumed. Both work bounds that issue proposed were
 // measured and rejected:
@@ -130,6 +144,20 @@ const gitTimeout = 5 * time.Second
 // outside its window, because nothing reads them — the domain filters both
 // LeadTime and DetectReverts through filterRange.
 const gitHistoryTimeout = 30 * time.Second
+
+// HistoryCeiling is gitHistoryTimeout under an exported name, and it exists for
+// exactly one reader: the test in core/cmd/irrlichd that pins
+// services.DoraGitBudget against it (#1563).
+//
+// A second spelling of one number is a drift risk this repo normally refuses,
+// so note that this one cannot drift — it is a constant DEFINED as the other,
+// not a copy of its value — and that the alternative was worse. The aggregate
+// budget lives in application/services, which core/architecture_test.go forbids
+// from importing an adapter, so services cannot read gitHistoryTimeout at all;
+// without an exported name the relation between the two would be a sentence in
+// a doc comment, which is precisely the "number that documents behaviour but is
+// not produced by it" AGENTS.md records drifting twice in two PRs.
+const HistoryCeiling = gitHistoryTimeout
 
 // costProfile names which of the two ceilings above a shellout runs under. It
 // is a REQUIRED argument of run() rather than a default the call sites can
@@ -312,6 +340,21 @@ func (a *Adapter) binary() string {
 // run executes `git args...` in dir under the ceiling cost names, and reports
 // whether git ANSWERED — as opposed to never having been asked.
 //
+// ctx is the CALLER'S budget, and it is a required argument for the reason
+// costProfile is: an operation that stacks calls has to decide where its
+// aggregate comes from, and a default would let it decide by omission. Two
+// deadlines are in play and the shorter always wins — this adapter's own
+// ceiling, derived here per call so a caller with no aggregate is still bounded
+// (#1543), and whatever the caller brought (#1563). A caller that deliberately
+// has none says so by name rather than by silence; services.noGitBudget is that
+// name, and its doc carries which paths are on it and why.
+//
+// An expired ctx arriving here is a NON-answer, not an empty one, and it costs
+// no new code: os/exec fails before Start, the error is not an *exec.ExitError
+// at all, and shellout.Answered already reports false for it (measured — see
+// that predicate's doc). That is what lets an abandoned sub-call compose with
+// #1543's polarity instead of needing a fourth state.
+//
 // answered is false for exactly three things: the ceiling killed the child,
 // the child never started (git missing, fork failure), or its output exceeded
 // gitMaxOutput. It is TRUE for every non-zero exit git produces on its own,
@@ -339,7 +382,7 @@ func (a *Adapter) binary() string {
 // `fatal:`), and it is the pre-existing behaviour; the distinction #1543 is
 // about is "git could not be RUN" versus "git ran and said no", and that is
 // the line drawn here.
-func (a *Adapter) run(cost costProfile, dir string, args ...string) (out []byte, answered bool) {
+func (a *Adapter) run(ctx context.Context, cost costProfile, dir string, args ...string) (out []byte, answered bool) {
 	if dir == "" {
 		// Nothing was asked, so nothing failed — the reading processTTYVia
 		// gives a non-positive pid. Deciding it here rather than at each
@@ -347,7 +390,7 @@ func (a *Adapter) run(cost costProfile, dir string, args ...string) (out []byte,
 		// of any particular git subcommand.
 		return nil, true
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), a.ceilingFor(cost))
+	ctx, cancel := context.WithTimeout(ctx, a.ceilingFor(cost))
 	defer cancel()
 
 	cmd := a.builder()(ctx, dir, args...)
@@ -400,8 +443,8 @@ func (a *Adapter) run(cost costProfile, dir string, args ...string) (out []byte,
 // branch to report: dir is not a repo, HEAD is detached, or the branch is
 // unborn. Callers must not overwrite a branch they already hold on a
 // non-answer — an empty string there carries no information (#1485/#1543).
-func (a *Adapter) GetBranch(dir string) (string, bool) {
-	out, answered := a.run(fixedCost, dir, gitRevParseCmd, "--abbrev-ref", "HEAD")
+func (a *Adapter) GetBranch(ctx context.Context, dir string) (string, bool) {
+	out, answered := a.run(ctx, fixedCost, dir, gitRevParseCmd, "--abbrev-ref", "HEAD")
 	if !answered {
 		return "", false
 	}
@@ -419,8 +462,8 @@ func (a *Adapter) GetBranch(dir string) (string, bool) {
 // is no HEAD — not a git repo, or an unborn branch with no commits yet (#373).
 // answered=false means git could not be run, which is not evidence about
 // either.
-func (a *Adapter) GetHeadCommit(dir string) (string, bool) {
-	out, answered := a.run(fixedCost, dir, gitRevParseCmd, "HEAD")
+func (a *Adapter) GetHeadCommit(ctx context.Context, dir string) (string, bool) {
+	out, answered := a.run(ctx, fixedCost, dir, gitRevParseCmd, "HEAD")
 	if !answered {
 		return "", false
 	}
@@ -438,8 +481,8 @@ func (a *Adapter) GetHeadCommit(dir string) (string, bool) {
 // all of those as ordinary non-zero exits. answered=false means the scan did
 // not happen, which is NOT "no reverts" — treating it as such is what makes a
 // yield sweep report "nothing flipped" for a repo it never read (#1543).
-func (a *Adapter) RevertedCommits(dir string) ([]string, bool) {
-	out, answered := a.run(historyCost, dir, "log", "--all", "--grep", "^This reverts commit ", "--pretty=format:%b")
+func (a *Adapter) RevertedCommits(ctx context.Context, dir string) ([]string, bool) {
+	out, answered := a.run(ctx, historyCost, dir, "log", "--all", "--grep", "^This reverts commit ", "--pretty=format:%b")
 	if !answered {
 		return nil, false
 	}
@@ -459,8 +502,8 @@ func (a *Adapter) RevertedCommits(dir string) ([]string, bool) {
 // git ran and there are no release tags (or dir is not a repo);
 // answered=false means git could not be run, and reporting that as "no
 // releases found for this project" is the false claim #1543 removes.
-func (a *Adapter) ListReleaseTags(dir string) ([]dora.TagInfo, bool) {
-	out, answered := a.run(fixedCost, dir, "for-each-ref", "--sort=creatordate", "--format=%(refname:short)%09%(creatordate:unix)", "refs/tags")
+func (a *Adapter) ListReleaseTags(ctx context.Context, dir string) ([]dora.TagInfo, bool) {
+	out, answered := a.run(ctx, fixedCost, dir, "for-each-ref", "--sort=creatordate", "--format=%(refname:short)%09%(creatordate:unix)", "refs/tags")
 	if !answered {
 		return nil, false
 	}
@@ -486,7 +529,7 @@ func (a *Adapter) ListReleaseTags(dir string) ([]dora.TagInfo, bool) {
 // answered=false is the case DORA must not average over: a partial failure is
 // worse than a total one, because a median lead time computed over the tags
 // that happened to succeed is a biased number reported as Available:true.
-func (a *Adapter) CommitsInRange(dir, fromRef, toRef string) ([]dora.CommitInfo, bool) {
+func (a *Adapter) CommitsInRange(ctx context.Context, dir, fromRef, toRef string) ([]dora.CommitInfo, bool) {
 	// toRef, unlike dir, is still guarded HERE: an empty one would become an
 	// empty argv entry rather than no call at all. run() handles the dir case.
 	if toRef == "" {
@@ -499,7 +542,7 @@ func (a *Adapter) CommitsInRange(dir, fromRef, toRef string) ([]dora.CommitInfo,
 	// \x01/\x02 are ASCII control bytes used as record/field separators —
 	// they won't collide with real commit message content, so a multi-line
 	// %B body can be parsed without spawning a process per commit.
-	out, answered := a.run(historyCost, dir, "log", "--pretty=format:%x01%H%x02%at%x02%B", rangeSpec)
+	out, answered := a.run(ctx, historyCost, dir, "log", "--pretty=format:%x01%H%x02%at%x02%B", rangeSpec)
 	if !answered {
 		return nil, false
 	}
@@ -531,13 +574,13 @@ func (a *Adapter) CommitsInRange(dir, fromRef, toRef string) ([]dora.CommitInfo,
 // and treating that as "never released" DROPS the revert from the failure
 // list, which makes Change Failure Rate read BETTER than reality — the one
 // path in this adapter where the collapse flatters the number (#1543).
-func (a *Adapter) TagContaining(dir, hash string) (string, bool) {
+func (a *Adapter) TagContaining(ctx context.Context, dir, hash string) (string, bool) {
 	// hash, unlike dir, is still guarded HERE — an empty one would become an
 	// empty argv entry. run() handles the dir case.
 	if hash == "" {
 		return "", true
 	}
-	out, answered := a.run(fixedCost, dir, "tag", "--contains", hash, "--sort=creatordate")
+	out, answered := a.run(ctx, fixedCost, dir, "tag", "--contains", hash, "--sort=creatordate")
 	if !answered {
 		return "", false
 	}
@@ -559,7 +602,7 @@ func (a *Adapter) TagContaining(dir, hash string) (string, bool) {
 // repository; answered=false means git could not be run, and reporting that to
 // a user as "project not found or not a git repository" is a second false
 // claim #1543 removes.
-func (a *Adapter) GetGitRoot(dir string) (string, bool) {
+func (a *Adapter) GetGitRoot(ctx context.Context, dir string) (string, bool) {
 	// This guard must stay, and it is NOT the one run() absorbed:
 	// nearestExistingDir("") walks Dir("") == "." and Stat(".") succeeds, so
 	// without it an empty dir would resolve to the DAEMON'S OWN working
@@ -568,7 +611,7 @@ func (a *Adapter) GetGitRoot(dir string) (string, bool) {
 		return "", true
 	}
 	dir = nearestExistingDir(dir)
-	out, answered := a.run(fixedCost, dir, gitRevParseCmd, "--path-format=absolute", "--git-common-dir")
+	out, answered := a.run(ctx, fixedCost, dir, gitRevParseCmd, "--path-format=absolute", "--git-common-dir")
 	if !answered {
 		return "", false
 	}
@@ -611,8 +654,8 @@ func nearestExistingDir(dir string) string {
 // caches this (filesystem.ConcurrencyTracker) memoises for the daemon's
 // lifetime. A guess cached forever as though it were resolved is the same
 // defect one layer up (#1528's "memoize a non-answer as a non-answer").
-func (a *Adapter) GetProjectName(dir string) (string, bool) {
-	root, answered := a.GetGitRoot(dir)
+func (a *Adapter) GetProjectName(ctx context.Context, dir string) (string, bool) {
+	root, answered := a.GetGitRoot(ctx, dir)
 	if root != "" {
 		return filepath.Base(root), answered
 	}

--- a/core/adapters/outbound/git/adapter_test.go
+++ b/core/adapters/outbound/git/adapter_test.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	"context"
 	"encoding/json"
 	"os"
 	"os/exec"
@@ -8,6 +9,15 @@ import (
 	"strings"
 	"testing"
 )
+
+// noBudget is the context this package's tests drive the adapter with where the
+// caller has no aggregate deadline — the great majority of them, since what
+// they grade is the adapter's OWN per-call ceiling, which run() derives from
+// whatever it is handed (#1563). It is the test-side twin of
+// services.noGitBudget, named for the same reason: an absence spelled out reads
+// differently from one inferred. The budget-aware tests in shellout_test.go
+// supply their own cancellable context instead.
+func noBudget() context.Context { return context.Background() }
 
 func TestNearestExistingDir(t *testing.T) {
 	t.Run("existing dir returns itself", func(t *testing.T) {
@@ -46,7 +56,7 @@ func TestGetGitRoot_DeletedSubdir(t *testing.T) {
 	a := New()
 
 	// Existing dir works as before.
-	got, answered := a.GetGitRoot(dir)
+	got, answered := a.GetGitRoot(noBudget(), dir)
 	if !answered {
 		t.Fatal("existing dir: git did not answer")
 	}
@@ -56,7 +66,7 @@ func TestGetGitRoot_DeletedSubdir(t *testing.T) {
 
 	// Deleted subdir resolves to the same repo root.
 	deleted := filepath.Join(dir, "nonexistent", "child")
-	got, answered = a.GetGitRoot(deleted)
+	got, answered = a.GetGitRoot(noBudget(), deleted)
 	if !answered {
 		t.Fatal("deleted subdir: git did not answer")
 	}
@@ -68,7 +78,7 @@ func TestGetGitRoot_DeletedSubdir(t *testing.T) {
 func TestGetGitRoot_NotARepo(t *testing.T) {
 	dir := t.TempDir()
 	a := New()
-	got, answered := a.GetGitRoot(dir)
+	got, answered := a.GetGitRoot(noBudget(), dir)
 	if !answered {
 		t.Fatal("a non-repo dir is an ANSWER — git ran and reported exit 128 (#1543)")
 	}
@@ -101,7 +111,7 @@ func TestGetProjectName_DeletedWorktree(t *testing.T) {
 
 	a := New()
 	deleted := filepath.Join(repoDir, ".claude", "worktrees", "62")
-	got, answered := a.GetProjectName(deleted)
+	got, answered := a.GetProjectName(noBudget(), deleted)
 	if !answered {
 		t.Fatal("git did not answer")
 	}
@@ -145,12 +155,12 @@ func commitFileForTest(t *testing.T, dir, name, content string) string {
 
 func TestGetHeadCommit(t *testing.T) {
 	a := New()
-	if got, answered := a.GetHeadCommit(t.TempDir()); got != "" || !answered {
+	if got, answered := a.GetHeadCommit(noBudget(), t.TempDir()); got != "" || !answered {
 		t.Errorf("non-repo dir: got (%q, %v), want (\"\", true)", got, answered)
 	}
 	dir := gitInitForTest(t)
 	sha := commitFileForTest(t, dir, "a.txt", "hello")
-	if got, answered := a.GetHeadCommit(dir); got != sha || !answered {
+	if got, answered := a.GetHeadCommit(noBudget(), dir); got != sha || !answered {
 		t.Errorf("got (%q, %v), want (%q, true)", got, answered, sha)
 	}
 }
@@ -161,12 +171,12 @@ func TestRevertedCommits(t *testing.T) {
 	shaA := commitFileForTest(t, dir, "a.txt", "A")
 	commitFileForTest(t, dir, "b.txt", "B")
 
-	if got, answered := a.RevertedCommits(dir); len(got) != 0 || !answered {
+	if got, answered := a.RevertedCommits(noBudget(), dir); len(got) != 0 || !answered {
 		t.Fatalf("no reverts yet: got (%v, %v)", got, answered)
 	}
 
 	runGitForTest(t, dir, "revert", "--no-edit", shaA)
-	got, answered := a.RevertedCommits(dir)
+	got, answered := a.RevertedCommits(noBudget(), dir)
 	if !answered {
 		t.Fatal("git did not answer")
 	}
@@ -180,7 +190,7 @@ func TestRevertedCommits(t *testing.T) {
 		t.Errorf("expected revert of %s in %v", shaA, got)
 	}
 
-	if r, answered := a.RevertedCommits(t.TempDir()); r != nil || !answered {
+	if r, answered := a.RevertedCommits(noBudget(), t.TempDir()); r != nil || !answered {
 		t.Errorf("non-repo dir: want (nil, true), got (%v, %v)", r, answered)
 	}
 }
@@ -232,13 +242,13 @@ func TestGetCWDFromTranscript_WrappedCodex(t *testing.T) {
 func TestListReleaseTags(t *testing.T) {
 	a := New()
 
-	if got, answered := a.ListReleaseTags(t.TempDir()); got != nil || !answered {
+	if got, answered := a.ListReleaseTags(noBudget(), t.TempDir()); got != nil || !answered {
 		t.Errorf("non-repo dir: want (nil, true), got (%v, %v)", got, answered)
 	}
 
 	dir := gitInitForTest(t)
 	commitFileForTest(t, dir, "a.txt", "A")
-	if got, answered := a.ListReleaseTags(dir); got != nil || !answered {
+	if got, answered := a.ListReleaseTags(noBudget(), dir); got != nil || !answered {
 		t.Fatalf("no tags yet: want (nil, true), got (%v, %v)", got, answered)
 	}
 
@@ -247,7 +257,7 @@ func TestListReleaseTags(t *testing.T) {
 	commitFileForTest(t, dir, "b.txt", "B")
 	runGitForTest(t, dir, "tag", "v0.2.0")
 
-	got, answered := a.ListReleaseTags(dir)
+	got, answered := a.ListReleaseTags(noBudget(), dir)
 	if !answered {
 		t.Fatal("git did not answer")
 	}
@@ -265,7 +275,7 @@ func TestListReleaseTags(t *testing.T) {
 func TestCommitsInRange(t *testing.T) {
 	a := New()
 
-	if got, answered := a.CommitsInRange(t.TempDir(), "", "HEAD"); got != nil || !answered {
+	if got, answered := a.CommitsInRange(noBudget(), t.TempDir(), "", "HEAD"); got != nil || !answered {
 		t.Errorf("non-repo dir: want (nil, true), got (%v, %v)", got, answered)
 	}
 
@@ -283,7 +293,7 @@ func TestCommitsInRange(t *testing.T) {
 	shaB := runGitForTest(t, dir, "rev-parse", "HEAD")
 	runGitForTest(t, dir, "tag", "v0.2.0")
 
-	oldest, answered := a.CommitsInRange(dir, "", "v0.1.0")
+	oldest, answered := a.CommitsInRange(noBudget(), dir, "", "v0.1.0")
 	if !answered {
 		t.Fatal("git did not answer for the oldest tag")
 	}
@@ -291,7 +301,7 @@ func TestCommitsInRange(t *testing.T) {
 		t.Fatalf("oldest tag (no predecessor): got %+v, want just %s", oldest, shaA)
 	}
 
-	between, answered := a.CommitsInRange(dir, "v0.1.0", "v0.2.0")
+	between, answered := a.CommitsInRange(noBudget(), dir, "v0.1.0", "v0.2.0")
 	if !answered {
 		t.Fatal("git did not answer for the range")
 	}
@@ -302,7 +312,7 @@ func TestCommitsInRange(t *testing.T) {
 		t.Fatalf("multi-line body not preserved: %q", between[0].Body)
 	}
 
-	if got, answered := a.CommitsInRange(dir, "v0.2.0", "v0.2.0"); got != nil || !answered {
+	if got, answered := a.CommitsInRange(noBudget(), dir, "v0.2.0", "v0.2.0"); got != nil || !answered {
 		t.Fatalf("empty range: want (nil, true), got (%v, %v)", got, answered)
 	}
 }
@@ -310,7 +320,7 @@ func TestCommitsInRange(t *testing.T) {
 func TestTagContaining(t *testing.T) {
 	a := New()
 
-	if got, answered := a.TagContaining(t.TempDir(), "deadbeef"); got != "" || !answered {
+	if got, answered := a.TagContaining(noBudget(), t.TempDir(), "deadbeef"); got != "" || !answered {
 		t.Errorf("non-repo dir: want (\"\", true), got (%q, %v)", got, answered)
 	}
 
@@ -320,12 +330,12 @@ func TestTagContaining(t *testing.T) {
 	commitFileForTest(t, dir, "b.txt", "B")
 	runGitForTest(t, dir, "tag", "v0.2.0")
 
-	if got, answered := a.TagContaining(dir, shaA); got != "v0.1.0" || !answered {
+	if got, answered := a.TagContaining(noBudget(), dir, shaA); got != "v0.1.0" || !answered {
 		t.Errorf("got (%q, %v), want (v0.1.0, true) — earliest tag containing the first commit", got, answered)
 	}
 	// An object name git cannot resolve exits 129 (measured, git 2.50.1) —
 	// still an ANSWER: git ran and told us no release contains it.
-	if got, answered := a.TagContaining(dir, "0000000000000000000000000000000000000000"); got != "" || !answered {
+	if got, answered := a.TagContaining(noBudget(), dir, "0000000000000000000000000000000000000000"); got != "" || !answered {
 		t.Errorf("unknown hash: want (\"\", true), got (%q, %v)", got, answered)
 	}
 }

--- a/core/adapters/outbound/git/budget_test.go
+++ b/core/adapters/outbound/git/budget_test.go
@@ -1,0 +1,115 @@
+package git
+
+import (
+	"context"
+	"os/exec"
+	"testing"
+	"time"
+)
+
+// This file is the adapter's half of #1563. The operation-level half — one
+// deadline over a whole sequence, and loops that check it themselves — is
+// core/application/services/git_budget_test.go; what belongs HERE is the two
+// properties the caller's budget only has because this adapter gives them to
+// it: that a caller's deadline reaches the child at all, and that a call made
+// under a spent one is a NON-answer rather than an empty one.
+//
+// The second is the load-bearing one and it is the whole reason an aggregate
+// budget is cheap here. #1543 built this package around "git answered" versus
+// "git was never asked"; a budget that abandoned a call and reported it as
+// "git ran and found nothing" would put the collapse back, this time with
+// DORA publishing a median over the ranges that fit inside the budget.
+
+// TestReadUnderASpentBudgetIsANonAnswer drives every method that starts a child
+// under a caller budget that is already gone.
+//
+// It uses the PRODUCTION adapter and a real repository, so what it grades is
+// the whole path — run's context derivation, os/exec's refusal to start, and
+// shellout.Answered's classification of an error that is not an *exec.ExitError
+// at all. A stub could not: the distinction it asserts is precisely the one no
+// faked return value can pin.
+func TestReadUnderASpentBudgetIsANonAnswer(t *testing.T) {
+	dir := gitInitForTest(t)
+	sha := commitFileForTest(t, dir, "a.txt", "A")
+	a := New()
+
+	spent, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	reads := []struct {
+		name string
+		call func(ctx context.Context) bool
+	}{
+		{"GetBranch", func(ctx context.Context) bool { _, ok := a.GetBranch(ctx, dir); return ok }},
+		{"GetHeadCommit", func(ctx context.Context) bool { _, ok := a.GetHeadCommit(ctx, dir); return ok }},
+		{"GetGitRoot", func(ctx context.Context) bool { _, ok := a.GetGitRoot(ctx, dir); return ok }},
+		{"GetProjectName", func(ctx context.Context) bool { _, ok := a.GetProjectName(ctx, dir); return ok }},
+		{"RevertedCommits", func(ctx context.Context) bool { _, ok := a.RevertedCommits(ctx, dir); return ok }},
+		{"ListReleaseTags", func(ctx context.Context) bool { _, ok := a.ListReleaseTags(ctx, dir); return ok }},
+		{"CommitsInRange", func(ctx context.Context) bool { _, ok := a.CommitsInRange(ctx, dir, "", "HEAD"); return ok }},
+		{"TagContaining", func(ctx context.Context) bool { _, ok := a.TagContaining(ctx, dir, sha); return ok }},
+	}
+
+	for _, r := range reads {
+		t.Run(r.name, func(t *testing.T) {
+			if r.call(spent) {
+				t.Errorf("%s reported that git ANSWERED under a spent aggregate budget. It was never asked — "+
+					"os/exec fails before Start — and reporting an empty answer instead of a non-answer is the "+
+					"#1543 collapse arriving through the #1563 budget: the caller then reads 'no releases', "+
+					"'no reverts' or 'not a repo' as a fact about a repository nothing looked at", r.name)
+			}
+			// Vacuity guard, in the same sub-test so it cannot drift from the
+			// claim: this repository DOES answer when the budget is live. Without
+			// it the assertion above passes for a read that never works.
+			if !r.call(noBudget()) {
+				t.Errorf("%s did not answer for a real repository under a live budget — the assertion above "+
+					"proves nothing if this read never answers at all", r.name)
+			}
+		})
+	}
+}
+
+// TestRunTakesTheShorterOfTheCallersBudgetAndItsOwnCeiling pins what the ctx
+// parameter did NOT change, which is the half a reviewer is most likely to
+// assume rather than check.
+//
+// #1543's guarantee is per-CALL and it survives: a caller with no aggregate at
+// all still gets gitTimeout/gitHistoryTimeout, because run derives its own
+// deadline from whatever it is handed. #1563 adds the other direction — a
+// caller whose budget is shorter wins, which is what makes an aggregate over a
+// sequence a real bound rather than a suggestion. Both directions are asserted,
+// because a run() that ignored the caller and a run() that ignored its own
+// ceiling each satisfy exactly one of them.
+func TestRunTakesTheShorterOfTheCallersBudgetAndItsOwnCeiling(t *testing.T) {
+	var seen time.Time
+	var bounded bool
+	record := func(ctx context.Context, dir string, args ...string) *exec.Cmd {
+		seen, bounded = ctx.Deadline()
+		return exec.CommandContext(ctx, gitPath, args...)
+	}
+
+	// A caller budget far SHORTER than the ceiling: the caller wins.
+	short, cancelShort := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancelShort()
+	before := time.Now()
+	withCeiling(record, 5*time.Second).GetBranch(short, "/tmp")
+	if !bounded {
+		t.Fatal("the child ran under a context with no deadline at all (#1543)")
+	}
+	if got := seen.Sub(before); got > time.Second {
+		t.Errorf("under a 20ms caller budget the child's deadline was %v away, want <= the caller's: run derives "+
+			"its ceiling from context.Background() again, so an aggregate over a sequence bounds nothing (#1563)", got)
+	}
+
+	// No caller budget at all: the adapter's OWN ceiling still applies.
+	before = time.Now()
+	withCeiling(record, 250*time.Millisecond).GetBranch(noBudget(), "/tmp")
+	if !bounded {
+		t.Fatal("with no caller budget the child ran unbounded: #1543's per-call guarantee is gone")
+	}
+	if got := seen.Sub(before); got > time.Second {
+		t.Errorf("with no caller budget the child's deadline was %v away, want ~250ms (this adapter's own "+
+			"ceiling): passing the caller's context through unchanged would leave every noGitBudget() call "+
+			"unbounded (#1543)", got)
+	}
+}

--- a/core/adapters/outbound/git/shellout_test.go
+++ b/core/adapters/outbound/git/shellout_test.go
@@ -144,7 +144,7 @@ func TestNonAnswerIsDistinguishableFromAGenuineMiss(t *testing.T) {
 	notARepo := t.TempDir()
 
 	// A genuine miss: git runs fine and reports that this is not a repo.
-	branch, answered := New().GetBranch(notARepo)
+	branch, answered := New().GetBranch(noBudget(), notARepo)
 	if !answered {
 		t.Fatal("a directory that is not a repo is an ANSWER — git exits 128 and has said so")
 	}
@@ -153,7 +153,7 @@ func TestNonAnswerIsDistinguishableFromAGenuineMiss(t *testing.T) {
 	}
 
 	// A non-answer: git cannot be run at all.
-	branch, answered = withCmd(missingGit).GetBranch(realRepo)
+	branch, answered = withCmd(missingGit).GetBranch(noBudget(), realRepo)
 	if answered {
 		t.Error("a git that never started was reported as an answer; \"\" would then " +
 			"mean \"this repo has no branch\", which is #1543")
@@ -180,21 +180,21 @@ func TestEveryShelloutReportsANonAnswer(t *testing.T) {
 		unread  func(*Adapter) bool // reports the adapter's answered bit
 		wantVal string              // description of what the zero value would have meant
 	}{
-		{"GetBranch", func(a *Adapter) bool { _, ok := a.GetBranch(repo); return ok },
+		{"GetBranch", func(a *Adapter) bool { _, ok := a.GetBranch(noBudget(), repo); return ok },
 			"detached HEAD"},
-		{"GetHeadCommit", func(a *Adapter) bool { _, ok := a.GetHeadCommit(repo); return ok },
+		{"GetHeadCommit", func(a *Adapter) bool { _, ok := a.GetHeadCommit(noBudget(), repo); return ok },
 			"not a git repo (persisted as YieldUnknown)"},
-		{"RevertedCommits", func(a *Adapter) bool { _, ok := a.RevertedCommits(repo); return ok },
+		{"RevertedCommits", func(a *Adapter) bool { _, ok := a.RevertedCommits(noBudget(), repo); return ok },
 			"this repo has no reverts"},
-		{"ListReleaseTags", func(a *Adapter) bool { _, ok := a.ListReleaseTags(repo); return ok },
+		{"ListReleaseTags", func(a *Adapter) bool { _, ok := a.ListReleaseTags(noBudget(), repo); return ok },
 			"no releases found for this project"},
-		{"CommitsInRange", func(a *Adapter) bool { _, ok := a.CommitsInRange(repo, "", "v0.1.0"); return ok },
+		{"CommitsInRange", func(a *Adapter) bool { _, ok := a.CommitsInRange(noBudget(), repo, "", "v0.1.0"); return ok },
 			"this release shipped no commits"},
-		{"TagContaining", func(a *Adapter) bool { _, ok := a.TagContaining(repo, sha); return ok },
+		{"TagContaining", func(a *Adapter) bool { _, ok := a.TagContaining(noBudget(), repo, sha); return ok },
 			"this commit was never released (which LOWERS change failure rate)"},
-		{"GetGitRoot", func(a *Adapter) bool { _, ok := a.GetGitRoot(repo); return ok },
+		{"GetGitRoot", func(a *Adapter) bool { _, ok := a.GetGitRoot(noBudget(), repo); return ok },
 			"project not found or not a git repository"},
-		{"GetProjectName", func(a *Adapter) bool { _, ok := a.GetProjectName(repo); return ok },
+		{"GetProjectName", func(a *Adapter) bool { _, ok := a.GetProjectName(noBudget(), repo); return ok },
 			"the directory basename, cached for the daemon's lifetime"},
 	}
 
@@ -231,20 +231,20 @@ func TestNotARepoIsAnAnswer(t *testing.T) {
 		name string
 		ok   func() bool
 	}{
-		{"not a repo/GetBranch", func() bool { _, ok := a.GetBranch(notARepo); return ok }},
-		{"not a repo/GetHeadCommit", func() bool { _, ok := a.GetHeadCommit(notARepo); return ok }},
-		{"not a repo/RevertedCommits", func() bool { _, ok := a.RevertedCommits(notARepo); return ok }},
-		{"not a repo/ListReleaseTags", func() bool { _, ok := a.ListReleaseTags(notARepo); return ok }},
-		{"not a repo/TagContaining", func() bool { _, ok := a.TagContaining(notARepo, "deadbeef"); return ok }},
-		{"not a repo/GetGitRoot", func() bool { _, ok := a.GetGitRoot(notARepo); return ok }},
+		{"not a repo/GetBranch", func() bool { _, ok := a.GetBranch(noBudget(), notARepo); return ok }},
+		{"not a repo/GetHeadCommit", func() bool { _, ok := a.GetHeadCommit(noBudget(), notARepo); return ok }},
+		{"not a repo/RevertedCommits", func() bool { _, ok := a.RevertedCommits(noBudget(), notARepo); return ok }},
+		{"not a repo/ListReleaseTags", func() bool { _, ok := a.ListReleaseTags(noBudget(), notARepo); return ok }},
+		{"not a repo/TagContaining", func() bool { _, ok := a.TagContaining(noBudget(), notARepo, "deadbeef"); return ok }},
+		{"not a repo/GetGitRoot", func() bool { _, ok := a.GetGitRoot(noBudget(), notARepo); return ok }},
 		// The seventh method. It was the one row missing from this table
 		// (#1551 QA), which mattered because CommitsInRange is the method
 		// whose non-answer biases a DORA median rather than blanking a field.
-		{"not a repo/CommitsInRange", func() bool { _, ok := a.CommitsInRange(notARepo, "", "HEAD"); return ok }},
-		{"unborn branch/GetHeadCommit", func() bool { _, ok := a.GetHeadCommit(unborn); return ok }},
-		{"unborn branch/RevertedCommits", func() bool { _, ok := a.RevertedCommits(unborn); return ok }},
-		{"unresolvable object/TagContaining", func() bool { _, ok := a.TagContaining(repo, "deadbeef"); return ok }},
-		{"unknown ref range/CommitsInRange", func() bool { _, ok := a.CommitsInRange(repo, "v9.9.9", "v9.9.8"); return ok }},
+		{"not a repo/CommitsInRange", func() bool { _, ok := a.CommitsInRange(noBudget(), notARepo, "", "HEAD"); return ok }},
+		{"unborn branch/GetHeadCommit", func() bool { _, ok := a.GetHeadCommit(noBudget(), unborn); return ok }},
+		{"unborn branch/RevertedCommits", func() bool { _, ok := a.RevertedCommits(noBudget(), unborn); return ok }},
+		{"unresolvable object/TagContaining", func() bool { _, ok := a.TagContaining(noBudget(), repo, "deadbeef"); return ok }},
+		{"unknown ref range/CommitsInRange", func() bool { _, ok := a.CommitsInRange(noBudget(), repo, "v9.9.9", "v9.9.8"); return ok }},
 	}
 	for _, tc := range cases {
 		if !tc.ok() {
@@ -266,24 +266,24 @@ func TestNothingAskedIsNotANonAnswer(t *testing.T) {
 		name string
 		ok   bool
 	}{
-		{"GetBranch", second(a.GetBranch(""))},
-		{"GetHeadCommit", second(a.GetHeadCommit(""))},
-		{"GetGitRoot", second(a.GetGitRoot(""))},
-		{"GetProjectName", second(a.GetProjectName(""))},
-		{"TagContaining/no hash", second(a.TagContaining("/tmp", ""))},
+		{"GetBranch", second(a.GetBranch(noBudget(), ""))},
+		{"GetHeadCommit", second(a.GetHeadCommit(noBudget(), ""))},
+		{"GetGitRoot", second(a.GetGitRoot(noBudget(), ""))},
+		{"GetProjectName", second(a.GetProjectName(noBudget(), ""))},
+		{"TagContaining/no hash", second(a.TagContaining(noBudget(), "/tmp", ""))},
 	}
 	for _, c := range checks {
 		if !c.ok {
 			t.Errorf("%s: an unasked question was reported as a non-answer", c.name)
 		}
 	}
-	if _, ok := a.RevertedCommits(""); !ok {
+	if _, ok := a.RevertedCommits(noBudget(), ""); !ok {
 		t.Error("RevertedCommits: an unasked question was reported as a non-answer")
 	}
-	if _, ok := a.ListReleaseTags(""); !ok {
+	if _, ok := a.ListReleaseTags(noBudget(), ""); !ok {
 		t.Error("ListReleaseTags: an unasked question was reported as a non-answer")
 	}
-	if _, ok := a.CommitsInRange("", "", ""); !ok {
+	if _, ok := a.CommitsInRange(noBudget(), "", "", ""); !ok {
 		t.Error("CommitsInRange: an unasked question was reported as a non-answer")
 	}
 }
@@ -315,7 +315,7 @@ func TestRunCeilingActuallyFires(t *testing.T) {
 	t.Parallel()
 
 	start := time.Now()
-	_, answered := withCeiling(stalledGit, testCeiling).GetBranch("/tmp")
+	_, answered := withCeiling(stalledGit, testCeiling).GetBranch(noBudget(), "/tmp")
 	elapsed := time.Since(start)
 
 	if answered {
@@ -350,7 +350,7 @@ func TestOrphanHoldingStdoutIsANonAnswer(t *testing.T) {
 	t.Parallel()
 
 	start := time.Now()
-	_, answered := withCeiling(orphanHoldingStdout, testCeiling).GetHeadCommit("/tmp")
+	_, answered := withCeiling(orphanHoldingStdout, testCeiling).GetHeadCommit(noBudget(), "/tmp")
 	elapsed := time.Since(start)
 
 	if answered {
@@ -373,7 +373,7 @@ func TestMissingBinaryFailsImmediately(t *testing.T) {
 	t.Parallel()
 
 	start := time.Now()
-	_, answered := withCeiling(missingGit, testCeiling).GetGitRoot("/tmp")
+	_, answered := withCeiling(missingGit, testCeiling).GetGitRoot(noBudget(), "/tmp")
 	elapsed := time.Since(start)
 
 	if answered {
@@ -404,7 +404,7 @@ func TestFloodingChildIsBoundedAndReportsANonAnswer(t *testing.T) {
 	t.Parallel()
 
 	start := time.Now()
-	_, answered := withCeiling(floodingGit, testCeiling).RevertedCommits("/tmp")
+	_, answered := withCeiling(floodingGit, testCeiling).RevertedCommits(noBudget(), "/tmp")
 	elapsed := time.Since(start)
 
 	if answered {
@@ -434,7 +434,7 @@ func TestUnderTheCapIsStillAnAnswer(t *testing.T) {
 	// A gitMaxOutput-1 row would cost a second 64 MiB pipe copy to assert what
 	// TestCappedBufferStopsAtItsLimit already pins at Limit: 8.
 	for _, n := range []int{1 << 10, gitMaxOutput} {
-		out, answered := withCmd(build(n)).run(fixedCost, "/tmp", "irrelevant")
+		out, answered := withCmd(build(n)).run(noBudget(), fixedCost, "/tmp", "irrelevant")
 		if !answered {
 			t.Errorf("%d bytes, under the %d-byte cap, was reported as a non-answer", n, gitMaxOutput)
 		}
@@ -467,7 +467,7 @@ func TestFailingGitDoesNotPublishItsStdoutAsData(t *testing.T) {
 
 	a := New()
 
-	head, answered := a.GetHeadCommit(unborn)
+	head, answered := a.GetHeadCommit(noBudget(), unborn)
 	if !answered {
 		t.Fatal("an unborn branch is an ANSWER — git ran and exited 128")
 	}
@@ -477,7 +477,7 @@ func TestFailingGitDoesNotPublishItsStdoutAsData(t *testing.T) {
 			"under the fake SHA %q is one the yield sweeper can never correlate", head, head)
 	}
 
-	branch, answered := a.GetBranch(unborn)
+	branch, answered := a.GetBranch(noBudget(), unborn)
 	if !answered {
 		t.Fatal("an unborn branch is an ANSWER for GetBranch too")
 	}
@@ -507,7 +507,7 @@ func TestPartialOutputBeforeAFatalIsNotACompleteAnswer(t *testing.T) {
 	}
 	a := withCmd(partial)
 
-	commits, answered := a.CommitsInRange("/tmp", "", "HEAD")
+	commits, answered := a.CommitsInRange(noBudget(), "/tmp", "", "HEAD")
 	if !answered {
 		t.Fatal("a git that exited 128 ANSWERED; only a killed or unstarted child has not")
 	}
@@ -517,7 +517,7 @@ func TestPartialOutputBeforeAFatalIsNotACompleteAnswer(t *testing.T) {
 			len(commits))
 	}
 
-	shas, answered := a.RevertedCommits("/tmp")
+	shas, answered := a.RevertedCommits(noBudget(), "/tmp")
 	if !answered {
 		t.Fatal("same for RevertedCommits")
 	}
@@ -534,7 +534,7 @@ func TestASuccessfulGitStillReturnsItsOutput(t *testing.T) {
 	repo := gitInitForTest(t)
 	sha := commitFileForTest(t, repo, "a.txt", "A")
 
-	if got, answered := New().GetHeadCommit(repo); got != sha || !answered {
+	if got, answered := New().GetHeadCommit(noBudget(), repo); got != sha || !answered {
 		t.Errorf("GetHeadCommit = (%q, %v), want (%q, true)", got, answered, sha)
 	}
 }
@@ -577,7 +577,7 @@ func TestProductionAdapterIsBounded(t *testing.T) {
 	}
 
 	start := time.Now()
-	_, answered := withBinary(stub).GetHeadCommit(t.TempDir())
+	_, answered := withBinary(stub).GetHeadCommit(noBudget(), t.TempDir())
 	elapsed := time.Since(start)
 
 	if answered {
@@ -635,7 +635,7 @@ func TestZeroValuedAdapterIsStillBounded(t *testing.T) {
 	}
 
 	start := time.Now()
-	_, answered := a.GetBranch("/tmp")
+	_, answered := a.GetBranch(noBudget(), "/tmp")
 	elapsed := time.Since(start)
 
 	if answered {
@@ -799,14 +799,14 @@ func TestEachShelloutRunsUnderTheCeilingForItsCostProfile(t *testing.T) {
 		want time.Duration
 		call func()
 	}{
-		{"GetBranch", gitTimeout, func() { a.GetBranch(dir) }},
-		{"GetHeadCommit", gitTimeout, func() { a.GetHeadCommit(dir) }},
-		{"GetGitRoot", gitTimeout, func() { a.GetGitRoot(dir) }},
-		{"GetProjectName", gitTimeout, func() { a.GetProjectName(dir) }},
-		{"ListReleaseTags", gitTimeout, func() { a.ListReleaseTags(dir) }},
-		{"TagContaining", gitTimeout, func() { a.TagContaining(dir, "deadbeef") }},
-		{"RevertedCommits", gitHistoryTimeout, func() { a.RevertedCommits(dir) }},
-		{"CommitsInRange", gitHistoryTimeout, func() { a.CommitsInRange(dir, "", "HEAD") }},
+		{"GetBranch", gitTimeout, func() { a.GetBranch(noBudget(), dir) }},
+		{"GetHeadCommit", gitTimeout, func() { a.GetHeadCommit(noBudget(), dir) }},
+		{"GetGitRoot", gitTimeout, func() { a.GetGitRoot(noBudget(), dir) }},
+		{"GetProjectName", gitTimeout, func() { a.GetProjectName(noBudget(), dir) }},
+		{"ListReleaseTags", gitTimeout, func() { a.ListReleaseTags(noBudget(), dir) }},
+		{"TagContaining", gitTimeout, func() { a.TagContaining(noBudget(), dir, "deadbeef") }},
+		{"RevertedCommits", gitHistoryTimeout, func() { a.RevertedCommits(noBudget(), dir) }},
+		{"CommitsInRange", gitHistoryTimeout, func() { a.CommitsInRange(noBudget(), dir, "", "HEAD") }},
 	}
 
 	const tolerance = 2 * time.Second // the read happens microseconds after the deadline is set
@@ -879,14 +879,14 @@ func TestTheTwoCeilingsAreIndependentAtRuntime(t *testing.T) {
 	a := withCeilings(stalledGit, short, long)
 
 	start := time.Now()
-	_, answered := a.GetBranch("/tmp")
+	_, answered := a.GetBranch(noBudget(), "/tmp")
 	fixedElapsed := time.Since(start)
 	if answered {
 		t.Error("GetBranch: a child killed by the ceiling was reported as an answer")
 	}
 
 	start = time.Now()
-	_, answered = a.RevertedCommits("/tmp")
+	_, answered = a.RevertedCommits(noBudget(), "/tmp")
 	historyElapsed := time.Since(start)
 	if answered {
 		t.Error("RevertedCommits: a child killed by the ceiling was reported as an answer")

--- a/core/application/services/dora_metrics.go
+++ b/core/application/services/dora_metrics.go
@@ -1,7 +1,9 @@
 package services
 
 import (
+	"context"
 	"errors"
+	"time"
 
 	"irrlicht/core/domain/dora"
 	"irrlicht/core/domain/session"
@@ -13,14 +15,56 @@ import (
 // in this iteration.
 const doraHotfixWindowHours = 24
 
+// DoraGitBudget is the ONE aggregate deadline covering an entire DORA
+// computation: the repo-root resolution, the release-tag listing, one commit
+// range per in-window tag, and one `tag --contains` per revert candidate.
+//
+// It exists because core/adapters/outbound/git bounds one CALL and this
+// operation stacks `1 + len(in-window tags) + len(revertCandidates)` of them,
+// with nothing bounding the sum, on a handler served by a server whose
+// WriteTimeout is deliberately 0 (core/cmd/irrlichd/startup.go). #1553 chose
+// its 30s history ceiling AGAINST that stack rather than against the largest
+// repository imaginable, which is why the two numbers are one decision and this
+// is its other half (#1563).
+//
+// The value is set by what it has to fit inside — except that here, uniquely,
+// there is nothing behind it to fall back on. There is no server-side write
+// ceiling, so the only real bound today is how long a browser tab (and its
+// user) will hold on. So it is derived from the OTHER direction, from the one
+// number that is measured: it must be at least git.HistoryCeiling, or a single
+// legitimate history walk on a repository at #1553's design point (1M commits,
+// measured at 30.5s) can never complete and the panel is permanently blank for
+// exactly the repositories #1553 raised that ceiling for. 2x is the smallest
+// multiple that lets a window containing more than one release finish there.
+//
+// That relation is pinned rather than restated, in core/cmd/irrlichd — the one
+// package that depends on both this service and the git adapter, since
+// core/architecture_test.go forbids application/services from importing an
+// adapter. Which is also why this constant is EXPORTED: nothing else here
+// needs it.
+//
+// It is not the only bound in play at runtime, and the second one is free.
+// serveHistoryDoraChart derives this from the REQUEST's context, so a browser
+// that gives up — or a daemon shutting down — cancels the git walks instead of
+// leaving them to run out this budget against a client nobody is listening on.
+const DoraGitBudget = 60 * time.Second
+
 // doraGitProbe is the narrow git surface ComputeDoraMetrics needs, matching
 // the yieldGitProbe/historySessionLister convention of small per-consumer
 // interfaces rather than a shared, ever-growing one.
+//
+// Every method takes the aggregate budget explicitly rather than the probe
+// holding one, because the alternative is two objects that can disagree: the
+// context this operation checks its loops against and the context its children
+// actually run under would be separately supplied, and a probe wired to a
+// different one would look identical from here. Passing it per call is
+// #1529's own shape (resolveClientHostIdentityVia hands ctx to each candidate
+// probe) and it welds the two together.
 type doraGitProbe interface {
-	GetGitRoot(dir string) (root string, answered bool)
-	ListReleaseTags(dir string) (tags []dora.TagInfo, answered bool)
-	CommitsInRange(dir, fromRef, toRef string) (commits []dora.CommitInfo, answered bool)
-	TagContaining(dir, hash string) (tag string, answered bool)
+	GetGitRoot(ctx context.Context, dir string) (root string, answered bool)
+	ListReleaseTags(ctx context.Context, dir string) (tags []dora.TagInfo, answered bool)
+	CommitsInRange(ctx context.Context, dir, fromRef, toRef string) (commits []dora.CommitInfo, answered bool)
+	TagContaining(ctx context.Context, dir, hash string) (tag string, answered bool)
 }
 
 // doraSessionLister is the narrow read ComputeDoraMetrics needs over the
@@ -38,6 +82,25 @@ type doraSessionLister interface {
 // about the repository made by a probe that never reached it.
 const doraGitUnreadable = "could not read this project's git history"
 
+// doraGitTooSlow is the Message for the one non-answer #1563 newly admits: the
+// aggregate budget ran out with git calls still to make.
+//
+// A SECOND string, where #1543 deliberately collapsed every unreadable outcome
+// into one, and the two arguments do not conflict. #1543's point is that a
+// probe which never reached the repository must not wear the message of an
+// ANSWER about the repository ("no releases found for this project"). This is
+// not an answer about the repository either — it is a different fact about the
+// READ, one the user can act on differently: git works fine, this window is too
+// expensive, narrow it. Collapsing it into doraGitUnreadable would send someone
+// looking for a broken git that is not broken.
+//
+// It is also the whole of this budget's observability, and deliberately so.
+// #1529's abandonment needed a counter (#1558) because it happens inside a
+// background sweep nobody is watching; this one is user-visible on the very
+// request that produced it, in the panel and in the JSON, so a counter would be
+// a second, weaker copy of a fact already on screen.
+const doraGitTooSlow = "this project's git history took too long to read — try a narrower window"
+
 // DoraResult is the outcome of ComputeDoraMetrics, ready for the HTTP
 // handler to serialize. Available is false when project didn't resolve to
 // a git repo, that repo has no release tags, or git could not be read at all
@@ -52,11 +115,34 @@ type DoraResult struct {
 	MTTR                dora.Metric
 }
 
+// doraUnavailable is the one blank result every read that did not happen
+// returns, and the single place the two unreadable messages are told apart.
+//
+// It keys on the budget rather than on which call failed, because the budget is
+// the fact that distinguishes them and the call site cannot see it: an
+// abandoned sub-call and a git that could not be run arrive at exactly the same
+// `answered == false` (core/adapters/outbound/git's run: an expired context
+// fails before Start, so shellout.Answered reports false — see that predicate's
+// doc). What matters far more than which message it picks is what it always
+// does: Available:false with all four metrics at their zero values. A budget
+// that abandoned mid-sequence and published the metrics computed so far would
+// be a biased sample presented as complete — a median lead time over the tags
+// that happened to fit, a Change Failure Rate missing the reverts nobody got to
+// — which is the failure gitMaxOutput's doc and #1553's rejection of `--since`
+// both exist to refuse. Blanking is the conservative answer; a smaller sample
+// wearing Available:true is a wrong one.
+func doraUnavailable(ctx context.Context) DoraResult {
+	if budgetSpent(ctx) {
+		return DoraResult{Available: false, Message: doraGitTooSlow}
+	}
+	return DoraResult{Available: false, Message: doraGitUnreadable}
+}
+
 // ComputeDoraMetrics computes all four DORA metrics for project (a
 // ProjectName, as used by the History tab's existing ?project= filter)
 // over [start, end], entirely on request — no persistence, no background
 // sweep (unlike YieldSweeper; DORA has no per-session state to mutate).
-func ComputeDoraMetrics(git doraGitProbe, sessions doraSessionLister, project string, start, end int64) (DoraResult, error) {
+func ComputeDoraMetrics(ctx context.Context, git doraGitProbe, sessions doraSessionLister, project string, start, end int64) (DoraResult, error) {
 	if project == "" {
 		return DoraResult{}, errors.New("project is required")
 	}
@@ -64,20 +150,30 @@ func ComputeDoraMetrics(git doraGitProbe, sessions doraSessionLister, project st
 		return DoraResult{Available: false, Message: "git or session data unavailable"}, nil
 	}
 
-	root, rootAnswered, err := resolveDoraProjectRoot(git, sessions, project)
+	// One deadline over the whole sequence, derived HERE rather than taken
+	// from the caller, so that every entry point gets it by calling this
+	// function instead of by remembering to wrap. The caller's own context
+	// still bounds it from outside (a cancelled request cancels this).
+	ctx, cancel := context.WithTimeout(ctx, DoraGitBudget)
+	defer cancel()
+
+	root, rootAnswered, err := resolveDoraProjectRoot(ctx, git, sessions, project)
 	if err != nil {
 		return DoraResult{}, err
 	}
 	if !rootAnswered {
-		return DoraResult{Available: false, Message: doraGitUnreadable}, nil
+		return doraUnavailable(ctx), nil
 	}
 	if root == "" {
 		return DoraResult{Available: false, Message: "project not found or not a git repository"}, nil
 	}
 
-	tags, answered := git.ListReleaseTags(root)
+	if budgetSpent(ctx) {
+		return doraUnavailable(ctx), nil
+	}
+	tags, answered := git.ListReleaseTags(ctx, root)
 	if !answered {
-		return DoraResult{Available: false, Message: doraGitUnreadable}, nil
+		return doraUnavailable(ctx), nil
 	}
 	if len(tags) == 0 {
 		return DoraResult{Available: false, Message: "no releases found for this project"}, nil
@@ -89,6 +185,13 @@ func ComputeDoraMetrics(git doraGitProbe, sessions doraSessionLister, project st
 	// one revert's containing tag still yields a Change Failure Rate, each
 	// quietly biased and therefore harder to notice than a chart that says it
 	// could not be drawn (#1543).
+	//
+	// #1563 adds one more way for a read not to happen — the aggregate budget
+	// running out — and it takes exactly the same exit rather than a gentler
+	// one. That is the decision the budget rests on: a deadline that abandoned
+	// mid-sequence and published a partial computation would have introduced
+	// the biased sample through a fourth door, this time as a LATENCY fix,
+	// which is a worse trade than the latency it removes.
 	//
 	// Blanking ALL FOUR metrics is the conservative part, not the principled
 	// part, and it is stated that way rather than defended. dora.Metric already
@@ -127,13 +230,28 @@ func ComputeDoraMetrics(git doraGitProbe, sessions doraSessionLister, project st
 		if !dora.InWindow(tag.Epoch, start, end) {
 			continue
 		}
+		// #1563: the budget is checked HERE, by the loop, rather than left to
+		// the children to inherit. An expired deadline does reach them — the
+		// adapter derives every call from this context — but inheriting alone
+		// produces the WRONG FACT: each remaining range still starts a git that
+		// fails instantly, and this reads as "every range was unreadable" where
+		// the truth is "I stopped after k". It is also the only way the
+		// aggregate becomes a bound a caller can OBSERVE rather than an
+		// accident of the children's own ceilings.
+		//
+		// After the InWindow skip, not before: a tag no metric reads costs
+		// nothing, and checking ahead of it would abandon a loop that had no
+		// work left to do.
+		if budgetSpent(ctx) {
+			return doraUnavailable(ctx), nil
+		}
 		from := ""
 		if i > 0 {
 			from = tags[i-1].Name
 		}
-		commits, answered := git.CommitsInRange(root, from, tag.Name)
+		commits, answered := git.CommitsInRange(ctx, root, from, tag.Name)
 		if !answered {
-			return DoraResult{Available: false, Message: doraGitUnreadable}, nil
+			return doraUnavailable(ctx), nil
 		}
 		commitsByTag[tag.Name] = commits
 	}
@@ -144,12 +262,26 @@ func ComputeDoraMetrics(git doraGitProbe, sessions doraSessionLister, project st
 	failures := make([]dora.ResolvedFailure, 0, len(hotfixes)+len(candidates))
 	failures = append(failures, hotfixes...)
 	for _, c := range candidates {
-		originalTag, answered := git.TagContaining(root, c.OriginalHash)
+		// The loop checks the budget itself, for the reason the range loop
+		// above does. This is also the stage a shared budget STARVES (#1558's
+		// shape): the tag listing and the ranges run first and can consume
+		// everything, leaving the candidates unread on a repository where the
+		// history walks are chronically slow. That is a real cost and it is
+		// stated rather than argued away — but note what it costs and what it
+		// does not. Starvation here costs AVAILABILITY, never correctness: the
+		// panel goes blank with doraGitTooSlow, exactly as an unreadable
+		// candidate already blanked it, and no number computed over a subset is
+		// ever published. #1529's herdr case had to weigh a wrong answer;
+		// this one does not.
+		if budgetSpent(ctx) {
+			return doraUnavailable(ctx), nil
+		}
+		originalTag, answered := git.TagContaining(ctx, root, c.OriginalHash)
 		if !answered {
 			// Silently dropping this candidate would make Change Failure Rate
 			// read BETTER than reality — the one collapse in this adapter
 			// that flatters the number rather than blanking it.
-			return DoraResult{Available: false, Message: doraGitUnreadable}, nil
+			return doraUnavailable(ctx), nil
 		}
 		if resolved, ok := dora.ResolveRevert(tags, c, originalTag); ok {
 			failures = append(failures, resolved)
@@ -179,7 +311,7 @@ func ComputeDoraMetrics(git doraGitProbe, sessions doraSessionLister, project st
 // support — which is the class of claim #1543 removes everywhere else. Hence
 // `unread == 0` rather than a majority test; it subsumes the no-candidates case,
 // where unread is 0 and "nothing to compute" is the honest answer.
-func resolveDoraProjectRoot(git doraGitProbe, sessions doraSessionLister, project string) (string, bool, error) {
+func resolveDoraProjectRoot(ctx context.Context, git doraGitProbe, sessions doraSessionLister, project string) (string, bool, error) {
 	all, err := sessions.ListAll()
 	if err != nil {
 		return "", true, err
@@ -189,7 +321,15 @@ func resolveDoraProjectRoot(git doraGitProbe, sessions doraSessionLister, projec
 		if st == nil || st.ProjectName != project || st.CWD == "" {
 			continue
 		}
-		root, answered := git.GetGitRoot(st.CWD)
+		// #1563: the candidates left are ones we DECLINED to look at, which is
+		// the unread case rather than the "no candidate resolved" case — so it
+		// poisons the answer exactly as an unread candidate does, and stops.
+		// The loop checks rather than inheriting, for the reason the two loops
+		// in ComputeDoraMetrics do.
+		if budgetSpent(ctx) {
+			return "", false, nil
+		}
+		root, answered := git.GetGitRoot(ctx, st.CWD)
 		if !answered {
 			unread++
 			continue

--- a/core/application/services/dora_metrics_test.go
+++ b/core/application/services/dora_metrics_test.go
@@ -1,6 +1,7 @@
 package services_test
 
 import (
+	"context"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -82,13 +83,13 @@ func doraCommitAt(t *testing.T, dir, name, content, message, date string) string
 }
 
 func TestComputeDoraMetrics_ProjectRequired(t *testing.T) {
-	if _, err := services.ComputeDoraMetrics(git.New(), &doraFakeSessions{}, "", 0, 1); err == nil {
+	if _, err := services.ComputeDoraMetrics(context.Background(), git.New(), &doraFakeSessions{}, "", 0, 1); err == nil {
 		t.Fatal("expected an error for an empty project")
 	}
 }
 
 func TestComputeDoraMetrics_ProjectNotFound(t *testing.T) {
-	result, err := services.ComputeDoraMetrics(git.New(), &doraFakeSessions{}, "no-such-project", 0, 1)
+	result, err := services.ComputeDoraMetrics(context.Background(), git.New(), &doraFakeSessions{}, "no-such-project", 0, 1)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -104,7 +105,7 @@ func TestComputeDoraMetrics_NoReleasesYet(t *testing.T) {
 	sessions := &doraFakeSessions{states: []*session.SessionState{
 		{SessionID: "s1", ProjectName: "proj", CWD: dir},
 	}}
-	result, err := services.ComputeDoraMetrics(git.New(), sessions, "proj", 0, 1<<62)
+	result, err := services.ComputeDoraMetrics(context.Background(), git.New(), sessions, "proj", 0, 1<<62)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -150,7 +151,7 @@ func TestComputeDoraMetrics_EndToEnd(t *testing.T) {
 		{SessionID: "s1", ProjectName: "proj", CWD: dir},
 	}}
 
-	result, err := services.ComputeDoraMetrics(git.New(), sessions, "proj", 0, 1<<62)
+	result, err := services.ComputeDoraMetrics(context.Background(), git.New(), sessions, "proj", 0, 1<<62)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -192,16 +193,20 @@ type doraRecordingProbe struct {
 	asked   []string // "<fromRef>..<toRef>" per CommitsInRange call, in order
 }
 
-func (p *doraRecordingProbe) GetGitRoot(string) (string, bool) { return p.root, true }
+func (p *doraRecordingProbe) GetGitRoot(context.Context, string) (string, bool) { return p.root, true }
 
-func (p *doraRecordingProbe) ListReleaseTags(string) ([]dora.TagInfo, bool) { return p.tags, true }
+func (p *doraRecordingProbe) ListReleaseTags(context.Context, string) ([]dora.TagInfo, bool) {
+	return p.tags, true
+}
 
-func (p *doraRecordingProbe) CommitsInRange(_, fromRef, toRef string) ([]dora.CommitInfo, bool) {
+func (p *doraRecordingProbe) CommitsInRange(_ context.Context, _, fromRef, toRef string) ([]dora.CommitInfo, bool) {
 	p.asked = append(p.asked, fromRef+".."+toRef)
 	return p.commits[toRef], true
 }
 
-func (p *doraRecordingProbe) TagContaining(string, string) (string, bool) { return "", true }
+func (p *doraRecordingProbe) TagContaining(context.Context, string, string) (string, bool) {
+	return "", true
+}
 
 // TestComputeDoraMetrics_SkipsCommitRangesNoMetricReads is #1553's work bound.
 // ComputeDoraMetrics used to walk the commits of EVERY release tag in the
@@ -235,7 +240,7 @@ func TestComputeDoraMetrics_SkipsCommitRangesNoMetricReads(t *testing.T) {
 		{SessionID: "s1", ProjectName: "proj", CWD: "/repo/sub"},
 	}}
 
-	result, err := services.ComputeDoraMetrics(probe, sessions, "proj", 30*day, 50*day)
+	result, err := services.ComputeDoraMetrics(context.Background(), probe, sessions, "proj", 30*day, 50*day)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/core/application/services/git_budget.go
+++ b/core/application/services/git_budget.go
@@ -1,0 +1,52 @@
+package services
+
+import "context"
+
+// noGitBudget is the context every git read that deliberately has NO aggregate
+// deadline runs under. Naming it is the whole point: #1563 gave an aggregate to
+// the two operations that stack an UNBOUNDED number of git calls
+// (ComputeDoraMetrics, YieldSweeper.Sweep) and left these without one, and a
+// named helper makes that a reviewable absence rather than a bare context whose
+// meaning the next reader has to infer. It is processlifecycle's
+// noAggregateBudget (#1529) one layer over, down to the reasoning.
+//
+// Its production call sites are the enricher's: adoptGitMetadata (2 git calls),
+// RefreshOnActivity (up to 3), CaptureYieldOnReady (1) and backfillOne (up to
+// 3). Three reasons they get none, and the third is the one that would actually
+// change an answer:
+//
+//   - The stack is bounded by a CONSTANT, not by the input. #1563's subject is
+//     `1 + len(in-window tags) + len(revertCandidates)` and `1 per project
+//     root` — counts a repository or a user's session list can grow without
+//     limit. Two and three cannot.
+//   - Their ceiling is already the SHORT one. Every read on these paths is
+//     fixedCost (gitTimeout, 5s), because none of them walks commit messages,
+//     so the worst case is 15s rather than the 30s-per-call the history walks
+//     can reach.
+//   - They run inside the detector loop, where a non-answer is what #1485/#1543
+//     spent six issues making safe: it declines to overwrite what the session
+//     already holds and leaves backfillOne willing to retry. An aggregate here
+//     would make those non-answers MORE frequent for no bounded gain — the loop
+//     has no deadline of its own to protect, and each read that goes unanswered
+//     is one more field left to a later pass.
+//
+// It does not violate core/architecture_shellout_test.go, and the reason is
+// what is DONE with it rather than what it is: that rule resolves a
+// package-local helper whose body is a bare root context and reports it exactly
+// like a literal context.Background(), so what keeps this legal is that nothing
+// here passes it to exec.CommandContext. Every git call downstream still
+// derives its own gitTimeout/gitHistoryTimeout from it, so each CHILD keeps a
+// ceiling. What is absent is only the ceiling ACROSS children.
+func noGitBudget() context.Context { return context.Background() }
+
+// budgetSpent reports whether an operation's aggregate budget is gone, and it
+// is the predicate every loop in this package that stacks git calls consults
+// BEFORE starting the next one.
+//
+// One named spelling rather than `ctx.Err() != nil` at five call sites, for the
+// reason shellout.Answered is one predicate rather than five: what it means is
+// not obvious from the expression. `ctx.Err() != nil` reads as an error check,
+// and the thing being decided is "have I run out of permission to look" — whose
+// correct handling (poison the answer, do not report the remaining work as
+// looked-at-and-empty) is the whole of #1529 and #1543.
+func budgetSpent(ctx context.Context) bool { return ctx.Err() != nil }

--- a/core/application/services/git_budget_test.go
+++ b/core/application/services/git_budget_test.go
@@ -1,0 +1,456 @@
+package services
+
+import (
+	"context"
+	"slices"
+	"testing"
+	"time"
+
+	"irrlicht/core/domain/dora"
+	"irrlicht/core/domain/session"
+)
+
+// This file is #1563's behavioural half: what an operation that stacks git
+// calls does when the ONE aggregate deadline covering it runs out. The value
+// half — that each budget is small enough to be worth having — is
+// TestDoraGitBudgetCoversOneHistoryWalk (core/cmd/irrlichd, the only package
+// that may depend on both this layer and the git adapter) and
+// TestYieldSweepBudgetFitsItsOwnTick below.
+//
+// Every assertion here turns on the BUDGET rather than on a wall clock, which
+// is what keeps these tests instant: the loops consult ctx.Err(), so a probe
+// that cancels the shared context at a chosen call drives the exact state a
+// slow repository would take minutes to reach. Nothing here sleeps.
+//
+// The probe is injected for the reason #1529's is: no arrangement of real
+// repositories can be made to exhaust a shared budget at call 3 of 6 on
+// purpose, and what the budget does when it has is the whole subject.
+
+// budgetProbe is a doraGitProbe/yieldGitProbe that records every git call it is
+// asked for and spends the whole remaining budget on the nth one. Cancelling
+// the context is how "this call consumed the budget" is expressed without
+// waiting for it: the loops read ctx.Err(), which cancellation and a fired
+// deadline set alike.
+//
+// It refuses to answer under an expired context, which is not decoration — it
+// is what the real adapter does (core/adapters/outbound/git's run hands the
+// context to exec.CommandContext, which fails before Start, and
+// shellout.Answered reports that as a NON-answer). A fake that answered anyway
+// would make the loop-check tests below pass for a reason that does not exist
+// in production, and would stop the two mutations in this file's header
+// isolating: removing a loop's own check would then change the RESULT as well
+// as the call count, so one mutation would redden both tests and neither would
+// pin its own obligation.
+type budgetProbe struct {
+	root          string
+	rootByCWD     map[string]string
+	tags          []dora.TagInfo
+	commits       map[string][]dora.CommitInfo
+	tagContaining map[string]string
+	reverted      map[string][]string
+
+	// exhaustAt is the 1-based index of the call that spends the budget. 0
+	// never exhausts it, which is how each test below gets its vacuity guard
+	// from the same fixture it makes its claim with.
+	exhaustAt int
+	cancel    context.CancelFunc
+
+	calls     []string
+	deadlines []time.Time
+	bounded   []bool
+}
+
+// begin records one call and reports whether the probe may answer it.
+//
+// The ATTEMPT is recorded before the refusal, and that order is load-bearing
+// rather than tidy: calls is what the loop-check tests read, so a probe that
+// recorded only the calls it ANSWERED would report an identical sequence
+// whether or not the loop checked its own budget — the loop would ask, the
+// probe would silently decline, and the assertion would be green against a
+// deleted check. Measured: with calls recorded after the refusal, deleting the
+// ranges loop's budget check left TestComputeDoraMetrics_ChecksTheBudgetAtEachLoopHead passing.
+//
+// It cancels AFTER recording, so the call that spends the budget still answers
+// — the work happened, the budget ran out on the way back.
+func (p *budgetProbe) begin(ctx context.Context, what string) bool {
+	p.calls = append(p.calls, what)
+	deadline, ok := ctx.Deadline()
+	p.deadlines = append(p.deadlines, deadline)
+	p.bounded = append(p.bounded, ok)
+	if ctx.Err() != nil {
+		// What the real adapter does: exec.CommandContext under an expired
+		// context fails before Start, and shellout.Answered reports that as a
+		// NON-answer (see that predicate's doc).
+		return false
+	}
+	if p.exhaustAt > 0 && len(p.calls) == p.exhaustAt {
+		p.cancel()
+	}
+	return true
+}
+
+func (p *budgetProbe) GetGitRoot(ctx context.Context, dir string) (string, bool) {
+	if !p.begin(ctx, "root:"+dir) {
+		return "", false
+	}
+	if p.rootByCWD != nil {
+		return p.rootByCWD[dir], true
+	}
+	return p.root, true
+}
+
+func (p *budgetProbe) ListReleaseTags(ctx context.Context, _ string) ([]dora.TagInfo, bool) {
+	if !p.begin(ctx, "tags") {
+		return nil, false
+	}
+	return p.tags, true
+}
+
+func (p *budgetProbe) CommitsInRange(ctx context.Context, _, _, toRef string) ([]dora.CommitInfo, bool) {
+	if !p.begin(ctx, "range:"+toRef) {
+		return nil, false
+	}
+	return p.commits[toRef], true
+}
+
+func (p *budgetProbe) TagContaining(ctx context.Context, _, hash string) (string, bool) {
+	if !p.begin(ctx, "contains:"+hash) {
+		return "", false
+	}
+	return p.tagContaining[hash], true
+}
+
+func (p *budgetProbe) RevertedCommits(ctx context.Context, dir string) ([]string, bool) {
+	if !p.begin(ctx, "reverts:"+dir) {
+		return nil, false
+	}
+	return p.reverted[dir], true
+}
+
+// doraFixture is three in-window releases, the last of which reverts a commit
+// from the first — so the full call sequence is root, tags, three ranges and
+// one `tag --contains`, six calls, and every stage this budget can abandon is
+// actually reached. A fixture without the revert would assert on a loop the
+// code never enters, which is a green that proves nothing.
+func doraFixture(cancel context.CancelFunc, exhaustAt int) *budgetProbe {
+	return &budgetProbe{
+		root:      "/repo",
+		exhaustAt: exhaustAt,
+		cancel:    cancel,
+		tags: []dora.TagInfo{
+			{Name: "v1.0.0", Epoch: 1000},
+			{Name: "v1.1.0", Epoch: 2000},
+			{Name: "v1.2.0", Epoch: 3000},
+		},
+		commits: map[string][]dora.CommitInfo{
+			"v1.0.0": {{Hash: "aaaaaaa", AuthorEpoch: 900, Body: "feat: a"}},
+			"v1.1.0": {{Hash: "bbbbbbb", AuthorEpoch: 1900, Body: "feat: b"}},
+			"v1.2.0": {{
+				Hash:        "ccccccc",
+				AuthorEpoch: 2900,
+				Body:        "Revert \"feat: a\"\n\nThis reverts commit aaaaaaa.\n",
+			}},
+		},
+		tagContaining: map[string]string{"aaaaaaa": "v1.0.0"},
+	}
+}
+
+// theWholeWindow spans every fixture epoch above.
+const theWholeWindow = int64(1 << 40)
+
+// TestComputeDoraMetrics_DerivesOneBudgetOverTheWholeSequence pins the two
+// structural claims the behavioural tests below cannot make, because those
+// supply their own context: that the computation derives a bounded one at all,
+// and that the SAME one spans every stage.
+//
+// One context rather than one per stage is the decision, not an implementation
+// detail: a deadline per call would read as a bound while summing to
+// `(1 + tags + candidates) x DoraGitBudget`, which is the unbounded stack this
+// issue is about wearing a bound's clothes. What a DORA request costs is one
+// number.
+func TestComputeDoraMetrics_DerivesOneBudgetOverTheWholeSequence(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	probe := doraFixture(cancel, 0)
+
+	before := time.Now()
+	result, err := ComputeDoraMetrics(ctx, probe, doraSessions("proj", "/repo/sub"), "proj", 0, theWholeWindow)
+	after := time.Now()
+	if err != nil {
+		t.Fatalf("ComputeDoraMetrics: %v", err)
+	}
+	if !result.Available {
+		t.Fatalf("the fixture must compute: %+v", result)
+	}
+	if len(probe.calls) < 2 {
+		t.Fatalf("only %d git call(s) were made (%v); this test asserts about a SEQUENCE", len(probe.calls), probe.calls)
+	}
+
+	for i, bounded := range probe.bounded {
+		if !bounded {
+			t.Fatalf("git call %d (%s) ran under a context with NO deadline: the DORA stack is unbounded again (#1563)",
+				i+1, probe.calls[i])
+		}
+	}
+	for i := 1; i < len(probe.deadlines); i++ {
+		if !probe.deadlines[i].Equal(probe.deadlines[0]) {
+			t.Errorf("git call %d (%s) ran under a different deadline from call 1 (%v apart): one deadline per call "+
+				"sums to len(calls) x DoraGitBudget and is not the aggregate this fix states (#1563)",
+				i+1, probe.calls[i], probe.deadlines[i].Sub(probe.deadlines[0]))
+		}
+	}
+	if probe.deadlines[0].After(after.Add(DoraGitBudget)) || !probe.deadlines[0].After(before) {
+		t.Errorf("the derived deadline is %v from the call, want a positive span no longer than DoraGitBudget (%v)",
+			probe.deadlines[0].Sub(before), DoraGitBudget)
+	}
+}
+
+// TestComputeDoraMetrics_ChecksTheBudgetAtEachLoopHead is #1529's point 2 one
+// layer over, and the reason each loop tests ctx.Err() itself instead of
+// letting the git calls inherit the deadline.
+//
+// Inheriting alone is not nothing — an expired context does kill every child —
+// but it produces the WRONG FACT and it costs a process per remaining item.
+// Each surviving tag would still fork a `git log` that dies before Start, and
+// the computation would report "every range was unreadable" where the truth is
+// "I stopped after one". Detecting exhaustion is also the only way the
+// aggregate becomes a bound a caller can observe rather than an accident of the
+// children's own ceilings.
+func TestComputeDoraMetrics_ChecksTheBudgetAtEachLoopHead(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	// Call 3 is the first commit range: root, tags, range:v1.0.0.
+	probe := doraFixture(cancel, 3)
+
+	if _, err := ComputeDoraMetrics(ctx, probe, doraSessions("proj", "/repo/sub"), "proj", 0, theWholeWindow); err != nil {
+		t.Fatalf("ComputeDoraMetrics: %v", err)
+	}
+
+	want := []string{"root:/repo/sub", "tags", "range:v1.0.0"}
+	if !slices.Equal(probe.calls, want) {
+		t.Errorf("the budget ran out at the first commit range and the computation went on to make %v, want %v: "+
+			"an aggregate deadline that is only INHERITED by the git calls is not detected by the loops, so every "+
+			"remaining tag and revert candidate still forks a doomed child and is reported unreadable rather than "+
+			"unread (#1563)", probe.calls, want)
+	}
+
+	// Vacuity guard: the same fixture with nothing exhausting the budget must
+	// reach every stage, or the assertion above would pass for a computation
+	// that simply stops early.
+	live, cancelLive := context.WithCancel(context.Background())
+	defer cancelLive()
+	full := doraFixture(cancelLive, 0)
+	if _, err := ComputeDoraMetrics(live, full, doraSessions("proj", "/repo/sub"), "proj", 0, theWholeWindow); err != nil {
+		t.Fatalf("ComputeDoraMetrics (vacuity guard): %v", err)
+	}
+	wantAll := []string{"root:/repo/sub", "tags", "range:v1.0.0", "range:v1.1.0", "range:v1.2.0", "contains:aaaaaaa"}
+	if !slices.Equal(full.calls, wantAll) {
+		t.Errorf("with budget to spare the computation made %v, want %v — the test above proves nothing if the "+
+			"sequence truncates regardless", full.calls, wantAll)
+	}
+}
+
+// TestComputeDoraMetrics_AbandonedSequenceBlanksRatherThanPublishes is the
+// load-bearing one, and the property the whole budget rests on.
+//
+// A git call abandoned because the budget ran out is a call we DECLINED TO
+// MAKE, so it must arrive as a NON-answer and take the same all-or-nothing exit
+// every other non-answer here takes (#1543). Getting it backwards is not a
+// missing nicety: publishing the metrics computed so far means a median lead
+// time over the tags that happened to fit inside the budget, and a Change
+// Failure Rate missing the reverts nobody got to — a biased sample presented as
+// complete, with Available:true, which is precisely the failure gitMaxOutput's
+// doc and #1553's rejection of `--since` both exist to refuse. A latency fix
+// that introduced it would be a bad trade: the panel would be WRONG instead of
+// slow, and silently so.
+func TestComputeDoraMetrics_AbandonedSequenceBlanksRatherThanPublishes(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	probe := doraFixture(cancel, 3)
+
+	result, err := ComputeDoraMetrics(ctx, probe, doraSessions("proj", "/repo/sub"), "proj", 0, theWholeWindow)
+	if err != nil {
+		t.Fatalf("ComputeDoraMetrics: %v", err)
+	}
+
+	if result.Available {
+		t.Errorf("two of three release ranges and the revert candidate were never read, and the panel published "+
+			"anyway: %+v. A budget that abandons mid-sequence and publishes what it has computes DORA over a "+
+			"biased subset and reports it as complete (#1563)", result)
+	}
+	for _, m := range []struct {
+		name string
+		got  dora.Metric
+	}{
+		{"DeploymentFrequency", result.DeploymentFrequency},
+		{"LeadTime", result.LeadTime},
+		{"ChangeFailureRate", result.ChangeFailureRate},
+		{"MTTR", result.MTTR},
+	} {
+		if m.got != (dora.Metric{}) {
+			t.Errorf("%s carries %+v on an abandoned computation; every metric must be its zero value, because "+
+				"the handler and the dashboard render whatever is non-empty", m.name, m.got)
+		}
+	}
+	if result.Message != doraGitTooSlow {
+		t.Errorf("Message = %q, want %q: an abandoned budget is a different fact from a git that could not be RUN, "+
+			"and the user's lever for it (a narrower window) is different too", result.Message, doraGitTooSlow)
+	}
+
+	// Vacuity guard: the identical fixture read within budget MUST publish, and
+	// publish something non-zero — otherwise the assertions above hold for a
+	// computation that never produces metrics at all, and the blank above would
+	// be evidence of nothing.
+	live, cancelLive := context.WithCancel(context.Background())
+	defer cancelLive()
+	full, err := ComputeDoraMetrics(live, doraFixture(cancelLive, 0), doraSessions("proj", "/repo/sub"), "proj", 0, theWholeWindow)
+	if err != nil {
+		t.Fatalf("ComputeDoraMetrics (vacuity guard): %v", err)
+	}
+	if !full.Available || full.DeploymentFrequency.Value == 0 {
+		t.Errorf("the same fixture read within budget produced %+v, want an available panel with a non-zero "+
+			"deployment frequency — if this fails, the assertions above pass for a fixture that computes nothing",
+			full)
+	}
+}
+
+// TestResolveDoraProjectRoot_AbandonedCandidateIsANonAnswer covers the FIRST
+// stage, which is the one where getting the polarity wrong produces a false
+// claim rather than a blank.
+//
+// resolveDoraProjectRoot walks every session of the project until one CWD
+// resolves to a repo. Its `unread == 0` rule already says that one candidate
+// nobody could read makes "project not found or not a git repository"
+// unsupportable (#1543). A candidate abandoned on the budget is the same thing
+// for a different reason — we declined to look at it — so it must poison the
+// answer identically. A budget that reported "not a git repository" for a
+// project whose later sessions were never examined would be #1543's exact
+// defect arriving through the latency fix.
+func TestResolveDoraProjectRoot_AbandonedCandidateIsANonAnswer(t *testing.T) {
+	sessions := oneSession{states: []*session.SessionState{
+		{SessionID: "s1", ProjectName: "proj", CWD: "/not/a/repo", State: session.StateReady},
+		{SessionID: "s2", ProjectName: "proj", CWD: "/repo/sub", State: session.StateReady},
+	}}
+	// s1 is a real directory that is not a repo (root "", answered) — so
+	// nothing but the abandonment can move the verdict.
+	roots := map[string]string{"/not/a/repo": "", "/repo/sub": "/repo"}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	probe := &budgetProbe{rootByCWD: roots, exhaustAt: 1, cancel: cancel}
+
+	result, err := ComputeDoraMetrics(ctx, probe, sessions, "proj", 0, theWholeWindow)
+	if err != nil {
+		t.Fatalf("ComputeDoraMetrics: %v", err)
+	}
+	// Two obligations, and they fail to different mutations: the loop must stop
+	// asking (this one), and what it stopped short of must poison the verdict
+	// (the message below).
+	if want := []string{"root:/not/a/repo"}; !slices.Equal(probe.calls, want) {
+		t.Errorf("the budget ran out at candidate 1 and the resolve went on to ask for %v, want %v: a loop that "+
+			"leaves the aggregate to its children forks a doomed `rev-parse` per remaining session (#1563)",
+			probe.calls, want)
+	}
+	if result.Message != doraGitTooSlow {
+		t.Errorf("Message = %q, want %q: session s2's CWD was never looked at because the budget ran out, and "+
+			"answering anything about whether this project is a git repository is a claim the daemon cannot "+
+			"support (#1543/#1563)", result.Message, doraGitTooSlow)
+	}
+
+	// Vacuity guard: the same two candidates read within budget, where the
+	// second resolves, must find the repo — otherwise the assertion above holds
+	// for a resolver that never answers.
+	live, cancelLive := context.WithCancel(context.Background())
+	defer cancelLive()
+	full := &budgetProbe{rootByCWD: roots, cancel: cancelLive,
+		tags: []dora.TagInfo{{Name: "v1.0.0", Epoch: 1000}}, commits: map[string][]dora.CommitInfo{}}
+	if got, err := ComputeDoraMetrics(live, full, sessions, "proj", 0, theWholeWindow); err != nil || !got.Available {
+		t.Errorf("within budget the same candidates produced (%+v, %v), want an available panel — if this fails, "+
+			"the assertion above passes for a resolver that never resolves anything", got, err)
+	}
+}
+
+// TestYieldSweep_StopsAtTheBudgetAndReportsWhatItDidNotRead is #1563's other
+// operation. The sweep stacks one `rev-parse` per session and one
+// `log --all --grep` per distinct project root, both unbounded in the input,
+// and #1553 raised the second to a 30s ceiling.
+//
+// Two obligations in one test because they are one behaviour: the loops stop
+// (rather than forking a doomed child per remaining item), and what they did
+// not read is COUNTED and logged. The second is the polarity that matters —
+// a root the sweep declined to scan must never be folded in as a root that was
+// scanned and had no reverts, which is how a sweep reports "nothing flipped"
+// for history it never read (#1543).
+func TestYieldSweep_StopsAtTheBudgetAndReportsWhatItDidNotRead(t *testing.T) {
+	states := []*session.SessionState{
+		{SessionID: "a", HeadCommit: "aaa", CWD: "/one"},
+		{SessionID: "b", HeadCommit: "bbb", CWD: "/two"},
+		{SessionID: "c", HeadCommit: "ccc", CWD: "/three"},
+	}
+	roots := map[string]string{"/one": "/one", "/two": "/two", "/three": "/three"}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	probe := &budgetProbe{rootByCWD: roots, exhaustAt: 2, cancel: cancel}
+	log := &gateLog{}
+	NewYieldSweeper(&diagFakeRepo{sessions: states}, probe, log, 0).Sweep(ctx)
+
+	for _, call := range probe.calls {
+		if len(call) >= 8 && call[:8] == "reverts:" {
+			t.Errorf("the budget ran out during root resolution and the sweep still scanned history: %v. "+
+				"Each of those is a `git log --all --grep` forked only to die before Start (#1563)", probe.calls)
+			break
+		}
+	}
+	if len(probe.calls) != 2 {
+		t.Errorf("the budget ran out at root 2 and the sweep made %d call(s) (%v), want 2: a loop that leaves the "+
+			"aggregate to its children keeps going and reports every remaining item as unreadable (#1563)",
+			len(probe.calls), probe.calls)
+	}
+	if !log.errorMentioning("could not resolve a repo root") {
+		t.Error("the sessions whose CWD was never resolved are invisible: a sweep that stops early must say so, " +
+			"or it looks exactly like a sweep that found nothing (#1543/#1563)")
+	}
+	if !log.errorMentioning("could not read git history") {
+		t.Error("the project roots the sweep declined to scan were not counted as unscanned. An unscanned root " +
+			"folded in as a scanned one with no findings is how a sweep reports 'nothing flipped' for history it " +
+			"never read (#1543)")
+	}
+
+	// Vacuity guard: the same sweep with budget to spare must read everything
+	// and complain about nothing, or the assertions above hold for a sweeper
+	// that always stops early and always logs.
+	live, cancelLive := context.WithCancel(context.Background())
+	defer cancelLive()
+	quiet := &gateLog{}
+	full := &budgetProbe{rootByCWD: roots, cancel: cancelLive}
+	NewYieldSweeper(&diagFakeRepo{sessions: states}, full, quiet, 0).Sweep(live)
+	if len(full.calls) != 6 {
+		t.Errorf("with budget to spare the sweep made %d call(s) (%v), want 6 (3 roots + 3 revert scans)",
+			len(full.calls), full.calls)
+	}
+	if quiet.errorMentioning("could not resolve a repo root") || quiet.errorMentioning("could not read git history") {
+		t.Errorf("a fully readable sweep reported unread work: %v", quiet.errors)
+	}
+}
+
+// TestYieldSweepBudgetFitsItsOwnTick is what makes yieldSweepBudget's value
+// evidence rather than a number someone liked. The sweep runs on a
+// time.Ticker, which DROPS ticks it overruns, so a budget at or above the
+// interval does not delay one sweep — it silently turns a 30-minute cadence
+// into whatever the git calls cost.
+//
+// Both constants live in this package, so unlike DORA's relation (pinned in
+// core/cmd/irrlichd, because application/services may not import an adapter)
+// this one is checkable where it is stated.
+func TestYieldSweepBudgetFitsItsOwnTick(t *testing.T) {
+	if yieldSweepBudget >= DefaultYieldSweepInterval {
+		t.Errorf("yieldSweepBudget (%v) is not smaller than DefaultYieldSweepInterval (%v): a sweep allowed to "+
+			"run for its whole tick overruns it, and Go's Ticker drops the ticks it overruns rather than queuing "+
+			"them (#1563)", yieldSweepBudget, DefaultYieldSweepInterval)
+	}
+	if yieldSweepBudget <= 0 {
+		t.Fatalf("yieldSweepBudget is %v: a non-positive budget makes context.WithTimeout fire immediately, so "+
+			"every sweep would abandon before its first git call", yieldSweepBudget)
+	}
+}

--- a/core/application/services/git_nonanswer_test.go
+++ b/core/application/services/git_nonanswer_test.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"context"
 	"testing"
 
 	"irrlicht/core/domain/dora"
@@ -29,28 +30,28 @@ type unreadGit struct {
 
 func (g *unreadGit) answered(probe string) bool { return !g.unreadFor[probe] }
 
-func (g *unreadGit) GetGitRoot(string) (string, bool) {
+func (g *unreadGit) GetGitRoot(context.Context, string) (string, bool) {
 	if !g.answered("root") {
 		return "", false
 	}
 	return g.root, true
 }
 
-func (g *unreadGit) ListReleaseTags(string) ([]dora.TagInfo, bool) {
+func (g *unreadGit) ListReleaseTags(context.Context, string) ([]dora.TagInfo, bool) {
 	if !g.answered("tags") {
 		return nil, false
 	}
 	return g.tags, true
 }
 
-func (g *unreadGit) CommitsInRange(_, _, toRef string) ([]dora.CommitInfo, bool) {
+func (g *unreadGit) CommitsInRange(_ context.Context, _, _, toRef string) ([]dora.CommitInfo, bool) {
 	if !g.answered("commits") {
 		return nil, false
 	}
 	return g.commits[toRef], true
 }
 
-func (g *unreadGit) TagContaining(string, string) (string, bool) {
+func (g *unreadGit) TagContaining(context.Context, string, string) (string, bool) {
 	if !g.answered("tagcontaining") {
 		return "", false
 	}
@@ -110,7 +111,7 @@ func TestDoraReportsUnreadableGitRatherThanAFalseVerdict(t *testing.T) {
 				commits:   commits,
 				unreadFor: map[string]bool{tc.unread: true},
 			}
-			got, err := ComputeDoraMetrics(git, doraSessions("proj", "/repo/sub"), "proj", 0, 9999)
+			got, err := ComputeDoraMetrics(context.Background(), git, doraSessions("proj", "/repo/sub"), "proj", 0, 9999)
 			if err != nil {
 				t.Fatalf("ComputeDoraMetrics: %v", err)
 			}
@@ -133,7 +134,7 @@ func TestDoraReportsUnreadableGitRatherThanAFalseVerdict(t *testing.T) {
 func TestDoraStillReportsItsGenuineVerdicts(t *testing.T) {
 	t.Run("no session resolves to a repo", func(t *testing.T) {
 		git := &unreadGit{root: ""}
-		got, err := ComputeDoraMetrics(git, doraSessions("proj", "/nowhere"), "proj", 0, 9999)
+		got, err := ComputeDoraMetrics(context.Background(), git, doraSessions("proj", "/nowhere"), "proj", 0, 9999)
 		if err != nil {
 			t.Fatalf("ComputeDoraMetrics: %v", err)
 		}
@@ -144,7 +145,7 @@ func TestDoraStillReportsItsGenuineVerdicts(t *testing.T) {
 
 	t.Run("a repo with no release tags", func(t *testing.T) {
 		git := &unreadGit{root: "/repo", tags: nil}
-		got, err := ComputeDoraMetrics(git, doraSessions("proj", "/repo/sub"), "proj", 0, 9999)
+		got, err := ComputeDoraMetrics(context.Background(), git, doraSessions("proj", "/repo/sub"), "proj", 0, 9999)
 		if err != nil {
 			t.Fatalf("ComputeDoraMetrics: %v", err)
 		}
@@ -162,7 +163,7 @@ func TestDoraStillReportsItsGenuineVerdicts(t *testing.T) {
 				"v0.2.0": {{Hash: "b", AuthorEpoch: 1900}},
 			},
 		}
-		got, err := ComputeDoraMetrics(git, doraSessions("proj", "/repo/sub"), "proj", 0, 9999)
+		got, err := ComputeDoraMetrics(context.Background(), git, doraSessions("proj", "/repo/sub"), "proj", 0, 9999)
 		if err != nil {
 			t.Fatalf("ComputeDoraMetrics: %v", err)
 		}
@@ -192,7 +193,7 @@ func TestResolveDoraProjectRootAnswersWhenAnyCandidateDid(t *testing.T) {
 		{SessionID: "b", ProjectName: "proj", CWD: "/two", State: session.StateReady},
 	}}
 
-	root, answered, err := resolveDoraProjectRoot(git, sessions, "proj")
+	root, answered, err := resolveDoraProjectRoot(context.Background(), git, sessions, "proj")
 	if err != nil {
 		t.Fatalf("resolveDoraProjectRoot: %v", err)
 	}
@@ -205,7 +206,7 @@ func TestResolveDoraProjectRootAnswersWhenAnyCandidateDid(t *testing.T) {
 
 	t.Run("every candidate unread is unreadable", func(t *testing.T) {
 		all := &countingRootGit{fn: func(string) (string, bool) { return "", false }}
-		_, answered, err := resolveDoraProjectRoot(all, sessions, "proj")
+		_, answered, err := resolveDoraProjectRoot(context.Background(), all, sessions, "proj")
 		if err != nil {
 			t.Fatalf("resolveDoraProjectRoot: %v", err)
 		}
@@ -235,7 +236,7 @@ func TestResolveDoraProjectRootAnswersWhenAnyCandidateDid(t *testing.T) {
 			{SessionID: "b", ProjectName: "proj", CWD: "/two", State: session.StateReady},
 			{SessionID: "c", ProjectName: "proj", CWD: "/three", State: session.StateReady},
 		}}
-		_, answered, err := resolveDoraProjectRoot(mixed, three, "proj")
+		_, answered, err := resolveDoraProjectRoot(context.Background(), mixed, three, "proj")
 		if err != nil {
 			t.Fatalf("resolveDoraProjectRoot: %v", err)
 		}
@@ -247,7 +248,7 @@ func TestResolveDoraProjectRootAnswersWhenAnyCandidateDid(t *testing.T) {
 
 	t.Run("no candidate at all is an answer", func(t *testing.T) {
 		none := &countingRootGit{fn: func(string) (string, bool) { return "", true }}
-		_, answered, err := resolveDoraProjectRoot(none, oneSession{}, "proj")
+		_, answered, err := resolveDoraProjectRoot(context.Background(), none, oneSession{}, "proj")
 		if err != nil {
 			t.Fatalf("resolveDoraProjectRoot: %v", err)
 		}
@@ -262,7 +263,7 @@ type countingRootGit struct {
 	unreadGit
 }
 
-func (g *countingRootGit) GetGitRoot(cwd string) (string, bool) { return g.fn(cwd) }
+func (g *countingRootGit) GetGitRoot(_ context.Context, cwd string) (string, bool) { return g.fn(cwd) }
 
 // enricherGit is a GitResolver whose branch/name probes report a non-answer.
 type enricherGit struct {
@@ -276,10 +277,18 @@ type enricherGit struct {
 	root           string
 }
 
-func (g *enricherGit) GetBranch(string) (string, bool)       { return g.branch, g.branchAnswered }
-func (g *enricherGit) GetProjectName(string) (string, bool)  { return g.name, g.nameAnswered }
-func (g *enricherGit) GetGitRoot(string) (string, bool)      { return g.root, g.rootAnswered }
-func (g *enricherGit) GetHeadCommit(string) (string, bool)   { return g.head, g.headAnswered }
+func (g *enricherGit) GetBranch(context.Context, string) (string, bool) {
+	return g.branch, g.branchAnswered
+}
+func (g *enricherGit) GetProjectName(context.Context, string) (string, bool) {
+	return g.name, g.nameAnswered
+}
+func (g *enricherGit) GetGitRoot(context.Context, string) (string, bool) {
+	return g.root, g.rootAnswered
+}
+func (g *enricherGit) GetHeadCommit(context.Context, string) (string, bool) {
+	return g.head, g.headAnswered
+}
 func (g *enricherGit) GetBranchFromTranscript(string) string { return "" }
 
 // GetCWDFromTranscript reports a MOVE: RefreshOnActivity only reaches the
@@ -436,7 +445,7 @@ func TestYieldSweepReportsRootsItCouldNotScan(t *testing.T) {
 	git := &unreadRevertGit{root: "/repo", unread: true}
 	s := NewYieldSweeper(&diagFakeRepo{}, git, log, 0)
 
-	s.collectRevertedSHAs(map[string]string{"/repo": "/repo/sub"})
+	s.collectRevertedSHAs(context.Background(), map[string]string{"/repo": "/repo/sub"})
 
 	if !log.errorMentioning("could not read git history") {
 		t.Errorf("a root whose revert scan never ran was not reported; logged: %v\n"+
@@ -447,7 +456,7 @@ func TestYieldSweepReportsRootsItCouldNotScan(t *testing.T) {
 	// sweeper that always complained would pass the arm above.
 	quiet := &gateLog{}
 	NewYieldSweeper(&diagFakeRepo{}, &unreadRevertGit{root: "/repo"}, quiet, 0).
-		collectRevertedSHAs(map[string]string{"/repo": "/repo/sub"})
+		collectRevertedSHAs(context.Background(), map[string]string{"/repo": "/repo/sub"})
 	if quiet.errorMentioning("could not read git history") {
 		t.Errorf("a fully readable sweep logged an unread-roots error: %v", quiet.errors)
 	}
@@ -468,7 +477,7 @@ func TestYieldSweepScansTheRootNotAPossiblyDeletedCWD(t *testing.T) {
 	s := NewYieldSweeper(&diagFakeRepo{}, git, &gateLog{}, 0)
 
 	rootDirs := map[string]string{}
-	if !s.recordRootDir(rootDirs, "/repo/worktrees/gone") {
+	if !s.recordRootDir(context.Background(), rootDirs, "/repo/worktrees/gone") {
 		t.Fatal("a resolvable root was reported as unresolved")
 	}
 	if got := rootDirs["/repo"]; got != "/repo" {
@@ -490,13 +499,13 @@ type unreadRevertGit struct {
 	rootUnread bool
 }
 
-func (g *unreadRevertGit) GetGitRoot(string) (string, bool) {
+func (g *unreadRevertGit) GetGitRoot(context.Context, string) (string, bool) {
 	if g.rootUnread {
 		return "", false
 	}
 	return g.root, true
 }
-func (g *unreadRevertGit) RevertedCommits(string) ([]string, bool) {
+func (g *unreadRevertGit) RevertedCommits(context.Context, string) ([]string, bool) {
 	if g.unread {
 		return nil, false
 	}
@@ -515,7 +524,7 @@ func TestYieldSweepReportsRootsItCouldNotResolve(t *testing.T) {
 	log := &gateLog{}
 	s := NewYieldSweeper(&diagFakeRepo{}, &unreadRevertGit{rootUnread: true}, log, 0)
 
-	s.indexByCommit([]*session.SessionState{
+	s.indexByCommit(context.Background(), []*session.SessionState{
 		{SessionID: "a", HeadCommit: "abc", CWD: "/repo/one"},
 		{SessionID: "b", HeadCommit: "def", CWD: "/repo/two"},
 	})
@@ -528,7 +537,7 @@ func TestYieldSweepReportsRootsItCouldNotResolve(t *testing.T) {
 	// Vacuity guard: a sweep that resolved every root must log nothing.
 	quiet := &gateLog{}
 	NewYieldSweeper(&diagFakeRepo{}, &unreadRevertGit{root: "/repo"}, quiet, 0).
-		indexByCommit([]*session.SessionState{{SessionID: "a", HeadCommit: "abc", CWD: "/repo/one"}})
+		indexByCommit(context.Background(), []*session.SessionState{{SessionID: "a", HeadCommit: "abc", CWD: "/repo/one"}})
 	if quiet.errorMentioning("could not resolve a repo root") {
 		t.Errorf("a fully resolvable sweep logged an unresolved-roots error: %v", quiet.errors)
 	}

--- a/core/application/services/metadata_enricher.go
+++ b/core/application/services/metadata_enricher.go
@@ -66,7 +66,7 @@ func (e *metadataEnricher) CaptureYieldOnReady(state *session.SessionState) {
 	if state == nil || state.YieldState == session.YieldReverted {
 		return
 	}
-	head, answered := e.git.GetHeadCommit(state.CWD)
+	head, answered := e.git.GetHeadCommit(noGitBudget(), state.CWD)
 	if !answered {
 		// A git that could not be run must not overwrite a verdict already
 		// reached — that is #1543's polarity, and it is why an existing
@@ -146,10 +146,13 @@ func (e *metadataEnricher) EnrichNewSession(state *session.SessionState, ev agen
 // adoptGitMetadata fills branch and project name from cwd, leaving either
 // untouched when git could not be run for it. Leaving them empty is what keeps
 // backfillOne willing to try again later.
+//
+// Two git calls, and deliberately no aggregate deadline over the pair — see
+// noGitBudget, which carries the argument for every enricher path.
 func (e *metadataEnricher) adoptGitMetadata(state *session.SessionState, cwd string) {
-	branch, branchAnswered := e.git.GetBranch(cwd)
+	branch, branchAnswered := e.git.GetBranch(noGitBudget(), cwd)
 	adoptIfAnswered(&state.GitBranch, branch, branchAnswered)
-	name, nameAnswered := e.git.GetProjectName(cwd)
+	name, nameAnswered := e.git.GetProjectName(noGitBudget(), cwd)
 	adoptIfAnswered(&state.ProjectName, name, nameAnswered)
 }
 
@@ -157,6 +160,9 @@ func (e *metadataEnricher) adoptGitMetadata(state *session.SessionState, cwd str
 // content and recomputes metrics. A single transcript read serves both metrics
 // and CWD extraction, eliminating the redundant 32KB read that
 // GetCWDFromTranscript would perform.
+//
+// Up to three git calls, and deliberately no aggregate deadline over them —
+// see noGitBudget.
 func (e *metadataEnricher) RefreshOnActivity(state *session.SessionState, transcriptPath string) {
 	// Refresh metrics first — the tailer now extracts LastCWD during parsing,
 	// so we get CWD for free without a separate file read.
@@ -173,7 +179,7 @@ func (e *metadataEnricher) RefreshOnActivity(state *session.SessionState, transc
 	}
 	if cwd != "" && cwd != state.CWD {
 		state.CWD = cwd
-		branch, branchAnswered := e.git.GetBranch(cwd)
+		branch, branchAnswered := e.git.GetBranch(noGitBudget(), cwd)
 		// The session has MOVED, so what is held describes the OLD directory
 		// and #1485's "never overwrite what you already hold" does not protect
 		// it. Reporting another repo's branch is a false claim where an empty
@@ -212,7 +218,7 @@ func (e *metadataEnricher) RefreshOnActivity(state *session.SessionState, transc
 		// (retryIdleProjectResolution, capped by
 		// maxIdleProjectResolveAttempts), so it cannot be relied on to undo a
 		// blanking; that is why nothing here claims a sweep will fix it.
-		gitRoot, rootAnswered := e.git.GetGitRoot(cwd)
+		gitRoot, rootAnswered := e.git.GetGitRoot(noGitBudget(), cwd)
 		switch {
 		case !rootAnswered:
 			// Leave ProjectName exactly as it is.
@@ -289,11 +295,11 @@ func (e *metadataEnricher) backfillOne(state *session.SessionState) bool {
 	// bounded retry open; it does not promise the value will eventually
 	// arrive.
 	if state.ProjectName == "" {
-		name, answered := e.git.GetProjectName(state.CWD)
+		name, answered := e.git.GetProjectName(noGitBudget(), state.CWD)
 		updated = adoptIfAnswered(&state.ProjectName, name, answered) || updated
 	}
 	if state.GitBranch == "" {
-		branch, answered := e.git.GetBranch(state.CWD)
+		branch, answered := e.git.GetBranch(noGitBudget(), state.CWD)
 		updated = adoptIfAnswered(&state.GitBranch, branch, answered) || updated
 	}
 	return updated

--- a/core/application/services/session_detector_bornready_test.go
+++ b/core/application/services/session_detector_bornready_test.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"context"
 	"testing"
 
 	"irrlicht/core/domain/agent"
@@ -13,8 +14,8 @@ import (
 // unexpected call panics loudly rather than silently returning a zero value.
 type bornGit struct{ outbound.GitResolver }
 
-func (bornGit) GetBranch(string) (string, bool)      { return "main", true }
-func (bornGit) GetProjectName(string) (string, bool) { return "project", true }
+func (bornGit) GetBranch(context.Context, string) (string, bool)      { return "main", true }
+func (bornGit) GetProjectName(context.Context, string) (string, bool) { return "project", true }
 
 type bornLog struct{ outbound.Logger }
 

--- a/core/application/services/testhelpers_test.go
+++ b/core/application/services/testhelpers_test.go
@@ -312,17 +312,17 @@ func (l *mockLogger) errorSnapshot() []string {
 
 type mockGit struct{}
 
-func (g *mockGit) GetBranch(dir string) (string, bool) { return "main", true }
-func (g *mockGit) GetProjectName(dir string) (string, bool) {
+func (g *mockGit) GetBranch(context.Context, string) (string, bool) { return "main", true }
+func (g *mockGit) GetProjectName(_ context.Context, dir string) (string, bool) {
 	if dir == "" {
 		return "", true
 	}
 	return "project", true
 }
-func (g *mockGit) GetGitRoot(dir string) (string, bool)       { return "", true }
-func (g *mockGit) GetHeadCommit(dir string) (string, bool)    { return "", true }
-func (g *mockGit) GetBranchFromTranscript(path string) string { return "" }
-func (g *mockGit) GetCWDFromTranscript(path string) string    { return "" }
+func (g *mockGit) GetGitRoot(context.Context, string) (string, bool)    { return "", true }
+func (g *mockGit) GetHeadCommit(context.Context, string) (string, bool) { return "", true }
+func (g *mockGit) GetBranchFromTranscript(path string) string           { return "" }
+func (g *mockGit) GetCWDFromTranscript(path string) string              { return "" }
 
 // cwdGit is a mockGit whose GetCWDFromTranscript returns a fixed cwd. It
 // mimics the production fswatcher path, where EventNewSession carries no

--- a/core/application/services/yield_sweeper.go
+++ b/core/application/services/yield_sweeper.go
@@ -22,11 +22,40 @@ type yieldSessionStore interface {
 	Save(state *session.SessionState) error
 }
 
+// yieldSweepBudget is the ONE aggregate deadline covering a whole sweep: the
+// per-session repo-root resolutions and one revert scan per deduped project
+// root. Both are unbounded in the input — a user's session list and the number
+// of distinct repositories in it — and #1553 raised the revert scan's own
+// ceiling to 30s, so before #1563 a sweep's worst case was
+// `(sessions + roots) x 30s` with nothing bounding the sum.
+//
+// The value is set by what it has to fit inside, which here is the sweep's own
+// tick: DefaultYieldSweepInterval. Go's Ticker drops ticks it overruns, so a
+// sweep longer than its interval does not queue up — it silently becomes a
+// slower sweep, which is the failure being bounded. A sixth of the default
+// interval leaves five sixths of every tick free and is pinned against it by
+// TestYieldSweepBudgetFitsItsOwnTick.
+//
+// One standing limit, stated rather than left to be discovered: the relation is
+// pinned against the DEFAULT interval, and a user who configures
+// YieldSweepInterval below this budget can still have a sweep outlive its tick.
+// That is the pre-existing behaviour unchanged (before #1563 any sweep could),
+// and it is bounded rather than unbounded now, so the budget is not derived
+// from s.interval — a small configured interval would then produce a budget too
+// small to read a single repository, turning a fast tick into a sweep that
+// never finishes anything.
+const yieldSweepBudget = DefaultYieldSweepInterval / 6
+
 // yieldGitProbe is the narrow git surface the sweeper needs: resolve a repo
 // root (to dedupe projects) and list the commits a repo has reverted.
+//
+// Both take the aggregate budget explicitly, for the reason doraGitProbe's
+// methods do: the context this sweep checks its loops against and the one its
+// children run under must be the same object, not two that a wiring could let
+// disagree.
 type yieldGitProbe interface {
-	GetGitRoot(dir string) (root string, answered bool)
-	RevertedCommits(dir string) (shas []string, answered bool)
+	GetGitRoot(ctx context.Context, dir string) (root string, answered bool)
+	RevertedCommits(ctx context.Context, dir string) (shas []string, answered bool)
 }
 
 // YieldSweeper periodically correlates `git revert` commits back to the
@@ -52,8 +81,12 @@ func NewYieldSweeper(store yieldSessionStore, git yieldGitProbe, log outbound.Lo
 }
 
 // Run sweeps once at startup, then every interval until ctx is cancelled.
+//
+// ctx is passed INTO each sweep since #1563, not merely consulted between them:
+// a daemon shutting down mid-sweep now cancels the git walks in flight instead
+// of waiting out however many 30s history ceilings are left.
 func (s *YieldSweeper) Run(ctx context.Context) {
-	s.Sweep()
+	s.Sweep(ctx)
 	ticker := time.NewTicker(s.interval)
 	defer ticker.Stop()
 	for {
@@ -61,7 +94,7 @@ func (s *YieldSweeper) Run(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			s.Sweep()
+			s.Sweep(ctx)
 		}
 	}
 }
@@ -69,19 +102,30 @@ func (s *YieldSweeper) Run(ctx context.Context) {
 // Sweep runs one correlation pass and returns the number of sessions newly
 // flipped to reverted. Safe to call repeatedly; only un-reverted sessions with
 // a recorded HeadCommit are ever touched.
-func (s *YieldSweeper) Sweep() int {
+//
+// ctx bounds the whole pass at yieldSweepBudget (#1563). A sweep abandoned on
+// it flips fewer sessions and says so — every root it did not reach is counted
+// and logged as unscanned, never as scanned-and-clean, which is the #1543
+// polarity this file already had for a git that could not run. Nothing is
+// permanently lost by abandoning: the sweep is idempotent and re-runs every
+// interval, and rootDirs is a map, so Go's randomized range order means
+// successive sweeps do not deterministically starve the same roots.
+func (s *YieldSweeper) Sweep(ctx context.Context) int {
+	ctx, cancel := context.WithTimeout(ctx, yieldSweepBudget)
+	defer cancel()
+
 	sessions, err := s.store.ListAll()
 	if err != nil {
 		s.logError("failed to list sessions for yield sweep", err)
 		return 0
 	}
 
-	byCommit, rootDirs := s.indexByCommit(sessions)
+	byCommit, rootDirs := s.indexByCommit(ctx, sessions)
 	if len(byCommit) == 0 {
 		return 0
 	}
 
-	reverted := s.collectRevertedSHAs(rootDirs)
+	reverted := s.collectRevertedSHAs(ctx, rootDirs)
 	if len(reverted) == 0 {
 		return 0
 	}
@@ -92,7 +136,7 @@ func (s *YieldSweeper) Sweep() int {
 // indexByCommit indexes un-reverted, git-tracked sessions by their HEAD
 // commit, and collects one representative directory per unique repo root so
 // each project's history is scanned exactly once.
-func (s *YieldSweeper) indexByCommit(sessions []*session.SessionState) (map[string][]*session.SessionState, map[string]string) {
+func (s *YieldSweeper) indexByCommit(ctx context.Context, sessions []*session.SessionState) (map[string][]*session.SessionState, map[string]string) {
 	byCommit := make(map[string][]*session.SessionState)
 	rootDirs := make(map[string]string)
 	unresolved := 0
@@ -101,7 +145,22 @@ func (s *YieldSweeper) indexByCommit(sessions []*session.SessionState) (map[stri
 			continue
 		}
 		byCommit[st.HeadCommit] = append(byCommit[st.HeadCommit], st)
-		if !s.recordRootDir(rootDirs, st.CWD) {
+		// #1563: the loop checks the aggregate itself rather than leaving it to
+		// the children. Inheriting alone would run a doomed `rev-parse` per
+		// remaining session and report every one of them as unresolved, which
+		// is the wrong fact (we stopped looking) and is also the count this
+		// sweep logs. Indexing continues — byCommit costs no git — so a
+		// truncated sweep still flips what the roots it DID read found.
+		//
+		// The CWD test is repeated here, ahead of recordRootDir's own, so that
+		// only a session that would actually have cost a git call is counted as
+		// unresolved: an empty CWD is "nothing to look at", which an
+		// abandonment does not turn into "not looked at".
+		if st.CWD != "" && budgetSpent(ctx) {
+			unresolved++
+			continue
+		}
+		if !s.recordRootDir(ctx, rootDirs, st.CWD) {
 			unresolved++
 		}
 	}
@@ -119,11 +178,11 @@ func (s *YieldSweeper) indexByCommit(sessions []*session.SessionState) (map[stri
 // resolved is false only when the root probe never ANSWERED — a different fact
 // from "not a repo", and the one the caller counts and reports rather than
 // dropping.
-func (s *YieldSweeper) recordRootDir(rootDirs map[string]string, cwd string) (resolved bool) {
+func (s *YieldSweeper) recordRootDir(ctx context.Context, rootDirs map[string]string, cwd string) (resolved bool) {
 	if cwd == "" {
 		return true
 	}
-	root, answered := s.git.GetGitRoot(cwd)
+	root, answered := s.git.GetGitRoot(ctx, cwd)
 	if !answered {
 		// A cwd whose root never resolved never enters rootDirs, so
 		// collectRevertedSHAs — which walks that map — cannot report it. It is
@@ -151,11 +210,22 @@ func (s *YieldSweeper) recordRootDir(rootDirs map[string]string, cwd string) (re
 
 // collectRevertedSHAs gathers every reverted commit SHA across the deduped
 // project roots.
-func (s *YieldSweeper) collectRevertedSHAs(rootDirs map[string]string) map[string]bool {
+func (s *YieldSweeper) collectRevertedSHAs(ctx context.Context, rootDirs map[string]string) map[string]bool {
 	reverted := make(map[string]bool)
 	unread := 0
 	for _, dir := range rootDirs {
-		shas, answered := s.git.RevertedCommits(dir)
+		// #1563: a root abandoned on the aggregate budget is a root we declined
+		// to scan, so it joins the unread count and the log line below rather
+		// than being dropped — "we stopped looking" and "git could not be run"
+		// are different facts, but they are the same fact HERE: this sweep did
+		// not read that history and must not be counted as having found no
+		// reverts in it. The loop checks rather than inheriting, so the count is
+		// the truth instead of "every remaining root failed".
+		if budgetSpent(ctx) {
+			unread++
+			continue
+		}
+		shas, answered := s.git.RevertedCommits(ctx, dir)
 		if !answered {
 			// #1543: "git could not be run" is not "this repo has no
 			// reverts". The sweep is idempotent and re-runs every interval, so

--- a/core/application/services/yield_sweeper_test.go
+++ b/core/application/services/yield_sweeper_test.go
@@ -1,6 +1,7 @@
 package services_test
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -84,7 +85,7 @@ func TestYieldSweeper_RevertCorrelates(t *testing.T) {
 	yieldRunGit(t, dir, "revert", "--no-edit", shaA)
 
 	sw := services.NewYieldSweeper(store, git.New(), &mockLogger{}, 0)
-	if n := sw.Sweep(); n != 1 {
+	if n := sw.Sweep(context.Background()); n != 1 {
 		t.Fatalf("want 1 flip, got %d", n)
 	}
 	if got := store.get("sess-a").YieldState; got != session.YieldReverted {
@@ -108,7 +109,7 @@ func TestYieldSweeper_RevertOnUnmergedBranch(t *testing.T) {
 	}}
 
 	sw := services.NewYieldSweeper(store, git.New(), &mockLogger{}, 0)
-	if n := sw.Sweep(); n != 1 {
+	if n := sw.Sweep(context.Background()); n != 1 {
 		t.Fatalf("want 1 flip (--all counts unmerged reverts), got %d", n)
 	}
 	if got := store.get("sess-a").YieldState; got != session.YieldReverted {
@@ -123,7 +124,7 @@ func TestYieldSweeper_NonGitCWD(t *testing.T) {
 		{SessionID: "sess-x", State: session.StateReady, CWD: t.TempDir(), HeadCommit: "", YieldState: session.YieldUnknown},
 	}}
 	sw := services.NewYieldSweeper(store, git.New(), &mockLogger{}, 0)
-	if n := sw.Sweep(); n != 0 {
+	if n := sw.Sweep(context.Background()); n != 0 {
 		t.Fatalf("want 0 flips, got %d", n)
 	}
 	if got := store.get("sess-x").YieldState; got != session.YieldUnknown {
@@ -140,10 +141,10 @@ func TestYieldSweeper_Idempotent(t *testing.T) {
 		{SessionID: "sess-a", State: session.StateReady, CWD: dir, HeadCommit: shaA, YieldState: session.YieldProductive},
 	}}
 	sw := services.NewYieldSweeper(store, git.New(), &mockLogger{}, 0)
-	if n := sw.Sweep(); n != 1 {
+	if n := sw.Sweep(context.Background()); n != 1 {
 		t.Fatalf("first sweep: want 1, got %d", n)
 	}
-	if n := sw.Sweep(); n != 0 {
+	if n := sw.Sweep(context.Background()); n != 0 {
 		t.Fatalf("second sweep: want 0 (idempotent), got %d", n)
 	}
 }
@@ -158,8 +159,10 @@ type fakeYieldGit struct {
 // Always answers. The non-answer cases live in git_nonanswer_test.go, which is
 // in the INTERNAL services package because they need collectRevertedSHAs and
 // indexByCommit; a knob here would be scaffolding no test in this file sets.
-func (f *fakeYieldGit) GetGitRoot(string) (string, bool)        { return f.root, true }
-func (f *fakeYieldGit) RevertedCommits(string) ([]string, bool) { return f.reverted, true }
+func (f *fakeYieldGit) GetGitRoot(context.Context, string) (string, bool) { return f.root, true }
+func (f *fakeYieldGit) RevertedCommits(context.Context, string) ([]string, bool) {
+	return f.reverted, true
+}
 
 // 1K sessions correlated against 10K reverted SHAs must complete well under the
 // 2s DoD bar. This measures the daemon's matching cost; the `git log` scan over
@@ -184,7 +187,7 @@ func TestYieldSweeper_Performance(t *testing.T) {
 	sw := services.NewYieldSweeper(store, &fakeYieldGit{root: "/repo", reverted: reverted}, &mockLogger{}, 0)
 
 	start := time.Now()
-	flipped := sw.Sweep()
+	flipped := sw.Sweep(context.Background())
 	elapsed := time.Since(start)
 
 	if elapsed > 2*time.Second {

--- a/core/cmd/irrlichd/dora_budget_test.go
+++ b/core/cmd/irrlichd/dora_budget_test.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"irrlicht/core/adapters/outbound/git"
+	"irrlicht/core/application/services"
+	"irrlicht/core/domain/dora"
+	"irrlicht/core/domain/session"
+)
+
+// TestDoraGitBudgetCoversOneHistoryWalk is what makes services.DoraGitBudget's
+// value evidence rather than a number someone liked, and it lives HERE because
+// this is the only package that may see both sides: core/architecture_test.go
+// forbids application/services from importing an adapter, so the service that
+// owns the budget cannot read the ceiling it has to cover.
+//
+// The relation is the one thing about that value that is derived rather than
+// judged. There is no server-side write ceiling behind this handler
+// (startup.go sets WriteTimeout to 0 deliberately), so nothing bounds the
+// budget from above except what a browser will wait for — but from BELOW it is
+// pinned: an aggregate shorter than one history ceiling means a single
+// legitimate `git log` on a large repository can never complete inside it, so
+// the DORA panel is permanently blank for exactly the repositories #1553 raised
+// that ceiling for. Lowering DoraGitBudget under this line would silently undo
+// #1553 for this path while every other test stayed green.
+func TestDoraGitBudgetCoversOneHistoryWalk(t *testing.T) {
+	if services.DoraGitBudget < git.HistoryCeiling {
+		t.Errorf("services.DoraGitBudget (%v) is shorter than git.HistoryCeiling (%v): a DORA computation could "+
+			"not finish ONE commit-range walk on a repository at #1553's design point, so the panel would be "+
+			"permanently unavailable for every repository that ceiling was raised for (#1563)",
+			services.DoraGitBudget, git.HistoryCeiling)
+	}
+}
+
+// TestHandleGetHistory_DoraHonoursTheRequestContext pins the second, free bound
+// #1563 buys: the git walks run under the REQUEST's context, so a browser that
+// navigates away — or a daemon shutting down — stops them, instead of leaving
+// up to DoraGitBudget of `git log` running for a response nobody will read.
+//
+// It is asserted through the RESPONSE rather than by watching processes,
+// because that is what the budget contract already guarantees: a cancelled
+// context makes the first git call a non-answer, and #1543's polarity turns
+// that into a blank panel rather than a claim about the repository. A handler
+// wired to context.Background() computes the whole thing and answers
+// Available:true.
+func TestHandleGetHistory_DoraHonoursTheRequestContext(t *testing.T) {
+	git := fakeDoraGit{
+		tags: []dora.TagInfo{{Name: "v1.0", Epoch: 0}, {Name: "v1.1", Epoch: 14 * 86400}},
+		commitsByTag: map[string][]dora.CommitInfo{
+			"v1.0": {{Hash: "a", AuthorEpoch: 0, Body: "initial"}},
+			"v1.1": {{Hash: "b", AuthorEpoch: 14*86400 - 3600, Body: "feat: add widget"}},
+		},
+	}
+	lister := fakeYieldLister{sessions: []*session.SessionState{doraSession("s1", "alpha", "/repo/alpha")}}
+	url := "/api/v1/history?chart=dora&project=alpha&start=0&end=" + strconv.Itoa(14*86400+1)
+
+	gone, cancel := context.WithCancel(context.Background())
+	cancel()
+	req := httptest.NewRequest(http.MethodGet, url, nil).WithContext(gone)
+	rec := httptest.NewRecorder()
+	handleGetHistory(nil, lister, nil, git)(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("want 200 (an unreadable panel is a well-formed answer, not an error), got %d: %s", rec.Code, rec.Body.String())
+	}
+	var resp historyDoraResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode %q: %v", rec.Body.String(), err)
+	}
+	if resp.Available {
+		t.Errorf("the client was gone before the first git call and the handler computed DORA anyway (%+v). "+
+			"Passing context.Background() instead of r.Context() leaves the walks running for a response nobody "+
+			"reads, on a server whose WriteTimeout is deliberately 0 (#1563)", resp)
+	}
+
+	// Vacuity guard: the same fixture on a live request MUST produce a panel,
+	// or the assertion above holds for a handler that never computes anything.
+	live := httptest.NewRecorder()
+	handleGetHistory(nil, lister, nil, git)(live, httptest.NewRequest(http.MethodGet, url, nil))
+	var ok historyDoraResponse
+	if err := json.Unmarshal(live.Body.Bytes(), &ok); err != nil {
+		t.Fatalf("decode %q: %v", live.Body.String(), err)
+	}
+	if !ok.Available {
+		t.Errorf("a live request produced %+v, want an available panel — if this fails, the assertion above "+
+			"passes for a handler that always answers unavailable", ok)
+	}
+}

--- a/core/cmd/irrlichd/handlers.go
+++ b/core/cmd/irrlichd/handlers.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -442,10 +443,10 @@ func toDoraMetric(m dora.Metric) doraMetric {
 // historyGitReader is the narrow git surface chart=dora needs, matching the
 // historySessionLister convention of small per-consumer interfaces.
 type historyGitReader interface {
-	GetGitRoot(dir string) (root string, answered bool)
-	ListReleaseTags(dir string) (tags []dora.TagInfo, answered bool)
-	CommitsInRange(dir, fromRef, toRef string) (commits []dora.CommitInfo, answered bool)
-	TagContaining(dir, hash string) (tag string, answered bool)
+	GetGitRoot(ctx context.Context, dir string) (root string, answered bool)
+	ListReleaseTags(ctx context.Context, dir string) (tags []dora.TagInfo, answered bool)
+	CommitsInRange(ctx context.Context, dir, fromRef, toRef string) (commits []dora.CommitInfo, answered bool)
+	TagContaining(ctx context.Context, dir, hash string) (tag string, answered bool)
 }
 
 // serveHistoryDoraChart serves chart=dora (#951): requires exactly one
@@ -455,7 +456,16 @@ type historyGitReader interface {
 // with Available:false, not an error, mirroring
 // serveHistoryAgentsChart's nil-reader / fetchHistoryCostSeries's
 // nil-tracker empty-but-valid payload convention.
-func serveHistoryDoraChart(w http.ResponseWriter, git historyGitReader, sessions historySessionLister, project, rangeKey string, start, end int64) {
+//
+// ctx is the REQUEST's context, and passing it is half of #1563's bound: the
+// other half is services.DoraGitBudget, which this derives from it, but a
+// browser that navigates away or a daemon shutting down cancels the git walks
+// immediately rather than leaving them to run out that budget for a response
+// nobody will read. Before #1563 the git calls were rooted at
+// context.Background() inside the adapter, so neither bound existed and this
+// handler could hold a connection for `N x 30s` on a server whose WriteTimeout
+// is deliberately 0.
+func serveHistoryDoraChart(ctx context.Context, w http.ResponseWriter, git historyGitReader, sessions historySessionLister, project, rangeKey string, start, end int64) {
 	if project == "" {
 		http.Error(w, "chart=dora requires ?project=<name>", http.StatusBadRequest)
 		return
@@ -465,7 +475,7 @@ func serveHistoryDoraChart(w http.ResponseWriter, git historyGitReader, sessions
 		return
 	}
 
-	result, err := services.ComputeDoraMetrics(git, sessions, project, start, end)
+	result, err := services.ComputeDoraMetrics(ctx, git, sessions, project, start, end)
 	if err != nil {
 		http.Error(w, errInternalErrorMsg, http.StatusInternalServerError)
 		return
@@ -774,7 +784,7 @@ func handleGetHistory(tracker outbound.CostTracker, sessions historySessionListe
 		// DORA metrics are a per-project period summary, not a cost time
 		// series — handle it before the cost-tracker path (#951).
 		if hq.chart == "dora" {
-			serveHistoryDoraChart(w, git, sessions, q.Get("project"), hq.rangeKey, hq.start, hq.end)
+			serveHistoryDoraChart(r.Context(), w, git, sessions, q.Get("project"), hq.rangeKey, hq.start, hq.end)
 			return
 		}
 

--- a/core/cmd/irrlichd/history_dora_endpoint_test.go
+++ b/core/cmd/irrlichd/history_dora_endpoint_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -19,17 +20,19 @@ type fakeDoraGit struct {
 	commitsByTag map[string][]dora.CommitInfo
 }
 
-func (f fakeDoraGit) GetGitRoot(dir string) (string, bool) { return dir, true }
-func (f fakeDoraGit) ListReleaseTags(dir string) ([]dora.TagInfo, bool) {
+func (f fakeDoraGit) GetGitRoot(_ context.Context, dir string) (string, bool) { return dir, true }
+func (f fakeDoraGit) ListReleaseTags(_ context.Context, dir string) ([]dora.TagInfo, bool) {
 	if dir == "" {
 		return nil, true
 	}
 	return f.tags, true
 }
-func (f fakeDoraGit) CommitsInRange(dir, fromRef, toRef string) ([]dora.CommitInfo, bool) {
+func (f fakeDoraGit) CommitsInRange(_ context.Context, dir, fromRef, toRef string) ([]dora.CommitInfo, bool) {
 	return f.commitsByTag[toRef], true
 }
-func (f fakeDoraGit) TagContaining(dir, hash string) (string, bool) { return "", true }
+func (f fakeDoraGit) TagContaining(_ context.Context, dir, hash string) (string, bool) {
+	return "", true
+}
 
 func doraSession(id, project, cwd string) *session.SessionState {
 	return &session.SessionState{SessionID: id, State: session.StateReady, ProjectName: project, CWD: cwd}

--- a/core/e2e/e2e_helpers_test.go
+++ b/core/e2e/e2e_helpers_test.go
@@ -251,12 +251,14 @@ func (l *nopLogger) Close() error                                            { r
 
 type stubGit struct{}
 
-func (g *stubGit) GetBranch(_ string) (string, bool)        { return "main", true }
-func (g *stubGit) GetProjectName(dir string) (string, bool) { return filepath.Base(dir), true }
-func (g *stubGit) GetGitRoot(_ string) (string, bool)       { return "", true }
-func (g *stubGit) GetHeadCommit(_ string) (string, bool)    { return "", true }
-func (g *stubGit) GetBranchFromTranscript(_ string) string  { return "" }
-func (g *stubGit) GetCWDFromTranscript(_ string) string     { return "" }
+func (g *stubGit) GetBranch(context.Context, string) (string, bool) { return "main", true }
+func (g *stubGit) GetProjectName(_ context.Context, dir string) (string, bool) {
+	return filepath.Base(dir), true
+}
+func (g *stubGit) GetGitRoot(context.Context, string) (string, bool)    { return "", true }
+func (g *stubGit) GetHeadCommit(context.Context, string) (string, bool) { return "", true }
+func (g *stubGit) GetBranchFromTranscript(_ string) string              { return "" }
+func (g *stubGit) GetCWDFromTranscript(_ string) string                 { return "" }
 
 type stubMetrics struct{}
 

--- a/core/ports/outbound/ports.go
+++ b/core/ports/outbound/ports.go
@@ -143,15 +143,32 @@ type Logger interface {
 // degrades an enrichment to "unknown" and must never be written over a value
 // the caller already holds. The two transcript readers carry no such value —
 // they read files, they start no child process.
+//
+// The ctx parameter is #1563, and the rule it draws is the one a reviewer can
+// check: EVERY method here that starts a child process takes one, and the two
+// that only read files do not. It is the caller's AGGREGATE budget over a whole
+// operation, not a per-call ceiling — the adapter keeps its own ceilings and
+// derives each call under whichever is shorter — and it exists because the
+// ceiling bounded one call while callers stacked several with nothing bounding
+// the sum. An operation that stacks (services.ComputeDoraMetrics,
+// YieldSweeper.Sweep) derives one deadline and checks it at each loop head
+// itself, because an aggregate only INHERITED by the children is one no caller
+// can observe as a bound and it produces the wrong fact — "everything was
+// unreadable" where the truth is "I stopped looking".
+//
+// A caller that deliberately has no aggregate passes services.noGitBudget()
+// (or its filesystem twin) rather than a bare context, so the absence is a name
+// a reviewer can see instead of one they have to infer — the shape
+// processlifecycle's noAggregateBudget established in #1529.
 type GitResolver interface {
-	GetBranch(dir string) (branch string, answered bool)
-	GetProjectName(dir string) (name string, answered bool)
+	GetBranch(ctx context.Context, dir string) (branch string, answered bool)
+	GetProjectName(ctx context.Context, dir string) (name string, answered bool)
 	// GetGitRoot returns the absolute path of the git repo root for the given
 	// directory, or "" if the directory is not inside a git repository.
-	GetGitRoot(dir string) (root string, answered bool)
+	GetGitRoot(ctx context.Context, dir string) (root string, answered bool)
 	// GetHeadCommit returns the full SHA of the current HEAD commit for the
 	// given directory, or "" if it is not inside a git repository (#373).
-	GetHeadCommit(dir string) (sha string, answered bool)
+	GetHeadCommit(ctx context.Context, dir string) (sha string, answered bool)
 	GetBranchFromTranscript(transcriptPath string) string
 	// GetCWDFromTranscript extracts the working directory from a transcript
 	// file by scanning the first few lines for a "cwd" field.


### PR DESCRIPTION
Closes #1563

`core/adapters/outbound/git` bounded ONE `exec.CommandContext`. Callers stack
several and nothing bounded the sum — `ComputeDoraMetrics` makes
`1 + len(in-window tags) + len(revertCandidates)` on a handler served by a
server whose `WriteTimeout` is deliberately 0, and `YieldSweeper.Sweep` makes
one per session plus one per project root. #1553 raised the history ceiling to
30s and picked 30 over 60 *because* of that stacking, so this is that
decision's other half.

## Where the budget lives, and what it cost at the port boundary

At the **operation**, not in the adapter: only the caller knows how many calls
it makes and what it has to fit inside. The adapter keeps its own per-call
ceilings and gains only the ability to run *under* a caller's context.

The port cost is one rule, chosen so a reviewer can check it rather than
re-derive it per method: **every git read that starts a child process takes a
`context.Context`; the two transcript readers, which start none, do not.**
`ports/outbound.GitResolver` gains it on four methods; the four DORA/yield reads
that live only on the adapter gain it too. `architecture_test.go` is fine with
this — `ports/` already imports `context` and no import direction changes — and
`architecture_shellout_test.go` is satisfied because `run()` still derives its
own `WithTimeout` before anything reaches `exec.CommandContext`.

The context is passed **per call** rather than held by the probe, deliberately.
A scope object (`git.Within(ctx)`) would have avoided every test-fake edit, but
it makes the context an operation checks its loops against and the context its
children run under two objects that can silently disagree — the shape #1390
removed for path confinement. Passing it per call is also #1529's own spelling
(`identify(ctx, pid)`).

Each loop checks the budget **itself**. An aggregate only inherited is one no
caller can observe as a bound, and it produces the wrong fact: every remaining
tag still forks a `git log` that dies before `Start`, and the result reads
"every range was unreadable" where the truth is "I stopped after one".

## Which operations got one, and which deliberately did not

| operation | aggregate | why |
|---|---|---|
| `services.ComputeDoraMetrics` | `DoraGitBudget` = 60s | unbounded in the input; served on a request with no write ceiling behind it |
| `services.YieldSweeper.Sweep` | `yieldSweepBudget` = tick/6 | unbounded in the input (sessions x roots); must fit inside its own tick |
| `adoptGitMetadata` (2), `RefreshOnActivity` (3), `CaptureYieldOnReady` (1), `backfillOne` (3) | **none**, named | `services.noGitBudget()` |
| `filesystem.ConcurrencyTracker.resolveProject` (1, memoised) | **none**, named | `filesystem.noGitBudget()` |

The absences are named, not silent — `noGitBudget()` is `processlifecycle`'s
`noAggregateBudget` one layer over, and its doc carries three reasons: the
stack is bounded by a constant rather than the input, every call on those paths
is on the short (5s) ceiling, and they run in the detector loop where each extra
non-answer costs a field that a later pass has to re-resolve. Two package-local
helpers rather than one shared `pkg/` helper, because the shellout rule can only
resolve a *package-local* root-context helper — a shared one would create a hole
in it.

`DoraGitBudget` is also derived rather than picked, in the one direction that
has a measured number: it must be at least `git.HistoryCeiling`, or a single
legitimate history walk on a repository at #1553's design point can never
complete and the panel is permanently blank for exactly the repositories that
ceiling was raised for. That relation is pinned in `core/cmd/irrlichd` (the only
package allowed to see both sides), and `git.HistoryCeiling` is a *definition*
of `gitHistoryTimeout`, not a copy of its value.

One bound came free: `serveHistoryDoraChart` now takes `r.Context()`, so a
browser that navigates away cancels the walks instead of leaving up to 60s of
`git log` running for a response nobody will read.

## What a partially-completed DORA computation publishes

**Nothing.** Every abandonment takes the same all-or-nothing exit every other
non-answer already took: `Available:false`, all four metrics at their zero
values, and a message of its own (`this project's git history took too long to
read — try a narrower window`) because "the budget ran out" is a different fact
from "git could not be run" and the user's lever for it is different too.

This is the decision the whole change rests on. Publishing what had been
computed would mean a median lead time over the tags that happened to fit inside
the budget and a Change Failure Rate missing the reverts nobody got to — a
biased sample presented as complete, which is the failure `gitMaxOutput`'s doc
and #1553's rejection of `--since` both exist to refuse. Introducing it as a
*latency* fix would be a worse trade than the latency it removes. The mutation
below shows exactly what that looks like: `LeadTime` over 1 of 3 ranges, still
`Available:true`.

A second message where #1543 collapsed everything into one string does not
contradict #1543: its point is that a probe which never reached the repository
must not wear the message of an *answer about the repository*. This one is not
that either.

## The starvation trade (#1558's shape), stated plainly

DORA's stages run in sequence — root resolution, tag listing, one range per
in-window tag, one `tag --contains` per revert candidate — and they compete for
one budget. An early stage that runs long starves the later ones: on a
repository where the history walks are chronically slow, the revert candidates
would never be read and the panel would be permanently blank where before it was
slow-but-correct. That is exactly the shape #1553 records for the per-call
ceiling, arriving one level up.

Three things bound it and none removes it:

- **It costs availability, never correctness.** Whatever stage starves, the
  outcome is the same honest blank. #1529's herdr version had to weigh a
  deferred *recovery* of a host identity; this one cannot produce a wrong
  number, because a subset is never published.
- **It is visible where it happens.** #1558's option 2 ("count it first") is
  the right order for a background sweep nobody watches; this abandonment is
  user-visible on the very request that produced it, in the panel and in the
  JSON, so a counter would be a weaker copy of a fact already on screen. The
  yield sweep, which *is* invisible, counts and logs every root it declined to
  scan.
- **The user has a lever**, and the message names it: a narrower window means
  fewer in-window tags.

Deliberately **not** split into per-stage sub-budgets. That is #1558's option 1
and it needs evidence about the real distribution of these walks, which this
change has none of.

## Mutation evidence — every one seen red

Reverted by copy-aside/copy-back with a `diff -q` assertion each time; never
`git stash`/`restore`/`reset`.

**The first draft of the loop-check test did not redden, and the fix is
committed.** `budgetProbe` originally recorded only the calls it *answered*, so
deleting the ranges loop's own budget check left
`TestComputeDoraMetrics_ChecksTheBudgetAtEachLoopHead` **passing** — the loop
asked, the probe silently declined, and the assertion was green against a
deleted check. The probe now records every *attempt* before deciding whether to
answer, and `begin`'s doc carries that measurement.

| # | mutation | test that went red |
|---|---|---|
| M1 | delete the ranges loop's `budgetSpent` check | `TestComputeDoraMetrics_ChecksTheBudgetAtEachLoopHead` |
| M2 | abandoned sub-call records an **empty answer** and continues | `TestComputeDoraMetrics_AbandonedSequenceBlanksRatherThanPublishes` |
| M3a | delete the root loop's check | `TestResolveDoraProjectRoot_AbandonedCandidateIsANonAnswer` (call assertion) |
| M3b | abandoned root candidate reported as an **answer** | same test (message assertion) |
| M4a | delete `indexByCommit`'s check | `TestYieldSweep_StopsAtTheBudgetAndReportsWhatItDidNotRead` |
| M4b | delete `collectRevertedSHAs`' check | same test |
| M4c | abandoned root skipped **silently** (not counted unscanned) | same test |
| M6 | `run()` reports a spent budget as an answer with empty output | `TestReadUnderASpentBudgetIsANonAnswer` (all 8 methods) |
| M7 | `run()` back to `context.Background()` (pre-fix spelling) | both git-adapter budget tests |
| M8 | handler passes `context.Background()` not `r.Context()` | `TestHandleGetHistory_DoraHonoursTheRequestContext` |
| M9 | `DoraGitBudget` lowered below `git.HistoryCeiling` | `TestDoraGitBudgetCoversOneHistoryWalk` |
| M10 | `yieldSweepBudget` raised past its own tick | `TestYieldSweepBudgetFitsItsOwnTick` |

M1 and M2 **isolate** — each reddens its own test and leaves the other green,
which is what makes them two obligations rather than one.

Real output, M2 (the load-bearing one):

```
--- FAIL: TestComputeDoraMetrics_AbandonedSequenceBlanksRatherThanPublishes
    git_budget_test.go:277: two of three release ranges and the revert candidate
    were never read, and the panel published anyway: {Available:true Message:
    DeploymentFrequency:{Value:907.2 ... SampleSize:3 Available:true}
    LeadTime:{Value:0.0277... SampleSize:1 Available:true}
    ChangeFailureRate:{Value:66.66 ... Message:2 of 3 releases flagged}
    MTTR:{Value:0.277... SampleSize:2 Available:true}}. A budget that abandons
    mid-sequence and publishes what it has computes DORA over a biased subset
    and reports it as complete (#1563)
```

`LeadTime` over `SampleSize:1` where three ranges exist is the biased sample,
published as `Available:true`.

Real output, M1:

```
--- FAIL: TestComputeDoraMetrics_ChecksTheBudgetAtEachLoopHead
    git_budget_test.go:231: the budget ran out at the first commit range and the
    computation went on to make [root:/repo/sub tags range:v1.0.0 range:v1.1.0],
    want [root:/repo/sub tags range:v1.0.0]
```

Real output, M3b — the false claim the root loop's polarity prevents:

```
--- FAIL: TestResolveDoraProjectRoot_AbandonedCandidateIsANonAnswer
    git_budget_test.go:355: Message = "project not found or not a git repository",
    want "this project's git history took too long to read — try a narrower window"
```

Real output, M4c — the yield sweep's silence:

```
--- FAIL: TestYieldSweep_StopsAtTheBudgetAndReportsWhatItDidNotRead
    git_budget_test.go:415: the project roots the sweep declined to scan were not
    counted as unscanned. An unscanned root folded in as a scanned one with no
    findings is how a sweep reports 'nothing flipped' for history it never read
```

Every test asserts the **budget** (`ctx.Err()`), never a wall clock — the probe
cancels the shared context at a chosen call, so the whole new suite is instant
and nothing sleeps. Each carries a vacuity guard from the same fixture: the
sequence that fits must complete, reach every stage, publish a non-zero metric,
and be counted by nobody as abandoned.

## Verification

- `go build ./core/...` and `GOOS=linux go build ./core/...` — pass
- `go test ./core/adapters/outbound/git/... -race -count=1` and `-count=4` — pass
- `go test ./core/application/services/... ./core/domain/dora/... -race -count=1` — pass
- `go test ./core/... -race -count=1` — pass
- `tools/preflight.sh --only go` — all PASS
- `tools/preflight.sh --only arch` — PASS (ARS composite 7.92871 -> 7.92937)

## Found, not fixed

- **#1564 is untouched.** `gitMaxOutput` still binds before the ceiling for
  `CommitsInRange`; nothing here moves either bound.
- **One unreproduced full-suite failure.** The first `go test ./core/... -race
  -count=1` run after adding these tests exited non-zero, and my command piped
  through `tail -30`, which truncated the `FAIL <pkg>` line — so the package is
  **unknown**. Five subsequent full runs, plus the `go` preflight gate and the
  pre-push hook's own core-suite run, all passed. I could not identify it and am
  not claiming it is unrelated; the new tests contain no sleeps and no wall-clock
  assertions tighter than 1s, which makes them an unlikely source but is an
  argument, not evidence.
- **The yield sweep's budget is pinned against the DEFAULT interval only.** A
  user who configures `YieldSweepInterval` below `yieldSweepBudget` can still
  have a sweep outlive its tick. That is unchanged from before (any sweep could),
  and it is stated on the constant. Deriving the budget from `s.interval` was
  rejected: a small configured interval would produce a budget too small to read
  a single repository.
- **`resolveDoraProjectRoot` is a fourth unbounded stack** the issue's table did
  not list — one `rev-parse` per session of the project until one resolves. It is
  inside the DORA aggregate now and checks the budget at its loop head like the
  others.
