### PR TITLE
fix(tooling): make swift-suite's tree-reap assertion poll, and bound the deadline from above (#1619)

### DIFF
--- a/tools/lib/swift-suite_test.sh
+++ b/tools/lib/swift-suite_test.sh
@@ -199,9 +199,21 @@ else
   # process group cannot reach it.
   export SWIFT_SUITE_GRANDCHILD_PIDFILE
   SWIFT_SUITE_GRANDCHILD_PIDFILE=$(mktemp -t swift-suite-gc)
+  # The grandchild's own lifetime and the deadline its reap is polled to below
+  # are declared as a pair, and the relation between them is checked rather
+  # than assumed (#1619). A poll that ran anywhere near ${gc_sleep}s would stop
+  # asserting anything: "the fixture exited by itself" and "the tree was
+  # reaped" would produce the same reading, and the case would pass vacuously.
+  # This is the wall from ABOVE — the reap latency measured below gives a
+  # deadline no lower bound worth speaking of, so without this it could be
+  # raised to any number at all with nothing objecting.
+  gc_sleep=300
+  reap_deadline=15
+  (( reap_deadline * 10 <= gc_sleep )) \
+    || fail "the reap deadline (${reap_deadline}s) is not an order of magnitude under the grandchild's own lifetime (${gc_sleep}s) — at that ratio a natural exit starts reading as a reap"
   start=$(date +%s)
   SWIFT_SUITE_TIMEOUT=2 swift_suite_run "$log" \
-    bash -c 'set -m; sleep 300 & echo $! > "$SWIFT_SUITE_GRANDCHILD_PIDFILE"; wait' >/dev/null 2>&1
+    bash -c 'set -m; sleep '"$gc_sleep"' & echo $! > "$SWIFT_SUITE_GRANDCHILD_PIDFILE"; wait' >/dev/null 2>&1
   hang_rc=$?
   elapsed=$(( $(date +%s) - start ))
   [[ "$hang_rc" -eq 124 ]] && pass "a hanging command returns 124" || fail "hang should return 124, got $hang_rc"
@@ -209,12 +221,54 @@ else
 
   gc=$(cat "$SWIFT_SUITE_GRANDCHILD_PIDFILE" 2>/dev/null)
   if [[ -n "$gc" ]]; then
-    sleep 1
-    if kill -0 "$gc" 2>/dev/null; then
-      kill -9 "$gc" 2>/dev/null   # don't leak it out of the test either way
-      fail "grandchild $gc survived the timeout kill — the process tree was not reaped"
+    # Polled, not slept (#1619). The first look happens with nothing in front
+    # of it, so a tree already reaped when swift_suite_run returned — which is
+    # what a correct implementation produces, since it posts SIGKILL and
+    # `wait`s before returning — is reported at once instead of after a fixed
+    # second. The deadline only absorbs a machine too busy to finish the
+    # teardown; a tree that genuinely survives still fails loudly, now with the
+    # elapsed time and the last state observed rather than a bare pid.
+    #
+    # `kill -0` is the predicate because it is a shell BUILTIN: it cannot fail
+    # to run, so "we could not look" can never come out as "it is gone". `ps`
+    # only DESCRIBES a pid that is still visible and never decides the verdict —
+    # a missing or broken `ps` prints nothing, and nothing would otherwise read
+    # as reaped.
+    #
+    # The residual failure mode #1619 names — the pid lingering as an unreaped
+    # ZOMBIE, which `kill -0` cannot tell from a live process — is not
+    # representable here, and a longer deadline would not have fixed it if it
+    # were. Measured: the grandchild's parent is the inner `bash -c`, which is
+    # itself in the victim list, and an orphaned zombie is reparented to launchd
+    # and reaped before the first look (0 polls). A zombie needs a LIVE parent
+    # that never waits, and this fixture has none. If one ever appeared anyway,
+    # the failure line below carries `Z <defunct>` and says so itself.
+    reap_start=$(date +%s)
+    looks=0
+    seen=""
+    while :; do
+      looks=$(( looks + 1 ))
+      if ! kill -0 "$gc" 2>/dev/null; then seen=gone; break; fi
+      psrow=$(ps -o stat=,command= -p "$gc" 2>/dev/null)
+      if [[ -n "$psrow" ]]; then
+        read -r gc_stat gc_cmd <<< "$psrow"
+        seen="state $gc_stat, command ${gc_cmd:0:60}"
+      else
+        seen="visible to kill -0, but ps prints no row for it"
+      fi
+      (( $(date +%s) - reap_start >= reap_deadline )) && break
+      sleep 0.1
+    done
+    reap_elapsed=$(( $(date +%s) - reap_start ))
+    if [[ "$seen" == gone ]]; then
+      # Printed rather than described in a comment: measured over 50 runs (25
+      # idle, 25 at load average ~55 on 10 cores) this was always look 1 at 0s,
+      # and a reap that started taking seconds would show up here instead of in
+      # a doc comment nothing re-derives (#1572).
+      pass "the whole process tree was reaped, not just the wrapper (gone on look $looks, after ${reap_elapsed}s)"
     else
