### PR TITLE
fix(tools): make budget_run's SIGKILL pass reach a descendant that survived SIGTERM (#1681)

### DIFF
--- a/tools/lib/gate-budget.sh
+++ b/tools/lib/gate-budget.sh
@@ -118,31 +118,58 @@ budget_exhausted() {
   budget_is_bounded && [[ "$(budget_remaining)" -le 0 ]]
 }
 
-# _budget_kill_tree <signal> <pid> — signal a process and every descendant.
+# _budget_tree_pids <pid> — <pid> and every descendant, deepest first.
 #
-# Killing only the direct child is not enough: `go test` forks a compiler and
-# a test binary per package, `npm` forks node, and gosec forks nothing but
-# holds the terminal — leaving those alive after the hook returns is how a
-# "bounded" run keeps burning the machine. Descendants are signalled first so
-# a shell that would exit on its own does not orphan them mid-walk.
+# COLLECTED BEFORE ANYTHING IS SIGNALLED, which is the whole trick and is what
+# #1681 was: the walk from a pid is a walk down `pgrep -P`, and once a process
+# dies its children are reparented to launchd (init on Linux), so the ppid
+# chain that finds them is gone. A second walk from the same pid AFTER the
+# SIGTERM therefore enumerates nobody, and the SIGKILL pass signals a corpse
+# while every descendant that ignored or slow-handled the SIGTERM outlives the
+# whole bounded run — the exact failure the tree kill exists to prevent.
+# Measured on the unfixed library: a leaf doing `trap '' TERM; exec sleep 45`
+# was still there with 40+ seconds to go after budget_run had reported a
+# correct TIMEOUT and returned.
 #
-# pgrep is on both macOS and Linux. If it is somehow absent the walk degrades
+# Deepest-first so a parent cannot spawn a replacement between two kills. The
+# order is the argument order `kill` receives, which it signals in sequence.
+#
+# pgrep is on both macOS and Linux. If it is somehow absent the list degrades
 # to the direct child, which still ends the wait and still reports TIMEOUT —
 # the verdict stays correct, only the cleanup is weaker.
 #
 # lib/swift-suite.sh has the same recursion (`_swift_suite_descendants`) and
-# they stay separate deliberately. That one exists to kill a tree that
-# `script -q` has moved into another SESSION and other process groups, so it
-# collects the pids first and signals them as a flat list with its own grace
-# period, inside a `{ … } 2>/dev/null` that hides the shell's job notice at the
-# one moment the gate is explaining itself. This one signals depth-first as it
-# walks and lets that notice through, because here it lands beside a named
-# TIMEOUT block rather than in place of one. Folding them together would mean
-# one of the two gets the wrong half. They are, however, verified to compose:
-# the swift gate under `--budget 45` kills the whole pty-wrapped tree and
-# leaves no xctest process behind (measured, #1570).
+# they stay separate deliberately — but note that the difference is no longer
+# in the WALK, which #1681 made identical because only one of the two spellings
+# is correct. What differs is the signalling around it: that one runs inside a
+# `{ … } 2>/dev/null` that hides the shell's job notice at the one moment the
+# gate is explaining itself, where this one lets that notice through because
+# here it lands beside a named TIMEOUT block rather than in place of one.
+# Folding them together would mean one of the two gets the wrong half. They
+# are, however, verified to compose: the swift gate under `--budget 45` kills
+# the whole pty-wrapped tree and leaves no xctest process behind (measured,
+# #1570).
+_budget_tree_pids() {
+  local kid
+  for kid in $(pgrep -P "$1" 2>/dev/null); do
+    _budget_tree_pids "$kid"
+  done
+  echo "$1"
+}
+
+# _budget_kill_tree <signal> <pid...> — signal every pid in a list collected by
+# _budget_tree_pids.
 #
-# The `|| :` guards the whole walk rather than the `kill`, and it is not about
+# Killing only the direct child is not enough: `go test` forks a compiler and
+# a test binary per package, `npm` forks node, and gosec forks nothing but
+# holds the terminal — leaving those alive after the hook returns is how a
+# "bounded" run keeps burning the machine.
+#
+# It takes a RECORDED list rather than walking one itself, so that the two
+# passes budget_run makes signal the same set: see _budget_tree_pids above for
+# why a second walk finds nothing.
+#
+# The `|| :` guards the whole call rather than the `kill`, and it is not about
 # the group's status — `return 0` discards that anyway. Signalling a pid that
 # is already gone is the NORMAL case here (a command that exited on its own,
 # and the second pass after SIGKILL), so `kill` exits non-zero as a matter of
