### PR TITLE
feat(tools): extend the real-home witness from new FILES to named domains' key sets AND values (#1688)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1701,11 +1701,17 @@ Before marking a ticket done, run the full suite — every layer must pass:
   collapsed by default) and a row still resolving `UserDefaults.standard` both
   write nothing too, so "wrote nothing" is worthless without "and it asked THIS
   store". The **runtime** witness #1672 also proposed — `tools/lib/swift-suite.sh`
-  comparing named domains' key SETS rather than directory entries — is #1688,
-  deferred with its measurement rather than dropped: the key set is quiet enough
-  to adopt (0 additions across two suite-length windows, against ~1 plist/218s
-  for the directory witness) but a growth-only check is green on any domain that
-  already has the key, i.e. on the machine that found this.
+  comparing named domains rather than directory entries — landed as #1688, and
+  what #1690 measured about it is why it compares VALUES and not only key sets:
+  the domain is quiet enough to adopt (0 changes across two suite-length
+  windows, against ~1 plist/218s for the directory witness) but a GROWTH-only
+  check is green on any domain that already holds the key, i.e. on the machine
+  that found this. Measured again in #1688, as the mutation that reddens the
+  #1672-shaped case and leaves the added/removed cases green. What no
+  before-to-after comparison of a domain can reach is the last step of the same
+  argument — an IDEMPOTENT write, which is #1672 exactly as it happened — so the
+  domain witness prints that limit on every clean run rather than a bare clean
+  line, and the checks that DO see it are the two in this paragraph.
   **#1689 is the READ half of the same member, and its premise turned out to be
   false in the useful direction.** `SettingsView.reconcileNotificationsMasterDefault()`
   DECIDED from `UserDefaults.standard.object(forKey:)` and wrote through
@@ -1958,7 +1964,28 @@ Before marking a ticket done, run the full suite — every layer must pass:
   suite-length windows, 4 unrelated background plists across one 870s window of
   interactive use. It is not filtered by name — #1661's leaked files were
   `<uuid>.plist`, so any name filter that quietened the churn would have
