### PR TITLE
fix(tooling): make gate-budget's tree-kill case observe survival, not a side effect it races with

### DIFF
--- a/tools/lib/gate-budget_test.sh
+++ b/tools/lib/gate-budget_test.sh
@@ -148,18 +148,95 @@ echo "== the whole process tree dies, not just the direct child =="
 # `go test` forks a compiler and a test binary per package and npm forks node,
 # so a bound that only kills the shell leaves the expensive part running after
 # the hook has returned — a "bounded" run that keeps burning the machine.
-marker=$(mktemp -t irrlicht-gate-budget-marker)
-rm -f "$marker"
-budget_run 1 bash -c "bash -c 'sleep 30; echo grandchild-survived >\"$marker\"' & wait"
+#
+# The fixture is a script that recurses to a fixed depth and whose LEAF `exec`s
+# its sleep. Both halves of that are load-bearing (#1616).
+#
+# `exec`, because the first version of this case asked whether a surviving
+# great-grandchild had written a marker file — and that great-grandchild was a
+# SHELL running `sleep 30; echo … >marker`, so "the sleep was interrupted" and
+# "the process survived" produced the same evidence. _budget_kill_tree signals
+# depth-first, so the `sleep` is signalled BEFORE the shell waiting on it; if
+# the walking shell is descheduled between those two kills, that shell reaps
+# its dead child and runs the next command in the list. The marker appeared
+# while `pgrep` found nothing — the writer was gone by the time the test
+# looked — so the two assertions contradicted each other, on a required check,
+# for a reason no reader could act on. Measured on the old fixture: 1 failure
+# in 600 runs under load, and 100% of runs with that window widened by 400µs
+# (the threshold is ~150µs, which is an ordinary preemption). After `exec`
+# there IS no next command — the observed process is the `sleep` itself, so it
+# either exists or it does not, and there is no mid-transition state to catch
+# it in.
+#
+# A script rather than a nest of quoted `bash -c`s, because the pids are then
+# reachable by a pattern unique to this run. The old survivor query was the bare
+# literal `sleep 30; echo grandchild-survived`, and `pgrep -f` matches ANY
+# process whose command line contains it — a concurrent copy of this suite, or
+# simply the shell that invoked it. Measured: a `bash -c` whose argv merely
+# quotes that string is reported as a survivor, so an agent or CI step that
+# names the pattern (to clean up after it, say) fails the assertion 100% of the
+# time for a reason that has nothing to do with the kill.
+fixture=$(mktemp -t irrlicht-gate-budget-fixture)
+leafpid=$(mktemp -t irrlicht-gate-budget-leafpid)
+trap 'rm -f "$fixture" "$leafpid"' EXIT
+cat >"$fixture" <<'FIXTURE'
+#!/usr/bin/env bash
+# $1 = file the leaf records its pid in; $2 = levels still to descend.
+# Each level backgrounds the next and waits, so budget_run has a TREE to walk
+# and not just a child: the leaf sits as deep below the pid it kills as a real
+# gate's test binary sits below `go test`.
+if [[ "${2:-0}" -gt 0 ]]; then
+  bash "$0" "$1" "$(($2 - 1))" &
+  wait
+  exit
+fi
+echo $$ >"$1"
+exec sleep 30
+FIXTURE
+# The bound is 2, not 1, and that is setup rather than slack for a race — the
+# race is gone by construction above. $SECONDS counts whole seconds, so
+# budget_run's first deadline check can fire almost immediately: `budget_run 1`
+# gives its command anywhere from ~0.15s to ~1s (measured over phase-randomised
+# runs), while the fixture needs ~12ms idle and ~35ms under heavy load to reach
+# its leaf. At 2 the floor is ~1.2s, so the guard below reports "the tree was
+# never built" only when something is really wrong. The old fixture had the
+# same exposure and answered it by passing vacuously.
+budget_run 2 bash "$fixture" "$leafpid" 2
 assert_eq "the wrapper still reports a timeout" "1" "$BUDGET_LAST_TIMED_OUT"
