### PR TITLE
feat(agent): let a managed-user-file permission declare a second file it writes

### DIFF
--- a/core/adapters/inbound/agents/managedfiles.go
+++ b/core/adapters/inbound/agents/managedfiles.go
@@ -17,8 +17,20 @@ type ManagedUserFile struct {
 	Key string
 	// Path is the resolved, absolute file the permission writes.
 	Path string
-	// Uninstall removes irrlicht's content from Path, reporting whether it
-	// modified anything.
+	// Also holds the resolved, absolute paths of every additional file the
+	// SAME permission's Apply closure writes (agent.ManagedUserFile.Also,
+	// #1718) — empty for the eight declarations that predate that field. It is
+	// resolved with the same rigor as Path (non-nil, resolves without error,
+	// absolute), because the two consumers that read it need completeness for
+	// the identical reason they need it of Path: #1449's grant-all refusal must
+	// see every file an Apply can write, not just the first, and the
+	// recorder's backup/restore sweep (ManagedUserFiles) would otherwise hand
+	// a file that was never snapshotted back to the user unrestored.
+	Also []string
+	// Uninstall removes irrlicht's content from Path (and, for a permission
+	// declaring Also, from every one of those files too — that is the
+	// closure's own job, not something this projection orchestrates),
+	// reporting whether it modified anything.
 	Uninstall func() (bool, error)
 }
 
@@ -93,10 +105,29 @@ func collectManagedFiles(catalog []agent.Agent, want func(key string) bool) ([]M
 			if !filepath.IsAbs(path) {
 				return nil, fmt.Errorf("adapter %q permission %q: managed file path %q is not absolute", a.Identity.Name, p.Key, path)
 			}
+			// Also gets the identical rigor as Path (#1718), over the SAME
+			// selected permission — this is not resolving another key's
+			// declaration, so it does not weaken the narrowed-projection rule
+			// collectManagedFiles otherwise upholds (see configsForKey's doc).
+			also := make([]string, 0, len(p.Writes.Also))
+			for i, resolveAlso := range p.Writes.Also {
+				if resolveAlso == nil {
+					return nil, fmt.Errorf("adapter %q permission %q: ManagedUserFile.Also[%d] is a nil resolver", a.Identity.Name, p.Key, i)
+				}
+				aPath, err := resolveAlso()
+				if err != nil {
+					return nil, fmt.Errorf("adapter %q permission %q: resolve managed file Also[%d]: %w", a.Identity.Name, p.Key, i, err)
+				}
+				if !filepath.IsAbs(aPath) {
+					return nil, fmt.Errorf("adapter %q permission %q: managed file Also[%d] path %q is not absolute", a.Identity.Name, p.Key, i, aPath)
+				}
+				also = append(also, aPath)
+			}
 			out = append(out, ManagedUserFile{
 				Adapter:   a.Identity.Name,
 				Key:       p.Key,
 				Path:      path,
+				Also:      also,
 				Uninstall: p.Writes.Uninstall,
 			})
 		}

--- a/core/adapters/inbound/agents/managedfiles_test.go
+++ b/core/adapters/inbound/agents/managedfiles_test.go
@@ -202,6 +202,125 @@ func TestManagedUserFilesIgnoresPermissionsThatDeclareNoFile(t *testing.T) {
 	}
 }
 
