### PR TITLE
fix(ci): make the snapshot-evidence reference copy fail the step it belongs to (#1646)

### DIFF
--- a/.github/workflows/macos-swift.yml
+++ b/.github/workflows/macos-swift.yml
@@ -341,7 +341,40 @@ jobs:
             bad=1
           fi
 
-          cp -R platforms/macos/Tests/__Snapshots__ "$SNAPSHOT_ARTIFACTS/__References__"
+          # The references, and the three outcomes that must not print the same
+          # thing (#1646). This copy's status used to be read by NOTHING: the
+          # `set +e` above is on for the whole block, so a failed `cp` neither
+          # aborted the step nor reached `bad`. The job stayed green and the
+          # uploaded artifact simply arrived without its `__References__` tree
+          # — the half a reader needs in order to compare a failure image
+          # against what it should have looked like. Measured, not inferred:
+          # with the source absent the block exits 0 and the artifact
+          # directory is empty.
+          #
+          # "There was nothing to copy", "the copy failed" and "it copied"
+          # point at three different places (the references moved or this
+          # checkout is incomplete / the destination is unwritable / fine), and
+          # a fourth outcome is the one no exit status can see: `cp -R` of an
+          # EMPTY tree SUCCEEDS, so the count is what tells a copy that landed
+          # from one that reported success and shipped nothing.
+          refsrc=platforms/macos/Tests/__Snapshots__
+          refdst="$SNAPSHOT_ARTIFACTS/__References__"
+          if [ ! -d "$refsrc" ]; then
+            echo "::error::there is no $refsrc to copy, so the artifact would carry failure images with nothing to compare them against. The references moved, or this checkout is incomplete."
+            bad=1
+          elif ! cp -R "$refsrc" "$refdst"; then
+            echo "::error::could not copy $refsrc into the artifact at $refdst — the failure images will have nothing to compare against."
+            bad=1
+          else
+            refs=$(find "$refdst" -name '*.png' 2>/dev/null | wc -l | tr -d ' ')
+            refs="${refs:-0}"
+            if [ "$refs" -lt 1 ]; then
+              echo "::error::the reference copy reported success but $refdst holds no images. An empty tree copies fine, so this reads exactly like a healthy artifact and is not one."
+              bad=1
+            else
+              echo "copied $refs reference image(s) into the artifact"
+            fi
+          fi
 
           primitives=$(find "$SNAPSHOT_ARTIFACTS/RasterPrimitiveEvidence" -name '*.png' 2>/dev/null | wc -l | tr -d ' ')
           # How many to expect is DERIVED — RasterPrimitiveEvidenceTests writes

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1113,6 +1113,37 @@ Before marking a ticket done, run the full suite — every layer must pass:
   step makes rather than claiming the step implements renaming.
   `preflight.sh`'s `tools` trigger gains this workflow, its fifth widening for
   this reason (#1591, #1629, #1639, #1641).
+- The snapshot-evidence copy:
+  `tools/lib/swift-snapshot-evidence_test.sh` is the same treatment for
+  `macos-swift.yml`'s "Collect the skipped suites' pixels" step (#1646), and
+  it is the family's cheapest member — a `cp -R` of the reference snapshots
+  into the artifact whose status was read by NOTHING. That step opens with
+  `set +e` for a good reason (its whole purpose is to run assertions that
+  fail), so the failed copy neither aborted nor reached `bad`: green job,
+  uploaded artifact missing the `__References__` tree, and therefore failure
+  images with nothing to compare against. Three outcomes now — copied /
+  nothing to copy / could not copy — plus a fourth no exit status can see, an
+  empty tree, which `cp -R` copies with a cheerful 0. **#1646 is where
+  extract-and-execute stopped being blocked by a real `swift test`**: the
+  fixture checkout's `tools/lib/swift-suite.sh` SOURCES the repo's own library
+  by absolute path and overrides only `swift_suite_run`, so the two predicates
+  the body consults are production code reading a committed log fixture, and
+  every outcome of a 20-minute macOS job is reachable in a second. That is the
+  shape to copy for any step whose blocker is one expensive command rather than
+  the body. Two arms carry more than they look: the references must be copied
+  even when the RUN is judged bad (this job exists to publish a failed run, so
+  a copy on the happy path only would ship nothing on exactly the runs the
+  artifact is for), and they must not be counted as failure images — 53
+  references would otherwise satisfy the "not one of the suites produced a
+  failure image" guard forever. The re-audit is in that file's header rather
+  than here: `exit "$bad"` decides, six guards write `bad`, and of the four
+  statements it cannot see, two degrade LOUDLY (a library that will not load
+  reports TRUNCATED — wrong headline, right verdict; a failed `mkdir -p`
+  reaches two guards, not the one the issue claimed) and one is silent and
+  cosmetic (`>> "$GITHUB_STEP_SUMMARY"`, whose text is already on stdout).
+  This workflow was in `preflight.sh`'s `tools` trigger since #1629, so the
+  trigger needed no sixth widening — the assertion simply joins the gate that
+  already covers it.
 - Which bash a workflow step gets: **there are two invocations and this repo
   conflated them** for the whole of the two bullets above (#1650). A step
   DECLARING `shell: bash` runs as `bash --noprofile --norc -e -o pipefail {0}`;

--- a/tools/lib/swift-snapshot-evidence_test.sh
+++ b/tools/lib/swift-snapshot-evidence_test.sh
@@ -1,0 +1,482 @@
+#!/usr/bin/env bash
+# swift-snapshot-evidence_test.sh — the lock on
+# .github/workflows/macos-swift.yml's "Collect the skipped suites' pixels"
+# step (#1646).
+#
+# ---------------------------------------------------------------------------
+# The defect
+#
+# That step opens with `set +e` — correctly, and with a long comment saying
+# why: a step whose whole purpose is to run assertions that fail cannot
+# inherit abort-on-first-failure (#1628/#1629). It then accumulates into `bad`
+# and ends `exit "$bad"`. Every statement in it either sets `bad` or feeds
+# something that does, with one exception:
+#
+#     cp -R platforms/macos/Tests/__Snapshots__ "$SNAPSHOT_ARTIFACTS/__References__"
+#
+# Its status was read by NOTHING. Under `set +e` a failed `cp` neither aborts
+# the step nor sets `bad`, so the job stays green and the uploaded evidence
+# artifact simply arrives without its `__References__` tree — the half a human
+# needs in order to compare a failure image against what it should have looked
+# like. A green check over a useless artifact.
+#
+# ---------------------------------------------------------------------------
+# What this file achieves, and what it does not
+#
+# EXTRACT-AND-EXECUTE, per the family this belongs to (#1641, #1645): the real
+# step body is read out of the real workflow file and RUN, under the shell
+# GitHub actually gives that step — derived through tools/lib/workflow-step.sh,
+# never typed. Running the block pins the property; a text scan pins one
+# spelling of a guard.
+#
+# #1646 itself declined to build a reproduction, on the grounds that the step
+# sources `swift-suite.sh` and drives a real `swift test`. Only the SECOND half
+# of that is unreachable here, and it is the half that can be replaced without
+# grading a different program:
+#
+#   the library   is the REAL one. The fixture checkout's
+#                 `tools/lib/swift-suite.sh` sources the repo's own file by
+#                 absolute path and overrides exactly one function, so
+#                 `swift_suite_completed` and `swift_suite_ran_tests` — the two
+#                 predicates the body consults — are the production ones,
+#                 reading a real committed log fixture from
+#                 tools/lib/testdata/swift-suite/.
+#   `swift test`  is not run. `swift_suite_run` is the pty runner that drives
+#                 it; the override writes a chosen log fixture, plants the
+#                 artifacts a chosen scenario would have produced, and returns
+#                 a chosen status. That is the whole of the substitution, and
+#                 it is what makes each of the step's own outcomes reachable in
+#                 a second rather than in a 20-minute macOS job.
+#
+# So what is graded is the step's STATUS ACCOUNTING — which statements can
+# reach `bad`, and what each of them says — against the real body, the real
+# shell, and the real predicates. What is NOT graded, said plainly rather than
+# implied: whether a real `swift test` writes what the artifact scenarios below
+# assume (that is #1615's evidence job doing its job on a runner), and whether
+# the predicates judge a real log correctly (that is swift-suite_test.sh, which
+# owns the committed log corpus this file borrows).
+#
+# ---------------------------------------------------------------------------
+# The obligations, in order
+#
+#   1. the pre-fix hazard is re-MEASURED, not described: the old one-line `cp`
+#      is emitted verbatim and run under the same derived shell with the source
+#      absent, and it must still exit 0 having copied nothing. It doubles as
+#      the vacuity guard — if `set +e` ever stopped swallowing that status the
+#      fix would be protecting nothing and every arm below would pass for the
+#      wrong reason.
+#   2. a healthy run still exits 0, and the references actually LAND in the
+#      artifact. Without this an arm that refuses everything is
+#      indistinguishable from one that works.
+#   3. nothing to copy → fail, naming the missing source.
+#   4. the copy fails → fail, naming the copy.
+#   5. the copy SUCCEEDS and lands nothing → fail. `cp -R` of an empty tree
+#      exits 0, so no status check anywhere can see this one.
+#   6. 3, 4 and 5 are told APART: each asserts the other two's wording is
+#      absent. A shared non-zero is satisfied by three refusals that all fire
+#      together — measured that way in #1644.
+#   7. the references are copied even when the RUN is judged bad, and are not
+#      counted as failure images. The evidence job exists to publish a failed
+#      run; a copy that only happened on the happy path would ship nothing on
+#      exactly the runs the artifact is for. The second half pins the
+#      `-not -path '*/__References__/*'` exclusion the count depends on — 53
+#      reference images would otherwise satisfy the "not one of the suites
+#      produced a failure image" guard forever.
+#   8. the audit's remaining blind statements are shown to be LOUD: a
+#      `. tools/lib/swift-suite.sh` that fails is read by nothing either, but
+#      it degrades to a failing step rather than a silent pass. Its diagnosis
+#      is wrong (it reports TRUNCATED), which is recorded here rather than
+#      claimed away.
+#
+# ---------------------------------------------------------------------------
+# The re-audit: which statement decides the status, and what it cannot see
+#
+# `exit "$bad"` decides, and `bad` is written by exactly six guards — the 124
+# hang, the truncation, the zero-test run, the copy (three outcomes, above),
+# the manifest count, and the failure-image count. Everything else in the block
+# is invisible to it unless it feeds one of those. #1646 traced this and found
+# one exception; measured rather than inherited, there are four, and three of
+# them are covered by something:
+#
+#   `. tools/lib/swift-suite.sh`  read by nothing. A library that does not load
+#                                 makes both predicate calls "command not
+#                                 found", so two guards fire and the step exits
+#                                 1 — LOUD, with the wrong headline. Obligation
+#                                 8 below drives it.
+#   `mkdir -p "$SNAPSHOT_ARTIFACTS"`
+#                                 read by nothing, and covered more strongly
+#                                 than #1646 claimed: with the directory
+#                                 missing, `expected` comes back empty (the
+#                                 `wc -l < …` REDIRECT fails, which is why that
+#                                 one carries a `:-0` default and the two
+#                                 `find | wc -l` counts do not — those always
+#                                 print `0`), so the manifest guard AND the
+#                                 failure-image guard both fire. Measured.
+#   `cp -R …`                     the defect. Fixed above; obligations 1-7.
+#   `… >> "$GITHUB_STEP_SUMMARY"` read by nothing and genuinely SILENT —
+#                                 measured, a failing append leaves the step at
+#                                 exit 0. Left alone deliberately: the same text
+#                                 is echoed to stdout on the line above, so the
+#                                 blast radius is a missing line in the run
+#                                 summary and no information is lost. Stated
+#                                 here so the next reader does not have to
+#                                 re-derive it.
+#
+# The two `if: always()` upload steps are outside this block and cannot be
+# reached by `bad` at all; both declare `if-no-files-found: error`, so an
+# artifact path that stopped matching fails the job rather than uploading
+# nothing quietly. Read, not assumed.
+set -uo pipefail
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+cd "$REPO_ROOT" || { echo "FAIL: swift-snapshot-evidence_test — cannot cd to $REPO_ROOT" >&2; exit 1; }
+
+# A missing tool is a hard failure, not a skip: exiting 0 here would read as a
+# PASS to shell-lib-suite.sh, so the gate would go green having asserted
+# nothing — the failure mode this whole issue family is made of.
+need() { command -v "$1" >/dev/null 2>&1 || { echo "FAIL: swift-snapshot-evidence_test — $1 not found" >&2; exit 1; }; }
+need git
+need mktemp
+need bash
+need cp
+need find
+need grep
+need id
+
+WF=.github/workflows/macos-swift.yml
+STEP="Collect the skipped suites' pixels"
+REAL_LIB="$REPO_ROOT/tools/lib/swift-suite.sh"
+LOGDATA="$REPO_ROOT/tools/lib/testdata/swift-suite"
+
+# shellcheck source=workflow-step.sh
+. tools/lib/workflow-step.sh
+
+TMP=$(mktemp -d -t swift-snapshot-evidence) || exit 1
+# One arm deliberately makes a directory unwritable, so the cleanup has to be
+# able to get back in. `u+rwX` and not `777`: the point is to undo the arm, not
+# to widen anything.
+trap 'chmod -R u+rwX "$TMP" 2>/dev/null; rm -rf "$TMP"' EXIT
+
+rc=0
+pass() { echo "  PASS: $1"; return 0; }
+fail() { echo "  FAIL: $1 — expected [$2] got [$3]" >&2; rc=1; return 0; }
+flat() { echo "$1" | tr '\n' ' ' | cut -c1-400; }
+
+want_status() { # label want got out
+  if [[ "$3" == "$2" ]]; then pass "$1 (exit $2)"; else fail "$1" "exit $2" "exit $3 :: $(flat "$4")"; fi
+  return 0
+}
+want_contains() { # label needle haystack
+  case "$3" in *"$2"*) pass "$1" ;; *) fail "$1" "output containing: $2" "$(flat "$3")" ;; esac
+  return 0
+}
+want_absent() { # label needle haystack
+  case "$3" in *"$2"*) fail "$1" "no output containing: $2" "$(flat "$3")" ;; *) pass "$1" ;; esac
+  return 0
+}
+
+# ---------------------------------------------------------------------------
+# Preconditions. Each of these is something that, if it quietly stopped being
+# true, would leave every arm below grading something other than what it says.
+
+# Running as root defeats the mode bits obligation 4 relies on, and a `cp` that
+# succeeded there would report a MISSING arm instead of a FAILED one — a red
+# for the wrong reason at best. Refuse rather than skip.
+if [[ "$(id -u)" -eq 0 ]]; then
+  echo "FAIL: swift-snapshot-evidence_test — running as root; the unwritable-destination arm cannot be driven, and a skip would read as a pass" >&2
+  exit 1
+fi
+
+for f in clean hung zero-tests; do
+  [[ -s "$LOGDATA/$f.log" ]] || { echo "FAIL: swift-snapshot-evidence_test — log fixture $LOGDATA/$f.log missing or empty" >&2; exit 1; }
+done
+[[ -f "$REAL_LIB" ]] || { echo "FAIL: swift-snapshot-evidence_test — $REAL_LIB not found" >&2; exit 1; }
+
+# ---------------------------------------------------------------------------
+# The invocation and the body, DERIVED from the workflow (#1650).
+#
+# macos-swift.yml is the ONE workflow in this repo that declares `shell: bash`
+# on a step, so this step's invocation genuinely differs from every other
+# harnessed step's — `bash --noprofile --norc -e -o pipefail` against the
+# `bash -e` the others get. Typing either would be a coin flip that reads as
+# fact; workflow-step.sh REFUSES rather than defaulting, which is why both of
+# these are hard exits and not fallbacks.
+if ! STEP_SHELL=$(workflow_step_shell "$WF" "$STEP"); then
+  echo "FAIL: swift-snapshot-evidence_test — could not derive the shell $WF gives '$STEP' (refusal above); nothing below would have graded the real program" >&2
+  exit 1
+fi
+read -r -a STEP_ARGV <<<"$STEP_SHELL"
+if ! STEP_BODY=$(workflow_step_body "$WF" "$STEP"); then
+  echo "FAIL: swift-snapshot-evidence_test — could not extract the body of '$STEP' from $WF (refusal above)" >&2
+  exit 1
+fi
+printf '%s\n' "$STEP_BODY" >"$TMP/step.sh"
+echo "== $WF :: '$STEP' runs under \`$STEP_SHELL\` (derived) =="
+
+# The substitution has to still be the substitution. If the body stopped
+# calling one of these — or the library stopped defining it — the fixture
+# library below would be overriding nothing, or shadowing something real, and
+# every arm would grade a different program while still going green.
+for fn in swift_suite_run swift_suite_completed swift_suite_ran_tests; do
+  grep -q "$fn" "$TMP/step.sh" \
+    || { echo "FAIL: swift-snapshot-evidence_test — the step body no longer calls $fn; the fixture library is grading something else" >&2; exit 1; }
+  grep -qE "^$fn\(\)" "$REAL_LIB" \
+    || { echo "FAIL: swift-snapshot-evidence_test — $REAL_LIB no longer defines $fn" >&2; exit 1; }
+done
+
+# ---------------------------------------------------------------------------
+# The fixture checkout.
+#
+# The body runs `cd platforms/macos` and sources `tools/lib/swift-suite.sh`
+# relative to its cwd, so every arm executes against a throwaway tree under
+# $TMP. The repo's real platforms/macos/Tests/__Snapshots__ is READ by nothing
+# here and written by nothing here; the reference images below are two empty
+# files, because what is being graded is the copy's accounting, not its bytes.
+CHECKOUT="$TMP/checkout"
+
+# build_checkout <refs-mode>   full | empty | absent
+#
+# `platforms/macos` itself always exists — the body cds into it, and a cd that
+# failed would give an arm a status unrelated to its obligation.
+build_checkout() {
+  rm -rf "$CHECKOUT"
+  mkdir -p "$CHECKOUT/tools/lib" "$CHECKOUT/platforms/macos/Tests"
+  case "$1" in
+    full)
+      mkdir -p "$CHECKOUT/platforms/macos/Tests/__Snapshots__/SessionRowSnapshotTests"
+      : >"$CHECKOUT/platforms/macos/Tests/__Snapshots__/SessionRowSnapshotTests/testRow.1.png"
+      : >"$CHECKOUT/platforms/macos/Tests/__Snapshots__/SessionRowSnapshotTests/testRow.2.png" ;;
+    empty)
+      # Present but carrying no images — the state in which `cp -R` succeeds
+      # and ships nothing.
+      mkdir -p "$CHECKOUT/platforms/macos/Tests/__Snapshots__" ;;
+    absent) : ;;
+    *) echo "FAIL: swift-snapshot-evidence_test — unmodelled refs mode: $1" >&2; exit 1 ;;
+  esac
+
+  # The fixture library: the REAL one, with the pty runner replaced. Sourcing
+  # by absolute path is what keeps `swift_suite_completed` and
+  # `swift_suite_ran_tests` production code reading a production log fixture.
+  cat >"$CHECKOUT/tools/lib/swift-suite.sh" <<'STUBLIB'
+. "$SSE_REAL_LIB"
+swift_suite_run() {
+  local log="$1"
+  cp "$SSE_LOG_SRC" "$log" || return 1
+  if [ -n "${SSE_ARTIFACTS:-}" ]; then
+    bash "$SSE_ARTIFACTS" || return 1
+  fi
+  return "${SSE_RC:-1}"
+}
+STUBLIB
+  return 0
+}
+
+# The artifact scenarios. Each is a script run (by the fixture library) at the
+# moment the real suite would have finished writing into $SNAPSHOT_ARTIFACTS,
+# with that variable exported by the body exactly as in production.
+#
+# `manifest.txt` carries one line per primitive, which is what the step derives
+# `expected` from — so a scenario cannot state a count the images do not back.
+mk_artifacts() { # <file> <failure-images> [extra shell]
+  cat >"$1" <<ART
+set -e
+mkdir -p "\$SNAPSHOT_ARTIFACTS/RasterPrimitiveEvidence"
+: >"\$SNAPSHOT_ARTIFACTS/RasterPrimitiveEvidence/flat.png"
+: >"\$SNAPSHOT_ARTIFACTS/RasterPrimitiveEvidence/stroke.png"
+: >"\$SNAPSHOT_ARTIFACTS/RasterPrimitiveEvidence/text.png"
+: >"\$SNAPSHOT_ARTIFACTS/RasterPrimitiveEvidence/symbol.png"
+printf 'flat\nstroke\ntext\nsymbol\n' >"\$SNAPSHOT_ARTIFACTS/RasterPrimitiveEvidence/manifest.txt"
+ART
+  if [[ "$2" -gt 0 ]]; then
+    cat >>"$1" <<ART
+mkdir -p "\$SNAPSHOT_ARTIFACTS/SessionRowSnapshotTests"
+: >"\$SNAPSHOT_ARTIFACTS/SessionRowSnapshotTests/testRow.1.png"
+ART
+  fi
+  if [[ -n "${3:-}" ]]; then printf '%s\n' "$3" >>"$1"; fi
+  return 0
+}
+
+ARM=0
+# run_step <script> <refs-mode> <log-fixture> <rc> [artifacts-script]
+# -> sets OUT / ST / RT (this arm's RUNNER_TEMP)
+run_step() {
+  ARM=$((ARM + 1))
+  RT="$TMP/rt.$ARM"
+  mkdir -p "$RT"
+  # No `set +e` around this. THIS file runs under `set -uo pipefail` and
+  # deliberately not `-e`, so a non-zero inner status — the expected outcome of
+  # most arms — is data, not an abort. Toggling errexit here would leave it on
+  # for the rest of the file, which is the option-you-cannot-see family the
+  # sibling issues (#1633, #1635) are made of.
+  OUT=$(cd "$CHECKOUT" && env \
+          RUNNER_TEMP="$RT" \
+          GITHUB_STEP_SUMMARY="$RT/summary.md" \
+          SSE_REAL_LIB="$REAL_LIB" \
+          SSE_LOG_SRC="$LOGDATA/$3.log" \
+          SSE_RC="$4" \
+          SSE_ARTIFACTS="${5:-}" \
+          "${STEP_ARGV[@]}" "$1" 2>&1)
+  ST=$?
+  return 0
+}
+
+MISSING='there is no platforms/macos/Tests/__Snapshots__ to copy'
+CANNOT='could not copy platforms/macos/Tests/__Snapshots__'
+LANDED_NOTHING='reference copy reported success but'
+COPIED='reference image(s) into the artifact'
+
+# ---------------------------------------------------------------------------
+# Obligation 1 — the pre-#1646 hazard, re-measured on every run.
+#
+# The old statement verbatim, in the two lines of context that decide its fate:
+# the block's own `set +e`, and the `exit "$bad"` that is the only thing
+# deciding the step's status. Committed here rather than quoted in an issue,
+# per AGENTS.md: a number — or a behaviour — which documents something but is
+# not produced by it drifts silently.
+echo ""
+echo "== the pre-#1646 bare \`cp\` (the defect, re-measured) =="
+build_checkout absent
+cat >"$TMP/predecessor-cp.sh" <<'OLD'
+set +e
+set -uo pipefail
+bad=0
+export SNAPSHOT_ARTIFACTS="$RUNNER_TEMP/snapshot-artifacts"
+mkdir -p "$SNAPSHOT_ARTIFACTS"
+cp -R platforms/macos/Tests/__Snapshots__ "$SNAPSHOT_ARTIFACTS/__References__"
+exit "$bad"
+OLD
+run_step "$TMP/predecessor-cp.sh" absent clean 0 ""
+if [[ "$ST" -eq 0 ]]; then
+  pass "the old bare \`cp\` still exits 0 when the source is absent — the hazard is real"
+else
+  fail "the pre-fix copy exits 0 under \`set +e\` when it fails (the hazard this pins)" \
+       "exit 0" "exit $ST — the hazard is GONE, so re-derive the fix rather than trusting it :: $(flat "$OUT")"
+fi
+if [[ -e "$RT/snapshot-artifacts/__References__" ]]; then
+  fail "...having copied nothing" "no __References__ in the artifact" "the directory exists — the arm did not reproduce the defect"
+else
+  pass "...having produced no __References__ tree in the artifact it uploads"
+fi
+
+# ---------------------------------------------------------------------------
+# Obligation 2 — the vacuity guard: a healthy run still passes, and the
+# references demonstrably land where the upload step ships them from.
+echo ""
+echo "== the real step, healthy run =="
+build_checkout full
+mk_artifacts "$TMP/art-healthy.sh" 1
+run_step "$TMP/step.sh" full clean 0 "$TMP/art-healthy.sh"
+want_status "a healthy evidence run passes" 0 "$ST" "$OUT"
+want_contains "...and says how many references it copied" "$COPIED" "$OUT"
+if [[ -f "$RT/snapshot-artifacts/__References__/SessionRowSnapshotTests/testRow.1.png" ]]; then
+  pass "...with the reference tree actually present under \$RUNNER_TEMP/snapshot-artifacts, which is what the upload step ships"
+else
+  fail "the references land in the uploaded artifact" "__References__/SessionRowSnapshotTests/testRow.1.png under $RT/snapshot-artifacts" \
+       "$(find "$RT/snapshot-artifacts" 2>/dev/null | tr '\n' ' ')"
+fi
+want_absent "...and reports none of the three copy refusals" "::error::" "$OUT"
+
+# ---------------------------------------------------------------------------
+# Obligation 3 — nothing to copy.
+echo ""
+echo "== nothing to copy =="
+build_checkout absent
+mk_artifacts "$TMP/art-absent.sh" 1
+run_step "$TMP/step.sh" absent clean 0 "$TMP/art-absent.sh"
+want_status "a missing reference tree FAILS the step" 1 "$ST" "$OUT"
+want_contains "...naming the source that is not there" "$MISSING" "$OUT"
+want_absent "...and not the 'could not copy' diagnosis (obligation 6)" "$CANNOT" "$OUT"
+want_absent "...and not the 'landed nothing' diagnosis (obligation 6)" "$LANDED_NOTHING" "$OUT"
+# The other guards must stay quiet, or this arm's non-zero would be someone
+# else's: a shared exit status is satisfied by every refusal firing at once.
+want_absent "...with the run itself still judged healthy" "TRUNCATED" "$OUT"
+
+# ---------------------------------------------------------------------------
+# Obligation 4 — the copy fails.
+#
+# The destination is made unwritable at the moment the suite finishes, which is
+# after the step's own `mkdir -p` and before its copy — the only window in
+# which `cp` can fail with the source present.
+echo ""
+echo "== the copy fails =="
+build_checkout full
+mk_artifacts "$TMP/art-locked.sh" 1 'chmod 500 "$SNAPSHOT_ARTIFACTS"'
+run_step "$TMP/step.sh" full clean 0 "$TMP/art-locked.sh"
+chmod -R u+rwX "$RT" 2>/dev/null
+want_status "an unwritable destination FAILS the step" 1 "$ST" "$OUT"
+want_contains "...naming the copy that could not be made" "$CANNOT" "$OUT"
+want_absent "...and not the 'nothing to copy' diagnosis (obligation 6)" "$MISSING" "$OUT"
+want_absent "...and not the 'landed nothing' diagnosis (obligation 6)" "$LANDED_NOTHING" "$OUT"
+
+# ---------------------------------------------------------------------------
+# Obligation 5 — the copy succeeds and ships nothing.
+#
+# The one outcome no exit status can see: `cp -R` of an empty tree returns 0,
+# so the artifact arrives with a `__References__` directory and no references
+# in it, which reads exactly like health.
+echo ""
+echo "== the copy succeeds and lands nothing =="
+build_checkout empty
+mk_artifacts "$TMP/art-emptyrefs.sh" 1
+run_step "$TMP/step.sh" empty clean 0 "$TMP/art-emptyrefs.sh"
+want_status "an empty reference tree FAILS the step even though cp succeeded" 1 "$ST" "$OUT"
+want_contains "...naming the copy that reported success and landed nothing" "$LANDED_NOTHING" "$OUT"
+want_absent "...and not the 'nothing to copy' diagnosis (obligation 6)" "$MISSING" "$OUT"
+want_absent "...and not the 'could not copy' diagnosis (obligation 6)" "$CANNOT" "$OUT"
+# ...and the premise of the arm: cp really did succeed.
+if [[ -d "$RT/snapshot-artifacts/__References__" ]]; then
+  pass "...with the copy having demonstrably succeeded (the directory is there)"
+else
+  fail "the empty-copy arm's premise" "an empty __References__ directory in the artifact" "it is absent — cp failed, so this arm graded obligation 4"
+fi
+
+# ---------------------------------------------------------------------------
+# Obligation 7 — the references travel with a FAILED run, and are not counted
+# as failure images.
+#
+# This job exists to publish a run that fails; a copy that only happened on the
+# happy path would ship nothing on exactly the runs the artifact is for. The
+# second half pins the count's `__References__` exclusion: the real tree holds
+# 53 images, so without that exclusion the "not one of the suites produced a
+# failure image" guard could never fire again.
+echo ""
+echo "== a truncated run still publishes its references, and they are not miscounted =="
+build_checkout full
+mk_artifacts "$TMP/art-nofailures.sh" 0
+run_step "$TMP/step.sh" full hung 1 "$TMP/art-nofailures.sh"
+want_status "a truncated run fails the step" 1 "$ST" "$OUT"
+want_contains "...diagnosed as truncated" "TRUNCATED" "$OUT"
+want_contains "...with the references copied anyway" "$COPIED" "$OUT"
+want_absent "...and no copy refusal" "$CANNOT" "$OUT"
+want_contains "...and the copied references NOT counted as failure images" \
+  "not one of the five suites produced a failure image" "$OUT"
+want_contains "...which the count line says out loud" "collected 0 failure image(s)" "$OUT"
+
+# ---------------------------------------------------------------------------
+# Obligation 8 — the audit's remaining blind statement, measured rather than
+# dismissed.
+#
+# `. tools/lib/swift-suite.sh` is the other statement in the block whose status
+# reaches nothing. It is NOT silent: with the library gone, the two predicate
+# calls become "command not found", both guards fire and the step exits 1. What
+# it gets wrong is the DIAGNOSIS — it reports the run as TRUNCATED, pointing a
+# reader at XCTest when the step never loaded its harness. Recorded here rather
+# than claimed away; it is a loud failure with a misleading headline, not a
+# green.
+echo ""
+echo "== a library that does not load is LOUD (audit, #1646) =="
+build_checkout full
+rm -f "$CHECKOUT/tools/lib/swift-suite.sh"
+mk_artifacts "$TMP/art-nolib.sh" 1
+run_step "$TMP/step.sh" full clean 0 "$TMP/art-nolib.sh"
+want_status "a missing swift-suite.sh fails the step rather than passing quietly" 1 "$ST" "$OUT"
+want_contains "...though it is diagnosed as a truncated run, which is not what happened" "TRUNCATED" "$OUT"
+
+echo ""
+if [[ "$rc" -eq 0 ]]; then
+  echo "swift-snapshot-evidence_test: OK"
+else
+  echo "swift-snapshot-evidence_test: FAILED" >&2
+fi
+exit "$rc"

