### PR TITLE
test(replay): report the one pairing shape a reason difference can hide, and measure why the other 48 are not it (#1707)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1487,7 +1487,18 @@ Before marking a ticket done, run the full suite — every layer must pass:
   Only KIND-MATCHED pairs carry a delta — where `compareOrdered` reports
   `state_differs` the two sides are not the same transition, so their timestamp
   difference means nothing and counting it would report one sequence divergence
-  twice. The reporting side (`timing_drift.go`) buckets and ranks those deltas;
+  twice. The neighbouring question — whether a differing `reason` should
+  demote a pair the same way — was measured in #1707 and answered NO: a reason
+  names the MECHANISM, both mechanisms exist on both sides, and the catalog's
+  dominant shape is a session's first `ready→working` reached through the
+  classifier default on one side and the force bounce on the other, with those
+  pairs sitting CLOSER in time than the ones that agree. What does survive the
+  argument is narrower and cannot be produced by renaming a string — exactly one
+  side SYNTHESIZED, the other classified — and it is `timeDelta.CrossMechanism`
+  plus `TestCrossMechanismPairsAreAlreadyReported`, which is a report rather than
+  a demotion: it asserts that every such pair in the catalog is already visible
+  to an existing mechanism, and fails the day one is not. The figures are in
+  `compareOrdered`'s doc comment as of that measurement, not restated here. The reporting side (`timing_drift.go`) buckets and ranks those deltas;
   it reuses `core/domain/stats.Percentile` rather than carrying its own.
   It is a **ratchet, not a tolerance gate**, and that is the deliberate
   shape: roughly a quarter of the catalog's kind-matched pairs are still more

--- a/tools/onboarding-factory/cmd/replay/extended_check.go
+++ b/tools/onboarding-factory/cmd/replay/extended_check.go
@@ -3,6 +3,7 @@ package main
 import (
 	"sort"
 
+	"irrlicht/core/application/services"
 	"irrlicht/core/domain/lifecycle"
 )
 
@@ -82,6 +83,51 @@ func (ec *extendedCheck) Fabricates() bool {
 	return ec.RecordedCount == 0 && ec.ReplayedCount > 0
 }
 
+// syntheticReasons is the set of reason strings that mark a transition as
+// SYNTHESIZED — emitted to recover an episode the observer would otherwise have
+// missed entirely (a collapsed waiting blip, a collapsed turn boundary, a turn
+// that had already finished before discovery) rather than decided by the
+// classifier ladder against what the transcript said.
+//
+// It names the exported constants rather than copying their text, so a rename
+// is a compile error here. Completeness is the part a reference cannot give:
+// a SIXTH synthesizer added to state_classifier.go would leave this set short
+// and CrossMechanism silently under-reporting, which is the failure mode where
+// "found nothing" and "could not look" produce the same output. That is why
+// TestSyntheticReasonsNamesEveryConstant scans that file's own source instead
+// of trusting this list — the same move TestAllHookEvents_CoversEveryConstant
+// makes for hook events.
+var syntheticReasons = map[string]bool{
+	services.SyntheticWaitingReason:          true,
+	services.SyntheticTurnSettleReason:       true,
+	services.SyntheticQueuedTurnStartReason:  true,
+	services.SyntheticCatchUpTurnStartReason: true,
+	services.SyntheticCatchUpTurnDoneReason:  true,
+}
+
+// CrossMechanism reports the one reason-level disagreement that is not a
+// mechanism NAME and cannot be produced by renaming a string: exactly one side
+// of this pair is a SYNTHESIZED transition and the other is a classifier
+// verdict (or the two sides are different synthesizers).
+//
+// The distinction matters because it is the only reason-level difference that
+// survives compareOrdered's own argument. A synthesized transition recovers an
+// episode that has no classifier verdict at all, so a pair that puts one
+// against the other is describing two different things however well their state
+// edges line up — where "transcript activity (ready → working)" against "force
+// ready→working on first activity" is one transition under two names, measured
+// (see compareOrdered).
+//
+// It is a REPORT, not a demotion. The pair keeps its timing delta, because
+// removing it would silently shrink #1480's population; what the catalog gate
+// asserts is that every such pair is already visible to an existing mechanism.
+func (d timeDelta) CrossMechanism() bool {
+	if d.RecordedReason == d.ReplayedReason {
+		return false
+	}
+	return syntheticReasons[d.RecordedReason] || syntheticReasons[d.ReplayedReason]
+}
+
 // dropInitTransitions filters out the synthetic initial-state row (empty
 // PrevState) that replay always emits first but the sidecar never records.
 func dropInitTransitions(replayed []transition) []transition {
@@ -113,6 +159,27 @@ func dropInitTransitions(replayed []transition) []transition {
 // are not the same transition there — that is what state_differs means — so
 // subtracting their timestamps yields a number with no meaning, and counting it
 // would report one sequence divergence twice.
+//
+// The REASON strings are carried out of this traversal but are deliberately NOT
+// part of the match predicate, and #1707 is where that was measured rather than
+// assumed. The tempting rule — "the two sides give different reasons, so they
+// are not the same transition" — is false, because a reason names the MECHANISM
+// that produced a transition and both mechanisms exist on both sides. The
+// catalog's dominant shape is a session's FIRST ready→working, which the daemon
+// reaches through the classifier's transcript_activity default while the replay
+// reaches it through the force bounce; the same recording then agrees on
+// "force" for every LATER ready→working. As of #1707: 49 of 836 kind-matched
+// pairs differ on reason, 45 of them that one shape, and the differing
+// population sits CLOSER in time than the agreeing one (77.6% within 1ms
+// against 19.7%) — i.e. more provably the same transition, not less. Demoting
+// them would inject 45 false divergences and delete four real drift
+// measurements, three of them pinned by name in knownFirstTransitionDrift.
+// Those figures are quoted as of that measurement, not as current counts, the
+// same way driftThreshold's histogram is.
+//
+// What IS worth reporting is the narrow shape a rename cannot produce, and it
+// has its own predicate rather than a second reading of these two strings — see
+// CrossMechanism.
 func compareOrdered(recorded []lifecycle.Event, replayedReal []transition) (matched []timeDelta, mismatches []transitionMismatch) {
 	n := min(len(recorded), len(replayedReal))
 	matched = make([]timeDelta, 0, n)
@@ -120,9 +187,11 @@ func compareOrdered(recorded []lifecycle.Event, replayedReal []transition) (matc
 		r, p := recorded[i], replayedReal[i]
 		if r.PrevState == p.PrevState && r.NewState == p.NewState {
 			matched = append(matched, timeDelta{
-				Index: i,
-				Kind:  r.PrevState + "→" + r.NewState,
-				Delta: p.VirtualTime.Sub(r.Timestamp),
+				Index:          i,
+				Kind:           r.PrevState + "→" + r.NewState,
+				Delta:          p.VirtualTime.Sub(r.Timestamp),
+				RecordedReason: r.Reason,
+				ReplayedReason: p.Reason,
 			})
 			continue
 		}

--- a/tools/onboarding-factory/cmd/replay/issue1707_pairing_test.go
+++ b/tools/onboarding-factory/cmd/replay/issue1707_pairing_test.go
@@ -1,0 +1,348 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+
+	"irrlicht/core/application/services"
+	"irrlicht/core/domain/lifecycle"
+)
+
+// Issue #1707: compareOrdered pairs a replayed transition with a recorded one
+// on prev_state/new_state and nothing else, and #1480 then hands every
+// kind-matched pair a timing delta — so the issue asked whether `reason`
+// belongs in the match predicate.
+//
+// It does not, and the measurement is what settled it rather than the argument.
+// Over the committed catalog: 49 of 836 kind-matched pairs differ on reason, of
+// which 45 are one shape — a session's FIRST ready→working, reached through the
+// classifier's transcript_activity default on the daemon side and through the
+// force bounce on the replay side, with the same recording then agreeing on
+// "force" for every later ready→working. Those 45 sit CLOSER in time than the
+// pairs that agree (77.6% within 1ms against 19.7%), which is the opposite of
+// what two different transitions look like. Three more are reason strings
+// edited after their sidecar was frozen. Putting `reason` in the predicate
+// would demote all 48 and delete four genuine drift measurements — three of
+// them pinned by name in knownFirstTransitionDrift — to reach one pair.
+//
+// What this file adds is not that count. A raw reason-difference counter would
+// only ever grow, for two reasons nobody will fix, and would report the one
+// real pair a second time. It adds the narrow predicate the count was hiding —
+// CrossMechanism, exactly one side synthesized — plus the assertion the
+// decision to close actually rests on: every such pair in the catalog is
+// already visible to an existing mechanism. The day one is not, this fails and
+// #1707 is a live issue again.
+
+// ---------------------------------------------------------------------------
+// 1. The predicate, against a committed corpus.
+// ---------------------------------------------------------------------------
+
+// pairingCase is one testdata/pairing/*.json row. Same two input slices
+// testdata/timing/ supplies; the two want_* fields are this corpus's own.
+type pairingCase struct {
+	Description string            `json:"description"`
+	Recorded    []lifecycle.Event `json:"recorded"`
+	Replayed    []transition      `json:"replayed"`
+	WantCross   []int             `json:"want_cross_mechanism"`
+	WantUnrep   bool              `json:"want_unreported"`
+}
+
+// TestCrossMechanismCorpus drives every committed shape through the production
+// pairing and pins both verdicts — which pairs the predicate must report AND
+// which it must leave alone. Only the second kind of row separates a predicate
+// that discriminates from one that fires on any reason difference, which is
+// precisely the rule #1707 rejected.
+func TestCrossMechanismCorpus(t *testing.T) {
+	dir := filepath.Join("testdata", "pairing")
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read corpus dir: %v", err)
+	}
+
+	var ran, sawCross, sawSilent, sawUnreported, sawReported int
+	for _, e := range entries {
+		if e.IsDir() || filepath.Ext(e.Name()) != ".json" {
+			continue
+		}
+		name := e.Name()
+		t.Run(strings.TrimSuffix(name, ".json"), func(t *testing.T) {
+			raw, err := os.ReadFile(filepath.Join(dir, name))
+			if err != nil {
+				t.Fatalf("read %s: %v", name, err)
+			}
+			var tc pairingCase
+			if err := json.Unmarshal(raw, &tc); err != nil {
+				t.Fatalf("parse %s: %v", name, err)
+			}
+			if tc.Description == "" {
+				t.Fatalf("%s has no description — a corpus row states what it pins", name)
+			}
+			if len(tc.Recorded) == 0 || len(tc.Replayed) == 0 {
+				t.Fatalf("%s supplies %d recorded / %d replayed — an empty side pins nothing",
+					name, len(tc.Recorded), len(tc.Replayed))
+			}
+
+			ec := &extendedCheck{
+				RecordedCount: len(tc.Recorded),
+				ReplayedCount: len(tc.Replayed),
+			}
+			ec.TimeDeltas, ec.OrderedMismatches = compareOrdered(tc.Recorded, tc.Replayed)
+			ec.OrderedMatches = len(ec.TimeDeltas)
+
+			// A row that produced no kind-matched pair asserts nothing about a
+			// predicate that only reads kind-matched pairs, while still
+			// passing and still counting toward the balance guards below.
+			if len(ec.TimeDeltas) == 0 {
+				t.Fatalf("%s produced no kind-matched pair — the predicate under test is never "+
+					"consulted, so this row passes without asserting anything", name)
+			}
+
+			var got []int
+			for _, d := range ec.TimeDeltas {
+				if d.CrossMechanism() {
+					got = append(got, d.Index)
+				}
+			}
+			want := tc.WantCross
+			if want == nil {
+				want = []int{}
+			}
+			if got == nil {
+				got = []int{}
+			}
+			if !reflect.DeepEqual(got, want) {
+				t.Errorf("%s:\n  cross-mechanism pairs = %v, want %v", tc.Description, got, want)
+			}
+
+			// The second verdict, and the one the catalog gate turns on: a
+			// cross-mechanism pair is UNREPORTED when the recording carries no
+			// ordered divergence, because then nothing else in this package
+			// says the two sequences failed to line up.
+			gotUnrep := len(got) > 0 && !ec.Diverges()
+			if gotUnrep != tc.WantUnrep {
+				t.Errorf("%s:\n  unreported = %t, want %t (cross pairs %v, diverges %t)",
+					tc.Description, gotUnrep, tc.WantUnrep, got, ec.Diverges())
+			}
+
+			if len(want) > 0 {
+				sawCross++
+			} else {
+				sawSilent++
+			}
+			if tc.WantUnrep {
+				sawUnreported++
+			} else {
+				sawReported++
+			}
+			ran++
+		})
+	}
+
+	if ran == 0 {
+		t.Fatal("no corpus case ran — testdata/pairing/ is empty or unreadable, and an empty corpus reads exactly like a passing one")
+	}
+	if sawCross == 0 {
+		t.Error("no corpus case expects a cross-mechanism pair — nothing here proves the predicate can fire")
+	}
+	if sawSilent == 0 {
+		t.Error("no corpus case expects silence — nothing here separates this predicate from one that " +
+			"reports every reason difference, which is the rule #1707 measured and rejected")
+	}
+	if sawUnreported == 0 || sawReported == 0 {
+		t.Errorf("corpus expects unreported on %d cases and reported on %d — both are needed, or a gate "+
+			"flagging every cross-mechanism pair looks identical to one flagging correctly",
+			sawUnreported, sawReported)
+	}
+	t.Logf("corpus: %d cases (%d expect a cross-mechanism pair, %d expect silence; %d unreported, %d already reported)",
+		ran, sawCross, sawSilent, sawUnreported, sawReported)
+}
+
+// syntheticReasonConstant matches the exported reason constants in the
+// classifier's own source. Anchored at the start of a const declaration so
+// prose mentioning a name in a doc comment is not counted.
+var syntheticReasonConstant = regexp.MustCompile(`(?m)^const\s+(Synthetic\w*Reason)\s*=`)
+
+// TestSyntheticReasonsNamesEveryConstant is the completeness guard syntheticReasons
+// cannot give itself. Naming a constant is compile-checked, but a SIXTH
+// synthesizer added to state_classifier.go would leave the set short and
+// CrossMechanism silently under-reporting — "found nothing" and "could not
+// look" producing the same output, which AGENTS.md forbids. So the classifier's
+// own source is the list, the same move TestAllHookEvents_CoversEveryConstant
+// makes for hook events.
+func TestSyntheticReasonsNamesEveryConstant(t *testing.T) {
+	path := mustAbs(t, filepath.Join("..", "..", "..", "..", "core", "application", "services", "state_classifier.go"))
+	src, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v — this guard cannot run, which is not the same as passing", path, err)
+	}
+
+	matches := syntheticReasonConstant.FindAllStringSubmatch(string(src), -1)
+	if len(matches) == 0 {
+		t.Fatalf("%s declares no Synthetic*Reason constant — either the classifier moved or this "+
+			"scan stopped matching, and both read as a pass if allowed to", path)
+	}
+
+	// Resolve each declared constant's VALUE by name against the set, rather
+	// than re-parsing the string literal: the set is keyed on the value, and
+	// pairing the two by name is what would silently drift.
+	declared := map[string]bool{}
+	for _, m := range matches {
+		declared[m[1]] = true
+	}
+	byName := map[string]string{
+		"SyntheticWaitingReason":          services.SyntheticWaitingReason,
+		"SyntheticTurnSettleReason":       services.SyntheticTurnSettleReason,
+		"SyntheticQueuedTurnStartReason":  services.SyntheticQueuedTurnStartReason,
+		"SyntheticCatchUpTurnStartReason": services.SyntheticCatchUpTurnStartReason,
+		"SyntheticCatchUpTurnDoneReason":  services.SyntheticCatchUpTurnDoneReason,
+	}
+
+	var missing []string
+	for name := range declared {
+		value, known := byName[name]
+		switch {
+		case !known:
+			missing = append(missing, fmt.Sprintf("%s (new synthesizer, unknown to this package)", name))
+		case !syntheticReasons[value]:
+			missing = append(missing, fmt.Sprintf("%s (known, but its value is not in syntheticReasons)", name))
+		}
+	}
+	sort.Strings(missing)
+	if len(missing) > 0 {
+		t.Errorf("state_classifier.go declares %d synthesizer reason constant(s) syntheticReasons does not "+
+			"cover:\n  %s\nCrossMechanism under-reports by exactly these, silently.",
+			len(missing), strings.Join(missing, "\n  "))
+	}
+	// And the other direction: an entry naming a constant the classifier no
+	// longer declares is dead weight that reads as coverage.
+	for name := range byName {
+		if !declared[name] {
+			t.Errorf("this package still names %s, which state_classifier.go no longer declares", name)
+		}
+	}
+	if len(syntheticReasons) != len(byName) {
+		t.Errorf("syntheticReasons holds %d values but this guard checks %d names — one of the two "+
+			"grew without the other, so the guard no longer covers the set",
+			len(syntheticReasons), len(byName))
+	}
+	t.Logf("checked %d synthesizer reason constant(s) against syntheticReasons", len(declared))
+}
+
+// ---------------------------------------------------------------------------
+// 2. The catalog assertion — the one this issue closes on.
+// ---------------------------------------------------------------------------
+
+// knownCrossMechanismPairs enumerates every kind-matched pair in the committed
+// catalog where exactly one side is a synthesized transition, together with
+// what ALREADY reports it.
+//
+// Machine-generated: TestCrossMechanismPairsAreAlreadyReported prints the exact
+// map literal to paste when the set legitimately changes. It is not maintained
+// by hand and must not be.
+//
+// The single entry is #1707's one genuine finding, and reading it is what
+// closed that issue: the pair is one index behind a state_differs, so the two
+// sequences are shifted and everything after the shift is suspect by
+// construction. That recording is already the most-reported in the catalog —
+// it is divergenceWitness, the named witness for Diverges in
+// issue1503_census_test.go, and a named entry in knownFirstTransitionDrift
+// carrying this exact pair's delta ("-18.621s at pair 1").
+var knownCrossMechanismPairs = map[string]string{
+	"copilot/scenarios/1-4_session-resume/recordings/2026-08-05-19-02-01_irrlichd-0.5.9+4b58365/transcript.jsonl": "pair 1 (working→ready) -18.621s: daemon \"turn already complete at first discovery → synthetic catch-up\" vs replay \"agent finished turn → ready\"",
+}
+
+// TestCrossMechanismPairsAreAlreadyReported is the assertion #1707 was closed
+// on, and it is deliberately not a gate over the 49 reason-differing pairs.
+//
+// It fails in three ways, the same three shapes #1480's ratchet uses:
+//
+//   - a NEW cross-mechanism pair appears — a pairing or classifier change
+//     started comparing a synthesized transition against a classified one;
+//   - a pinned pair stops appearing, so the entry has rotted into an excuse;
+//   - any cross-mechanism pair sits in a recording that does NOT otherwise
+//     diverge, which is the condition the whole dismissal rests on. #1707 was
+//     closed because the one real pair is already reported by an existing
+//     mechanism; a pair that nothing else reports is that argument failing, and
+//     is the signal to reopen it rather than to widen this list.
+func TestCrossMechanismPairsAreAlreadyReported(t *testing.T) {
+	type crossPair struct {
+		name  string
+		delta timeDelta
+		clean bool // the recording carries no ordered divergence
+	}
+	var found []crossPair
+	var kindMatched int
+
+	checked := forEachSidecarRecording(t, func(name string, ec *extendedCheck) {
+		kindMatched += len(ec.TimeDeltas)
+		for _, d := range ec.TimeDeltas {
+			if !d.CrossMechanism() {
+				continue
+			}
+			found = append(found, crossPair{name: name, delta: d, clean: !ec.Diverges()})
+		}
+	})
+
+	// The measurement's own fail-loudly guard: a walk that reached every
+	// recording and produced no kind-matched pair compared nothing, and
+	// reporting "no cross-mechanism pairs" from it would be a finding about the
+	// harness wearing the shape of a clean catalog.
+	if kindMatched == 0 {
+		t.Fatalf("walked %d sidecar-driven recordings and produced ZERO kind-matched pairs — "+
+			"the predicate was never consulted", checked)
+	}
+
+	sort.Slice(found, func(i, j int) bool {
+		if found[i].name != found[j].name {
+			return found[i].name < found[j].name
+		}
+		return found[i].delta.Index < found[j].delta.Index
+	})
+
+	var literal strings.Builder
+	for _, p := range found {
+		fmt.Fprintf(&literal, "\t%q: %q,\n", p.name, describeCrossMechanism(p.delta))
+	}
+	t.Logf("%d cross-mechanism pair(s) over %d kind-matched pairs in %d recordings:\n%s",
+		len(found), kindMatched, checked, literal.String())
+
+	seen := map[string]bool{}
+	for _, p := range found {
+		seen[p.name] = true
+		if _, known := knownCrossMechanismPairs[p.name]; !known {
+			t.Errorf("%s newly pairs a synthesized transition against a classified one (%s) — a "+
+				"pairing or classifier change started comparing two different transitions. Paste "+
+				"the printed literal into knownCrossMechanismPairs only with a reason per entry.",
+				p.name, describeCrossMechanism(p.delta))
+		}
+		if p.clean {
+			t.Errorf("%s carries a cross-mechanism pair (%s) in a recording that does NOT otherwise "+
+				"diverge — nothing else in this package reports it. That is the condition #1707 was "+
+				"closed against; reopen it rather than widening knownCrossMechanismPairs.",
+				p.name, describeCrossMechanism(p.delta))
+		}
+	}
+	for name := range knownCrossMechanismPairs {
+		if !seen[name] {
+			t.Errorf("knownCrossMechanismPairs entry %q no longer pairs a synthesized transition "+
+				"against a classified one — delete it. Note that the catalog then exercises this "+
+				"predicate nowhere, so check the entry was fixed rather than merely stopped being "+
+				"reached (a recording that stops producing kind-matched pairs looks the same here).", name)
+		}
+	}
+}
+
+// describeCrossMechanism is the one spelling of a cross-mechanism figure,
+// shared by the pasteable literal and the two errors, so a reader comparing
+// them is looking at the same rendering.
+func describeCrossMechanism(d timeDelta) string {
+	return fmt.Sprintf("pair %d (%s) %+.3fs: daemon %q vs replay %q",
+		d.Index, d.Kind, d.Delta.Seconds(), d.RecordedReason, d.ReplayedReason)
+}

--- a/tools/onboarding-factory/cmd/replay/testdata/pairing/README.md
+++ b/tools/onboarding-factory/cmd/replay/testdata/pairing/README.md
@@ -1,0 +1,32 @@
+# Transition-pairing corpus (#1707)
+
+One file per reason-difference shape `timeDelta.CrossMechanism` must get right,
+committed rather than improvised so the evidence outlives the PR that added it
+(AGENTS.md: "Prefer committing that mutation to describing it").
+
+Each case supplies the two slices `compareOrdered` takes — already filtered,
+exactly as `runExtendedCheck` hands them over: `recorded` has passed
+`filterStateTransitions` (primary session, non-empty `prev_state`) and
+`replayed` has passed `dropInitTransitions` (no synthetic init row). Same shape
+as `testdata/timing/`, one field different.
+
+`want_cross_mechanism` lists the pair indices the predicate must report, and
+`want_unreported` says whether the resulting check would leave such a pair
+INVISIBLE — cross-mechanism in a sequence that does not otherwise diverge. That
+second verdict is the one the catalog gate turns on, and it needs both answers
+present: `catchup-against-classified.json` is the shape that must fail the
+catalog gate, `catchup-behind-a-state-differs.json` is the committed catalog's
+actual shape (copilot `1-4`, where the same pair sits behind a `state_differs`
+and `Diverges` already reports it), and if only one of those existed a gate that
+flagged every cross-mechanism pair and one that flagged correctly would be
+indistinguishable.
+
+Four cases must stay SILENT and they carry as much of the argument as the two
+that fire. `mechanism-name-split.json` is the catalog's dominant reason
+difference — 45 of the 49 measured at #1707 — and a predicate that reported it
+would turn one transition under two mechanism names into 45 findings.
+`reason-string-rename.json` is the population the issue predicted would grow,
+and it grows for a reason nobody will fix: a frozen sidecar keeps the wording
+that was current when it was recorded. `same-synthesizer-both-sides.json` pins
+that the predicate keys on the ASYMMETRY rather than on the presence of the word
+synthetic. `identical-reasons.json` is the ordinary vacuity guard.

--- a/tools/onboarding-factory/cmd/replay/testdata/pairing/catchup-against-classified.json
+++ b/tools/onboarding-factory/cmd/replay/testdata/pairing/catchup-against-classified.json
@@ -1,0 +1,26 @@
+{
+  "description": "a synthesized catch-up paired against a classifier verdict, in a sequence with no mismatch anywhere — the shape the catalog gate must flag, because nothing else in this package would report it",
+  "recorded": [
+    {
+      "seq": 1,
+      "ts": "2026-08-05T19:02:28.760000+02:00",
+      "kind": "state_transition",
+      "session_id": "s",
+      "prev_state": "working",
+      "new_state": "ready",
+      "reason": "turn already complete at first discovery → synthetic catch-up"
+    }
+  ],
+  "replayed": [
+    {
+      "virtual_time": "2026-08-05T19:02:10.139000+02:00",
+      "prev_state": "working",
+      "new_state": "ready",
+      "reason": "agent finished turn → ready"
+    }
+  ],
+  "want_cross_mechanism": [
+    0
+  ],
+  "want_unreported": true
+}

--- a/tools/onboarding-factory/cmd/replay/testdata/pairing/catchup-behind-a-state-differs.json
+++ b/tools/onboarding-factory/cmd/replay/testdata/pairing/catchup-behind-a-state-differs.json
@@ -1,0 +1,41 @@
+{
+  "description": "the committed catalog's actual shape (copilot 1-4): the same cross-mechanism pair sitting one index behind a state_differs, so the recording already diverges and the pair is reported by an existing mechanism",
+  "recorded": [
+    {
+      "seq": 1,
+      "ts": "2026-08-05T19:02:10.139000+02:00",
+      "kind": "state_transition",
+      "session_id": "s",
+      "prev_state": "working",
+      "new_state": "ready",
+      "reason": "agent finished turn → ready"
+    },
+    {
+      "seq": 2,
+      "ts": "2026-08-05T19:02:28.760000+02:00",
+      "kind": "state_transition",
+      "session_id": "s",
+      "prev_state": "working",
+      "new_state": "ready",
+      "reason": "turn already complete at first discovery → synthetic catch-up"
+    }
+  ],
+  "replayed": [
+    {
+      "virtual_time": "2026-08-05T19:02:07.787000+02:00",
+      "prev_state": "ready",
+      "new_state": "working",
+      "reason": "transcript activity (ready → working)"
+    },
+    {
+      "virtual_time": "2026-08-05T19:02:10.139000+02:00",
+      "prev_state": "working",
+      "new_state": "ready",
+      "reason": "agent finished turn → ready"
+    }
+  ],
+  "want_cross_mechanism": [
+    1
+  ],
+  "want_unreported": false
+}

--- a/tools/onboarding-factory/cmd/replay/testdata/pairing/identical-reasons.json
+++ b/tools/onboarding-factory/cmd/replay/testdata/pairing/identical-reasons.json
@@ -1,0 +1,39 @@
+{
+  "description": "the vacuity guard: both sides agree on the reason, so a predicate that reported everything would be indistinguishable from one that reports correctly",
+  "recorded": [
+    {
+      "seq": 1,
+      "ts": "2026-06-11T23:03:14.327000+02:00",
+      "kind": "state_transition",
+      "session_id": "s",
+      "prev_state": "ready",
+      "new_state": "working",
+      "reason": "force ready→working on first activity"
+    },
+    {
+      "seq": 2,
+      "ts": "2026-06-11T23:03:32.250000+02:00",
+      "kind": "state_transition",
+      "session_id": "s",
+      "prev_state": "working",
+      "new_state": "ready",
+      "reason": "agent finished turn → ready"
+    }
+  ],
+  "replayed": [
+    {
+      "virtual_time": "2026-06-11T23:03:14.327000+02:00",
+      "prev_state": "ready",
+      "new_state": "working",
+      "reason": "force ready→working on first activity"
+    },
+    {
+      "virtual_time": "2026-06-11T23:03:32.249000+02:00",
+      "prev_state": "working",
+      "new_state": "ready",
+      "reason": "agent finished turn → ready"
+    }
+  ],
+  "want_cross_mechanism": [],
+  "want_unreported": false
+}

--- a/tools/onboarding-factory/cmd/replay/testdata/pairing/mechanism-name-split.json
+++ b/tools/onboarding-factory/cmd/replay/testdata/pairing/mechanism-name-split.json
@@ -1,0 +1,24 @@
+{
+  "description": "the catalog's dominant reason difference — a session's first ready→working, reached through the classifier default on one side and the force bounce on the other. Two names for one transition: must stay silent, or 45 pairs become findings",
+  "recorded": [
+    {
+      "seq": 1,
+      "ts": "2026-06-11T23:03:14.327000+02:00",
+      "kind": "state_transition",
+      "session_id": "s",
+      "prev_state": "ready",
+      "new_state": "working",
+      "reason": "transcript activity (ready → working)"
+    }
+  ],
+  "replayed": [
+    {
+      "virtual_time": "2026-06-11T23:03:14.326000+02:00",
+      "prev_state": "ready",
+      "new_state": "working",
+      "reason": "force ready→working on first activity"
+    }
+  ],
+  "want_cross_mechanism": [],
+  "want_unreported": false
+}

--- a/tools/onboarding-factory/cmd/replay/testdata/pairing/reason-string-rename.json
+++ b/tools/onboarding-factory/cmd/replay/testdata/pairing/reason-string-rename.json
@@ -1,0 +1,24 @@
+{
+  "description": "a reason string edited after the recording was frozen, so the sidecar keeps the old wording forever. Benign by construction and expected to grow: must stay silent",
+  "recorded": [
+    {
+      "seq": 1,
+      "ts": "2026-04-11T11:52:09.100000+02:00",
+      "kind": "state_transition",
+      "session_id": "s",
+      "prev_state": "working",
+      "new_state": "waiting",
+      "reason": "turn ended with question → waiting"
+    }
+  ],
+  "replayed": [
+    {
+      "virtual_time": "2026-04-11T11:52:09.100000+02:00",
+      "prev_state": "working",
+      "new_state": "waiting",
+      "reason": "turn ended with question or cue → waiting"
+    }
+  ],
+  "want_cross_mechanism": [],
+  "want_unreported": false
+}

--- a/tools/onboarding-factory/cmd/replay/testdata/pairing/same-synthesizer-both-sides.json
+++ b/tools/onboarding-factory/cmd/replay/testdata/pairing/same-synthesizer-both-sides.json
@@ -1,0 +1,24 @@
+{
+  "description": "a synthesized transition the replay reproduced as the SAME synthesizer — agreement, not a cross-mechanism pair. Pins that the predicate keys on the asymmetry and not on the word synthetic",
+  "recorded": [
+    {
+      "seq": 1,
+      "ts": "2026-04-26T11:56:30.500000+02:00",
+      "kind": "state_transition",
+      "session_id": "s",
+      "prev_state": "working",
+      "new_state": "waiting",
+      "reason": "user-blocking tool opened and closed in one pass → synthetic waiting"
+    }
+  ],
+  "replayed": [
+    {
+      "virtual_time": "2026-04-26T11:56:30.500000+02:00",
+      "prev_state": "working",
+      "new_state": "waiting",
+      "reason": "user-blocking tool opened and closed in one pass → synthetic waiting"
+    }
+  ],
+  "want_cross_mechanism": [],
+  "want_unreported": false
+}

--- a/tools/onboarding-factory/cmd/replay/testdata/pairing/two-different-synthesizers.json
+++ b/tools/onboarding-factory/cmd/replay/testdata/pairing/two-different-synthesizers.json
@@ -1,0 +1,26 @@
+{
+  "description": "both sides synthesized, by DIFFERENT synthesizers — a queued-turn re-open against a catch-up turn start, two recoveries of two different collapsed episodes. A cross-mechanism pair even though neither side is a classifier verdict",
+  "recorded": [
+    {
+      "seq": 1,
+      "ts": "2026-04-26T11:56:30.500000+02:00",
+      "kind": "state_transition",
+      "session_id": "s",
+      "prev_state": "ready",
+      "new_state": "working",
+      "reason": "new session created (turn already in progress at first discovery)"
+    }
+  ],
+  "replayed": [
+    {
+      "virtual_time": "2026-04-26T11:56:30.500000+02:00",
+      "prev_state": "ready",
+      "new_state": "working",
+      "reason": "queued follow-up turn began → synthetic re-open"
+    }
+  ],
+  "want_cross_mechanism": [
+    0
+  ],
+  "want_unreported": true
+}

--- a/tools/onboarding-factory/cmd/replay/timing_drift.go
+++ b/tools/onboarding-factory/cmd/replay/timing_drift.go
@@ -37,6 +37,18 @@ type timeDelta struct {
 	Index int
 	Kind  string
 	Delta time.Duration
+
+	// RecordedReason/ReplayedReason are the two sides' reason strings, carried
+	// out of the same traversal that paired them (#1707). They are what
+	// CrossMechanism reads; see compareOrdered for why a difference between
+	// them is NOT a demotion, and extended_check.go's CrossMechanism for the
+	// one shape of difference that is worth reporting.
+	//
+	// No json tag is needed — timeDelta is reached only through
+	// extendedCheck.TimeDeltas, which is `json:"-"`, so nothing here can move a
+	// golden byte.
+	RecordedReason string
+	ReplayedReason string
 }
 
 // Abs is |Delta|, the quantity every bucket and percentile below is taken over.


### PR DESCRIPTION
Closes #1707.

## What I re-derived, and where it differs from the issue

The issue's numbers come from an unpushed local branch (`8171d810`), so I re-measured
from scratch — three fields onto `timeDelta` inside `compareOrdered`'s existing traversal,
then a throwaway walk over the catalog. Over **314 sidecar-driven recordings / 836
kind-matched pairs** (the issue says 834; the catalog gained one recording in #1699, and
836 is what `minKindMatchedPairs` already pins):

| n | shape | |
|---|---|---|
| 44 | daemon `transcript activity (ready → working)` vs replay `force ready→working on first activity` | mechanism-name split |
| **1** | the same shape **mirrored** (codex `4-2`: daemon forced, replay classified) | mechanism-name split |
| 2 | `turn ended with question → waiting` vs `…question or cue…` | frozen-sidecar rename |
| 1 | `user ESC interrupt while working → ready (cancellation)` vs `…→ ready` | frozen-sidecar rename |
| **1** | copilot `1-4`: synthesized catch-up vs classified | genuinely two transitions |

**49 total.** Note the issue's own table sums to **48** — it lost the mirrored codex `4-2`
case, which is the same shape with the sides swapped. That is a one-low of exactly the kind
#1503 was filed about, in the issue that inherited #1503's lesson.

## The 44-benign check — step one, and it held

The issue marks that classification **assumed**, arrived at by reading two strings. Four
independent measurements, none of which is the strings:

1. **Timing distribution.** The reason-**differing** population is *tighter* than the
   agreeing one — 77.6% within 1ms against 19.7%, p50 538µs against 2.95ms. Two different
   transitions do not land sub-millisecond apart 38 times out of 49. Only 5 of 49 exceed
   #1480's 1s threshold, and **all five are already named in `knownFirstTransitionDrift`**.
2. **Position.** Every one of the 45 mechanism-split pairs is **pair 0** — the session's
   first transition.
3. **The surrounding sequence.** In the recordings that do not otherwise diverge, every
   other pair matches on reason. `claudecode/2-7` is the clearest: 10/10 matched, zero
   mismatches, pair 0 split, and pairs 2/4/6/8 (later `ready→working`s) both say `force`.
4. **The sidecar itself.** `gemini-cli/2-1`'s `events.jsonl` shows the daemon creating the
   session `ready` at 14.325 and emitting `ready→working` via the classifier default at
   14.327 — then `force` for every later one (19: seq 123). Both mechanisms exist on both
   sides; which one fires on the *first* activity after session creation is where the two
   differ.

So the 44 (45) are one transition under two mechanism names. **Had this gone the other
way — a meaningful fraction of them genuinely mispaired — I would have taken option (1)**,
because at that point the demotion is buying a real population rather than one pair, and
the drift measurements it deletes would have been meaningless anyway.

## The decision: neither option as written

**Not option (1) — `reason` in the match predicate.** Refuted by the measurement above. It
would demote 45 pairs the evidence says are the same transition, delete four genuine drift
measurements (three currently pinned by name), and flip 14 currently sequence-clean
recordings into the divergent census — a definitional change wearing the shape of a
behaviour finding. Mutation M2 below is exactly this predicate, and its output is the cost.

**Not option (2) as written either — a raw reason-difference count.** 48 of the 49 are
benign *by construction* and grow monotonically for two reasons nobody will fix (a
mechanism split that is a property of the daemon's entry paths, and renames a frozen
sidecar can never catch up with). And the 1 real pair is one index behind a `state_differs`
at pair 0, in the recording that is **already** `divergenceWitness` (issue1503) **and**
already a named `knownFirstTransitionDrift` entry carrying this exact pair's `-18.621s`.
Counting it again is precisely what `compareOrdered`'s own comment forbids: "counting it
would report one sequence divergence twice."

**What lands is the narrow predicate the count was hiding.** `timeDelta.CrossMechanism` —
exactly one side is a **synthesized** transition (a recovery of a collapsed/missed episode)
and the other is a classifier verdict. That is the only reason-level difference that
survives #1480's argument and the only one a rename cannot produce. It measures **1** on
the committed catalog, and it is a **report, not a demotion**: the pair keeps its timing
delta.

`TestCrossMechanismPairsAreAlreadyReported` then asserts the thing this issue is actually
closed on: **every cross-mechanism pair in the catalog is already visible to an existing
mechanism.** Three failure shapes, #1480's: a new pair appears; a pinned pair rots; or —
the one that matters — a cross-mechanism pair sits in a recording that does **not**
otherwise diverge, which is the dismissal's premise failing and the signal to reopen #1707
rather than widen the list. The pinned list is machine-generated and pasted from the test's
own output.

## Nothing serialized

The reason strings ride `timeDelta`, reached only through `extendedCheck.TimeDeltas`
(`json:"-"`), following that field's own precedent. **Zero goldens change** — `git status`
after a full `tools/replay-fixtures.sh` shows only the four source paths.

## Committed mutation evidence

`testdata/pairing/` — seven shapes, both verdicts, in `testdata/timing/`'s shape. Three
mutations, each applied and reverted in isolation:

| mutation | red on | silent on |
|---|---|---|
| **M1** drop the asymmetry (`\|\|` instead of `!=` over the synthetic set) | `same-synthesizer-both-sides` only | every other corpus row, both catalog arms |
| **M2** the issue's option (1): `RecordedReason != ReplayedReason` | `mechanism-name-split`, `reason-string-rename`, **and both catalog arms** — 48 new pairs, 14 of them in clean recordings | the two catch-up rows, `identical-reasons` |
| **M3** drop `SyntheticCatchUpTurnDoneReason` from the set | `TestSyntheticReasonsNamesEveryConstant`, the **rot** arm, both catch-up rows | the four silent rows |

M2's output is also the answer to "what would option (1) have cost", re-derivable by anyone.

`TestSyntheticReasonsNamesEveryConstant` scans `state_classifier.go`'s own source rather
than trusting the set — a sixth synthesizer would otherwise leave `CrossMechanism` silently
under-reporting, which is "found nothing" and "could not look" producing the same output.
Both directions are checked, and an unreadable file or a zero-match scan is a refusal.

## Verification

- `go test ./tools/onboarding-factory/... -race -count=1` — PASS
- `tools/replay-fixtures.sh` — PASS, no golden moved
- `tools/preflight.sh --only go|arch|tools|skills` — PASS; the pre-push hook's full
  `--changed` run (incl. security) also PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)