@@ -155,14 +182,36 @@ budget_exhausted() {
 # alone moved the abort one line down onto `wait` and returned 143 — as
 # plausible a wrong answer as the 1 it replaced.
 _budget_kill_tree() {
-  local sig="$1" pid="$2" child
+  local sig="$1"
+  shift || true
   {
-    for child in $(pgrep -P "$pid" 2>/dev/null); do
-      _budget_kill_tree "$sig" "$child"
-    done
-    kill "-$sig" "$pid" 2>/dev/null
+    kill "-$sig" "$@" 2>/dev/null
   } || :
   return 0
+}
+
+# _budget_any_alive <pid...> — 0 while any of them is still there, 1 once all
+# are gone. The grace loop's subject (#1681, and #1616's corollary: observe the
+# SUBJECT, never a side effect it produces on its way out).
+#
+# What it replaces is `kill -0 "$pid"` on the WRAPPER alone, which is the wrong
+# subject twice over: the wrapper is an ordinary `bash` that dies on SIGTERM in
+# milliseconds whatever its descendants do, so the loop it gated ended
+# immediately and the grace period was never spent on the processes it exists
+# for. The wrapper is polled here too, and costs nothing to include — measured
+# on bash 3.2.57, a TERMed background child answers `kill -0` for 7-14 busy
+# iterations before this shell reaps it, i.e. microseconds, so it never holds
+# the loop open as a zombie.
+#
+# `kill -0` and not `ps`: a builtin cannot be missing or broken, where an
+# external binary that fails to run prints nothing and nothing reads exactly
+# like "everything is gone" (await-gone.sh's rule 3, same reasoning).
+_budget_any_alive() {
+  local p
+  for p in "$@"; do
+    kill -0 "$p" 2>/dev/null && return 0
+  done
+  return 1
 }
 
 # budget_run <seconds> <cmd...> — run <cmd...> bounded to <seconds> of wall
@@ -210,7 +259,7 @@ budget_run() {
   # caller's `-e` (#1635). `{ …; } &` runs in a SUBSHELL, so the change cannot
   # reach the caller — that is the whole reason this one region is spelled with
   # a `set` where the two in-process ones (the timeout region below, and
-  # _budget_kill_tree's walk above) use `{ … } || :`, which is the same guard
+  # _budget_kill_tree's signal above) use `{ … } || :`, which is the same guard
   # by the only means available there. Without it the child
   # inherits errexit and dies on a command that exits non-zero BEFORE the write
   # below, so the "it finished" signal never appears, budget_run polls to the
@@ -270,12 +319,27 @@ budget_run() {
       # never reached — the two things preflight.sh reads from this library,
       # both wrong, and neither with anything to look at.
       {
-        _budget_kill_tree TERM "$pid"
+        # Collected ONCE, before the first signal, and both passes signal that
+        # same recorded list (#1681). Re-walking after the SIGTERM enumerates
+        # nobody — the descendants have been reparented — so the SIGKILL pass
+        # would signal a corpse and anything that ignored the SIGTERM would
+        # outlive the bound. _budget_tree_pids carries the full reasoning.
+        local victims
+        victims=$(_budget_tree_pids "$pid")
+        # Unquoted on purpose here and below: a whitespace-separated pid list.
+        # shellcheck disable=SC2086
+        _budget_kill_tree TERM $victims
         local hard=$SECONDS
-        while [[ $((SECONDS - hard)) -lt "$BUDGET_TERM_GRACE_SECONDS" ]] && kill -0 "$pid" 2>/dev/null; do
+        # The loop waits on the TREE, not on the wrapper. The wrapper is a
+        # `bash` that dies on SIGTERM in milliseconds regardless of what it is
+        # waiting for, so gating the grace period on it spent no grace at all
+        # on the processes the grace period is for.
+        # shellcheck disable=SC2086
+        while [[ $((SECONDS - hard)) -lt "$BUDGET_TERM_GRACE_SECONDS" ]] && _budget_any_alive $victims; do
           sleep "$BUDGET_POLL_SECONDS"
         done
-        _budget_kill_tree KILL "$pid"
+        # shellcheck disable=SC2086
+        _budget_kill_tree KILL $victims
         wait "$pid" 2>/dev/null
         rm -f "$statusfile" "$statusfile.part"
       } || :

--- a/tools/lib/gate-budget_test.sh
+++ b/tools/lib/gate-budget_test.sh
@@ -55,6 +55,11 @@ assert_le() {
   [[ "$3" -le "$2" ]] && pass "$1 ($3 <= $2)" || fail "$1" "<= $2" "$3"
   return 0
 }
+# assert_ge <label> <floor> <actual>
+assert_ge() {
+  [[ "$3" -ge "$2" ]] && pass "$1 ($3 >= $2)" || fail "$1" ">= $2" "$3"
+  return 0
+}
 
 echo "== budget_open refuses anything that is not a whole number of seconds =="
 # A bound that quietly is not one is worse than no bound: the caller stops
@@ -157,9 +162,9 @@ echo "== the whole process tree dies, not just the direct child =="
 # `exec`, because the first version of this case asked whether a surviving
 # great-grandchild had written a marker file — and that great-grandchild was a
 # SHELL running `sleep 30; echo … >marker`, so "the sleep was interrupted" and
-# "the process survived" produced the same evidence. _budget_kill_tree signals
-# depth-first, so the `sleep` is signalled BEFORE the shell waiting on it; if
-# the walking shell is descheduled between those two kills, that shell reaps
+# "the process survived" produced the same evidence. budget_run signals
+# deepest-first, so the `sleep` is signalled BEFORE the shell waiting on it; if
+# the signalling shell is descheduled between those two kills, that shell reaps
 # its dead child and runs the next command in the list. The marker appeared
 # while `pgrep` found nothing — the writer was gone by the time the test
 # looked — so the two assertions contradicted each other, on a required check,
@@ -180,11 +185,13 @@ echo "== the whole process tree dies, not just the direct child =="
 # time for a reason that has nothing to do with the kill.
 fixture=$(mktemp -t irrlicht-gate-budget-fixture)
 leafpid=$(mktemp -t irrlicht-gate-budget-leafpid)
-trap 'rm -f "$fixture" "$leafpid"' EXIT
+leafpid_ign=$(mktemp -t irrlicht-gate-budget-leafpid-ign)
+trap 'rm -f "$fixture" "$leafpid" "$leafpid_ign"' EXIT
 cat >"$fixture" <<'FIXTURE'
 #!/usr/bin/env bash
 # $1 = file the leaf records its pid in; $2 = levels still to descend;
-# $3 = the leaf's own lifetime in seconds.
+# $3 = the leaf's own lifetime in seconds; $4 = the leaf's SIGTERM disposition,
+# `term-dying` or `term-ignoring`.
 # Each level backgrounds the next and waits, so budget_run has a TREE to walk
 # and not just a child: the leaf sits as deep below the pid it kills as a real
 # gate's test binary sits below `go test`.
@@ -197,14 +204,51 @@ cat >"$fixture" <<'FIXTURE'
 # born makes the reap assertion pass having observed nothing. Refusing BEFORE
 # the pid is recorded routes that to the loud "the tree was never built" branch.
 leaf_sleep="${3:?the leaf lifetime must be passed as \$3}"
+# The disposition is REQUIRED and its value is checked against a closed set,
+# for the same reason and with the same routing (#1681). An absent or
+# misspelled one defaulting to `term-dying` would silently turn the
+# TERM-ignoring case below into a second copy of the TERM-dying one — a case
+# that no longer reaches the defect it was written for, passing.
+#
+# No apostrophe in that message, deliberately: bash 3.2 treats a `'` inside a
+# parameter expansion's word as a QUOTE even when the whole expansion is
+# double-quoted, so "the leaf's disposition" here is a parse error for the
+# WHOLE fixture. Measured — it is the same trap await-gone.sh records at
+# AWAIT_GONE_DEFAULT_WHAT, and the assertion below is what names it.
+leaf_term="${4:?the SIGTERM disposition of the leaf must be passed as \$4}"
+case "$leaf_term" in
+  term-dying | term-ignoring) ;;
+  *) echo "fixture: unknown SIGTERM disposition '$leaf_term'" >&2; exit 64 ;;
+esac
 if [[ "${2:-0}" -gt 0 ]]; then
-  bash "$0" "$1" "$(($2 - 1))" "$leaf_sleep" &
+  bash "$0" "$1" "$(($2 - 1))" "$leaf_sleep" "$leaf_term" &
   wait
   exit
 fi
+# `trap ''` sets the disposition to IGNORE, and an ignored disposition is
+# INHERITED ACROSS EXEC where a caught one is reset to the default — so the
+# leaf keeps #1616's `exec` (no next command, no mid-transition state to catch
+# it in) and is still the descendant SIGTERM does not reach. Measured on bash
+# 3.2.57 / macOS 25.5: the exec'd `sleep` answers `kill -0` after a SIGTERM
+# that would have ended it. Doing it with a HANDLER instead would reintroduce
+# exactly the ambiguity #1616 removed.
+[[ "$leaf_term" == "term-ignoring" ]] && trap '' TERM
 echo $$ >"$1"
 exec sleep "$leaf_sleep"
 FIXTURE
+# A fixture that will not PARSE fails every case below through the "the tree
+# was never built" branch — loud, but pointing at the bound rather than at the
+# heredoc, and the shell's own diagnostic lands on stderr several assertions
+# away from the failure it caused. Asserted here so the cause is named where it
+# happens. Not hypothetical: writing that `${4:?}` message with an apostrophe
+# in it broke this file exactly once, and the run reported five failures none
+# of which said "syntax error".
+if bash -n "$fixture" 2>/dev/null; then
+  pass "the process-tree fixture parses"
+else
+  fail "the process-tree fixture must parse before anything can be graded with it" \
+       "a fixture bash accepts" "$(bash -n "$fixture" 2>&1 | tr '\n' ' ')"
+fi
 # The leaf's own lifetime and the deadline its reap is polled to below are
 # declared as a PAIR, and await_gone_bound checks the relation between them
 # rather than leaving it to arithmetic nobody runs (#1627). The pair used to be
@@ -228,6 +272,38 @@ await_gone_bound "$reap_deadline" "$leaf_sleep" "the leaf's own sleep" \
   || fail "the reap deadline and the leaf's lifetime must stay an order of magnitude apart" \
           "await_gone_bound to accept ${reap_deadline}s against ${leaf_sleep}s" \
           "$AWAIT_GONE_REASON"
+
+# ONE predicate for both tree-kill cases below, reading the two variables each
+# case sets rather than taking arguments (await_gone calls its predicate with
+# none). One rather than two because that is the whole finding behind #1627:
+# two fixtures polling for the same thing, written two PRs apart, had drifted
+# in four ways that were not stylistic.
+#
+# This is the half of await-gone's seam a single `kill -0` cannot cover: the
+# intermediate shells are a SET, reachable only by the fixture's (unique) path,
+# and `pgrep` is an external binary that can be missing or broken while `kill`
+# is a builtin that cannot. So its status is read three ways rather than two —
+# 0 matched, 1 matched nothing, anything else (2, 3, or 127 for a pgrep that is
+# not there at all) means the enumeration did not happen, which is reported as
+# "could not look" instead of joining the empty output that spells "gone". The
+# leaf itself is matched by the pid it recorded, with the builtin: after `exec`
+# its command line is just `sleep <n>`, and it is the process the cases are
+# about.
+tw_probe_fixture=""
+tw_probe_leaf=""
+budget_tree_gone() {
+  local shells rc
+  shells=$(pgrep -f "$tw_probe_fixture" 2>/dev/null); rc=$?
+  if [[ "$rc" -gt 1 ]]; then
+    AWAIT_GONE_LOOKED=0
+    AWAIT_GONE_ALIVE="pgrep -f exited $rc, so the fixture's shells were never enumerated"
+    return 0
+  fi
+  AWAIT_GONE_LOOKED=1
+  AWAIT_GONE_ALIVE="${shells//$'\n'/ }"
+  kill -0 "$tw_probe_leaf" 2>/dev/null && AWAIT_GONE_ALIVE="$AWAIT_GONE_ALIVE$tw_probe_leaf(the exec'd leaf)"
+  return 0
+}
 # The bound is 2, not 1, and that is setup rather than slack for a race — the
 # race is gone by construction above. $SECONDS counts whole seconds, so
 # budget_run's first deadline check can fire almost immediately: `budget_run 1`
@@ -236,8 +312,31 @@ await_gone_bound "$reap_deadline" "$leaf_sleep" "the leaf's own sleep" \
 # its leaf. At 2 the floor is ~1.2s, so the guard below reports "the tree was
 # never built" only when something is really wrong. The old fixture had the
 # same exposure and answered it by passing vacuously.
-budget_run 2 bash "$fixture" "$leafpid" 2 "$leaf_sleep"
+#
+# The grace period is raised from the suite-wide 1s for the two tree cases,
+# and the number is what makes the two elapsed assertions below separable
+# rather than a preference (#1681). budget_run's own deadline check is on
+# `$SECONDS`, so a `budget_run 2` detects its bound anywhere in (1.0s, 2.05s],
+# and the grace loop spends (grace-1, grace] on top: at grace=4 a run that
+# spends the grace lands in (4.0s, 6.1s] and one that does not lands in
+# (1.0s, 2.1s], which a whole-second clock can tell apart with a margin on
+# each side. At the suite-wide 1s the two populations are adjacent and the
+# assertions would be measuring scheduler noise.
+tree_grace=4
+# shellcheck disable=SC2034  # read by gate-budget.sh, sourced above
+BUDGET_TERM_GRACE_SECONDS="$tree_grace"
+
+start=$SECONDS
+budget_run 2 bash "$fixture" "$leafpid" 2 "$leaf_sleep" term-dying
+dying_elapsed=$((SECONDS - start))
 assert_eq "the wrapper still reports a timeout" "1" "$BUDGET_LAST_TIMED_OUT"
+# The other direction of the grace loop's condition, and the vacuity guard for
+# the assertion in the TERM-ignoring case below: a loop that had simply dropped
+# its condition — spinning out the full grace on every timeout — would satisfy
+# that one just as well, and would make every gate's TIMEOUT cost the grace it
+# does not need. Here the whole tree is gone milliseconds after the SIGTERM, so
+# the grace must not be spent at all.
+assert_le "a tree that dies on SIGTERM does not spend the grace period" "3" "$dying_elapsed"
 
 leaf=$(cat "$leafpid" 2>/dev/null)
 if [[ -z "$leaf" ]]; then
@@ -249,30 +348,8 @@ else
   # Polled to a deadline rather than slept, through the shared poll in
   # tools/lib/await-gone.sh (#1627) — which is also where the deadline/lifetime
   # wall above and the rule this predicate follows are written down once.
-  #
-  # This is the half of that seam a single `kill -0` cannot cover: the
-  # intermediate shells are a SET, reachable only by the fixture's (unique)
-  # path, and `pgrep` is an external binary that can be missing or broken while
-  # `kill` is a builtin that cannot. So its status is read three ways rather
-  # than two — 0 matched, 1 matched nothing, anything else (2, 3, or 127 for a
-  # pgrep that is not there at all) means the enumeration did not happen, which
-  # is reported as "could not look" instead of joining the empty output that
-  # spells "gone". The leaf itself is matched by the pid it recorded, with the
-  # builtin: after `exec` its command line is just `sleep <n>`, and it is the
-  # process the whole case is about.
-  budget_tree_gone() {
-    local shells rc
-    shells=$(pgrep -f "$fixture" 2>/dev/null); rc=$?
-    if [[ "$rc" -gt 1 ]]; then
-      AWAIT_GONE_LOOKED=0
-      AWAIT_GONE_ALIVE="pgrep -f exited $rc, so the fixture's shells were never enumerated"
-      return 0
-    fi
-    AWAIT_GONE_LOOKED=1
-    AWAIT_GONE_ALIVE="${shells//$'\n'/ }"
-    kill -0 "$leaf" 2>/dev/null && AWAIT_GONE_ALIVE="$AWAIT_GONE_ALIVE$leaf(the exec'd leaf)"
-    return 0
-  }
+  tw_probe_fixture="$fixture"
+  tw_probe_leaf="$leaf"
   await_gone "$reap_deadline" "$leaf_sleep" budget_tree_gone "the leaf's own sleep"
   case $? in
     0) pass "no descendant of the killed command outlived the bound (gone on look $AWAIT_GONE_LOOKS, after ${AWAIT_GONE_ELAPSED}s)" ;;
