### PR TITLE
fix(macos): stop the notifications-master reconcile deciding from the machine (#1689)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1553,6 +1553,65 @@ Before marking a ticket done, run the full suite — every layer must pass:
   to adopt (0 additions across two suite-length windows, against ~1 plist/218s
   for the directory witness) but a growth-only check is green on any domain that
   already has the key, i.e. on the machine that found this.
+  **#1689 is the READ half of the same member, and its premise turned out to be
+  false in the useful direction.** `SettingsView.reconcileNotificationsMasterDefault()`
+  DECIDED from `UserDefaults.standard.object(forKey:)` and wrote through
+  `@AppStorage`, so under a pinned render the guard consulted the machine while
+  the write landed in the store the host supplied — and
+  `NotificationSettings.masterEnabled()` defaulted to `.standard` too, so the
+  VALUE came off the machine as well. Four things are worth carrying.
+  **`@AppStorage` CAN express "absent"**, which is what the issue (and the
+  #940 comment) assumed it could not, and it is why this needed no product seam
+  either: SwiftUI declares `AppStorage.init(_:store:)` for `Bool?` — and `Int?`,
+  `Double?`, `String?`, `URL?`, `Data?` — and an optional wrapper answers `nil`
+  for a key that is not in the store. So the fix is a second `@AppStorage` over
+  the same key, and the decision and the write are ONE store by construction
+  rather than two that a host keeps in sync; the alternative the issue proposed
+  (`SettingsView(defaults: UserDefaults = .standard)`, threaded to three call
+  sites) is a convention with a default argument, where this is a property of
+  SwiftUI's own resolution. Two wrappers over one key is not #1672's `@State`
+  mirror: neither caches, so they cannot disagree and there is no write-back
+  loop. The `anyEventEnabled` half comes from the view's three per-event
+  toggles — verbatim the expression it already used for its
+  blocked-notifications hint — with the RULE still
+  `NotificationSettings.masterEnabled(master:anyEventEnabled:)`.
+  **No real user was affected, and the proof is one grep**: nothing in the app
+  target applies `.defaultAppStorage(_:)`, so there `@AppStorage` and
+  `UserDefaults.standard` are the same domain and the guard cannot take the
+  wrong branch. It is a test-isolation defect wearing a user-facing shape, which
+  is the reverse of #1672 — and the equivalence is measured rather than argued,
+  over eight value shapes at one key (absent, `Bool`, `Int`, three `String`s):
+  the optional `@AppStorage` agrees with a bare `object(forKey:) == nil` and the
+  `Bool` one with `bool(forKey:)`'s coercion on all eight, including the five
+  only a hand-run `defaults write` can produce. The plausible alternative
+  (`object(forKey:) as? Bool == nil`) disagrees on five of them, which is what
+  makes that arm discriminating.
+  **The structural half is a FOURTH rule in `PersistentDefaultsLintTests`,
+  scoped to `Irrlicht/Views/` and banning the RECEIVER rather than a set of
+  accessors** — so a read, a mutation and a bare `UserDefaults.standard` handed
+  to something that takes a store are one rule. Reads stay legal everywhere else
+  for #1662's reason, and an app-wide read ban is not tractable: measured, 16
+  non-comment references exist in the app target and 14 are ordinary reads in
+  managers, models and the menu-bar controller, so the rule would arrive with 14
+  exemptions. The narrowing is a property, not a preference — `Irrlicht/Views/`
+  is exactly the set of files declaring a SwiftUI `View` (14 files; a `: View`
+  conformance appears nowhere else in the target) and it is the code
+  `PinnedSnapshotHost` pins. It held exactly two references, both reads, both
+  removed, so it carries no exemption list. Its declared limit is a false
+  NEGATIVE, not a false positive: a view calling a helper that reads the domain
+  for it is invisible (`MenuBarStyle` and `ContextPressureThreshold` both hold
+  such reads).
+  **And the mutation nobody asked for is again where the coverage was.** The
+  first lock written for the guard — "an explicit `notificationsEnabled = false`
+  is not overridden" — stays GREEN when the guard is deleted, because the fix
+  passes `master:` into the pure rule and `false ?? anyEventEnabled` is still
+  `false`. The value is held by the RULE; what the guard buys is that a render
+  whose key is already present persists NOTHING, i.e. #1672's write-back loop in
+  a second place, idempotent and therefore invisible to every value comparison.
+  Asserting it needs the key seeded through `register(defaults:)` rather than
+  `set`, so it is PRESENT for the read (`object(forKey:)` merges the domains)
+  while `writtenKeys` stays a clean observation of what the render itself
+  persisted.
   **The fourth member is the WALL CLOCK, and it is the one where pinning the
   other three would have looked like coverage** (#1663).
   `SessionListView.formatResetTime` stacked four machine reads —

--- a/platforms/macos/Irrlicht/Views/SettingsView.swift
+++ b/platforms/macos/Irrlicht/Views/SettingsView.swift
@@ -52,6 +52,26 @@ struct SettingsView: View {
     // existing notification setups don't silently vanish. Since #1183 this
     // also gates the firing path itself (`NotificationSettings.masterEnabled`).
     @AppStorage(NotificationSettings.masterEnabledKey) private var notificationsEnabled: Bool = false
+    /// The same key read as an OPTIONAL, so this view can tell an ABSENT master
+    /// key from a `false` one — the distinction
+    /// `reconcileNotificationsMasterDefault()` exists for (#1689).
+    ///
+    /// SwiftUI declares `AppStorage.init(_:store:)` for `Bool?` (and `Int?`,
+    /// `Double?`, `String?`, `URL?`, `Data?`), and an optional wrapper answers
+    /// `nil` for a key that is not in the store. So "absent" IS expressible
+    /// through `@AppStorage`, and expressing it that way is what makes the
+    /// reconcile's DECISION and its WRITE resolve one store: both are
+    /// `@AppStorage` over this key in this view, so `.defaultAppStorage(_:)`
+    /// moves them together and nothing can move one without the other. The read
+    /// this replaced was `UserDefaults.standard.object(forKey:)`, which under a
+    /// pinned render consulted the machine while the write landed in the pinned
+    /// store.
+    ///
+    /// Not a second COPY of the state, which is what #1672 was: neither wrapper
+    /// caches, both read the same store on every access, so they cannot disagree
+    /// and there is no write-back loop to guard. Nothing writes through this
+    /// one.
+    @AppStorage(NotificationSettings.masterEnabledKey) private var storedNotificationsMaster: Bool?
     @AppStorage(NotificationEvent.ready.enabledKey) private var notifyOnReady: Bool = false
     @AppStorage(NotificationEvent.waiting.enabledKey) private var notifyOnWaiting: Bool = false
     @AppStorage(NotificationEvent.contextPressure.enabledKey) private var notifyOnContextPressure: Bool = false
@@ -690,12 +710,29 @@ struct SettingsView: View {
     /// still absent from `UserDefaults` — once set (by this reconcile or by
     /// the user), it's never overridden again.
     ///
-    /// Materializes exactly what `NotificationSettings.masterEnabled()` already
+    /// Materializes exactly what `NotificationSettings.masterEnabled` already
     /// computes for the absent-key case, so the firing path (#1183) and this
     /// toggle share one definition of the fallback instead of two copies.
+    ///
+    /// Every value here comes from this view's own `@AppStorage` — the store the
+    /// write goes to — rather than from `UserDefaults.standard` (#1689):
+    ///
+    /// - **absent-ness** from `storedNotificationsMaster`, whose doc comment
+    ///   carries why an optional `@AppStorage` is the seam.
+    /// - **`anyEventEnabled`** from the three per-event toggles, which is the
+    ///   spelling this view already uses for its blocked-notifications hint
+    ///   above. The reconcile therefore agrees with what the user is looking at,
+    ///   where `allCases.contains { UserDefaults.standard.bool(forKey:) }` was a
+    ///   second reading of a second store.
+    /// - **the rule** still from `NotificationSettings`, whose pure form takes
+    ///   both inputs, so the fallback keeps one definition. `master:` is passed
+    ///   rather than assumed `nil`: the guard above already established that,
+    ///   and passing it means the guard and the decision read one value.
     private func reconcileNotificationsMasterDefault() {
-        guard UserDefaults.standard.object(forKey: NotificationSettings.masterEnabledKey) == nil else { return }
-        notificationsEnabled = NotificationSettings.masterEnabled()
+        guard storedNotificationsMaster == nil else { return }
+        notificationsEnabled = NotificationSettings.masterEnabled(
+            master: storedNotificationsMaster,
+            anyEventEnabled: notifyOnReady || notifyOnWaiting || notifyOnContextPressure)
     }
 
     private func checkNotificationAuth() {
@@ -706,9 +743,14 @@ struct SettingsView: View {
             DispatchQueue.main.async {
                 notificationsDenied = settings.authorizationStatus == .denied
             }
-            let anyEnabled = NotificationEvent.allCases.contains {
-                UserDefaults.standard.bool(forKey: $0.enabledKey)
-            }
+            // The view's own toggles, not a second read of
+            // `UserDefaults.standard` (#1689). Same values in the app — these
+            // `@AppStorage` wrappers resolve `.standard` there — and the same
+            // expression the hint above uses, so this view now holds no
+            // reference to the process domain at all, which is what
+            // `PersistentDefaultsLintTests`' fourth rule enforces over
+            // `Irrlicht/Views/`.
+            let anyEnabled = notifyOnReady || notifyOnWaiting || notifyOnContextPressure
             if settings.authorizationStatus == .notDetermined, anyEnabled {
                 DispatchQueue.main.async {
                     center.requestAuthorization(options: [.alert, .sound]) { granted, _ in

--- a/platforms/macos/Tests/PersistentDefaultsLintTests.swift
+++ b/platforms/macos/Tests/PersistentDefaultsLintTests.swift
@@ -51,17 +51,48 @@ import XCTest
 /// #1672's fix: the construct appears **zero** times in the app target, so the
 /// rule needs no exemption and gets none.
 ///
-/// READS are deliberately left alone, in both targets. `UserDefaults.standard.`
-/// `object(forKey:)` is how a test says "and the process domain was not
-/// touched", which is the assertion that would have caught this class in the
-/// first place; banning it would ban the evidence along with the defect. In the
-/// app a read is how `reconcileNotificationsMasterDefault()` distinguishes an
-/// absent key from a `false` one, which `@AppStorage` cannot express.
+/// READS are deliberately left legal by the three rules above, in both targets.
+/// `UserDefaults.standard.object(forKey:)` is how a test says "and the process
+/// domain was not touched", which is the assertion that would have caught this
+/// class in the first place; banning it would ban the evidence along with the
+/// defect. And app-target-wide a read ban is not tractable: measured, the app
+/// contains **16** `UserDefaults.standard` references outside comments, of which
+/// after #1689 **14** are ordinary reads in managers, models and the menu-bar
+/// controller — none of them a view, none reachable by any pin — so the rule
+/// would arrive with 14 exemptions, which is a list rather than a rule.
 ///
-/// There is deliberately **no exemption list** for any of the three rules, for
+/// **A fourth rule, narrowed to where a read IS a defect: `Irrlicht/Views/`.**
+/// #1689 is the read half of #1672 — `reconcileNotificationsMasterDefault()`
+/// DECIDED from `UserDefaults.standard.object(forKey:)` and wrote through
+/// `@AppStorage`, so under a pinned render the guard consulted the machine while
+/// the write landed in the store the host supplied. No mutation rule can see
+/// that, because the offending statement is a read. What makes the narrowing
+/// work rather than arbitrary is the measurement: `Irrlicht/Views/` is exactly
+/// the set of files declaring a SwiftUI `View` (14 files; `grep` for a `: View`
+/// conformance finds none anywhere else in the app target), it is the code
+/// `PinnedSnapshotHost` pins, and it held exactly **two** references to the
+/// process domain — `SettingsView.swift:697` and `:710`, both reads, both
+/// removed by #1689 — so this rule carries no exemption list either.
+///
+/// The rule bans the RECEIVER, not a set of accessors, so a read, a mutation and
+/// a bare `UserDefaults.standard` handed to a function that takes a store are
+/// one rule. In a view every one of them is the same defect: a value taken from
+/// the machine where the equivalent value was available from the INPUT.
+/// `@AppStorage` — including the optional form, which is how #1689 expresses
+/// "absent" — honours `.defaultAppStorage(_:)`, and a view that needs a whole
+/// store takes one (`SessionManager.init(defaults:)`).
+///
+/// Its declared limit is the same one a directory scan always has: a view
+/// calling a helper that reads the process domain for it is invisible here
+/// (`MenuBarStyle` and `ContextPressureThreshold` both contain such reads).
+/// That is a false NEGATIVE, so it cannot make the rule wrong — only incomplete
+/// — and closing it would need a call-graph, which is what the behavioural half
+/// (`PinnedAppStorageSnapshotTests`) covers for the sites that matter.
+///
+/// There is deliberately **no exemption list** for any of the four rules, for
 /// the reason `core/architecture_hookbody_test.go` gives: a test that genuinely
-/// needs a raw suite, or a genuine write to the process domain, amends this rule
-/// in a reviewable diff.
+/// needs a raw suite, or a genuine write to the process domain, or a view that
+/// genuinely cannot take its store, amends this rule in a reviewable diff.
 final class PersistentDefaultsLintTests: XCTestCase {
 
     // MARK: - The rule, as a pure function
@@ -88,11 +119,20 @@ final class PersistentDefaultsLintTests: XCTestCase {
         "UserDefaults" + #"\s*\.\s*standard\s*\.\s*(?:"#
         + mutators.joined(separator: "|") + #")\s*\("#
 
+    /// Any reference to the process preference domain at all — read, mutation or
+    /// the bare receiver passed along. Applied only to the view sources (#1689).
+    private static let processDomainPattern = "UserDefaults" + #"\s*\.\s*standard"#
+
     private static let testTargetDirectories = ["Tests", "TestsHarness"]
 
     /// The app target. One directory, and the walk below fails loudly if it is
     /// not there — a renamed target must not read as a clean tree.
     private static let appTargetDirectories = ["Irrlicht"]
+
+    /// The view sources — measured to be exactly the files declaring a SwiftUI
+    /// `View`, which is what makes the fourth rule's narrowing a property rather
+    /// than a preference. See the type's doc comment.
+    private static let viewTargetDirectories = ["Irrlicht/Views"]
 
     /// 1-based line numbers of every offending construction in `source`.
     ///
@@ -110,6 +150,13 @@ final class PersistentDefaultsLintTests: XCTestCase {
     /// `source`. Same comment handling, same declared limits.
     static func mutatingLines(in source: String) -> [Int] {
         lines(matching: mutationPattern, in: source)
+    }
+
+    /// 1-based line numbers of every reference to `UserDefaults.standard` in
+    /// `source`, whatever is done with it (#1689). Same comment handling, same
+    /// declared limits.
+    static func processDomainLines(in source: String) -> [Int] {
+        lines(matching: processDomainPattern, in: source)
     }
 
     private static func lines(matching pattern: String, in source: String) -> [Int] {
@@ -343,6 +390,127 @@ final class PersistentDefaultsLintTests: XCTestCase {
         XCTAssertFalse(Self.mutationCorpus.filter { !$0.want.isEmpty }.isEmpty, "no must-flag rows")
     }
 
+    // MARK: - Committed mutation evidence for the view rule (#1689)
+
+    /// One row per spelling, pinned to the verdict `processDomainLines` must
+    /// return.
+    ///
+    /// The first three rows are where this rule differs from the mutation rule
+    /// above and are the whole reason it exists: in a view a READ is a defect,
+    /// so it is flagged here and must stay legal there — asserted in both
+    /// directions below, because a "narrower rule" that turned out to be the
+    /// same rule would be indistinguishable from coverage. The `want: []` rows
+    /// carry the rest of the value: the `@AppStorage` declaration and the
+    /// injected store are the seams that REPLACE the construct, so a rule that
+    /// flagged either would ban its own fix.
+    private static let viewCorpus: [(name: String, source: String, want: [Int])] = [
+        (
+            "a READ is the whole point of THIS rule — #1689's guard was one",
+            "guard \(processDomain).object(forKey: k) == nil else { return }",
+            [1]
+        ),
+        (
+            "so is the coercing read the same view used for anyEventEnabled",
+            "let any = allCases.contains { \(processDomain).bool(forKey: $0.enabledKey) }",
+            [1]
+        ),
+        (
+            "handing the bare receiver to something that takes a store counts too — "
+                + "that is the shape a half-done store-threading refactor produces",
+            "notificationsEnabled = NotificationSettings.masterEnabled(defaults: \(processDomain))",
+            [1]
+        ),
+        (
+            "a mutation is flagged here as well: the two rules overlap in a view on purpose",
+            "\(processDomain).set(true, forKey: \"k\")",
+            [1]
+        ),
+        (
+            "whitespace around the dot does not evade it",
+            "UserDefaults" + " . standard .object(forKey: \"k\")",
+            [1]
+        ),
+        (
+            "every occurrence is reported, not only the first",
+            "let a = \(processDomain).bool(forKey: \"a\")\nlet unrelated = 1\nlet b = \(processDomain).bool(forKey: \"b\")",
+            [1, 3]
+        ),
+        (
+            "the seam that replaces it — an @AppStorage declaration names no store",
+            "@AppStorage(NotificationSettings.masterEnabledKey) private var master: Bool?",
+            []
+        ),
+        (
+            "nor does the optional form #1689 uses to express ABSENT",
+            "guard storedNotificationsMaster == nil else { return }",
+            []
+        ),
+        (
+            "a view that takes a whole store is reading its INPUT, not the machine",
+            "SessionManager(defaults: defaults).summaryDisplayMode",
+            []
+        ),
+        (
+            "a similarly named receiver is not UserDefaults.standard",
+            "standardDefaults.object(forKey: \"k\")",
+            []
+        ),
+        (
+            "a line comment naming the construct is documentation, not a call",
+            "// #1689: this used to read \(processDomain).object(forKey:)",
+            []
+        ),
+        (
+            "a doc comment naming it is documentation too",
+            "/// The read this replaced was \(processDomain).object(forKey:).",
+            []
+        ),
+        (
+            "LIMIT: a string literal holding the construct is flagged, because a line scan cannot tell it from a call",
+            "let needle = \"\(processDomain)\"",
+            [1]
+        ),
+        (
+            "LIMIT: a block comment holding the construct is flagged, for the same reason",
+            "/* \(processDomain).object(forKey: \"k\") */",
+            [1]
+        )
+    ]
+
+    func testViewScanReturnsThePinnedVerdictForEverySpelling() {
+        for row in Self.viewCorpus {
+            XCTAssertEqual(
+                Self.processDomainLines(in: row.source), row.want,
+                "\(row.name)\n---\n\(row.source)\n---"
+            )
+        }
+    }
+
+    /// The vacuity guard for the live view scan: after #1689 the construct
+    /// appears nowhere under `Irrlicht/Views/`, so "no offenders" and "the rule
+    /// stopped matching anything" are otherwise the same output.
+    func testTheViewCorpusContainsBothVerdicts() {
+        XCTAssertFalse(Self.viewCorpus.filter { $0.want.isEmpty }.isEmpty, "no must-not-flag rows")
+        XCTAssertFalse(Self.viewCorpus.filter { !$0.want.isEmpty }.isEmpty, "no must-flag rows")
+    }
+
+    /// The two rules are DIFFERENT rules, asserted rather than assumed.
+    ///
+    /// Without this, a view rule that had silently been written as the mutation
+    /// rule — or a `mutators` list that grew `object` — would pass every row
+    /// above and every live scan, while the reads #1689 is about went unflagged
+    /// in views and the reads #1662 deliberately protects went flagged
+    /// everywhere. Both directions are named because each is one edit away.
+    func testTheViewRuleAndTheMutationRuleDisagreeAboutReads() {
+        let read = "let before = \(Self.processDomain).object(forKey: \"summaryDisplayMode\")"
+        XCTAssertEqual(Self.processDomainLines(in: read), [1],
+                       "the view rule stopped flagging a read — it has collapsed into the "
+                       + "mutation rule and #1689's defect is invisible to it")
+        XCTAssertEqual(Self.mutatingLines(in: read), [],
+                       "the mutation rule started flagging a read — that bans the assertion "
+                       + "a test uses to prove the process domain was untouched (#1662)")
+    }
+
     // MARK: - The live scan
 
     /// Walks every Swift source in the test targets, applying `rule` to each,
@@ -447,6 +615,35 @@ final class PersistentDefaultsLintTests: XCTestCase {
             instead: `@AppStorage`, which honours `.defaultAppStorage(_:)`, or \
             an injected `UserDefaults` (`SessionManager.init(defaults:)`). \
             Reads are fine.
+
+            \(offenders.joined(separator: "\n"))
+            """
+        )
+    }
+
+    /// #1689: no VIEW touches the process preference domain at all — the half
+    /// the three rules above are blind to, because the offending statement is a
+    /// read and reads are legal everywhere else.
+    func testNoViewSourceResolvesTheProcessPreferenceDomain() throws {
+        let (offenders, filesScanned) = try scan(Self.viewTargetDirectories, Self.processDomainLines(in:))
+
+        XCTAssertGreaterThan(filesScanned, 0, "the scan read no Swift files — it checked nothing")
+        XCTAssertEqual(
+            offenders, [],
+            """
+            A view resolves UserDefaults.standard. In a view that is a value read \
+            from the MACHINE where the same value is available from the INPUT: \
+            `PinnedSnapshotHost` pins `.defaultAppStorage(_:)`, so a rendered view \
+            reads the preferences it is GIVEN — but only through a seam that \
+            honours it. A READ is enough to break that, which is why this rule is \
+            not the mutation rule above: #1689's \
+            `reconcileNotificationsMasterDefault()` DECIDED from this domain and \
+            wrote through `@AppStorage`, so under a pinned render the guard \
+            consulted the developer's com.apple.dt.xctest.tool while the write \
+            landed in the store the host supplied. Use `@AppStorage` — the \
+            optional form (`Bool?`) expresses an ABSENT key, which is what that \
+            guard needed — or take a `UserDefaults` the way \
+            `SessionManager.init(defaults:)` does.
 
             \(offenders.joined(separator: "\n"))
             """

--- a/platforms/macos/Tests/PinnedAppStorageSnapshotTests.swift
+++ b/platforms/macos/Tests/PinnedAppStorageSnapshotTests.swift
@@ -337,6 +337,15 @@ final class PinnedAppStorageSnapshotTests: XCTestCase {
     /// "wrote nothing" assertion passes vacuously under.
     private func renderSettingsPanel(_ store: InMemoryDefaults) -> PinnedSnapshotHost {
         store.set(true, forKey: NotificationSettings.masterEnabledKey)
+        return hostSettingsPanel(store)
+    }
+
+    /// The same render with NOTHING seeded — the state #1689's arms need, since
+    /// an absent `notificationsEnabled` is the only state
+    /// `reconcileNotificationsMasterDefault()` acts on. Split out of
+    /// `renderSettingsPanel` rather than parameterised so #1672's helper keeps
+    /// meaning exactly what its doc comment says.
+    private func hostSettingsPanel(_ store: InMemoryDefaults) -> PinnedSnapshotHost {
         let view = SettingsView(isPresented: .constant(true),
                                 showPermissionsReview: .constant(false),
                                 sessionManager: SessionManager(defaults: store))
@@ -412,4 +421,283 @@ final class PinnedAppStorageSnapshotTests: XCTestCase {
             """
         )
     }
+
+    // MARK: - A render DECIDES from the store it writes into (#1689)
+
+    /// #1689: `reconcileNotificationsMasterDefault()` read
+    /// `UserDefaults.standard.object(forKey:)` to decide whether the master key
+    /// was absent, and wrote the answer through `@AppStorage`. Under a pinned
+    /// render those are two different stores — the guard consulted the machine
+    /// while the write landed here — and `NotificationSettings.masterEnabled()`
+    /// defaulted to `.standard` too, so the VALUE came off the machine as well.
+    ///
+    /// ## What the expected value is, and why it is not written down
+    ///
+    /// Each arm computes it by calling the app's own
+    /// `NotificationSettings.masterEnabled(defaults:)` over a SECOND store
+    /// arranged identically — the untouched reference implementation, in the
+    /// condition the render leaves the driven store in (a `SessionManager` over
+    /// each, so both carry the `register(defaults:)` seed). A hand-written
+    /// `true`/`false` per row would be a second copy of the rule that could
+    /// drift from it, and the whole obligation here is that the seam did not
+    /// change what the reconcile decides — AGENTS.md's #1664 warning, where
+    /// `TimeZone.autoupdatingCurrent` read like the obvious mirror and was
+    /// measurably wrong.
+    ///
+    /// ## Why the arms are derived from `allCases`
+    ///
+    /// The fix reads "any event enabled" from this view's own three
+    /// `@AppStorage` toggles — the expression `SettingsView` already uses for
+    /// its blocked-notifications hint — instead of
+    /// `allCases.contains { defaults.bool(forKey:) }`. Those are two spellings
+    /// of one fact, so a fourth `NotificationEvent` that someone forgets to OR
+    /// in gets an arm here by existing rather than by being remembered.
+    ///
+    /// ## The two guards
+    ///
+    /// `readKeys` is the weak one and is here for fail-loud only: the master
+    /// key is read by the toggle's own `@AppStorage` whether the reconcile
+    /// consults this store or not, so it proves the panel rendered and asked,
+    /// not which store decided. `writtenKeys` is the discriminating one — the
+    /// pre-fix guard consulted a machine domain that HAS `notificationsEnabled`
+    /// (measured: `com.apple.dt.xctest.tool` holds `= 1`), returned early, and
+    /// persisted nothing at all.
+    func testTheMasterReconcileDecidesFromThePinnedStoreAndNotTheMachine() {
+        var arrangements: [(name: String, enabled: [NotificationEvent])] = [
+            ("no event enabled", [])
+        ]
+        for event in NotificationEvent.allCases {
+            arrangements.append(("only \(event.rawValue) enabled", [event]))
+        }
+        arrangements.append(("every event enabled", NotificationEvent.allCases))
+
+        for arrangement in arrangements {
+            let expected = NotificationSettings.masterEnabled(
+                defaults: arrangedStore(enabling: arrangement.enabled))
+
+            let store = arrangedStore(enabling: arrangement.enabled)
+            let host = hostSettingsPanel(store)
+            XCTAssertFalse(host.view.subviews.isEmpty,
+                           "\(arrangement.name): the panel hosted nothing — "
+                           + "this check cannot have run")
+            XCTAssertTrue(
+                store.readKeys.contains(NotificationSettings.masterEnabledKey),
+                "\(arrangement.name): nothing asked the pinned store for "
+                + "\(NotificationSettings.masterEnabledKey), so this arm proves nothing — "
+                + "the notifications section did not render")
+            XCTAssertTrue(
+                store.writtenKeys.contains(NotificationSettings.masterEnabledKey),
+                """
+                \(arrangement.name): the reconcile persisted no master default into the \
+                pinned store. Its guard is deciding from another store — \
+                UserDefaults.standard, which under `swift test` is the developer's \
+                com.apple.dt.xctest.tool and already holds \
+                \(NotificationSettings.masterEnabledKey) = \
+                \(String(describing: UserDefaults.standard.object(forKey: NotificationSettings.masterEnabledKey))), \
+                so it returns early. Everything this render wrote: \
+                \(store.writtenKeys.sorted()).
+                """
+            )
+            XCTAssertEqual(
+                store.object(forKey: NotificationSettings.masterEnabledKey) as? Bool, expected,
+                """
+                \(arrangement.name): the reconcile wrote \
+                \(String(describing: store.object(forKey: NotificationSettings.masterEnabledKey))) \
+                where the app's own NotificationSettings.masterEnabled(defaults:) computes \
+                \(expected) over the same store. The decision is reading preferences this \
+                render was not given.
+                """
+            )
+        }
+    }
+
+    /// A store carrying nothing but the named events' enable keys, plus the
+    /// `register(defaults:)` seed a `SessionManager` puts there — so the
+    /// reference implementation and the driven render read stores in the same
+    /// condition.
+    private func arrangedStore(enabling events: [NotificationEvent]) -> InMemoryDefaults {
+        let defaults = InMemoryDefaults()
+        for event in events { defaults.set(true, forKey: event.enabledKey) }
+        _ = SessionManager(defaults: defaults)
+        return defaults
+    }
+
+    /// The #940 semantic the reconcile exists inside, as a LOCK: a master key
+    /// that is present and `false` is the user's answer, and an enabled event
+    /// does not overrule it.
+    ///
+    /// It discriminates on a FRESH domain, where the pre-fix guard finds no
+    /// `notificationsEnabled` in `UserDefaults.standard`, gets past itself, and
+    /// writes the machine's per-event OR — `true` on this machine, whose three
+    /// `notifyOn*` keys are all `1` — over the `false` this store holds. On THIS
+    /// machine it passes both before and after the fix, and one mutation says why
+    /// that is not an oversight: **deleting the guard leaves this arm green**,
+    /// because the fix passes `master:` into `NotificationSettings.masterEnabled`
+    /// and `false ?? anyEventEnabled` is still `false`. The value is held by the
+    /// rule, so what the guard actually buys is the arm below, and the two are
+    /// separate tests for exactly that reason.
+    func testAnExplicitlyDisabledMasterSurvivesARenderWithEveryEventEnabled() {
+        let store = arrangedStore(enabling: NotificationEvent.allCases)
+        store.set(false, forKey: NotificationSettings.masterEnabledKey)
+
+        let host = hostSettingsPanel(store)
+        XCTAssertFalse(host.view.subviews.isEmpty,
+                       "the panel hosted nothing — this check cannot have run")
+        XCTAssertEqual(
+            store.object(forKey: NotificationSettings.masterEnabledKey) as? Bool, false,
+            "rendering Settings overrode an explicit `notificationsEnabled = false` — "
+            + "the one-time #940 migration is meant to run only while the key is ABSENT")
+    }
+
+    /// What the guard buys that the rule does not: a render whose master key is
+    /// already there PERSISTS NOTHING. #940 says the migration "runs only while
+    /// the key is still absent", and without the guard every render writes the
+    /// key back — #1672's write-back loop in a second place, idempotent and
+    /// therefore invisible to any value comparison (see
+    /// `InMemoryDefaults.writtenKeys`).
+    ///
+    /// The key is seeded through `register(defaults:)` rather than `set`, which
+    /// is the measurement device: registration makes it PRESENT for the read
+    /// (`object(forKey:)` merges the two domains, so the optional `@AppStorage`
+    /// answers non-nil exactly as the pre-fix `object(forKey:)` did) while
+    /// leaving the application domain — the only thing `writtenKeys` reports —
+    /// empty, so "the render persisted it" and "the test put it there" cannot be
+    /// confused. `true` is seeded rather than `false` so the whole notifications
+    /// section renders instead of staying collapsed.
+    ///
+    /// Note this arrangement is deliberately not one the app produces:
+    /// `NotificationSettings.masterEnabledKey` is kept out of `SessionManager`'s
+    /// `register(defaults:)` seed on purpose, because a registered value would
+    /// disable the upgrade fallback forever.
+    func testARenderWhoseMasterKeyIsAlreadyPresentPersistsNothing() {
+        let store = arrangedStore(enabling: NotificationEvent.allCases)
+        store.register(defaults: [NotificationSettings.masterEnabledKey: true])
+
+        let host = hostSettingsPanel(store)
+        XCTAssertFalse(host.view.subviews.isEmpty,
+                       "the panel hosted nothing — this check cannot have run")
+        XCTAssertTrue(
+            store.readKeys.contains(NotificationSettings.masterEnabledKey),
+            "nothing asked the pinned store for \(NotificationSettings.masterEnabledKey), "
+            + "so 'it persisted nothing' proves nothing")
+        XCTAssertFalse(
+            store.writtenKeys.contains(NotificationSettings.masterEnabledKey),
+            """
+            Rendering Settings re-persisted \(NotificationSettings.masterEnabledKey) \
+            although the key was already present. The one-time #940 migration is \
+            meant to run only while it is ABSENT; writing it on every render is \
+            #1672's write-back loop again, and an idempotent write is invisible to \
+            every value comparison and to the plist's mtime. Everything this \
+            render wrote: \(store.writtenKeys.sorted()).
+            """
+        )
+    }
+
+    // MARK: - The seam reads what the removed code read (#1689)
+
+    /// Reads one key through both `@AppStorage` spellings the fix relies on.
+    private struct BoolStorageProbe: View {
+        let key: String
+        let report: BoolStorageReport
+
+        @AppStorage private var flag: Bool
+        @AppStorage private var optional: Bool?
+
+        init(key: String, report: BoolStorageReport) {
+            self.key = key
+            self.report = report
+            self._flag = AppStorage(wrappedValue: false, key)
+            self._optional = AppStorage(key)
+        }
+
+        var body: some View {
+            report.flag = flag
+            report.optionalIsNil = optional == nil
+            report.rendered = true
+            return Color.clear
+        }
+    }
+
+    private final class BoolStorageReport {
+        var flag = false
+        var optionalIsNil = true
+        var rendered = false
+    }
+
+    /// The equivalence the fix rests on, measured rather than argued.
+    ///
+    /// #1689 replaces two reads with two `@AppStorage` reads of the same keys:
+    /// `UserDefaults.standard.object(forKey:) == nil` becomes an optional
+    /// `@AppStorage` answering `nil`, and
+    /// `allCases.contains { UserDefaults.standard.bool(forKey:) }` becomes the OR
+    /// of three `Bool` `@AppStorage`s. Requirement: in the app — where
+    /// `@AppStorage` resolves `.standard` — the new reads answer what the old
+    /// ones answered. AGENTS.md's #1664 note is why this is a test and not a
+    /// sentence: `TimeZone.autoupdatingCurrent` read like the obvious mirror of
+    /// `Locale.autoupdatingCurrent` and was measurably wrong.
+    ///
+    /// The shapes go beyond what the app can produce on purpose. Only the first
+    /// three are reachable — these keys are written exclusively through
+    /// `@AppStorage(…) var …: Bool` in `SettingsView` (the toggles and this
+    /// reconcile) and seeded as a Swift `Bool` by `SessionManager`'s
+    /// `register(defaults:)`; `git grep` over the app target finds no other
+    /// writer, and the web dashboard's same-named keys live in `localStorage`,
+    /// not in this domain. The other five are what a hand-run
+    /// `defaults write … -string` can leave there, and they are driven because
+    /// they are where the two spellings COULD differ:
+    ///
+    /// - the optional `@AppStorage` could plausibly have been
+    ///   `object(forKey:) as? Bool`, which answers `nil` for a `String` where
+    ///   the removed guard's bare `object(forKey:) == nil` answers `false`;
+    /// - the `Bool` `@AppStorage` could plausibly not apply
+    ///   `bool(forKey:)`'s string/number coercion.
+    ///
+    /// Measured on macOS 26 / Swift 6.2, neither is the case: all eight shapes
+    /// agree on both spellings, so the equivalence is complete rather than
+    /// merely covering the reachable set. Every row is therefore asserted, and
+    /// the table is printed (`IRR1689 …`) so the measurement is produced by the
+    /// run instead of living in this comment.
+    func testBothAppStorageSpellingsAnswerWhatTheRemovedReadsAnswered() {
+        for shape in Self.coercionShapes {
+            let store = InMemoryDefaults()
+            if let value = shape.value { store.set(value, forKey: "irrProbeKey") }
+
+            // What the removed code would have answered over this same store.
+            let objectWasNil = store.object(forKey: "irrProbeKey") == nil
+            let boolRead = store.bool(forKey: "irrProbeKey")
+
+            let report = BoolStorageReport()
+            _ = PinnedSnapshotHost(BoolStorageProbe(key: "irrProbeKey", report: report),
+                                   width: 40, height: 40, defaults: store)
+            XCTAssertTrue(report.rendered,
+                          "\(shape.name): the probe never rendered — this check cannot have run")
+
+            print("IRR1689 shape=\(shape.name) objectWasNil=\(objectWasNil) "
+                  + "optionalIsNil=\(report.optionalIsNil) "
+                  + "bool(forKey:)=\(boolRead) appStorageBool=\(report.flag)")
+
+            XCTAssertEqual(
+                report.optionalIsNil, objectWasNil,
+                "\(shape.name): the optional @AppStorage disagrees with "
+                + "object(forKey:) == nil, which is the guard #1689 replaced")
+            XCTAssertEqual(
+                report.flag, boolRead,
+                "\(shape.name): the Bool @AppStorage disagrees with bool(forKey:), "
+                + "which is what NotificationSettings.masterEnabled reads the "
+                + "per-event keys through")
+        }
+    }
+
+    /// Every shape the probe is driven with — the three the app can store at
+    /// these keys and five it cannot. See the arm above.
+    private static let coercionShapes: [(name: String, value: Any?)] = [
+        ("absent", nil),
+        ("Bool true", true),
+        ("Bool false", false),
+        ("Int 1", 1),
+        ("Int 0", 0),
+        ("String \"1\"", "1"),
+        ("String \"YES\"", "YES"),
+        ("String \"nonsense\"", "nonsense")
+    ]
 }


### PR DESCRIPTION
Closes #1689.

## The seam, and why that one

The issue's premise is false, in the useful direction, and that is what picked the seam.

> `@AppStorage` cannot express "absent", only "absent reads as `false`" … It needs the
> store, and SwiftUI exposes no public `\.defaultAppStorage` getter.

SwiftUI declares `AppStorage.init(_ key: String, store: UserDefaults? = nil)` for
`Bool?` — and for `Int?`, `Double?`, `String?`, `URL?`, `Data?` — and an optional
wrapper answers `nil` for a key that is not in the store. So the fix is a second
`@AppStorage` over the same key:

```swift
@AppStorage(NotificationSettings.masterEnabledKey) private var notificationsEnabled: Bool = false
@AppStorage(NotificationSettings.masterEnabledKey) private var storedNotificationsMaster: Bool?

private func reconcileNotificationsMasterDefault() {
    guard storedNotificationsMaster == nil else { return }
    notificationsEnabled = NotificationSettings.masterEnabled(
        master: storedNotificationsMaster,
        anyEventEnabled: notifyOnReady || notifyOnWaiting || notifyOnContextPressure)
}
```

That is **shape 1** in the preference order — an existing SwiftUI key already honoured,
needing no new product seam — and it is preferable to the alternative the issue proposes
(`SettingsView(defaults: UserDefaults = .standard)` threaded to three call sites) for a
reason beyond diff size: it makes the decision and the write **one store by
construction** rather than two kept in sync. Both are `@AppStorage` over the same key in
the same view, so `.defaultAppStorage(_:)` moves them together and there is no state in
which a host pins one and forgets the other. A default argument is a convention; this is
a property of SwiftUI's own resolution. The same argument #1662 made for the view half of
its member ("no product seam was needed"), one read later.

Three details worth stating:

- **Two wrappers over one key is not #1672's `@State` mirror.** Neither caches — both
  read the store on every access — so they cannot disagree and there is no write-back
  loop to guard. Nothing writes through the optional one.
- **`anyEventEnabled` comes from the view's own three per-event toggles**, which is
  verbatim the expression `SettingsView` already used eighteen lines above the guard for
  its blocked-notifications hint (`notificationsDenied && (notifyOnReady || notifyOnWaiting
  || notifyOnContextPressure)`). So the reconcile now agrees with what the user is
  looking at, where `allCases.contains { UserDefaults.standard.bool(forKey:) }` was a
  second reading of a second store. The RULE is still
  `NotificationSettings.masterEnabled(master:anyEventEnabled:)` — one definition of the
  fallback, as before.
- **`master:` is passed rather than assumed `nil`.** The guard already established it,
  and passing it means the guard and the decision read one value. Consequence recorded
  under mutation M1 below.

`checkNotificationAuth()`'s read (`SettingsView.swift:710` pre-fix) moves the same way.
Not required by the defect — the issue is right that it is gated on
`Bundle.main.bundleIdentifier != nil && pathExtension == "app"` and does not run under
`swift test` — but it is what leaves `Irrlicht/Views/` free of the process domain, which
is what lets the new lint rule carry no exemption list.

## Is a real user affected? No — proven, not assumed

The claim is "in the shipping app the guard cannot take the wrong branch", and the reason
is that `@AppStorage`'s store and `UserDefaults.standard` are the same object there. Two
greps over the app target, both run:

```
$ grep -rn "\.defaultAppStorage(" Irrlicht/
Irrlicht/Views/SettingsView.swift:64:   /// … so `.defaultAppStorage(_:)`      # doc comment
Irrlicht/Views/SettingsView.swift:974:  /// free — `@AppStorage` honours `.defaultAppStorage(_:)`, so   # doc comment
$ grep -rn "AppStorage(" Irrlicht/ | grep "store:"
(no output)
```

No application of `.defaultAppStorage(_:)` and no `@AppStorage(…, store:)` anywhere in
the app, so every `@AppStorage` resolves the environment default, which is
`UserDefaults.standard`. The guard read that same domain. **So this is a test-isolation
defect wearing a user-facing shape** — the reverse of #1672, which read like fixture
hygiene and was persisting two preferences into real user domains. It is stated as such
rather than inherited from the issue: the issue says "inert on this machine because the
key is present", which is true and is a *second*, weaker reason (measured below); the
load-bearing reason is that the two stores are one in the app.

What was live regardless: a pinned render was reading the machine at this site, which is
exactly the property #1662 exists to remove.

## Requirement 2: the seam does not change what the code resolves to

Two reads were replaced, so two equivalences are owed, and both are measured rather than
argued — AGENTS.md's #1664 note (`TimeZone.autoupdatingCurrent` read like the obvious
mirror and was measurably wrong) is why.

`testBothAppStorageSpellingsAnswerWhatTheRemovedReadsAnswered` drives one key through
both spellings over eight value shapes and prints the table on every run:

```
IRR1689 shape=absent            objectWasNil=true  optionalIsNil=true  bool(forKey:)=false appStorageBool=false
IRR1689 shape=Bool true         objectWasNil=false optionalIsNil=false bool(forKey:)=true  appStorageBool=true
IRR1689 shape=Bool false        objectWasNil=false optionalIsNil=false bool(forKey:)=false appStorageBool=false
IRR1689 shape=Int 1             objectWasNil=false optionalIsNil=false bool(forKey:)=true  appStorageBool=true
IRR1689 shape=Int 0             objectWasNil=false optionalIsNil=false bool(forKey:)=false appStorageBool=false
IRR1689 shape=String "1"        objectWasNil=false optionalIsNil=false bool(forKey:)=true  appStorageBool=true
IRR1689 shape=String "YES"      objectWasNil=false optionalIsNil=false bool(forKey:)=true  appStorageBool=true
IRR1689 shape=String "nonsense" objectWasNil=false optionalIsNil=false bool(forKey:)=false appStorageBool=false
```

Total agreement, on all eight — so the equivalence is complete rather than merely
covering the reachable set. Only the first three shapes are reachable in the app
(`git grep` finds these four keys written exclusively through `@AppStorage(…) var …: Bool`
in `SettingsView` and seeded as a Swift `Bool` by `SessionManager`'s
`register(defaults:)`; the web dashboard's same-named keys are `localStorage`). The other
five are driven because they are where the two spellings *could* have differed: the
plausible alternative reading `object(forKey:) as? Bool == nil` disagrees on five of
them, which is mutation M6.

The other equivalence — that the OR over three toggles computes what
`allCases.contains { bool(forKey:) }` computed — is asserted per arrangement in the
behavioural arm, whose expected value is produced by calling the app's own
`NotificationSettings.masterEnabled(defaults:)` over a second, identically arranged
store. No `true`/`false` is written down anywhere in the table, so it cannot drift from
the rule. The arrangements are derived from `NotificationEvent.allCases`, so a fourth
event nobody remembers to OR in gets an arm by existing.

## The read-side lint decision: tractable when narrowed to `Irrlicht/Views/`, measured

#1690's third rule scans the app target for `UserDefaults.standard` **mutations**; this
site is a read, so it is invisible to it. Measured before deciding:

| scope | non-comment `UserDefaults.standard` references | verdict |
|---|---|---|
| app target (`Irrlicht/`) | **16** — 14 outside `Views/`, all ordinary reads in `MenuBarController` (6), `MenuBarStyle` (3), `DaemonManager` (2), `LoginItemManager`, `SessionManager`, `ContextPressureThreshold`, `SessionState` | **intractable** — the rule would arrive with 14 exemptions, which is a list, not a rule |
| `Irrlicht/Views/` | **2**, both in `SettingsView.swift` (`:697`, `:710`), both reads, both removed by this PR | **adopted** — zero exemptions |

So the fourth rule is `testNoViewSourceResolvesTheProcessPreferenceDomain`, scoped to
`Irrlicht/Views/`. Three things about it:

- **It bans the RECEIVER, not a set of accessors** (`UserDefaults\s*\.\s*standard`), so a
  read, a mutation, and a bare `UserDefaults.standard` handed to a function that takes a
  store are one rule. In a view every one of them is the same defect: a value read from
  the MACHINE where the equivalent value was available from the INPUT.
- **The narrowing is a property, not a preference.** `Irrlicht/Views/` is exactly the set
  of files declaring a SwiftUI `View` — 14 files, and a `: View` conformance appears
  nowhere else in the app target (grepped) — and it is the code `PinnedSnapshotHost` pins.
- **Its declared limit is a false NEGATIVE**, so it cannot make the rule wrong, only
  incomplete: a view calling a helper that reads the domain for it is invisible here
  (`MenuBarStyle` and `ContextPressureThreshold` both hold such reads). Closing it needs a
  call graph; the behavioural half covers the sites that matter.

Its committed evidence is a 14-row corpus pinned to both verdicts (including the two
declared limits of a line scan that the existing corpora already carry), plus
`testTheViewRuleAndTheMutationRuleDisagreeAboutReads`, which asserts in both directions
that the fourth rule flags a read and the second one does not — because a "narrower rule"
that had silently become the same rule would pass every other check here.

## RED before, green after

`testTheMasterReconcileDecidesFromThePinnedStoreAndNotTheMachine`, on the pre-fix tree
(`swift test --filter PinnedAppStorageSnapshotTests`, 10 failures, one arrangement shown
of five):

```
PinnedAppStorageSnapshotTests.swift:488: error: … testTheMasterReconcileDecidesFromThePinnedStoreAndNotTheMachine :
XCTAssertTrue failed - only ready enabled: the reconcile persisted no master default into
the pinned store. Its guard is deciding from another store — UserDefaults.standard, which
under `swift test` is the developer's com.apple.dt.xctest.tool and already holds
notificationsEnabled = Optional(1), so it returns early. Everything this render wrote:
["notifyOnReady"].

PinnedAppStorageSnapshotTests.swift:501: error: … : XCTAssertEqual failed: ("nil") is not
equal to ("Optional(true)") - only ready enabled: the reconcile wrote nil where the app's
own NotificationSettings.masterEnabled(defaults:) computes true over the same store. The
decision is reading preferences this render was not given.

     Executed 10 tests, with 10 failures (0 unexpected) in 0.437 seconds
```

Note the failure message quotes the mechanism: the machine's domain *has* the key, so
pre-fix the guard returns early and writes nothing — which is the issue's "inert on this
machine", observed from inside the test rather than inferred.

After the fix: `Executed 12 tests, with 0 failures`.

## Mutation evidence

Everything added passes by construction, so each was broken deliberately. One mutation
per foreground command, applied by copy-aside and reverted by copy-back, with
`git status --porcelain` asserted afterwards each time (3 modified files, no more, no
fewer). Every mutation was also confirmed to have actually landed before the run, per
#1390.

| # | Mutation | Result |
|---|---|---|
| M1 | delete `guard storedNotificationsMaster == nil else { return }` | **RED**, exactly one arm: `testARenderWhoseMasterKeyIsAlreadyPresentPersistsNothing` — *"Rendering Settings re-persisted notificationsEnabled although the key was already present … Everything this render wrote: ["notificationsEnabled", "notifyOnContextPressure", "notifyOnReady", "notifyOnWaiting"]"*. All 11 other arms and the whole lint suite stay green |
| M2 | put back **only** the read in `checkNotificationAuth()`, not the guard | **RED**, exactly one arm: the new view lint rule, reporting `Irrlicht/Views/SettingsView.swift:754`. Every behavioural arm green — which is the point, since this is a read no behavioural test can reach (`checkNotificationAuth` is bundle-gated) |
| M3 | collapse the fourth rule into the mutation rule (`processDomainPattern = mutationPattern`) | **RED**: `testTheViewRuleAndTheMutationRuleDisagreeAboutReads` plus 7 corpus rows. The **live** view scan stays green, which is why that disagreement test exists |
| M4 | `hostSettingsPanel` stops passing `defaults:`, so the render resolves `UserDefaults.standard` | **RED**: the `readKeys` vacuity guards fire — *"nothing asked the pinned store for notificationsEnabled, so this arm proves nothing"* — plus #1672's own arm. The accident this guard exists for |
| M5 | drop the per-event OR (`anyEventEnabled: false`), keeping the store correct | **RED** on exactly the 4 arrangements with an event enabled: *"wrote Optional(false) … where NotificationSettings.masterEnabled(defaults:) computes true"*. The requirement-2 discriminator: right store, wrong decision |
| M6 | state the reference read as the plausible alternative (`object(forKey:) as? Bool == nil`) | **RED** on exactly the 5 non-`Bool` shapes. Proves the coercion table discriminates between the two candidate semantics instead of pinning a tautology |

### M1 is the one worth reading

It reddened nothing on its first attempt. The lock written for the guard —
*"an explicit `notificationsEnabled = false` is not overridden by an enabled event"* —
stayed **green** with the guard deleted, because the fix passes `master:` into the pure
rule and `false ?? anyEventEnabled` is still `false`. The value is held by the RULE, not
by the guard. What the guard actually buys is that a render whose key is already present
persists **nothing** — #1672's write-back loop in a second place, idempotent and
therefore invisible to every value comparison and to the plist's mtime.

Asserting that needs the key seeded through `register(defaults:)` rather than `set`, so
it is PRESENT for the read (`object(forKey:)` merges the two domains, so the optional
`@AppStorage` answers non-nil exactly as the pre-fix `object(forKey:)` did) while
`writtenKeys` — the application domain only — stays a clean observation of what the
render itself persisted. That arrangement is deliberately not one the app produces
(`masterEnabledKey` is kept out of `SessionManager`'s seed on purpose) and says so where
it lives. The value lock stays, with its inertness recorded in its own doc comment rather
than left to be rediscovered.

## Before / after key sets for `com.apple.dt.xctest.tool`

Same hard constraint #1690 recorded: a clean baseline for this domain is not obtainable
(the only ways to clear it are `defaults delete` on a real domain — forbidden after
#1661 — or redirecting the preferences root, which `InMemoryDefaults`' doc comment records
as measured and ineffective). So the comparison can only show "unchanged".

| | key count | state |
|---|---|---|
| baseline (before any run of mine) | 18 | `notificationsEnabled = 1`, `notifyOnReady = 1`, `notifyOnWaiting = 1`, `notifyOnContextPressure = 1`, `soundOnContextPressure = sosumi`, `soundOnReady = funk`; no `soundOnWaiting` |
| after gate run #1 | 18 | `diff` byte-identical, mtime `1786919878`, 631 B |
| after gate run #2 (the pre-push hook) | 18 | `diff` byte-identical, mtime `1786919878`, 631 B |

That baseline is also the measurement behind two claims in this PR: the key's presence is
why the pre-fix guard returns early here (the issue's "inert on this machine"), and the
three `notifyOn*` keys all reading `1` is why the value half would be wrong in the other
direction on a fresh domain.

The in-repo equivalent of a clean baseline is the empty `InMemoryDefaults` the new arms
start from: no master key at all, and the arm asserts what the render put there.

## What my work left behind: nothing

- `swift-suite.sh`'s real-home witness: `no new entries in Library/Preferences
  Library/Sounds under /Users/ingo`, on both gate runs.
- `~/Library/Preferences`: 204 entries, `diff` of the listing identical across both runs.
- `~/Library/Preferences/io.irrlicht.app.plist`: mtime `1786965780`, 135 B — unchanged
  throughout, including the pre-fix and mutation runs.
- `~/Library/Preferences/com.apple.dt.xctest.tool.plist`: mtime `1786919878`, 631 B
  throughout.
- `~/Library/Sounds`: 2 entries before and after.
- No `defaults write` or `defaults delete` was run against any real domain; nothing here
  deletes, moves or overwrites anything under the real home. Every mutation was a
  copy-aside/copy-back inside the worktree, and `~/prefs-rescue-2026-08-16/` was not
  touched, read from, or restored from.

## Gates

- `tools/preflight.sh --only swift` — **PASS**, exit status read directly (redirected to a
  file, `$?` on the next line, never through a pipe). **412 tests, 0 failures.** Per
  #1523 the exit code is the signal, not the totals line.
- Second run: the pre-push hook's `tools/preflight.sh --changed` — `gofmt` PASS,
  `macOS Swift build + test` PASS, every other gate correctly SKIP for a
  `platforms/macos/` + `AGENTS.md` diff. Push status read directly and
  `git status -sb` confirms the tracking branch.
- **Zero reference PNGs regenerated** — `git status --porcelain` names four files, none of
  them an image. The last five PRs in this family each changed zero PNGs and so does this
  one; the untouched set is itself the evidence that neither the seam nor the new arms
  changed any rendering.
- `tools/preflight.sh --only tools` — **not run and not owed**: this diff touches nothing
  under `tools/` (`git diff --stat` is `AGENTS.md` plus `platforms/macos/**`).
  `tools/lib/` was deliberately left alone — #1684 is active on that branch.
- CodeScene / ARS are advisory per AGENTS.md and were not chased. #1676 and #1686 both
  recorded that on these view files CodeScene flags argument count on exactly the code
  that is the fix.

## New defect filed

- **#1693** — `SessionManager.sendNotification` gates on
  `NotificationSettings.masterEnabled()`, which defaults to `UserDefaults.standard`, while
  the very next line reads the sound choice through the object's own injected `defaults`.
  Same family, a different call site with a different store provider, so it is filed
  rather than folded in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
