### PR TITLE
fix(tools): give both reap polls one bounded implementation (#1627)

### DIFF
--- a/tools/lib/await-gone.sh
+++ b/tools/lib/await-gone.sh
@@ -1,0 +1,285 @@
+#!/usr/bin/env bash
+# await-gone.sh — poll until a process, or a set of them, is gone. Bounded from
+# BOTH ends, and loud when it could not look at all (#1627).
+#
+# This file is sourced, not executed:
+#
+#   . tools/lib/await-gone.sh
+#
+#   leaf_gone() {                       # the predicate — see "The predicate"
+#     AWAIT_GONE_LOOKED=1               # I was able to look
+#     AWAIT_GONE_ALIVE=""               # ...and nothing is there
+#     kill -0 "$pid" 2>/dev/null && AWAIT_GONE_ALIVE="pid $pid"
+#   }
+#
+#   deadline=3 lifetime=30
+#   await_gone_bound "$deadline" "$lifetime" "the leaf's own sleep" || fail ...
+#   await_gone "$deadline" "$lifetime" leaf_gone "the leaf's own sleep"
+#   case $? in
+#     0) pass "gone on look $AWAIT_GONE_LOOKS, after ${AWAIT_GONE_ELAPSED}s" ;;
+#     1) fail "still there after ${AWAIT_GONE_ELAPSED}s / $AWAIT_GONE_LOOKS looks; last seen: $AWAIT_GONE_LAST" ;;
+#     2) fail "$AWAIT_GONE_REASON" ;;
+#   esac
+#
+# Shell options, both directions, because every other library here now says so
+# (#1633, #1635):
+#
+#   this file  requires nothing of the caller's options and changes none of
+#              them. Both functions RETURN their verdict — 0, 1 or 2 — whether
+#              or not `-e` is set. The caller's predicate is invoked as the
+#              left operand of `||`, so errexit is ignored for the whole of its
+#              body: a predicate built on `kill -0`, whose non-zero return is
+#              its ORDINARY answer, cannot abort the caller from in here.
+#   the caller must keep `$?` reachable if it wants to tell the three apart.
+#              Under `-e` a bare non-zero return aborts the caller on that
+#              line — write `|| rc=$?`, or read `$?` in a `case` as above
+#              (#1629).
+#
+# ---------------------------------------------------------------------------
+# Why this exists
+#
+# Two fixtures polled for a process tree to be reaped, written two PRs apart,
+# and they had drifted in four ways that are not stylistic — `$SECONDS` vs
+# `date +%s`, a SET matched by pattern vs ONE recorded pid, only one of them
+# describing the last-observed state, and only one of them checking the
+# deadline against the fixture's own lifetime. The last of those is the defect
+# #1627 was filed about; the rest is why fixing it in place would have left a
+# third fixture inheriting nothing.
+#
+# Three rules live here rather than in a comment in one of them.
+#
+# 1. POLLED, NOT SLEPT (#1586, #1619). A fixture that waits by sleeping a fixed
+#    interval and then looks once has not observed what it waits for: the sleep
+#    only has to be shorter than the machine is slow to turn a correct kill into
+#    a red, and it makes the passing case slower than it needs to be. The first
+#    look here happens with nothing in front of it, so a tree already reaped
+#    when the killer returned — which is what a correct implementation produces,
+#    since it posts SIGKILL and `wait`s before returning — is reported at once.
+#    Measured for both current callers, and neither has a lower bound worth
+#    speaking of: 50/50 gone on look 1 at 0s for gate-budget's tree (25 idle at
+#    load ~4, 25 at load 27→53 on 10 cores, #1627) and the same 50/50 for
+#    swift-suite's grandchild (#1619). The deadline is therefore slack for a
+#    machine too busy to finish a teardown, never a latency being fitted.
+#
+# 2. THE WALL FROM ABOVE — await_gone_bound (#1619's M4, #1627). Precisely
+#    because there is no latency to fit, nothing pulls the deadline DOWN, and a
+#    deadline anywhere near the subject's own lifetime stops asserting
+#    anything: "the fixture exited by itself" and "the fixture was reaped"
+#    produce the same reading, and the case passes vacuously. So the deadline
+#    and the subject's lifetime are declared as a PAIR and the relation between
+#    them is checked rather than assumed. AWAIT_GONE_RATIO is the order of
+#    magnitude that separates the two readings; it is a constant, not a knob.
+#
+# 3. "COULD NOT LOOK" IS NOT "IT IS GONE". This repo's central bug family
+#    (#1485/#1492/#1513/#1524/#1533/#1537, and AGENTS.md's "a verification
+#    mechanism must fail loudly when it cannot run") lands here in its purest
+#    form: a predicate that fails to RUN reports nothing, and nothing is
+#    byte-identical to a subject that is gone — so the poll returns success the
+#    instant it goes blind. #1619 answered that by choosing `kill -0`, a shell
+#    BUILTIN, as the predicate, so there is no PATH lookup, no exec and no
+#    external binary that can be missing. That is still the rule and a
+#    predicate should be built from builtins wherever it can be.
+#
+#    But it cannot always be: gate-budget's fixture polls a SET of shells that
+#    only `pgrep -f <pattern>` can enumerate, and `pgrep` is an external binary
+#    like any other. So the rule is backed by a mechanism as well as stated: a
+#    predicate reports whether it was ABLE to look (AWAIT_GONE_LOOKED)
+#    separately from what it SAW (AWAIT_GONE_ALIVE), and a predicate that could
+#    not look is a loud refusal (2) rather than a pass (0). A predicate that
+#    returns without setting either is a refusal too — the alternative is that
+#    the previous look's values survive into this one, which is the same
+#    failure wearing a different hat.
+#
+# ---------------------------------------------------------------------------
+# The predicate, and why it reports through VARIABLES
+#
+# A predicate is a shell FUNCTION taking no arguments. It sets:
+#
+#   AWAIT_GONE_LOOKED  1 if it was able to look at all, 0 if it was not.
+#   AWAIT_GONE_ALIVE   when LOOKED=1: a description of everything still there,
+#                      or the empty string when the subject is gone. When
+#                      LOOKED=0: why it could not look.
+#
+# BOTH are cleared to a sentinel before every call and BOTH must be set. A
+# predicate that reports one and not the other is refused rather than read at
+# its default, because every default here is one of the two answers: leaving
+# LOOKED unset would inherit the previous look's "I looked", and leaving ALIVE
+# unset at the empty string is literally the word "gone".
+#
+# Its return status is ignored on purpose — `kill -0` and `pgrep` both answer
+# "nothing there" with a non-zero status, so a status-carried verdict would be
+# the same conflation this file exists to remove.
+#
+# Reporting through variables rather than stdout is what keeps rule 3 whole.
+# Capturing stdout means `desc=$(predicate)`, which forks a subshell per look;
+# a builtin predicate would then depend on a fork succeeding, on exactly the
+# loaded machine the deadline exists for, and the fork's failure mode is
+# precisely the empty-output-reads-as-gone shape above. Called plainly, a
+# predicate made of builtins costs no fork at all and its assignments are
+# visible here. tools/lib/await-gone_test.sh asserts that seam directly: a
+# predicate incrementing a counter must have incremented it exactly
+# AWAIT_GONE_LOOKS times when await_gone returns, which a subshell would lose.
+#
+# `ps` — the only way to say WHAT state a surviving pid is in — may DESCRIBE a
+# subject inside a predicate but must never decide the verdict: a missing or
+# broken `ps` prints nothing, and nothing would otherwise read as reaped. Set
+# AWAIT_GONE_LOOKED from the builtin and use `ps` only to fill in
+# AWAIT_GONE_ALIVE.
+
+# How long to wait between looks. A knob only so this library's own tests can
+# run in milliseconds; both real callers use the default.
+: "${AWAIT_GONE_POLL_SECONDS:=0.1}"
+
+# The order of magnitude await_gone_bound requires between the poll deadline
+# and the subject's own lifetime. NOT a knob: lowering it is exactly the edit
+# the guard exists to refuse, and it would be invisible in a diff that also
+# raised a deadline.
+AWAIT_GONE_RATIO=10
+
+# Set by await_gone. Declared here so a caller reading them under `set -u`
+# after a refusal that returned before the loop still gets a defined value.
+AWAIT_GONE_LOOKS=0
+AWAIT_GONE_ELAPSED=0
+AWAIT_GONE_LAST=""
+AWAIT_GONE_REASON=""
+
+# Set by the predicate, read by await_gone. See "The predicate" above.
+AWAIT_GONE_LOOKED=""
+AWAIT_GONE_ALIVE=""
+
+# What both of the above are cleared to before each look. Any value that is not
+# a legal answer would do; this one is spelled so that it cannot be mistaken
+# for a description of a real process if it ever reaches a failure line.
+AWAIT_GONE_UNREPORTED='<the predicate did not report>'
+
+# What a caller that names no subject gets in the refusal text. A variable and
+# not an inline `${3:-…}` default, because bash treats a `'` inside a parameter
+# expansion's word as a QUOTE even when the whole expansion is double-quoted —
+# measured on 3.2.57: `x="${1:-the subject's own lifetime}"` is a parse error
+# ("unexpected EOF while looking for matching `''"), where the same text
+# reached through a variable is fine.
+AWAIT_GONE_DEFAULT_WHAT="the subject's own lifetime"
+
+# _await_gone_refuse <message> — record and print a refusal. One place, so a
+# refusal always reaches both the caller's AWAIT_GONE_REASON and stderr; a
+# refusal that only set the variable would be silent in the log of a caller
+# that forgot to print it.
+_await_gone_refuse() {
+  AWAIT_GONE_REASON="await-gone: refusing — $1"
+  printf '%s\n' "$AWAIT_GONE_REASON" >&2
+  return 2
+}
+
+# await_gone_bound <deadline> <lifetime> [what] — the wall from above (rule 2).
+# 0 when the deadline is an order of magnitude under the subject's own
+# lifetime, 2 with a named reason otherwise.
+#
+# Callers state it at the point where the two numbers are DECLARED, so a wrong
+# pair is reported before the fixture spends any time; await_gone re-checks it
+# anyway and fails closed, so skipping the call cannot buy an unbounded poll.
+await_gone_bound() {
+  local deadline="${1:-}" lifetime="${2:-}" what="${3:-$AWAIT_GONE_DEFAULT_WHAT}"
+  AWAIT_GONE_REASON=""
+  case "$deadline" in
+    '' | *[!0-9]*)
+      _await_gone_refuse "the deadline must be a whole number of seconds, got '$deadline'"
+      return 2 ;;
+  esac
+  case "$lifetime" in
+    '' | *[!0-9]*)
+      _await_gone_refuse "$what must be a whole number of seconds, got '$lifetime'"
+      return 2 ;;
+  esac
+  # A zero deadline is refused rather than accepted as "look once": the ratio
+  # below is vacuously satisfied by it, so it would slip through the one check
+  # that gives this poll its meaning while being a different assertion
+  # entirely.
+  if [ "$deadline" -lt 1 ]; then
+    _await_gone_refuse "the deadline must be at least 1s; 'look exactly once' is a different assertion and the ratio check below cannot bound it"
+    return 2
+  fi
+  if [ "$lifetime" -lt 1 ]; then
+    _await_gone_refuse "$what must be at least 1s, got ${lifetime}s — there is nothing for the deadline to be under"
+    return 2
+  fi
+  if [ "$(( deadline * AWAIT_GONE_RATIO ))" -le "$lifetime" ]; then
+    return 0
+  fi
+  _await_gone_refuse "a ${deadline}s deadline is not ${AWAIT_GONE_RATIO}x under $what (${lifetime}s) — at that ratio a subject that exited BY ITSELF reads exactly like one that was reaped, and the poll stops asserting anything"
+  return 2
+}
+
+# await_gone <deadline> <lifetime> <predicate-fn> [what] — poll until the
+# predicate says the subject is gone.
+#
+#   0  gone. AWAIT_GONE_LOOKS / AWAIT_GONE_ELAPSED say how quickly.
+#   1  still there when the deadline expired. AWAIT_GONE_LAST carries the last
+#      state observed, so the caller's failure line can self-identify (a
+#      zombie, say) instead of printing a bare pid.
+#   2  the poll could not be judged at all: a bad bound, no such predicate, or
+#      a predicate that could not look. Distinct from 1 because "it survived"
+#      and "nothing was checked" are different answers, and AWAIT_GONE_REASON
+#      names which.
+await_gone() {
+  local deadline="${1:-}" lifetime="${2:-}" pred="${3:-}" what="${4:-$AWAIT_GONE_DEFAULT_WHAT}"
+
+  AWAIT_GONE_LOOKS=0
+  AWAIT_GONE_ELAPSED=0
+  AWAIT_GONE_LAST=""
+  AWAIT_GONE_REASON=""
+
+  # Re-checked here rather than trusted to the caller, and it fails CLOSED:
+  # the bound is the only thing that makes this poll assert anything, so a
+  # caller that skipped await_gone_bound, or called it with numbers other than
+  # the ones it then polls with, must not get an unbounded poll. Same shape as
+  # hookjson.DecodeConfined re-checking its declared permission set.
+  await_gone_bound "$deadline" "$lifetime" "$what" || return 2
+
+  if [ -z "$pred" ] || ! declare -F "$pred" >/dev/null 2>&1; then
+    _await_gone_refuse "'$pred' is not a shell function, so there is no predicate to look with — a poll with nothing to ask would run to the deadline and report the subject gone"
+    return 2
+  fi
+
+  local start=$SECONDS
+  while :; do
+    AWAIT_GONE_LOOKS=$(( AWAIT_GONE_LOOKS + 1 ))
+    # Cleared before every call so a predicate that returns without reporting
+    # is caught here instead of silently re-using the previous look's answer.
+    AWAIT_GONE_LOOKED="$AWAIT_GONE_UNREPORTED"
+    AWAIT_GONE_ALIVE="$AWAIT_GONE_UNREPORTED"
+    # `|| :` and not a bare call: a predicate's ordinary answer is a non-zero
+    # status (`kill -0` on a dead pid, `pgrep` matching nothing), and a
+    # compound left operand of `||` runs with errexit ignored throughout — so
+    # a caller with `-e` set neither dies inside the predicate nor needs to
+    # know this. The status is discarded by design; the verdict is the two
+    # variables above.
+    "$pred" || :
+    AWAIT_GONE_ELAPSED=$(( SECONDS - start ))
+
+    case "$AWAIT_GONE_LOOKED" in
+      1) ;;
+      0)
+        local why="$AWAIT_GONE_ALIVE"
+        [ "$why" = "$AWAIT_GONE_UNREPORTED" ] && why="no reason given"
+        _await_gone_refuse "the predicate '$pred' could not look on look $AWAIT_GONE_LOOKS: ${why:-no reason given}. Being unable to look must not be reported as the subject being gone"
+        return 2 ;;
+      *)
+        _await_gone_refuse "the predicate '$pred' returned without setting AWAIT_GONE_LOOKED on look $AWAIT_GONE_LOOKS, so there is no way to tell 'nothing is there' from 'nothing was checked'"
+        return 2 ;;
+    esac
+
+    if [ "$AWAIT_GONE_ALIVE" = "$AWAIT_GONE_UNREPORTED" ]; then
+      _await_gone_refuse "the predicate '$pred' reported that it looked but never set AWAIT_GONE_ALIVE on look $AWAIT_GONE_LOOKS — an unset description defaults to the empty string, which is this poll's spelling of 'the subject is gone'"
+      return 2
+    fi
+
+    AWAIT_GONE_LAST="$AWAIT_GONE_ALIVE"
+    if [ -z "$AWAIT_GONE_ALIVE" ]; then
+      return 0
+    fi
+    if [ "$AWAIT_GONE_ELAPSED" -ge "$deadline" ]; then
+      return 1
+    fi
+    sleep "$AWAIT_GONE_POLL_SECONDS"
+  done
+}

