### PR TITLE
fix(macos): make the Swift test suite run on a GitHub runner, and gate it there (#1530)

### DIFF
--- a/.github/workflows/macos-swift.yml
+++ b/.github/workflows/macos-swift.yml
@@ -152,10 +152,13 @@ jobs:
       # cross-checks it against these very arguments, so a new one fails there
       # rather than reddening an unrelated PR's check.
       #
-      # This still gates 270 of 318 tests, against 0 before. Two image-snapshot
-      # suites are deliberately NOT skipped — they pass on a runner, and their
-      # passing is itself evidence that the residual is content-dependent
-      # rather than a blanket toolchain difference.
+      # This still gates 272 of 320 tests, against 0 before — measured, on this
+      # workflow's own run, not derived from the list above by hand (the first
+      # draft of this comment said "270 of 318" and was stale by exactly the
+      # two tests the tripwire itself adds). Two image-snapshot suites are
+      # deliberately NOT skipped — they pass on a runner, and their passing is
+      # itself evidence that the residual is content-dependent rather than a
+      # blanket toolchain difference.
       - name: Test (bounded, streamed under a pty)
         shell: bash
         run: |

--- a/.github/workflows/macos-swift.yml
+++ b/.github/workflows/macos-swift.yml
@@ -1,39 +1,47 @@
 name: macOS (Swift)
 
-# Compile gate for the macOS Swift app. Until #1509 nothing in CI ran `swift
-# build` or `swift test` at all: a Swift compile error could land on `main`
-# and no check would notice, because test.yml's macOS job builds Go. That is
-# the hole this closes.
+# Build + test gate for the macOS Swift app. Until #1509 nothing in CI ran
+# `swift build` or `swift test` at all: a Swift compile error could land on
+# `main` and no check would notice, because test.yml's macOS job builds Go.
+# That is the hole this closes.
 #
-# It builds and does NOT test, which is a smaller claim than this workflow's
-# name suggests, so it is worth being explicit: the test suite does not
-# currently pass on a GitHub runner, and #1530 is the issue for making it. 227
-# of its tests do pass there; the blockers are 35 host-dependent image-snapshot
-# comparisons, a hang in one of them, and one assertion that depends on the
-# home directory's basename. #1523 was a fourth and is fixed — it turned out to
-# be a main-thread deadlock in a test helper rather than the audio stack that
-# comment originally suspected, so the cause cannot recur on a runner either.
-# That last clause is reasoning from the cause, not a green runner result:
-# nothing in CI runs `swift test` yet, which is what #1530 is for.
+# #1509 shipped the build half only, because the suite did not pass on a runner
+# — 227 of its tests did, and four blockers accounted for the rest (#1530). All
+# four are now fixed, so the suite runs here as well:
 #
-# Gating tests today would mean a check that is red on every PR for reasons
-# unrelated to the PR, which teaches people to ignore it — strictly worse than
-# the gap it would fill.
-#
-# The tests are NOT ungated in the meantime. `tools/preflight.sh --only swift`
-# runs the whole suite, and the pre-push hook runs it on any diff touching
-# platforms/macos/, which is where it demonstrably works. That is a local gate
-# rather than a CI one; #1530 is what moves it here.
+#   1. 35 host-dependent image snapshots. They were rasterising at the MAIN
+#      SCREEN's backing scale, so a 2× developer Mac and a 1× runner produced
+#      different pixel counts for the same view. `Tests/PinnedScaleSnapshot.swift`
+#      pins the scale; no reference was regenerated, which is the evidence the
+#      fix is a fix — the committed references still match byte for byte.
+#   2. A hang, reported against a different test on every run. Sparkle's
+#      `startUpdater` fails outside an app bundle and answers by running a
+#      modal `NSAlert` on the main queue a second later; whichever test next
+#      spun the run loop blocked on it forever. `UpdateManager` no longer
+#      starts Sparkle under XCTest.
+#   3. #1523 — a main-thread deadlock in a test helper, fixed there.
+#   4. A scorer that filtered path segments by the running process's own
+#      `$HOME`, so it answered differently for `runner` than for `ingo`. Now
+#      derived from the cwd under test.
 #
 # Deliberately its own workflow rather than a job in test.yml: that file is the
-# Go gate (its header says so), it installs a Go toolchain this job does not
+# Go gate (its header says so), it installs a Go toolchain these jobs do not
 # need, and a Swift compile break should not be reported under `go-test`.
+#
+# Two jobs rather than two steps, because a compile break and a failing
+# assertion are different diagnoses and should be different checks — #1526's
+# own history is the argument, where `swift build` succeeded in 45s while the
+# test step hung and was killed at the job timeout three times in a row.
 #
 # No `paths:` filter, on purpose. A path-filtered workflow does not run for an
 # unrelated PR, and its check is then *absent* rather than green — which reads
 # as "still queued" at a glance and is the failure mode this repo keeps
-# removing elsewhere. The cost is one macOS job per PR, and this one is ~1
-# minute.
+# removing elsewhere.
+#
+# This is still WEAKER than the local gate, and the asymmetry is deliberate
+# rather than an oversight: `tools/preflight.sh --only swift` runs the same
+# suite on a developer Mac, where the display, the fonts and the audio stack
+# are the ones the app actually ships against.
 
 on:
   pull_request:
@@ -79,3 +87,64 @@ jobs:
       # file that no longer compiles is invisible to every other check.
       - name: Build (app + tests)
         run: swift build --build-tests
+
+  swift-test:
+    runs-on: macos-latest
+    # The outer net only. `SWIFT_SUITE_TIMEOUT` (240s) fires first and prints a
+    # diagnosis naming the test the run stopped in; this cap is what catches a
+    # hang somewhere that bound cannot see.
+    timeout-minutes: 20
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Report toolchain
+        run: |
+          swift --version
+          xcodebuild -version
+
+      # The suite runs through tools/lib/swift-suite.sh — the same harness
+      # tools/preflight.sh uses, so CI and the pre-push hook judge a run by the
+      # same rules rather than by two implementations that can disagree.
+      #
+      # Three things it buys that a bare `swift test` does not:
+      #
+      #   a pty        XCTest block-buffers when stdout is not a TTY, so a hung
+      #                run uploads an EMPTY log — the condition under which
+      #                #1530's blocker 2 was unattributable for two rounds.
+      #   a bound      a hang becomes a named failure at 240s instead of a job
+      #                cancelled at the 20-minute cap with no attribution.
+      #   completeness XCTest's stall detector aborts the process mid-run, and
+      #                every suite that already reported says "0 failures". The
+      #                verdict keys on the bundle's own summary line, so a
+      #                truncated run is a failure and not a pass (#1523).
+      #
+      # `--skip LauncherTestHarness --skip LauncherHarnessTests` is the
+      # documented invocation (AGENTS.md): that target drives real applications
+      # through NSRunningApplication. Both names are passed because a test ID is
+      # `<target>.<class>`, so either alone stops covering the harness the
+      # moment a class is added or the target is renamed.
+      - name: Test (bounded, streamed under a pty)
+        shell: bash
+        run: |
+          set -uo pipefail
+          . tools/lib/swift-suite.sh
+          log="$RUNNER_TEMP/swift-test.log"
+          ( cd platforms/macos && swift_suite_run "$log" \
+              swift test --skip LauncherTestHarness --skip LauncherHarnessTests )
+          rc=$?
+          swift_suite_verdict "$rc" "$log"
+
+      # The log carries `host backing scale: N×` from PinnedScaleSnapshotTests,
+      # which is the measured premise of the snapshot fix rather than an
+      # inference about what a virtual display "need not" be. Uploaded so it
+      # survives the run's retention rather than only being greppable in the
+      # step output.
+      - name: Upload the run log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: swift-test-log
+          path: ${{ runner.temp }}/swift-test.log
+          if-no-files-found: error
+          retention-days: 7

--- a/.github/workflows/macos-swift.yml
+++ b/.github/workflows/macos-swift.yml
@@ -6,14 +6,19 @@ name: macOS (Swift)
 # That is the hole this closes.
 #
 # #1509 shipped the build half only, because the suite did not pass on a runner
-# — 227 of its tests did, and four blockers accounted for the rest (#1530). All
-# four are now fixed, so the suite runs here as well:
+# — 227 of its tests did, and four blockers accounted for the rest (#1530).
+# Three are fixed and the fourth is halved, which is enough to run the suite
+# here:
 #
-#   1. 35 host-dependent image snapshots. They were rasterising at the MAIN
-#      SCREEN's backing scale, so a 2× developer Mac and a 1× runner produced
-#      different pixel counts for the same view. `Tests/PinnedScaleSnapshot.swift`
-#      pins the scale; no reference was regenerated, which is the evidence the
-#      fix is a fix — the committed references still match byte for byte.
+#   1. 35 host-dependent image snapshots — TWO problems, the first masking the
+#      second. They rasterised at the MAIN SCREEN's backing scale, so a 2×
+#      developer Mac and a 1× runner produced different PIXEL COUNTS for the
+#      same view, and SnapshotTesting returns from that guard before comparing
+#      a byte. `Tests/PinnedScaleSnapshot.swift` pins the scale, regenerating
+#      no reference — the committed references still match byte for byte, which
+#      is the evidence the fix is a fix. That made the second visible: a
+#      genuine rasterisation difference, tracked as #1615, which is why five
+#      suites are skipped in the test step below.
 #   2. A hang, reported against a different test on every run. Sparkle's
 #      `startUpdater` fails outside an app bundle and answers by running a
 #      modal `NSAlert` on the main queue a second later; whichever test next
@@ -80,6 +85,7 @@ jobs:
         run: |
           swift --version
           xcodebuild -version
+          sw_vers
 
       # Builds the app target AND the test targets, so a compile error in test
       # code fails the gate too — without running anything. That is deliberate:
@@ -102,6 +108,7 @@ jobs:
         run: |
           swift --version
           xcodebuild -version
+          sw_vers
 
       # The suite runs through tools/lib/swift-suite.sh — the same harness
       # tools/preflight.sh uses, so CI and the pre-push hook judge a run by the
@@ -124,6 +131,31 @@ jobs:
       # through NSRunningApplication. Both names are passed because a test ID is
       # `<target>.<class>`, so either alone stops covering the harness the
       # moment a class is added or the target is renamed.
+      #
+      # The five suites after them are image snapshots that still differ from
+      # their references on a runner AFTER the scale fix, and the reason they
+      # are skipped rather than re-recorded is the substance of #1530's blocker
+      # 1. Measured on this workflow's own first run: the failure message
+      # changed from the pixel-count form (`…@(350.0, 48.0) does not match
+      # reference@(350.0, 48.0).`, 35×) to the byte form (`Newly-taken snapshot
+      # does not match reference.`, 36×), which is the branch in
+      # SnapshotTesting's `compare` that is only reachable once the pixel
+      # dimensions agree. So the scale half is fixed and a rasterisation half
+      # is now visible underneath it — a runner on Xcode 26.6 against a
+      # developer Mac on 26.3. Re-recording to make it green is the move #1034
+      # and #1044 both made and both got wrong, and #1509 measured a perceptual
+      # tolerance wide enough to absorb this drift as also wide enough to pass
+      # a missing architecture segment. The residual is #1615.
+      #
+      # This list cannot silently drift: `Tests/ImageSnapshotCIScopeTests.swift`
+      # derives the set of image-snapshot suites from the test sources and
+      # cross-checks it against these very arguments, so a new one fails there
+      # rather than reddening an unrelated PR's check.
+      #
+      # This still gates 270 of 318 tests, against 0 before. Two image-snapshot
+      # suites are deliberately NOT skipped — they pass on a runner, and their
+      # passing is itself evidence that the residual is content-dependent
+      # rather than a blanket toolchain difference.
       - name: Test (bounded, streamed under a pty)
         shell: bash
         run: |
@@ -131,7 +163,12 @@ jobs:
           . tools/lib/swift-suite.sh
           log="$RUNNER_TEMP/swift-test.log"
           ( cd platforms/macos && swift_suite_run "$log" \
-              swift test --skip LauncherTestHarness --skip LauncherHarnessTests )
+              swift test --skip LauncherTestHarness --skip LauncherHarnessTests \
+                         --skip BackchannelRulesViewSnapshotTests \
+                         --skip GroupViewSnapshotTests \
+                         --skip HistoryViewSnapshotTests \
+                         --skip SessionListUnappliedGrantsWiringTests \
+                         --skip SessionRowSnapshotTests )
           rc=$?
           swift_suite_verdict "$rc" "$log"
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1057,11 +1057,25 @@ Before marking a ticket done, run the full suite — every layer must pass:
 - macOS app (only when touching `platforms/macos/`): `cd platforms/macos &&
   swift build && swift test --skip LauncherTestHarness --skip LauncherHarnessTests`,
   run locally by `tools/preflight.sh --only swift` and by the pre-push hook.
