### PR TITLE
docs(gemini-cli): schedule deprecation for v0.7 — the adapter can no longer be verified

### DIFF
--- a/.claude/skills/ir:agent-releases/SKILL.md
+++ b/.claude/skills/ir:agent-releases/SKILL.md
@@ -77,8 +77,18 @@ you verified against, since it may lag the newest release.
 - Note: sessions have been SQLite (drizzle) since ~2026-02-14, **not** JSON files. Legacy JSON storage still exists in `packages/opencode/src/storage/storage.ts` but `session.ts` no longer routes through it — do not mistake the leftover for live storage.
 - The DB filename is channel-scoped upstream (`opencode-<channel>.db`); stable channels (`latest`/`beta`/`prod`) get plain `opencode.db` — see `packages/core/src/database/database.ts`
 
-#### Gemini CLI
-- Maintained — track it in sweeps like any other adapter. It carried an "unmaintained, skip by default" marking from 2026-07-15 until #1717 reversed it: the flag was about maintainer time, not viability, and #1717 shipped a hook-based state-detection pilot against it (`core/adapters/inbound/agents/geminicli/hooks.go`), which needs the same release watch every other hook-installing adapter gets.
+#### Gemini CLI — ⚠️ scheduled for deprecation in irrlicht v0.7
+- **Deprecation scheduled (decided 2026-08-20, at v0.5.10).** The maintainer can no longer
+  authenticate against Gemini CLI at all: the account is tier-ineligible
+  (`IneligibleTierError: This client is no longer supported for Gemini Code Assist for
+  individuals… migrate to the Antigravity suite of products`), which blocks every live turn and
+  therefore every re-recording. An adapter nobody can exercise cannot be verified, and this repo
+  does not keep claims it cannot re-check. **Until v0.7 it stays in sweeps as below**; at v0.7 it
+  is removed. Note what this is NOT: an upstream break, or a verdict on the adapter's quality —
+  #1717 shipped its hook channel the same day, and it passes every gate. Reversible if auth is
+  restored (an `aistudio.google.com` key with `security.auth.selectedType: "gemini-api-key"` is a
+  separate path from the retired Code Assist OAuth, and was not tried).
+- Until then, track it in sweeps like any other adapter. It carried an "unmaintained, skip by default" marking from 2026-07-15 until #1717 reversed it: the flag was about maintainer time, not viability, and #1717 shipped a hook-based state-detection pilot against it (`core/adapters/inbound/agents/geminicli/hooks.go`), which needs the same release watch every other hook-installing adapter gets.
 - Check: `https://github.com/google-gemini/gemini-cli/releases` — **authoritative; the repo has no root `CHANGELOG.md`** (404s on `main`)
 - Releases very frequently (nightlies + previews) — focus on stable, group the rest
 - Best evidence is a local clone + `git diff <old-tag>..<new-tag>` on `packages/core/src/config/storage.ts` and `packages/core/src/services/chatRecordingService.ts`

--- a/.claude/skills/ir:agent-releases/references/monitoring-surface.md
+++ b/.claude/skills/ir:agent-releases/references/monitoring-surface.md
@@ -489,9 +489,19 @@ Lines arrive `TrimSpace`'d, so leading indentation is already gone.
 - Drop/reformat `> Tokens: … sent, … received` → kills tokens, cost, model attribution, **and** `assistant_message` in one stroke. Localization or thousands-separators (`1,234`) also defeat `[\d.]+`.
 - ⚠️ **The subtlest one:** aider printing **periodic keepalive/spinner/progress lines** into the `.md` would reset the idle anchor every tick and **suppress `IdleFlush` indefinitely → permanent `working`**. This requires no change to any marker string, just extra output.
 
-### 10. Gemini CLI (`gemini-cli`)
+### 10. Gemini CLI (`gemini-cli`) — ⚠️ scheduled for deprecation in irrlicht v0.7
 
-**Maintained — track it in sweeps like any other adapter.** It carried an "unmaintained,
+> **Deprecation scheduled 2026-08-20 (at v0.5.10), effective v0.7.** The maintainer's account is
+> tier-ineligible — `IneligibleTierError: This client is no longer supported for Gemini Code
+> Assist for individuals… migrate to the Antigravity suite of products` — so no live turn, and
+> therefore no re-recording, is possible on this machine. The adapter is not broken and did not
+> fail: #1717 shipped its hook channel the same day and every gate passes. It is being retired
+> because it cannot be **verified**, which is a different claim and the honest one. Sweeps
+> continue as described below until v0.7. Reversible: `gemini-api-key` auth (a key from
+> `aistudio.google.com/apikey`, with `security.auth.selectedType` switched away from
+> `oauth-personal`) is a separate path from the retired Code Assist OAuth and was not attempted.
+
+**Tracked in sweeps like any other adapter until then.** It carried an "unmaintained,
 skip by default" marking from 2026-07-15 until #1717 reversed it: the flag was about
 maintainer time, not viability. #1717's audit found the flag was blocking the strongest
 hook-based state-detection candidate in the whole set — Gemini CLI ships `gemini hooks


### PR DESCRIPTION
Marks `gemini-cli` for deprecation at irrlicht **v0.7** (current: 0.5.10). Decided 2026-08-20.

## Why

The maintainer's account is **tier-ineligible** against Gemini CLI:

```
IneligibleTierError: This client is no longer supported for Gemini Code Assist
for individuals... migrate to the Antigravity suite of products
```

Every live turn fails, headless and interactive OAuth alike — so no re-recording is possible on this
machine, and no claim about the adapter can be re-checked. **An adapter nobody can exercise cannot be
verified**, and this repo does not keep claims it cannot re-run.

## What this is not

Stated explicitly in both files, because the marking would otherwise be read as something it isn't:

- **Not an upstream break.** Gemini CLI works; the account's entitlement was withdrawn.
- **Not a quality verdict.** #1717 shipped gemini-cli's hook channel *the same day* — `Notification`
  (narrow permission assert), `AfterTool` (broad release), `AfterAgent` (turn-done) over `hookbeacon`
  delivery, all eight contract families wired, every gate green. It is the most capable hook adapter
  in the set on paper.
- **Not irreversible.** The untried path is named in both files so nobody has to rediscover it: the
  CLI supports four auth types, and `gemini-api-key` (a key from `aistudio.google.com/apikey`, with
  `security.auth.selectedType` switched off `oauth-personal`) does not involve Code Assist at all.

## Scope

Prose only, in the two files that carried the previous maintenance marking. Sweeps continue unchanged
until v0.7.

- `.claude/skills/ir:agent-releases/SKILL.md`
- `.claude/skills/ir:agent-releases/references/monitoring-surface.md`

Deliberately **not** touched, as separate decisions rather than oversights:

- `replaydata/agents/adapters.json` — the capability model has no `deprecated` maturity state, and
  inventing one to carry a prose fact would put a claim somewhere `of validate` would then have to
  police.
- `site/docs/adapters.html` — a **user-facing** deprecation notice is a communications decision, not a
  bookkeeping one. Flagged for the maintainer rather than shipped here.
- The adapter code itself — it stays and keeps working until v0.7.

`tools/skill-lint.sh`: 23 files, 0 errors, 0 warnings.

Follows #1717.