### PR TITLE
fix(ci): run every tools/lib test file, and say how many ran (#1639)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -94,18 +94,37 @@ jobs:
       # the pre-push hook. Their local gate is that same hook, which
       # `git push --no-verify` disables — so CI has to run them independently,
       # or the checks guarding the gate ride on the gate they guard.
+      #
+      # The loop lives in tools/lib/shell-lib-suite.sh, which tools/preflight.sh's
+      # `tools` gate calls too — ONE implementation, for the reason
+      # macos-swift.yml gives for sharing swift-suite.sh: CI and the pre-push
+      # hook judge a run by the same rules rather than by two implementations
+      # that can disagree. They did disagree, and this was the wrong half
+      # (#1639): the loop was written inline here with no `|| rc=1`, and this
+      # file declares no `shell:` and no `defaults:`, so it ran under GitHub's
+      # default `bash --noprofile --norc -eo pipefail`. The FIRST failing file
+      # aborted the step, every later file in glob order never ran, and nothing
+      # in the log distinguished that from a clean run — one push per red file.
+      # The runner prints a census (found / skipped / ran / failed) and refuses
+      # an empty corpus, so "it all passed" cannot be read off a loop that
+      # stopped early or found nothing.
+      #
+      # posix-lint_test.sh drives tools/posix-lint.sh, which REQUIRES a static
+      # bashism linter and refuses to pass without one (#1423 is about a gate
+      # that passed having checked nothing, so it fails rather than skipping).
+      # This runner is macos-latest, whose image ships neither shellcheck nor
+      # checkbashisms — which is the same reason the gate itself lives in
+      # linux.yml. Both run there. Installing a linter here would cost every PR
+      # 20-40s to re-test what linux.yml already tested. Naming it as a skip
+      # ARGUMENT rather than as a `case` pattern in a copied loop is what makes
+      # it fail loudly if it ever stops matching a real file.
+      #
+      # `|| rc=$?` rather than a bare call: it is the spelling that keeps the
+      # status under the `-e` above (`|| true` would not — it hands back
+      # `true`'s status, silently reporting every failing run as 0).
       - name: Test the shared shell libs
         run: |
-          for t in tools/lib/*_test.sh; do
-            # posix-lint_test.sh drives tools/posix-lint.sh, which REQUIRES a
-            # static bashism linter and refuses to pass without one (#1423 is
-            # about a gate that passed having checked nothing, so it fails
-            # rather than skipping). This runner is macos-latest, whose image
-            # ships neither shellcheck nor checkbashisms — which is the same
-            # reason the gate itself lives in linux.yml. Both run there.
-            # Installing a linter here would cost every PR 20-40s to re-test
-            # what linux.yml already tested.
-            case "$t" in */posix-lint_test.sh) continue ;; esac
-            echo "== $t =="
-            bash "$t"
-          done
+          rc=0
+          . tools/lib/shell-lib-suite.sh
+          shell_lib_suite_run tools/lib posix-lint_test.sh || rc=$?
+          exit "$rc"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -948,13 +948,48 @@ Before marking a ticket done, run the full suite — every layer must pass:
     being walked surfaces as its recipes naming nothing rather than as silence.
   - Its own mutation evidence is committed (`tw_fixture_correct` /
     `tw_fixture_aborts` / `tw_fixture_leaks`, four synthetic bijection cases,
-    and a real walk over a directory holding three of the four libraries). The
+    and a real walk over a directory holding three of the libraries,
+    swift-suite.sh deliberately not among them — phrased that way rather than
+    as "three of the four" because #1639 added a fifth and made that count
+    stale). The
     fixtures matter in both directions: a leaked `set +e` is a *working* fix for
     the return value, so obligation (a) passes it and only (b) objects.
   What it buys over a hand-written lock was measured on this repo: deleting
   `_budget_kill_tree`'s own guard reddens the tripwire and leaves
   `gate-budget_test.sh`'s whole `-e` block green, because that helper is only
   ever reached through a region `budget_run` guards separately.