--- a/tools/lib/await-gone_test.sh
+++ b/tools/lib/await-gone_test.sh
@@ -1,0 +1,235 @@
+#!/usr/bin/env bash
+# await-gone_test.sh — unit tests for lib/await-gone.sh. Plain bash, no
+# framework, matching tools/lib/gate-budget_test.sh. Run directly, or via
+# tools/preflight.sh's `tools` gate.
+#
+# Covers #1627. Two fixtures — gate-budget_test.sh's killed process tree and
+# swift-suite_test.sh's killed grandchild — polled for a reap with two
+# implementations of the same idiom, and only one of them bounded its deadline
+# from above. This file grades the library both of them now call.
+#
+# ---------------------------------------------------------------------------
+# What is a LOCK here and what is not
+#
+# The library is new, so almost nothing in it "passes by construction" in the
+# sense AGENTS.md exempts: every assertion below is over behaviour this change
+# ADDS, and each therefore owes a deliberate mutation seen red. Those mutations
+# are in the PR body; the ones about the predicate contract are COMMITTED
+# instead, as the deliberately-wrong predicates whose names end in
+# `_predicate` — the shape `hookjson`'s `forgetfulReceiver` uses, so the
+# evidence outlives the PR that added it. No count is stated, because nothing
+# would keep one honest.
+#
+# The two that are genuinely locks — behaviour that predates this change and
+# must not move — are named where they sit:
+#
+#   the RATIO REFUSAL at 15s against a 30s lifetime, which is #1627's
+#   subject: the exact pair gate-budget_test.sh carried, and the pair
+#   swift-suite_test.sh's own `(( reap_deadline * 10 <= gc_sleep ))` (#1619's
+#   M4) would have refused had it been applied there.
+#
+#   GONE ON LOOK 1, which is #1619's measurement replayed as an assertion: a
+#   subject already gone when the poll starts is reported at once rather than
+#   after a fixed sleep.
+
+set -uo pipefail   # NOT -e: assertions capture non-zero return codes
+
+DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=await-gone.sh
+source "$DIR/await-gone.sh"
+
+# A missing tool is a hard failure, not a skip: exiting 0 here would read as a
+# PASS to preflight's shell_lib_tests and to test.yml's loop, so the gate would
+# go green having asserted nothing.
+need() { command -v "$1" >/dev/null 2>&1 || { echo "FAIL: await-gone_test — $1 not found" >&2; exit 1; }; }
+need sleep
+
+# Keep the suite in milliseconds rather than seconds. The interval is how long
+# the poll waits between looks and changes nothing about what is asserted.
+AWAIT_GONE_POLL_SECONDS=0.02
+
+fails=0
+pass() { echo "  PASS: $1"; return 0; }
+fail() { echo "  FAIL: $1 — expected [$2] got [$3]"; fails=$((fails + 1)); return 0; }
+assert_eq() {
+  if [[ "$2" == "$3" ]]; then pass "$1"; else fail "$1" "$2" "$3"; fi
+}
+# The refusal assertions name a FRAGMENT of the message, never just the status:
+# every refusal here returns 2, so "it returned 2" is satisfied by the wrong
+# refusal firing. Same rule contracttesting's negative self-tests follow.
+assert_reason() {
+  case "$AWAIT_GONE_REASON" in
+    *"$2"*) pass "$1" ;;
+    *) fail "$1" "a refusal naming: $2" "${AWAIT_GONE_REASON:-nothing was recorded}" ;;
+  esac
+}
+
+echo ""
+echo "== await_gone_bound: the wall from ABOVE (#1619's M4, #1627) =="
+
+# THE LOCK. 15s against a 30s lifetime is exactly what gate-budget_test.sh
+# carried, and exactly what swift-suite_test.sh's inline guard would have
+# refused. A 2:1 ratio means "the fixture exited by itself" and "the fixture
+# was reaped" produce the same reading.
+await_gone_bound 15 30 "the leaf's own sleep" 2>/dev/null
+assert_eq "refuses the 15s-against-30s pair #1627 found" "2" "$?"
+assert_reason "...and the refusal names both numbers and the subject" "a 15s deadline is not 10x under the leaf's own sleep (30s)"
+
+# The vacuity guard. A guard that refused everything would satisfy the case
+# above and read as excellent coverage; these two are the pairs the callers
+# actually use.
+await_gone_bound 3 30 "the leaf's own sleep" 2>/dev/null
+assert_eq "accepts 3s against 30s — gate-budget_test.sh's pair, exactly at the wall" "0" "$?"
+await_gone_bound 15 300 "the grandchild's own lifetime" 2>/dev/null
+assert_eq "accepts 15s against 300s — swift-suite_test.sh's pair" "0" "$?"
+
+# One second past the wall. The boundary is where a guard is worth having: at
+# 3/30 the caller sits ON it, so the next author who raises the deadline by one
+# second is the case this must catch.
+await_gone_bound 4 30 "the leaf's own sleep" 2>/dev/null
+assert_eq "refuses 4s against 30s — one second past the wall" "2" "$?"
+
+await_gone_bound "" 30 2>/dev/null
+assert_eq "refuses an empty deadline" "2" "$?"
+await_gone_bound 3s 30 2>/dev/null
+assert_eq "refuses a non-numeric deadline" "2" "$?"
+assert_reason "...naming what it could not read" "the deadline must be a whole number of seconds, got '3s'"
+await_gone_bound 3 forever 2>/dev/null
+assert_eq "refuses a non-numeric lifetime" "2" "$?"
+await_gone_bound 0 30 2>/dev/null
+assert_eq "refuses a zero deadline rather than reading it as 'look once'" "2" "$?"
+assert_reason "...saying why zero is a different assertion" "'look exactly once' is a different assertion"
+
+echo ""
+echo "== await_gone re-checks the bound and fails CLOSED =="
+# The caller states the bound where the two numbers are declared, so a wrong
+# pair is reported before the fixture spends any time. That call is a
+# convenience; this is the enforcement. A caller that skipped it, or that
+# polled with numbers other than the ones it checked, must not get an
+# unbounded poll — hookjson.DecodeConfined's shape.
+already_gone() { AWAIT_GONE_LOOKED=1; AWAIT_GONE_ALIVE=""; }
+await_gone 15 30 already_gone "the leaf's own sleep" 2>/dev/null
+assert_eq "refuses a bad bound even when the subject IS gone" "2" "$?"
+assert_reason "...with the bound's own refusal, not a poll result" "is not 10x under"
+
+echo ""
+echo "== a subject already gone is reported on LOOK 1 (#1619, #1627) =="
+# The other lock. Measured 50/50 at look 1 / 0s for both callers, so the poll
+# must report at once rather than after a fixed sleep — that is the whole
+# difference between polling and #1586's sleeping fixture.
+await_gone 3 30 already_gone "the leaf's own sleep"
+rc=$?
+assert_eq "returns 0 for a subject that is already gone" "0" "$rc"
+assert_eq "...on the first look, with nothing in front of it" "1" "$AWAIT_GONE_LOOKS"
+assert_eq "...and no time on the clock" "0" "$AWAIT_GONE_ELAPSED"
+
+echo ""
+echo "== a subject that outlives the deadline fails LOUDLY, with evidence =="
+# The failure line has to self-identify: elapsed, look count and the last state
+# observed. A bare pid is what swift-suite_test.sh's predecessor printed, and
+# it cannot tell a live process from an unreaped zombie.
+victim_cmd() { AWAIT_GONE_LOOKED=1; AWAIT_GONE_ALIVE=""; kill -0 "$victim" 2>/dev/null && AWAIT_GONE_ALIVE="pid $victim (state R, the fixture's own sleep)"; }
+sleep 30 & victim=$!
+await_gone 1 10 victim_cmd "the victim's own sleep"
+rc=$?
+assert_eq "returns 1 for a subject that is still there at the deadline" "1" "$rc"
+[[ "$AWAIT_GONE_ELAPSED" -ge 1 ]] \
+  && pass "...having actually waited to the deadline (${AWAIT_GONE_ELAPSED}s)" \
+  || fail "...having actually waited to the deadline" ">= 1s" "${AWAIT_GONE_ELAPSED}s"
+[[ "$AWAIT_GONE_LOOKS" -gt 1 ]] \
+  && pass "...over more than one look ($AWAIT_GONE_LOOKS)" \
+  || fail "...over more than one look" "> 1" "$AWAIT_GONE_LOOKS"
+assert_eq "...carrying the last state observed, not a bare pid" "pid $victim (state R, the fixture's own sleep)" "$AWAIT_GONE_LAST"
+kill -9 "$victim" 2>/dev/null
+wait "$victim" 2>/dev/null
+
+echo ""
+echo "== 'could not look' is NOT 'it is gone' =="
+# The committed mutation evidence for the rule #1619 recorded as a comment.
+# Each of these three predicates is wrong in exactly ONE way, and every one of
+# them reports NOTHING ALIVE — which is byte-identical to a reaped subject.
+# A poll that read them at face value would return 0, i.e. would certify a kill
+# it never observed.
+blind_predicate() { AWAIT_GONE_LOOKED=0; AWAIT_GONE_ALIVE="pgrep is not on PATH"; }
+await_gone 3 30 blind_predicate "the leaf's own sleep" 2>/dev/null
+assert_eq "a predicate that could not look refuses (2), never passes (0)" "2" "$?"
+assert_reason "...naming the predicate and why it was blind" "could not look on look 1: pgrep is not on PATH"
+
+# The one above still has something to SAY. This one is the shape a real
+# enumerator failure takes — `out=$(pgrep …)` that did not run enumerated
+# nothing, so there is nothing to describe either — and it is the one that
+# matters: an empty description is this poll's spelling of "the subject is
+# gone", so without the LOOKED check it returns 0 and certifies a kill it never
+# observed. Measured at the real call site: with `pgrep` replaced by a binary
+# that is not on PATH, gate-budget_test.sh's PREDECESSOR poll printed
+# `no descendant of the killed command outlived the bound (gone after 0s)` and
+# `ALL PASS`.
+blind_and_silent_predicate() { AWAIT_GONE_LOOKED=0; AWAIT_GONE_ALIVE=""; }
+await_gone 3 30 blind_and_silent_predicate "the leaf's own sleep" 2>/dev/null
+assert_eq "a predicate that could not look AND saw nothing still refuses" "2" "$?"
+assert_reason "...rather than letting its silence read as 'gone'" "no reason given"
+
+mute_predicate() { :; }
+await_gone 3 30 mute_predicate "the leaf's own sleep" 2>/dev/null
+assert_eq "a predicate that reports nothing at all refuses" "2" "$?"
+assert_reason "...saying the two readings cannot be told apart" "no way to tell 'nothing is there' from 'nothing was checked'"
+
+half_predicate() { AWAIT_GONE_LOOKED=1; }
+await_gone 3 30 half_predicate "the leaf's own sleep" 2>/dev/null
+assert_eq "a predicate that looked but described nothing refuses" "2" "$?"
+assert_reason "...saying an unset description IS the word 'gone'" "never set AWAIT_GONE_ALIVE"
+
+await_gone 3 30 no_such_predicate "the leaf's own sleep" 2>/dev/null
+assert_eq "a predicate that is not a function at all refuses" "2" "$?"
+assert_reason "...rather than polling to the deadline and reporting it gone" "is not a shell function"
+
+echo ""
+echo "== a broken \`ps\` DESCRIBES nothing; the builtin still decides =="
+# swift-suite_test.sh's rule, replayed: `ps` may say WHAT state a surviving pid
+# is in, but a missing or broken `ps` prints nothing, and nothing would
+# otherwise read as reaped. The verdict comes from `kill -0`, a builtin that
+# cannot fail to run; `ps` only fills in the description.
+sleep 30 & victim=$!
+broken_ps_predicate() {
+  AWAIT_GONE_LOOKED=1
+  AWAIT_GONE_ALIVE=""
+  if kill -0 "$victim" 2>/dev/null; then
+    local row
+    row=$(irrlicht-no-such-ps -o stat= -p "$victim" 2>/dev/null)
+    AWAIT_GONE_ALIVE="pid $victim${row:+ ($row)}"
+  fi
+}
+await_gone 1 10 broken_ps_predicate "the victim's own sleep"
+assert_eq "a live subject is still reported alive when the describer is gone" "1" "$?"
+assert_eq "...described by what the builtin knows" "pid $victim" "$AWAIT_GONE_LAST"
+kill -9 "$victim" 2>/dev/null
+wait "$victim" 2>/dev/null
+
+echo ""
+echo "== the predicate runs in the CALLER's shell, not a subshell =="
+# The seam is what keeps the rule above whole. Capturing a predicate's stdout
+# would mean `$(…)` — a fork per look, on exactly the loaded machine the
+# deadline exists for, whose failure mode is empty output, which is this
+# poll's spelling of "gone". Reporting through variables costs a builtin
+# predicate no fork at all. A subshell would lose every increment below, so
+# this assertion is the seam rather than a description of it.
+counted=0
+counting_predicate() {
+  counted=$(( counted + 1 ))
+  AWAIT_GONE_LOOKED=1
+  AWAIT_GONE_ALIVE=""
+  [[ "$counted" -lt 4 ]] && AWAIT_GONE_ALIVE="still counting ($counted)"
+  return 0
+}
+await_gone 3 30 counting_predicate "the counter's own lifetime"
+assert_eq "the poll ends when the predicate says gone" "0" "$?"
+assert_eq "the predicate's writes are visible to the caller" "4" "$counted"
+assert_eq "...exactly once per look" "$AWAIT_GONE_LOOKS" "$counted"
+
+echo ""
+if [[ "$fails" -eq 0 ]]; then
+  echo "await-gone_test: ALL PASS"
+  exit 0
+fi
+echo "await-gone_test: $fails FAILED"
+exit 1

