### PR TITLE
fix(rig): declare kiro-cli's third managed file; make agent-home isolation one declaration

### DIFF
--- a/core/adapters/inbound/agents/kirocli/agent.go
+++ b/core/adapters/inbound/agents/kirocli/agent.go
@@ -119,15 +119,28 @@ func Agent() agent.Agent {
 						Min:   minCLIVersion,
 						Probe: []string{kiroCLIBinary, "--version"},
 					},
-					// Also: the SAME Apply closure also rewrites
-					// chat.defaultAgent in settings/cli.json
-					// (ensureDefaultAgent, hookinstaller.go) — a second shared,
-					// user-owned file beyond Path (issue #1718's Also field).
-					// Undeclared, that write is invisible to
+					// Also: the SAME Apply closure writes TWO further files
+					// beyond Path (issue #1718's Also field), and both are in
+					// the user's real agent home:
+					//   settings/cli.json          — chat.defaultAgent
+					//                                (ensureDefaultAgent)
+					//   .irrlicht-prior-default.json — what that setting held
+					//                                first (recordPriorDefaultAgentOnce)
+					// Undeclared, either write is invisible to
 					// agents.ManagedUserFiles / --print-managed-files, the
 					// recording rig's snapshot/restore sweep — see
-					// TestKiroCLIAlso_SettingsFileIsAManagedFile
+					// TestKiroCLIAlso_SettingsFileIsAManagedFile and
+					// TestKiroCLIAlso_PriorDefaultSidecarIsAManagedFile
 					// (core/cmd/irrlichd) for the mutation evidence.
+					//
+					// The sidecar is irrlicht's OWN document rather than a
+					// file kiro-cli reads, which is why it was missed — but
+					// "shared, user-owned" is about WHERE it lands, not who
+					// authored it, and the residue it leaves is not inert:
+					// recordPriorDefaultAgentOnce deliberately never
+					// overwrites, so a copy a recording left in the
+					// operator's real ~/.kiro is what a LATER real grant
+					// reads instead of their actual chat.defaultAgent.
 					//
 					// What this does NOT change, stated because it would
 					// otherwise be assumed: PermissionService.sharedConfigRefusal
@@ -142,7 +155,7 @@ func Agent() agent.Agent {
 					// not a verdict-changing one. Declared anyway because the
 					// two are independent consumers and the recorder's sweep
 					// is not co-located with anything.
-					Also: []func() (string, error){kiroSettingsPath},
+					Also: []func() (string, error){kiroSettingsPath, priorDefaultStatePath},
 				},
 			},
 		},