-  quietened the incident. `Tests/RealHomePathLintTests.swift` is the structural
+  quietened the incident.
+  **That witness has a SECOND half since #1688, and the split between the two is
+  the point rather than the sum**: the directory half watches for new FILES,
+  while `SWIFT_SUITE_WITNESSED_DOMAINS` compares
+  `com.apple.dt.xctest.tool` and `io.irrlicht.app` key set AND values through
+  `defaults export`, because #1672 was a write into an existing key of an
+  existing domain and moved no directory entry at all. Neither half is a
+  superset. It COMPARES — `defaults write`/`delete` on a real domain is as
+  forbidden as `rm`, so nothing there has a write path and the test corpus
+  answers through a committed stub reader
+  (`tools/lib/testdata/swift-suite/defaults-stub.sh`) rather than writing a
+  domain to make itself deterministic. Three things are load-bearing. The
+  vacuity guard is a **control probe** (`NSGlobalDomain`, read and never
+  compared) rather than the watched domains' contents, because "both domains
+  hold no keys" is a legitimate fresh-machine state where "no watched directory
+  present" is not — a contents-based guard would refuse on a new machine
+  forever. An EMPTY answer is `UNREADABLE`, not a clean empty domain, and the
+  one row where that distinction is a silent pass rather than a mislabelled
+  failure is a silent reader over an already-empty domain. And the limit is
+  printed on every clean run: an idempotent write is invisible to any
+  before/after comparison, so a saturated domain and a clean one would otherwise
+  read identically. `Tests/RealHomePathLintTests.swift` is the structural
   half, over the app AND test targets, with an existence-checked exemption list
   (two entries) because the safe construct is built out of the banned one.
   The suite also aborts intermittently (#1523) in a way that **truncates the

--- a/tools/lib/shell-lib-errexit_test.sh
+++ b/tools/lib/shell-lib-errexit_test.sh
@@ -483,12 +483,38 @@ row 'swift-suite.sh::_swift_suite_witness_slug' '_swift_suite_witness_slug' 0 \
 row 'swift-suite.sh::_swift_suite_witness_snapshot' '_swift_suite_witness_snapshot' 0 \
     '. tools/lib/swift-suite.sh; mkdir -p "$TW_TMP/wh-snap/Library/Preferences" "$TW_TMP/ws-snap"; : >"$TW_TMP/wh-snap/Library/Preferences/a.plist"; SWIFT_SUITE_WITNESS_HOME="$TW_TMP/wh-snap"' \
     '_swift_suite_witness_snapshot "$TW_TMP/ws-snap" before'
+# The domain half (#1688) reaches an external reader, so the two entry points
+# below and the five rows after them all answer through the COMMITTED stub —
+# never the real defaults(1). Two reasons, and the second is the binding one: a
+# row asserting 0 while riding on the developer's live io.irrlicht.app would be
+# a coin flip (the running app rewrites SULastCheckTime on Sparkle's schedule),
+# and the only way to make a REAL domain deterministic is to write it, which is
+# the incident this half exists to report rather than to reproduce.
+SS_DATA=tools/lib/testdata/swift-suite
+DOM_SETUP=". tools/lib/swift-suite.sh; export SWIFT_SUITE_STUB_DIR=\"\$TW_TMP/dom\"; bash $SS_DATA/seed-domains.sh \"\$TW_TMP/dom\"; SWIFT_SUITE_WITNESS_DEFAULTS=$SS_DATA/defaults-stub.sh"
+
 row 'swift-suite.sh::swift_suite_witness_before' 'swift_suite_witness_before' 0 \
-    '. tools/lib/swift-suite.sh; mkdir -p "$TW_TMP/wh-before/Library/Preferences" "$TW_TMP/ws-before"; : >"$TW_TMP/wh-before/Library/Preferences/a.plist"; SWIFT_SUITE_WITNESS_HOME="$TW_TMP/wh-before"' \
+    "$DOM_SETUP"'; mkdir -p "$TW_TMP/wh-before/Library/Preferences" "$TW_TMP/ws-before"; : >"$TW_TMP/wh-before/Library/Preferences/a.plist"; SWIFT_SUITE_WITNESS_HOME="$TW_TMP/wh-before"' \
     'swift_suite_witness_before "$TW_TMP/ws-before"'
 row 'swift-suite.sh::swift_suite_witness_verdict' 'swift_suite_witness_verdict (nothing changed)' 0 \
-    '. tools/lib/swift-suite.sh; mkdir -p "$TW_TMP/wh-verdict/Library/Preferences" "$TW_TMP/ws-verdict"; : >"$TW_TMP/wh-verdict/Library/Preferences/a.plist"; SWIFT_SUITE_WITNESS_HOME="$TW_TMP/wh-verdict"; swift_suite_witness_before "$TW_TMP/ws-verdict"' \
+    "$DOM_SETUP"'; mkdir -p "$TW_TMP/wh-verdict/Library/Preferences" "$TW_TMP/ws-verdict"; : >"$TW_TMP/wh-verdict/Library/Preferences/a.plist"; SWIFT_SUITE_WITNESS_HOME="$TW_TMP/wh-verdict"; swift_suite_witness_before "$TW_TMP/ws-verdict"' \
     'swift_suite_witness_verdict "$TW_TMP/ws-verdict" >/dev/null'
+
+row 'swift-suite.sh::_swift_suite_domain_flatten' '_swift_suite_domain_flatten' 0 \
+    "$DOM_SETUP" \
+    '_swift_suite_domain_flatten < "$TW_TMP/dom/com.apple.dt.xctest.tool" >/dev/null'
+row 'swift-suite.sh::_swift_suite_domain_state' '_swift_suite_domain_state' 0 \
+    "$DOM_SETUP" \
+    '_swift_suite_domain_state com.apple.dt.xctest.tool >/dev/null'
+row 'swift-suite.sh::_swift_suite_witness_domain_snapshot' '_swift_suite_witness_domain_snapshot' 0 \
+    "$DOM_SETUP"'; mkdir -p "$TW_TMP/dom-snap"' \
+    '_swift_suite_witness_domain_snapshot "$TW_TMP/dom-snap" before'
+row 'swift-suite.sh::_swift_suite_witness_domain_report' '_swift_suite_witness_domain_report' 0 \
+    "$DOM_SETUP"'; printf "a\tv\n" > "$TW_TMP/dom-body"; printf "a\n" > "$TW_TMP/dom-keys"' \
+    '_swift_suite_witness_domain_report + "$TW_TMP/dom-keys" "$TW_TMP/dom-body" >/dev/null'
+row 'swift-suite.sh::_swift_suite_witness_domain_verdict' '_swift_suite_witness_domain_verdict (nothing changed)' 0 \
+    "$DOM_SETUP"'; mkdir -p "$TW_TMP/dom-state"; _swift_suite_witness_domain_snapshot "$TW_TMP/dom-state" before; _swift_suite_witness_domain_snapshot "$TW_TMP/dom-state" after' \
+    '_swift_suite_witness_domain_verdict "$TW_TMP/dom-state" >/dev/null'
 
 # ---------------------------------------------------------------------------
 # The exemption map

--- a/tools/lib/swift-suite.sh
+++ b/tools/lib/swift-suite.sh
@@ -155,6 +155,101 @@ SWIFT_SUITE_GREP_OPTS="-a"
 # unrelated third-party churn (Google, WhatsApp, Claude, VS Code).
 SWIFT_SUITE_WITNESSED_DIRS=("Library/Preferences" "Library/Sounds")
 
+# ---------------------------------------------------------------------------
+# The domain half of the witness (#1688; the gap #1672 left open)
+# ---------------------------------------------------------------------------
+#
+# The directory witness above watches for new FILES. #1672 was a write into an
+# ALREADY-EXISTING key of an ALREADY-EXISTING domain — `NotificationEventRow`
+# persisted two sound choices merely by being rendered — so no file appeared, no
+# directory entry changed, and the witness was green on every run that did it.
+# A new-entry check cannot see that defect in principle, not by oversight.
+#
+# So this half compares two named domains' KEY SETS *and* their VALUES:
+#
+#   com.apple.dt.xctest.tool   what UserDefaults.standard resolves to under
+#                              `swift test` (18 keys on this machine, all of
+#                              them the app's own — the same 18 #1690 measured).
+#   io.irrlicht.app            the app's own domain, which a test constructing
+#                              an app type must never reach at all.
+#
+# WHAT IT SEES, and this is the whole list:
+#
+#   a key APPEARING      the first persist of a key on a domain that lacked it
+#                        — a CI runner, a new developer machine, a newly added
+#                        preference key.
+#   a key DISAPPEARING   a `removeObject` against a real domain. Strictly worse
+#                        than an addition, and reported separately for that
+#                        reason.
+#   a value CHANGING     at a key that was already there. This is the case the
+#                        directory witness and a growth-only key-set witness are
+#                        both structurally blind to, and it is why this half
+#                        exists.
+#   the domain APPEARING or EMPTYING wholesale.
+#
+# WHAT IT CANNOT SEE, stated here because a saturated domain otherwise reads
+# EXACTLY like a clean one, and the verdict prints this every time it passes:
+#
+#   an IDEMPOTENT write — the same value stored back at a key that already
+#   holds it. That is #1672 as it actually happened. Both keys were already
+#   present at the values being written, so the domain stayed byte-identical
+#   and the plist's mtime never moved (`1786919878`, measured across an
+#   instrumented pre-fix run that PRINTED the two writes). No comparison of a
+#   domain against itself can distinguish that from no write at all. The checks
+#   that do see it are in-process and live in platforms/macos:
+#   `PersistentDefaultsLintTests`' app-target mutation scan and
+#   `InMemoryDefaults.writtenKeys`.
+#
+# So this half's value is the FIRST occurrence and the CHANGED occurrence, and
+# the honest framing is that it is a second, independent net rather than a
+# tighter one. It runs here rather than in the suite for the reason the whole
+# witness does: it is what still runs when the suite abort()s (#1523), when the
+# tree is killed at SWIFT_SUITE_TIMEOUT, or when `--budget` kills the gate.
+#
+# IT COMPARES. It never repairs. `defaults export <domain> -` is the entire
+# mechanism — there is no `defaults write`, no `defaults delete` and no removal
+# path anywhere in this file, because a "clean up what the tests left" sweep is
+# what removed ~1895 files from a real ~/Library/Preferences during #1661.
+#
+# NOISE, measured on the author's machine and stated as measured:
+#
+#   0 changes   across a full `swift build` + suite gate run, both domains
+#   0 changes   across a second gate run
+#
+# Quieter than the directory half by construction: ~/Library/Preferences is
+# written by every background daemon on the machine, where a preference domain
+# is written only by processes that own it. The residual is `io.irrlicht.app`
+# on a machine where the app is RUNNING — Sparkle rewrites `SULastCheckTime` on
+# its default 86400s interval (no `SUScheduledCheckInterval` is declared in the
+# bundle; checked), i.e. ~0.07% of a 60s window, and the app rewrites
+# `projectGroupOrder` when the user reorders groups. Both are named in the
+# failure message with the same "re-run; ours reappears" advice the directory
+# half gives, and neither is filtered by name, for #1661's reason.
+SWIFT_SUITE_WITNESSED_DOMAINS=("com.apple.dt.xctest.tool" "io.irrlicht.app")
+
+# The control probe. NEVER compared before-to-after — it is a machine domain and
+# churns on its own (`ACDMonthlyAnalyticsLastPosted` moves without anyone asking
+# it to). It answers exactly one question: did the reader actually read
+# anything? Without it, "both watched domains hold no keys" — the state of a
+# fresh CI runner or a new developer machine — is indistinguishable from a
+# reader that is broken, misdirected or stubbed out, and the second of those
+# would report a clean domain delta on every run forever. The directory half's
+# vacuity guard cannot be copied here, because "no keys in either domain" is a
+# legitimate state there where "no watched directory present" is not.
+SWIFT_SUITE_WITNESS_CONTROL_DOMAIN="${SWIFT_SUITE_WITNESS_CONTROL_DOMAIN:-NSGlobalDomain}"
+
+# The reader, injectable for ONE caller: tools/lib/swift-suite_test.sh, which
+# has to drive an added key, a removed key and a changed value to prove this
+# half can fail. The only way to do that against the real `defaults` is to
+# `defaults write` a domain on the developer's machine — which is the incident,
+# not a test of it. So the test points this at a committed stub
+# (tools/lib/testdata/swift-suite/defaults-stub.sh) and everything downstream of
+# the external command is production code. The two things a stub cannot pin —
+# that a real `defaults export` answers a plist for a live domain and an empty
+# dict for one that does not exist — are pinned by read-only arms in that same
+# file against the real binary.
+SWIFT_SUITE_WITNESS_DEFAULTS="${SWIFT_SUITE_WITNESS_DEFAULTS:-defaults}"
+
 # swift_suite_witness_home — the home to watch.
 #
 # From the PASSWORD DATABASE, not `$HOME`. bash's `~user` expansion consults
@@ -222,6 +317,228 @@ _swift_suite_witness_snapshot() {
   return 0
 }
 
+# _swift_suite_domain_flatten — read a `defaults export` plist on stdin, write
+# one `<key>\t<flattened value>` line per TOP-LEVEL key.
+#
+# Top-level keys are the `<key>` elements at exactly ONE tab of indentation, and
+# that is a property of the format rather than a heuristic: `plutil`/`defaults`
+# indent by depth, and XML escapes `<` inside text, so no value can produce a
+# line beginning with a tab followed by `<key>`. Nested dictionaries' keys are
+# at two tabs or more and are folded into their parent's value, which is what we
+# want — a change anywhere inside a top-level key's value is a change of that
+# key. Output is one line per key so the comparison is line-based like the
+# directory half, and so `cut -f1` recovers the key even for a value that itself
+# contains a tab.
+_swift_suite_domain_flatten() {
+  awk '
+    /^\t<key>/ {
+      if (k != "") print k "\t" v
+      s = $0
+      sub(/^\t<key>/, "", s); sub(/<\/key>[ \t]*$/, "", s)
+      k = s; v = ""; next
+    }
+    /^<\/dict>/ { if (k != "") { print k "\t" v; k = "" } next }
+    {
+      if (k != "") {
+        s = $0
+        sub(/^[ \t]+/, "", s)
+        v = (v == "" ? s : v " " s)
+      }
+    }
+    END { if (k != "") print k "\t" v }
+  '
+}
+
+# _swift_suite_domain_state <domain> — the three-state snapshot of ONE domain,
+# printed as a STATE marker line followed by the flattened key/value body.
+#
+# The three states are kept apart for the same reason the directory half keeps
+# its three apart, and the mapping is measured rather than assumed:
+#
+#   PRESENT     the reader answered a plist holding at least one key.
+#   ABSENT      the reader answered a plist holding NO keys. `defaults export`
+#               answers `<dict/>` at status 0 for a domain that does not exist
+#               (measured), so "no such domain" and "exists and is empty" are
+#               one state here. Nothing downstream branches on the difference,
+#               and merging them costs one read where distinguishing them would
+#               cost two — i.e. a second, later view of the same domain.
+#   UNREADABLE  the reader failed, produced nothing, or produced something that
+#               is not a plist. An EMPTY answer is deliberately NOT a clean
+#               empty domain: a reader that could not run at all answers empty
+#               too, and that is the one failure this whole file exists to keep
+#               distinguishable from a finding.
+#
+# Always returns 0 — the diagnosis is the verdict's job, so that one place
+# decides what an unreadable domain means instead of two that can disagree.
+_swift_suite_domain_state() {
+  local domain="${1:-}" out body rc=0
+  if [[ -z "$domain" ]]; then
+    printf 'UNREADABLE\n'
+    return 0
+  fi
+  # `|| rc=$?` rather than a bare assignment: under a CALLER's `-e` an
+  # assignment from a failing command substitution aborts the caller on that
+  # line, which is #1633's defect in this same file.
+  # `:-defaults` as well as the declaration above: a caller that UNSETS the knob
+  # (the shape a test's teardown takes) would otherwise make this line an
+  # unbound-variable error under `set -u`, which is a witness that cannot look
+  # failing for a reason nothing here would report.
+  out=$("${SWIFT_SUITE_WITNESS_DEFAULTS:-defaults}" export "$domain" - 2>/dev/null) || rc=$?
+  if (( rc != 0 )) || [[ -z "$out" || "$out" != *"<plist"* ]]; then
+    printf 'UNREADABLE\n'
+    return 0
+  fi
+  body=$(printf '%s\n' "$out" | _swift_suite_domain_flatten | sort) || body=""
+  if [[ -z "$body" ]]; then
+    printf 'ABSENT\n'
+  else
+    printf 'PRESENT\n%s\n' "$body"
+  fi
+  return 0
+}
+
+# _swift_suite_witness_domain_snapshot <statedir> <phase> — every watched
+# domain, plus the control probe, into <statedir>/domain_<slug>.<phase>.
+_swift_suite_witness_domain_snapshot() {
+  local statedir="$1" phase="$2" domain slug
+  _swift_suite_domain_state "$SWIFT_SUITE_WITNESS_CONTROL_DOMAIN" > "$statedir/CONTROL.$phase"
+  for domain in "${SWIFT_SUITE_WITNESSED_DOMAINS[@]}"; do
+    slug=$(_swift_suite_witness_slug "$domain")
+    _swift_suite_domain_state "$domain" > "$statedir/domain_$slug.$phase"
+  done
+  return 0
+}
+
+# _swift_suite_witness_domain_report <marker> <keyfile> <bodyfile> — print each
+# named key with the value it carries in <bodyfile>. Shared by the created,
+# added and removed arms so the three cannot drift into printing different
+# shapes. Both arguments are real FILES, never process substitutions: the body
+# is re-read once per key, and a `<(…)` FIFO can only be read once — which would
+# print the first key's value and empty strings after it.
+_swift_suite_witness_domain_report() {
+  local marker="$1" keyfile="$2" bodyfile="$3" key value
+  while IFS= read -r key; do
+    [[ -n "$key" ]] || continue
+    value=$(awk -F'\t' -v k="$key" '$1 == k { print $2; exit }' "$bodyfile")
+    printf '    %s %s = %s\n' "$marker" "$key" "$value"
+  done < "$keyfile"
+  return 0
+}
+
+# _swift_suite_witness_domain_verdict <statedir> — 0 only if every watched
+# domain's key set AND values are demonstrably what they were before the run.
+# Non-zero if a key appeared, a key vanished, an existing key's value moved, the
+# domain appeared or emptied, or the witness could not look.
+_swift_suite_witness_domain_verdict() {
+  local statedir="${1:-}" ok=0 domain slug before after bstate astate cstate
+  local b a bk ak chg added removed changed n ckey summary=""
+  [[ -n "$statedir" && -d "$statedir" ]] || { echo "_swift_suite_witness_domain_verdict: needs an existing <statedir>" >&2; return 1; }
+
+  cstate=$(head -1 "$statedir/CONTROL.after" 2>/dev/null) || cstate=""
+  if [[ "$cstate" != "PRESENT" ]]; then
+    echo "domain witness: the control read of $SWIFT_SUITE_WITNESS_CONTROL_DOMAIN answered '${cstate:-nothing at all}'." >&2
+    echo "  That domain is never compared — it exists so a reader that cannot read is not" >&2
+    echo "  mistaken for two domains that did not change. This run is unwitnessed there." >&2
+    ok=1
+  fi
+
+  for domain in "${SWIFT_SUITE_WITNESSED_DOMAINS[@]}"; do
+    slug=$(_swift_suite_witness_slug "$domain")
+    before="$statedir/domain_$slug.before"
+    after="$statedir/domain_$slug.after"
+    if [[ ! -f "$before" || ! -f "$after" ]]; then
+      echo "domain witness: $domain was never snapshotted — it is unwitnessed, not clean." >&2
+      ok=1
+      continue
+    fi
+    bstate=$(head -1 "$before" 2>/dev/null); astate=$(head -1 "$after" 2>/dev/null)
+    if [[ "$bstate" == "UNREADABLE" || "$astate" == "UNREADABLE" ]]; then
+      echo "domain witness: $domain could not be read — this run is unwitnessed there." >&2
+      echo "  Inability to look must not print the same thing as finding nothing." >&2
+      ok=1
+      continue
+    fi
+    if [[ "$bstate" == "PRESENT" && "$astate" == "ABSENT" ]]; then
+      echo "domain witness: $domain held keys before the run and holds none now." >&2
+      echo "  Nothing in this repository is allowed to remove a real preference domain (#1661)." >&2
+      ok=1
+      continue
+    fi
+    if [[ "$bstate" == "ABSENT" && "$astate" == "PRESENT" ]]; then
+      echo "domain witness: the run CREATED $domain, which held no keys before it:" >&2
+      tail -n +2 "$after" > "$statedir/.cmp-a"
+      cut -f1 "$statedir/.cmp-a" > "$statedir/.cmp-keys"
+      _swift_suite_witness_domain_report + "$statedir/.cmp-keys" "$statedir/.cmp-a" >&2
+      echo "  A test must not persist into a real preference domain (#1661, #1672)." >&2
+      ok=1
+      continue
+    fi
+    if [[ "$bstate" == "ABSENT" && "$astate" == "ABSENT" ]]; then
+      summary+="${summary:+, }$domain (no keys)"
+      continue
+    fi
+
+    b="$statedir/.cmp-b"; a="$statedir/.cmp-a"; bk="$statedir/.cmp-bk"; ak="$statedir/.cmp-ak"; chg="$statedir/.cmp-chg"
+    tail -n +2 "$before" | sort > "$b"
+    tail -n +2 "$after"  | sort > "$a"
+    cut -f1 "$b" | sort > "$bk"
+    cut -f1 "$a" | sort > "$ak"
+    comm -13 "$b" "$a" | cut -f1 | sort -u > "$chg"
+
+    added=$(comm -13 "$bk" "$ak")
+    removed=$(comm -23 "$bk" "$ak")
+    # A key is CHANGED when its whole line moved and the key itself is on both
+    # sides — subtracting the added set is what stops a new key being counted
+    # twice, once as an addition and once as a change.
+    changed=$(comm -12 "$chg" "$bk")
+
+    if [[ -n "$added" ]]; then
+      n=$(printf '%s\n' "$added" | wc -l | tr -d ' ')
+      echo "domain witness: the run ADDED $n key(s) to $domain:" >&2
+      printf '%s\n' "$added" > "$statedir/.cmp-keys"
+      _swift_suite_witness_domain_report + "$statedir/.cmp-keys" "$a" >&2
+      echo "  A test must not persist into a real preference domain (#1661, #1672)." >&2
+      ok=1
+    fi
+    if [[ -n "$removed" ]]; then
+      n=$(printf '%s\n' "$removed" | wc -l | tr -d ' ')
+      echo "domain witness: the run REMOVED $n key(s) from $domain:" >&2
+      printf '%s\n' "$removed" > "$statedir/.cmp-keys"
+      _swift_suite_witness_domain_report - "$statedir/.cmp-keys" "$b" >&2
+      echo "  Nothing in this repository is allowed to delete a real preference (#1661)." >&2
+      ok=1
+    fi
+    if [[ -n "$changed" ]]; then
+      n=$(printf '%s\n' "$changed" | wc -l | tr -d ' ')
+      echo "domain witness: the run CHANGED $n existing key(s) in $domain:" >&2
+      printf '%s\n' "$changed" > "$statedir/.cmp-keys"
+      while IFS= read -r ckey; do
+        [[ -n "$ckey" ]] || continue
+        printf '    ~ %s\n      before: %s\n      after:  %s\n' \
+          "$ckey" \
+          "$(awk -F'\t' -v k="$ckey" '$1 == k { print $2; exit }' "$b")" \
+          "$(awk -F'\t' -v k="$ckey" '$1 == k { print $2; exit }' "$a")" >&2
+      done < "$statedir/.cmp-keys"
+      echo "  This is the shape the directory witness cannot see: a write into an existing" >&2
+      echo "  key of an existing domain (#1672). If it is io.irrlicht.app, the running app" >&2
+      echo "  also writes SULastCheckTime and projectGroupOrder — re-run to tell that apart;" >&2
+      echo "  ours reappears every time. Nothing here rewrites anything either way." >&2
+      ok=1
+    fi
+    if [[ -z "$added$removed$changed" ]]; then
+      summary+="${summary:+, }$domain ($(wc -l < "$bk" | tr -d ' ') keys)"
+    fi
+  done
+
+  if (( ok == 0 )); then
+    echo "domain witness: ${summary:-no domains watched} — key sets and values unchanged."
+    echo "  That is NOT proof the run wrote nothing. A write of the value a key ALREADY"
+    echo "  holds changes no key and no value, which is exactly how #1672 happened; only"
+    echo "  PersistentDefaultsLintTests and InMemoryDefaults.writtenKeys see that one."
+  fi
+  return "$ok"
+}
+
 # swift_suite_witness_before <statedir> — snapshot ahead of the run.
 #
 # Always returns 0. A snapshot that could not be taken is recorded rather than
@@ -232,12 +549,17 @@ swift_suite_witness_before() {
   local statedir="${1:-}"
   [[ -n "$statedir" && -d "$statedir" ]] || { echo "swift_suite_witness_before: needs an existing <statedir>" >&2; return 1; }
   _swift_suite_witness_snapshot "$statedir" before || :
+  # The domain half does not depend on the home resolving, so it is taken even
+  # when the directory half could not be: two independent nets, and a failure of
+  # one must not silently take the other with it.
+  _swift_suite_witness_domain_snapshot "$statedir" before || :
   return 0
 }
 
 # swift_suite_witness_verdict <statedir> — 0 only if the run demonstrably added
-# nothing to any watched directory. Non-zero if it added something, if
-# something vanished, or if the witness could not look.
+# nothing to any watched directory AND left every watched domain's key set and
+# values as it found them. Non-zero if it added something, if something
+# vanished, if a preference value moved, or if either half could not look.
 swift_suite_witness_verdict() {
   local statedir="${1:-}" ok=0 looked=0 dir slug before after added removed bstate astate
   [[ -n "$statedir" && -d "$statedir" ]] || { echo "swift_suite_witness_verdict: needs an existing <statedir>" >&2; return 1; }
@@ -248,6 +570,7 @@ swift_suite_witness_verdict() {
     return 1
   fi
   _swift_suite_witness_snapshot "$statedir" after || :
+  _swift_suite_witness_domain_snapshot "$statedir" after || :
 
   for dir in "${SWIFT_SUITE_WITNESSED_DIRS[@]}"; do
     slug=$(_swift_suite_witness_slug "$dir")
@@ -316,6 +639,16 @@ swift_suite_witness_verdict() {
   if (( ok == 0 )); then
     echo "real-home witness: no new entries in ${SWIFT_SUITE_WITNESSED_DIRS[*]} under $(cat "$statedir/HOME.before")"
   fi
+
+  # ALWAYS run, and never short-circuited by the directory half's verdict: the
+  # two nets see different things (#1672 moves no directory entry, #1661 moved
+  # no preference value), so a run that trips one still has to be told about the
+  # other. `|| drc=$?` for #1633's reason — a bare call under a caller's `-e`
+  # would abort here and the combined status would never be returned.
+  local drc=0
+  _swift_suite_witness_domain_verdict "$statedir" || drc=$?
+  (( drc == 0 )) || ok=1
+
   return "$ok"
 }
 

--- a/tools/lib/swift-suite_test.sh
+++ b/tools/lib/swift-suite_test.sh
@@ -28,6 +28,12 @@ cd "$REPO_ROOT" || { echo "FAIL: cannot cd to repo root $REPO_ROOT" >&2; exit 1;
 need() { command -v "$1" >/dev/null 2>&1 || { echo "FAIL: swift-suite_test — $1 not found" >&2; exit 1; }; }
 need grep
 need git
+# The domain half of the witness (#1688) reads through defaults(1). Required
+# rather than skipped-around: swift-suite.sh is macOS-only by construction (the
+# `script -q "$log"` pty spelling, `swift test`), so a host without `defaults`
+# cannot grade that half at all — and a gate that reports PASS having asserted
+# nothing is the failure mode this whole file exists to remove.
+need defaults
 
 . tools/lib/swift-suite.sh
 # The reap poll below is the shared one (#1627); tools/lib/await-gone_test.sh
@@ -541,16 +547,38 @@ _witness_scrub() {
   esac
 }
 
+DOMAIN_STUB_CMD="$REPO_ROOT/tools/lib/testdata/swift-suite/defaults-stub.sh"
+DOMAIN_SEED="$REPO_ROOT/tools/lib/testdata/swift-suite/seed-domains.sh"
+[[ -x "$DOMAIN_STUB_CMD" ]] || fail "the committed defaults stub is missing or not executable: $DOMAIN_STUB_CMD"
+[[ -x "$DOMAIN_SEED" ]] || fail "the committed domain seeder is missing or not executable: $DOMAIN_SEED"
+
+# Every body below comes from the ONE committed generator, baseline and
+# mutations alike — a second copy of the export shape would make a formatting
+# difference read as "every key changed", i.e. it would report the fixture
+# rather than the defect.
+_domain_stub() { "$DOMAIN_SEED" "$1"; }
+
 # _witness_case <name> <want-rc> <mutation-fn> [expected-substring]
+#
+# The domain half is pointed at the committed stub with a baseline that does not
+# move, so these rows grade the DIRECTORY half alone. Left on the real reader
+# they would ride on whatever the developer's live `io.irrlicht.app` did during
+# the window, and a row asserting rc 0 would be a coin flip.
 _witness_case() {
-  local name="$1" want="$2" mutate="$3" needle="${4:-}" home state out got
+  local name="$1" want="$2" mutate="$3" needle="${4:-}" home state stub out got
   home=$(_witness_home) || { fail "$name: could not build the fixture home"; return; }
   state=$(mktemp -d -t swift-suite-witness-state) || { fail "$name: no state dir"; return; }
+  stub=$(mktemp -d -t swift-suite-witness-stub) || { fail "$name: no stub dir"; return; }
+  _domain_stub "$stub"
+  export SWIFT_SUITE_STUB_DIR="$stub"
+  SWIFT_SUITE_WITNESS_DEFAULTS="$DOMAIN_STUB_CMD"
 
   SWIFT_SUITE_WITNESS_HOME="$home" swift_suite_witness_before "$state"
   "$mutate" "$home"
   out=$(SWIFT_SUITE_WITNESS_HOME="$home" swift_suite_witness_verdict "$state" 2>&1)
   got=$?
+  unset SWIFT_SUITE_WITNESS_DEFAULTS SWIFT_SUITE_STUB_DIR
+  _witness_scrub "$stub"
 
   if [[ "$got" == "$want" ]]; then
     pass "$name → rc $got"
@@ -622,6 +650,209 @@ _moved_home=$(HOME=/tmp/definitely-not-the-home swift_suite_witness_home)
 [[ "${#SWIFT_SUITE_WITNESSED_DIRS[@]}" -ge 2 ]] \
   && pass "watching ${#SWIFT_SUITE_WITNESSED_DIRS[@]} directories: ${SWIFT_SUITE_WITNESSED_DIRS[*]}" \
   || fail "the watched set has shrunk to ${#SWIFT_SUITE_WITNESSED_DIRS[@]} — the guard covers almost nothing"
+[[ "${#SWIFT_SUITE_WITNESSED_DOMAINS[@]}" -ge 2 ]] \
+  && pass "watching ${#SWIFT_SUITE_WITNESSED_DOMAINS[@]} domains: ${SWIFT_SUITE_WITNESSED_DOMAINS[*]}" \
+  || fail "the watched domain set has shrunk to ${#SWIFT_SUITE_WITNESSED_DOMAINS[@]} — the guard covers almost nothing"
+
+echo "== domain witness (#1688) =="
+# Every case here answers through the COMMITTED stub reader, never through the
+# real defaults(1), and the reason is the same one that keeps the directory
+# arms on a fixture home: the only way to drive an added key, a removed key or a
+# changed value against a real domain is to `defaults write` the developer's
+# machine, which is #1661's incident rather than a test of it. Nothing below has
+# a write path over any real domain.
+#
+# What the stub cannot pin — that a real `defaults export` answers a plist for a
+# live domain and an empty dict for one that does not exist — is pinned at the
+# end of this section, read-only, against the real binary.
+
+# _domain_case <name> <want-rc> <mutation-fn> [expected-substring] [baseline-fn]
+#
+# <mutation-fn> runs BETWEEN the two snapshots — it is what the run did.
+# <baseline-fn> runs BEFORE the first one and is how a case states the machine
+# it is on: a domain that already holds the key, or one that holds nothing at
+# all. Both are needed, because "the run emptied a domain" and "the domain was
+# empty on both sides" are the same after-state and opposite verdicts.
+#
+# The fixture home is held constant, so a failure here can only come from the
+# domain half. That is the counterpart to _witness_case holding the domains
+# constant, and it is what makes the two halves' evidence separable.
+_domain_case() {
+  local name="$1" want="$2" mutate="$3" needle="${4:-}" baseline="${5:-}" home state stub out got
+  home=$(_witness_home) || { fail "$name: could not build the fixture home"; return; }
+  state=$(mktemp -d -t swift-suite-witness-state) || { fail "$name: no state dir"; return; }
+  stub=$(mktemp -d -t swift-suite-witness-stub) || { fail "$name: no stub dir"; return; }
+  _domain_stub "$stub"
+  [[ -z "$baseline" ]] || "$baseline" "$stub"
+  export SWIFT_SUITE_STUB_DIR="$stub"
+  SWIFT_SUITE_WITNESS_DEFAULTS="$DOMAIN_STUB_CMD"
+
+  SWIFT_SUITE_WITNESS_HOME="$home" swift_suite_witness_before "$state"
+  "$mutate" "$stub"
+  out=$(SWIFT_SUITE_WITNESS_HOME="$home" swift_suite_witness_verdict "$state" 2>&1)
+  got=$?
+  unset SWIFT_SUITE_WITNESS_DEFAULTS SWIFT_SUITE_STUB_DIR
+
+  if [[ "$got" == "$want" ]]; then
+    pass "$name → rc $got"
+  else
+    fail "$name: expected rc $want, got $got; output: $out"
+  fi
+  if [[ -n "$needle" ]]; then
+    case "$out" in
+      *"$needle"*) pass "$name: names '$needle'" ;;
+      *) fail "$name: output does not name '$needle'; got: $out" ;;
+    esac
+  fi
+  # Every row must leave the DIRECTORY half's clean line intact. Without this a
+  # domain mutation that somehow reddened the directory half would satisfy the
+  # rc assertion above for the wrong reason.
+  case "$out" in
+    *"no new entries"*) : ;;
+    *) fail "$name: the directory half should have been clean; got: $out" ;;
+  esac
+  _witness_scrub "$stub"
+  _witness_scrub "$home"
+  _witness_scrub "$state"
+}
+
+_domain_noop() { :; }
+# #1672's shape, and the whole reason this half exists: a value written at a key
+# that was already there. No file appears, no directory entry moves, no key set
+# grows — so the directory witness and a growth-only key-set witness are both
+# green on it.
+_domain_change_value() { "$DOMAIN_SEED" --one "$1/com.apple.dt.xctest.tool" soundOnReady=glass soundOnContextPressure=sosumi; }
+_domain_add_key()      { "$DOMAIN_SEED" --one "$1/com.apple.dt.xctest.tool" soundOnReady=funk soundOnContextPressure=sosumi soundOnWaiting=ping; }
+_domain_remove_key()   { "$DOMAIN_SEED" --one "$1/com.apple.dt.xctest.tool" soundOnReady=funk; }
+_domain_create()       { "$DOMAIN_SEED" --one "$1/io.irrlicht.app" notifyOnReady=1; }
+_domain_empty()        { "$DOMAIN_SEED" --empty "$1/io.irrlicht.app"; }
+_domain_reader_fails() { printf '1\n' > "$1/com.apple.dt.xctest.tool.rc"; }
+_domain_reader_silent(){ : > "$1/com.apple.dt.xctest.tool"; }
+_domain_control_dead() { : > "$1/$SWIFT_SUITE_WITNESS_CONTROL_DOMAIN"; }
+# Baselines. A machine on which neither watched domain holds anything is a fresh
+# CI runner or a new developer machine — legitimate, and it must NOT read as a
+# failure. The control probe is what keeps that honest; a guard keyed on the
+# watched domains' contents would refuse there forever.
+_domain_baseline_fresh() {
+  "$DOMAIN_SEED" --empty "$1/com.apple.dt.xctest.tool"
+  "$DOMAIN_SEED" --empty "$1/io.irrlicht.app"
+}
+_domain_baseline_no_app() { "$DOMAIN_SEED" --empty "$1/io.irrlicht.app"; }
+
+# The vacuity guard. Without it every row below is satisfied by a witness that
+# always fails — and this one carries a second obligation, since a saturated
+# domain and a clean one read identically and the output has to say so.
+_domain_case "a run that touched no domain passes" 0 _domain_noop "key sets and values unchanged"
+_domain_case "and says what that does NOT prove" 0 _domain_noop "NOT proof the run wrote nothing"
+_domain_case "a fresh machine's empty domains pass" 0 _domain_noop "no keys" _domain_baseline_fresh
+
+# The three deltas.
+_domain_case "a value changed at an existing key is caught (#1672's shape)" 1 _domain_change_value "CHANGED 1 existing key"
+_domain_case "  and it names the key and both values" 1 _domain_change_value "before: <string>funk</string>"
+_domain_case "an added key is caught" 1 _domain_add_key "ADDED 1 key(s) to com.apple.dt.xctest.tool"
+_domain_case "a removed key is caught" 1 _domain_remove_key "REMOVED 1 key(s)"
+
+# The domain as a whole appearing or emptying.
+_domain_case "a domain the run created is caught" 1 _domain_create "CREATED io.irrlicht.app" _domain_baseline_no_app
+_domain_case "a domain the run emptied is caught" 1 _domain_empty "holds none now"
+
+# "Could not look" must never print what "found nothing" prints. All three of
+# these are a clean domain report from a witness that returned early.
+_domain_case "a reader that fails fails loudly" 1 _domain_reader_fails "could not be read"
+_domain_case "a reader that answers nothing is not a clean domain" 1 _domain_reader_silent "could not be read"
+# The row above is not enough on its own, and the difference is the #1479
+# lesson: with the domain PRESENT beforehand, a silent reader still returns 1 —
+# as "the domain was emptied", which is the right status for the wrong reason.
+# Over a domain that was already empty there is no second reason left, so this
+# is the one row where treating an empty answer as a clean empty domain is a
+# silent PASS rather than a mislabelled failure.
+_domain_case "a silent reader over an already-empty domain is not clean either" 1 _domain_reader_silent "could not be read" _domain_baseline_fresh
+_domain_case "a dead control probe fails loudly" 1 _domain_control_dead "control read of"
+
+# A verdict with no before-snapshot must not report the domains as clean either.
+_dom_no_before=$(mktemp -d -t swift-suite-witness-state)
+_dom_stub=$(mktemp -d -t swift-suite-witness-stub)
+_domain_stub "$_dom_stub"
+export SWIFT_SUITE_STUB_DIR="$_dom_stub"
+_out=$(SWIFT_SUITE_WITNESS_DEFAULTS="$DOMAIN_STUB_CMD" swift_suite_witness_verdict "$_dom_no_before" 2>&1)
+case "$_out" in
+  *"key sets and values unchanged"*) fail "an unwitnessed run reported the domains clean: $_out" ;;
+  *) pass "an unwitnessed run does not report the domains clean" ;;
+esac
+unset SWIFT_SUITE_STUB_DIR
+_witness_scrub "$_dom_no_before"
+_witness_scrub "$_dom_stub"
+
+# THE DISCRIMINATING ARM. The point of this whole half is that the predecessor
+# was structurally blind to #1672's shape, so it is asserted directly rather
+# than argued: the same run, the same fixture home, one preference value moved —
+# the directory half prints its clean line and the domain half is what fails.
+_disc_home=$(_witness_home)
+_disc_state=$(mktemp -d -t swift-suite-witness-state)
+_disc_stub=$(mktemp -d -t swift-suite-witness-stub)
+_domain_stub "$_disc_stub"
+export SWIFT_SUITE_STUB_DIR="$_disc_stub"
+# shellcheck disable=SC2034  # read by the sourced library, not by this file:
+# tools/lib/swift-suite.sh's _swift_suite_domain_state resolves it as the reader
+# command (see the `${SWIFT_SUITE_WITNESS_DEFAULTS:-defaults}` there, whose
+# fallback is also what makes the `unset` below safe under `set -u`).
+SWIFT_SUITE_WITNESS_DEFAULTS="$DOMAIN_STUB_CMD"
+SWIFT_SUITE_WITNESS_HOME="$_disc_home" swift_suite_witness_before "$_disc_state"
+_domain_change_value "$_disc_stub"
+_disc_out=$(SWIFT_SUITE_WITNESS_HOME="$_disc_home" swift_suite_witness_verdict "$_disc_state" 2>&1)
+_disc_rc=$?
+unset SWIFT_SUITE_WITNESS_DEFAULTS SWIFT_SUITE_STUB_DIR
+case "$_disc_out" in
+  *"no new entries"*"CHANGED 1 existing key"*)
+    [[ "$_disc_rc" -eq 1 ]] \
+      && pass "the old witness is green on #1672's shape while the new half fails it" \
+      || fail "the discriminating case returned rc $_disc_rc, not 1: $_disc_out" ;;
+  *) fail "expected a clean directory line AND a domain CHANGED line; got: $_disc_out" ;;
+esac
+_witness_scrub "$_disc_home"
+_witness_scrub "$_disc_state"
+_witness_scrub "$_disc_stub"
+
+# The flattener's declared property: TOP-LEVEL keys only. A nested dictionary's
+# keys belong to their parent's value, and a rule that reported them would name
+# a key nobody can address and would miss the parent changing.
+_flat_dir=$(mktemp -d -t swift-suite-witness-stub)
+"$DOMAIN_SEED" --one "$_flat_dir/body" a=1
+"$DOMAIN_SEED" --empty "$_flat_dir/empty"
+_flat=$(_swift_suite_domain_flatten < "$_flat_dir/body")
+# The KEY column, not the line: `notTopLevel` legitimately appears inside the
+# `nested` key's flattened VALUE, and a substring test over the whole line would
+# report that as a failure — a false alarm that would then be "fixed" by
+# weakening the assertion.
+_flat_keys=$(printf '%s\n' "$_flat" | cut -f1)
+case "$_flat_keys" in
+  *notTopLevel*) fail "the flattener reported a nested key as top-level: $_flat_keys" ;;
+  *) pass "the flattener reports top-level keys only (keys: $(printf '%s' "$_flat_keys" | tr '\n' ' '))" ;;
+esac
+case "$_flat" in
+  *"notTopLevel"*) pass "a nested key's content rides in its parent's value, so a change inside it is a change of that key" ;;
+  *) fail "the nested dictionary's content was dropped from its parent's value: $_flat" ;;
+esac
+[[ "$(printf '%s\n' "$_flat" | wc -l | tr -d ' ')" == "2" ]] \
+  && pass "the flattener reports one line per top-level key (a, nested)" \
+  || fail "the flattener produced $(printf '%s\n' "$_flat" | wc -l | tr -d ' ') lines, expected 2: $_flat"
+[[ -z "$(_swift_suite_domain_flatten < "$_flat_dir/empty")" ]] \
+  && pass "an empty dict flattens to nothing" \
+  || fail "an empty dict must flatten to nothing"
+_witness_scrub "$_flat_dir"
+
+# The two facts about the REAL defaults(1) that the stub above cannot establish.
+# Read-only, and deliberately against the control domain rather than
+# com.apple.dt.xctest.tool, which is legitimately absent on a machine that has
+# never run this suite.
+_real_present=$(_swift_suite_domain_state "$SWIFT_SUITE_WITNESS_CONTROL_DOMAIN" | head -1)
+[[ "$_real_present" == "PRESENT" ]] \
+  && pass "the real defaults(1) answers a plist for a live domain ($SWIFT_SUITE_WITNESS_CONTROL_DOMAIN → PRESENT)" \
+  || fail "the real defaults(1) answered '$_real_present' for $SWIFT_SUITE_WITNESS_CONTROL_DOMAIN — the domain half is reading nothing"
+_real_absent=$(_swift_suite_domain_state io.irrlicht.no.such.domain.1688 | head -1)
+[[ "$_real_absent" == "ABSENT" ]] \
+  && pass "the real defaults(1) answers an empty dict for a domain that does not exist (→ ABSENT)" \
+  || fail "a nonexistent domain read as '$_real_absent', not ABSENT"
 
 if [[ "$rc" -eq 0 ]]; then echo "swift-suite_test: ALL PASS"; else echo "swift-suite_test: FAILURES" >&2; fi
 exit "$rc"

