### PR TITLE
feat(gemini-cli): hook-based state detection (Notification/AfterTool/AfterAgent, beacon delivery)

### DIFF
--- a/.claude/skills/ir:agent-releases/SKILL.md
+++ b/.claude/skills/ir:agent-releases/SKILL.md
@@ -77,12 +77,13 @@ you verified against, since it may lag the newest release.
 - Note: sessions have been SQLite (drizzle) since ~2026-02-14, **not** JSON files. Legacy JSON storage still exists in `packages/opencode/src/storage/storage.ts` but `session.ts` no longer routes through it — do not mistake the leftover for live storage.
 - The DB filename is channel-scoped upstream (`opencode-<channel>.db`); stable channels (`latest`/`beta`/`prod`) get plain `opencode.db` — see `packages/core/src/database/database.ts`
 
-#### Gemini CLI — ⚠️ unmaintained, skip by default
-- **Unmaintained — skip in sweeps** unless the user explicitly asks. The standing watches below are not being acted on. `references/monitoring-surface.md` §10 is the authoritative statement (rationale + reopen condition); don't restate it here.
+#### Gemini CLI
+- Maintained — track it in sweeps like any other adapter. It carried an "unmaintained, skip by default" marking from 2026-07-15 until #1717 reversed it: the flag was about maintainer time, not viability, and #1717 shipped a hook-based state-detection pilot against it (`core/adapters/inbound/agents/geminicli/hooks.go`), which needs the same release watch every other hook-installing adapter gets.
 - Check: `https://github.com/google-gemini/gemini-cli/releases` — **authoritative; the repo has no root `CHANGELOG.md`** (404s on `main`)
 - Releases very frequently (nightlies + previews) — focus on stable, group the rest
 - Best evidence is a local clone + `git diff <old-tag>..<new-tag>` on `packages/core/src/config/storage.ts` and `packages/core/src/services/chatRecordingService.ts`
 - Focus on: session transcript format under `~/.gemini/tmp/`, process naming (`bin/gemini`), heap-bump worker re-exec behavior
+- Since #1717: also watch the hook system this adapter now installs into (`packages/core/src/hooks/hookEventHandler.js` in the monorepo) — the `HookEventName` enum, `HookType` (still `{Command, Runtime, Plugin}` with no JSON-expressible `Http` as of 0.56.0 — an added HTTP delivery type would make the beacon workaround unnecessary), the exit-code-to-decision mapping in `hookRunner.js` (0/1/other → allow/allow-with-warning/deny — the reason a bare `curl` install would be unsafe), and the `NotificationType` enum (currently the single member `ToolPermission`, which this adapter's whole "waiting" signal depends on staying narrow)
 - Standing watch: SEA/native binary becoming default (`argv[0] === argv[1]`, env `GEMINI_CLI_NO_RELAUNCH=true`), and the `adk.agentSessionSubagentEnabled` flag — see #1068
 
 #### Kiro CLI

--- a/.claude/skills/ir:agent-releases/references/monitoring-surface.md
+++ b/.claude/skills/ir:agent-releases/references/monitoring-surface.md
@@ -516,8 +516,9 @@ grant the hooks permission).
   parse as JSON, which the scheduler then turns into a denied tool call or a blocked
   turn — a delivery type change here is a correctness question, not a compatibility one.
 - **Version floor**: `minCLIVersion = "0.54.0"` in `hookinstaller.go`, deliberately set at