-# Give a survivor time to prove it survived: without the tree kill the
-# grandchild would still be sleeping here and would write the marker at t+30.
-sleep 2
-survivors=$(pgrep -f 'sleep 30; echo grandchild-survived' | wc -l | tr -d ' ')
-assert_eq "no descendant of the killed command is still running" "0" "$survivors"
-[[ -e "$marker" ]] && fail "the grandchild must not outlive the bound" "no marker file" "marker written"
-[[ -e "$marker" ]] || pass "the grandchild did not outlive the bound"
-rm -f "$marker"
+
+leaf=$(cat "$leafpid" 2>/dev/null)
+if [[ -z "$leaf" ]]; then
+  # Loud, not silent: with no leaf pid there is nothing to look at, and "the
+  # tree was never built" must not be reported as "the tree died".
+  fail "the fixture reached its leaf before the bound expired" \
+       "a recorded pid" "an empty pidfile — the tree-kill assertion never ran"
+else
+  # Poll to a generous deadline instead of sleeping a fixed 2s and looking
+  # once. A fixed wait only has to be shorter than the machine is slow to turn
+  # a correct kill into a red, and it makes the pass slower than it needs to be;
+  # this returns the moment the tree is gone and says how long it waited when it
+  # does not. The shells are matched by the fixture's (unique) path, the leaf by
+  # the pid it recorded — after `exec` its command line is just `sleep 30`.
+  start=$SECONDS
+  alive=""
+  while :; do
+    alive="$(pgrep -f "$fixture" 2>/dev/null | tr '\n' ' ')"
+    kill -0 "$leaf" 2>/dev/null && alive="$alive$leaf(the exec'd leaf)"
+    [[ -z "$alive" ]] && break
+    [[ $((SECONDS - start)) -ge 15 ]] && break
+    sleep 0.1
+  done
+  elapsed=$((SECONDS - start))
+  if [[ -z "$alive" ]]; then
+    pass "no descendant of the killed command outlived the bound (gone after ${elapsed}s)"
+  else
+    fail "no descendant of the killed command may outlive the bound" \
+         "every descendant gone within 15s" "still alive after ${elapsed}s: $alive"
+  fi
+  kill -0 "$leaf" 2>/dev/null && kill -9 "$leaf" 2>/dev/null  # never leak a 30s sleep
+fi
+pkill -f "$fixture" 2>/dev/null
+rm -f "$fixture" "$leafpid"
 
 echo ""
 echo "== end to end: tools/preflight.sh names the gate that ran out of time =="
@@ -168,7 +245,9 @@ echo "== end to end: tools/preflight.sh names the gate that ran out of time =="
 # produces both verdicts in one run: gofmt TIMEOUT, then every gate behind it
 # NOT RUN. No --changed, so this does not depend on the branch's diff.
 probe="$ROOT/tools/.preflight-budget-probe-$$.sh"
-trap 'rm -f "$probe"' EXIT
+# Replaces the tree-kill block's trap, so it re-names that block's files: both
+# are already gone by here, but a reordering must not silently lose them.
+trap 'rm -f "$probe" "$fixture" "$leafpid"' EXIT
 python3 - "$ROOT/tools/preflight.sh" "$probe" <<'PY'
 import sys
 src, dst = sys.argv[1], sys.argv[2]


### PR DESCRIPTION
## What

`tools/lib/gate-budget_test.sh`'s tree-kill case flaked on `macos-latest`, and it
runs inside **`go-test`** — one of the two checks this repo gates on — so it
reddened PRs that touch no shell and no Go. It reported two contradictory things
at once: `survivors` was `0` and the marker file existed anyway.

This replaces the observation, not the timeout.

## The mechanism — reproduced, not hypothesised

The issue's hypothesis was marked unverified. It is now verified, two ways.