--- a/tools/lib/swift-suite_test.sh
+++ b/tools/lib/swift-suite_test.sh
@@ -769,6 +769,20 @@ _domain_case "a reader that answers nothing is not a clean domain" 1 _domain_rea
 _domain_case "a silent reader over an already-empty domain is not clean either" 1 _domain_reader_silent "could not be read" _domain_baseline_fresh
 _domain_case "a dead control probe fails loudly" 1 _domain_control_dead "control read of"
 
+# A flattener that cannot RUN answers exactly like a domain holding no keys —
+# empty output, status discarded by the pipeline it sits in — so "the parser is
+# broken" and "the domain is empty" would otherwise be the same report on every
+# domain at once. This is the second thing the control probe buys, and it is
+# asserted rather than argued: the control is flattened by the same code, so a
+# broken flattener drives it to ABSENT and the refusal fires. `awk` is shadowed
+# by a shell function, which the verdict's command substitution inherits; it is
+# unset immediately after so nothing else in this file runs under it.
+awk() { return 1; }
+_domain_case "a flattener that cannot run is a refusal, not an empty domain" 1 _domain_noop "control read of"
+unset -f awk
+command -v awk >/dev/null && pass "awk is the real one again after the shadow" \
+  || fail "the awk shadow outlived its case — every assertion after it is suspect"
+
 # A verdict with no before-snapshot must not report the domains as clean either.
 _dom_no_before=$(mktemp -d -t swift-suite-witness-state)
 _dom_stub=$(mktemp -d -t swift-suite-witness-stub)