-      pass "the whole process tree was reaped, not just the wrapper"
+      kill -9 "$gc" 2>/dev/null   # don't leak it out of the test either way
+      fail "grandchild $gc survived the timeout kill — the process tree was not reaped (still there after ${reap_elapsed}s / $looks looks; last seen: $seen)"
     fi
   else
     fail "grandchild never recorded its pid; the kill assertion did not run"


### PR DESCRIPTION
`tools/lib/swift-suite_test.sh`'s tree-reap assertion waited with a fixed
`sleep 1` and then called `kill -0` exactly once. It now polls to a deadline,
passes on the first look when the tree is already gone, and fails with the
elapsed time, the number of looks and the last state observed — the idiom
`tools/lib/gate-budget_test.sh` took in #1618.

## The measured reap-latency distribution

The issue is explicit that this is unverified and much weaker than #1616's
defect. It measures weaker still than that, and the honest reading is that the
1s wait was ample by an enormous margin.

`swift_suite_run` posts SIGTERM, sleeps 2s, posts SIGKILL and `wait`s for the
wrapper **before returning**, so the grandchild has been dead for over two
seconds by the time the old `sleep 1` even began.

Measured over 50 runs of the hang case, latency taken from the instant
`swift_suite_run` returned, with `kill -0` (a builtin — no fork between the
return and the first look):

| condition | runs | still visible at first look | zombie state seen | polls to gone | elapsed |
|---|---|---|---|---|---|
| idle | 25 | 0 | 0 | 0 | 0s |
| load average ~55 on 10 cores | 25 | 0 | 0 | 0 | 0s |

There is no distribution to fit: it is 0 in 50/50. This fix therefore stands on
the shape, not on a risk. What it does buy is one second off every pass, a
failure line a reader can act on, and one idiom across the two sibling fixtures.

## Calibrating the deadline — the wall is from ABOVE

Because the measurement gives no lower bound worth speaking of, a deadline
justified only from below could be raised to anything. So the bound is the other
way round and it is **checked, not written down**: a poll approaching the
fixture's own `sleep 300` stops asserting anything, since "the fixture exited by
itself" and "the tree was reaped" become the same reading. The two numbers are
declared as a pair and the case fails if the deadline is not an order of
magnitude under the lifetime (mutation M4 below). 15s also matches
`gate-budget_test.sh`.

Two other candidate upper walls were measured and do **not** bind at 15s, stated
so nobody re-derives them: pid reuse (~12 pids/s idle, ~20/s under this harness;
recycling this pid needs the allocator to wrap ~99999 pids, i.e. hours, not
seconds), and the cost of the deadline itself (paid only on a red).

## Does polling weaken the assertion? Yes — by exactly one identified shape

Not by any partial fix of the mechanism under test. Nothing reaps
asynchronously after `swift_suite_run` returns:

* The only `&` in the entire file is `script -q "$log" "$@" < /dev/null 2>&1 &`
  on line 232 (`grep -n '&\s*$\|) &\|} &' tools/lib/swift-suite.sh` returns that
  one line).
* The timeout path is a **brace group** — not a subshell, not backgrounded —
  running `kill -TERM $victims; sleep 2; kill -KILL $victims; wait "$child"`,
  and only then `return 124`.

So SIGKILL is posted and the wrapper reaped before the function returns, and any
regression of `_swift_suite_descendants` leaves a process that never dies at all
(measured: M1 and M2 below both sit at `state S` for the full 15s). Nothing
reaps between 1s and 15s.

The one shape a 15s poll would newly admit is a **future restructuring that
moved the kill sequence off the return path** (`{ …; sleep 2; kill -KILL …; } &`).
That is real and is not dismissed: no deadline at or above the existing 2s grace
can exclude it, so the deadline is the wrong tool for it. What surfaces it
instead is the figure the pass line now prints — `gone on look 1, after 0s`
today, `gone on look 37 after 3s` under such a change. Also worth stating: no
caller depends on the timing. `tools/preflight.sh`'s `swift_suite` and
`macos-swift.yml` both call `swift_suite_verdict` next and then end.

