### PR TITLE
fix(git): stop CommitsInRange asking git for a body it will not read (#1564)

### DIFF
--- a/core/adapters/outbound/git/adapter.go
+++ b/core/adapters/outbound/git/adapter.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -78,10 +79,13 @@ const gitRevParseCmd = "rev-parse"
 // property #1543 established and #1563 deliberately did not weaken.
 const gitTimeout = 5 * time.Second
 
-// gitHistoryTimeout is the ceiling for the two shellouts that read every commit
-// MESSAGE in their range: RevertedCommits (`log --all --grep`) and
-// CommitsInRange (`log --pretty=%B`). They are the only two whose cost grows
-// with the size of the history, and #1553 is that one 5s ceiling covered both
+// gitHistoryTimeout is the ceiling for the shellouts whose cost grows with the
+// size of the history: RevertedCommits (`log --all --grep`) and CommitsInRange
+// (`log --pretty=%s` over the range, plus, only when the range holds a
+// revert-shaped commit, a `log --no-walk --pretty=%B` over that subset — #1564
+// split what was one `log --pretty=%B` call).
+//
+// #1553 is that ONE 5s ceiling covered both
 // profiles — so a repository big enough to exceed it got a permanent NON-answer
 // where before #1543 it got a correct-but-slow one, the DORA panel reading
 // "could not read this project's git history" forever and the yield sweep
@@ -175,8 +179,13 @@ const (
 	// history walks because it reads the commit graph rather than every commit
 	// message (see gitTimeout, which carries that measurement).
 	fixedCost costProfile = iota
-	// historyCost is a shellout that reads every commit MESSAGE in its range.
-	// There are exactly two and both are `git log`.
+	// historyCost is a shellout whose cost is bounded by the size of the
+	// history rather than independent of it. Three call sites, all `git log`:
+	// the two walks that read every commit MESSAGE in their range
+	// (RevertedCommits, CommitsInRange's first call), and #1564's body fetch,
+	// which reads a SUBSET of one range's messages — smaller, but bounded by
+	// the range and not by a constant, so the short ceiling would make a
+	// legitimately revert-heavy range a non-answer.
 	historyCost
 )
 
@@ -191,12 +200,30 @@ const (
 // 100k-commit repo is ~190 MB and a 1M-commit one ~1.9 GB, all buffered by
 // cmd.Output() before #1543 with nothing to stop it.
 //
-// Which of the two bounds actually binds for CommitsInRange at scale is worth
-// knowing before reading #1553 as more than it is: 64 MiB is reached at
-// ~36,000 commits in a single range at that rate, while the 30s ceiling is not
-// reached until ~1M. Raising the ceiling therefore restores RevertedCommits,
-// whose output is only the MATCHING bodies, and leaves CommitsInRange's real
-// wall where it was — #1564.
+// Which of the two bounds actually binds is worth knowing before reading #1553
+// as more than it is. For RevertedCommits it is the ceiling, and raising it
+// restored that method: its output is only the MATCHING bodies. For
+// CommitsInRange it was NOT the ceiling — at 1.9 KB/commit, 64 MiB is reached
+// at ~36,000 commits in a single range while 30s is not reached until ~1M, so
+// #1553 left that method's real wall exactly where it was. That was #1564, and
+// it is fixed at the source rather than by moving either bound: CommitsInRange
+// no longer asks for a body it will not read (see that method), which puts its
+// output at ~80 bytes/commit and the same 64 MiB at ~835,000 commits — past
+// the ceiling, so the two walls are now in the order the ceiling's own
+// reasoning assumes.
+//
+// Measured rather than extrapolated, on a 36,000-commit synthetic carrying
+// 1.9 KB messages (the rate above), same machine and git:
+//
+//	%H %at %B (until #1564)   70,659,428 bytes   1,963/commit   overflows
+//	%H %at %s (the range)      2,893,807 bytes      80/commit
+//	%B for the 360 revert-shaped commits            708,665 bytes
+//
+// What remains, stated because a wall that has moved reads as a wall that has
+// gone: the body fetch can still overflow, on a range holding ~36k
+// revert-SHAPED commits. Reaching that needs a range that already exceeded this
+// cap before #1564, so nothing that worked got worse — but the class is
+// narrowed rather than removed.
 //
 // run() reports overflow as a NON-ANSWER rather than truncating, which is the
 // opposite of cliprobe's choice and deliberately so: a truncated version banner
@@ -383,6 +410,29 @@ func (a *Adapter) binary() string {
 // about is "git could not be RUN" versus "git ran and said no", and that is
 // the line drawn here.
 func (a *Adapter) run(ctx context.Context, cost costProfile, dir string, args ...string) (out []byte, answered bool) {
+	return a.runWithInput(ctx, cost, dir, nil, args...)
+}
+
+// runWithInput is run with something on the child's stdin. Exactly one call
+// site supplies one — CommitsInRange's body fetch, which hands git a newline-
+// separated list of revisions for `log --no-walk --stdin` (#1564).
+//
+// stdin is an in-memory reader and must stay one. The nil default below is not
+// bookkeeping: a git that decided to WAIT for input would otherwise block until
+// the ceiling, which is why run() leaves it nil and says so. A finite
+// bytes.Reader cannot produce that — git reaches EOF whether or not it wanted
+// more — so this widens the surface by an amount that is bounded by the
+// argument's type rather than by a convention. A pipe fed by a goroutine, or
+// anything that can block, would not be.
+//
+// The alternative was putting the revisions on ARGV, and it was rejected on a
+// measurement rather than on taste: at 41 bytes per hash a range holding more
+// than ~25k revert-shaped commits exceeds ARG_MAX, and execve then fails before
+// Start — a non-answer for a range that reads fine TODAY. Feeding them through
+// stdin is what makes #1564 strictly better than what it replaces in every case
+// rather than better in the common one, and it is pinned by
+// TestBodyFetchPutsItsRevisionsOnStdinNotArgv.
+func (a *Adapter) runWithInput(ctx context.Context, cost costProfile, dir string, stdin io.Reader, args ...string) (out []byte, answered bool) {
 	if dir == "" {
 		// Nothing was asked, so nothing failed — the reading processTTYVia
 		// gives a non-positive pid. Deciding it here rather than at each
@@ -395,11 +445,13 @@ func (a *Adapter) run(ctx context.Context, cost costProfile, dir string, args ..
 
 	cmd := a.builder()(ctx, dir, args...)
 	cmd.WaitDelay = shellout.WaitDelay
-	// Explicit rather than load-bearing: a nil Stdin is already /dev/null, so
+	// nil for every call but one, and a nil Stdin is already /dev/null, so
 	// os/exec never hands the daemon's own stdin to the child. Spelled out so
 	// a later edit does not "helpfully" wire one up — a git that decided to
 	// prompt (a credential helper, a hook) would then block until the ceiling.
-	cmd.Stdin = nil
+	// The one exception is runWithInput's finite in-memory reader, whose doc
+	// carries why that hazard cannot arise from it.
+	cmd.Stdin = stdin
 	buf := shellout.CappedBuffer{Limit: gitMaxOutput}
 	cmd.Stdout = &buf
 	// stderr is left nil (i.e. /dev/null) rather than captured: nothing here
@@ -522,6 +574,20 @@ func (a *Adapter) ListReleaseTags(ctx context.Context, dir string) ([]dora.TagIn
 	return tags, true
 }
 
+// commitSubjectFormat and commitBodyFormat are the two shapes CommitsInRange
+// asks for. \x01/\x02 are ASCII control bytes used as record/field separators
+// — they won't collide with real commit message content, so a multi-line %B
+// body can be parsed without spawning a process per commit.
+//
+// They differ in their last field alone (%s against %B) so that one parser
+// reads both, and commitBodyFormat is character-for-character the format the
+// single-call form used until #1564 — the second call IS the old command,
+// restricted to the commits that need it.
+const (
+	commitSubjectFormat = "--pretty=format:%x01%H%x02%at%x02%s"
+	commitBodyFormat    = "--pretty=format:%x01%H%x02%at%x02%B"
+)
+
 // CommitsInRange returns the commits reachable from toRef but not fromRef
 // (fromRef empty walks toRef's entire history — for the oldest release
 // tag, which has no predecessor) (#951).
@@ -529,6 +595,36 @@ func (a *Adapter) ListReleaseTags(ctx context.Context, dir string) ([]dora.TagIn
 // answered=false is the case DORA must not average over: a partial failure is
 // worse than a total one, because a median lead time computed over the tags
 // that happened to succeed is a biased number reported as Available:true.
+//
+// It makes ONE call for the range and a second only when the range holds a
+// revert-shaped commit, which is #1564 and needs its trade stating. The single
+// %B call this replaces wrote ~1.9 KB per commit (measured on this repo), so it
+// reached gitMaxOutput at ~36k commits in one range — the oldest-tag case,
+// where fromRef is empty and the range is the whole history — and #1553's
+// raised ceiling could not help, because 30s is not reached until ~1M. Asking
+// for %s instead drops that to ~80 bytes/commit, and the bodies the one
+// consumer of them needs (dora.DetectReverts, past the subject line only for
+// dora.HasRevertSubject) come from a `--no-walk` fetch over that subset.
+//
+// The issue proposed getting them from a second `--grep`-filtered walk of the
+// same range instead, and that was MEASURED AND REJECTED. A `--grep` walk runs
+// its regex over every commit message in the range, so it costs MORE than the
+// %B walk it was meant to relieve, and worst in the ordinary case where nothing
+// matches and the regex cannot short-circuit — the same shape #1553 measured
+// for `--max-count`. On a 36k-commit synthetic with 1.9 KB messages
+// (git 2.50.1 / Apple Git-155, darwin/arm64, packed, warm cache, best of 3):
+//
+//	current  %H %at %B, one call        902ms   70,659,428 bytes  (overflows)
+//	issue    %H %at + grep ^revert     3313ms    2,000,000 + up   (3.7x slower)
+//	this     %H %at %s + no-walk        831ms    2,893,807 + 708,665 bytes
+//
+// So the split shipped here is not a trade at all on that fixture: it is
+// FASTER than what it replaces (the subject walk writes 24x less) and 20x
+// smaller, which matters under #1563's aggregate because DORA's stages compete
+// for one 60s budget and the range loop is the stage that starves the later
+// ones. The second call is skipped entirely when nothing in the range is
+// revert-shaped, and when it does run its cost is O(matching commits) — 72ms
+// for 360 of them — rather than O(range).
 func (a *Adapter) CommitsInRange(ctx context.Context, dir, fromRef, toRef string) ([]dora.CommitInfo, bool) {
 	// toRef, unlike dir, is still guarded HERE: an empty one would become an
 	// empty argv entry rather than no call at all. run() handles the dir case.
@@ -539,13 +635,77 @@ func (a *Adapter) CommitsInRange(ctx context.Context, dir, fromRef, toRef string
 	if fromRef != "" {
 		rangeSpec = fromRef + ".." + toRef
 	}
-	// \x01/\x02 are ASCII control bytes used as record/field separators —
-	// they won't collide with real commit message content, so a multi-line
-	// %B body can be parsed without spawning a process per commit.
-	out, answered := a.run(ctx, historyCost, dir, "log", "--pretty=format:%x01%H%x02%at%x02%B", rangeSpec)
+	out, answered := a.run(ctx, historyCost, dir, "log", commitSubjectFormat, rangeSpec)
 	if !answered {
 		return nil, false
 	}
+	commits := parseCommitRecords(out)
+	// %s is git's SUBJECT, which is not byte-identical to the first line of
+	// %B — it skips leading blank lines and folds a multi-line first paragraph
+	// onto one line. Both differences can only ADD a match here, never remove
+	// one (a first line that already begins with "revert" has nothing to strip
+	// and nothing to fold in front of it), so this selects a superset of the
+	// commits DetectReverts will read past the subject of. A superset costs a
+	// body nobody reads; a subset would cost a Change Failure Rate sample.
+	// TestSubjectSelectsASupersetOfTheBodySubjects pins the direction against
+	// real git.
+	var needBody []int
+	for i := range commits {
+		if dora.HasRevertSubject(commits[i].Body) {
+			needBody = append(needBody, i)
+		}
+	}
+	if len(needBody) == 0 {
+		return commits, true
+	}
+	return a.fillBodies(ctx, dir, commits, needBody)
+}
+
+// fillBodies replaces the subject in commits[i].Body with the commit's full
+// message, for each i in needBody, via one `log --no-walk` over those
+// revisions alone.
+//
+// It fails CLOSED in both of its two ways to come up short — git not answering,
+// and git answering without a commit that was asked for. The second is the one
+// worth spelling out: a revert-shaped commit left carrying only its subject
+// does not blank anything, it silently becomes an `unresolved` count in
+// DetectReverts instead of a Change Failure Rate sample, which makes the
+// number read BETTER than reality. That is the single direction this adapter's
+// doc calls worse than a blank chart (see TagContaining), so "I asked for N and
+// got N-1" is a non-answer rather than a partial one.
+func (a *Adapter) fillBodies(ctx context.Context, dir string, commits []dora.CommitInfo, needBody []int) ([]dora.CommitInfo, bool) {
+	var revs bytes.Buffer
+	revs.Grow(len(needBody) * 41)
+	for _, i := range needBody {
+		revs.WriteString(commits[i].Hash)
+		revs.WriteByte('\n')
+	}
+	// historyCost, not fixedCost: what this reads is a subset of the range's
+	// commit MESSAGES, so its cost is bounded by the history rather than
+	// independent of it — the line the two profiles are drawn on. The short
+	// ceiling would make a legitimately revert-heavy range a non-answer.
+	out, answered := a.runWithInput(ctx, historyCost, dir, &revs, "log", "--no-walk", commitBodyFormat, "--stdin")
+	if !answered {
+		return nil, false
+	}
+	bodies := make(map[string]string, len(needBody))
+	for _, c := range parseCommitRecords(out) {
+		bodies[c.Hash] = c.Body
+	}
+	for _, i := range needBody {
+		body, ok := bodies[commits[i].Hash]
+		if !ok {
+			return nil, false
+		}
+		commits[i].Body = body
+	}
+	return commits, true
+}
+
+// parseCommitRecords reads the \x01/\x02-delimited output of either format
+// above. The third field is whatever that format put there — a subject or a
+// full body — so this deliberately does not name it.
+func parseCommitRecords(out []byte) []dora.CommitInfo {
 	var commits []dora.CommitInfo
 	for _, record := range bytes.Split(out, []byte{0x01}) {
 		if len(record) == 0 {
@@ -561,7 +721,7 @@ func (a *Adapter) CommitsInRange(ctx context.Context, dir, fromRef, toRef string
 		}
 		commits = append(commits, dora.CommitInfo{Hash: string(parts[0]), AuthorEpoch: epoch, Body: string(parts[2])})
 	}
-	return commits, true
+	return commits
 }
 
 // TagContaining returns the earliest release tag (by creation date) that

--- a/core/adapters/outbound/git/adapter_test.go
+++ b/core/adapters/outbound/git/adapter_test.go
@@ -308,8 +308,17 @@ func TestCommitsInRange(t *testing.T) {
 	if len(between) != 1 || between[0].Hash != shaB {
 		t.Fatalf("v0.1.0..v0.2.0: got %+v, want just %s", between, shaB)
 	}
-	if !strings.Contains(between[0].Body, "Fixes #123.") {
-		t.Fatalf("multi-line body not preserved: %q", between[0].Body)
+	// Since #1564 an ordinary commit carries its SUBJECT, not its whole
+	// message: the range walk asks for %s, and only the revert-shaped commits
+	// — the only ones DetectReverts reads past the subject of — get a %B fetch.
+	// So the assertion this row used to make ("Fixes #123." survives) is now
+	// false BY DESIGN, and asserting the subject in its place would leave the
+	// multi-line parse this fixture exists for untested. It asserts the
+	// contract instead; the newline-bearing half is exercised where it now
+	// lives, in TestCommitsInRangeBodyContract's revert-shaped commits.
+	if between[0].Body != "add b.txt" {
+		t.Fatalf("Body = %q, want just the subject %q — dora.CommitInfo.Body carries the full "+
+			"message only for a revert-shaped commit (#1564)", between[0].Body, "add b.txt")
 	}
 
 	if got, answered := a.CommitsInRange(noBudget(), dir, "v0.2.0", "v0.2.0"); got != nil || !answered {

--- a/core/adapters/outbound/git/commitsinrange_test.go
+++ b/core/adapters/outbound/git/commitsinrange_test.go
@@ -1,0 +1,851 @@
+package git
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"irrlicht/core/domain/dora"
+)
+
+// This file covers #1564: CommitsInRange stopped asking git for a body it will
+// not read, which took its output from ~1.9 KB per commit to ~80 bytes and
+// moved the gitMaxOutput wall from ~36k commits in one range to ~835k.
+//
+// The risk that change carries is NOT a crash. It is a silently different
+// RESULT SET — a range walk that drops or duplicates a commit corrupts
+// LeadTime's median exactly the way `--since` would have, and #1553 rejected
+// that option on those grounds. So the load-bearing test here is an ORACLE:
+// the single `--pretty=%B` call this replaced, run directly against the same
+// fixture, with the adapter required to agree with it commit for commit and
+// verdict for verdict.
+//
+// MUTATION EVIDENCE is committed rather than only described. The three
+// comparisons — diffCommitSets, diffRevertVerdicts, diffBodyContract — RETURN
+// findings instead of calling t.Errorf, and
+// TestTheComparisonsCatchEveryWayTheSplitCanComeUpShort runs all three against
+// a result broken in exactly ONE way, requiring the right one to name what
+// broke and the others to stay SILENT. Those silences are half the evidence:
+// without them, seven mutations against three checks are equally satisfied by
+// three checks that report on everything. A comparison that quietly stopped
+// discriminating is indistinguishable from health, and a paragraph in a merged
+// PR body is re-run by nothing.
+//
+// The mutations applied to the PRODUCTION code (which a test in this package
+// cannot make) are in the PR body, and each is reproduced here as a row:
+// `bodiesNeverFetched` is the production `fillBodies` deleted,
+// `bodiesFetchedByTrailer` is its filter changed from the subject to the
+// trailer, and `subsetOfCommits` is the range walk returning fewer commits than
+// it read.
+//
+// One row earns its keep in a way the others do not, and it is why there are
+// three comparisons rather than two: `bodiesFetchedByTrailer` leaves both the
+// commit set and the DetectReverts verdict UNCHANGED. Only the body contract
+// sees it.
+
+// singleCallOracle is the command CommitsInRange made until #1564, verbatim.
+// It is the yardstick every set assertion below measures against: a set that
+// agrees with it is by definition the set that shipped before the split.
+func singleCallOracle(t *testing.T, dir, rangeSpec string) []dora.CommitInfo {
+	t.Helper()
+	cmd := exec.Command("git", "log", commitBodyFormat, rangeSpec)
+	cmd.Dir = dir
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("oracle `git log %s`: %v", rangeSpec, err)
+	}
+	return parseCommitRecords(out)
+}
+
+// awkwardCommit is one fixture commit: a name, so the corpus reads as a list of
+// SHAPES rather than of strings, and the message written. No row carries an
+// expected verdict — the oracle decides those, which is the whole point of
+// having one.
+type awkwardCommit struct {
+	name string
+	msg  string
+}
+
+// awkwardCommits is the fixture's shape, and every row is here because it can
+// tell a correct split from a broken one. The plain commits are the bulk a
+// dropped-commit bug hides in; the revert rows are what a subject filter can
+// miss; and the last few are the places `%s` and the first line of `%B`
+// legitimately DIFFER, which is where a superset argument either holds or does
+// not.
+var awkwardCommits = []awkwardCommit{
+	{"plain", "feat: add a thing\n\nwith a body paragraph."},
+	{"plain-no-body", "chore: tidy"},
+	{"revert-standard", "Revert \"feat: add a thing\"\n\nThis reverts commit 1111111111111111111111111111111111111111.\n"},
+	{"revert-lowercase", "revert: undo the thing\n\nThis reverts commit 2222222222222222222222222222222222222222.\n"},
+	{"revert-shouty", "REVERT the other thing\n\nThis reverts commit 3333333333333333333333333333333333333333.\n"},
+	// Revert-shaped subject, NO trailer. DetectReverts counts this as
+	// `unresolved` rather than as a candidate, and it only gets there if the
+	// body was fetched — a split that fetched bodies by grepping for the
+	// TRAILER instead of the subject would still classify it correctly by
+	// accident, so it needs the row below to be caught.
+	{"revert-no-trailer", "revert: a non-standard revert\n\nno trailer at all here."},
+	// Trailer, NOT a revert subject. DetectReverts must IGNORE it. A split
+	// that widened its filter to the trailer would fetch this body for
+	// nothing; a split that classified on the trailer would count it wrongly.
+	{"trailer-without-revert-subject", "feat: mentions a revert\n\nThis reverts commit 4444444444444444444444444444444444444444.\n"},
+	// A body LINE starting with "revert". `git log --grep=^revert` is
+	// line-anchored, so the issue's proposed second call would have matched
+	// this one; DetectReverts must not.
+	{"revert-word-in-body", "feat: something else\n\nrevert was considered and rejected."},
+	{"revert-mid-subject", "fix: do not revert this\n\nThis reverts commit 5555555555555555555555555555555555555555.\n"},
+	// Multi-line first paragraph: git folds it into ONE line for %s, so %s
+	// and the first line of %B differ here.
+	{"folded-subject", "Revert \"a subject that\nspans two lines\"\n\nThis reverts commit 6666666666666666666666666666666666666666.\n"},
+	{"folded-subject-plain", "feat: a subject that\nspans two lines\n\nbody."},
+	// Control bytes are what the record/field separators are, so a commit
+	// carrying \x02 in its body proves the parse is not confused by content.
+	{"body-with-field-separator", "chore: separators\n\nliteral \x02 in the body."},
+	{"unicode", "feat: ünïcödé sübjéct ✓\n\nbody."},
+	{"long-body", "feat: long\n\n" + strings.Repeat("filler line for a long body\n", 40)},
+}
+
+// buildAwkwardRepo commits every row of awkwardCommits, tags v0.1.0 at the
+// first and v0.2.0 at the last, and returns the repo dir.
+func buildAwkwardRepo(t *testing.T) string {
+	t.Helper()
+	dir := gitInitForTest(t)
+	for i, c := range awkwardCommits {
+		if err := os.WriteFile(filepath.Join(dir, "f.txt"), []byte(strconv.Itoa(i)), 0o644); err != nil {
+			t.Fatalf("write f.txt: %v", err)
+		}
+		runGitForTest(t, dir, "add", "f.txt")
+		// --cleanup=verbatim so git does not strip the shapes the rows exist
+		// to carry.
+		runGitForTest(t, dir, "commit", "--cleanup=verbatim", "-m", c.msg)
+		if i == 0 {
+			runGitForTest(t, dir, "tag", "v0.1.0")
+		}
+	}
+	runGitForTest(t, dir, "tag", "v0.2.0")
+	return dir
+}
+
+// TestCommitsInRangeReturnsTheSameSetAsTheSingleCallForm is #1564's central
+// obligation. Hash and AuthorEpoch must match the pre-split command exactly, in
+// order, with no commit dropped and none repeated — and dora.DetectReverts must
+// reach the SAME verdict from the adapter's commits as from the oracle's,
+// including the `unresolved` count, which is the half a set comparison alone
+// cannot see.
+func TestCommitsInRangeReturnsTheSameSetAsTheSingleCallForm(t *testing.T) {
+	t.Parallel()
+	dir := buildAwkwardRepo(t)
+	a := New()
+
+	for _, rangeSpec := range []struct{ name, from, to, spec string }{
+		{"whole history (the oldest-tag case #1564 is about)", "", "v0.2.0", "v0.2.0"},
+		{"between two tags", "v0.1.0", "v0.2.0", "v0.1.0..v0.2.0"},
+	} {
+		t.Run(rangeSpec.name, func(t *testing.T) {
+			want := singleCallOracle(t, dir, rangeSpec.spec)
+			got, answered := a.CommitsInRange(noBudget(), dir, rangeSpec.from, rangeSpec.to)
+			if !answered {
+				t.Fatal("git did not answer")
+			}
+			// Vacuity guard: a fixture that produced no commits, or only one
+			// kind of commit, would satisfy every assertion below without
+			// discriminating anything.
+			if len(want) < len(awkwardCommits)-1 {
+				t.Fatalf("the oracle read %d commits from a fixture of %d; this range is not "+
+					"exercising the corpus", len(want), len(awkwardCommits))
+			}
+			// Vacuity guard on the corpus itself: a fixture with no revert
+			// candidates AND no unresolved cannot tell a body-fetch bug from a
+			// no-op, because both checks below would be comparing zero to zero.
+			cands, unresolved := detectRevertsOver(want)
+			if len(cands) == 0 || unresolved == 0 {
+				t.Fatalf("the fixture produced %d revert candidate(s) and %d unresolved; both "+
+					"must be non-zero", len(cands), unresolved)
+			}
+			for _, finding := range diffCommitSets(got, want) {
+				t.Error(finding)
+			}
+			for _, finding := range diffRevertVerdicts(got, want) {
+				t.Error(finding)
+			}
+		})
+	}
+}
+
+// detectRevertsOver runs the domain's detector over one range's commits, under
+// a single synthetic tag and a window wide enough to hold everything — the
+// shape ComputeDoraMetrics assembles, reduced to the one range under test.
+func detectRevertsOver(commits []dora.CommitInfo) ([]dora.RevertCandidate, int) {
+	tags := []dora.TagInfo{{Name: "v0.2.0", Epoch: 1}}
+	return dora.DetectReverts(tags, map[string][]dora.CommitInfo{"v0.2.0": commits}, 0, 1<<62)
+}
+
+// diffCommitSets compares WHICH commits came back and in what order, reporting
+// a dropped commit, a repeated one and a wrong author time as different
+// findings, because they come from different bugs and only the first is
+// visible in a length comparison.
+//
+// It returns findings rather than calling t.Errorf so that
+// TestTheComparisonsCatchEveryWayTheSplitCanComeUpShort can require it to
+// SPEAK about a result known to be wrong. A check that silently stopped
+// discriminating reads exactly like a passing test.
+func diffCommitSets(got, want []dora.CommitInfo) []string {
+	var findings []string
+	if len(got) != len(want) {
+		findings = append(findings, fmt.Sprintf("got %d commits, want %d — a range walk that "+
+			"drops or duplicates commits corrupts LeadTime's median while still publishing "+
+			"Available:true", len(got), len(want)))
+	}
+	seen := map[string]int{}
+	for _, c := range got {
+		seen[c.Hash]++
+	}
+	for _, c := range got {
+		if n := seen[c.Hash]; n > 1 {
+			findings = append(findings, fmt.Sprintf("commit %s returned %d times; DORA would "+
+				"weight it %dx in the median", short(c.Hash), n, n))
+			seen[c.Hash] = 1
+		}
+	}
+	for i := range want {
+		if i >= len(got) {
+			findings = append(findings, fmt.Sprintf("commit %d (%s) is missing from the "+
+				"split's result", i, short(want[i].Hash)))
+			continue
+		}
+		if got[i].Hash != want[i].Hash {
+			findings = append(findings, fmt.Sprintf("commit %d: hash %s, want %s (order differs "+
+				"or a commit was dropped)", i, short(got[i].Hash), short(want[i].Hash)))
+			continue
+		}
+		if got[i].AuthorEpoch != want[i].AuthorEpoch {
+			findings = append(findings, fmt.Sprintf("commit %s: AuthorEpoch %d, want %d — "+
+				"LeadTime is the median over exactly this field",
+				short(want[i].Hash), got[i].AuthorEpoch, want[i].AuthorEpoch))
+		}
+	}
+	return findings
+}
+
+// diffRevertVerdicts is the half a set comparison cannot see: the same commits,
+// carrying bodies complete enough (or not) for DetectReverts to reach the same
+// verdict. `unresolved` is compared as carefully as the candidates are —
+// a revert whose body never arrived does not vanish, it MOVES from one count to
+// the other, and Change Failure Rate then reads better than reality.
+func diffRevertVerdicts(got, want []dora.CommitInfo) []string {
+	gotCands, gotUnresolved := detectRevertsOver(got)
+	wantCands, wantUnresolved := detectRevertsOver(want)
+
+	var findings []string
+	if len(gotCands) != len(wantCands) || gotUnresolved != wantUnresolved {
+		findings = append(findings, fmt.Sprintf("DetectReverts over the split read %d "+
+			"candidate(s)/%d unresolved, over the single-call form %d/%d. A revert that arrives "+
+			"carrying only its subject is not a blank chart — it silently becomes an `unresolved` "+
+			"count instead of a Change Failure Rate sample, which makes the number read BETTER "+
+			"than reality\n got: %+v\nwant: %+v",
+			len(gotCands), gotUnresolved, len(wantCands), wantUnresolved, gotCands, wantCands))
+	}
+	for i := range wantCands {
+		if i < len(gotCands) && gotCands[i] != wantCands[i] {
+			findings = append(findings, fmt.Sprintf("revert candidate %d: got %+v, want %+v",
+				i, gotCands[i], wantCands[i]))
+		}
+	}
+	return findings
+}
+
+func short(hash string) string {
+	if len(hash) > 8 {
+		return hash[:8]
+	}
+	return hash
+}
+
+// TestTheComparisonsCatchEveryWayTheSplitCanComeUpShort is this change's
+// committed mutation evidence. Each row breaks a CORRECT result in exactly one
+// way and names the comparison that must report it, a fragment of the finding
+// it must produce, and — the half that carries the discrimination — the
+// comparison that must stay SILENT.
+//
+// Three rows reproduce a mutation actually applied to the production code while
+// this was written (see the file header); the rest cover the shapes a future
+// edit could introduce.
+func TestTheComparisonsCatchEveryWayTheSplitCanComeUpShort(t *testing.T) {
+	t.Parallel()
+	dir := buildAwkwardRepo(t)
+	correct, answered := New().CommitsInRange(noBudget(), dir, "", "v0.2.0")
+	if !answered {
+		t.Fatal("git did not answer")
+	}
+
+	// The vacuity guard, and it is what makes every row below mean something:
+	// a comparison that reported unconditionally would satisfy all seven.
+	if f := diffCommitSets(correct, correct); len(f) != 0 {
+		t.Fatalf("the set comparison reported %v against a correct result", f)
+	}
+	if f := diffRevertVerdicts(correct, correct); len(f) != 0 {
+		t.Fatalf("the verdict comparison reported %v against a correct result", f)
+	}
+	if f := diffBodyContract(correct, correct); len(f) != 0 {
+		t.Fatalf("the body-contract comparison reported %v against a correct result", f)
+	}
+
+	// subjectOnly is every commit reduced to its subject line — what
+	// CommitsInRange would return with fillBodies deleted.
+	subjectOnly := func(in []dora.CommitInfo) []dora.CommitInfo {
+		out := clone(in)
+		for i := range out {
+			out[i].Body, _, _ = strings.Cut(out[i].Body, "\n")
+		}
+		return out
+	}
+
+	cases := []struct {
+		name      string
+		break_    func([]dora.CommitInfo) []dora.CommitInfo
+		bySet     string // fragment the set comparison must report ("" = must be silent)
+		byVerdict string // fragment the verdict comparison must report ("" = must be silent)
+		byBody    string // fragment the body-contract comparison must report ("" = silent)
+	}{
+		{
+			// THE mutation this change owes: a two-call form that returns a
+			// subset. #1553 rejected `--since` because a dropped commit moves
+			// LeadTime's median while still publishing Available:true.
+			name:   "subsetOfCommits: the range walk returns one commit fewer",
+			break_: func(in []dora.CommitInfo) []dora.CommitInfo { return clone(in[1:]) },
+			bySet:  "corrupts LeadTime's median",
+		},
+		{
+			name:   "dropsTheLastCommit: a truncated read",
+			break_: func(in []dora.CommitInfo) []dora.CommitInfo { return clone(in[:len(in)-1]) },
+			bySet:  "is missing from the split's result",
+		},
+		{
+			name: "duplicatesOneCommit: a merge that appends instead of replacing",
+			break_: func(in []dora.CommitInfo) []dora.CommitInfo {
+				return append(clone(in), in[0])
+			},
+			bySet: "returned 2 times",
+		},
+		{
+			name: "reordersTwo: the body fetch's order overwriting the walk's",
+			break_: func(in []dora.CommitInfo) []dora.CommitInfo {
+				out := clone(in)
+				out[0], out[1] = out[1], out[0]
+				return out
+			},
+			bySet: "order differs",
+		},
+		{
+			name: "losesAnAuthorEpoch: %at dropped from the subject format",
+			break_: func(in []dora.CommitInfo) []dora.CommitInfo {
+				out := clone(in)
+				out[0].AuthorEpoch = 0
+				return out
+			},
+			bySet: "LeadTime is the median over exactly this field",
+		},
+		{
+			// fillBodies deleted: every commit carries only its subject, so
+			// every revert loses its trailer. The set is UNCHANGED, which is
+			// exactly why the verdict comparison exists.
+			name:      "bodiesNeverFetched: fillBodies deleted",
+			break_:    subjectOnly,
+			byVerdict: "unresolved",
+			byBody:    "not fetched in full",
+		},
+		{
+			// Bodies fetched for the commits carrying the TRAILER rather than
+			// for the commits with a revert SUBJECT. This is the row that earns
+			// the third comparison, and it is the only one here that grades a
+			// shape THIS implementation cannot express — it filters on subjects
+			// it already holds, and no subject contains the trailer. What it
+			// grades is the issue's own proposed option 1, a second
+			// `--grep`-filtered walk, whose natural pattern is the trailer.
+			//
+			// It changes nothing DetectReverts can see: a revert-shaped commit
+			// with no trailer is `unresolved` whether its body was fetched or
+			// not, so the set and the verdict are both unchanged and the sole
+			// breakage is of what CommitInfo.Body promises. A future consumer of
+			// Body is who that costs, which is exactly the failure a
+			// verdict-only check licenses — and the reason the filter here asks
+			// about the subject.
+			name: "bodiesFetchedByTrailer: the filter asks the wrong question",
+			break_: func(in []dora.CommitInfo) []dora.CommitInfo {
+				out := clone(in)
+				for i := range out {
+					if dora.HasRevertSubject(out[i].Body) && !strings.Contains(out[i].Body, "This reverts commit") {
+						out[i].Body, _, _ = strings.Cut(out[i].Body, "\n")
+					}
+				}
+				return out
+			},
+			byBody: "not fetched in full",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			broken := tc.break_(correct)
+			// The harness's own guard, in the shape #1390 earned: a mutation
+			// that changed nothing makes every comparison below report about
+			// something other than the row it names.
+			if len(broken) == len(correct) && sameBodies(broken, correct) {
+				t.Fatal("this row did not actually change anything, so whatever the comparisons " +
+					"report below is not about the mutation it names")
+			}
+			assertFinding(t, "set comparison", diffCommitSets(broken, correct), tc.bySet)
+			assertFinding(t, "verdict comparison", diffRevertVerdicts(broken, correct), tc.byVerdict)
+			assertFinding(t, "body-contract comparison", diffBodyContract(broken, correct), tc.byBody)
+		})
+	}
+}
+
+// assertFinding requires the named comparison to report `fragment`, or — when
+// fragment is empty — to report nothing at all. A bare "it failed" is refused:
+// "the comparison spoke" and "THIS finding fired" are different claims, and
+// only the second is evidence the check reaches what the row names.
+func assertFinding(t *testing.T, who string, findings []string, fragment string) {
+	t.Helper()
+	joined := strings.Join(findings, "\n")
+	if fragment == "" {
+		if len(findings) != 0 {
+			t.Errorf("the %s was expected to stay silent about this mutation and reported:\n%s\n"+
+				"Two checks that both report on everything cannot tell these mutations apart",
+				who, joined)
+		}
+		return
+	}
+	if !strings.Contains(joined, fragment) {
+		t.Errorf("the %s did not report %q. It said:\n%s", who, fragment, joined)
+	}
+}
+
+func clone(in []dora.CommitInfo) []dora.CommitInfo {
+	return append([]dora.CommitInfo(nil), in...)
+}
+
+func sameBodies(a, b []dora.CommitInfo) bool {
+	for i := range a {
+		if i >= len(b) || a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// diffBodyContract is the third comparison, and the mutation corpus is what
+// shows it is not a duplicate of the other two: an adapter that fetched bodies
+// by grepping for the TRAILER instead of the subject returns the same commit
+// set AND the same DetectReverts verdict — the two checks above are both
+// silent — while leaving a revert-shaped commit carrying only its subject, in
+// breach of what dora.CommitInfo.Body promises. That is the shape a future
+// consumer of Body would be hurt by, and this is the only thing that sees it.
+//
+// The three clauses are exactly what CommitInfo.Body guarantees, no more:
+// nothing here asserts that a non-revert commit's Body is its %B, because
+// #1564's whole subject is that it is not.
+func diffBodyContract(got []dora.CommitInfo, want []dora.CommitInfo) []string {
+	full := make(map[string]string, len(want))
+	for _, c := range want {
+		full[c.Hash] = c.Body
+	}
+	var findings []string
+	for _, c := range got {
+		whole, ok := full[c.Hash]
+		if !ok {
+			continue // a foreign commit is the set comparison's finding, not this one's
+		}
+		// 1. The verdict HasRevertSubject reaches is the same one it would
+		//    reach on the complete message. This is what makes the subject a
+		//    safe stand-in for the body in the filter, and it is asserted
+		//    rather than the subject STRING, because git's %s folds a
+		//    multi-line first paragraph and so is not byte-identical to %B's
+		//    first line — only prefix-identical, which is all the filter reads.
+		if dora.HasRevertSubject(c.Body) != dora.HasRevertSubject(whole) {
+			findings = append(findings, fmt.Sprintf("commit %s: HasRevertSubject is %v over the "+
+				"body returned and %v over the complete message — the filter and the detector "+
+				"would disagree about the same commit", short(c.Hash),
+				dora.HasRevertSubject(c.Body), dora.HasRevertSubject(whole)))
+			continue
+		}
+		// 2. Nothing arrives empty when there was something to carry.
+		if c.Body == "" && whole != "" {
+			findings = append(findings, fmt.Sprintf("commit %s came back with an empty body",
+				short(c.Hash)))
+			continue
+		}
+		// 3. A revert-shaped commit carries its COMPLETE message, or its
+		//    trailer is unreadable and it silently stops being a Change
+		//    Failure Rate sample.
+		if dora.HasRevertSubject(c.Body) && trimRecordSeparator(c.Body) != trimRecordSeparator(whole) {
+			findings = append(findings, fmt.Sprintf("commit %s is revert-shaped but its body was "+
+				"not fetched in full:\n got %q\nwant %q", short(c.Hash), c.Body, whole))
+		}
+	}
+	return findings
+}
+
+// trimRecordSeparator removes the trailing newlines `--pretty=format:` leaves
+// on a body.
+//
+// `format:` SEPARATES records with a newline (where `tformat:` would terminate
+// them), and the parser attributes that newline to the body it follows — so how
+// many trailing newlines a body carries depends on its POSITION in git's
+// output, and the two calls emit their records in different orders. That is a
+// pre-existing property of this parse, not something #1564 introduced, and it is
+// read by nothing: DetectReverts cuts the subject at the first newline and
+// matches the trailer with a multi-line-anchored pattern. It is trimmed HERE
+// rather than fixed in the parser because fixing it would change the bodies the
+// single-call form returned too, which is a separate change from this one.
+func trimRecordSeparator(body string) string { return strings.TrimRight(body, "\n") }
+
+// TestCommitsInRangeBodyContract pins what dora.CommitInfo.Body now promises,
+// which is the one thing #1564 deliberately WEAKENED.
+func TestCommitsInRangeBodyContract(t *testing.T) {
+	t.Parallel()
+	dir := buildAwkwardRepo(t)
+
+	got, answered := New().CommitsInRange(noBudget(), dir, "", "v0.2.0")
+	if !answered {
+		t.Fatal("git did not answer")
+	}
+	want := singleCallOracle(t, dir, "v0.2.0")
+
+	// Vacuity guard: clause 3 is the only one that can fail for a body-fetch
+	// bug, and it never runs on a corpus holding no revert.
+	revertShaped := 0
+	for _, c := range want {
+		if dora.HasRevertSubject(c.Body) {
+			revertShaped++
+		}
+	}
+	if revertShaped == 0 {
+		t.Fatal("no commit in the fixture is revert-shaped, so the contract's third clause was " +
+			"never exercised")
+	}
+	for _, finding := range diffBodyContract(got, want) {
+		t.Error(finding)
+	}
+}
+
+// TestCommitsInRangeAsksForNoBodiesWhenNothingIsRevertShaped is the reason the
+// change is worth making at all: on the ordinary repository the body fetch does
+// not happen, so the range costs one process and ~80 bytes per commit. Without
+// this, an implementation that always made the second call would pass every
+// other test here while spending #1563's aggregate budget twice over.
+func TestCommitsInRangeAsksForNoBodiesWhenNothingIsRevertShaped(t *testing.T) {
+	t.Parallel()
+	dir := gitInitForTest(t)
+	commitFileForTest(t, dir, "a.txt", "A")
+	commitFileForTest(t, dir, "b.txt", "B")
+	runGitForTest(t, dir, "tag", "v0.1.0")
+
+	a, calls := recordingAdapter()
+	if _, answered := a.CommitsInRange(noBudget(), dir, "", "v0.1.0"); !answered {
+		t.Fatal("git did not answer")
+	}
+
+	argvs := calls.argv()
+	if len(argvs) != 1 {
+		t.Fatalf("a range holding no revert-shaped commit cost %d git processes, want 1: %v",
+			len(argvs), argvs)
+	}
+	if !slicesContains(argvs[0], commitSubjectFormat) {
+		t.Errorf("the range walk asked for %v, not %s — asking for %%B over the whole range is "+
+			"#1564 itself: ~1.9 KB per commit, and gitMaxOutput at ~36k commits",
+			argvs[0], commitSubjectFormat)
+	}
+	if slicesContains(argvs[0], commitBodyFormat) {
+		t.Errorf("the range walk asked for the full body format %s", commitBodyFormat)
+	}
+}
+
+// TestBodyFetchPutsItsRevisionsOnStdinNotArgv pins the decision recorded on
+// runWithInput. At 41 bytes per hash, a range holding more than ~25k
+// revert-shaped commits would exceed ARG_MAX, and execve fails before Start —
+// a non-answer for a range that reads fine today. On stdin there is no such
+// bound, which is what makes #1564 strictly better than what it replaces rather
+// than better in the common case.
+func TestBodyFetchPutsItsRevisionsOnStdinNotArgv(t *testing.T) {
+	t.Parallel()
+	dir := buildAwkwardRepo(t)
+
+	// What the adapter WOULD have returned, to name the commits whose bodies
+	// the fetch owes — read through the production path, since the capturing
+	// fixture below replaces the very call under inspection.
+	full, answered := New().CommitsInRange(noBudget(), dir, "", "v0.2.0")
+	if !answered {
+		t.Fatal("git did not answer")
+	}
+
+	a, calls := recordingAdapter()
+	if _, answered := a.CommitsInRange(noBudget(), dir, "", "v0.2.0"); !answered {
+		t.Fatal("git did not answer")
+	}
+	argvs := calls.argv()
+	if len(argvs) != 2 {
+		t.Fatalf("a range holding revert-shaped commits cost %d git processes, want 2: %v",
+			len(argvs), argvs)
+	}
+	if !slicesContains(argvs[1], "--stdin") || !slicesContains(argvs[1], "--no-walk") {
+		t.Errorf("the body fetch ran %v, want `log --no-walk --stdin`", argvs[1])
+	}
+	for _, c := range full {
+		for _, arg := range argvs[1] {
+			if arg == c.Hash {
+				t.Fatalf("hash %s was passed on ARGV; a revert-heavy range then dies at ARG_MAX "+
+					"with a non-answer, for a range the single-call form could read", c.Hash[:8])
+			}
+		}
+	}
+
+	// The other half: absent from argv is only good news if the revisions
+	// reached git at all. This reads what the child actually received.
+	capturing, stdinOf := capturingSecondCall(t)
+	capturing.CommitsInRange(noBudget(), dir, "", "v0.2.0")
+	fed := stdinOf()
+	if fed == "" {
+		t.Fatal("the body fetch was given no revisions on stdin either, so nothing was asked for")
+	}
+	wanted := 0
+	for _, c := range full {
+		if !dora.HasRevertSubject(c.Body) {
+			continue
+		}
+		wanted++
+		if !strings.Contains(fed, c.Hash) {
+			t.Errorf("revert-shaped commit %s was not among the revisions fed to the body fetch",
+				c.Hash[:8])
+		}
+	}
+	if wanted == 0 {
+		t.Fatal("no commit in the fixture was revert-shaped, so the loop above asserted nothing")
+	}
+}
+
+// TestBodyFetchRunsUnderTheHistoryCeiling closes the gap
+// TestEachShelloutRunsUnderTheCeilingForItsCostProfile cannot reach: that table
+// drives CommitsInRange against a child which exits at once and writes nothing,
+// so no commit is revert-shaped, the body fetch never happens, and the ceiling
+// it runs under is measured by nobody. #1564's second call is a `git log` whose
+// cost is bounded by the range rather than by a constant, so the short
+// enrichment ceiling would make a legitimately revert-heavy range a non-answer.
+func TestBodyFetchRunsUnderTheHistoryCeiling(t *testing.T) {
+	t.Parallel()
+	dir := buildAwkwardRepo(t)
+
+	a, calls := recordingAdapter()
+	if _, answered := a.CommitsInRange(noBudget(), dir, "", "v0.2.0"); !answered {
+		t.Fatal("git did not answer")
+	}
+	budgets := calls.budgets()
+	if len(budgets) != 2 {
+		t.Fatalf("measured %d child budgets, want 2; the body fetch did not run, so this test "+
+			"asserted nothing about it", len(budgets))
+	}
+	// The same vacuity guard the sibling table carries: with one value the
+	// assertion below cannot tell the two profiles apart.
+	if gitHistoryTimeout <= gitTimeout {
+		t.Fatalf("gitHistoryTimeout (%v) is not longer than gitTimeout (%v)",
+			gitHistoryTimeout, gitTimeout)
+	}
+	const tolerance = 2 * time.Second
+	if diff := gitHistoryTimeout - budgets[1]; diff < 0 || diff > tolerance {
+		t.Errorf("the body fetch ran under a %v budget, want ~%v (the enrichment ceiling is %v). "+
+			"On the short one, a range holding many revert-shaped commits becomes a non-answer "+
+			"and the DORA panel blanks", budgets[1], gitHistoryTimeout, gitTimeout)
+	}
+}
+
+// TestBodyFetchFailsClosedWhenACommitComesBackMissing is the guard that makes
+// "I asked for N and got N-1" a NON-answer instead of a partial one. It is the
+// one failure in this method that does not blank anything on its own: a
+// revert-shaped commit left carrying only its subject finds no trailer, becomes
+// an `unresolved` count, and Change Failure Rate reads BETTER than reality.
+func TestBodyFetchFailsClosedWhenACommitComesBackMissing(t *testing.T) {
+	t.Parallel()
+	dir := buildAwkwardRepo(t)
+
+	// A git whose body fetch answers with nothing at all: exit 0, empty
+	// stdout, which is what an upstream `--no-walk` that stopped resolving the
+	// revisions on stdin would look like.
+	var n int
+	var mu sync.Mutex
+	a := New()
+	real := a.execGitCmd
+	a.cmd = func(ctx context.Context, d string, args ...string) *exec.Cmd {
+		mu.Lock()
+		n++
+		second := n == 2
+		mu.Unlock()
+		if second {
+			return exec.CommandContext(ctx, "/bin/sh", "-c", "exit 0")
+		}
+		return real(ctx, d, args...)
+	}
+
+	if got, answered := a.CommitsInRange(noBudget(), dir, "", "v0.2.0"); answered {
+		t.Errorf("a body fetch that returned none of the commits it asked for was reported as an "+
+			"ANSWER, publishing %d commit(s) whose reverts are now invisible; Change Failure Rate "+
+			"then reads better than reality, the one direction this adapter calls worse than a "+
+			"blank chart", len(got))
+	}
+}
+
+// TestSubjectSelectsASupersetOfTheBodySubjects is the argument the whole split
+// rests on, checked against real git rather than reasoned about: %s is not
+// byte-identical to the first line of %B — it skips leading blank lines and
+// folds a multi-line first paragraph onto one line — and the claim is that
+// neither difference can REMOVE a match.
+//
+// The direction matters. A superset costs a body nobody reads. A subset costs a
+// Change Failure Rate sample, silently.
+func TestSubjectSelectsASupersetOfTheBodySubjects(t *testing.T) {
+	t.Parallel()
+	dir := buildAwkwardRepo(t)
+
+	subjects := singleCallOracleWith(t, dir, commitSubjectFormat, "v0.2.0")
+	bodies := singleCallOracle(t, dir, "v0.2.0")
+	if len(subjects) != len(bodies) || len(bodies) == 0 {
+		t.Fatalf("the two formats read %d and %d commits; they must read the same non-empty set",
+			len(subjects), len(bodies))
+	}
+
+	subjectMatches, bodyMatches := 0, 0
+	for i := range bodies {
+		bySubject := dora.HasRevertSubject(subjects[i].Body)
+		byBody := dora.HasRevertSubject(bodies[i].Body)
+		if bySubject {
+			subjectMatches++
+		}
+		if byBody {
+			bodyMatches++
+		}
+		if byBody && !bySubject {
+			t.Errorf("commit %s: %%B's first line is revert-shaped but %%s is not (%q vs %q). "+
+				"The adapter would not fetch its body, DetectReverts would find no trailer, and "+
+				"the revert would silently become an `unresolved` count",
+				bodies[i].Hash[:8], bodies[i].Body, subjects[i].Body)
+		}
+	}
+	// Vacuity guard, both ways: a corpus where nothing is revert-shaped
+	// satisfies the arm above, and so does one where everything is.
+	if bodyMatches == 0 || bodyMatches == len(bodies) {
+		t.Fatalf("%d of %d fixture commits are revert-shaped by %%B; the superset claim is not "+
+			"being exercised", bodyMatches, len(bodies))
+	}
+	if subjectMatches < bodyMatches {
+		t.Errorf("%%s selected %d commits and %%B's first line %d; the subject filter must never "+
+			"select fewer", subjectMatches, bodyMatches)
+	}
+}
+
+func singleCallOracleWith(t *testing.T, dir, format, rangeSpec string) []dora.CommitInfo {
+	t.Helper()
+	cmd := exec.Command("git", "log", format, rangeSpec)
+	cmd.Dir = dir
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("`git log %s %s`: %v", format, rangeSpec, err)
+	}
+	return parseCommitRecords(out)
+}
+
+// ---------------------------------------------------------------------------
+// Recording seam
+// ---------------------------------------------------------------------------
+
+// callLog records the argv of each git child, so a test can assert HOW MANY
+// processes a range cost and what each was asked for — the two facts #1564 is
+// about that no return value carries.
+type callLog struct {
+	mu        sync.Mutex
+	argvs     [][]string
+	deadlines []time.Duration
+}
+
+func (c *callLog) argv() [][]string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([][]string(nil), c.argvs...)
+}
+
+func (c *callLog) budgets() []time.Duration {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]time.Duration(nil), c.deadlines...)
+}
+
+// recordingAdapter is the production adapter with its builder wrapped: real git
+// runs, and the argv is recorded on the way through. Wrapping rather than
+// faking is deliberate — a fake git would make every assertion here a statement
+// about the fake.
+func recordingAdapter() (*Adapter, *callLog) {
+	log := &callLog{}
+	a := New()
+	build := a.execGitCmd
+	a.cmd = func(ctx context.Context, dir string, args ...string) *exec.Cmd {
+		log.mu.Lock()
+		log.argvs = append(log.argvs, append([]string(nil), args...))
+		var budget time.Duration
+		if deadline, ok := ctx.Deadline(); ok {
+			budget = time.Until(deadline)
+		}
+		log.deadlines = append(log.deadlines, budget)
+		log.mu.Unlock()
+		return build(ctx, dir, args...)
+	}
+	return a, log
+}
+
+// capturingSecondCall is the production adapter with its SECOND child replaced
+// by a shell that copies its stdin to a file. It is how a test reads what the
+// adapter actually fed git, without a production seam existing only for the
+// test: the adapter sets cmd.Stdin on whatever the builder returned, so a child
+// that drains stdin observes exactly the bytes runWithInput supplied.
+//
+// The substituted child produces no commit records, so the call it stands in
+// for reports a non-answer. That is fine and is why this is a separate fixture
+// from recordingAdapter: what it is used to assert is the INPUT, and the
+// fail-closed behaviour on an empty body fetch has its own test.
+func capturingSecondCall(t *testing.T) (*Adapter, func() string) {
+	t.Helper()
+	sink := filepath.Join(t.TempDir(), "stdin.txt")
+	var n int
+	var mu sync.Mutex
+	a := New()
+	build := a.execGitCmd
+	a.cmd = func(ctx context.Context, dir string, args ...string) *exec.Cmd {
+		mu.Lock()
+		n++
+		second := n == 2
+		mu.Unlock()
+		if second {
+			return exec.CommandContext(ctx, "/bin/sh", "-c", "cat > "+sink)
+		}
+		return build(ctx, dir, args...)
+	}
+	return a, func() string {
+		b, err := os.ReadFile(sink)
+		if err != nil {
+			return ""
+		}
+		return string(b)
+	}
+}
+
+func slicesContains(haystack []string, needle string) bool {
+	for _, s := range haystack {
+		if s == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/core/domain/dora/dora.go
+++ b/core/domain/dora/dora.go
@@ -27,8 +27,25 @@ type TagInfo struct {
 	Epoch int64
 }
 
-// CommitInfo is a single commit's hash, author-time unix epoch, and full
-// message body (subject + body, as git's %B gives it).
+// CommitInfo is a single commit's hash, author-time unix epoch, and message.
+//
+// Body is guaranteed to begin with the commit's subject and to be the complete
+// message (git's %B) for every commit HasRevertSubject reports true for. Note
+// what "the subject" means precisely: a git adapter may supply %s, which folds
+// a multi-line first paragraph onto one line and so is not byte-identical to
+// %B's first line. HasRevertSubject reaches the same verdict on both, which is
+// the property that matters and the one the adapter pins. Body is NOT
+// guaranteed to be complete for the others, and
+// that asymmetry is the whole of #1564: a range walk that streams every
+// commit's full message reaches gitMaxOutput at ~36k commits, where the only
+// consumer that reads past the subject line is DetectReverts and it reads past
+// it only for the commits HasRevertSubject selects. So the git adapter fetches
+// subjects for the range and full bodies for that subset alone.
+//
+// A new consumer that needs more than the subject of an arbitrary commit must
+// therefore widen what the adapter fetches rather than assume this field is
+// %B; the guarantee above is what it can rely on, and it is pinned by
+// TestCommitsInRangeBodyContract in the git adapter.
 type CommitInfo struct {
 	Hash        string
 	AuthorEpoch int64
@@ -84,6 +101,28 @@ var (
 // metric computed over commits the service never fetched, which is a silently
 // wrong number rather than a visible failure.
 func InWindow(epoch, from, to int64) bool { return epoch >= from && epoch <= to }
+
+// HasRevertSubject reports whether body's SUBJECT — everything up to its first
+// newline — has git's standard revert shape. It is the first of DetectReverts'
+// two conditions, and the only one that can be decided from the subject alone;
+// the second (the "This reverts commit <hash>." trailer) needs the body.
+//
+// It is exported for the same reason InWindow is, and against the same
+// failure. Since #1564 the git adapter decides, from the subject, which
+// commits it will fetch a full body for — so the adapter and DetectReverts
+// have to be asking ONE question. A second spelling that drifted would not
+// produce a slower answer: a commit whose subject the adapter no longer
+// recognised would arrive here carrying only its subject, DetectReverts would
+// find no trailer in it, and the revert would silently become an `unresolved`
+// count instead of a Change Failure Rate sample. That reads BETTER than
+// reality, which is the one direction #1543 singles out as worse than a blank.
+func HasRevertSubject(body string) bool {
+	subject := body
+	if i := strings.IndexByte(subject, '\n'); i >= 0 {
+		subject = subject[:i]
+	}
+	return revertSubjectPattern.MatchString(subject)
+}
 
 // filterRange returns the tags whose Epoch falls within [from, to].
 func filterRange(tags []TagInfo, from, to int64) []TagInfo {
@@ -186,11 +225,13 @@ func DetectHotfixes(tags []TagInfo, windowHours int, from, to int64) []ResolvedF
 func DetectReverts(tags []TagInfo, commitsByTag map[string][]CommitInfo, from, to int64) (candidates []RevertCandidate, unresolved int) {
 	for _, tag := range filterRange(tags, from, to) {
 		for _, c := range commitsByTag[tag.Name] {
-			subject := c.Body
-			if i := strings.IndexByte(subject, '\n'); i >= 0 {
-				subject = subject[:i]
-			}
-			if !revertSubjectPattern.MatchString(subject) {
+			// The same predicate the git adapter filters on, not a copy of
+			// it — see HasRevertSubject. Note the ORDER this establishes and
+			// which CommitInfo.Body's guarantee depends on: nothing below
+			// reads past the subject line until this has passed, so a commit
+			// carrying only its subject is skipped here rather than
+			// misclassified.
+			if !HasRevertSubject(c.Body) {
 				continue
 			}
 			m := revertTrailerPattern.FindStringSubmatch(c.Body)


### PR DESCRIPTION
Closes #1564

`gitMaxOutput` (64 MiB), not #1553's raised ceiling, is what stopped
`CommitsInRange` on a large history. At ~1.9 KB of commit message per commit
the cap is reached at ~36,000 commits in one range, where 30s is not reached
until ~1M — so raising the ceiling restored `RevertedCommits`, whose output is
only the matching bodies, and left this method's real wall exactly where it was.

## The numbers, re-verified before building on them

Re-measured on this repo, current `main` (git 2.50.1 / Apple Git-155,
darwin/arm64, warm cache). The issue's figures still describe the code:

| population | bytes | commits | bytes/commit |
|---|---|---|---|
| `%H %at %B`, reachable from HEAD | 2,589,072 | 1,381 | **1,874** |
| `%H %at` alone | 73,192 | 1,381 | 53 |

64 MiB / 1,874 = **35,810 commits**, confirming the issue's ~36,000. One figure
of the issue's is corrected: the reduction is **29x**, not ~40x, once the second
call's output is counted (2,589,072 → 73,192 + 16,086 here).

`gitMaxOutput`'s doc comment carried the wrong reading of #1553's result and is
corrected.

## The issue's proposed split was measured and REJECTED

The issue suggested fetching `%H%at` and getting bodies from a
`--grep`-filtered second call. A `--grep` walk runs its regex over **every
commit message in the range**, so it costs more than the `%B` walk it was meant
to relieve — and worst in the ordinary case, where nothing matches and the
regex cannot short-circuit at the first line. That is the same shape #1553
measured for `--max-count`, arriving again.

Built a `git fast-import` synthetic: 36,000 commits, one branch, ~1.9 KB
messages (this repo's measured rate), packed, warm cache, 29 MiB `.git`. Best
of 3 per row, output to `/dev/null`:

| form | wall | output |
|---|---|---|
| **current** `%H %at %B`, one call | **902 ms** | 70,659,428 bytes — *overflows* |
| **issue** `%H %at` + `--grep ^revert` | **3313 ms** | 1.9 MB + up |
| **this PR** `%H %at %s` + `--no-walk` | **831 ms** | 2,893,807 + 708,665 bytes |

Breaking the middle row down: `%H %at` alone is 713 ms, and the `--grep` walk is
**2179 ms with 62% of commits matching and 2608 ms with none** — the no-match
case is the slower one, which is the short-circuit effect and is the case real
repositories are in. So the issue's split is **3.7x slower** than what it
replaces. It also does not remove the class it targets: on that fixture the
grep call's own output was 43.8 MB, within striking distance of the same cap.

## What shipped instead

Ask for `%s` over the range (~80 bytes/commit), then fetch full bodies with
`git log --no-walk` over **only** the revert-shaped commits. Not a trade at all
on that fixture: **faster than the status quo** (831 vs 902 ms — the subject
walk writes 24x less) and 20x smaller. The second call is skipped entirely when
the range holds no revert-shaped commit, and when it runs its cost is
O(matching commits) — 72 ms for 360 — rather than O(range).

`git log --grep` is line-anchored and case-folds with `--regexp-ignore-case`
(verified against real git), which is *why* the trailer is the wrong thing to
filter on and the subject is the right one; the subject is also already in hand
from call 1, so no scan is needed to decide.

**End to end on the 36k repo, through the real `run()` and its cap:**

```
OLD single-call %B form: answered=false bytes=0 elapsed=671ms (cap=67108864)
NEW split form:          answered=true commits=36000 elapsed=877ms
commits carrying a full (>200 byte) body: 360
DetectReverts over the split: 360 candidates, 0 unresolved
```

The old form is a **non-answer** — the blank panel #1564 describes. The new one
returns every commit with its reverts intact.

New walls: the range walk's 64 MiB is reached at ~835,000 commits (past the
ceiling, so the two bounds are now in the order the ceiling's own reasoning
assumes). Stated rather than left implied — the class is **narrowed, not
removed**: the body fetch can still overflow on a range holding ~36k
revert-*shaped* commits, which needs a range that already exceeded the cap
before this change, so nothing that worked got worse.

## What it costs under #1563's aggregate

A **credit, not a debit**, which is the opposite of what the issue assumed.
`ComputeDoraMetrics` runs under `DoraGitBudget` (60s) and #1563 names the range
loop as the stage that starves the later ones. Measured, that loop now finishes
in 92% of the time it used to on a large range, so the revert-candidate stage
behind it gets *more* budget, not less.

The process count does rise, from 1 per range to at most 2 — but only for
ranges that contain a revert-shaped commit, and the extra child is ~10 ms of
spawn plus 0.2 ms per matching commit. Per-range worst-case *ceiling* exposure
goes from 30s to 60s, since each call derives its own; that only matters under
an aggregate, and the only caller of this method has a 60s one. No
`services.noGitBudget()` path calls `CommitsInRange`.

The second call runs on `historyCost` (30s), not the 5s enrichment ceiling: its
cost is bounded by the range rather than by a constant.

## Revisions go on stdin, not argv — and that is load-bearing

At 41 bytes per hash, a range with more than ~25k revert-shaped commits exceeds
`ARG_MAX`; `execve` then fails before `Start` and `shellout.Answered` reports a
**non-answer**, for a range the single-call form could have read. On stdin there
is no such bound, which is what makes this **strictly better than what it
replaces in every case** rather than better in the common one.

`run()` documents `cmd.Stdin = nil` so a later edit does not "helpfully" wire
one up — a git that WAITED for input would block until the ceiling. A finite
`bytes.Reader` cannot produce that (git reaches EOF whether or not it wanted
more), so the widening is bounded by the argument's type. `run()` keeps its
signature; `runWithInput` is the one call site.

## The domain predicate is shared, not copied

`dora.HasRevertSubject` is exported for the same reason `dora.InWindow` was in
#1553, and against the same failure: the adapter's filter and `DetectReverts`
must ask ONE question. A second spelling that drifted would not produce a
slower answer — a commit the adapter stopped recognising would arrive carrying
only its subject, find no trailer, and silently become an `unresolved` count
instead of a Change Failure Rate sample. That reads BETTER than reality, the
one direction #1543 singles out as worse than a blank.

`%s` is not byte-identical to `%B`'s first line (it folds a multi-line first
paragraph and skips leading blanks), so the filter selects a **superset** —
neither difference can remove a match. Pinned against real git by
`TestSubjectSelectsASupersetOfTheBodySubjects`.

## `dora.CommitInfo.Body` is deliberately weakened, and says so

It now guarantees: at least the subject, and the **complete** message for every
commit `HasRevertSubject` is true for. It had exactly one production consumer
(`DetectReverts`), which reads past the subject only after that test passes.
One pre-existing test asserted the old contract and is updated in place with
the reason.

## Tests

The risk here is a silently different **result set**, not a crash, so the
load-bearing test is an **oracle**: the single `--pretty=%B` call this replaces,
run directly against the same fixture, with the adapter required to agree with
it commit for commit and verdict for verdict.

The fixture is 14 commits chosen to have shape a filter bug can hide in — plain,
revert with trailer, revert without trailer (the `unresolved` case), a trailer
under a non-revert subject, a body LINE starting with "revert" (which the
issue's line-anchored `--grep` *would* have matched), a folded multi-line
subject, a literal `\x02` field separator in a body, unicode, a long body.

Three comparisons **return findings** instead of calling `t.Errorf`, so they can
be graded: `diffCommitSets`, `diffRevertVerdicts`, `diffBodyContract`.
`TestTheComparisonsCatchEveryWayTheSplitCanComeUpShort` runs all three against a
result broken in exactly ONE way and requires the right one to name what broke
**and the others to stay silent** — without those silences, seven mutations
against three checks are equally satisfied by three checks that report on
everything. Each carries the vacuity guard (all three silent on a correct
result) plus a no-op guard (a row that changed nothing fails loudly).

One row earns the third comparison and is the reason there are three rather than
two: bodies fetched by the **trailer** rather than the subject leave both the
commit set and the `DetectReverts` verdict unchanged — a revert-shaped commit
with no trailer is `unresolved` either way — and breach only what
`CommitInfo.Body` promises. It is also the only row grading a shape this
implementation cannot express (it filters on subjects it already holds); what it
grades is the issue's own option 1, whose natural `--grep` pattern is the
trailer.

### Mutation evidence — every one applied to the PRODUCTION code and seen red

Reverted by copy-aside/copy-back with a `diff -q` assertion each time, then a
`git status --porcelain` check; never `git stash`/`restore`/`reset`. Two first
drafts did not measure what they claimed and were fixed rather than reported as
passes: M2 as first written (`parseCommitRecords(out)[1:]`) **panicked** on an
empty range and aborted the test binary, so it was a crash rather than the silent
subset it names; and a "filter by trailer" mutation turned out to be
inexpressible in this implementation (no subject contains the trailer), so it
silently degenerated into M1 and was replaced by M3.

| # | mutation | tests that went red |
|---|---|---|
| M1 | `fillBodies` never called | 6, incl. the oracle, the body contract, the process-count and ceiling tests |
| M2 | the range walk silently returns a **subset** (one commit fewer) | the oracle test, **and only it** |
| M3 | the filter hand-rolled (`HasPrefix(..., "Revert \"")`) instead of `dora.HasRevertSubject` | body contract, oracle, stdin test |
| M4 | revisions on **argv** instead of stdin | `TestBodyFetchPutsItsRevisionsOnStdinNotArgv` |
| M5 | the fail-closed guard removed (a missing commit keeps its subject) | `TestBodyFetchFailsClosedWhenACommitComesBackMissing` |
| M6 | the range walk asks for `%B` again (i.e. #1564 not fixed) | `TestCommitsInRangeAsksForNoBodiesWhenNothingIsRevertShaped`, plus the updated contract row |
| M7 | the body fetch on the short (5s) enrichment ceiling | `TestBodyFetchRunsUnderTheHistoryCeiling` |

M2 is the mutation this change specifically owes — a two-call form returning a
subset, the failure `--since` was rejected for in #1553. It isolates:

```
--- FAIL: TestCommitsInRangeReturnsTheSameSetAsTheSingleCallForm/whole_history_(the_oldest-tag_case_#1564_is_about)
    commitsinrange_test.go:172: got 13 commits, want 14 — a range walk that drops or
    duplicates commits corrupts LeadTime's median while still publishing Available:true
    commitsinrange_test.go:172: commit 0: hash ade4637f, want 1894a057 (order differs
    or a commit was dropped)
```

M5, the fail-closed guard — the one failure here that blanks nothing on its own:

```
--- FAIL: TestBodyFetchFailsClosedWhenACommitComesBackMissing
    commitsinrange_test.go:688: a body fetch that returned none of the commits it asked
    for was reported as an ANSWER, publishing 14 commit(s) whose reverts are now
    invisible; Change Failure Rate then reads better than reality, the one direction
    this adapter calls worse than a blank chart
```

M7, the cost profile. `TestEachShelloutRunsUnderTheCeilingForItsCostProfile`
cannot reach the second call — it drives `CommitsInRange` against a child that
exits at once and writes nothing, so nothing is revert-shaped and the body fetch
never happens — which is why this test is new:

```
--- FAIL: TestBodyFetchRunsUnderTheHistoryCeiling
    commitsinrange_test.go:654: the body fetch ran under a 4.999993416s budget, want
    ~30s (the enrichment ceiling is 5s). On the short one, a range holding many
    revert-shaped commits becomes a non-answer and the DORA panel blanks
```

M4, the argv/ARG_MAX decision:

```
--- FAIL: TestBodyFetchPutsItsRevisionsOnStdinNotArgv
    commitsinrange_test.go:591: the body fetch ran [log --no-walk --pretty=format:… b9b7…
    9b73… bd15… 72ce… 89ce…], want `log --no-walk --stdin`
    commitsinrange_test.go:596: hash b9b79060 was passed on ARGV; a revert-heavy range
    then dies at ARG_MAX with a non-answer, for a range the single-call form could read
```

**The overflow-is-a-non-answer property is untouched.** `run()`'s
`CappedBuffer` and its `Overflowed()` arm are unchanged, both calls go through
it, and `TestFloodingChildIsBoundedAndReportsANonAnswer` /
`TestUnderTheCapIsStillAnAnswer` still pin it. This change reduces what is
buffered rather than changing what happens when the cap is hit.

## Verification

All foreground, all pass:

- `go build ./core/...` and `GOOS=linux go build ./core/...`
- `go test ./core/adapters/outbound/git/... -race -count=1` and `-count=4`
- `go test ./core/application/services/... ./core/domain/dora/... -race -count=1`
- `go test ./core/... -race -count=1`
- `tools/preflight.sh --only go` — all PASS
- `tools/preflight.sh --only arch` — PASS (ARS composite 7.929369 → 7.928494, no
  category regression)
- pre-push hook ran `--changed --budget 540`: gofmt / ARS / core tests / security
  all PASS, no `TIMEOUT`, no `NOT RUN`; `git status -sb` confirms the tracking
  branch.

## Found, not fixed

- **`--pretty=format:` SEPARATES records with a newline** (where `tformat:`
  terminates them), and `parseCommitRecords` attributes that newline to the body
  it follows — so how many trailing newlines a `Body` carries depends on its
  POSITION in git's output. Pre-existing, unchanged here, and read by nothing:
  `DetectReverts` cuts the subject at the first newline and matches the trailer
  with a multi-line-anchored pattern. It is trimmed in the test's body comparison
  rather than fixed in the parser, because fixing it would also change the bodies
  the single-call form returned — a separate change from this one. Documented on
  `trimRecordSeparator`.
- **The `--no-walk` fetch's output order is git's, not the range's.** Harmless
  because the merge is keyed by hash, but worth knowing before anyone makes the
  merge positional.
- **The residual overflow class.** A range holding ~36k revert-shaped commits can
  still overflow the body fetch. It is stated on `gitMaxOutput` rather than left
  implied, and reaching it requires a range that already failed before this
  change.
- **`gitHistoryTimeout`'s own measurements were taken on ~60-byte synthetic
  messages**, where output is negligible. This PR's fixture shows the ratio
  between the two walk kinds is very different at realistic message sizes (a
  `--grep` walk goes from *cheaper* than a `%B` walk to ~3x more expensive). The
  ceiling's stated commit-count walls are therefore optimistic for `--grep` on a
  real repository. Not adjusted here — that is a claim about `RevertedCommits`,
  which this PR does not touch — but it is the next thing to measure if that
  ceiling is revisited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