@@ -845,10 +859,24 @@ _witness_scrub "$_flat_dir"
 # Read-only, and deliberately against the control domain rather than
 # com.apple.dt.xctest.tool, which is legitimately absent on a machine that has
 # never run this suite.
-_real_present=$(_swift_suite_domain_state "$SWIFT_SUITE_WITNESS_CONTROL_DOMAIN" | head -1)
+_real_snapshot=$(_swift_suite_domain_state "$SWIFT_SUITE_WITNESS_CONTROL_DOMAIN")
+_real_present=$(printf '%s\n' "$_real_snapshot" | head -1)
 [[ "$_real_present" == "PRESENT" ]] \
   && pass "the real defaults(1) answers a plist for a live domain ($SWIFT_SUITE_WITNESS_CONTROL_DOMAIN → PRESENT)" \
   || fail "the real defaults(1) answered '$_real_present' for $SWIFT_SUITE_WITNESS_CONTROL_DOMAIN — the domain half is reading nothing"
+# The real header, on real bytes. This is where the `<!DOCTYPE …>` line the
+# committed fixtures deliberately do NOT carry is covered: the seeder would only
+# ever hold a hand-copy of it, which drifts silently, while these two lines
+# assert that the real tool emits one AND that the production reader parses keys
+# out of an answer containing it.
+_real_raw=$(defaults export "$SWIFT_SUITE_WITNESS_CONTROL_DOMAIN" - 2>/dev/null)
+case "$_real_raw" in
+  *"<!DOCTYPE plist"*) pass "the real defaults(1) output carries a DOCTYPE line — the shape the fixtures omit" ;;
+  *) fail "the real defaults(1) output carries no DOCTYPE; the assumption the fixtures are pruned against no longer holds" ;;
+esac
+[[ "$(printf '%s\n' "$_real_snapshot" | tail -n +2 | grep -c .)" -gt 0 ]] \
+  && pass "...and the reader still flattens keys out of it" \
+  || fail "the reader produced no keys from the real DOCTYPE-carrying output"
 _real_absent=$(_swift_suite_domain_state io.irrlicht.no.such.domain.1688 | head -1)
 [[ "$_real_absent" == "ABSENT" ]] \
   && pass "the real defaults(1) answers an empty dict for a domain that does not exist (→ ABSENT)" \

