### PR TITLE
fix(ci): fail the ARS badge step when all five push attempts fail (#1641)

### DIFF
--- a/.github/workflows/ars.yml
+++ b/.github/workflows/ars.yml
@@ -58,9 +58,32 @@ jobs:
             echo "No badge changes to commit"
           else
             git commit -m "chore: update ARS badge [skip ci]"
+            # `pushed` is the only thing that can tell "it went in on attempt
+            # 3" from "it never went in", and until #1641 nothing did. The
+            # loop's last statement was `sleep`, which succeeds — so five
+            # failed attempts ended the loop with status 0, and the step, the
+            # job and this workflow's check all went GREEN with the badge
+            # unpushed. GitHub's implicit `-e` (a step declaring no `shell:`
+            # runs as `bash --noprofile --norc -e -o pipefail {0}`) does not
+            # save it: errexit is suppressed for every command in an `&&` list
+            # except the one after the final `&&`, which is precisely what
+            # MAKES this a retry rather than one attempt. That suppression is
+            # wanted; what was missing is anything that reads the exhausted
+            # case. Measured, not reasoned about — the pre-fix loop is emitted
+            # verbatim by tools/lib/ars-badge-push_test.sh and still exits 0
+            # there on every run, and that test executes THIS block.
+            #
+            # `|| true` on the push is the false fix and is deliberately not
+            # used: it makes the loop's own status 0 for the same reason, one
+            # level down (#1629 measured the same trap on a `$?` capture).
+            pushed=0
             for i in 1 2 3 4 5; do
-              git pull --rebase origin main && git push && break
+              if git pull --rebase origin main && git push; then pushed=1; break; fi
               echo "Push attempt $i failed, retrying..."
               sleep $((i * 3))
             done
+            if [ "$pushed" -ne 1 ]; then
+              echo "::error::ARS badge was NOT pushed: all 5 \`git pull --rebase origin main && git push\` attempts to origin/main failed. The badge commit exists only on this runner; README.md on main still shows the previous score."
+              exit 1
+            fi
           fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -990,6 +990,43 @@ Before marking a ticket done, run the full suite — every layer must pass:
   re-measured on every run, which doubles as the vacuity guard — if bash ever
   stopped aborting, the fix would be protecting nothing and would pass for the
   wrong reason.
+- The ARS badge push: `tools/lib/ars-badge-push_test.sh` EXTRACTS
+  `.github/workflows/ars.yml`'s "Commit badge update" step out of the workflow
+  file and EXECUTES it against a git stub, under
+  `bash --noprofile --norc -e -o pipefail` — GitHub's documented invocation for
+  a step declaring no `shell:`. Behavioural rather than a text scan, because a
+  scan pins one spelling of a guard where running the block pins the property.
+  Before #1641 the push-retry loop's last statement was `sleep`, which
+  succeeds, so five failed attempts ended the loop — and the step, the job and
+  this workflow's check — at status 0 with the badge unpushed and nothing
+  saying so; the observable symptom is a README badge that quietly stops
+  tracking `main` behind a green history. `-e` does not save it: errexit is
+  suppressed for every command in an `&&` list except the one after the final
+  `&&`, which is exactly what MAKES the loop a retry. Three things are
+  load-bearing. The pre-fix loop is emitted verbatim there and re-measured on
+  every run, so "five failures exit 0" is a fact rather than a sentence in a
+  merged PR body — and it is the vacuity guard, since a bash that stopped
+  behaving that way would leave every other arm passing for the wrong reason.
+  The **third-attempt** arm is what keeps the fix honest: a "fix" dropping the
+  retry, or one that stops suppressing errexit inside the `&&` list, satisfies
+  the exhausted-case arm just as well and simply gives up after one attempt.
+  And the git stub answers an **unmodelled** subcommand with a loud, distinctive
+  99 naming the call, never a quiet 0 — a stub that said "fine" to a call it
+  does not model would make every arm pass for a reason unrelated to its
+  obligation (seen red: adding one `git status` to the step reports
+  `STUB: unmodelled call`, not a pass).
+  **No linter was built, and the measurement is the reason.** Over the 19
+  multi-line `run:` blocks in `.github/workflows/`, a rule keyed on "the
+  block's last statement is `echo`/`sleep`/`cat`/`printf`" flags 6 and **misses
+  this very defect** — the loop is nested inside an `if`/`else`, so the block's
+  last line is `fi` — while 4 of the 6 it does flag are correct code; a rule
+  keyed on `|| true` flags 2 and also misses it; "the block contains a loop"
+  flags 3, of which 1 is the defect. No candidate both catches the subject and
+  stays quiet on the correct blocks, so a green would claim coverage it does
+  not have — the same conclusion #1629 reached by the same measurement about a
+  `$?`-keyed rule, and #1639 about the sibling family. `preflight.sh`'s `tools`
+  trigger gains `ars.yml`, its fourth widening for this reason (#1591, #1629,
+  #1639), because that assertion lives entirely inside that gate.
 - Factory: `go test ./tools/onboarding-factory/... -race -count=1`.
 - Replay: `tools/replay-fixtures.sh` — gated in CI by linux.yml, and run
   natively as `tools/preflight.sh`'s `replay fixtures` gate, so golden drift

--- a/tools/lib/ars-badge-push_test.sh
+++ b/tools/lib/ars-badge-push_test.sh
@@ -1,0 +1,289 @@
+#!/usr/bin/env bash
+# ars-badge-push_test.sh — the lock on .github/workflows/ars.yml's
+# "Commit badge update" step (#1641).
+#
+# ---------------------------------------------------------------------------
+# What is being asserted, and why each obligation exists
+#
+# The defect: the step's push-retry loop was
+#
+#     for i in 1 2 3 4 5; do
+#       git pull --rebase origin main && git push && break
+#       echo "Push attempt $i failed, retrying..."
+#       sleep $((i * 3))
+#     done
+#
+# The loop's last statement is `sleep`, which succeeds. So when all five
+# attempts failed the loop simply ended, `sleep`'s 0 became the step's status,
+# and the step, the job and the badge check all went GREEN with the badge
+# unpushed. GitHub's implicit `-e` does not save it: `A && B && break` is an
+# `&&` list, and errexit is suppressed for every command in such a list except
+# the one following the final `&&` — which is exactly what MAKES this a retry
+# rather than a single attempt. The suppression is wanted; what was missing is
+# anything that then READS the exhausted-retries case.
+#
+# The obligations, in order:
+#
+#   1. the defect is re-MEASURED, not described. The pre-fix loop is emitted
+#      verbatim and run under the shell GitHub actually uses, so "five failures
+#      exit 0" is a fact on every run rather than a sentence in a merged PR
+#      body. It doubles as the vacuity guard: if bash ever stopped behaving
+#      that way, the fix would be protecting nothing and every arm below would
+#      pass for the wrong reason.
+#   2. the real step — extracted from the real workflow file and EXECUTED —
+#      fails when every attempt fails, and says what did not happen. This is
+#      deliberately behavioural rather than a text scan: a scan pins one
+#      spelling of a guard, where running the block pins the property.
+#   3. the retry is still a retry. A "fix" that dropped the loop, or that
+#      stopped suppressing errexit inside the `&&` list, also satisfies
+#      obligation 2 — it just gives up after one attempt. So a run whose third
+#      attempt succeeds must exit 0 AND show that the first two were retried.
+#   4. the clean paths still pass: nothing staged, and a first-attempt push.
+#
+# Deliberately NOT a general workflow linter, and the measurement is the
+# honest part. Over this repo's 19 multi-line `run:` blocks, a rule keyed on
+# "the block's last statement is echo/sleep/cat/printf" flags 6 and MISSES
+# THIS ONE — ars.yml's retry loop is nested inside an if/else, so the block's
+# last line is `fi` — while 4 of the 6 it does flag are correct code. A rule
+# keyed on `|| true` flags 2 and also misses this one. A rule keyed on "the
+# block contains a loop" flags 3, of which 1 is this defect. No candidate rule
+# both catches the subject and stays quiet on the correct blocks, so a
+# linter's green would claim coverage it does not have. This is a lock on the
+# ONE call site that exists — the same conclusion, reached the same way, as
+# #1629's scan in swift-suite_test.sh.
+set -uo pipefail
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+cd "$REPO_ROOT" || { echo "FAIL: ars-badge-push_test — cannot cd to $REPO_ROOT" >&2; exit 1; }
+
+# A missing tool is a hard failure, not a skip: exiting 0 here would read as a
+# PASS to the runner that drives this file, so it would go green having
+# asserted nothing — the failure mode this whole issue family is made of.
+need() { command -v "$1" >/dev/null 2>&1 || { echo "FAIL: ars-badge-push_test — $1 not found" >&2; exit 1; }; }
+need git
+need mktemp
+need awk
+need bash
+
+WF=.github/workflows/ars.yml
+STEP='Commit badge update'
+
+TMP=$(mktemp -d -t ars-badge-push) || exit 1
+trap 'rm -rf "$TMP"' EXIT
+
+rc=0
+pass() { echo "  PASS: $1"; return 0; }
+fail() { echo "  FAIL: $1 — expected [$2] got [$3]" >&2; rc=1; return 0; }
+flat() { echo "$1" | tr '\n' ' '; }
+
+want_status() { # label want got out
+  if [[ "$3" == "$2" ]]; then pass "$1 (exit $2)"; else fail "$1" "exit $2" "exit $3 :: $(flat "$4")"; fi
+  return 0
+}
+want_contains() { # label needle haystack
+  case "$3" in *"$2"*) pass "$1" ;; *) fail "$1" "output containing: $2" "$(flat "$3")" ;; esac
+  return 0
+}
+want_absent() { # label needle haystack
+  case "$3" in *"$2"*) fail "$1" "no output containing: $2" "$(flat "$3")" ;; *) pass "$1" ;; esac
+  return 0
+}
+
+# ---------------------------------------------------------------------------
+# The harness: stubs, then a body, run under the shell GitHub gives a step.
+#
+# GitHub invokes a step declaring no `shell:` as
+# `bash --noprofile --norc -e -o pipefail {0}`. `-e` is what makes the
+# suppression inside the `&&` list observable at all, so running these bodies
+# under anything else would grade a different program.
+#
+# `git` and `sleep` are shell FUNCTIONS rather than PATH shims so the body's
+# own lines survive byte-for-byte — in particular `sleep $((i * 3))`, which
+# would otherwise cost 45 wall-clock seconds per exhausted-retry case.
+# An unexpected git subcommand returns a loud, distinctive 99 instead of a
+# quiet 0: a stub that silently answered "fine" to a call it did not model
+# would make every arm below pass for a reason unrelated to its obligation.
+stub_prelude() { # $1 = attempt the push first succeeds on (99 = never)
+                 # $2 = status of `git diff --staged --quiet` (1 = changes staged)
+  cat <<STUB
+STUB_SUCCEED_ON=$1
+STUB_STAGED=$2
+STUB_PUSHES=0
+git() {
+  case "\$1" in
+    config|add|commit) return 0 ;;
+    diff)  return "\$STUB_STAGED" ;;
+    pull)  return 0 ;;
+    push)
+      STUB_PUSHES=\$((STUB_PUSHES + 1))
+      if [ "\$STUB_PUSHES" -ge "\$STUB_SUCCEED_ON" ]; then return 0; fi
+      return 1 ;;
+    *) echo "STUB: unmodelled call: git \$*" >&2; return 99 ;;
+  esac
+}
+sleep() { :; }
+STUB
+}
+
+# run_body <file-with-body> <succeed-on> <staged-status> -> sets OUT / ST
+run_body() {
+  local body="$1" script="$TMP/step.sh"
+  { stub_prelude "$2" "$3"; cat "$body"; } >"$script"
+  # No `set +e` guard around this: THIS file runs under `set -uo pipefail` and
+  # deliberately not `-e`, so a non-zero inner status — which is the expected
+  # outcome of half the arms below — is data, not an abort. Toggling errexit
+  # here would leave it ON for the rest of the file, which is the
+  # option-you-cannot-see family the sibling issues (#1633, #1635) are made of.
+  OUT=$(bash --noprofile --norc -e -o pipefail "$script" 2>&1)
+  ST=$?
+  return 0
+}
+
+# ---------------------------------------------------------------------------
+# Obligation 1 — the defect, re-measured on every run.
+#
+# The pre-#1641 loop, verbatim, wrapped in nothing. Committed here rather than
+# quoted in an issue, per AGENTS.md: "a number which documents behaviour but is
+# not produced by it drifts silently".
+echo "== the pre-#1641 loop shape (the defect, re-measured) =="
+cat >"$TMP/predecessor.sh" <<'OLD'
+git commit -m "chore: update ARS badge [skip ci]"
+for i in 1 2 3 4 5; do
+  git pull --rebase origin main && git push && break
+  echo "Push attempt $i failed, retrying..."
+  sleep $((i * 3))
+done
+OLD
+run_body "$TMP/predecessor.sh" 99 1
+if [[ "$ST" -eq 0 ]]; then
+  pass "the old loop still exits 0 after five failed pushes — the hazard is real"
+else
+  fail "the old loop exits 0 after five failed pushes (the hazard this pins)" \
+       "exit 0" "exit $ST — the hazard is GONE, so re-derive the fix rather than trusting it :: $(flat "$OUT")"
+fi
+want_contains "...having really exhausted all five attempts" "Push attempt 5 failed" "$OUT"
+
+# ---------------------------------------------------------------------------
+# Obligations 2-4 — the REAL step, extracted from the REAL workflow and run.
+echo ""
+echo "== $WF: $STEP =="
+
+if [[ ! -f "$WF" ]]; then
+  fail "$WF is readable" "the workflow file" "not found — the step check could not run"
+else
+  # Extract the named step's `run: |` body and dedent it. Keyed on the step
+  # NAME, so a body that moved within the file is still found and a step that
+  # was renamed is a loud refusal rather than a silent zero-line body.
+  awk -v want="$STEP" '
+    !inblock && $0 ~ /^[[:space:]]*-[[:space:]]+name:[[:space:]]*/ {
+      n = $0; sub(/^[[:space:]]*-[[:space:]]+name:[[:space:]]*/, "", n)
+      gsub(/^["'"'"']|["'"'"']$/, "", n)
+      cur = (n == want)
+      next
+    }
+    !inblock && cur && $0 ~ /^[[:space:]]*run:[[:space:]]*\|[[:space:]]*$/ {
+      inblock = 1; ind = match($0, /[^ ]/); next
+    }
+    inblock {
+      if ($0 ~ /^[[:space:]]*$/) { print ""; next }
+      if (match($0, /[^ ]/) <= ind) { inblock = 0; cur = 0; next }
+      print substr($0, ind + 2)
+    }
+  ' "$WF" >"$TMP/step-body.sh"
+
+  # The extraction has to have found something. A scan that silently stopped
+  # matching reads exactly like a workflow with no hazard in it, and every
+  # arm below would then grade an empty file — which exits 0 and looks like a
+  # clean push.
+  lines=$(grep -cve '^[[:space:]]*$' "$TMP/step-body.sh")
+  if [[ "${lines:-0}" -lt 5 ]]; then
+    fail "the '$STEP' step body was extracted from $WF" \
+         "at least 5 non-blank lines" "$lines — the scan has gone blind, not the step clean"
+  else
+    pass "extracted the '$STEP' step body from $WF ($lines non-blank lines)"
+
+    # Obligation 2: every attempt fails.
+    run_body "$TMP/step-body.sh" 99 1
+    want_status "every push attempt fails" 1 "$ST" "$OUT"
+    want_contains "...and the step says the badge was NOT pushed" "NOT pushed" "$OUT"
+    want_contains "...as a workflow error annotation, so it surfaces on the run" "::error::" "$OUT"
+    want_contains "...having really exhausted all five attempts" "Push attempt 5 failed" "$OUT"
+
+    # Obligation 3: the retry is still a retry. This is the arm that a "fix"
+    # dropping the loop — or removing the errexit suppression inside the `&&`
+    # list, which would abort at the first failed pull — cannot satisfy.
+    run_body "$TMP/step-body.sh" 3 1
+    want_status "a push that succeeds on the third attempt" 0 "$ST" "$OUT"
+    want_contains "...retried after the first failure" "Push attempt 1 failed" "$OUT"
+    want_contains "...and after the second" "Push attempt 2 failed" "$OUT"
+    want_absent "...without claiming the badge went unpushed" "NOT pushed" "$OUT"
+
+    # Obligation 4: the clean paths.
+    run_body "$TMP/step-body.sh" 1 1
+    want_status "a push that succeeds first time" 0 "$ST" "$OUT"
+    want_absent "...with no retry noise" "Push attempt" "$OUT"
+
+    run_body "$TMP/step-body.sh" 99 0
+    want_status "nothing staged to commit" 0 "$ST" "$OUT"
+    want_contains "...and it says so" "No badge changes to commit" "$OUT"
+
+    # `|| true` is the false fix for this family and is refused by name: it
+    # would let the loop end without aborting while leaving `true`'s status
+    # behind, so the exhausted case would read as 0 all over again (#1629
+    # measured the same thing one level down, on a `$?` capture).
+    #
+    # Full-line comments are stripped first, and that is not tidiness: the
+    # step's own comment EXPLAINS why `|| true` is not used, so a raw scan
+    # fails on the sentence saying the right thing. Measured — it did.
+    code=$(grep -v '^[[:space:]]*#' "$TMP/step-body.sh")
+    want_absent "the step does not reach for \`|| true\`" "|| true" "$code"
+    # ...and the strip must not have eaten the code, or the arm above is
+    # vacuous: an empty haystack contains no needle.
+    want_contains "...checked against the step's real code, not an empty strip" "git push" "$code"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# ...and preflight's `tools` gate has to FIRE on a diff touching only ars.yml,
+# or under --changed (the pre-push hook's path) every assertion above is
+# skipped on precisely the commit that can break it. That is #1591's, #1629's
+# and #1639's shape, each fixed by widening this same trigger. The regex is
+# EXTRACTED and matched rather than string-compared, so this is a behavioural
+# assertion and not a lock on one spelling of an alternation.
+echo ""
+echo "== tools/preflight.sh's \`tools\` trigger =="
+PF=tools/preflight.sh
+if [[ ! -f "$PF" ]]; then
+  fail "$PF is readable" "the preflight script" "not found — the trigger check could not run"
+else
+  tools_re=$(grep -a "run_gate_scoped '\^tools/lib/" "$PF" \
+             | sed -E "s/^[[:space:]]*run_gate_scoped '//; s/'[[:space:]]*\\\\?[[:space:]]*$//")
+  if [[ -z "$tools_re" ]]; then
+    fail "the tools-gate trigger regex could be read from $PF" \
+         "one run_gate_scoped line starting ^tools/lib/" "no such line — the scan has gone blind, not the trigger wrong"
+  else
+    pass "read the tools-gate trigger regex from $PF"
+    for probe in "$WF" tools/lib/ars-badge-push_test.sh; do
+      if printf '%s\n' "$probe" | grep -qE "$tools_re"; then
+        pass "...it fires on a diff touching $probe"
+      else
+        fail "the tools gate fires on a diff touching $probe" "a match" "no match against: $tools_re"
+      fi
+    done
+    # The vacuity guard: a trigger that matched everything would satisfy both
+    # probes above and scope nothing.
+    if printf '%s\n' core/domain/session.go | grep -qE "$tools_re"; then
+      fail "the tools-gate trigger still scopes" "no match for core/domain/session.go" "it matches everything: $tools_re"
+    else
+      pass "...and still does not fire on an unrelated core/ file"
+    fi
+  fi
+fi
+
+echo ""
+if [[ "$rc" -eq 0 ]]; then
+  echo "ars-badge-push_test: ALL PASS"
+else
+  echo "ars-badge-push_test: FAILURES" >&2
+fi
+exit "$rc"