+- The shell-lib suite runner: `tools/lib/shell-lib-suite.sh` is the ONE
+  implementation behind test.yml's "Test the shared shell libs" step and
+  `tools/preflight.sh`'s `tools` gate. Before #1639 those were two copies of
+  the same loop that disagreed about the only thing that matters: preflight's
+  collected every file's status, CI's had no `|| rc=1` and — test.yml declaring
+  no `shell:` and no `defaults:`, so GitHub's `bash --noprofile --norc -eo
+  pipefail` applies — aborted on the FIRST failing file with every later file
+  in glob order never run and nothing in the log saying so. One round trip per
+  red file, on suites that take seconds each. The sharing follows
+  `macos-swift.yml`'s own reason for sharing `swift-suite.sh`: CI and the
+  pre-push hook judge a run by the same rules rather than by two
+  implementations that can disagree. Three things about it are load-bearing.
+  It prints a **census** — found / skipped / ran / failed — because "they all
+  passed" and "the loop stopped early" had no distinguishing line in either
+  predecessor. An **empty corpus is a named refusal** (status 2, distinct from
+  1) rather than either predecessor's answer, both measured: CI's loop iterated
+  once with the literal unexpanded pattern (nullglob is off by default and
+  `-eo pipefail` does not change it) and died with `No such file or directory`,
+  while preflight's `[[ -e "$t" ]] || continue` filtered that out and returned
+  0, passing silently. And the two callers' one remaining scope difference —
+  CI skips `posix-lint_test.sh`, which needs a linter the macos image lacks —
+  is an **argument** that is validated against the corpus before anything runs,
+  so a skip that stops matching a real file is a refusal instead of a `case`
+  pattern quietly matching nothing. Its tests are
+  `tools/lib/shell-lib-suite_test.sh`, which grades the runner in BARE
+  STATEMENT position as well as under `|| rc=$?`: bash suppresses errexit for a
+  function's whole body when the call sits in a `||` position, so a runner that
+  ran its files as bare `bash "$f"` statements is invisible from the `||` shape
+  and from the CI step itself. Both predecessors are emitted verbatim there and
+  re-measured on every run, which doubles as the vacuity guard — if bash ever
+  stopped aborting, the fix would be protecting nothing and would pass for the
+  wrong reason.
 - Factory: `go test ./tools/onboarding-factory/... -race -count=1`.
 - Replay: `tools/replay-fixtures.sh` — gated in CI by linux.yml, and run
   natively as `tools/preflight.sh`'s `replay fixtures` gate, so golden drift

--- a/tools/lib/shell-lib-errexit_test.sh
+++ b/tools/lib/shell-lib-errexit_test.sh
@@ -343,6 +343,18 @@ row 'gosec-report.sh::gosec_report_check' 'gosec_report_check (a clean report)' 
     '. tools/lib/gosec-report.sh' \
     'gosec_report_check tools/lib/testdata/gosec-report/clean.json tripwire >/dev/null 2>&1'
 
+# Driven against a THROWAWAY corpus, never against tools/lib itself: this
+# function runs every `*_test.sh` it finds, and this file is one of them, so
+# pointing it at the real directory would re-enter the whole suite (and this
+# tripwire) once per row. Both statuses are distinctive — 0 for a corpus that
+# passes, 2 for the refusal — so neither can be confused with an errexit abort.
+row 'shell-lib-suite.sh::shell_lib_suite_run' 'shell_lib_suite_run (a corpus that all passes)' 0 \
+    '. tools/lib/shell-lib-suite.sh; mkdir -p "$TW_TMP/suite-ok"; printf "exit 0\n" >"$TW_TMP/suite-ok/a_test.sh"' \
+    'shell_lib_suite_run "$TW_TMP/suite-ok" >/dev/null'
+row 'shell-lib-suite.sh::shell_lib_suite_run' 'shell_lib_suite_run (refuses an empty corpus)' 2 \
+    '. tools/lib/shell-lib-suite.sh; mkdir -p "$TW_TMP/suite-empty"' \
+    'shell_lib_suite_run "$TW_TMP/suite-empty" >/dev/null 2>&1'
+
 row 'swift-suite.sh::swift_suite_completed' 'swift_suite_completed' 0 \
     '. tools/lib/swift-suite.sh' \
     'swift_suite_completed tools/lib/testdata/swift-suite/clean.log'
@@ -520,7 +532,9 @@ case "$b" in
 esac
 
 # --- and the discovery half, mutated for real ------------------------------
-# A scratch lib dir carrying three of the four libraries. Every recipe of the
+# A scratch lib dir carrying three of the libraries, swift-suite.sh
+# deliberately not among them — phrased that way rather than as "three of the
+# four" because a fifth library (#1639) made that count stale. Every recipe of the
 # missing one must come back ORPHAN, which is what "a library stopped being
 # walked" looks like from here. Without this the bijection is only ever graded
 # against hand-written lists.

--- a/tools/lib/shell-lib-suite.sh
+++ b/tools/lib/shell-lib-suite.sh
@@ -1,0 +1,205 @@
+#!/usr/bin/env bash
+# shell-lib-suite.sh — run a directory's `*_test.sh` files so that "every one
+# of them passed" and "the loop stopped early" cannot print the same thing
+# (#1639).
+#
+# This file is sourced, not executed:
+#
+#   . tools/lib/shell-lib-suite.sh
+#   rc=0
+#   shell_lib_suite_run tools/lib posix-lint_test.sh || rc=$?
+#   exit "$rc"
+#
+# Shell options, both directions, because the convention above depends on them
+# and every other library here now says so (#1633, #1635):
+#
+#   this file  requires nothing of the caller's options and changes none of
+#              them. shell_lib_suite_run RETURNS its verdict — 0, 1 or 2 —
+#              whether or not `-e` is set, and runs every file it found
+#              regardless of what any of them did.
+#   the caller must keep `$?` reachable if it wants to distinguish the three.
+#              Under `-e` a bare non-zero return aborts the caller on that
+#              line, which is fine when the call is the step's last statement
+#              but loses the code otherwise — write `|| rc=$?` (#1629).
+#
+# ---------------------------------------------------------------------------
+# Why this exists
+#
+# There were two implementations of this loop and they disagreed about the one
+# thing that matters. `.github/workflows/test.yml`'s step was:
+#
+#     for t in tools/lib/*_test.sh; do
+#       case "$t" in */posix-lint_test.sh) continue ;; esac
+#       echo "== $t =="
+#       bash "$t"
+#     done
+#
+# with no `|| rc=1`. That file declares no `shell:` and no `defaults:`, so the
+# step runs under GitHub's documented default, `bash --noprofile --norc -eo
+# pipefail`. The FIRST failing file aborted the step; every later file in glob
+# order never ran, and NOTHING in the log said so — the output simply ended
+# after that file's own `== header ==`. Measured, three fixtures with the first
+# and the last failing: only the first one's header and body appear, and the
+# step exits 1. A failure in `changed-files_test.sh` (first alphabetically)
+# therefore hid the other eight, one round trip each.
+#
+# `tools/preflight.sh`'s `shell_lib_tests` — the local mirror of that same
+# step — did the opposite (`bash "$t" || rc=1`) and ran all of them. So CI and
+# the pre-push hook judged the same corpus by two implementations that could,
+# and did, disagree. This is the one implementation both now call, for the
+# reason `.github/workflows/macos-swift.yml` gives for sharing
+# `tools/lib/swift-suite.sh`: "CI and the pre-push hook judge a run by the same
+# rules rather than by two implementations that can disagree."
+#
+# The two callers still differ in SCOPE, deliberately: test.yml skips
+# `posix-lint_test.sh`, which needs a static bashism linter the macos image
+# does not ship (linux.yml runs it, and the gate it tests, for that reason).
+# That difference is now an ARGUMENT rather than a second loop — and a skip
+# naming a file that does not exist is a hard refusal (below), so it cannot
+# silently stop matching the way a `case` pattern in a duplicated loop could.
+#
+# ---------------------------------------------------------------------------
+# The empty-corpus refusal is not defensive noise
+#
+# Both old spellings got this wrong, in opposite directions, and both were
+# measured rather than reasoned about:
+#
+#   test.yml's      `for t in dir/*_test.sh` with nullglob OFF (bash's default,
+#                   and GitHub's `-eo pipefail` does not change it) iterates
+#                   ONCE with the literal unexpanded pattern, so the step died
+#                   with `bash: dir/*_test.sh: No such file or directory` and
+#                   exit 127 — non-zero, but reading as a missing file rather
+#                   than as "the corpus this gate exists to run is empty".
+#   preflight's     `[[ -e "$t" ]] || continue` filtered that literal out and
+#                   returned 0. A corpus that vanished passed SILENTLY, which
+#                   is AGENTS.md's "absence of a finding and inability to look
+#                   must never produce the same output" in its purest form.
+#
+# So finding nothing is a named refusal here, and the `[ -e ]` filter is kept
+# so the answer is the same whether or not the caller has `nullglob` set.
+#
+# ---------------------------------------------------------------------------
+# Exit statuses
+#
+#   0  every file that ran passed
+#   1  at least one file FAILED — and every other file still ran, which is the
+#      whole point
+#   2  the run could not be judged at all: no directory, no corpus, a skip that
+#      matches nothing, or a census that does not add up. Distinct from 1
+#      because "nine tests, one red" and "nothing was checked" are different
+#      answers, and 2 is also what makes this function drivable by
+#      shell-lib-errexit_test.sh, whose recipes need a status a bare errexit
+#      abort (always 1) cannot forge.
+
+# The glob is a variable so the census message can name it, not so callers can
+# change it — nothing passes one, and `*_test.sh` is the convention every
+# caller and every test file in tools/lib/ already follows.
+SHELL_LIB_SUITE_GLOB='*_test.sh'
+
+# shell_lib_suite_run <dir> [skip-basename ...]
+shell_lib_suite_run() {
+  local dir="${1:-}"
+  if [ $# -gt 0 ]; then shift; fi
+
+  if [ -z "$dir" ]; then
+    printf 'shell-lib-suite: refusing — no directory was named.\n' >&2
+    return 2
+  fi
+  if [ ! -d "$dir" ]; then
+    printf 'shell-lib-suite: refusing — %s is not a directory, so the corpus could not be read.\n' "$dir" >&2
+    return 2
+  fi
+
+  # `[ -e ]` rather than a bare glob expansion: with nullglob OFF (the default,
+  # and what GitHub's `bash --noprofile --norc -eo pipefail` runs with) an empty
+  # directory yields the literal pattern, and with nullglob ON it yields
+  # nothing. Both land on `found == 0` below, so the refusal does not depend on
+  # a shell option the caller may or may not have set.
+  local files=() f
+  for f in "$dir"/$SHELL_LIB_SUITE_GLOB; do
+    if [ -e "$f" ]; then files+=("$f"); fi
+  done
+
+  local found=${#files[@]}
+  if [ "$found" -eq 0 ]; then
+    printf 'shell-lib-suite: refusing — no %s files under %s. A corpus that vanished and a corpus that passed must not print the same thing.\n' \
+      "$SHELL_LIB_SUITE_GLOB" "$dir" >&2
+    return 2
+  fi
+
+  # The skip list, validated BEFORE anything runs. A skip that names no file is
+  # a hard refusal rather than a no-op: the one thing a by-name exclusion must
+  # never do is silently stop excluding — or silently stop being needed —
+  # because from the log both look exactly like a clean run.
+  local skiplist=$'\n' skip base matched
+  for skip in ${1+"$@"}; do
+    case "$skip" in
+      '')
+        printf 'shell-lib-suite: refusing — an empty skip name was passed.\n' >&2
+        return 2 ;;
+      */*)
+        printf 'shell-lib-suite: refusing — the skip %s is a path; name a bare file name so the match is unambiguous.\n' "$skip" >&2
+        return 2 ;;
+    esac
+    matched=0
+    for f in "${files[@]}"; do
+      if [ "${f##*/}" = "$skip" ]; then matched=1; fi
+    done
+    if [ "$matched" -eq 0 ]; then
+      printf 'shell-lib-suite: refusing — the skip list names %s, which matches no file under %s. Either it was renamed or it is gone; a skip that stopped matching is indistinguishable from a clean run.\n' \
+        "$skip" "$dir" >&2
+      return 2
+    fi
+    skiplist="$skiplist$skip"$'\n'
+  done
+
+  local rc=0 ran=0 skipped=0 failed=0 failed_names="" skipped_names="" is_skip
+  for f in "${files[@]}"; do
+    base="${f##*/}"
+    is_skip=0
+    case "$skiplist" in
+      *$'\n'"$base"$'\n'*) is_skip=1 ;;
+    esac
+    if [ "$is_skip" -eq 1 ]; then
+      skipped=$((skipped + 1))
+      skipped_names="$skipped_names $base"
+      printf '== %s == SKIPPED by name\n' "$f"
+      continue
+    fi
+    printf '== %s ==\n' "$f"
+    # `if bash …` and not a bare call: errexit is suppressed for a command in
+    # an `if` condition, so this is what lets a failing file be RECORDED
+    # instead of aborting a caller that has `-e` on.
+    if bash "$f"; then
+      :
+    else
+      rc=1
+      failed=$((failed + 1))
+      failed_names="$failed_names $base"
+    fi
+    ran=$((ran + 1))
+  done
+
+  # The census. Printed on every path that got this far, pass or fail, because
+  # a count of what was actually executed is the single line that tells a
+  # truncated run from a clean one — which is the defect this file exists to
+  # remove, and it had no line of its own in either predecessor.
+  printf 'shell-lib-suite: %s — found %d, skipped %d (%s), ran %d, failed %d\n' \
+    "$dir" "$found" "$skipped" "${skipped_names:-none}" "$ran" "$failed"
+  if [ -n "$failed_names" ]; then
+    printf 'shell-lib-suite: FAILED:%s\n' "$failed_names" >&2
+  fi
+
+  # ...and the census has to add up. This cannot catch an abort — an aborted
+  # run never reaches this line at all, and that case is held instead by
+  # shell-lib-errexit_test.sh, which drives this function under a caller's `-e`
+  # and grades what it returns. What it DOES catch is the next edit to the loop
+  # above: a `continue`, a `break` or an early `return` that skips a file
+  # without counting it, which is exactly the shape of the defect being fixed.
+  if [ $((ran + skipped)) -ne "$found" ]; then
+    printf 'shell-lib-suite: refusing — the census does not add up: %d ran + %d skipped != %d found. The loop did not reach every file it discovered.\n' \
+      "$ran" "$skipped" "$found" >&2
+    return 2
+  fi
+  return "$rc"
+}