--- a/tools/lib/testdata/swift-suite/defaults-stub.sh
+++ b/tools/lib/testdata/swift-suite/defaults-stub.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# defaults-stub.sh — a stand-in for defaults(1), for grading the domain half of
+# tools/lib/swift-suite.sh's witness.
+#
+# It exists because the only way to drive an added key, a removed key or a
+# changed value against the REAL `defaults` is to `defaults write` a domain in
+# the developer's home — which is #1661's incident, not a test of it. Nothing in
+# this repository writes a real preference domain, so the external command is
+# swapped and everything downstream of it stays production code.
+#
+# Contract, deliberately narrow: it models `export <domain> -` and nothing else.
+#
+#   $SWIFT_SUITE_STUB_DIR/<domain>        the bytes to emit on stdout.
+#   $SWIFT_SUITE_STUB_DIR/<domain>.rc     the status to exit with (default 0).
+#
+# An UNMODELLED domain is a loud 99 naming the call, never a quiet 0 — the same
+# rule ars-badge-push_test.sh's git stub follows. A stub that answered "fine" to
+# a call it does not model would make every arm pass for a reason unrelated to
+# its obligation, and here it would specifically hand the control probe an empty
+# answer, which is one of the states under test.
+
+set -uo pipefail
+
+if [[ "${1:-}" != "export" || "${3:-}" != "-" ]]; then
+  echo "STUB: unmodelled call: defaults $*" >&2
+  exit 99
+fi
+
+domain="${2:-}"
+dir="${SWIFT_SUITE_STUB_DIR:-}"
+if [[ -z "$dir" || ! -d "$dir" ]]; then
+  echo "STUB: SWIFT_SUITE_STUB_DIR is not a directory: '${dir}'" >&2
+  exit 99
+fi
+if [[ ! -f "$dir/$domain" ]]; then
+  echo "STUB: unmodelled domain: $domain (no $dir/$domain)" >&2
+  exit 99
+fi
+
+cat "$dir/$domain"
+if [[ -f "$dir/$domain.rc" ]]; then
+  exit "$(cat "$dir/$domain.rc")"
+fi
+exit 0

