### PR TITLE
fix(fswatcher): record a transcript as reported only once a subscriber received it (#1679)

### DIFF
--- a/core/adapters/inbound/agents/fswatcher/reconcile_test.go
+++ b/core/adapters/inbound/agents/fswatcher/reconcile_test.go
@@ -73,6 +73,54 @@ func expectNoEvent(t *testing.T, ch <-chan agent.Event, d time.Duration) {
 	}
 }
 
+// drainAvailableNewSessions records the transcript path of every new-session
+// event already queued on ch, without blocking. Used where the caller has
+// ordered itself against the producer and "everything currently buffered" is
+// therefore a complete answer rather than a snapshot.
+func drainAvailableNewSessions(ch <-chan agent.Event, into map[string]bool) {
+	for {
+		select {
+		case ev := <-ch:
+			if ev.Type == agent.EventNewSession {
+				into[ev.TranscriptPath] = true
+			}
+		default:
+			return
+		}
+	}
+}
+
+// collectNewSessionsUntil keeps recording new-session paths off ch until into
+// holds want of them or the deadline passes. It polls rather than sleeping the
+// whole window so a fast machine finishes fast and a slow one still passes.
+func collectNewSessionsUntil(ch <-chan agent.Event, into map[string]bool, want int, deadline time.Time) {
+	for len(into) < want && time.Now().Before(deadline) {
+		select {
+		case ev := <-ch:
+			if ev.Type == agent.EventNewSession {
+				into[ev.TranscriptPath] = true
+			}
+		case <-time.After(20 * time.Millisecond):
+		}
+	}
+}
+
+// seedTranscriptBacklog writes n transcript files into one project directory
+// under a fresh root and returns the root plus their paths, so a test can drive
+// a startup backlog of a chosen size.
+func seedTranscriptBacklog(t *testing.T, n int) (root string, paths []string) {
+	t.Helper()
+	root = setupFakeProjects(t)
+	dir := filepath.Join(root, "-Users-test-myproject")
+	paths = make([]string, 0, n)
+	for i := 0; i < n; i++ {
+		p := filepath.Join(dir, fmt.Sprintf("session-%03d.jsonl", i))
+		writeTranscript(t, p, `{"type":"init"}`+"\n")
+		paths = append(paths, p)
+	}
+	return root, paths
+}
+
 func TestEffectiveReconcileInterval(t *testing.T) {
 	tests := []struct {
 		name string
@@ -492,14 +540,7 @@ func TestWatch_ReconcileRecoversNewSessionEventBroadcastDropped(t *testing.T) {
 
 	run := func(t *testing.T, interval, settle time.Duration) (burst int, delivered map[string]bool, want []string) {
 		t.Helper()
-		root := setupFakeProjects(t)
-		dir := filepath.Join(root, "-Users-test-myproject")
-		want = make([]string, 0, files)
-		for i := 0; i < files; i++ {
-			p := filepath.Join(dir, fmt.Sprintf("session-%03d.jsonl", i))
-			writeTranscript(t, p, `{"type":"init"}`+"\n")
-			want = append(want, p)
-		}
+		root, want := seedTranscriptBacklog(t, files)
 
 		w := NewWithRoot(root, testAdapter, 0).WithReconcileInterval(interval)
 		// The production shape (subscriberBuffer slots), deliberately not read
@@ -523,29 +564,11 @@ func TestWatch_ReconcileRecoversNewSessionEventBroadcastDropped(t *testing.T) {
 		// Frozen on Watch's goroutine with the sweep's ticker not yet created,
 		// so this drain is exactly what the burst's broadcasts delivered.
 		delivered = make(map[string]bool, files)
-		for draining := true; draining; {
-			select {
-			case ev := <-ch:
-				if ev.Type == agent.EventNewSession {
-					delivered[ev.TranscriptPath] = true
-				}
-			default:
-				draining = false
-			}
-		}
+		drainAvailableNewSessions(ch, delivered)
 		burst = len(delivered)
 		close(release)
 
-		deadline := time.Now().Add(settle)
-		for len(delivered) < files && time.Now().Before(deadline) {
-			select {
-			case ev := <-ch:
-				if ev.Type == agent.EventNewSession {
-					delivered[ev.TranscriptPath] = true
-				}
-			case <-time.After(20 * time.Millisecond):
-			}
-		}
+		collectNewSessionsUntil(ch, delivered, files, time.Now().Add(settle))
 		return burst, delivered, want
 	}
 

--- a/core/adapters/inbound/agents/fswatcher/reconcile_test.go
+++ b/core/adapters/inbound/agents/fswatcher/reconcile_test.go
@@ -2,6 +2,7 @@ package fswatcher
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -461,5 +462,131 @@ func TestWatch_ReconcileRecoversFileUnderAnUnwatchableDir(t *testing.T) {
 	t.Run("sweep disabled leaves it invisible", func(t *testing.T) {
 		ch := run(t, -1)
 		expectNoEvent(t, ch, 500*time.Millisecond)
+	})
+}
+
+// The reconcile sweep must recover a new-session event that broadcast DROPPED.
+//
+// Issue #1679: emit recorded emitted[path] = size BEFORE broadcasting, and
+// broadcast is a non-blocking send that discards the event when a subscriber's
+// buffer is full. reconcileFile then returns early on `known && prev == size`,
+// so a dropped event was indistinguishable, to the sweep, from a delivered
+// one — the recovery mechanism that exists for the notification fsnotify never
+// delivered (#1248) was disarmed by the very act that lost the event.
+//
+// The overflow here is a property of the fixture rather than injected timing: a
+// Subscribe() channel holds subscriberBuffer events and the backlog scan emits
+// every pre-existing transcript in one uninterrupted burst on Watch's own
+// goroutine, so with the consumer not yet reading, exactly the first
+// subscriberBuffer fit and the rest have nowhere to go. #1680's
+// onBacklogScanComplete seam freezes the watcher at the end of that burst,
+// which is what makes "how many did the burst deliver" an exact count instead
+// of one racing the first sweep.
+//
+// The disabled-sweep subtest is the control: the dropped events stay lost, so
+// the recovered case is evidence about the sweep rather than about the buffer
+// draining on its own. Both subtests refuse to pass if the burst delivered
+// everything, since a fixture that never overflows grades nothing.
+func TestWatch_ReconcileRecoversNewSessionEventBroadcastDropped(t *testing.T) {
+	const files = subscriberBuffer + 16
+
+	run := func(t *testing.T, interval, settle time.Duration) (burst int, delivered map[string]bool, want []string) {
+		t.Helper()
+		root := setupFakeProjects(t)
+		dir := filepath.Join(root, "-Users-test-myproject")
+		want = make([]string, 0, files)
+		for i := 0; i < files; i++ {
+			p := filepath.Join(dir, fmt.Sprintf("session-%03d.jsonl", i))
+			writeTranscript(t, p, `{"type":"init"}`+"\n")
+			want = append(want, p)
+		}
+
+		w := NewWithRoot(root, testAdapter, 0).WithReconcileInterval(interval)
+		// The production shape (subscriberBuffer slots), deliberately not read
+		// until the burst is over.
+		ch := w.Subscribe()
+
+		atBoundary := make(chan struct{})
+		release := make(chan struct{})
+		w.onBacklogScanComplete = func() { close(atBoundary); <-release }
+
+		ctx, cancel := context.WithCancel(context.Background())
+		t.Cleanup(cancel)
+		go func() { _ = w.Watch(ctx) }()
+
+		select {
+		case <-atBoundary:
+		case <-time.After(10 * time.Second):
+			t.Fatal("the backlog scan never completed")
+		}
+
+		// Frozen on Watch's goroutine with the sweep's ticker not yet created,
+		// so this drain is exactly what the burst's broadcasts delivered.
+		delivered = make(map[string]bool, files)
+		for draining := true; draining; {
+			select {
+			case ev := <-ch:
+				if ev.Type == agent.EventNewSession {
+					delivered[ev.TranscriptPath] = true
+				}
+			default:
+				draining = false
+			}
+		}
+		burst = len(delivered)
+		close(release)
+
+		deadline := time.Now().Add(settle)
+		for len(delivered) < files && time.Now().Before(deadline) {
+			select {
+			case ev := <-ch:
+				if ev.Type == agent.EventNewSession {
+					delivered[ev.TranscriptPath] = true
+				}
+			case <-time.After(20 * time.Millisecond):
+			}
+		}
+		return burst, delivered, want
+	}
+
+	// mustHaveOverflowed is the vacuity guard both subtests need: everything
+	// below is about events broadcast had to discard, so a burst that delivered
+	// all of them means the fixture no longer reaches the defect.
+	mustHaveOverflowed := func(t *testing.T, burst int) {
+		t.Helper()
+		if burst >= files {
+			t.Fatalf("the backlog burst delivered all %d new-session events, so nothing was dropped and this "+
+				"test grades nothing — Subscribe's buffer is %d, so the fixture needs more files than that",
+				files, subscriberBuffer)
+		}
+	}
+
+	t.Run("sweep enabled recovers the dropped events", func(t *testing.T) {
+		burst, delivered, want := run(t, 100*time.Millisecond, 8*time.Second)
+		mustHaveOverflowed(t, burst)
+
+		var missing []string
+		for _, p := range want {
+			if !delivered[p] {
+				missing = append(missing, filepath.Base(p))
+			}
+		}
+		if len(missing) > 0 {
+			t.Errorf("%d of %d new-session events (the burst delivered %d) were dropped by broadcast and never "+
+				"recovered by the reconcile sweep: %v — the sweep skipped them because emit recorded them as "+
+				"reported before broadcast had a chance to discard them (#1679)",
+				len(missing), files, burst, missing)
+		}
+	})
+
+	t.Run("sweep disabled leaves them lost", func(t *testing.T) {
+		burst, delivered, _ := run(t, -1, 500*time.Millisecond)
+		mustHaveOverflowed(t, burst)
+
+		if len(delivered) != burst {
+			t.Errorf("with the sweep disabled, %d events arrived after the burst's %d — something other than the "+
+				"sweep is delivering them, so the recovered case above is not evidence about the sweep",
+				len(delivered)-burst, burst)
+		}
 	})
 }

--- a/core/adapters/inbound/agents/fswatcher/watcher.go
+++ b/core/adapters/inbound/agents/fswatcher/watcher.go
@@ -84,9 +84,13 @@ type Watcher struct {
 	// WithReconcileInterval). Zero means defaultReconcileInterval; negative
 	// disables the sweep.
 	reconcileInterval time.Duration
-	// emitted records the size last broadcast for each transcript path, so the
+	// emitted records the size last DELIVERED to a subscriber for each
+	// transcript path, so the
 	// reconcile sweep can distinguish state fsnotify already reported from
-	// state it missed. Entries are removed when a file is deleted, so a
+	// state it missed. Delivered rather than merely broadcast: broadcast drops
+	// on a full subscriber buffer, and an entry written for a dropped event
+	// tells the sweep the state was reported when nothing downstream ever saw
+	// it (#1679 — see emit). Entries are removed when a file is deleted, so a
 	// recreated path is reported as a new session again. It is otherwise
 	// bounded by the number of transcript files this run has reported on —
 	// the same order as the tree the watcher already walks — so it is not
@@ -452,13 +456,26 @@ func (w *Watcher) dispatchEvent(watcher *fsnotify.Watcher, ev fsnotify.Event, ok
 	return true
 }
 
+// subscriberBuffer is the capacity of the channel Subscribe returns. Named
+// rather than inline so a test can quote the bound it is actually up against
+// instead of carrying a second copy of the number that can drift from it.
+//
+// It is not large enough for a startup backlog and is not meant to be: measured
+// against a real ~/.claude/projects with 128 transcripts inside the default
+// 5-day maxAge, the scan emits all 128 in ~90ms and a consumer costing 1ms per
+// event already receives only 75 (issue #1679). What makes that survivable is
+// that a drop stays recoverable by the reconcile sweep — see emit — not that
+// the buffer is big. Raising it, or making the send block, is a separate
+// decision about the drop policy and is deliberately not made here.
+const subscriberBuffer = 64
+
 // Subscribe returns a channel that receives transcript events. The channel is
 // buffered so a slow consumer doesn't block the watcher. The capacity must be
 // large enough to absorb bursts from concurrent sessions and subagent
 // transcripts — all files in the watched tree share this single channel, and
 // broadcast silently drops events when the channel is full.
 func (w *Watcher) Subscribe() <-chan agent.Event {
-	ch := make(chan agent.Event, 64)
+	ch := make(chan agent.Event, subscriberBuffer)
 	w.subMu.Lock()
 	w.subs = append(w.subs, ch)
 	w.subMu.Unlock()
@@ -587,7 +604,8 @@ func (w *Watcher) isStale(mtime time.Time) bool {
 	return w.maxAge > 0 && !mtime.IsZero() && time.Since(mtime) > w.maxAge
 }
 
-// emit records the size being reported for path and broadcasts the event.
+// emit broadcasts the event for path and records the size, in that order and
+// only if the broadcast reached a subscriber.
 // Every new-session and activity emission goes through here so the reconcile
 // sweep can tell the state fsnotify already reported from the state it missed,
 // and therefore never re-reports a file the normal event path handled.
@@ -603,24 +621,51 @@ func (w *Watcher) emit(typ agent.EventType, sessionID, projectDir, path string, 
 	if prev, ok := w.emitted[path]; ok && prev == size && typ == agent.EventNewSession {
 		return
 	}
+	// Record only what a subscriber actually received. broadcast drops when a
+	// subscriber's buffer is full, and recording first made a dropped event
+	// indistinguishable — to reconcileFile's `known && prev == size` early
+	// return — from a delivered one, so the sweep that exists to recover a
+	// notification fsnotify never delivered (#1248) was disarmed by the very
+	// act that lost the event (#1679). Leaving the entry unwritten is what
+	// keeps the sweep armed to re-report it on the next interval.
+	//
+	// "Delivered" is deliberately *any* subscriber rather than *every* one.
+	// Requiring all of them would tie this map to the slowest consumer: one
+	// wedged subscriber would make every sweep re-report the whole tree and
+	// hand every healthy subscriber a duplicate. The cost of the weaker
+	// predicate is that with more than one subscriber, a drop that hits only
+	// some of them is recorded as reported and stays unrecoverable for those.
+	// Production has exactly one subscriber per watcher — SessionDetector's
+	// drainWatcher, one per registered Watcher — so the two predicates coincide
+	// there today; the multi-subscriber case is tests and measurement rigs.
+	if !w.broadcast(w.eventFor(typ, sessionID, projectDir, path, size)) {
+		return
+	}
 	if w.emitted == nil {
 		w.emitted = make(map[string]int64)
 	}
 	w.emitted[path] = size
-	w.broadcast(w.eventFor(typ, sessionID, projectDir, path, size))
 }
 
-// broadcast sends an event to all subscribers. Non-blocking: drops if consumer
-// hasn't drained.
-func (w *Watcher) broadcast(ev agent.Event) {
+// broadcast sends an event to all subscribers and reports whether at least one
+// of them received it. Non-blocking: a subscriber whose buffer is full is
+// skipped rather than waited on, so an unresponsive consumer can never wedge
+// the watcher — see emit for what the return value is for, and Subscribe for
+// why the drop policy itself is left alone. A watcher with no subscribers at
+// all reports false for the same reason a full buffer does: nothing downstream
+// learned anything.
+func (w *Watcher) broadcast(ev agent.Event) bool {
 	w.subMu.Lock()
 	defer w.subMu.Unlock()
+	deliveredToAny := false
 	for _, ch := range w.subs {
 		select {
 		case ch <- ev:
+			deliveredToAny = true
 		default:
 		}
 	}
+	return deliveredToAny
 }
 
 // waitForRoot polls until the root directory exists or ctx is cancelled.


### PR DESCRIPTION
Closes #1679

## Production reachability: **established**, not inferred

#1679 marked impact as inferred. It is now measured, against the real
`~/.claude/projects` on this machine at the production default `maxAge` (120h),
with the real `Watcher` and a real `Subscribe()` channel. Nothing was written —
the harness only `ReadDir`s, `stat`s and arms kqueue watches.

**The backlog is 2× the buffer on an ordinary developer machine.** Non-stale
`.jsonl` per adapter root, `find -mtime -5`:

| root | total | within 5d |
|---|---|---|
| `.claude/projects` | 915 | **128** |
| `.codex/sessions` | 314 | 4 |
| `.pi/agent/sessions` | 226 | 0 |
| `.gemini/antigravity-cli/brain` | 192 | 0 |
| `.gemini/tmp` | 86 | 0 |
| `.kiro/sessions/cli` | 79 | 0 |
| `.vibe/logs/session` | 22 | 0 |
| `.copilot/session-state` | 5 | 0 |

The pipeline's total buffering is `Subscribe`'s 64 + `SessionDetector.merged`'s
16 ≈ 81. 128 > 81, so overflow needs only a consumer slower than the emitter.

**How slow the real consumer is, from the live daemon's own log** — not modelled.
`~/Library/Application Support/Irrlicht/logs/events.log.2`, daemon start
`2026-08-09T19:31:37.974162+02:00`, `max session age: 120h0m0s`:

```
claude-code    new-session events=   7  span=  0.199s  mean=   33.2ms/event
codex          new-session events=   7  span=  0.002s  mean=    0.4ms/event
pi             new-session events=   2  span=  0.003s  mean=    3.3ms/event
```

33ms per claude-code event, dominated by `onNewSession`'s `repo.Load` +
`record` + log write + PID encode.

**That startup is also a natural experiment**, three adapters under one daemon.
Files whose mtime is *now* in `[T-5d, T]` — a lower bound on what was non-stale
at T, since mtime only increases: codex 7 → **7 delivered**, pi 2 → **2
delivered**, claude-code **≥164 → 7 delivered**. Small backlogs deliver whole;
the large one did not. Cumulative distinct claude-code new-session events after
that start: 7 at +1s, 7 at +30s, 7 at +120s — the 15s sweep ran for the
daemon's remaining ~4h and recovered none of them, which is exactly this defect.

I could not fully account for 7 rather than the ~81 the buffer arithmetic
predicts (the shared 16-slot `merged` and 11 concurrent watchers are candidates;
I did not isolate it). Stated rather than smoothed over.

**Controlled measurement, real tree, real `Subscribe()`, sweep running 60s at
15s** (`EMITTED` counted against a second overflow-proof subscriber, #1674's
`subscribeLossless`):

| consumer cost | emitted | delivered to the 64-slot channel | never recovered by 3–4 sweeps |
|---|---|---|---|
| 0ms | 128 | 128 | 0 |
| 1ms | 128 | 75 | 53 |
| 5ms | 128 | 74 | 54 |
| **33ms** (measured) | 128 | **67** | **61** |

Backlog scan: 128 events in ~91ms. **A 1ms consumer already loses 53 of 128.**
Only a zero-cost consumer keeps up, and the real one costs 33ms.

**Answer**: a full 64-slot channel is reachable in ordinary first-run operation
on a machine with a few months of Claude Code history. It needs no 15,000-event
synthetic backlog — 128 files and any non-trivial consumer suffice.

### What is still NOT established

- **Whether the detector recovers from the downstream shape** #1679 describes
  (`EventActivity` for a session it was never told about). Unverified; I did not
  look. This change removes the way a *drop* produces that shape, but a lost
  fsnotify notification for an already-known file can still reach `case known:`.
- **Reachability without a backlog scan** (a burst from many concurrent
  sessions). Not measured.
- **A second, structurally present race, deliberately NOT filed**:
  `SessionDetector.AddWatcher` spawns `go drainWatcher` (whose first statement
  is `w.Subscribe()`) and `PermissionService.startWatching` then does
  `go w.Watch(ctx)` with no synchronization between them, so the backlog scan
  can broadcast to an empty subscriber list. Read off the code — and it did
  **not** reproduce: 20 runs of production's exact ordering against the real
  128-file tree with a zero-cost consumer (which loses 0 of 128 when Subscribe
  precedes Watch) lost 0 events, worst run 0. `Watch` performs `waitForRoot`,
  `fsnotify.NewWatcher()` and `watcher.Add(root)` before emitting anything,
  which is apparently enough. Filing an unreproduced race would be a claim
  without evidence, so it is recorded here instead. Note it is *mitigated* by
  this change either way: a broadcast nobody received is no longer recorded.

## The mechanism, and what it costs

`broadcast` now returns whether **at least one** subscriber received the event,
and `emit` writes `emitted[path] = size` only then — broadcast first, record
second.

**Any subscriber, not every one.** Requiring all of them ties `emitted` to the
slowest consumer: one wedged subscriber makes every sweep re-report the whole
tree and hand every healthy subscriber a duplicate. **The cost of the weaker
predicate**: with more than one subscriber, a drop that hits only some of them
is still recorded as reported and stays unrecoverable for those. Production has
exactly one subscriber per watcher — `SessionDetector.drainWatcher`, the only
non-test `inbound.Watcher` `Subscribe()` call site (`session_detector.go:623`) —
so the two predicates coincide there today; the multi-subscriber case is tests
and measurement rigs. This is visible in the numbers above: the after-fix
real-tree run had to drop its own lossless subscriber, because that subscriber
alone satisfies "delivered to any".

**Zero subscribers report false**, for the same reason a full buffer does:
nothing downstream learned anything. That is what makes the unreproduced race
above harmless.

**Second-order cost**: while a subscriber is genuinely wedged, `emitted` stops
filling, so `reconcileFile` reaches `idFor` for every file every sweep — for
codex that means re-decoding every transcript (~250ms/sweep on a 301-file tree,
per `reconcileFile`'s own doc comment) instead of ~3ms. It resolves itself as
soon as the consumer drains, and a permanently wedged detector is not a state
worth optimizing for.

**Also added**: `subscriberBuffer = 64`, named so the test can quote the bound
it is up against rather than carrying a second copy of the number.

## Drop policy: deliberately NOT changed

Per the brief's second item. The non-blocking send is a real design decision —
an unresponsive subscriber must not wedge the watcher — and this change makes a
drop *recoverable* rather than pretending it did not happen. Raising the buffer
or blocking the send is a separate decision about the drop policy; I did not
make it, and I did not file it either, because after this change I have no
evidence of remaining harm from a drop (the sweep recovers it within one
interval, measured: 0.12s at a 100ms interval, and 128/128 within 60s at the
production 15s interval). Surfacing a drop *count* (the issue's second
suggestion) is likewise not done: with recovery in place the failure mode is no
longer silent-and-permanent, only silent-and-transient.

## RED before, green after

**RED** — the defect test against `main`'s emit/broadcast order, `-race
-count=3`, deterministic 3/3:

```
    reconcile_test.go:575: 16 of 80 new-session events (the burst delivered 64) were dropped by broadcast
    and never recovered by the reconcile sweep: [session-064.jsonl session-065.jsonl session-066.jsonl
    session-067.jsonl session-068.jsonl session-069.jsonl session-070.jsonl session-071.jsonl
    session-072.jsonl session-073.jsonl session-074.jsonl session-075.jsonl session-076.jsonl
    session-077.jsonl session-078.jsonl session-079.jsonl] — the sweep skipped them because emit recorded
    them as reported before broadcast had a chance to discard them (#1679)
--- FAIL: TestWatch_ReconcileRecoversNewSessionEventBroadcastDropped (8.54s)
    --- FAIL: .../sweep_enabled_recovers_the_dropped_events (8.02s)
    --- PASS: .../sweep_disabled_leaves_them_lost (0.53s)
FAIL	irrlicht/core/adapters/inbound/agents/fswatcher	26.117s
```

**GREEN** after, `-race -count=3`:

```
--- PASS: TestWatch_ReconcileRecoversNewSessionEventBroadcastDropped (0.66s)
    --- PASS: .../sweep_enabled_recovers_the_dropped_events (0.12s)
    --- PASS: .../sweep_disabled_leaves_them_lost (0.54s)
ok  	irrlicht/core/adapters/inbound/agents/fswatcher	3.349s
```

The overflow is a property of the fixture, not injected timing: 80 transcripts
(`subscriberBuffer + 16`), a `Subscribe()` channel not read until the burst is
over, and #1680's `onBacklogScanComplete` seam freezing the watcher at the end
of the scan — before the sweep's ticker is even created — so "the burst
delivered 64" is an exact count rather than one racing the first sweep. Both
subtests carry a **vacuity guard** that refuses to pass if the burst delivered
everything, and `sweep disabled leaves them lost` is the **control**: without
the sweep the dropped events stay lost, so the recovered case is evidence about
the sweep rather than about the buffer draining on its own.

## Mutation evidence

One at a time, copy-aside/copy-back, `git status --porcelain` asserted empty
after each (all four confirmed `PORCELAIN_CLEAN`).

| mutation | verdict |
|---|---|
| **M1** record before broadcast (`main`'s order) restored | **RED** — the new test's `sweep_enabled…` arm, 3/3 |
| **M2** same, run against the whole package | **RED** — only the new test fails; nothing else notices, which is the point |
| **M3** keep the reorder, make `broadcast` `return true` unconditionally | **RED** — proves the *return value* is load-bearing, not merely the statement order |
| **M4** the over-fix: never record `emitted` at all | **RED** — `TestReconcile_DoesNotReEmitWhatWasAlreadyReported`, `…SilentAfterNormalEventPathEmitted`, `…EmitsActivityWhenFileGrewUnobserved`, `…ThenFsnotifyCreateDoesNotDuplicateNewSession` |

M4 is the one worth keeping: "stop recording" also makes the new test pass, and
those four pre-existing locks are what forbid it. M3 and M4 together pin the
predicate from both sides.

## #1680 / #998 still caught

Re-ran #1680's own committed regression mutation — `watcher.Add(w.root)` moved
to **after** `addExistingDirs` — on top of this change, `-race -count=3`:

```
    watcher_test.go:961: the brand-new top-level directory "brand-new-session" was not discovered before
    the backlog scan completed (15000 events were broadcast during the scan, none of them a new-session
    event for it) — discovery is waiting on the full backlog scan, which is issue #998's defect
--- FAIL: TestWatch_NewTopLevelDir_DiscoveredDuringBacklogScan (2.14s)
--- PASS: TestWatch_ScanBoundaryReportsALateDiscoveryAsLate (0.00s)
```

3/3 red, same message and the same 15000-event count as PR #1680 recorded, so
this change did not weaken it. `…ReportsALateDiscoveryAsLate` passing is correct
— it locks the boundary reporting a late discovery *as* late, which this
mutation does not break, exactly as #1680 described. That test uses
`subscribeLossless`, so every one of its 15000 scan broadcasts is delivered and
`emitted` is recorded as before: no interaction with this change.

## Gates

| gate | result |
|---|---|
| `tools/preflight.sh --only go` | **PASS** — exit 0 read directly, not through a pipe (gofmt, core module tests, onboarding-factory, replaydata validate, recording-rig smoke, replay fixtures). Run twice: before and after the test-helper extraction |
| `tools/preflight.sh --only arch` | **PASS** — exit 0 read directly, twice; ARS composite 7.927769889 → 7.927836262 (improved) |
| `go test ./core/adapters/inbound/agents/fswatcher/ -race -count=1` | PASS |
| new test, `-race -count=3` | PASS 3/3 (and the whole package at `-count=3`) |
| CI on the first push | all 15 checks green except the advisory CodeScene one above |

`--only arch` was run because this changes production code.

**Not run, stated rather than implied**: `web`, `tools`, `skills`, `posix`,
`security`, `swift` — this diff is two files in one Go package and touches none
of those file families. Not verified against a Linux runner (`--linux` needs
Docker); the change is platform-independent Go with no build tags, which is an
argument rather than a measurement.

## CodeScene: red, advisory, looked at — one finding fixed, one left with its cause unexplained

Three findings on the first push. Two were real and are fixed; one is left, and
what I do **not** know about it is stated rather than smoothed over.

| file | rule | impact | action |
|---|---|---|---|
| `reconcile_test.go` | **critical** Bumpy Road Ahead | 10.00 → 9.46 | **fixed** |
| `reconcile_test.go` | advisory Complex Method | 10.00 → 9.46 | **fixed** |
| `watcher.go` | **critical** Low Cohesion | 7.90 → 6.99 | **left**, see below |

**Fixed**: the new test had two near-identical drain loops and the backlog
seeding all inside one closure inside the test function. Lifted into three
helpers beside the file's existing `expectEvent`/`writeTranscript`, which also
gave each drain a name saying why it is correct — the non-blocking one is only
sound because the caller has ordered itself against the producer. The defect
mutation was re-run against the refactored test: **still RED 3/3**, identical
message, identical 16-of-80 count, so the extraction did not disarm it.

**Left, and honestly unexplained**: I could not attribute `watcher.go`'s Low
Cohesion to anything in the diff. Measured: the file has **44 top-level funcs
before and after** — no method was added, and the only structural addition is
one package-level `const`. It grew 1054 → 1099 lines, essentially all doc
comment. So the two obvious causes are ruled out, and I do not have a third; no
CodeScene CLI is installed here, so I could not bisect it locally, and the
hosted check only reports per-file totals.

What I *do* have is PR #1680's measurement that **this file sits on a cohesion
cliff**: adding one small method there moved it 7.91 → **7.00**, an order of
magnitude worse than the advisory finding it removed, which is why #1680 shipped
the inline form. This PR's 7.90 → **6.99** is that same ~0.91 step from a
*different* change. So the one refactor CodeScene's finding would normally
suggest is measured to make this file's score worse, and the only lever I can
see that is left is deleting explanatory comments — which trades a real asset
for a tool's number and runs against this repo's own convention of keeping the
reasoning next to the code it constrains.

Not chased further: AGENTS.md has CodeScene as advisory and not a merge gate, "a
prompt to look closer, not something to chase to green". This is the looking.

## Scope

`core/adapters/inbound/agents/fswatcher/` only — `watcher.go` and
`reconcile_test.go`, in two commits (the fix, then the test-helper extraction). `tools/lib/` untouched (another agent was working there).
The real-tree measurement harness was build-tagged, read-only, and removed
before the commit; it is not part of the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