--- a/tools/lib/shell-lib-suite.sh
+++ b/tools/lib/shell-lib-suite.sh
@@ -184,6 +184,7 @@ shell_lib_suite_run() {
   # a count of what was actually executed is the single line that tells a
   # truncated run from a clean one — which is the defect this file exists to
   # remove, and it had no line of its own in either predecessor.
+  skipped_names="${skipped_names# }"
   printf 'shell-lib-suite: %s — found %d, skipped %d (%s), ran %d, failed %d\n' \
     "$dir" "$found" "$skipped" "${skipped_names:-none}" "$ran" "$failed"
   if [ -n "$failed_names" ]; then

--- a/tools/lib/shell-lib-suite_test.sh
+++ b/tools/lib/shell-lib-suite_test.sh
@@ -251,7 +251,7 @@ run_suite "$TMP/skip" b_test.sh
 want_status "a skip that matches" 0 "$ST" "$OUT"
 want_absent "...excludes exactly that file" "RAN b_test.sh" "$OUT"
 want_contains "...runs its neighbours" "RAN a_test.sh" "$OUT"
-want_contains "...and the census accounts for it" "found 3, skipped 1 ( b_test.sh), ran 2, failed 0" "$OUT"
+want_contains "...and the census accounts for it" "found 3, skipped 1 (b_test.sh), ran 2, failed 0" "$OUT"
 
 # The mutation for obligation 4: the same call with a name nothing matches.
 # This is what a rename or a deletion of posix-lint_test.sh looks like from

--- a/tools/lib/shell-lib-suite_test.sh
+++ b/tools/lib/shell-lib-suite_test.sh
@@ -1,0 +1,384 @@
+#!/usr/bin/env bash
+# shell-lib-suite_test.sh — the tests for tools/lib/shell-lib-suite.sh, the one
+# implementation behind .github/workflows/test.yml's "Test the shared shell
+# libs" step and tools/preflight.sh's `tools` gate (#1639).
+#
+# ---------------------------------------------------------------------------
+# What is being asserted, and why each obligation exists
+#
+# The defect was a loop with no `|| rc=1` running under GitHub's default
+# `bash --noprofile --norc -eo pipefail`: the first failing file aborted the
+# step and every later file never ran, with nothing in the log distinguishing
+# that from a clean run. So the obligations are, in order:
+#
+#   1. an EARLY failure and a LATE failure are BOTH reported. A fix that only
+#      collects the status of the last file, or that reports "1 failed" when
+#      two did, satisfies "the step goes red" and still costs a round trip.
+#   2. the predecessors' behaviour is committed rather than described. Both old
+#      spellings are emitted verbatim into an inner script and run under the
+#      shell GitHub actually uses, so "the first failing file hides the rest"
+#      and "an empty corpus passes silently" are re-measured on every run
+#      instead of being true the day they were pasted into an issue. They are
+#      also the vacuity guard for obligation 1: if bash ever stopped aborting
+#      there, the new runner would be protecting nothing and would pass for the
+#      wrong reason.
+#   3. an empty corpus is a NAMED refusal, not a pass and not a `No such file`.
+#   4. a skip that stops matching is a hard refusal. The scope difference
+#      between the two callers (CI skips posix-lint_test.sh, which needs a
+#      linter the macos image lacks) is an argument now, and an argument that
+#      quietly matches nothing is the same silent-skip defect one level down.
+#   5. the census adds up — driven against a DELIBERATELY MUTATED copy of the
+#      library, because the guard is something this change ADDS and therefore
+#      passes by construction until something breaks the thing it protects.
+#   6. both call sites really do go through the shared runner, so the two
+#      implementations cannot come back.
+#
+# The fixtures are built in a tempdir rather than committed under testdata/
+# because they must be EXECUTED, and a corpus of deliberately-failing
+# `*_test.sh` files under tools/lib/ would be picked up by the very glob under
+# test — including by the real CI step. (tools/lib/testdata/ is excluded from
+# the posix and skill gates' walks for the same class of reason, but the glob
+# here is `tools/lib/*_test.sh`, which testdata/ does not protect against.)
+set -uo pipefail
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+cd "$REPO_ROOT" || { echo "FAIL: shell-lib-suite_test — cannot cd to $REPO_ROOT" >&2; exit 1; }
+
+# A missing tool is a hard failure, not a skip: exiting 0 here would read as a
+# PASS to the very runner under test, so this file would go green having
+# asserted nothing — the failure mode the whole issue family is made of.
+need() { command -v "$1" >/dev/null 2>&1 || { echo "FAIL: shell-lib-suite_test — $1 not found" >&2; exit 1; }; }
+need git
+need mktemp
+need sed
+need grep
+
+LIB=tools/lib/shell-lib-suite.sh
+[[ -f "$LIB" ]] || { echo "FAIL: shell-lib-suite_test — $LIB not found" >&2; exit 1; }
+
+TMP=$(mktemp -d -t shell-lib-suite) || exit 1
+trap 'rm -rf "$TMP"' EXIT
+
+rc=0
+pass() { echo "  PASS: $1"; return 0; }
+fail() { echo "  FAIL: $1 — expected [$2] got [$3]" >&2; rc=1; return 0; }
+flat() { echo "$1" | tr '\n' ' '; }
+
+want_status() { # label want got out
+  if [[ "$3" == "$2" ]]; then pass "$1 (exit $2)"; else fail "$1" "exit $2" "exit $3 :: $(flat "$4")"; fi
+  return 0
+}
+want_contains() { # label needle haystack
+  case "$3" in *"$2"*) pass "$1" ;; *) fail "$1" "output containing: $2" "$(flat "$3")" ;; esac
+  return 0
+}
+want_absent() { # label needle haystack
+  case "$3" in *"$2"*) fail "$1" "no output containing: $2" "$(flat "$3")" ;; *) pass "$1" ;; esac
+  return 0
+}
+
+# mkcorpus <dir> <spec...> — each spec is `name:0` (passes) or `name:1` (fails).
+# Every fixture announces itself, so "did this file run" is answerable from the
+# captured output rather than inferred from a status.
+mkcorpus() {
+  local dir="$1"; shift
+  mkdir -p "$dir" || return 1
+  local spec name status
+  for spec in "$@"; do
+    name="${spec%%:*}"; status="${spec##*:}"
+    printf '#!/usr/bin/env bash\necho "RAN %s"\nexit %s\n' "$name" "$status" >"$dir/$name"
+  done
+  return 0
+}
+
+# run_suite <dir> [skip...] — the library, sourced and driven under the shell
+# GitHub runs steps with, exactly as test.yml's step now does. Output lands in
+# $OUT and the status in $ST.
+run_suite() {
+  local script="$TMP/run-suite.sh"
+  SLS_ARGS_DIR="$1"; shift
+  SLS_ARGS_SKIPS="$*"
+  export SLS_ARGS_DIR SLS_ARGS_SKIPS
+  cat >"$script" <<'RUNNER'
+rc=0
+. tools/lib/shell-lib-suite.sh
+# Word-splitting $SLS_ARGS_SKIPS is intentional: it is this test's own list of
+# bare file names, never user input.
+# shellcheck disable=SC2086
+shell_lib_suite_run "$SLS_ARGS_DIR" $SLS_ARGS_SKIPS || rc=$?
+exit "$rc"
+RUNNER
+  OUT=$(bash --noprofile --norc -eo pipefail "$script" 2>&1); ST=$?
+  return 0
+}
+
+# run_suite_bare <dir> [skip...] — the same call as the LAST STATEMENT of the
+# inner script, with no `|| rc=$?` anywhere.
+#
+# This shape is not redundant with run_suite, it is the only one that can see
+# the hazard. Bash suppresses errexit for a function's ENTIRE body when the
+# call sits in a `||` (or `if`, or `&&`) position, so a library that ran its
+# test files as bare `bash "$f"` statements — the defect being fixed, moved one
+# level down — is invisible from run_suite and from test.yml's step, and would
+# only surface the day a caller wrote the call bare. shell-lib-errexit_test.sh
+# grades this position too, but it cannot grade it against a FAILING corpus:
+# its obligation reads the inner shell's status, and a documented 1 is
+# indistinguishable from an errexit abort, which also exits 1. Here the
+# fixtures announce themselves, so "it returned 1" and "it aborted at the first
+# red file" are told apart by whether the later files ran.
+run_suite_bare() {
+  local script="$TMP/run-suite-bare.sh"
+  SLS_ARGS_DIR="$1"; shift
+  SLS_ARGS_SKIPS="$*"
+  export SLS_ARGS_DIR SLS_ARGS_SKIPS
+  cat >"$script" <<'RUNNERBARE'
+. tools/lib/shell-lib-suite.sh
+# shellcheck disable=SC2086
+shell_lib_suite_run "$SLS_ARGS_DIR" $SLS_ARGS_SKIPS
+RUNNERBARE
+  OUT=$(bash --noprofile --norc -eo pipefail "$script" 2>&1); ST=$?
+  return 0
+}
+
+echo "== the runner reports every file, not just the ones before the first red =="
+
+# --- the vacuity guard: a corpus that all passes -----------------------------
+# Without it, a runner that reported failure unconditionally would satisfy
+# every case below and read as excellent coverage.
+mkcorpus "$TMP/clean" a_test.sh:0 b_test.sh:0 c_test.sh:0
+run_suite "$TMP/clean"
+want_status "a corpus that all passes" 0 "$ST" "$OUT"
+want_contains "...and every file ran (a)" "RAN a_test.sh" "$OUT"
+want_contains "...and every file ran (b)" "RAN b_test.sh" "$OUT"
+want_contains "...and every file ran (c)" "RAN c_test.sh" "$OUT"
+want_contains "...and the census says so" "found 3, skipped 0 (none), ran 3, failed 0" "$OUT"
+
+# --- obligation 1: an EARLY red and a LATE red are both reported -------------
+# a and c fail, b passes. Under the old spelling only a's own output survives;
+# the fix has to produce all three, a failed count of 2, and BOTH names.
+mkcorpus "$TMP/mixed" a_test.sh:1 b_test.sh:0 c_test.sh:1
+run_suite "$TMP/mixed"
+want_status "a corpus with an early AND a late failure" 1 "$ST" "$OUT"
+want_contains "the early failing file ran" "RAN a_test.sh" "$OUT"
+want_contains "the file BETWEEN the two failures ran" "RAN b_test.sh" "$OUT"
+want_contains "the LATE failing file ran — the whole defect" "RAN c_test.sh" "$OUT"
+want_contains "the census counts both failures" "found 3, skipped 0 (none), ran 3, failed 2" "$OUT"
+want_contains "...and names them" "FAILED: a_test.sh c_test.sh" "$OUT"
+
+# ...and the same corpus with the call in BARE STATEMENT position, where the
+# caller's `-e` is live inside the function body. See run_suite_bare's comment:
+# this is the only shape that can see the defect having moved one level down.
+run_suite_bare "$TMP/mixed"
+want_status "the same corpus, called as a bare statement under -e" 1 "$ST" "$OUT"
+want_contains "bare position: the early failing file ran" "RAN a_test.sh" "$OUT"
+want_contains "bare position: the file between them ran" "RAN b_test.sh" "$OUT"
+want_contains "bare position: the late failing file ran too" "RAN c_test.sh" "$OUT"
+want_contains "bare position: the census still printed" "found 3, skipped 0 (none), ran 3, failed 2" "$OUT"
+
+# --- obligation 2: the predecessors, measured rather than described ----------
+# test.yml's loop as it stood, verbatim, with only `tools/lib` replaced by the
+# fixture dir — run under `bash --noprofile --norc -eo pipefail`, which is
+# GitHub's documented invocation for a step declaring no `shell:`.
+echo ""
+echo "== the two predecessors, run under GitHub's own default shell =="
+export SLS_DIR="$TMP/mixed"
+cat >"$TMP/old-ci-loop.sh" <<'OLDCI'
+for t in "$SLS_DIR"/*_test.sh; do
+  case "$t" in */posix-lint_test.sh) continue ;; esac
+  echo "== $t =="
+  bash "$t"
+done
+OLDCI
+old_out=$(bash --noprofile --norc -eo pipefail "$TMP/old-ci-loop.sh" 2>&1); old_st=$?
+want_status "test.yml's old loop still goes red" 1 "$old_st" "$old_out"
+want_contains "...having run the first file" "RAN a_test.sh" "$old_out"
+# The load-bearing half of the pair. If bash ever stopped aborting here — a
+# future runner spelling, a `defaults:` block someone adds — the new runner
+# would be protecting nothing and every case above would pass for the wrong
+# reason. Absence of the hazard and absence of the check must not look alike.
+want_absent "...and the DEFECT is still real: the file after it never ran" "RAN b_test.sh" "$old_out"
+want_absent "...nor the late failing one" "RAN c_test.sh" "$old_out"
+
+# preflight's old loop over an EMPTY corpus: `[[ -e "$t" ]] || continue`
+# filtered the literal unexpanded pattern out and returned 0 — a corpus that
+# vanished passing silently, which is the same defect in its purest form.
+mkdir -p "$TMP/empty"
+export SLS_EMPTY="$TMP/empty"
+cat >"$TMP/old-preflight-loop.sh" <<'OLDPF'
+rc=0
+for t in "$SLS_EMPTY"/*_test.sh; do
+  [[ -e "$t" ]] || continue
+  bash "$t" || rc=1
+done
+exit "$rc"
+OLDPF
+oldpf_out=$(bash --noprofile --norc -eo pipefail "$TMP/old-preflight-loop.sh" 2>&1); oldpf_st=$?
+want_status "preflight's old loop passed an EMPTY corpus silently" 0 "$oldpf_st" "$oldpf_out"
+want_absent "...saying nothing at all about it" "found" "$oldpf_out"
+
+# ...and CI's old loop over the same empty corpus did not pass, but did not say
+# what was wrong either: nullglob is OFF by default (and `-eo pipefail` does not
+# change it), so the loop iterated once with the literal pattern and died on a
+# missing file. Non-zero, and unattributable.
+cat >"$TMP/old-ci-empty.sh" <<'OLDCIE'
+for t in "$SLS_EMPTY"/*_test.sh; do
+  case "$t" in */posix-lint_test.sh) continue ;; esac
+  echo "== $t =="
+  bash "$t"
+done
+OLDCIE
+oldcie_out=$(bash --noprofile --norc -eo pipefail "$TMP/old-ci-empty.sh" 2>&1); oldcie_st=$?
+want_status "CI's old loop over an empty corpus died on the literal glob" 127 "$oldcie_st" "$oldcie_out"
+want_contains "...reading as a missing file, not as an empty corpus" "No such file or directory" "$oldcie_out"
+
+# --- obligation 3: the empty corpus is a named refusal ----------------------
+echo ""
+echo "== a run that could not be judged refuses with 2, and says why =="
+run_suite "$TMP/empty"
+want_status "an empty corpus" 2 "$ST" "$OUT"
+want_contains "...names the glob and the directory" "no *_test.sh files under $TMP/empty" "$OUT"
+want_contains "...and says why that is not a pass" "must not print the same thing" "$OUT"
+
+run_suite "$TMP/there-is-no-such-directory"
+want_status "a directory that does not exist" 2 "$ST" "$OUT"
+want_contains "...is refused by name" "is not a directory" "$OUT"
+
+# --- obligation 4: the skip cannot silently stop matching -------------------
+echo ""
+echo "== the by-name skip =="
+mkcorpus "$TMP/skip" a_test.sh:0 b_test.sh:0 c_test.sh:0
+run_suite "$TMP/skip" b_test.sh
+want_status "a skip that matches" 0 "$ST" "$OUT"
+want_absent "...excludes exactly that file" "RAN b_test.sh" "$OUT"
+want_contains "...runs its neighbours" "RAN a_test.sh" "$OUT"
+want_contains "...and the census accounts for it" "found 3, skipped 1 ( b_test.sh), ran 2, failed 0" "$OUT"
+
+# The mutation for obligation 4: the same call with a name nothing matches.
+# This is what a rename or a deletion of posix-lint_test.sh looks like from
+# test.yml, and it must be loud — in the old `case "$t" in */posix-lint_test.sh)`
+# spelling it was a pattern that simply stopped matching, i.e. silence.
+run_suite "$TMP/skip" was-renamed_test.sh
+want_status "a skip that matches nothing" 2 "$ST" "$OUT"
+want_contains "...names it" "the skip list names was-renamed_test.sh" "$OUT"
+want_contains "...and says why silence would be worse" "indistinguishable from a clean run" "$OUT"
+
+run_suite "$TMP/skip" sub/dir_test.sh
+want_status "a skip spelled as a path" 2 "$ST" "$OUT"
+want_contains "...is refused rather than matched loosely" "is a path" "$OUT"
+
+# --- obligation 5: the census guard, against a mutated library --------------
+#
+# This guard is something the change ADDS, so it passes by construction and
+# owes a deliberate mutation (AGENTS.md). The mutation is committed here rather
+# than described in a PR body: a copy of the real library with an uncounted
+# `continue` spliced into its run loop — the exact shape of a future edit that
+# skips a file without accounting for it. The real file is never touched.
+echo ""
+echo "== the census guard, driven against a deliberately mutated copy =="
+mutdir="$TMP/mutlib"
+mkdir -p "$mutdir"
+# Both patterns below are LITERAL text matched against the library's source —
+# `$f` and `${f##*/}` must reach sed and grep unexpanded, which is the whole
+# point of the single quotes.
+# shellcheck disable=SC2016
+sed 's|^    printf .== %s ==.n. "\$f"$|    if [ "${f##*/}" = b_test.sh ]; then continue; fi\n&|' \
+  "$LIB" >"$mutdir/shell-lib-suite.sh"
+# shellcheck disable=SC2016
+if ! grep -q 'if \[ "${f##\*/}" = b_test.sh \]; then continue; fi' "$mutdir/shell-lib-suite.sh"; then
+  fail "the census mutation was applied" "a spliced uncounted continue" "the splice matched nothing — the mutation harness is stale, not the library clean"
+else
+  pass "the census mutation was applied to the copy"
+  export SLS_MUT="$mutdir/shell-lib-suite.sh" SLS_MUT_DIR="$TMP/clean"
+  cat >"$TMP/run-mut.sh" <<'MUT'
+rc=0
+. "$SLS_MUT"
+shell_lib_suite_run "$SLS_MUT_DIR" || rc=$?
+exit "$rc"
+MUT
+  mut_out=$(bash --noprofile --norc -eo pipefail "$TMP/run-mut.sh" 2>&1); mut_st=$?
+  want_status "a loop that skips a file without counting it" 2 "$mut_st" "$mut_out"
+  want_contains "...is refused by the census" "the census does not add up: 2 ran + 0 skipped != 3 found" "$mut_out"
+fi
+# ...and the unmutated library over the same corpus must NOT refuse, or the
+# case above would be satisfied by a guard that fires unconditionally.
+run_suite "$TMP/clean"
+want_absent "...and the real library over the same corpus does not" "census does not add up" "$OUT"
+
+# --- obligation 6: both call sites go through the shared runner -------------
+#
+# Not a general workflow linter, and the scope is the honest part: this is a
+# lock on the TWO call sites that exist, so the duplication #1639 removed
+# cannot come back unnoticed. It reads the files rather than running them.
+echo ""
+echo "== both callers really do call the one implementation =="
+WF=.github/workflows/test.yml
+if [[ ! -f "$WF" ]]; then
+  fail "the call-site check could run" "$WF" "not found"
+else
+  # Vacuity guard first: a scan that stopped finding the step reads exactly
+  # like a workflow with no duplication in it.
+  step=$(awk '/^      - name: Test the shared shell libs$/{found=1} found{print}' "$WF")
+  if [[ -z "$step" ]]; then
+    fail "the scan finds the step in $WF" "a 'Test the shared shell libs' step" "no such step — the scan has gone blind, not the workflow clean"
+  else
+    pass "the scan reads $WF's 'Test the shared shell libs' step"
+    want_contains "...and it calls the shared runner" "shell_lib_suite_run tools/lib posix-lint_test.sh" "$step"
+    want_absent "...rather than carrying its own loop" 'for t in tools/lib/*_test.sh' "$step"
+    want_contains "...keeping \$? reachable under GitHub's implicit -e" '|| rc=$?' "$step"
+  fi
+fi
+
+PF=tools/preflight.sh
+if [[ ! -f "$PF" ]]; then
+  fail "the call-site check could run" "$PF" "not found"
+else
+  pf=$(cat "$PF")
+  want_contains "$PF sources the shared runner" 'lib/shell-lib-suite.sh' "$pf"
+  want_contains "...and its gate calls it" "shell_lib_suite_run tools/lib" "$pf"
+  want_absent "...rather than carrying its own loop" 'for t in tools/lib/*_test.sh' "$pf"
+
+  # ...and the `tools` gate has to FIRE on a diff that touches only test.yml,
+  # or under --changed (the pre-push hook's path) the workflow assertions above
+  # are skipped on precisely the commit that can break them. That is #1591's
+  # and #1629's shape, both of which were fixed by widening this same trigger.
+  # The regex is EXTRACTED and matched rather than string-compared, so it is a
+  # behavioural assertion and not a lock on one spelling of an alternation.
+  tools_re=$(grep -a "run_gate_scoped '\^tools/lib/" "$PF" \
+             | sed -E "s/^[[:space:]]*run_gate_scoped '//; s/'[[:space:]]*\\\\?[[:space:]]*$//")
+  if [[ -z "$tools_re" ]]; then
+    fail "the tools-gate trigger regex could be read from $PF" "one run_gate_scoped line starting ^tools/lib/" "no such line — the scan has gone blind, not the trigger wrong"
+  else
+    pass "read the tools-gate trigger regex from $PF"
+    for probe in .github/workflows/test.yml tools/lib/shell-lib-suite_test.sh; do
+      if printf '%s\n' "$probe" | grep -qE "$tools_re"; then
+        pass "...it fires on a diff touching $probe"
+      else
+        fail "the tools gate fires on a diff touching $probe" "a match" "no match against: $tools_re"
+      fi
+    done
+    # The vacuity guard: a trigger that matched everything would satisfy both
+    # probes above and scope nothing.
+    if printf '%s\n' core/domain/session.go | grep -qE "$tools_re"; then
+      fail "the tools-gate trigger still scopes" "no match for core/domain/session.go" "it matches everything: $tools_re"
+    else
+      pass "...and still does not fire on an unrelated core/ file"
+    fi
+  fi
+fi
+
+# The skip CI passes has to name a file that is really there. The library
+# refuses at runtime if it does not — this is the same assertion one push
+# earlier, on the machine that can act on it.
+if [[ -e tools/lib/posix-lint_test.sh ]]; then
+  pass "the skip test.yml passes names a file that exists (tools/lib/posix-lint_test.sh)"
+else
+  fail "the skip test.yml passes names a real file" "tools/lib/posix-lint_test.sh" "missing — CI's step will refuse with status 2 until the skip is updated"
+fi
+
+echo ""
+if [[ "$rc" -eq 0 ]]; then
+  echo "shell-lib-suite_test: ALL PASS"
+else
+  echo "shell-lib-suite_test: FAILURES" >&2
+fi
+exit "$rc"