--- a/tools/lib/testdata/swift-suite/seed-domains.sh
+++ b/tools/lib/testdata/swift-suite/seed-domains.sh
@@ -26,9 +26,22 @@
 
 set -uo pipefail
 
+# _head — the two header lines the reader downstream actually keys on:
+# `_swift_suite_domain_state` classifies an answer as readable on the `<plist`
+# substring, and the flattener starts at the first tab-indented `<key>`.
+#
+# It deliberately carries NO `<!DOCTYPE …>` line, though the real
+# `defaults export` emits one. Two reasons, and the second is why this is not a
+# gap. A hand-copied constant that documents another program's output but is not
+# produced by it drifts silently and is then trusted — the rule AGENTS.md states
+# for replay's measured figures — and this one would drift into a fixture that
+# no longer represents the tool it stands in for while every test stayed green.
+# And nothing here is the DOCTYPE's coverage anyway: swift-suite_test.sh reads
+# the REAL `defaults export` and asserts, on those bytes, that its output does
+# carry a DOCTYPE and that the production reader still answers PRESENT with keys
+# over it. Real bytes are a strictly better witness of that than a copy of them.
 _head() {
   printf '<?xml version="1.0" encoding="UTF-8"?>\n'
-  printf '<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">\n'
   printf '<plist version="1.0">\n'
 }
 
