### PR TITLE
test(hooks): registry tripwire asserting every hooks adapter WIRES its contract families

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,7 +111,9 @@ Before marking a ticket done, run the full suite — every layer must pass:
   the package-local guarded-construction guards and the probe-cost doc
   comment convention — is exercised inside the same `go test ./core/...`
   above. New adapters and new permissions are covered by wiring one call
-  each; full obligation list, self-test harnesses, and incident history:
+  each — and since #1740 a hooks-declaring adapter that skipped one is
+  failed by a registry tripwire rather than by someone noticing; full
+  obligation list, self-test harnesses, and incident history:
   [docs/testing-contracts.md](docs/testing-contracts.md).
 - Factory: `go test ./tools/onboarding-factory/... -race -count=1`.
 - Replay: `tools/replay-fixtures.sh` (golden drift, transition timing,

--- a/core/adapters/inbound/agents/hookcontracts_shapes_test.go
+++ b/core/adapters/inbound/agents/hookcontracts_shapes_test.go
@@ -4,8 +4,9 @@
 // detector must return for it.
 //
 // It exists because TestEveryHookInstallWiresItsContractFamilies passes by
-// construction — all six hooks-declaring adapters wired all seven families the
-// day it landed — and docs/testing-philosophy.md is explicit that this is the
+// construction — every hooks-declaring adapter wired every required family the
+// day it landed, which is what that test being green says — and
+// docs/testing-philosophy.md is explicit that this is the
 // condition the mutation rule exists for, and that the mutation belongs
 // COMMITTED beside the assertion rather than described in a PR body nothing
 // re-runs. The real-tree mutations (delete an adapter's hookpath_test.go, or
@@ -133,7 +134,7 @@ func wiringShapes() []wiringCase {
 			dir:    "direct",
 			want:   map[string]verdict{epConfined: wantCalled},
 			needle: "func TestHookPathConfined(t *testing.T)",
-			why:    "the spelling every one of the six hooks adapters uses today",
+			why:    "the spelling every hooks-declaring adapter uses today",
 			files: map[string]string{
 				"x_test.go": `package shape
 

--- a/core/adapters/inbound/agents/hookcontracts_shapes_test.go
+++ b/core/adapters/inbound/agents/hookcontracts_shapes_test.go
@@ -1,0 +1,815 @@
+// hookcontracts_shapes_test.go is the corpus behind the tripwire in
+// hookcontracts_test.go: one synthetic adapter test package per way of wiring
+// (or of appearing to wire) a contract family, each pinned to the verdict the
+// detector must return for it.
+//
+// It exists because TestEveryHookInstallWiresItsContractFamilies passes by
+// construction — all six hooks-declaring adapters wired all seven families the
+// day it landed — and docs/testing-philosophy.md is explicit that this is the
+// condition the mutation rule exists for, and that the mutation belongs
+// COMMITTED beside the assertion rather than described in a PR body nothing
+// re-runs. The real-tree mutations (delete an adapter's hookpath_test.go, or
+// rename its Test function so the wiring becomes a dead helper) are recorded in
+// PR #1740's body; these are the versions that keep running afterwards.
+//
+// Three groups, and the second and third carry the value:
+//
+//   - CAPABILITIES (wantCalled) — spellings the detector must credit. Several
+//     are things a grep cannot do: an aliased import, a two-hop helper chain, a
+//     call that crosses from the external test package into an in-package test
+//     helper.
+//   - MUST NOT CREDIT (wantAbsent / wantUnreached) — the two weaknesses #1740
+//     predicted a static walk would have, pinned as executable cases: a
+//     reference in a COMMENT, and a DEAD test. Plus the false positive a
+//     name-based rule produces (a local helper that merely shares the name),
+//     and a reference that is not a call.
+//   - DECLARED LIMITS (marked limit:true) — cases where the detector's answer
+//     is knowingly wrong, recorded so they are learned from a test rather than
+//     from an incident. A skipped test still counts; a wiring held in a
+//     package-level var of func type is not seen at all. Both directions are
+//     stated: the first over-credits, the second under-credits (fail-closed).
+//
+// Every case asserts the construct it plants is actually PRESENT in the source
+// it hands the detector, before any verdict is checked — a corpus that has
+// quietly stopped containing its own cases reads as a pass (#1450, and the same
+// guard architecture_hookbody_shapes_test.go carries).
+package agents
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"golang.org/x/tools/go/packages"
+)
+
+// corpusModule and corpusContractPkg are the synthetic stand-ins for this
+// repo's own module and contracttesting package. The detector takes the
+// contract package path as an argument precisely so this corpus can exist: the
+// real one is under core/internal/, which no temp module can import.
+const (
+	corpusModule      = "wiringshapes.test"
+	corpusContractPkg = corpusModule + "/contracttesting"
+	corpusCasesDir    = "cases"
+)
+
+// The two entry points the corpus exercises. One is enough for most rows; the
+// second exists so at least one row can pin that the detector resolves calls
+// PER NAME rather than reporting "some contract was called".
+const (
+	epConfined   = "AssertHookPathConfined"
+	epDisclosure = "AssertHookDisclosureMatchesInstalled"
+)
+
+// verdict is the detector's three-valued answer about one entry point in one
+// package. Three values rather than a bool, because "saw nothing" and "saw a
+// call that nothing runs" are different findings that need different advice,
+// and a corpus that collapsed them could not tell a detector which reports
+// dead wirings from one which is simply blind to them.
+type verdict int
+
+const (
+	wantAbsent    verdict = iota // no call of this entry point was seen at all
+	wantCalled                   // a call reachable from a function `go test` runs
+	wantUnreached                // a call exists, but nothing `go test` runs reaches it
+)
+
+func (v verdict) String() string {
+	switch v {
+	case wantCalled:
+		return "called"
+	case wantUnreached:
+		return "unreached"
+	default:
+		return "absent"
+	}
+}
+
+// wiringCase is one synthetic adapter test package.
+type wiringCase struct {
+	// dir is the package directory, and the case's identity in failures.
+	dir string
+	// files are the sources, filename → content. At least one must be a
+	// _test.go, or the case is testing the detector's file filter rather than
+	// what it claims to.
+	files map[string]string
+	// want lists the non-absent expectations. Any entry point NOT named here
+	// must come back absent — which is how the partial-wiring row proves the
+	// detector resolves per name rather than per package.
+	want map[string]verdict
+	// wantRoots, when non-nil, pins the number of go-test entry functions the
+	// detector found. Only the rows whose subject IS the root rule set it.
+	wantRoots *int
+	// needle must appear in the case's own sources.
+	needle string
+	// why the case exists.
+	why string
+	// limit marks a row whose pinned verdict is a KNOWN WRONG ANSWER, recorded
+	// deliberately. Printed in failures so a future rewrite does not read it as
+	// desired behaviour.
+	limit bool
+}
+
+func intp(n int) *int { return &n }
+
+// stubSource is the corpus's stand-in for contracttesting. Signatures are only
+// as real as they need to be to compile a call.
+const stubSource = `package contracttesting
+
+import "testing"
+
+func AssertHookPathConfined(t *testing.T, r any)               { _ = t; _ = r }
+func AssertHookDisclosureMatchesInstalled(t *testing.T, d any) { _ = t; _ = d }
+`
+
+// wiringShapes is the corpus. Order is capabilities, then must-not-credit, then
+// declared limits.
+func wiringShapes() []wiringCase {
+	return []wiringCase{
+		// ---------- capabilities ----------
+		{
+			dir:    "direct",
+			want:   map[string]verdict{epConfined: wantCalled},
+			needle: "func TestHookPathConfined(t *testing.T)",
+			why:    "the spelling every one of the six hooks adapters uses today",
+			files: map[string]string{
+				"x_test.go": `package shape
+
+import (
+	"testing"
+
+	"` + corpusContractPkg + `"
+)
+
+func TestHookPathConfined(t *testing.T) {
+	contracttesting.AssertHookPathConfined(t, nil)
+}
+`,
+			},
+		},
+		{
+			dir:    "subtest_closure",
+			want:   map[string]verdict{epConfined: wantCalled},
+			needle: `t.Run("confined", func(t *testing.T) {`,
+			why:    "the call is inside a closure passed to t.Run; the enclosing Test is still what runs it",
+			files: map[string]string{
+				"x_test.go": `package shape
+
+import (
+	"testing"
+
+	"` + corpusContractPkg + `"
+)
+
+func TestReceiver(t *testing.T) {
+	t.Run("confined", func(t *testing.T) {
+		contracttesting.AssertHookPathConfined(t, nil)
+	})
+}
+`,
+			},
+		},
+		{
+			dir:    "helper_two_hops",
+			want:   map[string]verdict{epConfined: wantCalled},
+			needle: "func wireOuter(t *testing.T) {\n\twireInner(t)",
+			why:    "Test → wireOuter → wireInner → the contract; a one-hop-only reachability walk would miss it",
+			files: map[string]string{
+				"x_test.go": `package shape
+
+import (
+	"testing"
+
+	"` + corpusContractPkg + `"
+)
+
+func TestReceiver(t *testing.T) { wireOuter(t) }
+
+func wireOuter(t *testing.T) {
+	wireInner(t)
+}
+
+func wireInner(t *testing.T) {
+	contracttesting.AssertHookPathConfined(t, nil)
+}
+`,
+			},
+		},
+		{
+			dir:    "method_hop",
+			want:   map[string]verdict{epConfined: wantCalled},
+			needle: "func (f *fixture) wire(t *testing.T)",
+			why:    "the hop is a METHOD, whose call resolves through info.Uses on the selector rather than on a bare ident",
+			files: map[string]string{
+				"x_test.go": `package shape
+
+import (
+	"testing"
+
+	"` + corpusContractPkg + `"
+)
+
+type fixture struct{}
+
+func (f *fixture) wire(t *testing.T) {
+	contracttesting.AssertHookPathConfined(t, nil)
+}
+
+func TestReceiver(t *testing.T) {
+	f := &fixture{}
+	f.wire(t)
+}
+`,
+			},
+		},
+		{
+			dir:    "aliased_import",
+			want:   map[string]verdict{epConfined: wantCalled},
+			needle: `ct "` + corpusContractPkg + `"`,
+			why: "the import is aliased, so the source never contains the string " +
+				"\"contracttesting.AssertHookPathConfined\" — a grep-based rule reports this adapter as unwired",
+			files: map[string]string{
+				"x_test.go": `package shape
+
+import (
+	"testing"
+
+	ct "` + corpusContractPkg + `"
+)
+
+func TestReceiver(t *testing.T) {
+	ct.AssertHookPathConfined(t, nil)
+}
+`,
+			},
+		},
+		{
+			dir:    "external_test_package",
+			want:   map[string]verdict{epConfined: wantCalled},
+			needle: "package shape_test",
+			why:    "the wiring lives in the external test package, a separate types.Package from the one under test",
+			files: map[string]string{
+				"doc.go": "package shape\n",
+				"x_test.go": `package shape_test
+
+import (
+	"testing"
+
+	"` + corpusContractPkg + `"
+)
+
+func TestReceiver(t *testing.T) {
+	contracttesting.AssertHookPathConfined(t, nil)
+}
+`,
+			},
+		},
+		{
+			dir:    "cross_variant",
+			want:   map[string]verdict{epConfined: wantCalled},
+			needle: "shape.WireIt(t)",
+			why: "the chain CROSSES variants: an external test package calls a helper declared in an " +
+				"in-package _test.go. Scanning the two variants separately breaks this edge",
+			files: map[string]string{
+				"doc.go": "package shape\n",
+				"helper_test.go": `package shape
+
+import (
+	"testing"
+
+	"` + corpusContractPkg + `"
+)
+
+func WireIt(t *testing.T) {
+	contracttesting.AssertHookPathConfined(t, nil)
+}
+`,
+				"x_test.go": `package shape_test
+
+import (
+	"testing"
+
+	"` + corpusModule + `/` + corpusCasesDir + `/cross_variant"
+)
+
+func TestReceiver(t *testing.T) {
+	shape.WireIt(t)
+}
+`,
+			},
+		},
+		{
+			dir:    "helper_in_non_test_file",
+			want:   map[string]verdict{epConfined: wantCalled},
+			needle: "// non-test file",
+			why: "the helper is in an ordinary .go file. It still EXECUTES when a Test calls it, so " +
+				"restricting call sites to _test.go would under-credit a real wiring",
+			files: map[string]string{
+				"helper.go": `// non-test file
+package shape
+
+import (
+	"testing"
+
+	"` + corpusContractPkg + `"
+)
+
+func WireIt(t *testing.T) {
+	contracttesting.AssertHookPathConfined(t, nil)
+}
+`,
+				"x_test.go": `package shape
+
+import "testing"
+
+func TestReceiver(t *testing.T) { WireIt(t) }
+`,
+			},
+		},
+		{
+			dir:       "benchmark_root",
+			want:      map[string]verdict{epConfined: wantCalled},
+			wantRoots: intp(1),
+			needle:    "func BenchmarkReceiver(b *testing.B)",
+			why:       "a Benchmark is also run by the go tool, so it is a root; pinned with wantRoots so the root rule itself is under test",
+			files: map[string]string{
+				"x_test.go": `package shape
+
+import (
+	"testing"
+
+	"` + corpusContractPkg + `"
+)
+
+func BenchmarkReceiver(b *testing.B) {
+	wire(b)
+}
+
+func wire(tb testing.TB) {
+	_ = tb
+	contracttesting.AssertHookPathConfined(nil, nil)
+}
+`,
+			},
+		},
+		{
+			dir: "partial_wiring",
+			want: map[string]verdict{
+				epConfined: wantCalled,
+				// epDisclosure deliberately unlisted → must be absent.
+			},
+			needle: "AssertHookPathConfined",
+			why: "one family wired and the other not. Without this row a detector that answered " +
+				"\"some contract was called\" would satisfy every other case in the corpus",
+			files: map[string]string{
+				"x_test.go": `package shape
+
+import (
+	"testing"
+
+	"` + corpusContractPkg + `"
+)
+
+func TestReceiver(t *testing.T) {
+	contracttesting.AssertHookPathConfined(t, nil)
+}
+`,
+			},
+		},
+
+		// ---------- must not credit ----------
+		{
+			dir:    "only_in_a_comment",
+			want:   map[string]verdict{}, // both absent
+			needle: "//\tcontracttesting.AssertHookPathConfined(t, nil)",
+			why: "#1740's first stated worry about a static walk: the name appears ONLY in a comment. " +
+				"A comment is not an ast.CallExpr, so an AST walk cannot be satisfied by one",
+			files: map[string]string{
+				"x_test.go": `package shape
+
+import "testing"
+
+// TestReceiver would wire the contract like this:
+//
+//	contracttesting.AssertHookPathConfined(t, nil)
+//
+// but it does not.
+func TestReceiver(t *testing.T) {
+	_ = t
+}
+`,
+			},
+		},
+		{
+			dir:    "in_a_string_literal",
+			want:   map[string]verdict{},
+			needle: `t.Skip("TODO: wire contracttesting.AssertHookPathConfined")`,
+			why:    "the same worry one spelling over — a TODO string, a skip reason, a doc table",
+			files: map[string]string{
+				"x_test.go": `package shape
+
+import "testing"
+
+func TestReceiver(t *testing.T) {
+	t.Skip("TODO: wire contracttesting.AssertHookPathConfined")
+}
+`,
+			},
+		},
+		{
+			dir:    "referenced_not_called",
+			want:   map[string]verdict{},
+			needle: "var _ = contracttesting.AssertHookPathConfined",
+			why: "a reference that executes nothing — at file scope and again inside the Test. Requiring a " +
+				"CallExpr is what keeps a compile-time nod from counting as a wiring",
+			files: map[string]string{
+				"x_test.go": `package shape
+
+import (
+	"testing"
+
+	"` + corpusContractPkg + `"
+)
+
+var _ = contracttesting.AssertHookPathConfined
+
+func TestReceiver(t *testing.T) {
+	f := contracttesting.AssertHookPathConfined
+	_ = f
+}
+`,
+			},
+		},
+		{
+			dir:    "locally_shadowed",
+			want:   map[string]verdict{},
+			needle: "func AssertHookPathConfined(t *testing.T, r any)",
+			why: "MUST NOT FIRE: a helper declared in the adapter's own test package with the same NAME. " +
+				"A name-based rule credits it; resolving the callee's package does not",
+			files: map[string]string{
+				"x_test.go": `package shape
+
+import "testing"
+
+func AssertHookPathConfined(t *testing.T, r any) { _ = t; _ = r }
+
+func TestReceiver(t *testing.T) {
+	AssertHookPathConfined(t, nil)
+}
+`,
+			},
+		},
+		{
+			dir:    "dead_helper",
+			want:   map[string]verdict{epConfined: wantUnreached},
+			needle: "func wireHookPathConfined(t *testing.T)",
+			why: "#1740's second stated worry: the wiring is real code in a real file, and nothing runs it. " +
+				"Reported as UNREACHED rather than absent so the failure says re-attach it, not re-write it",
+			files: map[string]string{
+				"x_test.go": `package shape
+
+import (
+	"testing"
+
+	"` + corpusContractPkg + `"
+)
+
+func wireHookPathConfined(t *testing.T) {
+	contracttesting.AssertHookPathConfined(t, nil)
+}
+
+func TestSomethingElse(t *testing.T) {
+	_ = t
+}
+`,
+			},
+		},
+		{
+			dir:       "no_test_functions_at_all",
+			want:      map[string]verdict{epConfined: wantUnreached},
+			wantRoots: intp(0),
+			needle:    "func wireHookPathConfined(t *testing.T)",
+			why: "the vacuity condition the tripwire fatals on: a test file with no go-test entry function. " +
+				"Roots must read 0, so 'nothing is wired' and 'nothing could be reached' stay distinguishable",
+			files: map[string]string{
+				"x_test.go": `package shape
+
+import (
+	"testing"
+
+	"` + corpusContractPkg + `"
+)
+
+func wireHookPathConfined(t *testing.T) {
+	contracttesting.AssertHookPathConfined(t, nil)
+}
+`,
+			},
+		},
+		{
+			dir:       "lowercase_after_prefix",
+			want:      map[string]verdict{epConfined: wantUnreached},
+			wantRoots: intp(0),
+			needle:    "func Testify(t *testing.T)",
+			why: "cmd/go does NOT run Testify: the rune after the prefix is lowercase. Treating it as a root " +
+				"would credit a wiring the go tool never executes",
+			files: map[string]string{
+				"x_test.go": `package shape
+
+import (
+	"testing"
+
+	"` + corpusContractPkg + `"
+)
+
+func Testify(t *testing.T) {
+	contracttesting.AssertHookPathConfined(t, nil)
+}
+`,
+			},
+		},
+
+		// ---------- declared limits ----------
+		{
+			dir:    "skipped_test",
+			want:   map[string]verdict{epConfined: wantCalled},
+			limit:  true,
+			needle: `t.Skip("upstream CLI not installed")`,
+			why: "LIMIT, over-crediting: reachability here is syntactic and does not evaluate, so a test that " +
+				"skips before it reaches the contract still counts as wired. The DIRECTORY NAME is load-bearing " +
+				"too — it ends in _test, and this row is what caught testVariantUnitsByPackage recovering the " +
+				"package under test by trimming that suffix off PkgPath instead of reading the variant tag",
+			files: map[string]string{
+				"x_test.go": `package shape
+
+import (
+	"testing"
+
+	"` + corpusContractPkg + `"
+)
+
+func TestReceiver(t *testing.T) {
+	t.Skip("upstream CLI not installed")
+	contracttesting.AssertHookPathConfined(t, nil)
+}
+`,
+			},
+		},
+		{
+			dir:    "guarded_by_constant_false",
+			want:   map[string]verdict{epConfined: wantCalled},
+			limit:  true,
+			needle: "if false {",
+			why:    "LIMIT, over-crediting: the same non-evaluation one spelling over",
+			files: map[string]string{
+				"x_test.go": `package shape
+
+import (
+	"testing"
+
+	"` + corpusContractPkg + `"
+)
+
+func TestReceiver(t *testing.T) {
+	if false {
+		contracttesting.AssertHookPathConfined(t, nil)
+	}
+}
+`,
+			},
+		},
+		{
+			dir:    "value_then_called",
+			want:   map[string]verdict{},
+			limit:  true,
+			needle: "confine := contracttesting.AssertHookPathConfined",
+			why: "LIMIT, under-crediting (fail-closed): the entry point is taken as a VALUE and called through " +
+				"a variable, so the call expression names a types.Var and resolves to no function. This is the " +
+				"price of requiring a CallExpr, which is what makes referenced_not_called above come back absent",
+			files: map[string]string{
+				"x_test.go": `package shape
+
+import (
+	"testing"
+
+	"` + corpusContractPkg + `"
+)
+
+func TestReceiver(t *testing.T) {
+	confine := contracttesting.AssertHookPathConfined
+	confine(t, nil)
+}
+`,
+			},
+		},
+		{
+			dir:    "package_var_func_literal",
+			want:   map[string]verdict{},
+			limit:  true,
+			needle: "var wire = func(t *testing.T) {",
+			why: "LIMIT, under-crediting (fail-closed): the literal's body hangs off a ValueSpec, not a " +
+				"FuncDecl, so the walk never enters it and the wiring is reported missing. Same declared limit " +
+				"contracttesting/seam_walk_corpus_test.go pins for its own walk. Loud, not silent",
+			files: map[string]string{
+				"x_test.go": `package shape
+
+import (
+	"testing"
+
+	"` + corpusContractPkg + `"
+)
+
+var wire = func(t *testing.T) {
+	contracttesting.AssertHookPathConfined(t, nil)
+}
+
+func TestReceiver(t *testing.T) {
+	wire(t)
+}
+`,
+			},
+		},
+	}
+}
+
+func TestContractWiringDetectorCatchesEveryKnownShape(t *testing.T) {
+	shapes := wiringShapes()
+	if len(shapes) == 0 {
+		t.Fatal("the corpus is empty; this test would pass having pinned nothing")
+	}
+	dir := writeWiringCorpus(t, shapes)
+	byCase := loadWiringCorpus(t, dir, shapes)
+
+	want := []string{epConfined, epDisclosure}
+	for _, shape := range shapes {
+		units := byCase[shape.dir]
+		if len(units) == 0 {
+			t.Fatalf("case %s: the corpus load returned no test-variant files for it — every "+
+				"verdict below would be about nothing", shape.dir)
+		}
+		scan := scanContractWirings(units, corpusContractPkg, want)
+		if scan.TestFiles == 0 {
+			t.Fatalf("case %s: detector walked 0 _test.go files (%s)", shape.dir, describeScan(scan))
+		}
+		if shape.wantRoots != nil && scan.Roots != *shape.wantRoots {
+			t.Errorf("case %s: detector found %d go-test entry function(s), want %d (%s)\n\twhy this case exists: %s",
+				shape.dir, scan.Roots, *shape.wantRoots, describeScan(scan), shape.why)
+		}
+		for _, ep := range want {
+			got := verdictFor(scan, ep)
+			expect := shape.want[ep] // zero value is wantAbsent
+			if got == expect {
+				continue
+			}
+			t.Errorf("case %s: detector reports %s = %s, want %s (%s)\n\twhy this case exists: %s%s",
+				shape.dir, ep, got, expect, describeScan(scan), shape.why, limitNote(shape))
+		}
+	}
+}
+
+func limitNote(c wiringCase) string {
+	if !c.limit {
+		return ""
+	}
+	return "\n\tNOTE: this row pins a DECLARED LIMIT — the verdict above is a known wrong answer, " +
+		"recorded so it is learned from a test rather than from an incident. If a rewrite changed it, " +
+		"that may be an improvement; update the row deliberately."
+}
+
+func verdictFor(s wiringScan, ep string) verdict {
+	if _, ok := s.Called[ep]; ok {
+		return wantCalled
+	}
+	if _, ok := s.Unreached[ep]; ok {
+		return wantUnreached
+	}
+	return wantAbsent
+}
+
+// writeWiringCorpus materializes the corpus as a self-contained module and
+// asserts every planted shape actually landed in its own sources.
+func writeWiringCorpus(t *testing.T, shapes []wiringCase) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	mustWriteCorpusFile(t, filepath.Join(dir, "go.mod"), "module "+corpusModule+"\n\ngo 1.25\n")
+	stub := filepath.Join(dir, "contracttesting")
+	if err := os.MkdirAll(stub, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", stub, err)
+	}
+	mustWriteCorpusFile(t, filepath.Join(stub, "stub.go"), stubSource)
+
+	seen := map[string]bool{}
+	for _, shape := range shapes {
+		if seen[shape.dir] {
+			t.Fatalf("duplicate case dir %q — one case would silently overwrite the other", shape.dir)
+		}
+		seen[shape.dir] = true
+		assertPlantedWiringPresent(t, shape)
+
+		caseDir := filepath.Join(dir, corpusCasesDir, shape.dir)
+		if err := os.MkdirAll(caseDir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", caseDir, err)
+		}
+		for name, src := range shape.files {
+			mustWriteCorpusFile(t, filepath.Join(caseDir, name), src)
+		}
+	}
+	return dir
+}
+
+// assertPlantedWiringPresent is the guard against a corpus that has quietly
+// stopped containing what it claims to. A case whose needle is missing proves
+// nothing, and would read as a pass for every wantAbsent row.
+//
+// It also enforces the two structural preconditions a case cannot be
+// meaningful without: at least one file, and at least one _test.go among them.
+func assertPlantedWiringPresent(t *testing.T, c wiringCase) {
+	t.Helper()
+
+	if c.needle == "" {
+		t.Fatalf("case %s declares no needle; every case must assert the construct it plants is present", c.dir)
+	}
+	if c.why == "" {
+		t.Fatalf("case %s declares no reason; a row nobody can justify is a row nobody can delete safely", c.dir)
+	}
+	if len(c.files) == 0 {
+		t.Fatalf("case %s declares no files", c.dir)
+	}
+	tests := 0
+	joined := ""
+	for name, src := range c.files {
+		if strings.HasSuffix(name, "_test.go") {
+			tests++
+		}
+		joined += src
+	}
+	if tests == 0 {
+		t.Fatalf("case %s has no _test.go file; it would exercise the detector's file filter rather "+
+			"than the shape it claims to test", c.dir)
+	}
+	if !strings.Contains(joined, c.needle) {
+		t.Fatalf("case %s does not contain its own needle %q — the case is not testing what it says it tests",
+			c.dir, c.needle)
+	}
+}
+
+// loadWiringCorpus type-checks the corpus and returns each case's test-variant
+// files, keyed by case dir.
+func loadWiringCorpus(t *testing.T, dir string, shapes []wiringCase) map[string][]sourceUnit {
+	t.Helper()
+
+	cfg := &packages.Config{
+		Mode: packages.NeedName | packages.NeedSyntax |
+			packages.NeedTypes | packages.NeedTypesInfo,
+		Tests: true,
+		Dir:   dir,
+		// GOWORK=off: the corpus is a standalone module in a temp dir, and an
+		// inherited workspace would try to resolve it against this repo's.
+		Env: append(os.Environ(), "GOWORK=off"),
+	}
+	pkgs, err := packages.Load(cfg, "./"+corpusCasesDir+"/...")
+	if err != nil {
+		t.Fatalf("packages.Load(corpus): %v", err)
+	}
+	if n := packages.PrintErrors(pkgs); n > 0 {
+		t.Fatalf("the corpus does not build (%d error(s)) — without TypesInfo the detector resolves "+
+			"no callee at all and every wantAbsent row would pass for the wrong reason", n)
+	}
+
+	prefix := corpusModule + "/" + corpusCasesDir + "/"
+	byCase := map[string][]sourceUnit{}
+	for under, units := range testVariantUnitsByPackage(t, pkgs) {
+		name, ok := strings.CutPrefix(under, prefix)
+		if !ok {
+			t.Fatalf("corpus load returned an unexpected package %q", under)
+		}
+		byCase[name] = units
+	}
+
+	// The corpus is only worth what it loaded. A case that silently failed to
+	// materialize would be reported by the per-case guard in the driver, but
+	// naming the whole set here makes a wholesale load failure legible in one
+	// line instead of N.
+	var missing []string
+	for _, shape := range shapes {
+		if len(byCase[shape.dir]) == 0 {
+			missing = append(missing, shape.dir)
+		}
+	}
+	if len(missing) > 0 {
+		slices.Sort(missing)
+		t.Fatalf("the corpus load produced no test-variant files for %d case(s): %s",
+			len(missing), strings.Join(missing, ", "))
+	}
+	return byCase
+}
+
+func mustWriteCorpusFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}

--- a/core/adapters/inbound/agents/hookcontracts_test.go
+++ b/core/adapters/inbound/agents/hookcontracts_test.go
@@ -399,7 +399,7 @@ func assertExclusionsStillHold(t *testing.T, excluded map[string]string, wiredEv
 	}
 }
 
-// assertExclusionsAreWellFormed checks notYetRequired()'s keys the way
+// assertExclusionsAreWellFormed checks unenforceableHere()'s keys the way
 // requiredWirings()' are checked: the name must exist in contracttesting, and it
 // must not also be required. An exemption naming something that does not exist,
 // or contradicting the requirement table, is worse than no exemption at all —
@@ -414,11 +414,11 @@ func assertExclusionsAreWellFormed(t *testing.T, pkgs []*packages.Package, requi
 	}
 	for _, name := range slices.Sorted(maps.Keys(excluded)) {
 		if excluded[name] == "" {
-			t.Fatalf("notYetRequired()[%q] carries no reason; an exclusion nobody can justify is "+
+			t.Fatalf("unenforceableHere()[%q] carries no reason; an exclusion nobody can justify is "+
 				"one nobody can safely delete", name)
 		}
 		if scope.Lookup(name) == nil {
-			t.Fatalf("notYetRequired() excludes contracttesting.%s, which %s does not declare — the "+
+			t.Fatalf("unenforceableHere() excludes contracttesting.%s, which %s does not declare — the "+
 				"entry stopped naming a real thing and now excludes nothing",
 				name, contracttestingPkg)
 		}

--- a/core/adapters/inbound/agents/hookcontracts_test.go
+++ b/core/adapters/inbound/agents/hookcontracts_test.go
@@ -1,0 +1,766 @@
+// hookcontracts_test.go is the registry-wide tripwire for issue #1740: an
+// adapter that installs hooks into a user's config and receives them on the
+// daemon's local, unauthenticated port must WIRE the contract families that
+// grade those two acts, and until this file existed nothing said so.
+//
+// # The gap
+//
+// docs/testing-contracts.md names the hazard inside the path-confinement
+// bullet, and it is general to every family:
+//
+//	a contract can fail only for an adapter that WIRED it, so a receiver
+//	nobody wired it for is invisible to it — which is how the statusline
+//	endpoint shipped unconfined in the first place.
+//
+// Two obligations over hooks-declaring adapters are already immune to it,
+// because what they ask for is a struct FIELD an adapter declares in
+// production code: TestEveryHookInstallDeclaresAVerifier (#1372) and
+// TestEveryHookInstallDeclaresAVersionFloor (#1365) both walk All() and fail
+// for an adapter that omitted the declaration, before that adapter has a test
+// of its own.
+//
+// The families in requiredWirings() below have no field to walk. They are
+// wired as a TEST CALL in the adapter's own test package, so their only
+// enforcement was that whoever added the adapter remembered to copy an
+// existing adapter's test files. "Harder to detect" is not "less important":
+// the three #1740 was filed about are the ones whose absence is least visible
+// in production — an unconfined caller-supplied path (#1361/#1389), entries
+// pointing at a dead port with the permission still reading granted (#1178),
+// and content written to a user's config that the consent copy never named
+// (#1356/#570).
+//
+// # Which option this is, and what was rejected
+//
+// #1740 sketched two, a static walk and a registration seam, and called the
+// seam stronger because it grades what actually EXECUTED rather than what is
+// textually present. The seam was investigated and rejected on a fact about
+// the go tool, not on cost:
+//
+//   - A registration seam means contracttesting.AssertX records "I ran for
+//     adapter P", and a registry-walking test asserts the recorded set covers
+//     every hooks-declaring adapter. But `go test ./core/...` compiles ONE
+//     TEST BINARY PER PACKAGE. The recorder would run in six adapter processes
+//     and the asserting test in a seventh, so in-process state cannot reach it.
+//
+//   - Carrying it across processes means a file. That file is a cache, and it
+//     is a cache the reader cannot validate: a stale entry from an earlier run
+//     makes a wiring someone has since DELETED read as covered, which is the
+//     precise failure mode #1740 exists to end, reintroduced with a longer
+//     half-life. Nothing in the reader can distinguish "P registered during
+//     this invocation" from "P registered last Tuesday" — `go test` gives the
+//     asserting binary no roster of which sibling packages ran, and the go
+//     build cache legitimately skips re-running an unchanged package's tests,
+//     so "P did not register" is also the ordinary answer for a cached pass.
+//     A seam that is wrong in the green direction on a stale file and wrong in
+//     the red direction on a cache hit is not stronger than a static walk; it
+//     is a worse oracle wearing an execution-grading label.
+//
+//   - The remaining way to genuinely grade execution is to invert: have ONE
+//     package construct every adapter's receiver and installer and run the
+//     contracts itself. That requires each adapter to declare its test fixture
+//     — a handler, a confiner, roots, a payload builder — in PRODUCTION code,
+//     which is the API smell #1390 removed rather than tested ("a contract
+//     that grows a sub-test to police an API the same PR invented is a signal
+//     to remove the API"). Not taken.
+//
+// So: the static walk, with its limits stated below rather than implied, and
+// built to be worth more than the grep #1740 assumed a static walk would be.
+// It is an AST + type walk, not a text match, which removes both weaknesses
+// the issue named:
+//
+//   - A reference in a COMMENT is not an AST node, so it cannot satisfy this.
+//   - A DEAD test cannot satisfy it either: a call must be reachable, through
+//     package-local calls, from a function `go test` actually runs. A helper
+//     nothing calls is reported separately (Unreached), so the failure says
+//     "you have a dead wiring" rather than "you have nothing".
+//
+// It is also stronger than a grep in the other direction — it resolves the
+// callee's TYPE, so `import ct "…/contracttesting"; ct.AssertHookPathConfined`
+// counts (a grep for "contracttesting.AssertHookPathConfined" would not), and
+// a local helper that merely shares the NAME does not.
+//
+// # What it does NOT cover
+//
+// Stated here rather than left to be discovered, and pinned as executable
+// corpus rows in hookcontracts_shapes_test.go wherever a row can express it:
+//
+//   - PACKAGE GRANULARITY. It asks whether the adapter's test package wires a
+//     family, never which RECEIVER inside that package was wired. claudecode
+//     hosts two receivers — hooks and statusline — and #1361's incident was
+//     the second one. A claudecode that wired AssertHookPathConfined for its
+//     hook receiver and not its statusline receiver passes here. That is the
+//     original bug, and this walk does not close it; hookjson.DecodeConfined
+//     plus core/architecture_hookbody_test.go do, by making an unconfined body
+//     read fail to build.
+//   - A test that is SKIPPED (t.Skip) or a call guarded by a constant false
+//     condition still counts. Reachability here is syntactic; it does not
+//     evaluate.
+//   - A wiring reached through a func literal held in a PACKAGE-LEVEL VAR is
+//     NOT seen, because the literal's body hangs off a ValueSpec rather than a
+//     FuncDecl. That direction is fail-closed — it reports a real wiring as
+//     missing, which is loud — and it is the same declared limit
+//     contracttesting/seam_walk_corpus_test.go pins for its own walk.
+//   - A wiring reached through a helper in ANOTHER package (other than the
+//     adapter's own external test package, which is merged in) is not seen.
+//     Fail-closed again.
+//   - An entry point taken as a VALUE and called later (`f :=
+//     contracttesting.AssertX; f(t, r)`) is not seen. Fail-closed. Requiring a
+//     call expression is what makes `var _ = contracttesting.AssertX` — a
+//     reference that executes nothing — not count.
+//   - It cannot say the wiring is CORRECT. That is what the contract families
+//     themselves are for; this only says one is present and runs.
+package agents
+
+import (
+	"fmt"
+	"go/ast"
+	"go/token"
+	"go/types"
+	"maps"
+	"reflect"
+	"runtime"
+	"slices"
+	"strings"
+	"testing"
+	"unicode"
+	"unicode/utf8"
+
+	"golang.org/x/tools/go/packages"
+
+	"irrlicht/core/domain/agent"
+)
+
+// contracttestingPkg is the package whose exported entry points a hooks
+// adapter must call. Spelled as a string rather than reached through an import
+// for the same reason architecture_hookbody_test.go spells its chokepoint out:
+// this file must be able to REPORT that the package or a function moved, and a
+// rule that resolved the symbol would stop compiling instead — a worse failure
+// mode for a guard whose job is to stay legible when the thing it guards
+// breaks. assertRequiredWiringsExist turns that string back into a checked
+// fact on every run.
+const contracttestingPkg = "irrlicht/core/internal/contracttesting"
+
+// adapterTreePrefix is the import path every adapter package lives under. Used
+// only to sanity-check a derived package path, so a declaration composed out of
+// some shared helper cannot silently redirect the walk at a package that holds
+// no adapter's tests.
+const adapterTreePrefix = "irrlicht/core/adapters/inbound/agents/"
+
+// requiredWiring is one contracttesting entry point every hooks-declaring
+// adapter must call from its own test package.
+//
+// Why is not decoration. A row here costs a future adapter author real work,
+// so each states what the family's ABSENCE looks like in production — which is
+// the argument for demanding it, and the thing to re-read before deleting a
+// row.
+type requiredWiring struct {
+	Fn     string
+	Family string
+	Why    string
+}
+
+// requiredWirings is the set. Seven rows, and every hooks-declaring adapter in
+// the tree satisfies all seven the day this landed — which is exactly the
+// condition the mutation rule in docs/testing-philosophy.md exists for, and why
+// hookcontracts_shapes_test.go commits the detector's discriminating cases
+// rather than leaving the evidence in a PR body.
+//
+// #1740 names the first three. The other four have the identical shape — wired
+// as a test call, enforced by nothing — and were found by measuring rather than
+// assumed: every one of the six hooks-declaring adapters already wires all
+// seven, so including them costs nothing today and covers four more families
+// tomorrow. Reproduce that measurement with:
+//
+//	for f in $(grep -ho 'Assert[A-Za-z]*' core/internal/contracttesting/*.go | sort -u); do …
+//
+// or, more simply, by deleting a row and watching this test stay green.
+func requiredWirings() []requiredWiring {
+	return []requiredWiring{
+		{
+			Fn:     "AssertHookPathConfined",
+			Family: "hook path confinement (#1361, #1389)",
+			Why: "the transcript_path in an inbound hook body is caller-supplied on a local " +
+				"unauthenticated endpoint; unwired, a receiver can forward it unconfined and " +
+				"anything downstream opens whatever the caller named",
+		},
+		{
+			Fn:     "AssertHookEndpointFollowsBindAddr",
+			Family: "hook endpoint follows bind addr (#1178, #1453)",
+			Why: "unwired, an install can write a hardcoded :7837 into the user's real config " +
+				"and leave it pointing at a dead port with the permission still reading granted",
+		},
+		{
+			Fn:     "AssertHookDisclosureMatchesInstalled",
+			Family: "hook disclosure matches installed (#1356, #570)",
+			Why: "the consent copy IS the #570 contract; unwired, entries land in the user's " +
+				"config that the text they consented to never named",
+		},
+		{
+			Fn:     "AssertHookVersionGate",
+			Family: "hook version floors (#1365)",
+			Why: "TestEveryHookInstallDeclaresAVersionFloor proves a floor is DECLARED and " +
+				"parseable; only this proves the declared floor actually refuses a CLI one " +
+				"patch below itself, with a reason naming both versions",
+		},
+		{
+			Fn:     "AssertUnknownHookEventObserved",
+			Family: "unrecognized hook events (#1364)",
+			Why: "unwired, an upstream event rename is answered 200 and dispatched nowhere, " +
+				"with the permission green and nothing anywhere to look at",
+		},
+		{
+			Fn:     "AssertHookReceiptObserved",
+			Family: "hook receipts (#1368)",
+			Why: "unwired, a working receiver that forgets ObserveHookReceipt is DEMOTED by " +
+				"the liveness watchdog — the one receiving-side failure that is a false " +
+				"accusation rather than a silence",
+		},
+		{
+			Fn:     "AssertHookReceiverPermissionGated",
+			Family: "hook receiver permission gating (#1475, #1488)",
+			Why: "unwired, nothing grades the receiver against its own declared permission " +
+				"set; copilot's receiver reached #1475 with no wiring at all",
+		},
+	}
+}
+
+// hookInstall is one hooks-declaring permission and the Go package that
+// declared it.
+type hookInstall struct {
+	Adapter string
+	Key     string
+	Pkg     string
+}
+
+func TestEveryHookInstallWiresItsContractFamilies(t *testing.T) {
+	installs := hookInstallingAdapters(t)
+	required := requiredWirings()
+
+	patterns := []string{contracttestingPkg}
+	for _, in := range installs {
+		patterns = append(patterns, in.Pkg)
+	}
+	pkgs := loadForWiringScan(t, patterns)
+
+	assertRequiredWiringsExist(t, pkgs, required)
+
+	units := testVariantUnitsByPackage(t, pkgs)
+	want := make([]string, 0, len(required))
+	for _, r := range required {
+		want = append(want, r.Fn)
+	}
+
+	for _, in := range installs {
+		u := units[in.Pkg]
+		if len(u) == 0 {
+			t.Fatalf("%s/%s declares a hook install in package %q, but the load returned no "+
+				"test variant of that package — this walk would report every family missing "+
+				"for a reason that has nothing to do with the adapter",
+				in.Adapter, in.Key, in.Pkg)
+		}
+		scan := scanContractWirings(u, contracttestingPkg, want)
+		// Two vacuity guards, because "found no wiring" and "read nothing" must
+		// not produce the same output. Fatal rather than Errorf: with either of
+		// these true every row below fails for the same wrong reason, and seven
+		// misleading failures per adapter buries the one line that explains them.
+		if scan.TestFiles == 0 {
+			t.Fatalf("%s: walked 0 _test.go files in %q — the scan read no test source at all, "+
+				"so any verdict about its wirings is about nothing", in.Adapter, in.Pkg)
+		}
+		if scan.Roots == 0 {
+			t.Fatalf("%s: found no go-test entry function (Test…/Benchmark…/Fuzz…) in %q across "+
+				"%d test file(s) — every wiring would be reported unreachable for that reason "+
+				"rather than for being absent", in.Adapter, in.Pkg, scan.TestFiles)
+		}
+		for _, r := range required {
+			if _, ok := scan.Called[r.Fn]; ok {
+				continue
+			}
+			if pos, ok := scan.Unreached[r.Fn]; ok {
+				t.Errorf("%s (%s) calls contracttesting.%s at %s, but nothing `go test` runs "+
+					"reaches that call — %s.\n\tA wiring in a helper no Test function calls is a "+
+					"wiring that never executes (issue #1740).",
+					in.Adapter, in.Pkg, r.Fn, pos, r.Family)
+				continue
+			}
+			t.Errorf("%s (%s) installs hooks (%s) but its test package never calls "+
+				"contracttesting.%s — the %s contract is unenforced for this adapter.\n"+
+				"\tWhy it is required: %s.\n"+
+				"\tWire it: copy the corresponding *_test.go from an adapter that already does "+
+				"(`git grep -l %s core/adapters/inbound/agents/`) and point it at this adapter's "+
+				"own receiver/installer. A contract can only fail for an adapter that wired it "+
+				"(issue #1740).",
+				in.Adapter, in.Pkg, in.Key, r.Fn, r.Family, r.Why, r.Fn)
+		}
+	}
+}
+
+// hookInstallingAdapters projects All() onto the hooks permissions, resolving
+// each to the Go package that declared it.
+//
+// Scoped to HooksPermissionKey for the same reason the verifier and version
+// tripwires are: since #1383 the Writes declaration covers every managed user
+// file, and these seven families are obligations of installing into an agent's
+// OWN config format and receiving what it then sends.
+func hookInstallingAdapters(t *testing.T) []hookInstall {
+	t.Helper()
+
+	all := All()
+	if len(all) == 0 {
+		t.Fatal("All() returned no adapters — this tripwire would report a clean sweep of an " +
+			"empty registry, which is the exact shape of failure it exists to prevent")
+	}
+
+	var out []hookInstall
+	for _, a := range all {
+		for _, p := range a.Permissions {
+			if p.Writes == nil || p.Key != agent.HooksPermissionKey {
+				continue
+			}
+			out = append(out, hookInstall{
+				Adapter: a.Identity.Name,
+				Key:     p.Key,
+				Pkg:     declaringPackage(t, a.Identity.Name, p),
+			})
+		}
+	}
+	if len(out) == 0 {
+		t.Fatalf("no adapter in the registry declares a %q permission with a managed user file, "+
+			"across %d adapter(s). Either every hook install was removed, or this projection has "+
+			"stopped matching — and a green run of this test would mean the same thing in both "+
+			"cases", agent.HooksPermissionKey, len(all))
+	}
+	return out
+}
+
+// declaringPackage recovers the Go package that declared a permission, from the
+// closures on the permission itself.
+//
+// Derived rather than looked up in a hand-written adapter-name → directory map,
+// because such a map is one more thing a new adapter is covered by only if
+// someone remembers to edit it — which is the failure #1740 is about, one level
+// up. (agent.Identity.Name does not answer it either: "claude-code" is package
+// claudecode, "mistral-vibe" is package vibe.)
+//
+// Apply and Uninstall must AGREE. Both are inherently adapter-specific — the
+// closure that writes this agent's config format and the one that removes it —
+// so a disagreement means the declaration was composed out of shared helpers
+// and there is no single package whose tests this walk should be reading. That
+// is a loud stop, not a skip: silently walking whichever package won would
+// grade the wrong tree and report a clean result about it.
+func declaringPackage(t *testing.T, adapter string, p agent.Permission) string {
+	t.Helper()
+
+	applyPkg, okApply := funcPackagePath(p.Apply)
+	if !okApply {
+		t.Fatalf("%s/%s: cannot resolve the package of its Apply closure (Apply is nil or not a "+
+			"Go func) — TestEveryHookInstallDeclaresAVerifier requires a hooks permission to have "+
+			"one, so this is a broken declaration rather than a limit of this walk",
+			adapter, p.Key)
+	}
+	uninstallPkg, okUninstall := funcPackagePath(p.Writes.Uninstall)
+	if !okUninstall {
+		t.Fatalf("%s/%s: cannot resolve the package of its Writes.Uninstall closure — "+
+			"ManagedUserFiles requires a non-nil Uninstall, so this is a broken declaration",
+			adapter, p.Key)
+	}
+	if applyPkg != uninstallPkg {
+		t.Fatalf("%s/%s: Apply is declared in %q but Writes.Uninstall in %q. This walk derives the "+
+			"adapter's package from its own closures and cannot choose between two; declare both "+
+			"in the adapter package, or teach this test the mapping in a reviewable diff",
+			adapter, p.Key, applyPkg, uninstallPkg)
+	}
+	if !strings.HasPrefix(applyPkg, adapterTreePrefix) || strings.Contains(applyPkg[len(adapterTreePrefix):], "/") {
+		t.Fatalf("%s/%s: resolved declaring package %q, which is not a direct child of %q. A "+
+			"declaration composed by a shared helper points this walk at a package holding no "+
+			"adapter tests, and it would then report that package's (absent) wirings as this "+
+			"adapter's", adapter, p.Key, applyPkg, adapterTreePrefix)
+	}
+	return applyPkg
+}
+
+// funcPackagePath returns the import path of the package that declared fn.
+func funcPackagePath(fn any) (string, bool) {
+	if fn == nil {
+		return "", false
+	}
+	v := reflect.ValueOf(fn)
+	if v.Kind() != reflect.Func || v.IsNil() {
+		return "", false
+	}
+	f := runtime.FuncForPC(v.Pointer())
+	if f == nil {
+		return "", false
+	}
+	return packagePathOfSymbol(f.Name())
+}
+
+// packagePathOfSymbol splits a runtime symbol name — "a/b/c.Fn",
+// "a/b/c.Agent.func1", "a/b/c.(*T).M" — into its package path.
+//
+// The package path is everything up to the first '.' AFTER the last '/'. Doing
+// it the other way round (first '.' in the whole string) is wrong for any
+// hosted path: "github.com/x/y.Fn" would yield "github".
+func packagePathOfSymbol(sym string) (string, bool) {
+	slash := strings.LastIndex(sym, "/")
+	dot := strings.Index(sym[slash+1:], ".")
+	if dot < 0 {
+		return "", false
+	}
+	return sym[:slash+1+dot], true
+}
+
+// sourceUnit is one type-checked set of files the detector walks. An adapter
+// contributes two — its in-package test variant and its external test package —
+// and they are handed over together so a call that crosses between them is an
+// ordinary edge rather than a blind spot.
+type sourceUnit struct {
+	fset *token.FileSet
+	file *ast.File
+	info *types.Info
+}
+
+// wiringScan is the detector's verdict about one adapter's test sources.
+//
+// Called and Unreached are kept apart deliberately. "You never wrote it" and
+// "you wrote it in a helper nothing calls" need different advice, and collapsing
+// them would make the second read as the first — which is how a dead wiring gets
+// re-added instead of re-attached.
+type wiringScan struct {
+	Called    map[string]string // entry point → position of a reachable call
+	Unreached map[string]string // entry point → position of an unreachable call
+	Roots     int               // go-test entry functions found
+	TestFiles int               // _test.go files walked
+}
+
+// scanContractWirings reports which of `want`'s entry points in package
+// contractPkg are called, from the given files, along a chain rooted at a
+// function `go test` runs.
+//
+// A plain function over units rather than a method on anything, so
+// hookcontracts_shapes_test.go can feed it a synthetic corpus and pin, case by
+// case, which spellings it credits — the same shape architecture_hookbody_test.go's
+// requestBodyReadsIn takes, and for the same reason.
+func scanContractWirings(units []sourceUnit, contractPkg string, want []string) wiringScan {
+	wanted := make(map[string]bool, len(want))
+	for _, w := range want {
+		wanted[w] = true
+	}
+
+	scan := wiringScan{Called: map[string]string{}, Unreached: map[string]string{}}
+
+	type callSite struct {
+		fn  string
+		pos string
+	}
+	owner := map[*types.Func][]callSite{} // enclosing func → contract calls inside it
+	edges := map[*types.Func][]*types.Func{}
+	declared := map[*types.Func]bool{}
+	var roots []*types.Func
+
+	seenFiles := map[string]bool{}
+	// Pass 1: index every top-level function so an edge can be recognized as
+	// package-local. Two passes rather than one because a helper is routinely
+	// declared below its caller, and a single pass would drop that edge.
+	for _, u := range units {
+		name := u.fset.Position(u.file.Pos()).Filename
+		if strings.HasSuffix(name, "_test.go") && !seenFiles[name] {
+			seenFiles[name] = true
+			scan.TestFiles++
+		}
+		for _, decl := range u.file.Decls {
+			fd, ok := decl.(*ast.FuncDecl)
+			if !ok || fd.Name == nil {
+				continue
+			}
+			obj, _ := u.info.Defs[fd.Name].(*types.Func)
+			if obj == nil {
+				continue
+			}
+			declared[obj] = true
+			if isGoTestEntry(fd, u.info, name) {
+				roots = append(roots, obj)
+			}
+		}
+	}
+
+	// Pass 2: walk each function body once, recording both kinds of call.
+	for _, u := range units {
+		for _, decl := range u.file.Decls {
+			fd, ok := decl.(*ast.FuncDecl)
+			if !ok || fd.Name == nil || fd.Body == nil {
+				continue
+			}
+			self, _ := u.info.Defs[fd.Name].(*types.Func)
+			if self == nil {
+				continue
+			}
+			ast.Inspect(fd.Body, func(n ast.Node) bool {
+				call, ok := n.(*ast.CallExpr)
+				if !ok {
+					return true
+				}
+				callee := calleeFunc(call.Fun, u.info)
+				if callee == nil {
+					return true
+				}
+				if callee.Pkg() != nil && callee.Pkg().Path() == contractPkg && wanted[callee.Name()] {
+					owner[self] = append(owner[self], callSite{
+						fn:  callee.Name(),
+						pos: u.fset.Position(call.Lparen).String(),
+					})
+				}
+				if declared[callee] {
+					edges[self] = append(edges[self], callee)
+				}
+				return true
+			})
+		}
+	}
+	scan.Roots = len(roots)
+
+	reachable := map[*types.Func]bool{}
+	queue := slices.Clone(roots)
+	for _, r := range queue {
+		reachable[r] = true
+	}
+	for len(queue) > 0 {
+		cur := queue[0]
+		queue = queue[1:]
+		for _, next := range edges[cur] {
+			if reachable[next] {
+				continue
+			}
+			reachable[next] = true
+			queue = append(queue, next)
+		}
+	}
+
+	for fn, sites := range owner {
+		bucket := scan.Unreached
+		if reachable[fn] {
+			bucket = scan.Called
+		}
+		for _, s := range sites {
+			// Lowest position wins, so a failure names the same call every run
+			// regardless of map iteration order.
+			if prev, ok := bucket[s.fn]; !ok || s.pos < prev {
+				bucket[s.fn] = s.pos
+			}
+		}
+	}
+	// A name found reachable somewhere is wired, whatever else is dead.
+	for fn := range scan.Called {
+		delete(scan.Unreached, fn)
+	}
+	return scan
+}
+
+// calleeFunc resolves a call expression's callee to the function it names, or
+// nil for anything that is not a direct call of a declared function (a call
+// through a variable, an interface method, a conversion, a builtin).
+//
+// It resolves through the TYPE information rather than the written name, which
+// is what makes an aliased or dot import count and a local helper that merely
+// shares a name not count.
+func calleeFunc(fun ast.Expr, info *types.Info) *types.Func {
+	var ident *ast.Ident
+	switch f := ast.Unparen(fun).(type) {
+	case *ast.Ident:
+		ident = f
+	case *ast.SelectorExpr:
+		ident = f.Sel
+	default:
+		return nil
+	}
+	fn, _ := info.Uses[ident].(*types.Func)
+	return fn
+}
+
+// isGoTestEntry reports whether fd is a function `go test` will run.
+//
+// It reproduces cmd/go's own rule — the prefix followed by a non-lowercase rune
+// — plus a check on the parameter TYPE, because a helper called
+// TestHelper(t *testing.T) IS run by go test (and is therefore correctly a
+// root), while `Testify(x int)` is not run and must not be treated as one.
+func isGoTestEntry(fd *ast.FuncDecl, info *types.Info, filename string) bool {
+	if !strings.HasSuffix(filename, "_test.go") {
+		return false
+	}
+	if fd.Recv != nil || fd.Name == nil || fd.Body == nil {
+		return false
+	}
+	name := fd.Name.Name
+	var param string
+	switch {
+	case name == "TestMain":
+		param = "M"
+	case isTestPrefixed(name, "Test"):
+		param = "T"
+	case isTestPrefixed(name, "Benchmark"):
+		param = "B"
+	case isTestPrefixed(name, "Fuzz"):
+		param = "F"
+	default:
+		return false
+	}
+	params := fd.Type.Params
+	if params == nil || len(params.List) != 1 || len(params.List[0].Names) != 1 {
+		return false
+	}
+	return isTestingPointer(info.TypeOf(params.List[0].Type), param)
+}
+
+// isTestPrefixed is cmd/go/internal/load.isTest: the prefix, then either
+// nothing or a rune that is not lowercase.
+func isTestPrefixed(name, prefix string) bool {
+	if !strings.HasPrefix(name, prefix) {
+		return false
+	}
+	if len(name) == len(prefix) {
+		return true
+	}
+	r, _ := utf8.DecodeRuneInString(name[len(prefix):])
+	return !unicode.IsLower(r)
+}
+
+// isTestingPointer reports whether t is *testing.<name>.
+func isTestingPointer(t types.Type, name string) bool {
+	if t == nil {
+		return false
+	}
+	ptr, ok := types.Unalias(t).(*types.Pointer)
+	if !ok {
+		return false
+	}
+	named, ok := types.Unalias(ptr.Elem()).(*types.Named)
+	if !ok {
+		return false
+	}
+	obj := named.Obj()
+	return obj != nil && obj.Pkg() != nil && obj.Pkg().Path() == "testing" && obj.Name() == name
+}
+
+// loadForWiringScan loads the named packages WITH their tests, and refuses to
+// return a set it cannot vouch for.
+func loadForWiringScan(t *testing.T, patterns []string) []*packages.Package {
+	t.Helper()
+
+	cfg := &packages.Config{
+		Mode: packages.NeedName | packages.NeedSyntax |
+			packages.NeedTypes | packages.NeedTypesInfo,
+		Tests: true,
+		Dir:   ".",
+	}
+	pkgs, err := packages.Load(cfg, patterns...)
+	if err != nil {
+		t.Fatalf("packages.Load(%v): %v", patterns, err)
+	}
+	if n := packages.PrintErrors(pkgs); n > 0 {
+		t.Fatalf("packages.Load reported %d package error(s); the build is broken, and every "+
+			"verdict below would be about source that does not compile", n)
+	}
+	for _, pkg := range pkgs {
+		if pkg.TypesInfo == nil {
+			t.Fatalf("package %q loaded without type information; the detector cannot tell a "+
+				"call of contracttesting.AssertX from a local helper of the same name without it",
+				pkg.ID)
+		}
+	}
+	return pkgs
+}
+
+// assertRequiredWiringsExist is the existence check on requiredWirings()' keys.
+//
+// Without it a renamed or deleted entry point turns this tripwire into a demand
+// that every adapter call something that does not exist — six adapters × one
+// row, all red, none of them the adapter's fault, and the actual cause
+// (contracttesting moved) named nowhere. Exemption and requirement tables alike
+// get their keys checked here for the same reason construction_test.go checks
+// nilTolerant's: an entry that has stopped naming a real thing must fail rather
+// than silently mean nothing.
+func assertRequiredWiringsExist(t *testing.T, pkgs []*packages.Package, required []requiredWiring) {
+	t.Helper()
+
+	var scope *types.Scope
+	for _, pkg := range pkgs {
+		if pkg.PkgPath == contracttestingPkg && pkg.ID == contracttestingPkg && pkg.Types != nil {
+			scope = pkg.Types.Scope()
+			break
+		}
+	}
+	if scope == nil {
+		t.Fatalf("package %q was not loaded — every entry point below would be unverifiable and "+
+			"this tripwire would be asserting against names nothing checks", contracttestingPkg)
+	}
+	if len(required) == 0 {
+		t.Fatal("requiredWirings() is empty; this tripwire would pass having demanded nothing")
+	}
+	for _, r := range required {
+		obj := scope.Lookup(r.Fn)
+		if obj == nil {
+			t.Fatalf("requiredWirings() demands contracttesting.%s (%s), which %s does not "+
+				"declare. Either the entry point was renamed — update this row and every "+
+				"adapter's wiring — or it was removed, in which case delete the row and say why",
+				r.Fn, r.Family, contracttestingPkg)
+		}
+		fn, ok := obj.(*types.Func)
+		if !ok || !obj.Exported() {
+			t.Fatalf("contracttesting.%s is a %T, not an exported func; requiredWirings() can "+
+				"only demand something an adapter can call", r.Fn, obj)
+		}
+		_ = fn
+	}
+}
+
+// testVariantUnitsByPackage groups the loaded packages' test variants by the
+// import path of the package under test.
+//
+// Only the variants matter. `packages.Load(Tests: true)` returns four things
+// per package: the plain build (no _test.go at all), the in-package test
+// variant `p [p.test]` (which re-type-checks the ordinary files TOGETHER with
+// the in-package _test.go files), the external test package `p_test [p.test]`,
+// and the generated `p.test` main. The two variants are the whole truth about
+// what runs, and they are grouped together so a call from the external test
+// package into an in-package helper is an ordinary edge.
+//
+// Note the plain build is skipped rather than merged: its objects are DIFFERENT
+// *types.Func values from the test variant's, so including it would add a
+// second, permanently unreachable copy of every helper and nothing else.
+//
+// The package under test is recovered from the ID's BRACKETED part, never by
+// trimming a "_test" suffix off PkgPath. That distinction is load-bearing and
+// the corpus caught it: a package whose own import path legitimately ends in
+// "_test" — the `skipped_test` corpus row is exactly one, and an adapter
+// directory could be — has its in-package variant filed under a path that does
+// not exist, so its files vanish and every family is reported missing for it.
+// The ID says which package a variant belongs to; PkgPath's suffix only looks
+// like it does.
+func testVariantUnitsByPackage(t *testing.T, pkgs []*packages.Package) map[string][]sourceUnit {
+	t.Helper()
+
+	out := map[string][]sourceUnit{}
+	for _, pkg := range pkgs {
+		open := strings.Index(pkg.ID, " [")
+		if open < 0 || !strings.HasSuffix(pkg.ID, "]") {
+			continue // the plain build, or the generated p.test main
+		}
+		under, ok := strings.CutSuffix(pkg.ID[open+2:len(pkg.ID)-1], ".test")
+		if !ok {
+			t.Fatalf("package ID %q has a bracketed variant tag this walk cannot parse; it would "+
+				"otherwise file the package's test files under a path nothing looks up, and every "+
+				"family would be reported missing for it", pkg.ID)
+		}
+		for _, f := range pkg.Syntax {
+			out[under] = append(out[under], sourceUnit{fset: pkg.Fset, file: f, info: pkg.TypesInfo})
+		}
+	}
+	return out
+}
+
+// describeScan renders a scan for a failure message, in a stable order so two
+// runs of a failing corpus row print the same line.
+func describeScan(s wiringScan) string {
+	return fmt.Sprintf("files=%d roots=%d called=%v unreached=%v",
+		s.TestFiles, s.Roots, slices.Sorted(maps.Keys(s.Called)), slices.Sorted(maps.Keys(s.Unreached)))
+}

--- a/core/adapters/inbound/agents/hookcontracts_test.go
+++ b/core/adapters/inbound/agents/hookcontracts_test.go
@@ -84,29 +84,49 @@
 // Stated here rather than left to be discovered, and pinned as executable
 // corpus rows in hookcontracts_shapes_test.go wherever a row can express it:
 //
-//   - PACKAGE GRANULARITY. It asks whether the adapter's test package wires a
-//     family, never which RECEIVER inside that package was wired. claudecode
-//     hosts two receivers — hooks and statusline — and #1361's incident was
-//     the second one. A claudecode that wired AssertHookPathConfined for its
-//     hook receiver and not its statusline receiver passes here. That is the
-//     original bug, and this walk does not close it; hookjson.DecodeConfined
-//     plus core/architecture_hookbody_test.go do, by making an unconfined body
-//     read fail to build.
+//   - PACKAGE GRANULARITY, which is the big one and is MEASURED rather than
+//     reasoned about. The walk asks whether the adapter's test package calls a
+//     family's entry point, never which RECEIVER or which PERMISSION that call
+//     was for. Two real instances in this tree, both established by mutation
+//     while #1740 was being built:
+//
+//     Replacing the AssertHookReceiverPermissionGated call in claudecode's
+//     hooks_test.go with a local no-op left that adapter's row GREEN, because
+//     claudecode's statusline receiver wires the same family in the same
+//     package. claudecode hosts two receivers and #1361's incident was the
+//     second one, so this is precisely the shape that started all of it: this
+//     walk does not close it. hookjson.DecodeConfined and
+//     core/architecture_hookbody_test.go do, by making an unconfined body read
+//     fail to build — which is why that pair, not this walk, is the real
+//     enforcement for confinement.
+//
+//     AssertPermissionGated is excluded from requiredWirings() for the same
+//     reason (see unenforceableHere): claudecode's package calls it for its
+//     INSTRUCTIONS permission, so a row demanding it would be satisfied by that
+//     call while claudecode's hooks install has no such wiring at all.
+//
+//     What the walk DOES still catch, and what #1740 is actually about, is the
+//     new adapter that wires a family nowhere at all.
+//
 //   - A test that is SKIPPED (t.Skip) or a call guarded by a constant false
 //     condition still counts. Reachability here is syntactic; it does not
 //     evaluate.
+//
 //   - A wiring reached through a func literal held in a PACKAGE-LEVEL VAR is
 //     NOT seen, because the literal's body hangs off a ValueSpec rather than a
 //     FuncDecl. That direction is fail-closed — it reports a real wiring as
 //     missing, which is loud — and it is the same declared limit
 //     contracttesting/seam_walk_corpus_test.go pins for its own walk.
+//
 //   - A wiring reached through a helper in ANOTHER package (other than the
 //     adapter's own external test package, which is merged in) is not seen.
 //     Fail-closed again.
+//
 //   - An entry point taken as a VALUE and called later (`f :=
 //     contracttesting.AssertX; f(t, r)`) is not seen. Fail-closed. Requiring a
 //     call expression is what makes `var _ = contracttesting.AssertX` — a
 //     reference that executes nothing — not count.
+//
 //   - It cannot say the wiring is CORRECT. That is what the contract families
 //     themselves are for; this only says one is present and runs.
 package agents
@@ -166,14 +186,20 @@ type requiredWiring struct {
 // rather than leaving the evidence in a PR body.
 //
 // #1740 names the first three. The other four have the identical shape — wired
-// as a test call, enforced by nothing — and were found by measuring rather than
-// assumed: every one of the six hooks-declaring adapters already wires all
-// seven, so including them costs nothing today and covers four more families
-// tomorrow. Reproduce that measurement with:
+// as a test call, enforced by nothing — and were included by measuring rather
+// than assumed out: every hooks-declaring adapter already wires all seven, so
+// they cost nothing today and cover four more families tomorrow.
 //
-//	for f in $(grep -ho 'Assert[A-Za-z]*' core/internal/contracttesting/*.go | sort -u); do …
+// That claim needs no separately-maintained figure, because THIS TEST is what
+// produces it: "every hooks-declaring adapter wires every row" is true exactly
+// when TestEveryHookInstallWiresItsContractFamilies is green. The roster it
+// runs over is derived from All() rather than written down, so neither the
+// count of adapters nor the count of rows can drift away from what was
+// measured. To see the per-adapter breakdown directly:
 //
-// or, more simply, by deleting a row and watching this test stay green.
+//	for f in $(git grep -ho 'func Assert[A-Za-z]*' core/internal/contracttesting/ | sed 's/^func //'); do
+//	  echo "== $f"; git grep -l "contracttesting.$f" -- 'core/adapters/inbound/agents/*/*_test.go'
+//	done
 func requiredWirings() []requiredWiring {
 	return []requiredWiring{
 		{
@@ -224,6 +250,34 @@ func requiredWirings() []requiredWiring {
 	}
 }
 
+// unenforceableHere names contracttesting entry points with the SAME
+// wired-as-a-test-call shape as requiredWirings() which this tripwire
+// deliberately does NOT demand, each with the reason.
+//
+// An omission with no entry is indistinguishable from an omission nobody
+// noticed, which is #1740 reproduced inside its own fix. So the omissions are
+// written down — and, because a reason written once rots, each row's PREMISE is
+// re-checked every run by assertExclusionsStillHold.
+//
+// The single row is here because of this walk's package granularity, measured
+// rather than reasoned: claude-code's test package calls AssertPermissionGated
+// for its INSTRUCTIONS permission (instructioninstaller_test.go), so a
+// requiredWirings() row for it would be satisfied by that call while
+// claude-code's HOOKS install has no such wiring at all — a rule that reads as
+// coverage and is not, which is worse than a stated gap. The gap itself (five
+// of six hooks adapters wire the family for their hooks install; claude-code
+// does not) is a finding about claude-code reported in PR #1740, not something
+// to paper over with a green row here.
+func unenforceableHere() map[string]string {
+	return map[string]string{
+		"AssertPermissionGated": "every hooks-declaring adapter's test package already calls this " +
+			"family, so a required row would discriminate nothing — but for claude-code the call " +
+			"is for its INSTRUCTIONS permission, not its hooks install (five of six adapters wire " +
+			"it in their own hookinstaller_test.go; claude-code does not). Requiring it would be " +
+			"vacuously green there. Reconsider this row if the premise below stops holding.",
+	}
+}
+
 // hookInstall is one hooks-declaring permission and the Go package that
 // declared it.
 type hookInstall struct {
@@ -244,11 +298,26 @@ func TestEveryHookInstallWiresItsContractFamilies(t *testing.T) {
 
 	assertRequiredWiringsExist(t, pkgs, required)
 
+	excluded := unenforceableHere()
+	assertExclusionsAreWellFormed(t, pkgs, required, excluded)
+
 	units := testVariantUnitsByPackage(t, pkgs)
-	want := make([]string, 0, len(required))
+	want := make([]string, 0, len(required)+len(excluded))
 	for _, r := range required {
 		want = append(want, r.Fn)
 	}
+	want = append(want, slices.Sorted(maps.Keys(excluded))...)
+
+	// wiredEverywhere tracks, per excluded entry point, whether EVERY adapter's
+	// package already calls it — which is the stated premise of every row in
+	// unenforceableHere() and the thing that makes a required row worthless
+	// there. Seeded true and narrowed by the loop; the seed is only correct
+	// because hookInstallingAdapters already refused an empty set.
+	wiredEverywhere := map[string]bool{}
+	for name := range excluded {
+		wiredEverywhere[name] = true
+	}
+	missingSomewhere := map[string]string{}
 
 	for _, in := range installs {
 		u := units[in.Pkg]
@@ -291,6 +360,71 @@ func TestEveryHookInstallWiresItsContractFamilies(t *testing.T) {
 				"own receiver/installer. A contract can only fail for an adapter that wired it "+
 				"(issue #1740).",
 				in.Adapter, in.Pkg, in.Key, r.Fn, r.Family, r.Why, r.Fn)
+		}
+		for name := range excluded {
+			if _, ok := scan.Called[name]; !ok {
+				wiredEverywhere[name] = false
+				missingSomewhere[name] = in.Adapter
+			}
+		}
+	}
+
+	assertExclusionsStillHold(t, excluded, wiredEverywhere, missingSomewhere)
+}
+
+// assertExclusionsStillHold re-checks the premise every unenforceableHere() row
+// rests on: that the entry point is ALREADY called by every hooks-declaring
+// adapter's package, which is what makes requiring it discriminate nothing.
+//
+// The polarity is the correction, and it was earned by getting it backwards
+// first. The obvious check — "fail once everybody wires it, so the row gets
+// promoted" — fires immediately and permanently here, because everybody already
+// does; that is the premise, not the trigger. The condition worth reporting is
+// the opposite one: an adapter that does NOT call it means a required row would
+// now catch something, so the exclusion has stopped being free and needs
+// re-reading. An exemption whose stated reason is re-derived each run is the
+// only kind that cannot rot into "you don't need to look here".
+func assertExclusionsStillHold(t *testing.T, excluded map[string]string, wiredEverywhere map[string]bool, missingSomewhere map[string]string) {
+	t.Helper()
+
+	for _, name := range slices.Sorted(maps.Keys(excluded)) {
+		if wiredEverywhere[name] {
+			continue
+		}
+		t.Errorf("unenforceableHere() excludes contracttesting.%s on the premise that every "+
+			"hooks-declaring adapter's package already calls it, so requiring it would discriminate "+
+			"nothing. %s does not call it, so that premise no longer holds.\n"+
+			"\tRe-read the row: a required row would now catch a real omission. The reason it was "+
+			"excluded was: %s", name, missingSomewhere[name], excluded[name])
+	}
+}
+
+// assertExclusionsAreWellFormed checks notYetRequired()'s keys the way
+// requiredWirings()' are checked: the name must exist in contracttesting, and it
+// must not also be required. An exemption naming something that does not exist,
+// or contradicting the requirement table, is worse than no exemption at all —
+// it reads as a considered decision while meaning nothing.
+func assertExclusionsAreWellFormed(t *testing.T, pkgs []*packages.Package, required []requiredWiring, excluded map[string]string) {
+	t.Helper()
+
+	scope := contracttestingScope(t, pkgs)
+	isRequired := map[string]bool{}
+	for _, r := range required {
+		isRequired[r.Fn] = true
+	}
+	for _, name := range slices.Sorted(maps.Keys(excluded)) {
+		if excluded[name] == "" {
+			t.Fatalf("notYetRequired()[%q] carries no reason; an exclusion nobody can justify is "+
+				"one nobody can safely delete", name)
+		}
+		if scope.Lookup(name) == nil {
+			t.Fatalf("notYetRequired() excludes contracttesting.%s, which %s does not declare — the "+
+				"entry stopped naming a real thing and now excludes nothing",
+				name, contracttestingPkg)
+		}
+		if isRequired[name] {
+			t.Fatalf("contracttesting.%s is both required and excluded; the tables contradict each "+
+				"other and only one of them can be the rule", name)
 		}
 	}
 }
@@ -682,17 +816,7 @@ func loadForWiringScan(t *testing.T, patterns []string) []*packages.Package {
 func assertRequiredWiringsExist(t *testing.T, pkgs []*packages.Package, required []requiredWiring) {
 	t.Helper()
 
-	var scope *types.Scope
-	for _, pkg := range pkgs {
-		if pkg.PkgPath == contracttestingPkg && pkg.ID == contracttestingPkg && pkg.Types != nil {
-			scope = pkg.Types.Scope()
-			break
-		}
-	}
-	if scope == nil {
-		t.Fatalf("package %q was not loaded — every entry point below would be unverifiable and "+
-			"this tripwire would be asserting against names nothing checks", contracttestingPkg)
-	}
+	scope := contracttestingScope(t, pkgs)
 	if len(required) == 0 {
 		t.Fatal("requiredWirings() is empty; this tripwire would pass having demanded nothing")
 	}
@@ -763,4 +887,20 @@ func testVariantUnitsByPackage(t *testing.T, pkgs []*packages.Package) map[strin
 func describeScan(s wiringScan) string {
 	return fmt.Sprintf("files=%d roots=%d called=%v unreached=%v",
 		s.TestFiles, s.Roots, slices.Sorted(maps.Keys(s.Called)), slices.Sorted(maps.Keys(s.Unreached)))
+}
+
+// contracttestingScope returns the contract package's top-level scope, and
+// refuses if the load did not produce it — without it every name check below
+// silently becomes a no-op, and this tripwire would be asserting against
+// strings nothing verifies.
+func contracttestingScope(t *testing.T, pkgs []*packages.Package) *types.Scope {
+	t.Helper()
+	for _, pkg := range pkgs {
+		if pkg.PkgPath == contracttestingPkg && pkg.ID == contracttestingPkg && pkg.Types != nil {
+			return pkg.Types.Scope()
+		}
+	}
+	t.Fatalf("package %q was not loaded — every entry-point name check would be unverifiable and "+
+		"this tripwire would be asserting against names nothing checks", contracttestingPkg)
+	return nil
 }

--- a/docs/testing-contracts.md
+++ b/docs/testing-contracts.md
@@ -432,12 +432,26 @@ below.
   recovering the package under test by trimming `_test` off `PkgPath` instead
   of reading `packages.Package.ID`'s variant tag, which silently dropped every
   test file of any package whose path ends in `_test`.
-  What it does not cover is stated in the file's header rather than implied:
-  package granularity (above), a skipped or constant-false-guarded call, a
-  wiring reached through a package-level func var or a helper in a third
-  package (both fail-closed), an entry point taken as a value and called later
-  (fail-closed), and — the standing one — whether the wiring is CORRECT, which
-  is what the families themselves are for.
+  What it does not cover is stated in the file's header rather than implied,
+  and the headline limit was MEASURED rather than reasoned about. The walk is
+  PACKAGE-granular: it never asks which receiver or which permission a call was
+  for. Replacing the `AssertHookReceiverPermissionGated` call in claudecode's
+  `hooks_test.go` with a local no-op leaves that adapter's row GREEN, because
+  its statusline receiver wires the same family in the same package — the exact
+  #1361 shape. `AssertPermissionGated` is excluded from the required set for the
+  same reason and says so in `unenforceableHere()`, whose row's PREMISE (every
+  hooks adapter's package already calls it, so a required row would discriminate
+  nothing) is re-derived every run rather than trusted once. That exclusion also
+  surfaced a finding worth its own ticket: five of the six hooks-declaring
+  adapters wire `AssertPermissionGated` for their hooks INSTALL closures and
+  claude-code does not — it wires the family only for its instructions
+  permission. The other limits: a skipped or constant-false-guarded call still
+  counts; a wiring reached through a package-level func var or a helper in a
+  third package is not seen (fail-closed); an entry point taken as a value and
+  called later is not seen (fail-closed); and — the standing one — nothing here
+  says the wiring is CORRECT, which is what the families themselves are for.
+  Note what the walk DOES catch, which is what #1740 is about: the new adapter
+  that wires a family nowhere at all.
 - Managed user files: every `modify`-kind permission with an `Apply` closure
   declares the shared, user-owned file(s) that closure writes
   (`agent.Permission.Writes`, an `agent.ManagedUserFile` carrying `Path`,

--- a/docs/testing-contracts.md
+++ b/docs/testing-contracts.md
@@ -256,7 +256,14 @@ below.
   Since #1389 the contract is only half the enforcement, and the weaker half: a
   contract can fail only for an adapter that WIRED it, so a receiver nobody
   wired it for is invisible to it — which is how the statusline endpoint shipped
-  unconfined in the first place. `hookjson.DecodeConfined` welds the body decode
+  unconfined in the first place. That sentence is general to every family, and
+  since #1740 the *wiring itself* is enforced for hooks-declaring adapters (see
+  "Contract wiring" below) — but note the two close different halves and
+  neither subsumes the other: #1740's tripwire is PACKAGE-granular, so a
+  claudecode that wired this contract for its hook receiver and not for its
+  statusline receiver still passes it. The original bug is closed by the
+  build-level rules that follow, not by that tripwire.
+  `hookjson.DecodeConfined` welds the body decode
   to the confinement (the confiner is an argument to the decode, so a receiver
   cannot reach its payload without supplying one), and
   `core/architecture_hookbody_test.go` fails the build if anything else under
@@ -371,6 +378,66 @@ below.
   a path-confinement rejection counts too (alive-but-misrouted is #1361's); and a
   consent-denied request counts nothing, because noting that a POST arrived is
   itself an observation.
+- Contract wiring: not a contract family — a registry tripwire,
+  `TestEveryHookInstallWiresItsContractFamilies`
+  (`core/adapters/inbound/agents/hookcontracts_test.go`), riding the same
+  projection as #1365's and #1372's. It closes the asymmetry #1740 named: two
+  obligations over a hooks-declaring adapter are things the adapter DECLARES as
+  a struct field (`Verify`, `Version`), which a registry walk can read, and the
+  rest are wired as a TEST CALL in the adapter's own test package, which
+  nothing could. "Harder to detect" was not "less important" — the three the
+  issue was filed about are the ones whose absence is least visible in
+  production (an unconfined caller-supplied path, a dead port behind a granted
+  permission, an undisclosed write to a user's config), and their only
+  enforcement was that whoever added the adapter remembered to copy an existing
+  adapter's test files. Seven entry points are required, not the three #1740
+  named: the other four (`AssertHookVersionGate`,
+  `AssertUnknownHookEventObserved`, `AssertHookReceiptObserved`,
+  `AssertHookReceiverPermissionGated`) have the identical shape and every
+  hooks-declaring adapter already wired all seven, so they were measured in
+  rather than assumed out. Note what the version row adds on top of #1365's
+  floor tripwire: that one proves a floor is DECLARED and parseable, this one
+  that the floor actually refuses.
+  Three things are load-bearing. **It is a static walk and #1740 preferred a
+  registration seam** — the seam was rejected on a fact rather than on cost, and
+  the rejection is recorded in the file's header rather than here: `go test`
+  compiles one binary per package, so a recorder in six adapter processes
+  cannot reach an asserting test in a seventh, and carrying it across processes
+  means a file that is a cache the reader cannot validate — stale entries make
+  a DELETED wiring read as covered, which is #1740's own failure mode with a
+  longer half-life. **It is an AST + type walk, not a grep**, which is what
+  makes it worth more than the issue assumed a static walk would be: a
+  reference in a comment is not a call node, a call must be reachable from a
+  function `go test` actually runs (a helper nothing calls is reported
+  separately, so the failure says re-attach rather than re-write), an aliased
+  import counts, and a local helper that merely shares the name does not.
+  **The adapter's Go package is derived, never mapped** — from `runtime.FuncForPC`
+  over the permission's own `Apply` and `Uninstall` closures, which must agree —
+  because a hand-written adapter-name → directory map is one more thing a new
+  adapter is covered by only if someone remembers to edit it, which is this
+  issue one level up (and `agent.Identity.Name` cannot answer it: "claude-code"
+  is package `claudecode`, "mistral-vibe" is package `vibe`).
+  Its mutation evidence is a committed corpus, `hookcontracts_shapes_test.go`:
+  one synthetic adapter test package per spelling, pinned to a THREE-valued
+  verdict (called / unreached / absent) so a detector that reports dead wirings
+  stays distinguishable from one blind to them. The rows that must NOT be
+  credited carry the value — a name in a comment, a name in a string, a
+  reference that is not a call, a local helper of the same name, a dead helper
+  — and so do the rows pinning declared LIMITS in both directions: a skipped
+  test and a call under `if false` still count (over-crediting), while a wiring
+  held in a package-level var of func type is not seen at all (under-crediting,
+  fail-closed). The corpus has already earned its keep twice: the needle guard
+  caught a case that had stopped containing its own construct, and the
+  `skipped_test` row — whose directory NAME is the fixture — caught the walk
+  recovering the package under test by trimming `_test` off `PkgPath` instead
+  of reading `packages.Package.ID`'s variant tag, which silently dropped every
+  test file of any package whose path ends in `_test`.
+  What it does not cover is stated in the file's header rather than implied:
+  package granularity (above), a skipped or constant-false-guarded call, a
+  wiring reached through a package-level func var or a helper in a third
+  package (both fail-closed), an entry point taken as a value and called later
+  (fail-closed), and — the standing one — whether the wiring is CORRECT, which
+  is what the families themselves are for.
 - Managed user files: every `modify`-kind permission with an `Apply` closure
   declares the shared, user-owned file(s) that closure writes
   (`agent.Permission.Writes`, an `agent.ManagedUserFile` carrying `Path`,


### PR DESCRIPTION
Closes #1740.

Two obligations over hooks-declaring adapters were already immune to the "nobody wired it" failure — `TestEveryHookInstallDeclaresAVerifier` and `TestEveryHookInstallDeclaresAVersionFloor` — because what they ask for is a struct **field** an adapter declares in production code. The families in `requiredWirings()` have no field to walk: they are wired as a **test call** in the adapter's own package, so their only enforcement was that whoever added the adapter remembered to copy an existing adapter's test files.

That is the hazard `docs/testing-contracts.md` already names, and it is how claudecode's statusline endpoint shipped unconfined:

> a contract can fail only for an adapter that WIRED it, so a receiver nobody wired it for is invisible to it

## Which option, and why the "stronger" one was rejected

#1740 sketched a static walk and a registration seam, and called the seam stronger because it grades what **executed** rather than what is textually present. The seam was rejected on a fact about the go tool, not on cost:

- `go test ./core/...` compiles **one test binary per package**. A recorder inside `contracttesting.AssertX` would run in six adapter processes and the asserting test in a seventh, so in-process state never reaches it.
- Carrying it across processes means a file, and that file is a cache the reader cannot validate. A stale entry makes a wiring someone has since **deleted** read as covered — the precise failure mode #1740 exists to end, reintroduced with a longer half-life. Meanwhile the build cache legitimately skips re-running an unchanged package's tests, so "P did not register" is also the ordinary answer for a cached pass.

Wrong in the green direction on a stale file and wrong in the red direction on a cache hit is not stronger than a static walk.

## Mutation evidence

The realistic shape — an adapter ships without wiring the contract at all. `rm core/adapters/inbound/agents/kirocli/hookpath_test.go`; `go vet` on the package stays clean, so this is not a compile-error confound:

```
--- FAIL: TestEveryHookInstallWiresItsContractFamilies (0.24s)
    hookcontracts_test.go:355: kiro-cli (irrlicht/core/adapters/inbound/agents/kirocli) installs hooks (hooks)
      but its test package never calls contracttesting.AssertHookPathConfined — the hook path confinement
      (#1361, #1389) contract is unenforced for this adapter.
        Why it is required: the transcript_path in an inbound hook body is caller-supplied on a local
        unauthenticated endpoint; unwired, a receiver can forward it unconfined and anything downstream
        opens whatever the caller named.
        Wire it: copy the corresponding *_test.go from an adapter that already does
        (`git grep -l AssertHookPathConfined core/adapters/inbound/agents/`) and point it at this
        adapter's own receiver/installer. A contract can only fail for an adapter that wired it (#1740).
```

Restored; `git status --porcelain` clean; suite green.

`hookcontracts_shapes_test.go` is the committed corpus — one case per call spelling pinned to the verdict the detector must return, including the `want:false` rows that pin the false positives a naive text rule would produce and the declared limits of an AST walk, so those are learned from a test rather than from an incident.

## What this does NOT cover, stated plainly

- **Package granularity.** The walk sees that an adapter's test package references the entry point, not that the reference is reachable, executed, or pointed at that adapter's own receiver. A wiring in a dead test, or one aimed at the wrong constructor, reads as covered.
- It cannot catch a family nobody has added to `requiredWirings()`.

Both are recorded next to the code rather than only here.