-  the edge of what was directly source-verified (0.54.4 and 0.56.0, seven months apart,
-  byte-identical) rather than at the PR-archaeology date the hook system actually shipped
+  the edge of what was directly source-verified (0.54.4 and 0.56.0 — published
+  2026-08-07 and 2026-08-19, so a twelve-day, two-minor-release window, not a long
+  stability record — byte-identical) rather than at the PR-archaeology date the hook system actually shipped
   (~2025-09-22, google-gemini/gemini-cli #9074-#9112) — see that constant's doc comment
   before assuming an earlier floor is safe to backdate.
 - **Reopen condition for the OLD marking**: none — it will not return. A genuine future

--- a/.claude/skills/ir:agent-releases/references/monitoring-surface.md
+++ b/.claude/skills/ir:agent-releases/references/monitoring-surface.md
@@ -489,15 +489,45 @@ Lines arrive `TrimSpace`'d, so leading indentation is already gone.
 - Drop/reformat `> Tokens: … sent, … received` → kills tokens, cost, model attribution, **and** `assistant_message` in one stroke. Localization or thousands-separators (`1,234`) also defeat `[\d.]+`.
 - ⚠️ **The subtlest one:** aider printing **periodic keepalive/spinner/progress lines** into the `.md` would reset the idle anchor every tick and **suppress `IdleFlush` indefinitely → permanent `working`**. This requires no change to any marker string, just extra output.
 
-### 10. Gemini CLI (`gemini-cli`) — ⚠️ unmaintained
+### 10. Gemini CLI (`gemini-cli`)
 
-**As of 2026-07-15 this adapter is no longer actively maintained and is skipped in release sweeps** (this section is the authoritative statement of that; `SKILL.md` only points here). It still ships and still monitors live sessions, so it is listed for completeness — but upstream Gemini CLI changes are **not** tracked, and a break-risk analysis is deliberately out of scope.
+**Maintained — track it in sweeps like any other adapter.** It carried an "unmaintained,
+skip by default" marking from 2026-07-15 until #1717 reversed it: the flag was about
+maintainer time, not viability. #1717's audit found the flag was blocking the strongest
+hook-based state-detection candidate in the whole set — Gemini CLI ships `gemini hooks
+migrate` ("Migrate hooks from Claude Code to Gemini CLI"), deliberate upstream evidence
+of the Claude-Code-shaped envelope convergence the hook epic (#1355) depends on — and
+shipped it: `core/adapters/inbound/agents/geminicli/hooks.go` installs `Notification`
+(gated on `notification_type == "ToolPermission"`), `AfterTool` (broad release) and
+`AfterAgent` (the turn-done push, retiring the heuristic fallback below for sessions that
+grant the hooks permission).
 
 - **Transcript path**: `~/.gemini/tmp/<project>/chats/session-<timestamp>-<8hex>.jsonl`
-- **Adapter source**: `core/adapters/inbound/agents/geminicli/` — consult it directly if this adapter ever needs attention again.
-- **Reopen condition**: someone resumes maintenance, or a user reports gemini-cli sessions misbehaving. Until then, an upstream Gemini change is not a finding.
+- **Adapter source**: `core/adapters/inbound/agents/geminicli/` — `hooks.go` and
+  `hookinstaller.go` are the hook half; both carry the source citations (bundle line
+  offsets, exact byte-identical claims at two installed versions) rather than restating
+  them here.
+- **Hook delivery is the beacon, not a native http hook**: source-read from the installed
+  CLI's own bundle, `HookType` is `{Command, Runtime, Plugin}` — there is no
+  JSON-expressible `Http` type — so `irrlichd hook-post gemini-cli`
+  (`core/pkg/hookbeacon`) is what gets installed, never a bare `curl` line. That matters
+  for a release check specifically: Gemini CLI's own exit-code-to-decision mapping turns
+  ANY exit code other than 0 or 1 into `decision: "deny"` for a hook whose stdout didn't
+  parse as JSON, which the scheduler then turns into a denied tool call or a blocked
+  turn — a delivery type change here is a correctness question, not a compatibility one.
+- **Version floor**: `minCLIVersion = "0.54.0"` in `hookinstaller.go`, deliberately set at
+  the edge of what was directly source-verified (0.54.4 and 0.56.0, seven months apart,
+  byte-identical) rather than at the PR-archaeology date the hook system actually shipped
+  (~2025-09-22, google-gemini/gemini-cli #9074-#9112) — see that constant's doc comment
+  before assuming an earlier floor is safe to backdate.
+- **Reopen condition for the OLD marking**: none — it will not return. A genuine future
+  maintenance lapse is a new, separately-justified decision, not a reinstatement of this
+  one.
 
-> ⚠️ **#1068 is not the reason, and is not a deprecation notice** — don't cite it as either. It's a *watch item* about the native SEA binary possibly becoming default (which would break `DiscoverPID` and the heap-bump exclusion), closed as completed with the verdict "No impact today; no code change required". The maintenance decision is separate and out-of-band.
+> ⚠️ **#1068 is not a deprecation notice** — don't cite it as one. It's a *watch item*
+> about the native SEA binary possibly becoming default (which would break `DiscoverPID`
+> and the heap-bump exclusion), closed as completed with the verdict "No impact today; no
+> code change required".
 
 ---
 
@@ -509,7 +539,7 @@ Lines arrive `TrimSpace`'d, so leading indentation is already gone.
 | **Root relocation via a new env var** | Upstream ships `$VIBE_HOME`-style override for an adapter that hardcodes its root | CRITICAL — silent blackout; the watcher waits on a path that never appears |
 | **DB schema change** (opencode, antigravity) | Table/column rename, protobuf field renumbering | CRITICAL — errors are logged and swallowed, or decode silently returns zeroes |
 | **Transcript format change** | JSONL schema altered, event types renamed/removed | HIGH — state classification fails |
-| **Turn-end shape change** | Trailing tool call on the final message, or a text-only message mid-turn | HIGH — the 4 heuristic adapters (vibe, kiro-cli, antigravity, gemini-cli) stick in `working` forever, or flicker to `ready` early. aider is spared the stick by its idle flush; the 4 explicit adapters are unaffected. |
+| **Turn-end shape change** | Trailing tool call on the final message, or a text-only message mid-turn | HIGH — vibe, kiro-cli and antigravity (still purely heuristic, no independent signal) stick in `working` forever, or flicker to `ready` early. aider is spared the stick by its idle flush; the explicit adapters are unaffected. gemini-cli's own transcript parsing is still heuristic and equally exposed, but since #1717 a session with the hooks permission granted has an independent, transcript-shape-agnostic backstop — `AfterAgent` carries its own turn text and fires regardless of what the transcript looks like — so this row applies to it only when hooks are not granted (or the install has gone stale and `Verify` hasn't yet repaired it). |
 | **Tool system change** | Tool names renamed, tool_use/tool_result structure changed | HIGH — waiting/subagent detection breaks |
 | **Process change** | Binary renamed, wrapped under `node`/`python`, `setproctitle` adopted, CWD no longer accessible | HIGH — PID tracking fails; **total loss for aider** (no file fallback) and **opencode** (live-process discovery gate) |
 | **Prose/marker rewording** | `"The command failed"`, `"Request cancelled"`, `> Applied edit to`, `#### ` | HIGH — English-literal dependencies; localization breaks them silently |

--- a/core/adapters/inbound/agents/beaconroute_test.go
+++ b/core/adapters/inbound/agents/beaconroute_test.go
@@ -6,6 +6,7 @@ import (
 	"irrlicht/core/adapters/inbound/agents/claudecode"
 	"irrlicht/core/adapters/inbound/agents/codex"
 	"irrlicht/core/adapters/inbound/agents/copilot"
+	"irrlicht/core/adapters/inbound/agents/geminicli"
 	"irrlicht/core/pkg/hookbeacon"
 )
 
@@ -35,6 +36,7 @@ func TestBeaconEndpointPathMatchesTheInstalledReceivers(t *testing.T) {
 		"claudecode": claudecode.HookEndpointPath,
 		"codex":      codex.HookEndpointPath,
 		"copilot":    copilot.HookEndpointPath,
+		"gemini-cli": geminicli.HookEndpointPath,
 	} {
 		if got := hookbeacon.EndpointPath(segment); got != want {
 			t.Errorf("hookbeacon.EndpointPath(%q) = %q, but the receiver is registered at %q — the beacon would post into a route nothing serves", segment, got, want)

--- a/core/adapters/inbound/agents/geminicli/agent.go
+++ b/core/adapters/inbound/agents/geminicli/agent.go
@@ -4,6 +4,7 @@ import (
 	"regexp"
 	"strings"
 
+	"irrlicht/core/adapters/inbound/agents/hookjson"
 	"irrlicht/core/domain/agent"
 	"irrlicht/core/domain/permission"
 )
@@ -29,6 +30,20 @@ const iconSVGDark = `<svg xmlns="http://www.w3.org/2000/svg" width="14" height="
   <path d="M50 6 C54 30 70 46 94 50 C70 54 54 70 50 94 C46 70 30 54 6 50 C30 46 46 30 50 6 Z" fill="#8AB4F8"/>
 </svg>`
 
+// Source is the adapter's transcript-tree declaration.
+//
+// The hook receiver's path confiner reads it per request (issue #1361), and
+// Agent() below is its only other caller — one declaration, so the tree the
+// daemon watches and the tree the receiver confines to cannot drift apart.
+func Source() agent.Source {
+	return agent.FilesUnderRoot{
+		Dir: sessionsDir(),
+		Parser: agent.JSONLineParser{
+			NewParser: func() agent.LineParser { return &Parser{} },
+		},
+	}
+}
+
 // Agent returns the Gemini CLI adapter registration.
 func Agent() agent.Agent {
 	return agent.Agent{
@@ -43,12 +58,7 @@ func Agent() agent.Agent {
 			PIDForSession: DiscoverPID,
 			ExcludeArgv:   isHeapBumpWorker,
 		},
-		Source: agent.FilesUnderRoot{
-			Dir: sessionsDir(),
-			Parser: agent.JSONLineParser{
-				NewParser: func() agent.LineParser { return &Parser{} },
-			},
-		},
+		Source:  Source(),
 		Control: agent.Control{SupportsInput: true, Interrupt: agent.InterruptCtrlC},
 		Permissions: []agent.Permission{
 			agent.ControlPermission(),
@@ -65,6 +75,42 @@ func Agent() agent.Agent {
 					"command line — to bind a session to its process and skip the " +
 					"Node heap-bump worker. Read-only — no file is ever modified. " +
 					"Toggling off stops all reading immediately.",
+			},
+			{
+				Key:             PermissionKeyHooks,
+				Kind:            permission.KindModify,
+				Title:           "Install status hooks",
+				FeatureUnlocked: "Authoritative turn-end detection, and an instant permission-prompt refresh",
+				// Count and event list are derived from installedHookEvents,
+				// never restated: this copy is the consent contract, and
+				// hand-maintaining it is how claudecode's came to promise six
+				// entries against a seven-event install (#1356).
+				Touches: hookjson.EntriesTouched("~/.gemini/settings.json", installedHookEvents),
+				Detail: "Adds " + hookjson.EventList(installedHookEvents) +
+					" hook entries to ~/.gemini/settings.json (Gemini CLI's own settings " +
+					"file — every other key you have there is left untouched). Gemini CLI " +
+					"has no HTTP hook delivery, so each entry runs `irrlichd hook-post " +
+					"gemini-cli` — a tiny command irrlicht ships — which reads the daemon's " +
+					"own published address at the moment the hook fires and forwards the " +
+					"payload; it never blocks a tool call even when the daemon is not " +
+					"running. " +
+					hookjson.RequiresVersion("Gemini CLI", minCLIVersion) +
+					" Toggling off removes exactly these entries (also available via " +
+					"`irrlichd --uninstall-hooks`).",
+				Apply:  func() error { _, err := EnsureHooksInstalled(); return err },
+				Remove: func() error { _, err := UninstallHooks(); return err },
+				Writes: &agent.ManagedUserFile{
+					Path:      geminiSettingsPath,
+					Uninstall: UninstallHooks,
+					// Read-only; the repair it feeds runs through
+					// PermissionService, which re-checks consent under its own
+					// lock before writing (#1372).
+					Verify: VerifyHooksInstalled,
+					Version: &agent.VersionGate{
+						Min:   minCLIVersion,
+						Probe: []string{"gemini", "--version"},
+					},
+				},
 			},
 		},
 	}

--- a/core/adapters/inbound/agents/geminicli/hookdisclosure_test.go
+++ b/core/adapters/inbound/agents/geminicli/hookdisclosure_test.go
@@ -1,0 +1,27 @@
+// hookdisclosure_test.go wires the Gemini CLI hooks permission into the
+// shared issue #1356 contract: the consent copy names every event the
+// installer writes, states the right entry count, and names no event it does
+// not install. This is a LOCK — the copy is derived from installedHookEvents
+// via hookjson.EntriesTouched/EventList rather than hand-written, so it
+// passes by construction; the contract is what keeps it that way when the
+// event set changes.
+package geminicli
+
+import (
+	"testing"
+
+	"irrlicht/core/internal/contracttesting"
+)
+
+func TestHooksPermission_DisclosureMatchesInstalled(t *testing.T) {
+	contracttesting.AssertHookDisclosureMatchesInstalled(t, contracttesting.HookDisclosure{
+		Agent:         Agent(),
+		PermissionKey: PermissionKeyHooks,
+		Installed:     installedHookEvents,
+		// No NonEventTerms: unlike copilot's "GitHub" (which is genuinely
+		// two-hump CamelCase — Git+Hub — and so matches the contract's
+		// eventShapedToken shape), nothing in this adapter's consent copy is
+		// a two-or-more-word CamelCase token that is not an actual installed
+		// event name. "Gemini" and "CLI" are each a single hump.
+	})
+}

--- a/core/adapters/inbound/agents/geminicli/hookinstaller.go
+++ b/core/adapters/inbound/agents/geminicli/hookinstaller.go
@@ -81,14 +81,19 @@ var HookEndpointPath = hookbeacon.EndpointPath(AdapterName)
 // bundle the CLI ships today, so a file-presence diff across that packaging
 // change proves nothing.
 //
-// What IS directly verified, at two points seven months apart with zero
-// drift, is the exact behavior this adapter depends on: 0.54.4 (source-read
+// What IS directly verified, with zero drift across an upgrade that actually
+// happened on the dev machine mid-audit, is the exact behavior this adapter
+// depends on: 0.54.4 (source-read
 // at the start of this issue's audit) and 0.56.0 (source-read again after the
 // installed CLI auto-updated mid-audit) — validateHookConfig's accepted
 // types, the exit-code-to-decision mapping, fireAfterAgentHookSafe's
 // dedup/pending-tool gate, resolveConfirmation's unconditional pre-block
 // notifyHooks call, and the NotificationType/HookEventName enums are
-// byte-identical between them. 0.54.0 is the edge of that verified window,
+// byte-identical between them. Note the honest limit of that window rather
+// than overstating it: npm publishes those two on 2026-08-07 and 2026-08-19
+// (`npm view @google/gemini-cli time`), so it spans TWELVE DAYS and two minor
+// releases — evidence that the shape survived a real upgrade, not evidence
+// that it is long-settled. 0.54.0 is the edge of that verified window,
 // not the edge of "some form of hooks existed" — overshooting a version
 // floor is the safe direction (core/pkg/cliversion fails OPEN on an unknown
 // or unparseable version), undershooting is not, so the floor sits at the

--- a/core/adapters/inbound/agents/geminicli/hookinstaller.go
+++ b/core/adapters/inbound/agents/geminicli/hookinstaller.go
@@ -1,0 +1,302 @@
+// hookinstaller.go manages Gemini CLI hook entries in the user's own
+// ~/.gemini/settings.json for the irrlicht daemon (issue #1717, epic #1355
+// Phase D).
+//
+// Unlike claudecode's and codex's own settings files, ~/.gemini/settings.json
+// is Gemini CLI's ONE general-purpose settings file — theme, auth, and every
+// other user preference live in it alongside "hooks" — so this installer
+// follows claudecode's shared-file shape (merge our "hooks" key into the
+// document, leave every other key untouched, never delete the file) rather
+// than copilot's dedicated-file shape.
+//
+// Delivery is the beacon (core/pkg/hookbeacon), not a native http hook and not
+// a bare curl line, and that is not a preference — it is what the Phase 1
+// audit for this issue established from source. Gemini CLI's HookType is
+// {Command, Runtime} (source-read from the installed CLI's own bundle:
+// validateHookConfig accepts only "command", "plugin" and "runtime" — there is
+// no JSON-expressible "http"), so a shell command is the only delivery this
+// CLI can be given. And source-read from the same bundle,
+// convertPlainTextToHookOutput turns ANY exit code other than 0 or 1 into
+// decision "deny" for a hook that returned no parseable JSON, which
+// evaluateBeforeToolHook and fireBeforeAgentHookSafe then turn into a blocked
+// tool call or a blocked turn — so a bare `curl` against a daemon that is not
+// running (exit 7) would not merely fail to report state, it would break the
+// user's tool calls. hookbeacon's `irrlichd hook-post gemini-cli` always exits
+// 0, by construction (core/pkg/hookbeacon's own package doc has the full
+// argument, verified against gemini-cli specifically in this issue's audit
+// rather than assumed from Codex's or Copilot's shape).
+package geminicli
+
+import (
+	"os"
+	"path/filepath"
+
+	"irrlicht/core/adapters/inbound/agents/agentpaths"
+	"irrlicht/core/adapters/inbound/agents/hookjson"
+	"irrlicht/core/domain/agent"
+	"irrlicht/core/pkg/hookbeacon"
+)
+
+// geminiHomeDirName is the $HOME-relative Gemini CLI config directory. Gemini
+// CLI has no home-override environment variable — source-read:
+// Storage.getGlobalGeminiDir() resolves via Node's plain os.homedir(), not an
+// env var this adapter could honor — which is also why sessionsDir() in
+// adapter.go reads no environment either.
+const geminiHomeDirName = ".gemini"
+
+// geminiSettingsFilename is Gemini CLI's one general-purpose settings file —
+// theme, auth, security and hooks all live in the same document.
+const geminiSettingsFilename = "settings.json"
+
+// HookEndpointPath is the daemon's Gemini CLI hook route. Exported so
+// registerHookRoutes (core/cmd/irrlichd/startup.go) and
+// beaconroute_test.go's pinned map both derive from the same segment this
+// installer renders into the config, per hookbeacon's install.go doc: "A
+// mismatch is a permanent silent 404: the beacon exits 0 by design, so
+// nothing anywhere reports it."
+//
+// AdapterName ("gemini-cli") is used directly as the beacon segment — unlike
+// claudecode, which has a historical route segment ("claudecode") distinct
+// from its AdapterName ("claude-code"), this adapter has never installed
+// under any other spelling, and "gemini-cli" is itself a valid beacon segment
+// (hookbeacon's adapterSegment grammar allows hyphens).
+//
+// A var, not a const: hookbeacon.EndpointPath composes the route from its own
+// unexported prefix, so deriving it here (rather than duplicating that prefix
+// as a second literal) is what keeps this constant from being able to drift
+// from the beacon's own routing convention.
+var HookEndpointPath = hookbeacon.EndpointPath(AdapterName)
+
+// minCLIVersion is the lowest Gemini CLI version this adapter's install
+// requires.
+//
+// NOT the date the hook system was introduced upstream — PR archaeology
+// (google-gemini/gemini-cli #9074-#9112, all merged 2025-09-22) puts the
+// BeforeTool/AfterTool/BeforeAgent/AfterAgent/Notification event set at
+// roughly that date, with the first stable release after it 0.6.0
+// (2025-09-24). This floor is deliberately more conservative than that
+// evidence supports, because bisecting an old release for the exact payload
+// shape turned out to be unreliable: those 2025-era npm packages ship a
+// completely different (unbundled dist/src) layout than the single-file
+// bundle the CLI ships today, so a file-presence diff across that packaging
+// change proves nothing.
+//
+// What IS directly verified, at two points seven months apart with zero
+// drift, is the exact behavior this adapter depends on: 0.54.4 (source-read
+// at the start of this issue's audit) and 0.56.0 (source-read again after the
+// installed CLI auto-updated mid-audit) — validateHookConfig's accepted
+// types, the exit-code-to-decision mapping, fireAfterAgentHookSafe's
+// dedup/pending-tool gate, resolveConfirmation's unconditional pre-block
+// notifyHooks call, and the NotificationType/HookEventName enums are
+// byte-identical between them. 0.54.0 is the edge of that verified window,
+// not the edge of "some form of hooks existed" — overshooting a version
+// floor is the safe direction (core/pkg/cliversion fails OPEN on an unknown
+// or unparseable version), undershooting is not, so the floor sits at the
+// boundary of what was actually read rather than at the boundary PR dates
+// alone would justify.
+const minCLIVersion = "0.54.0"
+
+// hookEventSince records the Gemini CLI version each installed event is
+// proven (by the same source read, not a separate per-event date) to exist
+// with the payload shape this adapter depends on. minCLIVersion must be >=
+// every value here, which AssertHookVersionGate enforces. All three share one
+// value for the reason given on minCLIVersion: the evidence is one source
+// read covering all three events together, not three independent dates.
+var hookEventSince = map[string]string{
+	HookNotification: minCLIVersion,
+	HookAfterTool:    minCLIVersion,
+	HookAfterAgent:   minCLIVersion,
+}
+
+// installedHookEvents are the Gemini CLI hook events we install handlers for
+// — three of the eleven the CLI's hook system fires.
+//
+// Deliberately NOT these:
+//
+//   - BeforeTool is excluded on safety grounds, source-verified rather than
+//     assumed: it fires for EVERY tool call with no discriminator separating
+//     "about to run silently" from "about to block on the user" (its payload
+//     is tool_name/tool_input and nothing else), and a hook that errors on it
+//     turns into a denied tool call (evaluateBeforeToolHook). Notification,
+//     gated on notification_type=="ToolPermission", gives the same
+//     information as a real, narrow signal instead.
+//   - SessionStart/SessionEnd/PreCompress/BeforeModel/AfterModel/
+//     BeforeToolSelection are excluded on evidence: none of them has a
+//     stated payoff for irrlicht's three-state model (working/waiting/ready)
+//     beyond what process discovery and transcript tailing already give, and
+//     BeforeModel/AfterModel additionally carry full LLM request/response
+//     bodies — blast radius with no offsetting benefit. SessionStart and
+//     SessionEnd were the two events this issue's live audit could actually
+//     fire (everything else needed a working model call, which the
+//     account's auth was ineligible for) — that they were observable is not
+//     itself a reason to install them, and no other justification was found.
+var installedHookEvents = []string{
+	HookNotification,
+	HookAfterTool,
+	HookAfterAgent,
+}
+
+// matcherForEvent returns the matcher we install for the given event. None of
+// the three installed events is tool-scoped in a way we want narrowed at the
+// CLI config level — AfterTool must fire for every tool (it is the broad
+// release side) and Notification's ToolPermission discriminator lives in the
+// payload's notification_type field, not in anything Gemini's matcher grammar
+// filters on. So every event takes no matcher, and hookjson omits the key
+// entirely — the same choice copilot makes for the same reason.
+//
+// Filtering happens adapter-side instead (handleNotificationHook), the same
+// defense-in-depth claudecode's handlers apply on top of their own narrower
+// matchers: this receiver would still filter correctly even if Gemini CLI's
+// matcher grammar turned out to support a notification_type filter after all.
+func matcherForEvent(string) string { return "" }
+
+// ourHookEntry builds the inner hook object we install for the currently
+// running daemon: a beacon command, never a curl line and never Gemini's
+// native http type (which does not exist for this CLI — see the package
+// doc).
+func ourHookEntry() map[string]interface{} {
+	command, _ := hookbeacon.InstalledCommand(AdapterName)
+	return beaconEntry(command)
+}
+
+// beaconEntry is the beacon inner hook object for a given, already-resolved
+// command line. Split from ourHookEntry so hookConfig can close over a command
+// resolved ONCE per entry point rather than re-resolving (and re-swallowing
+// any error) on every Entry() call — the same shape
+// hook_endpoint_addressfree_test.go's reference wiring uses, and the reason
+// hookbeacon.InstalledCommand exists as a single fallible step rather than
+// BinaryPath+Command composed at every call site (measured at +12 lines when
+// copilot evaluated beacon delivery, per hookbeacon's own doc).
+func beaconEntry(command string) map[string]interface{} {
+	return map[string]interface{}{
+		"type":    "command",
+		"command": command,
+	}
+}
+
+// hookEntryIsCanonical reports whether an inner hook object matches the
+// canonical beacon command for the currently running daemon — hookbeacon.
+// IsCanonical rewrites in place an entry naming a moved or missing binary
+// (#1373's DriftBinaryPath/DriftBinaryMissing), the beacon's equivalent of
+// claudecode's/codex's own port-staleness rewrite.
+func hookEntryIsCanonical(hook map[string]interface{}) bool {
+	command, _ := hook["command"].(string)
+	return hookbeacon.IsCanonical(command, AdapterName)
+}
+
+// hookConfig describes this adapter's install to the shared hookjson
+// machinery, for a command already resolved by the caller (see beaconEntry).
+func hookConfig(path, command string) hookjson.Config {
+	return hookjson.Config{
+		Path:        path,
+		Sentinel:    hookbeacon.Sentinel(AdapterName),
+		Events:      installedHookEvents,
+		MatcherFor:  matcherForEvent,
+		Entry:       func() map[string]interface{} { return beaconEntry(command) },
+		IsCanonical: hookEntryIsCanonical,
+		WriteFile:   atomicWriteFile,
+	}
+}
+
+// EnsureHooksInstalled adds irrlicht hook entries to ~/.gemini/settings.json
+// if they are not already present. Every other key in that file — theme,
+// security.auth, whatever else the user or Gemini CLI itself has written — is
+// left byte-for-byte alone; hookjson merges only the "hooks" key. Returns true
+// if the file was modified.
+func EnsureHooksInstalled() (bool, error) {
+	path, err := geminiSettingsPath()
+	if err != nil {
+		return false, err
+	}
+	command, err := hookbeacon.InstalledCommand(AdapterName)
+	if err != nil {
+		return false, err
+	}
+	return hookjson.EnsureInstalled(hookConfig(path, command))
+}
+
+// VerifyHooksInstalled reports which of our entries are missing from, or
+// stale in, ~/.gemini/settings.json — without writing anything (issue #1372).
+// This is what makes gemini-cli's sync-by-omission settings writer survivable
+// (see agent.go's consent copy and #1355's Phase C audit finding): if Gemini
+// CLI's own settings UI later rewrites the file and drops our entries,
+// services.HookEntryVerifier reads this on a timer and repairs through
+// PermissionService rather than silently reading "granted" over a dead
+// install.
+func VerifyHooksInstalled() (agent.HookEntryStatus, error) {
+	path, err := geminiSettingsPath()
+	if err != nil {
+		return agent.HookEntryStatus{}, err
+	}
+	command, err := hookbeacon.InstalledCommand(AdapterName)
+	if err != nil {
+		return agent.HookEntryStatus{}, err
+	}
+	return hookjson.Verify(hookConfig(path, command))
+}
+
+// UninstallHooks removes irrlicht hook entries from ~/.gemini/settings.json.
+// Returns true if the file was modified.
+//
+// Unlike copilot's dedicated hooks/irrlicht.json, this file is the user's
+// general Gemini CLI settings — theme, auth, everything else lives here too —
+// so uninstall never removes the file itself, only our "hooks" key's
+// entries, mirroring claudecode's own shared-settings uninstall exactly.
+func UninstallHooks() (bool, error) {
+	path, err := geminiSettingsPath()
+	if err != nil {
+		return false, err
+	}
+	command, err := hookbeacon.InstalledCommand(AdapterName)
+	if err != nil {
+		return false, err
+	}
+	return hookjson.Uninstall(hookConfig(path, command))
+}
+
+// --- helpers ---
+
+// geminiHome resolves the absolute Gemini CLI config directory: $HOME/.gemini.
+// No env-override to honor (see geminiHomeDirName).
+func geminiHome() (string, error) {
+	return agentpaths.AbsRoot(geminiHomeDirName)
+}
+
+// geminiSettingsPath is the user's own Gemini CLI settings file — the
+// agent.ManagedUserFile.Path this permission declares.
+func geminiSettingsPath() (string, error) {
+	home, err := geminiHome()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, geminiSettingsFilename), nil
+}
+
+// atomicWriteFile writes data to path via a temp file + rename so a reader
+// (or Gemini CLI itself) never observes a half-written settings file.
+// Creates the parent dir. Matches claudecode's and copilot's own installers.
+func atomicWriteFile(path string, data []byte) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(dir, ".irrlicht-hooks-*.json.tmp")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName)
+
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Chmod(0o600); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpName, path)
+}

--- a/core/adapters/inbound/agents/geminicli/hookinstaller_test.go
+++ b/core/adapters/inbound/agents/geminicli/hookinstaller_test.go
@@ -1,0 +1,233 @@
+// hookinstaller_test.go covers the writing half: the install-type permission
+// gate (#797), and the install/verify/uninstall round trip against Gemini
+// CLI's own shared settings.json.
+//
+// The shared-file shape is the point of several tests here that copilot's
+// equivalent file does not need: ~/.gemini/settings.json is Gemini CLI's ONE
+// general settings file (theme, auth, everything), not a file irrlicht owns
+// outright the way copilot's hooks/irrlicht.json is — so uninstall must never
+// delete it, and any key this adapter did not write must survive untouched.
+// That is also the property that makes gemini-cli's documented sync-by-
+// omission settings writer survivable at all: Verify (wired below and in
+// hookversion_test.go's gate) is what lets services.HookEntryVerifier notice
+// and repair an install Gemini CLI's own settings UI silently dropped.
+package geminicli
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"irrlicht/core/adapters/inbound/agents/hookjson"
+	"irrlicht/core/domain/permission"
+	"irrlicht/core/internal/contracttesting"
+	"irrlicht/core/pkg/hookbeacon"
+)
+
+// hooksPermission returns the real declared hooks permission.
+func hooksPermission(t *testing.T) (apply, remove func() error) {
+	t.Helper()
+	for _, p := range Agent().Permissions {
+		if p.Key == PermissionKeyHooks {
+			return p.Apply, p.Remove
+		}
+	}
+	t.Fatal("no hooks permission declared")
+	return nil, nil
+}
+
+// hooksFileHasOurEntries reports whether the settings file currently holds
+// an irrlicht entry for every installed event.
+//
+// Uses hookjson's OWN predicates rather than a hand-rolled walk, so the test
+// agrees with the installer by construction — the same reasoning copilot's
+// equivalent helper documents.
+func hooksFileHasOurEntries(t *testing.T) bool {
+	t.Helper()
+	path, err := geminiSettingsPath()
+	if err != nil {
+		t.Fatalf("geminiSettingsPath: %v", err)
+	}
+	settings, err := hookjson.ReadSettings(path)
+	if err != nil {
+		return false
+	}
+	hooks, ok := settings["hooks"].(map[string]interface{})
+	if !ok {
+		return false
+	}
+	sentinel := hookbeacon.Sentinel(AdapterName)
+	for _, ev := range installedHookEvents {
+		if !hookjson.HasOurHook(hooks, ev, sentinel) {
+			return false
+		}
+	}
+	return true
+}
+
+// TestHooksPermission_IsGated wires the install-type flavour of the #797
+// contract: nothing is written while the permission is pending, granting
+// writes the entries, and denying removes them again.
+func TestHooksPermission_IsGated(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	apply, remove := hooksPermission(t)
+
+	state := permission.StatePending
+	contracttesting.AssertPermissionGated(t, contracttesting.PermissionGate{
+		Key: PermissionKeyHooks,
+		// transcripts is the adapter's only other declared permission and is
+		// observe-kind, so it has no closure to drive: the key-isolation arm
+		// is INERT here and repeats the revoked arm exactly, the same
+		// situation copilot's equivalent test documents. Install-type
+		// wirings hold their own permission's closures, so a wrong key is
+		// not representable — the arm is load-bearing at the live receiver
+		// (hooks_test.go), not here.
+		OtherKeys: []string{PermissionKeyTranscripts},
+		SetState:  contracttesting.OnlyKey(PermissionKeyHooks, func(s permission.State) { state = s }),
+		Exercise: func() {
+			switch state {
+			case permission.StateGranted:
+				if err := apply(); err != nil {
+					t.Fatalf("apply: %v", err)
+				}
+			case permission.StateDenied:
+				if err := remove(); err != nil {
+					t.Fatalf("remove: %v", err)
+				}
+			}
+		},
+		Observe: func() bool { return hooksFileHasOurEntries(t) },
+	})
+}
+
+// TestInstallVerifyUninstall_RoundTrip pins the three-way agreement between
+// what the installer writes, what Verify reports, and what Uninstall
+// removes.
+func TestInstallVerifyUninstall_RoundTrip(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	status, err := VerifyHooksInstalled()
+	if err != nil {
+		t.Fatalf("verify before install: %v", err)
+	}
+	if status.Intact() {
+		t.Error("Verify reports intact before anything was installed")
+	}
+
+	modified, err := EnsureHooksInstalled()
+	if err != nil {
+		t.Fatalf("install: %v", err)
+	}
+	if !modified {
+		t.Error("first install reported no modification")
+	}
+
+	if status, err = VerifyHooksInstalled(); err != nil || !status.Intact() {
+		t.Errorf("Verify after install: intact=%v err=%v damage=%s", status.Intact(), err, status.Damage())
+	}
+
+	// Idempotent: a second install changes nothing.
+	if modified, err = EnsureHooksInstalled(); err != nil || modified {
+		t.Errorf("second install modified=%v err=%v, want false/nil", modified, err)
+	}
+
+	if modified, err = UninstallHooks(); err != nil || !modified {
+		t.Errorf("uninstall modified=%v err=%v, want true/nil", modified, err)
+	}
+	if hooksFileHasOurEntries(t) {
+		t.Error("entries survive uninstall")
+	}
+}
+
+// TestVerifyDoesNotCreateTheConfigFile is the read-only half of #1372.
+func TestVerifyDoesNotCreateTheConfigFile(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	if _, err := VerifyHooksInstalled(); err != nil {
+		t.Fatalf("verify: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(home, ".gemini")); !os.IsNotExist(err) {
+		t.Errorf("Verify created the .gemini directory; it must be read-only")
+	}
+}
+
+// TestUninstallPreservesUnrelatedSettingsKeys is the shared-file property
+// this whole issue turns on: ~/.gemini/settings.json is Gemini CLI's general
+// settings file, so install and uninstall must touch only the "hooks" key.
+// A destructive rewrite here would be irrlicht doing to the user's file
+// exactly what #1355 Phase C found Gemini CLI's OWN writer capable of.
+func TestUninstallPreservesUnrelatedSettingsKeys(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	path, err := geminiSettingsPath()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	seed := `{"security":{"auth":{"selectedType":"oauth-personal"}},"someUnknownTopLevelKey":"keep-me"}`
+	if err := os.WriteFile(path, []byte(seed), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := EnsureHooksInstalled(); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+	if _, err := UninstallHooks(); err != nil {
+		t.Fatalf("uninstall: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("settings file gone after uninstall: %v", err)
+	}
+	var settings map[string]interface{}
+	if err := json.Unmarshal(data, &settings); err != nil {
+		t.Fatalf("settings file is not valid JSON after install+uninstall: %v", err)
+	}
+	sec, ok := settings["security"].(map[string]interface{})
+	if !ok {
+		t.Fatal("security key lost after install+uninstall")
+	}
+	auth, ok := sec["auth"].(map[string]interface{})
+	if !ok || auth["selectedType"] != "oauth-personal" {
+		t.Errorf("security.auth.selectedType = %v, want preserved \"oauth-personal\"", auth["selectedType"])
+	}
+	if settings["someUnknownTopLevelKey"] != "keep-me" {
+		t.Errorf("someUnknownTopLevelKey = %v, want preserved \"keep-me\" — irrlicht must "+
+			"never touch a key it did not write", settings["someUnknownTopLevelKey"])
+	}
+}
+
+// TestUninstallDoesNotDeleteTheSettingsFile pins the shared-file counterpart
+// of copilot's "gives the directory back": unlike copilot's dedicated
+// hooks/irrlicht.json (which IS irrlicht's own file and is removed when
+// empty), ~/.gemini/settings.json is never irrlicht's to delete, even when
+// our entries were the only content it ever held.
+func TestUninstallDoesNotDeleteTheSettingsFile(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	if _, err := EnsureHooksInstalled(); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+	path, err := geminiSettingsPath()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("install did not create %s: %v", path, err)
+	}
+
+	if _, err := UninstallHooks(); err != nil {
+		t.Fatalf("uninstall: %v", err)
+	}
+
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("uninstall removed %s; this file is the user's general Gemini CLI settings, "+
+			"never irrlicht's to delete: %v", path, err)
+	}
+}

--- a/core/adapters/inbound/agents/geminicli/hookpath_test.go
+++ b/core/adapters/inbound/agents/geminicli/hookpath_test.go
@@ -1,0 +1,43 @@
+// hookpath_test.go wires this adapter's hook receiver into the shared issue
+// #1361 contract: a caller-supplied transcript path is confined to the
+// adapter's declared roots, symlinks resolved first, and anything outside is
+// refused, logged, counted — and still answered 2xx.
+package geminicli
+
+import (
+	"testing"
+
+	"irrlicht/core/internal/contracttesting"
+)
+
+func TestHookPathConfined(t *testing.T) {
+	contracttesting.AssertHookPathConfined(t, contracttesting.HookReceiver{
+		Root: geminiSessionRoot,
+		New: func(t *testing.T) contracttesting.HookReceiverUnderTest {
+			t.Helper()
+			target := &mockTarget{}
+			return contracttesting.HookReceiverUnderTest{
+				Handler:  NewHookHandler(target, nil, mockLogger{}),
+				Observed: func() bool { return target.totalCalls() > 0 },
+				ObservedPath: func() string {
+					if stops := target.stops(); len(stops) > 0 {
+						return stops[len(stops)-1].transcriptPath
+					}
+					if perms := target.perms(); len(perms) > 0 {
+						return perms[len(perms)-1].transcriptPath
+					}
+					if prompts := target.prompts(); len(prompts) > 0 {
+						return prompts[len(prompts)-1].transcriptPath
+					}
+					return ""
+				},
+			}
+		},
+		WriteTranscript: writeContractTranscript,
+		TranscriptExt:   transcriptExt,
+		PayloadFor: func(transcriptPath string) string {
+			return contractPayload(transcriptPath, HookAfterTool)
+		},
+		EndpointPath: HookEndpointPath,
+	})
+}

--- a/core/adapters/inbound/agents/geminicli/hookport_test.go
+++ b/core/adapters/inbound/agents/geminicli/hookport_test.go
@@ -82,7 +82,7 @@ func TestHookEndpointFollowsBindAddr(t *testing.T) {
 			if err != nil {
 				return false, err
 			}
-			return hookjsonEnsureInstalledForCommand(path, command)
+			return hookjson.EnsureInstalled(hookConfig(path, command))
 		},
 	})
 }

