### PR TITLE
fix(macos): stop the Swift suite writing into the developer's real home (#1669, #1670)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1443,6 +1443,41 @@ Before marking a ticket done, run the full suite — every layer must pass:
   user's real app preferences: `UserDefaults.standard` under `swift test`
   resolves to `com.apple.dt.xctest.tool`, measured against a byte-identical
   `io.irrlicht.app.plist` across a full run).
+  **A sibling family reads the machine for its WRITES rather than its
+  formatting**, and is closed the same way: `AppHome`
+  (`Irrlicht/Managers/AppHome.swift`) is now the one place the app resolves the
+  user's home, and under XCTest it answers a per-process directory beneath
+  `NSTemporaryDirectory()`. Five call sites resolved it directly and three of
+  them wrote — a fixture into the live daemon's
+  `~/Library/Application Support/Irrlicht/instances/`, the developer's own
+  `session-order.json` **overwritten** with test data (`{"order":["b","a"]}`,
+  measured), and `~/Library/Sounds/IrrlichtCustom-<event>.<ext>` behind a
+  `defer` (#1669, #1670; #1661 was the same class in `~/Library/Preferences`).
+  Four things there are worth carrying. **`HOME` is inert** — measured,
+  `HOME=<tmp>` alone leaves `NSHomeDirectory()` at the real home and only
+  `CFFIXED_USER_HOME` moves it — so a redirect built on `HOME` looks like a fix
+  and changes nothing; the redirect is therefore in-process and keyed on
+  `NSClassFromString("XCTestCase")`, the signal #832 already uses to keep tests
+  off the live daemon socket, so it holds under a bare `swift test` and under
+  Xcode rather than only under a script that sets an env var. **Nothing sweeps**:
+  a function deleting files from a directory it did not create is what removed
+  ~1895 files from a real `~/Library/Preferences` during #1661, and no code in
+  this family has a removal path. **The standing guard is split by what each
+  half can see** — `tools/lib/swift-suite.sh`'s witness brackets the `swift
+  test` invocation and fails on any new entry in `~/Library/Preferences` or
+  `~/Library/Sounds`, which is the only check that still runs when the suite
+  ABORTS (#1523) and a `defer` does not, while
+  `Tests/RealHomeIsolationTests.swift` locks the resolved PATHS, because the
+  worst of #1669 is an overwrite that adds no directory entry and the level that
+  would see the rest is written continuously by the live daemon. And the
+  witness's noise is a function of its WINDOW, stated honestly because the
+  flattering version is what erodes a guard: 0 additions across each of two
+  suite-length windows, 4 unrelated background plists across one 870s window of
+  interactive use. It is not filtered by name — #1661's leaked files were
+  `<uuid>.plist`, so any name filter that quietened the churn would have
+  quietened the incident. `Tests/RealHomePathLintTests.swift` is the structural
+  half, over the app AND test targets, with an existence-checked exemption list
+  (two entries) because the safe construct is built out of the banned one.
   The suite also aborts intermittently (#1523) in a way that **truncates the
   run** while every suite that did report says "0 failures" — so the exit code
   is the only reliable signal, never the last totals line you can see. That is

--- a/platforms/macos/Irrlicht/Managers/AppHome.swift
+++ b/platforms/macos/Irrlicht/Managers/AppHome.swift
@@ -1,0 +1,109 @@
+import Foundation
+
+/// The one place this app resolves the user's home directory.
+///
+/// # What #1669 and #1670 are
+///
+/// Five call sites resolved the real home directly and wrote under it. Three of
+/// them are reached from the test suite, so `swift test` on a developer machine
+/// wrote into the *live* directories the running daemon and app own:
+///
+/// ```
+///   ~/Library/Application Support/Irrlicht/instances/<uuid>.json   fixture, `defer`-cleaned
+///   ~/Library/Application Support/Irrlicht/session-order.json      OVERWRITTEN, no cleanup at all
+///   ~/Library/Sounds/IrrlichtCustom-<event>.<ext>                  installed, `defer`-cleaned
+///   ~/Library/Sounds/                                              created if absent
+/// ```
+///
+/// The `defer`s hold on the ordinary path and are skipped on exactly the runs
+/// that fail: XCTest's stall detector answers a hung expectation by `abort()`ing
+/// the process (#1523), `tools/lib/swift-suite.sh` kills the tree at 240s, and
+/// `--budget` kills the gate. `session-order.json` had no cleanup in any case —
+/// a suite run replaced the developer's real session ordering with test data
+/// (`{"order":["b","a"],"version":1}`, measured).
+///
+/// # Why this shape
+///
+/// **Not a `HOME` redirect.** Measured on this machine with a standalone binary:
+///
+/// ```
+///   HOME=<tmp>                          NSHomeDirectory = /Users/ingo   (unchanged)
+///   HOME=<tmp> CFFIXED_USER_HOME=<tmp>  NSHomeDirectory = <tmp>         (redirected)
+/// ```
+///
+/// `HOME` alone moves nothing in Foundation, so a fix built on it would look
+/// like a fix and change nothing. `CFFIXED_USER_HOME` does work — the whole
+/// suite passes under it, 352 tests, and the redirected tree is where the four
+/// paths above land — but it only applies when the suite is launched through a
+/// script that sets it. A developer typing `swift test`, or running the suite
+/// from Xcode, is exactly who got hit, and would still be.
+///
+/// **Not a cleanup sweep.** A function whose job is to delete files from a
+/// directory it did not create, in the developer's home, is what removed ~1895
+/// files from a real `~/Library/Preferences` while #1661 was being fixed.
+/// Nothing here deletes anything, ever. The test home is created under
+/// `NSTemporaryDirectory()`, which the OS reclaims; no code of ours removes it.
+///
+/// So the redirect happens **inside the process**, keyed on the same signal
+/// `SessionManager.isRunningUnitTests` already uses to keep unit tests off the
+/// developer's live daemon socket (#832 — "so unit tests never race against
+/// whatever daemon happens to be reachable on the machine"). That decision was
+/// already made for the network; this is the same decision for the filesystem,
+/// and it holds however the suite is launched.
+///
+/// `RealHomeIsolationTests` is the behavioural half — it fails if any of the
+/// resolved paths lands inside the password-database home — and
+/// `RealHomePathLintTests` is the structural half: it fails the build on a
+/// home-resolving construct anywhere in the app or test targets except the two
+/// files that are allowed one. Together they are what makes a *future* call
+/// site inherit this rather than have to remember it.
+enum AppHome {
+
+    /// True when this process is a test bundle.
+    ///
+    /// The same expression `SessionManager.isRunningUnitTests` uses, and
+    /// deliberately not a copy of that property: it is `@MainActor`-isolated on
+    /// an `ObservableObject`, and this type is consulted from `nonisolated`
+    /// static context (`SoundChoice.previewURL`, `notificationSound(for:)`).
+    ///
+    /// It answers for `swift test` and for Xcode alike. `XCTestConfigurationFilePath`
+    /// would not: only Xcode's runner sets it, and this project's actual test
+    /// command is `swift test`.
+    static var isRunningTests: Bool { NSClassFromString("XCTestCase") != nil }
+
+    /// The home directory this process may write into: the user's real home in
+    /// the app, a per-process temporary directory under test.
+    static var url: URL { isRunningTests ? testHome : realHome }
+
+    /// `<home>/Library`. Equivalent to
+    /// `FileManager.url(for: .libraryDirectory, in: .userDomainMask)` for a
+    /// non-sandboxed app — that API resolves the same `<home>/Library` — with
+    /// the difference that this one is redirected under test and that one is
+    /// not.
+    static var library: URL { url.appendingPathComponent("Library", isDirectory: true) }
+
+    private static var realHome: URL { FileManager.default.homeDirectoryForCurrentUser }
+
+    /// Created once per process, named after the pid so two concurrent test
+    /// processes cannot share one.
+    ///
+    /// `fatalError` rather than a fallback, and that is the load-bearing line:
+    /// the only fallback available is the real home, which is the outcome this
+    /// type exists to make impossible. A trap is a legible red; a silent
+    /// fallback is #1669 and #1670 coming back with a mechanism that claims to
+    /// have fixed them.
+    private static let testHome: URL = {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("irrlicht-test-home-\(ProcessInfo.processInfo.processIdentifier)",
+                                    isDirectory: true)
+        do {
+            try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        } catch {
+            fatalError("""
+                AppHome could not create the test home at \(dir.path): \(error).
+                Refusing to fall back to the real home — that is #1669/#1670.
+                """)
+        }
+        return dir
+    }()
+}

--- a/platforms/macos/Irrlicht/Managers/SessionManager+Debug.swift
+++ b/platforms/macos/Irrlicht/Managers/SessionManager+Debug.swift
@@ -13,7 +13,7 @@ extension SessionManager {
     func writeDebugState() {
         guard isDebugMode else { return }
 
-        let debugDir = FileManager.default.homeDirectoryForCurrentUser
+        let debugDir = AppHome.url
             .appendingPathComponent(".irrlicht")
         let debugFile = debugDir.appendingPathComponent("debug-state.json")
 

--- a/platforms/macos/Irrlicht/Managers/SessionManager+Notifications.swift
+++ b/platforms/macos/Irrlicht/Managers/SessionManager+Notifications.swift
@@ -191,11 +191,10 @@ extension SessionManager {
         case .none, .speak:
             return nil
         case .custom(let installedFilename, _):
-            let library = FileManager.default.urls(for: .libraryDirectory, in: .userDomainMask).first
-            let path = library?
+            let path = AppHome.library
                 .appendingPathComponent("Sounds")
                 .appendingPathComponent(installedFilename).path
-            if let path, FileManager.default.fileExists(atPath: path) {
+            if FileManager.default.fileExists(atPath: path) {
                 return UNNotificationSound(named: UNNotificationSoundName(installedFilename))
             }
             return UNNotificationSound(named: UNNotificationSoundName("Ping.aiff"))

--- a/platforms/macos/Irrlicht/Managers/SessionManager.swift
+++ b/platforms/macos/Irrlicht/Managers/SessionManager.swift
@@ -273,8 +273,11 @@ class SessionManager: ObservableObject {
     init(focusMonitor: FocusStateProviding = FocusMonitor()) {
         self.focusMonitor = focusMonitor
 
-        let homeURL = FileManager.default.homeDirectoryForCurrentUser
-        let supportPath = homeURL
+        // `AppHome`, not the real home: both paths below are WRITTEN — a
+        // fixture into `instances/`, and `session-order.json` overwritten with
+        // whatever a test left in `sessionOrder` — and under `swift test` those
+        // are the live daemon's own files (#1669).
+        let supportPath = AppHome.url
             .appendingPathComponent("Library")
             .appendingPathComponent("Application Support")
             .appendingPathComponent("Irrlicht")

--- a/platforms/macos/Irrlicht/Managers/SoundPlayer.swift
+++ b/platforms/macos/Irrlicht/Managers/SoundPlayer.swift
@@ -219,14 +219,13 @@ enum SoundPlayer {
     }
 
     /// Resolves `~/Library/Sounds/`, creating it if necessary.
+    ///
+    /// Through `AppHome` rather than `FileManager.url(for: .libraryDirectory,
+    /// in: .userDomainMask, …)`, which resolves the same `<home>/Library` and
+    /// is not redirected under test — this method both writes into that
+    /// directory and creates it when absent, which is #1670.
     static func soundsDirectory() throws -> URL {
-        let library = try FileManager.default.url(
-            for: .libraryDirectory,
-            in: .userDomainMask,
-            appropriateFor: nil,
-            create: false
-        )
-        let sounds = library.appendingPathComponent("Sounds", isDirectory: true)
+        let sounds = AppHome.library.appendingPathComponent("Sounds", isDirectory: true)
         if !FileManager.default.fileExists(atPath: sounds.path) {
             try FileManager.default.createDirectory(at: sounds, withIntermediateDirectories: true)
         }

--- a/platforms/macos/Irrlicht/Models/SoundChoice.swift
+++ b/platforms/macos/Irrlicht/Models/SoundChoice.swift
@@ -86,8 +86,7 @@ enum SoundChoice: Hashable {
             guard let name = systemSoundFilename else { return nil }
             return URL(fileURLWithPath: "/System/Library/Sounds/\(name)")
         case .custom(let installedFilename, _):
-            let library = FileManager.default.urls(for: .libraryDirectory, in: .userDomainMask).first
-            return library?.appendingPathComponent("Sounds").appendingPathComponent(installedFilename)
+            return AppHome.library.appendingPathComponent("Sounds").appendingPathComponent(installedFilename)
         case .none, .speak:
             return nil
         }

--- a/platforms/macos/Tests/RealHomeIsolationTests.swift
+++ b/platforms/macos/Tests/RealHomeIsolationTests.swift
@@ -1,0 +1,138 @@
+import XCTest
+@testable import Irrlicht
+
+/// The behavioural half of #1669 / #1670: no path this app writes to resolves
+/// inside the developer's real home while the suite is running.
+///
+/// # Why this is a path lock rather than a filesystem delta
+///
+/// `tools/lib/swift-suite.sh`'s witness watches `~/Library/Preferences` and
+/// `~/Library/Sounds` for entries that appear across a run, and that shape
+/// catches #1670 exactly. It cannot catch #1669, for two reasons that are worth
+/// stating rather than leaving to be rediscovered:
+///
+/// * the worst of #1669 is an **overwrite** — `session-order.json` already
+///   exists, so replacing its contents with test data adds no entry to any
+///   directory and a name-delta witness reports clean.
+/// * the level that WOULD see the other half is
+///   `~/Library/Application Support/Irrlicht/instances/`, which the live daemon
+///   writes to continuously (measured: two files modified inside 60s with
+///   nothing of ours running), so watching it is a false-positive machine.
+///
+/// So that instance is locked here instead, on the resolved path, where there
+/// is no noise at all.
+///
+/// # Order is load-bearing
+///
+/// The `AppHome` assertions come first and `return` on failure, before anything
+/// that could *create* a directory. `SoundPlayer.soundsDirectory()` creates
+/// `<home>/Library/Sounds` when it is absent, so a version of this test that
+/// called it first would, on a machine where the redirect is broken AND that
+/// directory does not exist, produce the very write it exists to forbid. A test
+/// for a leak must not be able to leak while failing.
+@MainActor
+final class RealHomeIsolationTests: XCTestCase {
+
+    /// The home `cfprefsd` and the user's shell both mean — read from the
+    /// password database, never from `HOME` or `NSHomeDirectory()`, both of
+    /// which this process is entitled to have moved. Shared with #1661's
+    /// witness rather than spelled a second way.
+    private var realHome: URL { PreferencesDirectoryWitness.passwordDatabaseHome }
+
+    // MARK: - The witness's own premises
+
+    /// Without this, every assertion below is vacuous in the direction that
+    /// matters: if `realHome` degenerated to something no path can be inside,
+    /// "outside the real home" would be true of the real home itself.
+    func testTheRealHomeIsAPlausibleDirectory() {
+        var isDirectory: ObjCBool = false
+        XCTAssertTrue(
+            FileManager.default.fileExists(atPath: realHome.path, isDirectory: &isDirectory),
+            "the password-database home \(realHome.path) does not exist — this test cannot tell "
+            + "'outside the real home' from 'the real home could not be found'"
+        )
+        XCTAssertTrue(isDirectory.boolValue, "\(realHome.path) is not a directory")
+        XCTAssertGreaterThan(
+            realHome.pathComponents.count, 1,
+            "the password-database home resolved to \(realHome.path) — a root-like answer makes "
+            + "containment trivially true and every assertion here meaningless"
+        )
+        // Deliberately NOT cross-checked against Foundation's own home. That
+        // would read as a stronger premise and is in fact a fragile one: a
+        // developer running the suite under `CFFIXED_USER_HOME` (which does
+        // move Foundation's answer, measured) would fail it for a reason
+        // unrelated to this lock, and `getpwuid` is the authority here anyway —
+        // it is what `cfprefsd` and the shell's `~user` both mean.
+    }
+
+    func testAppHomeReportsThisProcessAsATestBundle() {
+        // If this is ever false in a test run, the redirect is off and every
+        // path below is the real one — so it is asserted rather than assumed.
+        XCTAssertTrue(AppHome.isRunningTests,
+                      "AppHome does not recognise this process as a test bundle")
+    }
+
+    // MARK: - The lock
+
+    func testNothingThisAppWritesToResolvesInsideTheRealHome() throws {
+        // Cheapest and side-effect-free first — see the note on ordering above.
+        try assertOutsideRealHome(AppHome.url, "AppHome.url")
+        try assertOutsideRealHome(AppHome.library, "AppHome.library")
+
+        let manager = SessionManager()
+        try assertOutsideRealHome(manager.instancesPath, "SessionManager.instancesPath")
+        try assertOutsideRealHome(manager.orderFilePath, "SessionManager.orderFilePath")
+
+        // Creates the directory it returns, which is why it is last.
+        try assertOutsideRealHome(try SoundPlayer.soundsDirectory(), "SoundPlayer.soundsDirectory()")
+
+        let preview = SoundChoice.custom(installedFilename: "IrrlichtCustom-ready.aiff",
+                                         displayPath: "/dev/null").previewURL
+        try assertOutsideRealHome(try XCTUnwrap(preview), "SoundChoice.previewURL")
+    }
+
+    /// The test home is a real, writable directory — otherwise "outside the
+    /// real home" would also be satisfied by a path that resolves nowhere, and
+    /// the suite's own writes would fail for a reason unrelated to the lock.
+    func testTheTestHomeExistsAndIsWritable() throws {
+        var isDirectory: ObjCBool = false
+        XCTAssertTrue(FileManager.default.fileExists(atPath: AppHome.url.path, isDirectory: &isDirectory),
+                      "AppHome.url \(AppHome.url.path) does not exist")
+        XCTAssertTrue(isDirectory.boolValue, "AppHome.url is not a directory")
+        XCTAssertTrue(FileManager.default.isWritableFile(atPath: AppHome.url.path),
+                      "AppHome.url is not writable — the suite's writes would fail here, not be redirected")
+    }
+
+    // MARK: - Containment
+
+    /// Component-wise, not `hasPrefix`: `/Users/ingo2` starts with the string
+    /// `/Users/ingo` and is a different home.
+    private static func contains(_ parent: URL, _ child: URL) -> Bool {
+        let p = parent.standardizedFileURL.resolvingSymlinksInPath().pathComponents
+        let c = child.standardizedFileURL.resolvingSymlinksInPath().pathComponents
+        guard c.count >= p.count else { return false }
+        return Array(c.prefix(p.count)) == p
+    }
+
+    /// `throws` rather than `XCTAssert`, so a failure stops the caller before
+    /// the next resolution — which for `soundsDirectory()` is also a creation.
+    private func assertOutsideRealHome(_ url: URL, _ label: String,
+                                       file: StaticString = #filePath, line: UInt = #line) throws {
+        guard !Self.contains(realHome, url) else {
+            let message = """
+                \(label) resolved to \(url.path), inside the real home \(realHome.path).
+                Under `swift test` this app must not write there: #1669 overwrote the developer's \
+                own session-order.json with test data and dropped fixtures into the live daemon's \
+                instances/, and #1670 installed audio into ~/Library/Sounds behind a `defer` that \
+                aborts skip. Resolve through `AppHome`.
+                """
+            XCTFail(message, file: file, line: line)
+            throw NotIsolated(message: message)
+        }
+    }
+
+    private struct NotIsolated: LocalizedError {
+        let message: String
+        var errorDescription: String? { message }
+    }
+}

--- a/platforms/macos/Tests/RealHomePathLintTests.swift
+++ b/platforms/macos/Tests/RealHomePathLintTests.swift
@@ -241,38 +241,58 @@ final class RealHomePathLintTests: XCTestCase {
         }
     }
 
-    func testNoSourceOutsideAppHomeResolvesTheRealHome() throws {
+    /// What one directory's walk found. Kept as a value so the test body is a
+    /// fold over three of them rather than three levels of nesting.
+    private struct Walk {
         var offenders: [String] = []
         var filesScanned = 0
-        var exemptionsHit = Set<String>()
+        var exemptionsHit: Set<String> = []
 
-        for directory in Self.scannedDirectories {
-            let root = Self.macosRoot.appendingPathComponent(directory)
-            var isDirectory: ObjCBool = false
-            guard FileManager.default.fileExists(atPath: root.path, isDirectory: &isDirectory),
-                  isDirectory.boolValue else {
-                // Loud, not silent: a walk over a directory that is not there
-                // finds nothing and is indistinguishable from a clean tree.
-                XCTFail("scanned directory \(directory) is missing at \(root.path)")
-                continue
-            }
-            guard let walk = FileManager.default.enumerator(at: root, includingPropertiesForKeys: nil) else {
-                XCTFail("could not enumerate \(root.path)")
-                continue
-            }
-            for case let url as URL in walk where url.pathExtension == "swift" {
-                let relative = url.path.replacingOccurrences(of: Self.macosRoot.path + "/", with: "")
-                filesScanned += 1
-                let occurrences = Self.offendingOccurrences(in: try String(contentsOf: url, encoding: .utf8))
-                if Self.exemptions[relative] != nil {
-                    if !occurrences.isEmpty { exemptionsHit.insert(relative) }
-                    continue
-                }
-                offenders.append(contentsOf: occurrences.map { "\(relative):\($0)" })
-            }
+        static func + (lhs: Walk, rhs: Walk) -> Walk {
+            Walk(offenders: lhs.offenders + rhs.offenders,
+                 filesScanned: lhs.filesScanned + rhs.filesScanned,
+                 exemptionsHit: lhs.exemptionsHit.union(rhs.exemptionsHit))
         }
+    }
 
-        XCTAssertGreaterThan(filesScanned, 0, "the scan read no Swift files — it checked nothing")
+    /// Walks one directory, or fails loudly. A walk over a directory that is
+    /// not there finds nothing and is indistinguishable from a clean tree, so
+    /// both unreachable cases `XCTFail` rather than returning an empty result.
+    private func walk(_ directory: String) throws -> Walk {
+        let root = Self.macosRoot.appendingPathComponent(directory)
+        var isDirectory: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: root.path, isDirectory: &isDirectory),
+              isDirectory.boolValue else {
+            XCTFail("scanned directory \(directory) is missing at \(root.path)")
+            return Walk()
+        }
+        guard let enumerator = FileManager.default.enumerator(at: root, includingPropertiesForKeys: nil) else {
+            XCTFail("could not enumerate \(root.path)")
+            return Walk()
+        }
+        var found = Walk()
+        for case let url as URL in enumerator where url.pathExtension == "swift" {
+            let relative = url.path.replacingOccurrences(of: Self.macosRoot.path + "/", with: "")
+            found.filesScanned += 1
+            let occurrences = Self.offendingOccurrences(in: try String(contentsOf: url, encoding: .utf8))
+            guard Self.exemptions[relative] == nil else {
+                if !occurrences.isEmpty { found.exemptionsHit.insert(relative) }
+                continue
+            }
+            found.offenders.append(contentsOf: occurrences.map { "\(relative):\($0)" })
+        }
+        return found
+    }
+
+    func testNoSourceOutsideAppHomeResolvesTheRealHome() throws {
+        var scan = Walk()
+        for directory in Self.scannedDirectories {
+            scan = scan + (try walk(directory))
+        }
+        let offenders = scan.offenders
+        let exemptionsHit = scan.exemptionsHit
+
+        XCTAssertGreaterThan(scan.filesScanned, 0, "the scan read no Swift files — it checked nothing")
         // An exemption that no longer covers anything is a rule that has quietly
         // grown wider than it needs to be, and — more to the point here — it is
         // the shape a scan takes when it has stopped reading the files it thinks

--- a/platforms/macos/Tests/RealHomePathLintTests.swift
+++ b/platforms/macos/Tests/RealHomePathLintTests.swift
@@ -1,0 +1,304 @@
+import XCTest
+
+/// The structural half of #1669 / #1670.
+///
+/// `AppHome` makes the safe resolution available and `RealHomeIsolationTests`
+/// proves the paths land outside the developer's home — but neither stops the
+/// next call site from asking Foundation for the real home directly. That is
+/// exactly how both instances arose: five call sites, written at five different
+/// times, each reasonably resolving `~` the obvious way, three of them reached
+/// from the test suite.
+///
+/// So the rule is enforced the way this repo enforces the same shape three times
+/// elsewhere — an agent-owned SQLite store is opened through `core/pkg/sqlitero`
+/// and never `sql.Open`; an inbound hook body is read only by
+/// `hookjson.DecodeConfined`; a test never constructs `UserDefaults(suiteName:)`
+/// (#1661) — by failing the build on any other call site.
+///
+/// # Scope, and why it is wider than the two suites that were filed
+///
+/// Both the **app** target and the **test** targets are scanned. The app target
+/// is where the resolution actually happens: every one of the four writes in
+/// #1669/#1670 was performed by product code that a test merely called. Scanning
+/// only `Tests/` would leave the class fully re-enterable from the side it
+/// entered from. Measured before writing this: after the rewrite, the whole tree
+/// contains exactly two occurrences outside the exemptions below, both of which
+/// are the exemptions — so the noise floor is zero, not "low".
+///
+/// # Exemptions
+///
+/// Unlike `PersistentDefaultsLintTests`, this rule HAS an exemption list, for a
+/// reason that does not apply there: the safe construct is itself built out of
+/// the banned one, so there must be at least one file allowed to spell it. Each
+/// entry carries a reason and is existence-checked, so an entry that stops
+/// naming a real file is a failure rather than a silent widening.
+final class RealHomePathLintTests: XCTestCase {
+
+    // MARK: - The rule, as a pure function
+
+    /// Assembled from pieces so this file's own source never contains a
+    /// contiguous match — the corpus fixtures below are built the same way.
+    /// Without that the scan would flag its own test data, and the fix for
+    /// *that* is an exclusion, which is a hole in the rule rather than a
+    /// property of it.
+    private enum Needle {
+        static let home = "homeDirectoryFor" + "CurrentUser"
+        static let nsHome = "NSHome" + "Directory"
+        static let userDomain = "userDomain" + "Mask"
+        static let tilde = "expandingTilde" + "InPath"
+    }
+
+    /// Each banned construct with the pattern that finds it.
+    ///
+    /// `NSHomeDirectory` requires a following `(` and the others do not, and the
+    /// asymmetry is deliberate: the first is a function whose NAME appears in
+    /// prose all over this repo, while `userDomainMask` and
+    /// `expandingTildeInPath` only ever appear as code. The corpus pins both
+    /// behaviours.
+    private static let constructs: [(name: String, pattern: String)] = [
+        (Needle.home, Needle.home),
+        (Needle.nsHome, Needle.nsHome + #"\s*\("#),
+        (Needle.userDomain, Needle.userDomain),
+        (Needle.tilde, Needle.tilde),
+    ]
+
+    private static let scannedDirectories = ["Irrlicht", "Tests", "TestsHarness"]
+
+    /// Files allowed one occurrence of a banned construct, with the reason.
+    ///
+    /// Paths are relative to `platforms/macos/` and are existence-checked by
+    /// `testEveryExemptionNamesAFileThatExists`.
+    private static let exemptions: [String: String] = [
+        "Irrlicht/Managers/AppHome.swift":
+            "the one place the user's home is resolved; every other call site goes through it",
+        "Tests/InMemoryDefaults.swift":
+            "#1661's witness resolves the home from the password database and needs a last-resort "
+            + "fallback when getpwuid answers nothing",
+    ]
+
+    /// `"<line>:<construct>"` for every offending occurrence in `source`,
+    /// sorted so the verdict is stable.
+    ///
+    /// Line comments are stripped first, padded with spaces so reported line
+    /// numbers survive the strip — several of the files scanned here discuss
+    /// these constructs at length in prose, and a rule that could not tell
+    /// documentation from a call would be unusable in this repo. Block comments
+    /// and string literals are deliberately NOT stripped: a line-based scan
+    /// cannot tell a literal from a call, and AGENTS.md's rule is that a
+    /// validator which cannot parse its input checks MORE, never less. Both
+    /// limits are pinned in the corpus.
+    static func offendingOccurrences(in source: String) -> [String] {
+        let code = commentsBlanked(source)
+        let text = code as NSString
+        var found: [String] = []
+        for construct in constructs {
+            guard let regex = try? NSRegularExpression(pattern: construct.pattern) else { continue }
+            regex.enumerateMatches(in: code, range: NSRange(location: 0, length: text.length)) { match, _, _ in
+                guard let match else { return }
+                let line = text.substring(to: match.range.location).components(separatedBy: "\n").count
+                found.append("\(line):\(construct.name)")
+            }
+        }
+        return found.sorted()
+    }
+
+    /// Replaces each line comment with spaces of the same UTF-16 width, so the
+    /// regex sees no comment and every match offset still maps to its line.
+    private static func commentsBlanked(_ source: String) -> String {
+        source.split(separator: "\n", omittingEmptySubsequences: false).map { line -> String in
+            guard let comment = line.range(of: "//") else { return String(line) }
+            let code = line[..<comment.lowerBound]
+            return code + String(repeating: " ", count: line.utf16.count - code.utf16.count)
+        }
+        .joined(separator: "\n")
+    }
+
+    // MARK: - Committed mutation evidence for the rule
+
+    /// One row per spelling, pinned to the verdict the scan must return.
+    ///
+    /// The `want: []` rows carry most of the value: a rule that flagged
+    /// everything and a rule that flagged correctly are indistinguishable
+    /// without them. `NSTemporaryDirectory()` and `AppHome.url` are the two the
+    /// fix itself introduces, so a rule that flagged them would make its own
+    /// remedy unusable.
+    private static let corpus: [(name: String, source: String, want: [String])] = [
+        (
+            "the construct #1669 was written with",
+            "let home = FileManager.default.\(Needle.home)",
+            ["1:\(Needle.home)"]
+        ),
+        (
+            "the C-style spelling of the same thing",
+            "let home = URL(fileURLWithPath: \(Needle.nsHome)())",
+            ["1:\(Needle.nsHome)"]
+        ),
+        (
+            "the search-path spelling #1670 was written with",
+            "FileManager.default.urls(for: .libraryDirectory, in: .\(Needle.userDomain)).first",
+            ["1:\(Needle.userDomain)"]
+        ),
+        (
+            "the string spelling",
+            "let p = (\"~/Library/Sounds\" as NSString).\(Needle.tilde)",
+            ["1:\(Needle.tilde)"]
+        ),
+        (
+            "one line can carry two different constructs",
+            "FileManager.default.url(for: .libraryDirectory, in: .\(Needle.userDomain), "
+                + "appropriateFor: URL(fileURLWithPath: \(Needle.nsHome)()), create: false)",
+            ["1:\(Needle.nsHome)", "1:\(Needle.userDomain)"]
+        ),
+        (
+            "every occurrence is reported, not only the first",
+            "let a = FileManager.default.\(Needle.home)\nlet unrelated = 1"
+                + "\nlet b = FileManager.default.\(Needle.home)",
+            ["1:\(Needle.home)", "3:\(Needle.home)"]
+        ),
+        (
+            "a line comment naming a construct is documentation, not a call",
+            "// never resolve \(Needle.home) outside AppHome",
+            []
+        ),
+        (
+            "a doc comment naming a construct is documentation too",
+            "/// `\(Needle.nsHome)()` and `\(Needle.home)` are both banned here",
+            []
+        ),
+        (
+            "a trailing comment does not taint the real code on its line",
+            "let home = AppHome.url // not FileManager.default.\(Needle.home)",
+            []
+        ),
+        (
+            "AppHome is the remedy and must never be flagged",
+            "let sounds = AppHome.library.appendingPathComponent(\"Sounds\")",
+            []
+        ),
+        (
+            "the temporary directory is not the home directory",
+            "let tmp = NSTemporary" + "Directory()",
+            []
+        ),
+        (
+            "FileManager.temporaryDirectory is not the home directory either",
+            "let tmp = FileManager.default.temporaryDirectory",
+            []
+        ),
+        (
+            "a bare mention of the function name without a call is not a call",
+            "let name = \"\(Needle.nsHome)\" + \"-marker\"",
+            []
+        ),
+        (
+            "the system-wide domain is a different domain",
+            "FileManager.default.urls(for: .libraryDirectory, in: .systemDomainMask).first",
+            []
+        ),
+        (
+            "LIMIT: a string literal holding a construct is flagged, because a line scan cannot tell it from a call",
+            "let needle = \"FileManager.default.\(Needle.home)\"",
+            ["1:\(Needle.home)"]
+        ),
+        (
+            "LIMIT: a block comment holding a construct is flagged, for the same reason",
+            "/* \(Needle.userDomain) */",
+            ["1:\(Needle.userDomain)"]
+        ),
+    ]
+
+    func testScanReturnsThePinnedVerdictForEverySpelling() {
+        for row in Self.corpus {
+            XCTAssertEqual(
+                Self.offendingOccurrences(in: row.source), row.want,
+                "\(row.name)\n---\n\(row.source)\n---"
+            )
+        }
+    }
+
+    /// The corpus is also the vacuity guard for the live scan: after this change
+    /// the tree contains no offenders, so "no offenders" and "the rule stopped
+    /// matching anything" are otherwise the same output.
+    func testTheCorpusContainsBothVerdictsForEveryConstruct() {
+        XCTAssertFalse(Self.corpus.filter { $0.want.isEmpty }.isEmpty, "no must-not-flag rows")
+        for construct in Self.constructs {
+            XCTAssertTrue(
+                Self.corpus.contains { row in row.want.contains { $0.hasSuffix(":\(construct.name)") } },
+                "no corpus row pins \(construct.name) as flagged — that construct is untested"
+            )
+        }
+    }
+
+    // MARK: - The live scan
+
+    func testEveryExemptionNamesAFileThatExists() {
+        for (relative, reason) in Self.exemptions {
+            XCTAssertTrue(
+                FileManager.default.fileExists(atPath: Self.macosRoot.appendingPathComponent(relative).path),
+                "exemption '\(relative)' (\(reason)) no longer names a file — a stale exemption "
+                + "silently widens the rule"
+            )
+        }
+    }
+
+    func testNoSourceOutsideAppHomeResolvesTheRealHome() throws {
+        var offenders: [String] = []
+        var filesScanned = 0
+        var exemptionsHit = Set<String>()
+
+        for directory in Self.scannedDirectories {
+            let root = Self.macosRoot.appendingPathComponent(directory)
+            var isDirectory: ObjCBool = false
+            guard FileManager.default.fileExists(atPath: root.path, isDirectory: &isDirectory),
+                  isDirectory.boolValue else {
+                // Loud, not silent: a walk over a directory that is not there
+                // finds nothing and is indistinguishable from a clean tree.
+                XCTFail("scanned directory \(directory) is missing at \(root.path)")
+                continue
+            }
+            guard let walk = FileManager.default.enumerator(at: root, includingPropertiesForKeys: nil) else {
+                XCTFail("could not enumerate \(root.path)")
+                continue
+            }
+            for case let url as URL in walk where url.pathExtension == "swift" {
+                let relative = url.path.replacingOccurrences(of: Self.macosRoot.path + "/", with: "")
+                filesScanned += 1
+                let occurrences = Self.offendingOccurrences(in: try String(contentsOf: url, encoding: .utf8))
+                if Self.exemptions[relative] != nil {
+                    if !occurrences.isEmpty { exemptionsHit.insert(relative) }
+                    continue
+                }
+                offenders.append(contentsOf: occurrences.map { "\(relative):\($0)" })
+            }
+        }
+
+        XCTAssertGreaterThan(filesScanned, 0, "the scan read no Swift files — it checked nothing")
+        // An exemption that no longer covers anything is a rule that has quietly
+        // grown wider than it needs to be, and — more to the point here — it is
+        // the shape a scan takes when it has stopped reading the files it thinks
+        // it is reading.
+        XCTAssertEqual(
+            exemptionsHit, Set(Self.exemptions.keys),
+            "an exemption covered nothing this run: either the file no longer needs it, or the "
+            + "scan did not actually read it"
+        )
+        XCTAssertEqual(
+            offenders, [],
+            """
+            Source outside `AppHome` resolves the user's real home directory. Use `AppHome.url` \
+            or `AppHome.library`, which redirect to a per-process temporary home under XCTest.
+
+            Resolving the real home here is what put a fixture into the live daemon's \
+            instances/ directory, replaced the developer's own session-order.json with test data \
+            and installed audio into ~/Library/Sounds behind a `defer` that aborts skip \
+            (#1669, #1670).
+
+            \(offenders.joined(separator: "\n"))
+            """
+        )
+    }
+
+    private static let macosRoot = URL(fileURLWithPath: #filePath)
+        .deletingLastPathComponent()        // Tests/
+        .deletingLastPathComponent()        // platforms/macos/
+}

--- a/platforms/macos/Tests/SessionManagerApiGroupsTests.swift
+++ b/platforms/macos/Tests/SessionManagerApiGroupsTests.swift
@@ -288,7 +288,7 @@ final class SessionManagerApiGroupsTests: XCTestCase {
             updatedAt: Date(timeIntervalSince1970: 0),
             role: "test-role", children: [child]
         )
-        let dir = instancesURL()
+        let dir = sut.instancesPath
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
         let fixturePath = dir.appendingPathComponent("\(id).json")
         try Data("{\"state\":\"working\",\"updated_at\":0}".utf8).write(to: fixturePath)
@@ -310,10 +310,12 @@ final class SessionManagerApiGroupsTests: XCTestCase {
                        "withState must preserve children across reset")
     }
 
-    private func instancesURL() -> URL {
-        FileManager.default.homeDirectoryForCurrentUser
-            .appendingPathComponent("Library/Application Support/Irrlicht/instances")
-    }
+    // The instances directory is deliberately NOT re-derived here. It used to
+    // be, from `homeDirectoryForCurrentUser`, and that is #1669: the fixture
+    // landed in the live daemon's own directory, and the test could disagree
+    // with the code under test about where that directory is. `sut.instancesPath`
+    // is the one the subject reads, which under test is `AppHome`'s per-process
+    // temporary home.
 
     // MARK: - SessionState.withChildren
 

--- a/tools/lib/shell-lib-errexit_test.sh
+++ b/tools/lib/shell-lib-errexit_test.sh
@@ -426,6 +426,33 @@ row 'swift-suite.sh::swift_suite_run' 'swift_suite_run (ordinary path)' 3 \
     '. tools/lib/swift-suite.sh; SWIFT_SUITE_TIMEOUT=5' \
     'swift_suite_run "$TW_TMP/swift-suite-run.log" bash -c "exit 3" >/dev/null 2>&1'
 
+# The real-home witness (#1669, #1670). Every recipe below drives a FIXTURE
+# home under $TW_TMP through SWIFT_SUITE_WITNESS_HOME — never the real one,
+# since planting a file in the developer's home to grade a guard against
+# planting files in the developer's home is the incident, not a test of it.
+#
+# All five are driven at 0, and that is a limitation stated rather than papered
+# over: each documents 1 for its failure paths, and a documented 1 is
+# indistinguishable from an errexit abort, which is this file's own rule about
+# distinctive statuses. Those paths are graded — eight of them, with their
+# messages — by swift-suite_test.sh, which is not under `-e`; what is asserted
+# here is the errexit/option property on the path a caller takes.
+row 'swift-suite.sh::swift_suite_witness_home' 'swift_suite_witness_home' 0 \
+    '. tools/lib/swift-suite.sh' \
+    'swift_suite_witness_home >/dev/null'
+row 'swift-suite.sh::_swift_suite_witness_slug' '_swift_suite_witness_slug' 0 \
+    '. tools/lib/swift-suite.sh' \
+    '_swift_suite_witness_slug Library/Preferences >/dev/null'
+row 'swift-suite.sh::_swift_suite_witness_snapshot' '_swift_suite_witness_snapshot' 0 \
+    '. tools/lib/swift-suite.sh; mkdir -p "$TW_TMP/wh-snap/Library/Preferences" "$TW_TMP/ws-snap"; : >"$TW_TMP/wh-snap/Library/Preferences/a.plist"; SWIFT_SUITE_WITNESS_HOME="$TW_TMP/wh-snap"' \
+    '_swift_suite_witness_snapshot "$TW_TMP/ws-snap" before'
+row 'swift-suite.sh::swift_suite_witness_before' 'swift_suite_witness_before' 0 \
+    '. tools/lib/swift-suite.sh; mkdir -p "$TW_TMP/wh-before/Library/Preferences" "$TW_TMP/ws-before"; : >"$TW_TMP/wh-before/Library/Preferences/a.plist"; SWIFT_SUITE_WITNESS_HOME="$TW_TMP/wh-before"' \
+    'swift_suite_witness_before "$TW_TMP/ws-before"'
+row 'swift-suite.sh::swift_suite_witness_verdict' 'swift_suite_witness_verdict (nothing changed)' 0 \
+    '. tools/lib/swift-suite.sh; mkdir -p "$TW_TMP/wh-verdict/Library/Preferences" "$TW_TMP/ws-verdict"; : >"$TW_TMP/wh-verdict/Library/Preferences/a.plist"; SWIFT_SUITE_WITNESS_HOME="$TW_TMP/wh-verdict"; swift_suite_witness_before "$TW_TMP/ws-verdict"' \
+    'swift_suite_witness_verdict "$TW_TMP/ws-verdict" >/dev/null'
+
 # ---------------------------------------------------------------------------
 # The exemption map
 #

--- a/tools/lib/swift-suite.sh
+++ b/tools/lib/swift-suite.sh
@@ -84,6 +84,237 @@ SWIFT_SUITE_TIMEOUT="${SWIFT_SUITE_TIMEOUT:-240}"
 # fooled an abort-check run against this very issue's output.
 SWIFT_SUITE_GREP_OPTS="-a"
 
+# ---------------------------------------------------------------------------
+# The real-home witness (#1669, #1670; the class #1661 opened)
+# ---------------------------------------------------------------------------
+#
+# A test run must not leave anything behind in the developer's home. Three
+# instances of the same defect have now shipped: 1136 preference plists
+# (#1661), a fixture plus an OVERWRITTEN session-order.json in the live
+# daemon's directory (#1669), and installed audio in ~/Library/Sounds (#1670).
+#
+# Each was fixed at its source. This is the standing check that the class has
+# not been re-entered — and it lives in the shell rather than in the suite for
+# one reason: it is the only place that still runs when the suite does NOT
+# finish. XCTest's stall detector `abort()`s the process (#1523),
+# swift_suite_run kills the tree at SWIFT_SUITE_TIMEOUT, and
+# `preflight.sh --budget` kills the gate. Those are exactly the runs where a
+# `defer`-based cleanup is skipped, i.e. the runs on which #1670 actually
+# leaks — so an in-process assertion is absent precisely when it is needed.
+#
+# It reads. It never deletes, moves, or writes anything under the home. That is
+# not a stylistic preference: a sweep of "files the tests probably left" is what
+# removed ~1895 files from a real ~/Library/Preferences while #1661 was being
+# fixed. Nothing here has a removal path at all.
+#
+# WHAT IS WATCHED, and why it is not more:
+#
+#   Library/Preferences  #1661's directory. 126-130 entries, 3ms to list.
+#   Library/Sounds       #1670's directory. 2 long-standing entries.
+#
+# NEITHER IS NOISE-FREE, and the honest version of the measurement matters more
+# than the flattering one. Measured on the author's machine:
+#
+#   0 additions   across each of two ~2 minute windows bracketing a full
+#                 352-test suite run (one of them also a cold `swift build`)
+#   4 additions   across one 870s window of ordinary interactive use —
+#                 com.apple.bluetooth, com.apple.DuetExpertCenter.MagicalMoments,
+#                 com.apple.voicetrigger, com.googlecode.iterm2. All background
+#                 daemons, none ours, all in Library/Preferences.
+#                 Library/Sounds took 0 over the same window.
+#
+# So the noise is a function of the WINDOW, which is the one variable here that
+# is under our control — hence tools/preflight.sh brackets the `swift test`
+# invocation only, not the build before it. At the measured background rate
+# (~1 new plist per 218s of active use) a ~5s healthy run carries a ~2% chance
+# of naming a stray plist.
+#
+# That residual is accepted rather than filtered, and the reason is #1661
+# itself: its 1136 leaked files were named `<uuid>.plist`, so no name-based
+# filter could have distinguished them from background churn without also
+# hiding them. A guard that answers "something appeared, here is its name" is
+# one a reader can judge in two seconds; a guard with an allowlist is one that
+# would have missed the incident it exists for.
+#
+# `Library/Application Support/Irrlicht` is deliberately NOT watched, and the
+# reason is not noise — it measured 0 additions over the same window. It is
+# that a new-entry witness CANNOT see #1669: the worst of that defect is an
+# overwrite of a file that already exists, which adds no entry, and the level
+# that would see the rest (`instances/`) is written continuously by the live
+# daemon (measured: two files modified inside 60s with nothing of ours
+# running). Watching it would report clean while the defect happened, which is
+# worse than not watching it. That instance is locked on the resolved path
+# instead, by `platforms/macos/Tests/RealHomeIsolationTests.swift`.
+#
+# The whole ~/Library was considered and rejected in #1668 with the
+# measurement: 6s over 887,491 files, and 24 of 41 changed entries were
+# unrelated third-party churn (Google, WhatsApp, Claude, VS Code).
+SWIFT_SUITE_WITNESSED_DIRS=("Library/Preferences" "Library/Sounds")
+
+# swift_suite_witness_home — the home to watch.
+#
+# From the PASSWORD DATABASE, not `$HOME`. bash's `~user` expansion consults
+# getpwnam, so it answers the real home even when `HOME` has been moved — and
+# `HOME` being moved is not hypothetical here, since redirecting it is one of
+# the things a future fix in this area might do. A witness that followed `HOME`
+# would then watch an empty temp directory, find nothing, and report clean
+# forever.
+#
+# SWIFT_SUITE_WITNESS_HOME overrides it, and exists for ONE caller:
+# tools/lib/swift-suite_test.sh, which has to plant a file under a watched
+# directory to prove the witness can fail. Planting one in the real home to
+# test a guard against planting files in the real home is not a joke this
+# repository can afford.
+swift_suite_witness_home() {
+  if [[ -n "${SWIFT_SUITE_WITNESS_HOME:-}" ]]; then
+    printf '%s\n' "$SWIFT_SUITE_WITNESS_HOME"
+    return 0
+  fi
+  local user home
+  user=$(id -un 2>/dev/null) || return 1
+  [[ -n "$user" ]] || return 1
+  eval "home=~$user" 2>/dev/null || return 1
+  [[ -n "$home" && "$home" != "~$user" ]] || return 1
+  printf '%s\n' "$home"
+}
+
+# _swift_suite_witness_slug <relative-dir> — a filename-safe key.
+_swift_suite_witness_slug() {
+  printf '%s\n' "${1//\//_}"
+}
+
+# _swift_suite_witness_snapshot <statedir> <phase> — list every watched
+# directory into <statedir>/<slug>.<phase>.
+#
+# The first line of each file is a STATE marker, and the three states are kept
+# apart on purpose. "the directory is not there" and "the directory is there and
+# empty" are different facts — a run that CREATES ~/Library/Sounds is #1670's
+# other half — and "the directory is there and could not be read" must never
+# read as either. A missing home is a failure of the snapshot itself.
+_swift_suite_witness_snapshot() {
+  local statedir="$1" phase="$2" home dir slug target
+  home=$(swift_suite_witness_home) || {
+    printf 'UNREADABLE\n' > "$statedir/HOME.$phase"
+    return 1
+  }
+  printf '%s\n' "$home" > "$statedir/HOME.$phase"
+  local entries
+  for dir in "${SWIFT_SUITE_WITNESSED_DIRS[@]}"; do
+    slug=$(_swift_suite_witness_slug "$dir")
+    target="$home/$dir"
+    if [[ ! -e "$target" ]]; then
+      printf 'ABSENT\n' > "$statedir/$slug.$phase"
+      continue
+    fi
+    # Captured rather than redirected straight to the file: `ls` failing after
+    # it has already written a partial listing would otherwise leave a file
+    # that looks like a successful snapshot.
+    if entries=$(ls -A "$target" 2>/dev/null); then
+      printf 'PRESENT\n%s' "${entries:+$entries$'\n'}" > "$statedir/$slug.$phase"
+    else
+      printf 'UNREADABLE\n' > "$statedir/$slug.$phase"
+    fi
+  done
+  return 0
+}
+
+# swift_suite_witness_before <statedir> — snapshot ahead of the run.
+#
+# Always returns 0. A snapshot that could not be taken is recorded rather than
+# raised, so the caller runs the suite either way and the diagnosis lands in
+# swift_suite_witness_verdict — one place that decides, instead of two that can
+# disagree about what an unreadable directory means.
+swift_suite_witness_before() {
+  local statedir="${1:-}"
+  [[ -n "$statedir" && -d "$statedir" ]] || { echo "swift_suite_witness_before: needs an existing <statedir>" >&2; return 1; }
+  _swift_suite_witness_snapshot "$statedir" before || :
+  return 0
+}
+
+# swift_suite_witness_verdict <statedir> — 0 only if the run demonstrably added
+# nothing to any watched directory. Non-zero if it added something, if
+# something vanished, or if the witness could not look.
+swift_suite_witness_verdict() {
+  local statedir="${1:-}" ok=0 looked=0 dir slug before after added removed bstate astate
+  [[ -n "$statedir" && -d "$statedir" ]] || { echo "swift_suite_witness_verdict: needs an existing <statedir>" >&2; return 1; }
+
+  if [[ ! -f "$statedir/HOME.before" ]]; then
+    echo "real-home witness: no 'before' snapshot exists — the run was NOT witnessed." >&2
+    echo "  A clean report here would mean 'nothing was measured', not 'nothing was written'." >&2
+    return 1
+  fi
+  _swift_suite_witness_snapshot "$statedir" after || :
+
+  for dir in "${SWIFT_SUITE_WITNESSED_DIRS[@]}"; do
+    slug=$(_swift_suite_witness_slug "$dir")
+    before="$statedir/$slug.before"
+    after="$statedir/$slug.after"
+    if [[ ! -f "$before" || ! -f "$after" ]]; then
+      echo "real-home witness: ~/$dir was never snapshotted — it is unwitnessed, not clean." >&2
+      ok=1
+      continue
+    fi
+    bstate=$(head -1 "$before" 2>/dev/null); astate=$(head -1 "$after" 2>/dev/null)
+    if [[ "$bstate" == "UNREADABLE" || "$astate" == "UNREADABLE" ]]; then
+      echo "real-home witness: ~/$dir could not be listed — this run is unwitnessed there." >&2
+      echo "  Inability to look must not print the same thing as finding nothing." >&2
+      ok=1
+      continue
+    fi
+    if [[ "$bstate" == "PRESENT" && "$astate" == "ABSENT" ]]; then
+      echo "real-home witness: ~/$dir EXISTED before the run and is gone now." >&2
+      echo "  Something in the suite removed a directory from the developer's home (#1661)." >&2
+      ok=1
+      continue
+    fi
+    # A directory that appeared is itself the finding — #1670 creates
+    # ~/Library/Sounds on a machine that never installed a custom sound.
+    if [[ "$bstate" == "ABSENT" && "$astate" == "PRESENT" ]]; then
+      echo "real-home witness: the run CREATED ~/$dir, which did not exist before it." >&2
+      ok=1
+    fi
+    # An `if`, not `[[ … ]] && looked=1`: the `&&` form returns non-zero when
+    # the condition is false, which under a CALLER's `set -e` aborts the
+    # function mid-loop — the failure mode #1633 documents for this same file.
+    if [[ "$bstate" == "PRESENT" || "$astate" == "PRESENT" ]]; then
+      looked=1
+    fi
+    added=$(comm -13 <(tail -n +2 "$before" | sort) <(tail -n +2 "$after" | sort))
+    removed=$(comm -23 <(tail -n +2 "$before" | sort) <(tail -n +2 "$after" | sort))
+    if [[ -n "$added" ]]; then
+      echo "real-home witness: the run left $(printf '%s\n' "$added" | wc -l | tr -d ' ') new entr(y/ies) in ~/$dir:" >&2
+      printf '%s\n' "$added" | sed 's/^/    + /' >&2
+      echo "  A test must leave nothing in the developer's home (#1661, #1669, #1670)." >&2
+      echo "  Background daemons also write here — a com.apple.* or third-party plist" >&2
+      echo "  appearing during the run is churn, measured at roughly one per 218s of" >&2
+      echo "  active use. Re-run to tell that apart from something this repo wrote;" >&2
+      echo "  ours will reappear every time. Nothing here deletes anything either way." >&2
+      ok=1
+    fi
+    if [[ -n "$removed" ]]; then
+      echo "real-home witness: the run REMOVED $(printf '%s\n' "$removed" | wc -l | tr -d ' ') entr(y/ies) from ~/$dir:" >&2
+      printf '%s\n' "$removed" | sed 's/^/    - /' >&2
+      echo "  Nothing in this repository is allowed to delete from the developer's home." >&2
+      ok=1
+    fi
+  done
+
+  # The vacuity guard. Every watched directory absent or empty is what a
+  # witness pointed at the wrong home looks like, and it would report a clean
+  # delta on every run forever.
+  if (( looked == 0 )); then
+    echo "real-home witness: not one watched directory was present with anything in it." >&2
+    echo "  Home read as: $(cat "$statedir/HOME.before" 2>/dev/null). Watched: ${SWIFT_SUITE_WITNESSED_DIRS[*]}" >&2
+    echo "  That is what a witness looking at the wrong place reports, so it is a failure." >&2
+    ok=1
+  fi
+
+  if (( ok == 0 )); then
+    echo "real-home witness: no new entries in ${SWIFT_SUITE_WITNESSED_DIRS[*]} under $(cat "$statedir/HOME.before")"
+  fi
+  return "$ok"
+}
+
 # swift_suite_completed <log> — did the test bundle report its own result?
 swift_suite_completed() {
   grep $SWIFT_SUITE_GREP_OPTS -qE "Test Suite '.*\.xctest' (passed|failed) at" "$1"

--- a/tools/lib/swift-suite_test.sh
+++ b/tools/lib/swift-suite_test.sh
@@ -500,5 +500,121 @@ $(grep -a 'offending run: block' <<<"$shape")"
   fi
 fi
 
+echo "== real-home witness (#1669, #1670) =="
+# Every case here runs against a FIXTURE home under $TMPDIR, never the real
+# one. That is not politeness: planting a file in the developer's home to prove
+# a guard against planting files in the developer's home would reproduce the
+# incident this guard exists for. `SWIFT_SUITE_WITNESS_HOME` exists for exactly
+# this caller and for no other.
+#
+# The `want 0` rows carry as much of the value as the rest: a witness that
+# reported unconditionally would satisfy every mutation below and read as
+# excellent coverage.
+
+# _witness_home — a fixture home shaped like a real one: Preferences present
+# and non-empty (so the vacuity guard is satisfied), Sounds absent (so the
+# "the run created it" case is reachable).
+_witness_home() {
+  local home
+  home=$(mktemp -d -t swift-suite-witness-home) || return 1
+  mkdir -p "$home/Library/Preferences" || return 1
+  printf 'x' > "$home/Library/Preferences/com.example.settled.plist" || return 1
+  printf '%s\n' "$home"
+}
+
+# _witness_scrub <dir> — remove a directory THIS FILE created, and refuse
+# anything else. The refusal is the point: it is a one-line reproduction of the
+# rule that a delete path must never be able to address a directory it did not
+# create.
+_witness_scrub() {
+  case "$1" in
+    "${TMPDIR:-/tmp}"swift-suite-witness-*|/tmp/swift-suite-witness-*|/var/folders/*/swift-suite-witness-*)
+      rm -rf "$1" ;;
+    *) echo "  refusing to remove '$1' — not a fixture this test created" >&2; return 1 ;;
+  esac
+}
+
+# _witness_case <name> <want-rc> <mutation-fn> [expected-substring]
+_witness_case() {
+  local name="$1" want="$2" mutate="$3" needle="${4:-}" home state out got
+  home=$(_witness_home) || { fail "$name: could not build the fixture home"; return; }
+  state=$(mktemp -d -t swift-suite-witness-state) || { fail "$name: no state dir"; return; }
+
+  SWIFT_SUITE_WITNESS_HOME="$home" swift_suite_witness_before "$state"
+  "$mutate" "$home"
+  out=$(SWIFT_SUITE_WITNESS_HOME="$home" swift_suite_witness_verdict "$state" 2>&1)
+  got=$?
+
+  if [[ "$got" == "$want" ]]; then
+    pass "$name → rc $got"
+  else
+    fail "$name: expected rc $want, got $got; output: $out"
+  fi
+  if [[ -n "$needle" ]]; then
+    case "$out" in
+      *"$needle"*) pass "$name: names '$needle'" ;;
+      *) fail "$name: output does not name '$needle'; got: $out" ;;
+    esac
+  fi
+  chmod -R u+rwX "$home" 2>/dev/null
+  _witness_scrub "$home"
+  _witness_scrub "$state"
+}
+
+_witness_noop() { :; }
+_witness_plant() { printf 'leak' > "$1/Library/Preferences/com.irrlicht.leaked-by-a-test.plist"; }
+_witness_remove_entry() { rm -f "$1/Library/Preferences/com.example.settled.plist"; }
+_witness_create_sounds() { mkdir -p "$1/Library/Sounds"; }
+_witness_install_sound() { mkdir -p "$1/Library/Sounds"; printf 'a' > "$1/Library/Sounds/IrrlichtCustom-ready.aiff"; }
+_witness_remove_dir() { rm -rf "$1/Library/Preferences"; }
+_witness_unreadable() { chmod 000 "$1/Library/Preferences"; }
+_witness_empty_home() { rm -rf "$1/Library"; }
+
+# The vacuity guard. Without it, every row below is satisfied by a witness that
+# always fails.
+_witness_case "a run that changed nothing passes" 0 _witness_noop "no new entries"
+# #1661's shape: a file appears in ~/Library/Preferences.
+_witness_case "a planted preference file is caught" 1 _witness_plant "com.irrlicht.leaked-by-a-test.plist"
+# #1670's shape, both halves.
+_witness_case "creating ~/Library/Sounds is caught" 1 _witness_create_sounds "CREATED"
+_witness_case "an installed sound is caught" 1 _witness_install_sound "IrrlichtCustom-ready.aiff"
+# The direction nothing in this repo is allowed to move in at all.
+_witness_case "a removed entry is caught" 1 _witness_remove_entry "REMOVED"
+_witness_case "a removed watched directory is caught" 1 _witness_remove_dir "gone now"
+# "Could not look" and "found nothing" must not print the same thing. Both of
+# these would be a clean report from a witness that simply returned early.
+_witness_case "an unreadable watched directory fails loudly" 1 _witness_unreadable "unwitnessed"
+_witness_case "a home with nothing to watch fails loudly" 1 _witness_empty_home "not one watched directory"
+
+# A verdict with no `before` snapshot is the same class: the run was not
+# witnessed, and saying nothing would mean "nothing was measured".
+_no_before=$(mktemp -d -t swift-suite-witness-state)
+_out=$(swift_suite_witness_verdict "$_no_before" 2>&1) && \
+  fail "a verdict with no before-snapshot must fail" || pass "no before-snapshot → fail"
+case "$_out" in
+  *"NOT witnessed"*) pass "an unwitnessed run says so" ;;
+  *) fail "an unwitnessed run must say so; got: $_out" ;;
+esac
+_witness_scrub "$_no_before"
+swift_suite_witness_verdict "" >/dev/null 2>&1 && fail "missing statedir must fail" || pass "missing statedir → fail"
+
+# The witness reads the PASSWORD DATABASE, not $HOME. A witness that followed
+# $HOME would watch an empty temp directory and report clean forever — and
+# moving $HOME is one of the things a future fix in this area might do.
+_real_home=$(swift_suite_witness_home)
+_moved_home=$(HOME=/tmp/definitely-not-the-home swift_suite_witness_home)
+[[ -n "$_real_home" && "$_real_home" == "$_moved_home" ]] \
+  && pass "swift_suite_witness_home ignores \$HOME ($_real_home)" \
+  || fail "swift_suite_witness_home followed \$HOME: '$_real_home' vs '$_moved_home'"
+[[ -d "$_real_home" ]] && pass "the home it reads is a directory" \
+  || fail "swift_suite_witness_home returned '$_real_home', which is not a directory"
+
+# The watched set is asserted rather than left implicit: it is the whole scope
+# of the guard, and silently shrinking it to nothing is indistinguishable from
+# a guard that finds nothing.
+[[ "${#SWIFT_SUITE_WITNESSED_DIRS[@]}" -ge 2 ]] \
+  && pass "watching ${#SWIFT_SUITE_WITNESSED_DIRS[@]} directories: ${SWIFT_SUITE_WITNESSED_DIRS[*]}" \
+  || fail "the watched set has shrunk to ${#SWIFT_SUITE_WITNESSED_DIRS[@]} — the guard covers almost nothing"
+
 if [[ "$rc" -eq 0 ]]; then echo "swift-suite_test: ALL PASS"; else echo "swift-suite_test: FAILURES" >&2; fi
 exit "$rc"

--- a/tools/preflight.sh
+++ b/tools/preflight.sh
@@ -594,8 +594,25 @@ swift_suite() {
   # that true after a class is added to the target or the target is renamed.
   # This matters more locally than in CI — here an unskipped harness test drives
   # the developer's own live terminal windows.
-  local log rc
+  local log rc witness wrc
   log=$(mktemp -t irrlicht-swift-suite) || return 1
+
+  # The real-home witness brackets the RUN, not the build: `swift build` writes
+  # under ~/Library/Caches and ~/Library/org.swift.swiftpm, neither of which is
+  # watched, and a tighter window is less exposed to third-party churn. See
+  # tools/lib/swift-suite.sh for what is watched and what deliberately is not.
+  #
+  # Deliberately NOT also wired into .github/workflows/macos-swift.yml. Its
+  # noise floor was measured HERE and not on a GitHub runner: 0 additions across
+  # each of two windows bracketing a full suite run, against 4 unrelated
+  # background plists across one 870s window of interactive use. A runner's
+  # background churn is unmeasured, and a guard that goes red for reasons nobody
+  # has characterised gets ignored — this one has to be believed the first time
+  # it fires. AGENTS.md already names this gate as the real one and CI as the
+  # floor.
+  witness=$(mktemp -d -t irrlicht-swift-witness) || return 1
+  swift_suite_witness_before "$witness"
+
   ( cd platforms/macos && swift_suite_run "$log" \
       swift test --skip LauncherTestHarness --skip LauncherHarnessTests )
   rc=$?
@@ -603,7 +620,18 @@ swift_suite() {
   # capturing it, so re-printing would double every line.
   swift_suite_verdict "$rc" "$log"
   rc=$?
+
+  # Judged even when the suite hung, aborted or failed — those are precisely
+  # the runs on which a `defer`-based cleanup does not run, so a witness that
+  # only spoke after a healthy run would be silent exactly when it matters.
+  swift_suite_witness_verdict "$witness"
+  wrc=$?
+  if (( wrc != 0 )); then
+    rc=1
+  fi
+
   rm -f "$log"
+  rm -rf "$witness"
   return "$rc"
 }
 


### PR DESCRIPTION
Closes #1669. Closes #1670.

Third and fourth instances of the class #1661/#1668 opened: a `swift test` run
writing into the developer's real home. Both are fixed at the source, and the
change adds a standing guard so the class is caught rather than re-derived.

## What each suite actually wrote, and how that was established

Not from mtimes. The live daemon writes into
`~/Library/Application Support/Irrlicht/instances/` continuously — measured,
two files modified inside 60s with nothing of ours running — so a fresh mtime
there is evidence of nothing. It was established two ways: by reading the call
chain, and by **running the whole suite with the home redirected** and
enumerating what landed in the redirected tree.

```
$ env CFFIXED_USER_HOME=$FAKE swift test --skip LauncherTestHarness --skip LauncherHarnessTests
Executed 352 tests, with 0 failures

$ find $FAKE
  <FAKE>/Library/Application Support/Irrlicht/instances          # created
  <FAKE>/Library/Application Support/Irrlicht/session-order.json # written
  <FAKE>/Library/Sounds                                          # created, empty
$ cat "<FAKE>/Library/Application Support/Irrlicht/session-order.json"
{"order":["b","a"],"version":1}
```

**#1669 — `SessionManagerApiGroupsTests`, and in fact every suite that
constructs a `SessionManager`.** `SessionManager.init` resolved both of its
on-disk paths off `homeDirectoryForCurrentUser` (`SessionManager.swift:276`),
with no seam — two `let`s computed in `init`. Three writes followed, and they
are not equally bad:

1. a `<uuid>.json` fixture into the daemon's live `instances/`, `defer`-cleaned;
2. **`session-order.json` overwritten**, with *no cleanup of any kind* —
   `deleteSession` calls `saveSessionOrder()` unconditionally
   (`SessionManager+SessionActions.swift:48`), and `updateSessionOrder` /
   `reorderSession` do the same from other suites. `{"order":["b","a"]}` above
   is test data; the developer's real file currently holds seven live session
   ids. This one is a clobber of user data, not a leak, and it was not in the
   original report;
3. `instances/` created on a machine that never ran the app.

**#1670 — `SoundPlayerTests`.** Four tests drive `installCustom` into
`SoundPlayer.soundsDirectory()`, which resolves `~/Library/Sounds` and creates
it if absent. Three write `IrrlichtCustom-<event>.<ext>` — the **production**
filename, which `notificationSound(for:)` then prefers over the fallback — and
each is cleaned only by a `defer`. `defer` does not run when XCTest's stall
detector `abort()`s the process (#1523), when `swift-suite.sh` kills the tree
at 240s, or when `--budget` kills the gate: the leak is conditioned on the
failure modes this repo already knows it has. The healthy path does clean up —
the real `~/Library/Sounds` holds only its two long-standing files
(`IrrlichtCustom-contextPressure.caf`, May 14; `notification.wav`, Feb 4).

## Mechanism, and why

One mechanism for both, because both are the same read: `AppHome`
(`Irrlicht/Managers/AppHome.swift`) is now the single place the app resolves
the user's home, and under XCTest it answers a per-process directory beneath
`NSTemporaryDirectory()`. All five product call sites go through it.

Three things were rejected, each on a measurement rather than a preference:

* **A `HOME` redirect does not work.** Measured with a standalone binary:
  `HOME=<tmp>` alone leaves `NSHomeDirectory()`, `homeDirectoryForCurrentUser`
  and the search-path APIs at the real home; only `CFFIXED_USER_HOME` moves
  them. (#1668's note that `NSHomeDirectory()` "DID return the temp dir" was
  measured with both set — `CFFIXED_USER_HOME` was doing the work.) A fix built
  on `HOME` would look like a fix and change nothing.
* **A `CFFIXED_USER_HOME` redirect in the runner does work** — the full suite
  passes under it, 352 tests — **but only when the suite is launched through a
  script that sets it.** A developer typing `swift test`, or running from
  Xcode, is exactly who got hit and would still be. So the redirect is
  in-process, keyed on `NSClassFromString("XCTestCase")` — the same signal
  `SessionManager.isRunningUnitTests` already uses to keep unit tests off the
  live daemon socket (#832). That decision was already made for the network;
  this is the same decision for the filesystem. Measured: an in-process
  `setenv` was not needed and is not used, but for the record it does still
  move the path APIs after CF has resolved once.
* **No sweep, anywhere.** A function whose job is to delete files from a
  directory it did not create, in the developer's home, is what removed ~1895
  files from a real `~/Library/Preferences` during #1661. Nothing in this
  change has a removal path over the home. The test home is created under
  `NSTemporaryDirectory()` and left for the OS.

Failure is a `fatalError`, not a fallback: the only fallback available is the
real home, which is the outcome the type exists to prevent.

`SessionManagerApiGroupsTests` no longer re-derives the instances directory at
all — it reads `sut.instancesPath`, so the test cannot disagree with the code
under test about where that directory is.

## The guard: measured noise floor and scope

Split in two, because the halves see different things.

**`tools/lib/swift-suite.sh`'s witness** snapshots `~/Library/Preferences` and
`~/Library/Sounds` before the `swift test` invocation and fails on any new
entry after it. It lives in the shell rather than in the suite for one reason:
it is the only thing that still runs when the suite does **not** finish —
which is exactly when a `defer` does not run either. It reads, and has no
removal path at all.

Noise floor, stated as measured rather than as it would flatter the guard:

| window | Preferences | Sounds |
|---|---|---|
| ~2 min, bracketing a full 352-test suite run (×2) | 0 added | 0 added |
| 870s of ordinary interactive use | **4 added** (`com.apple.bluetooth`, `com.apple.DuetExpertCenter.MagicalMoments`, `com.apple.voicetrigger`, `com.googlecode.iterm2`) | 0 added |

So the noise is a function of the **window**, which is the one variable under
our control — hence the bracket is the run, not the build before it. At the
measured background rate (~1 plist per 218s of active use) a ~5s healthy run
carries a ~2% chance of naming a stray plist. That residual is accepted rather
than filtered: #1661's 1136 leaked files were named `<uuid>.plist`, so any
name-based filter that quietened the churn would have quietened the incident.
The failure message says so and tells the reader to re-run — ours reappears,
churn does not.

**`~/Library/Application Support/Irrlicht` is deliberately NOT watched**, and
the reason is not noise — it measured 0 additions at the watched (non-recursive)
level over the same 870s. It is that a new-entry witness **cannot see #1669**:
the worst of that defect is an overwrite of a file that already exists, and the
level that would see the rest (`instances/`) is written continuously by the live
daemon. Watching it would report clean while the defect happened, which is worse
than not watching it. So that instance is locked on the resolved **path**
instead, by `RealHomeIsolationTests`, where there is no noise at all.

The whole `~/Library` was rejected in #1668 (6s over 887,491 files, 24 of 41
changed entries unrelated third-party churn) and is not revisited.

The witness fails loudly when it cannot look: `ABSENT` / `PRESENT` /
`UNREADABLE` are three distinct states, a missing `before` snapshot is a
refusal, and a run in which no watched directory was present with anything in
it fails as "the witness looked at the wrong place" rather than passing.

**It is deliberately not wired into `macos-swift.yml`.** The noise floor above
was measured on a developer machine and a runner's is unmeasured; a guard that
goes red for uncharacterised reasons gets ignored, and this one has to be
believed the first time it fires. AGENTS.md already names the local gate as the
real one and CI as the floor.

**`RealHomePathLintTests`** is the structural half — a source scan over the app
**and** test targets for `homeDirectoryForCurrentUser`, `NSHomeDirectory(`,
`userDomainMask` and `expandingTildeInPath`. The app target is in scope because
that is where the resolution actually happened; scanning only `Tests/` would
leave the class re-enterable from the side it entered from. Measured before
writing it: after the rewrite the tree contains exactly two occurrences outside
the exemptions, both of which are the exemptions. Unlike
`PersistentDefaultsLintTests` it has an exemption list, because the safe
construct is built out of the banned one; each entry carries a reason and is
existence-checked.

## Mutation evidence

Every mutation was applied and reverted in one foreground call, with a
`diff` against a copy-aside proving the revert, and each was designed so a
broken redirect cannot write to the real home while the mutation is live —
`RealHomeIsolationTests` asserts `AppHome.url` first and `return`s on failure,
before anything that could *create* a directory (`soundsDirectory()` does).

| # | mutation | expected | observed |
|---|---|---|---|
| M1 | `AppHome.url` returns the real home under test | isolation lock red | `RealHomeIsolationTests` failed: *"AppHome.url resolved to /Users/ingo, inside the real home /Users/ingo"* — 0 files added to the real home while it ran |
| M2 | plant `FileManager.default.homeDirectoryForCurrentUser` in a non-exempt test file | live scan red | `["Tests/SessionManagerApiGroupsTests.swift:17:homeDirectoryForCurrentUser"]` |
| M3 | rename an exemption to a file that does not exist | existence check red | *"exemption 'Tests/InMemoryDefaultsRenamed.swift' … no longer names a file"*, plus the `exemptionsHit` arm |
| M4 | drop `userDomainMask` from the rule's construct list | corpus red | three corpus rows, incl. the two-constructs-on-one-line row |

The shell witness's mutation evidence is **committed**, in
`tools/lib/swift-suite_test.sh` — eight cases against a fixture home under
`$TMPDIR` (never the real one), each pinned to the fragment of the message it
must produce: a planted plist, a created `~/Library/Sounds`, an installed
sound, a removed entry, a removed watched directory, an unreadable directory,
a home with nothing to watch, and a verdict with no `before` snapshot. The
`want 0` vacuity row is there for the reason the rest of this repo keeps it: a
witness that reported unconditionally would satisfy all eight.

One unplanned red is worth recording, because it is the mechanism working:
`tools/lib/shell-lib-errexit_test.sh` failed on arrival with five `UNDRIVEN`
complaints naming the new witness functions. Recipes were added; all five are
driven at 0 and that limit is stated in place — each documents 1 for its
failure paths, and a documented 1 is indistinguishable from an errexit abort.

## Before / after, real home

Counted immediately around the final `tools/preflight.sh --only swift` run:

| directory | before | after | added | removed |
|---|---|---|---|---|
| `~/Library/Preferences` | 130 | 130 | 0 | 0 |
| `~/Library/Sounds` | 2 | 2 | 0 | 0 |
| `~/Library/Application Support/Irrlicht` | 18 | 18 | 0 | 0 |

Files added anywhere under the real home by this work: **0**. Every experiment
that could write ran against a redirected home under `$TMPDIR` and refused to
write unless every resolved path was provably inside it.

One observation left explicitly unattributed rather than dismissed:
`~/Library/Sounds`' directory mtime was recent at the start of this work (its
two files' mtimes are May 14 and Feb 4), which is the signature of an entry
created and removed. It predates the first snapshot taken here, so nothing in
this branch can establish what did it.

## Gates

| gate | result |
|---|---|
| `tools/preflight.sh --only swift` | **PASS** — exit 0, bundle reported `passed`, `Executed 360 tests, with 0 failures` (352 before this change + 8 new). The exit code is the signal, not the totals line (#1523). |
| `tools/preflight.sh --only tools` | **PASS** — `shell-lib-suite: tools/lib — found 14, skipped 0, ran 14, failed 0` |
| pre-push hook (`--changed --budget 540`) | PASS: `tools/lib shell-lib tests`, `gofmt`, `macOS Swift build + test`; everything else correctly SKIP |

Not run, and out of scope for this diff: the `go`, `web`, `arch`, `posix`,
`security` and `linux` groups — no Go, web, or POSIX-`sh` file is touched, and
the pre-push run reported each of them SKIP for that reason rather than being
suppressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**Follow-up commit `b54fb76b`.** CodeScene (advisory) flagged the lint's live
scan for deep nesting — a loop over three directories, two guards, an inner
loop and a branch inside it. The walk is now one method returning a value and
the test body folds three of them. Behaviour unchanged, and measured rather
than asserted: **both mutations were re-run against the refactored scan** (M2
still reports `Tests/SessionManagerApiGroupsTests.swift:17`, M3 still reddens
both the existence check and the `exemptionsHit` arm), since a rewritten guard
owes its predecessor's cases. The swift gate was re-run after it — exit 0, 360
tests, witness clean, 0 files added to the real home.

Every CI check on the branch now passes, CodeScene included.