+// TestManagedUserFilesResolvesAlso is the #1718 widening's defect test:
+// ManagedUserFiles must carry every Also file, resolved to an absolute path,
+// alongside Path — not just Path. It is a defect test rather than a contract
+// test because collectManagedFiles is the ONE function every projection
+// shares, so dropping the resolution there is a single missed loop rather
+// than something that could pass by construction.
+func TestManagedUserFilesResolvesAlso(t *testing.T) {
+	path := func(p string) func() (string, error) {
+		return func() (string, error) { return p, nil }
+	}
+	catalog := []agent.Agent{
+		writerAdapter("mistral-vibe", agent.HooksPermissionKey, &agent.ManagedUserFile{
+			Path:      path("/tmp/vibe/.vibe/hooks.toml"),
+			Also:      []func() (string, error){path("/tmp/vibe/.vibe/config.toml")},
+			Uninstall: func() (bool, error) { return false, nil },
+		}),
+	}
+
+	got, err := ManagedUserFiles(catalog)
+	if err != nil {
+		t.Fatalf("ManagedUserFiles(): %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("ManagedUserFiles() = %v, want exactly one entry", got)
+	}
+	if want := []string{"/tmp/vibe/.vibe/config.toml"}; len(got[0].Also) != 1 || got[0].Also[0] != want[0] {
+		t.Errorf("Also = %v, want %v — the recorder cannot back up a file this projection does not name", got[0].Also, want)
+	}
+}
+
+// TestManagedUserFilesRejectsUnusableAlsoDeclarations mirrors
+// TestManagedUserFilesRejectsUnusableDeclarations for the Also field: a nil
+// resolver, one that errors, or one that resolves to a relative path must be
+// an error from the FULL projection — the same rigor Path already gets,
+// because a silently-dropped Also file is invisible to both
+// --print-managed-files and the recorder in exactly the shape #1449 is about.
+func TestManagedUserFilesRejectsUnusableAlsoDeclarations(t *testing.T) {
+	path := func(p string) func() (string, error) {
+		return func() (string, error) { return p, nil }
+	}
+	uninstall := func() (bool, error) { return false, nil }
+
+	cases := []struct {
+		name string
+		also []func() (string, error)
+		want string
+	}{
+		{"nil Also resolver", []func() (string, error){nil}, "Also[0]"},
+		{"Also resolve fails", []func() (string, error){
+			func() (string, error) { return "", errors.New("no vibe home") },
+		}, "no vibe home"},
+		{"Also relative path", []func() (string, error){path("config.toml")}, "not absolute"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			catalog := []agent.Agent{writerAdapter("mistral-vibe", agent.HooksPermissionKey, &agent.ManagedUserFile{
+				Path:      path("/tmp/vibe/.vibe/hooks.toml"),
+				Also:      tc.also,
+				Uninstall: uninstall,
+			})}
+			got, err := ManagedUserFiles(catalog)
+			if err == nil {
+				t.Fatalf("ManagedUserFiles() = %v, want an error naming %q", got, tc.want)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("error %q does not name %q", err, tc.want)
+			}
+		})
+	}
+}
+
+// TestNarrowedProjectionsSurviveABrokenAlsoDeclarationOnAnotherKey is
+// TestNarrowedProjectionsSurviveABrokenDeclarationOnAnotherKey's Also
+// counterpart (#1718): a narrowed projection must not resolve — and so must
+// not be able to fail on — an Also entry belonging to a permission outside its
+// own narrowing, any more than it may fail on that permission's Path.
+//
+// A LOCK, not a defect test: collectManagedFiles resolves Path and Also inside
+// the SAME `want(p.Key)`-filtered loop iteration (see the code), so there is no
+// separate ordering to get wrong — Also's narrow-before-resolve property is
+// structurally inherited from Path's, not a second mechanism that could drift
+// from it. Written anyway because AGENTS.md treats that order as a rule, not
+// an optimization, and a rule earns a test that would catch someone splitting
+// Also's resolution into its own pass later.
+func TestNarrowedProjectionsSurviveABrokenAlsoDeclarationOnAnotherKey(t *testing.T) {
+	path := func(p string) func() (string, error) {
+		return func() (string, error) { return p, nil }
+	}
+	uninstall := func() (bool, error) { return false, nil }
+	brokenAlso := &agent.ManagedUserFile{
+		Path:      path("/tmp/kitty/kitty.conf"),
+		Also:      []func() (string, error){func() (string, error) { return "relative/also.toml", nil }},
+		Uninstall: uninstall,
+	}
+	good := &agent.ManagedUserFile{
+		Path:      path("/tmp/x/CLAUDE.md"),
+		Uninstall: uninstall,
+	}
+	catalog := []agent.Agent{
+		writerAdapter("kitty", "remote-control", brokenAlso),
+		writerAdapter("alpha", agent.InstructionsPermissionKey, good),
+	}
+
+	got, err := InstructionConfigs(catalog)
+	if err != nil {
+		t.Fatalf("InstructionConfigs() failed on a broken Also declaration it does not collect: %v — "+
+			"--uninstall-task-eta would abort without removing anything from the user's CLAUDE.md", err)
+	}
+	if len(got) != 1 || got[0].Adapter != "alpha" {
+		t.Fatalf("InstructionConfigs() = %v, want exactly alpha/instructions", got)
+	}
+
+	// The full projection must still refuse it, the same as for a broken Path.
+	if _, err := ManagedUserFiles(catalog); err == nil {
+		t.Error("ManagedUserFiles() accepted a broken Also declaration — the recorder would read a short list as success")
+	}
+}
+
 // TestHookConfigsIsTheHooksSliceOfManagedUserFiles pins the narrowing
 // `--uninstall-hooks` depends on (#1383). Widening the declaration must not
 // widen what that command touches: it removes hook entries and records the