--- a/core/adapters/inbound/agents/geminicli/hookport_test.go
+++ b/core/adapters/inbound/agents/geminicli/hookport_test.go
@@ -1,0 +1,88 @@
+// hookport_test.go wires the Gemini CLI hook installer into the shared issue
+// #1178 contract, under its DeliveryAddressFree route (#1453): the installed
+// entry carries no address at all, because it names the
+// `irrlichd hook-post gemini-cli` beacon, which resolves the daemon's address
+// itself at fire time. This adapter is the first production adopter of the
+// route hook_endpoint_addressfree_test.go's reference wiring exists to
+// exercise — see this file for what "adopts it" concretely means.
+package geminicli
+
+import (
+	"testing"
+
+	"irrlicht/core/adapters/inbound/agents/hookjson"
+	"irrlicht/core/internal/contracttesting"
+	"irrlicht/core/pkg/hookbeacon"
+)
+
+// TestHookEntry_IsABeaconCommand pins the exact object Gemini CLI reads,
+// which the shared contract deliberately does not look at — it only cares
+// that the delivery inside carries no address. The type is "command", never
+// "http" (Gemini CLI has no such hook type — see hookinstaller.go's package
+// doc) and never a bare curl line (which would fail closed on tool calls
+// whenever the daemon is down).
+func TestHookEntry_IsABeaconCommand(t *testing.T) {
+	command, err := hookbeacon.InstalledCommand(AdapterName)
+	if err != nil {
+		t.Fatalf("resolving the beacon command: %v", err)
+	}
+	entry := beaconEntry(command)
+	if got, want := entry["type"], "command"; got != want {
+		t.Errorf("type = %v, want %v", got, want)
+	}
+	got, _ := entry["command"].(string)
+	if got != command {
+		t.Errorf("command = %q, want %q", got, command)
+	}
+	if _, ok := entry["url"]; ok {
+		t.Error("entry carries a url key; beacon delivery names no address")
+	}
+}
+
+func TestHookEndpointFollowsBindAddr(t *testing.T) {
+	// Checked up front so a resolution failure reads as itself rather than
+	// as the empty-delivery wiring error assertDeliveryIsOurs would report.
+	if _, err := hookbeacon.InstalledCommand(AdapterName); err != nil {
+		t.Fatalf("resolving the beacon command: %v", err)
+	}
+
+	contracttesting.AssertHookEndpointFollowsBindAddr(t, contracttesting.HookInstaller{
+		Delivery: contracttesting.DeliveryAddressFree,
+		SettingsPath: func(t *testing.T) string {
+			home := t.TempDir()
+			t.Setenv("HOME", home)
+			path, err := geminiSettingsPath()
+			if err != nil {
+				t.Fatalf("resolving the gemini settings path: %v", err)
+			}
+			return path
+		},
+		Sentinel: hookbeacon.Sentinel(AdapterName),
+		Events:   installedHookEvents,
+		Entry:    ourHookEntry,
+		// Beacon delivery is a `type: command` entry; the delivery string is
+		// the whole command, since there is no url field and nothing
+		// address-shaped inside it.
+		EndpointOf: func(hook map[string]interface{}) string {
+			c, _ := hook["command"].(string)
+			return c
+		},
+		EnsureInstalled: EnsureHooksInstalled,
+		Uninstall:       UninstallHooks,
+		// ForeignInstall seeds an entry naming a DIFFERENT (nonexistent)
+		// irrlicht binary — the address-free counterpart of seeding a
+		// stale-port install — so the contract can assert EnsureInstalled
+		// rewrites it in place rather than duplicating it.
+		ForeignInstall: func() (bool, error) {
+			path, err := geminiSettingsPath()
+			if err != nil {
+				return false, err
+			}
+			command, err := hookbeacon.Command("/nonexistent-irrlicht-1717/bin/irrlichd", AdapterName)
+			if err != nil {
+				return false, err
+			}
+			return hookjsonEnsureInstalledForCommand(path, command)
+		},
+	})
+}