**Naturally, under load.** 600 iterations of the verbatim fixture (6 parallel
workers, 40 CPU burners on 10 cores), one failure — the issue's exact line:

```
  FAIL: the grandchild must not outlive the bound — expected [no marker file] got [marker written]
  ^^ [w2] iteration 80 of 100
[w2] 100 iterations, 1 FAILED
```

In that same sweep a second worker logged the corroborating signature without
winning the race:

```
nat-w1.log: Terminated-lines=1 | [w1 K=0] N=100 clean=99 MARKER=1 survivors=0
nat-w2.log: Terminated-lines=1 | [w2 K=0] N=100 clean=100 MARKER=0 survivors=0
```

`bash: line 1: NNNNN Terminated: 15 sleep 30` is the *inner shell* reporting its
own child's death — it only prints if that shell outlived its `sleep`. The
window is entered about twice per 600 runs and won about once.

**Deterministically.** Injecting a delay at exactly the suspected point turns it
into a reliable failure, and the response is graded:

| injected window | marker written |
|---|---|
| ~400 us | 25/25 |
| ~200 us | 23/25 |
| ~150 us | 7/25 |
| ~100 us | 0/25 |
| 0 (unmodified) | 0/25 |

So: **`_budget_kill_tree` signals depth-first**, meaning the `sleep` is signalled
*before* the shell waiting on it. If the walking shell is descheduled for as
little as ~150 us between those two `kill`s, that shell reaps its dead child and
proceeds to the next command in `sleep 30; echo grandchild-survived >marker`.
`pgrep` then finds nothing, because the writer is gone by the time the test
looks. The tree really was killed; the fixture simply could not tell
"the sleep was interrupted" from "the process survived".

Note the issue's aside about `tools/lib/swift-suite.sh` is the other way round:
that one *also* kills deepest-first, so the order is not the difference.

## The fix

The fixture is now a script that recurses to the same depth and whose **leaf
`exec`s its sleep**. After `exec` there is no next command — the observed
process *is* the `sleep`, so it exists or it does not, and there is no
mid-transition state to be caught in. Survival is then read directly: the
intermediate shells by the fixture's unique path, the leaf by the pid it
records. That is polled to a generous deadline and fails with the elapsed time
and the pids still alive, per AGENTS.md's rule that a fixture which waits by
sleeping has not observed what it waits for.

No timeout was lengthened to hide anything. (The bound moves 1 -> 2 for an
unrelated, measured reason — see below.)

## Two further defects in the same six lines

Both found while measuring, both fixed by the same change:

1. **The survivor query matched unrelated processes.** It was the bare literal
   `sleep 30; echo grandchild-survived`, and `pgrep -f` matches *any* process
   whose argv contains it — a concurrent copy of the suite, or the shell that
   invoked it. Measured directly:

   ```
   pgrep -f result:
   89771 bash -c : "sleep 30; echo grandchild-survived"; sleep 4
   ```

   This is not theoretical: it produced a 20/20 "failure" run of my own harness
   before I identified it, because the invoking tool call's argv carried the
   literal in a trailing cleanup line. The new pattern is the fixture's mktemp
   path.

2. **The case could pass vacuously.** `$SECONDS` is whole seconds and
   `budget_run`'s first deadline check can fire at once, so `budget_run 1` gives
   its command anywhere from ~0.15s to ~1s (measured over phase-randomised
   runs). The fixture needs ~12ms idle and ~35ms under heavy load to reach its
   leaf, so the old case could kill a tree it had not finished building and
   report a clean pass. The bound is now `2` (floor ~1.2s) and an unbuilt tree
   is a **loud** failure rather than a silent pass.

## Mutation evidence — the descendant-tree property is still caught

`gate-budget.sh` was mutated three ways (copy-aside / copy-back, with
`git status --porcelain` asserted clean afterwards and the file byte-identical
to `HEAD`). Each was seen red against the **hardened** test:

