### PR TITLE
fix(ci): make the replaydata deletion guard REFUSE when it cannot read its diff (#1645)

### DIFF
--- a/.github/workflows/replaydata-deletion-guard.yml
+++ b/.github/workflows/replaydata-deletion-guard.yml
@@ -22,6 +22,12 @@ name: Replaydata deletion guard
 #   - renames (git mv, incl. the id-prefix folder rename) — never counted as
 #     deletions.
 #
+# There is a THIRD outcome besides fail and pass, and it is a FAILURE: the
+# guard could not read a diff at all. Everything that could leave `$deletions`
+# empty for a reason other than "nothing was deleted" is a named refusal in the
+# step below, because an empty `$deletions` is this guard's success condition
+# and so an inability to look is otherwise byte-identical to a clean PR (#1645).
+#
 # Background: #268 Phase 1 introduced a blanket scenarios/+regression guard; it
 # was later made folder-granular + cell-aware so the pipeline can retire orphan
 # recordings and drop scenarios/ assessment.json, while still protecting every
@@ -53,11 +59,68 @@ jobs:
           head="${{ github.event.pull_request.head.sha }}"
           echo "Comparing merge-base($base, $head) ...head $head"
 
+          # -------------------------------------------------------------------
+          # THE REFUSALS (#1645). This step FAILS on "$violations is non-empty",
+          # and $violations is empty in two completely different situations: the
+          # diff was clean, and no diff was ever read. Each block below turns one
+          # way of not reading a diff into a loud failure, so that the second
+          # situation stops printing the first one's PASS line.
+          #
+          # Refusal 1 — no pull_request context. `on: workflow_dispatch` (above)
+          # has no `github.event.pull_request`, so BOTH expressions expand to the
+          # empty string and the diff below becomes `git diff "..."`, which git
+          # reads as HEAD...HEAD: exit 0, no output, PASS — having compared a
+          # commit with itself. Measured on git 2.50.1, and reachable by anyone
+          # pressing "Run workflow".
+          if [ -z "$base" ] || [ -z "$head" ]; then
+            echo "::error::deletion guard REFUSED: no pull_request context (base='$base', head='$head'), so there is no base...head diff to read. This is NOT a pass — nothing was examined. Run this guard from a pull request."
+            exit 1
+          fi
+
+          # Refusal 2 — an object this checkout does not have. `fetch-depth: 0`
+          # on the checkout above makes it unlikely, not impossible (a base
+          # branch force-pushed or deleted between the event and this job leaves
+          # base.sha unreachable from every ref the checkout fetched), and it is
+          # one edit to that step away from ordinary. Checked per side so the log
+          # names WHICH commit is missing. `&& return 0` keeps the failing
+          # rev-parse inside an && list, where errexit does not apply, so the
+          # message below is what reports it rather than a bare abort.
+          require_commit() { # <label> <sha>
+            git rev-parse --verify --quiet "$2^{commit}" >/dev/null && return 0
+            echo "::error::deletion guard REFUSED: the $1 commit $2 is not present in this checkout, so the base...head diff cannot be computed. This is NOT a pass — nothing was examined."
+            exit 1
+          }
+          require_commit base "$base"
+          require_commit head "$head"
+
           # Three-dot (base...head) diffs from the MERGE BASE to head — only what
           # this branch changed since it forked (avoids phantom deletions on
           # stale branches). --diff-filter=D = deletions; --find-renames=50% keeps
           # git mv as a rename (not a delete), documented + stable.
-          deletions=$(git diff --name-only --diff-filter=D --find-renames=50% "$base...$head" -- 'replaydata/**' || true)
+          #
+          # Refusal 3 — the diff itself. Until #1645 this line ended in
+          # `|| true`, which turned a git that FAILED into an empty $deletions —
+          # this guard's success condition. The classification loop then read
+          # nothing, $violations stayed empty, and the step printed
+          # "OK: no disallowed deletions" and exited 0 having examined no diff at
+          # all; a git exiting 128 was byte-for-byte a clean PR. Captured with
+          # `if !` rather than left to the `set -e` above for two reasons:
+          # errexit is suppressed inside an `if` condition, so the status is ours
+          # to read, and the message then names what could not be done where a
+          # bare abort names only a line.
+          if ! deletions=$(git diff --name-only --diff-filter=D --find-renames=50% "$base...$head" -- 'replaydata/**'); then
+            echo "::error::deletion guard REFUSED: git could not diff $base...$head (see the fatal above), so the guard examined NOTHING. This is NOT a pass."
+            exit 1
+          fi
+
+          # "Nothing was deleted" and "nothing was read" are now different exit
+          # statuses. This makes them different STRINGS in the log too, which is
+          # what someone reading a green run actually sees.
+          deleted_count=0
+          if [ -n "$deletions" ]; then
+            deleted_count=$(printf '%s\n' "$deletions" | wc -l | tr -d ' ')
+          fi
+          echo "Examined $deleted_count deleted path(s) under replaydata/."
 
           # A scenarios/ recording folder is a LIVE cell iff it holds a
           # metadata.json at HEAD (the working tree == HEAD; we checked it out).
@@ -125,4 +188,4 @@ jobs:
             exit 1
           fi
 
-          echo "OK: no disallowed deletions (orphan recordings, assessment.json, and renames are permitted)."
+          echo "OK: examined $deleted_count deleted path(s), none disallowed (orphan recordings, assessment.json, and renames are permitted)."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1027,6 +1027,50 @@ Before marking a ticket done, run the full suite — every layer must pass:
   `$?`-keyed rule, and #1639 about the sibling family. `preflight.sh`'s `tools`
   trigger gains `ars.yml`, its fourth widening for this reason (#1591, #1629,
   #1639), because that assertion lives entirely inside that gate.
+- The replaydata deletion guard:
+  `tools/lib/replaydata-deletion-guard_test.sh` does to
+  `.github/workflows/replaydata-deletion-guard.yml`'s "Detect deletions of
+  load-bearing replaydata" step what the bullet above does to ars.yml —
+  extracts it and EXECUTES it against a git stub, under the same
+  `bash --noprofile --norc -e -o pipefail`. It is the same family's most
+  expensive member, because that workflow is a **merge gate**: before #1645 its
+  diff was captured as `deletions=$(git diff … || true)`, and an empty
+  `$deletions` is the gate's SUCCESS condition — so a git exiting 128 produced
+  no violations, printed `OK: no disallowed deletions` and exited 0, permitting
+  exactly the #268 deletion the gate exists to refuse. **Where** the defect sat
+  is the part worth carrying: this block was spot-checked and cleared TWICE
+  during #1639 and #1641, both times on the strength of the classification
+  LOOP, which is genuinely fine. The statement that decides the step's status
+  is the loop's INPUT, one line above it — a `case` walk over `$deletions` can
+  only ever be as good as `$deletions`, and nothing in the loop can see that it
+  was handed an empty string by a failure rather than by a clean PR.
+  Three outcomes now, never two: deletions found and disallowed (fail), no
+  deletions (pass), and **could not determine** (fail, naming why). Three
+  refusals implement the third, and the second of them is a SECOND measured
+  hazard rather than defensive padding — `on: workflow_dispatch` carries no
+  `github.event.pull_request`, so both `${{ }}` expressions expand to the empty
+  string and `git diff "..."` is `HEAD...HEAD`: exit 0, no output, PASS. That is
+  measured against real git in the lock, not stubbed, since a claim about how
+  git parses `...` has to be made by git. Note honestly what each refusal
+  independently buys: deleting the empty-context one still leaves the run
+  failing, because an empty sha does not rev-parse either — what it uniquely
+  buys is the DIAGNOSIS ("no pull_request context" rather than "the base commit
+  is not present in this checkout", which points at the checkout instead of the
+  trigger). The commit-presence refusal is the one that is defensive: with
+  `fetch-depth: 0` no ordinary condition was found that makes `base.sha`
+  unreachable, so unlike the other two it is not backed by a reproduction, only
+  by the observation that it is one edit to the checkout step away.
+  Two more things about the lock. `cell_is_live` reads the WORKING TREE, so
+  "live cell" and "orphan cell" are properties of the directory a body runs
+  in — every arm executes against a throwaway tree under `$TMP`, and the real
+  deletion-guarded catalog is never touched. And what the stub CANNOT grade is
+  said out loud: `git mv` is permitted because git's own rename detection
+  reports an R that `--diff-filter=D` drops, not because of anything the step
+  does, and detection is ON by default in modern git — so `--find-renames=50%`
+  pins the threshold, not the behaviour, and that arm grades the invocation the
+  step makes rather than claiming the step implements renaming.
+  `preflight.sh`'s `tools` trigger gains this workflow, its fifth widening for
+  this reason (#1591, #1629, #1639, #1641).
 - Factory: `go test ./tools/onboarding-factory/... -race -count=1`.
 - Replay: `tools/replay-fixtures.sh` — gated in CI by linux.yml, and run
   natively as `tools/preflight.sh`'s `replay fixtures` gate, so golden drift

--- a/tools/lib/replaydata-deletion-guard_test.sh
+++ b/tools/lib/replaydata-deletion-guard_test.sh
@@ -1,0 +1,482 @@
+#!/usr/bin/env bash
+# replaydata-deletion-guard_test.sh — the lock on
+# .github/workflows/replaydata-deletion-guard.yml's "Detect deletions of
+# load-bearing replaydata" step (#1645).
+#
+# ---------------------------------------------------------------------------
+# What is being asserted, and why each obligation exists
+#
+# The defect: the step captured its diff as
+#
+#     deletions=$(git diff --name-only --diff-filter=D --find-renames=50% \
+#                   "$base...$head" -- 'replaydata/**' || true)
+#
+# and then classified `$deletions` into `$violations`, failing iff
+# `$violations` was non-empty. `|| true` makes a git that FAILED produce an
+# empty `$deletions` — which is this guard's SUCCESS condition. The
+# classification loop read nothing, `$violations` stayed empty, and the step
+# printed "OK: no disallowed deletions" and exited 0 having examined no diff at
+# all. A git exiting 128 was byte-for-byte a clean PR. This is a MERGE GATE, so
+# its blind spot permits exactly what it exists to prevent: #268 requires a
+# recording to be retired by `git mv` into regression/ and never deleted.
+#
+# Note WHERE the defect was, because this block was spot-checked and cleared
+# twice while the sibling issues were worked (#1639's agent, then #1641's
+# brief). Both readings were of the classification LOOP, which is fine — it
+# accumulates into `$violations` and reports after the loop. The statement that
+# decides the step's status is the loop's INPUT, one line above it.
+#
+# The obligations, in order:
+#
+#   1. both pre-fix hazards are re-MEASURED, not described. The `|| true`
+#      capture is emitted verbatim and run under the shell GitHub actually
+#      gives a step, and the empty-context expansion is run against REAL git.
+#      They double as the vacuity guard: if either stopped behaving that way
+#      the fix would be protecting nothing and every arm below would pass for
+#      the wrong reason.
+#   2. the real step — extracted from the real workflow file and EXECUTED —
+#      still FAILS on each kind of disallowed deletion. Without this a gate
+#      that refuses everything is indistinguishable from one that works.
+#   3. a clean diff still passes, and the step is shown to have actually
+#      diffed rather than to have exited early.
+#   4. a git that FAILS now fails the step, names why, and does NOT print the
+#      pass line.
+#   5. the permitted cases still pass — orphan recordings, a live cell's
+#      assessment.json, a rename, a deletion outside any recording folder.
+#      A fix that made the guard refuse more than it should would be reverted
+#      by the first person it blocked, so this is not optional politeness.
+#   6. the two NEW refusals fire: an empty pull_request context, and a base or
+#      head commit this checkout does not have.
+#
+# Behavioural rather than a text scan, per #1647: a scan pins one spelling of a
+# guard where running the block pins the property, and this file then runs on a
+# real runner for free because test.yml discovers tools/lib/*_test.sh.
+#
+# What the stub CANNOT grade, said plainly rather than implied: `git mv` is
+# permitted because git's own rename detection reports a rename as R (filtered
+# out by --diff-filter=D), not because of anything this step does. Rename
+# detection is also ON by default in modern git, so `--find-renames=50%` pins
+# the THRESHOLD, not the behaviour. The rename arm therefore models git
+# faithfully — the stub reports the old path as a deletion when the invocation
+# does NOT ask for rename detection — which grades the invocation the step
+# makes rather than claiming the step implements renaming.
+set -uo pipefail
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+cd "$REPO_ROOT" || { echo "FAIL: replaydata-deletion-guard_test — cannot cd to $REPO_ROOT" >&2; exit 1; }
+
+# A missing tool is a hard failure, not a skip: exiting 0 here would read as a
+# PASS to the runner that drives this file, so it would go green having
+# asserted nothing — the failure mode this whole issue family is made of.
+need() { command -v "$1" >/dev/null 2>&1 || { echo "FAIL: replaydata-deletion-guard_test — $1 not found" >&2; exit 1; }; }
+need git
+need mktemp
+need awk
+need sed
+need bash
+need wc
+
+WF=.github/workflows/replaydata-deletion-guard.yml
+STEP='Detect deletions of load-bearing replaydata'
+
+TMP=$(mktemp -d -t replaydata-deletion-guard) || exit 1
+trap 'rm -rf "$TMP"' EXIT
+
+rc=0
+pass() { echo "  PASS: $1"; return 0; }
+fail() { echo "  FAIL: $1 — expected [$2] got [$3]" >&2; rc=1; return 0; }
+flat() { echo "$1" | tr '\n' ' '; }
+
+want_status() { # label want got out
+  if [[ "$3" == "$2" ]]; then pass "$1 (exit $2)"; else fail "$1" "exit $2" "exit $3 :: $(flat "$4")"; fi
+  return 0
+}
+want_contains() { # label needle haystack
+  case "$3" in *"$2"*) pass "$1" ;; *) fail "$1" "output containing: $2" "$(flat "$3")" ;; esac
+  return 0
+}
+want_absent() { # label needle haystack
+  case "$3" in *"$2"*) fail "$1" "no output containing: $2" "$(flat "$3")" ;; *) pass "$1" ;; esac
+  return 0
+}
+
+# ---------------------------------------------------------------------------
+# The fixture checkout.
+#
+# The step's `cell_is_live` reads the WORKING TREE (`[ -f replaydata/agents/
+# $a/scenarios/$fold/metadata.json ]`), so "live cell" and "orphan cell" are
+# properties of the directory the body runs in, not of the diff. Every body is
+# therefore executed with this as its cwd. It is a throwaway tree under
+# $TMP — the real replaydata/ catalog is deletion-guarded (by this very
+# workflow) and is never touched, read or written by this file.
+CHECKOUT="$TMP/checkout"
+mkdir -p "$CHECKOUT/replaydata/agents/claudecode/scenarios/1-1_live/recordings/r1"
+mkdir -p "$CHECKOUT/replaydata/agents/claudecode/scenarios/9-9_orphan/recordings/r1"
+mkdir -p "$CHECKOUT/replaydata/agents/claudecode/regressions/8-8_frozen"
+mkdir -p "$CHECKOUT/replaydata/orchestrators/gastown/scenarios"
+# The live cell holds a metadata.json at HEAD; the orphan deliberately does not.
+echo '{"id":"1-1_live"}' >"$CHECKOUT/replaydata/agents/claudecode/scenarios/1-1_live/metadata.json"
+
+LIVE=replaydata/agents/claudecode/scenarios/1-1_live
+ORPHAN=replaydata/agents/claudecode/scenarios/9-9_orphan
+
+# ---------------------------------------------------------------------------
+# The harness: stubs, then a body, run under the shell GitHub gives a step.
+#
+# GitHub invokes a step declaring no `shell:` as
+# `bash --noprofile --norc -e -o pipefail {0}`. Running these bodies under
+# anything else would grade a different program — the whole `|| true` question
+# is about what errexit does and does not reach.
+#
+# `git` and `jq` are shell FUNCTIONS rather than PATH shims so the body's own
+# lines survive byte-for-byte. `command -v` finds functions, which is what
+# neutralises the step's `command -v jq || sudo apt-get install …` line without
+# editing it; `sudo` is stubbed to a loud 99 so that if the jq shim ever stops
+# matching, this file fails noisily instead of quietly shelling out to apt-get
+# on whatever machine it is running on.
+#
+# An unmodelled git subcommand returns a loud, distinctive 99 naming the call
+# instead of a quiet 0: a stub that silently answered "fine" to something it
+# does not model would make every arm below pass for a reason unrelated to its
+# obligation.
+#
+# STUB_ARGV_FILE records the argv of every `git diff` the body performs, so an
+# arm can assert the step ACTUALLY DIFFED rather than exited before looking —
+# an arm that passes because nothing ran is this issue's own shape one level up.
+stub_prelude() { # $1 = base sha, $2 = head sha, $3 = diff mode, $4 = deletions payload
+                 # $5 = space-separated list of shas `git rev-parse` must not find
+  cat <<STUB
+STUB_BASE='$1'
+STUB_HEAD='$2'
+STUB_DIFF_MODE='$3'
+STUB_DELETIONS='$4'
+STUB_MISSING=' $5 '
+STUB_ARGV_FILE='$TMP/git-diff-argv'
+jq() { :; }
+sudo() { echo "STUB: unmodelled call: sudo \$*" >&2; return 99; }
+git() {
+  case "\$1" in
+    rev-parse)
+      # The step asks \`git rev-parse --verify --quiet <sha>^{commit}\`.
+      sha=\${@: -1}
+      sha=\${sha%^\{commit\}}
+      case "\$STUB_MISSING" in
+        *" \$sha "*) return 1 ;;
+      esac
+      echo "\$sha"
+      return 0 ;;
+    diff)
+      printf '%s\n' "git \$*" >>"\$STUB_ARGV_FILE"
+      case "\$STUB_DIFF_MODE" in
+        ok)
+          if [ -n "\$STUB_DELETIONS" ]; then printf '%s\n' "\$STUB_DELETIONS"; fi
+          return 0 ;;
+        fail)
+          echo "fatal: bad object \$STUB_BASE" >&2
+          return 128 ;;
+        rename)
+          # Real git: a detected rename is R, which --diff-filter=D drops.
+          # WITHOUT rename detection the same \`git mv\` is reported as a
+          # deletion of the old path plus an addition of the new one, and
+          # --diff-filter=D yields the old path.
+          case " \$* " in
+            *" --find-renames"*|*" --find-renames="*) return 0 ;;
+            *) printf '%s\n' "\$STUB_DELETIONS"; return 0 ;;
+          esac ;;
+        *) echo "STUB: unmodelled diff mode: \$STUB_DIFF_MODE" >&2; return 99 ;;
+      esac ;;
+    *) echo "STUB: unmodelled call: git \$*" >&2; return 99 ;;
+  esac
+}
+STUB
+}
+
+# run_body <file-with-body> <base> <head> <mode> <deletions> [missing-shas]
+# -> sets OUT / ST / ARGV
+run_body() {
+  local body="$1" script="$TMP/step.sh"
+  rm -f "$TMP/git-diff-argv"
+  { stub_prelude "$2" "$3" "$4" "$5" "${6:-}"; cat "$body"; } >"$script"
+  # No `set +e` guard around this: THIS file runs under `set -uo pipefail` and
+  # deliberately not `-e`, so a non-zero inner status — the expected outcome of
+  # half the arms below — is data, not an abort. Toggling errexit here would
+  # leave it on for the rest of the file, which is the option-you-cannot-see
+  # family the sibling issues (#1633, #1635) are made of.
+  OUT=$(cd "$CHECKOUT" && bash --noprofile --norc -e -o pipefail "$script" 2>&1)
+  ST=$?
+  ARGV=$(cat "$TMP/git-diff-argv" 2>/dev/null || true)
+  return 0
+}
+
+BASE_SHA=1111111111111111111111111111111111111111
+HEAD_SHA=2222222222222222222222222222222222222222
+
+# ---------------------------------------------------------------------------
+# Obligation 1a — the `|| true` hazard, re-measured on every run.
+#
+# The pre-#1645 capture, verbatim, with the classification tail trimmed to the
+# one case it needs (the two `${{ }}` expressions are the `base=`/`head=`
+# lines). Committed here rather than quoted in an issue, per AGENTS.md: "a
+# number which documents behaviour but is not produced by it drifts silently".
+echo "== the pre-#1645 \`|| true\` capture (the defect, re-measured) =="
+cat >"$TMP/predecessor-ortrue.sh" <<'OLD'
+set -euo pipefail
+base="$STUB_BASE"
+head="$STUB_HEAD"
+deletions=$(git diff --name-only --diff-filter=D --find-renames=50% "$base...$head" -- 'replaydata/**' || true)
+violations=""
+while IFS= read -r f; do
+  [ -z "$f" ] && continue
+  case "$f" in
+    replaydata/agents/scenarios.json)
+      violations="$violations  - $f  (matrix catalog)"$'\n' ;;
+    *) : ;;
+  esac
+done <<< "$deletions"
+if [ -n "$violations" ]; then
+  echo "::error::PR deletes load-bearing replaydata (catalog or referenced recordings)."
+  exit 1
+fi
+echo "OK: no disallowed deletions (orphan recordings, assessment.json, and renames are permitted)."
+OLD
+run_body "$TMP/predecessor-ortrue.sh" "$BASE_SHA" "$HEAD_SHA" fail ""
+if [[ "$ST" -eq 0 ]]; then
+  pass "the old capture still exits 0 when git FAILS — the hazard is real"
+else
+  fail "the old \`|| true\` capture exits 0 when git fails (the hazard this pins)" \
+       "exit 0" "exit $ST — the hazard is GONE, so re-derive the fix rather than trusting it :: $(flat "$OUT")"
+fi
+want_contains "...printing its own pass line over a git that fatally failed" \
+  "OK: no disallowed deletions" "$OUT"
+
+# ---------------------------------------------------------------------------
+# Obligation 1b — the empty-context hazard, measured against REAL git.
+#
+# `on: workflow_dispatch` has no `github.event.pull_request`, so both `${{ }}`
+# expressions expand to the empty string and the diff becomes `git diff "..."`.
+# This is not stubbed: a claim about how git parses `...` has to be made by git.
+echo ""
+echo "== the pre-#1645 empty pull_request context, against real git =="
+EMPTYREPO="$TMP/emptyctx"
+mkdir -p "$EMPTYREPO/replaydata/agents"
+echo '{}' >"$EMPTYREPO/replaydata/agents/scenarios.json"
+if ! ( cd "$EMPTYREPO" \
+       && git -c init.defaultBranch=main init -q . \
+       && git -c user.email=t@example.com -c user.name=t add -A \
+       && git -c user.email=t@example.com -c user.name=t commit -qm init ) >/dev/null 2>&1; then
+  fail "a throwaway repo could be built for the empty-context measurement" \
+       "an initialised repo" "git init/commit failed — the measurement could not run"
+else
+  e_base=""; e_head=""
+  e_out=$( cd "$EMPTYREPO" && git diff --name-only --diff-filter=D --find-renames=50% "$e_base...$e_head" -- 'replaydata/**' 2>&1 )
+  e_st=$?
+  if [[ "$e_st" -eq 0 && -z "$e_out" ]]; then
+    pass "real git reads \`...\` as HEAD...HEAD: exit 0, no output — so the pre-fix step PASSED on workflow_dispatch"
+  else
+    fail "real git answers an empty base...head with a silent success (the hazard this pins)" \
+         "exit 0 and no output" "exit $e_st :: $(flat "$e_out") — the hazard is GONE, so re-derive the refusal rather than trusting it"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Obligations 2-6 — the REAL step, extracted from the REAL workflow and run.
+echo ""
+echo "== $WF: $STEP =="
+
+if [[ ! -f "$WF" ]]; then
+  fail "$WF is readable" "the workflow file" "not found — the step check could not run"
+else
+  # Extract the named step's `run: |` body and dedent it. Keyed on the step
+  # NAME, so a body that moved within the file is still found and a step that
+  # was renamed is a loud refusal rather than a silent zero-line body.
+  awk -v want="$STEP" '
+    !inblock && $0 ~ /^[[:space:]]*-[[:space:]]+name:[[:space:]]*/ {
+      n = $0; sub(/^[[:space:]]*-[[:space:]]+name:[[:space:]]*/, "", n)
+      gsub(/^["'"'"']|["'"'"']$/, "", n)
+      cur = (n == want)
+      next
+    }
+    !inblock && cur && $0 ~ /^[[:space:]]*run:[[:space:]]*\|[[:space:]]*$/ {
+      inblock = 1; ind = match($0, /[^ ]/); next
+    }
+    inblock {
+      if ($0 ~ /^[[:space:]]*$/) { print ""; next }
+      if (match($0, /[^ ]/) <= ind) { inblock = 0; cur = 0; next }
+      print substr($0, ind + 2)
+    }
+  ' "$WF" >"$TMP/step-body-raw.sh"
+
+  # The extraction has to have found something. A scan that silently stopped
+  # matching reads exactly like a workflow with no hazard in it, and every arm
+  # below would then grade an empty file — which exits 0 and looks like a clean
+  # PR. The floor is far below the body's real size: the point is to catch a
+  # scan that returned nothing or a fragment, not to pin a line count.
+  lines=$(grep -cve '^[[:space:]]*$' "$TMP/step-body-raw.sh")
+  if [[ "${lines:-0}" -lt 30 ]]; then
+    fail "the '$STEP' step body was extracted from $WF" \
+         "at least 30 non-blank lines" "$lines — the scan has gone blind, not the step clean"
+  else
+    pass "extracted the '$STEP' step body from $WF ($lines non-blank lines)"
+
+    # ...and the WHOLE step, not just its head. The classification loop and the
+    # pass line live at the far end of the block; an extractor that stopped at
+    # the first dedent would still clear the line floor above.
+    body_raw=$(cat "$TMP/step-body-raw.sh")
+    want_contains "...through to the classification loop" 'violations=' "$body_raw"
+    want_contains "...and through to the step's own pass line" 'OK: examined' "$body_raw"
+
+    # Substitute the two workflow expressions the runner would have expanded.
+    # Nothing else is touched — this is the real body.
+    sed -e 's|\${{ github\.event\.pull_request\.base\.sha }}|$STUB_BASE|g' \
+        -e 's|\${{ github\.event\.pull_request\.head\.sha }}|$STUB_HEAD|g' \
+        "$TMP/step-body-raw.sh" >"$TMP/step-body.sh"
+    body=$(cat "$TMP/step-body.sh")
+    want_contains "the base expression was substituted" 'base="$STUB_BASE"' "$body"
+    want_contains "the head expression was substituted" 'head="$STUB_HEAD"' "$body"
+    # If an expression were respelled, the sed would match nothing and the body
+    # would still carry `${{`, which bash rejects as a bad substitution — a
+    # confusing failure attributed to the wrong thing. Name it here instead.
+    want_absent "...leaving no unexpanded \${{ }} expression behind" '${{' "$body"
+
+    # -- Obligation 2: every kind of disallowed deletion still FAILS. --------
+    echo ""
+    echo "-- disallowed deletions still fail (the vacuity guard) --"
+    for probe in \
+      "replaydata/agents/scenarios.json|(matrix catalog)" \
+      "replaydata/orchestrators/gastown/scenarios/1-1.json|(orchestrator scenario fixture)" \
+      "replaydata/agents/claudecode/regressions/8-8_frozen/assessment.json|(regression recording)" \
+      "$LIVE/metadata.json|(metadata.json of live cell" \
+      "$LIVE/recordings/r1/events.jsonl|(recording of live cell" \
+      "$LIVE/subagents/s1.jsonl|(recording of live cell"
+    do
+      path=${probe%%|*}; note=${probe#*|}
+      run_body "$TMP/step-body.sh" "$BASE_SHA" "$HEAD_SHA" ok "$path"
+      want_status "deleting $path fails the gate" 1 "$ST" "$OUT"
+      want_contains "...as a workflow error annotation" "::error::PR deletes load-bearing replaydata" "$OUT"
+      want_contains "...naming it: $note" "$note" "$OUT"
+    done
+
+    # -- Obligation 3: a clean diff still passes. ---------------------------
+    echo ""
+    echo "-- a clean diff still passes --"
+    run_body "$TMP/step-body.sh" "$BASE_SHA" "$HEAD_SHA" ok ""
+    want_status "no deletions at all" 0 "$ST" "$OUT"
+    want_contains "...and says so, with the count it examined" "OK: examined 0 deleted path(s)" "$OUT"
+    # The anti-blindness guard: a pass obtained by never diffing is this
+    # issue's own shape. The stub records every diff it was asked for.
+    want_contains "...having ACTUALLY run the diff" "git diff" "$ARGV"
+
+    # What the step asked git for, read off the invocation it actually made
+    # rather than off the source. Three-dot keeps stale branches from showing
+    # phantom deletions; the pathspec is what scopes the gate; --diff-filter=D
+    # is what makes the output deletions at all.
+    want_contains "...as a three-dot base...head diff" "$BASE_SHA...$HEAD_SHA" "$ARGV"
+    want_contains "...restricted to replaydata/**" "replaydata/**" "$ARGV"
+    want_contains "...filtered to deletions" "--diff-filter=D" "$ARGV"
+    want_contains "...still asking for rename detection at the documented threshold" "--find-renames=50%" "$ARGV"
+
+    # -- Obligation 4: a git that FAILS is a refusal, not a pass. -----------
+    echo ""
+    echo "-- a git that fails is now a REFUSAL --"
+    run_body "$TMP/step-body.sh" "$BASE_SHA" "$HEAD_SHA" fail ""
+    want_status "git exits 128 mid-diff" 1 "$ST" "$OUT"
+    want_contains "...as a workflow error annotation, so it surfaces on the run" "::error::" "$OUT"
+    want_contains "...saying the guard examined nothing" "examined NOTHING" "$OUT"
+    want_contains "...and saying that is not a pass" "NOT a pass" "$OUT"
+    # The heart of #1645: the failing path must not be able to print the
+    # passing path's line. Both spellings are refused — the pre-fix one so a
+    # revert cannot pass this arm, and the current one.
+    want_absent "...and NOT the step's pass line (pre-fix spelling)" "OK: no disallowed deletions" "$OUT"
+    want_absent "...and NOT the step's pass line (current spelling)" "OK: examined" "$OUT"
+
+    # -- Obligation 5: the permitted cases still pass. ----------------------
+    echo ""
+    echo "-- the permitted deletions still pass --"
+    for path in \
+      "$ORPHAN/recordings/r1/events.jsonl" \
+      "$ORPHAN/metadata.json" \
+      "$LIVE/assessment.json" \
+      "replaydata/README.md"
+    do
+      run_body "$TMP/step-body.sh" "$BASE_SHA" "$HEAD_SHA" ok "$path"
+      want_status "deleting $path is permitted" 0 "$ST" "$OUT"
+      want_contains "...and it examined the path rather than skipping the diff" "Examined 1 deleted path(s)" "$OUT"
+    done
+
+    # A `git mv`: real git reports it as R, which --diff-filter=D drops. The
+    # stub models that faithfully — it reports the old path as a deletion only
+    # when the invocation does NOT ask for rename detection — so this arm
+    # grades the invocation, and would go red against a step that stopped
+    # asking. See this file's header for what that does and does not prove.
+    run_body "$TMP/step-body.sh" "$BASE_SHA" "$HEAD_SHA" rename "$LIVE/recordings/r1/events.jsonl"
+    want_status "a git mv of a live cell's recording is permitted" 0 "$ST" "$OUT"
+    want_contains "...counted as no deletion at all" "OK: examined 0 deleted path(s)" "$OUT"
+
+    # -- Obligation 6: the two new refusals. -------------------------------
+    echo ""
+    echo "-- an unreadable base/head is a REFUSAL --"
+    run_body "$TMP/step-body.sh" "" "" ok ""
+    want_status "an empty pull_request context (workflow_dispatch)" 1 "$ST" "$OUT"
+    want_contains "...naming the missing context" "no pull_request context" "$OUT"
+    want_absent "...and NOT printing the pass line" "OK: examined" "$OUT"
+    # It must refuse BEFORE diffing, or the refusal is decoration over a
+    # HEAD...HEAD comparison that already happened.
+    want_absent "...without having diffed anything" "git diff" "$ARGV"
+
+    run_body "$TMP/step-body.sh" "$BASE_SHA" "$HEAD_SHA" ok "" "$BASE_SHA"
+    want_status "a base commit this checkout does not have" 1 "$ST" "$OUT"
+    want_contains "...naming which side is missing" "the base commit $BASE_SHA is not present" "$OUT"
+    want_absent "...and NOT printing the pass line" "OK: examined" "$OUT"
+
+    run_body "$TMP/step-body.sh" "$BASE_SHA" "$HEAD_SHA" ok "" "$HEAD_SHA"
+    want_status "a head commit this checkout does not have" 1 "$ST" "$OUT"
+    want_contains "...naming which side is missing" "the head commit $HEAD_SHA is not present" "$OUT"
+    want_absent "...and NOT printing the pass line" "OK: examined" "$OUT"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# ...and preflight's `tools` gate has to FIRE on a diff touching only this
+# workflow, or under --changed (the pre-push hook's path) every assertion above
+# is skipped on precisely the commit that can break it. That is #1591's,
+# #1629's, #1639's and #1641's shape, each fixed by widening this same trigger;
+# this is its fifth widening. The regex is EXTRACTED and matched rather than
+# string-compared, so this is a behavioural assertion and not a lock on one
+# spelling of an alternation.
+echo ""
+echo "== tools/preflight.sh's \`tools\` trigger =="
+PF=tools/preflight.sh
+if [[ ! -f "$PF" ]]; then
+  fail "$PF is readable" "the preflight script" "not found — the trigger check could not run"
+else
+  tools_re=$(grep -a "run_gate_scoped '\^tools/lib/" "$PF" \
+             | sed -E "s/^[[:space:]]*run_gate_scoped '//; s/'[[:space:]]*\\\\?[[:space:]]*$//")
+  if [[ -z "$tools_re" ]]; then
+    fail "the tools-gate trigger regex could be read from $PF" \
+         "one run_gate_scoped line starting ^tools/lib/" "no such line — the scan has gone blind, not the trigger wrong"
+  else
+    pass "read the tools-gate trigger regex from $PF"
+    for probe in "$WF" tools/lib/replaydata-deletion-guard_test.sh; do
+      if printf '%s\n' "$probe" | grep -qE "$tools_re"; then
+        pass "...it fires on a diff touching $probe"
+      else
+        fail "the tools gate fires on a diff touching $probe" "a match" "no match against: $tools_re"
+      fi
+    done
+    # The vacuity guard: a trigger that matched everything would satisfy both
+    # probes above and scope nothing.
+    if printf '%s\n' core/domain/session.go | grep -qE "$tools_re"; then
+      fail "the tools-gate trigger still scopes" "no match for core/domain/session.go" "it matches everything: $tools_re"
+    else
+      pass "...and still does not fire on an unrelated core/ file"
+    fi
+  fi
+fi
+
+echo ""
+if [[ "$rc" -eq 0 ]]; then
+  echo "replaydata-deletion-guard_test: ALL PASS"
+else
+  echo "replaydata-deletion-guard_test: FAILURES" >&2
+fi
+exit "$rc"

--- a/tools/preflight.sh
+++ b/tools/preflight.sh
@@ -449,7 +449,13 @@ if want tools; then
   # and executes it, so the assertion that an exhausted push-retry fails the
   # step lives entirely in this gate — and a commit editing only ars.yml is
   # once again exactly the one that breaks it.
-  run_gate_scoped '^tools/lib/|^tools/[^/]*\.sh$|^tools/git-hooks/|^go\.work$|^\.github/dependabot\.yml$|^site/install\.sh$|^\.github/workflows/(ars|macos-swift|test)\.yml$' \
+  # .github/workflows/replaydata-deletion-guard.yml joins them for the fifth
+  # time (#1645): replaydata-deletion-guard_test.sh EXTRACTS that workflow's
+  # "Detect deletions of load-bearing replaydata" step and executes it, so the
+  # assertion that an unreadable diff REFUSES rather than printing the pass
+  # line lives entirely in this gate. Same story, fifth file: a commit editing
+  # only that workflow is exactly the one that breaks it.
+  run_gate_scoped '^tools/lib/|^tools/[^/]*\.sh$|^tools/git-hooks/|^go\.work$|^\.github/dependabot\.yml$|^site/install\.sh$|^\.github/workflows/(ars|macos-swift|replaydata-deletion-guard|test)\.yml$' \
                   "tools/lib shell-lib tests" shell_lib_tests
 fi
 


### PR DESCRIPTION
Closes #1645

`.github/workflows/replaydata-deletion-guard.yml` is a **merge gate**, and its
inability to look produced its own PASS line. That makes it the most expensive
member of this family: the failure mode is to permit exactly what it exists to
prevent — the #268 deletion of a load-bearing recording.

## The statement that decides the step's status

This block was spot-checked and cleared **twice** while the family was worked
(#1639's agent, then #1641's brief). Both readings were of the classification
`while`/`case` loop, which is genuinely fine — it accumulates into `$violations`
and reports after the loop. The defect is the loop's **input**, one line above
it:

```sh
deletions=$(git diff --name-only --diff-filter=D --find-renames=50% "$base...$head" -- 'replaydata/**' || true)
```

Naming this precisely, because it is what the two clean reads missed:

- **The statement that decides the step's status** is `if [ -n "$violations" ]`.
- **The statements whose failure it cannot see** are every one that feeds
  `$violations`: the `git diff` capture above (`|| true` converts a failure into
  an empty string), and the two `${{ }}` expansions that produce `$base` and
  `$head`. A `case` walk over `$deletions` can only ever be as good as
  `$deletions`, and nothing inside the loop can tell an empty string handed over
  by a *failure* from one handed over by a *clean PR*. Both spellings of "no
  finding" and "could not look" collapse into the same empty variable, and empty
  is the gate's success condition.

## Two hazards, both measured — and which of the two I am fixing

**Hazard 1 (the issue's subject): `|| true`.** Re-measured on every run by the
committed reproduction in the lock (`M1` below shows the same thing as a
mutation of the real step):

```
Comparing merge-base(1111…, 2222…) ...head 2222…
fatal: bad object 1111…
Examined 0 deleted path(s) under replaydata/.
OK: examined 0 deleted path(s), none disallowed (…)
--- MUTANT EXIT=0
```

**Hazard 2 (found while checking base/head resolvability, and it is reachable
today by ordinary means):** the workflow declares `workflow_dispatch:`. A manual
dispatch carries no `github.event.pull_request`, so **both** `${{ }}` expressions
expand to the empty string and the diff becomes `git diff "..."`. Measured
against real git (git 2.50.1), not stubbed, because a claim about how git parses
`...` has to be made by git:

```
== probe: base='' head='' -> the workflow_dispatch expansion ==
status=0
output=[]
```

git reads `...` as `HEAD...HEAD`. Pre-fix, pressing "Run workflow" produced a
**green** run whose log said `OK: no disallowed deletions`, having compared a
commit with itself. That measurement is now committed as the second half of the
lock's obligation 1.

**Base/head resolvability, stated honestly.** The checkout is
`actions/checkout@v7` with `fetch-depth: 0` and `ref: <head sha>`. I found **no
ordinary CI condition** that makes `base.sha` or `head.sha` unfetched — with full
depth, `base.sha` is normally reachable from `refs/heads/main`, and `head.sha` is
the commit the job checked out. So of the three refusals added, two are backed by
a reproduction (`|| true`, empty context) and the third — an object missing from
the checkout — is **defensive and marked as such**: it is not backed by a
reproduction, only by the observation that it is one edit to the checkout step
away (a `fetch-depth` change, a force-pushed or deleted base branch).

## The fix, and why this spelling

Three outcomes now, never two: **found and disallowed** (fail), **no deletions**
(pass), **could not determine** (fail, naming why).

I did not simply drop `|| true` and lean on `set -e`. The step's options are
`set -euo pipefail`, set by the step's own first line (the runner itself gives a
plain `bash -e {0}` — see the note at the end), so a bare drop *would* abort. It
would abort with a line number and nothing else, and the three "cannot look"
cases would still be indistinguishable from each other in the log. Instead each
gets an explicit, named refusal:

```sh
if [ -z "$base" ] || [ -z "$head" ]; then
  echo "::error::deletion guard REFUSED: no pull_request context (…). This is NOT a pass — nothing was examined."
  exit 1
fi

require_commit() { # <label> <sha>
  git rev-parse --verify --quiet "$2^{commit}" >/dev/null && return 0
  echo "::error::deletion guard REFUSED: the $1 commit $2 is not present in this checkout …"
  exit 1
}
require_commit base "$base"
require_commit head "$head"

if ! deletions=$(git diff … "$base...$head" -- 'replaydata/**'); then
  echo "::error::deletion guard REFUSED: git could not diff $base...$head …, so the guard examined NOTHING. This is NOT a pass."
  exit 1
fi
```

`if !` rather than `set -e` for two reasons: errexit is suppressed inside an `if`
condition, so the status is ours to *read*; and the message then names what could
not be done. `&& return 0` in `require_commit` keeps the failing `rev-parse`
inside an `&&` list, where errexit does not apply, so the message reports it
rather than a bare abort.

Plus the count line the issue asked for, so "nothing was deleted" and "nothing
was read" are different **strings** and not only different exit codes:

```
Examined 0 deleted path(s) under replaydata/.
OK: examined 0 deleted path(s), none disallowed (…)
```

**On the two refusals overlapping.** Deleting the empty-context refusal still
leaves the run failing, because an empty sha does not `rev-parse` either
(measured — M2 below reddens exactly one arm, the message one). What that refusal
uniquely buys is the **diagnosis**: "no pull_request context" instead of "the
base commit `` is not present in this checkout", which points at the checkout
rather than at the trigger. Said out loud rather than implied, because an
overlapping guard that nobody knows is overlapping is the next wrong dismissal.

## The lock

`tools/lib/replaydata-deletion-guard_test.sh`, following #1647's shape and its
author's recommendation: **extract the step from the real workflow and execute
it** against a git stub, rather than scan its text. A scan pins one spelling of a
guard; running the block pins the property. It runs on a real runner for free
because `test.yml` discovers `tools/lib/*_test.sh` — the shared runner's census
went from `found 12` to `found 13` with no wiring.

65 assertions. Anti-blindness guards carried over from #1647 and extended:

- a short or failed **extraction** is a NAMED refusal (`0 — the scan has gone
  blind, not the step clean`), plus arms asserting the extraction reached the
  classification loop *and* the pass line, so an extractor that stopped at the
  first dedent cannot clear the line floor;
- an **unmodelled `git` subcommand** in the stub returns a loud, distinctive 99
  naming the call, never a quiet 0;
- the `${{ }}` **substitutions are asserted to have happened**, and that no
  `${{` survived (which bash would reject as a bad substitution, failing for a
  confusing reason);
- the stub **records the argv of every `git diff`**, so a pass obtained by never
  diffing — this issue's own shape one level up — is caught (`having ACTUALLY
  run the diff`).

Two things the lock deliberately does not claim. `cell_is_live` reads the
**working tree**, so every arm runs against a throwaway tree under `$TMP`; the
real deletion-guarded catalog is never read, written or deleted. And `git mv` is
permitted because git's own rename detection reports an `R` that
`--diff-filter=D` drops, **not** because of anything the step does — detection is
on by default in modern git, so `--find-renames=50%` pins the threshold, not the
behaviour. The stub models that faithfully (it reports the old path as a deletion
only when the invocation does *not* ask for rename detection), so that arm grades
the invocation the step makes rather than claiming the step implements renaming.
This is stated in the test's header too.

## Every obligation's RED evidence

Ten deliberate mutations, each applied and reverted in its **own** foreground
call, each followed by `git status --porcelain` returning empty against a
committed baseline (per #1635's incident, no mutation was left on disk).

| # | mutation | obligation reddened | result |
|---|---|---|---|
| M1 | restore `deletions=$(… \|\| true)` | 4 — git that fails | 5 arms red |
| M2 | delete the empty-context refusal | 6a — diagnosis | 1 arm red |
| M3 | delete both `require_commit` calls | 6b — missing commit | 6 arms red |
| M4 | `cell_is_live` always true (over-refuse) | 5 — permitted cases | 2 arms red |
| M5 | `done <<< ""` (permit everything) | 2 — vacuity guard | 18 arms red |
| M6 | rename the step (blind the extractor) | anti-blindness | named refusal |
| M7 | add `git status` to the step | anti-blindness (stub) | exit 99, loud |
| M8 | drop `--find-renames=50%` | 5 — rename | 3 arms red |
| M9 | narrow the preflight `tools` trigger | trigger widening | 1 arm red |
| M10 | replace the diff with an empty literal | 3 — actually diffed | 32 arms red |

Pasted reds, abridged to the load-bearing lines:

**M1 — the defect itself, restored:**
```
  FAIL: git exits 128 mid-diff — expected [exit 1] got [exit 0 :: … fatal: bad object 1111… Examined 0 deleted path(s) … OK: examined 0 deleted path(s), none disallowed …]
  FAIL: ...saying the guard examined nothing — expected [output containing: examined NOTHING]
  FAIL: ...and NOT the step's pass line (current spelling) — expected [no output containing: OK: examined]
```

**M2 — the empty-context refusal, deleted (note: only the message arm reddens):**
```
  FAIL: ...naming the missing context — expected [output containing: no pull_request context]
        got [… ::error::deletion guard REFUSED: the base commit  is not present in this checkout …]
```

**M3 — `require_commit` calls deleted:**
```
  FAIL: a base commit this checkout does not have — expected [exit 1] got [exit 0 :: … OK: examined 0 deleted path(s), none disallowed …]
  FAIL: a head commit this checkout does not have — expected [exit 1] got [exit 0 :: …]
```

**M4 — the gate over-refuses (the arm that stops a fix nobody would keep):**
```
  FAIL: deleting …/scenarios/9-9_orphan/recordings/r1/events.jsonl is permitted — expected [exit 0]
        got [exit 1 :: … - …/9-9_orphan/recordings/r1/events.jsonl  (recording of live cell 'claudecode/9-9_orphan')]
  FAIL: deleting …/scenarios/9-9_orphan/metadata.json is permitted — expected [exit 0] got [exit 1 :: …]
```

**M5 — the gate permits everything (the vacuity guard; 18 arms, all of obligation 2):**
```
  FAIL: deleting replaydata/agents/scenarios.json fails the gate
  FAIL: deleting replaydata/orchestrators/gastown/scenarios/1-1.json fails the gate
  FAIL: deleting replaydata/agents/claudecode/regressions/8-8_frozen/assessment.json fails the gate
  FAIL: deleting …/scenarios/1-1_live/metadata.json fails the gate
  FAIL: deleting …/scenarios/1-1_live/recordings/r1/events.jsonl fails the gate
  FAIL: deleting …/scenarios/1-1_live/subagents/s1.jsonl fails the gate
  (+ the 12 annotation/naming arms)
```

**M6 — the step renamed:**
```
  FAIL: the '…' step body was extracted from … — expected [at least 30 non-blank lines]
        got [0 — the scan has gone blind, not the step clean]
```

**M7 — an unmodelled `git` subcommand:**
```
  got [exit 99 :: … STUB: unmodelled call: git status --porcelain ]
```

**M8 — rename detection dropped from the invocation:**
```
  FAIL: ...still asking for rename detection at the documented threshold
        got [git diff --name-only --diff-filter=D 1111…...2222… -- replaydata/** ]
  FAIL: a git mv of a live cell's recording is permitted — expected [exit 0] got [exit 1 …]
```

**M9 — the preflight trigger narrowed back:**
```
  FAIL: the tools gate fires on a diff touching .github/workflows/replaydata-deletion-guard.yml
        got [no match against: …|^\.github/workflows/(ars|macos-swift|test)\.yml$]
```

**M10 — the step never diffs at all:**
```
  FAIL: ...having ACTUALLY run the diff — expected [output containing: git diff]
  FAIL: ...as a three-dot base...head diff / ...restricted to replaydata/** / ...filtered to deletions
  (+ all 18 of obligation 2, and obligation 4's arms)
```

Obligation 1 has no mutation of its own by construction: it **is** the pre-fix
code, committed and re-measured on every run. It is the vacuity guard for the
whole file — if bash or git ever stopped behaving that way, every arm below would
be passing for the wrong reason and it says so by name.

## What ran where

**On a real GitHub runner:**

- **The fixed step itself**, dispatched on this branch:
  https://github.com/ingo-eichhorst/Irrlicht/actions/runs/31960152598 — **failure**,
  and that is the *correct* outcome, not a broken build. `workflow_dispatch`
  carries no PR context, which is Hazard 2. The runner log:
  ```
  Comparing merge-base(, ) ...head
  ##[error]deletion guard REFUSED: no pull_request context (base='', head=''), so there is no base...head diff to read. This is NOT a pass — nothing was examined. Run this guard from a pull request.
  ##[error]Process completed with exit code 1.
  ```
  Before this PR that same dispatch printed `OK: no disallowed deletions` and
  went **green**. This is the fix demonstrated on a runner, not locally.
- **The lock**, via `test.yml`'s `tools/lib/*_test.sh` discovery — `test.yml`
  triggers on `pull_request` with no paths filter, so it runs on this PR.

**NOT on a runner, and worth being precise about:** the deletion guard's
`pull_request` trigger is filtered to `paths: ['replaydata/**']`. This PR touches
no `replaydata/` file, so the guard workflow will **not** run as a PR check here.
Everything above about its PR path is from the extracted-and-executed step
locally, plus the `workflow_dispatch` run on the real runner.

**Locally:** all ten mutations, the two hazard measurements, and the gates below.

## Gates

- `tools/preflight.sh --only tools` — **PASS**. `shell-lib-suite: tools/lib —
  found 13, skipped 0 (none), ran 13, failed 0` (12 before this PR).
- `tools/preflight.sh --only skills` — **not run, and not applicable**: no
  `.claude/skills/**/*.md` file is touched by this diff.
- Pre-push hook (`tools/preflight.sh --changed`, budget 420s): POSIX sh lint
  **PASS**, tools/lib shell-lib tests **PASS**, gofmt **PASS**, macOS Swift build
  + test **PASS**; every other gate **SKIP** (this diff cannot reach them).

## A note on the runner's actual shell — measured, and it is not what the family assumes

The dispatched run's log shows the step invoked as:

```
shell: /usr/bin/bash -e {0}
```

That is **errexit only** — no `--noprofile`, no `--norc`, and **no `-o
pipefail`**. `bash --noprofile --norc -eo pipefail {0}` is what `shell: bash`
gives, not what a step declaring no `shell:` gets. This step is unaffected: it
sets `set -euo pipefail` on its own first line, so from line 1 onward it runs
under exactly the options the lock uses. But the same premise is stated as fact
in `tools/lib/ars-badge-push_test.sh`, `tools/lib/shell-lib-suite.sh`,
`.github/workflows/test.yml` and AGENTS.md, for steps that do **not** set their
own options. Filed separately rather than fixed here (the siblings are out of
this PR's scope); I checked each of those call sites for a live dependency on
`pipefail` and found none, so it is a wrong premise rather than a live defect
today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