--- a/tools/lib/gate-budget_test.sh
+++ b/tools/lib/gate-budget_test.sh
@@ -25,6 +25,8 @@ DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT="$(cd "$DIR/../.." && pwd)"
 # shellcheck source=gate-budget.sh
 source "$DIR/gate-budget.sh"
+# shellcheck source=await-gone.sh
+source "$DIR/await-gone.sh"
 
 # Keep the suite in seconds rather than tens of seconds. The grace period is
 # how long budget_run waits between SIGTERM and SIGKILL; 1s is plenty for the
@@ -181,18 +183,51 @@ leafpid=$(mktemp -t irrlicht-gate-budget-leafpid)
 trap 'rm -f "$fixture" "$leafpid"' EXIT
 cat >"$fixture" <<'FIXTURE'
 #!/usr/bin/env bash
-# $1 = file the leaf records its pid in; $2 = levels still to descend.
+# $1 = file the leaf records its pid in; $2 = levels still to descend;
+# $3 = the leaf's own lifetime in seconds.
 # Each level backgrounds the next and waits, so budget_run has a TREE to walk
 # and not just a child: the leaf sits as deep below the pid it kills as a real
 # gate's test binary sits below `go test`.
+#
+# The lifetime is an ARGUMENT rather than a literal because the poll below is
+# bounded against it (#1627), and a number the guard reads from one place and
+# the fixture from another is a pair that can drift apart silently. `${3:?}`
+# and not `$3`: without `set -u` an unset one expands to the empty string,
+# `sleep ""` fails instantly, and a leaf that exits by itself the moment it is
+# born makes the reap assertion pass having observed nothing. Refusing BEFORE
+# the pid is recorded routes that to the loud "the tree was never built" branch.
+leaf_sleep="${3:?the leaf lifetime must be passed as \$3}"
 if [[ "${2:-0}" -gt 0 ]]; then
