### PR TITLE
fix(macos): pin @AppStorage on the snapshot host instead of hand-pinning the developer's real preference domain (#1662)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1435,14 +1435,57 @@ Before marking a ticket done, run the full suite — every layer must pass:
   `HistoryViewSnapshotTests`' `setUp` rather than keeping it, deliberately —
   with no process-wide assignment left, those 8 references are themselves the
   live evidence that the seam reaches every date the panel draws.
-  Still open in this family, each with its evidence in the issue rather than
+  **The third member is `@AppStorage`, and it is the one where the seam already
+  existed** (#1662). `GroupViewSnapshotTests` and `SessionRowSnapshotTests` each
+  held eight real preference keys open in `setUp` and put them back in
+  `tearDown`, `AdapterIconAppearanceTests` six — and unlike the locale and the
+  zone, **no product seam was needed for the views**: SwiftUI's own
+  `.defaultAppStorage(_:)` is honoured by `@AppStorage`, where `format: .number`
+  ignores `\.locale` and a file-scope `DateFormatter` is reachable from no view
+  at all. So the whole view half is one modifier on `PinnedSnapshotHost`. Three
+  things there are worth carrying. The parameter is typed **`InMemoryDefaults`,
+  not `UserDefaults`**, so `.standard` is not expressible at a snapshot host —
+  the type guarantee #1390 prefers over a guard, one family further on — and its
+  default is an EMPTY store, which is what made adoption free: an unset key
+  renders at the `@AppStorage` declaration's own default, which is exactly what
+  the deleted `setUp`s were assigning, so all 53 references still match and none
+  was regenerated. **A suite that forgets to pass its store gets isolation and a
+  visible failure** ("my pinned value did not reach the view"), never a
+  reference that silently photographs someone's Settings — the polarity is what
+  makes the default safe. And the abort path (#1523, the 240s tree kill,
+  `--budget`) is answered by **removing the state, not unwinding it more
+  carefully**: with nothing written there is nothing a skipped `tearDown` can
+  fail to restore.
+  Two keys did need a product seam, because they are not `@AppStorage` and no
+  environment reaches them: `SessionManager` reads `summaryDisplayMode` and
+  `projectGroupOrder` itself, so it takes the store it reads them from
+  (`.standard` by default). One measured trap there, found by the change's own
+  new test rather than in review: **`didSet` DOES fire for a write in the second
+  phase of a base class's own `init`**, so seeding a value read from the store
+  wrote it straight back — in the app, a preference persisted into the user's
+  real `io.irrlicht.app` domain that they never set. The seed goes through the
+  `@Published` STORAGE (`self._summaryDisplayMode = Published(initialValue:)`),
+  which the property observer does not see.
+  Measured while doing it, and it settles the "is this hypothetical" question the
+  issue left open: with the pin deleted, the probe in
+  `PinnedAppStorageSnapshotTests` reads `menuBarStyle = combined`,
+  `notificationsEnabled = true` and `advancedSettingsExpanded = true` off this
+  machine — the nine keys nothing pinned were live inputs, not a worry. The
+  structural half is `PersistentDefaultsLintTests`' second rule, which fails the
+  build on any `UserDefaults.standard` **mutation** in the test targets; READS
+  are deliberately left legal, because `object(forKey:)` is how a test says "and
+  the process domain was not touched", and banning it would ban the evidence
+  along with the defect. What that rule cannot see is a production call site a
+  test drives — measured, two sound keys still reach that domain across a full
+  gate run and no test source names the write (#1672).
+  Still open in this family, with its evidence in the issue rather than
   asserted here: `SessionListView.formatResetTime` (#1663 — a timezone pin
   reaches two of its three machine reads and leaves the `Date()` that picks the
-  format string, so it was left whole rather than half-covered) and
-  `@AppStorage`/`UserDefaults` (#1662 — and no, a test run does not modify the
-  user's real app preferences: `UserDefaults.standard` under `swift test`
-  resolves to `com.apple.dt.xctest.tool`, measured against a byte-identical
-  `io.irrlicht.app.plist` across a full run).
+  format string, so it was left whole rather than half-covered). And no, a test
+  run does not modify the user's real app preferences:
+  `UserDefaults.standard` under `swift test` resolves to
+  `com.apple.dt.xctest.tool`, measured again across two full gate runs against a
+  byte- and mtime-identical `io.irrlicht.app.plist`.
   **A sibling family reads the machine for its WRITES rather than its
   formatting**, and is closed the same way: `AppHome`
   (`Irrlicht/Managers/AppHome.swift`) is now the one place the app resolves the

--- a/platforms/macos/Irrlicht/Managers/SessionManager+GroupComposition.swift
+++ b/platforms/macos/Irrlicht/Managers/SessionManager+GroupComposition.swift
@@ -224,12 +224,12 @@ extension SessionManager {
     // MARK: - Project Group Order Management
 
     func loadProjectGroupOrder() {
-        projectGroupOrder = UserDefaults.standard.stringArray(forKey: projectGroupOrderKey) ?? []
+        projectGroupOrder = defaults.stringArray(forKey: projectGroupOrderKey) ?? []
         print("📋 Loaded project group order with \(projectGroupOrder.count) groups")
     }
 
     func saveProjectGroupOrder() {
-        UserDefaults.standard.set(projectGroupOrder, forKey: projectGroupOrderKey)
+        defaults.set(projectGroupOrder, forKey: projectGroupOrderKey)
         print("💾 Saved project group order with \(projectGroupOrder.count) groups")
     }
 

--- a/platforms/macos/Irrlicht/Managers/SessionManager+Notifications.swift
+++ b/platforms/macos/Irrlicht/Managers/SessionManager+Notifications.swift
@@ -65,7 +65,7 @@ extension SessionManager {
     }
 
     func sendContextPressureNotification(session: SessionState, threshold: ContextPressureThreshold, metrics: SessionMetrics) {
-        guard UserDefaults.standard.bool(forKey: NotificationEvent.contextPressure.enabledKey) else { return }
+        guard defaults.bool(forKey: NotificationEvent.contextPressure.enabledKey) else { return }
         let label = session.projectName ?? session.shortId
 
         let title: String
@@ -105,8 +105,8 @@ extension SessionManager {
         // Skip subagent sessions to avoid notification noise
         if session.parentSessionId != nil { return }
 
-        let notifyReady = UserDefaults.standard.bool(forKey: "notifyOnReady")
-        let notifyWaiting = UserDefaults.standard.bool(forKey: "notifyOnWaiting")
+        let notifyReady = defaults.bool(forKey: "notifyOnReady")
+        let notifyWaiting = defaults.bool(forKey: "notifyOnWaiting")
 
         let title: String
         let event: NotificationEvent
@@ -147,7 +147,7 @@ extension SessionManager {
         // UNNotificationContent entirely, is covered.
         guard NotificationSettings.masterEnabled() else { return }
         guard canUseUserNotifications else { return }
-        let choice = Self.choice(for: event)
+        let choice = Self.choice(for: event, defaults: defaults)
         let content = UNMutableNotificationContent()
         content.title = title
         content.body = body
@@ -207,12 +207,22 @@ extension SessionManager {
     /// Convenience for tests + callers that want the event → sound lookup in
     /// a single hop. Production path uses `choice(for:)` + `notificationSound(for:)`
     /// directly to avoid double-reading UserDefaults.
-    nonisolated static func resolveNotificationSound(for event: NotificationEvent) -> UNNotificationSound? {
-        notificationSound(for: choice(for: event))
+    nonisolated static func resolveNotificationSound(
+        for event: NotificationEvent,
+        defaults: UserDefaults = .standard
+    ) -> UNNotificationSound? {
+        notificationSound(for: choice(for: event, defaults: defaults))
     }
 
-    nonisolated static func choice(for event: NotificationEvent) -> SoundChoice {
-        let raw = UserDefaults.standard.string(forKey: event.soundKey) ?? SoundChoice.default.rawValue
+    /// `defaults` is a parameter rather than `.standard` for #1662's reason:
+    /// a test driving this must not have to write the developer's real
+    /// `com.apple.dt.xctest.tool` domain and put it back in a `tearDown` the
+    /// aborting runs skip.
+    nonisolated static func choice(
+        for event: NotificationEvent,
+        defaults: UserDefaults = .standard
+    ) -> SoundChoice {
+        let raw = defaults.string(forKey: event.soundKey) ?? SoundChoice.default.rawValue
         return SoundChoice(rawValue: raw) ?? .default
     }
 

--- a/platforms/macos/Irrlicht/Managers/SessionManager+Relay.swift
+++ b/platforms/macos/Irrlicht/Managers/SessionManager+Relay.swift
@@ -11,10 +11,10 @@ import Foundation
 // merge, so the same daemon reached over both paths shows once.
 
 extension SessionManager {
-    var useLocalDaemon: Bool { UserDefaults.standard.bool(forKey: "useLocalDaemon") }
-    var useRelayServer: Bool { UserDefaults.standard.bool(forKey: "useRelayServer") }
+    var useLocalDaemon: Bool { defaults.bool(forKey: "useLocalDaemon") }
+    var useRelayServer: Bool { defaults.bool(forKey: "useRelayServer") }
     var relayServerURL: String {
-        (UserDefaults.standard.string(forKey: "relayServerURL") ?? "")
+        (defaults.string(forKey: "relayServerURL") ?? "")
             .trimmingCharacters(in: .whitespacesAndNewlines)
     }
 

--- a/platforms/macos/Irrlicht/Managers/SessionManager.swift
+++ b/platforms/macos/Irrlicht/Managers/SessionManager.swift
@@ -96,10 +96,12 @@ class SessionManager: ObservableObject {
     /// summary shown at once), which was mostly noise. There is no per-row
     /// toggle on macOS (see SessionRowView.summaryBlock). Persisted in
     /// UserDefaults (#799) so the choice survives app restarts.
-    @Published var summaryDisplayMode: SummaryDisplayMode = SummaryDisplayMode(
-        rawValue: UserDefaults.standard.string(forKey: "summaryDisplayMode") ?? ""
-    ) ?? .waiting {
-        didSet { UserDefaults.standard.set(summaryDisplayMode.rawValue, forKey: "summaryDisplayMode") }
+    /// Seeded from `defaults` in `init` rather than in the declaration, because
+    /// a property initializer cannot see `self.defaults` — and because Swift
+    /// does not run `didSet` for a write performed inside `init`, so the seed
+    /// reads the store without writing back to it (#1662).
+    @Published var summaryDisplayMode: SummaryDisplayMode = .waiting {
+        didSet { defaults.set(summaryDisplayMode.rawValue, forKey: "summaryDisplayMode") }
     }
 
     /// Set of session IDs present in apiGroups (for fast membership check).
@@ -270,8 +272,32 @@ class SessionManager: ObservableObject {
     /// be reachable on the machine (issue #832).
     let isRunningUnitTests = NSClassFromString("XCTestCase") != nil
 
-    init(focusMonitor: FocusStateProviding = FocusMonitor()) {
+    /// Where this manager's user preferences live. `.standard` in the app —
+    /// the only store there is — and injectable so a test does not have to
+    /// hand-pin keys in a REAL persistent domain and hand them back in
+    /// `tearDown` (#1662).
+    ///
+    /// `UserDefaults.standard` under `swift test` is
+    /// `com.apple.dt.xctest.tool`, a plist in the developer's own
+    /// `~/Library/Preferences` that every previous run wrote into, so the
+    /// save/restore dance both (a) rendered whatever a killed run happened to
+    /// leave behind and (b) depended on a `tearDown` that #1523's aborts, the
+    /// 240s tree kill and `--budget` all skip. An injected `InMemoryDefaults`
+    /// has nothing to restore because it wrote nothing.
+    ///
+    /// Scope: this covers the preferences **SessionManager itself** reads —
+    /// `summaryDisplayMode`, `projectGroupOrder`, the Sources flags, the
+    /// notification toggles and the `register(defaults:)` seed. Preferences
+    /// read elsewhere (`MenuBarController`, `LoginItemManager`,
+    /// `ContextPressureThreshold.current`, `MenuBarStyle.current`) still
+    /// resolve `.standard`; the views' own `@AppStorage` reads are covered by
+    /// `PinnedSnapshotHost`'s `defaultAppStorage` pin instead.
+    let defaults: UserDefaults
+
+    init(focusMonitor: FocusStateProviding = FocusMonitor(),
+         defaults: UserDefaults = .standard) {
         self.focusMonitor = focusMonitor
+        self.defaults = defaults
 
         // `AppHome`, not the real home: both paths below are WRITTEN — a
         // fixture into `instances/`, and `session-order.json` overwritten with
@@ -312,7 +338,22 @@ class SessionManager: ObservableObject {
             defaultsSeed[event.enabledKey] = false
             defaultsSeed[event.soundKey] = event.defaultSound.rawValue
         }
-        UserDefaults.standard.register(defaults: defaultsSeed)
+        defaults.register(defaults: defaultsSeed)
+
+        // Seeded after `register(defaults:)` so an unset key falls back to the
+        // registration domain exactly as it does in the app.
+        //
+        // Assigned through the `@Published` STORAGE rather than through the
+        // property, because a base class DOES run `didSet` for a write in the
+        // second phase of its own `init` (measured — the first draft of this
+        // seam persisted "waiting" into the store on every construction, which
+        // in the app means writing a preference into the user's real
+        // `io.irrlicht.app` domain that they never set). Seeding a value read
+        // from the store must not write it back.
+        self._summaryDisplayMode = Published(
+            initialValue: SummaryDisplayMode(
+                rawValue: defaults.string(forKey: "summaryDisplayMode") ?? ""
+            ) ?? .waiting)
 
         // Reconnect sources live when a Sources setting changes (no relaunch).
         // didChangeNotification fires for any default; sourcesSettingsChanged

--- a/platforms/macos/Tests/AdapterIconAppearanceTests.swift
+++ b/platforms/macos/Tests/AdapterIconAppearanceTests.swift
@@ -28,44 +28,27 @@ import SwiftUI
 final class AdapterIconAppearanceTests: XCTestCase {
     private var sessionManager: SessionManager!
     private var savedRegistry: [String: AgentBranding] = [:]
-    private var savedDefaults: [String: Any?] = [:]
 
-    /// The `@AppStorage` keys `SessionRowView` reads. Pinned for the same
-    /// reason `SessionRowSnapshotTests` pins them: they live in
-    /// `UserDefaults.standard`, so an unpinned render depends on whatever the
-    /// xctest domain happens to hold — including a value a previous run left
-    /// behind after being killed before `tearDown` (#1523 does exactly that).
-    /// `debugMode` is the one that matters most here: it adds a line to the
-    /// row's VStack inside a fixed-height frame, shifting the metrics line up
-    /// and out of the icon probe box.
-    private static let pinnedDefaults: [String: Any] = [
-        "displayMode": "context",
-        "debugMode": false,
-        "showCostDisplay": false,
-        "summaryDisplayMode": SummaryDisplayMode.waiting.rawValue,
-        ContextPressureThreshold.valueKey: 80,
-        ContextPressureThreshold.unitKey: ContextPressureThreshold.Unit.percent.rawValue,
-    ]
+    /// This suite's own preference store (#1662). It replaces a six-key
+    /// snapshot-and-restore over the REAL `com.apple.dt.xctest.tool` domain,
+    /// which depended on a `tearDown` that #1523's aborts, the 240s tree kill
+    /// and `--budget` all skip. Empty is the right content: every key
+    /// `SessionRowView` reads then resolves at its own `@AppStorage` default,
+    /// which is what the deleted dictionary was assigning. `debugMode` is the
+    /// one that matters most here — it adds a line to the row's VStack inside a
+    /// fixed-height frame, shifting the metrics line up and out of the icon
+    /// probe box — and it defaults to `false`.
+    private let defaults = InMemoryDefaults()
 
     override func setUp() async throws {
         try await super.setUp()
-        let defaults = UserDefaults.standard
-        for (key, value) in Self.pinnedDefaults {
-            savedDefaults[key] = defaults.object(forKey: key)
-            defaults.set(value, forKey: key)
-        }
-        sessionManager = SessionManager()
+        sessionManager = SessionManager(defaults: defaults)
         savedRegistry = AgentRegistry.byName
         AgentRegistry.byName["antigravity"] = TestAgentBranding.antigravity
     }
 
     override func tearDown() async throws {
         AgentRegistry.byName = savedRegistry
-        let defaults = UserDefaults.standard
-        for (key, value) in savedDefaults {
-            if let value { defaults.set(value, forKey: key) } else { defaults.removeObject(forKey: key) }
-        }
-        savedDefaults = [:]
         sessionManager = nil
         try await super.tearDown()
     }
@@ -197,16 +180,18 @@ final class AdapterIconAppearanceTests: XCTestCase {
         return measured
     }
 
+    /// Built through `PinnedSnapshotHost` — the type every other snapshot suite
+    /// hosts through — rather than a hand-rolled `NSHostingView`, so this suite
+    /// inherits the preference pin (#1662) the way it already inherits the
+    /// appearance one, instead of re-implementing it. The appearance is still
+    /// this suite's own subject and is passed through.
     private func host(_ session: SessionState, appearance: NSAppearance.Name) -> NSView {
-        let wrapped = SessionRowView(session: session, agentNumber: 1)
-            .environmentObject(sessionManager)
-            .frame(width: 350, height: 48)
-            .background(Color(NSColor.windowBackgroundColor))
-        let hosting = NSHostingView(rootView: wrapped)
-        hosting.appearance = NSAppearance(named: appearance)
-        hosting.frame = CGRect(x: 0, y: 0, width: 350, height: 48)
-        hosting.layoutSubtreeIfNeeded()
-        return hosting
+        PinnedSnapshotHost(
+            SessionRowView(session: session, agentNumber: 1)
+                .environmentObject(sessionManager)
+                .frame(width: 350, height: 48)
+                .background(Color(NSColor.windowBackgroundColor)),
+            width: 350, height: 48, appearance: appearance, defaults: defaults).view
     }
 
     private func loadAntigravityGhost() throws -> SessionState {

--- a/platforms/macos/Tests/GroupViewSnapshotTests.swift
+++ b/platforms/macos/Tests/GroupViewSnapshotTests.swift
@@ -6,33 +6,23 @@ import SnapshotTesting
 @MainActor
 final class GroupViewSnapshotTests: XCTestCase {
     private var sessionManager: SessionManager!
-    private var originalShowCostDisplay: Any?
-    private var originalProjectCostTimeframe: Any?
+
+    /// This suite's own preference store, written by nothing and read by
+    /// nothing else (#1662). It replaces a `setUp` that overwrote
+    /// `showCostDisplay` and `projectCostTimeframe` in the REAL
+    /// `com.apple.dt.xctest.tool` domain and a `tearDown` that put them back —
+    /// which the runs that abort (#1523), get their tree killed at 240s or run
+    /// out of `--budget` never reached, so those values were left behind for
+    /// the next run to render under.
+    ///
+    /// Empty on purpose: every key `GroupView` reads then resolves at its own
+    /// `@AppStorage` default, which is exactly what the deleted `setUp` was
+    /// assigning (`false` and `CostTimeframe.day`), so no reference moved.
+    private let defaults = InMemoryDefaults()
 
     override func setUp() async throws {
         try await super.setUp()
-        // GroupView uses @AppStorage (UserDefaults.standard), so we can't isolate
-        // via suiteName. Snapshot the real keys and restore them in tearDown so
-        // the developer's defaults aren't mutated by test runs.
-        originalShowCostDisplay = UserDefaults.standard.object(forKey: "showCostDisplay")
-        originalProjectCostTimeframe = UserDefaults.standard.object(forKey: "projectCostTimeframe")
-        UserDefaults.standard.set(false, forKey: "showCostDisplay")
-        UserDefaults.standard.set("day", forKey: "projectCostTimeframe")
-        sessionManager = SessionManager()
-    }
-
-    override func tearDown() async throws {
-        if let value = originalShowCostDisplay {
-            UserDefaults.standard.set(value, forKey: "showCostDisplay")
-        } else {
-            UserDefaults.standard.removeObject(forKey: "showCostDisplay")
-        }
-        if let value = originalProjectCostTimeframe {
-            UserDefaults.standard.set(value, forKey: "projectCostTimeframe")
-        } else {
-            UserDefaults.standard.removeObject(forKey: "projectCostTimeframe")
-        }
-        try await super.tearDown()
+        sessionManager = SessionManager(defaults: defaults)
     }
 
     private func makeSession(id: String) -> SessionState {
@@ -61,13 +51,14 @@ final class GroupViewSnapshotTests: XCTestCase {
     private func host(_ view: some View, height: CGFloat = 48) -> PinnedSnapshotHost {
         // `PinnedSnapshotHost` pins the appearance — so snapshots don't depend
         // on the current system appearance, which `Color(NSColor.windowBackgroundColor)`
-        // otherwise adapts to — and the locale (#1630).
+        // otherwise adapts to — the locale (#1630) and the preference store
+        // every `@AppStorage` in the subtree resolves through (#1662).
         PinnedSnapshotHost(
             view
                 .environmentObject(sessionManager)
                 .frame(width: 350, height: height)
                 .background(Color(NSColor.windowBackgroundColor)),
-            width: 350, height: height)
+            width: 350, height: height, defaults: defaults)
     }
 
     private func seedThreeGroups() -> [SessionManager.AgentGroup] {

--- a/platforms/macos/Tests/PersistentDefaultsLintTests.swift
+++ b/platforms/macos/Tests/PersistentDefaultsLintTests.swift
@@ -15,15 +15,30 @@ import XCTest
 /// This is what makes the fix cover the *target* rather than one suite: a test
 /// written next year inherits it without anyone remembering #1661.
 ///
-/// Scope, stated so it is not mistaken for more: this bans the construct that
-/// mints a *new* persistent domain, and therefore a new file, per call. It does
-/// not ban `UserDefaults.standard`, which several suites here mutate under
-/// snapshot-and-restore — that writes into one already-existing domain rather
-/// than accreting files, and is a different problem with a different fix.
+/// **Two rules, because #1662 closed the case this file used to defer.** The
+/// first bans the construct that mints a *new* persistent domain, and therefore
+/// a new file, per call (#1661). The second bans **mutating**
+/// `UserDefaults.standard` — which this file previously called "a different
+/// problem with a different fix", correctly: under `swift test` that resolves
+/// to `com.apple.dt.xctest.tool`, one already-existing plist in the developer's
+/// real `~/Library/Preferences`, so it accretes no files and is not #1661. It
+/// is #1662: six suites wrote keys there in `setUp` and restored them in
+/// `tearDown`, which is per-suite rather than a property of the snapshot
+/// strategy, pinned a smaller set than the views read, and depended on a
+/// `tearDown` that the runs which abort (#1523), get their tree killed at 240s
+/// or run out of `--budget` never reach. Now that `PinnedSnapshotHost` supplies
+/// a store and `SessionManager` takes one, no test needs to write that domain,
+/// so the rule can be stated rather than deferred.
 ///
-/// There is deliberately **no exemption list**, for the reason
+/// READS are deliberately left alone. `UserDefaults.standard.object(forKey:)`
+/// is how a test says "and the process domain was not touched", which is the
+/// assertion that would have caught this class in the first place; banning it
+/// would ban the evidence along with the defect.
+///
+/// There is deliberately **no exemption list** for either rule, for the reason
 /// `core/architecture_hookbody_test.go` gives: a test that genuinely needs a raw
-/// suite amends this rule in a reviewable diff.
+/// suite, or a genuine write to the process domain, amends this rule in a
+/// reviewable diff.
 final class PersistentDefaultsLintTests: XCTestCase {
 
     // MARK: - The rule, as a pure function
@@ -37,6 +52,19 @@ final class PersistentDefaultsLintTests: XCTestCase {
 
     private static let pattern = "UserDefaults" + #"\s*\(\s*suiteName\s*:"#
 
+    /// The `UserDefaults.standard` mutators, longest-first so `setValue` is not
+    /// consumed by `set`. Every entry either writes the domain or names it to
+    /// `cfprefsd`; `register` is included because a registration domain is
+    /// process-wide state a later test then reads.
+    private static let mutators = [
+        "removePersistentDomain", "setPersistentDomain", "removeObject",
+        "removeSuite", "setValue", "register", "addSuite", "set"
+    ]
+
+    private static let mutationPattern =
+        "UserDefaults" + #"\s*\.\s*standard\s*\.\s*(?:"#
+        + mutators.joined(separator: "|") + #")\s*\("#
+
     private static let testTargetDirectories = ["Tests", "TestsHarness"]
 
     /// 1-based line numbers of every offending construction in `source`.
@@ -48,6 +76,16 @@ final class PersistentDefaultsLintTests: XCTestCase {
     /// and AGENTS.md's rule is that a validator which cannot parse its input
     /// checks MORE, never less. Both limits are pinned in the corpus.
     static func offendingLines(in source: String) -> [Int] {
+        lines(matching: pattern, in: source)
+    }
+
+    /// 1-based line numbers of every `UserDefaults.standard` MUTATION in
+    /// `source`. Same comment handling, same declared limits.
+    static func mutatingLines(in source: String) -> [Int] {
+        lines(matching: mutationPattern, in: source)
+    }
+
+    private static func lines(matching pattern: String, in source: String) -> [Int] {
         let code = commentsBlanked(source)
         guard let regex = try? NSRegularExpression(pattern: pattern) else { return [] }
         let text = code as NSString
@@ -128,8 +166,9 @@ final class PersistentDefaultsLintTests: XCTestCase {
             []
         ),
         (
-            "UserDefaults.standard is deliberately out of scope",
-            "UserDefaults.standard.set(true, forKey: \"k\")",
+            "a process-domain write is out of scope for THIS rule — it mints no "
+                + "new domain and no new file; the sibling rule below is what covers it",
+            "\(processDomain).set(true, forKey: \"k\")",
             []
         ),
         (
@@ -167,9 +206,121 @@ final class PersistentDefaultsLintTests: XCTestCase {
         XCTAssertFalse(Self.corpus.filter { !$0.want.isEmpty }.isEmpty, "no must-flag rows")
     }
 
+    // MARK: - Committed mutation evidence for the mutation rule (#1662)
+
+    /// Assembled the same way as `constructor`, for the same reason: a
+    /// contiguous match in this file's own source would make the rule flag its
+    /// own test data.
+    private static let processDomain = "UserDefaults" + ".standard"
+
+    /// One row per spelling, pinned to the verdict `mutatingLines` must return.
+    ///
+    /// The `want: []` rows are where the value is. `object(forKey:)` and
+    /// `string(forKey:)` are the reads a test uses to PROVE the domain was not
+    /// touched, so a rule that flagged them would ban the evidence along with
+    /// the defect; `standardDefaults.set` and a same-named method on another
+    /// receiver are the false positives a bare `.set(` rule produces; and
+    /// `InMemoryDefaults().set` is the construct every converted suite now uses.
+    private static let mutationCorpus: [(name: String, source: String, want: [Int])] = [
+        (
+            "a write to the process domain is the whole point of the rule",
+            "\(processDomain).set(false, forKey: \"showCostDisplay\")",
+            [1]
+        ),
+        (
+            "so is the removal half of a snapshot-and-restore tearDown",
+            "\(processDomain).removeObject(forKey: \"debugMode\")",
+            [1]
+        ),
+        (
+            "the KVC spelling does not evade it",
+            "\(processDomain).setValue(1, forKey: \"k\")",
+            [1]
+        ),
+        (
+            "setValue is not swallowed by the shorter `set` alternative",
+            "\(processDomain).setValue(1, forKey: \"k\")\n\(processDomain).set(1, forKey: \"k\")",
+            [1, 2]
+        ),
+        (
+            "naming a domain to cfprefsd counts, since that call schedules a write-back",
+            "\(processDomain).removePersistentDomain(forName: \"x\")",
+            [1]
+        ),
+        (
+            "register seeds process-wide state a later test reads",
+            "\(processDomain).register(defaults: [:])",
+            [1]
+        ),
+        (
+            "whitespace around the dots and the paren does not evade it",
+            "UserDefaults" + " . standard . set (true, forKey: \"k\")",
+            [1]
+        ),
+        (
+            "every occurrence is reported, not only the first",
+            "\(processDomain).set(1, forKey: \"a\")\nlet unrelated = 1\n\(processDomain).set(2, forKey: \"b\")",
+            [1, 3]
+        ),
+        (
+            "a READ is the assertion that proves the domain was untouched, and stays legal",
+            "let before = \(processDomain).object(forKey: \"summaryDisplayMode\")",
+            []
+        ),
+        (
+            "so does every other read accessor",
+            "if \(processDomain).string(forKey: \"k\") == nil { }",
+            []
+        ),
+        (
+            "the store every converted suite now writes is not the process domain",
+            "InMemoryDefaults().set(true, forKey: \"k\")",
+            []
+        ),
+        (
+            "an injected store held in a property is not the process domain either",
+            "defaults.set(80, forKey: ContextPressureThreshold.valueKey)",
+            []
+        ),
+        (
+            "a similarly named receiver is not UserDefaults.standard",
+            "standardDefaults.set(true, forKey: \"k\")",
+            []
+        ),
+        (
+            "a line comment naming the construct is documentation, not a call",
+            "// never write \(processDomain).set(...) in a test",
+            []
+        ),
+        (
+            "LIMIT: a string literal holding the construct is flagged, because a line scan cannot tell it from a call",
+            "let needle = \"\(processDomain).set(\"",
+            [1]
+        )
+    ]
+
+    func testMutationScanReturnsThePinnedVerdictForEverySpelling() {
+        for row in Self.mutationCorpus {
+            XCTAssertEqual(
+                Self.mutatingLines(in: row.source), row.want,
+                "\(row.name)\n---\n\(row.source)\n---"
+            )
+        }
+    }
+
+    /// The vacuity guard for the live mutation scan: after #1662 the construct
+    /// appears nowhere in the test targets, so "no offenders" and "the rule
+    /// stopped matching anything" are otherwise the same output.
+    func testTheMutationCorpusContainsBothVerdicts() {
+        XCTAssertFalse(Self.mutationCorpus.filter { $0.want.isEmpty }.isEmpty, "no must-not-flag rows")
+        XCTAssertFalse(Self.mutationCorpus.filter { !$0.want.isEmpty }.isEmpty, "no must-flag rows")
+    }
+
     // MARK: - The live scan
 
-    func testNoTestConstructsAPersistentUserDefaultsSuite() throws {
+    /// Walks every Swift source in the test targets, applying `rule` to each,
+    /// and returns `file:line` for every hit plus how many files were read.
+    private func scanTestTargets(_ rule: (String) -> [Int]) throws -> (offenders: [String], filesScanned: Int) {
         var offenders: [String] = []
         var filesScanned = 0
 
@@ -196,9 +347,14 @@ final class PersistentDefaultsLintTests: XCTestCase {
                 filesScanned += 1
                 let source = try String(contentsOf: url, encoding: .utf8)
                 let relative = url.path.replacingOccurrences(of: macosRoot.path + "/", with: "")
-                offenders.append(contentsOf: Self.offendingLines(in: source).map { "\(relative):\($0)" })
+                offenders.append(contentsOf: rule(source).map { "\(relative):\($0)" })
             }
         }
+        return (offenders, filesScanned)
+    }
+
+    func testNoTestConstructsAPersistentUserDefaultsSuite() throws {
+        let (offenders, filesScanned) = try scanTestTargets(Self.offendingLines(in:))
 
         XCTAssertGreaterThan(filesScanned, 0, "the scan read no Swift files — it checked nothing")
         XCTAssertEqual(
@@ -209,6 +365,26 @@ final class PersistentDefaultsLintTests: XCTestCase {
             developer's real ~/Library/Preferences that \
             `removePersistentDomain(forName:)` does not remove and that nothing \
             in this repository is allowed to delete (#1661 — 1136 of them).
+
+            \(offenders.joined(separator: "\n"))
+            """
+        )
+    }
+
+    func testNoTestMutatesTheProcessPreferenceDomain() throws {
+        let (offenders, filesScanned) = try scanTestTargets(Self.mutatingLines(in:))
+
+        XCTAssertGreaterThan(filesScanned, 0, "the scan read no Swift files — it checked nothing")
+        XCTAssertEqual(
+            offenders, [],
+            """
+            A test mutates UserDefaults.standard, which under `swift test` is \
+            the developer's real com.apple.dt.xctest.tool domain. Take an \
+            `InMemoryDefaults` instead — `PinnedSnapshotHost(…, defaults:)` for \
+            an `@AppStorage` read, `SessionManager(defaults:)` for the \
+            preferences it owns — so there is nothing to restore in a `tearDown` \
+            that an aborted run (#1523), a 240s tree kill or an exhausted \
+            `--budget` never reaches (#1662). Reads are fine.
 
             \(offenders.joined(separator: "\n"))
             """

--- a/platforms/macos/Tests/PinnedAppStorageSnapshotTests.swift
+++ b/platforms/macos/Tests/PinnedAppStorageSnapshotTests.swift
@@ -1,0 +1,325 @@
+import AppKit
+import SwiftUI
+import XCTest
+@testable import Irrlicht
+
+/// Locks the property #1662 is about: a rendered view reads the preferences it
+/// is GIVEN, not the ones the machine happens to hold — and a suite that
+/// supplies them writes nothing it has to put back.
+///
+/// ## What was wrong
+///
+/// `GroupViewSnapshotTests` and `SessionRowSnapshotTests` each read eight real
+/// `UserDefaults.standard` keys into `Any?` fields in `setUp`, overwrote them,
+/// and restored them in `tearDown`. `AdapterIconAppearanceTests` did the same
+/// for six. Under `swift test` that domain is `com.apple.dt.xctest.tool` — a
+/// persistent plist in the developer's own `~/Library/Preferences` — so the
+/// arrangement failed in three separate ways:
+///
+/// 1. It was **per-suite**, not a property of the snapshot strategy: a new
+///    suite hosting one of these views rendered under whatever the domain
+///    happened to hold. That is the complaint #1659 made about the time-zone
+///    `setUp`, one family later.
+/// 2. The pinned set was **smaller than the set the views read**. Measured on
+///    this machine, that domain also carried `advancedSettingsExpanded`,
+///    `backchannelActivation`, `menuBarStyle`, `notificationsEnabled`,
+///    `notifyOnContextPressure`, `notifyOnReady`, `notifyOnWaiting`,
+///    `projectGroupOrder` and `taskEtaActivation` — nine keys nothing pinned,
+///    one of them holding the developer's real project names.
+/// 3. A **`tearDown` is not a guarantee**. #1523 aborts the process mid-run,
+///    `tools/lib/swift-suite.sh` kills the tree at 240s and `--budget` kills
+///    the gate; none of those run a `tearDown`, so the pinned values stayed in
+///    a domain the NEXT run reads.
+///
+/// ## What replaces it
+///
+/// `PinnedSnapshotHost` applies `.defaultAppStorage(_:)` over an
+/// `InMemoryDefaults`, so every `@AppStorage` in the hosted subtree resolves
+/// through a store that touches no domain at all, and `SessionManager` takes
+/// the store it reads its own persisted preferences from. There is nothing to
+/// restore, so nothing is left behind by a run that never reaches its
+/// `tearDown` — point 3 is answered by removing the state rather than by
+/// unwinding it more carefully. The parameter is typed `InMemoryDefaults` and
+/// not `UserDefaults`, so `.standard` is not expressible at a snapshot host at
+/// all — point 1, held by the type the way the locale and time-zone pins are.
+///
+/// ## The shape of every arm here
+///
+/// The trap this suite is written around is `PinnedScaleSnapshotTests`':
+/// asserting "renders with cost hidden" is green on a machine whose domain
+/// already says so, whether the pin reached the view or not. So each arm drives
+/// **two** preference sets through one view and requires them to disagree —
+/// whatever the machine holds, at most one arm can agree with it — and
+/// everything goes through `PinnedSnapshotHost` itself rather than a hosting
+/// view assembled here, so "the host that pins" and "the host the proof was
+/// taken on" cannot be two objects that disagree.
+@MainActor
+final class PinnedAppStorageSnapshotTests: XCTestCase {
+
+    // MARK: - The pin reaches the pixels
+
+    private func costedGroup() -> SessionManager.AgentGroup {
+        SessionManager.AgentGroup(
+            name: "alpha",
+            agents: [],
+            costs: ["day": 12.34, "week": 56.78, "month": 90.12, "year": 345.67]
+        )
+    }
+
+    /// Rasterise one `GroupView` through the host the suites use, under a store
+    /// the caller has arranged.
+    ///
+    /// `store: nil` means "pass no argument", i.e. exactly what a real suite
+    /// writes when it wants isolation and nothing else.
+    private func rasterizedGroup(store: InMemoryDefaults?) -> Data {
+        let manager = SessionManager(defaults: store ?? InMemoryDefaults())
+        let group = costedGroup()
+        manager.apiGroups = [group]
+        let content = GroupView(group: group)
+            .environmentObject(manager)
+            .frame(width: 350, height: 48)
+            .background(Color(NSColor.windowBackgroundColor))
+        let host = store.map {
+            PinnedSnapshotHost(content, width: 350, height: 48, defaults: $0)
+        } ?? PinnedSnapshotHost(content, width: 350, height: 48)
+        let image = PinnedScaleSnapshot.rasterize(host.view, scale: PinnedScaleSnapshot.referenceScale)
+        // "could not rasterise" and "rasterised to the same thing" must never
+        // produce the same verdict.
+        guard let data = image.tiffRepresentation, !data.isEmpty else {
+            XCTFail("the group row rasterised to nothing — this check cannot have run")
+            return Data()
+        }
+        return data
+    }
+
+    private func store(_ pairs: [String: Any]) -> InMemoryDefaults {
+        let defaults = InMemoryDefaults()
+        for (key, value) in pairs { defaults.set(value, forKey: key) }
+        return defaults
+    }
+
+    /// The load-bearing arm, and the acceptance test #1662 asks for: two
+    /// preference sets, one view, and the renders must differ.
+    ///
+    /// This is what a reverted pin fails. Delete `.defaultAppStorage(defaults)`
+    /// from `PinnedSnapshotHost` and both renders come from
+    /// `UserDefaults.standard` — identical — which is what this refuses.
+    func testTheSameViewRendersDifferentlyUnderTwoPinnedPreferenceSets() {
+        let shown = store(["showCostDisplay": true, "projectCostTimeframe": "day"])
+        let hidden = store(["showCostDisplay": false, "projectCostTimeframe": "day"])
+
+        // Rendering must be deterministic first, or "they differ" proves
+        // nothing about the preferences.
+        XCTAssertEqual(rasterizedGroup(store: store(["showCostDisplay": true])),
+                       rasterizedGroup(store: store(["showCostDisplay": true])),
+                       "the same view rasterised twice under the same store differs — "
+                       + "the both-sides arms below are not measuring preferences")
+
+        XCTAssertNotEqual(
+            rasterizedGroup(store: shown), rasterizedGroup(store: hidden),
+            "the group row rendered identically with showCostDisplay true and false — "
+            + "the pinned store is reaching nothing, and the render is coming from "
+            + "UserDefaults.standard (showCostDisplay = "
+            + "\(String(describing: UserDefaults.standard.object(forKey: "showCostDisplay"))))")
+    }
+
+    /// A second key, chosen because it changes rendered TEXT rather than
+    /// presence: `$12.34 / day` against `$345.67 / year`. A pin that reached
+    /// only booleans would pass the arm above.
+    func testTheSameViewRendersDifferentlyUnderTwoCostTimeframes() {
+        let day = store(["showCostDisplay": true, "projectCostTimeframe": "day"])
+        let year = store(["showCostDisplay": true, "projectCostTimeframe": "year"])
+        XCTAssertNotEqual(
+            rasterizedGroup(store: day), rasterizedGroup(store: year),
+            "the group row rendered identically under projectCostTimeframe day and year")
+    }
+
+    /// …and the store a suite gets when it names none carries NOTHING from the
+    /// machine, so the arms above cannot pass while every real snapshot renders
+    /// under someone's Settings.
+    ///
+    /// Stated as an emptiness check rather than as "is not `.standard`" because
+    /// that is the property that actually matters and it fails loudly if the
+    /// parameter is ever re-typed to `UserDefaults` and defaulted to
+    /// `.standard`. The second assertion is its vacuity guard: on a hypothetical
+    /// machine whose process domain were also empty, the first would be
+    /// satisfiable by the very thing it is supposed to exclude.
+    func testTheHostsDefaultStoreCarriesNothingFromTheMachine() {
+        let host = PinnedSnapshotHost(Color.clear, width: 10, height: 10)
+        XCTAssertTrue(
+            host.defaults.dictionaryRepresentation().isEmpty,
+            "the host's default preference store is not empty — it carries "
+            + "\(host.defaults.dictionaryRepresentation().keys.sorted())")
+        XCTAssertFalse(
+            UserDefaults.standard.dictionaryRepresentation().isEmpty,
+            "UserDefaults.standard is empty in this process, so the assertion above "
+            + "cannot tell an isolated store from the process domain")
+    }
+
+    // MARK: - Every key the deleted setUps pinned, and every key they missed
+
+    /// What a hosted subtree actually read. A class so the SwiftUI value type
+    /// can write into it.
+    private final class AppStorageReport {
+        var values: [String: String] = [:]
+        var rendered = false
+    }
+
+    /// One `@AppStorage` per key named in #1662 — the eight the two snapshot
+    /// suites pinned by hand and the nine they did not — read back as strings.
+    ///
+    /// Every declaration repeats the app's own default, so a key that failed to
+    /// resolve through the pinned store reports that default rather than the
+    /// driven value, and the arm below names it.
+    private struct AppStorageProbe: View {
+        @AppStorage("showCostDisplay") private var showCostDisplay: Bool = false
+        @AppStorage("projectCostTimeframe") private var projectCostTimeframe: String = CostTimeframe.day.rawValue
+        @AppStorage("displayMode") private var displayMode: String = DisplayMode.context.rawValue
+        @AppStorage("debugMode") private var debugMode: Bool = false
+        @AppStorage("costDisplayMode") private var costDisplayMode: String = "cost"
+        @AppStorage(ContextPressureThreshold.valueKey) private var thresholdValue: Double = ContextPressureThreshold.defaultValue
+        @AppStorage(ContextPressureThreshold.unitKey) private var thresholdUnit: String = ContextPressureThreshold.defaultUnit.rawValue
+        @AppStorage("advancedSettingsExpanded") private var advancedSettingsExpanded: Bool = false
+        @AppStorage("backchannelActivation") private var backchannelActivation: Bool = false
+        @AppStorage(MenuBarStyle.storageKey) private var menuBarStyle: String = MenuBarStyle.lights.rawValue
+        @AppStorage(NotificationSettings.masterEnabledKey) private var notificationsEnabled: Bool = false
+        @AppStorage(NotificationEvent.contextPressure.enabledKey) private var notifyOnContextPressure: Bool = false
+        @AppStorage(NotificationEvent.ready.enabledKey) private var notifyOnReady: Bool = false
+        @AppStorage(NotificationEvent.waiting.enabledKey) private var notifyOnWaiting: Bool = false
+        @AppStorage("taskEtaActivation") private var taskEtaActivation: Bool = false
+
+        let report: AppStorageReport
+
+        var body: some View {
+            report.values = [
+                "showCostDisplay": String(showCostDisplay),
+                "projectCostTimeframe": projectCostTimeframe,
+                "displayMode": displayMode,
+                "debugMode": String(debugMode),
+                "costDisplayMode": costDisplayMode,
+                ContextPressureThreshold.valueKey: String(thresholdValue),
+                ContextPressureThreshold.unitKey: thresholdUnit,
+                "advancedSettingsExpanded": String(advancedSettingsExpanded),
+                "backchannelActivation": String(backchannelActivation),
+                MenuBarStyle.storageKey: menuBarStyle,
+                NotificationSettings.masterEnabledKey: String(notificationsEnabled),
+                NotificationEvent.contextPressure.enabledKey: String(notifyOnContextPressure),
+                NotificationEvent.ready.enabledKey: String(notifyOnReady),
+                NotificationEvent.waiting.enabledKey: String(notifyOnWaiting),
+                "taskEtaActivation": String(taskEtaActivation)
+            ]
+            report.rendered = true
+            return Color.clear
+        }
+    }
+
+    /// Values chosen so that every one of them differs from the app's declared
+    /// default for its key — asserted below rather than eyeballed, because a
+    /// row that accidentally matched its default would be green whether the
+    /// store reached the view or not.
+    private static let drivenValues: [String: Any] = [
+        "showCostDisplay": true,
+        "projectCostTimeframe": CostTimeframe.year.rawValue,
+        "displayMode": DisplayMode.history60s.rawValue,
+        "debugMode": true,
+        "costDisplayMode": "co2",
+        ContextPressureThreshold.valueKey: 37.0,
+        ContextPressureThreshold.unitKey: ContextPressureThreshold.Unit.tokens.rawValue,
+        "advancedSettingsExpanded": true,
+        "backchannelActivation": true,
+        MenuBarStyle.storageKey: MenuBarStyle.combined.rawValue,
+        NotificationSettings.masterEnabledKey: true,
+        NotificationEvent.contextPressure.enabledKey: true,
+        NotificationEvent.ready.enabledKey: true,
+        NotificationEvent.waiting.enabledKey: true,
+        "taskEtaActivation": true
+    ]
+
+    private func probeReport(store: InMemoryDefaults?) -> AppStorageReport {
+        let report = AppStorageReport()
+        let probe = AppStorageProbe(report: report)
+        _ = store.map { PinnedSnapshotHost(probe, width: 40, height: 40, defaults: $0) }
+            ?? PinnedSnapshotHost(probe, width: 40, height: 40)
+        return report
+    }
+
+    /// Every `@AppStorage` key #1662 names resolves through the host's store —
+    /// the eight the deleted `setUp`s pinned AND the nine they missed.
+    ///
+    /// The nine are the point. Nothing about the mechanism distinguishes them
+    /// from the eight, which is exactly why a fix that extended the hand-kept
+    /// lists would have had to name them and a fix that moves the pin onto the
+    /// type does not. This arm names them anyway, so "covered by construction"
+    /// is a measurement rather than an argument.
+    func testEveryKeyNamedInTheIssueResolvesThroughTheHostsStore() {
+        let driven = probeReport(store: store(Self.drivenValues))
+        XCTAssertTrue(driven.rendered, "the probe never rendered — this check cannot have run")
+
+        let untouched = probeReport(store: nil)
+        XCTAssertTrue(untouched.rendered, "the probe never rendered — this check cannot have run")
+
+        for key in Self.drivenValues.keys.sorted() {
+            guard let seen = driven.values[key], let fallback = untouched.values[key] else {
+                XCTFail("the probe reported nothing for \(key) — it does not read that key")
+                continue
+            }
+            // The vacuity guard, per key: a driven value equal to the app's own
+            // default would be green whether the store reached the view or not.
+            XCTAssertNotEqual(
+                seen, fallback,
+                "\(key) reads \(seen) both when driven and when unset — that row proves nothing")
+        }
+    }
+
+    // MARK: - The preferences SessionManager owns, not the views
+
+    /// `summaryDisplayMode` and `projectGroupOrder` are not `@AppStorage`;
+    /// `SessionManager` reads them itself, which is why the deleted `setUp`s
+    /// had to pin `summaryDisplayMode` in the process domain and why
+    /// `projectGroupOrder` — the key holding this developer's real project
+    /// names — was reachable at all.
+    func testSessionManagerReadsItsPersistedPreferencesFromTheStoreItIsGiven() {
+        let collapsed = store([
+            "summaryDisplayMode": SummaryDisplayMode.collapsed.rawValue,
+            "projectGroupOrder": ["gamma", "beta", "alpha"]
+        ])
+        let waiting = store([
+            "summaryDisplayMode": SummaryDisplayMode.waiting.rawValue,
+            "projectGroupOrder": ["alpha"]
+        ])
+
+        XCTAssertEqual(SessionManager(defaults: collapsed).summaryDisplayMode, .collapsed)
+        XCTAssertEqual(SessionManager(defaults: waiting).summaryDisplayMode, .waiting)
+    }
+
+    /// Building a manager over an empty store WRITES nothing into it — so the
+    /// app does not start persisting a preference the user never set, and a
+    /// suite's store stays a statement of what that suite asked for.
+    func testBuildingASessionManagerWritesNoPreference() {
+        let empty = InMemoryDefaults()
+        _ = SessionManager(defaults: empty)
+        XCTAssertNil(empty.object(forKey: "summaryDisplayMode"),
+                     "constructing a SessionManager persisted summaryDisplayMode")
+        XCTAssertNil(empty.object(forKey: "projectGroupOrder"),
+                     "constructing a SessionManager persisted projectGroupOrder")
+    }
+
+    /// The WRITE direction, and the one that makes the abort path moot: toggling
+    /// the mode on an injected manager leaves the process domain byte-for-byte
+    /// as it was, so there is nothing for a `tearDown` to put back and nothing
+    /// for an aborted run to leave behind.
+    func testTogglingTheModeLeavesTheProcessDomainUntouched() {
+        let injected = InMemoryDefaults()
+        let before = UserDefaults.standard.object(forKey: "summaryDisplayMode") as? String
+
+        let manager = SessionManager(defaults: injected)
+        manager.summaryDisplayMode = .collapsed
+
+        XCTAssertEqual(injected.string(forKey: "summaryDisplayMode"),
+                       SummaryDisplayMode.collapsed.rawValue,
+                       "the write did not reach the injected store")
+        XCTAssertEqual(UserDefaults.standard.object(forKey: "summaryDisplayMode") as? String, before,
+                       "the write reached UserDefaults.standard — the seam leaks into the "
+                       + "developer's com.apple.dt.xctest.tool domain")
+    }
+}

--- a/platforms/macos/Tests/PinnedLocaleSnapshot.swift
+++ b/platforms/macos/Tests/PinnedLocaleSnapshot.swift
@@ -163,10 +163,28 @@ extension View {
 /// classification from that same string, so such a suite loses the scale pin,
 /// the locale pin and its CI classification together, as one visible failure
 /// there.
+/// #1662 moved the **preferences** pin here for the third time, and it is the
+/// one where "a picture of the machine" was most literally true: `@AppStorage`
+/// resolves `UserDefaults.standard`, which under `swift test` is the
+/// `com.apple.dt.xctest.tool` domain — a real, persistent plist that every
+/// previous run of this suite wrote into. `GroupViewSnapshotTests` and
+/// `SessionRowSnapshotTests` each held eight of those keys open by hand in
+/// `setUp` and put them back in `tearDown`, which fails in three ways at once:
+/// it is per-suite rather than a property of the snapshot strategy, it pins a
+/// SMALLER set than the views read (nine more keys sat in that domain
+/// unpinned, one of them holding the developer's real project names), and a
+/// `tearDown` does not run for the runs that need it most — #1523 aborts the
+/// process, `swift-suite.sh` kills the tree at 240s and `--budget` kills the
+/// gate. `PinnedAppStorageSnapshotTests` grades this object.
 struct PinnedSnapshotHost {
     /// The laid-out hosting view. Read it to inspect what was rendered; pass
     /// the `PinnedSnapshotHost` itself to `assertSnapshot`.
     let view: NSView
+
+    /// The store every `@AppStorage` in the hosted subtree resolved through.
+    /// Read it to assert what a render was driven by; write to it BEFORE
+    /// constructing the host to drive a render.
+    let defaults: InMemoryDefaults
 
     /// Host `content` at a fixed size, appearance and locale.
     ///
@@ -183,17 +201,33 @@ struct PinnedSnapshotHost {
     ///     `HistoryViewSnapshotTests`' own `setUp` until this parameter
     ///     existed, which is exactly the "one suite remembers" shape the
     ///     locale pin was moved here to stop.
+    ///   - defaults: the preference store `@AppStorage` resolves through
+    ///     (#1662). Typed `InMemoryDefaults`, **not** `UserDefaults`, so
+    ///     `.standard` is not expressible here: a `.pinnedImage` snapshot
+    ///     cannot photograph the machine's preferences even by passing the
+    ///     wrong argument. The default is a fresh, empty store, so an
+    ///     unspecified key renders at the `@AppStorage` declaration's own
+    ///     default — which is what the committed references were recorded
+    ///     under, so adopting this regenerated none of them. A suite that
+    ///     forgets to pass its store gets ISOLATION and a visible failure
+    ///     ("my pinned value did not reach the view"), never a reference that
+    ///     silently encodes someone's Settings.
     init(_ content: some View,
          width: CGFloat,
          height: CGFloat,
          appearance: NSAppearance.Name = .darkAqua,
          locale: Locale = PinnedLocaleSnapshot.referenceLocale,
-         timeZone: TimeZone = PinnedTimeZoneSnapshot.referenceTimeZone) {
+         timeZone: TimeZone = PinnedTimeZoneSnapshot.referenceTimeZone,
+         defaults: InMemoryDefaults = InMemoryDefaults()) {
         let hosting = NSHostingView(
-            rootView: content.pinnedLocale(locale).pinnedTimeZone(timeZone, locale: locale))
+            rootView: content
+                .pinnedLocale(locale)
+                .pinnedTimeZone(timeZone, locale: locale)
+                .defaultAppStorage(defaults))
         hosting.appearance = NSAppearance(named: appearance)
         hosting.frame = CGRect(x: 0, y: 0, width: width, height: height)
         hosting.layoutSubtreeIfNeeded()
         self.view = hosting
+        self.defaults = defaults
     }
 }

--- a/platforms/macos/Tests/SessionManagerApiGroupsTests.swift
+++ b/platforms/macos/Tests/SessionManagerApiGroupsTests.swift
@@ -15,23 +15,21 @@ final class SessionManagerApiGroupsTests: XCTestCase {
     typealias AgentGroup = SessionManager.AgentGroup
 
     private var sut: SessionManager!
-    private var originalProjectGroupOrder: Any?
+
+    /// This suite's own preference store (#1662). `seedLocalApiGroups` →
+    /// `orderedGroups` PERSISTS `projectGroupOrder`, which under `swift test`
+    /// meant writing the developer's real `com.apple.dt.xctest.tool` domain and
+    /// putting it back in a `tearDown` the aborting runs skip — measured, that
+    /// domain was left holding this developer's actual project names. An
+    /// injected store has nothing to restore.
+    private let defaults = InMemoryDefaults()
 
     override func setUp() async throws {
         try await super.setUp()
-        // seedLocalApiGroups → orderedGroups persists projectGroupOrder to
-        // UserDefaults.standard. Snapshot + restore so the developer's real
-        // group order survives the test run (same pattern as the snapshot tests).
-        originalProjectGroupOrder = UserDefaults.standard.object(forKey: "projectGroupOrder")
-        sut = SessionManager()
+        sut = SessionManager(defaults: defaults)
     }
 
     override func tearDown() async throws {
-        if let originalProjectGroupOrder {
-            UserDefaults.standard.set(originalProjectGroupOrder, forKey: "projectGroupOrder")
-        } else {
-            UserDefaults.standard.removeObject(forKey: "projectGroupOrder")
-        }
         sut = nil
         try await super.tearDown()
     }

--- a/platforms/macos/Tests/SessionManagerCoalescingTests.swift
+++ b/platforms/macos/Tests/SessionManagerCoalescingTests.swift
@@ -17,15 +17,18 @@ final class SessionManagerCoalescingTests: XCTestCase {
     typealias AgentGroup = SessionManager.AgentGroup
 
     private var sut: SessionManager!
-    private var originalProjectGroupOrder: Any?
+
+    /// This suite's own preference store (#1662). `seedLocalApiGroups` →
+    /// `orderedGroups` PERSISTS `projectGroupOrder`, which under `swift test`
+    /// meant writing the developer's real `com.apple.dt.xctest.tool` domain and
+    /// putting it back in a `tearDown` the aborting runs skip — measured, that
+    /// domain was left holding this developer's actual project names. An
+    /// injected store has nothing to restore.
+    private let defaults = InMemoryDefaults()
 
     override func setUp() async throws {
         try await super.setUp()
-        // seedLocalApiGroups persists projectGroupOrder to UserDefaults; snapshot
-        // + restore so the developer's real order survives the run (same pattern
-        // as the apiGroups tests).
-        originalProjectGroupOrder = UserDefaults.standard.object(forKey: "projectGroupOrder")
-        sut = SessionManager()
+        sut = SessionManager(defaults: defaults)
         // Long windows so the trailing timer never fires mid-test — flushes are
         // driven explicitly via flushPendingUIRefreshForTests().
         sut.uiRefreshInterval = 1000
@@ -33,11 +36,6 @@ final class SessionManagerCoalescingTests: XCTestCase {
     }
 
     override func tearDown() async throws {
-        if let originalProjectGroupOrder {
-            UserDefaults.standard.set(originalProjectGroupOrder, forKey: "projectGroupOrder")
-        } else {
-            UserDefaults.standard.removeObject(forKey: "projectGroupOrder")
-        }
         sut = nil
         try await super.tearDown()
     }

--- a/platforms/macos/Tests/SessionRowSnapshotTests.swift
+++ b/platforms/macos/Tests/SessionRowSnapshotTests.swift
@@ -6,13 +6,25 @@ import SnapshotTesting
 @MainActor
 final class SessionRowSnapshotTests: XCTestCase {
     private var sessionManager: SessionManager!
-    private var originalDisplayMode: Any?
-    private var originalDebugMode: Any?
-    private var originalShowCost: Any?
-    private var originalThresholdValue: Any?
-    private var originalThresholdUnit: Any?
-    private var originalSummaryDisplayMode: Any?
     private var savedAgentRegistry: [String: AgentBranding] = [:]
+
+    /// This suite's own preference store (#1662). It replaces a `setUp` that
+    /// overwrote six keys in the REAL `com.apple.dt.xctest.tool` domain —
+    /// `displayMode`, `debugMode`, `showCostDisplay`, both
+    /// `ContextPressureThreshold` keys and `summaryDisplayMode` — and a
+    /// `tearDown` that put them back, which the runs that abort (#1523), get
+    /// their tree killed at 240s or run out of `--budget` never reached.
+    ///
+    /// Empty on purpose: every one of those keys resolves to the value the
+    /// deleted `setUp` was assigning. `debugMode` and `showCostDisplay` default
+    /// to `false`; `ContextPressureThreshold` defaults to 80 percent (#689);
+    /// `displayMode` defaults to `DisplayMode.context`, which is what the old
+    /// pin's lowercase `"context"` decoded to as well (it is not a valid raw
+    /// value — `DisplayMode.context.rawValue` is `"Context"` — so it fell back
+    /// to the same case); and `SessionManager` reads `summaryDisplayMode` from
+    /// this store, where absent means `.waiting`, the pre-#985 default the old
+    /// `setUp` pinned. So no reference moved.
+    private let defaults = InMemoryDefaults()
 
     override func setUp() async throws {
         try await super.setUp()
@@ -54,46 +66,12 @@ final class SessionRowSnapshotTests: XCTestCase {
             </svg>
             """
         )
-        // SessionRowView reads several keys via @AppStorage (UserDefaults.standard).
-        // Snapshot + restore so the developer's defaults survive the test run.
-        let defaults = UserDefaults.standard
-        originalDisplayMode = defaults.object(forKey: "displayMode")
-        originalDebugMode = defaults.object(forKey: "debugMode")
-        originalShowCost = defaults.object(forKey: "showCostDisplay")
-        originalThresholdValue = defaults.object(forKey: ContextPressureThreshold.valueKey)
-        originalThresholdUnit = defaults.object(forKey: ContextPressureThreshold.unitKey)
-        originalSummaryDisplayMode = defaults.object(forKey: "summaryDisplayMode")
-        defaults.set("context", forKey: "displayMode")
-        defaults.set(false, forKey: "debugMode")
-        defaults.set(false, forKey: "showCostDisplay")
-        // Pin the context-pressure threshold so the alert snapshot is independent
-        // of the developer's Settings (issue #689 made it configurable).
-        defaults.set(80, forKey: ContextPressureThreshold.valueKey)
-        defaults.set(ContextPressureThreshold.Unit.percent.rawValue, forKey: ContextPressureThreshold.unitKey)
-        // summaryDisplayMode persists (#799, mode added #985) — pin it so
-        // SessionManager's init value doesn't depend on the developer's real
-        // toggle state. "waiting" matches the pre-#985 default (not collapsed).
-        defaults.set(SummaryDisplayMode.waiting.rawValue, forKey: "summaryDisplayMode")
-        sessionManager = SessionManager()
+        sessionManager = SessionManager(defaults: defaults)
     }
 
     override func tearDown() async throws {
-        restore(key: "displayMode", value: originalDisplayMode)
-        restore(key: "debugMode", value: originalDebugMode)
-        restore(key: "showCostDisplay", value: originalShowCost)
-        restore(key: ContextPressureThreshold.valueKey, value: originalThresholdValue)
-        restore(key: ContextPressureThreshold.unitKey, value: originalThresholdUnit)
-        restore(key: "summaryDisplayMode", value: originalSummaryDisplayMode)
         AgentRegistry.byName = savedAgentRegistry
         try await super.tearDown()
-    }
-
-    private func restore(key: String, value: Any?) {
-        if let value {
-            UserDefaults.standard.set(value, forKey: key)
-        } else {
-            UserDefaults.standard.removeObject(forKey: key)
-        }
     }
 
     // A fixed, far-past instant: anything timestamped here reads as "stale" to
@@ -195,13 +173,14 @@ final class SessionRowSnapshotTests: XCTestCase {
         // current system appearance (Color(NSColor.windowBackgroundColor)
         // adapts otherwise) — most tests pin dark aqua; the light-mode pill
         // contrast tests below (issue #984) pin aqua instead. The host also
-        // pins the locale (#1630).
+        // pins the locale (#1630) and the preference store every `@AppStorage`
+        // in the subtree resolves through (#1662).
         PinnedSnapshotHost(
             view
                 .environmentObject(sessionManager)
                 .frame(width: 350, height: height)
                 .background(Color(NSColor.windowBackgroundColor)),
-            width: 350, height: height, appearance: appearance)
+            width: 350, height: height, appearance: appearance, defaults: defaults)
     }
 
     /// Decodes a daemon-shaped session fixture (issue #757). Accepts either a
@@ -322,7 +301,7 @@ final class SessionRowSnapshotTests: XCTestCase {
     }
 
     private func snapshotHistoryMode(_ mode: String, testName: String = #function) {
-        UserDefaults.standard.set(mode, forKey: "displayMode")
+        defaults.set(mode, forKey: "displayMode")
         let session = makeSession(state: .working, metrics: makeMetrics())
         sessionManager.stateHistory[session.id] = sampleHistory()
         let view = host(session)

--- a/platforms/macos/Tests/SoundPlayerTests.swift
+++ b/platforms/macos/Tests/SoundPlayerTests.swift
@@ -7,26 +7,29 @@ final class SoundPlayerTests: XCTestCase {
 
     // MARK: - resolveNotificationSound
 
+    /// The sound choice is read from a store this test owns, not from
+    /// `UserDefaults.standard` (#1662) — which under `swift test` is the
+    /// developer's real `com.apple.dt.xctest.tool` domain, and which these
+    /// three cases wrote and then cleaned up in a `defer` that #1523's aborts,
+    /// the 240s tree kill and `--budget` all skip.
     func testResolveBuiltInProducesNamedSound() throws {
-        let defaults = UserDefaults.standard
+        let defaults = InMemoryDefaults()
         let event = NotificationEvent.ready
         defaults.set(SoundChoice.chime.rawValue, forKey: event.soundKey)
-        defer { defaults.removeObject(forKey: event.soundKey) }
 
-        let sound = SessionManager.resolveNotificationSound(for: event)
+        let sound = SessionManager.resolveNotificationSound(for: event, defaults: defaults)
         XCTAssertNotNil(sound, "built-in choice should produce a UNNotificationSound")
     }
 
     func testResolveNoneAndSpeakReturnNil() {
-        let defaults = UserDefaults.standard
+        let defaults = InMemoryDefaults()
         let event = NotificationEvent.waiting
-        defer { defaults.removeObject(forKey: event.soundKey) }
 
         defaults.set(SoundChoice.none.rawValue, forKey: event.soundKey)
-        XCTAssertNil(SessionManager.resolveNotificationSound(for: event))
+        XCTAssertNil(SessionManager.resolveNotificationSound(for: event, defaults: defaults))
 
         defaults.set(SoundChoice.speak(.default).rawValue, forKey: event.soundKey)
-        XCTAssertNil(SessionManager.resolveNotificationSound(for: event))
+        XCTAssertNil(SessionManager.resolveNotificationSound(for: event, defaults: defaults))
     }
 
     // MARK: - SpokenVoice / voice(for:)
@@ -67,17 +70,16 @@ final class SoundPlayerTests: XCTestCase {
     }
 
     func testResolveMissingCustomFallsBackToPing() {
-        let defaults = UserDefaults.standard
+        let defaults = InMemoryDefaults()
         let event = NotificationEvent.contextPressure
         let missing = SoundChoice.custom(installedFilename: "IrrlichtCustom-doesnotexist.caf", displayPath: "/tmp/x.mp3")  // NOSONAR (swift:S1075) — test fixture value, not a real endpoint
         defaults.set(missing.rawValue, forKey: event.soundKey)
-        defer { defaults.removeObject(forKey: event.soundKey) }
 
         // We can't introspect UNNotificationSound's name, so the assertion is
         // limited to "produces a non-nil fallback rather than crashing or
         // returning nil." Combined with the explicit Ping branch in
         // resolveNotificationSound, this guards against the regression.
-        let sound = SessionManager.resolveNotificationSound(for: event)
+        let sound = SessionManager.resolveNotificationSound(for: event, defaults: defaults)
         XCTAssertNotNil(sound, "missing custom should fall back to Ping, not nil")
     }
 


### PR DESCRIPTION
Closes #1662.

## The seam, and why it needed no product change for the views

`@AppStorage` honours SwiftUI's own `.defaultAppStorage(_:)`. That is the
difference from the two siblings this family already closed: `format: .number`
demonstrably ignores `\.locale` (#1630) and a file-scope `DateFormatter` is
reachable from no view at all (#1659), so both of those needed a product seam.
This one did not — `PinnedSnapshotHost` applies the modifier and every
`@AppStorage` in the hosted subtree resolves through the store it is given.
Not a single view file changed.

Three decisions inside that:

- **The parameter is typed `InMemoryDefaults`, not `UserDefaults`.** `.standard`
  is therefore not expressible at a snapshot host — a `.pinnedImage` snapshot
  cannot photograph the machine's preferences even by passing the wrong
  argument. Same trade as `Snapshotting.pinnedImage` being declared over
  `PinnedSnapshotHost`: a type rather than a modifier plus a guard.
- **The default is an EMPTY store**, which is what made adoption free. An unset
  key renders at the `@AppStorage` declaration's own default, and that is
  exactly what the deleted `setUp`s were assigning (`false`, `CostTimeframe.day`,
  80 percent, `DisplayMode.context` — the old lowercase `"context"` pin was not
  even a valid raw value and fell back to the same case). **All 53 committed
  references still match byte-for-byte; none was regenerated.** That untouched
  set is the same evidence #1630 and #1659 used.
- **Forgetting to pass a store fails in the safe direction.** A suite that omits
  it gets isolation plus a visible failure ("my pinned value did not reach the
  view"), never a reference that silently encodes someone's Settings.

Two keys did need a seam, because they are not `@AppStorage` and no environment
reaches them: `SessionManager` reads `summaryDisplayMode` and `projectGroupOrder`
itself, so `SessionManager.init` takes the store it reads them from, defaulting
to `.standard`. `projectGroupOrder` is the key the issue notes was holding this
developer's real project names.

Converted along the way, because they are the same defect through the same
domain: `AdapterIconAppearanceTests` (six keys; it now hosts through
`PinnedSnapshotHost` rather than a hand-rolled `NSHostingView`, so it inherits
the preference pin the way it already inherits the appearance one),
`SessionManagerApiGroupsTests`, `SessionManagerCoalescingTests` and
`SoundPlayerTests`.

### One trap, found by the change's own test rather than in review

**`didSet` DOES fire for a write in the second phase of a base class's own
`init`.** The first draft seeded `summaryDisplayMode` from the store in `init`
and the observer wrote it straight back — in the app, that persists a preference
into the user's real `io.irrlicht.app` domain that they never set. Caught by
`testBuildingASessionManagerWritesNoPreference` on its first run:

```
PinnedAppStorageSnapshotTests.swift:301: XCTAssertNil failed: "waiting"
  - constructing a SessionManager persisted summaryDisplayMode
```

The seed now goes through the `@Published` storage
(`self._summaryDisplayMode = Published(initialValue:)`), which the observer does
not see.

## How the abort path is handled

By **removing the state, not unwinding it more carefully**. `tearDown` is
skipped by exactly the runs that fail — #1523 `abort()`s the process,
`swift-suite.sh` kills the tree at 240s, `--budget` kills the gate — so a fix
that made the save/restore more careful would have addressed nothing the issue
reports. Nothing is written now: the host's store is in-memory (`InMemoryDefaults`
from #1668 overrides every mutating entry point), and `SessionManager`'s writes
go to the store it was handed. There is no restore step in any of the six
converted suites, so there is nothing a skipped `tearDown` can fail to do.

The structural half is a second rule in `PersistentDefaultsLintTests`: the build
fails on any `UserDefaults.standard` **mutation** in the test targets, so a suite
written next year cannot re-grow the hand-pin. That file previously called this
"a different problem with a different fix", correctly — it is #1662, not #1661 —
and the deferral is now closed rather than restated. **Reads are deliberately
still legal**: `object(forKey:)` is how a test says "and the process domain was
not touched", which is the assertion that would have caught this class in the
first place; banning it would ban the evidence along with the defect. No
exemption list, for the reason `architecture_hookbody_test.go` gives.

## The premise, re-verified rather than inherited

The issue's severe reading is **still not real**, measured on this machine
rather than taken on trust:

```
$ defaults read com.apple.dt.xctest.tool     # the domain a swift test writes
{ advancedSettingsExpanded = 1; menuBarStyle = combined; notificationsEnabled = 1;
  projectGroupOrder = ( besenkammer, irrlicht, interplay ); … }
$ plutil -p ~/Library/Preferences/io.irrlicht.app.plist   # the app's own domain
```

`io.irrlicht.app.plist` was `mtime 1786917158, 104 bytes` before the work and
`mtime 1786917158, 104 bytes` after two full `tools/preflight.sh --only swift`
runs — byte- and mtime-identical. So this was fixture fragility, as filed.

But the **fragility half is not hypothetical**, and that is what the issue could
not establish. With the pin deleted (mutation A below), the probe reads
`menuBarStyle = combined`, `notificationsEnabled = true`,
`advancedSettingsExpanded = true` straight off this machine. The nine unpinned
keys the issue names were live inputs to a render, not a worry about one.

## Mutation evidence

Everything this change adds passes by construction, so each was broken
deliberately and seen red. One mutation per run, applied and reverted by
copy-aside/copy-back with a `git status --porcelain` assertion afterwards.

| # | Mutation | Result |
|---|---|---|
| A | delete `.defaultAppStorage(defaults)` from `PinnedSnapshotHost` | RED — every one of the 15 keys reports `reads X both when driven and when unset`, and the values it reads are this machine's |
| B | `SessionManager` seeds `summaryDisplayMode` from `UserDefaults.standard` again | RED — `("waiting") is not equal to ("collapsed")` |
| C | seed one key into the host's default store | RED — `the host's default preference store is not empty — it carries ["smuggledFromTheMachine"]` |
| D | `summaryDisplayMode`'s `didSet` no longer writes | RED — `the write did not reach the injected store` |
| E | plant `UserDefaults.standard.set(…)` in an uncalled helper in `SoundChoiceTests` | RED — live scan reports `Tests/SoundChoiceTests.swift:61` |
| — | (not a planted mutation) the new live scan's first run | RED on real tree content — `Tests/PersistentDefaultsLintTests.swift:170`, the pre-existing corpus row, now assembled like every other |
| — | (not a planted mutation) `testBuildingASessionManagerWritesNoPreference`'s first run | RED — see the trap above |

Both lint rules also carry committed corpus rows pinning **both** verdicts, and
the `want: []` rows are where the value is: reads, `InMemoryDefaults().set`, an
injected `defaults.set`, and a similarly-named receiver must all stay unflagged,
plus the declared line-scan LIMIT (a string literal is flagged).

**One assertion was deliberately NOT reddened.** The second half of D — "the
write reached `UserDefaults.standard`" — can only be driven by pointing the
persist path at the real `com.apple.dt.xctest.tool` domain and writing
`summaryDisplayMode = collapsed` into it. That is an overwrite in the user's
real home, which this repository does not do on purpose after #1661, so it was
described rather than run. The half that was run proves the arm reaches the
write path at all.

## Before/after counts under the real home

| | before | after |
|---|---|---|
| `~/Library/Preferences` entries | 130 | 134 |
| `~/Library/Sounds` entries | 2 | 2 |
| `~/Library/Application Support/Irrlicht` entries | 18 | 18 |
| `io.irrlicht.app.plist` | mtime 1786917158, 104 B | mtime 1786917158, 104 B |

The four added `Preferences` entries are `com.apple.AdPlatforms`,
`com.apple.AvatarUI.Staryu`, `com.apple.photos.shareddefaults` and
`com.apple.textInput.keyboardServices.textReplacement` — unrelated Apple
background plists, which is the noise profile AGENTS.md already records for a
long window of interactive use. **Nothing this work produced added a file**, and
`swift-suite.sh`'s own witness agreed on both gate runs: `real-home witness: no
new entries in Library/Preferences Library/Sounds under /Users/ingo`. The
`Preferences` listing was byte-identical across both full gate runs.

## Gates

- `tools/preflight.sh --only swift` — **PASS**, exit status read directly
  (redirected to a file, `$?` on the next line), twice: once mid-work and once
  on the final restored tree. 370 tests, 0 failures. Per #1523 the exit code is
  the signal, not the totals line — both runs agree.
- `tools/preflight.sh --only tools` — **not run, and not owed**: this diff
  touches nothing under `tools/` (`git diff --stat` is `AGENTS.md` plus
  `platforms/macos/**`).
- The pre-push hook ran `--changed`: `gofmt` PASS, `macOS Swift build + test`
  PASS, everything else correctly SKIP for a macOS-only diff.
- CodeScene / ARS are advisory per AGENTS.md and were not chased.

## New defect filed

#1672 — two sound keys (`soundOnReady = funk`, `soundOnContextPressure = sosumi`)
still appear in the real `com.apple.dt.xctest.tool` domain across a full gate
run, written through a **production** call site that no test source names, so
the new source-level lint cannot see it. The two obvious candidates are ruled
out with evidence in that issue; which call site does it, and whether it
predates this branch, are both marked unproven.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
