### PR TITLE
fix(ci): derive each harness's step invocation instead of asserting the wrong one (#1650)

### DIFF
--- a/.github/workflows/ars.yml
+++ b/.github/workflows/ars.yml
@@ -64,7 +64,9 @@ jobs:
             # failed attempts ended the loop with status 0, and the step, the
             # job and this workflow's check all went GREEN with the badge
             # unpushed. GitHub's implicit `-e` (a step declaring no `shell:`
-            # runs as `bash --noprofile --norc -e -o pipefail {0}`) does not
+            # and no `defaults:` runs as `bash -e {0}` — errexit only, NO
+            # pipefail and no `--noprofile/--norc`, which is what `shell: bash`
+            # gives; measured, run 31960152598) does not
             # save it: errexit is suppressed for every command in an `&&` list
             # except the one after the final `&&`, which is precisely what
             # MAKES this a retry rather than one attempt. That suppression is

--- a/.github/workflows/replaydata-deletion-guard.yml
+++ b/.github/workflows/replaydata-deletion-guard.yml
@@ -53,8 +53,11 @@ jobs:
 
       - name: Detect deletions of load-bearing replaydata
         run: |
+          # `set -euo pipefail` on the step's own first line, deliberately: a
+          # step declaring no `shell:` gets `bash -e {0}` from the runner —
+          # errexit only, NO pipefail (measured, run 31960152598's own step
+          # header) — so nounset and pipefail are this line's to supply.
           set -euo pipefail
-          command -v jq >/dev/null || { sudo apt-get update -qq && sudo apt-get install -y -qq jq; }
           base="${{ github.event.pull_request.base.sha }}"
           head="${{ github.event.pull_request.head.sha }}"
           echo "Comparing merge-base($base, $head) ...head $head"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -102,7 +102,10 @@ jobs:
       # that can disagree. They did disagree, and this was the wrong half
       # (#1639): the loop was written inline here with no `|| rc=1`, and this
       # file declares no `shell:` and no `defaults:`, so it ran under GitHub's
-      # default `bash --noprofile --norc -eo pipefail`. The FIRST failing file
+      # default for such a step — `bash -e {0}`, errexit ONLY (measured, run
+      # 31960152598; `bash --noprofile --norc -eo pipefail` is what a step
+      # DECLARING `shell: bash` gets, and this comment claimed it until
+      # #1650). The FIRST failing file
       # aborted the step, every later file in glob order never ran, and nothing
       # in the log distinguished that from a clean run — one push per red file.
       # The runner prints a census (found / skipped / ran / failed) and refuses

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -963,8 +963,9 @@ Before marking a ticket done, run the full suite — every layer must pass:
   `tools/preflight.sh`'s `tools` gate. Before #1639 those were two copies of
   the same loop that disagreed about the only thing that matters: preflight's
   collected every file's status, CI's had no `|| rc=1` and — test.yml declaring