--- a/tools/preflight.sh
+++ b/tools/preflight.sh
@@ -439,7 +439,12 @@ if want tools; then
   # (#1629): swift-suite_test.sh asserts that every step there reading `$?`
   # disarms GitHub's `-e` first, and a commit editing only that workflow is
   # exactly the commit that breaks the invariant — so leaving it out would skip
-  # the check precisely when it matters.
+  # the check precisely when it matters. Since #1646 it earns its place twice
+  # over: swift-snapshot-evidence_test.sh EXTRACTS that workflow's "Collect the
+  # skipped suites' pixels" step and executes it, so the assertion that a
+  # failed reference copy fails the step — rather than shipping an artifact
+  # with nothing to compare against — also lives entirely inside this gate. No
+  # widening was needed for it; the entry was already here.
   # .github/workflows/test.yml joins them for the third time (#1639):
   # shell-lib-suite_test.sh asserts that its "Test the shared shell libs" step
   # goes through the shared runner rather than growing its own loop back, and a


### PR DESCRIPTION
Closes #1646.

## The fix

`.github/workflows/macos-swift.yml`'s `swift-snapshot-evidence` step opens with `set +e` — correctly, and the block says why: a step whose whole purpose is to run assertions that fail cannot inherit abort-on-first-failure (#1628/#1629). It accumulates into `bad` and ends `exit "$bad"`. One statement's status was read by nothing:

```sh
cp -R platforms/macos/Tests/__Snapshots__ "$SNAPSHOT_ARTIFACTS/__References__"
```

**#1646 filed this on a READ of the block and said so. I ran it before changing anything**, extracting the decisive lines and executing them under the shell that step gets:

```
cp: platforms/macos/Tests/__Snapshots__: No such file or directory
cp status was: 1 (read by nothing)
STEP EXIT: 0
(artifact contents above; empty = no __References__)
```

Green step, empty artifact — failure images with nothing to compare them against.

Three outcomes now, per #1645's discipline, because they point at three different places: **nothing to copy** (the references moved or the checkout is incomplete), **could not copy** (the destination is unwritable), **copied**. Plus a fourth no exit status can see: `cp -R` of an EMPTY tree *succeeds*, so a count is what tells a copy that landed from one that reported success and shipped nothing. Each refusal names what is missing from the artifact.

## Extract-and-execute: achieved, and how

`tools/lib/swift-snapshot-evidence_test.sh` reads the **real** step body out of the **real** workflow and RUNS it, under the invocation that step actually gets — derived through `tools/lib/workflow-step.sh`, never typed. `macos-swift.yml` is the one workflow here declaring `shell: bash`, so this is the family's first harness whose step resolves to `bash --noprofile --norc -e -o pipefail` rather than `bash -e`; the harness prints the derived invocation on every run.