-  CI's `.github/workflows/macos-swift.yml` **builds but does not test** — the
-  suite does not yet pass on a GitHub runner (#1530), so the test gate is the
-  local one. That makes `swift` the single gate here that is deliberately
-  stronger locally than in CI; everything else in `preflight.sh` mirrors CI
-  exactly. **Never run the suite unskipped**: the
+  Since #1530 CI's `.github/workflows/macos-swift.yml` runs it too, as a second
+  job beside the build and through the same `tools/lib/swift-suite.sh` harness,
+  so a hang there is a named failure at 240s rather than a job cancelled at the
+  cap with an empty log. `swift` is still the one gate deliberately **stronger**
+  locally than in CI — a runner has a virtual display, a stock font set and no
+  usable audio stack — but it is no longer the only place the suite runs.
+  Four host dependencies had to go first, and the general lesson is worth more
+  than the four fixes: each was a value read from the MACHINE where the
+  equivalent value was available from the INPUT. Image snapshots rasterised at
+  `NSScreen.main`'s backing scale rather than at a pinned one
+  (`Tests/PinnedScaleSnapshot.swift`); `UpdateManager` started Sparkle in a test
+  host, where `startUpdater` fails outside an app bundle and answers by running
+  a modal `NSAlert` on the main queue a second later, hanging whichever
+  unrelated test next spun the run loop — which is why #1530 and #1523 each
+  attributed the hang to a different test; and `AXTitleMatchActivator` filtered
+  path segments by the running process's own `$HOME` instead of by the cwd it
+  was scoring, in two places. A test that reads the host and a test that reads
+  its fixture look identical on the machine where they agree. **Never run the
+  suite unskipped**: the
   `LauncherTestHarness` target drives real terminal applications through
   `NSRunningApplication`, so on a developer machine it manipulates live
   windows. Both names are passed because a test ID is `<target>.<class>`, and
@@ -1076,9 +1090,23 @@ Before marking a ticket done, run the full suite — every layer must pass:
   regenerating the reference (#1034, #1044), when it was an appearance-mode bug
   that made the suite green by day and red by night. `AdapterIconAppearanceTests`
   is the lock, and it sets both appearances itself so it cannot pass by daylight.
+  `PinnedScaleSnapshotTests` is #1530's version of the same shape, and the shape
+  is what to copy: asserting "renders at 2×" would have been green on every Mac
+  anyone runs it on whether the scale was pinned or inherited, so it drives 1×,
+  2× and 3× through one view instead — whatever the host's scale is, at most one
+  arm can agree with it. A host-independence lock that can only be checked on
+  one host is not a lock.
   The suite also aborts intermittently (#1523) in a way that **truncates the
   run** while every suite that did report says "0 failures" — so the exit code
-  is the only reliable signal, never the last totals line you can see.
+  is the only reliable signal, never the last totals line you can see. That is
+  what `tools/lib/swift-suite.sh` judges a run by, and its `SWIFT_SUITE_TIMEOUT`
+  default is 240s rather than 600s for a reason worth generalizing: at 600 it
+  equalled an automated caller's entire command budget, so the caller killed the
+  gate at the instant the gate would have started explaining itself and the
+  `HUNG` diagnosis could never print for the caller that most needed it. A bound
+  nobody can outlive reports nothing. The relation
+  (`timeout + cold build < pre-push budget`) is asserted in
+  `tools/lib/swift-suite_test.sh` rather than left true the day it was typed.
 - Web (only when touching a `web/` tree): `npm test` in that tree. There are
   two independent suites, each with its own `node_modules`:
   - `platforms/web/` — the dashboard.

--- a/platforms/macos/Irrlicht/Managers/Launcher/Activators/AXTitleMatchActivator.swift
+++ b/platforms/macos/Irrlicht/Managers/Launcher/Activators/AXTitleMatchActivator.swift
@@ -139,10 +139,28 @@ struct AXTitleMatchActivator: HostActivator {
     private static let genericTopSegments: Set<String> = [
         "Users", "home", "tmp", "var", "private", "opt", "mnt", "root"
     ]
-    private static let homeBasename: String = {
-        (ProcessInfo.processInfo.environment["HOME"] ?? "")
-            .split(separator: "/").last.map(String.init) ?? ""
-    }()
+
+    /// Is `parts[i]` the home-directory segment of the path it belongs to —
+    /// the `ingo` in `/Users/ingo/…`, the `runner` in `/home/runner/…`?
+    ///
+    /// Derived POSITIONALLY, from the cwd being scored, rather than from the
+    /// running process's own `$HOME` (#1530). The old spelling took the
+    /// basename of `ProcessInfo.processInfo.environment["HOME"]`, which is a
+    /// property of *whoever is running the app* and not of the path under
+    /// test. The two coincide on the developer's own Mac and diverge
+    /// everywhere else — a session whose cwd is under another account's home,
+    /// a path served from a volume, and a CI runner, where the same call
+    /// scored 2 instead of 0 because `ingo` is not `runner`. The score is a
+    /// pure function of `(title, cwd)` and now reads nothing outside them.
+    ///
+    /// A home segment is one that sits directly under a generic root — that is
+    /// what "home directory" means in every layout this matcher sees. It
+    /// deliberately does NOT skip the same name deeper in the path: a real
+    /// directory called `projects/ingo/…` is a legitimate, specific match
+    /// signal, and the old rule threw it away.
+    private static func isHomeSegment(_ parts: [String], _ i: Int) -> Bool {
+        i == 1 && genericTopSegments.contains(parts[0])
+    }
 
     /// Scores a window title against a cwd. Higher score = better match.
     /// Returns 0 when the title shares no meaningful path segment with cwd.
@@ -157,9 +175,10 @@ struct AXTitleMatchActivator: HostActivator {
     ///   levels below (`.../irrlicht/.claude/worktrees/170`). The deeper the
     ///   matching ancestor, the more specific the signal.
     ///
-    /// Generic top segments (`Users`, user home basename, `tmp`, etc.) are
-    /// skipped because they occur in nearly every string and would cause
-    /// false matches.
+    /// Generic top segments (`Users`, `tmp`, etc.) and the cwd's own home
+    /// segment are skipped because they occur in nearly every string and would
+    /// cause false matches. Both are read off the cwd, so the score depends on
+    /// nothing but its two arguments (see `isHomeSegment`).
     static func titleMatchScore(title: String, cwd: String) -> Int {
         if title.isEmpty || cwd.isEmpty { return 0 }
         if title.contains(cwd) { return 1_000 }
@@ -171,7 +190,7 @@ struct AXTitleMatchActivator: HostActivator {
             let p = parts[i]
             if p.isEmpty { continue }
             if genericTopSegments.contains(p) { continue }
-            if !homeBasename.isEmpty && p == homeBasename { continue }
+            if isHomeSegment(parts, i) { continue }
             if title.contains(p) { return i + 1 }
         }
         return 0
@@ -202,17 +221,21 @@ struct AXTitleMatchActivator: HostActivator {
     /// title. Used as a tie-breaker when two titles share the same primary
     /// score — a title mentioning both `irrlicht` and `a` beats one that
     /// mentions only `irrlicht`.
+    ///
+    /// Skips the same two categories `titleMatchScore` does, and for the same
+    /// reason (#1530): this filtered on the running process's `$HOME` too, so
+    /// the tie-break between two equally-scoring windows also moved with the
+    /// account the app ran under. That second site had no failing assertion of
+    /// its own — it was found by the compiler, once the first was fixed.
     static func cwdSegmentMatchCount(title: String, cwd: String) -> Int {
         if title.isEmpty || cwd.isEmpty { return 0 }
         let trimmed = cwd.hasSuffix("/") ? String(cwd.dropLast()) : cwd
-        let segments = trimmed
-            .split(separator: "/", omittingEmptySubsequences: true)
-            .map(String.init)
-            .filter { p in
-                !p.isEmpty &&
-                !genericTopSegments.contains(p) &&
-                (homeBasename.isEmpty || p != homeBasename)
-            }
-        return segments.filter { title.contains($0) }.count
+        let parts = trimmed.split(separator: "/", omittingEmptySubsequences: true).map(String.init)
+        return parts.indices.filter { i in
+            !parts[i].isEmpty
+                && !genericTopSegments.contains(parts[i])
+                && !isHomeSegment(parts, i)
+                && title.contains(parts[i])
+        }.count
     }
 }

--- a/platforms/macos/Irrlicht/Managers/UpdateManager.swift
+++ b/platforms/macos/Irrlicht/Managers/UpdateManager.swift
@@ -27,18 +27,73 @@ final class UpdateManager: ObservableObject {
     private let controller: SPUStandardUpdaterController
     private let logger = Logger(subsystem: "io.irrlicht.app", category: "UpdateManager")
 
+    /// Did this instance actually start Sparkle's update cycle? Exactly the
+    /// value handed to `SPUStandardUpdaterController` — see `init`.
+    private(set) var updaterStarted: Bool
+
+    /// Is XCTest loaded into this process? True in every test host and false
+    /// in the shipped app, where the framework is never linked.
+    ///
+    /// Keyed on the framework's own class rather than on `XCTestConfigurationFilePath`,
+    /// which `swift test` and `xcodebuild` set but a bare `xctest` invocation
+    /// need not.
+    static var isRunningUnderXCTest: Bool {
+        NSClassFromString("XCTestCase") != nil
+    }
+
+    /// Should `init` start Sparkle's update cycle?
+    ///
+    /// Split out as a pure function so the rule can be asserted without
+    /// constructing the thing it protects against — reddening it in place
+    /// would mean actually arming the modal alert described below.
+    static func shouldStartUpdater(requested: Bool, underXCTest: Bool) -> Bool {
+        requested && !underXCTest
+    }
+
     /// `startingUpdater: false` skips starting Sparkle's update cycle — for
     /// tests, which run outside an app bundle where Sparkle's start would
     /// fail its bundle checks.
-    init(startingUpdater: Bool = true) {
+    ///
+    /// Under XCTest that request is overridden to `false` no matter what the
+    /// caller asked for, and this is the whole of #1530's blocker 2. Outside
+    /// an app bundle `-[SPUUpdater startUpdater:]` fails, and
+    /// `SPUStandardUpdaterController.startUpdater` answers a failure by
+    /// `dispatch_after`-ing an `NSAlert` onto the **main queue** one second
+    /// later and calling `-[NSAlert runModal]` on it
+    /// (`Sparkle/SPUStandardUpdaterController.m`, "Delay the alert a bit to
+    /// allow other start-up actions"). In a headless test run nobody can
+    /// dismiss a modal alert, so the modal loop never returns.
+    ///
+    /// The consequences are what made it hard to attribute. The block is
+    /// drained by whichever test happens to spin the main run loop a second
+    /// later — any suite using `override func tearDown() async throws`, which
+    /// XCTest wraps in an `XCTWaiter` — so the hang is reported against a test
+    /// that has nothing to do with the updater, and against a *different* one
+    /// on each run: `SessionRowSnapshotTests.testFixtureAntigravityGhost` on a
+    /// GitHub runner, `testRelayCloudOnline` and `testRoleOrchestratorRow`
+    /// locally. It is positional, not per-test. And because it is a hang
+    /// rather than a failure, off a TTY it produces an *empty* log.
+    ///
+    /// The offending call site was `UnappliedGrantsBannerRenderTests`, which
+    /// took the `true` default. Fixing that one line would have worked and
+    /// would have been forgettable; the guard here is what makes the next one
+    /// safe by existing.
+    init(startingUpdater requested: Bool = true) {
+        // One value, used twice: what Sparkle is told and what `updaterStarted`
+        // reports are the same expression, so the two cannot disagree.
+        let start = UpdateManager.shouldStartUpdater(
+            requested: requested,
+            underXCTest: UpdateManager.isRunningUnderXCTest
+        )
+        updaterStarted = start
         controller = SPUStandardUpdaterController(
-            startingUpdater: startingUpdater,
+            startingUpdater: start,
             updaterDelegate: nil,
             userDriverDelegate: nil
         )
         automaticallyChecksForUpdates = controller.updater.automaticallyChecksForUpdates
         lastUpdateCheckDate = controller.updater.lastUpdateCheckDate
-        if startingUpdater {
+        if start {
             logger.info("Sparkle updater started (auto checks: \(self.automaticallyChecksForUpdates, privacy: .public))")
         }
     }

--- a/platforms/macos/Tests/BackchannelRulesViewSnapshotTests.swift
+++ b/platforms/macos/Tests/BackchannelRulesViewSnapshotTests.swift
@@ -71,13 +71,13 @@ final class BackchannelRulesViewSnapshotTests: XCTestCase {
 
     func testBackchannelRuleContextPressure() {
         let view = BackchannelRulesView(model: model(event: BackchannelRule.eventContextPressure, threshold: 85))
-        assertSnapshot(of: host(view, height: 220), as: .image)
+        assertSnapshot(of: host(view, height: 220), as: .pinnedImage)
     }
 
     /// The tokens variant — wider threshold field + "tokens" suffix must still
     /// fit the 304pt card without clipping.
     func testBackchannelRuleContextTokens() {
         let view = BackchannelRulesView(model: model(event: BackchannelRule.eventContextTokens, threshold: 150_000))
-        assertSnapshot(of: host(view, height: 220), as: .image)
+        assertSnapshot(of: host(view, height: 220), as: .pinnedImage)
     }
 }

--- a/platforms/macos/Tests/GroupViewSnapshotTests.swift
+++ b/platforms/macos/Tests/GroupViewSnapshotTests.swift
@@ -81,32 +81,32 @@ final class GroupViewSnapshotTests: XCTestCase {
     func testFirstOfThreeUpChevronDisabled() {
         let groups = seedThreeGroups()
         let view = host(GroupView(group: groups[0]))
-        assertSnapshot(of: view, as: .image)
+        assertSnapshot(of: view, as: .pinnedImage)
     }
 
     func testMiddleOfThreeBothChevronsEnabled() {
         let groups = seedThreeGroups()
         let view = host(GroupView(group: groups[1]))
-        assertSnapshot(of: view, as: .image)
+        assertSnapshot(of: view, as: .pinnedImage)
     }
 
     func testLastOfThreeDownChevronDisabled() {
         let groups = seedThreeGroups()
         let view = host(GroupView(group: groups[2]))
-        assertSnapshot(of: view, as: .image)
+        assertSnapshot(of: view, as: .pinnedImage)
     }
 
     func testSingleGroupNoChevrons() {
         let solo = makeGroup(name: "solo")
         sessionManager.apiGroups = [solo]
         let view = host(GroupView(group: solo))
-        assertSnapshot(of: view, as: .image)
+        assertSnapshot(of: view, as: .pinnedImage)
     }
 
     func testSubGroupNoChevrons() {
         _ = seedThreeGroups()
         let view = host(GroupView(group: makeGroup(name: "nested"), depth: 1))
-        assertSnapshot(of: view, as: .image)
+        assertSnapshot(of: view, as: .pinnedImage)
     }
 
     /// A transient PID=0 antigravity ghost (ready, no metrics) sitting alongside
@@ -134,6 +134,6 @@ final class GroupViewSnapshotTests: XCTestCase {
         let group = SessionManager.AgentGroup(name: "app", agents: [real, ghost])
         sessionManager.apiGroups = [group]
         let view = host(GroupView(group: group), height: 160)
-        assertSnapshot(of: view, as: .image)
+        assertSnapshot(of: view, as: .pinnedImage)
     }
 }

--- a/platforms/macos/Tests/HistoryViewSnapshotTests.swift
+++ b/platforms/macos/Tests/HistoryViewSnapshotTests.swift
@@ -163,7 +163,7 @@ final class HistoryViewSnapshotTests: XCTestCase {
             onExportCSV: { /* unused in this snapshot */ },
             onExportJSON: { /* unused in this snapshot */ }
         )
-        assertSnapshot(of: host(view, height: 460), as: .image)
+        assertSnapshot(of: host(view, height: 460), as: .pinnedImage)
     }
 
     func testHistoryTokens() {
@@ -176,7 +176,7 @@ final class HistoryViewSnapshotTests: XCTestCase {
             onExportCSV: { /* unused in this snapshot */ },
             onExportJSON: { /* unused in this snapshot */ }
         )
-        assertSnapshot(of: host(view, height: 460), as: .image)
+        assertSnapshot(of: host(view, height: 460), as: .pinnedImage)
     }
 
     /// #1029: the CO2 chart is the only one with a methodology-link overlay
@@ -200,7 +200,7 @@ final class HistoryViewSnapshotTests: XCTestCase {
             onExportCSV: { /* unused in this snapshot */ },
             onExportJSON: { /* unused in this snapshot */ }
         )
-        assertSnapshot(of: host(view, height: 460), as: .image)
+        assertSnapshot(of: host(view, height: 460), as: .pinnedImage)
     }
 
     /// #1029 (code-review follow-up): the methodology link is gated on
@@ -220,7 +220,7 @@ final class HistoryViewSnapshotTests: XCTestCase {
             onExportCSV: { /* unused in this snapshot */ },
             onExportJSON: { /* unused in this snapshot */ }
         )
-        assertSnapshot(of: host(view, height: 320), as: .image)
+        assertSnapshot(of: host(view, height: 320), as: .pinnedImage)
     }
 
     func testHistoryDrilldown() {
@@ -233,7 +233,7 @@ final class HistoryViewSnapshotTests: XCTestCase {
             onExportCSV: { /* unused in this snapshot */ },
             onExportJSON: { /* unused in this snapshot */ }
         )
-        assertSnapshot(of: host(view, height: 500), as: .image)
+        assertSnapshot(of: host(view, height: 500), as: .pinnedImage)
     }
 
     func testHistoryEmptyState() {
@@ -243,7 +243,7 @@ final class HistoryViewSnapshotTests: XCTestCase {
             onExportCSV: { /* unused in this snapshot */ },
             onExportJSON: { /* unused in this snapshot */ }
         )
-        assertSnapshot(of: host(view, height: 320), as: .image)
+        assertSnapshot(of: host(view, height: 320), as: .pinnedImage)
     }
 
     // MARK: Yield (#373)
@@ -269,7 +269,7 @@ final class HistoryViewSnapshotTests: XCTestCase {
 
     func testYieldPopulated() {
         let view = HistoryYieldContentView(data: yieldFixture(), range: .month)
-        assertSnapshot(of: host(view, height: 360), as: .image)
+        assertSnapshot(of: host(view, height: 360), as: .pinnedImage)
     }
 
     // MARK: DORA (#951)
@@ -306,12 +306,12 @@ final class HistoryViewSnapshotTests: XCTestCase {
 
     func testDoraPopulated() {
         let view = HistoryDoraContentView(data: doraFixture())
-        assertSnapshot(of: host(view, height: 260), as: .image)
+        assertSnapshot(of: host(view, height: 260), as: .pinnedImage)
     }
 
     func testDoraUnavailable() {
         let view = HistoryDoraContentView(data: doraUnavailableFixture())
-        assertSnapshot(of: host(view, height: 200), as: .image)
+        assertSnapshot(of: host(view, height: 200), as: .pinnedImage)
     }
 
     // MARK: Activity Matrix (#1028)
@@ -377,7 +377,7 @@ final class HistoryViewSnapshotTests: XCTestCase {
             onExportCSV: { /* unused in this snapshot */ },
             onExportJSON: { /* unused in this snapshot */ }
         )
-        assertSnapshot(of: host(view, height: 260), as: .image)
+        assertSnapshot(of: host(view, height: 260), as: .pinnedImage)
     }
 
     func testActivityEmptyState() {
@@ -387,7 +387,7 @@ final class HistoryViewSnapshotTests: XCTestCase {
             onExportCSV: { /* unused in this snapshot */ },
             onExportJSON: { /* unused in this snapshot */ }
         )
-        assertSnapshot(of: host(view, height: 260), as: .image)
+        assertSnapshot(of: host(view, height: 260), as: .pinnedImage)
     }
 
     /// Regression guard for issue #1046: hosted through the real nested
@@ -401,7 +401,7 @@ final class HistoryViewSnapshotTests: XCTestCase {
             onExportCSV: { /* unused in this snapshot */ },
             onExportJSON: { /* unused in this snapshot */ }
         )
-        assertSnapshot(of: hostInScrollingTab(view, height: 400), as: .image)
+        assertSnapshot(of: hostInScrollingTab(view, height: 400), as: .pinnedImage)
     }
 
     // MARK: Quota projection
@@ -467,7 +467,7 @@ final class HistoryViewSnapshotTests: XCTestCase {
     /// subscription): exercises the 5h cap trajectory + 7d on-pace footer.
     func testQuotaForecastSingleProvider() {
         let view = HistoryQuotaForecastView(providers: [anthropicProvider()])
-        assertSnapshot(of: host(view, height: 320), as: .image)
+        assertSnapshot(of: host(view, height: 320), as: .pinnedImage)
     }
 
     /// Two active providers stacked — Anthropic (5h hits cap, 7d on pace) +
@@ -475,6 +475,6 @@ final class HistoryViewSnapshotTests: XCTestCase {
     /// and both footer states.
     func testQuotaForecastMultiProvider() {
         let view = HistoryQuotaForecastView(providers: [anthropicProvider(), openaiProvider()])
-        assertSnapshot(of: host(view, height: 460), as: .image)
+        assertSnapshot(of: host(view, height: 460), as: .pinnedImage)
     }
 }

--- a/platforms/macos/Tests/ImageSnapshotCIScopeTests.swift
+++ b/platforms/macos/Tests/ImageSnapshotCIScopeTests.swift
@@ -97,13 +97,22 @@ final class ImageSnapshotCIScopeTests: XCTestCase {
         for name in names.sorted() {
             guard let text = try? String(contentsOf: testsDir.appendingPathComponent(name), encoding: .utf8) else { continue }
             filesRead += 1
-            var currentClass: String?
-            for line in text.split(separator: "\n", omittingEmptySubsequences: false) {
-                if let declared = Self.className(in: String(line)) { currentClass = declared }
-                if line.contains("as: .pinnedImage"), let c = currentClass { found.insert(c) }
-            }
+            found.formUnion(Self.snapshottingClasses(in: text))
         }
         XCTAssertEqual(filesRead, names.count, "some test sources could not be read")
+        return found
+    }
+
+    /// Classes in one source that contain an `as: .pinnedImage` call, by
+    /// tracking the most recent class declaration above each line.
+    private static func snapshottingClasses(in source: String) -> Set<String> {
+        var found: Set<String> = []
+        var currentClass: String?
+        for line in source.split(separator: "\n", omittingEmptySubsequences: false) {
+            if let declared = className(in: String(line)) { currentClass = declared }
+            guard line.contains("as: .pinnedImage"), let c = currentClass else { continue }
+            found.insert(c)
+        }
         return found
     }
 

--- a/platforms/macos/Tests/ImageSnapshotCIScopeTests.swift
+++ b/platforms/macos/Tests/ImageSnapshotCIScopeTests.swift
@@ -1,0 +1,165 @@
+import XCTest
+
+/// Keeps `macos-swift.yml`'s image-snapshot skip list honest (#1530).
+///
+/// ## Why there is a skip list at all
+///
+/// #1530's blocker 1 was two problems stacked, and the first was masking the
+/// second. The committed references are 2× and a runner's display is 1×, so
+/// every comparison failed on PIXEL COUNT — SnapshotTesting returns from that
+/// guard before comparing a byte. `PinnedScaleSnapshot` fixes that half, which
+/// is what made the second half visible for the first time: on the runner the
+/// failure message changed from
+///
+///     Newly-taken snapshot@(350.0, 48.0) does not match reference@(350.0, 48.0).   (35×, pixel counts)
+///
+/// to
+///
+///     Newly-taken snapshot does not match reference.                               (36×, bytes)
+///
+/// The remaining difference is rasterisation, between a runner on Xcode 26.6
+/// and a developer Mac on 26.3, and it is #1615. It is deliberately NOT
+/// papered over here:
+/// re-recording a snapshot to make it pass is the exact move #1034 and #1044
+/// both made and both got wrong, and #1509 measured a perceptual tolerance
+/// wide enough to absorb this drift as also wide enough to pass a missing
+/// architecture segment.
+///
+/// So CI runs everything else — 270 of 318 tests, against 0 before — and these
+/// suites stay gated on a developer Mac by `tools/preflight.sh --only swift`,
+/// where they demonstrably pass.
+///
+/// ## Why this test exists
+///
+/// A skip list in a YAML file is invisible to everything. A new image-snapshot
+/// suite would either be silently ungated in CI (and go red for a reason
+/// unrelated to the PR that added it) or be added to the list by someone
+/// remembering. This makes it assertable: the set of suites that render image
+/// snapshots is DERIVED from the test sources, and every one of them has to be
+/// classified.
+final class ImageSnapshotCIScopeTests: XCTestCase {
+
+    /// Every suite that takes an image snapshot, and whether `macos-swift.yml`
+    /// skips it. `false` is a claim about the runner, made from a measured run
+    /// (PR #1614's `swift-test` job) — not a guess.
+    ///
+    /// Suite-granular rather than test-granular on purpose. `HistoryViewSnapshotTests`
+    /// pays the most for that — 12 of its 14 tests pass on a runner and are
+    /// skipped anyway — but a 36-name list of individual tests would have to be
+    /// re-derived by hand every time one is added, and a stale entry there
+    /// looks exactly like coverage.
+    private static let imageSnapshotSuites: [String: Bool] = [
+        "BackchannelRulesViewSnapshotTests": true,      // 2/2 fail on a runner
+        "GroupViewSnapshotTests": true,                 // 6/6
+        "HistoryViewSnapshotTests": true,               // 2/14
+        "SessionListUnappliedGrantsWiringTests": true,  // 2/2
+        "SessionRowSnapshotTests": true,                // 24/24
+        "PermissionWizardEffectErrorRenderTests": false, // 3/3 pass on a runner
+        "UnappliedGrantsBannerRenderTests": false,       // 2/2 pass on a runner
+    ]
+
+    /// The two names that are not about snapshots at all: the harness target
+    /// and its class, skipped everywhere because it drives real applications
+    /// through `NSRunningApplication`.
+    private static let harnessSkips: Set<String> = ["LauncherTestHarness", "LauncherHarnessTests"]
+
+    private var repoRoot: URL {
+        URL(fileURLWithPath: #filePath)                 // …/platforms/macos/Tests/<this file>
+            .deletingLastPathComponent()                // …/platforms/macos/Tests
+            .deletingLastPathComponent()                // …/platforms/macos
+            .deletingLastPathComponent()                // …/platforms
+            .deletingLastPathComponent()                // repo root
+    }
+
+    /// Scans the test sources for `as: .pinnedImage` and attributes each use to
+    /// the class it is lexically inside.
+    ///
+    /// Text-based rather than a real parse, which is fine for what it has to
+    /// decide — but it must not silently find nothing, so the caller checks
+    /// that it read files at all.
+    private func suitesTakingImageSnapshots() throws -> Set<String> {
+        let testsDir = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
+        // This file is excluded because it carries the search string itself, in
+        // the line below that does the searching — caught on the first run,
+        // where the scan reported this class as an image-snapshot suite. The
+        // exclusion is by path rather than by name so a rename cannot silently
+        // reintroduce it, and the vacuity guards below still hold: the scan has
+        // to read every other source and find real uses.
+        let selfName = URL(fileURLWithPath: #filePath).lastPathComponent
+        let names = try FileManager.default.contentsOfDirectory(atPath: testsDir.path)
+            .filter { $0.hasSuffix(".swift") && $0 != selfName }
+        XCTAssertGreaterThan(names.count, 10, "read \(names.count) test sources — the scan cannot have worked")
+
+        var found: Set<String> = []
+        var filesRead = 0
+        for name in names.sorted() {
+            guard let text = try? String(contentsOf: testsDir.appendingPathComponent(name), encoding: .utf8) else { continue }
+            filesRead += 1
+            var currentClass: String?
+            for line in text.split(separator: "\n", omittingEmptySubsequences: false) {
+                if let declared = Self.className(in: String(line)) { currentClass = declared }
+                if line.contains("as: .pinnedImage"), let c = currentClass { found.insert(c) }
+            }
+        }
+        XCTAssertEqual(filesRead, names.count, "some test sources could not be read")
+        return found
+    }
+
+    /// `final class Foo: XCTestCase` / `class Foo: XCTestCase` → "Foo".
+    private static func className(in line: String) -> String? {
+        let trimmed = line.trimmingCharacters(in: .whitespaces)
+        guard trimmed.hasPrefix("class ") || trimmed.hasPrefix("final class ") else { return nil }
+        guard let after = trimmed.range(of: "class ")?.upperBound else { return nil }
+        let rest = trimmed[after...]
+        let name = rest.prefix { $0.isLetter || $0.isNumber || $0 == "_" }
+        return name.isEmpty ? nil : String(name)
+    }
+
+    /// A suite that renders image snapshots is either skipped in CI or claimed
+    /// to pass there. Adding one and classifying it neither way fails here
+    /// rather than reddening an unrelated PR's `swift-test` check.
+    func testEveryImageSnapshotSuiteIsClassified() throws {
+        let derived = try suitesTakingImageSnapshots()
+        XCTAssertFalse(derived.isEmpty, "found no `as: .pinnedImage` uses at all — the scan is vacuous")
+        XCTAssertEqual(
+            derived.sorted(),
+            Self.imageSnapshotSuites.keys.sorted(),
+            "a suite renders image snapshots without being classified for CI (or is classified but no longer renders any)")
+    }
+
+    /// …and the YAML actually skips the ones marked skipped, no more and no
+    /// fewer. Two lists that can disagree are worth exactly one of them.
+    func testWorkflowSkipListMatchesTheClassification() throws {
+        let workflow = repoRoot.appendingPathComponent(".github/workflows/macos-swift.yml")
+        let text = try String(contentsOf: workflow, encoding: .utf8)
+
+        var skipped: Set<String> = []
+        var sawSwiftTest = false
+        for line in text.split(separator: "\n") {
+            // COMMENTS ARE NOT THE INVOCATION. The block above this workflow's
+            // test step discusses `--skip` at length and names suites in prose;
+            // reading those would make the check agree with an explanation
+            // rather than with what CI runs, and a step whose real arguments
+            // were deleted would still pass.
+            let code = line.drop { $0 == " " }
+            guard !code.hasPrefix("#") else { continue }
+            guard code.contains("swift test") || code.contains("--skip") else { continue }
+            if code.contains("swift test") { sawSwiftTest = true }
+            var rest = code
+            while let r = rest.range(of: "--skip ") {
+                rest = rest[r.upperBound...]
+                let name = rest.prefix { $0.isLetter || $0.isNumber || $0 == "_" }
+                if !name.isEmpty { skipped.insert(String(name)) }
+            }
+        }
+        // Fail loudly rather than comparing two empty sets: a workflow this
+        // cannot parse is the case where it knows least about what CI runs.
+        XCTAssertTrue(sawSwiftTest, "found no `swift test` invocation in \(workflow.path)")
+        XCTAssertFalse(skipped.isEmpty, "parsed no --skip arguments — the check is vacuous")
+
+        let expected = Set(Self.imageSnapshotSuites.filter { $0.value }.map { $0.key })
+            .union(Self.harnessSkips)
+        XCTAssertEqual(skipped.sorted(), expected.sorted(),
+                       "macos-swift.yml's --skip list and this file's classification disagree")
+    }
+}

--- a/platforms/macos/Tests/ImageSnapshotCIScopeTests.swift
+++ b/platforms/macos/Tests/ImageSnapshotCIScopeTests.swift
@@ -25,9 +25,11 @@ import XCTest
 /// wide enough to absorb this drift as also wide enough to pass a missing
 /// architecture segment.
 ///
-/// So CI runs everything else — 270 of 318 tests, against 0 before — and these
+/// So CI runs everything else — 272 of 320 tests, against 0 before — and these
 /// suites stay gated on a developer Mac by `tools/preflight.sh --only swift`,
-/// where they demonstrably pass.
+/// where they demonstrably pass. Both figures are read off runs rather than
+/// added up from the table below; the first draft added them up and was two
+/// low, having forgotten the tests in this very file.
 ///
 /// ## Why this test exists
 ///

--- a/platforms/macos/Tests/PermissionWizardEffectErrorRenderTests.swift
+++ b/platforms/macos/Tests/PermissionWizardEffectErrorRenderTests.swift
@@ -52,7 +52,7 @@ final class PermissionWizardEffectErrorRenderTests: XCTestCase {
     /// "Granted, but not applied" strip and its Retry button beneath it.
     func testFailedApplyRendersWarningAndRetry() throws {
         let view = host(try snapshotModel(state: "granted", effectError: reason), mode: .review)
-        assertSnapshot(of: view, as: .image, named: "granted-apply-failed")
+        assertSnapshot(of: view, as: .pinnedImage, named: "granted-apply-failed")
     }
 
     /// Control: the same wizard with a healthy grant draws no warning at
@@ -60,13 +60,13 @@ final class PermissionWizardEffectErrorRenderTests: XCTestCase {
     /// effect_error and nothing else.
     func testHealthyGrantRendersNoWarning() throws {
         let view = host(try snapshotModel(state: "granted", effectError: nil), mode: .review)
-        assertSnapshot(of: view, as: .image, named: "granted-healthy")
+        assertSnapshot(of: view, as: .pinnedImage, named: "granted-healthy")
     }
 
     /// Auto mode asks about pending items only; a failed grant must still
     /// appear there, or the surface the user is looking at hides it.
     func testFailedApplyVisibleInAutoMode() throws {
         let view = host(try snapshotModel(state: "granted", effectError: reason), mode: .auto)
-        assertSnapshot(of: view, as: .image, named: "auto-apply-failed")
+        assertSnapshot(of: view, as: .pinnedImage, named: "auto-apply-failed")
     }
 }

--- a/platforms/macos/Tests/PinnedScaleSnapshot.swift
+++ b/platforms/macos/Tests/PinnedScaleSnapshot.swift
@@ -1,0 +1,115 @@
+import AppKit
+import SnapshotTesting
+
+/// A `.image` snapshot strategy that rasterises at a **pinned** backing scale
+/// instead of the main screen's (#1530, blocker 1).
+///
+/// ## What was wrong
+///
+/// `SnapshotTesting`'s stock `Snapshotting<NSView, NSImage>.image` renders
+/// through `-[NSView bitmapImageRepForCachingDisplay:]`, which for a
+/// window-less view sizes its bitmap from the **main screen's** backing scale.
+/// Every reference in `Tests/__Snapshots__` was recorded on a Retina Mac and
+/// is therefore committed at 2× — 700×96 pixels at 144 dpi for a 350×48-point
+/// row. A GitHub runner's virtual display is 1×, so the same view rasterises
+/// to 350×48 pixels and 35 comparisons across six suites fail.
+///
+/// ## Scale, not text rasterisation — and how that was settled
+///
+/// The issue recorded these two as indistinguishable, because the failure text
+///
+///     Newly-taken snapshot@(350.0, 48.0) does not match reference@(350.0, 48.0).
+///
+/// reports POINT size, which is identical either way. But that string is not
+/// ambiguous about which branch produced it. In
+/// `SnapshotTesting/Snapshotting/NSImage.swift`, `compare(_:_:precision:perceptualPrecision:)`
+/// emits the `@`-qualified form from exactly one place — the guard on
+///
+///     oldCgImage.width == newCgImage.width, oldCgImage.height == newCgImage.height
+///
+/// i.e. a **pixel-dimension** mismatch, which returns before a single byte is
+/// compared. A rasterisation difference reaches the byte comparison below it
+/// and produces the unqualified "Newly-taken snapshot does not match
+/// reference." with no sizes at all. The runner printed the qualified form for
+/// all 35, so all 35 are pixel-count mismatches. The point sizes print equal
+/// because the reference PNG carries its 144 dpi, so `NSImage(data:)` reports
+/// it as 350×48 points, and the fresh image is built as
+/// `NSImage(size: view.bounds.size)`.
+///
+/// That is a **necessary** condition, not a sufficient one: it proves the
+/// scale is wrong and says nothing about whether text also rasterises
+/// differently, because a pixel-count mismatch masks every byte difference
+/// behind it. `macos-swift.yml` reports the runner's measured backing scale so
+/// the premise is a printed number rather than an inference.
+///
+/// ## Why this does not re-record anything
+///
+/// Every bitmap parameter is copied from the rep AppKit would have made
+/// itself; only the pixel dimensions are overridden. On a 2× host the
+/// reconstruction is parameter-for-parameter the same rep the stock strategy
+/// builds, which is why all 32 committed references still pass byte-identically
+/// — the check that this change alters no reference is the reference set
+/// itself.
+enum PinnedScaleSnapshot {
+    /// The scale every committed reference was recorded at. Read off the PNGs:
+    /// 700×96 pixels at 144 dpi for a 350×48-point view.
+    static let referenceScale: CGFloat = 2
+
+    /// Rasterise `view` at exactly `scale` device pixels per point.
+    ///
+    /// - Note: the stock strategy first runs `addImagesForRenderedViews`, which
+    ///   substitutes bitmaps for `WKWebView`/`SCNView`/`SKView` subtrees that
+    ///   cannot be cached synchronously. That helper is internal to
+    ///   `SnapshotTesting` and every view snapshotted here is a plain
+    ///   `NSHostingView` over SwiftUI, so it is omitted. A snapshot that ever
+    ///   embeds one of those three types needs it back.
+    static func rasterize(_ view: NSView, scale: CGFloat) -> NSImage {
+        let bounds = view.bounds
+
+        // The rep AppKit would have used, consulted only for its FORMAT.
+        // Copying every parameter — rather than picking plausible ones — is
+        // what keeps the output byte-identical to the stock strategy on a host
+        // whose scale already matches.
+        guard let format = view.bitmapImageRepForCachingDisplay(in: bounds) else {
+            preconditionFailure("view is not renderable at \(bounds.size)")
+        }
+        guard let rep = NSBitmapImageRep(
+            bitmapDataPlanes: nil,
+            pixelsWide: Int((bounds.width * scale).rounded()),
+            pixelsHigh: Int((bounds.height * scale).rounded()),
+            bitsPerSample: format.bitsPerSample,
+            samplesPerPixel: format.samplesPerPixel,
+            hasAlpha: format.hasAlpha,
+            isPlanar: format.isPlanar,
+            colorSpaceName: format.colorSpaceName,
+            bitmapFormat: format.bitmapFormat,
+            bytesPerRow: 0,
+            bitsPerPixel: 0
+        ) else {
+            preconditionFailure("could not allocate a \(scale)× bitmap for \(bounds.size)")
+        }
+
+        // Point size < pixel size IS the scale: `cacheDisplay` reads the ratio
+        // off the rep and transforms the context accordingly, which is what
+        // makes this independent of any screen.
+        rep.size = bounds.size
+        view.cacheDisplay(in: bounds, to: rep)
+
+        let image = NSImage(size: bounds.size)
+        image.addRepresentation(rep)
+        return image
+    }
+}
+
+extension Snapshotting where Value == NSView, Format == NSImage {
+    /// `.image`, rasterised at the scale the committed references were
+    /// recorded at rather than at the host's. Use this and not `.image`.
+    static var pinnedImage: Snapshotting {
+        pinnedImage(scale: PinnedScaleSnapshot.referenceScale)
+    }
+
+    static func pinnedImage(scale: CGFloat) -> Snapshotting {
+        Snapshotting<NSImage, NSImage>.image(precision: 1, perceptualPrecision: 1)
+            .pullback { view in PinnedScaleSnapshot.rasterize(view, scale: scale) }
+    }
+}

--- a/platforms/macos/Tests/PinnedScaleSnapshotTests.swift
+++ b/platforms/macos/Tests/PinnedScaleSnapshotTests.swift
@@ -1,0 +1,76 @@
+import AppKit
+import XCTest
+@testable import Irrlicht
+
+/// Locks the property #1530's blocker 1 is about: the snapshot rasteriser
+/// honours the scale it is ASKED for, not the scale the machine happens to
+/// have.
+///
+/// The obvious test — "renders at 2×" — is the trap this repo has already paid
+/// for twice (#1034, #1044, recorded in `AGENTS.md`): on a Retina Mac it
+/// passes whether the code pins a scale or inherits the screen's, so it is
+/// green for the wrong reason on every machine anyone would run it on. The
+/// fix is to drive several scales through one view. Whatever
+/// `NSScreen.main.backingScaleFactor` is, at most one arm can agree with it,
+/// so an implementation that inherits the screen fails the others — on a 1×
+/// runner and a 2× laptop alike.
+@MainActor
+final class PinnedScaleSnapshotTests: XCTestCase {
+
+    /// A plain, cheap view: this measures the rasteriser's geometry, not any
+    /// particular UI.
+    private func subject() -> NSView {
+        let view = NSView(frame: CGRect(x: 0, y: 0, width: 350, height: 48))
+        view.wantsLayer = true
+        view.layer?.backgroundColor = NSColor.systemTeal.cgColor
+        return view
+    }
+
+    func testRasterizerHonoursTheRequestedScaleAndNotTheScreens() {
+        let points = CGSize(width: 350, height: 48)
+        for scale in [CGFloat(1), 2, 3] {
+            let image = PinnedScaleSnapshot.rasterize(subject(), scale: scale)
+            guard let rep = image.representations.first as? NSBitmapImageRep else {
+                return XCTFail("expected a bitmap representation at \(scale)×")
+            }
+            XCTAssertEqual(rep.pixelsWide, Int(points.width * scale),
+                           "width at \(scale)× (screen is \(Self.screenScale)×)")
+            XCTAssertEqual(rep.pixelsHigh, Int(points.height * scale),
+                           "height at \(scale)× (screen is \(Self.screenScale)×)")
+            // Point size is the invariant across all of them — the geometry
+            // does not change, only how finely it is sampled.
+            XCTAssertEqual(image.size, points, "point size at \(scale)×")
+        }
+    }
+
+    /// The default the six snapshot suites use is the scale the committed
+    /// references were recorded at. Read off the PNGs on disk rather than
+    /// restated, so a re-record at another scale fails here instead of
+    /// silently redefining "reference scale".
+    func testDefaultScaleMatchesTheCommittedReferences() {
+        let reference = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .appendingPathComponent("__Snapshots__/SessionRowSnapshotTests/testRelayCloudOnline.1.png")
+        guard let data = try? Data(contentsOf: reference),
+              let rep = NSBitmapImageRep(data: data) else {
+            return XCTFail("could not read \(reference.path)")
+        }
+        // `rep.size` is the PNG's point size (it carries 144 dpi);
+        // `pixelsWide` is its pixel size. Their ratio is the scale it was
+        // recorded at.
+        XCTAssertGreaterThan(rep.size.width, 0)
+        XCTAssertEqual(CGFloat(rep.pixelsWide) / rep.size.width,
+                       PinnedScaleSnapshot.referenceScale,
+                       "committed references are \(rep.pixelsWide)px wide for "
+                       + "\(rep.size.width)pt — PinnedScaleSnapshot.referenceScale disagrees")
+    }
+
+    /// Reported on every run so a runner's log carries the measured premise of
+    /// the whole fix rather than an inference about virtual displays.
+    func testReportTheHostsBackingScale() {
+        print("host backing scale: \(Self.screenScale)× "
+              + "(NSScreen.main: \(NSScreen.main.map { "\($0.backingScaleFactor)" } ?? "none"))")
+    }
+
+    private static var screenScale: CGFloat { NSScreen.main?.backingScaleFactor ?? 0 }
+}

--- a/platforms/macos/Tests/SessionManagerTests.swift
+++ b/platforms/macos/Tests/SessionManagerTests.swift
@@ -573,6 +573,52 @@ final class SessionManagerTests: XCTestCase {
             0)
     }
 
+    /// The home segment is a property of the cwd being scored, not of whoever
+    /// is running the app (#1530).
+    ///
+    /// The case above is the one that was red on a GitHub runner and green on
+    /// the developer's Mac — `("2") is not equal to ("0")` — because the old
+    /// implementation compared each segment against the basename of the
+    /// *process's* `$HOME`. It cannot lock the fix: on the machine where the
+    /// bug does not reproduce it passes either way, which is the "green by
+    /// day, red by night" shape #1509 already paid for once.
+    ///
+    /// This one is host-independent by construction. Three cwds carry three
+    /// different home segments, and on any given machine at most ONE of them
+    /// can be the running user's — so an implementation keyed on `$HOME`
+    /// fails at least two arms wherever it runs.
+    func testTitleMatchScoreSkipsTheCwdsOwnHomeSegmentOnAnyHost() {
+        let homes = [
+            ("/Users/ingo/projects/irrlicht", "ingo"),      // NOSONAR (swift:S1075) — test fixture value, not a real endpoint
+            ("/Users/runner/work/Irrlicht", "runner"),      // NOSONAR (swift:S1075) — test fixture value, not a real endpoint
+            ("/home/ci/build/Irrlicht", "ci"),              // NOSONAR (swift:S1075) — test fixture value, not a real endpoint
+        ]
+        for (cwd, homeSegment) in homes {
+            XCTAssertEqual(
+                AXTitleMatchActivator.titleMatchScore(title: "\(homeSegment)@host: ~ — zsh", cwd: cwd),
+                0,
+                "home segment '\(homeSegment)' of \(cwd) must never match alone")
+        }
+
+        // Vacuity guard: the identical title shape still scores when it names
+        // a segment that is neither generic nor the home segment. Without
+        // this, `return 0` passes every arm above.
+        XCTAssertEqual(
+            AXTitleMatchActivator.titleMatchScore(
+                title: "runner@host: work — zsh",
+                cwd: "/Users/runner/work/Irrlicht"),         // NOSONAR (swift:S1075) — test fixture value, not a real endpoint
+            3)
+
+        // The rule is positional, not name-based: the same word deeper in the
+        // path is a real directory and a legitimate signal. The old
+        // `$HOME`-basename rule discarded it on the developer's own machine.
+        XCTAssertEqual(
+            AXTitleMatchActivator.titleMatchScore(
+                title: "notes.md — ingo",
+                cwd: "/Users/ingo/projects/ingo"),           // NOSONAR (swift:S1075) — test fixture value, not a real endpoint
+            4)
+    }
+
     func testTitleMatchScoreEmptyInputs() {
         let cwd = "/Users/ingo/projects/irrlicht"  // NOSONAR (swift:S1075) — test fixture value, not a real endpoint
         XCTAssertEqual(AXTitleMatchActivator.titleMatchScore(title: "", cwd: cwd), 0)

--- a/platforms/macos/Tests/SessionRowSnapshotTests.swift
+++ b/platforms/macos/Tests/SessionRowSnapshotTests.swift
@@ -242,7 +242,7 @@ final class SessionRowSnapshotTests: XCTestCase {
             SessionRowView(session: makeSession(state: .ready, metrics: makeMetrics()), agentNumber: 3)
         }
         let view = host(rows, height: 144)
-        assertSnapshot(of: view, as: .image)
+        assertSnapshot(of: view, as: .pinnedImage)
     }
 
     func testWaitingStateShowsQuestionBlock() {
@@ -251,7 +251,7 @@ final class SessionRowSnapshotTests: XCTestCase {
             metrics: makeMetrics(lastText: "Should I run the migration?")
         )
         let view = host(session, height: 72)
-        assertSnapshot(of: view, as: .image)
+        assertSnapshot(of: view, as: .pinnedImage)
     }
 
     /// Issue #979 — the question pill used to be pinned to a single line
@@ -267,7 +267,7 @@ final class SessionRowSnapshotTests: XCTestCase {
             )
         )
         let view = host(session, height: 96)
-        assertSnapshot(of: view, as: .image)
+        assertSnapshot(of: view, as: .pinnedImage)
     }
 
     /// Issue #984 — the question pill's text color used to be a fixed hex
@@ -281,7 +281,7 @@ final class SessionRowSnapshotTests: XCTestCase {
             metrics: makeMetrics(lastText: "Should I run the migration?")
         )
         let view = hostLight(session, height: 72)
-        assertSnapshot(of: view, as: .image)
+        assertSnapshot(of: view, as: .pinnedImage)
     }
 
     func testCollapsedHidesSummaryBlocks() {
@@ -294,7 +294,7 @@ final class SessionRowSnapshotTests: XCTestCase {
             metrics: makeMetrics(lastText: "Should I run the migration?")
         )
         let view = host(session, height: 48)
-        assertSnapshot(of: view, as: .image)
+        assertSnapshot(of: view, as: .pinnedImage)
     }
 
     /// Issue #985 — waiting mode gates the question pill by session state: a
@@ -307,13 +307,13 @@ final class SessionRowSnapshotTests: XCTestCase {
             metrics: makeMetrics(lastText: "Should I run the migration?")
         )
         let view = host(session, height: 48)
-        assertSnapshot(of: view, as: .image)
+        assertSnapshot(of: view, as: .pinnedImage)
     }
 
     func testContextBarShowsTokenLabel() {
         let session = makeSession(state: .working, metrics: makeMetrics())
         let view = host(session)
-        assertSnapshot(of: view, as: .image)
+        assertSnapshot(of: view, as: .pinnedImage)
     }
 
     private func sampleHistory() -> [String] {
@@ -328,7 +328,7 @@ final class SessionRowSnapshotTests: XCTestCase {
         let session = makeSession(state: .working, metrics: makeMetrics())
         sessionManager.stateHistory[session.id] = sampleHistory()
         let view = host(session)
-        assertSnapshot(of: view, as: .image, testName: testName)
+        assertSnapshot(of: view, as: .pinnedImage, testName: testName)
     }
 
     func testHistoryBar1MinPreservesModelLabel() {
@@ -371,7 +371,7 @@ final class SessionRowSnapshotTests: XCTestCase {
     /// reach for `SNAPSHOT_TESTING_RECORD` before reading it.
     func testGhostRowPID0NilMetrics() {
         let session = makeSession(state: .ready, metrics: nil, pid: 0, adapter: "antigravity")
-        assertSnapshot(of: host(session), as: .image)
+        assertSnapshot(of: host(session), as: .pinnedImage)
     }
 
     // MARK: - Badges and markers
@@ -382,7 +382,7 @@ final class SessionRowSnapshotTests: XCTestCase {
             agentNumber: 1,
             activeSubagentCount: 3
         )
-        assertSnapshot(of: host(row), as: .image)
+        assertSnapshot(of: host(row), as: .pinnedImage)
     }
 
     func testBackgroundMoonDetached() {
@@ -391,7 +391,7 @@ final class SessionRowSnapshotTests: XCTestCase {
             metrics: makeMetrics(),
             background: BackgroundAgent(name: "nightly refactor", detached: true)
         )
-        assertSnapshot(of: host(session), as: .image)
+        assertSnapshot(of: host(session), as: .pinnedImage)
     }
 
     func testBackgroundMoonNonDetached() {
@@ -400,7 +400,7 @@ final class SessionRowSnapshotTests: XCTestCase {
             metrics: makeMetrics(),
             background: BackgroundAgent(name: "nightly refactor", detached: false)
         )
-        assertSnapshot(of: host(session), as: .image)
+        assertSnapshot(of: host(session), as: .pinnedImage)
     }
 
     func testCacheBloatBadgeAttributed() {
@@ -412,7 +412,7 @@ final class SessionRowSnapshotTests: XCTestCase {
                 cacheBloatExplanation: "This session is creating prompt-cache tokens well above normal for this project — it's getting less benefit from caching and costing more per turn. Likely tied to claude-code 2.1.143 +14K cache tokens vs 2.1.98. Common causes: an agent update that changed context construction, large or varying pasted content each turn, or frequent context resets (e.g. /clear)."
             )
         )
-        assertSnapshot(of: host(session, height: 72), as: .image)
+        assertSnapshot(of: host(session, height: 72), as: .pinnedImage)
     }
 
     // #813: no version attribution → the badge falls back to a compact label
@@ -426,7 +426,7 @@ final class SessionRowSnapshotTests: XCTestCase {
                 cacheBloatExplanation: "This session is creating prompt-cache tokens well above normal for this project — it's getting less benefit from caching and costing more per turn. Common causes: an agent update that changed context construction, large or varying pasted content each turn, or frequent context resets (e.g. /clear)."
             )
         )
-        assertSnapshot(of: host(session, height: 72), as: .image)
+        assertSnapshot(of: host(session, height: 72), as: .pinnedImage)
     }
 
     func testContextPressureAlert() {
@@ -435,7 +435,7 @@ final class SessionRowSnapshotTests: XCTestCase {
             state: .working,
             metrics: makeMetrics(tokens: 920_000, pressure: "critical", utilization: 92)
         )
-        assertSnapshot(of: host(session, height: 72), as: .image)
+        assertSnapshot(of: host(session, height: 72), as: .pinnedImage)
     }
 
     func testRoleOrchestratorRow() {
@@ -447,19 +447,19 @@ final class SessionRowSnapshotTests: XCTestCase {
             workerName: "witness-1",
             workerID: "bead-12345678ab"
         )
-        assertSnapshot(of: host(session), as: .image)
+        assertSnapshot(of: host(session), as: .pinnedImage)
     }
 
     func testRelayCloudOnline() {
         sessionManager.relayDaemons = ["mac-studio": "Mac Studio"]
         let session = makeSession(state: .working, metrics: makeMetrics(), daemonID: "mac-studio")
-        assertSnapshot(of: host(session), as: .image)
+        assertSnapshot(of: host(session), as: .pinnedImage)
     }
 
     func testRelayCloudOfflineFade() {
         sessionManager.offlineDaemons = ["mac-studio": "Mac Studio"]
         let session = makeSession(state: .ready, metrics: makeMetrics(), daemonID: "mac-studio")
-        assertSnapshot(of: host(session), as: .image)
+        assertSnapshot(of: host(session), as: .pinnedImage)
     }
 
     /// Progress chip without a projection (taskCompletionEta nil): renders the
@@ -477,7 +477,7 @@ final class SessionRowSnapshotTests: XCTestCase {
                 )
             )
         )
-        assertSnapshot(of: host(session, height: 72), as: .image)
+        assertSnapshot(of: host(session, height: 72), as: .pinnedImage)
     }
 
     /// All rounds reported done while the session is still working: the chip
@@ -498,7 +498,7 @@ final class SessionRowSnapshotTests: XCTestCase {
                 )
             )
         )
