### PR TITLE
fix(macos): stop a Settings render persisting the sound defaults it just read (#1672)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1507,8 +1507,52 @@ Before marking a ticket done, run the full suite — every layer must pass:
   are deliberately left legal, because `object(forKey:)` is how a test says "and
   the process domain was not touched", and banning it would ban the evidence
   along with the defect. What that rule cannot see is a production call site a
-  test drives — measured, two sound keys still reach that domain across a full
-  gate run and no test source names the write (#1672).
+  test merely DRIVES, and **#1672 is that gap, closed**. The write was
+  `NotificationEventRow`: it mirrored its sound key into `@State`, loaded it in
+  `.onAppear` and persisted it back from `.onChange(of:)`, so merely RENDERING
+  the row wrote the value it had just read — and `SettingsViewTests` renders
+  `SettingsView`. Four things there are worth carrying.
+  **The loop is #1673's `didSet` trap in SwiftUI clothing**, and the fix is the
+  same move: remove the second copy rather than guard the write-back more
+  carefully. The row is `@AppStorage` over its own key now, derived on every
+  render, with a `Binding` whose `set` runs only for a pick — so it needed no new
+  product seam and inherits `.defaultAppStorage` the way every other
+  `@AppStorage` does.
+  **It was invisible for two compounding reasons, and both of them qualify any
+  "the domain did not change" measurement in this area.** It wrote back the value
+  `register(defaults:)` had just seeded, so no value changed, the plist's mtime
+  never moved, and `object(forKey:)`/`dictionaryRepresentation()` — which merge
+  the registration domain under the application one — read identically either
+  way. Only the application domain's KEY SET distinguishes a persisted default
+  from a registered one, which is what `InMemoryDefaults.writtenKeys` is for, and
+  even that saturates: once the key is there, the write is undetectable. And it
+  fired only for the events whose `defaultSound` differs from
+  `SoundChoice.default` (`.ping`) — `.ready` (funk) and `.contextPressure`
+  (sosumi) wrote, `.waiting` did not, because for it the loaded value equalled the
+  `@State` initial one and `.onChange` never fired.
+  **Two of three keys is what made the right hypothesis look falsified.** #1672's
+  own body rules out "every rendered row writes its default back" on the grounds
+  that `soundOnWaiting` was absent and that a SettingsView-only run left the
+  plist mtime unchanged — both measurements correct, the conclusion wrong,
+  because the real rule was one step narrower and the write was idempotent. A
+  dismissal can be right about what it ran and wrong about what that excludes;
+  the way out was an instrumented run naming the call site (a `print` in
+  `handle`, reverted), not a better inference.
+  **The structural half is a THIRD rule in `PersistentDefaultsLintTests`: the
+  same mutation scan over the APP target**, which is where a test-source scan is
+  blind by construction. Measured, it reports exactly `SettingsView.swift:987`
+  and `:1004` against the pre-fix tree and zero after, so it carries no
+  exemption list. Its behavioural counterpart is
+  `testRenderingTheNotificationRowsPersistsNoSoundChoice`, whose vacuity guard is
+  `InMemoryDefaults.readKeys`: a row that never rendered (the master gate is
+  collapsed by default) and a row still resolving `UserDefaults.standard` both
+  write nothing too, so "wrote nothing" is worthless without "and it asked THIS
+  store". The **runtime** witness #1672 also proposed — `tools/lib/swift-suite.sh`
+  comparing named domains' key SETS rather than directory entries — is #1688,
+  deferred with its measurement rather than dropped: the key set is quiet enough
+  to adopt (0 additions across two suite-length windows, against ~1 plist/218s
+  for the directory witness) but a growth-only check is green on any domain that
+  already has the key, i.e. on the machine that found this.
   **The fourth member is the WALL CLOCK, and it is the one where pinning the
   other three would have looked like coverage** (#1663).
   `SessionListView.formatResetTime` stacked four machine reads —

--- a/platforms/macos/Irrlicht/Views/SettingsView.swift
+++ b/platforms/macos/Irrlicht/Views/SettingsView.swift
@@ -894,7 +894,87 @@ private struct NotificationEventRow: View {
     let sampleText: String
     let onImportError: (String) -> Void
 
-    @State private var selection: SoundChoice = .default
+    /// The row's ONE copy of the sound choice, and the reason there is no
+    /// `@State` mirror of it (#1672).
+    ///
+    /// This used to be `@State private var selection: SoundChoice = .default`,
+    /// loaded from `UserDefaults.standard` in `.onAppear` and persisted back
+    /// from `.onChange(of: selection)`. Those three pieces form a loop: the
+    /// load is itself a change, so merely RENDERING the row wrote the value it
+    /// had just read straight back into the process's preference domain — a
+    /// preference the user never picked, persisted into their real
+    /// `io.irrlicht.app` domain in the app, and into
+    /// `com.apple.dt.xctest.tool` under `swift test`, which is where #1672
+    /// found it.
+    ///
+    /// Two properties of that write are worth keeping written down, because
+    /// they are what made it survive #1662's audit:
+    ///
+    /// - **It wrote the value it had just read**, so nothing observable
+    ///   changed. The plist's mtime does not move, and a merged
+    ///   `dictionaryRepresentation()` reads the same whether a value came from
+    ///   the registration domain or from the application domain. On a machine
+    ///   that has already run the suite once, the write is undetectable by any
+    ///   value comparison — only the first run on a fresh domain shows up, and
+    ///   only in the KEY SET.
+    /// - **It fired for exactly the events whose `defaultSound` differs from
+    ///   `SoundChoice.default`** (`.ping`): `.ready` (funk) and
+    ///   `.contextPressure` (sosumi). For `.waiting` the loaded value equalled
+    ///   the `@State` initial one, so `.onChange` never fired and
+    ///   `soundOnWaiting` was never written. Two of three keys appearing is
+    ///   what made "every rendered row writes its default back" look
+    ///   falsified, when the real rule was one step narrower.
+    ///
+    /// `@AppStorage` answers it by removing the second copy rather than by
+    /// guarding the loop: there is nothing to load, so a render has nothing to
+    /// write back, and a write happens only when the `Picker` hands
+    /// `soundBinding` a value the user chose. It also inherits #1662's seam for
+    /// free — `@AppStorage` honours `.defaultAppStorage(_:)`, so
+    /// `PinnedSnapshotHost` already resolves this through an
+    /// `InMemoryDefaults`.
+    @AppStorage private var storedSound: String
+
+    /// The key is per-event, so the wrapper is built here rather than declared
+    /// with a literal. `wrappedValue:` is what an UNSET key reads as; it is not
+    /// written, which is the whole point. It matches `SessionManager`'s
+    /// `register(defaults:)` seed, so an unset key and a seeded one agree.
+    init(event: NotificationEvent,
+         enabled: Binding<Bool>,
+         sampleText: String,
+         onImportError: @escaping (String) -> Void) {
+        self.event = event
+        self._enabled = enabled
+        self.sampleText = sampleText
+        self.onImportError = onImportError
+        self._storedSound = AppStorage(wrappedValue: event.defaultSound.rawValue,
+                                       event.soundKey)
+    }
+
+    /// Derived on every render, never stored.
+    private var selection: SoundChoice {
+        SoundChoice(rawValue: storedSound) ?? event.defaultSound
+    }
+
+    /// The picker's binding. `get` derives from the store; `set` runs only for
+    /// a pick that came from the control.
+    ///
+    /// The sentinel is deliberately NOT persisted, and `get` still answers the
+    /// previous choice while the open panel runs — so the control reverts on
+    /// its own, which is what the old code needed an explicit
+    /// `selection = previous` assignment for.
+    private var soundBinding: Binding<SoundChoice> {
+        let stored = $storedSound
+        let fallback = event.defaultSound
+        return Binding(
+            get: { SoundChoice(rawValue: stored.wrappedValue) ?? fallback },
+            set: { newValue in
+                guard newValue != .customPickerSentinel else {
+                    self.pickCustomFile(into: stored)
+                    return
+                }
+                stored.wrappedValue = newValue.rawValue
+            })
+    }
 
     var body: some View {
         // One row (issue #940): toggle + label + sound picker + preview all
@@ -905,7 +985,7 @@ private struct NotificationEventRow: View {
             HStack(spacing: IrrSpacing.sp2) {
                 LeadingToggle(isOn: $enabled, label: event.displayName)
 
-                Picker("", selection: $selection) {
+                Picker("", selection: soundBinding) {
                     ForEach(SoundChoice.builtIns, id: \.self) { choice in
                         Text(choice.displayName).tag(choice)
                     }
@@ -924,9 +1004,6 @@ private struct NotificationEventRow: View {
                 .disabled(!enabled)
                 .frame(width: 112)
                 .tooltip(selection.displayName)
-                .onChange(of: selection) { newValue in
-                    handle(newValue)
-                }
 
                 Button {
                     SoundPlayer.preview(selection, sampleText: sampleText)
@@ -959,7 +1036,6 @@ private struct NotificationEventRow: View {
                 .tooltip("Open System Settings → Accessibility → Spoken Content")
             }
         }
-        .onAppear { loadFromDefaults() }
     }
 
     private static func openSpokenContentSettings() {
@@ -972,22 +1048,7 @@ private struct NotificationEventRow: View {
         }
     }
 
-    private func loadFromDefaults() {
-        let raw = UserDefaults.standard.string(forKey: event.soundKey) ?? event.defaultSound.rawValue
-        selection = SoundChoice(rawValue: raw) ?? event.defaultSound
-    }
-
-    private func handle(_ newValue: SoundChoice) {
-        if newValue == .customPickerSentinel {
-            let previous = SoundChoice(rawValue: UserDefaults.standard.string(forKey: event.soundKey) ?? "") ?? .default
-            selection = previous
-            pickCustomFile()
-            return
-        }
-        UserDefaults.standard.set(newValue.rawValue, forKey: event.soundKey)
-    }
-
-    private func pickCustomFile() {
+    private func pickCustomFile(into stored: Binding<String>) {
         let panel = NSOpenPanel()
         panel.allowsMultipleSelection = false
         panel.canChooseDirectories = false
@@ -1001,8 +1062,7 @@ private struct NotificationEventRow: View {
             switch result {
             case .success(let installed):
                 let choice = SoundChoice.custom(installedFilename: installed, displayPath: url.path)
-                UserDefaults.standard.set(choice.rawValue, forKey: event.soundKey)
-                selection = choice
+                stored.wrappedValue = choice.rawValue
                 onImportError("")
             case .failure(let error):
                 onImportError("Could not import audio file: \(error.localizedDescription)")

--- a/platforms/macos/Tests/InMemoryDefaults.swift
+++ b/platforms/macos/Tests/InMemoryDefaults.swift
@@ -68,10 +68,45 @@ final class InMemoryDefaults: UserDefaults {
     /// read against a real suite.
     private var registered: [String: Any] = [:]
 
+    /// Every key this store has been ASKED for. See `readKeys`.
+    private var reads: Set<String> = []
+
     /// XCTest drives one test at a time here, but `SessionManager` and friends
     /// read defaults from other queues, and a double that flaked under that
     /// would be debugged as a product bug. `UserDefaults` itself is thread-safe.
     private let lock = NSLock()
+
+    /// The keys WRITTEN through this store, with the registration domain
+    /// excluded — and that exclusion is the entire reason this exists (#1672).
+    ///
+    /// `object(forKey:)` and `dictionaryRepresentation()` both merge `registered`
+    /// under `store`, so neither can answer "did this render PERSIST anything".
+    /// The write #1672 is about put back the exact value `register(defaults:)`
+    /// had just seeded, so every merged view of the store — and, on a real
+    /// domain, every value comparison and the plist's own mtime — reads
+    /// identically whether it happened or not. Only the key set of the
+    /// application domain tells them apart.
+    /// `testBuildingASessionManagerWritesNoPreference` can assert through
+    /// `object(forKey:)` only because the two keys it names are not in that
+    /// seed. The three sound keys are.
+    var writtenKeys: Set<String> {
+        lock.lock()
+        defer { lock.unlock() }
+        return Set(store.keys)
+    }
+
+    /// The keys this store was READ for. The vacuity guard for any
+    /// "wrote nothing" assertion over a rendered view: without it, a view that
+    /// never rendered and a view that rendered and wrote nothing produce the
+    /// same verdict — AGENTS.md's "absence of a finding and inability to look
+    /// must never produce the same output". A view whose `@AppStorage` resolved
+    /// `UserDefaults.standard` instead of this store also reads as "wrote
+    /// nothing", and this is what separates that case out too.
+    var readKeys: Set<String> {
+        lock.lock()
+        defer { lock.unlock() }
+        return reads
+    }
 
     /// - Note: `super.init(suiteName: nil)` binds the process's *own*
     ///   application domain, which already exists — it mints no new domain and
@@ -99,6 +134,10 @@ final class InMemoryDefaults: UserDefaults {
     override func object(forKey defaultName: String) -> Any? {
         lock.lock()
         defer { lock.unlock() }
+        // Recorded here rather than in each derived accessor: Foundation funnels
+        // every read through this primitive, which is the same argument the
+        // overrides below rest on.
+        reads.insert(defaultName)
         return store[defaultName] ?? registered[defaultName]
     }
 

--- a/platforms/macos/Tests/PersistentDefaultsLintTests.swift
+++ b/platforms/macos/Tests/PersistentDefaultsLintTests.swift
@@ -30,15 +30,38 @@ import XCTest
 /// a store and `SessionManager` takes one, no test needs to write that domain,
 /// so the rule can be stated rather than deferred.
 ///
-/// READS are deliberately left alone. `UserDefaults.standard.object(forKey:)`
-/// is how a test says "and the process domain was not touched", which is the
-/// assertion that would have caught this class in the first place; banning it
-/// would ban the evidence along with the defect.
+/// **A third rule, because two source rules over the TEST targets could not see
+/// #1672 at all.** #1662 removed every `UserDefaults.standard` mutation from the
+/// test targets and two keys still appeared in the developer's real
+/// `com.apple.dt.xctest.tool` domain across a suite run: `soundOnReady = funk`
+/// and `soundOnContextPressure = sosumi`. The write was in the APP —
+/// `NotificationEventRow` mirrored its sound key into `@State`, loaded it in
+/// `.onAppear` and persisted it back from `.onChange`, so merely RENDERING the
+/// row wrote the value it had just read — and `SettingsViewTests` renders
+/// `SettingsView`. A rule that scans only test sources is structurally blind to
+/// that: the offending line is in a file it does not read.
 ///
-/// There is deliberately **no exemption list** for either rule, for the reason
-/// `core/architecture_hookbody_test.go` gives: a test that genuinely needs a raw
-/// suite, or a genuine write to the process domain, amends this rule in a
-/// reviewable diff.
+/// So the mutation rule is applied to the app target too. It is not a weaker
+/// claim there, it is a stronger one: in the app that domain is the user's real
+/// `io.irrlicht.app`, so a write there persists a preference the user never set
+/// — the same defect #1673's `Published(initialValue:)` trap was, one layer up.
+/// Every persist in this app has a seam that does not need it: `@AppStorage`,
+/// which honours `.defaultAppStorage(_:)` and is therefore pinnable, or an
+/// injected `UserDefaults` (`SessionManager.init(defaults:)`). Measured after
+/// #1672's fix: the construct appears **zero** times in the app target, so the
+/// rule needs no exemption and gets none.
+///
+/// READS are deliberately left alone, in both targets. `UserDefaults.standard.`
+/// `object(forKey:)` is how a test says "and the process domain was not
+/// touched", which is the assertion that would have caught this class in the
+/// first place; banning it would ban the evidence along with the defect. In the
+/// app a read is how `reconcileNotificationsMasterDefault()` distinguishes an
+/// absent key from a `false` one, which `@AppStorage` cannot express.
+///
+/// There is deliberately **no exemption list** for any of the three rules, for
+/// the reason `core/architecture_hookbody_test.go` gives: a test that genuinely
+/// needs a raw suite, or a genuine write to the process domain, amends this rule
+/// in a reviewable diff.
 final class PersistentDefaultsLintTests: XCTestCase {
 
     // MARK: - The rule, as a pure function
@@ -66,6 +89,10 @@ final class PersistentDefaultsLintTests: XCTestCase {
         + mutators.joined(separator: "|") + #")\s*\("#
 
     private static let testTargetDirectories = ["Tests", "TestsHarness"]
+
+    /// The app target. One directory, and the walk below fails loudly if it is
+    /// not there — a renamed target must not read as a clean tree.
+    private static let appTargetDirectories = ["Irrlicht"]
 
     /// 1-based line numbers of every offending construction in `source`.
     ///
@@ -321,6 +348,16 @@ final class PersistentDefaultsLintTests: XCTestCase {
     /// Walks every Swift source in the test targets, applying `rule` to each,
     /// and returns `file:line` for every hit plus how many files were read.
     private func scanTestTargets(_ rule: (String) -> [Int]) throws -> (offenders: [String], filesScanned: Int) {
+        try scan(Self.testTargetDirectories, rule)
+    }
+
+    /// Walks every Swift source under `directories`, applying `rule` to each,
+    /// and returns `file:line` for every hit plus how many files were read.
+    ///
+    /// Parameterised by directory rather than duplicated per target, so the app
+    /// scan #1672 adds cannot drift from the test scan it shares a rule with.
+    private func scan(_ directories: [String],
+                      _ rule: (String) -> [Int]) throws -> (offenders: [String], filesScanned: Int) {
         var offenders: [String] = []
         var filesScanned = 0
 
@@ -328,15 +365,15 @@ final class PersistentDefaultsLintTests: XCTestCase {
             .deletingLastPathComponent()        // Tests/
             .deletingLastPathComponent()        // platforms/macos/
 
-        for directory in Self.testTargetDirectories {
+        for directory in directories {
             let root = macosRoot.appendingPathComponent(directory)
             var isDirectory: ObjCBool = false
             guard FileManager.default.fileExists(atPath: root.path, isDirectory: &isDirectory),
                   isDirectory.boolValue else {
-                // A renamed or removed test target must be loud, not silent: a
-                // walk over a directory that is not there finds nothing and is
+                // A renamed or removed target must be loud, not silent: a walk
+                // over a directory that is not there finds nothing and is
                 // indistinguishable from a clean tree.
-                XCTFail("test target directory \(directory) is missing at \(root.path)")
+                XCTFail("target directory \(directory) is missing at \(root.path)")
                 continue
             }
             guard let walk = FileManager.default.enumerator(at: root, includingPropertiesForKeys: nil) else {
@@ -385,6 +422,31 @@ final class PersistentDefaultsLintTests: XCTestCase {
             preferences it owns — so there is nothing to restore in a `tearDown` \
             that an aborted run (#1523), a 240s tree kill or an exhausted \
             `--budget` never reaches (#1662). Reads are fine.
+
+            \(offenders.joined(separator: "\n"))
+            """
+        )
+    }
+
+    /// #1672: the same rule over the APP target — the half a test-source scan
+    /// is structurally blind to, because the write it missed was a production
+    /// line a test merely *drove*.
+    func testNoAppSourceMutatesTheProcessPreferenceDomain() throws {
+        let (offenders, filesScanned) = try scan(Self.appTargetDirectories, Self.mutatingLines(in:))
+
+        XCTAssertGreaterThan(filesScanned, 0, "the scan read no Swift files — it checked nothing")
+        XCTAssertEqual(
+            offenders, [],
+            """
+            App code mutates UserDefaults.standard. In the app that is the \
+            user's real io.irrlicht.app domain, so a write reachable from a \
+            render persists a preference they never set; under `swift test` the \
+            same line writes the developer's com.apple.dt.xctest.tool domain, \
+            which is where #1672 was found and which no scan of the TEST \
+            sources can see. Persist through a seam that a test can pin \
+            instead: `@AppStorage`, which honours `.defaultAppStorage(_:)`, or \
+            an injected `UserDefaults` (`SessionManager.init(defaults:)`). \
+            Reads are fine.
 
             \(offenders.joined(separator: "\n"))
             """

--- a/platforms/macos/Tests/PinnedAppStorageSnapshotTests.swift
+++ b/platforms/macos/Tests/PinnedAppStorageSnapshotTests.swift
@@ -322,4 +322,94 @@ final class PinnedAppStorageSnapshotTests: XCTestCase {
                        "the write reached UserDefaults.standard — the seam leaks into the "
                        + "developer's com.apple.dt.xctest.tool domain")
     }
+
+    // MARK: - A render must PERSIST nothing (#1672)
+
+    /// The keys #1672 is about.
+    private static let soundKeys = Set(NotificationEvent.allCases.map(\.soundKey))
+
+    /// `SettingsView`, hosted the way a snapshot suite hosts a view, over
+    /// `store`.
+    ///
+    /// `notificationsEnabled` is seeded true because the three
+    /// `NotificationEventRow`s live behind the master gate (#940) and a
+    /// collapsed section renders none of them — which is precisely the shape a
+    /// "wrote nothing" assertion passes vacuously under.
+    private func renderSettingsPanel(_ store: InMemoryDefaults) -> PinnedSnapshotHost {
+        store.set(true, forKey: NotificationSettings.masterEnabledKey)
+        let view = SettingsView(isPresented: .constant(true),
+                                showPermissionsReview: .constant(false),
+                                sessionManager: SessionManager(defaults: store))
+            .environmentObject(UpdateManager(startingUpdater: false))
+            .environmentObject(DaemonManager())
+        return PinnedSnapshotHost(view,
+                                  width: SessionListView.panelWidth,
+                                  height: 520,
+                                  defaults: store)
+    }
+
+    /// #1672, as a property of a render: showing the notification rows writes
+    /// no sound choice into the store they resolved through.
+    ///
+    /// ## Why this asserts over `writtenKeys` and not `object(forKey:)`
+    ///
+    /// `SessionManager.init` puts all three sound keys into the store's
+    /// REGISTRATION domain, so `object(forKey:)` answers non-nil for every one
+    /// of them whether anything persisted or not — that is why
+    /// `testBuildingASessionManagerWritesNoPreference` above can use it (its two
+    /// keys are not in that seed) and why this one cannot. It is also why the
+    /// defect survived #1662's audit against a real domain: the row wrote back
+    /// the value `register(defaults:)` had just handed it, so no value changed,
+    /// the plist's mtime never moved, and every merged view of the domain read
+    /// identically. Only the application domain's KEY SET tells a persisted
+    /// default from a registered one.
+    ///
+    /// ## The vacuity guard
+    ///
+    /// A row that never rendered — the master gate is collapsed by default, so
+    /// that is the likely accident — and a row whose `@AppStorage` resolved
+    /// `UserDefaults.standard` instead of the pinned store both also write
+    /// nothing here. `readKeys` separates them: the rows must have ASKED this
+    /// store for all three keys.
+    ///
+    /// ## Why the sound keys and not the whole written set
+    ///
+    /// Scoped deliberately. Measured on this machine, a clean render writes
+    /// exactly `["notificationsEnabled"]` — the key this test seeds itself — so
+    /// a full-set equality would pass today. It is not asserted anyway:
+    /// `SettingsView`'s `.onAppear` reconciles `taskEtaActivation` and
+    /// `backchannelActivation` against the daemon (SettingsView.swift:413-452)
+    /// inside a `Task`, and those write `@AppStorage` keys whenever the daemon
+    /// answers before the assertion runs. Pinning the whole set would make this
+    /// a timing assertion dressed as a preference one, and its failures would
+    /// name a race rather than #1672. The general "no app code writes the
+    /// process domain directly" claim is `PersistentDefaultsLintTests`' third
+    /// rule; this arm is #1672's own. The failure message prints the whole set
+    /// regardless, so a surprise there is still legible.
+    func testRenderingTheNotificationRowsPersistsNoSoundChoice() {
+        let store = InMemoryDefaults()
+        let host = renderSettingsPanel(store)
+        XCTAssertFalse(host.view.subviews.isEmpty,
+                       "the panel hosted nothing — this check cannot have run")
+
+        for key in Self.soundKeys.sorted() {
+            XCTAssertTrue(
+                store.readKeys.contains(key),
+                "the rows never read \(key) from the pinned store, so 'nothing was written' "
+                + "proves nothing — either the section stayed collapsed or the row is "
+                + "resolving UserDefaults.standard")
+        }
+
+        XCTAssertEqual(
+            store.writtenKeys.intersection(Self.soundKeys), [],
+            """
+            Rendering the notification rows PERSISTED a sound choice — a value \
+            the user never picked. In the app that lands in their real \
+            io.irrlicht.app domain; under `swift test` it lands in the \
+            developer's com.apple.dt.xctest.tool, which is where #1672 found \
+            soundOnReady = funk and soundOnContextPressure = sosumi. Everything \
+            this render wrote: \(store.writtenKeys.sorted()).
+            """
+        )
+    }
 }

--- a/platforms/macos/Tests/SettingsViewTests.swift
+++ b/platforms/macos/Tests/SettingsViewTests.swift
@@ -15,23 +15,38 @@ final class SettingsViewTests: XCTestCase {
     // samples the four corners + center of the resulting bitmap, and asserts
     // every sampled pixel is fully opaque.
     func testSettingsViewBackgroundIsOpaque() throws {
+        // Hosted through `PinnedSnapshotHost` rather than a bare
+        // `NSHostingView`, and that is #1672 rather than tidiness. This is the
+        // one test in the suite that renders `SettingsView`, so before the fix
+        // it was the run that persisted `soundOnReady = funk` and
+        // `soundOnContextPressure = sosumi` into the developer's real
+        // `com.apple.dt.xctest.tool` domain. The row no longer writes on
+        // render, but this render is also the only thing driving
+        // `reconcileNotificationsMasterDefault()` and the daemon reconciles at
+        // SettingsView.swift:413-452, each of which writes an `@AppStorage`
+        // key — so the domain the writes CAN reach is pinned here too, instead
+        // of the fix resting on one call site staying quiet.
+        //
+        // The host also pins dark aqua (its default), which is what this test
+        // set by hand: `NSColor.windowBackgroundColor` then resolves
+        // deterministically. The test verifies opacity, not hue, but
+        // appearance-pinning keeps the render stable across themes.
+        //
         // SettingsView requires its environment objects (crashes without
         // them). startingUpdater: false keeps Sparkle from starting its
         // update cycle, which would fail outside an app bundle.
+        let store = InMemoryDefaults()
         let view = SettingsView(isPresented: .constant(true),
                                 showPermissionsReview: .constant(false),
-                                sessionManager: SessionManager())
+                                sessionManager: SessionManager(defaults: store))
             .environmentObject(UpdateManager(startingUpdater: false))
             .environmentObject(DaemonManager())
-        let hosting = NSHostingView(rootView: view)
-        // Pin to dark aqua so NSColor.windowBackgroundColor resolves
-        // deterministically — the test verifies opacity, not hue, but
-        // appearance-pinning keeps the render stable across themes.
-        hosting.appearance = NSAppearance(named: .darkAqua)
         // SettingsView pins its width to SessionListView.panelWidth (issue
         // #940 — shared with History/the session list) and its own 520 height.
-        hosting.frame = CGRect(x: 0, y: 0, width: SessionListView.panelWidth, height: 520)
-        hosting.layoutSubtreeIfNeeded()
+        let hosting = PinnedSnapshotHost(view,
+                                         width: SessionListView.panelWidth,
+                                         height: 520,
+                                         defaults: store).view
 
         guard let bitmap = hosting.bitmapImageRepForCachingDisplay(in: hosting.bounds) else {
             XCTFail("bitmapImageRepForCachingDisplay returned nil")


### PR DESCRIPTION
Closes #1672.

## The call site, proven

`NotificationEventRow.handle(_:)` — `SettingsView.swift:987` pre-fix — driven by
`.onAppear { loadFromDefaults() }` through `.onChange(of: selection)`. The row
had three pieces that form a loop:

```swift
@State private var selection: SoundChoice = .default              // .ping
.onAppear { loadFromDefaults() }                                  // selection = stored/registered value
.onChange(of: selection) { handle($0) }                           // UserDefaults.standard.set(...)
```

The load is itself a change, so merely **rendering** the row wrote back the
value it had just read.

Not inferred — measured. `handle(_:)` and `loadFromDefaults()` were
instrumented with a `print` (probe applied, run, reverted; the tree was
`git status --porcelain`-clean afterwards) and `swift test --filter
SettingsViewTests` produced:

```
IRRPROBE1672 load key=soundOnContextPressure storeRaw=sosumi selectionBefore=ping
IRRPROBE1672 load key=soundOnWaiting        storeRaw=ping   selectionBefore=ping
IRRPROBE1672 load key=soundOnReady          storeRaw=funk   selectionBefore=ping
IRRPROBE1672 handle key=soundOnContextPressure newValue=sosumi
IRRPROBE1672 handle key=soundOnReady          newValue=funk
```

Two `handle` lines, and the third event's absence explained in the same output:
`.waiting`'s `defaultSound` is `.ping`, which **is** `SoundChoice.default`, so
its load changed nothing and `.onChange` never fired. `soundOnReady = funk` and
`soundOnContextPressure = sosumi`, `soundOnWaiting` absent — exactly the key set
the issue reports.

`SettingsViewTests.testSettingsViewBackgroundIsOpaque` is the whole driver: it
is the only test in the suite that renders `SettingsView` (`git grep 'SettingsView('
-- Tests` returns one hit).

### Where the issue's reasoning went wrong, since it matters for the next one

The issue rules this out as "not supported", on two correct measurements:

- **`soundOnWaiting` is still absent.** True, and it is what this mechanism
  PREDICTS. The hypothesis it falsifies is "every rendered row writes its default
  back"; the real rule is one step narrower — every row whose `defaultSound`
  differs from `SoundChoice.default`.
- **The SettingsView-only run left the plist mtime unchanged (`1786919878`).**
  Also true, and re-measured here: the write is **idempotent**. Both keys were
  already in the domain at their written values, so `cfprefsd` had nothing to
  dirty. My own instrumented run left that domain byte-identical and its mtime at
  `1786919878` **while the probe printed the two writes**, which is the two facts
  standing side by side.

A dismissal can be right about what it ran and wrong about what that excludes.
What settled it was instrumenting the call site, not a better inference.

## Does it predate the branch? Yes — proven

`git blame` puts `@State private var selection: SoundChoice = .default` at
**d2f75a95, 2026-05-14** ("feat(macos): selectable notification sounds per event
(#253) (#327)"), and `git log -L` confirms that commit introduced the line.
`.onAppear`/`.onChange`/`handle`/`loadFromDefaults` are all from the same commit.
That is three months before #1662, so the issue's "a concurrent `swift test`
from another worktree is an equally good explanation" is now excluded: the write
is in code that has been on `main` since May.

## Production impact, not only fixture hygiene

This is the same defect #1673's `Published(initialValue:)` trap was, one layer
up: in the app, **opening Settings persisted two sound preferences the user never
chose** into their real `io.irrlicht.app` domain. Any user who ever opened the
Notifications section has `soundOnReady` and `soundOnContextPressure` written
into their application domain, where they were meant to stay in the in-memory
registration domain and follow future default changes. `swift test` was the
messenger.

## The fix, and why that seam

Remove the second copy rather than guard the write-back — the move #1673's PR
states and #1662's whole argument rests on ("removing the state, not unwinding it
more carefully"). The row is now `@AppStorage` over its own key:

- `storedSound` is an `@AppStorage` built in `init` (the key is per-event, so it
  cannot be a literal). `wrappedValue:` is what an unset key READS as; it is not
  written.
- `selection` is **derived** on every render. There is nothing to load, so a
  render has nothing to write back.
- The Picker takes a `Binding` whose `set` is the only write path in the row, and
  runs only for a pick that came from the control.

Three reasons this seam and not another:

1. **No product seam was needed.** `@AppStorage` honours SwiftUI's own
   `.defaultAppStorage(_:)`, which `PinnedSnapshotHost` already applies — so the
   row inherits #1662's pin for free and becomes testable without a new
   parameter. Compare the two siblings that needed one: `format: .number` ignores
   `\.locale` (#1630) and a file-scope `DateFormatter` is reachable from no view
   (#1659).
2. **It is narrower than the alternative.** A guard flag (`isLoading`) or an
   optional `@State` would have kept the loop and made it depend on SwiftUI's
   update ordering — precisely the "more careful unwinding" this family rejects.
3. **The sentinel path got simpler, not more complex.** `customPickerSentinel`
   is not persisted, and `get` still answers the previous choice while the open
   panel runs, so the control reverts on its own. The old code needed an explicit
   `selection = previous` assignment for that.

`pickCustomFile` takes the binding, so the custom-import success path writes the
same one store.

## Closing the gap the source lint structurally cannot see

Three parts, in decreasing order of how much they cover.

**A third rule in `PersistentDefaultsLintTests`: the existing
`UserDefaults.standard`-mutation scan, over the APP target.** This is the
structural answer to "a production write a test drives" — the offending line
lives in a file a test-source scan does not read. Same `mutatingLines(in:)`
regex, same committed corpus (both verdicts, including the declared line-scan
limits), one parameterised walk so the two scans cannot drift. Measured: the app
target contains **zero** such mutations after this change, so the rule carries no
exemption list.

**`InMemoryDefaults.writtenKeys` and `.readKeys`.** `writtenKeys` reports the
application domain only, and that exclusion is the point:
`SessionManager.init`'s `register(defaults:)` seeds all three sound keys, so
`object(forKey:)` and `dictionaryRepresentation()` — which merge the two domains
— answer non-nil whether anything persisted or not. That is the same property
that made the write invisible on a real domain. `readKeys` is the vacuity guard:
a row that never rendered (the master gate is collapsed by default) and a row
still resolving `UserDefaults.standard` both write nothing too.

**`testRenderingTheNotificationRowsPersistsNoSoundChoice`** renders
`SettingsView` through `PinnedSnapshotHost` and asserts the rows read all three
keys from the pinned store and persisted none of them. It is scoped to the sound
keys on purpose: a clean render writes exactly `["notificationsEnabled"]` (the
key the test seeds itself, measured), but `SettingsView`'s `.onAppear` reconciles
`taskEtaActivation` and `backchannelActivation` against the daemon inside a
`Task`, so a whole-set equality would be a timing assertion dressed as a
preference one. The failure message prints the whole set regardless.

**`SettingsViewTests` now hosts through `PinnedSnapshotHost`.** Defence in depth
rather than trust in one call site staying quiet: that render also drives
`reconcileNotificationsMasterDefault()` and the two daemon reconciles, each of
which writes an `@AppStorage` key. Pinning the store means the fix does not rest
on the row alone.

### The runtime witness: recommended, deferred, with the measurement

The issue's "concrete next step" was extending `tools/lib/swift-suite.sh`'s
witness from new FILES to named domains' KEY SETS. Filed as **#1688** rather
than done here, for two reasons stated honestly:

- **`tools/lib/` was being actively rewritten by #1684** (branch
  `feat/1684-bash-lint-gate`, open and assigned, no PR yet). Two agents editing
  `tools/lib/*.sh` concurrently is how a lint gate and a witness overwrite each
  other. Deferred on concurrency, not on merit.
- **Noise floor: 0 additions across two windows.** `com.apple.dt.xctest.tool`
  held 18 keys, byte-identical, across a full 404-test run and again across a
  filtered run. That is far quieter than the directory witness's measured
  background rate (~1 new plist per 218s of active use), because a preference
  domain is only written by processes that own it. So it is cheap and needs no
  allowlist — **recommended**.
- **But it would not have caught this bug on the machine that found it**, and
  #1688 says so in its own body. A growth-only check is blind to a domain whose
  key set is already saturated: both keys were present before the run that wrote
  them again. Its value is the FIRST occurrence on a fresh domain — a CI runner, a
  new machine, a newly added key.

## Before / after key sets for `com.apple.dt.xctest.tool`

The honest framing first: **a clean baseline for this domain was not obtainable,
and that is a hard constraint rather than an omission.** The two keys are already
in the developer's real domain, and the only ways to clear them are
`defaults delete` on a real domain (forbidden after #1661) or redirecting the
preferences root — which `InMemoryDefaults`' own doc comment records as measured
and ineffective, and which I re-confirmed: `CFFIXED_USER_HOME` and `HOME` both
leave `defaults read` resolving the real home, because `cfprefsd` runs outside
the client's environment. So the domain comparison below can only show
"unchanged", and "unchanged" is what an idempotent write looks like too.

| | key count | keys |
|---|---|---|
| baseline (before any run of mine) | 18 | includes `soundOnContextPressure = sosumi`, `soundOnReady = funk`; **no** `soundOnWaiting` |
| after the instrumented **pre-fix** run | 18 | byte-identical, mtime `1786919878` — *while the probe printed two writes* |
| after a full **post-fix** 404-test run | 18 | byte-identical, mtime `1786919878` |
| after gate run #1 | 18 | byte-identical |
| after gate run #2 | 18 | byte-identical |

So the *decisive* before/after is the instrumented one, on the code path itself:

| | probe lines |
|---|---|
| pre-fix, `--filter SettingsViewTests` | `handle key=soundOnReady newValue=funk`, `handle key=soundOnContextPressure newValue=sosumi` |
| post-fix, **full 404-test suite** | **none** — the row's only remaining write (`Binding.set`) was instrumented and never executed |

The in-repo equivalent of the clean baseline is the empty `InMemoryDefaults` in
`testRenderingTheNotificationRowsPersistsNoSoundChoice`: it starts with no sound
key at all and ends with none.

## Mutation evidence

Everything added passes by construction, so each was broken deliberately and
seen red. One mutation per foreground command, applied by copy-aside and
reverted by copy-back, with `git status --porcelain` asserted afterwards each
time (5 modified files, no more, no fewer).

| # | Mutation | Result |
|---|---|---|
| M1 | restore `SettingsView.swift` to its pre-fix state | **RED** — the new app-target lint reports exactly `Irrlicht/Views/SettingsView.swift:987` and `:1004`, and the new render test's vacuity guard reports `the rows never read soundOnReady from the pinned store … the row is resolving UserDefaults.standard` for all three keys |
| M2 | re-add the write-back loop through the NEW seam (`.onAppear { storedSound = selection.rawValue }`) | **RED** — `Rendering the notification rows PERSISTED a sound choice`, naming all three keys, with the full written set printed |
| M3 | drop the test's `notificationsEnabled` seed, so the master gate stays collapsed | **RED** — the `readKeys` vacuity guard fires on all three keys, which is the accident it exists for |
| M4 | make `writtenKeys` merge the registration domain (i.e. what `object(forKey:)` already answers) | **RED** — reports all three sound keys plus the entire `SessionManager` seed, which is the measurement behind "only the key set of the application domain can tell these apart" |
| — | (not planted) the pre-fix probe run | the instrumented `handle` naming two of three keys — see above |
| — | (not planted) the post-fix probe run | zero write-path calls across 404 tests |

M1 is also the red-first for the fix itself: the new render test **fails on the
pre-fix tree**, for the right reason and with the right message.

Not reddened, and named rather than implied: **"a pick still persists" has no
test.** `NotificationEventRow` is `private` and driving a SwiftUI `Picker` from
XCTest is not available here, so that direction is held by the type — the
Picker's only binding is `soundBinding`, whose `set` is the row's only write —
and not by an assertion. The read direction IS covered, by `readKeys`.

## Gates

- `tools/preflight.sh --only swift` — **PASS**, twice, exit status read directly
  (redirected to a file, `$?` on the next line — never through a pipe). 404
  tests, 0 failures, and the bundle reported its own result both times. Per #1523
  the exit code is the signal, not the totals line.
- The pre-push hook ran `--changed`: `gofmt` PASS, `macOS Swift build + test`
  PASS, every other gate correctly SKIP for a `platforms/macos/` + `AGENTS.md`
  diff.
- `tools/preflight.sh --only tools` — **not run, and not owed**: this diff
  touches nothing under `tools/` (`git diff --stat` is `AGENTS.md` plus
  `platforms/macos/**`). The witness that would have touched it is #1688.
- CodeScene / ARS are advisory per AGENTS.md and were not chased.

## What my own work left behind: nothing

- `swift-suite.sh`'s real-home witness: `no new entries in Library/Preferences
  Library/Sounds under /Users/ingo`, on both gate runs.
- `~/Library/Preferences` listing: **byte-identical** across a bracketed gate run.
- `~/Library/Preferences/io.irrlicht.app.plist`: `mtime 1786965780, 135 B` before
  and after a bracketed gate run.
- `~/Library/Preferences/com.apple.dt.xctest.tool.plist`: `mtime 1786919878, 631 B`
  throughout — unchanged by every run in this PR, including the pre-fix ones.
- `~/Library/Sounds`: 2 entries before and after.
- Nothing in this work deletes, moves, or overwrites anything under the real
  home. No `defaults write` or `defaults delete` was run against any real domain;
  every destructive experiment was a copy-aside/copy-back inside the worktree.

## New defects filed

- **#1688** — extend `swift-suite.sh`'s witness from new FILES to named domains'
  key SETS (the issue's own next step; carries the noise-floor measurement and
  the saturation limit above).
- **#1689** — `SettingsView.reconcileNotificationsMasterDefault()` decides from
  `UserDefaults.standard` while writing through the pinned `@AppStorage` store,
  so under a pinned render the decision comes from the machine and the write goes
  elsewhere. Inert on this machine (the key is present, so the guard returns
  early — measured); live on a fresh domain. Filed separately because it needs a
  product seam (`@AppStorage` cannot express "absent") and this fix needed none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