@@ -47,7 +60,8 @@ seed_one() {
 }
 
 seed_empty() {
-  { _head; printf '<dict/>\n</plist>\n'; } > "$1"
+  local path="$1"
+  { _head; printf '<dict/>\n</plist>\n'; } > "$path"
 }
 
 case "${1:-}" in

--- a/tools/lib/testdata/swift-suite/seed-domains.sh
+++ b/tools/lib/testdata/swift-suite/seed-domains.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# seed-domains.sh — the ONE generator of `defaults export` bodies for
+# defaults-stub.sh to answer with.
+#
+#   seed-domains.sh <dir>                    the baseline: the control domain
+#                                            and both watched domains, present
+#                                            and settled.
+#   seed-domains.sh --one <path> [k=v]...    one domain body with those keys.
+#   seed-domains.sh --empty <path>           what a domain that does not exist
+#                                            reads as: status 0, `<dict/>`
+#                                            (measured against the real binary).
+#
+# One generator rather than two, because every mutation swift-suite_test.sh
+# drives is a delta FROM the baseline: a second, hand-kept copy of the body
+# shape would make an unrelated formatting difference read as "every key
+# changed", i.e. it would report the fixture rather than the defect.
+#
+# Two callers need it. shell-lib-errexit_test.sh's recipes assert a status of 0,
+# and a row riding on the developer's live io.irrlicht.app would be a coin flip.
+# swift-suite_test.sh drives the deltas.
+#
+# Every body carries a NESTED dictionary on purpose: the flattener's declared
+# property is that only TOP-LEVEL keys are reported, and a corpus with nothing
+# nested in it cannot tell a correct flattener from one that reports every key
+# at every depth.
+
+set -uo pipefail
+
+_head() {
+  printf '<?xml version="1.0" encoding="UTF-8"?>\n'
+  printf '<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">\n'
+  printf '<plist version="1.0">\n'
+}
+
+seed_one() {
+  local path="$1"; shift
+  local kv
+  {
+    _head
+    printf '<dict>\n'
+    for kv in "$@"; do
+      printf '\t<key>%s</key>\n\t<string>%s</string>\n' "${kv%%=*}" "${kv#*=}"
+    done
+    printf '\t<key>nested</key>\n\t<dict>\n\t\t<key>notTopLevel</key>\n\t\t<string>x</string>\n\t</dict>\n'
+    printf '</dict>\n</plist>\n'
+  } > "$path"
+}
+
+seed_empty() {
+  { _head; printf '<dict/>\n</plist>\n'; } > "$1"
+}
+
+case "${1:-}" in
+  --one)
+    [[ -n "${2:-}" ]] || { echo "seed-domains.sh --one: needs <path>" >&2; exit 2; }
+    path="$2"; shift 2
+    seed_one "$path" "$@"
+    ;;
+  --empty)
+    [[ -n "${2:-}" ]] || { echo "seed-domains.sh --empty: needs <path>" >&2; exit 2; }
+    seed_empty "$2"
+    ;;
+  "")
+    echo "seed-domains.sh: needs <dir>, --one <path> or --empty <path>" >&2
+    exit 2
+    ;;
+  *)
+    dir="$1"
+    mkdir -p "$dir" || exit 2
+    seed_one "$dir/${SWIFT_SUITE_WITNESS_CONTROL_DOMAIN:-NSGlobalDomain}" AppleLanguages=en
+    seed_one "$dir/com.apple.dt.xctest.tool" soundOnReady=funk soundOnContextPressure=sosumi
+    seed_one "$dir/io.irrlicht.app" projectGroupOrder=irrlicht
+    ;;
+esac


### PR DESCRIPTION
Closes #1688.

`tools/lib/swift-suite.sh`'s real-home witness watched DIRECTORIES for new
entries. #1672 was a write into an already-existing key of an already-existing
domain, so it moved no directory entry and the witness was green on every run
that did it. This adds the second half.

## The mechanism

`SWIFT_SUITE_WITNESSED_DOMAINS` — `com.apple.dt.xctest.tool` (what
`UserDefaults.standard` resolves to under `swift test`) and `io.irrlicht.app`
(the app's own domain, which a test constructing an app type must never reach) —
snapshotted through `defaults export <domain> -` before and after the run, and
compared as **key set AND values**, one flattened line per top-level key.

It **compares**. There is no `defaults write`, no `defaults delete`, no removal
path, and nothing in the change writes any real domain — not even the tests
(below).

It rides the existing entry points (`swift_suite_witness_before` /
`swift_suite_witness_verdict`), so it inherits the property those exist for: it
is what still runs when the suite `abort()`s (#1523), when the tree is killed at
`SWIFT_SUITE_TIMEOUT`, or when `--budget` kills the gate — the runs on which a
`defer` does not run. `preflight.sh` needed no change; its `wrc != 0 → rc=1` was
already there.

## What it sees, and what it cannot

**Sees:** a key appearing; a key disappearing (a `removeObject` against a real
domain, reported separately because it is strictly worse); **a value changing at
a key that was already there**; the domain appearing or emptying wholesale.

**Cannot see:** an **idempotent** write — the same value stored back at a key
that already holds it. That is #1672 as it actually happened. Both keys were
already present at the values being written, so the domain stayed byte-identical
and the plist's mtime never moved. Re-measured here: `com.apple.dt.xctest.tool`'s
plist is still at mtime `1786919878`, the exact value #1690 recorded 48h earlier.
No before/after comparison of a domain can distinguish that from no write at all.

So the clean line is not a bare clean line — it says so every time, because
otherwise a saturated domain and a clean one read identically:

```
domain witness: com.apple.dt.xctest.tool (18 keys), io.irrlicht.app (2 keys) — key sets and values unchanged.
  That is NOT proof the run wrote nothing. A write of the value a key ALREADY
  holds changes no key and no value, which is exactly how #1672 happened; only
  PersistentDefaultsLintTests and InMemoryDefaults.writtenKeys see that one.
```

Two other stated limits. Nested-dictionary keys are folded into their top-level
parent's value rather than reported separately (a change anywhere inside is a
change of that key). And `defaults export` answers `<dict/>` at status 0 for a
domain that does not exist, so "no such domain" and "exists and is empty" are one
state — nothing downstream branches on the difference, and telling them apart
would cost a second, later view of the same domain.

## Failing loudly when it cannot look

Three states, `ABSENT` / `PRESENT` / `UNREADABLE`, matching the directory half.

- The reader failing, answering nothing, or answering something that is not a
  plist is **`UNREADABLE`**, never a clean empty domain.
- A missing `before` snapshot refuses, per domain.
- The vacuity guard is a **control probe** — `NSGlobalDomain`, read on every
  snapshot and **never compared** (it churns on its own; `ACDMonthlyAnalyticsLastPosted`
  moves without anyone asking). It answers one question: did the reader read?
  The directory half's guard could not be copied: "both watched domains hold no
  keys" is a legitimate fresh-machine state, where "no watched directory present"
  is not, so a contents-based guard would refuse on a new machine forever.

## Measured noise floor, on this machine

| window | `com.apple.dt.xctest.tool` | `io.irrlicht.app` |
|---|---|---|
| full `tools/preflight.sh --only swift` (cold build + 414-test suite) | 18 keys, byte-identical | 2 keys, byte-identical |
| second `--only swift` (warm, 7s) | 18 keys, byte-identical | 2 keys, byte-identical |

0 changes, both windows, both domains — quieter than the directory half by
construction, since `~/Library/Preferences` is written by every background daemon
on the machine while a preference domain is written only by processes that own
it. The 18 keys reproduce #1690's count exactly.

**The residual, stated rather than flattered.** `io.irrlicht.app` is live: the
app is running. Sparkle rewrites `SULastCheckTime` on its default 86400s interval
(no `SUScheduledCheckInterval` is declared in the bundle — checked), i.e. ~0.07%
of a 60s window, and the app rewrites `projectGroupOrder` when the user reorders
groups. That figure is **reasoned from the interval, not measured over a long
window** — the two windows above are the measurement I have. Separately measured:
that plist's *file* mtime had moved 51 minutes before those windows while its
contents were identical across them, which is a `cfprefsd` flush and is invisible
to a value comparison — the reason this witness reads values and not mtimes.
Neither name is filtered, for #1661's reason (its leaked files were
`<uuid>.plist`, so any name filter that quietened the churn would have quietened
the incident); the failure message names both and gives the directory half's
"re-run; ours reappears" advice.

## Evidence: five mutations, each seen red