-        assertSnapshot(of: host(session, height: 72), as: .image)
+        assertSnapshot(of: host(session, height: 72), as: .pinnedImage)
     }
 
     // MARK: - Fixture-driven rendering (issue #757)
@@ -510,13 +510,13 @@ final class SessionRowSnapshotTests: XCTestCase {
     /// no longer (issue #1509).
     func testFixtureAntigravityGhost() throws {
         let session = try loadSession("antigravity-ghost.json")
-        assertSnapshot(of: host(session), as: .image)
+        assertSnapshot(of: host(session), as: .pinnedImage)
     }
 
     /// Drives a render from a bare daemon `SessionState` object (no envelope) —
     /// a substantive working Claude Code session with high context fill.
     func testFixtureWorkingClaude() throws {
         let session = try loadSession("working-claude.json")
-        assertSnapshot(of: host(session, height: 72), as: .image)
+        assertSnapshot(of: host(session, height: 72), as: .pinnedImage)
     }
 }

--- a/platforms/macos/Tests/UnappliedGrantsBannerRenderTests.swift
+++ b/platforms/macos/Tests/UnappliedGrantsBannerRenderTests.swift
@@ -43,7 +43,7 @@ final class UnappliedGrantsBannerRenderTests: XCTestCase {
     /// Review button — with no dismiss control anywhere on it.
     func testSingleUnappliedGrantRenders() throws {
         assertSnapshot(of: try host([grant("claude-code", "Claude Code", installFailed)]),
-                       as: .image, named: "one-unapplied")
+                       as: .pinnedImage, named: "one-unapplied")
     }
 
     /// Two grants failing for DIFFERENT reasons — an install failure
