### PR TITLE
docs(process): bounded-wait recipe, findings checkpointing, generalise the sourced-figure rule

### DIFF
--- a/.claude/skills/ir:exec/SKILL.md
+++ b/.claude/skills/ir:exec/SKILL.md
@@ -1039,3 +1039,31 @@ Phase 6.
   notification wakes a subagent from its own background job; the run stalls
   silently, indistinguishable from having finished. Block in the foreground
   instead, however slow.
+- **Driving an interactive CLI (a `tmux` pane, a chat REPL, anything a turn
+  would otherwise wait on) hits the same 600s watchdog as an unscoped
+  `preflight.sh` run, and loses more when it does** — the environment stays
+  live while the agent's own work in flight is gone. One Bash call per step:
+  issue the command and return; never send input and then wait on the same
+  call. Every wait is a bounded polling loop that always returns, e.g.
+  ```bash
+  for i in $(seq 1 10); do sleep 3; tmux -S <sock> capture-pane -p -t <sess> | tail -20; echo "--- poll $i ---"; done
+  ```
+  `timeout N` wraps anything that can hang, and a minified or multi-megabyte
+  bundle is never read whole — `timeout 60 grep -n -o -E
+  '.{200}<pattern>.{600}'` or `sed -n '<a>,<b>p'`, the same bounded-read shape
+  as chunking `preflight.sh` above. Tear down every spawned process before
+  ending a turn — a stall here doesn't just cost the turn, it leaves the
+  process running. (Real incident, #1726: five watchdog stalls plus one
+  API-error death in one session driving interactive CLIs for #1716/#1717 —
+  one stall left two orphaned CLI processes running ~20 minutes against the
+  account, another left 1526 lines uncommitted.)
+- **Findings that live only in an agent's context die with the turn, exactly
+  the way uncommitted code does.** For any multi-phase audit or
+  investigation, checkpoint findings to a scratchpad file as you go — append,
+  never rewrite, so a stall costs at most the last unwritten increment. It's
+  the same discipline `git commit -m wip` applies to code (never `git stash`,
+  whose stack is shared across worktrees — AGENTS.md's Process Rules), aimed
+  at notes instead of a working tree. (Real incident, #1726: three of the
+  five stalls above destroyed audit work that had to be re-derived from
+  scratch; once file-checkpointing was imposed, a fourth stall cost
+  nothing — a 23KB findings file survived and the agent resumed from it.)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,6 +113,28 @@ were added before they could catch anything and carry the weaker evidence that t
 it plants (below), and the harness built on #1390's lesson from the start, carrying a
 deliberate no-match row that must report `STALE` (#1450).
 
+**A figure that documents behaviour states the command that produces it, or it
+is marked as an estimate.** This is the counterpart to the rule above, from
+the other direction: that one is about a check going silently blind, this one
+is about a *number* silently drifting away from what it once measured — typed
+once, then repeated by hand until it no longer describes anything. First
+named for the replay tree's own catalog counts ("Replay's measured figures"
+below, where `knownFirstTransitionDrift` and `censusOfTheCommittedCatalog` are
+the machine-generated shape to copy), it is not scoped to replay and was
+violated twice in one day outside it (#1726). PR #1724's version-floor
+rationale claimed two source-read versions were *"seven months apart with
+zero drift"* — in `hookinstaller.go`, in `monitoring-surface.md`, and in the
+PR body — where `npm view @google/gemini-cli time` puts them **twelve days**
+apart (2026-08-07 to 2026-08-19); the error ran in the direction that
+overstates the evidence, since a
+twelve-day window is far weaker support for "byte-identical" than seven
+months. The review that caught it then wrote its own summary claiming
+subagents "stalled seven times"; the real count, from the transcript, is
+five. Neither figure had a command behind it — both were typed from memory
+under the same pressure the rule exists to catch. The fix is the same shape
+either way: derive the number in code and print the literal, or say in the
+same sentence that the figure is an estimate and how it was arrived at.
+
 **A fixture that waits by SLEEPING has not observed what it waits for, and the
 assertion after the sleep is not evidence that it has.** Poll the condition to a
 generous deadline and fail with the elapsed time: that turns "the machine was busy"
@@ -1570,10 +1592,11 @@ Before marking a ticket done, run the full suite — every layer must pass:
   figure beside the divergence figure, because a `go test` that passes prints
   nothing without `-v` and an unread measurement is the failure mode this
   closes.
-- Replay's measured figures: the counterpart rule to "a verification mechanism
-  must fail loudly when it cannot run" is that **a number which documents
-  behaviour but is not produced by it drifts silently, and is then quoted with
-  full confidence**. The replay tree carried one example of each outcome:
+- Replay's measured figures: the worked example for the general rule above —
+  "a figure that documents behaviour states the command that produces it, or
+  it is marked as an estimate," including the evidence it was violated
+  outside the replay tree (#1726) — rather than repeating either here. The
+  replay tree carried one example of each outcome:
   `knownFirstTransitionDrift` is machine-generated and stayed right across a
   change that reshaped the distribution it describes, while the
   `zero`/`fabricated`/`divergent` counts were typed by hand and went wrong twice
@@ -2408,7 +2431,12 @@ invocations it takes. **Do not background the unscoped run to make it fit**:
 a subagent is not woken by its own background job, so the run stalls silently
 with the work committed but never pushed
 (`.claude/skills/ir:exec/SKILL.md` Phase 4 step 11 has the incident and the
-same recipe). Chunking is still the recipe for a *manual* unscoped run;
+same recipe). The same shape recurs for any subagent driving an interactive
+process, not just preflight — one Bash call per step, every wait a bounded
+polling loop, `timeout N` on anything that can hang, and findings
+checkpointed to a file before they're used, so a stall costs a turn instead
+of the work — see the two bullets that skill's Notes section carries beside
+that same incident (#1726). Chunking is still the recipe for a *manual* unscoped run;
 `--budget` is what covers the `--changed` run the hook performs, and the two
 compose — `--only <group> --budget <n>` bounds one group.
 


### PR DESCRIPTION
Closes #1726

## Summary

Three cheap process fixes, all evidence gathered in #1726 from #1716/#1717's 2026-08-20 session — this PR is the fix, not a re-investigation.

1. **Bounded-wait recipe for driving interactive CLIs.** Five watchdog stalls plus one API-error death in one session, every one from a subagent blocking 600s on an interactive process. Documented the recipe that actually worked — one Bash call per step, every wait a bounded polling loop, `timeout N` on anything that can hang, never read a minified bundle whole, tear down spawned processes before ending a turn — as two new bullets in `.claude/skills/ir:exec/SKILL.md`'s Notes section, placed immediately beside the existing "don't background the unscoped preflight run" incident so the two read as one rule about work that nothing durable backs. Added a pointer from AGENTS.md's "Local CI parity" section, where the background-stall guidance already lived.
2. **Checkpoint findings to a file before using them.** Same section, same placement: three of the five stalls destroyed audit work that had to be re-derived; once file-checkpointing was imposed, the next stall cost nothing — a 23KB findings file survived and the agent resumed from it.
3. **Generalised "a figure nothing produces drifts" out of AGENTS.md's replay-specific section.** The rule ("Replay's measured figures") was stated as a fact about the replay tree and was violated twice in one day outside it: PR #1724's version-floor rationale claimed two source-read gemini-cli versions were *"seven months apart with zero drift"* where `npm view @google/gemini-cli time` puts them **twelve days** apart (2026-08-07 to 2026-08-19) — overstating the evidence — and the review that caught it then claimed subagents "stalled seven times" when the real count is five. Promoted the rule to a new general paragraph in AGENTS.md's Testing section (beside its sibling "A verification mechanism must fail loudly when it cannot run"), carrying both new violations as evidence it binds generally. The replay-specific bullet keeps every one of its specifics — `knownFirstTransitionDrift`, `censusOfTheCommittedCatalog`, the #1478/#1503 incident — untouched, and now opens by pointing up at the general rule as its worked example instead of restating it.

## The optional lint (item 3) — assessed, not built

Measured rather than guessed, per the ticket's instruction: a same-line heuristic (a spelled-out number word 1–20/dozen adjacent to a time/count unit, suppressed by a same-line `#issue` reference, backtick span, or hedge word) run over the full 23-file tracked skill corpus (`git ls-files -- '.claude/skills/*.md' '*/SKILL.md' 'SKILL.md'` minus `testdata/`) produces **1 raw candidate, 0 flagged** — the one hit (`ir:test-mac/SKILL.md:337`, "it had already happened three times") is correctly suppressed by a same-line `#1449` citation.

That is very low noise on today's snapshot, but not enough to ship on:
- n=1 is too small a sample to trust same-line proximity generally. This repo's prose wraps at ~80 cols, so a claim and its citation routinely land 2–4 physical lines apart within one sentence (`ir:release/SKILL.md` alone carries 22 `#NNN` citations in dense wrapped prose) — the one real hit passing was a short sentence, not evidence the approach generalises.
- No true-positive fixture exists in the real corpus to validate recall against — by definition, no currently-tracked skill file contains a known-unsourced figure (if one did, it would be a bug to fix, not evidence the check works).
- A version robust to wrapped-paragraph citations needs window/paragraph-scoped reference tracking, comparable in complexity to `skill-lint.sh`'s own `ref-direction` heuristic, which the file's header already documents as carrying "a real false-positive rate."

**Recommendation: ship the documented rule alone; do not add a skill-lint check.** This is a legitimate outcome per the ticket ("a noisy warning everyone learns to ignore is worse than no warning") and per the honest low-confidence read of the one real data point available.

## What owes mutation evidence and what doesn't

Per AGENTS.md's Testing section: **everything in this PR is pure prose** (two `.md` files, no code, no new mechanical check). No mutation evidence is owed and none is claimed. `tools/` was not touched.

## Test plan

- [x] `tools/skill-lint.sh --strict` over the full corpus — 23 files, 0 errors, 0 warnings
- [x] `tools/preflight.sh --only skills` (foreground) — PASS
- [x] Pre-push hook's `tools/preflight.sh --changed` ran clean on push (skill-file lint PASS, gofmt PASS, everything else correctly SKIP — diff touches only `AGENTS.md` and one `SKILL.md`)
- [x] Manually re-read both edited sections in context to confirm no other AGENTS.md bullet's reference to "Replay's measured figures" (the "Probe costs in doc comments" and "macOS app" bullets) went stale — both still resolve correctly since the bullet's label was kept

🤖 Generated with [Claude Code](https://claude.com/claude-code)