#1646's stated reason for not reproducing was that the step "sources `swift-suite.sh` and drives a real `swift test`". Only the second half is genuinely unreachable, and it is the half that can be replaced without grading a different program:

* **the library is the real one.** The fixture checkout's `tools/lib/swift-suite.sh` sources the repo's own file by absolute path and overrides exactly one function, so `swift_suite_completed` and `swift_suite_ran_tests` — the two predicates the body consults — are production code reading a committed log fixture from `tools/lib/testdata/swift-suite/`.
* **`swift test` is not run.** `swift_suite_run` is the pty runner that drives it; the override writes a chosen log fixture, plants the artifacts a chosen scenario would have produced, and returns a chosen status. That is the whole substitution, and it makes every outcome of a 20-minute macOS job reachable in a second.

So no text assertion was needed anywhere. What is graded is the step's **status accounting** against the real body, the real shell and the real predicates. Stated limits, in the file's header rather than only here: it does not grade whether a real `swift test` writes what the scenarios assume (that is the evidence job on a runner), nor whether the predicates judge a real log correctly (that is `swift-suite_test.sh`, which owns the log corpus this borrows). A precondition asserts the body still calls all three `swift_suite_*` names and the real library still defines them, so the substitution cannot silently stop being the substitution.

Eight obligations: the pre-fix hazard re-measured every run (also the vacuity guard); a healthy run still exiting 0 with the references demonstrably under `$RUNNER_TEMP/snapshot-artifacts`; the three copy outcomes; each of those three asserting the **other two's wording is absent** (a shared non-zero is satisfied by three refusals firing together — #1644 measured that); the references travelling with a **failed** run and not being counted as failure images; and the audit arm below.

