### PR TITLE
fix(ci): publish the ARS badge to a gist instead of a push main can never accept (#1654)

### DIFF
--- a/.github/workflows/ars.yml
+++ b/.github/workflows/ars.yml
@@ -5,17 +5,40 @@ on:
     branches: [main]
   workflow_dispatch:
 
+# The badge is published by PATCHing a gist with a separate GIST_SECRET PAT,
+# not the workflow token — so the default token needs checkout and nothing
+# more. This is the shape codescene-badge.yml already had; ars.yml is the one
+# that did not.
+#
+# It used to be `contents: write`, held for exactly one reason: a "Commit badge
+# update" step that committed the rewritten README.md and pushed it straight to
+# `main`. The "Protect Main" ruleset requires a pull request, so that push was
+# refused on EVERY run —
+#
+#     remote: error: GH013: Repository rule violations found for refs/heads/main.
+#     remote: - Changes must be made through a pull request.
+#
+# — and had been since 2026-04-26, the date of the last badge commit that
+# landed. A rule violation is not a transient condition, so all five retries
+# failed for the same reason: the job computed a fresh score, rewrote README.md
+# on the runner and threw it away, for roughly four months (#1654). Before
+# #1647 made the failure loud it did that behind a green check.
+#
+# The badge now goes to the same gist coverage.yml and codescene-badge.yml
+# already write to, README stops being rewritten at all, and nothing in this
+# job writes to the repository — which also means the workflow token sitting
+# next to a third-party CLI (pinned by commit, but still) can no longer push
+# anything.
+permissions:
+  contents: read
+
 jobs:
   update-ars-badge:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Go
         uses: actions/setup-go@v7
@@ -24,10 +47,9 @@ jobs:
           cache: false
 
       - name: Install ARS CLI
-        # Pinned to the commit v0.0.9 points at, not the tag: a tag can be moved
-        # to different code after the fact, and this job holds contents: write.
-        # Go resolves the hash back to v0.0.9 and still verifies it against the
-        # checksum database.
+        # Pinned to the commit v0.0.9 points at, not the tag: a tag can be
+        # moved to different code after the fact. Go resolves the hash back to
+        # v0.0.9 and still verifies it against the checksum database.
         run: go install github.com/ingo-eichhorst/agent-readyness/cmd/ars@e0ce48b9644df71b8f41b11c8c5655e3efa59660
 
       - name: Run ARS scan
@@ -35,9 +57,8 @@ jobs:
         # `cat` — which succeeds. So ANY failure of `ars scan` (a missing CLI, a
         # renamed flag, a panic) ended this step at status 0 with an error
         # message where the badge should be, the next step's grep matched
-        # nothing, its `if` was skipped, and "Commit badge update" reported
-        # `No badge changes to commit`: three green steps and a README badge
-        # silently frozen at its previous score (#1644).
+        # nothing, its `if` was skipped in silence, and the badge stayed frozen
+        # at its previous score behind three green steps (#1644).
         #
         # The `|| true` was NOT protecting a legitimate non-zero. `ars scan`
         # exits non-zero for a low score only when a threshold is set — pinned
@@ -61,31 +82,40 @@ jobs:
           ars scan ./core --no-llm --badge > ars-output.txt 2>&1 || scan_status=$?
           cat ars-output.txt
           if [ "$scan_status" -ne 0 ]; then
-            echo "::error::ARS scan FAILED (exit $scan_status). No score was produced, so README.md was NOT updated and still shows the previous score. The scan's own output is above."
+            echo "::error::ARS scan FAILED (exit $scan_status). No score was produced, so the badge gist was NOT updated and README's ARS badge still renders the previous score. The scan's own output is above."
             exit 1
           fi
 
-      - name: Extract and update ARS badge
+      - name: Extract ARS badge
         # Three outcomes, never two — the same discipline #1645 put on the
-        # deletion guard. The badge was extracted and written (pass); the scan
-        # produced output with no badge in it (fail, naming that the output
-        # format changed); the rewrite did not land in README.md (fail, naming
-        # that). Each `if [ -n … ]` below used to be a silent skip whose only
-        # trace was a `No badge changes to commit` in the NEXT step.
+        # deletion guard. The badge was extracted and a payload written (pass);
+        # the scan produced output with no badge in it (fail, naming that the
+        # output format changed); the badge URL could not be turned into an
+        # endpoint payload (fail, naming which part of it could not). Each
+        # `if [ -n … ]` here used to be a silent skip whose only trace was a
+        # `No badge changes to commit` in a step that no longer exists.
         #
-        # The last guard is the one that is easy to leave out and is the same
-        # defect one level down: `sed` exits 0 having matched nothing, so a
-        # README whose badge line was reformatted (or removed, or a URL carrying
-        # a `&` that sed re-reads as the whole match) leaves the file untouched
-        # while this step prints "README updated". Re-reading the file for the
-        # URL just written is what tells "the score did not change" — where the
-        # rewrite is a no-op because it wrote the same URL back, and README
-        # therefore CONTAINS it — from "nothing was rewritten".
+        # What #1654 changed: this step used to `sed -i` the score into
+        # README.md for the next step to commit and push. It now builds the
+        # shields.io ENDPOINT payload that README's badge reads out of a gist,
+        # so there is nothing to commit and nothing for a branch ruleset to
+        # refuse.
+        #
+        # The decode is the guard that is easy to leave out, and it is the same
+        # class of defect one level down. shields.io's STATIC-badge path is
+        # escaped — `--` is a literal dash, `_` and `%20` are spaces, `__` is a
+        # literal underscore, `%2F` is a slash — while the ENDPOINT schema takes
+        # plain text. Publishing the path's bytes unchanged renders a badge
+        # reading `Agent--Assisted%207.9%2F10`: wrong, permanently, and green
+        # about it, which is the failure mode this whole issue is made of. So
+        # the escaping is undone, and an escape this step does not model is a
+        # refusal rather than a guess — a validator that cannot parse its input
+        # checks MORE, never less.
         run: |
           ARS_BADGE=$(grep "img.shields.io/badge/ARS" ars-output.txt | head -1 || echo "")
           echo "ARS Badge line: $ARS_BADGE"
           if [ -z "$ARS_BADGE" ]; then
-            echo "::error::the ARS scan succeeded but its output carries no img.shields.io/badge/ARS line, so there is no score to write. README.md was NOT updated and still shows the previous score — most likely \`--badge\` stopped emitting one, or the output format changed. Full scan output:"
+            echo "::error::the ARS scan succeeded but its output carries no img.shields.io/badge/ARS line, so there is no score to publish. The badge gist was NOT updated and README's ARS badge still renders the previous score — most likely \`--badge\` stopped emitting one, or the output format changed. Full scan output:"
             cat ars-output.txt
             exit 1
           fi
@@ -93,102 +123,107 @@ jobs:
           ARS_URL=$(echo "$ARS_BADGE" | grep -o 'https://img\.shields\.io/badge/ARS[^)]*' | head -1 || echo "")
           echo "ARS URL: $ARS_URL"
           if [ -z "$ARS_URL" ]; then
-            echo "::error::a badge line was found but no https://img.shields.io/badge/ARS… URL could be read out of it, so README.md was NOT updated. The line was: $ARS_BADGE"
+            echo "::error::a badge line was found but no https://img.shields.io/badge/ARS… URL could be read out of it, so the badge gist was NOT updated. The line was: $ARS_BADGE"
             exit 1
           fi
 
-          sed -i "s|https://img.shields.io/badge/ARS-[^)]*|${ARS_URL}|g" README.md
-          if ! grep -qF "$ARS_URL" README.md; then
-            echo "::error::README.md does not contain the badge URL this step just wrote, so the badge is NOT updated. Either README.md carries no https://img.shields.io/badge/ARS-… URL for the rewrite to match, or the rewrite produced something else. Wanted: $ARS_URL"
+          # `--` is shields.io's escape for a literal dash, so the field
+          # separator is a SINGLE dash: park the escaped pairs on two bytes a
+          # URL cannot carry, split, then put them back inside `unescape`.
+          ARS_PATH=${ARS_URL#https://img.shields.io/badge/}
+          ARS_PATH=${ARS_PATH%%\?*}
+          esc=${ARS_PATH//--/$'\x1f'}
+          esc=${esc//__/$'\x1e'}
+          IFS=- read -r LABEL MESSAGE COLOR EXTRA <<<"$esc"
+          if [ -z "$LABEL" ] || [ -z "$MESSAGE" ] || [ -z "$COLOR" ] || [ -n "$EXTRA" ]; then
+            echo "::error::the ARS badge URL does not split into a label, a message and a color, so no endpoint payload could be built and the badge gist was NOT updated. shields.io's static-badge path is <label>-<message>-<color>; this one was: $ARS_PATH"
             exit 1
           fi
-          echo "README updated with ARS badge URL"
 
-      - name: Commit badge update
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add README.md
-          if git diff --staged --quiet; then
-            echo "No badge changes to commit"
-          else
-            git commit -m "chore: update ARS badge [skip ci]"
-            # `pushed` is the only thing that can tell "it went in on attempt
-            # 3" from "it never went in", and until #1641 nothing did. The
-            # loop's last statement was `sleep`, which succeeds — so five
-            # failed attempts ended the loop with status 0, and the step, the
-            # job and this workflow's check all went GREEN with the badge
-            # unpushed. GitHub's implicit `-e` (a step declaring no `shell:`
-            # and no `defaults:` runs as `bash -e {0}` — errexit only, NO
-            # pipefail and no `--noprofile/--norc`, which is what `shell: bash`
-            # gives; measured, run 31960152598) does not
-            # save it: errexit is suppressed for every command in an `&&` list
-            # except the one after the final `&&`, which is precisely what
-            # MAKES this a retry rather than one attempt. That suppression is
-            # wanted; what was missing is anything that reads the exhausted
-            # case. Measured, not reasoned about — the pre-fix loop is emitted
-            # verbatim by tools/lib/ars-badge-push_test.sh and still exits 0
-            # there on every run, and that test executes THIS block.
-            #
-            # `|| true` on the push is the false fix and is deliberately not
-            # used: it makes the loop's own status 0 for the same reason, one
-            # level down (#1629 measured the same trap on a `$?` capture).
-            #
-            # `attempts` counts the attempts that were actually MADE, and the
-            # message below states that number rather than a literal 5 (#1655).
-            # Until then, a rebase that failed INSIDE the rebase — a conflict,
-            # not a rejected push — left the tree mid-rebase, and every later
-            # `git pull` refused outright with "Pulling is not possible because
-            # you have unmerged files": four of the five attempts could not
-            # run, while the message still attributed all five to the push.
-            # Measured on run 31963062408, whose attempt 1 conflicted add/add
-            # and whose attempts 2-5 are verbatim identical refusals. That run
-            # was a `workflow_dispatch` on a branch, so its ref differed from
-            # main — the MECHANISM is measured, that a push-to-main run reaches
-            # it is ASSUMED (two badge runs racing on the same README line, or
-            # a README edit landing between checkout and push).
-            #
-            # Today `attempts` is always 5 here, because the only other way out
-            # of the loop is the refusal below. It is derived anyway: the claim
-            # "all 5 failed" is only true if all 5 were attempted, and a
-            # measured number cannot outrun the facts if the loop ever grows
-            # another way to skip one.
-            pushed=0
-            attempts=0
-            for i in 1 2 3 4 5; do
-              # Attempt N+1 has to start from the state attempt N did.
-              #
-              # The rebase is ASKED about rather than aborted unconditionally,
-              # because "no rebase in progress" is the NORMAL case here — an
-              # ordinary rejected push, which is what this retry exists for,
-              # leaves none — and `git rebase --abort` exits 128 there. So a
-              # spelling that merely reads that status turns every healthy
-              # retry into a reported failure, while `git rebase --abort ||
-              # true` throws away the one status that matters. Asking first is
-              # what tells "there was nothing to abort" (fine) from "there was,
-              # and it could not be undone" — in which case the tree is still
-              # mid-rebase, no further attempt can run, and burning them would
-              # blame a cause nothing tested. Both spellings are committed and
-              # re-measured in tools/lib/ars-badge-push_test.sh.
-              if [ -d "$(git rev-parse --git-path rebase-merge)" ] || [ -d "$(git rev-parse --git-path rebase-apply)" ]; then
-                # Neither message says "attempt $((i - 1))'s rebase": on the
-                # first pass that reads "attempt 0", and while nothing before
-                # this loop rebases, a diagnosis that is wrong in the one state
-                # nobody expected is the worst place to be wrong.
-                if git rebase --abort; then
-                  echo "An unfinished rebase was in progress; aborted it so attempt $i starts from a clean tree"
-                else
-                  echo "::error::ARS badge was NOT pushed: a \`git pull --rebase\` left this runner mid-rebase and \`git rebase --abort\` could not undo it, so the tree is still dirty and attempts $i-5 cannot run. Only $attempts of 5 attempts were made. README.md on main still shows the previous score."
-                  exit 1
-                fi
-              fi
-              attempts=$((attempts + 1))
-              if git pull --rebase origin main && git push; then pushed=1; break; fi
-              echo "Push attempt $i failed, retrying..."
-              sleep $((i * 3))
-            done
-            if [ "$pushed" -ne 1 ]; then
-              echo "::error::ARS badge was NOT pushed: $attempts of 5 \`git pull --rebase origin main && git push\` attempts to origin/main were made, and every one of them failed. The badge commit exists only on this runner; README.md on main still shows the previous score."
+          unescape() {
+            local s="$1"
+            s=${s//"%20"/" "}
+            s=${s//"%2F"/"/"}
+            s=${s//"%2f"/"/"}
+            s=${s//"_"/" "}
+            s=${s//$'\x1e'/"_"}
+            s=${s//$'\x1f'/"-"}
+            printf '%s' "$s"
+          }
+          LABEL=$(unescape "$LABEL")
+          MESSAGE=$(unescape "$MESSAGE")
+          COLOR=$(unescape "$COLOR")
+          case "$LABEL$MESSAGE$COLOR" in
+            *%*)
+              echo "::error::the ARS badge URL carries a percent-escape this step does not decode, so the gist was NOT updated rather than publishing bytes the badge would render literally. Decoded as far as it got: label=[$LABEL] message=[$MESSAGE] color=[$COLOR]"
               exit 1
-            fi
+              ;;
+          esac
+
+          jq -n -c --arg label "$LABEL" --arg message "$MESSAGE" --arg color "$COLOR" \
+            '{schemaVersion: 1, label: $label, message: $message, color: $color}' >ars-badge.json
+          echo "ARS badge endpoint payload:"
+          cat ars-badge.json
+
+      - name: Update Gist with ARS score
+        env:
+          GIST_SECRET: ${{ secrets.GIST_SECRET }}
+          # The same badges gist coverage.yml and codescene-badge.yml write to
+          # — this adds a third file to it, so #1654 needed no new secret.
+          COVERAGE_GIST_ID: ${{ secrets.COVERAGE_GIST_ID }}
+        run: |
+          if [ -z "$GIST_SECRET" ]; then
+            echo "::error::GIST_SECRET is not set in repository secrets, so the ARS badge could not be published at all. The gist still holds its previous ars.json and README's ARS badge renders the previous score."
+            exit 1
           fi
+          if [ -z "$COVERAGE_GIST_ID" ]; then
+            echo "::error::COVERAGE_GIST_ID is not set in repository secrets, so there is no gist for the ARS badge to be published to. README's ARS badge renders the previous score."
+            exit 1
+          fi
+
+          # The emptiness guard the pipeline-free read still needs: a missing,
+          # unreadable or blank-message payload and a published badge must not
+          # come out of this step looking the same.
+          MESSAGE=$(jq -r '.message // empty' ars-badge.json 2>/dev/null || echo "")
+          if [ -z "$MESSAGE" ]; then
+            echo "::error::there is no ARS badge payload to publish — ars-badge.json is missing, unreadable, or carries an empty message. The gist was NOT updated and README's ARS badge renders the previous score."
+            exit 1
+          fi
+
+          BADGE_JSON=$(cat ars-badge.json)
+          jq -n --arg content "$BADGE_JSON" '{"files":{"ars.json":{"content":$content}}}' >gist-payload.json
+
+          # curl writes "000" to %{http_code} when no response was received
+          # (DNS/TLS/connect failure) AND exits non-zero — under this step's
+          # implicit `-e` a bare `$(curl …)` would abort the step right there,
+          # with no annotation and no diagnosis. So the status is captured and
+          # reported next to the code: "the API said no" and "the API was never
+          # reached" are different failures, and both are named by one refusal
+          # rather than one of them being silent.
+          curl_status=0
+          http_code=$(curl -sS -o gist-response.json -w '%{http_code}' \
+            --connect-timeout 10 --max-time 30 \
+            --retry 3 --retry-delay 2 --retry-all-errors \
+            -X PATCH \
+            -H "Authorization: token $GIST_SECRET" \
+            -H "Content-Type: application/json" \
+            -d @gist-payload.json \
+            "https://api.github.com/gists/$COVERAGE_GIST_ID") || curl_status=$?
+          echo "HTTP $http_code (curl exit $curl_status)"
+          # A non-numeric `$http_code` would make the arithmetic tests below
+          # print `integer expression expected` and evaluate FALSE, i.e. fall
+          # through to the success line — so its shape is decided first.
+          case "$http_code" in
+            ''|*[!0-9]*) http_code_usable=0 ;;
+            *)           http_code_usable=1 ;;
+          esac
+          if [ "$curl_status" -ne 0 ] || [ "$http_code_usable" -ne 1 ] || [ "$http_code" -lt 200 ] || [ "$http_code" -ge 300 ]; then
+            echo "::error::the ARS badge gist update FAILED (HTTP $http_code, curl exit $curl_status), so the gist still holds its previous ars.json and README's ARS badge renders the previous score."
+            if [ -s gist-response.json ]; then
+              cat gist-response.json
+            else
+              echo "(no response body — likely a transport failure)"
+            fi
+            exit 1
+          fi
+          echo "Published ARS badge to gist: $MESSAGE"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -223,12 +223,37 @@ Before marking a ticket done, run the full suite — every layer must pass:
   whether the regression is worth addressing before merging. Deterministic
   and workflow-agnostic: it fires on any push, not tied to a specific agent
   skill.
+  **What IS required is stated here positively**, because "not required by
+  branch protection" appears twice in this section and nothing said what is —
+  the sentence #1432 filed as the one creating the false impression. Measured
+  with `gh api repos/ingo-eichhorst/Irrlicht/rulesets/15993081`: the "Protect
+  Main" ruleset is active on `main` with **zero** bypass actors and carries
+  `pull_request`, `required_linear_history`, `deletion`, `non_fast_forward`
+  and `required_status_checks`, whose required contexts are exactly **`go-test`
+  and `build-test`**. Classic branch protection on `main` is empty
+  (`.required_status_checks.contexts` is `[]`), so the ruleset is the whole of
+  it. When #1432 was filed (2026-08-09) that ruleset carried no
+  `required_status_checks` rule at all, so this is a behaviour CHANGE, not a
+  restatement. Its consequence is #1432's own scope item 3: a **CONFLICTING**
+  PR dispatches no `pull_request` workflows, so those two checks come back
+  ABSENT rather than red — and an absent required check reads as "waiting for
+  status to be reported", i.e. indistinguishable from still-queued. That is
+  correct behaviour with a confusing symptom; rebase the PR and the checks
+  appear.
+  The ARS score is also what the README's ARS badge shows, and since #1654 it
+  is published the way the CodeScene one is: `.github/workflows/ars.yml`
+  PATCHes a shields.io endpoint payload into the badges gist on every push to
+  `main` and writes nothing to the repository. It used to commit a rewritten
+  README.md and push it to `main` — which the `pull_request` rule above refused
+  on every run from 2026-04-26 onward, silently until #1647.
 - Code health: CodeScene posts a "CodeScene Code Health Review" check on every
   PR automatically (via the CodeScene GitHub App, configured on codescene.io
   project 82148 — not a workflow in this repo). Like the ARS score, it's
   advisory, not a merge gate: neither branch protection nor the "Protect
-  Main" ruleset requires it to pass. A red result is a prompt to look
-  closer, not something to chase to green before merging or releasing. The
+  Main" ruleset requires it to pass — that ruleset's required contexts are
+  `go-test` and `build-test` and nothing else (bullet above). A red result is
+  a prompt to look closer, not something to chase to green before merging or
+  releasing. The
   README's CodeScene badge shows the live score, auto-refreshed on every
   push to `main` by `.github/workflows/codescene-badge.yml`. For concrete,
   file:line-level findings (rule, message, fix effort) rather than a
@@ -1151,112 +1176,104 @@ Before marking a ticket done, run the full suite — every layer must pass:
   actually gets — DERIVED from the workflow, today `bash -e` (see "Which bash a
   workflow step gets" below; this bullet claimed
   `bash --noprofile --norc -e -o pipefail` until #1650). Behavioural rather
-  than a text scan, because a
-  scan pins one spelling of a guard where running the block pins the property.
-  Before #1641 the push-retry loop's last statement was `sleep`, which
-  succeeds, so five failed attempts ended the loop — and the step, the job and
-  this workflow's check — at status 0 with the badge unpushed and nothing
-  saying so; the observable symptom is a README badge that quietly stops
-  tracking `main` behind a green history. `-e` does not save it: errexit is
-  suppressed for every command in an `&&` list except the one after the final
-  `&&`, which is exactly what MAKES the loop a retry. Three things are
-  load-bearing. The pre-fix loop is emitted verbatim there and re-measured on
-  every run, so "five failures exit 0" is a fact rather than a sentence in a
-  merged PR body — and it is the vacuity guard, since a bash that stopped
-  behaving that way would leave every other arm passing for the wrong reason.
-  The **third-attempt** arm is what keeps the fix honest: a "fix" dropping the
-  retry, or one that stops suppressing errexit inside the `&&` list, satisfies
-  the exhausted-case arm just as well and simply gives up after one attempt.
-  And the git stub answers an **unmodelled** subcommand with a loud, distinctive
-  99 naming the call, never a quiet 0 — a stub that said "fine" to a call it
-  does not model would make every arm pass for a reason unrelated to its
-  obligation (seen red: adding one `git status` to the step reports
-  `STUB: unmodelled call`, not a pass).
-  **No linter was built, and the measurement is the reason.** Over the 19
-  multi-line `run:` blocks in `.github/workflows/`, a rule keyed on "the
-  block's last statement is `echo`/`sleep`/`cat`/`printf`" flags 6 and **misses
-  this very defect** — the loop is nested inside an `if`/`else`, so the block's
-  last line is `fi` — while 4 of the 6 it does flag are correct code; a rule
-  keyed on `|| true` flags 2 and also misses it; "the block contains a loop"
-  flags 3, of which 1 is the defect. No candidate both catches the subject and
-  stays quiet on the correct blocks, so a green would claim coverage it does
-  not have — the same conclusion #1629 reached by the same measurement about a
-  `$?`-keyed rule, and #1639 about the sibling family. `preflight.sh`'s `tools`
-  trigger gains `ars.yml`, its fourth widening for this reason (#1591, #1629,
-  #1639), because that assertion lives entirely inside that gate.
-  **The two steps ABOVE it produced the same symptom for the same reason**
-  (#1644): `ars scan … || true` followed by a `cat` that succeeds, then an
+  than a text scan, because a scan pins one spelling of a guard where running
+  the block pins the property. The FILENAME now describes nothing in the file
+  and is kept deliberately: it was written for a "Commit badge update" step
+  (#1641), and #1654 deleted that step, so there is no push left anywhere in
+  this workflow. Its header is the description instead.
+  **The job could never do what it was built to do, and was green about it for
+  four months** (#1654). It pushed the badge commit straight to `main`, which
+  the "Protect Main" ruleset refuses — `GH013: Repository rule violations
+  found` — and a rule violation is not a transient condition, so none of the
+  five retries could ever clear it. Every run since 2026-04-26 computed a
+  score, rewrote README.md on the runner and threw it away: README read
+  `8.1/10` while the scan returned `7.9/10`. Before #1647 made the failure
+  loud, it did that behind a green check. The fix is codescene-badge.yml's
+  shape — the extract step builds a shields.io ENDPOINT payload, a new "Update
+  Gist with ARS score" step PATCHes it into the same badges gist coverage.yml
+  and codescene-badge.yml already write to (no new secret: `GIST_SECRET` and
+  `COVERAGE_GIST_ID` were already configured), and README's badge became an
+  `img.shields.io/endpoint?url=…` pointing at `ars.json` in that gist. Nothing
+  is committed, so nothing can be refused, and the job dropped from
+  `contents: write` to `contents: read` — a real reduction, since that grant
+  existed only for the push and this job runs a third-party CLI (pinned by
+  commit, but still) next to the workflow token.
+  **What that deleted is a real loss and is named rather than glossed**:
+  #1641's four obligations (the pre-fix retry loop replayed verbatim, five
+  failed pushes exiting 0; the exhausted case failing loudly; the
+  third-attempt arm proving the retry is still a retry; the clean paths) and
+  #1655's six (the same loop against REAL git in a throwaway repo — the
+  mid-rebase wreckage, the ordinary rejected push, the committed rejected
+  `git rebase --abort` spelling, the unabortable-rebase refusal). "A rewritten
+  guard replays its predecessor's cases" is about a guard being REWRITTEN;
+  here the mechanism was REMOVED, and contorting those obligations into
+  passing against a step that does not exist is the vacuous green this whole
+  family is about. The retry-loop defect they fixed is now covered nowhere,
+  because no retry loop remains in this repo's workflows — if one is written
+  again, they are in git history at `ae85182f`. `workflow-step_test.sh` moved
+  its real-workflow row and its `shell:` mutation target from
+  'Commit badge update' to 'Run ARS scan' for the same reason.
+  **The two steps that PRODUCE the badge are #1644's and they survived the
+  deletion**: `ars scan … || true` followed by a `cat` that succeeds, then an
   extract step whose `if [ -n "$ARS_BADGE" ]` skipped in silence — three green
-  steps, `No badge changes to commit`, and a frozen badge. The `|| true` was
-  **not** protecting a legitimate low-score exit, and that had to be checked
-  rather than assumed because the issue proposed leaving it in place: pinned
-  v0.0.9 returns `ExitError{Code: 2}` only under `if p.threshold > 0`, this
-  invocation passes no `--threshold`, and there is no `.arsrc.yml` to supply
-  one — measured, the pinned binary scoring `./core` at 7.9/10 exits 0. So the
-  scan's status is now read (`|| scan_status=$?`, never a bare `; rc=$?`, the
-  line #1629's implicit `-e` never reaches) and three outcomes are
-  distinguished where there were two: the scan FAILED / it succeeded with no
-  badge line in its output / the badge was extracted. Three things about the
-  shape are worth carrying. Each refusal asserts the other two's WORDING is
-  ABSENT, because a shared non-zero is satisfied by three refusals that all
-  fire together — measured: deleting the missing-badge refusal leaves the step
-  exiting 1 via the URL refusal, so every status arm stays green and only the
-  wording arms go red. The last guard is the same defect one level down —
-  `sed` exits 0 having matched nothing, so the file is re-read for the URL just
-  written, which is also what tells the legitimate no-op of an unchanged score
-  (the URL is present, because it was written back identically) from a rewrite
-  that landed nowhere; deleting THAT refusal is not merely silent, since the
-  empty `$ARS_URL` then deletes README's badge URL outright (measured). And a
-  failed scan **fails the job**, because this workflow gates nothing: it runs
-  post-merge on `main`, no PR and no merge depends on it, and its own "Install
-  ARS CLI" step already fails the job for the likeliest transient cause (a
-  `go install` outage) — a scan that could not run was the one failure here
-  that was silent.
-  **#1655 is the same loop again, and the defect there is STATE rather than
-  status** — which is why it needed a second kind of fixture. A `git pull
-  --rebase` that fails INSIDE the rebase leaves the tree mid-rebase, and every
-  later `git pull` then refuses outright (`Pulling is not possible because you
-  have unmerged files`), so four of the five attempts could not run while the
-  closing message attributed all five to the push. The stub above cannot
-  produce that and cannot undo it, so obligations 12-17 run the extracted body
-  against **real git in a throwaway repo** whose "origin" is a local path —
-  one fixture that conflicts add/add, one whose `pre-receive` declines the
-  first N pushes (the ordinary race, which leaves no rebase). The property
-  asserted is not a message git may reword: it is how many attempts reached
-  `git pull` with a clean tree, read off git's own rebase state.
-  Three things are load-bearing. The step **asks** whether a rebase is in
-  progress (`git rev-parse --git-path rebase-merge`/`rebase-apply`) before
-  aborting, because "no rebase in progress" is the NORMAL case and
-  `git rebase --abort` exits 128 there — so a spelling that merely reads that
-  status turns every healthy retry red, and the `|| true` spelling discards the
-  one status that matters (already refused by name by this file's existing
-  arm). That rejected spelling is **committed** beside the shipped one and
-  re-measured: it is indistinguishable from the fix on the CONFLICTING fixture
-  and only the ordinary-rejection fixture tells them apart, which is why that
-  fixture exists. And the closing message states a **derived** count
-  (`$attempts of 5`) rather than a literal 5 — the issue's own point, that
-  "all 5 failed" is only true if all 5 were attempted. Today that number is
-  always 5 there; deriving it is what stops the sentence outrunning the facts
-  if the loop ever grows another way to skip one. The one branch the fix ADDS —
-  an abort that itself fails, where the tree is still dirty and stopping is the
-  only honest move — has no "before the fix" to be red against, so it carries
-  an injected mutation (the fixture makes `git rebase --abort` answer non-zero)
-  rather than a reproduction: a rebase that genuinely cannot be aborted has no
-  portable fixture. Reachability is carried from the issue **unchanged**: the
-  mechanism is measured (run 31963062408, a `workflow_dispatch` whose ref
-  differed from main), that a push-to-main run reaches it is ASSUMED. The
-  `actions/checkout@v7` here still carries no `fetch-depth:` — the depth-1
-  clone is why that run saw add/add — and #1655 deliberately did not change it.
-  Audited while there, per "dismissals carry evidence": the only statement left
-  in this job whose status is read more narrowly than it is produced is
-  `git diff --staged --quiet`, whose three-valued status (0 / 1 / error) an
-  `if` reads as two-valued — and the misread routes to the `else` branch, where
-  `git commit` with nothing staged exits 1 and errexit aborts the step.
-  Measured under `bash -e` rather than argued: it degrades to a LOUD failure,
-  never a silent pass. `git config` / `git add` / `git commit` are simple
-  commands in bare statement position, so errexit already decides on them (also
-  measured), and no `run:` block in this workflow reads a `${{ }}` expansion, so
-  #1645's second hazard has no instance here.
+  steps and a frozen badge. The `|| true` was **not** protecting a legitimate
+  low-score exit, and that had to be checked rather than assumed because the
+  issue proposed leaving it in place: pinned v0.0.9 returns `ExitError{Code: 2}`
+  only under `if p.threshold > 0`, this invocation passes no `--threshold`, and
+  there is no `.arsrc.yml` to supply one — measured, the pinned binary scoring
+  `./core` at 7.9/10 exits 0. So the scan's status is read (`|| scan_status=$?`,
+  never a bare `; rc=$?`, the line #1629's implicit `-e` never reaches) and
+  three outcomes are distinguished where there were two. A failed scan **fails
+  the job**, because this workflow gates nothing: it runs post-merge on `main`,
+  no PR and no merge depends on it, and its own "Install ARS CLI" step already
+  fails the job for the likeliest transient cause (a `go install` outage) — a
+  scan that could not run was the one failure here that was silent.
+  Each refusal asserts EVERY other refusal's WORDING is ABSENT — nine of them
+  now, across three steps, driven from one table rather than pairwise by hand —
+  because a shared non-zero is satisfied by refusals that all fire together.
+  Re-measured against the new extract step: deleting the missing-badge refusal
+  leaves it exiting 1 via the URL refusal, so every status arm stays green and
+  only the wording arms go red, exactly as #1644 measured on its predecessor.
+  **The gist step is entirely new, so every one of its obligations passes the
+  moment it is written**, and the two mutations worth carrying are the ones
+  that do NOT simply flip a status. Dropping `|| curl_status=$?` makes a
+  transport failure abort the step under the implicit `-e` with an EMPTY log —
+  no annotation, no diagnosis, "could not be attempted" going silent — while
+  the status arm stays green. And replacing the numeric-shape check on
+  `%{http_code}` with a bare `[ -z … ]` lets a non-numeric code print
+  `integer expression expected` twice, evaluate FALSE, and reach the SUCCESS
+  line: a failed publish reported as a publish. Both spellings are
+  codescene-badge.yml's, noted here rather than changed there.
+  **The decode is the guard that is easy to leave out**, and it is the same
+  class of defect one level down. shields.io's STATIC-badge path is escaped
+  (`--` is a literal dash, `_` and `%20` are spaces, `__` is a literal
+  underscore, `%2F` is a slash) while the ENDPOINT schema takes plain text, so
+  publishing the path's bytes renders a badge reading
+  `Agent--Assisted%207.9%2F10` — wrong, permanently, and green about it. An
+  escape the step does not model is a refusal rather than a guess. It needs TWO
+  mutations, not one: skipping the decode entirely is caught by the
+  percent-escape refusal acting as a second line of defence, so the arm that
+  pins the decode itself is only discriminating against a decode wrong in one
+  way the `%` guard cannot see — dropping just the `--` → `-` restore, which
+  reddens exactly the payload-equality arms and nothing else.
+  The **`contents: read`** claim is a lock, so it is driven against two
+  deliberately mutated copies as well as the real file, and the real file is
+  mutated too: a predicate that had stopped matching would read identically to
+  a clean workflow.
+  **No linter was built, and the measurement is the reason.** Over the
+  multi-line `run:` blocks in `.github/workflows/`, a rule keyed on "the
+  block's last statement is `echo`/`sleep`/`cat`/`printf`" flagged 6 and
+  **missed the #1641 defect** — that loop was nested inside an `if`/`else`, so
+  the block's last line was `fi` — while 4 of the 6 it did flag were correct
+  code; a rule keyed on `|| true` flagged 2 and also missed it; "the block
+  contains a loop" flagged 3, of which 1 was the defect. That subject is gone
+  with the push step, but the conclusion is not: no candidate rule both catches
+  its subject and stays quiet on the correct blocks, so a green would claim
+  coverage it does not have — the same conclusion #1629 reached by the same
+  measurement about a `$?`-keyed rule, and #1639 about the sibling family.
+  `preflight.sh`'s `tools` trigger already carries `ars.yml` (#1641's widening,
+  the fourth for this reason — #1591, #1629, #1639), so #1654 needed no sixth:
+  the new assertions simply join the gate that already covers the file.
 - The replaydata deletion guard:
   `tools/lib/replaydata-deletion-guard_test.sh` does to
   `.github/workflows/replaydata-deletion-guard.yml`'s "Detect deletions of
@@ -1438,7 +1455,10 @@ Before marking a ticket done, run the full suite — every layer must pass:
   Verified while fixing it, per "dismissals carry evidence": **no live pipefail
   dependency existed** anywhere in `.github/workflows/`. All 16 pipeline-
   carrying lines were read — ars.yml's two are `$(… | head -1 || echo "")` and
-  its `sed "s|…|…|"` is a delimiter not a pipe; the deletion guard sets its own
+  its `sed "s|…|…|"` was a delimiter not a pipe (that `sed` went with the
+  README rewrite in #1654, which added no pipeline: its `jq` calls read and
+  write files rather than piping, and its `curl` status is captured with
+  `|| curl_status=$?`); the deletion guard sets its own
   `set -euo pipefail`; macos-swift.yml is on the `shell: bash` side already;
   test.yml's is inside an `echo` message; and codescene-badge.yml's
   `SCORE=$(… | jq -r …)` and coverage.yml's `pct=$(…)` are each followed

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![Version](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2Fingo-eichhorst%2FIrrlicht%2Fmain%2Fversion.json&query=%24.version&label=version&color=%2334C759)](version.json)
 
 [![CodeScene](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fingo-eichhorst%2F9f14c8e5f25c1ccf5d6500c1685fd9fb%2Fraw%2Fcodescene.json)](https://github.com/ingo-eichhorst/Irrlicht/actions/workflows/codescene-badge.yml)
-[![ARS](https://img.shields.io/badge/ARS-Agent--Ready%208.1%2F10-green)](https://github.com/ingo-eichhorst/agent-readyness)
+[![ARS](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Fingo-eichhorst%2F9f14c8e5f25c1ccf5d6500c1685fd9fb%2Fraw%2Fars.json)](https://github.com/ingo-eichhorst/agent-readyness)
 [![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=ingo-eichhorst_Irrlicht&metric=security_rating)](https://sonarcloud.io/summary/overall?id=ingo-eichhorst_Irrlicht)
 [![Reliability Rating](https://sonarcloud.io/api/project_badges/measure?project=ingo-eichhorst_Irrlicht&metric=reliability_rating)](https://sonarcloud.io/summary/overall?id=ingo-eichhorst_Irrlicht)
 [![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=ingo-eichhorst_Irrlicht&metric=sqale_rating)](https://sonarcloud.io/summary/overall?id=ingo-eichhorst_Irrlicht)

--- a/tools/lib/ars-badge-push_test.sh
+++ b/tools/lib/ars-badge-push_test.sh
@@ -1,114 +1,133 @@
 #!/usr/bin/env bash
 # ars-badge-push_test.sh — the lock on .github/workflows/ars.yml's badge job.
 #
-# The filename predates its scope. It was written for the "Commit badge update"
-# step (#1641) and grew to cover "Run ARS scan" and "Extract and update ARS
-# badge" (#1644) — the two steps that PRODUCE the badge that step pushes. One
-# harness per workflow rather than one per step, because the three share a
+# The filename no longer describes the file at all, and that is deliberate.
+# It was written for a "Commit badge update" step (#1641), grew to cover
+# "Run ARS scan" and "Extract and update ARS badge" (#1644), grew again for
+# the same push step's rebase wreckage (#1655) — and then #1654 DELETED the
+# push. There is no longer a push anywhere in this workflow to be the "push"
+# in this filename: the badge goes to a gist, README is never rewritten, and
+# the job holds `contents: read`. Renaming the file was declined as churn
+# against six commits of history; this header is the description instead.
+#
+# One harness per workflow rather than one per step, because the steps share a
 # workflow file, a `workflow_step_shell` derivation, an assertion vocabulary
 # and one preflight trigger; splitting them would duplicate all four and let
 # the copies disagree, which is what tools/lib/workflow-step.sh exists to stop.
-# Renaming the file was declined as pure churn against five commits of history.
 #
 # ---------------------------------------------------------------------------
-# What is being asserted, and why each obligation exists
+# What #1654 removed, and why those obligations are GONE rather than adapted
 #
-# The defect: the step's push-retry loop was
+# AGENTS.md: "a rewritten guard replays its predecessor's cases or it is not
+# known to be a superset." That rule is about a guard being REWRITTEN. Here a
+# mechanism was REMOVED — `.github/workflows/ars.yml` no longer commits, no
+# longer pushes, and no longer touches README.md — so the obligations that
+# graded the push step have nothing left to grade. Contorting them into
+# passing against a step that does not exist would be the exact failure this
+# family is about: a green that asserts nothing. They are deleted, and named
+# here so the deletion is on the record rather than discovered by a reviewer:
 #
-#     for i in 1 2 3 4 5; do
-#       git pull --rebase origin main && git push && break
-#       echo "Push attempt $i failed, retrying..."
-#       sleep $((i * 3))
-#     done
+#   #1641, obligations 1-4 — the pre-fix retry loop replayed verbatim (five
+#     failed pushes exiting 0); the real step failing loudly when every
+#     attempt failed; the third-attempt arm proving the retry is still a
+#     retry; the clean paths (nothing staged, first-attempt push).
+#   #1655, obligations 12-17 — the same loop against REAL git in a throwaway
+#     repo: the pre-fix loop reaching a clean tree on 1 of 5 attempts; every
+#     attempt starting clean after the fix; the ordinary rejected push
+#     succeeding on the third try; the rejected `git rebase --abort` spelling
+#     committed beside the shipped one; a first-attempt push landing on
+#     origin; and the refusal for a rebase that cannot be aborted.
 #
-# The loop's last statement is `sleep`, which succeeds. So when all five
-# attempts failed the loop simply ended, `sleep`'s 0 became the step's status,
-# and the step, the job and the badge check all went GREEN with the badge
-# unpushed. GitHub's implicit `-e` does not save it: `A && B && break` is an
-# `&&` list, and errexit is suppressed for every command in such a list except
-# the one following the final `&&` — which is exactly what MAKES this a retry
-# rather than a single attempt. The suppression is wanted; what was missing is
-# anything that then READS the exhausted-retries case.
+# With them went their machinery: the `git`/`sleep` stub, the real-git fixture
+# builder (`fixture_build`, `fgit`, `fixture_conflicts`), the mid-rebase
+# instrumentation (`attempt_prelude`, `run_in_repo`, `want_starts`), and the
+# two committed predecessor loops. `tools/lib/workflow-step_test.sh` moved its
+# real-workflow row and its `shell:` mutation target from 'Commit badge update'
+# to 'Run ARS scan' for the same reason.
 #
-# The obligations, in order:
-#
-#   1. the defect is re-MEASURED, not described. The pre-fix loop is emitted
-#      verbatim and run under the shell GitHub actually uses, so "five failures
-#      exit 0" is a fact on every run rather than a sentence in a merged PR
-#      body. It doubles as the vacuity guard: if bash ever stopped behaving
-#      that way, the fix would be protecting nothing and every arm below would
-#      pass for the wrong reason.
-#   2. the real step — extracted from the real workflow file and EXECUTED —
-#      fails when every attempt fails, and says what did not happen. This is
-#      deliberately behavioural rather than a text scan: a scan pins one
-#      spelling of a guard, where running the block pins the property.
-#   3. the retry is still a retry. A "fix" that dropped the loop, or that
-#      stopped suppressing errexit inside the `&&` list, also satisfies
-#      obligation 2 — it just gives up after one attempt. So a run whose third
-#      attempt succeeds must exit 0 AND show that the first two were retried.
-#   4. the clean paths still pass: nothing staged, and a first-attempt push.
-#
-# Obligations 12-17 are #1655's, on the same loop and against REAL git in a
-# throwaway repo, because the defect there is STATE rather than status — a
-# rebase that conflicts leaves the tree mid-rebase and the stub above can no
-# more produce that than it can undo it. Their header sits with them.
+# What that deletion COSTS is worth stating plainly: the defect #1641 and
+# #1655 fixed — a retry loop whose exhausted case reads as success — is no
+# longer covered anywhere, because no retry loop remains in this repo's
+# workflows. If one is ever written again, those obligations are in git
+# history at ae85182f and should be brought back with it.
 #
 # ---------------------------------------------------------------------------
-# #1644 — the two steps ABOVE it, same job, same symptom
+# What #1654 was, and what this file now grades
 #
-# The badge that step pushes is produced by "Run ARS scan" and "Extract and
-# update ARS badge", and both used to answer "I could not look" with the same
-# bytes as "there was nothing to do":
+# The badge job pushed its commit straight to `main`, which the "Protect Main"
+# ruleset refuses with `GH013: Repository rule violations found`. Not a
+# transient condition, so no retry could ever clear it: every run since
+# 2026-04-26 computed a score, rewrote README.md on the runner and threw it
+# away. README read `8.1/10` while the scan returned `7.9/10` — four months
+# wrong, and green about it until #1647 made the failure loud.
 #
-#     ars scan ./core --no-llm --badge > ars-output.txt 2>&1 || true
-#     cat ars-output.txt
+# The fix is codescene-badge.yml's shape: build a shields.io ENDPOINT payload
+# and PATCH it into the gist README already reads its Coverage and CodeScene
+# badges from. Nothing is committed, so nothing can be refused.
 #
-# `|| true` swallows any failure and the block's last statement is `cat`, which
-# succeeds. `ars-output.txt` then holds an error, the extract step's `grep`
-# matches nothing, its `if [ -n "$ARS_BADGE" ]` is skipped in silence, README is
-# untouched, and "Commit badge update" reports `No badge changes to commit`.
-# Three green steps and a badge frozen at its previous score.
+# The obligations, in order. A-group is #1644's, unchanged in kind; B-group is
+# #1644's extract obligations adapted to a step that builds a payload instead
+# of rewriting a file, plus the two refusals the decode ADDS; C-group is all
+# new and therefore carries AGENTS.md's mutation rule in its strongest form —
+# every one of them passes the moment it is written, so each was seen red by a
+# deliberate mutation before landing (the mutations are named in the PR body
+# and reproducible from the arms below).
 #
-# The obligations added for it:
+#   A1. the pre-#1644 scan body is re-MEASURED, not described: emitted verbatim
+#       and run against a failing `ars`, it still exits 0. The permanent
+#       vacuity guard for A2-A3 — if `|| true` + a trailing `cat` ever stopped
+#       exiting 0, the fix would be protecting nothing.
+#   A2. a FAILED scan is no longer green, and the step says the badge was not
+#       updated. The scan's own output is still printed, or the failure has no
+#       diagnosis in the log.
+#   A3. a scan that SUCCEEDS is still green (the vacuity guard for A2 — a step
+#       that failed unconditionally would satisfy A2 perfectly).
+#   B1. the pre-#1644 extract body, verbatim, over an error output: still exit
+#       0, still silent. The half of that predecessor that rewrote README is
+#       never reached on this path, which is the point — the hazard was the
+#       silent SKIP, and the skip is what the new refusals replace.
+#   B2. a normal run still produces a badge: a valid shields.io endpoint
+#       payload with the scanned score in it. The vacuity guard for B3-B6, and
+#       the only arm that would notice the whole step being replaced by
+#       `exit 1`.
+#   B3. output with NO badge line is a named failure.
+#   B4. a badge line carrying no extractable URL is its OWN named failure.
+#   B5. a URL that does not split into label/message/color is its OWN named
+#       failure — the "empty badge value" case, which before #1654 could not
+#       arise because the URL was copied around as one opaque string.
+#   B6. a URL carrying a percent-escape the decode does not model is its OWN
+#       named failure, rather than a badge that renders `%3A` at the reader.
+#   C1. the gist step publishes: the endpoint payload is PATCHed to
+#       api.github.com/gists/<id> with the token, and the step is green.
+#   C2. an unset GIST_SECRET is a named failure, and nothing is sent.
+#   C3. an unset COVERAGE_GIST_ID is a named failure, and nothing is sent.
+#   C4. a missing or empty-message payload is a named failure, and nothing is
+#       sent — "the extract step produced nothing" and "the API refused" must
+#       not read alike.
+#   C5. a non-2xx answer is a named failure, with the API's own body in the
+#       log.
+#   C6. a curl that never reached the API is the same named failure and says
+#       so — under this step's implicit `-e` a bare `$(curl …)` would abort
+#       with no annotation at all, which is the "could not be attempted"
+#       outcome going silent.
+#   C7. the job writes NOTHING to the repository: no `contents: write`, no
+#       `git push`. That is a lock (it passes by construction), so it is
+#       driven against deliberately mutated copies as well as the real file.
 #
-#   5. the defect is re-MEASURED, not described: both pre-#1644 bodies are
-#      emitted verbatim and run against a failing `ars`, and both still exit 0
-#      with README unchanged. The permanent vacuity guard for 6-11 — if that
-#      ever stopped reproducing, they would all pass for the wrong reason.
-#   6. a FAILED scan is no longer green, and the step says the badge was not
-#      updated. The scan's own output is still printed, on both paths, or the
-#      failure has no diagnosis in the log.
-#   7. a scan that SUCCEEDS is still green (the vacuity guard for 6 — a step
-#      that failed unconditionally would satisfy 6 perfectly).
-#   8. a NORMAL run still rewrites the badge: the real README.md, the real
-#      extract body, a new score in, the new URL in the file and the old one
-#      gone. The vacuity guard for 9-11, and the only arm that would notice the
-#      whole step being replaced by `exit 1`.
-#   9. output with NO badge line is a named failure — the third outcome the
-#      issue is about, since it means `--badge` stopped emitting one rather
-#      than that the score was unchanged.
-#  10. a badge line carrying no extractable URL is its OWN named failure.
-#  11. a rewrite that did not land in README.md is its OWN named failure. `sed`
-#      exits 0 having matched nothing, so this is the same defect one level
-#      down, and re-reading the file for the URL just written is what
-#      distinguishes it from the legitimate no-op of an unchanged score.
-#
-#  9-11 additionally assert that each refusal does NOT print the other two's
-#  wording. Three refusals that all fire together, or all print the same
-#  sentence, would satisfy every arm above while leaving the operator exactly
-#  where the `if` skips left them: a red step and no idea which thing broke.
+# EVERY refusal above additionally asserts that no OTHER refusal's wording is
+# present. Refusals that all fire together, or that print the same sentence,
+# satisfy every status arm while leaving the operator exactly where the silent
+# `if` skips left them: something is red, and no idea which thing broke
+# (#1677/#1678).
 #
 # Deliberately NOT a general workflow linter, and the measurement is the
-# honest part. Over this repo's 19 multi-line `run:` blocks, a rule keyed on
-# "the block's last statement is echo/sleep/cat/printf" flags 6 and MISSES
-# THIS ONE — ars.yml's retry loop is nested inside an if/else, so the block's
-# last line is `fi` — while 4 of the 6 it does flag are correct code. A rule
-# keyed on `|| true` flags 2 and also misses this one. A rule keyed on "the
-# block contains a loop" flags 3, of which 1 is this defect. No candidate rule
-# both catches the subject and stays quiet on the correct blocks, so a
-# linter's green would claim coverage it does not have. This is a lock on the
-# ONE call site that exists — the same conclusion, reached the same way, as
-# #1629's scan in swift-suite_test.sh.
+# honest part. Over this repo's multi-line `run:` blocks, a rule keyed on "the
+# block's last statement is echo/sleep/cat/printf" flags 6 blocks of which 4
+# are correct code; a rule keyed on `|| true` flags 2. No candidate rule both
+# catches the subject and stays quiet on the correct blocks, so a linter's
+# green would claim coverage it does not have. This is a lock on the ONE
+# workflow that exists — the same conclusion, reached the same way, as #1629's
+# scan in swift-suite_test.sh.
 set -uo pipefail
 
 REPO_ROOT=$(git rev-parse --show-toplevel)
@@ -124,11 +143,15 @@ need awk
 need sed
 need grep
 need bash
+# jq is not stubbed: the payload the gist step builds has to be REAL JSON, and
+# only jq can say so. `curl` deliberately is NOT needed — it is shadowed by a
+# shell function in every arm below, so nothing here can reach the network.
+need jq
 
 WF=.github/workflows/ars.yml
-STEP='Commit badge update'
 SCAN_STEP='Run ARS scan'
-EXTRACT_STEP='Extract and update ARS badge'
+EXTRACT_STEP='Extract ARS badge'
+GIST_STEP='Update Gist with ARS score'
 
 # The step's body AND the shell it runs under both come from the workflow file,
 # through tools/lib/workflow-step.sh — see the invocation block below.
@@ -147,12 +170,21 @@ want_status() { # label want got out
   if [[ "$3" == "$2" ]]; then pass "$1 (exit $2)"; else fail "$1" "exit $2" "exit $3 :: $(flat "$4")"; fi
   return 0
 }
+want_nonzero() { # label got out
+  if [[ "$2" -ne 0 ]]; then pass "$1 (exit $2)"; else fail "$1" "a non-zero exit" "exit 0 :: $(flat "$3")"; fi
+  return 0
+}
 want_contains() { # label needle haystack
   case "$3" in *"$2"*) pass "$1" ;; *) fail "$1" "output containing: $2" "$(flat "$3")" ;; esac
   return 0
 }
 want_absent() { # label needle haystack
   case "$3" in *"$2"*) fail "$1" "no output containing: $2" "$(flat "$3")" ;; *) pass "$1" ;; esac
+  return 0
+}
+want_file_contains() { # label needle file
+  if grep -qF "$2" "$3" 2>/dev/null; then pass "$1"
+  else fail "$1" "$3 containing: $2" "$(flat "$(cat "$3" 2>/dev/null)")"; fi
   return 0
 }
 
@@ -164,14 +196,12 @@ want_absent() { # label needle haystack
 # `bash --noprofile --norc -e -o pipefail {0}`, but a step declaring nothing —
 # which is what ars.yml's steps do — gets `bash -e {0}`. No `--noprofile`, no
 # `--norc`, and **no pipefail**; measured off run 31960152598's own step header.
-# `-e` is what makes the errexit suppression inside the `&&` list observable at
-# all and is present either way, so this file's obligations are unaffected —
-# but supplying pipefail to a body production runs without is a FALSE GREEN in
-# the direction that matters: a pipeline whose left-hand command fails is
-# graded as an abort here and swallowed in CI. So the invocation is read out of
-# the workflow, and a step that later gains `shell: bash` moves this harness
-# with it. workflow-step.sh REFUSES rather than defaulting when it cannot find
-# the step, which is why this is a hard exit and not a fallback.
+# Supplying pipefail to a body production runs without is a FALSE GREEN in the
+# direction that matters: a pipeline whose left-hand command fails is graded as
+# an abort here and swallowed in CI. So the invocation is read out of the
+# workflow, and a step that later gains `shell: bash` moves this harness with
+# it. workflow-step.sh REFUSES rather than defaulting when it cannot find the
+# step, which is why this is a hard exit and not a fallback.
 #
 # Derived once per step, never once per file: the three steps are independent
 # declarations and any one of them could gain a `shell:` on its own.
@@ -190,570 +220,91 @@ derive_or_die() { # <step-name> -> sets DERIVED, or exits
 }
 use_shell() { read -r -a STEP_ARGV <<<"$1"; }
 
-derive_or_die "$STEP";         STEP_SHELL="$DERIVED"
 derive_or_die "$SCAN_STEP";    SCAN_SHELL="$DERIVED"
 derive_or_die "$EXTRACT_STEP"; EXTRACT_SHELL="$DERIVED"
-use_shell "$STEP_SHELL"
+derive_or_die "$GIST_STEP";    GIST_SHELL="$DERIVED"
 echo "== $WF: derived step invocations =="
-echo "   '$STEP' -> \`$STEP_SHELL\`"
 echo "   '$SCAN_STEP' -> \`$SCAN_SHELL\`"
 echo "   '$EXTRACT_STEP' -> \`$EXTRACT_SHELL\`"
+echo "   '$GIST_STEP' -> \`$GIST_SHELL\`"
 
 # ---------------------------------------------------------------------------
-# The harness: stubs, then a body, run under that shell.
+# The refusal vocabulary. Every refusal this job can print gets a needle, and
+# every arm that drives one asserts the other eight are ABSENT — a shared
+# non-zero is satisfied by refusals that all fire together, and by refusals
+# that all print the same sentence.
 #
-# `git` and `sleep` are shell FUNCTIONS rather than PATH shims so the body's
-# own lines survive byte-for-byte — in particular `sleep $((i * 3))`, which
-# would otherwise cost 45 wall-clock seconds per exhausted-retry case.
-# An unexpected git subcommand returns a loud, distinctive 99 instead of a
-# quiet 0: a stub that silently answered "fine" to a call it did not model
-# would make every arm below pass for a reason unrelated to its obligation.
-#
-# `rev-parse` answers a path that does not exist, which is this stub world's
-# only honest answer: its `pull` always succeeds, so no rebase is ever left in
-# progress here. `rebase` is deliberately left UNMODELLED — with rev-parse
-# answering "no rebase directory" the step must never reach `git rebase
-# --abort`, so a future edit that aborts unconditionally is reported by the
-# loud 99 rather than passing quietly. The case that genuinely needs a rebase
-# to exist is #1655's, and it runs against real git in a throwaway repo below.
-stub_prelude() { # $1 = attempt the push first succeeds on (99 = never)
-                 # $2 = status of `git diff --staged --quiet` (1 = changes staged)
-  cat <<STUB
-STUB_SUCCEED_ON=$1
-STUB_STAGED=$2
-STUB_PUSHES=0
-git() {
-  case "\$1" in
-    config|add|commit) return 0 ;;
-    diff)  return "\$STUB_STAGED" ;;
-    pull)  return 0 ;;
-    rev-parse) echo "./.stub-says-no-rebase-in-progress"; return 0 ;;
-    push)
-      STUB_PUSHES=\$((STUB_PUSHES + 1))
-      if [ "\$STUB_PUSHES" -ge "\$STUB_SUCCEED_ON" ]; then return 0; fi
-      return 1 ;;
-    *) echo "STUB: unmodelled call: git \$*" >&2; return 99 ;;
+# A `case` rather than nine `P_*` variables read through `${!v}`: an indirect
+# expansion of a key that does not exist yields the EMPTY string, and an empty
+# needle makes `want_absent` pass vacuously — so a typo in a key name would
+# have silently deleted an obligation. Here an unknown key is a loud refusal,
+# and the self-check below then proves the whole table is usable before any arm
+# runs. (shellcheck cannot see indirect reads either and flagged all nine as
+# unused, SC2034, which is how this was found.)
+REFUSALS='SCANFAIL NOBADGE NOURL NOTRIPLE ESCAPE NOSECRET NOGISTID NOPAYLOAD GISTFAIL'
+phrase() {
+  case "$1" in
+    SCANFAIL)  printf '%s' 'ARS scan FAILED' ;;
+    NOBADGE)   printf '%s' 'carries no img.shields.io/badge/ARS line' ;;
+    NOURL)     printf '%s' 'could be read out of it' ;;
+    NOTRIPLE)  printf '%s' 'does not split into a label, a message and a color' ;;
+    ESCAPE)    printf '%s' 'carries a percent-escape this step does not decode' ;;
+    NOSECRET)  printf '%s' 'GIST_SECRET is not set in repository secrets' ;;
+    NOGISTID)  printf '%s' 'COVERAGE_GIST_ID is not set in repository secrets' ;;
+    NOPAYLOAD) printf '%s' 'there is no ARS badge payload to publish' ;;
+    GISTFAIL)  printf '%s' 'the ARS badge gist update FAILED' ;;
+    *)         echo "FAIL: ars-badge-push_test — no refusal phrase for key '$1'" >&2; return 9 ;;
   esac
