### PR TITLE
fix(ci): make a failed or badge-less ARS scan fail the badge job instead of freezing the badge (#1644)

### DIFF
--- a/.github/workflows/ars.yml
+++ b/.github/workflows/ars.yml
@@ -31,23 +31,78 @@ jobs:
         run: go install github.com/ingo-eichhorst/agent-readyness/cmd/ars@e0ce48b9644df71b8f41b11c8c5655e3efa59660
 
       - name: Run ARS scan
+        # `|| true` used to sit on the scan, and the step's last statement was
+        # `cat` — which succeeds. So ANY failure of `ars scan` (a missing CLI, a
+        # renamed flag, a panic) ended this step at status 0 with an error
+        # message where the badge should be, the next step's grep matched
+        # nothing, its `if` was skipped, and "Commit badge update" reported
+        # `No badge changes to commit`: three green steps and a README badge
+        # silently frozen at its previous score (#1644).
+        #
+        # The `|| true` was NOT protecting a legitimate non-zero. `ars scan`
+        # exits non-zero for a low score only when a threshold is set — pinned
+        # v0.0.9's internal/pipeline/pipeline.go guards it with
+        # `if p.threshold > 0 && … Composite < p.threshold { ExitError{Code: 2} }`,
+        # the flag is documented as "minimum composite score (exit code 2 if
+        # below)", this invocation passes no `--threshold`, and the repo carries
+        # no `.arsrc.yml` for `projectCfg.Scoring.Threshold` to supply one.
+        # Measured: the pinned binary scoring ./core at 7.9/10 — below the 8.1
+        # the README showed at the time — exits 0. So every non-zero here is a
+        # real failure and the job should say so.
+        #
+        # `|| scan_status=$?` rather than a bare `ars …; scan_status=$?`: the
+        # runner gives this step `bash -e {0}`, under which the bare form aborts
+        # at the failing command and never reaches the capture (#1629 is that
+        # exact trap). An `||` list suppresses errexit, so the status is ours to
+        # read. `cat` runs before the verdict, so the scan's own output is in
+        # the log on both paths.
         run: |
-          ars scan ./core --no-llm --badge > ars-output.txt 2>&1 || true
+          scan_status=0
+          ars scan ./core --no-llm --badge > ars-output.txt 2>&1 || scan_status=$?
           cat ars-output.txt
+          if [ "$scan_status" -ne 0 ]; then
+            echo "::error::ARS scan FAILED (exit $scan_status). No score was produced, so README.md was NOT updated and still shows the previous score. The scan's own output is above."
+            exit 1
+          fi
 
       - name: Extract and update ARS badge
+        # Three outcomes, never two — the same discipline #1645 put on the
+        # deletion guard. The badge was extracted and written (pass); the scan
+        # produced output with no badge in it (fail, naming that the output
+        # format changed); the rewrite did not land in README.md (fail, naming
+        # that). Each `if [ -n … ]` below used to be a silent skip whose only
+        # trace was a `No badge changes to commit` in the NEXT step.
+        #
+        # The last guard is the one that is easy to leave out and is the same
+        # defect one level down: `sed` exits 0 having matched nothing, so a
+        # README whose badge line was reformatted (or removed, or a URL carrying
+        # a `&` that sed re-reads as the whole match) leaves the file untouched
+        # while this step prints "README updated". Re-reading the file for the
+        # URL just written is what tells "the score did not change" — where the
+        # rewrite is a no-op because it wrote the same URL back, and README
+        # therefore CONTAINS it — from "nothing was rewritten".
         run: |
           ARS_BADGE=$(grep "img.shields.io/badge/ARS" ars-output.txt | head -1 || echo "")
           echo "ARS Badge line: $ARS_BADGE"
-
-          if [ -n "$ARS_BADGE" ]; then
-            ARS_URL=$(echo "$ARS_BADGE" | grep -o 'https://img\.shields\.io/badge/ARS[^)]*' | head -1 || echo "")
-            echo "ARS URL: $ARS_URL"
-            if [ -n "$ARS_URL" ]; then
-              sed -i "s|https://img.shields.io/badge/ARS-[^)]*|${ARS_URL}|g" README.md
-              echo "README updated with ARS badge URL"
-            fi
+          if [ -z "$ARS_BADGE" ]; then
+            echo "::error::the ARS scan succeeded but its output carries no img.shields.io/badge/ARS line, so there is no score to write. README.md was NOT updated and still shows the previous score — most likely \`--badge\` stopped emitting one, or the output format changed. Full scan output:"
+            cat ars-output.txt
+            exit 1
           fi
+
+          ARS_URL=$(echo "$ARS_BADGE" | grep -o 'https://img\.shields\.io/badge/ARS[^)]*' | head -1 || echo "")
+          echo "ARS URL: $ARS_URL"
+          if [ -z "$ARS_URL" ]; then
+            echo "::error::a badge line was found but no https://img.shields.io/badge/ARS… URL could be read out of it, so README.md was NOT updated. The line was: $ARS_BADGE"
+            exit 1
+          fi
+
+          sed -i "s|https://img.shields.io/badge/ARS-[^)]*|${ARS_URL}|g" README.md
+          if ! grep -qF "$ARS_URL" README.md; then
+            echo "::error::README.md does not contain the badge URL this step just wrote, so the badge is NOT updated. Either README.md carries no https://img.shields.io/badge/ARS-… URL for the rewrite to match, or the rewrite produced something else. Wanted: $ARS_URL"
+            exit 1
+          fi
+          echo "README updated with ARS badge URL"
 
       - name: Commit badge update
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -991,9 +991,9 @@ Before marking a ticket done, run the full suite — every layer must pass:
   re-measured on every run, which doubles as the vacuity guard — if bash ever
   stopped aborting, the fix would be protecting nothing and would pass for the
   wrong reason.
-- The ARS badge push: `tools/lib/ars-badge-push_test.sh` EXTRACTS
-  `.github/workflows/ars.yml`'s "Commit badge update" step out of the workflow
-  file and EXECUTES it against a git stub, under the invocation that step
+- The ARS badge job: `tools/lib/ars-badge-push_test.sh` EXTRACTS each of
+  `.github/workflows/ars.yml`'s three `run:` steps out of the workflow
+  file and EXECUTES it against a stub, under the invocation that step
   actually gets — DERIVED from the workflow, today `bash -e` (see "Which bash a
   workflow step gets" below; this bullet claimed
   `bash --noprofile --norc -e -o pipefail` until #1650). Behavioural rather
@@ -1030,6 +1030,44 @@ Before marking a ticket done, run the full suite — every layer must pass:
   `$?`-keyed rule, and #1639 about the sibling family. `preflight.sh`'s `tools`
   trigger gains `ars.yml`, its fourth widening for this reason (#1591, #1629,
   #1639), because that assertion lives entirely inside that gate.
+  **The two steps ABOVE it produced the same symptom for the same reason**
+  (#1644): `ars scan … || true` followed by a `cat` that succeeds, then an
+  extract step whose `if [ -n "$ARS_BADGE" ]` skipped in silence — three green
+  steps, `No badge changes to commit`, and a frozen badge. The `|| true` was
+  **not** protecting a legitimate low-score exit, and that had to be checked
+  rather than assumed because the issue proposed leaving it in place: pinned
+  v0.0.9 returns `ExitError{Code: 2}` only under `if p.threshold > 0`, this
+  invocation passes no `--threshold`, and there is no `.arsrc.yml` to supply
+  one — measured, the pinned binary scoring `./core` at 7.9/10 exits 0. So the
+  scan's status is now read (`|| scan_status=$?`, never a bare `; rc=$?`, the
+  line #1629's implicit `-e` never reaches) and three outcomes are
+  distinguished where there were two: the scan FAILED / it succeeded with no
+  badge line in its output / the badge was extracted. Three things about the
+  shape are worth carrying. Each refusal asserts the other two's WORDING is
+  ABSENT, because a shared non-zero is satisfied by three refusals that all
+  fire together — measured: deleting the missing-badge refusal leaves the step
+  exiting 1 via the URL refusal, so every status arm stays green and only the
+  wording arms go red. The last guard is the same defect one level down —
+  `sed` exits 0 having matched nothing, so the file is re-read for the URL just
+  written, which is also what tells the legitimate no-op of an unchanged score
+  (the URL is present, because it was written back identically) from a rewrite
+  that landed nowhere; deleting THAT refusal is not merely silent, since the
+  empty `$ARS_URL` then deletes README's badge URL outright (measured). And a
+  failed scan **fails the job**, because this workflow gates nothing: it runs
+  post-merge on `main`, no PR and no merge depends on it, and its own "Install
+  ARS CLI" step already fails the job for the likeliest transient cause (a
+  `go install` outage) — a scan that could not run was the one failure here
+  that was silent.
+  Audited while there, per "dismissals carry evidence": the only statement left
+  in this job whose status is read more narrowly than it is produced is
+  `git diff --staged --quiet`, whose three-valued status (0 / 1 / error) an
+  `if` reads as two-valued — and the misread routes to the `else` branch, where
+  `git commit` with nothing staged exits 1 and errexit aborts the step.
+  Measured under `bash -e` rather than argued: it degrades to a LOUD failure,
+  never a silent pass. `git config` / `git add` / `git commit` are simple
+  commands in bare statement position, so errexit already decides on them (also
+  measured), and no `run:` block in this workflow reads a `${{ }}` expansion, so
+  #1645's second hazard has no instance here.
 - The replaydata deletion guard:
   `tools/lib/replaydata-deletion-guard_test.sh` does to
   `.github/workflows/replaydata-deletion-guard.yml`'s "Detect deletions of

--- a/tools/lib/ars-badge-push_test.sh
+++ b/tools/lib/ars-badge-push_test.sh
@@ -1,6 +1,14 @@
 #!/usr/bin/env bash
-# ars-badge-push_test.sh — the lock on .github/workflows/ars.yml's
-# "Commit badge update" step (#1641).
+# ars-badge-push_test.sh — the lock on .github/workflows/ars.yml's badge job.
+#
+# The filename predates its scope. It was written for the "Commit badge update"
+# step (#1641) and grew to cover "Run ARS scan" and "Extract and update ARS
+# badge" (#1644) — the two steps that PRODUCE the badge that step pushes. One
+# harness per workflow rather than one per step, because the three share a
+# workflow file, a `workflow_step_shell` derivation, an assertion vocabulary
+# and one preflight trigger; splitting them would duplicate all four and let
+# the copies disagree, which is what tools/lib/workflow-step.sh exists to stop.
+# Renaming the file was declined as pure churn against five commits of history.
 #
 # ---------------------------------------------------------------------------
 # What is being asserted, and why each obligation exists
@@ -40,6 +48,51 @@
 #      attempt succeeds must exit 0 AND show that the first two were retried.
 #   4. the clean paths still pass: nothing staged, and a first-attempt push.
 #
+# ---------------------------------------------------------------------------
+# #1644 — the two steps ABOVE it, same job, same symptom
+#
+# The badge that step pushes is produced by "Run ARS scan" and "Extract and
+# update ARS badge", and both used to answer "I could not look" with the same
+# bytes as "there was nothing to do":
+#
+#     ars scan ./core --no-llm --badge > ars-output.txt 2>&1 || true
+#     cat ars-output.txt
+#
+# `|| true` swallows any failure and the block's last statement is `cat`, which
+# succeeds. `ars-output.txt` then holds an error, the extract step's `grep`
+# matches nothing, its `if [ -n "$ARS_BADGE" ]` is skipped in silence, README is
+# untouched, and "Commit badge update" reports `No badge changes to commit`.
+# Three green steps and a badge frozen at its previous score.
+#
+# The obligations added for it:
+#
+#   5. the defect is re-MEASURED, not described: both pre-#1644 bodies are
+#      emitted verbatim and run against a failing `ars`, and both still exit 0
+#      with README unchanged. The permanent vacuity guard for 6-11 — if that
+#      ever stopped reproducing, they would all pass for the wrong reason.
+#   6. a FAILED scan is no longer green, and the step says the badge was not
+#      updated. The scan's own output is still printed, on both paths, or the
+#      failure has no diagnosis in the log.
+#   7. a scan that SUCCEEDS is still green (the vacuity guard for 6 — a step
+#      that failed unconditionally would satisfy 6 perfectly).
+#   8. a NORMAL run still rewrites the badge: the real README.md, the real
+#      extract body, a new score in, the new URL in the file and the old one
+#      gone. The vacuity guard for 9-11, and the only arm that would notice the
+#      whole step being replaced by `exit 1`.
+#   9. output with NO badge line is a named failure — the third outcome the
+#      issue is about, since it means `--badge` stopped emitting one rather
+#      than that the score was unchanged.
+#  10. a badge line carrying no extractable URL is its OWN named failure.
+#  11. a rewrite that did not land in README.md is its OWN named failure. `sed`
+#      exits 0 having matched nothing, so this is the same defect one level
+#      down, and re-reading the file for the URL just written is what
+#      distinguishes it from the legitimate no-op of an unchanged score.
+#
+#  9-11 additionally assert that each refusal does NOT print the other two's
+#  wording. Three refusals that all fire together, or all print the same
+#  sentence, would satisfy every arm above while leaving the operator exactly
+#  where the `if` skips left them: a red step and no idea which thing broke.
+#
 # Deliberately NOT a general workflow linter, and the measurement is the
 # honest part. Over this repo's 19 multi-line `run:` blocks, a rule keyed on
 # "the block's last statement is echo/sleep/cat/printf" flags 6 and MISSES
@@ -69,6 +122,8 @@ need bash
 
 WF=.github/workflows/ars.yml
 STEP='Commit badge update'
+SCAN_STEP='Run ARS scan'
+EXTRACT_STEP='Extract and update ARS badge'
 
 # The step's body AND the shell it runs under both come from the workflow file,
 # through tools/lib/workflow-step.sh — see the invocation block below.
@@ -112,12 +167,32 @@ want_absent() { # label needle haystack
 # the workflow, and a step that later gains `shell: bash` moves this harness
 # with it. workflow-step.sh REFUSES rather than defaulting when it cannot find
 # the step, which is why this is a hard exit and not a fallback.
-if ! STEP_SHELL=$(workflow_step_shell "$WF" "$STEP"); then
-  echo "FAIL: ars-badge-push_test — could not derive the shell $WF gives '$STEP' (refusal above); nothing below would have graded the real program" >&2
-  exit 1
-fi
-read -r -a STEP_ARGV <<<"$STEP_SHELL"
-echo "== $WF :: '$STEP' runs under \`$STEP_SHELL\` (derived) =="
+#
+# Derived once per step, never once per file: the three steps are independent
+# declarations and any one of them could gain a `shell:` on its own.
+#
+# `derive_or_die` writes to a GLOBAL rather than printing its answer, because
+# the obvious `x=$(derive_or_die …)` spelling runs the function in a subshell,
+# where its `exit 1` exits only that subshell and the caller carries on with an
+# empty invocation — a refusal that does not refuse, in a file about exactly
+# that.
+DERIVED=
+derive_or_die() { # <step-name> -> sets DERIVED, or exits
+  if ! DERIVED=$(workflow_step_shell "$WF" "$1"); then
+    echo "FAIL: ars-badge-push_test — could not derive the shell $WF gives '$1' (refusal above); nothing below would have graded the real program" >&2
+    exit 1
+  fi
+}
+use_shell() { read -r -a STEP_ARGV <<<"$1"; }
+
+derive_or_die "$STEP";         STEP_SHELL="$DERIVED"
+derive_or_die "$SCAN_STEP";    SCAN_SHELL="$DERIVED"
+derive_or_die "$EXTRACT_STEP"; EXTRACT_SHELL="$DERIVED"
+use_shell "$STEP_SHELL"
+echo "== $WF: derived step invocations =="
+echo "   '$STEP' -> \`$STEP_SHELL\`"
+echo "   '$SCAN_STEP' -> \`$SCAN_SHELL\`"
+echo "   '$EXTRACT_STEP' -> \`$EXTRACT_SHELL\`"
 
 # ---------------------------------------------------------------------------
 # The harness: stubs, then a body, run under that shell.
@@ -256,6 +331,300 @@ else
     # ...and the strip must not have eaten the code, or the arm above is
     # vacuous: an empty haystack contains no needle.
     want_contains "...checked against the step's real code, not an empty strip" "git push" "$code"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# #1644 — the two steps that PRODUCE the badge "Commit badge update" pushes.
+#
+# Every case runs in a throwaway directory holding exactly what the runner's
+# workspace holds at that point (an `ars-output.txt`, a `README.md`), so the
+# repo's real README.md is never written to. The one arm that grades the real
+# README COPIES it in — that arm is the reason `sed`'s pattern is checked
+# against the file it actually has to match rather than against a fixture
+# written to match it.
+
+want_file_contains() { # label needle file
+  if grep -qF "$2" "$3" 2>/dev/null; then pass "$1"
+  else fail "$1" "$3 containing: $2" "$(flat "$(cat "$3" 2>/dev/null)")"; fi
+  return 0
+}
+want_file_absent() { # label needle file
+  if grep -qF "$2" "$3" 2>/dev/null; then fail "$1" "$3 NOT containing: $2" "$(flat "$(cat "$3" 2>/dev/null)")"
+  else pass "$1"; fi
+  return 0
+}
+
+# The `ars` stub prints ./.ars-stdout and returns the status it was built with.
+# A subcommand it does not model answers a loud, distinctive 99 naming the call,
+# and a MISSING ./.ars-stdout a 98 — never a quiet 0, which is what would make
+# every arm below pass for a reason unrelated to its obligation.
+ars_stub() { # $1 = status the stub returns for `ars scan`
+  cat <<STUB
+ars() {
+  case "\$1" in
+    scan) cat ./.ars-stdout || { echo "STUB: no ./.ars-stdout in \$(pwd)" >&2; return 98; }
+          return $1 ;;
+    *)    echo "STUB: unmodelled call: ars \$*" >&2; return 99 ;;
+  esac
+}
+STUB
+}
+
+# GNU vs BSD `sed -i`. ars.yml runs on ubuntu-latest, where `-i` takes no
+# argument; this harness runs wherever the shell-lib suite runs, which includes
+# test.yml's macos-latest runner and every developer's Mac, where BSD sed reads
+# the SCRIPT as `-i`'s backup suffix. Measured on this machine:
+# `sed -i "s|a|b|g" f` -> `sed: 1: "…": invalid command code f`, file unchanged.
+# So `-i` is re-expressed portably over the REAL sed, preserving the script
+# semantics this file grades — in particular that a script matching nothing
+# rewrites the file with identical bytes and exits 0, which is obligation 11's
+# whole subject. Any other `-i` form is a loud refusal, not a quiet 0.
+sed_shim() {
+  cat <<'STUB'
+sed() {
+  if [ "$1" = "-i" ]; then
+    if [ "$#" -ne 3 ]; then echo "STUB: unmodelled sed -i form: sed $*" >&2; return 99; fi
+    command sed "$2" "$3" >"$3.stub.new" || return $?
+    command mv "$3.stub.new" "$3" || return $?
+    return 0
+  fi
+  command sed "$@"
+}
+STUB
+}
+
+CASE=
+new_case() { # <name> -> sets CASE to a fresh, empty directory
+  CASE="$TMP/case-$1"
+  rm -rf "$CASE"
+  mkdir -p "$CASE" || { echo "FAIL: ars-badge-push_test — cannot create case dir $CASE" >&2; exit 1; }
+  { ars_stub "${2:-0}"; sed_shim; } >"$CASE/.prelude"
+}
+
+run_step() { # <workdir> <shell-string> <body-file> -> sets OUT / ST
+  local dir="$1" body="$3" script="$1/.step.sh"
+  use_shell "$2"
+  { cat "$dir/.prelude"; cat "$body"; } >"$script"
+  # Same reasoning as run_body: no `set +e` toggle, because a non-zero inner
+  # status is the EXPECTED outcome of most arms here and is data, not an abort.
+  OUT=$(cd "$dir" && "${STEP_ARGV[@]}" .step.sh 2>&1)
+  ST=$?
+  return 0
+}
+
+extract_body() { # <step-name> <min-non-blank-lines> <outfile> -> 0 on success
+  local name="$1" min="$2" out="$3" lines
+  if ! workflow_step_body "$WF" "$name" >"$out"; then
+    fail "the '$name' step body was extracted from $WF" \
+         "the step's run: | body" "workflow-step refused (above) — the scan has gone blind, not the step clean"
+    return 1
+  fi
+  lines=$(grep -cve '^[[:space:]]*$' "$out")
+  if [[ "${lines:-0}" -lt "$min" ]]; then
+    fail "the '$name' step body was extracted from $WF" \
+         "at least $min non-blank lines" "$lines — the scan has gone blind, not the step clean"
+    return 1
+  fi
+  pass "extracted the '$name' step body from $WF ($lines non-blank lines)"
+  return 0
+}
+
+# The four refusals must be told apart by their WORDING, not only by a shared
+# non-zero. Three refusals printing the same sentence would satisfy every
+# status arm below and leave an operator exactly where the silent `if` skips
+# left them: something is red, and no idea which thing broke.
+P_SCANFAIL='ARS scan FAILED'
+P_NOBADGE='carries no img.shields.io/badge/ARS line'
+P_NOURL='could be read out of it'
+P_NOWRITE='does not contain the badge URL this step just wrote'
+
+SCAN_ERR='ars: command failed: no such subcommand'
+NEW_URL='https://img.shields.io/badge/ARS-Agent--Ready%209.9%2F10-brightgreen'
+badge_output() { # <url> -> a plausible `ars scan --badge` tail
+  printf 'Badge\n----------------------------------------\n[![ARS](%s)](https://github.com/ingo-eichhorst/agent-readyness)\n' "$1"
+}
+
+# The real README is read, not assumed: if it carries no ARS badge URL there is
+# nothing for this workflow to rewrite, and obligations 8 and 5 would both be
+# grading a fixture written to match the pattern under test.
+OLD_URL=$(grep -o 'https://img\.shields\.io/badge/ARS[^)]*' README.md | head -1 || echo "")
+
+echo ""
+echo "== $WF: $SCAN_STEP / $EXTRACT_STEP =="
+
+if [[ -z "$OLD_URL" ]]; then
+  fail "README.md carries an ARS badge URL for the badge job to rewrite" \
+       "one https://img.shields.io/badge/ARS-… URL in README.md" \
+       "none — either the badge was removed (this job then has nothing to do and should say so) or this scan has gone blind"
+elif [[ "$OLD_URL" == "$NEW_URL" ]]; then
+  fail "the fixture score differs from README's, or the rewrite arm is vacuous" \
+       "a NEW_URL unlike README's current badge" "both are $OLD_URL"
+else
+  pass "read README.md's current badge URL ($OLD_URL)"
+
+  # -------------------------------------------------------------------------
+  # Obligation 5 — the pre-#1644 bodies, verbatim, re-measured on every run.
+  #
+  # Committed rather than quoted in the issue, per AGENTS.md: "a number which
+  # documents behaviour but is not produced by it drifts silently". This is
+  # also the vacuity guard for 6-11: if `|| true` + a trailing `cat` ever
+  # stopped exiting 0, the fix would be protecting nothing.
+  cat >"$TMP/pre1644-scan.sh" <<'OLD'
+ars scan ./core --no-llm --badge > ars-output.txt 2>&1 || true
+cat ars-output.txt
+OLD
+  cat >"$TMP/pre1644-extract.sh" <<'OLD'
+ARS_BADGE=$(grep "img.shields.io/badge/ARS" ars-output.txt | head -1 || echo "")
+echo "ARS Badge line: $ARS_BADGE"
+
+if [ -n "$ARS_BADGE" ]; then
+  ARS_URL=$(echo "$ARS_BADGE" | grep -o 'https://img\.shields\.io/badge/ARS[^)]*' | head -1 || echo "")
+  echo "ARS URL: $ARS_URL"
+  if [ -n "$ARS_URL" ]; then
+    sed -i "s|https://img.shields.io/badge/ARS-[^)]*|${ARS_URL}|g" README.md
+    echo "README updated with ARS badge URL"
+  fi
+fi
+OLD
+
+  echo ""
+  echo "-- the pre-#1644 bodies (the defect, re-measured) --"
+  new_case pre1644 1
+  printf '%s\n' "$SCAN_ERR" >"$CASE/.ars-stdout"
+  cp README.md "$CASE/README.md"
+  run_step "$CASE" "$SCAN_SHELL" "$TMP/pre1644-scan.sh"
+  if [[ "$ST" -eq 0 ]]; then
+    pass "the old scan body still exits 0 with a failing \`ars\` — the hazard is real"
+  else
+    fail "the old scan body exits 0 with a failing \`ars\` (the hazard this pins)" \
+         "exit 0" "exit $ST — the hazard is GONE, so re-derive the fix rather than trusting it :: $(flat "$OUT")"
+  fi
+  run_step "$CASE" "$EXTRACT_SHELL" "$TMP/pre1644-extract.sh"
+  want_status "...and the old extract body over that error output" 0 "$ST" "$OUT"
+  want_file_contains "...leaving README.md's badge exactly as it was" "$OLD_URL" "$CASE/README.md"
+
+  # -------------------------------------------------------------------------
+  # Obligations 6-7 — the REAL "Run ARS scan" step, extracted and executed.
+  echo ""
+  echo "-- $SCAN_STEP --"
+  # A floor of 2, not of "however many lines the fixed step has": the pre-#1644
+  # body was two lines, so a higher floor would report the mutation that
+  # RESTORES it as "the scan has gone blind" rather than as obligation 6 going
+  # red — a negative result for the wrong reason reads as coverage it is not.
+  # `workflow_step_body` already refuses a zero-line body, which is the blindness
+  # this floor exists on top of.
+  if extract_body "$SCAN_STEP" 2 "$TMP/scan-body.sh"; then
+    new_case scanfail 3
+    printf '%s\n' "$SCAN_ERR" >"$CASE/.ars-stdout"
+    run_step "$CASE" "$SCAN_SHELL" "$TMP/scan-body.sh"
+    if [[ "$ST" -eq 0 ]]; then
+      fail "a failing \`ars scan\` fails the step" "a non-zero exit" "exit 0 :: $(flat "$OUT")"
+    else
+      pass "a failing \`ars scan\` fails the step (exit $ST)"
+    fi
+    want_contains "...as a workflow error annotation, so it surfaces on the run" "::error::" "$OUT"
+    want_contains "...naming the scan as what failed" "$P_SCANFAIL" "$OUT"
+    want_contains "...and that the badge was therefore not updated" "NOT updated" "$OUT"
+    # Without this the failure has no diagnosis anywhere: `ars`'s own message is
+    # redirected into the file, so a step that exits 1 without printing it is a
+    # red X over an empty log.
+    want_contains "...with the scan's own output still in the log" "$SCAN_ERR" "$OUT"
+
+    # Obligation 7, the vacuity guard: a step that failed unconditionally would
+    # satisfy every arm above.
+    new_case scanok 0
+    badge_output "$NEW_URL" >"$CASE/.ars-stdout"
+    run_step "$CASE" "$SCAN_SHELL" "$TMP/scan-body.sh"
+    want_status "a succeeding \`ars scan\` still passes" 0 "$ST" "$OUT"
+    want_absent "...with no error annotation" "::error::" "$OUT"
+    want_file_contains "...having captured the scan output for the next step" "$NEW_URL" "$CASE/ars-output.txt"
+
+    # `|| true` is the false fix for this family and is refused by name — it is
+    # what the step used to carry. Comments are stripped first for the same
+    # reason the push arm strips them: the workflow's prose explains why it is
+    # not used, and a raw scan fails on the sentence saying the right thing.
+    code=$(grep -v '^[[:space:]]*#' "$TMP/scan-body.sh")
+    want_absent "the scan step does not reach for \`|| true\`" "|| true" "$code"
+    want_contains "...checked against the step's real code, not an empty strip" "ars scan" "$code"
+  fi
+
+  # -------------------------------------------------------------------------
+  # Obligations 8-11 — the REAL "Extract and update ARS badge" step.
+  echo ""
+  echo "-- $EXTRACT_STEP --"
+  if extract_body "$EXTRACT_STEP" 8 "$TMP/extract-body.sh"; then
+    # Obligation 8, the vacuity guard for 9-11: a fix that refuses everything
+    # is indistinguishable from one that works until something still works.
+    # Graded against the REAL README.md, so the `sed` pattern is checked
+    # against the file it has to match.
+    new_case extractok 0
+    badge_output "$NEW_URL" >"$CASE/ars-output.txt"
+    cp README.md "$CASE/README.md"
+    run_step "$CASE" "$EXTRACT_SHELL" "$TMP/extract-body.sh"
+    want_status "a normal run still updates the badge" 0 "$ST" "$OUT"
+    want_contains "...and says so" "README updated with ARS badge URL" "$OUT"
+    want_file_contains "...having written the new URL into README.md" "$NEW_URL" "$CASE/README.md"
+    want_file_absent "...and replaced the old one rather than appending" "$OLD_URL" "$CASE/README.md"
+    want_absent "...with no error annotation" "::error::" "$OUT"
+
+    # Obligation 9 — output with no badge line at all.
+    new_case nobadge 0
+    printf '%s\n' "$SCAN_ERR" >"$CASE/ars-output.txt"
+    cp README.md "$CASE/README.md"
+    run_step "$CASE" "$EXTRACT_SHELL" "$TMP/extract-body.sh"
+    if [[ "$ST" -eq 0 ]]; then
+      fail "output with no badge line fails the step" "a non-zero exit" "exit 0 :: $(flat "$OUT")"
+    else
+      pass "output with no badge line fails the step (exit $ST)"
+    fi
+    want_contains "...as a workflow error annotation" "::error::" "$OUT"
+    want_contains "...naming the missing badge line specifically" "$P_NOBADGE" "$OUT"
+    want_contains "...and printing the output it could not read a badge out of" "$SCAN_ERR" "$OUT"
+    want_absent "...not confused with the unreadable-URL refusal" "$P_NOURL" "$OUT"
+    want_absent "...nor with the rewrite-did-not-land refusal" "$P_NOWRITE" "$OUT"
+    want_file_contains "...leaving README.md's badge untouched" "$OLD_URL" "$CASE/README.md"
+
+    # Obligation 10 — a badge line whose URL cannot be read. Same shape one
+    # level down, and the issue asked for it by name.
+    new_case nourl 0
+    printf '[![ARS](img.shields.io/badge/ARS-unparseable)](x)\n' >"$CASE/ars-output.txt"
+    cp README.md "$CASE/README.md"
+    run_step "$CASE" "$EXTRACT_SHELL" "$TMP/extract-body.sh"
+    if [[ "$ST" -eq 0 ]]; then
+      fail "a badge line with no extractable URL fails the step" "a non-zero exit" "exit 0 :: $(flat "$OUT")"
+    else
+      pass "a badge line with no extractable URL fails the step (exit $ST)"
+    fi
+    want_contains "...naming the unreadable URL specifically" "$P_NOURL" "$OUT"
+    want_absent "...not confused with the missing-badge-line refusal" "$P_NOBADGE" "$OUT"
+    want_absent "...nor with the rewrite-did-not-land refusal" "$P_NOWRITE" "$OUT"
+    want_file_contains "...leaving README.md's badge untouched" "$OLD_URL" "$CASE/README.md"
+
+    # Obligation 11 — the rewrite that matched nothing. `sed` exits 0 having
+    # matched nothing, so before #1644 this printed "README updated" over an
+    # unchanged file and the push step then reported `No badge changes`.
+    new_case nowrite 0
+    badge_output "$NEW_URL" >"$CASE/ars-output.txt"
+    printf '# Irrlicht\n\nA README carrying no ARS badge at all.\n' >"$CASE/README.md"
+    run_step "$CASE" "$EXTRACT_SHELL" "$TMP/extract-body.sh"
+    if [[ "$ST" -eq 0 ]]; then
+      fail "a rewrite that matched nothing fails the step" "a non-zero exit" "exit 0 :: $(flat "$OUT")"
+    else
+      pass "a rewrite that matched nothing fails the step (exit $ST)"
+    fi
+    want_contains "...naming the unwritten README specifically" "$P_NOWRITE" "$OUT"
+    want_absent "...and does NOT claim the README was updated" "README updated with ARS badge URL" "$OUT"
+    want_absent "...not confused with the missing-badge-line refusal" "$P_NOBADGE" "$OUT"
+    want_absent "...nor with the unreadable-URL refusal" "$P_NOURL" "$OUT"
+
+    # The step's two `|| echo ""` are deliberate and stay — they keep an empty
+    # capture readable so the named refusal above can report it, rather than
+    # letting errexit abort with a line number. `|| true` is the different
+    # thing, and the one this family keeps having to refuse.
+    code=$(grep -v '^[[:space:]]*#' "$TMP/extract-body.sh")
+    want_absent "the extract step does not reach for \`|| true\`" "|| true" "$code"
+    want_contains "...checked against the step's real code, not an empty strip" "sed -i" "$code"
   fi
 fi
 


### PR DESCRIPTION
Closes #1644

Seventh member of the family, two steps above #1641's. Same job, same user-visible symptom: a
README badge that quietly stops tracking `main` behind a green history.

```
ars scan ./core --no-llm --badge > ars-output.txt 2>&1 || true
cat ars-output.txt
```

`|| true` swallows any failure, the block's last statement is `cat` and it succeeds, so the step
is green with an error message where the badge should be. `grep` then matches nothing, the
extract step's `if [ -n "$ARS_BADGE" ]` is skipped in **silence**, README is untouched, and
"Commit badge update" reports `No badge changes to commit`. Three green steps.

## The `|| true` was not protecting anything — checked, not assumed

The issue explicitly said *"probably not by removing the `|| true`: it may well be there because
`ars scan` exits non-zero on a low score, and no comment says either way — worth checking against
the CLI before touching it."* Checked, three ways, and it does not:

- `ars scan --help` documents `--threshold float   minimum composite score (exit code 2 if below)`.
- Pinned `v0.0.9`'s source guards that path with `if p.threshold > 0 && p.scored != nil &&
  p.scored.Composite < p.threshold { return &types.ExitError{Code: 2} }`
  (`internal/pipeline/pipeline.go:193`). The workflow passes **no** `--threshold`, and the repo
  carries **no `.arsrc.yml`** for `projectCfg.Scoring.Threshold` to supply one, so `p.threshold`
  is 0 and the branch is unreachable.
- Measured, with the binary the workflow actually installs
  (`go install …/cmd/ars@e0ce48b9644df71b8f41b11c8c5655e3efa59660`), scanning `./core`:

  ```
  ARS EXIT=0
  [![ARS](https://img.shields.io/badge/ARS-Agent--Assisted%207.9%2F10-yellow)](…)
  ```

  7.9/10 — *below* the 8.1 the README shows — and it exits 0.

So every non-zero from this invocation is a real failure. `tools/ars-gate.sh` already relies on
that: it runs `ars scan … --json` under `set -euo pipefail` with no `|| true` at all.

## Blast radius: a failed scan fails the job

Argued rather than picked. This workflow's only product is a README badge; it triggers on push to
`main` and `workflow_dispatch`, gates nothing, and is required by neither branch protection nor
the "Protect Main" ruleset. Failing it costs a red X on a post-merge workflow, which is exactly
the signal wanted — "the badge is no longer tracking main". The transient-failure worry is
already answered by the job itself: the likeliest transient cause is a `go install` outage, and
the **"Install ARS CLI" step has no `|| true` and already fails the job for it**. Making the scan
consistent with its own installer is the coherent choice; "silently stale" was the only failure
in this job that was quiet, and it is now unreachable.

## The fix — three outcomes, never two

**"Run ARS scan"**: `|| scan_status=$?` (an `||` list, where errexit is suppressed and the status
is ours to read) rather than a bare `ars …; scan_status=$?`, which under GitHub's `bash -e {0}`
aborts at the failing command and never reaches the capture — #1629's exact trap. `cat` runs
*before* the verdict, so the scan's own output is in the log on both paths; without that a
failure is a red X over an empty step.

**"Extract and update ARS badge"**: each silent `if [ -n … ]` skip becomes a named refusal —
**no badge line in the output** (the outcome the issue is about: it means the format changed, not
that the score is unchanged), and **no URL readable out of the badge line** (the same shape one
level down, which the issue asked for by name).

Plus a third the issue did not name and which is the same defect one level further down: `sed`
exits 0 having matched nothing, so a README whose badge line was reformatted or removed leaves
the file untouched while the step prints `README updated`. The file is now re-read for the URL
just written. That is also what distinguishes the **legitimate** no-op — an unchanged score
rewrites the same URL back, so README *contains* it — from a rewrite that landed nowhere.

## Neighbour audit — every deciding statement, every blind one

All six steps, under the invocation `tools/lib/workflow-step.sh` derives: **`bash -e`** for all
three `run:` steps (re-confirmed on a real runner this PR dispatched — `shell: /usr/bin/bash -e {0}`).

| Step | Statement that DECIDES the status | Statements whose failure it CANNOT see |
|---|---|---|
| Checkout code | the action's own | — (`uses:` step, no `run:` block) |
| Set up Go | the action's own | — (`uses:` step, no `run:` block) |
| Install ARS CLI | `go install …` — the only statement | **none**: no `\|\|`, no pipe, no substitution, nothing after it |
| Run ARS scan (before) | `cat ars-output.txt` | `ars scan … \|\| true` |
| Run ARS scan (after) | `if [ "$scan_status" -ne 0 ]` → `exit 1`; the `if` itself on the clean path | `cat` — but it aborts loudly under `-e`, it is not silent |
| Extract badge (before) | `echo "README updated…"` on the happy path, **the `if` compound itself on both skips** | `grep \| head \|\| echo ""` ×2 (a pipeline reports `head`'s 0), and `sed -i`, which exits 0 having matched nothing |
| Extract badge (after) | three refusal blocks ending `exit 1`; the final `echo` on the success path | the two captures are still blind to `grep`'s status **by construction** — now harmless, because the emptiness they produce is read one line later by a named refusal; `sed -i` is still blind to matching nothing, and is read by the `grep -qF` after it |
| Commit badge update | `if git diff --staged --quiet` (branch choice); `echo "No badge changes…"`; `if [ "$pushed" -ne 1 ]` → `exit 1` | see below |

**Clearing "Commit badge update", with the evidence** — this family's two worst instances were
both cleared by someone reading the construct that *looked* like the hazard instead of the
statement that decides the status, so:

- `git config` ×2, `git add README.md`, `git commit` are **simple commands in bare statement
  position**, so errexit already decides on them. Measured, not reasoned about:

  ```
  $ bash -e probe.sh   # git(){ return 7; }; git add README.md; echo reached
  A_EXIT=7   (and no 'reached' line)
  ```

- `git diff --staged --quiet` is the one statement in the whole job whose status is read **more
  narrowly than it is produced**: three-valued (0 no diff / 1 diff / error), read by an `if` as
  two-valued. I traced where the misread lands rather than stopping at "a construct exists":

  ```
  $ bash -e probe2.sh   # git diff -> 128, git commit -> 1
  B: took the CHANGES branch (128 read as 'there are changes')
  git: nothing to commit
  B_EXIT=1
  ```

  It degrades to a **loud** abort, never a silent pass. Left alone deliberately.

- `sleep $((i * 3))` is #1641's defect, now read by `pushed`. The `git pull --rebase && git push`
  pair sits in an `if` condition, where errexit is suppressed and the status is read.
- No `run:` block in this workflow reads a `${{ }}` expansion, so #1645's second hazard (a
  `workflow_dispatch` expanding the PR context to empty) **has no instance here**. Checked by
  reading all six steps: the only `${{ }}` in the file is `token:` in the checkout `with:`.

Two things the audit turned up that are **not** status-blindness and are filed rather than fixed:
**#1654** (the push is refused by the Protect Main ruleset on every run — the badge has actually
been frozen since 2026-04-26 for that reason, which #1647 made visible) and **#1655** (the retry
loop never aborts a failed rebase, so 4 of the 5 attempts cannot run).

## The lock

Extends `tools/lib/ars-badge-push_test.sh` rather than adding a sibling: the three steps share a
workflow file, one `workflow_step_shell` derivation, one assertion vocabulary and one preflight
trigger, and splitting them would duplicate all four and let the copies disagree — which is what
`tools/lib/workflow-step.sh` exists to stop. The filename now predates its scope; renaming was
declined as churn against five commits of history, and the header says so.

Seven obligations added (5-11), numbered in the file. Each case runs in a throwaway directory; the
one arm that grades the **real** `README.md` copies it in, so `sed`'s pattern is checked against
the file it has to match rather than against a fixture written to match it.

Anti-blindness carried forward: the `ars` stub answers an unmodelled subcommand with a loud **99**
naming the call (and a missing fixture with 98), never a quiet 0; each extraction asserts a
non-blank line floor; and each refusal asserts the **other two's wording is absent**, because a
shared non-zero is satisfied by three refusals that all fire together.

One portability note: `sed -i` is re-expressed over the *real* `sed` inside the stub prelude,
because this harness runs on macOS (test.yml's runner and every dev machine) where BSD `sed`
reads the script as `-i`'s backup suffix — measured: `sed: 1: "…": invalid command code f`, file
unchanged. The rewritten form preserves the semantics under test, including "a script matching
nothing rewrites identical bytes and exits 0", which is obligation 11's whole subject.

## Evidence — every obligation's mutation, seen RED

One mutation per foreground call, applied and reverted in the same call with a
`git status --porcelain` assertion after each (all eight came back clean). Green baseline first:
`ars-badge-push_test: ALL PASS`, exit 0.

**M1 — restore the pre-fix scan body (obligation 6).** Obligation 7 stays green:
```
FAIL: a failing `ars scan` fails the step — expected [a non-zero exit] got [exit 0 :: ars: command failed: no such subcommand ]
FAIL: ...as a workflow error annotation, so it surfaces on the run
FAIL: ...naming the scan as what failed
FAIL: ...and that the badge was therefore not updated
FAIL: the scan step does not reach for `|| true`
```

**M2 — the verdict fires on every scan, `-ne 0` → `-ge 0` (obligation 7).** Obligation 6 stays green:
```
PASS: a failing `ars scan` fails the step (exit 1)
FAIL: a succeeding `ars scan` still passes — expected [exit 0] got [exit 1 :: … ::error::ARS scan FAILED (exit 0)…]
FAIL: ...with no error annotation
```

**M3 — the `sed -i` rewrite removed (obligation 8, the vacuity guard).** 9-11 stay green:
```
FAIL: a normal run still updates the badge — expected [exit 0] got [exit 1 …]
FAIL: ...and says so
FAIL: ...having written the new URL into README.md
FAIL: ...and replaced the old one rather than appending
```

**M4 — the missing-badge-line refusal deleted (obligation 9).** This is the one that shows why
the wording arms are load-bearing: **every status arm stays green**, because the URL refusal one
level down still exits 1 — only the wording distinguishes them:
```
PASS: output with no badge line fails the step (exit 1)
FAIL: ...naming the missing badge line specifically
FAIL: ...and printing the output it could not read a badge out of
FAIL: ...not confused with the unreadable-URL refusal
```

**M5 — the unreadable-URL refusal deleted (obligation 10).** Note the third line: without that
refusal the empty `$ARS_URL` makes `sed` **delete** README's badge outright, so the mutation is
not merely silent, it is destructive:
```
FAIL: a badge line with no extractable URL fails the step
FAIL: ...naming the unreadable URL specifically
FAIL: ...leaving README.md's badge untouched
```

**M6 — the post-`sed` verification deleted (obligation 11).** 8-10 stay green:
```
FAIL: a rewrite that matched nothing fails the step
FAIL: ...naming the unwritten README specifically
FAIL: ...and does NOT claim the README was updated
```

**M7 — the step calls `ars version`, which the stub does not model (stub loudness).** Exit 99,
named, rather than a quiet pass:
```
STUB: unmodelled call: ars version
FAIL: ...naming the scan as what failed
FAIL: a succeeding `ars scan` still passes
```

**M8 — the extract step renamed out from under the harness (extraction blindness).**
```
workflow-step: refusing — .github/workflows/ars.yml has no step named "Extract and update ARS badge". …
FAIL: ars-badge-push_test — could not derive the shell … nothing below would have graded the real program
```

**Obligation 5 is a committed reproduction, not a mutation** — the pre-#1644 bodies are emitted
verbatim and re-measured on every run, the way #1642/#1647/#1649 all did:
```
PASS: the old scan body still exits 0 with a failing `ars` — the hazard is real
PASS: ...and the old extract body over that error output (exit 0)
PASS: ...leaving README.md's badge exactly as it was
```
If bash ever stopped behaving that way, obligations 6-11 would all be passing for the wrong
reason, and this is what would say so.

## What ran where

**On a real GitHub runner** (`workflow_dispatch` against a throwaway branch, deleted afterwards
so its badge commit could not land on this PR —
[run 31963062408](https://github.com/ingo-eichhorst/Irrlicht/actions/runs/31963062408)):

```
success  Install ARS CLI
success  Run ARS scan
success  Extract and update ARS badge
failure  Commit badge update
```
```
shell: /usr/bin/bash -e {0}
[![ARS](https://img.shields.io/badge/ARS-Agent--Assisted%207.9%2F10-yellow)](…)
ARS Badge line: [![ARS](https://img.shields.io/badge/ARS-Agent--Assisted%207.9%2F10-yellow)](…)
ARS URL: https://img.shields.io/badge/ARS-Agent--Assisted%207.9%2F10-yellow
README updated with ARS badge URL
```

So both fixed steps run green on a real runner with the real CLI and the real README, and the
post-`sed` verification passes there — the vacuity guard obtained on the machine that matters.
The final step's failure is **not** this PR's: it is #1655 (the rebase left mid-conflict poisoning
retries 2-5), reachable there because the dispatch ref differed from `main`. It is the same
failure `main` has been showing since #1647 for the #1654 reason.

**Locally**: everything else — the mutation matrix, the `ars` source and exit-code checks, the
`bash -e` probes, and the lock itself. The lock will also run on a real runner for free on every
push, via test.yml's `tools/lib/*_test.sh` discovery.

**Not obtainable**: a real run of a *failing* scan. `ars.yml` triggers only on push to `main` and
`workflow_dispatch`, and there is no way to make the pinned CLI fail on a runner without editing
the workflow to lie. That is what the extract-and-execute harness is for.

## Gates

| Gate | Result |
|---|---|
| `tools/preflight.sh --only tools` | **PASS** — `shell-lib-suite: tools/lib — found 14, skipped 0 (none), ran 14, failed 0` |
| `tools/preflight.sh --only skills` | not run — no `.claude/skills/**/*.md` touched (`AGENTS.md` is outside `skill-lint.sh`'s walk, which reads `.claude/skills/` plus tracked `SKILL.md` files) |
| pre-push hook (`--changed`) | PASS on push — `POSIX sh lint` PASS, `tools/lib shell-lib tests` PASS, the rest SKIP for this diff |

The `tools` gate's trigger already covers `ars.yml` (#1641's widening), so a diff touching only
the workflow still runs this lock — asserted by the harness's own last section.

### Post-open: the lock itself, confirmed on a runner

All 14 PR checks green. `go-test`
([31963392611](https://github.com/ingo-eichhorst/Irrlicht/actions/runs/31963392611)) runs the
`tools/lib/*_test.sh` loop on macos-latest, so the seven new obligations executed there too:

```
== tools/lib/ars-badge-push_test.sh ==
== .github/workflows/ars.yml: Run ARS scan / Extract and update ARS badge ==
ars-badge-push_test: ALL PASS
shell-lib-suite: tools/lib — found 14, skipped 1 (posix-lint_test.sh), ran 13, failed 0
```

That is also the `sed -i` portability note paying for itself: BSD `sed` is what that runner has.
