### PR TITLE
fix(macos): stop the snapshot references encoding the recording host's TIMEZONE (#1659)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1399,12 +1399,50 @@ Before marking a ticket done, run the full suite — every layer must pass:
   `format: .number` at `BackchannelRulesView.swift:149` is the only
   `FormatStyle` in the app (every other numeric render is `String(format:)`,
   which takes no locale, or an `Int` interpolation, which carries no grouping).
-  The sibling family that is NOT closed is **timezone**: `HistoryFormat`'s
-  formatters pin `en_US_POSIX` but never set `timeZone`, and 8 of the 14
-  `HistoryViewSnapshotTests` references contain their output, held only by that
-  suite's own `setUp` — #1659, kept separate because a process-global
-  `private static let DateFormatter` is not reachable from the view environment
-  the way a `FormatStyle` is, so it needs its own seam rather than a second key.
+  **The sibling family is TIMEZONE, and closing it found a second machine read
+  nobody had named** (#1659). `HistoryFormat`'s formatters pinned `en_US_POSIX`
+  and never set `timeZone`, so 8 of the 14 `HistoryViewSnapshotTests` references
+  were held only by that suite's own `setUp` assigning `NSTimeZone.default`.
+  The seam is `\.formatTimeZone` (`Irrlicht/Views/FormatTimeZoneEnvironment.swift`),
+  and unlike `\.formatLocale` it could not be read by the formatters as they
+  stood — a file-scope `private static let DateFormatter` is reachable from no
+  view — so `HistoryFormat.axisLabel`/`clock`/`fullDateTime` take a `TimeZone`
+  as a REQUIRED argument and the views pass what they read. A zone-less call
+  site is `error: missing argument for parameter 'timeZone' in call`. The
+  default is `NSTimeZone.default` and **not** `TimeZone.autoupdatingCurrent`,
+  which reads like the obvious mirror of `\.formatLocale`'s
+  `Locale.autoupdatingCurrent` and is wrong: measured, after
+  `NSTimeZone.default = UTC` an unset `DateFormatter` renders UTC while
+  `TimeZone.autoupdatingCurrent` **and** `TimeZone.current` both still report
+  the host zone, so either would have been a real change for exactly the
+  processes that assign it. The pinned zone is `UTC` because that is what the
+  references were recorded under, so nothing was regenerated.
+  Two things there are worth carrying beyond the fix. **The pin is three
+  environments, not one**: pinning only `\.formatTimeZone` still reddened 6 of
+  the 14, because **Swift Charts resolves `AxisMarks(values: .automatic(…))`
+  through `\.calendar`** — whose default `Calendar.current` *does* follow
+  `NSTimeZone.default` — so the deleted `setUp` had been holding tick and
+  gridline POSITIONS as well as label text, which is why the `compact` quota
+  chart moved despite drawing no axis labels at all. `PinnedSnapshotHost` now
+  pins `\.formatTimeZone`, `\.calendar` (rebuilt `.gregorian` + the pinned
+  locale, so the host's week rules go too) and `\.timeZone`. And **the two
+  halves are separately invisible**: reverting the product seam while keeping
+  the pins reddens 4 references, dropping the `\.calendar` pin reddens the other
+  6, and the union is the 8 — reverting the seam leaves every `M/d` label green
+  on a `Europe/Berlin` host, because a one-hour shift does not change a date.
+  That is #1630's mutation B one family later: only the rendered-string
+  assertions in `PinnedTimeZoneSnapshotTests` catch it. That suite deletes
+  `HistoryViewSnapshotTests`' `setUp` rather than keeping it, deliberately —
+  with no process-wide assignment left, those 8 references are themselves the
+  live evidence that the seam reaches every date the panel draws.
+  Still open in this family, each with its evidence in the issue rather than
+  asserted here: `SessionListView.formatResetTime` (#1663 — a timezone pin
+  reaches two of its three machine reads and leaves the `Date()` that picks the
+  format string, so it was left whole rather than half-covered) and
+  `@AppStorage`/`UserDefaults` (#1662 — and no, a test run does not modify the
+  user's real app preferences: `UserDefaults.standard` under `swift test`
+  resolves to `com.apple.dt.xctest.tool`, measured against a byte-identical
+  `io.irrlicht.app.plist` across a full run).
   The suite also aborts intermittently (#1523) in a way that **truncates the
   run** while every suite that did report says "0 failures" — so the exit code
   is the only reliable signal, never the last totals line you can see. That is

--- a/platforms/macos/Irrlicht/Views/FormatTimeZoneEnvironment.swift
+++ b/platforms/macos/Irrlicht/Views/FormatTimeZoneEnvironment.swift
@@ -1,0 +1,87 @@
+import SwiftUI
+
+/// The time zone `DateFormatter`-based rendering resolves through (#1659).
+///
+/// ## Why this exists at all
+///
+/// `HistoryFormat`'s cached formatters pinned `locale` to `en_US_POSIX` and
+/// never set `timeZone`, so every date string the History panel draws came out
+/// of `NSTimeZone.default` — the machine. Eight of the fourteen committed
+/// `HistoryViewSnapshotTests` references contain that output, and they were
+/// correct only because that one suite's `setUp` assigned
+/// `NSTimeZone.default = UTC` and put it back in `tearDown`. A new suite hosting
+/// `HistoryContentView` / `HistoryActivityContentView` /
+/// `HistoryQuotaForecastView` without copying those seven lines would have
+/// recorded the developer's own time zone into a reference.
+///
+/// This is the time-zone sibling of `\.formatLocale` (#1630), and it exists for
+/// the same reason: the value was being read from the MACHINE where the
+/// equivalent value was available from the INPUT. It is a separate key rather
+/// than a second use of that one because the two are separately overridable —
+/// a host may want POSIX-stable numbers and local wall-clock times, or the
+/// reverse — and because they are read by different machinery (`FormatStyle`
+/// vs `DateFormatter`).
+///
+/// ## Why the environment could NOT reach the formatters as they stood
+///
+/// `\.formatLocale` works for `BackchannelRulesView` because a `FormatStyle` is
+/// *constructed per render*, inside `body`, so the view can hand it a value it
+/// read from the environment. `HistoryFormat`'s formatters were file-scope
+/// `private static let DateFormatter`s: one object per process, built on first
+/// touch, reachable from no view. Setting this key alone would therefore have
+/// changed nothing — the vacuous-green shape #1630 measured for
+/// `.environment(\.locale, …)`.
+///
+/// So the product change is not "add a key". It is that `HistoryFormat`'s
+/// entry points now **require** a `TimeZone` argument, and the views that call
+/// them read it from here. A new call site that has no zone to pass is a
+/// compile error rather than a silent read of `NSTimeZone.default`.
+///
+/// ## Why the default is `NSTimeZone.default` and not `.autoupdatingCurrent`
+///
+/// Because `NSTimeZone.default` is, *by construction*, the value an unset
+/// `DateFormatter.timeZone` already resolved through — the same
+/// "by construction identical" bar `\.formatLocale`'s
+/// `Locale.autoupdatingCurrent` default met. A user in Berlin still sees Berlin
+/// times.
+///
+/// `TimeZone.autoupdatingCurrent` and `TimeZone.current` would NOT have met it.
+/// Measured on this host (`Europe/Berlin`), after `NSTimeZone.default = UTC`:
+///
+///     TimeZone.current               = Europe/Berlin   (does NOT follow it)
+///     TimeZone.autoupdatingCurrent   = Europe/Berlin   (does NOT follow it)
+///     unset DateFormatter            = 22:13 = UTC     (DOES follow it)
+///
+/// so either of those two would have been a real behaviour change for any
+/// process that assigns `NSTimeZone.default` — which is precisely the History
+/// snapshot suite, and would have quietly broken the eight references this
+/// change exists to protect.
+///
+/// `defaultValue` is a **computed** property for the same reason: read per
+/// access, so it tracks a later assignment exactly the way the unset formatter
+/// did (also measured — an unset `DateFormatter` created *before* the
+/// assignment still rendered UTC after it, so "captured at first use" is not
+/// the semantics these formatters had).
+private struct FormatTimeZoneKey: EnvironmentKey {
+    /// The time zone an unset `DateFormatter.timeZone` already resolves
+    /// through. Overriding this key with anything else is a deliberate act;
+    /// nothing in the app does it, and the snapshot hosts do.
+    static var defaultValue: TimeZone { NSTimeZone.default }
+}
+
+extension EnvironmentValues {
+    /// Time zone for `DateFormatter`-based rendering in this subtree.
+    ///
+    /// Read it and pass it to the formatter (`HistoryFormat.axisLabel(d,
+    /// bucketSeconds: s, timeZone: formatTimeZone)`) — like `\.formatLocale`
+    /// and unlike `\.locale`, nothing consults this implicitly.
+    ///
+    /// Hoist it into a local before using it inside an escaping builder
+    /// closure (Swift Charts' `AxisValueLabel`, `ForEach`'s content): reading
+    /// a property wrapper from a captured `self` outside `body` evaluation is
+    /// what SwiftUI warns about, and the local is free.
+    var formatTimeZone: TimeZone {
+        get { self[FormatTimeZoneKey.self] }
+        set { self[FormatTimeZoneKey.self] = newValue }
+    }
+}

--- a/platforms/macos/Irrlicht/Views/HistoryView.swift
+++ b/platforms/macos/Irrlicht/Views/HistoryView.swift
@@ -1053,6 +1053,12 @@ struct HistoryActivityContentView: View {
     let onExportCSV: () -> Void
     let onExportJSON: () -> Void
 
+    /// #1659 — the column headers and the tooltip render dates, so this view
+    /// takes the zone (and the tooltip's locale) as an INPUT rather than
+    /// letting `DateFormatter` read `NSTimeZone.default`.
+    @Environment(\.formatTimeZone) private var formatTimeZone
+    @Environment(\.formatLocale) private var formatLocale
+
     private static let cellWidth: CGFloat = 28
     private static let rowHeight: CGFloat = 34
     private static let rowLabelWidth: CGFloat = 130
@@ -1121,6 +1127,11 @@ struct HistoryActivityContentView: View {
     // backstop in case a very wide grid still reports past its frame.
     private var grid: some View {
         let maxTotal = computeMaxTotal()
+        // Hoisted out of the `ForEach` builders below: reading an
+        // `@Environment` property from a captured `self` inside an escaping
+        // builder closure is the pattern SwiftUI warns about, and a local costs
+        // nothing.
+        let zone = formatTimeZone
         return HStack(alignment: .top, spacing: 0) {
             // Sticky row-label column: not inside the horizontal ScrollView
             // below, so it never scrolls away as the grid scrolls sideways.
@@ -1140,7 +1151,7 @@ struct HistoryActivityContentView: View {
                 VStack(alignment: .leading, spacing: 0) {
                     HStack(spacing: 0) {
                         ForEach(Array(data.bucketStarts.enumerated()), id: \.offset) { _, ts in
-                            Text(HistoryFormat.axisLabel(Date(timeIntervalSince1970: TimeInterval(ts)), bucketSeconds: data.bucketSeconds))
+                            Text(HistoryFormat.axisLabel(Date(timeIntervalSince1970: TimeInterval(ts)), bucketSeconds: data.bucketSeconds, timeZone: zone))
                                 .font(.system(size: 8))
                                 .foregroundColor(.secondary)
                                 .frame(width: Self.cellWidth, height: Self.rowHeight)
@@ -1178,8 +1189,10 @@ struct HistoryActivityContentView: View {
             }
         }
         .frame(width: Self.cellWidth, height: Self.rowHeight)
-        .tooltip(Self.tooltipText(project: project, ts: ts, counts: counts))
-        .accessibilityLabel(Self.tooltipText(project: project, ts: ts, counts: counts))
+        .tooltip(Self.tooltipText(project: project, ts: ts, counts: counts,
+                                  timeZone: formatTimeZone, locale: formatLocale))
+        .accessibilityLabel(Self.tooltipText(project: project, ts: ts, counts: counts,
+                                             timeZone: formatTimeZone, locale: formatLocale))
     }
 
     private func segHeight(_ count: Double, _ total: Double, _ barHeight: CGFloat) -> CGFloat {
@@ -1187,24 +1200,24 @@ struct HistoryActivityContentView: View {
         return max(0, CGFloat(count / total) * barHeight)
     }
 
-    /// Full date+time for the tooltip — the column header uses the existing
-    /// shared `HistoryFormat.axisLabel` (same HH:mm-vs-date split every other
-    /// chart's x-axis already uses), but nothing there covers a full
-    /// timestamp, so this one's genuinely new.
-    private static let fullDateTimeFormatter: DateFormatter = {
-        let f = DateFormatter()
-        f.dateStyle = .medium
-        f.timeStyle = .short
-        return f
-    }()
-
     /// Matches the web tooltip's field order (project, full timestamp, then
     /// working/waiting/ready). Ready is explicitly labeled as a per-bucket
     /// transition count, not a concurrency count — it has no duration to be
     /// "concurrent" in, unlike working/waiting.
-    private static func tooltipText(project: String, ts: Int64, counts: HistoryStateResponse.Counts) -> String {
+    ///
+    /// The full timestamp lives in `HistoryFormat.fullDateTime` (#1659) rather
+    /// than in a `private static let DateFormatter` here: it was the third
+    /// formatter in this file reading the machine, on both the zone and the
+    /// locale axis. Nothing asserts this particular pass-through, and that is
+    /// stated rather than implied — see `PinnedTimeZoneSnapshotTests`'
+    /// "what this suite does not reach" note for the measurement (a
+    /// window-less `NSHostingView` publishes no accessibility children, and
+    /// `.tooltip` draws into a separate `NSPanel`), so neither call site
+    /// contributes anything a test can read back.
+    private static func tooltipText(project: String, ts: Int64, counts: HistoryStateResponse.Counts,
+                                    timeZone: TimeZone, locale: Locale) -> String {
         let date = Date(timeIntervalSince1970: TimeInterval(ts))
-        let when = fullDateTimeFormatter.string(from: date)
+        let when = HistoryFormat.fullDateTime(date, timeZone: timeZone, locale: locale)
         return "\(project), \(when): \(Int(counts.working)) working, \(Int(counts.waiting)) waiting, \(Int(counts.ready)) transitioned to ready"
     }
 }
@@ -1215,6 +1228,9 @@ private struct HistoryCostChart: View {
     let data: HistoryResponse
     let orderedProjects: [String]
     var chart: HistoryChart = .cost
+
+    /// #1659 — the x-axis tick labels are dates.
+    @Environment(\.formatTimeZone) private var formatTimeZone
 
     private struct Datum: Identifiable {
         let id: String
@@ -1278,7 +1294,12 @@ private struct HistoryCostChart: View {
     }
 
     var body: some View {
-        Chart {
+        // Hoisted out of the escaping `AxisValueLabel` builder below (#1659):
+        // Swift Charts evaluates that closure outside `body`, where reading an
+        // `@Environment` property off a captured `self` is what SwiftUI warns
+        // about.
+        let zone = formatTimeZone
+        return Chart {
             ForEach(costData) { d in
                 AreaMark(
                     x: .value("Time", d.date),
@@ -1323,7 +1344,7 @@ private struct HistoryCostChart: View {
                 AxisGridLine()
                 AxisValueLabel {
                     if let d = value.as(Date.self) {
-                        Text(HistoryFormat.axisLabel(d, bucketSeconds: data.bucketSeconds))
+                        Text(HistoryFormat.axisLabel(d, bucketSeconds: data.bucketSeconds, timeZone: zone))
                     }
                 }
             }
@@ -1419,6 +1440,9 @@ struct QuotaProviderVM: Identifiable {
 struct HistoryQuotaForecastView: View {
     let providers: [QuotaProviderVM]
 
+    /// #1659 — the "▲ cap …" label is a wall-clock time.
+    @Environment(\.formatTimeZone) private var formatTimeZone
+
     var body: some View {
         VStack(alignment: .leading, spacing: IrrSpacing.sp3) {
             Text("Rate limits")
@@ -1465,7 +1489,7 @@ struct HistoryQuotaForecastView: View {
             HistoryQuotaChart(window: w, compact: true)
                 .frame(height: 84)
             if let cap = w.projectedCap {
-                Text("▲ cap \(HistoryFormat.clock(cap))")
+                Text("▲ cap \(HistoryFormat.clock(cap, timeZone: formatTimeZone))")
                     .font(.caption2)
                     .foregroundColor(IrrColors.waiting)
                     .lineLimit(1)
@@ -1486,6 +1510,12 @@ private struct HistoryQuotaChart: View {
     /// Strips the x-axis labels and the "cap" annotation for the small
     /// per-provider cards in the forecast strip.
     var compact: Bool = false
+
+    /// #1659 — the non-compact x-axis tick labels are dates. Note that the
+    /// only call site in the app today passes `compact: true`, so that branch
+    /// currently renders in no committed reference; the seam is wired anyway
+    /// so the first non-compact caller does not reintroduce the machine read.
+    @Environment(\.formatTimeZone) private var formatTimeZone
 
     private struct Pt: Identifiable {
         let id: String
@@ -1518,7 +1548,9 @@ private struct HistoryQuotaChart: View {
     private var showTime: Bool { window.end.timeIntervalSince(window.start) <= 86_400 }
 
     var body: some View {
-        Chart {
+        // Hoisted for the escaping `AxisValueLabel` builder below (#1659).
+        let zone = formatTimeZone
+        return Chart {
             RuleMark(y: .value("Cap", 100))
                 .foregroundStyle(IrrColors.pressureHigh.opacity(0.8))
                 .lineStyle(StrokeStyle(lineWidth: 1, dash: [4, 3]))
@@ -1561,7 +1593,7 @@ private struct HistoryQuotaChart: View {
                 if !compact {
                     AxisValueLabel {
                         if let d = v.as(Date.self) {
-                            Text(HistoryFormat.axisLabel(d, bucketSeconds: showTime ? 3_600 : 86_400))
+                            Text(HistoryFormat.axisLabel(d, bucketSeconds: showTime ? 3_600 : 86_400, timeZone: zone))
                         }
                     }
                 }
@@ -1636,29 +1668,77 @@ enum HistoryFormat {
         return tokens(v)
     }
 
-    // Cached formatters — DateFormatter init is expensive and these fire per
-    // axis tick. POSIX-pinned so snapshot tests stay stable; timezone tracks the
-    // process default (daemon + app share one Mac).
-    private static let hourMinute = posix("HH:mm")
-    private static let monthDay = posix("M/d")
-    private static let weekdayClock = posix("EEE h:mm a")
+    private static let hourMinuteFormat = "HH:mm"
+    private static let monthDayFormat = "M/d"
+    private static let weekdayClockFormat = "EEE h:mm a"
 
-    private static func posix(_ format: String) -> DateFormatter {
-        let f = DateFormatter()
-        f.locale = Locale(identifier: "en_US_POSIX")
-        f.dateFormat = format
-        return f
+    // Formatters are cached — `DateFormatter` init is expensive and these fire
+    // per axis tick and per activity-grid cell — but keyed by the time zone
+    // (and, for the full timestamp, the locale) they were built for, rather
+    // than being three process-global `static let`s.
+    //
+    // The old shape pinned the locale to `en_US_POSIX` and left `timeZone`
+    // unset, which meant every date string in the History panel came out of
+    // `NSTimeZone.default`: the machine (#1659). A caller now has to say which
+    // zone it wants, so a new call site is a compile error rather than another
+    // silent machine read; the views get theirs from `\.formatTimeZone`, whose
+    // default is `NSTimeZone.default` — by construction what the unset
+    // formatters already resolved through, so no user sees a different time.
+    private static let cacheLock = NSLock()
+    private static var cache: [String: DateFormatter] = [:]
+
+    private static func cached(_ key: String, _ make: () -> DateFormatter) -> DateFormatter {
+        cacheLock.lock()
+        defer { cacheLock.unlock() }
+        if let hit = cache[key] { return hit }
+        let made = make()
+        cache[key] = made
+        return made
+    }
+
+    /// POSIX-locale formatter for `format`, rendering in `zone`.
+    ///
+    /// `locale` is assigned before `dateFormat` on purpose: `dateFormat` is
+    /// interpreted against the formatter's current locale, so the reverse order
+    /// silently re-interprets the pattern.
+    private static func posix(_ format: String, _ zone: TimeZone) -> DateFormatter {
+        cached("posix\u{1}\(zone.identifier)\u{1}\(format)") {
+            let f = DateFormatter()
+            f.locale = Locale(identifier: "en_US_POSIX")
+            f.timeZone = zone
+            f.dateFormat = format
+            return f
+        }
     }
 
     /// X-axis tick label: `HH:mm` for sub-day buckets, `M/d` otherwise —
     /// matching the web `histAxisLabel`.
-    static func axisLabel(_ date: Date, bucketSeconds: Int64) -> String {
-        (bucketSeconds < 86_400 ? hourMinute : monthDay).string(from: date)
+    static func axisLabel(_ date: Date, bucketSeconds: Int64, timeZone: TimeZone) -> String {
+        posix(bucketSeconds < 86_400 ? hourMinuteFormat : monthDayFormat, timeZone).string(from: date)
     }
 
     /// Weekday + 12-hour clock, e.g. "Sat 3:15 PM" — for projected-cap and reset.
-    static func clock(_ date: Date) -> String {
-        weekdayClock.string(from: date)
+    static func clock(_ date: Date, timeZone: TimeZone) -> String {
+        posix(weekdayClockFormat, timeZone).string(from: date)
+    }
+
+    /// Full date + time for the activity grid's tooltip / accessibility label.
+    ///
+    /// Unlike the axis formatters this one is deliberately **localised** —
+    /// `.medium` + `.short` in the reader's own conventions is the right thing
+    /// for a tooltip, and `\.formatLocale`'s default (`Locale.autoupdatingCurrent`)
+    /// is what an unset `DateFormatter.locale` already resolved through. Both
+    /// axes come from the caller for the same reason: so the value is an INPUT
+    /// and not a property of whichever Mac happens to be rendering.
+    static func fullDateTime(_ date: Date, timeZone: TimeZone, locale: Locale) -> String {
+        cached("full\u{1}\(timeZone.identifier)\u{1}\(locale.identifier)") {
+            let f = DateFormatter()
+            f.locale = locale
+            f.timeZone = timeZone
+            f.dateStyle = .medium
+            f.timeStyle = .short
+            return f
+        }.string(from: date)
     }
 }
 

--- a/platforms/macos/Irrlicht/Views/SessionListView.swift
+++ b/platforms/macos/Irrlicht/Views/SessionListView.swift
@@ -1117,6 +1117,20 @@ struct SessionListView: View {
         }
     }
 
+    // #1663 — these two are the timezone family's third site, and #1659
+    // deliberately left them alone rather than half-covering them. Threading
+    // `\.formatTimeZone` / `\.formatLocale` in (as `HistoryFormat` now does)
+    // would reach two of `formatResetTime`'s three machine reads and leave the
+    // one that matters most: `Date()` below selects a different FORMAT STRING
+    // either side of midnight, so a snapshot pinned on zone and locale alone is
+    // still a snapshot of the day it was recorded. That needs an injectable
+    // "now", which is a wider seam than this issue.
+    //
+    // Unreached by any committed reference today — the whole chain is behind
+    // `guard let snap = session.metrics?.rateLimit` (:705) and no fixture under
+    // Tests/Fixtures carries a rate-limit window (verified by grep, both files).
+    // The first fixture that seeds one bakes locale, timezone and the recording
+    // day into a reference at once; read #1663 before adding it.
     private func formatClockTime(_ date: Date) -> String {
         let f = DateFormatter()
         f.dateStyle = .none

--- a/platforms/macos/Tests/HistoryViewSnapshotTests.swift
+++ b/platforms/macos/Tests/HistoryViewSnapshotTests.swift
@@ -7,27 +7,25 @@ import SnapshotTesting
 // pure visual-rendering snapshots, not interaction tests, so export wiring is
 // irrelevant (SonarQube swift:S1186 flags each occurrence individually).
 @MainActor
+// This suite used to open with a `setUp`/`tearDown` pair assigning
+// `NSTimeZone.default = UTC` and putting it back, because eight of its
+// fourteen references contain `HistoryFormat`'s date output. That pin now
+// lives on `PinnedSnapshotHost` (#1659), which is what every host below goes
+// through, so it cannot be forgotten by the next suite to render these views —
+// and it is scoped to the hosted subtree instead of to the process, so an
+// aborted run (#1523) cannot leave the process's time zone reassigned.
+//
+// Deleting it here is deliberate and load-bearing: with the process-wide pin
+// gone, these eight references are the live evidence that the seam reaches
+// every date this panel draws. A call site that stopped passing
+// `\.formatTimeZone` would render this `Europe/Berlin` machine's clock and
+// redden them.
 final class HistoryViewSnapshotTests: XCTestCase {
-    private var originalTimeZone: TimeZone!
-
-    override func setUp() async throws {
-        try await super.setUp()
-        // Pin the timezone so the chart's x-axis labels (HH:mm / M/d) render
-        // identically regardless of the machine running the test.
-        originalTimeZone = NSTimeZone.default
-        NSTimeZone.default = TimeZone(identifier: "UTC")!
-    }
-
-    override func tearDown() async throws {
-        NSTimeZone.default = originalTimeZone
-        try await super.tearDown()
-    }
-
     private func host(_ view: some View, height: CGFloat) -> PinnedSnapshotHost {
         let width = SessionListView.panelWidth
         // `PinnedSnapshotHost` pins dark aqua so snapshots don't depend on the
-        // current system appearance (matches SessionRowSnapshotTests), and the
-        // locale (#1630).
+        // current system appearance (matches SessionRowSnapshotTests), the
+        // locale (#1630) and the time zone (#1659).
         return PinnedSnapshotHost(
             view
                 .frame(width: width, height: height)

--- a/platforms/macos/Tests/PinnedLocaleSnapshot.swift
+++ b/platforms/macos/Tests/PinnedLocaleSnapshot.swift
@@ -86,6 +86,47 @@ extension View {
         environment(\.formatLocale, locale)
             .environment(\.locale, locale)
     }
+
+    /// Pin the time zone this subtree renders dates in, for a snapshot host
+    /// (#1659). Scoped to the subtree, unlike the `NSTimeZone.default`
+    /// assignment `HistoryViewSnapshotTests` used to make, so it cannot leak
+    /// past a test that aborts before its `tearDown` (#1523).
+    ///
+    /// Sets **three** environments, and the second one is the one nobody would
+    /// predict. Measured, by deleting that suite's `setUp` and keeping only
+    /// `\.formatTimeZone`: six of its fourteen references still reddened, and
+    /// they all went green again under `TZ=UTC`. So the string formatting was
+    /// not the only machine read.
+    ///
+    /// - `\.formatTimeZone` is the seam the `DateFormatter`s consult
+    ///   (`Irrlicht/Views/FormatTimeZoneEnvironment.swift`). It decides what a
+    ///   tick LABEL says.
+    /// - `\.calendar` is what **Swift Charts** resolves `AxisMarks(values:
+    ///   .automatic(…))` through, so it decides WHERE the ticks and gridlines
+    ///   are — which is why `testQuotaForecast*` moved even though its chart
+    ///   is `compact` and draws no axis labels at all. Its default is
+    ///   `Calendar.current`, whose `timeZone` DOES follow `NSTimeZone.default`
+    ///   (measured; `TimeZone.current` notably does not), which is how the old
+    ///   `setUp` reached it by accident.
+    /// - `\.timeZone` is SwiftUI's own. Nothing in this app is known to read
+    ///   it, and its default did NOT follow `NSTimeZone.default`, so it was
+    ///   `Europe/Berlin` while every committed reference was recorded — but
+    ///   pinning it changes no reference (measured: all 14 still match), and a
+    ///   host that pins two of the three time zones in its environment would be
+    ///   an odd thing to leave behind.
+    ///
+    /// The calendar is rebuilt rather than copied from `Calendar.current`,
+    /// which carries the host's calendar identity and week rules as well as its
+    /// zone. `.gregorian` + the pinned locale reproduces the recording host
+    /// exactly (all 14 references still match) while no longer depending on it.
+    fileprivate func pinnedTimeZone(_ timeZone: TimeZone, locale: Locale) -> some View {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = timeZone
+        calendar.locale = locale
+        return environment(\.formatTimeZone, timeZone)
+            .environment(\.calendar, calendar)
+            .environment(\.timeZone, timeZone)
+    }
 }
 
 /// The rasterisable host a `.pinnedImage` snapshot is taken of — and the only
@@ -110,6 +151,13 @@ extension View {
 /// itself, so "the host the suites use" and "the host the pin was proven on"
 /// cannot be two things that disagree.
 ///
+/// #1659 moved the **time zone** pin here for the same reason, out of
+/// `HistoryViewSnapshotTests`' `setUp`. That one had a second problem a
+/// subtree environment does not have: it assigned `NSTimeZone.default`, which
+/// is process-wide, so it depended on `tearDown` running to put the process
+/// back — and per #1523 this suite intermittently aborts mid-run.
+/// `PinnedTimeZoneSnapshotTests` grades it here, on this object.
+///
 /// The remaining hole is the one a type cannot close: a suite that stops using
 /// `.pinnedImage` altogether. `ImageSnapshotCIScopeTests` already derives its CI
 /// classification from that same string, so such a suite loses the scale pin,
@@ -131,12 +179,18 @@ struct PinnedSnapshotHost {
     ///     tests are the one caller that passes `.aqua`).
     ///   - locale: defaults to the locale every committed reference was
     ///     recorded under. Only the tests that PROVE the pin pass anything else.
+    ///   - timeZone: same, for date rendering (#1659). It was
+    ///     `HistoryViewSnapshotTests`' own `setUp` until this parameter
+    ///     existed, which is exactly the "one suite remembers" shape the
+    ///     locale pin was moved here to stop.
     init(_ content: some View,
          width: CGFloat,
          height: CGFloat,
          appearance: NSAppearance.Name = .darkAqua,
-         locale: Locale = PinnedLocaleSnapshot.referenceLocale) {
-        let hosting = NSHostingView(rootView: content.pinnedLocale(locale))
+         locale: Locale = PinnedLocaleSnapshot.referenceLocale,
+         timeZone: TimeZone = PinnedTimeZoneSnapshot.referenceTimeZone) {
+        let hosting = NSHostingView(
+            rootView: content.pinnedLocale(locale).pinnedTimeZone(timeZone, locale: locale))
         hosting.appearance = NSAppearance(named: appearance)
         hosting.frame = CGRect(x: 0, y: 0, width: width, height: height)
         hosting.layoutSubtreeIfNeeded()

--- a/platforms/macos/Tests/PinnedTimeZoneSnapshot.swift
+++ b/platforms/macos/Tests/PinnedTimeZoneSnapshot.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+/// The time zone every image snapshot is rendered under, so a committed
+/// reference is a picture of the VIEW and not of the recording machine's clock
+/// (#1659).
+///
+/// ## What was wrong
+///
+/// `HistoryFormat`'s cached formatters pinned the locale and never set
+/// `timeZone`, so `HH:mm` / `M/d` / `EEE h:mm a` all came out of
+/// `NSTimeZone.default`. Eight of the fourteen committed
+/// `HistoryViewSnapshotTests` references contain that output, and the only
+/// thing keeping them right was that suite's own `setUp`:
+///
+///     originalTimeZone = NSTimeZone.default
+///     NSTimeZone.default = TimeZone(identifier: "UTC")!
+///
+/// That is the third value these references were reading off the MACHINE where
+/// it was available from the INPUT — after the backing scale
+/// (`PinnedScaleSnapshot`, #1530) and the locale (`PinnedLocaleSnapshot`,
+/// #1630) — and it was the one still held by seven lines a new suite has to
+/// remember to copy. It is now held by `PinnedSnapshotHost`, whose only
+/// initializer applies it, so a suite cannot host a view without it.
+///
+/// ## Why `UTC`
+///
+/// For the same reason `PinnedLocaleSnapshot.referenceLocale` is `de_DE` and
+/// `PinnedScaleSnapshot.referenceScale` is `2`: **it is what the committed
+/// references were recorded under**, so adopting it regenerates nothing.
+/// `AGENTS.md` names re-recording a reference to make a test pass as the move
+/// #1034 and #1044 both made and both got wrong.
+///
+/// This one is a stronger statement than the locale's, because it is not the
+/// recording host's own zone (that is `Europe/Berlin`) — it is the value that
+/// suite deliberately assigned. Moving the pin here is a straight transfer of
+/// an existing decision from one suite's `setUp` to the type every suite goes
+/// through.
+enum PinnedTimeZoneSnapshot {
+    /// The time zone every committed reference was recorded under — read off
+    /// `HistoryViewSnapshotTests.setUp` as it stood before #1659, which is now
+    /// deleted because this is where that pin lives.
+    static let referenceTimeZone = TimeZone(identifier: "UTC")!
+
+    /// A zone whose wall clock differs from `referenceTimeZone` at every
+    /// instant (fixed +09:00, no DST).
+    ///
+    /// Its job is the same as `PinnedLocaleSnapshot.contrastingLocale`'s: keep
+    /// `referenceTimeZone` from being changed into something that makes the
+    /// both-sides arms tautological. `Asia/Tokyo` also differs from the
+    /// recording host's `Europe/Berlin`, so neither arm of a two-zone test can
+    /// agree with the machine — which is what makes such a test able to fail
+    /// on this laptop and on a UTC runner alike.
+    static let contrastingTimeZone = TimeZone(identifier: "Asia/Tokyo")!
+}

--- a/platforms/macos/Tests/PinnedTimeZoneSnapshotTests.swift
+++ b/platforms/macos/Tests/PinnedTimeZoneSnapshotTests.swift
@@ -1,0 +1,293 @@
+import AppKit
+import SwiftUI
+import XCTest
+@testable import Irrlicht
+
+/// Locks the property #1659 is about: an image snapshot renders under the time
+/// zone it is ASKED for, not the one the machine happens to be in.
+///
+/// The obvious test — "renders 00:00" — is the trap, and it is the same one
+/// `PinnedScaleSnapshotTests` and `PinnedLocaleSnapshotTests` are written
+/// around. `HistoryViewSnapshotTests` used to assign `NSTimeZone.default = UTC`
+/// in `setUp`, so on any machine an assertion of "renders as UTC" passes
+/// whether the formatter read its argument or the process default. The fix is
+/// to drive BOTH zones through one view: whatever `NSTimeZone.default` is, at
+/// most one arm can agree with it, so an implementation that reads the machine
+/// fails the other — on this `Europe/Berlin` laptop and on a UTC runner alike.
+///
+/// Everything below goes through `PinnedSnapshotHost`, the type the suites
+/// snapshot, rather than through a hosting view this file assembles: "the host
+/// that pins" and "the host the proof was taken on" must not be two objects
+/// that can disagree.
+///
+/// ## What this suite does NOT reach, and how that was measured
+///
+/// `HistoryActivityContentView.tooltipText` also renders a date, and #1659
+/// threads `\.formatTimeZone` and `\.formatLocale` into it — but no assertion
+/// here grades that pass-through, because neither of its two call sites
+/// produces anything a test can read back. `.tooltip(…)`
+/// (`SessionListView.swift`) is an `onHover`-only modifier that draws into a
+/// separate `NSPanel` and adds nothing to the view tree, and `.accessibilityLabel(…)`
+/// is not rasterised: a window-less `NSHostingView` over three `Text`s reports
+/// `accessibilityChildren() == nil` and `accessibilityLabel() == nil` at the
+/// root (measured — SwiftUI builds the AX tree lazily for a real AX client, and
+/// there is none in an `xctest` process). What IS graded is the formatter it
+/// calls, `HistoryFormat.fullDateTime`, directly.
+@MainActor
+final class PinnedTimeZoneSnapshotTests: XCTestCase {
+
+    /// 2023-11-14 22:13:20 UTC — late enough in the UTC day that `Asia/Tokyo`
+    /// (+09:00, no DST) is already on the NEXT date, so the two zones differ in
+    /// the `M/d` label as well as in `HH:mm`.
+    private let instant = Date(timeIntervalSince1970: 1_700_000_000)
+
+    private var utc: TimeZone { PinnedTimeZoneSnapshot.referenceTimeZone }
+    private var tokyo: TimeZone { PinnedTimeZoneSnapshot.contrastingTimeZone }
+
+    // MARK: - The formatters honour the zone they are GIVEN
+
+    /// Both x-axis formats, both zones. This is also the arm that would catch
+    /// the specific hazard #1659 describes — a formatter cached under one zone
+    /// and handed back for another — since a cache keyed only by format string
+    /// would answer the second call with the first call's formatter.
+    func testAxisLabelsRenderInTheZoneTheyAreGiven() {
+        XCTAssertEqual(HistoryFormat.axisLabel(instant, bucketSeconds: 3_600, timeZone: utc), "22:13")
+        XCTAssertEqual(HistoryFormat.axisLabel(instant, bucketSeconds: 3_600, timeZone: tokyo), "07:13")
+        XCTAssertEqual(HistoryFormat.axisLabel(instant, bucketSeconds: 86_400, timeZone: utc), "11/14")
+        XCTAssertEqual(HistoryFormat.axisLabel(instant, bucketSeconds: 86_400, timeZone: tokyo), "11/15")
+    }
+
+    func testClockRendersInTheZoneItIsGiven() {
+        XCTAssertEqual(HistoryFormat.clock(instant, timeZone: utc), "Tue 10:13 PM")
+        XCTAssertEqual(HistoryFormat.clock(instant, timeZone: tokyo), "Wed 7:13 AM")
+    }
+
+    /// The tooltip formatter, which is the one that varies on BOTH axes: it is
+    /// deliberately localised, so it is graded against a locale it is given as
+    /// well as a zone.
+    func testFullDateTimeRendersInTheZoneAndLocaleItIsGiven() {
+        let en = Locale(identifier: "en_US")
+        // U+202F, narrow no-break space before the AM/PM marker — measured, not
+        // guessed. `clock` above has an ordinary space because it is
+        // `en_US_POSIX`; this formatter is localised and ICU is not.
+        XCTAssertEqual(HistoryFormat.fullDateTime(instant, timeZone: utc, locale: en),
+                       "Nov 14, 2023 at 10:13\u{202F}PM")
+        XCTAssertEqual(HistoryFormat.fullDateTime(instant, timeZone: tokyo, locale: en),
+                       "Nov 15, 2023 at 7:13\u{202F}AM")
+        // Same instant, same zone, a locale that spells the date differently —
+        // so this arm cannot pass while the locale argument is being dropped.
+        XCTAssertNotEqual(HistoryFormat.fullDateTime(instant, timeZone: utc, locale: en),
+                          HistoryFormat.fullDateTime(instant, timeZone: utc,
+                                                     locale: Locale(identifier: "de_DE")))
+    }
+
+    /// The two constants the both-sides arms rely on really do disagree at the
+    /// instant those arms use, so a future edit cannot quietly make this suite
+    /// tautological by pointing them at the same offset.
+    func testReferenceAndContrastingTimeZonesRenderDifferently() {
+        let a = HistoryFormat.clock(instant, timeZone: PinnedTimeZoneSnapshot.referenceTimeZone)
+        let b = HistoryFormat.clock(instant, timeZone: PinnedTimeZoneSnapshot.contrastingTimeZone)
+        XCTAssertNotEqual(a, b, "referenceTimeZone and contrastingTimeZone render the same clock (\(a)) — "
+                          + "every both-sides assertion here is vacuous")
+    }
+
+    // MARK: - The pin reaches the pixels
+
+    /// A forecast strip whose one window has a non-nil `projectedCap`, so it
+    /// renders `Text("▲ cap \(HistoryFormat.clock(cap)))` — the same call site
+    /// `testQuotaForecastSingleProvider`'s committed reference contains.
+    private func forecastView() -> some View {
+        let start = instant
+        let window = QuotaWindowVM(
+            label: "5h",
+            planLabel: "Claude Max",
+            start: start,
+            end: start.addingTimeInterval(5 * 3_600),
+            now: start.addingTimeInterval(3_600),
+            usedPercent: 42,
+            projectedCap: start.addingTimeInterval(3 * 3_600),
+            isStale: false
+        )
+        return HistoryQuotaForecastView(providers: [
+            QuotaProviderVM(id: "anthropic", iconKey: "anthropic",
+                            planLabel: "Claude Max", windows: [window])
+        ])
+    }
+
+    /// Rasterise the forecast strip through the host the suites use, at the
+    /// scale the committed references were recorded at.
+    ///
+    /// `timeZone: nil` means "pass no argument", i.e. exactly what every real
+    /// suite writes.
+    private func rasterizedForecast(timeZone: TimeZone?) -> Data {
+        let host = timeZone.map {
+            PinnedSnapshotHost(forecastView().frame(width: 320, height: 220),
+                               width: 320, height: 220, timeZone: $0)
+        } ?? PinnedSnapshotHost(forecastView().frame(width: 320, height: 220),
+                                width: 320, height: 220)
+        let image = PinnedScaleSnapshot.rasterize(host.view, scale: PinnedScaleSnapshot.referenceScale)
+        // "could not rasterise" and "rasterised to the same thing" must never
+        // produce the same verdict.
+        guard let data = image.tiffRepresentation, !data.isEmpty else {
+            XCTFail("the forecast strip rasterised to nothing — this check cannot have run")
+            return Data()
+        }
+        return data
+    }
+
+    /// The load-bearing arm, and the one that would have caught #1630's
+    /// mutation B in this family: revert the product seam so the formatters
+    /// read `NSTimeZone.default` again and both renders become the machine's
+    /// clock — identical — which is what this refuses.
+    func testTheSameViewRendersDifferentlyUnderTwoPinnedTimeZones() {
+        // The premise, stated loudly first: these two zones must actually
+        // produce different text for this fixture, or a byte comparison below
+        // would be measuring nothing.
+        let cap = instant.addingTimeInterval(3 * 3_600)
+        XCTAssertNotEqual(HistoryFormat.clock(cap, timeZone: utc),
+                          HistoryFormat.clock(cap, timeZone: tokyo),
+                          "the fixture's projected cap reads the same in both zones — "
+                          + "the pixel comparison below cannot fail for the right reason")
+
+        // …and rendering is deterministic, or "they differ" proves nothing.
+        XCTAssertEqual(rasterizedForecast(timeZone: utc), rasterizedForecast(timeZone: utc),
+                       "the same view rasterised twice under the same zone differs — "
+                       + "this suite's both-sides arms are not measuring the time zone")
+
+        XCTAssertNotEqual(rasterizedForecast(timeZone: utc), rasterizedForecast(timeZone: tokyo),
+                          "the forecast strip rendered identically under UTC and Asia/Tokyo — "
+                          + "the pinned zone is reaching nothing, and the render is coming from "
+                          + "NSTimeZone.default (\(NSTimeZone.default.identifier))")
+    }
+
+    /// …and the zone a suite gets when it names none is the one the committed
+    /// references were recorded under, so the arms above cannot pass while every
+    /// real snapshot renders under something else.
+    ///
+    /// Stated separately from the arms above so a change to `referenceTimeZone`
+    /// fails HERE, naming the constant, rather than as eight opaque byte
+    /// mismatches in `HistoryViewSnapshotTests`.
+    func testTheHostsDefaultTimeZoneIsTheReferenceTimeZone() {
+        XCTAssertEqual(rasterizedForecast(timeZone: nil),
+                       rasterizedForecast(timeZone: PinnedTimeZoneSnapshot.referenceTimeZone),
+                       "the host's default time zone is not `PinnedTimeZoneSnapshot.referenceTimeZone`")
+        XCTAssertNotEqual(rasterizedForecast(timeZone: nil),
+                          rasterizedForecast(timeZone: PinnedTimeZoneSnapshot.contrastingTimeZone),
+                          "the host renders the same under both zones — the equality above is vacuous")
+    }
+
+    // MARK: - Every time-zone-carrying environment is pinned, not just the seam
+
+    /// Collects what a hosted subtree actually sees. A class so the SwiftUI
+    /// value type can write into it.
+    private final class EnvironmentReport {
+        var formatTimeZone: TimeZone?
+        var calendar: Calendar?
+        var timeZone: TimeZone?
+    }
+
+    private struct EnvironmentProbe: View {
+        @Environment(\.formatTimeZone) private var formatTimeZone
+        @Environment(\.calendar) private var calendar
+        @Environment(\.timeZone) private var timeZone
+        let report: EnvironmentReport
+
+        var body: some View {
+            report.formatTimeZone = formatTimeZone
+            report.calendar = calendar
+            report.timeZone = timeZone
+            return Color.clear
+        }
+    }
+
+    /// The host pins **all three** environments a date can be read from, not
+    /// only the seam this issue is named after.
+    ///
+    /// This arm exists because the first draft of #1659 pinned only
+    /// `\.formatTimeZone` and six of the fourteen `HistoryViewSnapshotTests`
+    /// references still reddened — Swift Charts resolves
+    /// `AxisMarks(values: .automatic(…))` through `\.calendar`, whose default
+    /// `Calendar.current` follows `NSTimeZone.default`, so the deleted `setUp`
+    /// had been holding tick and gridline POSITIONS as well as label text. A
+    /// pixel comparison cannot separate those two; this can.
+    func testTheHostPinsEveryTimeZoneCarryingEnvironment() {
+        let report = EnvironmentReport()
+        _ = PinnedSnapshotHost(EnvironmentProbe(report: report),
+                               width: 40, height: 40, timeZone: tokyo)
+
+        // "the probe never rendered" and "the probe saw the right thing" must
+        // not produce the same verdict.
+        guard let seen = report.formatTimeZone else {
+            return XCTFail("the probe's body never evaluated — this check cannot have run")
+        }
+        XCTAssertEqual(seen, tokyo, "`\\.formatTimeZone` is not pinned by the host")
+        XCTAssertEqual(report.calendar?.timeZone, tokyo,
+                       "`\\.calendar` is not pinned by the host — Swift Charts picks its date "
+                       + "ticks through this, so the reference positions come from the machine")
+        XCTAssertEqual(report.timeZone, tokyo, "`\\.timeZone` is not pinned by the host")
+        // …and the calendar's identity and week rules, which also decide tick
+        // boundaries, are not the host's either.
+        XCTAssertEqual(report.calendar?.identifier, .gregorian,
+                       "the host's calendar identity is not pinned")
+        // NOTE when this one fails: `Locale` prints its identifier and nothing
+        // else, so an autoupdating `de_DE` and a fixed `de_DE` produce a
+        // baffling "(de_DE) is not equal to (de_DE)". They are genuinely
+        // different — the autoupdating one is the MACHINE — and telling them
+        // apart is the whole point, so the strict comparison stays.
+        XCTAssertEqual(report.calendar?.locale, PinnedLocaleSnapshot.referenceLocale,
+                       "the host's calendar locale is not `PinnedLocaleSnapshot.referenceLocale` "
+                       + "(if both sides print the same identifier, one of them is autoupdating)")
+    }
+
+    // MARK: - The seam costs the app nothing
+
+    /// `\.formatTimeZone` defaults to `NSTimeZone.default`, which is what an
+    /// unset `DateFormatter.timeZone` already resolved through — so the shipping
+    /// app renders exactly what it rendered before #1659, on every host. A user
+    /// in Berlin still sees Berlin times.
+    ///
+    /// The unpinned formatter here is spelled the way `HistoryFormat.posix` was
+    /// before #1659, verbatim, so this is a comparison against the old code
+    /// rather than against a description of it.
+    func testTheDefaultIsIndistinguishableFromTheUnpinnedFormatterItReplaced() {
+        let before = DateFormatter()
+        before.locale = Locale(identifier: "en_US_POSIX")
+        before.dateFormat = "HH:mm"            // `timeZone` deliberately never set
+
+        XCTAssertEqual(
+            HistoryFormat.axisLabel(instant, bucketSeconds: 3_600,
+                                    timeZone: EnvironmentValues().formatTimeZone),
+            before.string(from: instant),
+            "the environment default renders a different wall clock than the formatter it replaced")
+    }
+
+    /// …and the default is `NSTimeZone.default` specifically, read per access —
+    /// not `TimeZone.autoupdatingCurrent`, and not a value captured once.
+    ///
+    /// This is the only assertion that can tell those apart, because they agree
+    /// on every host until something assigns `NSTimeZone.default`. Measured on
+    /// this machine: after `NSTimeZone.default = UTC`, an unset `DateFormatter`
+    /// renders UTC while `TimeZone.autoupdatingCurrent` and `TimeZone.current`
+    /// both still report `Europe/Berlin` — so either of those two as the default
+    /// would have been a real behaviour change for exactly the processes that
+    /// assign it, which is what `HistoryViewSnapshotTests` used to be.
+    ///
+    /// It is the one place left in this target that assigns `NSTimeZone.default`;
+    /// it restores it from a teardown block, which XCTest runs on failure too.
+    func testTheDefaultFollowsNSTimeZoneDefaultAndNotAutoupdatingCurrent() {
+        // Pick a zone the host is not already in, so "it followed" and "it was
+        // already that" cannot look the same.
+        let target = NSTimeZone.default == tokyo ? utc : tokyo
+        let original = NSTimeZone.default
+        addTeardownBlock { NSTimeZone.default = original }
+        NSTimeZone.default = target
+
+        XCTAssertEqual(EnvironmentValues().formatTimeZone, target,
+                       "`\\.formatTimeZone`'s default does not follow NSTimeZone.default — "
+                       + "either it is captured rather than computed, or it reads something else")
+        XCTAssertNotEqual(TimeZone.autoupdatingCurrent, target,
+                          "TimeZone.autoupdatingCurrent followed NSTimeZone.default on this host — "
+                          + "the measurement this default rests on no longer holds; re-check the "
+                          + "choice in FormatTimeZoneEnvironment.swift")
+    }
+}


### PR DESCRIPTION
Closes #1659

`HistoryFormat`'s three cached formatters pinned `en_US_POSIX` and never set
`timeZone`, so every date the History panel draws came out of
`NSTimeZone.default` — the machine. **8 of the 14 committed
`HistoryViewSnapshotTests` references contain that output**, and they were right
only because that suite's own `setUp` assigned `NSTimeZone.default = UTC` and
`tearDown` put it back. Seven lines, in one suite, that the next suite to host
these views has to remember to copy.

## Could the `\.formatLocale` seam reach them? No — and the reason shapes the fix

`\.formatLocale` (#1630) works because a `FormatStyle` is constructed *per
render*, inside `body`, so the view can hand it a value read from the
environment. `HistoryFormat`'s formatters were file-scope
`private static let DateFormatter`s: one object per process, reachable from no
view. Setting a second environment key alone would have changed nothing — the
vacuous-green shape #1630 measured for `.environment(\.locale, …)`, arriving
inside its own fix.

So the seam is not "add a key". `HistoryFormat.axisLabel` / `clock` /
`fullDateTime` now take a **required** `TimeZone`, and the four views that call
them read `\.formatTimeZone`. A call site with no zone to pass does not compile
(mutation E below). Formatters are still cached — `DateFormatter` init is
expensive and these fire per axis tick and per grid cell — but keyed by
`(zone, format)` rather than being three process-global `static let`s, which
also makes the "captured at first use" hazard the issue describes
inexpressible.

**One correction to the issue, since it is load-bearing for the test design:**
that capture hazard was not real for the shape that existed. An unset
`DateFormatter` created *before* `NSTimeZone.default` is assigned still renders
the new zone — measured:

```
A. early before override          = 2023-11-14 23:13
-- after NSTimeZone.default = UTC --
A. early AFTER override           = 2023-11-14 22:13  <- tracks default
```

## Which zone, and why the default is not the obvious one

**`UTC`**, because it is what the committed references were recorded under — the
same argument `PinnedLocaleSnapshot.referenceLocale` is `de_DE` and
`referenceScale` is `2`. **No reference PNG was regenerated**; `git status` over
`*.png` is empty and all 53 still match byte-for-byte on the recording host.
`AGENTS.md` names re-recording to make a test pass as the move #1034 and #1044
both got wrong; pinning what is already there means this PR never has to make
that call.

The environment key's default is **`NSTimeZone.default`**, not
`TimeZone.autoupdatingCurrent`. The latter reads like the exact mirror of
`\.formatLocale`'s `Locale.autoupdatingCurrent` and is wrong here — measured on
this `Europe/Berlin` host:

| after `NSTimeZone.default = UTC` | reports |
|---|---|
| unset `DateFormatter` | **UTC** |
| `TimeZone.autoupdatingCurrent` | `Europe/Berlin` |
| `TimeZone.current` | `Europe/Berlin` |
| `Calendar.current.timeZone` | **UTC** |

so `autoupdatingCurrent` would have been a real behaviour change for exactly the
processes that assign it. `defaultValue` is computed rather than stored for the
same reason: read per access, so it tracks an assignment the way the unset
formatter did. A user in Berlin still sees Berlin times, by construction.

## The second machine read, which nobody had named

Pinning only `\.formatTimeZone` and deleting the `setUp` still reddened **6 of
the 14** references — and they all went green again under `TZ=UTC`, so something
else was reading the process.

**Swift Charts resolves `AxisMarks(values: .automatic(…))` through
`\.calendar`**, whose default `Calendar.current` *does* follow
`NSTimeZone.default` (table above). The deleted `setUp` had been holding tick
and gridline **positions** as well as label text — which is why
`testQuotaForecast*` moved even though its chart is `compact` and draws no axis
labels at all. `PinnedSnapshotHost` therefore pins three environments:
`\.formatTimeZone`, `\.calendar` (rebuilt as `.gregorian` + the pinned locale,
so the host's week rules go with it) and `\.timeZone`. Pinning the last two
changed no reference — measured, all 14 still match.

## `HistoryViewSnapshotTests`' `setUp` is deleted, not kept

Deliberately, and it is the strongest evidence in the PR. Keeping it would have
left those 8 references green whether or not the seam reached anything — #1630's
mutation B in advance. With no process-wide assignment left, they are the live
proof that every date this panel draws goes through the pin: a call site that
stopped passing `\.formatTimeZone` renders this `Europe/Berlin` machine's clock
and reddens them.

## Proof the pin takes effect

`PinnedTimeZoneSnapshotTests` (9 tests) drives **two** zones through one view —
the `PinnedScaleSnapshotTests` / `PinnedLocaleSnapshotTests` shape — so whatever
`NSTimeZone.default` is, at most one arm can agree with it. It grades
`PinnedSnapshotHost`, the object the suites snapshot, not a host this file
assembled.

`Text` cannot be read back the way `PinnedLocaleSnapshotTests` reads an
`NSTextField`: a window-less `NSHostingView` over three `Text`s reports
`accessibilityChildren() == nil` at the root (measured — SwiftUI builds the AX
tree lazily for a real AX client, and an `xctest` process has none). So the
proof is split: **rendered strings** asserted directly off `HistoryFormat`, and
at view level a **byte comparison of two rasterisations**, which is the shape
that discriminates — a seam reaching nothing makes both renders the machine's
clock, i.e. *identical*. Both a determinism guard (same zone twice must be
byte-identical) and a premise guard (the two zones must produce different text
for this fixture) run first, so the byte comparison cannot fail for the wrong
reason. A separate arm hosts an environment probe and asserts all three pins,
because a pixel comparison cannot tell "wrong label" from "wrong tick position".

## Mutation evidence — every one seen red, one per run, applied and reverted

**A. Pin `Asia/Tokyo` as `referenceTimeZone`** — the blast-radius measurement:

```
-[HistoryViewSnapshotTests testActivityPopulated] : failed - Snapshot does not match reference.
-[HistoryViewSnapshotTests testActivityWideGridStaysWithinPanelWidth] : failed - …
-[HistoryViewSnapshotTests testHistoryCO2] : failed - …
-[HistoryViewSnapshotTests testHistoryDrilldown] : failed - …
-[HistoryViewSnapshotTests testHistoryPopulated] : failed - …
-[HistoryViewSnapshotTests testHistoryTokens] : failed - …
-[HistoryViewSnapshotTests testQuotaForecastMultiProvider] : failed - …
-[HistoryViewSnapshotTests testQuotaForecastSingleProvider] : failed - …
	 Executed 337 tests, with 16 failures
```

**Exactly the 8 the issue names**, and nothing else in the other 45 committed
references — independent confirmation that its list is exact. The other 8
failures are this suite's own constants arms correctly reporting themselves
vacuous, since the mutation makes `referenceTimeZone == contrastingTimeZone`:

```
-[PinnedTimeZoneSnapshotTests testReferenceAndContrastingTimeZonesRenderDifferently] :
  XCTAssertNotEqual failed: ("Wed 7:13 AM") is equal to ("Wed 7:13 AM") —
  every both-sides assertion here is vacuous
```

**B. Revert the product seam** (delete both `f.timeZone = …` assignments,
keeping every pin) — the load-bearing one, and it reproduces #1630's mutation B
one family later:

```
-[HistoryViewSnapshotTests testActivityPopulated] : failed - Snapshot does not match reference.
-[HistoryViewSnapshotTests testActivityWideGridStaysWithinPanelWidth] : failed - …
-[HistoryViewSnapshotTests testQuotaForecastMultiProvider] : failed - …
-[HistoryViewSnapshotTests testQuotaForecastSingleProvider] : failed - …
-[PinnedTimeZoneSnapshotTests testAxisLabelsRenderInTheZoneTheyAreGiven] : XCTAssertEqual failed: ("23:13") is not equal to ("22:13")
-[PinnedTimeZoneSnapshotTests testAxisLabelsRenderInTheZoneTheyAreGiven] : XCTAssertEqual failed: ("11/14") is not equal to ("11/15")
-[PinnedTimeZoneSnapshotTests testClockRendersInTheZoneItIsGiven] : XCTAssertEqual failed: ("Tue 11:13 PM") is not equal to ("Tue 10:13 PM")
-[PinnedTimeZoneSnapshotTests testTheSameViewRendersDifferentlyUnderTwoPinnedTimeZones] :
  XCTAssertNotEqual failed: ("1128726 bytes") is equal to ("1128726 bytes") - the forecast strip
  rendered identically under UTC and Asia/Tokyo — the pinned zone is reaching nothing, and the
  render is coming from NSTimeZone.default (Europe/Berlin)
	 Executed 337 tests, with 15 failures
```

**Only 4 of the 8 references redden.** The four cost-chart ones stay green
because their labels are `M/d` and a one-hour Berlin offset does not change a
date — a pin that silently does nothing is invisible to half the snapshots, and
only the rendered-string assertions catch it. That is the entire reason this PR
asserts strings rather than trusting that `.environment(…)` "worked".

**C. Drop the `\.calendar` pin, keeping everything else** — the complement, and
the union of B and C is exactly the 8:

```
-[HistoryViewSnapshotTests testHistoryCO2] : failed - …          ┐
-[HistoryViewSnapshotTests testHistoryDrilldown] : failed - …    │ the 6 Swift Charts
-[HistoryViewSnapshotTests testHistoryPopulated] : failed - …    │ references; the 2
-[HistoryViewSnapshotTests testHistoryTokens] : failed - …       │ activity ones draw
-[HistoryViewSnapshotTests testQuotaForecastMultiProvider] : …   │ no chart and stay
-[HistoryViewSnapshotTests testQuotaForecastSingleProvider] : …  ┘ green
-[PinnedTimeZoneSnapshotTests testTheHostPinsEveryTimeZoneCarryingEnvironment] :
  XCTAssertEqual failed: ("Optional(Europe/Berlin)") is not equal to ("Optional(Asia/Tokyo)") -
  `\.calendar` is not pinned by the host — Swift Charts picks its date ticks through this,
  so the reference positions come from the machine
	 Executed 337 tests, with 8 failures
```

**E. A call site that omits the zone** — the compile error the required
parameter buys:

```
HistoryView.swift:1492:56: error: missing argument for parameter 'timeZone' in call
```

(Applied first at the Swift Charts axis inside `HistoryCostChart.body`, where it
compiles to `error: the compiler is unable to type-check this expression in
reasonable time` — still a failed build, but the clean message comes from the
smaller `windowCard` call site, so that is the one quoted.)

## The two latent sites #1659 documented

- **`HistoryView.fullDateTimeFormatter` — covered.** It is now
  `HistoryFormat.fullDateTime(_:timeZone:locale:)`, taking both axes as inputs
  and reached through `\.formatTimeZone` / `\.formatLocale`; the formatter is
  asserted directly (two zones, and two locales at one zone so the locale
  argument cannot be silently dropped). Stated rather than implied: **nothing
  grades the pass-through from `cell(…)` into `tooltipText`**, because neither
  call site produces a readable artifact — `.tooltip` is an `onHover`-only
  modifier drawing into a separate `NSPanel`, and `.accessibilityLabel` is not
  rasterised (the AX measurement above). What remains unproven there is the
  wiring of two arguments of distinct types, which cannot be transposed.
- **`SessionListView.formatResetTime` — deliberately NOT covered, filed as
  #1663.** A timezone pin reaches two of its three machine reads and leaves the
  one that matters most: `Date()` selects a different *format string* either
  side of midnight, so a snapshot pinned on zone and locale alone is still a
  snapshot of the recording day. Half-covering it would make it look safe. Its
  unreachedness is verified rather than assumed — `grep -rln "rate_limit\|rateLimit"
  platforms/macos/Tests/Fixtures/ platforms/macos/Tests/MockInstanceFiles/` returns
  nothing, and the two fixture files that exist carry no rate-limit window;
  `RateLimitInfo` *is* built in `QuotaMenuBarRendererTests`, which grades a
  different renderer and takes no image snapshot. A comment at the site points
  at #1663 before the first fixture bakes it in.

## `UserDefaults` sweep — the next member of this family

**The severe reading is not real, and that was checked first.** A test run
cannot modify the user's actual app preferences: `UserDefaults.standard` in a
SwiftPM test process resolves to `com.apple.dt.xctest.tool`, which holds exactly
the values the two suites' `setUp` assigns (`showCostDisplay = 0`,
`projectCostTimeframe = day`, `displayMode = context`, `summaryDisplayMode =
waiting`), while `io.irrlicht.app` holds this user's own different ones (`1`,
`year`, `Context`, `collapsed`). A full `tools/preflight.sh --only swift` left
`~/Library/Preferences/io.irrlicht.app.plist` identical in mtime and size
(`1786897204 2319` before and after).

Filed, not fixed here:

- **#1662** — the fixture-fragility finding. Two suites pin 8 real keys by hand;
  the domain also carries 9 keys neither suite pins and that persist between
  runs, and per #1523 an aborted run skips `tearDown` entirely.
- **#1661** — a separate, genuine leak found while measuring it:
  `NotificationMasterGateTests` mints a UUID preference suite per test and
  `removePersistentDomain` empties the domain without deleting the file. **1136
  empty 42-byte plists** have accumulated in `~/Library/Preferences` since
  Jul 31; the count went 1136 → 1140 across one gate run in this PR.

## Gates

| Gate | Result |
|---|---|
| `tools/preflight.sh --only swift` | **PASS** (exit 0) — 337 tests, 0 failures |
| pre-push hook (`--changed --budget 540`) | **PASS** (exit 0) — `swift` and `gofmt` PASS, everything else correctly SKIP |
| `git status --porcelain -- '*.png'` | empty — **no reference regenerated** |

Exit codes read directly off the next line, never through a pipe: per #1523 the
suite can abort in a way that truncates the run while every suite that did
report says "0 failures", and per `AGENTS.md` this repo's shell is zsh, where
`${PIPESTATUS[0]}` expands to nothing.

**CI will not grade the change that matters.** `HistoryViewSnapshotTests` is one
of the five suites `macos-swift.yml`'s `swift-test` job skips (#1615), so a
green check on this PR says nothing about the 8 references this PR is about. The
`swift-snapshot-evidence` job does run it — but its assertion is that *at least
one* of those suites produced a failure image, which is satisfied by the
pre-existing #1615 rasterisation drift regardless of anything here. The local
`swift` gate is the only place these references are graded.
`PinnedTimeZoneSnapshotTests` itself is **not** skipped and is host-independent
by construction, so the pin's proof does run in CI even though its subject does
not.

## Not addressed

#1615's rasterisation question, and the `@AppStorage` family (#1662), which is
the next one of these and has its own blast radius.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
