### PR TITLE
fix(tooling): make budget_run honour its contract under a caller's `-e` (#1635)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -912,6 +912,49 @@ Before marking a ticket done, run the full suite — every layer must pass:
   `install-uninstall_test.sh` now *executes* the installer under `dash` rather
   than `sh` (macOS ships `/bin/dash`), which is the runtime half — it reaches
   only the lines a case runs, where the linter reads every line.
+- Sourced shell libraries: not a contract family — a tripwire,
+  `tools/lib/shell-lib-errexit_test.sh`, over every `tools/lib/*.sh` that is
+  not a `*_test.sh`. Each function it can drive must, under a caller's
+  `set -e`, return what its library DOCUMENTS rather than aborting the caller,
+  and must leave the caller's shell options byte-identical. It exists because
+  three issues in a row were the same defect in a different file — #1629 (a
+  workflow step reading `$?` on a line GitHub's implicit `-e` never reached),
+  #1633 (`swift_suite_run`'s post-timeout kill sequence aborting before
+  `return 124`), #1635 (`budget_run`'s backgrounded child inheriting errexit
+  and dying before writing the status file that is its "it finished" signal,
+  so a gate that failed instantly was reported as a TIMEOUT that burned the
+  whole budget) — and each sibling was found only because someone happened to
+  look. These files are SOURCED, so they run with whatever options their caller
+  has, and none of them said anything about that. Four things are load-bearing:
+  - **Bare statement position is the whole point.** Every other calling shape —
+    `if f`, `f || x`, `x=$(f)` — makes bash ignore errexit for the whole
+    function body, and (measured on 3.2.57) for a subshell that body
+    backgrounds as well. The very call that came back 1 instead of 3 against
+    the unfixed `gate-budget.sh` returns 3 written as `budget_run … || rc=$?`,
+    so a lock written that way is green against a broken library.
+  - **`$(set +o)` cannot capture the options.** bash 3.2 reports errexit and
+    nounset as OFF inside a command substitution regardless of the parent —
+    measured, same shell, same instant: `$( )` gives `set +o errexit` where a
+    redirect to a file gives `set -o errexit`. A probe built the obvious way is
+    byte-identical before and after any leak and can never fail. The redirect
+    spelling is used, and `tw_fixture_leaks` is its committed guard.
+  - **No function is blind-called.** Each has a named setup+call recipe;
+    expected statuses are chosen DISTINCTIVE (0, 2, 3, 124) because a documented
+    1 is indistinguishable from an errexit abort, which also exits 1. Anything
+    undrivable is named in `TW_EXEMPT_KEYS` with its reason — today one entry,
+    `swift_suite_run` on a non-Darwin host, and it is inactive on macOS where
+    the suite actually runs. Recipe keys and exemption keys are existence-
+    checked against the walk in BOTH directions, so a library that stopped
+    being walked surfaces as its recipes naming nothing rather than as silence.
+  - Its own mutation evidence is committed (`tw_fixture_correct` /
+    `tw_fixture_aborts` / `tw_fixture_leaks`, four synthetic bijection cases,
+    and a real walk over a directory holding three of the four libraries). The
+    fixtures matter in both directions: a leaked `set +e` is a *working* fix for
+    the return value, so obligation (a) passes it and only (b) objects.
+  What it buys over a hand-written lock was measured on this repo: deleting
+  `_budget_kill_tree`'s own guard reddens the tripwire and leaves
+  `gate-budget_test.sh`'s whole `-e` block green, because that helper is only
+  ever reached through a region `budget_run` guards separately.
 - Factory: `go test ./tools/onboarding-factory/... -race -count=1`.
 - Replay: `tools/replay-fixtures.sh` — gated in CI by linux.yml, and run
   natively as `tools/preflight.sh`'s `replay fixtures` gate, so golden drift

--- a/tools/lib/gate-budget.sh
+++ b/tools/lib/gate-budget.sh
@@ -8,6 +8,18 @@
 #   budget_exhausted && ...            # nothing left — do not start a gate
 #   budget_run "$(budget_remaining)" go test ./...
 #
+# Shell options, both directions, because the convention above depends on them
+# and used to say nothing about them (#1635, the sibling of #1633):
+#
+#   this file  requires nothing of the caller's options and changes none of
+#              them. budget_run returns the command's own status, or
+#              BUDGET_TIMEOUT_RC with BUDGET_LAST_TIMED_OUT=1 for a kill,
+#              whether or not `-e` is set.
+#   the caller must keep `$?` reachable. Under `-e` a non-zero return aborts
+#              the caller on the line above, so nothing reads
+#              BUDGET_LAST_TIMED_OUT and a timeout and a failure are the same
+#              thing — write `set +e` first, or `|| rc=$?` (#1629).
+#
 # ---------------------------------------------------------------------------
 # Why this exists (#1570)
 #