@@ -285,7 +362,105 @@ else
   kill -0 "$leaf" 2>/dev/null && kill -9 "$leaf" 2>/dev/null  # never leak the leaf's sleep
 fi
 pkill -f "$fixture" 2>/dev/null
-rm -f "$fixture" "$leafpid"
+rm -f "$leafpid"
+
+echo ""
+echo "== the SIGKILL pass reaches a descendant that SURVIVED the SIGTERM (#1681) =="
+# The case above cannot see this one: its leaf is a plain `exec sleep`, which
+# dies on SIGTERM, so budget_run's second pass only ever signals corpses and
+# nothing depends on it reaching anybody. A descendant that IGNORES SIGTERM is
+# what makes the SIGKILL pass load-bearing — and it is not a contrived shape,
+# it is the handler-carrying processes (the ones that clean up on TERM, i.e.
+# exactly the slow ones) that a bound has to reach.
+#
+# What #1681 measured on the unfixed library: budget_run reported a correct
+# TIMEOUT and returned, and the leaf was still there with 40+ seconds of its
+# sleep to go. The SIGKILL pass re-walked `pgrep -P` from a pid that SIGTERM
+# had already killed, so it enumerated nobody — the descendants had been
+# reparented to launchd — and signalled a corpse.
+
+# The vacuity guard, and it is not optional: if the leaf turned out to die on
+# SIGTERM after all — a fixture edit dropping the trap, an `exec` that reset
+# the disposition, a future macOS that does not inherit it — the case below
+# would pass while asserting nothing beyond what the case above already
+# asserts, which is this repo's most-repeated failure shape. So the property
+# the case rests on is OBSERVED here, on every run, rather than cited from a
+# measurement in a merged PR body.
+#
+# Depth 0, so the leaf is a direct child of this shell and its own SIGTERM is
+# the only one in play. `await_gone` is expected to return 1 — the subject
+# survived to the deadline — which is the loudest available spelling of "it is
+# still there": a positive observation bounded from both ends, not a sleep.
+: >"$leafpid_ign"
+bash "$fixture" "$leafpid_ign" 0 "$leaf_sleep" term-ignoring &
+ign_child=$!
+ign_wait=$((SECONDS + 5))
+while [[ ! -s "$leafpid_ign" && "$SECONDS" -lt "$ign_wait" ]]; do sleep 0.05; done
+ign_leaf=$(cat "$leafpid_ign" 2>/dev/null)
+if [[ -z "$ign_leaf" ]]; then
+  fail "the TERM-ignoring leaf had to record its pid before it could be graded" \
+       "a recorded pid within 5s" "an empty pidfile — the vacuity guard never ran"
+else
+  kill -TERM "$ign_leaf" 2>/dev/null
+  tw_probe_fixture="$fixture"
+  tw_probe_leaf="$ign_leaf"
+  # 1s against a 30s leaf: signal delivery is measured in microseconds, so this
+  # is six orders of magnitude of slack, and the pair still clears
+  # await_gone_bound's 10:1 wall.
+  await_gone 1 "$leaf_sleep" budget_tree_gone "the leaf's own sleep"
+  case $? in
+    1) pass "the fixture's TERM-ignoring leaf really does survive a SIGTERM (${AWAIT_GONE_ELAPSED}s / $AWAIT_GONE_LOOKS looks: $AWAIT_GONE_LAST)" ;;
+    0) fail "the case below is vacuous unless its leaf survives SIGTERM" \
+            "a leaf still alive 1s after SIGTERM" \
+            "it was gone on look $AWAIT_GONE_LOOKS — the trap did not take, so the SIGKILL pass is not what is being graded" ;;
+    *) fail "the leaf's SIGTERM disposition had to be observable at all" \
+            "a poll that could look" "$AWAIT_GONE_REASON" ;;
+  esac
+fi
+kill -9 "$ign_leaf" 2>/dev/null
+wait "$ign_child" 2>/dev/null
+: >"$leafpid_ign"
+
+# And now the case itself: the same tree, under the same bound, with the leaf
+# SIGTERM cannot reach.
+start=$SECONDS
+budget_run 2 bash "$fixture" "$leafpid_ign" 2 "$leaf_sleep" term-ignoring
+ign_elapsed=$((SECONDS - start))
+assert_eq "the wrapper still reports a timeout (TERM-ignoring leaf)" "1" "$BUDGET_LAST_TIMED_OUT"
+# The grace loop's SUBJECT, which the reap assertion below cannot see: with the
+# victims collected before the SIGTERM, a loop still gated on the wrapper alone
+# posts the SIGKILL immediately and the leaf is just as dead — sooner. What is
+# lost is the grace itself, for every gate whose children clean up on SIGTERM
+# rather than ignoring it, which is the only reason the grace period exists.
+# The wrapper is the wrong subject because it is an ordinary `bash` that dies
+# on SIGTERM in milliseconds whatever it is waiting for (#1616's corollary:
+# observe the SUBJECT, not a side effect it produces on its way out).
+assert_ge "a descendant still alive holds the grace period open" "$tree_grace" "$ign_elapsed"
+
+leaf_ign=$(cat "$leafpid_ign" 2>/dev/null)
+if [[ -z "$leaf_ign" ]]; then
+  fail "the fixture reached its TERM-ignoring leaf before the bound expired" \
+       "a recorded pid" "an empty pidfile — the SIGKILL assertion never ran"
+else
+  tw_probe_fixture="$fixture"
+  tw_probe_leaf="$leaf_ign"
+  await_gone "$reap_deadline" "$leaf_sleep" budget_tree_gone "the leaf's own sleep"
+  case $? in
+    0) pass "a descendant that ignored SIGTERM is still gone when the bound returns (gone on look $AWAIT_GONE_LOOKS, after ${AWAIT_GONE_ELAPSED}s)" ;;
+    1) fail "the SIGKILL pass must reach a descendant that survived the SIGTERM" \
+            "every descendant gone within ${reap_deadline}s" \
+            "still alive after ${AWAIT_GONE_ELAPSED}s / $AWAIT_GONE_LOOKS looks: $AWAIT_GONE_LAST" ;;
+    *) fail "the reap had to be observable at all" \
+            "a poll that could look" "$AWAIT_GONE_REASON" ;;
+  esac
+  kill -0 "$leaf_ign" 2>/dev/null && kill -9 "$leaf_ign" 2>/dev/null  # never leak the leaf's sleep
+fi
+pkill -f "$fixture" 2>/dev/null
+rm -f "$fixture" "$leafpid_ign"
+# Back to the suite-wide grace: everything after this point is about statuses
+# and shell options, not about how long a kill takes.
+# shellcheck disable=SC2034  # read by gate-budget.sh, sourced above
+BUDGET_TERM_GRACE_SECONDS=1
 
 echo ""
 echo "== budget_run under the CALLER's \`-e\` (#1635) =="
