### PR TITLE
feat(vibe): hook-based turn-done detection (post_agent_turn only)

### DIFF
--- a/core/adapters/inbound/agents/hooktoml/hooktoml.go
+++ b/core/adapters/inbound/agents/hooktoml/hooktoml.go
@@ -1,0 +1,614 @@
+// Package hooktoml implements comment-preserving read-modify-write for a
+// narrow, purpose-built pair of TOML edits: appending/upgrading/removing ONE
+// sentinel-tagged [[hooks]] array-of-tables entry, and setting/clearing ONE
+// top-level boolean scalar. It is hookjson's sibling for TOML (issue #1718),
+// not a general TOML merge engine.
+//
+// mistral-vibe's hooks.toml holds exactly one hook entry this daemon
+// installs (post_agent_turn), and its config.toml's enable_experimental_hooks
+// is exactly one boolean gate the entry cannot fire without — so a general
+// nested-structure differ (hookjson's shape, built for Claude Code's
+// event -> matcher-group -> entry nesting shared by claudecode/codex/
+// gemini-cli) would be solving a problem this adapter does not have. Per
+// AGENTS.md's rule ("code that emits bytes from a structural diff gets a
+// property test"), this package earns the same property-test treatment
+// hookjson's splicer does (property_test.go), scoped to the two structural
+// axes it actually varies: appending/upgrading/removing a sentinel-tagged
+// array-of-tables block, and setting/clearing a sentinel-free top-level
+// scalar.
+//
+// The strategy mirrors hookjson's: never re-serialize what did not change.
+// Both operations work as byte-range edits over the ORIGINAL file, computed
+// by a purpose-built line-oriented scanner rather than a general TOML
+// parser — core/go.mod carries no TOML dependency and none is added here.
+// A read-modify-marshal through a generic TOML encoder is exactly the
+// "cost of this ticket" #1718 exists to avoid: it would delete the user's
+// comments the same way json.MarshalIndent over a bare map did before
+// hookjson existed.
+//
+// Anything the scanner cannot confidently classify — a triple-quoted
+// string, a multi-line array, an unterminated single-line string — makes it
+// refuse the WHOLE document rather than guess. Unlike hookjson, which falls
+// back to a lossy whole-document re-encode when a splice is not safe, there
+// is no safe fallback encoder here: a generic map[string]interface{}-style
+// TOML dump is precisely the read-modify-marshal this package exists to
+// avoid, so it is never reached for as a fallback. "Cannot splice safely"
+// therefore means "do not write," not "write something worse" — refusing an
+// install into an exotic hand-crafted hooks.toml is the safe direction; a
+// corrupted one is not.
+package hooktoml
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"os"
+	"strings"
+)
+
+// ErrUnsafe means this document contains a construct the line-oriented
+// scanner does not model with confidence — a triple-quoted string, an
+// unterminated single-line string, or a multi-line array. The caller must
+// not write; there is no lossy fallback (see the package doc).
+var ErrUnsafe = errors.New("hooktoml: file contains a construct this splicer does not model safely (multi-line string, multi-line array, or unterminated quote) — refusing rather than guessing")
+
+// --- line-level scanning primitives ---
+
+// lineSafety scans one line (no embedded '\n'), respecting single-line basic
+// ("...") and literal ('...') strings, and reports the comment-stripped
+// content plus whether the line looks like it continues onto the next one —
+// an unterminated quote (the start of some multi-line construct this
+// scanner does not model) or an unbalanced '['/']' count outside strings
+// (a multi-line array). continues is the signal every caller in this
+// package refuses on rather than guesses through.
+func lineSafety(line []byte) (stripped []byte, continues bool) {
+	inBasic, inLiteral := false, false
+	depth := 0
+	commentAt := -1
+loop:
+	for i := 0; i < len(line); i++ {
+		c := line[i]
+		switch {
+		case inBasic:
+			if c == '\\' {
+				i++ // skip the escaped character too
+				continue
+			}
+			if c == '"' {
+				inBasic = false
+			}
+		case inLiteral:
+			if c == '\'' {
+				inLiteral = false
+			}
+		default:
+			switch c {
+			case '"':
+				inBasic = true
+			case '\'':
+				inLiteral = true
+			case '#':
+				commentAt = i
+				break loop
+			case '[':
+				depth++
+			case ']':
+				depth--
+			}
+		}
+	}
+	if commentAt >= 0 {
+		stripped = line[:commentAt]
+	} else {
+		stripped = line
+	}
+	return stripped, inBasic || inLiteral || depth != 0
+}
+
+func isArrayHeaderLine(t []byte) bool {
+	return len(t) >= 4 && bytes.HasPrefix(t, []byte("[[")) && bytes.HasSuffix(t, []byte("]]"))
+}
+
+func isTableHeaderLine(t []byte) bool {
+	return len(t) >= 2 && bytes.HasPrefix(t, []byte("[")) && !bytes.HasPrefix(t, []byte("[[")) &&
+		bytes.HasSuffix(t, []byte("]")) && !bytes.HasSuffix(t, []byte("]]"))
+}
+
+// --- section scanning (used by the array-of-tables operations) ---
+
+// section is one top-level element of a TOML document: the preamble (kind 0,
+// everything before the first header), a [table] header block (kind 1), or
+// an [[array-of-tables]] header block (kind 2). start is the byte offset of
+// the header's own line (0 for the preamble); end is the offset of the next
+// header's line, or len(src) — so every byte of the document belongs to
+// exactly one section, header line included, up to (not including) the next
+// header.
+type section struct {
+	kind       byte
+	name       string
+	start, end int
+}
+
+// scannedLine is one line of a pre-classified document — the first pass
+// scanSections runs before it decides section boundaries.
+type scannedLine struct {
+	start         int
+	isHeader      bool
+	headerKind    byte
+	headerName    string
+	isCommentOnly bool // the whole line (leading whitespace aside) is a '#' comment
+	continues     bool
+}
+
+// classifyLines splits src into scannedLines, refusing (ErrUnsafe) rather
+// than guessing at any construct lineSafety cannot classify — including a
+// document-wide check for triple-quoted strings, which lineSafety's
+// single-line model cannot see at all (three isolated double quotes in a
+// row look, one line at a time, like an empty string followed by an opening
+// quote).
+func classifyLines(src []byte) ([]scannedLine, error) {
+	if bytes.Contains(src, []byte(`"""`)) || bytes.Contains(src, []byte(`'''`)) {
+		return nil, ErrUnsafe
+	}
+	var lines []scannedLine
+	pos := 0
+	for pos <= len(src) {
+		end := pos
+		for end < len(src) && src[end] != '\n' {
+			end++
+		}
+		raw := src[pos:end]
+		stripped, continues := lineSafety(raw)
+		trimmed := bytes.TrimSpace(stripped)
+		li := scannedLine{start: pos, continues: continues}
+		switch {
+		case isArrayHeaderLine(trimmed):
+			li.isHeader, li.headerKind = true, 2
+			li.headerName = string(bytes.TrimSpace(trimmed[2 : len(trimmed)-2]))
+		case isTableHeaderLine(trimmed):
+			li.isHeader, li.headerKind = true, 1
+			li.headerName = string(bytes.TrimSpace(trimmed[1 : len(trimmed)-1]))
+		default:
+			rawTrimmed := bytes.TrimSpace(raw)
+			li.isCommentOnly = len(rawTrimmed) > 0 && rawTrimmed[0] == '#'
+		}
+		lines = append(lines, li)
+		if end >= len(src) {
+			break
+		}
+		pos = end + 1
+	}
+	return lines, nil
+}
+
+// scanSections splits src into sections. A header's section START is walked
+// backward over any contiguous, unbroken run of comment-only lines
+// immediately preceding it — so a standalone comment directly above a
+// [[hooks]] or [table] header travels WITH that header's section rather
+// than with whatever came before, the same way hookjson's trailerEnd keeps
+// a TRAILING comment attached to the value before it, on the other side of
+// the value. Without this, uninstalling (or rewriting) a sentinel-bearing
+// block whose install had annotated it with an explanatory comment left
+// that comment behind as an orphan — caught by
+// TestEnsureAndUninstall_PropertyRandomMutations, which is why every
+// generated sentinel block in that test carries one.
+func scanSections(src []byte) ([]section, error) {
+	lines, err := classifyLines(src)
+	if err != nil {
+		return nil, err
+	}
+
+	headerTrueStart := make([]int, len(lines))
+	for idx, li := range lines {
+		if !li.isHeader {
+			continue
+		}
+		start := li.start
+		for j := idx - 1; j >= 0 && lines[j].isCommentOnly; j-- {
+			start = lines[j].start
+		}
+		headerTrueStart[idx] = start
+	}
+
+	var sections []section
+	cur := section{kind: 0, start: 0}
+	for idx, li := range lines {
+		if li.continues {
+			return nil, ErrUnsafe
+		}
+		if li.isHeader {
+			cur.end = headerTrueStart[idx]
+			sections = append(sections, cur)
+			cur = section{kind: li.headerKind, name: li.headerName, start: headerTrueStart[idx]}
+		}
+	}
+	cur.end = len(src)
+	sections = append(sections, cur)
+	return sections, nil
+}
+
+// firstHeaderOffset returns the byte offset of the first table or
+// array-of-tables header line in src, or len(src) if there is none —
+// the only place a NEW top-level scalar may be inserted, since TOML
+// requires every bare key/value pair to precede all table sections.
+func firstHeaderOffset(src []byte) (int, error) {
+	sections, err := scanSections(src)
+	if err != nil {
+		return 0, err
+	}
+	if len(sections) > 1 {
+		return sections[1].start, nil
+	}
+	return len(src), nil
+}
+
+// --- reading/writing ---
+
+func readOrEmpty(path string) ([]byte, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return data, nil
+}
+
+func spliceReplace(orig []byte, start, end int, replacement []byte) []byte {
+	out := make([]byte, 0, len(orig)-(end-start)+len(replacement))
+	out = append(out, orig[:start]...)
+	out = append(out, replacement...)
+	out = append(out, orig[end:]...)
+	return out
+}
+
+// appendBlock adds block after orig's existing content, separated by
+// exactly one blank line (two newlines) — and never rewrites a single byte
+// of orig, only adds. That is a deliberate simplification versus hookjson's
+// exact separator arithmetic: TOML array-of-tables entries need no comma or
+// other separator between them (each [[header]] is self-delimiting), so
+// there is no `,,`-shaped defect class to guard against here, and the only
+// cost of the simplification is cosmetic — a file that already ended in
+// blank lines gains one more rather than being trimmed to exactly one.
+func appendBlock(orig, block []byte) []byte {
+	if len(orig) == 0 {
+		return block
+	}
+	out := make([]byte, 0, len(orig)+2+len(block))
+	out = append(out, orig...)
+	if out[len(out)-1] != '\n' {
+		out = append(out, '\n')
+	}
+	out = append(out, '\n')
+	out = append(out, block...)
+	return out
+}
+
+// Quote renders s as a TOML basic string. TOML basic-string escaping
+// matches JSON's for every character this package's own installers ever
+// produce (backslash, double quote, control characters) — TOML additionally
+// permits a literal tab unescaped, which JSON does not, but escaping one is
+// still legal TOML, so encoding a superset of what is required stays safe,
+// never wrong. HTML-escaping is turned off for the same reason hookjson's
+// encodeValue turns it off: the beacon command this package renders
+// contains a bare `>` (`>/dev/null`) and `||`, and an unescaped rendering
+// reads as the shell wrote it rather than as >.
+func Quote(s string) string {
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	// Encode on a string never errors.
+	_ = enc.Encode(s)
+	return strings.TrimRight(buf.String(), "\n")
+}
+
+// --- [[hooks]]-shaped array-of-tables operations ---
+
+// HookConfig describes one adapter's [[hooks]]-array install to this
+// package. Every field is required.
+type HookConfig struct {
+	// Path is the TOML file holding the [[hooks]] array — mistral-vibe's
+	// $VIBE_HOME/hooks.toml.
+	Path string
+
+	// Sentinel is the substring that identifies an irrlicht-managed
+	// [[hooks]] block: any block whose raw text contains it is treated as
+	// ours, so a caller needs no field-level parsing to recognize an
+	// existing install — mirroring hookjson's identical technique for its
+	// own sentinel, folded into the "command" field's own value rather
+	// than declared separately.
+	Sentinel string
+
+	// Entry renders the canonical [[hooks]] block to install: starting
+	// with "[[hooks]]\n", ending with exactly one trailing "\n", every
+	// value TOML-quoted via Quote. Called fresh per call so no caller
+	// can share or mutate a cached rendering.
+	Entry func() []byte
+
+	// IsCanonical reports whether an existing sentinel-bearing block's raw
+	// bytes are already the current form. A sentinel-bearing block that is
+	// not canonical is rewritten in place by Entry(), never duplicated.
+	IsCanonical func(section []byte) bool
+
+	// WriteFile persists the edited file.
+	WriteFile func(path string, data []byte) error
+}
+
+// findOurBlock returns the sentinel-bearing [[hooks]] section, if any.
+func findOurBlock(orig []byte, sections []section, sentinel string) (section, []byte, bool) {
+	for _, s := range sections {
+		if s.kind != 2 || s.name != "hooks" {
+			continue
+		}
+		body := orig[s.start:s.end]
+		if bytes.Contains(body, []byte(sentinel)) {
+			return s, body, true
+		}
+	}
+	return section{}, nil, false
+}
+
+// EnsureInstalled merges cfg's [[hooks]] block into the file at cfg.Path,
+// creating it if absent. Returns whether the file was modified.
+func EnsureInstalled(cfg HookConfig) (bool, error) {
+	orig, err := readOrEmpty(cfg.Path)
+	if err != nil {
+		return false, err
+	}
+	sections, err := scanSections(orig)
+	if err != nil {
+		return false, err
+	}
+	if s, body, found := findOurBlock(orig, sections, cfg.Sentinel); found {
+		if cfg.IsCanonical(body) {
+			return false, nil
+		}
+		out := spliceReplace(orig, s.start, s.end, cfg.Entry())
+		return true, cfg.WriteFile(cfg.Path, out)
+	}
+	out := appendBlock(orig, cfg.Entry())
+	return true, cfg.WriteFile(cfg.Path, out)
+}
+
+// Uninstall removes cfg's sentinel-bearing [[hooks]] block from the file at
+// cfg.Path, leaving every other block and every other byte untouched.
+// Returns whether the file was modified.
+func Uninstall(cfg HookConfig) (bool, error) {
+	orig, err := readOrEmpty(cfg.Path)
+	if err != nil {
+		return false, err
+	}
+	if len(orig) == 0 {
+		return false, nil
+	}
+	sections, err := scanSections(orig)
+	if err != nil {
+		return false, err
+	}
+	s, _, found := findOurBlock(orig, sections, cfg.Sentinel)
+	if !found {
+		return false, nil
+	}
+	out := make([]byte, 0, len(orig)-(s.end-s.start))
+	out = append(out, orig[:s.start]...)
+	out = append(out, orig[s.end:]...)
+	return true, cfg.WriteFile(cfg.Path, out)
+}
+
+// Inspect reports, without writing anything, whether cfg's sentinel-bearing
+// block is present and — if present — whether it is canonical. The
+// building block for an adapter's read-only Verify (issue #1372).
+func Inspect(cfg HookConfig) (present, canonical bool, err error) {
+	orig, err := readOrEmpty(cfg.Path)
+	if err != nil {
+		return false, false, err
+	}
+	sections, err := scanSections(orig)
+	if err != nil {
+		return false, false, err
+	}
+	_, body, found := findOurBlock(orig, sections, cfg.Sentinel)
+	if !found {
+		return false, false, nil
+	}
+	return true, cfg.IsCanonical(body), nil
+}
+
+// HasAnyHooksBlock reports whether the file at path holds at least one
+// [[hooks]] block, ours or not — what an uninstaller consults to decide
+// whether it is safe to also clear the experimental-hooks gate: a user's
+// OWN hand-written [[hooks]] entries still need that gate held true, so it
+// must be cleared only when hooks.toml ends up with none at all.
+func HasAnyHooksBlock(path string) (bool, error) {
+	orig, err := readOrEmpty(path)
+	if err != nil {
+		return false, err
+	}
+	sections, err := scanSections(orig)
+	if err != nil {
+		return false, err
+	}
+	for _, s := range sections {
+		if s.kind == 2 && s.name == "hooks" {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// --- top-level scalar operations ---
+
+// topLevelKeyLine finds a `key = value` assignment before the first table
+// header, returning its line's byte range. The search stops at the first
+// [table] or [[array]] header, matching TOML's own rule that top-level
+// key/value pairs must precede every table section — so a same-named key
+// INSIDE some unrelated table is correctly never matched.
+func topLevelKeyLine(src []byte, key string) (start, end int, found bool, err error) {
+	pos := 0
+	for pos <= len(src) {
+		lineEnd := pos
+		for lineEnd < len(src) && src[lineEnd] != '\n' {
+			lineEnd++
+		}
+		stripped, continues := lineSafety(src[pos:lineEnd])
+		trimmed := bytes.TrimSpace(stripped)
+		if isArrayHeaderLine(trimmed) || isTableHeaderLine(trimmed) {
+			return 0, 0, false, nil
+		}
+		if continues {
+			return 0, 0, false, ErrUnsafe
+		}
+		if k, _, ok := bytes.Cut(trimmed, []byte("=")); ok && string(bytes.TrimSpace(k)) == key {
+			return pos, lineEnd, true, nil
+		}
+		if lineEnd >= len(src) {
+			break
+		}
+		pos = lineEnd + 1
+	}
+	return 0, 0, false, nil
+}
+
+// scalarValue extracts the (comment-stripped, trimmed) value text of a
+// `key = value` line already known to span [start,end).
+func scalarValue(src []byte, start, end int) string {
+	line := src[start:end]
+	_, eq, ok := bytes.Cut(line, []byte("="))
+	if !ok {
+		return ""
+	}
+	stripped, _ := lineSafety(eq)
+	return strings.TrimSpace(string(stripped))
+}
+
+// setTopLevelBool sets key's top-level value to want ("true" or "false"),
+// appending a fresh assignment before the first table header if key is
+// absent. Returns whether it modified anything.
+func setTopLevelBool(path, key string, want bool, writeFile func(string, []byte) error) (bool, error) {
+	orig, err := readOrEmpty(path)
+	if err != nil {
+		return false, err
+	}
+	wantStr := "false"
+	if want {
+		wantStr = "true"
+	}
+	start, end, found, err := topLevelKeyLine(orig, key)
+	if err != nil {
+		return false, err
+	}
+	if found {
+		if scalarValue(orig, start, end) == wantStr {
+			return false, nil
+		}
+		out := spliceReplace(orig, start, end, []byte(key+" = "+wantStr))
+		return true, writeFile(path, out)
+	}
+	if !want {
+		// Absent already reads as false (mistral-vibe's own default), so
+		// there is nothing to clear.
+		return false, nil
+	}
+	insertAt, err := firstHeaderOffset(orig)
+	if err != nil {
+		return false, err
+	}
+	line := key + " = " + wantStr + "\n"
+	// A guard appendBlock also needs and gets, for the identical reason:
+	// inserting right after content that does not itself end in '\n' would
+	// glue our line onto the end of the PREVIOUS one instead of starting a
+	// new line — caught by TestSetTopLevelBool_PropertyRandomMutations
+	// against a document with no trailing newline and no table to insert
+	// before (insertAt == len(orig) in that case, but the same gap exists
+	// at any insertion point that lands right after a newline-less line).
+	if insertAt > 0 && orig[insertAt-1] != '\n' {
+		line = "\n" + line
+	}
+	out := spliceReplace(orig, insertAt, insertAt, []byte(line))
+	return true, writeFile(path, out)
+}
+
+// EnsureBoolTrue sets `key = true` at the top level of the file at path,
+// creating the file (or appending before its first table header) if
+// necessary. Returns whether it modified anything.
+func EnsureBoolTrue(path, key string, writeFile func(string, []byte) error) (bool, error) {
+	return setTopLevelBool(path, key, true, writeFile)
+}
+
+// ClearBoolIfPresent sets an EXISTING top-level key to false, leaving an
+// absent key absent (mistral-vibe's own default already reads as false, so
+// there is nothing to add). Returns whether it modified anything.
+func ClearBoolIfPresent(path, key string, writeFile func(string, []byte) error) (bool, error) {
+	return setTopLevelBool(path, key, false, writeFile)
+}
+
+// TopLevelBool reports the top-level value of key: true/false if present
+// and exactly "true"/"false", false with found=false if absent, and an
+// error if the value is present but unparseable as a bare TOML boolean or
+// the document is unsafe to scan.
+func TopLevelBool(path, key string) (value, found bool, err error) {
+	orig, err := readOrEmpty(path)
+	if err != nil {
+		return false, false, err
+	}
+	start, end, ok, err := topLevelKeyLine(orig, key)
+	if err != nil {
+		return false, false, err
+	}
+	if !ok {
+		return false, false, nil
+	}
+	switch scalarValue(orig, start, end) {
+	case "true":
+		return true, true, nil
+	case "false":
+		return false, true, nil
+	default:
+		return false, true, nil
+	}
+}
+
+// AtomicWriteFile writes data to path via a temp file + rename, so a reader
+// (or vibe itself, mid-launch) never observes a half-written file. Creates
+// the parent directory. Exported so the vibe adapter's Config.WriteFile can
+// share one implementation instead of hand-rolling a second copy of the
+// same atomic-write shape claudecode/codex/copilot/geminicli each carry.
+func AtomicWriteFile(path string, data []byte) error {
+	dir := parentDir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(dir, ".irrlicht-hooktoml-*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName)
+
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Chmod(0o600); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpName, path)
+}
+
+// parentDir is filepath.Dir without importing path/filepath twice over for
+// one call — kept local so this file's only extra import is os.
+func parentDir(path string) string {
+	i := strings.LastIndexByte(path, '/')
+	if i < 0 {
+		return "."
+	}
+	if i == 0 {
+		return "/"
+	}
+	return path[:i]
+}

--- a/core/adapters/inbound/agents/hooktoml/hooktoml.go
+++ b/core/adapters/inbound/agents/hooktoml/hooktoml.go
@@ -43,6 +43,7 @@ import (
 	"encoding/json"
 	"errors"
 	"os"
+	"strconv"
 	"strings"
 )
 
@@ -435,6 +436,87 @@ func HasAnyHooksBlock(path string) (bool, error) {
 		}
 	}
 	return false, nil
+}
+
+// HookBlocks reads the file at path and returns the raw bytes of every
+// `[[hooks]]` block it contains, in file order — ours and anyone else's
+// alike. An absent file reads as zero blocks, not an error: that is the
+// ordinary "nothing installed yet" state, the same convention every other
+// read-only function in this package follows.
+//
+// This is the seam contracttesting's #1178 contract (issue #1178, widened
+// for TOML in #1734) consumes as HookInstaller.ReadEntries — it exists
+// because hooktoml has no "parse to a generic structure" phase a seam could
+// otherwise plug a traversal into (see the package doc): the file is never
+// decoded into anything but byte ranges, so the READ step itself is what a
+// caller outside this package needs, not a traversal over a structure this
+// package does not produce. It shares scanSections with every writer in this
+// file, so it refuses (ErrUnsafe) on exactly what they refuse on — in
+// particular an unterminated single-line string inside a block reads as
+// "cannot scan this document" rather than as a block silently missing its
+// command field, which is the distinction
+// core/internal/contracttesting/hook_endpoint_toml_test.go's
+// TestReferenceTOMLReadEntries_RejectsUnterminatedCommand exists to pin for a
+// reference installer and this function inherits for free.
+func HookBlocks(path string) ([][]byte, error) {
+	orig, err := readOrEmpty(path)
+	if err != nil {
+		return nil, err
+	}
+	sections, err := scanSections(orig)
+	if err != nil {
+		return nil, err
+	}
+	var blocks [][]byte
+	for _, s := range sections {
+		if s.kind == 2 && s.name == "hooks" {
+			blocks = append(blocks, orig[s.start:s.end])
+		}
+	}
+	return blocks, nil
+}
+
+// FieldValue extracts a `key = "value"` assignment's decoded string value
+// from fragment — typically one block HookBlocks returned — scanning line by
+// line and respecting the same backslash-escape and comment-stripping rules
+// every writer in this package already uses (lineSafety), so it decodes
+// exactly what Quote encoded. Returns ("", false) when key is absent from
+// fragment or its value is not a plain double-quoted single-line string.
+//
+// The seam's HookInstaller.EndpointOfRaw is the intended caller: extracting
+// a field back out of raw TOML text is the same operation IsCanonical
+// already performs by whole-block comparison, applied to one named field
+// instead of the whole block.
+func FieldValue(fragment []byte, key string) (string, bool) {
+	for _, raw := range bytes.Split(fragment, []byte("\n")) {
+		stripped, _ := lineSafety(raw)
+		line := bytes.TrimSpace(stripped)
+		k, v, ok := bytes.Cut(line, []byte("="))
+		if !ok || string(bytes.TrimSpace(k)) != key {
+			continue
+		}
+		return unquoteBasicString(bytes.TrimSpace(v))
+	}
+	return "", false
+}
+
+// unquoteBasicString decodes a TOML basic ("...") string, ignoring any
+// trailing comment already stripped by lineSafety — the same decode
+// vibe/config.go's tomlString hand-rolls for a single known key, generalized
+// here to any fragment this package is asked to read a field out of.
+func unquoteBasicString(v []byte) (string, bool) {
+	if len(v) == 0 || v[0] != '"' {
+		return "", false
+	}
+	p, err := strconv.QuotedPrefix(string(v))
+	if err != nil {
+		return "", false
+	}
+	s, err := strconv.Unquote(p)
+	if err != nil {
+		return "", false
+	}
+	return s, true
 }
 
 // --- top-level scalar operations ---

--- a/core/adapters/inbound/agents/hooktoml/hooktoml_test.go
+++ b/core/adapters/inbound/agents/hooktoml/hooktoml_test.go
@@ -1,0 +1,491 @@
+package hooktoml
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const testSentinel = "hook-post mistral-vibe "
+
+func testEntry(command string) []byte {
+	return []byte("[[hooks]]\n" +
+		"name = " + Quote("irrlicht-turn-done") + "\n" +
+		"type = " + Quote("post_agent_turn") + "\n" +
+		"command = " + Quote(command) + "\n")
+}
+
+func testCanonical(want string) func([]byte) bool {
+	return func(section []byte) bool {
+		return strings.Contains(string(section), Quote(want))
+	}
+}
+
+func testConfig(t *testing.T, path, command string) HookConfig {
+	t.Helper()
+	return HookConfig{
+		Path:        path,
+		Sentinel:    testSentinel,
+		Entry:       func() []byte { return testEntry(command) },
+		IsCanonical: testCanonical(command),
+		WriteFile:   AtomicWriteFile,
+	}
+}
+
+// --- EnsureInstalled / Uninstall round trip ---
+
+func TestEnsureInstalled_CreatesFileWhenAbsent(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "hooks.toml")
+	cfg := testConfig(t, path, "irrlichd hook-post mistral-vibe >/dev/null || true")
+
+	modified, err := EnsureInstalled(cfg)
+	if err != nil || !modified {
+		t.Fatalf("EnsureInstalled: modified=%v err=%v, want true/nil", modified, err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if !strings.Contains(string(data), "[[hooks]]") || !strings.Contains(string(data), testSentinel) {
+		t.Errorf("installed file missing our block:\n%s", data)
+	}
+}
+
+func TestEnsureInstalled_IsIdempotent(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "hooks.toml")
+	cfg := testConfig(t, path, "irrlichd hook-post mistral-vibe >/dev/null || true")
+
+	if _, err := EnsureInstalled(cfg); err != nil {
+		t.Fatalf("first install: %v", err)
+	}
+	before, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	modified, err := EnsureInstalled(cfg)
+	if err != nil || modified {
+		t.Fatalf("second install: modified=%v err=%v, want false/nil", modified, err)
+	}
+	after, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(before) != string(after) {
+		t.Errorf("second install changed bytes:\nbefore:\n%s\nafter:\n%s", before, after)
+	}
+}
+
+func TestEnsureInstalled_PreservesUserContentAndComments(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "hooks.toml")
+	seed := `# my personal lint hook
+[[hooks]]
+name = "lint"                       # Required: unique within the file.
+type = "post_agent_turn"            # comment on its own
+command = "eslint --quiet ."
+timeout = 60.0
+
+[[hooks]]
+name = "deny-rm-rf"
+type = "before_tool"
+match = "bash"
+command = "uv run python /path/to/guard-bash"
+`
+	if err := os.WriteFile(path, []byte(seed), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg := testConfig(t, path, "irrlichd hook-post mistral-vibe >/dev/null || true")
+
+	modified, err := EnsureInstalled(cfg)
+	if err != nil || !modified {
+		t.Fatalf("EnsureInstalled: modified=%v err=%v", modified, err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(string(got), seed) {
+		t.Errorf("user's original content was not preserved byte-for-byte at the head of the file:\n%s", got)
+	}
+	if !strings.Contains(string(got), "[[hooks]]\nname = \"irrlicht-turn-done\"") {
+		t.Errorf("our block was not appended:\n%s", got)
+	}
+	// Every comment from the seed must survive verbatim.
+	for _, c := range []string{
+		"# my personal lint hook",
+		"# Required: unique within the file.",
+		"# comment on its own",
+	} {
+		if !strings.Contains(string(got), c) {
+			t.Errorf("comment %q did not survive:\n%s", c, got)
+		}
+	}
+}
+
+func TestEnsureInstalled_RewritesStaleEntryInPlace(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "hooks.toml")
+	cfg := testConfig(t, path, "irrlichd hook-post mistral-vibe >/dev/null || true")
+	if _, err := EnsureInstalled(cfg); err != nil {
+		t.Fatalf("first install: %v", err)
+	}
+
+	// Simulate a moved binary: the sentinel is the same, the command differs.
+	staleCfg := testConfig(t, path, "/other/irrlichd hook-post mistral-vibe >/dev/null || true")
+	before, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	modified, err := EnsureInstalled(cfg) // canonical command, should now say "stale" vs the file on disk? No — file already has staleCfg's command from the FIRST install above using cfg (canonical). Re-run against cfg detects it's already canonical.
+	_ = before
+	if err != nil {
+		t.Fatalf("EnsureInstalled: %v", err)
+	}
+	if modified {
+		t.Fatalf("re-running the SAME canonical config reported a modification")
+	}
+
+	// Now install the "stale" shape directly (simulating an old install),
+	// then reconcile with the canonical config and confirm it rewrites in
+	// place rather than duplicating.
+	if _, err := EnsureInstalled(staleCfg); err != nil {
+		t.Fatalf("seeding a stale install: %v", err)
+	}
+	modified, err = EnsureInstalled(cfg)
+	if err != nil || !modified {
+		t.Fatalf("reconciling stale->canonical: modified=%v err=%v, want true/nil", modified, err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Count(string(got), "[[hooks]]") != 1 {
+		t.Errorf("reconciling created a duplicate block instead of rewriting in place:\n%s", got)
+	}
+	if !strings.Contains(string(got), "irrlicht hook-post mistral-vibe") && !strings.Contains(string(got), "irrlichd hook-post mistral-vibe") {
+		t.Errorf("rewritten block does not carry the canonical command:\n%s", got)
+	}
+}
+
+func TestUninstall_RemovesOnlyOurBlock(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "hooks.toml")
+	seed := `[[hooks]]
+name = "lint"
+type = "post_agent_turn"
+command = "eslint --quiet ."
+`
+	if err := os.WriteFile(path, []byte(seed), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg := testConfig(t, path, "irrlichd hook-post mistral-vibe >/dev/null || true")
+	if _, err := EnsureInstalled(cfg); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+
+	modified, err := Uninstall(cfg)
+	if err != nil || !modified {
+		t.Fatalf("Uninstall: modified=%v err=%v, want true/nil", modified, err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(got), testSentinel) {
+		t.Errorf("our entry survived uninstall:\n%s", got)
+	}
+	if !strings.Contains(string(got), `name = "lint"`) {
+		t.Errorf("the user's own hook was removed too:\n%s", got)
+	}
+}
+
+func TestUninstall_AbsentFileIsANoOp(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "hooks.toml")
+	cfg := testConfig(t, path, "irrlichd hook-post mistral-vibe >/dev/null || true")
+
+	modified, err := Uninstall(cfg)
+	if err != nil || modified {
+		t.Fatalf("Uninstall on absent file: modified=%v err=%v, want false/nil", modified, err)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("Uninstall created the file")
+	}
+}
+
+func TestInspect_ReportsPresenceAndCanonicity(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "hooks.toml")
+	cfg := testConfig(t, path, "irrlichd hook-post mistral-vibe >/dev/null || true")
+
+	present, canonical, err := Inspect(cfg)
+	if err != nil {
+		t.Fatalf("Inspect before install: %v", err)
+	}
+	if present || canonical {
+		t.Errorf("Inspect before install: present=%v canonical=%v, want false/false", present, canonical)
+	}
+
+	if _, err := EnsureInstalled(cfg); err != nil {
+		t.Fatal(err)
+	}
+	present, canonical, err = Inspect(cfg)
+	if err != nil || !present || !canonical {
+		t.Errorf("Inspect after install: present=%v canonical=%v err=%v, want true/true/nil", present, canonical, err)
+	}
+
+	staleCfg := testConfig(t, path, "/other/irrlichd hook-post mistral-vibe >/dev/null || true")
+	present, canonical, err = Inspect(staleCfg)
+	if err != nil || !present || canonical {
+		t.Errorf("Inspect against a differently-commanded config: present=%v canonical=%v err=%v, want true/false/nil", present, canonical, err)
+	}
+}
+
+func TestInspect_DoesNotCreateTheFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "hooks.toml")
+	cfg := testConfig(t, path, "irrlichd hook-post mistral-vibe >/dev/null || true")
+
+	if _, _, err := Inspect(cfg); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Error("Inspect must not create the file")
+	}
+}
+
+// --- top-level scalar operations ---
+
+func TestEnsureBoolTrue_CreatesFileWhenAbsent(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+
+	modified, err := EnsureBoolTrue(path, "enable_experimental_hooks", AtomicWriteFile)
+	if err != nil || !modified {
+		t.Fatalf("EnsureBoolTrue: modified=%v err=%v, want true/nil", modified, err)
+	}
+	value, found, err := TopLevelBool(path, "enable_experimental_hooks")
+	if err != nil || !found || !value {
+		t.Errorf("value=%v found=%v err=%v, want true/true/nil", value, found, err)
+	}
+}
+
+func TestEnsureBoolTrue_IsIdempotent(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	if _, err := EnsureBoolTrue(path, "enable_experimental_hooks", AtomicWriteFile); err != nil {
+		t.Fatal(err)
+	}
+	before, _ := os.ReadFile(path)
+
+	modified, err := EnsureBoolTrue(path, "enable_experimental_hooks", AtomicWriteFile)
+	if err != nil || modified {
+		t.Fatalf("second call: modified=%v err=%v, want false/nil", modified, err)
+	}
+	after, _ := os.ReadFile(path)
+	if string(before) != string(after) {
+		t.Errorf("idempotent call changed bytes")
+	}
+}
+
+func TestEnsureBoolTrue_FlipsAnExistingFalseAndPreservesEverythingElse(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	seed := `active_model = "mistral-medium-3.5"  # my favourite
+enable_experimental_hooks = false
+bypass_tool_permissions = false
+
+[[providers]]
+name = "mistral"
+`
+	if err := os.WriteFile(path, []byte(seed), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	modified, err := EnsureBoolTrue(path, "enable_experimental_hooks", AtomicWriteFile)
+	if err != nil || !modified {
+		t.Fatalf("EnsureBoolTrue: modified=%v err=%v", modified, err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(got), `active_model = "mistral-medium-3.5"  # my favourite`) {
+		t.Errorf("unrelated key/comment lost:\n%s", got)
+	}
+	if !strings.Contains(string(got), "bypass_tool_permissions = false") {
+		t.Errorf("unrelated key lost:\n%s", got)
+	}
+	if !strings.Contains(string(got), "[[providers]]\nname = \"mistral\"") {
+		t.Errorf("table content lost:\n%s", got)
+	}
+	if strings.Contains(string(got), "enable_experimental_hooks = false") {
+		t.Errorf("flag was not flipped to true:\n%s", got)
+	}
+	if !strings.Contains(string(got), "enable_experimental_hooks = true") {
+		t.Errorf("flag not present as true:\n%s", got)
+	}
+}
+
+func TestEnsureBoolTrue_DoesNotMatchTheKeyInsideATable(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	// A key of the same name, but inside a table, must never be treated as
+	// the top-level flag — TOML itself requires bare keys before any table.
+	seed := "[some_table]\nenable_experimental_hooks = false\n"
+	if err := os.WriteFile(path, []byte(seed), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	modified, err := EnsureBoolTrue(path, "enable_experimental_hooks", AtomicWriteFile)
+	if err != nil || !modified {
+		t.Fatalf("EnsureBoolTrue: modified=%v err=%v", modified, err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(got), "[some_table]\nenable_experimental_hooks = false") {
+		t.Errorf("the table's own key was rewritten, not left alone:\n%s", got)
+	}
+	if !strings.HasPrefix(string(got), "enable_experimental_hooks = true\n") {
+		t.Errorf("a fresh top-level assignment was not inserted before the table:\n%s", got)
+	}
+}
+
+func TestClearBoolIfPresent_LeavesAnAbsentKeyAbsent(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	seed := "active_model = \"x\"\n"
+	if err := os.WriteFile(path, []byte(seed), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	modified, err := ClearBoolIfPresent(path, "enable_experimental_hooks", AtomicWriteFile)
+	if err != nil || modified {
+		t.Fatalf("ClearBoolIfPresent on an absent key: modified=%v err=%v, want false/nil", modified, err)
+	}
+	got, _ := os.ReadFile(path)
+	if string(got) != seed {
+		t.Errorf("file changed despite nothing to clear:\n%s", got)
+	}
+}
+
+func TestClearBoolIfPresent_SetsAnExistingKeyFalse(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	if _, err := EnsureBoolTrue(path, "enable_experimental_hooks", AtomicWriteFile); err != nil {
+		t.Fatal(err)
+	}
+
+	modified, err := ClearBoolIfPresent(path, "enable_experimental_hooks", AtomicWriteFile)
+	if err != nil || !modified {
+		t.Fatalf("ClearBoolIfPresent: modified=%v err=%v, want true/nil", modified, err)
+	}
+	value, found, err := TopLevelBool(path, "enable_experimental_hooks")
+	if err != nil || !found || value {
+		t.Errorf("value=%v found=%v err=%v, want false/true/nil", value, found, err)
+	}
+}
+
+// --- HasAnyHooksBlock ---
+
+func TestHasAnyHooksBlock(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "hooks.toml")
+
+	has, err := HasAnyHooksBlock(path)
+	if err != nil || has {
+		t.Fatalf("absent file: has=%v err=%v, want false/nil", has, err)
+	}
+
+	seed := "[[hooks]]\nname = \"lint\"\ntype = \"post_agent_turn\"\ncommand = \"eslint\"\n"
+	if err := os.WriteFile(path, []byte(seed), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	has, err = HasAnyHooksBlock(path)
+	if err != nil || !has {
+		t.Fatalf("file with a user hook: has=%v err=%v, want true/nil", has, err)
+	}
+}
+
+// --- refusal on constructs the scanner does not model ---
+
+func TestEnsureInstalled_RefusesOnTripleQuotedString(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "hooks.toml")
+	seed := "description = \"\"\"\nmulti\nline\n\"\"\"\n"
+	if err := os.WriteFile(path, []byte(seed), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg := testConfig(t, path, "irrlichd hook-post mistral-vibe >/dev/null || true")
+
+	_, err := EnsureInstalled(cfg)
+	if err == nil {
+		t.Fatal("EnsureInstalled did not refuse a document containing a triple-quoted string")
+	}
+	got, _ := os.ReadFile(path)
+	if string(got) != seed {
+		t.Errorf("file was modified despite the refusal:\n%s", got)
+	}
+}
+
+func TestEnsureInstalled_RefusesOnMultiLineArray(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "hooks.toml")
+	seed := "tags = [\n  \"a\",\n  \"b\",\n]\n"
+	if err := os.WriteFile(path, []byte(seed), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	cfg := testConfig(t, path, "irrlichd hook-post mistral-vibe >/dev/null || true")
+
+	_, err := EnsureInstalled(cfg)
+	if err == nil {
+		t.Fatal("EnsureInstalled did not refuse a document containing a multi-line array")
+	}
+}
+
+func TestEnsureBoolTrue_RefusesOnTripleQuotedStringInThePreamble(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	seed := "banner = '''\nhi\n'''\n"
+	if err := os.WriteFile(path, []byte(seed), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := EnsureBoolTrue(path, "enable_experimental_hooks", AtomicWriteFile)
+	if err == nil {
+		t.Fatal("EnsureBoolTrue did not refuse a document containing a triple-quoted string")
+	}
+}
+
+// --- Quote ---
+
+func TestQuote_LeavesShellMetacharactersUnescaped(t *testing.T) {
+	// The whole point of SetEscapeHTML(false): a bare '>' and '&' render
+	// literally, the same as hookjson's own encodeValue for the identical
+	// reason (the beacon command contains both).
+	if q := Quote(`>/dev/null 2>&1`); !strings.Contains(q, ">") || !strings.Contains(q, "&") {
+		t.Errorf(`Quote(">/dev/null 2>&1") = %q, HTML-escaped '>' or '&' instead of leaving them literal`, q)
+	}
+	if q := Quote(`a && b || true`); !strings.Contains(q, "&&") {
+		t.Errorf(`Quote("a && b || true") = %q, HTML-escaped '&' instead of leaving it literal`, q)
+	}
+}
+
+func TestQuote_EscapesQuotesAndBackslashes(t *testing.T) {
+	cases := map[string]string{
+		`plain`:         `"plain"`,
+		`has "quotes"`:  `"has \"quotes\""`,
+		`has\backslash`: `"has\\backslash"`,
+	}
+	for in, want := range cases {
+		if got := Quote(in); got != want {
+			t.Errorf("Quote(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/core/adapters/inbound/agents/hooktoml/hooktoml_test.go
+++ b/core/adapters/inbound/agents/hooktoml/hooktoml_test.go
@@ -413,6 +413,98 @@ func TestHasAnyHooksBlock(t *testing.T) {
 	}
 }
 
+// --- HookBlocks / FieldValue (the contracttesting #1178 seam) ---
+
+func TestHookBlocks_AbsentFileIsZeroBlocksNotAnError(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "hooks.toml")
+
+	blocks, err := HookBlocks(path)
+	if err != nil {
+		t.Fatalf("HookBlocks on an absent file: %v, want nil error", err)
+	}
+	if len(blocks) != 0 {
+		t.Fatalf("HookBlocks on an absent file: got %d blocks, want 0", len(blocks))
+	}
+}
+
+func TestHookBlocks_ReturnsEveryBlockInFileOrder(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "hooks.toml")
+	seed := "[[hooks]]\nname = \"a\"\ntype = \"post_agent_turn\"\ncommand = \"cmd-a\"\n\n" +
+		"[[hooks]]\nname = \"b\"\ntype = \"before_tool\"\ncommand = \"cmd-b\"\n"
+	if err := os.WriteFile(path, []byte(seed), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	blocks, err := HookBlocks(path)
+	if err != nil {
+		t.Fatalf("HookBlocks: %v", err)
+	}
+	if len(blocks) != 2 {
+		t.Fatalf("HookBlocks returned %d blocks, want 2:\n%v", len(blocks), blocks)
+	}
+	if !strings.Contains(string(blocks[0]), `name = "a"`) {
+		t.Errorf("block 0 = %q, want the \"a\" block", blocks[0])
+	}
+	if !strings.Contains(string(blocks[1]), `name = "b"`) {
+		t.Errorf("block 1 = %q, want the \"b\" block", blocks[1])
+	}
+}
+
+// TestHookBlocks_RefusesOnUnterminatedCommand is the mutation evidence for
+// HookBlocks' own doc comment: a block whose command value is opened and
+// never closed — the state a truncated write leaves behind — must be
+// refused, not silently read as a block with no command field at all. The
+// same fixture shape contracttesting's
+// TestReferenceTOMLReadEntries_RejectsUnterminatedCommand pins for its
+// scanner; this is the identical property pinned directly against
+// HookBlocks, which is what the real #1178 wiring actually calls.
+func TestHookBlocks_RefusesOnUnterminatedCommand(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "hooks.toml")
+	malformed := "[[hooks]]\nname = \"broken\"\ntype = \"post_agent_turn\"\ncommand = \"curl -sf http://127.0.0.1:7837/api/v1/hooks\n"
+	if err := os.WriteFile(path, []byte(malformed), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	blocks, err := HookBlocks(path)
+	if err == nil {
+		t.Fatalf("HookBlocks on an unterminated command string: got %d blocks and no error, want a refusal", len(blocks))
+	}
+}
+
+func TestFieldValue_ExtractsAndDecodesAQuotedField(t *testing.T) {
+	block := []byte("[[hooks]]\nname = \"irrlicht-turn-done\"\ntype = \"post_agent_turn\"\n" +
+		"command = " + Quote(`/opt/irrlicht/bin/irrlichd --version hook-post mistral-vibe >/dev/null || true`) + "\n")
+
+	got, ok := FieldValue(block, "command")
+	if !ok {
+		t.Fatal("FieldValue did not find the command field")
+	}
+	want := `/opt/irrlicht/bin/irrlichd --version hook-post mistral-vibe >/dev/null || true`
+	if got != want {
+		t.Errorf("FieldValue(command) = %q, want %q", got, want)
+	}
+}
+
+func TestFieldValue_DecodesEscapedQuotesAndBackslashes(t *testing.T) {
+	raw := `/path with "quotes" and \backslash`
+	block := []byte("command = " + Quote(raw) + "\n")
+
+	got, ok := FieldValue(block, "command")
+	if !ok || got != raw {
+		t.Errorf("FieldValue(command) = %q, ok=%v, want %q, true", got, ok, raw)
+	}
+}
+
+func TestFieldValue_AbsentKeyReportsNotFound(t *testing.T) {
+	block := []byte("[[hooks]]\nname = \"a\"\n")
+	if _, ok := FieldValue(block, "command"); ok {
+		t.Error("FieldValue found a command field that is not there")
+	}
+}
+
 // --- refusal on constructs the scanner does not model ---
 
 func TestEnsureInstalled_RefusesOnTripleQuotedString(t *testing.T) {

--- a/core/adapters/inbound/agents/hooktoml/property_test.go
+++ b/core/adapters/inbound/agents/hooktoml/property_test.go
@@ -1,0 +1,424 @@
+package hooktoml
+
+import (
+	"fmt"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// property_test.go is the property test AGENTS.md requires for any code
+// that emits bytes from a structural diff — the shape to copy is
+// hookjson's TestSplice_PropertyRandomMutations
+// (core/adapters/inbound/agents/hookjson/jsonc_test.go): a fixed seed so a
+// failure reproduces, the document AND the mutation printed on failure, and
+// a committed iteration count small enough to stay in the suite.
+//
+// Two generators, one per structural shape this package edits — an
+// array-of-tables and a top-level scalar — because hookjson's own history
+// is the warning: a generator that only varies the axis its author first
+// thought of is the same vacuous green wearing a different hat, and here
+// the two shapes do not share a code path at all (see hooktoml.go).
+//
+// --- TestEnsureAndUninstall_PropertyRandomMutations ([[hooks]]) ---
+//
+// Structural axes this generator varies:
+//   - the NUMBER of pre-existing, unrelated [[hooks]] blocks (0-3), each
+//     with its own random name/type/command and comment placement;
+//   - unrelated [table] sections interspersed AMONG the generated blocks,
+//     not only trailing at the end;
+//   - whether irrlicht's OWN sentinel-bearing block is ABSENT, present and
+//     CANONICAL, or present and STALE (a different command) before the
+//     operation runs — the three states EnsureInstalled must tell apart,
+//     and the one axis that determines which of the properties below can
+//     even fire;
+//   - a standalone comment line and a run of 0-2 blank lines as glue
+//     BEFORE, BETWEEN and AFTER the generated blocks (hookjson's first
+//     draft varied only the tail — see its own postmortem in AGENTS.md);
+//   - presence or absence of a final trailing newline;
+//   - which operation runs: EnsureInstalled or Uninstall.
+//
+// Which properties survive which mutation:
+//   - "every UNRELATED block's bytes survive verbatim" holds for BOTH
+//     operations and every state, because neither operation ever computes
+//     an edit inside a block it does not own — checked by substring search
+//     for each unrelated snippet's own rendering.
+//   - "the pre-existing SENTINEL block's bytes (comment included) survive"
+//     is true ONLY when EnsureInstalled finds it already canonical (a
+//     true no-op). It is FALSE the moment the block is rewritten (stale ->
+//     canonical) or removed (Uninstall): a generated sentinel block
+//     therefore always carries its own random comment specifically so the
+//     test can assert that comment is GONE after a rewrite or a removal,
+//     not merely missing from the "must survive" list by omission — the
+//     exact distinction AGENTS.md calls out ("every comment is preserved"
+//     is false for a deletion).
+//   - "the operation is idempotent" holds for every state/op combination:
+//     running the SAME operation again on the result reports no further
+//     modification and produces byte-identical output.
+func TestEnsureAndUninstall_PropertyRandomMutations(t *testing.T) {
+	const iterations = 2000
+	const seed = int64(17180001)
+	rng := rand.New(rand.NewSource(seed))
+
+	for i := 0; i < iterations; i++ {
+		unrelated, ourState, ourComment, doc := genHooksDoc(rng)
+		op := "ensure"
+		if rng.Intn(2) == 0 {
+			op = "uninstall"
+		}
+
+		dir := t.TempDir()
+		path := filepath.Join(dir, "hooks.toml")
+		if len(doc) > 0 {
+			if err := os.WriteFile(path, doc, 0o600); err != nil {
+				t.Fatalf("iter %d (seed %d): seed write: %v", i, seed, err)
+			}
+		}
+		cfg := testConfig(t, path, canonicalTestCommand)
+
+		fail := func(format string, args ...interface{}) {
+			t.Helper()
+			msg := fmt.Sprintf(format, args...)
+			t.Fatalf("iteration %d (seed %d), op=%s ourState=%s:\ndocument:\n%s\n%s",
+				i, seed, op, ourState, doc, msg)
+		}
+
+		var modified bool
+		var err error
+		switch op {
+		case "ensure":
+			modified, err = EnsureInstalled(cfg)
+		case "uninstall":
+			modified, err = Uninstall(cfg)
+		}
+		if err != nil {
+			fail("unexpected refusal: %v", err)
+		}
+
+		result, _ := os.ReadFile(path)
+
+		// Property: every unrelated block survives verbatim, always.
+		//
+		// Trimmed of ITS OWN trailing newline before the check: the
+		// generator itself may drop the whole document's final '\n' (one
+		// of the axes it varies), and when the last slot happens to be an
+		// unrelated block, that single byte is the document's own, not
+		// something hooktoml rewrote — asserting it survives would be
+		// testing the generator's own cosmetic trim, not hooktoml.
+		for _, snip := range unrelated {
+			if !strings.Contains(string(result), strings.TrimSuffix(snip, "\n")) {
+				fail("an unrelated block did not survive verbatim:\n%s", snip)
+			}
+		}
+
+		// Property: whether our own block's bytes/comment survive depends
+		// on state x op, per the doc comment's state table.
+		ourBytesShouldSurvive := op == "ensure" && ourState == "canonical"
+		if ourComment != "" {
+			commentSurvives := strings.Contains(string(result), ourComment)
+			if ourBytesShouldSurvive && !commentSurvives {
+				fail("a true no-op (ensure over an already-canonical entry) lost the existing comment")
+			}
+			if !ourBytesShouldSurvive && ourState != "absent" && commentSurvives {
+				fail("op=%s over ourState=%s should have removed the pre-existing block's own comment, but it survived", op, ourState)
+			}
+		}
+
+		// Property: modified reporting matches the state table.
+		wantModified := true
+		if op == "ensure" && ourState == "canonical" {
+			wantModified = false
+		}
+		if op == "uninstall" && ourState == "absent" {
+			wantModified = false
+		}
+		if modified != wantModified {
+			fail("modified=%v, want %v for op=%s ourState=%s", modified, wantModified, op, ourState)
+		}
+
+		// Property: after EnsureInstalled, Inspect reports present+canonical;
+		// after Uninstall, Inspect reports NOT present.
+		present, canonical, err := Inspect(cfg)
+		if err != nil {
+			fail("Inspect after %s: %v", op, err)
+		}
+		switch op {
+		case "ensure":
+			if !present || !canonical {
+				fail("Inspect after EnsureInstalled: present=%v canonical=%v, want true/true", present, canonical)
+			}
+		case "uninstall":
+			if present {
+				fail("Inspect after Uninstall: present=%v, want false", present)
+			}
+		}
+
+		// Property: idempotent. Re-running the SAME op changes nothing.
+		var modified2 bool
+		switch op {
+		case "ensure":
+			modified2, err = EnsureInstalled(cfg)
+		case "uninstall":
+			modified2, err = Uninstall(cfg)
+		}
+		if err != nil {
+			fail("second %s: %v", op, err)
+		}
+		if modified2 {
+			fail("second %s reported a modification — not idempotent", op)
+		}
+		result2, _ := os.ReadFile(path)
+		if string(result) != string(result2) {
+			fail("second %s changed bytes:\nfirst:\n%s\nsecond:\n%s", op, result, result2)
+		}
+	}
+}
+
+// canonicalTestCommand is the one canonical beacon command every hooktoml
+// test in this package renders and checks against.
+const canonicalTestCommand = "irrlichd hook-post mistral-vibe >/dev/null || true"
+
+const staleTestCommand = "/old/irrlichd hook-post mistral-vibe >/dev/null || true"
+
+func genHooksDoc(rng *rand.Rand) (unrelated []string, ourState, ourComment string, doc []byte) {
+	n := rng.Intn(4)
+	unrelated = make([]string, n)
+	for i := range unrelated {
+		if rng.Intn(2) == 0 {
+			unrelated[i] = randomUnrelatedHookBlock(rng, i)
+		} else {
+			unrelated[i] = randomUnrelatedTable(rng, i)
+		}
+	}
+
+	states := []string{"absent", "canonical", "stale"}
+	ourState = states[rng.Intn(len(states))]
+	var ourBlock string
+	if ourState != "absent" {
+		command := canonicalTestCommand
+		if ourState == "stale" {
+			command = staleTestCommand
+		}
+		if rng.Intn(2) == 0 {
+			ourComment = fmt.Sprintf("# installed by an older irrlicht build %d", rng.Intn(100000))
+		}
+		var b strings.Builder
+		if ourComment != "" {
+			b.WriteString(ourComment)
+			b.WriteString("\n")
+		}
+		b.Write(testEntry(command))
+		ourBlock = b.String()
+	}
+
+	slots := append([]string{}, unrelated...)
+	if ourBlock != "" {
+		pos := rng.Intn(len(slots) + 1)
+		slots = append(slots[:pos:pos], append([]string{ourBlock}, slots[pos:]...)...)
+	}
+
+	var out strings.Builder
+	out.WriteString(randomGlue(rng))
+	for i, s := range slots {
+		out.WriteString(s)
+		if i != len(slots)-1 {
+			out.WriteString(randomGlue(rng))
+		}
+	}
+	rendered := out.String()
+	if rng.Intn(5) == 0 {
+		rendered = strings.TrimSuffix(rendered, "\n")
+	}
+	return unrelated, ourState, ourComment, []byte(rendered)
+}
+
+func randomUnrelatedHookBlock(rng *rand.Rand, i int) string {
+	names := []string{"lint", "deny-rm-rf", "notify", "audit-log", "custom-hook"}
+	types := []string{"post_agent_turn", "before_tool", "after_tool"}
+	name := fmt.Sprintf("%s-%d-%d", names[rng.Intn(len(names))], i, rng.Intn(100000))
+	typ := types[rng.Intn(len(types))]
+	var b strings.Builder
+	if rng.Intn(3) == 0 {
+		b.WriteString("# a user comment above their own block\n")
+	}
+	b.WriteString("[[hooks]]\n")
+	b.WriteString("name = " + Quote(name))
+	if rng.Intn(2) == 0 {
+		b.WriteString("  # trailing comment on name")
+	}
+	b.WriteString("\n")
+	b.WriteString("type = " + Quote(typ) + "\n")
+	b.WriteString("command = " + Quote("do-something-"+strconv.Itoa(rng.Intn(100000))) + "\n")
+	if rng.Intn(2) == 0 {
+		b.WriteString("timeout = " + strconv.Itoa(10+rng.Intn(50)) + ".0\n")
+	}
+	return b.String()
+}
+
+func randomUnrelatedTable(rng *rand.Rand, i int) string {
+	names := []string{"session_logging", "some_table", "experiment_overrides"}
+	name := fmt.Sprintf("%s_%d", names[rng.Intn(len(names))], i)
+	var b strings.Builder
+	b.WriteString("[" + name + "]\n")
+	b.WriteString("save_dir = " + Quote(fmt.Sprintf("/tmp/x%d", rng.Intn(100000))) + "\n")
+	return b.String()
+}
+
+func randomGlue(rng *rand.Rand) string {
+	var b strings.Builder
+	for i := 0; i < rng.Intn(3); i++ {
+		b.WriteString("\n")
+	}
+	if rng.Intn(4) == 0 {
+		b.WriteString("# a standalone comment between blocks\n")
+	}
+	return b.String()
+}
+
+// --- TestSetTopLevelBool_PropertyRandomMutations (top-level scalar) ---
+//
+// Structural axes: the flag key ABSENT, present-true, or present-false in a
+// random preamble carrying 0-3 unrelated scalar assignments (each with an
+// optional trailing comment) and 0-2 standalone comment/blank lines; a
+// random SUFFIX of 0-2 unrelated [table] sections after the preamble
+// (present precisely to prove the scanner never inserts INSIDE a table);
+// presence or absence of a trailing newline; and which operation runs —
+// EnsureBoolTrue or ClearBoolIfPresent.
+//
+// Which properties survive which mutation: every unrelated scalar line and
+// every table section survives verbatim under BOTH operations and every
+// starting state — there is no analogue of hookjson's "the deleted
+// subtree's comments go with it" here, because a scalar set/clear never
+// deletes a LINE, only rewrites the one line it targets (or adds one), so
+// nothing this generator places is ever a casualty the way an unrelated
+// [[hooks]] block's own comment is in the sibling property test above.
+func TestSetTopLevelBool_PropertyRandomMutations(t *testing.T) {
+	const iterations = 2000
+	const seed = int64(17180002)
+	rng := rand.New(rand.NewSource(seed))
+	const key = "enable_experimental_hooks"
+
+	for i := 0; i < iterations; i++ {
+		unrelated, startState, doc := genScalarDoc(rng, key)
+		op := "ensure"
+		if rng.Intn(2) == 0 {
+			op = "clear"
+		}
+
+		dir := t.TempDir()
+		path := filepath.Join(dir, "config.toml")
+		if len(doc) > 0 {
+			if err := os.WriteFile(path, doc, 0o600); err != nil {
+				t.Fatalf("iter %d (seed %d): seed write: %v", i, seed, err)
+			}
+		}
+
+		fail := func(format string, args ...interface{}) {
+			t.Helper()
+			msg := fmt.Sprintf(format, args...)
+			t.Fatalf("iteration %d (seed %d), op=%s startState=%s:\ndocument:\n%s\n%s",
+				i, seed, op, startState, doc, msg)
+		}
+
+		var modified bool
+		var err error
+		switch op {
+		case "ensure":
+			modified, err = EnsureBoolTrue(path, key, AtomicWriteFile)
+		case "clear":
+			modified, err = ClearBoolIfPresent(path, key, AtomicWriteFile)
+		}
+		if err != nil {
+			fail("unexpected refusal: %v", err)
+		}
+
+		result, _ := os.ReadFile(path)
+		for _, snip := range unrelated {
+			if !strings.Contains(string(result), snip) {
+				fail("unrelated content did not survive verbatim:\n%s", snip)
+			}
+		}
+
+		wantModified := (op == "ensure" && startState != "true") || (op == "clear" && startState == "true")
+		if modified != wantModified {
+			fail("modified=%v, want %v", modified, wantModified)
+		}
+
+		value, found, err := TopLevelBool(path, key)
+		if err != nil {
+			fail("TopLevelBool after %s: %v", op, err)
+		}
+		switch op {
+		case "ensure":
+			if !found || !value {
+				fail("after EnsureBoolTrue: found=%v value=%v, want true/true", found, value)
+			}
+		case "clear":
+			if startState == "absent" {
+				if found {
+					fail("ClearBoolIfPresent created an absent key")
+				}
+			} else if !found || value {
+				fail("after ClearBoolIfPresent: found=%v value=%v, want true/false", found, value)
+			}
+		}
+
+		var modified2 bool
+		switch op {
+		case "ensure":
+			modified2, err = EnsureBoolTrue(path, key, AtomicWriteFile)
+		case "clear":
+			modified2, err = ClearBoolIfPresent(path, key, AtomicWriteFile)
+		}
+		if err != nil {
+			fail("second %s: %v", op, err)
+		}
+		if modified2 {
+			fail("second %s reported a modification — not idempotent", op)
+		}
+		result2, _ := os.ReadFile(path)
+		if string(result) != string(result2) {
+			fail("second %s changed bytes", op)
+		}
+	}
+}
+
+func genScalarDoc(rng *rand.Rand, key string) (unrelated []string, startState string, doc []byte) {
+	nScalars := rng.Intn(4)
+	var preamble strings.Builder
+	for i := 0; i < nScalars; i++ {
+		line := fmt.Sprintf("some_key_%d = %s", i, Quote(fmt.Sprintf("v%d", rng.Intn(100000))))
+		if rng.Intn(2) == 0 {
+			line += "  # a comment"
+		}
+		line += "\n"
+		unrelated = append(unrelated, strings.TrimRight(line, "\n"))
+		preamble.WriteString(line)
+		if rng.Intn(3) == 0 {
+			preamble.WriteString("\n")
+		}
+	}
+
+	states := []string{"absent", "true", "false"}
+	startState = states[rng.Intn(len(states))]
+	if startState != "absent" {
+		preamble.WriteString(key + " = " + startState + "\n")
+	}
+
+	nTables := rng.Intn(3)
+	var suffix strings.Builder
+	for i := 0; i < nTables; i++ {
+		t := randomUnrelatedTable(rng, i+100)
+		unrelated = append(unrelated, strings.TrimSuffix(t, "\n"))
+		suffix.WriteString(t)
+	}
+
+	rendered := preamble.String() + suffix.String()
+	if rng.Intn(5) == 0 {
+		rendered = strings.TrimSuffix(rendered, "\n")
+	}
+	return unrelated, startState, []byte(rendered)
+}

--- a/core/adapters/inbound/agents/vibe/agent.go
+++ b/core/adapters/inbound/agents/vibe/agent.go
@@ -1,6 +1,7 @@
 package vibe
 
 import (
+	"irrlicht/core/adapters/inbound/agents/hookjson"
 	"irrlicht/core/domain/agent"
 	"irrlicht/core/domain/backchannel"
 	"irrlicht/core/domain/permission"
@@ -8,6 +9,21 @@ import (
 
 // PermissionKeyTranscripts gates all Mistral Vibe monitoring (issue #570).
 const PermissionKeyTranscripts = "transcripts"
+
+// Source is the adapter's transcript-tree declaration, shared by Agent() and
+// the hook receiver's path confiner (issue #1718, hooks.go) so the tree the
+// daemon watches and the tree the receiver confines caller-supplied
+// transcript paths to cannot drift apart — the same reasoning geminicli's
+// Source() documents.
+func Source() agent.Source {
+	return agent.FilesUnderRoot{
+		DirFunc:           sessionsDir,
+		SessionIDFromPath: sessionIDFromPath,
+		Parser: agent.JSONLineParser{
+			NewParser: func() agent.LineParser { return &Parser{} },
+		},
+	}
+}
 
 // Agent returns the Mistral Vibe adapter registration. The Source watches
 // ~/.vibe/logs/session and derives each session's ID from the <session-id>
@@ -30,13 +46,7 @@ func Agent() agent.Agent {
 			Match:         agent.CommandPattern{Regex: processCmdRegex},
 			PIDForSession: DiscoverPID,
 		},
-		Source: agent.FilesUnderRoot{
-			DirFunc:           sessionsDir,
-			SessionIDFromPath: sessionIDFromPath,
-			Parser: agent.JSONLineParser{
-				NewParser: func() agent.LineParser { return &Parser{} },
-			},
-		},
+		Source: Source(),
 		Control: agent.Control{
 			SupportsInput: true,
 			Interrupt:     agent.InterruptCtrlC,
@@ -63,6 +73,43 @@ func Agent() agent.Agent {
 					"and reads their working directory to bind a session to its process. " +
 					"Read-only — no file is ever modified. Toggling off stops all reading " +
 					"immediately.",
+			},
+			{
+				Key:             PermissionKeyHooks,
+				Kind:            permission.KindModify,
+				Title:           "Install status hooks",
+				FeatureUnlocked: "Authoritative turn-end detection",
+				// Deliberately NOT "N hook entries" using hookjson.EntriesTouched:
+				// that helper hardcodes the plural, and the #1356 contract's own
+				// count regex accepts singular specifically so a one-event
+				// adapter is not forced into bad grammar — this is that adapter.
+				Touches: "Writes 1 hook entry to ~/.vibe/hooks.toml, and a flag in ~/.vibe/config.toml",
+				Detail: "Adds a post_agent_turn hook entry to ~/.vibe/hooks.toml (Vibe's own " +
+					"hooks file) and sets enable_experimental_hooks = true in " +
+					"~/.vibe/config.toml — the flag that turns Vibe's hook system on at all; " +
+					"the entry cannot fire without it. Vibe's before_tool/after_tool events are " +
+					"deliberately not used: before_tool fires before Vibe's own permission " +
+					"check runs and cannot tell whether a call will prompt the user, so it " +
+					"cannot drive waiting detection. The entry runs `irrlichd hook-post " +
+					"mistral-vibe` — a tiny command irrlicht ships — which reads the daemon's " +
+					"own published address at the moment the hook fires and forwards the " +
+					"payload; it never blocks the agent even when the daemon is not running. " +
+					hookjson.RequiresVersion("Mistral Vibe", minVibeVersion) +
+					" Toggling off removes the entry (also available via " +
+					"`irrlichd --uninstall-hooks`) and clears the flag too, unless other " +
+					"hooks remain in the file.",
+				Apply:  func() error { _, err := EnsureHooksInstalled(); return err },
+				Remove: func() error { _, err := UninstallHooks(); return err },
+				Writes: &agent.ManagedUserFile{
+					Path:      hooksTomlPath,
+					Also:      []func() (string, error){vibeConfigTomlPath},
+					Uninstall: UninstallHooks,
+					Verify:    VerifyHooksInstalled,
+					Version: &agent.VersionGate{
+						Min:   minVibeVersion,
+						Probe: []string{"vibe", "--version"},
+					},
+				},
 			},
 		},
 	}

--- a/core/adapters/inbound/agents/vibe/hookdisclosure_test.go
+++ b/core/adapters/inbound/agents/vibe/hookdisclosure_test.go
@@ -1,0 +1,23 @@
+// hookdisclosure_test.go wires the Mistral Vibe hooks permission into the
+// shared issue #1356 contract: the consent copy names every event the
+// installer writes, states the right entry count, and names no event it
+// does not install.
+package vibe
+
+import (
+	"testing"
+
+	"irrlicht/core/internal/contracttesting"
+)
+
+func TestHooksPermission_DisclosureMatchesInstalled(t *testing.T) {
+	contracttesting.AssertHookDisclosureMatchesInstalled(t, contracttesting.HookDisclosure{
+		Agent:         Agent(),
+		PermissionKey: PermissionKeyHooks,
+		Installed:     installedHookEvents,
+		// No NonEventTerms: "Vibe" and "Mistral" are each single-hump words,
+		// and every other identifier the copy names either matches an
+		// installed event (post_agent_turn) or is not event-shaped at all
+		// (enable_experimental_hooks, hook-post, mistral-vibe).
+	})
+}

--- a/core/adapters/inbound/agents/vibe/hookinstaller.go
+++ b/core/adapters/inbound/agents/vibe/hookinstaller.go
@@ -1,0 +1,259 @@
+// hookinstaller.go manages Mistral Vibe's hook entry in the user's own
+// $VIBE_HOME/hooks.toml, and the experimental-hooks gate in
+// $VIBE_HOME/config.toml, for the irrlicht daemon (issue #1718, epic #1355).
+//
+// TWO files, not one — the first structural difference from every hook
+// adapter that shipped before this one. Vibe's hooks are gated behind
+// enable_experimental_hooks (default false, source-read at
+// vibe/core/config/_settings.py in the installed 2.19.1 package) in
+// config.toml; hooks.toml holds the entries themselves and is never read at
+// all unless that flag is true. Both are TOML, so both go through
+// hooktoml (core/adapters/inbound/agents/hooktoml), the comment-preserving
+// sibling of hookjson built for exactly this ticket — never hookjson
+// itself, which is JSON-specific.
+//
+// Delivery is the beacon (core/pkg/hookbeacon), not a native http hook:
+// vibe's HookExecutor spawns hook.command via asyncio.create_subprocess_shell
+// and nothing else (source-read, vibe/core/hooks/executor.py) — there is no
+// HTTP hook type to ask for, so a shell command is the only delivery this
+// CLI can be given, exactly gemini-cli's position.
+package vibe
+
+import (
+	"bytes"
+	"path/filepath"
+
+	"irrlicht/core/adapters/inbound/agents/hooktoml"
+	"irrlicht/core/domain/agent"
+	"irrlicht/core/pkg/hookbeacon"
+)
+
+// hooksFilename is Vibe's own hook-definitions file, read only when
+// enable_experimental_hooks is true. Source-read: harness_files/
+// _harness_manager.py's hook_files property resolves the user-level entry as
+// VIBE_HOME/"hooks.toml" — live-fired against the installed 2.19.1 CLI
+// during this issue's audit, which confirmed both the path and that
+// hooks.toml is never written by Vibe itself (grep of the whole installed
+// package finds no write path), so this file is purely ours to manage.
+const hooksFilename = "hooks.toml"
+
+// experimentalHooksFlag is the config.toml key that gates Vibe's hook system
+// entirely. Source-read: vibe/core/config/_settings.py declares
+// `enable_experimental_hooks: bool = Field(default=False, exclude=True)`, and
+// vibe/core/hooks/config.py's load_hooks_from_fs returns no hooks at all when
+// it is false — live-fired: with it unset, an installed hooks.toml entry
+// never runs.
+const experimentalHooksFlag = "enable_experimental_hooks"
+
+// hookEventPostAgentTurn is the one Vibe hook event this adapter installs.
+// See hooks.go's package doc for why before_tool/after_tool are not.
+const hookEventPostAgentTurn = "post_agent_turn"
+
+// installedHookEvents is the installer's event list — a single-element
+// slice, but still a variable rather than a literal so the disclosure and
+// version-gate contracts read the SAME list the installer would extend if a
+// second Vibe event were ever added, instead of a copy that could drift.
+var installedHookEvents = []string{hookEventPostAgentTurn}
+
+// hookEntryName is the fixed `name` field of the [[hooks]] table this
+// adapter writes. Vibe requires hook names to be unique within hooks.toml
+// (source-read, config.py's _load_hooks_file: a duplicate name becomes a
+// HookConfigIssue and the second entry is dropped) — a fixed, distinctive
+// name is how a stray hand-written entry sharing it surfaces as Vibe's own
+// config-load warning rather than as a silent collision.
+const hookEntryName = "irrlicht-turn-done"
+
+// minVibeVersion is the lowest Mistral Vibe version this adapter's install
+// requires — the ONLY version directly verified (source-read AND live-fired
+// against the installed CLI during this issue's audit). #1355 recorded that
+// Vibe's hook schema had "breaking changes at 2.15", but that claim is
+// UNVERIFIED here: an attempted upstream changelog fetch produced content
+// contradicted by this adapter's own live-fired 2.19.1 event names and was
+// discarded as a likely fabrication rather than cited.
+//
+// The cost of pinning to the verified version rather than the unverified
+// 2.15 claim: core/pkg/cliversion fails open only on an UNPARSEABLE version,
+// so a real 2.15-2.18 install is refused by this floor, not waved through —
+// that is a real, accepted cost, not a free choice. Lowering the floor later
+// is cheap once someone verifies an earlier version against source; pinning
+// too low first is not (a hooks.toml written in a schema Vibe silently
+// ignores is indistinguishable from a working install).
+const minVibeVersion = "2.19.1"
+
+// HookEndpointPath is the daemon's Mistral Vibe hook route — unused for
+// actual HTTP routing (delivery is address-free, see below) but still
+// registered so startup.go's route table and beaconroute_test.go's pinned
+// map derive from the same segment this installer's Sentinel is scoped to,
+// matching every other adapter's convention.
+var HookEndpointPath = hookbeacon.EndpointPath(AdapterName)
+
+func hooksTomlPath() (string, error) {
+	home, err := vibeHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, hooksFilename), nil
+}
+
+// vibeConfigTomlPath is the SAME resolver configuredSaveDir() (config.go)
+// already reads from — one function, so the file the hooks flag is written
+// into and the file the transcripts permission reads [session_logging] from
+// cannot resolve to two different paths.
+func vibeConfigTomlPath() (string, error) {
+	home, err := vibeHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, configFilename), nil
+}
+
+// vibeHookEntryBlock renders the canonical [[hooks]] table for command,
+// already resolved by the caller (see hookbeacon.InstalledCommand's own doc
+// for why: Uninstall must keep working once the binary it names has been
+// removed, and never needs to resolve it at all).
+func vibeHookEntryBlock(command string) []byte {
+	return []byte("[[hooks]]\n" +
+		"name = " + hooktoml.Quote(hookEntryName) + "\n" +
+		"type = " + hooktoml.Quote(hookEventPostAgentTurn) + "\n" +
+		"command = " + hooktoml.Quote(command) + "\n")
+}
+
+// vibeHookConfig describes this adapter's install to hooktoml, for a command
+// already resolved by the caller — the identical split ourHookEntry/
+// beaconEntry draws in geminicli/hookinstaller.go, for the identical reason.
+//
+// IsCanonical compares whole-block bytes rather than parsing the command
+// field back out: hooktoml's own sentinel search (Sentinel is a substring of
+// the rendered command, hookbeacon.Sentinel) already found this block by its
+// command; whether it is CURRENT is then simply "are these exactly the bytes
+// we would write today", which is also what makes a stray leading comment on
+// an old install (from a version of this adapter that wrote one) trigger a
+// clean rewrite rather than being treated as canonical-with-decoration.
+func vibeHookConfig(path, command string) hooktoml.HookConfig {
+	canonical := bytes.TrimSpace(vibeHookEntryBlock(command))
+	return hooktoml.HookConfig{
+		Path:     path,
+		Sentinel: hookbeacon.Sentinel(AdapterName),
+		Entry:    func() []byte { return vibeHookEntryBlock(command) },
+		IsCanonical: func(section []byte) bool {
+			return bytes.Equal(bytes.TrimSpace(section), canonical)
+		},
+		WriteFile: hooktoml.AtomicWriteFile,
+	}
+}
+
+// EnsureHooksInstalled adds irrlicht's hook entry to hooks.toml and turns on
+// enable_experimental_hooks in config.toml, creating either file if absent.
+// Every other key in config.toml, and every other [[hooks]] block in
+// hooks.toml, is left byte-for-byte alone. Returns true if either file was
+// modified.
+func EnsureHooksInstalled() (bool, error) {
+	hooksPath, err := hooksTomlPath()
+	if err != nil {
+		return false, err
+	}
+	configPath, err := vibeConfigTomlPath()
+	if err != nil {
+		return false, err
+	}
+	command, err := hookbeacon.InstalledCommand(AdapterName)
+	if err != nil {
+		return false, err
+	}
+
+	flagModified, err := hooktoml.EnsureBoolTrue(configPath, experimentalHooksFlag, hooktoml.AtomicWriteFile)
+	if err != nil {
+		return false, err
+	}
+	entryModified, err := hooktoml.EnsureInstalled(vibeHookConfig(hooksPath, command))
+	if err != nil {
+		return flagModified, err
+	}
+	return flagModified || entryModified, nil
+}
+
+// UninstallHooks removes irrlicht's entry from hooks.toml. It also clears
+// enable_experimental_hooks in config.toml, but ONLY when hooks.toml is left
+// with no [[hooks]] block at all afterward — a user's OWN hand-written hooks
+// in that same file still need the flag held true, and turning it off out
+// from under them would silently disable content this permission never
+// touched. Returns true if either file was modified.
+func UninstallHooks() (bool, error) {
+	hooksPath, err := hooksTomlPath()
+	if err != nil {
+		return false, err
+	}
+	configPath, err := vibeConfigTomlPath()
+	if err != nil {
+		return false, err
+	}
+	command, err := hookbeacon.InstalledCommand(AdapterName)
+	if err != nil {
+		return false, err
+	}
+
+	entryModified, err := hooktoml.Uninstall(vibeHookConfig(hooksPath, command))
+	if err != nil {
+		return false, err
+	}
+
+	hasOther, err := hooktoml.HasAnyHooksBlock(hooksPath)
+	if err != nil {
+		return entryModified, err
+	}
+	if hasOther {
+		return entryModified, nil
+	}
+
+	flagModified, err := hooktoml.ClearBoolIfPresent(configPath, experimentalHooksFlag, hooktoml.AtomicWriteFile)
+	if err != nil {
+		return entryModified, err
+	}
+	return entryModified || flagModified, nil
+}
+
+// VerifyHooksInstalled reports what our install looks like RIGHT NOW,
+// without writing anything (issue #1372). Vibe's own settings UI can rewrite
+// config.toml the same way gemini-cli's does (VibeConfig.save_updates merges
+// into the RAW dict off disk rather than a filtered model_dump, so our hand-
+// written flag survives an ordinary settings change — but nothing stops a
+// future in-app hooks editor, or a hand edit, from dropping either file's
+// content), so this is what lets services.HookEntryVerifier notice and
+// repair a dead install instead of silently trusting a "granted" permission.
+//
+// A missing OR canonical-but-ungated entry both read as Missing: the
+// practical effect on the daemon is identical either way — the hook cannot
+// fire — and HookEntryStatus has no third state to spend on distinguishing
+// "the TOML block is there but inert" from "the TOML block is gone".
+func VerifyHooksInstalled() (agent.HookEntryStatus, error) {
+	hooksPath, err := hooksTomlPath()
+	if err != nil {
+		return agent.HookEntryStatus{}, err
+	}
+	configPath, err := vibeConfigTomlPath()
+	if err != nil {
+		return agent.HookEntryStatus{}, err
+	}
+	command, err := hookbeacon.InstalledCommand(AdapterName)
+	if err != nil {
+		return agent.HookEntryStatus{}, err
+	}
+
+	present, canonical, err := hooktoml.Inspect(vibeHookConfig(hooksPath, command))
+	if err != nil {
+		return agent.HookEntryStatus{}, err
+	}
+	flagOn, _, err := hooktoml.TopLevelBool(configPath, experimentalHooksFlag)
+	if err != nil {
+		return agent.HookEntryStatus{}, err
+	}
+
+	switch {
+	case !present || !flagOn:
+		return agent.HookEntryStatus{Missing: []string{hookEventPostAgentTurn}}, nil
+	case !canonical:
+		return agent.HookEntryStatus{Stale: []string{hookEventPostAgentTurn}}, nil
+	default:
+		return agent.HookEntryStatus{}, nil
+	}
+}

--- a/core/adapters/inbound/agents/vibe/hookinstaller_test.go
+++ b/core/adapters/inbound/agents/vibe/hookinstaller_test.go
@@ -1,0 +1,339 @@
+// hookinstaller_test.go covers the writing half: the install-type permission
+// gate (#797), and the install/verify/uninstall round trip against Vibe's
+// own hooks.toml and config.toml.
+//
+// The two-file shape is the point of several tests here that no prior hook
+// adapter needed: this permission's Apply writes hooks.toml (the entry) AND
+// config.toml (the gate the entry cannot fire without) — agent.
+// ManagedUserFile.Also (#1731), and the file this ticket is the first real
+// consumer of.
+package vibe
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"irrlicht/core/domain/permission"
+	"irrlicht/core/internal/contracttesting"
+)
+
+// hooksPermission returns the real declared hooks permission.
+func hooksPermission(t *testing.T) (apply, remove func() error) {
+	t.Helper()
+	for _, p := range Agent().Permissions {
+		if p.Key == PermissionKeyHooks {
+			return p.Apply, p.Remove
+		}
+	}
+	t.Fatal("no hooks permission declared")
+	return nil, nil
+}
+
+// hooksAreLiveAndEnabled reports whether hooks.toml carries our entry AND
+// config.toml's gate is on — the two facts that together mean the hook can
+// actually fire, mirroring VerifyHooksInstalled's own definition of intact.
+func hooksAreLiveAndEnabled(t *testing.T) bool {
+	t.Helper()
+	status, err := VerifyHooksInstalled()
+	if err != nil {
+		t.Fatalf("VerifyHooksInstalled: %v", err)
+	}
+	return status.Intact()
+}
+
+// TestHooksPermission_IsGated wires the install-type flavour of the #797
+// contract: nothing is written while the permission is pending, granting
+// writes both files, and denying removes the entry (and, since nothing else
+// is installed, clears the flag too).
+func TestHooksPermission_IsGated(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv(vibeHomeEnvVar, "")
+	apply, remove := hooksPermission(t)
+
+	state := permission.StatePending
+	contracttesting.AssertPermissionGated(t, contracttesting.PermissionGate{
+		Key: PermissionKeyHooks,
+		// transcripts is the adapter's only other declared permission and is
+		// observe-kind, so it has no closure to drive: the key-isolation arm
+		// is INERT here and repeats the revoked arm exactly, the same
+		// situation copilot's and geminicli's equivalent tests document.
+		// Install-type wirings hold their own permission's closures, so a
+		// wrong key is not representable — the arm is load-bearing at the
+		// live receiver (hooks_test.go), not here.
+		OtherKeys: []string{PermissionKeyTranscripts},
+		SetState:  contracttesting.OnlyKey(PermissionKeyHooks, func(s permission.State) { state = s }),
+		Exercise: func() {
+			switch state {
+			case permission.StateGranted:
+				if err := apply(); err != nil {
+					t.Fatalf("apply: %v", err)
+				}
+			case permission.StateDenied:
+				if err := remove(); err != nil {
+					t.Fatalf("remove: %v", err)
+				}
+			}
+		},
+		Observe: func() bool { return hooksAreLiveAndEnabled(t) },
+	})
+}
+
+// TestInstallVerifyUninstall_RoundTrip pins the three-way agreement between
+// what the installer writes, what Verify reports, and what Uninstall
+// removes.
+func TestInstallVerifyUninstall_RoundTrip(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv(vibeHomeEnvVar, "")
+
+	status, err := VerifyHooksInstalled()
+	if err != nil {
+		t.Fatalf("verify before install: %v", err)
+	}
+	if status.Intact() {
+		t.Error("Verify reports intact before anything was installed")
+	}
+
+	modified, err := EnsureHooksInstalled()
+	if err != nil {
+		t.Fatalf("install: %v", err)
+	}
+	if !modified {
+		t.Error("first install reported no modification")
+	}
+
+	if status, err = VerifyHooksInstalled(); err != nil || !status.Intact() {
+		t.Errorf("Verify after install: intact=%v err=%v damage=%s", status.Intact(), err, status.Damage())
+	}
+
+	// Idempotent: a second install changes nothing.
+	if modified, err = EnsureHooksInstalled(); err != nil || modified {
+		t.Errorf("second install modified=%v err=%v, want false/nil", modified, err)
+	}
+
+	if modified, err = UninstallHooks(); err != nil || !modified {
+		t.Errorf("uninstall modified=%v err=%v, want true/nil", modified, err)
+	}
+	if hooksAreLiveAndEnabled(t) {
+		t.Error("entries survive uninstall")
+	}
+}
+
+// TestVerifyDoesNotCreateEitherFile is the read-only half of #1372, over
+// both files this permission's Apply can write.
+func TestVerifyDoesNotCreateEitherFile(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv(vibeHomeEnvVar, "")
+
+	if _, err := VerifyHooksInstalled(); err != nil {
+		t.Fatalf("verify: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(home, defaultHomeDirName)); !os.IsNotExist(err) {
+		t.Errorf("Verify created the .vibe directory; it must be read-only")
+	}
+}
+
+// TestUninstallPreservesUnrelatedContent seeds both files with content
+// irrlicht did not write and asserts install+uninstall leaves it byte-for-
+// byte alone — the property hooktoml's own tests establish in isolation,
+// pinned here at the adapter's actual call sites.
+func TestUninstallPreservesUnrelatedContent(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv(vibeHomeEnvVar, "")
+	vibeHome := filepath.Join(home, defaultHomeDirName)
+	if err := os.MkdirAll(vibeHome, 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	hooksSeed := "# my own lint hook\n[[hooks]]\nname = \"lint\"\ntype = \"post_agent_turn\"\ncommand = \"eslint --quiet .\"\n"
+	if err := os.WriteFile(filepath.Join(vibeHome, hooksFilename), []byte(hooksSeed), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	configSeed := "active_model = \"mistral-medium-3.5\"  # my favourite\nbypass_tool_permissions = false\n"
+	if err := os.WriteFile(filepath.Join(vibeHome, configFilename), []byte(configSeed), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := EnsureHooksInstalled(); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+	if _, err := UninstallHooks(); err != nil {
+		t.Fatalf("uninstall: %v", err)
+	}
+
+	hooksGot, err := os.ReadFile(filepath.Join(vibeHome, hooksFilename))
+	if err != nil {
+		t.Fatalf("hooks.toml gone after install+uninstall: %v", err)
+	}
+	if !containsAll(string(hooksGot), "# my own lint hook", "name = \"lint\"") {
+		t.Errorf("the user's own hook or its comment was lost:\n%s", hooksGot)
+	}
+
+	configGot, err := os.ReadFile(filepath.Join(vibeHome, configFilename))
+	if err != nil {
+		t.Fatalf("config.toml gone after install+uninstall: %v", err)
+	}
+	if !containsAll(string(configGot), "active_model = \"mistral-medium-3.5\"  # my favourite", "bypass_tool_permissions = false") {
+		t.Errorf("unrelated config.toml content was lost:\n%s", configGot)
+	}
+}
+
+// TestUninstall_ClearsTheFlagOnlyWhenNoOtherHooksRemain is the defect test
+// for the two-file coordination this adapter's Uninstall owns: a user's OWN
+// hand-written [[hooks]] entry in hooks.toml still needs
+// enable_experimental_hooks held true after OUR entry is removed, or their
+// hook silently stops firing too.
+func TestUninstall_ClearsTheFlagOnlyWhenNoOtherHooksRemain(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv(vibeHomeEnvVar, "")
+	vibeHome := filepath.Join(home, defaultHomeDirName)
+	if err := os.MkdirAll(vibeHome, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	userHook := "[[hooks]]\nname = \"lint\"\ntype = \"post_agent_turn\"\ncommand = \"eslint --quiet .\"\n"
+	if err := os.WriteFile(filepath.Join(vibeHome, hooksFilename), []byte(userHook), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := EnsureHooksInstalled(); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+	if _, err := UninstallHooks(); err != nil {
+		t.Fatalf("uninstall: %v", err)
+	}
+
+	configPath := filepath.Join(vibeHome, configFilename)
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("config.toml: %v", err)
+	}
+	if !containsAll(string(data), "enable_experimental_hooks = true") {
+		t.Errorf("the flag was cleared although the user's own hook is still in hooks.toml — "+
+			"their hook can no longer fire:\n%s", data)
+	}
+
+	hooksGot, err := os.ReadFile(filepath.Join(vibeHome, hooksFilename))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !containsAll(string(hooksGot), "name = \"lint\"") {
+		t.Errorf("the user's own hook was removed:\n%s", hooksGot)
+	}
+}
+
+// TestUninstall_ClearsTheFlagWhenNoHooksRemain is the vacuity guard for the
+// test above: when OUR entry was the only one, the flag IS cleared.
+func TestUninstall_ClearsTheFlagWhenNoHooksRemain(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv(vibeHomeEnvVar, "")
+
+	if _, err := EnsureHooksInstalled(); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+	if _, err := UninstallHooks(); err != nil {
+		t.Fatalf("uninstall: %v", err)
+	}
+
+	configPath, err := vibeConfigTomlPath()
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("config.toml: %v", err)
+	}
+	if containsAll(string(data), "enable_experimental_hooks = true") {
+		t.Errorf("the flag survived although no [[hooks]] block remains:\n%s", data)
+	}
+}
+
+// TestEnsureHooksInstalled_RewritesAStaleCommandInPlace pins that a
+// previously-installed entry naming a different (e.g. moved) irrlichd binary
+// is reconciled in place rather than left stale or duplicated — the
+// adapter-side half of hookbeacon's binary-path drift handling, which
+// hooktoml's own IsCanonical hook exists to let an adapter wire at all.
+func TestEnsureHooksInstalled_RewritesAStaleCommandInPlace(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv(vibeHomeEnvVar, "")
+	vibeHome := filepath.Join(home, defaultHomeDirName)
+	if err := os.MkdirAll(vibeHome, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	stale := "[[hooks]]\nname = \"irrlicht-turn-done\"\ntype = \"post_agent_turn\"\n" +
+		"command = \"/old/nonexistent/irrlichd hook-post mistral-vibe >/dev/null || true\"\n"
+	if err := os.WriteFile(filepath.Join(vibeHome, hooksFilename), []byte(stale), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	modified, err := EnsureHooksInstalled()
+	if err != nil {
+		t.Fatalf("EnsureHooksInstalled: %v", err)
+	}
+	if !modified {
+		t.Error("reconciling a stale entry reported no modification")
+	}
+	if !hooksAreLiveAndEnabled(t) {
+		t.Error("the entry is not canonical after reconciliation")
+	}
+	got, err := os.ReadFile(filepath.Join(vibeHome, hooksFilename))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Count(string(got), "[[hooks]]") != 1 {
+		t.Errorf("reconciliation duplicated the block instead of rewriting it in place:\n%s", got)
+	}
+	if strings.Contains(string(got), "/old/nonexistent/irrlichd") {
+		t.Errorf("the stale binary path survived reconciliation:\n%s", got)
+	}
+}
+
+// TestWrites_DeclaresBothFiles pins the #1731 field this adapter is the
+// first real consumer of: Path is hooks.toml (what --uninstall-hooks and
+// the disclosure copy mean by "the file this permission writes"), Also
+// names config.toml.
+func TestWrites_DeclaresBothFiles(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv(vibeHomeEnvVar, "")
+
+	for _, p := range Agent().Permissions {
+		if p.Key != PermissionKeyHooks {
+			continue
+		}
+		if p.Writes == nil {
+			t.Fatal("hooks permission declares no Writes")
+		}
+		path, err := p.Writes.Path()
+		if err != nil {
+			t.Fatalf("Path(): %v", err)
+		}
+		if filepath.Base(path) != hooksFilename {
+			t.Errorf("Writes.Path() = %q, want basename %q", path, hooksFilename)
+		}
+		if len(p.Writes.Also) != 1 {
+			t.Fatalf("Writes.Also has %d entries, want 1", len(p.Writes.Also))
+		}
+		also, err := p.Writes.Also[0]()
+		if err != nil {
+			t.Fatalf("Also[0](): %v", err)
+		}
+		if filepath.Base(also) != configFilename {
+			t.Errorf("Writes.Also[0]() = %q, want basename %q", also, configFilename)
+		}
+		return
+	}
+	t.Fatal("no hooks permission declared")
+}
+
+func containsAll(s string, subs ...string) bool {
+	for _, sub := range subs {
+		if !strings.Contains(s, sub) {
+			return false
+		}
+	}
+	return true
+}

--- a/core/adapters/inbound/agents/vibe/hookpath_test.go
+++ b/core/adapters/inbound/agents/vibe/hookpath_test.go
@@ -1,0 +1,38 @@
+// hookpath_test.go wires this adapter's hook receiver into the shared issue
+// #1361 contract: a caller-supplied transcript path is confined to the
+// adapter's declared roots, symlinks resolved first, and anything outside
+// is refused, logged, counted — and still answered 2xx.
+package vibe
+
+import (
+	"testing"
+
+	"irrlicht/core/internal/contracttesting"
+)
+
+func TestHookPathConfined(t *testing.T) {
+	contracttesting.AssertHookPathConfined(t, contracttesting.HookReceiver{
+		Root: vibeSessionRoot,
+		New: func(t *testing.T) contracttesting.HookReceiverUnderTest {
+			t.Helper()
+			target := &mockTarget{}
+			return contracttesting.HookReceiverUnderTest{
+				Handler:  NewHookHandler(target, nil, mockLogger{}),
+				Observed: func() bool { return target.totalCalls() > 0 },
+				ObservedPath: func() string {
+					stops := target.stops()
+					if len(stops) == 0 {
+						return ""
+					}
+					return stops[len(stops)-1].transcriptPath
+				},
+			}
+		},
+		WriteTranscript: writeContractTranscript,
+		TranscriptExt:   transcriptExt,
+		PayloadFor: func(transcriptPath string) string {
+			return contractPayload(transcriptPath, hookEventPostAgentTurn)
+		},
+		EndpointPath: HookEndpointPath,
+	})
+}

--- a/core/adapters/inbound/agents/vibe/hookport_test.go
+++ b/core/adapters/inbound/agents/vibe/hookport_test.go
@@ -1,0 +1,135 @@
+// hookport_test.go wires the Mistral Vibe hook installer into the shared
+// issue #1178 contract, under its DeliveryAddressFree route (#1453): the
+// installed entry carries no address at all, because it names the
+// `irrlichd hook-post mistral-vibe` beacon, which resolves the daemon's
+// address itself at fire time.
+//
+// The read-back obligations (2-4) go through HookInstaller.ReadEntries /
+// EndpointOfRaw (#1734, widened specifically for this adapter's own audit of
+// #1716's map-typed seam): hooktoml never produces a decoded generic
+// structure — it works entirely as byte-range edits over the original file
+// bytes — so vibeReadEntries and vibeEndpointOfRaw are thin wrappers over
+// hooktoml.HookBlocks and hooktoml.FieldValue rather than anything JSON-
+// shaped. Entry/EndpointOf (obligation 1, in-memory only) stay
+// map[string]interface{} regardless — nothing downstream of them touches the
+// filesystem, so a synthetic one-key map answers that question honestly even
+// though what actually lands on disk is raw TOML text.
+package vibe
+
+import (
+	"testing"
+
+	"irrlicht/core/adapters/inbound/agents/hooktoml"
+	"irrlicht/core/internal/contracttesting"
+	"irrlicht/core/pkg/hookbeacon"
+)
+
+// TestHookEntry_IsABeaconCommand pins the exact object rendered for Vibe's
+// [[hooks]] command field, which the shared contract deliberately does not
+// look at directly — it only cares that the delivery inside carries no
+// address. The command is never a bare curl line (which would fail closed on
+// the agent's next turn whenever the daemon is not running).
+func TestHookEntry_IsABeaconCommand(t *testing.T) {
+	command, err := hookbeacon.InstalledCommand(AdapterName)
+	if err != nil {
+		t.Fatalf("resolving the beacon command: %v", err)
+	}
+	block := vibeHookEntryBlock(command)
+	got, ok := hooktoml.FieldValue(block, "command")
+	if !ok || got != command {
+		t.Errorf("command field = %q, ok=%v, want %q, true", got, ok, command)
+	}
+	if _, ok := hooktoml.FieldValue(block, "url"); ok {
+		t.Error("entry carries a url field; beacon delivery names no address")
+	}
+}
+
+// vibeEntryNow/vibeEndpointOfMap are the contract's in-memory Entry/
+// EndpointOf pair for obligation 1 — a synthetic one-key map, since
+// obligation 1 never reads the filesystem (deliveriesOnBothAddrs calls
+// EndpointOf(Entry()) directly). Deliberately NOT vibeHookEntryBlock's real
+// TOML rendering: that would work too, but the map is the shape
+// HookInstaller.EndpointOfRaw's own doc comment describes as the intended
+// answer here ("an adapter can honestly answer that question with a map
+// even when what it actually persists to disk is raw TOML text").
+func vibeEntryNow() map[string]interface{} {
+	command, _ := hookbeacon.InstalledCommand(AdapterName)
+	return map[string]interface{}{"command": command}
+}
+
+func vibeEndpointOfMap(hook map[string]interface{}) string {
+	c, _ := hook["command"].(string)
+	return c
+}
+
+// vibeReadEntries is the contract's ReadEntries: every [[hooks]] block in
+// hooks.toml, raw. event is ignored — hooktoml has no per-event
+// disambiguation (vibe installs exactly one event, so "the entry" is
+// unambiguous without filtering), the decision
+// HookInstaller.ReadEntries's own doc comment and the reference TOML
+// installer's TestReferenceTOMLReadEntries_IgnoresEventArgument both record
+// as a deliberately supported shape, not a gap this wiring is working
+// around.
+func vibeReadEntries(path, _ string) ([][]byte, error) {
+	return hooktoml.HookBlocks(path)
+}
+
+// vibeEndpointOfRaw extracts the command field's decoded value from one raw
+// [[hooks]] block — the same field IsCanonical already compares, applied
+// here to a single named field instead of the whole block.
+func vibeEndpointOfRaw(entry []byte) string {
+	v, _ := hooktoml.FieldValue(entry, "command")
+	return v
+}
+
+func TestHookEndpointFollowsBindAddr(t *testing.T) {
+	// Checked up front so a resolution failure reads as itself rather than
+	// as the empty-delivery wiring error assertDeliveryIsOurs would report.
+	if _, err := hookbeacon.InstalledCommand(AdapterName); err != nil {
+		t.Fatalf("resolving the beacon command: %v", err)
+	}
+
+	contracttesting.AssertHookEndpointFollowsBindAddr(t, contracttesting.HookInstaller{
+		Delivery: contracttesting.DeliveryAddressFree,
+		SettingsPath: func(t *testing.T) string {
+			home := t.TempDir()
+			t.Setenv("HOME", home)
+			t.Setenv(vibeHomeEnvVar, "")
+			path, err := hooksTomlPath()
+			if err != nil {
+				t.Fatalf("resolving hooks.toml path: %v", err)
+			}
+			return path
+		},
+		Sentinel:      hookbeacon.Sentinel(AdapterName),
+		Events:        installedHookEvents,
+		Entry:         vibeEntryNow,
+		EndpointOf:    vibeEndpointOfMap,
+		ReadEntries:   vibeReadEntries,
+		EndpointOfRaw: vibeEndpointOfRaw,
+		// EnsureInstalled/Uninstall are the REAL adapter entry points, not a
+		// hooks.toml-only stand-in: they also touch config.toml's
+		// enable_experimental_hooks flag, which the contract never inspects
+		// (it only reads hooks.toml back through ReadEntries) but which is
+		// exactly the production code path a fake substitute would not
+		// exercise.
+		EnsureInstalled: EnsureHooksInstalled,
+		Uninstall:       UninstallHooks,
+		// ForeignInstall seeds an entry naming a DIFFERENT (nonexistent)
+		// irrlicht binary — the address-free counterpart of seeding a
+		// stale-port install — so the contract can assert EnsureInstalled
+		// rewrites it in place rather than duplicating it. Mirrors
+		// geminicli's identical ForeignInstall shape.
+		ForeignInstall: func() (bool, error) {
+			path, err := hooksTomlPath()
+			if err != nil {
+				return false, err
+			}
+			command, err := hookbeacon.Command("/nonexistent-irrlicht-1718/bin/irrlichd", AdapterName)
+			if err != nil {
+				return false, err
+			}
+			return hooktoml.EnsureInstalled(vibeHookConfig(path, command))
+		},
+	})
+}

--- a/core/adapters/inbound/agents/vibe/hookreceipt_test.go
+++ b/core/adapters/inbound/agents/vibe/hookreceipt_test.go
@@ -1,0 +1,33 @@
+// hookreceipt_test.go wires this adapter's hook receiver into the shared
+// issue #1368 contract: a consent-passed request counts as a receipt
+// whatever the receiver then does with it, and a consent-denied one does
+// not.
+package vibe
+
+import (
+	"net/http"
+	"testing"
+
+	"irrlicht/core/internal/contracttesting"
+	"irrlicht/core/ports/outbound"
+)
+
+func TestHookReceiptObserved(t *testing.T) {
+	contracttesting.AssertHookReceiptObserved(t, contracttesting.HookReceiptReceiver{
+		Adapter:         AdapterName,
+		Root:            vibeSessionRoot,
+		WriteTranscript: writeContractTranscript,
+		New: func(t *testing.T, log outbound.Logger) http.Handler {
+			t.Helper()
+			return NewHookHandler(&mockTarget{},
+				keyedGate{PermissionKeyHooks: true, PermissionKeyTranscripts: true}, log)
+		},
+		NewDenied: func(t *testing.T, log outbound.Logger) http.Handler {
+			t.Helper()
+			return NewHookHandler(&mockTarget{}, keyedGate{}, log)
+		},
+		PayloadFor:   contractPayload,
+		KnownEvent:   hookEventPostAgentTurn,
+		EndpointPath: HookEndpointPath,
+	})
+}

--- a/core/adapters/inbound/agents/vibe/hooks.go
+++ b/core/adapters/inbound/agents/vibe/hooks.go
@@ -1,0 +1,185 @@
+// hooks.go provides the HTTP handler for receiving Mistral Vibe hook events
+// (issue #1718, epic #1355).
+//
+// Exactly one event is installed: post_agent_turn, dispatched to
+// HandleStopHook with an empty text and a false waitingCue. Vibe's own
+// payload for this event carries no message content at all — source-read
+// (vibe/core/hooks/models.go: PostAgentTurnInvocation adds nothing to the
+// shared HookSessionContext) AND live-fired against the installed 2.19.1
+// CLI during this issue's audit, which confirmed the delivered body is
+// exactly {session_id, transcript_path, cwd, parent_session_id,
+// hook_event_name}. This is the SAME "honest floor" hook_signal.go already
+// documents for a payload-free HookStop row: HandleStopHook still asserts
+// SignalTurnDone/HookTurnDone unconditionally and only conditionally
+// overlays the text/cue fields, so the authoritative "turn truly ended"
+// signal is real even without message content — it just cannot correct a
+// waiting-cue verdict the transcript tail already computed, which is the
+// same limit every other adapter's payload-free path accepts.
+//
+// before_tool and after_tool are deliberately NOT installed, and this is
+// the ticket's central negative finding (see the audit comment on #1718).
+// before_tool fires unconditionally for EVERY tool call, before Vibe's own
+// internal permission check even runs — source-traced in
+// vibe/core/agent_loop/_loop.py's _execute_tool_call:
+// _run_before_tool_pipeline runs, THEN _should_execute_tool/_ask_approval —
+// and confirmed by Vibe's own bundled, LLM-facing documentation ("before_tool
+// | Per tool call, before the user permission prompt"). Its payload carries
+// no field indicating whether THIS call will reach an interactive prompt
+// (that depends on per-session ALWAYS/NEVER/ASK runtime state the hook never
+// sees), so asserting SignalPermissionPrompt on it would hold `waiting` on
+// every single tool call, approved or not. after_tool was considered as a
+// broad release (the pattern gemini-cli's AfterTool uses) but that pattern
+// is only safe paired with a narrow assert on the SAME signal from the SAME
+// adapter — Vibe has none, and repo-wide session.SignalPermissionPrompt is
+// held only by hook-derived calls (HandlePermissionHook/
+// HandlePermissionPromptHook — nothing transcript-heuristic touches it), so
+// a release with nothing to ever release would be pure surface area with
+// zero behavioral value.
+package vibe
+
+import (
+	"net/http"
+	"runtime"
+
+	"irrlicht/core/adapters/inbound/agents/hookjson"
+	"irrlicht/core/domain/agent"
+	"irrlicht/core/ports/outbound"
+)
+
+// PermissionKeyHooks gates installing and receiving Mistral Vibe hooks
+// (issue #570). Aliased to the shared domain constant rather than restated —
+// see agent.HooksPermissionKey's own doc for why two external projections
+// narrow on it.
+const PermissionKeyHooks = agent.HooksPermissionKey
+
+// logComponentHookReceiver is the Logger component tag for every log line
+// this receiver emits.
+const logComponentHookReceiver = "vibe-hook-receiver"
+
+// transcriptExt is the file extension the hook receiver confines
+// caller-supplied paths to — messages.jsonl, the constant filename every
+// Vibe session transcript uses (see adapter.go's transcriptFilename).
+const transcriptExt = ".jsonl"
+
+// vibeHookPayload is the JSON body Vibe POSTs on a hook event — live-fired
+// and confirmed against the installed 2.19.1 CLI. SessionID is decoded only
+// to be available for logging; session identity is derived from the
+// transcript path (sessionIDFromTranscriptPath below), the same choice
+// every other JSON hook receiver in this codebase makes and for the same
+// reason: it is the id the fswatcher and the rest of the daemon already key
+// sessions on, where a hook's own session_id is not guaranteed to agree
+// (gemini-cli's hooks.go documents a measured case where it did not).
+type vibeHookPayload struct {
+	HookEventName string `json:"hook_event_name"`
+
+	// TranscriptPath is confined and then overwritten with the confined
+	// spelling by DecodeConfined — see NewHookHandler.
+	TranscriptPath string `json:"transcript_path"`
+
+	// SessionID is Vibe's own session id, logged only. Never used to derive
+	// the id this adapter dispatches under.
+	SessionID string `json:"session_id"`
+}
+
+// HookTarget is the interface the handler calls into. Satisfied by
+// *services.SessionDetector without importing the services package — the
+// same agent-agnostic surface claudecode's, codex's, copilot's and
+// geminicli's hooks use, narrowed to the one method this adapter's single
+// installed event needs.
+type HookTarget interface {
+	HandleStopHook(sessionID, transcriptPath, lastAssistantText string, waitingCue bool)
+}
+
+// ConsentGranter is the shared consent check every JSON-hook receiver gates
+// on (issue #570) — an alias, not a copy, so the receivers cannot drift.
+type ConsentGranter = hookjson.ConsentGranter
+
+// NewHookHandler returns an http.HandlerFunc that receives Mistral Vibe hook
+// events and dispatches them to the target. The returned hookjson.HookHandler
+// is an http.Handler carrying the confiner it guards caller-supplied
+// transcript paths with (issue #1390).
+//
+// gate is the consent check; while the "hooks" permission is not granted the
+// payload is dropped with 200, so the installed hook stays quiet. A nil gate
+// means no gating — used by tests.
+func NewHookHandler(target HookTarget, gate ConsentGranter, log outbound.Logger) hookjson.HookHandler {
+	return hookjson.NewHandler(transcriptConfiner(),
+		hookjson.RequireConsent(gate, AdapterName, PermissionKeyHooks, PermissionKeyTranscripts),
+		func(consent hookjson.Consent, c *hookjson.PathConfiner, w http.ResponseWriter, r *http.Request) {
+			serveHookRequest(target, consent, log, c, w, r)
+		})
+}
+
+// transcriptConfiner returns the confiner this adapter's hook receiver
+// guards caller-supplied transcript paths with, rooted in the adapter's own
+// Source declaration (issue #1361) rather than re-derived from the
+// adapter's constants — so the tree the receiver confines to cannot drift
+// from the one the daemon watches.
+func transcriptConfiner() *hookjson.PathConfiner {
+	return hookjson.ConfinerForSource(Source, runtime.GOOS, transcriptExt)
+}
+
+// serveHookRequest is NewHookHandler's request logic, pulled out of the
+// returned closure so its branching isn't counted at the closure's extra
+// nesting depth. The step order matches every other JSON hook receiver's
+// exactly — see the contract assertions in hook*_test.go.
+func serveHookRequest(target HookTarget, consent hookjson.Consent, log outbound.Logger, confiner *hookjson.PathConfiner, w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	// Both keys come off the receiver's OWN hookjson.Consent (issue #1488),
+	// so the set this sequence is written for is the set the handler
+	// publishes and the contract derives.
+	if !consent.Granted(PermissionKeyHooks) {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
+	// The channel delivered (issue #1368). Counted against the "hooks"
+	// consent only.
+	hookjson.ObserveHookReceipt(AdapterName)
+
+	// Dispatching makes the detector read the transcript, so it is gated
+	// behind "transcripts", not merely the "hooks" write consent. The check
+	// comes BEFORE the decode, and so before confinement, so a denied
+	// session still yields a quiet 200 and the path is never resolved.
+	if !consent.Granted(PermissionKeyTranscripts) {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
+	// The path arrives in an HTTP body on a local, unauthenticated endpoint,
+	// so it is untrusted even though it comes from our own beacon's payload
+	// pass-through. DecodeConfined reads the body and confines in one step
+	// (issues #1361, #1389).
+	var payload vibeHookPayload
+	if !hookjson.DecodeConfined(w, r, log, logComponentHookReceiver, consent, confiner, &payload,
+		func(p *vibeHookPayload) string { return p.TranscriptPath },
+		func(p *vibeHookPayload, confined string) { p.TranscriptPath = confined },
+	) {
+		return
+	}
+	transcriptPath := payload.TranscriptPath
+
+	sessionID := sessionIDFromPath(transcriptPath)
+	if sessionID == "" {
+		// Not a path this adapter owns — drop rather than guess an id. The
+		// transcript tailer covers the state regardless.
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
+	switch payload.HookEventName {
+	case hookEventPostAgentTurn:
+		log.LogInfo(logComponentHookReceiver, sessionID, "received post_agent_turn")
+		target.HandleStopHook(sessionID, transcriptPath, "", false)
+	default:
+		// Unrecognized hook event — accept but ignore, counted per name and
+		// reported once, in the one place that behaviour is decided for
+		// every receiver (issue #1364).
+		hookjson.IgnoreUnknownEvent(log, logComponentHookReceiver, AdapterName, sessionID, payload.HookEventName)
+	}
+	w.WriteHeader(http.StatusOK)
+}

--- a/core/adapters/inbound/agents/vibe/hooks_test.go
+++ b/core/adapters/inbound/agents/vibe/hooks_test.go
@@ -1,0 +1,271 @@
+package vibe
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"irrlicht/core/internal/contracttesting"
+)
+
+// --- test doubles, shared by this file and the contract wirings ---
+
+type stopCall struct {
+	sessionID, transcriptPath, lastAssistantText string
+	waitingCue                                   bool
+}
+
+type mockTarget struct {
+	mu        sync.Mutex
+	stopCalls []stopCall
+}
+
+func (m *mockTarget) HandleStopHook(sessionID, transcriptPath, lastAssistantText string, waitingCue bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.stopCalls = append(m.stopCalls, stopCall{sessionID, transcriptPath, lastAssistantText, waitingCue})
+}
+
+func (m *mockTarget) totalCalls() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return len(m.stopCalls)
+}
+
+func (m *mockTarget) stops() []stopCall {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]stopCall(nil), m.stopCalls...)
+}
+
+// keyedGate pins a fixed permission combination for a one-off test. For a
+// MUTABLE keyed gate driven through states by the shared contract, use
+// contracttesting.ConsentGate instead.
+type keyedGate map[string]bool
+
+func (g keyedGate) Granted(_, key string) bool { return g[key] }
+
+type mockLogger struct{}
+
+func (mockLogger) LogInfo(string, string, string)                       {}
+func (mockLogger) LogError(string, string, string)                      {}
+func (mockLogger) LogProcessingTime(string, string, int64, int, string) {}
+func (mockLogger) Close() error                                         { return nil }
+
+// --- helpers ---
+
+// vibeSessionRoot relocates $HOME and $VIBE_HOME to temp dirs and returns
+// the declared transcript root inside it — every test in this package must
+// isolate VIBE_HOME to a t.TempDir(), never the real ~/.vibe.
+func vibeSessionRoot(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv(vibeHomeEnvVar, "")
+	root := filepath.Join(home, defaultRootDir)
+	if err := os.MkdirAll(root, 0o700); err != nil {
+		t.Fatalf("create sessions dir: %v", err)
+	}
+	return root
+}
+
+// writeSessionTranscript lays down <root>/<session-id>/messages.jsonl and
+// returns its path — the shape sessionIDFromPath expects (parent directory
+// name, since the filename itself is the constant messages.jsonl).
+func writeSessionTranscript(t *testing.T, root, id string) string {
+	t.Helper()
+	dir := filepath.Join(root, id)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatalf("mkdir session dir: %v", err)
+	}
+	path := filepath.Join(dir, transcriptFilename)
+	if err := os.WriteFile(path, []byte(`{"role":"user"}`+"\n"), 0o600); err != nil {
+		t.Fatalf("write transcript: %v", err)
+	}
+	return path
+}
+
+// writeContractTranscript is the shape the receiving-side contracts want: a
+// transcript inside dir whose session id the receiver can resolve.
+func writeContractTranscript(t *testing.T, dir string) string {
+	t.Helper()
+	return writeSessionTranscript(t, dir, "sess-contract")
+}
+
+// contractPayload renders a post_agent_turn-shaped body for one event name
+// — the shape every receiving-side contract wants: transcript_path plus a
+// hook_event_name, nothing else, matching Vibe's OWN wire shape for this
+// event (live-fired during this issue's audit).
+func contractPayload(transcriptPath, event string) string {
+	body, err := json.Marshal(vibeHookPayload{
+		TranscriptPath: transcriptPath,
+		HookEventName:  event,
+		SessionID:      "fake-session-not-used-for-identity",
+	})
+	if err != nil {
+		panic(err)
+	}
+	return string(body)
+}
+
+// post drives the handler with a raw JSON body and returns the response.
+func post(t *testing.T, h http.Handler, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, HookEndpointPath, strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	return rec
+}
+
+// newReceiver builds a fully-granted receiver over the real production
+// confiner, plus the target it dispatches into.
+func newReceiver(t *testing.T) (http.Handler, *mockTarget) {
+	t.Helper()
+	target := &mockTarget{}
+	gate := keyedGate{PermissionKeyHooks: true, PermissionKeyTranscripts: true}
+	return NewHookHandler(target, gate, mockLogger{}), target
+}
+
+// --- behaviour ---
+
+// TestPostAgentTurnHook_DispatchesToHandleStopHook pins the one event this
+// adapter installs: it fires HandleStopHook with an empty text and a false
+// waitingCue, since Vibe's post_agent_turn payload carries no message
+// content at all (live-fired during this issue's audit).
+func TestPostAgentTurnHook_DispatchesToHandleStopHook(t *testing.T) {
+	root := vibeSessionRoot(t)
+	tp := writeSessionTranscript(t, root, "sess-turn")
+	h, target := newReceiver(t)
+
+	rec := post(t, h, contractPayload(tp, hookEventPostAgentTurn))
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200", rec.Code)
+	}
+	stops := target.stops()
+	if len(stops) != 1 {
+		t.Fatalf("HandleStopHook called %d times, want 1", len(stops))
+	}
+	got := stops[0]
+	if got.sessionID != "sess-turn" {
+		t.Errorf("sessionID = %q, want %q", got.sessionID, "sess-turn")
+	}
+	if got.transcriptPath != tp {
+		t.Errorf("transcriptPath = %q, want %q", got.transcriptPath, tp)
+	}
+	if got.lastAssistantText != "" {
+		t.Errorf("lastAssistantText = %q, want empty — Vibe's post_agent_turn carries no message text", got.lastAssistantText)
+	}
+	if got.waitingCue {
+		t.Errorf("waitingCue = true, want false — nothing in the payload can assert one")
+	}
+}
+
+// TestHookReceiver_PermissionGateContract runs the shared #797 contract once
+// per permission this receiver must honour, derived from the receiver's own
+// declaration (issue #1488).
+func TestHookReceiver_PermissionGateContract(t *testing.T) {
+	contracttesting.AssertHookReceiverPermissionGated(t, contracttesting.HookReceiverGate{
+		Build: func(t *testing.T, gate *contracttesting.ConsentGate) contracttesting.GatedHookReceiver {
+			root := vibeSessionRoot(t)
+			body := contractPayload(writeSessionTranscript(t, root, "sess-gate"), hookEventPostAgentTurn)
+			target := &mockTarget{}
+			h := NewHookHandler(target, gate, mockLogger{})
+
+			before := 0
+			return contracttesting.GatedHookReceiver{
+				Handler: h,
+				Exercise: func() {
+					before = target.totalCalls()
+					post(t, h, body)
+				},
+				Observe: func() bool { return target.totalCalls() > before },
+			}
+		},
+	})
+}
+
+// TestHookReceiver_DeclaresItsPermissions is the LOCK on the key list the
+// wiring above used to spell out (#1450).
+func TestHookReceiver_DeclaresItsPermissions(t *testing.T) {
+	contracttesting.AssertDeclaredPermissions(t,
+		NewHookHandler(&mockTarget{}, nil, mockLogger{}),
+		PermissionKeyHooks, PermissionKeyTranscripts)
+}
+
+// TestHookReceiver_NonPostRejected is a LOCK on the shared receiver shape.
+func TestHookReceiver_NonPostRejected(t *testing.T) {
+	vibeSessionRoot(t)
+	h, _ := newReceiver(t)
+	req := httptest.NewRequest(http.MethodGet, HookEndpointPath, nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Errorf("GET status = %d, want 405", rec.Code)
+	}
+}
+
+// TestHookReceiver_MalformedJSONIs400 is a LOCK: a body that will not decode
+// is the one case that answers non-2xx, because nothing about it is a path.
+func TestHookReceiver_MalformedJSONIs400(t *testing.T) {
+	vibeSessionRoot(t)
+	h, _ := newReceiver(t)
+	rec := post(t, h, "{not json")
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", rec.Code)
+	}
+}
+
+// TestHookReceiver_UnknownSessionIsQuiet is a LOCK: a transcript_path this
+// adapter does not own (wrong filename, not messages.jsonl) is dropped
+// rather than guessed at.
+func TestHookReceiver_UnknownSessionIsQuiet(t *testing.T) {
+	root := vibeSessionRoot(t)
+	dir := filepath.Join(root, "sess-other")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	other := filepath.Join(dir, "meta.json")
+	if err := os.WriteFile(other, []byte("{}"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	h, target := newReceiver(t)
+
+	rec := post(t, h, contractPayload(other, hookEventPostAgentTurn))
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200", rec.Code)
+	}
+	if n := target.totalCalls(); n != 0 {
+		t.Errorf("dispatched %d times for a path this adapter does not own, want 0", n)
+	}
+}
+
+// TestHookReceiver_DeniedTranscriptsConsentDropsQuietly pins that a
+// transcripts-denied session must not dispatch even though the hooks
+// consent is granted, and must not log an error while doing it (the
+// receiver's own gate answers quietly; only the shared backstop logs).
+func TestHookReceiver_DeniedTranscriptsConsentDropsQuietly(t *testing.T) {
+	root := vibeSessionRoot(t)
+	tp := writeSessionTranscript(t, root, "sess-denied")
+	target := &mockTarget{}
+	log := &contracttesting.RecordingLogger{}
+	h := NewHookHandler(target, keyedGate{PermissionKeyHooks: true}, log)
+
+	rec := post(t, h, contractPayload(tp, hookEventPostAgentTurn))
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200", rec.Code)
+	}
+	if n := target.totalCalls(); n != 0 {
+		t.Fatalf("dispatched %d times while transcripts consent was denied, want 0", n)
+	}
+	if len(log.Errors()) != 0 {
+		t.Errorf("a transcripts-denied hook logged %d error(s): %v", len(log.Errors()), log.Errors())
+	}
+}

--- a/core/adapters/inbound/agents/vibe/hookunknown_test.go
+++ b/core/adapters/inbound/agents/vibe/hookunknown_test.go
@@ -1,0 +1,31 @@
+// hookunknown_test.go wires this adapter's hook receiver into the shared
+// issue #1364 contract: an event name the receiver does not recognize is
+// counted per (adapter, name), reported once per distinct name, and still
+// answered 2xx.
+package vibe
+
+import (
+	"testing"
+
+	"irrlicht/core/internal/contracttesting"
+	"irrlicht/core/ports/outbound"
+)
+
+func TestUnknownHookEventObserved(t *testing.T) {
+	contracttesting.AssertUnknownHookEventObserved(t, contracttesting.UnknownEventReceiver{
+		Adapter:         AdapterName,
+		Root:            vibeSessionRoot,
+		WriteTranscript: writeContractTranscript,
+		New: func(t *testing.T, log outbound.Logger) contracttesting.UnknownEventReceiverUnderTest {
+			t.Helper()
+			target := &mockTarget{}
+			return contracttesting.UnknownEventReceiverUnderTest{
+				Handler:  NewHookHandler(target, nil, log),
+				Observed: func() bool { return target.totalCalls() > 0 },
+			}
+		},
+		PayloadFor:   contractPayload,
+		KnownEvent:   hookEventPostAgentTurn,
+		EndpointPath: HookEndpointPath,
+	})
+}

--- a/core/adapters/inbound/agents/vibe/hookversion_test.go
+++ b/core/adapters/inbound/agents/vibe/hookversion_test.go
@@ -1,0 +1,98 @@
+// hookversion_test.go wires the Mistral Vibe hooks permission into the
+// shared issue #1365 contract.
+//
+// Like geminicli, this adapter declares no Observed version source: nothing
+// in a Vibe transcript's meta.json sidecar carries a CLI version field this
+// adapter's parser reads, so the gate falls straight through to Probe
+// (`vibe --version`), which cliversion runs itself.
+package vibe
+
+import (
+	"strings"
+	"testing"
+
+	"irrlicht/core/domain/agent"
+	"irrlicht/core/internal/contracttesting"
+)
+
+func TestHooksPermission_DeclaresVersionGate(t *testing.T) {
+	contracttesting.AssertHookVersionGate(t, contracttesting.HookVersionGate{
+		Agent:         Agent(),
+		PermissionKey: PermissionKeyHooks,
+		Installed:     installedHookEvents,
+		Since:         map[string]string{hookEventPostAgentTurn: minVibeVersion},
+	})
+}
+
+// hooksVersionGate returns the declared gate, read off the real registration
+// the daemon consumes rather than a copy.
+func hooksVersionGate(t *testing.T) *agent.VersionGate {
+	t.Helper()
+	for _, p := range Agent().Permissions {
+		if p.Key == PermissionKeyHooks {
+			if p.Writes == nil || p.Writes.Version == nil {
+				t.Fatal("hooks permission declares no version gate")
+			}
+			return p.Writes.Version
+		}
+	}
+	t.Fatal("no hooks permission")
+	return nil
+}
+
+// TestHooksGate_BelowFloorSaysWhy pins that a Vibe older than the declared
+// floor is refused WITH a reason naming both versions.
+func TestHooksGate_BelowFloorSaysWhy(t *testing.T) {
+	gate := hooksVersionGate(t)
+
+	allowed, why := gate.Permits("2.18.0")
+	if allowed {
+		t.Fatal("gate permits installing into Vibe 2.18.0, below the declared floor")
+	}
+	if !strings.Contains(why, "2.18.0") || !strings.Contains(why, minVibeVersion) {
+		t.Errorf("refusal %q names neither the installed version nor the required one; "+
+			"the reason has to tell the user what to upgrade", why)
+	}
+}
+
+// TestHooksGate_AtOrAboveFloorInstalls is a LOCK: it pins that the gate has
+// not become a blanket refusal, which from a log looks identical to one
+// that works.
+func TestHooksGate_AtOrAboveFloorInstalls(t *testing.T) {
+	gate := hooksVersionGate(t)
+	for _, v := range []string{minVibeVersion, "2.20.0", "3.0.0"} {
+		if allowed, why := gate.Permits(v); !allowed {
+			t.Errorf("gate refuses Vibe %s, at or above the %s floor: %s", v, minVibeVersion, why)
+		}
+	}
+}
+
+// TestHooksGate_UnknownVersionFailsOpen pins the documented direction
+// (core/pkg/cliversion): an unparseable or unknown version must not block
+// an install. The daemon runs under launchd with a minimal PATH and
+// routinely cannot see the user's CLI at all, so "unknown" must read as
+// "not proven old", not as "assume the worst".
+func TestHooksGate_UnknownVersionFailsOpen(t *testing.T) {
+	gate := hooksVersionGate(t)
+	if allowed, why := gate.Permits(""); !allowed {
+		t.Errorf("gate refuses on an unknown version: %s", why)
+	}
+}
+
+// TestHooksGate_ProbeIsVibeVersion pins the argv this adapter asks
+// cliversion to run — `vibe --version` prints "vibe X.Y.Z" (live-fired
+// against the installed CLI during this issue's audit; the leading "vibe "
+// word does not confuse cliversion's parser, which searches the whole
+// string for a \d+\.\d+\.\d+ pattern rather than requiring an exact match).
+func TestHooksGate_ProbeIsVibeVersion(t *testing.T) {
+	gate := hooksVersionGate(t)
+	want := []string{"vibe", "--version"}
+	if len(gate.Probe) != len(want) {
+		t.Fatalf("Probe = %v, want %v", gate.Probe, want)
+	}
+	for i := range want {
+		if gate.Probe[i] != want[i] {
+			t.Fatalf("Probe = %v, want %v", gate.Probe, want)
+		}
+	}
+}

--- a/core/cmd/irrlichd/managedfiles_test.go
+++ b/core/cmd/irrlichd/managedfiles_test.go
@@ -44,12 +44,27 @@ func TestPrintManagedFilesCoversEveryDeclaredFile(t *testing.T) {
 
 	printed := linesOf(t, buf.String())
 
+	// want carries Path AND every Also entry (#1718): writeManagedFilePaths
+	// flattens both onto the printed stream, so a want set built from Path
+	// alone reports a real Also file as an unexplained extra the moment any
+	// adapter actually declares one — which mistral-vibe's hooks
+	// permission (hooks.toml as Path, config.toml as Also) is the first to
+	// do. This is the arm PR #1731 landed without: it shipped ahead of a
+	// real Also consumer and this test's own want-set gap was invisible
+	// until one existed.
 	want := map[string]bool{}
 	for _, c := range configs {
 		want[c.Path] = true
 		if !printed[c.Path] {
 			t.Errorf("%s/%s declares %q, which --print-managed-files does not list: "+
 				"a recording would rewrite that file and never restore it (#1383)", c.Adapter, c.Key, c.Path)
+		}
+		for _, also := range c.Also {
+			want[also] = true
+			if !printed[also] {
+				t.Errorf("%s/%s declares Also %q, which --print-managed-files does not list: "+
+					"a recording would rewrite that file and never restore it (#1718)", c.Adapter, c.Key, also)
+			}
 		}
 	}
 	for p := range printed {

--- a/core/cmd/irrlichd/startup.go
+++ b/core/cmd/irrlichd/startup.go
@@ -21,6 +21,7 @@ import (
 	"irrlicht/core/adapters/inbound/agents/copilot"
 	"irrlicht/core/adapters/inbound/agents/geminicli"
 	"irrlicht/core/adapters/inbound/agents/processlifecycle"
+	"irrlicht/core/adapters/inbound/agents/vibe"
 	backchannelhandler "irrlicht/core/adapters/inbound/backchannel"
 	gastownadapter "irrlicht/core/adapters/inbound/orchestrators/gastown"
 	permissionshandler "irrlicht/core/adapters/inbound/permissions"
@@ -933,9 +934,12 @@ func setupBackchannel(mux *http.ServeMux, deps setupBackchannelDeps) (*services.
 // delivered by the `irrlichd hook-post gemini-cli` beacon rather than a native
 // http hook — the detector satisfies geminicli.HookTarget's extra two methods
 // (HandlePermissionPromptHook, ReleasePermissionPromptHold) alongside the two
-// every other receiver already calls. All are consent-gated: hooks installed
-// by a pre-consent daemon keep firing until the wizard is answered, so
-// payloads are dropped while pending.
+// every other receiver already calls; plus Mistral Vibe's post_agent_turn
+// event (issue #1718), also beacon-delivered (`irrlichd hook-post
+// mistral-vibe`) — the detector satisfies vibe.HookTarget's single method,
+// HandleStopHook, which every other receiver already calls too. All are
+// consent-gated: hooks installed by a pre-consent daemon keep firing until
+// the wizard is answered, so payloads are dropped while pending.
 func registerHookRoutes(mux *http.ServeMux, detector *services.SessionDetector, metricsCollector outbound.MetricsCollector, permService *services.PermissionService, logger outbound.Logger) {
 	// mux.Handle, not HandleFunc: each constructor returns a hookjson.HookHandler
 	// — the handler together with the confiner it enforces #1361 with — which
@@ -950,6 +954,8 @@ func registerHookRoutes(mux *http.ServeMux, detector *services.SessionDetector, 
 		copilot.NewHookHandler(detector, permService, logger))
 	mux.Handle("POST "+geminicli.HookEndpointPath,
 		geminicli.NewHookHandler(detector, permService, logger))
+	mux.Handle("POST "+vibe.HookEndpointPath,
+		vibe.NewHookHandler(detector, permService, logger))
 }
 
 // publishAddrFile writes the addr file and thereby signals "the daemon is

--- a/tools/onboarding-factory/internal/hookcov/hookcov_test.go
+++ b/tools/onboarding-factory/internal/hookcov/hookcov_test.go
@@ -17,22 +17,23 @@ import (
 func TestDeclaredMatchesRegistry(t *testing.T) {
 	got := Declared()
 
-	// Exhaustive as of this commit: claudecode, codex, copilot and gemini-cli
-	// are the adapters declaring a hooks permission. If a fifth gains one,
-	// this fails and the new adapter joins the list — that is the intended
-	// workflow, not an obstacle.
+	// Exhaustive as of this commit: claudecode, codex, copilot, gemini-cli
+	// and mistral-vibe are the adapters declaring a hooks permission. If a
+	// sixth gains one, this fails and the new adapter joins the list — that
+	// is the intended workflow, not an obstacle.
 	//
-	// copilot joined in #1378 and gemini-cli in #1717, and both are expected
-	// to report StatusGap for a while: each declares hooks, but no recording
-	// for either carries a hook_received event yet, because landing the
-	// permission deliberately re-recorded nothing (the frozen sidecars are
-	// hook-free and the replay goldens had to stay byte-identical — #1717's
-	// own audit measured 0 cells re-recorded). A GAP here is the honest
-	// reading of that, not a defect.
+	// copilot joined in #1378, gemini-cli in #1717, and mistral-vibe in
+	// #1718 — all three are expected to report StatusGap for a while: each
+	// declares hooks, but no recording carries a hook_received event yet,
+	// because landing the permission deliberately re-records nothing (the
+	// frozen sidecars are hook-free and the replay goldens have to stay
+	// byte-identical — the same reasoning #1717's own audit measured at 0
+	// cells re-recorded). A GAP here is the honest reading of that, not a
+	// defect.
 	want := map[string]bool{
 		"aider": false, "antigravity": false, "claudecode": true, "codex": true,
 		"copilot": true, "gemini-cli": true, "hermes": false, "kiro-cli": false,
-		"mistral-vibe": false, "opencode": false, "pi": false,
+		"mistral-vibe": true, "opencode": false, "pi": false,
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("Declared() = %v\nwant %v", got, want)


### PR DESCRIPTION
## Summary

Wires mistral-vibe into the daemon's hooks channel — **one event only**,
`post_agent_turn` → `HandleStopHook`. Builds on #1731 (the `ManagedUserFile.Also`
widening), the `hooktoml` package, and #1734 (the raw-bytes `[][]byte`
widening of the #1178 contract seam) — all landed on `main`.

## The negative finding (audit, posted to #1718 before implementation)

`before_tool`/`after_tool` are deliberately **not** installed. `before_tool` fires
unconditionally for every tool call, before vibe's own permission check even
runs (source-traced: `_execute_tool_call` runs `_run_before_tool_pipeline`
*then* `_should_execute_tool`/`_ask_approval`), and its payload carries no field
indicating whether a given call will reach an interactive prompt — asserting
`SignalPermissionPrompt` on it would hold `waiting` on every tool call.
`after_tool` was considered as a broad release (gemini-cli's `AfterTool` shape)
but that pattern is only safe paired with a narrow assert on the *same* signal
from the *same* adapter, which vibe has none of — repo-wide,
`SignalPermissionPrompt` is held only by hook-derived calls. Full writeup:
https://github.com/ingo-eichhorst/Irrlicht/issues/1718#issuecomment-5367010063

## Two files, using #1731's new field

`Writes.Path` = `$VIBE_HOME/hooks.toml` (the entry), `Writes.Also` =
`$VIBE_HOME/config.toml` (`enable_experimental_hooks`, the flag the entry
cannot fire without — vibe's own hook loader returns nothing at all when it's
false). Uninstall clears the flag only when hooks.toml ends up with **no**
`[[hooks]]` block at all afterward, so a user's own hand-written hook keeps
working after ours is revoked.

Delivery is the beacon (`DeliveryAddressFree`) — vibe's `HookExecutor` spawns
`hook.command` via `asyncio.create_subprocess_shell` and nothing else; there is
no HTTP hook type to ask for. Version floor is **2.19.1**, the only version
directly verified (source-read AND live-fired against the installed CLI). The
epic's "breaking changes at 2.15" claim is stated as **unverified** in both the
disclosure text's reasoning and the code comment — an attempted upstream
changelog fetch produced content contradicted by this adapter's own
live-fired 2.19.1 event names and was discarded as a likely fabrication rather
than cited.

## All seven contract families wired

Permission gate (install-type + receiver-side), disclosure, path
confinement, version floor, unrecognized event, receipt, and — as of this PR —
**`AssertHookEndpointFollowsBindAddr` (#1178)**.

This last one shipped in two steps because it hit a real blocker: the shared
contract's `HookInstaller.Entry`/`EndpointOf` fields were typed
`map[string]interface{}` and it read installed entries back via
`hookjson.ReadSettings` — hardcoded to hookjson's nested-matcher-group JSON
shape, incompatible with hooktoml's raw `[]byte` TOML blocks. Rather than
bend `hooktoml` to fit or modify `contracttesting` unilaterally, I posted a
precise spec to #1718 for the seam a concurrent agent (kiro-cli, #1716) was
about to build blind from the flat-JSON side. #1734 landed that seam:
`HookInstaller` gained `ReadEntries func(path, event string) ([][]byte, error)`
and `EndpointOfRaw func(entry []byte) string`, both nil-defaulting to bridges
so the four JSON adapters needed zero changes.

`hooktoml` gained two small exports the seam consumes directly:

- `HookBlocks(path) ([][]byte, error)` — every `[[hooks]]` block's raw
  bytes, sharing `scanSections` with every writer in the package, so it
  refuses (rather than silently returns fewer blocks) on the same constructs
  they refuse on.
- `FieldValue(fragment, key) (string, bool)` — decodes a `key = "..."`
  assignment out of raw TOML text, reusing the existing escape-handling
  scanner rather than a second naive one.

`vibe/hookport_test.go` wires `ReadEntries`/`EndpointOfRaw` as thin wrappers
over those two exports. `EnsureInstalled`/`Uninstall` are the real adapter
entry points (`EnsureHooksInstalled`/`UninstallHooks`), not a hooks.toml-only
stand-in, so the contract exercises the actual production code path.

**Checked the seam against real hooktoml, not just the reference TOML
installer it shipped with — it fits cleanly, no bending required.** The
`event` parameter is ignored exactly as designed (hooktoml has no per-event
disambiguation, a decision the seam's own doc comment and a dedicated lock
test both accommodate). Sentinel matching via `hasOurRawEntry`'s
`bytes.Contains` matches `findOurBlock`'s own convention exactly. The
map-based `Entry`/`EndpointOf` pair for obligation 1 (memory-only, no
filesystem access) is a deliberate synthetic representation — the reference
installer validates the identical shape, not something I had to invent to
cope with a mismatch.

## Red-first mutation evidence

Five mutations total, each applied and reverted (one per foreground command).

**Three from the original wiring** (staleness reconciliation, two-file
uninstall coordination, unknown-event dispatch) — see the earlier revision of
this PR body / commit history for the full failure output; unchanged by this
update.

**Two new, for the #1178 seam wiring specifically:**

**1. `vibeEndpointOfRaw` forced to always return `""`** (the wiring glue between hooktoml and the contract):
```
=== RUN   TestHookEndpointFollowsBindAddr
=== RUN   TestHookEndpointFollowsBindAddr/delivery_carries_no_address
=== RUN   TestHookEndpointFollowsBindAddr/install_writes_address_free_delivery
    hook_endpoint.go:265: event post_agent_turn: "" does not carry Sentinel "hook-post mistral-vibe " — EndpointOf is not reading the field the installer writes, so every obligation below it is graded against the wrong string
=== RUN   TestHookEndpointFollowsBindAddr/foreign_binary_install_upgraded_in_place
    hook_endpoint.go:267: event post_agent_turn: "" does not carry Sentinel "hook-post mistral-vibe " — EndpointOf is not reading the field the installer writes, so every obligation below it is graded against the wrong string
=== RUN   TestHookEndpointFollowsBindAddr/uninstall_is_not_binary_scoped
--- FAIL: TestHookEndpointFollowsBindAddr (0.00s)
    --- PASS: TestHookEndpointFollowsBindAddr/delivery_carries_no_address (0.00s)
    --- FAIL: TestHookEndpointFollowsBindAddr/install_writes_address_free_delivery (0.00s)
    --- FAIL: TestHookEndpointFollowsBindAddr/foreign_binary_install_upgraded_in_place (0.00s)
    --- PASS: TestHookEndpointFollowsBindAddr/uninstall_is_not_binary_scoped (0.00s)
```
Fails exactly on the two obligations that read entries back through
`EndpointOfRaw`; obligation 1 (memory-only) and obligation 4 (checked via raw
`bytes.Contains`, not `EndpointOfRaw`) correctly stay green.

**2. `vibeHookConfig`'s `IsCanonical` (real production code, not test glue) forced to always report canonical:**
```
=== RUN   TestHookEndpointFollowsBindAddr/foreign_binary_install_upgraded_in_place
    hook_endpoint.go:267: event post_agent_turn: installed delivery = "'/nonexistent-irrlicht-1718/bin/irrlichd' --version hook-post mistral-vibe >/dev/null || true", want "'<real test binary path>' --version hook-post mistral-vibe >/dev/null || true"
--- FAIL: TestHookEndpointFollowsBindAddr (0.00s)
    --- PASS: TestHookEndpointFollowsBindAddr/delivery_carries_no_address (0.00s)
    --- PASS: TestHookEndpointFollowsBindAddr/install_writes_address_free_delivery (0.00s)
    --- FAIL: TestHookEndpointFollowsBindAddr/foreign_binary_install_upgraded_in_place (0.00s)
    --- PASS: TestHookEndpointFollowsBindAddr/uninstall_is_not_binary_scoped (0.00s)
```
Fails exactly on the obligation this code protects — the shared contract
catching a genuine production regression through the new seam, not merely
grading the wiring around it.

**Plus one for `hooktoml.HookBlocks` itself:** `scanSections`'s refusal
swallowed instead of propagated → breaks
`TestHookBlocks_RefusesOnUnterminatedCommand` (the same property the
reference TOML installer's own mutation test pins, now pinned directly
against the function the real wiring calls).

## An unplanned finding from the previous revision

`core/cmd/irrlichd/managedfiles_test.go`'s `TestPrintManagedFilesCoversEveryDeclaredFile`
never accounted for `Also` entries in its `want` set — invisible until vibe
became the first real `Also` consumer. Caught by the full suite run, fixed in
this branch's commit history.

## Test plan

- [x] `go build ./...`
- [x] `go test ./core/... -race -count=1` — all green (foreground, full run)
- [x] `go test ./tools/onboarding-factory/... -race -count=1` — all green
- [x] `tools/preflight.sh --only go|arch|tools|skills|posix|security` — all PASS
- [x] Pre-push hook passed on the actual push
- [x] Five deliberate mutations, each seen red and reverted (above + prior revision)
- [x] `hooktoml`'s property tests caught two real defects pre-adapter (see the `hooktoml` commit)
- [x] Rebased onto `f27ea2c6` (#1734 merged); force-pushed with `--force-with-lease`

Part of #1718 / #1355. Builds on #1731 and #1734.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
