### PR TITLE
fix(ci): tell "the snapshot-evidence harness never loaded" from "the run was truncated" (#1678)

### DIFF
--- a/.github/workflows/macos-swift.yml
+++ b/.github/workflows/macos-swift.yml
@@ -53,9 +53,11 @@ name: macOS (Swift)
 # skipped suites failed on no machine anybody could look at, so every statement
 # about WHAT differs was inferred from which suites pass. It is not a gate on
 # the pixels — those failing is its expected outcome and it does not judge them
-# — but it IS a gate on itself: a run that hung, was truncated, executed
-# nothing, or produced no images fails it, because "collected no evidence" and
-# "found no difference" must never print the same thing.
+# — but it IS a gate on itself: a run whose harness never loaded, or that hung,
+# was truncated, executed nothing, or produced no images fails it, because
+# "collected no evidence" and "found no difference" must never print the same
+# thing. Since #1678 those five are told apart from each other as well, not
+# only from health: the first used to be reported as the second.
 #
 # It costs a third macOS job per PR (macOS minutes bill at 10×). That is
 # deliberate for as long as the suites are skipped and #1615's step 3 is open;
@@ -308,7 +310,50 @@ jobs:
           # indistinguishable from an assertion failure.)
           set +e
           set -uo pipefail
-          . tools/lib/swift-suite.sh
+
+          # The harness, and the refusal that tells "the predicates could not
+          # be LOADED" from "the predicates RAN and reported truncation"
+          # (#1678). This source's status used to be read by nothing, and the
+          # result was not silent but MISDIAGNOSED. Measured with the library
+          # removed, under this step's own derived shell — four `::error::`
+          # lines, in this order:
+          #
+          #   the evidence run was TRUNCATED: the bundle never reported …
+          #   the evidence run executed 0 tests.
+          #   RasterPrimitiveEvidenceTests wrote no manifest …
+          #   not one of the five suites produced a failure image … #1615 has moved
+          #
+          # Every `swift_suite_*` call below becomes "command not found", so
+          # four guards fire at once. The first sends a reader to XCTest's
+          # stall detector (#1523) and the last says this workflow's own suite
+          # classification is stale. None of it happened: nothing ran.
+          #
+          # TWO checks rather than one, because a source that RETURNS 0 having
+          # defined nothing reads exactly like one that worked — an emptied or
+          # truncated file, or one whose last statement succeeded after an
+          # earlier error. `command -v` is the only thing that tells those
+          # apart, and it is what makes this three outcomes instead of two.
+          # The names are listed rather than derived because the guard asks
+          # "did this file's contents take effect", which any one of them
+          # answers; a fourth predicate call added below and not listed here
+          # is still covered by the three.
+          #
+          # Both refuse HERE rather than adding to `bad`: `swift_suite_run` is
+          # what PRODUCES everything the guards below judge, so continuing
+          # would grade an evidence run that was never started. The two
+          # wordings are deliberately disjoint, because a shared exit 1 is
+          # satisfied by refusals that all fire together (#1644).
+          if ! . tools/lib/swift-suite.sh; then
+            echo "::error::could not load the test harness tools/lib/swift-suite.sh, so the evidence run was never started and nothing below can judge it. This is NOT a truncated test bundle — look at the checkout, not at XCTest."
+            exit 1
+          fi
+          for fn in swift_suite_run swift_suite_completed swift_suite_ran_tests; do
+            if ! command -v "$fn" >/dev/null 2>&1; then
+              echo "::error::tools/lib/swift-suite.sh was read but defines no $fn, so the evidence run was never started and nothing below can judge it. This is NOT a truncated test bundle — the harness loaded and is unusable."
+              exit 1
+            fi
+          done
+
           log="$RUNNER_TEMP/swift-snapshot-evidence.log"
           export SNAPSHOT_ARTIFACTS="$RUNNER_TEMP/snapshot-artifacts"
           mkdir -p "$SNAPSHOT_ARTIFACTS"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1290,13 +1290,42 @@ Before marking a ticket done, run the full suite — every layer must pass:
   references would otherwise satisfy the "not one of the suites produced a
   failure image" guard forever. The re-audit is in that file's header rather
   than here: `exit "$bad"` decides, six guards write `bad`, and of the four
-  statements it cannot see, two degrade LOUDLY (a library that will not load
-  reports TRUNCATED — wrong headline, right verdict; a failed `mkdir -p`
-  reaches two guards, not the one the issue claimed) and one is silent and
-  cosmetic (`>> "$GITHUB_STEP_SUMMARY"`, whose text is already on stdout).
+  statements it cannot see, one degrades loudly (a failed `mkdir -p` reaches
+  two guards, not the one the issue claimed) and one is silent and cosmetic
+  (`>> "$GITHUB_STEP_SUMMARY"`, whose text is already on stdout).
   This workflow was in `preflight.sh`'s `tools` trigger since #1629, so the
   trigger needed no sixth widening — the assertion simply joins the gate that
   already covers it.
+  **The fourth is the one worth carrying, because #1677 pinned it WRONG on
+  purpose and #1678 had to correct it.** `. tools/lib/swift-suite.sh` was also
+  read by nothing, and that failure was never silent — every `swift_suite_*`
+  call becomes "command not found", so the step exits 1. What it got wrong was
+  the DIAGNOSIS, and by more than #1646 recorded: measured, **four** headlines
+  fire at once, opening with `TRUNCATED` (which sends a reader to XCTest's
+  stall detector, #1523) and closing with "not one of the five suites produced
+  a failure image … #1615 has moved" (which accuses this workflow's own suite
+  classification). #1677 recorded that as an audit finding and committed an arm
+  asserting the wrong headline — loud, and honest about being wrong, but a test
+  pinning incorrect behaviour reads as coverage, which is why it was filed
+  rather than left as a note. Three outcomes now, on #1645's discipline and on
+  the same shape as the copy: **loaded** / **could not load** (the source's
+  status, now read) / **loaded and defines nothing** (`command -v`, because
+  `. an-empty-file` exits 0 — the outcome no status check can see, exactly as
+  an empty `cp -R` is). Both refuse before the run rather than adding to
+  `bad`, since `swift_suite_run` produces everything the six guards judge.
+  Two things the mutation runs settle. The wording arms are what
+  discriminate and the status arms are not: dropping the source status check
+  leaves the step still exiting 1 via the OTHER refusal, so only "naming the
+  harness it could not load" and the mutual-absence arm go red — #1644's
+  measurement, reproduced one family on, and the reason each refusal asserts
+  every other refusal's wording is absent. And keeping both refusals but
+  replacing `exit 1` with a continue leaves both NAMING arms green while the
+  four headline-absent arms go red, so those arms hold the exit placement
+  rather than the message. The sibling `swift-test` step does **not** have this
+  defect and needed no change: measured the same way, `swift_suite_verdict` is
+  itself among the missing functions, so no headline prints at all and the step
+  exits 127 with three `command not found` lines — loud, undiagnosed, but never
+  wrong. Weaker, not broken; #1702 covers it.
 - Which bash a workflow step gets: **there are two invocations and this repo
   conflated them** for the whole of the two bullets above (#1650). A step
   DECLARING `shell: bash` runs as `bash --noprofile --norc -e -o pipefail {0}`;

--- a/tools/lib/swift-snapshot-evidence_test.sh
+++ b/tools/lib/swift-snapshot-evidence_test.sh
@@ -82,27 +82,44 @@
 #      `-not -path '*/__References__/*'` exclusion the count depends on — 53
 #      reference images would otherwise satisfy the "not one of the suites
 #      produced a failure image" guard forever.
-#   8. the audit's remaining blind statements are shown to be LOUD: a
-#      `. tools/lib/swift-suite.sh` that fails is read by nothing either, but
-#      it degrades to a failing step rather than a silent pass. Its diagnosis
-#      is wrong (it reports TRUNCATED), which is recorded here rather than
-#      claimed away.
+#   8. a harness that will not LOAD is refused by name, not misdiagnosed
+#      (#1678). Until then this arm pinned the opposite: the step reported the
+#      run as TRUNCATED, plus three more headlines, none of which happened.
+#   9. a harness that loads and defines NOTHING is refused too, and told apart
+#      from 8. `. an-empty-file` exits 0, so no status check anywhere can see
+#      this one — it is to the source what obligation 5 is to the copy.
+#  10. 8 and 9 are told APART, and neither borrows a verdict from the four
+#      guards below them: each asserts the other's wording is absent, and both
+#      assert all four run-shape headlines are absent. A shared exit 1 is
+#      satisfied by refusals that all fire together — measured that way in
+#      #1644, and measured again in #1678, where all four fired at once.
 #
 # ---------------------------------------------------------------------------
 # The re-audit: which statement decides the status, and what it cannot see
 #
-# `exit "$bad"` decides, and `bad` is written by exactly six guards — the 124
-# hang, the truncation, the zero-test run, the copy (three outcomes, above),
-# the manifest count, and the failure-image count. Everything else in the block
-# is invisible to it unless it feeds one of those. #1646 traced this and found
-# one exception; measured rather than inherited, there are four, and three of
-# them are covered by something:
+# `exit "$bad"` decides for everything after the harness has loaded, and `bad`
+# is written by exactly six guards — the 124 hang, the truncation, the zero-test
+# run, the copy (three outcomes, above), the manifest count, and the
+# failure-image count. The two load refusals (#1678) are the exception and exit
+# directly, because they fire before `bad` exists and before anything those
+# guards judge has been produced. Everything else in the block is invisible to
+# the status unless it feeds one of the six. #1646 traced this and found one
+# blind statement; measured rather than inherited, there were four. TWO are now
+# read (the source, #1678; the copy, #1646), one is still unread but degrades
+# loudly through two other guards, and the fourth is silent and stated rather
+# than dismissed:
 #
-#   `. tools/lib/swift-suite.sh`  read by nothing. A library that does not load
-#                                 makes both predicate calls "command not
-#                                 found", so two guards fire and the step exits
-#                                 1 — LOUD, with the wrong headline. Obligation
-#                                 8 below drives it.
+#   `. tools/lib/swift-suite.sh`  WAS read by nothing, and the result was LOUD
+#                                 with the wrong headline: every `swift_suite_*`
+#                                 call became "command not found", so FOUR
+#                                 guards fired — TRUNCATED, `executed 0 tests`,
+#                                 the missing manifest, and "not one of the five
+#                                 suites produced a failure image … #1615 has
+#                                 moved". #1646 said two; measured, it is four,
+#                                 and the last of them accuses this workflow's
+#                                 own suite classification. Read now, in two
+#                                 checks, and refused before the run: #1678,
+#                                 obligations 8-10 below.
 #   `mkdir -p "$SNAPSHOT_ARTIFACTS"`
 #                                 read by nothing, and covered more strongly
 #                                 than #1646 claimed: with the directory
@@ -326,6 +343,16 @@ CANNOT='could not copy platforms/macos/Tests/__Snapshots__'
 LANDED_NOTHING='reference copy reported success but'
 COPIED='reference image(s) into the artifact'
 
+# The two load refusals (#1678), and the four run-shape headlines they must not
+# borrow a verdict from. Before #1678 a harness that would not load printed all
+# four of these and none of its own — the whole of obligations 8-10.
+NOLOAD='could not load the test harness tools/lib/swift-suite.sh'
+UNUSABLE='was read but defines no'
+TRUNCATED='TRUNCATED'
+ZERO_TESTS='executed 0 tests'
+NO_MANIFEST='wrote no manifest'
+NO_FAILURES='not one of the five suites produced a failure image'
+
 # ---------------------------------------------------------------------------
 # Obligation 1 — the pre-#1646 hazard, re-measured on every run.
 #
@@ -390,7 +417,7 @@ want_absent "...and not the 'could not copy' diagnosis (obligation 6)" "$CANNOT"
 want_absent "...and not the 'landed nothing' diagnosis (obligation 6)" "$LANDED_NOTHING" "$OUT"
 # The other guards must stay quiet, or this arm's non-zero would be someone
 # else's: a shared exit status is satisfied by every refusal firing at once.
-want_absent "...with the run itself still judged healthy" "TRUNCATED" "$OUT"
+want_absent "...with the run itself still judged healthy" "$TRUNCATED" "$OUT"
 
 # ---------------------------------------------------------------------------
 # Obligation 4 — the copy fails.
@@ -446,7 +473,12 @@ build_checkout full
 mk_artifacts "$TMP/art-nofailures.sh" 0
 run_step "$TMP/step.sh" full hung 1 "$TMP/art-nofailures.sh"
 want_status "a truncated run fails the step" 1 "$ST" "$OUT"
-want_contains "...diagnosed as truncated" "TRUNCATED" "$OUT"
+want_contains "...diagnosed as truncated" "$TRUNCATED" "$OUT"
+# The other direction of obligation 10, and the vacuity guard for the whole of
+# #1678: a load refusal that fired unconditionally would swallow this arm, and a
+# real truncation must still be reported as one.
+want_absent "...and NOT as a harness that could not be loaded (#1678)" "$NOLOAD" "$OUT"
+want_absent "...nor as a harness that loaded and is unusable (#1678)" "$UNUSABLE" "$OUT"
 want_contains "...with the references copied anyway" "$COPIED" "$OUT"
 want_absent "...and no copy refusal" "$CANNOT" "$OUT"
 want_contains "...and the copied references NOT counted as failure images" \
@@ -454,24 +486,60 @@ want_contains "...and the copied references NOT counted as failure images" \
 want_contains "...which the count line says out loud" "collected 0 failure image(s)" "$OUT"
 
 # ---------------------------------------------------------------------------
-# Obligation 8 — the audit's remaining blind statement, measured rather than
-# dismissed.
+# Obligations 8 and 10 — the harness cannot be loaded at all.
 #
-# `. tools/lib/swift-suite.sh` is the other statement in the block whose status
-# reaches nothing. It is NOT silent: with the library gone, the two predicate
-# calls become "command not found", both guards fire and the step exits 1. What
-# it gets wrong is the DIAGNOSIS — it reports the run as TRUNCATED, pointing a
-# reader at XCTest when the step never loaded its harness. Recorded here rather
-# than claimed away; it is a loud failure with a misleading headline, not a
-# green.
+# `. tools/lib/swift-suite.sh` was the other statement in the block whose status
+# reached nothing. It was never silent: with the library gone, every
+# `swift_suite_*` call becomes "command not found" and the step exits 1. What it
+# got WRONG was the diagnosis, and by more than #1646 recorded — measured, FOUR
+# headlines fire, the first pointing a reader at XCTest's stall detector
+# (#1523) and the last accusing this workflow's own suite classification of
+# being stale. This arm asserted the first of those until #1678, which is a test
+# pinning incorrect behaviour: the four `want_absent`s below are the correction,
+# and each of them is the arm that would have gone red then.
 echo ""
-echo "== a library that does not load is LOUD (audit, #1646) =="
+echo "== a harness that does not load is refused BY NAME (#1678) =="
 build_checkout full
 rm -f "$CHECKOUT/tools/lib/swift-suite.sh"
 mk_artifacts "$TMP/art-nolib.sh" 1
 run_step "$TMP/step.sh" full clean 0 "$TMP/art-nolib.sh"
 want_status "a missing swift-suite.sh fails the step rather than passing quietly" 1 "$ST" "$OUT"
-want_contains "...though it is diagnosed as a truncated run, which is not what happened" "TRUNCATED" "$OUT"
+want_contains "...naming the harness it could not load" "$NOLOAD" "$OUT"
+want_absent "...and NOT diagnosed as a truncated test bundle (#1678)" "$TRUNCATED" "$OUT"
+want_absent "...nor as a run that executed 0 tests" "$ZERO_TESTS" "$OUT"
+want_absent "...nor as a fixture that wrote no manifest" "$NO_MANIFEST" "$OUT"
+want_absent "...nor as five suites that have started passing on a runner" "$NO_FAILURES" "$OUT"
+want_absent "...and not the other load refusal's wording (obligation 10)" "$UNUSABLE" "$OUT"
+
+# ---------------------------------------------------------------------------
+# Obligations 9 and 10 — the harness loads and is unusable.
+#
+# The outcome no status check can see, and the reason the fix is two checks
+# rather than one: `. an-empty-file` exits 0. A truncated, emptied or
+# half-written library therefore satisfies the source's own status while
+# defining none of the predicates, and every headline above comes back. This is
+# to the source exactly what obligation 5 is to the copy.
+echo ""
+echo "== a harness that loads and defines nothing is refused too (#1678) =="
+build_checkout full
+: >"$CHECKOUT/tools/lib/swift-suite.sh"
+mk_artifacts "$TMP/art-emptylib.sh" 1
+run_step "$TMP/step.sh" full clean 0 "$TMP/art-emptylib.sh"
+want_status "a swift-suite.sh that defines nothing fails the step" 1 "$ST" "$OUT"
+want_contains "...naming the predicate it does not define" "$UNUSABLE" "$OUT"
+want_absent "...and not the 'could not load' diagnosis (obligation 10)" "$NOLOAD" "$OUT"
+want_absent "...and NOT diagnosed as a truncated test bundle" "$TRUNCATED" "$OUT"
+want_absent "...nor as a run that executed 0 tests" "$ZERO_TESTS" "$OUT"
+want_absent "...nor as a fixture that wrote no manifest" "$NO_MANIFEST" "$OUT"
+want_absent "...nor as five suites that have started passing on a runner" "$NO_FAILURES" "$OUT"
+# ...and the premise of the arm: sourcing an empty file really does succeed, so
+# the status check alone could not have caught this one.
+if bash -c '. "$1"' _ "$CHECKOUT/tools/lib/swift-suite.sh"; then
+  pass "...with sourcing the empty library having demonstrably SUCCEEDED (exit 0), which is why the second check exists"
+else
+  fail "the unusable-library arm's premise" "sourcing an empty file to exit 0" \
+       "it exited non-zero — this arm graded obligation 8"
+fi
 
 echo ""
 if [[ "$rc" -eq 0 ]]; then


### PR DESCRIPTION
Closes #1678.

## The defect, re-measured before changing anything

`.github/workflows/macos-swift.yml`'s `swift-snapshot-evidence` step sources the harness and
reads its status with nothing:

```sh
set +e
set -uo pipefail
. tools/lib/swift-suite.sh
```

#1678 filed this on #1677's audit. I drove it first, extracting the real body through
`tools/lib/workflow-step.sh` and running it under the shell that step actually gets
(`bash --noprofile --norc -e -o pipefail`, derived) with the library deliberately absent:

```
step.sh: line 15: tools/lib/swift-suite.sh: No such file or directory
step.sh: line 19: swift_suite_run: command not found
step.sh: line 39: swift_suite_completed: command not found
::error::the evidence run was TRUNCATED: the bundle never reported its own result, so the suites after the last one shown never ran.
step.sh: line 43: swift_suite_ran_tests: command not found
::error::the evidence run executed 0 tests.
copied 1 reference image(s) into the artifact
::error::RasterPrimitiveEvidenceTests wrote no manifest — the fixture did not run at all, so the count below cannot be judged.
::error::not one of the five suites produced a failure image. Either SNAPSHOT_ARTIFACTS stopped being honoured, or those suites now PASS on a runner — in which case ImageSnapshotCIScopeTests' classification, and the skip list in swift-test derived from it, is stale and #1615 has moved.
### ---- exit: 1 ----
```

**It is worse than the issue described, and the correction matters.** #1646 and #1678 both
say two guards fire. Measured, **four** do. The headline is `TRUNCATED` (#1523's shape,
pointing a reader at XCTest's stall detector) and the closer accuses this workflow's own
suite classification of being stale and #1615 of having moved. Nothing ran; there was no
bundle to truncate and no suite to reclassify.

## The fix — three outcomes, and their wording

Same discipline as #1645 and as this step's own copy guard, and the same shape: two of the
three outcomes are told apart by a status, and the third by nothing a status can see.

| outcome | what happened | what it prints |
|---|---|---|
| **loaded** | the harness is there and usable | nothing; the run proceeds and the six guards judge it |
| **could not load** | `. tools/lib/swift-suite.sh` reported failure | `::error::could not load the test harness tools/lib/swift-suite.sh, so the evidence run was never started and nothing below can judge it. This is NOT a truncated test bundle — look at the checkout, not at XCTest.` |
| **loaded and defines nothing** | source exited 0, `command -v` finds no predicate | `::error::tools/lib/swift-suite.sh was read but defines no <fn>, so the evidence run was never started and nothing below can judge it. This is NOT a truncated test bundle — the harness loaded and is unusable.` |

**Two checks rather than one, and the second is the one no status can reach.** `. an-empty-file`
exits **0** — measured, and asserted as the third outcome's arm premise, so an emptied,
truncated or half-written library satisfies the source's own status while defining none of
the predicates and every wrong headline comes back. That is exactly what an empty `cp -R`
is to #1677's reference copy, one statement up.

**Both refuse with `exit 1` rather than adding to `bad`**, because `swift_suite_run` PRODUCES
everything the six guards judge — continuing would grade an evidence run that was never
started, which is the cascade above. Mutation M5 below is that decision seen red.

The three predicate names are listed rather than derived, stated rather than left implied:
the guard asks "did this file's contents take effect", which any ONE of them answers, so a
fourth predicate call added later and not listed here is still covered by the three.

## The pinning arm, corrected

`tools/lib/swift-snapshot-evidence_test.sh`'s obligation 8 asserted the wrong headline —
deliberately and honestly, but a test pinning incorrect behaviour reads as coverage. It now
reads:

* **obligation 8** — the harness cannot be loaded: refused by name, and **not** diagnosed as
  a truncated bundle, a zero-test run, a missing manifest, or five suites that have started
  passing on a runner. Those four `want_absent`s are precisely the arms that would have gone
  red under #1677.
* **obligation 9** — the harness loads and defines nothing: refused by name, with the arm's
  own premise asserted (sourcing the empty library really does exit 0, so the status check
  alone could not have caught it) — the same shape as obligation 5's "cp really did succeed".
* **obligation 10** — 8 and 9 are told apart: each asserts the other's wording is absent, and
  both assert all four run-shape headlines are absent. **This is #1677's rule, and M3 below
  is it re-measured:** a shared non-zero is satisfied by refusals that all fire together, so
  the status arms prove nothing on their own.
* **obligation 7 gains the reverse direction** — a genuinely truncated run must still be
  reported as one and **not** as either load failure. That is the vacuity guard for the whole
  change: a refusal that fired unconditionally would otherwise swallow it (M4).

## The sibling step: it does NOT have this misdiagnosis

Checked rather than assumed, and `swift-suite.sh` itself was not touched (another agent owns
it under #1688). `swift-test` sources the same library and also reads nothing. Same probe,
same shell, library absent:

```
step.sh: line 28: tools/lib/swift-suite.sh: No such file or directory
step.sh: line 30: swift_suite_run: command not found
step.sh: line 38: swift_suite_verdict: command not found
### ---- exit: 127 ----
```

The missing function there IS `swift_suite_verdict`, so **no headline can print at all**. The
step is loud (127) and **undiagnosed** — never misdiagnosed. Strictly better than this step's
pre-fix state, which is why nothing was changed there. It is still short of #1645's third
outcome (a refusal naming what could not be done), so it is filed as **#1702** with the
measurement above, rather than left as a sentence in this body.

## Mutation evidence

Every arm the change adds, seen red. One mutation per foreground run, applied and reverted
copy-aside/copy-back with a `git status --porcelain` assertion and a `diff -q` restore check
after each.

**M1 — revert to the bare `. tools/lib/swift-suite.sh` (the pre-#1678 state).** 10 arms red,
across obligations 8 and 9 only; every other obligation, including obligation 7's two new
absent arms, stayed green:
```
FAIL: ...naming the harness it could not load — expected [output containing: could not load the test harness tools/lib/swift-suite.sh]
FAIL: ...and NOT diagnosed as a truncated test bundle (#1678) — expected [no output containing: TRUNCATED]
FAIL: ...nor as a run that executed 0 tests
FAIL: ...nor as a fixture that wrote no manifest
FAIL: ...nor as five suites that have started passing on a runner
FAIL: ...naming the predicate it does not define — expected [output containing: was read but defines no]
```

**M2 — delete the `command -v` loop, keep the source status check.** Red on obligation 9's
five arms **and nothing else**, which is the isolation claim:
```
== a harness that does not load is refused BY NAME (#1678) ==      (all green)
== a harness that loads and defines nothing is refused too (#1678) ==
  FAIL: ...naming the predicate it does not define
  FAIL: ...and NOT diagnosed as a truncated test bundle
  FAIL: ...nor as a run that executed 0 tests
  FAIL: ...nor as a fixture that wrote no manifest
  FAIL: ...nor as five suites that have started passing on a runner
```

**M3 — stop reading the source's status, keep the `command -v` loop.** This is #1644's
measurement reproduced, and the reason obligation 10 exists: the step **still exits 1**, so
every status arm stays green and only the WORDING arms go red — exactly two of them:
```
FAIL: ...naming the harness it could not load — expected [output containing: could not load the test harness tools/lib/swift-suite.sh]
FAIL: ...and not the other load refusal's wording (obligation 10) — expected [no output containing: was read but defines no]
```

**M4 — vacuity probe: the load refusal fires unconditionally.** Red on the healthy arm, so no
arm reports unconditionally — and red on obligation 7's new reverse assertion, which is that
arm's own evidence:
```
FAIL: a healthy evidence run passes — expected [exit 0] got [exit 1 :: ::error::could not load the test harness …]
FAIL: ...diagnosed as truncated — expected [output containing: TRUNCATED]
FAIL: ...and NOT as a harness that could not be loaded (#1678) — expected [no output containing: could not load the test harness …]
```
(plus obligations 3, 4, 5 and 9, as an unconditional refusal must.)

**M5 — keep both refusals but replace `exit 1` with a continue.** Both NAMING arms stay
green and only the eight headline-absent arms go red, so those arms hold the **exit
placement** rather than the message — which is the evidence for refusing before the run
rather than accumulating into `bad`:
```
== a harness that does not load is refused BY NAME (#1678) ==
  FAIL: ...and NOT diagnosed as a truncated test bundle (#1678)
  FAIL: ...nor as a run that executed 0 tests
  FAIL: ...nor as a fixture that wrote no manifest
  FAIL: ...nor as five suites that have started passing on a runner
  FAIL: ...and not the other load refusal's wording (obligation 10)
== a harness that loads and defines nothing is refused too (#1678) ==
  FAIL: ...and NOT diagnosed as a truncated test bundle
  FAIL: ...nor as a run that executed 0 tests
  FAIL: ...nor as a fixture that wrote no manifest
  FAIL: ...nor as five suites that have started passing on a runner
```

## Gates

Local, macOS, each its own foreground invocation with the exit status read directly (never
through a pipe — this repo's shell is zsh, where `${PIPESTATUS[0]}` yields nothing and
`status` is read-only).

* `tools/preflight.sh --only tools` → **PASS**, exit 0. `shell-lib-suite: tools/lib — found 17, skipped 0 (none), ran 17, failed 0`; `workflow-step_test` resolves this step to `bash --noprofile --norc -e -o pipefail` and the harness prints the same derivation.
* `tools/preflight.sh --only bash` → **PASS**, exit 0. `bash-lint: 117 of 128 bash file(s)`, shellcheck 0.11.0 at `--severity=warning`.
* `tools/preflight.sh --only swift` → **PASS**, exit 0. `ImageSnapshotCIScopeTests`' four tests pass, which is the check that matters here: that suite text-parses this very workflow for `--skip `/`--filter ` tokens, so it is what proves the two new `::error::` messages injected no phantom suite into the skip-list derivation. Both messages were written to carry neither token.
* `python3 -c yaml.safe_load` parses the workflow and reports the three jobs and five evidence-job steps.
* The pre-push hook ran `--changed`: POSIX sh lint PASS, bash lint PASS, `tools/lib` shell-lib tests PASS, gofmt PASS, macOS Swift build + test PASS, everything else SKIP.

**The runner half has since landed, and it is the half that could not be measured locally.**
`swift-snapshot-evidence` passes on `macos-latest` in 2m5s, and its step log carries both
things this change had to leave as a prediction:

```
shell: /bin/bash --noprofile --norc -e -o pipefail {0}
copied 53 reference image(s) into the artifact
collected 36 failure image(s) and 7 of 7 primitive image(s)
```

The first line is the invocation `workflow-step.sh` DERIVED and the harness printed, confirmed
by the runner itself against the `bash -e` its `Report toolchain` neighbour gets — so the arms
above graded the real program. The next two are a healthy evidence run reaching the same
numbers as #1677's, with **no `::error::` emitted**: the two new guards are inert on the happy
path, which is the one property a fixture cannot establish about production. `swift-build` and
`swift-test` pass beside it; `ars-gate`, both web suites, all three CodeQL analyses, SonarCloud
and CodeScene (advisory) pass. **All 16 checks pass.** `go-test` ran this harness on the
runner too — `== tools/lib/swift-snapshot-evidence_test.sh ==` → `swift-snapshot-evidence_test: OK`,
in the census `found 17, skipped 2 (bash-lint_test.sh posix-lint_test.sh), ran 15, failed 0`.

## Also here

* `AGENTS.md`'s snapshot-evidence bullet no longer documents the wrong headline as current
  behaviour. It carries the corrected count (four headlines, not two), the three outcomes,
  the two mutation findings worth reusing (M3's wording-vs-status split, M5's exit
  placement), and the sibling-step answer with #1702.
* The step's own header comment now lists the harness-load failure among the shapes this job
  gates itself on, and says the first used to be reported as the second.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