-  no `shell:` and no `defaults:`, so GitHub's `bash --noprofile --norc -eo
-  pipefail` applies — aborted on the FIRST failing file with every later file
+  no `shell:` and no `defaults:`, so GitHub's `bash -e {0}` applies (errexit
+  only; see "Which bash a workflow step gets" below) — aborted on the FIRST
+  failing file with every later file
   in glob order never run and nothing in the log saying so. One round trip per
   red file, on suites that take seconds each. The sharing follows
   `macos-swift.yml`'s own reason for sharing `swift-suite.sh`: CI and the
@@ -975,7 +976,7 @@ Before marking a ticket done, run the full suite — every layer must pass:
   predecessor. An **empty corpus is a named refusal** (status 2, distinct from
   1) rather than either predecessor's answer, both measured: CI's loop iterated
   once with the literal unexpanded pattern (nullglob is off by default and
-  `-eo pipefail` does not change it) and died with `No such file or directory`,
+  neither invocation changes it) and died with `No such file or directory`,
   while preflight's `[[ -e "$t" ]] || continue` filtered that out and returned
   0, passing silently. And the two callers' one remaining scope difference —
   CI skips `posix-lint_test.sh`, which needs a linter the macos image lacks —
@@ -992,9 +993,11 @@ Before marking a ticket done, run the full suite — every layer must pass:
   wrong reason.
 - The ARS badge push: `tools/lib/ars-badge-push_test.sh` EXTRACTS
   `.github/workflows/ars.yml`'s "Commit badge update" step out of the workflow
-  file and EXECUTES it against a git stub, under
-  `bash --noprofile --norc -e -o pipefail` — GitHub's documented invocation for
-  a step declaring no `shell:`. Behavioural rather than a text scan, because a
+  file and EXECUTES it against a git stub, under the invocation that step
+  actually gets — DERIVED from the workflow, today `bash -e` (see "Which bash a
+  workflow step gets" below; this bullet claimed
+  `bash --noprofile --norc -e -o pipefail` until #1650). Behavioural rather
+  than a text scan, because a
   scan pins one spelling of a guard where running the block pins the property.
   Before #1641 the push-retry loop's last statement was `sleep`, which
   succeeds, so five failed attempts ended the loop — and the step, the job and
@@ -1031,8 +1034,9 @@ Before marking a ticket done, run the full suite — every layer must pass:
   `tools/lib/replaydata-deletion-guard_test.sh` does to
   `.github/workflows/replaydata-deletion-guard.yml`'s "Detect deletions of
   load-bearing replaydata" step what the bullet above does to ars.yml —
-  extracts it and EXECUTES it against a git stub, under the same
-  `bash --noprofile --norc -e -o pipefail`. It is the same family's most
+  extracts it and EXECUTES it against a git stub, under the same derived
+  invocation (`bash -e` for that step, which is why the step supplies its own
+  `set -euo pipefail` on line 1). It is the same family's most
   expensive member, because that workflow is a **merge gate**: before #1645 its
   diff was captured as `deletions=$(git diff … || true)`, and an empty
   `$deletions` is the gate's SUCCESS condition — so a git exiting 128 produced
@@ -1071,6 +1075,54 @@ Before marking a ticket done, run the full suite — every layer must pass:
   step makes rather than claiming the step implements renaming.
   `preflight.sh`'s `tools` trigger gains this workflow, its fifth widening for
   this reason (#1591, #1629, #1639, #1641).
+- Which bash a workflow step gets: **there are two invocations and this repo
+  conflated them** for the whole of the two bullets above (#1650). A step
+  DECLARING `shell: bash` runs as `bash --noprofile --norc -e -o pipefail {0}`;
+  a step declaring no `shell:` and no `defaults:` runs as **`bash -e {0}`** —
+  errexit only, no `--noprofile`, no `--norc` and **no pipefail**. That is
+  measured off a runner rather than read off the docs: run 31960152598's own
+  group header for `replaydata-deletion-guard.yml`'s step reads
+  `shell: /usr/bin/bash -e {0}`. Of this repo's workflows only
+  `macos-swift.yml` declares `shell: bash` (on two steps; its job-level
+  `defaults:` sets `working-directory` and no shell), so every other step is on
+  the `bash -e` side.
+  **The direction of the error is what made it worth a library rather than a
+  comment fix.** Four harnesses extracted a step body and ran it under the
+  pipefail spelling, each saying in its own header that running it under
+  anything else "would grade a different program" — which was true, and was
+  what they were doing. A body whose correctness depends on pipefail
+  (`x=$(thing | grep -v skip)`) is graded SAFE by a harness that supplies it and
+  swallows the failure in production: a false green, the same "absence of a
+  finding and inability to look produce the same output" shape as the rest of
+  this section. (Under `shell: bash` the error reverses and is loud.)
+  So the invocation is **derived, not typed**: `tools/lib/workflow-step.sh`
+  answers `workflow_step_shell <workflow> <step>` and `workflow_step_body`
+  off the same one-pass scan, so a harness cannot grade one step's body under
+  another step's shell, and a step that later gains `shell: bash` — or whose
+  job or workflow gains a `defaults: { run: { shell: … } }` — moves its harness
+  with it. It REFUSES (status 2, naming what it could not do) for an unreadable
+  file, an absent step, a DUPLICATE step name, an unmodelled `shell:` value and
+  a step with no `run: |` block, and never falls back to a default: a harness
+  handed a plausible `bash -e` for a step that no longer exists would grade an
+  empty body, which exits 0 and reads as a clean run. Its tests are
+  `tools/lib/workflow-step_test.sh` over the committed corpus
+  `tools/lib/testdata/workflow-step/` (one fixture per declaration shape, plus
+  the refusals), and three of its obligations are the ones to keep: the two
+  invocations are shown to grade the SAME body differently (without that,
+  deriving is ceremony and a derivation stuck on one answer looks correct); a
+  copy of a real workflow is mutated BOTH ways, since a derivation hard-wired
+  to either answer passes one direction; and the five real harnessed steps are
+  resolved through the same code, which is what stops
+  `swift-suite_test.sh`'s hand-written `shell: bash` spelling — correct, and
+  left alone — from silently stopping to match.
+  Verified while fixing it, per "dismissals carry evidence": **no live pipefail
+  dependency existed** anywhere in `.github/workflows/`. All 16 pipeline-
+  carrying lines were read — ars.yml's two are `$(… | head -1 || echo "")` and
+  its `sed "s|…|…|"` is a delimiter not a pipe; the deletion guard sets its own
+  `set -euo pipefail`; macos-swift.yml is on the `shell: bash` side already;
+  test.yml's is inside an `echo` message; and codescene-badge.yml's
+  `SCORE=$(… | jq -r …)` and coverage.yml's `pct=$(…)` are each followed
+  immediately by an explicit emptiness guard that does the work pipefail would.
 - Factory: `go test ./tools/onboarding-factory/... -race -count=1`.
 - Replay: `tools/replay-fixtures.sh` — gated in CI by linux.yml, and run
   natively as `tools/preflight.sh`'s `replay fixtures` gate, so golden drift

--- a/tools/lib/ars-badge-push_test.sh
+++ b/tools/lib/ars-badge-push_test.sh
@@ -63,10 +63,17 @@ need() { command -v "$1" >/dev/null 2>&1 || { echo "FAIL: ars-badge-push_test �
 need git
 need mktemp
 need awk
+need sed
+need grep
 need bash
 
 WF=.github/workflows/ars.yml
 STEP='Commit badge update'
+
+# The step's body AND the shell it runs under both come from the workflow file,
+# through tools/lib/workflow-step.sh — see the invocation block below.
+# shellcheck source=workflow-step.sh
+. tools/lib/workflow-step.sh
 
 TMP=$(mktemp -d -t ars-badge-push) || exit 1
 trap 'rm -rf "$TMP"' EXIT
@@ -90,12 +97,30 @@ want_absent() { # label needle haystack
 }
 
 # ---------------------------------------------------------------------------
-# The harness: stubs, then a body, run under the shell GitHub gives a step.
+# The invocation, DERIVED from the workflow rather than spelled here (#1650).
 #
-# GitHub invokes a step declaring no `shell:` as
-# `bash --noprofile --norc -e -o pipefail {0}`. `-e` is what makes the
-# suppression inside the `&&` list observable at all, so running these bodies
-# under anything else would grade a different program.
+# GitHub has two bash invocations and this file used to state the wrong one as
+# fact: a step DECLARING `shell: bash` gets
+# `bash --noprofile --norc -e -o pipefail {0}`, but a step declaring nothing —
+# which is what ars.yml's steps do — gets `bash -e {0}`. No `--noprofile`, no
+# `--norc`, and **no pipefail**; measured off run 31960152598's own step header.
+# `-e` is what makes the errexit suppression inside the `&&` list observable at
+# all and is present either way, so this file's obligations are unaffected —
+# but supplying pipefail to a body production runs without is a FALSE GREEN in
+# the direction that matters: a pipeline whose left-hand command fails is
+# graded as an abort here and swallowed in CI. So the invocation is read out of
+# the workflow, and a step that later gains `shell: bash` moves this harness
+# with it. workflow-step.sh REFUSES rather than defaulting when it cannot find
+# the step, which is why this is a hard exit and not a fallback.
+if ! STEP_SHELL=$(workflow_step_shell "$WF" "$STEP"); then
+  echo "FAIL: ars-badge-push_test — could not derive the shell $WF gives '$STEP' (refusal above); nothing below would have graded the real program" >&2
+  exit 1
+fi
+read -r -a STEP_ARGV <<<"$STEP_SHELL"
+echo "== $WF :: '$STEP' runs under \`$STEP_SHELL\` (derived) =="
+
+# ---------------------------------------------------------------------------
+# The harness: stubs, then a body, run under that shell.
 #
 # `git` and `sleep` are shell FUNCTIONS rather than PATH shims so the body's
 # own lines survive byte-for-byte — in particular `sleep $((i * 3))`, which
@@ -134,7 +159,7 @@ run_body() {
   # outcome of half the arms below — is data, not an abort. Toggling errexit
   # here would leave it ON for the rest of the file, which is the
   # option-you-cannot-see family the sibling issues (#1633, #1635) are made of.
-  OUT=$(bash --noprofile --norc -e -o pipefail "$script" 2>&1)
+  OUT=$("${STEP_ARGV[@]}" "$script" 2>&1)
   ST=$?
   return 0
 }
@@ -171,25 +196,16 @@ echo "== $WF: $STEP =="
 if [[ ! -f "$WF" ]]; then
   fail "$WF is readable" "the workflow file" "not found — the step check could not run"
 else
-  # Extract the named step's `run: |` body and dedent it. Keyed on the step
-  # NAME, so a body that moved within the file is still found and a step that
-  # was renamed is a loud refusal rather than a silent zero-line body.
-  awk -v want="$STEP" '
-    !inblock && $0 ~ /^[[:space:]]*-[[:space:]]+name:[[:space:]]*/ {
-      n = $0; sub(/^[[:space:]]*-[[:space:]]+name:[[:space:]]*/, "", n)
-      gsub(/^["'"'"']|["'"'"']$/, "", n)
-      cur = (n == want)
-      next
-    }
-    !inblock && cur && $0 ~ /^[[:space:]]*run:[[:space:]]*\|[[:space:]]*$/ {
-      inblock = 1; ind = match($0, /[^ ]/); next
-    }
-    inblock {
-      if ($0 ~ /^[[:space:]]*$/) { print ""; next }
-      if (match($0, /[^ ]/) <= ind) { inblock = 0; cur = 0; next }
-      print substr($0, ind + 2)
-    }
-  ' "$WF" >"$TMP/step-body.sh"
+  # Extract the named step's `run: |` body and dedent it — through the same
+  # library that derived the invocation above, so the shell this file grades
+  # under and the body it grades cannot come from two different steps. Keyed on
+  # the step NAME, so a body that moved within the file is still found and a
+  # step that was renamed is a loud refusal rather than a silent zero-line body.
+  if ! workflow_step_body "$WF" "$STEP" >"$TMP/step-body.sh"; then
+    fail "the '$STEP' step body was extracted from $WF" \
+         "the step's run: | body" "workflow-step refused (above) — the scan has gone blind, not the step clean"
+    : >"$TMP/step-body.sh"
+  fi
 
   # The extraction has to have found something. A scan that silently stopped
   # matching reads exactly like a workflow with no hazard in it, and every

--- a/tools/lib/replaydata-deletion-guard_test.sh
+++ b/tools/lib/replaydata-deletion-guard_test.sh
@@ -75,9 +75,15 @@ need awk
 need sed
 need bash
 need wc
+need grep
 
 WF=.github/workflows/replaydata-deletion-guard.yml
 STEP='Detect deletions of load-bearing replaydata'
+
+# The step's body AND the shell it runs under both come from the workflow file,
+# through tools/lib/workflow-step.sh — see the invocation block below.
+# shellcheck source=workflow-step.sh
+. tools/lib/workflow-step.sh
 
 TMP=$(mktemp -d -t replaydata-deletion-guard) || exit 1
 trap 'rm -rf "$TMP"' EXIT
@@ -121,24 +127,39 @@ LIVE=replaydata/agents/claudecode/scenarios/1-1_live
 ORPHAN=replaydata/agents/claudecode/scenarios/9-9_orphan
 
 # ---------------------------------------------------------------------------
-# The harness: stubs, then a body, run under the shell GitHub gives a step.
+# The invocation, DERIVED from the workflow rather than spelled here (#1650).
 #
-# GitHub invokes a step declaring no `shell:` as
-# `bash --noprofile --norc -e -o pipefail {0}`. Running these bodies under
-# anything else would grade a different program — the whole `|| true` question
-# is about what errexit does and does not reach.
+# GitHub has two bash invocations and this file used to state the wrong one as
+# fact: a step DECLARING `shell: bash` gets
+# `bash --noprofile --norc -e -o pipefail {0}`, but a step declaring nothing —
+# which is what this workflow's step does — gets `bash -e {0}`. No
+# `--noprofile`, no `--norc`, and **no pipefail**; measured off run
+# 31960152598's own header for THIS step:
 #
-# `git` and `jq` are shell FUNCTIONS rather than PATH shims so the body's own
-# lines survive byte-for-byte. `command -v` finds functions, which is what
-# neutralises the step's `command -v jq || sudo apt-get install …` line without
-# editing it; `sudo` is stubbed to a loud 99 so that if the jq shim ever stops
-# matching, this file fails noisily instead of quietly shelling out to apt-get
-# on whatever machine it is running on.
+#     guard  Detect deletions of load-bearing replaydata   shell: /usr/bin/bash -e {0}
 #
-# An unmodelled git subcommand returns a loud, distinctive 99 naming the call
-# instead of a quiet 0: a stub that silently answered "fine" to something it
-# does not model would make every arm below pass for a reason unrelated to its
-# obligation.
+# The step sets `set -euo pipefail` on its own first line, so what it actually
+# runs with is unchanged either way — but the harness must not be the thing
+# that supplies it, because then a step that dropped that line would still be
+# graded under pipefail here and swallow a mid-pipeline failure in CI. Reading
+# the invocation out of the workflow is what keeps the two in step;
+# workflow-step.sh REFUSES rather than defaulting when it cannot find the step,
+# which is why this is a hard exit and not a fallback.
+if ! STEP_SHELL=$(workflow_step_shell "$WF" "$STEP"); then
+  echo "FAIL: replaydata-deletion-guard_test — could not derive the shell $WF gives '$STEP' (refusal above); nothing below would have graded the real program" >&2
+  exit 1
+fi
+read -r -a STEP_ARGV <<<"$STEP_SHELL"
+echo "== $WF :: '$STEP' runs under \`$STEP_SHELL\` (derived) =="
+
+# ---------------------------------------------------------------------------
+# The harness: stubs, then a body, run under that shell.
+#
+# `git` is a shell FUNCTION rather than a PATH shim so the body's own lines
+# survive byte-for-byte. An unmodelled git subcommand returns a loud,
+# distinctive 99 naming the call instead of a quiet 0: a stub that silently
+# answered "fine" to something it does not model would make every arm below
+# pass for a reason unrelated to its obligation.
 #
 # STUB_ARGV_FILE records the argv of every `git diff` the body performs, so an
 # arm can assert the step ACTUALLY DIFFED rather than exited before looking —
@@ -152,8 +173,6 @@ STUB_DIFF_MODE='$3'
 STUB_DELETIONS='$4'
 STUB_MISSING=' $5 '
 STUB_ARGV_FILE='$TMP/git-diff-argv'
-jq() { :; }
-sudo() { echo "STUB: unmodelled call: sudo \$*" >&2; return 99; }
 git() {
   case "\$1" in
     rev-parse)
@@ -202,7 +221,7 @@ run_body() {
   # half the arms below — is data, not an abort. Toggling errexit here would
   # leave it on for the rest of the file, which is the option-you-cannot-see
   # family the sibling issues (#1633, #1635) are made of.
-  OUT=$(cd "$CHECKOUT" && bash --noprofile --norc -e -o pipefail "$script" 2>&1)
+  OUT=$(cd "$CHECKOUT" && "${STEP_ARGV[@]}" "$script" 2>&1)
   ST=$?
   ARGV=$(cat "$TMP/git-diff-argv" 2>/dev/null || true)
   return 0
@@ -286,25 +305,16 @@ echo "== $WF: $STEP =="
 if [[ ! -f "$WF" ]]; then
   fail "$WF is readable" "the workflow file" "not found — the step check could not run"
 else
-  # Extract the named step's `run: |` body and dedent it. Keyed on the step
-  # NAME, so a body that moved within the file is still found and a step that
-  # was renamed is a loud refusal rather than a silent zero-line body.
-  awk -v want="$STEP" '
-    !inblock && $0 ~ /^[[:space:]]*-[[:space:]]+name:[[:space:]]*/ {
-      n = $0; sub(/^[[:space:]]*-[[:space:]]+name:[[:space:]]*/, "", n)
-      gsub(/^["'"'"']|["'"'"']$/, "", n)
-      cur = (n == want)
-      next
-    }
-    !inblock && cur && $0 ~ /^[[:space:]]*run:[[:space:]]*\|[[:space:]]*$/ {
-      inblock = 1; ind = match($0, /[^ ]/); next
-    }
-    inblock {
-      if ($0 ~ /^[[:space:]]*$/) { print ""; next }
-      if (match($0, /[^ ]/) <= ind) { inblock = 0; cur = 0; next }
-      print substr($0, ind + 2)
-    }
-  ' "$WF" >"$TMP/step-body-raw.sh"
+  # Extract the named step's `run: |` body and dedent it — through the same
+  # library that derived the invocation above, so the shell this file grades
+  # under and the body it grades cannot come from two different steps. Keyed on
+  # the step NAME, so a body that moved within the file is still found and a
+  # step that was renamed is a loud refusal rather than a silent zero-line body.
+  if ! workflow_step_body "$WF" "$STEP" >"$TMP/step-body-raw.sh"; then
+    fail "the '$STEP' step body was extracted from $WF" \
+         "the step's run: | body" "workflow-step refused (above) — the scan has gone blind, not the step clean"
+    : >"$TMP/step-body-raw.sh"
+  fi
 
   # The extraction has to have found something. A scan that silently stopped
   # matching reads exactly like a workflow with no hazard in it, and every arm

--- a/tools/lib/shell-lib-errexit_test.sh
+++ b/tools/lib/shell-lib-errexit_test.sh
@@ -213,7 +213,19 @@ tw_bijection() {
 # The two obligations
 #
 # Both build an inner script and run it under `bash --noprofile --norc -e -o
-# pipefail`, which is GitHub's own `shell: bash` invocation. `: > "$TW_REACHED"`
+# pipefail`. That is GitHub's `shell: bash` invocation, and it is chosen here as
+# the STRICTEST caller any of these libraries has rather than as "the" step
+# shell: these files are sourced from three places with three different option
+# sets — macos-swift.yml's two steps (`shell: bash`, so exactly this),
+# test.yml's step (no `shell:`, so `bash -e` — errexit only, no pipefail; that
+# is #1650's correction, and this file used to imply the two were the same) and
+# tools/preflight.sh (`set -uo pipefail`, no `-e` at all). The obligations here
+# are about what `-e` does to a callee, and `-e` is in all three; the extra
+# `pipefail` can only make a callee's own pipeline abort EARLIER, so the error
+# runs toward a false accusation (loud) rather than a false pass (silent).
+# A harness EXECUTING one named step's body derives its invocation instead —
+# see tools/lib/workflow-step.sh — because there the direction reverses.
+# `: > "$TW_REACHED"`
 # is emitted immediately before the call, so an inner shell that died in its
 # setup (a bad path, a source that failed) is reported as a probe that could
 # not run rather than as the defect — those exit 1 too, which is byte-identical
