### PR TITLE
fix(tooling): run the PUSHING worktree's own git hook, not the main checkout's

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -835,8 +835,10 @@ Before marking a ticket done, run the full suite — every layer must pass:
   skill file is edited, and `testdata/` is excluded from the gate's own walk
   because those fixtures are deliberately corrupt.
 - POSIX shell scripts: `tools/posix-lint.sh` checks every tracked file whose
-  **first line** is a `#!/bin/sh` shebang — today `site/install.sh` and
-  `tools/linux-replay-entrypoint.sh`. Line 1 only, because
+  **first line** is a `#!/bin/sh` shebang — today `site/install.sh`,
+  `tools/linux-replay-entrypoint.sh` and `tools/git-hooks/shim` (#1591 brought
+  the third into scope, which is the whole reason that file was written in
+  POSIX sh rather than bash). Line 1 only, because
   `tools/lib/install-uninstall_test.sh` is a bash file that writes `#!/bin/sh`
   stubs inside a heredoc, and a content grep would try to lint it as POSIX sh.
   It runs two different kinds of check on each file: a real POSIX shell's
@@ -1151,8 +1153,41 @@ one command in a pipeline exited zero.
 
 `tools/install-git-hooks.sh` (run once per clone; worktrees share the parent
 repo's hooks automatically) wires `tools/preflight.sh`'s fast gates as a
-pre-push hook, so a push that would fail CI is rejected locally instead. The
-hook runs `tools/preflight.sh --changed --budget 540`, which scopes every gate
+pre-push hook, so a push that would fail CI is rejected locally instead. What
+it installs into the shared `.git/hooks/<name>` is neither the hook script nor
+a symlink to it, but a copy of `tools/git-hooks/shim`, which resolves the
+**pushing** working tree at run time and execs *that* tree's
+`tools/git-hooks/<name>` (#1591). Before that, the installed hook was a symlink
+into the MAIN checkout, so every worktree's push ran the main checkout's
+script — meaning a hook change in a worktree did not govern that worktree's own
+push, and anything under `tools/git-hooks/` was untestable from the branch that
+changed it. PR #1590 rewrote the hook to bound its own runtime and its own push
+ran the old unbounded one, hitting the exact defect it was fixing. Three
+consequences worth knowing:
+
+- **The shim is now the one link a `git pull` cannot update.** Changing
+  `tools/git-hooks/shim` means re-running the installer; changing
+  `tools/git-hooks/pre-push` does not. That is the right way round — the shim
+  resolves a path and execs, and has no reason to change. The installer
+  overwrites whatever it finds (an older symlink install, a hand-edited copy,
+  a stale shim), so re-running it is always safe and a second run in a row
+  installs nothing.
+- **A revision that genuinely carries no hook passes, loudly**, on stderr —
+  a bisect, or a branch predating the file, has no gate there to skip, and
+  refusing would only make `git bisect` hostile.
+- **A hook missing from the tree while `HEAD` still carries it refuses**, as
+  does one present but not executable. That is a broken working tree, not a
+  revision without the hook, and a gate skipped because a file was invisible is
+  this repo's most-repeated failure shape.
+
+`tools/lib/git-hooks_test.sh` covers both halves in throwaway repos (bare
+origin + main checkout + linked worktree, pushing over a filesystem path), and
+carries the mutation beside the assertion: one case installs the pre-#1591
+symlink and pins the OPPOSITE outcome from the identical rig, so an assertion
+that the worktree's refusing hook ran cannot be satisfied by a rig where
+nothing ran at all.
+
+The hook runs `tools/preflight.sh --changed --budget 540`, which scopes every gate
 to the packages and web trees the push's diff actually touches (vs
 `origin/main`), so a typical push finishes in seconds rather than re-running
 the whole suite. A large or cross-cutting diff (or a `go.mod`/`go.sum` change,
@@ -1210,7 +1245,13 @@ actually reads. Without that second layer a pure-Go push paid for an `npm
 audit` of both web trees and was rejected by a pre-existing advisory it could
 not have caused (#1213) — forcing `--no-verify`, which disables every other
 gate too. Both layers read the same changed set, from
-`tools/lib/changed-files.sh`; its unit tests run in the `tools` gate.
+`tools/lib/changed-files.sh`; its unit tests run in the `tools` gate. That set
+counts **untracked, non-ignored** files as well as committed, staged and
+unstaged ones (#1591). It did not until then: `git diff` cannot see a file
+that was never added and `--cached` only catches it once staged, so a
+newly written script selected no gates at all while the function's own doc
+said uncommitted work counted. Invisible to the pre-push hook — a file has to
+be committed to be pushed — and wrong for every manual `--changed` run.
 
 Two of the failure modes it won't catch: environment-specific timing flakes
 that only manifest on loaded Linux CI runners (not this machine), and true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,6 +53,12 @@ go test ./core/... -race -count=1   # run the Go suite (see AGENTS.md for the fu
 tools/install-git-hooks.sh     # one-time: wire the pre-push preflight check
 ```
 
+The hook it installs is a shim that runs the *pushing* working tree's own
+`tools/git-hooks/pre-push`, so worktrees need no separate install and a change
+to the hook is exercised by the push that makes it. Re-run the installer only
+when `tools/git-hooks/shim` itself changes — it overwrites, and running it
+twice installs nothing.
+
 The full suite — Go unit + e2e, the onboarding-factory, replay fixtures, and the
 web suites — is listed in [AGENTS.md](AGENTS.md#testing). **A change is only done
 when every layer passes.** No exceptions.

--- a/tools/git-hooks/shim
+++ b/tools/git-hooks/shim
@@ -1,0 +1,83 @@
+#!/bin/sh
+# shim — the file tools/install-git-hooks.sh copies, verbatim, into the shared
+# .git/hooks/ directory under each hook's name. It is not itself a hook: it is
+# the indirection that makes the real hooks worktree-local.
+#
+# WHY IT EXISTS (#1591). Linked worktrees share the parent repo's .git/hooks/.
+# The installer used to symlink .git/hooks/<name> at the MAIN checkout's
+# tools/git-hooks/<name>, so every worktree's push ran the main checkout's
+# script. The consequence, stated plainly: a change to a hook in a worktree
+# did not govern that worktree's own push. PR #1590 rewrote the pre-push hook
+# to bound its own runtime, and its own push ran the OLD unbounded hook, which
+# then blew the command budget — the exact defect that PR fixes, in the
+# session that fixed it. Anything under tools/git-hooks/ was untestable from
+# the branch that changed it, and landed on main having only ever been run by
+# hand. It also mixed versions silently: a worktree based on an older main
+# pushed through whatever hook the main checkout happened to have.
+#
+# THE TRADE, STATED RATHER THAN LEFT IMPLIED. This file becomes the one part
+# of the chain a `git pull` cannot update — changing it requires re-running
+# tools/install-git-hooks.sh. That is deliberate and is the right way round:
+# these few lines resolve a path and exec, and have no reason to change, while
+# tools/git-hooks/pre-push changes often and is now picked up by every push
+# with no install step at all. The installer overwrites whatever it finds
+# (older symlink install, hand-edited copy, stale shim), so re-running it is
+# always safe, always sufficient, and a no-op when nothing changed.
+#
+# TWO MEASURED FACTS ABOUT THE HOOK ENVIRONMENT (git 2.50.1, macOS; a linked
+# worktree pushing through a hook in the shared hooks dir):
+#   * $0 is the MAIN checkout's .git/hooks/<name>, NOT anything under the
+#     pushing worktree — so the repository root must never be derived from it.
+#     `git rev-parse --show-toplevel` DOES return the pushing worktree's root
+#     (GIT_DIR is set to <main>/.git/worktrees/<name>, which knows its own
+#     work tree), which is why that is what is used below. Git also runs hooks
+#     with cwd at the pushing tree's root even when `git push` was invoked
+#     from a subdirectory, but rev-parse is used anyway: it is correct under
+#     both, and does not have to be re-verified if that guarantee moves.
+#   * the basename of $0 IS the hook name, because git looks a hook up by name
+#     in the hooks directory. That is what lets one shim serve every hook.
+#
+# GIT_DIR / GIT_WORK_TREE / GIT_INDEX_FILE are deliberately left alone here:
+# the resolution above reads GIT_DIR, and unsetting them is the delegated
+# hook's own documented job (tools/git-hooks/pre-push does it, for its own
+# reasons, after this shim has done its work).
+set -u
+
+hook_name=${0##*/}
+
+root=$(git rev-parse --show-toplevel 2>/dev/null) || root=
+if [ -z "$root" ]; then
+  echo "$hook_name shim: cannot resolve the working tree root — 'git rev-parse --show-toplevel' failed." >&2
+  echo "  Refusing rather than skipping: a gate that cannot find itself must not read as a pass." >&2
+  echo "  Push once with --no-verify if this is genuinely not a working tree." >&2
+  exit 1
+fi
+
+hook=$root/tools/git-hooks/$hook_name
+
+if [ -x "$hook" ]; then
+  exec "$hook" "$@"
+fi
+
+# Not runnable here. Two very different situations, and they get OPPOSITE
+# answers on purpose — "fail loudly" everywhere makes `git bisect` hostile,
+# and "pass quietly" everywhere is a silently-missing gate.
+if git cat-file -e "HEAD:tools/git-hooks/$hook_name" 2>/dev/null; then
+  # This revision DOES carry the hook, so its absence — or a stripped exec bit
+  # — is an accident: a deleted file, an interrupted checkout, a copy made
+  # without permissions. A gate skipped because a file was invisible is this
+  # repo's most-repeated failure shape, so this case is loud and refuses.
+  echo "$hook_name shim: $hook is missing or not executable, yet HEAD carries tools/git-hooks/$hook_name." >&2
+  echo "  That is a broken working tree, not a revision without the hook — refusing the push." >&2
+  echo "  Restore it (git checkout -- tools/git-hooks/$hook_name) or chmod +x it; --no-verify skips once." >&2
+  exit 1
+fi
+
+# This revision genuinely has no such hook: an old branch, a bisect, a worktree
+# checked out from before the file existed. There is no gate here to skip, so
+# refusing would only punish `git bisect` for a hook that was never this
+# revision's to run. Allow it — but say so on stderr, every time, naming the
+# one reading that would mean something is wrong.
+echo "$hook_name shim: this revision carries no tools/git-hooks/$hook_name — nothing to run, allowing the push." >&2
+echo "  Expected during a bisect, or on a branch predating the hook. On an up-to-date branch it means it was deleted." >&2
+exit 0

--- a/tools/install-git-hooks.sh
+++ b/tools/install-git-hooks.sh
@@ -1,18 +1,70 @@
 #!/usr/bin/env bash
-# install-git-hooks.sh — symlink tools/git-hooks/* into .git/hooks/, so they
+# install-git-hooks.sh — install tools/git-hooks/* into .git/hooks/, so they
 # run without a manual step every time. git does not version .git/hooks/, so
 # this needs one run per clone (worktrees share the parent repo's .git/hooks
 # automatically — no separate install needed there).
+#
+# What lands in .git/hooks/<name> is NEITHER the hook script NOR a symlink to
+# it: it is tools/git-hooks/shim, copied verbatim under each hook's name. The
+# shim resolves the PUSHING working tree at run time and execs that tree's own
+# tools/git-hooks/<name>. Read that file for the full reasoning; in one line
+# (#1591): worktrees share this hooks directory, so a symlink pinned every
+# worktree to the MAIN checkout's script and a hook change in a worktree did
+# not govern that worktree's own push.
+#
+# Consequence, stated rather than left implied: the SHIM is now the one thing
+# a `git pull` cannot update, so re-run this script after tools/git-hooks/shim
+# changes. It overwrites whatever it finds — an older symlink install, a
+# hand-edited copy, a stale shim — so re-running is always safe and always
+# sufficient, and a second run in a row installs nothing.
 #
 # Usage: tools/install-git-hooks.sh
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
-HOOKS_DIR="$(git -C "$ROOT_DIR" rev-parse --git-common-dir)/hooks"
+
+# `git rev-parse --git-common-dir` answers RELATIVE to the caller's cwd (plain
+# `.git` from the top of the main checkout), so it has to be re-anchored on
+# ROOT_DIR or a run from anywhere else creates `./.git/hooks` in the wrong
+# place and installs nothing where git will look. Re-anchoring by hand rather
+# than with --path-format=absolute keeps this working on git < 2.31.
+COMMON_DIR="$(git -C "$ROOT_DIR" rev-parse --git-common-dir)"
+case "$COMMON_DIR" in
+  /*) ;;
+  *) COMMON_DIR="$ROOT_DIR/$COMMON_DIR" ;;
+esac
+HOOKS_DIR="$COMMON_DIR/hooks"
+SHIM="$ROOT_DIR/tools/git-hooks/shim"
+
+if [[ ! -f "$SHIM" ]]; then
+  echo "install-git-hooks: $SHIM is missing — refusing to install hooks that would have nothing to delegate through." >&2
+  exit 1
+fi
 
 mkdir -p "$HOOKS_DIR"
 for hook in "$ROOT_DIR"/tools/git-hooks/*; do
   name="$(basename "$hook")"
-  ln -sf "$hook" "$HOOKS_DIR/$name"
-  echo "installed $name -> $HOOKS_DIR/$name"
+  # The shim is this installer's payload, not a hook. git would never run a
+  # file by that name, but installing it would still be noise in a directory
+  # every worktree shares.
+  [[ "$name" == "shim" ]] && continue
+
+  target="$HOOKS_DIR/$name"
+  # Idempotent: a target that is already a regular file with the shim's exact
+  # bytes is left alone. `! -L` matters — cmp follows a symlink, so a link
+  # pointing AT the shim would otherwise compare equal and never be replaced
+  # by a real copy.
+  if [[ -f "$target" && ! -L "$target" ]] && cmp -s "$SHIM" "$target"; then
+    echo "up to date  $name  ($target)"
+    continue
+  fi
+
+  # rm before cp: `cp` onto a symlink writes THROUGH it, and the install this
+  # replaces left exactly such a symlink — pointing at the main checkout's
+  # tools/git-hooks/<name>. Without the rm, upgrading an old clone would
+  # overwrite the tracked hook script with the shim.
+  rm -f "$target"
+  cp "$SHIM" "$target"
+  chmod +x "$target"
+  echo "installed   $name  ($target -> shim -> <pushing worktree>/tools/git-hooks/$name)"
 done

--- a/tools/lib/changed-files.sh
+++ b/tools/lib/changed-files.sh
@@ -21,10 +21,19 @@
 # can exercise the scoping rules without running a scanner.
 
 # changed_files_vs_origin_main — everything this branch touches relative to
-# origin/main: committed since the merge base, unstaged, and staged. Emits
-# newline-separated repo-relative paths, sorted and de-duplicated. Uncommitted
-# work counts because a pre-push run should reflect the tree in front of you,
-# not only what is already committed.
+# origin/main: committed since the merge base, unstaged, staged, and untracked
+# (excluding anything gitignored). Emits newline-separated repo-relative paths,
+# sorted and de-duplicated. Uncommitted work counts because a pre-push run
+# should reflect the tree in front of you, not only what is already committed.
+#
+# The untracked line is #1591's half. `git diff` cannot see a file that was
+# never added, and `--cached` only catches it once it is staged — so a brand
+# new file selected NO gates while this function's doc said uncommitted work
+# counted. That is harmless for the pre-push hook (a file has to be committed
+# to be pushed) and wrong for a manual `tools/preflight.sh --changed`, where
+# the gates covering a newly written script were silently skipped. A gate
+# skipped because a file was invisible is this repo's most-repeated failure
+# shape, so this is fixed rather than documented away.
 #
 # Returns non-zero when no baseline can be established — origin/main never
 # fetched, a shallow clone, unrelated histories. That case has to be an error
@@ -50,6 +59,15 @@ changed_files_vs_origin_main() {
     git diff --name-only "$base" HEAD
     git diff --name-only HEAD
     git diff --name-only --cached
+    # --full-name and the `:/` pathspec are both load-bearing, and the naive
+    # spelling would look right forever: a bare `git ls-files --others` lists
+    # only what is under the CALLER'S cwd and prints it cwd-relative, while the
+    # three `git diff` lines above are repo-root-relative over the whole repo
+    # regardless of cwd. Called from the repo root — which is where preflight
+    # and the pre-push hook call it — the two spellings agree exactly. Measured
+    # from tools/ with an untracked core/new.go and tools/new.sh: the bare form
+    # emits `new.sh` alone, this one emits both, root-relative.
+    git ls-files --others --exclude-standard --full-name -- :/
   } 2>/dev/null | LC_ALL=C sort -u
 }
 

--- a/tools/lib/changed-files_test.sh
+++ b/tools/lib/changed-files_test.sh
@@ -52,6 +52,15 @@ assert_contains() {
   esac
   return 0
 }
+# assert_not_contains <label> <needle> <haystack>
+assert_not_contains() {
+  local label="$1" needle="$2" haystack="$3"
+  case "$haystack" in
+    *"$needle"*) fail "$label" "does NOT contain: $needle" "$haystack" ;;
+    *) pass "$label" ;;
+  esac
+  return 0
+}
 
 # No copy of security-scan.sh's GO_MODULES/WEB_TREES lives here on purpose.
 # These predicates are pure string matching and never stat the filesystem, so
@@ -132,17 +141,61 @@ trap 'rm -rf "$TMP"' EXIT
   echo '{}' >core/go.mod && git add core/go.mod      # staged, uncommitted
   echo unstaged >README.md                            # untracked-but-modified peer
   git add README.md && echo more >>README.md          # staged AND then modified
+  mkdir -p tools && echo new >tools/brand-new.sh      # never added: #1591's miss
+  echo 'ignored/' >.gitignore && git add .gitignore   # (staged, so it shows up too)
+  mkdir -p ignored && echo x >ignored/noise.txt       # untracked AND gitignored
 ) >/dev/null 2>&1
 out=$( cd "$TMP" && . "$DIR/changed-files.sh" && changed_files_vs_origin_main )
-assert_eq "collects committed + staged + unstaged, sorted and de-duplicated" \
-  "$(printf 'README.md\ncore/go.mod\ncore/main.go')" "$out"
+assert_eq "collects committed + staged + unstaged + untracked, sorted and de-duplicated" \
+  "$(printf '.gitignore\nREADME.md\ncore/go.mod\ncore/main.go\ntools/brand-new.sh')" "$out"
+
+echo "== #1591: an untracked new file counts, a gitignored one does not =="
+# git diff cannot see a file that was never added, and --cached only catches it
+# once staged — so before #1591 a brand new file selected NO gates, while this
+# function's doc said uncommitted work counted. Harmless for the pre-push hook
+# (a file must be committed to be pushed) and wrong for a manual
+# `tools/preflight.sh --changed`, where the gates covering a newly written
+# script were silently skipped. The gitignored half is the other direction: an
+# untracked set that swept in build output would put every gate in scope on
+# every run, which is a different way of meaning nothing.
+assert_contains "an untracked new file is in the changed set" "tools/brand-new.sh" "$out"
+assert_not_contains "a gitignored untracked file is NOT" "ignored/noise.txt" "$out"
+
+# The end-to-end shape the fix is actually for: from git, through the changed
+# set, into the predicate that decides whether a gate runs.
+UNTRACKED_ONLY="$(mktemp -d)"
+trap 'rm -rf "$TMP" "$UNTRACKED_ONLY"' EXIT
+(
+  cd "$UNTRACKED_ONLY" || exit 1
+  git init -q . && git config user.email t@t && git config user.name t
+  mkdir -p core && echo package main >core/main.go
+  git add -A && git commit -qm base
+  git update-ref refs/remotes/origin/main HEAD
+  mkdir -p core && echo 'package main' >core/brand_new.go   # untracked, nothing else changed
+) >/dev/null 2>&1
+uo=$( cd "$UNTRACKED_ONLY" && . "$DIR/changed-files.sh" && changed_files_vs_origin_main )
+assert_eq "a tree whose ONLY change is an untracked file is not an empty set" \
+  "core/brand_new.go" "$uo"
+assert_scope "…and that file puts its Go module in scope" \
+  in go_module_touched core "$uo"
+
+echo "== the changed set is repo-root-relative from any cwd =="
+# `git ls-files --others` alone lists only what is under the CALLER's cwd and
+# prints it cwd-relative, while the three `git diff` lines are root-relative
+# over the whole repo. Called from the repo root — the only place preflight and
+# the hook call it — the two spellings are identical, so the wrong one would
+# look right forever, and every predicate here matches on a root-relative
+# prefix.
+sub=$( cd "$UNTRACKED_ONLY/core" && . "$DIR/changed-files.sh" && changed_files_vs_origin_main )
+assert_eq "called from a subdirectory → same root-relative set, not 'brand_new.go'" \
+  "core/brand_new.go" "$sub"
 
 echo "== changed_files_vs_origin_main: no resolvable baseline must abort, not return an empty set =="
 # An empty result is byte-for-byte what "nothing changed" looks like, and an
 # empty set scopes every gate to a skip. Returning 0 there would mean a fresh
 # or shallow clone gets a fully green pre-push run that checked nothing.
 NOREMOTE="$(mktemp -d)"
-trap 'rm -rf "$TMP" "$NOREMOTE"' EXIT
+trap 'rm -rf "$TMP" "$UNTRACKED_ONLY" "$NOREMOTE"' EXIT
 (
   cd "$NOREMOTE" || exit 1
   git init -q . && git config user.email t@t && git config user.name t
@@ -161,7 +214,7 @@ echo "== callers hard-fail rather than skip everything when this lib is missing 
 # sibling lib/ reproduces exactly that.
 REPO_ROOT_FOR_TEST="$(cd "$DIR/../.." && pwd)"
 NOLIB="$(mktemp -d)"
-trap 'rm -rf "$TMP" "$NOREMOTE" "$NOLIB"' EXIT
+trap 'rm -rf "$TMP" "$UNTRACKED_ONLY" "$NOREMOTE" "$NOLIB"' EXIT
 for script in security-scan.sh preflight.sh; do
   # --local on security-scan.sh keeps a regression off the network: without the
   # guard it would fall through to the gh alert gates instead of exiting here.

--- a/tools/lib/git-hooks_test.sh
+++ b/tools/lib/git-hooks_test.sh
@@ -1,0 +1,284 @@
+#!/usr/bin/env bash
+# git-hooks_test.sh — unit tests for tools/install-git-hooks.sh and
+# tools/git-hooks/shim. Plain bash (no framework), matching the style of the
+# other tools/lib/*_test.sh files. Run directly, or via tools/preflight.sh's
+# `tools` gate. Exits non-zero on any failed assertion.
+#
+# Covers issue #1591: linked worktrees share the parent repo's .git/hooks/, and
+# the installer used to put a SYMLINK to the main checkout's script there — so
+# a hook change made in a worktree did not govern that worktree's own push, and
+# anything under tools/git-hooks/ was untestable from the branch that changed
+# it. The headline assertion is `worktree's own refusing hook is the one that
+# runs`, and the mutation that makes it mean something is committed beside it
+# rather than described in a PR body: `pre-#1591 symlink install` builds the
+# identical rig, installs the old way, and pins the OPPOSITE outcome. Same
+# worktree, same refusing hook, one difference — the install method — and the
+# push is allowed. Without that case, an assertion that a refusal happened
+# could be satisfied by a rig where nothing worked at all.
+#
+# NOTHING HERE TOUCHES THE REAL .git/hooks/. Every case builds a throwaway
+# repo trio (bare "origin" + main checkout + linked worktree) under mktemp -d,
+# and pushes over a filesystem path. The hooks installed are stubs that echo a
+# marker; tools/preflight.sh is never invoked.
+
+set -uo pipefail   # NOT -e: assertions capture non-zero return codes
+
+DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$DIR/../.." && pwd)"
+
+# Hermetic git: a developer (or CI image) carrying a global core.hooksPath, or
+# a commit.gpgsign, would otherwise change what these cases measure. Pinning
+# both config layers to /dev/null is why every rig sets user.name/email itself.
+export GIT_CONFIG_GLOBAL=/dev/null
+export GIT_CONFIG_SYSTEM=/dev/null
+export GIT_TERMINAL_PROMPT=0
+
+fails=0
+pass() {
+  local label="$1"
+  echo "  PASS: $label"
+  return 0
+}
+fail() {
+  local label="$1" expected="$2" got="$3"
+  echo "  FAIL: $label — expected [$expected] got [$got]"
+  fails=$((fails + 1))
+  return 0
+}
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  [[ "$expected" == "$actual" ]] && pass "$label" || fail "$label" "$expected" "$actual"
+  return 0
+}
+assert_contains() {
+  local label="$1" needle="$2" haystack="$3"
+  case "$haystack" in
+    *"$needle"*) pass "$label" ;;
+    *) fail "$label" "contains: $needle" "$haystack" ;;
+  esac
+  return 0
+}
+assert_not_contains() {
+  local label="$1" needle="$2" haystack="$3"
+  case "$haystack" in
+    *"$needle"*) fail "$label" "does NOT contain: $needle" "$haystack" ;;
+    *) pass "$label" ;;
+  esac
+  return 0
+}
+
+# One parent temp dir, one trap. Rigs are subdirectories of it rather than
+# separate mktemp -d results collected into an array: `RIG=$(new_rig)` runs in
+# a command substitution, so anything the helper appended to a shell array
+# there would be discarded with the subshell and the rigs would outlive the
+# run.
+ROOT_TMP="$(mktemp -d)"
+trap 'rm -rf "$ROOT_TMP"' EXIT
+
+# hook_stub <marker> <exit-code> — a pre-push hook that identifies WHICH COPY
+# of the script ran and then succeeds or refuses. It reports the marker baked
+# into the script text, never anything read from the cwd: git runs hooks with
+# cwd at the pushing worktree either way, so a cwd-derived marker would say
+# "worktree" even when the main checkout's script is the one executing — which
+# is precisely the confusion this whole issue is about.
+hook_stub() {
+  cat <<EOF
+#!/bin/sh
+echo "HOOK-SCRIPT-FROM=$1"
+echo "HOOK-ARGC=\$# HOOK-ARG1=\${1-none}"
+read -r first_ref_line
+[ -n "\$first_ref_line" ] && echo "HOOK-STDIN=nonempty"
+exit $2
+EOF
+}
+
+# make_rig <dir> — bare origin + main checkout (carrying this repo's real
+# installer and shim, plus a pre-push stub marked `main`) + a linked worktree
+# on branch `feature`. Leaves NO hook installed; each case chooses how.
+make_rig() {
+  local root="$1"
+  mkdir -p "$root"
+  (
+    set -e
+    cd "$root"
+    git init -q --bare origin.git
+    git init -q -b main checkout
+    cd checkout
+    git config user.email t@t
+    git config user.name t
+    git remote add origin "$root/origin.git"
+    mkdir -p tools/git-hooks
+    cp "$REPO_ROOT/tools/install-git-hooks.sh" tools/install-git-hooks.sh
+    cp "$REPO_ROOT/tools/git-hooks/shim" tools/git-hooks/shim
+    chmod +x tools/install-git-hooks.sh tools/git-hooks/shim
+    hook_stub main 0 >tools/git-hooks/pre-push
+    chmod +x tools/git-hooks/pre-push
+    git add -A
+    git commit -qm base
+    git push -q origin main
+    git worktree add -q ../worktree -b feature
+    cd ../worktree
+    git config user.email t@t
+    git config user.name t
+  ) >/dev/null 2>&1
+}
+
+new_rig() {
+  local t
+  t="$(mktemp -d "$ROOT_TMP/rig.XXXXXX")"
+  make_rig "$t"
+  echo "$t"
+}
+
+# ===========================================================================
+echo "== the installer writes a shim, not a symlink, and not the hook itself =="
+RIG="$(new_rig)"
+(cd "$RIG/checkout" && bash tools/install-git-hooks.sh) >/dev/null 2>&1
+TARGET="$RIG/checkout/.git/hooks/pre-push"
+if [[ -L "$TARGET" ]]; then kind=symlink; elif [[ -f "$TARGET" ]]; then kind=file; else kind=absent; fi
+assert_eq "installed pre-push is a regular file" "file" "$kind"
+if cmp -s "$REPO_ROOT/tools/git-hooks/shim" "$TARGET"; then same=yes; else same=no; fi
+assert_eq "installed pre-push is byte-for-byte tools/git-hooks/shim" "yes" "$same"
+if [[ -x "$TARGET" ]]; then x=yes; else x=no; fi
+assert_eq "installed pre-push is executable" "yes" "$x"
+
+# ===========================================================================
+echo "== #1591 HEADLINE: a worktree's own hook governs that worktree's push =="
+# The worktree's copy of the hook refuses; the main checkout's still passes.
+# With the shim installed, the refusal must be the WORKTREE's.
+RIG="$(new_rig)"
+(cd "$RIG/checkout" && bash tools/install-git-hooks.sh) >/dev/null 2>&1
+(
+  cd "$RIG/worktree"
+  hook_stub worktree 1 >tools/git-hooks/pre-push
+  chmod +x tools/git-hooks/pre-push
+  git add -A && git commit -qm "worktree hook refuses"
+) >/dev/null 2>&1
+out=$(cd "$RIG/worktree" && git push origin feature 2>&1)
+rc=$?
+assert_eq "push is REFUSED" "1" "$rc"
+assert_contains "the hook that ran is the WORKTREE's copy" "HOOK-SCRIPT-FROM=worktree" "$out"
+assert_not_contains "the main checkout's copy did NOT run" "HOOK-SCRIPT-FROM=main" "$out"
+# exec must not eat the hook's interface: git hands a pre-push hook the remote
+# name and URL as argv, and the ref lines on stdin.
+assert_contains "argv survives the shim's exec" "HOOK-ARGC=2 HOOK-ARG1=origin" "$out"
+assert_contains "stdin survives the shim's exec" "HOOK-STDIN=nonempty" "$out"
+
+# ===========================================================================
+echo "== the committed mutation: the pre-#1591 symlink install lets it through =="
+# Identical rig, identical refusing worktree hook. The ONLY difference is the
+# install method. If this case ever starts refusing too, the headline above has
+# stopped discriminating and is passing for some other reason.
+RIG="$(new_rig)"
+ln -sf "$RIG/checkout/tools/git-hooks/pre-push" "$RIG/checkout/.git/hooks/pre-push"
+(
+  cd "$RIG/worktree"
+  hook_stub worktree 1 >tools/git-hooks/pre-push
+  chmod +x tools/git-hooks/pre-push
+  git add -A && git commit -qm "worktree hook refuses"
+) >/dev/null 2>&1
+out=$(cd "$RIG/worktree" && git push origin feature 2>&1)
+rc=$?
+assert_eq "old symlink install: the refusing push is ALLOWED — the defect" "0" "$rc"
+assert_contains "old symlink install: the MAIN checkout's copy ran" "HOOK-SCRIPT-FROM=main" "$out"
+assert_not_contains "old symlink install: the worktree's copy never ran" "HOOK-SCRIPT-FROM=worktree" "$out"
+
+# ===========================================================================
+echo "== a revision that genuinely carries no hook passes DELIBERATELY, loudly =="
+# The bisect / old-branch case: refusing here would punish `git bisect` for a
+# hook that was never this revision's to run.
+RIG="$(new_rig)"
+(cd "$RIG/checkout" && bash tools/install-git-hooks.sh) >/dev/null 2>&1
+(
+  cd "$RIG/worktree"
+  git rm -q tools/git-hooks/pre-push
+  git commit -qm "a revision from before the hook existed"
+) >/dev/null 2>&1
+out=$(cd "$RIG/worktree" && git push origin feature 2>&1)
+rc=$?
+assert_eq "no hook in HEAD and none on disk → push ALLOWED" "0" "$rc"
+assert_contains "…and it says so rather than passing in silence" "carries no tools/git-hooks/pre-push" "$out"
+
+# ===========================================================================
+echo "== a hook missing from the tree but present in HEAD REFUSES, loudly =="
+# A deleted file / interrupted checkout is an accident, not a revision without
+# the gate. A gate skipped because a file was invisible is this repo's
+# most-repeated failure shape.
+RIG="$(new_rig)"
+(cd "$RIG/checkout" && bash tools/install-git-hooks.sh) >/dev/null 2>&1
+(cd "$RIG/worktree" && echo x >x && git add x && git commit -qm work) >/dev/null 2>&1
+rm -f "$RIG/worktree/tools/git-hooks/pre-push"
+out=$(cd "$RIG/worktree" && git push origin feature 2>&1)
+rc=$?
+assert_eq "HEAD carries the hook, disk does not → push REFUSED" "1" "$rc"
+assert_contains "…and it names the broken working tree" "broken working tree" "$out"
+
+# ===========================================================================
+echo "== a present-but-not-executable hook REFUSES too =="
+RIG="$(new_rig)"
+(cd "$RIG/checkout" && bash tools/install-git-hooks.sh) >/dev/null 2>&1
+(cd "$RIG/worktree" && echo x >x && git add x && git commit -qm work) >/dev/null 2>&1
+chmod -x "$RIG/worktree/tools/git-hooks/pre-push"
+out=$(cd "$RIG/worktree" && git push origin feature 2>&1)
+rc=$?
+assert_eq "hook present but chmod -x → push REFUSED" "1" "$rc"
+assert_contains "…and it says what to do about it" "chmod +x" "$out"
+
+# ===========================================================================
+echo "== the installer replaces an older non-shim hook, and is idempotent =="
+RIG="$(new_rig)"
+TARGET="$RIG/checkout/.git/hooks/pre-push"
+# Start from exactly what the pre-#1591 installer left behind.
+ln -sf "$RIG/checkout/tools/git-hooks/pre-push" "$TARGET"
+first=$(cd "$RIG/checkout" && bash tools/install-git-hooks.sh 2>&1)
+assert_contains "an older symlink install is replaced, not left in place" "installed   pre-push" "$first"
+if [[ -L "$TARGET" ]]; then kind=symlink; elif [[ -f "$TARGET" ]]; then kind=file; else kind=absent; fi
+assert_eq "…by a regular file" "file" "$kind"
+# The `rm -f` before `cp` is what makes this safe: `cp` onto a symlink writes
+# THROUGH it, so without the rm this run would have overwritten the tracked
+# hook script with the shim's bytes.
+assert_contains "the tracked hook script was NOT written through the symlink" \
+  "HOOK-SCRIPT-FROM=main" "$(cat "$RIG/checkout/tools/git-hooks/pre-push")"
+second=$(cd "$RIG/checkout" && bash tools/install-git-hooks.sh 2>&1)
+assert_contains "a second run installs nothing" "up to date  pre-push" "$second"
+assert_not_contains "…and does not reinstall" "installed   pre-push" "$second"
+if [[ -e "$RIG/checkout/.git/hooks/shim" ]]; then stray=yes; else stray=no; fi
+assert_eq "the shim itself is never installed as a hook" "no" "$stray"
+
+# ===========================================================================
+echo "== the installer works from any cwd, and from a linked worktree =="
+# `git rev-parse --git-common-dir` answers relative to the CALLER's cwd, so an
+# installer that used it raw would create ./.git/hooks wherever it was invoked
+# and install nothing where git looks.
+RIG="$(new_rig)"
+ELSEWHERE="$(mktemp -d "$ROOT_TMP/elsewhere.XXXXXX")"
+(cd "$ELSEWHERE" && bash "$RIG/checkout/tools/install-git-hooks.sh") >/dev/null 2>&1
+if cmp -s "$REPO_ROOT/tools/git-hooks/shim" "$RIG/checkout/.git/hooks/pre-push"; then same=yes; else same=no; fi
+assert_eq "run from an unrelated cwd → the hook still lands in the real hooks dir" "yes" "$same"
+if [[ -e "$ELSEWHERE/.git" ]]; then stray=yes; else stray=no; fi
+assert_eq "…and no stray .git is created in that cwd" "no" "$stray"
+
+RIG="$(new_rig)"
+# From the worktree, --git-common-dir must resolve to the MAIN checkout's .git.
+(cd "$RIG/worktree" && bash tools/install-git-hooks.sh) >/dev/null 2>&1
+if cmp -s "$REPO_ROOT/tools/git-hooks/shim" "$RIG/checkout/.git/hooks/pre-push"; then same=yes; else same=no; fi
+assert_eq "run from a linked worktree → installs into the SHARED hooks dir" "yes" "$same"
+if [[ -e "$RIG/worktree/.git/hooks/pre-push" ]]; then stray=yes; else stray=no; fi
+assert_eq "…not into a per-worktree hooks dir git never reads" "no" "$stray"
+
+# ===========================================================================
+echo "== the installer refuses when the shim is missing =="
+RIG="$(new_rig)"
+rm -f "$RIG/checkout/tools/git-hooks/shim"
+out=$(cd "$RIG/checkout" && bash tools/install-git-hooks.sh 2>&1)
+rc=$?
+assert_eq "no shim → exit 1, not a hook chain with nothing to delegate through" "1" "$rc"
+assert_contains "…and it names the file" "tools/git-hooks/shim" "$out"
+
+echo ""
+if [[ "$fails" -eq 0 ]]; then
+  echo "git-hooks_test: ALL PASS"
+else
+  echo "git-hooks_test: $fails FAILED" >&2
+  exit 1
+fi