--- a/tools/preflight.sh
+++ b/tools/preflight.sh
@@ -444,7 +444,12 @@ if want tools; then
   # shell-lib-suite_test.sh asserts that its "Test the shared shell libs" step
   # goes through the shared runner rather than growing its own loop back, and a
   # commit editing only that workflow is again exactly the one that breaks it.
-  run_gate_scoped '^tools/lib/|^tools/[^/]*\.sh$|^tools/git-hooks/|^go\.work$|^\.github/dependabot\.yml$|^site/install\.sh$|^\.github/workflows/(macos-swift|test)\.yml$' \
+  # .github/workflows/ars.yml joins them for the fourth time (#1641):
+  # ars-badge-push_test.sh EXTRACTS that workflow's "Commit badge update" step
+  # and executes it, so the assertion that an exhausted push-retry fails the
+  # step lives entirely in this gate — and a commit editing only ars.yml is
+  # once again exactly the one that breaks it.
+  run_gate_scoped '^tools/lib/|^tools/[^/]*\.sh$|^tools/git-hooks/|^go\.work$|^\.github/dependabot\.yml$|^site/install\.sh$|^\.github/workflows/(ars|macos-swift|test)\.yml$' \
                   "tools/lib shell-lib tests" shell_lib_tests
 fi
 