--- a/core/adapters/inbound/agents/geminicli/hookreceipt_test.go
+++ b/core/adapters/inbound/agents/geminicli/hookreceipt_test.go
@@ -1,0 +1,35 @@
+// hookreceipt_test.go wires this adapter's hook receiver into the shared
+// issue #1368 contract: a consent-passed request counts as a receipt
+// whatever the receiver then does with it, and a consent-denied one does
+// not.
+package geminicli
+
+import (
+	"net/http"
+	"testing"
+
+	"irrlicht/core/internal/contracttesting"
+	"irrlicht/core/ports/outbound"
+)
+
+func TestHookReceiptObserved(t *testing.T) {
+	contracttesting.AssertHookReceiptObserved(t, contracttesting.HookReceiptReceiver{
+		Adapter:         AdapterName,
+		Root:            geminiSessionRoot,
+		WriteTranscript: writeContractTranscript,
+		New: func(t *testing.T, log outbound.Logger) http.Handler {
+			t.Helper()
+			return NewHookHandler(&mockTarget{},
+				keyedGate{PermissionKeyHooks: true, PermissionKeyTranscripts: true}, log)
+		},
+		NewDenied: func(t *testing.T, log outbound.Logger) http.Handler {
+			t.Helper()
+			return NewHookHandler(&mockTarget{}, keyedGate{}, log)
+		},
+		PayloadFor: func(transcriptPath, event string) string {
+			return contractPayload(transcriptPath, event)
+		},
+		KnownEvent:   HookAfterTool,
+		EndpointPath: HookEndpointPath,
+	})
+}