-  bash "$0" "$1" "$(($2 - 1))" &
+  bash "$0" "$1" "$(($2 - 1))" "$leaf_sleep" &
   wait
   exit
 fi
 echo $$ >"$1"
-exec sleep 30
+exec sleep "$leaf_sleep"
 FIXTURE
+# The leaf's own lifetime and the deadline its reap is polled to below are
+# declared as a PAIR, and await_gone_bound checks the relation between them
+# rather than leaving it to arithmetic nobody runs (#1627). The pair used to be
+# 30 and 15 — a 2:1 ratio, which still held the property with 15s to spare but
+# held it by accident: trimming the leaf's sleep (it is there to be long, and a
+# future author cutting test runtime would read 30s as waste) or raising the
+# deadline (which is exactly what #1619 proposed doing to the sibling fixture)
+# removes it with nothing objecting.
+#
+# 3s is the LARGEST value the wall admits against a 30s leaf, and it is chosen
+# from that direction because the measurement gives nothing to choose from
+# below: 50/50 runs — 25 idle at load ~4, 25 at load 27→53 on 10 cores — found
+# this tree already gone on look 1 at 0s, budget_run having posted SIGKILL and
+# `wait`ed before it returned. So the deadline is pure slack for a busy
+# machine, and the leaf stays at 30 rather than growing to buy a longer one:
+# the only cost a longer leaf carries is a bigger `sleep` to leak if this
+# fixture is ever killed before its own cleanup runs.
+leaf_sleep=30
+reap_deadline=3
+await_gone_bound "$reap_deadline" "$leaf_sleep" "the leaf's own sleep" \
+  || fail "the reap deadline and the leaf's lifetime must stay an order of magnitude apart" \
+          "await_gone_bound to accept ${reap_deadline}s against ${leaf_sleep}s" \
+          "$AWAIT_GONE_REASON"
 # The bound is 2, not 1, and that is setup rather than slack for a race — the
 # race is gone by construction above. $SECONDS counts whole seconds, so
 # budget_run's first deadline check can fire almost immediately: `budget_run 1`