--- a/tools/preflight.sh
+++ b/tools/preflight.sh
@@ -152,6 +152,16 @@ fi
   echo "cannot load $SCRIPT_DIR/lib/gate-budget.sh — refusing to run a budgeted gate set with no budget" >&2
   exit 2
 }
+# ---- the shared shell-lib suite runner (#1639) ----------------------------
+# Sourced unconditionally and fatally, for the same reason as the budget above:
+# `shell_lib_tests` would otherwise be an unbound command, and a `tools` gate
+# that cannot run must not be able to look like one that found nothing.
+# shellcheck source=lib/shell-lib-suite.sh
+. "$SCRIPT_DIR/lib/shell-lib-suite.sh" || {
+  echo "cannot load $SCRIPT_DIR/lib/shell-lib-suite.sh — refusing to run the shell-lib gate blind" >&2
+  exit 2
+}
+
 budget_open "$BUDGET" || exit 2
 if budget_is_bounded; then
   echo "budget: this run is bounded to ${BUDGET}s of wall clock in total."
@@ -346,13 +356,22 @@ web_tree() {
 }
 
 # -- tools (mirrors test.yml's "Test the shared shell libs" step) ------------
+# Not a mirror any more — the SAME implementation (#1639). This used to be a
+# second copy of the loop, and the two copies disagreed about the one thing
+# that matters: this one collected every file's status, CI's aborted on the
+# first failing file with the rest never run and nothing saying so. One
+# implementation, for the reason macos-swift.yml gives for sharing
+# swift-suite.sh: CI and the pre-push hook judge a run by the same rules rather
+# than by two implementations that can disagree.
+#
+# The one difference that remains is deliberate and is now an ARGUMENT: CI
+# passes `posix-lint_test.sh` as a skip because the macos runner ships no
+# static bashism linter (linux.yml runs that file). A developer machine is
+# expected to have one — the `posix` gate above refuses rather than skipping
+# without it — so nothing is skipped here.
 shell_lib_tests() {
-  local rc=0 t
-  for t in tools/lib/*_test.sh; do
-    [[ -e "$t" ]] || continue
-    bash "$t" || rc=1
-  done
-  return "$rc"
+  shell_lib_suite_run tools/lib
+  return $?
 }
 
 # ===========================================================================
@@ -421,7 +440,11 @@ if want tools; then
   # disarms GitHub's `-e` first, and a commit editing only that workflow is
   # exactly the commit that breaks the invariant — so leaving it out would skip
   # the check precisely when it matters.
-  run_gate_scoped '^tools/lib/|^tools/[^/]*\.sh$|^tools/git-hooks/|^go\.work$|^\.github/dependabot\.yml$|^site/install\.sh$|^\.github/workflows/macos-swift\.yml$' \
+  # .github/workflows/test.yml joins them for the third time (#1639):
+  # shell-lib-suite_test.sh asserts that its "Test the shared shell libs" step
+  # goes through the shared runner rather than growing its own loop back, and a
+  # commit editing only that workflow is again exactly the one that breaks it.
+  run_gate_scoped '^tools/lib/|^tools/[^/]*\.sh$|^tools/git-hooks/|^go\.work$|^\.github/dependabot\.yml$|^site/install\.sh$|^\.github/workflows/(macos-swift|test)\.yml$' \
                   "tools/lib shell-lib tests" shell_lib_tests
 fi
 


### PR DESCRIPTION
Closes #1639

## The defect

`.github/workflows/test.yml`'s "Test the shared shell libs" step was a loop with no
`|| rc=1`. The file declares no `shell:` and no `defaults:`, so GitHub runs it as
`bash --noprofile --norc -eo pipefail`: the **first** failing file aborted the step, every
later file in glob order never ran, and nothing in the log distinguished that from a clean
run. Ten `tools/lib/*_test.sh` files exist today and this step runs nine of them
(`posix-lint_test.sh` is skipped by name), so a failure in `changed-files_test.sh` — first
alphabetically — hid eight others, one push per red file, on suites that take seconds each.

`tools/preflight.sh`'s `shell_lib_tests`, the local mirror of the same step, did the
opposite (`bash "$t" || rc=1`) and ran all of them.

## The fix

`tools/lib/shell-lib-suite.sh` — one sourced implementation, called by both:

```yaml
      - name: Test the shared shell libs
        run: |
          rc=0
          . tools/lib/shell-lib-suite.sh
          shell_lib_suite_run tools/lib posix-lint_test.sh || rc=$?
          exit "$rc"
```

```sh
shell_lib_tests() {
  shell_lib_suite_run tools/lib
  return $?
}
```

It runs every file it found regardless of what any of them did, and makes the coverage
observable, which is the actual defect (AGENTS.md: "absence of a finding and inability to
look must never produce the same output"):

* a **census** on every run — `shell-lib-suite: tools/lib — found 11, skipped 0 (none), ran 11, failed 0`
  — plus a `FAILED: <names>` line. Neither predecessor had any line that told a truncated
  run from a clean one.
* an **empty corpus is a named refusal** with a distinct status (2, so "nothing was
  checked" is not the same answer as "nine ran, one red").
* the **skip is validated against the corpus before anything runs**: a skip matching no
  file is a refusal, not a no-op.
* the census must **add up** (`ran + skipped == found`), which catches the next `continue`
  or early `return` added to that loop.

I checked which empty-glob semantics apply rather than assuming (`nullglob` is off by
default and `-eo pipefail` does not change it — measured), and both predecessors got it
wrong in opposite directions. Both behaviours are now committed as assertions rather than
described here:

```
  PASS: preflight's old loop passed an EMPTY corpus silently (exit 0)
  PASS: ...saying nothing at all about it
  PASS: CI's old loop over an empty corpus died on the literal glob (exit 127)
  PASS: ...reading as a missing file, not as an empty corpus
```

So the silent-pass form lived on the **local** side; CI's form was non-zero but
unattributable. The shared runner refuses by name in both cases.

## Point 3 — the sharing decision: ONE implementation

Both callers go through `tools/lib/shell-lib-suite.sh`. The repo's own precedent decides
it: `macos-swift.yml` runs the Swift suite through `tools/lib/swift-suite.sh` precisely so
"CI and the pre-push hook judge a run by the same rules rather than by two implementations
that can disagree". Here they *did* disagree, and #1639 is the bill for it — the two copies
had drifted on the single line that decides whether the gate reports what it found.

**The scope difference is preserved as an argument, not as a second loop.** CI passes
`posix-lint_test.sh` as a skip (the macos image ships no static bashism linter; linux.yml
runs that file and the gate it tests). preflight passes no skip, because a developer
machine is expected to have a linter — the `posix` gate refuses rather than skipping
without one. And it cannot silently stop matching: the runner validates every skip against
the corpus **before** running anything and refuses with status 2 naming the skip, where the
old `case "$t" in */posix-lint_test.sh)` pattern would simply have stopped matching. There
is a second, earlier assertion of the same thing in `shell-lib-suite_test.sh`, on the
machine that can act on it.

Two consequences worth knowing:

* the new library is under `tools/lib/`, so `shell-lib-errexit_test.sh` **discovers** it —
  covered by existing rather than by remembering. Two driving recipes were added (statuses
  0 and 2, distinctive per that file's rule), pointed at a throwaway corpus, never at
  `tools/lib` itself: this function runs every `*_test.sh` it finds, and that file is one
  of them.
* `preflight.sh`'s `tools` trigger now includes `.github/workflows/test.yml`, or under
  `--changed` a test.yml-only commit would skip the gate that checks it — the third
  widening for that exact reason (#1591, #1629).

## Evidence

Every obligation was seen RED against a deliberate mutation, one mutation per run, each
applied and reverted in the same invocation with a `git status --porcelain` assertion after
the revert. Reproduced with `bash --noprofile --norc -eo pipefail`, GitHub's documented
invocation for a step declaring no `shell:`.

**M1 — the `if bash "$f"` guard replaced by a bare call plus a `$?` test** (the defect,
moved one level down):

```
  PASS: the same corpus, called as a bare statement under -e (exit 1)
  PASS: bare position: the early failing file ran
  FAIL: bare position: the file between them ran — expected [output containing: RAN b_test.sh] got [== …/mixed/a_test.sh == RAN a_test.sh ]
  FAIL: bare position: the late failing file ran too — expected [output containing: RAN c_test.sh] got [== …/mixed/a_test.sh == RAN a_test.sh ]
  FAIL: bare position: the census still printed — expected [output containing: found 3, skipped 0 (none), ran 3, failed 2] got [== …/mixed/a_test.sh == RAN a_test.sh ]