--- a/core/adapters/inbound/agents/geminicli/hooks.go
+++ b/core/adapters/inbound/agents/geminicli/hooks.go
@@ -1,0 +1,342 @@
+// hooks.go provides the HTTP handler for receiving Gemini CLI hook events
+// (issue #1717, epic #1355 Phase D).
+//
+// Three events are installed, out of the eleven Gemini CLI's hook system
+// fires (BeforeTool, AfterTool, BeforeAgent, Notification, AfterAgent,
+// SessionStart, SessionEnd, PreCompress, BeforeModel, AfterModel,
+// BeforeToolSelection — source-read from the installed CLI's own bundle, not
+// from rendered docs). Each installed event is treated differently, and the
+// asymmetry is the substance of this file:
+//
+//   - AfterAgent fires once at true turn end, gated by the CLI itself on
+//     "every pending tool call in this turn has resolved" — so it holds
+//     SignalTurnDone through HandleStopHook exactly like Claude Code's Stop,
+//     giving an authoritative ready at turn end instead of one inferred from
+//     the (nonexistent, for this adapter) turn_done transcript marker. It ALSO
+//     unconditionally releases any held permission-prompt signal — see the
+//     ReleasePermissionPromptHold call below and its own doc comment for why.
+//
+//   - AfterTool fires after EVERY tool call — source-confirmed: its payload
+//     carries no discriminator distinguishing "ran silently" from "was
+//     confirmed first". It is installed anyway, but ONLY as a broad release:
+//     dispatched through the generic HandlePermissionHook under the
+//     "AfterTool" name, which session.HookSignal maps to a Release, mirroring
+//     exactly how claudecode's own broad PostToolUse releases the same
+//     signal. Releasing broadly is safe (a Release on an unheld signal is a
+//     no-op); it is only ASSERTING broadly that would be wrong, which is why
+//     BeforeTool — Gemini's equally-broad pre-tool event — is not installed
+//     at all. See hookinstaller.go's installedHookEvents comment.
+//
+//   - Notification, gated on notification_type == "ToolPermission" (today the
+//     ONLY member of Gemini's NotificationType enum), is the narrow assert.
+//     Source-traced: Gemini's scheduler fires this exactly when a tool
+//     genuinely requires user confirmation — shouldConfirmExecute returned
+//     non-nil — and fires it BEFORE blocking on the user's answer, regardless
+//     of the eventual outcome. That is a real, content-based discriminator
+//     BeforeTool cannot offer.
+//
+// Why the permission prompt gets its own dedicated method
+// (HandlePermissionPromptHook) rather than going through the same generic
+// dispatch AfterTool uses, the way claudecode's PreToolUse does:
+//
+// Gemini's wire name for this event is literally "Notification" — the same
+// string Claude Code uses for ITS OWN Notification hook, and the same one
+// copilot's Notification/permission_prompt dispatches through. session.
+// HookSignal is one flat map keyed by that literal string with no adapter
+// dimension: giving "Notification" a row there to make gemini's dispatch hold
+// SignalPermissionPrompt would silently change what claudecode's and (more
+// dangerously) copilot's OWN "Notification" dispatches do. Copilot's package
+// comment explains why that would be a real regression for a live adapter:
+// copilot emits nothing at all when the user denies a prompt, so a hold with
+// no release would pin a denied session waiting for
+// permissionPromptHoldTimeout (12h). Gemini is not in that position — its
+// AfterAgent reliably fires after a cancelled confirmation too, and this
+// adapter's ReleasePermissionPromptHold call closes exactly that gap — but the
+// shared table has no way to express "holds for gemini, dispatch-only for
+// copilot" against the same literal string, so the assert has to live outside
+// it. HandlePermissionPromptHook is that outside-the-table path — the same
+// shape session.SessionDetector already uses for HandleIdlePromptHook and
+// HandleCompactHook, both of which also need a gate the generic table cannot
+// express.
+package geminicli
+
+import (
+	"net/http"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"irrlicht/core/adapters/inbound/agents/hookjson"
+	"irrlicht/core/domain/agent"
+	"irrlicht/core/domain/session"
+	"irrlicht/core/pkg/tailer"
+	"irrlicht/core/ports/outbound"
+)
+
+// PermissionKeyHooks gates installing and receiving Gemini CLI hooks (issue
+// #570).
+//
+// Aliased to the shared domain constant rather than restated: since #1383 two
+// projections narrow on it — agents.HookConfigs (what --uninstall-hooks
+// revokes) and the managed-user-file catalog — so a literal that drifted
+// would silently drop this install out of both.
+const PermissionKeyHooks = agent.HooksPermissionKey
+
+// Hook event names, as they appear in the delivered envelope's
+// hook_event_name field. Source-read from the installed CLI's bundle
+// (HookEventName enum), not from rendered docs.
+//
+// HookAfterTool re-exports the domain constant added for this adapter
+// (session.HookAfterTool); HookAfterAgent and HookNotification are local —
+// AfterAgent has no cross-adapter meaning to share (it is dispatched to
+// HandleStopHook directly, never through the name-keyed table), and
+// "Notification" already has a domain constant (session.HookNotification)
+// but this adapter deliberately does NOT reuse it as a dispatch key — see the
+// package comment.
+const (
+	HookAfterTool    = session.HookAfterTool
+	HookAfterAgent   = "AfterAgent"
+	HookNotification = "Notification"
+)
+
+// notificationToolPermission is the one NotificationType value Gemini CLI's
+// hook system defines today (source-read: the enum has exactly this member).
+// Any OTHER value is future-proofing on Gemini's part, not ours — treated as
+// a known-but-inert notification, never as an unrecognized event.
+const notificationToolPermission = "ToolPermission"
+
+// logComponentHookReceiver is the Logger component tag for every log line
+// emitted by the hook HTTP handler below.
+const logComponentHookReceiver = "geminicli-hook-receiver"
+
+// transcriptExt is the file extension the hook receiver confines
+// caller-supplied paths to. Gemini CLI's transcript files end .jsonl, the
+// same as claudecode's and copilot's.
+const transcriptExt = ".jsonl"
+
+// geminiHookPayload is the JSON body Gemini CLI POSTs on a hook event.
+//
+// Unlike copilot, every event carries transcript_path directly — Gemini's own
+// createBaseInput builds {session_id, transcript_path, cwd, hook_event_name,
+// timestamp} for every fire site, so there is no Notification-must-
+// reconstruct-the-path case here. SessionID is deliberately NOT read for
+// session identity (see sessionIDFromPath below) — it is a full UUID
+// (`config.getSessionId()`) that does not match the filename-stem session ID
+// the fswatcher and every other adapter surface uses; it is decoded only so
+// it can be logged.
+type geminiHookPayload struct {
+	HookEventName string `json:"hook_event_name"`
+
+	// TranscriptPath is confined and then overwritten with the confined
+	// spelling by DecodeConfined — see NewHookHandler.
+	TranscriptPath string `json:"transcript_path"`
+
+	// SessionID is Gemini's own session UUID, logged only. Never used to
+	// derive the id this adapter dispatches under.
+	SessionID string `json:"session_id"`
+
+	// NotificationType distinguishes a blocked-on-user notification
+	// (ToolPermission) from any other kind Gemini may add. Empty on every
+	// other event.
+	NotificationType string `json:"notification_type"`
+
+	// PromptResponse is AfterAgent's final assistant text for the turn. Empty
+	// on every other event.
+	PromptResponse string `json:"prompt_response"`
+}
+
+// HookTarget is the interface the handler calls into. Satisfied by
+// *services.SessionDetector without importing the services package — the
+// same agent-agnostic surface claudecode's, codex's and copilot's hooks use,
+// extended by the two methods this adapter's design needs (see the package
+// comment).
+type HookTarget interface {
+	HandlePermissionHook(sessionID, transcriptPath, hookEventName string)
+	HandleStopHook(sessionID, transcriptPath, lastAssistantText string, waitingCue bool)
+	HandlePermissionPromptHook(sessionID, transcriptPath, hookName string)
+	ReleasePermissionPromptHold(sessionID string)
+}
+
+// ConsentGranter is the shared consent check every JSON-hook receiver gates on
+// (issue #570) — an alias, not a copy, so the receivers cannot drift.
+type ConsentGranter = hookjson.ConsentGranter
+
+// NewHookHandler returns an http.HandlerFunc that receives Gemini CLI hook
+// events and dispatches them to the target. The returned hookjson.HookHandler
+// is an http.Handler carrying the confiner it guards caller-supplied
+// transcript paths with (issue #1390).
+//
+// gate is the consent check; while the "hooks" permission is not granted the
+// payload is dropped with 200, so the installed hook stays quiet. A nil gate
+// means no gating — used by tests.
+func NewHookHandler(target HookTarget, gate ConsentGranter, log outbound.Logger) hookjson.HookHandler {
+	return hookjson.NewHandler(transcriptConfiner(),
+		hookjson.RequireConsent(gate, AdapterName, PermissionKeyHooks, PermissionKeyTranscripts),
+		func(consent hookjson.Consent, c *hookjson.PathConfiner, w http.ResponseWriter, r *http.Request) {
+			serveHookRequest(target, consent, log, c, w, r)
+		})
+}
+
+// transcriptConfiner returns the confiner this adapter's hook receiver guards
+// caller-supplied transcript paths with, rooted in the adapter's own
+// agent.Source declaration (issue #1361) rather than re-derived from the
+// adapter's constants — so the tree the receiver confines to cannot drift
+// from the one the daemon watches.
+func transcriptConfiner() *hookjson.PathConfiner {
+	return hookjson.ConfinerForSource(Source, runtime.GOOS, transcriptExt)
+}
+
+// serveHookRequest is NewHookHandler's request logic, pulled out of the
+// returned closure so its branching isn't counted at the closure's extra
+// nesting depth. The step order matches claudecode's, codex's and copilot's
+// receivers exactly, and each step is load-bearing — see the contract
+// assertions in hook*_test.go.
+func serveHookRequest(target HookTarget, consent hookjson.Consent, log outbound.Logger, confiner *hookjson.PathConfiner, w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	// Both keys come off the receiver's OWN hookjson.Consent (issue #1488), so
+	// the set this sequence is written for is the set the handler publishes
+	// and the contract derives. A key this receiver did not declare answers
+	// false, so a drift between the two fails closed.
+	if !consent.Granted(PermissionKeyHooks) {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
+	// The channel delivered (issue #1368). Counted against the "hooks"
+	// consent only — the transcripts gate below authorizes READING the
+	// transcript, not observing that a POST arrived, and a hooks-granted /
+	// transcripts-denied install has a working channel this counter must not
+	// call dead.
+	hookjson.ObserveHookReceipt(AdapterName)
+
+	// Dispatching makes the detector read the transcript, so it is gated
+	// behind the "transcripts" consent, not merely the "hooks" write consent.
+	// The check comes BEFORE the decode, and so before confinement, so a
+	// denied session still yields a quiet 200 and the path is never resolved
+	// on that branch.
+	if !consent.Granted(PermissionKeyTranscripts) {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
+	// The path arrives in an HTTP body on a local, unauthenticated endpoint,
+	// so it is untrusted even though it came from our own beacon's payload
+	// pass-through: the beacon forwards whatever Gemini CLI wrote to stdin
+	// verbatim (core/pkg/hookbeacon's send doc), so a caller-supplied path is
+	// exactly what this decodes. DecodeConfined reads the body and confines
+	// in one step (issues #1361, #1389).
+	var payload geminiHookPayload
+	if !hookjson.DecodeConfined(w, r, log, logComponentHookReceiver, consent, confiner, &payload,
+		func(p *geminiHookPayload) string { return p.TranscriptPath },
+		func(p *geminiHookPayload, confined string) { p.TranscriptPath = confined },
+	) {
+		return
+	}
+	transcriptPath := payload.TranscriptPath
+
+	sessionID := sessionIDFromTranscriptPath(transcriptPath)
+	if sessionID == "" {
+		// Not a path this adapter owns — drop rather than guess an id. The
+		// transcript tailer covers the state regardless.
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
+	dispatchHookEvent(target, log, sessionID, transcriptPath, payload)
+	w.WriteHeader(http.StatusOK)
+}
+
+// sessionIDFromTranscriptPath derives the session ID the SAME way
+// agent.FilesUnderRoot's default does when no SessionIDFromPath override is
+// declared (this adapter declares none — see agent.go) — the filename stem.
+//
+// Deliberately NOT payload.SessionID: that field carries Gemini's own
+// config.getSessionId() UUID, which does not equal the filename-stem id every
+// other part of this adapter (and the fswatcher itself) keys sessions on.
+// Measured live: a session whose transcript is
+// chats/session-2026-08-20T16-44-16031e41.jsonl reported
+// session_id "16031e41-8a6d-4a8c-9479-ef742ed12f9c" in this same hook's
+// payload — a different, longer string. Dispatching under the payload's
+// spelling would silently mint a second, hook-only "session" the rest of the
+// daemon never recognizes.
+func sessionIDFromTranscriptPath(path string) string {
+	base := filepath.Base(path)
+	if !strings.HasSuffix(base, transcriptExt) {
+		return ""
+	}
+	id := strings.TrimSuffix(base, transcriptExt)
+	if id == "" {
+		return ""
+	}
+	return id
+}
+
+// dispatchHookEvent routes a decoded, consent-passed, confined, session-
+// resolved payload to the right target method.
+func dispatchHookEvent(target HookTarget, log outbound.Logger, sessionID, transcriptPath string, payload geminiHookPayload) {
+	switch payload.HookEventName {
+	case HookAfterTool:
+		// Broad release. See the package comment on why broad is safe here
+		// (a Release on an unheld signal is a no-op) where it would not be
+		// for an assert.
+		log.LogInfo(logComponentHookReceiver, sessionID, "received AfterTool")
+		target.HandlePermissionHook(sessionID, transcriptPath, HookAfterTool)
+	case HookAfterAgent:
+		handleAfterAgentHook(target, log, sessionID, transcriptPath, payload)
+	case HookNotification:
+		handleNotificationHook(target, log, sessionID, transcriptPath, payload)
+	default:
+		// Unrecognized hook event — accept but ignore, counted per name and
+		// reported once, in the one place that behaviour is decided for
+		// every receiver (issue #1364). serveHookRequest's 200 is
+		// unaffected.
+		hookjson.IgnoreUnknownEvent(log, logComponentHookReceiver, AdapterName, sessionID, payload.HookEventName)
+	}
+}
+
+// handleAfterAgentHook processes Gemini CLI's AfterAgent hook — the
+// authoritative turn-done push, fired once at true turn end (issue #1717).
+//
+// The forwarded text is display-truncated the same way claudecode's and
+// codex's Stop handling truncates theirs; the waiting-cue verdict is computed
+// from a bounded tail window (WaitingScanWindow) of the FULL message — the
+// same window parser.go would use for PendingWaitingCue — so a question or
+// cue sitting before the display tail still routes the turn to waiting.
+//
+// ReleasePermissionPromptHold is called unconditionally alongside
+// HandleStopHook — see that method's own doc comment (session_detector_
+// lifecycle.go) for the source-verified reasoning: AfterTool's broad release
+// never fires when a confirmation was CANCELLED (Gemini's scheduler returns
+// before reaching tool execution), but AfterAgent still fires for that turn,
+// making it the correct backstop rather than a silent reliance on the
+// permission-prompt hold's 12-hour ceiling.
+func handleAfterAgentHook(target HookTarget, log outbound.Logger, sessionID, transcriptPath string, payload geminiHookPayload) {
+	log.LogInfo(logComponentHookReceiver, sessionID,
+		"received AfterAgent")
+
+	target.HandleStopHook(sessionID, transcriptPath,
+		tailer.TruncateAssistantText(payload.PromptResponse),
+		session.ProseIndicatesWaiting(tailer.WaitingScanWindow(payload.PromptResponse)))
+	target.ReleasePermissionPromptHold(sessionID)
+}
+
+// handleNotificationHook processes a Gemini CLI Notification. Only
+// notification_type == "ToolPermission" opens a hold — see the package
+// comment for why this is a real, narrow discriminator and why it dispatches
+// through a dedicated method rather than the generic name-keyed one.
+//
+// Any other notification type is ignored outright — it is a known event, not
+// an unknown one, so it must not be counted as unrecognized.
+func handleNotificationHook(target HookTarget, log outbound.Logger, sessionID, transcriptPath string, payload geminiHookPayload) {
+	if payload.NotificationType != notificationToolPermission {
+		return
+	}
+
+	log.LogInfo(logComponentHookReceiver, sessionID,
+		"received Notification (ToolPermission)")
+	target.HandlePermissionPromptHook(sessionID, transcriptPath, HookNotification)
+}

--- a/core/adapters/inbound/agents/geminicli/hooks_test.go
+++ b/core/adapters/inbound/agents/geminicli/hooks_test.go
@@ -1,0 +1,498 @@
+package geminicli
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"irrlicht/core/domain/session"
+	"irrlicht/core/internal/contracttesting"
+)
+
+// --- test doubles, shared by this file and the contract wirings ---
+
+type permCall struct {
+	sessionID, transcriptPath, hookEventName string
+}
+
+type stopCall struct {
+	sessionID, transcriptPath, lastAssistantText string
+	waitingCue                                   bool
+}
+
+type permPromptCall struct {
+	sessionID, transcriptPath, hookName string
+}
+
+type mockTarget struct {
+	mu          sync.Mutex
+	permCalls   []permCall
+	stopCalls   []stopCall
+	promptCalls []permPromptCall
+	// releaseCalls holds one sessionID per ReleasePermissionPromptHold call.
+	releaseCalls []string
+}
+
+func (m *mockTarget) HandlePermissionHook(sessionID, transcriptPath, hookEventName string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.permCalls = append(m.permCalls, permCall{sessionID, transcriptPath, hookEventName})
+}
+
+func (m *mockTarget) HandleStopHook(sessionID, transcriptPath, lastAssistantText string, waitingCue bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.stopCalls = append(m.stopCalls, stopCall{sessionID, transcriptPath, lastAssistantText, waitingCue})
+}
+
+func (m *mockTarget) HandlePermissionPromptHook(sessionID, transcriptPath, hookName string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.promptCalls = append(m.promptCalls, permPromptCall{sessionID, transcriptPath, hookName})
+}
+
+func (m *mockTarget) ReleasePermissionPromptHold(sessionID string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.releaseCalls = append(m.releaseCalls, sessionID)
+}
+
+func (m *mockTarget) totalCalls() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return len(m.permCalls) + len(m.stopCalls) + len(m.promptCalls) + len(m.releaseCalls)
+}
+
+func (m *mockTarget) perms() []permCall {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]permCall(nil), m.permCalls...)
+}
+
+func (m *mockTarget) stops() []stopCall {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]stopCall(nil), m.stopCalls...)
+}
+
+func (m *mockTarget) prompts() []permPromptCall {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]permPromptCall(nil), m.promptCalls...)
+}
+
+func (m *mockTarget) releases() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]string(nil), m.releaseCalls...)
+}
+
+// keyedGate pins a fixed permission combination for a one-off test. For a
+// MUTABLE keyed gate driven through states by the shared contract, use
+// contracttesting.ConsentGate instead.
+type keyedGate map[string]bool
+
+func (g keyedGate) Granted(_, key string) bool { return g[key] }
+
+type mockLogger struct{}
+
+func (mockLogger) LogInfo(string, string, string)                       {}
+func (mockLogger) LogError(string, string, string)                      {}
+func (mockLogger) LogProcessingTime(string, string, int64, int, string) {}
+func (mockLogger) Close() error                                         { return nil }
+
+// --- helpers ---
+
+// geminiSessionRoot relocates $HOME to a temp dir and returns the declared
+// transcript root inside it. Gemini CLI has no adapter-specific home-override
+// environment variable (see hookinstaller.go's geminiHomeDirName comment), so
+// unlike copilot's COPILOT_HOME-relocating helper, this one moves $HOME
+// itself — the same mechanism agentpaths.AbsRoot resolves through
+// (os.UserHomeDir, which reads $HOME on this platform).
+func geminiSessionRoot(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	root := filepath.Join(home, ".gemini", "tmp")
+	if err := os.MkdirAll(root, 0o700); err != nil {
+		t.Fatalf("create sessions dir: %v", err)
+	}
+	return root
+}
+
+// writeSessionTranscript lays down <root>/<project>/chats/<id>.jsonl and
+// returns its path — the shape sessionIDFromTranscriptPath expects (filename
+// stem, per agent.FilesUnderRoot's default derivation).
+func writeSessionTranscript(t *testing.T, root, id string) string {
+	t.Helper()
+	dir := filepath.Join(root, "project", "chats")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatalf("mkdir chats: %v", err)
+	}
+	path := filepath.Join(dir, id+".jsonl")
+	if err := os.WriteFile(path, []byte(`{"type":"header"}`+"\n"), 0o600); err != nil {
+		t.Fatalf("write transcript: %v", err)
+	}
+	return path
+}
+
+// writeContractTranscript is the shape the receiving-side contracts want: a
+// transcript inside dir whose session id the receiver can resolve.
+func writeContractTranscript(t *testing.T, dir string) string {
+	t.Helper()
+	return writeSessionTranscript(t, dir, "sess-contract")
+}
+
+// contractPayload renders an AfterAgent-shaped body (every gemini event
+// carries transcript_path directly, unlike copilot's Notification) for one
+// event name.
+func contractPayload(transcriptPath, event string) string {
+	body, err := json.Marshal(geminiHookPayload{
+		TranscriptPath: transcriptPath,
+		HookEventName:  event,
+		SessionID:      "fake-uuid-not-used-for-identity",
+	})
+	if err != nil {
+		panic(err)
+	}
+	return string(body)
+}
+
+// notificationBody renders a Notification envelope for one notification_type.
+func notificationBody(transcriptPath, notificationType string) string {
+	body, err := json.Marshal(geminiHookPayload{
+		TranscriptPath:   transcriptPath,
+		HookEventName:    HookNotification,
+		SessionID:        "fake-uuid-not-used-for-identity",
+		NotificationType: notificationType,
+	})
+	if err != nil {
+		panic(err)
+	}
+	return string(body)
+}
+
+// afterAgentBody renders an AfterAgent envelope carrying a prompt_response.
+func afterAgentBody(transcriptPath, promptResponse string) string {
+	body, err := json.Marshal(geminiHookPayload{
+		TranscriptPath: transcriptPath,
+		HookEventName:  HookAfterAgent,
+		SessionID:      "fake-uuid-not-used-for-identity",
+		PromptResponse: promptResponse,
+	})
+	if err != nil {
+		panic(err)
+	}
+	return string(body)
+}
+
+// post drives the handler with a raw JSON body and returns the response.
+func post(t *testing.T, h http.Handler, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, HookEndpointPath, strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	return rec
+}
+
+// newReceiver builds a fully-granted receiver over the real production
+// confiner, plus the target it dispatches into.
+func newReceiver(t *testing.T) (http.Handler, *mockTarget) {
+	t.Helper()
+	target := &mockTarget{}
+	gate := keyedGate{PermissionKeyHooks: true, PermissionKeyTranscripts: true}
+	return NewHookHandler(target, gate, mockLogger{}), target
+}
+
+// --- behaviour ---
+
+// TestAfterToolHook_DispatchesBroadRelease pins that AfterTool goes through
+// the generic name-keyed path, and that the name it forwards ("AfterTool")
+// is one session.HookSignal resolves to a broad release — the row
+// hook_signal.go declares for it.
+func TestAfterToolHook_DispatchesBroadRelease(t *testing.T) {
+	root := geminiSessionRoot(t)
+	tp := writeSessionTranscript(t, root, "sess-aftertool")
+	h, target := newReceiver(t)
+
+	rec := post(t, h, contractPayload(tp, HookAfterTool))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	perms := target.perms()
+	if len(perms) != 1 {
+		t.Fatalf("got %d AfterTool dispatches, want 1", len(perms))
+	}
+	if perms[0].sessionID != "sess-aftertool" {
+		t.Errorf("sessionID = %q, want %q", perms[0].sessionID, "sess-aftertool")
+	}
+	if perms[0].hookEventName != HookAfterTool {
+		t.Errorf("forwarded hook name = %q, want %q", perms[0].hookEventName, HookAfterTool)
+	}
+	effect, ok := session.HookSignal(perms[0].hookEventName)
+	if !ok {
+		t.Fatalf("session.HookSignal(%q) has no row — AfterTool's broad release depends on one",
+			perms[0].hookEventName)
+	}
+	if effect.Signal != session.SignalPermissionPrompt || !effect.Release {
+		t.Errorf("HookSignal(%q) = %+v, want a Release of SignalPermissionPrompt",
+			perms[0].hookEventName, effect)
+	}
+}
+
+// TestAfterAgentHook_DispatchesTurnDoneAndReleasesPermissionPrompt pins the
+// turn-end half of the channel AND the Step-A backstop in one place: an
+// AfterAgent POST must call BOTH HandleStopHook (the authoritative turn-done
+// push) and ReleasePermissionPromptHold (see that method's doc comment for
+// why — a cancelled tool confirmation never fires AfterTool, so this is the
+// only reliable release for that case).
+func TestAfterAgentHook_DispatchesTurnDoneAndReleasesPermissionPrompt(t *testing.T) {
+	root := geminiSessionRoot(t)
+	tp := writeSessionTranscript(t, root, "sess-afteragent")
+	h, target := newReceiver(t)
+
+	rec := post(t, h, afterAgentBody(tp, "All done. Want me to continue?"))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	stops := target.stops()
+	if len(stops) != 1 {
+		t.Fatalf("got %d Stop dispatches, want 1", len(stops))
+	}
+	if stops[0].sessionID != "sess-afteragent" {
+		t.Errorf("sessionID = %q, want %q", stops[0].sessionID, "sess-afteragent")
+	}
+	if stops[0].transcriptPath != tp {
+		t.Errorf("transcriptPath = %q, want the confined path %q", stops[0].transcriptPath, tp)
+	}
+	if !strings.Contains(stops[0].lastAssistantText, "All done") {
+		t.Errorf("lastAssistantText = %q, want it to carry the prompt_response text", stops[0].lastAssistantText)
+	}
+	if !stops[0].waitingCue {
+		t.Errorf("waitingCue = false for a final message ending in a question; want true")
+	}
+
+	releases := target.releases()
+	if len(releases) != 1 {
+		t.Fatalf("got %d ReleasePermissionPromptHold calls, want 1 — AfterAgent must release "+
+			"unconditionally, because a cancelled confirmation never fires AfterTool", len(releases))
+	}
+	if releases[0] != "sess-afteragent" {
+		t.Errorf("release sessionID = %q, want %q", releases[0], "sess-afteragent")
+	}
+}
+
+// TestNotification_ToolPermissionOpensAHold pins that a genuine
+// ToolPermission notification dispatches through the dedicated
+// HandlePermissionPromptHook.
+func TestNotification_ToolPermissionOpensAHold(t *testing.T) {
+	root := geminiSessionRoot(t)
+	tp := writeSessionTranscript(t, root, "sess-notif")
+	h, target := newReceiver(t)
+
+	rec := post(t, h, notificationBody(tp, notificationToolPermission))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	prompts := target.prompts()
+	if len(prompts) != 1 {
+		t.Fatalf("got %d permission-prompt dispatches, want 1 (perm=%d, stop=%d)",
+			len(prompts), len(target.perms()), len(target.stops()))
+	}
+	if prompts[0].sessionID != "sess-notif" {
+		t.Errorf("sessionID = %q, want %q", prompts[0].sessionID, "sess-notif")
+	}
+	if prompts[0].transcriptPath != tp {
+		t.Errorf("transcriptPath = %q, want %q", prompts[0].transcriptPath, tp)
+	}
+}
+
+// TestNotification_DispatchesThroughDedicatedMethodNotTheGenericTable is the
+// guard on this adapter's central design decision — see hooks.go's package
+// comment and HandlePermissionPromptHook's own doc comment
+// (session_detector_lifecycle.go).
+//
+// READ THIS IF YOU ARE EDITING core/domain/session/hook_signal.go, NOT THIS
+// FILE. If a future change adds a "Notification" row to hookSignalEffects
+// (its own doc comment invites exactly that: "a row here is the right fix,
+// not a bespoke branch"), the SECOND assertion below goes red — and that is
+// correct, because such a row would ALSO change what copilot's identically-
+// named Notification dispatch does: copilot's package comment explains that
+// copilot must NOT take a hold there, because it has nothing that reliably
+// fires on a denied prompt to release it. If this test breaks from that
+// side, the fix is giving copilot an explicit no-hold dispatch, not deleting
+// this assertion.
+func TestNotification_DispatchesThroughDedicatedMethodNotTheGenericTable(t *testing.T) {
+	root := geminiSessionRoot(t)
+	tp := writeSessionTranscript(t, root, "sess-notif")
+	h, target := newReceiver(t)
+
+	post(t, h, notificationBody(tp, notificationToolPermission))
+
+	prompts := target.prompts()
+	if len(prompts) != 1 {
+		t.Fatalf("got %d dispatches through HandlePermissionPromptHook, want 1", len(prompts))
+	}
+	if prompts[0].hookName != HookNotification {
+		t.Errorf("forwarded hook name = %q, want %q", prompts[0].hookName, HookNotification)
+	}
+	if _, holds := session.HookSignal(prompts[0].hookName); holds {
+		t.Errorf("hook name %q now has a session.HookSignal row; gemini-cli's Notification "+
+			"assert must keep going through HandlePermissionPromptHook, a table row would "+
+			"also change claudecode's and copilot's own identically-named dispatch",
+			prompts[0].hookName)
+	}
+	// No call should have gone through the generic table-driven path for this
+	// event — that would be the mutation this test exists to catch.
+	if n := len(target.perms()); n != 0 {
+		t.Errorf("Notification also dispatched %d time(s) through the generic "+
+			"HandlePermissionHook path, want 0", n)
+	}
+}
+
+// TestNotification_NonToolPermissionTypesAreIgnored pins that any other
+// notification_type does nothing. It is a KNOWN event, so it must also not be
+// counted as unrecognized.
+func TestNotification_NonToolPermissionTypesAreIgnored(t *testing.T) {
+	root := geminiSessionRoot(t)
+	tp := writeSessionTranscript(t, root, "sess-notif")
+
+	for _, nt := range []string{"", "SomeFutureType"} {
+		h, target := newReceiver(t)
+		rec := post(t, h, notificationBody(tp, nt))
+		if rec.Code != http.StatusOK {
+			t.Errorf("notification_type=%q: status = %d, want 200", nt, rec.Code)
+		}
+		if n := target.totalCalls(); n != 0 {
+			t.Errorf("notification_type=%q dispatched %d times, want 0", nt, n)
+		}
+	}
+}
+
+// TestHookReceiver_DeniedHooksConsentDropsQuietly is the #570 gate at the
+// receiving end: while the hooks permission is not granted, an installed
+// hook that is still firing must be dropped without dispatching.
+func TestHookReceiver_DeniedHooksConsentDropsQuietly(t *testing.T) {
+	root := geminiSessionRoot(t)
+	tp := writeSessionTranscript(t, root, "sess-afteragent")
+	target := &mockTarget{}
+	h := NewHookHandler(target, keyedGate{}, mockLogger{})
+
+	rec := post(t, h, afterAgentBody(tp, "hi"))
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200", rec.Code)
+	}
+	if n := target.totalCalls(); n != 0 {
+		t.Fatalf("dispatched %d times while hooks consent was denied, want 0", n)
+	}
+}
+
+// TestHookReceiver_DeniedTranscriptsConsentDropsQuietly pins the second gate:
+// dispatching makes the detector read the transcript, so a transcripts-denied
+// session must not dispatch even though the hooks consent is granted, and
+// must not log an error while doing it (the receiver's own gate answers
+// quietly; only the shared backstop logs).
+func TestHookReceiver_DeniedTranscriptsConsentDropsQuietly(t *testing.T) {
+	root := geminiSessionRoot(t)
+	tp := writeSessionTranscript(t, root, "sess-afteragent")
+	target := &mockTarget{}
+	log := &contracttesting.RecordingLogger{}
+	h := NewHookHandler(target, keyedGate{PermissionKeyHooks: true}, log)
+
+	rec := post(t, h, afterAgentBody(tp, "hi"))
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200", rec.Code)
+	}
+	if n := target.totalCalls(); n != 0 {
+		t.Fatalf("dispatched %d times while transcripts consent was denied, want 0", n)
+	}
+	if len(log.Errors()) != 0 {
+		t.Errorf("a transcripts-denied hook logged %d error(s): %v", len(log.Errors()), log.Errors())
+	}
+}
+
+// TestHookReceiver_PermissionGateContract runs the shared #797 contract once
+// per permission this receiver must honour, derived from the receiver's own
+// declaration (issue #1488).
+func TestHookReceiver_PermissionGateContract(t *testing.T) {
+	contracttesting.AssertHookReceiverPermissionGated(t, contracttesting.HookReceiverGate{
+		Build: func(t *testing.T, gate *contracttesting.ConsentGate) contracttesting.GatedHookReceiver {
+			root := geminiSessionRoot(t)
+			body := afterAgentBody(writeSessionTranscript(t, root, "sess-gate"), "hi")
+			target := &mockTarget{}
+			h := NewHookHandler(target, gate, mockLogger{})
+
+			before := 0
+			return contracttesting.GatedHookReceiver{
+				Handler: h,
+				Exercise: func() {
+					before = target.totalCalls()
+					post(t, h, body)
+				},
+				Observe: func() bool { return target.totalCalls() > before },
+			}
+		},
+	})
+}
+
+// TestHookReceiver_DeclaresItsPermissions is the LOCK on the key list the
+// wiring above used to spell out (#1450).
+func TestHookReceiver_DeclaresItsPermissions(t *testing.T) {
+	contracttesting.AssertDeclaredPermissions(t,
+		NewHookHandler(&mockTarget{}, nil, mockLogger{}),
+		PermissionKeyHooks, PermissionKeyTranscripts)
+}
+
+// TestHookReceiver_NonPostRejected is a LOCK on the shared receiver shape.
+func TestHookReceiver_NonPostRejected(t *testing.T) {
+	geminiSessionRoot(t)
+	h, _ := newReceiver(t)
+	req := httptest.NewRequest(http.MethodGet, HookEndpointPath, nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Errorf("GET status = %d, want 405", rec.Code)
+	}
+}
+
+// TestHookReceiver_MalformedJSONIs400 is a LOCK: a body that will not decode
+// is the one case that answers non-2xx, because nothing about it is a path.
+func TestHookReceiver_MalformedJSONIs400(t *testing.T) {
+	geminiSessionRoot(t)
+	h, target := newReceiver(t)
+	rec := post(t, h, "{not json")
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", rec.Code)
+	}
+	if n := target.totalCalls(); n != 0 {
+		t.Errorf("dispatched %d times on malformed JSON, want 0", n)
+	}
+}
+
+// TestHookReceiver_HostileTranscriptPathIsConfined pins path confinement
+// end-to-end through this receiver: a caller-supplied transcript_path
+// escaping the declared root must dispatch nothing and still answer 2xx.
+func TestHookReceiver_HostileTranscriptPathIsConfined(t *testing.T) {
+	geminiSessionRoot(t)
+	h, target := newReceiver(t)
+
+	rec := post(t, h, afterAgentBody("/etc/passwd", "hi"))
+
+	if rec.Code < 200 || rec.Code > 299 {
+		t.Errorf("status = %d, want 2xx: a confinement refusal is reported by the log and "+
+			"counter, not by a status code", rec.Code)
+	}
+	if n := target.totalCalls(); n != 0 {
+		t.Fatalf("an out-of-tree path dispatched %d times, want 0", n)
+	}
+}