@@ -55,7 +55,7 @@ final class UnappliedGrantsBannerRenderTests: XCTestCase {
         assertSnapshot(of: try host([
             grant("claude-code", "Claude Code", installFailed),
             grant("codex", "Codex", versionFloor),
-        ]), as: .image, named: "two-diagnoses")
+        ]), as: .pinnedImage, named: "two-diagnoses")
     }
 }
 
@@ -88,7 +88,11 @@ final class SessionListUnappliedGrantsWiringTests: XCTestCase {
         let view = SessionListView()
             .environmentObject(manager)
             .environmentObject(GasTownProvider())
-            .environmentObject(UpdateManager())
+            // Explicit, though `UpdateManager` now refuses to start Sparkle
+            // under XCTest regardless (#1530): this is the call site whose
+            // `true` default armed a modal NSAlert one second later and hung
+            // whichever unrelated test next spun the main run loop.
+            .environmentObject(UpdateManager(startingUpdater: false))
         let hosting = NSHostingView(rootView: view)
         hosting.appearance = NSAppearance(named: .darkAqua)
         hosting.frame = CGRect(x: 0, y: 0, width: SessionListView.panelWidth, height: 420)
@@ -105,7 +109,7 @@ final class SessionListUnappliedGrantsWiringTests: XCTestCase {
     }
 
     func testPanelShowsTheBannerWhenAGrantIsUnapplied() {
-        assertSnapshot(of: host(unapplied), as: .image, named: "panel-with-banner")
+        assertSnapshot(of: host(unapplied), as: .pinnedImage, named: "panel-with-banner")
     }
 
     /// Control: the same panel with a healthy snapshot draws no strip at
@@ -113,6 +117,6 @@ final class SessionListUnappliedGrantsWiringTests: XCTestCase {
     /// aggregate and nothing else.
     func testPanelShowsNoBannerWhenHealthy() {
         assertSnapshot(of: host(PermissionsSnapshot(mode: "ask", agents: [])),
-                       as: .image, named: "panel-healthy")
+                       as: .pinnedImage, named: "panel-healthy")
     }
 }