@@ -420,7 +595,7 @@ echo "== end to end: tools/preflight.sh names the gate that ran out of time =="
 probe="$ROOT/tools/.preflight-budget-probe-$$.sh"
 # Replaces the tree-kill block's trap, so it re-names that block's files: both
 # are already gone by here, but a reordering must not silently lose them.
-trap 'rm -f "$probe" "$fixture" "$leafpid"' EXIT
+trap 'rm -f "$probe" "$fixture" "$leafpid" "$leafpid_ign"' EXIT
 python3 - "$ROOT/tools/preflight.sh" "$probe" <<'PY'
 import sys
 src, dst = sys.argv[1], sys.argv[2]

--- a/tools/lib/shell-lib-errexit_test.sh
+++ b/tools/lib/shell-lib-errexit_test.sh
@@ -102,7 +102,7 @@ need grep
 need mktemp
 need jq      # gosec_report_check refuses (2) without it, which would fail that
              # row for an unrelated reason and read as this one.
-need pgrep   # _budget_kill_tree / _swift_suite_descendants walk with it.
+need pgrep   # _budget_tree_pids / _swift_suite_descendants walk with it.
 need diff    # obligation (b) IS a diff; without it every call reads as a leak.
 
 LIBDIR="$REPO_ROOT/tools/lib"