@@ -129,12 +141,27 @@ budget_exhausted() {
 # one of the two gets the wrong half. They are, however, verified to compose:
 # the swift gate under `--budget 45` kills the whole pty-wrapped tree and
 # leaves no xctest process behind (measured, #1570).
+#
+# The `|| :` guards the whole walk rather than the `kill`, and it is not about
+# the group's status — `return 0` discards that anyway. Signalling a pid that
+# is already gone is the NORMAL case here (a command that exited on its own,
+# and the second pass after SIGKILL), so `kill` exits non-zero as a matter of
+# course; under a CALLER's `-e` the shell then dies inside this helper and the
+# `return 0` two lines down is a lie the caller never gets to read (#1635).
+# A compound command that is the left operand of `||` runs with errexit
+# ignored throughout, so one token covers the region including whatever is
+# added to it later. Guarding the commands individually is a measured
+# near-miss, not an equivalent: in #1633's sibling defect `|| :` on the kills
+# alone moved the abort one line down onto `wait` and returned 143 — as
+# plausible a wrong answer as the 1 it replaced.
 _budget_kill_tree() {
   local sig="$1" pid="$2" child
-  for child in $(pgrep -P "$pid" 2>/dev/null); do
-    _budget_kill_tree "$sig" "$child"
-  done
-  kill "-$sig" "$pid" 2>/dev/null
+  {
+    for child in $(pgrep -P "$pid" 2>/dev/null); do
+      _budget_kill_tree "$sig" "$child"
+    done
+    kill "-$sig" "$pid" 2>/dev/null
+  } || :
   return 0
 }
 
@@ -156,6 +183,13 @@ budget_run() {
     echo "gate-budget: budget_run needs a command to run" >&2
     return 2
   fi
+  # Deliberately NOT guarded, unlike the two regions below. `"$@"` is the
+  # last command before the return, so under a caller's `-e` "errexit aborts
+  # here" and "the function returns this status" are the same number to every
+  # caller — errexit exits with the status of the command that tripped it —
+  # and BUDGET_LAST_TIMED_OUT is already 0 from above. Guarding it would add
+  # code no test can distinguish (#1633 reached the same conclusion about
+  # swift_suite_run's final `wait`).
   if [[ "$secs" -eq 0 ]]; then
     "$@"
     return $?
@@ -171,12 +205,38 @@ budget_run() {
   local statusfile
   statusfile=$(mktemp -t irrlicht-gate-budget) || return 2
 
-  { "$@"; echo "$?" >"$statusfile.part" && mv -f "$statusfile.part" "$statusfile"; } &
+  #
+  # `set +e` first, and it is what makes the ordinary path work at all under a
+  # caller's `-e` (#1635). `{ …; } &` runs in a SUBSHELL, so the change cannot
+  # reach the caller — that is the whole reason this one region is spelled with
+  # a `set` where the two in-process ones (the timeout region below, and
+  # _budget_kill_tree's walk above) use `{ … } || :`, which is the same guard
+  # by the only means available there. Without it the child
+  # inherits errexit and dies on a command that exits non-zero BEFORE the write
+  # below, so the "it finished" signal never appears, budget_run polls to the
+  # full deadline and reports a TIMEOUT for a command that exited in
+  # milliseconds — measured: `exit 3` came back 1 after 19.55s. There is no
+  # spelling that both preserves the caller's errexit inside a shell-function
+  # command and still captures that command's status: `"$@" || rc=$?` disables
+  # it for the body too, by the same rule.
+  { set +e; "$@"; echo "$?" >"$statusfile.part" && mv -f "$statusfile.part" "$statusfile"; } &
   local pid=$!
 
   local started=$SECONDS rc
   while :; do
     if [[ -s "$statusfile" ]]; then
+      # Deliberately UNGUARDED, unlike the timeout region below, and the
+      # reasoning is worth keeping because the opposite looks obviously right:
+      # `wait` reports the CHILD's status, and the child is the group above, so
+      # its status is the `mv`'s — not the command's. This branch is only
+      # entered once that `mv` has landed, so `wait` here is provably 0.
+      # Measured: WAIT-STATUS=0 for a command exiting 0, 3 and 127 alike. A
+      # `|| :` here would be a guard no mutation can redden, which AGENTS.md
+      # treats the same as a defect test that passes on main. `-s` is likewise
+      # what makes `cat` safe to read as a status, and `rm -f` cannot fail.
+      # If the child's body ever changes so that its status IS the command's,
+      # tools/lib/shell-lib-errexit_test.sh's `budget_run (ordinary path)` row
+      # is what catches it.
       rc=$(cat "$statusfile")
       rm -f "$statusfile" "$statusfile.part"
       wait "$pid" 2>/dev/null
@@ -188,6 +248,8 @@ budget_run() {
       # that finished is a false accusation of the exact kind this file is
       # supposed to replace.
       if [[ -s "$statusfile" ]]; then
+        # Unguarded for the same reason as its twin above — the child reached
+        # its `mv`, so `wait` is 0.
         rc=$(cat "$statusfile")
         rm -f "$statusfile" "$statusfile.part"
         wait "$pid" 2>/dev/null
@@ -198,14 +260,25 @@ budget_run() {
       # lands immediately beside the caller's named TIMEOUT block, so it reads
       # as corroboration, and silencing shell diagnostics wholesale to tidy one
       # line would hide the next one nobody predicted.
-      _budget_kill_tree TERM "$pid"
-      local hard=$SECONDS
-      while [[ $((SECONDS - hard)) -lt "$BUDGET_TERM_GRACE_SECONDS" ]] && kill -0 "$pid" 2>/dev/null; do
-        sleep "$BUDGET_POLL_SECONDS"
-      done
-      _budget_kill_tree KILL "$pid"
-      wait "$pid" 2>/dev/null
-      rm -f "$statusfile" "$statusfile.part"
+      #
+      # The whole kill-and-reap region is guarded, not its individual
+      # commands (#1635, and #1633 in the sibling library). Every command in
+      # here is EXPECTED to fail: after SIGTERM plus the grace the victim is
+      # gone, so the second `kill` exits non-zero and `wait` reports the
+      # signal. Under a caller's `-e` the shell died on the first of them, so
+      # BUDGET_LAST_TIMED_OUT was never set and `return "$BUDGET_TIMEOUT_RC"`
+      # never reached — the two things preflight.sh reads from this library,
+      # both wrong, and neither with anything to look at.
+      {
+        _budget_kill_tree TERM "$pid"
+        local hard=$SECONDS
+        while [[ $((SECONDS - hard)) -lt "$BUDGET_TERM_GRACE_SECONDS" ]] && kill -0 "$pid" 2>/dev/null; do
+          sleep "$BUDGET_POLL_SECONDS"
+        done
+        _budget_kill_tree KILL "$pid"
+        wait "$pid" 2>/dev/null
+        rm -f "$statusfile" "$statusfile.part"
+      } || :
       # shellcheck disable=SC2034  # read by the caller (tools/preflight.sh), not here
       BUDGET_LAST_TIMED_OUT=1
       return "$BUDGET_TIMEOUT_RC"

--- a/tools/lib/gate-budget_test.sh
+++ b/tools/lib/gate-budget_test.sh
@@ -239,6 +239,130 @@ pkill -f "$fixture" 2>/dev/null
 rm -f "$fixture" "$leafpid"
 
 echo ""
+echo "== budget_run under the CALLER's \`-e\` (#1635) =="
+# gate-budget.sh is SOURCED (tools/preflight.sh), so budget_run runs with
+# whatever shell options its caller happens to have. Unlike #1633's sibling
+# defect this broke the ORDINARY path as well as the timeout one, and what it
+# produced there is a false accusation: the backgrounded child inherits errexit
+# and dies on a command that exits non-zero BEFORE writing the status file that
+# is its "it finished" signal (gate-budget.sh's own comment above it), so
+# budget_run polls to the full deadline and reports a TIMEOUT for a command
+# that exited in milliseconds. Measured on the unfixed library: `exit 3` came
+# back 1 after 19.55s, with BUDGET_LAST_TIMED_OUT never set — every failing
+# gate reported as a timeout it was not, and every gate behind it as NOT RUN.
+#
+# Everything below is driven under `bash --noprofile --norc -e -o pipefail`,
+# which is GitHub's own `shell: bash` invocation, in TWO different calling
+# shapes because bash's errexit-context rule makes each blind to the other's
+# defect:
+#
+#   the STATUS is read in a BARE statement position, the shape this library's
+#            header documents. Called from a `||` or an `if`, bash ignores -e
+#            for the whole function body — and, measured, for the backgrounded
+#            child too — so the hazard cannot fire there and every assertion
+#            below would pass against the unfixed library.
+#   the LEAK is read where a line after the call still runs, which under -e a
+#            bare non-zero return does not: the caller aborts on it. A `||`
+#            position still EXECUTES any `set` the body performs, so that is
+#            exactly where a library that turned -e off and forgot becomes
+#            visible.
+#
+# BUDGET_LAST_TIMED_OUT is read in the bare shape anyway, through an EXIT trap:
+# the flag is the signal preflight.sh classifies on, and reading it in a `||`
+# probe would read it in the one shape where it was never wrong.
+e_lib="$DIR/gate-budget.sh"
+e_marker=$(mktemp -t gate-budget-e-marker)
+e_flag=$(mktemp -t gate-budget-e-flag)
+e_before=$(mktemp -t gate-budget-e-opts-before)
+e_after=$(mktemp -t gate-budget-e-opts-after)
+export E_LIB="$e_lib" E_MARKER="$e_marker" E_FLAG="$e_flag" \
+       E_OPTS_BEFORE="$e_before" E_OPTS_AFTER="$e_after"
+
+# --- the ordinary path: a command that fails INSTANTLY ----------------------
+rm -f "$e_marker" "$e_flag"
+start=$SECONDS
+e_out=$(bash --noprofile --norc -e -o pipefail /dev/stdin 2>&1 <<'PROBE'
+set -uo pipefail
+. "$E_LIB"
+BUDGET_POLL_SECONDS=0.05
+BUDGET_TERM_GRACE_SECONDS=1
+# Runs even when errexit aborts the shell, which is the only way to read the
+# flag from the bare shape a correct 3 also aborts on.
+trap 'echo "$BUDGET_LAST_TIMED_OUT" > "$E_FLAG"' EXIT
+budget_run 20 bash -c ': > "$E_MARKER"; exit 3'
+PROBE
+)
+e_rc=$?
+elapsed=$((SECONDS - start))
+
+# A verification that could not run must not read as one that found nothing:
+# an inner shell that died before ever launching the command (a bad path, a
+# source that failed) also exits 1, which is byte-identical to the defect.
+if [[ -e "$e_marker" ]]; then
+  pass "the -e probe actually ran its command (the fixture left its marker)"
+else
+  fail "the -e probe never launched its command, so the assertions below measured something else" \
+       "a marker at $e_marker" "no marker; it printed: $e_out"
+fi
+assert_eq "a command that exits 3 returns 3 under the caller's -e" "3" "$e_rc"
+assert_le "...and does not burn the budget waiting for a command that already exited" "8" "$elapsed"
+assert_eq "...and does not set the timeout flag" "0" "$(cat "$e_flag" 2>/dev/null)"
+
+# --- the timeout path -------------------------------------------------------
+rm -f "$e_marker" "$e_flag"
+e_out=$(bash --noprofile --norc -e -o pipefail /dev/stdin 2>&1 <<'PROBE'
+set -uo pipefail
+. "$E_LIB"
+BUDGET_POLL_SECONDS=0.05
+BUDGET_TERM_GRACE_SECONDS=1
+trap 'echo "$BUDGET_LAST_TIMED_OUT" > "$E_FLAG"' EXIT
+budget_run 2 bash -c ': > "$E_MARKER"; sleep 60'
+PROBE
+)
+e_rc=$?
+if [[ -e "$e_marker" ]]; then
+  pass "the -e timeout probe actually ran its command (the fixture left its marker)"
+else
+  fail "the -e timeout probe never launched its command" \
+       "a marker at $e_marker" "no marker; it printed: $e_out"
+fi
+assert_eq "an over-budget command returns BUDGET_TIMEOUT_RC under the caller's -e" \
+          "$BUDGET_TIMEOUT_RC" "$e_rc"
+assert_eq "...and DOES set the timeout flag" "1" "$(cat "$e_flag" 2>/dev/null)"
+
+# --- and none of it is paid for by leaking the caller's options -------------
+# `set +o` REDIRECTED TO A FILE, never `$(set +o)`: bash 3.2 — /bin/bash on
+# macOS — reports errexit and nounset as OFF inside a command substitution no
+# matter what the parent has (measured on 3.2.57), so a probe built the obvious
+# way is byte-identical before and after and can never see a leak. `set` is a
+# builtin, so redirecting it does not fork. Both paths are driven in the one
+# probe, because a `set +e` added to either would leak from either.
+rm -f "$e_before" "$e_after"
+leak_out=$(bash --noprofile --norc -e -o pipefail /dev/stdin 2>&1 <<'PROBE'
+set -uo pipefail
+. "$E_LIB"
+BUDGET_POLL_SECONDS=0.05
+BUDGET_TERM_GRACE_SECONDS=1
+set +o > "$E_OPTS_BEFORE"
+ordinary=0; budget_run 20 bash -c 'exit 3' || ordinary=$?
+timedout=0; budget_run 2 bash -c 'sleep 60' || timedout=$?
+set +o > "$E_OPTS_AFTER"
+echo "leak probe: ordinary=$ordinary timeout=$timedout"
+PROBE
+)
+if [[ ! -s "$e_before" || ! -s "$e_after" ]]; then
+  fail "the option-leak probe recorded no before/after option dump — it could not run" \
+       "two non-empty dumps" "it printed: $leak_out"
+elif diff "$e_before" "$e_after" >/dev/null 2>&1; then
+  pass "the caller's shell options are unchanged across the call"
+else
+  fail "budget_run LEAKED a shell option change back to its caller" "no diff" \
+       "$(diff "$e_before" "$e_after" | tr '\n' ' ')"
+fi
+rm -f "$e_marker" "$e_flag" "$e_before" "$e_after"
+unset E_LIB E_MARKER E_FLAG E_OPTS_BEFORE E_OPTS_AFTER
+
+echo ""
 echo "== end to end: tools/preflight.sh names the gate that ran out of time =="
 # One mutated COPY of preflight.sh, with the gofmt gate's command replaced by a
 # sleep. gofmt is the first gate of the go group, so `--only go --budget 3`

--- a/tools/lib/shell-lib-errexit_test.sh
+++ b/tools/lib/shell-lib-errexit_test.sh
@@ -1,0 +1,567 @@
+#!/usr/bin/env bash
+# shell-lib-errexit_test.sh — a tripwire over EVERY sourced shell library in
+# tools/lib/: each function it can drive must, under a caller's `set -e`,
+# return what its library documents rather than aborting the caller, and must
+# leave the caller's shell options byte-identical.
+#
+# ---------------------------------------------------------------------------
+# Why this exists
+#
+# Three issues in a row were the same defect in a different file. #1629:
+# .github/workflows/macos-swift.yml read `$?` on a line GitHub's implicit `-e`
+# never reached. #1633: swift_suite_run's post-timeout kill sequence aborted
+# before `return 124`, so a hang was reported as an ordinary failure. #1635:
+# budget_run's backgrounded child inherited errexit and died before writing the
+# status file that is its "it finished" signal, so a gate that failed instantly
+# was reported as a TIMEOUT that burned the whole remaining budget, with
+# BUDGET_LAST_TIMED_OUT never set.
+#
+# Every one of them was found by hand, and the sibling in each case was found
+# only because someone happened to look. These files are SOURCED, so they run
+# with whatever options their caller has, and none of them said anything about
+# that. This file is the "covered by existing rather than by remembering" half:
+# a fourth library, or a fifth function in an existing one, is graded by being
+# discovered, not by anyone wiring it.
+#
+# ---------------------------------------------------------------------------
+# Three things about the shape are load-bearing
+#
+# 1. BARE STATEMENT POSITION IS THE WHOLE POINT. Every other calling shape —
+#    `if f`, `f || x`, `x=$(f)`, `f && y` — makes bash ignore errexit for the
+#    entire function body, and, measured here on bash 3.2.57, for a subshell
+#    the body backgrounds as well. So the hazard cannot fire in those shapes:
+#    the very call that returned 1 instead of 3 against the unfixed
+#    gate-budget.sh returns 3 when written as `budget_run … || rc=$?`. A lock
+#    written that way is green against a broken library. Obligation (a) below
+#    therefore emits the call as the LAST statement of an inner script and
+#    reads the inner shell's exit status — errexit exits with the status of
+#    the command that tripped it, so in that shape the shell's status IS what
+#    the function returned, whether it returned or was aborted.
+#
+# 2. `$(set +o)` CANNOT BE USED TO CAPTURE THE OPTIONS. bash 3.2 — /bin/bash
+#    on macOS, and what this suite runs under — reports errexit and nounset as
+#    OFF inside a command substitution no matter what the parent has. Measured
+#    on 3.2.57, same shell, same instant:
+#
+#        inside $( ) : set +o errexit    redirected to a file : set -o errexit
+#
+#    A probe built the obvious way is therefore byte-identical before and after
+#    any leak and can never fail. Obligation (b) uses `set +o > "$file"`, which
+#    is fork-free (`set` is a builtin) and covers every `set -o` option, where
+#    `$-` has no flag character for pipefail. The committed fixture
+#    `tw_fixture_leaks` is that probe's own guard: it leaks deliberately, and
+#    obligation (b) is required to report it.
+#
+# 3. NO FUNCTION IS BLIND-CALLED. Some have side effects, some need a fixture,
+#    one would run for a minute. Each is driven by a named recipe — a setup
+#    line and a call line — and anything the tripwire cannot safely drive is
+#    NAMED in TW_EXEMPT_KEYS with its reason. Both key sets are existence-
+#    checked against the walk in both directions, so a recipe or an exemption
+#    that stops naming a real function is a failure rather than a silent no-op
+#    (the idiom core/'s nilTolerant / mustBeNonZero / applyWritesNoUserFile
+#    already use). Silent skipping is the failure mode this whole issue family
+#    is made of.
+#
+# The walk is `tools/lib/*.sh` minus `*_test.sh`. That glob does not recurse,
+# so the deliberately-corrupt fixtures under testdata/ never enter it — the
+# same split skill-lint.sh and posix-lint.sh already draw.
+#
+# ---------------------------------------------------------------------------
+# Its own mutation evidence is committed, not described (AGENTS.md, #1479)
+#
+# tw_fixture_correct / tw_fixture_aborts / tw_fixture_leaks are driven through
+# the same two obligations as the real libraries, with the correct one as the
+# vacuity guard — an obligation that reported unconditionally would satisfy
+# every mutation and read as excellent coverage. tw_bijection is self-tested
+# against four synthetic key sets, and the discovery half is mutated for real:
+# the walk is pointed at a scratch directory holding three of the four
+# libraries, and every recipe of the missing one must be reported ORPHAN.
+
+# SC2016 is file-level and is the design rather than an oversight: every
+# recipe's setup and call line, and every line of the two probe builders, is
+# shell SOURCE TEXT emitted verbatim into an inner script. `$TW_REPO`,
+# `$TW_REACHED`, `$!` and `$?` inside those strings must be expanded by THAT
+# shell, from the exported environment, not by this one. Nothing under
+# tools/lib/ is linted by any gate today — checked: preflight.sh's posix gate
+# keys on a `#!/bin/sh` shebang and runs `--shell=sh`, and no workflow runs a
+# bash lint — so this is for whoever runs one by hand.
+# shellcheck disable=SC2016
+
+set -uo pipefail   # NOT -e: this file's whole subject is what -e does to a
+                   # callee, and the assertions capture non-zero statuses.
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+cd "$REPO_ROOT" || { echo "FAIL: shell-lib-errexit_test — cannot cd to $REPO_ROOT" >&2; exit 1; }
+
+# A missing tool is a hard failure, not a skip: exiting 0 here would read as a
+# PASS to preflight's shell_lib_tests and to test.yml's loop, so the gate would
+# go green having asserted nothing.
+need() { command -v "$1" >/dev/null 2>&1 || { echo "FAIL: shell-lib-errexit_test — $1 not found" >&2; exit 1; }; }
+need git
+need grep
+need mktemp
+need jq      # gosec_report_check refuses (2) without it, which would fail that
+             # row for an unrelated reason and read as this one.
+need pgrep   # _budget_kill_tree / _swift_suite_descendants walk with it.
+need diff    # obligation (b) IS a diff; without it every call reads as a leak.
+
+LIBDIR="$REPO_ROOT/tools/lib"
+TW_TMP=$(mktemp -d -t shell-lib-errexit) || exit 1
+trap 'rm -rf "$TW_TMP"' EXIT
+export TW_TMP
+
+fails=0
+pass() { echo "  PASS: $1"; return 0; }
+fail() { echo "  FAIL: $1 — expected [$2] got [$3]"; fails=$((fails + 1)); return 0; }
+
+# ---------------------------------------------------------------------------
+# The reporting seam.
+#
+# The obligations below report through pass/fail like every other test here,
+# except while TW_RECORDING is set — then a failure is appended to TW_RECORD
+# instead. That is what lets the committed fixtures grade the obligations
+# themselves: a self-test asserts that an obligation REPORTED, and names a
+# fragment of its own failure message, because "something failed" and "THIS
+# obligation failed" are different claims.
+TW_RECORDING=""
+TW_RECORD=""
+tw_pass() { [[ -n "$TW_RECORDING" ]] && return 0; pass "$1"; }
+tw_fail() {
+  if [[ -n "$TW_RECORDING" ]]; then TW_RECORD="$TW_RECORD$1 — expected [$2] got [$3]"$'\n'; return 0; fi
+  fail "$1" "$2" "$3"
+}
+tw_record_begin() { TW_RECORDING=1; TW_RECORD=""; }
+tw_record_end()   { TW_RECORDING=""; }
+
+# mustReport <label> <fragment> — the self-test verdict. A bare failure is
+# refused: the record has to name a fragment of the obligation's own message.
+mustReport() {
+  if [[ -z "$TW_RECORD" ]]; then
+    fail "$1" "the obligation to report" "it stayed silent"
+    return 0
+  fi
+  case "$TW_RECORD" in
+    *"$2"*) pass "$1" ;;
+    *) fail "$1" "a report naming: $2" "$(echo "$TW_RECORD" | tr '\n' ' ')" ;;
+  esac
+  return 0
+}
+# mustBeSilent <label> — the vacuity guard's verdict.
+mustBeSilent() {
+  if [[ -z "$TW_RECORD" ]]; then pass "$1"
+  else fail "$1" "silence" "$(echo "$TW_RECORD" | tr '\n' ' ')"; fi
+  return 0
+}
+
+# ---------------------------------------------------------------------------
+# Discovery
+#
+# tw_discover <dir> — one `lib.sh::func` line per function found. Lines
+# beginning with `!` are refusals, not results: a library the scan read and
+# found no function in, and a `function name {` declaration, which this scan
+# does not understand. Both are hard failures rather than an empty result,
+# because "found nothing" and "could not look" must never produce the same
+# output.
+tw_discover() {
+  local dir="$1" f base names alt
+  for f in "$dir"/*.sh; do
+    [[ -e "$f" ]] || continue
+    case "$f" in *_test.sh) continue ;; esac
+    base=$(basename "$f")
+    alt=$(grep -acE '^[[:space:]]*function[[:space:]]+[A-Za-z_]' "$f")
+    if [[ "$alt" -gt 0 ]]; then
+      echo "! $base declares $alt function(s) with the \`function name {\` spelling, which this scan does not understand — it would be walked and silently found empty"
+    fi
+    names=$(grep -aE '^[A-Za-z_][A-Za-z0-9_]*[[:space:]]*\(\)[[:space:]]*\{?[[:space:]]*$' "$f" | sed -E 's/[[:space:]]*\(\).*$//')
+    if [[ -z "$names" ]]; then
+      echo "! $base was walked and no function was found in it — the scan cannot read this file"
+      continue
+    fi
+    while IFS= read -r n; do
+      [[ -n "$n" ]] && echo "$base::$n"
+    done <<<"$names"
+  done
+}
+
+# tw_bijection <discovered> <recipe-keys> <exempt-keys> — one complaint per
+# line, silence when the three agree. Checked in BOTH directions on purpose:
+# the undriven half catches a function nobody wrote a recipe for, and the
+# orphan halves catch a library that stopped being walked at all — the recipes
+# then name nothing, which is the failure this whole file exists to prevent
+# reading as coverage.
+tw_bijection() {
+  local discovered="$1" recipes="$2" exempt="$3" k
+  while IFS= read -r k; do
+    [[ -z "$k" ]] && continue
+    case $'\n'"$recipes"$'\n' in *$'\n'"$k"$'\n'*) continue ;; esac
+    case $'\n'"$exempt"$'\n' in *$'\n'"$k"$'\n'*) continue ;; esac
+    echo "UNDRIVEN $k — no driving recipe and no entry in TW_EXEMPT_KEYS"
+  done <<<"$discovered"
+  while IFS= read -r k; do
+    [[ -z "$k" ]] && continue
+    case $'\n'"$discovered"$'\n' in *$'\n'"$k"$'\n'*) continue ;; esac
+    echo "ORPHAN-RECIPE $k — a recipe naming no function the walk found"
+  done <<<"$recipes"
+  while IFS= read -r k; do
+    [[ -z "$k" ]] && continue
+    case $'\n'"$discovered"$'\n' in *$'\n'"$k"$'\n'*) continue ;; esac
+    echo "ORPHAN-EXEMPTION $k — an exemption naming no function the walk found"
+  done <<<"$exempt"
+}
+
+# ---------------------------------------------------------------------------
+# The two obligations
+#
+# Both build an inner script and run it under `bash --noprofile --norc -e -o
+# pipefail`, which is GitHub's own `shell: bash` invocation. `: > "$TW_REACHED"`
+# is emitted immediately before the call, so an inner shell that died in its
+# setup (a bad path, a source that failed) is reported as a probe that could
+# not run rather than as the defect — those exit 1 too, which is byte-identical
+# to several of the failures being graded.
+export TW_REACHED="$TW_TMP/reached"
+export TW_OPTS_BEFORE="$TW_TMP/opts.before"
+export TW_OPTS_AFTER="$TW_TMP/opts.after"
+
+# tw_obligation_status <label> <want> <setup> <call>
+tw_obligation_status() {
+  local label="$1" want="$2" setup="$3" call="$4" probe out got
+  probe="$TW_TMP/probe.status.sh"
+  rm -f "$TW_REACHED"
+  printf '%s\n' 'set -uo pipefail' "$setup" ': > "$TW_REACHED"' "$call" >"$probe"
+  out=$(bash --noprofile --norc -e -o pipefail "$probe" 2>&1); got=$?
+  if [[ ! -e "$TW_REACHED" ]]; then
+    tw_fail "$label: the probe never reached the call, so nothing was graded" \
+            "a probe that ran its setup" "it printed: $(echo "$out" | tr '\n' ' ')"
+    return 0
+  fi
+  if [[ "$got" == "$want" ]]; then
+    tw_pass "$label: returned $want in a bare statement under the caller's -e"
+  else
+    tw_fail "$label: in a bare statement under \`bash --noprofile --norc -e -o pipefail\` it returned $got, not the documented $want — it aborted the caller instead of returning" \
+            "$want" "$got ($(echo "$out" | tr '\n' ' '))"
+  fi
+  return 0
+}
+
+# tw_obligation_leak <label> <setup> <call>
+#
+# Read in a `|| rc=$?` position, which is the ONLY place it can be read: under
+# -e a bare non-zero return aborts the caller, so there is no line after the
+# call to take the second dump from. A `||` position still EXECUTES any `set`
+# the body performs, so a library that turned an option off and forgot is
+# exactly as visible there.
+tw_obligation_leak() {
+  local label="$1" setup="$2" call="$3" probe out
+  probe="$TW_TMP/probe.leak.sh"
+  rm -f "$TW_REACHED" "$TW_OPTS_BEFORE" "$TW_OPTS_AFTER"
+  printf '%s\n' 'set -uo pipefail' "$setup" \
+    'set +o > "$TW_OPTS_BEFORE"' ': > "$TW_REACHED"' \
+    'tw_rc=0; { '"$call"'; } || tw_rc=$?' \
+    'set +o > "$TW_OPTS_AFTER"' >"$probe"
+  out=$(bash --noprofile --norc -e -o pipefail "$probe" 2>&1)
+  if [[ ! -e "$TW_REACHED" || ! -s "$TW_OPTS_BEFORE" || ! -s "$TW_OPTS_AFTER" ]]; then
+    tw_fail "$label: the option-leak probe recorded no before/after dump — it could not run" \
+            "two non-empty dumps and a reached marker" "it printed: $(echo "$out" | tr '\n' ' ')"
+    return 0
+  fi
+  if diff "$TW_OPTS_BEFORE" "$TW_OPTS_AFTER" >/dev/null 2>&1; then
+    tw_pass "$label: left the caller's shell options byte-identical"
+  else
+    tw_fail "$label: LEAKED a shell option change back to its caller" "no diff" \
+            "$(diff "$TW_OPTS_BEFORE" "$TW_OPTS_AFTER" | tr '\n' ' ')"
+  fi
+  return 0
+}
+
+# ---------------------------------------------------------------------------
+# The driving recipes
+#
+# One row per (function, documented outcome). Fields: key, label, expected
+# status, setup line, call line. Both lines are emitted VERBATIM into the inner
+# script, so `$TW_REPO` and friends are expanded by that shell from the
+# environment, never here.
+#
+# Expected statuses are chosen to be DISTINCTIVE wherever the function offers
+# the choice — 0, 2, 3, 124. A recipe whose documented answer is 1 would be
+# indistinguishable from an errexit abort, which also exits 1, so predicates
+# are driven in the state where they answer true.
+SEP=$'\034'
+TW_ROWS=""
+row() { TW_ROWS="$TW_ROWS$1$SEP$2$SEP$3$SEP$4$SEP$5"$'\n'; }
+
+# A throwaway repo with an origin/main ref, so changed_files_vs_origin_main is
+# driven against a baseline it can resolve without depending on this clone
+# having fetched one (a CI checkout may not have).
+TW_REPO="$TW_TMP/repo"; export TW_REPO
+mkdir -p "$TW_REPO"
+(
+  cd "$TW_REPO" &&
+  git init -q . &&
+  git config user.email tripwire@example.invalid &&
+  git config user.name tripwire &&
+  git config commit.gpgsign false &&
+  : > a.txt && git add a.txt && git commit -qm baseline &&
+  git update-ref refs/remotes/origin/main HEAD
+) >/dev/null 2>&1 || { echo "FAIL: shell-lib-errexit_test — could not build the scratch git repo" >&2; exit 1; }
+
+row 'changed-files.sh::changed_files_vs_origin_main' 'changed_files_vs_origin_main' 0 \
+    '. tools/lib/changed-files.sh; cd "$TW_REPO"' \
+    'changed_files_vs_origin_main >/dev/null'
+row 'changed-files.sh::go_module_touched' 'go_module_touched' 0 \
+    '. tools/lib/changed-files.sh' \
+    'go_module_touched core "core/x.go"'
+row 'changed-files.sh::web_tree_touched' 'web_tree_touched' 0 \
+    '. tools/lib/changed-files.sh' \
+    'web_tree_touched platforms/web "platforms/web/package-lock.json"'
+
+row 'gate-budget.sh::budget_open' 'budget_open (refuses a non-numeric bound)' 2 \
+    '. tools/lib/gate-budget.sh' \
+    'budget_open 10m 2>/dev/null'
+row 'gate-budget.sh::budget_is_bounded' 'budget_is_bounded' 0 \
+    '. tools/lib/gate-budget.sh; budget_open 5' \
+    'budget_is_bounded'
+row 'gate-budget.sh::budget_remaining' 'budget_remaining' 0 \
+    '. tools/lib/gate-budget.sh; budget_open 5' \
+    'budget_remaining >/dev/null'
+row 'gate-budget.sh::budget_exhausted' 'budget_exhausted' 0 \
+    '. tools/lib/gate-budget.sh; budget_open 5; _BUDGET_STARTED_AT=$((SECONDS - 10))' \
+    'budget_exhausted'
+# Its documented contract is `return 0` unconditionally, and signalling a pid
+# that is already gone is its NORMAL case — the second pass after SIGKILL, and
+# every command that exited on its own. Measured: 1 against the unfixed library.
+row 'gate-budget.sh::_budget_kill_tree' '_budget_kill_tree (already-dead pid)' 0 \
+    '. tools/lib/gate-budget.sh; sh -c "exit 0" & tw_dead=$!; wait "$tw_dead" || :' \
+    '_budget_kill_tree TERM "$tw_dead"'
+row 'gate-budget.sh::budget_run' 'budget_run (ordinary path)' 3 \
+    '. tools/lib/gate-budget.sh; BUDGET_POLL_SECONDS=0.05' \
+    'budget_run 20 bash -c "exit 3"'
+row 'gate-budget.sh::budget_run' 'budget_run (timeout path)' 124 \
+    '. tools/lib/gate-budget.sh; BUDGET_POLL_SECONDS=0.05; BUDGET_TERM_GRACE_SECONDS=1' \
+    'budget_run 2 bash -c "sleep 60" 2>/dev/null'
+
+row 'gosec-report.sh::gosec_report_check' 'gosec_report_check (a clean report)' 0 \
+    '. tools/lib/gosec-report.sh' \
+    'gosec_report_check tools/lib/testdata/gosec-report/clean.json tripwire >/dev/null 2>&1'
+
+row 'swift-suite.sh::swift_suite_completed' 'swift_suite_completed' 0 \
+    '. tools/lib/swift-suite.sh' \
+    'swift_suite_completed tools/lib/testdata/swift-suite/clean.log'
+row 'swift-suite.sh::swift_suite_ran_tests' 'swift_suite_ran_tests' 0 \
+    '. tools/lib/swift-suite.sh' \
+    'swift_suite_ran_tests tools/lib/testdata/swift-suite/clean.log'
+row 'swift-suite.sh::swift_suite_bundle_failed' 'swift_suite_bundle_failed' 0 \
+    '. tools/lib/swift-suite.sh' \
+    'swift_suite_bundle_failed tools/lib/testdata/swift-suite/bundle-failed.log'
+row 'swift-suite.sh::swift_suite_last_test' 'swift_suite_last_test' 0 \
+    '. tools/lib/swift-suite.sh' \
+    'swift_suite_last_test tools/lib/testdata/swift-suite/clean.log >/dev/null'
+row 'swift-suite.sh::_swift_suite_hung_headline' '_swift_suite_hung_headline' 0 \
+    '. tools/lib/swift-suite.sh; SWIFT_SUITE_TIMEOUT=1' \
+    '_swift_suite_hung_headline 2>/dev/null'
+row 'swift-suite.sh::swift_suite_verdict' 'swift_suite_verdict (a clean run)' 0 \
+    '. tools/lib/swift-suite.sh' \
+    'swift_suite_verdict 0 tools/lib/testdata/swift-suite/clean.log >/dev/null 2>&1'
+row 'swift-suite.sh::_swift_suite_descendants' '_swift_suite_descendants' 0 \
+    '. tools/lib/swift-suite.sh' \
+    '_swift_suite_descendants $$ >/dev/null'
+# The timeout path of this one is #1633's own dedicated lock in
+# swift-suite_test.sh, which drives a real hang through a pty; driving it here
+# too would spend the same seconds twice for the same assertion.
+row 'swift-suite.sh::swift_suite_run' 'swift_suite_run (ordinary path)' 3 \
+    '. tools/lib/swift-suite.sh; SWIFT_SUITE_TIMEOUT=5' \
+    'swift_suite_run "$TW_TMP/swift-suite-run.log" bash -c "exit 3" >/dev/null 2>&1'
+
+# ---------------------------------------------------------------------------
+# The exemption map
+#
+# Keys are existence-checked against the walk whether or not the exemption is
+# ACTIVE on this host, so an entry that stops naming a real function fails
+# rather than quietly doing nothing. tw_exempt_reason returns non-zero when the
+# function is drivable here, in which case its recipe runs normally.
+TW_EXEMPT_KEYS='swift-suite.sh::swift_suite_run'
+tw_exempt_reason() {
+  case "$1" in
+    'swift-suite.sh::swift_suite_run')
+      [[ "$(uname -s)" == "Darwin" ]] && return 1
+      echo "needs BSD script(1) for its pty; the spelling and argument order differ on $(uname -s), and the only production caller is a Darwin-guarded gate. Driven on macOS, which is where test.yml runs this suite."
+      return 0
+      ;;
+  esac
+  return 1
+}
+
+# ---------------------------------------------------------------------------
+echo "== the walk reads every sourced library in tools/lib/ =="
+discovery=$(tw_discover "$LIBDIR")
+refusals=$(echo "$discovery" | grep '^!' || :)
+discovered=$(echo "$discovery" | grep -v '^!' || :)
+if [[ -n "$refusals" ]]; then
+  while IFS= read -r r; do
+    [[ -n "$r" ]] && fail "the scan refused a library" "a readable library" "${r#! }"
+  done <<<"$refusals"
+else
+  pass "every library the walk read yielded functions, in a spelling it understands"
+fi
+lib_count=$(echo "$discovered" | sed -E 's/::.*$//' | sort -u | grep -c . || :)
+fn_count=$(echo "$discovered" | grep -c . || :)
+echo "     walked $lib_count librar(ies), $fn_count function(s)"
+
+recipe_keys=$(echo "$TW_ROWS" | cut -d"$SEP" -f1 | sort -u | grep . || :)
+exempt_keys=$(echo "$TW_EXEMPT_KEYS" | tr ' ' '\n' | grep . | sort -u || :)
+row_count=$(echo "$TW_ROWS" | grep -c . || :)
+# The table's own vacuity guard. Without it a `row` that stopped appending —
+# a renamed helper, a lost SEP — would leave every complaint below to be
+# reported as "UNDRIVEN", i.e. as a fault of the libraries rather than of this
+# file.
+[[ "$row_count" -ge "$fn_count" ]] \
+  && pass "the recipe table carries at least one row per discovered function ($row_count rows / $fn_count functions)" \
+  || fail "the recipe table carries at least one row per discovered function" ">= $fn_count rows" "$row_count"
+
+complaints=$(tw_bijection "$discovered" "$recipe_keys" "$exempt_keys")
+if [[ -z "$complaints" ]]; then
+  pass "every discovered function has a driving recipe or a named exemption, and every key names a real function"
+else
+  while IFS= read -r c; do
+    [[ -n "$c" ]] && fail "recipes and the walk disagree" "a bijection" "$c"
+  done <<<"$complaints"
+fi
+
+echo ""
+echo "== each function, under \`bash --noprofile --norc -e -o pipefail\` =="
+while IFS="$SEP" read -r key label want setup call; do
+  [[ -z "$key" ]] && continue
+  if reason=$(tw_exempt_reason "$key"); then
+    echo "  EXEMPT: $key — $reason"
+    continue
+  fi
+  tw_obligation_status "$label" "$want" "$setup" "$call"
+  tw_obligation_leak "$label" "$setup" "$call"
+done <<<"$TW_ROWS"
+
+# ---------------------------------------------------------------------------
+echo ""
+echo "== the tripwire's own mutation evidence =="
+# Committed rather than described: a paragraph in a merged PR body is re-run by
+# nothing, and an obligation that silently stopped discriminating looks exactly
+# like health. Each fixture is wrong in exactly ONE way, and each case names
+# both what must be reported and what must stay silent — three mutations
+# against two obligations are equally satisfied by two obligations that report
+# on everything.
+TW_FIXTURES="$TW_TMP/fixtures.sh"; export TW_FIXTURES
+cat >"$TW_FIXTURES" <<'FIXTURES'
+# Correct: guards its expected-to-fail command and touches no shell option.
+tw_fixture_correct() { false || :; return 0; }
+# Wrong in one way: unguarded, so under a caller's -e it aborts before its
+# `return 0`. This is #1633's and #1635's shape reduced to two lines.
+tw_fixture_aborts() { false; return 0; }
+# Wrong in one way: "fixes" the abort by disarming errexit and never restoring
+# it. Returns the documented 0, so obligation (a) is satisfied — the leak lock
+# is the only thing that objects.
+tw_fixture_leaks() { set +e; false; return 0; }
+FIXTURES
+fx='. "$TW_FIXTURES"'
+
+tw_record_begin
+tw_obligation_status 'selftest/correct' 0 "$fx" 'tw_fixture_correct'
+tw_obligation_leak   'selftest/correct'   "$fx" 'tw_fixture_correct'
+tw_record_end
+mustBeSilent "the vacuity guard: a correct function passes both obligations"
+
+tw_record_begin
+tw_obligation_status 'selftest/aborts' 0 "$fx" 'tw_fixture_aborts'
+tw_record_end
+mustReport "obligation (a) reports a function that aborts its caller under -e" \
+           "it returned 1, not the documented 0"
+
+tw_record_begin
+tw_obligation_leak 'selftest/aborts' "$fx" 'tw_fixture_aborts'
+tw_record_end
+mustBeSilent "...and obligation (b) stays silent about it — it leaks nothing"
+
+tw_record_begin
+tw_obligation_leak 'selftest/leaks' "$fx" 'tw_fixture_leaks'
+tw_record_end
+mustReport "obligation (b) reports a leaked shell option — so the \`set +o >file\` spelling really can see one" \
+           "LEAKED a shell option change"
+
+tw_record_begin
+tw_obligation_status 'selftest/leaks' 0 "$fx" 'tw_fixture_leaks'
+tw_record_end
+mustBeSilent "...and obligation (a) stays silent about it — a leaked \`set +e\` returns the documented 0, which is exactly why (b) is not redundant"
+
+tw_record_begin
+tw_obligation_status 'selftest/unreachable' 0 '. "$TW_TMP/there-is-no-such-file.sh"' 'tw_fixture_correct'
+tw_record_end
+mustReport "a probe that could not run is reported as that, not as the defect" \
+           "the probe never reached the call"
+
+# --- the bijection, over synthetic key sets --------------------------------
+three=$'a.sh::one\na.sh::two\nb.sh::three'
+b=$(tw_bijection "$three" "$three" "")
+[[ -z "$b" ]] && pass "bijection vacuity guard: agreeing sets produce no complaint" \
+              || fail "bijection vacuity guard" "silence" "$b"
+
+b=$(tw_bijection "$three" $'a.sh::one\na.sh::two' "")
+case "$b" in
+  *"UNDRIVEN b.sh::three"*) pass "bijection reports a function with no recipe and no exemption" ;;
+  *) fail "bijection reports a function with no recipe and no exemption" "UNDRIVEN b.sh::three" "$b" ;;
+esac
+
+b=$(tw_bijection $'a.sh::one\na.sh::two' "$three" "")
+case "$b" in
+  *"ORPHAN-RECIPE b.sh::three"*) pass "bijection reports a recipe naming nothing — how a library that stopped being walked surfaces" ;;
+  *) fail "bijection reports a recipe naming nothing" "ORPHAN-RECIPE b.sh::three" "$b" ;;
+esac
+
+b=$(tw_bijection "$three" "$three" 'a.sh::gone')
+case "$b" in
+  *"ORPHAN-EXEMPTION a.sh::gone"*) pass "bijection reports an exemption naming nothing — the existence check on TW_EXEMPT_KEYS" ;;
+  *) fail "bijection reports an exemption naming nothing" "ORPHAN-EXEMPTION a.sh::gone" "$b" ;;
+esac
+
+# --- and the discovery half, mutated for real ------------------------------
+# A scratch lib dir carrying three of the four libraries. Every recipe of the
+# missing one must come back ORPHAN, which is what "a library stopped being
+# walked" looks like from here. Without this the bijection is only ever graded
+# against hand-written lists.
+mutdir="$TW_TMP/libs-minus-one"
+mkdir -p "$mutdir"
+cp "$LIBDIR"/changed-files.sh "$LIBDIR"/gate-budget.sh "$LIBDIR"/gosec-report.sh "$mutdir/"
+mut=$(tw_discover "$mutdir" | grep -v '^!' || :)
+missing=$(tw_bijection "$mut" "$recipe_keys" "$exempt_keys" | grep -c '^ORPHAN-RECIPE swift-suite\.sh::' || :)
+swift_recipes=$(echo "$recipe_keys" | grep -c '^swift-suite\.sh::' || :)
+if [[ "$swift_recipes" -lt 1 ]]; then
+  fail "the discovery mutation had something to remove" "at least one swift-suite recipe" "$swift_recipes"
+elif [[ "$missing" -eq "$swift_recipes" ]]; then
+  pass "a library dropped from the walk is reported once per orphaned recipe ($missing of $swift_recipes)"
+else
+  fail "a library dropped from the walk is reported once per orphaned recipe" "$swift_recipes" "$missing"
+fi
+# ...and the same walk over the untouched directory must NOT report them, or
+# the case above would be satisfied by a check that complains unconditionally.
+still=$(tw_bijection "$discovered" "$recipe_keys" "$exempt_keys" | grep -c '^ORPHAN-RECIPE swift-suite\.sh::' || :)
+[[ "$still" -eq 0 ]] && pass "...and the real walk reports none of them" \
+                     || fail "the real walk must not report swift-suite recipes as orphans" "0" "$still"
+
+# --- the two scan refusals --------------------------------------------------
+scandir="$TW_TMP/scan-refusals"
+mkdir -p "$scandir"
+printf '#!/usr/bin/env bash\n# no functions here at all\necho hi\n' >"$scandir/empty-lib.sh"
+printf '#!/usr/bin/env bash\nfunction ksh_style {\n  :\n}\n' >"$scandir/ksh-style.sh"
+scanout=$(tw_discover "$scandir")
+case "$scanout" in
+  *"empty-lib.sh was walked and no function was found"*) pass "the scan refuses a library it read and found empty, rather than returning nothing" ;;
+  *) fail "the scan refuses a library it read and found empty" "a refusal naming empty-lib.sh" "$scanout" ;;
+esac
+case "$scanout" in
+  *"ksh-style.sh declares 1 function(s) with the \`function name {\` spelling"*) pass "the scan refuses a spelling it does not understand, rather than walking past it" ;;
+  *) fail "the scan refuses a spelling it does not understand" "a refusal naming ksh-style.sh" "$scanout" ;;
+esac
+
+echo ""
+if [[ "$fails" -eq 0 ]]; then
+  echo "shell-lib-errexit_test: ALL PASS"
+else
+  echo "shell-lib-errexit_test: $fails FAILED" >&2
+  exit 1
+fi


### PR DESCRIPTION
Closes #1635.

`tools/lib/gate-budget.sh` is sourced (`tools/preflight.sh:151`), so `budget_run` runs
with whatever shell options its caller has. Unlike #1633's sibling this broke the
**ordinary** path as well as the timeout one, and what it produced there is a false
accusation — the failure this repo treats as worse than a silence (#1368's watchdog).

## The mechanism, confirmed before fixing

The issue said the abort was in the CHILD. It is — and there is a second one in the
parent, so both had to be found. Traced with `set -x` against the unfixed file.

**Child.** The trace shows the command run and then *nothing*:

```
+ local pid=76643
+ bash -c 'exit 3'                <- the command
+ :                               <- the poll loop's next tick
+ [[ -s /var/…/irrlicht-gate-budget.oXJF5WkNhc ]]
```

`grep -E '\+ (echo|mv)'` over all 157 trace lines: **no match**. The child inherits
errexit, dies on the non-zero command, and never reaches
`echo "$?" >"$statusfile.part" && mv …` — which is the documented "it finished" signal
(`gate-budget.sh:164`). So budget_run polls to the deadline.

**Parent.** Then, on both paths, the shell dies inside `_budget_kill_tree`:

```
ordinary path:  + [[ 3 -ge 3 ]] … + _budget_kill_tree TERM 76643 … + kill -TERM 76643   <- aborts (pid already gone)
timeout path:   + _budget_kill_tree KILL 77317 … + kill -KILL 77317                     <- aborts (already reaped)
```

before `BUDGET_LAST_TIMED_OUT=1` and `return "$BUDGET_TIMEOUT_RC"` — the two things
`preflight.sh` reads from this library, both wrong.

## The mechanism chosen, and why

Three **region** guards, never per-command — #1633 measured that `|| :` on the
individual `kill`s just moves the abort one line down onto `wait` and returns 143.

| where | guard | why that spelling |
|---|---|---|
| the backgrounded child | `{ set +e; "$@"; echo "$?" >… ; } &` | `&` makes it a SUBSHELL, so the change provably cannot reach the caller. There is no spelling that both preserves the caller's errexit inside a shell-function command *and* captures that command's status — `"$@" \|\| rc=$?` disables it for the body too, by the same rule — so this loses nothing. |
| `_budget_kill_tree`'s walk | `{ … } \|\| :` | Its contract is an unconditional `return 0`, and signalling an already-gone pid is its NORMAL case. In-process, so `set` is not available: a manual save/restore leaks on any early return, and `local -` does not exist on bash 3.2 (`local: '-': not a valid identifier`). |
| `budget_run`'s kill-and-reap region | `{ … } \|\| :` | Same, and every command in it is *expected* to fail. One token covers whatever is added to the region later. |

**Two things deliberately NOT guarded**, each with the measurement:

- **The `secs -eq 0` passthrough.** `"$@"` is the last command before the return, so
  "errexit aborts here" and "the function returns this status" are the same number to
  every caller, and `BUDGET_LAST_TIMED_OUT` is already 0. #1633 reached the same
  conclusion about `swift_suite_run`'s final `wait`.
- **The two status-file reap regions.** I guarded these first, then mutated them (M4
  below) and **nothing went red**, so they came back out. `wait` there reports the
  CHILD's status — which is the `mv`'s, not the command's — and the branch is only
  entered once that `mv` has landed. Measured with an instrumented copy:
  `WAIT-STATUS=0` for commands exiting 0, 3 *and* 127. A guard no mutation can redden
  is what AGENTS.md treats the same as a defect test that passes on `main`. The file
  now carries that measurement where the guard would have gone, and names the tripwire
  row that catches it if the child body ever changes.

## The RED, before the fix

`tools/lib/gate-budget_test.sh`'s new `#1635` block, run against the unfixed library:

```
== budget_run under the CALLER's `-e` (#1635) ==
  PASS: the -e probe actually ran its command (the fixture left its marker)
  FAIL: a command that exits 3 returns 3 under the caller's -e — expected [3] got [1]
  FAIL: ...and does not burn the budget waiting for a command that already exited — expected [<= 8] got [20]
  PASS: ...and does not set the timeout flag
  PASS: the -e timeout probe actually ran its command (the fixture left its marker)
  FAIL: an over-budget command returns BUDGET_TIMEOUT_RC under the caller's -e — expected [124] got [1]
  FAIL: ...and DOES set the timeout flag — expected [1] got [0]
  PASS: the caller's shell options are unchanged across the call
```

The four reds are the defect; the four greens are locks (two "could-not-run" guards,
the ordinary path's flag, and the leak lock). `BUDGET_LAST_TIMED_OUT` is read from the
BARE shape through an `EXIT` trap, because a `||` probe would read it in the one shape
where it was never wrong.

### Proof the caller's options are unchanged

`set +o` **redirected to a file**, before and after, compared with `diff`. The spelling
is load-bearing rather than style, and I re-verified it on this machine's bash 3.2.57:
inside `$( )` the same shell at the same instant reports `set +o errexit` where the
redirect reports `set -o errexit`. A probe built the obvious way is byte-identical
before and after any leak and can never fail.

## Part B — the tripwire

`tools/lib/shell-lib-errexit_test.sh`. This family has produced three false fixes in
three issues (#1629, #1633, #1635), each found by hand. It walks every
`tools/lib/*.sh` that is not a `*_test.sh` — **4 libraries, 18 functions** — and for
each function it can drive asserts (a) a bare statement under
`bash --noprofile --norc -e -o pipefail` returns the documented status, and (b) the
caller's `set +o` dump is byte-identical afterwards. Runtime **7.4s**; it is picked up
by `preflight.sh`'s `for t in tools/lib/*_test.sh` and test.yml's identical loop with
no wiring.

`testdata/` never enters: `tools/lib/*.sh` does not recurse — the same split
`skill-lint.sh` and `posix-lint.sh` already draw.

**Bare statement position is the whole point**, stated in the file's header. Measured
against the unfixed library: `budget_run 20 bash -c 'exit 3'` returns **1** as a bare
statement and **3** written `|| rc=$?`, because bash ignores errexit for the whole
function body in that shape — and, measured here, for the subshell the body backgrounds
as well. A lock written that way is green against a broken library.

### The exemption list

Keys are existence-checked against the walk **in both directions**, so an entry that
stops naming a real function fails rather than silently doing nothing, and a library
that stopped being walked surfaces as its recipes naming nothing.

| key | active when | reason |
|---|---|---|
| `swift-suite.sh::swift_suite_run` | `uname -s` != Darwin | Needs BSD `script(1)` for its pty; the spelling and argument order differ on Linux, and the only production caller is a Darwin-guarded gate. **Inactive on macOS**, which is where test.yml runs this suite, so the function is really driven there. Same call `swift-suite_test.sh` already makes. |

That is the whole list — every other function has a driving recipe. Expected statuses
are chosen DISTINCTIVE (0, 2, 3, 124) wherever the function offers the choice, because
a documented `1` is indistinguishable from an errexit abort, which also exits 1; so
predicates are driven in the state where they answer true.

### Mutation evidence

**Committed, inside the file** (AGENTS.md #1479 — a paragraph in a merged PR body is
re-run by nothing). Each case names what must be reported *and* what must stay silent;
three mutations against two obligations are equally satisfied by two obligations that
report on everything.

| committed fixture / case | obligation (a) | obligation (b) |
|---|---|---|
| `tw_fixture_correct` (`false \|\| :; return 0`) | silent — the vacuity guard | silent |
| `tw_fixture_aborts` (`false; return 0`) | **reports** `it returned 1, not the documented 0` | silent — it leaks nothing |
| `tw_fixture_leaks` (`set +e; false; return 0`) | silent — it returns the documented 0 | **reports** `LEAKED a shell option change` |
| setup sourcing a file that is not there | **reports** `the probe never reached the call` | — |

`tw_fixture_leaks` is the one that shows (b) is not redundant: a leaked `set +e` is a
*working* fix for the return value, and the leak lock is the only thing that objects.
It is also the probe's own guard, per "a verification mechanism must fail loudly when
it cannot run" — a `$(set +o)` probe cannot report it.

**The discovery half** — four synthetic `tw_bijection` cases (agreeing sets → silence;
a function with no recipe → `UNDRIVEN`; a recipe naming nothing → `ORPHAN-RECIPE`; an
exemption naming nothing → `ORPHAN-EXEMPTION`) plus a real walk over a scratch directory
holding three of the four libraries, which must report **8 of 8** swift-suite recipes as
orphans while the real walk reports **0**. Plus the two scan refusals: a library read
and found empty, and a `function name {` declaration the scan does not understand —
both hard failures rather than an empty result.

**Against the real library**, every mutation applied by copy-aside/copy-back, asserted
to have CHANGED the file (#1390), with `shasum` + `git status --porcelain` back to
baseline after each:

| # | mutation | tripwire | `gate-budget_test.sh` `#1635` block |
|---|---|---|---|
| M1 | child loses its `set +e` | RED: `budget_run (ordinary path)` … `returned 124, not the documented 3` | RED ×3 (status, elapsed, flag) |
| M2 | timeout region loses its `\|\| :` | RED: `budget_run (timeout path)` … `returned 143, not the documented 124` — #1633's exact near-miss number | RED ×2 |
| M3 | `_budget_kill_tree` loses its own `\|\| :` | RED: `_budget_kill_tree (already-dead pid)` … `returned 1, not the documented 0` | **ALL PASS** |
| M4 | the two reap regions lose their `\|\| :` | **ALL PASS** | **ALL PASS** → guard removed, see above |
| M5 | the whole pre-fix file (`c76453e2`) | RED ×3 | RED ×4 |
| M6 | "fixed" instead with a leaked `set +e` in `budget_run` | RED ×2 leak + RED ×1 status | RED ×1, the leak lock only — every status assertion PASSES |

**M3 is the argument for Part B.** Deleting a private helper's own guard reddens the
tripwire and leaves the hand-written `-e` block entirely green, because that helper is
only ever reached through a region `budget_run` guards separately. M6 is the argument
for obligation (b) over (a) alone.

## Gates

Each as its own foreground invocation, exit status read **directly**, not through a pipe.

- `tools/preflight.sh --only tools` — **PASS** (`PREFLIGHT_TOOLS_EXIT=0`). All nine
  `tools/lib/*_test.sh` report `ALL PASS`, including the new `shell-lib-errexit_test`,
  which the gate picked up from its glob with no wiring.
- `tools/preflight.sh --only posix` — **PASS** (`PREFLIGHT_POSIX_EXIT=0`). Not strictly
  in scope (that gate keys on a first-line `#!/bin/sh`; the new file is
  `#!/usr/bin/env bash`), run anyway because #1611 widened its file selection.
- `--only swift` **not run**: nothing in the diff matches that gate's trigger
  (`^platforms/macos/|^\.github/workflows/macos-swift\.yml$|^tools/preflight\.sh$|^tools/lib/swift-suite(_test)?\.sh$`),
  and `swift-suite.sh` is unchanged — the tripwire only *calls* it. The
  `LauncherTestHarness`/`LauncherHarnessTests` targets were not run at any point.
- `--only skills` **not run**: no `.claude/skills/**/*.md` in the diff. `skill-lint.sh`
  reads that tree plus any tracked `SKILL.md`; `AGENTS.md` is neither (checked its
  header, not assumed).
- Pre-push hook (`--changed --budget 540`): `tools/lib shell-lib tests` PASS, `gofmt`
  PASS, everything else SKIP.
- Informational: **nothing under `tools/lib/` is linted by any gate today** — checked
  `preflight.sh` and every workflow; the only shellcheck in the repo is `posix-lint.sh`'s
  `--shell=sh` over `#!/bin/sh` files. Run by hand anyway (shellcheck 0.11.0):
  `gate-budget.sh` is **clean**; the new test file reports three `SC2015`s, the
  `A && pass || fail` idiom every sibling in that directory already uses (`pass` returns
  0, so C is unreachable). Its `SC2016`s are silenced with a file-level directive and a
  justification, because the recipe strings are source text for an inner shell *by
  design*.

## Scope

`AGENTS.md` gains one bullet documenting the tripwire beside the other registry
tripwires, with the two facts that are not guessable — bare statement position, and
the `$(set +o)` trap.

## Found on the way, filed not fixed

**#1639** — `test.yml`'s "Test the shared shell libs" step is a loop with no `|| rc=1`,
under GitHub's default `bash -eo pipefail` (no `shell:` or `defaults:` anywhere in that
file — grepped). The first failing test file aborts the step and the remaining seven are
never run, with nothing in the log distinguishing that from "the rest passed". Measured
with three fixtures, middle one failing: the CI spelling stops after two,
`preflight.sh`'s `shell_lib_tests` runs all three. Out of scope here — this PR only
*adds* a ninth file to that loop — but it is the same shape as the family above and it
now costs one round trip per red file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