```

Note **which** cases went red and which did not, because it is the reason the test grades
two calling shapes. Bash suppresses errexit for a function's entire body when the call sits
in a `||` position, so the `|| rc=$?` cases — and test.yml's step itself — stayed green
against this mutation. Only the bare-statement shape can see it.

**The early-and-late obligation, green on the fix** (a, c fail; b passes; a is first in
glob order):

```
  PASS: a corpus with an early AND a late failure (exit 1)
  PASS: the early failing file ran
  PASS: the file BETWEEN the two failures ran
  PASS: the LATE failing file ran — the whole defect
  PASS: the census counts both failures
  PASS: ...and names them
```

and the same three fixtures through **test.yml's loop as it stood**, still measured on
every run rather than quoted here once — this is also the vacuity guard, because if bash
ever stopped aborting there the fix would be protecting nothing:

```
  PASS: test.yml's old loop still goes red (exit 1)
  PASS: ...having run the first file
  PASS: ...and the DEFECT is still real: the file after it never ran
  PASS: ...nor the late failing one
```

**M2 — the empty-corpus refusal disarmed** (the zero-files / cannot-run guard actually
firing):

```
  FAIL: an empty corpus — expected [exit 2] got [exit 0 :: shell-lib-suite: …/empty — found 0, skipped 0 (none), ran 0, failed 0 ]
  FAIL: ...names the glob and the directory — expected [output containing: no *_test.sh files under …/empty] got […]
  FAIL: ...and says why that is not a pass — expected [output containing: must not print the same thing] got […]