@@ -354,6 +366,37 @@ row 'shell-lib-suite.sh::shell_lib_suite_run' 'shell_lib_suite_run (a corpus tha
 row 'shell-lib-suite.sh::shell_lib_suite_run' 'shell_lib_suite_run (refuses an empty corpus)' 2 \
     '. tools/lib/shell-lib-suite.sh; mkdir -p "$TW_TMP/suite-empty"' \
     'shell_lib_suite_run "$TW_TMP/suite-empty" >/dev/null 2>&1'
+
+# Driven against the committed fixture corpus rather than against a real
+# workflow: these rows grade what the functions do to their CALLER under -e,
+# and a fixture cannot be edited out from under them by an unrelated workflow
+# change. Both statuses are distinctive — 0 for an answer, 2 for a refusal —
+# so neither can be confused with an errexit abort, and the refusal rows are
+# the load-bearing half here: refusing rather than defaulting is the whole
+# contract (#1650), and a refusal that aborted its caller would take the
+# harness down instead of being reported.
+WS_DATA=tools/lib/testdata/workflow-step
+row 'workflow-step.sh::workflow_step_shell' 'workflow_step_shell (a step declaring no shell:)' 0 \
+    ". tools/lib/workflow-step.sh" \
+    "workflow_step_shell $WS_DATA/no-shell.yml 'Plain step' >/dev/null"
+row 'workflow-step.sh::workflow_step_shell' 'workflow_step_shell (refuses a step it cannot find)' 2 \
+    ". tools/lib/workflow-step.sh" \
+    "workflow_step_shell $WS_DATA/no-shell.yml 'No such step' >/dev/null 2>&1"
+row 'workflow-step.sh::workflow_step_body' 'workflow_step_body (a step with a run: | block)' 0 \
+    ". tools/lib/workflow-step.sh" \
+    "workflow_step_body $WS_DATA/no-shell.yml 'Plain step' >/dev/null"
+row 'workflow-step.sh::workflow_step_body' 'workflow_step_body (refuses a uses: step)' 2 \
+    ". tools/lib/workflow-step.sh" \
+    "workflow_step_body $WS_DATA/no-run-block.yml 'Uses step' >/dev/null 2>&1"
+row 'workflow-step.sh::_workflow_step_record' '_workflow_step_record (refuses an unreadable file)' 2 \
+    ". tools/lib/workflow-step.sh" \
+    "_workflow_step_record $WS_DATA/no-such-file.yml 'Plain step' >/dev/null 2>&1"
+row 'workflow-step.sh::_workflow_step_scan' '_workflow_step_scan' 0 \
+    ". tools/lib/workflow-step.sh" \
+    "_workflow_step_scan $WS_DATA/no-shell.yml 'Plain step' >/dev/null"
+row 'workflow-step.sh::_workflow_step_field' '_workflow_step_field' 0 \
+    '. tools/lib/workflow-step.sh' \
+    '_workflow_step_field "matches 1" matches >/dev/null'
 
 row 'swift-suite.sh::swift_suite_completed' 'swift_suite_completed' 0 \
     '. tools/lib/swift-suite.sh' \

--- a/tools/lib/shell-lib-suite.sh
+++ b/tools/lib/shell-lib-suite.sh
@@ -35,8 +35,11 @@
 #     done
 #
 # with no `|| rc=1`. That file declares no `shell:` and no `defaults:`, so the
-# step runs under GitHub's documented default, `bash --noprofile --norc -eo
-# pipefail`. The FIRST failing file aborted the step; every later file in glob
+# step runs under GitHub's documented default for such a step, `bash -e {0}` —
+# errexit ONLY, no pipefail (measured off run 31960152598's own step header;
+# `bash --noprofile --norc -eo pipefail` is what `shell: bash` gives, and this
+# comment claimed it until #1650). The FIRST failing file aborted the step,
+# which `-e` alone is enough to do; every later file in glob
 # order never ran, and NOTHING in the log said so — the output simply ended
 # after that file's own `== header ==`. Measured, three fixtures with the first
 # and the last failing: only the first one's header and body appear, and the
@@ -65,7 +68,8 @@
 # measured rather than reasoned about:
 #
 #   test.yml's      `for t in dir/*_test.sh` with nullglob OFF (bash's default,
-#                   and GitHub's `-eo pipefail` does not change it) iterates
+#                   and neither GitHub's `-e` nor `shell: bash`'s added
+#                   `-o pipefail` changes it) iterates
 #                   ONCE with the literal unexpanded pattern, so the step died
 #                   with `bash: dir/*_test.sh: No such file or directory` and
 #                   exit 127 — non-zero, but reading as a missing file rather
@@ -111,7 +115,9 @@ shell_lib_suite_run() {
   fi
 
   # `[ -e ]` rather than a bare glob expansion: with nullglob OFF (the default,
-  # and what GitHub's `bash --noprofile --norc -eo pipefail` runs with) an empty
+  # and what both of GitHub's invocations — `bash -e` for a step declaring
+  # nothing, `bash --noprofile --norc -e -o pipefail` for `shell: bash` — run
+  # with) an empty
   # directory yields the literal pattern, and with nullglob ON it yields
   # nothing. Both land on `found == 0` below, so the refusal does not depend on
   # a shell option the caller may or may not have set.

--- a/tools/lib/shell-lib-suite_test.sh
+++ b/tools/lib/shell-lib-suite_test.sh
@@ -6,10 +6,12 @@
 # ---------------------------------------------------------------------------
 # What is being asserted, and why each obligation exists
 #
-# The defect was a loop with no `|| rc=1` running under GitHub's default
-# `bash --noprofile --norc -eo pipefail`: the first failing file aborted the
-# step and every later file never ran, with nothing in the log distinguishing
-# that from a clean run. So the obligations are, in order:
+# The defect was a loop with no `|| rc=1` running under GitHub's default for a
+# step declaring no `shell:` — `bash -e {0}`, errexit only (#1650; this file
+# used to say `bash --noprofile --norc -eo pipefail`, which is what
+# `shell: bash` gives): the first failing file aborted the step and every later
+# file never ran, with nothing in the log distinguishing that from a clean run.
+# So the obligations are, in order:
 #
 #   1. an EARLY failure and a LATE failure are BOTH reported. A fix that only
 #      collects the status of the last file, or that reports "1 failed" when
@@ -55,6 +57,32 @@ need grep
 
 LIB=tools/lib/shell-lib-suite.sh
 [[ -f "$LIB" ]] || { echo "FAIL: shell-lib-suite_test — $LIB not found" >&2; exit 1; }
+
+WF=.github/workflows/test.yml
+STEP='Test the shared shell libs'
+
+# shellcheck source=workflow-step.sh
+. tools/lib/workflow-step.sh
+
+# The invocation, DERIVED from the workflow rather than spelled here (#1650).
+#
+# Everything below models test.yml's step, so it has to run under the shell
+# that step really gets. GitHub has two bash invocations and this file used to
+# state the wrong one: `bash --noprofile --norc -eo pipefail` is what a step
+# DECLARING `shell: bash` gets, while test.yml declares neither `shell:` nor
+# `defaults:` and so gets `bash -e {0}` — errexit only, no pipefail (measured,
+# run 31960152598's own step header). `-e` is the option every obligation here
+# turns on and it is present either way, so the verdicts do not move; what
+# moves is what this file would grade if the step ever grew a pipeline, since
+# supplying pipefail to a body production runs without reports it safe while
+# production swallows the failure. workflow-step.sh REFUSES rather than
+# defaulting when it cannot find the step, which is why this is a hard exit.
+if ! STEP_SHELL=$(workflow_step_shell "$WF" "$STEP"); then
+  echo "FAIL: shell-lib-suite_test — could not derive the shell $WF gives '$STEP' (refusal above); nothing below would have graded the real program" >&2
+  exit 1
+fi
+read -r -a STEP_ARGV <<<"$STEP_SHELL"
+echo "== $WF :: '$STEP' runs under \`$STEP_SHELL\` (derived) =="
 
 TMP=$(mktemp -d -t shell-lib-suite) || exit 1
 trap 'rm -rf "$TMP"' EXIT
@@ -108,7 +136,7 @@ rc=0
 shell_lib_suite_run "$SLS_ARGS_DIR" $SLS_ARGS_SKIPS || rc=$?
 exit "$rc"
 RUNNER
-  OUT=$(bash --noprofile --norc -eo pipefail "$script" 2>&1); ST=$?
+  OUT=$("${STEP_ARGV[@]}" "$script" 2>&1); ST=$?
   return 0
 }
 
@@ -136,7 +164,7 @@ run_suite_bare() {
 # shellcheck disable=SC2086
 shell_lib_suite_run "$SLS_ARGS_DIR" $SLS_ARGS_SKIPS
 RUNNERBARE
-  OUT=$(bash --noprofile --norc -eo pipefail "$script" 2>&1); ST=$?
+  OUT=$("${STEP_ARGV[@]}" "$script" 2>&1); ST=$?
   return 0
 }
 
@@ -177,8 +205,8 @@ want_contains "bare position: the census still printed" "found 3, skipped 0 (non
 
 # --- obligation 2: the predecessors, measured rather than described ----------
 # test.yml's loop as it stood, verbatim, with only `tools/lib` replaced by the
-# fixture dir — run under `bash --noprofile --norc -eo pipefail`, which is
-# GitHub's documented invocation for a step declaring no `shell:`.
+# fixture dir — run under the invocation derived from the workflow above, which
+# for a step declaring no `shell:` is `bash -e`.
 echo ""
 echo "== the two predecessors, run under GitHub's own default shell =="
 export SLS_DIR="$TMP/mixed"
@@ -189,7 +217,7 @@ for t in "$SLS_DIR"/*_test.sh; do
   bash "$t"
 done
 OLDCI
-old_out=$(bash --noprofile --norc -eo pipefail "$TMP/old-ci-loop.sh" 2>&1); old_st=$?
+old_out=$("${STEP_ARGV[@]}" "$TMP/old-ci-loop.sh" 2>&1); old_st=$?
 want_status "test.yml's old loop still goes red" 1 "$old_st" "$old_out"
 want_contains "...having run the first file" "RAN a_test.sh" "$old_out"
 # The load-bearing half of the pair. If bash ever stopped aborting here — a
@@ -212,14 +240,14 @@ for t in "$SLS_EMPTY"/*_test.sh; do
 done
 exit "$rc"
 OLDPF
-oldpf_out=$(bash --noprofile --norc -eo pipefail "$TMP/old-preflight-loop.sh" 2>&1); oldpf_st=$?
+oldpf_out=$("${STEP_ARGV[@]}" "$TMP/old-preflight-loop.sh" 2>&1); oldpf_st=$?
 want_status "preflight's old loop passed an EMPTY corpus silently" 0 "$oldpf_st" "$oldpf_out"
 want_absent "...saying nothing at all about it" "found" "$oldpf_out"
 
 # ...and CI's old loop over the same empty corpus did not pass, but did not say
-# what was wrong either: nullglob is OFF by default (and `-eo pipefail` does not
-# change it), so the loop iterated once with the literal pattern and died on a
-# missing file. Non-zero, and unattributable.
+# what was wrong either: nullglob is OFF by default (and neither `-e` nor
+# `shell: bash`'s `-o pipefail` changes it), so the loop iterated once with the
+# literal pattern and died on a missing file. Non-zero, and unattributable.
 cat >"$TMP/old-ci-empty.sh" <<'OLDCIE'
 for t in "$SLS_EMPTY"/*_test.sh; do
   case "$t" in */posix-lint_test.sh) continue ;; esac
