### PR TITLE
fix(replay): grade the Stop hook — a table row, and the stale per-pass flag that made it a no-op (#1695)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1438,6 +1438,52 @@ Before marking a ticket done, run the full suite — every layer must pass:
   nothing objecting. One recording remains in `knownZeroTransition` because
   reaching it needs 69ms, i.e. it can only be bought by making two goldens
   assert something false — the trade this whole line of work exists to refuse.
+- Replay's hook channel: replay grades a recorded hook through exactly two
+  shared things — `session.hookSignalEffects`, which decides whether a hook
+  NAME does anything at all, and `applyHookEvent`, which decides whether the
+  effect reaches the classifier. Both had to be right before any hook was
+  gradeable, and #1695 is the run where only the first was looked at.
+  **A hook absent from the table is silently dropped**, which is #1320's
+  lesson; `HookStop` was absent on the stated grounds that its effect "carries
+  a payload a name-keyed lookup cannot supply". True about the payload, false
+  about the consequence: `signalPolicies`' turn-done `apply` guards BOTH
+  payload fields, so a payload-free hold still asserts `HookTurnDone` and the
+  degradation is one-directional — it can add to the cue verdict and can never
+  clear one the transcript found. That row is now present, and
+  `TestPayloadFreeTurnDoneNeverClearsATranscriptCue` is the property rather
+  than the paragraph. What the row does NOT replace is
+  `SessionDetector.HandleStopHook`, which has the payload and must keep it:
+  dropping the payload while keeping the hold reddens exactly one arm of
+  `TestSessionDetector_StopHook_DrivesTheTurnDoneTransition`, the turn that
+  ended on a question, and that arm is the whole argument for the two
+  entry points coexisting.
+  **The second half is the one that reads as health.** With the row added and
+  nothing else, every golden stayed byte-identical — `applyHookEvent` copied
+  `r.lastMetrics`, whose `NoSubstantiveActivity` belongs to the last TRANSCRIPT
+  batch, and `runClassifier`'s mirror of #329's short-circuit then discarded a
+  classification that had already answered `ready`. The flag is PER PASS and a
+  hook pass is a different pass; the daemon never had the problem because its
+  synthetic activity event goes through `RefreshOnActivity`, which recomputes
+  it. So a hook table row is worth checking end-to-end against a recording, not
+  just against the table's own test.
+  The payoff is that `cause` in a golden finally means something: a
+  hook-produced `ready` (`cause: "hook"`, at the hook's own timestamp) and a
+  transcript-produced one (`cause: "debounce_coalesce"`) are different bytes,
+  so the provenance question needed no new field. codex's
+  `2-13_turn-end-terminal-text` went from 2 of 4 recorded transitions
+  reproduced to 4 of 4 with zero mismatches, and #1388's two ">1s drift"
+  entries left that population — those were the short-circuit, not the
+  "structural" debounce lag they were recorded as.
+  Only ONE recording in the catalog can grade a Stop, and the register that
+  says so is machine-generated (`stopHookCensus`,
+  `TestStopHookIsGradedByTheCommittedCatalog`) because a hand-written one is
+  what #1695 had to correct: `replaydata/agents/claudecode/` carries no
+  Stop-bearing sidecar at all, and the catalog's other two Stops belong to
+  co-resident claude-code sessions inside another adapter's multi-agent
+  recording — one naming a session the replay does not drive, one on a sidecar
+  that cannot drive a replay. A catalog with no Stop at all is a REFUSAL there,
+  not a pass.
+
 - Replay goldens (when a recording or replay-output change is in play):
   regenerate with `UPDATE_REPLAY_GOLDENS=1 go test
   ./tools/onboarding-factory/cmd/replay/... -count=1` (the `-count=1`

--- a/core/application/services/session_detector_stop_hook_e2e_test.go
+++ b/core/application/services/session_detector_stop_hook_e2e_test.go
@@ -1,0 +1,111 @@
+package services_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"irrlicht/core/domain/session"
+)
+
+// TestSessionDetector_StopHook_DrivesTheTurnDoneTransition covers what #1695
+// measured to be covered by NOTHING: SessionDetector.HandleStopHook's EFFECT.
+//
+// The gap was total and easy to mistake for coverage. Every `HandleStopHook`
+// reference in a `_test.go` before this file is a mock — claudecode's, codex's
+// and copilot's `mockTarget` — so the receiving adapters grade the CALL, and
+// deleting the `signals.Hold(…, SignalTurnDone, …)` line from the real handler
+// left `go test ./core/...` green apart from an unrelated tmux flake, plus the
+// whole replay byte-identity gate green. #1695's fix makes the replay half of
+// that red for a recording that carries a Stop; this file is the other half,
+// and it is the half no golden can reach, because the payload the daemon
+// threads in — the turn's final assistant text and the waiting-cue verdict
+// computed over the FULL message (#1150) — is not a field of lifecycle.Event
+// and so is absent from every recording on disk.
+//
+// Both arms were seen red against the deletion above. The second is also red
+// against a weaker mutation — dropping the payload and keeping the hold, i.e.
+// exactly what the hookSignalEffects row alone delivers — which is why
+// HandleStopHook stays a dedicated entry point beside that row rather than
+// being replaced by it.
+func TestSessionDetector_StopHook_DrivesTheTurnDoneTransition(t *testing.T) {
+	tests := []struct {
+		name string
+		// what the hook's payload carries, i.e. what only the daemon has.
+		lastAssistantText string
+		waitingCue        bool
+		want              string
+		why               string
+	}{
+		{
+			name:              "plain turn end → ready",
+			lastAssistantText: "Done. All tests pass.",
+			waitingCue:        false,
+			want:              session.StateReady,
+			why: "the Stop hook is the authoritative turn-done signal (#1161); " +
+				"without its hold the transcript tail alone says the turn is still running",
+		},
+		{
+			name:              "turn ended on a question → waiting",
+			lastAssistantText: "I can take either branch — which one should I target?",
+			waitingCue:        true,
+			want:              session.StateWaiting,
+			why: "the cue was computed over the hook's full message (#1150); the " +
+				"transcript tail below carries none, so only the payload can route this to waiting",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tw := newMockAgentWatcher()
+			pw := newMockProcessWatcher()
+			repo := newMockRepo()
+
+			const sid = "stop1"
+			const path = "/home/.claude/projects/-Users-test/stop1.jsonl"
+
+			// The transcript says the turn is NOT over: "assistant_message" is
+			// codex's spelling and is deliberately outside IsAgentDone's
+			// "assistant"/"assistant_output" fallback, so nothing here can
+			// reach ready on its own. The tail carries no cue either, so the
+			// waiting arm cannot be satisfied by prose the classifier already
+			// sees. Every state below is therefore the hook's doing.
+			metrics := &funcMetrics{fn: func(_, _ string) (*session.SessionMetrics, error) {
+				return &session.SessionMetrics{
+					LastEventType:     "assistant_message",
+					LastAssistantText: "Working on it.",
+				}, nil
+			}}
+
+			det := newDetectorWithMetrics(tw, pw, repo, metrics)
+			repo.states[sid] = &session.SessionState{
+				SessionID:      sid,
+				State:          session.StateWorking,
+				TranscriptPath: path,
+				FirstSeen:      time.Now().Unix(),
+				UpdatedAt:      time.Now().Unix(),
+				Metrics:        &session.SessionMetrics{LastEventType: "assistant_message"},
+			}
+
+			// LIFO: registering the drain first makes teardown cancel() then
+			// wait for Run to return, which is what reaps the goroutine.
+			done := make(chan error, 1)
+			defer func() { <-done }()
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			go func() { done <- det.Run(ctx) }()
+
+			time.Sleep(20 * time.Millisecond) // let seedFromDisk finish
+
+			det.HandleStopHook(sid, path, tt.lastAssistantText, tt.waitingCue)
+			waitForSessionState(repo, sid, tt.want, 5*time.Second)
+
+			repo.mu.Lock()
+			got := repo.lastSavedState[sid]
+			repo.mu.Unlock()
+			if got != tt.want {
+				t.Fatalf("after Stop hook: state = %q, want %q — %s", got, tt.want, tt.why)
+			}
+		})
+	}
+}

--- a/core/domain/session/hook_signal.go
+++ b/core/domain/session/hook_signal.go
@@ -64,13 +64,34 @@ type HookSignalEffect struct {
 // hookSignalEffects is the single source of truth for hook-name → SignalKind
 // for the hooks a caller may act on knowing only the name.
 //
-// Three hooks are absent, for two different reasons — worth keeping apart,
-// because they imply different things about whether a future row belongs here:
+// Two hooks are absent. A third, HookStop, was — and the reason it was is
+// worth stating, because it was measured to be wrong in exactly one step
+// (#1695):
 //
-//   - HookStop genuinely cannot be a row. Its effect carries a payload (the
-//     turn's final assistant text and the waiting-cue verdict computed from it)
-//     into SignalPayload, and a name-keyed lookup has no way to supply that.
-//     HandleStopHook stays a dedicated entry point.
+//   - HookStop carries a payload (the turn's final assistant text and the
+//     waiting-cue verdict computed over the *full* message rather than the
+//     200-rune transcript tail, #1150) which a name-keyed lookup cannot
+//     supply. That much is true, and it is why HandleStopHook stays a
+//     dedicated entry point — the daemon has the payload and must not lose it.
+//     What does NOT follow, and is what kept this row out until #1695, is that
+//     a name-only caller therefore cannot act. Read signalPolicies' turn-done
+//     row: its apply sets HookTurnDone unconditionally and guards BOTH payload
+//     fields (`if c.Payload.LastAssistantText != ""`, `if c.Payload.WaitingCue`),
+//     so a payload-free hold delivers the signal's whole assertion — the turn
+//     ended, authoritatively — and the degradation is ONE-DIRECTIONAL: it can
+//     add nothing to the cue verdict, and can never clear or mask a cue the
+//     transcript already found on its own. It also cannot pin, because that
+//     row is consumeOnce. TestPayloadFreeTurnDoneNeverClearsATranscriptCue is
+//     that property as a test rather than as this paragraph.
+//     So the row is an honest floor, not a lie: a name-only caller gets a
+//     correct-but-weaker verdict, and the one thing it gives up is a cue that
+//     sits outside the transcript tail.
+//     The cost of leaving it out was concrete. The replay harness reads this
+//     table, so with no row it dropped every recorded Stop, and the
+//     hook-produced `ready` in codex's 2-13_turn-end-terminal-text golden was
+//     reproduced from the transcript's own turn_done two seconds later — the
+//     same bytes as a transcript-produced ready, so a Stop-handling regression
+//     was invisible to every golden in the catalog (#1695, filed off #1388).
 //   - HookNotification and HookPreCompact are excluded only because their
 //     *gate* is adapter-side: the claudecode HTTP handler forwards Notification
 //     solely for notification_type "idle_prompt" and PreCompact solely for
@@ -102,6 +123,13 @@ var hookSignalEffects = map[string]HookSignalEffect{
 	// The tool ran, so whatever was blocking on it no longer is.
 	HookPostToolUse:        {Signal: SignalPermissionPrompt, Release: true},
 	HookPostToolUseFailure: {Signal: SignalPermissionPrompt, Release: true},
+	// The turn ended, authoritatively, at true turn end (#1161). Name-only
+	// here: a caller with the hook's payload — SessionDetector.HandleStopHook,
+	// which every adapter routes Stop through — holds SignalTurnDone itself
+	// and supplies it, so this row is what a caller WITHOUT the payload gets
+	// (the replay harness). See the paragraph above for why that is a floor
+	// rather than a wrong answer.
+	HookStop: {Signal: SignalTurnDone},
 }
 
 // HookSignal reports the signal effect of a hook event name. ok is false for a

--- a/core/domain/session/hook_signal_test.go
+++ b/core/domain/session/hook_signal_test.go
@@ -1,6 +1,9 @@
 package session
 
-import "testing"
+import (
+	"testing"
+	"time"
+)
 
 // TestHookSignalTable pins the hook-name → SignalKind mapping that
 // SessionDetector.HandlePermissionHook and the replay harness's applyHookEvent
@@ -22,9 +25,15 @@ func TestHookSignalTable(t *testing.T) {
 		{HookPostToolUse, SignalPermissionPrompt, true, true},
 		{HookPostToolUseFailure, SignalPermissionPrompt, true, true},
 
-		// Payload-gated: the name alone does not determine the effect, so
-		// these are absent from the table by design (see hookSignalEffects).
-		{HookStop, "", false, false},
+		// Payload-ENRICHED rather than payload-gated (#1695): the name alone
+		// determines the signal, and the payload only ever adds to it. A
+		// caller holding this row's effect gets a correct-but-weaker verdict —
+		// see hookSignalEffects, and
+		// TestPayloadFreeTurnDoneNeverClearsATranscriptCue for the property
+		// that makes "weaker" true rather than "wrong".
+		{HookStop, SignalTurnDone, false, true},
+
+		// Gated adapter-side: no recording in replaydata/ fires one yet.
 		{HookNotification, "", false, false},
 		{HookPreCompact, "", false, false},
 
@@ -59,4 +68,78 @@ func TestHookSignalEffectsReferenceKnownSignals(t *testing.T) {
 				hookName, effect.Signal)
 		}
 	}
+}
+
+// TestPayloadFreeTurnDoneNeverClearsATranscriptCue is the property that makes
+// HookStop safe as a hookSignalEffects row (#1695). The row hands a name-only
+// caller a SignalTurnDone hold with an EMPTY SignalPayload, and the question
+// that decides whether that is a floor or a lie is what an empty payload does
+// to a cue the transcript already found: if it overwrote PendingWaitingCue and
+// LastAssistantText, a turn that ended on a question would be forced to ready
+// and the row would be actively wrong. It does not — signalPolicies' turn-done
+// apply guards both fields — so the degradation is one-directional: the hook
+// can push a finished turn to waiting, and can never pull one out of it.
+//
+// Seen red by deliberately unguarding that apply (`c.Metrics.PendingWaitingCue
+// = c.Payload.WaitingCue`, and the same for LastAssistantText): the first arm
+// fails on all three of its assertions, the second stays green — it locks the
+// enrichment direction, which the mutation does not break.
+//
+// Stated rather than left implied, because it changes what this test is worth:
+// the two GUARDS were already locked, by TestSignalHolds_TurnDonePreservesPriorText
+// and TestSignalHolds_TurnDoneCueIsAdditive in signal_hold_test.go, and both go
+// red on the same mutation. What is new here is the CONCLUSION those locks
+// support and neither states — that after an empty-payload overlay the metrics
+// still answer IsWaitingForUserInput() true — which is the whole of the
+// argument for the HookStop row and is the assertion that would survive a
+// future apply rewritten to reach the same fields another way.
+func TestPayloadFreeTurnDoneNeverClearsATranscriptCue(t *testing.T) {
+	const sid = "s1"
+	at := time.Unix(1_700_000_000, 0)
+
+	t.Run("cue found by the transcript survives an empty payload", func(t *testing.T) {
+		h := NewSignalHolds()
+		h.Hold(sid, SignalTurnDone, SignalPayload{}, at)
+
+		m := &SessionMetrics{
+			LastEventType:     "assistant_message",
+			LastAssistantText: "Which branch should I target?",
+			PendingWaitingCue: true,
+		}
+		h.Overlay(sid, m, at)
+
+		if !m.HookTurnDone {
+			t.Fatal("empty-payload turn-done hold did not set HookTurnDone: the row asserts nothing")
+		}
+		if !m.PendingWaitingCue {
+			t.Error("empty payload cleared PendingWaitingCue: the row would force a question-ended turn to ready")
+		}
+		if m.LastAssistantText != "Which branch should I target?" {
+			t.Errorf("empty payload overwrote LastAssistantText = %q, want the transcript's own text", m.LastAssistantText)
+		}
+		if !m.IsWaitingForUserInput() {
+			t.Error("IsWaitingForUserInput() is false after an empty-payload turn-done overlay: the cue was lost")
+		}
+	})
+
+	t.Run("payload can add a cue the transcript missed", func(t *testing.T) {
+		h := NewSignalHolds()
+		h.Hold(sid, SignalTurnDone, SignalPayload{
+			LastAssistantText: "…and which branch should I target?",
+			WaitingCue:        true,
+		}, at)
+
+		// The transcript tail carried no cue (#1150: the question sits before
+		// the 200-rune tail). This is what the daemon's payload buys and what
+		// a name-only caller gives up.
+		m := &SessionMetrics{LastEventType: "assistant_message", LastAssistantText: "Done."}
+		h.Overlay(sid, m, at)
+
+		if !m.PendingWaitingCue {
+			t.Error("payload WaitingCue did not reach the metrics: HandleStopHook's enrichment is a no-op")
+		}
+		if !m.IsWaitingForUserInput() {
+			t.Error("IsWaitingForUserInput() is false: the hook-delivered cue did not route the turn to waiting")
+		}
+	})
 }