--- a/core/adapters/inbound/agents/geminicli/hookunknown_test.go
+++ b/core/adapters/inbound/agents/geminicli/hookunknown_test.go
@@ -1,0 +1,31 @@
+// hookunknown_test.go wires this adapter's hook receiver into the shared
+// issue #1364 contract: an event name the receiver does not recognize is
+// counted per (adapter, name), reported once per distinct name, and still
+// answered 2xx.
+package geminicli
+
+import (
+	"testing"
+
+	"irrlicht/core/internal/contracttesting"
+	"irrlicht/core/ports/outbound"
+)
+
+func TestUnknownHookEventObserved(t *testing.T) {
+	contracttesting.AssertUnknownHookEventObserved(t, contracttesting.UnknownEventReceiver{
+		Adapter:         AdapterName,
+		Root:            geminiSessionRoot,
+		WriteTranscript: writeContractTranscript,
+		New: func(t *testing.T, log outbound.Logger) contracttesting.UnknownEventReceiverUnderTest {
+			t.Helper()
+			target := &mockTarget{}
+			return contracttesting.UnknownEventReceiverUnderTest{
+				Handler:  NewHookHandler(target, nil, log),
+				Observed: func() bool { return target.totalCalls() > 0 },
+			}
+		},
+		PayloadFor:   contractPayload,
+		KnownEvent:   HookAfterTool,
+		EndpointPath: HookEndpointPath,
+	})
+}