## Re-audit: what decides the status, and what it cannot see

`exit "$bad"` decides. `bad` is written by exactly six guards — the 124 hang, the truncation, the zero-test run, the copy (now three outcomes), the manifest count, the failure-image count. #1646 traced this and found one blind statement. Measured rather than inherited, there are **four**:

| statement | status read by | outcome |
|---|---|---|
| `. tools/lib/swift-suite.sh` | nothing | **loud, misdiagnosed.** Both predicate calls become "command not found", two guards fire, step exits 1 — reported as `TRUNCATED`, pointing a reader at XCTest when the harness never loaded. Driven by obligation 8. |
| `mkdir -p "$SNAPSHOT_ARTIFACTS"` | nothing | **loud, and more strongly than #1646 claimed.** Measured: with the directory missing, `expected` comes back empty (the `wc -l < …` *redirect* fails — which is why that one carries `:-0` and the two `find \| wc -l` counts do not; those always print `0`), so the manifest guard **and** the failure-image guard both fire. |
| `cp -R …` | nothing | **the defect.** Fixed. |
| `… >> "$GITHUB_STEP_SUMMARY"` | nothing | **genuinely silent** — measured, a failing append leaves the step at exit 0. Left alone deliberately, and stated rather than dismissed: the identical text is echoed to stdout on the line above, so the blast radius is one missing line in the run summary and no information is lost. |