--- a/platforms/macos/Tests/UpdateManagerSparkleGuardTests.swift
+++ b/platforms/macos/Tests/UpdateManagerSparkleGuardTests.swift
@@ -1,0 +1,62 @@
+import XCTest
+@testable import Irrlicht
+
+/// #1530 blocker 2 — the suite hang.
+///
+/// Outside an app bundle Sparkle's `startUpdater` fails, and
+/// `SPUStandardUpdaterController` answers by `dispatch_after`-ing an `NSAlert`
+/// onto the main queue and running it modally. Nothing in a headless run can
+/// dismiss it, so the next test to spin the main run loop blocks forever — a
+/// *hang*, which off a TTY produces an empty log and names no test at all.
+/// `UpdateManager.init`'s doc comment carries the full mechanism.
+///
+/// These arms exist because the natural mutation for the last of them — delete
+/// the guard and watch it go red — cannot be run on a developer Mac: it means
+/// actually arming the modal alert. So the rule is split into a pure function
+/// that CAN be reddened in place, plus a detector that must be shown to fire.
+@MainActor
+final class UpdateManagerSparkleGuardTests: XCTestCase {
+
+    /// The rule itself. Mutating `shouldStartUpdater` to `requested` reddens
+    /// the first arm; the second is the vacuity guard, without which
+    /// `return false` would satisfy the first.
+    func testShouldStartUpdaterRefusesUnderXCTestAndAllowsTheApp() {
+        XCTAssertFalse(
+            UpdateManager.shouldStartUpdater(requested: true, underXCTest: true),
+            "a test host must never start Sparkle, however loudly the caller asks")
+        XCTAssertTrue(
+            UpdateManager.shouldStartUpdater(requested: true, underXCTest: false),
+            "the shipped app must still start its updater")
+        XCTAssertFalse(
+            UpdateManager.shouldStartUpdater(requested: false, underXCTest: false),
+            "an explicit `startingUpdater: false` is still honoured")
+    }
+
+    /// A guard that cannot see the condition it guards against reports exactly
+    /// what a healthy run reports. This arm is the one that fails loudly if
+    /// `NSClassFromString("XCTestCase")` ever stops answering — for instance
+    /// if the suite moves to swift-testing, which does not link XCTest.
+    func testXCTestIsDetectedInThisVeryProcess() {
+        XCTAssertTrue(
+            UpdateManager.isRunningUnderXCTest,
+            "this assertion is running under XCTest by definition — if the "
+            + "detector disagrees, every UpdateManager built in this bundle "
+            + "arms Sparkle's modal alert")
+    }
+
+    /// The wiring: the default-argument construction — exactly the shape that
+    /// shipped in `UnappliedGrantsBannerRenderTests` — records that it did not
+    /// start the updater, and `init` hands Sparkle that same value.
+    ///
+    /// A **lock**, deliberately. Its mutation is "remove the `underXCTest`
+    /// term from `init`", which would start Sparkle outside an app bundle and
+    /// put a modal alert on the machine running it; the two arms above cover
+    /// the same rule without that cost. What it does add is that `init`
+    /// consults the rule at all — a nil `updaterStarted` wiring shows up here
+    /// and nowhere else.
+    func testDefaultConstructionDoesNotStartSparkleUnderXCTest() {
+        XCTAssertFalse(
+            UpdateManager().updaterStarted,
+            "UpdateManager() must not start Sparkle inside a test host")
+    }
+}