| mutation | hardened test |
|---|---|
| descendant walk removed | `FAIL ... still alive after 15s: 23326 23327 23328(the exec'd leaf)` |
| walk stops after one level | `FAIL ... still alive after 15s: 28756 28757(the exec'd leaf)` |
| deepest process spared | `FAIL ... still alive after 15s: 31078(the exec'd leaf)` |

The third is the one showing this is a strengthening, not a weakening. Under it
the **old** case passed all three of its assertions while a `sleep 30` genuinely
outlived its bound:

```
###### ORIGINAL test under M3 ######
  PASS: the wrapper still reports a timeout
  PASS: no descendant of the killed command is still running
  PASS: the grandchild did not outlive the bound

###### HARDENED test under M3 ######
  PASS: the wrapper still reports a timeout
  FAIL: no descendant of the killed command may outlive the bound — expected [every descendant gone within 15s] got [still alive after 15s: 31078(the exec'd leaf)]
```

The old `pgrep` pattern matched only the intermediate *shells*, never the
innermost `sleep`, so a walk that spared the deepest process was invisible to it.

And under the first mutation, the old **marker** assertion also passed:

```
###### ORIGINAL test under M1 (descendant walk removed) ######
  PASS: the wrapper still reports a timeout
  FAIL: no descendant of the killed command is still running — expected [0] got [2]
  PASS: the grandchild did not outlive the bound
```

The marker would only be written at t+30 while the case finishes at t+3, so it
could never observe survival — the survivor count was what carried the property,
and the marker check's only reachable failure was the race itself. The hardened
case carries both in one assertion.

## Rates

| | before | after |
|---|---|---|
| case, 600 iterations under identical load | 1 / 600 | 0 / 600 |
| whole suite, 20 runs under 40 burners | 0 / 20 | 0 / 20 |
| wall clock, 600 case iterations | 5m01s | 3m21s |

The whole-suite figure is not sensitive enough to see a 1-in-600 case (stated
rather than presented as evidence of a fix). The speedup is the poll returning
at once instead of always sleeping 2s.

## Verification

- `bash tools/lib/gate-budget_test.sh` — `ALL PASS`, repeatedly.
- `tools/preflight.sh --only tools` — PASS (36s).
- `tools/preflight.sh --only posix` — PASS.
- Pre-push hook: `tools/lib shell-lib tests PASS`, no `TIMEOUT`; tracking branch
  confirmed with `git status -sb`.
- Where it reaches CI: confirmed as `test.yml`'s **`go-test`** job, in the
  `for t in tools/lib/*_test.sh` loop ("Test the shared shell libs"). Mirrored
  locally by `tools/preflight.sh`'s `tools` gate.

## Found, not fixed here

`tools/lib/swift-suite_test.sh:212` has the same *class* of defect — a fixed
`sleep 1` followed by a single `kill -0` look. It is much weaker than the one
fixed here (its fixture is already pid-based and unambiguous; the only exposure
is a spurious red if the kill has not completed within 1s, e.g. a zombie not yet
reaped on a loaded runner), and it runs in the same `go-test` loop. It is left
alone deliberately: `tools/lib/swift-suite_test.sh` is in the `swift` gate's
trigger set, so editing it makes every push run a cold `swift build` +
`swift test` — a suite AGENTS.md records as intermittently hanging on this
machine (#1523/#1530) — which would gate this flake fix on an unrelated,
known-unreliable gate. Worth its own change.

Also observed but out of scope: `_budget_kill_tree`'s depth-first order means a
*shell-script* gate whose current command is killed can run one or two more of
its own commands before its own signal lands. `swift-suite.sh` narrows this by
collecting the pid list first and signalling it in a single `kill` call;
`gate-budget.sh` recurses and signals per pid. Real but minor — the gate is being
reported `TIMEOUT` anyway — and changing a shipping kill path did not belong in
an urgent flake fix.

Closes #1616
