### PR TITLE
fix(tooling): posix-lint walks untracked files, so it can see the script that put it in scope

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -834,13 +834,24 @@ Before marking a ticket done, run the full suite — every layer must pass:
   `tools/lib/testdata/skill-lint/` — so the assertions never move when a real
   skill file is edited, and `testdata/` is excluded from the gate's own walk
   because those fixtures are deliberately corrupt.
-- POSIX shell scripts: `tools/posix-lint.sh` checks every tracked file whose
-  **first line** is a `#!/bin/sh` shebang — today `site/install.sh`,
+- POSIX shell scripts: `tools/posix-lint.sh` checks every file git knows
+  about — tracked, plus **untracked and not gitignored** (#1611) — whose
+  **first line** is a `#!/bin/sh` shebang; today `site/install.sh`,
   `tools/linux-replay-entrypoint.sh` and `tools/git-hooks/shim` (#1591 brought
   the third into scope, which is the whole reason that file was written in
   POSIX sh rather than bash). Line 1 only, because
   `tools/lib/install-uninstall_test.sh` is a bash file that writes `#!/bin/sh`
   stubs inside a heredoc, and a content grep would try to lint it as POSIX sh.
+  The untracked half is #1611 and it is #1591's own consequence one layer
+  down: once `changed_files_vs_origin_main` counted untracked files, a brand
+  new `#!/bin/sh` script DID put this gate in scope, and a gate walking
+  `git ls-files` then could not see the file that summoned it — `ALL PASS`
+  over a file it never read, this gate's founding incident arriving through
+  file selection. Untracked paths join the SAME stream and the SAME loop as
+  tracked ones rather than getting a second walk, so the `testdata/` exclusion
+  and the line-1 rule cannot apply to only half the set; the mis-implementation
+  is not hypothetical — measured, a second walk lints the deliberately-corrupt
+  fixture corpus and the linter's own bash source.
   It runs two different kinds of check on each file: a real POSIX shell's
   parser (`dash -n`) and **every** static bashism linter installed —
   `shellcheck --shell=sh` filtered to its POSIX-compatibility codes

--- a/tools/lib/posix-lint_test.sh
+++ b/tools/lib/posix-lint_test.sh
@@ -22,6 +22,12 @@
 # eight `bad-*` assertions and be worthless, and only the clean fixture can
 # tell those two apart.
 #
+# Cases 10a-10e cover #1611, the same shape arriving through file SELECTION:
+# the gate walked `git ls-files` and so could not see an untracked script,
+# which since #1609 is exactly the file that puts it in scope. They build
+# their own throwaway git repos, because the fixtures here are tracked and
+# tracked-ness is the property under test.
+#
 # The last two cases assert the gate's REFUSALS rather than its findings —
 # that a missing POSIX shell and a missing bashism linter each exit 2 instead
 # of passing. Those are the paths by which this gate could itself become the
@@ -195,6 +201,150 @@ rc=$?
 assert_eq "discovery: the repo's real #!/bin/sh scripts pass (exit 0)" "0" "$rc"
 assert_contains "discovery: site/install.sh is in scope" "site/install.sh" "$out"
 assert_not_contains "discovery: testdata fixtures are excluded" "testdata/posix-lint" "$out"
+
+# ===========================================================================
+# 10a-10e. UNTRACKED FILES (#1611).
+#
+#     `git ls-files` lists index entries only. That was harmless until #1609
+#     taught `changed_files_vs_origin_main` to include untracked files: a new,
+#     untracked `#!/bin/sh` script now DOES put this gate in scope via
+#     `tools/preflight.sh --changed`, and the gate then walked the index and
+#     could not see the file that summoned it — `ALL PASS` over a file it
+#     never read. That is #1423 arriving through file selection instead of
+#     through the pipeline, so it gets the same treatment: a committed
+#     mutation rather than one that disappears with the PR.
+#
+#     These cases cannot use the fixtures above — those are TRACKED, which is
+#     the one property under test — so each builds a throwaway git repo and
+#     plants its own untracked file there.
+#
+#     Measured on the pre-fix gate, the same scratch repo: `posix-lint: 1
+#     file(s)` / `ALL PASS` / exit 0 with `untracked-bad.sh` sitting in the
+#     tree carrying a deliberate `[[ ]]`.
+# ===========================================================================
+
+# scratch_repo <dir> — a throwaway git repo holding a copy of the gate at the
+# path it derives its root from (<root>/tools/posix-lint.sh, via $0) plus ONE
+# tracked, clean `#!/bin/sh` script. Callers plant the untracked file whose
+# treatment is under test, so the file-count line below is a full census.
+#
+# The gate copy is itself untracked and carries a `#!/usr/bin/env bash`
+# shebang, so it doubles as "an untracked file that is NOT POSIX sh must not
+# be dragged into the walk" — if it were, every count below would be one high.
+scratch_repo() {
+  local d="$1"
+  rm -rf "$d" && mkdir -p "$d/tools" && cp "$LINT" "$d/tools/posix-lint.sh" || return 1
+  (
+    cd "$d" || exit 1
+    git init -q . || exit 1
+    printf '#!/bin/sh\necho clean\n' > tracked-clean.sh || exit 1
+    git add tracked-clean.sh || exit 1
+    # The fixture IS the test here. A scratch repo that did not come up would
+    # make every assertion below grade a tree git cannot read, and a gate that
+    # found nothing to lint is indistinguishable from a gate that found
+    # nothing wrong — the shape this whole file exists to refuse.
+    [[ -n "$(git ls-files)" ]] || exit 1
+  ) || return 1
+}
+
+untracked_tmp="$(mktemp -d)"
+scratch="$untracked_tmp/repo"
+
+# 10a. THE MUTATION. An untracked #!/bin/sh file carrying a bashism must make
+#      the gate FAIL and must be NAMED. Without this case the fix is
+#      unfalsifiable: the gate passes on a clean tree either way, and passing
+#      is exactly what it did before for the wrong reason.
+if scratch_repo "$scratch"; then
+  printf '#!/bin/sh\nif [[ "$1" == x ]]; then echo hi; fi\n' > "$scratch/untracked-bad.sh"
+  out=$( cd "$scratch" && ./tools/posix-lint.sh 2>&1 )
+  rc=$?
+  assert_eq "untracked: a bashism in an UNTRACKED script fails the gate" "1" "$rc"
+  assert_contains "untracked: the untracked file is named on a FAIL line" \
+    "FAIL [bashisms] untracked-bad.sh" "$out"
+else
+  echo "  FAIL: untracked: scratch repo could not be built" >&2
+  fails=$((fails + 1))
+fi
+
+# 10b. The direction that fails SILENTLY, and therefore the one that needs the
+#      stronger assertion: a clean untracked script must pass AND must have
+#      been SEEN. Exit 0 alone is satisfied by never looking at it, which is
+#      the defect. So pin the census — 2 files, the tracked one and the
+#      untracked one, which also rules out the file being counted twice — and
+#      pin the per-file `ok` line that says the gate actually read it.
+if scratch_repo "$scratch"; then
+  printf '#!/bin/sh\necho untracked and clean\n' > "$scratch/untracked-clean.sh"
+  out=$( cd "$scratch" && ./tools/posix-lint.sh 2>&1 )
+  rc=$?
+  assert_eq "untracked: a clean UNTRACKED script passes (exit 0)" "0" "$rc"
+  assert_contains "untracked: the file count moved — it was actually walked" \
+    "posix-lint: 2 file(s)" "$out"
+  assert_contains "untracked: the clean untracked file is reported ok" \
+    "ok  untracked-clean.sh" "$out"
+else
+  echo "  FAIL: untracked: scratch repo could not be built" >&2
+  fails=$((fails + 1))
+fi
+
+# 10c. The testdata/ exclusion applies to untracked files too — a plausible
+#      mis-implementation is a SECOND walk that skips the filters the first
+#      one applies. Pinning the count at 1 rather than only the exit status is
+#      what tells "excluded" from "walked and happened to be clean".
+if scratch_repo "$scratch"; then
+  mkdir -p "$scratch/tools/lib/testdata/posix-lint"
+  printf '#!/bin/sh\nif [[ "$1" == x ]]; then echo hi; fi\n' \
+    > "$scratch/tools/lib/testdata/posix-lint/bad-untracked.sh"
+  out=$( cd "$scratch" && ./tools/posix-lint.sh 2>&1 )
+  rc=$?
+  assert_eq "untracked: a fixture under testdata/ is still excluded (exit 0)" "0" "$rc"
+  assert_contains "untracked: testdata/ exclusion leaves the census at 1" \
+    "posix-lint: 1 file(s)" "$out"
+else
+  echo "  FAIL: untracked: scratch repo could not be built" >&2
+  fails=$((fails + 1))
+fi
+
+# 10d. The FIRST-LINE rule applies to untracked files too. This file is bash
+#      and writes a `#!/bin/sh` stub inside a heredoc — exactly the shape of
+#      tools/lib/install-uninstall_test.sh, which is why the selector reads
+#      line 1 and not the file's content.
+if scratch_repo "$scratch"; then
+  {
+    printf '#!/usr/bin/env bash\n'
+    printf 'cat > stub <<EOF\n#!/bin/sh\nif [[ "$1" == x ]]; then echo hi; fi\nEOF\n'
+  } > "$scratch/untracked-bash.sh"
+  out=$( cd "$scratch" && ./tools/posix-lint.sh 2>&1 )
+  rc=$?
+  assert_eq "untracked: a bash file quoting a #!/bin/sh stub is not linted (exit 0)" "0" "$rc"
+  assert_contains "untracked: first-line rule leaves the census at 1" \
+    "posix-lint: 1 file(s)" "$out"
+else
+  echo "  FAIL: untracked: scratch repo could not be built" >&2
+  fails=$((fails + 1))
+fi
+
+# 10e. A LOCK, not a mutation — say so rather than let it read as evidence.
+#      #1609 measured that a bare `git ls-files --others` lists only what is
+#      under the CALLER'S cwd, and prints it cwd-relative, so the naive
+#      spelling looks correct forever from the repo root. The gate cds to its
+#      own root before discovering, so `--full-name -- :/` cannot be
+#      discriminated from the bare form here today and this case passes either
+#      way. It is kept because the `cd` is the only thing making that true,
+#      and a future refactor that moves it would otherwise silently reinstate
+#      the cwd-scoped walk.
+if scratch_repo "$scratch"; then
+  printf '#!/bin/sh\nif [[ "$1" == x ]]; then echo hi; fi\n' > "$scratch/untracked-bad.sh"
+  out=$( cd "$scratch/tools" && ./posix-lint.sh 2>&1 )
+  rc=$?
+  assert_eq "untracked (lock): invoked from a subdirectory, still fails" "1" "$rc"
+  assert_contains "untracked (lock): the root-relative path is named" \
+    "FAIL [bashisms] untracked-bad.sh" "$out"
+else
+  echo "  FAIL: untracked: scratch repo could not be built" >&2
+  fails=$((fails + 1))
+fi
+
+rm -rf "$untracked_tmp"
 
 # ===========================================================================
 # 11. Refusal: no POSIX shell. A PATH without dash/ash must exit 2, not 0.

--- a/tools/posix-lint.sh
+++ b/tools/posix-lint.sh
@@ -46,7 +46,8 @@
 # not skips: no POSIX shell available, no static linter available, and an
 # empty file set. Each exits 2 with a message saying what to install.
 #
-# Scope: every tracked file whose FIRST LINE is a POSIX-sh shebang
+# Scope: every file git knows about — tracked, plus untracked and not
+# gitignored (#1611) — whose FIRST LINE is a POSIX-sh shebang
 # (`#!/bin/sh`, `#!/usr/bin/env sh`, with or without flags). Matching line 1
 # only is deliberate — `tools/lib/install-uninstall_test.sh` is a bash file
 # that writes `#!/bin/sh` stubs inside a heredoc, and a content grep would try
@@ -100,17 +101,50 @@ if [[ ${#FILES[@]} -eq 0 ]]; then
   # `ALL PASS`. The empty-set guard below cannot catch that, because it only
   # fires when EVERY file is missed. NUL delimiting also survives newlines and
   # spaces in paths (this repo tracks one with a space).
+  #
+  # UNTRACKED FILES ARE WALKED TOO (#1611), and the second `ls-files` is that.
+  # `git ls-files` alone lists index entries only, which was harmless until
+  # #1609 taught `changed_files_vs_origin_main` (tools/lib/changed-files.sh)
+  # to include untracked files: a brand-new `#!/bin/sh` script now DOES put
+  # this gate in scope via `tools/preflight.sh --changed`, and the gate then
+  # walked the index and could not see the file that summoned it — `ALL PASS`
+  # over a file it never read. That is this script's own founding incident
+  # (see lint_bashisms below) arriving through file selection instead of the
+  # pipeline. `--exclude-standard` keeps .gitignore honoured, which is what
+  # keeps `.claude/worktrees/` — entire checkouts of this repo — out of the
+  # walk, the same reason `find` was rejected above.
+  #
+  # `--full-name -- :/` is the spelling changed-files.sh uses and measured:
+  # a bare `--others` lists only what is under the CALLER'S cwd and prints it
+  # cwd-relative, while `git ls-files` is repo-root-relative over the whole
+  # repo. Here the `cd "$ROOT_DIR"` above already pins cwd to the repo root,
+  # so the two spellings agree TODAY — it is kept in lockstep with its sibling
+  # rather than re-derived, because the naive spelling looks correct forever
+  # from the root and would start dropping files the moment that `cd` moved.
+  #
+  # Both lists feed ONE stream and ONE loop, so every path — tracked or not —
+  # is subject to the same two rules: the `testdata/` exclusion and the
+  # first-line shebang test. A second loop for the untracked half is the
+  # obvious alternative and is the mis-implementation cases 10c/10d of
+  # tools/lib/posix-lint_test.sh were written against: measured, it lints the
+  # deliberately-corrupt fixture corpus AND this file's own bash copy. The two
+  # sets are disjoint by construction (index vs `--others`), so `-u` is not
+  # what prevents double-counting; it is the shared `sort` the existing walk
+  # already needed.
   while IFS= read -r -d '' f; do
     [[ "$f" == */testdata/* ]] && continue
     if [[ ! -f "$f" ]]; then
-      # Loud, not silent: a tracked path the walk cannot open is exactly the
-      # blind spot above, and the whole point of this gate is that "not
-      # looked at" must never render as "clean".
-      echo "posix-lint: skipping $f (tracked but not a regular file)" >&2
+      # Loud, not silent: a path git listed but the walk cannot open is
+      # exactly the blind spot above, and the whole point of this gate is
+      # that "not looked at" must never render as "clean".
+      echo "posix-lint: skipping $f (listed by git but not a regular file)" >&2
       continue
     fi
     is_posix_shebang "$f" && FILES+=("$f")
-  done < <(git -c core.quotePath=off ls-files -z | LC_ALL=C sort -z -u)
+  done < <({
+    git -c core.quotePath=off ls-files -z
+    git -c core.quotePath=off ls-files --others --exclude-standard --full-name -z -- :/
+  } | LC_ALL=C sort -z -u)
 fi
 
 if [[ ${#FILES[@]} -eq 0 ]]; then


### PR DESCRIPTION
Closes #1611

## The gap

`tools/posix-lint.sh` selected its files with `git ls-files`, which lists index
entries only. That was harmless while an untracked file could not put the gate
in scope either — the gate simply did not run.

PR #1609 changed that: `changed_files_vs_origin_main` now counts untracked,
non-gitignored files, so a new `#!/bin/sh` script **does** put the posix gate in
scope. The gate then walked the index, could not see the file that summoned it,
and reported `ALL PASS` over a file it never read — this gate's own founding
incident ("printed `ALL PASS` over an installer carrying a deliberate `[[ ]]`")
arriving through file **selection** instead of through the pipeline.

Reproduced in this worktree at `63c0f095`, with one untracked bashism-carrying
script as the only change in the tree:

```
$ printf '#!/bin/sh\nif [[ "$1" == x ]]; then echo hi; fi\n' > scratch-untracked-probe.sh
$ tools/preflight.sh --changed --only posix
  POSIX sh lint (#!/bin/sh bashisms)
posix-lint: 3 file(s); parser=dash, bashisms=shellcheck checkbashisms
  ok  site/install.sh
  ok  tools/git-hooks/shim
  ok  tools/linux-replay-entrypoint.sh
posix-lint: ALL PASS
  POSIX sh lint (#!/bin/sh bashisms)                         PASS
```

The gate ran *because of* that file — with a clean tree the same command reports
`SKIP (no changed files match)` — and none of the three files it read was it.

## Blast radius — confirmed as stated, with one correction

Local runs only; a bashism cannot reach `main` through this. To be pushed a file
must be committed, which makes it an index entry, which `git ls-files` sees; CI
checks out a commit, so everything it walks is tracked. Verified by running the
gate unscoped on a clean checkout and by the reproduction above.

The one correction to the issue's wording: it says the pre-push hook "never sees"
an untracked file. The hook runs `tools/preflight.sh --changed`, so it **does**
put the gate in scope for an untracked file sitting in the tree at push time — it
just isn't pushing that file. Same audience, same harm (a developer told their new
script is clean when nothing looked at it), one more entry point than stated.

## The fix

Untracked paths join the **same stream and the same loop** as tracked ones, using
the spelling `tools/lib/changed-files.sh` already measured:

```sh
git ls-files --others --exclude-standard --full-name -- :/
```

- `--exclude-standard` keeps `.gitignore` honoured, which is what keeps
  `.claude/worktrees/` — entire checkouts of this repo — out of the walk, the
  same reason `find` was rejected in the first place.
- `--full-name -- :/` is redundant *today*, because the gate `cd`s to its own root
  before discovering, and the comment says so rather than implying it is load
  bearing. It is kept in lockstep with its sibling because the naive spelling
  looks correct forever from the root and would start dropping files the moment
  that `cd` moved.
- One loop, not two, so the `testdata/` exclusion and the line-1 shebang rule
  cannot apply to only half the set.

## Mutation evidence

Committed as cases 10a-10e in `tools/lib/posix-lint_test.sh`, which build
throwaway git repos — the corpus fixtures are tracked, and tracked-ness is the
property under test.

### 1. The defect direction, against the unfixed gate

Gate restored from `HEAD` by copy-aside/copy-back (never `git stash`), tree
asserted identical before and after:

```
  FAIL: untracked: a bashism in an UNTRACKED script fails the gate — expected [1] got [0]
  FAIL: untracked: the untracked file is named on a FAIL line — expected [contains 'FAIL [bashisms] untracked-bad.sh'] got [posix-lint: 1 file(s); parser=dash, bashisms=shellcheck checkbashisms
posix-lint: ALL PASS]
```

### 2. The untracked-and-CLEAN direction, which is the one that fails silently

Note the first line: on the unfixed gate a clean untracked script **passes**, so
exit status alone is vacuous here. The assertions that discriminate are the ones
proving the file was actually *seen*:

```
  PASS: untracked: a clean UNTRACKED script passes (exit 0)
  FAIL: untracked: the file count moved — it was actually walked — expected [contains 'posix-lint: 2 file(s)'] got [posix-lint: 1 file(s); parser=dash, bashisms=shellcheck checkbashisms
posix-lint: ALL PASS]
  FAIL: untracked: the clean untracked file is reported ok — expected [contains 'ok  untracked-clean.sh'] got [posix-lint: 1 file(s); parser=dash, bashisms=shellcheck checkbashisms
posix-lint: ALL PASS]
```

### 3. The guards this PR *adds* (10c/10d), against a mis-implemented fix

Cases 10c/10d pass on `main` — they are not defect tests, they are guards on the
new code — so per AGENTS.md they owe a deliberate mutation. The plausible wrong
shape is a **second** walk for the untracked half that skips the two rules the
first one applies. Measured, that walk lints the deliberately-corrupt fixture
corpus and drags in the linter's own bash source (census 3, not 1):

```
  FAIL: untracked: a fixture under testdata/ is still excluded (exit 0) — expected [0] got [1]
  FAIL: untracked: testdata/ exclusion leaves the census at 1 — expected [contains 'posix-lint: 1 file(s)'] got [posix-lint: 3 file(s); ...
FAIL [bashisms] tools/lib/testdata/posix-lint/bad-untracked.sh
  FAIL: untracked: a bash file quoting a #!/bin/sh stub is not linted (exit 0) — expected [0] got [1]
  FAIL: untracked: first-line rule leaves the census at 1 — expected [contains 'posix-lint: 1 file(s)'] got [posix-lint: 3 file(s); ...
```

### 4. Case 10e is a LOCK, and says so

The subdirectory case cannot discriminate `--full-name -- :/` from the bare form
while the gate `cd`s to its root first — it passes either way. It is labelled a
lock in the file rather than presented as evidence, and is kept because that `cd`
is the only thing making it true.

### 5. Green after the fix

```
posix-lint_test: ALL PASS
```

and end to end, the same reproduction that printed `ALL PASS` now prints:

```
posix-lint: 4 file(s); parser=dash, bashisms=shellcheck checkbashisms
FAIL [bashisms] scratch-untracked-probe.sh
scratch-untracked-probe.sh:2:4: warning: In POSIX sh, [[ ]] is undefined. [SC3010]
...
  POSIX sh lint (#!/bin/sh bashisms)                         FAIL
```

## Where this suite actually runs

Worth restating because it decides what CI proves about this change:
`tools/lib/posix-lint_test.sh` runs in **`linux.yml`** ("Test the POSIX-sh gate"),
and `test.yml`'s `tools/lib/*_test.sh` loop skips it **by name** — it needs a
static bashism linter the macOS image does not ship. Locally, `preflight.sh`'s
`tools` gate does run it (its loop has no such exclusion), which is where the
green above comes from.

## Verification

- `tools/preflight.sh --only posix` — PASS
- `tools/preflight.sh --only tools` — PASS (includes `posix-lint_test`, confirmed
  by grepping the gate's own output for the new case names)
- Pre-push hook: PASS on both, no `TIMEOUT`, no `NOT RUN`; push confirmed landed
  via `git status -sb` showing a tracking branch.
- `swift` stayed `SKIP`: `tools/preflight.sh` is deliberately untouched.

## Not fixed here

- `tools/posix-lint.sh`'s "listed by git but not a regular file" message can now
  fire for an untracked **nested git repository**, which `git ls-files --others`
  emits as a `dir/` entry. It is loud rather than silent, which is the gate's
  design, so it is noise and not a blind spot — left alone rather than special
  cased on speculation.
- `tools/preflight.sh`'s posix-gate comment still says "The `#!/bin/sh` corpus is
  three files today". Still true of the tracked corpus, and editing that file
  would have pulled a ~10 minute Swift suite into this PR's scope for a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