## The zombie question — answered, not waited out

The issue's stated residual failure mode is the killed pid lingering as an
unreaped zombie, making `kill -0` succeed. Polling longer does not fix that, so
it was worked out rather than assumed.

* **`kill -0` really cannot tell them apart.** Verified on a deliberately
  constructed zombie: `kill -0` succeeds while `ps -o stat=,command=` prints
  `Z <defunct>`.
* **Who the parent is.** Captured live mid-hang: `sleep 300` (own pgid, per
  `set -m`) → inner `bash -c` (`Ss+`, session leader) → `script` → the test
  shell. The grandchild's parent is the inner `bash -c`, which is **itself in
  the victim list**.
* **So a persistent zombie is not representable.** A zombie needs a live parent
  that never waits. Here the parent is guaranteed dead, so the zombie is
  orphaned, reparented to launchd and reaped — measured at **0 polls**, before
  the first look, on the constructed zombie whose parent was then killed.
  Consistent with 0 zombie states in 50 hang-case runs.

`kill -0` therefore stays the predicate, and for a second reason: it is a shell
**builtin** and cannot fail to run, where a missing or broken `ps` prints
nothing and nothing would read as "gone" — inability to look wearing a pass.
`ps` is used only to **describe** a pid that is still visible and never decides
the verdict, so the failure line names `state S, command sleep 300` — or
`Z <defunct>`, self-identifying, if one ever does appear. A `Z`-tolerant
*verdict* was deliberately not added: it could not redden any real regression (a
surviving grandchild is `S`/`R`, never `Z`) and could not be given a mutation
without a new `perl` dependency, so it would have been a branch that never
executes.

## Mutation evidence

Each applied by copy-aside, seen red, reverted by copy-back (never
`git checkout`/`restore`/`reset`), with `git status --porcelain` confirmed clean
afterwards. Each mutation script asserts its anchor was found and that the file
actually changed, so a mutation that failed to apply cannot read as a pass.

**M1 — `_swift_suite_descendants` recursion dropped** (the mutation the issue
asks for), exit 1:

```
  FAIL — grandchild 51596 survived the timeout kill — the process tree was not reaped (still there after 15s / 119 looks; last seen: state S, command sleep 300)
```

**M2 — walk stops after one level**, exit 1:

```
  FAIL — grandchild 52711 survived the timeout kill — the process tree was not reaped (still there after 15s / 115 looks; last seen: state S, command sleep 300)
```

**M3 — the fixture no longer records its pid**, i.e. the existing vacuity guard,
which the restructuring must not bypass. Exit 1:

```
  FAIL — grandchild never recorded its pid; the kill assertion did not run
```

**M4 — the guard this change ADDS**, deadline raised to 40s. Exit 1:

```
  FAIL — the reap deadline (40s) is not an order of magnitude under the grandchild's own lifetime (300s) — at that ratio a natural exit starts reading as a reap
```

Green baseline, three consecutive runs: `the whole process tree was reaped, not
just the wrapper (gone on look 1, after 0s)` / `ALL PASS`.

## Gates

Run as separate foreground invocations, exit code read directly.

| gate | result | evidence |
|---|---|---|
| `tools/preflight.sh --only tools` | **PASS** (exit 0) | `tools/lib shell-lib tests  PASS` |
| `tools/preflight.sh --only swift` | **PASS** (exit 0), 44s | `Test Suite 'IrrlichtPackageTests.xctest' passed`, `Executed 320 tests, with 0 failures`, 0 occurrences of `unexpected signal code 6` |
| `--only skills` | not run | no `.claude/skills/**/*.md` in the diff (`git diff --name-only origin/main...HEAD` is one file) |
| pre-push hook (`--changed --budget 540`) | **PASS** | `tools/lib shell-lib tests PASS`, `gofmt PASS`, `macOS Swift build + test PASS`, rest SKIP |

The swift gate was expected to be the risk here (#1523/#1530/#1615 — AGENTS.md
records the suite aborting intermittently and stopping at
`SessionRowSnapshotTests.testRelayCloudOnline` on this machine). It did not:
that test passed in 0.006s and the bundle reported its own result, which is what
`swift_suite_verdict` requires. Nothing failed for unrelated reasons, so there is
nothing to discount. Note the gate ran against a warm `.build`, so this is not
evidence about cold-build timing.

Closes #1619