@@ -366,6 +366,21 @@ row 'gate-budget.sh::budget_exhausted' 'budget_exhausted' 0 \
 row 'gate-budget.sh::_budget_kill_tree' '_budget_kill_tree (already-dead pid)' 0 \
     '. tools/lib/gate-budget.sh; sh -c "exit 0" & tw_dead=$!; wait "$tw_dead" || :' \
     '_budget_kill_tree TERM "$tw_dead"'
+# Driven on a pid whose `pgrep -P` finds NOTHING, which is the errexit-exposed
+# half: pgrep exits 1 when a process has no children, and that is the ordinary
+# case for the deepest pid of every walk. A pid WITH children is exercised by
+# the timeout row below, which now reaches this function with a real tree under
+# it (#1681).
+row 'gate-budget.sh::_budget_tree_pids' '_budget_tree_pids (a pid with no children)' 0 \
+    '. tools/lib/gate-budget.sh; sh -c "exit 0" & tw_leaf=$!; wait "$tw_leaf" || :' \
+    '_budget_tree_pids "$tw_leaf" >/dev/null'
+# Its other documented status, 1 (they are all gone), is deliberately NOT
+# driven, for the reason this file states about await_gone's 1: a documented 1
+# is indistinguishable from an errexit abort. The 0 arm is the one a caller can
+# tell apart, and it is also the one the grace loop spins on.
+row 'gate-budget.sh::_budget_any_alive' '_budget_any_alive (a pid that is alive)' 0 \
+    '. tools/lib/gate-budget.sh' \
+    '_budget_any_alive "$$"'
 row 'gate-budget.sh::budget_run' 'budget_run (ordinary path)' 3 \
     '. tools/lib/gate-budget.sh; BUDGET_POLL_SECONDS=0.05' \
     'budget_run 20 bash -c "exit 3"'