### PR DESCRIPTION
Closes #1641

## The defect

`.github/workflows/ars.yml`'s "Commit badge update" step retried the badge push five times:

```sh
for i in 1 2 3 4 5; do
  git pull --rebase origin main && git push && break
  echo "Push attempt $i failed, retrying..."
  sleep $((i * 3))
done
```

The loop's last statement is `sleep`, which succeeds. So when all five attempts failed the loop
simply ended, `sleep`'s 0 became the step's status, and the step, the job and this workflow's
check all went **green** with the badge unpushed. GitHub's implicit `-e` (a step declaring no
`shell:` runs as `bash --noprofile --norc -e -o pipefail {0}`) does not save it: errexit is
suppressed for every command in an `&&` list except the one after the final `&&` — which is
exactly what *makes* the loop a retry. That suppression is wanted; what was missing is anything
that then **reads** the exhausted case. The observable symptom is a README badge that quietly
stops tracking `main` behind a green history.

## The fix

The retry behaviour is unchanged — `pushed` is added, and it is the only thing that can tell
"it went in on attempt 3" from "it never went in":

```sh
pushed=0
for i in 1 2 3 4 5; do
  if git pull --rebase origin main && git push; then pushed=1; break; fi
  echo "Push attempt $i failed, retrying..."
  sleep $((i * 3))
done
if [ "$pushed" -ne 1 ]; then
  echo "::error::ARS badge was NOT pushed: all 5 \`git pull --rebase origin main && git push\` attempts to origin/main failed. The badge commit exists only on this runner; README.md on main still shows the previous score."
  exit 1
fi
```