@@ -227,7 +255,7 @@ for t in "$SLS_EMPTY"/*_test.sh; do
   bash "$t"
 done
 OLDCIE
-oldcie_out=$(bash --noprofile --norc -eo pipefail "$TMP/old-ci-empty.sh" 2>&1); oldcie_st=$?
+oldcie_out=$("${STEP_ARGV[@]}" "$TMP/old-ci-empty.sh" 2>&1); oldcie_st=$?
 want_status "CI's old loop over an empty corpus died on the literal glob" 127 "$oldcie_st" "$oldcie_out"
 want_contains "...reading as a missing file, not as an empty corpus" "No such file or directory" "$oldcie_out"
 
@@ -295,7 +323,7 @@ rc=0
 shell_lib_suite_run "$SLS_MUT_DIR" || rc=$?
 exit "$rc"
 MUT
-  mut_out=$(bash --noprofile --norc -eo pipefail "$TMP/run-mut.sh" 2>&1); mut_st=$?
+  mut_out=$("${STEP_ARGV[@]}" "$TMP/run-mut.sh" 2>&1); mut_st=$?
   want_status "a loop that skips a file without counting it" 2 "$mut_st" "$mut_out"
   want_contains "...is refused by the census" "the census does not add up: 2 ran + 0 skipped != 3 found" "$mut_out"
 fi
@@ -311,17 +339,22 @@ want_absent "...and the real library over the same corpus does not" "census does
 # cannot come back unnoticed. It reads the files rather than running them.
 echo ""
 echo "== both callers really do call the one implementation =="
-WF=.github/workflows/test.yml
 if [[ ! -f "$WF" ]]; then
   fail "the call-site check could run" "$WF" "not found"
 else
-  # Vacuity guard first: a scan that stopped finding the step reads exactly
-  # like a workflow with no duplication in it.
-  step=$(awk '/^      - name: Test the shared shell libs$/{found=1} found{print}' "$WF")
+  # Read through the same library that derived the invocation, so this scan and
+  # the invocation above cannot be talking about two different steps. Vacuity
+  # guard first: a scan that stopped finding the step reads exactly like a
+  # workflow with no duplication in it, and workflow-step.sh REFUSES rather
+  # than returning an empty body for a step it cannot find.
+  if ! step=$(workflow_step_body "$WF" "$STEP"); then
+    fail "the scan finds the step in $WF" "a '$STEP' step" "workflow-step refused (above) — the scan has gone blind, not the workflow clean"
+    step=""
+  fi
   if [[ -z "$step" ]]; then
-    fail "the scan finds the step in $WF" "a 'Test the shared shell libs' step" "no such step — the scan has gone blind, not the workflow clean"
+    :
   else
-    pass "the scan reads $WF's 'Test the shared shell libs' step"
+    pass "the scan reads $WF's '$STEP' step"
     want_contains "...and it calls the shared runner" "shell_lib_suite_run tools/lib posix-lint_test.sh" "$step"
     want_absent "...rather than carrying its own loop" 'for t in tools/lib/*_test.sh' "$step"
     want_contains "...keeping \$? reachable under GitHub's implicit -e" '|| rc=$?' "$step"

--- a/tools/lib/testdata/workflow-step/body-lookalikes.yml
+++ b/tools/lib/testdata/workflow-step/body-lookalikes.yml
@@ -1,0 +1,21 @@
+name: A body carrying lines that look like structure
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Tricky body
+        run: |
+          # a comment inside the body
+          violations=""
+          violations="$violations  - name: not a step"$'\n'
+          echo "shell: pwsh"
+          if true; then
+            echo indented
+          fi
+
+          echo after a blank line
+      - name: The step after it
+        shell: bash
+        run: |
+          echo two

--- a/tools/lib/testdata/workflow-step/duplicate-names.yml
+++ b/tools/lib/testdata/workflow-step/duplicate-names.yml
@@ -1,0 +1,12 @@
+name: Two steps carrying the same name
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+      - name: Checkout code
+        shell: bash
+        run: |
+          echo one

--- a/tools/lib/testdata/workflow-step/job-defaults-after-steps.yml
+++ b/tools/lib/testdata/workflow-step/job-defaults-after-steps.yml
@@ -1,0 +1,12 @@
+name: Job-level defaults written after the steps
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Inheriting step
+        run: |
+          echo one
+    defaults:
+      run:
+        shell: bash

--- a/tools/lib/testdata/workflow-step/job-defaults-no-shell.yml
+++ b/tools/lib/testdata/workflow-step/job-defaults-no-shell.yml
@@ -1,0 +1,12 @@
+name: Job defaults that declare no shell (macos-swift.yml's shape)
+on: [push]
+jobs:
+  build:
+    runs-on: macos-latest
+    defaults:
+      run:
+        working-directory: platforms/macos
+    steps:
+      - name: Plain step
+        run: |
+          echo one

--- a/tools/lib/testdata/workflow-step/job-defaults.yml
+++ b/tools/lib/testdata/workflow-step/job-defaults.yml
@@ -1,0 +1,13 @@
+name: Job-level defaults
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+        working-directory: sub
+    steps:
+      - name: Inheriting step
+        run: |
+          echo one

--- a/tools/lib/testdata/workflow-step/no-run-block.yml
+++ b/tools/lib/testdata/workflow-step/no-run-block.yml
@@ -1,0 +1,10 @@
+name: Steps with no `run: |` block
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Uses step
+        uses: actions/checkout@v7
+      - name: Single-line run step
+        run: echo one

--- a/tools/lib/testdata/workflow-step/no-shell.yml
+++ b/tools/lib/testdata/workflow-step/no-shell.yml
@@ -1,0 +1,10 @@
+name: No shell anywhere
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Plain step
+        run: |
+          echo one
+          echo two

--- a/tools/lib/testdata/workflow-step/shell-after-run.yml
+++ b/tools/lib/testdata/workflow-step/shell-after-run.yml
@@ -1,0 +1,10 @@
+name: shell declared after run
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Declaring step
+        run: |
+          echo one
+        shell: bash

--- a/tools/lib/testdata/workflow-step/shell-custom-template.yml
+++ b/tools/lib/testdata/workflow-step/shell-custom-template.yml
@@ -1,0 +1,10 @@
+name: Step declares a custom shell template
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Templated step
+        shell: bash -x {0}
+        run: |
+          echo one

--- a/tools/lib/testdata/workflow-step/shell-sh.yml
+++ b/tools/lib/testdata/workflow-step/shell-sh.yml
@@ -1,0 +1,10 @@
+name: Step declares sh
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Posix step
+        shell: sh
+        run: |
+          echo one

--- a/tools/lib/testdata/workflow-step/shell-unmodelled.yml
+++ b/tools/lib/testdata/workflow-step/shell-unmodelled.yml
@@ -1,0 +1,10 @@
+name: Step declares a shell this library does not model
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Powershell step
+        shell: pwsh
+        run: |
+          Write-Output one

--- a/tools/lib/testdata/workflow-step/step-shell-bash.yml
+++ b/tools/lib/testdata/workflow-step/step-shell-bash.yml
@@ -1,0 +1,13 @@
+name: Step declares bash
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Plain step
+        run: |
+          echo untouched
+      - name: Declaring step
+        shell: bash
+        run: |
+          echo one

--- a/tools/lib/testdata/workflow-step/two-jobs.yml
+++ b/tools/lib/testdata/workflow-step/two-jobs.yml
@@ -1,0 +1,18 @@
+name: Two jobs, one with defaults and one without
+on: [push]
+jobs:
+  strict:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Step in the strict job
+        run: |
+          echo one
+  loose:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Step in the loose job
+        run: |
+          echo two

--- a/tools/lib/testdata/workflow-step/workflow-defaults.yml
+++ b/tools/lib/testdata/workflow-step/workflow-defaults.yml
@@ -1,0 +1,12 @@
+name: Workflow-level defaults
+on: [push]
+defaults:
+  run:
+    shell: bash
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Inheriting step
+        run: |
+          echo one

--- a/tools/lib/workflow-step.sh
+++ b/tools/lib/workflow-step.sh
@@ -1,0 +1,295 @@
+#!/usr/bin/env bash
+# workflow-step.sh — read a named GitHub Actions step out of a workflow file:
+# the `run: |` body it executes, and the SHELL INVOCATION the runner will
+# execute that body with (#1650).
+#
+# ---------------------------------------------------------------------------
+# Why the second half exists
+#
+# GitHub has TWO different bash invocations and this repo conflated them for
+# the whole of the extract-and-execute family's life:
+#
+#   a step DECLARING `shell: bash`   →  bash --noprofile --norc -e -o pipefail {0}
+#   a step declaring NOTHING         →  bash -e {0}
+#
+# The second is measured, not read off the docs — from run 31960152598's own
+# group header for a step of replaydata-deletion-guard.yml, which declares no
+# `shell:` and no `defaults:`:
+#
+#     guard  Detect deletions of load-bearing replaydata   shell: /usr/bin/bash -e {0}
+#
+# So the default is errexit ONLY: no `--noprofile`, no `--norc`, and **no
+# `-o pipefail`**. Every harness in tools/lib/ that extracts a step body and
+# runs it was running it under the FIRST spelling regardless, and each said in
+# its own header that running the body under anything else "would grade a
+# different program" — which was true, and was what they were doing.
+#
+# The direction of that error is what makes it worth a library rather than a
+# comment fix. `pipefail` makes a pipeline report its LEFTMOST failure instead
+# of only its last command's status, so a body whose correctness depends on it
+#
+#     manifest=$(list_things | grep -v skip)     # git fails; grep still exits 0
+#
+# is graded CORRECT by a harness that supplies pipefail and swallows the
+# failure in production, which does not. The harness reports the step safe
+# while the step is not — a false green, in the one direction that matters, of
+# exactly the "absence of a finding and inability to look must never produce
+# the same output" shape this whole family is about. (Under `shell: bash` the
+# error runs the other way and is loud: a harness omitting pipefail would fail
+# a body that CI passes.)
+#
+# So the invocation is derived from the workflow rather than typed: a step that
+# later gains or loses a `shell:` declaration, or whose job or workflow gains a
+# `defaults: { run: { shell: … } }`, moves its harness with it. Nothing here is
+# a mapping anyone maintains; the workflow file is the only input.
+#
+# ---------------------------------------------------------------------------
+# What it refuses, and why refusing is the point
+#
+# A derivation that cannot find its step must FAIL, never fall back to a
+# default: a harness handed a plausible-looking `bash -e` for a step that no
+# longer exists would go on to grade an empty body, which exits 0 and reads as
+# a clean run. Every refusal below is a distinct status-2 message naming what
+# could not be done:
+#
+#   - the workflow file is not readable
+#   - no step carries that name
+#   - MORE than one step carries that name (which one was being graded?)
+#   - the step declares a `shell:` this library does not model
+#   - (body only) the step has no `run: |` block, or an empty one
+#
+# Status 2 rather than 1 throughout, so a refusal is distinguishable from an
+# errexit abort in a caller — the same reason shell-lib-suite.sh separates them.
+#
+# ---------------------------------------------------------------------------
+# What the parser does and does not understand
+#
+# It is an indentation walk over the subset of YAML these workflows are written
+# in, not a YAML parser: block sequences of steps, `run: |` block scalars, and
+# `defaults: { run: { shell: } }` at workflow and job level. It deliberately
+# does NOT understand flow mappings (`{shell: bash}`), other block-scalar
+# spellings (`|-`, `|+`, `>`), or `shell:` values carrying a custom template
+# (`bash -x {0}`) — each is a refusal rather than a guess, because a guess here
+# is silently graded as fact. tools/lib/workflow-step_test.sh pins every one of
+# those refusals against a committed fixture, and pins the derivation for the
+# four workflows this repo actually harnesses.
+#
+# Key ORDER inside a step does not matter (`shell:` may follow `run:`), and
+# neither does the position of a job's `defaults:` block relative to its
+# `steps:` — the job's shell is resolved per job index at EOF, so a `defaults:`
+# written after the steps still applies to them.
+
+# The invocation GitHub gives each shell keyword, minus the `{0}` script
+# argument the caller supplies itself. Sourced callers read these through
+# workflow_step_shell; they are not a mapping to maintain per harness.
+#
+# `bash -e` is the DEFAULT (no `shell:`, no `defaults:`) — documented by GitHub
+# as `bash -e {0}`, falling back to `sh -e {0}` where bash is absent. The
+# fallback is not modelled: every runner this repo uses (ubuntu-latest,
+# macos-latest) ships bash, and a harness that silently graded a body under
+# `sh` would be the premise defect again in a new spelling.
+WORKFLOW_STEP_SHELL_DEFAULT='bash -e'
+WORKFLOW_STEP_SHELL_BASH='bash --noprofile --norc -e -o pipefail'
+WORKFLOW_STEP_SHELL_SH='sh -e'
+
+# _workflow_step_scan <workflow-file> <step-name>
+#
+# One pass over the file, emitting a fixed-shape record:
+#
+#     matches <n>          how many steps carry that name (0, 1, or more)
+#     step_shell <v>       the step's own `shell:` value, or empty
+#     job_shell <v>        the containing job's defaults shell, or empty
+#     wf_shell <v>         the workflow's defaults shell, or empty
+#     has_run <0|1>        whether the step has a `run: |` block scalar
+#     body                 marker; every line after this is body
+#
+# Both public functions read this same record, so they cannot disagree about
+# WHICH step they are describing — a harness that graded one step's body under
+# another step's shell would be this issue reproduced inside its own fix.
+#
+# It carries no awk function, deliberately: tools/lib/shell-lib-errexit_test.sh
+# walks every `tools/lib/*.sh` for shell functions and REFUSES a file
+# containing the `function name {` spelling it cannot read — and it refuses on
+# the text, which an awk program embedded in a shell library is also made of.
+# The state machine below therefore commits the wanted step's fields as it
+# learns them (`collecting`) rather than flushing a buffer from three call
+# sites, which is what a helper would have been for.
+_workflow_step_scan() {
+  awk -v want="$2" '
+    {
+      col = match($0, /[^ ]/)          # 1-based column of the first non-space
+
+      # --- inside a `run: |` block scalar: everything indented past the
+      # `run:` key is body, blank lines included. Nothing in here is read as
+      # structure, which is what keeps a body line like `  - foo` from being
+      # mistaken for a step.
+      if (in_run) {
+        if (col == 0)      { if (collecting) m_body = m_body "\n"; next }
+        if (col > run_col) { if (collecting) m_body = m_body substr($0, run_col + 2) "\n"; next }
+        in_run = 0                 # dedent: fall through and read this line as structure
+      }
+      if (col == 0) next                                   # blank
+      t = substr($0, col)
+      if (substr(t, 1, 1) == "#") next                     # comment
+      ind = col - 1
+
+      # --- a `defaults:` block ends at the first line indented no deeper
+      if (def_state && ind <= def_ind) def_state = 0
+
+      # --- step boundaries: a sequence item inside a `steps:` list
+      if (in_steps && ind <= steps_ind) { in_steps = 0; in_step = 0; collecting = 0; s_shell = "" }
+      if (in_steps && t ~ /^-[ \t]+/) {
+        in_step = 1; step_ind = ind; collecting = 0; s_shell = ""
+        t = substr(t, match(t, /[^- \t]/))                 # read the first key inline
+        ind = ind + 2                                      # ...as a step key
+      } else if (in_step && ind <= step_ind) {
+        in_step = 0; collecting = 0; s_shell = ""
+      }
+
+      # --- workflow / job structure
+      if (ind == 0) {
+        def_state = 0
+        if (t ~ /^defaults:/)   { def_state = 1; def_ind = 0; def_scope = "wf"; next }
+        if (t ~ /^jobs:/)       { in_jobs = 1; job_ind = -1; next }
+        in_jobs = 0; next
+      }
+      if (in_jobs && job_ind < 0 && !in_step) { job_ind = ind }
+      if (in_jobs && ind == job_ind && !in_step && t ~ /:[ \t]*$/) {
+        job_idx++; in_steps = 0; next
+      }
+
+      # --- defaults: run: shell:
+      if (def_state == 1 && t ~ /^run:/)   { def_state = 2; next }
+      if (def_state == 2 && t ~ /^shell:/) {
+        v = t; sub(/^shell:[ \t]*/, "", v); gsub(/[ \t]+$/, "", v)
+        gsub(/^["'"'"']|["'"'"']$/, "", v)
+        if (def_scope == "wf") wf_shell = v; else job_shell[job_idx] = v
+        next
+      }
+      if (t ~ /^defaults:/ && !in_step) { def_state = 1; def_ind = ind; def_scope = "job"; next }
+
+      if (t ~ /^steps:/) { in_steps = 1; steps_ind = ind; next }
+
+      # --- step keys. The wanted step is committed as its fields are LEARNED
+      # (`collecting`), so a `shell:` written before the `name:` is carried over
+      # from s_shell and one written after lands straight in m_shell.
+      if (in_step && ind > step_ind) {
+        if (t ~ /^name:/) {
+          v = t; sub(/^name:[ \t]*/, "", v); gsub(/[ \t]+$/, "", v)
+          gsub(/^["'"'"']|["'"'"']$/, "", v)
+          if (v == want) {
+            matches++
+            if (matches == 1) { collecting = 1; m_shell = s_shell; m_job = job_idx }
+          }
+          next
+        }
+        if (t ~ /^shell:/) {
+          v = t; sub(/^shell:[ \t]*/, "", v); gsub(/[ \t]+$/, "", v)
+          gsub(/^["'"'"']|["'"'"']$/, "", v)
+          if (collecting) m_shell = v; else s_shell = v
+          next
+        }
+        if (t ~ /^run:[ \t]*\|[ \t]*$/) {
+          in_run = 1; run_col = col
+          if (collecting) m_hasrun = 1
+          next
+        }
+      }
+    }
+    END {
+      printf "matches %d\n", matches
+      printf "step_shell %s\n", m_shell
+      printf "job_shell %s\n", job_shell[m_job]
+      printf "wf_shell %s\n", wf_shell
+      printf "has_run %d\n", m_hasrun
+      printf "body\n"
+      printf "%s", m_body
+    }
+  ' "$1"
+}
+
+# _workflow_step_field <record> <key> — the value of one header line.
+_workflow_step_field() {
+  printf '%s\n' "$1" | awk -v k="$2" '$1 == k { $1 = ""; sub(/^ /, ""); print; exit } $1 == "body" { exit }'
+}
+
+# _workflow_step_record <workflow-file> <step-name> — the scan, with the two
+# refusals both public functions share (unreadable file, no/ambiguous step).
+_workflow_step_record() {
+  local wf="$1" name="$2" rec matches
+  if [ ! -f "$wf" ]; then
+    printf 'workflow-step: refusing — %s is not a readable file, so nothing about the "%s" step could be derived. This is NOT a default.\n' "$wf" "$name" >&2
+    return 2
+  fi
+  rec=$(_workflow_step_scan "$wf" "$name") || {
+    printf 'workflow-step: refusing — the scan of %s failed, so nothing about the "%s" step could be derived.\n' "$wf" "$name" >&2
+    return 2
+  }
+  matches=$(_workflow_step_field "$rec" matches)
+  if [ "${matches:-0}" -eq 0 ]; then
+    printf 'workflow-step: refusing — %s has no step named "%s". A harness cannot grade a step that is not there, and falling back to a default would grade an empty body as a clean run.\n' "$wf" "$name" >&2
+    return 2
+  fi
+  if [ "$matches" -gt 1 ]; then
+    printf 'workflow-step: refusing — %s has %s steps named "%s", so which one a harness grades is not decidable. Rename one.\n' "$wf" "$matches" "$name" >&2
+    return 2
+  fi
+  printf '%s\n' "$rec"
+  return 0
+}
+
+# workflow_step_shell <workflow-file> <step-name>
+#
+# Prints the argv the runner executes the step's body with, WITHOUT the script
+# path — e.g. `bash -e` or `bash --noprofile --norc -e -o pipefail`. Callers
+# split it into an array and append their own script:
+#
+#     read -r -a argv <<<"$(workflow_step_shell "$WF" "$STEP")" || exit 1
+#     "${argv[@]}" "$script"
+#
+# 0 on success, 2 on any refusal (message on stderr).
+workflow_step_shell() {
+  local wf="${1:-}" name="${2:-}" rec want src
+  rec=$(_workflow_step_record "$wf" "$name") || return 2
+
+  want=$(_workflow_step_field "$rec" step_shell); src="the step's own \`shell:\`"
+  if [ -z "$want" ]; then
+    want=$(_workflow_step_field "$rec" job_shell); src="the job's \`defaults: run: shell:\`"
+  fi
+  if [ -z "$want" ]; then
+    want=$(_workflow_step_field "$rec" wf_shell); src="the workflow's \`defaults: run: shell:\`"
+  fi
+
+  case "$want" in
+    '')     printf '%s\n' "$WORKFLOW_STEP_SHELL_DEFAULT"; return 0 ;;
+    bash)   printf '%s\n' "$WORKFLOW_STEP_SHELL_BASH";    return 0 ;;
+    sh)     printf '%s\n' "$WORKFLOW_STEP_SHELL_SH";      return 0 ;;
+  esac
+  printf 'workflow-step: refusing — %s: step "%s" declares `shell: %s` (via %s), which this library does not model. Add it here rather than letting a harness grade the body under the wrong shell.\n' \
+    "$wf" "$name" "$want" "$src" >&2
+  return 2
+}
+
+# workflow_step_body <workflow-file> <step-name>
+#
+# Prints the step's `run: |` body, dedented to column 0. 0 on success, 2 on any
+# refusal — including a step whose body is missing or blank, because an empty
+# body exits 0 under every invocation and is indistinguishable from a step that
+# passes.
+workflow_step_body() {
+  local wf="${1:-}" name="${2:-}" rec body lines
+  rec=$(_workflow_step_record "$wf" "$name") || return 2
+
+  if [ "$(_workflow_step_field "$rec" has_run)" != "1" ]; then
+    printf 'workflow-step: refusing — %s: step "%s" has no `run: |` block to extract (a `uses:` step, or a single-line `run:` this library does not model).\n' "$wf" "$name" >&2
+    return 2
+  fi
+  body=$(printf '%s\n' "$rec" | sed '1,/^body$/d')
+  lines=$(printf '%s\n' "$body" | grep -cve '^[[:space:]]*$')
+  if [ "${lines:-0}" -eq 0 ]; then
+    printf 'workflow-step: refusing — %s: the "%s" step body came back empty. A scan that has gone blind and a step with nothing in it must not read alike.\n' "$wf" "$name" >&2
+    return 2
+  fi
+  printf '%s\n' "$body"
+  return 0
+}