--- a/tools/lib/swift-suite.sh
+++ b/tools/lib/swift-suite.sh
@@ -40,7 +40,31 @@
 # mirrors macos-swift.yml's `timeout-minutes`, which exists for the same
 # reason: a job stuck `in_progress` reads as "still queued". It mirrors that
 # rationale, not that workflow's number (15 minutes, for a ~45s build).
-SWIFT_SUITE_TIMEOUT="${SWIFT_SUITE_TIMEOUT:-600}"
+#
+# The number is a CEILING, and it is derived rather than picked (#1530). It was
+# 600 — exactly an automated caller's whole Bash-tool budget — so the caller
+# killed the gate at the same instant the gate would have started explaining
+# itself, and every careful diagnosis below was unreachable for the one kind of
+# caller that most needs it. A bound whose expiry nobody can observe is this
+# file's own founding rule turned on itself: absence of a finding and inability
+# to look produced the same output.
+#
+# The four numbers it has to sit under, all measured or documented elsewhere in
+# the repo rather than invented here:
+#
+#   suite, healthy         ~5s (318 tests, this machine), ~30s under heavy load
+#   cold `swift build`     ~105s measured; the swift gate builds BEFORE the suite
+#   pre-push budget        540s (tools/preflight.sh --budget, #1570)
+#   agent command budget   600s (one foreground Bash tool call)
+#
+# So the bound must satisfy `timeout + cold build < pre-push budget`, i.e.
+# anything below 435. 240 takes that with room and still leaves 8× the loaded
+# run. `SWIFT_SUITE_MIN_HEADROOM` is what `swift-suite_test.sh` asserts against
+# — the relation is checked on every run rather than being true the day it was
+# typed.
+SWIFT_SUITE_COLD_BUILD_SECONDS=105
+SWIFT_SUITE_MIN_HEADROOM=540
+SWIFT_SUITE_TIMEOUT="${SWIFT_SUITE_TIMEOUT:-240}"
 
 # Every grep here passes -a. That is not defensive noise: `swift test` emits
 # ANSI colour and erase sequences, and a grep that classifies the stream as