`|| true` is deliberately not used and is refused by name in the test: it makes the loop's own
status 0 for the same reason, one level down (#1629 measured the same trap on a `$?` capture).

**`tools/lib/ars-badge-push_test.sh`** is the lock, and it is deliberately **behavioural, not a
text scan**: it EXTRACTS that step out of the real workflow file, keyed on the step *name*, and
EXECUTES it against a git stub under GitHub's own bash invocation. A scan pins one spelling of a
guard; running the block pins the property. Four obligations — the exhausted case fails and says
what did not happen; the retry is still a retry (an attempt-3 success exits 0 having retried
twice); the clean paths still pass; and the pre-fix loop is emitted **verbatim** and re-measured
on every run, which is both the committed reproduction and the vacuity guard. Three guards keep
it from going quietly blind: an extraction returning fewer than 5 lines is a named refusal
("the scan has gone blind, not the step clean"), the stub answers an **unmodelled** git
subcommand with a loud 99 naming the call rather than a quiet 0, and the `|| true` scan asserts
its comment-strip did not eat the code.

`preflight.sh`'s `tools` trigger gains `ars.yml` — the **fourth** widening for this exact reason
(#1591, #1629, #1639) — because that assertion lives entirely inside that gate, so a commit
editing only `ars.yml` would otherwise skip it under `--changed`.

## Point 2 — the sweep, in full

Method: extracted **every** multi-line `run:` block from **all 11** workflow files with an awk
walk (`run: |` + indentation), and read each one for the general shape rather than for "a loop":
*any block whose LAST statement can succeed while an earlier one failed*. 19 blocks, matching the
issue's own sizing. `.github/workflows/` has 38 `run:` keys total, 19 multi-line and 19
single-line; there are **no** folded (`run: >`) blocks — checked, not assumed.

| block | verdict |
|---|---|
| `ars.yml:53` "Commit badge update" | **the defect — fixed here** |
| `ars.yml:34` "Run ARS scan" + `ars.yml:39` "Extract and update ARS badge" | **new defect → #1644** |
| `replaydata-deletion-guard.yml:49` | **new defect → #1645** |
| `macos-swift.yml:296` snapshot-evidence | **new defect (low) → #1646** |
| `codescene-badge.yml:25` | clear — the only failable statement is `SCORE=$(… \| jq …)`, and a simple assignment from a command substitution IS subject to `-e`; a `-z`/`null` guard with `exit 1` follows it |
| `codescene-badge.yml:44`, `coverage.yml:48` | clear — parameter expansion + an if/elif/else that always assigns + a trailing `echo >> $GITHUB_ENV`; nothing earlier can fail unreported |
| `codescene-badge.yml:61`, `coverage.yml:63` | clear — end on an `http_code` guard whose false branch IS the success condition, with `exit 1` in the true branch |
| `coverage.yml:27` | read, deliberate — see below |
| `macos-swift.yml:102`, `:125` | clear — three diagnostic version commands, each a bare statement under `-e` |
| `macos-swift.yml:269` | clear — same, plus a final `ls … \|\| echo "no …"` that is an intentional print-either-way in a diagnostic step |
| `macos-swift.yml:193` swift-test | clear — this is #1629's fix; ends on `swift_suite_verdict "$rc"`, whose status IS the step's |
| `star-history.yml:47` | clear — ends on `go run ./tools/starhistory`, whose status IS the step's |
| `star-history.yml:54` | clear — every earlier statement is a bare command under `-e`, and it ends on `gh pr merge`, whose status IS the step's. (Correcting the brief's spot-check: it ends on `gh pr merge`, not on `git push`; same conclusion) |
| `test.yml:54` gofmt | clear — ends on a guard with `exit 1` in its true branch |
| `test.yml:126` | clear — this is #1642's fix, `… \|\| rc=$?; exit "$rc"` |

**The four workflows with no multi-line block at all** were read too, since the brief's
spot-checks were reads rather than runs: `linux.yml` (5 steps, each a single command — the one
`&&` chain, `cd core && go build ./...`, is in final position so its status is the step's),
`web-test.yml` (2 single-command steps), `ars-gate.yml` (1), `pages.yml` (**no `run:` key at
all**).

**`coverage.yml:27` — read, and reported rather than filed, with the reasoning.** The swallow is
deliberate *in the code* (`go test …; go tool cover …` — a `;`, not an `&&`, plus `2>/dev/null`),
and the failure is not silent in the way this family is about: an empty `pct` sets `count=0`,
`COVERAGE="0.0"`, and the badge goes to `0.0%` / red. But note the brief's justification does
**not** hold as stated: AGENTS.md says nothing about coverage.yml (grepped — 8 hits, all
unrelated), so "AGENTS.md says so" is not the evidence. The real cover is that test failures are
gated by `test.yml` on the PR, where `coverage.yml` only runs on push to `main`. The residual —
a partial `coverage.out` from an aborted run yielding a plausible-but-wrong percentage — is real
but is a wrong *number*, not a green-on-failure, so I left it unfiled rather than adding noise.

## Point 3 — the guard decision: **no linter**, and here is the measurement

#1639's agent rejected a `$?`-keyed rule on measured coverage. I ran the equivalent measurement
here: three candidate rules applied mechanically to all 19 blocks.

| candidate rule | flags | catches #1641? | false positives |
|---|---|---|---|
| last statement is `echo`/`sleep`/`cat`/`printf`/`true`/`:` | 6 | **NO** | 4 of 6 |
| block contains `\|\| true` | 2 | **NO** | 0 of 2 |
| block contains a `for`/`while`/`until` | 3 | yes | 2 of 3 |

The decisive row is the first, and it is decisive precisely because it is the rule that reads
most like the hazard. **It misses the very defect it would have been written for**: `ars.yml`'s
retry loop is nested inside an `if`/`else`, so the block's last *line* is `fi`. Catching it needs
a rule that knows the `else` branch ends in a `for` whose body ends in `sleep` — i.e. a shell
parser, not a text scan — and a green from the text version would claim coverage over exactly
the case it cannot see, while flagging four correct blocks (`codescene-badge.yml:25`, `:44`,
`coverage.yml:27`, `:48`).

The `|| true` rule is the interesting near-miss: 2 flags, 0 false positives, and both flags are
**real** (they are #1644 and #1645). It is a good *finding* rule and a useless *guard* rule — it
has nothing to say about the subject defect, so it could not have gated this PR.

The third rule catches the subject only by being over-broad ("contains a loop" says nothing about
whether the loop reports), and both its other hits need a human read anyway.

So: **the lock is on the ONE call site that exists**, the same conclusion #1629 reached by the
same measurement, and no general workflow linter was built. With 19 blocks, three of them already
carrying purpose-built assertions from this issue family, a mechanical sweep on demand beats a
green check that over-claims.

## Point 4 — evidence

Reproduced with `bash --noprofile --norc -e -o pipefail`, GitHub's documented invocation for a
step declaring no `shell:`.

**What ran on a real runner, precisely.** The **lock** did: `tools/lib/ars-badge-push_test.sh`
is discovered by `test.yml`'s "Test the shared shell libs" step, so this PR's own `go-test` job
([run 31958970699](https://github.com/ingo-eichhorst/Irrlicht/actions/runs/31958970699),
macos-latest, pass) executed the fixed `ars.yml` step body under the runner's own bash and
reported:

```
== tools/lib/ars-badge-push_test.sh ==
ars-badge-push_test: ALL PASS
shell-lib-suite: tools/lib — found 12, skipped 1 (posix-lint_test.sh), ran 11, failed 0
```

**The workflow itself did not**, and cannot on a branch: `ars.yml` triggers on `push: [main]`
and `workflow_dispatch` only, so there is no PR-triggered job for it and its next real execution
will be the first, on merge. Every RED figure below is therefore the local reproduction of
GitHub's shell driving the workflow file's own extracted step body — stated explicitly rather
than left to be inferred.

### RED — the new test against the UNFIXED `ars.yml` (the defect test, seen fail first)

```
== .github/workflows/ars.yml: Commit badge update ==
  PASS: extracted the 'Commit badge update' step body from .github/workflows/ars.yml (13 non-blank lines)
  FAIL: every push attempt fails — expected [exit 1] got [exit 0 :: Push attempt 1 failed, retrying... Push attempt 2 failed, retrying... Push attempt 3 failed, retrying... Push attempt 4 failed, retrying... Push attempt 5 failed, retrying... ]
  FAIL: ...and the step says the badge was NOT pushed — expected [output containing: NOT pushed] got [...]
  FAIL: ...as a workflow error annotation, so it surfaces on the run — expected [output containing: ::error::] got [...]
  PASS: ...having really exhausted all five attempts
```

**Exit 0 → exit 1** is the whole of the fix, measured on the real file both ways.

### The mutations — each applied and reverted in ONE foreground call, with a `git status --porcelain` assertion after the revert

**M2 — the guard replaced by the false fix (`… && git push || true`, no `pushed`):** 5 arms red,
including the `|| true` refusal itself.

```
  FAIL: every push attempt fails — expected [exit 1] got [exit 0 :: Push attempt 1 failed … Push attempt 5 failed …]
  FAIL: ...and the step says the badge was NOT pushed — expected [output containing: NOT pushed] got […]
  FAIL: ...as a workflow error annotation, so it surfaces on the run — expected [output containing: ::error::] got […]
  FAIL: ...with no retry noise — expected [no output containing: Push attempt] got […]
  FAIL: the step does not reach for `|| true` — expected [no output containing: || true] got […]
```

**M3 — the retry dropped, guard kept** (a single attempt plus the `pushed` check). This is the
mutation that shows the retry arm is not inert: obligation 2 stays fully green, and only the
retry obligations object.

```
  PASS: every push attempt fails (exit 1)
  PASS: ...and the step says the badge was NOT pushed
  PASS: ...as a workflow error annotation, so it surfaces on the run
  FAIL: ...having really exhausted all five attempts — expected [output containing: Push attempt 5 failed] got [::error::ARS badge was NOT pushed: …]
  FAIL: a push that succeeds on the third attempt — expected [exit 0] got [exit 1 :: ::error::ARS badge was NOT pushed: …]
  FAIL: ...retried after the first failure — expected [output containing: Push attempt 1 failed] got […]
  FAIL: ...and after the second — expected [output containing: Push attempt 2 failed] got […]
  FAIL: ...without claiming the badge went unpushed — expected [no output containing: NOT pushed] got […]
```

**M5 — the step renamed**, so the extraction matches nothing. The vacuity guard fires and names
the reason, instead of 15 arms silently not running:

```
  FAIL: the 'Commit badge update' step body was extracted from .github/workflows/ars.yml — expected [at least 5 non-blank lines] got [0 — the scan has gone blind, not the step clean]
```

**M6 — one `git status --short` added to the step**, i.e. a call the harness's stub does not
model. It refuses loudly rather than answering a quiet 0, which is what stops every arm from
passing for a reason unrelated to its obligation:

```
  FAIL: every push attempt fails — expected [exit 1] got [exit 99 :: STUB: unmodelled call: git status --short ]
  FAIL: ...and the step says the badge was NOT pushed — expected [output containing: NOT pushed] got [STUB: unmodelled call: git status --short ]
```

M6's first attempt is itself worth recording: the splice used the wrong indentation and the
harness's own `assert old in s, "M6 splice did not match — mutation NOT applied"` caught it
(#1390's rule), so a mutation that never landed did not get reported as a passing arm.

**M1 (the guard removed) and M4 (preflight's trigger un-widened)** are the RED block above —
that run *is* the unmutated-predecessor state for both, and it shows the trigger arm red too:

```
  FAIL: the tools gate fires on a diff touching .github/workflows/ars.yml — expected [a match] got [no match against: ^tools/lib/|^tools/[^/]*\.sh$|^tools/git-hooks/|^go\.work$|^\.github/dependabot\.yml$|^site/install\.sh$|^\.github/workflows/(macos-swift|test)\.yml$]
```

Every revert was followed by `git status --porcelain` (never `git checkout --`/`restore`/`reset
--hard`) and by a re-run of the suite confirming exit 0.

### The two filed findings, also measured (not merely read)

#1644 — the three `ars.yml` step bodies extracted and run with `ars` stubbed to fail:

```
ars: command failed: no such subcommand
STEP 'Run ARS scan' EXIT=0
ARS Badge line:
STEP 'Extract and update ARS badge' EXIT=0
No badge changes to commit
STEP 'Commit badge update' EXIT=0
=> README badge line unchanged, job GREEN throughout
```

#1645 — the deletion-guard step body extracted and run with `git diff` stubbed to fail:

```
fatal: bad object BASESHA
OK: no disallowed deletions (orphan recordings, assessment.json, and renames are permitted).
GUARD STEP EXIT=0
```

...with a control run (working `git diff`, one real violation → `::error::` + exit 1) proving the
guard is otherwise healthy, so the finding is about the failure path only.

#1646 is a **read**, not a run, and its issue says so: reproducing it means driving a real
`swift test`, and the trace (every other statement in that block is either a guard or an input to
one; `cp -R` is the sole exception) is what the finding rests on.

## Gates

Each run as its own **foreground** invocation, exit status read **directly**, never through a
pipe:

| gate | result |
|---|---|
| `tools/preflight.sh --only tools` | **PASS** (exit 0) — `shell-lib-suite: tools/lib — found 12, skipped 0 (none), ran 12, failed 0` (11 → 12 with the new file) |
| `tools/preflight.sh --only posix` | **PASS** (exit 0) — `posix-lint: 3 file(s); parser=dash, bashisms=shellcheck checkbashisms` … `ALL PASS`. Run because the posix trigger fires on any `*.sh`, though no `#!/bin/sh` file is touched |
| `tools/preflight.sh --changed --only go` | **PASS** (exit 0) — gofmt PASS, every Go gate correctly SKIP |
| `tools/preflight.sh --changed --only swift` | **PASS** (exit 0) — fires because `tools/preflight.sh` is in its trigger set |
| pre-push hook (`preflight.sh --changed --budget 540`) | **PASS** (`PUSH_EXIT=0`) — POSIX lint PASS, tools PASS, gofmt PASS, macOS Swift build + test PASS, everything else SKIP; no TIMEOUT and no NOT RUN |
| `shellcheck -S style tools/lib/ars-badge-push_test.sh` | clean (exit 0), no disables needed |
| `--only skills` | **not run**, and that is its whole trigger set: no `.claude/skills/**/*.md` and no `SKILL.md` is touched. `AGENTS.md` is edited but `skill-lint.sh` reads only those two families — checked in the linter, not assumed |

Every PR check on this branch is green (`go-test`, `build-test`, `ars-gate`, `swift-build`,
`swift-test`, `swift-snapshot-evidence`, both web suites, CodeQL, CodeScene, SonarCloud). See
"Point 4" above for exactly which half of the evidence a real runner produced and which half it
could not: the lock ran there, `ars.yml` itself cannot until merge.

## Out of scope — filed, not fixed

* **#1644** — `ars.yml`'s scan→extract path: a failed `ars scan` leaves the badge stale with
  three green steps. Same job, different steps.
* **#1645** — `replaydata-deletion-guard.yml`: `deletions=$(git diff … || true)` makes a failing
  diff print the guard's own PASS line. This one is a **merge gate**, and it had been
  spot-checked and cleared twice on the strength of its loop, which is genuinely fine — the
  defect is the line above it.
* **#1646** (low) — `macos-swift.yml`'s snapshot-evidence step: `cp -R … __References__` under
  `set +e`, status read by nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

