### PR TITLE
fix(macos): stop the snapshot references encoding the recording host's LOCALE (#1630)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1402,9 +1402,9 @@ Before marking a ticket done, run the full suite — every layer must pass:
   The sibling family that is NOT closed is **timezone**: `HistoryFormat`'s
   formatters pin `en_US_POSIX` but never set `timeZone`, and 8 of the 14
   `HistoryViewSnapshotTests` references contain their output, held only by that
-  suite's own `setUp` — tracked separately, since a process-global
+  suite's own `setUp` — #1659, kept separate because a process-global
   `private static let DateFormatter` is not reachable from the view environment
-  the way a `FormatStyle` is.
+  the way a `FormatStyle` is, so it needs its own seam rather than a second key.
   The suite also aborts intermittently (#1523) in a way that **truncates the
   run** while every suite that did report says "0 failures" — so the exit code
   is the only reliable signal, never the last totals line you can see. That is

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1362,6 +1362,49 @@ Before marking a ticket done, run the full suite — every layer must pass:
   2× and 3× through one view instead — whatever the host's scale is, at most one
   arm can agree with it. A host-independence lock that can only be checked on
   one host is not a lock.
+  **Scale was not the only such value: the LOCALE was one too** (#1630).
+  `BackchannelRulesView`'s threshold field renders through `format: .number`, so
+  its reference PNG read `150.000` — a picture of the recording contributor's
+  `de_DE` regional settings, where a runner renders `150,000`. Three things
+  there are worth carrying and none is the obvious one. **The fix the issue
+  proposed does not work**: `TextField(_:value:format:)` ignores `\.locale`, so
+  `.environment(\.locale, …)` on the hosted view leaves the field reading
+  `150.000` while `@Environment(\.locale)` inside that same subtree reports
+  `en_US` — a pin that is set and reaches nothing, which is the vacuous green
+  this section is about, arriving inside its own fix. A product seam was
+  therefore unavoidable; it is `\.formatLocale`
+  (`Irrlicht/Views/FormatLocaleEnvironment.swift`), defaulting to
+  `Locale.autoupdatingCurrent`, which is *by construction* the locale a bare
+  `.number` already resolved through — deliberately NOT `\.locale`, which SwiftUI
+  derives from bundle localizations and which would have been a user-visible
+  change of unknown sign. **The pinned locale is `de_DE`** for the same reason
+  `referenceScale` is 2: it is what the committed references were recorded
+  under, so #1630 regenerated NO reference and the untouched 53-PNG set is
+  itself the evidence that neither the seam nor the pin changed any rendering.
+  Any other choice buys a cosmetic preference with a re-record — the move
+  #1034/#1044 got wrong. And the pin is a **type, not a modifier plus a
+  guard**: `Snapshotting.pinnedImage` is declared over `PinnedSnapshotHost`,
+  whose only initializer applies the pin, so a suite that forgets is a compile
+  error. The first draft applied the modifier by hand in seven host helpers and
+  added a source scan to police it — a guard over an API the same change
+  invented (#1390's lesson), and it flagged `ImageSnapshotCIScopeTests` and
+  `RasterPrimitiveEvidenceTests` on its first run for merely saying the words.
+  What the type cannot close is a suite that stops using `.pinnedImage`
+  altogether; that string is also what `ImageSnapshotCIScopeTests` derives its
+  CI classification from, so such a suite loses both pins and its CI
+  classification together, as one visible failure there.
+  Measured while doing it: **exactly one** committed reference is
+  locale-dependent — pinning `en_US` instead reddens
+  `testBackchannelRuleContextTokens` and nothing else in the other 52, and
+  `format: .number` at `BackchannelRulesView.swift:149` is the only
+  `FormatStyle` in the app (every other numeric render is `String(format:)`,
+  which takes no locale, or an `Int` interpolation, which carries no grouping).
+  The sibling family that is NOT closed is **timezone**: `HistoryFormat`'s
+  formatters pin `en_US_POSIX` but never set `timeZone`, and 8 of the 14
+  `HistoryViewSnapshotTests` references contain their output, held only by that
+  suite's own `setUp` — tracked separately, since a process-global
+  `private static let DateFormatter` is not reachable from the view environment
+  the way a `FormatStyle` is.
   The suite also aborts intermittently (#1523) in a way that **truncates the
   run** while every suite that did report says "0 failures" — so the exit code
   is the only reliable signal, never the last totals line you can see. That is

--- a/platforms/macos/Irrlicht/Views/BackchannelRulesView.swift
+++ b/platforms/macos/Irrlicht/Views/BackchannelRulesView.swift
@@ -42,6 +42,12 @@ struct BackchannelRulesView: View {
     @StateObject private var model = BackchannelRulesModel()
     @State private var saveTask: Task<Void, Never>? = nil
 
+    /// The locale the threshold field's `.number` style resolves through.
+    /// Defaults to `Locale.autoupdatingCurrent`, i.e. exactly what a bare
+    /// `format: .number` already used — see `FormatLocaleEnvironment.swift`
+    /// for why this seam has to exist and why it is not `\.locale` (#1630).
+    @Environment(\.formatLocale) private var formatLocale
+
     private let events: [EventOption] = [
         EventOption(id: BackchannelRule.eventWaiting, label: "Waiting"),
         EventOption(id: BackchannelRule.eventReady, label: "Ready"),
@@ -146,7 +152,7 @@ struct BackchannelRulesView: View {
                     TextField(isTokens ? "150000" : "85", value: Binding(
                         get: { rule.wrappedValue.trigger.threshold ?? fallback },
                         set: { rule.wrappedValue.trigger.threshold = $0 }
-                    ), format: .number)
+                    ), format: .number.locale(formatLocale))
                     .frame(width: isTokens ? 72 : 48)
                     .textFieldStyle(.roundedBorder)
                     Text(isTokens ? "tokens" : "%").font(.caption).foregroundColor(.secondary)

--- a/platforms/macos/Irrlicht/Views/FormatLocaleEnvironment.swift
+++ b/platforms/macos/Irrlicht/Views/FormatLocaleEnvironment.swift
@@ -1,0 +1,63 @@
+import SwiftUI
+
+/// The locale `FormatStyle`-based rendering resolves through (#1630).
+///
+/// ## Why this exists at all
+///
+/// `TextField(_:value:format:)` **ignores `\.locale`**. That is measured, not
+/// assumed: rendering `BackchannelRulesView` inside an `NSHostingView` under
+/// `.environment(\.locale, Locale(identifier: "en_US"))` on a `de_DE` Mac
+/// leaves the threshold field reading `150.000`, while `@Environment(\.locale)`
+/// read from inside the very same subtree reports `en_US`. The environment
+/// arrives; the format style does not consult it. `format: .number` is
+/// `FloatingPointFormatStyle<Double>()`, whose `locale` property defaults to
+/// `Locale.autoupdatingCurrent` — the *process's* locale, which no view
+/// modifier can reach.
+///
+/// The consequence was #1630: the committed reference PNG for
+/// `BackchannelRulesViewSnapshotTests.testBackchannelRuleContextTokens` is a
+/// picture of the recording contributor's regional settings (`150.000`), and a
+/// `macos-latest` runner — or any contributor on a `,`-grouping locale —
+/// renders `150,000` and fails with a message that says nothing about why.
+/// There is no test-only fix for that, because there is nothing in the test's
+/// reach that the format style reads. This key is the seam.
+///
+/// ## Why not `\.locale`
+///
+/// Because adopting `\.locale` here would be a **user-visible change of
+/// unknown sign**, which is exactly what #1630 must not trade for snapshot
+/// stability. SwiftUI derives `\.locale` from the bundle's localizations, not
+/// from `Locale.autoupdatingCurrent`, so the two can disagree for a user whose
+/// language and region differ — and the separator genuinely varies with that
+/// resolution (measured on this host: `en_US` → `150,000`, `de_DE`/`en_DE` →
+/// `150.000`, `fr_FR`/`en_FR` → `150 000`, `de_CH` → `150'000`, `hi_IN` →
+/// `1,50,000`).
+///
+/// This key's default is `Locale.autoupdatingCurrent`, so
+/// `.number.locale(formatLocale)` is *by construction* the same style a bare
+/// `.number` already is — asserted in
+/// `PinnedLocaleSnapshotTests.testDefaultIsIndistinguishableFromABareNumberStyle`,
+/// and evidenced more strongly by the fact that #1630 regenerated **no**
+/// reference PNG: every committed snapshot still matches byte-for-byte on the
+/// host that recorded it.
+///
+/// Making this view honour `\.locale` may well be the right localisation
+/// decision later. It is a separate decision, with a separate blast radius,
+/// and it is not made here.
+private struct FormatLocaleKey: EnvironmentKey {
+    /// The locale a bare `format: .number` / `.percent` / `.currency` already
+    /// resolves through. Overriding this key with anything else is a
+    /// deliberate act; nothing in the app does it, and the snapshot suites do.
+    static let defaultValue: Locale = .autoupdatingCurrent
+}
+
+extension EnvironmentValues {
+    /// Locale for `FormatStyle`-based rendering in this subtree.
+    ///
+    /// Read it and pass it to the style (`.number.locale(formatLocale)`) —
+    /// unlike `\.locale`, nothing consults this implicitly.
+    var formatLocale: Locale {
+        get { self[FormatLocaleKey.self] }
+        set { self[FormatLocaleKey.self] = newValue }
+    }
+}

--- a/platforms/macos/Tests/BackchannelRulesViewSnapshotTests.swift
+++ b/platforms/macos/Tests/BackchannelRulesViewSnapshotTests.swift
@@ -40,16 +40,18 @@ final class BackchannelRulesViewSnapshotTests: XCTestCase {
 
     /// Host at the rule card's real budget inside Settings: panel 360 −
     /// 20×2 horizontal padding − 16 leading inset = 304pt.
-    private func host(_ view: some View, height: CGFloat) -> NSView {
+    private func host(_ view: some View, height: CGFloat) -> PinnedSnapshotHost {
         let width: CGFloat = 304
-        let wrapped = view
-            .frame(width: width, height: height)
-            .background(Color(NSColor.windowBackgroundColor))
-        let hosting = NSHostingView(rootView: wrapped)
-        hosting.appearance = NSAppearance(named: .darkAqua)
-        hosting.frame = CGRect(x: 0, y: 0, width: width, height: height)
-        hosting.layoutSubtreeIfNeeded()
-        return hosting
+        // `PinnedSnapshotHost` pins the appearance AND the locale. The latter
+        // is load-bearing here and nowhere else in the suite set: the threshold
+        // field groups thousands through `format: .number`, so without it the
+        // reference is a picture of the recording machine's regional settings —
+        // `150.000` on the Mac that recorded it, `150,000` on a runner (#1630).
+        return PinnedSnapshotHost(
+            view
+                .frame(width: width, height: height)
+                .background(Color(NSColor.windowBackgroundColor)),
+            width: width, height: height)
     }
 
     /// A model with one rule using the given context event + threshold, plus a

--- a/platforms/macos/Tests/GroupViewSnapshotTests.swift
+++ b/platforms/macos/Tests/GroupViewSnapshotTests.swift
@@ -58,18 +58,16 @@ final class GroupViewSnapshotTests: XCTestCase {
         )
     }
 
-    private func host(_ view: some View, height: CGFloat = 48) -> NSView {
-        let wrapped = view
-            .environmentObject(sessionManager)
-            .frame(width: 350, height: height)
-            .background(Color(NSColor.windowBackgroundColor))
-        let hosting = NSHostingView(rootView: wrapped)
-        // Pin to dark aqua so snapshots don't depend on the current system
-        // appearance (Color(NSColor.windowBackgroundColor) adapts otherwise).
-        hosting.appearance = NSAppearance(named: .darkAqua)
-        hosting.frame = CGRect(x: 0, y: 0, width: 350, height: height)
-        hosting.layoutSubtreeIfNeeded()
-        return hosting
+    private func host(_ view: some View, height: CGFloat = 48) -> PinnedSnapshotHost {
+        // `PinnedSnapshotHost` pins the appearance — so snapshots don't depend
+        // on the current system appearance, which `Color(NSColor.windowBackgroundColor)`
+        // otherwise adapts to — and the locale (#1630).
+        PinnedSnapshotHost(
+            view
+                .environmentObject(sessionManager)
+                .frame(width: 350, height: height)
+                .background(Color(NSColor.windowBackgroundColor)),
+            width: 350, height: height)
     }
 
     private func seedThreeGroups() -> [SessionManager.AgentGroup] {

--- a/platforms/macos/Tests/HistoryViewSnapshotTests.swift
+++ b/platforms/macos/Tests/HistoryViewSnapshotTests.swift
@@ -23,18 +23,16 @@ final class HistoryViewSnapshotTests: XCTestCase {
         try await super.tearDown()
     }
 
-    private func host(_ view: some View, height: CGFloat) -> NSView {
+    private func host(_ view: some View, height: CGFloat) -> PinnedSnapshotHost {
         let width = SessionListView.panelWidth
-        let wrapped = view
-            .frame(width: width, height: height)
-            .background(Color(NSColor.windowBackgroundColor))
-        let hosting = NSHostingView(rootView: wrapped)
-        // Pin to dark aqua so snapshots don't depend on the current system
-        // appearance (matches SessionRowSnapshotTests).
-        hosting.appearance = NSAppearance(named: .darkAqua)
-        hosting.frame = CGRect(x: 0, y: 0, width: width, height: height)
-        hosting.layoutSubtreeIfNeeded()
-        return hosting
+        // `PinnedSnapshotHost` pins dark aqua so snapshots don't depend on the
+        // current system appearance (matches SessionRowSnapshotTests), and the
+        // locale (#1630).
+        return PinnedSnapshotHost(
+            view
+                .frame(width: width, height: height)
+                .background(Color(NSColor.windowBackgroundColor)),
+            width: width, height: height)
     }
 
     /// host() wraps its view directly in `.frame(width:)`, which alone bounds
@@ -47,7 +45,7 @@ final class HistoryViewSnapshotTests: XCTestCase {
     /// frame → ScrollView { VStack { view } }, matching HistoryView.content
     /// verbatim — so a regression in the grid's width-clamping modifier shows
     /// up as an image diff here even though it wouldn't via host().
-    private func hostInScrollingTab(_ view: some View, height: CGFloat) -> NSView {
+    private func hostInScrollingTab(_ view: some View, height: CGFloat) -> PinnedSnapshotHost {
         let width = SessionListView.panelWidth
         let wrapped = ScrollView {
             VStack(alignment: .leading, spacing: 0) {
@@ -56,11 +54,7 @@ final class HistoryViewSnapshotTests: XCTestCase {
         }
         .frame(width: width, height: height)
         .background(Color(NSColor.windowBackgroundColor))
-        let hosting = NSHostingView(rootView: wrapped)
-        hosting.appearance = NSAppearance(named: .darkAqua)
-        hosting.frame = CGRect(x: 0, y: 0, width: width, height: height)
-        hosting.layoutSubtreeIfNeeded()
-        return hosting
+        return PinnedSnapshotHost(wrapped, width: width, height: height)
     }
 
     /// Four daily buckets (bucketSeconds = 86400 → M/d axis labels), three

--- a/platforms/macos/Tests/PermissionWizardEffectErrorRenderTests.swift
+++ b/platforms/macos/Tests/PermissionWizardEffectErrorRenderTests.swift
@@ -35,16 +35,12 @@ final class PermissionWizardEffectErrorRenderTests: XCTestCase {
         return try JSONDecoder().decode(PermissionsSnapshot.self, from: Data(json.utf8))
     }
 
-    private func host(_ snap: PermissionsSnapshot, mode: PermissionWizardView.Mode) -> NSView {
+    private func host(_ snap: PermissionsSnapshot, mode: PermissionWizardView.Mode) -> PinnedSnapshotHost {
         let manager = SessionManager()
         manager.permissionsSnapshot = snap
         let view = PermissionWizardView(mode: mode, lockedAgents: ["claude-code"], onClose: {})
             .environmentObject(manager)
-        let hosting = NSHostingView(rootView: view)
-        hosting.appearance = NSAppearance(named: .darkAqua)
-        hosting.frame = CGRect(x: 0, y: 0, width: SessionListView.panelWidth, height: 420)
-        hosting.layoutSubtreeIfNeeded()
-        return hosting
+        return PinnedSnapshotHost(view, width: SessionListView.panelWidth, height: 420)
     }
 
     /// The defect case: a grant whose Apply failed. The reference shows the

--- a/platforms/macos/Tests/PinnedLocaleSnapshot.swift
+++ b/platforms/macos/Tests/PinnedLocaleSnapshot.swift
@@ -1,0 +1,145 @@
+import AppKit
+import SwiftUI
+@testable import Irrlicht
+
+/// The locale every image snapshot is rendered under, so a committed reference
+/// is a picture of the VIEW and not of the recording machine's regional
+/// settings (#1630).
+///
+/// ## What went wrong
+///
+/// `BackchannelRulesView`'s threshold field renders through `format: .number`,
+/// which resolves via `Locale.autoupdatingCurrent`. The reference host is
+/// `de_DE`, so
+/// `__Snapshots__/BackchannelRulesViewSnapshotTests/testBackchannelRuleContextTokens.1.png`
+/// reads `150.000`; a `macos-latest` runner is `en_US` and renders `150,000`.
+/// Every contributor whose Mac groups thousands differently fails that test
+/// locally, with a "Snapshot does not match reference." that names no cause.
+/// This is the locale sibling of what `PinnedScaleSnapshot` is for the backing
+/// scale: a value read from the MACHINE where the equivalent value was
+/// available from the INPUT.
+///
+/// ## Why `de_DE` and not `en_US`
+///
+/// For the same reason `PinnedScaleSnapshot.referenceScale` is 2 rather than
+/// the "nicest" scale: **it is what the committed references were recorded
+/// under**, so adopting it regenerates nothing. `AGENTS.md` names re-recording
+/// a reference to make a test pass as the move #1034 and #1044 both made and
+/// both got wrong; pinning the recording host's own locale means #1630 never
+/// has to make that call, and the untouched reference set is then itself the
+/// evidence that the pin changed no rendering.
+///
+/// This is a statement about the PNGs on disk, not a preference. If the
+/// catalog is ever re-recorded wholesale on another host, this constant moves
+/// with it.
+enum PinnedLocaleSnapshot {
+    /// The locale every committed reference was recorded under. Measured:
+    /// `defaults read -g AppleLocale` on the reference Mac → `de_DE`, and the
+    /// tokens reference shows `150.000`, which is `de_DE` grouping.
+    static let referenceLocale = Locale(identifier: "de_DE")
+
+    /// A locale that groups thousands differently from `referenceLocale`.
+    /// `en_US` is what a `macos-latest` runner uses — the exact host that
+    /// reported #1630.
+    ///
+    /// Its job is to keep `referenceLocale` from being changed into something
+    /// that makes the both-sides arms tautological; the arms themselves name
+    /// their locales literally, so they stay a statement about ICU rather than
+    /// about whatever this file currently pins.
+    static let contrastingLocale = Locale(identifier: "en_US")
+
+    /// Every `NSTextField` in a rendered hierarchy, as
+    /// `(placeholder, displayed string)`.
+    ///
+    /// Used to read what a SwiftUI `TextField` actually PUT ON SCREEN, which
+    /// is the only way to prove a locale pin reached the format style rather
+    /// than merely being set. Callers must check the field they wanted was
+    /// found — "no such field" and "the field said the right thing" must never
+    /// produce the same verdict.
+    static func textFields(in view: NSView) -> [(placeholder: String?, value: String)] {
+        var found: [(placeholder: String?, value: String)] = []
+        func walk(_ v: NSView) {
+            if let field = v as? NSTextField {
+                found.append((field.placeholderString, field.stringValue))
+            }
+            v.subviews.forEach(walk)
+        }
+        walk(view)
+        return found
+    }
+}
+
+extension View {
+    /// Pin the locale this subtree renders under, for a snapshot host.
+    ///
+    /// Sets **both** locale environments on purpose. `\.formatLocale` is the
+    /// one `FormatStyle`-based rendering reads (see
+    /// `Irrlicht/Views/FormatLocaleEnvironment.swift` — `TextField(value:format:)`
+    /// demonstrably ignores `\.locale`), and `\.locale` is the one SwiftUI's own
+    /// localized rendering reads. A snapshot host wants neither of them coming
+    /// from the machine.
+    ///
+    /// On the reference host this is a no-op — both environments already
+    /// resolve to `de_DE` there — which is why applying it regenerated no
+    /// reference.
+    fileprivate func pinnedLocale(_ locale: Locale) -> some View {
+        environment(\.formatLocale, locale)
+            .environment(\.locale, locale)
+    }
+}
+
+/// The rasterisable host a `.pinnedImage` snapshot is taken of — and the only
+/// way to build one.
+///
+/// ## Why this is a type and not a modifier every suite remembers to apply
+///
+/// The first draft of #1630 applied `.pinnedLocale()` by hand in each of the
+/// seven host helpers and added a source scan asserting that every file taking
+/// an image snapshot mentioned it. That is a guard policing an API the same
+/// change invented, which this repo treats as a signal to remove the API
+/// (`AGENTS.md`, #1390) — and the scan was weak for the usual reason: it could
+/// not tell a file that *has* the call from one that merely *documents* it, and
+/// it flagged `ImageSnapshotCIScopeTests` and `RasterPrimitiveEvidenceTests` on
+/// its first run for saying the words.
+///
+/// So `Snapshotting.pinnedImage` is declared over **this type** rather than over
+/// `NSView`. A suite cannot hand it an unpinned hierarchy, because the only
+/// initializer applies the pin itself: forgetting is a compile error, not a
+/// reference PNG that quietly photographs someone's regional settings.
+/// `PinnedLocaleSnapshotTests` grades this object and not one it assembled
+/// itself, so "the host the suites use" and "the host the pin was proven on"
+/// cannot be two things that disagree.
+///
+/// The remaining hole is the one a type cannot close: a suite that stops using
+/// `.pinnedImage` altogether. `ImageSnapshotCIScopeTests` already derives its CI
+/// classification from that same string, so such a suite loses the scale pin,
+/// the locale pin and its CI classification together, as one visible failure
+/// there.
+struct PinnedSnapshotHost {
+    /// The laid-out hosting view. Read it to inspect what was rendered; pass
+    /// the `PinnedSnapshotHost` itself to `assertSnapshot`.
+    let view: NSView
+
+    /// Host `content` at a fixed size, appearance and locale.
+    ///
+    /// - Parameters:
+    ///   - width/height: the hosting view's frame. Callers keep their own
+    ///     `.frame`/`.background` modifiers on `content` — this changes no
+    ///     geometry, which is why adopting it regenerated no reference.
+    ///   - appearance: pinned for the same reason the locale is; every suite
+    ///     already did this by hand (`SessionRowSnapshotTests`' light-mode pill
+    ///     tests are the one caller that passes `.aqua`).
+    ///   - locale: defaults to the locale every committed reference was
+    ///     recorded under. Only the tests that PROVE the pin pass anything else.
+    init(_ content: some View,
+         width: CGFloat,
+         height: CGFloat,
+         appearance: NSAppearance.Name = .darkAqua,
+         locale: Locale = PinnedLocaleSnapshot.referenceLocale) {
+        let hosting = NSHostingView(rootView: content.pinnedLocale(locale))
+        hosting.appearance = NSAppearance(named: appearance)
+        hosting.frame = CGRect(x: 0, y: 0, width: width, height: height)
+        hosting.layoutSubtreeIfNeeded()
+        self.view = hosting
+    }
+}

--- a/platforms/macos/Tests/PinnedLocaleSnapshotTests.swift
+++ b/platforms/macos/Tests/PinnedLocaleSnapshotTests.swift
@@ -1,0 +1,138 @@
+import AppKit
+import SwiftUI
+import XCTest
+@testable import Irrlicht
+
+/// Locks the property #1630 is about: an image snapshot renders under the
+/// locale it is ASKED for, not the locale the machine happens to have.
+///
+/// The obvious test — "renders `150.000`" — is the trap, and it is the same one
+/// `PinnedScaleSnapshotTests` is written around: on the `de_DE` Mac that
+/// recorded the references it passes whether the locale is pinned or inherited
+/// from the process, so it would be green for the wrong reason on the only
+/// machine anyone had run it on. The fix is to drive BOTH locales through one
+/// view. Whatever `Locale.autoupdatingCurrent` is, at most one arm can agree
+/// with it, so an implementation that inherits the process locale fails the
+/// other — on a `de_DE` laptop and an `en_US` runner alike.
+///
+/// Everything here goes through `PinnedSnapshotHost`, the type the suites
+/// snapshot, rather than through a hosting view this file assembles: "the host
+/// that pins" and "the host the proof was taken on" must not be two objects
+/// that can disagree.
+@MainActor
+final class PinnedLocaleSnapshotTests: XCTestCase {
+
+    // MARK: - The pin reaches the pixels
+
+    /// The threshold field as it is actually rendered, read back off the
+    /// `NSTextField` SwiftUI puts in the view tree.
+    ///
+    /// Reading the rendered string rather than trusting that the environment
+    /// "was set" is the whole point: setting a locale and then rendering a view
+    /// that ignores it is precisely the defect — #1630's own suggested fix,
+    /// `.environment(\.locale, …)` on its own, does exactly that and changes
+    /// nothing, which is why the seam in
+    /// `Irrlicht/Views/FormatLocaleEnvironment.swift` had to exist.
+    private func renderedThreshold(locale: Locale, placeholder: String = "150000") -> String? {
+        let model = BackchannelRulesModel()
+        model.rules = [
+            BackchannelRule(
+                id: "r1", enabled: true, name: "Auto-compact",
+                trigger: .init(event: BackchannelRule.eventContextTokens, threshold: 150_000),
+                actions: [.init(kind: BackchannelRule.actionInput, preset: BackchannelRule.presetCompact)],
+                adapter: nil
+            )
+        ]
+        let host = PinnedSnapshotHost(
+            BackchannelRulesView(model: model).frame(width: 304, height: 220),
+            width: 304, height: 220, locale: locale)
+
+        // The tokens field is identified by the placeholder the view gives it
+        // (`BackchannelRulesView`'s `isTokens ? "150000" : "85"`), not by
+        // position — a reordered card must not silently start measuring the
+        // rule-name field instead.
+        return PinnedLocaleSnapshot.textFields(in: host.view)
+            .first { $0.placeholder == placeholder }?.value
+    }
+
+    /// The load-bearing arm. Three locales, one view; the host can be at most
+    /// one of them.
+    func testTheThresholdFieldRendersUnderThePinnedLocaleNotTheProcessLocale() {
+        let cases: [(Locale, String)] = [
+            (Locale(identifier: "en_US"), "150,000"),
+            (Locale(identifier: "de_DE"), "150.000"),
+            // U+202F, narrow no-break space — measured, not guessed.
+            (Locale(identifier: "fr_FR"), "150\u{202F}000"),
+        ]
+        for (locale, expected) in cases {
+            guard let rendered = renderedThreshold(locale: locale) else {
+                // "could not find the field" and "the field said the right
+                // thing" must never produce the same verdict.
+                return XCTFail("no text field with placeholder \"150000\" in the rendered tree — "
+                               + "this check cannot have run (process locale: \(Locale.autoupdatingCurrent.identifier))")
+            }
+            XCTAssertEqual(rendered, expected,
+                           "pinned \(locale.identifier) but rendered \(rendered.debugDescription) "
+                           + "— the process locale is \(Locale.autoupdatingCurrent.identifier)")
+        }
+    }
+
+    /// The locale the suites actually pin renders what the committed reference
+    /// shows. Stated separately from the arm above so a change to
+    /// `referenceLocale` fails HERE, naming the constant, rather than as an
+    /// opaque byte mismatch in `BackchannelRulesViewSnapshotTests`.
+    func testReferenceLocaleRendersTheGroupingTheCommittedReferenceShows() {
+        XCTAssertEqual(renderedThreshold(locale: PinnedLocaleSnapshot.referenceLocale), "150.000",
+                       "the committed tokens reference PNG reads \"150.000\"")
+    }
+
+    /// …and the default a suite gets when it names no locale is that same one,
+    /// so the arms above cannot pass while every real snapshot renders under
+    /// something else.
+    func testTheHostsDefaultLocaleIsTheReferenceLocale() {
+        let model = BackchannelRulesModel()
+        model.rules = [
+            BackchannelRule(
+                id: "r1", enabled: true, name: "Auto-compact",
+                trigger: .init(event: BackchannelRule.eventContextTokens, threshold: 150_000),
+                actions: [.init(kind: BackchannelRule.actionInput, preset: BackchannelRule.presetCompact)],
+                adapter: nil
+            )
+        ]
+        let defaulted = PinnedSnapshotHost(
+            BackchannelRulesView(model: model).frame(width: 304, height: 220),
+            width: 304, height: 220)   // no `locale:` — exactly what the suites write
+        let rendered = PinnedLocaleSnapshot.textFields(in: defaulted.view)
+            .first { $0.placeholder == "150000" }?.value
+        XCTAssertEqual(rendered, renderedThreshold(locale: PinnedLocaleSnapshot.referenceLocale),
+                       "the host's default locale is not `PinnedLocaleSnapshot.referenceLocale`")
+    }
+
+    /// …and the two constants the both-sides arms rely on really do disagree,
+    /// so a future edit cannot quietly make this suite tautological by setting
+    /// them to the same thing.
+    func testReferenceAndContrastingLocalesGroupDifferently() {
+        let a = 150_000.0.formatted(.number.locale(PinnedLocaleSnapshot.referenceLocale))
+        let b = 150_000.0.formatted(.number.locale(PinnedLocaleSnapshot.contrastingLocale))
+        XCTAssertNotEqual(a, b, "referenceLocale and contrastingLocale group thousands the same way (\(a)) — "
+                          + "every both-sides assertion here is vacuous")
+    }
+
+    // MARK: - The seam costs the app nothing
+
+    /// `\.formatLocale` defaults to `Locale.autoupdatingCurrent`, which is what
+    /// a bare `.number` already resolves through — so the shipping app renders
+    /// exactly what it rendered before #1630, on every host, for every locale.
+    ///
+    /// This is the weaker half of that claim (one host, five numbers). The
+    /// stronger half is that #1630 regenerated no reference PNG: all 53
+    /// committed snapshots still match byte-for-byte on the machine that
+    /// recorded them, with the seam in place.
+    func testDefaultIsIndistinguishableFromABareNumberStyle() {
+        for value in [150_000.0, 85, 1234.5, -9_876_543.21, 0] {
+            XCTAssertEqual(value.formatted(.number),
+                           value.formatted(.number.locale(.autoupdatingCurrent)),
+                           "`.number` and `.number.locale(.autoupdatingCurrent)` differ for \(value)")
+        }
+    }
+}

--- a/platforms/macos/Tests/PinnedScaleSnapshot.swift
+++ b/platforms/macos/Tests/PinnedScaleSnapshot.swift
@@ -101,15 +101,23 @@ enum PinnedScaleSnapshot {
     }
 }
 
-extension Snapshotting where Value == NSView, Format == NSImage {
+extension Snapshotting where Value == PinnedSnapshotHost, Format == NSImage {
     /// `.image`, rasterised at the scale the committed references were
     /// recorded at rather than at the host's. Use this and not `.image`.
+    ///
+    /// Declared over `PinnedSnapshotHost` rather than `NSView` since #1630:
+    /// backing scale was not the only value these references were reading off
+    /// the MACHINE — the locale was too, and a hosting view that has already
+    /// been built cannot be asked to render under a different one. Requiring
+    /// the host type makes both pins a precondition of taking the snapshot at
+    /// all; see that type's doc comment for why this is a type rather than a
+    /// modifier plus a guard.
     static var pinnedImage: Snapshotting {
         pinnedImage(scale: PinnedScaleSnapshot.referenceScale)
     }
 
     static func pinnedImage(scale: CGFloat) -> Snapshotting {
         Snapshotting<NSImage, NSImage>.image(precision: 1, perceptualPrecision: 1)
-            .pullback { view in PinnedScaleSnapshot.rasterize(view, scale: scale) }
+            .pullback { host in PinnedScaleSnapshot.rasterize(host.view, scale: scale) }
     }
 }

--- a/platforms/macos/Tests/SessionRowSnapshotTests.swift
+++ b/platforms/macos/Tests/SessionRowSnapshotTests.swift
@@ -178,32 +178,30 @@ final class SessionRowSnapshotTests: XCTestCase {
         return session
     }
 
-    private func host(_ session: SessionState, height: CGFloat = 48) -> NSView {
+    private func host(_ session: SessionState, height: CGFloat = 48) -> PinnedSnapshotHost {
         host(SessionRowView(session: session, agentNumber: 1), height: height)
     }
 
-    private func host(_ view: some View, height: CGFloat = 48) -> NSView {
+    private func host(_ view: some View, height: CGFloat = 48) -> PinnedSnapshotHost {
         host(view, height: height, appearance: .darkAqua)
     }
 
-    private func hostLight(_ session: SessionState, height: CGFloat = 48) -> NSView {
+    private func hostLight(_ session: SessionState, height: CGFloat = 48) -> PinnedSnapshotHost {
         host(SessionRowView(session: session, agentNumber: 1), height: height, appearance: .aqua)
     }
 
-    private func host(_ view: some View, height: CGFloat = 48, appearance: NSAppearance.Name) -> NSView {
-        let wrapped = view
-            .environmentObject(sessionManager)
-            .frame(width: 350, height: height)
-            .background(Color(NSColor.windowBackgroundColor))
-        let hosting = NSHostingView(rootView: wrapped)
-        // Pin appearance explicitly so snapshots don't depend on the current
-        // system appearance (Color(NSColor.windowBackgroundColor) adapts
-        // otherwise) — most tests pin dark aqua; the light-mode pill
-        // contrast tests below (issue #984) pin aqua instead.
-        hosting.appearance = NSAppearance(named: appearance)
-        hosting.frame = CGRect(x: 0, y: 0, width: 350, height: height)
-        hosting.layoutSubtreeIfNeeded()
-        return hosting
+    private func host(_ view: some View, height: CGFloat = 48, appearance: NSAppearance.Name) -> PinnedSnapshotHost {
+        // Appearance is passed explicitly so snapshots don't depend on the
+        // current system appearance (Color(NSColor.windowBackgroundColor)
+        // adapts otherwise) — most tests pin dark aqua; the light-mode pill
+        // contrast tests below (issue #984) pin aqua instead. The host also
+        // pins the locale (#1630).
+        PinnedSnapshotHost(
+            view
+                .environmentObject(sessionManager)
+                .frame(width: 350, height: height)
+                .background(Color(NSColor.windowBackgroundColor)),
+            width: 350, height: height, appearance: appearance)
     }
 
     /// Decodes a daemon-shaped session fixture (issue #757). Accepts either a

--- a/platforms/macos/Tests/UnappliedGrantsBannerRenderTests.swift
+++ b/platforms/macos/Tests/UnappliedGrantsBannerRenderTests.swift
@@ -23,7 +23,7 @@ final class UnappliedGrantsBannerRenderTests: XCTestCase {
                        key: "hooks", title: "Install hooks", reason: reason)
     }
 
-    private func host(_ items: [UnappliedGrant]) throws -> NSView {
+    private func host(_ items: [UnappliedGrant]) throws -> PinnedSnapshotHost {
         let summary = try XCTUnwrap(UnappliedGrantSummary(items: items))
         // Composited over the panel's own background, because the banner's
         // fill is a 12%-alpha wash: hosted on transparency it lands on white
@@ -32,11 +32,7 @@ final class UnappliedGrantsBannerRenderTests: XCTestCase {
         // that and made the reason text unreadable.
         let root = UnappliedGrantsBanner(summary: summary, onReview: {})
             .background(Color(NSColor.windowBackgroundColor))
-        let hosting = NSHostingView(rootView: root)
-        hosting.appearance = NSAppearance(named: .darkAqua)
-        hosting.frame = CGRect(x: 0, y: 0, width: SessionListView.panelWidth, height: 120)
-        hosting.layoutSubtreeIfNeeded()
-        return hosting
+        return PinnedSnapshotHost(root, width: SessionListView.panelWidth, height: 120)
     }
 
     /// One unapplied grant: singular headline, the cause spelled out, and a
@@ -82,7 +78,7 @@ final class UnappliedGrantsBannerAbsenceTests: XCTestCase {
 @MainActor
 final class SessionListUnappliedGrantsWiringTests: XCTestCase {
 
-    private func host(_ snap: PermissionsSnapshot?) -> NSView {
+    private func host(_ snap: PermissionsSnapshot?) -> PinnedSnapshotHost {
         let manager = SessionManager()
         manager.permissionsSnapshot = snap
         let view = SessionListView()
@@ -93,11 +89,7 @@ final class SessionListUnappliedGrantsWiringTests: XCTestCase {
             // `true` default armed a modal NSAlert one second later and hung
             // whichever unrelated test next spun the main run loop.
             .environmentObject(UpdateManager(startingUpdater: false))
-        let hosting = NSHostingView(rootView: view)
-        hosting.appearance = NSAppearance(named: .darkAqua)
-        hosting.frame = CGRect(x: 0, y: 0, width: SessionListView.panelWidth, height: 420)
-        hosting.layoutSubtreeIfNeeded()
-        return hosting
+        return PinnedSnapshotHost(view, width: SessionListView.panelWidth, height: 420)
     }
 
     private var unapplied: PermissionsSnapshot {


### PR DESCRIPTION
Closes #1630

`Tests/__Snapshots__/BackchannelRulesViewSnapshotTests/testBackchannelRuleContextTokens.1.png`
reads **`150.000`** — a picture of the recording contributor's `de_DE` regional
settings. A `macos-latest` runner, or any contributor whose Mac groups thousands
differently, renders `150,000` and fails with a "Snapshot does not match
reference." that says nothing about why.

## The issue's proposed test-only fix does not work — measured

#1630 suggested `.environment(\.locale, Locale(identifier: "en_US_POSIX"))` on
the hosted view. **`TextField(_:value:format:)` ignores `\.locale`.** Rendering
`BackchannelRulesView` inside an `NSHostingView` under
`.environment(\.locale, Locale(identifier: "en_US"))` on this `de_DE` Mac:

| `\.locale` override | `@Environment(\.locale)` seen inside the subtree | `TextField(…, format: .number)` renders |
|---|---|---|
| none | `de_DE` | `150.000` |
| `en_US` | `en_US` | **`150.000`** |
| `de_DE` | `de_DE` | `150.000` |
| `en_US_POSIX` | `en_US_POSIX` | **`150.000`** |

The environment arrives. The format style never consults it — `.number` is
`FloatingPointFormatStyle<Double>()`, whose `locale` defaults to
`Locale.autoupdatingCurrent`, the *process's* locale, which no view modifier can
reach. A pin applied only in the test is therefore a pin that reaches nothing:
the vacuous-green shape, arriving inside its own fix. A product seam was
unavoidable.

## What changed

**1. A product seam that costs users nothing** —
`Irrlicht/Views/FormatLocaleEnvironment.swift` adds `\.formatLocale`, defaulting
to `Locale.autoupdatingCurrent`, and `BackchannelRulesView` reads it
(`format: .number.locale(formatLocale)`). `.number.locale(.autoupdatingCurrent)`
is *by construction* the style a bare `.number` already was, so a German user
still sees `150.000`.

Deliberately **not** `\.locale`: SwiftUI derives that from bundle localizations
rather than from `Locale.autoupdatingCurrent`, so adopting it would be a
user-visible change of unknown sign, and the separator genuinely varies with the
resolution (measured here: `en_US` → `150,000`, `de_DE`/`en_DE` → `150.000`,
`fr_FR`/`en_FR` → `150 000`, `de_CH` → `150'000`, `hi_IN` → `1,50,000`).
Adopting `\.locale` may well be the right localisation decision later; it is a
separate decision with a separate blast radius and is not made here.

**2. The locale pinned is `de_DE`** — `PinnedLocaleSnapshot.referenceLocale`, for
the same reason `PinnedScaleSnapshot.referenceScale` is `2` rather than the
"nicest" scale: *it is what the committed references were recorded under*.

**No reference PNG was regenerated.** `git status` over `*.png` is empty and all
53 committed snapshots still match byte-for-byte on the machine that recorded
them, with the seam and the pin in place — that untouched set is itself the
evidence that neither changed any rendering, the same argument `PinnedScaleSnapshot`
made. `AGENTS.md` names re-recording a reference to make a test pass as the move
#1034 and #1044 both made and both got wrong; pinning the recording host's own
locale means this PR never has to make that call. Any other choice would have
bought a cosmetic preference with a re-record.

**3. The pin is a TYPE, not a modifier plus a guard.**
`Snapshotting.pinnedImage` is now declared over `PinnedSnapshotHost`, whose only
initializer applies the pin — so a suite that forgets is a **compile error**,
not a reference that quietly photographs someone's regional settings. All seven
host helpers now return it; `assertSnapshot` call sites are unchanged.

The first draft did apply a `.pinnedLocale()` modifier by hand in each helper
and added a source scan asserting every image-snapshot file mentioned it. That
is a guard policing an API the same change invented (#1390's lesson: remove the
API instead), and it was weak for the usual reason — it could not tell a file
that *has* the call from one that merely *documents* it, flagging
`ImageSnapshotCIScopeTests` and `RasterPrimitiveEvidenceTests` on its first run
for saying the words. It is gone.

What the type cannot close: a suite that stops using `.pinnedImage` altogether.
`ImageSnapshotCIScopeTests` already derives its CI classification from that same
string, so such a suite loses the scale pin, the locale pin and its CI
classification together, as one visible failure there.

## Proof the pin takes effect

`PinnedLocaleSnapshotTests` reads back the **rendered string** off the
`NSTextField` SwiftUI puts in the tree, and drives **three locales through one
view** — the `PinnedScaleSnapshotTests` shape. Whatever the host's locale is, at
most one arm can agree with it, so a render that inherits the process locale
fails the others on a `de_DE` laptop and an `en_US` runner alike. It grades
`PinnedSnapshotHost` — the object the suites actually snapshot — not a hosting
view the test assembled, so "the host that pins" and "the host the proof was
taken on" cannot be two things that disagree.

## Mutation evidence — every one seen red

**A. Pin the opposite locale** (`referenceLocale` → `en_US`; simulates an
`en_US` contributor without touching any system setting):

```
Tests/BackchannelRulesViewSnapshotTests.swift:83: error: -[…testBackchannelRuleContextTokens] : failed - Snapshot does not match reference.
Tests/PinnedLocaleSnapshotTests.swift:85: error: -[…testReferenceLocaleRendersTheGroupingTheCommittedReferenceShows] : XCTAssertEqual failed: ("Optional("150,000")") is not equal to ("Optional("150.000")") - the committed tokens reference PNG reads "150.000"
Tests/PinnedLocaleSnapshotTests.swift:117: error: -[…testReferenceAndContrastingLocalesGroupDifferently] : XCTAssertNotEqual failed: ("150,000") is equal to ("150,000") - … every both-sides assertion here is vacuous
	 Executed 328 tests, with 3 failures
```

That is #1630 reproduced deliberately. Note **exactly one** of the 53 references
reddens — independent confirmation that this is the only locale-dependent render
in the catalog, and that `testBackchannelRuleContextPressure`'s `85` is spelled
identically in both locales, as the issue said.

**B. Revert the product seam to bare `format: .number`, keeping the pin** — the
load-bearing one:

```
Tests/PinnedLocaleSnapshotTests.swift:74: error: XCTAssertEqual failed: ("150.000") is not equal to ("150,000") - pinned en_US but rendered "150.000" — the process locale is de_DE
Tests/PinnedLocaleSnapshotTests.swift:74: error: XCTAssertEqual failed: ("150.000") is not equal to ("150 000") - pinned fr_FR but rendered "150.000" — the process locale is de_DE
	 Executed 328 tests, with 2 failures
```

**The snapshot stayed green.** A pin without the seam is undetectable by the
snapshot on the recording host — only the string assertion catches it. That is
the entire reason this PR asserts the rendered string rather than trusting that
`.environment(…)` "worked".

**C. Break the field lookup** (match a placeholder no field has) — the loud
guard fires rather than passing quietly:

```
Tests/PinnedLocaleSnapshotTests.swift:71: error: failed - no text field with placeholder "150000" in the rendered tree — this check cannot have run (process locale: de_DE)
```

**D. Write a host helper the pre-#1630 way** (plain `NSHostingView`, no pin):

```
Tests/BackchannelRulesViewSnapshotTests.swift:90:28: error: cannot convert value of type 'NSView' to expected argument type 'PinnedSnapshotHost'
```

## Sibling sweep

Every image-snapshot suite (7 classes, 6 reference directories, 53 PNGs) was
traced to the product view it renders and the formatting paths that view reaches.

**Locale — one site, now fixed.** `format: .number` at
`BackchannelRulesView.swift:149` is the **only** `FormatStyle` in the whole app:
no other `Text(_, format:)` / `TextField(_, format:)` / `.formatted(`, zero
`NumberFormatter`/`ByteCountFormatter`/`DateComponentsFormatter`/`Measurement`.
Every other numeric render is either `String(format:)` (~40 sites, **none**
passing a `locale:` argument, so POSIX on every host) or an `Int` interpolation
in a `Text` (`%lld`, no grouping under any locale — no `Double` is interpolated
into a `Text` anywhere). Swift Charts axis labels use explicit
`AxisValueLabel { Text(<our own POSIX string>) }` on both axes, so Charts'
locale-aware default tick formatting is never reached. `HistoryFormat.posix(…)`
already sets `f.locale = en_US_POSIX` *before* `f.dateFormat` — the correct
order — and needs no change. Mutation A's one-reference blast radius is the
measurement backing all of this.

**Timezone — the sibling family this PR does NOT close.** `HistoryFormat`'s
formatters pin the locale but never set `timeZone`, and 8 of the 14
`HistoryViewSnapshotTests` references contain their output. It is held today
only by that suite's own `setUp` (`NSTimeZone.default = UTC`), and the
formatters are process-global `private static let`s whose timezone is captured
at first use in the process. Not trivially covered by this pin — a
`DateFormatter` created at file scope is not reachable from the view environment
the way a `FormatStyle` is — so it is filed as #1659 rather than scope-crept
here.

**Two latent, reached by nothing today** (each with the reason, so the dismissal
carries evidence): `SessionListView.formatResetTime` (`:1130`) stacks
`Calendar.current`, wall-clock `Date()` and an unpinned `DateFormatter` and
renders as real `Text`, but its whole chain is behind
`guard let snap = session.metrics?.rateLimit else { return }` and no fixture in
the tree carries `rate_limit`; the first snapshot that seeds one bakes locale,
timezone and the recording *day* at once. `HistoryView.fullDateTimeFormatter`
(`:1194`) is unpinned on both axes but its only call sites are `.tooltip(…)` and
`.accessibilityLabel(…)`, and `tooltip` is an `onHover`-only modifier drawing
into a separate `NSPanel` that adds nothing to the view tree.

## Gates

| Gate | Result |
|---|---|
| `tools/preflight.sh --only swift` | **PASS** (exit 0) |
| `tools/preflight.sh --changed --budget 500` | **PASS** (exit 0) — every other gate `SKIP`, correctly: the diff is `platforms/macos/` + `AGENTS.md` |
| `swift test --skip LauncherTestHarness --skip LauncherHarnessTests` | **exit 0**, 328 tests, 0 failures |

Exit codes read directly, never through a pipe — per #1523 the suite can abort in
a way that truncates the run while every suite that did report says "0 failures",
and per AGENTS.md this repo's shell is zsh, where `${PIPESTATUS[0]}` expands to
nothing (it did, on the first attempt).

**CI will not grade the change that matters.** `BackchannelRulesViewSnapshotTests`
is one of the five suites `macos-swift.yml` skips (#1615), so a green `swift-test`
check on this PR says nothing about the reference this PR is about. The local
`swift` gate is the only place it runs. `swift-build` and the 270-odd tests CI
does run still apply, and `ImageSnapshotCIScopeTests` — which is CI-gated — keeps
the skip list honest.

## Not addressed

#1615's own question (why the *rasterisation* differs on a runner) is untouched.
`testBackchannelRuleContextPressure` renders `85`, spelled identically in both
locales, and still differs by 6370 px on a runner — that is #1615's population,
not this one, and #1615's policy question remains open and belongs to its owner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