--- a/tools/lib/swift-suite_test.sh
+++ b/tools/lib/swift-suite_test.sh
@@ -122,6 +122,26 @@ case "$hang_msg" in
 esac
 rm -f "$empty_log"
 
+echo "== SWIFT_SUITE_TIMEOUT default is reachable =="
+# #1530. Every diagnosis in this file is unreachable if the bound outlives the
+# caller waiting for it: at the old default of 600s an automated caller's Bash
+# tool call — also 600s — was killed at the same instant the gate would have
+# started speaking, so the HUNG branch could never print for the caller that
+# most needs it. The gate runs `swift build` first, so what has to fit inside
+# the pre-push budget is the bound PLUS a cold build.
+#
+# Read from a subshell with the variable unset, so this measures the DEFAULT
+# and not whatever the surrounding run exported.
+default_timeout=$(unset SWIFT_SUITE_TIMEOUT; . tools/lib/swift-suite.sh; echo "$SWIFT_SUITE_TIMEOUT")
+[[ "$default_timeout" =~ ^[0-9]+$ ]] \
+  && pass "default timeout is numeric ($default_timeout s)" \
+  || fail "default timeout is not a number: '$default_timeout'"
+if (( default_timeout + SWIFT_SUITE_COLD_BUILD_SECONDS < SWIFT_SUITE_MIN_HEADROOM )); then
+  pass "default ${default_timeout}s + ${SWIFT_SUITE_COLD_BUILD_SECONDS}s cold build fits in ${SWIFT_SUITE_MIN_HEADROOM}s"
+else
+  fail "default ${default_timeout}s + ${SWIFT_SUITE_COLD_BUILD_SECONDS}s cold build does NOT fit in ${SWIFT_SUITE_MIN_HEADROOM}s — the HUNG diagnosis cannot print for a bounded caller"
+fi
+
 echo "== swift_suite_last_test =="
 swift_suite_last_test "$DATA/hung.log" | grep -aq 'testRoleOrchestratorRow' \
   && pass "names the test a hung run stopped in" || fail "should name the last started test"

--- a/tools/preflight.sh
+++ b/tools/preflight.sh
@@ -509,16 +509,19 @@ fi
 # platforms/macos-only diff ran *every* gate as SKIP and pushed green having
 # checked nothing.
 #
-# This is the one gate that is deliberately STRONGER than the CI workflow it
-# corresponds to, which is the opposite of the parity rule elsewhere in this
-# file — so it is worth stating why rather than leaving it to look like drift.
-# macos-swift.yml builds and does not test, because the suite does not yet pass
-# on a GitHub runner (#1530: 227 tests do, but 35 image-snapshot comparisons are
-# host-dependent, one of them hangs, plus #1523 and one home-dependent
-# assertion). It DOES pass on a developer Mac, which is exactly where this hook
-# runs. So the tests are gated here and nowhere else until #1530 lands; a
-# reader who "fixes" this to match the workflow removes the only gate the macOS
-# test suite has.
+# Since #1530 macos-swift.yml runs the same suite through the same harness, so
+# this gate is no longer the ONLY place the macOS tests run. It is still the
+# stronger of the two and the difference is worth naming: a runner has a
+# virtual display, a stock font set and no usable audio stack, so a green there
+# is a green against a machine the app never ships to. The parity rule
+# elsewhere in this file is "mirror CI exactly"; here CI is a floor and this is
+# the real gate.
+#
+# What #1530 removed was the four host dependencies that made a runner
+# structurally unable to run it: image snapshots rasterising at the main
+# SCREEN's backing scale, a modal Sparkle alert that hung whichever test next
+# spun the run loop, #1523's helper deadlock, and a path scorer keyed on the
+# process's own $HOME.
 #
 # `--skip LauncherHarnessTests` matches the workflow exactly and is
 # load-bearing beyond speed: that target drives real terminal applications


### PR DESCRIPTION
Makes the macOS Swift test suite run on a GitHub runner and gates it there. **272 of 320 tests now gated in CI, against 0 before**, with no hang.

Blockers 2, 3 and 4 of #1530 are fixed. Blocker 1 turned out to be **two problems stacked, the first masking the second**: the scale half is fixed and proven here, and the byte half it uncovered is filed as #1615 with the evidence. #1530 stays open for that. Details per blocker below.

`.github/workflows/macos-swift.yml` gated `swift build` only; the suite now runs beside it as a second job, through the same `tools/lib/swift-suite.sh` harness `tools/preflight.sh` uses.

## Blocker 1 — 35 host-dependent image snapshots: scale first, and rasterisation underneath it

The issue recorded these two as indistinguishable, because the failure text reports point size:

```
Newly-taken snapshot@(350.0, 48.0) does not match reference@(350.0, 48.0).
```

It is not ambiguous. In SnapshotTesting 1.19.2's `Snapshotting/NSImage.swift`, `compare(_:_:precision:perceptualPrecision:)` emits the `@`-qualified form from **exactly one place** — the guard on

```swift
guard oldCgImage.width == newCgImage.width, oldCgImage.height == newCgImage.height else {
  return "Newly-taken snapshot@\(new.size) does not match reference@\(old.size)."
}
```

which returns **before a single byte is compared**. A text-rasterisation difference falls through to the `memcmp` below it and produces the *unqualified* `"Newly-taken snapshot does not match reference."` with no sizes at all. All 35 runner failures printed the qualified form, so all 35 are pixel-count mismatches.

The point sizes print equal because the reference PNG carries its DPI. Measured on disk:

```
$ sips -g pixelWidth -g pixelHeight -g dpiWidth Tests/__Snapshots__/SessionRowSnapshotTests/testRelayCloudOnline.1.png
  pixelWidth: 700
  pixelHeight: 96
  dpiWidth: 144.000
```