@@ -201,7 +236,7 @@ FIXTURE
 # its leaf. At 2 the floor is ~1.2s, so the guard below reports "the tree was
 # never built" only when something is really wrong. The old fixture had the
 # same exposure and answered it by passing vacuously.
-budget_run 2 bash "$fixture" "$leafpid" 2
+budget_run 2 bash "$fixture" "$leafpid" 2 "$leaf_sleep"
 assert_eq "the wrapper still reports a timeout" "1" "$BUDGET_LAST_TIMED_OUT"
 
 leaf=$(cat "$leafpid" 2>/dev/null)
@@ -211,29 +246,43 @@ if [[ -z "$leaf" ]]; then
   fail "the fixture reached its leaf before the bound expired" \
        "a recorded pid" "an empty pidfile — the tree-kill assertion never ran"
 else
-  # Poll to a generous deadline instead of sleeping a fixed 2s and looking
-  # once. A fixed wait only has to be shorter than the machine is slow to turn
-  # a correct kill into a red, and it makes the pass slower than it needs to be;
-  # this returns the moment the tree is gone and says how long it waited when it
-  # does not. The shells are matched by the fixture's (unique) path, the leaf by
-  # the pid it recorded — after `exec` its command line is just `sleep 30`.
-  start=$SECONDS
-  alive=""
-  while :; do
-    alive="$(pgrep -f "$fixture" 2>/dev/null | tr '\n' ' ')"
-    kill -0 "$leaf" 2>/dev/null && alive="$alive$leaf(the exec'd leaf)"
-    [[ -z "$alive" ]] && break
-    [[ $((SECONDS - start)) -ge 15 ]] && break
-    sleep 0.1
-  done
-  elapsed=$((SECONDS - start))
-  if [[ -z "$alive" ]]; then
-    pass "no descendant of the killed command outlived the bound (gone after ${elapsed}s)"
-  else
-    fail "no descendant of the killed command may outlive the bound" \
-         "every descendant gone within 15s" "still alive after ${elapsed}s: $alive"
-  fi
-  kill -0 "$leaf" 2>/dev/null && kill -9 "$leaf" 2>/dev/null  # never leak a 30s sleep
+  # Polled to a deadline rather than slept, through the shared poll in
+  # tools/lib/await-gone.sh (#1627) — which is also where the deadline/lifetime
+  # wall above and the rule this predicate follows are written down once.
+  #
+  # This is the half of that seam a single `kill -0` cannot cover: the
+  # intermediate shells are a SET, reachable only by the fixture's (unique)
+  # path, and `pgrep` is an external binary that can be missing or broken while
+  # `kill` is a builtin that cannot. So its status is read three ways rather
+  # than two — 0 matched, 1 matched nothing, anything else (2, 3, or 127 for a
+  # pgrep that is not there at all) means the enumeration did not happen, which
+  # is reported as "could not look" instead of joining the empty output that
+  # spells "gone". The leaf itself is matched by the pid it recorded, with the
+  # builtin: after `exec` its command line is just `sleep <n>`, and it is the
+  # process the whole case is about.
+  budget_tree_gone() {
+    local shells rc
+    shells=$(pgrep -f "$fixture" 2>/dev/null); rc=$?
+    if [[ "$rc" -gt 1 ]]; then
+      AWAIT_GONE_LOOKED=0
+      AWAIT_GONE_ALIVE="pgrep -f exited $rc, so the fixture's shells were never enumerated"
+      return 0
+    fi
+    AWAIT_GONE_LOOKED=1
+    AWAIT_GONE_ALIVE="${shells//$'\n'/ }"
+    kill -0 "$leaf" 2>/dev/null && AWAIT_GONE_ALIVE="$AWAIT_GONE_ALIVE$leaf(the exec'd leaf)"
+    return 0
+  }
+  await_gone "$reap_deadline" "$leaf_sleep" budget_tree_gone "the leaf's own sleep"
+  case $? in
+    0) pass "no descendant of the killed command outlived the bound (gone on look $AWAIT_GONE_LOOKS, after ${AWAIT_GONE_ELAPSED}s)" ;;
+    1) fail "no descendant of the killed command may outlive the bound" \
+            "every descendant gone within ${reap_deadline}s" \
+            "still alive after ${AWAIT_GONE_ELAPSED}s / $AWAIT_GONE_LOOKS looks: $AWAIT_GONE_LAST" ;;
+    *) fail "the reap had to be observable at all" \
+            "a poll that could look" "$AWAIT_GONE_REASON" ;;
+  esac
+  kill -0 "$leaf" 2>/dev/null && kill -9 "$leaf" 2>/dev/null  # never leak the leaf's sleep
 fi
 pkill -f "$fixture" 2>/dev/null
 rm -f "$fixture" "$leafpid"

