### PR TITLE
feat(tools): bring the recording rig's bash into bash-lint, and un-blind the file shellcheck was abandoning (#1687)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -961,8 +961,9 @@ Before marking a ticket done, run the full suite — every layer must pass:
   only the lines a case runs, where the linter reads every line.
 - Bash scripts: `tools/bash-lint.sh` runs `shellcheck --shell=bash
   --severity=warning` over every file git knows about — tracked, plus untracked
-  and not gitignored — whose **first line** is a bash shebang. 83 files /
-  ~19k lines, and until #1684 **no static linter read one of them**: the bullet
+  and not gitignored — whose **first line** is a bash shebang. 117 files
+  (83 at #1684, plus the 34 #1687 brought in), and until #1684 **no static
+  linter read one of them**: the bullet
   above selects on `#!/bin/sh` line 1, deliberately (#1611), so every bash file
   fell through — including the bounded gate runner (`gate-budget.sh`), the
   pre-push hook's own scoping rules (`changed-files.sh`), the shared suite
@@ -971,14 +972,27 @@ Before marking a ticket done, run the full suite — every layer must pass:
   #1423 and #1611. It found 26 findings, all fixed or annotated.
   Four decisions are load-bearing and each was measured rather than preferred.
   - **DEFAULT-IN, opt-out with a reason.** The scope is not a prefix list — it
-    is everything, minus three declared `EXCLUDE` globs each carrying its
+    is everything, minus the declared `EXCLUDE` globs each carrying its
     justification, and an exclusion that matches NOTHING is a hard refusal
     (exit 2) rather than a no-op, the same both-directions existence check
     `TW_EXEMPT_KEYS` and `nilTolerant` get. So a bash file added anywhere is
-    covered by existing, and the two families that are out — the
-    deliberately-corrupt `testdata/` corpora, and the recording rig's per-agent
-    drivers plus their `.tmpl` (#1687: 79 findings, and one file whose analysis
-    shellcheck silently ABANDONS) — are out visibly.
+    covered by existing. Since #1687 **exactly one** family is out — the
+    deliberately-corrupt `testdata/` corpora — which puts more weight on that
+    refusal than it carried before: it is now the only proof the existence
+    check works, so a second exclusion owes its own arm in the suite.
+    #1687 brought in the other two, the recording rig's per-agent drivers
+    (`replaydata/**`, 33 files) and the `.tmpl` they are generated from: 89
+    findings, all fixed or annotated, and **byte-identical on 0.9.0 and
+    0.11.0**, which extends the version-agreement measurement below to that
+    corpus rather than assuming it carries. Why they were worth it beyond the
+    count: #1388/#1694 found codex's driver had ROTTED against codex-cli
+    0.147.0 and produced a healthy-looking fixture — `driver.exit-reason: ok`,
+    zero rollouts — from a run that did nothing. Ten drivers steer live TUIs by
+    grepping literal strings, and no static analyser had read one of them.
+    Of the 78 SC2034s, 77 were verified cross-file seams and annotated per
+    site; the one with no consumer anywhere (`SKILL_DIR` in the gastown driver)
+    was deleted rather than annotated, which is the distinction the rule turns
+    on.
   - **A severity FLOOR, not posix-lint's named code set**, and the reason the
     precedent was not followed is that SC3xxx is a closed family by definition
     while "bugs in bash" is not: an opt-in code list is not enforced on a code
@@ -1006,16 +1020,31 @@ Before marking a ticket done, run the full suite — every layer must pass:
     for the same reason `posix-lint.sh` refuses to filter its parse-abort codes
     into silence, and it is the gate's most valuable rule: it caught the
     construct **four times in this PR's own new prose**, and
-    `replaydata/_lib/drive/contracts.sh` has been carrying it unnoticed (#1687 —
-    rewording that one line surfaces an SC2005 the file currently hides). The
+    `replaydata/_lib/drive/contracts.sh` carried it from #508 until #1687 —
+    for that whole time shellcheck's ONLY output for that file was the two
+    parse errors. **No extra guard was added for it in #1687, because the floor
+    already refuses it**: with the file in scope the gate goes red on
+    SC1073/SC1072, measured on 0.9.0 and 0.11.0 alike. Note the correction to
+    #1687's own framing while quoting it — "rewording that one line surfaces an
+    SC2005" is true at shellcheck's DEFAULT severity and false at this gate's,
+    since SC2005 is `style`; at `--severity=warning` the reworded file reports
+    nothing. What the floor buys is not the hidden finding but the end of the
+    abandonment, i.e. that any finding a future edit introduces is visible at
+    all. The
     sibling SC1125 is the `# shellcheck disable=SCxxxx — <prose>` spelling; the
     disable IS still honoured (measured on both versions), but the reason must
     go behind a second `#`.
   The sanctioned escape hatch is a per-SITE `# shellcheck disable=SCxxxx  #
-  <reason>` naming its consumer's `file:line` — all 17 SC2034s are that, each
-  verified to have a real reader — and never a code removed from the gate.
+  <reason>` naming its consumer's `file:line` — all 94 SC2034s are that (17 at
+  #1684, 77 at #1687), each verified to have a real reader — and never a code
+  removed from the gate.
   A directive covers only the NEXT command, so four adjacent knob assignments
-  need four.
+  need four. Two consequences #1687 measured and had to work around: a `;`-
+  joined declaration line (`A=(); B=(); C=()`) takes a directive only on its
+  FIRST assignment, so such lines are split one per line rather than left with
+  a directive that appears to cover three and covers one; and a directive
+  placed before the file's first COMMAND applies file-wide, which is a blanket
+  disable wearing a per-site shape and is not used.
   It lives in **`linux.yml`** beside `posix-lint.sh`, but for a DIFFERENT
   reason, and the difference is the decision: posix-lint needs ubuntu because
   `/bin/sh` must genuinely BE dash there — a property of the runtime — whereas

--- a/replaydata/_lib/drive/contracts.sh
+++ b/replaydata/_lib/drive/contracts.sh
@@ -35,8 +35,17 @@ emit_session_contract() {
 
 # drive_exit maps EXIT_REASON to the process exit code and exits. Every case
 # (including the catch-all) calls exit, so this function never returns
-# normally — no trailing `return` (it would be unreachable dead code;
-# shellcheck SC2317 flags exactly that).
+# normally — no trailing `return`, which would be unreachable dead code and is
+# what SC2317 flags.
+#
+# Note how that code is named: NOT by opening a comment line with the linter's
+# own name. A comment whose FIRST word after `#` is that name is parsed as a
+# DIRECTIVE, and an unparseable one (SC1073/SC1072) makes the analysis of the
+# WHOLE file be abandoned — every later finding silently disappears. This file
+# carried exactly that from #508 until #1687, during which shellcheck's only
+# output for it was the two parse errors. tools/bash-lint.sh keeps SC1072/SC1073
+# inside its severity floor so the construct fails the gate rather than reading
+# as a clean file.
 drive_exit() {
   case "$EXIT_REASON" in
     ok)            exit 0 ;;

--- a/replaydata/_lib/drive/drive-lib_test.sh
+++ b/replaydata/_lib/drive/drive-lib_test.sh
@@ -25,11 +25,25 @@ TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
 
 # Driver-owned globals the helpers read/write.
+# shellcheck disable=SC2034  # read by the sourced replaydata/_lib/drive/slots.sh (alloc_slot) and contracts.sh (emit_session_contract)
 STAGING="$TMP"
 DRIVER_LOG="$TMP/driver.log"
+# shellcheck disable=SC2034  # read by the sourced replaydata/_lib/drive/slots.sh:56 (alloc_slot)
 DRIVE_MARKER_PREFIX="$TMP/.fake-start-marker"
-SES_SESSION=(); SES_TRANSCRIPT=(); SES_UUID=(); SES_EXPECTED=()
-SES_MARKER=(); SES_CWD=(); SES_ALIVE=()
+# shellcheck disable=SC2034  # driver-owned slot array; the sourced replaydata/_lib/drive/slots.sh reads it (save_active/load_slot/alloc_slot)
+SES_SESSION=()
+# shellcheck disable=SC2034  # driver-owned slot array; read by the sourced replaydata/_lib/drive/slots.sh (save_active/load_slot) and contracts.sh (emit_session_contract)
+SES_TRANSCRIPT=()
+# shellcheck disable=SC2034  # driver-owned slot array; the sourced replaydata/_lib/drive/slots.sh reads it (save_active/load_slot/alloc_slot)
+SES_UUID=()
+# shellcheck disable=SC2034  # driver-owned slot array; the sourced replaydata/_lib/drive/slots.sh reads it (save_active/load_slot/alloc_slot)
+SES_EXPECTED=()
+# shellcheck disable=SC2034  # driver-owned slot array; the sourced replaydata/_lib/drive/slots.sh reads it (save_active/load_slot/alloc_slot)
+SES_MARKER=()
+# shellcheck disable=SC2034  # driver-owned slot array written by the sourced replaydata/_lib/drive/slots.sh:63 (alloc_slot); kept current here for the shared slot model
+SES_CWD=()
+# shellcheck disable=SC2034  # driver-owned slot array written by the sourced replaydata/_lib/drive/slots.sh:64 (alloc_slot); kept current here for the shared slot model
+SES_ALIVE=()
 N_SLOTS=0; ACTIVE=0
 SESSION=""; TRANSCRIPT=""; UUID=""; EXPECTED_TURNS=0; MARKER=""
 
@@ -77,9 +91,19 @@ assert_eq "session.uuids = daemon_sid per slot" "$(printf 'ses1\nses2')" "$(cat 
 assert_eq "transcript.paths per slot"  "$(printf '/t/ses1.jsonl\n/t/ses2.jsonl')" "$(cat "$TMP/transcript.paths")"
 
 echo "== drive_exit: EXIT_REASON → exit code =="
+# EXIT_REASON is the INPUT to drive_exit, read by the sourced
+# replaydata/_lib/drive/contracts.sh — each subshell below sets it and the
+# function under test consumes it. One directive per assignment because a
+# directive covers only the next command, and shellcheck picks a single site
+# per variable to report: pinning only the one it happens to name today would
+# leave the other three to fail the gate the moment that choice moved.
+# shellcheck disable=SC2034  # read by the sourced replaydata/_lib/drive/contracts.sh (drive_exit)
 ( EXIT_REASON="ok";            drive_exit ); assert_eq "ok → 0"            0   "$?"
+# shellcheck disable=SC2034  # read by the sourced replaydata/_lib/drive/contracts.sh (drive_exit)
 ( EXIT_REASON="timeout";       drive_exit ); assert_eq "timeout → 124"    124 "$?"
+# shellcheck disable=SC2034  # read by the sourced replaydata/_lib/drive/contracts.sh (drive_exit)
 ( EXIT_REASON="nonzero(2)";    drive_exit ); assert_eq "nonzero(2) → 2"   2   "$?"
+# shellcheck disable=SC2034  # read by the sourced replaydata/_lib/drive/contracts.sh (drive_exit)
 ( EXIT_REASON="weird";         drive_exit ); assert_eq "unknown → 1"      1   "$?"
 
 echo "== dismiss_dialog_if_visible: poll+dismiss mechanics only (tmux faked) =="

--- a/replaydata/_lib/drive/slots.sh
+++ b/replaydata/_lib/drive/slots.sh
@@ -60,7 +60,9 @@ alloc_slot() {
   SES_UUID[$N_SLOTS]=""
   SES_EXPECTED[$N_SLOTS]=0
   SES_MARKER[$N_SLOTS]="$marker"
+  # shellcheck disable=SC2034  # written here for the DRIVERS that read it — the slot's cwd is used to launch and to locate the agent process (e.g. replaydata/agents/antigravity/driver-interactive.sh's tmux -c and claudecode's per-cwd slot lookup)
   SES_CWD[$N_SLOTS]="$cwd"
+  # shellcheck disable=SC2034  # written here for the DRIVERS that read it — the teardown/summary arms branch on it (e.g. replaydata/agents/antigravity, claudecode, codex, gemini-cli, kiro-cli driver-interactive.sh)
   SES_ALIVE[$N_SLOTS]=1
   ACTIVE=$N_SLOTS
   SESSION="$sess"

--- a/replaydata/_lib/drive/turn-count_test.sh
+++ b/replaydata/_lib/drive/turn-count_test.sh
@@ -53,6 +53,7 @@ count() {
   ( set +u
     # shellcheck disable=SC1090
     source "$ROOT/replaydata/agents/$agent/turn-count.sh"
+    # shellcheck disable=SC2034  # read by the sourced replaydata/agents/<agent>/turn-count.sh's turn_count
     TRANSCRIPT="$transcript"
     turn_count )
 }

--- a/replaydata/agents/aider/driver-interactive.sh
+++ b/replaydata/agents/aider/driver-interactive.sh
@@ -54,7 +54,9 @@ DRIVER_LOG="$STAGING/driver.log"
 # (a subset of its case arms — accepting ≠ producing), read directly by
 # recipe-lint so the grammar has ONE owner here, not a parallel manifest.
 # tmux-TUI driver.
+# shellcheck disable=SC2034  # scraped from this file's SOURCE by tools/onboarding-factory/scripts/lib/recipe-lint.sh:97 (sed), never expanded in shell
 DRIVE_ELICITS="send slash wait_turn interrupt sleep"
+# shellcheck disable=SC2034  # scraped from this file's SOURCE by tools/onboarding-factory/scripts/lib/recipe-lint.sh:113 (sed), never expanded in shell
 DRIVE_SLASH_REQUIRES_STEP_TYPE=false
 
 # Per-run git-init'd CWD — same trick as drive-aider.sh; aider walks up

--- a/replaydata/agents/antigravity/driver-interactive.sh
+++ b/replaydata/agents/antigravity/driver-interactive.sh
@@ -78,6 +78,7 @@ fi
 STAGING="$1"
 UUID="$2"            # preferred session id; some agents mint their own (ignore then)
 TIMEOUT_S="$3"
+# shellcheck disable=SC2034  # positional arg $4 of the driver protocol (tools/onboarding-factory/scripts/run-cell.sh:379); named so the slot is not silently reused, though this adapter's launch does not read it
 SETTINGS_PATH="$4"   # scenario settings blob; wire into the launch if the agent reads one
 SCRIPT_JSON="$5"
 
@@ -90,6 +91,7 @@ DRIVER_LOG="$STAGING/driver.log"
 # column starts ON the slot model: porting a multi-session step is "wire the seam
 # + call alloc_slot/load_slot", not rebuilding the slot bookkeeping (#666).
 _DRIVE_LIB="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../_lib/drive" && pwd)"
+# shellcheck disable=SC2034  # read by the sourced replaydata/_lib/drive/slots.sh:56 (alloc_slot)
 DRIVE_MARKER_PREFIX="$STAGING/.antigravity-marker"
 # shellcheck source=/dev/null
 source "$_DRIVE_LIB/slots.sh"
@@ -104,8 +106,15 @@ source "$_DRIVE_LIB/teardown.sh"
 # with zero slots; launch_repl allocs slot 1, and restart/start_session alloc
 # more. ACTIVE indexes the live slot; SESSION/TRANSCRIPT/UUID mirror it.
 N_SLOTS=0; ACTIVE=0
-SES_SESSION=(); SES_TRANSCRIPT=(); SES_UUID=(); SES_EXPECTED=()
-SES_MARKER=(); SES_CWD=(); SES_ALIVE=()
+SES_SESSION=()
+SES_TRANSCRIPT=()
+SES_UUID=()
+# shellcheck disable=SC2034  # driver-owned slot array; the sourced replaydata/_lib/drive/slots.sh reads it (save_active/load_slot/alloc_slot)
+SES_EXPECTED=()
+# shellcheck disable=SC2034  # driver-owned slot array; the sourced replaydata/_lib/drive/slots.sh reads it (save_active/load_slot/alloc_slot)
+SES_MARKER=()
+SES_CWD=()
+SES_ALIVE=()
 
 # recipe-lint contract (#508 #4): the step types this driver genuinely ELICITS,
 # read directly by recipe-lint (no separate manifest). Start with ONLY the seams
@@ -114,7 +123,9 @@ SES_MARKER=(); SES_CWD=(); SES_ALIVE=()
 # recipe-lint flags a recipe needing it as a semantic_gap before recording. Set
 # DRIVE_SLASH_REQUIRES_STEP_TYPE=true if antigravity is headless-first (a bare
 # send "/cmd" stores literal text instead of reaching the REPL).
+# shellcheck disable=SC2034  # scraped from this file's SOURCE by tools/onboarding-factory/scripts/lib/recipe-lint.sh:97 (sed), never expanded in shell
 DRIVE_ELICITS="send slash wait_turn keys sleep interrupt exit_clean restart resume sigkill start_session session"
+# shellcheck disable=SC2034  # scraped from this file's SOURCE by tools/onboarding-factory/scripts/lib/recipe-lint.sh:113 (sed), never expanded in shell
 DRIVE_SLASH_REQUIRES_STEP_TYPE=false
 RUN_CWD="${IRRLICHT_ONBOARD_CWD:-$STAGING/cwd}"
 mkdir -p "$RUN_CWD"
@@ -363,7 +374,7 @@ send_text() { # <text>
 # claudecode/gemini-cli step_keys: intentional word-splitting of the key list.
 step_keys() { # <keys>
   local keys="$1"
-  # shellcheck disable=SC2086 — intentional word-splitting of the key list
+  # shellcheck disable=SC2086  # intentional word-splitting of the key list
   tmux send-keys -t "$SESSION" $keys
   echo "[driver] keys[s$ACTIVE]: $keys" >&2
   sleep 0.3

--- a/replaydata/agents/claudecode/driver-interactive.sh
+++ b/replaydata/agents/claudecode/driver-interactive.sh
@@ -77,7 +77,9 @@ DRIVER_LOG="$STAGING/driver.log"
 # owner here, not a parallel manifest. Full tmux-TUI driver; every dispatched
 # step type is genuinely produced — `send|slash` is one arm, so a slash typed
 # via send reaches the REPL.
+# shellcheck disable=SC2034  # scraped from this file's SOURCE by tools/onboarding-factory/scripts/lib/recipe-lint.sh:97 (sed), never expanded in shell
 DRIVE_ELICITS="send slash wait_turn interrupt keys sleep restart resume reset_session sigkill exit_clean start_session session"
+# shellcheck disable=SC2034  # scraped from this file's SOURCE by tools/onboarding-factory/scripts/lib/recipe-lint.sh:113 (sed), never expanded in shell
 DRIVE_SLASH_REQUIRES_STEP_TYPE=false
 
 # Per-run CWD so claude writes its transcript under a unique
@@ -371,7 +373,7 @@ step_interrupt() {
 #   {"type": "keys", "keys": "Up Up Enter"}
 step_keys() {
   local keys="$1"
-  # shellcheck disable=SC2086 — intentional word-splitting of the key list
+  # shellcheck disable=SC2086  # intentional word-splitting of the key list
   tmux send-keys -t "$CURRENT_TMUX" $keys
   echo "[driver] keys[s$ACTIVE]: $keys" >&2
   sleep 0.3

--- a/replaydata/agents/codex/driver-interactive.sh
+++ b/replaydata/agents/codex/driver-interactive.sh
@@ -181,8 +181,11 @@ MARKER=""
 # lifetime. SES_ALIVE[i]=1 while its tmux session is still running.
 SES_SESSION=()
 SES_TRANSCRIPT=()
+# shellcheck disable=SC2034  # driver-owned slot array; the sourced replaydata/_lib/drive/slots.sh reads it (save_active/load_slot/alloc_slot)
 SES_UUID=()
+# shellcheck disable=SC2034  # driver-owned slot array; the sourced replaydata/_lib/drive/slots.sh reads it (save_active/load_slot/alloc_slot)
 SES_EXPECTED=()
+# shellcheck disable=SC2034  # driver-owned slot array; the sourced replaydata/_lib/drive/slots.sh reads it (save_active/load_slot/alloc_slot)
 SES_MARKER=()
 SES_CWD=()
 SES_ALIVE=()
@@ -200,6 +203,7 @@ TRUSTED_CWDS=()
 # shared model in lib/drive/slots.sh — byte-identical to pi's except the marker
 # filename, set via DRIVE_MARKER_PREFIX (#508 #3).
 _DRIVE_LIB="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../_lib/drive" && pwd)"
+# shellcheck disable=SC2034  # read by the sourced replaydata/_lib/drive/slots.sh:56 (alloc_slot)
 DRIVE_MARKER_PREFIX="$STAGING/.codex-start-marker"
 # shellcheck source=lib/drive/slots.sh
 source "$_DRIVE_LIB/slots.sh"
@@ -220,7 +224,9 @@ source "$(dirname "${BASH_SOURCE[0]}")/boot-gates.sh"
 # and whether slash commands need a dedicated step type. recipe-lint reads these
 # constants directly, so the grammar has ONE owner — this driver — not a
 # parallel manifest. Full tmux-TUI driver (claudecode set + fork).
+# shellcheck disable=SC2034  # scraped from this file's SOURCE by tools/onboarding-factory/scripts/lib/recipe-lint.sh:97 (sed), never expanded in shell
 DRIVE_ELICITS="send slash wait_turn interrupt keys sleep restart resume reset_session fork sigkill exit_clean start_session session"
+# shellcheck disable=SC2034  # scraped from this file's SOURCE by tools/onboarding-factory/scripts/lib/recipe-lint.sh:113 (sed), never expanded in shell
 DRIVE_SLASH_REQUIRES_STEP_TYPE=false
 
 # Has the active slot's cwd already had its trust dialog accepted this
@@ -816,7 +822,7 @@ while read -r step; do
       # such as codex's /model two-step selector. Example:
       #   {"type":"keys","keys":"Down Down Enter"}
       ks=$(jq -r '.keys' <<<"$step")
-      # shellcheck disable=SC2086 — intentional word-splitting of the key list
+      # shellcheck disable=SC2086  # intentional word-splitting of the key list
       tmux send-keys -t "$SESSION" $ks
       echo "[driver] keys[s$ACTIVE]: $ks" >&2
       sleep 0.5

--- a/replaydata/agents/copilot/driver-interactive.sh
+++ b/replaydata/agents/copilot/driver-interactive.sh
@@ -78,6 +78,7 @@ fi
 STAGING="$1"
 UUID="$2"            # preferred session id; some agents mint their own (ignore then)
 TIMEOUT_S="$3"
+# shellcheck disable=SC2034  # positional arg $4 of the driver protocol (tools/onboarding-factory/scripts/run-cell.sh:379); named so the slot is not silently reused, though this adapter's launch does not read it
 SETTINGS_PATH="$4"   # scenario settings blob; wire into the launch if the agent reads one
 SCRIPT_JSON="$5"
 
@@ -90,6 +91,7 @@ DRIVER_LOG="$STAGING/driver.log"
 # column starts ON the slot model: porting a multi-session step is "wire the seam
 # + call alloc_slot/load_slot", not rebuilding the slot bookkeeping (#666).
 _DRIVE_LIB="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../_lib/drive" && pwd)"
+# shellcheck disable=SC2034  # read by the sourced replaydata/_lib/drive/slots.sh:56 (alloc_slot)
 DRIVE_MARKER_PREFIX="$STAGING/.copilot-marker"
 # shellcheck source=/dev/null
 source "$_DRIVE_LIB/slots.sh"
@@ -119,7 +121,10 @@ SES_SESSION=(); SES_TRANSCRIPT=(); SES_UUID=(); SES_EXPECTED=()
 # Transcripts of sessions retired by an in-place rotation (reset_session).
 # They are dead, so they get no slot, but the fixture must still span them.
 RETIRED_TRANSCRIPTS=()
-SES_MARKER=(); SES_CWD=(); SES_ALIVE=()
+# shellcheck disable=SC2034  # driver-owned slot array; the sourced replaydata/_lib/drive/slots.sh reads it (save_active/load_slot/alloc_slot)
+SES_MARKER=()
+SES_CWD=()
+SES_ALIVE=()
 
 # recipe-lint contract (#508 #4): the step types this driver genuinely ELICITS,
 # read directly by recipe-lint (no separate manifest). Start with ONLY the seams
@@ -128,7 +133,9 @@ SES_MARKER=(); SES_CWD=(); SES_ALIVE=()
 # recipe-lint flags a recipe needing it as a semantic_gap before recording. Set
 # DRIVE_SLASH_REQUIRES_STEP_TYPE=true if copilot is headless-first (a bare
 # send "/cmd" stores literal text instead of reaching the REPL).
+# shellcheck disable=SC2034  # scraped from this file's SOURCE by tools/onboarding-factory/scripts/lib/recipe-lint.sh:97 (sed), never expanded in shell
 DRIVE_ELICITS="send slash sleep wait_turn exit_clean sigkill interrupt keys restart start_session session reset_session resume"
+# shellcheck disable=SC2034  # scraped from this file's SOURCE by tools/onboarding-factory/scripts/lib/recipe-lint.sh:113 (sed), never expanded in shell
 DRIVE_SLASH_REQUIRES_STEP_TYPE=false
 RUN_CWD="${IRRLICHT_ONBOARD_CWD:-$STAGING/cwd}"
 mkdir -p "$RUN_CWD"
@@ -482,6 +489,7 @@ while IFS= read -r step; do
     # Copilot exits on /exit; Ctrl-D is not a documented quit path here.
     exit_clean)      slash_cmd "/exit"
                      wait_tmux_session_gone "$SESSION" 15 || true
+                     # shellcheck disable=SC2034  # part of the shared slot model replaydata/_lib/drive/slots.sh:64 (alloc_slot) initialises; this driver keeps it current but has no branch that reads it, while sibling drivers do (e.g. antigravity's exit summary)
                      SES_ALIVE[$ACTIVE]=0 ;;
     start_session)   save_active
                      launch_repl ;;

--- a/replaydata/agents/gemini-cli/driver-interactive.sh
+++ b/replaydata/agents/gemini-cli/driver-interactive.sh
@@ -94,8 +94,11 @@ SHELL_MODE=0
 # Per-slot state (1-based; index 0 unused). Each slot is one session lifetime.
 SES_SESSION=()
 SES_TRANSCRIPT=()
+# shellcheck disable=SC2034  # driver-owned slot array; the sourced replaydata/_lib/drive/slots.sh reads it (save_active/load_slot/alloc_slot)
 SES_UUID=()
+# shellcheck disable=SC2034  # driver-owned slot array; the sourced replaydata/_lib/drive/slots.sh reads it (save_active/load_slot/alloc_slot)
 SES_EXPECTED=()
+# shellcheck disable=SC2034  # driver-owned slot array; the sourced replaydata/_lib/drive/slots.sh reads it (save_active/load_slot/alloc_slot)
 SES_MARKER=()
 SES_CWD=()
 SES_ALIVE=()
@@ -112,6 +115,7 @@ TRUSTED_CWDS=()
 # EXACTLY the gemini fswatcher session_id (extractSessionID), so the shared
 # epilogue lists the right ids with no gemini-specific override.
 _DRIVE_LIB="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../_lib/drive" && pwd)"
+# shellcheck disable=SC2034  # read by the sourced replaydata/_lib/drive/slots.sh:56 (alloc_slot)
 DRIVE_MARKER_PREFIX="$STAGING/.gemini-marker"
 # shellcheck source=../../_lib/drive/slots.sh
 source "$_DRIVE_LIB/slots.sh"
@@ -125,7 +129,9 @@ source "$_DRIVE_LIB/teardown.sh"
 # has a working seam below; a primitive whose arm is still a `not_implemented`
 # stub must NOT appear here, so recipe-lint flags a recipe needing it as a
 # semantic_gap (exit 4) before recording.
+# shellcheck disable=SC2034  # scraped from this file's SOURCE by tools/onboarding-factory/scripts/lib/recipe-lint.sh:97 (sed), never expanded in shell
 DRIVE_ELICITS="send slash wait_turn keys sleep restart resume reset_session sigkill exit_clean start_session session"
+# shellcheck disable=SC2034  # scraped from this file's SOURCE by tools/onboarding-factory/scripts/lib/recipe-lint.sh:113 (sed), never expanded in shell
 DRIVE_SLASH_REQUIRES_STEP_TYPE=false
 
 # --- API-key auth (shared by every launch) -----------------------------------
@@ -334,7 +340,7 @@ step_wait_turn() {
 #   {"type":"keys","keys":"Down"}   {"type":"keys","keys":"Down Down Enter"}
 step_keys() { # <keys>
   local keys="$1"
-  # shellcheck disable=SC2086 — intentional word-splitting of the key list
+  # shellcheck disable=SC2086  # intentional word-splitting of the key list
   tmux send-keys -t "$SESSION" $keys
   echo "[driver] keys[s$ACTIVE]: $keys" >&2
   # Gemini's `!` toggles shell mode ("esc to disable"). Track it so a following

--- a/replaydata/agents/hermes/driver-interactive.sh
+++ b/replaydata/agents/hermes/driver-interactive.sh
@@ -76,6 +76,7 @@ if [[ $# -ne 5 ]]; then
 fi
 
 STAGING="$1"
+# shellcheck disable=SC2034  # positional arg $2 of the driver protocol (tools/onboarding-factory/scripts/run-cell.sh:379); read by the sourced replaydata/_lib/drive/slots.sh (save_active/load_slot)
 UUID="$2"            # preferred session id; some agents mint their own (ignore then)
 TIMEOUT_S="$3"
 SETTINGS_PATH="$4"   # scenario settings blob; wire into the launch if the agent reads one
@@ -90,6 +91,7 @@ DRIVER_LOG="$STAGING/driver.log"
 # column starts ON the slot model: porting a multi-session step is "wire the seam
 # + call alloc_slot/load_slot", not rebuilding the slot bookkeeping (#666).
 _DRIVE_LIB="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../_lib/drive" && pwd)"
+# shellcheck disable=SC2034  # read by the sourced replaydata/_lib/drive/slots.sh:56 (alloc_slot)
 DRIVE_MARKER_PREFIX="$STAGING/.hermes-marker"
 # shellcheck source=/dev/null
 source "$_DRIVE_LIB/slots.sh"
@@ -100,8 +102,17 @@ source "$_DRIVE_LIB/contracts.sh"
 # with zero slots; launch_repl allocs slot 1, and restart/start_session alloc
 # more. ACTIVE indexes the live slot; SESSION/TRANSCRIPT/UUID mirror it.
 N_SLOTS=0; ACTIVE=0
-SES_SESSION=(); SES_TRANSCRIPT=(); SES_UUID=(); SES_EXPECTED=()
-SES_MARKER=(); SES_CWD=(); SES_ALIVE=(); SES_LAUNCH_TS=()
+SES_SESSION=()
+SES_TRANSCRIPT=()
+SES_UUID=()
+# shellcheck disable=SC2034  # driver-owned slot array; the sourced replaydata/_lib/drive/slots.sh reads it (save_active/load_slot/alloc_slot)
+SES_EXPECTED=()
+# shellcheck disable=SC2034  # driver-owned slot array; the sourced replaydata/_lib/drive/slots.sh reads it (save_active/load_slot/alloc_slot)
+SES_MARKER=()
+SES_CWD=()
+# shellcheck disable=SC2034  # driver-owned slot array written by the sourced replaydata/_lib/drive/slots.sh:64 (alloc_slot); kept current here for the shared slot model
+SES_ALIVE=()
+SES_LAUNCH_TS=()
 
 # recipe-lint contract (#508 #4): the step types this driver genuinely ELICITS,
 # read directly by recipe-lint (no separate manifest). Start with ONLY the seams
@@ -110,7 +121,9 @@ SES_MARKER=(); SES_CWD=(); SES_ALIVE=(); SES_LAUNCH_TS=()
 # recipe-lint flags a recipe needing it as a semantic_gap before recording. Set
 # DRIVE_SLASH_REQUIRES_STEP_TYPE=true if hermes is headless-first (a bare
 # send "/cmd" stores literal text instead of reaching the REPL).
+# shellcheck disable=SC2034  # scraped from this file's SOURCE by tools/onboarding-factory/scripts/lib/recipe-lint.sh:97 (sed), never expanded in shell
 DRIVE_ELICITS="send slash sleep wait_turn"
+# shellcheck disable=SC2034  # scraped from this file's SOURCE by tools/onboarding-factory/scripts/lib/recipe-lint.sh:113 (sed), never expanded in shell
 DRIVE_SLASH_REQUIRES_STEP_TYPE=false
 RUN_CWD="${IRRLICHT_ONBOARD_CWD:-$STAGING/cwd}"
 mkdir -p "$RUN_CWD"

--- a/replaydata/agents/kiro-cli/driver-interactive.sh
+++ b/replaydata/agents/kiro-cli/driver-interactive.sh
@@ -164,6 +164,7 @@ ACTIVE=0
 # .jsonl), so it sources the same lib (#508 #3). The per-slot marker filename is
 # set via DRIVE_MARKER_PREFIX.
 _DRIVE_LIB="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../_lib/drive" && pwd)"
+# shellcheck disable=SC2034  # read by the sourced replaydata/_lib/drive/slots.sh:56 (alloc_slot)
 DRIVE_MARKER_PREFIX="$STAGING/.kiro-launch-marker"
 # shellcheck source=../../_lib/drive/slots.sh
 source "$_DRIVE_LIB/slots.sh"
@@ -181,7 +182,9 @@ source "$_DRIVE_LIB/teardown.sh"
 # it is invisible to the daemon and MUST NOT be used for recording (FINDINGS.md
 # §7). slash commands reach the live TUI directly (a bare send "/cmd" is NOT
 # stored as literal text), so DRIVE_SLASH_REQUIRES_STEP_TYPE stays false.
+# shellcheck disable=SC2034  # scraped from this file's SOURCE by tools/onboarding-factory/scripts/lib/recipe-lint.sh:97 (sed), never expanded in shell
 DRIVE_ELICITS="send slash wait_turn sleep keys rewind_fork interrupt restart resume reset_session sigkill exit_clean start_session session"
+# shellcheck disable=SC2034  # scraped from this file's SOURCE by tools/onboarding-factory/scripts/lib/recipe-lint.sh:113 (sed), never expanded in shell
 DRIVE_SLASH_REQUIRES_STEP_TYPE=false
 
 remaining_seconds() { local now; now=$(date +%s); (( now >= DEADLINE )) && echo 0 || echo $((DEADLINE - now)); }
@@ -384,7 +387,7 @@ send_slash() { # <text>
 # step_keys in drive-claudecode-interactive.sh.
 send_keys() { # <key-token-list>
   local keys="$1"
-  # shellcheck disable=SC2086 — intentional word-splitting of the key list
+  # shellcheck disable=SC2086  # intentional word-splitting of the key list
   tmux send-keys -t "$SESSION" $keys
   echo "[driver] keys[s$ACTIVE]: $keys (no turn expected)" >&2
   sleep 0.3
@@ -415,7 +418,9 @@ step_rewind_fork() {
       SES_SESSION[$N_SLOTS]="$SESSION"
       SES_TRANSCRIPT[$N_SLOTS]="$KIRO_SESSIONS_DIR/$child_uuid.jsonl"
       SES_UUID[$N_SLOTS]="$child_uuid"
+      # shellcheck disable=SC2034  # driver-owned slot array; the sourced replaydata/_lib/drive/slots.sh reads it (save_active/load_slot/alloc_slot)
       SES_EXPECTED[$N_SLOTS]=0
+      # shellcheck disable=SC2034  # driver-owned slot array; the sourced replaydata/_lib/drive/slots.sh reads it (save_active/load_slot/alloc_slot)
       SES_MARKER[$N_SLOTS]="$MARKER"
       SES_CWD[$N_SLOTS]="${SES_CWD[$ACTIVE]}"
       SES_ALIVE[$N_SLOTS]=1

--- a/replaydata/agents/mistral-vibe/driver-interactive.sh
+++ b/replaydata/agents/mistral-vibe/driver-interactive.sh
@@ -98,6 +98,7 @@ VIBE_SESSION_GLOB='session_*'
 EXIT_DRIVER_FAULT="nonzero(2)"
 
 _DRIVE_LIB="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../_lib/drive" && pwd)"
+# shellcheck disable=SC2034  # read by the sourced replaydata/_lib/drive/slots.sh:56 (alloc_slot)
 DRIVE_MARKER_PREFIX="$STAGING/.mistral-vibe-marker"
 # shellcheck source=/dev/null
 source "$_DRIVE_LIB/slots.sh"
@@ -111,8 +112,15 @@ source "$_DRIVE_LIB/teardown.sh"
 # with zero slots; launch_repl allocs slot 1, and restart/start_session alloc
 # more. ACTIVE indexes the live slot; SESSION/TRANSCRIPT/UUID mirror it.
 N_SLOTS=0; ACTIVE=0
-SES_SESSION=(); SES_TRANSCRIPT=(); SES_UUID=(); SES_EXPECTED=()
-SES_MARKER=(); SES_CWD=(); SES_ALIVE=()
+SES_SESSION=()
+SES_TRANSCRIPT=()
+SES_UUID=()
+# shellcheck disable=SC2034  # driver-owned slot array; the sourced replaydata/_lib/drive/slots.sh reads it (save_active/load_slot/alloc_slot)
+SES_EXPECTED=()
+# shellcheck disable=SC2034  # driver-owned slot array; the sourced replaydata/_lib/drive/slots.sh reads it (save_active/load_slot/alloc_slot)
+SES_MARKER=()
+SES_CWD=()
+SES_ALIVE=()
 
 # recipe-lint contract (#508 #4): the step types this driver genuinely ELICITS,
 # read directly by recipe-lint (no separate manifest). Start with ONLY the seams
@@ -124,7 +132,9 @@ SES_MARKER=(); SES_CWD=(); SES_ALIVE=()
 # Tool-executing recipes: set the recipe's settings.bypass_tool_permissions=true
 # and launch_repl adds `vibe --auto-approve` so tool calls run unattended (not a
 # step type — a launch-mode toggle, so it stays out of DRIVE_ELICITS).
+# shellcheck disable=SC2034  # scraped from this file's SOURCE by tools/onboarding-factory/scripts/lib/recipe-lint.sh:97 (sed), never expanded in shell
 DRIVE_ELICITS="send slash sleep wait_turn exit_clean restart sigkill resume keys start_session session interrupt"
+# shellcheck disable=SC2034  # scraped from this file's SOURCE by tools/onboarding-factory/scripts/lib/recipe-lint.sh:113 (sed), never expanded in shell
 DRIVE_SLASH_REQUIRES_STEP_TYPE=false
 RUN_CWD="${IRRLICHT_ONBOARD_CWD:-$STAGING/cwd}"
 mkdir -p "$RUN_CWD"
@@ -455,7 +465,9 @@ slash_cmd() { # <text>
     PRE_LAUNCH_DIRS="$(find "$HOME/.vibe/logs/session" -maxdepth 1 -type d -name "$VIBE_SESSION_GLOB" 2>/dev/null | sort)"
     type_enter "$text"
     TRANSCRIPT=""; UUID=""
-    SES_TRANSCRIPT[$ACTIVE]=""; SES_UUID[$ACTIVE]=""
+    SES_TRANSCRIPT[$ACTIVE]=""
+    # shellcheck disable=SC2034  # driver-owned slot array; the sourced replaydata/_lib/drive/slots.sh reads it (save_active/load_slot/alloc_slot)
+    SES_UUID[$ACTIVE]=""
     EXPECTED_TURNS=0
     echo "[driver] slash[s$ACTIVE]: $text → session rotation; re-resolving transcript on next wait_turn" >&2
     return 0
@@ -558,6 +570,7 @@ step_resume() {
   sleep 1
   SESSION="mistral-vibedrv-$$-$(date +%s)-resume${ACTIVE}"
   SES_SESSION[$ACTIVE]="$SESSION"
+  # shellcheck disable=SC2034  # part of the shared slot model replaydata/_lib/drive/slots.sh:64 (alloc_slot) initialises; this driver keeps it current but has no branch that reads it, while sibling drivers do (e.g. antigravity's exit summary)
   SES_ALIVE[$ACTIVE]=1
   echo "[driver] resume[s$ACTIVE]: relaunch vibe --resume $resume_id (same dir=$(daemon_sid "$TRANSCRIPT"))" >&2
   boot_vibe_active "" "$resume_id"
@@ -619,7 +632,7 @@ while IFS= read -r step; do
                      # /model ModelPickerApp, C-c to clear a pre-filled input, etc.
                      # e.g. {"type":"keys","keys":"Down Enter"}.
                      ks="$(jq -r '.keys' <<<"$step")"
-                     # shellcheck disable=SC2086 — intentional word-split of the key list
+                     # shellcheck disable=SC2086  # intentional word-split of the key list
                      tmux send-keys -t "$SESSION" $ks
                      echo "[driver] keys[s$ACTIVE]: $ks" >&2
                      sleep 0.5 ;;

--- a/replaydata/agents/opencode/driver-interactive.sh
+++ b/replaydata/agents/opencode/driver-interactive.sh
@@ -94,7 +94,9 @@ DRIVER_LOG="$STAGING/driver.log"
 # sigkill/mid_turn_send, but ONLY via those STEP TYPES (a bare send "/cmd" never
 # reaches the REPL). The `live` no-op marker forces a plain send/wait_turn
 # recipe onto the long-lived run_live path.
+# shellcheck disable=SC2034  # scraped from this file's SOURCE by tools/onboarding-factory/scripts/lib/recipe-lint.sh:97 (sed), never expanded in shell
 DRIVE_ELICITS="send wait_turn sleep slash reset_session interrupt keys restart sigkill mid_turn_send start_session session live"
+# shellcheck disable=SC2034  # scraped from this file's SOURCE by tools/onboarding-factory/scripts/lib/recipe-lint.sh:113 (sed), never expanded in shell
 DRIVE_SLASH_REQUIRES_STEP_TYPE=true
 
 # Per-run cwd so each scenario launches a fresh opencode project context.
@@ -195,7 +197,7 @@ run_live() {
     exit 1
   }
 
-  local session="ocdrv-$$-$(date +%s)"
+  local session; session="ocdrv-$$-$(date +%s)"
   # Per-turn baseline: the terminal-step-finish high-water mark captured at the
   # moment a send fires. oc_wait_turn waits for the terminal count to strictly
   # exceed it — exactly one NEW `stop` per turn. (A raw all-step count compared
@@ -466,7 +468,7 @@ run_live() {
       EXIT_REASON="$NONZERO_2"
       return 1
     fi
-    # shellcheck disable=SC2086 — intentional word-splitting of the key list
+    # shellcheck disable=SC2086  # intentional word-splitting of the key list
     tmux send-keys -t "$session" $keys
     echo "[driver] live keys: $keys" >&2
     sleep 0.5

--- a/replaydata/agents/pi/driver-interactive.sh
+++ b/replaydata/agents/pi/driver-interactive.sh
@@ -129,7 +129,9 @@ MARKER=""
 SES_SESSION=()
 SES_TRANSCRIPT=()
 SES_UUID=()
+# shellcheck disable=SC2034  # driver-owned slot array; the sourced replaydata/_lib/drive/slots.sh reads it (save_active/load_slot/alloc_slot)
 SES_EXPECTED=()
+# shellcheck disable=SC2034  # driver-owned slot array; the sourced replaydata/_lib/drive/slots.sh reads it (save_active/load_slot/alloc_slot)
 SES_MARKER=()
 SES_CWD=()
 SES_ALIVE=()
@@ -140,6 +142,7 @@ ACTIVE=0
 # shared model in lib/drive/slots.sh — byte-identical to codex's except the
 # marker filename, set via DRIVE_MARKER_PREFIX (#508 #3).
 _DRIVE_LIB="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../_lib/drive" && pwd)"
+# shellcheck disable=SC2034  # read by the sourced replaydata/_lib/drive/slots.sh:56 (alloc_slot)
 DRIVE_MARKER_PREFIX="$STAGING/.pi-start-marker"
 # shellcheck source=lib/drive/slots.sh
 source "$_DRIVE_LIB/slots.sh"
@@ -160,7 +163,9 @@ source "$_DRIVE_LIB/teardown.sh"
 # picker UIs (e.g. /tree). start_session launches a second concurrent REPL
 # without tearing down the active one. Any step may carry {"session":N} to route
 # to slot N first.
+# shellcheck disable=SC2034  # scraped from this file's SOURCE by tools/onboarding-factory/scripts/lib/recipe-lint.sh:97 (sed), never expanded in shell
 DRIVE_ELICITS="send slash wait_turn interrupt keys sleep exit_clean resume reset_session start_session session"
+# shellcheck disable=SC2034  # scraped from this file's SOURCE by tools/onboarding-factory/scripts/lib/recipe-lint.sh:113 (sed), never expanded in shell
 DRIVE_SLASH_REQUIRES_STEP_TYPE=false
 
 # boot_session brings up a pi REPL in the active slot's tmux session
@@ -454,7 +459,7 @@ while read -r step; do
       # arm touches NEITHER EXPECTED_TURNS nor the multi-session contract
       # files (session.uuids / transcript.paths).
       ks=$(jq -r '.keys' <<<"$step")
-      # shellcheck disable=SC2086 — intentional word-splitting of the key list
+      # shellcheck disable=SC2086  # intentional word-splitting of the key list
       tmux send-keys -t "$SESSION" $ks
       echo "[driver] keys[s$ACTIVE]: $ks" >&2
       sleep 0.5

--- a/replaydata/orchestrators/gastown/driver.sh
+++ b/replaydata/orchestrators/gastown/driver.sh
@@ -29,7 +29,6 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || true)"
 [[ -n "$REPO_ROOT" ]] || { echo "not in a git repo" >&2; exit 1; }
 

--- a/tools/bash-lint.sh
+++ b/tools/bash-lint.sh
@@ -44,6 +44,37 @@
 #     SC2155 ×1  declare-and-assign masking a return value.
 #     SC2188 ×1  `> "$LOG"` — a redirection with no command.
 #
+# WHAT THE SECOND WAVE FOUND (#1687), when the two remaining exclusions — the
+# recording rig's per-agent drivers under `replaydata/` and the `.tmpl` they are
+# generated from — came in. 89 findings over 34 files (79 under `replaydata/`,
+# 10 in the template), and the census is IDENTICAL on 0.9.0 and 0.11.0, which
+# extends the version-agreement measurement above to this corpus rather than
+# assuming it:
+#
+#     SC2034 ×78 the driver protocol's declared-variable seam, and every one
+#                verified to have a real consumer before it was annotated:
+#                `DRIVE_ELICITS` / `DRIVE_SLASH_REQUIRES_STEP_TYPE` (24) are
+#                scraped out of the driver's SOURCE TEXT by
+#                scripts/lib/recipe-lint.sh and never expanded in a shell at
+#                all; the `SES_*` slot arrays and the view vars (48) are
+#                read/written by the sourced `replaydata/_lib/drive/*.sh`;
+#                `SETTINGS_PATH`/`UUID` (5) name positional slots of the
+#                driver protocol run-cell.sh:379 invokes. One — `SKILL_DIR` in
+#                the gastown driver — had NO consumer anywhere in the repo and
+#                was deleted rather than annotated.
+#     SC1125 ×8  `# shellcheck disable=SC2086 — <prose>`. The disable IS
+#                honoured (re-measured on both versions), so the fix is a
+#                respelling, not a behaviour change.
+#     SC1072/3×2 `replaydata/_lib/drive/contracts.sh`, whose whole analysis was
+#                abandoned — see the note on comments below.
+#     SC2155 ×1  `local session="ocdrv-$$-$(date +%s)"` in opencode's driver.
+#
+# Why the drivers were worth bringing in, beyond the count: #1388/#1694 found
+# that codex's driver had ROTTED against codex-cli 0.147.0 and produced a
+# healthy-looking fixture — `driver.exit-reason: ok`, zero rollouts — from a run
+# that did nothing. Ten adapter drivers steer live TUIs by grepping literal
+# strings, and until #1687 no static analyser read one of them.
+#
 # ONE FILE AT A TIME, and that is not an implementation detail. Measured: given
 # several files in ONE invocation, shellcheck suppresses SC2034 for a name used
 # in ANY of them — `shellcheck tools/lib/swift-suite_test.sh` reports 2
@@ -122,11 +153,22 @@
 # FIRST word after `#` is the linter's name is parsed as a DIRECTIVE, and an
 # unparseable one (SC1072/SC1073) makes it ABANDON the file — every later
 # finding silently disappears. This header tripped exactly that on its first
-# run, and `replaydata/_lib/drive/contracts.sh` has been carrying it unnoticed
-# (measured: rewording that one line surfaces an SC2005 the file currently
-# hides). So never open a comment line with that word — and note that the gate
+# run, and `replaydata/_lib/drive/contracts.sh` carried it from #508 until
+# #1687. So never open a comment line with that word — and note that the gate
 # below catches it, because an abandoned analysis reports SC1072/SC1073 at
 # ERROR severity and therefore fails rather than reading as clean.
+#
+# The floor was checked against that file rather than assumed, and the check
+# was worth running because it corrects the issue's own framing. #1687 quoted
+# "rewording that one line surfaces an SC2005 the file currently hides", which
+# is true at shellcheck's DEFAULT severity and false at this gate's: SC2005 is
+# `style`, so at `--severity=warning` the reworded file reports nothing at all.
+# What the floor catches is therefore not the hidden finding but the
+# ABANDONMENT itself — the file goes from "2 errors and no analysis" to
+# "analysed, clean", and any finding a future edit introduces is now visible
+# instead of swallowed. That is the whole reason SC1072/SC1073 sit inside the
+# floor, and the reason no extra guard was added for the construct: the gate
+# already refuses it, measured on 0.9.0 and 0.11.0 alike.
 #
 # NEVER SILENTLY PASSES. Four ways out are hard refusals (exit 2), not skips:
 # no shellcheck, an empty in-scope file set, an exclusion rule that matches
@@ -171,12 +213,6 @@ ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 EXCLUDE=(
   '*/testdata/*'
   'a deliberately-corrupt fixture corpus, driven by its own unit test rather than by this gate — the split tools/skill-lint.sh and tools/posix-lint.sh already draw for theirs'
-
-  'replaydata/*'
-  'the recording rigs per-agent drivers. Measured per-file: 79 findings, 68 of them SC2034 over the driver protocols declared-variable seam, 8 SC1125, plus replaydata/_lib/drive/contracts.sh, whose whole analysis is ABANDONED because a prose comment opens with the linters name. Bringing them in is a separate piece of work, filed as issue #1687'
-
-  '*/templates/*.tmpl'
-  'a template expanded into the driver family above, and carrying the same 10 SC2034 seam variables — excluded with replaydata/ rather than separately from it'
 )
 
 # ─── Discovery ──────────────────────────────────────────────────────────────

--- a/tools/lib/bash-lint_test.sh
+++ b/tools/lib/bash-lint_test.sh
@@ -150,9 +150,11 @@ assert_contains "floor: the run names the severity it applied" "--severity=warni
 #    skill-lint.sh's rule that a validator which cannot parse its input checks
 #    MORE, never less.
 #
-#    `replaydata/_lib/drive/contracts.sh` carries this construct today (outside
-#    this gate's scope; filed as #1687), and tools/bash-lint.sh's own header
-#    tripped it on the gate's first run.
+#    `replaydata/_lib/drive/contracts.sh` carried this construct from #508 until
+#    #1687, the whole time outside this gate's scope, and tools/bash-lint.sh's own
+#    header tripped it on the gate's first run. Cases 6f/6g below are the same
+#    construct graded at a real `replaydata/` path, now that the family is in
+#    scope.
 # ===========================================================================
 prose_tmp="$(mktemp -d)"
 hidden="$prose_tmp/reworded.sh"
@@ -197,11 +199,23 @@ assert_not_contains "discovery: the fixture corpus is excluded" "ok  tools/lib/t
 # than a count that would need editing on every new script.
 assert_contains "discovery: the census names both halves" "bash-lint: " "$out"
 assert_contains "discovery: ...including the testdata exclusion's own tally" "*/testdata/*=" "$out"
-assert_contains "discovery: ...and the recording-rig exclusion's" "replaydata/*=" "$out"
 
-# The excluded families must be genuinely absent from the linted list, not
-# merely uncounted.
-assert_not_contains "discovery: replaydata drivers are excluded" "ok  replaydata/" "$out"
+# The excluded family must be genuinely absent from the linted list, not merely
+# uncounted.
+assert_not_contains "discovery: the fixture corpus is not linted" "ok  tools/lib/testdata/bash-lint/" "$out"
+
+# ...and the family that came IN with #1687 must be genuinely present. Named
+# files rather than a count: re-excluding all 34 recording-rig scripts would
+# drop the corpus from 117 to 83, which every threshold below still accepts.
+# `contracts.sh` specifically, because it is the file whose analysis shellcheck
+# ABANDONED for the whole of its life before #1687 — a gate reporting `ok` for
+# it is the one line that says the abandonment is gone AND the file is read.
+assert_contains "scope (#1687): the recording rig's drivers are linted" \
+  "ok  replaydata/agents/codex/driver-interactive.sh" "$out"
+assert_contains "scope (#1687): ...including the shared driver libs" \
+  "ok  replaydata/_lib/drive/contracts.sh" "$out"
+assert_contains "scope (#1687): ...and the template they are generated from" \
+  "ok  tools/onboarding-factory/scripts/templates/drive-interactive.sh.tmpl" "$out"
 
 # ...and the exclusions must not have swallowed the corpus. `--list` is the
 # machine-readable form of the census; a scope that collapsed to a handful of
@@ -241,12 +255,16 @@ scratch_repo() {
     cd "$d" || exit 1
     git init -q . || exit 1
     printf '#!/usr/bin/env bash\nset -eu\necho clean\n' > tracked-clean.sh || exit 1
-    # One inhabitant per exclusion rule. Without these the gate refuses (case
-    # 7), which would make every assertion here grade the wrong path.
-    mkdir -p tools/lib/testdata/bash-lint replaydata/_lib tools/templates || exit 1
+    # One inhabitant for the single remaining exclusion rule. Without it the
+    # gate refuses (case 7), which would make every assertion here grade the
+    # wrong path. It carries an SC2034 deliberately: a CLEAN fixture would pass
+    # whether it was excluded or linted, so only a broken one can tell those
+    # apart, and cases 6c/7 rely on that.
+    mkdir -p tools/lib/testdata/bash-lint replaydata/_lib || exit 1
     printf '#!/usr/bin/env bash\nfoo=1\n' > tools/lib/testdata/bash-lint/fixture.sh || exit 1
-    printf '#!/usr/bin/env bash\nbar=1\n' > replaydata/_lib/driver.sh || exit 1
-    printf '#!/usr/bin/env bash\nbaz=1\n' > tools/templates/drive.sh.tmpl || exit 1
+    # Since #1687 `replaydata/` is IN scope, so this one has to be clean — it is
+    # here as a stand-in for the recording rig, not as an exemption.
+    printf '#!/usr/bin/env bash\nset -eu\necho driver\n' > replaydata/_lib/driver.sh || exit 1
     git add -A . || exit 1
     # The fixture IS the test here. A scratch repo that did not come up would
     # make every assertion below grade a tree git cannot read, and a gate that
@@ -286,16 +304,17 @@ if scratch_repo "$scratch"; then
   assert_eq "untracked: a clean UNTRACKED script passes (exit 0)" "0" "$rc"
   assert_contains "untracked: the clean untracked file is reported ok" \
     "ok  untracked-clean.sh" "$out"
-  # 2 linted (tracked-clean.sh + untracked-clean.sh) of 5 discovered; the gate's
-  # own copy is untracked bash under tools/ and IS linted, making 3 of 6.
+  # 3 linted (tracked-clean.sh + replaydata/_lib/driver.sh + untracked-clean.sh)
+  # of 4 discovered; the gate's own copy is bash under tools/ and IS linted,
+  # making 4 of 5. Only the testdata fixture is excluded.
   assert_contains "untracked: the census counts it exactly once" \
-    "bash-lint: 3 of 6 bash file(s)" "$out"
+    "bash-lint: 4 of 5 bash file(s)" "$out"
 else
   echo "  FAIL: untracked: scratch repo could not be built" >&2
   fails=$((fails + 1))
 fi
 
-# 6c. The exclusions apply to untracked files too — a plausible
+# 6c. The exclusion applies to untracked files too — a plausible
 #     mis-implementation is a SECOND walk that skips the filters the first one
 #     applies, which is the mistake posix-lint_test.sh's cases 10c/10d were
 #     written against. Pinning the census rather than only the exit status is
@@ -303,15 +322,62 @@ fi
 if scratch_repo "$scratch"; then
   printf '#!/usr/bin/env bash\nset -u\nd=""\nrm -rf "$d/lib"\n' \
     > "$scratch/tools/lib/testdata/bash-lint/untracked-bad.sh"
-  printf '#!/usr/bin/env bash\nset -u\nd=""\nrm -rf "$d/lib"\n' \
-    > "$scratch/replaydata/untracked-bad.sh"
   out=$( cd "$scratch" && ./tools/bash-lint.sh 2>&1 )
   rc=$?
   assert_eq "untracked: an excluded-family untracked file is still excluded (exit 0)" "0" "$rc"
   assert_contains "untracked: the exclusion census counts them" "*/testdata/*=2" "$out"
-  assert_contains "untracked: ...and the replaydata rule counts both of its own" "replaydata/*=2" "$out"
 else
   echo "  FAIL: untracked: scratch repo could not be built" >&2
+  fails=$((fails + 1))
+fi
+
+# ===========================================================================
+# 6f. THE #1687 SCOPE MUTATION, and the reason it is here rather than in the
+#     committed corpus: a deliberately-broken fixture cannot live under
+#     `replaydata/` — the gate would fail on it forever, and that catalog is
+#     CI-deletion-guarded (#268), so the evidence could not be retired either.
+#     A scratch repo is the only place the planted file can carry the real
+#     path.
+#
+#     Both directions, because each alone is satisfied by the wrong gate:
+#     a finding under `replaydata/` must FAIL (the exclusion #1684 declared
+#     made this pass), and the same tree without it must PASS (a gate that
+#     rejected everything would satisfy the first).
+if scratch_repo "$scratch"; then
+  mkdir -p "$scratch/replaydata/agents/codex"
+  printf '#!/usr/bin/env bash\nset -u\nd=""\nrm -rf "$d/lib"\n' \
+    > "$scratch/replaydata/agents/codex/driver-interactive.sh"
+  out=$( cd "$scratch" && ./tools/bash-lint.sh 2>&1 )
+  rc=$?
+  assert_eq "scope (#1687): a finding under replaydata/ FAILS the gate" "1" "$rc"
+  assert_contains "scope (#1687): the driver is named on a FAIL line" \
+    "FAIL replaydata/agents/codex/driver-interactive.sh" "$out"
+
+  # 6g. The construct #1687 was filed for, at a real recording-rig path: a
+  #     comment whose first word is the linter's own name. It is NOT reported
+  #     as a style nit — it ABANDONS the file, so the SC2115 two lines down
+  #     disappears. The gate must still go red, via SC1073, because those parse
+  #     errors are inside its severity floor. This asserts scope and floor
+  #     together: either one missing and the file reads as clean.
+  printf '#!/usr/bin/env bash\n# shellcheck this comment is prose, not a directive\nset -u\nd=""\nrm -rf "$d/lib"\n' \
+    > "$scratch/replaydata/agents/codex/driver-interactive.sh"
+  out=$( cd "$scratch" && ./tools/bash-lint.sh 2>&1 )
+  rc=$?
+  assert_eq "scope (#1687): an ABANDONED replaydata file fails rather than reading clean" "1" "$rc"
+  assert_contains "scope (#1687): ...reported as the unparseable directive it is" "SC1073" "$out"
+  # The abandonment is what makes this worth its own case: shellcheck's only
+  # output for the file is the parse error, and the rm below it is invisible.
+  assert_not_contains "scope (#1687): ...and the SC2115 below it is indeed swallowed" "SC2115" "$out"
+
+  printf '#!/usr/bin/env bash\nset -eu\necho clean driver\n' \
+    > "$scratch/replaydata/agents/codex/driver-interactive.sh"
+  out=$( cd "$scratch" && ./tools/bash-lint.sh 2>&1 )
+  rc=$?
+  assert_eq "scope (#1687, vacuity): a clean driver at the same path passes" "0" "$rc"
+  assert_contains "scope (#1687, vacuity): ...and was actually read" \
+    "ok  replaydata/agents/codex/driver-interactive.sh" "$out"
+else
+  echo "  FAIL: scope: scratch repo could not be built" >&2
   fails=$((fails + 1))
 fi
 
@@ -357,15 +423,20 @@ fi
 #    for exemption maps — `TW_EXEMPT_KEYS` in shell-lib-errexit_test.sh,
 #    `nilTolerant` in construction_test.go, `shell_lib_suite_run`'s skip list —
 #    keys are existence-checked, because an entry that stopped naming anything
-#    real reads from the log exactly like coverage. A repo with no replaydata/
-#    is that state.
+#    real reads from the log exactly like coverage. A repo with no fixture
+#    corpus is that state.
+#
+#    Since #1687 there is exactly ONE exclusion left, which makes this case
+#    carry more weight than it did: it is the only remaining proof that the
+#    existence check works at all, so if a future exclusion is added it should
+#    get its own arm here rather than rely on this one.
 # ===========================================================================
 if scratch_repo "$scratch"; then
-  rm -rf "$scratch/replaydata"
+  rm -rf "$scratch/tools/lib/testdata"
   out=$( cd "$scratch" && ./tools/bash-lint.sh 2>&1 )
   rc=$?
   assert_eq "refusal: an exclusion matching nothing exits 2 (not a silent pass)" "2" "$rc"
-  assert_contains "refusal: it names the dead rule" "replaydata/*" "$out"
+  assert_contains "refusal: it names the dead rule" "*/testdata/*" "$out"
   assert_contains "refusal: ...and repeats the reason that rule was written for" \
     "Its stated reason was" "$out"
 else
@@ -397,6 +468,9 @@ fi
 # ===========================================================================
 if scratch_repo "$scratch"; then
   rm -f "$scratch/tracked-clean.sh"
+  # ...and the recording-rig stand-in, which since #1687 is in scope and would
+  # otherwise keep the in-scope set non-empty.
+  rm -f "$scratch/replaydata/_lib/driver.sh"
   printf '/tools/bash-lint.sh\n' > "$scratch/.gitignore"
   # `git rm --cached` as well as the .gitignore: scratch_repo already TRACKED
   # the gate copy, and .gitignore only governs untracked paths.

--- a/tools/lib/testdata/bash-lint/README.md
+++ b/tools/lib/testdata/bash-lint/README.md
@@ -22,15 +22,20 @@ by nothing.
 | `bad-declare-assign.sh` | SC2155 | `local x=$(cmd)` masks `cmd`'s status. |
 | `bad-redirect-no-command.sh` | SC2188 | a redirection with no command. |
 | `bad-directive-prose.sh` | SC1072/SC1073 | a prose comment opening with the linter's name is parsed as a directive, and an unparseable one makes it **abandon the file**. |
-| `bad-directive-keyvalue.sh` | SC1125 | a directive whose reason is appended without a second `#`. |
+| `bad-directive-keyvalue.sh` | SC1125 | a directive whose reason is appended without a second `#`. Eight sites in `replaydata/` were written this way; #1687 respelled them. |
 | `good-clean.sh` | — | the **vacuity guard**. A linter that failed everything would satisfy all nine above. |
 | `style-noisy-but-warning-clean.sh` | — | the severity floor, in the one direction the `bad-*` files cannot reach: shellcheck exits 1 carrying only SC2086/SC2012, below the floor, and the gate must pass it. |
 
 `bad-directive-prose.sh` is the one to read first, because its failure mode is
 silence rather than noise: the SC2115 on its last line is **invisible** while
 line 12 is present, and `bash-lint_test.sh` proves that by rewording that one
-line and asserting the finding appears. `replaydata/_lib/drive/contracts.sh` has
-been carrying the same construct unnoticed (#1687), and `tools/bash-lint.sh`'s own
-header tripped it on the gate's first run.
+line and asserting the finding appears. `replaydata/_lib/drive/contracts.sh`
+carried the same construct from #508 until #1687 — outside the gate's scope for
+all of it — and `tools/bash-lint.sh`'s own header tripped it on the gate's first
+run. Since #1687 that file is in scope and clean, and
+`bash-lint_test.sh`'s scope cases plant the construct at a `replaydata/` path in
+a scratch repo, because a broken fixture cannot live in that catalog: the gate
+would fail on it forever and #268's deletion guard would not let it be
+retired.
 
 Do not "fix" the findings in `bad-*.sh`. They are the assertions.

--- a/tools/onboarding-factory/scripts/smoke-test.sh
+++ b/tools/onboarding-factory/scripts/smoke-test.sh
@@ -108,6 +108,14 @@ echo ""
 # multi-file invocation cross-suppresses SC2034), and runs in linux.yml and
 # `tools/preflight.sh --only bash`. Two mechanisms where one of them could not
 # fail is worse than one that can.
+#
+# Note the scope that sentence did NOT cover until #1687, because it is the
+# tree this file's own suites live in: `replaydata/**` was a declared exclusion
+# of that gate, so the three driver-lib suites run above — and every per-agent
+# driver they exercise — were read by no static analyser at all, while the
+# `bash -n` pass at the top of this file walks only `scripts/`. #1687 removed
+# the exclusion, so the deferral above is now true of the recording rig as
+# well as of the factory scripts.
 echo "== shellcheck =="
 echo "  (covered by tools/bash-lint.sh — linux.yml, or tools/preflight.sh --only bash)"
 

--- a/tools/onboarding-factory/scripts/templates/drive-interactive.sh.tmpl
+++ b/tools/onboarding-factory/scripts/templates/drive-interactive.sh.tmpl
@@ -76,8 +76,10 @@ if [[ $# -ne 5 ]]; then
 fi
 
 STAGING="$1"
+# shellcheck disable=SC2034  # positional arg $2 of the driver protocol (tools/onboarding-factory/scripts/run-cell.sh:379); read by the sourced replaydata/_lib/drive/slots.sh (save_active/load_slot)
 UUID="$2"            # preferred session id; some agents mint their own (ignore then)
 TIMEOUT_S="$3"
+# shellcheck disable=SC2034  # positional arg $4 of the driver protocol (tools/onboarding-factory/scripts/run-cell.sh:379); named so the slot is not silently reused, though this adapter's launch does not read it
 SETTINGS_PATH="$4"   # scenario settings blob; wire into the launch if the agent reads one
 SCRIPT_JSON="$5"
 
@@ -90,6 +92,7 @@ DRIVER_LOG="$STAGING/driver.log"
 # column starts ON the slot model: porting a multi-session step is "wire the seam
 # + call alloc_slot/load_slot", not rebuilding the slot bookkeeping (#666).
 _DRIVE_LIB="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../_lib/drive" && pwd)"
+# shellcheck disable=SC2034  # read by the sourced replaydata/_lib/drive/slots.sh:56 (alloc_slot)
 DRIVE_MARKER_PREFIX="$STAGING/.__AGENT__-marker"
 # shellcheck source=/dev/null
 source "$_DRIVE_LIB/slots.sh"
@@ -100,8 +103,17 @@ source "$_DRIVE_LIB/contracts.sh"
 # with zero slots; launch_repl allocs slot 1, and restart/start_session alloc
 # more. ACTIVE indexes the live slot; SESSION/TRANSCRIPT/UUID mirror it.
 N_SLOTS=0; ACTIVE=0
-SES_SESSION=(); SES_TRANSCRIPT=(); SES_UUID=(); SES_EXPECTED=()
-SES_MARKER=(); SES_CWD=(); SES_ALIVE=()
+SES_SESSION=()
+SES_TRANSCRIPT=()
+# shellcheck disable=SC2034  # driver-owned slot array; the sourced replaydata/_lib/drive/slots.sh reads it (save_active/load_slot/alloc_slot)
+SES_UUID=()
+# shellcheck disable=SC2034  # driver-owned slot array; the sourced replaydata/_lib/drive/slots.sh reads it (save_active/load_slot/alloc_slot)
+SES_EXPECTED=()
+# shellcheck disable=SC2034  # driver-owned slot array; the sourced replaydata/_lib/drive/slots.sh reads it (save_active/load_slot/alloc_slot)
+SES_MARKER=()
+SES_CWD=()
+# shellcheck disable=SC2034  # driver-owned slot array written by the sourced replaydata/_lib/drive/slots.sh:64 (alloc_slot); kept current here for the shared slot model
+SES_ALIVE=()
 
 # recipe-lint contract (#508 #4): the step types this driver genuinely ELICITS,
 # read directly by recipe-lint (no separate manifest). Start with ONLY the seams
@@ -110,7 +122,9 @@ SES_MARKER=(); SES_CWD=(); SES_ALIVE=()
 # recipe-lint flags a recipe needing it as a semantic_gap before recording. Set
 # DRIVE_SLASH_REQUIRES_STEP_TYPE=true if __AGENT__ is headless-first (a bare
 # send "/cmd" stores literal text instead of reaching the REPL).
+# shellcheck disable=SC2034  # scraped from this file's SOURCE by tools/onboarding-factory/scripts/lib/recipe-lint.sh:97 (sed), never expanded in shell
 DRIVE_ELICITS="send slash sleep"
+# shellcheck disable=SC2034  # scraped from this file's SOURCE by tools/onboarding-factory/scripts/lib/recipe-lint.sh:113 (sed), never expanded in shell
 DRIVE_SLASH_REQUIRES_STEP_TYPE=false
 RUN_CWD="${IRRLICHT_ONBOARD_CWD:-$STAGING/cwd}"
 mkdir -p "$RUN_CWD"
@@ -177,6 +191,7 @@ send_text() { # <text>
 
 # --- Step dispatch: ALL standard arms present; stubs fail loudly -------------
 launch_repl
+# shellcheck disable=SC2034  # read by the sourced replaydata/_lib/drive/slots.sh (save_active/load_slot)
 EXPECTED_TURNS=0
 while IFS= read -r step; do
   type="$(jq -r '.type' <<<"$step")"


### PR DESCRIPTION
Closes #1687.

`tools/bash-lint.sh` (#1684) shipped **default-IN with three declared exclusions**. Two
of them were one family — the recording rig's per-agent drivers under `replaydata/**`
and the `.tmpl` they are generated from — and #1684 filed this to carry the rest of the
work. This removes both. **Exactly one exclusion is left** (`*/testdata/*`, the
deliberately-corrupt fixture corpora).

Scope: **83 → 117 files.** 33 under `replaydata/` plus the template.

---

## The scope change

Both entries came out of `EXCLUDE`; the machinery was extended, not duplicated — no
second walk, per #1611's lesson that a second walk is how `posix-lint`'s exclusions
nearly stopped applying to half its set.

Nothing stayed excluded from `replaydata/`. The template came in **deliberately rather
than incidentally**: it is where new drivers are generated from, so the per-site
annotations below are inherited by the next adapter instead of being rediscovered.

One consequence is worth flagging for review, and it is stated in the suite rather than
left implicit: with a single exclusion remaining, case 7 (*an exclusion that matches
nothing exits 2*) is now the **only** proof the existence check works at all. A future
second exclusion owes its own arm there.

---

## Triage of all 89

Measured per-file at the gate's own floor (`--shell=bash --severity=warning`), which
reproduces #1687's figure exactly: **79 under `replaydata/`, 10 in the `.tmpl`**.

| code | n | disposition |
|---|---:|---|
| SC2034 | 78 | 77 annotated per site; **1 deleted** |
| SC1125 | 8 | respelled |
| SC1072/SC1073 | 2 | the abandoning comment, reworded |
| SC2155 | 1 | declare/assign split |

No code was blanket-disabled and no exclusion was added to reach zero.

### SC2034 ×78 — every consumer verified by grep *before* annotating

| variable | n | consumer, checked |
|---|---:|---|
| `DRIVE_SLASH_REQUIRES_STEP_TYPE` | 12 | `scripts/lib/recipe-lint.sh:113` |
| `DRIVE_ELICITS` | 12 | `scripts/lib/recipe-lint.sh:97` |
| `SES_MARKER` | 10 | `_lib/drive/slots.sh` save_active/load_slot/alloc_slot |
| `DRIVE_MARKER_PREFIX` | 10 | `_lib/drive/slots.sh:56` (alloc_slot) |
| `SES_EXPECTED` | 9 | `_lib/drive/slots.sh` |
| `SES_ALIVE` | 6 | `slots.sh:64` writes; drivers branch on it |
| `SES_UUID` | 5 | `_lib/drive/slots.sh` |
| `SETTINGS_PATH` | 3 | driver protocol arg `$4`, `run-cell.sh:379` |
| `UUID`, `SES_CWD` | 2 ea | arg `$2` / slot cwd, read by drivers |
| `TRANSCRIPT`, `STAGING`, `SES_TRANSCRIPT`, `SES_SESSION`, `EXPECTED_TURNS`, `EXIT_REASON` | 1 ea | the sourced `_lib/drive/*.sh` or `turn-count.sh` |
| **`SKILL_DIR`** | **1** | **none — deleted** |

Two of these are worth reading twice. `DRIVE_ELICITS` and
`DRIVE_SLASH_REQUIRES_STEP_TYPE` (24 of the 78, the largest class) are **never expanded
in a shell at all** — `recipe-lint.sh` scrapes them out of the driver's *source text*
with `sed`. Deleting them to satisfy shellcheck would have silently disarmed the
semantic recipe lint, which is precisely the failure the "verify the consumer" rule
exists to prevent.

`SKILL_DIR` (`replaydata/orchestrators/gastown/driver.sh:32`) is the one that went the
other way: `git grep SKILL_DIR` returns its own assignment and one unrelated Python
file, nothing else in the repo. No consumer, so it was deleted rather than annotated —
that distinction is the whole point of the rule, and annotating it would have been a
dismissal carrying no evidence.

**Two mechanical facts I had to measure, both now recorded in AGENTS.md**, because the
naive fix is wrong in each case:

- A directive covers only the **next command**, so a `;`-joined line
  `SES_SESSION=(); SES_TRANSCRIPT=(); SES_UUID=(); SES_EXPECTED=()` takes its directive
  on the *first* assignment only. Such lines are split one per line. A directive sitting
  above a three-assignment line, appearing to cover three and covering one, is worse
  than no annotation.
- A directive placed before the file's **first command** applies **file-wide**. That is
  a blanket disable wearing a per-site shape, and is not used anywhere here.

### SC1125 ×8 — respelled, behaviour unchanged

`# shellcheck disable=SC2086 — <prose>` → `…SC2086  # <prose>`. Re-measured on both
versions: the em-dash form **does** honour the disable (a probe with the directive
correctly placed above the offending command reports 1 finding as SC1125 and 0
otherwise), so this is a spelling fix, not a repaired suppression.

### SC2155 ×1

`local session="ocdrv-$$-$(date +%s)"` → declare then assign, in opencode's driver.
Under `set -e` a failing `date` now aborts rather than yielding a truncated tmux session
name — strictly the better failure.

---

## The malformed-directive case: **already caught, kept, no new guard**

Asked directly in the issue, so answered directly.

`replaydata/_lib/drive/contracts.sh:39` opened a prose comment with the word
`shellcheck`. Measured before the fix:

```
$ shellcheck --shell=bash --severity=warning --format=gcc replaydata/_lib/drive/contracts.sh
…:39:1:  error: Couldn't parse this shellcheck directive. Fix to allow more checks. [SC1073]
…:39:16: error: Expected '=' after directive key. …                                [SC1072]
```

Those two lines were the **entire** output for that file, from #508 until now.
SC1072/SC1073 are `error` severity, so **the existing floor catches it the moment the
file is in scope** — #1684 put them inside the floor for exactly this. Kept as is; the
exclusion was the only thing hiding it. Mutation M3 below is that claim run against the
real file.

**One correction to the issue's framing, since it will otherwise be quoted onward.**
#1687 says rewording the line "immediately surfaces an `SC2005` the file currently
hides". True at shellcheck's *default* severity; false at this gate's, because SC2005 is
`style`:

```
reworded, --severity=warning : (no output)
reworded, --severity=style   : …:30:10: note: Useless echo? … [SC2005]
```

So what the floor buys here is not the hidden finding — it is below the floor either
way — but the **end of the abandonment**: the file goes from *2 errors and no analysis*
to *analysed and clean*, and any finding a future edit introduces is visible at all.
That correction is recorded in `tools/bash-lint.sh`'s header and in AGENTS.md rather
than only here.

I probed whether the floor covers the *class* or only that spelling — 10 comment shapes,
measured. Every abandoning spelling reports SC1072/SC1073, including two I would not
have predicted (`# shellcheck-style comments are fine, right?` and `# shellcheck: …`).
The residual hole is a prose comment that happens to parse as a *valid* directive
(`# shellcheck source=…`, `shell=…`, `enable=…` are silent). That is contrived enough
that no machinery was added for it, and it is named here rather than left undiscovered.

---

## Mutation evidence

Anything added owes a red. Applied and reverted one per call, `git status --porcelain`
asserted clean after each.

**M1 — restore the `replaydata/*` exclusion.** The scope change's own mutation.

```
  FAIL: scope (#1687): the recording rig's drivers are linted — expected [contains 'ok  replaydata/agents/codex/driver-interactive.sh']
        got [bash-lint: 84 of 128 bash file(s); excluded: */testdata/*=11 replaydata/*=33
  FAIL: scope (#1687): a finding under replaydata/ FAILS the gate — expected [1] got [0]
  FAIL: scope (#1687): an ABANDONED replaydata file fails rather than reading clean — expected [1] got [0]
  FAIL: scope (#1687): ...reported as the unparseable directive it is — expected [contains 'SC1073']
  FAIL: untracked: the census counts it exactly once — expected [contains 'bash-lint: 4 of 5 bash file(s)']
bash-lint_test: 9 FAILED
```

The third line is #1687 reproduced exactly: **with the exclusion back, an abandoned file
reads as a pass.**

**M2 — delete one per-site SC2034 disable** (proves the annotations are load-bearing,
not decoration):

```
FAIL replaydata/agents/codex/driver-interactive.sh
…:227:1: warning: DRIVE_ELICITS appears unused. Verify use (or export if used externally). [SC2034]
gate rc=1
```

**M3 — restore the abandoning comment in the real `contracts.sh`**, verbatim:

```
FAIL replaydata/_lib/drive/contracts.sh
…:39:1:  error: Couldn't parse this shellcheck directive. Fix to allow more checks. [SC1073]
…:39:16: error: Expected '=' after directive key. …                                [SC1072]
gate rc=1
```

**M4 — restore the em-dash directive spelling:**

```
FAIL replaydata/agents/pi/driver-interactive.sh
…:462:35: error: Invalid key=value pair? Ignoring the rest of this directive starting here. [SC1125]
gate rc=1
```

One mutation **failed to apply and said so** rather than passing quietly — M2's first
filter matched nothing and its `assert removed == 1` fired. That is #1390's rule doing
its job inside this PR; the green it would otherwise have produced is exactly the
failure mode this whole gate is about.

### Committed, not just described

Per "prefer committing that mutation to describing it", the scope evidence is in the
suite as cases **6f/6g**, both directions:

- a finding under `replaydata/` **fails** the gate and is **named**;
- the abandonment construct at a `replaydata/` path fails via SC1073, **and** the SC2115
  below it is asserted **absent** — the silence is the finding;
- a clean driver at the same path **passes and is reported `ok`** (vacuity).

They live in a scratch repo rather than in `tools/lib/testdata/bash-lint/`, and the
reason is stated in the code: a deliberately-broken fixture **cannot** live under
`replaydata/` — the gate would fail on it forever and #268's deletion guard would not
let it be retired.

Case 5 additionally pins `contracts.sh` by name as `ok`, since a count-based check would
not notice all 34 files leaving scope (117 → 83 clears every threshold in the file).

---

## Cross-version check

CI runs shellcheck **0.9.0**; this machine has **0.11.0**. #1684 measured them identical
at `-S warning` over *its* corpus; that is not a proof for a new one, so I fetched 0.9.0
and measured:

|  | 0.9.0 | 0.11.0 |
|---|---:|---:|
| baseline (at `HEAD`, via `git archive`) | 89 | 89 |
| after this PR | **0** | **0** |

`diff` of the two baseline reports: **byte-identical**, same codes, same `line:col`. The
floor was not touched.

---

## Also fixed: a dismissal that had gone stale

`tools/onboarding-factory/scripts/smoke-test.sh` says shellcheck is "covered by
`tools/bash-lint.sh`". True of the factory `scripts/` tree it sits in — but that file
also *runs* three driver-lib suites out of `replaydata/`, and its own `bash -n` pass
walks only `scripts/`. So for the drivers the deferral pointed at a gate that had them
excluded. The comment now says which scope it did **not** cover until this PR. No code
change.

---

## Gates

Each its own foreground call, exit status read directly (never through a pipe).

| gate | result |
|---|---|
| `tools/preflight.sh --only bash` | **PASS** — 117 of 128, `ALL PASS` |
| `tools/preflight.sh --only tools` | **PASS** |
| `tools/preflight.sh --only posix` | **PASS** (3 files; no `#!/bin/sh` file touched — checked, not assumed) |
| `tools/preflight.sh --changed --only go` | **PASS** — gofmt, replaydata validate, recording-rig smoke test, replay fixtures |
| `--changed --only skills / arch / security / web` | SKIP (diff selects none) |
| `bash -n` over every touched `.sh`/`.tmpl` | **PASS** |
| pre-push hook (full `--changed --budget 540`) | **PASS** — every gate PASS or SKIP |

`swift` is SKIP: nothing under `platforms/macos/` is touched.

**One process note, since it is the documented incident.** The first `git push` was
killed at the 2-minute default while the pre-push hook was mid-run — commit made, push
not sent. Recovered by running each `--changed` group in the foreground first, then
re-pushing under a 600s timeout with the hook fully running. Nothing was pushed with
`--no-verify`.