-}
-sleep() { :; }
-STUB
-}
-
-# run_body <file-with-body> <succeed-on> <staged-status> -> sets OUT / ST
-run_body() {
-  local body="$1" script="$TMP/step.sh"
-  { stub_prelude "$2" "$3"; cat "$body"; } >"$script"
-  # No `set +e` guard around this: THIS file runs under `set -uo pipefail` and
-  # deliberately not `-e`, so a non-zero inner status — which is the expected
-  # outcome of half the arms below — is data, not an abort. Toggling errexit
-  # here would leave it ON for the rest of the file, which is the
-  # option-you-cannot-see family the sibling issues (#1633, #1635) are made of.
-  OUT=$("${STEP_ARGV[@]}" "$script" 2>&1)
-  ST=$?
   return 0
 }
 
-# ---------------------------------------------------------------------------
-# Obligation 1 — the defect, re-measured on every run.
-#
-# The pre-#1641 loop, verbatim, wrapped in nothing. Committed here rather than
-# quoted in an issue, per AGENTS.md: "a number which documents behaviour but is
-# not produced by it drifts silently".
-echo "== the pre-#1641 loop shape (the defect, re-measured) =="
-cat >"$TMP/predecessor.sh" <<'OLD'
-git commit -m "chore: update ARS badge [skip ci]"
-for i in 1 2 3 4 5; do
-  git pull --rebase origin main && git push && break
-  echo "Push attempt $i failed, retrying..."
-  sleep $((i * 3))
-done
-OLD
-run_body "$TMP/predecessor.sh" 99 1
-if [[ "$ST" -eq 0 ]]; then
-  pass "the old loop still exits 0 after five failed pushes — the hazard is real"
-else
-  fail "the old loop exits 0 after five failed pushes (the hazard this pins)" \
-       "exit 0" "exit $ST — the hazard is GONE, so re-derive the fix rather than trusting it :: $(flat "$OUT")"
-fi
-want_contains "...having really exhausted all five attempts" "Push attempt 5 failed" "$OUT"
-
-# ---------------------------------------------------------------------------
-# Obligations 2-4 — the REAL step, extracted from the REAL workflow and run.
-echo ""
-echo "== $WF: $STEP =="
-
-if [[ ! -f "$WF" ]]; then
-  fail "$WF is readable" "the workflow file" "not found — the step check could not run"
-else
-  # Extract the named step's `run: |` body and dedent it — through the same
-  # library that derived the invocation above, so the shell this file grades
-  # under and the body it grades cannot come from two different steps. Keyed on
-  # the step NAME, so a body that moved within the file is still found and a
-  # step that was renamed is a loud refusal rather than a silent zero-line body.
-  if ! workflow_step_body "$WF" "$STEP" >"$TMP/step-body.sh"; then
-    fail "the '$STEP' step body was extracted from $WF" \
-         "the step's run: | body" "workflow-step refused (above) — the scan has gone blind, not the step clean"
-    : >"$TMP/step-body.sh"
-  fi
-
-  # The extraction has to have found something. A scan that silently stopped
-  # matching reads exactly like a workflow with no hazard in it, and every
-  # arm below would then grade an empty file — which exits 0 and looks like a
-  # clean push.
-  lines=$(grep -cve '^[[:space:]]*$' "$TMP/step-body.sh")
-  if [[ "${lines:-0}" -lt 5 ]]; then
-    fail "the '$STEP' step body was extracted from $WF" \
-         "at least 5 non-blank lines" "$lines — the scan has gone blind, not the step clean"
-  else
-    pass "extracted the '$STEP' step body from $WF ($lines non-blank lines)"
-
-    # Obligation 2: every attempt fails.
-    run_body "$TMP/step-body.sh" 99 1
-    want_status "every push attempt fails" 1 "$ST" "$OUT"
-    want_contains "...and the step says the badge was NOT pushed" "NOT pushed" "$OUT"
-    want_contains "...as a workflow error annotation, so it surfaces on the run" "::error::" "$OUT"
-    want_contains "...having really exhausted all five attempts" "Push attempt 5 failed" "$OUT"
-
-    # Obligation 3: the retry is still a retry. This is the arm that a "fix"
-    # dropping the loop — or removing the errexit suppression inside the `&&`
-    # list, which would abort at the first failed pull — cannot satisfy.
-    run_body "$TMP/step-body.sh" 3 1
-    want_status "a push that succeeds on the third attempt" 0 "$ST" "$OUT"
-    want_contains "...retried after the first failure" "Push attempt 1 failed" "$OUT"
-    want_contains "...and after the second" "Push attempt 2 failed" "$OUT"
-    want_absent "...without claiming the badge went unpushed" "NOT pushed" "$OUT"
-
-    # Obligation 4: the clean paths.
-    run_body "$TMP/step-body.sh" 1 1
-    want_status "a push that succeeds first time" 0 "$ST" "$OUT"
-    want_absent "...with no retry noise" "Push attempt" "$OUT"
-
-    run_body "$TMP/step-body.sh" 99 0
-    want_status "nothing staged to commit" 0 "$ST" "$OUT"
-    want_contains "...and it says so" "No badge changes to commit" "$OUT"
-
-    # `|| true` is the false fix for this family and is refused by name: it
-    # would let the loop end without aborting while leaving `true`'s status
-    # behind, so the exhausted case would read as 0 all over again (#1629
-    # measured the same thing one level down, on a `$?` capture).
-    #
-    # Full-line comments are stripped first, and that is not tidiness: the
-    # step's own comment EXPLAINS why `|| true` is not used, so a raw scan
-    # fails on the sentence saying the right thing. Measured — it did.
-    code=$(grep -v '^[[:space:]]*#' "$TMP/step-body.sh")
-    want_absent "the step does not reach for \`|| true\`" "|| true" "$code"
-    # ...and the strip must not have eaten the code, or the arm above is
-    # vacuous: an empty haystack contains no needle.
-    want_contains "...checked against the step's real code, not an empty strip" "git push" "$code"
-  fi
-fi
-
-# ---------------------------------------------------------------------------
-# #1655 — the retry that could not retry. Obligations 12-17.
-#
-# The stub above cannot reach this one, and that is the point rather than a
-# limitation to work around: its `git pull` returns a status and leaves no
-# state, where the whole defect is STATE. A `git pull --rebase` that fails
-# INSIDE the rebase — a conflict, not a rejected push — leaves the tree
-# mid-rebase, and every later `git pull` then refuses outright:
-#
-#     error: Pulling is not possible because you have unmerged files.
-#
-# So four of the five attempts could not run at all, while the step's closing
-# message attributed all five to the push. Measured on run 31963062408, whose
-# attempt 1 conflicted `add/add` on .github/workflows/ars.yml and whose
-# attempts 2-5 are verbatim identical refusals.
-#
-# Reachability is stated as the issue states it, and the distinction is kept:
-# the MECHANISM is measured (any failed rebase leaves the same wreckage — the
-# arms below reproduce it against real git), while "a push-to-main run can
-# reach it" is ASSUMED. That run was a `workflow_dispatch` on a branch, so its
-# ref differed from main; a badge run whose rebase conflicts on main (two runs
-# racing on the same README line, a README edit landing between checkout and
-# push) would burn attempts 2-5 the same way, but that has not been observed.
-# `actions/checkout@v7` here carries no `fetch-depth:`, i.e. a depth-1 clone,
-# which is why the rebase saw add/add rather than ordinary history — noted
-# because the fixture reproduces that shape, NOT changed: the depth is a
-# separate decision with its own cost.
-#
-# The obligations:
-#
-#  12. the defect is re-MEASURED against real git, not described: the pre-#1655
-#      loop, run in a throwaway repo rigged to conflict, reaches a clean tree
-#      on exactly ONE of its five attempts. The permanent vacuity guard for
-#      13-16 — if a future git stopped leaving the tree mid-rebase, they would
-#      all pass for the wrong reason.
-#  13. the real step, same fixture: all five attempts start from a clean tree,
-#      the loop really runs five times, and it still fails loudly — and its
-#      closing message names how many attempts were MADE rather than a fixed 5.
-#  14. the ordinary rejected push this loop exists for still works: rejected
-#      twice, retried, accepted on the third attempt, with the commit actually
-#      landing on origin. No rebase is involved anywhere in that path.
-#  15. the rejected SPELLING is committed beside the shipped one and
-#      re-measured: a `git rebase --abort` whose status is read but which never
-#      asks whether there is a rebase to abort turns 14 red, because "no rebase
-#      in progress" exits 128. It handles 12's fixture perfectly, so the
-#      ordinary-rejection fixture is the only one that tells the two apart.
-#  16. a first-attempt push in a real repo still lands, with no retry noise.
-#  17. the refusal the fix ADDS is reached and says the right thing: an abort
-#      that FAILS leaves the tree mid-rebase, so the remaining attempts are as
-#      doomed as they were before the fix — the step stops, names the abort as
-#      what could not be done, and reports how many attempts were made. This is
-#      the one arm with no "before the fix" to be red against, so it carries an
-#      injected mutation instead (see attempt_prelude).
-#
-# What is NOT re-measured here is the `|| true` spelling the issue names
-# first. It is refused one level up, by name, by the arm above
-# (`the step does not reach for \`|| true\``) — the same refusal #1629 and
-# #1644 earned — so a body that discards the abort's status does not compile
-# past this file, and a variant demonstrating it would need a rebase that
-# cannot be aborted, which no portable fixture produces.
-
-echo ""
-echo "== $WF: $STEP — the retry that could not retry (#1655) =="
-
-# The fixture's git runs with the developer's own configuration out of the way.
-# A global `pull.rebase`, `commit.gpgsign`, `core.hooksPath` or
-# `init.defaultBranch` would otherwise decide what these repos do, and these
-# arms assert on the CONFLICT rather than on whoever's ~/.gitconfig ran them.
-# HOME is redirected as well, for a git predating GIT_CONFIG_GLOBAL — and
-# because nothing here may read or write the real one.
-FIXTURE_HOME="$TMP/fixture-home"
-NO_GITCONFIG="$TMP/fixture-gitconfig-that-does-not-exist"
-mkdir -p "$FIXTURE_HOME" || { echo "FAIL: ars-badge-push_test — cannot create $FIXTURE_HOME" >&2; exit 1; }
-fgit() {
-  env HOME="$FIXTURE_HOME" GIT_CONFIG_NOSYSTEM=1 \
-      GIT_CONFIG_GLOBAL="$NO_GITCONFIG" GIT_CONFIG_SYSTEM="$NO_GITCONFIG" \
-      GIT_TERMINAL_PROMPT=0 git "$@"
+want_only() { # <fired-key> <output>
+  local fired="$1" out="$2" k
+  want_contains "...naming $fired specifically" "$(phrase "$fired")" "$out"
+  for k in $REFUSALS; do
+    [[ "$k" == "$fired" ]] && continue
+    want_absent "...and not confused with $k" "$(phrase "$k")" "$out"
+  done
+  return 0
 }
-
-# fixture_build <dir> <kind> [reject-n]
-#
-# A bare `origin.git` reachable only by filesystem path — nothing here fetches
-# from, pushes to or otherwise contacts the real origin — plus a `work/` clone
-# holding an uncommitted README.md, which is what the step's `git add README.md`
-# stages.
-#
-#   conflict : origin/main and the badge commit each ADD README.md, so
-#              `git pull --rebase origin main` conflicts add/add — the shape
-#              run 31963062408 hit, reproduced here without its depth-1 clone.
-#   reject   : no divergence at all. origin's pre-receive hook declines the
-#              first <reject-n> pushes, which is the ordinary race the retry
-#              loop exists for: the branch is not behind, `git pull --rebase`
-#              is a no-op, and NOTHING is left mid-rebase.
-fixture_build() {
-  local dir="$1" kind="$2" rejects="${3:-0}" origin="$1/origin.git"
-  rm -rf "$dir" || return 1
-  mkdir -p "$dir" || return 1
-  fgit init -q --bare "$origin" >/dev/null 2>&1 || return 1
-  # `git init -b main` is git >= 2.28; the symbolic-ref spelling is not, and a
-  # harness that refused on an older git would be reporting its own age as the
-  # step's defect.
-  fgit -C "$origin" symbolic-ref HEAD refs/heads/main >/dev/null 2>&1 || return 1
-  fgit clone -q "$origin" "$dir/seed" >/dev/null 2>&1 || return 1
-  (
-    cd "$dir/seed" || exit 1
-    fgit config user.name fixture || exit 1
-    fgit config user.email fixture@example.invalid || exit 1
-    printf 'seed\n' >seed.txt || exit 1
-    fgit add seed.txt && fgit commit -qm "seed" && fgit push -q origin main
-  ) >/dev/null 2>&1 || return 1
-
-  if [[ "$kind" == conflict ]]; then
-    # work/ is cloned BEFORE origin gains its README.md, so the two adds are
-    # genuinely concurrent.
-    fgit clone -q "$origin" "$dir/work" >/dev/null 2>&1 || return 1
-    (
-      cd "$dir/seed" || exit 1
-      fgit pull -q --rebase origin main || exit 1
-      printf 'ARS badge, as origin already has it\n' >README.md || exit 1
-      fgit add README.md && fgit commit -qm "someone else's README" && fgit push -q origin main
-    ) >/dev/null 2>&1 || return 1
-  else
-    if [[ "$rejects" -gt 0 ]]; then
-      cat >"$origin/hooks/pre-receive" <<HOOK || return 1
-#!/bin/sh
-n=0
-[ -f "\$GIT_DIR/reject-count" ] && n=\$(cat "\$GIT_DIR/reject-count")
-n=\$((n + 1))
-printf '%s\n' "\$n" >"\$GIT_DIR/reject-count"
-if [ "\$n" -le $rejects ]; then
-  echo "fixture: simulated concurrent update to main, try again" >&2
-  exit 1
-fi
-exit 0
-HOOK
-      chmod +x "$origin/hooks/pre-receive" || return 1
-    fi
-    fgit clone -q "$origin" "$dir/work" >/dev/null 2>&1 || return 1
-  fi
-
-  (
-    cd "$dir/work" || exit 1
-    fgit config user.name fixture && fgit config user.email fixture@example.invalid
-  ) >/dev/null 2>&1 || return 1
-  printf 'ARS badge, as this run computed it\n' >"$dir/work/README.md" || return 1
+want_no_refusal() { # <label> <output>
+  local out="$2" k found=""
+  for k in $REFUSALS; do
+    case "$out" in *"$(phrase "$k")"*) found="$k" ;; esac
+  done
+  if [[ -z "$found" ]]; then pass "$1"; else fail "$1" "no refusal wording" "it printed $found's :: $(flat "$out")"; fi
   return 0
 }
 
-# The instrumentation. `git` cannot be stubbed here — the whole subject is what
-# real git leaves on disk — so exactly one thing is observed: at the moment
-# each attempt reaches `git pull`, was the tree mid-rebase? That is the
-# property the issue is about (attempt N+1 starting from the state attempt N
-# did) and it is read off git's OWN rebase state rather than off the
-# "Pulling is not possible…" message, which git is free to reword.
-#
-# The optional second argument is the one deliberate mutation this section
-# injects rather than builds: `git rebase --abort` answering non-zero. The
-# refusal it drives (obligation 17) is something the fix ADDS, so it has no
-# "before the fix" to be seen red against, and a rebase that genuinely cannot
-# be aborted has no portable fixture — a read-only `.git` behaves differently
-# per filesystem and is root-dependent. Everything else still runs against real
-# git; only the abort's answer is replaced.
-attempt_prelude() { # <log-file> [break-abort]
-  local log="$1" brk=""
-  if [[ "${2:-}" == break-abort ]]; then
-    brk='  if [ "$1" = rebase ]; then echo "fixture: abort refused" >&2; return 1; fi'
-  fi
-  cat <<PRELUDE
-git() {
-  if [ "\$1" = pull ]; then
-    if [ -d "\$(command git rev-parse --git-path rebase-merge 2>/dev/null)" ] ||
-       [ -d "\$(command git rev-parse --git-path rebase-apply 2>/dev/null)" ]; then
-      echo mid-rebase >>"$log"
-    else
-      echo clean >>"$log"
-    fi
-  fi
-$brk
-  command git "\$@"
-}
-sleep() { :; }
-PRELUDE
-}
-
-# run_in_repo <fixture-dir> <body-file> [break-abort]
-#   -> sets OUT / ST / PULLS / CLEAN_STARTS
-run_in_repo() {
-  local dir="$1" body="$2" log="$1/.attempts" script="$1/.step.sh"
-  : >"$log"
-  { attempt_prelude "$log" "${3:-}"; cat "$body"; } >"$script"
-  use_shell "$STEP_SHELL"
-  # Same reasoning as run_body: no `set +e` toggle, a non-zero inner status is
-  # data. The counts are read with awk rather than `grep -c`, which exits 1 on
-  # no match and would need an `|| …` that can append a second line to the
-  # capture.
-  OUT=$(cd "$dir/work" && env HOME="$FIXTURE_HOME" GIT_CONFIG_NOSYSTEM=1 \
-        GIT_CONFIG_GLOBAL="$NO_GITCONFIG" GIT_CONFIG_SYSTEM="$NO_GITCONFIG" \
-        GIT_TERMINAL_PROMPT=0 "${STEP_ARGV[@]}" "$script" 2>&1)
-  ST=$?
-  PULLS=$(awk 'END{print NR+0}' "$log")
-  CLEAN_STARTS=$(awk '$0=="clean"{n++} END{print n+0}' "$log")
-  return 0
-}
-
-want_starts() { # label want-clean want-pulls
-  if [[ "$CLEAN_STARTS" == "$2" && "$PULLS" == "$3" ]]; then
-    pass "$1 ($CLEAN_STARTS of $PULLS attempts started from a clean tree)"
-  else
-    fail "$1" "$2 clean start(s) out of $3 pulls" \
-         "$CLEAN_STARTS of $PULLS :: $(flat "$OUT")"
-  fi
-  return 0
-}
-
-# The committed predecessor: today's loop, verbatim, with no abort anywhere.
-cat >"$TMP/pre1655.sh" <<'OLD'
-git config user.name "github-actions[bot]"
-git config user.email "github-actions[bot]@users.noreply.github.com"
-git add README.md
-git commit -m "chore: update ARS badge [skip ci]"
-pushed=0
-for i in 1 2 3 4 5; do
-  if git pull --rebase origin main && git push; then pushed=1; break; fi
-  echo "Push attempt $i failed, retrying..."
-  sleep $((i * 3))
-done
-if [ "$pushed" -ne 1 ]; then
-  echo "::error::ARS badge was NOT pushed: all 5 attempts failed."
-  exit 1
-fi
-OLD
-
-# The rejected SPELLING, committed beside the one that shipped rather than
-# described in a PR body: a `git rebase --abort` whose status IS read, placed
-# after each failed attempt, which never asks whether there is a rebase to
-# abort. It is the reading of the issue's second suggestion a careful person
-# actually writes, and `git rebase --abort` with no rebase in progress exits
-# 128 — so every healthy retry becomes a reported failure.
-cat >"$TMP/naive1655.sh" <<'NAIVE'
-git config user.name "github-actions[bot]"
-git config user.email "github-actions[bot]@users.noreply.github.com"
-git add README.md
-git commit -m "chore: update ARS badge [skip ci]"
-pushed=0
-for i in 1 2 3 4 5; do
-  if git pull --rebase origin main && git push; then pushed=1; break; fi
-  echo "Push attempt $i failed, retrying..."
-  if ! git rebase --abort; then
-    echo "::error::naive spelling: attempt $i's rebase could not be aborted."
+# The table has to be USABLE before anything is graded through it, and the
+# property it exists for has to hold STRUCTURALLY rather than case by case: an
+# empty needle passes every `want_absent` vacuously, and a needle that is a
+# substring of another refusal's makes `want_only` unsatisfiable for one of the
+# pair no matter how the workflow is written. Both are the "a verification
+# mechanism must fail loudly when it cannot run" rule, and neither is visible
+# from an arm.
+for k in $REFUSALS; do
+  kp=$(phrase "$k") || { echo "FAIL: ars-badge-push_test — refusal key '$k' has no phrase" >&2; exit 1; }
+  if [[ -z "$kp" ]]; then
+    echo "FAIL: ars-badge-push_test — refusal key '$k' maps to an EMPTY phrase; every want_absent on it would pass vacuously" >&2
     exit 1
   fi
-  sleep $((i * 3))
+  for j in $REFUSALS; do
+    [[ "$j" == "$k" ]] && continue
+    jp=$(phrase "$j")
+    case "$jp" in
+      *"$kp"*)
+        echo "FAIL: ars-badge-push_test — $k's needle [$kp] is a substring of $j's [$jp]; the two refusals cannot be told apart" >&2
+        exit 1 ;;
+    esac
+  done
 done
