### PR TITLE
fix(tooling): make swift_suite_run return 124 under a caller's `-e` (#1633)

### DIFF
--- a/tools/lib/swift-suite.sh
+++ b/tools/lib/swift-suite.sh
@@ -8,6 +8,17 @@
 #   swift_suite_run "$log" swift test --skip LauncherHarnessTests
 #   swift_suite_verdict "$?" "$log"
 #
+# Shell options, both directions, because the convention above depends on them
+# and used to say nothing about them (#1633):
+#
+#   this file  requires nothing of the caller's options and changes none of
+#              them. swift_suite_run returns the command's status, or 124 for
+#              a hang, whether or not `-e` is set.
+#   the caller must keep `$?` reachable. Under `-e` a non-zero return aborts
+#              the caller on the line above, so swift_suite_verdict never runs
+#              and a hang and a failure print the same thing — write `set +e`
+#              first, or `|| rc=$?` (#1629, .github/workflows/macos-swift.yml).
+#
 # Why any of this exists. XCTest's stall detector responds to a hung
 # expectation by calling `abort()` on the whole process. The run then stops
 # partway — 33 of 40 suites, in the measured case — and the aggregate total
@@ -257,6 +268,21 @@ swift_suite_run() {
     # an error *in this file* at exactly the moment the gate is trying to
     # explain itself. The notice is written when `wait` reaps, so the
     # redirection has to cover the wait, not just the kills.
+    #
+    # The trailing `|| :` is the opposite — safety, not legibility — and it is
+    # not about the group's status, which `return 124` discards anyway. Every
+    # command in here is EXPECTED to fail: after SIGTERM plus the grace the
+    # victims are gone, so `kill -KILL` exits non-zero and `wait` reports the
+    # signal. Under a CALLER's `-e` the shell then dies on the first of them
+    # and `return 124` is never reached, so a hang comes back as an ordinary
+    # failure and swift_suite_verdict — which keys its entire hang diagnosis on
+    # that 124 — diagnoses the wrong thing (#1633). A compound command that is
+    # the left operand of `||` runs with errexit ignored throughout, so this
+    # one token covers the whole block, including whatever is added to it
+    # later. Guarding the commands individually is NOT equivalent, and the
+    # near-miss is why this spelling was chosen: `|| :` on the two kills alone
+    # moves the abort onto `wait` and returns 143 — as plausible a wrong answer
+    # as the 1 it replaces. Measured all three ways in #1633.
     {
       # Unquoted on purpose: a whitespace-separated pid list.
       # shellcheck disable=SC2086
@@ -265,7 +291,7 @@ swift_suite_run() {
       # shellcheck disable=SC2086
       kill -KILL $victims 2>/dev/null
       wait "$child"
-    } 2>/dev/null
+    } 2>/dev/null || :
     return 124
   fi
 

--- a/tools/lib/swift-suite_test.sh
+++ b/tools/lib/swift-suite_test.sh
@@ -274,6 +274,112 @@ else
     fail "grandchild never recorded its pid; the kill assertion did not run"
   fi
   rm -f "$log" "$SWIFT_SUITE_GRANDCHILD_PIDFILE"
+
+  # -------------------------------------------------------------------------
+  # ...and all of that has to hold under the CALLER's `-e` (#1633).
+  #
+  # swift_suite_run is SOURCED, so it runs with whatever shell options its
+  # caller happens to have, and its post-timeout sequence issues commands that
+  # are EXPECTED to fail: after SIGTERM plus the 2s grace the victims are
+  # already gone, so `kill -KILL` exits non-zero and `wait` reports the signal.
+  # Under `-e` the shell dies on the first of those — before `return 124` — and
+  # 124 is the single value swift_suite_verdict's entire hang diagnosis keys on.
+  #
+  # Two assertions in two DIFFERENT calling shapes, because bash's
+  # errexit-context rule makes each one blind to the other's defect:
+  #
+  #   the 124   is read in a BARE statement position, the shape this file's
+  #             header documents. Called from a `||` or an `if`, bash ignores
+  #             -e for the whole function body, so the hazard cannot fire there
+  #             and the assertion would pass against the unfixed lib.
+  #   the leak  is read where a line after the call still runs, which under -e
+  #             a bare 124 does not — the caller aborts on it (#1629, fixed on
+  #             the caller side). A `||` position still EXECUTES any `set` the
+  #             body performs, so that is exactly where a library which turned
+  #             -e off and forgot to restore it becomes visible.
+  echo "== swift_suite_run under the caller's \`-e\` (#1633) =="
+
+  # `bash --noprofile --norc -e -o pipefail` is GitHub's own `shell: bash`
+  # invocation, the same one calling_shape uses below. Everything the inner
+  # shell needs arrives through the environment, so the heredocs are QUOTED and
+  # carry no escaping to get wrong.
+  e_log=$(mktemp -t swift-suite-e-log)
+  e_pidfile=$(mktemp -t swift-suite-e-gc)
+  e_opts_before=$(mktemp -t swift-suite-e-opts-before)
+  e_opts_after=$(mktemp -t swift-suite-e-opts-after)
+  export SWIFT_SUITE_E_LOG="$e_log" SWIFT_SUITE_E_PIDFILE="$e_pidfile" \
+         SWIFT_SUITE_E_SLEEP="$gc_sleep" \
+         SWIFT_SUITE_E_OPTS_BEFORE="$e_opts_before" SWIFT_SUITE_E_OPTS_AFTER="$e_opts_after"
+
+  # The hang, driven exactly as the header documents it. Its return value is
+  # read as the inner shell's EXIT STATUS, and that is the only place it can be
+  # read: a correct 124 aborts the caller right there, so there is no line
+  # after the call to print it from. errexit exits with the status of the
+  # command that tripped it, so the inner shell's status IS what the function
+  # returned — 124 once the timeout path runs to its end, and otherwise
+  # whatever aborted it first (measured: 1 at `kill -KILL`, 143 at `wait`).
+  errexit_hang_probe() {
+    bash --noprofile --norc -e -o pipefail /dev/stdin 2>&1 <<'PROBE'
+set -uo pipefail
+. tools/lib/swift-suite.sh
+SWIFT_SUITE_TIMEOUT=2 swift_suite_run "$SWIFT_SUITE_E_LOG" \
+  bash -c 'set -m; sleep "$SWIFT_SUITE_E_SLEEP" & echo $! > "$SWIFT_SUITE_E_PIDFILE"; wait'
+PROBE
+  }
+  e_hang_out=$(errexit_hang_probe); e_hang_rc=$?
+
+  # A verification that could not run must not read as one that found nothing:
+  # an inner shell that died before reaching the timeout path (a bad cwd, a
+  # source that failed) exits 1, which is indistinguishable from the defect.
+  # The fixture recording its pid is the proof that the path was reached.
+  [[ -s "$e_pidfile" ]] \
+    && pass "the -e probe reached the timeout path (its fixture recorded a pid)" \
+    || fail "the -e probe never launched its fixture, so the assertion below measured something else; it printed: $e_hang_out"
+
+  [[ "$e_hang_rc" -eq 124 ]] \
+    && pass "a hanging command returns 124 under the caller's -e too" \
+    || fail "under \`bash --noprofile --norc -e -o pipefail\` a hang came back $e_hang_rc, not 124 — the post-timeout kill sequence aborted the shell before \`return 124\`; it printed: $e_hang_out"
+
+  e_gc=$(cat "$e_pidfile" 2>/dev/null)
+  [[ -n "$e_gc" ]] && kill -9 "$e_gc" 2>/dev/null   # don't leak it out of a red run
+  : > "$e_pidfile"
+
+  # The other direction. Whatever swift_suite_run does about -e, it must not
+  # pay for it by leaving the caller's options changed: a library that turns
+  # errexit off and forgets to restore it is invisible for exactly the same
+  # reason as the defect above, and does more damage.
+  #
+  # `set +o` REDIRECTED TO A FILE is the probe, and the spelling is
+  # load-bearing rather than a style choice. `$(set +o)` runs in a command
+  # substitution, and bash 3.2 — which is what /bin/bash is on macOS — reports
+  # errexit and nounset as OFF inside one no matter what the parent has
+  # (measured), so a probe built that way is byte-identical before and after
+  # and can never see an errexit leak. `set` is a builtin, so redirecting it
+  # does not fork. (`$-` is fork-free too, but has no flag character for
+  # pipefail; the dump covers every `set -o` option there is.)
+  leak_out=$(bash --noprofile --norc -e -o pipefail /dev/stdin 2>&1 <<'PROBE'
+set -uo pipefail
+. tools/lib/swift-suite.sh
+set +o > "$SWIFT_SUITE_E_OPTS_BEFORE"
+leak_rc=0
+SWIFT_SUITE_TIMEOUT=2 swift_suite_run "$SWIFT_SUITE_E_LOG" \
+  bash -c 'set -m; sleep "$SWIFT_SUITE_E_SLEEP" & echo $! > "$SWIFT_SUITE_E_PIDFILE"; wait' || leak_rc=$?
+set +o > "$SWIFT_SUITE_E_OPTS_AFTER"
+echo "leak probe: swift_suite_run returned $leak_rc"
+PROBE
+)
+  if [[ ! -s "$e_opts_before" || ! -s "$e_opts_after" ]]; then
+    fail "the option-leak probe recorded no before/after option dump — it could not run; it printed: $leak_out"
+  elif diff "$e_opts_before" "$e_opts_after" >/dev/null 2>&1; then
+    pass "the caller's shell options are unchanged across the call"
+  else
+    fail "swift_suite_run LEAKED a shell option change back to its caller:
+$(diff "$e_opts_before" "$e_opts_after" | sed 's/^/    /')"
+  fi
+
+  e_gc=$(cat "$e_pidfile" 2>/dev/null)
+  [[ -n "$e_gc" ]] && kill -9 "$e_gc" 2>/dev/null
+  rm -f "$e_log" "$e_pidfile" "$e_opts_before" "$e_opts_after"
 fi
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #1633.

`swift_suite_run` is sourced, so it runs with whatever shell options its caller
has. Its post-timeout sequence issues commands that are **expected** to fail —
after SIGTERM plus the 2s grace the victims are gone, so `kill -KILL` exits
non-zero and `wait` reports the signal — and under `-e` the shell died on the
first of them, before `return 124`. 124 is the single value
`swift_suite_verdict`'s entire hang diagnosis keys on, so a hang came back as
an ordinary failure, with the `{ … } 2>/dev/null` wrapper hiding the evidence.

Latent, not live, and I checked both callers rather than assuming: `preflight.sh`
line 103 is `set -uo pipefail` and is the file's only `set`; `macos-swift.yml`
leads both steps with `set +e` as of #1632.

## The mechanism, and why this one

Guard the **whole block** — `{ … } 2>/dev/null || :` — not the individual
commands. A compound command that is the left operand of `||` runs with errexit
ignored throughout, so one token covers the region including whatever is added
to it later.

I measured four spellings against a hanging fixture under
`bash --noprofile --norc -e -o pipefail`, reading the function's return value as
the inner shell's exit status (errexit exits with the status of the command that
tripped it, so in the header's bare-statement shape that status *is* the return):

```
baseline    hang under -e: 1      hang without -e: 124   normal-path rc=3
killsonly   hang under -e: 143    hang without -e: 124   normal-path rc=3
percmd      hang under -e: 124    hang without -e: 124   normal-path rc=3
grouplvl    hang under -e: 124    hang without -e: 124   normal-path rc=3
```

**`killsonly` is the issue's own suggested fix** (`|| true` on each `kill`) and
it is a **false fix**: it moves the abort one line down onto `wait`, which
reports the signalled child, and returns **143** — as plausible a wrong answer
as the 1 it replaces, and the same family as #1629's `|| true`. This is the
whole argument for the group-level guard over the per-command one: what actually
went wrong here is a command in the region being forgotten one at a time, and
the group guard is the only spelling that is monotone over the region.

Two mechanisms I rejected, with the reason:

- **Save/restore `-e` around the region.** The auto-restoring spelling (`local -`)
  does not exist on macOS's bash 3.2, which is `/bin/bash` here — measured:
  ``local: `-': not a valid identifier``. A manual save/restore leaks on any
  early return or interrupt, and a library that turns `-e` off and forgets is
  invisible for exactly the reason this issue is about.
- **Touching the normal path.** The final `wait "$child"` is the function's last
  command, so "errexit aborts there" and "the function returns that status" are
  the same number to every caller — unobservable, so changing it would add code
  no test can reach. The timeout path differs precisely because the aborting
  command is *not* the one whose status we want.

## The RED, before the fix

```
== swift_suite_run under the caller's `-e` (#1633) ==
  ok   — the -e probe reached the timeout path (its fixture recorded a pid)
  FAIL — under `bash --noprofile --norc -e -o pipefail` a hang came back 1, not 124 — the post-timeout kill sequence aborted the shell before `return 124`; it printed: ^D
  ok   — the caller's shell options are unchanged across the call
swift-suite_test: FAILURES
```

Independently localised before writing the fix, with marks in an instrumented
copy (the real file cannot report it — the `{ … } 2>/dev/null` wrapper hides its
own stderr):

```
=== marks reached with -e (inner shell exit=1) ===       === without -e (exit=0) ===
1 before kill-TERM                                       1 before kill-TERM
2 after kill-TERM (status 0)                             2 after kill-TERM (status 0)
3 before kill-KILL     <- aborts here                    3 before kill-KILL
                                                         4 after kill-KILL (status 1)
                                                         5 after wait
                                                         6 reached return 124
                                                         REACHED-AFTER-CALL rc=124
```

## The test

Extends `tools/lib/swift-suite_test.sh`'s Darwin block (`+106` lines, no new
file). It drives the function under GitHub's exact `shell: bash` invocation and
adds **two assertions in two different calling shapes**, because bash's
errexit-context rule makes each blind to the other's defect:

- **the 124** is read in a **bare statement** position, the shape the header
  documents. Called from a `||` or an `if`, bash ignores `-e` for the whole
  function body, so the hazard cannot fire and the assertion would have passed
  against the unfixed lib.
- **the leak** is read where a line after the call still runs, which under `-e`
  a bare 124 does not — the caller aborts on it. A `||` position still
  *executes* any `set` the body performs, so that is exactly where a leak shows.

Plus two "it could not run" guards, per AGENTS.md: an inner shell that dies
early *also* exits 1, which is byte-identical to the defect's own verdict.

### Proof the caller's options are unchanged

`set +o` **redirected to a file**, before and after, compared with `diff`. The
spelling is load-bearing rather than style: `$(set +o)` runs in a command
substitution, and bash 3.2 reports errexit and nounset as **off** inside one no
matter what the parent has — measured — so a probe built that way is
byte-identical before and after and can never see an errexit leak. `set` is a
builtin, so redirecting it does not fork. (`$-` is fork-free too but has no flag
character for `pipefail`; the dump covers every `set -o` option.)

## Mutation evidence

Every mutation applied to the committed files by copy-aside/copy-back, with
`shasum` + `git status --porcelain` asserted back to baseline after each. Each
row lists what must go red **and what must stay green** — six mutations against
three assertions are equally satisfied by three assertions that report on
everything.

| # | mutation | RED | stays green |
|---|---|---|---|
| M1 | delete the fix's `\|\| :` (the defect itself) | `a hang came back **1**, not 124` | probe-reached, leak lock |
| M2 | the issue's suggested fix: `\|\| :` on the two kills only | `a hang came back **143**, not 124` | probe-reached, leak lock |
| M3 | make the `-e` probe unable to run (source a lib that isn't there) | `the -e probe never launched its fixture … No such file or directory` **and** the 124 assertion, reporting `came back 1` — the point of the guard | leak lock |
| M4 | "fix" the 124 with a leaked `set +e` instead | `swift_suite_run LEAKED a shell option change back to its caller: < set -o errexit / > set +o errexit` | probe-reached, **and the 124 assertion PASSES** |
| M5 | drop the leak probe's second option dump | `the option-leak probe recorded no before/after option dump — it could not run` | probe-reached, 124 |

M4 is the one that shows the leak lock is not redundant: a leaked `set +e` is a
*working* fix for the return value, and the leak lock is the only thing that
objects to it.

## Documentation

The header documented the calling convention and said nothing about the shell
options it depends on — per the issue, that is the actual defect. It now states
the constraint in both directions: this library requires nothing of the caller's
options and changes none of them; the caller still has to keep `$?` reachable,
with `set +e` or `|| rc=$?` (#1629).

## Gates

Run as separate foreground invocations per AGENTS.md.

- `tools/preflight.sh --only tools` — **PASS** (`tools/lib shell-lib tests`;
  `swift-suite_test: ALL PASS`).
- `tools/preflight.sh --only swift` — **PASS**, exit status read directly rather
  than through a pipe (`REAL_PREFLIGHT_SWIFT_EXIT=0`). Per #1523 the exit code
  is the only reliable signal, and the run also reported its bundle line
  (`Test Suite 'IrrlichtPackageTests.xctest' passed at …`), so it was not
  truncated. The `LauncherTestHarness`/`LauncherHarnessTests` targets were not
  run — the gate passes both `--skip` names.
- `--only skills` not run: no `.claude/skills/**/*.md` in this diff.
- `posix` does not cover this file: `posix-lint.sh` selects on a first-line
  `#!/bin/sh` shebang, and `swift-suite.sh` is `#!/usr/bin/env bash`.
- Nothing shellchecks bash under `tools/lib/` in any gate (checked
  `preflight.sh` and the workflows). Run informationally anyway: the only
  findings are the two pre-existing `SC2034`s on `SWIFT_SUITE_COLD_BUILD_SECONDS`
  and `SWIFT_SUITE_MIN_HEADROOM`, which the test file reads. No new findings.
- The pre-push hook's `--changed` run: `tools/lib shell-lib tests` PASS,
  `macOS Swift build + test` PASS, `gofmt` PASS, everything else SKIP.

Test file runtime went from ~7s to ~16s: the two probes each spend the
`SWIFT_SUITE_TIMEOUT=2` bound plus the sequence's own 2s SIGKILL grace.

## Scope

Fixes `swift_suite_run` only, as the issue asks. **`tools/lib/gate-budget.sh`
has the same hazard and worse** — filed as #1635 rather than fixed here.
Measured, not assumed: under `-e` its `budget_run` reports a command that exits
3 as `1` **after 19.55s**, because the backgrounded child inherits errexit and
aborts before writing the status file that is its "it finished" signal — so a
gate that failed instantly is reported as a TIMEOUT that burned the whole
budget. Latent for the same reason (its only caller is `preflight.sh`, no `-e`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