--- a/tools/preflight.sh
+++ b/tools/preflight.sh
@@ -360,11 +360,12 @@ shell_lib_tests() {
 # ===========================================================================
 
 # ---- posix group (mirrors linux.yml's "Lint POSIX sh scripts" step) --------
-# The #!/bin/sh corpus is two files today (site/install.sh and
-# tools/linux-replay-entrypoint.sh) and the gate re-lints all of them whenever
-# it fires — it is a fraction of a second, and the trigger cannot enumerate
-# them anyway, because a NEW POSIX script is exactly the file the gate most
-# needs to see on the push that adds it. So the regex is deliberately loose:
+# The #!/bin/sh corpus is three files today (site/install.sh,
+# tools/linux-replay-entrypoint.sh and tools/git-hooks/shim) and the gate
+# re-lints all of them whenever it fires — it is a fraction of a second, and
+# the trigger cannot enumerate them anyway, because a NEW POSIX script is
+# exactly the file the gate most needs to see on the push that adds it. So the
+# regex is deliberately loose:
 # any *.sh, any extensionless file under tools/ or site/, plus the linter and
 # its own corpus. Over-firing costs milliseconds; under-firing is #1209's
 # silent-skip shape again.
@@ -412,7 +413,10 @@ if want tools; then
   # site/install.sh is in the trigger set because tools/lib/install-uninstall_test.sh
   # tests it (#1416). Without it a push touching only the installer would SKIP
   # the one gate that covers the installer.
-  run_gate_scoped '^tools/lib/|^tools/[^/]*\.sh$|^go\.work$|^\.github/dependabot\.yml$|^site/install\.sh$' \
+  # tools/git-hooks/ is in it for the same reason (#1591): git-hooks_test.sh
+  # covers the shim and the hook scripts, and neither matches `^tools/[^/]*\.sh$`
+  # — they are extensionless files one directory down.
+  run_gate_scoped '^tools/lib/|^tools/[^/]*\.sh$|^tools/git-hooks/|^go\.work$|^\.github/dependabot\.yml$|^site/install\.sh$' \
                   "tools/lib shell-lib tests" shell_lib_tests
 fi
 


### PR DESCRIPTION
Closes #1591

## The premise, verified rather than trusted

`.git/hooks/pre-push` in this repo really is a symlink into the **main
checkout**:

```
$ ls -l "$(git rev-parse --git-common-dir)/hooks/pre-push"
lrwxr-xr-x  ...  pre-push -> /Users/ingo/projects/irrlicht/tools/git-hooks/pre-push
```

Reproduced end to end in a throwaway trio (bare origin + main checkout + linked
worktree). The worktree's own hook says `exit 1`; the push is **allowed**,
because the main checkout's copy is what ran:

```
--- push from worktree (its own hook says REFUSE) ---
HOOK-FROM: worktree            <- the MAIN checkout's script, reading the worktree's cwd
To ../origin.git
 * [new branch]      feature -> feature
```

## How the hook environment actually behaves (measured, git 2.50.1, macOS)

Probed from inside a real pre-push hook while a **linked worktree** pushed:

```
PWD=<worktree>                                        <- worktree root, even when `git push` ran from a subdirectory
dollar0=<main-checkout>/.git/hooks/pre-push           <- the MAIN checkout, always
GIT_DIR=<main-checkout>/.git/worktrees/wt             <- set
GIT_WORK_TREE=<unset>
show-toplevel=<worktree>                              <- correct, WITH GIT_DIR set
git-common-dir=<main-checkout>/.git
```

So `git rev-parse --show-toplevel` is exactly what is needed and needs no
`GIT_DIR` unsetting first, while `$0` must never be used to find the root. Its
*basename* is reliable — git looks a hook up by name — which is what lets one
shim serve every hook.

One correction to the issue: `tools/git-hooks/pre-push` does **not** resolve
the root with `rev-parse`; it relies on git's cwd guarantee (`./tools/preflight.sh`).
That still worked, so the defect was narrower than "the worktree's preflight
never ran" — the *hook script itself* came from main while everything it
invoked came from the worktree.

## The fix

`tools/git-hooks/shim`, a POSIX-sh file copied **verbatim** into
`.git/hooks/<name>` by the installer. It resolves the pushing tree and execs
that tree's own `tools/git-hooks/<name>`.

**Decision 1 — the shim is the one link a `git pull` cannot update.** Stated in
both files rather than left implied. It is the right way round: the shim
resolves a path and execs and has no reason to change, while the hook it
delegates to changes often and is now picked up with no install step. The
installer therefore **overwrites** whatever it finds — an older symlink, a
hand-edited copy, a stale shim — and a second run installs nothing.

The `rm -f` before `cp` is load-bearing, not tidiness: `cp` onto a symlink
writes *through* it, so upgrading an old clone without it would overwrite the
tracked hook script with the shim's bytes. That has a test.

**Decision 2 — the two ways a hook can be absent get opposite answers.**
"Fail loudly" everywhere makes `git bisect` hostile; "pass quietly" everywhere
is a silently-missing gate. The distinguisher is `HEAD`:

- **No hook on disk and none in `HEAD`** → this revision genuinely carries no
  gate (bisect, a branch predating the file). There is nothing to skip, so it
  **passes**, with a note on stderr every time naming the reading that would
  mean something is wrong.
- **No hook on disk but `HEAD` carries it**, or present-but-not-executable →
  a broken working tree, not a revision without the hook. **Refuses**, and says
  what to do about it. A gate skipped because a file was invisible is this
  repo's most-repeated failure shape.

`git rev-parse --show-toplevel` failing also refuses: a gate that cannot find
itself must not read as a pass.

## Also: `changed-files.sh` missed untracked files — fixed, not documented away

`git diff` cannot see a file that was never added and `--cached` only catches it
once staged, so a newly written file selected **no gates at all** on a manual
`tools/preflight.sh --changed`, while the function's own doc said uncommitted
work counted. Fixed rather than documented, because a gate silently skipped for
an invisible file is precisely the shape above.

`--full-name -- :/` is load-bearing and the naive spelling would have looked
right forever. Measured, called from `tools/` with an untracked `core/new.go`
and `tools/new.sh`:

```
git ls-files --others --exclude-standard              -> new.sh              (cwd-scoped, cwd-relative)
git ls-files --others --exclude-standard --full-name -- :/  -> core/new.go
                                                               tools/new.sh  (matches git diff)
```

`--exclude-standard` keeps gitignored build output out; a set that swept it in
would put every gate in scope on every run, which is a different way of meaning
nothing. Both directions are asserted.

## Tests, and the mutations seen red

`tools/lib/git-hooks_test.sh` (new, 30 assertions, ~9s) builds throwaway repo
trios and performs **real pushes** over a filesystem path. Nothing in it touches
the real `.git/hooks/` — verified untouched after the whole session.

Per AGENTS.md the headline mutation is **committed beside the assertion** rather
than described here: one case installs the pre-#1591 symlink into the
*identical* rig with the *identical* refusing worktree hook and pins the
**opposite** outcome. Without it, "a refusal happened" could be satisfied by a
rig where nothing ran at all.

Six deliberate mutations were also run live, restored by copy-aside/copy-back
with a `git status --porcelain` assertion after each (never `git stash` — shared
across worktrees here):

| # | mutation | result |
|---|---|---|
| 1 | `install-git-hooks.sh` reverted to the pre-#1591 symlink installer | **19 FAILED** — incl. `push is REFUSED expected [1] got [0]`, `the hook that ran is the WORKTREE's copy expected [contains: HOOK-SCRIPT-FROM=worktree] got [HOOK-SCRIPT-FROM=main]` |
| 2 | shim's `HEAD`-check replaced with `if false` (always passes) | **4 FAILED**, all in the two must-refuse cases; the bisect case stays green |
| 3 | shim's deliberate pass flipped to `exit 1` (always refuses) | **1 FAILED**, only the bisect case; both must-refuse cases stay green |
| 4 | `rm -f "$target"` dropped before `cp` | **4 FAILED** — incl. `the tracked hook script was NOT written through the symlink`, which the mutation overwrites with the shim |
| 5 | untracked line removed from `changed-files.sh` | **5 FAILED** — incl. `a tree whose ONLY change is an untracked file is not an empty set expected [core/brand_new.go] got []` |
| 6 | naive `git ls-files --others` (no `--full-name -- :/`) | **1 FAILED** — only the subdirectory case: `expected [core/brand_new.go] got [brand_new.go]` |

Mutations 2 and 3 are the pair that matters for Decision 2: opposite polarities
redden **disjoint** arms, which is what proves the two missing-hook situations
are genuinely distinguished rather than both landing on one answer.

Mutation 1 also surfaced a latent bug in the old installer, now fixed and
tested: `git rev-parse --git-common-dir` answers *relative to the caller's cwd*,
so running the installer from anywhere but the repo root created a stray
`./.git/hooks` and installed nothing where git looks
(`…no stray .git is created in that cwd — expected [no] got [yes]`).

Composition with the **real** hook (not a stub) was checked too, by squeezing
the budget so it terminates fast: the shim execs this worktree's own
`tools/git-hooks/pre-push`, which runs `./tools/preflight.sh --changed --budget 1`
from the right cwd and reports `TIMEOUT` by name.

## The irony, stated plainly

**This PR's own push still ran the old hook**, because the fix cannot govern the
branch that introduces it — the shim only takes effect once someone re-runs
`tools/install-git-hooks.sh`, and the installed hook is shared repo state that
other in-flight worktrees are using, so this branch deliberately did **not**
install it. That is the same shape as PR #1590 and is exactly what this change
removes for the *next* hook edit.

What was done instead:

- the behaviour was exercised in throwaway rigs with real `git push` calls, which
  is stronger than one hand-run, and it is committed so it re-runs forever;
- the real shared `.git/hooks/pre-push` was left exactly as found
  (verified: still the pre-#1591 symlink);
- every gate this diff triggers was run **chunked, in the foreground**, by hand.

## Verification

| gate | result |
|---|---|
| `tools/preflight.sh --only tools` | **PASS** (includes the new `git-hooks_test.sh`) |
| `tools/preflight.sh --only posix` | **PASS** — `3 file(s); parser=dash, bashisms=shellcheck checkbashisms`, and `ok tools/git-hooks/shim` is one of them |
| `tools/preflight.sh --only skills` | **PASS** (23 files) |
| `--changed --only go` | gofmt **PASS**; the rest correctly SKIP |
| `--changed --only arch` / `web` / `security` | correctly **SKIP** |
| `--changed --only swift` | **TIMEOUT**, twice, at 460s and 540s — see below |
| `cd platforms/macos && swift build` | **PASS** (4.62s) — what `macos-swift.yml` actually gates |

The `swift` gate fires only because its trigger includes `^tools/preflight\.sh$`;
this diff contains **zero** Swift files, and the whole `preflight.sh` change is
one reflowed comment plus `^tools/git-hooks/` added to the `tools` gate's trigger
regex. Both runs stall inside `SessionRowSnapshotTests`, which is the condition
AGENTS.md already records as measured on this machine **at `origin/main`**
(#1523/#1530: "the suite reaches `SessionRowSnapshotTests.testRelayCloudOnline`
and stops there"). Marked honestly: I did **not** re-measure it on `origin/main`
in this session, so "pre-existing" rests on AGENTS.md's recorded measurement plus
the fact that the diff cannot reach Swift, not on a fresh A/B.

The `tools` gate's trigger gained `^tools/git-hooks/` — without it a push
touching only the shim or a hook would have skipped the one gate that covers
them, which is #1209's silent-skip shape.

## Found, not fixed

`tools/posix-lint.sh` walks `git ls-files`, which lists tracked and staged files
but **not** untracked ones. So now that an untracked `#!/bin/sh` script puts the
posix gate *in scope*, the gate can fire and then lint every file except the new
one — the "gate ran, saw nothing" shape it was built to remove. Not fixed here:
it needs its own mutation evidence, and untracked files are neither pushed nor
present in CI, so the blast radius is a manual `--changed` run only. Worth its
own issue.

## Not done

Not merged. The installed hook is unchanged on this machine, so
`tools/install-git-hooks.sh` needs one run after merge to pick the shim up
(it overwrites the old symlink and is idempotent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
