### PR TITLE
docs(macos): accept image snapshots as reference-host-only, in one place, with the count derived (#1615)

### DIFF
--- a/.github/workflows/macos-swift.yml
+++ b/.github/workflows/macos-swift.yml
@@ -48,6 +48,14 @@ name: macOS (Swift)
 # suite on a developer Mac, where the display, the fonts and the audio stack
 # are the ones the app actually ships against.
 #
+# WHY five suites are skipped rather than fixed, and why that is now permanent,
+# is in `AGENTS.md`'s "macOS app" bullet under Testing — the decision record for
+# #1615. It is not restated here: this file's own copy of it said CI gates "270
+# of 318 tests", then "272 of 320", and was 115 tests stale by the time #1615
+# closed. The current figures are printed by
+# `ImageSnapshotCIScopeTests.testTheUngatedPopulationIsExactlyTheSkippedSuites`
+# on every run of the suite, and the ungated count is asserted there.
+#
 # A THIRD job, `swift-snapshot-evidence`, runs the five skipped suites on
 # purpose and uploads what they render (#1615, step 1). Until it existed, the
 # skipped suites failed on no machine anybody could look at, so every statement
@@ -59,17 +67,36 @@ name: macOS (Swift)
 # thing. Since #1678 those five are told apart from each other as well, not
 # only from health: the first used to be reported as the second.
 #
-# It costs a third macOS job per PR (macOS minutes bill at 10×). That is
-# deliberate for as long as the suites are skipped and #1615's step 3 is open;
-# once the policy question is answered, narrowing this job to
-# `workflow_dispatch` — or deleting it — is the cheap part.
+# Since #1615 it runs on `workflow_dispatch` ONLY, and that is the cost the
+# decision releases: it collected the evidence for a policy question that is now
+# answered, and a third macOS job per PR (macOS minutes bill at 10×) buys
+# nothing while the answer stands. It is narrowed rather than deleted because it
+# is the only way anyone can ever look at these pixels again — a runner OS bump,
+# a contributor asking whether the residual moved, or #1615 being reopened — and
+# rebuilding it from a git revert is strictly more work than dispatching it:
+#
+#   gh workflow run "macOS (Swift)" --ref <branch>
+#
+# runs all three jobs and produces two artifacts (14-day retention):
+# `swift-snapshot-evidence` — every failure image the five suites wrote, the
+# committed `__References__` beside them to diff against, and
+# `RasterPrimitiveEvidenceTests`' six primitive rasters + hashes — and
+# `swift-snapshot-evidence-log`, the run itself. There is no diff image: that
+# branch of SnapshotTesting is behind `__XCODE_BUILT_PRODUCTS_DIR_PATHS`, which
+# SwiftPM does not set, so the diff is computed off the pair after download.
+#
+# Note what it becomes on a PR: SKIPPED, not absent. That is the distinction the
+# `paths:` decision above turns on — a skipped job is reported and legible,
+# where an undispatched workflow's check reads as "still queued".
 
 on:
   pull_request:
   push:
     branches: [main]
-  # So the pixels can be re-collected on demand — for a toolchain bump on the
-  # runner, say — without pushing a commit to ask.
+  # The build and test jobs run on every event here. `swift-snapshot-evidence`
+  # runs on THIS one only (its `if:` below) — since #1615 it is the sole way its
+  # pixels are collected, which is why the trigger stays and why the job names
+  # it rather than the workflow dropping it.
   workflow_dispatch:
 
 permissions:
@@ -151,45 +178,30 @@ jobs:
       # `<target>.<class>`, so either alone stops covering the harness the
       # moment a class is added or the target is renamed.
       #
-      # The five suites after them are image snapshots that still differ from
-      # their references on a runner AFTER the scale fix, and the reason they
-      # are skipped rather than re-recorded is the substance of #1530's blocker
-      # 1. Measured on this workflow's own first run: the failure message
-      # changed from the pixel-count form (`…@(350.0, 48.0) does not match
-      # reference@(350.0, 48.0).`, 35×) to the byte form (`Newly-taken snapshot
-      # does not match reference.`, 36×), which is the branch in
-      # SnapshotTesting's `compare` that is only reachable once the pixel
-      # dimensions agree. So the scale half is fixed and a rasterisation half
-      # is now visible underneath it.
+      # The five suites after them are image snapshots that differ from their
+      # references on a runner, byte for byte, for a reason nobody has explained
+      # — and that is now a permanent, deliberate exclusion rather than a
+      # pending fix. The decision, the pixel measurements behind it, and the
+      # three levers it rejects (re-recording, a perceptual tolerance, pinning
+      # the runner's Xcode — all three measured) are in `AGENTS.md`'s "macOS
+      # app" bullet under Testing. No figure from it is repeated here; this
+      # comment carried two and both went stale.
       #
-      # It is NOT the Xcode difference this comment used to name. Measured by
-      # #1615's evidence job and its throwaway probe: all 15 Xcodes installed
-      # on `macos-latest` — 26.0 through 26.6, including 26.3.0 build 17C529,
-      # bit-for-bit the reference Mac's own — produce the same 36 failures,
-      # while that Mac on that build produces none. The toolchain is not the
-      # variable; the OS is (runner macOS 26.5.2 / 25F84, reference 26.5 /
-      # 25F71). Re-recording to make it green is the move #1034
-      # and #1044 both made and both got wrong, and #1509 measured a perceptual
-      # tolerance wide enough to absorb this drift as also wide enough to pass
-      # a missing architecture segment. The residual is #1615.
-      #
-      # What they render is not lost by being skipped: `swift-snapshot-evidence`
-      # below runs these same five and uploads the images, which is how #1615
-      # gets looked at rather than reasoned about.
+      # Two image-snapshot suites are deliberately NOT skipped: they pass on a
+      # runner, which is itself the evidence that the residual is
+      # content-dependent rather than a blanket host difference.
       #
       # This list cannot silently drift: `Tests/ImageSnapshotCIScopeTests.swift`
       # derives the set of image-snapshot suites from the test sources and
-      # cross-checks it against these very arguments — and, since the evidence
-      # job exists, against ITS arguments too, so the two invocations cannot
-      # come to disagree about which suites are the skipped ones.
+      # cross-checks it against these very arguments — and against the evidence
+      # job's arguments too, so the two invocations cannot come to disagree
+      # about which suites are the skipped ones. That file also counts what the
+      # skip costs and asserts it, so the population CI never grades cannot grow
+      # without a line in a diff.
       #
-      # This still gates 272 of 320 tests, against 0 before — measured, on this
-      # workflow's own run, not derived from the list above by hand (the first
-      # draft of this comment said "270 of 318" and was stale by exactly the
-      # two tests the tripwire itself adds). Two image-snapshot suites are
-      # deliberately NOT skipped — they pass on a runner, and their passing is
-      # itself evidence that the residual is content-dependent rather than a
-      # blanket toolchain difference.
+      # What they render is not lost by being skipped: `swift-snapshot-evidence`
+      # below runs these same five on demand and uploads the images (see the
+      # `gh workflow run` line in this file's header).
       - name: Test (bounded, streamed under a pty)
         shell: bash
         run: |
@@ -312,7 +324,16 @@ jobs:
   # this job is to run the assertions that fail, so sharing a conclusion with
   # it would either turn that check red for the expected outcome or force this
   # one to swallow its own failures.
+  #
+  # ON DEMAND ONLY since #1615 (see this file's header for the trade and for how
+  # to invoke it). The condition is on the JOB rather than the workflow because
+  # the workflow's other two jobs must keep running on every PR and push, and
+  # because `Tests/ImageSnapshotCIScopeTests.swift` cross-checks this job's
+  # `--filter` list against `swift-test`'s `--skip` list — splitting it into a
+  # dispatch-only workflow of its own would move one half of that check into a
+  # file the check does not read.
   swift-snapshot-evidence:
+    if: github.event_name == 'workflow_dispatch'
     runs-on: macos-latest
     timeout-minutes: 20
     steps:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1752,6 +1752,91 @@ Before marking a ticket done, run the full suite — every layer must pass:
   cap with an empty log. `swift` is still the one gate deliberately **stronger**
   locally than in CI — a runner has a virtual display, a stock font set and no
   usable audio stack — but it is no longer the only place the suite runs.
+  **Image snapshots are graded on the reference host only, permanently and by
+  choice. This paragraph is the decision record for #1615; `macos-swift.yml`'s
+  header, `ImageSnapshotCIScopeTests` and the issue threads point here rather
+  than restating it.** Five suites — `BackchannelRulesViewSnapshotTests`,
+  `GroupViewSnapshotTests`, `HistoryViewSnapshotTests`,
+  `SessionListUnappliedGrantsWiringTests`, `SessionRowSnapshotTests` — are
+  `--skip`ped in CI and run under `tools/preflight.sh --only swift` and the
+  pre-push hook and nowhere else. Two further image-snapshot suites
+  (`PermissionWizardEffectErrorRenderTests`, `UnappliedGrantsBannerRenderTests`)
+  reproduce byte-identically on a runner, stay gated there, and their passing is
+  itself the evidence that the residual is content-dependent rather than a
+  blanket host difference.
+  **How big the exclusion is, is DERIVED and asserted rather than typed.**
+  `ImageSnapshotCIScopeTests.testTheUngatedPopulationIsExactlyTheSkippedSuites`
+  counts those five suites' tests off the live bundle through XCTest's own
+  `XCTestSuite(forTestCaseClass:)` — so it agrees with a run's `Executed N
+  tests` by construction rather than by a source scan agreeing with a test
+  runner by luck — pins the total at **48**, and prints the whole census on
+  every run. It also fails if a skipped suite goes EMPTY, which is the rot this
+  decision creates: a suite that runs on one machine and holds nothing runs
+  nowhere, and reads exactly like one that passes everywhere. The gated
+  remainder is printed and deliberately NOT pinned, because it moves with every
+  test anyone adds anywhere in the target — 388 of 436 measured on 2026-08-19 on
+  the reference Mac. That split is "Replay's measured figures" applied one
+  platform over, and this is the file that earned it: `macos-swift.yml`'s header
+  claimed "270 of 318", was corrected to "272 of 320" by the PR that measured
+  it, and was 115 tests stale (320 → 435) by the time #1615 was closed.
+  **Re-recording the references is not the fix, and is the one move to refuse.**
+  It is what #1034 and #1044 both did, both wrongly, to what turned out to be an
+  appearance-mode bug (the cautionary tale below). Here it is worse: the runner
+  is on a *newer* OS than the reference Mac (runner macOS 26.5.2 / 25F84,
+  reference 26.5 / 25F71), so re-recording chases a moving image AND inverts
+  which host is authoritative — the app ships to the developer Mac's OS, not to
+  a runner image. `git status --porcelain platforms/macos/Tests/__Snapshots__`
+  is the check; every PR in this line of work (#1614, #1630/#1658, #1659, #1662,
+  #1628, #1615) regenerated **zero** PNGs, and the untouched 53-reference set is
+  what makes each of their claims checkable.
+  **A perceptual tolerance is not the fix either**: #1509 measured one wide
+  enough to absorb this class of drift as also wide enough to pass a **missing
+  architecture segment**. A tolerance that admits the defect it was sized
+  against is a deleted assertion with a number on it.
+  **What is measured, and what is still unknown.** The pixels HAVE been looked
+  at (#1628, from the evidence job's artifacts) and the hypothesis #1615 opened
+  with — "the failing renders are the ones drawing glyph/vector content" — is
+  **dead as stated**: a fixture rendering one thing each (flat fill, stroked
+  bezier, system-font text, an SF Symbol, and each of those again in a
+  translucent dynamic `Color.secondary`) came back byte-identical between runner
+  and reference host on all six. The 36 failures are two populations: 34 whose
+  differing pixels sit inside the 28 × 28 px box `SessionState.adapterIcon`
+  draws, at maxΔ 1-5/255 over 0.01-0.9% of the image — brand icons rasterised
+  from an inline SVG string through `NSImage(data:)`, a path no SwiftUI
+  primitive reaches — and 2 `BackchannelRulesView` control labels at maxΔ
+  142/197, the same glyphs sitting ~1 device pixel lower, i.e. a sub-point
+  baseline landing on a different pixel phase. The toolchain is measured NOT to
+  be the variable: all 15 Xcodes on `macos-latest`, including 26.3.0 build
+  17C529 which is bit-for-bit the reference Mac's, produce the same 36 failures,
+  while that Mac on that build produces none. **What nobody has established is
+  WHY** — "the OS differs" is where the evidence stops, not a root cause, and
+  accepting the containment does not make anything about `NSImage(data:)`'s SVG
+  rasteriser known. One residual is predicted rather than measured: #1658 pinned
+  the locale, so `testBackchannelRuleContextTokens`'s remaining difference
+  *should* now be rasterisation only, and no post-#1658 runner render has been
+  diffed against the reference to confirm it.
+  **What the decision costs, stated here rather than discovered later: a
+  contributor without a Mac cannot run these 48 tests at all, and CI will not
+  run them either.** An outside contributor's image-snapshot change is ungraded
+  until the maintainer next runs `tools/preflight.sh --only swift` or pushes
+  through the pre-push hook — and CI is not merely silent about it, it is
+  confidently green, because the suites are skipped by name. That contribution
+  shape is not hypothetical: PR #1470 was merged from a fork on 2026-08-19
+  touching five files in `platforms/macos/`. It touched no image-snapshot suite,
+  so it is the shape rather than an instance, and no cheap mitigation is built
+  here — the honest statement is that the local gate and the pre-push hook are
+  the whole of the coverage for those 48, and that a fork PR's green `swift-test`
+  check says nothing about them.
+  **The pixels can still be collected, on demand.** `swift-snapshot-evidence`
+  ran on every PR while the policy question was open and now runs on
+  `workflow_dispatch` only — narrowed rather than deleted, because it is the
+  only way anyone can look at these renders again (a runner OS bump, a
+  contributor asking whether the residual moved, #1615 reopened), and a third
+  macOS job per PR at 10× billing buys nothing while the answer stands. `gh
+  workflow run "macOS (Swift)" --ref <branch>` publishes the failure images, the
+  committed references beside them and the six primitive rasters; the job still
+  fails loudly when it cannot COLLECT, which is the property that made its
+  output trustworthy in the first place.
   Four host dependencies had to go first, and the general lesson is worth more
   than the four fixes: each was a value read from the MACHINE where the
   equivalent value was available from the INPUT. Image snapshots rasterised at
@@ -2161,11 +2246,12 @@ Before marking a ticket done, run the full suite — every layer must pass:
   form is the only option.
   **And the `rate_limit` fixture #1663 anticipated is seeded, but NOT as a
   committed PNG.** The clock obstacle is gone; what remains is unrelated to it
-  and is why the PNG form is still the wrong one — per #1615 every
-  committed-reference image suite currently fails on a runner over
-  rasterisation, so a new one would have to be classified as skipped in
-  `ImageSnapshotCIScopeTests` and would buy a check that runs on one Mac. The
-  two-render-in-memory form runs everywhere, so that is what the fixture is.
+  and is why the PNG form is still the wrong one — a new committed-reference
+  image suite is a coin flip on whether it is gradeable in CI at all (5 of the 7
+  existing ones are not; see the reference-host-only decision record in the
+  macOS bullet above), and one that lands on the wrong side buys a check that
+  runs on one Mac. The two-render-in-memory form runs everywhere, so that is
+  what the fixture is.
   And no, a test
   run does not modify the user's real app preferences:
   `UserDefaults.standard` under `swift test` resolves to

--- a/platforms/macos/Tests/ImageSnapshotCIScopeTests.swift
+++ b/platforms/macos/Tests/ImageSnapshotCIScopeTests.swift
@@ -331,17 +331,22 @@ final class ImageSnapshotCIScopeTests: XCTestCase {
         for index in 0..<Int(count) {
             let candidate: AnyClass = buffer[index]
             let mangled = NSStringFromClass(candidate).split(separator: ".", maxSplits: 1)
-            guard mangled.count == 2, mangled[0] == module else { continue }
-            var parent: AnyClass? = class_getSuperclass(candidate)
-            while let step = parent {
-                if step == XCTestCase.self {
-                    found[String(mangled[1])] = candidate
-                    break
-                }
-                parent = class_getSuperclass(step)
-            }
+            guard mangled.count == 2, mangled[0] == module, descendsFromXCTestCase(candidate) else { continue }
+            found[String(mangled[1])] = candidate
         }
         return found
+    }
+
+    /// Walks the superclass chain rather than asking `is XCTestCase.Type`,
+    /// because a subclass of a subclass is still a suite XCTest runs and the
+    /// count has to match what a run reports.
+    private static func descendsFromXCTestCase(_ candidate: AnyClass) -> Bool {
+        var parent: AnyClass? = class_getSuperclass(candidate)
+        while let step = parent {
+            if step == XCTestCase.self { return true }
+            parent = class_getSuperclass(step)
+        }
+        return false
     }
 
     /// How many tests XCTest would run for one class — asked of XCTest itself,

--- a/platforms/macos/Tests/ImageSnapshotCIScopeTests.swift
+++ b/platforms/macos/Tests/ImageSnapshotCIScopeTests.swift
@@ -1,39 +1,21 @@
+import ObjectiveC
 import XCTest
 
-/// Keeps `macos-swift.yml`'s image-snapshot skip list honest (#1530).
+/// Keeps `macos-swift.yml`'s image-snapshot skip list honest (#1530), and
+/// measures what that list costs (#1615).
 ///
-/// ## Why there is a skip list at all
+/// ## The policy this file enforces is written down once, in AGENTS.md
 ///
-/// #1530's blocker 1 was two problems stacked, and the first was masking the
-/// second. The committed references are 2× and a runner's display is 1×, so
-/// every comparison failed on PIXEL COUNT — SnapshotTesting returns from that
-/// guard before comparing a byte. `PinnedScaleSnapshot` fixes that half, which
-/// is what made the second half visible for the first time: on the runner the
-/// failure message changed from
-///
-///     Newly-taken snapshot@(350.0, 48.0) does not match reference@(350.0, 48.0).   (35×, pixel counts)
-///
-/// to
-///
-///     Newly-taken snapshot does not match reference.                               (36×, bytes)
-///
-/// The remaining difference is rasterisation, and it is #1615. It is not the
-/// Xcode gap this comment used to name: measured by that issue's evidence job,
-/// all 15 Xcodes on `macos-latest` — including 26.3.0 build 17C529, the
-/// reference Mac's own build — produce the same 36 failures, and the residual
-/// is confined to the brand icons `SessionState.adapterIcon` rasterises from
-/// inline SVG through `NSImage(data:)`, at 1-5/255 on 0.3-0.9% of a row's
-/// pixels. It is deliberately NOT papered over here:
-/// re-recording a snapshot to make it pass is the exact move #1034 and #1044
-/// both made and both got wrong, and #1509 measured a perceptual tolerance
-/// wide enough to absorb this drift as also wide enough to pass a missing
-/// architecture segment.
-///
-/// So CI runs everything else — 272 of 320 tests, against 0 before — and these
-/// suites stay gated on a developer Mac by `tools/preflight.sh --only swift`,
-/// where they demonstrably pass. Both figures are read off runs rather than
-/// added up from the table below; the first draft added them up and was two
-/// low, having forgotten the tests in this very file.
+/// Image snapshots are graded on the reference host only, permanently and by
+/// choice. The decision, the measured evidence behind it, why re-recording and
+/// `perceptualPrecision` are not the fix, and what is still unknown are all in
+/// `AGENTS.md`'s "macOS app" bullet under Testing (#1615, step 3). Nothing here
+/// restates any of it, because a fact written down in N places drifts in N-1 of
+/// them — which is not a worry but this file's own history: the paragraph
+/// removed from here said CI gates "272 of 320 tests", a figure measured once
+/// on one run and 115 tests stale when #1615 was closed. It lives in
+/// `testTheUngatedPopulationIsExactlyTheSkippedSuites` below now, where it is
+/// re-derived on every run.
 ///
 /// ## Why this test exists
 ///
@@ -50,6 +32,14 @@ import XCTest
 /// deliberately opposite argument lists, so the parse below is per-invocation:
 /// a union over the file is satisfied by moving a suite from one command to the
 /// other, which is exactly the drift worth catching.
+///
+/// That job now runs only on `workflow_dispatch` (the policy it was collecting
+/// evidence for is decided), and the parse deliberately does not care: it reads
+/// the two commands' ARGUMENTS, not the triggers, so both invocations stay
+/// cross-checked whether or not one of them fires on a PR. A job whose skip
+/// list has silently drifted apart from this classification produces a
+/// misleading artifact on the day someone finally dispatches it, which is worse
+/// than an ordinary red — nothing else would ever look.
 final class ImageSnapshotCIScopeTests: XCTestCase {
 
     /// Every suite that takes an image snapshot, and whether `macos-swift.yml`
@@ -289,5 +279,130 @@ final class ImageSnapshotCIScopeTests: XCTestCase {
                       "an evidence-only suite now takes image snapshots: \(derived.intersection(Self.evidenceOnlySuites).sorted())")
         XCTAssertTrue(Set(Self.imageSnapshotSuites.keys).isDisjoint(with: Self.evidenceOnlySuites),
                       "a suite is classified both as an image-snapshot suite and as evidence-only")
+    }
+
+    // MARK: - What the decision costs, counted rather than typed (#1615)
+
+    /// How many tests the reference-host-only decision takes out of CI.
+    ///
+    /// Pinned because it is the one figure the decision record in `AGENTS.md`
+    /// states, and a number that documents behaviour without being produced by
+    /// it drifts silently and is then quoted with full confidence — this
+    /// repo's rule for the replay census, applied to the same failure one
+    /// platform over. It moves only when someone adds or removes a test in a
+    /// suite CI does not run, which is precisely the event the record needs
+    /// surfaced: a test written into an ungated suite is graded on one machine
+    /// in the world, forever, and that should cost a deliberate line in a diff.
+    ///
+    /// The TOTAL is deliberately not pinned. It moves with every test added
+    /// anywhere in the target — 320 when the workflow header typed it, 435 at
+    /// #1615 — so pinning it would make an unrelated PR edit a literal about
+    /// image snapshots, and the ratchet would be reset rather than read. It is
+    /// printed instead, on every run of this test and by every run of the
+    /// suite itself (`Executed N tests`).
+    private static let committedUngatedTestCount = 48
+
+    /// The module the gated test target's classes live in, read off this class
+    /// rather than typed: a literal here that stopped naming the real target
+    /// would select no classes at all, and "found nothing" is the failure this
+    /// whole file exists to make impossible.
+    private static var gatedTargetModule: String {
+        String(NSStringFromClass(ImageSnapshotCIScopeTests.self).split(separator: ".").first ?? "")
+    }
+
+    /// Every `XCTestCase` subclass in this target, by simple name.
+    ///
+    /// Deliberately scoped to one module, which is what keeps
+    /// `LauncherTestHarness` out — its classes drive real applications through
+    /// `NSRunningApplication`, and while merely counting a class's test methods
+    /// runs none of them, the safest way not to run that target is not to touch
+    /// it. That also makes the total the RIGHT one: `swift test` skips the
+    /// harness at every invocation this repo documents, so the number below is
+    /// the number a run reports.
+    private static func testCaseClasses() -> [String: AnyClass] {
+        let module = gatedTargetModule
+        var found: [String: AnyClass] = [:]
+        let count = objc_getClassList(nil, 0)
+        guard count > 0 else { return found }
+        let buffer = UnsafeMutablePointer<AnyClass>.allocate(capacity: Int(count))
+        defer { buffer.deallocate() }
+        objc_getClassList(AutoreleasingUnsafeMutablePointer<AnyClass>(buffer), count)
+
+        for index in 0..<Int(count) {
+            let candidate: AnyClass = buffer[index]
+            let mangled = NSStringFromClass(candidate).split(separator: ".", maxSplits: 1)
+            guard mangled.count == 2, mangled[0] == module else { continue }
+            var parent: AnyClass? = class_getSuperclass(candidate)
+            while let step = parent {
+                if step == XCTestCase.self {
+                    found[String(mangled[1])] = candidate
+                    break
+                }
+                parent = class_getSuperclass(step)
+            }
+        }
+        return found
+    }
+
+    /// How many tests XCTest would run for one class — asked of XCTest itself,
+    /// so it agrees with the run's own `Executed N tests` by construction
+    /// rather than by a source scan agreeing with a test runner by luck.
+    private static func testCount(of cls: AnyClass) -> Int {
+        XCTestSuite(forTestCaseClass: cls).tests.count
+    }
+
+    /// The census: how much of the suite CI grades, how much it does not, and
+    /// that the ungated part still exists.
+    ///
+    /// Two failures it is built to report and one it is not. It reports the
+    /// ungated population CHANGING, which is the figure `AGENTS.md` quotes.
+    /// And it reports a skipped suite going EMPTY — a suite that runs on one
+    /// machine and contains nothing runs nowhere, and reads exactly like a
+    /// suite that passes everywhere, which is the shape this repo keeps
+    /// removing. It does NOT report those tests failing on the reference host;
+    /// only running them does that, which is why the decision record names
+    /// `tools/preflight.sh --only swift` and the pre-push hook as the whole of
+    /// the gate.
+    func testTheUngatedPopulationIsExactlyTheSkippedSuites() throws {
+        let classes = Self.testCaseClasses()
+        XCTAssertGreaterThan(classes.count, 20,
+                             "found \(classes.count) test classes in module \(Self.gatedTargetModule) — the runtime scan cannot have worked, and an empty scan would report a comfortable 0 ungated tests")
+
+        var counts: [String: Int] = [:]
+        for name in Self.imageSnapshotSuites.keys.sorted() {
+            guard let cls = classes[name] else {
+                XCTFail("\(name) is classified for CI but is not a test class in this bundle — the classification names a suite that no longer exists")
+                continue
+            }
+            counts[name] = Self.testCount(of: cls)
+        }
+
+        let skipped = Self.imageSnapshotSuites.filter { $0.value }.keys.sorted()
+        for name in skipped {
+            XCTAssertGreaterThan(counts[name] ?? 0, 0,
+                                 "\(name) is skipped in CI and now holds no tests at all — it runs on no machine anywhere, which is indistinguishable from passing on all of them")
+        }
+
+        let ungated = skipped.reduce(0) { $0 + (counts[$1] ?? 0) }
+        let total = classes.values.reduce(0) { $0 + Self.testCount(of: $1) }
+        XCTAssertGreaterThan(total, ungated,
+                             "counted \(total) tests in total and \(ungated) ungated — the total cannot be the smaller number")
+
+        // Printed on every run, because the figures a reader wants are the two
+        // this test refuses to pin, and a passing test that prints nothing is
+        // an unread measurement.
+        print("ci-scope census: module=\(Self.gatedTargetModule) total=\(total) "
+              + "gated=\(total - ungated) ungated=\(ungated) skippedSuites=\(skipped.count)")
+        for name in Self.imageSnapshotSuites.keys.sorted() {
+            print("ci-scope suite \(name) tests=\(counts[name] ?? -1) "
+                  + "skippedInCI=\(Self.imageSnapshotSuites[name] == true)")
+        }
+
+        XCTAssertEqual(ungated, Self.committedUngatedTestCount, """
+            the number of tests CI never grades changed: \(ungated), committed \(Self.committedUngatedTestCount).
+            Those tests run on the reference Mac and nowhere else (AGENTS.md, "macOS app"), so this is a
+            deliberate line in a diff rather than a stale figure. If the change is intended, set
+            `committedUngatedTestCount` to \(ungated) and say in the PR which suite moved.
+            """)
     }
 }

--- a/tools/lib/swift-suite.sh
+++ b/tools/lib/swift-suite.sh
@@ -63,7 +63,14 @@
 # The four numbers it has to sit under, all measured or documented elsewhere in
 # the repo rather than invented here:
 #
-#   suite, healthy         ~5s (318 tests, this machine), ~30s under heavy load
+#   suite, healthy         ~4s (436 tests, this machine, 2026-08-19), ~30s
+#                          under heavy load. Dated because it is a hand-typed
+#                          count of a growing suite: it read 318 for as long as
+#                          the suite held 435, and the same drift in
+#                          macos-swift.yml is what #1615 had to fix. The live
+#                          figure is printed by ImageSnapshotCIScopeTests'
+#                          census line on every run. What the bound below needs
+#                          from it is only its ORDER of magnitude.
 #   cold `swift build`     ~105s measured; the swift gate builds BEFORE the suite
 #   pre-push budget        540s (tools/preflight.sh --budget, #1570)
 #   agent command budget   600s (one foreground Bash tool call)


### PR DESCRIPTION
Answers #1615's step 3 with its own **option 3**: image snapshots are graded on the
reference host only, permanently and by choice. Nothing here tries to fix the pixel
difference, and no reference PNG was regenerated —
`git status --porcelain platforms/macos/Tests/__Snapshots__` is empty.

## The decision now lives in one place

**`AGENTS.md`'s "macOS app" bullet under Testing.** `macos-swift.yml`'s header and
`ImageSnapshotCIScopeTests`' class doc now point there and restate none of it — the
reason being this file's own history: the header said "270 of 318", was corrected to
"272 of 320" by the PR that measured it, and was **115 tests stale (320 → 435)** by
today. A fact written in N places drifts in N−1.

AGENTS.md was chosen over the workflow header (CI implementation detail — the skip list
lives there, the policy does not) and over `site/docs/` (user-facing; this is a
contributor rule, and `CONTRIBUTING.md` already routes every testing question to
`AGENTS.md#testing`).

The record states, plainly: which five suites and how many tests; why re-recording is
refused (#1034/#1044, plus the runner being on a **newer** OS, which makes a re-record
chase a moving image *and* invert which host is authoritative); why `perceptualPrecision`
is refused (#1509 measured one wide enough for this drift as also wide enough to pass a
**missing architecture segment**); what has been measured; what has not; and what the
decision costs.

## The count is derived, not typed

`ImageSnapshotCIScopeTests.testTheUngatedPopulationIsExactlyTheSkippedSuites` counts the
skipped suites' tests off the **live bundle** through XCTest's own
`XCTestSuite(forTestCaseClass:)` — so it agrees with `Executed N tests` by construction,
not by a source scan agreeing with a test runner by luck. Cross-check from this branch's
own run: the census printed `total=436` and the bundle reported `Executed 436 tests`.

    ci-scope census: module=IrrlichtTests total=436 gated=388 ungated=48 skippedSuites=5

- **Pinned: `ungated` (48).** It moves only when someone adds or removes a test in a
  suite CI never runs — exactly the event the record needs surfaced, and worth one
  deliberate line in a diff.
- **Printed, not pinned: the total and the gated remainder.** They move with every test
  added anywhere in the target, so pinning them would make an unrelated PR edit a
  literal about image snapshots, and the ratchet would be reset rather than read.
- A skipped suite going **empty** is a named failure: a suite that runs on one machine
  and holds nothing runs nowhere, which reads exactly like one that passes everywhere.

## What I narrowed, and the cost it releases

`swift-snapshot-evidence` drops to **`workflow_dispatch` only** (job-level `if:`).
Narrowed rather than deleted, deliberately:

- it is the only way anyone can ever look at these pixels again (runner OS bump, a
  contributor asking whether the residual moved, #1615 reopened);
- `tools/lib/swift-snapshot-evidence_test.sh` extracts and executes that step's body, and
  deleting the job would delete that lock with it;
- `ImageSnapshotCIScopeTests` cross-checks the classification against **both** `swift
  test` invocations — deleting the job removes the second one, and moving it to a
  separate workflow file would move half the check into a file the check does not read.
  That is why the condition is on the **job**, not the workflow.

Saved: one macOS job per PR at 10× billing. The header now carries the invocation
(`gh workflow run "macOS (Swift)" --ref <branch>`) and what it produces (failure images +
`__References__` + the six primitive rasters + the run log; no diff image, by
construction — that branch of SnapshotTesting is behind
`__XCODE_BUILT_PRODUCTS_DIR_PATHS`, which SwiftPM never sets). On a PR the job now reads
**Skipped**, not absent — the distinction this workflow's no-`paths:` decision turns on.

## The failure mode this creates, stated rather than discovered

**A contributor without a Mac cannot run these 48 tests at all, and CI will not run them
either.** Worse than silence: the `swift-test` check is confidently **green**, because
the suites are skipped by name. An outside contributor's image-snapshot change is
ungraded until the maintainer next runs `tools/preflight.sh --only swift` or pushes
through the pre-push hook. That contribution shape is not hypothetical — PR #1470 merged
from a fork today touching five files under `platforms/macos/`; it touched no
image-snapshot suite, so it is the shape rather than an instance.

I did **not** build a mitigation. Two cheap ones, if you want them (each is a separate,
one-line-ish PR):

1. `.github/PULL_REQUEST_TEMPLATE.md`'s test-plan block gains a line: *"macOS image
   snapshots (`SessionRow`/`GroupView`/`History`/`BackchannelRules`/`UnappliedGrants`)
   are graded on the maintainer's Mac only — say so if you changed one and could not run
   them."*
2. `CONTRIBUTING.md`'s "Swift (app)" paragraph links the decision record.

## Mutation evidence

The tripwire is the thing this PR changes the input of, so all four were run against
**this branch**, one per foreground call, each reverted with `git status --porcelain`
asserted empty afterwards.

**1 — a non-image-snapshot suite added to the gate's skip list** (`--skip
QuotaChipClockTests`):

```
ImageSnapshotCIScopeTests.swift:232: error: -[… testWorkflowSkipListMatchesTheClassification] :
XCTAssertEqual failed: ("[… "LauncherTestHarness", "QuotaChipClockTests", "SessionList…"]") is not
equal to ("[… "LauncherTestHarness", "SessionList…"]") - macos-swift.yml's --skip list and this
file's classification disagree
```

**2 — a suite dropped from the now dispatch-only evidence job** (`--filter
HistoryViewSnapshotTests`). This is the coupling check: narrowing the trigger did **not**
drop half the cross-check.

```
ImageSnapshotCIScopeTests.swift:262: error: -[… testEvidenceJobRunsExactlyTheSuitesTheGateSkips] :
XCTAssertEqual failed: ("["Backchannel…", "GroupView…", "RasterPrimitiveEvidenceTests", …]") is not
equal to ("["Backchannel…", "GroupView…", "HistoryViewSnapshotTests", "RasterPrimitive…", …]") -
the evidence job collects a different set of suites than swift-test skips
```

**3 — one test renamed out of a permanently-skipped suite** (48 → 47), the new derived
count:

```
ImageSnapshotCIScopeTests.swift:401: error: -[… testTheUngatedPopulationIsExactlyTheSkippedSuites] :
XCTAssertEqual failed: ("47") is not equal to ("48") - the number of tests CI never grades changed:
47, committed 48.
ci-scope census: module=IrrlichtTests total=435 gated=388 ungated=47 skippedSuites=5
```

**4 — a permanently-skipped suite emptied** (all six `GroupViewSnapshotTests` methods
renamed), the rot guard:

```
ImageSnapshotCIScopeTests.swift:382: error: XCTAssertGreaterThan failed: ("0") is not greater than
("0") - GroupViewSnapshotTests is skipped in CI and now holds no tests at all — it runs on no
machine anywhere, which is indistinguishable from passing on all of them
ImageSnapshotCIScopeTests.swift:401: error: XCTAssertEqual failed: ("42") is not equal to ("48")
```

Note what mutation 4 does *not* redden: `testEveryImageSnapshotSuiteIsClassified` stays
green, because the renamed methods still contain `as: .pinnedImage`. The census is the
only thing that sees an ungated suite hollowing out.

## Verification

- `tools/preflight.sh --only swift` — **PASS**, `Executed 436 tests, with 0 failures`
  (all 48 ungated ones among them), census `total=436 gated=388 ungated=48`.
- `tools/preflight.sh --only tools` — **PASS**, `found 19, skipped 0, ran 19, failed 0`;
  includes `swift-snapshot-evidence_test.sh`, `swift-test-step_test.sh`,
  `swift-suite_test.sh` and `workflow-step_test.sh`, all of which read this workflow.
- Workflow YAML parses (`yaml.safe_load`); three jobs, evidence job's `if:` is
  `github.event_name == 'workflow_dispatch'`.
- `git grep swift-snapshot-evidence` — the only references are inside this workflow, that
  shell lock, `AGENTS.md` and the tripwire's doc; `tools/preflight.sh` and the pre-push
  hook are unaffected (their `swift` gate never ran that job).
- No reference PNG changed.

## #1530: my call is **close it, but not on this PR's strength alone**

Blockers 2 (Sparkle's modal `NSAlert`), 3 (#1523) and 4 (the `$HOME`-dependent scorer)
are fixed in #1614 and verified — `SoundPlayerTests` is absent from the skip list, so
#1523's quarantine is gone. Blocker 1's scale half is fixed; its rasterisation half is
what this PR **accepts** rather than fixes. #1530's actual goal — gating `swift test` in
CI — is met: 388 of 436 tests, against 0 before.

What stops me recommending "close it on merge" is a **fifth** host dependency, found
while checking this: the `macos-swift` run on `main` at 19:49 today (the #1470 merge)
went **red**, and not on any of the four:

```
InMemoryDefaultsTests.swift:164: error: -[… testTheDoubleAddsNothingToTheRealPreferencesDirectory] :
XCTAssertEqual failed: ("["com.apple.siri.ODDI.MetricsWorker.plist"]") is not equal to ("[]") -
The defaults double reached disk. #1661 is back…
```

That is a background OS process writing into `/Users/runner/Library/Preferences` during
the test window, accusing the double of a write it did not make — the same "unfiltered
directory witness" trade `AGENTS.md` documents for `swift-suite.sh`, but inside a test
where it is a false accusation rather than a report. Unrelated to #1615, not one of
#1530's four, and it means "the suite runs green on a runner" is not currently true on
`main`. I have not filed it — the diagnosis above is one `gh issue create` away and the
call is yours.

So: **`Fixes #1615` here; #1530 is ready to close on its own terms** (four blockers: three
fixed, one accepted with the containment written down and asserted), and the flake above
deserves its own issue rather than silently redefining what the epic tracks.

## Premises of the two issues that are no longer true

Worth flagging because both would otherwise be repeated:

- **"Nobody has diffed the actual pixels" is false.** #1628 did, from the evidence job's
  artifacts: 34 failures inside the 28 × 28 px box `SessionState.adapterIcon` draws at
  maxΔ 1-5/255, and 2 `BackchannelRulesView` control labels at maxΔ 142/197 sitting ~1
  device pixel lower.
- **The SF-Symbols/vector hypothesis is not unverified — it is measured dead.** Flat
  fill, stroked bezier, system-font text and an SF Symbol, each also in a translucent
  dynamic `Color.secondary`: all six byte-identical between runner and reference host.
  What differs is an inline-SVG `NSImage(data:)` raster, which no SwiftUI primitive
  reaches. The record says so, and says equally plainly that **why** it differs is still
  unknown — "the OS versions differ" is where the evidence stops, not a cause.
- One thing in the record is marked **predicted, not measured**: #1658 pinned the locale,
  so `testBackchannelRuleContextTokens`'s residual *should* now be rasterisation only. No
  post-#1658 runner render has been diffed to confirm it.

Fixes #1615
Refs #1530

🤖 Generated with [Claude Code](https://claude.com/claude-code)