--- a/core/application/services/permission_shared_config_gate_test.go
+++ b/core/application/services/permission_shared_config_gate_test.go
@@ -319,17 +319,28 @@ func TestSharedConfigGate_KiroCLIAlsoDeclarationReachesTheGuard(t *testing.T) {
 	realKiroHome := filepath.Join("/Users/someone", ".kiro")
 	t.Setenv("KIRO_HOME", realKiroHome)
 
+	// The settings/cli.json resolver is picked out by what it RESOLVES TO, not
+	// by its index: kiro-cli declares more than one Also entry (the second is
+	// the prior-default sidecar, core/cmd/irrlichd's
+	// TestKiroCLIAlso_PriorDefaultSidecarIsAManagedFile), and an index would
+	// silently retarget this test at a different file the day the order moved.
 	var kirocliAlso func() (string, error)
 	for _, p := range kirocli.Agent().Permissions {
-		if p.Key == kirocli.PermissionKeyHooks && p.Writes != nil {
-			if len(p.Writes.Also) != 1 {
-				t.Fatalf("kirocli's hooks permission declares %d Also entries, want exactly 1 (settings/cli.json)", len(p.Writes.Also))
+		if p.Key != kirocli.PermissionKeyHooks || p.Writes == nil {
+			continue
+		}
+		for _, resolve := range p.Writes.Also {
+			got, err := resolve()
+			if err != nil {
+				t.Fatalf("resolving one of kiro-cli's Also entries: %v", err)
 			}
-			kirocliAlso = p.Writes.Also[0]
+			if filepath.Base(got) == "cli.json" && filepath.Base(filepath.Dir(got)) == "settings" {
+				kirocliAlso = resolve
+			}
 		}
 	}
 	if kirocliAlso == nil {
-		t.Fatal("kirocli.Agent() declares no hooks permission with Writes")
+		t.Fatal("kirocli.Agent() declares no hooks permission whose Writes.Also resolves a settings/cli.json")
 	}
 	wantAlsoPath, err := kirocliAlso()
 	if err != nil {

--- a/core/application/services/permission_shared_config_gate_test.go
+++ b/core/application/services/permission_shared_config_gate_test.go
@@ -319,29 +319,7 @@ func TestSharedConfigGate_KiroCLIAlsoDeclarationReachesTheGuard(t *testing.T) {
 	realKiroHome := filepath.Join("/Users/someone", ".kiro")
 	t.Setenv("KIRO_HOME", realKiroHome)
 
-	// The settings/cli.json resolver is picked out by what it RESOLVES TO, not
-	// by its index: kiro-cli declares more than one Also entry (the second is
-	// the prior-default sidecar, core/cmd/irrlichd's
-	// TestKiroCLIAlso_PriorDefaultSidecarIsAManagedFile), and an index would
-	// silently retarget this test at a different file the day the order moved.
-	var kirocliAlso func() (string, error)
-	for _, p := range kirocli.Agent().Permissions {
-		if p.Key != kirocli.PermissionKeyHooks || p.Writes == nil {
-			continue
-		}
-		for _, resolve := range p.Writes.Also {
-			got, err := resolve()
-			if err != nil {
-				t.Fatalf("resolving one of kiro-cli's Also entries: %v", err)
-			}
-			if filepath.Base(got) == "cli.json" && filepath.Base(filepath.Dir(got)) == "settings" {
-				kirocliAlso = resolve
-			}
-		}
-	}
-	if kirocliAlso == nil {
-		t.Fatal("kirocli.Agent() declares no hooks permission whose Writes.Also resolves a settings/cli.json")
-	}
+	kirocliAlso := kirocliSettingsAlsoResolver(t)
 	wantAlsoPath, err := kirocliAlso()
 	if err != nil {
 		t.Fatalf("kiro-cli's real Also resolver: %v", err)
@@ -380,4 +358,32 @@ func TestSharedConfigGate_KiroCLIAlsoDeclarationReachesTheGuard(t *testing.T) {
 	if log2.errorMentioning(wantAlsoPath) {
 		t.Errorf("the refusal named %q even though Also was not declared on this permission — it cannot have evaluated a resolver it was never given", wantAlsoPath)
 	}
+}
+
+// kirocliSettingsAlsoResolver extracts kiro-cli's REAL settings/cli.json Also
+// resolver off its own registration.
+//
+// It is picked out by what it RESOLVES TO, not by its index: kiro-cli declares
+// more than one Also entry (the second is the prior-default sidecar,
+// core/cmd/irrlichd's TestKiroCLIAlso_PriorDefaultSidecarIsAManagedFile), and
+// an index would silently retarget the caller at a different file the day the
+// declaration order moved.
+func kirocliSettingsAlsoResolver(t *testing.T) func() (string, error) {
+	t.Helper()
+	for _, p := range kirocli.Agent().Permissions {
+		if p.Key != kirocli.PermissionKeyHooks || p.Writes == nil {
+			continue
+		}
+		for _, resolve := range p.Writes.Also {
+			got, err := resolve()
+			if err != nil {
+				t.Fatalf("resolving one of kiro-cli's Also entries: %v", err)
+			}
+			if filepath.Base(got) == "cli.json" && filepath.Base(filepath.Dir(got)) == "settings" {
+				return resolve
+			}
+		}
+	}
+	t.Fatal("kirocli.Agent() declares no hooks permission whose Writes.Also resolves a settings/cli.json")
+	return nil
 }

--- a/core/cmd/irrlichd/kirocli_alsofile_test.go
+++ b/core/cmd/irrlichd/kirocli_alsofile_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 
@@ -29,10 +30,13 @@ func kirocliHooksPermission(t *testing.T) agent.Permission {
 
 // TestKiroCLIAlso_SettingsFileIsAManagedFile is the mutation-evidence test for
 // issue #1718's Also field applied to kiro-cli's hooks install (issue #1716):
-// EnsureHooksInstalled's single Apply closure writes TWO shared, user-owned
-// files — the agent config (Writes.Path) and chat.defaultAgent inside
-// settings/cli.json (hookinstaller.go's ensureDefaultAgent) — and only the
-// first is Writes.Path. Undeclared, the second is invisible to both
+// EnsureHooksInstalled's single Apply closure writes THREE shared, user-owned
+// files — the agent config (Writes.Path), chat.defaultAgent inside
+// settings/cli.json (hookinstaller.go's ensureDefaultAgent), and the
+// prior-default sidecar (the sibling test below) — and only the first is
+// Writes.Path. This test grades the settings/cli.json one; each file gets its
+// own test so a declaration that goes missing names WHICH file it was.
+// Undeclared, settings/cli.json is invisible to both
 // consumers that need to see it: the #1449 grant-all refusal
 // (PermissionService.sharedConfigRefusal) and the recording rig's
 // snapshot/restore sweep (agents.ManagedUserFiles, --print-managed-files).
@@ -80,16 +84,22 @@ func TestKiroCLIAlso_SettingsFileIsAManagedFile(t *testing.T) {
 	if perm.Writes == nil {
 		t.Fatal("kirocli hooks permission declares no Writes")
 	}
-	if len(perm.Writes.Also) != 1 {
-		t.Fatalf("Writes.Also has %d entries, want exactly 1 (settings/cli.json)", len(perm.Writes.Also))
-	}
-	also, err := perm.Writes.Also[0]()
-	if err != nil {
-		t.Fatalf("resolving Writes.Also[0]: %v", err)
-	}
+	// Selected by SUFFIX, not by index: this permission declares more than one
+	// Also entry (the prior-default sidecar is the sibling test below), and an
+	// index would make this test's subject depend on declaration order.
 	wantSuffix := filepath.Join("settings", "cli.json")
-	if !strings.HasPrefix(also, kiroHome) || !strings.HasSuffix(also, wantSuffix) {
-		t.Errorf("Writes.Also[0] = %q, want it under %q ending in %q", also, kiroHome, wantSuffix)
+	also := ""
+	for i, resolve := range perm.Writes.Also {
+		got, err := resolve()
+		if err != nil {
+			t.Fatalf("resolving Writes.Also[%d]: %v", i, err)
+		}
+		if strings.HasPrefix(got, kiroHome) && strings.HasSuffix(got, wantSuffix) {
+			also = got
+		}
+	}
+	if also == "" {
+		t.Fatalf("Writes.Also declares no entry under %q ending in %q", kiroHome, wantSuffix)
 	}
 
 	configs, err := agents.ManagedUserFiles(declaredConsentCatalog())
@@ -105,10 +115,10 @@ func TestKiroCLIAlso_SettingsFileIsAManagedFile(t *testing.T) {
 	if kirocliCfg == nil {
 		t.Fatal("agents.ManagedUserFiles projects no kiro-cli/hooks entry at all")
 	}
-	if len(kirocliCfg.Also) != 1 || kirocliCfg.Also[0] != also {
-		t.Errorf("projected ManagedUserFile.Also = %v, want [%q] — the recorder's snapshot/restore "+
-			"sweep resolves this slice directly, so an entry missing here is a file it will never "+
-			"back up before a grant-all daemon can rewrite it", kirocliCfg.Also, also)
+	if !slices.Contains(kirocliCfg.Also, also) {
+		t.Errorf("projected ManagedUserFile.Also = %v, want it to contain %q — the recorder's "+
+			"snapshot/restore sweep resolves this slice directly, so an entry missing here is a "+
+			"file it will never back up before a grant-all daemon can rewrite it", kirocliCfg.Also, also)
 	}
 
 	var buf bytes.Buffer
@@ -118,5 +128,63 @@ func TestKiroCLIAlso_SettingsFileIsAManagedFile(t *testing.T) {
 	if !strings.Contains(buf.String(), also) {
 		t.Errorf("--print-managed-files does not list %q — the recording rig protects only what "+
 			"this command names", also)
+	}
+}
+
+// TestKiroCLIAlso_PriorDefaultSidecarIsAManagedFile covers the THIRD file
+// kiro-cli's single hooks Apply closure writes into the user's real agent
+// home, and the only one #1718's audit did not declare:
+// $KIRO_HOME/.irrlicht-prior-default.json, written by
+// recordPriorDefaultAgentOnce (hookinstaller.go) on the way through
+// ensureDefaultAgent.
+//
+// It matters for one consumer and one failure, both concrete. The onboarding
+// recording rig protects exactly what `--print-managed-files` names
+// (tools/onboarding-factory/scripts/lib/managed-file-snapshot.sh asks the
+// daemon and keeps no literal list), so an undeclared file is one the
+// snapshot never backs up and the EXIT-trap restore never hands back — a
+// grant-all recording daemon creates it in the operator's real ~/.kiro and
+// leaves it there. The residue is not inert: recordPriorDefaultAgentOnce
+// deliberately never overwrites an existing record, so the stale sidecar a
+// recording left behind is what a LATER real grant reads instead of the
+// user's actual chat.defaultAgent — and a subsequent uninstall then restores
+// the recording's snapshot of that setting rather than the user's own choice.
+//
+// Same shape as the settings/cli.json case above and the same fix (one Also
+// entry), separated into its own test so the two files' declarations can fail
+// independently: a single assertion over the whole slice cannot say WHICH
+// file stopped being protected.
+func TestKiroCLIAlso_PriorDefaultSidecarIsAManagedFile(t *testing.T) {
+	kiroHome := filepath.Join(t.TempDir(), "kiro-home")
+	t.Setenv("KIRO_HOME", kiroHome)
+
+	perm := kirocliHooksPermission(t)
+	if perm.Writes == nil {
+		t.Fatal("kirocli hooks permission declares no Writes")
+	}
+
+	want := filepath.Join(kiroHome, ".irrlicht-prior-default.json")
+	found := false
+	for i, resolve := range perm.Writes.Also {
+		got, err := resolve()
+		if err != nil {
+			t.Fatalf("resolving Writes.Also[%d]: %v", i, err)
+		}
+		if got == want {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("Writes.Also declares no entry resolving to %q — recordPriorDefaultAgentOnce "+
+			"writes it on every install, so the recording rig cannot back it up or hand it back", want)
+	}
+
+	var buf bytes.Buffer
+	if err := printManagedFiles(&buf); err != nil {
+		t.Fatalf("printManagedFiles: %v", err)
+	}
+	if !strings.Contains(buf.String(), want) {
+		t.Errorf("--print-managed-files does not list %q — the recording rig protects only what "+
+			"this command names", want)
 	}
 }

--- a/core/cmd/irrlichd/kirocli_alsofile_test.go
+++ b/core/cmd/irrlichd/kirocli_alsofile_test.go
@@ -84,23 +84,8 @@ func TestKiroCLIAlso_SettingsFileIsAManagedFile(t *testing.T) {
 	if perm.Writes == nil {
 		t.Fatal("kirocli hooks permission declares no Writes")
 	}
-	// Selected by SUFFIX, not by index: this permission declares more than one
-	// Also entry (the prior-default sidecar is the sibling test below), and an
-	// index would make this test's subject depend on declaration order.
 	wantSuffix := filepath.Join("settings", "cli.json")
-	also := ""
-	for i, resolve := range perm.Writes.Also {
-		got, err := resolve()
-		if err != nil {
-			t.Fatalf("resolving Writes.Also[%d]: %v", i, err)
-		}
-		if strings.HasPrefix(got, kiroHome) && strings.HasSuffix(got, wantSuffix) {
-			also = got
-		}
-	}
-	if also == "" {
-		t.Fatalf("Writes.Also declares no entry under %q ending in %q", kiroHome, wantSuffix)
-	}
+	also := resolvedAlsoUnder(t, perm, kiroHome, wantSuffix)
 
 	configs, err := agents.ManagedUserFiles(declaredConsentCatalog())
 	if err != nil {
@@ -187,4 +172,26 @@ func TestKiroCLIAlso_PriorDefaultSidecarIsAManagedFile(t *testing.T) {
 		t.Errorf("--print-managed-files does not list %q — the recording rig protects only what "+
 			"this command names", want)
 	}
+}
+
+// resolvedAlsoUnder returns the one Writes.Also entry that resolves under root
+// and ends in suffix.
+//
+// Selected by what it RESOLVES TO, not by index: kiro-cli's hooks permission
+// declares more than one Also entry, and an index would make a test's subject
+// depend on declaration order — a silent retarget at a different file the day
+// somebody reorders the slice.
+func resolvedAlsoUnder(t *testing.T, perm agent.Permission, root, suffix string) string {
+	t.Helper()
+	for i, resolve := range perm.Writes.Also {
+		got, err := resolve()
+		if err != nil {
+			t.Fatalf("resolving Writes.Also[%d]: %v", i, err)
+		}
+		if strings.HasPrefix(got, root) && strings.HasSuffix(got, suffix) {
+			return got
+		}
+	}
+	t.Fatalf("Writes.Also declares no entry under %q ending in %q", root, suffix)
+	return ""
 }

--- a/replaydata/agents/copilot/driver-interactive.sh
+++ b/replaydata/agents/copilot/driver-interactive.sh
@@ -198,7 +198,22 @@ launch_repl() {
   # gate to exist before they can observe anything about it.
   [[ -n "${COPILOT_PLAN_MODE:-}" ]] && args+=(--plan)
   [[ -n "${RESUME_ID:-}" ]] && args+=("--resume=$RESUME_ID")
-  tmux new-session -d -s "$SESSION" -x 200 -y 50 -c "${SES_CWD[$ACTIVE]}" copilot "${args[@]}" \
+  # Prefix with `env COPILOT_HOME=…`, as drive-codex-interactive.sh does for
+  # CODEX_HOME. seed_copilot_home EXPORTS the variable, which is enough for a
+  # direct child and not for this one: the pane's command is spawned by the tmux
+  # SERVER, whose environment was fixed when that server started, so on any
+  # machine where a server is already running — a developer's own terminal,
+  # essentially always — the export does not reach copilot. Measured on a
+  # private `-L` socket: against a server started without the variable, a pane
+  # created by a shell that exported it reads <UNSET>, and the same server with
+  # this prefix reads the value. That is the exact failure this driver's own
+  # seed_copilot_home comment describes ("the daemon would observe no copilot
+  # session at all and every cell would record an empty fixture"), reached by a
+  # route the export cannot close. Found by
+  # TestEveryRigHomeRowsDriverPassesTheHomeThroughTmux
+  # (tools/onboarding-factory/internal/righome) on its first run.
+  tmux new-session -d -s "$SESSION" -x 200 -y 50 -c "${SES_CWD[$ACTIVE]}" \
+    env "COPILOT_HOME=$COPILOT_HOME" copilot "${args[@]}" \
     >>"$DRIVER_LOG.stdout.$ACTIVE" 2>>"$DRIVER_LOG.stderr" \
     || { echo "[driver] failed to launch copilot under tmux" >&2; EXIT_REASON="nonzero(2)"; exit 1; }
   tmux pipe-pane -t "$SESSION" -o "cat >> '$DRIVER_LOG.stdout.$ACTIVE'" 2>/dev/null || true

--- a/replaydata/agents/kiro-cli/driver-interactive.sh
+++ b/replaydata/agents/kiro-cli/driver-interactive.sh
@@ -115,11 +115,39 @@ mkdir -p "$STAGING"
 DRIVER_LOG="$STAGING/driver.log"
 
 # kiro-cli mints its OWN session UUID per `chat` launch and writes
-# ~/.kiro/sessions/cli/<uuid>.jsonl. We discover it as the newest .jsonl whose
-# mtime is after the slot's MARKER; the session id is the filename stem (the
-# daemon keys on it and it is the `--resume-id` arg).
-KIRO_SESSIONS_DIR="$HOME/.kiro/sessions/cli"
+# <kiro home>/sessions/cli/<uuid>.jsonl. We discover it as the newest .jsonl
+# whose mtime is after the slot's MARKER; the session id is the filename stem
+# (the daemon keys on it and it is the `--resume-id` arg).
+#
+# KIRO_HOME, not $HOME: kiro-cli relocates its entire home from that variable
+# (docs: "global agents, prompts, skills, steering, settings, and sessions"),
+# and so does the daemon — kirocli/adapter.go's sessionsDir and
+# hookinstaller.go's kiroHome both go through agentpaths.FromEnv. The recording
+# rig exports it before the daemon spawns (tools/onboarding-factory/scripts/
+# lib/agent-home.sh, opt-in), so a driver that kept resolving $HOME/.kiro would
+# make the two watch and write different homes.
+#
+# Absolute-only, mirroring drive-codex-interactive.sh and agentpaths.FromEnv
+# itself: a `${KIRO_HOME:-…}` default would accept a relative value the daemon
+# silently ignores in favour of $HOME/.kiro, i.e. the same disagreement.
+KIRO_HOME_RESOLVED="$HOME/.kiro"
+if [[ -n "${KIRO_HOME:-}" ]]; then
+  if [[ "$KIRO_HOME" != /* ]]; then
+    echo "[driver] KIRO_HOME must be absolute — the daemon's agentpaths.FromEnv" >&2
+    echo "[driver] ignores a relative value and falls back to \$HOME/.kiro, so the" >&2
+    echo "[driver] daemon and kiro-cli would use two different homes." >&2
+    echo "[driver] Got: '$KIRO_HOME'" >&2
+    # A bare exit, not EXIT_REASON: this runs before $NONZERO_2 is declared and
+    # before `trap cleanup EXIT` is armed, so there is no exit-reason file to
+    # write and referencing the constant here would die on set -u instead of
+    # printing the diagnosis above.
+    exit 1
+  fi
+  KIRO_HOME_RESOLVED="$KIRO_HOME"
+fi
+KIRO_SESSIONS_DIR="$KIRO_HOME_RESOLVED/sessions/cli"
 mkdir -p "$KIRO_SESSIONS_DIR"
+echo "[driver] kiro home: $KIRO_HOME_RESOLVED" >&2
 
 # Per-run CWD so each launch has its own cwd, isolating the cwd-based PID match.
 # run-cell.sh's cross-adapter mode overrides this via $IRRLICHT_ONBOARD_CWD so a
@@ -239,8 +267,17 @@ boot_session() {
   [[ -n "$resume_id" ]] && launch="$launch --resume-id $resume_id"
   # `|| { … exit … }` keeps a launch failure from aborting under set -e WITHOUT
   # an accurate exit-reason — the cleanup trap then records nonzero(2).
+  # Prefix with `env KIRO_HOME=…`, exactly as drive-codex-interactive.sh does
+  # for CODEX_HOME: the pane's command is spawned by the tmux SERVER, which on
+  # a dev machine essentially always pre-dates this driver and was started
+  # without KIRO_HOME — so the export the rig performed does NOT reach it.
+  # Measured on a private `-L` socket: against a server started without the
+  # variable, a pane created by a shell that exported it reads <UNSET>, and the
+  # same server with this prefix reads the value. Without the prefix the daemon
+  # would watch the isolated home while kiro-cli wrote to the real one, and the
+  # fixture would come back empty with nothing saying why.
   tmux new-session -d -s "$sess" -x 200 -y 50 -c "$cwd" \
-    "$launch" \
+    env "KIRO_HOME=$KIRO_HOME_RESOLVED" sh -c "$launch" \
     >>"$DRIVER_LOG.stdout" 2>>"$DRIVER_LOG.stderr" \
     || { echo "[driver] failed to launch kiro-cli under tmux" >&2; EXIT_REASON="$NONZERO_2"; exit 1; }
   tmux pipe-pane -t "$sess" -o "cat >> '$slot_stdout'"

--- a/replaydata/agents/mistral-vibe/driver-interactive.sh
+++ b/replaydata/agents/mistral-vibe/driver-interactive.sh
@@ -97,6 +97,40 @@ DRIVER_LOG="$STAGING/driver.log"
 VIBE_SESSION_GLOB='session_*'
 EXIT_DRIVER_FAULT="nonzero(2)"
 
+# VIBE_HOME, not $HOME: vibe relocates its whole home from that variable
+# (v2.19.1 vibe/core/paths/_vibe_home.py — VIBE_HOME = os.getenv("VIBE_HOME") or
+# ~/.vibe, SESSION_LOG_DIR = VIBE_HOME/"logs"/"session"), and so does the daemon
+# (vibe/adapter.go sessionsDir, vibe/config.go vibeHomeDir). The recording rig
+# exports it before the daemon spawns (tools/onboarding-factory/scripts/lib/
+# agent-home.sh, opt-in — vibe's API key can live in $VIBE_HOME/.env, so a
+# scratch home is never defaulted into), and a driver still resolving
+# $HOME/.vibe would make the two watch and write different homes.
+#
+# Absolute-only, mirroring drive-codex-interactive.sh: upstream applies
+# expanduser().resolve() and would accept "~/x" or a relative path, but irrlicht
+# resolves through agentpaths.FromEnv, which LOGS AND IGNORES anything
+# non-absolute and falls back to ~/.vibe — so accepting one here would be the
+# same daemon/driver disagreement with an extra step.
+VIBE_HOME_RESOLVED="$HOME/.vibe"
+if [[ -n "${VIBE_HOME:-}" ]]; then
+  if [[ "$VIBE_HOME" != /* ]]; then
+    echo "[driver] VIBE_HOME must be absolute — the daemon's agentpaths.FromEnv" >&2
+    echo "[driver] ignores a relative value and falls back to \$HOME/.vibe, so the" >&2
+    echo "[driver] daemon and vibe would use two different homes." >&2
+    echo "[driver] Got: '$VIBE_HOME'" >&2
+    # A bare exit: this runs before `trap cleanup EXIT` is armed, so there is no
+    # exit-reason file to write yet.
+    exit 1
+  fi
+  VIBE_HOME_RESOLVED="$VIBE_HOME"
+fi
+# The one spelling of the session root. It was written out four times before
+# this variable existed, which is three chances for a relocation to reach only
+# some of them.
+VIBE_SESSION_ROOT="$VIBE_HOME_RESOLVED/logs/session"
+mkdir -p "$VIBE_SESSION_ROOT"
+echo "[driver] vibe home: $VIBE_HOME_RESOLVED" >&2
+
 _DRIVE_LIB="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../_lib/drive" && pwd)"
 # shellcheck disable=SC2034  # read by the sourced replaydata/_lib/drive/slots.sh:56 (alloc_slot)
 DRIVE_MARKER_PREFIX="$STAGING/.mistral-vibe-marker"
@@ -171,7 +205,7 @@ remaining_seconds() { local now; now=$(date +%s); (( now >= DEADLINE )) && echo 
 # the active slot (TRANSCRIPT is the messages.jsonl, UUID is the dir name).
 resolve_transcript() {
   [[ -n "$TRANSCRIPT" ]] && return 0
-  local sroot="$HOME/.vibe/logs/session"
+  local sroot="$VIBE_SESSION_ROOT"
   local _ d cand
   for _ in $(seq 1 60); do
     cand=""
@@ -262,7 +296,7 @@ FIRST_SEND_PENDING=0
 boot_vibe_active() {
   local prompt="$1" resume_id="$2"
   command -v tmux >/dev/null 2>&1 || { echo "[driver] tmux required" >&2; EXIT_REASON="$EXIT_DRIVER_FAULT"; exit 1; }
-  PRE_LAUNCH_DIRS="$(find "$HOME/.vibe/logs/session" -maxdepth 1 -type d -name "$VIBE_SESSION_GLOB" 2>/dev/null | sort)"
+  PRE_LAUNCH_DIRS="$(find "$VIBE_SESSION_ROOT" -maxdepth 1 -type d -name "$VIBE_SESSION_GLOB" 2>/dev/null | sort)"
   tmux kill-session -t "$SESSION" 2>/dev/null || true
   : > "$DRIVER_LOG.stdout.$ACTIVE"
   mkdir -p "${SES_CWD[$ACTIVE]}"
@@ -296,8 +330,17 @@ boot_vibe_active() {
     vibe_args+=("$prompt")
     echo "[driver] launching with prompt as positional arg: ${prompt:0:60}" >&2
   fi
+  # Prefix with `env VIBE_HOME=…`, exactly as drive-codex-interactive.sh does
+  # for CODEX_HOME: the pane's command is spawned by the tmux SERVER, which on a
+  # dev machine essentially always pre-dates this driver and was started without
+  # VIBE_HOME — so the export the rig performed does NOT reach it. Measured on a
+  # private `-L` socket: against a server started without the variable, a pane
+  # created by a shell that exported it reads <UNSET>, and the same server with
+  # this prefix reads the value. Without it the daemon would watch the isolated
+  # home while vibe wrote to the real one, and the fixture would come back empty
+  # with nothing saying why.
   tmux new-session -d -s "$SESSION" -x 200 -y 50 -c "${SES_CWD[$ACTIVE]}" -- \
-    vibe "${vibe_args[@]}" 2>>"$DRIVER_LOG.stderr" \
+    env "VIBE_HOME=$VIBE_HOME_RESOLVED" vibe "${vibe_args[@]}" 2>>"$DRIVER_LOG.stderr" \
     || { echo "[driver] failed to launch vibe under tmux" >&2; EXIT_REASON="$EXIT_DRIVER_FAULT"; exit 1; }
   tmux pipe-pane -t "$SESSION" -o "cat >> '$DRIVER_LOG.stdout.$ACTIVE'"
   echo "[driver] tmux started: $SESSION (slot=$ACTIVE, cwd=${SES_CWD[$ACTIVE]})" >&2
@@ -355,7 +398,7 @@ launch_repl() {
 # what "the dialog is up" means.
 wait_turn() {
   resolve_transcript || {
-    echo "[driver] wait_turn[s$ACTIVE]: vibe never created a session dir under ~/.vibe/logs/session" >&2
+    echo "[driver] wait_turn[s$ACTIVE]: vibe never created a session dir under $VIBE_SESSION_ROOT" >&2
     EXIT_REASON="readiness_timeout"
     return 1
   }
@@ -454,7 +497,7 @@ slash_cmd() { # <text>
     local old_tmux="$SESSION" old_cwd="${SES_CWD[$ACTIVE]}"
     save_active
     SES_ALIVE[$ACTIVE]=0
-    PRE_LAUNCH_DIRS="$(find "$HOME/.vibe/logs/session" -maxdepth 1 -type d -name "$VIBE_SESSION_GLOB" 2>/dev/null | sort)"
+    PRE_LAUNCH_DIRS="$(find "$VIBE_SESSION_ROOT" -maxdepth 1 -type d -name "$VIBE_SESSION_GLOB" 2>/dev/null | sort)"
     type_enter "$text"
     alloc_slot "$old_tmux" "$old_cwd"
     SES_ALIVE[$ACTIVE]=1
@@ -462,7 +505,7 @@ slash_cmd() { # <text>
     return 0
   fi
   if [[ " $ROTATING_SLASHES " == *" $text "* ]]; then
-    PRE_LAUNCH_DIRS="$(find "$HOME/.vibe/logs/session" -maxdepth 1 -type d -name "$VIBE_SESSION_GLOB" 2>/dev/null | sort)"
+    PRE_LAUNCH_DIRS="$(find "$VIBE_SESSION_ROOT" -maxdepth 1 -type d -name "$VIBE_SESSION_GLOB" 2>/dev/null | sort)"
     type_enter "$text"
     TRANSCRIPT=""; UUID=""
     SES_TRANSCRIPT[$ACTIVE]=""

--- a/tools/onboarding-factory/internal/righome/righome.go
+++ b/tools/onboarding-factory/internal/righome/righome.go
@@ -33,6 +33,8 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+
+	"irrlicht/core/pkg/pathutil"
 )
 
 // TableScript is the shell library that carries the declaration, relative to
@@ -93,9 +95,17 @@ var Unisolatable = map[string]string{
 // otherwise be the same answer.
 func Table(repoRoot string) ([]Row, error) {
 	script := filepath.Join(repoRoot, TableScript)
+	// bash is resolved through pathutil rather than run by bare name, which is
+	// this repo's own answer to SonarQube go:S4036 (that package's doc comment
+	// names the rule): a local attacker who can write to a directory earlier on
+	// the inherited PATH would otherwise choose the interpreter that reads the
+	// declaration this whole package exists to trust. MustResolve falls back to
+	// the bare name when no trusted directory has it, so a machine with an
+	// unusual layout degrades to today's behaviour rather than failing to run
+	// the check at all.
 	// #nosec G204 -- script path is built from a caller-supplied repo root and
 	// a package constant, never from external input.
-	cmd := exec.Command("bash", "-c", `set -euo pipefail; source "$1"; agent_home_table`, "_", script)
+	cmd := exec.Command(pathutil.MustResolve("bash"), "-c", `set -euo pipefail; source "$1"; agent_home_table`, "_", script)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return nil, fmt.Errorf("running agent_home_table from %s: %w: %s", script, err, strings.TrimSpace(string(out)))
@@ -142,14 +152,30 @@ func Table(repoRoot string) ([]Row, error) {
 // an adapter, which is a different test), so the committed mutation evidence is
 // a corpus driving THIS function with deliberately wrong inputs.
 func Reconcile(rows []Row, exempt map[string]string, declaresHooks map[string]bool) []string {
-	var problems []string
-
 	if len(declaresHooks) == 0 {
 		return []string{"the adapter registry projection is empty — nothing below can fail, " +
 			"so this is a broken measurement rather than a clean result"}
 	}
 
+	// Three independent questions, one per helper — the table's own rows, the
+	// exemption map's own entries, and the adapters neither of them covers.
+	// Kept apart rather than folded into one walk because each names a
+	// different fragment in its message, and the corpus beside this file
+	// asserts that a case wrong in ONE way fires exactly one of them.
+	rowFor, problems := checkRows(rows, exempt, declaresHooks)
+	problems = append(problems, checkExemptions(exempt, declaresHooks)...)
+	problems = append(problems, checkUncovered(rowFor, exempt, declaresHooks)...)
+
+	sort.Strings(problems)
+	return problems
+}
+
+// checkRows validates the rig table's own rows and returns the row index the
+// uncovered-adapter check needs, so the two cannot disagree about which
+// adapters actually have a usable row (a duplicate contributes only its first).
+func checkRows(rows []Row, exempt map[string]string, declaresHooks map[string]bool) (map[string]Row, []string) {
 	rowFor := make(map[string]Row, len(rows))
+	var problems []string
 	for _, r := range rows {
 		if _, known := declaresHooks[r.Adapter]; !known {
 			problems = append(problems, fmt.Sprintf(
@@ -172,8 +198,16 @@ func Reconcile(rows []Row, exempt map[string]string, declaresHooks map[string]bo
 				r.Adapter, TableScript, r.EnvVar, truncate(reason)))
 		}
 	}
+	return rowFor, problems
+}
 
-	for adapter, reason := range exempt {
+// checkExemptions validates the exemption map's own keys in both directions: an
+// entry for an adapter the registry does not have, and one for an adapter that
+// installs no hooks. Both read as coverage of an obligation that was never
+// there.
+func checkExemptions(exempt map[string]string, declaresHooks map[string]bool) []string {
+	var problems []string
+	for adapter := range exempt {
 		declares, known := declaresHooks[adapter]
 		switch {
 		case !known:
@@ -185,25 +219,29 @@ func Reconcile(rows []Row, exempt map[string]string, declaresHooks map[string]bo
 				"Unisolatable names adapter %q, which declares no hooks permission — it is "+
 					"exempt from an obligation it never had", adapter))
 		}
-		_ = reason
 	}
+	return problems
+}
 
+// checkUncovered is the obligation itself: a hooks-declaring adapter in neither
+// declaration.
+func checkUncovered(rowFor map[string]Row, exempt map[string]string, declaresHooks map[string]bool) []string {
+	var problems []string
 	for _, adapter := range sortedKeys(declaresHooks) {
 		if !declaresHooks[adapter] {
 			continue
 		}
 		_, hasRow := rowFor[adapter]
 		_, isExempt := exempt[adapter]
-		if !hasRow && !isExempt {
-			problems = append(problems, fmt.Sprintf(
-				"adapter %q installs hooks into the user's config but has neither a row in %s "+
-					"nor an Unisolatable entry saying why it cannot have one. Add whichever is "+
-					"true — an isolation story is a decision, and an omission looks exactly like "+
-					"a decision that was made silently", adapter, TableScript))
+		if hasRow || isExempt {
+			continue
 		}
+		problems = append(problems, fmt.Sprintf(
+			"adapter %q installs hooks into the user's config but has neither a row in %s "+
+				"nor an Unisolatable entry saying why it cannot have one. Add whichever is "+
+				"true — an isolation story is a decision, and an omission looks exactly like "+
+				"a decision that was made silently", adapter, TableScript))
 	}
-
-	sort.Strings(problems)
 	return problems
 }
 

--- a/tools/onboarding-factory/internal/righome/righome.go
+++ b/tools/onboarding-factory/internal/righome/righome.go
@@ -1,0 +1,225 @@
+// Package righome joins two facts that live in two trees and had nothing
+// holding them together: which adapters the recording rig can isolate onto a
+// scratch agent home (declared in
+// tools/onboarding-factory/scripts/lib/agent-home.sh) and which adapters
+// install hooks into the user's config (declared in the daemon's adapter
+// registry, agent.Agent.Permissions).
+//
+// The failure it exists to catch is silent and was measured rather than
+// imagined. The rig EXPORTS the variable the table names, before spawning the
+// daemon; the daemon is a direct child and inherits it, while the agent CLI is
+// launched by the driver through `tmux new-session` and therefore inherits the
+// tmux SERVER's environment. So a table row naming a variable the daemon does
+// not actually read — a rename upstream, a typo, an adapter whose override was
+// never wired — leaves the daemon watching the operator's real home and the CLI
+// writing to the scratch one, or the reverse. Either way the recording comes
+// back with no session in it and nothing anywhere says why. Reconcile is the
+// static half of that (is there a row at all); the test beside it is the
+// behavioural half (does setting the row's variable actually move the adapter's
+// session root AND every file its hooks install writes).
+//
+// It is deliberately NOT a claim that isolation is required. The rig protects
+// the user's declared agent configs unconditionally, through
+// lib/managed-file-snapshot.sh's snapshot/restore of `--print-managed-files`,
+// and that is a hard gate on the spawn. What this package enforces is that an
+// adapter's isolation story is a DECISION — a row, or a named reason it cannot
+// have one — rather than an omission nobody noticed.
+package righome
+
+import (
+	"bufio"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// TableScript is the shell library that carries the declaration, relative to
+// the repository root.
+const TableScript = "tools/onboarding-factory/scripts/lib/agent-home.sh"
+
+// Policy is how the rig treats an adapter's home variable when the operator
+// leaves it unset. See agent-home.sh for the per-adapter reasoning, which is
+// where it belongs — this type only needs to know the two values exist.
+type Policy string
+
+const (
+	// PolicyDefault — the rig points the variable at a staging directory when
+	// the operator leaves it unset.
+	PolicyDefault Policy = "default"
+	// PolicyOptIn — the rig does nothing unless the operator exports an
+	// absolute path, because a scratch home would start without state the run
+	// needs (a credential, a provider declaration, a persisted consent).
+	PolicyOptIn Policy = "optin"
+)
+
+// Row is one adapter's declaration.
+type Row struct {
+	Adapter string
+	EnvVar  string
+	Policy  Policy
+}
+
+// Unisolatable names every hooks-declaring adapter that has NO row, with the
+// structural reason. Both entries are properties of the adapter's own path
+// resolution rather than work nobody has got to yet, which is the difference
+// between an exemption list and a to-do list — if one of these ever became
+// "not done yet", it should move out of here and into agent-home.sh.
+//
+// The keys are existence-checked in both directions by
+// TestRigHomeTableMatchesTheAdapterRegistry: an entry naming an adapter that
+// does not declare hooks (or does not exist) fails, exactly as a hooks adapter
+// in neither place does.
+var Unisolatable = map[string]string{
+	"claudecode": "HALF-relocatable, which is worse than not at all: transcripts follow " +
+		"CLAUDE_CONFIG_DIR (claudecode/adapter.go transcriptsDir) but the hook config does " +
+		"not — claudeSettingsPath (claudecode/hookinstaller.go) joins os.UserHomeDir() with " +
+		".claude/settings.json unconditionally. A row would move the session store while the " +
+		"install kept landing in the operator's real settings.json, i.e. claim an isolation " +
+		"it does not have.",
+	"gemini-cli": "no override exists at all: defaultRootDir is \".gemini/tmp\" under $HOME and " +
+		"geminiHome() is $HOME/.gemini, with no os.Getenv anywhere in " +
+		"core/adapters/inbound/agents/geminicli. Its hook recordings can only run against the " +
+		"real home, with the managed-file snapshot as the whole of the protection.",
+}
+
+// Table runs agent-home.sh's own declaration rather than parsing the file, so
+// the rig and this package cannot read the table differently. It refuses — it
+// never returns a short list — on anything it cannot read with confidence: a
+// shell that will not source, a malformed row, or an EMPTY table. That last one
+// is the important refusal: every consistency check downstream is satisfied by
+// a table with no rows in it, so "nothing declared" and "nothing wrong" would
+// otherwise be the same answer.
+func Table(repoRoot string) ([]Row, error) {
+	script := filepath.Join(repoRoot, TableScript)
+	// #nosec G204 -- script path is built from a caller-supplied repo root and
+	// a package constant, never from external input.
+	cmd := exec.Command("bash", "-c", `set -euo pipefail; source "$1"; agent_home_table`, "_", script)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("running agent_home_table from %s: %w: %s", script, err, strings.TrimSpace(string(out)))
+	}
+
+	var rows []Row
+	scanner := bufio.NewScanner(strings.NewReader(string(out)))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) != 3 {
+			return nil, fmt.Errorf("%s: malformed row %q: want '<adapter> <ENV_VAR> <policy>'", TableScript, line)
+		}
+		policy := Policy(fields[2])
+		if policy != PolicyDefault && policy != PolicyOptIn {
+			return nil, fmt.Errorf("%s: row %q declares unknown policy %q", TableScript, line, fields[2])
+		}
+		rows = append(rows, Row{Adapter: fields[0], EnvVar: fields[1], Policy: policy})
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("reading agent_home_table output: %w", err)
+	}
+	if len(rows) == 0 {
+		return nil, fmt.Errorf("%s: agent_home_table declared no adapters — every consistency "+
+			"check over it is vacuously satisfied by an empty table", TableScript)
+	}
+	return rows, nil
+}
+
+// Reconcile reports every disagreement between the rig's table, the exemption
+// map, and the registry's view of which adapters declare hooks. An empty result
+// means they agree.
+//
+// declaresHooks is the registry projection (adapter slug → declares a hooks
+// permission), with an entry for EVERY adapter — a false is "asked and
+// answered", not "absent" — which is what lets an unknown adapter name in
+// either declaration be told apart from one that simply installs no hooks.
+//
+// Split out as a pure function on purpose: the live wiring cannot be mutated to
+// prove these checks discriminate (mutating it means editing the shell table or
+// an adapter, which is a different test), so the committed mutation evidence is
+// a corpus driving THIS function with deliberately wrong inputs.
+func Reconcile(rows []Row, exempt map[string]string, declaresHooks map[string]bool) []string {
+	var problems []string
+
+	if len(declaresHooks) == 0 {
+		return []string{"the adapter registry projection is empty — nothing below can fail, " +
+			"so this is a broken measurement rather than a clean result"}
+	}
+
+	rowFor := make(map[string]Row, len(rows))
+	for _, r := range rows {
+		if _, known := declaresHooks[r.Adapter]; !known {
+			problems = append(problems, fmt.Sprintf(
+				"%s names adapter %q, which is not in the daemon's adapter registry — the rig "+
+					"would export %s for an adapter that does not exist",
+				TableScript, r.Adapter, r.EnvVar))
+			continue
+		}
+		if prev, dup := rowFor[r.Adapter]; dup {
+			problems = append(problems, fmt.Sprintf(
+				"%s declares adapter %q twice (%s and %s) — which row wins is the order of a "+
+					"heredoc", TableScript, r.Adapter, prev.EnvVar, r.EnvVar))
+			continue
+		}
+		rowFor[r.Adapter] = r
+		if reason, both := exempt[r.Adapter]; both {
+			problems = append(problems, fmt.Sprintf(
+				"adapter %q has BOTH a row in %s (%s) and an Unisolatable entry (%q) — one of "+
+					"the two is stale and a reader cannot tell which",
+				r.Adapter, TableScript, r.EnvVar, truncate(reason)))
+		}
+	}
+
+	for adapter, reason := range exempt {
+		declares, known := declaresHooks[adapter]
+		switch {
+		case !known:
+			problems = append(problems, fmt.Sprintf(
+				"Unisolatable names adapter %q, which is not in the daemon's adapter registry — "+
+					"an exemption for something that does not exist reads as coverage", adapter))
+		case !declares:
+			problems = append(problems, fmt.Sprintf(
+				"Unisolatable names adapter %q, which declares no hooks permission — it is "+
+					"exempt from an obligation it never had", adapter))
+		}
+		_ = reason
+	}
+
+	for _, adapter := range sortedKeys(declaresHooks) {
+		if !declaresHooks[adapter] {
+			continue
+		}
+		_, hasRow := rowFor[adapter]
+		_, isExempt := exempt[adapter]
+		if !hasRow && !isExempt {
+			problems = append(problems, fmt.Sprintf(
+				"adapter %q installs hooks into the user's config but has neither a row in %s "+
+					"nor an Unisolatable entry saying why it cannot have one. Add whichever is "+
+					"true — an isolation story is a decision, and an omission looks exactly like "+
+					"a decision that was made silently", adapter, TableScript))
+		}
+	}
+
+	sort.Strings(problems)
+	return problems
+}
+
+func sortedKeys(m map[string]bool) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func truncate(s string) string {
+	const max = 60
+	if len(s) <= max {
+		return s
+	}
+	return s[:max] + "…"
+}

--- a/tools/onboarding-factory/internal/righome/righome_corpus_test.go
+++ b/tools/onboarding-factory/internal/righome/righome_corpus_test.go
@@ -1,0 +1,273 @@
+package righome
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// This file is the committed mutation evidence for Reconcile and Table, in the
+// shape AGENTS.md asks for: "prefer committing that mutation to describing it",
+// because a paragraph in a merged PR body is re-run by nothing.
+//
+// The live wiring next door cannot supply it. Mutating THAT means editing the
+// shell table or an adapter's path resolution, which is a different change with
+// a different blast radius, and the evidence would live in a PR description
+// again. So each row below is an input that is wrong in exactly ONE way, paired
+// with the fragment of the problem Reconcile must report AND the fragments it
+// must NOT — the silences are half the evidence, since seven mutations against
+// one function are equally satisfied by a function that complains about
+// everything.
+
+// registry is a stand-in for hookcov.Declared(): every adapter present, the
+// value answering "declares a hooks permission". A false is "asked and
+// answered", which is what lets an unknown name be told from a hookless one.
+func registry() map[string]bool {
+	return map[string]bool{
+		"claudecode":   true,
+		"codex":        true,
+		"copilot":      true,
+		"gemini-cli":   true,
+		"kiro-cli":     true,
+		"mistral-vibe": true,
+		"aider":        false,
+		"pi":           false,
+	}
+}
+
+func goodRows() []Row {
+	return []Row{
+		{Adapter: "copilot", EnvVar: "COPILOT_HOME", Policy: PolicyDefault},
+		{Adapter: "codex", EnvVar: "CODEX_HOME", Policy: PolicyOptIn},
+		{Adapter: "kiro-cli", EnvVar: "KIRO_HOME", Policy: PolicyOptIn},
+		{Adapter: "mistral-vibe", EnvVar: "VIBE_HOME", Policy: PolicyOptIn},
+	}
+}
+
+func goodExempt() map[string]string {
+	return map[string]string{
+		"claudecode": "hook config is $HOME-anchored",
+		"gemini-cli": "no override exists",
+	}
+}
+
+// allFragments is every distinguishing phrase Reconcile can produce. A case
+// names the ones it expects; everything else in this list must be absent, which
+// is what stops a mutation from being "satisfied" by an unrelated complaint.
+var allFragments = []string{
+	"neither a row",
+	"not in the daemon's adapter registry — the rig",
+	"an exemption for something that does not exist",
+	"declares no hooks permission",
+	"has BOTH a row",
+	"twice",
+	"broken measurement",
+}
+
+func TestReconcileNamesEveryWrongShape(t *testing.T) {
+	cases := []struct {
+		name    string
+		rows    []Row
+		exempt  map[string]string
+		reg     map[string]bool
+		reports []string // fragments that MUST appear; empty means "silent"
+		names   string   // an adapter name the report must also carry, when relevant
+	}{
+		{
+			// The vacuity guard. Without it a Reconcile that reported
+			// unconditionally would satisfy every row below and read as
+			// excellent coverage.
+			name:   "the real shape reports nothing",
+			rows:   goodRows(),
+			exempt: goodExempt(),
+			reg:    registry(),
+		},
+		{
+			// A non-hooks adapter with a row is legitimate: isolation is useful
+			// for fixture hygiene whether or not the adapter installs anything.
+			// This is the want:false case — the rule must not drift into
+			// "only hooks adapters may be isolated".
+			name:   "a row for a hookless adapter is fine",
+			rows:   append(goodRows(), Row{Adapter: "aider", EnvVar: "AIDER_HOME", Policy: PolicyOptIn}),
+			exempt: goodExempt(),
+			reg:    registry(),
+		},
+		{
+			name:    "a hooks adapter with neither a row nor an exemption",
+			rows:    goodRows()[:3], // mistral-vibe dropped
+			exempt:  goodExempt(),
+			reg:     registry(),
+			reports: []string{"neither a row"},
+			names:   "mistral-vibe",
+		},
+		{
+			name:    "a row naming an adapter the registry does not have",
+			rows:    append(goodRows(), Row{Adapter: "kiro", EnvVar: "KIRO_HOME", Policy: PolicyOptIn}),
+			exempt:  goodExempt(),
+			reg:     registry(),
+			reports: []string{"not in the daemon's adapter registry — the rig"},
+			names:   "kiro",
+		},
+		{
+			name:   "an exemption naming an adapter the registry does not have",
+			rows:   goodRows(),
+			exempt: map[string]string{"claudecode": "x", "gemini-cli": "y", "gemini": "z"},
+			reg:    registry(),
+			// The stale name is the whole point: an exemption for something that
+			// does not exist reads as coverage of something that does.
+			reports: []string{"an exemption for something that does not exist"},
+			names:   "gemini",
+		},
+		{
+			name:    "an exemption for an adapter that declares no hooks",
+			rows:    goodRows(),
+			exempt:  map[string]string{"claudecode": "x", "gemini-cli": "y", "aider": "z"},
+			reg:     registry(),
+			reports: []string{"declares no hooks permission"},
+			names:   "aider",
+		},
+		{
+			name:    "an adapter with both a row and an exemption",
+			rows:    goodRows(),
+			exempt:  map[string]string{"claudecode": "x", "gemini-cli": "y", "codex": "z"},
+			reg:     registry(),
+			reports: []string{"has BOTH a row"},
+			names:   "codex",
+		},
+		{
+			name:    "the same adapter declared twice",
+			rows:    append(goodRows(), Row{Adapter: "codex", EnvVar: "CODEX_DIR", Policy: PolicyOptIn}),
+			exempt:  goodExempt(),
+			reg:     registry(),
+			reports: []string{"twice"},
+			names:   "codex",
+		},
+		{
+			// The measurement-broke case, distinct from a clean result. Without
+			// it, a caller whose registry projection came back empty would get
+			// an empty problem list — the "absence of a finding and inability to
+			// look produce the same output" shape.
+			name:    "an empty registry projection refuses",
+			rows:    goodRows(),
+			exempt:  goodExempt(),
+			reg:     map[string]bool{},
+			reports: []string{"broken measurement"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := strings.Join(Reconcile(tc.rows, tc.exempt, tc.reg), "\n")
+
+			for _, want := range tc.reports {
+				if !strings.Contains(got, want) {
+					t.Errorf("report does not contain %q\nreport was:\n%s", want, got)
+				}
+			}
+			if tc.names != "" && !strings.Contains(got, `"`+tc.names+`"`) {
+				t.Errorf("report does not name the offending adapter %q\nreport was:\n%s", tc.names, got)
+			}
+
+			// Every fragment this case did NOT claim must be absent. "Reconcile
+			// failed" and "THIS check fired" are different claims and only the
+			// second is evidence.
+			for _, frag := range allFragments {
+				if containsString(tc.reports, frag) {
+					continue
+				}
+				if strings.Contains(got, frag) {
+					t.Errorf("report unexpectedly contains %q — this case is wrong in one way and "+
+						"must fire one check\nreport was:\n%s", frag, got)
+				}
+			}
+			if len(tc.reports) == 0 && got != "" {
+				t.Errorf("expected a silent report, got:\n%s", got)
+			}
+		})
+	}
+}
+
+func containsString(hay []string, needle string) bool {
+	for _, h := range hay {
+		if h == needle {
+			return true
+		}
+	}
+	return false
+}
+
+// TestTableRefusesRatherThanReturningAShortList covers the reader. Every check
+// in Reconcile is satisfied by a table that came back empty or truncated, so
+// Table must never hand one back — "a validator that cannot parse its input
+// checks MORE, never less".
+func TestTableRefusesRatherThanReturningAShortList(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want string
+	}{
+		{
+			name: "an empty table",
+			body: "agent_home_table() { :; }\n",
+			want: "declared no adapters",
+		},
+		{
+			name: "a row missing its policy",
+			body: "agent_home_table() { printf '%s\\n' 'codex CODEX_HOME'; }\n",
+			want: "malformed row",
+		},
+		{
+			name: "a row with an unknown policy",
+			body: "agent_home_table() { printf '%s\\n' 'codex CODEX_HOME maybe'; }\n",
+			want: "unknown policy",
+		},
+		{
+			name: "a shell that will not source",
+			body: "agent_home_table() { \n",
+			want: "running agent_home_table",
+		},
+		{
+			// The vacuity guard for this table: a well-formed stand-in must be
+			// READ, not merely not-refused, or every row above could be passing
+			// because the reader rejects everything.
+			name: "a well-formed table is read",
+			body: "agent_home_table() { printf '%s\\n' 'codex CODEX_HOME optin'; }\n",
+			want: "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			path := filepath.Join(root, TableScript)
+			if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(path, []byte("#!/usr/bin/env bash\n"+tc.body), 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			rows, err := Table(root)
+			if tc.want == "" {
+				if err != nil {
+					t.Fatalf("a well-formed table was refused: %v", err)
+				}
+				if len(rows) != 1 || rows[0].Adapter != "codex" || rows[0].EnvVar != "CODEX_HOME" {
+					t.Fatalf("read %+v, want one codex/CODEX_HOME/optin row", rows)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected a refusal naming %q, got %d rows and no error", tc.want, len(rows))
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("refusal does not name %q: %v", tc.want, err)
+			}
+			if rows != nil {
+				t.Errorf("a refusal returned %d rows — a short list is what every check downstream "+
+					"cannot tell from a clean one", len(rows))
+			}
+		})
+	}
+}

--- a/tools/onboarding-factory/internal/righome/righome_corpus_test.go
+++ b/tools/onboarding-factory/internal/righome/righome_corpus_test.go
@@ -159,32 +159,44 @@ func TestReconcileNamesEveryWrongShape(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			got := strings.Join(Reconcile(tc.rows, tc.exempt, tc.reg), "\n")
-
-			for _, want := range tc.reports {
-				if !strings.Contains(got, want) {
-					t.Errorf("report does not contain %q\nreport was:\n%s", want, got)
-				}
-			}
-			if tc.names != "" && !strings.Contains(got, `"`+tc.names+`"`) {
-				t.Errorf("report does not name the offending adapter %q\nreport was:\n%s", tc.names, got)
-			}
-
-			// Every fragment this case did NOT claim must be absent. "Reconcile
-			// failed" and "THIS check fired" are different claims and only the
-			// second is evidence.
-			for _, frag := range allFragments {
-				if containsString(tc.reports, frag) {
-					continue
-				}
-				if strings.Contains(got, frag) {
-					t.Errorf("report unexpectedly contains %q — this case is wrong in one way and "+
-						"must fire one check\nreport was:\n%s", frag, got)
-				}
-			}
-			if len(tc.reports) == 0 && got != "" {
-				t.Errorf("expected a silent report, got:\n%s", got)
-			}
+			assertReported(t, got, tc.reports, tc.names)
+			assertSilentOnEverythingElse(t, got, tc.reports)
 		})
+	}
+}
+
+// assertReported is the positive half: the fragments this case claims, plus the
+// offending adapter's name. Naming a fragment of the obligation's OWN message
+// rather than accepting any failure is the rule this corpus is built on —
+// "Reconcile failed" and "THIS check fired" are different claims.
+func assertReported(t *testing.T, got string, want []string, names string) {
+	t.Helper()
+	for _, w := range want {
+		if !strings.Contains(got, w) {
+			t.Errorf("report does not contain %q\nreport was:\n%s", w, got)
+		}
+	}
+	if names != "" && !strings.Contains(got, `"`+names+`"`) {
+		t.Errorf("report does not name the offending adapter %q\nreport was:\n%s", names, got)
+	}
+}
+
+// assertSilentOnEverythingElse is the half that carries most of the evidence:
+// without it, eight inputs wrong in eight ways are equally satisfied by a
+// Reconcile that complains about everything.
+func assertSilentOnEverythingElse(t *testing.T, got string, claimed []string) {
+	t.Helper()
+	for _, frag := range allFragments {
+		if containsString(claimed, frag) {
+			continue
+		}
+		if strings.Contains(got, frag) {
+			t.Errorf("report unexpectedly contains %q — this case is wrong in one way and must "+
+				"fire one check\nreport was:\n%s", frag, got)
+		}
+	}
+	if len(claimed) == 0 && got != "" {
+		t.Errorf("expected a silent report, got:\n%s", got)
 	}
 }
 
@@ -250,24 +262,40 @@ func TestTableRefusesRatherThanReturningAShortList(t *testing.T) {
 
 			rows, err := Table(root)
 			if tc.want == "" {
-				if err != nil {
-					t.Fatalf("a well-formed table was refused: %v", err)
-				}
-				if len(rows) != 1 || rows[0].Adapter != "codex" || rows[0].EnvVar != "CODEX_HOME" {
-					t.Fatalf("read %+v, want one codex/CODEX_HOME/optin row", rows)
-				}
+				assertTableWasRead(t, rows, err)
 				return
 			}
-			if err == nil {
-				t.Fatalf("expected a refusal naming %q, got %d rows and no error", tc.want, len(rows))
-			}
-			if !strings.Contains(err.Error(), tc.want) {
-				t.Errorf("refusal does not name %q: %v", tc.want, err)
-			}
-			if rows != nil {
-				t.Errorf("a refusal returned %d rows — a short list is what every check downstream "+
-					"cannot tell from a clean one", len(rows))
-			}
+			assertTableRefused(t, rows, err, tc.want)
 		})
+	}
+}
+
+// assertTableWasRead is this corpus's vacuity guard: a well-formed stand-in
+// must be READ, not merely not-refused, or every refusal row above could be
+// passing because the reader rejects everything it is handed.
+func assertTableWasRead(t *testing.T, rows []Row, err error) {
+	t.Helper()
+	if err != nil {
+		t.Fatalf("a well-formed table was refused: %v", err)
+	}
+	if len(rows) != 1 || rows[0].Adapter != "codex" || rows[0].EnvVar != "CODEX_HOME" {
+		t.Fatalf("read %+v, want one codex/CODEX_HOME/optin row", rows)
+	}
+}
+
+// assertTableRefused pins both halves of a refusal: it names its own reason,
+// and it returns NO rows. A short list is exactly what every check downstream
+// cannot tell from a clean one.
+func assertTableRefused(t *testing.T, rows []Row, err error, want string) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("expected a refusal naming %q, got %d rows and no error", want, len(rows))
+	}
+	if !strings.Contains(err.Error(), want) {
+		t.Errorf("refusal does not name %q: %v", want, err)
+	}
+	if rows != nil {
+		t.Errorf("a refusal returned %d rows — a short list is what every check downstream "+
+			"cannot tell from a clean one", len(rows))
 	}
 }

--- a/tools/onboarding-factory/internal/righome/righome_test.go
+++ b/tools/onboarding-factory/internal/righome/righome_test.go
@@ -94,80 +94,94 @@ func TestEveryRigHomeRowRelocatesBothHalves(t *testing.T) {
 			home := filepath.Join(t.TempDir(), "scratch-home")
 			t.Setenv(row.EnvVar, home)
 
-			// agents.All() is called AFTER the variable is set, and the order is
-			// the property rather than test hygiene. Three of the four rows
-			// (copilot, codex, kiro-cli) declare a static Source.Dir computed by
-			// their package's sessionsDir() at Agent() CONSTRUCTION time, so the
-			// watched root is frozen when the registry is built; only vibe's
-			// DirFunc re-resolves lazily. That is exactly why run-cell.sh has to
-			// export before spawn_record_daemon rather than at any convenient
-			// point — a daemon already running cannot be relocated. Building the
-			// registry first here reported all three as "does not relocate",
-			// which is true of the object and false of the daemon.
-			var a agent.Agent
-			found := false
-			for _, cand := range agents.All() {
-				if shard.SlugForAdapter(cand.Identity.Name) == row.Adapter {
-					a, found = cand, true
-				}
-			}
-			if !found {
-				t.Fatalf("no registry adapter with slug %q", row.Adapter)
-			}
-
-			// Half one: the watched session root.
-			src, isFiles := a.Source.(agent.FilesUnderRoot)
-			if !isFiles {
-				t.Fatalf("adapter %q declares Source %T, which this arm cannot resolve — a row "+
-					"for a non-FilesUnderRoot adapter needs its own half-one check rather than "+
-					"being waved through", row.Adapter, a.Source)
-			}
-			roots := src.AllRootsFor("darwin")
-			if len(roots) == 0 {
-				t.Fatalf("adapter %q resolves no session roots at all", row.Adapter)
-			}
-			for _, root := range roots {
-				if !strings.HasPrefix(root, home) {
-					t.Errorf("with %s=%s the session root is still %q — the daemon would watch the "+
-						"operator's real store while the driver wrote to the scratch home, and the "+
-						"recording would contain their sessions and not the driver's",
-						row.EnvVar, home, root)
-				}
-			}
-
-			// Half two: every file the hooks install writes.
-			var hooks *agent.Permission
-			for i := range a.Permissions {
-				if a.Permissions[i].Key == permissionKeyHooks {
-					hooks = &a.Permissions[i]
-				}
-			}
-			if hooks == nil {
-				t.Fatalf("adapter %q has a rig home row but declares no hooks permission — this "+
-					"arm's second half has nothing to grade, so the row's promise is only half "+
-					"checked; say so in the table rather than leaving it implied", row.Adapter)
-			}
-			if hooks.Writes == nil || hooks.Writes.Path == nil {
-				t.Fatalf("adapter %q's hooks permission declares no Writes.Path", row.Adapter)
-			}
-
-			resolvers := append([]func() (string, error){hooks.Writes.Path}, hooks.Writes.Also...)
-			for i, resolve := range resolvers {
-				label := "Writes.Path"
-				if i > 0 {
-					label = "Writes.Also[" + itoa(i-1) + "]"
-				}
-				got, err := resolve()
-				if err != nil {
-					t.Fatalf("resolving %s for %q: %v", label, row.Adapter, err)
-				}
-				if !strings.HasPrefix(got, home) {
-					t.Errorf("with %s=%s the hooks install still writes %s to %q — the install "+
-						"would land in the operator's real config while everything else in the run "+
-						"claimed to be isolated", row.EnvVar, home, label, got)
-				}
-			}
+			a := registryAdapterAfterEnv(t, row.Adapter)
+			assertSessionRootRelocates(t, row, home, a)
+			assertHookWritesRelocate(t, row, home, a)
 		})
+	}
+}
+
+// registryAdapterAfterEnv builds the registry and finds one adapter, and is a
+// separate step because it must run AFTER the caller has set the env var.
+//
+// That ordering is the property rather than test hygiene. Three of the four
+// rows (copilot, codex, kiro-cli) declare a static Source.Dir computed by their
+// package's sessionsDir() at Agent() CONSTRUCTION time, so the watched root is
+// frozen when the registry is built; only vibe's DirFunc re-resolves lazily.
+// That is exactly why run-cell.sh has to export before spawn_record_daemon
+// rather than at any convenient point — a daemon already running cannot be
+// relocated. Building the registry first here reported all three as "does not
+// relocate", which is true of the object and false of the daemon.
+func registryAdapterAfterEnv(t *testing.T, slug string) agent.Agent {
+	t.Helper()
+	for _, cand := range agents.All() {
+		if shard.SlugForAdapter(cand.Identity.Name) == slug {
+			return cand
+		}
+	}
+	t.Fatalf("no registry adapter with slug %q", slug)
+	return agent.Agent{}
+}
+
+// assertSessionRootRelocates is half one: if the watched root does not move,
+// the daemon records the operator's own sessions instead of the driver's.
+func assertSessionRootRelocates(t *testing.T, row Row, home string, a agent.Agent) {
+	t.Helper()
+	src, isFiles := a.Source.(agent.FilesUnderRoot)
+	if !isFiles {
+		t.Fatalf("adapter %q declares Source %T, which this arm cannot resolve — a row for a "+
+			"non-FilesUnderRoot adapter needs its own half-one check rather than being waved "+
+			"through", row.Adapter, a.Source)
+	}
+	roots := src.AllRootsFor("darwin")
+	if len(roots) == 0 {
+		t.Fatalf("adapter %q resolves no session roots at all", row.Adapter)
+	}
+	for _, root := range roots {
+		if !strings.HasPrefix(root, home) {
+			t.Errorf("with %s=%s the session root is still %q — the daemon would watch the "+
+				"operator's real store while the driver wrote to the scratch home, and the "+
+				"recording would contain their sessions and not the driver's",
+				row.EnvVar, home, root)
+		}
+	}
+}
+
+// assertHookWritesRelocate is half two: if a written file does not move, the
+// install lands in the operator's real config while everything else in the run
+// claims to be isolated — the worst of the outcomes, because it looks isolated.
+func assertHookWritesRelocate(t *testing.T, row Row, home string, a agent.Agent) {
+	t.Helper()
+	var hooks *agent.Permission
+	for i := range a.Permissions {
+		if a.Permissions[i].Key == permissionKeyHooks {
+			hooks = &a.Permissions[i]
+		}
+	}
+	if hooks == nil {
+		t.Fatalf("adapter %q has a rig home row but declares no hooks permission — this arm's "+
+			"second half has nothing to grade, so the row's promise is only half checked; say "+
+			"so in the table rather than leaving it implied", row.Adapter)
+	}
+	if hooks.Writes == nil || hooks.Writes.Path == nil {
+		t.Fatalf("adapter %q's hooks permission declares no Writes.Path", row.Adapter)
+	}
+
+	resolvers := append([]func() (string, error){hooks.Writes.Path}, hooks.Writes.Also...)
+	for i, resolve := range resolvers {
+		label := "Writes.Path"
+		if i > 0 {
+			label = "Writes.Also[" + itoa(i-1) + "]"
+		}
+		got, err := resolve()
+		if err != nil {
+			t.Fatalf("resolving %s for %q: %v", label, row.Adapter, err)
+		}
+		if !strings.HasPrefix(got, home) {
+			t.Errorf("with %s=%s the hooks install still writes %s to %q — the install would "+
+				"land in the operator's real config while everything else in the run claimed "+
+				"to be isolated", row.EnvVar, home, label, got)
+		}
 	}
 }
 
@@ -218,34 +232,65 @@ func TestEveryRigHomeRowsDriverPassesTheHomeThroughTmux(t *testing.T) {
 					"cannot be checked, and a check that cannot run must say so", row.Adapter, err)
 			}
 
-			lines := strings.Split(string(src), "\n")
-			launches := 0
-			for i, line := range lines {
-				if !strings.Contains(line, "tmux new-session") {
-					continue
-				}
-				launches++
-				// The launch commonly spans continuation lines; take a small
-				// window rather than the single line.
-				end := i + 4
-				if end > len(lines) {
-					end = len(lines)
-				}
-				window := strings.Join(lines[i:end], "\n")
-				if !strings.Contains(window, "env \""+row.EnvVar+"=") &&
-					!strings.Contains(window, "env "+row.EnvVar+"=") {
-					t.Errorf("%s:%d launches the agent under tmux without an explicit "+
-						"`env %s=…` prefix.\n%s\nThe pane inherits the tmux SERVER's environment, "+
-						"not the exported one, so on any machine with a server already running the "+
-						"daemon would watch the scratch home while the CLI wrote to the real one.",
-						path, i+1, row.EnvVar, strings.TrimRight(window, "\n"))
-				}
+			for _, l := range tmuxLaunchesMissingEnv(string(src), row.EnvVar) {
+				t.Errorf("%s:%d launches the agent under tmux without an explicit `env %s=…` "+
+					"prefix.\n%s\nThe pane inherits the tmux SERVER's environment, not the "+
+					"exported one, so on any machine with a server already running the daemon "+
+					"would watch the scratch home while the CLI wrote to the real one.",
+					path, l.line, row.EnvVar, l.window)
 			}
 			// Vacuity guard: a driver with no tmux launch at all satisfies the
-			// loop above by never entering it.
-			if launches == 0 {
+			// check above by having nothing to walk.
+			if n := countTmuxLaunches(string(src)); n == 0 {
 				t.Errorf("%s contains no `tmux new-session` at all — this arm graded nothing", path)
 			}
 		})
 	}
+}
+
+// launchSite is one `tmux new-session` that does not carry the home variable.
+type launchSite struct {
+	line   int
+	window string
+}
+
+// tmuxLaunchWindow returns the launch statement starting at index i — the line
+// plus up to three continuations, since these launches routinely wrap.
+func tmuxLaunchWindow(lines []string, i int) string {
+	end := i + 4
+	if end > len(lines) {
+		end = len(lines)
+	}
+	return strings.TrimRight(strings.Join(lines[i:end], "\n"), "\n")
+}
+
+// countTmuxLaunches is the vacuity guard's own measurement, kept separate from
+// the verdict so "no launches found" cannot be confused with "all launches OK".
+func countTmuxLaunches(src string) int {
+	n := 0
+	for _, line := range strings.Split(src, "\n") {
+		if strings.Contains(line, "tmux new-session") {
+			n++
+		}
+	}
+	return n
+}
+
+// tmuxLaunchesMissingEnv names every launch site that does not pass envVar
+// explicitly. Both quoting styles are accepted because codex's driver writes
+// `env "CODEX_HOME=$X"` and a future one may not quote.
+func tmuxLaunchesMissingEnv(src, envVar string) []launchSite {
+	var out []launchSite
+	lines := strings.Split(src, "\n")
+	for i, line := range lines {
+		if !strings.Contains(line, "tmux new-session") {
+			continue
+		}
+		window := tmuxLaunchWindow(lines, i)
+		if strings.Contains(window, "env \""+envVar+"=") || strings.Contains(window, "env "+envVar+"=") {
+			continue
+		}
+		out = append(out, launchSite{line: i + 1, window: window})
+	}
+	return out
 }

--- a/tools/onboarding-factory/internal/righome/righome_test.go
+++ b/tools/onboarding-factory/internal/righome/righome_test.go
@@ -1,0 +1,251 @@
+package righome
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"irrlicht/core/adapters/inbound/agents"
+	"irrlicht/core/domain/agent"
+	"irrlicht/tools/onboarding-factory/internal/hookcov"
+	"irrlicht/tools/onboarding-factory/internal/shard"
+)
+
+// permissionKeyHooks mirrors hookcov's private constant of the same value. The
+// join below is pinned against hookcov.Declared(), so a rename on either side
+// surfaces as an adapter reporting no hooks permission rather than as silence.
+const permissionKeyHooks = "hooks"
+
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	out, err := exec.Command("git", "rev-parse", "--show-toplevel").Output()
+	if err != nil {
+		t.Fatalf("resolving the repo root: %v", err)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// TestRigHomeTableMatchesTheAdapterRegistry is the static arm: every adapter
+// that installs hooks into the user's config either has a row in the rig's
+// table or a named reason it cannot have one, and neither declaration names an
+// adapter that does not exist.
+//
+// This is the WEAKER of the two arms in this file and it is worth saying so.
+// It cannot tell a good isolation story from a bad one — only that somebody
+// decided. Its value is that a SEVENTH hook adapter is graded by existing
+// rather than by whoever adds it remembering the recording rig exists, and that
+// the two structural exemptions (claudecode, gemini-cli) are written down where
+// the next person looks rather than rediscovered.
+func TestRigHomeTableMatchesTheAdapterRegistry(t *testing.T) {
+	rows, err := Table(repoRoot(t))
+	if err != nil {
+		t.Fatalf("reading the rig's home table: %v", err)
+	}
+
+	declares := hookcov.Declared()
+	hooksAdapters := 0
+	for _, d := range declares {
+		if d {
+			hooksAdapters++
+		}
+	}
+	// Vacuity guard. Reconcile refuses an empty projection, but a projection
+	// that is merely all-false passes every check below having graded nothing.
+	if hooksAdapters == 0 {
+		t.Fatalf("hookcov.Declared() reports no hooks-declaring adapter at all (%d adapters) — "+
+			"the join is broken, not clean", len(declares))
+	}
+
+	for _, p := range Reconcile(rows, Unisolatable, declares) {
+		t.Error(p)
+	}
+}
+
+// TestEveryRigHomeRowRelocatesBothHalves is the arm that carries the weight.
+//
+// A row is a promise the rig acts on: it exports that variable before spawning
+// the daemon, and the driver passes the same value to the agent CLI. Two things
+// have to move for that to mean anything, and an adapter can move one without
+// the other — claudecode is exactly that shape, which is why it is exempt
+// rather than rowed:
+//
+//	the SESSION ROOT the daemon watches (agent.Source), and
+//	every FILE the hooks install writes (Writes.Path plus every Also).
+//
+// If the session root does not move, the daemon watches the operator's real
+// store and records their own sessions instead of the driver's. If a written
+// file does not move, the install lands in the operator's real config while
+// everything else claims to be isolated — the worst of the three outcomes,
+// because it is the one that looks isolated.
+//
+// It grades the DECLARED variable against the REAL resolvers, so a row naming a
+// variable no adapter reads fails here even though it is perfectly well formed
+// and passes the static arm above.
+func TestEveryRigHomeRowRelocatesBothHalves(t *testing.T) {
+	rows, err := Table(repoRoot(t))
+	if err != nil {
+		t.Fatalf("reading the rig's home table: %v", err)
+	}
+
+	for _, row := range rows {
+		t.Run(row.Adapter, func(t *testing.T) {
+			home := filepath.Join(t.TempDir(), "scratch-home")
+			t.Setenv(row.EnvVar, home)
+
+			// agents.All() is called AFTER the variable is set, and the order is
+			// the property rather than test hygiene. Three of the four rows
+			// (copilot, codex, kiro-cli) declare a static Source.Dir computed by
+			// their package's sessionsDir() at Agent() CONSTRUCTION time, so the
+			// watched root is frozen when the registry is built; only vibe's
+			// DirFunc re-resolves lazily. That is exactly why run-cell.sh has to
+			// export before spawn_record_daemon rather than at any convenient
+			// point — a daemon already running cannot be relocated. Building the
+			// registry first here reported all three as "does not relocate",
+			// which is true of the object and false of the daemon.
+			var a agent.Agent
+			found := false
+			for _, cand := range agents.All() {
+				if shard.SlugForAdapter(cand.Identity.Name) == row.Adapter {
+					a, found = cand, true
+				}
+			}
+			if !found {
+				t.Fatalf("no registry adapter with slug %q", row.Adapter)
+			}
+
+			// Half one: the watched session root.
+			src, isFiles := a.Source.(agent.FilesUnderRoot)
+			if !isFiles {
+				t.Fatalf("adapter %q declares Source %T, which this arm cannot resolve — a row "+
+					"for a non-FilesUnderRoot adapter needs its own half-one check rather than "+
+					"being waved through", row.Adapter, a.Source)
+			}
+			roots := src.AllRootsFor("darwin")
+			if len(roots) == 0 {
+				t.Fatalf("adapter %q resolves no session roots at all", row.Adapter)
+			}
+			for _, root := range roots {
+				if !strings.HasPrefix(root, home) {
+					t.Errorf("with %s=%s the session root is still %q — the daemon would watch the "+
+						"operator's real store while the driver wrote to the scratch home, and the "+
+						"recording would contain their sessions and not the driver's",
+						row.EnvVar, home, root)
+				}
+			}
+
+			// Half two: every file the hooks install writes.
+			var hooks *agent.Permission
+			for i := range a.Permissions {
+				if a.Permissions[i].Key == permissionKeyHooks {
+					hooks = &a.Permissions[i]
+				}
+			}
+			if hooks == nil {
+				t.Fatalf("adapter %q has a rig home row but declares no hooks permission — this "+
+					"arm's second half has nothing to grade, so the row's promise is only half "+
+					"checked; say so in the table rather than leaving it implied", row.Adapter)
+			}
+			if hooks.Writes == nil || hooks.Writes.Path == nil {
+				t.Fatalf("adapter %q's hooks permission declares no Writes.Path", row.Adapter)
+			}
+
+			resolvers := append([]func() (string, error){hooks.Writes.Path}, hooks.Writes.Also...)
+			for i, resolve := range resolvers {
+				label := "Writes.Path"
+				if i > 0 {
+					label = "Writes.Also[" + itoa(i-1) + "]"
+				}
+				got, err := resolve()
+				if err != nil {
+					t.Fatalf("resolving %s for %q: %v", label, row.Adapter, err)
+				}
+				if !strings.HasPrefix(got, home) {
+					t.Errorf("with %s=%s the hooks install still writes %s to %q — the install "+
+						"would land in the operator's real config while everything else in the run "+
+						"claimed to be isolated", row.EnvVar, home, label, got)
+				}
+			}
+		})
+	}
+}
+
+func itoa(i int) string {
+	if i == 0 {
+		return "0"
+	}
+	var b []byte
+	for i > 0 {
+		b = append([]byte{byte('0' + i%10)}, b...)
+		i /= 10
+	}
+	return string(b)
+}
+
+// TestEveryRigHomeRowsDriverPassesTheHomeThroughTmux is the other half of the
+// promise a row makes, and the half the rig cannot keep on its own.
+//
+// run-cell.sh EXPORTS the variable, which reaches the daemon because the daemon
+// is a direct child. The agent CLI is not: the driver launches it with `tmux
+// new-session`, and the pane's command is spawned by the tmux SERVER, whose
+// environment was fixed when that server started. On a dev machine a server is
+// essentially always already running — started by the operator's own terminal,
+// long before any recording — so the export does NOT reach the pane. Measured
+// on a private `-L` socket so no real session was touched: against a server
+// started without the variable, a pane created by a shell that exported it
+// reads `<UNSET>`, and the same server with an explicit `env VAR=…` prefix on
+// the new-session command line reads the value.
+//
+// The consequence is the worst kind of failure the rig has: the daemon watches
+// the scratch home, the CLI writes to the real one, the recording contains no
+// session at all, and nothing anywhere says why. So every rowed adapter's
+// interactive driver must pass the home explicitly. codex's driver already did;
+// this arm is what stops that from being one driver's private knowledge.
+func TestEveryRigHomeRowsDriverPassesTheHomeThroughTmux(t *testing.T) {
+	root := repoRoot(t)
+	rows, err := Table(root)
+	if err != nil {
+		t.Fatalf("reading the rig's home table: %v", err)
+	}
+
+	for _, row := range rows {
+		t.Run(row.Adapter, func(t *testing.T) {
+			path := filepath.Join(root, "replaydata", "agents", row.Adapter, "driver-interactive.sh")
+			src, err := os.ReadFile(path) // #nosec G304 -- path built from the repo root and a table row
+			if err != nil {
+				t.Fatalf("reading %s's driver: %v — a table row for an adapter with no driver "+
+					"cannot be checked, and a check that cannot run must say so", row.Adapter, err)
+			}
+
+			lines := strings.Split(string(src), "\n")
+			launches := 0
+			for i, line := range lines {
+				if !strings.Contains(line, "tmux new-session") {
+					continue
+				}
+				launches++
+				// The launch commonly spans continuation lines; take a small
+				// window rather than the single line.
+				end := i + 4
+				if end > len(lines) {
+					end = len(lines)
+				}
+				window := strings.Join(lines[i:end], "\n")
+				if !strings.Contains(window, "env \""+row.EnvVar+"=") &&
+					!strings.Contains(window, "env "+row.EnvVar+"=") {
+					t.Errorf("%s:%d launches the agent under tmux without an explicit "+
+						"`env %s=…` prefix.\n%s\nThe pane inherits the tmux SERVER's environment, "+
+						"not the exported one, so on any machine with a server already running the "+
+						"daemon would watch the scratch home while the CLI wrote to the real one.",
+						path, i+1, row.EnvVar, strings.TrimRight(window, "\n"))
+				}
+			}
+			// Vacuity guard: a driver with no tmux launch at all satisfies the
+			// loop above by never entering it.
+			if launches == 0 {
+				t.Errorf("%s contains no `tmux new-session` at all — this arm graded nothing", path)
+			}
+		})
+	}
+}

--- a/tools/onboarding-factory/internal/righome/righome_test.go
+++ b/tools/onboarding-factory/internal/righome/righome_test.go
@@ -241,7 +241,7 @@ func TestEveryRigHomeRowsDriverPassesTheHomeThroughTmux(t *testing.T) {
 			}
 			// Vacuity guard: a driver with no tmux launch at all satisfies the
 			// check above by having nothing to walk.
-			if n := countTmuxLaunches(string(src)); n == 0 {
+			if countTmuxLaunches(string(src)) == 0 {
 				t.Errorf("%s contains no `tmux new-session` at all — this arm graded nothing", path)
 			}
 		})

--- a/tools/onboarding-factory/scripts/lib/agent-home.sh
+++ b/tools/onboarding-factory/scripts/lib/agent-home.sh
@@ -166,10 +166,18 @@ agent_home_field() {
 
 # agent_home_var <adapter> prints the env var that relocates the adapter's home,
 # or nothing when it has no row.
-agent_home_var() { agent_home_field "$1" 2; }
+agent_home_var() {
+  local adapter="${1:-}"
+  agent_home_field "$adapter" 2
+  return 0
+}
 
 # agent_home_policy <adapter> prints "default" or "optin", or nothing.
-agent_home_policy() { agent_home_field "$1" 3; }
+agent_home_policy() {
+  local adapter="${1:-}"
+  agent_home_field "$adapter" 3
+  return 0
+}
 
 # agent_home_isolate <adapter> <staging-default-dir> resolves, validates,
 # exports and creates the adapter's home, and reports on stdout what it did.

--- a/tools/onboarding-factory/scripts/lib/agent-home.sh
+++ b/tools/onboarding-factory/scripts/lib/agent-home.sh
@@ -1,0 +1,239 @@
+#!/usr/bin/env bash
+# agent-home.sh — the recording rig's per-adapter "agent home" isolation, owned
+# once instead of once per script.
+#
+# Several agents resolve their WHOLE config directory — session store, settings
+# and (for a hook-installing adapter) the hook config the daemon writes — from a
+# single env var. Pointing that var at a scratch directory is what keeps a
+# recording off the operator's real ~/.codex, ~/.copilot, ~/.kiro or ~/.vibe.
+#
+# WHAT THIS IS NOT FOR. The rig already protects the user's declared agent
+# configs unconditionally: lib/managed-file-snapshot.sh asks the daemon for
+# `--print-managed-files`, backs every one of them up before the daemon spawns,
+# and hands them back from an EXIT trap — and spawn_record_daemon REFUSES to
+# start if that snapshot fails. So this file is not a data-loss guard and must
+# not be described as one. What it buys is narrower and still real:
+#
+#   - The session store. Without it the daemon watches the operator's REAL
+#     session directory, so their own live sessions can land in the fixture and
+#     the recorded session lands in their store. That is why copilot defaults.
+#   - Crash safety. Restore runs from an EXIT trap, so SIGKILL or a panic leaves
+#     the real configs rewritten. An isolated home has nothing to hand back.
+#   - Reproducibility. A run starts from a known-empty (or deliberately seeded)
+#     home rather than from whatever the operator's looks like today.
+#
+# THE FAILURE THIS FILE ACTUALLY REMOVES is not any of those three — it is that
+# the lever was HALF-WIRED and failed silently. run-cell.sh exports the var, so
+# the daemon (a direct child) inherits it, while the agent CLI is launched by
+# the driver through `tmux new-session` and therefore inherits the tmux SERVER's
+# environment. Measured on this machine (private `-L` socket, so no real session
+# was touched): against a server started without the variable, a pane created by
+# a shell that exported it reads `<UNSET>`; the same server with an explicit
+# `env VAR=… ` prefix on the new-session command line reads the value. A dev
+# machine essentially always has a tmux server already running, so setting the
+# var got you a daemon watching the scratch home and a CLI writing to the real
+# one — an empty fixture, with nothing anywhere saying why. Every driver that
+# honours a row here therefore prefixes `env VAR=…` on its own tmux launch;
+# codex's driver already did, and that is the shape the others copy.
+#
+# Usage — one call, before the daemon spawns, so the daemon inherits the value
+# and `--print-managed-files` resolves under it:
+#   source "$SCRIPT_DIR/lib/agent-home.sh"
+#   agent_home_isolate "$ADAPTER" "$STAGING/agent-home" || exit 1
+
+# agent_home_table prints the declaration, one row per adapter:
+#
+#   <adapter> <ENV_VAR> <policy>
+#
+# It is a heredoc rather than an array because macOS ships bash 3.2, where
+# `declare -A` is a hard runtime error (run-cell-multi.sh says the same at its
+# own slot bookkeeping). It is also the single source the Go tripwire reads —
+# TestRigHomeTableMatchesTheAdapterRegistry
+# (tools/onboarding-factory/internal/righome) SOURCES this file and runs this
+# function rather than parsing it, so the two cannot drift.
+#
+# POLICY — the distinction is load-bearing and predates this file:
+#
+#   default  The var is set to a staging directory when the caller leaves it
+#            unset. Only copilot. Safe to default because Copilot's credentials
+#            live in the OS keychain, not in COPILOT_HOME, so a scratch home
+#            needs no re-login (verified on CLI 1.0.77 — see the copilot
+#            driver's seed_copilot_home).
+#
+#   optin    Nothing happens unless the caller exports an absolute path, which
+#            the operator is expected to have SEEDED first. Everything else.
+#
+#            The general rule is NOT "credentials", which is how codex's block
+#            phrased it and which is too narrow: it is that a scratch home
+#            starts without some piece of state the run needs, and every way of
+#            missing it ends in a blocking interactive prompt inside the tmux
+#            pane that no driver has an arm for — so the cell stalls to timeout
+#            and records nothing. A credential is one such piece of state. The
+#            per-adapter reasons below are NOT interchangeable and are recorded
+#            individually, because two of them are not credentials at all:
+#
+#     codex        CREDENTIALS. auth.json lives in CODEX_HOME, so defaulting it
+#                  to an empty staging dir would leave every codex recording
+#                  silently unauthenticated. Seed the scratch home with a copy
+#                  of auth.json (#1388).
+#     mistral-vibe THE PROVIDER DECLARATION, which is upstream of the
+#                  credential. It is tempting to read config.toml's
+#                  `api_key_env_var` as "the key is in an env var, so a scratch
+#                  home loses nothing" — that is true of the SECRET and false of
+#                  the lookup: `[[providers]]` (api_base, api_key_env_var,
+#                  backend) lives in $VIBE_HOME/config.toml, and
+#                  resolve_api_key(env_key) (v2.19.1
+#                  vibe/core/config/_settings.py) reads the process env and then
+#                  the OS keyring UNDER THAT NAME. A home with no config.toml
+#                  falls back to DEFAULT_PROVIDERS, so an operator on any
+#                  non-default provider has the wrong name looked up, raises
+#                  MissingAPIKeyError, and cli.py:92 answers an interactive
+#                  session by running the onboarding WIZARD in the pane.
+#                  Separately, $VIBE_HOME/.env is a real credential location in
+#                  its own right — persist_api_key
+#                  (vibe/setup/auth/api_key_persistence.py) writes the key there
+#                  when the keyring raises, and paths/_vibe_home.py declares
+#                  GLOBAL_ENV_FILE = VIBE_HOME/".env" — so on a keyring-less
+#                  host, or under VIBE_TEST_DISABLE_KEYRING=1, the secret IS in
+#                  this directory. Seed config.toml, and .env if you have one.
+#                  NOT trusted_folders.toml, which also lives here and looks
+#                  like it should matter: the driver passes `--trust` on every
+#                  launch already, because the staging cwd lives under the
+#                  irrlicht git repo and is untrusted whichever home is in use
+#                  (see launch_repl in the mistral-vibe driver). Relocating the
+#                  home loses nothing there that a fresh cwd had not lost.
+#     kiro-cli     PERSISTED TRUST-ALL CONSENT — and note this is the one row
+#                  where the credential rule says "safe to default" and the
+#                  answer is still no. kiro-cli's token is at
+#                  ~/.aws/sso/cache/kiro-auth-token-cli.json, which follows $HOME
+#                  and not $KIRO_HOME, and the real ~/.kiro holds no credential
+#                  material at all (agents/, argv.json, extensions/, logs/,
+#                  powers/, sessions/, settings/, skills/, steering/). What it
+#                  DOES hold is settings/cli.json, whose
+#                  chat.disableTrustAllConfirmation is the persisted consent the
+#                  kiro driver states it depends on — "kiro-cli launches with
+#                  persisted --trust-all-tools consent, so a fresh cwd never
+#                  stalls on a trust picker" (step_restart's own comment). A
+#                  scratch home has no such file. Seed settings/cli.json.
+#                  Whether kiro-cli actually blocks there is NOT verified —
+#                  doing so means driving the live CLI — so this row is opt-in
+#                  on the strength of the driver's stated premise no longer
+#                  holding, which is the honest reason rather than a measured
+#                  one. Defaulting it would also change the recording conditions
+#                  of all 28 existing kiro-cli recordings at once.
+#
+#            A "default AND seed from the real home" third policy was considered
+#            and not built: it would copy the operator's own config into staging
+#            on every run, which trades an explicit, auditable operator step for
+#            an implicit read of their real home, and it cannot be tested here
+#            without a live CLI to prove the seeded home actually boots.
+#
+# NOT IN THE TABLE, and why — both are structural, neither is a to-do:
+#
+#   claudecode   HALF-relocatable, which is worse than not at all. Its
+#                transcripts follow CLAUDE_CONFIG_DIR
+#                (claudecode/adapter.go transcriptsDir) but its hook config does
+#                NOT — claudeSettingsPath (claudecode/hookinstaller.go) joins
+#                os.UserHomeDir() with ".claude/settings.json" unconditionally.
+#                A row here would move the session store while the install kept
+#                landing in the operator's real settings.json, i.e. it would
+#                claim an isolation it does not have.
+#   gemini-cli   No override exists at all. defaultRootDir is ".gemini/tmp"
+#                under $HOME and geminiHome() is $HOME/.gemini; there is no
+#                os.Getenv anywhere in core/adapters/inbound/agents/geminicli.
+#                Its hook recordings can only run against the real home, with
+#                the managed-file snapshot as the whole of the protection.
+#
+# Those two are named in righome.Unisolatable with the same reasons, and the
+# tripwire fails if a hooks-declaring adapter is in neither place.
+agent_home_table() {
+  cat <<'TABLE'
+copilot COPILOT_HOME default
+codex CODEX_HOME optin
+kiro-cli KIRO_HOME optin
+mistral-vibe VIBE_HOME optin
+TABLE
+  return 0
+}
+
+# agent_home_field <adapter> <column-number> prints one field of an adapter's
+# row, or nothing when the adapter has no row.
+agent_home_field() {
+  local adapter="$1" col="$2"
+  agent_home_table | awk -v a="$adapter" -v c="$col" '$1 == a { print $c; found = 1 } END { exit !found }' || true
+  return 0
+}
+
+# agent_home_var <adapter> prints the env var that relocates the adapter's home,
+# or nothing when it has no row.
+agent_home_var() { agent_home_field "$1" 2; }
+
+# agent_home_policy <adapter> prints "default" or "optin", or nothing.
+agent_home_policy() { agent_home_field "$1" 3; }
+
+# agent_home_isolate <adapter> <staging-default-dir> resolves, validates,
+# exports and creates the adapter's home, and reports on stdout what it did.
+#
+# It ALWAYS prints exactly one `agent-home:` line, including for an adapter with
+# no row and for an opt-in one the caller left unset. That is deliberate: an
+# isolation step whose "did nothing" and "worked" cases are both silent is
+# indistinguishable from one that was never reached, which is the defect the
+# tmux measurement in this file's header is an instance of.
+#
+# A RELATIVE value is a hard failure, never a fallback. The daemon resolves
+# these through agentpaths.FromEnv, which logs and IGNORES a non-absolute value
+# and falls back to $HOME — so accepting one here would point the daemon at the
+# real home while the driver used the relative one, which is the same
+# daemon/CLI disagreement in a different disguise (#1388 recorded it for codex).
+agent_home_isolate() {
+  local adapter="${1:-}" staging_default="${2:-}"
+  local var policy current
+
+  if [[ -z "$adapter" ]]; then
+    echo "agent-home: usage: agent_home_isolate <adapter> <staging-default-dir>" >&2
+    return 1
+  fi
+
+  var="$(agent_home_var "$adapter")"
+  policy="$(agent_home_policy "$adapter")"
+
+  if [[ -z "$var" ]]; then
+    echo "agent-home: $adapter — no home override is wired (lib/agent-home.sh); the daemon and the CLI both use the real \$HOME"
+    return 0
+  fi
+
+  # Indirect expansion rather than `${!var}` gymnastics at every use site; bash
+  # 3.2 supports it and it keeps the value read in one place.
+  current="${!var:-}"
+
+  if [[ -z "$current" && "$policy" == "default" ]]; then
+    if [[ -z "$staging_default" ]]; then
+      echo "agent-home: $adapter declares policy 'default' but no staging directory was passed" >&2
+      return 1
+    fi
+    current="$staging_default"
+  fi
+
+  if [[ -z "$current" ]]; then
+    echo "agent-home: $adapter — NOT isolated; export $var=<absolute path> to keep this run off the real home"
+    return 0
+  fi
+
+  if [[ "$current" != /* ]]; then
+    echo "agent-home: $var must be absolute (got '$current')" >&2
+    echo "            the daemon resolves it through agentpaths.FromEnv, which IGNORES a" >&2
+    echo "            relative value and falls back to \$HOME — so the daemon and the agent" >&2
+    echo "            CLI would watch and write two different homes, and the fixture would" >&2
+    echo "            come back empty with nothing saying why" >&2
+    return 1
+  fi
+
+  if ! mkdir -p "$current"; then
+    echo "agent-home: cannot create $var=$current" >&2
+    return 1
+  fi
+
+  export "$var=$current"
+  echo "agent-home: $adapter — $var=$current (daemon + driver share this home)"
+  return 0
+}

--- a/tools/onboarding-factory/scripts/lib/agent-home_test.sh
+++ b/tools/onboarding-factory/scripts/lib/agent-home_test.sh
@@ -1,0 +1,233 @@
+#!/usr/bin/env bash
+# agent-home_test.sh — unit tests for agent-home.sh. Plain bash (no framework),
+# matching the style of golden-scope_test.sh. Run directly or via
+# scripts/smoke-test.sh.
+#
+# Why this exists. agent_home_isolate replaced two hand-written per-adapter
+# blocks — copilot's staging default in run-cell.sh AND run-cell-multi.sh, and
+# codex's opt-in absolute-only guard in run-cell.sh only — neither of which had
+# any coverage. Per AGENTS.md, "a rewritten guard replays its predecessor's
+# cases or it is not known to be a superset", so the copilot and codex cases
+# below are transcribed from the blocks that were deleted, not invented for the
+# new function:
+#
+#   copilot  unset  → exported to the staging default, directory created
+#   copilot  set    → the caller's value wins over the staging default
+#   codex    unset  → nothing exported (isolation is opt-in for credentials)
+#   codex    set    → exported, directory created
+#   codex    relative → HARD FAILURE, because the daemon's agentpaths.FromEnv
+#                     ignores a relative value and falls back to $HOME (#1388)
+#
+# Everything else here is new behaviour and therefore owes a deliberate
+# mutation rather than a "before" run. The mutations are committed beside the
+# assertions rather than described in a PR body: `mutation_*` below re-declares
+# a deliberately WRONG table or a deliberately WRONG guard and asserts the
+# suite's own claims flip. Without them, a function that exported nothing at all
+# would satisfy several of the assertions above (an unset opt-in var is
+# indistinguishable from a broken exporter).
+
+set -uo pipefail   # NOT -e: assertions capture non-zero return codes
+
+DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=agent-home.sh
+source "$DIR/agent-home.sh"
+
+fails=0
+pass() { local label="$1"; echo "  PASS: $label"; return 0; }
+fail() { local label="$1" expected="$2" got="$3"; echo "  FAIL: $label — expected [$expected] got [$got]"; fails=$((fails + 1)); return 0; }
+assert_eq() {
+  local label="$1" expected="$2" got="$3"
+  [[ "$got" == "$expected" ]] && pass "$label" || fail "$label" "$expected" "$got"
+  return 0
+}
+
+TMP="$(mktemp -d -t agent-home-test)"
+mkdir -p "$TMP/probe"
+trap 'rm -rf "$TMP"' EXIT
+
+# run_isolate <adapter> <staging-default> [VAR=value ...] runs
+# agent_home_isolate in a CHILD bash and publishes three globals: RUN_STATUS,
+# RUN_VALUE (the adapter's variable as a CHILD process sees it) and RUN_OUT (its
+# stdout+stderr, newlines flattened).
+#
+# The value is read back through `env` in a child rather than from the calling
+# shell, because that is the only thing that distinguishes the property under
+# test from a plain assignment: the daemon is spawned as a child process and
+# inherits the environment, so a function that set the variable without
+# EXPORTing it would leave every in-shell assertion green and the daemon on the
+# real home. That is this file's own version of "assert the operation actually
+# happened".
+#
+# Three separate files rather than one delimited string: the reported output is
+# multi-line by design (the relative-path refusal prints four lines), and a
+# field-splitting parse over it silently mis-assigns every column — which is how
+# this helper's first draft reported fifteen failures that were all its own.
+RUN_STATUS=""; RUN_VALUE=""; RUN_OUT=""
+run_isolate() {
+  local adapter="$1" staging="$2"; shift 2
+  local var
+  var="$(agent_home_var "$adapter")"
+  env "$@" bash -c '
+    source "$1/agent-home.sh"
+    agent_home_isolate "$2" "$3"
+    st=$?
+    printf "%d" "$st" > "$4/status"
+    # Read back through a CHILD `env`, never from this shell: an unexported
+    # assignment is invisible to the daemon and to nothing else.
+    if [[ -n "$5" ]]; then env | sed -n "s/^$5=//p" > "$4/value"; else : > "$4/value"; fi
+  ' _ "$DIR" "$adapter" "$staging" "$TMP/probe" "$var" >"$TMP/probe/out" 2>&1
+  RUN_STATUS="$(cat "$TMP/probe/status" 2>/dev/null)"
+  RUN_VALUE="$(cat "$TMP/probe/value" 2>/dev/null)"
+  RUN_OUT="$(cat "$TMP/probe/out" 2>/dev/null | tr '\n' ' ')"
+  return 0
+}
+
+echo "== the table is not empty (vacuity guard) =="
+# Every assertion below is satisfied by an empty table: agent_home_var returns
+# nothing, agent_home_isolate takes the "no row" branch and exits 0, and the
+# whole suite passes having exercised no adapter at all.
+rows="$(agent_home_table | grep -c .)"
+[[ "$rows" -ge 4 ]] && pass "table declares $rows adapters" \
+  || fail "table declares at least 4 adapters" ">=4" "$rows"
+
+echo "== every row is well formed =="
+malformed="$(agent_home_table | awk 'NF != 3 || $2 !~ /^[A-Z_]+$/ || ($3 != "default" && $3 != "optin") { print NR": "$0 }')"
+assert_eq "no malformed rows" "" "$malformed"
+
+echo "== predecessor's cases: copilot (policy=default) =="
+run_isolate copilot "$TMP/cop" -u COPILOT_HOME
+assert_eq "unset → exit 0" "0" "$RUN_STATUS"
+assert_eq "unset → exported to the staging default" "$TMP/cop" "$RUN_VALUE"
+[[ -d "$TMP/cop" ]] && pass "unset → staging dir created" || fail "unset → staging dir created" "dir" "missing"
+
+run_isolate copilot "$TMP/cop-default" COPILOT_HOME="$TMP/cop-explicit"
+assert_eq "explicit value wins over the staging default" "$TMP/cop-explicit" "$RUN_VALUE"
+
+echo "== predecessor's cases: codex (policy=optin) =="
+run_isolate codex "$TMP/unused" -u CODEX_HOME
+assert_eq "unset → exit 0" "0" "$RUN_STATUS"
+assert_eq "unset → NOTHING exported (credentials live in CODEX_HOME)" "" "$RUN_VALUE"
+[[ -d "$TMP/unused" ]] && fail "unset → no staging dir created" "missing" "dir" \
+  || pass "unset → no staging dir created"
+case "$RUN_OUT" in
+  *"NOT isolated"*) pass "unset → says so out loud" ;;
+  *) fail "unset → says so out loud" "a 'NOT isolated' line" "$RUN_OUT" ;;
+esac
+
+run_isolate codex "$TMP/unused2" CODEX_HOME="$TMP/codex-home"
+assert_eq "set → exit 0" "0" "$RUN_STATUS"
+assert_eq "set → exported" "$TMP/codex-home" "$RUN_VALUE"
+
+# That last assertion does NOT discriminate against a missing `export`, and the
+# measurement is why this arm exists: run_isolate hands the value in through
+# `env VAR=…`, so the child already carries it exported and re-exporting is a
+# no-op. Deleting the export from agent_home_isolate reddens exactly ONE of the
+# assertions above — copilot's staging default, the only case where the function
+# introduces a variable that was previously unset.
+#
+# An operator who sets the variable as a plain shell variable and runs the rig
+# in the same shell is the case that needs the export, so it is driven directly
+# here rather than through run_isolate.
+got="$(bash -c '
+  source "$1/agent-home.sh"
+  CODEX_HOME="$2"          # set, deliberately NOT exported
+  agent_home_isolate codex /unused >/dev/null 2>&1
+  env | sed -n "s/^CODEX_HOME=//p"
+' _ "$DIR" "$TMP/codex-noexport")"
+assert_eq "an unexported caller variable is exported onward to the daemon" "$TMP/codex-noexport" "$got"
+
+run_isolate codex "$TMP/unused3" CODEX_HOME="relative/codex"
+assert_eq "RELATIVE → hard failure" "1" "$RUN_STATUS"
+case "$RUN_OUT" in
+  *"must be absolute"*) pass "relative → names why" ;;
+  *) fail "relative → names why" "'must be absolute'" "$RUN_OUT" ;;
+esac
+
+echo "== the two adapters this file was added for =="
+for pair in "kiro-cli KIRO_HOME" "mistral-vibe VIBE_HOME"; do
+  set -- $pair
+  a="$1"; v="$2"
+  assert_eq "$a declares $v" "$v" "$(agent_home_var "$a")"
+  assert_eq "$a is opt-in" "optin" "$(agent_home_policy "$a")"
+  run_isolate "$a" "$TMP/unused-$a" -u "$v"
+  assert_eq "$a unset → nothing exported" "" "$RUN_VALUE"
+  run_isolate "$a" "$TMP/unused-$a" "$v=$TMP/$a-home"
+  assert_eq "$a set → exported" "$TMP/$a-home" "$RUN_VALUE"
+  run_isolate "$a" "$TMP/unused-$a" "$v=rel/$a"
+  assert_eq "$a relative → hard failure" "1" "$RUN_STATUS"
+done
+
+echo "== an adapter with no row is reported, never silent =="
+run_isolate aider "$TMP/unused-aider"
+assert_eq "no row → exit 0" "0" "$RUN_STATUS"
+case "$RUN_OUT" in
+  *"no home override is wired"*) pass "no row → says so out loud" ;;
+  *) fail "no row → says so out loud" "a 'no home override' line" "$RUN_OUT" ;;
+esac
+
+echo "== refusals =="
+out="$(agent_home_isolate 2>&1)"; st=$?
+assert_eq "no adapter → exit 1" "1" "$st"
+case "$out" in *usage*) pass "no adapter → usage line" ;; *) fail "no adapter → usage line" "usage" "$out" ;; esac
+
+# A 'default' row with no staging directory to fall back on is a caller bug, and
+# the one shape where doing nothing would look identical to working: the var
+# stays unset, the adapter records against the real home, and every other
+# assertion here is still green.
+out="$(env -u COPILOT_HOME bash -c 'source "$1/agent-home.sh"; agent_home_isolate copilot 2>&1' _ "$DIR")"; st=$?
+assert_eq "default policy + no staging dir → exit 1" "1" "$st"
+case "$out" in
+  *"no staging directory"*) pass "default policy + no staging dir → names why" ;;
+  *) fail "default policy + no staging dir → names why" "'no staging directory'" "$out" ;;
+esac
+
+# ---------------------------------------------------------------------------
+# Committed mutation evidence. Each block re-declares one piece of the lib the
+# WRONG way and asserts the property above actually flips — because an assertion
+# that would pass against a broken implementation is not evidence of anything.
+# ---------------------------------------------------------------------------
+echo "== mutation: an exporter that assigns without exporting =="
+# The whole point of running before the daemon spawns is that the daemon
+# INHERITS the value. A local assignment satisfies every in-shell check.
+mut="$(env -u COPILOT_HOME bash -c '
+  source "$1/agent-home.sh"
+  agent_home_isolate() { local v; v="$(agent_home_var "$1")"; eval "$v=\"\$2\""; return 0; }
+  agent_home_isolate copilot "$2" >/dev/null
+  env | grep -c "^COPILOT_HOME=" || true
+' _ "$DIR" "$TMP/mut-cop")"
+assert_eq "MUTATION: unexported assignment is invisible to a child" "0" "$mut"
+
+echo "== mutation: the relative-path guard removed =="
+# Deleting the guard makes a relative value succeed, which is exactly the #1388
+# shape: the driver uses "rel/codex" while the daemon silently falls back to
+# $HOME/.codex.
+mut="$(env CODEX_HOME="rel/codex" bash -c '
+  source "$1/agent-home.sh"
+  agent_home_isolate() {
+    local v; v="$(agent_home_var "$1")"
+    export "$v=${!v}"; return 0
+  }
+  agent_home_isolate codex "$2" >/dev/null 2>&1; printf "%d" "$?"
+' _ "$DIR" "$TMP/unused-mut")"
+assert_eq "MUTATION: without the guard a relative value passes" "0" "$mut"
+
+echo "== mutation: a table row naming the wrong variable =="
+# The rig exports what the table says. A row naming a variable the daemon does
+# not read exports something nothing honours — daemon on the real home, CLI on
+# the isolated one, empty fixture. Nothing in THIS file can catch that; it is
+# what righome's Go tripwire grades, and the assertion here is only that the
+# table is what decides.
+mut="$(env -u KIRO_HOME bash -c '
+  source "$1/agent-home.sh"
+  agent_home_table() { printf "%s\n" "kiro-cli WRONG_HOME optin"; }
+  agent_home_var kiro-cli
+' _ "$DIR")"
+assert_eq "MUTATION: the table alone decides the variable" "WRONG_HOME" "$mut"
+
+echo ""
+if [[ "$fails" -eq 0 ]]; then
+  echo "agent-home_test.sh: ALL PASS"
+  exit 0
+fi
+echo "agent-home_test.sh: $fails FAILED" >&2
+exit 1

--- a/tools/onboarding-factory/scripts/run-cell-multi.sh
+++ b/tools/onboarding-factory/scripts/run-cell-multi.sh
@@ -75,6 +75,11 @@ source "$SCRIPT_DIR/lib/recipe-lint.sh"
 source "$SCRIPT_DIR/lib/pick-recording.sh"
 # shellcheck source=lib/completeness-check.sh
 source "$SCRIPT_DIR/lib/completeness-check.sh"
+# Per-adapter agent-home isolation, shared with run-cell.sh — before this file
+# existed only COPILOT_HOME was handled here while run-cell.sh also handled
+# CODEX_HOME, i.e. exactly the one-rig-only drift #1214 is about.
+# shellcheck source=lib/agent-home.sh
+source "$SCRIPT_DIR/lib/agent-home.sh"
 
 DRY_RUN=0
 positional=()
@@ -230,20 +235,25 @@ write_error_manifest() {
     > "$MANIFEST"
 }
 
-# Copilot resolves its whole config dir — session store included — from
-# COPILOT_HOME, and the DAEMON reads that variable eagerly when it builds the
-# adapter's watcher, so it has to be exported BEFORE the spawn below. The
-# driver defaults it to "<its staging subdir>/copilot-home" only when unset, so
-# leaving it unset here points the daemon at the real ~/.copilot while the
-# driver writes to staging: the daemon then observes every one of the user's
-# own copilot sessions and none of the driver's, and curation fails with
-# "primary session does not appear in the recording". run-cell.sh has always
-# done this; the multi rig predates the copilot adapter and did not.
+# Agent-home isolation, one call per adapter in this cell, from the SAME
+# declaration run-cell.sh reads (lib/agent-home.sh). It has to run BEFORE the
+# spawn below: the DAEMON reads these variables eagerly when it builds each
+# adapter's watcher, and `--print-managed-files` — the list the snapshot
+# protects — resolves under them too.
+#
+# The copilot case this replaces is the one that showed what a missed export
+# costs: unset, the daemon watches the real ~/.copilot while the driver writes
+# to staging, so it observes every one of the user's own copilot sessions and
+# none of the driver's, and curation fails with "primary session does not
+# appear in the recording". Its "<staging subdir>/copilot-home" default is
+# preserved exactly by the per-adapter spelling below.
+#
+# It also closes the drift that motivated the shared lib: this loop handled
+# COPILOT_HOME and nothing else, while run-cell.sh handled CODEX_HOME too — so
+# a codex cross-adapter recording could not be isolated at all, whatever the
+# operator exported.
 for _a in "${ADAPTERS[@]}"; do
-  [[ "$_a" == "copilot" ]] || continue
-  export COPILOT_HOME="${COPILOT_HOME:-$STAGING/copilot/copilot-home}"
-  mkdir -p "$COPILOT_HOME"
-  echo "copilot: COPILOT_HOME=$COPILOT_HOME (daemon + driver share this store)"
+  agent_home_isolate "$_a" "$STAGING/$_a/$_a-home" || exit 1
 done
 
 # --- Spawn ONE isolated --record daemon ---------------------------------

--- a/tools/onboarding-factory/scripts/run-cell.sh
+++ b/tools/onboarding-factory/scripts/run-cell.sh
@@ -51,6 +51,11 @@ source "$SCRIPT_DIR/lib/pick-recording.sh"
 # reason the daemon lifecycle is (#1214).
 # shellcheck source=lib/completeness-check.sh
 source "$SCRIPT_DIR/lib/completeness-check.sh"
+# Per-adapter agent-home isolation — the declaration of which adapters have a
+# relocatable home, and which of them default to staging, shared with
+# run-cell-multi.sh for the same reason (#1214).
+# shellcheck source=lib/agent-home.sh
+source "$SCRIPT_DIR/lib/agent-home.sh"
 
 RECORDER="off"
 ATTACH=0
@@ -245,41 +250,20 @@ fi
 #    periodic flush, and pick the recording file from whatever the
 #    daemon is writing to (env override > default
 #    ~/.local/share/irrlicht/recordings/).
-# Copilot resolves its whole config dir — session store included — from
-# COPILOT_HOME, and the DAEMON reads that variable eagerly when it builds the
-# adapter's watcher. The driver defaults it to "$STAGING/copilot-home" only
-# when unset, so leaving it unset here would point the daemon at the real
-# ~/.copilot while the driver wrote to staging: the daemon would observe no
-# copilot session at all and every cell would record an empty fixture.
-# Exporting it once, before the daemon spawns, keeps both halves on one store.
-# (--config-dir is deprecated upstream in favour of this variable.)
-if [[ "$ADAPTER" == "copilot" ]]; then
-  export COPILOT_HOME="${COPILOT_HOME:-$STAGING/copilot-home}"
-  mkdir -p "$COPILOT_HOME"
-  echo "copilot: COPILOT_HOME=$COPILOT_HOME (daemon + driver share this store)"
-fi
-
-# Codex resolves its config dir from CODEX_HOME the same way — the daemon's
-# codexHome() and both codex drivers honour it — but it deliberately does NOT
-# get copilot's staging default. Codex keeps its CREDENTIALS in that directory
-# (auth.json), so defaulting to an empty staging dir would leave every codex
-# recording unauthenticated. Isolation is therefore opt-in: export an absolute
-# CODEX_HOME (seeded with a copy of auth.json) to keep the run off the real
-# ~/.codex entirely. Exported here so the DAEMON inherits the same value the
-# drivers will use — codexHome() decides where hooks.json is installed, and
-# hence which file `--print-managed-files` tells the recorder to protect.
-# Absolute-only, because codexHome() ignores a relative value and silently
-# falls back to $HOME/.codex (#1388).
-if [[ "$ADAPTER" == "codex" && -n "${CODEX_HOME:-}" ]]; then
-  if [[ "$CODEX_HOME" != /* ]]; then
-    echo "codex: CODEX_HOME must be absolute (got '$CODEX_HOME') — the daemon" >&2
-    echo "       ignores relative values, so it and the driver would disagree" >&2
-    exit 1
-  fi
-  export CODEX_HOME
-  mkdir -p "$CODEX_HOME"
-  echo "codex: CODEX_HOME=$CODEX_HOME (daemon + driver share this home)"
-fi
+# Agent-home isolation. Which adapters have a relocatable home, which env var
+# each reads, and which of them default to staging rather than being opt-in, is
+# ONE declaration in lib/agent-home.sh — a per-adapter `if` here is how codex's
+# isolation came to exist in this script and not in run-cell-multi.sh (the same
+# split that made #1178's config snapshot reach one recorder and not the other,
+# #1214). It runs BEFORE spawn_record_daemon so the daemon inherits the value
+# and `--print-managed-files` — which is what the snapshot protects — resolves
+# under the isolated home rather than the operator's real one.
+#
+# The staging default is spelled "<adapter>-home" so copilot — the one adapter
+# on the `default` policy — keeps resolving to exactly the "$STAGING/copilot-home"
+# its own driver falls back to when run standalone. Two spellings of one default
+# is how the daemon and the driver end up on different stores.
+agent_home_isolate "$ADAPTER" "$STAGING/$ADAPTER-home" || exit 1
 
 if [[ "$ATTACH" == "1" ]]; then
   ATTACHED_RECORDINGS_DIR="${IRRLICHT_RECORDINGS_DIR:-$HOME/.local/share/irrlicht/recordings}"

--- a/tools/onboarding-factory/scripts/smoke-test.sh
+++ b/tools/onboarding-factory/scripts/smoke-test.sh
@@ -72,6 +72,10 @@ echo ""
 echo "== unit tests (lib/golden-scope_test.sh) =="
 bash "$SCRIPT_DIR/lib/golden-scope_test.sh" || rc=1
 
+echo ""
+echo "== unit tests (lib/agent-home_test.sh) =="
+bash "$SCRIPT_DIR/lib/agent-home_test.sh" || rc=1
+
 # completeness-gate / catalog-drift / consistency gates were retired (#528):
 # `of validate` + `of coverage` (Go) now own schema + referential + coverage
 # integrity, and a per-scenario shard is the single source for a cell, so the


### PR DESCRIPTION
## What this started as, and why it changed

The brief was "the rig cannot record a hooks cell for kiro-cli or mistral-vibe without writing into the operator's real `~/.kiro` / `~/.vibe`". **That premise is wrong and I verified it rather than implementing it.** The rig already protects those files, hard:

- `go run ./core/cmd/irrlichd --print-managed-files` lists all four (`~/.kiro/agents/irrlicht.json`, `~/.kiro/settings/cli.json`, `~/.vibe/hooks.toml`, `~/.vibe/config.toml`).
- `lib/managed-file-snapshot.sh` asks the daemon for that list (no literal list, no fallback), backs each file up, and restores from an EXIT trap — handling `saved` / `absent` / `absentdir` and refusing to destroy a file the agent created mid-run.
- `spawn-record-daemon.sh:112` makes it a hard gate: a failed snapshot refuses the spawn.

So nothing here is motivated by data loss. Two real things remained.

---

## 1. kiro-cli writes a THIRD file, and it is undeclared

`recordPriorDefaultAgentOnce` (`kirocli/hookinstaller.go:573`) writes `$KIRO_HOME/.irrlicht-prior-default.json` on every install. It is in neither `Writes.Path` nor `Writes.Also`, so `--print-managed-files` never names it and the rig never backs it up or hands it back.

The residue is not inert: that function **deliberately never overwrites**, so the copy a recording leaves in the operator's real `~/.kiro` is what a LATER real grant reads instead of their actual `chat.defaultAgent` — and a subsequent uninstall then restores the recording's snapshot of that setting rather than their own choice.

Fixed by declaring it in `Writes.Also`, the mechanism #1718 added for exactly this.

**Seen red before the fix** (`TestKiroCLIAlso_PriorDefaultSidecarIsAManagedFile`):

```
--- FAIL: TestKiroCLIAlso_PriorDefaultSidecarIsAManagedFile (0.00s)
    kirocli_alsofile_test.go:168: Writes.Also declares no entry resolving to ".../kiro-home/.irrlicht-prior-default.json" — recordPriorDefaultAgentOnce writes it on every install, so the recording rig cannot back it up or hand it back
    kirocli_alsofile_test.go:177: --print-managed-files does not list ".../kiro-home/.irrlicht-prior-default.json" — the recording rig protects only what this command names
FAIL	irrlicht/core/cmd/irrlichd	0.420s
```

---

## 2. The home-isolation lever was half-wired, and failed silently

`run-cell.sh` exports the home variable. The daemon inherits it (direct child). The agent CLI does **not**: the driver launches it with `tmux new-session`, and the pane's command is spawned by the tmux SERVER, whose environment was fixed when that server started.

Measured on a private `-L` socket, so no real session was touched:

```
pane saw IRR_PROBE_VAR = [<UNSET>]
pane saw IRR_PROBE_VAR = [isolated-home] (env-prefixed)
```

On a dev machine a server is essentially always already running, so setting `KIRO_HOME`/`VIBE_HOME` today gets you a daemon watching the scratch home and a CLI writing to the real one — an empty fixture with nothing saying why. codex's driver already prefixed `env CODEX_HOME=…`; that was one driver's private knowledge.

**copilot had the same hole, on the one adapter that DEFAULTS to a staging home** — i.e. on every copilot recording. Found by the new tripwire on its first run (see mutation evidence below).

### The mechanism

`tools/onboarding-factory/scripts/lib/agent-home.sh` — one table, one function:

```
copilot COPILOT_HOME default
codex CODEX_HOME optin
kiro-cli KIRO_HOME optin
mistral-vibe VIBE_HOME optin
```

It replaces per-adapter blocks in `run-cell.sh` (copilot, codex) and `run-cell-multi.sh` (copilot **only** — codex could not be isolated in the cross-adapter rig at all, the #1214 one-rig-only drift). Copilot's staging default is preserved byte-for-byte (`$STAGING/copilot-home`). It always prints one line, including for "no row" and "opt-in, unset", so "did nothing" and "worked" are not both silent.

### Why kiro-cli and mistral-vibe are opt-in, not copilot-shaped

The rule is **not** "credentials" — that is codex's phrasing and it is too narrow. It is that a scratch home starts without state the run needs, and every way of missing it ends in a blocking interactive prompt in the tmux pane that no driver has an arm for.

- **mistral-vibe — the provider declaration, upstream of the credential.** `config.toml`'s `api_key_env_var` reads like "the key is in an env var, so a scratch home loses nothing" — true of the SECRET, false of the LOOKUP. `[[providers]]` lives in `$VIBE_HOME/config.toml`, and `resolve_api_key(env_key)` (`vibe/core/config/_settings.py:101`) reads the process env then the OS keyring **under that name**. A home with no `config.toml` falls back to `DEFAULT_PROVIDERS`, so any non-default provider looks up the wrong name → `MissingAPIKeyError` → `cli.py:92` runs the onboarding **wizard** in the pane. Separately `$VIBE_HOME/.env` is a real credential location: `persist_api_key` writes there when the keyring raises.
  **Not** `trusted_folders.toml`, which looks like it should matter and does not: the driver already passes `--trust` on every launch because the staging cwd lives under the irrlicht repo and is untrusted whichever home is in use.
- **kiro-cli — persisted trust-all consent.** Its token is at `~/.aws/sso/cache/kiro-auth-token-cli.json`, which follows `$HOME` not `$KIRO_HOME`, and the real `~/.kiro` holds no credential material. So the credential rule says "safe to default" — and the answer is still no, because `settings/cli.json`'s `chat.disableTrustAllConfirmation` is the consent the kiro driver states it depends on ("kiro-cli launches with persisted --trust-all-tools consent, so a fresh cwd never stalls on a trust picker", `step_restart`). Whether it actually blocks is **not verified** — that needs driving the live CLI — so the row is opt-in on the strength of the driver's premise no longer holding, stated as such.

A third "default AND seed from the real home" policy was considered and not built: it trades an explicit operator step for an implicit read of their real home, and cannot be tested without a live CLI.

---

## 3. The tripwire: `tools/onboarding-factory/internal/righome`

Placed in the factory module, not `core/`, because it is a property of the RECORDING RIG and the factory is already the tree that joins the daemon's adapter registry to the catalog (`internal/hookcov` is the precedent, same import, same shape). A `core/` test reading a file under `tools/` would invert that.

Three arms. Every one was seen red.

**A. A hooks adapter with neither a row nor a named exemption** (mutation: delete kiro-cli's row):

```
--- FAIL: TestRigHomeTableMatchesTheAdapterRegistry (0.02s)
    righome_test.go:61: adapter "kiro-cli" installs hooks into the user's config but has neither a row in tools/onboarding-factory/scripts/lib/agent-home.sh nor an Unisolatable entry saying why it cannot have one. Add whichever is true — an isolation story is a decision, and an omission looks exactly like a decision that was made silently
```

**B. A row whose variable does not actually relocate both halves** (mutation: `kiro-cli KIRO_HOME optin` → `KIRO_HOME_WRONG`):

```
--- FAIL: TestEveryRigHomeRowRelocatesBothHalves/kiro-cli (0.00s)
    righome_test.go:130: with KIRO_HOME_WRONG=... the session root is still ".kiro/sessions/cli" — the daemon would watch the operator's real store while the driver wrote to the scratch home, and the recording would contain their sessions and not the driver's
    righome_test.go:164: with KIRO_HOME_WRONG=... the hooks install still writes Writes.Path to "/Users/ingo/.kiro/agents/irrlicht.json" — the install would land in the operator's real config while everything else in the run claimed to be isolated
    righome_test.go:164: ... Writes.Also[0] to "/Users/ingo/.kiro/settings/cli.json" ...
    righome_test.go:164: ... Writes.Also[1] to "/Users/ingo/.kiro/.irrlicht-prior-default.json" ...
```

(Note `Also[1]` — the file this PR declares. The two halves of this PR grade each other.)

**C. A rowed adapter whose driver does not pass the home through tmux.** This was **not** a mutation — it is what the arm reported against `main` on its first run:

```
--- FAIL: TestEveryRigHomeRowsDriverPassesTheHomeThroughTmux/copilot (0.00s)
    righome_test.go:237: .../replaydata/agents/copilot/driver-interactive.sh:201 launches the agent under tmux without an explicit `env COPILOT_HOME=…` prefix.
      tmux new-session -d -s "$SESSION" -x 200 -y 50 -c "${SES_CWD[$ACTIVE]}" copilot "${args[@]}" \
    The pane inherits the tmux SERVER's environment, not the exported one, so on any machine with a server already running the daemon would watch the scratch home while the CLI wrote to the real one.
```

Fixed in the same PR.

### Exemptions carry structural facts, not to-dos

- **claudecode** — HALF-relocatable, which is worse than not at all: transcripts follow `CLAUDE_CONFIG_DIR` but `claudeSettingsPath` joins `os.UserHomeDir()` with `.claude/settings.json` unconditionally. A row would move the session store while the install kept landing in the real `settings.json`.
- **gemini-cli** — no override exists at all: `defaultRootDir` is `.gemini/tmp` under `$HOME`, `geminiHome()` is `$HOME/.gemini`, no `os.Getenv` anywhere in the package.

Both keys are existence-checked in both directions.

---

## Mutation evidence for the shell lib

Committed beside the assertions (`agent-home_test.sh`), and each also run live:

**Drop the `export`** (assign locally instead):
```
  FAIL: unset → exported to the staging default — expected [.../cop] got []
  FAIL: an unexported caller variable is exported onward to the daemon — expected [.../codex-noexport] got []
agent-home_test.sh: 2 FAILED
```
Recorded honestly: the first draft reddened only ONE arm, because `run_isolate` hands the value in through `env VAR=…` so the child already carries it exported. The second arm was added to make the mutation discriminate for the opt-in rows too.

**Remove the absolute-path guard:**
```
  FAIL: RELATIVE → hard failure — expected [1] got [0]
  FAIL: relative → names why — expected ['must be absolute'] got [agent-home: codex — CODEX_HOME=relative/codex (daemon + driver share this home) ]
  FAIL: kiro-cli relative → hard failure — expected [1] got [0]
  FAIL: mistral-vibe relative → hard failure — expected [1] got [0]
agent-home_test.sh: 4 FAILED
```

`righome_corpus_test.go` carries the rest as a committed corpus: one input wrong in exactly one way per row, each naming the fragment it must report **and** the fragments it must leave silent, plus a correct-baseline vacuity guard and a `want:false` row (a row for a hookless adapter is legitimate).

---

## Two corrections to my own work, recorded rather than quietly fixed

Both are the shape this repo cares about — a check that looked like it was working and was not — so they are here rather than only in a handover note.

**The shell test helper mis-parsed its own output and reported 15 phantom failures.** `run_isolate`'s first draft packed status, exported value and output into one `\037`-delimited string and split it with `sed -n`. The reported output is multi-line by design (the relative-path refusal prints four lines), so the field split silently mis-assigned every column and the suite reported 15 failures that were all its own. It now writes three separate files. The comment saying so is committed above the helper, because a test harness that can lie about its subject is worth a warning label.

**The "drop the `export`" mutation first reddened only ONE arm, and the weaker evidence was nearly shipped.** `run_isolate` hands the value in through `env VAR=…`, so the child already carries it exported and re-exporting is a no-op — meaning every opt-in row's `set → exported` assertion passes against a function that never exports anything. Only copilot's staging default, where the function introduces a previously-unset variable, discriminated. Rather than record "the mutation reddens one arm", I added the arm that makes it discriminate for the opt-in rows too: an operator who sets the variable as a plain shell variable and runs the rig in the same shell. The mutation now reddens two, and the measurement is committed beside the assertion.

## Something the test caught that is worth knowing

Three of the four rowed adapters (copilot, codex, kiro-cli) compute `Source.Dir` at `Agent()` **construction** time, so the watched root is frozen when the registry is built; only vibe's `DirFunc` re-resolves lazily. Building the registry before setting the variable reported all three as "does not relocate" — true of the object, false of the daemon. **That is why `run-cell.sh` must export before `spawn_record_daemon` and not at any convenient point: a daemon already running cannot be relocated.** The test now models the daemon's real ordering and says so.

---

## SonarCloud: one real finding, fixed

The PR's quality gate failed on exactly one condition — `new_security_rating` = B, required A — driven by a single new VULNERABILITY:

```
VULNERABILITY  MINOR  go:S4036  tools/onboarding-factory/internal/righome/righome.go:98
  Make sure the "PATH" variable only contains fixed, unwriteable directories.
```

**Real, and fixed properly rather than suppressed** (NOSONAR does not work for Go in this repo). `Table` ran `exec.Command("bash", ...)` by bare name, so a local attacker who can write to a directory earlier on the inherited PATH chooses the interpreter that reads the very declaration this package exists to trust. `core/pkg/pathutil` is this repo's own answer to that rule — its package doc names `go:S4036` — and `kirocli/kiroctl.go` already documents why PATH-prepending cannot defeat it. Now `pathutil.MustResolve("bash")`, which falls back to the bare name on an unusual layout so the check degrades to today's behaviour rather than failing to run.

The other ten findings were `go:S3776` (cognitive complexity) and two `shelldre` shell rules; none affected the gate (`new_maintainability_rating` passed at A). CodeScene independently flagged the same functions as Bumpy Road / Complex Method. Since they were all new code in this PR, I split them rather than suppressing:

- `Reconcile` → `checkRows` / `checkExemptions` / `checkUncovered`, one per question. Kept as three rather than folded into one walk **because the corpus asserts a case wrong in ONE way fires exactly one check** — merging them would have made those silence assertions harder to keep honest.
- `TestEveryRigHomeRowRelocatesBothHalves` → `registryAdapterAfterEnv` / `assertSessionRootRelocates` / `assertHookWritesRelocate`. The extraction also gives the "build the registry AFTER setting the env var" ordering a named home instead of a comment buried mid-function.
- `TestReconcileNamesEveryWrongShape` → `assertReported` / `assertSilentOnEverythingElse`, which names the two halves of the evidence.
- `TestTableRefusesRatherThanReturningAShortList` → `assertTableWasRead` (the vacuity guard) / `assertTableRefused`.
- The tmux scan → `tmuxLaunchesMissingEnv` / `countTmuxLaunches`, deliberately separate so "no launches found" cannot be confused with "all launches OK".
- The two `Also`-by-suffix lookups → named helpers in both test files.
- `agent-home.sh`'s two one-line accessors gained `local` + explicit `return` (shelldre:S7679/S7682).

**Outcome: SonarCloud quality gate is now OK** — all five conditions green (`new_security_rating` A), and the PR's new-code issue count is **0**, down from 11.

**CodeScene still fails and I stopped rather than chasing it.** AGENTS.md is explicit that it is advisory, not a merge gate ("a prompt to look closer, not something to chase to green"). I looked, and the fixes above took it from 7 violations to 5 with one file improving in Code Health (`permission_shared_config_gate_test.go` 9.69 → 9.92) and `Reconcile` dropping off entirely. What it now flags are the **extracted helpers themselves** — `assertHookWritesRelocate`, `kirocliSettingsAlsoResolver`, `assertTableWasRead`, `Table` — because each extraction becomes a method with its own threshold. Going further means splitting a single `for` loop that resolves and checks one list, and splitting a two-clause `if` in a vacuity guard, both of which make the code harder to read to satisfy a metric. That is the point at which the advisory should be left advisory.

**All three detectors were re-run against their mutations AFTER the refactor**, because a refactor that leaves a detector green while breaking it is precisely this PR's subject:

- copilot's `env` prefix removed again → `TestEveryRigHomeRowsDriverPassesTheHomeThroughTmux/copilot` red at `driver-interactive.sh:215`
- `kiro-cli KIRO_HOME` → `KIRO_HOME_WRONG` → `TestEveryRigHomeRowRelocatesBothHalves/kiro-cli` red on the session root and all three written files
- kiro-cli's row deleted → `TestRigHomeTableMatchesTheAdapterRegistry` red

## Gates

`go test ./core/... -race -count=1`, `go test ./tools/onboarding-factory/... -race -count=1`, `of validate`, `smoke-test.sh`, `preflight --only arch|tools|bash|posix`, `replay-fixtures.sh` — all pass. Zero golden drift (`git status --porcelain` clean apart from the intended files). No recording was run and nothing under the user's real home was written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


