### PR TITLE
feat(tools): lint the 83 bash scripts no static linter had ever read (#1684)

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -54,6 +54,48 @@ jobs:
       - name: Test the POSIX-sh gate
         run: bash tools/lib/posix-lint_test.sh
 
+      # BASH gate (#1684) — the sibling of the two steps above, over the OTHER
+      # shell family. 83 bash files / ~19k lines that no static linter read at
+      # all: the bounded gate runner (tools/lib/gate-budget.sh), the pre-push
+      # hook's own scoping rules (changed-files.sh), the shared suite runner and
+      # every extract-and-execute workflow lock. posix-lint.sh selects on a
+      # `#!/bin/sh` FIRST LINE, deliberately (#1611), so every bash file fell
+      # outside it — the same file-selection blindness class as #1423 and #1611.
+      #
+      # THIS JOB IS THE HOST FOR A DIFFERENT REASON THAN posix-lint.sh's, and
+      # the difference matters. That gate needs ubuntu because `/bin/sh` must
+      # genuinely BE dash here — the property under test is a property of the
+      # runtime. shellcheck is a static analyser over the bash language and
+      # reads no interpreter at all: measured, a 0.9.0 x86_64 binary under
+      # Rosetta on arm64 macOS and a native arm64 0.11.0 return byte-identical
+      # findings at this gate's severity floor, so neither the OS nor the arch
+      # enters the verdict. What picks this job is only that the ubuntu image
+      # ships shellcheck (0.9.0) and macos-latest ships none, so hosting it in
+      # test.yml would `brew install` one on every PR.
+      #
+      # The version split is why the floor is `warning` and not `style`: at
+      # `warning` all of 0.9.0 / 0.10.0 / 0.11.0 agree byte-for-byte over the
+      # whole corpus, while at `style` this runner's 0.9.0 reports 138 findings
+      # a developer's 0.11.0 cannot produce (137 × SC2317) against 25 the other
+      # way (SC2329) — a preflight that passes a diff this job rejects, which is
+      # the round-trip posix-lint.sh's monotonicity argument exists to prevent.
+      # tools/bash-lint.sh's header carries the full measurement.
+      #
+      # Runs before setup-go for the same reason as the two above: no toolchain,
+      # a couple of seconds, and behind the Go steps a compile error would abort
+      # the job and leave a tooling-only PR with no tooling feedback.
+      - name: Lint bash scripts
+        run: tools/bash-lint.sh
+
+      # The gate's own unit tests, over the deliberately-broken corpus under
+      # tools/lib/testdata/bash-lint/. Here rather than in test.yml's
+      # `tools/lib/*_test.sh` loop for the same reason posix-lint_test.sh is:
+      # they need shellcheck, and the macos image ships none. A gate that passes
+      # by construction is what #1684 is about, so the mutation corpus has to
+      # run somewhere — this is where it can.
+      - name: Test the bash-lint gate
+        run: bash tools/lib/bash-lint_test.sh
+
       - name: Set up Go
         uses: actions/setup-go@v7
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -115,6 +115,13 @@ jobs:
       # ARGUMENT rather than as a `case` pattern in a copied loop is what makes
       # it fail loudly if it ever stops matching a real file.
       #
+      # bash-lint_test.sh (#1684) is skipped for exactly the same reason — it
+      # drives tools/bash-lint.sh, which refuses without shellcheck — and
+      # linux.yml runs both it and its gate. It is a SECOND argument rather than
+      # a second loop, and shell_lib_suite_run validates every name in the list
+      # against the corpus before running anything, so a skip that stopped
+      # matching a real file is a refusal rather than a quiet no-op.
+      #
       # `|| rc=$?` rather than a bare call: it is the spelling that keeps the
       # status under the `-e` above (`|| true` would not — it hands back
       # `true`'s status, silently reporting every failing run as 0).
@@ -122,5 +129,5 @@ jobs:
         run: |
           rc=0
           . tools/lib/shell-lib-suite.sh
-          shell_lib_suite_run tools/lib posix-lint_test.sh || rc=$?
+          shell_lib_suite_run tools/lib posix-lint_test.sh bash-lint_test.sh || rc=$?
           exit "$rc"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -912,6 +912,83 @@ Before marking a ticket done, run the full suite — every layer must pass:
   `install-uninstall_test.sh` now *executes* the installer under `dash` rather
   than `sh` (macOS ships `/bin/dash`), which is the runtime half — it reaches
   only the lines a case runs, where the linter reads every line.
+- Bash scripts: `tools/bash-lint.sh` runs `shellcheck --shell=bash
+  --severity=warning` over every file git knows about — tracked, plus untracked
+  and not gitignored — whose **first line** is a bash shebang. 83 files /
+  ~19k lines, and until #1684 **no static linter read one of them**: the bullet
+  above selects on `#!/bin/sh` line 1, deliberately (#1611), so every bash file
+  fell through — including the bounded gate runner (`gate-budget.sh`), the
+  pre-push hook's own scoping rules (`changed-files.sh`), the shared suite
+  runner and every extract-and-execute workflow lock, i.e. the machinery
+  deciding whether the other gates pass. Same file-selection blindness class as
+  #1423 and #1611. It found 26 findings, all fixed or annotated.
+  Four decisions are load-bearing and each was measured rather than preferred.
+  - **DEFAULT-IN, opt-out with a reason.** The scope is not a prefix list — it
+    is everything, minus three declared `EXCLUDE` globs each carrying its
+    justification, and an exclusion that matches NOTHING is a hard refusal
+    (exit 2) rather than a no-op, the same both-directions existence check
+    `TW_EXEMPT_KEYS` and `nilTolerant` get. So a bash file added anywhere is
+    covered by existing, and the two families that are out — the
+    deliberately-corrupt `testdata/` corpora, and the recording rig's per-agent
+    drivers plus their `.tmpl` (#1687: 79 findings, and one file whose analysis
+    shellcheck silently ABANDONS) — are out visibly.
+  - **A severity FLOOR, not posix-lint's named code set**, and the reason the
+    precedent was not followed is that SC3xxx is a closed family by definition
+    while "bugs in bash" is not: an opt-in code list is not enforced on a code
+    shellcheck adds later. The floor is `warning` because that is where the
+    VERSION SPLIT vanishes. Measured per-file over the whole corpus with 0.9.0,
+    0.10.0 and 0.11.0 binaries side by side: at `warning` all three are
+    **byte-identical** (26 findings, same line:col); at `style` they are not,
+    and the asymmetry runs in BOTH directions with the damage on the CI side —
+    138 findings CI's 0.9.0 reports which a local 0.11.0 cannot produce
+    (137 × SC2317) against 25 the other way (SC2329). A `style` floor would
+    make `preflight --only bash` pass a diff linux.yml rejects, the exact
+    round-trip posix-lint's monotonicity argument exists to prevent. `-x`
+    (external sources) is off, also measured: these libraries source through
+    variable paths, so it changed the count by zero.
+  - **ONE FILE PER INVOCATION.** Measured: shellcheck given several files at
+    once suppresses SC2034 for a name used in ANY of them — one file alone
+    reports 2 findings, the same file beside `await-gone.sh` reports 0. A
+    multi-file gate's verdict would depend on which other files shared the
+    command line, which `--changed` scoping makes differ between a push and
+    CI's full run. It is also why the count is 26 where a single multi-file run
+    over the same tree says 15.
+  - **A comment line whose FIRST word is the linter's name is a DIRECTIVE**, and
+    an unparseable one makes shellcheck ABANDON the file — every later finding
+    silently disappears. That is inside the floor (SC1072/SC1073 are `error`)
+    for the same reason `posix-lint.sh` refuses to filter its parse-abort codes
+    into silence, and it is the gate's most valuable rule: it caught the
+    construct **four times in this PR's own new prose**, and
+    `replaydata/_lib/drive/contracts.sh` has been carrying it unnoticed (#1687 —
+    rewording that one line surfaces an SC2005 the file currently hides). The
+    sibling SC1125 is the `# shellcheck disable=SCxxxx — <prose>` spelling; the
+    disable IS still honoured (measured on both versions), but the reason must
+    go behind a second `#`.
+  The sanctioned escape hatch is a per-SITE `# shellcheck disable=SCxxxx  #
+  <reason>` naming its consumer's `file:line` — all 17 SC2034s are that, each
+  verified to have a real reader — and never a code removed from the gate.
+  A directive covers only the NEXT command, so four adjacent knob assignments
+  need four.
+  It lives in **`linux.yml`** beside `posix-lint.sh`, but for a DIFFERENT
+  reason, and the difference is the decision: posix-lint needs ubuntu because
+  `/bin/sh` must genuinely BE dash there — a property of the runtime — whereas
+  shellcheck is a static analyser that reads no interpreter, so neither the OS
+  nor the arch enters the verdict (the 0.9.0 measurement above was taken from an
+  x86_64 binary under Rosetta on arm64 macOS and agrees byte-for-byte with a
+  native arm64 0.11.0). What picks the host is only that the ubuntu image ships
+  shellcheck and macos-latest ships none. Mirrored locally by
+  `tools/preflight.sh --only bash`. Its tests are `tools/lib/bash-lint_test.sh`
+  over the committed corpus under `tools/lib/testdata/bash-lint/` — one
+  deliberately-broken fixture per rule class, `good-clean.sh` as the vacuity
+  guard, `style-noisy-but-warning-clean.sh` pinning the floor in the one
+  direction the `bad-*` files cannot reach, and the abandonment fixture proved
+  by REWORDING its directive line and asserting the hidden SC2115 appears.
+  That suite runs in `linux.yml`, not in test.yml's `tools/lib/*_test.sh` loop —
+  it needs a linter the macOS image lacks, and it is the loop's SECOND skip
+  argument. `shell-lib-suite_test.sh` now derives that list from the workflow
+  step and existence-checks every name, because the one-file check it had would
+  have gone on passing while saying nothing about the new entry.
+
 - Sourced shell libraries: not a contract family — a tripwire,
   `tools/lib/shell-lib-errexit_test.sh`, over every `tools/lib/*.sh` that is
   not a `*_test.sh`. Each function it can drive must, under a caller's
@@ -1647,8 +1724,8 @@ it once instead of round-tripping through GitHub Actions per fix. Gates run
 **cheapest first**, in two phases, not in "CI's order": there is no single CI
 order to mirror, since those are separate workflows GitHub runs concurrently,
 and the order is load-bearing under `--budget` (below) because it decides which
-gates survive a squeeze. `skill-file lint` and `POSIX sh lint` are the only
-coverage their file families have and cost a fraction of a second each, so they
+gates survive a squeeze. `skill-file lint`, `POSIX sh lint` and `bash lint` are the
+only coverage their file families have and cost a second or two each, so they
 run before four minutes of `go test` — which is the argument test.yml already
 makes in-file for running the skill lint before `setup-go`.
 
@@ -1658,6 +1735,7 @@ tools/preflight.sh --linux        # + full Linux parity (slow: needs Docker)
 tools/preflight.sh --only go      # just the test.yml-equivalent gates
 tools/preflight.sh --only arch    # just the ARS architecture gate
 tools/preflight.sh --only skills  # just the .claude/skills/**/*.md linter
+tools/preflight.sh --only bash    # just the shellcheck lint over bash scripts
 tools/preflight.sh --only swift   # just the macOS Swift build + test suite
 tools/preflight.sh --budget 540   # bound the whole run; see "The budget" below
 ```
@@ -1667,7 +1745,7 @@ debugging convenience — the unscoped run does not reliably fit a foreground
 `Bash` call's 600s budget** (it reliably exceeds it on this machine; the long
 pole is the `go` group's core suite + replay fixtures). Run each group as its
 own **foreground** invocation instead of the single unscoped command:
-`tools/preflight.sh --only go|web|arch|tools|skills|posix|security|swift` (see
+`tools/preflight.sh --only go|web|arch|tools|skills|posix|bash|security|swift` (see
 `tools/preflight.sh --help` for the current group list; `linux` stays opt-in
 and needs Docker). Every gate still runs — chunking only changes how many
 invocations it takes. **Do not background the unscoped run to make it fit**:

--- a/examples/coding-factory/drive.sh
+++ b/examples/coding-factory/drive.sh
@@ -27,7 +27,7 @@ turns() {
 # Truncates the log so banner-detection doesn't match an old run.
 boot_codex() {
   tmux kill-session -t "$SESSION" 2>/dev/null || true
-  > "$LOG"   # fresh log so 'OpenAI Codex' detection doesn't hit the old banner
+  : > "$LOG" # fresh log so 'OpenAI Codex' detection doesn't hit the old banner
 
   # --no-alt-screen keeps codex inline so tmux pipe-pane can capture it (alt-screen
   # would clear the pane and hide the banner/trust prompt).

--- a/tools/bash-lint.sh
+++ b/tools/bash-lint.sh
@@ -1,0 +1,371 @@
+#!/usr/bin/env bash
+# bash-lint.sh — run a static analyser over every BASH script this repo ships.
+#
+# WHY THIS EXISTS (#1684). `tools/posix-lint.sh` selects files whose FIRST LINE
+# is a `#!/bin/sh` shebang, deliberately and for a good reason (#1611 — a
+# content grep would try to lint a bash file that writes `#!/bin/sh` stubs
+# inside a heredoc). The consequence was that every `bash` file in the repo sat
+# outside every static linter here: measured at the time this was written,
+# 23 files / 8,431 lines under `tools/lib/` alone, including the bounded gate
+# runner (`gate-budget.sh`), the pre-push hook's scoping rules
+# (`changed-files.sh`), the shared suite runner (`shell-lib-suite.sh`), the
+# workflow-step resolver and the Swift harness. That is the machinery that
+# decides whether every OTHER gate passes, and nothing read it.
+#
+# It is the same file-selection blindness class as #1423 and #1611: a gate
+# whose selection rule silently excludes a whole family reads exactly like a
+# gate that passed. So this one is DEFAULT-IN — every bash file git knows
+# about is linted unless a declared exclusion says otherwise, with a reason,
+# and an exclusion that stopped matching anything is a hard refusal rather
+# than a silent no-op (see EXCLUDE below). A bash file added anywhere in the
+# repo is covered by existing rather than by someone remembering to widen a
+# prefix list.
+#
+# WHAT IT FOUND when it was first run over the corpus it now guards — 26
+# findings over 81 files / 18,304 lines, all fixed or annotated in the PR that
+# added this file:
+#
+#     SC2034 ×17 variable assigned and never used *in this file*. Every one a
+#                genuine cross-file seam (a knob a sourced library reads, an
+#                output variable a caller reads, an env var the daemon reads),
+#                so every one is a per-SITE disable naming its consumer's
+#                file:line — never a code deleted from the gate.
+#     SC2115 ×2  `rm -rf "$NOLIB/lib"` → `rm -rf /lib` when the var is empty.
+#                `set -u` does NOT catch an empty variable, and `$(mktemp -d)`
+#                yields empty on failure. This shape is why the issue was filed.
+#     SC2209 ×2  `kind=file` — a FALSE POSITIVE, and checked rather than
+#                assumed: the assertion two lines down compares against the
+#                literal `"file"`, so the string is what was meant; shellcheck
+#                reads it as a missing `$(…)` because `file(1)` is a command.
+#     SC2164 ×2  `cd "$DIR"` with no `|| exit`, in preflight.sh and
+#                security-scan.sh — both of which then run every gate against
+#                whatever tree the caller happened to be in.
+#     SC1087 ×1  `$agent[` read as an array expansion.
+#     SC2155 ×1  declare-and-assign masking a return value.
+#     SC2188 ×1  `> "$LOG"` — a redirection with no command.
+#
+# ONE FILE AT A TIME, and that is not an implementation detail. Measured: given
+# several files in ONE invocation, shellcheck suppresses SC2034 for a name used
+# in ANY of them — `shellcheck tools/lib/swift-suite_test.sh` reports 2
+# findings, `shellcheck tools/lib/swift-suite_test.sh tools/lib/await-gone.sh`
+# reports 0. A multi-file gate's verdict would therefore depend on which OTHER
+# files happened to be in the same command, which under `--changed` scoping
+# differs between a developer's push and CI's full run. Per-file is the only
+# deterministic choice, and it is why the count above is 26 where a single
+# multi-file invocation over the same tree reports 15.
+#
+# ─── THE SEVERITY FLOOR IS `warning`, AND THAT IS A MEASUREMENT ─────────────
+#
+# `tools/posix-lint.sh` filters shellcheck's output to a NAMED CODE SET rather
+# than a severity band, so general style debt cannot be dragged into a gate
+# about POSIX compatibility. That precedent was weighed and deliberately not
+# followed here, because the two gates want different things: SC3xxx is a
+# closed family by definition ("In POSIX sh, X is undefined"), whereas "bugs in
+# bash" has no such family — an opt-in list of codes means a code shellcheck
+# adds later is not enforced until someone remembers to add it, which is the
+# "covered by remembering" shape AGENTS.md argues against throughout. A
+# severity FLOOR is covered by existing: `error` and `warning` codes added by a
+# future shellcheck are enforced the day the runner's image bumps.
+#
+# What the floor has to survive is a VERSION SPLIT: CI's ubuntu image ships
+# 0.9.0, a developer's brew ships 0.11.0. Measured per-file over the whole
+# in-scope corpus (81 files / 18,304 lines at the commit this landed on), with
+# 0.9.0 and 0.10.0 binaries fetched from koalaman's releases and run beside the
+# local 0.11.0:
+#
+#     -S warning   0.9.0 → 26   0.10.0 → 26   0.11.0 → 26   BYTE-IDENTICAL
+#     -S style     0.9.0 → 312  0.10.0 → 312  0.11.0 → 199  163 disagreements
+#
+# At `warning` the version asymmetry runs in NEITHER direction: same codes, same
+# files, same line:col, across two minor versions. At `style` it runs in BOTH,
+# and dominantly in the direction that hurts — 138 findings CI's 0.9.0 reports
+# which a local 0.11.0 cannot even produce (137 × SC2317 "command appears
+# unreachable", plus one SC2015), against 25 the other way (SC2329 "function
+# never invoked", which 0.9.0 does not have). A developer's
+# `tools/preflight.sh --only bash` would be green while linux.yml went red on
+# 138 findings their own shellcheck does not implement — the round-trip that
+# posix-lint.sh's monotonicity argument exists to prevent, running in the worse
+# of the two directions. So `style` is out of scope on evidence rather than on a
+# guess about noise, and the floor is the band where three versions provably
+# agree.
+#
+# `--external-sources` (`-x`) is OFF, also measured: these libraries are
+# sourced through variable paths (`. "$DIR/await-gone.sh"`), which shellcheck
+# cannot resolve without a `source-path`, so `-x` changed the finding count by
+# exactly zero. It is not on because it would buy nothing while making the
+# verdict depend on the caller's cwd.
+#
+# The escape hatch is a per-SITE `# shellcheck disable=SCxxxx` carrying a
+# reason, which is a reviewable diff at the place the exemption applies. There
+# is deliberately no repo-wide code-exclusion list — the same choice
+# `core/architecture_test.go` and `core/architecture_hookbody_test.go` make.
+# Note the spelling: the reason goes behind a SECOND `#`. Measured on both
+# 0.9.0 and 0.11.0, `# shellcheck disable=SC2034 — reason` still applies the
+# disable but reports SC1125 at ERROR severity for the trailing prose, so this
+# gate rejects it — which is how eight such directives in replaydata/ were
+# found.
+#
+# WHERE IT RUNS. `.github/workflows/linux.yml`'s `build-test` job, beside
+# `posix-lint.sh`, because that image already ships shellcheck. The reason is
+# NOT the one posix-lint has, and the difference matters: posix-lint needs
+# ubuntu because `/bin/sh` must genuinely BE dash there, i.e. the property
+# under test is a property of the runtime. shellcheck is a static analyser over
+# the bash language and reads no interpreter at all — the measurements above
+# were taken with a 0.9.0 x86_64 binary under Rosetta on arm64 macOS and agree
+# byte-for-byte with a native arm64 0.11.0, so neither the OS nor the arch
+# enters the verdict. What picks the host is purely that macos-latest ships no
+# static linter at all, so hosting this in test.yml would have to
+# `brew install` one on every PR. Mirrored locally by
+# `tools/preflight.sh --only bash`.
+#
+# A NOTE ON THIS FILE'S OWN COMMENTS, which is not trivia. A comment line whose
+# FIRST word after `#` is the linter's name is parsed as a DIRECTIVE, and an
+# unparseable one (SC1072/SC1073) makes it ABANDON the file — every later
+# finding silently disappears. This header tripped exactly that on its first
+# run, and `replaydata/_lib/drive/contracts.sh` has been carrying it unnoticed
+# (measured: rewording that one line surfaces an SC2005 the file currently
+# hides). So never open a comment line with that word — and note that the gate
+# below catches it, because an abandoned analysis reports SC1072/SC1073 at
+# ERROR severity and therefore fails rather than reading as clean.
+#
+# NEVER SILENTLY PASSES. Four ways out are hard refusals (exit 2), not skips:
+# no shellcheck, an empty in-scope file set, an exclusion rule that matches
+# nothing, and a file git listed that cannot be opened. And a shellcheck that
+# exits >1, or exits 1 while printing nothing, is reported as a failure to
+# CHECK rather than as a clean file — that is #1423's founding incident, where
+# a linter that failed to run printed `ALL PASS` over an installer carrying a
+# deliberate `[[ ]]`.
+#
+# Usage:
+#   tools/bash-lint.sh              # lint every discovered bash script
+#   tools/bash-lint.sh FILE...      # lint just these files (used by tests;
+#                                     exclusions and discovery do not apply)
+#   tools/bash-lint.sh --list       # print the in-scope file list, one per line
+set -uo pipefail
+
+FILES=()
+LIST_ONLY=0
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    # Print the whole leading comment block, the same self-documenting idiom
+    # tools/posix-lint.sh and tools/preflight.sh use, so --help can't drift.
+    -h|--help) awk 'NR>1 && /^#/ {print; next} NR>1 {exit}' "$0"; exit 0 ;;
+    --list) LIST_ONLY=1; shift ;;
+    --) shift; FILES+=("$@"); break ;;
+    -*) echo "unknown arg: $1" >&2; exit 2 ;;
+    *) FILES+=("$1"); shift ;;
+  esac
+done
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+
+# ─── Declared exclusions ────────────────────────────────────────────────────
+# Pairs of <glob> <reason>. Everything else that carries a bash shebang IS
+# linted, so the gate cannot go blind to a whole directory by omission — only
+# by an entry here, which is a reviewable diff carrying its own justification.
+#
+# Each glob is matched against the repo-root-relative path with `[[ == ]]`, and
+# each MUST match at least one discovered file or the gate refuses (below). An
+# exclusion that stopped matching is indistinguishable from coverage from the
+# log, which is the same silent-green shape this gate is about.
+EXCLUDE=(
+  '*/testdata/*'
+  'a deliberately-corrupt fixture corpus, driven by its own unit test rather than by this gate — the split tools/skill-lint.sh and tools/posix-lint.sh already draw for theirs'
+
+  'replaydata/*'
+  'the recording rigs per-agent drivers. Measured per-file: 79 findings, 68 of them SC2034 over the driver protocols declared-variable seam, 8 SC1125, plus replaydata/_lib/drive/contracts.sh, whose whole analysis is ABANDONED because a prose comment opens with the linters name. Bringing them in is a separate piece of work, filed as issue #1687'
+
+  '*/templates/*.tmpl'
+  'a template expanded into the driver family above, and carrying the same 10 SC2034 seam variables — excluded with replaydata/ rather than separately from it'
+)
+
+# ─── Discovery ──────────────────────────────────────────────────────────────
+
+# is_bash_shebang <file> — true when line 1 selects a bash interpreter.
+# Reads ONE line rather than slurping: only line 1 can carry a shebang, and
+# matching on line 1 alone is what stops a script that quotes another
+# interpreter's shebang inside a heredoc from being misclassified (#1611's
+# lesson, applied in the mirror direction).
+is_bash_shebang() {
+  local first
+  IFS= read -r first < "$1" 2>/dev/null || return 1
+  case "$first" in
+    '#!'*bash) return 0 ;;
+    '#!'*bash\ *) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+EXCLUDED_COUNT=()   # parallel to EXCLUDE's glob entries: how many each matched
+DISCOVERED=0
+
+if [[ ${#FILES[@]} -eq 0 ]]; then
+  cd "$ROOT_DIR" || exit 2
+
+  # The walk is `tools/posix-lint.sh`'s, deliberately in lockstep with it
+  # rather than re-derived — that file's header carries the full reasoning and
+  # the incidents behind each flag. In brief: `git ls-files` and not `find`,
+  # because `find .` descends into `.claude/worktrees/` and would lint every
+  # other branch's scripts as if they were this one's; `-z` with
+  # `core.quotePath=off`, because the default C-quotes any non-ASCII path into
+  # a string that is not a real path and the file then drops out of the walk
+  # with no message; and the second `ls-files --others --exclude-standard`,
+  # because a brand-new untracked script is exactly the file that puts this
+  # gate in scope via `tools/preflight.sh --changed` (#1611).
+  for ((ei = 0; ei < ${#EXCLUDE[@]}; ei += 2)); do
+    EXCLUDED_COUNT+=(0)
+  done
+
+  while IFS= read -r -d '' f; do
+    is_bash_shebang "$f" || continue
+    if [[ ! -f "$f" ]]; then
+      # Loud, not silent. A path git listed but the walk cannot open is the
+      # blind spot this gate exists to remove, and "not looked at" must never
+      # render as "clean".
+      echo "bash-lint: refusing — $f was listed by git but is not a regular file" >&2
+      exit 2
+    fi
+    DISCOVERED=$((DISCOVERED + 1))
+    excluded=0
+    slot=0
+    for ((ei = 0; ei < ${#EXCLUDE[@]}; ei += 2)); do
+      # shellcheck disable=SC2053  # the RHS is a GLOB on purpose — that is what
+      # an exclusion rule is. Quoting it would turn every entry into a literal
+      # path comparison and silently exclude nothing, which the refusal below
+      # would then report as a broken rule rather than as coverage.
+      if [[ "$f" == ${EXCLUDE[ei]} ]]; then
+        EXCLUDED_COUNT[slot]=$(( ${EXCLUDED_COUNT[slot]} + 1 ))
+        excluded=1
+        break
+      fi
+      slot=$((slot + 1))
+    done
+    [[ "$excluded" -eq 1 ]] && continue
+    FILES+=("$f")
+  done < <({
+    git -c core.quotePath=off ls-files -z
+    git -c core.quotePath=off ls-files --others --exclude-standard --full-name -z -- :/
+  } | LC_ALL=C sort -z -u)
+
+  # An exclusion that matches nothing is a REFUSAL, not a no-op. The repo's own
+  # idiom for exemption maps — `TW_EXEMPT_KEYS` in shell-lib-errexit_test.sh,
+  # `nilTolerant` in core/application/services/construction_test.go — is that
+  # keys are existence-checked, because an entry that stopped naming anything
+  # real reads from the log exactly like coverage.
+  slot=0
+  for ((ei = 0; ei < ${#EXCLUDE[@]}; ei += 2)); do
+    if [[ "${EXCLUDED_COUNT[slot]}" -eq 0 ]]; then
+      echo "bash-lint: refusing — the exclusion '${EXCLUDE[ei]}' matched no discovered bash file." >&2
+      echo "  Its stated reason was: ${EXCLUDE[ei + 1]}" >&2
+      echo "  Either the family moved or it is gone; an exclusion that stopped excluding must not read as coverage." >&2
+      exit 2
+    fi
+    slot=$((slot + 1))
+  done
+fi
+
+if [[ ${#FILES[@]} -eq 0 ]]; then
+  # Not a pass. An empty set means discovery and the repo disagree about where
+  # bash lives — the same silent-green shape as above, one layer up.
+  echo "bash-lint: refusing — no bash scripts found, so nothing was checked." >&2
+  exit 2
+fi
+
+if [[ "$LIST_ONLY" -eq 1 ]]; then
+  printf '%s\n' "${FILES[@]}"
+  exit 0
+fi
+
+# ─── Tool discovery ─────────────────────────────────────────────────────────
+# One linter, and its absence is a hard failure with an install hint rather
+# than a skip. "The linter wasn't there" must not read as "the code is clean" —
+# that is the exact failure mode #1423 is about, and it is the one thing that
+# would make this gate the defect it was built to remove.
+#
+# Only shellcheck: `checkbashisms`, posix-lint.sh's other linter, exists to
+# find bash-isms in POSIX sh and has nothing to say about a bash file.
+if ! command -v shellcheck >/dev/null 2>&1; then
+  echo "bash-lint: no shellcheck found — refusing to pass a run that checked nothing." >&2
+  echo "  Install it:  brew install shellcheck   |   apt-get install -y shellcheck" >&2
+  echo "  CI's ubuntu image ships 0.9.0; this gate is the check that guards main." >&2
+  exit 2
+fi
+
+SC_VERSION="$(shellcheck --version 2>/dev/null | awk '/^version:/ {print $2}')"
+[[ -z "$SC_VERSION" ]] && SC_VERSION="unknown"
+SEVERITY=warning
+
+# lint_one <file> — print findings to stdout, return 1 when any were found OR
+# when shellcheck could not be trusted to have looked.
+#
+# EVERY BRANCH DISTINGUISHES "clean" FROM "did not run", which is why the exit
+# status is read explicitly instead of testing a captured string for emptiness.
+# The obvious spelling — `out=$(shellcheck … | grep …); [[ -z "$out" ]]` —
+# reproduces #1423 inside the gate: a linter or filter that fails to execute
+# leaves the capture empty, empty reads as clean, and the file is reported ok.
+# posix-lint.sh's first draft did exactly that and printed `ALL PASS` over an
+# installer carrying a deliberate `[[ ]]`.
+#
+# `--shell=bash` is explicit rather than inferred from the shebang so the
+# gate's verdict cannot depend on how a shebang is spelled; discovery has
+# already established that every file here is bash.
+lint_one() {
+  local f="$1" raw rc
+  raw=$(shellcheck --shell=bash --severity="$SEVERITY" --format=gcc "$f" 2>&1); rc=$?
+  case "$rc" in
+    0) return 0 ;;
+    1)
+      # rc 1 means "findings", so an EMPTY capture here means the output was
+      # lost, not that the file is clean. Absence of a finding and inability to
+      # look must not produce the same answer.
+      if [[ -z "$raw" ]]; then
+        printf 'shellcheck exited 1 (findings) but printed nothing — the output was lost, so this file was NOT checked.\n'
+        return 1
+      fi
+      printf '%s\n' "$raw"
+      return 1 ;;
+    *)
+      printf 'shellcheck could not check this file (exit %s):\n%s\n' "$rc" "$raw"
+      return 1 ;;
+  esac
+}
+
+# ─── Run ────────────────────────────────────────────────────────────────────
+
+# Name what ran, over how much, under which rules. A run that cannot be read
+# back to "what actually looked at this" is a run whose green means nothing in
+# particular — and the excluded census is half of that: an exclusion widening
+# to swallow the corpus would otherwise look like a clean gate.
+if [[ "$DISCOVERED" -gt 0 ]]; then
+  excluded_note=""
+  slot=0
+  for ((ei = 0; ei < ${#EXCLUDE[@]}; ei += 2)); do
+    excluded_note+=" ${EXCLUDE[ei]}=${EXCLUDED_COUNT[slot]}"
+    slot=$((slot + 1))
+  done
+  echo "bash-lint: ${#FILES[@]} of $DISCOVERED bash file(s); excluded:$excluded_note"
+else
+  echo "bash-lint: ${#FILES[@]} file(s) named on the command line"
+fi
+echo "bash-lint: shellcheck $SC_VERSION, --severity=$SEVERITY, external-sources=off"
+
+rc=0
+for f in "${FILES[@]}"; do
+  if out=$(lint_one "$f"); then
+    echo "  ok  $f"
+  else
+    echo "FAIL $f" >&2
+    printf '%s\n' "$out" >&2
+    rc=1
+  fi
+done
+
+if [[ "$rc" -ne 0 ]]; then
+  echo >&2
+  echo "bash-lint: FAILED — the above are shellcheck findings at severity $SEVERITY or above." >&2
+  echo "  Fix them, or add a per-site '# shellcheck disable=SCxxxx  # <reason>' where the" >&2
+  echo "  finding is a false positive. Do not disable a code repo-wide." >&2
+  exit 1
+fi
+
+echo "bash-lint: ALL PASS"

--- a/tools/lib/await-gone.sh
+++ b/tools/lib/await-gone.sh
@@ -273,6 +273,10 @@ await_gone() {
       return 2
     fi
 
+    # shellcheck disable=SC2034  # this IS the library's output: every caller
+    # prints it on failure (await-gone_test.sh 142/204, gate-budget_test.sh
+    # 358/412/452, swift-suite_test.sh 270), and line 20 of this file documents
+    # it as the contract. Unused within this file by design.
     AWAIT_GONE_LAST="$AWAIT_GONE_ALIVE"
     if [ -z "$AWAIT_GONE_ALIVE" ]; then
       return 0

--- a/tools/lib/await-gone_test.sh
+++ b/tools/lib/await-gone_test.sh
@@ -46,6 +46,10 @@ need sleep
 
 # Keep the suite in milliseconds rather than seconds. The interval is how long
 # the poll waits between looks and changes nothing about what is asserted.
+#
+# shellcheck disable=SC2034  # read by the SOURCED library, not by this file:
+# await-gone.sh defaults it at line 131 and sleeps on it at 283. shellcheck does
+# not follow a source through a variable path, so it cannot see the consumer.
 AWAIT_GONE_POLL_SECONDS=0.02
 
 fails=0
@@ -214,6 +218,11 @@ echo "== the predicate runs in the CALLER's shell, not a subshell =="
 # predicate no fork at all. A subshell would lose every increment below, so
 # this assertion is the seam rather than a description of it.
 counted=0
+# shellcheck disable=SC2034  # AWAIT_GONE_LOOKED / AWAIT_GONE_ALIVE are this
+# predicate's whole OUTPUT — await-gone.sh reads both after every call (the
+# `case` at 260-269 and the comparison at 271). Reporting through variables
+# rather than stdout is the seam the comment above describes, so an "unused"
+# verdict here is shellcheck failing to follow the source, not dead code.
 counting_predicate() {
   counted=$(( counted + 1 ))
   AWAIT_GONE_LOOKED=1

--- a/tools/lib/bash-lint_test.sh
+++ b/tools/lib/bash-lint_test.sh
@@ -1,0 +1,479 @@
+#!/usr/bin/env bash
+# bash-lint_test.sh — unit tests for tools/bash-lint.sh. Plain bash (no
+# framework), matching the style of lib/posix-lint_test.sh. Run directly, or via
+# linux.yml's "Test the bash-lint gate" step. Exits non-zero on any failed
+# assertion.
+#
+# Covers issue #1684. Every bash file in this repo was outside every static
+# linter it runs — 23 files / 8,431 lines under tools/lib/ alone, which is the
+# machinery deciding whether every OTHER gate passes. It is the same
+# file-selection blindness class as #1423 and #1611: a gate whose selection rule
+# excludes a whole family reads exactly like a gate that passed.
+#
+# THE POINT OF THIS FILE is that the new gate can be shown RED. Per AGENTS.md's
+# rule for gates that pass by construction, the deliberate mutation is the
+# evidence — so rather than a scratch mutation that disappears with the PR, the
+# corpus is committed under testdata/bash-lint/ and asserted here, one rule
+# class per fixture.
+#
+# `good-clean.sh` carries as much weight as the nine broken fixtures: it is the
+# vacuity guard. A linter that failed every input would satisfy all nine and be
+# worthless, and only the clean fixture tells those two apart.
+# `style-noisy-but-warning-clean.sh` pins the severity floor in the one
+# direction the bad-* files cannot reach.
+#
+# The refusal cases are the other half, and they are the paths by which this
+# gate could itself become the thing it was built to remove — a green check
+# that ran nothing: no shellcheck, an empty file set, an exclusion rule that
+# has stopped matching, and a shellcheck that could not check.
+
+set -uo pipefail   # NOT -e: assertions capture non-zero return codes
+
+NAME="bash-lint_test"
+DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$DIR/../.." && pwd)"
+LINT="$ROOT/tools/bash-lint.sh"
+FIXTURES="$DIR/testdata/bash-lint"
+
+fails=0
+pass() { echo "  PASS: $1"; return 0; }
+fail() {
+  echo "  FAIL: $1 — expected [$2] got [$3]"
+  fails=$((fails + 1))
+  return 0
+}
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  [[ "$expected" == "$actual" ]] && pass "$label" || fail "$label" "$expected" "$actual"
+  return 0
+}
+assert_contains() {
+  local label="$1" needle="$2" haystack="$3"
+  [[ "$haystack" == *"$needle"* ]] && pass "$label" \
+    || fail "$label" "contains '$needle'" "${haystack:0:300}"
+  return 0
+}
+assert_not_contains() {
+  local label="$1" needle="$2" haystack="$3"
+  [[ "$haystack" != *"$needle"* ]] && pass "$label" \
+    || fail "$label" "does NOT contain '$needle'" "${haystack:0:300}"
+  return 0
+}
+
+# stub_path <dir> [extra-tool ...] — a PATH holding only the tools the gate
+# needs to RUN, so a case can remove exactly one thing and isolate it. `sh` and
+# `bash` stay reachable deliberately: the wrong outcome for a missing linter is
+# the gate degrading to something weaker and calling that a check.
+stub_path() {
+  local d="$1"; shift
+  mkdir -p "$d" || return 1
+  local t real
+  for t in sh bash git awk sed basename dirname sort cat mktemp printf "$@"; do
+    real="$(command -v "$t" 2>/dev/null)" && ln -sf "$real" "$d/$t"
+  done
+  return 0
+}
+
+echo "== $NAME =="
+
+# ===========================================================================
+# 0. The gate needs shellcheck. Without it every assertion below would be
+#    grading the refusal path instead of the detection path, and a suite that
+#    quietly stopped checking detection is this issue wearing a new mask. So
+#    say plainly whether it is there, and let cases 8-9 (which REMOVE it on
+#    purpose) be the only ones that run without it.
+# ===========================================================================
+if ! command -v shellcheck >/dev/null 2>&1; then
+  # Not a skip-to-green. Reported as a failure of the ENVIRONMENT so it cannot
+  # be mistaken for the corpus passing. CI runs this on ubuntu-latest, whose
+  # image ships shellcheck 0.9.0.
+  echo "  FAIL: environment — shellcheck not found, so the detection path cannot be tested here" >&2
+  echo "        install: brew install shellcheck  |  apt-get install -y shellcheck" >&2
+  echo "$NAME: 1 FAILED" >&2
+  exit 1
+fi
+pass "environment: shellcheck $(shellcheck --version | awk '/^version:/ {print $2}') is available"
+
+# ===========================================================================
+# 1. Every rule class must be CAUGHT. One fixture per class; the class is in
+#    the filename so a red run names the construct, not just a path.
+#
+#    These are the mutations. Against the state of the repo before #1684 all
+#    nine PASS, because nothing read a bash file at all.
+# ===========================================================================
+for fixture in "$FIXTURES"/bad-*.sh; do
+  base="$(basename "$fixture")"
+  out=$("$LINT" "$fixture" 2>&1)
+  rc=$?
+  assert_eq "detect: $base is rejected (exit 1)" "1" "$rc"
+  # Exit status alone is satisfied by the gate erroring for an unrelated reason
+  # (a refusal exits 2, but a future refactor could exit 1). Pin the file's own
+  # name on a FAIL line so the rejection is about THIS file.
+  assert_contains "detect: $base is named on a FAIL line" "FAIL $fixture" "$out"
+done
+
+# ===========================================================================
+# 2. The vacuity guard: clean bash must PASS. Without this, a linter that
+#    rejected every input would satisfy all nine assertions above.
+# ===========================================================================
+out=$("$LINT" "$FIXTURES/good-clean.sh" 2>&1)
+rc=$?
+assert_eq "vacuity: good-clean.sh passes (exit 0)" "0" "$rc"
+assert_contains "vacuity: good-clean.sh reports ALL PASS" "ALL PASS" "$out"
+assert_contains "vacuity: ...and says it actually read the file" "ok  $FIXTURES/good-clean.sh" "$out"
+
+# ===========================================================================
+# 3. The severity floor, in the only direction the bad-* fixtures cannot
+#    reach. They all trip a warning or an error, so they exercise the "report
+#    it" arm; this fixture makes shellcheck exit 1 carrying ONLY findings BELOW
+#    the floor (SC2086, SC2012), which the gate must discard.
+#
+#    Without it, lowering the floor to `style` leaves the whole suite green
+#    while 199 findings land across the corpus, 163 of which CI's 0.9.0 and a
+#    local 0.11.0 disagree about — see tools/bash-lint.sh's header.
+# ===========================================================================
+out=$("$LINT" "$FIXTURES/style-noisy-but-warning-clean.sh" 2>&1)
+rc=$?
+assert_eq "floor: style-noisy but warning-clean still passes (exit 0)" "0" "$rc"
+assert_contains "floor: the run names the severity it applied" "--severity=warning" "$out"
+
+# ===========================================================================
+# 4. THE SILENT ONE. `bad-directive-prose.sh` carries an SC2115 that shellcheck
+#    never reports, because a comment line opening with the linter's own name is
+#    parsed as a directive and an unparseable directive ABANDONS the file.
+#
+#    Asserting only "the fixture is rejected" (case 1 already does) would not
+#    show that. This case rewords that ONE line and asserts the hidden finding
+#    appears — which is the whole reason SC1072/SC1073 must be inside the floor
+#    rather than filtered away as a parse nit. It is the same argument
+#    posix-lint.sh makes with PARSE_ABORT_CODES, and the same shape as
+#    skill-lint.sh's rule that a validator which cannot parse its input checks
+#    MORE, never less.
+#
+#    `replaydata/_lib/drive/contracts.sh` carries this construct today (outside
+#    this gate's scope; filed as #1687), and tools/bash-lint.sh's own header
+#    tripped it on the gate's first run.
+# ===========================================================================
+prose_tmp="$(mktemp -d)"
+hidden="$prose_tmp/reworded.sh"
+if sed '/^# shellcheck this line is prose/s/^# shellcheck /# NOTE: /' \
+      "$FIXTURES/bad-directive-prose.sh" > "$hidden"; then
+  # The rewording has to have HAPPENED. A sed that matched nothing would leave
+  # the file identical, the assertion below would fail, and the failure would
+  # point at the gate instead of at this test.
+  if cmp -s "$hidden" "$FIXTURES/bad-directive-prose.sh"; then
+    fail "abandonment: the fixture's directive line was reworded" "a changed file" "byte-identical — the sed matched nothing"
+  else
+    pass "abandonment: the fixture's directive line was reworded"
+    out=$("$LINT" "$hidden" 2>&1)
+    rc=$?
+    assert_eq "abandonment: the reworded copy is still rejected" "1" "$rc"
+    assert_contains "abandonment: ...and NOW the hidden SC2115 is reported" "SC2115" "$out"
+    # And the original must NOT report it — that asymmetry is the finding.
+    orig=$("$LINT" "$FIXTURES/bad-directive-prose.sh" 2>&1)
+    assert_not_contains "abandonment: the original hides the SC2115 entirely" "SC2115" "$orig"
+    assert_contains "abandonment: ...reporting only the unparseable directive" "SC1073" "$orig"
+  fi
+else
+  fail "abandonment: the fixture could be copied" "a copy under $prose_tmp" "sed failed"
+fi
+rm -rf "$prose_tmp"
+
+# ===========================================================================
+# 5. Discovery. The gate must find the repo's real bash and must NOT walk its
+#    own deliberately-broken corpus — if it did, CI would be permanently red
+#    and the corpus would have to be deleted, taking the evidence with it.
+# ===========================================================================
+out=$("$LINT" 2>&1)
+rc=$?
+assert_eq "discovery: the repo's real bash scripts pass (exit 0)" "0" "$rc"
+assert_contains "discovery: tools/preflight.sh is in scope" "ok  tools/preflight.sh" "$out"
+assert_contains "discovery: tools/lib/gate-budget.sh is in scope" "ok  tools/lib/gate-budget.sh" "$out"
+assert_contains "discovery: the gate lints ITSELF" "ok  tools/bash-lint.sh" "$out"
+assert_not_contains "discovery: the fixture corpus is excluded" "ok  tools/lib/testdata/" "$out"
+
+# The census is what tells "it linted the corpus" from "it excluded the corpus
+# and passed". Both numbers are printed, so assert the shape of the line rather
+# than a count that would need editing on every new script.
+assert_contains "discovery: the census names both halves" "bash-lint: " "$out"
+assert_contains "discovery: ...including the testdata exclusion's own tally" "*/testdata/*=" "$out"
+assert_contains "discovery: ...and the recording-rig exclusion's" "replaydata/*=" "$out"
+
+# The excluded families must be genuinely absent from the linted list, not
+# merely uncounted.
+assert_not_contains "discovery: replaydata drivers are excluded" "ok  replaydata/" "$out"
+
+# ...and the exclusions must not have swallowed the corpus. `--list` is the
+# machine-readable form of the census; a scope that collapsed to a handful of
+# files would satisfy every assertion above.
+# `wc -l`, not `grep -c <pattern>`: the default `grep` on a developer machine
+# here is ugrep, which does not take GNU's BRE `\|` alternation, so a
+# pattern-based count silently collapsed to 1 — a check that reports a number
+# nothing produced, which is this section's own subject.
+listed=$("$LINT" --list 2>&1)
+listed_n=$(printf '%s\n' "$listed" | grep -c .)
+if [[ "$listed_n" -ge 60 ]]; then
+  pass "discovery: --list reports $listed_n in-scope files (a corpus, not a handful)"
+else
+  fail "discovery: --list reports a real corpus" "at least 60 files" "$listed_n"
+fi
+
+# ===========================================================================
+# 6. UNTRACKED FILES. `git ls-files` alone lists index entries only, which is
+#    #1611's defect: since #1609 a brand-new untracked script is exactly the
+#    file that puts a lint gate in scope via `tools/preflight.sh --changed`, and
+#    a gate walking the index could not see the file that summoned it.
+#
+#    These cases cannot use the fixtures above — those are TRACKED, which is
+#    the property under test — so each builds a throwaway git repo.
+# ===========================================================================
+
+# scratch_repo <dir> — a throwaway repo holding a copy of the gate at the path
+# it derives its root from (<root>/tools/bash-lint.sh, via $0), one tracked
+# clean bash script, and one file per declared exclusion so the gate's
+# exclusion-existence refusal is satisfied. Callers plant the untracked file
+# whose treatment is under test, so the census below is a full one.
+scratch_repo() {
+  local d="$1"
+  rm -rf "$d" && mkdir -p "$d/tools" || return 1
+  cp "$LINT" "$d/tools/bash-lint.sh" || return 1
+  (
+    cd "$d" || exit 1
+    git init -q . || exit 1
+    printf '#!/usr/bin/env bash\nset -eu\necho clean\n' > tracked-clean.sh || exit 1
+    # One inhabitant per exclusion rule. Without these the gate refuses (case
+    # 7), which would make every assertion here grade the wrong path.
+    mkdir -p tools/lib/testdata/bash-lint replaydata/_lib tools/templates || exit 1
+    printf '#!/usr/bin/env bash\nfoo=1\n' > tools/lib/testdata/bash-lint/fixture.sh || exit 1
+    printf '#!/usr/bin/env bash\nbar=1\n' > replaydata/_lib/driver.sh || exit 1
+    printf '#!/usr/bin/env bash\nbaz=1\n' > tools/templates/drive.sh.tmpl || exit 1
+    git add -A . || exit 1
+    # The fixture IS the test here. A scratch repo that did not come up would
+    # make every assertion below grade a tree git cannot read, and a gate that
+    # found nothing to lint is indistinguishable from one that found nothing
+    # wrong — the shape this whole file exists to refuse.
+    [[ -n "$(git ls-files)" ]] || exit 1
+  ) || return 1
+}
+
+untracked_tmp="$(mktemp -d)"
+scratch="$untracked_tmp/repo"
+
+# 6a. THE MUTATION. An untracked bash file carrying a finding must make the gate
+#     FAIL and must be NAMED. Without this the untracked walk is unfalsifiable:
+#     the gate passes on a clean tree either way.
+if scratch_repo "$scratch"; then
+  printf '#!/usr/bin/env bash\nset -u\nd=""\nrm -rf "$d/lib"\n' > "$scratch/untracked-bad.sh"
+  out=$( cd "$scratch" && ./tools/bash-lint.sh 2>&1 )
+  rc=$?
+  assert_eq "untracked: a finding in an UNTRACKED script fails the gate" "1" "$rc"
+  assert_contains "untracked: the untracked file is named on a FAIL line" \
+    "FAIL untracked-bad.sh" "$out"
+else
+  echo "  FAIL: untracked: scratch repo could not be built" >&2
+  fails=$((fails + 1))
+fi
+
+# 6b. The direction that fails SILENTLY, and therefore the one needing the
+#     stronger assertion: a clean untracked script must pass AND must have been
+#     SEEN. Exit 0 alone is satisfied by never looking at it, which is the
+#     defect. So pin the per-file `ok` line and the census — which also rules
+#     out the file being counted twice by the two `ls-files` streams.
+if scratch_repo "$scratch"; then
+  printf '#!/usr/bin/env bash\nset -eu\necho untracked and clean\n' > "$scratch/untracked-clean.sh"
+  out=$( cd "$scratch" && ./tools/bash-lint.sh 2>&1 )
+  rc=$?
+  assert_eq "untracked: a clean UNTRACKED script passes (exit 0)" "0" "$rc"
+  assert_contains "untracked: the clean untracked file is reported ok" \
+    "ok  untracked-clean.sh" "$out"
+  # 2 linted (tracked-clean.sh + untracked-clean.sh) of 5 discovered; the gate's
+  # own copy is untracked bash under tools/ and IS linted, making 3 of 6.
+  assert_contains "untracked: the census counts it exactly once" \
+    "bash-lint: 3 of 6 bash file(s)" "$out"
+else
+  echo "  FAIL: untracked: scratch repo could not be built" >&2
+  fails=$((fails + 1))
+fi
+
+# 6c. The exclusions apply to untracked files too — a plausible
+#     mis-implementation is a SECOND walk that skips the filters the first one
+#     applies, which is the mistake posix-lint_test.sh's cases 10c/10d were
+#     written against. Pinning the census rather than only the exit status is
+#     what tells "excluded" from "walked and happened to be clean".
+if scratch_repo "$scratch"; then
+  printf '#!/usr/bin/env bash\nset -u\nd=""\nrm -rf "$d/lib"\n' \
+    > "$scratch/tools/lib/testdata/bash-lint/untracked-bad.sh"
+  printf '#!/usr/bin/env bash\nset -u\nd=""\nrm -rf "$d/lib"\n' \
+    > "$scratch/replaydata/untracked-bad.sh"
+  out=$( cd "$scratch" && ./tools/bash-lint.sh 2>&1 )
+  rc=$?
+  assert_eq "untracked: an excluded-family untracked file is still excluded (exit 0)" "0" "$rc"
+  assert_contains "untracked: the exclusion census counts them" "*/testdata/*=2" "$out"
+  assert_contains "untracked: ...and the replaydata rule counts both of its own" "replaydata/*=2" "$out"
+else
+  echo "  FAIL: untracked: scratch repo could not be built" >&2
+  fails=$((fails + 1))
+fi
+
+# 6d. The FIRST-LINE rule. A file whose line 1 is not a bash shebang is not
+#     linted, however much bash it quotes — the mirror of #1611's reason for
+#     posix-lint keying on line 1, and what stops a `#!/bin/sh` script (which
+#     posix-lint owns) being graded here under bash rules.
+if scratch_repo "$scratch"; then
+  {
+    printf '#!/bin/sh\n'
+    printf '# POSIX sh, and posix-lint.sh owns it. It quotes bash below.\n'
+    printf 'cat > stub <<EOF\n#!/usr/bin/env bash\nd=""\nrm -rf "$d/lib"\nEOF\n'
+  } > "$scratch/untracked-posix.sh"
+  out=$( cd "$scratch" && ./tools/bash-lint.sh 2>&1 )
+  rc=$?
+  assert_eq "first-line: a #!/bin/sh file is not linted as bash (exit 0)" "0" "$rc"
+  assert_not_contains "first-line: ...and is not in the census at all" "untracked-posix.sh" "$out"
+else
+  echo "  FAIL: untracked: scratch repo could not be built" >&2
+  fails=$((fails + 1))
+fi
+
+# 6e. A LOCK, not a mutation — say so rather than let it read as evidence. The
+#     gate cds to its own root before discovering, so `--full-name -- :/`
+#     cannot be discriminated from the bare `--others` form here today and this
+#     case passes either way. It is kept because that `cd` is the only thing
+#     making it true, and a refactor moving it would silently reinstate the
+#     cwd-scoped walk #1609 measured.
+if scratch_repo "$scratch"; then
+  printf '#!/usr/bin/env bash\nset -u\nd=""\nrm -rf "$d/lib"\n' > "$scratch/untracked-bad.sh"
+  out=$( cd "$scratch/tools" && ./bash-lint.sh 2>&1 )
+  rc=$?
+  assert_eq "untracked (lock): invoked from a subdirectory, still fails" "1" "$rc"
+  assert_contains "untracked (lock): the root-relative path is named" \
+    "FAIL untracked-bad.sh" "$out"
+else
+  echo "  FAIL: untracked: scratch repo could not be built" >&2
+  fails=$((fails + 1))
+fi
+
+# ===========================================================================
+# 7. Refusal: an exclusion that matches NOTHING. This is the repo's own idiom
+#    for exemption maps — `TW_EXEMPT_KEYS` in shell-lib-errexit_test.sh,
+#    `nilTolerant` in construction_test.go, `shell_lib_suite_run`'s skip list —
+#    keys are existence-checked, because an entry that stopped naming anything
+#    real reads from the log exactly like coverage. A repo with no replaydata/
+#    is that state.
+# ===========================================================================
+if scratch_repo "$scratch"; then
+  rm -rf "$scratch/replaydata"
+  out=$( cd "$scratch" && ./tools/bash-lint.sh 2>&1 )
+  rc=$?
+  assert_eq "refusal: an exclusion matching nothing exits 2 (not a silent pass)" "2" "$rc"
+  assert_contains "refusal: it names the dead rule" "replaydata/*" "$out"
+  assert_contains "refusal: ...and repeats the reason that rule was written for" \
+    "Its stated reason was" "$out"
+else
+  echo "  FAIL: refusal: scratch repo could not be built" >&2
+  fails=$((fails + 1))
+fi
+
+# ...and the same tree WITH the family present must not refuse, or the case
+# above would be satisfied by a guard that fires unconditionally.
+if scratch_repo "$scratch"; then
+  out=$( cd "$scratch" && ./tools/bash-lint.sh 2>&1 )
+  rc=$?
+  assert_eq "refusal (vacuity): the same tree with every family present passes" "0" "$rc"
+else
+  echo "  FAIL: refusal: scratch repo could not be built" >&2
+  fails=$((fails + 1))
+fi
+
+# ===========================================================================
+# 8. Refusal: an EMPTY IN-SCOPE set. Reached here in its most dangerous form —
+#    a tree where bash WAS discovered and every file of it was excluded. That
+#    is the shape an over-broad exclusion produces, and it must not read as a
+#    clean gate. (A tree with no bash at all lands on the same refusal; this
+#    variant is the one the exclusion-existence check cannot also catch.)
+#
+#    The gate's own copy is bash under tools/, so it is .gitignore'd rather
+#    than deleted — it is the thing being run, and `--exclude-standard` is
+#    exactly what makes an ignored file invisible to the walk.
+# ===========================================================================
+if scratch_repo "$scratch"; then
+  rm -f "$scratch/tracked-clean.sh"
+  printf '/tools/bash-lint.sh\n' > "$scratch/.gitignore"
+  # `git rm --cached` as well as the .gitignore: scratch_repo already TRACKED
+  # the gate copy, and .gitignore only governs untracked paths.
+  ( cd "$scratch" && git rm -q --cached tools/bash-lint.sh && git add -A . ) >/dev/null 2>&1
+  out=$( cd "$scratch" && bash tools/bash-lint.sh 2>&1 )
+  rc=$?
+  assert_eq "refusal: a corpus where everything was excluded exits 2" "2" "$rc"
+  assert_contains "refusal: ...saying nothing was checked" "nothing was checked" "$out"
+else
+  echo "  FAIL: refusal: scratch repo could not be built" >&2
+  fails=$((fails + 1))
+fi
+
+rm -rf "$untracked_tmp"
+
+# ===========================================================================
+# 9. Refusal: no shellcheck. A PATH without it must exit 2, not 0. `sh` and
+#    `bash` stay reachable deliberately — the wrong outcome is the gate falling
+#    back to something weaker (`bash -n`, say) and calling that a static check,
+#    which is precisely the #1423 defect.
+# ===========================================================================
+stub="$(mktemp -d)"
+trap 'rm -rf "${stub:?}"' EXIT
+stub_path "$stub"
+out=$(PATH="$stub" "$LINT" "$FIXTURES/good-clean.sh" 2>&1)
+rc=$?
+assert_eq "refusal: no shellcheck exits 2 (not a silent pass)" "2" "$rc"
+assert_contains "refusal: names what to install" "brew install shellcheck" "$out"
+# ...and with it present the SAME invocation passes, or the case above is
+# satisfied by a PATH too small to run the gate at all.
+stub_path "$stub" shellcheck
+out=$(PATH="$stub" "$LINT" "$FIXTURES/good-clean.sh" 2>&1)
+rc=$?
+assert_eq "refusal (vacuity): the same stub PATH with shellcheck passes" "0" "$rc"
+
+# ===========================================================================
+# 10. A LINTER THAT CANNOT RUN MUST NOT READ AS CLEAN — #1423 reproduced inside
+#     the gate built to fix it, and not hypothetical: posix-lint.sh's first
+#     draft piped into `grep` and tested the capture for emptiness, so when the
+#     filter failed to execute the capture came back empty, empty read as clean,
+#     and it printed `ALL PASS` over an installer carrying a deliberate `[[ ]]`.
+#
+#     Two stubs, because there are two ways for the output to be lost and only
+#     one of them has a distinctive exit code:
+#       10a  exit 2 with no output — "could not check"
+#       10b  exit 1 with no output — claims findings, produced none
+# ===========================================================================
+broken="$(mktemp -d)"
+stub_path "$broken"
+printf '#!/bin/sh\nexit 2\n' > "$broken/shellcheck"
+chmod +x "$broken/shellcheck"
+out=$(PATH="$broken" "$LINT" "$FIXTURES/good-clean.sh" 2>&1)
+rc=$?
+assert_eq "broken linter: silent exit-2 is a FAILURE, not a clean file" "1" "$rc"
+assert_contains "broken linter: says it could not check" "could not check" "$out"
+
+printf '#!/bin/sh\nexit 1\n' > "$broken/shellcheck"
+chmod +x "$broken/shellcheck"
+out=$(PATH="$broken" "$LINT" "$FIXTURES/good-clean.sh" 2>&1)
+rc=$?
+assert_eq "broken linter: exit-1-with-no-output is a FAILURE, not a clean file" "1" "$rc"
+assert_contains "broken linter: says the output was lost" "the output was lost" "$out"
+rm -rf "$broken"
+
+# ===========================================================================
+# 11. The gate lints ITSELF and its own test, under the rules it enforces. Not
+#     ceremony: it is bash under tools/, so a gate that excluded its own source
+#     would be the file-selection blindness this issue is about, in the one file
+#     where it is least excusable.
+# ===========================================================================
+out=$("$LINT" "$ROOT/tools/bash-lint.sh" "$DIR/bash-lint_test.sh" 2>&1)
+rc=$?
+assert_eq "bootstrap: the gate and its own test pass the gate" "0" "$rc"
+
+if [[ "$fails" -eq 0 ]]; then
+  echo "$NAME: ALL PASS"
+else
+  echo "$NAME: $fails FAILED" >&2
+  exit 1
+fi

--- a/tools/lib/changed-files_test.sh
+++ b/tools/lib/changed-files_test.sh
@@ -230,7 +230,13 @@ for script in security-scan.sh preflight.sh; do
   # now (#1570 added gate-budget.sh to preflight.sh and gosec-report.sh to
   # security-scan.sh), so whichever they reach first is the one they name —
   # this case pins the REFUSAL, not which file it happens to be about.
-  rm -rf "$NOLIB/lib"
+  #
+  # `${NOLIB:?}`, not `$NOLIB` (#1684): `set -u` catches an UNSET variable but
+  # not an EMPTY one, and `$(mktemp -d)` yields the empty string when mktemp
+  # fails, at which point this line is `rm -rf /lib`. The `:?` makes an empty
+  # value abort the expansion instead. Same shape as the unguarded interpolation
+  # that removed ~1,895 files from a real ~/Library/Preferences during #1661.
+  rm -rf "${NOLIB:?}/lib"
   out=$( cd "$REPO_ROOT_FOR_TEST" && bash "$NOLIB/$script" "${args[@]}" 2>&1 )
   rc=$?
   assert_eq "$script --changed with no lib/ at all → exit 2, not a silent pass" "2" "$rc"
@@ -248,7 +254,7 @@ for script in security-scan.sh preflight.sh; do
   rc=$?
   assert_eq "$script --changed with only changed-files.sh missing → exit 2" "2" "$rc"
   assert_contains "$script names changed-files.sh in its error" "changed-files.sh" "$out"
-  rm -rf "$NOLIB/lib"
+  rm -rf "${NOLIB:?}/lib"
 done
 
 echo ""

--- a/tools/lib/gate-budget_test.sh
+++ b/tools/lib/gate-budget_test.sh
@@ -291,6 +291,9 @@ await_gone_bound "$reap_deadline" "$leaf_sleep" "the leaf's own sleep" \
 # about.
 tw_probe_fixture=""
 tw_probe_leaf=""
+# shellcheck disable=SC2034  # AWAIT_GONE_LOOKED / AWAIT_GONE_ALIVE are this
+# predicate's output, read by await-gone.sh after every call — see
+# tools/lib/await-gone.sh's header for the contract.
 budget_tree_gone() {
   local shells rc
   shells=$(pgrep -f "$tw_probe_fixture" 2>/dev/null); rc=$?

--- a/tools/lib/git-hooks_test.sh
+++ b/tools/lib/git-hooks_test.sh
@@ -135,7 +135,7 @@ echo "== the installer writes a shim, not a symlink, and not the hook itself =="
 RIG="$(new_rig)"
 (cd "$RIG/checkout" && bash tools/install-git-hooks.sh) >/dev/null 2>&1
 TARGET="$RIG/checkout/.git/hooks/pre-push"
-if [[ -L "$TARGET" ]]; then kind=symlink; elif [[ -f "$TARGET" ]]; then kind=file; else kind=absent; fi
+if [[ -L "$TARGET" ]]; then kind=symlink; elif [[ -f "$TARGET" ]]; then kind="file"; else kind=absent; fi
 assert_eq "installed pre-push is a regular file" "file" "$kind"
 if cmp -s "$REPO_ROOT/tools/git-hooks/shim" "$TARGET"; then same=yes; else same=no; fi
 assert_eq "installed pre-push is byte-for-byte tools/git-hooks/shim" "yes" "$same"
@@ -232,7 +232,7 @@ TARGET="$RIG/checkout/.git/hooks/pre-push"
 ln -sf "$RIG/checkout/tools/git-hooks/pre-push" "$TARGET"
 first=$(cd "$RIG/checkout" && bash tools/install-git-hooks.sh 2>&1)
 assert_contains "an older symlink install is replaced, not left in place" "installed   pre-push" "$first"
-if [[ -L "$TARGET" ]]; then kind=symlink; elif [[ -f "$TARGET" ]]; then kind=file; else kind=absent; fi
+if [[ -L "$TARGET" ]]; then kind=symlink; elif [[ -f "$TARGET" ]]; then kind="file"; else kind=absent; fi
 assert_eq "…by a regular file" "file" "$kind"
 # The `rm -f` before `cp` is what makes this safe: `cp` onto a symlink writes
 # THROUGH it, so without the rm this run would have overwritten the tracked

--- a/tools/lib/shell-lib-suite_test.sh
+++ b/tools/lib/shell-lib-suite_test.sh
@@ -399,13 +399,35 @@ else
   fi
 fi
 
-# The skip CI passes has to name a file that is really there. The library
-# refuses at runtime if it does not — this is the same assertion one push
+# EVERY skip CI passes has to name a file that is really there. The library
+# refuses at runtime if one does not — this is the same assertion one push
 # earlier, on the machine that can act on it.
-if [[ -e tools/lib/posix-lint_test.sh ]]; then
-  pass "the skip test.yml passes names a file that exists (tools/lib/posix-lint_test.sh)"
+#
+# The list is DERIVED from the step body read above, not hand-written here
+# (#1684 added a second skip, `bash-lint_test.sh`, and a one-file check would
+# have gone on passing while saying nothing about it). Deriving also means the
+# vacuity guard is load-bearing: a scan that stopped finding the invocation
+# would name no skips at all, which is indistinguishable from a step that
+# skips nothing.
+if [[ -z "$step" ]]; then
+  fail "the skip list could be read" "a '$STEP' step body" "empty — covered by the failure above"
 else
-  fail "the skip test.yml passes names a real file" "tools/lib/posix-lint_test.sh" "missing — CI's step will refuse with status 2 until the skip is updated"
+  skips=$(printf '%s\n' "$step" \
+          | sed -n 's/.*shell_lib_suite_run[[:space:]]\{1,\}tools\/lib[[:space:]]\{1,\}\([^|]*\).*/\1/p' \
+          | tr -s ' ' '\n' | sed '/^$/d')
+  if [[ -z "$skips" ]]; then
+    fail "the derived skip list is non-empty" "at least one skip name" "none — either the invocation moved or the sed stopped matching; a skip list that reads as empty proves nothing"
+  else
+    pass "read $(printf '%s\n' "$skips" | wc -l | tr -d ' ') skip name(s) out of $WF's step"
+    while IFS= read -r skip; do
+      [[ -z "$skip" ]] && continue
+      if [[ -e "tools/lib/$skip" ]]; then
+        pass "the skip test.yml passes names a file that exists (tools/lib/$skip)"
+      else
+        fail "the skip test.yml passes names a real file" "tools/lib/$skip" "missing — CI's step will refuse with status 2 until the skip is updated"
+      fi
+    done <<< "$skips"
+  fi
 fi
 
 echo ""

--- a/tools/lib/swift-suite.sh
+++ b/tools/lib/swift-suite.sh
@@ -73,6 +73,10 @@
 # run. `SWIFT_SUITE_MIN_HEADROOM` is what `swift-suite_test.sh` asserts against
 # — the relation is checked on every run rather than being true the day it was
 # typed.
+# shellcheck disable=SC2034  # both are read by swift-suite_test.sh (142-145),
+# which asserts `default_timeout + COLD_BUILD < MIN_HEADROOM` on every run
+# rather than leaving the relation true only on the day it was typed. They are
+# deliberately declared here, beside the budget arithmetic they document.
 SWIFT_SUITE_COLD_BUILD_SECONDS=105
 SWIFT_SUITE_MIN_HEADROOM=540
 SWIFT_SUITE_TIMEOUT="${SWIFT_SUITE_TIMEOUT:-240}"

--- a/tools/lib/swift-suite_test.sh
+++ b/tools/lib/swift-suite_test.sh
@@ -243,6 +243,11 @@ else
     # and reaped before the first look (0 polls). A zombie needs a LIVE parent
     # that never waits, and this fixture has none. If one ever appeared anyway,
     # the failure line below carries `Z <defunct>` and says so itself.
+    # shellcheck disable=SC2034  # AWAIT_GONE_LOOKED / AWAIT_GONE_ALIVE are this
+    # predicate's whole OUTPUT, read by await-gone.sh after every call (its
+    # `case` at 260-269 and its comparison at 271) — reporting through variables
+    # rather than stdout is that library's documented seam, so an "unused"
+    # verdict here is shellcheck not following the source.
     grandchild_gone() {
       AWAIT_GONE_LOOKED=1
       AWAIT_GONE_ALIVE=""

--- a/tools/lib/testdata/bash-lint/README.md
+++ b/tools/lib/testdata/bash-lint/README.md
@@ -1,0 +1,36 @@
+# bash-lint fixture corpus
+
+Deliberately-broken `bash` scripts, one shellcheck rule class per file, plus two
+clean controls. They exist so `tools/bash-lint.sh` can be shown *capable of
+failing* — a gate that passes by construction is exactly the defect #1423 and
+#1684 were filed about, and evidence living only in a merged PR body is re-run
+by nothing.
+
+`tools/lib/bash-lint_test.sh` drives this directory. The gate itself excludes
+`*/testdata/*` from its own walk, so these files never fail CI — the same split
+`tools/posix-lint.sh` and `tools/skill-lint.sh` draw for their corpora.
+
+## What each file pins
+
+| file | code | why it is here |
+|---|---|---|
+| `bad-rm-rf-var.sh` | SC2115 | `rm -rf "$var/lib"` → `/lib`. The shape #1684 was filed about. |
+| `bad-assign-command.sh` | SC2209 | `var=command` assigns a string and runs nothing. |
+| `bad-unused-var.sh` | SC2034 | assigned, never used — a rename that landed in one place. |
+| `bad-cd-unchecked.sh` | SC2164 | `cd` with no `\|\| exit`; everything after runs in the wrong tree. |
+| `bad-array-brace.sh` | SC1087 | `$var[` read as an array expansion. |
+| `bad-declare-assign.sh` | SC2155 | `local x=$(cmd)` masks `cmd`'s status. |
+| `bad-redirect-no-command.sh` | SC2188 | a redirection with no command. |
+| `bad-directive-prose.sh` | SC1072/SC1073 | a prose comment opening with the linter's name is parsed as a directive, and an unparseable one makes it **abandon the file**. |
+| `bad-directive-keyvalue.sh` | SC1125 | a directive whose reason is appended without a second `#`. |
+| `good-clean.sh` | — | the **vacuity guard**. A linter that failed everything would satisfy all nine above. |
+| `style-noisy-but-warning-clean.sh` | — | the severity floor, in the one direction the `bad-*` files cannot reach: shellcheck exits 1 carrying only SC2086/SC2012, below the floor, and the gate must pass it. |
+
+`bad-directive-prose.sh` is the one to read first, because its failure mode is
+silence rather than noise: the SC2115 on its last line is **invisible** while
+line 12 is present, and `bash-lint_test.sh` proves that by rewording that one
+line and asserting the finding appears. `replaydata/_lib/drive/contracts.sh` has
+been carrying the same construct unnoticed (#1687), and `tools/bash-lint.sh`'s own
+header tripped it on the gate's first run.
+
+Do not "fix" the findings in `bad-*.sh`. They are the assertions.

--- a/tools/lib/testdata/bash-lint/bad-array-brace.sh
+++ b/tools/lib/testdata/bash-lint/bad-array-brace.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# SC1087 (error severity) — `$var[` is read as an array expansion, so the
+# intended `$var` followed by a literal `[` needs `${var}[`.
+set -uo pipefail
+
+agent=claudecode
+grep -q "$agent[[:space:]]" /dev/null || true

--- a/tools/lib/testdata/bash-lint/bad-assign-command.sh
+++ b/tools/lib/testdata/bash-lint/bad-assign-command.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# SC2209 — `var=command` assigns the STRING "command" and runs nothing, where
+# `var=$(command)` was meant. An assertion downstream then compares against a
+# literal and passes for the wrong reason.
+set -uo pipefail
+
+kind=file
+printf '%s\n' "$kind"

--- a/tools/lib/testdata/bash-lint/bad-cd-unchecked.sh
+++ b/tools/lib/testdata/bash-lint/bad-cd-unchecked.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# SC2164 — `cd` with no `|| exit`. When the cd fails the script keeps going in
+# the WRONG directory, and everything after it operates on the caller's tree.
+set -uo pipefail
+
+cd /nonexistent-directory-for-the-fixture
+rm -f ./generated-output

--- a/tools/lib/testdata/bash-lint/bad-declare-assign.sh
+++ b/tools/lib/testdata/bash-lint/bad-declare-assign.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# SC2155 — `local x=$(cmd)` masks cmd's return value: the declaration always
+# succeeds, so a failing command is invisible to `set -e` and to `$?`.
+set -euo pipefail
+
+report() {
+  local out=$(false)
+  printf '%s\n' "$out"
+}
+report

--- a/tools/lib/testdata/bash-lint/bad-directive-keyvalue.sh
+++ b/tools/lib/testdata/bash-lint/bad-directive-keyvalue.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# SC1125 — a directive whose reason is appended without a second `#`.
+#
+# Measured on both 0.9.0 and 0.11.0: the `disable=` IS still honoured (the
+# SC2034 below does not fire), so this is not a broken suppression — it is an
+# ERROR-severity complaint about the spelling, which is exactly what makes it
+# worth catching, because the correct form is one character away and eight
+# directives in replaydata/ are written this way.
+set -uo pipefail
+
+# shellcheck disable=SC2034 — set for a sourced consumer to read
+SEAM_FOR_A_CONSUMER=1

--- a/tools/lib/testdata/bash-lint/bad-directive-prose.sh
+++ b/tools/lib/testdata/bash-lint/bad-directive-prose.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# SC1072/SC1073 — THE MOST IMPORTANT FIXTURE HERE, because its failure mode is
+# silence. A comment line whose first word is the linter's own name is parsed
+# as a DIRECTIVE, and one it cannot parse makes it ABANDON the file: every
+# other finding below simply disappears.
+#
+# The SC2115 on the last line is what proves it. Reword line 12 so it is not a
+# directive and shellcheck reports the rm; leave it and the rm is invisible.
+# This is not hypothetical — replaydata/_lib/drive/contracts.sh has carried it
+# unnoticed (measured), and tools/bash-lint.sh's own header tripped it on the
+# gate's first run.
+# shellcheck this line is prose, not a directive, and that is the defect
+set -uo pipefail
+
+scratch=""
+rm -rf "$scratch/lib"

--- a/tools/lib/testdata/bash-lint/bad-redirect-no-command.sh
+++ b/tools/lib/testdata/bash-lint/bad-redirect-no-command.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# SC2188 — a redirection with no command. It works in bash (it truncates), but
+# it is indistinguishable from a line whose command was accidentally deleted,
+# and `: > "$log"` says the truncation was meant.
+set -uo pipefail
+
+log="$(mktemp)"
+> "$log"
+printf 'ok\n' >> "$log"

--- a/tools/lib/testdata/bash-lint/bad-rm-rf-var.sh
+++ b/tools/lib/testdata/bash-lint/bad-rm-rf-var.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# SC2115 — `rm -rf "$var/lib"` becomes `rm -rf /lib` when $var is empty.
+#
+# This is the shape #1684 was filed about, and the reachability is the point:
+# `set -u` catches an UNSET variable but not an EMPTY one, and `$(mktemp -d)`
+# yields the empty string when mktemp fails. The fix is one character —
+# "${scratch:?}/lib" — and the same shape removed ~1,895 files from a real
+# ~/Library/Preferences during the work behind #1661.
+set -uo pipefail
+
+scratch="$(mktemp -d)"
+rm -rf "$scratch/lib"

--- a/tools/lib/testdata/bash-lint/bad-unused-var.sh
+++ b/tools/lib/testdata/bash-lint/bad-unused-var.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# SC2034 — assigned and never used. Often a genuine cross-file seam (a knob a
+# sourced library reads, an output variable a caller reads), which is why the
+# sanctioned answer is a per-site `# shellcheck disable=SC2034  # <reason>`
+# rather than deleting the line — but it is equally often a variable renamed
+# in one place and not the other, which is a live defect.
+set -uo pipefail
+
+WAS_RENAMED_HERE=1
+printf 'but read under the old name: %s\n' "${WAS_RENAMED_THERE:-}"

--- a/tools/lib/testdata/bash-lint/good-clean.sh
+++ b/tools/lib/testdata/bash-lint/good-clean.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# THE VACUITY GUARD. Clean bash, and it carries as much weight as every
+# bad-*.sh beside it: a linter that simply failed everything would satisfy
+# each of those and be worthless, and only this file can tell the two apart.
+set -euo pipefail
+
+greet() {
+  local who="$1"
+  printf 'hello, %s\n' "$who"
+}
+
+target="$(mktemp -d)"
+trap 'rm -rf "${target:?}"' EXIT
+greet world
+cd "$target" || exit 1
+printf 'done\n'

--- a/tools/lib/testdata/bash-lint/style-noisy-but-warning-clean.sh
+++ b/tools/lib/testdata/bash-lint/style-noisy-but-warning-clean.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# The severity floor, pinned in the ONE direction the bad-*.sh files cannot
+# reach. They all trip a warning or an error, so they exercise the "report it"
+# arm; this file makes shellcheck exit 1 carrying only findings BELOW the
+# floor — SC2086 (unquoted expansion, info) and SC2012 (`ls | wc`, style).
+#
+# Without it, lowering the floor to `style` — or dropping --severity
+# altogether — leaves the whole suite green while 199 findings land on files
+# nobody has linted before, 163 of which CI's shellcheck 0.9.0 and a local
+# 0.11.0 disagree about (see tools/bash-lint.sh's header for the measurement).
+set -uo pipefail
+
+dir=$1
+echo $dir
+count=$(ls "$dir" | wc -l)
+echo "$count"

--- a/tools/onboarding-factory/scripts/lib/adapter-tables_test.sh
+++ b/tools/onboarding-factory/scripts/lib/adapter-tables_test.sh
@@ -106,7 +106,10 @@ for d in "$ROOT"/replaydata/agents/*/driver-interactive.sh; do
     fail "$agent: turn-count.sh exists but the driver never sources it" "the driver would call an undefined turn_count"
     continue
   fi
-  if ! grep -q "\"$agent\"\|[[:space:]]$agent[[:space:]]" "$TEST_FILE"; then
+  # `${agent}` braced, not `$agent` (#1684): `$agent[` is read as an array
+  # expansion, so the literal `[[:space:]]` that follows it needs the brace to
+  # end the name.
+  if ! grep -q "\"$agent\"\|[[:space:]]${agent}[[:space:]]" "$TEST_FILE"; then
     fail "$agent: extracted counter is not exercised by turn-count_test.sh" \
          "add it to the adapter list so a regression in its counter is caught"
     continue

--- a/tools/onboarding-factory/scripts/lib/spawn-record-daemon_test.sh
+++ b/tools/onboarding-factory/scripts/lib/spawn-record-daemon_test.sh
@@ -53,12 +53,26 @@ assert_eq() {
 
 # Spend no real time in the grace periods; the tick COUNTS stay >1 so the
 # escalation still has to poll its way through each rung.
+#
+# All four are read by the SOURCED library, not by this file:
+# spawn-record-daemon.sh sleeps on POLL_TICK_S (139, 152) and bounds each rung
+# with SOCK_TICKS (137), INT_TICKS (165) and TERM_TICKS (167). The linter does
+# not follow a source through a variable path, so it cannot see the consumer —
+# hence one scoped disable per knob (a directive covers only the next command).
+# shellcheck disable=SC2034
 RECORD_DAEMON_POLL_TICK_S=0
+# shellcheck disable=SC2034
 RECORD_DAEMON_INT_TICKS=3
+# shellcheck disable=SC2034
 RECORD_DAEMON_TERM_TICKS=3
+# shellcheck disable=SC2034
 RECORD_DAEMON_SOCK_TICKS=3
 
 # fresh_staging gives a case its own staging dir and clears the lib's state.
+#
+# shellcheck disable=SC2034  # RECORD_DAEMON_PID / _STAGING are the LIBRARY's
+# state (declared at spawn-record-daemon.sh 36/38, read at 149/162/174) —
+# seeding them is how a case puts the lib into the state it wants to grade.
 fresh_staging() {
   local name="$1"
   STAGING="$TMP/$name"
@@ -74,6 +88,9 @@ fresh_staging() {
 # the liveness probe, and a delivered signal kills the fake unless it is in the
 # ignore list (SIGKILL can never be ignored, as in the kernel). SIGNALS_SENT
 # records the escalation order.
+# shellcheck disable=SC2034  # RECORD_DAEMON_PID is the library's state, read
+# by its `kill -"$sig" "$RECORD_DAEMON_PID"` at spawn-record-daemon.sh:149 —
+# which is exactly the call the shadowed `kill` below intercepts.
 fake_daemon() {
   FAKE_IGNORES=" $* "
   FAKE_ALIVE=1
@@ -128,6 +145,10 @@ while IFS= read -r _; do entries=$((entries + 1)); done \
 assert_eq "five entries, not six" "5" "$entries"
 
 echo "== a caller-set ready-session TTL is forwarded, absent otherwise =="
+# shellcheck disable=SC2034  # not read by this file: it is set so
+# record_daemon_env picks it out of the ENVIRONMENT and forwards it, which is
+# the assertion two lines down. The daemon is the eventual consumer
+# (core/domain/config/config.go:168).
 IRRLICHT_READY_SESSION_TTL=45s
 assert_eq "TTL forwarded" "IRRLICHT_READY_SESSION_TTL=45s" \
   "$(record_daemon_env /s/recordings 127.0.0.1:7837 "" | grep READY_SESSION_TTL)"
@@ -192,6 +213,9 @@ echo "== an unwritable backup dir refuses to start the daemon =="
 # A snapshot that cannot save the user's config must stop the run before the
 # grant-all daemon has rewritten anything — there would be nothing to hand back.
 fresh_staging unwritable
+# shellcheck disable=SC2034  # managed-file-snapshot.sh's own state (declared
+# at its line 44); clearing it here is what makes this case a FRESH snapshot
+# rather than a second one over a spent handle.
 MANAGED_FILE_BACKUP_DIR=""   # the case above left a spent snapshot behind
 : > "$TMP/unwritable/managed-file-backup"   # a FILE where the dir must go
 err="$(spawn_record_daemon /nonexistent/irrlichd "$TMP/unwritable" 127.0.0.1:7838 "" 2>&1)"

--- a/tools/onboarding-factory/scripts/run-cell.sh
+++ b/tools/onboarding-factory/scripts/run-cell.sh
@@ -421,7 +421,12 @@ if [[ -f "$STAGING/session.uuids" ]]; then
     export IRRLICHT_EXTRA_SESSION_IDS="$EXTRA_IDS"
     # Concatenate all transcript paths (newline-separated) so curate
     # can build a single transcript.jsonl in chronological order.
-    export IRRLICHT_EXTRA_TRANSCRIPTS="$(cat "$STAGING/transcript.paths")"
+    #
+    # Assigned then exported, not `export X="$(cat …)"` (#1684): `export`
+    # always succeeds, so the combined form discards `cat`'s status and an
+    # unreadable paths file would export an empty list rather than fail here.
+    IRRLICHT_EXTRA_TRANSCRIPTS="$(cat "$STAGING/transcript.paths")"
+    export IRRLICHT_EXTRA_TRANSCRIPTS
     echo "multi-session: primary=$ACTUAL_UUID, extras=$EXTRA_IDS"
   fi
 fi

--- a/tools/onboarding-factory/scripts/smoke-test.sh
+++ b/tools/onboarding-factory/scripts/smoke-test.sh
@@ -86,16 +86,21 @@ echo "== unit tests (replaydata/_lib/drive/turn-count_test.sh) =="
 bash "$SCRIPT_DIR/../../../replaydata/_lib/drive/turn-count_test.sh" || rc=1
 
 echo ""
-echo "== shellcheck (advisory) =="
-if command -v shellcheck >/dev/null 2>&1; then
-  # -x follows `source`d libs; advisory only — does not change rc.
-  find "$SCRIPT_DIR" -maxdepth 3 -name '*.sh' -type f | sort | while IFS= read -r f; do
-    shellcheck -S warning -x "$f" || true
-  done
-  echo "  (advisory — see findings above, if any)"
-else
-  echo "  (shellcheck not installed — skipped)"
-fi
+# The advisory shellcheck pass that used to live here is gone (#1684). It was
+# the shape AGENTS.md rules out: `|| true` per file so findings never moved rc,
+# a trailing `echo` so the block always exited 0, and a silent
+# `(shellcheck not installed — skipped)` on a runner that ships none — so
+# "nothing was found" and "nothing looked" printed the same verdict, and the
+# nine real findings in this tree (SC1087, SC2155, and seven SC2034) sat in a
+# 100-line log for as long as it existed.
+#
+# `tools/bash-lint.sh` now covers this whole tree as a REAL gate: it refuses
+# rather than skipping when shellcheck is absent, lints one file at a time (a
+# multi-file invocation cross-suppresses SC2034), and runs in linux.yml and
+# `tools/preflight.sh --only bash`. Two mechanisms where one of them could not
+# fail is worse than one that can.
+echo "== shellcheck =="
+echo "  (covered by tools/bash-lint.sh — linux.yml, or tools/preflight.sh --only bash)"
 
 echo ""
 if [[ $rc -eq 0 ]]; then

--- a/tools/preflight.sh
+++ b/tools/preflight.sh
@@ -21,6 +21,7 @@
 #                                      (composite/category score vs origin/main)
 #   .github/workflows/macos-swift.yml — swift build + swift test for the
 #                                      macOS app (#1509)
+#                                      plus its bash-lint step (#1684)
 #   .github/workflows/linux.yml     — its replay-fixtures step natively (see
 #                                      below); the rest — build + full test
 #                                      suite (-race) under Linux, via the
@@ -67,6 +68,7 @@
 #   tools/preflight.sh --only skills   # just the .claude/skills/**/*.md linter
 #   tools/preflight.sh --only swift    # just the macOS Swift build + test suite
 #   tools/preflight.sh --only posix    # just the #!/bin/sh POSIX/bashism lint
+#   tools/preflight.sh --only bash     # just the shellcheck lint over bash scripts
 #   tools/preflight.sh --only linux    # just the Linux Docker gate
 #   tools/preflight.sh --changed       # scope every gate to the packages/trees
 #                                        this branch changes vs origin/main —
@@ -104,7 +106,11 @@ set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
-cd "$ROOT_DIR"
+# `|| exit 2` and not a bare cd (#1684): every gate below is scoped by a
+# repo-root-relative regex and several shell out to `git`, so a failed cd would
+# run the whole suite against the caller's tree and report the result as CI
+# parity.
+cd "$ROOT_DIR" || exit 2
 
 RUN_LINUX=0
 ONLY=""
@@ -130,7 +136,7 @@ done
 # Not `GROUPS` — that is a bash built-in holding the caller's supplementary
 # group IDs, and assigning to it silently does nothing, so the check would
 # compare against a list of numeric gids and reject every real group name.
-VALID_GROUPS=(go web arch tools skills posix security swift linux)
+VALID_GROUPS=(go web arch tools skills posix bash security swift linux)
 if [[ -n "$ONLY" ]]; then
   known=0
   for g in "${VALID_GROUPS[@]}"; do [[ "$ONLY" == "$g" ]] && known=1; done
@@ -403,6 +409,30 @@ if want posix; then
   CURRENT_GROUP=posix
   run_gate_scoped '\.sh$|^(tools|site)/[^/]*$|^tools/git-hooks/|^tools/lib/testdata/posix-lint/' \
                   "POSIX sh lint (#!/bin/sh bashisms)" tools/posix-lint.sh
+fi
+
+# ---- bash group (mirrors linux.yml's "Lint bash scripts" step) --------------
+# The sibling of the posix gate, over the OTHER shell family: 83 bash files /
+# ~19k lines that no static linter read at all until #1684, including the
+# bounded gate runner, the pre-push hook's own scoping rules and every
+# extract-and-execute workflow lock — the machinery that decides whether the
+# gates above pass.
+#
+# Same loose trigger as the posix gate, and for the same reason: the whole
+# corpus is re-linted whenever it fires (a couple of seconds), because a NEW
+# bash script is exactly the file the gate most needs to see on the push that
+# adds it, and the trigger cannot enumerate one that does not exist yet. The
+# `^tools/git-hooks/` alternative is not decoration — `pre-push` is a tracked
+# bash script with no suffix.
+#
+# Like the posix gate, this can legitimately be unrunnable on a machine that has
+# no shellcheck installed. It still FAILS rather than skipping — a gate whose
+# absence looks like a pass is the defect #1423 was filed about, and preflight
+# is not the place to reintroduce it.
+if want bash; then
+  CURRENT_GROUP=bash
+  run_gate_scoped '\.sh$|^(tools|site)/[^/]*$|^tools/git-hooks/|^tools/lib/testdata/bash-lint/' \
+                  "bash lint (shellcheck)" tools/bash-lint.sh
 fi
 
 # ---- skills group (mirrors test.yml's "Lint skill files" step) ------------

--- a/tools/security-scan.sh
+++ b/tools/security-scan.sh
@@ -60,7 +60,10 @@ set -uo pipefail
 # lib/ source below still works from any caller's working directory.
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT=$(git rev-parse --show-toplevel)
-cd "$REPO_ROOT"
+# `|| exit 2` and not a bare cd (#1684): every scanner below is invoked on
+# repo-relative module paths, so a failed cd would scan whatever tree the caller
+# happened to be in and report its verdict as this repo's.
+cd "$REPO_ROOT" || exit 2
 
 # Sourced unconditionally and fatally, the same shape as the --changed lib
 # below: without it gosec_report_check is undefined, `case $?` would take the


### PR DESCRIPTION
Closes #1684

`tools/posix-lint.sh` selects files whose **first line** is `#!/bin/sh`, deliberately
(#1611). The consequence was that **every bash file in this repo sat outside every static
linter it runs** — including `gate-budget.sh` (bounds the pre-push hook),
`changed-files.sh` (the hook's own scoping rules), `shell-lib-suite.sh`,
`workflow-step.sh`, `swift-suite.sh` and every extract-and-execute workflow lock: the
machinery deciding whether the *other* gates pass. Same file-selection blindness class as
#1423 and #1611 — a gate whose selection rule excludes a whole family reads exactly like
a gate that passed.

---

## 1. Scope decision: default-IN, opt-out with a reason

The issue proposed `tools/lib/**`. I went wider, because scoping to one directory
*reproduces* the class the issue names — the next `tools/foo.sh` would be invisible, and
the linted set would have to be widened by someone remembering.

So the gate lints **everything git knows about** (tracked, plus untracked and not
gitignored, the same walk `posix-lint.sh` uses after #1611) whose **line 1** is a bash
shebang, minus three declared `EXCLUDE` globs, each carrying its own justification in the
source. **An exclusion that matches nothing is a hard refusal (exit 2), not a no-op** —
the same both-directions existence check `TW_EXEMPT_KEYS` and `nilTolerant` get, because
an entry that stopped naming anything real reads from the log exactly like coverage.

| | files | why |
|---|---:|---|
| **linted** | **83** | ~19k lines: `tools/**`, `examples/**`, `.claude/skills/**`, `tools/git-hooks/pre-push` (extensionless, matched by shebang not suffix) |
| excluded `*/testdata/*` | 11 | deliberately-corrupt fixture corpora, driven by their own unit tests — the split `skill-lint.sh` and `posix-lint.sh` already draw |
| excluded `replaydata/*` | 31 | the recording rig's per-agent drivers — measured 79 findings, 68 of them the driver protocol's declared-variable seam, plus one file whose analysis shellcheck **abandons**. Filed as **#1687** rather than blanket-disabling codes to reach zero |
| excluded `*/templates/*.tmpl` | 1 | the template the above are generated from, carrying the same 10 seam variables — excluded *with* `replaydata/`, not separately from it |

The census line prints both halves on every run (`83 of 126 bash file(s); excluded:
*/testdata/*=11 replaydata/*=31 */templates/*.tmpl=1`), so an exclusion widening to
swallow the corpus cannot read as a clean gate.

## 2. Severity floor: `warning`, and it is a measurement

`posix-lint.sh`'s precedent is a **named code set**, so general style debt stays out. I
weighed it and deliberately did not follow it: `SC3xxx` is a closed family *by
definition* ("In POSIX sh, X is undefined"), whereas "bugs in bash" has no such family —
an opt-in code list means a code shellcheck adds later is not enforced until someone
remembers, which is the "covered by remembering" shape AGENTS.md argues against
throughout. A severity **floor** is covered by existing.

What the floor has to survive is the version split, so I fetched 0.9.0 and 0.10.0 from
koalaman's releases and ran all three **per-file** over the whole in-scope corpus
(81 files / 18,304 lines at `d76aa137`):

| floor | 0.9.0 | 0.10.0 | 0.11.0 | verdict |
|---|---:|---:|---:|---|
| `-S warning` | 26 | 26 | 26 | **byte-identical** — same codes, same files, same `line:col` |
| `-S style` | 312 | 312 | 199 | **163 disagreements** |

`-S style` is out of scope on that evidence, not on a guess about noise. `-S error` alone
would have caught 1 of the 26.

`--external-sources` (`-x`) is **off**, also measured: these libraries source through
variable paths (`. "$DIR/await-gone.sh"`), which shellcheck cannot resolve without a
`source-path`, so `-x` changed the count by exactly **zero** (26 → 26).

### One file per invocation — a measured constraint, not a detail

`shellcheck` given several files in **one** invocation suppresses SC2034 for a name used
in **any** of them:

```
$ shellcheck --shell=bash -S warning tools/lib/swift-suite_test.sh
  swift-suite_test.sh:247 AWAIT_GONE_LOOKED appears unused  [SC2034]
  swift-suite_test.sh:256 AWAIT_GONE_ALIVE  appears unused  [SC2034]
$ shellcheck --shell=bash -S warning tools/lib/swift-suite_test.sh tools/lib/await-gone.sh
  (nothing)
```

A multi-file gate's verdict would therefore depend on which *other* files shared the
command line — which `--changed` scoping makes differ between a developer's push and CI's
full run. Per-file is the only deterministic choice.

**This also corrects the issue's arithmetic in both directions, and I got it wrong once
before catching it.** My first pass measured multi-file, saw 11 under `tools/lib` instead
of the issue's 13, and concluded 2 had been fixed incidentally by #1683. That was wrong:
they were *masked*, because #1683 added a cross-file read of `AWAIT_GONE_ALIVE` in
`gate-budget_test.sh`. Per-file, `tools/lib` yields exactly the issue's **13** at HEAD,
and the full in-scope corpus yields **26**.

## 3. CI placement — and which direction the asymmetry runs

**`linux.yml`**, beside `posix-lint.sh`, plus a second step for its unit tests. But **the
reason is not posix-lint's**, and the difference is the decision:

- `posix-lint.sh` needs ubuntu because `/bin/sh` must genuinely **be** dash there — the
  property under test is a property of the runtime.
- `shellcheck` is a static analyser over the bash *language* and reads no interpreter at
  all. Measured: the 0.9.0 figures above came from an **x86_64 binary under Rosetta on
  arm64 macOS** and agree byte-for-byte with a native arm64 0.11.0. Neither the OS nor
  the arch enters the verdict.

So "the subject is bash that runs on macOS" does **not** argue for a macOS runner here.
What picks the host is only that ubuntu ships shellcheck (0.9.0) and macos-latest ships
none, so hosting it in test.yml would `brew install` one on every PR to lint 83 files.

**The asymmetry, at the chosen floor, runs in neither direction** — 0.9.0 / 0.10.0 /
0.11.0 are byte-identical over 18,304 lines. At `style` it runs in **both**, and
dominantly in the direction that hurts: **138** findings CI's 0.9.0 reports that a local
0.11.0 *cannot produce* (137 × SC2317 "command appears unreachable" + 1 × SC2015) against
**25** the other way (SC2329, which 0.9.0 does not have). That is worse than the framing
in the task — a developer's `preflight --only bash` would be green while `linux.yml` went
red on findings their own shellcheck does not implement, the exact round-trip
posix-lint's monotonicity argument exists to prevent. Choosing `warning` removes the
asymmetry rather than picking a side of it.

## 4. Per-finding triage — all 26

The issue's 13 are the first four blocks. The other 13 are findings of the gate being
built; they are not "new defects found while looking at something else" but the gate's own
output, and it cannot land red — so they are fixed here and each is named.

### SC2115 ×2 — real, the shape the issue was filed about

`tools/lib/changed-files_test.sh:233,251` — `rm -rf "$NOLIB/lib"` → `rm -rf /lib`.
`set -u` catches an *unset* variable, not an empty one, and `$(mktemp -d)` yields empty
on failure. **Fixed**: `"${NOLIB:?}/lib"`, with the reachability recorded at the site.

### SC2209 ×2 — **NOT live defects; the issue's guess was the wrong way round**

`tools/lib/git-hooks_test.sh:138,235` — `kind=file`. The issue expected "an assertion may
be comparing against a literal". Checked: the assertion two lines down *is*
`assert_eq "installed pre-push is a regular file" "file" "$kind"`, so the **string is
what was meant** and the test is correct. shellcheck flags it only because `file(1)` is a
command. **Fixed** by quoting (`kind="file"`) — shellcheck's own second suggestion — so
the intent is explicit and no disable is needed.

### SC2034 ×17 — every one a verified cross-file seam

All 17 are per-site `# shellcheck disable=SC2034  # <reason>` naming the consumer's
`file:line`. Every consumer was grepped, not assumed:

| site | variable(s) | consumer |
|---|---|---|
| `await-gone_test.sh:49` | `AWAIT_GONE_POLL_SECONDS` | `await-gone.sh:131` (default), `:283` (`sleep`) |
| `await-gone_test.sh:219,221` | `AWAIT_GONE_LOOKED/_ALIVE` | `await-gone.sh:260-271` — the predicate's whole output |
| `await-gone.sh:276` | `AWAIT_GONE_LAST` | the library's documented output; printed by 4 files, 6 sites |
| `gate-budget_test.sh:302` | `AWAIT_GONE_LOOKED/_ALIVE` | same predicate contract |
| `swift-suite_test.sh:247,256` | `AWAIT_GONE_LOOKED/_ALIVE` | same predicate contract |
| `swift-suite.sh:76,77` | `SWIFT_SUITE_COLD_BUILD_SECONDS/_MIN_HEADROOM` | `swift-suite_test.sh:142-145` asserts their relation |
| `spawn-record-daemon_test.sh:56-59` | 4 × `RECORD_DAEMON_*_TICKS/_TICK_S` | `spawn-record-daemon.sh:137,139,152,165,167` |
| `spawn-record-daemon_test.sh:68,81` | `RECORD_DAEMON_PID/_STAGING` | `spawn-record-daemon.sh:36,38,149,162,174` |
| `spawn-record-daemon_test.sh:131` | `IRRLICHT_READY_SESSION_TTL` | read out of the ENV by `record_daemon_env`; daemon consumer at `core/domain/config/config.go:168` |
| `spawn-record-daemon_test.sh:195` | `MANAGED_FILE_BACKUP_DIR` | `managed-file-snapshot.sh:44` |

A directive covers only the **next command**, which is why the four adjacent knob
assignments need four disables — the single grouped one I wrote first left three findings
standing, and the gate said so.

### SC2164 ×2 — real

`tools/preflight.sh:107`, `tools/security-scan.sh:63` — a bare `cd "$ROOT_DIR"`. Both
scripts then run every gate/scanner on repo-relative paths, so a failed `cd` would grade
whatever tree the caller was in and report it as this repo's. **Fixed**: `|| exit 2`.

### SC1087 ×1 — cosmetic, fixed

`adapter-tables_test.sh:109` — `$agent[[:space:]]` inside a grep pattern, read as an array
expansion. **Fixed**: `${agent}[[:space:]]`.

### SC2155 ×1 — real

`run-cell.sh:424` — `export IRRLICHT_EXTRA_TRANSCRIPTS="$(cat …)"`. `export` always
succeeds, so an unreadable paths file would export an empty list rather than fail.
**Fixed**: assign, then export.

### SC2188 ×1 — cosmetic, fixed

`examples/coding-factory/drive.sh:30` — `> "$LOG"`. **Fixed**: `: > "$LOG"`.

## 5. Refusals, and the rule the gate exists to not break

Four hard refusals (**exit 2**), never skips:

1. **no shellcheck** — with an install hint. `posix-lint.sh`'s founding incident is a
   linter that failed to run printing `ALL PASS` over an installer carrying a deliberate
   `[[ ]]`.
2. **an empty in-scope set** — including its most dangerous form, *bash was discovered and
   all of it was excluded*.
3. **an exclusion rule matching nothing.**
4. **a path git listed that cannot be opened.**

Plus two *failure* (exit 1) paths that distinguish "clean" from "did not look": shellcheck
exiting **>1**, and shellcheck exiting **1 while printing nothing**. The exit status is
read explicitly; nothing is piped into `grep` and tested for emptiness, which is exactly
how `posix-lint.sh`'s first draft reproduced #1423 inside itself.

**SC1072/SC1073 are inside the floor on purpose**, and this turned out to be the gate's
most valuable rule. A comment line whose **first word after `#` is the linter's name** is
parsed as a *directive*, and an unparseable one makes shellcheck **abandon the file** —
every later finding silently disappears. It caught the construct **four times in this
PR's own new prose**, and `replaydata/_lib/drive/contracts.sh` has been carrying it
unnoticed: as-is, SC1073/SC1072 are the *only* output shellcheck produces for that file,
and rewording that one line surfaces an SC2005 it currently hides (measured; filed as
#1687). The sibling SC1125 is the `# shellcheck disable=SCxxxx — <prose>` spelling — the
disable **is** still honoured (measured on both 0.9.0 and 0.11.0), but the prose costs an
`error`-severity finding, and eight directives in `replaydata/` are written that way.

## 6. Committed fixtures — `tools/lib/testdata/bash-lint/`

One deliberately-broken file per rule class, so the mutation evidence outlives the PR
(`tools/lib/testdata/posix-lint/` is the shape, README included):

`bad-rm-rf-var.sh` (SC2115) · `bad-assign-command.sh` (SC2209) · `bad-unused-var.sh`
(SC2034) · `bad-cd-unchecked.sh` (SC2164) · `bad-array-brace.sh` (SC1087) ·
`bad-declare-assign.sh` (SC2155) · `bad-redirect-no-command.sh` (SC2188) ·
`bad-directive-prose.sh` (SC1072/SC1073) · `bad-directive-keyvalue.sh` (SC1125)

plus two controls that carry as much weight: **`good-clean.sh`**, the vacuity guard (a
linter that failed everything would satisfy all nine `bad-*` assertions), and
**`style-noisy-but-warning-clean.sh`**, which makes shellcheck exit 1 carrying only
SC2086/SC2012 — pinning the floor in the one direction the `bad-*` files cannot reach.

`bad-directive-prose.sh` is graded by more than "it is rejected": the test **rewords its
directive line, asserts the sed actually changed the file, and then asserts the hidden
SC2115 appears** while the original reports only SC1073. That asymmetry *is* the finding.

Verified identical on 0.9.0 and 0.11.0 for all 11 fixtures.

## 7. Mutation evidence — 10 deliberate mutations of the gate, all seen RED

Each applied to a copy, run, reverted by copy-back, with a `git status --porcelain`
assertion between (never `git stash` / `checkout` / `restore`). The harness asserts its
own mutation **changed the file** — which caught three stale regexes on the first attempt
and is #1390's lesson applied.

```
MUTATION M1  severity floor raised to error: RED (exit 1) — caught by:
        FAIL: detect: bad-assign-command.sh is rejected (exit 1) — expected [1] got [0]
        FAIL: detect: bad-cd-unchecked.sh is rejected (exit 1) — expected [1] got [0]
        FAIL: detect: bad-declare-assign.sh is rejected (exit 1) — expected [1] got [0]
        FAIL: detect: bad-redirect-no-command.sh is rejected (exit 1) — expected [1] got [0]
MUTATION M2  severity floor lowered to style: RED (exit 1) — caught by:
        FAIL: floor: style-noisy but warning-clean still passes (exit 0) — expected [0] got [1]
        FAIL: discovery: the repo's real bash scripts pass (exit 0) — expected [0] got [1]
MUTATION M3  SC1xxx filtered out of the findings: RED (exit 1) — caught by:
        FAIL: detect: bad-array-brace.sh is rejected (exit 1) — expected [1] got [0]
        FAIL: detect: bad-directive-keyvalue.sh is rejected (exit 1) — expected [1] got [0]
MUTATION M4  exclusion-matched-nothing refusal off: RED (exit 1) — caught by:
        FAIL: refusal: an exclusion matching nothing exits 2 (not a silent pass) — expected [2] got [0]
MUTATION M5  empty-in-scope refusal becomes a pass: RED (exit 1) — caught by:
        FAIL: refusal: a corpus where everything was excluded exits 2 — expected [2] got [0]
        FAIL: refusal: ...saying nothing was checked — got [bash-lint: ALL PASS (nothing to do)]
MUTATION M6  missing-shellcheck refusal removed: RED (exit 1) — caught by:
        FAIL: refusal: no shellcheck exits 2 (not a silent pass) — expected [2] got [1]
MUTATION M7  shellcheck exit>1 read as clean: RED (exit 1) — caught by:
        FAIL: broken linter: silent exit-2 is a FAILURE, not a clean file — expected [1] got [0]
MUTATION M8  exit-1-with-no-output read as clean: RED (exit 1) — caught by:
        FAIL: broken linter: says the output was lost — expected [contains 'the output was lost']
MUTATION M9  walk reverted to tracked files only: RED (exit 1) — caught by:
        FAIL: untracked: a finding in an UNTRACKED script fails the gate — expected [1] got [0]
MUTATION M10 exclusion glob quoted (the SC2053 "fix"): RED (exit 1) — caught by:
        FAIL: discovery: the repo's real bash scripts pass (exit 0) — expected [0] got [2]
final tree check: RESTORED
```

Two more, against `shell-lib-suite_test.sh`'s newly-derived skip list (mutating
`test.yml`, same copy-back protocol):

```
MUTATION S1 a skip naming a file that does not exist: RED — FAIL: the skip test.yml
            passes names a real file — expected [tools/lib/renamed-away_test.sh]
MUTATION S2 the invocation replaced by a bare loop: RED — the derivation goes blind and
            says so, rather than reporting an empty skip list as clean
final tree check: RESTORED
```

M10 is worth a note: quoting the exclusion glob is what shellcheck's own SC2053
*suggests*, and doing it makes every exclusion match nothing. The gate's
exclusion-existence refusal turns that into a loud exit 2 instead of a silently narrowed
scope — which is why that site carries a scoped `# shellcheck disable=SC2053` with the
reason, rather than the "fix".

## 8. The bootstrap

The gate is bash under `tools/`, so **it lints itself and its own test**, and a case
asserts that (`discovery: the gate lints ITSELF`). It found two real things in its own
source on the first run: the SC1072/SC1073 directive-prose trap in its header (twice), and
an SC2053 on the glob comparison that is a genuine false positive and now carries a scoped
disable. Both are in the diff.

## 9. Also removed: an advisory check that could not fail

`tools/onboarding-factory/scripts/smoke-test.sh` already ran shellcheck over
`scripts/**` — with `|| true` per file, a trailing `echo` so the block always exited 0,
and a silent `(shellcheck not installed — skipped)` on a runner that ships none. So
"nothing was found" and "nothing looked" printed the same verdict, and that is where nine
of the 26 findings had been sitting. `bash-lint.sh` now covers that tree as a real gate,
so the advisory block is replaced by a pointer to it. Two mechanisms where one of them
cannot fail is worse than one that can.

## 10. Wiring

- `.github/workflows/linux.yml` — `Lint bash scripts` + `Test the bash-lint gate`, before
  `setup-go` (no toolchain, a couple of seconds, and behind the Go steps a compile error
  would abort the job and leave a tooling-only PR with no tooling feedback).
- `.github/workflows/test.yml` — `bash-lint_test.sh` added as a **second skip argument**
  (macos-latest ships no shellcheck; the gate refuses rather than skipping). Not a second
  loop: `shell_lib_suite_run` validates every skip name against the corpus before running
  anything.
- `tools/lib/shell-lib-suite_test.sh` — the "the skip names a real file" check now
  **derives** the list from the workflow step instead of hardcoding one filename. The
  one-file check would have gone on passing while saying nothing about the new entry.
- `tools/preflight.sh` — a new `bash` group (`--only bash`), same loose trigger as the
  posix gate and for the same reason: a *new* bash script is exactly the file the gate
  most needs to see on the push that adds it, and a trigger cannot enumerate one that
  does not exist yet.
- `AGENTS.md` — one bullet beside "POSIX shell scripts", carrying the four measured
  decisions.

## 11. Gates, stated honestly

| gate | result |
|---|---|
| `tools/preflight.sh --only bash` | **PASS** (83 files, `ALL PASS`) |
| `tools/preflight.sh --only tools` | **PASS** — `found 17, skipped 0, ran 17, failed 0` |
| `tools/preflight.sh --only posix` | **PASS** |
| `tools/preflight.sh --only skills` | **PASS** |
| `tools/bash-lint.sh` under shellcheck **0.9.0** | **PASS** (CI's version, run via a PATH stub) |
| `tools/lib/bash-lint_test.sh` under 0.11.0 and 0.9.0 | **ALL PASS** both |
| `tools/onboarding-factory/scripts/smoke-test.sh` | **PASS** |
| pre-push hook (`preflight --changed --budget 540`) | **PASS** — bash / tools / gofmt / replaydata validate / rig smoke / replay fixtures / macOS Swift all PASS; core, ARS, web, security SKIP (no matching files in the diff) |

Not run: `--only go`'s core suite and `--linux` — this diff touches no Go and no
`#!/bin/sh` file. `--only swift` ran via the hook and passed.

## Related

- **#1687** (filed) — the excluded `replaydata/` family, including the `contracts.sh`
  abandonment and the 8 × SC1125
- #1423, #1611 — the file-selection blindness class this is the third instance of
- #1661 — the `rm -rf` incident the SC2115 shape rhymes with
- #1681, #1683 — where this was flagged