--- a/tools/lib/shell-lib-errexit_test.sh
+++ b/tools/lib/shell-lib-errexit_test.sh
@@ -316,6 +316,28 @@ mkdir -p "$TW_REPO"
   git update-ref refs/remotes/origin/main HEAD
 ) >/dev/null 2>&1 || { echo "FAIL: shell-lib-errexit_test — could not build the scratch git repo" >&2; exit 1; }
 
+# await_gone's third documented status, 1 (the subject survived to the
+# deadline), is deliberately NOT driven here: a documented 1 is
+# indistinguishable from an errexit abort, which is this file's own rule about
+# distinctive statuses. That path is graded by tools/lib/await-gone_test.sh,
+# which is not under `-e`; what is asserted here is the option property on the
+# two statuses a caller can tell apart.
+row 'await-gone.sh::await_gone_bound' 'await_gone_bound (an order of magnitude apart)' 0 \
+    '. tools/lib/await-gone.sh' \
+    'await_gone_bound 3 30'
+row 'await-gone.sh::await_gone_bound' 'await_gone_bound (refuses a deadline near the lifetime)' 2 \
+    '. tools/lib/await-gone.sh' \
+    'await_gone_bound 15 30 2>/dev/null'
+row 'await-gone.sh::await_gone' 'await_gone (a subject already gone)' 0 \
+    '. tools/lib/await-gone.sh; tw_gone() { AWAIT_GONE_LOOKED=1; AWAIT_GONE_ALIVE=""; }' \
+    'await_gone 3 30 tw_gone'
+row 'await-gone.sh::await_gone' 'await_gone (refuses a predicate that could not look)' 2 \
+    '. tools/lib/await-gone.sh; tw_blind() { AWAIT_GONE_LOOKED=0; AWAIT_GONE_ALIVE="pgrep is not on PATH"; }' \
+    'await_gone 3 30 tw_blind 2>/dev/null'
+row 'await-gone.sh::_await_gone_refuse' '_await_gone_refuse' 2 \
+    '. tools/lib/await-gone.sh' \
+    '_await_gone_refuse "driven by the tripwire" 2>/dev/null'
+
 row 'changed-files.sh::changed_files_vs_origin_main' 'changed_files_vs_origin_main' 0 \
     '. tools/lib/changed-files.sh; cd "$TW_REPO"' \
     'changed_files_vs_origin_main >/dev/null'

--- a/tools/lib/swift-suite_test.sh
+++ b/tools/lib/swift-suite_test.sh
@@ -30,6 +30,9 @@ need grep
 need git
 
 . tools/lib/swift-suite.sh
+# The reap poll below is the shared one (#1627); tools/lib/await-gone_test.sh
+# grades it, and its header carries the rules this file used to state inline.
+. tools/lib/await-gone.sh
 
 DATA=tools/lib/testdata/swift-suite
 rc=0
@@ -201,15 +204,14 @@ else
   SWIFT_SUITE_GRANDCHILD_PIDFILE=$(mktemp -t swift-suite-gc)
   # The grandchild's own lifetime and the deadline its reap is polled to below
   # are declared as a pair, and the relation between them is checked rather
-  # than assumed (#1619). A poll that ran anywhere near ${gc_sleep}s would stop
-  # asserting anything: "the fixture exited by itself" and "the tree was
-  # reaped" would produce the same reading, and the case would pass vacuously.
-  # This is the wall from ABOVE — the reap latency measured below gives a
-  # deadline no lower bound worth speaking of, so without this it could be
-  # raised to any number at all with nothing objecting.
+  # than assumed (#1619). That check used to be an inline `(( ))` here and is
+  # now await_gone_bound, because the sibling fixture in gate-budget_test.sh
+  # had no such wall at all and inheriting one from a comment in this file was
+  # what #1627 found had not happened. The reasoning moved with it, into
+  # tools/lib/await-gone.sh's header; what stays here is the pair itself.
   gc_sleep=300
   reap_deadline=15
-  (( reap_deadline * 10 <= gc_sleep )) \
+  await_gone_bound "$reap_deadline" "$gc_sleep" "the grandchild's own lifetime" \
     || fail "the reap deadline (${reap_deadline}s) is not an order of magnitude under the grandchild's own lifetime (${gc_sleep}s) — at that ratio a natural exit starts reading as a reap"
   start=$(date +%s)
   SWIFT_SUITE_TIMEOUT=2 swift_suite_run "$log" \
@@ -221,19 +223,17 @@ else
 
   gc=$(cat "$SWIFT_SUITE_GRANDCHILD_PIDFILE" 2>/dev/null)
   if [[ -n "$gc" ]]; then
-    # Polled, not slept (#1619). The first look happens with nothing in front
-    # of it, so a tree already reaped when swift_suite_run returned — which is
-    # what a correct implementation produces, since it posts SIGKILL and
-    # `wait`s before returning — is reported at once instead of after a fixed
-    # second. The deadline only absorbs a machine too busy to finish the
-    # teardown; a tree that genuinely survives still fails loudly, now with the
-    # elapsed time and the last state observed rather than a bare pid.
+    # Polled, not slept (#1619) — through the shared poll, which is where both
+    # of that decision's rules now live rather than in this comment: the first
+    # look happens with nothing in front of it, and a predicate reports whether
+    # it was ABLE to look separately from what it saw.
     #
-    # `kill -0` is the predicate because it is a shell BUILTIN: it cannot fail
-    # to run, so "we could not look" can never come out as "it is gone". `ps`
-    # only DESCRIBES a pid that is still visible and never decides the verdict —
-    # a missing or broken `ps` prints nothing, and nothing would otherwise read
-    # as reaped.
+    # What this predicate contributes is the ORDER. `kill -0` is a shell
+    # BUILTIN and cannot fail to run, so it alone decides; `ps` runs only after
+    # it has already said "still there", and only to say WHAT state that is. A
+    # missing or broken `ps` therefore costs a description, never a verdict —
+    # invert those two and nothing would distinguish a reaped process from a
+    # host with no `ps` on it.
     #
     # The residual failure mode #1619 names — the pid lingering as an unreaped
     # ZOMBIE, which `kill -0` cannot tell from a live process — is not
@@ -243,33 +243,35 @@ else
     # and reaped before the first look (0 polls). A zombie needs a LIVE parent
     # that never waits, and this fixture has none. If one ever appeared anyway,
     # the failure line below carries `Z <defunct>` and says so itself.