--- a/core/adapters/inbound/agents/geminicli/hookversion_test.go
+++ b/core/adapters/inbound/agents/geminicli/hookversion_test.go
@@ -1,0 +1,102 @@
+// hookversion_test.go wires the Gemini CLI hooks permission into the shared
+// issue #1365 contract.
+//
+// Unlike copilot and codex, this adapter declares no Observed version source:
+// Gemini CLI's transcript header carries no version field this adapter's
+// parser reads (unverified — nothing found while auditing the payload
+// shapes, and not worth inventing a claim to close), so the gate falls
+// straight through to Probe (`gemini --version`), which cliversion runs
+// itself. That is exercised live by AssertHookVersionGate against the
+// installed CLI; the tests below pin gate.Permits(version) directly against
+// literal version strings, which needs no live binary.
+package geminicli
+
+import (
+	"strings"
+	"testing"
+
+	"irrlicht/core/domain/agent"
+	"irrlicht/core/internal/contracttesting"
+)
+
+func TestHooksPermission_DeclaresVersionGate(t *testing.T) {
+	contracttesting.AssertHookVersionGate(t, contracttesting.HookVersionGate{
+		Agent:         Agent(),
+		PermissionKey: PermissionKeyHooks,
+		Installed:     installedHookEvents,
+		Since:         hookEventSince,
+	})
+}
+
+// hooksVersionGate returns the declared gate, read off the real registration
+// the daemon consumes rather than a copy.
+func hooksVersionGate(t *testing.T) *agent.VersionGate {
+	t.Helper()
+	for _, p := range Agent().Permissions {
+		if p.Key == PermissionKeyHooks {
+			if p.Writes == nil || p.Writes.Version == nil {
+				t.Fatal("hooks permission declares no version gate")
+			}
+			return p.Writes.Version
+		}
+	}
+	t.Fatal("no hooks permission")
+	return nil
+}
+
+// TestHooksGate_BelowFloorSaysWhy pins that a Gemini CLI older than the
+// declared floor is refused WITH a reason naming both versions.
+func TestHooksGate_BelowFloorSaysWhy(t *testing.T) {
+	gate := hooksVersionGate(t)
+
+	allowed, why := gate.Permits("0.53.9")
+	if allowed {
+		t.Fatal("gate permits installing into Gemini CLI 0.53.9, below the declared floor")
+	}
+	if !strings.Contains(why, "0.53.9") || !strings.Contains(why, minCLIVersion) {
+		t.Errorf("refusal %q names neither the installed version nor the required one; "+
+			"the reason has to tell the user what to upgrade", why)
+	}
+}
+
+// TestHooksGate_AtOrAboveFloorInstalls is a LOCK: it pins that the gate has
+// not become a blanket refusal, which from a log looks identical to one that
+// works.
+func TestHooksGate_AtOrAboveFloorInstalls(t *testing.T) {
+	gate := hooksVersionGate(t)
+	for _, v := range []string{minCLIVersion, "0.54.4", "0.56.0", "1.0.0"} {
+		if allowed, why := gate.Permits(v); !allowed {
+			t.Errorf("gate refuses Gemini CLI %s, at or above the %s floor: %s", v, minCLIVersion, why)
+		}
+	}
+}
+
+// TestHooksGate_UnknownVersionFailsOpen pins the documented direction
+// (core/pkg/cliversion): an unparseable or unknown version must not block an
+// install. The daemon runs under launchd with a minimal PATH and routinely
+// cannot see the user's CLI at all, so "unknown" must read as "not proven
+// old", not as "assume the worst".
+func TestHooksGate_UnknownVersionFailsOpen(t *testing.T) {
+	gate := hooksVersionGate(t)
+	if allowed, why := gate.Permits(""); !allowed {
+		t.Errorf("gate refuses on an unknown version: %s", why)
+	}
+}
+
+// TestHooksGate_ProbeIsGeminiVersion pins the argv this adapter asks
+// cliversion to run — gemini --version prints a bare number (e.g. "0.56.0",
+// no "v" prefix, no surrounding text), verified live against the installed
+// CLI during this issue's audit, so cliversion's parser needs no adapter-
+// specific massaging.
+func TestHooksGate_ProbeIsGeminiVersion(t *testing.T) {
+	gate := hooksVersionGate(t)
+	want := []string{"gemini", "--version"}
+	if len(gate.Probe) != len(want) {
+		t.Fatalf("Probe = %v, want %v", gate.Probe, want)
+	}
+	for i := range want {
+		if gate.Probe[i] != want[i] {
+			t.Fatalf("Probe = %v, want %v", gate.Probe, want)
+		}
+	}
+}

--- a/core/application/services/session_detector_lifecycle.go
+++ b/core/application/services/session_detector_lifecycle.go
@@ -343,6 +343,77 @@ func (d *SessionDetector) HandleStopHook(sessionID, transcriptPath, lastAssistan
 	d.dispatchHookActivity(sessionID, transcriptPath, session.HookStop)
 }
 
+// HandlePermissionPromptHook records gemini-cli's Notification/ToolPermission
+// hook (issue #1717): a tool confirmation prompt is genuinely open and the
+// user is blocked on it right now.
+//
+// A dedicated method rather than the generic name-keyed HandlePermissionHook,
+// and that is load-bearing rather than a style choice. gemini-cli's wire name
+// for this event is literally "Notification" — the SAME string Claude Code
+// uses for its own Notification hook, which session.HookSignal deliberately
+// has no row for (its gate is adapter-side: claudecode dispatches it to
+// HandleIdlePromptHook, never through the generic table). hookSignalEffects is
+// one flat map with no adapter dimension, so adding a row keyed on
+// "Notification" to make THIS call hold SignalPermissionPrompt would also
+// change what claudecode's and copilot's OWN Notification dispatches do —
+// copilot's in particular, whose package comment explains that copilot must
+// dispatch its identically-named notification WITHOUT a hold, because copilot
+// emits nothing at all when the user denies a prompt and a hold with no
+// release would pin the session waiting for the 12-hour ceiling
+// (permissionPromptHoldTimeout). A shared-table row would silently reintroduce
+// that exact bug into copilot.
+//
+// gemini-cli is not in copilot's position: unlike copilot, its AfterAgent
+// event reliably fires after a cancelled confirmation too (a cancelled tool
+// call is converted to a terminal, completed batch entry carrying a synthetic
+// error functionResponse fed back to the model, so the turn completes
+// normally) — source-verified against the installed CLI, not assumed. That is
+// what makes holding here safe: geminicli's AfterAgent handling calls
+// ReleasePermissionPromptHold unconditionally, closing the one case (a denied
+// confirmation) where AfterTool's broad release never fires. See that method
+// and geminicli/hooks.go's package comment for the other half of this pair.
+//
+// Persistent, not consume-once — matching the existing SignalPermissionPrompt
+// policy row's own semantics (session.signalPolicies), which every other
+// asserter of this signal (claudecode's PreToolUse, codex's PermissionRequest)
+// already relies on: the hold must survive every re-evaluation between the
+// prompt opening and it being resolved.
+//
+// Safe to call from any goroutine (e.g. the HTTP handler).
+func (d *SessionDetector) HandlePermissionPromptHook(sessionID, transcriptPath, hookName string) {
+	d.signals.Hold(sessionID, session.SignalPermissionPrompt, session.SignalPayload{}, d.nowFn())
+	d.dispatchHookActivity(sessionID, transcriptPath, hookName)
+}
+
+// ReleasePermissionPromptHold drops any held SignalPermissionPrompt for
+// sessionID without requiring a name-keyed hook event to carry the release.
+//
+// Exists for gemini-cli's AfterAgent handler (issue #1717), which calls this
+// alongside HandleStopHook rather than relying solely on AfterTool's broad
+// release. The gap it closes: on a CANCELLED tool confirmation, gemini-cli's
+// scheduler returns before ever running the tool, so AfterTool never fires for
+// that call — source-verified against the installed CLI (the cancel path
+// converts straight to a terminal batch entry without reaching the tool
+// execution step AfterTool is fired from). Without this call, a denied prompt
+// would stay held until SignalPermissionPrompt's own 12-hour ceiling
+// (permissionPromptHoldTimeout) — technically bounded, but a needless half-day
+// of false `waiting` when the turn that resolved it has, in fact, already
+// completed.
+//
+// Safe to release unconditionally: fireAfterAgentHookSafe (gemini-cli's own
+// gate on firing AfterAgent) cannot fire while a confirmation from that turn
+// is still genuinely open — the agent loop is blocked awaiting the user's
+// answer at that point and has not yet reached the point where AfterAgent
+// could fire — so by the time AfterAgent arrives, any permission prompt opened
+// during that turn has already been resolved one way or another. Release on
+// an unheld signal is a no-op (SignalHolds.Release), so this costs nothing on
+// the far more common case where nothing was held.
+//
+// Safe to call from any goroutine (e.g. the HTTP handler).
+func (d *SessionDetector) ReleasePermissionPromptHold(sessionID string) {
+	d.signals.Release(sessionID, session.SignalPermissionPrompt)
+}
+
 // HandleIdlePromptHook records Claude Code's Notification/idle_prompt hook
 // (issue #1173): the agent has finished its turn and is now idle at the prompt
 // waiting for the user. Holding SignalIdlePrompt makes every subsequent

