### PR TITLE
fix(macos): stop the notification firing path gating on the machine (#1693)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1736,6 +1736,54 @@ Before marking a ticket done, run the full suite — every layer must pass:
   `set`, so it is PRESENT for the read (`object(forKey:)` merges the domains)
   while `writtenKeys` stays a clean observation of what the render itself
   persisted.
+  **#1693 is that same read one call site on, and it is where this member's fix
+  stopped being a seam and became a REMOVAL.** `SessionManager.sendNotification`
+  guarded on `NotificationSettings.masterEnabled()` — default argument
+  `UserDefaults.standard` — while the next line read the sound choice from
+  `self.defaults`, so one method decided WHETHER to notify from the machine and
+  WHICH sound from its input, two frames below a
+  `checkStateTransitionNotification` that had just read `notifyOnReady` off that
+  same injected store. Four things are worth carrying.
+  **The DEFAULT ARGUMENT was the defect rather than the call, so it went.** Four
+  `UserDefaults = .standard` parameter defaults existed in the app target and
+  three had no caller relying on them (`masterEnabled`, `choice`,
+  `resolveNotificationSound`), so removing all three cost no call site anything —
+  the compile is that measurement — and the pre-fix spelling is now `error:
+  missing argument for parameter 'defaults' in call`. Where removal is possible
+  the compiler is a strictly stronger guard than a lint rule (#1659's shape),
+  which is the whole reason no fifth `PersistentDefaultsLintTests` rule was
+  added.
+  **That fifth rule was measured and rejected on its own terms, not by
+  inheriting #1689's count.** Re-measured here: the app target holds **14**
+  non-comment `UserDefaults.standard` receivers and `Irrlicht/Views/` holds
+  **0**, so widening the fourth rule app-wide is still intractable. The narrower
+  candidate — ban a default argument that resolves `.standard` — would today
+  flag exactly **one** declaration, `SessionManager.init(defaults:)`, which is
+  the seam all four existing rules' failure messages RECOMMEND; and removing
+  that default would push a `.standard` into `Irrlicht/Views/` (the
+  `SessionListView` preview), which rule 4 exists to keep out and which would
+  slip past it only because the leading-dot spelling evades its receiver regex.
+  A line scan also cannot tell an `init` default from a `func` default across a
+  multi-line signature without a parser, and per this section's parse rule it
+  would then have to flag both. One exemption or a parser: the count is recorded
+  instead.
+  **Under `swift test` the READ is the only observable, and that is not a
+  weakness of the test — it is why nothing graded this call site for its whole
+  life.** `canUseUserNotifications` is false outside an app bundle, so
+  `sendNotification` returns before scheduling a `UNNotificationRequest` or
+  reaching `SoundPlayer.speak` and the gate's DECISION has no downstream value
+  to assert on. `InMemoryDefaults.readKeys` is what remains, and "which store
+  was asked" IS the defect rather than a proxy for it. The discriminating arm
+  asserts the read SET equals what `NotificationSettings.masterEnabled(defaults:)`
+  performs over an identically arranged second store — obtained by calling the
+  rule, never written down — because a decorative `_ = defaults.object(forKey:)`
+  above a guard still resolving `.standard` satisfies "the store was asked" and
+  is invisible to every other assertion in the suite (measured: exactly that one
+  arm reddens).
+  **And the mutation that reddens NOTHING is recorded rather than omitted**:
+  re-adding the removed default alone, call site untouched, leaves all 414 tests
+  green. Nothing locks the removal — the guarantee is the compiler's, and only
+  for call sites that already exist.
   **The fourth member is the WALL CLOCK, and it is the one where pinning the
   other three would have looked like coverage** (#1663).
   `SessionListView.formatResetTime` stacked four machine reads —

--- a/platforms/macos/Irrlicht/Managers/SessionManager+Notifications.swift
+++ b/platforms/macos/Irrlicht/Managers/SessionManager+Notifications.swift
@@ -145,7 +145,14 @@ extension SessionManager {
         // future caller can route around it. Gating here rather than at the two
         // call sites is also why the spoken voice, which bypasses
         // UNNotificationContent entirely, is covered.
-        guard NotificationSettings.masterEnabled() else { return }
+        //
+        // `defaults` is passed, and `masterEnabled` no longer takes a default
+        // for it (#1693): this line used to call `masterEnabled()`, whose
+        // default argument was `UserDefaults.standard`, so one method decided
+        // WHETHER to notify from the machine and read WHICH sound from its
+        // input — the store `checkStateTransitionNotification` had just read
+        // `notifyOnReady`/`notifyOnWaiting` from two frames up.
+        guard NotificationSettings.masterEnabled(defaults: defaults) else { return }
         guard canUseUserNotifications else { return }
         let choice = Self.choice(for: event, defaults: defaults)
         let content = UNMutableNotificationContent()
@@ -209,7 +216,7 @@ extension SessionManager {
     /// directly to avoid double-reading UserDefaults.
     nonisolated static func resolveNotificationSound(
         for event: NotificationEvent,
-        defaults: UserDefaults = .standard
+        defaults: UserDefaults
     ) -> UNNotificationSound? {
         notificationSound(for: choice(for: event, defaults: defaults))
     }
@@ -218,9 +225,18 @@ extension SessionManager {
     /// a test driving this must not have to write the developer's real
     /// `com.apple.dt.xctest.tool` domain and put it back in a `tearDown` the
     /// aborting runs skip.
+    ///
+    /// It carries no DEFAULT for #1693's reason, which is the sibling of that
+    /// one: a store that can be omitted is a store nobody has to think about,
+    /// and the omission reads as "the caller decided" where it means "the
+    /// caller did not". `masterEnabled(defaults:)` above lost its default in
+    /// the same change — these two were the notification path's remaining
+    /// `UserDefaults = .standard` parameter defaults, both with zero callers
+    /// relying on them, so removal was free and the compiler now holds what a
+    /// lint rule would have had to.
     nonisolated static func choice(
         for event: NotificationEvent,
-        defaults: UserDefaults = .standard
+        defaults: UserDefaults
     ) -> SoundChoice {
         let raw = defaults.string(forKey: event.soundKey) ?? SoundChoice.default.rawValue
         return SoundChoice(rawValue: raw) ?? .default

--- a/platforms/macos/Irrlicht/Models/NotificationEvent.swift
+++ b/platforms/macos/Irrlicht/Models/NotificationEvent.swift
@@ -60,11 +60,26 @@ enum NotificationSettings {
         master ?? anyEventEnabled
     }
 
-    /// `UserDefaults`-reading wrapper, used by the firing path and by
-    /// `SettingsView`'s one-time reconcile. Reads through `object(forKey:)`
-    /// rather than `bool(forKey:)` — the latter flattens "absent" to `false`
-    /// and would silence exactly the installs the fallback exists for.
-    static func masterEnabled(defaults: UserDefaults = .standard) -> Bool {
+    /// `UserDefaults`-reading wrapper, used by the firing path. Reads through
+    /// `object(forKey:)` rather than `bool(forKey:)` — the latter flattens
+    /// "absent" to `false` and would silence exactly the installs the fallback
+    /// exists for.
+    ///
+    /// `defaults` is REQUIRED (#1693, #1659's shape). It defaulted to
+    /// `UserDefaults.standard`, and that default is what made #1693 possible
+    /// AND invisible: `SessionManager.sendNotification` called `masterEnabled()`
+    /// while the very next line read the sound choice from the store the object
+    /// was GIVEN, and nothing about the call site said which store it was
+    /// consulting. With the default gone, a call site that cannot name a store
+    /// is `error: missing argument for parameter 'defaults' in call` rather
+    /// than a silent read of the process domain — which under `swift test` is
+    /// the developer's own `com.apple.dt.xctest.tool`.
+    ///
+    /// Removing it cost no call site anything: the one production caller has a
+    /// store, `SettingsView`'s reconcile calls the pure
+    /// `masterEnabled(master:anyEventEnabled:)` since #1689, and every test
+    /// caller already passed one.
+    static func masterEnabled(defaults: UserDefaults) -> Bool {
         masterEnabled(
             master: defaults.object(forKey: masterEnabledKey) as? Bool,
             anyEventEnabled: NotificationEvent.allCases.contains { defaults.bool(forKey: $0.enabledKey) }

--- a/platforms/macos/Tests/SessionManagerNotificationStoreTests.swift
+++ b/platforms/macos/Tests/SessionManagerNotificationStoreTests.swift
@@ -1,0 +1,201 @@
+import XCTest
+@testable import Irrlicht
+
+/// #1693: the notification firing path must decide from the store the manager
+/// was GIVEN, never from the process preference domain.
+///
+/// # The defect
+///
+/// One method read two stores. `checkStateTransitionNotification` took
+/// `notifyOnReady` / `notifyOnWaiting` off `self.defaults` — the store #1662
+/// gave `SessionManager` so a test would not have to write the developer's real
+/// domain — and the `sendNotification` it then called guarded on
+/// `NotificationSettings.masterEnabled()`, whose default argument was
+/// `UserDefaults.standard`. Under `swift test` that is
+/// `com.apple.dt.xctest.tool`, a plist in the developer's own
+/// `~/Library/Preferences`; on the machine this was found on it holds
+/// `notificationsEnabled = 1`, so the gate answered "yes" whatever a fixture
+/// arranged. It is #1689's shape one call site further on: a guard gated on the
+/// right RULE and reading the wrong STORE.
+///
+/// # What is observable here, and what is not — stated rather than left implied
+///
+/// `sendNotification`'s second guard is `canUseUserNotifications`, which is
+/// false outside an app bundle, so under `swift test` the method returns before
+/// it can schedule a `UNNotificationRequest` or reach `SoundPlayer.speak`.
+/// There is therefore no downstream VALUE to assert on and the gate's decision
+/// is genuinely unobservable here — which is exactly why nothing graded this
+/// call site before.
+///
+/// The READ is observable. `InMemoryDefaults.readKeys` records every key the
+/// store was asked for, and "which store was asked" *is* the defect, not a
+/// proxy for it. Each arm therefore asserts on the keys the driven store was
+/// asked for during the call, and each takes a DELTA around the call rather
+/// than the whole set, so `SessionManager.init`'s own reads cannot be mistaken
+/// for the gate's.
+///
+/// Both arms assert `canUseUserNotifications` is false rather than assuming it:
+/// a runner that ever gained a bundle would otherwise fire real notifications
+/// at a developer and call `UNUserNotificationCenter.current()`, which traps
+/// outside one. That precondition's own mutation — making the property true —
+/// is not run, and the reason is recorded rather than skipped: it would make
+/// `setupNotificationDelegate()` reach `UNUserNotificationCenter.current()`
+/// from `init`, which aborts the whole runner, so the mutation destroys the
+/// harness instead of grading it.
+@MainActor
+final class SessionManagerNotificationStoreTests: XCTestCase {
+
+    // MARK: - Arms
+
+    /// The firing path's master gate asks the store the manager was given.
+    ///
+    /// Driven at `sendNotification` itself, the funnel every notification leaves
+    /// through, so the arm does not depend on any particular caller reaching it.
+    ///
+    /// The arrangement is the upgrade-fallback one `NotificationSettings`
+    /// exists for: `notificationsEnabled` absent, no event enabled. That makes
+    /// the gate answer *false*, so the method returns AT the gate — nothing
+    /// downstream is entered at all — and it is also the arrangement under
+    /// which `masterEnabled(defaults:)` reads the most keys, because
+    /// `allCases.contains` short-circuits on the first enabled event and here
+    /// there is none.
+    func testTheMasterGateAsksTheStoreTheManagerWasGiven() {
+        let (manager, store) = arrangedManager()
+        guard !manager.canUseUserNotifications else {
+            return XCTFail(bundleGuardMessage)
+        }
+
+        let before = store.readKeys
+        manager.sendNotification(
+            identifier: "irrlicht-state-sess_1693",
+            title: "Agent ready",
+            body: "irrlicht (main)",
+            sessionID: "sess_1693",
+            event: .ready)
+        let asked = store.readKeys.subtracting(before)
+
+        XCTAssertTrue(
+            asked.contains(NotificationSettings.masterEnabledKey),
+            """
+            sendNotification's master gate never asked the store this manager \
+            was GIVEN for \(NotificationSettings.masterEnabledKey). It is \
+            deciding from another one — UserDefaults.standard, which under \
+            `swift test` is the developer's com.apple.dt.xctest.tool and right \
+            now holds \(NotificationSettings.masterEnabledKey) = \
+            \(String(describing: UserDefaults.standard.object(forKey: NotificationSettings.masterEnabledKey))), \
+            so the gate answers that machine's setting whatever this fixture \
+            arranges. Everything the call did ask this store for: \
+            \(asked.sorted()).
+            """)
+
+        XCTAssertEqual(
+            asked, referenceReads(),
+            """
+            The gate asked this store, but not the way \
+            NotificationSettings.masterEnabled(defaults:) asks one. Driving \
+            sendNotification read \(asked.sorted()); calling the app's own rule \
+            over an identically arranged store reads \(referenceReads().sorted()). \
+            A read that does not DECIDE — the master key fetched and thrown \
+            away while the guard still resolves another store — satisfies the \
+            assertion above and is what this one separates out. The expected \
+            set is produced by calling the rule, never written down, so a \
+            fourth NotificationEvent is covered by existing.
+            """)
+    }
+
+    /// The two store reads inside one firing path land in one store — which is
+    /// the asymmetry #1693 is about, driven end to end through the production
+    /// entry point rather than at the funnel.
+    ///
+    /// `checkStateTransitionNotification` reads `notifyOnReady` /
+    /// `notifyOnWaiting` off `self.defaults` and then calls `sendNotification`,
+    /// whose gate read the process domain. Same object, same call chain, two
+    /// stores. The first assertion is the vacuity guard: without it a
+    /// transition that never reached the firing path at all reports the same
+    /// verdict as one whose gate read the wrong store.
+    func testTheTwoStoreReadsInOneFiringPathLandInTheSameStore() {
+        let (manager, store) = arrangedManager(enabling: [.ready])
+        guard !manager.canUseUserNotifications else {
+            return XCTFail(bundleGuardMessage)
+        }
+
+        let before = store.readKeys
+        manager.checkStateTransitionNotification(session: readySession(), previousState: .working)
+        let asked = store.readKeys.subtracting(before)
+
+        XCTAssertTrue(
+            asked.contains(NotificationEvent.ready.enabledKey),
+            """
+            checkStateTransitionNotification never asked this store for \
+            \(NotificationEvent.ready.enabledKey), so it did not reach the \
+            firing path and this arm proves nothing about the gate. Everything \
+            the call asked this store for: \(asked.sorted()).
+            """)
+
+        XCTAssertTrue(
+            asked.contains(NotificationSettings.masterEnabledKey),
+            """
+            One method, two stores: checkStateTransitionNotification read \
+            \(NotificationEvent.ready.enabledKey) off the store it was given \
+            and the sendNotification it called then decided from another one. \
+            UserDefaults.standard holds \
+            \(NotificationSettings.masterEnabledKey) = \
+            \(String(describing: UserDefaults.standard.object(forKey: NotificationSettings.masterEnabledKey))) \
+            here, so the gate's answer comes off this machine. Everything the \
+            call asked this store for: \(asked.sorted()).
+            """)
+    }
+
+    // MARK: - Fixtures
+
+    /// A manager over a store in the condition the app puts one in — nothing
+    /// but `SessionManager`'s own `register(defaults:)` seed — plus the named
+    /// events switched on.
+    ///
+    /// `masterEnabledKey` is deliberately never seeded, matching the app: it is
+    /// kept out of that seed on purpose so `object(forKey:)` can still answer
+    /// nil and the upgrade fallback stays reachable.
+    private func arrangedManager(enabling events: [NotificationEvent] = [])
+        -> (manager: SessionManager, store: InMemoryDefaults) {
+        let store = InMemoryDefaults()
+        for event in events { store.set(true, forKey: event.enabledKey) }
+        return (SessionManager(defaults: store), store)
+    }
+
+    /// The keys `NotificationSettings.masterEnabled(defaults:)` asks a store
+    /// for, measured by asking a second, identically arranged one — so the
+    /// expected set is produced by the app's own rule instead of being a key
+    /// list this file keeps in sync by hand.
+    private func referenceReads(enabling events: [NotificationEvent] = []) -> Set<String> {
+        let store = InMemoryDefaults()
+        for event in events { store.set(true, forKey: event.enabledKey) }
+        _ = SessionManager(defaults: store)
+        let before = store.readKeys
+        _ = NotificationSettings.masterEnabled(defaults: store)
+        return store.readKeys.subtracting(before)
+    }
+
+    private func readySession() -> SessionState {
+        SessionState(
+            id: "sess_1693",
+            state: .ready,
+            model: "claude-opus-4-7",
+            cwd: "/Users/test/projects/irrlicht",  // NOSONAR (swift:S1075) — test fixture value, not a real endpoint
+            transcriptPath: nil,
+            gitBranch: "main",
+            projectName: "irrlicht",
+            firstSeen: Date(timeIntervalSince1970: 1_700_000_000),
+            updatedAt: Date(timeIntervalSince1970: 1_700_000_000),
+            eventCount: 0,
+            lastEvent: nil)
+    }
+
+    private let bundleGuardMessage = """
+        canUseUserNotifications is TRUE under this runner. These arms drive \
+        sendNotification, which past that guard schedules a real \
+        UNNotificationRequest and calls UNUserNotificationCenter.current() — at \
+        a developer, from a test. Refusing rather than running: the arms below \
+        assert on which store the gate read, and neither needs the notification \
+        to be delivered.
+        """
+}


### PR DESCRIPTION
Closes #1693.

## The fix, and the seam

```diff
-        guard NotificationSettings.masterEnabled() else { return }
+        guard NotificationSettings.masterEnabled(defaults: defaults) else { return }
```

```diff
-    static func masterEnabled(defaults: UserDefaults = .standard) -> Bool {
+    static func masterEnabled(defaults: UserDefaults) -> Bool {
```

The issue calls the first line a one-token fix and then asks the real question:
should the default argument go at all. **It goes**, and so do the notification
path's two others, because that default is what made the defect possible *and*
invisible — nothing at the call site said which store it was consulting.

Measured before deciding, not after. The app target held **four**
`UserDefaults = .standard` parameter defaults:

| declaration | callers relying on the default | verdict |
|---|---|---|
| `NotificationSettings.masterEnabled(defaults:)` | **1** — the defect itself. `SettingsView`'s reconcile has called the pure `masterEnabled(master:anyEventEnabled:)` since #1689; every test caller already passed a store | removed |
| `SessionManager.choice(for:defaults:)` | 0 — both call sites (`sendNotification`, `resolveNotificationSound`) pass explicitly | removed |
| `SessionManager.resolveNotificationSound(for:defaults:)` | 0 — no production caller at all; 4 test callers in `SoundPlayerTests`, all explicit | removed |
| `SessionManager.init(defaults:)` | 8 — 2 production (`IrrlichtApp.swift:22`, `SessionListView.swift:1249`) + 6 tests | **kept** (see the lint section) |

So removal cost no call site anything, and the compile is that measurement
rather than a claim about it. `masterEnabled()` is now `error: missing argument
for parameter 'defaults' in call` — #1659's shape, and the reason this PR adds
no fifth lint rule: **where removal is possible the compiler is a strictly
stronger guard than a line scan.** The three lint rules that police
`UserDefaults.standard` exist because that expression is always well-typed and
the compiler can never object to it; a defaulted parameter is the one member of
this family the compiler *can* refuse, so it is refused.

## Is a real user affected? No — proven, not inherited

The claim is that in the shipping app `self.defaults` and `UserDefaults.standard`
are the same object, so the guard could not take a different branch from the
line below it. Two facts, both from source rather than from the issue:

```
$ git grep -n "SessionManager(" -- platforms/macos/Irrlicht
Irrlicht/IrrlichtApp.swift:22:              let sessionManager = SessionManager()
Irrlicht/Managers/SessionManager+Relay.swift:25:  /// … every SessionManager()   # doc comment
Irrlicht/Views/SessionListView.swift:1249:  let manager = SessionManager()      # PreviewProvider

$ git grep -n "\.defaults *=" -- platforms/macos/Irrlicht
Irrlicht/Managers/SessionManager.swift:300:        self.defaults = defaults      # the init assignment
```

Every production construction site takes the default `.standard`, and `defaults`
is a `let` assigned once in `init`, so nothing can rebind it afterwards. The
registration domain follows too: `init` calls `defaults.register(defaults:)` on
that same object, which is what the pre-fix `masterEnabled()` was reading
through. **So this is a test-isolation defect wearing a user-facing shape** —
#1689's shape one call site on.

**Under `swift test` it was live**, and the RED below shows it holding: the
injected store was asked for *nothing*.

## What is observable here, and what is not — stated rather than left implied

`sendNotification`'s second guard is `canUseUserNotifications`, false outside an
app bundle, so under `swift test` the method returns before scheduling a
`UNNotificationRequest` or reaching `SoundPlayer.speak`. There is no downstream
value to assert on and the gate's DECISION is genuinely unobservable — which is
also why nothing graded this call site for its whole life.

The READ is observable, and "which store was asked" **is** the defect rather
than a proxy for it. `InMemoryDefaults.readKeys` is the instrument; each arm
takes a DELTA around the call so `SessionManager.init`'s own reads cannot be
mistaken for the gate's. Both arms assert `canUseUserNotifications` is false
rather than assuming it — verified empirically on the first run (neither arm
took that branch), and a runner that gained a bundle now refuses instead of
firing real notifications at a developer.

That precondition's own mutation is **not run, with the reason recorded** rather
than skipped: making the property true would have `setupNotificationDelegate()`
reach `UNUserNotificationCenter.current()` from `init`, which traps outside an
app bundle and aborts the whole runner. The mutation destroys the harness
instead of grading it.

## RED before

`swift test --filter SessionManagerNotificationStoreTests`, against the tree
with the fix not yet applied — **exit status 1, 2 tests, 3 failures**:

```
SessionManagerNotificationStoreTests.swift:77: error: … testTheMasterGateAsksTheStoreTheManagerWasGiven :
XCTAssertTrue failed - sendNotification's master gate never asked the store this
manager was GIVEN for notificationsEnabled. It is deciding from another one —
UserDefaults.standard, which under `swift test` is the developer's
com.apple.dt.xctest.tool and right now holds notificationsEnabled = Optional(1),
so the gate answers that machine's setting whatever this fixture arranges.
Everything the call did ask this store for: [].

SessionManagerNotificationStoreTests.swift:91: error: … : XCTAssertEqual failed:
("[]") is not equal to ("["notifyOnReady", "notifyOnWaiting",
"notificationsEnabled", "notifyOnContextPressure"]") - The gate asked this store,
but not the way NotificationSettings.masterEnabled(defaults:) asks one. …

SessionManagerNotificationStoreTests.swift:135: error: … testTheTwoStoreReadsInOneFiringPathLandInTheSameStore :
XCTAssertTrue failed - One method, two stores: checkStateTransitionNotification
read notifyOnReady off the store it was given and the sendNotification it called
then decided from another one. UserDefaults.standard holds notificationsEnabled =
Optional(1) here, so the gate's answer comes off this machine. Everything the
call asked this store for: ["notifyOnReady", "notifyOnWaiting"].

     Executed 2 tests, with 3 failures (0 unexpected) in 0.021 seconds
```

The third message is the issue's asymmetry rendered as a measurement: lines
108-109 asked the injected store, line 148 did not. And the first observes the
mechanism from inside rather than inferring it — the machine's domain *has* the
key, at `1`, so the pre-fix gate answered "yes" whatever a fixture arranged.

**Green after**: `Executed 2 tests, with 0 failures`, and the full suite
`Executed 414 tests, with 0 failures`.

## Mutation evidence

One mutation per foreground command, applied by copy-aside and reverted by
copy-back, `git status --porcelain` asserted afterwards each time (3 files, no
more, no fewer), and each confirmed to have actually landed before the run (per
#1390 — a `diff` that came back empty aborts instead of running). Every run is
the **full** suite, so "exactly these arms" is a measurement over 414 tests.

| # | Mutation | Result |
|---|---|---|
| M1 | delete the master guard line entirely | **RED**, exactly the 2 new arms (3 assertions). Everything else green |
| M2 | restore the pre-fix spelling — re-add the default argument *and* call `masterEnabled()` | **RED**, the identical 3 assertions. This is the red-first run, reproduced from the merged tree |
| M3 | decorative read: `_ = defaults.object(forKey: masterEnabledKey)` above a guard still resolving `UserDefaults.standard` | **RED on exactly one assertion** — arm 1's read-set equality. Arm 1's "the store was asked" assertion stays green, arm 2 stays green, and the whole of `PersistentDefaultsLintTests` stays green |
| M4 | `checkStateTransitionNotification` returns before the firing path (`!= nil` → `== nil`) | **RED**, exactly arm 2, and the **vacuity guard reports it**: *"never asked this store for notifyOnReady, so it did not reach the firing path and this arm proves nothing about the gate"* — not the defect message. Arm 1 unaffected |
| M5 | re-add the removed default argument alone, call site untouched | **GREEN — 414 tests, 0 failures.** Reported rather than omitted; see below |

### M3 is the one that justifies the second assertion

Per #1692's M1 lesson: an assertion phrased so that the *presence* of a read
satisfies it is satisfied by a read that decides nothing. M3 is that code, and
it is expressible — `UserDefaults.standard` in `Irrlicht/Managers/` is invisible
to rule 3 (a read, not a mutation) and to rule 4 (scoped to `Irrlicht/Views/`),
which M3 confirms by leaving the entire lint suite green. What separates it is
the read SET: the arm asserts the delta equals what
`NotificationSettings.masterEnabled(defaults:)` performs over an identically
arranged second store. That expected set is **obtained by calling the rule**,
never written down, so a fourth `NotificationEvent` is covered by existing, and
the fixture is deliberately the arrangement where `allCases.contains`
short-circuits on nothing — master absent, no event enabled — which is also the
arrangement where the gate answers *false* and the method returns AT the guard.

### M5 is a gap, not an omission

Nothing in the suite locks the default-argument removal: re-adding it is green.
The guarantee is the compiler's, and only for call sites that already exist. A
fifth lint rule is what would close it — which is exactly the decision below,
so the gap is stated where the decision is made rather than left for a reader
to notice.

## The lint decision: measured, and not adopted

Re-measured here rather than inherited from #1692, with a scanner mirroring
`PersistentDefaultsLintTests`' own comment-blanking:

| scope | non-comment `UserDefaults.standard` receivers | `UserDefaults = .standard` default args |
|---|---|---|
| app target (`Irrlicht/`, 75 files) | **14** — all outside `Views/`, all ordinary reads in `MenuBarController` (6), `MenuBarStyle` (3), `DaemonManager` (2), `LoginItemManager`, `ContextPressureThreshold`, `SessionState` | **1 after this PR** (was 4) |
| `Irrlicht/Views/` (21 files) | **0** | **0** |

**Widening rule 4 app-wide is still intractable** — 14 exemptions, which is a
list, not a rule. That number is #1692's, re-derived rather than quoted.

**The narrower candidate — "a default argument that resolves `.standard`" — is
not tractable either, and the reasons are specific:**

1. After this PR it would flag exactly **one** declaration:
   `SessionManager.init(defaults:)`. That is the seam **all four existing rules'
   failure messages recommend** ("take a `UserDefaults` the way
   `SessionManager.init(defaults:)` does"). A rule that flags its own prescribed
   fix is the wrong rule.
2. Removing that default to reach zero exemptions would make
   `SessionListView_Previews` read `SessionManager(defaults: .standard)` — a
   `.standard` in `Irrlicht/Views/`, which rule 4 exists to keep out, and which
   would slip past rule 4 only because the leading-dot spelling evades its
   `UserDefaults\s*\.\s*standard` receiver regex. It also puts `.standard` into
   6 test files that currently say nothing about it.
3. A line/regex scan cannot tell an `init` default from a `func` default: all
   three removed declarations and the `init` put the default on a line carrying
   neither keyword (multi-line signatures), and a cross-line pattern bounded by
   braces would include or exclude the `init` by an accident of what precedes
   it. Per this repo's rule a validator that cannot parse its input checks MORE,
   which lands back on point 1.

So: one exemption, or a parser. Neither is worth it against a guarantee the
compiler already holds for every call site that exists. **The count is recorded
in AGENTS.md so the next agent in this family re-decides from a number rather
than from a paragraph.**

## Before / after key sets for `com.apple.dt.xctest.tool`

Same constraint #1690 and #1692 recorded: a clean baseline for this domain is
not obtainable (the only routes are `defaults delete` on a real domain —
forbidden after #1661 — or redirecting the preferences root, which
`InMemoryDefaults`' doc comment records as measured and ineffective). So the
comparison can only show "unchanged", and it does.

| | keys | state |
|---|---|---|
| baseline (before any run of mine) | **18** | `notificationsEnabled = 1`, `notifyOnReady = 1`, `notifyOnWaiting = 1`, `notifyOnContextPressure = 1`, `soundOnReady = funk`, `soundOnContextPressure = sosumi`; no `soundOnWaiting` |
| after gate run #1 (`--only swift`) | **18** | `diff` byte-identical; plist mtime `1786919878`, 631 B |
| after gate run #2 (the pre-push hook) | **18** | `diff` byte-identical; same mtime and size |

That baseline is also the measurement behind the RED: `notificationsEnabled = 1`
is *why* the pre-fix gate answered yes here, quoted by the failure message
itself.

The in-repo equivalent of a clean baseline is the empty `InMemoryDefaults` each
arm starts from — no master key at all, which is the upgrade-fallback state the
rule exists for.

## What my work left behind: nothing

- `swift-suite.sh`'s real-home witness: `no new entries in Library/Preferences
  Library/Sounds under /Users/ingo`, on both gate runs.
- `~/Library/Preferences`: **207** entries, listing `diff` identical across
  baseline and both runs.
- `~/Library/Preferences/io.irrlicht.app.plist`: mtime `1787090295`, 146 B —
  unchanged throughout, including the pre-fix and all five mutation runs.
- `~/Library/Preferences/com.apple.dt.xctest.tool.plist`: mtime `1786919878`,
  631 B throughout.
- `~/Library/Sounds`: 2 entries before and after.
- No `defaults write` or `defaults delete` against any real domain; no
  `killall cfprefsd`. Every mutation was a copy-aside/copy-back inside the
  worktree, reverted with `git status --porcelain` asserted — never `git stash`,
  `git checkout --`, `git restore` or `git reset`. `~/prefs-rescue-2026-08-16/`
  and `~/irrlicht-hookconfig-baseline-2026-08-18/` were not touched, read from
  or restored from. `LauncherTestHarness` / `LauncherHarnessTests` never ran.

## Gates

- `tools/preflight.sh --only swift` — **PASS**, exit status read directly
  (redirected to a file, `$?` on the next line, never through a pipe).
  **414 tests, 0 failures.** Per #1523 the exit code is the signal, not the
  totals line.
- Second run: the pre-push hook's `tools/preflight.sh --changed --budget 540` —
  `gofmt` PASS, `macOS Swift build + test` PASS, every other gate correctly SKIP
  for a `platforms/macos/` + `AGENTS.md` diff. Push status read directly
  (exit 0) and `git status -sb` confirms the tracking branch.
- **Zero reference PNGs regenerated** — verified here: `git status --porcelain`
  names four files, none of them an image, and `git diff --stat origin/main`
  lists three. The untouched reference set is itself the evidence that neither
  the removal nor the new arms changed any rendering. (That the preceding six
  PRs in this family also changed none is inherited from #1692's record, not
  re-verified here.)
- `--only go` / `--only tools` — **not run and not owed**: `git diff --stat`
  is `AGENTS.md` plus `platforms/macos/**`. Two other agents are active in
  `core/` and `tools/` on this repo, so those trees were deliberately not
  touched.
- CodeScene / ARS are advisory per AGENTS.md and were not chased.

## Noted while here, not fixed

M4 is the measurement: inverting `checkStateTransitionNotification`'s
subagent-skip guard (`parentSessionId != nil` → `== nil`) reddens **only** the
new arm. Before this PR that method — the production entry point for every
ready/waiting notification — had no test coverage at all, including its #-noise
subagent skip. Not filed as a defect (nothing is wrong with the code), but it is
why arm 2 drives the production path rather than only the `sendNotification`
funnel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