```

**M3 — the stale-skip refusal disarmed.** The mutated run reports `skipped 0, ran 3` and
exits 0: a skip that stopped matching becomes silence, which is the shape the argument
exists to remove.

```
  FAIL: a skip that matches nothing — expected [exit 2] got [exit 0 :: … found 3, skipped 0 (none), ran 3, failed 0 ]
  FAIL: ...names it — expected [output containing: the skip list names was-renamed_test.sh] got […]
  FAIL: ...and says why silence would be worse — expected [output containing: indistinguishable from a clean run] got […]
```

**M4 — the census accounting guard disarmed.** Its own mutation is *committed*, not
described: the test splices an uncounted `continue` into a **copy** of the library
(asserting the splice matched, per #1390) and requires the census to refuse. With the guard
removed the mutated copy reports `found 3 … ran 2` and exits 0:

```
  PASS: the census mutation was applied to the copy
  FAIL: a loop that skips a file without counting it — expected [exit 2] got [exit 0 :: … found 3, skipped 0 (none), ran 2, failed 0 ]
  FAIL: ...is refused by the census — expected [output containing: the census does not add up: 2 ran + 0 skipped != 3 found] got […]
```

**M5 / M6 — each call site reverted to its own inline loop**, so the duplication cannot
come back unnoticed:

```
  FAIL: ...and it calls the shared runner — expected [output containing: shell_lib_suite_run tools/lib posix-lint_test.sh] got [ … for t in tools/lib/*_test.sh; do … ]
  FAIL: ...rather than carrying its own loop — expected [no output containing: for t in tools/lib/*_test.sh] got […]
  FAIL: ...keeping $? reachable under GitHub's implicit -e — expected [output containing: || rc=$?] got […]
```
```
  FAIL: ...and its gate calls it — expected [output containing: shell_lib_suite_run tools/lib] got [#!/usr/bin/env bash # preflight.sh — … ]
  FAIL: ...rather than carrying its own loop — expected [no output containing: for t in tools/lib/*_test.sh] got […]
```

**M7 — `set +e` leaked out of `shell_lib_suite_run`**, proving the two new
`shell-lib-errexit_test.sh` recipes actually grade the new library rather than being inert
wiring:

```
  FAIL: shell_lib_suite_run (a corpus that all passes): LEAKED a shell option change back to its caller — expected [no diff] got [4c4 < set -o errexit --- > set +o errexit ]
  FAIL: shell_lib_suite_run (refuses an empty corpus): LEAKED a shell option change back to its caller — expected [no diff] got [4c4 < set -o errexit --- > set +o errexit ]
```

**M8 — `test.yml` dropped from preflight's `tools` trigger**, which is what would make
every workflow assertion above skip on the one commit that can break it. The trigger check
extracts the regex and matches paths against it rather than string-comparing a spelling,
and carries its own vacuity guard (an unrelated `core/` file must NOT match):

```
  FAIL: the tools gate fires on a diff touching .github/workflows/test.yml — expected [a match] got [no match against: ^tools/lib/|^tools/[^/]*\.sh$|…]
```

The vacuity guards are all present and green: a corpus that all passes exits 0 with every
file run; the unmutated library over the same corpus does **not** trip the census guard; the
`tools` trigger still does not fire on `core/domain/session.go`; and the two predecessors
are re-measured rather than asserted from memory.

**Confirmed on a real runner.** This PR's own `go-test` job
([run 31957331613](https://github.com/ingo-eichhorst/Irrlicht/actions/runs/31957331613), macos-latest,
pass) ended the step with:

```
shell-lib-suite: tools/lib — found 11, skipped 1 ( posix-lint_test.sh), ran 10, failed 0
```

which is the census this change exists to produce, with the CI-only skip applied and
accounted for. (The stray space inside the parens was tidied in a follow-up commit; the
figures are unchanged.) Everything else above rests on the local reproduction of GitHub's
documented shell, since a red CI run cannot be arranged cheaply.

## Gates

Each run as its own foreground invocation, exit status read directly (never through a pipe):

| gate | result |
|---|---|
| `tools/preflight.sh --only tools` | **PASS** — `shell-lib-suite: tools/lib — found 11, skipped 0 (none), ran 11, failed 0` |
| `tools/preflight.sh --only posix` | **PASS** (`posix-lint: ALL PASS`) — run although no `#!/bin/sh` file is touched, because `preflight`'s posix trigger fires on any `*.sh` |
| `bash tools/lib/shell-lib-suite_test.sh` | PASS (new) |
| `bash tools/lib/shell-lib-errexit_test.sh` | PASS (2 new recipes) |
| `shellcheck -S style` on both new files | clean (2 deliberate `SC2016` disables on literal source-text patterns) |
| pre-push hook (`preflight.sh --changed`) | PASS — including `macOS Swift build + test` |
| `--only skills` | not run: no `.claude/skills/**/*.md` or `SKILL.md` touched, which is that gate's whole trigger set |

`AGENTS.md` is edited but is linted by nothing (`skill-lint.sh` reads `.claude/skills/**/*.md`
plus tracked `SKILL.md` files only — checked, not assumed).

## Out of scope — reported, not fixed

* **`linux.yml` does NOT have this defect.** Checked by reading the file: every step is a
  single command (`tools/posix-lint.sh`, `bash tools/lib/posix-lint_test.sh`, `go build`,
  `go test`, `tools/replay-fixtures.sh`), so there is no loop to truncate.
* **`ars.yml`'s "Commit badge update" step has a different silent-failure defect** — filed
  separately as #1641. Its 5-attempt push-retry loop ends with `sleep`, so exhausting all
  five attempts leaves the step exiting **0**: the badge push failed and the check is green.
  Measured with the same probe technique, all attempts failing → `STEP EXIT=0`.
* `coverage.yml`'s `for dir in core` loop is single-element, and that workflow deliberately
  swallows test failures (AGENTS.md says so) — not a new finding.
* `replaydata-deletion-guard.yml`'s `while IFS= read -r f` loop accumulates into
  `$violations` and reports after the loop, with every body command in an `if`/`case`/
  assignment position — read, and it does not have this shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