--- a/tools/lib/workflow-step_test.sh
+++ b/tools/lib/workflow-step_test.sh
@@ -1,0 +1,373 @@
+#!/usr/bin/env bash
+# workflow-step_test.sh — the tests for tools/lib/workflow-step.sh, the one
+# implementation that answers "which shell does the runner give THIS step, and
+# what is in it" for every extract-and-execute harness in tools/lib/ (#1650).
+#
+# ---------------------------------------------------------------------------
+# What is being asserted, and why each obligation exists
+#
+# The defect this library removes was a PREMISE. Four harnesses, three
+# workflow comments and three AGENTS.md bullets stated as fact that a step
+# declaring no `shell:` runs under `bash --noprofile --norc -eo pipefail`. It
+# does not — that is what `shell: bash` gives; the default is `bash -e {0}`,
+# measured off run 31960152598's own step header. So the harnesses were
+# supplying `pipefail` to bodies production runs without, each while saying in
+# its header that running the body under anything else "would grade a different
+# program".
+#
+# The obligations, in order:
+#
+#   1. the derivation is right for every declaration shape, driven against a
+#      COMMITTED fixture corpus (testdata/workflow-step/) rather than against
+#      strings built in the test — one file per shape, so the mutation evidence
+#      outlives this PR the way tools/lib/testdata/posix-lint/'s does.
+#   2. every way of NOT being able to answer is a loud refusal naming what
+#      could not be done, never a fallback to the default. A harness handed a
+#      plausible `bash -e` for a step that no longer exists would go on to
+#      grade an empty body, which exits 0 and reads as a clean run.
+#   3. the body is extracted verbatim, including lines that look like YAML
+#      structure — and a `shell:` INSIDE a body does not change the answer.
+#   4. the two invocations really do grade the same body differently. This is
+#      the vacuity guard for the whole library: if they did not, deriving would
+#      be ceremony, and a derivation that always answered `bash -e` would look
+#      exactly as correct as one that reads the file.
+#   5. the derivation FOLLOWS a workflow that changes. A real workflow is
+#      copied, a `shell:` declaration is inserted and then removed, and the
+#      answer has to move both ways. That is the mutation AGENTS.md asks of
+#      anything a change adds, committed here rather than described in a PR
+#      body that nothing re-runs.
+#   6. the five real steps this repo harnesses resolve to what the runner
+#      really gives them. That is the existence check the brief asks for: a
+#      harness (or a workflow comment) still spelling its invocation by hand —
+#      swift-suite_test.sh does, correctly, for macos-swift.yml's two
+#      `shell: bash` steps — cannot silently stop matching, because this file
+#      goes red and names the file if that declaration is ever dropped.
+set -uo pipefail
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+cd "$REPO_ROOT" || { echo "FAIL: workflow-step_test — cannot cd to $REPO_ROOT" >&2; exit 1; }
+
+# A missing tool is a hard failure, not a skip: exiting 0 here would read as a
+# PASS to the runner that drives this file, so it would go green having
+# asserted nothing — the failure mode this whole issue family is made of.
+need() { command -v "$1" >/dev/null 2>&1 || { echo "FAIL: workflow-step_test — $1 not found" >&2; exit 1; }; }
+need git
+need awk
+need sed
+need mktemp
+need bash
+
+LIB=tools/lib/workflow-step.sh
+[[ -f "$LIB" ]] || { echo "FAIL: workflow-step_test — $LIB not found" >&2; exit 1; }
+# shellcheck source=workflow-step.sh
+. "$LIB"
+
+DATA=tools/lib/testdata/workflow-step
+[[ -d "$DATA" ]] || { echo "FAIL: workflow-step_test — the fixture corpus $DATA is missing" >&2; exit 1; }
+
+TMP=$(mktemp -d -t workflow-step) || exit 1
+trap 'rm -rf "$TMP"' EXIT
+
+rc=0
+pass() { echo "  PASS: $1"; return 0; }
+fail() { echo "  FAIL: $1 — expected [$2] got [$3]" >&2; rc=1; return 0; }
+flat() { echo "$1" | tr '\n' ' '; }
+
+# want_shell <fixture> <step> <expected argv>
+want_shell() {
+  local got st
+  got=$(workflow_step_shell "$DATA/$1" "$2" 2>&1); st=$?
+  if [[ "$st" -ne 0 ]]; then
+    fail "$1 :: $2" "$3" "refused($st): $(flat "$got")"
+  elif [[ "$got" == "$3" ]]; then
+    pass "$1 :: $2 -> $3"
+  else
+    fail "$1 :: $2" "$3" "$got"
+  fi
+  return 0
+}
+
+# want_refusal <label> <needle> <cmd...> — status 2 AND a message naming why.
+# A bare non-zero is refused: "it failed" and "it refused FOR THIS REASON" are
+# different claims, and only the second is what a caller reads.
+want_refusal() {
+  local label="$1" needle="$2"; shift 2
+  local got st
+  got=$("$@" 2>&1); st=$?
+  if [[ "$st" -ne 2 ]]; then
+    fail "$label" "status 2 and a message naming: $needle" "status $st :: $(flat "$got")"
+    return 0
+  fi
+  case "$got" in
+    *"$needle"*) pass "$label (refused 2, naming: $needle)" ;;
+    *) fail "$label" "a refusal naming: $needle" "$(flat "$got")" ;;
+  esac
+  return 0
+}
+
+# ---------------------------------------------------------------------------
+# Obligation 1 — every declaration shape, off the committed corpus.
+echo "== the derivation, per declaration shape (testdata/workflow-step/) =="
+DEFAULT='bash -e'
+BASH='bash --noprofile --norc -e -o pipefail'
+
+want_shell no-shell.yml                 'Plain step'                  "$DEFAULT"
+want_shell step-shell-bash.yml          'Declaring step'              "$BASH"
+# ...and the step BESIDE it in the same job is unaffected. A derivation that
+# leaked one step's declaration onto its neighbours would satisfy every other
+# row here.
+want_shell step-shell-bash.yml          'Plain step'                  "$DEFAULT"
+want_shell shell-after-run.yml          'Declaring step'              "$BASH"
+want_shell job-defaults.yml             'Inheriting step'             "$BASH"
+want_shell job-defaults-after-steps.yml 'Inheriting step'             "$BASH"
+want_shell job-defaults-no-shell.yml    'Plain step'                  "$DEFAULT"
+want_shell workflow-defaults.yml        'Inheriting step'             "$BASH"
+want_shell two-jobs.yml                 'Step in the strict job'      "$BASH"
+want_shell two-jobs.yml                 'Step in the loose job'       "$DEFAULT"
+want_shell shell-sh.yml                 'Posix step'                  'sh -e'
+
+# ---------------------------------------------------------------------------
+# Obligation 2 — the refusals.
+echo ""
+echo "== everything it cannot answer is a refusal, never a default =="
+want_refusal "a workflow file that does not exist" "is not a readable file" \
+  workflow_step_shell "$DATA/no-such-workflow.yml" 'Plain step'
+want_refusal "a step name no step carries" "has no step named" \
+  workflow_step_shell "$DATA/no-shell.yml" 'Not a step in there'
+want_refusal "a name carried by TWO steps" "steps named" \
+  workflow_step_shell "$DATA/duplicate-names.yml" 'Checkout code'
+want_refusal "a shell keyword this library does not model" "does not model" \
+  workflow_step_shell "$DATA/shell-unmodelled.yml" 'Powershell step'
+want_refusal "a custom shell template" "does not model" \
+  workflow_step_shell "$DATA/shell-custom-template.yml" 'Templated step'
+want_refusal "a \`uses:\` step has no body to extract" "no \`run: |\` block" \
+  workflow_step_body "$DATA/no-run-block.yml" 'Uses step'
+want_refusal "a single-line \`run:\` is not modelled either" "no \`run: |\` block" \
+  workflow_step_body "$DATA/no-run-block.yml" 'Single-line run step'
+want_refusal "the body of a step that does not exist" "has no step named" \
+  workflow_step_body "$DATA/no-shell.yml" 'Not a step in there'
+
+# ...and the refusals are not the whole answer set: a shape that IS modelled
+# still comes back. Without this, a library that refused everything would
+# satisfy every arm above.
+if body=$(workflow_step_body "$DATA/no-shell.yml" 'Plain step' 2>&1); then
+  pass "...while a modelled step still yields its body"
+else
+  fail "a modelled step still yields its body" "the body" "refused: $(flat "$body")"
+fi
+
+# ---------------------------------------------------------------------------
+# Obligation 3 — the body, verbatim, including lines that look like structure.
+echo ""
+echo "== the body is extracted verbatim =="
+body=$(workflow_step_body "$DATA/body-lookalikes.yml" 'Tricky body')
+want_line() {
+  case $'\n'"$body"$'\n' in
+    *$'\n'"$1"$'\n'*) pass "the body carries: $1" ;;
+    *) fail "the body carries: $1" "that line, dedented to column 0" "$(flat "$body")" ;;
+  esac
+  return 0
+}
+want_line '# a comment inside the body'
+want_line 'violations=""'
+want_line 'violations="$violations  - name: not a step"$'"'"'\n'"'"''
+want_line 'echo "shell: pwsh"'
+want_line 'if true; then'
+want_line '  echo indented'      # relative indentation survives
+want_line 'fi'
+want_line 'echo after a blank line'
+# The body must stop at the step boundary, or a harness would execute the NEXT
+# step's lines as part of this one.
+case "$body" in
+  *'echo two'*) fail "the body stops at the next step" "no 'echo two'" "$(flat "$body")" ;;
+  *) pass "...and stops at the next step" ;;
+esac
+# A `shell:` line INSIDE a body is text, not a declaration. A parser that read
+# structure out of block scalars would answer `pwsh` here and refuse.
+want_shell body-lookalikes.yml 'Tricky body' "$DEFAULT"
+want_shell body-lookalikes.yml 'The step after it' "$BASH"
+
+# ---------------------------------------------------------------------------
+# Obligation 4 — the two invocations grade the same body DIFFERENTLY, and in
+# which direction.
+#
+# This is the whole reason the library exists rather than a comment fix. The
+# probe is the shape any step is one edit away from growing:
+#
+#     out=$(false | cat)      # the left-hand command failed; `cat` did not
+#
+# Under `bash -e` — what a step declaring no `shell:` really gets — the
+# pipeline's status is `cat`'s 0, the assignment succeeds, and the body sails
+# past a command that failed. Under `--noprofile --norc -e -o pipefail`, the
+# same line reports `false`'s 1 and errexit aborts the body there.
+#
+# So a harness supplying pipefail to a body production runs without grades that
+# body as SAFE while production swallows the failure: a false green, in the one
+# direction that matters. Measured here on every run rather than argued.
+echo ""
+echo "== the two invocations really do grade the same body differently =="
+cat >"$TMP/pipefail-probe.sh" <<'PROBE'
+out=$(false | cat)
+echo "REACHED"
+PROBE
+read -r -a argv_default <<<"$DEFAULT"
+read -r -a argv_bash <<<"$BASH"
+d_out=$("${argv_default[@]}" "$TMP/pipefail-probe.sh" 2>&1); d_st=$?
+b_out=$("${argv_bash[@]}" "$TMP/pipefail-probe.sh" 2>&1); b_st=$?
+if [[ "$d_st" -eq 0 && "$d_out" == *REACHED* ]]; then
+  pass "under \`$DEFAULT\` a mid-pipeline failure is SWALLOWED (exit 0, body continues)"
+else
+  fail "under \`$DEFAULT\` a mid-pipeline failure is swallowed" "exit 0 and REACHED" "exit $d_st :: $(flat "$d_out")"
+fi
+if [[ "$b_st" -ne 0 && "$b_out" != *REACHED* ]]; then
+  pass "under \`$BASH\` the same body ABORTS there (exit $b_st, nothing after it runs)"
+else
+  fail "under \`$BASH\` the same body aborts" "a non-zero exit and no REACHED" "exit $b_st :: $(flat "$b_out")"
+fi
+
+# ---------------------------------------------------------------------------
+# Obligation 5 — the derivation FOLLOWS the workflow, both ways.
+#
+# A copy of a REAL workflow, mutated. Both directions are driven, because a
+# derivation hard-wired to `bash -e` passes the removal and only the insertion
+# catches it, and one hard-wired to the pipefail spelling passes the insertion
+# and only the removal catches it.
+#
+# The mutation is asserted to have APPLIED before its effect is read (#1390:
+# a mutation harness whose mutation silently no-ops reports the unmutated
+# result as evidence).
+echo ""
+echo "== the derivation follows a step that gains or loses \`shell:\` =="
+REAL=.github/workflows/ars.yml
+REALSTEP='Commit badge update'
+if [[ ! -f "$REAL" ]]; then
+  fail "$REAL is readable" "the workflow file" "not found — the mutation could not run"
+else
+  want_shell_file() { # <file> <step> <expected> <label>
+    local got st
+    got=$(workflow_step_shell "$1" "$2" 2>&1); st=$?
+    if [[ "$st" -eq 0 && "$got" == "$3" ]]; then pass "$4 -> $3"
+    else fail "$4" "$3" "status $st :: $(flat "$got")"; fi
+    return 0
+  }
+  cp "$REAL" "$TMP/mutant.yml"
+  want_shell_file "$TMP/mutant.yml" "$REALSTEP" "$DEFAULT" "the unmutated copy"
+
+  # Insert `shell: bash` immediately after the step's own `- name:` line, at
+  # the indentation a sibling key uses.
+  awk -v want="$REALSTEP" '
+    { print }
+    $0 ~ /^[[:space:]]*-[[:space:]]+name:[[:space:]]*/ {
+      n = $0; sub(/^[[:space:]]*-[[:space:]]+name:[[:space:]]*/, "", n)
+      if (n == want) { ind = match($0, /[^ ]/); printf "%*sshell: bash\n", ind + 1, "" }
+    }
+  ' "$TMP/mutant.yml" >"$TMP/mutant-shell.yml"
+  if ! grep -q '^ *shell: bash$' "$TMP/mutant-shell.yml"; then
+    fail "the \`shell: bash\` insertion applied" "a mutated copy carrying it" "the awk inserted nothing — the mutation below measured the unmutated file"
+  else
+    pass "the \`shell: bash\` insertion applied to the copy"
+    want_shell_file "$TMP/mutant-shell.yml" "$REALSTEP" "$BASH" "...and the step that GAINED \`shell: bash\`"
+  fi
+
+  # ...and back: removing it returns the answer to the default. Driven on the
+  # mutated copy so the removal has something to remove.
+  grep -v '^ *shell: bash$' "$TMP/mutant-shell.yml" >"$TMP/mutant-removed.yml"
+  if grep -q '^ *shell: bash$' "$TMP/mutant-removed.yml"; then
+    fail "the \`shell: bash\` removal applied" "a copy without it" "it is still there — the arm below measured the wrong file"
+  else
+    pass "the \`shell: bash\` removal applied to the copy"
+    want_shell_file "$TMP/mutant-removed.yml" "$REALSTEP" "$DEFAULT" "...and the step that LOST it again"
+  fi
+
+  # The same, one level up: a JOB that gains a `defaults: run: shell:`.
+  awk '
+    { print }
+    $0 ~ /^[[:space:]]*runs-on:/ && !done {
+      ind = match($0, /[^ ]/)
+      printf "%*sdefaults:\n", ind - 1 + 1, ""
+      printf "%*srun:\n",      ind + 1 + 1, ""
+      printf "%*sshell: bash\n", ind + 3 + 1, ""
+      done = 1
+    }
+  ' "$TMP/mutant.yml" >"$TMP/mutant-jobdefaults.yml"
+  if ! grep -q '^ *defaults:$' "$TMP/mutant-jobdefaults.yml"; then
+    fail "the job-level \`defaults:\` insertion applied" "a mutated copy carrying it" "the awk inserted nothing"
+  else
+    pass "the job-level \`defaults:\` insertion applied to the copy"
+    want_shell_file "$TMP/mutant-jobdefaults.yml" "$REALSTEP" "$BASH" "...and a step whose JOB gained \`defaults: run: shell: bash\`"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Obligation 6 — the real steps this repo harnesses.
+#
+# Not a second copy of the mapping: these rows are read FROM the workflows by
+# the same code the harnesses use, so they cannot state a shell the derivation
+# does not produce. What they pin is that each harnessed step still EXISTS
+# under the name its harness looks up, and which side of the pipefail split it
+# is on — including macos-swift.yml's two `shell: bash` steps, whose invocation
+# swift-suite_test.sh still spells by hand (correctly). If that declaration is
+# ever dropped, this file names the file rather than swift-suite_test.sh
+# quietly grading under the wrong shell.
+echo ""
+echo "== the real harnessed steps =="
+real_row() { # <workflow> <step> <expected>
+  local got st
+  got=$(workflow_step_shell "$1" "$2" 2>&1); st=$?
+  if [[ "$st" -eq 0 && "$got" == "$3" ]]; then
+    pass "$1 :: $2 -> $3"
+  else
+    fail "$1 :: $2" "$3" "status $st :: $(flat "$got")"
+  fi
+  return 0
+}
+real_row .github/workflows/ars.yml                        'Commit badge update'                         "$DEFAULT"
+real_row .github/workflows/test.yml                       'Test the shared shell libs'                  "$DEFAULT"
+real_row .github/workflows/replaydata-deletion-guard.yml  'Detect deletions of load-bearing replaydata' "$DEFAULT"
+real_row .github/workflows/macos-swift.yml                'Test (bounded, streamed under a pty)'        "$BASH"
+real_row .github/workflows/macos-swift.yml                "Collect the skipped suites' pixels"          "$BASH"
+
+# ---------------------------------------------------------------------------
+# ...and preflight's `tools` gate has to FIRE on a diff touching this library,
+# its corpus, or any workflow it reads — or under --changed (the pre-push
+# hook's path) every assertion above is skipped on precisely the commit that
+# can break it. That is #1591's, #1629's, #1639's, #1641's and #1645's shape,
+# each fixed by widening this same trigger. The regex is EXTRACTED and matched
+# rather than string-compared, so this is a behavioural assertion and not a
+# lock on one spelling of an alternation.
+echo ""
+echo "== tools/preflight.sh's \`tools\` trigger =="
+PF=tools/preflight.sh
+if [[ ! -f "$PF" ]]; then
+  fail "$PF is readable" "the preflight script" "not found — the trigger check could not run"
+else
+  tools_re=$(grep -a "run_gate_scoped '\^tools/lib/" "$PF" \
+             | sed -E "s/^[[:space:]]*run_gate_scoped '//; s/'[[:space:]]*\\\\?[[:space:]]*$//")
+  if [[ -z "$tools_re" ]]; then
+    fail "the tools-gate trigger regex could be read from $PF" \
+         "one run_gate_scoped line starting ^tools/lib/" "no such line — the scan has gone blind, not the trigger wrong"
+  else
+    pass "read the tools-gate trigger regex from $PF"
+    for probe in tools/lib/workflow-step.sh tools/lib/workflow-step_test.sh \
+                 "$DATA/no-shell.yml" .github/workflows/macos-swift.yml; do
+      if printf '%s\n' "$probe" | grep -qE "$tools_re"; then
+        pass "...it fires on a diff touching $probe"
+      else
+        fail "the tools gate fires on a diff touching $probe" "a match" "no match against: $tools_re"
+      fi
+    done
+    if printf '%s\n' core/domain/session.go | grep -qE "$tools_re"; then
+      fail "the tools-gate trigger still scopes" "no match for core/domain/session.go" "it matches everything: $tools_re"
+    else
+      pass "...and still does not fire on an unrelated core/ file"
+    fi
+  fi
+fi
+
+echo ""
+if [[ "$rc" -eq 0 ]]; then
+  echo "workflow-step_test: ALL PASS"
+else
+  echo "workflow-step_test: FAILURES" >&2
+fi
+exit "$rc"