-    reap_start=$(date +%s)
-    looks=0
-    seen=""
-    while :; do
-      looks=$(( looks + 1 ))
-      if ! kill -0 "$gc" 2>/dev/null; then seen=gone; break; fi
+    grandchild_gone() {
+      AWAIT_GONE_LOOKED=1
+      AWAIT_GONE_ALIVE=""
+      kill -0 "$gc" 2>/dev/null || return 0
+      local psrow gc_stat gc_cmd
       psrow=$(ps -o stat=,command= -p "$gc" 2>/dev/null)
       if [[ -n "$psrow" ]]; then
         read -r gc_stat gc_cmd <<< "$psrow"
-        seen="state $gc_stat, command ${gc_cmd:0:60}"
+        AWAIT_GONE_ALIVE="state $gc_stat, command ${gc_cmd:0:60}"
       else
-        seen="visible to kill -0, but ps prints no row for it"
+        AWAIT_GONE_ALIVE="visible to kill -0, but ps prints no row for it"
       fi
-      (( $(date +%s) - reap_start >= reap_deadline )) && break
-      sleep 0.1
-    done
-    reap_elapsed=$(( $(date +%s) - reap_start ))
-    if [[ "$seen" == gone ]]; then
-      # Printed rather than described in a comment: measured over 50 runs (25
-      # idle, 25 at load average ~55 on 10 cores) this was always look 1 at 0s,
-      # and a reap that started taking seconds would show up here instead of in
-      # a doc comment nothing re-derives (#1572).
-      pass "the whole process tree was reaped, not just the wrapper (gone on look $looks, after ${reap_elapsed}s)"
-    else
-      kill -9 "$gc" 2>/dev/null   # don't leak it out of the test either way
-      fail "grandchild $gc survived the timeout kill — the process tree was not reaped (still there after ${reap_elapsed}s / $looks looks; last seen: $seen)"
-    fi
+      return 0
+    }
+    await_gone "$reap_deadline" "$gc_sleep" grandchild_gone "the grandchild's own lifetime"
+    case $? in
+      0)
+        # Printed rather than described in a comment: measured over 50 runs (25
+        # idle, 25 at load average ~55 on 10 cores) this was always look 1 at 0s,
+        # and a reap that started taking seconds would show up here instead of in
+        # a doc comment nothing re-derives (#1572).
+        pass "the whole process tree was reaped, not just the wrapper (gone on look $AWAIT_GONE_LOOKS, after ${AWAIT_GONE_ELAPSED}s)" ;;
+      1)
+        kill -9 "$gc" 2>/dev/null   # don't leak it out of the test either way
+        fail "grandchild $gc survived the timeout kill — the process tree was not reaped (still there after ${AWAIT_GONE_ELAPSED}s / $AWAIT_GONE_LOOKS looks; last seen: $AWAIT_GONE_LAST)" ;;
+      *)
+        kill -9 "$gc" 2>/dev/null
+        fail "the reap had to be observable at all: $AWAIT_GONE_REASON" ;;
+    esac
   else
     fail "grandchild never recorded its pid; the kill assertion did not run"
   fi


### PR DESCRIPTION
Closes #1627.

Two fixtures poll for a process tree to be reaped and only one bounded its
deadline from above:

| | fixture lifetime | poll deadline | ratio | ratio checked? |
|---|---|---|---|---|
| `gate-budget_test.sh` (before) | `exec sleep 30` | 15s | 2:1 | no |
| `swift-suite_test.sh` (#1625) | `sleep 300` | 15s | 20:1 | yes |
| `gate-budget_test.sh` (after) | `exec sleep 30` | **3s** | **10:1** | **yes** |

Not a live defect before this — 15s against a 30s leaf still left 15s of
margin — but the property was held by arithmetic nobody ran.

---

## 1. The measurement, and how it chose the numbers

Same question #1619 asked of its own fixture: **is there any reap latency to
fit?** Answer here is the same — there is none.

The harness reproduces `gate-budget_test.sh`'s case exactly (same fixture,
same recursion depth, same `exec`'d leaf, same `BUDGET_TERM_GRACE_SECONDS=1` /
`BUDGET_POLL_SECONDS=0.05`) and records the **look number** at which the tree
is first observed gone. The look number is the metric rather than a
`date`/`python3` delta on purpose: putting a fork in front of the first look
delays it and biases the answer toward "already gone".

```
== idle: 25 iterations, load at start: 3.90 3.50 3.53 ==
iter 1..25: gone looks=1 elapsed=0s timed_out=1     (all 25 identical)

== loaded: 25 iterations, 50 CPU spinners on 10 cores ==
== load before measurement: 27.52 9.19 5.58 ==
iter 1..25: gone looks=1 elapsed=0s timed_out=1     (all 25 identical)
== load after measurement: 53.41 18.97 9.40 ==
```

**Distribution: 50/50 gone on look 1 at 0s.** min = max = p50 = p100 = look 1.
Nothing was ever observed alive on the first look, idle or at load average 53
on 10 cores. That is by construction rather than by luck: `budget_run`'s
timeout path posts SIGTERM, waits for the child, posts SIGKILL and `wait`s
before it returns, so the tree is dead before the poll starts.

**So the deadline has no lower bound to fit, and is bounded only from above.**
Given that, the choice is the largest value the wall admits:

- **The leaf stays at 30s.** The only cost a longer leaf carries is a bigger
  `sleep` to leak if the fixture is ever killed before its own cleanup runs —
  and 30s is already what the case needs to outlive a 2s bound.
- **The deadline drops 15s → 3s**, the maximum `deadline * 10 <= lifetime`
  permits against 30. It is 3× the whole `budget_run` bound and 30 poll
  intervals, against a measured latency of zero looks.
- Sitting exactly ON the wall is deliberate: both edits #1627 named — trimming
  the leaf, raising the deadline — now go red on the first second of movement.
  M1 and M2 below are those two edits.

`swift-suite_test.sh`'s 15s/300s pair is unchanged; it already satisfied the
wall.

---

## 2. Extract or not: extracted, and what the seam had to solve

The issue is right that the obvious extraction does not serve both call sites
— one polls a SET by `pgrep -f`, the other ONE recorded pid by `kill -0`. The
decision hinged on whether a seam could exist that does **not** weaken the
`kill -0`-is-a-builtin rule it is supposed to carry, because the naive one
does: a predicate reporting through stdout means `desc=$(predicate)`, i.e. a
**fork per look** on exactly the loaded machine the deadline exists for, whose
failure mode is empty output — which is this poll's spelling of "gone". That
would have re-created the bug inside the fix.

`tools/lib/await-gone.sh`'s predicate is a shell **function** that reports by
assigning two variables and is called plainly, so a builtin predicate costs no
fork at all. `await-gone_test.sh` asserts that seam rather than describing it
(a counting predicate must have incremented exactly `AWAIT_GONE_LOOKS` times —
a subshell loses every increment; M6).

That settled, extraction earns three things a fix-in-place could not:

1. **The wall lives in one place** (`await_gone_bound`) and `await_gone`
   **re-checks it and fails closed**, so a caller that skips the check cannot
   buy an unbounded poll (`hookjson.DecodeConfined`'s shape; M4).
2. **A rule became a mechanism.** #1619 recorded "use a builtin predicate" as a
   comment. A predicate now reports whether it was **able to look**
   (`AWAIT_GONE_LOOKED`) separately from what it **saw** (`AWAIT_GONE_ALIVE`),
   and a predicate that could not look is a loud refusal, never a pass. This is
   not decoration — `gate-budget_test.sh` needed it, and it was **live**:

   ```
   # PRE-CHANGE gate-budget_test.sh, `pgrep` replaced by a binary not on PATH:
     PASS: no descendant of the killed command outlived the bound (gone after 0s)
   gate-budget_test: ALL PASS
   ```

   An unrunnable enumerator certified a kill it never observed. Post-change,
   the same mutation is M9 below.
3. **A third fixture inherits all of it** by sourcing one file, instead of by
   reading whichever sibling it happened to find.

**The predecessors' cases are replayed, not superseded** (AGENTS.md; #1450):
the 15/30 refusal is a named lock in `await-gone_test.sh` carrying #1619's M4,
gone-on-look-1 is #1619's measurement as an assertion, the "`ps` describes but
never decides" rule has its own case (a broken describer must not turn a live
subject into a reaped one), and the survivor line still carries elapsed, look
count and last-observed state.

---

## 3. The tripwire obligation