-if [ "$pushed" -ne 1 ]; then
-  echo "::error::ARS badge was NOT pushed: all 5 attempts failed."
-  exit 1
-fi
-NAIVE
-
-# The refusal. If the fixture does not actually conflict, every arm below
-# grades a program that never met the defect — a run that "found nothing" and
-# a run that could not look must not print the same thing. Probed on its OWN
-# fixture instance, because probing consumes the tree it leaves mid-rebase.
-fixture_conflicts() { # <dir>
-  (
-    cd "$1/work" || exit 1
-    fgit add README.md >/dev/null 2>&1 || exit 1
-    fgit commit -qm "chore: update ARS badge [skip ci]" >/dev/null 2>&1 || exit 1
-    fgit pull --rebase origin main >/dev/null 2>&1 && exit 1
-    [ -d "$(fgit rev-parse --git-path rebase-merge)" ] ||
-      [ -d "$(fgit rev-parse --git-path rebase-apply)" ]
-  )
-}
-
-if [[ ! -s "$TMP/step-body.sh" ]]; then
-  fail "the '$STEP' step body is available for the #1655 arms" \
-       "the extracted body" "empty or missing — the extraction above refused, so these arms would grade nothing"
-elif ! fixture_build "$TMP/fix-probe" conflict; then
-  fail "the #1655 conflict fixture could be built" \
-       "a throwaway origin.git + work clone under $TMP" \
-       "fixture_build failed — these arms cannot run, and a skip here would read as a pass"
-elif ! fixture_conflicts "$TMP/fix-probe"; then
-  fail "the #1655 conflict fixture produces a rebase that really conflicts" \
-       "\`git pull --rebase origin main\` failing and leaving a rebase in progress" \
-       "it did not — this git no longer reproduces the defect's precondition, so nothing below would be graded"
-else
-  pass "the #1655 conflict fixture leaves a real rebase in progress ($(fgit --version))"
-
-  # Obligation 12 — the defect, re-measured against real git.
-  if ! fixture_build "$TMP/fix-old" conflict; then
-    fail "a fresh conflict fixture for the pre-#1655 loop" "a built fixture" "fixture_build failed"
-  else
-    run_in_repo "$TMP/fix-old" "$TMP/pre1655.sh"
-    want_starts "the pre-#1655 loop reaches a clean tree on exactly 1 of its 5 attempts — the hazard is real" 1 5
-    want_status "...and still fails, for a cause four attempts never tested" 1 "$ST" "$OUT"
-  fi
-
-  # Obligation 13 — the real step, same fixture.
-  if ! fixture_build "$TMP/fix-new" conflict; then
-    fail "a fresh conflict fixture for the real step" "a built fixture" "fixture_build failed"
-  else
-    run_in_repo "$TMP/fix-new" "$TMP/step-body.sh"
-    want_starts "every one of the 5 attempts starts from a clean tree" 5 5
-    want_status "...and a rebase that keeps conflicting still fails the step" 1 "$ST" "$OUT"
-    want_contains "...as a workflow error annotation" "::error::" "$OUT"
-    want_contains "...saying the badge was NOT pushed" "NOT pushed" "$OUT"
-    want_contains "...having really reached the fifth attempt" "Push attempt 5 failed" "$OUT"
-    want_contains "...and reporting that it undid each conflicted rebase" "unfinished rebase was in progress" "$OUT"
-    # The issue's closing line: "all 5 attempts failed" is only true if all 5
-    # were attempted. The count is DERIVED from the loop rather than typed, so
-    # the sentence cannot outrun the facts; the needle here is the measurement
-    # this run just took, not a literal.
-    want_contains "...naming the number of attempts actually made, not a fixed 5" "$PULLS of 5" "$OUT"
-    origin_head=$(fgit -C "$TMP/fix-new/origin.git" log --oneline -1 2>&1)
-    want_absent "...and origin/main really did not get the badge commit" "update ARS badge" "$origin_head"
-  fi
-
-  # Obligation 14 — the ordinary rejected push the loop exists for. THE arm a
-  # status-reading abort with no in-progress check turns red (obligation 15).
-  if ! fixture_build "$TMP/fix-race" reject 2; then
-    fail "a rejected-push fixture for the real step" "a built fixture" "fixture_build failed"
-  else
-    run_in_repo "$TMP/fix-race" "$TMP/step-body.sh"
-    want_status "a push rejected twice, no rebase anywhere, succeeds on the third attempt" 0 "$ST" "$OUT"
-    want_starts "...all three attempts having started from a clean tree" 3 3
-    want_contains "...retried after the first rejection" "Push attempt 1 failed" "$OUT"
-    want_contains "...and after the second" "Push attempt 2 failed" "$OUT"
-    want_absent "...with no error annotation" "::error::" "$OUT"
-    want_absent "...and no claim that the badge went unpushed" "NOT pushed" "$OUT"
-    origin_head=$(fgit -C "$TMP/fix-race/origin.git" log --oneline -1 2>&1)
-    want_contains "...the badge commit having really landed on origin/main" "update ARS badge" "$origin_head"
-  fi
-
-  # Obligation 15 — the rejected spelling, committed and re-measured.
-  if ! fixture_build "$TMP/fix-naive-race" reject 2; then
-    fail "a rejected-push fixture for the naive spelling" "a built fixture" "fixture_build failed"
-  else
-    run_in_repo "$TMP/fix-naive-race" "$TMP/naive1655.sh"
-    if [[ "$ST" -ne 0 ]]; then
-      pass "an unguarded \`git rebase --abort\` breaks the ordinary rejected push (exit $ST) — why the step asks first"
-    else
-      fail "an unguarded \`git rebase --abort\` breaks the ordinary rejected push (the reason the shipped spelling asks whether a rebase is in progress)" \
-           "a non-zero exit" "exit 0 — that spelling is no longer distinguishable from the shipped one, so re-derive the choice :: $(flat "$OUT")"
-    fi
-    want_contains "...giving up on the very first retry, on an abort that had nothing to abort" \
-                  "naive spelling: attempt 1's rebase could not be aborted" "$OUT"
-  fi
-  if ! fixture_build "$TMP/fix-naive-conflict" conflict; then
-    fail "a conflict fixture for the naive spelling" "a built fixture" "fixture_build failed"
-  else
-    # ...and it handles the CONFLICT fixture perfectly. Without this, the
-    # obligation above reads as "that spelling is broken", when what is true is
-    # narrower and is the whole reason 14 exists: the two spellings are
-    # indistinguishable on the fixture the issue was reported from.
-    run_in_repo "$TMP/fix-naive-conflict" "$TMP/naive1655.sh"
-    want_starts "the naive spelling is indistinguishable from the shipped one on a CONFLICTING fixture" 5 5
-  fi
-
-  # Obligation 17 — the refusal the fix ADDS, and its only coverage. An abort
-  # that fails is the one case where asking first is not enough: the tree is
-  # still mid-rebase, so the remaining attempts are exactly as doomed as they
-  # were before the fix. The step must stop and say so rather than burn them.
-  if ! fixture_build "$TMP/fix-stuck" conflict; then
-    fail "a conflict fixture for the unabortable rebase" "a built fixture" "fixture_build failed"
-  else
-    run_in_repo "$TMP/fix-stuck" "$TMP/step-body.sh" break-abort
-    want_status "a rebase that cannot be aborted fails the step" 1 "$ST" "$OUT"
-    want_contains "...as a workflow error annotation" "::error::" "$OUT"
-    want_contains "...naming the abort as what could not be done" "could not undo it" "$OUT"
-    want_contains "...and saying how many attempts were made, not claiming 5" "Only 1 of 5" "$OUT"
-    want_starts "...having stopped instead of burning the remaining attempts" 1 1
-  fi
-
-  # Obligation 16 — the clean path, in a real repo.
-  if ! fixture_build "$TMP/fix-clean" reject 0; then
-    fail "a clean fixture for the real step" "a built fixture" "fixture_build failed"
-  else
-    run_in_repo "$TMP/fix-clean" "$TMP/step-body.sh"
-    want_status "a first-attempt push in a real repo" 0 "$ST" "$OUT"
-    want_starts "...having pulled exactly once" 1 1
-    want_absent "...with no retry noise" "Push attempt" "$OUT"
-    origin_head=$(fgit -C "$TMP/fix-clean/origin.git" log --oneline -1 2>&1)
-    want_contains "...and the badge commit on origin/main" "update ARS badge" "$origin_head"
-  fi
-fi
+pass "the $(printf '%s\n' $REFUSALS | wc -l | tr -d ' ') refusal needles are non-empty and pairwise distinguishable"
 
 # ---------------------------------------------------------------------------