--- a/core/domain/session/metrics.go
+++ b/core/domain/session/metrics.go
@@ -262,7 +262,11 @@ type SessionMetrics struct {
 	// true turn end (issue #1161). Transient and live-only: the detector's
 	// SignalTurnDone policy applies it for the single classify pass the Stop
 	// hook triggered and then releases the hold (consume-once), so it never
-	// bleeds into the next turn and is never set under replay. IsAgentDone()
+	// bleeds into the next turn. It IS set under replay since #1695 — the
+	// harness holds the same signal off a recorded hook_received{Stop}, with
+	// an empty SignalPayload (see hookSignalEffects) — which is what makes a
+	// hook-produced ready distinguishable from a transcript-produced one in a
+	// committed golden. IsAgentDone()
 	// treats it as authoritative, taking precedence over the transcript-tail
 	// heuristic (and its codex carve-out) below.
 	HookTurnDone bool `json:"-"`
@@ -538,7 +542,8 @@ func (m *SessionMetrics) IsAgentDone() bool {
 	// overlaid by the detector for claudecode. It takes precedence over the
 	// transcript-tail signals below — a clean, per-adapter turn-done push that
 	// doesn't depend on the "assistant"/"assistant_output" heuristic (and its
-	// codex carve-out). Only ever set live, never under replay. Checked after
+	// codex carve-out). Set live, and — since #1695 — under replay too, from a
+	// recorded hook_received{Stop} via hookSignalEffects. Checked after
 	// the open-tool / live-background guards so a Stop that fires while a
 	// sub-agent tool or Bash run_in_background is still outstanding does not
 	// prematurely flip the session to ready.

--- a/replaydata/agents/claudecode/scenarios/5-4_architect-editor-pair/recordings/2026-05-29-23-33-27_irrlichd-0.4.7+37990a5/transcript.jsonl.replay.json.golden
+++ b/replaydata/agents/claudecode/scenarios/5-4_architect-editor-pair/recordings/2026-05-29-23-33-27_irrlichd-0.4.7+37990a5/transcript.jsonl.replay.json.golden
@@ -16,8 +16,8 @@
     "wall_clock_session_duration": 55086476000,
     "state_durations": {
       "ready": 20602189000,
-      "waiting": 10443012000,
-      "working": 24041275000
+      "waiting": 10548103000,
+      "working": 23936184000
     },
     "flicker_count": 1,
     "flickers_by_category": {
@@ -63,9 +63,9 @@
     },
     {
       "index": 2,
-      "event_index": 5,
-      "virtual_time": "2026-05-29T23:34:37.398345+02:00",
-      "cause": "debounce_coalesce",
+      "event_index": -1,
+      "virtual_time": "2026-05-29T23:34:37.293254+02:00",
+      "cause": "hook",
       "prev_state": "working",
       "new_state": "waiting",
       "reason": "permission prompt open → waiting",

--- a/replaydata/agents/codex/scenarios/2-13_turn-end-terminal-text/recordings/2026-08-18-00-42-27_irrlichd-0.5.10+1869727/transcript.jsonl.replay.json.golden
+++ b/replaydata/agents/codex/scenarios/2-13_turn-end-terminal-text/recordings/2026-08-18-00-42-27_irrlichd-0.5.10+1869727/transcript.jsonl.replay.json.golden
@@ -10,18 +10,21 @@
   "summary": {
     "total_events": 12,
     "consumed_events": 12,
-    "total_transitions": 3,
+    "total_transitions": 5,
     "first_event_time": "2026-08-18T00:42:33.531567+02:00",
     "last_event_time": "2026-08-18T00:42:38.225446+02:00",
     "wall_clock_session_duration": 4693879000,
     "state_durations": {
-      "working": 4693879000
+      "ready": 2017806000,
+      "working": 2676073000
     },
-    "flicker_count": 1,
+    "flicker_count": 2,
     "flickers_by_category": {
+      "ready_between_working": 1,
       "working_between_ready": 1
     },
     "flickers_by_reason": {
+      "agent finished turn → ready": 1,
       "force ready→working on first activity": 1
     },
     "cum_input_tokens": 23773,
@@ -59,6 +62,35 @@
     },
     {
       "index": 2,
+      "event_index": -1,
+      "virtual_time": "2026-08-18T00:42:36.20764+02:00",
+      "cause": "hook",
+      "prev_state": "working",
+      "new_state": "ready",
+      "reason": "agent finished turn → ready",
+      "last_event_type": "user_message",
+      "has_open_tool": false,
+      "is_agent_done": true,
+      "needs_user_attention": false,
+      "waiting_for_user_input": false
+    },
+    {
+      "index": 3,
+      "event_index": 11,
+      "virtual_time": "2026-08-18T00:42:38.225446+02:00",
+      "cause": "debounce_coalesce",
+      "prev_state": "ready",
+      "new_state": "working",
+      "reason": "force ready→working on first activity",
+      "last_event_type": "turn_done",
+      "has_open_tool": false,
+      "is_agent_done": true,
+      "needs_user_attention": false,
+      "waiting_for_user_input": false,
+      "last_assistant_text_head": "The capital of France is Paris."
+    },
+    {
+      "index": 4,
       "event_index": 11,
       "virtual_time": "2026-08-18T00:42:38.225446+02:00",
       "cause": "debounce_coalesce",
@@ -111,20 +143,8 @@
   "extended_check": {
     "sidecar_path": "",
     "recorded_transition_count": 4,
-    "replayed_transition_count": 2,
-    "ordered_matches": 2,
-    "ordered_mismatches": [
-      {
-        "index": 2,
-        "kind": "missing_in_replay",
-        "recorded": "ready→working"
-      },
-      {
-        "index": 3,
-        "kind": "missing_in_replay",
-        "recorded": "working→ready"
-      }
-    ],
+    "replayed_transition_count": 4,
+    "ordered_matches": 4,
     "recorded_unique_kinds": [
       "ready→working",
       "working→ready"

--- a/replaydata/agents/codex/scenarios/2-19_tool-gate-permission-prompt/recordings/2026-08-18-00-40-25_irrlichd-0.5.10+1869727/transcript.jsonl.replay.json.golden
+++ b/replaydata/agents/codex/scenarios/2-19_tool-gate-permission-prompt/recordings/2026-08-18-00-40-25_irrlichd-0.5.10+1869727/transcript.jsonl.replay.json.golden
@@ -12,11 +12,11 @@
     "consumed_events": 19,
     "total_transitions": 3,
     "first_event_time": "2026-08-18T00:40:35.743301+02:00",
-    "last_event_time": "2026-08-18T00:40:48.977475+02:00",
-    "wall_clock_session_duration": 13234174000,
+    "last_event_time": "2026-08-18T00:40:47.019525+02:00",
+    "wall_clock_session_duration": 11276224000,
     "state_durations": {
       "ready": 2376333000,
-      "working": 10857841000
+      "working": 8899891000
     },
     "flicker_count": 0,
     "flickers_by_category": {},
@@ -56,21 +56,18 @@
     },
     {
       "index": 2,
-      "event_index": 18,
-      "virtual_time": "2026-08-18T00:40:48.977475+02:00",
-      "cause": "debounce_coalesce",
+      "event_index": -1,
+      "virtual_time": "2026-08-18T00:40:47.019525+02:00",
+      "cause": "hook",
       "prev_state": "working",
       "new_state": "waiting",
       "reason": "permission prompt open → waiting",
-      "last_event_type": "function_call",
-      "has_open_tool": true,
-      "open_tool_names": [
-        "exec"
-      ],
+      "last_event_type": "function_call_output",
+      "has_open_tool": false,
       "is_agent_done": false,
       "needs_user_attention": false,
-      "waiting_for_user_input": false,
-      "last_assistant_text_head": "The explicit escalation route isn’t accepted by this workspace’s permission …"
+      "waiting_for_user_input": true,
+      "last_assistant_text_head": "I’ll create `hello.txt` with the exact two-byte content `hi` using the shell, …"
     }
   ],
   "sessions": [

--- a/tools/onboarding-factory/cmd/replay/issue1480_timing_test.go
+++ b/tools/onboarding-factory/cmd/replay/issue1480_timing_test.go
@@ -266,8 +266,20 @@ var knownFirstTransitionDrift = map[string]string{
 // at 2s. Measured on 2-19: hook_received at 00:40:47.019, golden
 // virtual_time 00:40:48.977 — 1.96s, one debounce window. It is the same
 // bimodal population `driftThreshold` was cut from, not a new mode.
+//
+// #1695 moved it back, 107 -> 105, and the reason is the same sentence read in
+// reverse. That "structural" cause was a defect after all: replay flipped at
+// the next debounce boundary because applyHookEvent carried a stale per-pass
+// NoSubstantiveActivity into the hook's own pass, so #329's short-circuit ate
+// the hook-time classification and the transition fell through to the next
+// debounce flush. With that fixed, both codex recordings flip at the hook's own
+// timestamp — 2-19's pair is now 00:40:47.019 against a golden virtual_time of
+// 00:40:47.019 — and both leave this population, taking it back below where
+// #1388 found it. Re-tightened rather than left at 107, per the #1517 note
+// below: a bound that absorbs an improvement as slack makes the next
+// regression free.
 const (
-	maxRecordingsDriftingOverThreshold = 107
+	maxRecordingsDriftingOverThreshold = 105
 	maxRecordingsDriftingOver5s        = 50
 )
 
@@ -296,8 +308,13 @@ const (
 // its two codex recordings took the population from 828/275 to 832/277.
 // Leaving the old values would have let the growth sit as slack, which is
 // precisely the #1517 mistake that paragraph records.
+// #1695 re-tightened the pair floor again, 832 -> 834: replay now reproduces
+// codex 2-13's hook-driven transition and the two it had been hiding, so that
+// recording contributes two more kind-matched pairs. The recording floor does
+// not move — 2-13 was already measuring — which is the shape to expect here,
+// since a recording joins this population once and then only adds pairs.
 const (
-	minKindMatchedPairs   = 832
+	minKindMatchedPairs   = 834
 	minMeasuredRecordings = 277
 )
 

--- a/tools/onboarding-factory/cmd/replay/issue1503_census_test.go
+++ b/tools/onboarding-factory/cmd/replay/issue1503_census_test.go
@@ -112,8 +112,8 @@ var censusOfTheCommittedCatalog = catalogCensus{
 	Recordings:                313,
 	Zero:                      1,
 	Fabricated:                1,
-	Divergent:                 143,
-	DivergentByCountsAndKinds: 142,
+	Divergent:                 142,
+	DivergentByCountsAndKinds: 141,
 	UnpairedSidecars:          0,
 	PairedButUngraded:         85,
 }

--- a/tools/onboarding-factory/cmd/replay/issue1518_census_lint_test.go
+++ b/tools/onboarding-factory/cmd/replay/issue1518_census_lint_test.go
@@ -121,20 +121,19 @@ var coincidentalCensusFigures = []censusFigureExemption{
 	},
 	{
 		File:   "replay_sidecar.go",
-		Marker: "+ 2ms cluster window",
+		Marker: "+ 28ms cluster (rejected)",
 		Reason: "the divergent column of a REJECTED cluster-window configuration " +
 			"in #1478's calibration table. The block above it says the columns " +
 			"'no longer equal the live gate's figures' and to read the table as a " +
-			"comparison between rows. It coincides with Divergent.",
+			"comparison between rows. It coincides with DivergentByCountsAndKinds.",
 	},
 	{
 		File:   "replay_sidecar.go",
 		Marker: "+ 69ms cluster (rejected)",
 		Reason: "the divergent column of another rejected row of the same #1478 " +
-			"table, coinciding with DivergentByCountsAndKinds. That two rejected " +
-			"rows collide with two different census fields is coincidence twice " +
-			"over, which is the strongest argument available that neither is a " +
-			"restatement.",
+			"table, coinciding with Divergent. That two rejected rows collide " +
+			"with two different census fields is coincidence twice over, which is " +
+			"the strongest argument available that neither is a restatement.",
 	},
 }
 
@@ -147,6 +146,14 @@ var coincidentalCensusFigures = []censusFigureExemption{
 // restated a live figure could not behave that way — it would have tracked the
 // figure rather than being overtaken by it. The existence check on both sides is
 // what surfaced all three moves in one run instead of leaving two of them to rot.
+//
+// #1695 is the same movement in the opposite direction and is worth recording
+// for that reason: both fields fell by one (one recording stopped diverging when
+// replay began honouring the Stop hook), and every collision walked back up the
+// same table — the 2ms entry stopped suppressing anything and was deleted, the
+// 28ms row started colliding and regained an entry, and the 69ms row swapped
+// fields again. Two runs, opposite signs, the same table, collisions tracking
+// the figures both times. A restatement cannot do that in either direction.
 //
 // No figure is quoted in this paragraph, deliberately: the first draft of it did
 // quote them and this very check reported five sites, in its own exemption file.

--- a/tools/onboarding-factory/cmd/replay/issue1695_stop_hook_test.go
+++ b/tools/onboarding-factory/cmd/replay/issue1695_stop_hook_test.go
@@ -1,0 +1,301 @@
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"irrlicht/core/domain/session"
+)
+
+// Issue #1695: before this file, a `hook_received{Stop}` in a committed sidecar
+// changed no byte of any golden. HookStop was absent from session's
+// hookSignalEffects, so applyHookEvent returned at its first line — and even
+// once a row was added the transition was still swallowed, by a stale per-pass
+// NoSubstantiveActivity carried in from the last transcript batch. Both are
+// fixed; what is easy to lose again is the KNOWLEDGE that the fix reaches
+// anything, because the shape of losing it is silence: a catalog whose only
+// gradeable Stop is retired, or a harness that stops reaching applyHookEvent,
+// looks exactly like a catalog that is fine.
+//
+// So the population is measured every run rather than described. Two things
+// come out of it:
+//
+//   - stopHookCensus, machine-printed and committed, the idiom #1503 and #1480
+//     use. It moves when a Stop-bearing recording is added or retired, and the
+//     failure names what moved.
+//   - a hard floor: at least one Stop in the catalog must be REPRODUCED, and a
+//     catalog carrying no Stop at all is a refusal rather than a pass.
+//
+// A Stop is counted as reproduced only when a replayed transition sits at the
+// hook's OWN virtual time. That is exact rather than approximate: applyHookEvent
+// stamps transitionCtx.virtTime with hookEv.Timestamp, so a transition at that
+// instant came from that hook and from nothing else. Matching on `cause:
+// "hook"` alone would not attribute it — 5 of the catalog's hook-bearing
+// sidecars carry a PermissionRequest or a PreToolUse, which produce the same
+// cause.
+
+// stopRecording is one committed recording's Stop standing.
+type stopRecording struct {
+	// Stops is how many hook_received{Stop} events the sidecar carries, for
+	// ANY session — including sessions the replay does not drive.
+	Stops int
+	// Reproduced is how many of them produced a replayed transition at the
+	// hook's own virtual time.
+	Reproduced int
+	// Why records, for a recording where Reproduced < Stops, what the walk
+	// could tell about the shortfall. It is prose, but it is DERIVED prose:
+	// the walk writes it from what it observed, so it cannot describe a
+	// recording that has changed underneath it.
+	Why string
+}
+
+// stopHookCensus is every recording in replaydata/ whose sidecar carries a
+// Stop hook, with how many of those Stops the replay reproduces.
+//
+// The two zero rows are the finding this file exists to keep visible, and they
+// correct the claim #1695 was filed with ("affects both hook adapters equally —
+// claudecode's Stop-bearing recordings have the same property"). Measured:
+// replaydata/agents/claudecode/ carries NO Stop-bearing sidecar at all — its 15
+// hook-bearing recordings are PermissionRequest / PreToolUse / PostToolUse /
+// PostToolUseFailure only. The catalog's other two Stops are co-resident
+// claude-code sessions inside another adapter's multi-agent recording, and
+// neither is gradeable for a reason that has nothing to do with Stop handling.
+//
+// Regenerate by pasting the literal the test prints.
+var stopHookCensus = map[string]stopRecording{
+	"codex/scenarios/2-13_turn-end-terminal-text/recordings/2026-08-18-00-42-27_irrlichd-0.5.10+1869727/transcript.jsonl": {
+		Stops: 1, Reproduced: 1,
+	},
+	"copilot/scenarios/4-2_multiple-agents-same-workspace/recordings/2026-08-05-17-26-52_irrlichd-0.5.9+5b580ea/transcript.jsonl": {
+		Stops: 1, Reproduced: 0,
+		Why: "every Stop names a session the replay does not drive",
+	},
+	"hermes/scenarios/4-2_multiple-agents-same-workspace/recordings/2026-08-03-01-11-06_irrlichd-0.5.9+aef737b/transcript.jsonl": {
+		Stops: 1, Reproduced: 0,
+		Why: "the sidecar could not drive this replay: sidecar cannot drive a replay: no transcript_activity events with file_size for primary session 20260803_011105_d40f63",
+	},
+}
+
+// sidecarHookEvent is the sliver of lifecycle.Event this walk reads. Decoded
+// locally rather than through lifecycle.Event so a future field addition there
+// cannot change what this measures.
+type sidecarHookEvent struct {
+	Kind      string    `json:"kind"`
+	SessionID string    `json:"session_id"`
+	HookName  string    `json:"hook_name"`
+	TS        time.Time `json:"ts"`
+}
+
+func TestStopHookIsGradedByTheCommittedCatalog(t *testing.T) {
+	root := replaydataRoot(t)
+	measured := map[string]stopRecording{}
+
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || filepath.Base(path) != eventsSidecarName {
+			return nil
+		}
+		if name, rec, ok := measureStopsIn(t, root, path); ok {
+			measured[name] = rec
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk replaydata/agents: %v", err)
+	}
+
+	// Fail loudly rather than pass quietly. An empty walk and a healthy one
+	// must not produce the same output: with no Stop in the catalog every
+	// assertion below is vacuously satisfied, which is precisely the state
+	// #1695 was filed about (a Stop channel exercised at record time and
+	// graded by nothing).
+	if len(measured) == 0 {
+		t.Fatal("no committed sidecar carries a hook_received{Stop} — this check cannot run, " +
+			"and a Stop-handling regression is once again invisible to every golden (#1695). " +
+			"Record one, or delete this file and say in the PR that the coverage went with it")
+	}
+
+	t.Logf("#1695 Stop census, measured over %d Stop-bearing recording(s):\n\n%s",
+		len(measured), stopCensusLiteral(measured))
+
+	assertSomeStopIsReproduced(t, measured)
+	assertCensusMatches(t, measured)
+}
+
+// assertSomeStopIsReproduced is the floor: whatever the census says about
+// individual recordings, at least one Stop in the catalog must produce a
+// transition, or the channel is once again exercised at record time and graded
+// by nothing.
+func assertSomeStopIsReproduced(t *testing.T, measured map[string]stopRecording) {
+	t.Helper()
+	var total int
+	for _, r := range measured {
+		total += r.Reproduced
+	}
+	if total > 0 {
+		return
+	}
+	t.Errorf("the catalog carries %d Stop-bearing recording(s) and the replay reproduces "+
+		"NONE of their Stops. Either hookSignalEffects lost its HookStop row, or "+
+		"applyHookEvent stopped reaching the classifier — both leave every golden "+
+		"byte-identical and both are #1695 returning", len(measured))
+}
+
+// assertCensusMatches compares the measurement to the committed literal in BOTH
+// directions. Both matter and they catch opposite things: an unlisted recording
+// is a change in what this repo can grade arriving unannounced, and a listed one
+// the walk no longer reaches is either a retirement or a walk that stopped
+// pairing — the #1517 blindness, which reads as health from the inside.
+func assertCensusMatches(t *testing.T, measured map[string]stopRecording) {
+	t.Helper()
+	for _, name := range sortedKeys(measured) {
+		got, want := measured[name], stopHookCensus[name]
+		if _, known := stopHookCensus[name]; !known {
+			t.Errorf("%s carries %d Stop(s) and is not in stopHookCensus — a new Stop-bearing "+
+				"recording is a change in what this repo can grade, so it lands in the census "+
+				"deliberately rather than by nobody noticing", name, got.Stops)
+			continue
+		}
+		if got.Stops != want.Stops || got.Reproduced != want.Reproduced {
+			t.Errorf("%s: measured {Stops:%d Reproduced:%d}, census says {Stops:%d Reproduced:%d}",
+				name, got.Stops, got.Reproduced, want.Stops, want.Reproduced)
+		}
+	}
+	for _, name := range sortedKeys(stopHookCensus) {
+		if _, ok := measured[name]; !ok {
+			t.Errorf("stopHookCensus names %s, which the walk no longer reaches — a retired or "+
+				"renamed recording, or a walk that stopped pairing", name)
+		}
+	}
+}
+
+// measureStopsIn grades one sidecar's Stops, returning the name it is filed
+// under in the census and ok=false for a sidecar carrying no Stop at all.
+//
+// A recording that cannot be replayed is REPORTED with Why rather than skipped:
+// "this sidecar has no gradeable Stop" and "this sidecar was never looked at"
+// must not produce the same census row, which is the whole shape #1695 is about.
+func measureStopsIn(t *testing.T, root, sidecar string) (string, stopRecording, bool) {
+	t.Helper()
+	stops := stopTimestamps(t, sidecar)
+	if len(stops) == 0 {
+		return "", stopRecording{}, false
+	}
+	transcript, paired := pairedTranscript(filepath.Dir(sidecar))
+	if !paired {
+		return rel(root, sidecar), stopRecording{
+			Stops: len(stops), Why: "no transcript is paired with this sidecar",
+		}, true
+	}
+	name := rel(root, transcript)
+
+	tp, sp, useSidecar := resolveInputPaths(transcript)
+	if !useSidecar {
+		return name, stopRecording{
+			Stops: len(stops),
+			Why:   "the sidecar cannot drive a replay at all (transcript-only fallback)",
+		}, true
+	}
+	report, err := runReplay(tp, sp, useSidecar, replaySettingsForTest(t, tp))
+	if err != nil {
+		t.Errorf("runReplay(%s): %v", name, err)
+		return name, stopRecording{Stops: len(stops), Why: "runReplay failed"}, true
+	}
+	return name, gradeStops(stops, report), true
+}
+
+// stopTimestamps returns the ts of every hook_received{Stop} in a sidecar.
+func stopTimestamps(t *testing.T, sidecar string) []time.Time {
+	t.Helper()
+	f, err := os.Open(sidecar)
+	if err != nil {
+		t.Fatalf("open sidecar %s: %v", sidecar, err)
+	}
+	defer f.Close()
+
+	var out []time.Time
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 0, 64*1024), 8*1024*1024)
+	for sc.Scan() {
+		line := sc.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		var ev sidecarHookEvent
+		if json.Unmarshal(line, &ev) != nil {
+			continue // a sidecar line this walk cannot read carries no Stop it can attribute
+		}
+		if ev.Kind == "hook_received" && ev.HookName == session.HookStop {
+			out = append(out, ev.TS)
+		}
+	}
+	if err := sc.Err(); err != nil {
+		t.Fatalf("scan sidecar %s: %v", sidecar, err)
+	}
+	return out
+}
+
+// gradeStops counts how many of a recording's Stops produced a replayed
+// transition at the hook's own virtual time.
+func gradeStops(stops []time.Time, report *replayReport) stopRecording {
+	at := map[int64]bool{}
+	for _, tr := range report.Transitions {
+		at[tr.VirtualTime.UnixNano()] = true
+	}
+	r := stopRecording{Stops: len(stops)}
+	for _, ts := range stops {
+		if at[ts.UnixNano()] {
+			r.Reproduced++
+		}
+	}
+	switch {
+	case r.Reproduced == r.Stops:
+	case report.SidecarFallback != "":
+		// The report says so itself, so quote it rather than infer: a
+		// transcript-only replay never reaches applyHookEvent at all, which is
+		// a different shortfall from a Stop naming a foreign session.
+		r.Why = "the sidecar could not drive this replay: " + report.SidecarFallback
+	case r.Reproduced == 0:
+		r.Why = "every Stop names a session the replay does not drive"
+	default:
+		r.Why = "some Stops name a session the replay does not drive"
+	}
+	return r
+}
+
+// stopCensusLiteral renders the measured census as the Go source to paste over
+// stopHookCensus. Rendered from the measurement rather than reported in prose,
+// because the transcription step is where a stale figure enters (#1503).
+func stopCensusLiteral(m map[string]stopRecording) string {
+	var b strings.Builder
+	b.WriteString("var stopHookCensus = map[string]stopRecording{\n")
+	for _, name := range sortedKeys(m) {
+		r := m[name]
+		fmt.Fprintf(&b, "\t%q: {\n\t\tStops: %d, Reproduced: %d,\n", name, r.Stops, r.Reproduced)
+		if r.Why != "" {
+			fmt.Fprintf(&b, "\t\tWhy: %q,\n", r.Why)
+		}
+		b.WriteString("\t},\n")
+	}
+	b.WriteString("}\n")
+	return b.String()
+}
+
+func sortedKeys(m map[string]stopRecording) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/tools/onboarding-factory/cmd/replay/replay_sidecar.go
+++ b/tools/onboarding-factory/cmd/replay/replay_sidecar.go
@@ -940,10 +940,35 @@ func (r *sidecarReplayer) clusterBoundary(eventIdx int) int64 {
 // auto-detects only a sibling named <transcript>.events.jsonl while every
 // sidecar in replaydata/ is named plain events.jsonl. See issue #1326.
 //
-// Hooks absent from the table are still ignored here. Stop could not be a table
-// row (its effect needs a payload lifecycle.Event does not carry); Notification
-// and PreCompact could be, but no recording in replaydata/ fires one — add each
-// as a table row together with the first recording that does.
+// Hooks absent from the table are still ignored here: Notification and
+// PreCompact could be rows, but no recording in replaydata/ fires one — add
+// each as a table row together with the first recording that does. Stop WAS
+// in that sentence until #1695; see hookSignalEffects for why a payload-free
+// row is a floor rather than a wrong answer, and TestStopHookIsGradedByTheCommittedCatalog
+// for the recording that now grades it.
+//
+// NoSubstantiveActivity is cleared before the overlay, and that one line is
+// what made the Stop channel reachable at all (#1695). The flag is PER PASS —
+// tailer.go sets it as `scan.linesParsed > 0 && !scan.substantive`, and
+// session_detector_activity.go's own comment says so in as many words — but
+// r.lastMetrics is the last TRANSCRIPT batch's metrics, and a hook pass is a
+// different pass that parses no transcript lines. Carrying the flag across was
+// therefore asserting something the harness never observed, and runClassifier's
+// mirror of #329's short-circuit then swallowed the hook: measured on codex's
+// 2-13_turn-end-terminal-text, the Stop overlaid HookTurnDone and the
+// classifier answered `ready / "agent finished turn → ready"` — and the
+// short-circuit above discarded it, one instruction before it would have been
+// emitted. The daemon does not have this problem because a hook's synthetic
+// activity event goes through processActivity, whose RefreshOnActivity re-tails
+// and RECOMPUTES the flag for that pass; false is what a zero-line pass yields.
+//
+// The declared limit: false is an approximation of that recomputation, not the
+// recomputation. A daemon pass that read new-but-non-substantive bytes between
+// the last fs event and the hook would compute true and skip, where this
+// computes false and classifies. That case cannot be reconstructed from the
+// sidecar (it records no stat for the hook's own moment), and the approximation
+// errs toward reproducing the daemon's recorded transition rather than toward
+// dropping it — which is the direction the whole extended check is scored in.
 func (r *sidecarReplayer) applyHookEvent(hookEv lifecycle.Event) {
 	effect, ok := session.HookSignal(hookEv.HookName)
 	if !ok {
@@ -954,6 +979,7 @@ func (r *sidecarReplayer) applyHookEvent(hookEv lifecycle.Event) {
 		return
 	}
 	domainMetrics := replayengine.TailerToDomain(r.lastMetrics)
+	domainMetrics.NoSubstantiveActivity = false
 	r.signals.Overlay(replaySessionKey, domainMetrics, hookEv.Timestamp)
 	r.runClassifier(domainMetrics, transitionCtx{eventIdx: -1, virtTime: hookEv.Timestamp, cause: causeHook}, true)
 }


### PR DESCRIPTION
Closes #1695

## 1. The measured current state — the issue's premise holds, and is worse than stated

#1695's one unverified claim was: *"I did not run a mutation of `HandleStopHook` itself against the full suite, so 'no gate reproduces a Stop-driven transition' is read off `applyHookEvent`'s early return plus the two goldens, not off a red run."* Run:

**M1 — `SessionDetector.HandleStopHook` stops holding `SignalTurnDone`** (the whole `d.signals.Hold(…, session.SignalTurnDone, session.SignalPayload{…}, …)` deleted, the two parameters discarded):

```
$ go test ./tools/onboarding-factory/cmd/replay/... -count=1
ok  	irrlicht/tools/onboarding-factory/cmd/replay	6.106s        <- GREEN

$ go test ./core/application/services/... ./core/domain/session/... ./core/e2e/... -count=1
ok  	irrlicht/core/application/services	23.775s
ok  	irrlicht/core/domain/session	0.289s
ok  	irrlicht/core/e2e	6.225s                                     <- GREEN

$ go test ./core/adapters/inbound/agents/... -count=1
(17 packages, all ok)                                              <- GREEN
```

So the issue is confirmed and then some. It expected the adapter suites to grade *something*; they grade the CALL, and every `HandleStopHook` in a `_test.go` before this PR is a mock (`claudecode`, `codex`, `copilot` `mockTarget`). **`HandleStopHook`'s effect on state was graded by nothing in the repo** — not replay, not services, not e2e, not the adapters.

Two claims in #1695 are corrected by measurement rather than argument:

- **"Affects both hook adapters equally — claudecode's `Stop`-bearing recordings have the same property."** `replaydata/agents/claudecode/` carries **no** Stop-bearing sidecar. Its 15 hook-bearing recordings are `PermissionRequest` / `PreToolUse` / `PostToolUse` / `PostToolUseFailure` only. The catalog holds exactly three Stops: codex `2-13`, and two co-resident **claude-code** sessions inside `copilot/4-2` and `hermes/4-2`.
- **"`HookStop` genuinely cannot be a row"** (from `hookSignalEffects`' own doc comment, quoted approvingly by the issue). See §2.

Unrelated flake seen once during M1 and disclosed rather than folded in: `TestReadLauncherEnv_Tmux_{AttachedClientIsTheHost,DetachedResolvesNoHost}` in `processlifecycle` (the #1586 fixture family). Three clean re-runs on the final tree, and this diff touches no file in that package (`git diff --name-only | grep processlifecycle` → empty).

## 2. The approach, and the two things I rejected

### Rejected: leaving it and writing a named exclusion (the issue's option 2b)

Because the stated reason for the exclusion is wrong in exactly one step. `hookSignalEffects` says a name-keyed lookup "has no way to supply" the Stop payload. True. It does not follow that a name-only caller cannot act — read `signalPolicies`' turn-done row:

```go
apply: func(c holdContext) {
    c.Metrics.HookTurnDone = true
    if c.Payload.LastAssistantText != "" { c.Metrics.LastAssistantText = c.Payload.LastAssistantText }
    if c.Payload.WaitingCue          { c.Metrics.PendingWaitingCue = true }
},
```

Both payload fields are **guarded**. A payload-free hold delivers the signal's whole assertion (the turn ended, authoritatively) and the degradation is **one-directional**: it can add to the cue verdict and can never clear or mask one the transcript already found. It also cannot pin a session in `ready` — that row is `consumeOnce: true`, so the hold is deleted the first time it is applied, which answers the #1355 Phase B worry directly rather than by assertion.

So the row is an honest floor, not a lie, and that is now a test rather than this paragraph: `TestPayloadFreeTurnDoneNeverClearsATranscriptCue`.

**The daemon's live behaviour does not change.** Verified by reading every call site, not assumed: all three receivers dispatch Stop through a dedicated `case HookStop:` arm to `HandleStopHook` (`claudecode/hooks.go:359`, `codex/hooks.go:203`, `copilot/hooks.go:305`), and the only non-switch `HandlePermissionHook` caller passes `HookNotification` explicitly (`copilot/hooks.go:344`). Nothing reaches the table with `"Stop"` at runtime. The table's other reader is the replay harness, which is the point.

### Rejected: carrying the Stop payload in `lifecycle.Event` (the issue's option 2a)

Not needed, and it would have been the more expensive of two ways to be wrong. All three Stops on disk predate any such field, so replay would apply an empty payload to them anyway — i.e. exactly what the row already gives, at the cost of a schema change #1355 Phase F flags as invalidating every hook event on disk.

### Chosen: the row, plus the reason it was not enough

**Adding the row alone changed zero bytes of zero goldens.** That is the half worth reading twice, because it looks exactly like "the row does nothing, the doc comment was right":

```
$ # HookStop: {Signal: SignalTurnDone} added, nothing else
$ go test ./tools/onboarding-factory/cmd/replay/... -count=1
ok  	irrlicht/tools/onboarding-factory/cmd/replay	6.113s
```

Instrumented, the classifier had already answered:

```
DBG hook=Stop ok=true state=working lastMetrics=true
DBG overlay hookTurnDone=true noSubst=true agentDone=true classify=ready/"agent finished turn → ready"
```

`applyHookEvent` copies `r.lastMetrics` — the last **transcript batch**'s metrics — and `NoSubstantiveActivity` is a **per-pass** flag (`tailer.go`: `scan.linesParsed > 0 && !scan.substantive`; `session_detector_activity.go:315-319` says so in as many words). A hook pass is a different pass that parses no transcript lines, so carrying the flag across asserted something the harness never observed, and `runClassifier`'s mirror of #329's short-circuit discarded the transition one instruction before it would have been emitted. The daemon never had this problem: a hook's synthetic activity goes through `processActivity` → `RefreshOnActivity`, which **recomputes** the flag for that pass.

One line, `domainMetrics.NoSubstantiveActivity = false`, with the declared limit stated where it lives: `false` approximates that recomputation rather than performing it, and errs toward reproducing the daemon's recorded transition rather than dropping it.

### The issue's option 3 needed no new field

"Make the golden record which SOURCE produced a transition." The mechanism already existed — `transition.Cause` — and was unreachable. With both halves fixed, codex `2-13`'s golden carries a hook-produced `ready` at `cause: "hook"` and a transcript-produced `ready` at `cause: "debounce_coalesce"`, in the same file:

```diff
   { "index": 2,
-    "event_index": 11, "virtual_time": "…T00:42:38.225446+02:00", "cause": "debounce_coalesce",
+    "event_index": -1, "virtual_time": "…T00:42:36.207640+02:00", "cause": "hook",
     "prev_state": "working", "new_state": "ready", "reason": "agent finished turn → ready" },
+  { "index": 3, … "cause": "debounce_coalesce", "prev_state": "ready",   "new_state": "working" },
+  { "index": 4, … "cause": "debounce_coalesce", "prev_state": "working", "new_state": "ready"  },
```

`00:42:36.207640` is byte-identical to the sidecar's `hook_received{Stop}` ts at seq 120, and the transition reproduces the daemon's seq 121. `extended_check` goes from `recorded 4 / replayed 2 / 2 missing_in_replay` to **`recorded 4 / replayed 4 / ordered_mismatches: none`**.

### What I did not do

- No new golden field, no `decided_by_tier` in the replay report. It would rewrite all ~399 goldens in the commit that introduces the thing they assert — the argument `extendedCheck.TimeDeltas`' `json:"-"` already makes.
- `waiting_cue.go` is untouched. The transcript path stays authoritative and unchanged; nothing here deletes inference.
- `HookNotification` / `HookPreCompact` stay out of the table: still no recording fires one. Unchanged from before.
- No re-recording. Every recording in `replaydata/` is byte-identical; only three `.golden` files moved.

## 3. Non-vacuity — the pasted RED, and exactly who notices

### R1 — the Stop channel: remove the `HookStop` row

```
--- FAIL: TestFixtureReplayByteIdentity/transcript.jsonl#121
    fixtures_test.go:39: replay output differs from golden
      replaydata/agents/codex/scenarios/2-13_turn-end-terminal-text/…/transcript.jsonl.replay.json.golden
--- FAIL: TestSidecarReplayTransitionTimesMatchTheDaemonsOwnLog
--- FAIL: TestCatalogCensusMatchesTheCommittedFigures
--- FAIL: TestStopHookIsGradedByTheCommittedCatalog
    issue1695_stop_hook_test.go:160: the catalog carries 3 Stop-bearing recording(s) and the replay
    reproduces NONE of their Stops. Either hookSignalEffects lost its HookStop row, or
    applyHookEvent stopped reaching the classifier — both leave every golden byte-identical
    and both are #1695 returning
FAIL	irrlicht/tools/onboarding-factory/cmd/replay
```

**Exactly one golden: codex `2-13`.** That is the honest number and it is smaller than #1694's three, because it is the whole population — one of the catalog's three Stops is gradeable and the other two are not, for reasons that have nothing to do with Stop handling:

| recording | Stops | reproduced | why not |
|---|---|---|---|
| `codex/2-13_turn-end-terminal-text` | 1 | **1** | — |
| `copilot/4-2_multiple-agents-same-workspace` | 1 | 0 | the Stop names co-resident claude-code session `31e6174f…`; the replay drives copilot's `2889f1c5…` |
| `hermes/4-2_multiple-agents-same-workspace` | 1 | 0 | `sidecar cannot drive a replay: no transcript_activity events with file_size for primary session …` |

That table is not prose — it is `stopHookCensus`, machine-printed by `TestStopHookIsGradedByTheCommittedCatalog` and pasted, per #1503's idiom. A new Stop-bearing recording fails it by name, and a catalog with **no** Stop at all is a `t.Fatal` refusal rather than a vacuous pass. A Stop counts as reproduced only when a replayed transition sits at the hook's **own** virtual time — exact attribution, because `cause: "hook"` alone is also produced by the 5 sidecars carrying a `PermissionRequest`/`PreToolUse`.

### R2 — the per-pass flag: put the stale `NoSubstantiveActivity` back

```
--- FAIL: TestFixtureReplayByteIdentity/transcript.jsonl#126  → codex/2-19_tool-gate-permission-prompt
--- FAIL: TestFixtureReplayByteIdentity/transcript.jsonl#121  → codex/2-13_turn-end-terminal-text
--- FAIL: TestFixtureReplayByteIdentity/transcript.jsonl#97   → claudecode/5-4_architect-editor-pair
--- FAIL: TestSidecarReplayTransitionTimesMatchTheDaemonsOwnLog
--- FAIL: TestCatalogCensusMatchesTheCommittedFigures
--- FAIL: TestStopHookIsGradedByTheCommittedCatalog
```

Three recordings — every hook-bearing recording whose hook produces a transition, across two adapters.

### M1 / M2 — `HandleStopHook`'s own effect (`TestSessionDetector_StopHook_DrivesTheTurnDoneTransition`)

**M1**, the hold deleted — both arms red:

```
--- FAIL: …/plain_turn_end_→_ready
    after Stop hook: state = "working", want "ready" — the Stop hook is the authoritative
    turn-done signal (#1161); without its hold the transcript tail alone says the turn is still running
--- FAIL: …/turn_ended_on_a_question_→_waiting
    after Stop hook: state = "working", want "waiting" — …
```

**M2**, the hold kept and the **payload dropped** — i.e. precisely what the new table row alone delivers:

```
--- FAIL: …/turn_ended_on_a_question_→_waiting
    after Stop hook: state = "ready", want "waiting" — the cue was computed over the hook's
    full message (#1150); the transcript tail below carries none, so only the payload can
    route this to waiting
```

One arm red, one green. That asymmetry *is* the argument for `HandleStopHook` remaining a dedicated entry point beside the row rather than being replaced by it — and it is a property no golden can ever reach, because the payload is not a field of `lifecycle.Event`.

### M3 — `TestPayloadFreeTurnDoneNeverClearsATranscriptCue`, both payload guards removed

```
--- FAIL: …/cue_found_by_the_transcript_survives_an_empty_payload
    empty payload cleared PendingWaitingCue: the row would force a question-ended turn to ready
    empty payload overwrote LastAssistantText = "", want the transcript's own text
    IsWaitingForUserInput() is false after an empty-payload turn-done overlay: the cue was lost
--- FAIL: TestSignalHolds_TurnDonePreservesPriorText
--- FAIL: TestSignalHolds_TurnDoneCueIsAdditive
```

Stated rather than implied: the two **guards** were already locked by those pre-existing tests. What the new one adds is the **conclusion** neither states — that after an empty-payload overlay the metrics still answer `IsWaitingForUserInput()` true — which is the entire argument for the row and is what would survive an `apply` rewritten to reach those fields another way. Its second arm stays green under the mutation; it locks the enrichment direction.

## 4. Goldens: three moved, across two adapters — said out loud

The brief flags cross-adapter golden churn as a reconsider signal, so: **it is cross-adapter, deliberately, and here is the argument.** The change is in the shared harness and the shared domain table, so "the adapter I touched" is *every hook-bearing recording whose hook produces a transition* — which is three of ~399. Every move is toward the daemon:

| golden | before | after | daemon's own ts |
|---|---|---|---|
| `codex/2-13` | `cause: debounce_coalesce` @ `00:42:38.225`, 2 of 4 transitions, 2 missing | `cause: hook` @ `00:42:36.208` + the two it was hiding, **4 of 4, no mismatches** | hook seq 120 `00:42:36.20764`, transition seq 121 |
| `codex/2-19` | `cause: debounce_coalesce` @ `00:40:48.977` (**1.96s** late) | `cause: hook` @ `00:40:47.019` (**exact**) | hook seq 191 `00:40:47.019525` |
| `claudecode/5-4` | `cause: debounce_coalesce` @ `23:34:37.398` (~99ms late) | `cause: hook` @ `23:34:37.293` (**~6ms**) | hook seq 48910 `23:34:37.293254`, transition seq 48911 `…37.299248` |

One honest wart, disclosed because it is a real difference and not only an improvement: `2-19`'s transition now fires at the right *instant* but records replay's last-known classifier inputs (`last_event_type: function_call_output`, `has_open_tool: false`) where the daemon's recorded `inputs` say `function_call` / `has_open_tool_call: true`. `applyHookEvent` has always classified against last-known metrics and cannot re-tail at the hook's moment — no sidecar records a stat there, the same limitation `readBoundaryFor` documents. The transition, its state pair and its rule all match the daemon; the ancillary fields beside it are the harness's, as before.

## 5. Ratchets and derived figures moved, each with its reason

| figure | change | why |
|---|---|---|
| `censusOfTheCommittedCatalog.Divergent` | 143 → 142 | codex `2-13` stopped diverging (4 of 4 reproduced). Pasted from the failing run, as #1503 intends. |
| `…DivergentByCountsAndKinds` | 142 → 141 | same recording, same reason; the near-miss spelling stays exactly one below. |
| `maxRecordingsDriftingOverThreshold` | 107 → **105** | #1388 raised this to 107 for these two codex recordings and recorded the cause as "structural — the daemon flips on the POST, replay flips at the next debounce boundary". It was the short-circuit. Both leave the population; re-tightened rather than banked as slack, per the #1517 note the constant carries. |
| `minKindMatchedPairs` | 832 → **834** | `2-13` now contributes two more kind-matched pairs. |
| `minMeasuredRecordings` | 277 → 277 | unchanged — `2-13` was already measuring. A recording joins that population once and then only adds pairs. |
| #1518 census-lint exemptions | 1 deleted, 1 added, 1 re-pointed | the collisions walked one row back up an **unchanged** #1478 table, mirroring #1388's move with the opposite sign. Recorded in that file as the strongest available evidence the table is not restating a live figure: a restatement cannot track the figure in both directions. |

## 6. Gates

| gate | result |
|---|---|
| `go run ./tools/onboarding-factory/cmd/of validate` | **PASS** — `catalog + cells are schema-valid and referentially consistent` |
| `tools/preflight.sh --only go` | **PASS** 6/6 — gofmt, core module tests, onboarding-factory tests, replaydata validate, recording-rig smoke test, replay fixtures |
| `tools/replay-fixtures.sh` (unscoped) | **PASS**, exit 0 — `142 recording(s)` divergent, agreeing with the census the Go side measures |
| `tools/preflight.sh --only arch` | **PASS** — composite 7.9315462 → 7.9316414, no category regression |
| `tools/skill-lint.sh` | exit 0 (AGENTS.md is not a skill file; run because the diff edits repo prose) |
| `--only web` / `posix` / `bash` / `security` / `swift` | **not run** — the diff touches no `web/` tree, no `#!/bin/sh` or bash file, no dependency manifest and no `platforms/macos/` file. Stated rather than claimed green. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
