### PR TITLE
feat(contracttesting): widen the hook-endpoint seam to raw bytes for TOML adapters

### DIFF
--- a/core/internal/contracttesting/hook_endpoint.go
+++ b/core/internal/contracttesting/hook_endpoint.go
@@ -142,10 +142,44 @@ type HookInstaller struct {
 	// Neither way of getting it wrong passes: an entry that is already
 	// canonical leaves obligation 3 with modified=false, and one that does not
 	// carry Sentinel is not recognized as ours, so EnsureInstalled appends a
-	// second matcher group and onlyEntry fails on the group count. The seed is
+	// second matcher group and onlyEntry fails on the entry count. The seed is
 	// additionally cross-checked against Sentinel before either obligation
 	// runs.
 	ForeignInstall func() (bool, error)
+
+	// EntriesOf extracts the inner hook-entry objects an event's raw value in
+	// the parsed settings map holds, regardless of nesting shape (issue
+	// #1716). Nil means NestedHookEntries — hookjson's own matcher-group
+	// shape, `[ {"matcher": ..., "hooks": [ {...} ] } ]` — which is what every
+	// adapter wired before #1716 (claudecode, codex, copilot, gemini-cli)
+	// already produces, so none of them need to set this field.
+	//
+	// It exists because that nesting is not universal: kiro-cli's hooks
+	// schema rejects it outright and falls back to a different agent while
+	// reporting install success (#1716's own audit), so its entries are FLAT —
+	// `[ {"command": ...} ]`, no matcher-group wrapper — and the four
+	// obligations built on "read back the one entry an event holds" needed a
+	// seam an adapter can supply instead of a shape hardcoded into the
+	// traversal. FlatHookEntries is that shape's counterpart.
+	//
+	// A TOML-shaped installer (mistral-vibe, #1718) fits the SAME seam for its
+	// half of the problem — decoding a TOML table's array-of-tables into
+	// `[]map[string]interface{}` is what most TOML libraries already do, so an
+	// adapter whose event value decodes that way can write its own
+	// EntriesOf identically to FlatHookEntries's body. What this field does
+	// NOT close for TOML is the file-reading step: readHooksMap below still
+	// calls hookjson.ReadSettings (JSON-only) to produce the map EntriesOf is
+	// handed, and #1718's own config is a dedicated hooks.toml rather than a
+	// "hooks" key inside a shared JSON document — so a TOML adapter needs an
+	// analogous seam THERE too (a HookInstaller.ReadSettings func(path string)
+	// (map[string]interface{}, error) field, defaulting to
+	// hookjson.ReadSettings, is the natural shape, mirroring this one) before
+	// AssertHookEndpointFollowsBindAddr can grade it end to end. Left
+	// undone here deliberately: guessing at #1718's exact schema from outside
+	// that work would be speculation this package cannot verify, where
+	// EntriesOf's shape is what THIS issue's own adapter (kiro-cli) already
+	// needs and proves against a real wiring (kirocli/hookport_test.go).
+	EntriesOf func(hooksMap map[string]interface{}, event string) ([]map[string]interface{}, error)
 }
 
 // AssertHookEndpointFollowsBindAddr runs the issue #1178 contract against h, in