### PR DESCRIPTION
Closes #1681

## The mechanism, and yes — the collect-before-signalling route

`budget_run`'s timeout path sent `_budget_kill_tree TERM "$pid"`, waited in a grace
loop on **`$pid` only**, then sent `_budget_kill_tree KILL "$pid"`. Both passes
walked `pgrep -P` **from the wrapper pid**, and by the second pass the wrapper was
dead — it is an ordinary `bash`, which dies on SIGTERM in milliseconds whatever its
children are doing. So the second walk enumerated nobody (the descendants had been
reparented to launchd) and the SIGKILL pass signalled a corpse.

I took the route the issue proposes and `tools/lib/swift-suite.sh` already uses, for
the reason its own comment gives (`_swift_suite_descendants`, lines 434-439: *"Collected
BEFORE anything is signalled, which is the whole trick"*). I found no reason the two
cases differ — the ppid chain is destroyed by the same event in both — so the walk is
now the same in both files, and the note in `gate-budget.sh` that used to justify two
different walks says so: what still differs between the two libraries is only the
signalling *around* the walk (swift-suite hides the shell's job notice; this one lets
it through, because here it lands beside a named TIMEOUT block rather than in place of
one).

Three functions where there were one:

- `_budget_tree_pids <pid>` — `<pid>` and every descendant, **deepest first**, so a
  parent cannot spawn a replacement between two kills. The list is the argument order
  `kill` receives, which it signals in sequence.
- `_budget_kill_tree <signal> <pid...>` — same name, same `|| :` guard (#1635's
  region, untouched), but it signals a **recorded list** instead of re-walking.
- `_budget_any_alive <pid...>` — the grace loop's new subject. `kill -0`, a builtin,
  not `ps`: an external binary that fails to run prints nothing and nothing reads
  exactly like "everything is gone" (`await-gone.sh`'s rule 3).

`budget_run` collects once, before the SIGTERM, and signals that same list on both
passes. The grace loop waits on the **tree** — #1616's corollary, observe the SUBJECT
and not a side effect it produces on its way out. The wrapper is polled too and costs
nothing to include: measured on bash 3.2.57, a TERMed background child answers
`kill -0` for 7-14 busy iterations before this shell reaps it, so it never holds the
loop open as a zombie.

## Red first

The defect test is a new case in `gate-budget_test.sh` whose leaf does
`trap '' TERM` before its `exec sleep`. An **ignored** disposition is inherited across
`exec` where a caught one is reset, so the leaf keeps #1616's `exec` — no next command,
no mid-transition state — and is still the descendant SIGTERM does not reach. Measured
on bash 3.2.57 / macOS 25.5.

**RED, against `origin/main`'s `gate-budget.sh` (7f007fda), library byte-identical:**

```
== the whole process tree dies, not just the direct child ==
  PASS: the process-tree fixture parses
  PASS: the wrapper still reports a timeout
  PASS: no descendant of the killed command outlived the bound (gone on look 1, after 0s)

== the SIGKILL pass reaches a descendant that SURVIVED the SIGTERM (#1681) ==
  PASS: the fixture's TERM-ignoring leaf really does survive a SIGTERM (1s / 7 looks: 20071(the exec'd leaf))
  PASS: the wrapper still reports a timeout (TERM-ignoring leaf)
  FAIL: the SIGKILL pass must reach a descendant that survived the SIGTERM — expected [every descendant gone within 3s] got [still alive after 3s / 22 looks: 20106(the exec'd leaf)]

gate-budget_test: 1 FAILED
```

Note what stayed green: the pre-existing tree-kill case. Its leaf is a plain
`exec sleep`, which dies on SIGTERM, so it never made the SIGKILL pass load-bearing —
which is exactly what the issue says.

**GREEN, after the fix:**

```
== the whole process tree dies, not just the direct child ==
  PASS: the process-tree fixture parses
  PASS: the wrapper still reports a timeout
  PASS: a tree that dies on SIGTERM does not spend the grace period (2 <= 3)
  PASS: no descendant of the killed command outlived the bound (gone on look 1, after 0s)

== the SIGKILL pass reaches a descendant that SURVIVED the SIGTERM (#1681) ==
  PASS: the fixture's TERM-ignoring leaf really does survive a SIGTERM (1s / 7 looks: 28874(the exec'd leaf))
  PASS: the wrapper still reports a timeout (TERM-ignoring leaf)
  PASS: a descendant still alive holds the grace period open (6 >= 4)
  PASS: a descendant that ignored SIGTERM is still gone when the bound returns (gone on look 1, after 0s)

gate-budget_test: ALL PASS
```

## Mutation evidence

Six, each applied and reverted in its own foreground call, each with the substitution
asserted to have applied (#1390) and a `git status --porcelain` assertion after the
restore. **Two of them are the point of the whole set: the reap assertion and the
grace-period assertion grade different halves of the fix, and each half has a mutation
the other does not catch.**

| # | mutation | red | stayed green |
|---|---|---|---|
| M1 | SIGKILL pass re-walks `_budget_tree_pids "$pid"` (collect-before-signal reverted, grace loop kept) | `the SIGKILL pass must reach a descendant that survived the SIGTERM — still alive after 3s / 24 looks` | everything else, incl. the grace assertion |
| M2 | grace loop back to `kill -0 "$pid"` (collection kept) | `a descendant still alive holds the grace period open — expected [>= 4] got [2]` | **the reap assertion** — the SIGKILL still reaches the leaf, just with no grace spent |
| M3 | grace loop's liveness condition deleted (spin the full grace always) | `a tree that dies on SIGTERM does not spend the grace period — expected [<= 3] got [6]` | the other three |
| M4 | fixture's `trap '' TERM` removed | `the case below is vacuous unless its leaf survives SIGTERM — it was gone on look 1` **and** the grace assertion | `a descendant that ignored SIGTERM is still gone` — the vacuous pass the guard exists to expose |
| M5 | apostrophe put back into the fixture's `${4:?…}` message | `the process-tree fixture must parse … unexpected EOF while looking for matching '` (+6 downstream) | — |
| M6 | case asks the fixture for `ignores-term`, a disposition it does not model | the closed-set refusal fires: 3 loud reds, `an empty pidfile — the SIGKILL assertion never ran` | — |

M2 is why the grace-loop half got its own assertion: without it, the change the issue
explicitly asks for (*"make the grace loop wait on the tree, not on `$pid` alone"*)
would have shipped held by nothing.

M5 is not hypothetical — it is what actually happened while writing this, and it is why
the fixture now gets a `bash -n` assertion: bash 3.2 treats a `'` inside a parameter
expansion's word as a QUOTE even when the whole expansion is double-quoted (the trap
`await-gone.sh` records at `AWAIT_GONE_DEFAULT_WHAT`), so one apostrophe broke the whole
fixture and the run reported five failures none of which said "syntax error".

The **tripwire** needed no deliberate mutation: adding two functions produced its
failure on the spot, which is the mechanism working —

```
PASS: the recipe table carries at least one row per discovered function (38 rows / 34 functions)
FAIL: recipes and the walk disagree — expected [a bijection] got [UNDRIVEN gate-budget.sh::_budget_tree_pids — …]
FAIL: recipes and the walk disagree — expected [a bijection] got [UNDRIVEN gate-budget.sh::_budget_any_alive — …]
```

Both now carry driving recipes (**40 rows / 34 functions**, from 38/32). `_budget_tree_pids`
is driven on a pid whose `pgrep -P` finds nothing, which is the errexit-exposed half —
`pgrep` exits 1 for a childless process, the ordinary case for the deepest pid of every
walk, and the tripwire measured that the `for … in $(pgrep …)` does not abort a caller
under `-e`. `_budget_any_alive`'s documented 1 is deliberately not driven, for this
file's own stated reason: a documented 1 is indistinguishable from an errexit abort.

## #1682's fixtures and its ratio wall

Both hold, and the wall was re-checked rather than assumed, because this PR does change
timing.

- The leaf/deadline pair #1682 put deliberately **on** the 10:1 wall is **untouched** —
  still `leaf_sleep=30` / `reap_deadline=3`, and `await_gone_bound 3 30` still accepts
  (`3 * AWAIT_GONE_RATIO == 30`, i.e. exactly at the wall, as intended).
- The one **new** `await_gone` call is the vacuity guard, `await_gone 1 30` — a 10:1
  clearance, comfortably inside the wall, and the numbers are declared at the call site
  so `await_gone`'s own fail-closed re-check is the check.
- What I *did* change is the grace period for the two tree cases, 1s → 4s, and it is a
  measurement rather than a preference: `budget_run 2` detects its own bound anywhere in
  (1.0s, 2.05s] because that check is on `$SECONDS`, and the grace loop spends
  (grace-1, grace] on top. At grace=4 a run that spends the grace lands in (4.0s, 6.1s]
  and one that does not lands in (1.0s, 2.1s] — which a whole-second clock separates
  with a margin each side. At the suite-wide 1s the two populations are adjacent and the
  assertions would have been measuring scheduler noise. Restored to 1 immediately after
  the block, so nothing downstream sees it.
- Measured stability, 4 consecutive runs at load ~4: the TERM-dying case read **2**
  every time (ceiling 3) and the TERM-ignoring case read **6** every time (floor 4).
  Under M2 the latter read 2; under M3 the former read 6.
- `tools/lib/await-gone_test.sh` (#1682's own suite): `ALL PASS`, unchanged.
- Both tree cases now share **one** predicate rather than a copy each — #1627's actual
  finding was two fixtures polling for the same thing having drifted in four ways, and a
  second inline copy is how that returns.

Cost: the `gate-budget_test.sh` suite goes from ~13s to ~19.5s (the vacuity guard's 1s,
the second bounded run's ~2s, and the deliberately-spent 4s grace).

## Gates

| gate | result |
|---|---|
| `tools/preflight.sh --only tools` | **PASS** (exit 0; `shell-lib-suite: tools/lib — found 16, skipped 0, ran 16, failed 0`) |
| pre-push hook (`--changed --budget 540`) | **PASS** — POSIX sh lint PASS, tools/lib shell-lib tests PASS, gofmt PASS, the rest SKIP on this diff |
| `--only swift` | not run, and not in scope: it triggers on `swift-suite{,_test}.sh`, neither of which this touches |
| `--only posix` | it selects on a `#!/bin/sh` first line; all three files here are `#!/usr/bin/env bash`. It ran anyway as part of the pre-push hook and passed |
| shellcheck | run by no gate over these files, checked by hand for parity: `origin/main` had one SC2034 in `gate-budget_test.sh`, this branch has the same one and no new warning |

`go-test`/CodeScene are unaffected by a `tools/lib/` diff; CodeScene is advisory.

## Scope

`tools/lib/` only — `gate-budget.sh`, `gate-budget_test.sh`, `shell-lib-errexit_test.sh`.
Nothing under `core/` or `.github/workflows/`. One doc line is now slightly stale and I
left it alone deliberately, being outside this scope: AGENTS.md's "Sourced shell
libraries" bullet still calls `_budget_kill_tree` a walk, and its parenthetical count
(*"7 libraries / 32 functions"* territory) has moved to 34.