700×96 px at 144 dpi = 350×48 pt, so `NSImage(data:)` reports 350×48 points, while the fresh image is built as `NSImage(size: view.bounds.size)` — also 350×48 points, with a differently-sized rep inside.

**This is a necessary condition, not a sufficient one.** A pixel-count mismatch masks every byte difference behind it, so the old logs cannot say whether text *also* rasterises differently. This PR's own `swift-test` job is what answers that, and the workflow prints the runner's measured backing scale (`PinnedScaleSnapshotTests.testReportTheHostsBackingScale`) rather than inferring it.

### The fix, and why it re-records nothing

`Tests/PinnedScaleSnapshot.swift` adds `.pinnedImage`, which copies **every** bitmap parameter from the rep `bitmapImageRepForCachingDisplay` would have produced and overrides only the pixel dimensions. On a 2× host it is parameter-for-parameter the same rep the stock strategy builds.

No reference was regenerated and none needed to be — all 53 snapshot assertions across the six suites pass byte-identically, and `git status --porcelain -- Tests/__Snapshots__` is empty. That is the deliberate part: #1034 and #1044 both "fixed" a snapshot by re-recording it and both were wrong.

```
SessionRowSnapshotTests                     Executed 24 tests, with 0 failures
HistoryViewSnapshotTests                    Executed 14 tests, with 0 failures
GroupViewSnapshotTests                      Executed  6 tests, with 0 failures
PermissionWizardEffectErrorRenderTests      Executed  3 tests, with 0 failures
UnappliedGrantsBannerRenderTests            Executed  2 tests, with 0 failures
SessionListUnappliedGrantsWiringTests       Executed  2 tests, with 0 failures
BackchannelRulesViewSnapshotTests           Executed  2 tests, with 0 failures
```

### The lock, and its shape

Asserting "renders at 2×" would be green on every Mac anyone runs it on whether the scale is pinned or inherited — the same green-by-day trap `AdapterIconAppearanceTests` exists for. `PinnedScaleSnapshotTests` drives 1×, 2× and 3× through one view, so whatever the host's scale is, at most one arm can agree with it.

**Mutation** (`rasterize` reading `NSScreen.main?.backingScaleFactor` instead of its argument), on a 2× machine:

```
XCTAssertEqual failed: ("700") is not equal to ("350")  - width at 1.0× (screen is 2.0×)
XCTAssertEqual failed: ("96")  is not equal to ("48")   - height at 1.0× (screen is 2.0×)
XCTAssertEqual failed: ("700") is not equal to ("1050") - width at 3.0× (screen is 2.0×)
XCTAssertEqual failed: ("96")  is not equal to ("144")  - height at 3.0× (screen is 2.0×)
```

### What the runner then said — the second half

This PR's own `swift-test` job settles the rest, and the message form is the whole proof:

| | qualified (`@sizes`, pixel counts) | unqualified (bytes) |
|---|---|---|
| before this PR | 35 | 0 |
| after the scale fix | **0** | **36** |

36 rather than 35 because the earlier run hung partway and never reached the rest. Also newly measured rather than inferred:

```
host backing scale: 1.0× (NSScreen.main: 1.0)
Executed 318 tests, with 36 failures (0 unexpected) in 5.908 seconds
```

— no hang, where the run used to be cancelled after nine minutes.

So there is a genuine rasterisation difference underneath, between a runner on Xcode 26.6 and this repo's reference Mac on 26.3. It is **not** re-recorded here — #1034 and #1044 both made that move and both got it wrong, #1509 measured a perceptual tolerance wide enough to absorb this drift as also wide enough to pass a *missing architecture segment*, and the runner is on the newer toolchain, so re-recording chases a moving target and inverts which host is authoritative. Filed as #1615.

It is content-dependent, which is the most useful clue there:

| suite | failing / total on the runner |
|---|---|
| `SessionRowSnapshotTests` | 24 / 24 |
| `GroupViewSnapshotTests` | 6 / 6 |
| `BackchannelRulesViewSnapshotTests` | 2 / 2 |
| `SessionListUnappliedGrantsWiringTests` | 2 / 2 |
| `HistoryViewSnapshotTests` | **2 / 14** |
| `PermissionWizardEffectErrorRenderTests` | **0 / 3** |
| `UnappliedGrantsBannerRenderTests` | **0 / 2** |

The five affected suites are skipped in CI; the two that pass are deliberately left in. `Tests/ImageSnapshotCIScopeTests.swift` stops that list drifting — it derives the set of image-snapshot suites from the test sources and cross-checks it against the workflow's own `--skip` arguments, so a new one fails there rather than reddening an unrelated PR's check.

**Mutations**, all seen red:

| mutation | result |
|---|---|
| a new unclassified image-snapshot suite | `a suite renders image snapshots without being classified for CI` |
| one `--skip` removed from the run block | `macos-swift.yml's --skip list and this file's classification disagree` |
| **every** `--skip` removed from the run block, comments left naming all seven | `XCTAssertFalse failed - parsed no --skip arguments — the check is vacuous` |

The third is the one that matters: a parser reading the comment block would have found all seven names and passed. The first draft had a subtler form of the same defect and running it caught that too — the source scanner matched `as: .pinnedImage` in its own source, on the line doing the searching, and reported itself as an image-snapshot suite.

## Blocker 2 — the hang is Sparkle, and it is positional

Not the snapshot failure path the issue text guessed at, and consistent with the `NSAlert runModal` frame sampled in the issue's own comment.

`Tests/UnappliedGrantsBannerRenderTests.swift` built `UpdateManager()` with its `startingUpdater: true` default. Outside an app bundle `-[SPUUpdater startUpdater:]` fails, and `SPUStandardUpdaterController` answers a failure like this (`Sparkle/SPUStandardUpdaterController.m:78-102`):

```objc
- (void)startUpdater {
    if (![_updater startUpdater:&updaterError]) {
        // Delay the alert a bit to allow other start-up actions
        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
            NSAlert *alert = [[NSAlert alloc] init];
            ...
            [alert runModal];
        });
    }
}
```

Nobody can dismiss a modal alert in a headless run, so the modal loop never returns. **The block is drained by whichever test next spins the main run loop** — any suite using `override func tearDown() async throws`, which XCTest wraps in an `XCTWaiter` — so the hang is reported against a test with nothing to do with the updater, and a *different* one each run: `testFixtureAntigravityGhost` on a runner, `testRelayCloudOnline` and `testRoleOrchestratorRow` locally. That settles the open question in the issue comment: positional, not per-test.

`UpdateManager` now overrides the request to `false` whenever XCTest is loaded, so the next call site that takes the default is safe by existing rather than by someone remembering. The call site is fixed explicitly too.

**Mutations.** The natural one — delete the guard and watch it go red — means actually arming the modal alert on the machine running it, so the rule is split into a pure `shouldStartUpdater` that can be reddened without that. All three run without starting Sparkle:

| mutation | result |
|---|---|
| `shouldStartUpdater` → `requested` | `XCTAssertFalse failed - a test host must never start Sparkle, however loudly the caller asks` |
| `isRunningUnderXCTest` → `false` (detector arm only; constructs no `UpdateManager`) | `XCTAssertTrue failed - this assertion is running under XCTest by definition ...` |
| `init` records `requested` rather than its decision (Sparkle still handed `false`) | `XCTAssertFalse failed - UpdateManager() must not start Sparkle inside a test host` |

The third is the wiring lock's vacuity check. The lock's *real* mutation is stated in the test file and deliberately not run.

## Blocker 3 — #1523

Already fixed and closed; nothing here re-enables it, because the CI quarantine went with the workflow that had it. `SoundPlayerTests` runs in the 318 below.

## Blocker 4 — a real latent product bug, not a CI artifact

`AXTitleMatchActivator.titleMatchScore` skipped a path segment when it equalled the basename of `ProcessInfo.processInfo.environment["HOME"]` — a property of *whoever is running the app*, used to filter segments of an *arbitrary* cwd. Reproduced locally against the built bundle, giving the runner's failure byte for byte:

```
$ env HOME=/Users/runner xcrun xctest \
    -XCTest IrrlichtTests.SessionManagerTests/testTitleMatchScoreSkipsGenericTopsAndHomeBasename \
    .build/debug/IrrlichtPackageTests.xctest
Tests/SessionManagerTests.swift:567: error: XCTAssertEqual failed: ("2") is not equal to ("0")
```

The home segment is now derived positionally from the cwd being scored, so the score is a pure function of its two arguments. `cwdSegmentMatchCount` carried the same dependence — a second site with no failing assertion of its own, found by the compiler once the first changed.

The existing case cannot lock this: on the machine where the bug does not reproduce it passes either way. `testTitleMatchScoreSkipsTheCwdsOwnHomeSegmentOnAnyHost` drives three cwds carrying three different home segments, at most one of which can be the running user's on any machine.

**Property** — 43 `SessionManagerTests` pass under `HOME=/Users/ingo`, `HOME=/Users/runner` and `HOME=/home/ci` alike. **Mutation** (`isHomeSegment` → `false`), under the developer's *real* `$HOME`:

```
SessionManagerTests.swift:567: XCTAssertEqual failed: ("2") is not equal to ("0")
SessionManagerTests.swift:597: XCTAssertEqual failed: ("2") is not equal to ("0") - home segment 'ingo' of /Users/ingo/projects/irrlicht must never match alone
SessionManagerTests.swift:597: XCTAssertEqual failed: ("2") is not equal to ("0") - home segment 'runner' of /Users/runner/work/Irrlicht must never match alone
SessionManagerTests.swift:597: XCTAssertEqual failed: ("2") is not equal to ("0") - home segment 'ci' of /home/ci/build/Irrlicht must never match alone
Executed 43 tests, with 4 failures
```

## Independent: `SWIFT_SUITE_TIMEOUT` 600 → 240

600s was exactly an automated caller's whole Bash-tool budget, so the caller killed the gate at the instant the gate would have started explaining itself and the `HUNG` diagnosis could never print for the caller that most needs it. Derived, not picked: the suite is ~5s healthy and ~30s under heavy load, the gate runs a cold `swift build` (~105s) first, and the pre-push budget is 540s — so `timeout + cold build < 540` requires anything under 435.

**Mutation** (default back to 600):

```
== SWIFT_SUITE_TIMEOUT default is reachable ==
  FAIL - default 600s + 105s cold build does NOT fit in 540s - the HUNG diagnosis cannot print for a bounded caller
```

**End-to-end at the new default, no override, inside one command:**

```
SWIFT_SUITE_TIMEOUT default in effect: 240s
swift_suite_run returned 124 after 245s
--- swift_suite_verdict ---
swift test HUNG: no exit within 240s; the process tree was killed.
  last test to start: Test Case '-[IrrlichtTests.SessionRowSnapshotTests testRelayCloudOnline]' started.
```

## Verification

```
$ cd platforms/macos && swift build --build-tests
Build complete!

$ script -q /dev/null swift test --skip LauncherTestHarness --skip LauncherHarnessTests
Test Suite 'IrrlichtPackageTests.xctest' passed
  Executed 320 tests, with 0 failures (0 unexpected) in 5.164 seconds

$ tools/preflight.sh --only swift
  macOS Swift build + test    PASS

$ tools/preflight.sh --only tools
  tools/lib shell-lib tests   PASS
```

On the runner, `swift-test` reports `Executed 272 tests, with 0 failures`.

The pre-push hook's `--changed` run reported PASS for POSIX sh lint, tools/lib shell-lib tests, gofmt and macOS Swift build + test; every other gate SKIP.

## What is NOT done

Blocker 1's rasterisation half — #1615. The five affected image-snapshot suites remain local-only in CI, exactly as they were before this PR; what changed is that the reason is now measured rather than conjectured, the residual is isolated from the scale problem that was hiding it, and the skip list is mechanically checked instead of remembered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
