### PR TITLE
fix(macos): close the quota chip's three remaining wall-clock reads (#1675)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1556,10 +1556,67 @@ Before marking a ticket done, run the full suite — every layer must pass:
   the app-wide clock injection #1663 defers. (The other function that issue names,
   `formatClockTime`, never read a clock: its two machine reads were the
   formatter's unset locale and zone, closed by the existing two seams.) Three
-  further wall-clock reads on the same chip stay unconverted (`quotaPacePercent`,
-  `mergeIntoBuckets`' staleness test, `formatTimeUntil`), and the first two are
-  pixel-visible, so the `rate_limit` fixture #1663 anticipates is still not safe
-  to seed: that is #1675, filed rather than folded in.
+  further wall-clock reads on the same chip were left unconverted
+  (`quotaPacePercent`, `mergeIntoBuckets`' staleness test, `formatTimeUntil`),
+  two of them pixel-visible, so the `rate_limit` fixture #1663 anticipates was
+  still not safe to seed: that became #1675, the member below.
+  **Those three are #1675, and they are where the family's assertion shape
+  needed a twin.** Same axis as the fourth member rather than a fifth one — the
+  clock again, three further reads of it. All three now take `now` as an input —
+  `quotaPacePercent(_:now:)` and `snapshotIsStale(_:now:)` as required
+  arguments, `QuotaResetFormat.timeUntil(_:now:)` likewise, and
+  `mergeIntoBuckets` / `quotaChipData` are `static` and pure so the fold cannot
+  read a clock at all. Six things are worth carrying.
+  **An extraction was again unavoidable, and the second one is not a leaf
+  view.** #1663's `QuotaResetLabel` works because the pixels and the decision
+  are the same `Text`; the staleness flip decides an `.opacity` applied to the
+  WHOLE chip while the decision was made in the data fold, two hundred lines
+  away, and `SessionListView.quotaChipView` cannot be hosted without dragging in
+  `SessionManager`. So the vehicle is a generic wrapper — `QuotaStaleDimmed<Content>`
+  (`Irrlicht/Views/QuotaChipParts.swift`) — which moves the decision to where the
+  pixels are and is hostable over any content. `QuotaWindowRow` beside it is the
+  ordinary leaf case, for the pace marker.
+  **The stored verdict was REMOVED rather than kept beside the derived one.**
+  `QuotaWidgetData.isStale` and `snapshotIsStale(snapshot, now:)` would have been
+  two spellings of one fact that could only drift, and the equivalence that makes
+  the removal safe is locked
+  (`QuotaChipClockTests.testTheMergeNeverKeepsASnapshotWhoseStalenessDisagreesWithIt`,
+  over every branch of the fold) rather than argued in a comment. `ChipBucket`
+  keeps its own copy because the merge genuinely branches on it. The residual
+  cost is stated where it lives: under the running default clock the fold's read
+  and the wrapper's read are microseconds apart, so at a `resetsAt` boundary a
+  chip can dim one frame before its tooltip says "stale".
+  **A both-sides pixel arm needs a must-not-differ twin.** "Two clocks, two
+  rasterisations" is satisfied by a view that varies with the clock for ANY
+  reason, including one unrelated to the property under test — so each arm is
+  paired with a fixture whose verdict is identical under both clocks (a window
+  the clock cannot pace; a snapshot stale under both). Both twins earned their
+  place: one mutation reddens only the dimming twin and another only the row's,
+  while the arms they guard stay green.
+  **A mutation whose two pinned instants are congruent is INERT and reads as a
+  passing test.** The row's twin was first mutated with a marker at
+  `epoch % 100` — and `referenceNow` and `contrastingNow` are both ≡ 0 (mod
+  100), being exactly 48h apart — so a genuinely clock-varying marker rendered
+  identically and the arm came back green. That is #1390's "assert the mutation
+  actually changed the thing" arriving in a Swift suite, and the check is one
+  line of arithmetic before trusting a green mutation run.
+  **This is the one member of the family CI grades.** `QuotaMenuBarRendererTests`
+  takes no `as: .pinnedImage`, so `ImageSnapshotCIScopeTests` does not skip it —
+  and every fixture in it was built from `Date()` while the renderer read
+  `Date()` again a moment later, two reads of the machine that merely agreed. So
+  nothing in it could tell a renderer honouring its `now:` from one discarding
+  it, and its own comment recorded that it could not pin an exact ramp boundary
+  for the same reason. Both are now closed, and `now` threads from one visible
+  read in `MenuBarImageBuilder.combinedImage` — the icon is rasterised into an
+  `NSStatusItem`, so no environment can reach it and #1659's required-argument
+  form is the only option.
+  **And the `rate_limit` fixture #1663 anticipated is seeded, but NOT as a
+  committed PNG.** The clock obstacle is gone; what remains is unrelated to it
+  and is why the PNG form is still the wrong one — per #1615 every
+  committed-reference image suite currently fails on a runner over
+  rasterisation, so a new one would have to be classified as skipped in
+  `ImageSnapshotCIScopeTests` and would buy a check that runs on one Mac. The
+  two-render-in-memory form runs everywhere, so that is what the fixture is.
   And no, a test
   run does not modify the user's real app preferences:
   `UserDefaults.standard` under `swift test` resolves to

--- a/platforms/macos/Irrlicht/App/MenuBarImageBuilder.swift
+++ b/platforms/macos/Irrlicht/App/MenuBarImageBuilder.swift
@@ -82,10 +82,18 @@ enum MenuBarImageBuilder {
         // Combined style shares its width budget with the dots, so the
         // quota bars render in a narrower, label-less layout there — see
         // QuotaMenuBarRenderer.buildSVG's `compact` handling.
+        //
+        // `now:` is the menu-bar icon's one wall-clock read (#1675). The icon is
+        // rasterised into an `NSStatusItem`, not rendered by SwiftUI, so
+        // `\.formatNow` cannot reach it — the clock has to be read somewhere and
+        // this is that place, once, visibly, rather than twice inside
+        // `rowSVG` where the 5h and 7d rows could be paced against two
+        // different instants.
         let quotaImage = style == .lights ? nil : QuotaMenuBarRenderer.imageForSelectedProvider(
             sessions: nonGtSessions,
             providerKey: MenuBarQuotaProvider.current,
-            compact: style == .combined
+            compact: style == .combined,
+            now: Date()
         )
         // .usage style with sessions active but no renderable quota yet
         // (fresh daemon start, or the selected provider hasn't ticked a

--- a/platforms/macos/Irrlicht/Views/FormatNowEnvironment.swift
+++ b/platforms/macos/Irrlicht/Views/FormatNowEnvironment.swift
@@ -51,22 +51,35 @@ import SwiftUI
 /// many times the subtree asks, which is what makes the same-day branch
 /// decidable from a fixture at all.
 ///
-/// ## Blast radius — deliberately two call sites, not an app-wide clock
+/// ## Blast radius — the quota chip, not an app-wide clock
 ///
 /// #1663 says an injectable clock across every wall-clock read in the app is a
-/// separate, wider change, and this is not it. **Exactly one call site reads
-/// this key**: `QuotaResetLabel`, the `"resets …"` text. The other function
-/// #1663 names, `formatClockTime` behind the quota tooltip, never read a clock
-/// at all — it had two machine reads, its formatter's unset `locale` and
-/// `timeZone`, so `\.formatTimeZone` and `\.formatLocale` close it entirely and
-/// `QuotaResetFormat.clock` takes no `now`. Everything else in
-/// `SessionListView` that touches the wall clock still touches it directly —
-/// `quotaPacePercent`, `formatTimeUntil`, and `mergeIntoBuckets`' staleness
-/// test — because none of those SELECTS A FORMAT, which is the property that
-/// made this one impossible to close from the test side. Two of the three are
-/// pixel-visible — the pace marker's position and the stale chip's opacity — so
-/// they are a real obstacle to the rate-limit snapshot fixture #1663
-/// anticipates, and they are filed as #1675 rather than folded in here.
+/// separate, wider change, and this is still not it. What this key reaches is
+/// the quota chip, and since #1675 that is **four call sites**, all in
+/// `SessionListView` and `QuotaChipParts`:
+///
+/// - `QuotaResetLabel` — the `"resets …"` text (#1663, the original).
+/// - `QuotaWindowRow` — the pace marker's x position (#1675).
+/// - `QuotaStaleDimmed` — the chip's stale opacity (#1675). A *discrete*
+///   function of the clock, so the sharper snapshot hazard of the two.
+/// - `SessionListView`'s own `@Environment(\.formatNow)`, read once per body
+///   evaluation and passed as an argument into `quotaChipData` and
+///   `quotaTooltip`, so the fold's staleness test, the tooltip's pace verdict
+///   and its "resets in 4h 12m" all describe one instant.
+///
+/// The other function #1663 names, `formatClockTime` behind the quota tooltip,
+/// never read a clock at all — it had two machine reads, its formatter's unset
+/// `locale` and `timeZone`, so `\.formatTimeZone` and `\.formatLocale` close it
+/// entirely and `QuotaResetFormat.clock` takes no `now`.
+///
+/// One quota clock read is deliberately NOT this key:
+/// `QuotaMenuBarRenderer` is rasterised into an `NSStatusItem` outside any
+/// SwiftUI environment, so it takes `now` as a required argument and
+/// `MenuBarImageBuilder.combinedImage` reads the wall clock once, visibly, for
+/// it — #1659's shape for exactly that case. Everything outside the quota chip
+/// (`HistoryView`'s pickers, `SessionRowView.taskEtaPresentation`,
+/// `SettingsView`'s relative dates) still reads the clock directly; those are
+/// the app-wide change, still deferred.
 struct FormatNow {
     private let read: () -> Date
 

--- a/platforms/macos/Irrlicht/Views/QuotaChipParts.swift
+++ b/platforms/macos/Irrlicht/Views/QuotaChipParts.swift
@@ -1,0 +1,160 @@
+import SwiftUI
+
+/// The two pieces of the quota chip whose rendering depends on the wall clock
+/// (#1675), each extracted into a view of its own for the reason #1663
+/// extracted `QuotaResetLabel`: it is the only way the site can be rendered by
+/// a test.
+///
+/// ## Why an extraction was unavoidable
+///
+/// Both reads live inside `SessionListView`. `quotaWindowRow` and
+/// `quotaChipView` are methods on it, so reaching either means hosting the
+/// whole 380pt panel with its three environment objects — and an
+/// `@Environment` read off a `SessionListView` value a test constructed
+/// itself, outside a view update, answers the DEFAULT. That is a pin reaching
+/// nothing wearing the shape of a passing test, which is exactly what #1663
+/// recorded when it hit the same wall one read earlier.
+///
+/// So the clock read moves to the smallest view that owns the pixels it
+/// changes. `QuotaWindowRow` owns the pace marker's x position;
+/// `QuotaStaleDimmed` owns the chip's opacity. Neither adds or removes a
+/// modifier, and no committed reference renders either site (re-measured while
+/// writing this: `git grep -n "rateLimit" -- platforms/macos/Tests` matches
+/// only a doc comment, and the six directories under `Tests/__Snapshots__`
+/// belong to suites that render session rows, groups, history, the wizard and
+/// the backchannel editor — none the panel header), so the 53-PNG set is
+/// untouched by construction rather than by inspection.
+///
+/// ## What each one is graded by
+///
+/// `QuotaChipClockTests` drives two pinned clocks through each of these views
+/// via `PinnedSnapshotHost` and refuses an identical rasterisation. That
+/// comparison is the only thing that catches the mutation this change exists
+/// to make catchable — putting `Date()` back at the call site — because every
+/// string- and value-level assertion stays green under it (#1676 measured
+/// exactly that for the reset label, one read earlier).
+
+/// One row inside a subscription chip: window label, the bar with its pace
+/// marker, the used percent, and — outside compact mode — the reset label.
+///
+/// In compact mode (multiple chips visible) the inline reset time is dropped —
+/// it lives in the tooltip — and the bar shrinks so two or three chips fit in
+/// the 380pt header.
+///
+/// Was `SessionListView.quotaWindowRow`. The `Date()` it used to read for the
+/// pace marker is now this view's `\.formatNow`, read once for the row: the old
+/// in-place comment worried that calling `quotaPacePercent` twice would let two
+/// `Date()` captures disagree by microseconds, and a stopped clock removes that
+/// hazard rather than routing around it.
+struct QuotaWindowRow: View {
+    let window: RateLimitWindowInfo
+    let compact: Bool
+
+    @Environment(\.formatNow) private var formatNow
+
+    var body: some View {
+        // Computed once per row, from one read of the clock — SwiftUI
+        // re-invokes view bodies on every SessionManager publish.
+        let pace = SessionListView.quotaPacePercent(window, now: formatNow())
+        HStack(spacing: 6) {
+            Text(SessionListView.quotaWindowLabel(window.windowMinutes))
+                .font(.system(size: 9, weight: .medium, design: .monospaced))
+                .foregroundColor(.secondary)
+                .frame(width: 14, alignment: .leading)
+
+            QuotaWindowRow.bar(percent: window.usedPercent,
+                               color: SessionListView.barColor(used: window.usedPercent, pace: pace),
+                               pacePercent: pace)
+                .frame(width: compact ? 60 : 70, height: 5)
+
+            Text("\(Int(window.usedPercent.rounded()))%")
+                .font(.system(size: 9, weight: .medium, design: .monospaced))
+                .foregroundColor(.primary)
+                .frame(width: 28, alignment: .trailing)
+
+            if !compact {
+                // A view of its own since #1663 — see `QuotaResetLabel`, which
+                // reads the four values this rendering used to take off the
+                // machine (now, calendar, zone, locale) from the environment.
+                QuotaResetLabel(resetsAt: window.resetsAt)
+            }
+        }
+    }
+
+    /// A rounded-rect progress bar with an optional vertical pace marker (thin
+    /// red line at `pacePercent`). The marker reads "where you should be if
+    /// you've been pacing evenly" — fill past the marker means burning quota
+    /// faster than the window's linear rate; fill behind it means headroom.
+    /// ZStack so the fill, track, and marker render with the same corner radius
+    /// without clipping artifacts at small sizes.
+    ///
+    /// Takes `pacePercent` as an argument and reads no clock: it is the pixels,
+    /// not the decision. Was `SessionListView.quotaBar`, unchanged.
+    @ViewBuilder
+    static func bar(percent: Double, color: Color, pacePercent: Double?) -> some View {
+        GeometryReader { geo in
+            ZStack(alignment: .leading) {
+                RoundedRectangle(cornerRadius: 2.5)
+                    .fill(Color.secondary.opacity(0.2))
+                RoundedRectangle(cornerRadius: 2.5)
+                    .fill(color)
+                    .frame(width: geo.size.width * min(1.0, max(0.0, percent / 100.0)))
+                if let pace = pacePercent, (0...100).contains(pace) {
+                    Rectangle()
+                        .fill(Color.red)
+                        .frame(width: 1)
+                        .offset(x: geo.size.width * (pace / 100.0) - 0.5)
+                }
+            }
+        }
+    }
+}
+
+/// Dims a quota chip whose snapshot pre-dates the current window.
+///
+/// The chip's staleness test is a **discrete** function of the clock, which is
+/// what makes it the worse of #1675's two pixel-visible reads: a reference
+/// recorded a minute before a fixture's `resetsAt` is correct, and permanently
+/// wrong a minute later. #1663 met the same shape in `formatResetTime`'s
+/// same-day branch.
+///
+/// The verdict is decided HERE, from this subtree's `\.formatNow`, rather than
+/// carried in from `mergeIntoBuckets` as it was before #1675. Two reasons, and
+/// the second is the load-bearing one:
+///
+/// - It is not a second source of truth. `SessionListView.snapshotIsStale` is
+///   the one implementation, and the merge's own verdict equals what this
+///   re-derives for every path through `mergeIntoBuckets` — the bucket only
+///   ever keeps `isStale` alongside the snapshot it was computed from. That is
+///   locked by
+///   `QuotaChipClockTests.testTheMergeNeverKeepsASnapshotWhoseStalenessDisagreesWithIt`
+///   rather than left as an argument.
+/// - A verdict computed in `SessionListView.quotaChipData` is one no test can
+///   drive, for the `@Environment`-answers-the-default reason at the top of
+///   this file. Computed here, it is a function of a pinnable environment
+///   value, so two clocks through one view produce two rasterisations — the
+///   only assertion shape that catches a `Date()` put back at the call site.
+///
+/// One consequence, stated rather than buried: under the *running* default
+/// clock this read and the merge's read are microseconds apart, so at a
+/// `resetsAt` boundary a chip can dim one frame before its tooltip says
+/// "stale". Both self-correct on the next `SessionManager` publish, and under
+/// any pinned clock they are the same instant. That is the same
+/// microsecond-disagreement class `quotaWindowRow` already documented for two
+/// `quotaPacePercent` calls, traded for a decision a test can reach.
+struct QuotaStaleDimmed<Content: View>: View {
+    let snapshot: RateLimitInfo
+    @ViewBuilder let content: Content
+
+    @Environment(\.formatNow) private var formatNow
+
+    /// The opacity a stale chip renders at. Named so a test asserts against the
+    /// production constant rather than a copy of it.
+    static var staleOpacity: Double { 0.5 }
+
+    var body: some View {
+        content
+            .opacity(SessionListView.snapshotIsStale(snapshot, now: formatNow())
+                     ? Self.staleOpacity : 1.0)
+    }
+}

--- a/platforms/macos/Irrlicht/Views/QuotaMenuBarRenderer.swift
+++ b/platforms/macos/Irrlicht/Views/QuotaMenuBarRenderer.swift
@@ -25,15 +25,26 @@ enum QuotaMenuBarRenderer {
     /// `compact` requests the narrower, label-less bars layout used in
     /// Combined style (ignored by the Circle visual style, which has no
     /// label to drop and is already compact).
+    ///
+    /// `now` is a required argument since #1675 — the pace marker's position is
+    /// a continuous function of it. This renderer is rasterised into an
+    /// `NSStatusItem` outside any SwiftUI environment, so `\.formatNow` cannot
+    /// reach it and the argument form is the one #1659 prescribes for exactly
+    /// that case (`HistoryFormat`'s `timeZone`). The clock is read ONCE, at the
+    /// one visible place — `MenuBarImageBuilder.combinedImage` — and is an input
+    /// everywhere below here, so the 5h and 7d rows of one icon can no longer be
+    /// paced against two different instants the way two `Date()` reads inside
+    /// `rowSVG` were.
     static func imageForSelectedProvider(
         sessions: [SessionState],
         providerKey: String?,
-        compact: Bool = false
+        compact: Bool = false,
+        now: Date
     ) -> NSImage? {
         guard let info = selectedSnapshot(sessions: sessions, providerKey: providerKey) else {
             return nil
         }
-        return buildImage(for: info, compact: compact)
+        return buildImage(for: info, compact: compact, now: now)
     }
 
     /// Freshest-`sampledAt`-wins across `sessions`, matching
@@ -61,11 +72,11 @@ enum QuotaMenuBarRenderer {
         return filtered.max { $0.info.sampledAt < $1.info.sampledAt }?.info
     }
 
-    static func buildImage(for info: RateLimitInfo, compact: Bool = false) -> NSImage? {
+    static func buildImage(for info: RateLimitInfo, compact: Bool = false, now: Date) -> NSImage? {
         let built: (svg: String, width: CGFloat)?
         switch QuotaVisualStyle.current {
-        case .bars: built = buildSVG(for: info, compact: compact)
-        case .circle: built = buildCircleSVG(for: info)
+        case .bars: built = buildSVG(for: info, compact: compact, now: now)
+        case .circle: built = buildCircleSVG(for: info, now: now)
         }
         guard let (svg, width) = built else { return nil }
         guard let data = svg.data(using: .utf8), let image = NSImage(data: data) else { return nil }
@@ -77,7 +88,7 @@ enum QuotaMenuBarRenderer {
     /// `compact` drops the "5h"/"7d" text label and narrows the bars —
     /// used in Combined style, where the icon's width is shared with the
     /// session-state dots. Defaults to `false` (today's Usage-style layout).
-    static func buildSVG(for info: RateLimitInfo, compact: Bool = false) -> (svg: String, width: CGFloat)? {
+    static func buildSVG(for info: RateLimitInfo, compact: Bool = false, now: Date) -> (svg: String, width: CGFloat)? {
         let fiveHour = info.windows.first { $0.canonicalWindowMinutes == 300 }
         let sevenDay = info.windows.first { $0.canonicalWindowMinutes == 10080 }
         guard fiveHour != nil || sevenDay != nil else { return nil }
@@ -88,10 +99,10 @@ enum QuotaMenuBarRenderer {
         <svg xmlns="http://www.w3.org/2000/svg" width="\(Int(width))" height="\(Int(height))">
         """
         if let fiveHour {
-            svg += rowSVG(label: "5h", window: fiveHour, rowY: 0, compact: compact)
+            svg += rowSVG(label: "5h", window: fiveHour, rowY: 0, compact: compact, now: now)
         }
         if let sevenDay {
-            svg += rowSVG(label: "7d", window: sevenDay, rowY: rowHeight, compact: compact)
+            svg += rowSVG(label: "7d", window: sevenDay, rowY: rowHeight, compact: compact, now: now)
         }
         svg += "</svg>"
         return (svg, width)
@@ -103,7 +114,7 @@ enum QuotaMenuBarRenderer {
     /// stay pinned to one fixed window rather than silently swap which
     /// number it's showing. Falls back to 7d only when 5h is absent (e.g.
     /// a fresh snapshot that hasn't carried both windows yet).
-    static func buildCircleSVG(for info: RateLimitInfo) -> (svg: String, width: CGFloat)? {
+    static func buildCircleSVG(for info: RateLimitInfo, now: Date) -> (svg: String, width: CGFloat)? {
         let fiveHour = info.windows.first { $0.canonicalWindowMinutes == 300 }
         let sevenDay = info.windows.first { $0.canonicalWindowMinutes == 10080 }
         guard let window = fiveHour ?? sevenDay else { return nil }
@@ -113,7 +124,7 @@ enum QuotaMenuBarRenderer {
         let cy = size / 2
         let radius = size / 2 - 2.25
         let strokeWidth: CGFloat = 2.5
-        let pace = pacePercent(for: window)
+        let pace = pacePercent(for: window, now: now)
         let hex = colorHex(usedPercent: window.usedPercent, pacePercent: pace)
 
         let circumference = 2 * Double.pi * Double(radius)
@@ -146,14 +157,14 @@ enum QuotaMenuBarRenderer {
 
     /// `compact` omits the leading "5h"/"7d" label and narrows the bar by
     /// `compactBarWidthFactor` — see `buildSVG`'s doc.
-    private static func rowSVG(label: String, window: RateLimitWindowInfo, rowY: CGFloat, compact: Bool = false) -> String {
+    private static func rowSVG(label: String, window: RateLimitWindowInfo, rowY: CGFloat, compact: Bool = false, now: Date) -> String {
         let effectiveBarWidth = compact ? barWidth * compactBarWidthFactor : barWidth
         let pct = min(max(window.usedPercent, 0), 100) / 100
         let filledWidth = effectiveBarWidth * pct
         let barX: CGFloat = compact ? 0 : labelWidth + gap
         let barY = rowY + (rowHeight - barHeight) / 2
         let textY = rowY + rowHeight * 0.78
-        let pace = pacePercent(for: window)
+        let pace = pacePercent(for: window, now: now)
         let hex = colorHex(usedPercent: window.usedPercent, pacePercent: pace)
 
         var svg = ""
@@ -183,8 +194,8 @@ enum QuotaMenuBarRenderer {
     /// usage had grown linearly since the window opened" can't drift between
     /// the two. Reachable here because `selectedSnapshot` no longer drops
     /// stale snapshots.
-    private static func pacePercent(for window: RateLimitWindowInfo) -> Double? {
-        SessionListView.quotaPacePercent(window)
+    private static func pacePercent(for window: RateLimitWindowInfo, now: Date) -> Double? {
+        SessionListView.quotaPacePercent(window, now: now)
     }
 
     /// Delegates to SessionListView.quotaColorTier — the same pace-aware

--- a/platforms/macos/Irrlicht/Views/QuotaResetFormat.swift
+++ b/platforms/macos/Irrlicht/Views/QuotaResetFormat.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
-/// The quota chip's two date renderings, as pure functions of their inputs
-/// (#1663).
+/// The quota chip's date renderings, as pure functions of their inputs (#1663,
+/// #1675).
 ///
 /// These were `SessionListView.formatResetTime` and `.formatClockTime`, two
 /// `private func`s that between them stacked four machine reads:
@@ -36,6 +36,35 @@ enum QuotaResetFormat {
         f.dateStyle = .none
         f.timeStyle = .short
         return f.string(from: date)
+    }
+
+    /// Coarse "time remaining" for the quota tooltip's "resets in …" — `"4h 12m"`,
+    /// `"3d 7h"`, `"12m"`. Never negative: a reset already past reads `"0m"`,
+    /// which is the state the chip's stale dimming is simultaneously reporting.
+    ///
+    /// Was `SessionListView.formatTimeUntil`, whose `date.timeIntervalSinceNow`
+    /// was #1675's third wall-clock read. Unlike the other two it is **not**
+    /// pixel-visible — its only call site is the `.tooltip(…)` bridge, an
+    /// `onHover`-only `NSPanel` that adds nothing to the view tree (measured by
+    /// #1659 and again by #1663) — so converting it buys consistency rather
+    /// than determinism, and it was converted anyway for three reasons stated
+    /// rather than assumed. It is the only remaining way for one tooltip to
+    /// describe two instants (`resetLabel`'s pace verdict and this line are
+    /// built one after the other from the same `now` now). It is a pure
+    /// function that was untestable and is now graded on strings. And leaving
+    /// it would have left the quota chip with exactly one machine read, which
+    /// is the state a future reader has to re-audit to discover is deliberate.
+    static func timeUntil(_ date: Date, now: Date) -> String {
+        let seconds = max(0, Int(date.timeIntervalSince(now)))
+        let h = seconds / 3600
+        let m = (seconds % 3600) / 60
+        if h >= 24 {
+            let d = h / 24
+            let rh = h % 24
+            return rh == 0 ? "\(d)d" : "\(d)d \(rh)h"
+        }
+        if h > 0 { return "\(h)h \(m)m" }
+        return "\(m)m"
     }
 
     /// Compact reset label for the chip row. A reset on the same day as `now`

--- a/platforms/macos/Irrlicht/Views/SessionListView.swift
+++ b/platforms/macos/Irrlicht/Views/SessionListView.swift
@@ -218,6 +218,14 @@ struct SessionListView: View {
     /// through — see `QuotaResetFormat`.
     @Environment(\.formatTimeZone) private var formatTimeZone
     @Environment(\.formatLocale) private var formatLocale
+    /// The clock every quota rendering in this panel resolves "now" from
+    /// (#1675). Read ONCE per body evaluation and passed down as an argument,
+    /// so the chip's three time-dependent answers — which snapshot counts as
+    /// stale, where the pace marker sits, and "resets in 4h 12m" — cannot be
+    /// computed against three different instants. Its default is
+    /// `FormatNow.wallClock`, which is by construction the `Date()` each of
+    /// those sites read for itself before.
+    @Environment(\.formatNow) private var formatNow
     @EnvironmentObject var gasTownProvider: GasTownProvider
     @EnvironmentObject var updateManager: UpdateManager
     @State private var isQuitButtonHovered = false
@@ -481,7 +489,11 @@ struct SessionListView: View {
                 // Em-dash + glyphs are visually redundant once any quota
                 // chip is filling the slot — the chip already implies
                 // session activity. Hide them while a chip is present.
-                if quotaChipData.isEmpty || !showQuotaForecast {
+                // The clock is an argument here only because the derivation
+                // takes one; emptiness is decided by whether any session
+                // carries a snapshot at all, which no instant can change.
+                if Self.quotaChipData(sessions: sessionManager.sessions, now: formatNow()).isEmpty
+                    || !showQuotaForecast {
                     Text("—")
                         .foregroundColor(.secondary)
 
@@ -559,7 +571,7 @@ struct SessionListView: View {
     @ViewBuilder
     private var headerTitleView: some View {
         if showQuotaForecast {
-            let chips = quotaChipData
+            let chips = Self.quotaChipData(sessions: sessionManager.sessions, now: formatNow())
             if !chips.isEmpty {
                 let visible = Array(chips.prefix(Self.maxVisibleQuotaChips))
                 let hidden = Array(chips.dropFirst(Self.maxVisibleQuotaChips))
@@ -626,7 +638,7 @@ struct SessionListView: View {
     /// Render mode for a provider chip. Subscription chips show the
     /// provider-emitted quota bars; usage chips show cumulative spend across all
     /// sessions on that provider.
-    private enum QuotaMode {
+    enum QuotaMode {
         case subscription
         case usage
     }
@@ -636,31 +648,62 @@ struct SessionListView: View {
     /// most-imminent window (subscription only), and the summed spend
     /// (usage only). `id` is the providerKey so SwiftUI ForEach has a
     /// stable identity.
-    private struct QuotaWidgetData: Identifiable {
+    ///
+    /// Deliberately carries **no** `isStale` since #1675. It used to, and that
+    /// made staleness a second spelling of a fact already implied by
+    /// `snapshot` — `snapshotIsStale(snapshot, now:)` returns the merge's own
+    /// verdict for every path through `mergeIntoBuckets` (locked by
+    /// `QuotaChipClockTests.testTheMergeNeverKeepsASnapshotWhoseStalenessDisagreesWithIt`),
+    /// so the two could only ever differ by drifting. Dropping it is also what
+    /// lets the flip be graded where it is *visible*: the chip re-derives it
+    /// inside `QuotaStaleDimmed`, from that subtree's `\.formatNow`, which a
+    /// snapshot host can pin and a test can rasterise twice.
+    struct QuotaWidgetData: Identifiable {
         let id: String
         let mode: QuotaMode
         let snapshot: RateLimitInfo
         let session: SessionState
         let imminent: RateLimitWindowInfo?
         let totalCostUSD: Double
-        let isStale: Bool
     }
 
     /// All chips to render, one per subscription/usage provider. See
-    /// `bucketForChips` for the bucketing rules.
-    private var quotaChipData: [QuotaWidgetData] {
+    /// `mergeIntoBuckets` for the bucketing rules.
+    ///
+    /// `static` and pure since #1675: `now` is a required argument, so the
+    /// staleness branch below is decided by an input rather than by the
+    /// machine, and `headerTitleView` passes the one `\.formatNow()` read it
+    /// makes per body evaluation. A call site with nothing to pass is
+    /// `error: missing argument for parameter 'now' in call` — #1659's shape,
+    /// which is what #1663 adopted for `QuotaResetFormat` and what this
+    /// extends.
+    static func quotaChipData(sessions: [SessionState], now: Date) -> [QuotaWidgetData] {
         var byProvider: [String: ChipBucket] = [:]
-        for session in sessionManager.sessions {
-            mergeIntoBuckets(session: session, into: &byProvider)
+        for session in sessions {
+            mergeIntoBuckets(session: session, into: &byProvider, now: now)
         }
         return byProvider
             .map { id, b in b.toWidgetData(id: id) }
             .sorted { $0.id < $1.id }
     }
 
+    /// True when any of `snap`'s windows has already reset at `now` — the
+    /// snapshot describes a window the provider has rolled over without us
+    /// seeing a fresh tick.
+    ///
+    /// The one implementation of the chip's staleness test (#1675). It is a
+    /// **discrete** function of the clock, which is what makes it a sharper
+    /// snapshot hazard than the pace marker: a reference recorded a minute
+    /// before a fixture's `resetsAt` is correct, and permanently wrong a minute
+    /// later. Callers pass the clock they render against; nothing here reads
+    /// one.
+    static func snapshotIsStale(_ snap: RateLimitInfo, now: Date) -> Bool {
+        snap.windows.contains(where: { $0.resetsAt <= now })
+    }
+
     /// Mutable accumulator for one provider bucket while folding
     /// sessions into chips.
-    private struct ChipBucket {
+    struct ChipBucket {
         var snapshot: RateLimitInfo
         var session: SessionState
         var imminent: RateLimitWindowInfo?
@@ -680,8 +723,7 @@ struct SessionListView: View {
                 snapshot: snapshot,
                 session: session,
                 imminent: imminent,
-                totalCostUSD: totalCostUSD,
-                isStale: isStale
+                totalCostUSD: totalCostUSD
             )
         }
     }
@@ -708,10 +750,17 @@ struct SessionListView: View {
     /// label ("cumulative spend across active sessions"). The usage chip
     /// itself renders the daemon's windowed per-provider rollup
     /// (`SessionManager.providerCosts`), not this cumulative figure.
-    private func mergeIntoBuckets(session: SessionState, into buckets: inout [String: ChipBucket]) {
+    ///
+    /// `now` is a required argument since #1675 — it used to be a `Date()` read
+    /// two lines down, which decided `isStale` and therefore the chip's
+    /// opacity. It is also read ONCE for the whole fold now rather than once
+    /// per session, so two sessions in the same evaluation cannot be judged
+    /// stale against two different instants.
+    static func mergeIntoBuckets(session: SessionState,
+                                 into buckets: inout [String: ChipBucket],
+                                 now: Date) {
         guard let snap = session.metrics?.rateLimit else { return }
-        let now = Date()
-        let snapIsStale = snap.windows.contains(where: { $0.resetsAt <= now })
+        let snapIsStale = snapshotIsStale(snap, now: now)
         let key = snap.providerKey(adapter: session.adapter)
             ?? "unknown:\(session.adapter ?? "")"
         let mode = resolveChipMode(snap: snap, providerKey: key)
@@ -763,7 +812,7 @@ struct SessionListView: View {
     /// Resolve which chip variant to render for a snapshot, honouring
     /// the user's per-provider preference (Settings → Providers) and
     /// falling back to auto-detection from snapshot shape.
-    private func resolveChipMode(snap: RateLimitInfo, providerKey: String) -> QuotaMode {
+    static func resolveChipMode(snap: RateLimitInfo, providerKey: String) -> QuotaMode {
         let preference = ProviderModePreference.current(for: providerKey)
         switch preference {
         case .subscription: return .subscription
@@ -780,54 +829,60 @@ struct SessionListView: View {
     ///   - usage        → provider icon + windowed spend, click-to-cycle (mockup 2)
     @ViewBuilder
     private func quotaChipView(_ d: QuotaWidgetData, compact: Bool) -> some View {
-        HStack(spacing: 6) {
-            // Provider icon (Anthropic / OpenAI) when we can infer one;
-            // otherwise fall back to the adapter icon so the chip never
-            // appears iconless. The quota bucket is provider-scoped, so
-            // the provider mark is the more meaningful brand.
-            //
-            // `.resizable().frame(...)` is load-bearing: `NSImage(data:)`
-            // on an SVG decodes inconsistently depending on the path's
-            // complexity — the Anthropic single-path mark lands at the
-            // SVG's declared 14×14 size, but the OpenAI multi-path knot
-            // decoded at viewBox-native 24×24, dominating the chip and
-            // pushing the body out of view. Forcing the SwiftUI frame
-            // normalises both regardless of underlying decode quirks.
-            if let icon = ProviderIconRegistry.image(forKey: d.snapshot.providerKey(adapter: d.session.adapter))
-                ?? d.session.adapterIcon(isDark: colorScheme == .dark) {
-                Image(nsImage: icon)
-                    .resizable()
-                    .renderingMode(.template)
-                    .frame(width: 14, height: 14)
-                    .foregroundColor(.primary)
-            }
-            switch d.mode {
-            case .subscription:
-                if d.snapshot.windows.isEmpty {
-                    // Subscription forced (or auto-detected) but the snapshot
-                    // carries no rate-limit windows. Symmetric with the usage
-                    // zero-state: a short phrase rather than an empty chip.
-                    Text("no subscription data")
-                        .font(.system(size: 9, design: .monospaced))
-                        .foregroundColor(.secondary)
-                        .frame(minWidth: 88, alignment: .leading)
-                } else {
-                    VStack(alignment: .leading, spacing: 1) {
-                        ForEach(d.snapshot.windows, id: \.windowMinutes) { window in
-                            quotaWindowRow(window, compact: compact)
+        // Stale snapshots render at half opacity so the user can tell the data
+        // pre-dates the current window — the values are still visible (better
+        // than an empty header) but visibly muted, and the tooltip names the
+        // staleness explicitly. Since #1675 the dimming lives in
+        // `QuotaStaleDimmed`, which decides it from ITS OWN subtree's
+        // `\.formatNow`: this is the one pixel-visible consequence of the
+        // chip's clock, and a wrapper is what lets a test rasterise it under
+        // two pinned clocks. The modifier order is unchanged — the tooltip
+        // still applies outside the opacity.
+        QuotaStaleDimmed(snapshot: d.snapshot) {
+            HStack(spacing: 6) {
+                // Provider icon (Anthropic / OpenAI) when we can infer one;
+                // otherwise fall back to the adapter icon so the chip never
+                // appears iconless. The quota bucket is provider-scoped, so
+                // the provider mark is the more meaningful brand.
+                //
+                // `.resizable().frame(...)` is load-bearing: `NSImage(data:)`
+                // on an SVG decodes inconsistently depending on the path's
+                // complexity — the Anthropic single-path mark lands at the
+                // SVG's declared 14×14 size, but the OpenAI multi-path knot
+                // decoded at viewBox-native 24×24, dominating the chip and
+                // pushing the body out of view. Forcing the SwiftUI frame
+                // normalises both regardless of underlying decode quirks.
+                if let icon = ProviderIconRegistry.image(forKey: d.snapshot.providerKey(adapter: d.session.adapter))
+                    ?? d.session.adapterIcon(isDark: colorScheme == .dark) {
+                    Image(nsImage: icon)
+                        .resizable()
+                        .renderingMode(.template)
+                        .frame(width: 14, height: 14)
+                        .foregroundColor(.primary)
+                }
+                switch d.mode {
+                case .subscription:
+                    if d.snapshot.windows.isEmpty {
+                        // Subscription forced (or auto-detected) but the snapshot
+                        // carries no rate-limit windows. Symmetric with the usage
+                        // zero-state: a short phrase rather than an empty chip.
+                        Text("no subscription data")
+                            .font(.system(size: 9, design: .monospaced))
+                            .foregroundColor(.secondary)
+                            .frame(minWidth: 88, alignment: .leading)
+                    } else {
+                        VStack(alignment: .leading, spacing: 1) {
+                            ForEach(d.snapshot.windows, id: \.windowMinutes) { window in
+                                QuotaWindowRow(window: window, compact: compact)
+                            }
                         }
                     }
+                case .usage:
+                    quotaUsageBody(d, compact: compact)
                 }
-            case .usage:
-                quotaUsageBody(d, compact: compact)
             }
         }
-        // Stale snapshots render at half opacity so the user can tell
-        // the data pre-dates the current window — the values are still
-        // visible (better than an empty header) but visibly muted, and
-        // the tooltip names the staleness explicitly.
-        .opacity(d.isStale ? 0.5 : 1.0)
-        .tooltip(quotaTooltip(d))
+        .tooltip(quotaTooltip(d, now: formatNow()))
     }
 
     /// Usage-mode chip body — windowed spend on this provider for the
@@ -879,45 +934,19 @@ struct SessionListView: View {
         return String(format: "$%.2f", cost)
     }
 
-    /// One row inside a chip. In compact mode (multiple chips visible)
-    /// the inline reset time is dropped — it lives in the tooltip — and
-    /// the bar shrinks so two or three chips fit in the 380pt header.
-    @ViewBuilder
-    private func quotaWindowRow(_ w: RateLimitWindowInfo, compact: Bool) -> some View {
-        // Compute once per row — SwiftUI re-invokes view bodies on every
-        // SessionManager publish, and calling quotaPacePercent twice
-        // would also let two Date() captures disagree by microseconds.
-        let pace = Self.quotaPacePercent(w)
-        HStack(spacing: 6) {
-            Text(quotaWindowLabel(w.windowMinutes))
-                .font(.system(size: 9, weight: .medium, design: .monospaced))
-                .foregroundColor(.secondary)
-                .frame(width: 14, alignment: .leading)
-
-            quotaBar(percent: w.usedPercent,
-                     color: Self.barColor(used: w.usedPercent, pace: pace),
-                     pacePercent: pace)
-                .frame(width: compact ? 60 : 70, height: 5)
-
-            Text("\(Int(w.usedPercent.rounded()))%")
-                .font(.system(size: 9, weight: .medium, design: .monospaced))
-                .foregroundColor(.primary)
-                .frame(width: 28, alignment: .trailing)
-
-            if !compact {
-                // A view of its own since #1663 — see `QuotaResetLabel`, which
-                // reads the four values this rendering used to take off the
-                // machine (now, calendar, zone, locale) from the environment.
-                QuotaResetLabel(resetsAt: w.resetsAt)
-            }
-        }
-    }
-
     /// "Expected percent used if you've been pacing evenly through the
-    /// window so far." Anchored to current wall-clock time, not the
-    /// snapshot's `sampledAt` — the marker should always reflect where
-    /// the user *should be* right now, independent of when the
-    /// snapshot was last refreshed.
+    /// window so far." Anchored to `now` — the caller's clock, not the
+    /// snapshot's `sampledAt` — so the marker reflects where the user
+    /// *should be* at that instant, independent of when the snapshot was
+    /// last refreshed.
+    ///
+    /// `now` is a required argument since #1675; it was a `Date()` read in the
+    /// body, which made the marker's x position a continuous function of the
+    /// wall clock and therefore unrenderable twice with the same result. The
+    /// two callers that can read an environment (`QuotaWindowRow`, and
+    /// `SessionListView`'s tooltip) pass `\.formatNow()`; `QuotaMenuBarRenderer`
+    /// is rasterised outside SwiftUI and threads the instant
+    /// `MenuBarImageBuilder` read down to here.
     ///
     /// Returns nil when the window can't be paced: zero-duration or
     /// missing `resetsAt`. A `resetsAt` already in the past produces a
@@ -932,48 +961,26 @@ struct SessionListView: View {
     /// `static` + non-private (like `barColor`) so `QuotaMenuBarRenderer`'s
     /// menu-bar icon can share this exact implementation instead of
     /// re-deriving the same math in a second place.
-    static func quotaPacePercent(_ w: RateLimitWindowInfo) -> Double? {
+    static func quotaPacePercent(_ w: RateLimitWindowInfo, now: Date) -> Double? {
         guard w.windowMinutes > 0 else { return nil }
         guard w.resetsAt.timeIntervalSince1970 > 0 else { return nil }
         let windowSeconds = Double(w.windowMinutes) * 60
         let windowStart = w.resetsAt.addingTimeInterval(-windowSeconds)
-        let elapsed = Date().timeIntervalSince(windowStart)
+        let elapsed = now.timeIntervalSince(windowStart)
         let pct = (elapsed / windowSeconds) * 100.0
         return min(100, max(0, pct))
     }
 
-    /// A rounded-rect progress bar with an optional vertical pace
-    /// marker (thin red line at `pacePercent`). The marker reads
-    /// "where you should be if you've been pacing evenly" — fill past
-    /// the marker means burning quota faster than the window's linear
-    /// rate; fill behind it means headroom. ZStack so the fill, track,
-    /// and marker render with the same corner radius without clipping
-    /// artifacts at small sizes.
-    @ViewBuilder
-    private func quotaBar(percent: Double, color: Color, pacePercent: Double?) -> some View {
-        GeometryReader { geo in
-            ZStack(alignment: .leading) {
-                RoundedRectangle(cornerRadius: 2.5)
-                    .fill(Color.secondary.opacity(0.2))
-                RoundedRectangle(cornerRadius: 2.5)
-                    .fill(color)
-                    .frame(width: geo.size.width * min(1.0, max(0.0, percent / 100.0)))
-                if let pace = pacePercent, (0...100).contains(pace) {
-                    Rectangle()
-                        .fill(Color.red)
-                        .frame(width: 1)
-                        .offset(x: geo.size.width * (pace / 100.0) - 0.5)
-                }
-            }
-        }
-    }
-
-    private func quotaTooltip(_ d: QuotaWidgetData) -> String {
+    /// `now` is a required argument here too — every time-dependent line in one
+    /// tooltip is built from the single `\.formatNow()` read `quotaChipView`
+    /// makes, so "resets in 4h 12m", "26pt over pace" and the staleness note
+    /// cannot describe three different instants.
+    private func quotaTooltip(_ d: QuotaWidgetData, now: Date) -> String {
         var lines: [String] = []
         if let plan = d.snapshot.planTypeLabel {
             lines.append(plan)
         }
-        if d.isStale {
+        if Self.snapshotIsStale(d.snapshot, now: now) {
             lines.append("⚠️ snapshot pre-dates current window — waiting for next statusline tick")
         }
         switch d.mode {
@@ -995,10 +1002,10 @@ struct SessionListView: View {
                 // load-bearing signal — so we drop it and put the
                 // verdict inline, no parentheses.
                 let used = Int(w.usedPercent.rounded())
-                let label = quotaWindowLabel(w.windowMinutes)
-                let resets = formatTimeUntil(w.resetsAt)
+                let label = Self.quotaWindowLabel(w.windowMinutes)
+                let resets = QuotaResetFormat.timeUntil(w.resetsAt, now: now)
                 var line = "\(label): \(used)% used · resets in \(resets)"
-                if let pace = Self.quotaPacePercent(w) {
+                if let pace = Self.quotaPacePercent(w, now: now) {
                     let delta = used - Int(pace.rounded())
                     let verdict: String
                     if delta > 0 { verdict = "\(delta)pt over pace" }
@@ -1031,7 +1038,21 @@ struct SessionListView: View {
         return lines.joined(separator: "\n")
     }
 
-    private func quotaWindowLabel(_ minutes: Int) -> String {
+    /// `static` + non-private since #1675 so the extracted `QuotaWindowRow`
+    /// can label its row with the same implementation rather than a second
+    /// copy.
+    ///
+    /// (`HistoryFormat.quotaWindowLabel` is a THIRD spelling of the same idea
+    /// and deliberately not reused, because the two are NOT interchangeable in
+    /// general: it does not tolerate Codex v1's 299/10079 off-by-one and rounds
+    /// with `%` rather than `>=`, so on a raw `windowMinutes` of 299 it answers
+    /// `"299m"` where this answers `"5h"`. Measured before saying so: no
+    /// rendering diverges today, because its one caller
+    /// (`HistoryView.swift:638`) passes `canonicalWindowMinutes`, which maps
+    /// 299 → 300, and filters to exactly 300/10080 first. So this is a note
+    /// about why they are not merged here, not a defect — merging them is a
+    /// behaviour decision, not a clock fix.)
+    static func quotaWindowLabel(_ minutes: Int) -> String {
         // Tolerate Codex v1's 299 / 10079 off-by-one quirk. Codex may report
         // a single weekly window, so label every supplied duration directly.
         switch minutes {
@@ -1138,19 +1159,6 @@ struct SessionListView: View {
     /// to read back.
     private func formatClockTime(_ date: Date) -> String {
         QuotaResetFormat.clock(date, timeZone: formatTimeZone, locale: formatLocale)
-    }
-
-    private func formatTimeUntil(_ date: Date) -> String {
-        let seconds = max(0, Int(date.timeIntervalSinceNow))
-        let h = seconds / 3600
-        let m = (seconds % 3600) / 60
-        if h >= 24 {
-            let d = h / 24
-            let rh = h % 24
-            return rh == 0 ? "\(d)d" : "\(d)d \(rh)h"
-        }
-        if h > 0 { return "\(h)h \(m)m" }
-        return "\(m)m"
     }
 
     private var sessionIconsView: some View {

--- a/platforms/macos/Tests/PinnedNowSnapshot.swift
+++ b/platforms/macos/Tests/PinnedNowSnapshot.swift
@@ -19,12 +19,21 @@ import Foundation
 /// the committed references were recorded under", because adopting a different
 /// value would have re-recorded a PNG — the move `AGENTS.md` names as the one
 /// #1034 and #1044 both got wrong. Nothing constrains this one, because **no
-/// committed reference contains a wall-clock-dependent rendering**: the only
-/// two sites that read one are behind `guard let snap = session.metrics?.rateLimit`
-/// (`SessionListView.swift`) and no fixture under `Tests/Fixtures` or
-/// `Tests/MockInstanceFiles` carries a rate-limit window (#1663 verified that
-/// by grep; re-measured while writing this, still zero matches). So this pin
-/// changed none of the 53 references, and that untouched set is the evidence.
+/// committed reference contains a wall-clock-dependent rendering**: every site
+/// that reads one is behind `guard let snap = session.metrics?.rateLimit`
+/// (`SessionListView.swift`, and since #1675 `QuotaChipParts.swift`) and no
+/// fixture under `Tests/Fixtures` or `Tests/MockInstanceFiles` carries a
+/// rate-limit window (#1663 verified that by grep; re-measured by #1675, still
+/// zero matches). So this pin changed none of the 53 references, and that
+/// untouched set is the evidence.
+///
+/// #1675 asked whether to seed one — a committed PNG of the chip — now that the
+/// clock is an input. The answer was no, for a reason that has nothing to do
+/// with the clock: per #1615 every committed-reference image suite currently
+/// fails on a CI runner over rasterisation and would have to be classified as
+/// skipped in `ImageSnapshotCIScopeTests`, so the fixture is seeded as
+/// two-render-in-memory arms (`QuotaChipClockTests`) that run everywhere
+/// instead.
 ///
 /// The polarity is #1662's: a suite that names no instant gets a FIXED one, not
 /// the machine's, so the first fixture to seed a rate-limit window cannot

--- a/platforms/macos/Tests/QuotaChipClockTests.swift
+++ b/platforms/macos/Tests/QuotaChipClockTests.swift
@@ -1,0 +1,389 @@
+import AppKit
+import SwiftUI
+import XCTest
+@testable import Irrlicht
+
+/// Locks #1675: the quota chip's three remaining wall-clock reads answer from
+/// the clock they are GIVEN, not the one the machine happens to be in.
+///
+/// This is #1663's suite (`PinnedNowSnapshotTests`) one read further on, and it
+/// keeps that file's shape deliberately: every axis drives **two** values
+/// through one view, because asserting a single rendering is green on the host
+/// that agrees with it whether the input reached the view or not.
+///
+/// ## The three reads, and what each one costs
+///
+/// | Read | Moves | Kind |
+/// |---|---|---|
+/// | `quotaPacePercent` — the pace marker's x | pixels | **continuous** |
+/// | `snapshotIsStale` — the chip's opacity | pixels | **discrete** |
+/// | `QuotaResetFormat.timeUntil` — "resets in 4h 12m" | tooltip only | continuous |
+///
+/// The discrete one is the worse hazard and is why this suite exists rather
+/// than a pin being enough: a continuous read makes a reference *wrong*, which
+/// somebody notices, while a discrete one makes a reference *correct until a
+/// wall-clock instant passes* and then permanently wrong — the same shape
+/// #1663 met in `formatResetTime`'s same-day branch, now on an `.opacity`.
+///
+/// ## What is graded where, and why it is split
+///
+/// The pure functions are graded on values, because a value says which branch
+/// ran. The two views (`QuotaWindowRow`, `QuotaStaleDimmed`) are graded in
+/// **pixels**, by rasterising each twice under different pins and refusing an
+/// identical result. That split is not stylistic: #1676 measured that putting
+/// `Date()` back at a call site leaves every value-level assertion green and
+/// reddens only the two-clock byte comparison. A suite of value tests over
+/// `snapshotIsStale` would have graded the arithmetic and missed the defect.
+///
+/// Each pixel arm is paired with a **must-not-differ** arm on a fixture whose
+/// verdict is the same under both clocks. Without those, "the bytes differ" is
+/// satisfied by a view that varies with the clock for any reason at all,
+/// including one unrelated to the property under test.
+///
+/// Everything goes through `PinnedSnapshotHost`, the type the snapshot suites
+/// use, so "the host that pins" and "the host the proof was taken on" cannot be
+/// two objects that disagree. Nothing here calls `as: .pinnedImage`, so there is
+/// no committed reference and `ImageSnapshotCIScopeTests` does not skip this
+/// suite — it is graded on a CI runner (#1615).
+@MainActor
+final class QuotaChipClockTests: XCTestCase {
+
+    // MARK: - Fixtures
+
+    /// The two instants #1663 established, 48 hours apart — a different
+    /// calendar day in every time zone.
+    private var early: Date { PinnedNowSnapshot.referenceNow }
+    private var late: Date { PinnedNowSnapshot.contrastingNow }
+
+    /// A 5h window resetting one hour after `early`, i.e. **between** the two
+    /// clocks: four of its five hours elapsed under one (pace 80%) and long
+    /// rolled over under the other. That single placement carries both flips —
+    /// continuous for the pace marker, discrete for the staleness — and every
+    /// premise assertion below re-derives it rather than trusting this comment.
+    private var flipping: RateLimitInfo {
+        info(resetsAt: early.addingTimeInterval(3_600), usedPercent: 42)
+    }
+
+    /// A window already rolled over at `early`, so it is stale under BOTH
+    /// clocks — the must-not-differ fixture for the dimming arm.
+    private var alreadyStale: RateLimitInfo {
+        info(resetsAt: early.addingTimeInterval(-3_600), usedPercent: 42)
+    }
+
+    /// A window with the "no expiry data" sentinel, so `quotaPacePercent`
+    /// returns nil under every clock — the must-not-differ fixture for the row
+    /// arm.
+    private var unpaceable: RateLimitInfo {
+        info(resetsAt: Date(timeIntervalSince1970: 0), usedPercent: 42)
+    }
+
+    private func info(resetsAt: Date, usedPercent: Double, windowMinutes: Int = 300) -> RateLimitInfo {
+        RateLimitInfo(
+            windows: [RateLimitWindowInfo(usedPercent: usedPercent,
+                                          windowMinutes: windowMinutes,
+                                          resetsAt: resetsAt)],
+            planType: "max",
+            sampledAt: early
+        )
+    }
+
+    private func session(id: String, adapter: String = "claude-code", rateLimit: RateLimitInfo) -> SessionState {
+        SessionState(
+            id: "sess_\(id)",
+            state: .working,
+            model: "claude-sonnet",
+            cwd: "/tmp",  // NOSONAR (swift:S1075) — test fixture value, not a real endpoint
+            firstSeen: early,
+            updatedAt: early,
+            metrics: SessionMetrics(
+                elapsedSeconds: 0,
+                totalTokens: 0,
+                modelName: "claude-sonnet",
+                contextWindow: nil,
+                contextUtilization: 0,
+                pressureLevel: "safe",
+                contextWindowUnknown: nil,
+                estimatedCostUSD: nil,
+                lastAssistantText: nil,
+                tasks: nil,
+                rateLimit: rateLimit
+            ),
+            adapter: adapter
+        )
+    }
+
+    // MARK: - Read 1: the pace marker is placed by the `now` it is given
+
+    /// One window, two clocks, two positions. Neither arm can be green on a
+    /// host reading `Date()`, because today is neither of these instants.
+    func testPacePercentIsPlacedByTheNowItIsGiven() {
+        let window = flipping.windows[0]
+        // The window opened 4h before `early` and closes 1h after it, so 4 of
+        // its 5 hours have elapsed: 80%. `late` is 48h further on, far past the
+        // reset, so the marker clamps to the bar's right edge.
+        XCTAssertEqual(SessionListView.quotaPacePercent(window, now: early), 80)
+        XCTAssertEqual(SessionListView.quotaPacePercent(window, now: late), 100)
+    }
+
+    /// The two nil branches keep answering nil whatever the clock says — a
+    /// window that cannot be paced must not acquire a marker from the clock.
+    func testPacePercentStaysUnpaceableUnderEveryClock() {
+        for now in [early, late] {
+            XCTAssertNil(SessionListView.quotaPacePercent(unpaceable.windows[0], now: now),
+                         "the resetsAt sentinel became paceable at \(now)")
+            let zeroLength = RateLimitWindowInfo(usedPercent: 42, windowMinutes: 0, resetsAt: late)
+            XCTAssertNil(SessionListView.quotaPacePercent(zeroLength, now: now),
+                         "a zero-length window became paceable at \(now)")
+        }
+    }
+
+    // MARK: - Read 2: the staleness flip is decided by the `now` it is given
+
+    /// The discrete flip, in both directions from one fixture — which is what
+    /// separates this from a value that merely shifts. An implementation that
+    /// hard-coded either verdict passes one of these and fails the other.
+    func testStalenessFlipsWithTheNowItIsGiven() {
+        XCTAssertFalse(SessionListView.snapshotIsStale(flipping, now: early),
+                       "a window resetting an hour from now is not stale yet")
+        XCTAssertTrue(SessionListView.snapshotIsStale(flipping, now: late),
+                      "a window that reset 47h ago is stale")
+    }
+
+    /// The boundary is inclusive (`resetsAt <= now`), which is the daemon-side
+    /// rule this mirrors. Pinned because `<` and `<=` are indistinguishable on
+    /// every fixture that is not exactly on the instant.
+    func testStalenessIsInclusiveAtTheResetInstant() {
+        let boundary = info(resetsAt: early, usedPercent: 42)
+        XCTAssertTrue(SessionListView.snapshotIsStale(boundary, now: early),
+                      "a window resetting exactly now is stale")
+        XCTAssertFalse(SessionListView.snapshotIsStale(boundary, now: early.addingTimeInterval(-1)),
+                       "a window resetting one second from now is not")
+    }
+
+    /// …and the flip survives the fold: the same two clocks through the whole
+    /// `sessions → chips` derivation, which is the call `SessionListView.body`
+    /// makes.
+    func testQuotaChipDataDrivesItsStalenessFromTheNowItIsGiven() {
+        let sessions = [session(id: "1", rateLimit: flipping)]
+        for (now, wantStale) in [(early, false), (late, true)] {
+            let chips = SessionListView.quotaChipData(sessions: sessions, now: now)
+            guard let chip = chips.first else {
+                return XCTFail("the derivation produced no chip at \(now) — this check cannot have run")
+            }
+            XCTAssertEqual(SessionListView.snapshotIsStale(chip.snapshot, now: now), wantStale,
+                           "the chip derived at \(now) reports the wrong staleness")
+        }
+    }
+
+    /// The lock that makes dropping `QuotaWidgetData.isStale` safe rather than
+    /// assumed: for **every** path through `mergeIntoBuckets`, the verdict the
+    /// merge computed and kept equals the verdict re-derived from the snapshot
+    /// it kept. If that ever stops holding, `QuotaStaleDimmed` and the
+    /// tooltip's staleness note are reporting something the merge disagrees
+    /// with.
+    ///
+    /// A lock over behaviour that predates #1675 — it passes by construction
+    /// against the current merge — so its evidence is a mutation of the merge,
+    /// not a red run before the fix (see the PR body's M5).
+    func testTheMergeNeverKeepsASnapshotWhoseStalenessDisagreesWithIt() {
+        let fresh = flipping
+        let stale = alreadyStale
+        // Each row is one bucket-collision shape the merge branches on.
+        let cases: [(name: String, sessions: [SessionState])] = [
+            ("single fresh", [session(id: "1", rateLimit: fresh)]),
+            ("single stale", [session(id: "1", rateLimit: stale)]),
+            ("stale first, then fresh", [session(id: "1", rateLimit: stale), session(id: "2", rateLimit: fresh)]),
+            ("fresh first, then stale", [session(id: "1", rateLimit: fresh), session(id: "2", rateLimit: stale)]),
+            ("two stale, second sampled later", [
+                session(id: "1", rateLimit: stale),
+                session(id: "2", rateLimit: RateLimitInfo(windows: stale.windows, planType: "max",
+                                                          sampledAt: early.addingTimeInterval(60))),
+            ]),
+        ]
+        var bucketsSeen = 0
+        for row in cases {
+            for now in [early, late] {
+                var buckets: [String: SessionListView.ChipBucket] = [:]
+                for s in row.sessions {
+                    SessionListView.mergeIntoBuckets(session: s, into: &buckets, now: now)
+                }
+                XCTAssertFalse(buckets.isEmpty, "\(row.name) at \(now): the fold produced no bucket")
+                for (key, bucket) in buckets {
+                    bucketsSeen += 1
+                    XCTAssertEqual(
+                        bucket.isStale,
+                        SessionListView.snapshotIsStale(bucket.snapshot, now: now),
+                        "\(row.name) at \(now), bucket \(key): the merge kept a staleness verdict "
+                        + "that disagrees with the snapshot it kept — the chip's dimming and the "
+                        + "merge's own bucketing are now two facts that can differ")
+                }
+            }
+        }
+        XCTAssertEqual(bucketsSeen, cases.count * 2,
+                       "the sweep did not reach one bucket per case per clock — it checked less "
+                       + "than it reports")
+    }
+
+    /// The merge prefers a fresh snapshot over a stale one regardless of
+    /// `sampledAt`, which is the rule the stored verdict exists for. Untestable
+    /// before #1675 made the fold pure — `mergeIntoBuckets` read the clock and
+    /// was a private method on a view — so this is new coverage of old
+    /// behaviour, and a lock rather than a defect test.
+    func testTheMergePrefersAFreshSnapshotOverAStaleOneEvenWhenTheStaleOneIsNewer() {
+        // The stale snapshot is sampled LATER, so a sampledAt-only rule picks it.
+        let newerButStale = RateLimitInfo(windows: alreadyStale.windows, planType: "max",
+                                          sampledAt: early.addingTimeInterval(600))
+        var buckets: [String: SessionListView.ChipBucket] = [:]
+        for s in [session(id: "1", rateLimit: newerButStale), session(id: "2", rateLimit: flipping)] {
+            SessionListView.mergeIntoBuckets(session: s, into: &buckets, now: early)
+        }
+        guard let bucket = buckets.values.first else {
+            return XCTFail("the fold produced no bucket — this check cannot have run")
+        }
+        XCTAssertFalse(bucket.isStale,
+                       "the fold kept the newer-but-stale snapshot over the fresh one")
+        XCTAssertEqual(bucket.snapshot.sampledAt, flipping.sampledAt,
+                       "the fold reports fresh but kept the stale snapshot's data")
+    }
+
+    // MARK: - Read 3: "resets in …" counts from the `now` it is given
+
+    func testTimeUntilCountsFromTheNowItIsGiven() {
+        let reset = early.addingTimeInterval(24 * 3_600 + 12 * 60)
+        // The day branch drops minutes, so 24h12m reads "1d" — pre-existing
+        // behaviour, pinned here because nothing pinned it before.
+        XCTAssertEqual(QuotaResetFormat.timeUntil(reset, now: early), "1d")
+        XCTAssertEqual(QuotaResetFormat.timeUntil(reset, now: early.addingTimeInterval(20 * 3_600)), "4h 12m")
+        XCTAssertEqual(QuotaResetFormat.timeUntil(reset, now: early.addingTimeInterval(24 * 3_600)), "12m")
+    }
+
+    /// A reset already past reads `"0m"` rather than a negative duration —
+    /// which is exactly the state `snapshotIsStale` is simultaneously reporting.
+    func testTimeUntilNeverCountsBackwards() {
+        XCTAssertEqual(QuotaResetFormat.timeUntil(early, now: late), "0m")
+    }
+
+    /// The day/hour spelling drops the hour component when it is zero, which is
+    /// the one branch a "4h 12m"-shaped fixture never reaches.
+    func testTimeUntilDropsAZeroHourComponent() {
+        XCTAssertEqual(QuotaResetFormat.timeUntil(early.addingTimeInterval(3 * 86_400), now: early), "3d")
+        XCTAssertEqual(QuotaResetFormat.timeUntil(early.addingTimeInterval(3 * 86_400 + 7 * 3_600), now: early), "3d 7h")
+    }
+
+    // MARK: - The pins reach the pixels
+
+    /// The real `QuotaWindowRow` — the view `SessionListView.quotaChipView`
+    /// renders — hosted through the type the snapshot suites use.
+    private func rasterizedRow(_ snapshot: RateLimitInfo, now: Date, compact: Bool = false) -> Data {
+        rasterize(QuotaWindowRow(window: snapshot.windows[0], compact: compact), now: now,
+                  width: 220, height: 24, what: "the quota window row")
+    }
+
+    /// The real `QuotaStaleDimmed`, over content whose own rendering carries no
+    /// clock — so the only thing that can move these bytes is the opacity.
+    private func rasterizedDimmedChip(_ snapshot: RateLimitInfo, now: Date) -> Data {
+        rasterize(QuotaStaleDimmed(snapshot: snapshot) {
+            Color.white.frame(width: 60, height: 20)
+        }, now: now, width: 60, height: 20, what: "the stale-dimmed chip")
+    }
+
+    private func rasterize(_ content: some View, now: Date,
+                           width: CGFloat, height: CGFloat, what: String) -> Data {
+        let host = PinnedSnapshotHost(content.frame(width: width, height: height),
+                                      width: width, height: height,
+                                      now: now)
+        let image = PinnedScaleSnapshot.rasterize(host.view, scale: PinnedScaleSnapshot.referenceScale)
+        // "could not rasterise" and "rasterised to the same thing" must never
+        // produce the same verdict.
+        guard let data = image.tiffRepresentation, !data.isEmpty else {
+            XCTFail("\(what) rasterised to nothing — this check cannot have run")
+            return Data()
+        }
+        return data
+    }
+
+    /// The load-bearing arm for read 1, and the one that catches the mutation
+    /// this change exists to make catchable: put `Date()` back inside
+    /// `QuotaWindowRow` and both renders become today's, identically. Every
+    /// value assertion above stays green under that mutation.
+    ///
+    /// Rendered in **compact** mode deliberately: that drops the reset label,
+    /// whose own clock read #1663 already covers, so the pace marker's x is the
+    /// only clock-dependent pixel left in the row and this arm reddens for
+    /// read 1 alone. The must-not-differ arm below is the same view in the same
+    /// mode with the marker removed, so the two differ in exactly one thing.
+    func testTheSameRowRendersDifferentlyUnderTwoPinnedNows() {
+        // The premise, loudly first: the pace must actually differ for this
+        // fixture, or the byte comparison measures nothing.
+        XCTAssertNotEqual(SessionListView.quotaPacePercent(flipping.windows[0], now: early),
+                          SessionListView.quotaPacePercent(flipping.windows[0], now: late),
+                          "the fixture paces identically under both pinned clocks — the pixel "
+                          + "comparison below cannot fail for the right reason")
+        // …and rendering is deterministic, or "they differ" proves nothing.
+        XCTAssertEqual(rasterizedRow(flipping, now: early, compact: true),
+                       rasterizedRow(flipping, now: early, compact: true),
+                       "the same row rasterised twice under one clock differs — this suite's "
+                       + "both-sides arms are not measuring the clock")
+
+        XCTAssertNotEqual(rasterizedRow(flipping, now: early, compact: true),
+                          rasterizedRow(flipping, now: late, compact: true),
+                          "the quota window row's pace marker sits at the same x under two pinned "
+                          + "clocks — `\\.formatNow` is reaching nothing and the marker's "
+                          + "position is coming from the machine's wall clock")
+    }
+
+    /// …and the must-not-differ half: a window the clock cannot pace, in
+    /// compact mode so the reset label (which #1663 already covers) is dropped
+    /// and the marker is the only clock-dependent pixel left. Two clocks, one
+    /// rendering. Without this, the arm above is satisfied by a row that varies
+    /// with the clock for any reason at all.
+    func testARowTheClockCannotPaceRendersIdenticallyUnderBothClocks() {
+        XCTAssertNil(SessionListView.quotaPacePercent(unpaceable.windows[0], now: early),
+                     "the premise of this arm is that this fixture has no pace marker")
+        XCTAssertEqual(rasterizedRow(unpaceable, now: early, compact: true),
+                       rasterizedRow(unpaceable, now: late, compact: true),
+                       "a row with no pace marker and no reset label still rendered differently "
+                       + "under two clocks — something else in this row reads the wall clock")
+    }
+
+    /// The load-bearing arm for read 2 — the discrete one. The content is a
+    /// plain white rectangle, so the only thing that can move a byte is the
+    /// `.opacity` the staleness verdict picks.
+    func testTheSameChipDimsUnderOneClockAndNotTheOther() {
+        XCTAssertNotEqual(SessionListView.snapshotIsStale(flipping, now: early),
+                          SessionListView.snapshotIsStale(flipping, now: late),
+                          "the fixture's staleness does not flip between the pinned clocks — the "
+                          + "pixel comparison below cannot fail for the right reason")
+        XCTAssertEqual(rasterizedDimmedChip(flipping, now: early),
+                       rasterizedDimmedChip(flipping, now: early),
+                       "the same chip rasterised twice under one clock differs")
+
+        XCTAssertNotEqual(rasterizedDimmedChip(flipping, now: early),
+                          rasterizedDimmedChip(flipping, now: late),
+                          "the chip rendered at the same opacity under a clock before and a clock "
+                          + "after its window reset — `\\.formatNow` is reaching nothing and the "
+                          + "stale dimming is coming from the machine's wall clock")
+    }
+
+    /// …and the must-not-differ half: a snapshot stale under BOTH clocks
+    /// renders identically. This is what makes the arm above a measurement of
+    /// the *flip* rather than of the clock leaking into the render some other
+    /// way.
+    func testAChipStaleUnderBothClocksRendersIdentically() {
+        XCTAssertTrue(SessionListView.snapshotIsStale(alreadyStale, now: early)
+                      && SessionListView.snapshotIsStale(alreadyStale, now: late),
+                      "the premise of this arm is that this fixture is stale under both clocks")
+        XCTAssertEqual(rasterizedDimmedChip(alreadyStale, now: early),
+                       rasterizedDimmedChip(alreadyStale, now: late),
+                       "a chip whose staleness verdict is identical under both clocks rendered "
+                       + "differently — the dimming is varying with something other than the "
+                       + "verdict")
+    }
+
+    /// The dimming really is the 50% the chip's doc comment claims, asserted
+    /// against the production constant rather than a copy of it — so an arm
+    /// above cannot be passing on a difference nobody can see.
+    func testTheStaleOpacityIsHalf() {
+        XCTAssertEqual(QuotaStaleDimmed<EmptyView>.staleOpacity, 0.5)
+    }
+}

--- a/platforms/macos/Tests/QuotaMenuBarRendererTests.swift
+++ b/platforms/macos/Tests/QuotaMenuBarRendererTests.swift
@@ -6,19 +6,49 @@ import XCTest
 /// pace-aware color ramp (must mirror SessionListView.barColor exactly —
 /// see QuotaChipBarColorTests for the popover-side pin of the same table),
 /// and the freshest-renderable snapshot selection across live sessions.
+///
+/// ## What #1675 changed here, and why it matters more in this suite than most
+///
+/// Every fixture below used to be built from `Date()` and every renderer entry
+/// point read `Date()` again a moment later, so the pace this suite *asked for*
+/// and the pace the renderer *computed* were two reads of the machine that
+/// merely agreed to within a millisecond. Two consequences, both now gone:
+/// the suite could not pin an exact ramp boundary (its own comment on
+/// `testBuildSVGColorThresholdsMirrorPopoverPaceRamp` recorded that as a
+/// standing limitation), and nothing in it could tell a renderer that honoured
+/// the instant it was given from one that ignored the argument and read the
+/// clock — the two answer identically whenever the argument IS the clock.
+///
+/// `now` is now a fixed instant and a required argument, so the fixtures are
+/// absolute, the boundary rows are exact, and
+/// `testTheBarsHonourTheNowTheyAreGiven` / `…TheCircle…` drive two clocks
+/// through one snapshot and refuse an unmoved marker. Unlike most of this
+/// family, this suite takes no image snapshot, so `ImageSnapshotCIScopeTests`
+/// does not skip it and all of the above is graded on a CI runner.
 @MainActor
 final class QuotaMenuBarRendererTests: XCTestCase {
+
+    /// The instant every fixture in this suite is built relative to, and the
+    /// one every renderer call is given. `PinnedNowSnapshot.referenceNow`
+    /// rather than a local constant so this suite and the popover-side
+    /// `QuotaChipClockTests` place a window at the same place on the timeline.
+    private let now = PinnedNowSnapshot.referenceNow
+
+    /// A different day in every time zone (`referenceNow + 48h`), so an arm
+    /// that drives two clocks cannot be made tautological by moving them
+    /// closer together.
+    private let laterNow = PinnedNowSnapshot.contrastingNow
 
     // MARK: - buildSVG (bars)
 
     func testBuildSVGReturnsNilWhenNoWindows() {
-        let info = RateLimitInfo(windows: [], sampledAt: Date())
-        XCTAssertNil(QuotaMenuBarRenderer.buildSVG(for: info))
+        let info = RateLimitInfo(windows: [], sampledAt: now)
+        XCTAssertNil(QuotaMenuBarRenderer.buildSVG(for: info, now: now))
     }
 
     func testBuildSVGIncludesBothRowsWhenBothWindowsPresent() {
         let info = makeInfo(fiveHour: 20, sevenDay: 40)
-        let result = QuotaMenuBarRenderer.buildSVG(for: info)
+        let result = QuotaMenuBarRenderer.buildSVG(for: info, now: now)
         XCTAssertNotNil(result)
         XCTAssertTrue(result!.svg.contains(">5h<"))
         XCTAssertTrue(result!.svg.contains(">7d<"))
@@ -26,10 +56,10 @@ final class QuotaMenuBarRendererTests: XCTestCase {
 
     func testBuildSVGOmitsMissingWindowRow() {
         let info = RateLimitInfo(
-            windows: [RateLimitWindowInfo(usedPercent: 40, windowMinutes: 10080, resetsAt: Date().addingTimeInterval(3600))],
-            sampledAt: Date()
+            windows: [RateLimitWindowInfo(usedPercent: 40, windowMinutes: 10080, resetsAt: now.addingTimeInterval(3600))],
+            sampledAt: now
         )
-        let result = QuotaMenuBarRenderer.buildSVG(for: info)
+        let result = QuotaMenuBarRenderer.buildSVG(for: info, now: now)
         XCTAssertNotNil(result)
         XCTAssertFalse(result!.svg.contains(">5h<"))
         XCTAssertTrue(result!.svg.contains(">7d<"))
@@ -39,7 +69,7 @@ final class QuotaMenuBarRendererTests: XCTestCase {
 
     func testBuildSVGCompactOmitsWindowLabels() {
         let info = makeInfo(fiveHour: 20, sevenDay: 40)
-        let result = QuotaMenuBarRenderer.buildSVG(for: info, compact: true)
+        let result = QuotaMenuBarRenderer.buildSVG(for: info, compact: true, now: now)
         XCTAssertNotNil(result)
         XCTAssertFalse(result!.svg.contains(">5h<"))
         XCTAssertFalse(result!.svg.contains(">7d<"))
@@ -47,8 +77,8 @@ final class QuotaMenuBarRendererTests: XCTestCase {
 
     func testBuildSVGCompactIsNarrowerThanDefault() {
         let info = makeInfo(fiveHour: 20, sevenDay: 40)
-        let normal = QuotaMenuBarRenderer.buildSVG(for: info, compact: false)
-        let compact = QuotaMenuBarRenderer.buildSVG(for: info, compact: true)
+        let normal = QuotaMenuBarRenderer.buildSVG(for: info, compact: false, now: now)
+        let compact = QuotaMenuBarRenderer.buildSVG(for: info, compact: true, now: now)
         XCTAssertNotNil(normal)
         XCTAssertNotNil(compact)
         XCTAssertLessThan(compact!.width, normal!.width)
@@ -61,8 +91,8 @@ final class QuotaMenuBarRendererTests: XCTestCase {
 
     func testBuildSVGCompactDefaultsToFalseWhenOmitted() {
         let info = makeInfo(fiveHour: 20, sevenDay: 40)
-        let omitted = QuotaMenuBarRenderer.buildSVG(for: info)
-        let explicitFalse = QuotaMenuBarRenderer.buildSVG(for: info, compact: false)
+        let omitted = QuotaMenuBarRenderer.buildSVG(for: info, now: now)
+        let explicitFalse = QuotaMenuBarRenderer.buildSVG(for: info, compact: false, now: now)
         XCTAssertEqual(omitted?.width, explicitFalse?.width)
         XCTAssertTrue(omitted!.svg.contains(">5h<"))
     }
@@ -70,19 +100,25 @@ final class QuotaMenuBarRendererTests: XCTestCase {
     /// Same ramp QuotaChipBarColorTests pins for SessionListView.barColor
     /// — this renderer must reach the identical verdict (as a bare hex
     /// instead of a SwiftUI Color) so the same window can't read green in
-    /// the icon while the popover shows it orange. Cases stay off the exact
-    /// threshold boundary on purpose: `windowWithPace` derives `pace` from
-    /// `Date()` at construction time and `buildSVG` re-evaluates it a moment
-    /// later, so an exact-boundary delta (e.g. precisely 5 or 15) can tip
-    /// either way on sub-millisecond wall-clock drift. Exact-boundary
-    /// pinning already lives in QuotaChipBarColorTests, which calls
-    /// `barColor(used:pace:)` directly with fixed Doubles and has none of
-    /// that drift.
+    /// the icon while the popover shows it orange.
+    ///
+    /// The **exact** boundary rows (delta precisely 5 and precisely 15) are
+    /// #1675's. Before it, `windowWithPace` derived `resetsAt` from one
+    /// `Date()` and `buildSVG` re-derived the pace from another a moment
+    /// later, so a delta sitting exactly on a threshold could tip either way
+    /// on sub-millisecond drift and this suite had to stay off the boundary
+    /// on purpose. With `now` an input on both sides the arithmetic is exact:
+    /// `windowWithPace(pace: 30)` places `resetsAt` so that
+    /// `quotaPacePercent(…, now: now)` returns 30.0 and nothing else.
     func testBuildSVGColorThresholdsMirrorPopoverPaceRamp() {
         let cases: [(name: String, used: Double, pace: Double, wantHex: String)] = [
             ("on pace",                30, 30, "34C759"),
             ("clearly still green",    33, 30, "34C759"),
+            ("exactly on the yellow boundary (delta 5)",  35, 30, "FFCC00"),
+            ("one point below it (delta 4.9)",          34.9, 30, "34C759"),
             ("clearly yellow",         36, 30, "FFCC00"),
+            ("exactly on the orange boundary (delta 15)", 45, 30, "FF9500"),
+            ("one point below it (delta 14.9)",         44.9, 30, "FFCC00"),
             ("clearly orange",         46, 30, "FF9500"),
             ("far ahead",              70, 30, "FF9500"),
             ("behind pace",            20, 40, "34C759"),
@@ -90,8 +126,8 @@ final class QuotaMenuBarRendererTests: XCTestCase {
         ]
         for c in cases {
             let window = windowWithPace(usedPercent: c.used, pace: c.pace)
-            let info = RateLimitInfo(windows: [window], sampledAt: Date())
-            let result = QuotaMenuBarRenderer.buildSVG(for: info)
+            let info = RateLimitInfo(windows: [window], sampledAt: now)
+            let result = QuotaMenuBarRenderer.buildSVG(for: info, now: now)
             XCTAssertTrue(
                 result?.svg.contains("#\(c.wantHex)") ?? false,
                 "\(c.name): expected #\(c.wantHex) in \(result?.svg ?? "nil")"
@@ -110,9 +146,9 @@ final class QuotaMenuBarRendererTests: XCTestCase {
         for c in cases {
             let info = RateLimitInfo(
                 windows: [RateLimitWindowInfo(usedPercent: c.used, windowMinutes: 300, resetsAt: Date(timeIntervalSince1970: 0))],
-                sampledAt: Date()
+                sampledAt: now
             )
-            let result = QuotaMenuBarRenderer.buildSVG(for: info)
+            let result = QuotaMenuBarRenderer.buildSVG(for: info, now: now)
             XCTAssertTrue(
                 result?.svg.contains("#\(c.wantHex)") ?? false,
                 "\(c.name): expected #\(c.wantHex) in \(result?.svg ?? "nil")"
@@ -123,8 +159,8 @@ final class QuotaMenuBarRendererTests: XCTestCase {
     // MARK: - buildCircleSVG
 
     func testBuildCircleSVGReturnsNilWhenNoWindows() {
-        let info = RateLimitInfo(windows: [], sampledAt: Date())
-        XCTAssertNil(QuotaMenuBarRenderer.buildCircleSVG(for: info))
+        let info = RateLimitInfo(windows: [], sampledAt: now)
+        XCTAssertNil(QuotaMenuBarRenderer.buildCircleSVG(for: info, now: now))
     }
 
     /// Regression pin: the circle must stay pinned to the 5h window even
@@ -137,7 +173,7 @@ final class QuotaMenuBarRendererTests: XCTestCase {
     /// would be orange.
     func testBuildCircleSVGPrefersFiveHourOverSevenDayEvenWhenLessDepleted() {
         let info = makeInfo(fiveHour: 20, sevenDay: 80, fiveHourResetsIn: 3600)
-        let result = QuotaMenuBarRenderer.buildCircleSVG(for: info)
+        let result = QuotaMenuBarRenderer.buildCircleSVG(for: info, now: now)
         XCTAssertNotNil(result)
         XCTAssertTrue(result!.svg.contains("#34C759"), "should use the 5h window's green (behind pace)")
         XCTAssertFalse(result!.svg.contains("#FF9500"), "must not leak the 7d window's orange (ahead of pace)")
@@ -148,8 +184,8 @@ final class QuotaMenuBarRendererTests: XCTestCase {
         // pace → orange, isolating "did it use the 7d window at all" from
         // the color-ramp tests above.
         let window = windowWithPace(usedPercent: 60, pace: 0, windowMinutes: 10080)
-        let info = RateLimitInfo(windows: [window], sampledAt: Date())
-        let result = QuotaMenuBarRenderer.buildCircleSVG(for: info)
+        let info = RateLimitInfo(windows: [window], sampledAt: now)
+        let result = QuotaMenuBarRenderer.buildCircleSVG(for: info, now: now)
         XCTAssertNotNil(result)
         XCTAssertTrue(result!.svg.contains("#FF9500"))
     }
@@ -158,32 +194,138 @@ final class QuotaMenuBarRendererTests: XCTestCase {
 
     func testPaceMarkerRenderedOnBarsWhenWindowHasFutureReset() {
         let info = makeInfo(fiveHour: 20, sevenDay: nil, fiveHourResetsIn: 3600)
-        let result = QuotaMenuBarRenderer.buildSVG(for: info)
+        let result = QuotaMenuBarRenderer.buildSVG(for: info, now: now)
         XCTAssertTrue(result!.svg.contains("fill=\"red\""))
     }
 
     func testPaceMarkerAbsentOnBarsWhenResetIsUnset() {
         let info = RateLimitInfo(
             windows: [RateLimitWindowInfo(usedPercent: 20, windowMinutes: 300, resetsAt: Date(timeIntervalSince1970: 0))],
-            sampledAt: Date()
+            sampledAt: now
         )
-        let result = QuotaMenuBarRenderer.buildSVG(for: info)
+        let result = QuotaMenuBarRenderer.buildSVG(for: info, now: now)
         XCTAssertFalse(result!.svg.contains("fill=\"red\""))
     }
 
     func testPaceMarkerStillRendersClampedWhenWindowAlreadyExpired() {
         let info = RateLimitInfo(
-            windows: [RateLimitWindowInfo(usedPercent: 20, windowMinutes: 300, resetsAt: Date().addingTimeInterval(-60))],
-            sampledAt: Date()
+            windows: [RateLimitWindowInfo(usedPercent: 20, windowMinutes: 300, resetsAt: now.addingTimeInterval(-60))],
+            sampledAt: now
         )
-        let result = QuotaMenuBarRenderer.buildSVG(for: info)
+        let result = QuotaMenuBarRenderer.buildSVG(for: info, now: now)
         XCTAssertTrue(result!.svg.contains("fill=\"red\""))
     }
 
     func testPaceMarkerRenderedOnCircleAsRedStroke() {
         let info = makeInfo(fiveHour: 20, sevenDay: nil, fiveHourResetsIn: 3600)
-        let result = QuotaMenuBarRenderer.buildCircleSVG(for: info)
+        let result = QuotaMenuBarRenderer.buildCircleSVG(for: info, now: now)
         XCTAssertTrue(result!.svg.contains("stroke=\"red\""))
+    }
+
+    // MARK: - …and the marker is placed by the `now` the renderer is GIVEN (#1675)
+
+    /// The load-bearing arm of #1675 on this side: one snapshot, two clocks,
+    /// and the pace marker must move. A renderer that ignores its `now:`
+    /// argument and reads `Date()` — which is exactly what every line here did
+    /// before #1675 — answers the same x twice and fails only here.
+    ///
+    /// The 7d window is present so the assertion covers both `rowSVG` calls:
+    /// each used to read the clock for itself, so one icon could pace its two
+    /// rows against two different instants.
+    func testTheBarsHonourTheNowTheyAreGiven() {
+        let info = makeInfo(fiveHour: 20, sevenDay: 40)
+
+        // The premise, loudly first: 48 hours must actually change the pace for
+        // this fixture, or the comparison below measures nothing.
+        let paceAtNow = SessionListView.quotaPacePercent(info.windows[0], now: now)
+        let paceLater = SessionListView.quotaPacePercent(info.windows[0], now: laterNow)
+        XCTAssertNotEqual(paceAtNow, paceLater,
+                          "the fixture's pace is the same under both clocks — this arm cannot "
+                          + "fail for the right reason")
+
+        guard let early = QuotaMenuBarRenderer.buildSVG(for: info, now: now),
+              let late = QuotaMenuBarRenderer.buildSVG(for: info, now: laterNow) else {
+            return XCTFail("the bars did not render at all — this check cannot have run")
+        }
+        // "no marker" and "an unmoved marker" must not produce the same verdict.
+        let earlyMarkers = Self.markerXs(in: early.svg, of: .barRect)
+        let lateMarkers = Self.markerXs(in: late.svg, of: .barRect)
+        XCTAssertEqual(earlyMarkers.count, 2,
+                       "expected one pace marker per row in \(early.svg)")
+        XCTAssertEqual(lateMarkers.count, 2,
+                       "expected one pace marker per row in \(late.svg)")
+        XCTAssertNotEqual(earlyMarkers, lateMarkers,
+                          "the pace markers sit at the same x under two clocks 48h apart — "
+                          + "`now:` is reaching nothing and the position is coming from the "
+                          + "machine's wall clock")
+    }
+
+    /// …and the ring's marker, which is placed by different arithmetic
+    /// (`buildCircleSVG` converts the pace to an angle) and so is not covered
+    /// by the arm above.
+    func testTheCircleHonoursTheNowItIsGiven() {
+        let info = makeInfo(fiveHour: 20, sevenDay: nil, fiveHourResetsIn: 3600)
+        XCTAssertNotEqual(SessionListView.quotaPacePercent(info.windows[0], now: now),
+                          SessionListView.quotaPacePercent(info.windows[0], now: laterNow),
+                          "the fixture's pace is the same under both clocks")
+
+        guard let early = QuotaMenuBarRenderer.buildCircleSVG(for: info, now: now),
+              let late = QuotaMenuBarRenderer.buildCircleSVG(for: info, now: laterNow) else {
+            return XCTFail("the ring did not render at all — this check cannot have run")
+        }
+        let earlyLine = Self.markerXs(in: early.svg, of: .ringTick)
+        let lateLine = Self.markerXs(in: late.svg, of: .ringTick)
+        XCTAssertEqual(earlyLine.count, 1, "expected one pace line in \(early.svg)")
+        XCTAssertEqual(lateLine.count, 1, "expected one pace line in \(late.svg)")
+        XCTAssertNotEqual(earlyLine, lateLine,
+                          "the ring's pace line sits at the same x under two clocks 48h apart — "
+                          + "`now:` is reaching nothing")
+    }
+
+    /// The two shapes the pace marker is drawn as, each naming the element it
+    /// is and the coordinate that positions it.
+    ///
+    /// An enum rather than two loose `String` parameters so the wrong pairing
+    /// (`x` with the ring's `stroke="red"`, which matches nothing and would
+    /// report "no marker") is not expressible — and so a reader sees which
+    /// element each arm is looking for.
+    private enum PaceMarkerShape {
+        /// `<rect … fill="red"/>`, one per bar row.
+        case barRect
+        /// `<line … stroke="red"/>`, the ring's radial tick.
+        case ringTick
+
+        /// The attribute carrying the marker's horizontal position.
+        var positionAttribute: String {
+            switch self {
+            case .barRect: return "x"
+            case .ringTick: return "x1"
+            }
+        }
+
+        /// A fragment appearing only in this element.
+        var signature: String {
+            switch self {
+            case .barRect: return "fill=\"red\""
+            case .ringTick: return "stroke=\"red\""
+            }
+        }
+    }
+
+    /// Every marker of `shape` in `svg`, by its horizontal position.
+    ///
+    /// Deliberately a text scan of the emitted SVG rather than a re-computation
+    /// of the geometry: re-deriving the expected x from `quotaPacePercent` would
+    /// pass for a renderer that computes the right number and then draws
+    /// somewhere else.
+    private static func markerXs(in svg: String, of shape: PaceMarkerShape) -> [String] {
+        svg.components(separatedBy: "<").compactMap { element -> String? in
+            guard element.contains(shape.signature) else { return nil }
+            guard let start = element.range(of: "\(shape.positionAttribute)=\"") else { return nil }
+            let rest = element[start.upperBound...]
+            guard let end = rest.range(of: "\"") else { return nil }
+            return String(rest[..<end.lowerBound])
+        }
     }
 
     // MARK: - selectedSnapshot
@@ -211,8 +353,8 @@ final class QuotaMenuBarRendererTests: XCTestCase {
     /// next statusline tick refreshes it.
     func testSelectedSnapshotKeepsStaleSnapshotsRatherThanDroppingThem() {
         let staleRateLimit = RateLimitInfo(
-            windows: [RateLimitWindowInfo(usedPercent: 10, windowMinutes: 300, resetsAt: Date().addingTimeInterval(-3600))],
-            sampledAt: Date().addingTimeInterval(-5)
+            windows: [RateLimitWindowInfo(usedPercent: 10, windowMinutes: 300, resetsAt: now.addingTimeInterval(-3600))],
+            sampledAt: now.addingTimeInterval(-5)
         )
         let stale = sessionState(id: "1", adapter: "claude-code", rateLimit: staleRateLimit)
         let got = QuotaMenuBarRenderer.selectedSnapshot(sessions: [stale], providerKey: nil)
@@ -225,7 +367,7 @@ final class QuotaMenuBarRendererTests: XCTestCase {
     func testSelectedSnapshotSkipsSnapshotWithEmptyWindows() {
         let unrenderable = sessionState(
             id: "unrenderable", adapter: "claude-code",
-            rateLimit: RateLimitInfo(windows: [], sampledAt: Date()) // freshest, but empty
+            rateLimit: RateLimitInfo(windows: [], sampledAt: now) // freshest, but empty
         )
         let renderable = makeSession(id: "2", adapter: "claude-code", usedPercent: 42, sampledSecondsAgo: 120)
         let got = QuotaMenuBarRenderer.selectedSnapshot(sessions: [unrenderable, renderable], providerKey: nil)
@@ -235,7 +377,7 @@ final class QuotaMenuBarRendererTests: XCTestCase {
     func testSelectedSnapshotReturnsNilWhenNoSessionCarriesRateLimit() {
         let plain = SessionState(
             id: "sess_1", state: .working, model: "claude-sonnet", cwd: "/tmp",  // NOSONAR (swift:S1075) — test fixture value, not a real endpoint
-            firstSeen: Date(), updatedAt: Date()
+            firstSeen: now, updatedAt: now
         )
         XCTAssertNil(QuotaMenuBarRenderer.selectedSnapshot(sessions: [plain], providerKey: nil))
     }
@@ -245,12 +387,12 @@ final class QuotaMenuBarRendererTests: XCTestCase {
     private func makeInfo(fiveHour: Double?, sevenDay: Double?, fiveHourResetsIn: TimeInterval = 3600) -> RateLimitInfo {
         var windows: [RateLimitWindowInfo] = []
         if let fiveHour {
-            windows.append(RateLimitWindowInfo(usedPercent: fiveHour, windowMinutes: 300, resetsAt: Date().addingTimeInterval(fiveHourResetsIn)))
+            windows.append(RateLimitWindowInfo(usedPercent: fiveHour, windowMinutes: 300, resetsAt: now.addingTimeInterval(fiveHourResetsIn)))
         }
         if let sevenDay {
-            windows.append(RateLimitWindowInfo(usedPercent: sevenDay, windowMinutes: 10080, resetsAt: Date().addingTimeInterval(3 * 86400)))
+            windows.append(RateLimitWindowInfo(usedPercent: sevenDay, windowMinutes: 10080, resetsAt: now.addingTimeInterval(3 * 86400)))
         }
-        return RateLimitInfo(windows: windows, sampledAt: Date())
+        return RateLimitInfo(windows: windows, sampledAt: now)
     }
 
     /// Builds a window whose `resetsAt` implies exactly `pace` percent
@@ -259,7 +401,7 @@ final class QuotaMenuBarRendererTests: XCTestCase {
     private func windowWithPace(usedPercent: Double, pace: Double, windowMinutes: Int = 300) -> RateLimitWindowInfo {
         let windowSeconds = Double(windowMinutes) * 60
         let elapsed = (pace / 100) * windowSeconds
-        let resetsAt = Date().addingTimeInterval(windowSeconds - elapsed)
+        let resetsAt = now.addingTimeInterval(windowSeconds - elapsed)
         return RateLimitWindowInfo(usedPercent: usedPercent, windowMinutes: windowMinutes, resetsAt: resetsAt)
     }
 
@@ -275,8 +417,8 @@ final class QuotaMenuBarRendererTests: XCTestCase {
         sampledSecondsAgo: TimeInterval
     ) -> SessionState {
         let rateLimit = RateLimitInfo(
-            windows: [RateLimitWindowInfo(usedPercent: usedPercent, windowMinutes: 300, resetsAt: Date().addingTimeInterval(3600))],
-            sampledAt: Date().addingTimeInterval(-sampledSecondsAgo)
+            windows: [RateLimitWindowInfo(usedPercent: usedPercent, windowMinutes: 300, resetsAt: now.addingTimeInterval(3600))],
+            sampledAt: now.addingTimeInterval(-sampledSecondsAgo)
         )
         return sessionState(id: id, adapter: adapter, rateLimit: rateLimit)
     }
@@ -300,8 +442,8 @@ final class QuotaMenuBarRendererTests: XCTestCase {
             state: .working,
             model: "claude-sonnet",
             cwd: "/tmp",  // NOSONAR (swift:S1075) — test fixture value, not a real endpoint
-            firstSeen: Date(),
-            updatedAt: Date(),
+            firstSeen: now,
+            updatedAt: now,
             metrics: metrics,
             adapter: adapter
         )


### PR DESCRIPTION
Closes #1675.

## Which reads were converted, and how each one is closed

| Read | Moves | Kind | Seam |
|---|---|---|---|
| `quotaPacePercent(_:)` — the pace marker's x | **pixels** | continuous | required `now:` argument; `QuotaWindowRow` reads `\.formatNow` |
| `mergeIntoBuckets`' staleness test — the chip's `.opacity` | **pixels** | **discrete** | `snapshotIsStale(_:now:)`, required argument; `QuotaStaleDimmed` reads `\.formatNow` |
| `formatTimeUntil(_:)` — the tooltip's "resets in 4h 12m" | tooltip only | continuous | `QuotaResetFormat.timeUntil(_:now:)`, required argument |

**All three are converted; none is left with a reason.** #1675 offered "convert
for uniformity or leave with a recorded reason" for the third, and the reason
for converting it is stated in `QuotaResetFormat.timeUntil`'s own doc comment
rather than only here: it was the last remaining way for **one tooltip to
describe two instants** (its "resets in" line and the pace verdict beside it
were two separate `Date()` reads), it is a pure function that was untestable and
is now graded on strings, and leaving it would have left the chip with exactly
one machine read — the state a future reader has to re-audit to discover is
deliberate. It buys consistency, not determinism, and the PR says so.

Two structural changes come with them, both required rather than tidying:

- **`mergeIntoBuckets` and `quotaChipData` are `static` and pure.** `now` is a
  required argument, read ONCE for the whole fold rather than once per session,
  so two sessions in one evaluation cannot be judged stale against two
  different instants. `headerTitleView` passes the single `formatNow()` read it
  makes, and so does `quotaTooltip(_:now:)`.
- **`QuotaWidgetData.isStale` is removed, not kept beside the derived verdict.**
  It was a second spelling of a fact already implied by `snapshot`, and two
  objects that can disagree are worth one of them. `ChipBucket` keeps its copy
  because the merge genuinely branches on it, and the equivalence that makes the
  removal safe is **locked over every branch of the fold**
  (`testTheMergeNeverKeepsASnapshotWhoseStalenessDisagreesWithIt`) rather than
  argued in a comment — M5 below is that lock's mutation.

  The residual cost is stated where it lives, not buried: under the *running*
  default clock the fold's read and the wrapper's read are microseconds apart,
  so at a `resetsAt` boundary a chip can dim one frame before its tooltip says
  "stale". Both self-correct on the next `SessionManager` publish, and under any
  pinned clock they are the same instant. That is the same
  microsecond-disagreement class `quotaWindowRow` already documented in-file for
  two `quotaPacePercent` calls, traded for a decision a test can reach.

## Why an extraction was again unavoidable — and why the second one is not a leaf view

#1663 hit this wall one read earlier: an `@Environment` read off a
`SessionListView` value a test constructed itself, outside a view update,
**answers the DEFAULT** — a pin reaching nothing wearing the shape of a passing
test. Both of these reads are inside methods on `SessionListView`, so the same
applies.

`QuotaWindowRow` is the ordinary case, `QuotaResetLabel`'s shape: the pixels and
the decision are in one small view. **The staleness one is not**, and that is the
design point worth reviewing. Its decision was made in the data fold and its
pixels are an `.opacity` applied to the *whole chip* two hundred lines away, and
`quotaChipView` cannot be hosted without dragging in `SessionManager`
(`providerCosts`, the timeframe cycle) — so the vehicle is a **generic wrapper**,
`QuotaStaleDimmed<Content>`, which moves the decision to where the pixels are and
is hostable over any content. `quotaChipView`'s modifier order is unchanged: the
tooltip still applies outside the opacity, and the opacity still covers the
provider icon.

Both live in a new `Irrlicht/Views/QuotaChipParts.swift`. No modifier was added
or removed and no geometry changed.

## `QuotaMenuBarRendererTests` — before and after

This is the part of the family that is **actually graded on a runner**: that
suite calls no `as: .pinnedImage`, so `ImageSnapshotCIScopeTests` does not skip
it (its 4 tests pass unchanged, and its derived classification is unaffected —
this PR adds no image-snapshot suite).

**Before.** 22 assertions across the stacked bars, the compact ring, the pace
marker, the color ramp and snapshot selection — with *every* fixture built from
`Date()` while the renderer read `Date()` again a moment later. Two consequences:

- Nothing in it could tell a renderer that **honours** the instant it is given
  from one that ignores the argument and reads the clock, because the two answer
  identically whenever the argument *is* the clock.
- It could not pin an **exact** ramp boundary. That was not a guess — its own
  comment on `testBuildSVGColorThresholdsMirrorPopoverPaceRamp` recorded it:
  "an exact-boundary delta (e.g. precisely 5 or 15) can tip either way on
  sub-millisecond wall-clock drift", so the cases deliberately stayed off the
  boundary.

**After.** `now` is a fixed instant (`PinnedNowSnapshot.referenceNow`, shared
with the popover-side suite) and a required argument on every entry point, so:

- The fixtures are absolute and the arithmetic is exact. Four **new boundary
  rows** pin what the suite previously could not: delta exactly 5 → yellow,
  delta 4.9 → green, delta exactly 15 → orange, delta 14.9 → yellow.
- Two **new both-sides arms** — `testTheBarsHonourTheNowTheyAreGiven` and
  `testTheCircleHonoursTheNowItIsGiven` — drive two clocks 48h apart through one
  snapshot and refuse an unmoved marker, reading the emitted SVG's marker `x`
  rather than re-deriving the geometry (re-deriving would pass for a renderer
  that computes the right number and draws somewhere else). The bars arm asserts
  **two** markers, because `rowSVG` used to read the clock per row, so one icon
  could pace its 5h and 7d rows against two different instants.
- 22 tests → 24; every pre-existing assertion is retained.

`MenuBarImageBuilder.combinedImage` reads `Date()` once, visibly, and threads it
down. The icon is rasterised into an `NSStatusItem` with no SwiftUI environment
anywhere near it, so the required-argument form is the only option — #1659's
shape for exactly that case.

## The `rate_limit` fixture question #1663 left open

**The clock obstacle is gone, and the fixture is seeded — but deliberately NOT
as a committed reference PNG.** Both halves of that matter.

Seeded: `Tests/QuotaChipClockTests.swift` renders a real `rate_limit` snapshot
through `QuotaWindowRow` and `QuotaStaleDimmed` via `PinnedSnapshotHost`, twice
per axis, comparing in memory. That is a fixture exercising the seam, which
#1675 correctly says a seam without one does not have.

Not a PNG, and the reason has nothing to do with the clock: per #1615 **every**
committed-reference image suite currently fails on a CI runner over
rasterisation, so a new one would have to be classified `true` (skipped) in
`ImageSnapshotCIScopeTests` — buying a check that runs on one developer Mac —
and classifying it `false` instead would be a guess, which that file explicitly
forbids ("`false` is a claim about the runner, made from a measured run — not a
guess"), and a wrong guess reddens `swift-test` for an unrelated PR. The
in-memory form runs everywhere. What a PNG would additionally buy is the chip's
*layout* (bar geometry, row spacing), which nothing covers today; that is a
separate, honest gap and is not what #1663's note was about.

Re-measured while writing this, not assumed:
`git grep -n "rateLimit\|rate_limit" -- platforms/macos/Tests/Fixtures
platforms/macos/Tests/MockInstanceFiles` → **zero matches**, so no committed
reference renders any of this and the 53-PNG set is untouched *by construction*.

## Mutation evidence

Everything here is added, so every arm owes a deliberate mutation. Nine were
applied and reverted **one per shell invocation**, each followed by
`git status --porcelain` re-read and diffed against the pre-mutation baseline
(`TREE MATCHES BASELINE` every time).

**M1 — `QuotaWindowRow` reads `Date()` instead of `formatNow()`** (the seam
reverted at the call site — #1675's "put the wall clock back", and #1676's M1
one read on). **1 failure, and every value assertion stayed green:**

```
QuotaChipClockTests.swift:328: error: -[…testTheSameRowRendersDifferentlyUnderTwoPinnedNows]
: XCTAssertNotEqual failed: ("86734 bytes") is equal to ("86734 bytes")
- the quota window row's pace marker sits at the same x under two pinned clocks —
  `\.formatNow` is reaching nothing and the marker's position is coming from the
  machine's wall clock
```

That is the measurement this whole shape exists for, reproduced: 51 of 52 tests
passed. The row arm is rendered in **compact** mode precisely so this reddens
for the pace marker alone — compact drops the reset label, whose own clock read
#1663 already covers.

**M2 — `QuotaStaleDimmed` reads `Date()` instead of `formatNow()`.** 1 failure,
the discrete one:

```
:361: …testTheSameChipDimsUnderOneClockAndNotTheOther : ("21454 bytes") is equal to ("21454 bytes")
- the chip rendered at the same opacity under a clock before and a clock after its
  window reset — `\.formatNow` is reaching nothing and the stale dimming is coming
  from the machine's wall clock
```

**M3 — `quotaPacePercent` ignores its `now:` and reads `Date()`.** 14 failures
across both suites, including the premise guards firing correctly rather than
passing:

```
:124: …testPacePercentIsPlacedByTheNowItIsGiven : ("Optional(100.0)") is not equal to ("Optional(80.0)")
:318: …TwoPinnedNows (premise) : the fixture paces identically under both pinned clocks
:328: …TwoPinnedNows : ("86734 bytes") is equal to ("86734 bytes")
QuotaMenuBarRendererTests:131: …ColorThresholdsMirrorPopoverPaceRamp : 6 rows, incl. both new exact boundaries
:257: …testTheBarsHonourTheNowTheyAreGiven : ("["49.50", "49.50"]") is equal to (same)
:280: …testTheCircleHonoursTheNowItIsGiven : ("["9.00"]") is equal to (same)
:190: …testBuildCircleSVGFallsBackToSevenDayWhenFiveHourAbsent : XCTAssertTrue failed
```

**M4 — `snapshotIsStale` ignores its `now:` and reads `Date()`.** 7 failures:

```
:146: …testStalenessFlipsWithTheNowItIsGiven : a window resetting an hour from now is not stale yet
:159: …testStalenessIsInclusiveAtTheResetInstant : a window resetting one second from now is not
:173: …testQuotaChipDataDrivesItsStalenessFromTheNowItIsGiven : ("true") is not equal to ("false")
:243/:245: …testTheMergePrefersAFreshSnapshotOverAStaleOne… : the fold kept the newer-but-stale snapshot
:353: …DimsUnderOneClockAndNotTheOther (premise) : the fixture's staleness does not flip
:361: …DimsUnderOneClockAndNotTheOther : ("21454 bytes") is equal to (same)
```

Note what M4 does **not** redden: the merge-consistency lock, which stays green
because both sides then read the same wrong clock. That is correct — it is a
lock about the fold's internal agreement, not about the clock — and it is why it
needs its own mutation:

**M5 — the merge keeps a verdict its snapshot disagrees with** (`existing.isStale
= true` where the fresh-wins branch sets `false`). 2 failures:

```
:213: …testTheMergeNeverKeepsASnapshotWhoseStalenessDisagreesWithIt : ("true") is not equal to ("false")
- stale first, then fresh at 2023-11-14 22:13:20 +0000, bucket anthropic: the merge kept a
  staleness verdict that disagrees with the snapshot it kept — the chip's dimming and the
  merge's own bucketing are now two facts that can differ
```

**M6 — `QuotaResetFormat.timeUntil` reads `timeIntervalSinceNow` again.** 5
failures, all five `timeUntil` assertions (`("0m") is not equal to ("1d")`, …).

**M7 — `QuotaMenuBarRenderer.pacePercent` discards its `now:`.** 9 failures **in
the suite CI runs**, and the popover suite stays entirely green — which is the
evidence that the renderer's own arms are the only thing covering that side:

```
:257: …testTheBarsHonourTheNowTheyAreGiven : ("["49.50", "49.50"]") is equal to (same)
:280: …testTheCircleHonoursTheNowItIsGiven : ("["9.00"]") is equal to (same)
:131: …ColorThresholdsMirrorPopoverPaceRamp : 5 rows, incl. both new exact boundaries
:190: …testBuildCircleSVGFallsBackToSevenDayWhenFiveHourAbsent
```

**M8 / M9 — the two must-not-differ twins.** A both-sides pixel arm is satisfied
by a view that varies with the clock for *any* reason, so each is paired with a
fixture whose verdict is identical under both clocks. Both twins earned their
place:

- M8 — the opacity fades with the clock instead of with the flip
  (`1.0 - min(0.4, formatNow().timeIntervalSince(sampledAt) / 1_000_000)`).
  **1 failure, only the twin**: `:376: …testAChipStaleUnderBothClocksRendersIdentically
  — the dimming is varying with something other than the verdict`.
- M9 — an unpaceable row acquires a clock-derived marker. **1 failure, only the
  twin**: `:343: …testARowTheClockCannotPaceRendersIdenticallyUnderBothClocks —
  something else in this row reads the wall clock`.

**M9's first attempt was INERT, and that is worth more than the mutation.** It
placed the marker at `Int(epoch) % 100` — and `referenceNow` (1700000000) and
`contrastingNow` (+48h) are **both ≡ 0 (mod 100)**, so a genuinely
clock-dependent marker rendered identically under both pins and the arm came
back green. A green mutation run read as "the test does not cover this"; the
arithmetic said the mutation varied nothing. Re-run as `Int(epoch / 3600) % 100`
(22 vs 70) it reddens exactly the twin. That is AGENTS.md's
"assert the mutation actually happened" (#1390) arriving inside a Swift suite,
and it is one line of arithmetic to check before trusting a green mutation.

One assertion is a **lock with no mutation of its own**:
`testTheStaleOpacityIsHalf`, which pins `QuotaStaleDimmed.staleOpacity` against
the production constant rather than a copy. It exists so an arm above cannot be
passing on a difference nobody can see.

## References

**Zero regenerated.** `git status --porcelain -- platforms/macos/Tests/__Snapshots__`
is empty across all three gate runs; all **53** committed PNGs still match.
Following #1658/#1664/#1673/#1676, the untouched set is itself the evidence that
neither the two new views, nor the removal of `QuotaWidgetData.isStale`, nor the
static fold changed any rendering — and per the grep above, no reference renders
this site at all, so it is untouched by construction rather than by inspection.

## Gates

- `tools/preflight.sh --only swift` — **PASS**, exit 0 read directly from `$?`,
  never through a pipe. `402 tests, 0 failures`; `grep -c "error: -\["` over the
  log = **0**. Per #1523 the exit code is the only reliable signal, and it is 0.
  Run three times (after the code, after the doc corrections, after a
  re-indentation), 0 each time. 385 → 402 = +15 new suite, +2 renderer arms.
- `tools/preflight.sh --only tools` / `skills` — **not run, and not required**:
  the diff is `AGENTS.md` + `platforms/macos/`, and `grep -n AGENTS
  tools/preflight.sh` finds only two comment lines, so no gate keys on the doc
  change (the same check #1676 recorded).
- Real-home safety: `swift-suite.sh`'s witness reported **`no new entries in
  Library/Preferences Library/Sounds`** on every run. Counts read read-only
  before and after: Preferences 202 entries / 264 files → 202 / 264; Sounds
  2 → 2; `~/Library/Preferences/io.irrlicht.app.plist` 135 bytes, mtime
  `Aug 17 13:23`, unchanged. Nothing deleted, moved or overwritten under the
  real home; no `defaults` write, no locale/timezone/`defaults` domain change;
  `LauncherTestHarness` / `LauncherHarnessTests` never run.
- `swift-test` on a GitHub runner — **PASS** (run on head `5170cda3`, which
  carried both new suites). That is what makes the "graded on a runner" claim
  above a measurement rather than an inference: `QuotaChipClockTests`'s pixel
  arms compare two renders taken on the *same* host, so #1615's rasterisation
  gap cannot reach them. `swift-build`, `swift-snapshot-evidence`, `go-test`,
  `build-test`, `ars-gate`, both web suites, CodeQL and Sonar also pass.
- **ARS advisory: pass.** **CodeScene advisory: fail**, on two files, and it was
  looked at rather than suppressed or ignored. Its own report also records the
  improvement: `SessionListView.swift` **8.43 → 8.70** (Primitive Obsession),
  from the removed `isStale` field and the row/bar/`formatTimeUntil` leaving it.
  - `QuotaMenuBarRendererTests.swift` — *Primitive Obsession / String Heavy
    Function Arguments* (10.00 → 9.39), on `markerXs(in:attribute:terminator:)`,
    three loose `String`s. **Fixed**, because it was a real weakness and not a
    score: the two shapes are now a named `PaceMarkerShape` enum
    (`.barRect` / `.ringTick`), each carrying its own element signature and
    position attribute — so pairing `x` with the ring's `stroke="red"`, which
    matches nothing and would report "no marker" from a passing-looking helper,
    is no longer expressible. The 24 assertions are unchanged and the full gate
    was re-run after it (`402 tests, 0 failures`, exit 0). Measured effect:
    *Primitive Obsession* cleared and the file went **9.39 → 9.69**. One
    advisory rule remains on it (*String Heavy Function Arguments*), and the
    report names no method for it, so what follows is a **hypothesis, not a
    measurement**: the likely subject is the pre-existing
    `makeSession(id:adapter:usedPercent:sampledSecondsAgo:)` /
    `sessionState(id:adapter:rateLimit:)` fixture helpers — two `String`
    parameters each, unchanged in shape, but whose bodies the `Date()` → `now`
    conversion touched, and the file scored 10.00 before this PR touched them.
    Confirming it needs the CodeScene UI, which needs auth. Either way it is a
    two-argument test-fixture signature and advisory.
  - `QuotaMenuBarRenderer.swift` — *Excess Number of Function Arguments*
    (10.00 → 9.69), on `rowSVG`'s fifth argument, which is `now:`. **Kept**,
    which is #1676's finding on this same family one read earlier: the argument
    *is* the fix, and bundling the five into a context struct would restore a
    memberwise initializer a call site can fill from the machine as easily as
    from its caller, with no compile error — precisely the property being
    bought. AGENTS.md: advisory is "a prompt to look closer, not something to
    chase to green".

## Also in this diff

`AGENTS.md`'s macOS bullet gains these three reads under its wall-clock member
(same axis, not a fifth member), carrying the six things worth reusing: why the
second extraction is a generic wrapper rather than a leaf view; why the stored
`isStale` was removed rather than kept beside the derived one; that a both-sides
pixel arm needs a must-not-differ twin; that **a mutation whose two pinned
instants are congruent is inert and reads as a passing test**; that this is the
one member of the family CI grades, and what its suite could not previously
tell apart; and the `rate_limit` fixture answer with the cost of the PNG form.

`FormatNowEnvironment.swift`'s blast-radius section and
`PinnedNowSnapshot.swift`'s "no committed reference is clock-dependent"
paragraph both named these three as unconverted and are corrected in place, so
the next reader is not sent to re-audit a closed question.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
