### PR TITLE
fix(macos): attribute the preferences witness to the run, so OS churn stops accusing the double (#1714)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1774,7 +1774,7 @@ Before marking a ticket done, run the full suite — every layer must pass:
   decision creates: a suite that runs on one machine and holds nothing runs
   nowhere, and reads exactly like one that passes everywhere. The gated
   remainder is printed and deliberately NOT pinned, because it moves with every
-  test anyone adds anywhere in the target — 388 of 436 measured on 2026-08-19 on
+  test anyone adds anywhere in the target — 392 of 440 measured on 2026-08-19 on
   the reference Mac. That split is "Replay's measured figures" applied one
   platform over, and this is the file that earned it: `macos-swift.yml`'s header
   claimed "270 of 318", was corrected to "272 of 320" by the PR that measured
@@ -2290,6 +2290,26 @@ Before marking a ticket done, run the full suite — every layer must pass:
   interactive use. It is not filtered by name — #1661's leaked files were
   `<uuid>.plist`, so any name filter that quietened the churn would have
   quietened the incident.
+  **The IN-PROCESS half of that guard made the opposite trade in #1714, and the
+  two are not in conflict — the difference is what each can say when it fires.**
+  `InMemoryDefaultsTests`' arm 2 ran the same wide net inside the suite and, on
+  a runner, reported `com.apple.siri.ODDI.MetricsWorker.plist` as *"The defaults
+  double reached disk. #1661 is back"*: a false ACCUSATION rather than a false
+  alarm, which is a different cost from the shell witness's, whose wording
+  already says "background daemons also write here … re-run to tell that apart"
+  and which CAN be re-run. A single in-process window cannot re-run itself, so
+  that assertion is now scoped to what the run OWNS — a UUID token woven through
+  every domain name and key the double is handed, plus this process's own
+  application domain, both derived at run time and neither a list of names the
+  run did not choose. What it gives up is exactly one shape, and it is committed
+  as a corpus row rather than described: a NEW file bearing a UUID this run did
+  not mint is no longer reported there. That population is still watched by the
+  two halves above, which is why the narrowing is affordable — the shell's
+  directory half brackets the whole run with the unattributed net, and its domain
+  half sees the write into `com.apple.dt.xctest.tool` that an added-entry witness
+  never could. Measured reachability before the fix: **1 failure in the 27
+  `macos-swift` runs on `main`** between the suite being gated there
+  (`a86ae50a`, 2026-08-16) and 2026-08-19.
   **That witness has a SECOND half since #1688, and the split between the two is
   the point rather than the sum**: the directory half watches for new FILES,
   while `SWIFT_SUITE_WITNESSED_DOMAINS` compares

--- a/platforms/macos/Tests/InMemoryDefaults.swift
+++ b/platforms/macos/Tests/InMemoryDefaults.swift
@@ -114,7 +114,10 @@ final class InMemoryDefaults: UserDefaults {
     ///   keys through the overrides below and calling `synchronize()`, left the
     ///   real preferences directory byte-for-byte unchanged; that measurement is
     ///   re-run on every suite run by
-    ///   `InMemoryDefaultsTests.testTheDoubleAddsNothingToTheRealPreferencesDirectory`).
+    ///   `InMemoryDefaultsTests.testTheDoubleLeavesNothingAttributableToItInTheRealPreferencesDirectory`,
+    ///   which since #1714 grades what the run OWNS rather than what the
+    ///   directory did — see `PreferencesDirectoryWitness` for what that gives
+    ///   up and what covers it instead).
     ///   The force-unwrap is deliberate and is the fail-loud: `init(suiteName:)`
     ///   answers nil only for the main bundle identifier, and if it ever did
     ///   answer nil here the correct outcome is a trap, not a silent fallback to
@@ -248,12 +251,61 @@ final class InMemoryDefaults: UserDefaults {
 }
 
 /// A read-only witness over a preferences directory: what files were there
-/// before, what files are there now, and what appeared in between.
+/// before, what files are there now, what appeared in between — and which of
+/// those appearances can be ATTRIBUTED to the run that asked.
 ///
 /// It reads and never writes, and it has no delete path at all — the whole
 /// point of #1661's rework is that no code here is allowed to remove a file
 /// from a directory it did not create, and the simplest way to hold that is to
 /// own no `removeItem` call anywhere in this file.
+///
+/// # Why attribution exists, and why the raw delta was not enough (#1714)
+///
+/// The raw delta answers *"did this directory change"*. The question the suite
+/// asks is *"did the SUBJECT change it"*, and on a GitHub runner those two
+/// produced different answers: `com.apple.siri.ODDI.MetricsWorker.plist` landed
+/// inside the measured window and the assertion reported it as **"The defaults
+/// double reached disk. #1661 is back"** — the most alarming sentence this
+/// suite can say, about a file the double had nothing to do with. That is not
+/// an ordinary flake: a false ACCUSATION is read, and acted on, as a finding.
+///
+/// A NAME FILTER is not the fix, and that is worth saying loudly because it is
+/// the obvious one. #1661's leaked files were named `<uuid>.plist`, so an
+/// allowlist wide enough to hide a `com.apple.*` metrics plist is wide enough
+/// to hide the incident — #1509's `perceptualPrecision` mistake in a different
+/// costume. The guard is therefore scoped to what the run OWNS, by two clauses,
+/// neither of which is a list of names the run did not choose:
+///
+///   the run's own token   an identifier minted per run and woven into every
+///                         domain name and key the subject is handed, so an
+///                         entry carrying it can only have come from the
+///                         subject. This is exactly #1661's own artifact shape
+///                         — a plist named for a suite the test minted.
+///   this process's own    what `super.init(suiteName: nil)` binds, derived
+///   application domain    from `Bundle`/`ProcessInfo` at run time rather than
+///                         written down. An entry named for it appearing is a
+///                         write that reached `super`.
+///
+/// # What that gives up, stated rather than left to be discovered
+///
+/// A NEW file whose name carries neither — a leak into a domain named nowhere
+/// in this process — is no longer reported here. `InMemoryDefaultsTests`
+/// commits that limit as a case (a `<uuid>.plist` bearing a UUID this run did
+/// not mint stays silent) so it is learned from a test rather than from an
+/// incident. Two things already cover it, and neither is inside this process:
+/// `tools/lib/swift-suite.sh`'s directory witness brackets the whole run with
+/// the wide, unattributed net — its wording says "background daemons also write
+/// here … re-run to tell that apart", which is the honest form of the same
+/// finding and the one this test could not use, since a single in-process
+/// window cannot re-run itself — and that file's domain half compares
+/// `com.apple.dt.xctest.tool`'s keys and VALUES across the run, which sees a
+/// write into an already-existing domain that no added-entry witness can.
+///
+/// The clauses are deterministic rather than statistical, which is why they are
+/// preferred to the other shape #1714 named (a difference taken over a control
+/// window with the subject not exercised): the
+/// measured failure was a metrics worker writing ONCE, and a one-shot write is
+/// exactly what a two-window subtraction cannot cancel.
 struct PreferencesDirectoryWitness {
 
     /// Failing to *look* and finding nothing must not produce the same answer.
@@ -263,14 +315,36 @@ struct PreferencesDirectoryWitness {
     /// it is also the difference between a real guarantee and a comfortable one.
     enum Failure: Error, CustomStringConvertible {
         case unreadable(path: String, underlying: Error)
+        /// The attribution could not be performed with the inputs it was given.
+        /// Same rule as `unreadable`, one layer up: a needle that matches
+        /// everything and a needle that matches nothing are both a guard that
+        /// has stopped asking the question, and both read as a pass.
+        case cannotAttribute(reason: String)
 
         var description: String {
             switch self {
             case let .unreadable(path, underlying):
                 return "could not read \(path): \(underlying) — " +
                        "the witness cannot report a delta it was unable to measure"
+            case let .cannotAttribute(reason):
+                return "could not attribute what appeared: \(reason) — " +
+                       "the witness cannot name a subject it was unable to identify"
             }
         }
+    }
+
+    /// One run's claim on the entries that appeared during its window.
+    struct Attribution {
+        /// Appeared, and carries the identifier this run minted.
+        let namedForThisRun: [String]
+        /// Appeared, and names the application domain THIS PROCESS binds.
+        let namedForThisProcess: [String]
+        /// Appeared, and is attributable to neither. Reported for context and
+        /// never asserted on — this is the population #1714 is about.
+        let unattributed: [String]
+
+        /// Everything this run is answerable for, sorted for a stable message.
+        var names: [String] { Set(namedForThisRun + namedForThisProcess).sorted() }
     }
 
     let directory: URL
@@ -311,5 +385,85 @@ struct PreferencesDirectoryWitness {
     /// Names present in `after` and not in `before`, sorted for a stable message.
     static func added(from before: Set<String>, to after: Set<String>) -> [String] {
         after.subtracting(before).sorted()
+    }
+
+    /// The application domain(s) this process's own `UserDefaults` binds.
+    ///
+    /// Derived at run time rather than written down, for the reason the whole
+    /// file exists: a committed literal is a name the run does not own, and a
+    /// name the run does not own is a filter. Measured under `swift test` on
+    /// 2026-08-19 this answers `["com.apple.dt.xctest.tool", "xctest"]` — the
+    /// first being the domain `PersistentDefaultsLintTests` and
+    /// `tools/lib/swift-suite.sh` each name independently, and the one
+    /// `super.init(suiteName: nil)` binds.
+    ///
+    /// Both spellings are collected because Foundation falls back to the
+    /// process name when a bundle identifier is absent, and which of the two is
+    /// live is a property of how the suite was launched (`swift test`, Xcode, a
+    /// bare `xctest`) rather than of anything here.
+    /// `InMemoryDefaultsTests.testThisProcessesOwnApplicationDomainIsDerivableAndAttributes`
+    /// is the vacuity guard, and it also refuses an answer short enough that
+    /// containment would stop being an attribution.
+    static var processApplicationDomains: Set<String> {
+        var domains: Set<String> = []
+        if let identifier = Bundle.main.bundleIdentifier, !identifier.isEmpty {
+            domains.insert(identifier)
+        }
+        let process = ProcessInfo.processInfo.processName
+        if !process.isEmpty {
+            domains.insert(process)
+        }
+        return domains
+    }
+
+    /// Split what appeared into what this run is answerable for and what it is
+    /// not.
+    ///
+    /// Matching is CONTAINMENT rather than equality on purpose: `cfprefsd`
+    /// names a file for a domain but is not obliged to name it *exactly* that
+    /// (a suffix, a temporary spelling during an atomic replace), and a guard
+    /// that only recognised the exact form would be a guard a different
+    /// spelling walks past. It cannot make the guard wider than the run owns —
+    /// both needles are values this process minted or derived from itself.
+    ///
+    /// Refuses rather than answering for an empty needle, and that refusal is
+    /// the load-bearing line: `"anything".contains("")` is **true** in Swift, so
+    /// an empty token does not narrow the guard, it silently restores the
+    /// unattributed net #1714 is about — with every OS write reported as the
+    /// subject's, and reading as a pass until the day it fires.
+    static func attribute(_ appeared: [String],
+                          toRun runToken: String,
+                          orProcessDomains domains: Set<String> = processApplicationDomains) throws -> Attribution {
+        guard !runToken.isEmpty else {
+            throw Failure.cannotAttribute(
+                reason: "the run token is empty, and every entry contains the empty string")
+        }
+        guard !domains.isEmpty else {
+            throw Failure.cannotAttribute(
+                reason: "this process's application domain could not be derived, so a write that "
+                      + "reached `super` would be attributable to nothing")
+        }
+        guard !domains.contains(where: \.isEmpty) else {
+            throw Failure.cannotAttribute(
+                reason: "an application domain is the empty string, and every entry contains it")
+        }
+
+        var run: [String] = []
+        var process: [String] = []
+        var other: [String] = []
+        for name in appeared {
+            if name.contains(runToken) {
+                // Checked first, so an entry matching both is reported once and
+                // under the more specific of the two.
+                run.append(name)
+            } else if domains.contains(where: { name.contains($0) }) {
+                process.append(name)
+            } else {
+                other.append(name)
+            }
+        }
+        return Attribution(namedForThisRun: run.sorted(),
+                           namedForThisProcess: process.sorted(),
+                           unattributed: other.sorted())
     }
 }

--- a/platforms/macos/Tests/InMemoryDefaultsTests.swift
+++ b/platforms/macos/Tests/InMemoryDefaultsTests.swift
@@ -1,18 +1,26 @@
 import XCTest
 
-/// Coverage for #1661's mechanism, in three arms.
+/// Coverage for #1661's mechanism, in four arms.
 ///
 /// 1. **Faithfulness** — the double answers what a real suite answers for
 ///    everything `NotificationSettings.masterEnabled(defaults:)` reads. A double
 ///    that is diskless but wrong would make `NotificationMasterGateTests` assert
 ///    nothing.
-/// 2. **The guarantee** — a run of the double adds no file to the real
-///    `~/Library/Preferences`.
+/// 2. **The guarantee** — a run of the double leaves nothing **of its own** in
+///    the real `~/Library/Preferences`. "Of its own" is #1714: the assertion
+///    used to be the raw before/after delta, which on a GitHub runner reported
+///    an OS-written Siri plist as "the defaults double reached disk".
 /// 3. **The witness's own mutation evidence** — arm 2 is only worth its ink if
 ///    its detector can fire. `PreferencesDirectoryWitness` is driven against
 ///    temporary directories this test creates, with the "it must stay silent"
 ///    cases beside the "it must report" ones, because a witness that reported
 ///    unconditionally would satisfy arm 2 forever.
+/// 4. **The attribution's mutation evidence** (#1714) — seeing a file appear
+///    and knowing whose it is are different claims, and only the second is what
+///    arm 2 now asserts. A committed corpus pins both verdicts, including the
+///    measured #1714 failure as a row that must stay silent and the shape's
+///    declared LIMIT as another, plus one end-to-end run of the whole pipeline
+///    against #1661's actual artifact.
 final class InMemoryDefaultsTests: XCTestCase {
 
     // MARK: - Arm 1: faithfulness
@@ -121,8 +129,8 @@ final class InMemoryDefaultsTests: XCTestCase {
 
     // MARK: - Arm 2: the #1661 guarantee
 
-    /// The property the whole issue is about: a run of the double leaves the
-    /// real `~/Library/Preferences` with exactly the files it started with.
+    /// The property the whole issue is about: a run of the double leaves nothing
+    /// **of its own** in the real `~/Library/Preferences`.
     ///
     /// Driven hard on purpose — many keys, every typed setter, `synchronize()`,
     /// the domain calls the pre-fix `tearDown` used, and a settle after each —
@@ -132,7 +140,16 @@ final class InMemoryDefaultsTests: XCTestCase {
     /// is no daemon-facing call left to schedule one: `InMemoryDefaults` names
     /// no suite, and `PersistentDefaultsLintTests` fails the build if any test
     /// does.
-    func testTheDoubleAddsNothingToTheRealPreferencesDirectory() throws {
+    ///
+    /// **"Of its own" is #1714 and is the whole difference.** The assertion used
+    /// to be the raw before/after delta, and on a runner the OS wrote
+    /// `com.apple.siri.ODDI.MetricsWorker.plist` inside the window — reported
+    /// here as "the double reached disk", which is a false accusation rather
+    /// than a false alarm. Every identifier below now carries `runToken`, so an
+    /// entry the double is answerable for is one the OS cannot produce; what
+    /// that gives up, and what still covers it, is on
+    /// `PreferencesDirectoryWitness`.
+    func testTheDoubleLeavesNothingAttributableToItInTheRealPreferencesDirectory() throws {
         let witness = PreferencesDirectoryWitness.realUserPreferences
         let before = try witness.snapshot()
 
@@ -142,33 +159,74 @@ final class InMemoryDefaultsTests: XCTestCase {
             "nothing is not evidence; check that this is the real preferences directory"
         )
 
+        let runToken = UUID().uuidString
+        var driven: InMemoryDefaults?
         for round in 0..<3 {
             let defaults = InMemoryDefaults()
             for index in 0..<50 {
-                defaults.set(true, forKey: "io.irrlicht.tests.leakProbe.\(round).\(index)")
-                defaults.set("value", forKey: "io.irrlicht.tests.leakProbeString.\(round).\(index)")
-                defaults.set(index, forKey: "io.irrlicht.tests.leakProbeInt.\(round).\(index)")
+                defaults.set(true, forKey: "io.irrlicht.tests.leakProbe.\(runToken).\(round).\(index)")
+                defaults.set("value", forKey: "io.irrlicht.tests.leakProbeString.\(runToken).\(round).\(index)")
+                defaults.set(index, forKey: "io.irrlicht.tests.leakProbeInt.\(runToken).\(round).\(index)")
             }
-            defaults.register(defaults: ["io.irrlicht.tests.leakProbeRegistered": true])
+            defaults.register(defaults: ["io.irrlicht.tests.leakProbeRegistered.\(runToken)": true])
             _ = defaults.synchronize()
             // The two calls the pre-fix teardown made, which are also the two
-            // observed to schedule a cfprefsd write-back.
-            defaults.removePersistentDomain(forName: "io.irrlicht.tests.leakProbe.\(round)")
+            // observed to schedule a cfprefsd write-back. The domain NAME is
+            // what `cfprefsd` would name a file after, so it carries the token.
+            defaults.removePersistentDomain(forName: "io.irrlicht.tests.leakProbe.\(runToken).\(round)")
             _ = defaults.synchronize()
+            driven = defaults
         }
+
+        // The three vacuity guards, before the measurement rather than after:
+        // a subject that was never driven, a token that never reached it, and a
+        // process domain that could not be derived each produce "nothing
+        // attributable appeared" while proving nothing at all.
+        let exercised = try XCTUnwrap(driven, "the exercise loop built no double")
+        XCTAssertEqual(exercised.writtenKeys.count, 150,
+                       "the double was not driven — 150 keys were written through it, and it holds "
+                       + "\(exercised.writtenKeys.count)")
+        XCTAssertTrue(
+            exercised.writtenKeys.allSatisfy { $0.contains(runToken) },
+            "the exercise stopped weaving this run's token into the identifiers it hands the double, "
+            + "so the attribution below is scoped to nothing this test names"
+        )
+        XCTAssertFalse(
+            PreferencesDirectoryWitness.processApplicationDomains.isEmpty,
+            "this process's application domain could not be derived, so a write reaching `super` "
+            + "would be attributable to nothing"
+        )
 
         // Give an asynchronous write-back a chance to land before measuring.
         Thread.sleep(forTimeInterval: 0.5)
 
-        let added = PreferencesDirectoryWitness.added(from: before, to: try witness.snapshot())
-        XCTAssertEqual(
-            added, [],
-            """
-            The defaults double reached disk. #1661 is back: files appeared in \
-            \(witness.directory.path) during this test, and nothing in this \
-            repository is allowed to delete them again.
+        let appeared = PreferencesDirectoryWitness.added(from: before, to: try witness.snapshot())
+        let attribution = try PreferencesDirectoryWitness.attribute(appeared, toRun: runToken)
 
-            \(added.joined(separator: "\n"))
+        // Two lists, not one, because the two clauses support different claims
+        // and a message that merged them would say more than the evidence does.
+        XCTAssertEqual(
+            attribution.names, [],
+            """
+            This test wrote into the real \(witness.directory.path), and nothing in this \
+            repository is allowed to delete it again.
+
+            Carrying this run's token (\(runToken)) — these can only be the DOUBLE's, \
+            because nothing else in the world has that string. #1661 is back:
+            \(attribution.namedForThisRun.isEmpty ? "  (none)" : attribution.namedForThisRun.map { "  \($0)" }.joined(separator: "\n"))
+
+            Naming this process's own application domain \
+            (\(PreferencesDirectoryWitness.processApplicationDomains.sorted().joined(separator: ", "))) \
+            — a write that reached `super`. That is the double if one of its overrides stopped \
+            overriding, and a #1672-class persist by something else this process rendered \
+            otherwise; `PersistentDefaultsLintTests` and `InMemoryDefaults.writtenKeys` tell \
+            those apart:
+            \(attribution.namedForThisProcess.isEmpty ? "  (none)" : attribution.namedForThisProcess.map { "  \($0)" }.joined(separator: "\n"))
+
+            \(attribution.unattributed.count) further entr(y/ies) appeared in the same window \
+            and are attributable to neither. Background daemons write here too — measured at \
+            roughly one plist per 218s of active use — so they are NOT part of this failure \
+            (#1714). tools/lib/swift-suite.sh is what still watches that population.
             """
         )
     }
@@ -247,6 +305,223 @@ final class InMemoryDefaultsTests: XCTestCase {
                 return
             }
             XCTAssertEqual(path, missing.path)
+        }
+    }
+
+    // MARK: - Arm 4: the attribution's committed mutation evidence (#1714)
+    //
+    // Arm 3 proves the witness can SEE a file appear. That is a different claim
+    // from "and it can tell whose it is", which is the claim #1714 turns on —
+    // and the one that, got wrong in the permissive direction, waves through the
+    // incident this file exists for. So the attribution gets its own corpus,
+    // with both verdicts carried: an attribution that reported everything and
+    // one that reported correctly are indistinguishable without the rows that
+    // must stay silent, and here those rows are ALSO the declared limit of the
+    // shape #1714 chose. A limit learned from a test is one nobody has to
+    // rediscover from an incident.
+
+    /// One window's worth of appearances, and the verdict the attribution owes
+    /// for it.
+    private struct AttributionCase {
+        let what: String
+        let appeared: [String]
+        let mustReport: [String]
+    }
+
+    func testAttributionReportsEveryLeakShapeAndStaysSilentOnEveryChurnShape() throws {
+        let runToken = UUID().uuidString
+        let domains = PreferencesDirectoryWitness.processApplicationDomains
+        let processDomain = try XCTUnwrap(
+            domains.sorted().first,
+            "this process's application domain could not be derived, so the clause that catches a "
+            + "write reaching `super` is graded by nothing below"
+        )
+        // A UUID this run minted for NOTHING — it names no domain, no key, and
+        // is handed to no subject. It stands in for #1661's leaked filenames as
+        // produced by somebody else's process.
+        let foreignUUID = UUID().uuidString
+        XCTAssertNotEqual(foreignUUID, runToken)
+
+        // The measured #1714 failure, and the background churn
+        // `tools/lib/swift-suite.sh` measured over an 870s window of ordinary
+        // interactive use. Committed as fixtures rather than described.
+        let churn = [
+            "com.apple.siri.ODDI.MetricsWorker.plist",
+            "com.apple.bluetooth.plist",
+            "com.apple.DuetExpertCenter.MagicalMoments.plist",
+            "com.apple.voicetrigger.plist",
+            "com.googlecode.iterm2.plist",
+        ]
+
+        // A premise, not decoration: if a derived process domain ever appeared
+        // inside one of those names the silent rows would go red for a reason
+        // unrelated to what they grade — and that condition is exactly "the
+        // derivation became too generic to be an attribution", which is worth
+        // failing on in its own right.
+        for name in churn {
+            for domain in domains {
+                XCTAssertFalse(
+                    name.contains(domain),
+                    "the derived process domain '\(domain)' occurs inside the churn fixture "
+                    + "'\(name)' — that derivation cannot attribute anything"
+                )
+            }
+        }
+
+        let leak1661 = "io.irrlicht.tests.NotificationMasterGate.\(runToken).plist"
+        let corpus: [AttributionCase] = [
+            .init(what: "#1661's own artifact — the empty plist cfprefsd left behind for a UUID "
+                      + "suite the test minted",
+                  appeared: [leak1661],
+                  mustReport: [leak1661]),
+            .init(what: "#1661's leaked files as the issue names them — a bare <uuid>.plist",
+                  appeared: ["\(runToken).plist"],
+                  mustReport: ["\(runToken).plist"]),
+            .init(what: "the domain this test itself names when it drives removePersistentDomain",
+                  appeared: ["io.irrlicht.tests.leakProbe.\(runToken).round0.plist"],
+                  mustReport: ["io.irrlicht.tests.leakProbe.\(runToken).round0.plist"]),
+            .init(what: "a spelling that merely CONTAINS the minted identifier — a suffixed or "
+                      + "temporary form is not a way past the guard, which is why the match is "
+                      + "containment and not equality",
+                  appeared: ["io.irrlicht.tests.leakProbe.\(runToken).round0.plist.tmp"],
+                  mustReport: ["io.irrlicht.tests.leakProbe.\(runToken).round0.plist.tmp"]),
+            .init(what: "a write that reached `super` — this process's own application domain, "
+                      + "which is what init(suiteName: nil) binds",
+                  appeared: ["\(processDomain).plist"],
+                  mustReport: ["\(processDomain).plist"]),
+            .init(what: "the leak and #1714's churn in the SAME window — the discriminator itself, "
+                      + "which is the row every other row exists to support",
+                  appeared: [leak1661, "com.apple.siri.ODDI.MetricsWorker.plist"],
+                  mustReport: [leak1661]),
+
+            .init(what: "#1714 itself: the Siri metrics plist a GitHub runner wrote inside the "
+                      + "window, reported as 'the defaults double reached disk'",
+                  appeared: ["com.apple.siri.ODDI.MetricsWorker.plist"],
+                  mustReport: []),
+            .init(what: "the background churn swift-suite.sh measured over an 870s window",
+                  appeared: churn,
+                  mustReport: []),
+            .init(what: "THE DECLARED LIMIT: a <uuid>.plist — #1661's exact shape — bearing a UUID "
+                      + "this run did not mint is NOT reported. That is what attribution gives up, "
+                      + "and what swift-suite.sh's unattributed net still watches for",
+                  appeared: ["\(foreignUUID).plist"],
+                  mustReport: []),
+            .init(what: "the vacuity guard: nothing appeared, so nothing is reported and nothing "
+                      + "is ignored",
+                  appeared: [],
+                  mustReport: []),
+        ]
+
+        for probe in corpus {
+            let attribution = try PreferencesDirectoryWitness.attribute(probe.appeared, toRun: runToken)
+            XCTAssertEqual(attribution.names, probe.mustReport.sorted(), probe.what)
+            XCTAssertEqual(
+                attribution.unattributed,
+                probe.appeared.filter { !probe.mustReport.contains($0) }.sorted(),
+                "\(probe.what) — the entries it must NOT report have to be accounted for, not "
+                + "silently dropped: a count is what tells the reader the window was noisy"
+            )
+        }
+    }
+
+    /// The whole pipeline, driven through the same three calls arm 2 makes,
+    /// against a directory this test created.
+    ///
+    /// Never the real home: the faithful mutation — making `InMemoryDefaults`
+    /// persist — writes into the developer's own `~/Library/Preferences`, which
+    /// is the incident this file exists to prevent, and there is no version of
+    /// that experiment worth its blast radius.
+    func testThePipelineReportsAn1661LeakWhileTheOSWritesInTheSameWindow() throws {
+        let directory = try makeTemporaryDirectory()
+        let witness = PreferencesDirectoryWitness(directory: directory)
+        FileManager.default.createFile(
+            atPath: directory.appendingPathComponent("pre-existing.plist").path, contents: Data())
+        let before = try witness.snapshot()
+        XCTAssertFalse(before.isEmpty, "a delta measured against nothing is not evidence")
+
+        let runToken = UUID().uuidString
+        // #1661's artifact as it actually was: an EMPTY plist named for the
+        // UUID suite the test minted. Empty is load-bearing — the file carries
+        // none of the values that were written, so only its name can attribute
+        // it, which is why the name clause exists at all.
+        let leak = "io.irrlicht.tests.NotificationMasterGate.\(runToken).plist"
+        FileManager.default.createFile(
+            atPath: directory.appendingPathComponent(leak).path, contents: Data())
+        // …and #1714, in the same window.
+        let churn = "com.apple.siri.ODDI.MetricsWorker.plist"
+        FileManager.default.createFile(
+            atPath: directory.appendingPathComponent(churn).path, contents: Data())
+
+        let appeared = PreferencesDirectoryWitness.added(from: before, to: try witness.snapshot())
+        XCTAssertEqual(
+            appeared, [churn, leak].sorted(),
+            "the witness did not see both files appear, so neither verdict below is evidence"
+        )
+
+        let attribution = try PreferencesDirectoryWitness.attribute(appeared, toRun: runToken)
+        XCTAssertEqual(attribution.namedForThisRun, [leak],
+                       "the guard no longer goes red against #1661's actual failure")
+        XCTAssertEqual(attribution.unattributed, [churn],
+                       "#1714's churn must be counted, and must not be part of the accusation")
+    }
+
+    /// The vacuity guard for the second attribution clause. A derivation that
+    /// answered nothing would retire it in silence, and a write that reached
+    /// `super` would then be attributable to nobody.
+    func testThisProcessesOwnApplicationDomainIsDerivableAndAttributes() throws {
+        let domains = PreferencesDirectoryWitness.processApplicationDomains
+        XCTAssertFalse(domains.isEmpty, "no application domain could be derived for this process")
+        for domain in domains {
+            XCTAssertFalse(domain.isEmpty)
+            XCTAssertFalse(domain.contains("/"), "'\(domain)' is a path, not a preference domain")
+            XCTAssertGreaterThan(
+                domain.count, 3,
+                "'\(domain)' is short enough that containment would match unrelated names"
+            )
+        }
+
+        let domain = try XCTUnwrap(domains.sorted().first)
+        let attribution = try PreferencesDirectoryWitness.attribute(
+            ["\(domain).plist"], toRun: UUID().uuidString)
+        XCTAssertEqual(
+            attribution.namedForThisProcess, ["\(domain).plist"],
+            "the derived domain does not match the file cfprefsd would name for it"
+        )
+    }
+
+    /// The fail-loud for the attribution itself, and it is not defensive noise:
+    /// `"anything".contains("")` is **true** in Swift, so an empty needle does
+    /// not narrow the guard — it silently restores the unattributed net #1714
+    /// removed, reporting every OS write as the subject's, and reads as a pass
+    /// until the day it fires.
+    /// Each arm names a fragment of its OWN refusal, because "it refused" and
+    /// "it refused for this reason" are different claims and all three guards
+    /// throw the same case — without the fragment, one guard could cover for
+    /// another's removal and the arms could not tell them apart.
+    func testAttributionRefusesAnInputThatWouldMakeItMatchEverythingOrNothing() {
+        let appeared = ["com.apple.siri.ODDI.MetricsWorker.plist"]
+
+        for (what, naming, call) in [
+            ("an empty run token", "the run token is empty",
+             { try PreferencesDirectoryWitness.attribute(appeared, toRun: "") }),
+            ("an empty process domain", "an application domain is the empty string", {
+                try PreferencesDirectoryWitness.attribute(appeared, toRun: "t", orProcessDomains: [""])
+            }),
+            ("no process domain at all", "could not be derived", {
+                try PreferencesDirectoryWitness.attribute(appeared, toRun: "t", orProcessDomains: [])
+            }),
+        ] as [(String, String, () throws -> PreferencesDirectoryWitness.Attribution)] {
+            XCTAssertThrowsError(try call(), what) { error in
+                guard case PreferencesDirectoryWitness.Failure.cannotAttribute = error else {
+                    XCTFail("\(what): expected .cannotAttribute, got \(error)")
+                    return
+                }
+                XCTAssertTrue(
+                    "\(error)".contains(naming),
+                    "\(what): refused, but not for its own reason — '\(naming)' is absent from "
+                    + "\"\(error)\", so this arm cannot tell its guard from another one's"
+                )
+            }
         }
     }
 

--- a/platforms/macos/Tests/InMemoryDefaultsTests.swift
+++ b/platforms/macos/Tests/InMemoryDefaultsTests.swift
@@ -328,48 +328,28 @@ final class InMemoryDefaultsTests: XCTestCase {
         let mustReport: [String]
     }
 
-    func testAttributionReportsEveryLeakShapeAndStaysSilentOnEveryChurnShape() throws {
-        let runToken = UUID().uuidString
-        let domains = PreferencesDirectoryWitness.processApplicationDomains
-        let processDomain = try XCTUnwrap(
-            domains.sorted().first,
-            "this process's application domain could not be derived, so the clause that catches a "
-            + "write reaching `super` is graded by nothing below"
-        )
-        // A UUID this run minted for NOTHING — it names no domain, no key, and
-        // is handed to no subject. It stands in for #1661's leaked filenames as
-        // produced by somebody else's process.
-        let foreignUUID = UUID().uuidString
-        XCTAssertNotEqual(foreignUUID, runToken)
+    /// The measured #1714 failure, and the background churn
+    /// `tools/lib/swift-suite.sh` measured over an 870s window of ordinary
+    /// interactive use. Committed as fixtures rather than described, so the
+    /// evidence outlives the PR that produced it.
+    private static let churnFixtures = [
+        "com.apple.siri.ODDI.MetricsWorker.plist",
+        "com.apple.bluetooth.plist",
+        "com.apple.DuetExpertCenter.MagicalMoments.plist",
+        "com.apple.voicetrigger.plist",
+        "com.googlecode.iterm2.plist",
+    ]
 
-        // The measured #1714 failure, and the background churn
-        // `tools/lib/swift-suite.sh` measured over an 870s window of ordinary
-        // interactive use. Committed as fixtures rather than described.
-        let churn = [
-            "com.apple.siri.ODDI.MetricsWorker.plist",
-            "com.apple.bluetooth.plist",
-            "com.apple.DuetExpertCenter.MagicalMoments.plist",
-            "com.apple.voicetrigger.plist",
-            "com.googlecode.iterm2.plist",
-        ]
-
-        // A premise, not decoration: if a derived process domain ever appeared
-        // inside one of those names the silent rows would go red for a reason
-        // unrelated to what they grade — and that condition is exactly "the
-        // derivation became too generic to be an attribution", which is worth
-        // failing on in its own right.
-        for name in churn {
-            for domain in domains {
-                XCTAssertFalse(
-                    name.contains(domain),
-                    "the derived process domain '\(domain)' occurs inside the churn fixture "
-                    + "'\(name)' — that derivation cannot attribute anything"
-                )
-            }
-        }
-
+    /// One row per shape, both verdicts carried. Lifted into its own table for
+    /// the reason `guardedConstructions()` is one in
+    /// `core/application/services/construction_test.go`: a corpus grows a row
+    /// at a time, and a row is easier to add to a table than to a method.
+    private func attributionCorpus(runToken: String,
+                                   processDomain: String,
+                                   foreignUUID: String) -> [AttributionCase] {
         let leak1661 = "io.irrlicht.tests.NotificationMasterGate.\(runToken).plist"
-        let corpus: [AttributionCase] = [
+        let probeDomain = "io.irrlicht.tests.leakProbe.\(runToken).round0.plist"
+        return [
             .init(what: "#1661's own artifact — the empty plist cfprefsd left behind for a UUID "
                       + "suite the test minted",
                   appeared: [leak1661],
@@ -378,13 +358,13 @@ final class InMemoryDefaultsTests: XCTestCase {
                   appeared: ["\(runToken).plist"],
                   mustReport: ["\(runToken).plist"]),
             .init(what: "the domain this test itself names when it drives removePersistentDomain",
-                  appeared: ["io.irrlicht.tests.leakProbe.\(runToken).round0.plist"],
-                  mustReport: ["io.irrlicht.tests.leakProbe.\(runToken).round0.plist"]),
+                  appeared: [probeDomain],
+                  mustReport: [probeDomain]),
             .init(what: "a spelling that merely CONTAINS the minted identifier — a suffixed or "
                       + "temporary form is not a way past the guard, which is why the match is "
                       + "containment and not equality",
-                  appeared: ["io.irrlicht.tests.leakProbe.\(runToken).round0.plist.tmp"],
-                  mustReport: ["io.irrlicht.tests.leakProbe.\(runToken).round0.plist.tmp"]),
+                  appeared: ["\(probeDomain).tmp"],
+                  mustReport: ["\(probeDomain).tmp"]),
             .init(what: "a write that reached `super` — this process's own application domain, "
                       + "which is what init(suiteName: nil) binds",
                   appeared: ["\(processDomain).plist"],
@@ -399,7 +379,7 @@ final class InMemoryDefaultsTests: XCTestCase {
                   appeared: ["com.apple.siri.ODDI.MetricsWorker.plist"],
                   mustReport: []),
             .init(what: "the background churn swift-suite.sh measured over an 870s window",
-                  appeared: churn,
+                  appeared: Self.churnFixtures,
                   mustReport: []),
             .init(what: "THE DECLARED LIMIT: a <uuid>.plist — #1661's exact shape — bearing a UUID "
                       + "this run did not mint is NOT reported. That is what attribution gives up, "
@@ -411,8 +391,40 @@ final class InMemoryDefaultsTests: XCTestCase {
                   appeared: [],
                   mustReport: []),
         ]
+    }
 
-        for probe in corpus {
+    func testAttributionReportsEveryLeakShapeAndStaysSilentOnEveryChurnShape() throws {
+        let runToken = UUID().uuidString
+        let domains = PreferencesDirectoryWitness.processApplicationDomains
+        let processDomain = try XCTUnwrap(
+            domains.sorted().first,
+            "this process's application domain could not be derived, so the clause that catches a "
+            + "write reaching `super` is graded by nothing below"
+        )
+        // A UUID this run minted for NOTHING — it names no domain, no key, and
+        // is handed to no subject. It stands in for #1661's leaked filenames as
+        // produced by somebody else's process.
+        let foreignUUID = UUID().uuidString
+        XCTAssertNotEqual(foreignUUID, runToken)
+
+        // A premise, not decoration: if a derived process domain ever appeared
+        // inside one of the churn fixtures the silent rows would go red for a
+        // reason unrelated to what they grade — and that condition is exactly
+        // "the derivation became too generic to be an attribution", which is
+        // worth failing on in its own right.
+        for name in Self.churnFixtures {
+            for domain in domains {
+                XCTAssertFalse(
+                    name.contains(domain),
+                    "the derived process domain '\(domain)' occurs inside the churn fixture "
+                    + "'\(name)' — that derivation cannot attribute anything"
+                )
+            }
+        }
+
+        for probe in attributionCorpus(runToken: runToken,
+                                       processDomain: processDomain,
+                                       foreignUUID: foreignUUID) {
             let attribution = try PreferencesDirectoryWitness.attribute(probe.appeared, toRun: runToken)
             XCTAssertEqual(attribution.names, probe.mustReport.sorted(), probe.what)
             XCTAssertEqual(


### PR DESCRIPTION
Closes #1714.

## The defect

`InMemoryDefaultsTests.testTheDoubleAddsNothingToTheRealPreferencesDirectory` snapshotted the
whole real `~/Library/Preferences`, exercised the in-memory `UserDefaults` double, and asserted
the directory gained nothing. On a GitHub runner the OS wrote a Siri metrics plist inside that
window and the assertion attributed it to the double:

```
InMemoryDefaultsTests.swift:164: error: … XCTAssertEqual failed:
  ("["com.apple.siri.ODDI.MetricsWorker.plist"]") is not equal to ("[]")
  - The defaults double reached disk. #1661 is back: files appeared in
    /Users/runner/Library/Preferences during this test, …
```
*(run 32295153905, `main` @ `5df32537`, job `swift-test` — read from the log, not from the issue.)*

It is a false **accusation**, not a false alarm. The witness answered *"did this directory
change"* where the question is *"did the SUBJECT change it"*.

**Measured reachability, wider than the issue had.** The issue records "1 of the last 3" and says
the frequency beyond that is unmeasured. Over every `macos-swift` run on `main` since the
`swift-test` job landed (`a86ae50a`, 2026-08-16) through 2026-08-19: **45 success, 1 failure, 1
cancelled** — so **1 in 46 graded runs**, not ~1 in 3. That is the number the #1530 call below rests
on, and it makes this a slow, expensive lie rather than a loud one.

## The shape chosen, and what it can no longer catch

**Attribution, not observation** — issue option 1. Two clauses, neither of them a list of names
the run did not choose:

| clause | needle | catches |
|---|---|---|
| the run's own token | a UUID minted per run, woven through every domain name and key the double is handed | #1661's own artifact — a plist named for a suite the test minted |
| this process's application domain | derived at run time from `Bundle`/`ProcessInfo`; measured `["com.apple.dt.xctest.tool", "xctest"]` | a write that reached `super`, which is what `init(suiteName: nil)` binds |

Both are deterministic: an OS-written file cannot carry a UUID this process minted a millisecond
ago. **Option 2 (a difference over a control window) was rejected on the measurement**: the
observed failure was a metrics worker writing *once*, and a one-shot write is exactly what a
two-window subtraction cannot cancel — it would have false-accused identically.

**What it can no longer catch, stated plainly:** a NEW file whose name carries neither needle — a
leak into a domain named nowhere in this process. Concretely, a `<uuid>.plist` bearing a UUID this
run did not mint, which is #1661's exact shape produced by somebody else. That is committed as a
corpus row (`THE DECLARED LIMIT`) so it is learned from a test rather than from an incident.

Two things still watch that population, and neither is inside this process:

- `tools/lib/swift-suite.sh`'s **directory half** brackets the whole `swift test` invocation with
  the same unattributed net. Its wording already handles the ambiguity ("Background daemons also
  write here … Re-run to tell that apart; ours will reappear every time"), and it **can** re-run —
  which a single in-process window cannot. That is the whole reason the two halves make opposite
  trades.
- Its **domain half** compares `com.apple.dt.xctest.tool`'s key set *and values* across the run,
  which sees a write into an already-existing domain that no added-entry witness can. Worth noting
  while we are here: on any machine where that plist already exists (it does on the reference Mac),
  the *old* assertion never covered the leak-through-`super` case either — a modification adds no
  directory entry. The new process-domain clause covers it only where the file does not yet exist,
  e.g. a fresh runner; the deterministic coverage for that direction is
  `testTheProcessesRealStandardDefaultsAreUntouched`, which predates this PR.

## Committed mutation evidence

Per AGENTS.md the evidence is committed beside the assertion, not described here — but each
mutation below was also applied to the tree, seen red, and reverted. Test file:line for every
assertion is in `platforms/macos/Tests/InMemoryDefaultsTests.swift`.

**The guard still goes red against #1661's ACTUAL failure.** `testThePipelineReportsAn1661LeakWhileTheOSWritesInTheSameWindow`
drives `snapshot()` → `added(from:to:)` → `attribute(_:toRun:)` end to end against an **empty**
plist named `io.irrlicht.tests.NotificationMasterGate.<minted-uuid>.plist` — #1661's artifact byte
for byte — planted in a directory the test creates, with `com.apple.siri.ODDI.MetricsWorker.plist`
planted in the *same window*. It reports the first and counts the second. Empty is load-bearing:
the file carries none of the values written, so only its NAME can attribute it.

**M3 — the pre-#1714 wide net, against the committed #1714 fixture.** `attribute` made to report
every appearance:

```
InMemoryDefaultsTests.swift:406: error: … XCTAssertEqual failed:
  ("["com.apple.siri.ODDI.MetricsWorker.plist"]") is not equal to ("[]")
  - #1714 itself: the Siri metrics plist a GitHub runner wrote inside the window,
    reported as 'the defaults double reached disk'
InMemoryDefaultsTests.swift:451: error: … XCTAssertEqual failed:
  ("["com.apple.siri.ODDI.MetricsWorker.plist", "io.irrlicht.tests.NotificationMasterGate.AE2E….plist"]")
  is not equal to ("["io.irrlicht.tests.NotificationMasterGate.AE2E….plist"]")
  - the guard no longer goes red against #1661's actual failure
→ Executed 16 tests, with 11 failures
```

**M1 — the run-token clause removed** → 12 failures, confined to the two attribution tests: every
leak row goes red, every churn row stays green.
**M2 — the process-domain clause removed** → exactly **3** failures: the `super` corpus row and the
derivation test, and nothing else. The two clauses are graded separately.
**M4 — the exercise stops weaving the token** into one of its three key families → exactly **1**
failure, the drift guard: *"the exercise stopped weaving this run's token into the identifiers it
hands the double, so the attribution below is scoped to nothing this test names"*.
**M5 — the empty-run-token refusal removed** → exactly **1** failure, that arm alone.
**M6 — both process-domain refusals removed** → exactly **2**, the other two arms, arm 1 green.
**M7 — the derivation made over-generic** (`["com"]`) → 13 failures including the corpus premise
(*"the derived process domain 'com' occurs inside the churn fixture …"*) and the length guard.

**M8 — the failure MESSAGE, rendered rather than reasoned about.** Three synthetic names fed to the
pure attribution (no file created anywhere), so the live assertion's text can be read:

```
This test wrote into the real /Users/ingo/Library/Preferences, and nothing in this repository is
allowed to delete it again.

Carrying this run's token (ADABAFF2-…) — these can only be the DOUBLE's, because nothing else in
the world has that string. #1661 is back:
  io.irrlicht.tests.leakProbe.ADABAFF2-….round0.plist

Naming this process's own application domain (com.apple.dt.xctest.tool, xctest) — a write that
reached `super`. That is the double if one of its overrides stopped overriding, and a
#1672-class persist by something else this process rendered otherwise; …
  com.apple.dt.xctest.tool.plist

1 further entr(y/ies) appeared in the same window and are attributable to neither. Background
daemons write here too — measured at roughly one plist per 218s of active use — so they are NOT
part of this failure (#1714). tools/lib/swift-suite.sh is what still watches that population.
```

The two clauses are printed as two lists on purpose: a process-domain hit is the double *or* a
#1672-class persist by something else this process rendered, and one merged sentence would claim
more than the evidence supports. The Siri name is now explicitly excluded and named as churn —
which is the whole fix, visible in the one place a reader will actually look.

## Vacuity guards

"Nothing attributable appeared" is also what these produce, so each is asserted before the
measurement: the directory snapshot is non-empty (pre-existing); the double was actually driven
(150 keys through `writtenKeys`); every written key carries the token; the process domain derives
to something non-empty, path-free and longer than 3 characters (a needle short enough for
containment to stop being an attribution). `attribute` **refuses** an empty needle rather than
answering — `"x".contains("")` is `true` in Swift, so an empty token silently restores the very net
this removes, green until the day it fires. Each refusal names a fragment of its own reason,
because all three throw the same case.

Nothing in this change writes, moves or deletes anything under a real home. There is still no
`removeItem` anywhere in `InMemoryDefaults.swift`, and every planted file is in a directory the
test itself created under `NSTemporaryDirectory()`.

## Verification

- `tools/preflight.sh --only swift` — **PASS**, `Executed 440 tests, with 0 failures` (436 before;
  +4 tests). Real-home witness: *no new entries*. Domain witness: *key sets and values unchanged*.
- `git status --porcelain platforms/macos/Tests/__Snapshots__` — empty. **Zero reference PNGs
  changed**, keeping the untouched 53-reference set intact.
- `AGENTS.md`'s derived figure updated with the measurement: 388 of 436 → **392 of 440**
  (`ci-scope census: module=IrrlichtTests total=440 gated=392 ungated=48 skippedSuites=5`).
- `--only tools` / `--only skills` not run: the diff touches neither `tools/` nor `.claude/skills/`.

## Also in this PR

**A second commit, `refactor(macos): lift the attribution corpus into its own table`.** CodeScene's
advisory check flagged `Large Method` on the corpus test (9.39 → 8.98 on the file). Fixed with this
repo's own idiom rather than as a metric chase — `guardedConstructions()` in
`core/application/services/construction_test.go` is the same table-returning shape — and re-measured
after the extraction with the same M3 mutation, which still reddens the identical 11 assertions
including `#1714 itself` and `THE DECLARED LIMIT`. No row changed.

## A premise of #1714 that is not quite right, and one of the old test's

Both are small and both are stated rather than left to be repeated:

- **#1714's reachability figure.** It reads "1 of the last 3" and says the frequency beyond that is
  not measured. Measured over the whole population it is **1 in 46**. The issue is right that it is
  intermittent; it is ~15× rarer than the sample implies, which strengthens the case for fixing the
  mechanism rather than waiting to see it again.
- **The old assertion did not cover what its own doc comment claimed.** `InMemoryDefaults.init()`
  said the "no write reaches `super`" measurement "is re-run on every suite run" by that test. On any
  machine where `com.apple.dt.xctest.tool.plist` already exists — it does on the reference Mac, 18
  keys, mtime 2026-08-17 — a write reaching `super` MODIFIES that file and adds no directory entry,
  so an added-entry witness was structurally blind to it. The deterministic coverage for that
  direction is and was `testTheProcessesRealStandardDefaultsAreUntouched`, plus `swift-suite.sh`'s
  domain half since #1688. The comment is corrected in this PR.

## #1530 determination — **closed**

Posted with its evidence at #1530 (comment `5348557340`) and the issue is closed. Short form:

All four blockers are resolved — 2, 3 and 4 fixed in #1614 (#1523 itself closed 2026-08-14 and
`SoundPlayerTests` is absent from the skip list), blocker 1's scale half fixed and its rasterisation
half permanently accepted with containment (#1615, closed by PR #1713). The fifth host dependency
PR #1713 found, and the sole reason it recommended leaving #1530 open, is this PR.

**The two claims are kept apart, because only one is supported by what I measured.**
*"The mechanism is gone"* is supported **by construction, not by observation**: the assertion no
longer reads any name the run does not own, and the exact failing input is a committed corpus row
pinned to a silent verdict that goes red the moment the pre-fix net is restored.
*"The intermittency was not observed again"* is separately true and nearly worthless — `swift-test`
is green on this PR (`Executed 392 tests, with 0 failures`, runner; all five `InMemoryDefaultsTests`
tests I touched ran and passed there), but at a 1-in-46 base rate a single green run is ~98% likely
even with the defect fully present. **The closure is made on the first, not the second.**

Not claimed: that the suite has no *other* host dependency (#1714 was the fifth, found by reading
`main`'s history rather than a PR's checks; a sixth gets its own issue), that CI grades the whole
suite (it grades 392 of 440 — the 48 image snapshots are reference-host-only by #1615's decision),
or that the rasterisation residual is understood.

**One dependency on the future, said out loud in the comment too:** #1530 is closed on the strength
of this PR, which is open at the time of writing. If it does not land, `main` still carries the
fifth host dependency and #1530 should be reopened rather than quietly assumed fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