`tools/lib/shell-lib-errexit_test.sh` walks every non-test `tools/lib/*.sh`, so
the new library arrived `UNDRIVEN` (measured — that is exactly what it printed).
Five recipes added; the walk now reads 7 libraries / 32 functions and the
bijection is clean. `await_gone`'s third status, **1** (the subject survived),
is deliberately not driven there and says so in a comment: a documented 1 is
indistinguishable from an errexit abort, which is that file's own rule. It is
graded by `await-gone_test.sh`, which is not under `-e`.

---

## 4. Mutation evidence

Everything here is behaviour the change ADDS, so every arm owes a red. One
mutation per foreground call, applied by copy-aside and reverted by copy-back,
with `git status --porcelain` asserted **empty** after each revert (it was, all
ten times). Each mutation asserts it applied before running (#1390).

| | mutation | result |
|---|---|---|
| M1 | `reap_deadline` 3 → 4 in `gate-budget_test.sh` | 2 FAILED |
| M2 | `leaf_sleep` 30 → 20 in `gate-budget_test.sh` | 2 FAILED |
| M3 | `AWAIT_GONE_RATIO` → 1 in the library | 5 FAILED |
| M4 | delete `await_gone`'s fail-closed re-check | 2 FAILED |
| M5 | stop consulting `AWAIT_GONE_LOOKED` | 5 FAILED |
| M6 | call the predicate in a subshell | 13 FAILED |
| M7 | drop the description sentinel check | 2 FAILED |
| M8 | `reap_deadline` 15 → 31 in `swift-suite_test.sh` (#1619's M4 replayed) | FAILURES |
| M9 | `pgrep` → a binary not on PATH, at the real call site | 1 FAILED |
| M10 | stop passing the leaf's lifetime to the fixture | 2 FAILED |

**M1** — the deadline moved one second past the wall. Both the caller's own
guard and the library's fail-closed re-check fire:

```
FAIL: the reap deadline and the leaf's lifetime must stay an order of magnitude apart
  — expected [await_gone_bound to accept 4s against 30s]
    got [await-gone: refusing — a 4s deadline is not 10x under the leaf's own sleep (30s)
         — at that ratio a subject that exited BY ITSELF reads exactly like one that was
         reaped, and the poll stops asserting anything]
FAIL: the reap had to be observable at all — expected [a poll that could look] got [<same>]
```

**M2** — the future author who reads a 30s sleep as waste:

```
FAIL: the reap deadline and the leaf's lifetime must stay an order of magnitude apart
  — expected [await_gone_bound to accept 3s against 20s]
    got [await-gone: refusing — a 3s deadline is not 10x under the leaf's own sleep (20s) …]
```

**M3 vs M4** are distinguishable, which is the point of running both — M3
reddens five arms, M4 exactly the two that isolate the re-check:

```
# M3 (ratio 10x -> 1x)
FAIL: refuses the 15s-against-30s pair #1627 found — expected [2] got [0]
FAIL: ...and the refusal names both numbers and the subject — got [nothing was recorded]
FAIL: refuses 4s against 30s — one second past the wall — expected [2] got [0]
FAIL: refuses a bad bound even when the subject IS gone — expected [2] got [0]
FAIL: ...with the bound's own refusal, not a poll result — got [nothing was recorded]

# M4 (re-check deleted)
FAIL: refuses a bad bound even when the subject IS gone — expected [2] got [0]
FAIL: ...with the bound's own refusal, not a poll result — got [nothing was recorded]
```

**M5** — the "could not look" discrimination removed. The load-bearing line is
the third: a blind predicate with nothing to describe returns **0**, i.e.
certifies a kill it never observed.

```
FAIL: a predicate that could not look refuses (2), never passes (0) — expected [2] got [1]
FAIL: ...naming the predicate and why it was blind — got [nothing was recorded]
FAIL: a predicate that could not look AND saw nothing still refuses — expected [2] got [0]
FAIL: ...rather than letting its silence read as 'gone' — got [nothing was recorded]
FAIL: ...saying the two readings cannot be told apart — got [<the sentinel refusal instead>]
```

**M6** — the predicate in a subshell. The seam assertion is the last two lines;
note the failure is loud, not silent, which is the design:

```
FAIL: the predicate's writes are visible to the caller — expected [4] got [0]
FAIL: ...exactly once per look — expected [1] got [0]
(+11 more: every predicate now reads as "returned without setting AWAIT_GONE_LOOKED")
```

**M7**:

```
FAIL: a predicate that looked but described nothing refuses — expected [2] got [1]
FAIL: ...saying an unset description IS the word 'gone' — got [nothing was recorded]
```

**M8** — #1619's M4 still fires after the extraction, plus the new re-check:

```
FAIL — the reap deadline (31s) is not an order of magnitude under the grandchild's own
       lifetime (300s) — at that ratio a natural exit starts reading as a reap
FAIL — the reap had to be observable at all: await-gone: refusing — a 31s deadline is not
       10x under the grandchild's own lifetime (300s) …
```

**M9** — the enumerator that cannot run, at the real call site. Compare with the
pre-change counterfactual quoted in section 2, which was `ALL PASS`:

```
FAIL: the reap had to be observable at all
  — expected [a poll that could look]
    got [await-gone: refusing — the predicate 'budget_tree_gone' could not look on look 1:
         pgrep -f exited 127, so the fixture's shells were never enumerated.
         Being unable to look must not be reported as the subject being gone]
```

**M10** — the fixture's leaf lifetime is now an argument, so `${3:?}` guards it.
Without it an empty `sleep ""` exits instantly and the reap assertion passes
having observed nothing; the refusal routes to the loud branch instead:

```
FAIL: the wrapper still reports a timeout — expected [1] got [0]
FAIL: the fixture reached its leaf before the bound expired
  — expected [a recorded pid] got [an empty pidfile — the tree-kill assertion never ran]
```

Some of this evidence is **committed** rather than living here: the
deliberately-wrong predicates in `await-gone_test.sh` (`blind_predicate`,
`blind_and_silent_predicate`, `mute_predicate`, `half_predicate`) are M5's and
M7's shape as fixtures, in `hookjson`'s `forgetfulReceiver` idiom, so they are
re-run on every gate instead of once in a merged PR body.

---

## 5. Gates

- `tools/preflight.sh --only tools` — **PASS** (exit 0). `shell-lib-suite:
  tools/lib — found 16, skipped 0 (none), ran 16, failed 0`.
- `tools/preflight.sh --only swift` — **PASS** (exit 0). Run because
  `swift-suite_test.sh` is in that gate's trigger set; full `swift build` +
  `swift test --skip LauncherTestHarness --skip LauncherHarnessTests`, real-home
  witness clean.
- `tools/preflight.sh --only posix` — **not run, and it does not apply**: the
  gate keys on a first-line `#!/bin/sh` shebang and both new files are
  `#!/usr/bin/env bash`. It ran anyway via the pre-push hook and passed.
- Pre-push hook (`--changed --budget 540`): POSIX sh lint PASS, tools PASS,
  gofmt PASS, macOS Swift PASS; everything else SKIP (no Go, web or replaydata
  in the diff).
- `go test ./core/...` not run — this diff touches no Go. CodeScene/ARS are
  advisory.

---

## 6. One new defect filed, not fixed here: #1681

While reading `gate-budget.sh` for the fixture rewrite: `budget_run`'s grace
loop waits for `$pid` **only**, and `$pid` is an ordinary bash that dies on
SIGTERM in milliseconds — so `_budget_kill_tree KILL "$pid"` then walks from an
already-dead pid, `pgrep -P` finds nothing, and the SIGKILL pass reaches no one.
A descendant that ignores SIGTERM outlives the entire bounded run. Measured on
`origin/main` with a `trap '' TERM` leaf: `RESULT: leaf SURVIVED the bounded run
— SIGKILL never reached it`. Out of scope here; filed with the reproduction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)