Applied and reverted one per invocation, `git status --porcelain` asserted after
each. **No real preference domain was written at any point** — the corpus answers
through a committed stub reader
(`tools/lib/testdata/swift-suite/defaults-stub.sh`), because the only way to
drive an added key, a removed key or a changed value against the real `defaults`
is to `defaults write` the developer's machine, which is #1661's incident rather
than a test of it. Verified at the end: both plists' mtimes unchanged
(`1786919878`, `1787091935`), `~/Library/Sounds` still holding only its two
long-standing files.

**M2 — the one the issue asked for: growth-only, i.e. the key-set witness #1690
described.** `changed=""`:

```
FAIL — a value changed at an existing key is caught (#1672's shape): expected rc 1, got 0;
       output: real-home witness: no new entries in Library/Preferences Library/Sounds under …
FAIL —   and it names the key and both values: output does not name 'before: <string>funk</string>'
  ok  — an added key is caught → rc 1
  ok  — a removed key is caught → rc 1
FAIL — expected a clean directory line AND a domain CHANGED line
```

That is exactly the blindness #1690 recorded, reproduced: additions and removals
still caught, #1672's shape green, whole verdict 0. The value comparison is what
sees it.

**The old witness failing to see it, end-to-end on the real gate.** The reader was
swapped for a harness that answers with one value changed at an existing key on
its second read (no committed change, no real domain touched), and
`tools/preflight.sh --only swift` was run for real:

```
GATE EXIT=1
real-home witness: no new entries in Library/Preferences Library/Sounds under /Users/ingo
domain witness: the run CHANGED 1 existing key(s) in com.apple.dt.xctest.tool:
    ~ soundOnReady
      before: <string>funk</string>
      after:  <string>glass</string>
  This is the shape the directory witness cannot see: a write into an existing
  key of an existing domain (#1672). …
  macOS Swift build + test                                   FAIL
```

The suite passed (414 tests, 0 failures) in that same run — the gate failed on
the witness alone, and the directory half printed its clean line beside it. That
pairing is also committed, as `swift-suite_test.sh`'s discriminating arm.

**M1 — the domain verdict reports but does not decide** (`(( drc == 0 )) || ok=1`
neutered): 10 rows red, every domain row returning 0.

**M3 — an empty answer reads as a clean empty domain** (the `-z "$out"` /
`<plist` check dropped). Worth its own note, per #1479's rule that "the arm
failed" and "THIS obligation failed" are different claims: over a domain that was
PRESENT beforehand this still returns 1, as "the domain was emptied" — the right
status for the wrong reason, which only the message assertion caught. The row that
makes it a **silent pass** is a silent reader over an *already-empty* domain,
added because of this mutation:

```
FAIL — a silent reader over an already-empty domain is not clean either: expected rc 1, got 0
```

**M4 — the control probe removed** (`if false`): `a dead control probe fails
loudly` red on both status and message.

**M5 — one recipe row deleted from `shell-lib-errexit_test.sh`**:

```
FAIL: recipes and the walk disagree — expected [a bijection] got
      [UNDRIVEN swift-suite.sh::_swift_suite_witness_domain_verdict — no driving recipe
       and no entry in TW_EXEMPT_KEYS]
```

All five new functions carry recipes there, and the two pre-existing witness
entry points' recipes were moved onto the stub for the same reason the tests
were: a row asserting 0 while riding on the developer's live `io.irrlicht.app`
would be a coin flip.

## Gates, stated honestly

| gate | result |
|---|---|
| `tools/preflight.sh --only tools` | **PASS** — `tools/lib — found 17, skipped 0, ran 17, failed 0` |
| `tools/preflight.sh --only bash` | **PASS** — 117 of 130 files, shellcheck 0.11.0 |
| `tools/preflight.sh --only swift` | **PASS** — cold build + `Executed 414 tests, with 0 failures`, bundle reported, both witness halves clean |
| pre-push hook (`--changed --budget 540`) | **PASS** — posix/bash/tools/gofmt/swift PASS, the rest SKIP |

Both gates were red first: `--only tools` and `--only bash` each failed on an
SC2034 for `SWIFT_SUITE_WITNESS_DEFAULTS` (a cross-file seam), fixed with a
per-site directive naming its consumer plus dropping a redundant restore
assignment — not by removing the code from the gate.

Not run: `go`, `web`, `arch`, `security`, `replay` — no Go, web, or replay file
is touched, and the pre-push hook's `--changed` scoping reports them SKIP for
that reason.

`.github/workflows/macos-swift.yml` is deliberately **not** touched: the witness
stays out of CI for the reason #1671 recorded (its noise floor is measured here
and a runner's is not), and that file is another agent's subject this round.

## New defect filed

None. Nothing was found in this area that was not already the subject of this
issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## SonarCloud: what failed, and why it was a real finding

The first push failed the quality gate on **`new_security_rating = 2`** (needs 1).
Not duplication — `new_duplicated_lines_density` was **0.0%** against the 3%
threshold, and every other condition was OK. One VULNERABILITY caused it:

```
MINOR VULNERABILITY shell:S5332 tools/lib/testdata/swift-suite/seed-domains.sh:31
  Make sure that using clear-text protocols is safe here.
```

That line was the `http://www.apple.com/DTDs/PropertyList-1.0.dtd` inside a plist
`<!DOCTYPE …>` the fixture generator **hand-copied** from `defaults export`. It
is the only `http://` in the whole diff (`git diff origin/main...HEAD | grep
'^+.*http://'` → one hit).

**Verdict: a real finding, fixed at the source — not suppressed, and not a
pre-existing condition my diff tipped over.** The rating is computed over NEW
code only and the line is new. And S5332 pointed at something worth removing on
its own merits, independent of security: a constant that documents another
program's output without being produced by it is the drift shape AGENTS.md names
for replay's measured figures. Nothing downstream read it — `_swift_suite_domain_state`
keys on the `<plist` substring, `_swift_suite_domain_flatten` on the first
tab-indented `<key>` — so the fixture carried a hand-copy that could stop
matching the real tool while every test stayed green.

So it is deleted, and the DOCTYPE's coverage moves to where it is stronger: an
assertion on the **real** `defaults export` bytes that the tool does emit one and
that the production reader still flattens keys out of an answer containing it.
Two mutations, both seen red:

- **M6** — `defaults export … | grep -v DOCTYPE`: the new DOCTYPE assertion goes
  red while its sibling (`…and the reader still flattens keys out of it`) stays
  green, so the two arms are independent rather than one assertion counted twice.
- **M7** — the control probe removed (`if false`): the new
  `a flattener that cannot run is a refusal, not an empty domain` arm goes red
  alongside `a dead control probe fails loudly`. That arm is #1688's second
  finding, and it came out of judging the S7682 smells: a flattener that cannot
  RUN answers exactly like a domain holding no keys, on every domain at once —
  the control is flattened by the same code, so it drives to `ABSENT` and the
  refusal fires. `awk` is shadowed by a shell function for one case and unset
  after, with an arm asserting the shadow did not outlive it.

`seed_empty` also binds its positional parameter (S7679) — free, and it masks
nothing.

**The seven remaining issues are CODE_SMELLs and are kept deliberately.**
`new_maintainability_rating` is 1, so none of them gates; each was judged rather
than waved through, and two of the three S7682 sites would be made *worse* by
complying:

| rule | site(s) | decision |
|---|---|---|
| `shelldre:S7682` "explicit return at end of function" | `seed-domains.sh:43,48,62` (`_head`, `seed_one`, `seed_empty`) | **Kept.** `return 0` would mask a failed write. Measured: `seed-domains.sh --one /nonexistent-dir/x a=1` exits 1, and under a probe's `-e` that aborts the setup *before* the call — so the errexit tripwire reports "the probe never reached the call" instead of grading against a silently-empty fixture. |
| `shelldre:S7682` | `swift-suite.sh:332` (`_swift_suite_domain_flatten`) | **Kept**, on the weaker version of the same reason. Measured: under `pipefail` — which is what `preflight.sh` sets — the function's status does reach `_swift_suite_domain_state`'s command substitution (7, not 0). `return 0` would discard it. It changes no verdict today (either way the domain reads `ABSENT` and the control probe fires), which is exactly why the shadowed-`awk` arm above was added instead. |
| `shelldre:S1192` "define a constant" ×3 | `swift-suite.sh:388,585,599` (`UNREADABLE`, `ABSENT`) | **Kept.** These are the state-marker literals *written into* and *read back from* the snapshot files — the wire format between `_swift_suite_domain_state` and the verdict. A shell variable would let a writer and a reader disagree while both compile; the literal is what makes the two sides provably the same three strings. This is the "a rule firing on code that IS the fix" case. |

No `NOSONAR` anywhere (and per AGENTS.md its support is shell-only, so a
suppression that looks applied elsewhere may do nothing — not relied on here).

Re-run after the fix: quality gate **OK** — `new_security_rating` 1,
`new_reliability_rating` 1, `new_maintainability_rating` 1,
`new_duplicated_lines_density` 0.0%, `new_security_hotspots_reviewed` 100%.
`SonarCloud Code Analysis` **pass**. Local gates re-run and green:
`--only tools` PASS, `--only bash` PASS, `--only swift` PASS (414 tests, both
witness halves clean), pre-push hook PASS.
