### PR TITLE
fix(macos): close the wall clock that picks formatResetTime's format string (#1663)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1521,9 +1521,11 @@ Before marking a ticket done, run the full suite — every layer must pass:
   family NOT read off the committed set, because no reference contains a
   wall-clock-dependent render; #1663 regenerated no PNG and the untouched 53 are
   the evidence.
-  **The blast radius is two call sites, deliberately** — the two functions #1663
-  names, not the app-wide clock injection it defers. Three further wall-clock
-  reads on the same chip stay unconverted (`quotaPacePercent`,
+  **The blast radius is ONE call site, deliberately** — `QuotaResetLabel`, not
+  the app-wide clock injection #1663 defers. (The other function that issue names,
+  `formatClockTime`, never read a clock: its two machine reads were the
+  formatter's unset locale and zone, closed by the existing two seams.) Three
+  further wall-clock reads on the same chip stay unconverted (`quotaPacePercent`,
   `mergeIntoBuckets`' staleness test, `formatTimeUntil`), and the first two are
   pixel-visible, so the `rate_limit` fixture #1663 anticipates is still not safe
   to seed: that is #1675, filed rather than folded in.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1478,10 +1478,56 @@ Before marking a ticket done, run the full suite — every layer must pass:
   along with the defect. What that rule cannot see is a production call site a
   test drives — measured, two sound keys still reach that domain across a full
   gate run and no test source names the write (#1672).
-  Still open in this family, with its evidence in the issue rather than
-  asserted here: `SessionListView.formatResetTime` (#1663 — a timezone pin
-  reaches two of its three machine reads and leaves the `Date()` that picks the
-  format string, so it was left whole rather than half-covered). And no, a test
+  **The fourth member is the WALL CLOCK, and it is the one where pinning the
+  other three would have looked like coverage** (#1663).
+  `SessionListView.formatResetTime` stacked four machine reads —
+  `Calendar.current`, `Date()`, and a `DateFormatter` with neither `locale` nor
+  `timeZone` — and #1659 left it whole rather than half-covering it, because
+  `Date()` there does not shift a rendered time, it **selects the format
+  string**: the same input renders `"09:00"` before midnight and `"Fr. 9:00"`
+  after. The seam is `\.formatNow` (`Irrlicht/Views/FormatNowEnvironment.swift`),
+  the formatting moved to `QuotaResetFormat` where all four values are REQUIRED
+  arguments (#1659's shape), and `PinnedSnapshotHost` gained a `now:` whose
+  default is a fixed instant, on #1662's polarity. Five things are worth
+  carrying.
+  **The distinction between the two halves is measured, not argued**: putting
+  `Date()` back at the call site leaves EVERY string assertion in
+  `PinnedNowSnapshotTests` green and reddens exactly one arm, the two-clock byte
+  comparison — the same "only the rendered assertion catches it" shape #1630's
+  mutation B and #1659's had, one family on.
+  **The key carries a closure, not a `Date`**, which is not the obvious mirror
+  of `\.formatTimeZone`'s computed `NSTimeZone.default` default: a computed
+  `Date()` default is a value never equal to itself, where that one is stable
+  between assignments, and a fixture wants ONE instant per subtree rather than a
+  fresh one per read (the microsecond-disagreement hazard `quotaWindowRow`
+  already documents for `quotaPacePercent`). `FormatNow.wallClock` is a single
+  stored value and `FormatNow(fixed:)` is the stopped form.
+  **`Calendar.current` was closed by taking `\.calendar`, not by forcing
+  `.gregorian`** — that key already existed, already defaults to
+  `Calendar.current`, and has been pinned by the host since #1659 — so a user on
+  a Japanese or Buddhist calendar keeps theirs. What IS forced is the calendar's
+  ZONE, to the zone the formatter renders in, so the day the branch is decided
+  in and the day the string is rendered in cannot disagree; that line is
+  load-bearing (removing it reddens four arms) while the identity provably is
+  not (measured across all 16 Foundation identifiers at a fixed zone, zero
+  disagreements, asserted rather than assumed — which is what justifies there
+  being no both-sides pixel arm for the calendar).
+  **A pin alone would have been untested by construction**, since #1663 verified
+  the site is reached by no committed reference. The row's `Text` is therefore
+  extracted into `QuotaResetLabel`, a view a test can host: an `@Environment`
+  read off a `SessionListView` value a test constructed itself, outside a view
+  update, answers the DEFAULT — a pin reaching nothing wearing the shape of a
+  passing test. `PinnedNowSnapshot.referenceNow` is the one constant in this
+  family NOT read off the committed set, because no reference contains a
+  wall-clock-dependent render; #1663 regenerated no PNG and the untouched 53 are
+  the evidence.
+  **The blast radius is two call sites, deliberately** — the two functions #1663
+  names, not the app-wide clock injection it defers. Three further wall-clock
+  reads on the same chip stay unconverted (`quotaPacePercent`,
+  `mergeIntoBuckets`' staleness test, `formatTimeUntil`), and the first two are
+  pixel-visible, so the `rate_limit` fixture #1663 anticipates is still not safe
+  to seed: that is #1675, filed rather than folded in.
+  And no, a test
   run does not modify the user's real app preferences:
   `UserDefaults.standard` under `swift test` resolves to
   `com.apple.dt.xctest.tool`, measured again across two full gate runs against a

--- a/platforms/macos/Irrlicht/Views/FormatNowEnvironment.swift
+++ b/platforms/macos/Irrlicht/Views/FormatNowEnvironment.swift
@@ -1,0 +1,104 @@
+import SwiftUI
+
+/// The wall clock date-dependent rendering resolves "now" through (#1663).
+///
+/// ## Why this exists at all
+///
+/// It is the third member of `SessionListView.formatResetTime`'s machine
+/// reads, and the only one where pinning the other two would have made the
+/// site *look* covered:
+///
+///     let cal = Calendar.current          // machine
+///     let now = Date()                    // wall clock  ← this key
+///     let f = DateFormatter()             // locale + timeZone both unpinned
+///     if cal.isDate(date, inSameDayAs: now) { … } else { f.dateFormat = "EEE H:mm" }
+///
+/// `\.formatTimeZone` (#1659) and `\.formatLocale` (#1630) reach the formatter.
+/// They do not reach the `if`. `Date()` there does not merely shift the
+/// rendered time — it selects a different **format string**, so one input
+/// renders `"9:00"` before midnight and `"Fri 9:00"` after. A reference PNG
+/// pinned on zone and locale alone is still a picture of the day it was
+/// recorded, and it fails for everybody — including the machine that recorded
+/// it — the next morning. That is why #1659 left this site whole rather than
+/// half-covering it.
+///
+/// ## Why the default costs the app nothing
+///
+/// `FormatNow.wallClock` calls `Date()` at the point of use, inside `body`,
+/// which is where the call sites called it before. So the shipping app reads
+/// the same clock at the same moment; the seam is invisible until something
+/// sets the key, and nothing in the app does.
+/// `PinnedNowSnapshotTests.testTheDefaultIsIndistinguishableFromTheWallClockItReplaced`
+/// asserts that rather than leaving it as a claim.
+///
+/// ## Why a closure and not a `Date`
+///
+/// Two reasons, and the second is the load-bearing one.
+///
+/// A `Date` whose `EnvironmentKey.defaultValue` is the computed `Date()` is a
+/// value that is **never equal to itself**. That is the obvious mirror of
+/// `\.formatTimeZone`'s computed `NSTimeZone.default` default and it is not the
+/// same thing: that one is stable between assignments, this one changes at
+/// every read, and SwiftUI compares environment values it has handed out.
+/// `FormatNow.wallClock` is a single stored value, so the environment a view
+/// sees is byte-identical from render to render exactly as it was before this
+/// key existed.
+///
+/// And a fixture wants ONE instant, not a fresh one per read: two reads of a
+/// computed-`Date` default inside one `body` disagree by microseconds, which is
+/// the hazard `SessionListView.quotaWindowRow` already documents for
+/// `quotaPacePercent`. `FormatNow(fixed:)` returns the same instant however
+/// many times the subtree asks, which is what makes the same-day branch
+/// decidable from a fixture at all.
+///
+/// ## Blast radius — deliberately two call sites, not an app-wide clock
+///
+/// #1663 says an injectable clock across every wall-clock read in the app is a
+/// separate, wider change, and this is not it. Exactly two call sites read this
+/// key: `QuotaResetLabel` (the `"resets …"` text) and `SessionListView`'s quota
+/// tooltip, i.e. the two functions #1663 names. Everything else in
+/// `SessionListView` that touches the wall clock still touches it directly —
+/// `quotaPacePercent`, `formatTimeUntil`, and `mergeIntoBuckets`' staleness
+/// test — because none of those SELECTS A FORMAT, which is the property that
+/// made this one impossible to close from the test side. Two of the three are
+/// pixel-visible — the pace marker's position and the stale chip's opacity — so
+/// they are a real obstacle to the rate-limit snapshot fixture #1663
+/// anticipates, and they are filed as #1675 rather than folded in here.
+struct FormatNow {
+    private let read: () -> Date
+
+    /// A clock that answers with whatever `read` returns.
+    init(_ read: @escaping () -> Date) { self.read = read }
+
+    /// A clock stopped at `instant` — the fixture form. Every read in the
+    /// subtree answers the same instant, so a rendering is a function of its
+    /// inputs.
+    init(fixed instant: Date) { self.init { instant } }
+
+    /// Read the clock. Spelled as a call (`formatNow()`) rather than a
+    /// property so the wall-clock read is visible at the site that performs
+    /// it, the way `Date()` was.
+    func callAsFunction() -> Date { read() }
+
+    /// The system wall clock: `Date()`, evaluated per read. By construction
+    /// what the call sites this key replaced already did.
+    static let wallClock = FormatNow { Date() }
+}
+
+private struct FormatNowKey: EnvironmentKey {
+    /// The clock the code this key replaced already read. Overriding it is a
+    /// deliberate act; nothing in the app does it, and the snapshot host does.
+    static let defaultValue = FormatNow.wallClock
+}
+
+extension EnvironmentValues {
+    /// The clock date rendering in this subtree resolves "now" from.
+    ///
+    /// Read it and call it (`QuotaResetFormat.resetLabel(d, now: formatNow(), …)`) —
+    /// like `\.formatTimeZone` and `\.formatLocale`, nothing consults this
+    /// implicitly.
+    var formatNow: FormatNow {
+        get { self[FormatNowKey.self] }
+        set { self[FormatNowKey.self] = newValue }
+    }
+}

--- a/platforms/macos/Irrlicht/Views/FormatNowEnvironment.swift
+++ b/platforms/macos/Irrlicht/Views/FormatNowEnvironment.swift
@@ -54,9 +54,12 @@ import SwiftUI
 /// ## Blast radius — deliberately two call sites, not an app-wide clock
 ///
 /// #1663 says an injectable clock across every wall-clock read in the app is a
-/// separate, wider change, and this is not it. Exactly two call sites read this
-/// key: `QuotaResetLabel` (the `"resets …"` text) and `SessionListView`'s quota
-/// tooltip, i.e. the two functions #1663 names. Everything else in
+/// separate, wider change, and this is not it. **Exactly one call site reads
+/// this key**: `QuotaResetLabel`, the `"resets …"` text. The other function
+/// #1663 names, `formatClockTime` behind the quota tooltip, never read a clock
+/// at all — it had two machine reads, its formatter's unset `locale` and
+/// `timeZone`, so `\.formatTimeZone` and `\.formatLocale` close it entirely and
+/// `QuotaResetFormat.clock` takes no `now`. Everything else in
 /// `SessionListView` that touches the wall clock still touches it directly —
 /// `quotaPacePercent`, `formatTimeUntil`, and `mergeIntoBuckets`' staleness
 /// test — because none of those SELECTS A FORMAT, which is the property that

--- a/platforms/macos/Irrlicht/Views/QuotaResetFormat.swift
+++ b/platforms/macos/Irrlicht/Views/QuotaResetFormat.swift
@@ -1,0 +1,115 @@
+import SwiftUI
+
+/// The quota chip's two date renderings, as pure functions of their inputs
+/// (#1663).
+///
+/// These were `SessionListView.formatResetTime` and `.formatClockTime`, two
+/// `private func`s that between them stacked four machine reads:
+/// `Calendar.current`, a wall-clock `Date()`, and a `DateFormatter` with
+/// neither `locale` nor `timeZone` set. Every one of them is now a **required
+/// argument**, which is #1659's shape for the same problem: a call site with
+/// nothing to pass is `error: missing argument for parameter 'now' in call`
+/// rather than another silent read of the machine.
+///
+/// The views get theirs from the environment — `\.formatNow` (#1663),
+/// `\.calendar` (SwiftUI's own, default `Calendar.current`), `\.formatTimeZone`
+/// (#1659, default `NSTimeZone.default`) and `\.formatLocale` (#1630, default
+/// `Locale.autoupdatingCurrent`). Each of those defaults is, by construction,
+/// what the unpinned spelling already resolved through, so no user sees a
+/// different string; `PinnedNowSnapshotTests` asserts that against a verbatim
+/// copy of the code these replaced rather than against a description of it.
+///
+/// Deliberately **not** cached, unlike `HistoryFormat`'s formatters. The code
+/// this replaced built a fresh `DateFormatter` per call, so keeping that keeps
+/// the change to what #1663 is about; a cache keyed by fewer axes than the
+/// function takes is also exactly the hazard #1659 records.
+enum QuotaResetFormat {
+
+    /// Short clock time — the quota tooltip's "Projected cap: …" line.
+    ///
+    /// Was `SessionListView.formatClockTime`, whose `DateFormatter` set
+    /// neither `locale` nor `timeZone`.
+    static func clock(_ date: Date, timeZone: TimeZone, locale: Locale) -> String {
+        let f = DateFormatter()
+        f.locale = locale
+        f.timeZone = timeZone
+        f.dateStyle = .none
+        f.timeStyle = .short
+        return f.string(from: date)
+    }
+
+    /// Compact reset label for the chip row. A reset on the same day as `now`
+    /// renders as short clock time ("11:14"); a reset on any other day renders
+    /// as "EEE H:mm" ("Fri 9:00"). Mirrors mockup 1's two spellings.
+    ///
+    /// Was `SessionListView.formatResetTime`. `now` is the argument #1663
+    /// exists for: it does not shift the rendered time, it picks which of the
+    /// two format strings above is used, so a site that reads it from the wall
+    /// clock cannot be photographed by a snapshot on one day and compared on
+    /// the next.
+    ///
+    /// `calendar` contributes its identity and week rules only — its **time
+    /// zone is overridden** with `timeZone`, so the day the branch is decided
+    /// in and the day the string is rendered in cannot disagree. That is not a
+    /// user-visible change: `Calendar.current.timeZone` and `NSTimeZone.default`
+    /// (the two arguments' respective defaults) are the same zone on any
+    /// process that does not assign the latter, and nothing in the app does.
+    /// It is also why there is no both-sides pixel arm for the calendar in
+    /// `PinnedNowSnapshotTests`: with the zone forced, the identifier does not
+    /// decide the branch — which that suite asserts across Foundation's
+    /// calendars rather than assuming.
+    static func resetLabel(_ date: Date,
+                           now: Date,
+                           calendar: Calendar,
+                           timeZone: TimeZone,
+                           locale: Locale) -> String {
+        var cal = calendar
+        cal.timeZone = timeZone
+
+        let f = DateFormatter()
+        f.locale = locale
+        f.timeZone = timeZone
+        if cal.isDate(date, inSameDayAs: now) {
+            f.dateStyle = .none
+            f.timeStyle = .short
+        } else {
+            f.dateFormat = "EEE H:mm"
+        }
+        return f.string(from: date)
+    }
+}
+
+/// The `"resets …"` text of one quota window row.
+///
+/// A view of its own, rather than a `Text` inline in
+/// `SessionListView.quotaWindowRow`, for one reason: it is the only way this
+/// site can be rendered by a test. `quotaWindowRow` is a method on
+/// `SessionListView`, so reaching it means hosting the whole panel with its
+/// three environment objects and a `SessionState` carrying a rate-limit
+/// snapshot — and an `@Environment` read from a `SessionListView` value a test
+/// constructed itself, outside a view update, answers the DEFAULT, which is a
+/// pin that reaches nothing wearing the shape of a passing test.
+///
+/// Hosted directly, its four environment reads resolve the way they do in the
+/// app, so `PinnedNowSnapshotTests` can drive two values through one view per
+/// axis and watch the pixels move.
+///
+/// The modifiers are the ones this text carried inline; no geometry changed,
+/// and no committed reference renders this site at all (#1663 verified that,
+/// and the 53-PNG set is unchanged by this extraction).
+struct QuotaResetLabel: View {
+    let resetsAt: Date
+
+    @Environment(\.formatNow) private var formatNow
+    @Environment(\.calendar) private var calendar
+    @Environment(\.formatTimeZone) private var formatTimeZone
+    @Environment(\.formatLocale) private var formatLocale
+
+    var body: some View {
+        Text("resets \(QuotaResetFormat.resetLabel(resetsAt, now: formatNow(), calendar: calendar, timeZone: formatTimeZone, locale: formatLocale))")
+            .font(.system(size: 9, design: .monospaced))
+            .foregroundColor(.secondary)
+            .lineLimit(1)
+            .truncationMode(.tail)
+    }
+}

--- a/platforms/macos/Irrlicht/Views/SessionListView.swift
+++ b/platforms/macos/Irrlicht/Views/SessionListView.swift
@@ -212,6 +212,12 @@ struct SessionListView: View {
     // re-tints it as a template — but the variant is the view's to pick,
     // never the process's (#1509).
     @Environment(\.colorScheme) private var colorScheme
+    /// The zone and locale the quota tooltip's clock renders in (#1663).
+    /// Defaults are `NSTimeZone.default` / `Locale.autoupdatingCurrent`, which
+    /// is exactly what the unset `DateFormatter` this replaced resolved
+    /// through — see `QuotaResetFormat`.
+    @Environment(\.formatTimeZone) private var formatTimeZone
+    @Environment(\.formatLocale) private var formatLocale
     @EnvironmentObject var gasTownProvider: GasTownProvider
     @EnvironmentObject var updateManager: UpdateManager
     @State private var isQuitButtonHovered = false
@@ -899,11 +905,10 @@ struct SessionListView: View {
                 .frame(width: 28, alignment: .trailing)
 
             if !compact {
-                Text("resets \(formatResetTime(w.resetsAt))")
-                    .font(.system(size: 9, design: .monospaced))
-                    .foregroundColor(.secondary)
-                    .lineLimit(1)
-                    .truncationMode(.tail)
+                // A view of its own since #1663 — see `QuotaResetLabel`, which
+                // reads the four values this rendering used to take off the
+                // machine (now, calendar, zone, locale) from the environment.
+                QuotaResetLabel(resetsAt: w.resetsAt)
             }
         }
     }
@@ -1117,41 +1122,22 @@ struct SessionListView: View {
         }
     }
 
-    // #1663 — these two are the timezone family's third site, and #1659
-    // deliberately left them alone rather than half-covering them. Threading
-    // `\.formatTimeZone` / `\.formatLocale` in (as `HistoryFormat` now does)
-    // would reach two of `formatResetTime`'s three machine reads and leave the
-    // one that matters most: `Date()` below selects a different FORMAT STRING
-    // either side of midnight, so a snapshot pinned on zone and locale alone is
-    // still a snapshot of the day it was recorded. That needs an injectable
-    // "now", which is a wider seam than this issue.
-    //
-    // Unreached by any committed reference today — the whole chain is behind
-    // `guard let snap = session.metrics?.rateLimit` (:705) and no fixture under
-    // Tests/Fixtures carries a rate-limit window (verified by grep, both files).
-    // The first fixture that seeds one bakes locale, timezone and the recording
-    // day into a reference at once; read #1663 before adding it.
+    /// Short clock time for the quota tooltip's "Projected cap" line.
+    ///
+    /// #1663 moved the formatting itself into `QuotaResetFormat`, where the
+    /// zone and locale it renders in are required arguments rather than two
+    /// more reads of the machine. This wrapper is what supplies them, from the
+    /// environment; it stays a method on the view because reading
+    /// `@Environment` is only meaningful on a value SwiftUI is updating, and
+    /// `quotaTooltip` is called from `body`.
+    ///
+    /// The tooltip is graded at the formatter and not in pixels, for the reason
+    /// #1659 recorded for `HistoryActivityContentView.tooltipText`: `.tooltip(…)`
+    /// is an `onHover`-only AppKit bridge that draws into a separate `NSPanel`
+    /// and adds nothing to the view tree, so there is nothing for a render test
+    /// to read back.
     private func formatClockTime(_ date: Date) -> String {
-        let f = DateFormatter()
-        f.dateStyle = .none
-        f.timeStyle = .short
-        return f.string(from: date)
-    }
-
-    /// Compact reset label for the chip row. Same-day resets render as
-    /// "HH:MM"; resets later in the week render as "EEE HH:MM" (e.g.
-    /// "Fri 9:00"). Mirrors mockup 1's "resets 11:14" / "resets Fri 9:00".
-    private func formatResetTime(_ date: Date) -> String {
-        let cal = Calendar.current
-        let now = Date()
-        let f = DateFormatter()
-        if cal.isDate(date, inSameDayAs: now) {
-            f.dateStyle = .none
-            f.timeStyle = .short
-        } else {
-            f.dateFormat = "EEE H:mm"
-        }
-        return f.string(from: date)
+        QuotaResetFormat.clock(date, timeZone: formatTimeZone, locale: formatLocale)
     }
 
     private func formatTimeUntil(_ date: Date) -> String {

--- a/platforms/macos/Tests/PinnedLocaleSnapshot.swift
+++ b/platforms/macos/Tests/PinnedLocaleSnapshot.swift
@@ -127,6 +127,24 @@ extension View {
             .environment(\.calendar, calendar)
             .environment(\.timeZone, timeZone)
     }
+
+    /// Stop the clock this subtree renders dates against, for a snapshot host
+    /// (#1663).
+    ///
+    /// The fourth value in this family that a reference was reading off the
+    /// machine, and the one whose failure is loudest: `Date()` inside
+    /// `SessionListView.formatResetTime` did not shift a rendered time, it
+    /// chose between `"9:00"` and `"Fri 9:00"`, so a reference recorded on one
+    /// side of midnight fails on the other — on the recording machine too.
+    ///
+    /// One environment, not three: unlike the time zone, nothing else in
+    /// SwiftUI carries a "now" a view could read instead. `\.formatNow` is the
+    /// only key `QuotaResetFormat`'s callers consult, and
+    /// `PinnedNowSnapshotTests.testTheHostStopsTheClockItIsGiven` grades that
+    /// on this object rather than on a hierarchy it assembled itself.
+    fileprivate func pinnedNow(_ instant: Date) -> some View {
+        environment(\.formatNow, FormatNow(fixed: instant))
+    }
 }
 
 /// The rasterisable host a `.pinnedImage` snapshot is taken of — and the only
@@ -212,18 +230,26 @@ struct PinnedSnapshotHost {
     ///     forgets to pass its store gets ISOLATION and a visible failure
     ///     ("my pinned value did not reach the view"), never a reference that
     ///     silently encodes someone's Settings.
+    ///   - now: the instant `\.formatNow` answers with (#1663). Its default is
+    ///     a fixed one rather than the wall clock, for #1662's polarity
+    ///     reason: a suite that names none gets DETERMINISM, never a reference
+    ///     that photographs the day it was recorded. Unconstrained by the
+    ///     committed set — no reference renders a wall-clock-dependent site
+    ///     today — so adopting it regenerated none of them.
     init(_ content: some View,
          width: CGFloat,
          height: CGFloat,
          appearance: NSAppearance.Name = .darkAqua,
          locale: Locale = PinnedLocaleSnapshot.referenceLocale,
          timeZone: TimeZone = PinnedTimeZoneSnapshot.referenceTimeZone,
-         defaults: InMemoryDefaults = InMemoryDefaults()) {
+         defaults: InMemoryDefaults = InMemoryDefaults(),
+         now: Date = PinnedNowSnapshot.referenceNow) {
         let hosting = NSHostingView(
             rootView: content
                 .pinnedLocale(locale)
                 .pinnedTimeZone(timeZone, locale: locale)
-                .defaultAppStorage(defaults))
+                .defaultAppStorage(defaults)
+                .pinnedNow(now))
         hosting.appearance = NSAppearance(named: appearance)
         hosting.frame = CGRect(x: 0, y: 0, width: width, height: height)
         hosting.layoutSubtreeIfNeeded()

--- a/platforms/macos/Tests/PinnedNowSnapshot.swift
+++ b/platforms/macos/Tests/PinnedNowSnapshot.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+/// The instant every image snapshot renders "now" as, so a committed reference
+/// is a picture of the VIEW and not of the DAY it was recorded (#1663).
+///
+/// ## What this is protecting against
+///
+/// `SessionListView.formatResetTime` picked its format string from `Date()`:
+/// the same reset renders `"9:00"` before midnight and `"Fri 9:00"` after. The
+/// scale (#1530), the locale (#1630), the time zone (#1659) and the preference
+/// store (#1662) were all values read from the MACHINE where they were
+/// available from the INPUT; this is the same shape with a sharper edge,
+/// because it fails on the recording machine itself the next morning rather
+/// than only on somebody else's.
+///
+/// ## Why the value is free to choose, unlike the other four
+///
+/// `referenceScale`, `referenceLocale` and `referenceTimeZone` are all "what
+/// the committed references were recorded under", because adopting a different
+/// value would have re-recorded a PNG — the move `AGENTS.md` names as the one
+/// #1034 and #1044 both got wrong. Nothing constrains this one, because **no
+/// committed reference contains a wall-clock-dependent rendering**: the only
+/// two sites that read one are behind `guard let snap = session.metrics?.rateLimit`
+/// (`SessionListView.swift`) and no fixture under `Tests/Fixtures` or
+/// `Tests/MockInstanceFiles` carries a rate-limit window (#1663 verified that
+/// by grep; re-measured while writing this, still zero matches). So this pin
+/// changed none of the 53 references, and that untouched set is the evidence.
+///
+/// The polarity is #1662's: a suite that names no instant gets a FIXED one, not
+/// the machine's, so the first fixture to seed a rate-limit window cannot
+/// photograph the recording day even by forgetting.
+enum PinnedNowSnapshot {
+    /// 2023-11-14 22:13:20 UTC. The same instant `PinnedTimeZoneSnapshotTests`
+    /// drives, so the two families' fixtures line up: it is late enough in the
+    /// UTC day that `Asia/Tokyo` (+09:00) is already on the next date, which is
+    /// what lets a single fixture vary the DAY on the time-zone axis as well as
+    /// on this one.
+    static let referenceNow = Date(timeIntervalSince1970: 1_700_000_000)
+
+    /// An instant on a different calendar day from `referenceNow` **in every
+    /// time zone**, so a both-sides arm cannot be quietly made tautological by
+    /// changing the zone it runs under.
+    ///
+    /// Exactly 48 hours later: the widest UTC offset in use is ±14:00, so two
+    /// instants two days apart cannot land on one local day anywhere. A smaller
+    /// gap would be sound for UTC and wrong for `Pacific/Kiritimati`.
+    static let contrastingNow = referenceNow.addingTimeInterval(48 * 3_600)
+}

--- a/platforms/macos/Tests/PinnedNowSnapshotTests.swift
+++ b/platforms/macos/Tests/PinnedNowSnapshotTests.swift
@@ -1,0 +1,402 @@
+import AppKit
+import SwiftUI
+import XCTest
+@testable import Irrlicht
+
+/// Locks the property #1663 is about: the quota chip's reset label renders
+/// against the clock, calendar, zone and locale it is GIVEN, not the four the
+/// machine happens to be in.
+///
+/// The obvious test — "renders 09:00" — is the trap this whole family is
+/// written around (`PinnedScaleSnapshotTests`, `PinnedLocaleSnapshotTests`,
+/// `PinnedTimeZoneSnapshotTests` each say it in their own terms). Asserting one
+/// rendering is green on the host that agrees with it whether the input reached
+/// the view or not. So every axis here drives **two** values through one view:
+/// whatever the machine is, at most one arm can agree with it.
+///
+/// The "now" axis is the one #1659 deliberately left open, and it is the
+/// sharpest of the four because it does not shift a rendered time — it selects
+/// a different FORMAT STRING. `"09:00"` before midnight, `"Fr. 9:00"` after,
+/// from the same input. A reference pinned on zone and locale alone is still a
+/// picture of the day it was recorded, and it fails on the recording machine
+/// itself the next morning.
+///
+/// ## What is graded where, and why it is split
+///
+/// `QuotaResetFormat` is graded directly, on strings: that is where the branch
+/// selection lives and a string says which branch ran. `QuotaResetLabel` is
+/// graded in pixels, by rasterising it twice under different pins and refusing
+/// an identical result: that is what catches a view which computes the right
+/// answer from the wrong input — a `Date()` left at the call site passes every
+/// string assertion in this file.
+///
+/// Everything goes through `PinnedSnapshotHost`, the type the snapshot suites
+/// use, rather than a hosting view assembled here: "the host that pins" and
+/// "the host the proof was taken on" must not be two objects that can disagree.
+///
+/// ## What this suite does NOT reach
+///
+/// The quota **tooltip**, which is `formatClockTime`'s only call site.
+/// `.tooltip(…)` is an `onHover`-only AppKit bridge drawing into a separate
+/// `NSPanel`; it adds nothing to the view tree, and a window-less
+/// `NSHostingView` populates no accessibility tree in an `xctest` process
+/// (measured by #1659 for the same reason, and by
+/// `PermissionWizardEffectErrorRenderTests`, which abandoned an AX walk after
+/// every query came back empty). So `QuotaResetFormat.clock` is graded on
+/// strings and its pass-through from `SessionListView`'s environment is held by
+/// the compiler — both arguments are required — and by nothing else. Stated
+/// rather than implied.
+@MainActor
+final class PinnedNowSnapshotTests: XCTestCase {
+
+    // MARK: - Fixtures
+
+    /// 2023-11-17 09:00:00 UTC — a Friday, so the not-same-day branch renders
+    /// the `"Fri 9:00"` spelling `QuotaResetFormat.resetLabel`'s own doc
+    /// comment uses as its example.
+    private let reset = Date(timeIntervalSince1970: 1_700_211_600)
+
+    /// 2023-11-17 08:00:00 UTC — an hour before the reset, same UTC day.
+    private let sameDayNow = Date(timeIntervalSince1970: 1_700_208_000)
+
+    /// 2023-11-16 23:00:00 UTC — ten hours before the reset, and the PREVIOUS
+    /// UTC day. In `Asia/Tokyo` (+09:00) it is 08:00 on the same local day as
+    /// the reset, which is what lets one (date, now) pair drive the branch from
+    /// the time-zone axis as well as from this one.
+    private let otherDayNow = Date(timeIntervalSince1970: 1_700_175_600)
+
+    private var utc: TimeZone { PinnedTimeZoneSnapshot.referenceTimeZone }
+    private var tokyo: TimeZone { PinnedTimeZoneSnapshot.contrastingTimeZone }
+    private var de: Locale { PinnedLocaleSnapshot.referenceLocale }
+    private var en: Locale { PinnedLocaleSnapshot.contrastingLocale }
+    private var gregorian: Calendar { Calendar(identifier: .gregorian) }
+
+    private func label(_ date: Date, now: Date,
+                       calendar: Calendar? = nil,
+                       zone: TimeZone? = nil,
+                       locale: Locale? = nil) -> String {
+        QuotaResetFormat.resetLabel(date, now: now,
+                                    calendar: calendar ?? gregorian,
+                                    timeZone: zone ?? utc,
+                                    locale: locale ?? de)
+    }
+
+    // MARK: - The branch is chosen by the "now" it is given
+
+    /// The whole point of #1663, in two lines: one reset, two clocks, two
+    /// different FORMATS. Neither arm can be green on a host that reads
+    /// `Date()`, because today is neither of these days.
+    func testResetLabelSelectsItsFormatFromTheNowItIsGiven() {
+        XCTAssertEqual(label(reset, now: sameDayNow), "09:00")
+        XCTAssertEqual(label(reset, now: otherDayNow), "Fr. 9:00")
+    }
+
+    /// …and the branch selection is not a property of one locale's spelling.
+    func testResetLabelSelectsItsFormatFromTheNowInEveryLocale() {
+        // U+202F, narrow no-break space before the AM/PM marker — measured, not
+        // guessed, and the same trap `PinnedTimeZoneSnapshotTests` records for
+        // `HistoryFormat.fullDateTime`. A plain space here fails with
+        // `("9:00 AM") is not equal to ("9:00 AM")`.
+        XCTAssertEqual(label(reset, now: sameDayNow, locale: en), "9:00\u{202F}AM")
+        XCTAssertEqual(label(reset, now: otherDayNow, locale: en), "Fri 9:00")
+    }
+
+    // MARK: - …and the zone, and the locale
+
+    /// One (reset, now) pair, two zones, and the zone decides the BRANCH as
+    /// well as the clock: in UTC the reset is tomorrow, in `Asia/Tokyo` it is
+    /// later today. An implementation that compared days in one zone and
+    /// rendered in another would fail here and nowhere else in this file.
+    func testResetLabelRendersAndBranchesInTheZoneItIsGiven() {
+        XCTAssertEqual(label(reset, now: otherDayNow, zone: utc), "Fr. 9:00")
+        XCTAssertEqual(label(reset, now: otherDayNow, zone: tokyo), "18:00")
+    }
+
+    /// Both branches on the locale axis, so an arm cannot pass while the
+    /// locale argument is dropped on the branch nobody looked at.
+    func testResetLabelRendersInTheLocaleItIsGiven() {
+        XCTAssertNotEqual(label(reset, now: sameDayNow, locale: de),
+                          label(reset, now: sameDayNow, locale: en))
+        XCTAssertNotEqual(label(reset, now: otherDayNow, locale: de),
+                          label(reset, now: otherDayNow, locale: en))
+    }
+
+    func testClockRendersInTheZoneAndLocaleItIsGiven() {
+        XCTAssertEqual(QuotaResetFormat.clock(reset, timeZone: utc, locale: de), "09:00")
+        XCTAssertEqual(QuotaResetFormat.clock(reset, timeZone: tokyo, locale: de), "18:00")
+        XCTAssertEqual(QuotaResetFormat.clock(reset, timeZone: utc, locale: en), "9:00\u{202F}AM")
+    }
+
+    // MARK: - The calendar argument, and why no pixel arm grades it
+
+    /// `resetLabel` overrides its calendar's time zone with the one it renders
+    /// in, so what the calendar argument still contributes is its IDENTITY and
+    /// week rules. This measures that the identity cannot change the verdict —
+    /// which is the evidence for there being no both-sides pixel arm for the
+    /// calendar below, rather than an assumption that there needn't be one.
+    ///
+    /// It is also the reason the argument is `\.calendar` (default
+    /// `Calendar.current`) and not a forced `.gregorian`: a user on a Japanese
+    /// or Buddhist calendar keeps theirs, and it demonstrably costs nothing.
+    func testTheCalendarIdentityDoesNotDecideTheBranch() {
+        let identifiers: [Calendar.Identifier] = [
+            .gregorian, .buddhist, .chinese, .coptic, .ethiopicAmeteMihret,
+            .ethiopicAmeteAlem, .hebrew, .iso8601, .indian, .islamic,
+            .islamicCivil, .islamicTabular, .islamicUmmAlQura, .japanese,
+            .persian, .republicOfChina,
+        ]
+        let pairs = [(reset, sameDayNow), (reset, otherDayNow)]
+
+        // The premise: these pairs really do exercise both branches, or every
+        // comparison below is one verdict compared against itself.
+        let gregorianVerdicts = Set(pairs.map { pair -> String in
+            label(pair.0, now: pair.1)
+        })
+        XCTAssertEqual(gregorianVerdicts.count, 2,
+                       "the fixture pairs no longer render both branches — "
+                       + "this sweep is comparing one verdict against itself")
+
+        for identifier in identifiers {
+            for (date, now) in pairs {
+                XCTAssertEqual(label(date, now: now, calendar: Calendar(identifier: identifier)),
+                               label(date, now: now, calendar: gregorian),
+                               "calendar `\(identifier)` decides the same-day branch differently "
+                               + "from `.gregorian` at a fixed zone — `QuotaResetFormat`'s doc "
+                               + "comment, and the missing pixel arm it justifies, are wrong")
+            }
+        }
+    }
+
+    // MARK: - The constants the both-sides arms rest on
+
+    /// `referenceNow` and `contrastingNow` really are on different days, in
+    /// both pinned zones, so a future edit cannot quietly make the pixel arms
+    /// tautological by moving them closer together.
+    func testReferenceAndContrastingNowsSelectDifferentBranches() {
+        for zone in [utc, tokyo] {
+            let a = label(PinnedNowSnapshot.referenceNow, now: PinnedNowSnapshot.referenceNow, zone: zone)
+            let b = label(PinnedNowSnapshot.referenceNow, now: PinnedNowSnapshot.contrastingNow, zone: zone)
+            XCTAssertNotEqual(a, b,
+                              "PinnedNowSnapshot.referenceNow and .contrastingNow render the same "
+                              + "label (\(a)) in \(zone.identifier) — every both-sides arm that "
+                              + "uses them is vacuous")
+        }
+    }
+
+    // MARK: - The seam costs the app nothing
+
+    /// The environment defaults render exactly what the code they replaced
+    /// rendered, on every host.
+    ///
+    /// Both old spellings are copied **verbatim** from `SessionListView` as it
+    /// stood before #1663, so this is a comparison against the old code and not
+    /// against a description of it.
+    func testTheDefaultsAreIndistinguishableFromTheCodeTheyReplaced() {
+        let env = EnvironmentValues()
+
+        // --- formatClockTime, verbatim ---
+        let oldClock = DateFormatter()
+        oldClock.dateStyle = .none
+        oldClock.timeStyle = .short
+        XCTAssertEqual(QuotaResetFormat.clock(reset, timeZone: env.formatTimeZone, locale: env.formatLocale),
+                       oldClock.string(from: reset),
+                       "`\\.formatTimeZone` / `\\.formatLocale` defaults render a different clock "
+                       + "than the unset DateFormatter they replaced")
+
+        // --- formatResetTime, verbatim, on both branches ---
+        // The wall clock is read on both sides, microseconds apart. The one way
+        // that is unsound is a day boundary falling between the two reads, so
+        // it is checked rather than hoped for.
+        func oldResetTime(_ date: Date) -> String {
+            let cal = Calendar.current
+            let now = Date()
+            let f = DateFormatter()
+            if cal.isDate(date, inSameDayAs: now) {
+                f.dateStyle = .none
+                f.timeStyle = .short
+            } else {
+                f.dateFormat = "EEE H:mm"
+            }
+            return f.string(from: date)
+        }
+
+        let openedAt = Date()
+        for date in [Date(), Date().addingTimeInterval(3 * 86_400)] {
+            XCTAssertEqual(
+                QuotaResetFormat.resetLabel(date, now: env.formatNow(),
+                                            calendar: env.calendar,
+                                            timeZone: env.formatTimeZone,
+                                            locale: env.formatLocale),
+                oldResetTime(date),
+                "the environment defaults render a different reset label than the code they "
+                + "replaced")
+        }
+        XCTAssertTrue(Calendar.current.isDate(openedAt, inSameDayAs: Date()),
+                      "a calendar day turned over while this test ran, so the two sides read "
+                      + "different days for a reason unrelated to the seam — re-run it")
+    }
+
+    /// …and the default clock is the wall clock read AT EACH CALL, not an
+    /// instant captured when the key was defined.
+    ///
+    /// This is the arm that separates `FormatNow.wallClock` from a stopped
+    /// clock that happens to be close to now, and it is the counterpart of
+    /// `PinnedTimeZoneSnapshotTests.testTheDefaultFollowsNSTimeZoneDefaultAndNotAutoupdatingCurrent`.
+    func testTheDefaultIsTheWallClockReadAtEachCall() {
+        let before = Date()
+        let read = EnvironmentValues().formatNow()
+        let after = Date()
+
+        XCTAssertGreaterThanOrEqual(read, before,
+                                    "`\\.formatNow`'s default answered with an instant from before "
+                                    + "it was called — it is captured, not read")
+        XCTAssertLessThanOrEqual(read, after,
+                                 "`\\.formatNow`'s default answered with an instant from the "
+                                 + "future — it is not reading the wall clock")
+        // Two reads of the default advance; two reads of a FIXED clock do not.
+        // Without this, a `FormatNow(fixed: Date())` default would pass both
+        // assertions above.
+        XCTAssertNotEqual(EnvironmentValues().formatNow(), read,
+                          "two reads of `\\.formatNow`'s default answered the same instant — "
+                          + "the default is stopped, not running")
+    }
+
+    /// …and a pinned clock is stopped: every read in a subtree answers the same
+    /// instant, which is what makes a rendering a function of its inputs.
+    func testAPinnedClockIsStopped() {
+        let stopped = FormatNow(fixed: PinnedNowSnapshot.referenceNow)
+        XCTAssertEqual(stopped(), PinnedNowSnapshot.referenceNow)
+        XCTAssertEqual(stopped(), stopped())
+    }
+
+    // MARK: - The pin reaches the pixels
+
+    /// The real `QuotaResetLabel` — the view `SessionListView.quotaWindowRow`
+    /// renders — hosted through the type the snapshot suites use.
+    private func rasterizedLabel(resetsAt: Date,
+                                 now: Date = PinnedNowSnapshot.referenceNow,
+                                 timeZone: TimeZone? = nil,
+                                 locale: Locale? = nil) -> Data {
+        let content = QuotaResetLabel(resetsAt: resetsAt).frame(width: 200, height: 24)
+        let host = PinnedSnapshotHost(content,
+                                      width: 200, height: 24,
+                                      locale: locale ?? PinnedLocaleSnapshot.referenceLocale,
+                                      timeZone: timeZone ?? PinnedTimeZoneSnapshot.referenceTimeZone,
+                                      now: now)
+        let image = PinnedScaleSnapshot.rasterize(host.view, scale: PinnedScaleSnapshot.referenceScale)
+        // "could not rasterise" and "rasterised to the same thing" must never
+        // produce the same verdict.
+        guard let data = image.tiffRepresentation, !data.isEmpty else {
+            XCTFail("the reset label rasterised to nothing — this check cannot have run")
+            return Data()
+        }
+        return data
+    }
+
+    /// The load-bearing arm, and the one that catches the mutation this whole
+    /// change exists to make catchable: put `Date()` back at the call site in
+    /// `QuotaResetLabel` and both renders become today's, identically — which
+    /// is what this refuses. Every string assertion above stays green under
+    /// that mutation.
+    func testTheSameLabelRendersDifferentlyUnderTwoPinnedNows() {
+        // The premise, loudly first: these two clocks must produce different
+        // text for this fixture, or the byte comparison measures nothing.
+        XCTAssertNotEqual(
+            label(PinnedNowSnapshot.referenceNow, now: PinnedNowSnapshot.referenceNow),
+            label(PinnedNowSnapshot.referenceNow, now: PinnedNowSnapshot.contrastingNow),
+            "the fixture reads the same under both pinned clocks — the pixel comparison below "
+            + "cannot fail for the right reason")
+
+        // …and rendering is deterministic, or "they differ" proves nothing.
+        XCTAssertEqual(rasterizedLabel(resetsAt: PinnedNowSnapshot.referenceNow),
+                       rasterizedLabel(resetsAt: PinnedNowSnapshot.referenceNow),
+                       "the same label rasterised twice under the same clock differs — this "
+                       + "suite's both-sides arms are not measuring the clock")
+
+        XCTAssertNotEqual(rasterizedLabel(resetsAt: PinnedNowSnapshot.referenceNow,
+                                          now: PinnedNowSnapshot.referenceNow),
+                          rasterizedLabel(resetsAt: PinnedNowSnapshot.referenceNow,
+                                          now: PinnedNowSnapshot.contrastingNow),
+                          "the reset label rendered identically under two pinned clocks — "
+                          + "`\\.formatNow` is reaching nothing and the branch is coming from "
+                          + "the machine's wall clock")
+    }
+
+    /// The zone reaches the pixels of THIS view too — `PinnedTimeZoneSnapshotTests`
+    /// proves it for the History panel, which shares no call site with this one.
+    func testTheSameLabelRendersDifferentlyUnderTwoPinnedTimeZones() {
+        XCTAssertNotEqual(label(PinnedNowSnapshot.referenceNow, now: PinnedNowSnapshot.referenceNow, zone: utc),
+                          label(PinnedNowSnapshot.referenceNow, now: PinnedNowSnapshot.referenceNow, zone: tokyo),
+                          "the fixture reads the same in both pinned zones — the pixel comparison "
+                          + "below cannot fail for the right reason")
+        XCTAssertNotEqual(rasterizedLabel(resetsAt: PinnedNowSnapshot.referenceNow, timeZone: utc),
+                          rasterizedLabel(resetsAt: PinnedNowSnapshot.referenceNow, timeZone: tokyo),
+                          "the reset label rendered identically under UTC and Asia/Tokyo — "
+                          + "`\\.formatTimeZone` is reaching nothing and the render is coming "
+                          + "from NSTimeZone.default (\(NSTimeZone.default.identifier))")
+    }
+
+    /// …and the locale.
+    func testTheSameLabelRendersDifferentlyUnderTwoPinnedLocales() {
+        XCTAssertNotEqual(label(PinnedNowSnapshot.referenceNow, now: PinnedNowSnapshot.referenceNow, locale: de),
+                          label(PinnedNowSnapshot.referenceNow, now: PinnedNowSnapshot.referenceNow, locale: en),
+                          "the fixture reads the same in both pinned locales — the pixel "
+                          + "comparison below cannot fail for the right reason")
+        XCTAssertNotEqual(rasterizedLabel(resetsAt: PinnedNowSnapshot.referenceNow, locale: de),
+                          rasterizedLabel(resetsAt: PinnedNowSnapshot.referenceNow, locale: en),
+                          "the reset label rendered identically under de_DE and en_US — "
+                          + "`\\.formatLocale` is reaching nothing")
+    }
+
+    // MARK: - The host stops the clock, and stops it at the reference instant
+
+    /// Collects what a hosted subtree actually sees. A class so the SwiftUI
+    /// value type can write into it.
+    private final class EnvironmentReport {
+        var formatNow: FormatNow?
+    }
+
+    private struct EnvironmentProbe: View {
+        @Environment(\.formatNow) private var formatNow
+        let report: EnvironmentReport
+
+        var body: some View {
+            report.formatNow = formatNow
+            return Color.clear
+        }
+    }
+
+    func testTheHostStopsTheClockItIsGiven() {
+        let report = EnvironmentReport()
+        _ = PinnedSnapshotHost(EnvironmentProbe(report: report),
+                               width: 40, height: 40,
+                               now: PinnedNowSnapshot.contrastingNow)
+
+        // "the probe never rendered" and "the probe saw the right thing" must
+        // not produce the same verdict.
+        guard let seen = report.formatNow else {
+            return XCTFail("the probe's body never evaluated — this check cannot have run")
+        }
+        XCTAssertEqual(seen(), PinnedNowSnapshot.contrastingNow,
+                       "`\\.formatNow` is not pinned by the host")
+        XCTAssertEqual(seen(), seen(),
+                       "the host's clock is still running — a subtree that reads it twice "
+                       + "renders two different instants")
+    }
+
+    /// …and the instant a suite gets when it names none is
+    /// `PinnedNowSnapshot.referenceNow`, so the arms above cannot pass while
+    /// every real snapshot renders against the machine's clock.
+    ///
+    /// Stated separately so a change to `referenceNow` fails HERE, naming the
+    /// constant, rather than as an opaque byte mismatch somewhere else.
+    func testTheHostsDefaultNowIsTheReferenceNow() {
+        let report = EnvironmentReport()
+        _ = PinnedSnapshotHost(EnvironmentProbe(report: report), width: 40, height: 40)
+        guard let seen = report.formatNow else {
+            return XCTFail("the probe's body never evaluated — this check cannot have run")
+        }
+        XCTAssertEqual(seen(), PinnedNowSnapshot.referenceNow,
+                       "the host's default clock is not `PinnedNowSnapshot.referenceNow`")
+    }
+}


### PR DESCRIPTION
Closes #1663.

## The seams, and which of the three reads each closes

`SessionListView.formatResetTime` stacked what #1663 counts as three machine reads
and what the signature now counts as four. Each is closed by making it an input;
none is closed by removal.

| Read | Seam | Kind |
|---|---|---|
| `Date()` — **selects the format string** | `\.formatNow` (new, `Irrlicht/Views/FormatNowEnvironment.swift`) | new product seam |
| `Calendar.current` | `\.calendar` — SwiftUI's own, default `Calendar.current`, pinned by `PinnedSnapshotHost` since #1659 | existing key, no new seam |
| `DateFormatter().timeZone` unset | `\.formatTimeZone` (#1659) | existing seam |
| `DateFormatter().locale` unset | `\.formatLocale` (#1630) | existing seam |

**All three (four) are closed.** The formatting itself moved out of the view into
`QuotaResetFormat.clock` / `.resetLabel`, where every one of them is a **required
argument** — #1659's shape, so a call site with nothing to pass is
`error: missing argument for parameter 'now' in call` rather than another silent
machine read. `formatClockTime`'s two reads are closed the same way, at the same
time.

Each default is *by construction* what the unpinned spelling already resolved
through (`Date()`, `Calendar.current`, `NSTimeZone.default`,
`Locale.autoupdatingCurrent`), so no user sees a different string. That is asserted
against a **verbatim copy** of the pre-#1663 code rather than against a description
of it (`testTheDefaultsAreIndistinguishableFromTheCodeTheyReplaced`), on both
branches, with a guard that fails loudly if a calendar day turns over mid-test.

### Two design points worth reviewing rather than skimming

**The key carries a closure, not a `Date`.** The obvious mirror of
`\.formatTimeZone`'s computed `NSTimeZone.default` default would be a computed
`Date()` default — and it is wrong twice. A computed `Date()` is a value *never
equal to itself*, where `NSTimeZone.default` is stable between assignments; and a
fixture wants **one** instant per subtree, not a fresh one per read (the
microsecond-disagreement hazard `quotaWindowRow` already documents in-file for
`quotaPacePercent`). So `FormatNow.wallClock` is a single stored value calling
`Date()` at the point of use — exactly where the call sites called it before — and
`FormatNow(fixed:)` is the stopped form.

**`Calendar.current` is closed by `\.calendar`, not by forcing `.gregorian`.** A
user on a Japanese or Buddhist calendar keeps theirs. What *is* forced is the
calendar's **zone**, to the zone the formatter renders in, so the day the branch is
decided in and the day the string is rendered in cannot disagree — that line is
load-bearing (mutation M6 below reddens four arms), while the identity provably is
not: measured across all 16 Foundation calendar identifiers at a fixed zone, zero
disagreements on `isDate(_:inSameDayAs:)`
(`testTheCalendarIdentityDoesNotDecideTheBranch`, with a vacuity guard that the
fixture pairs still span both branches). That measurement is what justifies there
being no both-sides pixel arm for the calendar, rather than an assumption that
there needn't be one.

## Blast radius — what was deliberately NOT converted

#1663 says an injectable clock across every wall-clock read in the app is a
separate, wider change. This is not it. **Exactly one call site reads `\.formatNow`**:
`QuotaResetLabel`. (Corrected in a follow-up commit after I grepped my own claim:
the other function #1663 names, `formatClockTime` behind the quota tooltip, never
read a clock — its two machine reads were the formatter's unset `locale` and
`timeZone`, so the existing two seams close it entirely and
`QuotaResetFormat.clock` takes no `now:`.)

Left alone, on the same chip, reached from the same
`guard let snap = session.metrics?.rateLimit` chain:

- `SessionListView.quotaPacePercent(_:)` — `Date()` placing the pace marker.
  **Pixel-visible.** Also read by `QuotaMenuBarRenderer`, so it is a shared static
  and would need the argument form, not the environment form.
- `mergeIntoBuckets`' staleness test — `$0.resetsAt <= now` driving
  `.opacity(isStale ? 0.5 : 1.0)`. **Pixel-visible, and discrete like #1663's own
  branch**, so a reference recorded before a fixture's `resetsAt` is correct and
  then permanently wrong.
- `formatTimeUntil(_:)` — `timeIntervalSinceNow` in the tooltip. Not pixel-visible.

Converting them is the app-wide clock change #1663 defers, and it matters for a
concrete reason: **#1663's closing note "only then is it worth seeding a
`rate_limit` fixture" is not yet true**, because two of those three would still
record the recording machine's clock. Filed as **#1675** rather than folded in, and
`FormatNowEnvironment.swift`'s doc comment names all three so the next reader does
not have to rediscover them.

## Coverage — and why a pin alone would have been untested by construction

#1663 verified the site is reached by no committed reference (re-measured:
`grep -rn "rate_limit\|rateLimit" Tests/Fixtures/ Tests/MockInstanceFiles/` returns
nothing; the two fixtures are `SessionRow/working-claude.json` and
`SessionRow/antigravity-ghost.json`). So the row's `Text` is extracted into
`QuotaResetLabel` — a view a test can host. That extraction is the point, not
tidying: an `@Environment` read off a `SessionListView` value a test constructed
itself, **outside a view update, answers the DEFAULT** — a pin that reaches nothing
wearing the shape of a passing test.

New suite `Tests/PinnedNowSnapshotTests.swift`, 15 tests, in
`PinnedTimeZoneSnapshotTests`' idiom (two values per axis through one view; no
committed reference — renders are rasterised through `PinnedSnapshotHost` and
compared to each other in memory).

**Both branches are exercised, in three independent ways** — that being the whole
point:
- `testResetLabelSelectsItsFormatFromTheNowItIsGiven` — one reset, two clocks:
  `"09:00"` vs `"Fr. 9:00"`. Neither arm can be green on a host reading `Date()`,
  since today is neither day.
- `…InEveryLocale` — same, `en_US`: `"9:00\u{202F}AM"` vs `"Fri 9:00"` (U+202F
  narrow no-break space, measured — the same trap #1659 records).
- `testResetLabelRendersAndBranchesInTheZoneItIsGiven` — **one** (reset, now) pair,
  two zones, where the *zone* flips the branch: in UTC the reset is tomorrow, in
  `Asia/Tokyo` it is later today. An implementation comparing days in one zone and
  rendering in another fails here and nowhere else in the file.

Plus `PinnedNowSnapshot` (`referenceNow` = 2023-11-14 22:13:20 UTC, the instant
`PinnedTimeZoneSnapshotTests` already drives; `contrastingNow` = +48h, so it is a
different local day in *every* zone — ±14:00 being the widest offset in use), and
`PinnedSnapshotHost`'s new `now:` parameter, defaulting to a fixed instant on
#1662's polarity: a suite that names none gets determinism, never a reference that
photographs the recording day.

## Mutation evidence

Everything here is added, so every arm owes a deliberate mutation. Six were applied
and reverted one per shell invocation, each restored with a `git status --porcelain`
assertion against the pre-mutation baseline. Filtered to the new suite (15 tests).

**M1 — `QuotaResetLabel` reads `Date()` instead of `formatNow()`** (the seam
reverted at the call site). 1 failure:

```
Tests/PinnedNowSnapshotTests.swift:316: error: -[…testTheSameLabelRendersDifferentlyUnderTwoPinnedNows]
: XCTAssertNotEqual failed: ("79054 bytes") is equal to ("79054 bytes")
- the reset label rendered identically under two pinned clocks — `\.formatNow` is
  reaching nothing and the branch is coming from the machine's wall clock
```

This is the measurement that matters: **every string assertion in the file stayed
green.** Only the rendered comparison catches it — #1630's mutation B and #1659's,
one family on.

**M2 — the call site reads `NSTimeZone.default` / `Locale.autoupdatingCurrent`
instead of the seams.** 2 failures, and note they are the *other* two axes, not M1's:

```
:332: …testTheSameLabelRendersDifferentlyUnderTwoPinnedTimeZones : ("79054 bytes") is equal to ("79054 bytes")
- the reset label rendered identically under UTC and Asia/Tokyo — `\.formatTimeZone` is
  reaching nothing and the render is coming from NSTimeZone.default (Europe/Berlin)
:345: …testTheSameLabelRendersDifferentlyUnderTwoPinnedLocales : ("79054 bytes") is equal to ("79054 bytes")
- the reset label rendered identically under de_DE and en_US — `\.formatLocale` is reaching nothing
```

**M3 — `QuotaResetFormat.resetLabel` ignores its `now:` argument and reads the wall
clock.** 8 failures across 6 tests — the branch arms, and both vacuity guards
firing correctly rather than passing:

```
:90:  …SelectsItsFormatFromTheNowItIsGiven      : ("Fr. 9:00") is not equal to ("09:00")
:100: …SelectsItsFormatFromTheNowInEveryLocale  : ("Fri 9:00") is not equal to ("9:00 AM")
:112: …RendersAndBranchesInTheZoneItIsGiven     : ("Fr. 18:00") is not equal to ("18:00")
:155: …testTheCalendarIdentityDoesNotDecideTheBranch : ("1") is not equal to ("2")
      - the fixture pairs no longer render both branches — this sweep is comparing one verdict against itself
:179: …testReferenceAndContrastingNowsSelectDifferentBranches : ("Di. 22:13") is equal to ("Di. 22:13")
:304: …TwoPinnedNows (premise) : ("Di. 22:13") is equal to ("Di. 22:13")
      - the fixture reads the same under both pinned clocks — the pixel comparison below cannot fail for the right reason
```

**M4 — the key's default captures one instant (`FormatNow(fixed: Date())`) instead
of reading the clock.** 1 failure — the arm that separates "running" from "stopped
near now", which the two bracket assertions alone cannot:

```
:259: …testTheDefaultIsTheWallClockReadAtEachCall : ("2026-08-17 18:40:01 +0000") is equal to (same)
- two reads of `\.formatNow`'s default answered the same instant — the default is stopped, not running
```

**M5 — `PinnedSnapshotHost` stops pinning the clock.** 3 failures, including the
"the probe never rendered vs. saw the right thing" split:

```
:316: …TwoPinnedNows            : ("79054 bytes") is equal to ("79054 bytes")
:380: …testTheHostStopsTheClockItIsGiven : ("2026-08-17 …") is not equal to ("2023-11-16 22:13:20 +0000")
:399: …testTheHostsDefaultNowIsTheReferenceNow : ("2026-08-17 …") is not equal to ("2023-11-14 22:13:20 +0000")
```

**M6 — the formatter stops forcing its calendar into the zone it renders in.** 4
failures, which is the evidence that line is load-bearing and that the
calendar-identity sweep is not ceremony:

```
:91:  …SelectsItsFormatFromTheNowItIsGiven     : ("09:00") is not equal to ("Fr. 9:00")
:101: …SelectsItsFormatFromTheNowInEveryLocale : ("9:00 AM") is not equal to ("Fri 9:00")
:111: …RendersAndBranchesInTheZoneItIsGiven    : ("09:00") is not equal to ("Fr. 9:00")
:155: …testTheCalendarIdentityDoesNotDecideTheBranch : ("1") is not equal to ("2")
```

Every mutation was reverted in the same invocation that applied it, and
`git status --porcelain` was re-read afterwards and matched the baseline byte for
byte each time.

## References

**Zero regenerated.** `git status --porcelain -- platforms/macos/Tests/__Snapshots__`
is empty; all **53** committed PNGs still match. Following #1658/#1664/#1673, the
untouched set is itself the evidence that neither the new seam, nor the host's new
`now:` pin, nor the `QuotaResetLabel` extraction changed any rendering.

## Gates

- `tools/preflight.sh --only swift` — **PASS**, exit 0 read directly (not through a
  pipe). `385 tests, 0 failures`; `grep -c "error: -\["` over the log = 0. Per
  #1523 the exit code is the signal, and it is 0.
- `tools/preflight.sh --only tools` — **not run, and not required**: nothing under
  `tools/` is touched (the diff is `AGENTS.md` + `platforms/macos/`), and
  `grep -n AGENTS tools/preflight.sh` finds only two comment lines, so no gate keys
  on the doc change either.
- Pre-push hook (`tools/preflight.sh --changed --budget 540`) — **PASS**: `gofmt`
  PASS, `macOS Swift build + test` PASS, everything else correctly SKIP.
- Real-home safety: `swift-suite.sh`'s witness reported *no new entries* in
  `~/Library/Preferences` / `~/Library/Sounds` across the gate. Counts read
  read-only before and after the gate: Preferences 197 entries / 259 files → 197 /
  259, Sounds 2 → 2. (Between task start and the gate the count moved 195 → 197 from
  Apple background plists — `com.apple.AppleMediaServices.plist`,
  `com.apple.messages.commsafety.plist` — which is the noise floor AGENTS.md already
  documents for interactive-length windows, not this change.) Nothing was deleted,
  moved or overwritten under the real home; no `defaults` write, no
  `killall cfprefsd`, no locale or timezone change; `LauncherTestHarness` /
  `LauncherHarnessTests` never run.
- CodeScene / ARS are advisory.
- Note for the reviewer: `go-test` has a known fswatcher flake (#1674,
  `TestWatch_NewTopLevelDir_DiscoveredDuringBacklogScan`) that can redden a
  Swift-only PR. That is #1674, not this change.

## CodeScene (advisory) — looked at, not chased

Two advisory findings, both on files this PR adds, and I am keeping both rather
than suppressing them. Recorded here so the judgment is reviewable:

- **`QuotaResetFormat.resetLabel` — Excess Number of Function Arguments (5).** The
  five arguments *are* the fix. Every one is a machine read that used to be
  implicit, and the required-argument shape is what makes a forgotten one
  `error: missing argument for parameter 'now' in call` — #1659's mechanism,
  named in AGENTS.md as the alternative to a source scan. Bundling them into a
  context struct would restore a memberwise initializer that a call site can fill
  from the machine as easily as from the environment, with no compile error, which
  is precisely the property being bought.
- **`PinnedNowSnapshotTests.swift` — Code Duplication.** The three both-sides pixel
  arms share a shape (premise assertion → two renders → byte comparison) and differ
  in their failure messages, which name the axis and the environment key that
  failed. Measured: mutation M2 above reddens the zone and locale arms with two
  different diagnoses; a shared helper would report one generic message for either.

Both are advisory per AGENTS.md ("a red result is a prompt to look closer, not
something to chase to green before merging"), and neither is a merge gate.

## Also in this diff

`AGENTS.md`'s macOS bullet gains this family's fourth member beside scale (#1530),
locale (#1630), zone (#1659) and `@AppStorage` (#1662), carrying the five things
worth reusing: the measured string-vs-pixel split, why the key is a closure, why
`Calendar.current` became `\.calendar` rather than a forced `.gregorian`, why a pin
alone would have been untested by construction, and the deliberate blast radius
with #1675 named.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
