### PR TITLE
feat(daemon): count whether the SCAN starved the client loop, per multiplexer (#1558)

### DIFF
--- a/core/adapters/inbound/agents/processlifecycle/clienthostbudget_darwin_test.go
+++ b/core/adapters/inbound/agents/processlifecycle/clienthostbudget_darwin_test.go
@@ -75,7 +75,7 @@ func TestResolveClientHostIdentity_ChecksTheBudgetBeforeEachCandidate(t *testing
 	defer cancel()
 
 	var probed []int
-	_, _ = resolveClientHostIdentityVia(ctx, []int{11, 12, 13, 14}, exhaustAt(2, cancel, &probed))
+	_, _ = resolveClientHostIdentityVia(ctx, clientLoopHerdr, []int{11, 12, 13, 14}, exhaustAt(2, cancel, &probed))
 
 	if want := []int{11, 12}; !slices.Equal(probed, want) {
 		t.Errorf("the budget ran out at candidate 2 and the loop went on to probe %v, want %v: "+
@@ -89,7 +89,7 @@ func TestResolveClientHostIdentity_ChecksTheBudgetBeforeEachCandidate(t *testing
 	probed = nil
 	stillLive, cancelLive := context.WithCancel(context.Background())
 	defer cancelLive()
-	_, _ = resolveClientHostIdentityVia(stillLive, []int{11, 12, 13, 14}, exhaustAt(0, cancelLive, &probed))
+	_, _ = resolveClientHostIdentityVia(stillLive, clientLoopHerdr, []int{11, 12, 13, 14}, exhaustAt(0, cancelLive, &probed))
 	if want := []int{11, 12, 13, 14}; !slices.Equal(probed, want) {
 		t.Errorf("with budget to spare the loop probed %v, want %v — the test above proves nothing "+
 			"if the loop truncates regardless", probed, want)
@@ -117,7 +117,7 @@ func TestResolveClientHostIdentity_AbandonedCandidateIsANonAnswer(t *testing.T) 
 	defer cancel()
 
 	var probed []int
-	host, hostKnown := resolveClientHostIdentityVia(ctx, []int{11, 12}, exhaustAt(1, cancel, &probed))
+	host, hostKnown := resolveClientHostIdentityVia(ctx, clientLoopHerdr, []int{11, 12}, exhaustAt(1, cancel, &probed))
 
 	if host != nil {
 		t.Errorf("an abandoned run named a host %+v; no candidate resolved one", host)
@@ -135,7 +135,7 @@ func TestResolveClientHostIdentity_AbandonedCandidateIsANonAnswer(t *testing.T) 
 	probed = nil
 	stillLive, cancelLive := context.WithCancel(context.Background())
 	defer cancelLive()
-	if _, hostKnown := resolveClientHostIdentityVia(stillLive, []int{11, 12}, exhaustAt(0, cancelLive, &probed)); !hostKnown {
+	if _, hostKnown := resolveClientHostIdentityVia(stillLive, clientLoopHerdr, []int{11, 12}, exhaustAt(0, cancelLive, &probed)); !hostKnown {
 		t.Error("two readable, genuinely hostless candidates read within budget is an ANSWER — " +
 			"if this fails, the assertion above passes for a loop that never says 'I looked'")
 	}

--- a/core/adapters/inbound/agents/processlifecycle/osutil_darwin.go
+++ b/core/adapters/inbound/agents/processlifecycle/osutil_darwin.go
@@ -1284,8 +1284,13 @@ const maxClientCandidates = 4
 // through the real hostIdentity and would otherwise have to name that probe
 // themselves. So the production probe is named twice, one line apart, which is
 // a drift worth knowing about and too small to be worth a seam.
-func resolveClientHostIdentity(ctx context.Context, pids []int) (*session.Launcher, bool) {
-	return resolveClientHostIdentityVia(ctx, pids, hostIdentity)
+//
+// It takes the multiplexer kind rather than naming one, because it is a
+// forwarding wrapper and which indirection this is, is the caller's fact —
+// hard-coding one here would make it a second call site claiming a kind, and
+// the whole of #1558's keying is that exactly one site claims each.
+func resolveClientHostIdentity(ctx context.Context, kind clientLoopKind, pids []int) (*session.Launcher, bool) {
+	return resolveClientHostIdentityVia(ctx, kind, pids, hostIdentity)
 }
 
 // hostIdentityProbe is the per-candidate identity read
@@ -1302,11 +1307,16 @@ type hostIdentityProbe func(ctx context.Context, pid int) (*session.Launcher, bo
 
 // resolveClientHostIdentityVia is resolveClientHostIdentity with the
 // per-candidate identity read injected.
-func resolveClientHostIdentityVia(ctx context.Context, pids []int, identify hostIdentityProbe) (*session.Launcher, bool) {
+func resolveClientHostIdentityVia(ctx context.Context, kind clientLoopKind, pids []int, identify hostIdentityProbe) (*session.Launcher, bool) {
 	readAll := len(pids) <= maxClientCandidates
 	if !readAll {
 		pids = pids[:maxClientCandidates]
 	}
+	// #1558: how many candidates THIS loop reached before the budget went, which
+	// is what separates "the scan spent it all" from "the loop spent its own
+	// share". The process-wide probed total cannot answer that — it sums over
+	// every loop and, before this change, over both multiplexers as well.
+	probedHere := 0
 	for _, pid := range pids {
 		if ctx.Err() != nil {
 			// #1529: the aggregate budget is gone and candidates are left. They
@@ -1323,11 +1333,17 @@ func resolveClientHostIdentityVia(ctx context.Context, pids []int, identify host
 			// slow-but-successful a herdr host would never resolve and nothing
 			// would say so. ONE event per loop, not one per candidate left —
 			// the break means the loop never learns how many those were.
-			observeHerdrCandidatesAbandoned()
+			//
+			// probedHere is what makes it #1558's figure rather than #1529's:
+			// zero means nothing but the scan can have spent the budget, since
+			// the scan is the only thing that ran between the WithTimeout and
+			// this check. See clientLoopStarvationRule.
+			observeClientCandidatesAbandoned(kind, probedHere)
 			readAll = false
 			break
 		}
-		observeHerdrCandidateProbed()
+		probedHere++
+		observeClientCandidateProbed(kind)
 		host, complete := identify(ctx, pid)
 		if host.HerdrPaneID != "" {
 			// A candidate that is itself a multiplexer pane has no window of
@@ -1496,7 +1512,7 @@ func resolveTmuxClientLauncherVia(socketPath string, scan clientPIDProbe, identi
 	if !probed {
 		return nil, false
 	}
-	return resolveClientHostIdentityVia(ctx, pids, identify)
+	return resolveClientHostIdentityVia(ctx, clientLoopTmux, pids, identify)
 }
 
 // clientPIDProbe is the attached-client scan resolveHerdrClientLauncherVia
@@ -1528,14 +1544,23 @@ type clientPIDProbe func(ctx context.Context, socketPath string) (pids []int, pr
 //   - The band is narrow. An lsof at its own shelloutTimeout is normally KILLED
 //     rather than slow, and a killed one is already (nil, false) via
 //     lsofProbeRan — so only the slow-and-successful window is new.
-//   - Nobody would see it. #1534 is that nothing counts probe non-answers, and
-//     that now covers budget abandonment too.
+//   - Somebody would now see it, which is the ONE of the three that changed.
+//     #1558 counts it: `client_host_loops[].starved_by_scan` in the diagnostics
+//     bundle's probes.json is exactly this case — an abandonment with no
+//     candidate probed, so nothing but the scan can have spent the budget — and
+//     it is keyed per multiplexer, because a merged figure could not say
+//     whether the ~0.3-0.45s lsof or the ~14ms `tmux list-clients` had starved.
+//     Until then the degradation was invisible by construction: #1573's
+//     abandonment scalar counted the loop spending its own share identically.
 //
 // Splitting the budget between the stages is the obvious alternative and is
-// deliberately NOT taken here: it needs evidence about the real distribution of
-// scan times, which #1529 has none of. This is the same trade #1553 records for
-// the git adapter — an unbounded call that answered slowly becomes a bounded
-// one that does not answer at all — and it is written down for the same reason.
+// deliberately still NOT taken: it needs evidence about the real distribution
+// of scan times, which #1529 has none of and which a starvation COUNT does not
+// supply either — the count says whether the case ever occurs, not what a
+// per-stage cap should be. This is the same trade #1553 records for the git
+// adapter — an unbounded call that answered slowly becomes a bounded one that
+// does not answer at all — and #1603 reached the same conclusion for DORA's
+// stages, declining a per-stage split for the same missing distribution.
 func resolveHerdrClientLauncherVia(socketPath string, scan clientPIDProbe, identify hostIdentityProbe) (*session.Launcher, bool) {
 	ctx, cancel := context.WithTimeout(context.Background(), clientHostBudget)
 	defer cancel()
@@ -1543,7 +1568,7 @@ func resolveHerdrClientLauncherVia(socketPath string, scan clientPIDProbe, ident
 	if !probed {
 		return nil, false
 	}
-	return resolveClientHostIdentityVia(ctx, pids, identify)
+	return resolveClientHostIdentityVia(ctx, clientLoopHerdr, pids, identify)
 }
 
 // clientHostCacheTTL is short enough that attaching a client is picked up by

--- a/core/adapters/inbound/agents/processlifecycle/osutil_darwin_test.go
+++ b/core/adapters/inbound/agents/processlifecycle/osutil_darwin_test.go
@@ -1337,7 +1337,7 @@ func TestResolveHostFromAncestry_ChainEndingAtInitIsAVerdict(t *testing.T) {
 	if term, hostPID, complete := resolveHostFromAncestry(noAggregateBudget(), orphan, newAncestryReads()); term != "" || hostPID != 0 || !complete {
 		t.Errorf("orphan: got (%q, %d, %v); want a completed in-loop walk that found nothing", term, hostPID, complete)
 	}
-	if _, hostKnown := resolveClientHostIdentity(noAggregateBudget(), []int{orphan}); !hostKnown {
+	if _, hostKnown := resolveClientHostIdentity(noAggregateBudget(), clientLoopHerdr, []int{orphan}); !hostKnown {
 		t.Error("a reparented candidate WAS read and has no window — that is an answer")
 	}
 }
@@ -1352,10 +1352,10 @@ func TestResolveClientHostIdentity_TruncatedCandidatesArePoisonToo(t *testing.T)
 	for i := range full {
 		full[i] = 1
 	}
-	if _, hostKnown := resolveClientHostIdentity(noAggregateBudget(), full); !hostKnown {
+	if _, hostKnown := resolveClientHostIdentity(noAggregateBudget(), clientLoopHerdr, full); !hostKnown {
 		t.Fatalf("exactly maxClientCandidates readable candidates is a complete look: %d", len(full))
 	}
-	if _, hostKnown := resolveClientHostIdentity(noAggregateBudget(), append(full, 1)); hostKnown {
+	if _, hostKnown := resolveClientHostIdentity(noAggregateBudget(), clientLoopHerdr, append(full, 1)); hostKnown {
 		t.Error("one candidate past the cap was never probed, so 'no client has a window' is unsupported")
 	}
 }
@@ -1387,7 +1387,7 @@ func TestHostIdentity_CarriesTheAncestryVerdict(t *testing.T) {
 func TestResolveClientHostIdentity_UnreadableCandidateIsNotDetached(t *testing.T) {
 	dead := exitedPID(t)
 
-	host, hostKnown := resolveClientHostIdentity(noAggregateBudget(), []int{dead})
+	host, hostKnown := resolveClientHostIdentity(noAggregateBudget(), clientLoopHerdr, []int{dead})
 
 	if host != nil {
 		t.Errorf("an unreadable candidate must not produce a host: %+v", host)
@@ -1404,7 +1404,7 @@ func TestResolveClientHostIdentity_UnreadableCandidateIsNotDetached(t *testing.T
 // ancestry walk terminates immediately and honestly (PID 1 has no parent), so
 // "no local window" here is evidence, and the answer stays an answer.
 func TestResolveClientHostIdentity_HostlessCandidateStaysDetached(t *testing.T) {
-	host, hostKnown := resolveClientHostIdentity(noAggregateBudget(), []int{1})
+	host, hostKnown := resolveClientHostIdentity(noAggregateBudget(), clientLoopHerdr, []int{1})
 
 	if host != nil {
 		t.Errorf("launchd has no window; reporting one is the #1348 misroute: %+v", host)
@@ -1423,13 +1423,13 @@ func TestResolveClientHostIdentity_OneUnreadableCandidatePoisonsTheAnswer(t *tes
 
 	// launchd first, so a loop that only remembered the FIRST candidate's
 	// verdict would answer "detached" here.
-	if _, hostKnown := resolveClientHostIdentity(noAggregateBudget(), []int{1, dead}); hostKnown {
+	if _, hostKnown := resolveClientHostIdentity(noAggregateBudget(), clientLoopHerdr, []int{1, dead}); hostKnown {
 		t.Error("one unreadable candidate makes 'no client has a window' unsupported (#1492)")
 	}
 	// launchd last, so a loop that only remembered the LAST verdict would
 	// answer "detached" here. Between them the two arms pin both spellings of
 	// "the accumulator was dropped".
-	if _, hostKnown := resolveClientHostIdentity(noAggregateBudget(), []int{dead, 1}); hostKnown {
+	if _, hostKnown := resolveClientHostIdentity(noAggregateBudget(), clientLoopHerdr, []int{dead, 1}); hostKnown {
 		t.Error("order must not change the verdict")
 	}
 }
@@ -1444,7 +1444,7 @@ func TestResolveClientHostIdentity_ResolvableCandidateStillWins(t *testing.T) {
 		"ITERM_SESSION_ID=w0t0p0-CLIENT",
 	})
 
-	host, hostKnown := resolveClientHostIdentity(noAggregateBudget(), []int{client})
+	host, hostKnown := resolveClientHostIdentity(noAggregateBudget(), clientLoopHerdr, []int{client})
 
 	if !hostKnown {
 		t.Fatal("a candidate whose own env names its host is readable by definition")
@@ -1456,7 +1456,7 @@ func TestResolveClientHostIdentity_ResolvableCandidateStillWins(t *testing.T) {
 	// The asymmetry the doc claims: a found host is evidence regardless of what
 	// the rest of the list did, so an unreadable candidate ahead of it must not
 	// poison a POSITIVE answer — only a negative one.
-	host, hostKnown = resolveClientHostIdentity(noAggregateBudget(), []int{exitedPID(t), client})
+	host, hostKnown = resolveClientHostIdentity(noAggregateBudget(), clientLoopHerdr, []int{exitedPID(t), client})
 	if !hostKnown || host == nil || host.TermProgram != "iTerm.app" {
 		t.Errorf("a resolving candidate wins outright past an unreadable one: got (%+v, %v)", host, hostKnown)
 	}

--- a/core/adapters/inbound/agents/processlifecycle/probecount.go
+++ b/core/adapters/inbound/agents/processlifecycle/probecount.go
@@ -196,38 +196,120 @@ func observeProbeMemoHit(kind probeKind) {
 	tally.memoHits.Add(1)
 }
 
-// herdrCandidates counts the two ways resolveClientHostIdentityVia's loop can
-// end for a candidate: it probed one, or it abandoned the rest on the aggregate
-// budget (#1529's clientHostBudget).
+// clientLoopKind names ONE attached-client indirection — one MULTIPLEXER, not
+// one tool and not one scan.
 //
-// This is #1558, and it is counted HERE rather than deferred because that issue
-// says so in its own words: "#1534 is that nothing counts probe non-answers,
-// and that now covers budget abandonment too, so this degradation is invisible
-// by construction", with "count it first" named as the cheapest option and the
-// measurement every other option needs.
+// Keyed for the reason probeKind is, and the failure it guards against is not
+// hypothetical here: it already happened. #1573 added these counters for herdr,
+// #1501 had already generalised the loop they sit in to a second producer, and
+// the tmux resolve therefore spent a year's worth of future evidence
+// incrementing a counter named `herdr_client_candidates_probed`. Measured
+// before this key existed: one `resolveTmuxClientLauncherVia` moved the herdr
+// figure by 2.
 //
-// It is NOT a probe row and is deliberately kept off the (kind, outcome) axis:
-// no child process is involved, so calling it "unanswered" would put a
-// different kind of fact in a column whose meaning is fixed by
-// probeOutcomeRule. It is published beside them instead.
+// The distinction is load-bearing rather than tidy, because the two scans ahead
+// of the shared loop differ by more than an order of magnitude — `tmux -S
+// <sock> list-clients` at ~14ms against an `lsof` of a herdr client log at
+// ~0.3-0.45s (clientHostBudget's own doc carries the first figure; the second
+// was re-measured at 0.44-0.48s while #1558 was being answered). clientHostBudget's
+// doc asserts that a cheap scan "leaves MORE of the budget for the candidates,
+// which is exactly the trade resolveHerdrClientLauncherVia's doc says lsof
+// loses" — i.e. it claims starvation is an lsof-side phenomenon. A merged
+// bucket cannot confirm or refute that claim, and it is the claim any decision
+// about splitting the budget per stage would rest on.
+type clientLoopKind string
+
+const (
+	// clientLoopHerdr is resolveHerdrClientLauncherVia — an `lsof` of the herdr
+	// client log, then the shared candidate loop.
+	clientLoopHerdr clientLoopKind = "herdr"
+	// clientLoopTmux is resolveTmuxClientLauncherVia (#1501) — a `tmux
+	// list-clients`, then the same loop.
+	clientLoopTmux clientLoopKind = "tmux"
+)
+
+// allClientLoopKinds is every declared multiplexer indirection, and the set
+// ClientLoopCounts reports. TestEveryClientLoopSiteDeclaresItsOwnKind grades
+// the call sites against it, so a THIRD multiplexer producer is covered by
+// existing rather than by remembering — which is precisely what #1501 did not
+// have when it reused herdr's.
+var allClientLoopKinds = []clientLoopKind{clientLoopHerdr, clientLoopTmux}
+
+// clientLoopTally is one multiplexer's three figures.
 //
-// probed is the denominator, and it is the half #1558 does not ask for. Without
-// it "12 abandoned" cannot be read at all — 12 out of 12 and 12 out of 10,000
-// are different findings and a single scalar cannot tell them apart.
-var herdrCandidates struct {
+// Atomics for the reason probeTally uses them: what these exist to observe is a
+// burst under load, and instrumentation that serializes when the events arrive
+// together would blunt the thing it measures.
+type clientLoopTally struct {
 	probed            atomic.Uint64
 	abandonedOnBudget atomic.Uint64
+	starvedByScan     atomic.Uint64
 }
 
-// observeHerdrCandidateProbed records one candidate the loop actually asked
-// about.
-func observeHerdrCandidateProbed() { herdrCandidates.probed.Add(1) }
+// clientLoopCounts maps every declared multiplexer to its tally. Built once at
+// init and never written again, exactly as probeCounts is and for the same
+// reason: adding an entry at runtime would make every read here a data race.
+var clientLoopCounts = func() map[clientLoopKind]*clientLoopTally {
+	m := make(map[clientLoopKind]*clientLoopTally, len(allClientLoopKinds))
+	for _, kind := range allClientLoopKinds {
+		m[kind] = &clientLoopTally{}
+	}
+	return m
+}()
 
-// observeHerdrCandidatesAbandoned records ONE abandonment event — the loop
+// undeclaredClientLoops counts observations naming a multiplexer nobody
+// declared, for the reason undeclaredProbes exists: dropping the observation
+// would make an uncounted loop indistinguishable from one that never ran.
+var undeclaredClientLoops atomic.Uint64
+
+// clientLoopStarvationRule records what "starved by scan" means, because that
+// is the whole of #1558 and a definition written twice is one that can describe
+// behaviour it no longer has (the bundle prints this string rather than a copy).
+//
+// The loop consults the budget before each candidate, so "the budget was
+// already gone when the loop asked about its FIRST candidate" is the only state
+// in which nothing but the scan can have spent it: between
+// context.WithTimeout(clientHostBudget) and that first check, the scan is the
+// only thing that ran. An abandonment with candidates already probed is the
+// loop spending its own share, which is a different fact with a different
+// remedy — and splitting the budget per stage, #1558's option 1, is a remedy
+// for the first only.
+const clientLoopStarvationRule = "an abandonment with ZERO candidates probed in that loop was STARVED BY THE SCAN — the scan ahead of the loop spent the whole aggregate budget (#1529/#1558); an abandonment with candidates already probed is the loop spending its own share, which a per-stage split would not fix"
+
+// observeClientCandidateProbed records one candidate the loop actually asked
+// about. It is the denominator, and it is the half #1558 does not ask for:
+// without it "12 abandoned" cannot be read at all — 12 out of 12 and 12 out of
+// 10,000 are different findings and a single scalar cannot tell them apart.
+func observeClientCandidateProbed(kind clientLoopKind) {
+	tally, declared := clientLoopCounts[kind]
+	if !declared {
+		undeclaredClientLoops.Add(1)
+		return
+	}
+	tally.probed.Add(1)
+}
+
+// observeClientCandidatesAbandoned records ONE abandonment event — the loop
 // stopping because the aggregate budget was gone — not one per candidate left
 // unread. The loop breaks on the first expired check, so it never learns how
 // many were left; counting the event is the fact it actually has.
-func observeHerdrCandidatesAbandoned() { herdrCandidates.abandonedOnBudget.Add(1) }
+//
+// probedBefore is how many candidates THIS loop had already probed. Zero is
+// #1558's starvation, and both figures are written from this one call rather
+// than from two call sites, so `starved <= abandoned` holds by construction
+// instead of by two sites agreeing — the same argument #1480 makes for deriving
+// two replay figures from one traversal.
+func observeClientCandidatesAbandoned(kind clientLoopKind, probedBefore int) {
+	tally, declared := clientLoopCounts[kind]
+	if !declared {
+		undeclaredClientLoops.Add(1)
+		return
+	}
+	tally.abandonedOnBudget.Add(1)
+	if probedBefore == 0 {
+		tally.starvedByScan.Add(1)
+	}
+}
 
 // ProbeCount is one probe kind's counters, as the diagnostics bundle reports
 // them. Exported for the composition root, which converts it into the
@@ -276,22 +358,58 @@ func ProbeCounts() []ProbeCount {
 // published rather than left to be inferred from rows that do not add up.
 func UndeclaredProbeKinds() uint64 { return undeclaredProbes.Load() }
 
-// HerdrCandidateCounts is the herdr client loop's two figures (#1558).
-type HerdrCandidateCounts struct {
-	// Probed is how many attached-client candidates the loop asked about.
-	Probed uint64
+// ClientLoopCount is one multiplexer's attached-client loop figures (#1558).
+//
+// Deliberately NOT a probe row and kept off the (kind, outcome) axis: no child
+// process is involved, so calling an abandonment "unanswered" would put a
+// different kind of fact in a column whose meaning is fixed by
+// probeOutcomeRule. It is published beside them instead.
+type ClientLoopCount struct {
+	// Multiplexer is the kind token, e.g. "herdr".
+	Multiplexer string
+	// CandidatesProbed is how many attached-client candidates this
+	// multiplexer's loop asked about — the denominator the other two are read
+	// against.
+	CandidatesProbed uint64
 	// AbandonedOnBudget is how many times the loop stopped early because
 	// clientHostBudget was already spent — one per event, not per candidate.
 	AbandonedOnBudget uint64
+	// StarvedByScan is the subset of those where the loop had probed NOTHING,
+	// i.e. the scan ahead of it spent the whole budget. This is the figure
+	// #1558 exists to obtain; see clientLoopStarvationRule.
+	StarvedByScan uint64
 }
 
-// HerdrCandidates snapshots that loop.
-func HerdrCandidates() HerdrCandidateCounts {
-	return HerdrCandidateCounts{
-		Probed:            herdrCandidates.probed.Load(),
-		AbandonedOnBudget: herdrCandidates.abandonedOnBudget.Load(),
+// ClientLoopCounts snapshots every declared multiplexer, sorted.
+//
+// Every kind is returned, including one that never ran, for the reason
+// ProbeCounts returns its zero rows: on a machine that uses only one
+// multiplexer the ZERO row is the evidence, and omitting it would leave a
+// reader unable to tell "never ran" from "this build has no such producer".
+func ClientLoopCounts() []ClientLoopCount {
+	out := make([]ClientLoopCount, 0, len(allClientLoopKinds))
+	for _, kind := range allClientLoopKinds {
+		tally := clientLoopCounts[kind]
+		out = append(out, ClientLoopCount{
+			Multiplexer:       string(kind),
+			CandidatesProbed:  tally.probed.Load(),
+			AbandonedOnBudget: tally.abandonedOnBudget.Load(),
+			StarvedByScan:     tally.starvedByScan.Load(),
+		})
 	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Multiplexer < out[j].Multiplexer })
+	return out
 }
+
+// UndeclaredClientLoopKinds is how many observations named a multiplexer nobody
+// declared. Non-zero means ClientLoopCounts is INCOMPLETE, published rather
+// than left to be inferred from rows that do not add up.
+func UndeclaredClientLoopKinds() uint64 { return undeclaredClientLoops.Load() }
+
+// ClientLoopStarvationRule is clientLoopStarvationRule, exported so the
+// diagnostics bundle prints the definition the numbers were produced by rather
+// than a second copy of it written in the application layer.
+func ClientLoopStarvationRule() string { return clientLoopStarvationRule }
 
 // ProbeOutcomeRule is probeOutcomeRule, exported so the diagnostics bundle
 // prints the definition it is actually counting by rather than a second copy

--- a/core/adapters/inbound/agents/processlifecycle/probecount_darwin_test.go
+++ b/core/adapters/inbound/agents/processlifecycle/probecount_darwin_test.go
@@ -132,45 +132,94 @@ func TestBundleIDMemoHitIsCounted(t *testing.T) {
 	}, "#1544's hand-back: a memo hides how often the probe RUNS, so a hit is its own outcome rather than an unreported one")
 }
 
-// TestHerdrCandidateAbandonmentIsCounted is #1558 inside #1534.
+// TestClientCandidateAbandonmentIsCounted is #1558 inside #1534.
 //
 // The loop's budget break produces the same (nil, false) a failed lsof
 // produces, so on a machine where the scan is chronically slow-but-successful a
 // herdr host would never resolve and nothing anywhere would say why. The
 // probed figure is the denominator: without it "12 abandoned" cannot be read.
-func TestHerdrCandidateAbandonmentIsCounted(t *testing.T) {
+// The three arms are the three things a reader of the bundle needs to be able
+// to tell apart, and only the first two existed before #1558: a loop that ran
+// to the end, a loop the SCAN starved, and a loop that spent its own share.
+// The third is the discriminating one — it is an abandonment too, and the
+// published pair could not distinguish it from the second, so "how often does
+// the scan starve the loop" had no answer in a bundle.
+func TestClientCandidateAbandonmentIsCounted(t *testing.T) {
 	identify := func(ctx context.Context, pid int) (*session.Launcher, bool) {
 		return &session.Launcher{}, true
 	}
 
 	t.Run("a live budget probes every candidate and abandons none", func(t *testing.T) {
-		before := HerdrCandidates()
-		if _, readAll := resolveClientHostIdentityVia(context.Background(), []int{11, 12}, identify); !readAll {
+		before := readClientLoopLedger()
+		if _, readAll := resolveClientHostIdentityVia(context.Background(), clientLoopHerdr, []int{11, 12}, identify); !readAll {
 			t.Fatal("every candidate was read and none has a host: that is an ANSWER (#1492)")
 		}
-		got := HerdrCandidates()
-		if probed := got.Probed - before.Probed; probed != 2 {
-			t.Errorf("probed moved by %d, want 2 — the denominator must count what the loop actually asked about", probed)
-		}
-		if abandoned := got.AbandonedOnBudget - before.AbandonedOnBudget; abandoned != 0 {
-			t.Errorf("abandoned moved by %d, want 0 — a loop that ran to the end abandoned nothing, and a counter that fires anyway measures nothing", abandoned)
-		}
+		assertClientLoopsMoved(t, before, map[string]ClientLoopCount{
+			"herdr": {Multiplexer: "herdr", CandidatesProbed: 2},
+		}, "a loop that ran to the end abandoned nothing and starved on nothing; a counter that fires anyway measures nothing")
 	})
 
-	t.Run("a spent budget abandons once and probes nothing", func(t *testing.T) {
+	t.Run("a budget already spent when the loop starts was STARVED BY THE SCAN", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
 
-		before := HerdrCandidates()
-		if _, readAll := resolveClientHostIdentityVia(ctx, []int{11, 12}, identify); readAll {
+		before := readClientLoopLedger()
+		if _, readAll := resolveClientHostIdentityVia(ctx, clientLoopHerdr, []int{11, 12}, identify); readAll {
 			t.Fatal("candidates we declined to look at must poison the answer (#1529)")
 		}
-		got := HerdrCandidates()
-		if abandoned := got.AbandonedOnBudget - before.AbandonedOnBudget; abandoned != 1 {
-			t.Errorf("abandoned moved by %d, want 1 — one event per loop, not one per candidate left unread", abandoned)
-		}
-		if probed := got.Probed - before.Probed; probed != 0 {
-			t.Errorf("probed moved by %d, want 0 — the loop broke before asking about anything", probed)
-		}
+		assertClientLoopsMoved(t, before, map[string]ClientLoopCount{
+			"herdr": {Multiplexer: "herdr", AbandonedOnBudget: 1, StarvedByScan: 1},
+		}, "the loop broke before asking about anything, so nothing but the scan can have spent the budget — "+
+			"ONE event per loop, not one per candidate left unread (#1558)")
 	})
+
+	t.Run("a budget the LOOP spent is an abandonment and is starved by nobody", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		var probed []int
+		before := readClientLoopLedger()
+		if _, readAll := resolveClientHostIdentityVia(ctx, clientLoopHerdr, []int{11, 12, 13, 14}, exhaustAt(2, cancel, &probed)); readAll {
+			t.Fatal("candidates we declined to look at must poison the answer (#1529)")
+		}
+		assertClientLoopsMoved(t, before, map[string]ClientLoopCount{
+			"herdr": {Multiplexer: "herdr", CandidatesProbed: 2, AbandonedOnBudget: 1},
+		}, "this loop probed two candidates and then ran out of budget on its own — it is an abandonment, "+
+			"and counting it as starved would report the scan for time the CANDIDATES spent. Splitting the "+
+			"budget per stage (#1558 option 1) would not help this case at all, which is why the two must "+
+			"be separate figures")
+	})
+}
+
+// TestEachMultiplexerCountsUnderItsOwnKind is #1558's other half, and the
+// failure it pins already shipped rather than being imagined.
+//
+// #1501 generalised the candidate loop to a second producer; #1573 then added
+// these counters keyed to nothing, named `herdr_client_candidates_*`. So every
+// tmux resolve incremented herdr's figures, and a bundle showing starvation
+// could not say whether the ~0.3-0.45s `lsof` or the ~14ms `tmux list-clients`
+// had starved it — which is precisely the comparison any decision about
+// splitting the budget would rest on.
+//
+// It drives the two PRODUCTION resolves rather than the shared loop, because
+// what is being pinned is which kind each producer passes; a test that called
+// the loop with a kind of its own would assert nothing about the wiring.
+func TestEachMultiplexerCountsUnderItsOwnKind(t *testing.T) {
+	identify := func(ctx context.Context, pid int) (*session.Launcher, bool) {
+		return &session.Launcher{}, true
+	}
+	scan := func(ctx context.Context, _ string) ([]int, bool) { return []int{11, 12}, true }
+
+	before := readClientLoopLedger()
+	_, _ = resolveHerdrClientLauncherVia("/tmp/irrlicht-1558/herdr.sock", scan, identify)
+	assertClientLoopsMoved(t, before, map[string]ClientLoopCount{
+		"herdr": {Multiplexer: "herdr", CandidatesProbed: 2},
+	}, "the herdr indirection must count under herdr and move no other multiplexer's row")
+
+	before = readClientLoopLedger()
+	_, _ = resolveTmuxClientLauncherVia("/private/tmp/tmux-501/default", scan, identify)
+	assertClientLoopsMoved(t, before, map[string]ClientLoopCount{
+		"tmux": {Multiplexer: "tmux", CandidatesProbed: 2},
+	}, "the tmux indirection must count under tmux: it spent #1501-to-#1558 incrementing a figure named "+
+		"`herdr_client_candidates_probed`, which is the shared-bucket defect #1534's per-call-site rule exists to prevent")
 }

--- a/core/adapters/inbound/agents/processlifecycle/probecount_test.go
+++ b/core/adapters/inbound/agents/processlifecycle/probecount_test.go
@@ -33,9 +33,9 @@ import (
 // defers parallel tests until the serial ones have finished, so a serial delta
 // cannot overlap the package's real-ceiling shellout tests.
 
-// probeLedger is one reading of every per-probe counter. The herdr figures are
-// deliberately not in it: they are not on the (kind, outcome) axis, and folding
-// them in would let a probe assertion vouch for a herdr one.
+// probeLedger is one reading of every per-probe counter. The client-loop
+// figures are deliberately not in it: they are not on the (kind, outcome) axis,
+// and folding them in would let a probe assertion vouch for a client-loop one.
 type probeLedger struct {
 	rows map[string]ProbeCount
 }
@@ -255,6 +255,254 @@ func TestProbeCountsReportsEveryDeclaredKind(t *testing.T) {
 	if !sort.SliceIsSorted(rows, func(i, j int) bool { return rows[i].Probe < rows[j].Probe }) {
 		t.Errorf("ProbeCounts is unsorted: %v — two captures of the same daemon must diff cleanly", rows)
 	}
+}
+
+// --- #1558's attached-client loop counters ---------------------------------
+//
+// The mechanism half, platform-neutral. The loop these describe is darwin-only,
+// so what the runtime tests beside it (probecount_darwin_test.go) cannot cover
+// on another platform is covered here by driving the observers directly — and
+// the source scan below is deliberately here too, because parsePackageSources
+// ignores build tags and a gate that only runs on darwin is a gate whose
+// absence on linux reads as a pass.
+
+// clientLoopLedger is one reading of every per-multiplexer counter. Separate
+// from probeLedger for the reason stated on it: two different axes, and one
+// ledger would let an assertion about one vouch for the other.
+type clientLoopLedger struct {
+	rows map[string]ClientLoopCount
+}
+
+// readClientLoopLedger snapshots the per-multiplexer counters.
+func readClientLoopLedger() clientLoopLedger {
+	l := clientLoopLedger{rows: map[string]ClientLoopCount{}}
+	for _, row := range ClientLoopCounts() {
+		l.rows[row.Multiplexer] = row
+	}
+	return l
+}
+
+// clientLoopsSince returns the rows that MOVED, with deltas in place of totals,
+// and only those — so a bare reflect.DeepEqual against a one-entry map is an
+// exhaustive claim: this multiplexer moved by exactly this much AND no other
+// multiplexer moved at all. The second half is what #1558's whole keying rests
+// on, since the defect it removes is one producer's loop landing in another's
+// bucket, which is invisible to any assertion that only checks its own row.
+func clientLoopsSince(before clientLoopLedger) map[string]ClientLoopCount {
+	moved := map[string]ClientLoopCount{}
+	for mux, now := range readClientLoopLedger().rows {
+		was := before.rows[mux]
+		delta := ClientLoopCount{
+			Multiplexer:       mux,
+			CandidatesProbed:  now.CandidatesProbed - was.CandidatesProbed,
+			AbandonedOnBudget: now.AbandonedOnBudget - was.AbandonedOnBudget,
+			StarvedByScan:     now.StarvedByScan - was.StarvedByScan,
+		}
+		if delta.CandidatesProbed != 0 || delta.AbandonedOnBudget != 0 || delta.StarvedByScan != 0 {
+			moved[mux] = delta
+		}
+	}
+	return moved
+}
+
+// assertClientLoopsMoved fails unless exactly want moved.
+func assertClientLoopsMoved(t *testing.T, before clientLoopLedger, want map[string]ClientLoopCount, why string) {
+	t.Helper()
+	if got := clientLoopsSince(before); !reflect.DeepEqual(got, want) {
+		t.Errorf("client loop counters moved by %v, want %v — %s", got, want, why)
+	}
+}
+
+// TestClientLoopStarvationIsDecidedByTheCandidateCount is the mechanism claim
+// under #1558's figure, driven without the darwin loop: an abandonment with no
+// candidates probed is starvation, one with candidates probed is not, and both
+// are abandonments.
+//
+// Both figures come from ONE call, so `starved <= abandoned` holds by
+// construction. That is asserted anyway, because the property this file exists
+// to protect is that a counter cannot quietly stop discriminating, and "the two
+// are written together" is a claim about the code rather than about the numbers.
+func TestClientLoopStarvationIsDecidedByTheCandidateCount(t *testing.T) {
+	before := readClientLoopLedger()
+	observeClientCandidatesAbandoned(clientLoopTmux, 0)
+	assertClientLoopsMoved(t, before, map[string]ClientLoopCount{
+		"tmux": {Multiplexer: "tmux", AbandonedOnBudget: 1, StarvedByScan: 1},
+	}, "zero candidates probed means the scan ahead of the loop spent the whole budget (#1558)")
+
+	before = readClientLoopLedger()
+	observeClientCandidatesAbandoned(clientLoopTmux, 3)
+	assertClientLoopsMoved(t, before, map[string]ClientLoopCount{
+		"tmux": {Multiplexer: "tmux", AbandonedOnBudget: 1},
+	}, "an abandonment after three candidates is the LOOP spending its own share; counting it as starved "+
+		"would attribute to the scan time the candidates spent, and a per-stage split would not help it")
+
+	before = readClientLoopLedger()
+	observeClientCandidateProbed(clientLoopHerdr)
+	assertClientLoopsMoved(t, before, map[string]ClientLoopCount{
+		"herdr": {Multiplexer: "herdr", CandidatesProbed: 1},
+	}, "a probed candidate is the denominator and is neither an abandonment nor a starvation")
+}
+
+// TestUndeclaredClientLoopKindIsCountedNotDropped is the guard on the guard,
+// the sibling of TestUndeclaredProbeKindIsCountedNotDropped. A multiplexer
+// nothing declared cannot be attributed to a row, and dropping the observation
+// would make an uncounted loop indistinguishable from one that never ran.
+func TestUndeclaredClientLoopKindIsCountedNotDropped(t *testing.T) {
+	beforeUndeclared := UndeclaredClientLoopKinds()
+	before := readClientLoopLedger()
+
+	observeClientCandidateProbed(clientLoopKind("not.a.multiplexer"))
+	observeClientCandidatesAbandoned(clientLoopKind("not.a.multiplexer"), 0)
+
+	if got := UndeclaredClientLoopKinds() - beforeUndeclared; got != 2 {
+		t.Errorf("undeclared observations = %d, want 2 — an unattributable loop must be reported, not swallowed", got)
+	}
+	assertClientLoopsMoved(t, before, map[string]ClientLoopCount{},
+		"an undeclared multiplexer must not be silently folded into some other producer's row")
+}
+
+// TestClientLoopCountsReportsEveryDeclaredKind pins the snapshot's shape, for
+// the reason TestProbeCountsReportsEveryDeclaredKind pins the probe one: on a
+// machine that uses only one multiplexer the ZERO row IS the evidence, and an
+// omitted row cannot be told apart from a producer this build does not have.
+func TestClientLoopCountsReportsEveryDeclaredKind(t *testing.T) {
+	if len(clientLoopCounts) != len(allClientLoopKinds) {
+		t.Fatalf("clientLoopCounts has %d entries for %d declared kinds — two kinds share a token, so they share a bucket",
+			len(clientLoopCounts), len(allClientLoopKinds))
+	}
+	rows := ClientLoopCounts()
+	if len(rows) != len(allClientLoopKinds) {
+		t.Fatalf("ClientLoopCounts returned %d rows for %d declared kinds", len(rows), len(allClientLoopKinds))
+	}
+	seen := map[string]bool{}
+	for _, row := range rows {
+		seen[row.Multiplexer] = true
+	}
+	for _, kind := range allClientLoopKinds {
+		if !seen[string(kind)] {
+			t.Errorf("ClientLoopCounts omits %q", kind)
+		}
+	}
+	if !sort.SliceIsSorted(rows, func(i, j int) bool { return rows[i].Multiplexer < rows[j].Multiplexer }) {
+		t.Errorf("ClientLoopCounts is unsorted: %v — two captures of the same daemon must diff cleanly", rows)
+	}
+	if !strings.Contains(ClientLoopStarvationRule(), "ZERO candidates probed") {
+		t.Errorf("the exported starvation rule must carry the definition the numbers were produced by, "+
+			"or the bundle prints a second copy that can describe behaviour it no longer has: %q", ClientLoopStarvationRule())
+	}
+}
+
+// TestEveryClientLoopSiteDeclaresItsOwnKind is the tripwire that makes a THIRD
+// multiplexer producer covered by existing rather than by remembering — which
+// is exactly what #1501 did not have when it reused herdr's counter.
+//
+// A "site" is a call to resolveClientHostIdentityVia that names a declared
+// constant. A call that FORWARDS a clientLoopKind parameter (the
+// resolveClientHostIdentity wrapper) names no multiplexer and is not a site;
+// it still counts toward the vacuity floor, so the scan cannot go quiet by
+// stopping to recognise anything.
+func TestEveryClientLoopSiteDeclaresItsOwnKind(t *testing.T) {
+	fset, files := parsePackageSources(t, ".")
+	declared := declaredClientLoopKindIdents(t, files)
+
+	if len(declared) != len(allClientLoopKinds) {
+		t.Fatalf("the source declares %d clientLoopKind constants but allClientLoopKinds lists %d — a kind that is not in allClientLoopKinds has no counter",
+			len(declared), len(allClientLoopKinds))
+	}
+	values := declaredValues(declared)
+	for _, kind := range allClientLoopKinds {
+		if !values[string(kind)] {
+			t.Errorf("allClientLoopKinds contains %q, which no clientLoopKind constant declares", kind)
+		}
+	}
+
+	usedBy, sites := clientLoopKindsBySite(fset, files, declared)
+
+	// Vacuity floor, the same shape and reason as the probe scan's: a scan that
+	// found no sites reports no violations and is indistinguishable from a
+	// clean package. Three: the two producers plus the forwarding wrapper.
+	const knownClientLoopSites = 3
+	if sites < knownClientLoopSites {
+		t.Fatalf("found %d resolveClientHostIdentityVia call sites, expected at least %d: the scan is not looking where it thinks it is, so its silence proves nothing",
+			sites, knownClientLoopSites)
+	}
+
+	for kind, where := range usedBy {
+		if len(where) > 1 {
+			t.Errorf("%s is passed by %d call sites (%s) — they share one bucket, so a climbing count cannot say which multiplexer stopped resolving, and the two scans behind them differ by more than an order of magnitude (#1558)",
+				kind, len(where), strings.Join(where, ", "))
+		}
+	}
+	for name := range declared {
+		if len(usedBy[name]) == 0 {
+			t.Errorf("%s is declared but passed by no call site — it publishes a permanent zero row that no producer can ever move", name)
+		}
+	}
+}
+
+// clientLoopKindsBySite returns, per declared kind identifier, the `file:line`
+// of every call site that passes it — plus how many resolveClientHostIdentityVia
+// calls were seen at all, the vacuity floor's input. An argument that is not a
+// declared constant (a forwarded parameter) contributes to sites and to no
+// kind, so it can neither be mistaken for coverage nor silence the floor.
+func clientLoopKindsBySite(fset *token.FileSet, files map[string]*ast.File, declared map[string]string) (usedBy map[string][]string, sites int) {
+	usedBy = map[string][]string{}
+	for name, file := range files {
+		ast.Inspect(file, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			fn, ok := call.Fun.(*ast.Ident)
+			if !ok || fn.Name != "resolveClientHostIdentityVia" || len(call.Args) < 2 {
+				return true
+			}
+			sites++
+			id, ok := call.Args[1].(*ast.Ident)
+			if !ok {
+				return true
+			}
+			if _, isKind := declared[id.Name]; !isKind {
+				return true
+			}
+			usedBy[id.Name] = append(usedBy[id.Name],
+				filepath.Base(name)+":"+strconv.Itoa(fset.Position(call.Pos()).Line))
+			return true
+		})
+	}
+	return usedBy, sites
+}
+
+// declaredClientLoopKindIdents returns the identifier names of every
+// `clientLoopKind` constant, mapped to its string value. Derived from the
+// source rather than listed here, so a new kind is graded by existing.
+func declaredClientLoopKindIdents(t *testing.T, files map[string]*ast.File) map[string]string {
+	t.Helper()
+	out := map[string]string{}
+	for _, file := range files {
+		for _, decl := range file.Decls {
+			gen, ok := decl.(*ast.GenDecl)
+			if !ok || gen.Tok != token.CONST {
+				continue
+			}
+			for _, spec := range gen.Specs {
+				vs, ok := spec.(*ast.ValueSpec)
+				if !ok {
+					continue
+				}
+				if typ, ok := vs.Type.(*ast.Ident); !ok || typ.Name != "clientLoopKind" {
+					continue
+				}
+				for i, name := range vs.Names {
+					out[name.Name] = probeKindLiteral(vs, i)
+				}
+			}
+		}
+	}
+	if len(out) == 0 {
+		t.Fatal("no clientLoopKind constants found in the package source — the scan is looking in the wrong place, so its silence proves nothing")
+	}
+	return out
 }
 
 // --- the static half: every run site names its own declared kind -----------

--- a/core/application/services/diagnostics_probes_test.go
+++ b/core/application/services/diagnostics_probes_test.go
@@ -51,9 +51,17 @@ func probeHealthFixture() ProbeHealthSnapshot {
 			{Probe: "kitten.window"},
 			{Probe: "lsof.cwd", Answered: 17},
 		},
-		OutcomeRule:                      "a child that ran to a normal exit ANSWERED; one killed, never started, or whose fork failed did not",
-		HerdrCandidatesProbed:            9,
-		HerdrCandidatesAbandonedOnBudget: 3,
+		OutcomeRule: "a child that ran to a normal exit ANSWERED; one killed, never started, or whose fork failed did not",
+		// Deliberately out of order for the same reason Probes is, and
+		// deliberately asymmetric: herdr starved on 2 of its 3 abandonments
+		// while tmux abandoned once and starved on none. A fixture where the
+		// two multiplexers agreed could not tell a per-row reading from a
+		// summed one (#1558).
+		ClientLoops: []ClientLoopCount{
+			{Multiplexer: "tmux", CandidatesProbed: 40, AbandonedOnBudget: 1},
+			{Multiplexer: "herdr", CandidatesProbed: 9, AbandonedOnBudget: 3, StarvedByScan: 2},
+		},
+		ClientLoopStarvationRule: "an abandonment with ZERO candidates probed in that loop was STARVED BY THE SCAN (#1529/#1558)",
 		// Deliberately out of order for the same reason Probes is.
 		HostGate: []HostGateOutcomeCount{
 			{Outcome: "rejected.no_known_host", Count: 4},
@@ -107,14 +115,61 @@ func TestProbesBundleReportsCounts(t *testing.T) {
 	if !strings.Contains(unanswered, "plutil.bundle_id") || !strings.Contains(unanswered, "#784") {
 		t.Errorf("a non-zero unanswered count must name the probe and what fails open on it: %q", unanswered)
 	}
-	if got["herdr_client_candidates_abandoned_on_budget"] != float64(3) {
-		t.Errorf("herdr abandonment = %v, want 3 (#1558)", got["herdr_client_candidates_abandoned_on_budget"])
+}
+
+// TestProbesBundleReportsClientLoopsPerMultiplexer is #1558's own coverage.
+//
+// Three claims, and each fails on a different mutation: the rows are PER
+// MULTIPLEXER (a summed pair cannot say which scan starved, and the two differ
+// by more than an order of magnitude); the starvation column is separate from
+// the abandonment one (they were one number, which is why the issue could not
+// be decided); and the notes name both figures against their denominators.
+func TestProbesBundleReportsClientLoopsPerMultiplexer(t *testing.T) {
+	got := probesJSON(t, buildTestServiceWithProbes(t, probeHealthFixture))
+
+	rows, _ := got["client_host_loops"].([]any)
+	if len(rows) != 2 {
+		t.Fatalf("client_host_loops has %d rows, want 2: %v — one row per multiplexer, including one that never ran", len(rows), got["client_host_loops"])
 	}
-	if got["herdr_client_candidates_probed"] != float64(9) {
-		t.Errorf("herdr probed = %v, want 9 — without the denominator the abandonment count cannot be read", got["herdr_client_candidates_probed"])
+	first, _ := rows[0].(map[string]any)
+	if first["multiplexer"] != "herdr" {
+		t.Errorf("first row = %v, want herdr (sorted by multiplexer) — two captures of one daemon must diff cleanly", first)
 	}
-	if note, _ := got["herdr_abandonment_note"].(string); !strings.Contains(note, "#1529") {
-		t.Errorf("a non-zero abandonment must explain itself: %q", note)
+	byMux := map[string]map[string]any{}
+	for _, row := range rows {
+		r, _ := row.(map[string]any)
+		mux, _ := r["multiplexer"].(string)
+		byMux[mux] = r
+	}
+	// The asymmetry IS the assertion: herdr starved twice, tmux never, and a
+	// view that summed them would publish "3 starved of 4" against neither.
+	if byMux["herdr"]["starved_by_scan"] != float64(2) || byMux["herdr"]["abandoned_on_budget"] != float64(3) || byMux["herdr"]["candidates_probed"] != float64(9) {
+		t.Errorf("herdr row = %v, want probed:9 abandoned:3 starved:2 kept apart", byMux["herdr"])
+	}
+	if byMux["tmux"]["starved_by_scan"] != float64(0) || byMux["tmux"]["abandoned_on_budget"] != float64(1) {
+		t.Errorf("tmux row = %v, want abandoned:1 starved:0 — an abandonment the LOOP caused is not a starvation", byMux["tmux"])
+	}
+	if rule, _ := got["client_host_loop_starvation_rule"].(string); !strings.Contains(rule, "ZERO candidates probed") {
+		t.Errorf("client_host_loop_starvation_rule must carry the rule the rows were produced by, from the package that produced them: %q", rule)
+	}
+
+	abandon, _ := got["client_host_loop_abandonment_note"].(string)
+	for _, want := range []string{"herdr abandoned 3 of 9", "tmux abandoned 1 of 40", "#1529", "deferred host-window recovery"} {
+		if !strings.Contains(abandon, want) {
+			t.Errorf("the abandonment note does not mention %q — it must name each multiplexer against its own denominator and say the answer fails safe: %q", want, abandon)
+		}
+	}
+	starved, _ := got["client_host_loop_starvation_note"].(string)
+	for _, want := range []string{"#1558", "herdr starved 2 of its 3", "availability, never correctness", "DISTRIBUTION"} {
+		if !strings.Contains(starved, want) {
+			t.Errorf("the starvation note does not mention %q — it must name the multiplexer, say what it costs, and refuse to invite tuning against a distribution nobody has: %q", want, starved)
+		}
+	}
+	// tmux appears in the fixed legend naming both scans, which is why this
+	// checks the ACCUSATION rather than the token: a note that credits every
+	// multiplexer with a starvation says nothing about which one is degrading.
+	if strings.Contains(starved, "tmux starved") {
+		t.Errorf("the starvation note reports tmux as starved, and it starved on nothing: %q", starved)
 	}
 }
 
@@ -125,14 +180,32 @@ func TestProbesBundleReportsCounts(t *testing.T) {
 func TestProbesBundleStaysTerseWhenNothingIsWrong(t *testing.T) {
 	got := probesJSON(t, buildTestServiceWithProbes(t, func() ProbeHealthSnapshot {
 		return ProbeHealthSnapshot{
-			Probes:                []ProbeCount{{Probe: "lsof.cwd", Answered: 17}},
-			OutcomeRule:           "a child that ran to a normal exit ANSWERED",
-			HerdrCandidatesProbed: 9,
+			Probes:      []ProbeCount{{Probe: "lsof.cwd", Answered: 17}},
+			OutcomeRule: "a child that ran to a normal exit ANSWERED",
+			// A busy but healthy loop: candidates probed, nothing abandoned,
+			// nothing starved. This is the vacuity guard for #1558's figure —
+			// a run that does NOT starve must be counted by nobody as starved,
+			// and its essay must not appear.
+			ClientLoops: []ClientLoopCount{{Multiplexer: "herdr", CandidatesProbed: 9}},
 		}
 	}))
 
+	// The rows themselves are NOT conditional and must still be published; only
+	// the essays are. Asserted here rather than left to the daemon test,
+	// because "healthy" is exactly the state in which an omitted zero row would
+	// look like an absent producer.
+	if rows, ok := got["client_host_loops"].([]any); !ok || len(rows) != 1 {
+		t.Errorf("client_host_loops = %v, want the row at zero — a healthy machine publishes the figure and not its explanation", got["client_host_loops"])
+	}
+
 	for _, field := range []string{
-		"unanswered_note", "herdr_abandonment_note", "undeclared_probe_kinds_note", "undeclared_probe_kinds",
+		"unanswered_note", "undeclared_probe_kinds_note", "undeclared_probe_kinds",
+		// #1558's two essays: a machine whose client loops abandoned nothing
+		// gets the rows and no prose. The starvation one is the load-bearing
+		// half — an explanation that fires on a healthy loop cannot report the
+		// degradation the issue is about.
+		"client_host_loop_abandonment_note", "client_host_loop_starvation_note",
+		"undeclared_client_loop_kinds", "undeclared_client_loop_kinds_note",
 		// #1525's essays follow the same rule: a machine whose gate never
 		// admitted on no evidence gets the rows and no prose.
 		"host_gate_aborted_walk_note", "host_gate_reconciliation_note",
@@ -168,11 +241,16 @@ func TestProbesBundleOmitsCountsWhenNotCollectedInDaemon(t *testing.T) {
 	// different question.
 	for _, field := range []string{
 		"probes", "total_unanswered", "undeclared_probe_kinds",
-		"herdr_client_candidates_probed", "herdr_client_candidates_abandoned_on_budget",
+		// #1558's rows and their essays, omitted for the HOST GATE's reason
+		// rather than this section's — see
+		// TestProbesBundleSaysWhyClientLoopCountsAreMissing.
+		"client_host_loops", "client_host_loop_starvation_rule",
+		"client_host_loop_abandonment_note", "client_host_loop_starvation_note",
+		"undeclared_client_loop_kinds",
 		// The notes that only make sense beside counts. outcome_rule is here
 		// too: a counting rule printed next to no counts describes numbers this
 		// section does not carry.
-		"memo_note", "outcome_rule", "unanswered_note", "herdr_abandonment_note",
+		"memo_note", "outcome_rule", "unanswered_note",
 		// #1525's rows and their essays, omitted for a DIFFERENT reason than
 		// the probe rows above — see TestProbesBundleSaysWhyHostGateCountsAreMissing.
 		"host_gate", "host_gate_outcome_rule", "host_gate_aborted_walk_note",
@@ -345,5 +423,27 @@ func TestProbesBundleSaysWhyHostGateCountsAreMissing(t *testing.T) {
 	// wrong about one of them and no test would notice.
 	if probeNote, _ := got["note"].(string); !strings.Contains(probeNote, "NOT zero") {
 		t.Errorf("the probe note stopped saying its own counters are non-zero here: %q", probeNote)
+	}
+}
+
+// TestProbesBundleSaysWhyClientLoopCountsAreMissing is the same obligation for
+// #1558's rows, and it is a third test rather than a line in the one above
+// because a reader has to be told WHICH of the two reasons applies.
+//
+// It is the host gate's: reaching the attached-client loop needs
+// ReadLauncherEnv or the liveness sweep's refreshMultiplexerHosts, and
+// `irrlichd --diagnose` runs neither, so these counters are structurally zero
+// here. A reader who carried the probe section's reason down — "small, real,
+// about this process's own collection" — would conclude that this process
+// resolves multiplexer hosts and that a zero starvation count means it found
+// none.
+func TestProbesBundleSaysWhyClientLoopCountsAreMissing(t *testing.T) {
+	got := probesJSON(t, buildTestServiceWithProbes(t, nil))
+
+	note, _ := got["client_host_loop_note"].(string)
+	for _, want := range []string{"structurally zero", "SAME reason", "refreshMultiplexerHosts", "/debug/bundle", "#1558"} {
+		if !strings.Contains(note, want) {
+			t.Errorf("the client-loop note does not mention %q — it must name which of the two reasons applies, why, and where the real evidence is: %q", want, note)
+		}
 	}
 }

--- a/core/application/services/diagnostics_service.go
+++ b/core/application/services/diagnostics_service.go
@@ -153,13 +153,20 @@ type ProbeHealthSnapshot struct {
 	// UndeclaredKinds is how many observations named a probe kind nobody
 	// declared. Non-zero means Probes is INCOMPLETE.
 	UndeclaredKinds uint64
-	// HerdrCandidatesProbed and HerdrCandidatesAbandonedOnBudget are #1558's
-	// figures: how many attached-client candidates the herdr host loop asked
-	// about, and how many times it stopped early because the aggregate budget
-	// was already spent. Not probe rows — no child process is involved — so
-	// they are reported beside them rather than as an outcome.
-	HerdrCandidatesProbed            uint64
-	HerdrCandidatesAbandonedOnBudget uint64
+	// ClientLoops is #1558's figures, one row per MULTIPLEXER: how many
+	// attached-client candidates that host loop asked about, how many times it
+	// stopped early because the aggregate budget was already spent, and how
+	// many of those had probed nothing at all — the scan ahead of the loop
+	// having spent the whole budget, which is the degradation #1558 was filed
+	// about. Not probe rows — no child process is involved — so they are
+	// reported beside them rather than as an outcome.
+	ClientLoops []ClientLoopCount
+	// ClientLoopStarvationRule is what "starved by scan" means, taken from the
+	// package that decides it for the reason OutcomeRule above is.
+	ClientLoopStarvationRule string
+	// UndeclaredClientLoopKinds is how many observations named a multiplexer
+	// nobody declared. Non-zero means ClientLoops is INCOMPLETE.
+	UndeclaredClientLoopKinds uint64
 	// HostGate is #1525's figures: what the #784 host-admission gate decided,
 	// per outcome. Not probe rows either, and carried here rather than in a
 	// snapshot of their own because they are the DOWNSTREAM view of the same
@@ -174,6 +181,30 @@ type ProbeHealthSnapshot struct {
 	// UndeclaredHostGateOutcomes is how many evaluations named an outcome
 	// nobody declared. Non-zero means HostGate is INCOMPLETE.
 	UndeclaredHostGateOutcomes uint64
+}
+
+// ClientLoopCount is one multiplexer's attached-client host loop, as probes.json
+// reports it (issue #1558). A plain mirror of processlifecycle's own row, for
+// the reason ProbeCount is one: application/services must not import an inbound
+// adapter.
+//
+// One row per multiplexer rather than one pair of scalars, because the two
+// scans ahead of the shared loop differ by more than an order of magnitude
+// (`tmux list-clients` ~14ms, `lsof` of a herdr client log ~0.3-0.45s) and a
+// merged figure cannot say which of them starved. That is not a hypothetical
+// merge: #1573's figures were named `herdr_*` while the tmux producer had been
+// incrementing them since #1501.
+type ClientLoopCount struct {
+	// Multiplexer is the token, e.g. "herdr".
+	Multiplexer string `json:"multiplexer"`
+	// CandidatesProbed is the denominator — how many attached-client candidates
+	// this loop asked about.
+	CandidatesProbed uint64 `json:"candidates_probed"`
+	// AbandonedOnBudget is how many times it stopped early on the aggregate
+	// budget (#1529), one per event rather than per candidate left unread.
+	AbandonedOnBudget uint64 `json:"abandoned_on_budget"`
+	// StarvedByScan is the subset of those where the loop had probed NOTHING.
+	StarvedByScan uint64 `json:"starved_by_scan"`
 }
 
 // HostGateOutcomeCount is one outcome of the #784 host-admission gate and how
@@ -661,9 +692,10 @@ func (s *DiagnosticsService) probesView() any {
 		// (or zeros) in it — the same rule hooksView follows, for a reason that
 		// is one step stronger. See the doc comment above.
 		return struct {
-			CollectedFrom string `json:"collected_from"`
-			Note          string `json:"note"`
-			HostGateNote  string `json:"host_gate_note"`
+			CollectedFrom  string `json:"collected_from"`
+			Note           string `json:"note"`
+			HostGateNote   string `json:"host_gate_note"`
+			ClientLoopNote string `json:"client_host_loop_note"`
 		}{
 			CollectedFrom: "cli",
 			Note: "Collected by `irrlichd --diagnose`, which is not the process that runs the daemon's " +
@@ -686,6 +718,18 @@ func (s *DiagnosticsService) probesView() any {
 				"not small-and-irrelevant. The gate's aborted-walk line IS logged, so events.log in this bundle still " +
 				"carries any `#784 host gate ADMITTED this session` line. For the counts, fetch GET /debug/bundle " +
 				"from the running daemon.",
+			// #1558's rows share the HOST GATE's reason, not the probe rows'.
+			// Said explicitly rather than left to be inferred from the field
+			// order: `--diagnose` really does run probes, so a reader who
+			// carried the probe sentence down to this section would conclude
+			// that this process resolves multiplexer hosts and that a zero
+			// here means it found no starvation. It resolves none.
+			ClientLoopNote: "The attached-client host loop counters (#1558) are omitted here for the SAME reason as the " +
+				"host-gate counters above and NOT for the probe counters' reason: reaching that loop needs " +
+				"ReadLauncherEnv or the liveness sweep's refreshMultiplexerHosts, and `irrlichd --diagnose` runs " +
+				"neither — it never builds a session detector and never resolves a herdr or tmux host, so these " +
+				"counters are structurally zero in this process rather than small-and-irrelevant. For the counts, " +
+				"fetch GET /debug/bundle from the running daemon.",
 		}
 	}
 
@@ -704,14 +748,18 @@ func (s *DiagnosticsService) probesView() any {
 	// captures of one daemon must diff cleanly.
 	hostGate := append([]HostGateOutcomeCount(nil), snap.HostGate...)
 	sort.Slice(hostGate, func(i, j int) bool { return hostGate[i].Outcome < hostGate[j].Outcome })
+	// Copied and sorted for the reason probes is.
+	clientLoops := append([]ClientLoopCount(nil), snap.ClientLoops...)
+	sort.Slice(clientLoops, func(i, j int) bool { return clientLoops[i].Multiplexer < clientLoops[j].Multiplexer })
 	return struct {
 		CollectedFrom       string                 `json:"collected_from"`
 		OutcomeRule         string                 `json:"outcome_rule"`
 		Probes              []ProbeCount           `json:"probes"`
 		TotalUnanswered     uint64                 `json:"total_unanswered"`
 		UndeclaredKinds     uint64                 `json:"undeclared_probe_kinds,omitempty"`
-		HerdrProbed         uint64                 `json:"herdr_client_candidates_probed"`
-		HerdrAbandoned      uint64                 `json:"herdr_client_candidates_abandoned_on_budget"`
+		ClientLoops         []ClientLoopCount      `json:"client_host_loops"`
+		ClientLoopRule      string                 `json:"client_host_loop_starvation_rule"`
+		ClientLoopUndecl    uint64                 `json:"undeclared_client_loop_kinds,omitempty"`
 		HostGate            []HostGateOutcomeCount `json:"host_gate"`
 		HostGateRule        string                 `json:"host_gate_outcome_rule"`
 		HostGateAbortNote   string                 `json:"host_gate_aborted_walk_note,omitempty"`
@@ -721,7 +769,9 @@ func (s *DiagnosticsService) probesView() any {
 		HostGatePlatformNte string                 `json:"host_gate_platform_note,omitempty"`
 		UnansweredNote      string                 `json:"unanswered_note,omitempty"`
 		UndeclaredNote      string                 `json:"undeclared_probe_kinds_note,omitempty"`
-		HerdrAbandonNote    string                 `json:"herdr_abandonment_note,omitempty"`
+		ClientAbandonNote   string                 `json:"client_host_loop_abandonment_note,omitempty"`
+		ClientStarvedNote   string                 `json:"client_host_loop_starvation_note,omitempty"`
+		ClientUndeclNote    string                 `json:"undeclared_client_loop_kinds_note,omitempty"`
 		MemoNote            string                 `json:"memo_note"`
 		PlatformNote        string                 `json:"platform_note,omitempty"`
 	}{
@@ -730,8 +780,9 @@ func (s *DiagnosticsService) probesView() any {
 		Probes:              probes,
 		TotalUnanswered:     totalUnanswered,
 		UndeclaredKinds:     snap.UndeclaredKinds,
-		HerdrProbed:         snap.HerdrCandidatesProbed,
-		HerdrAbandoned:      snap.HerdrCandidatesAbandonedOnBudget,
+		ClientLoops:         clientLoops,
+		ClientLoopRule:      snap.ClientLoopStarvationRule,
+		ClientLoopUndecl:    snap.UndeclaredClientLoopKinds,
 		HostGate:            hostGate,
 		HostGateRule:        snap.HostGateOutcomeRule,
 		HostGateAbortNote:   hostGateAbortedWalkNote(hostGate),
@@ -741,7 +792,9 @@ func (s *DiagnosticsService) probesView() any {
 		HostGatePlatformNte: hostGatePlatformNote(),
 		UnansweredNote:      unansweredProbeNote(probes),
 		UndeclaredNote:      undeclaredProbeKindsNote(snap.UndeclaredKinds),
-		HerdrAbandonNote:    herdrAbandonmentNote(snap.HerdrCandidatesAbandonedOnBudget),
+		ClientAbandonNote:   clientLoopAbandonmentNote(clientLoops),
+		ClientStarvedNote:   clientLoopStarvationNote(clientLoops),
+		ClientUndeclNote:    undeclaredClientLoopKindsNote(snap.UndeclaredClientLoopKinds),
 		MemoNote: "memo_hits are calls a memo answered without starting a child (#1544), so they are NOT " +
 			"included in answered/unanswered — answered+unanswered is how often a child actually ran, and " +
 			"answered+unanswered+memo_hits is how often the probe was asked. Only ps.proc_info and " +
@@ -906,18 +959,77 @@ func undeclaredProbeKindsNote(n uint64) string {
 		"daemon, not a machine condition.", n)
 }
 
-// herdrAbandonmentNote fires only when the herdr client loop actually stopped
-// early on its aggregate budget (#1558). It is the one figure in this file
-// whose absence was the whole reason the issue could not be decided.
-func herdrAbandonmentNote(n uint64) string {
+// clientLoopAbandonmentNote fires only when some attached-client loop actually
+// stopped early on its aggregate budget (#1529/#1558).
+//
+// It names the multiplexers rather than summing, because the two producers'
+// scans differ by more than an order of magnitude and a total says nothing
+// about which indirection is degrading.
+func clientLoopAbandonmentNote(rows []ClientLoopCount) string {
+	var parts []string
+	var total uint64
+	for _, row := range rows {
+		if row.AbandonedOnBudget == 0 {
+			continue
+		}
+		total += row.AbandonedOnBudget
+		parts = append(parts, fmt.Sprintf("%s abandoned %d of %d candidate probe(s)",
+			row.Multiplexer, row.AbandonedOnBudget, row.CandidatesProbed))
+	}
+	if total == 0 {
+		return ""
+	}
+	return fmt.Sprintf("%s — the aggregate budget (#1529) was already spent when the loop reached a "+
+		"candidate. The answer is then \"I could not look\", which clears no stored host and is re-probed "+
+		"on the next sweep, so this is a deferred host-window recovery rather than a wrong answer. "+
+		"See client_host_loop_starvation_note for the half of this that #1558 is actually about.",
+		strings.Join(parts, "; "))
+}
+
+// clientLoopStarvationNote is #1558's own figure, and the reason that issue
+// could not be decided before it existed.
+//
+// It is deliberately a SEPARATE note from the abandonment one rather than a
+// sentence inside it: an abandonment after the loop probed candidates is the
+// loop spending its own share, which splitting the budget per stage would not
+// fix, and the two arriving as one number is exactly what made "how often does
+// the scan starve the loop" unanswerable. It also states the denominator and
+// what a reader should do with a non-zero — a bare count invites the tuning the
+// issue exists to defer until there is a distribution.
+func clientLoopStarvationNote(rows []ClientLoopCount) string {
+	var parts []string
+	var total uint64
+	for _, row := range rows {
+		if row.StarvedByScan == 0 {
+			continue
+		}
+		total += row.StarvedByScan
+		parts = append(parts, fmt.Sprintf("%s starved %d of its %d abandonment(s)",
+			row.Multiplexer, row.StarvedByScan, row.AbandonedOnBudget))
+	}
+	if total == 0 {
+		return ""
+	}
+	return fmt.Sprintf("#1558: %s. A starved loop probed NO candidate at all, so the scan ahead of it "+
+		"(lsof for herdr, `tmux list-clients` for tmux) spent the whole aggregate budget on its own and "+
+		"still succeeded — the one window #1529's bound does not cover, and the case in which splitting "+
+		"the budget between the two stages would help. It costs availability, never correctness: the "+
+		"answer is \"I could not look\", no stored host is cleared, and the memo re-probes next sweep. "+
+		"Before acting on this, capture the DISTRIBUTION of scan times behind it; a starvation count on "+
+		"its own does not say what a per-stage cap should be.", strings.Join(parts, "; "))
+}
+
+// undeclaredClientLoopKindsNote fires only when an observation named a
+// multiplexer nobody declared, i.e. client_host_loops is incomplete. The
+// sibling of undeclaredProbeKindsNote and for the same reason: rows that do not
+// add up must say so rather than be reconciled by a reader.
+func undeclaredClientLoopKindsNote(n uint64) string {
 	if n == 0 {
 		return ""
 	}
-	return fmt.Sprintf("The herdr client loop abandoned its remaining candidates %d time(s) because the "+
-		"aggregate budget (#1529) was already spent — normally because the lsof scan ahead of it ran "+
-		"slowly and still SUCCEEDED, which is the one window that bound does not cover. The answer is "+
-		"then \"I could not look\", which clears no stored host and is re-probed on the next sweep, so "+
-		"this is a deferred host-window recovery rather than a wrong answer (#1558).", n)
+	return fmt.Sprintf("%d attached-client loop observation(s) named a multiplexer that is not in "+
+		"allClientLoopKinds, so client_host_loops above is INCOMPLETE and something is wired wrong "+
+		"(#1558).", n)
 }
 
 // probePlatformNote says out loud that these probes are macOS-only, so an

--- a/core/cmd/irrlichd/paths.go
+++ b/core/cmd/irrlichd/paths.go
@@ -170,14 +170,15 @@ func liveHookHealth(watchdog *services.HookLivenessWatchdog, verifier *services.
 func liveProbeHealth() func() services.ProbeHealthSnapshot {
 	return func() services.ProbeHealthSnapshot {
 		rows := processlifecycle.ProbeCounts()
-		herdr := processlifecycle.HerdrCandidates()
+		loops := processlifecycle.ClientLoopCounts()
 		gate := processlifecycle.HostGateCounts()
 		snap := services.ProbeHealthSnapshot{
-			Probes:                           make([]services.ProbeCount, 0, len(rows)),
-			OutcomeRule:                      processlifecycle.ProbeOutcomeRule(),
-			UndeclaredKinds:                  processlifecycle.UndeclaredProbeKinds(),
-			HerdrCandidatesProbed:            herdr.Probed,
-			HerdrCandidatesAbandonedOnBudget: herdr.AbandonedOnBudget,
+			Probes:                    make([]services.ProbeCount, 0, len(rows)),
+			OutcomeRule:               processlifecycle.ProbeOutcomeRule(),
+			UndeclaredKinds:           processlifecycle.UndeclaredProbeKinds(),
+			ClientLoops:               make([]services.ClientLoopCount, 0, len(loops)),
+			ClientLoopStarvationRule:  processlifecycle.ClientLoopStarvationRule(),
+			UndeclaredClientLoopKinds: processlifecycle.UndeclaredClientLoopKinds(),
 			// #1525's outcomes ride this snapshot rather than one of their own:
 			// an aborted walk is the downstream view of a probe that did not
 			// answer, so the two figures are only useful side by side, and one
@@ -193,6 +194,14 @@ func liveProbeHealth() func() services.ProbeHealthSnapshot {
 				Answered:   row.Answered,
 				Unanswered: row.Unanswered,
 				MemoHits:   row.MemoHits,
+			})
+		}
+		for _, row := range loops {
+			snap.ClientLoops = append(snap.ClientLoops, services.ClientLoopCount{
+				Multiplexer:       row.Multiplexer,
+				CandidatesProbed:  row.CandidatesProbed,
+				AbandonedOnBudget: row.AbandonedOnBudget,
+				StarvedByScan:     row.StarvedByScan,
 			})
 		}
 		for _, row := range gate {


### PR DESCRIPTION
Closes #1558

The issue asks whether to split `clientHostBudget` between its two stages, and
argues for option 2 first — count it, because options 1 and 3 both need a
distribution nobody has measured. This does the measurement and lands on
**measure, do not split**.

## What was already counted, and why it could not answer the question

#1573 (for #1534) publishes two scalars in `probes.json`:
`herdr_client_candidates_probed` and `herdr_client_candidates_abandoned_on_budget`.
Driven against the real loop before any change, they cannot answer "how often
does the scan starve the loop?" for two independent reasons.

**Scan starvation and loop exhaustion are the same number.** Measured:

```
SCAN STARVATION       -> probed +0, abandoned_on_budget +1
LOOP EXHAUSTION       -> probed +2, abandoned_on_budget +1
```

`abandoned_on_budget` moves by exactly 1 in both. The only difference is
`probed`, which is a process-wide sum over every loop, so no reading of a
bundle can tell them apart. They are different findings: only the first is the
degradation #1558 is about, and splitting the budget per stage is a remedy for
the first only — it does nothing for a loop that legitimately spent its own
share.

**The `herdr_`-named figures count the tmux producer too.** #1501 generalised
`resolveClientHostIdentityVia` to a second producer; #1573 then added counters
keyed to nothing. Measured:

```
TMUX resolve moved herdr_client_candidates_probed by 2, abandoned by 0
```

So a non-zero starvation figure could not say whether an `lsof` or a
`tmux list-clients` had starved — which is the comparison any decision about
splitting the budget rests on. This is the shared-bucket defect #1534's own
per-call-site rule exists to prevent, arriving in a counter #1534 added.

## What this adds

`client_host_loops`, one row per **multiplexer**, replacing the two scalars:

| field | meaning |
|---|---|
| `candidates_probed` | the denominator, unchanged in meaning |
| `abandoned_on_budget` | one event per loop, unchanged in meaning |
| `starved_by_scan` | **new** — the subset with ZERO candidates probed |

`starved_by_scan` is #1558's figure. The loop consults the budget before each
candidate, so "already expired at candidate 1" is the only state in which
nothing but the scan can have spent it: between
`context.WithTimeout(clientHostBudget)` and that first check, the scan is the
only thing that ran. Both figures are written from **one** call site
(`observeClientCandidatesAbandoned(kind, probedBefore)`), so `starved <=
abandoned` holds by construction rather than by two sites agreeing.

The two ~day-old key names change, deliberately: they were wrong (they named
herdr for a figure covering both producers), and a per-multiplexer starvation
count read against a merged denominator is unreadable.

Also published: `client_host_loop_starvation_rule`, taken from the package that
decides it rather than restated one layer up; `undeclared_client_loop_kinds`;
and two notes that fire **only** when non-zero. The starvation note names the
multiplexer against its own denominator and explicitly refuses to invite tuning
("capture the DISTRIBUTION of scan times behind it; a starvation count on its
own does not say what a per-stage cap should be").

The `--diagnose` form omits the rows for the **host gate's** reason, not the
probe rows': reaching this loop needs `ReadLauncherEnv` or the liveness sweep's
`refreshMultiplexerHosts`, and that process builds no session detector, so these
counters are structurally zero rather than small-and-irrelevant. A reader who
carried the probe section's reason down would conclude the CLI resolves
multiplexer hosts and that its zero means it found no starvation.

## Does the tmux scan's cheapness change the starvation picture?

Re-measured on this machine, 3 runs each:

| scan | measured | margin vs the 2s budget |
|---|---|---|
| `tmux list-clients -F '#{client_pid}'` | 0.00-0.01s | ~200x |
| `lsof` (a comparable path) | 0.44-0.48s | **~4.3x** |

Two things follow, and they point the same way. tmux starving the loop is
implausible at a ~200x margin — which is an argument for **keying** the counter,
not for splitting the budget: a starvation attributed to the wrong producer is
the one reading that would send tuning in the wrong direction.

And the herdr margin is **tighter than the issue's own footer states** — it
quotes ~0.3s and a "~7x margin"; the figure here is 0.44-0.48s, so ~4.3x. That
narrows the band without closing the argument: it is one machine, one moment,
and it is exactly the kind of number the issue is right to want a distribution
of rather than a point estimate. `clientHostBudget`'s doc already carries the
14ms tmux figure; the 0.3s herdr figure is now stated as a range beside it.

## Recommendation: measure, do not split

Deliberately **not** splitting the budget between the stages. It is #1558's
option 1 and it still needs a distribution nobody has — and note a starvation
count does not supply one: it says whether the case ever occurs, not what a
per-stage cap should be. #1603 declined the same split for DORA's stages on the
same grounds, and its hand-back's framing carries here with one substitution:
it costs **availability only**, never correctness. A non-answer clears no stored
host (#1492) and the memo re-probes on the next sweep, so the cost is a deferred
host-window recovery.

The issue's "Unverified" footer still stands: no slow-but-successful `lsof` has
been observed. A non-zero `starved_by_scan` in a bundle from a daemon that has
run for a while is now the first evidence either way, and the note beside it
says what to collect before acting.

## Mutation evidence — six, each seen red

The starvation figure is new, so it has no "before the fix" to run against and
owes deliberate mutations instead. Every one below was applied by copy-aside,
run, and reverted by copy-back with `git status --porcelain` asserted clean.
Every assertion turns on `ctx.Err()`, never a wall clock; nothing sleeps.

**M1 — starvation counted unconditionally (the wrong axis: every abandonment
blamed on the scan).** Two independent tests, one through the production loop
and one through the observer directly:

```
--- FAIL: TestClientCandidateAbandonmentIsCounted/a_budget_the_LOOP_spent_is_an_abandonment_and_is_starved_by_nobody
    probecount_darwin_test.go:185: client loop counters moved by map[herdr:{herdr 2 1 1}], want map[herdr:{herdr 2 1 0}]
--- FAIL: TestClientLoopStarvationIsDecidedByTheCandidateCount
    probecount_test.go:334: client loop counters moved by map[tmux:{tmux 0 1 1}], want map[tmux:{tmux 0 1 0}]
```

**M2 — starvation never counted.** The same two tests, other polarity:

```
--- FAIL: TestClientCandidateAbandonmentIsCounted/a_budget_already_spent_when_the_loop_starts_was_STARVED_BY_THE_SCAN
    probecount_darwin_test.go:170: client loop counters moved by map[herdr:{herdr 0 1 0}], want map[herdr:{herdr 0 1 1}]
--- FAIL: TestClientLoopStarvationIsDecidedByTheCandidateCount
    probecount_test.go:328: client loop counters moved by map[tmux:{tmux 0 1 0}], want map[tmux:{tmux 0 1 1}]
```

**M3 — starvation derived from the process-wide `probed` total instead of this
loop's own count.** This is the wrong-axis mutation that matters most, because
it is the shape the published denominator invites: once anything else has
probed, every real starvation is silently reclassified.

```
--- FAIL: TestClientCandidateAbandonmentIsCounted/a_budget_already_spent_when_the_loop_starts_was_STARVED_BY_THE_SCAN
    probecount_darwin_test.go:170: client loop counters moved by map[herdr:{herdr 0 1 0}], want map[herdr:{herdr 0 1 1}]
```

**M4 — the tmux producer reuses herdr's key** (#1501's shipped defect,
reproduced). Two independent layers catch it, runtime and static:

```
--- FAIL: TestEachMultiplexerCountsUnderItsOwnKind
    probecount_darwin_test.go:221: client loop counters moved by map[herdr:{herdr 2 0 0}], want map[tmux:{tmux 2 0 0}]
--- FAIL: TestEveryClientLoopSiteDeclaresItsOwnKind
    probecount_test.go:432: clientLoopHerdr is passed by 2 call sites (osutil_darwin.go:1515, osutil_darwin.go:1562) — they share one bucket
    probecount_test.go:438: clientLoopTmux is declared but passed by no call site
```

**M5 — the static scan stops finding its call sites.** The vacuity floor must
refuse rather than report a clean package:

```
--- FAIL: TestEveryClientLoopSiteDeclaresItsOwnKind
    probecount_test.go:426: found 0 resolveClientHostIdentityVia call sites, expected at least 3:
      the scan is not looking where it thinks it is, so its silence proves nothing
```

**M6 — the starvation note fires unconditionally.** The essay's vacuity guard;
note the mutated output printing `#1558: .` with an empty subject:

```
--- FAIL: TestProbesBundleStaysTerseWhenNothingIsWrong
    diagnostics_probes_test.go:215: client_host_loop_starvation_note is present on a healthy machine:
      #1558: . A starved loop probed NO candidate at all, … — an explanation that always fires explains nothing
```

**Vacuity guards** (a run that does not starve is counted by nobody as starved),
each red under M1: `a live budget probes every candidate and abandons none`
asserts the delta is `{probed: 2}` and **nothing else moved** — `clientLoopsSince`
returns only the rows that moved, so a one-entry `DeepEqual` is an exhaustive
claim across every multiplexer; `a budget the LOOP spent …` is the
discriminating arm; and the healthy-machine bundle test asserts the rows are
published at zero while both essays stay absent.

**Locks** (pass by construction, no mutation owed): the existing #1529/#1492
budget tests in `clienthostbudget_darwin_test.go`, which this change only
re-points at the new signature.

## Verification — all foreground

- `go build ./core/...` and `GOOS=linux go build ./core/...` — clean
- `go test ./core/adapters/inbound/agents/processlifecycle/... -race -count=1` and `-count=4` — ok
- `go test ./core/application/services/... -race -count=1` — ok
- `go test ./core/... -race -count=1` — no failures
- `tools/preflight.sh --only go` — 7/7 PASS
- `tools/preflight.sh --only arch` — PASS (composite 7.9285 -> 7.9277, not a regression)
- pre-push hook: gofmt / ARS / core module tests / replay fixtures / security scan all PASS, no TIMEOUT, no NOT RUN

## Scope

Observability only. No probe's behaviour or classification changes, no budget
value changes, and no stage is given a sub-budget. The one behavioural line
touched is the loop's own bookkeeping (`probedHere`), which decides nothing the
loop returns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