The three `swift_suite_*` predicate calls and the `rc -eq 124` check all set `bad` — #1646's reading of those confirmed. The two `if: always()` upload steps are outside the block and unreachable by `bad`; both declare `if-no-files-found: error`, so an artifact path that stopped matching fails the job rather than uploading nothing quietly (read at lines 417/426, not assumed).

## Mutation evidence

Every arm the change adds, seen red. One mutation per run, applied and reverted with a `git status --porcelain` assertion after each.

**M1 — revert the block to the bare `cp` (the pre-fix state).** 8 arms red across obligations 2, 3, 4, 5 and 7:
```
FAIL: a missing reference tree FAILS the step — expected [exit 1] got [exit 0 :: cp: … No such file or directory  collected 1 failure image(s) …]
FAIL: an unwritable destination FAILS the step — expected [exit 1] got [exit 0 :: cp: … Permission denied …]
FAIL: an empty reference tree FAILS the step even though cp succeeded — expected [exit 1] got [exit 0 …]
FAIL: ...and says how many references it copied — expected [output containing: reference image(s) into the artifact]
```

**M2 — fold "nothing to copy" into "could not copy"** (`if ! cp` only). Red on obligation 3's two arms *and nothing else*, which is the isolation claim:
```
FAIL: ...naming the source that is not there — got [::error::could not copy platforms/macos/Tests/__Snapshots__ …]
FAIL: ...and not the 'could not copy' diagnosis (obligation 6)
```