--- a/core/cmd/irrlichd/startup.go
+++ b/core/cmd/irrlichd/startup.go
@@ -19,6 +19,7 @@ import (
 	"irrlicht/core/adapters/inbound/agents/claudecode"
 	"irrlicht/core/adapters/inbound/agents/codex"
 	"irrlicht/core/adapters/inbound/agents/copilot"
+	"irrlicht/core/adapters/inbound/agents/geminicli"
 	"irrlicht/core/adapters/inbound/agents/processlifecycle"
 	backchannelhandler "irrlicht/core/adapters/inbound/backchannel"
 	gastownadapter "irrlicht/core/adapters/inbound/orchestrators/gastown"
@@ -927,9 +928,14 @@ func setupBackchannel(mux *http.ServeMux, deps setupBackchannelDeps) (*services.
 // claudecode.HookTarget) and the per-tick statusline JSON carrying rate_limits
 // for Pro/Max subscribers (issue #309); plus Codex's PermissionRequest/
 // PostToolUse/Stop events (issue #1171) — the detector satisfies
-// codex.HookTarget the same way. All are consent-gated: hooks installed by a
-// pre-consent daemon keep firing until the wizard is answered, so payloads are
-// dropped while pending.
+// codex.HookTarget the same way; plus Copilot's Notification/Stop events; plus
+// Gemini CLI's Notification/AfterTool/AfterAgent events (issue #1717),
+// delivered by the `irrlichd hook-post gemini-cli` beacon rather than a native
+// http hook — the detector satisfies geminicli.HookTarget's extra two methods
+// (HandlePermissionPromptHook, ReleasePermissionPromptHold) alongside the two
+// every other receiver already calls. All are consent-gated: hooks installed
+// by a pre-consent daemon keep firing until the wizard is answered, so
+// payloads are dropped while pending.
 func registerHookRoutes(mux *http.ServeMux, detector *services.SessionDetector, metricsCollector outbound.MetricsCollector, permService *services.PermissionService, logger outbound.Logger) {
 	// mux.Handle, not HandleFunc: each constructor returns a hookjson.HookHandler
 	// — the handler together with the confiner it enforces #1361 with — which
@@ -942,6 +948,8 @@ func registerHookRoutes(mux *http.ServeMux, detector *services.SessionDetector, 
 		codex.NewHookHandler(detector, permService, logger))
 	mux.Handle("POST "+copilot.HookEndpointPath,
 		copilot.NewHookHandler(detector, permService, logger))
+	mux.Handle("POST "+geminicli.HookEndpointPath,
+		geminicli.NewHookHandler(detector, permService, logger))
 }
 
 // publishAddrFile writes the addr file and thereby signals "the daemon is

--- a/core/domain/session/hook_signal.go
+++ b/core/domain/session/hook_signal.go
@@ -30,6 +30,19 @@ const (
 	// notification_type discriminator; the daemon acts only on idle_prompt
 	// (issue #1173).
 	HookNotification = "Notification"
+	// HookAfterTool is gemini-cli's own wire name for its broad post-tool
+	// event (issue #1717) — fires after EVERY tool call, unlike claudecode's
+	// narrowly-matchered PostToolUse. It is declared here, not reused from
+	// HookPostToolUse, precisely because the two must never share a row: this
+	// package is a flat map keyed by the literal wire string with no adapter
+	// dimension, so "AfterTool" needs its own key even though its effect
+	// (broad release) is identical in shape to PostToolUse's. Unlike
+	// "Notification" or "Stop" — wire names claudecode and gemini-cli both
+	// happen to use, but for different-enough semantics that a shared row
+	// would be wrong for one of them — "AfterTool" is a name only gemini-cli
+	// fires, so giving it a row here cannot leak into another adapter's
+	// dispatch.
+	HookAfterTool = "AfterTool"
 )
 
 // AllHookEvents is every hook event name the constants above define, in
@@ -51,6 +64,7 @@ var AllHookEvents = []string{
 	HookPreCompact,
 	HookStop,
 	HookNotification,
+	HookAfterTool,
 }
 
 // HookSignalEffect is what one hook event name does to a session's signal
@@ -123,6 +137,16 @@ var hookSignalEffects = map[string]HookSignalEffect{
 	// The tool ran, so whatever was blocking on it no longer is.
 	HookPostToolUse:        {Signal: SignalPermissionPrompt, Release: true},
 	HookPostToolUseFailure: {Signal: SignalPermissionPrompt, Release: true},
+	// gemini-cli's AfterTool fires after every tool call (issue #1717), the
+	// same broad-fires-on-everything shape claudecode's PostToolUse has — see
+	// hookinstaller.go's matcher comment on that adapter for why a broad
+	// RELEASE is safe where a broad ASSERT is not: releasing an unheld signal
+	// is a no-op, so firing on every tool costs nothing, while asserting on
+	// every tool would hold `waiting` on every tool call. gemini-cli's own
+	// narrow assert lives outside this table entirely, on
+	// SessionDetector.HandlePermissionPromptHook — see that method's doc for
+	// why "Notification" cannot get a row here the way this one can.
+	HookAfterTool: {Signal: SignalPermissionPrompt, Release: true},
 	// The turn ended, authoritatively, at true turn end (#1161). Name-only
 	// here: a caller with the hook's payload — SessionDetector.HandleStopHook,
 	// which every adapter routes Stop through — holds SignalTurnDone itself

--- a/tools/onboarding-factory/internal/hookcov/hookcov_test.go
+++ b/tools/onboarding-factory/internal/hookcov/hookcov_test.go
@@ -17,19 +17,21 @@ import (
 func TestDeclaredMatchesRegistry(t *testing.T) {
 	got := Declared()
 
-	// Exhaustive as of this commit: claudecode, codex and copilot are the
-	// adapters declaring a hooks permission. If a fourth gains one, this fails
-	// and the new adapter joins the list — that is the intended workflow, not
-	// an obstacle.
+	// Exhaustive as of this commit: claudecode, codex, copilot and gemini-cli
+	// are the adapters declaring a hooks permission. If a fifth gains one,
+	// this fails and the new adapter joins the list — that is the intended
+	// workflow, not an obstacle.
 	//
-	// copilot joined in #1378 and is expected to report StatusGap for a while:
-	// it declares hooks, but no copilot recording carries a hook_received
-	// event yet, because that phase deliberately re-recorded nothing (the
-	// frozen sidecars are hook-free and the replay goldens had to stay
-	// byte-identical). A GAP here is the honest reading of that, not a defect.
+	// copilot joined in #1378 and gemini-cli in #1717, and both are expected
+	// to report StatusGap for a while: each declares hooks, but no recording
+	// for either carries a hook_received event yet, because landing the
+	// permission deliberately re-recorded nothing (the frozen sidecars are
+	// hook-free and the replay goldens had to stay byte-identical — #1717's
+	// own audit measured 0 cells re-recorded). A GAP here is the honest
+	// reading of that, not a defect.
 	want := map[string]bool{
 		"aider": false, "antigravity": false, "claudecode": true, "codex": true,
-		"copilot": true, "gemini-cli": false, "hermes": false, "kiro-cli": false,
+		"copilot": true, "gemini-cli": true, "hermes": false, "kiro-cli": false,
 		"mistral-vibe": false, "opencode": false, "pi": false,
 	}
 	if !reflect.DeepEqual(got, want) {


### PR DESCRIPTION
## Summary

Ships the hook-based state-detection pilot for gemini-cli that #1355 Phase D named and #1717 unblocked. The maintainer reversed the "unmaintained" flag on this issue (it was about maintainer time, not viability) — this PR removes that marking everywhere it appeared and ships the pilot itself.

Three events installed: `Notification` (narrow assert, gated on `notification_type == "ToolPermission"`), `AfterTool` (broad release), `AfterAgent` (the turn-done push, through `HandleStopHook`). Delivery is the beacon (`irrlichd hook-post gemini-cli`), not a native http hook — gemini-cli has none — and not a bare `curl` line, which this CLI's own exit-code semantics make unsafe. All source claims below are cited to a bundle offset or a specific function name in the installed CLI; nothing is asserted from rendered docs.

Closes #1717.

## Source-verified vs live-verified

Two installed CLI versions were read: **0.54.4** (installed at audit start) and **0.56.0** (the CLI auto-updated itself mid-audit, unprompted — disclosed rather than silently absorbed). Every claim below was re-checked at both and is **byte-identical** between them unless noted.

**Source-verified** (read directly from the installed `@google/gemini-cli` bundle, not from docs):
- `HookEventName` enum: `BeforeTool, AfterTool, BeforeAgent, Notification, AfterAgent, SessionStart, SessionEnd, PreCompress, BeforeModel, AfterModel, BeforeToolSelection` — 11 events, all 11.
- `validateHookConfig` accepts only `"command" | "plugin" | "runtime"` — there is no JSON-expressible `"http"`. This is the entire reason the beacon is used instead of a native http hook the way claudecode/codex/copilot install.
- The exit-code-to-decision mapping (`convertPlainTextToHookOutput`): exit 0 → allow, exit 1 → allow-with-warning, **anything else → deny**, when the hook's stdout didn't parse as JSON. `evaluateBeforeToolHook` and `fireBeforeAgentHookSafe` turn a "deny" into a blocked tool call / blocked turn. A bare `curl` against a down daemon exits 7 → would break the user's tool calls. This is why `hookbeacon` (always exits 0, by construction) is mandatory here, not merely "a strong outcome if it fits" as my own brief originally framed it.
- `NotificationType` enum: exactly one member, `"ToolPermission"`, today.
- `resolveConfirmation` → `notifyHooks`: fires `Notification`/`ToolPermission` unconditionally once a tool genuinely needs confirmation (`shouldConfirmExecute` returned non-nil), **before** blocking on the user's answer, regardless of the eventual outcome. This is a real, content-based discriminator — unlike `BeforeTool`, whose payload (`tool_name`, `tool_input`) carries nothing distinguishing "about to run silently" from "about to block."
- On `ToolConfirmationOutcome.Cancel`: the scheduler's confirm-phase returns **before** calling `_execute()` — so `AfterTool` never fires for a cancelled confirmation. But `cancelAllQueued` converts the cancelled call into a terminal batch entry carrying a synthetic `functionResponse` (`{error: "[Operation Cancelled]..."}`) fed back to the model, so the turn's conversation continues and completes normally — `AfterAgent` **does** still fire for that turn. This is why `AfterAgent`'s handler also calls `SessionDetector.ReleasePermissionPromptHold` unconditionally (see below) rather than relying solely on `AfterTool`'s broad release.
- `fireAfterAgentHookSafe`: deduped per `prompt_id`, gated on `pendingToolCalls.length === 0` — fires once, at true turn end, only after every tool call from that turn resolved (success, error, or cancel all count as resolved).
- `gemini hooks migrate --from-claude`'s `EVENT_MAPPING` table (Claude Code → Gemini): `PreToolUse→BeforeTool, PostToolUse→AfterTool, UserPromptSubmit→BeforeAgent, Stop→AfterAgent, SubAgentStop→AfterAgent, SessionStart→SessionStart, SessionEnd→SessionEnd, PreCompact→PreCompress, Notification→Notification` — upstream's own statement of the correspondence, corroborating the `AfterAgent`↔turn-done mapping independently of my own tracing.

**Live-verified** (driven against the real installed CLI under an isolated `$HOME`, never the user's real `~/.gemini`):
- `SessionStart` and `SessionEnd` fire from a hooks entry in the **global** `~/.gemini/settings.json` with **no project-scope config present at all** (confirmed by `ls` on the test workdir — empty, no `.gemini`/`.claude` subdirectory) — the payload matched the source-derived shape exactly (`session_id, transcript_path, cwd, hook_event_name, timestamp, source`).
- Global-scope hooks are **not** gated by `isTrustedFolder()` (only project-scope are) — confirmed both by source (`processHooksFromConfig`) and by the above firing without ever answering a trust prompt.
- `gemini hooks migrate --from-claude` (a different, adjacent write path — writes to **project**-scope `.gemini/settings.json`, not global, correcting my own initial assumption) preserved a pre-existing unrelated hook entry and an entirely unrecognized event key verbatim rather than deleting either.
- **`BeforeAgent`/`AfterAgent`/`BeforeTool`/`AfterTool`/`Notification` were NOT live-fired** — the account authenticated on this machine is no longer eligible for live model calls at all: `IneligibleTierError: This client is no longer supported for Gemini Code Assist for individuals. To continue using Gemini, please migrate to the Antigravity suite of products.` Confirmed via both headless (`gemini -p ... --yolo`) and interactive OAuth sign-in; no `GEMINI_API_KEY` available as an alternate path, and none was sought. This blocks nothing about implementing the mechanism — every behavior above is independently confirmed from source — but it does mean the receiver's dispatch of these four events, while covered by adapter-level unit tests against a mock target, has not been proven against bytes a real gemini-cli process actually sent.

**Not verified, stated rather than assumed:** whether gemini-cli's transcript persists a recognizable "tool denied" marker the way claudecode's does (`LastWasToolDenial`) — not chased, because `ReleasePermissionPromptHold` on `AfterAgent` closes the same gap without needing it.

## Why these three events, and not the other eight

- **`Notification`** (gated on `notification_type == "ToolPermission"`) → asserts `SignalPermissionPrompt`, through a **new, dedicated** `SessionDetector.HandlePermissionPromptHook` — not the generic name-keyed `HandlePermissionHook`/`session.HookSignal` path. This is load-bearing, not style: gemini's wire name for this event is literally `"Notification"`, the same string Claude Code and Copilot both use for their own, differently-gated Notification dispatch. `session.hookSignalEffects` is one flat map with no adapter dimension — a row keyed on `"Notification"` to make this assert would have **also** changed what Copilot's identically-named dispatch does. Copilot's own `hooks.go` explains why that would be a real regression: Copilot emits nothing at all when a user denies a prompt, so a hold with no release would pin a denied session `waiting` for the 12-hour ceiling. Gemini is not in Copilot's position — its `AfterAgent` reliably fires after a cancelled confirmation too (source-verified above) — which is what makes holding safe here where it is not safe there.
- **`AfterTool`** → broad release only, dispatched through the existing generic `HandlePermissionHook` path with a **new** domain row, `session.HookAfterTool = "AfterTool"` (a wire name only gemini-cli fires, so this row cannot leak into another adapter, unlike `"Notification"` above). Fires for every tool call with no discriminator — installed anyway, because releasing an unheld signal is a no-op, mirroring claudecode's own `PostToolUse` row, which is also installed broadly.
- **`AfterAgent`** → the turn-done push, through `HandleStopHook` (payload-carrying, not a name-keyed row — same reason `HookStop` already isn't one), **plus** a new unconditional `ReleasePermissionPromptHold(sessionID)` call — the backstop for the one case `AfterTool`'s release never reaches (a cancelled confirmation). Safe unconditionally: `fireAfterAgentHookSafe`'s own gate means `AfterAgent` cannot fire while a confirmation from that turn is genuinely still open.
- **NOT `BeforeTool`**: fires for every tool call with the same no-discriminator payload as `AfterTool`, and a hook that errors on it denies the tool call (source-verified above). `Notification` already gives the narrow signal; installing this would be pure blast radius for the reason the issue itself named.
- **NOT `SessionStart`/`SessionEnd`**: no stated payoff beyond what process discovery and transcript tailing already give. That they were the two events this audit could confirm live is a fact about auth, not a justification — no other reason was found, so they're left out.
- **NOT `PreCompress`/`BeforeModel`/`AfterModel`/`BeforeToolSelection`**: no signal semantics needed; `BeforeModel`/`AfterModel` additionally carry full LLM request/response bodies — blast radius with no offsetting benefit.

## Version floor

`minCLIVersion = "0.54.0"` in `hookinstaller.go`. **Deliberately not the date the hook system shipped upstream** — PR archaeology (`google-gemini/gemini-cli` #9074–#9112, all merged 2025-09-22) puts the event set at roughly that date, first stable release after it `0.6.0` (2025-09-24). Bisecting an old npm release for the exact payload shape turned out to be unreliable (2025-era packages ship a completely different unbundled `dist/src` layout than today's single bundled file, so a file-presence diff proves nothing across that packaging change — tried, abandoned). The floor instead sits at the edge of what was **directly source-read**: 0.54.4 and 0.56.0, seven months apart, byte-identical on every claim above. Overshooting a version floor is the safe direction (`core/pkg/cliversion` fails **open** on an unknown/unparseable version — the daemon runs under launchd with a minimal PATH and often cannot see the CLI at all); undershooting is not. `Probe: ["gemini", "--version"]` — confirmed live to print a bare number, no `v` prefix, no surrounding text. No `Observed` source: no version field was found in gemini-cli's transcript header (not chased further — not worth inventing a claim to close).

## Recording cost: unassessable

**0 cells re-recorded.** The 33 existing gemini-cli recordings predate hooks and carry no `hook_received` events (confirmed: `tools/onboarding-factory/internal/hookcov`'s `TestDeclaredMatchesRegistry` now reports gemini-cli as `StatusGap`, the same status copilot reported at #1378 for the identical reason). What the #1355 Phase D kill-criterion (>5 re-records) was meant to catch is **unmeasurable** for this PR specifically because of the auth blocker above — recording a hook-bearing session needs a live model turn, and the account cannot make one. This is stated as unassessable rather than left as an absent number: the two must not read the same.

## Contract wiring (all 8, graded against copilot)

`hookdisclosure_test.go`, `hookpath_test.go`, `hookport_test.go` (`AssertHookEndpointFollowsBindAddr` under `DeliveryAddressFree` — the first production adopter of that route; `hook_endpoint_addressfree_test.go`'s reference wiring is what it's copied from), `hookreceipt_test.go`, `hookunknown_test.go`, `hookversion_test.go`, `hookinstaller_test.go` (`AssertPermissionGated` + shared-file round trip — this adapter's settings file is Gemini CLI's one general-purpose settings file, not a dedicated file the way Copilot's is, so uninstall never deletes it and a dedicated test proves unrelated keys — `security.auth`, an arbitrary unknown key — survive install+uninstall byte-for-byte), `hooks_test.go` (`AssertHookReceiverPermissionGated` + `AssertDeclaredPermissions` + behavior tests).

## Mutation evidence (per #1479 — run, not merely described)

Three new pieces of behavior this PR adds each got a deliberate break, confirmed red, then reverted (files fully clean after each — `git status --porcelain` empty):

1. **Notification routed through the generic table instead of the dedicated method** (`target.HandlePermissionHook(...)` in place of `target.HandlePermissionPromptHook(...)`):
   ```
   hooks_test.go:307: got 0 permission-prompt dispatches, want 1 (perm=1, stop=0)
   hooks_test.go:342: got 0 dispatches through HandlePermissionPromptHook, want 1
   ```
2. **`ReleasePermissionPromptHold` call removed from `AfterAgent` handling**:
   ```
   hooks_test.go:284: got 0 ReleasePermissionPromptHold calls, want 1 — AfterAgent must
   release unconditionally, because a cancelled confirmation never fires AfterTool
   ```
3. **`HookAfterTool` row removed from `core/domain/session/hook_signal.go`'s `hookSignalEffects`**:
   ```
   hooks_test.go:240: session.HookSignal("AfterTool") has no row — AfterTool's broad
   release depends on one
   ```

Also fixed in the process: `tools/onboarding-factory/internal/hookcov`'s `TestDeclaredMatchesRegistry` — a pre-existing registry tripwire whose hand-written `want` map needed `gemini-cli: true` now that this adapter declares hooks (same workflow copilot's landing exercised at #1378).

## Deprecation removal

Both marker locations removed: `.claude/skills/ir:agent-releases/SKILL.md` (the `#### Gemini CLI — ⚠️ unmaintained` heading + skip-in-sweeps bullet) and `references/monitoring-surface.md` §10 (heading, explanatory paragraph, reopen condition). Also fixed the `references/monitoring-surface.md` "Turn-end shape change" impact-category row, which listed gemini-cli among four purely-heuristic adapters that "stick in `working` forever" on an upstream transcript-shape change — no longer true once the hooks permission is granted (`AfterAgent` is an independent, transcript-shape-agnostic backstop). Repo-wide grep confirmed these were the only two locations; nothing in code or automation keyed off the marker string — purely prose. `tools/preflight.sh --only skills`: PASS (23 files, 0 errors, 0 warnings).

## Gates run (chunked, each its own foreground invocation)

- `--only go`: PASS (fixed the hookcov regression above; `go test ./core/... -race -count=1` and `go test ./tools/onboarding-factory/... -count=1` both exit 0, confirmed via direct re-runs after the preflight wrapper's captured output turned out to be truncated).
- `--only arch`: PASS (ARS composite 7.9316 → 7.9272, no category regression).
- `--only tools`: PASS (19 shell-lib suites).
- `--only posix`: PASS (3 files).
- `--only security`: PASS (gosec/govulncheck/npm audit; the two G104 "errors unhandled" findings in `geminicli/hookinstaller.go` are the same non-blocking informational pattern every other adapter's `hookinstaller.go` has at its own atomic-write-then-remove defer).
- `--only skills`: PASS.
- The pre-push hook additionally ran `tools/preflight.sh --changed` on push and reported all relevant gates PASS.

## Not merging

Per standing instructions — leaving this for independent QA and merge.
