### PR TITLE
fix(macos): stop NotificationMasterGateTests creating preference files at all (#1661)

### DIFF
--- a/platforms/macos/Tests/InMemoryDefaults.swift
+++ b/platforms/macos/Tests/InMemoryDefaults.swift
@@ -8,7 +8,7 @@ import Foundation
 /// `NotificationMasterGateTests` minted a fresh `UserDefaults(suiteName:)` per
 /// test with a UUID name and called `removePersistentDomain(forName:)` in
 /// `tearDown`. That call empties the *domain* and does not remove the *file*;
-/// 1160 42-byte plists had accumulated in a developer's real
+/// 1136 42-byte plists had accumulated in a developer's real
 /// `~/Library/Preferences` before anyone looked.
 ///
 /// # Why the obvious fixes were rejected, with what was measured
@@ -191,8 +191,12 @@ final class InMemoryDefaults: UserDefaults {
 
     override func setPersistentDomain(_ domain: [String: Any], forName domainName: String) {}
 
+    /// `nil`, never the store: this object HAS no persistent domain, and
+    /// answering with the dictionary would say the opposite — that the values a
+    /// test wrote are sitting in one. Reading a real domain here is not the
+    /// alternative, since that is the daemon call the type exists to avoid.
     override func persistentDomain(forName domainName: String) -> [String: Any]? {
-        dictionaryRepresentation()
+        nil
     }
 
     override func addSuite(named suiteName: String) {}

--- a/platforms/macos/Tests/InMemoryDefaults.swift
+++ b/platforms/macos/Tests/InMemoryDefaults.swift
@@ -1,0 +1,272 @@
+import Foundation
+
+/// A `UserDefaults` that never reaches disk, and the read-only witness that
+/// proves it.
+///
+/// # What #1661 is
+///
+/// `NotificationMasterGateTests` minted a fresh `UserDefaults(suiteName:)` per
+/// test with a UUID name and called `removePersistentDomain(forName:)` in
+/// `tearDown`. That call empties the *domain* and does not remove the *file*;
+/// 1160 42-byte plists had accumulated in a developer's real
+/// `~/Library/Preferences` before anyone looked.
+///
+/// # Why the obvious fixes were rejected, with what was measured
+///
+/// **Unlink the file in `tearDown`.** `cfprefsd` owns the file and rewrites it
+/// on its own schedule, including *after the process has exited*, at which
+/// point no code of ours is running. Measured on this machine over four
+/// experiments on identical sequences: 60/60 files came back, then 0/40, then
+/// 0/60, then 120/120. Both orderings produced both outcomes, so no in-process
+/// sequence can be shown to prevent it. And `tearDown` does not run at all for
+/// the runs that most need it — XCTest's stall detector `abort()`s the process
+/// (#1523), `tools/lib/swift-suite.sh` kills the tree at 240s, and
+/// `--budget` kills the gate.
+///
+/// **Sweep the leftovers on the way in.** That is a function whose job is to
+/// delete files from a directory it did not create, in the developer's home.
+/// One mutation of its filename filter removed ~1895 files from a real
+/// `~/Library/Preferences`. There is no version of that idea worth its blast
+/// radius, so nothing here deletes anything, ever.
+///
+/// **Redirect the preferences root.** `CFFIXED_USER_HOME`, `HOME`, and
+/// `CFPREFERENCES_AVOID_DAEMON=1` were each measured with a standalone binary
+/// that wrote one key to a fresh suite. All three redirect `NSHomeDirectory()`
+/// and `FileManager.homeDirectoryForCurrentUser` — and the plist still landed
+/// in the *real* `~/Library/Preferences` every time:
+///
+/// ```
+///   HOME + CFFIXED_USER_HOME        NSHomeDirectory redirected, file in real home
+///   + CFPREFERENCES_AVOID_DAEMON=1  NSHomeDirectory redirected, file in real home
+/// ```
+///
+/// The write is not performed by the process that asks for it. `cfprefsd` runs
+/// as the user, outside the test process's environment, and resolves the home
+/// from the password database — so a client-side environment variable cannot
+/// move it. That is why the redirect is not the mechanism.
+///
+/// # So the mechanism is: never ask `cfprefsd` for anything
+///
+/// The only thing `NotificationSettings.masterEnabled(defaults:)` needs is a
+/// `UserDefaults`-shaped key-value store. `InMemoryDefaults` is one, backed by
+/// a dictionary, with every mutating entry point overridden so that no write
+/// path reaches the superclass. Nothing is created, so nothing has to be
+/// cleaned up, so no cleanup can go wrong — the leak becomes inexpressible
+/// rather than tidied up after.
+///
+/// `PersistentDefaultsLintTests` is the other half: it fails the build on any
+/// `UserDefaults(suiteName:` in the test targets, so the next test inherits
+/// this instead of having to remember it.
+final class InMemoryDefaults: UserDefaults {
+
+    /// Values written through this object. Never touched by the superclass.
+    private var store: [String: Any] = [:]
+
+    /// Values supplied via `register(defaults:)`. Foundation's registration
+    /// domain is in-memory and loses to the application domain, and this
+    /// reproduces both properties so a test that registers reads what it would
+    /// read against a real suite.
+    private var registered: [String: Any] = [:]
+
+    /// XCTest drives one test at a time here, but `SessionManager` and friends
+    /// read defaults from other queues, and a double that flaked under that
+    /// would be debugged as a product bug. `UserDefaults` itself is thread-safe.
+    private let lock = NSLock()
+
+    /// - Note: `super.init(suiteName: nil)` binds the process's *own*
+    ///   application domain, which already exists — it mints no new domain and
+    ///   creates no file (measured: a process doing exactly this, writing many
+    ///   keys through the overrides below and calling `synchronize()`, left the
+    ///   real preferences directory byte-for-byte unchanged; that measurement is
+    ///   re-run on every suite run by
+    ///   `InMemoryDefaultsTests.testTheDoubleAddsNothingToTheRealPreferencesDirectory`).
+    ///   The force-unwrap is deliberate and is the fail-loud: `init(suiteName:)`
+    ///   answers nil only for the main bundle identifier, and if it ever did
+    ///   answer nil here the correct outcome is a trap, not a silent fallback to
+    ///   an object that writes into the developer's home.
+    init() {
+        super.init(suiteName: nil)!
+    }
+
+    // MARK: - Primitive methods
+    //
+    // Apple documents these as the primitives a `UserDefaults` subclass must
+    // override; every derived accessor (`bool(forKey:)`, `string(forKey:)`,
+    // `integer(forKey:)`, KVC reads) funnels through them. That funnelling was
+    // verified rather than assumed — see `InMemoryDefaultsTests`'s faithfulness
+    // arm, which drives each derived accessor and pins the answer.
+
+    override func object(forKey defaultName: String) -> Any? {
+        lock.lock()
+        defer { lock.unlock() }
+        return store[defaultName] ?? registered[defaultName]
+    }
+
+    override func set(_ value: Any?, forKey defaultName: String) {
+        lock.lock()
+        defer { lock.unlock() }
+        if let value {
+            store[defaultName] = value
+        } else {
+            store.removeValue(forKey: defaultName)
+        }
+    }
+
+    override func removeObject(forKey defaultName: String) {
+        lock.lock()
+        defer { lock.unlock() }
+        store.removeValue(forKey: defaultName)
+    }
+
+    override func dictionaryRepresentation() -> [String: Any] {
+        lock.lock()
+        defer { lock.unlock() }
+        return registered.merging(store) { _, written in written }
+    }
+
+    // MARK: - Typed setters
+    //
+    // Foundation funnels `setBool:forKey:` and friends into `setObject:forKey:`,
+    // so overriding the primitive alone happens to be enough today. They are
+    // overridden anyway: the whole guarantee of this type is that no write
+    // reaches the superclass, and resting that guarantee on an undocumented
+    // funnel would make a future Foundation change a silent leak rather than a
+    // test failure. Each boxes the value the way Foundation does, so
+    // `object(forKey:) as? Bool` — what `NotificationSettings` actually reads —
+    // answers identically to a real suite.
+
+    override func set(_ value: Bool, forKey defaultName: String) {
+        set(NSNumber(value: value) as Any, forKey: defaultName)
+    }
+
+    override func set(_ value: Int, forKey defaultName: String) {
+        set(NSNumber(value: value) as Any, forKey: defaultName)
+    }
+
+    override func set(_ value: Double, forKey defaultName: String) {
+        set(NSNumber(value: value) as Any, forKey: defaultName)
+    }
+
+    override func set(_ value: Float, forKey defaultName: String) {
+        set(NSNumber(value: value) as Any, forKey: defaultName)
+    }
+
+    override func set(_ url: URL?, forKey defaultName: String) {
+        set(url as Any?, forKey: defaultName)
+    }
+
+    /// Real `UserDefaults` archives URLs; this stores the value, so the reader
+    /// is overridden to match rather than inheriting a decoder for an encoding
+    /// that was never applied.
+    override func url(forKey defaultName: String) -> URL? {
+        object(forKey: defaultName) as? URL
+    }
+
+    /// KVC writes — `@AppStorage` and `setValue(_:forKey:)` reach defaults this
+    /// way. Routed to the primitive so they cannot slip past it.
+    override func setValue(_ value: Any?, forKey key: String) {
+        set(value, forKey: key)
+    }
+
+    override func value(forKey key: String) -> Any? {
+        object(forKey: key)
+    }
+
+    // MARK: - Registration and domains
+
+    override func register(defaults registrationDictionary: [String: Any]) {
+        lock.lock()
+        defer { lock.unlock() }
+        registered.merge(registrationDictionary) { _, new in new }
+    }
+
+    /// No-ops rather than forwards, and this is the load-bearing one.
+    ///
+    /// `removePersistentDomain(forName:)` is what the pre-fix `tearDown` called,
+    /// and naming a domain to `cfprefsd` is itself one of the operations
+    /// observed to schedule a write-back. Forwarding any of these to the
+    /// superclass would reach the daemon and could create a file — the exact
+    /// outcome this type exists to make impossible.
+    override func removePersistentDomain(forName domainName: String) {}
+
+    override func setPersistentDomain(_ domain: [String: Any], forName domainName: String) {}
+
+    override func persistentDomain(forName domainName: String) -> [String: Any]? {
+        dictionaryRepresentation()
+    }
+
+    override func addSuite(named suiteName: String) {}
+
+    override func removeSuite(named suiteName: String) {}
+
+    /// There is nothing to flush. Answering `true` keeps callers that check the
+    /// result on the success path.
+    override func synchronize() -> Bool { true }
+}
+
+/// A read-only witness over a preferences directory: what files were there
+/// before, what files are there now, and what appeared in between.
+///
+/// It reads and never writes, and it has no delete path at all — the whole
+/// point of #1661's rework is that no code here is allowed to remove a file
+/// from a directory it did not create, and the simplest way to hold that is to
+/// own no `removeItem` call anywhere in this file.
+struct PreferencesDirectoryWitness {
+
+    /// Failing to *look* and finding nothing must not produce the same answer.
+    /// An unreadable directory silently snapshotting as the empty set would make
+    /// every delta zero and every #1661 assertion pass forever — AGENTS.md's
+    /// "a verification mechanism must fail loudly when it cannot run", and here
+    /// it is also the difference between a real guarantee and a comfortable one.
+    enum Failure: Error, CustomStringConvertible {
+        case unreadable(path: String, underlying: Error)
+
+        var description: String {
+            switch self {
+            case let .unreadable(path, underlying):
+                return "could not read \(path): \(underlying) — " +
+                       "the witness cannot report a delta it was unable to measure"
+            }
+        }
+    }
+
+    let directory: URL
+
+    /// The directory `cfprefsd` actually writes to for this user.
+    ///
+    /// Resolved from the password database, not from `NSHomeDirectory()` or
+    /// `$HOME`. That is not defensive noise: `HOME` and `CFFIXED_USER_HOME` both
+    /// move `NSHomeDirectory()` and neither moves the daemon (measured — see the
+    /// note on `InMemoryDefaults`), so a witness reading the environment would
+    /// watch an empty temp directory while the leak landed in the real home, and
+    /// report a clean delta.
+    static var realUserPreferences: PreferencesDirectoryWitness {
+        PreferencesDirectoryWitness(directory: passwordDatabaseHome
+            .appendingPathComponent("Library", isDirectory: true)
+            .appendingPathComponent("Preferences", isDirectory: true))
+    }
+
+    static var passwordDatabaseHome: URL {
+        if let entry = getpwuid(getuid()), let dir = entry.pointee.pw_dir {
+            return URL(fileURLWithPath: String(cString: dir))
+        }
+        // Nothing sensible to fall back to that would not be a lie; the
+        // environment is the one source already known to be wrong here.
+        return URL(fileURLWithPath: NSHomeDirectory())
+    }
+
+    /// Every entry name directly in the directory. Throws rather than answering
+    /// the empty set when it cannot look.
+    func snapshot() throws -> Set<String> {
+        do {
+            return Set(try FileManager.default.contentsOfDirectory(atPath: directory.path))
+        } catch {
+            throw Failure.unreadable(path: directory.path, underlying: error)
+        }
+    }
+
+    /// Names present in `after` and not in `before`, sorted for a stable message.
+    static func added(from before: Set<String>, to after: Set<String>) -> [String] {
+        after.subtracting(before).sorted()
+    }
+}

--- a/platforms/macos/Tests/InMemoryDefaultsTests.swift
+++ b/platforms/macos/Tests/InMemoryDefaultsTests.swift
@@ -116,7 +116,7 @@ final class InMemoryDefaultsTests: XCTestCase {
         defaults.set(true, forKey: key)
 
         XCTAssertNil(UserDefaults.standard.object(forKey: key))
-        XCTAssertNil(defaults.persistentDomain(forName: "com.apple.finder")?["nonexistent"])
+        XCTAssertNil(defaults.persistentDomain(forName: "com.apple.finder"), "the double must not read a real domain, nor claim to be one")
     }
 
     // MARK: - Arm 2: the #1661 guarantee

--- a/platforms/macos/Tests/InMemoryDefaultsTests.swift
+++ b/platforms/macos/Tests/InMemoryDefaultsTests.swift
@@ -1,0 +1,265 @@
+import XCTest
+
+/// Coverage for #1661's mechanism, in three arms.
+///
+/// 1. **Faithfulness** — the double answers what a real suite answers for
+///    everything `NotificationSettings.masterEnabled(defaults:)` reads. A double
+///    that is diskless but wrong would make `NotificationMasterGateTests` assert
+///    nothing.
+/// 2. **The guarantee** — a run of the double adds no file to the real
+///    `~/Library/Preferences`.
+/// 3. **The witness's own mutation evidence** — arm 2 is only worth its ink if
+///    its detector can fire. `PreferencesDirectoryWitness` is driven against
+///    temporary directories this test creates, with the "it must stay silent"
+///    cases beside the "it must report" ones, because a witness that reported
+///    unconditionally would satisfy arm 2 forever.
+final class InMemoryDefaultsTests: XCTestCase {
+
+    // MARK: - Arm 1: faithfulness
+
+    /// The exact read `NotificationSettings.masterEnabled(defaults:)` performs:
+    /// `object(forKey:) as? Bool`, which must distinguish absent from
+    /// explicitly-false. `bool(forKey:)` cannot, which is why production does
+    /// not use it for the master key — so a double that collapsed the two would
+    /// silently retire `testAbsentKeyIsDistinguishableFromExplicitFalse`.
+    func testAbsentExplicitTrueAndExplicitFalseAreThreeDistinctAnswers() {
+        let defaults = InMemoryDefaults()
+
+        XCTAssertNil(defaults.object(forKey: "k"))
+        XCTAssertFalse(defaults.bool(forKey: "k"))
+
+        defaults.set(true, forKey: "k")
+        XCTAssertEqual(defaults.object(forKey: "k") as? Bool, true)
+        XCTAssertTrue(defaults.bool(forKey: "k"))
+
+        defaults.set(false, forKey: "k")
+        XCTAssertNotNil(defaults.object(forKey: "k"))
+        XCTAssertEqual(defaults.object(forKey: "k") as? Bool, false)
+        XCTAssertFalse(defaults.bool(forKey: "k"))
+
+        defaults.removeObject(forKey: "k")
+        XCTAssertNil(defaults.object(forKey: "k"))
+    }
+
+    /// Every derived accessor funnels through the overridden primitive. Pinned
+    /// rather than assumed: the type's guarantee is that no write reaches the
+    /// superclass, and a derived accessor that did not funnel would read a real
+    /// domain while the writes sat in the dictionary.
+    func testDerivedAccessorsReadThroughTheOverriddenPrimitive() {
+        let defaults = InMemoryDefaults()
+
+        defaults.set("s", forKey: "string")
+        defaults.set(7, forKey: "int")
+        defaults.set(1.5, forKey: "double")
+        defaults.set(Float(2.5), forKey: "float")
+        defaults.set([1, 2, 3], forKey: "array")
+        defaults.set(["a": 1], forKey: "dictionary")
+        defaults.set(Data([0x01]), forKey: "data")
+        defaults.set(URL(fileURLWithPath: "/tmp/x"), forKey: "url")  // NOSONAR (swift:S1075) — test fixture value
+
+        XCTAssertEqual(defaults.string(forKey: "string"), "s")
+        XCTAssertEqual(defaults.integer(forKey: "int"), 7)
+        XCTAssertEqual(defaults.double(forKey: "double"), 1.5)
+        XCTAssertEqual(defaults.float(forKey: "float"), 2.5)
+        XCTAssertEqual(defaults.array(forKey: "array") as? [Int], [1, 2, 3])
+        XCTAssertEqual(defaults.dictionary(forKey: "dictionary") as? [String: Int], ["a": 1])
+        XCTAssertEqual(defaults.data(forKey: "data"), Data([0x01]))
+        XCTAssertEqual(defaults.url(forKey: "url"), URL(fileURLWithPath: "/tmp/x"))  // NOSONAR (swift:S1075)
+    }
+
+    /// KVC is how `@AppStorage` writes. Routed to the primitive so it cannot
+    /// slip past the store and land in the process's real application domain.
+    func testKeyValueCodingWritesLandInTheStore() {
+        let defaults = InMemoryDefaults()
+
+        defaults.setValue("via-kvc", forKey: "kvcKey")
+
+        XCTAssertEqual(defaults.object(forKey: "kvcKey") as? String, "via-kvc")
+        XCTAssertEqual(defaults.value(forKey: "kvcKey") as? String, "via-kvc")
+    }
+
+    /// The registration domain loses to a written value and survives a removal
+    /// of one, exactly as Foundation's does.
+    func testRegisteredDefaultsAreVisibleButLoseToWrittenValues() {
+        let defaults = InMemoryDefaults()
+        defaults.register(defaults: ["reg": true])
+
+        XCTAssertTrue(defaults.bool(forKey: "reg"))
+
+        defaults.set(false, forKey: "reg")
+        XCTAssertFalse(defaults.bool(forKey: "reg"))
+
+        defaults.removeObject(forKey: "reg")
+        XCTAssertTrue(defaults.bool(forKey: "reg"), "the registration must survive removing the written value")
+    }
+
+    /// Two doubles are two stores. A shared one would let tests leak state into
+    /// each other, which is the other half of why the pre-fix code minted a
+    /// fresh suite per test in the first place.
+    func testInstancesDoNotShareState() {
+        let a = InMemoryDefaults()
+        let b = InMemoryDefaults()
+
+        a.set(true, forKey: "shared")
+
+        XCTAssertTrue(a.bool(forKey: "shared"))
+        XCTAssertNil(b.object(forKey: "shared"))
+    }
+
+    /// The developer's own preferences are not read through and not written to.
+    /// `super.init(suiteName: nil)` binds the process's real application domain,
+    /// so "the overrides never reach super" has to be asserted, not assumed.
+    func testTheProcessesRealStandardDefaultsAreUntouched() {
+        let key = "io.irrlicht.tests.inMemoryDefaults.\(UUID().uuidString)"
+        let defaults = InMemoryDefaults()
+
+        defaults.set(true, forKey: key)
+
+        XCTAssertNil(UserDefaults.standard.object(forKey: key))
+        XCTAssertNil(defaults.persistentDomain(forName: "com.apple.finder")?["nonexistent"])
+    }
+
+    // MARK: - Arm 2: the #1661 guarantee
+
+    /// The property the whole issue is about: a run of the double leaves the
+    /// real `~/Library/Preferences` with exactly the files it started with.
+    ///
+    /// Driven hard on purpose — many keys, every typed setter, `synchronize()`,
+    /// the domain calls the pre-fix `tearDown` used, and a settle after each —
+    /// because the write-back this replaces was asynchronous and arrived late.
+    /// This cannot catch a write that lands after *this process* exits; nothing
+    /// running inside the process can. What makes that acceptable is that there
+    /// is no daemon-facing call left to schedule one: `InMemoryDefaults` names
+    /// no suite, and `PersistentDefaultsLintTests` fails the build if any test
+    /// does.
+    func testTheDoubleAddsNothingToTheRealPreferencesDirectory() throws {
+        let witness = PreferencesDirectoryWitness.realUserPreferences
+        let before = try witness.snapshot()
+
+        XCTAssertFalse(
+            before.isEmpty,
+            "the witness saw an empty \(witness.directory.path) — a delta measured against " +
+            "nothing is not evidence; check that this is the real preferences directory"
+        )
+
+        for round in 0..<3 {
+            let defaults = InMemoryDefaults()
+            for index in 0..<50 {
+                defaults.set(true, forKey: "io.irrlicht.tests.leakProbe.\(round).\(index)")
+                defaults.set("value", forKey: "io.irrlicht.tests.leakProbeString.\(round).\(index)")
+                defaults.set(index, forKey: "io.irrlicht.tests.leakProbeInt.\(round).\(index)")
+            }
+            defaults.register(defaults: ["io.irrlicht.tests.leakProbeRegistered": true])
+            _ = defaults.synchronize()
+            // The two calls the pre-fix teardown made, which are also the two
+            // observed to schedule a cfprefsd write-back.
+            defaults.removePersistentDomain(forName: "io.irrlicht.tests.leakProbe.\(round)")
+            _ = defaults.synchronize()
+        }
+
+        // Give an asynchronous write-back a chance to land before measuring.
+        Thread.sleep(forTimeInterval: 0.5)
+
+        let added = PreferencesDirectoryWitness.added(from: before, to: try witness.snapshot())
+        XCTAssertEqual(
+            added, [],
+            """
+            The defaults double reached disk. #1661 is back: files appeared in \
+            \(witness.directory.path) during this test, and nothing in this \
+            repository is allowed to delete them again.
+
+            \(added.joined(separator: "\n"))
+            """
+        )
+    }
+
+    // MARK: - Arm 3: the witness's committed mutation evidence
+    //
+    // Arm 2's assertion is only as good as its detector, and the faithful
+    // mutation — making `InMemoryDefaults` persist — writes into the
+    // developer's real `~/Library/Preferences`, which is the incident this
+    // change exists to prevent. So the detector is driven here against
+    // directories this test creates, with both verdicts pinned: a witness that
+    // reported everything and one that reported correctly are
+    // indistinguishable without the cases that must stay silent.
+
+    func testWitnessReportsAFileThatAppeared() throws {
+        let directory = try makeTemporaryDirectory()
+        let witness = PreferencesDirectoryWitness(directory: directory)
+        let before = try witness.snapshot()
+
+        FileManager.default.createFile(atPath: directory.appendingPathComponent("leaked.plist").path, contents: Data())
+
+        XCTAssertEqual(PreferencesDirectoryWitness.added(from: before, to: try witness.snapshot()), ["leaked.plist"])
+    }
+
+    func testWitnessReportsEveryFileThatAppeared() throws {
+        let directory = try makeTemporaryDirectory()
+        let witness = PreferencesDirectoryWitness(directory: directory)
+        let before = try witness.snapshot()
+
+        for name in ["b.plist", "a.plist"] {
+            FileManager.default.createFile(atPath: directory.appendingPathComponent(name).path, contents: Data())
+        }
+
+        XCTAssertEqual(
+            PreferencesDirectoryWitness.added(from: before, to: try witness.snapshot()),
+            ["a.plist", "b.plist"]
+        )
+    }
+
+    /// Must stay silent: nothing changed.
+    func testWitnessIsSilentWhenNothingAppeared() throws {
+        let directory = try makeTemporaryDirectory()
+        FileManager.default.createFile(atPath: directory.appendingPathComponent("pre-existing.plist").path, contents: Data())
+        let witness = PreferencesDirectoryWitness(directory: directory)
+        let before = try witness.snapshot()
+
+        XCTAssertEqual(PreferencesDirectoryWitness.added(from: before, to: try witness.snapshot()), [])
+    }
+
+    /// Must stay silent: a file that *went away* is not a leak, and reporting it
+    /// would turn every unrelated `cfprefsd` tidy-up into a red suite.
+    func testWitnessIsSilentWhenAFileDisappeared() throws {
+        let directory = try makeTemporaryDirectory()
+        let doomed = directory.appendingPathComponent("removed-by-someone-else.plist")
+        FileManager.default.createFile(atPath: doomed.path, contents: Data())
+        let witness = PreferencesDirectoryWitness(directory: directory)
+        let before = try witness.snapshot()
+
+        // Removing a file this test created, in a directory this test created.
+        try FileManager.default.removeItem(at: doomed)
+
+        XCTAssertEqual(PreferencesDirectoryWitness.added(from: before, to: try witness.snapshot()), [])
+    }
+
+    /// The fail-loud. A witness that cannot look must not answer "nothing
+    /// changed": absence of a finding and inability to look would otherwise
+    /// produce the same output, and arm 2 would pass forever on a typo in a
+    /// path.
+    func testWitnessThrowsRatherThanReportingNothingWhenItCannotRead() throws {
+        let missing = try makeTemporaryDirectory().appendingPathComponent("does-not-exist", isDirectory: true)
+        let witness = PreferencesDirectoryWitness(directory: missing)
+
+        XCTAssertThrowsError(try witness.snapshot()) { error in
+            guard case PreferencesDirectoryWitness.Failure.unreadable(let path, _) = error else {
+                XCTFail("expected .unreadable, got \(error)")
+                return
+            }
+            XCTAssertEqual(path, missing.path)
+        }
+    }
+
+    // MARK: - Helpers
+
+    /// A directory this test creates, so that the one `removeItem` above is
+    /// provably scoped to something it made itself. Cleanup is XCTest's, via
+    /// the temporary directory it hands out; nothing here sweeps a shared one.
+    private func makeTemporaryDirectory() throws -> URL {
+        let url = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("io.irrlicht.tests.witness.\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        addTeardownBlock { try? FileManager.default.removeItem(at: url) }
+        return url
+    }
+}

--- a/platforms/macos/Tests/NotificationMasterGateTests.swift
+++ b/platforms/macos/Tests/NotificationMasterGateTests.swift
@@ -15,23 +15,25 @@ import XCTest
 /// pure-helper idiom `SessionManagerFocusTests` uses for the Focus/DND gate.
 final class NotificationMasterGateTests: XCTestCase {
 
-    private var suiteName: String!
-    private var defaults: UserDefaults!
-
-    override func setUp() {
-        super.setUp()
-        // A throwaway suite, never `.standard` — these tests must not mutate the
-        // developer's real notification preferences.
-        suiteName = "io.irrlicht.tests.NotificationMasterGate.\(UUID().uuidString)"
-        defaults = UserDefaults(suiteName: suiteName)
-    }
-
-    override func tearDown() {
-        defaults.removePersistentDomain(forName: suiteName)
-        defaults = nil
-        suiteName = nil
-        super.tearDown()
-    }
+    /// `InMemoryDefaults`, never a named suite and never `.standard`.
+    ///
+    /// This class is #1661: it used to mint a fresh `UserDefaults` suite per
+    /// test with a UUID name and remove the *domain* in `tearDown`, which does
+    /// not remove the *file*. 1160 of them had accumulated in a developer's real
+    /// `~/Library/Preferences`. The double writes to a dictionary, so there is
+    /// nothing to clean up and no cleanup that can go wrong — see
+    /// `InMemoryDefaults` for the three redirects that were measured and
+    /// rejected first, and `PersistentDefaultsLintTests` for the rule that stops
+    /// the next test re-introducing it.
+    ///
+    /// XCTest instantiates the class once per test method, so this initializer
+    /// already gives every case its own store — the isolation the per-test UUID
+    /// suite was reaching for, without the file. There is deliberately no
+    /// `setUp` and no `tearDown`: nothing is allocated outside this process, so
+    /// the fix holds for exactly the runs that never reach a teardown — an
+    /// `abort()` from XCTest's stall detector (#1523), `swift-suite.sh`'s 240s
+    /// tree kill, a `--budget` kill.
+    private let defaults = InMemoryDefaults()
 
     // MARK: - Pure decision
 

--- a/platforms/macos/Tests/NotificationMasterGateTests.swift
+++ b/platforms/macos/Tests/NotificationMasterGateTests.swift
@@ -19,7 +19,7 @@ final class NotificationMasterGateTests: XCTestCase {
     ///
     /// This class is #1661: it used to mint a fresh `UserDefaults` suite per
     /// test with a UUID name and remove the *domain* in `tearDown`, which does
-    /// not remove the *file*. 1160 of them had accumulated in a developer's real
+    /// not remove the *file*. 1136 of them had accumulated in a developer's real
     /// `~/Library/Preferences`. The double writes to a dictionary, so there is
     /// nothing to clean up and no cleanup that can go wrong — see
     /// `InMemoryDefaults` for the three redirects that were measured and

--- a/platforms/macos/Tests/PersistentDefaultsLintTests.swift
+++ b/platforms/macos/Tests/PersistentDefaultsLintTests.swift
@@ -5,7 +5,7 @@ import XCTest
 /// `InMemoryDefaults` makes the safe thing available; it cannot make the unsafe
 /// thing impossible, because `UserDefaults(suiteName:)` is a Foundation
 /// initializer and nothing stops the next test from calling it. That is exactly
-/// how 1160 plists reached a developer's real `~/Library/Preferences`: one
+/// how 1136 plists reached a developer's real `~/Library/Preferences`: one
 /// suite, one test class, no reviewer with a reason to notice.
 ///
 /// So the rule is enforced the way AGENTS.md enforces the same shape twice
@@ -208,7 +208,7 @@ final class PersistentDefaultsLintTests: XCTestCase {
             `InMemoryDefaults` instead: a named suite leaves a file in the \
             developer's real ~/Library/Preferences that \
             `removePersistentDomain(forName:)` does not remove and that nothing \
-            in this repository is allowed to delete (#1661 — 1160 of them).
+            in this repository is allowed to delete (#1661 — 1136 of them).
 
             \(offenders.joined(separator: "\n"))
             """

--- a/platforms/macos/Tests/PersistentDefaultsLintTests.swift
+++ b/platforms/macos/Tests/PersistentDefaultsLintTests.swift
@@ -1,0 +1,217 @@
+import XCTest
+
+/// The structural half of #1661.
+///
+/// `InMemoryDefaults` makes the safe thing available; it cannot make the unsafe
+/// thing impossible, because `UserDefaults(suiteName:)` is a Foundation
+/// initializer and nothing stops the next test from calling it. That is exactly
+/// how 1160 plists reached a developer's real `~/Library/Preferences`: one
+/// suite, one test class, no reviewer with a reason to notice.
+///
+/// So the rule is enforced the way AGENTS.md enforces the same shape twice
+/// elsewhere — an agent-owned SQLite store is opened through `core/pkg/sqlitero`
+/// and never `sql.Open`, and an inbound hook body is read only by
+/// `hookjson.DecodeConfined` — by failing the build on any other call site.
+/// This is what makes the fix cover the *target* rather than one suite: a test
+/// written next year inherits it without anyone remembering #1661.
+///
+/// Scope, stated so it is not mistaken for more: this bans the construct that
+/// mints a *new* persistent domain, and therefore a new file, per call. It does
+/// not ban `UserDefaults.standard`, which several suites here mutate under
+/// snapshot-and-restore — that writes into one already-existing domain rather
+/// than accreting files, and is a different problem with a different fix.
+///
+/// There is deliberately **no exemption list**, for the reason
+/// `core/architecture_hookbody_test.go` gives: a test that genuinely needs a raw
+/// suite amends this rule in a reviewable diff.
+final class PersistentDefaultsLintTests: XCTestCase {
+
+    // MARK: - The rule, as a pure function
+
+    /// Assembled from two pieces so this file's own source never contains a
+    /// contiguous match. Every corpus fixture below is assembled the same way.
+    /// Without that, the scan would flag its own test data — and the fix for
+    /// *that* is an exclusion, which is a hole in the rule rather than a
+    /// property of it.
+    private static let constructor = "UserDefaults" + "("
+
+    private static let pattern = "UserDefaults" + #"\s*\(\s*suiteName\s*:"#
+
+    private static let testTargetDirectories = ["Tests", "TestsHarness"]
+
+    /// 1-based line numbers of every offending construction in `source`.
+    ///
+    /// Line comments are stripped first, padded with spaces so that offsets —
+    /// and therefore reported line numbers — survive the strip. Block comments
+    /// and string literals are **not** stripped, and that is a decision rather
+    /// than an omission: a line-based scan cannot tell a literal from a call,
+    /// and AGENTS.md's rule is that a validator which cannot parse its input
+    /// checks MORE, never less. Both limits are pinned in the corpus.
+    static func offendingLines(in source: String) -> [Int] {
+        let code = commentsBlanked(source)
+        guard let regex = try? NSRegularExpression(pattern: pattern) else { return [] }
+        let text = code as NSString
+        var lines: [Int] = []
+        regex.enumerateMatches(in: code, range: NSRange(location: 0, length: text.length)) { match, _, _ in
+            guard let match else { return }
+            lines.append(text.substring(to: match.range.location).components(separatedBy: "\n").count)
+        }
+        return lines
+    }
+
+    /// Replaces each line comment with spaces of the same UTF-16 width, so the
+    /// regex sees no comment and every match offset still maps to its original
+    /// line.
+    private static func commentsBlanked(_ source: String) -> String {
+        source.split(separator: "\n", omittingEmptySubsequences: false).map { line -> String in
+            guard let comment = line.range(of: "//") else { return String(line) }
+            let code = line[..<comment.lowerBound]
+            return code + String(repeating: " ", count: line.utf16.count - code.utf16.count)
+        }
+        .joined(separator: "\n")
+    }
+
+    // MARK: - Committed mutation evidence for the rule
+
+    /// One row per spelling, pinned to the verdict the scan must return.
+    ///
+    /// The `want: []` rows carry most of the value: a rule that flagged
+    /// everything and a rule that flagged correctly are indistinguishable
+    /// without them, and two of them (`super.init`, the similarly-named helper)
+    /// are the false positives a bare substring rule produces. The two rows that
+    /// are pinned as flagged *despite* being harmless are declared limits of a
+    /// line-based scan, learned here rather than from an incident.
+    private static let corpus: [(name: String, source: String, want: [Int])] = [
+        (
+            "a plain construction is the whole point of the rule",
+            "let defaults = \(constructor)suiteName: \"x\")",
+            [1]
+        ),
+        (
+            "whitespace around the paren and the colon does not evade it",
+            "let defaults = " + "UserDefaults" + " ( suiteName : \"x\")",
+            [1]
+        ),
+        (
+            "a call split across lines is reported at the line it starts on",
+            "let defaults = \(constructor)\n    suiteName: \"x\"\n)",
+            [1]
+        ),
+        (
+            "every occurrence is reported, not only the first",
+            "let a = \(constructor)suiteName: \"x\")\nlet unrelated = 1\nlet b = \(constructor)suiteName: \"y\")",
+            [1, 3]
+        ),
+        (
+            "a line comment naming the construct is documentation, not a call",
+            "// never write \(constructor)suiteName:) in a test",
+            []
+        ),
+        (
+            "a doc comment naming the construct is documentation too",
+            "/// see \(constructor)suiteName:) and why it is banned",
+            []
+        ),
+        (
+            "a trailing comment does not taint the real code on its line",
+            "let d = InMemoryDefaults() // not \(constructor)suiteName: \"x\")",
+            []
+        ),
+        (
+            "super.init(suiteName:) inside the double is not this construct",
+            "super.init(suiteName: nil)!",
+            []
+        ),
+        (
+            "a similarly named helper is not a UserDefaults suite",
+            "let d = makeUserDefaults(suiteNameHint: \"x\")",
+            []
+        ),
+        (
+            "UserDefaults.standard is deliberately out of scope",
+            "UserDefaults.standard.set(true, forKey: \"k\")",
+            []
+        ),
+        (
+            "a suiteless construction mints no domain",
+            "let d = " + "UserDefaults" + "()",
+            []
+        ),
+        (
+            "LIMIT: a string literal holding the construct is flagged, because a line scan cannot tell it from a call",
+            "let needle = \"\(constructor)suiteName:\"",
+            [1]
+        ),
+        (
+            "LIMIT: a block comment holding the construct is flagged, for the same reason",
+            "/* \(constructor)suiteName: \"x\") */",
+            [1]
+        )
+    ]
+
+    func testScanReturnsThePinnedVerdictForEverySpelling() {
+        for row in Self.corpus {
+            XCTAssertEqual(
+                Self.offendingLines(in: row.source), row.want,
+                "\(row.name)\n---\n\(row.source)\n---"
+            )
+        }
+    }
+
+    /// The corpus is also the vacuity guard for the live scan below: after this
+    /// change the construct appears nowhere in the test targets, so "no
+    /// offenders" and "the rule stopped matching anything" are otherwise the
+    /// same output.
+    func testTheCorpusContainsBothVerdicts() {
+        XCTAssertFalse(Self.corpus.filter { $0.want.isEmpty }.isEmpty, "no must-not-flag rows")
+        XCTAssertFalse(Self.corpus.filter { !$0.want.isEmpty }.isEmpty, "no must-flag rows")
+    }
+
+    // MARK: - The live scan
+
+    func testNoTestConstructsAPersistentUserDefaultsSuite() throws {
+        var offenders: [String] = []
+        var filesScanned = 0
+
+        let macosRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()        // Tests/
+            .deletingLastPathComponent()        // platforms/macos/
+
+        for directory in Self.testTargetDirectories {
+            let root = macosRoot.appendingPathComponent(directory)
+            var isDirectory: ObjCBool = false
+            guard FileManager.default.fileExists(atPath: root.path, isDirectory: &isDirectory),
+                  isDirectory.boolValue else {
+                // A renamed or removed test target must be loud, not silent: a
+                // walk over a directory that is not there finds nothing and is
+                // indistinguishable from a clean tree.
+                XCTFail("test target directory \(directory) is missing at \(root.path)")
+                continue
+            }
+            guard let walk = FileManager.default.enumerator(at: root, includingPropertiesForKeys: nil) else {
+                XCTFail("could not enumerate \(root.path)")
+                continue
+            }
+            for case let url as URL in walk where url.pathExtension == "swift" {
+                filesScanned += 1
+                let source = try String(contentsOf: url, encoding: .utf8)
+                let relative = url.path.replacingOccurrences(of: macosRoot.path + "/", with: "")
+                offenders.append(contentsOf: Self.offendingLines(in: source).map { "\(relative):\($0)" })
+            }
+        }
+
+        XCTAssertGreaterThan(filesScanned, 0, "the scan read no Swift files — it checked nothing")
+        XCTAssertEqual(
+            offenders, [],
+            """
+            A test constructs a persistent preference suite. Use \
+            `InMemoryDefaults` instead: a named suite leaves a file in the \
+            developer's real ~/Library/Preferences that \
+            `removePersistentDomain(forName:)` does not remove and that nothing \
+            in this repository is allowed to delete (#1661 — 1160 of them).
+
+            \(offenders.joined(separator: "\n"))
+            """
+        )
+    }
+}


### PR DESCRIPTION
Closes #1661

## What changed

`NotificationMasterGateTests` no longer creates a preference suite. It takes an
`InMemoryDefaults` — a `UserDefaults` backed by a dictionary — so **nothing is
created, nothing has to be cleaned up, and no cleanup can go wrong.**

Three files, one rewired suite:

| file | role |
| --- | --- |
| `Tests/InMemoryDefaults.swift` | the diskless `UserDefaults`, plus `PreferencesDirectoryWitness` (read-only, no delete path) |
| `Tests/InMemoryDefaultsTests.swift` | faithfulness, the no-file guarantee, and the witness's own corpus |
| `Tests/PersistentDefaultsLintTests.swift` | fails the build on any `UserDefaults(suiteName:` under `Tests/` or `TestsHarness/` |
| `Tests/NotificationMasterGateTests.swift` | rewired; no `setUp`, no `tearDown` |

## Why the sweep approach was replaced

An earlier attempt at this issue concluded that cleanup had to happen "on the
way IN", and implemented `reclaimStale()`: a function that enumerated
`~/Library/Preferences` and unlinked every file matching a name prefix. One
mutation of that filename filter removed ~1,895 files from a real
`~/Library/Preferences`. The issue text invites the same shape ("cleanup of the
existing 1136 is a one-liner") and **this PR deliberately does not do it, and
adds no code that could**.

The rule the design now holds: *no code path here deletes anything from a
directory it did not itself create.* The only `removeItem` calls in the diff
are a test removing a UUID-named temp directory it made two lines earlier.

## What was measured before choosing the mechanism

Each rejected option, with what was run.

**Unlink the file in `tearDown`.** `cfprefsd` owns the file and rewrites it on
its own schedule, including after the process has exited. Measured over four
experiments on identical sequences: 60/60 files came back, 0/40, 0/60, 120/120.
Both orderings produced both outcomes, so no in-process sequence can be shown
to prevent it. `tearDown` also does not run for the runs that most need it —
XCTest's stall `abort()` (#1523), `swift-suite.sh`'s 240s tree kill, a
`--budget` kill.

**Redirect the preferences root — `CFFIXED_USER_HOME` — which is what this
rework set out to do. It does not work.** Measured with a standalone binary
that writes one key to a fresh suite:

| environment | `NSHomeDirectory()` | where the plist landed |
| --- | --- | --- |
| `HOME` + `CFFIXED_USER_HOME` → temp dir | temp dir | **real `~/Library/Preferences`** |
| the above + `CFPREFERENCES_AVOID_DAEMON=1` | temp dir | **real `~/Library/Preferences`** |

Both runs were verified by file-count delta on the real directory (179→180,
180→181) and by the leaked file's own name. The redirect moves
`NSHomeDirectory()` and `FileManager.homeDirectoryForCurrentUser` and moves
nothing else, because the process asking for the write is not the process
performing it: `cfprefsd` runs as the user, outside the test process's
environment, and resolves the home from the password database. There is no
client-side lever.

That measurement is also why `PreferencesDirectoryWitness.realUserPreferences`
resolves its directory from `getpwuid`, not from `NSHomeDirectory()` — a
witness reading the environment would watch an empty temp directory while the
leak landed in the real home and report a clean delta.

## How it covers the target rather than one suite

`InMemoryDefaults` makes the safe thing available; `PersistentDefaultsLintTests`
makes the unsafe thing fail the build, the way `sqlitero` and
`hookjson.DecodeConfined` are enforced. There is no exemption list: a test that
genuinely needs a raw suite amends the rule in a reviewable diff.

Scope, stated so it is not read as more: the rule bans the construct that mints
a *new* persistent domain per call. It does not ban `UserDefaults.standard`,
which several suites mutate under snapshot-and-restore — that is #1662, and its
measurement (the xctest process's `.standard` resolves to
`com.apple.dt.xctest.tool`, not `io.irrlicht.app`) is why it is a different
problem with a different fix.

## Fail-loud, in three places

Per "a verification mechanism must fail loudly when it cannot run":

- `PreferencesDirectoryWitness.snapshot()` **throws** rather than answering the
  empty set when it cannot read — otherwise every delta is zero forever.
- the no-file guarantee asserts its `before` snapshot is **non-empty** before
  trusting a zero delta.
- the lint asserts it read **> 0** Swift files and that both target directories
  exist.
- `InMemoryDefaults.init` force-unwraps `super.init(suiteName: nil)`: a trap,
  never a silent fallback to an object that writes into the developer's home.

## Mutation evidence

Everything here is new, so nothing has a "before the fix" to run against. Four
mutations were applied and reverted one at a time; each is safe by construction
(no mutation writes outside the worktree or a temp directory).

| # | mutation | result |
| --- | --- | --- |
| M1 | `InMemoryDefaults.set` writes a file into the directory the guard watches (with the watched directory redirected to a temp dir this experiment created) | RED — `testTheDoubleAddsNothingToTheRealPreferencesDirectory`: *"The defaults double reached disk. #1661 is back"*, naming `leaked-by-mutation.plist`. The vacuity guard did not fire, because the temp directory was pre-populated. |
| M2 | `PreferencesDirectoryWitness.snapshot()` returns `[]` instead of throwing | RED — `testWitnessThrowsRatherThanReportingNothingWhenItCannotRead`: *"did not throw an error"* |
| M3 | a `UserDefaults(suiteName:` planted in `SoundChoiceTests.swift` | RED — the live scan, naming `Tests/SoundChoiceTests.swift:61` |
| M4 | the lint regex made whitespace-intolerant | RED on exactly 2 of the 13 corpus rows (`whitespace around the paren…`, `a call split across lines…`), **silent on the other 11** — the discrimination, not just a failure |

**One mutation was NOT run, deliberately.** The most faithful one — making
`InMemoryDefaults` back itself with a real named suite, so the guard fires
against the *real* `~/Library/Preferences` — writes a file into the user's home,
which is the incident this PR exists to prevent, and (measured above) no
redirect makes it safe. It is described instead. What it would have proven is
covered from two sides that were run: the detector fires on a file appearing
(M1 and the committed witness corpus), and a real named suite writes into the
passwd home (the `CFFIXED_USER_HOME` probes above, which produced exactly that
file twice).

Committed rather than described, per AGENTS.md: the witness's corpus (a file
appeared / several appeared / nothing changed / a file *disappeared* is not a
leak / it cannot look) and the lint's 13-row corpus, whose `want: []` rows carry
the value — `super.init(suiteName:)`, `makeUserDefaults(suiteNameHint:)`,
`UserDefaults.standard`, a suiteless construction, three comment shapes. Two
rows are pinned as flagged *despite being harmless* — a string literal and a
block comment — as declared limits of a line-based scan, per "a validator that
cannot parse its input checks MORE, never less."

## Counts

Real `~/Library/Preferences`, measured around a full `tools/preflight.sh --only swift`:

```
entries BEFORE = 121      files BEFORE (recursive) = 181
entries AFTER  = 121      files AFTER  (recursive) = 181
diff: IDENTICAL
```

against the issue's own pre-fix measurement of **+4 files per suite run**.

Honest accounting of what this work itself added there: **2 files**, both from
the `CFFIXED_USER_HOME` experiment that established the redirect does not work
(`io.irrlicht.probe.bothset.*.plist`, `io.irrlicht.probe.avoiddaemon.*.plist`).
They were left in place rather than deleted, because deleting from the user's
home is the thing this change exists to stop. One further file appeared during
the pre-push window — `com.apple.TrustedPeersHelper.plist`, written by Apple's
own keychain machinery, unrelated to this suite.

## The two sibling suites

This change adds **no redirect**, so it covers neither of them: they are
untouched and unverified here.

- `SessionManagerApiGroupsTests` → `~/Library/Application Support/Irrlicht/instances`
- `SoundPlayerTests` → `~/Library/Sounds`

One factual note for whoever picks them up, stated as an observation and not a
dismissal: after this gate run `~/Library/Sounds` still held only its two
long-standing files (May 14, Feb 4), and the `instances` directory's mtime
cannot be attributed to the suite, because the live daemon writes session JSON
into it continuously.

## Gates

```
tools/preflight.sh --only swift    PASS (exit 0)
```

Read as the exit code, not the totals line (#1523). The run was also checked
against `swift-suite.sh`'s own three shape rules: the bundle reported its own
result (`Test Suite 'IrrlichtPackageTests.xctest' passed`), it executed 352
tests, 0 failures.

`--only tools` was not run: nothing under `tools/` is touched. The pre-push hook
ran `--changed` and selected exactly one gate, `macOS Swift build + test`, PASS.


Re-run after the second commit (`persistentDomain` answers nil; the leak count
is the issue's own 1136): `--only swift` PASS, exit 0, 352 tests, 0 failures,
`~/Library/Preferences` entry list byte-identical again.

**CodeScene is red and is not being chased**, per AGENTS.md's rule that it is
advisory. Looked at rather than dismissed: `InMemoryDefaults.swift` is flagged
for *Primitive Obsession* / *String Heavy Function Arguments*, which is the
shape of `UserDefaults` itself — an override whose signature is not
`(_ value: Bool, forKey: String)` does not override anything, so there is no
version of this type that avoids it. `InMemoryDefaultsTests.swift` is flagged
for *Code Duplication* across the four witness cases; they are deliberately
four named cases rather than a table, because each names the verdict it pins
and two of them exist to stay **silent**. Resulting code health on both files
is 9.39.