**M3 — drop the empty-landing post-condition** (trust `cp`'s status alone). Red on obligation 5 alone:
```
FAIL: an empty reference tree FAILS the step even though cp succeeded — got [exit 0 :: copied 0 reference image(s) into the artifact …]
```

**M4 — skip the copy when the run was judged bad.** Red on obligation 7's copy-anyway arm alone:
```
FAIL: ...with the references copied anyway — got [… the run already failed; skipping the reference copy …]
```

**M5 — drop `-not -path '*/__References__/*'` from the failure-image count.** Red on the two miscount arms alone:
```
FAIL: ...and the copied references NOT counted as failure images — got [copied 2 reference image(s) … collected 2 failure image(s) …]
FAIL: ...which the count line says out loud — expected [collected 0 failure image(s)]
```

**M6 — vacuity probe: the copy block refuses unconditionally.** Red on the healthy arm alone, so no arm reports unconditionally:
```
FAIL: a healthy evidence run passes — expected [exit 0] got [exit 1 :: copied 2 reference image(s) into the artifact …]
```

**M7 — rename the step in the workflow.** The harness REFUSES rather than grading an empty body as a clean run:
```
workflow-step: refusing — .github/workflows/macos-swift.yml has no step named "Collect the skipped suites' pixels". …
FAIL: swift-snapshot-evidence_test — could not derive the shell … nothing below would have graded the real program
```

## Gates

Run locally on macOS, each as its own foreground invocation, exit status read directly (not through a pipe — this repo's shell is zsh, where `${PIPESTATUS[0]}` silently yields nothing):

* `tools/preflight.sh --only tools` → **PASS**, exit 0. The shell-lib runner reports `found 15, skipped 0, ran 15, failed 0` — the new file is one of them.
* `tools/preflight.sh --only swift` → **PASS**, exit 0. `ImageSnapshotCIScopeTests`' four tests pass, which matters here: that suite text-parses this very workflow for `--skip `/`--filter ` tokens, so it is the check that the new `::error::` copy did not inject a phantom suite into the skip-list derivation.
* The pre-push hook ran `--changed`: `tools/lib shell-lib tests` PASS, `gofmt` PASS, `macOS Swift build + test` PASS, everything else SKIP.
* `shellcheck -S warning` clean on the new file; `python3 -c yaml.safe_load` parses the workflow and reports the three jobs and five evidence-job steps.

**What ran where.** Everything above is local. The real-runner half has since landed too — all 16 PR checks pass — and it is worth quoting, because two of the three things it confirms could not be measured locally:

* **`swift-snapshot-evidence`** (macos-latest, 1m15s, pass). Its step log now carries the line that did not exist before:
  ```
  copied 53 reference image(s) into the artifact
  collected 36 failure image(s) and 7 of 7 primitive image(s)
  ```
  53 is the whole committed `__Snapshots__` tree, so the copy is reported rather than assumed — and the second line is obligation 7's second half against the REAL tree rather than a two-image fixture: 36 failure images, not 89, so the 53 references are still excluded from the count they would otherwise satisfy forever. No `::error::` was emitted.
* **the derived invocation, confirmed by the runner itself.** The same log's group headers read `shell: /bin/bash --noprofile --norc -e -o pipefail {0}` for this step and `shell: /bin/bash -e {0}` for the `Report toolchain` step beside it — which is exactly the split `workflow-step.sh` derived and the harness printed. That is #1650's premise re-measured for free.
* **`go-test`** (macos-latest, pass) ran the new harness on the runner: `== tools/lib/swift-snapshot-evidence_test.sh ==` → `swift-snapshot-evidence_test: OK`, in the census `found 15, skipped 1 (posix-lint_test.sh), ran 14, failed 0`.

`swift-build`, `swift-test`, `build-test`, `ars-gate`, both web suites, CodeQL, SonarCloud and CodeScene (advisory) all pass. `go-test` did not hit #1674's fswatcher flake on this run.

## Also here

* `AGENTS.md` gains the family bullet, beside the ars.yml and deletion-guard ones — including the part worth reusing: this is where extract-and-execute stopped being blocked by an expensive command, by overriding one function of a sourced library rather than stubbing the library.
* `tools/preflight.sh`'s `tools`-gate comment records that `macos-swift.yml` now earns its place there twice. **No sixth widening was needed** — that workflow has been in the trigger since #1629, and `workflow-step_test.sh` already pinned this step by name, so the new harness joins a gate that already covers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