-# #1644 — the two steps that PRODUCE the badge "Commit badge update" pushes.
-#
-# Every case runs in a throwaway directory holding exactly what the runner's
-# workspace holds at that point (an `ars-output.txt`, a `README.md`), so the
-# repo's real README.md is never written to. The one arm that grades the real
-# README COPIES it in — that arm is the reason `sed`'s pattern is checked
-# against the file it actually has to match rather than against a fixture
-# written to match it.
-
-want_file_contains() { # label needle file
-  if grep -qF "$2" "$3" 2>/dev/null; then pass "$1"
-  else fail "$1" "$3 containing: $2" "$(flat "$(cat "$3" 2>/dev/null)")"; fi
-  return 0
-}
-want_file_absent() { # label needle file
-  if grep -qF "$2" "$3" 2>/dev/null; then fail "$1" "$3 NOT containing: $2" "$(flat "$(cat "$3" 2>/dev/null)")"
-  else pass "$1"; fi
-  return 0
-}
+# The harness: a case directory holding exactly what the runner's workspace
+# holds at that point, a prelude of stubs, then a step body run under the shell
+# that step actually gets. The repo's own tree is never written to.
 
 # The `ars` stub prints ./.ars-stdout and returns the status it was built with.
 # A subcommand it does not model answers a loud, distinctive 99 naming the call,