### PR DESCRIPTION
Closes #1650

## The premise, re-measured

Two invocations, and this repo conflated them:

| the step declares | the runner executes |
| --- | --- |
| `shell: bash` (or a job/workflow `defaults: run: shell: bash`) | `bash --noprofile --norc -e -o pipefail {0}` |
| nothing | `bash -e {0}` — errexit only, **no pipefail**, no `--noprofile/--norc` |

**Measured myself rather than inherited from the issue.** Both headers come off
one real run — `macos-swift.yml` run 31960611408, which has steps of both kinds:

```
$ gh run view 31960611408 --log | grep -o 'shell: .*' | sort -u
shell: /bin/bash --noprofile --norc -e -o pipefail {0}
shell: /bin/bash -e {0}
```

and the issue's own measurement reproduces:

```
$ gh run view 31960152598 --log | grep -o 'shell: .*' | sort -u
shell: /usr/bin/bash -e {0}
```

## Per-site result

| Site | What it claimed | What the step actually gets | Verdict |
| --- | --- | --- | --- |
| `.github/workflows/ars.yml:66` | "a step declaring no `shell:` runs as `bash --noprofile --norc -e -o pipefail {0}`" | `bash -e {0}` | **corrected** |
| `.github/workflows/test.yml:105` | "GitHub's default `bash --noprofile --norc -eo pipefail`" | `bash -e {0}` | **corrected** |
| `.github/workflows/replaydata-deletion-guard.yml` | carried no invocation claim at all (checked: no `noprofile`/`pipefail` outside the step's own `set -euo pipefail`) | `bash -e {0}` | **nothing to correct**; added a note saying why line 1 supplies pipefail itself |
| `.github/workflows/macos-swift.yml:196`, `:298` | "GitHub runs `shell: bash` as `bash --noprofile --norc -e -o pipefail {0}`" | exactly that — both steps carry `shell: bash` on the step, four lines above each comment | **left alone** |
| `AGENTS.md` "shell-lib suite runner" (×2) | "GitHub's `bash --noprofile --norc -eo pipefail` applies"; "`-eo pipefail` does not change [nullglob]" | `bash -e {0}` | **corrected** |
| `AGENTS.md` "ARS badge push" | "`bash --noprofile --norc -e -o pipefail` — GitHub's documented invocation for a step declaring no `shell:`" | `bash -e {0}` | **corrected** |
| `AGENTS.md` "replaydata deletion guard" | "under the same `bash --noprofile --norc -e -o pipefail`" | `bash -e {0}` | **corrected** |
| `tools/lib/ars-badge-push_test.sh:96` | same claim, and it ran bodies under it | `bash -e` | **corrected + derived** |
| `tools/lib/replaydata-deletion-guard_test.sh:127` | same claim, and it ran bodies under it | `bash -e` | **corrected + derived** |
| `tools/lib/shell-lib-suite_test.sh` (×5 sites) | same claim, and it ran bodies under it | `bash -e` | **corrected + derived** |
| `tools/lib/shell-lib-suite.sh:38`, `:68`, `:114` | same claim, in the reasoning about the aborting loop and about nullglob | `bash -e {0}` | **corrected** (the reasoning survives: `-e` alone aborts the loop, and nullglob is off under both) |
| `tools/lib/shell-lib-errexit_test.sh:215` | "`bash --noprofile --norc -e -o pipefail`, which is GitHub's own `shell: bash` invocation" | true as written | **left, wording widened** — it is a tripwire over libraries with three callers of different strictness (macos-swift's `shell: bash` steps, test.yml's `bash -e` step, `preflight.sh`'s `set -uo pipefail`), not a harness for one step. It now says the invocation is chosen as the *strictest* caller and that the extra pipefail can only make a callee abort earlier — a false accusation (loud), not a false green (silent). |
| `tools/lib/gate-budget_test.sh:254` | "`bash --noprofile --norc -e -o pipefail`, which is GitHub's own `shell: bash` invocation" | true as written | **left alone.** `gate-budget.sh` is sourced only by `tools/preflight.sh` — `grep -rn 'preflight.sh' .github/workflows/` returns four comment references and zero invocations, so it has no workflow step at all; the strict shell there is a deliberately strict *caller*, and the sentence names the right variant. |
| `tools/lib/swift-suite_test.sh` (5 sites) | every one says `shell: bash` | true as written — `macos-swift.yml`'s two steps declare it | **left alone**, and now existence-checked: `workflow-step_test.sh` resolves both of those steps through the derivation and fails naming the file if the declaration is ever dropped. |

## Was there a live `pipefail` dependency? No — verified, not inherited

Every pipeline-carrying line in every `run:` body was extracted and read (16
lines; `sed "s|…|…|"` in ars.yml is a delimiter, not a pipe):

- **ars.yml** — `ARS_BADGE=$(grep … | head -1 || echo "")` and
  `ARS_URL=$(echo … | grep -o … | head -1 || echo "")`. The `|| echo ""` makes
  the substitution's status 0 under either invocation, and the caller then tests
  `[ -n "$ARS_BADGE" ]`. "Commit badge update" — #1641's subject — contains no
  pipeline at all.
- **replaydata-deletion-guard.yml** — five `printf … | wc -l` / `printf … | sed`
  pipelines, under the step's own `set -euo pipefail` on line 1, so pipefail is
  on in production regardless of the invocation.
- **test.yml** — one, inside an `echo "::error::…$(echo "$unformatted" | tr …)"`
  message.
- **macos-swift.yml** — three, in a step that declares `shell: bash` (and sets
  `set +e` itself). Correctly modelled already.
- **codescene-badge.yml** — `SCORE=$(tools/codescene-report.sh … | jq -r …)` is
  followed *immediately* by `if [ -z "$SCORE" ] || [ "$SCORE" = "null" ]; then
  … exit 1; fi`.
- **coverage.yml** — `pct=$(… | grep "^total:" | awk … | tr -d '%')` is followed
  by `if [ -n "$pct" ] && [ "$pct" != "0" ]`; the two `$(echo … | bc)` pipelines
  have `echo` on the left, which cannot fail.

So this is a wrong premise, not a live defect, and **no new bug was filed**. The
last two are outside the harnessed set and are the only near-misses; both hand-
roll the emptiness check pipefail would have made unnecessary.

## The direction of the error — why this is more than a text fix

`pipefail` makes a pipeline report its leftmost failure instead of its last
command's status. A body one edit away from

```sh
manifest=$(list_things | grep -v skip)     # the left-hand command failed; grep did not
```

is graded **correct** by a harness that supplies pipefail, and **swallows the
failure** in production, which does not. The harness reports the step safe while
the step is not: a false green, the same "absence of a finding and inability to
look produce the same output" shape as the rest of this family. (Under
`shell: bash` the error reverses and is loud — a harness omitting pipefail would
fail a body CI passes. Only the no-`shell:` side is silent, and that is the side
every harness was on.)

## How each harness derives its invocation now

New `tools/lib/workflow-step.sh` — one indentation walk over the workflow,
answering both questions from the same scan so a harness cannot grade one step's
body under another step's shell:

- `workflow_step_shell <workflow> <step>` → the argv, e.g. `bash -e`. Resolution
  order: the step's own `shell:`, then the containing job's
  `defaults: run: shell:`, then the workflow's, then the default.
- `workflow_step_body <workflow> <step>` → the dedented `run: |` body. Output is
  **byte-identical** to the awk extractor it replaces on all three real steps
  (verified by diff before the swap), so this is a refactor plus a refusal, not
  a re-implementation with new behaviour.

It **refuses**, status 2 with a message naming what it could not do, and never
falls back: unreadable file, no step of that name, **more than one** step of that
name, an unmodelled `shell:` value (`pwsh`, or a custom `bash -x {0}` template),
and a step with no `run: |` block. A harness handed a plausible `bash -e` for a
step that no longer exists would go on to grade an empty body, which exits 0 and
reads as a clean run.

Job-level `defaults:` written *after* `steps:` still applies (the job's shell is
resolved per job index at EOF), and key order inside a step does not matter
(`shell:` may follow `run:`). Deliberately **not** understood, each a refusal
rather than a guess: flow mappings, `|-`/`|+`/`>` block scalars, custom shell
templates.

Three harnesses now source it: `ars-badge-push_test.sh`,
`replaydata-deletion-guard_test.sh`, `shell-lib-suite_test.sh`. Each prints the
derived invocation as its first line, so a run says which shell it graded under.

## Mutation evidence — every obligation seen RED

Applied and reverted **one per foreground call**, each verified byte-identical
after revert.

**M1 — the step's own `shell:` is never read** (`if (collecting) m_shell = m_shell`):

```
FAIL: step-shell-bash.yml :: Declaring step — expected [bash --noprofile --norc -e -o pipefail] got [bash -e]
FAIL: shell-after-run.yml :: Declaring step — expected [bash --noprofile --norc -e -o pipefail] got [bash -e]
FAIL: shell-sh.yml :: Posix step — expected [sh -e] got [bash -e]
FAIL: a shell keyword this library does not model — expected [status 2 …] got [status 0 :: bash -e]
FAIL: a custom shell template — expected [status 2 …] got [status 0 :: bash -e]
FAIL: body-lookalikes.yml :: The step after it — expected [bash --noprofile --norc -e -o pipefail] got [bash -e]
FAIL: ...and the step that GAINED `shell: bash` — expected [bash --noprofile --norc -e -o pipefail] got [bash -e]
FAIL: .github/workflows/macos-swift.yml :: Test (bounded, streamed under a pty) — … got [bash -e]
FAIL: .github/workflows/macos-swift.yml :: Collect the skipped suites' pixels — … got [bash -e]
```

The three harnesses stayed **green** under M1 — all three of their steps are on
the `bash -e` side, which is exactly why `macos-swift.yml`'s two rows are the
discriminator and why the corpus carries `shell: bash` fixtures at all.

**M2 — #1650's own premise reinstated** (`WORKFLOW_STEP_SHELL_DEFAULT='bash --noprofile --norc -e -o pipefail'`):

```
FAIL: no-shell.yml :: Plain step — expected [bash -e] got [bash --noprofile --norc -e -o pipefail]
FAIL: step-shell-bash.yml :: Plain step — … (a step BESIDE a declaring one)
FAIL: job-defaults-no-shell.yml :: Plain step — … (macos-swift.yml's working-directory-only shape)
FAIL: two-jobs.yml :: Step in the loose job — …
FAIL: body-lookalikes.yml :: Tricky body — …
FAIL: the unmutated copy — …
FAIL: ...and the step that LOST it again — …
FAIL: .github/workflows/ars.yml :: Commit badge update — …
FAIL: .github/workflows/test.yml :: Test the shared shell libs — …
FAIL: .github/workflows/replaydata-deletion-guard.yml :: Detect deletions … — …
```

and the three harnesses reported `ALL PASS` while announcing
``runs under `bash --noprofile --norc -e -o pipefail` (derived)`` — i.e. the
pre-#1650 state reproduced: the harnesses cannot tell, which is the whole point.

**M3 — the "no such step" refusal falls back to the default instead of refusing:**

```
FAIL: a step name no step carries — expected [status 2 and a message naming: has no step named] got [status 0 :: bash -e]
FAIL: the body of a step that does not exist — expected [a refusal naming: has no step named] got [… no `run: |` block …]
```

and with `ars.yml`'s step *renamed* on top of M3, the harness refuses loudly
rather than grading an empty body:

```
FAIL: the 'Commit badge update' step body was extracted from .github/workflows/ars.yml — got [workflow-step refused (above) — the scan has gone blind, not the step clean]
FAIL: … — expected [at least 5 non-blank lines] got [0 — the scan has gone blind, not the step clean]
```

**M4 — the brief's obligation: the harness follows a step that gains `shell:`,
and a body relying on the difference is graded accordingly.** The identical
mutated body (`probe=$(false | cat)` spliced into ars.yml's step), run twice:

```
M4a  no `shell:` declared
     == …ars.yml :: 'Commit badge update' runs under `bash -e` (derived) ==
     ars-badge-push_test: ALL PASS          # production semantics: the failure is swallowed

M4b  the same body + `shell: bash`
     == …ars.yml :: 'Commit badge update' runs under `bash --noprofile --norc -e -o pipefail` (derived) ==
     FAIL: ...and the step says the badge was NOT pushed — expected [output containing: NOT pushed] got []
     FAIL: ...as a workflow error annotation … got []
     FAIL: ...having really exhausted all five attempts … got []
     FAIL: a push that succeeds on the third attempt — expected [exit 0] got [exit 1]
     FAIL: ...retried after the first failure … got []
     FAIL: ...and after the second … got []
     FAIL: a push that succeeds first time — expected [exit 0] got [exit 1]
```

**One red nobody planned, which is the good kind.** Adding the library made
`shell-lib-errexit_test.sh` (the #1629/#1633/#1635 tripwire) go red on its own:

```
FAIL: the scan refused a library — got [workflow-step.sh declares 1 function(s) with the `function name {` spelling, which this scan does not understand — it would be walked and silently found empty]
FAIL: recipes and the walk disagree — got [UNDRIVEN workflow-step.sh::workflow_step_shell — no driving recipe and no entry in TW_EXEMPT_KEYS]   (×5 functions)
```

The first is the awk program's own `function flush_step()` matching a grep over
the file's text. Rather than weaken the scan, the state machine was restructured
to commit the wanted step's fields as it learns them (`collecting`), so it needs
no helper at all. The second was answered with seven recipes (0 for an answer, 2
for a refusal — the refusal rows are the load-bearing half: a refusal that
aborted its caller would take the harness down instead of being reported).

**Committed, not described.** The corpus is `tools/lib/testdata/workflow-step/`
— 14 fixtures, one per declaration shape and refusal — plus three obligations in
`workflow-step_test.sh` that keep the derivation honest: the two invocations are
shown to grade the *same* body differently (without it, deriving is ceremony); a
copy of a real workflow is mutated **both ways** (a derivation hard-wired to
either answer passes one direction); and the five real harnessed steps resolve
through the same code.

## Also in this PR

The deletion guard's `command -v jq >/dev/null || { sudo apt-get … jq; }` was
dead — `grep -n 'jq' .github/workflows/replaydata-deletion-guard.yml` now returns
nothing, i.e. the install was the only reference in the file. Removed, along
with the two harness stubs (`jq() { :; }`, `sudo() { … 99; }`) that existed only
to neutralise it.

## What ran where

**On a real runner — including this PR's own run, which re-measures the premise
a third time.** Every step of `test.yml`'s `go-test` job on run 31961873535
reports the corrected invocation, seven steps over:

```
$ gh run view 31961873535 --log | grep 'shell: ' | sort -u
go-test  gofmt check                       shell: /bin/bash -e {0}
go-test  Lint skill files                  shell: /bin/bash -e {0}
go-test  Smoke-test the recording rig      shell: /bin/bash -e {0}
go-test  Test core module                  shell: /bin/bash -e {0}
go-test  Test onboarding-factory module    shell: /bin/bash -e {0}
go-test  Test starhistory module           shell: /bin/bash -e {0}
go-test  Test the shared shell libs        shell: /bin/bash -e {0}
```

and the new suite ran there, deriving the same answers it derives locally:

```
== .github/workflows/ars.yml :: 'Commit badge update' runs under `bash -e` (derived) ==
== .github/workflows/replaydata-deletion-guard.yml :: 'Detect deletions …' runs under `bash -e` (derived) ==
== .github/workflows/test.yml :: 'Test the shared shell libs' runs under `bash -e` (derived) ==
   PASS: ...and the step that GAINED `shell: bash` -> bash --noprofile --norc -e -o pipefail
   PASS: ...and a step whose JOB gained `defaults: run: shell: bash` -> bash --noprofile --norc -e -o pipefail
workflow-step_test: ALL PASS
shell-lib-suite: tools/lib — found 14, skipped 1 (posix-lint_test.sh), ran 13, failed 0
```

Plus the two `gh run view` measurements quoted at the top (existing runs). This
PR's diff touches no `replaydata/`, so the deletion-guard workflow does not fire
on it — its step is graded by the harness only.

- **Locally:** every mutation above, and the gates below.

## Gates

- `tools/preflight.sh --only tools` → **PASS**
  (`shell-lib-suite: tools/lib — found 14, skipped 0 (none), ran 14, failed 0`;
  zero `FAIL` lines in 41KB of output). The `tools` trigger already covers
  `^tools/lib/` and `^\.github/workflows/(ars|macos-swift|replaydata-deletion-guard|test)\.yml$`,
  which is every file this PR asserts about — **no sixth widening was needed**,
  and `workflow-step_test.sh` asserts that, including for `macos-swift.yml`.
- `--only swift` **not run**: `platforms/macos/`, `macos-swift.yml`,
  `tools/preflight.sh` and `tools/lib/swift-suite{,_test}.sh` — the whole of that
  gate's trigger — are untouched by this diff.
- `--only skills` **not run**: no `.claude/skills/**/*.md` in the diff.
- The pre-push hook (`preflight.sh --changed`) ran and passed on the push.
- **All 16 PR checks pass**, including `go-test` (which is where the new suite
  runs on a real runner), `swift-build`/`swift-test`/`swift-snapshot-evidence`,
  `ars-gate`, CodeQL, CodeScene and SonarCloud.