--- a/core/application/services/permission_shared_config_gate.go
+++ b/core/application/services/permission_shared_config_gate.go
@@ -59,21 +59,45 @@ func (s *PermissionService) sharedConfigRefusal(p agent.Permission) error {
 	if s.allowSharedConfigWrites {
 		return nil
 	}
-	// A nil resolver is a malformed declaration, not a permission that writes
-	// nothing — that shape is Writes == nil above. Same direction as an erroring
-	// resolver: a file we cannot name is not one we can call safe. Unreachable
-	// in a CI-green tree (agents.ManagedUserFiles rejects it), but the guard's
-	// correctness must not rest on a test in another package.
-	if p.Writes.Path == nil {
-		return fmt.Errorf("refusing to run %s's install in IRRLICHT_PERMISSION_MODE=grant-all: "+
-			"it declares a managed user file with no Path resolver", p.Key)
+	// Path plus every Also entry (#1718): a single Apply closure that writes
+	// two files is only safe under grant-all when BOTH resolve inside the
+	// isolated home. Checking Path alone would wave an Apply through whose
+	// SECOND file lands in the user's real config — invisible to this guard in
+	// exactly the way an undeclared write always is, which is the incident
+	// #1449 exists to prevent. Path is checked first so its error message (the
+	// one every existing test pins) is unchanged when Also is empty.
+	if err := s.refuseIfOutsideIsolatedHome(p.Key, "Path", p.Writes.Path); err != nil {
+		return err
 	}
-	path, err := p.Writes.Path()
+	for i, also := range p.Writes.Also {
+		if err := s.refuseIfOutsideIsolatedHome(p.Key, fmt.Sprintf("Also[%d]", i), also); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// refuseIfOutsideIsolatedHome resolves one file a permission's Apply writes
+// and refuses if it is unresolvable or lands outside the daemon's isolated
+// home. label names which resolver failed (e.g. "Path", "Also[0]") so a
+// multi-file permission's refusal says which of its files is the problem
+// rather than leaving the reader to guess.
+func (s *PermissionService) refuseIfOutsideIsolatedHome(key, label string, resolve func() (string, error)) error {
+	// A nil resolver is a malformed declaration, not a permission that writes
+	// nothing — that shape is Writes == nil in the caller. Same direction as an
+	// erroring resolver: a file we cannot name is not one we can call safe.
+	// Unreachable in a CI-green tree (agents.ManagedUserFiles rejects it), but
+	// the guard's correctness must not rest on a test in another package.
+	if resolve == nil {
+		return fmt.Errorf("refusing to run %s's install in IRRLICHT_PERMISSION_MODE=grant-all: "+
+			"it declares a managed user file with no %s resolver", key, label)
+	}
+	path, err := resolve()
 	if err != nil {
 		// Fail closed. An unresolvable path is not a licence to write: we cannot
 		// name the file, so we certainly cannot say it is safe to modify.
 		return fmt.Errorf("refusing to write %s's shared config in IRRLICHT_PERMISSION_MODE=grant-all: "+
-			"cannot resolve which file it writes (%v)", p.Key, err)
+			"cannot resolve which file it writes (%s: %v)", key, label, err)
 	}
 	if s.isolatedHome != "" && pathInsideRoot(s.isolatedHome, path) {
 		return nil

--- a/core/application/services/permission_shared_config_gate_test.go
+++ b/core/application/services/permission_shared_config_gate_test.go
@@ -177,6 +177,87 @@ func TestSharedConfigGate_PermissionWritingNothingIsNeverGated(t *testing.T) {
 	}
 }
 
+// writingPermissionWithAlso is writingPermission plus one or more Also files
+// (#1718) — the shape mistral-vibe's hooks permission needs: one Apply closure
+// writing hooks.toml (Path) and the enable_experimental_hooks flag in a
+// separate config.toml (Also).
+func writingPermissionWithAlso(path string, also []string, applied *bool) agent.Permission {
+	p := writingPermission(path, applied)
+	for _, a := range also {
+		aPath := a
+		p.Writes.Also = append(p.Writes.Also, func() (string, error) { return aPath, nil })
+	}
+	return p
+}
+
+// TestSharedConfigGate_RefusesWhenAlsoResolvesOutsideTheIsolatedHome is the
+// #1718 widening's defect test: a permission whose Path is safely inside the
+// isolated home but whose Also file is the user's REAL config must still be
+// refused. Checking Path alone would let exactly this Apply run — writing
+// hooks.toml into the recorder's sandbox while the SAME closure flips
+// enable_experimental_hooks in the user's real ~/.vibe/config.toml, unprotected
+// and unrestored, which is #1449's incident one file over.
+func TestSharedConfigGate_RefusesWhenAlsoResolvesOutsideTheIsolatedHome(t *testing.T) {
+	applied := false
+	sandbox := "/tmp/irr-sandbox"
+	safePath := filepath.Join(sandbox, ".vibe", "hooks.toml")
+	realAlso := filepath.Join("/Users/someone", ".vibe", "config.toml")
+	svc, log := sharedConfigService(config.PermissionModeGrantAll, sandbox, false)
+
+	grant(svc, writingPermissionWithAlso(safePath, []string{realAlso}, &applied))
+
+	if applied {
+		t.Error("Apply ran although its Also file resolves outside the isolated home — " +
+			"a grant-all daemon would write enable_experimental_hooks into the user's real config.toml")
+	}
+	if !log.errorMentioning(realAlso) {
+		t.Errorf("the refusal did not name the Also file it refused; errors were %v", log.errors)
+	}
+}
+
+// TestSharedConfigGate_AllowsWhenPathAndAlsoAreBothInsideTheIsolatedHome is the
+// vacuity guard for the test above: a permission declaring Also is not refused
+// merely for declaring it — only when one of its files actually lands outside
+// the isolated home.
+func TestSharedConfigGate_AllowsWhenPathAndAlsoAreBothInsideTheIsolatedHome(t *testing.T) {
+	applied := false
+	sandbox := "/tmp/irr-sandbox"
+	svc, log := sharedConfigService(config.PermissionModeGrantAll, sandbox, false)
+
+	grant(svc, writingPermissionWithAlso(
+		filepath.Join(sandbox, ".vibe", "hooks.toml"),
+		[]string{filepath.Join(sandbox, ".vibe", "config.toml")},
+		&applied))
+
+	if !applied {
+		t.Errorf("Apply was refused although Path and Also both resolve inside the isolated home %s; errors were %v",
+			sandbox, log.errors)
+	}
+}
+
+// TestSharedConfigGate_UnresolvableAlsoFailsClosed mirrors
+// TestSharedConfigGate_UnresolvablePathFailsClosed for the second file: an Also
+// resolver that errors must refuse just as an unresolvable Path does, naming
+// which entry (Also[0]) failed.
+func TestSharedConfigGate_UnresolvableAlsoFailsClosed(t *testing.T) {
+	applied := false
+	sandbox := "/tmp/irr-sandbox"
+	svc, log := sharedConfigService(config.PermissionModeGrantAll, sandbox, false)
+	p := writingPermission(filepath.Join(sandbox, ".vibe", "hooks.toml"), &applied)
+	p.Writes.Also = []func() (string, error){
+		func() (string, error) { return "", errors.New("no vibe home") },
+	}
+
+	grant(svc, p)
+
+	if applied {
+		t.Error("Apply ran although its Also[0] resolver could not resolve a path")
+	}
+	if !log.errorMentioning("no vibe home") || !log.errorMentioning("Also[0]") {
+		t.Errorf("the refusal did not carry the resolution failure and the failing entry's label; errors were %v", log.errors)
+	}
+}
+
 // TestSharedConfigGate_RelativeRootRefuses pins the one comparison detail that
 // could silently invert the guard: pathInsideRoot only ever answers true for a
 // pair of absolute paths, so a root that arrives relative (or empty) refuses

--- a/core/cmd/irrlichd/main.go
+++ b/core/cmd/irrlichd/main.go
@@ -423,7 +423,13 @@ func printManagedFiles(w io.Writer) error {
 	return nil
 }
 
-// writeManagedFilePaths prints each distinct path once. The dedup is
+// writeManagedFilePaths prints each distinct path once, flattening every
+// entry's Path AND its Also files (#1718) onto the same one-line-per-file
+// stream: the rig's managed_file_paths() backs up and restores whatever this
+// prints, one file per line, with no notion of "these two lines are one
+// permission" — an Also file left out of this flatten would never be
+// snapshotted before grant-all can write it and never restored after, exactly
+// the gap #1449's guard exists to keep from being silent. The dedup is
 // load-bearing rather than cosmetic: the rig keys its backups by line index, so
 // a path listed twice would be backed up under two indices and restored twice.
 // Since #1383 the shipped catalog actually produces a duplicate — claudecode's
@@ -431,12 +437,18 @@ func printManagedFiles(w io.Writer) error {
 // this is exercised by the real registry rather than only by a synthetic case.
 func writeManagedFilePaths(w io.Writer, configs []agents.ManagedUserFile) {
 	seen := make(map[string]bool, len(configs))
-	for _, c := range configs {
-		if seen[c.Path] {
-			continue
+	print := func(path string) {
+		if seen[path] {
+			return
 		}
-		seen[c.Path] = true
-		fmt.Fprintln(w, c.Path)
+		seen[path] = true
+		fmt.Fprintln(w, path)
+	}
+	for _, c := range configs {
+		print(c.Path)
+		for _, also := range c.Also {
+			print(also)
+		}
 	}
 }
 

--- a/core/cmd/irrlichd/managedfiles_test.go
+++ b/core/cmd/irrlichd/managedfiles_test.go
@@ -183,6 +183,32 @@ func TestWriteManagedFilePathsDeduplicates(t *testing.T) {
 	}
 }
 
+// TestWriteManagedFilePathsFlattensAlso is the #1718 widening's defect test:
+// the rig's managed_file_paths() backs up and restores one file per printed
+// line, with no notion that two lines belong to the same permission — so an
+// Also file that is not flattened onto this stream is never snapshotted
+// before a grant-all daemon can write it and never restored after (#1449's
+// gap one layer up). Also entries are deduplicated against Path and against
+// each other exactly like Path is.
+func TestWriteManagedFilePathsFlattensAlso(t *testing.T) {
+	var buf bytes.Buffer
+	writeManagedFilePaths(&buf, []agents.ManagedUserFile{
+		{Adapter: "mistral-vibe", Key: "hooks", Path: "/tmp/vibe/.vibe/hooks.toml",
+			Also: []string{"/tmp/vibe/.vibe/config.toml"}},
+		{Adapter: "alpha", Key: "hooks", Path: "/tmp/alpha/settings.json"},
+	})
+	got := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	want := []string{"/tmp/vibe/.vibe/hooks.toml", "/tmp/vibe/.vibe/config.toml", "/tmp/alpha/settings.json"}
+	if len(got) != len(want) {
+		t.Fatalf("printed %q, want %q — an Also file the recorder never learns about is never backed up", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("line %d = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
 // TestUninstallHookConfigsSurvivesOneFailingAdapter pins the fix for a failure
 // that used to end the whole command: hookjson refuses to rewrite a config it
 // cannot parse, so a single hand-edited ~/.claude/settings.json aborted the

--- a/core/domain/agent/declaration.go
+++ b/core/domain/agent/declaration.go
@@ -199,6 +199,32 @@ type ManagedUserFile struct {
 	// CLAUDE.md instruction blocks, the kitty remote-control block — depend on
 	// no upstream CLI feature and leave it nil.
 	Version *VersionGate
+
+	// Also resolves zero or more ADDITIONAL shared, user-owned files this
+	// permission's single Apply closure writes, beyond Path (issue #1718).
+	//
+	// Path stays what every existing narrowed projection (agents.HookConfigs,
+	// `--uninstall-hooks`) means by "the file this permission writes" — adding
+	// this field changes that meaning for nobody, and all eight declaration
+	// sites that existed before it compile and behave unchanged with it left
+	// nil. It exists because mistral-vibe's hooks install is the first whose
+	// Apply genuinely spans two files: the hook entries themselves
+	// ($VIBE_HOME/hooks.toml) and a separate boolean gate
+	// (enable_experimental_hooks in $VIBE_HOME/config.toml) that must also be
+	// true or the entries are never read. Neither #1449's grant-all refusal nor
+	// the recorder's full backup/restore sweep (agents.ManagedUserFiles) can see
+	// a write this field does not name — an undeclared secondary write is
+	// invisible to both, which is the exact shape of the incident #1449 exists
+	// to prevent, so both MUST resolve every entry here with the same rigor as
+	// Path (core/application/services/permission_shared_config_gate.go,
+	// core/adapters/inbound/agents/managedfiles.go).
+	//
+	// Deliberately not folded into Path becoming a slice: Path is read by name
+	// in enough places (log lines, the narrowed uninstall commands' per-file
+	// reporting) that widening its type would touch every one of them for a
+	// property only two adapters need. An adapter with a second file appends
+	// one resolver here instead.
+	Also []func() (string, error)
 }
 
 // HookEntryStatus is one read-only look at an install (issue #1372): which of


### PR DESCRIPTION
## Summary

Shared-type change only — **no adapter uses this yet**. The mistral-vibe adapter
(#1718) follows in a separate PR on top of this once it merges.

`agent.ManagedUserFile.Path` is singular, and every one of the eight existing
declarations (claudecode ×3, codex, copilot, geminicli, kitty) only ever needed
one file. mistral-vibe's hooks install (#1718) is the first whose single `Apply`
closure needs to write **two**: the hook entries themselves
(`$VIBE_HOME/hooks.toml`) and a separate boolean gate
(`enable_experimental_hooks` in `$VIBE_HOME/config.toml`) that must also be
`true` or the CLI never reads the entries.

This adds `Also []func() (string, error)` — additive, not a change to `Path`'s
type — and widens the two consumers that must see every file an `Apply` can
write, or an undeclared secondary write is invisible to both in exactly the
shape #1449's incident was:

- `PermissionService.sharedConfigRefusal` (#1449's grant-all guard) now refuses
  when **either** `Path` or any `Also` entry resolves outside the daemon's
  isolated home.
- `agents.ManagedUserFiles` (the recorder's full backup/restore projection) now
  resolves and carries every `Also` entry with the same rigor as `Path`
  (non-nil, resolves without error, absolute). `writeManagedFilePaths` flattens
  `Path` + `Also` onto the one-line-per-file stream the recording rig's
  `managed_file_paths()` backs up and restores from — it has no notion that two
  lines belong to one permission.

## What does NOT change

- `Writes.Path` stays the file every existing narrowed projection means by "the
  file this permission writes." `agents.HookConfigs` still narrows to it, and
  `--uninstall-hooks` still means the hooks file alone.
- `configsForKey`'s narrow-before-resolve order (AGENTS.md: a rule, not an
  optimization) is preserved by construction — `Also` is resolved inside the
  SAME `want(p.Key)`-filtered loop iteration as `Path`, so there is no second
  ordering to get wrong. Pinned as a lock:
  `TestNarrowedProjectionsSurviveABrokenAlsoDeclarationOnAnotherKey`.
- `hook_reverify.go:319-326` and `paths.go:234` were checked and need no
  change. `hook_reverify.go` only reads `Writes.Path` for a best-effort log
  line — the actual re-verification runs through the adapter's own `Verify`
  closure, which is free to check whatever files it needs internally.
  `paths.go`'s `hookAdapterNames` only tests `Writes != nil` to decide whether
  an adapter earns a hook-liveness diagnostics row; it does not care which or
  how many files `Writes` names.

## Known weakness of landing this alone

No adapter declares `Also` yet, so the only thing exercising the new path is
the test suite added here. The behavior is real (verified below with red-first
mutations against synthetic declarations), but it has no live consumer until
the mistral-vibe PR lands on top. Splitting it out was the coordinator's call
per #1718's own ~200-line guidance (this PR is 334 lines) — flagging the
tradeoff explicitly rather than let a reviewer find it.

## Red-first mutation evidence

Three obligations, one mutation each, applied and reverted (each in its own
foreground command; full failure output below).

**1. `sharedConfigRefusal` must refuse when the SECONDARY file is outside the isolated home, not only Path.**

Mutation: drop the `Also` loop, checking only `Path`.

```
=== RUN   TestSharedConfigGate_RefusesWhenAlsoResolvesOutsideTheIsolatedHome
    permission_shared_config_gate_test.go:210: Apply ran although its Also file resolves outside the isolated home — a grant-all daemon would write enable_experimental_hooks into the user's real config.toml
    permission_shared_config_gate_test.go:214: the refusal did not name the Also file it refused; errors were []
--- FAIL: TestSharedConfigGate_RefusesWhenAlsoResolvesOutsideTheIsolatedHome (0.00s)
=== RUN   TestSharedConfigGate_AllowsWhenPathAndAlsoAreBothInsideTheIsolatedHome
--- PASS: TestSharedConfigGate_AllowsWhenPathAndAlsoAreBothInsideTheIsolatedHome (0.00s)
=== RUN   TestSharedConfigGate_UnresolvableAlsoFailsClosed
    permission_shared_config_gate_test.go:254: Apply ran although its Also[0] resolver could not resolve a path
    permission_shared_config_gate_test.go:257: the refusal did not carry the resolution failure and the failing entry's label; errors were []
--- FAIL: TestSharedConfigGate_UnresolvableAlsoFailsClosed (0.00s)
```

The vacuity guard (`AllowsWhenPathAndAlsoAreBothInsideTheIsolatedHome`) stays
green under the mutation, as it must — it isn't testing the removed code path.
Every pre-existing gate test also stayed green (Path's own arm is untouched by
this mutation). Reverted; full gate suite green again.

**2. The recorder projection `agents.ManagedUserFiles` must resolve and carry every Also entry.**

Mutation: replace the `Also` resolution loop with `var also []string` (never populated).

```
=== RUN   TestManagedUserFilesResolvesAlso
    managedfiles_test.go:231: Also = [], want [/tmp/vibe/.vibe/config.toml] — the recorder cannot back up a file this projection does not name
--- FAIL: TestManagedUserFilesResolvesAlso (0.00s)
=== RUN   TestManagedUserFilesRejectsUnusableAlsoDeclarations
=== RUN   TestManagedUserFilesRejectsUnusableAlsoDeclarations/nil_Also_resolver
    managedfiles_test.go:268: ManagedUserFiles() = [{mistral-vibe hooks /tmp/vibe/.vibe/hooks.toml [] 0x104aeb880}], want an error naming "Also[0]"
=== RUN   TestManagedUserFilesRejectsUnusableAlsoDeclarations/Also_resolve_fails
    managedfiles_test.go:268: ManagedUserFiles() = [...], want an error naming "no vibe home"
=== RUN   TestManagedUserFilesRejectsUnusableAlsoDeclarations/Also_relative_path
    managedfiles_test.go:268: ManagedUserFiles() = [...], want an error naming "not absolute"
--- FAIL: TestManagedUserFilesRejectsUnusableAlsoDeclarations (0.00s)
```

All four new arms go red; `TestHookConfigsIsTheHooksSliceOfManagedUserFiles` and
every other existing test in the package stayed green. Reverted; green again.

**3. `writeManagedFilePaths` must flatten `Also` onto the printed stream.**

Mutation: drop the inner `for _, also := range c.Also { print(also) }` loop.

```
=== RUN   TestWriteManagedFilePathsDeduplicates
--- PASS: TestWriteManagedFilePathsDeduplicates (0.00s)
=== RUN   TestWriteManagedFilePathsFlattensAlso
    managedfiles_test.go:203: printed ["/tmp/vibe/.vibe/hooks.toml" "/tmp/alpha/settings.json"], want ["/tmp/vibe/.vibe/hooks.toml" "/tmp/vibe/.vibe/config.toml" "/tmp/alpha/settings.json"] — an Also file the recorder never learns about is never backed up
--- FAIL: TestWriteManagedFilePathsFlattensAlso (0.00s)
```

`TestWriteManagedFilePathsDeduplicates` (Path-only) stays green, confirming the
mutation is scoped to the new behavior. Reverted; green again.

## Test plan

- [x] `go build ./core/...`
- [x] `go test ./core/... -race -count=1` — all green (foreground, full run)
- [x] `tools/preflight.sh --only go` — PASS
- [x] `tools/preflight.sh --only arch` — PASS (composite 7.9272 → 7.9271, no regression)
- [x] `tools/preflight.sh --only tools` — PASS
- [x] `tools/preflight.sh --only skills` — PASS
- [x] `tools/preflight.sh --only posix` — PASS
- [x] `tools/preflight.sh --only security` — PASS (pre-existing informational-only findings elsewhere in the tree, no High/High, none introduced by this diff)
- [x] Every new obligation carries red-first mutation evidence (above)
- [x] Pre-push hook (`preflight.sh --changed`) passed on push

Part of #1718 / #1355.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