@@ -359,7 +393,7 @@ func assertUninstallIsNotForeignScoped(t armT, h HookInstaller, r deliveryRules,
 	}
 	hooksMap := readHooksMap(t, path)
 	for _, event := range h.Events {
-		if hookjson.HasOurHook(hooksMap, event, h.Sentinel) {
+		if hasOurEntry(t, h, hooksMap, event) {
 			t.Errorf("event %s: %s survived uninstall", event, r.foreign)
 		}
 	}
@@ -384,7 +418,7 @@ func assertEveryEventDelivers(t armT, h HookInstaller, r deliveryRules, path, wa
 	t.Helper()
 	hooksMap := readHooksMap(t, path)
 	for _, event := range h.Events {
-		got := h.EndpointOf(onlyEntry(t, hooksMap, event))
+		got := h.EndpointOf(onlyEntry(t, h, hooksMap, event))
 		assertDeliveryIsOurs(t, h, "event "+event, got)
 		if got != want {
 			t.Errorf("event %s: installed delivery = %q, want %q", event, got, want)
@@ -522,44 +556,123 @@ func seedForeignInstall(t armT, h HookInstaller, r deliveryRules, path string) {
 	r.seed(t, h)
 
 	// Sentinel is the one field nothing else cross-checks, and a wrong value
-	// makes the uninstall-survival assertion pass vacuously — HasOurHook would
+	// makes the uninstall-survival assertion pass vacuously — hasOurEntry would
 	// simply find nothing, for the wrong reason. Confirming the seeded install
 	// is matched by the declared sentinel turns that silent hole into a wiring
 	// error.
 	seeded := readHooksMap(t, path)
 	for _, event := range h.Events {
-		if !hookjson.HasOurHook(seeded, event, h.Sentinel) {
+		if !hasOurEntry(t, h, seeded, event) {
 			t.Fatalf("event %s: %s is not matched by Sentinel %q — the contract is wired wrong", event, r.foreign, h.Sentinel)
 		}
 	}
 }
 
-// onlyEntry returns the single inner hook of the event's single matcher group,
-// failing on any other shape — which is the assertion, not incidental: an
-// upgrade that appends a second group instead of rewriting in place shows up
-// here as a group count of 2.
-func onlyEntry(t reporter, hooksMap map[string]interface{}, event string) map[string]interface{} {
-	t.Helper()
+// entriesOf resolves h's EntriesOf, defaulting to NestedHookEntries — the
+// shape every adapter wired before #1716 already produces, so leaving the
+// field nil is what every existing wiring continues to do.
+func entriesOf(h HookInstaller) func(map[string]interface{}, string) ([]map[string]interface{}, error) {
+	if h.EntriesOf != nil {
+		return h.EntriesOf
+	}
+	return NestedHookEntries
+}
+
+// NestedHookEntries is hookjson's own matcher-group shape:
+// `hooksMap[event] = [ {"matcher": ..., "hooks": [ {...}, ... ] }, ... ]`.
+// It flattens every group's inner hooks into one list, so "exactly one
+// entry" (onlyEntry's own obligation) also catches a mutation that appends a
+// second GROUP rather than a second entry within one — the two are
+// indistinguishable once flattened, which is the point: onlyEntry does not
+// need to separately police group count and per-group entry count.
+func NestedHookEntries(hooksMap map[string]interface{}, event string) ([]map[string]interface{}, error) {
 	groups, ok := hooksMap[event].([]interface{})
 	if !ok {
-		t.Fatalf("event %s: missing from the settings file or not an array", event)
+		return nil, fmt.Errorf("missing from the settings file or not an array")
 	}
-	if len(groups) != 1 {
-		t.Fatalf("event %s: expected exactly 1 matcher group (in-place upgrade, no duplicate appended), got %d", event, len(groups))
+	var out []map[string]interface{}
+	for _, g := range groups {
+		group, ok := g.(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("matcher group is not an object: %v", g)
+		}
+		hooks, ok := group["hooks"].([]interface{})
+		if !ok {
+			return nil, fmt.Errorf("matcher group has no \"hooks\" array: %v", group)
+		}
+		for _, e := range hooks {
+			entry, ok := e.(map[string]interface{})
+			if !ok {
+				return nil, fmt.Errorf("inner hook is not an object: %v", e)
+			}
+			out = append(out, entry)
+		}
 	}
-	group, ok := groups[0].(map[string]interface{})
+	return out, nil
+}
+
+// FlatHookEntries is the flat shape kiro-cli's hook schema requires instead:
+// `hooksMap[event] = [ {"command": ...}, ... ]` — no matcher-group wrapper at
+// all, each array element itself the inner hook object.
+func FlatHookEntries(hooksMap map[string]interface{}, event string) ([]map[string]interface{}, error) {
+	arr, ok := hooksMap[event].([]interface{})
 	if !ok {
-		t.Fatalf("event %s: matcher group is not an object: %v", event, groups[0])
+		return nil, fmt.Errorf("missing from the settings file or not an array")
 	}
-	entries, ok := group["hooks"].([]interface{})
-	if !ok || len(entries) != 1 {
-		t.Fatalf("event %s: expected exactly 1 inner hook, got %v", event, group["hooks"])
+	var out []map[string]interface{}
+	for _, e := range arr {
+		entry, ok := e.(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("entry is not an object: %v", e)
+		}
+		out = append(out, entry)
 	}
-	entry, ok := entries[0].(map[string]interface{})
-	if !ok {
-		t.Fatalf("event %s: inner hook is not an object: %v", event, entries[0])
+	return out, nil
+}
+
+// onlyEntry returns the single inner hook entry an event holds, via h's
+// resolved EntriesOf, failing on any other count — which is the assertion,
+// not incidental: an upgrade that appends a second entry (nested shape: a
+// second matcher group; flat shape: a second array element) instead of
+// rewriting in place shows up here as a count of 2, regardless of shape.
+func onlyEntry(t reporter, h HookInstaller, hooksMap map[string]interface{}, event string) map[string]interface{} {
+	t.Helper()
+	entries, err := entriesOf(h)(hooksMap, event)
+	if err != nil {
+		t.Fatalf("event %s: %v", event, err)
 	}
-	return entry
+	if len(entries) != 1 {
+		t.Fatalf("event %s: expected exactly 1 inner hook entry (in-place upgrade, no duplicate appended), got %d", event, len(entries))
+	}
+	return entries[0]
+}
+
+// hasOurEntry reports whether ANY of an event's entries carries h.Sentinel,
+// via h's resolved EntriesOf — the flat-shape-aware counterpart of
+// hookjson.HasOurHook, which hardcodes the nested matcher-group traversal
+// (core/adapters/inbound/agents/hookjson's own entryIsSentinel) and so
+// cannot see a flat entry at all. Checks the same two delivery fields
+// entryIsSentinel does ("command", the shape codex/gemini-cli/kiro-cli use,
+// and "url", claudecode's and copilot's native http entries), so an adapter
+// migrating between the two is still recognized either way, matching
+// hookjson's own behaviour for the shapes EntriesOf already normalizes into
+// plain maps.
+func hasOurEntry(t reporter, h HookInstaller, hooksMap map[string]interface{}, event string) bool {
+	t.Helper()
+	entries, err := entriesOf(h)(hooksMap, event)
+	if err != nil {
+		// Not an error here: "missing from the settings file" is exactly
+		// "not found", the answer this predicate is asked for.
+		return false
+	}
+	for _, entry := range entries {
+		for _, field := range []string{"command", "url"} {
+			if v, ok := entry[field].(string); ok && strings.Contains(v, h.Sentinel) {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // readHooksMap reads the settings file through the same codec the installers

--- a/core/internal/contracttesting/hook_endpoint.go
+++ b/core/internal/contracttesting/hook_endpoint.go
@@ -42,6 +42,8 @@
 package contracttesting
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"regexp"
 	"strings"
@@ -148,7 +150,7 @@ type HookInstaller struct {
 	ForeignInstall func() (bool, error)
 
 	// EntriesOf extracts the inner hook-entry objects an event's raw value in
-	// the parsed settings map holds, regardless of nesting shape (issue
+	// the PARSED JSON settings map holds, regardless of nesting shape (issue
 	// #1716). Nil means NestedHookEntries — hookjson's own matcher-group
 	// shape, `[ {"matcher": ..., "hooks": [ {...} ] } ]` — which is what every
 	// adapter wired before #1716 (claudecode, codex, copilot, gemini-cli)
@@ -160,26 +162,74 @@ type HookInstaller struct {
 	// `[ {"command": ...} ]`, no matcher-group wrapper — and the four
 	// obligations built on "read back the one entry an event holds" needed a
 	// seam an adapter can supply instead of a shape hardcoded into the
-	// traversal. FlatHookEntries is that shape's counterpart.
+	// traversal. FlatHookEntries is that shape's counterpart, and kiro-cli
+	// sets EntriesOf: FlatHookEntries and nothing else in this struct — the
+	// two fields below exist for adapters this layer cannot reach at all.
 	//
-	// A TOML-shaped installer (mistral-vibe, #1718) fits the SAME seam for its
-	// half of the problem — decoding a TOML table's array-of-tables into
-	// `[]map[string]interface{}` is what most TOML libraries already do, so an
-	// adapter whose event value decodes that way can write its own
-	// EntriesOf identically to FlatHookEntries's body. What this field does
-	// NOT close for TOML is the file-reading step: readHooksMap below still
-	// calls hookjson.ReadSettings (JSON-only) to produce the map EntriesOf is
-	// handed, and #1718's own config is a dedicated hooks.toml rather than a
-	// "hooks" key inside a shared JSON document — so a TOML adapter needs an
-	// analogous seam THERE too (a HookInstaller.ReadSettings func(path string)
-	// (map[string]interface{}, error) field, defaulting to
-	// hookjson.ReadSettings, is the natural shape, mirroring this one) before
-	// AssertHookEndpointFollowsBindAddr can grade it end to end. Left
-	// undone here deliberately: guessing at #1718's exact schema from outside
-	// that work would be speculation this package cannot verify, where
-	// EntriesOf's shape is what THIS issue's own adapter (kiro-cli) already
-	// needs and proves against a real wiring (kirocli/hookport_test.go).
+	// This field is deliberately NOT what a TOML-shaped installer
+	// (mistral-vibe, #1718) uses. #1718's own audit measured the gap
+	// precisely: hooktoml never produces a decoded, generic
+	// map[string]interface{} at any point — it works entirely as byte-range
+	// edits over the original file bytes (scanSections), and identifies "our"
+	// block by bytes.Contains over the WHOLE rendered block's raw text against
+	// Sentinel, never by parsing a field back out. A seam typed
+	// map[string]interface{} cannot represent that without inventing a parse
+	// step that does not exist on that side. See ReadEntries and
+	// EndpointOfRaw below, which a TOML adapter uses INSTEAD of this field —
+	// EntriesOf stays purely a convenience layer for JSON-shaped adapters,
+	// consumed only by ReadEntries's own default implementation.
 	EntriesOf func(hooksMap map[string]interface{}, event string) ([]map[string]interface{}, error)
+
+	// ReadEntries reads the settings file at path and returns the RAW bytes
+	// of every entry belonging to event, however the format encodes one —
+	// for JSON, the marshaled bytes of one inner hook object; for TOML, the
+	// exact bytes of one `[[hooks]]` block. Nil means a default built from
+	// EntriesOf (in turn defaulting to NestedHookEntries) plus
+	// hookjson.ReadSettings plus json.Marshal per entry, which is what every
+	// JSON-shaped adapter — every one wired before #1718, and kiro-cli's
+	// EntriesOf: FlatHookEntries — satisfies without setting this field.
+	//
+	// It exists because the READ step itself has to be pluggable, not just
+	// the traversal after it (#1718's audit, correcting this seam's own first
+	// draft): hooktoml has no "parse to a generic structure" phase for
+	// ReadSettings to feed EntriesOf, so an adapter whose config is not
+	// JSON — TOML, or any future format — supplies ReadEntries directly and
+	// never touches EntriesOf or hookjson.ReadSettings at all. The event
+	// parameter is passed through unfiltered when there is nothing to
+	// filter: #1718's audit records that hooktoml has no per-event
+	// disambiguation today (vibe installs exactly one event, so "the
+	// entry" is unambiguous without it) — an adapter's own ReadEntries is
+	// free to ignore the parameter for that reason, and this seam does not
+	// need to force per-event filtering into existence to be well-formed.
+	//
+	// An entry's raw bytes are also what hasOurRawEntry checks with a plain
+	// bytes.Contains against Sentinel — matching hooktoml's OWN sentinel
+	// convention exactly (a substring of the whole rendered block, not a
+	// named field), so that check needs no adapter-supplied closure at all,
+	// for ANY shape this field can represent.
+	ReadEntries func(path, event string) ([][]byte, error)
+
+	// EndpointOfRaw extracts the delivery string from one entry's raw bytes,
+	// as ReadEntries returns them. Nil means a default that json.Unmarshals
+	// the bytes into a map[string]interface{} and calls EndpointOf on it —
+	// exactly what every JSON-shaped adapter already gets from EndpointOf
+	// alone, so none of them set this field either.
+	//
+	// A TOML adapter supplies both ReadEntries and EndpointOfRaw together —
+	// #1718's own IsCanonical already works by exact []byte comparison
+	// against a freshly-rendered canonical block and never parses a
+	// `command` field back out of TOML text, so EndpointOfRaw is the same
+	// kind of operation applied to a different substring.
+	//
+	// Entry/EndpointOf (above) are UNCHANGED and stay map[string]interface{}
+	// — they compare what the adapter would install NOW, entirely in memory,
+	// against two bind addresses (obligation 1), and never touch the
+	// filesystem. An adapter can honestly answer that question with a map
+	// even when what it actually persists to disk is raw TOML text, because
+	// nothing downstream of Entry()/EndpointOf() reads the file — only
+	// ReadEntries/EndpointOfRaw do, which is exactly why the two pairs are
+	// independent fields rather than one seam trying to serve both jobs.
+	EndpointOfRaw func(entry []byte) string
 }
 
 // AssertHookEndpointFollowsBindAddr runs the issue #1178 contract against h, in
@@ -391,9 +441,8 @@ func assertUninstallIsNotForeignScoped(t armT, h HookInstaller, r deliveryRules,
 	if !modified {
 		t.Fatalf("expected modified=true removing %s from a daemon on %s", r.foreign, AltBindAddr)
 	}
-	hooksMap := readHooksMap(t, path)
 	for _, event := range h.Events {
-		if hasOurEntry(t, h, hooksMap, event) {
+		if hasOurRawEntry(t, h, path, event) {
 			t.Errorf("event %s: %s survived uninstall", event, r.foreign)
 		}
 	}
@@ -416,9 +465,8 @@ func deliveryOn(t armT, h HookInstaller, bindAddr string) string {
 // because an "address-free" delivery grew an address.
 func assertEveryEventDelivers(t armT, h HookInstaller, r deliveryRules, path, want string) {
 	t.Helper()
-	hooksMap := readHooksMap(t, path)
 	for _, event := range h.Events {
-		got := h.EndpointOf(onlyEntry(t, h, hooksMap, event))
+		got := endpointOfRaw(h)(onlyRawEntry(t, h, path, event))
 		assertDeliveryIsOurs(t, h, "event "+event, got)
 		if got != want {
 			t.Errorf("event %s: installed delivery = %q, want %q", event, got, want)
@@ -556,13 +604,12 @@ func seedForeignInstall(t armT, h HookInstaller, r deliveryRules, path string) {
 	r.seed(t, h)
 
 	// Sentinel is the one field nothing else cross-checks, and a wrong value
-	// makes the uninstall-survival assertion pass vacuously — hasOurEntry would
-	// simply find nothing, for the wrong reason. Confirming the seeded install
-	// is matched by the declared sentinel turns that silent hole into a wiring
-	// error.
-	seeded := readHooksMap(t, path)
+	// makes the uninstall-survival assertion pass vacuously — hasOurRawEntry
+	// would simply find nothing, for the wrong reason. Confirming the seeded
+	// install is matched by the declared sentinel turns that silent hole
+	// into a wiring error.
 	for _, event := range h.Events {
-		if !hasOurEntry(t, h, seeded, event) {
+		if !hasOurRawEntry(t, h, path, event) {
 			t.Fatalf("event %s: %s is not matched by Sentinel %q — the contract is wired wrong", event, r.foreign, h.Sentinel)
 		}
 	}
@@ -630,14 +677,63 @@ func FlatHookEntries(hooksMap map[string]interface{}, event string) ([]map[strin
 	return out, nil
 }
 
-// onlyEntry returns the single inner hook entry an event holds, via h's
-// resolved EntriesOf, failing on any other count — which is the assertion,
-// not incidental: an upgrade that appends a second entry (nested shape: a
-// second matcher group; flat shape: a second array element) instead of
-// rewriting in place shows up here as a count of 2, regardless of shape.
-func onlyEntry(t reporter, h HookInstaller, hooksMap map[string]interface{}, event string) map[string]interface{} {
+// rawEntriesOf resolves h's ReadEntries, defaulting to a bridge built from
+// readSettingsHooksMap (hookjson.ReadSettings) + entriesOf(h) (EntriesOf,
+// itself defaulting to NestedHookEntries) + json.Marshal per entry — the
+// path every JSON-shaped adapter (every one wired before #1718, and
+// kiro-cli's EntriesOf: FlatHookEntries) satisfies without setting
+// ReadEntries at all. A non-JSON adapter (TOML, or any future format)
+// supplies ReadEntries directly and this bridge is never called for it.
+func rawEntriesOf(h HookInstaller) func(path, event string) ([][]byte, error) {
+	if h.ReadEntries != nil {
+		return h.ReadEntries
+	}
+	return func(path, event string) ([][]byte, error) {
+		hooksMap, err := readSettingsHooksMap(path)
+		if err != nil {
+			return nil, err
+		}
+		entries, err := entriesOf(h)(hooksMap, event)
+		if err != nil {
+			return nil, err
+		}
+		raw := make([][]byte, 0, len(entries))
+		for _, e := range entries {
+			b, err := json.Marshal(e)
+			if err != nil {
+				return nil, fmt.Errorf("marshal entry: %w", err)
+			}
+			raw = append(raw, b)
+		}
+		return raw, nil
+	}
+}
+
+// endpointOfRaw resolves h's EndpointOfRaw, defaulting to a bridge that
+// json.Unmarshals the bytes into a map and calls h.EndpointOf on it — what
+// every JSON-shaped adapter already gets from EndpointOf alone.
+func endpointOfRaw(h HookInstaller) func(entry []byte) string {
+	if h.EndpointOfRaw != nil {
+		return h.EndpointOfRaw
+	}
+	return func(entry []byte) string {
+		var m map[string]interface{}
+		if err := json.Unmarshal(entry, &m); err != nil {
+			return ""
+		}
+		return h.EndpointOf(m)
+	}
+}
+
+// onlyRawEntry returns the single raw entry an event holds, via h's resolved
+// ReadEntries, failing on any other count — which is the assertion, not
+// incidental: an upgrade that appends a second entry (nested JSON: a second
+// matcher group; flat JSON: a second array element; TOML: a second
+// `[[hooks]]` block) instead of rewriting in place shows up here as a count
+// of 2, regardless of shape.
+func onlyRawEntry(t reporter, h HookInstaller, path, event string) []byte {
 	t.Helper()
-	entries, err := entriesOf(h)(hooksMap, event)
+	entries, err := rawEntriesOf(h)(path, event)
 	if err != nil {
 		t.Fatalf("event %s: %v", event, err)
 	}
@@ -647,42 +743,44 @@ func onlyEntry(t reporter, h HookInstaller, hooksMap map[string]interface{}, eve
 	return entries[0]
 }
 
-// hasOurEntry reports whether ANY of an event's entries carries h.Sentinel,
-// via h's resolved EntriesOf — the flat-shape-aware counterpart of
-// hookjson.HasOurHook, which hardcodes the nested matcher-group traversal
-// (core/adapters/inbound/agents/hookjson's own entryIsSentinel) and so
-// cannot see a flat entry at all. Checks the same two delivery fields
-// entryIsSentinel does ("command", the shape codex/gemini-cli/kiro-cli use,
-// and "url", claudecode's and copilot's native http entries), so an adapter
-// migrating between the two is still recognized either way, matching
-// hookjson's own behaviour for the shapes EntriesOf already normalizes into
-// plain maps.
-func hasOurEntry(t reporter, h HookInstaller, hooksMap map[string]interface{}, event string) bool {
+// hasOurRawEntry reports whether ANY of an event's raw entries contains
+// h.Sentinel as a byte substring, via h's resolved ReadEntries — a single,
+// fully format-agnostic check that replaces hookjson.HasOurHook (which
+// hardcodes the nested matcher-group traversal and inspects only "command"
+// or "url" fields by name, so it cannot see a flat JSON entry and has no
+// notion of a TOML block at all). Matching on raw bytes rather than a named
+// field is not a weaker check adopted for convenience — it is hooktoml's OWN
+// sentinel convention (#1718's audit: "findOurBlock locates our block by
+// bytes.Contains over the whole rendered block's raw bytes... there is no
+// index/key addressing an entry"), so this function satisfies that
+// convention exactly rather than approximating it, and needs no
+// adapter-supplied closure for ANY shape ReadEntries can represent.
+func hasOurRawEntry(t reporter, h HookInstaller, path, event string) bool {
 	t.Helper()
-	entries, err := entriesOf(h)(hooksMap, event)
+	entries, err := rawEntriesOf(h)(path, event)
 	if err != nil {
 		// Not an error here: "missing from the settings file" is exactly
 		// "not found", the answer this predicate is asked for.
 		return false
 	}
+	sentinel := []byte(h.Sentinel)
 	for _, entry := range entries {
-		for _, field := range []string{"command", "url"} {
-			if v, ok := entry[field].(string); ok && strings.Contains(v, h.Sentinel) {
-				return true
-			}
+		if bytes.Contains(entry, sentinel) {
+			return true
 		}
 	}
 	return false
 }
 
-// readHooksMap reads the settings file through the same codec the installers
-// use and returns its top-level "hooks" object (nil when absent).
-func readHooksMap(t reporter, path string) map[string]interface{} {
-	t.Helper()
+// readSettingsHooksMap reads the settings file through the same codec the
+// JSON installers use and returns its top-level "hooks" object (nil when
+// absent). Used only by rawEntriesOf's default JSON bridge — a non-JSON
+// ReadEntries never calls this.
+func readSettingsHooksMap(path string) (map[string]interface{}, error) {
 	settings, err := hookjson.ReadSettings(path)
 	if err != nil {
-		t.Fatalf("read %s: %v", path, err)
+		return nil, err
 	}
 	hooksMap, _ := settings["hooks"].(map[string]interface{})
-	return hooksMap
+	return hooksMap, nil
 }

--- a/core/internal/contracttesting/hook_endpoint.go
+++ b/core/internal/contracttesting/hook_endpoint.go
@@ -466,7 +466,7 @@ func deliveryOn(t armT, h HookInstaller, bindAddr string) string {
 func assertEveryEventDelivers(t armT, h HookInstaller, r deliveryRules, path, want string) {
 	t.Helper()
 	for _, event := range h.Events {
-		got := endpointOfRaw(h)(onlyRawEntry(t, h, path, event))
+		got := endpointOfRaw(t, h)(onlyRawEntry(t, h, path, event))
 		assertDeliveryIsOurs(t, h, "event "+event, got)
 		if got != want {
 			t.Errorf("event %s: installed delivery = %q, want %q", event, got, want)
@@ -712,14 +712,39 @@ func rawEntriesOf(h HookInstaller) func(path, event string) ([][]byte, error) {
 // endpointOfRaw resolves h's EndpointOfRaw, defaulting to a bridge that
 // json.Unmarshals the bytes into a map and calls h.EndpointOf on it — what
 // every JSON-shaped adapter already gets from EndpointOf alone.
-func endpointOfRaw(h HookInstaller) func(entry []byte) string {
+//
+// The default bridge FAILS LOUDLY (t.Fatalf) rather than returning "" when
+// the entry does not unmarshal as JSON. It must: "" is not a neutral value
+// for this contract's DeliveryAddressFree route — assertDeliveryCarriesNoAddress
+// checks that the delivery is IDENTICAL across bind addresses and carries no
+// address-shaped fragment, and "" satisfies both trivially. A non-JSON entry
+// shape with no EndpointOfRaw supplied would therefore make obligation 1 pass
+// having graded nothing — the exact "absence of a finding and inability to
+// look must never produce the same output" failure AGENTS.md's Testing
+// section names, and it very nearly shipped that way: the first version of
+// this bridge returned "" and was caught only by assertDeliveryIsOurs, a
+// NEIGHBOURING guard the bridge itself does not control and that obligation 1
+// does not call before its own address check.
+// TestEndpointOfRaw_MissingBridgeFailsLoudlyNotSilently (hook_endpoint_test.go)
+// is the committed lock: it drives this function directly, with no neighbour
+// in the call at all, so there is nothing else in the picture that could be
+// catching it. That isolation was chosen over reproducing the original defect
+// end-to-end (a real installer, run twice — once with assertDeliveryIsOurs
+// intact and once disabled, to tell "something failed" from "THIS bridge
+// caught it" apart) because it grades the same claim without depending on
+// the rest of the contract staying wired the way it happened to be wired the
+// day this was found; that end-to-end double run is recorded as this fix's
+// review evidence rather than committed a second time.
+func endpointOfRaw(t reporter, h HookInstaller) func(entry []byte) string {
 	if h.EndpointOfRaw != nil {
 		return h.EndpointOfRaw
 	}
 	return func(entry []byte) string {
+		t.Helper()
 		var m map[string]interface{}
 		if err := json.Unmarshal(entry, &m); err != nil {
-			return ""
+			t.Fatalf("entry %q does not unmarshal as JSON (%v) — a non-JSON entry shape must supply HookInstaller.EndpointOfRaw", entry, err)
+			return "" // unreachable: t.Fatalf on *testing.T calls runtime.Goexit
 		}
 		return h.EndpointOf(m)
 	}

--- a/core/internal/contracttesting/hook_endpoint_flat_test.go
+++ b/core/internal/contracttesting/hook_endpoint_flat_test.go
@@ -1,0 +1,340 @@
+// hook_endpoint_flat_test.go exercises AssertHookEndpointFollowsBindAddr's
+// EntriesOf seam (issue #1716) against a reference FLAT-shape installer, the
+// same role hook_endpoint_addressfree_test.go's referenceBeaconInstaller
+// plays for the DeliveryAddressFree route: proof the seam works, built and
+// driven BEFORE any real adapter declares it, so this obligation is not
+// "exemption with no test behind it" for the months between the seam
+// landing and kiro-cli's own PR adopting it.
+//
+// It is scaffolding, and says so exactly as that file does: once kiro-cli
+// wires EntriesOf: FlatHookEntries for real (kirocli/hookport_test.go), that
+// adapter's wiring becomes the honest coverage and this file should be
+// reduced to whatever it still uniquely proves, or deleted.
+//
+// The flat merge logic below is deliberately NOT hookjson.EnsureInstalled —
+// that function only ever writes the nested matcher-group shape, which is
+// exactly what a flat-shape agent's hook schema rejects (#1716's own audit:
+// kiro-cli falls back to a different agent while reporting install success
+// against a nested entry). So this file carries its own minimal flat merge,
+// reusing hookjson.ReadSettings/WriteSettings UNMODIFIED for the actual
+// byte-level splice — the risky part, already property-tested in hookjson —
+// rather than writing a second structural-diff writer. This is the same
+// shape kirocli/hookinstaller.go uses in the adapter that motivated this
+// seam.
+package contracttesting
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"irrlicht/core/adapters/inbound/agents/agentpaths"
+	"irrlicht/core/adapters/inbound/agents/hookjson"
+	"irrlicht/core/pkg/hookbeacon"
+)
+
+// referenceFlatAdapter is the route segment the beacon posts to for this
+// fixture's flat-shape reference installer.
+const referenceFlatAdapter = "reference-flat"
+
+// referenceFlatHomeEnv relocates the fixture's config home. Deliberately a
+// dedicated env var, distinct from referenceBeaconHomeEnv, so the two
+// reference installers' fixtures cannot collide if ever driven in the same
+// process.
+const referenceFlatHomeEnv = "IRRLICHT_TEST_REFERENCE_FLAT_HOME"
+
+// referenceFlatForeignBinary mirrors referenceForeignBinary: an absolute,
+// nonexistent irrlichd — the drift the beacon newly admits.
+const referenceFlatForeignBinary = "/nonexistent-irrlicht-1716/bin/irrlichd"
+
+var referenceFlatEvents = []string{"postToolUse", "stop"}
+
+// referenceFlatHome mirrors referenceBeaconHome's reasoning exactly,
+// including the deliberately empty default: an unset override must fail
+// loudly rather than resolve into a developer's real $HOME.
+func referenceFlatHome() (string, error) {
+	return agentpaths.AbsRoot(agentpaths.FromEnv(referenceFlatAdapter, referenceFlatHomeEnv, ""))
+}
+
+func referenceFlatConfigPath() (string, error) {
+	home, err := referenceFlatHome()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, "hooks.json"), nil
+}
+
+func referenceFlatEntry(command string) map[string]interface{} {
+	return map[string]interface{}{"command": command}
+}
+
+func referenceFlatEndpointOf(hook map[string]interface{}) string {
+	c, _ := hook["command"].(string)
+	return c
+}
+
+func referenceFlatEntryNow() map[string]interface{} {
+	command, _ := hookbeacon.InstalledCommand(referenceFlatAdapter)
+	return referenceFlatEntry(command)
+}
+
+func referenceFlatIsCanonical(hook map[string]interface{}) bool {
+	c, _ := hook["command"].(string)
+	return hookbeacon.IsCanonical(c, referenceFlatAdapter)
+}
+
+func referenceFlatWriteFile(path string, data []byte) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0o600)
+}
+
+// referenceFlatEnsureInstalled merges a flat entry for every event into the
+// settings file's "hooks" key, upgrading a stale sentinel-bearing entry in
+// place rather than duplicating it — the flat-shape analogue of
+// hookjson.EnsureInstalled's own reconciliation, over the SAME
+// ReadSettings/WriteSettings pair (the tested byte-level splice), differing
+// only in how one event's array is shaped.
+func referenceFlatEnsureInstalled() (bool, error) {
+	path, err := referenceFlatConfigPath()
+	if err != nil {
+		return false, err
+	}
+	command, err := hookbeacon.InstalledCommand(referenceFlatAdapter)
+	if err != nil {
+		return false, err
+	}
+	settings, err := hookjson.ReadSettings(path)
+	if err != nil {
+		return false, err
+	}
+	hooksMap, ok := settings["hooks"].(map[string]interface{})
+	if !ok {
+		hooksMap = map[string]interface{}{}
+		settings["hooks"] = hooksMap
+	}
+	sentinel := hookbeacon.Sentinel(referenceFlatAdapter)
+	modified := false
+	for _, event := range referenceFlatEvents {
+		arr, _ := hooksMap[event].([]interface{})
+		newArr, changed := reconcileFlatEventForTest(arr, sentinel, func() map[string]interface{} {
+			return referenceFlatEntry(command)
+		}, referenceFlatIsCanonical)
+		if changed {
+			hooksMap[event] = newArr
+			modified = true
+		}
+	}
+	if !modified {
+		return false, nil
+	}
+	return true, hookjson.WriteSettings(path, settings, referenceFlatWriteFile)
+}
+
+// referenceFlatUninstall removes every sentinel-bearing flat entry, whatever
+// binary it names — not scoped to the currently resolved one, matching
+// referenceBeaconUninstall's own reasoning.
+func referenceFlatUninstall() (bool, error) {
+	path, err := referenceFlatConfigPath()
+	if err != nil {
+		return false, err
+	}
+	settings, err := hookjson.ReadSettings(path)
+	if err != nil {
+		return false, err
+	}
+	hooksMap, ok := settings["hooks"].(map[string]interface{})
+	if !ok {
+		return false, nil
+	}
+	sentinel := hookbeacon.Sentinel(referenceFlatAdapter)
+	modified := false
+	for _, event := range referenceFlatEvents {
+		arr, ok := hooksMap[event].([]interface{})
+		if !ok {
+			continue
+		}
+		var kept []interface{}
+		removed := false
+		for _, e := range arr {
+			entry, ok := e.(map[string]interface{})
+			if ok {
+				if c, _ := entry["command"].(string); strings.Contains(c, sentinel) {
+					removed = true
+					continue
+				}
+			}
+			kept = append(kept, e)
+		}
+		if removed {
+			modified = true
+			if len(kept) == 0 {
+				delete(hooksMap, event)
+			} else {
+				hooksMap[event] = kept
+			}
+		}
+	}
+	if !modified {
+		return false, nil
+	}
+	return true, hookjson.WriteSettings(path, settings, referenceFlatWriteFile)
+}
+
+// referenceFlatForeignInstall seeds an entry naming a different, nonexistent
+// irrlichd binary — the flat-shape counterpart of referenceBeaconForeignInstall.
+func referenceFlatForeignInstall() (bool, error) {
+	path, err := referenceFlatConfigPath()
+	if err != nil {
+		return false, err
+	}
+	command, err := hookbeacon.Command(referenceFlatForeignBinary, referenceFlatAdapter)
+	if err != nil {
+		return false, err
+	}
+	settings, err := hookjson.ReadSettings(path)
+	if err != nil {
+		return false, err
+	}
+	hooksMap, ok := settings["hooks"].(map[string]interface{})
+	if !ok {
+		hooksMap = map[string]interface{}{}
+		settings["hooks"] = hooksMap
+	}
+	sentinel := hookbeacon.Sentinel(referenceFlatAdapter)
+	modified := false
+	for _, event := range referenceFlatEvents {
+		arr, _ := hooksMap[event].([]interface{})
+		newArr, changed := reconcileFlatEventForTest(arr, sentinel, func() map[string]interface{} {
+			return referenceFlatEntry(command)
+		}, referenceFlatIsCanonical)
+		if changed {
+			hooksMap[event] = newArr
+			modified = true
+		}
+	}
+	if !modified {
+		return false, nil
+	}
+	return true, hookjson.WriteSettings(path, settings, referenceFlatWriteFile)
+}
+
+// reconcileFlatEventForTest mirrors kirocli/hookinstaller.go's
+// reconcileFlatEvent: rewrite a sentinel-bearing entry that is not canonical,
+// append a fresh one only when none exists. Kept local to this test file
+// rather than exported from hook_endpoint.go, because it is fixture
+// machinery for the reference installer, not part of the contract's own
+// grading surface (that surface is EntriesOf/onlyEntry/hasOurEntry).
+func reconcileFlatEventForTest(arr []interface{}, sentinel string, entry func() map[string]interface{}, isCanonical func(map[string]interface{}) bool) ([]interface{}, bool) {
+	found := false
+	changed := false
+	out := make([]interface{}, 0, len(arr)+1)
+	for _, e := range arr {
+		m, ok := e.(map[string]interface{})
+		if !ok {
+			out = append(out, e)
+			continue
+		}
+		if c, _ := m["command"].(string); strings.Contains(c, sentinel) {
+			found = true
+			if !isCanonical(m) {
+				m = entry()
+				changed = true
+			}
+		}
+		out = append(out, m)
+	}
+	if !found {
+		out = append(out, entry())
+		changed = true
+	}
+	return out, changed
+}
+
+// referenceFlatInstaller is the whole flat-shape wiring, as one value —
+// mirroring referenceBeaconInstaller's own role exactly, one field
+// different: EntriesOf: FlatHookEntries.
+func referenceFlatInstaller() HookInstaller {
+	return HookInstaller{
+		Delivery: DeliveryAddressFree,
+		SettingsPath: func(t *testing.T) string {
+			t.Setenv(referenceFlatHomeEnv, t.TempDir())
+			path, err := referenceFlatConfigPath()
+			if err != nil {
+				t.Fatalf("resolving the reference flat hooks path: %v", err)
+			}
+			return path
+		},
+		Sentinel:        hookbeacon.Sentinel(referenceFlatAdapter),
+		Events:          referenceFlatEvents,
+		Entry:           referenceFlatEntryNow,
+		EndpointOf:      referenceFlatEndpointOf,
+		EnsureInstalled: referenceFlatEnsureInstalled,
+		Uninstall:       referenceFlatUninstall,
+		ForeignInstall:  referenceFlatForeignInstall,
+		EntriesOf:       FlatHookEntries,
+	}
+}
+
+// TestFlatEntryShapeContract is the vacuity guard: the full #1178 contract,
+// run against a CORRECT flat-shape installer, end to end, via
+// AssertHookEndpointFollowsBindAddr itself — the same entry point a real
+// adapter calls — rather than the arm-by-arm self-tests below.
+func TestFlatEntryShapeContract(t *testing.T) {
+	if _, err := hookbeacon.InstalledCommand(referenceFlatAdapter); err != nil {
+		t.Fatalf("resolving the beacon command: %v", err)
+	}
+	AssertHookEndpointFollowsBindAddr(t, referenceFlatInstaller())
+}
+
+// TestFlatHookEntries_NestedShapeIsNotFlat pins FlatHookEntries against the
+// shape it is NOT: a nested matcher-group array, where each element is a
+// GROUP object ({"matcher":..., "hooks":[...]}) rather than an inner hook
+// entry itself. FlatHookEntries must still return it as a "entry" (matching
+// what the value on disk literally contains, structurally) — the shape
+// mismatch is exactly why an adapter reading kiro-cli's rejected nested
+// install would see the wrong thing, which is the defect #1716 catches, not
+// one FlatHookEntries introduces.
+func TestFlatHookEntries_NestedShapeIsNotFlat(t *testing.T) {
+	hooksMap := map[string]interface{}{
+		"stop": []interface{}{
+			map[string]interface{}{"matcher": "", "hooks": []interface{}{
+				map[string]interface{}{"command": "irrlichd hook-post kiro-cli"},
+			}},
+		},
+	}
+	entries, err := FlatHookEntries(hooksMap, "stop")
+	if err != nil {
+		t.Fatalf("FlatHookEntries: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("got %d entries, want 1 (the outer group object itself)", len(entries))
+	}
+	if _, hasCommand := entries[0]["command"]; hasCommand {
+		t.Error("FlatHookEntries read a nested group as if it carried \"command\" directly — " +
+			"it must return the group object UNINTERPRETED, not reach into it")
+	}
+	if _, hasHooks := entries[0]["hooks"]; !hasHooks {
+		t.Error("FlatHookEntries lost the group's own \"hooks\" key — it must return the raw " +
+			"element, not a nested-shape-aware transformation of it")
+	}
+}
+
+// TestNestedHookEntries_FlatShapeIsNotNested is the mirror: NestedHookEntries
+// fed a flat array (no "hooks" sub-key) must refuse rather than silently
+// return zero entries, which would make onlyEntry's "expected exactly 1"
+// check pass VACUOUSLY for a nested-shape adapter that regressed to writing
+// flat entries by mistake — reporting "0 entries" would read as "event
+// missing" (a different, wrong diagnosis) rather than "shape mismatch".
+func TestNestedHookEntries_FlatShapeIsNotNested(t *testing.T) {
+	hooksMap := map[string]interface{}{
+		"stop": []interface{}{
+			map[string]interface{}{"command": "irrlichd hook-post kiro-cli"},
+		},
+	}
+	if _, err := NestedHookEntries(hooksMap, "stop"); err == nil {
+		t.Error("NestedHookEntries accepted a flat array element with no \"hooks\" key and no error")
+	}
+}

--- a/core/internal/contracttesting/hook_endpoint_selftest_test.go
+++ b/core/internal/contracttesting/hook_endpoint_selftest_test.go
@@ -395,9 +395,12 @@ func TestEndpointArm_SecondAssertions(t *testing.T) {
 			}, hookjson.EnsureInstalled)
 		}
 		rec := observe(t, func(at armT) { assertUpgradedInPlace(at, mutated, r, mutated.SettingsPath(t)) })
-		mustReport(t, rec, "expected exactly 1 matcher group",
+		mustReport(t, rec, "expected exactly 1 inner hook entry",
 			"an install that appends a second group beside the foreign entry instead of "+
-				"repointing it (M3b)")
+				"repointing it (M3b) — reworded from \"matcher group\" to \"inner hook entry\" "+
+				"when onlyEntry became shape-agnostic (issue #1716's EntriesOf seam): a second "+
+				"matcher group and a second flat array element are the same defect once "+
+				"flattened, so one message now covers both")
 	})
 
 	// Obligation 4's second claim: the entries are actually GONE. Reporting

--- a/core/internal/contracttesting/hook_endpoint_test.go
+++ b/core/internal/contracttesting/hook_endpoint_test.go
@@ -1,0 +1,138 @@
+// hook_endpoint_test.go carries direct unit coverage of the two default
+// bridges (endpointOfRaw, rawEntriesOf) that does not need a whole reference
+// installer — both were found, by a coordinator review of #1734, to have a
+// silent-failure shape the rest of this file's own obligations do not
+// exercise, because the obligations only ever run these bridges through a
+// CORRECT reference installer.
+//
+// endpointOfRaw's default bridge used to return "" when an entry did not
+// unmarshal as JSON, which is not a neutral value under the
+// DeliveryAddressFree route: assertDeliveryCarriesNoAddress
+// (hook_endpoint.go) checks that the delivery is IDENTICAL across bind
+// addresses and carries no address-shaped fragment, and "" satisfies both
+// trivially — so a non-JSON entry shape with EndpointOfRaw left unset made
+// obligation 1 pass having graded nothing. It was caught in review only
+// because a NEIGHBOURING guard (assertDeliveryIsOurs) happened to run first
+// in the one obligation that calls it before the address check; the fix
+// (see endpointOfRaw's own doc comment) makes the bridge itself fail loudly,
+// and TestEndpointOfRaw_MissingBridgeFailsLoudlyNotSilently below is the
+// isolated lock for it — no neighbour anywhere in the call.
+//
+// rawEntriesOf's default bridge was the natural next question: can IT
+// return an empty slice, no error, on a settings file it only "half
+// understands" — present, valid JSON, but shaped wrong? An empty slice with
+// no error is indistinguishable from "nothing installed yet" downstream
+// (onlyRawEntry's own "expected exactly 1" check would fire either way), so
+// if the bridge produced one for a malformed file it would be the read-side
+// twin of the write-side defect, just with a less exotic failure mode. It
+// does not (traced and locked below), but the tracing is committed as tests
+// rather than left as a claim in a PR body.
+package contracttesting
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestRawEntriesOf_HooksKeyPresentButWrongShape_IsAnErrorNotEmpty is the
+// concrete case: "hooks" exists in the settings file — so
+// readSettingsHooksMap's own type assertion is the one that can go quiet —
+// but its VALUE is not a map at all (a string, standing in for any
+// non-object JSON value). readSettingsHooksMap's comma-ok assertion turns
+// that into hooksMap == nil with no error; the traced claim under test is
+// that entriesOf's own next assertion (hooksMap[event].([]interface{}) on a
+// nil map) is what turns "wrong shape" into a real error rather than into a
+// silently empty entry list.
+func TestRawEntriesOf_HooksKeyPresentButWrongShape_IsAnErrorNotEmpty(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "settings.json")
+	// "hooks" is a STRING, not an object — present, valid JSON, wrong shape.
+	if err := os.WriteFile(path, []byte(`{"hooks":"not-an-object"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	h := HookInstaller{} // EntriesOf nil -> NestedHookEntries; ReadEntries nil -> the default bridge
+	entries, err := rawEntriesOf(h)(path, "stop")
+	if err == nil {
+		t.Fatalf("rawEntriesOf on a settings file whose \"hooks\" key is a string: got %d entries and no error, want a refusal — a malformed shape must not read as \"nothing installed\"", len(entries))
+	}
+}
+
+// TestRawEntriesOf_EventKeyGenuinelyAbsent_IsAlsoAnError is the companion
+// case on the same code path, stated so the mutation evidence above is not
+// mistaken for "any parse produces an error": a WELL-FORMED hooks object
+// that simply does not mention the requested event is ALSO reported as an
+// error by NestedHookEntries/FlatHookEntries ("missing from the settings
+// file or not an array") — not silently zero — which is a stronger
+// contract than strictly necessary but is the one this seam already makes,
+// and this test locks it rather than leaving it to be discovered by reading
+// NestedHookEntries's source.
+func TestRawEntriesOf_EventKeyGenuinelyAbsent_IsAlsoAnError(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "settings.json")
+	if err := os.WriteFile(path, []byte(`{"hooks":{}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	h := HookInstaller{}
+	if _, err := rawEntriesOf(h)(path, "stop"); err == nil {
+		t.Fatal("rawEntriesOf on a hooks object with no \"stop\" key: got no error, want one")
+	}
+}
+
+// TestRawEntriesOf_EventPresentButEmptyArray_IsLegitimatelyZero is the
+// vacuity guard for both tests above: an event key that IS present, and IS
+// an array, and genuinely holds nothing, is the everyday "nothing installed
+// for this event yet" state and must NOT be refused — refusing it would make
+// the two error cases above meaningless (every input would error) and would
+// make an adapter's very first, pre-install read of its own settings file
+// fail this seam outright.
+func TestRawEntriesOf_EventPresentButEmptyArray_IsLegitimatelyZero(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "settings.json")
+	if err := os.WriteFile(path, []byte(`{"hooks":{"stop":[]}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	h := HookInstaller{}
+	entries, err := rawEntriesOf(h)(path, "stop")
+	if err != nil {
+		t.Fatalf("rawEntriesOf on a genuinely empty \"stop\" array: %v, want nil error", err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("rawEntriesOf on a genuinely empty \"stop\" array: got %d entries, want 0", len(entries))
+	}
+}
+
+// TestEndpointOfRaw_MissingBridgeFailsLoudlyNotSilently is the committed
+// lock for endpointOfRaw's own doc comment: its default JSON bridge, called
+// with an entry that does not unmarshal as JSON, reports the parse failure
+// itself rather than answering "". It drives endpointOfRaw DIRECTLY through
+// the package's own negative-self-test harness (observe/mustReport/
+// mustBeSilent, selftest_test.go) — the same harness every <family>_selftest_
+// test.go uses — so there is no neighbouring assertion anywhere in the call
+// that could be catching this instead: a broken bridge here has nothing else
+// standing between it and the recorder.
+func TestEndpointOfRaw_MissingBridgeFailsLoudlyNotSilently(t *testing.T) {
+	h := HookInstaller{
+		EndpointOf: func(hook map[string]interface{}) string {
+			c, _ := hook["command"].(string)
+			return c
+		},
+		// EndpointOfRaw deliberately left nil: this is the case under test.
+	}
+
+	broken := observe(t, func(at armT) {
+		endpointOfRaw(at, h)([]byte("[[hooks]]\ncommand = \"not json at all\"\n"))
+	})
+	mustReport(t, broken, "does not unmarshal as JSON", "non-JSON entry, EndpointOfRaw unset")
+
+	// Vacuity guard: an ordinary JSON entry — every adapter wired before
+	// #1718, and kiro-cli's flat shape — reaches h.EndpointOf silently, the
+	// same default bridge every existing wiring already depends on.
+	correct := observe(t, func(at armT) {
+		endpointOfRaw(at, h)([]byte(`{"command":"curl -sf http://127.0.0.1:7837/api/v1/hooks"}`))
+	})
+	mustBeSilent(t, correct, "well-formed JSON entry")
+}

--- a/core/internal/contracttesting/hook_endpoint_toml_test.go
+++ b/core/internal/contracttesting/hook_endpoint_toml_test.go
@@ -1,0 +1,440 @@
+// hook_endpoint_toml_test.go exercises AssertHookEndpointFollowsBindAddr's
+// ReadEntries/EndpointOfRaw seam (issue #1718's audit of #1716's own
+// EntriesOf) against a reference TOML-shaped reference installer — the same
+// role hook_endpoint_addressfree_test.go's referenceBeaconInstaller and
+// hook_endpoint_flat_test.go's referenceFlatInstaller play for their own
+// routes: proof the seam works, built and driven BEFORE any real adapter
+// declares it, so it is not "exemption with no test behind it" for the
+// months between the seam landing and mistral-vibe's own PR (#1733) adopting
+// it.
+//
+// It is scaffolding, and says so exactly as those two files do: once a real
+// TOML-writing adapter wires ReadEntries/EndpointOfRaw for its own hooktoml
+// package, that adapter's wiring becomes the honest coverage and this file
+// should be reduced to whatever it still uniquely proves, or deleted.
+//
+// Two things this file is deliberately NOT trying to do. It is not a TOML
+// parser, and it does not attempt to be spec-compliant: hooktoml itself never
+// produces a decoded generic structure (#1718's audit — "works entirely as
+// byte-range edits over the original file bytes"), so a reference installer
+// exercising the same seam has to be a byte-range scanner too, or it would be
+// proving the wrong shape. And it declares exactly ONE event
+// (referenceTOMLEvents), matching #1718's audit finding that hooktoml has no
+// per-event disambiguation today (a flat `[[hooks]]` sequence, one event
+// installed) — see referenceTOMLReadEntries's doc comment for the decision
+// this settles: the seam does NOT require per-event lookup, an adapter's
+// ReadEntries is free to ignore the event parameter when its format has
+// nothing to filter on, and HookInstaller.ReadEntries already documents this
+// (the file comment there, added alongside this one).
+package contracttesting
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"irrlicht/core/adapters/inbound/agents/agentpaths"
+	"irrlicht/core/pkg/daemonaddr"
+)
+
+// referenceTOMLAdapter is this fixture's adapter segment, distinct from every
+// other reference installer's so a wiring mistake sorts to the wrong fixture
+// loudly rather than silently sharing state.
+const referenceTOMLAdapter = "reference-toml"
+
+// referenceTOMLHomeEnv relocates the fixture's config home.
+const referenceTOMLHomeEnv = "IRRLICHT_TEST_REFERENCE_TOML_HOME"
+
+// referenceTOMLSentinel is the port-independent substring marking our
+// [[hooks]] block. Unlike the JSON reference installers, which reuse
+// hookbeacon.Sentinel, this one is a plain constant: DeliveryURL mode (this
+// fixture's route — see referenceTOMLInstaller) needs no beacon at all, and a
+// TOML adapter's own sentinel is exactly this kind of arbitrary marker
+// string, matched by bytes.Contains rather than parsed out of a named field
+// (#1718's own findOurBlock convention).
+const referenceTOMLSentinel = "managed-by-irrlicht-reference-toml-v1"
+
+// referenceTOMLEvents declares exactly one event, deliberately: see the file
+// comment for why that is the shape being proven, not a simplification.
+var referenceTOMLEvents = []string{"postToolUse"}
+
+// referenceTOMLHome mirrors referenceBeaconHome/referenceFlatHome's own
+// reasoning exactly, including the deliberately empty default.
+func referenceTOMLHome() (string, error) {
+	return agentpaths.AbsRoot(agentpaths.FromEnv(referenceTOMLAdapter, referenceTOMLHomeEnv, ""))
+}
+
+func referenceTOMLConfigPath() (string, error) {
+	home, err := referenceTOMLHome()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, "hooks.toml"), nil
+}
+
+// referenceTOMLDeliveryNow renders the command line this installer would
+// write for whatever bind address daemonaddr.EnvBindAddr currently names —
+// the same "read the env, render the string" shape deliveryOn drives every
+// reference installer through.
+//
+// The sentinel is embedded IN the delivery string itself (a query
+// parameter), not appended as a separate comment line: assertDeliveryIsOurs
+// (hook_endpoint.go) requires the string EndpointOf/EndpointOfRaw returns to
+// carry Sentinel directly, the same way a real DeliveryURL adapter's url or
+// command line carries it — a beacon adapter gets this for free because
+// hookbeacon.Sentinel is itself a substring of the rendered command, and a
+// URL adapter has to render it into the endpoint the same way.
+func referenceTOMLDeliveryNow() string {
+	port := daemonaddr.PortOf(os.Getenv(daemonaddr.EnvBindAddr))
+	return fmt.Sprintf("curl -sf http://127.0.0.1:%d/api/v1/hooks?agent=%s", port, referenceTOMLSentinel)
+}
+
+// referenceTOMLEntry/referenceTOMLEndpointOf are the contract's in-memory
+// Entry/EndpointOf pair — obligation 1 (deliveriesOnBothAddrs) never touches
+// the filesystem or ReadEntries/EndpointOfRaw at all, exactly as
+// HookInstaller.EndpointOfRaw's own doc comment states: "an adapter can
+// honestly answer that question with a map even when what it actually
+// persists to disk is raw TOML text."
+func referenceTOMLEntry(delivery string) map[string]interface{} {
+	return map[string]interface{}{"command": delivery}
+}
+
+func referenceTOMLEndpointOf(hook map[string]interface{}) string {
+	c, _ := hook["command"].(string)
+	return c
+}
+
+func referenceTOMLEntryNow() map[string]interface{} {
+	return referenceTOMLEntry(referenceTOMLDeliveryNow())
+}
+
+// referenceTOMLBlock renders one canonical `[[hooks]]` block for delivery, as
+// raw bytes — the unit scanTOMLHookBlocks splits a file into and the unit
+// referenceTOMLEnsureInstalled compares whole. The command value is rendered
+// with %q, which for these delivery strings (no quotes, no backslashes)
+// produces exactly a TOML basic string. No separate sentinel comment line is
+// needed: a canonical delivery already carries Sentinel (see
+// referenceTOMLDeliveryNow), so bytes.Contains(block, sentinel) — what
+// hasOurRawEntry actually checks — finds it inside the command value.
+func referenceTOMLBlock(delivery string) []byte {
+	return []byte(fmt.Sprintf(
+		"[[hooks]]\nevent = %q\ncommand = %q\n",
+		referenceTOMLEvents[0], delivery,
+	))
+}
+
+func referenceTOMLBlockNow() []byte {
+	return referenceTOMLBlock(referenceTOMLDeliveryNow())
+}
+
+// scanTOMLHookBlocks splits data into its `[[hooks]]` blocks, each block
+// running from its own marker line to the line before the next marker or
+// EOF. It is a byte-range scanner, not a TOML parser, matching hooktoml's own
+// approach (#1718's audit).
+//
+// It REFUSES rather than silently returning fewer entries than the file
+// actually holds when a block's command value is not a well-formed TOML
+// basic string — specifically, an opened `command = "` with no closing `"`
+// before the block ends. That is the one failure mode a byte-range scanner
+// can hit that a generic-structure parser would report as a parse error, and
+// it is exactly the state a truncated or corrupted write leaves behind: an
+// unclosed string reads, to a scanner with no validation, as "no command
+// field" — silently indistinguishable from an entry that was never given
+// one. TestReferenceTOMLReadEntries_RejectsUnterminatedCommand is the
+// committed mutation evidence for this refusal; see its own comment for what
+// it proves and why the alternative (endpointOfRaw quietly returning "") is
+// the wrong place to catch it.
+func scanTOMLHookBlocks(data []byte) ([][]byte, error) {
+	const marker = "[[hooks]]"
+	var blocks [][]byte
+	lines := bytes.SplitAfter(data, []byte("\n"))
+	var current []byte
+	inBlock := false
+	flush := func() {
+		if inBlock {
+			blocks = append(blocks, current)
+			current = nil
+		}
+	}
+	for _, line := range lines {
+		if len(bytes.TrimSpace(line)) == len(marker) && string(bytes.TrimSpace(line)) == marker {
+			flush()
+			inBlock = true
+			current = append([]byte{}, line...)
+			continue
+		}
+		if inBlock {
+			current = append(current, line...)
+		}
+	}
+	flush()
+
+	for _, b := range blocks {
+		if !balancedCommandQuotes(b) {
+			return nil, fmt.Errorf("malformed [[hooks]] block: command value has no closing quote: %q", b)
+		}
+	}
+	return blocks, nil
+}
+
+// balancedCommandQuotes reports whether block's "command = " value, if any,
+// is closed by a matching quote. A block with no "command = " at all is not
+// this function's business — an entry legitimately naming no command is a
+// different, EndpointOfRaw-visible problem ("" carries no Sentinel, so
+// assertDeliveryIsOurs catches it) — this only refuses the case where a value
+// was clearly STARTED and never finished.
+func balancedCommandQuotes(block []byte) bool {
+	const marker = "command = \""
+	i := bytes.Index(block, []byte(marker))
+	if i < 0 {
+		return true
+	}
+	rest := block[i+len(marker):]
+	return bytes.IndexByte(rest, '"') >= 0
+}
+
+// referenceTOMLReadEntries is the contract's ReadEntries: it reads the whole
+// file and returns every `[[hooks]]` block's raw bytes, IGNORING event.
+//
+// That is the seam's answer to #1718's per-event disambiguation gap: this
+// format has no field the entries could be filtered on (referenceTOMLEvents
+// declares exactly one), so there is nothing for the parameter to select
+// between, and ReadEntries is free to return everything every time. A format
+// that DID need to disambiguate would filter here — the parameter exists for
+// exactly that adapter — but the parameter's presence does not obligate every
+// implementation to use it.
+func referenceTOMLReadEntries(path, _ string) ([][]byte, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return scanTOMLHookBlocks(data)
+}
+
+// referenceTOMLEndpointOfRaw extracts the command value out of one raw
+// [[hooks]] block. Entries reaching this function have already passed
+// scanTOMLHookBlocks's balancedCommandQuotes check, so the closing quote this
+// looks for is guaranteed to exist for a well-formed entry; a block with no
+// "command = " field at all yields "", which assertDeliveryIsOurs (in
+// hook_endpoint.go) is what turns into a loud failure rather than a silent
+// pass — see that function's own comment for why an empty, sentinel-free
+// delivery cannot slip through unnoticed.
+func referenceTOMLEndpointOfRaw(entry []byte) string {
+	const marker = "command = \""
+	i := bytes.Index(entry, []byte(marker))
+	if i < 0 {
+		return ""
+	}
+	rest := entry[i+len(marker):]
+	j := bytes.IndexByte(rest, '"')
+	if j < 0 {
+		return ""
+	}
+	return string(rest[:j])
+}
+
+func referenceTOMLWriteFile(path string, data []byte) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0o600)
+}
+
+// referenceTOMLEnsureInstalled rebuilds the file's block set from scratch —
+// every non-sentinel block kept verbatim, one fresh canonical block
+// appended — and compares the result byte-for-byte against what was already
+// on disk before writing, which is what makes a same-address second call
+// idempotent (modified=false) without a separate "is this already canonical"
+// predicate. That mirrors #1718's own audit of IsCanonical: "works by exact
+// []byte comparison against a freshly-rendered canonical block."
+func referenceTOMLEnsureInstalled() (bool, error) {
+	path, err := referenceTOMLConfigPath()
+	if err != nil {
+		return false, err
+	}
+	data, err := os.ReadFile(path)
+	if err != nil && !os.IsNotExist(err) {
+		return false, err
+	}
+	blocks, err := scanTOMLHookBlocks(data)
+	if err != nil {
+		return false, err
+	}
+	var rest [][]byte
+	for _, b := range blocks {
+		if !bytes.Contains(b, []byte(referenceTOMLSentinel)) {
+			rest = append(rest, b)
+		}
+	}
+	rest = append(rest, referenceTOMLBlockNow())
+	newData := bytes.Join(rest, nil)
+	if bytes.Equal(newData, data) {
+		return false, nil
+	}
+	if err := referenceTOMLWriteFile(path, newData); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// referenceTOMLUninstall drops every sentinel-bearing block, whatever
+// delivery it names — not scoped to the currently resolved bind address,
+// matching every other reference installer's uninstall.
+func referenceTOMLUninstall() (bool, error) {
+	path, err := referenceTOMLConfigPath()
+	if err != nil {
+		return false, err
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	blocks, err := scanTOMLHookBlocks(data)
+	if err != nil {
+		return false, err
+	}
+	var rest [][]byte
+	removed := false
+	for _, b := range blocks {
+		if bytes.Contains(b, []byte(referenceTOMLSentinel)) {
+			removed = true
+			continue
+		}
+		rest = append(rest, b)
+	}
+	if !removed {
+		return false, nil
+	}
+	if err := referenceTOMLWriteFile(path, bytes.Join(rest, nil)); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// referenceTOMLInstaller is the whole TOML-shape wiring, as one value —
+// mirroring referenceBeaconInstaller/referenceFlatInstaller's own role.
+// DeliveryURL, not DeliveryAddressFree: this fixture is proving the
+// ReadEntries/EndpointOfRaw seam, which is independent of delivery mode, and
+// DeliveryURL needs no ForeignInstall/hookbeacon machinery, keeping the two
+// concerns separate.
+func referenceTOMLInstaller() HookInstaller {
+	return HookInstaller{
+		Delivery: DeliveryURL,
+		SettingsPath: func(t *testing.T) string {
+			t.Setenv(referenceTOMLHomeEnv, t.TempDir())
+			path, err := referenceTOMLConfigPath()
+			if err != nil {
+				t.Fatalf("resolving the reference TOML hooks path: %v", err)
+			}
+			return path
+		},
+		Sentinel:        referenceTOMLSentinel,
+		Events:          referenceTOMLEvents,
+		Entry:           referenceTOMLEntryNow,
+		EndpointOf:      referenceTOMLEndpointOf,
+		EnsureInstalled: referenceTOMLEnsureInstalled,
+		Uninstall:       referenceTOMLUninstall,
+		ReadEntries:     referenceTOMLReadEntries,
+		EndpointOfRaw:   referenceTOMLEndpointOfRaw,
+		// EntriesOf is deliberately left nil: this fixture never produces a
+		// decoded map[string]interface{} for its on-disk form at all, which
+		// is the whole point being proven (see the file comment).
+	}
+}
+
+// TestTOMLEntryShapeContract is the vacuity guard: the full #1178 contract,
+// run against a CORRECT TOML-shape installer, end to end, via
+// AssertHookEndpointFollowsBindAddr itself.
+func TestTOMLEntryShapeContract(t *testing.T) {
+	AssertHookEndpointFollowsBindAddr(t, referenceTOMLInstaller())
+}
+
+// TestReferenceTOMLReadEntries_RejectsUnterminatedCommand is the mutation
+// evidence HookInstaller.ReadEntries's doc comment promises: a shape this
+// scanner cannot parse is refused with an error, not silently read as zero
+// (or one empty) entries.
+//
+// The malformed fixture below opens `command = "` and never closes it before
+// the block ends — the state a truncated write leaves behind. Without
+// balancedCommandQuotes's check, scanTOMLHookBlocks would return the block
+// unmodified (a scanner with no validation has no way to know a field is
+// missing versus cut off), referenceTOMLEndpointOfRaw would then find no
+// closing quote and answer "", and that "" would reach assertDeliveryIsOurs
+// as an ordinary empty delivery — reported as "does not carry Sentinel", the
+// SAME message a genuinely blank entry produces. That message is correct for
+// an entry with no command at all; it is the wrong diagnosis for a file that
+// is corrupted, and it is why the refusal belongs at the READ step rather
+// than being left for EndpointOfRaw's caller to notice downstream.
+func TestReferenceTOMLReadEntries_RejectsUnterminatedCommand(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "hooks.toml")
+	malformed := []byte("[[hooks]]\nevent = \"postToolUse\"\ncommand = \"curl -sf http://127.0.0.1:7837/api/v1/hooks\n# " + referenceTOMLSentinel + "\n")
+	if err := os.WriteFile(path, malformed, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	entries, err := referenceTOMLReadEntries(path, referenceTOMLEvents[0])
+	if err == nil {
+		t.Fatalf("ReadEntries on a block with an unterminated command string: got %d entries and no error, want a refusal", len(entries))
+	}
+}
+
+// TestReferenceTOMLReadEntries_EmptyFileIsZeroEntriesNotAnError is
+// RejectsUnterminatedCommand's own vacuity guard: a genuinely empty (or
+// absent) settings file is the everyday "nothing installed yet" state, not a
+// parse failure, and must not trip the refusal above.
+func TestReferenceTOMLReadEntries_EmptyFileIsZeroEntriesNotAnError(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "hooks.toml")
+
+	entries, err := referenceTOMLReadEntries(path, referenceTOMLEvents[0])
+	if err != nil {
+		t.Fatalf("ReadEntries on a nonexistent file: %v, want nil error", err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("ReadEntries on a nonexistent file: got %d entries, want 0", len(entries))
+	}
+
+	if err := os.WriteFile(path, []byte(""), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	entries, err = referenceTOMLReadEntries(path, referenceTOMLEvents[0])
+	if err != nil {
+		t.Fatalf("ReadEntries on an empty file: %v, want nil error", err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("ReadEntries on an empty file: got %d entries, want 0", len(entries))
+	}
+}
+
+// TestReferenceTOMLReadEntries_IgnoresEventArgument is a lock (passes by
+// construction) on the per-event-lookup decision documented on
+// HookInstaller.ReadEntries and in this file's header: this format has
+// nothing to filter an event by, so ReadEntries returns the same blocks
+// regardless of what event is asked for, deliberately.
+func TestReferenceTOMLReadEntries_IgnoresEventArgument(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "hooks.toml")
+	if err := os.WriteFile(path, referenceTOMLBlock("curl -sf http://127.0.0.1:7837/api/v1/hooks"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	declared, err := referenceTOMLReadEntries(path, referenceTOMLEvents[0])
+	if err != nil {
+		t.Fatalf("ReadEntries(declared event): %v", err)
+	}
+	other, err := referenceTOMLReadEntries(path, "some-event-name-this-format-never-declared")
+	if err != nil {
+		t.Fatalf("ReadEntries(unrelated event name): %v", err)
+	}
+	if len(declared) != 1 || len(other) != 1 {
+		t.Fatalf("got %d and %d entries for two different event arguments, want 1 and 1 — this format has no per-event field to filter on", len(declared), len(other))
+	}
+}


### PR DESCRIPTION
## Summary

#1716's `HookInstaller.EntriesOf` seam (issue #1178's contract family,
`AssertHookEndpointFollowsBindAddr`) made the JSON matcher-group traversal
pluggable so kiro-cli's flat entry shape could be graded too. mistral-vibe's
#1718 audit (see [that issue's "Spec input for the shared #1178 seam"
comment](https://github.com/ingo-eichhorst/Irrlicht/issues/1718#issuecomment-5368126477))
found that design does not extend to a TOML-writing adapter (`hooktoml`) for
three independent reasons:

1. The **read step itself** has to be pluggable, not just the traversal after
   it — `hooktoml` never produces a decoded generic structure at all. It
   works entirely as byte-range edits over the original file bytes, so there
   is nothing for a `map[string]interface{}`-shaped `EntriesOf` to receive.
2. `map[string]interface{}` is the wrong currency for an entry — a TOML
   `[[hooks]]` block is a byte range, not a decodable value.
3. `hookjson.HasOurHook` is called at two more sites beyond the traversal
   (the seed cross-check and the uninstall-survival check), both hardcoded to
   the nested matcher-group shape and to named-field inspection.

## What changed

`HookInstaller` gains two new fields, both optional:

- `ReadEntries func(path, event string) ([][]byte, error)` — reads the
  settings file and returns the **raw bytes** of every entry belonging to
  `event`, however the format encodes one.
- `EndpointOfRaw func(entry []byte) string` — extracts the delivery string
  from one entry's raw bytes.

Both default to bridges built from the existing `EntriesOf` /
`hookjson.ReadSettings` / `EndpointOf` machinery, so **every JSON-shaped
adapter needs zero changes** — the four wired before #1716, plus kiro-cli's
`EntriesOf: FlatHookEntries`. A TOML adapter supplies `ReadEntries` and
`EndpointOfRaw` directly and never touches `EntriesOf` or
`hookjson.ReadSettings` at all.

The sentinel check (`hasOurRawEntry`, replacing `hookjson.HasOurHook` at all
three of its former call sites) is now a single, fully format-agnostic
`bytes.Contains` over an entry's raw bytes — which is not a weaker check
adopted for convenience, it is `hooktoml`'s **own** sentinel convention
(`findOurBlock` matches by `bytes.Contains` over the whole rendered block's
raw text, never by parsing a field back out), so this satisfies that
convention exactly rather than approximating it.

`Entry`/`EndpointOf` (the in-memory pair grading obligation 1 — "does the
delivery follow the bind address") are **unchanged**: they never touch the
filesystem, so an adapter can honestly answer that question with a map even
when what it persists to disk is raw TOML text.

## How a TOML-shaped installer satisfies this

`hook_endpoint_toml_test.go` is a new reference installer — a byte-range
`[[hooks]]` block scanner, deliberately not a real TOML parser, matching
`hooktoml`'s own approach — proving the seam end-to-end via
`TestTOMLEntryShapeContract`, which runs the full `#1178` contract through
`AssertHookEndpointFollowsBindAddr` exactly as a real adapter would call it.

It also settles the per-event-lookup question #1718 raised (`hooktoml` has no
per-event disambiguation today — a flat `[[hooks]]` sequence, one event
installed): the reference installer declares exactly one event and its
`ReadEntries` **ignores the `event` parameter entirely**
(`TestReferenceTOMLReadEntries_IgnoresEventArgument` is the lock). The seam
does not require per-event lookup — an adapter is free to ignore the
parameter when its format has nothing to filter on.

## Mutation evidence

Every mutation below was applied, seen red, and reverted, one per commit-less
foreground step (not preserved as separate commits, but each is independently
reproducible from the description):

- **Malformed shape is refused, not silently emptied.** A `[[hooks]]` block
  whose `command = "..."` value is truncated (never closed) is refused by
  `ReadEntries` with an error. Disabling the balance check
  (`balancedCommandQuotes`) makes `TestReferenceTOMLReadEntries_RejectsUnterminatedCommand`
  fail: the malformed fixture is silently read as 1 entry with no error —
  exactly the "cannot tell a corrupted write from an empty file" failure mode
  this refusal exists to prevent.
- **`ReadEntries` is load-bearing.** Removing it from the reference
  installer's wiring falls back to the default JSON bridge
  (`hookjson.ReadSettings` on TOML bytes), which fails loudly:
  `invalid character 'h' looking for beginning of value`. `TestTOMLEntryShapeContract`
  goes red on 3 of 4 sub-tests.
- **`EndpointOfRaw` is load-bearing.** Removing it falls back to the default
  bridge (`json.Unmarshal` of raw TOML bytes into a map), which fails
  *silently* and returns `""` — caught not by the bridge itself but by
  `assertDeliveryIsOurs`'s existing vacuity guard ("does not carry Sentinel").
  `TestTOMLEntryShapeContract` goes red on 2 of 4 sub-tests (the other two
  don't call `EndpointOfRaw` at all, which is noted in the test).
- **Vacuity guard**: `TestTOMLEntryShapeContract` itself, run against a
  correct fixture, passes 4/4 — the positive case every mutation above is
  measured against.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./internal/contracttesting/... -v` — full package green,
      including the pre-existing seam-walk structural tests, self-tests, and
      every other contract family
- [x] `gofmt -l` clean
- [x] Three deliberate mutations (above) applied, confirmed red, reverted
- [x] `tools/preflight.sh --only go|arch|tools|skills|posix|bash|security` —
      all green (swift/web untouched, correctly skipped)
- [x] Pre-push hook (`--changed`) ran clean on push

Linked: #1178, #1716, #1718

🤖 Generated with [Claude Code](https://claude.com/claude-code)