@@ -771,45 +322,62 @@ ars() {
 STUB
 }
 
-# GNU vs BSD `sed -i`. ars.yml runs on ubuntu-latest, where `-i` takes no
-# argument; this harness runs wherever the shell-lib suite runs, which includes
-# test.yml's macos-latest runner and every developer's Mac, where BSD sed reads
-# the SCRIPT as `-i`'s backup suffix. Measured on this machine:
-# `sed -i "s|a|b|g" f` -> `sed: 1: "…": invalid command code f`, file unchanged.
-# So `-i` is re-expressed portably over the REAL sed, preserving the script
-# semantics this file grades — in particular that a script matching nothing
-# rewrites the file with identical bytes and exits 0, which is obligation 11's
-# whole subject. Any other `-i` form is a loud refusal, not a quiet 0.
-sed_shim() {
-  cat <<'STUB'
-sed() {
-  if [ "$1" = "-i" ]; then
-    if [ "$#" -ne 3 ]; then echo "STUB: unmodelled sed -i form: sed $*" >&2; return 99; fi
-    command sed "$2" "$3" >"$3.stub.new" || return $?
-    command mv "$3.stub.new" "$3" || return $?
-    return 0
-  fi
-  command sed "$@"
+# The `curl` stub. This is the ONLY thing standing between this file and a
+# write to the live badges gist — the one the README's Coverage and CodeScene
+# badges render from right now — so it is a shell FUNCTION shadowing the real
+# binary rather than a PATH shim that a body could route around, and it
+# records every call it received. `.curl-calls` existing at all is the witness
+# that the request was attempted; its ABSENCE is what the refusal arms assert,
+# because "the step refused" and "the step published and we did not look" are
+# otherwise the same output.
+curl_stub() { # $1 = http code printed, $2 = exit status, $3 = response body
+  cat <<STUB
+curl() {
+  printf '%s\n' "\$*" >>./.curl-calls
+  _co_out=""
+  _co_prev=""
+  for _co_a in "\$@"; do
+    if [ "\$_co_prev" = "-o" ]; then _co_out="\$_co_a"; fi
+    _co_prev="\$_co_a"
+  done
+  if [ -n "\$_co_out" ]; then printf '%s' '$3' >"\$_co_out"; fi
+  printf '%s' '$1'
+  return $2
 }
 STUB
 }
 
 CASE=
-new_case() { # <name> -> sets CASE to a fresh, empty directory
+new_case() { # <name> -> sets CASE to a fresh, empty directory with an empty prelude
   CASE="$TMP/case-$1"
   rm -rf "$CASE"
   mkdir -p "$CASE" || { echo "FAIL: ars-badge-push_test — cannot create case dir $CASE" >&2; exit 1; }
-  { ars_stub "${2:-0}"; sed_shim; } >"$CASE/.prelude"
+  : >"$CASE/.prelude"
 }
+with_ars()  { ars_stub "$1" >>"$CASE/.prelude"; }
+with_curl() { curl_stub "$1" "$2" "$3" >>"$CASE/.prelude"; }
 
-run_step() { # <workdir> <shell-string> <body-file> -> sets OUT / ST
+run_step() { # <workdir> <shell-string> <body-file> [VAR=value ...] -> sets OUT / ST
   local dir="$1" body="$3" script="$1/.step.sh"
   use_shell "$2"
   { cat "$dir/.prelude"; cat "$body"; } >"$script"
-  # Same reasoning as run_body: no `set +e` toggle, because a non-zero inner
-  # status is the EXPECTED outcome of most arms here and is data, not an abort.
-  OUT=$(cd "$dir" && "${STEP_ARGV[@]}" .step.sh 2>&1)
+  shift 3
+  # No `set +e` guard: THIS file runs under `set -uo pipefail` and deliberately
+  # not `-e`, so a non-zero inner status — the expected outcome of most arms
+  # below — is data, not an abort. Toggling errexit here would leave it ON for
+  # the rest of the file, which is the option-you-cannot-see family the sibling
+  # issues (#1633, #1635) are made of.
+  OUT=$(cd "$dir" && env "$@" "${STEP_ARGV[@]}" .step.sh 2>&1)
   ST=$?
+  return 0
+}
+
+want_no_request() { # <label>
+  if [[ -e "$CASE/.curl-calls" ]]; then
+    fail "$1" "no request to the gist API" "the stub recorded: $(flat "$(cat "$CASE/.curl-calls")")"
+  else
+    pass "$1"
+  fi
   return 0
 }
 
@@ -830,51 +398,89 @@ extract_body() { # <step-name> <min-non-blank-lines> <outfile> -> 0 on success
   return 0
 }
 
-# The four refusals must be told apart by their WORDING, not only by a shared
-# non-zero. Three refusals printing the same sentence would satisfy every
-# status arm below and leave an operator exactly where the silent `if` skips
-# left them: something is red, and no idea which thing broke.
-P_SCANFAIL='ARS scan FAILED'
-P_NOBADGE='carries no img.shields.io/badge/ARS line'
-P_NOURL='could be read out of it'
-P_NOWRITE='does not contain the badge URL this step just wrote'
-
 SCAN_ERR='ars: command failed: no such subcommand'
 NEW_URL='https://img.shields.io/badge/ARS-Agent--Ready%209.9%2F10-brightgreen'
+NEW_JSON='{"schemaVersion":1,"label":"ARS","message":"Agent-Ready 9.9/10","color":"brightgreen"}'
+GIST_ID='stubgistid0123456789abcdef'
 badge_output() { # <url> -> a plausible `ars scan --badge` tail
   printf 'Badge\n----------------------------------------\n[![ARS](%s)](https://github.com/ingo-eichhorst/agent-readyness)\n' "$1"
 }
 
-# The real README is read, not assumed: if it carries no ARS badge URL there is
-# nothing for this workflow to rewrite, and obligations 8 and 5 would both be
-# grading a fixture written to match the pattern under test.
-OLD_URL=$(grep -o 'https://img\.shields\.io/badge/ARS[^)]*' README.md | head -1 || echo "")
-
+# ---------------------------------------------------------------------------
+# A1 / A2 / A3 — the "Run ARS scan" step. Unchanged by #1654 except for one
+# sentence of its refusal, which used to claim README.md was not updated and
+# now names the gist.
 echo ""
-echo "== $WF: $SCAN_STEP / $EXTRACT_STEP =="
+echo "== $WF: $SCAN_STEP =="
 
-if [[ -z "$OLD_URL" ]]; then
-  fail "README.md carries an ARS badge URL for the badge job to rewrite" \
-       "one https://img.shields.io/badge/ARS-… URL in README.md" \
-       "none — either the badge was removed (this job then has nothing to do and should say so) or this scan has gone blind"
-elif [[ "$OLD_URL" == "$NEW_URL" ]]; then
-  fail "the fixture score differs from README's, or the rewrite arm is vacuous" \
-       "a NEW_URL unlike README's current badge" "both are $OLD_URL"
-else
-  pass "read README.md's current badge URL ($OLD_URL)"
-
-  # -------------------------------------------------------------------------
-  # Obligation 5 — the pre-#1644 bodies, verbatim, re-measured on every run.
-  #
-  # Committed rather than quoted in the issue, per AGENTS.md: "a number which
-  # documents behaviour but is not produced by it drifts silently". This is
-  # also the vacuity guard for 6-11: if `|| true` + a trailing `cat` ever
-  # stopped exiting 0, the fix would be protecting nothing.
-  cat >"$TMP/pre1644-scan.sh" <<'OLD'
+# The pre-#1644 body, verbatim. Committed here rather than quoted in an issue,
+# per AGENTS.md: "a number which documents behaviour but is not produced by it
+# drifts silently".
+cat >"$TMP/pre1644-scan.sh" <<'OLD'
 ars scan ./core --no-llm --badge > ars-output.txt 2>&1 || true
 cat ars-output.txt
 OLD
-  cat >"$TMP/pre1644-extract.sh" <<'OLD'
+
+new_case pre1644-scan
+with_ars 1
+printf '%s\n' "$SCAN_ERR" >"$CASE/.ars-stdout"
+run_step "$CASE" "$SCAN_SHELL" "$TMP/pre1644-scan.sh"
+if [[ "$ST" -eq 0 ]]; then
+  pass "A1: the old scan body still exits 0 with a failing \`ars\` — the hazard is real"
+else
+  fail "A1: the old scan body exits 0 with a failing \`ars\` (the hazard this pins)" \
+       "exit 0" "exit $ST — the hazard is GONE, so re-derive the fix rather than trusting it :: $(flat "$OUT")"
+fi
+
+# A floor of 2, not of "however many lines the fixed step has": the pre-#1644
+# body was two lines, so a higher floor would report the mutation that RESTORES
+# it as "the scan has gone blind" rather than as A2 going red — a negative
+# result for the wrong reason reads as coverage it is not.
+if extract_body "$SCAN_STEP" 2 "$TMP/scan-body.sh"; then
+  new_case scanfail
+  with_ars 3
+  printf '%s\n' "$SCAN_ERR" >"$CASE/.ars-stdout"
+  run_step "$CASE" "$SCAN_SHELL" "$TMP/scan-body.sh"
+  want_nonzero "A2: a failing \`ars scan\` fails the step" "$ST" "$OUT"
+  want_contains "...as a workflow error annotation, so it surfaces on the run" "::error::" "$OUT"
+  want_only SCANFAIL "$OUT"
+  want_contains "...and that the badge was therefore not updated" "NOT updated" "$OUT"
+  # Without this the failure has no diagnosis anywhere: `ars`'s own message is
+  # redirected into the file, so a step that exits 1 without printing it is a
+  # red X over an empty log.
+  want_contains "...with the scan's own output still in the log" "$SCAN_ERR" "$OUT"
+
+  new_case scanok
+  with_ars 0
+  badge_output "$NEW_URL" >"$CASE/.ars-stdout"
+  run_step "$CASE" "$SCAN_SHELL" "$TMP/scan-body.sh"
+  want_status "A3: a succeeding \`ars scan\` still passes" 0 "$ST" "$OUT"
+  want_no_refusal "...with no refusal wording anywhere" "$OUT"
+  want_file_contains "...having captured the scan output for the next step" "$NEW_URL" "$CASE/ars-output.txt"
+
+  # `|| true` is the false fix for this family and is refused by name — it is
+  # what the step used to carry. Full-line comments are stripped first, and
+  # that is not tidiness: the step's prose EXPLAINS why it is not used, so a
+  # raw scan fails on the sentence saying the right thing. Measured — it did.
+  code=$(grep -v '^[[:space:]]*#' "$TMP/scan-body.sh")
+  want_absent "the scan step does not reach for \`|| true\`" "|| true" "$code"
+  want_contains "...checked against the step's real code, not an empty strip" "ars scan" "$code"
+fi
+
+# ---------------------------------------------------------------------------
+# B1-B6 — the "Extract ARS badge" step. Before #1654 this step `sed -i`'d the
+# score into README.md; it now builds the shields.io endpoint payload the gist
+# step publishes. The obligations are #1644's, adapted: same three-outcomes
+# discipline, a different artifact, plus the two refusals the decode adds.
+echo ""
+echo "== $WF: $EXTRACT_STEP =="
+
+# The pre-#1644 extract body, verbatim. Only its silent-SKIP path is reachable
+# here (an ars-output.txt with no badge in it), and that is the whole hazard:
+# `if [ -n "$ARS_BADGE" ]` with no `else` answered "I could not look" with the
+# same bytes as "there was nothing to do". Its README-rewriting half went with
+# the mechanism #1654 deleted and is not replayed.
+cat >"$TMP/pre1644-extract.sh" <<'OLD'
 ARS_BADGE=$(grep "img.shields.io/badge/ARS" ars-output.txt | head -1 || echo "")
 echo "ARS Badge line: $ARS_BADGE"
 
@@ -888,144 +494,246 @@ if [ -n "$ARS_BADGE" ]; then
 fi
 OLD
 
-  echo ""
-  echo "-- the pre-#1644 bodies (the defect, re-measured) --"
-  new_case pre1644 1
-  printf '%s\n' "$SCAN_ERR" >"$CASE/.ars-stdout"
-  cp README.md "$CASE/README.md"
-  run_step "$CASE" "$SCAN_SHELL" "$TMP/pre1644-scan.sh"
-  if [[ "$ST" -eq 0 ]]; then
-    pass "the old scan body still exits 0 with a failing \`ars\` — the hazard is real"
+new_case pre1644-extract
+printf '%s\n' "$SCAN_ERR" >"$CASE/ars-output.txt"
+run_step "$CASE" "$EXTRACT_SHELL" "$TMP/pre1644-extract.sh"
+want_status "B1: the old extract body over an error output still exits 0 — the hazard is real" 0 "$ST" "$OUT"
+want_no_refusal "...and says nothing about it" "$OUT"
+
+if extract_body "$EXTRACT_STEP" 8 "$TMP/extract-body.sh"; then
+  # B2, the vacuity guard for B3-B6: a fix that refuses everything is
+  # indistinguishable from one that works until something still works.
+  new_case extractok
+  badge_output "$NEW_URL" >"$CASE/ars-output.txt"
+  run_step "$CASE" "$EXTRACT_SHELL" "$TMP/extract-body.sh"
+  want_status "B2: a normal run still produces a badge payload" 0 "$ST" "$OUT"
+  want_no_refusal "...with no refusal wording anywhere" "$OUT"
+  if [[ -s "$CASE/ars-badge.json" ]]; then
+    pass "...having written ars-badge.json"
+    built=$(jq -Sc . "$CASE/ars-badge.json" 2>&1)
+    wanted=$(printf '%s' "$NEW_JSON" | jq -Sc . 2>&1)
+    if [[ "$built" == "$wanted" ]]; then
+      pass "...as the shields.io endpoint payload for the scanned score ($built)"
+    else
+      fail "the payload is the endpoint schema for the scanned score" "$wanted" "$built"
+    fi
   else
-    fail "the old scan body exits 0 with a failing \`ars\` (the hazard this pins)" \
-         "exit 0" "exit $ST — the hazard is GONE, so re-derive the fix rather than trusting it :: $(flat "$OUT")"
+    fail "B2: a normal run still produces a badge payload" "a non-empty ars-badge.json" "missing or empty :: $(flat "$OUT")"
   fi
-  run_step "$CASE" "$EXTRACT_SHELL" "$TMP/pre1644-extract.sh"
-  want_status "...and the old extract body over that error output" 0 "$ST" "$OUT"
-  want_file_contains "...leaving README.md's badge exactly as it was" "$OLD_URL" "$CASE/README.md"
+  # The decode is the reason this step is more than a copy: shields.io's
+  # static-badge PATH escapes `-` as `--` and spaces as `%20`, while the
+  # endpoint schema takes plain text. A step that published the path's bytes
+  # would render `Agent--Ready%209.9%2F10` at every reader, forever, greenly.
+  want_file_contains "...with shields.io's path escaping undone, not published raw" \
+                     '"message":"Agent-Ready 9.9/10"' "$CASE/ars-badge.json"
 
-  # -------------------------------------------------------------------------
-  # Obligations 6-7 — the REAL "Run ARS scan" step, extracted and executed.
-  echo ""
-  echo "-- $SCAN_STEP --"
-  # A floor of 2, not of "however many lines the fixed step has": the pre-#1644
-  # body was two lines, so a higher floor would report the mutation that
-  # RESTORES it as "the scan has gone blind" rather than as obligation 6 going
-  # red — a negative result for the wrong reason reads as coverage it is not.
-  # `workflow_step_body` already refuses a zero-line body, which is the blindness
-  # this floor exists on top of.
-  if extract_body "$SCAN_STEP" 2 "$TMP/scan-body.sh"; then
-    new_case scanfail 3
-    printf '%s\n' "$SCAN_ERR" >"$CASE/.ars-stdout"
-    run_step "$CASE" "$SCAN_SHELL" "$TMP/scan-body.sh"
-    if [[ "$ST" -eq 0 ]]; then
-      fail "a failing \`ars scan\` fails the step" "a non-zero exit" "exit 0 :: $(flat "$OUT")"
-    else
-      pass "a failing \`ars scan\` fails the step (exit $ST)"
-    fi
-    want_contains "...as a workflow error annotation, so it surfaces on the run" "::error::" "$OUT"
-    want_contains "...naming the scan as what failed" "$P_SCANFAIL" "$OUT"
-    want_contains "...and that the badge was therefore not updated" "NOT updated" "$OUT"
-    # Without this the failure has no diagnosis anywhere: `ars`'s own message is
-    # redirected into the file, so a step that exits 1 without printing it is a
-    # red X over an empty log.
-    want_contains "...with the scan's own output still in the log" "$SCAN_ERR" "$OUT"
+  # B3 — output with no badge line at all.
+  new_case nobadge
+  printf '%s\n' "$SCAN_ERR" >"$CASE/ars-output.txt"
+  run_step "$CASE" "$EXTRACT_SHELL" "$TMP/extract-body.sh"
+  want_nonzero "B3: output with no badge line fails the step" "$ST" "$OUT"
+  want_contains "...as a workflow error annotation" "::error::" "$OUT"
+  want_only NOBADGE "$OUT"
+  want_contains "...and printing the output it could not read a badge out of" "$SCAN_ERR" "$OUT"
 
-    # Obligation 7, the vacuity guard: a step that failed unconditionally would
-    # satisfy every arm above.
-    new_case scanok 0
-    badge_output "$NEW_URL" >"$CASE/.ars-stdout"
-    run_step "$CASE" "$SCAN_SHELL" "$TMP/scan-body.sh"
-    want_status "a succeeding \`ars scan\` still passes" 0 "$ST" "$OUT"
-    want_absent "...with no error annotation" "::error::" "$OUT"
-    want_file_contains "...having captured the scan output for the next step" "$NEW_URL" "$CASE/ars-output.txt"
+  # B4 — a badge line whose URL cannot be read.
+  new_case nourl
+  printf '[![ARS](img.shields.io/badge/ARS-unparseable)](x)\n' >"$CASE/ars-output.txt"
+  run_step "$CASE" "$EXTRACT_SHELL" "$TMP/extract-body.sh"
+  want_nonzero "B4: a badge line with no extractable URL fails the step" "$ST" "$OUT"
+  want_only NOURL "$OUT"
 
-    # `|| true` is the false fix for this family and is refused by name — it is
-    # what the step used to carry. Comments are stripped first for the same
-    # reason the push arm strips them: the workflow's prose explains why it is
-    # not used, and a raw scan fails on the sentence saying the right thing.
-    code=$(grep -v '^[[:space:]]*#' "$TMP/scan-body.sh")
-    want_absent "the scan step does not reach for \`|| true\`" "|| true" "$code"
-    want_contains "...checked against the step's real code, not an empty strip" "ars scan" "$code"
+  # B5 — the "empty badge value" case: a URL that yields no message or no
+  # color. Before #1654 the URL travelled as one opaque string and an empty
+  # score could not be seen at all.
+  new_case notriple
+  badge_output 'https://img.shields.io/badge/ARS-' >"$CASE/ars-output.txt"
+  run_step "$CASE" "$EXTRACT_SHELL" "$TMP/extract-body.sh"
+  want_nonzero "B5: a badge URL with an empty message fails the step" "$ST" "$OUT"
+  want_only NOTRIPLE "$OUT"
+  if [[ -e "$CASE/ars-badge.json" ]]; then
+    fail "...and wrote no payload for the next step to publish" "no ars-badge.json" "$(flat "$(cat "$CASE/ars-badge.json")")"
+  else
+    pass "...and wrote no payload for the next step to publish"
   fi
 
-  # -------------------------------------------------------------------------
-  # Obligations 8-11 — the REAL "Extract and update ARS badge" step.
-  echo ""
-  echo "-- $EXTRACT_STEP --"
-  if extract_body "$EXTRACT_STEP" 8 "$TMP/extract-body.sh"; then
-    # Obligation 8, the vacuity guard for 9-11: a fix that refuses everything
-    # is indistinguishable from one that works until something still works.
-    # Graded against the REAL README.md, so the `sed` pattern is checked
-    # against the file it has to match.
-    new_case extractok 0
-    badge_output "$NEW_URL" >"$CASE/ars-output.txt"
-    cp README.md "$CASE/README.md"
-    run_step "$CASE" "$EXTRACT_SHELL" "$TMP/extract-body.sh"
-    want_status "a normal run still updates the badge" 0 "$ST" "$OUT"
-    want_contains "...and says so" "README updated with ARS badge URL" "$OUT"
-    want_file_contains "...having written the new URL into README.md" "$NEW_URL" "$CASE/README.md"
-    want_file_absent "...and replaced the old one rather than appending" "$OLD_URL" "$CASE/README.md"
-    want_absent "...with no error annotation" "::error::" "$OUT"
+  # B6 — an escape the decode does not model. A guess here is published as
+  # fact and read by everyone who looks at the README.
+  new_case escape
+  badge_output 'https://img.shields.io/badge/ARS-Agent%3AReady-green' >"$CASE/ars-output.txt"
+  run_step "$CASE" "$EXTRACT_SHELL" "$TMP/extract-body.sh"
+  want_nonzero "B6: a percent-escape the step cannot decode fails the step" "$ST" "$OUT"
+  want_only ESCAPE "$OUT"
 
-    # Obligation 9 — output with no badge line at all.
-    new_case nobadge 0
-    printf '%s\n' "$SCAN_ERR" >"$CASE/ars-output.txt"
-    cp README.md "$CASE/README.md"
-    run_step "$CASE" "$EXTRACT_SHELL" "$TMP/extract-body.sh"
-    if [[ "$ST" -eq 0 ]]; then
-      fail "output with no badge line fails the step" "a non-zero exit" "exit 0 :: $(flat "$OUT")"
-    else
-      pass "output with no badge line fails the step (exit $ST)"
-    fi
+  code=$(grep -v '^[[:space:]]*#' "$TMP/extract-body.sh")
+  # The step's two `|| echo ""` are deliberate and stay — they keep an empty
+  # capture readable so the named refusal can report it, rather than letting
+  # errexit abort with a line number. `|| true` is the different thing, and the
+  # one this family keeps having to refuse.
+  want_absent "the extract step does not reach for \`|| true\`" "|| true" "$code"
+  want_contains "...checked against the step's real code, not an empty strip" "ars-badge.json" "$code"
+  # ...and it no longer touches README.md at all, which is the whole of #1654.
+  want_absent "...and it no longer rewrites README.md" "README.md" "$code"
+fi
+
+# ---------------------------------------------------------------------------
+# C1-C6 — the "Update Gist with ARS score" step. All new in #1654, so every
+# obligation here passes the moment it is written: each one was seen red by a
+# deliberate mutation of the step before landing.
+echo ""
+echo "== $WF: $GIST_STEP =="
+
+if extract_body "$GIST_STEP" 8 "$TMP/gist-body.sh"; then
+  # C1 — the happy path, driven END TO END: the extract step writes
+  # ars-badge.json and the gist step publishes THAT file, so the two steps'
+  # only contract is exercised rather than assumed.
+  new_case gistok
+  with_curl 200 0 '{"html_url":"https://gist.github.com/stub"}'
+  badge_output "$NEW_URL" >"$CASE/ars-output.txt"
+  run_step "$CASE" "$EXTRACT_SHELL" "$TMP/extract-body.sh"
+  want_status "the extract step ran, so the gist step has a real payload to publish" 0 "$ST" "$OUT"
+  run_step "$CASE" "$GIST_SHELL" "$TMP/gist-body.sh" GIST_SECRET=stub-token "COVERAGE_GIST_ID=$GIST_ID"
+  want_status "C1: a 200 from the gist API passes the step" 0 "$ST" "$OUT"
+  want_no_refusal "...with no refusal wording anywhere" "$OUT"
+  want_contains "...saying what it published" "Published ARS badge to gist: Agent-Ready 9.9/10" "$OUT"
+  if [[ -s "$CASE/.curl-calls" ]]; then
+    pass "...having actually issued the request (the stub recorded it)"
+    call=$(cat "$CASE/.curl-calls")
+    want_contains "...as a PATCH" "-X PATCH" "$call"
+    want_contains "...to the gist the secret names" "https://api.github.com/gists/$GIST_ID" "$call"
+    want_contains "...carrying the token" "Authorization: token stub-token" "$call"
+  else
+    fail "C1: the gist step issued a request" "a recorded curl call" "none — the step went green without publishing anything"
+  fi
+  published=$(jq -Sc '.files["ars.json"].content | fromjson' "$CASE/gist-payload.json" 2>&1)
+  wanted=$(printf '%s' "$NEW_JSON" | jq -Sc . 2>&1)
+  if [[ "$published" == "$wanted" ]]; then
+    pass "...publishing the endpoint payload as ars.json ($published)"
+  else
+    fail "the request body carries the endpoint payload as ars.json" "$wanted" "$published"
+  fi
+
+  # C2 — an unset GIST_SECRET.
+  new_case nosecret
+  with_curl 200 0 '{}'
+  printf '%s\n' "$NEW_JSON" >"$CASE/ars-badge.json"
+  run_step "$CASE" "$GIST_SHELL" "$TMP/gist-body.sh" GIST_SECRET= "COVERAGE_GIST_ID=$GIST_ID"
+  want_nonzero "C2: an unset GIST_SECRET fails the step" "$ST" "$OUT"
+  want_contains "...as a workflow error annotation" "::error::" "$OUT"
+  want_only NOSECRET "$OUT"
+  want_no_request "...and nothing was sent to the gist API"
+
+  # C3 — an unset COVERAGE_GIST_ID.
+  new_case nogistid
+  with_curl 200 0 '{}'
+  printf '%s\n' "$NEW_JSON" >"$CASE/ars-badge.json"
+  run_step "$CASE" "$GIST_SHELL" "$TMP/gist-body.sh" GIST_SECRET=stub-token COVERAGE_GIST_ID=
+  want_nonzero "C3: an unset COVERAGE_GIST_ID fails the step" "$ST" "$OUT"
+  want_only NOGISTID "$OUT"
+  want_no_request "...and nothing was sent to the gist API"
+
+  # C4 — no payload, in both its shapes: the file is absent, and the file is
+  # there with an empty message. Both are "the badge value is empty", and both
+  # must be refused BEFORE anything is sent — publishing a blank badge is the
+  # silent-wrong-score failure this issue is about, in a new spelling.
+  new_case nopayload
+  with_curl 200 0 '{}'
+  run_step "$CASE" "$GIST_SHELL" "$TMP/gist-body.sh" GIST_SECRET=stub-token "COVERAGE_GIST_ID=$GIST_ID"
+  want_nonzero "C4: a missing ars-badge.json fails the step" "$ST" "$OUT"
+  want_only NOPAYLOAD "$OUT"
+  want_no_request "...and nothing was sent to the gist API"
+
+  new_case emptymessage
+  with_curl 200 0 '{}'
+  printf '%s\n' '{"schemaVersion":1,"label":"ARS","message":"","color":"green"}' >"$CASE/ars-badge.json"
+  run_step "$CASE" "$GIST_SHELL" "$TMP/gist-body.sh" GIST_SECRET=stub-token "COVERAGE_GIST_ID=$GIST_ID"
+  want_nonzero "C4: an empty badge message fails the step" "$ST" "$OUT"
+  want_only NOPAYLOAD "$OUT"
+  want_no_request "...and no blank badge was published"
+
+  # C5 — the API answered, and said no. Both a 4xx and a 5xx, because a guard
+  # written as `-ge 400` would pass the first and a guard written as
+  # `!= 200` would pass neither, and only one of those is the shape shipped.
+  for code_body in '404 {"message":"Not Found"}' '503 {"message":"Service Unavailable"}'; do
+    http_code=${code_body%% *}
+    body=${code_body#* }
+    new_case "http$http_code"
+    with_curl "$http_code" 0 "$body"
+    printf '%s\n' "$NEW_JSON" >"$CASE/ars-badge.json"
+    run_step "$CASE" "$GIST_SHELL" "$TMP/gist-body.sh" GIST_SECRET=stub-token "COVERAGE_GIST_ID=$GIST_ID"
+    want_nonzero "C5: HTTP $http_code fails the step" "$ST" "$OUT"
     want_contains "...as a workflow error annotation" "::error::" "$OUT"
-    want_contains "...naming the missing badge line specifically" "$P_NOBADGE" "$OUT"
-    want_contains "...and printing the output it could not read a badge out of" "$SCAN_ERR" "$OUT"
-    want_absent "...not confused with the unreadable-URL refusal" "$P_NOURL" "$OUT"
-    want_absent "...nor with the rewrite-did-not-land refusal" "$P_NOWRITE" "$OUT"
-    want_file_contains "...leaving README.md's badge untouched" "$OLD_URL" "$CASE/README.md"
+    want_only GISTFAIL "$OUT"
+    want_contains "...naming the code it got" "HTTP $http_code" "$OUT"
+    want_contains "...and printing the API's own answer" "$body" "$OUT"
+  done
 
-    # Obligation 10 — a badge line whose URL cannot be read. Same shape one
-    # level down, and the issue asked for it by name.
-    new_case nourl 0
-    printf '[![ARS](img.shields.io/badge/ARS-unparseable)](x)\n' >"$CASE/ars-output.txt"
-    cp README.md "$CASE/README.md"
-    run_step "$CASE" "$EXTRACT_SHELL" "$TMP/extract-body.sh"
-    if [[ "$ST" -eq 0 ]]; then
-      fail "a badge line with no extractable URL fails the step" "a non-zero exit" "exit 0 :: $(flat "$OUT")"
-    else
-      pass "a badge line with no extractable URL fails the step (exit $ST)"
-    fi
-    want_contains "...naming the unreadable URL specifically" "$P_NOURL" "$OUT"
-    want_absent "...not confused with the missing-badge-line refusal" "$P_NOBADGE" "$OUT"
-    want_absent "...nor with the rewrite-did-not-land refusal" "$P_NOWRITE" "$OUT"
-    want_file_contains "...leaving README.md's badge untouched" "$OLD_URL" "$CASE/README.md"
+  # C6 — the API was never reached. curl writes "000" and exits non-zero; under
+  # this step's implicit `-e` an uncaptured status would abort the step right
+  # there, with no annotation and no diagnosis — "could not be attempted" going
+  # silent, which is the outcome #1645 exists to keep distinguishable.
+  new_case transport
+  with_curl 000 7 ''
+  printf '%s\n' "$NEW_JSON" >"$CASE/ars-badge.json"
+  run_step "$CASE" "$GIST_SHELL" "$TMP/gist-body.sh" GIST_SECRET=stub-token "COVERAGE_GIST_ID=$GIST_ID"
+  want_nonzero "C6: a curl that never reached the API fails the step" "$ST" "$OUT"
+  want_contains "...as a workflow error annotation" "::error::" "$OUT"
+  want_only GISTFAIL "$OUT"
+  want_contains "...naming curl's own exit status, not only the code" "curl exit 7" "$OUT"
+  want_contains "...and saying there was no answer to print" "no response body" "$OUT"
 
-    # Obligation 11 — the rewrite that matched nothing. `sed` exits 0 having
-    # matched nothing, so before #1644 this printed "README updated" over an
-    # unchanged file and the push step then reported `No badge changes`.
-    new_case nowrite 0
-    badge_output "$NEW_URL" >"$CASE/ars-output.txt"
-    printf '# Irrlicht\n\nA README carrying no ARS badge at all.\n' >"$CASE/README.md"
-    run_step "$CASE" "$EXTRACT_SHELL" "$TMP/extract-body.sh"
-    if [[ "$ST" -eq 0 ]]; then
-      fail "a rewrite that matched nothing fails the step" "a non-zero exit" "exit 0 :: $(flat "$OUT")"
-    else
-      pass "a rewrite that matched nothing fails the step (exit $ST)"
-    fi
-    want_contains "...naming the unwritten README specifically" "$P_NOWRITE" "$OUT"
-    want_absent "...and does NOT claim the README was updated" "README updated with ARS badge URL" "$OUT"
-    want_absent "...not confused with the missing-badge-line refusal" "$P_NOBADGE" "$OUT"
-    want_absent "...nor with the unreadable-URL refusal" "$P_NOURL" "$OUT"
+  # A non-numeric `%{http_code}` must not fall through to the success line: the
+  # arithmetic tests would print `integer expression expected` and evaluate
+  # FALSE, which is a pass. Committed because that is exactly the shape this
+  # file keeps finding — a status read more narrowly than it is produced.
+  new_case garbagecode
+  with_curl 'not-a-code' 0 '{}'
+  printf '%s\n' "$NEW_JSON" >"$CASE/ars-badge.json"
+  run_step "$CASE" "$GIST_SHELL" "$TMP/gist-body.sh" GIST_SECRET=stub-token "COVERAGE_GIST_ID=$GIST_ID"
+  want_nonzero "C6: an unreadable HTTP code fails the step rather than passing it" "$ST" "$OUT"
+  want_only GISTFAIL "$OUT"
 
-    # The step's two `|| echo ""` are deliberate and stay — they keep an empty
-    # capture readable so the named refusal above can report it, rather than
-    # letting errexit abort with a line number. `|| true` is the different
-    # thing, and the one this family keeps having to refuse.
-    code=$(grep -v '^[[:space:]]*#' "$TMP/extract-body.sh")
-    want_absent "the extract step does not reach for \`|| true\`" "|| true" "$code"
-    want_contains "...checked against the step's real code, not an empty strip" "sed -i" "$code"
-  fi
+  code=$(grep -v '^[[:space:]]*#' "$TMP/gist-body.sh")
+  want_absent "the gist step does not reach for \`|| true\`" "|| true" "$code"
+  want_contains "...checked against the step's real code, not an empty strip" "api.github.com/gists" "$code"
+fi
+
+# ---------------------------------------------------------------------------
+# C7 — the job writes NOTHING to the repository.
+#
+# This is a lock: it passes by construction against the workflow as shipped.
+# Per AGENTS.md that is the reason for a deliberate mutation, not an exemption
+# from one — so the predicate is a function over a FILE, driven against the
+# real workflow (must pass) and against two copies broken in exactly one way
+# each (must fail). Without the mutated copies, a predicate that had stopped
+# matching would read identically to a clean workflow.
+echo ""
+echo "== $WF: the job writes nothing to the repository (#1654) =="
+writes_to_repo() { # <workflow-file> -> 0 if it grants or performs a repo write
+  grep -qE '^[[:space:]]*contents:[[:space:]]*write' "$1" && return 0
+  grep -qE '^[[:space:]]*git[[:space:]]+push' "$1" && return 0
+  return 1
+}
+if writes_to_repo "$WF"; then
+  fail "the badge job holds no repo write" \
+       "no \`contents: write\` and no \`git push\` in $WF" \
+       "it has one — that is #1654: the push is refused by the Protect Main ruleset on every run"
+else
+  pass "the badge job holds no \`contents: write\` and pushes nothing"
+fi
+sed 's/^\( *\)contents: read/\1contents: write/' "$WF" >"$TMP/mutant-write.yml"
+if ! grep -qE '^[[:space:]]*contents:[[:space:]]*write' "$TMP/mutant-write.yml"; then
+  fail "the \`contents: write\` mutation applied" "a mutated copy carrying it" "the sed changed nothing — the arm below graded the unmutated file"
+elif writes_to_repo "$TMP/mutant-write.yml"; then
+  pass "...and a copy that regained \`contents: write\` is caught"
+else
+  fail "a copy that regained \`contents: write\` is caught" "a detection" "it passed — this check has gone blind"
+fi
+{ cat "$WF"; printf '          git push\n'; } >"$TMP/mutant-push.yml"
+if writes_to_repo "$TMP/mutant-push.yml"; then
+  pass "...and a copy that regained a \`git push\` is caught"
+else
+  fail "a copy that regained a \`git push\` is caught" "a detection" "it passed — this check has gone blind"
 fi
 
 # ---------------------------------------------------------------------------

--- a/tools/lib/workflow-step_test.sh
+++ b/tools/lib/workflow-step_test.sh
@@ -239,7 +239,7 @@ fi
 echo ""
 echo "== the derivation follows a step that gains or loses \`shell:\` =="
 REAL=.github/workflows/ars.yml
-REALSTEP='Commit badge update'
+REALSTEP='Run ARS scan'
 if [[ ! -f "$REAL" ]]; then
   fail "$REAL is readable" "the workflow file" "not found — the mutation could not run"
 else
@@ -321,7 +321,7 @@ real_row() { # <workflow> <step> <expected>
   fi
   return 0
 }
-real_row .github/workflows/ars.yml                        'Commit badge update'                         "$DEFAULT"
+real_row .github/workflows/ars.yml                        'Run ARS scan'                                "$DEFAULT"
 real_row .github/workflows/test.yml                       'Test the shared shell libs'                  "$DEFAULT"
 real_row .github/workflows/replaydata-deletion-guard.yml  'Detect deletions of load-bearing replaydata' "$DEFAULT"
 real_row .github/workflows/macos-swift.yml                'Test (bounded, streamed under a pty)'        "$BASH"

--- a/tools/preflight.sh
+++ b/tools/preflight.sh
@@ -486,10 +486,14 @@ if want tools; then
   # goes through the shared runner rather than growing its own loop back, and a
   # commit editing only that workflow is again exactly the one that breaks it.
   # .github/workflows/ars.yml joins them for the fourth time (#1641):
-  # ars-badge-push_test.sh EXTRACTS that workflow's "Commit badge update" step
-  # and executes it, so the assertion that an exhausted push-retry fails the
-  # step lives entirely in this gate — and a commit editing only ars.yml is
-  # once again exactly the one that breaks it.
+  # ars-badge-push_test.sh EXTRACTS that workflow's `run:` steps and executes
+  # them, so the assertion that each of them refuses distinguishably — rather
+  # than going green with a stale badge — lives entirely in this gate, and a
+  # commit editing only ars.yml is once again exactly the one that breaks it.
+  # #1654 replaced the step that first earned this entry ("Commit badge
+  # update", whose push to main the Protect Main ruleset refused on every run)
+  # with a gist PATCH; the entry needed no widening, only the steps behind it
+  # changed.
   # .github/workflows/replaydata-deletion-guard.yml joins them for the fifth
   # time (#1645): replaydata-deletion-guard_test.sh EXTRACTS that workflow's
   # "Detect deletions of load-bearing replaydata" step and executes it, so the


### PR DESCRIPTION
Closes #1654.

## The defect

`.github/workflows/ars.yml`'s "Commit badge update" step pushed the badge commit straight to `main`. The "Protect Main" ruleset carries a `pull_request` rule with **zero** bypass actors, so the push was refused on every run:

```
remote: error: GH013: Repository rule violations found for refs/heads/main.
remote: - Changes must be made through a pull request.
```

A rule violation is not a transient condition, so none of the five retries could ever clear it. The last badge commit that landed is `244f11d2` (**2026-04-26**). Every run since computed a score, rewrote `README.md` on the runner and threw it away — **roughly four months**, silently, until #1647 made the failure loud.

**Premise re-verified rather than taken from the issue.** Measured locally with the ARS CLI on this tree:

```
[![ARS](https://img.shields.io/badge/ARS-Agent--Assisted%207.9%2F10-yellow)](https://github.com/ingo-eichhorst/agent-readyness)
```

README showed `ARS-Agent--Ready%208.1%2F10-green`. So both halves of the badge were stale: the score *and* the band name. `gh api repos/ingo-eichhorst/Irrlicht/rulesets/15993081` confirms the ruleset is active on `main`, has zero bypass actors, and carries `pull_request`, `required_linear_history`, `deletion`, `non_fast_forward`, `required_status_checks` — the last with contexts `go-test` and `build-test`. Classic branch protection on `main` is empty, so the ruleset is the whole of it.

## The approach (option 2 from the issue — the gist endpoint)

`codescene-badge.yml`'s shape, followed rather than re-derived:

- **"Extract and update ARS badge" becomes "Extract ARS badge".** It stops `sed -i`'ing `README.md` and builds the shields.io **endpoint** payload `ars-badge.json` instead.
- **New "Update Gist with ARS score" step** PATCHes it into the badges gist as `ars.json`.
- **"Commit badge update" is deleted outright** — no commit, no push, no retry loop.
- **`contents: write` becomes `contents: read`**, moved to workflow level to match `codescene-badge.yml`. That grant existed for exactly one reason: the push. The job runs a third-party CLI (`ars@e0ce48b9...`, pinned by commit) next to the workflow token, so removing the write is a real reduction in blast radius, not bookkeeping.
- **README's badge** becomes `img.shields.io/endpoint?url=...%2Fraw%2Fars.json`, in the same URL-encoding shape as the CodeScene line directly above it.

**No new secret is needed.** `GIST_SECRET` and `COVERAGE_GIST_ID` are already configured repo secrets — `coverage.yml` and `codescene-badge.yml` write `coverage.json` and `codescene.json` into that same gist today. This adds a third file to it.

### The decode, which is the one non-obvious part

shields.io's **static-badge path** is escaped — `--` is a literal dash, `_` and `%20` are spaces, `__` a literal underscore, `%2F` a slash — while the **endpoint schema** takes plain text. Publishing the path's bytes unchanged would render a badge reading `Agent--Assisted%207.9%2F10`: wrong, permanently, and green about it, which is this issue's failure mode in a new spelling. So the escaping is undone, and an escape the step does not model is a **refusal**, not a guess.

## Three outcomes, never two (#1645)

Nine refusals across the three steps, each with **distinct** wording, and each asserting that no *other* refusal's wording is present (#1677/#1678 — a shared non-zero is satisfied by refusals that all fire together):

| key | step | what it names |
|---|---|---|
| `SCANFAIL` | Run ARS scan | the scan failed, no score produced |
| `NOBADGE` | Extract | the scan's output carries no badge line |
| `NOURL` | Extract | a badge line with no extractable URL |
| `NOTRIPLE` | Extract | the URL does not split into label/message/color (the empty-badge-value case) |
| `ESCAPE` | Extract | a percent-escape the decode does not model |
| `NOSECRET` | Gist | `GIST_SECRET` unset |
| `NOGISTID` | Gist | `COVERAGE_GIST_ID` unset |
| `NOPAYLOAD` | Gist | `ars-badge.json` missing, unreadable, or blank-message |
| `GISTFAIL` | Gist | non-2xx **or** the API never reached |

## Obligations DELETED, and why

`tools/lib/ars-badge-push_test.sh` graded three steps across four issues. This change deletes the step two of those issues were about. AGENTS.md's *"a rewritten guard replays its predecessor's cases"* is about a guard being **rewritten**; here a mechanism is **removed**, and contorting those obligations into passing against a step that does not exist is the vacuous green this family exists to prevent. So they are deleted, named here rather than left for a reviewer to notice:

- **#1641, obligations 1-4** — the pre-fix retry loop replayed verbatim (five failed pushes exiting 0); the real step failing loudly when every attempt failed; the third-attempt arm proving the retry is still a retry; the clean paths (nothing staged, first-attempt push).
- **#1655, obligations 12-17** — the same loop against **real git** in a throwaway repo: the pre-fix loop reaching a clean tree on 1 of 5 attempts; every attempt starting clean after the fix; the ordinary rejected push succeeding on the third try; the rejected `git rebase --abort` spelling committed beside the shipped one; a first-attempt push landing on origin; the unabortable-rebase refusal.

With them went their machinery: the `git`/`sleep` stub, `fixture_build`/`fgit`/`fixture_conflicts`, `attempt_prelude`/`run_in_repo`/`want_starts`, and the two committed predecessor loops. `tools/lib/workflow-step_test.sh` moved its real-workflow row and its `shell:` mutation target from `'Commit badge update'` to `'Run ARS scan'` for the same reason.

**This deletes PR #1706 (#1655), merged shortly before this branch was cut, and #1641's loud-failure fix with it.** That was known and accepted when the approach was chosen. What it costs, stated plainly: the retry-loop defect those two issues fixed — a loop whose exhausted case reads as success — is now covered **nowhere**, because no retry loop remains in this repo's workflows. If one is written again, those obligations are in git history at `ae85182f` and should come back with it. Both the test file's header and AGENTS.md record that.

**Kept and adapted** (#1644's, since the scan is unchanged and the extract step keeps its job): the pre-#1644 predecessor bodies re-measured on every run, the failed-scan/succeeded-scan pair, the normal-run vacuity guard, the missing-badge and unreadable-URL refusals with their measured wording, and the `|| true` refusal-by-name on every step.

## Mutation evidence

Everything the gist step and the decode add passes the moment it is written, so each was seen **red** by a deliberate mutation of `ars.yml` — applied, run, reverted, restore verified byte-identical each time. Verbatim excerpts:

**M1 — delete the `GIST_SECRET` refusal**

```
FAIL: C2: an unset GIST_SECRET fails the step - expected [a non-zero exit] got [exit 0 :: HTTP 200 (curl exit 0) Published ARS badge to gist: Agent-Ready 9.9/10 ]
FAIL: ...naming NOSECRET specifically - expected [output containing: GIST_SECRET is not set in repository secrets] got [...]
FAIL: ...and nothing was sent to the gist API - expected [no request to the gist API] got [the stub recorded: ... -H Authorization: token  -H ... https://api.github.com/gists/stubgistid... ]
```

Note the empty token in the recorded call: without the refusal the request goes out unauthenticated.

**M2 — delete the `COVERAGE_GIST_ID` refusal**

```
FAIL: C3: an unset COVERAGE_GIST_ID fails the step - expected [a non-zero exit] got [exit 0 :: HTTP 200 (curl exit 0) Published ARS badge to gist: Agent-Ready 9.9/10 ]
FAIL: ...naming NOGISTID specifically - expected [output containing: COVERAGE_GIST_ID is not set in repository secrets] got [...]
FAIL: ...and nothing was sent to the gist API - expected [no request to the gist API] got [the stub recorded: ... https://api.github.com/gists/ ]
```

**M3 — delete the empty/missing-payload refusal**

```
FAIL: ...naming NOPAYLOAD specifically - expected [output containing: there is no ARS badge payload to publish] got [cat: ars-badge.json: No such file or directory ]
FAIL: C4: an empty badge message fails the step - expected [a non-zero exit] got [exit 0 :: HTTP 200 (curl exit 0) Published ARS badge to gist:  ]
FAIL: ...and no blank badge was published - expected [no request to the gist API] got [the stub recorded: ...]
```

Worth reading closely: the two shapes degrade **differently**. A missing file fails loudly-but-undiagnosed (`cat` aborts under `-e`); a present-but-blank message **publishes a blank badge and reports success**.

**M4 — delete the non-2xx / transport refusal.** 404, 503, transport failure and the unreadable-code case all go green:

```
FAIL: C5: HTTP 404 fails the step - expected [a non-zero exit] got [exit 0 :: HTTP 404 (curl exit 0) Published ARS badge to gist: Agent-Ready 9.9/10 ]
FAIL: C5: HTTP 503 fails the step - expected [a non-zero exit] got [exit 0 :: HTTP 503 (curl exit 0) Published ARS badge to gist: Agent-Ready 9.9/10 ]
FAIL: C6: a curl that never reached the API fails the step - expected [a non-zero exit] got [exit 0 :: HTTP 000 (curl exit 7) Published ARS badge to gist: Agent-Ready 9.9/10 ]
```

**M5a — drop `|| curl_status=$?`.** The transport failure aborts under the implicit `-e`, with an **empty log**:

```
FAIL: ...as a workflow error annotation - expected [output containing: ::error::] got [ ]
FAIL: ...naming GISTFAIL specifically - expected [output containing: the ARS badge gist update FAILED] got [ ]
FAIL: ...naming curl's own exit status, not only the code - expected [output containing: curl exit 7] got [ ]
```

The status arm stays green — the step *does* fail — but there is nothing in the log saying why. "Could not be attempted" going silent.

**M5b — replace the numeric-shape check on `%{http_code}` with a bare `[ -z ... ]`**

```
FAIL: C6: an unreadable HTTP code fails the step rather than passing it - expected [a non-zero exit] got [exit 0 :: HTTP not-a-code (curl exit 0) .step.sh: line 54: [: not-a-code: integer expression expected .step.sh: line 54: [: not-a-code: integer expression expected Published ARS badge to gist: Agent-Ready 9.9/10 ]
```

A failed publish reported as a publish. **M5a and M5b are both `codescene-badge.yml`'s current spellings** — noted here, deliberately not changed there; a follow-up issue is the honest home for that.

**M6 — delete the label/message/color triple refusal**

```
FAIL: B5: a badge URL with an empty message fails the step - expected [a non-zero exit] got [exit 0 :: ... ARS badge endpoint payload: {"schemaVersion":1,"label":"ARS","message":"","color":""} ]
FAIL: ...and wrote no payload for the next step to publish - expected [no ars-badge.json] got [{"schemaVersion":1,"label":"ARS","message":"","color":""} ]
```

**M7 — delete the unmodelled-percent-escape refusal**

```
FAIL: B6: a percent-escape the step cannot decode fails the step - expected [a non-zero exit] got [exit 0 :: ... {"schemaVersion":1,"label":"ARS","message":"Agent%3AReady","color":"green"} ]
```

**M8 — skip the decode entirely.** This reddens B2 *via the escape refusal*, which is a second line of defence rather than the arm under test. So a narrower mutation was needed:

**M8b — drop only the literal-dash restore** (a decode wrong in one way the `%` guard cannot see; the byte in `got` below is the sentinel the split uses, rendered by jq as a `` escape):

```
FAIL: the payload is the endpoint schema for the scanned score - expected [{"color":"brightgreen","label":"ARS","message":"Agent-Ready 9.9/10","schemaVersion":1}] got [{"color":"brightgreen","label":"ARS","message":"Agent<sentinel>Ready 9.9/10","schemaVersion":1}]
FAIL: ...with shields.io's path escaping undone, not published raw - expected [... containing: "message":"Agent-Ready 9.9/10"] got [{"schemaVersion":1,"label":"ARS","message":"Agent<sentinel>Ready 9.9/10","color":"brightgreen"} ]
```

Exactly the two payload-equality arms, nothing else.

**M9 — the job regains `contents: write`**

```
FAIL: the badge job holds no repo write - expected [no `contents: write` and no `git push` in .github/workflows/ars.yml] got [it has one - that is #1654: the push is refused by the Protect Main ruleset on every run]
```

**M10 — delete the missing-badge-line refusal.** #1644's measurement, re-run against the new step: the **status** arm stays green because the URL refusal fires, and only the **wording** arms go red:

```
FAIL: ...naming NOBADGE specifically - expected [output containing: carries no img.shields.io/badge/ARS line] got [... ::error::a badge line was found but no https://img.shields.io/badge/ARS... URL could be read out of it ...]
FAIL: ...and not confused with NOURL - expected [no output containing: could be read out of it] got [...]
```

**M11 — put a README rewrite back into the extract step**

```
FAIL: ...and it no longer rewrites README.md - expected [no output containing: README.md] got [...sed -i "s|https://img.shields.io/badge/ARS-[^)]*|${ARS_URL}|g" README.md...]
```

**M12 — make one refusal needle a substring of another.** The harness's own self-check, added because `shellcheck` SC2034 exposed that the phrase table was read through `${!v}` — an indirect read of a mistyped key yields the **empty string**, and an empty needle passes every `want_absent` vacuously:

```
FAIL: ars-badge-push_test - NOTRIPLE's needle [gist update FAILED] is a substring of GISTFAIL's [the ARS badge gist update FAILED]; the two refusals cannot be told apart
```

The table is now a `case` (unknown key produces a loud refusal) plus a startup check that all nine needles are non-empty and pairwise non-substring.

## Nothing in the tests touches the network

`curl` is shadowed by a shell **function**, not a PATH shim, in every arm — the live badges gist (the one the README's Coverage and CodeScene badges render from right now) is never written to. The stub records every call it receives, so "the step refused" and "the step published and we did not look" are distinguishable: the refusal arms assert `.curl-calls` does **not** exist.

## Also in this PR

**AGENTS.md**, three places:

1. *The ARS badge job* bullet — rewritten: what #1654 was, the gist route, the permission reduction, the deleted obligations named, the two non-obvious gist-step mutations, and the two-mutations-not-one point about the decode. The "no linter was built" measurement is kept as history with its subject noted as gone.
2. *Which bash a workflow step gets* — the pipefail audit said "ars.yml's ... `sed "s|...|...|"` is a delimiter not a pipe". That `sed` is gone; the sentence now records that #1654 added no pipeline (`jq` reads and writes files, `curl`'s status is captured).
3. *Architecture score* / *Code health* — **#1432's scope items 2 and 3**, which nothing had recorded. What IS required is now stated positively: the "Protect Main" ruleset (id 15993081, active, zero bypass actors) requires exactly `go-test` and `build-test`; classic branch protection on `main` is empty. #1432 was filed when that list was empty, so this is a behaviour change, and its consequence is named — a **CONFLICTING** PR dispatches no `pull_request` workflows, so those checks come back *absent* rather than red, and absent reads as "waiting for status to be reported", i.e. indistinguishable from still-queued. This does not close #1432; its item 1 is a policy call.

**tools/preflight.sh** — the `tools` gate's comment named the deleted step. The trigger regex itself needed **no** widening: it already carries `ars.yml` from #1641.

## What this PR can and cannot prove

`ars.yml` runs **only on push to `main`** (plus `workflow_dispatch`), so **its real behaviour cannot be observed from this PR**. Proven here:

- every step body, extracted from the real workflow and **executed** under the invocation the runner gives it (derived, `bash -e`) — `bash tools/lib/ars-badge-push_test.sh`: ALL PASS
- `tools/preflight.sh --only tools`: PASS (18/18 shell-lib suites)
- `tools/bash-lint.sh`: ALL PASS
- the workflow YAML parses, and the step list is `Checkout code, Set up Go, Install ARS CLI, Run ARS scan, Extract ARS badge, Update Gist with ARS score` with `permissions: {contents: read}` and no job-level override
- the README URL is well-formed: shields.io answers `200` for it today with `<title>custom badge: resource not found</title>` — the encoding is accepted and the *file* is simply not in the gist yet. The identically-shaped CodeScene URL returns `<title>code health: 8.6/10</title>`.

**Not proven before merge, and worth checking on the first post-merge `main` run:**

1. the run is green and its log ends `Published ARS badge to gist: Agent-Assisted 7.9/10`
2. the gist gains a third file, `ars.json`
3. the README badge renders **`ARS Agent-Assisted 7.9/10`** (yellow), not `Agent-Ready 8.1/10` (green) — note the band name changes too, not only the number
4. until (2) happens the badge shows shields.io's "resource not found" placeholder. That window is between this merge and the first `main` push — i.e. this merge itself closes it.

`--only posix` and `--only skills` were not run: the diff touches no `#!/bin/sh` file and no skill markdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
