### PR TITLE
test(permissions): grade what Apply actually WROTE, not only that Writes exists (#1741)

### DIFF
--- a/core/cmd/irrlichd/managedwrites_shapes_test.go
+++ b/core/cmd/irrlichd/managedwrites_shapes_test.go
@@ -245,47 +245,43 @@ func TestPathUnderDirRefusesEveryUncontainedShape(t *testing.T) {
 func TestPackageLevelPathResolversPinsEverySpelling(t *testing.T) {
 	cases := []struct {
 		name string
-		file string // file name inside the synthetic package
+		// file is the name inside the synthetic package. Empty means
+		// "a.go" — only the _test.go row needs to say otherwise, and repeating
+		// it on every other row is noise a reader has to check anyway.
+		file string
 		src  string
 		want []string
 	}{{
 		name: "the ordinary spelling",
-		file: "a.go",
 		src:  "package p\nfunc settingsPath() (string, error) { return \"\", nil }\n",
 		want: []string{"settingsPath"},
 	}, {
 		name: "named results",
-		file: "a.go",
 		src:  "package p\nfunc settingsPath() (path string, err error) { return }\n",
 		want: []string{"settingsPath"},
 	}, {
 		name: "two names on one result field",
-		file: "a.go",
 		src:  "package p\nfunc twoStrings() (a, b string) { return }\n",
 		want: nil, // (string, string), not (string, error)
 	}, {
 		name: "exported is still a resolver",
-		file: "a.go",
 		src:  "package p\nfunc SettingsPath() (string, error) { return \"\", nil }\n",
 		want: []string{"SettingsPath"},
 	}, {
 		// FALSE POSITIVE a text rule produces: it takes a parameter, so it is
 		// not something a ManagedUserFile field can hold.
 		name: "takes a parameter",
-		file: "a.go",
 		src:  "package p\nfunc pathUnder(root string) (string, error) { return \"\", nil }\n",
 		want: nil,
 	}, {
 		// FALSE POSITIVE: the result types are not (string, error).
 		name: "returns the wrong pair",
-		file: "a.go",
 		src:  "package p\nfunc info() (string, bool) { return \"\", false }\n",
 		want: nil,
 	}, {
 		// FALSE POSITIVE: a METHOD cannot be a ManagedUserFile resolver, and
 		// its receiver is what tells it apart from one.
 		name: "a method with the same signature",
-		file: "a.go",
 		src:  "package p\ntype T struct{}\nfunc (t T) settingsPath() (string, error) { return \"\", nil }\n",
 		want: nil,
 	}, {
@@ -296,14 +292,12 @@ func TestPackageLevelPathResolversPinsEverySpelling(t *testing.T) {
 		// resolver", so it is a hole rather than a loud refusal, which is
 		// exactly why it is written down.
 		name: "a func literal in a package-level var",
-		file: "a.go",
 		src:  "package p\nvar settingsPath = func() (string, error) { return \"\", nil }\n",
 		want: nil,
 	}, {
 		// DECLARED LIMIT: the walk compares result types syntactically, so a
 		// local alias of error is not recognised.
 		name: "an aliased error type",
-		file: "a.go",
 		src:  "package p\ntype myErr = error\nfunc settingsPath() (string, myErr) { return \"\", nil }\n",
 		want: nil,
 	}, {
@@ -315,7 +309,6 @@ func TestPackageLevelPathResolversPinsEverySpelling(t *testing.T) {
 		want: nil,
 	}, {
 		name: "several in one file, sorted",
-		file: "a.go",
 		src: "package p\n" +
 			"func zPath() (string, error) { return \"\", nil }\n" +
 			"func aPath() (string, error) { return \"\", nil }\n",
@@ -324,15 +317,19 @@ func TestPackageLevelPathResolversPinsEverySpelling(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
+			name := tc.file
+			if name == "" {
+				name = "a.go"
+			}
 			dir := t.TempDir()
-			if err := os.WriteFile(filepath.Join(dir, tc.file), []byte(tc.src), 0o600); err != nil {
+			if err := os.WriteFile(filepath.Join(dir, name), []byte(tc.src), 0o600); err != nil {
 				t.Fatal(err)
 			}
 			// The row's own vacuity guard: the case must actually contain the
 			// construct it plants, or a corpus that quietly stopped carrying
 			// its own test cases would read as a pass (the rule
 			// core/architecture_hookbody_shapes_test.go states).
-			assertParses(t, dir, tc.file)
+			assertParses(t, dir, name)
 
 			got, err := packageLevelPathResolvers(dir)
 			if err != nil {

--- a/core/cmd/irrlichd/managedwrites_shapes_test.go
+++ b/core/cmd/irrlichd/managedwrites_shapes_test.go
@@ -1,0 +1,442 @@
+// managedwrites_shapes_test.go is the committed mutation evidence for
+// managedwrites_test.go's two arms.
+//
+// Per docs/testing-philosophy.md, a guard a change ADDS owes a deliberate
+// mutation seen red, and the mutation is worth more committed than described:
+// "a paragraph in a merged PR body is re-run by nothing and an assertion that
+// silently stops discriminating looks exactly like health."
+//
+// Two things are graded here that the live catalog cannot express.
+//
+// The GRADING (gradeWrites/treeDiff) is driven with snapshots no correct
+// adapter produces — a modified pre-existing file, a REMOVED file, an
+// allowance that absorbs nothing, a path that merely shares a string prefix
+// with an allowance root. Each row carries both verdicts on purpose: a
+// detector that reports everything and one that reports correctly are
+// indistinguishable without the cases that must stay SILENT.
+//
+// The WALK (packageLevelPathResolvers) is driven over source strings, one row
+// per spelling, pinned to the verdict it must return. The want:false rows are
+// where the value is (#1450): three of them are false positives a text-based
+// rule would produce, and two are declared LIMITS of an ast.FuncDecl walk —
+// pinned so the next person learns them from a test rather than from an
+// incident.
+package main
+
+import (
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// The grading
+// ---------------------------------------------------------------------------
+
+// TestGradeWritesReportsEveryKnownShape drives gradeWrites over one case per
+// shape, each wrong in exactly ONE way, and pins both what it must report and
+// what it must leave silent.
+func TestGradeWritesReportsEveryKnownShape(t *testing.T) {
+	const allowRoot = "irrlicht-home"
+	allowed := []allowance{{Root: allowRoot, Reason: "the daemon's own state"}}
+
+	cases := []struct {
+		name           string
+		observed       []string
+		declared       []string
+		wantUndeclared []string
+		wantMissing    []string
+		wantAllowed    int
+	}{{
+		name:     "the correct case — every observed write is declared, nothing declared is unwritten",
+		observed: []string{"home/.vibe/config.toml", "home/.vibe/hooks.toml"},
+		declared: []string{"home/.vibe/hooks.toml", "home/.vibe/config.toml"},
+	}, {
+		// #1739's shape: a second file the same Apply writes, undeclared.
+		name:           "an undeclared write is reported",
+		observed:       []string{"home/.kiro/agents/irrlicht.json", "home/.kiro/.irrlicht-prior-default.json"},
+		declared:       []string{"home/.kiro/agents/irrlicht.json"},
+		wantUndeclared: []string{"home/.kiro/.irrlicht-prior-default.json"},
+	}, {
+		// The shape a "which files APPEARED" check misses entirely: the file
+		// was already there and Apply rewrote it. treeDiff is what makes this
+		// reachable; gradeWrites only has to not special-case it.
+		name:           "a modified pre-existing file is reported like a created one",
+		observed:       []string{"home/.zshrc"},
+		declared:       []string{"home/.claude/settings.json"},
+		wantUndeclared: []string{"home/.zshrc"},
+		wantMissing:    []string{"home/.claude/settings.json"},
+	}, {
+		name:        "a declared file nothing wrote is reported — the vacuity direction",
+		observed:    []string{},
+		declared:    []string{"home/.config/kitty/kitty.conf"},
+		wantMissing: []string{"home/.config/kitty/kitty.conf"},
+	}, {
+		// The failure a misconfigured sandbox produces. Without the Missing
+		// direction this row is a clean sweep, which is the whole reason
+		// gradeWrites reports both ways.
+		name:     "nothing observed and nothing declared is NOT reported by this function",
+		observed: []string{},
+		declared: []string{},
+	}, {
+		name:        "a file inside an allowance is absorbed, not reported",
+		observed:    []string{"irrlicht-home/sessions.db", "home/.codex/hooks.json"},
+		declared:    []string{"home/.codex/hooks.json"},
+		wantAllowed: 1,
+	}, {
+		name:        "the allowance root itself is absorbed",
+		observed:    []string{"irrlicht-home"},
+		declared:    []string{},
+		wantAllowed: 1,
+	}, {
+		// Segment-aware containment. A string-prefix test would absorb this,
+		// and it is a different file entirely.
+		name:           "a sibling that merely shares the allowance root's prefix is reported",
+		observed:       []string{"irrlicht-home-backup/leak.json"},
+		declared:       []string{},
+		wantUndeclared: []string{"irrlicht-home-backup/leak.json"},
+	}, {
+		// A permission that DELETES a user file has written to it in every
+		// sense this declaration is about. treeDiff surfaces the removal; this
+		// row pins that gradeWrites treats it like any other change.
+		name:           "a removed undeclared file is reported",
+		observed:       []string{"home/.claude/settings.json.bak"},
+		declared:       []string{},
+		wantUndeclared: []string{"home/.claude/settings.json.bak"},
+	}, {
+		name:           "several undeclared writes are all reported, sorted",
+		observed:       []string{"home/b.json", "home/a.json"},
+		declared:       []string{},
+		wantUndeclared: []string{"home/a.json", "home/b.json"},
+	}}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			v := gradeWrites(tc.observed, tc.declared, allowed)
+			if got, want := strings.Join(v.Undeclared, ","), strings.Join(tc.wantUndeclared, ","); got != want {
+				t.Errorf("Undeclared = [%s], want [%s]", got, want)
+			}
+			if got, want := strings.Join(v.Missing, ","), strings.Join(tc.wantMissing, ","); got != want {
+				t.Errorf("Missing = [%s], want [%s]", got, want)
+			}
+			if got := v.Allowed[allowRoot]; got != tc.wantAllowed {
+				t.Errorf("allowance %q absorbed %d paths, want %d", allowRoot, got, tc.wantAllowed)
+			}
+		})
+	}
+}
+
+// TestTreeDiffSeesEveryKindOfChange pins what a snapshot pair can and cannot
+// tell apart. The last row is a DECLARED LIMIT rather than a defect: a write
+// that restores size, mtime and content exactly is not a change any diff of
+// this shape can see, and saying so here is cheaper than someone re-deriving it
+// from a green test.
+func TestTreeDiffSeesEveryKindOfChange(t *testing.T) {
+	base := func() map[string]fileState {
+		return map[string]fileState{
+			"home/.codex/hooks.json": {Size: 10, ModNano: 100, Sum: "aaa"},
+			"home/.zshrc":            {Size: 20, ModNano: 200, Sum: "bbb"},
+		}
+	}
+
+	cases := []struct {
+		name string
+		// mutate turns the "after" snapshot into the case.
+		mutate func(map[string]fileState)
+		want   []string
+	}{{
+		name:   "nothing changed",
+		mutate: func(map[string]fileState) {},
+		want:   nil,
+	}, {
+		name: "a created file",
+		mutate: func(m map[string]fileState) {
+			m["home/.vibe/hooks.toml"] = fileState{Size: 1, ModNano: 300, Sum: "ccc"}
+		},
+		want: []string{"home/.vibe/hooks.toml"},
+	}, {
+		name:   "content rewritten at the same size",
+		mutate: func(m map[string]fileState) { s := m["home/.zshrc"]; s.Sum = "zzz"; m["home/.zshrc"] = s },
+		want:   []string{"home/.zshrc"},
+	}, {
+		name:   "identical content rewritten — caught by mtime alone",
+		mutate: func(m map[string]fileState) { s := m["home/.zshrc"]; s.ModNano = 999; m["home/.zshrc"] = s },
+		want:   []string{"home/.zshrc"},
+	}, {
+		name:   "a removed file",
+		mutate: func(m map[string]fileState) { delete(m, "home/.codex/hooks.json") },
+		want:   []string{"home/.codex/hooks.json"},
+	}, {
+		name: "everything at once, sorted",
+		mutate: func(m map[string]fileState) {
+			delete(m, "home/.zshrc")
+			m["home/.a"] = fileState{Size: 1}
+		},
+		want: []string{"home/.a", "home/.zshrc"},
+	}, {
+		// DECLARED LIMIT. Kept as a want:none row because it is the one thing
+		// this mechanism cannot observe, and a reader who assumes otherwise
+		// would trust a green further than it goes.
+		name: "a write that restores size, mtime AND content is invisible — the declared limit",
+		mutate: func(m map[string]fileState) {
+			m["home/.zshrc"] = fileState{Size: 20, ModNano: 200, Sum: "bbb"}
+		},
+		want: nil,
+	}}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			after := base()
+			tc.mutate(after)
+			got := treeDiff(base(), after)
+			if strings.Join(got, ",") != strings.Join(tc.want, ",") {
+				t.Errorf("treeDiff = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestPathUnderDirRefusesEveryUncontainedShape pins the fail-closed
+// precondition's containment rule. Every want:false row here is a path the
+// precondition must REFUSE to run a closure for, and the traversal rows are why
+// the rule is filepath.Rel rather than a string prefix.
+func TestPathUnderDirRefusesEveryUncontainedShape(t *testing.T) {
+	const root = "/tmp/scratch/001"
+	cases := []struct {
+		path string
+		want bool
+	}{
+		{"/tmp/scratch/001", true},
+		{"/tmp/scratch/001/home/.claude/settings.json", true},
+		{"/tmp/scratch/001/./home/x", true},
+		{"/tmp/scratch/0011/home/x", false},  // sibling sharing the prefix
+		{"/tmp/scratch/001/../002/x", false}, // traversal back out
+		{"/tmp/scratch", false},              // the parent
+		{"/Users/ingo/.claude/settings.json", false},
+		{"relative/path", false}, // not absolute: cannot be proven contained
+		{"", false},
+	}
+	for _, tc := range cases {
+		if got := pathUnderDir(root, tc.path); got != tc.want {
+			t.Errorf("pathUnderDir(%q, %q) = %v, want %v", root, tc.path, got, tc.want)
+		}
+	}
+	// A relative ROOT can never contain anything: the precondition would
+	// otherwise wave a path through against a root it could not resolve.
+	if pathUnderDir("scratch", "/tmp/scratch/x") {
+		t.Error("pathUnderDir accepted a relative root — that direction fails open")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// The walk
+// ---------------------------------------------------------------------------
+
+// TestPackageLevelPathResolversPinsEverySpelling is the static arm's corpus:
+// one source file per spelling, pinned to whether the walk must report it.
+//
+// The want:false rows carry the value. Three are false positives a text-based
+// rule ("grep for func.*(string, error)") would produce; two are declared
+// limits of walking ast.FuncDecl over syntactic types.
+func TestPackageLevelPathResolversPinsEverySpelling(t *testing.T) {
+	cases := []struct {
+		name string
+		file string // file name inside the synthetic package
+		src  string
+		want []string
+	}{{
+		name: "the ordinary spelling",
+		file: "a.go",
+		src:  "package p\nfunc settingsPath() (string, error) { return \"\", nil }\n",
+		want: []string{"settingsPath"},
+	}, {
+		name: "named results",
+		file: "a.go",
+		src:  "package p\nfunc settingsPath() (path string, err error) { return }\n",
+		want: []string{"settingsPath"},
+	}, {
+		name: "two names on one result field",
+		file: "a.go",
+		src:  "package p\nfunc twoStrings() (a, b string) { return }\n",
+		want: nil, // (string, string), not (string, error)
+	}, {
+		name: "exported is still a resolver",
+		file: "a.go",
+		src:  "package p\nfunc SettingsPath() (string, error) { return \"\", nil }\n",
+		want: []string{"SettingsPath"},
+	}, {
+		// FALSE POSITIVE a text rule produces: it takes a parameter, so it is
+		// not something a ManagedUserFile field can hold.
+		name: "takes a parameter",
+		file: "a.go",
+		src:  "package p\nfunc pathUnder(root string) (string, error) { return \"\", nil }\n",
+		want: nil,
+	}, {
+		// FALSE POSITIVE: the result types are not (string, error).
+		name: "returns the wrong pair",
+		file: "a.go",
+		src:  "package p\nfunc info() (string, bool) { return \"\", false }\n",
+		want: nil,
+	}, {
+		// FALSE POSITIVE: a METHOD cannot be a ManagedUserFile resolver, and
+		// its receiver is what tells it apart from one.
+		name: "a method with the same signature",
+		file: "a.go",
+		src:  "package p\ntype T struct{}\nfunc (t T) settingsPath() (string, error) { return \"\", nil }\n",
+		want: nil,
+	}, {
+		// DECLARED LIMIT, the same one core/architecture_hookbody_test.go and
+		// contracttesting/seam_walk_corpus_test.go pin for their own walks: a
+		// func literal held in a package-level var hangs off a ValueSpec, not a
+		// FuncDecl. Note the direction — this one reads as "no undeclared
+		// resolver", so it is a hole rather than a loud refusal, which is
+		// exactly why it is written down.
+		name: "a func literal in a package-level var",
+		file: "a.go",
+		src:  "package p\nvar settingsPath = func() (string, error) { return \"\", nil }\n",
+		want: nil,
+	}, {
+		// DECLARED LIMIT: the walk compares result types syntactically, so a
+		// local alias of error is not recognised.
+		name: "an aliased error type",
+		file: "a.go",
+		src:  "package p\ntype myErr = error\nfunc settingsPath() (string, myErr) { return \"\", nil }\n",
+		want: nil,
+	}, {
+		// _test.go files are excluded: a resolver a test declares is not one an
+		// Apply closure can write through.
+		name: "declared in a test file",
+		file: "a_test.go",
+		src:  "package p\nfunc settingsPath() (string, error) { return \"\", nil }\n",
+		want: nil,
+	}, {
+		name: "several in one file, sorted",
+		file: "a.go",
+		src: "package p\n" +
+			"func zPath() (string, error) { return \"\", nil }\n" +
+			"func aPath() (string, error) { return \"\", nil }\n",
+		want: []string{"aPath", "zPath"},
+	}}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			if err := os.WriteFile(filepath.Join(dir, tc.file), []byte(tc.src), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			// The row's own vacuity guard: the case must actually contain the
+			// construct it plants, or a corpus that quietly stopped carrying
+			// its own test cases would read as a pass (the rule
+			// core/architecture_hookbody_shapes_test.go states).
+			assertParses(t, dir, tc.file)
+
+			got, err := packageLevelPathResolvers(dir)
+			if err != nil {
+				t.Fatalf("packageLevelPathResolvers: %v", err)
+			}
+			sort.Strings(got)
+			if strings.Join(got, ",") != strings.Join(tc.want, ",") {
+				t.Errorf("resolvers = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// assertParses is the corpus's own guard: a row whose source no longer compiles
+// as Go would report "no resolvers" for a reason unrelated to the spelling
+// under test.
+func assertParses(t *testing.T, dir, file string) {
+	t.Helper()
+	fset := token.NewFileSet()
+	path := filepath.Join(dir, file)
+	f, err := parser.ParseFile(fset, path, nil, 0)
+	if err != nil {
+		t.Fatalf("the corpus row's own source does not parse (%s): %v", file, err)
+	}
+	if f.Name == nil || f.Name.Name == "" {
+		t.Fatalf("the corpus row's own source declares no package")
+	}
+	// And it must contain at least one declaration, so an empty row cannot
+	// masquerade as a want:nil case.
+	if len(f.Decls) == 0 {
+		t.Fatalf("the corpus row's own source declares nothing")
+	}
+}
+
+// TestPackageLevelPathResolversRefusesAnUnreadableDirectory is the walk's
+// "fail loudly when it cannot run" arm: a directory it cannot parse must be an
+// error, never an empty result. Both read as "no undeclared resolver" to a
+// caller that ignores the error, which is why the caller t.Fatals on it.
+func TestPackageLevelPathResolversRefusesAnUnreadableDirectory(t *testing.T) {
+	if _, err := packageLevelPathResolvers(filepath.Join(t.TempDir(), "no-such-dir")); err == nil {
+		t.Error("parsing a nonexistent directory returned no error — an unreadable package " +
+			"would report the same empty result as a clean one")
+	}
+
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "broken.go"), []byte("package p\nfunc ("), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := packageLevelPathResolvers(dir); err == nil {
+		t.Error("parsing an unparseable file returned no error — a validator that cannot read " +
+			"its input must check MORE, never less")
+	}
+}
+
+// TestPackageDirOfResolverRefusesAnythingItCannotMap pins the reflection→
+// directory mapping, including the shapes that must not silently resolve to
+// some other package's source.
+func TestPackageDirOfResolverRefusesAnythingItCannotMap(t *testing.T) {
+	dir, pkg, err := packageDirOfResolver("irrlicht/core/adapters/inbound/agents/kirocli.priorDefaultStatePath")
+	if err != nil {
+		t.Fatalf("mapping a real resolver: %v", err)
+	}
+	if pkg != "kirocli" {
+		t.Errorf("package name = %q, want kirocli", pkg)
+	}
+	if _, statErr := os.Stat(filepath.Join(dir, "hookinstaller.go")); statErr != nil {
+		t.Errorf("mapped %q, which does not hold kirocli's installer: %v", dir, statErr)
+	}
+
+	for _, bad := range []struct{ name, in string }{
+		{"no package qualifier", "someFuncWithNoDot"},
+		{"another module", "example.com/other/pkg.Resolver"},
+		{"a package that does not exist", "irrlicht/core/adapters/inbound/agents/nosuchadapter.Resolver"},
+	} {
+		if _, _, err := packageDirOfResolver(bad.in); err == nil {
+			t.Errorf("%s: packageDirOfResolver(%q) returned no error — it would grade the "+
+				"wrong package, or none, in silence", bad.name, bad.in)
+		}
+	}
+}
+
+// TestEnvKeptDuringScrubKeepsOnlyWhatTheRunnerNeeds pins the allow-list. Every
+// per-agent home override an adapter honours today is listed explicitly, so a
+// change that started keeping one — which would point that adapter's install at
+// the developer's real config while this test believed it was sandboxed — is a
+// failure rather than a silent widening.
+func TestEnvKeptDuringScrubKeepsOnlyWhatTheRunnerNeeds(t *testing.T) {
+	for _, name := range []string{"PATH", "TMPDIR", "GOCACHE"} {
+		if !envKeptDuringScrub(name) {
+			t.Errorf("the scrub clears %s, which the test runner needs", name)
+		}
+	}
+	// The overrides #1739's righome work and services.sharedConfigRefusal
+	// enumerate, plus HOME itself, which newScratchHome sets explicitly after
+	// the scrub rather than keeping.
+	for _, name := range []string{
+		"HOME", "CODEX_HOME", "COPILOT_HOME", "KIRO_HOME", "VIBE_HOME",
+		"XDG_CONFIG_HOME", "CLAUDE_CONFIG_DIR", "IRRLICHT_HOME",
+		"IRRLICHT_ALLOW_SHARED_CONFIG_WRITES", "PI_CODING_AGENT_SESSION_DIR",
+	} {
+		if envKeptDuringScrub(name) {
+			t.Errorf("the scrub KEEPS %s — an adapter honouring it would resolve its install "+
+				"against the developer's real environment while this test reported on an "+
+				"empty scratch tree", name)
+		}
+	}
+}

--- a/core/cmd/irrlichd/managedwrites_test.go
+++ b/core/cmd/irrlichd/managedwrites_test.go
@@ -1,0 +1,873 @@
+// managedwrites_test.go closes the gap issue #1741 was filed about, one file
+// over from managedfiles_test.go's TestEveryModifyPermissionDeclaresTheFileItWrites.
+//
+// That test asks whether a modify-kind permission with a non-nil Apply HAS a
+// Writes declaration. It never asks whether the declaration COVERS every file
+// that Apply actually writes, and the difference has produced two real defects:
+//
+//   - #1718/#1731 — kiro-cli's and mistral-vibe's installs each wrote a SECOND
+//     shared user file no declaration named. Fixed by adding
+//     agent.ManagedUserFile.Also.
+//   - #1739 — kiro-cli's recordPriorDefaultAgentOnce writes
+//     $KIRO_HOME/.irrlicht-prior-default.json, undeclared even AFTER Also
+//     existed. Not inert: that function deliberately never overwrites, so a
+//     copy left behind by a recording is what a LATER real grant reads instead
+//     of the operator's actual chat.defaultAgent.
+//
+// An undeclared file is invisible to `--print-managed-files`, therefore to the
+// recording rig's snapshot_managed_files backup, and therefore to #1449's
+// PermissionService.sharedConfigRefusal. All three read the declaration.
+//
+// # Two arms, because one mechanism cannot reach every permission
+//
+// RUNTIME (TestEveryModifyPermissionDeclaresEveryFileItsApplyWrites) is the
+// arm that carries the weight: it runs each Apply against a scratch $HOME and
+// grades the files that actually changed. That is the only thing that sees a
+// path built inline with filepath.Join inside Apply — the shape #1741 measured
+// the obvious static rule to miss entirely — and it needs no per-adapter
+// knowledge, so a NEW modify permission is graded by existing rather than by
+// someone remembering this file.
+//
+// STATIC (TestExternalInstallerPackagesDeclareEveryPathResolver) exists for the
+// one permission the runtime arm must not execute. kiro-cli's Apply shells out
+// to the real kiro-cli binary (`agent create`, `agent set-default`), and
+// running it inside `go test ./core/...` was measured, not assumed, to be
+// non-deterministic in two independent ways:
+//
+//   - The binary is present on a developer machine and absent on a CI runner.
+//     With it absent, EnsureHooksInstalled fails at its first step and writes
+//     NOTHING — the check would pass having graded nothing, which is exactly
+//     the "inability to look reads as a clean result" failure
+//     docs/testing-philosophy.md is about.
+//   - With it present, the CHILD process writes its own state: measured on
+//     2026-08-22, `kiro-cli agent create irrlicht --from kiro_default` under a
+//     scratch $HOME created
+//     $HOME/Library/Application Support/kiro-cli/data.sqlite3 (see the PR body
+//     for the raw output). Which further files it writes depends on whether
+//     the developer is logged in — a verdict nobody controls.
+//
+// So kiro-cli's Apply is not run. Its permission is named in
+// applyRunsAnExternalCLI with that reason, and the static arm grades its
+// package instead: every package-level `func() (string, error)` there must be
+// one the declaration names, or be named in notAManagedFilePath with why. The
+// declared side is DERIVED from production by reflecting the function names out
+// of Writes.Path/Writes.Also, so it cannot drift from a hand-kept list, and the
+// walk is vacuity-guarded by requiring every reflected name to be found in the
+// package it claims to have parsed.
+//
+// #1741 measured the static rule at roughly one false positive per adapter —
+// every adapter has a home-ROOT resolver with that exact signature — which is
+// why it is scoped to the packages the runtime arm cannot execute rather than
+// run catalog-wide. One exemption today, not eight.
+//
+// # What NEITHER arm covers
+//
+// Stated here rather than left to be discovered; the corpus in
+// managedwrites_shapes_test.go pins each of these that a case can express.
+//
+//   - A write to an absolute path that follows neither $HOME nor any
+//     environment variable (a hard-coded /etc/... say) lands outside the walked
+//     scratch tree and is invisible to the runtime arm. The static arm sees it
+//     only if it goes through a package-level resolver.
+//   - A write that leaves size, mtime AND content byte-identical is not a
+//     change any snapshot diff can see.
+//   - A permission that creates only a DIRECTORY (no file in it) is not
+//     reported: the walk records non-directory entries.
+//   - gastown/state's Apply is the no-op declaredConsentCatalog passes, not the
+//     watcher the daemon wires, so running it grades the no-op. It declares no
+//     Writes and is already covered by applyWritesNoUserFile next door.
+//   - The static arm reads FuncDecls. A resolver held in a package-level var
+//     (`var p = func() (string, error) {…}`) is not seen — fail-closed in the
+//     wrong direction here, since it would read as "no undeclared resolver", so
+//     it is pinned as a want:false corpus row rather than left implied. It is
+//     the same declared limit core/architecture_hookbody_test.go and
+//     contracttesting/seam_walk_corpus_test.go carry for their own walks.
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"sort"
+	"strings"
+	"testing"
+
+	"irrlicht/core/domain/agent"
+)
+
+// ---------------------------------------------------------------------------
+// Declarations
+// ---------------------------------------------------------------------------
+
+// externalInstaller describes a permission whose Apply spawns an agent's own
+// CLI, which is why the runtime arm must not execute it. Binary is checked
+// against the permission's OWN declared version probe, so an entry cannot name
+// a tool the permission has nothing to do with.
+type externalInstaller struct {
+	// Binary is the executable Apply spawns. It must equal the first element
+	// of the permission's Writes.Version.Probe — the same constant the adapter
+	// resolves the binary from — so this map cannot claim a shellout the
+	// declaration does not corroborate.
+	Binary string
+	// Reason is why running it inside `go test` is not acceptable.
+	Reason string
+}
+
+// applyRunsAnExternalCLI names every permission whose Apply the runtime arm
+// refuses to execute, with the reason. Keys are existence-checked in both
+// directions: an entry naming a permission that does not exist, or one whose
+// Apply is nil, fails — an exemption for an obligation nobody had reads as
+// coverage.
+//
+// It is deliberately a list rather than a derived predicate. "Does this
+// package contain exec.Command" is derivable and wrong: processlifecycle
+// contains several and kitty's Apply spawns none of them, so the derived
+// version would wave through the one permission in that package that a scratch
+// home CAN grade. Reachability from Apply is the property, and nothing short of
+// a call-graph walk decides it — so this is a claim someone wrote down and a
+// reviewer can check, the same trade applyWritesNoUserFile makes next door.
+var applyRunsAnExternalCLI = map[string]externalInstaller{
+	"kiro-cli/hooks": {
+		Binary: "kiro-cli",
+		Reason: "EnsureHooksInstalled shells out to `kiro-cli agent create` and " +
+			"`kiro-cli agent set-default` (kiroctl.go). Measured 2026-08-22: with the " +
+			"binary ABSENT the closure fails at its first step and writes nothing, so the " +
+			"runtime arm would grade an empty set; with it PRESENT the child writes its own " +
+			"state under $HOME/Library/Application Support/kiro-cli/, and how much more it " +
+			"writes depends on whether the developer is logged in. Either way the verdict " +
+			"stops being a property of this repo. Graded by the static arm instead",
+	},
+}
+
+// notAManagedFilePath names package-level (string, error) resolvers in an
+// external-installer package that legitimately name no managed user file, with
+// the reason. Keys are "<package>.<func>" and are existence-checked: an entry
+// the walk does not find is stale and fails.
+//
+// #1741 measured this class at roughly one per adapter — the home ROOT every
+// other path in the package is built on. Scoping the static arm to the packages
+// the runtime arm cannot execute is what keeps this map at one entry.
+var notAManagedFilePath = map[string]string{
+	"kirocli.kiroHome": "resolves $KIRO_HOME itself — the directory every other resolver in " +
+		"the package joins onto, not a file anything writes",
+}
+
+// scratchAllowances are the subtrees of the scratch home whose contents are not
+// graded, with the reason. Deliberately NOT existence-checked: this is a
+// BOUNDARY, not a finding, so an allowance that matches nothing is the ordinary
+// case rather than a stale entry.
+func scratchAllowances(sh scratchHome) []allowance {
+	rel, err := filepath.Rel(sh.Root, sh.IrrlichtHome)
+	if err != nil {
+		rel = filepath.Base(sh.IrrlichtHome)
+	}
+	return []allowance{{
+		Root: rel,
+		Reason: "IRRLICHT_HOME — the daemon's OWN state, which agent.ManagedUserFile is " +
+			"defined against rather than a member of (a managed file follows $HOME and " +
+			"outlives the daemon; this tree does neither)",
+	}}
+}
+
+// ---------------------------------------------------------------------------
+// The runtime arm
+// ---------------------------------------------------------------------------
+
+// TestEveryModifyPermissionDeclaresEveryFileItsApplyWrites runs each modify
+// permission's Apply against a scratch $HOME and grades the files that changed
+// against what the permission declares.
+//
+// Two obligations, and both directions are load-bearing:
+//
+//   - Every file Apply WROTE is declared. This is #1741 itself — an undeclared
+//     write is invisible to --print-managed-files, to the recording rig's
+//     backup, and to #1449's refusal.
+//   - Every file the permission DECLARES was written. This is the vacuity
+//     guard, and it is the one that makes a misconfigured sandbox loud instead
+//     of clean: if $HOME had not taken, every closure would write to the real
+//     home, the scratch diff would be EMPTY, and a check that only looked for
+//     undeclared writes would report a flawless sweep.
+//
+// Contract test — it passes by construction against a correct catalog, so its
+// whole value is that it can fail. Seen red by deleting mistral-vibe's Also
+// entry and by neutering kitty's write (see the PR body); the corpus in
+// managedwrites_shapes_test.go carries the committed mutation evidence for the
+// grading itself.
+func TestEveryModifyPermissionDeclaresEveryFileItsApplyWrites(t *testing.T) {
+	sh := newScratchHome(t)
+
+	// Built AFTER the scratch home is in place: three adapters compute a static
+	// Source.Dir at Agent() construction time, so a registry built earlier is
+	// frozen against the developer's real environment (the same ordering
+	// righome.registryAdapterAfterEnv documents).
+	catalog := declaredConsentCatalog()
+	if len(catalog) == 0 {
+		t.Fatal("empty consent catalog — this check would pass vacuously")
+	}
+
+	// FAIL CLOSED. Every declared path in the WHOLE catalog is resolved and
+	// proven to land inside the scratch tree before a single closure runs.
+	//
+	// #1449's PermissionService.sharedConfigRefusal asks the same lexical
+	// question, and is deliberately not what runs here: it refuses one Apply at
+	// a time, from inside the service, so the first eight closures would have
+	// executed before the ninth's escape was noticed. A test that executes
+	// installers needs containment established for all of them up front, and it
+	// needs it without an IRRLICHT_ALLOW_SHARED_CONFIG_WRITES escape hatch in
+	// reach.
+	graded := gradablePermissions(t, catalog)
+	for _, g := range graded {
+		for _, f := range g.declared {
+			if f.err != nil {
+				t.Fatalf("%s: resolving %s failed (%v) — a test that cannot name the file a "+
+					"closure is about to write must not run that closure", g.id, f.label, f.err)
+			}
+			if !filepath.IsAbs(f.abs) || !pathUnderDir(sh.Root, f.abs) {
+				t.Fatalf("%s declares %s = %q, which is OUTSIDE the scratch home %q. "+
+					"Refusing to run any Apply: this test would be writing to a shared config "+
+					"the developer actually uses", g.id, f.label, f.abs, sh.Root)
+			}
+		}
+	}
+
+	allowed := scratchAllowances(sh)
+	executed := 0
+	for _, g := range graded {
+		t.Run(g.id, func(t *testing.T) {
+			before := walkScratch(t, sh.Root)
+			applyErr := g.perm.Apply()
+			after := walkScratch(t, sh.Root)
+
+			if applyErr != nil {
+				t.Fatalf("Apply returned %v — the closure was cut short, so the file set below "+
+					"is whatever it managed before failing and grading it would report a "+
+					"partial sweep as a clean one. If this permission's install genuinely "+
+					"cannot complete in a scratch home, name it in applyRunsAnExternalCLI "+
+					"with the reason", applyErr)
+			}
+
+			observed := treeDiff(before, after)
+			v := gradeWrites(observed, g.declaredRel(sh.Root), allowed)
+
+			for _, p := range v.Undeclared {
+				t.Errorf("Apply wrote %q, which %s declares in neither Writes.Path nor "+
+					"Writes.Also. That file is invisible to --print-managed-files, so the "+
+					"recording rig never backs it up and #1449's grant-all refusal never sees "+
+					"it (#1741). Declare it, or explain it as an allowance", p, g.id)
+			}
+			for _, p := range v.Missing {
+				t.Errorf("%s declares %q but running Apply changed nothing there. Either the "+
+					"declaration resolves to the wrong file, or the closure no longer writes "+
+					"it — and if NEITHER is true, the scratch home is not where the writes "+
+					"went, which makes every 'no undeclared write' result above meaningless",
+					g.id, p)
+			}
+		})
+		executed++
+	}
+
+	if executed == 0 {
+		t.Fatal("no permission was executed — every modify permission is exempt, so this " +
+			"check graded nothing")
+	}
+}
+
+// gradablePermission is one permission the runtime arm will execute, with its
+// declaration already resolved.
+type gradablePermission struct {
+	id       string
+	perm     agent.Permission
+	declared []declaredFile
+}
+
+// declaredFile is one entry of a permission's Writes, resolved.
+type declaredFile struct {
+	label string // "Writes.Path" / "Writes.Also[0]"
+	abs   string
+	err   error
+}
+
+func (g gradablePermission) declaredRel(root string) []string {
+	out := make([]string, 0, len(g.declared))
+	for _, f := range g.declared {
+		rel, err := filepath.Rel(root, f.abs)
+		if err != nil {
+			continue
+		}
+		out = append(out, rel)
+	}
+	return out
+}
+
+// gradablePermissions selects the permissions the runtime arm executes and
+// validates every exemption's key while it is at it: an entry in
+// applyRunsAnExternalCLI that names no real permission, or one whose Binary
+// disagrees with the permission's own version probe, is a claim of coverage
+// nobody can check.
+func gradablePermissions(t *testing.T, catalog []agent.Agent) []gradablePermission {
+	t.Helper()
+
+	seen := map[string]bool{}
+	var out []gradablePermission
+	for _, a := range catalog {
+		for _, p := range a.Permissions {
+			if p.Apply == nil {
+				continue
+			}
+			id := a.Identity.Name + "/" + p.Key
+			seen[id] = true
+			if ext, skip := applyRunsAnExternalCLI[id]; skip {
+				assertExternalInstallerAgrees(t, id, ext, p)
+				continue
+			}
+			out = append(out, gradablePermission{id: id, perm: p, declared: resolveDeclared(p)})
+		}
+	}
+
+	for id := range applyRunsAnExternalCLI {
+		if !seen[id] {
+			t.Errorf("applyRunsAnExternalCLI names %q, which is not a permission with an Apply "+
+				"closure in the consent catalog — an exemption for an obligation that does not "+
+				"exist reads as coverage", id)
+		}
+	}
+	return out
+}
+
+// assertExternalInstallerAgrees ties an exemption to the permission's own
+// declaration. Without it the map is free text: any permission could be waved
+// out of the runtime arm by asserting it shells out to something.
+func assertExternalInstallerAgrees(t *testing.T, id string, ext externalInstaller, p agent.Permission) {
+	t.Helper()
+	if strings.TrimSpace(ext.Reason) == "" {
+		t.Errorf("applyRunsAnExternalCLI[%q] carries no reason", id)
+	}
+	if p.Writes == nil || p.Writes.Version == nil || len(p.Writes.Version.Probe) == 0 {
+		t.Errorf("applyRunsAnExternalCLI[%q] claims Apply spawns %q, but the permission "+
+			"declares no Writes.Version.Probe to corroborate it", id, ext.Binary)
+		return
+	}
+	if got := p.Writes.Version.Probe[0]; got != ext.Binary {
+		t.Errorf("applyRunsAnExternalCLI[%q] names binary %q, but the permission's own version "+
+			"probe runs %q — one of the two is stale and a reader cannot tell which",
+			id, ext.Binary, got)
+	}
+}
+
+// resolveDeclared resolves Writes.Path and every Writes.Also entry, keeping the
+// resolution error rather than dropping it: a resolver that fails is a file we
+// cannot prove is inside the scratch home, which is the fail-closed case.
+func resolveDeclared(p agent.Permission) []declaredFile {
+	if p.Writes == nil {
+		return nil
+	}
+	var out []declaredFile
+	if p.Writes.Path != nil {
+		abs, err := p.Writes.Path()
+		out = append(out, declaredFile{label: "Writes.Path", abs: abs, err: err})
+	}
+	for i, also := range p.Writes.Also {
+		abs, err := also()
+		out = append(out, declaredFile{label: fmt.Sprintf("Writes.Also[%d]", i), abs: abs, err: err})
+	}
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// The scratch home
+// ---------------------------------------------------------------------------
+
+// scratchHome is the tree every closure under test is confined to.
+type scratchHome struct {
+	// Root is what the walk covers.
+	Root string
+	// Home is $HOME, inside Root.
+	Home string
+	// IrrlichtHome is $IRRLICHT_HOME, also inside Root so a write there is
+	// SEEN and explained by an allowance rather than landing outside the walk.
+	IrrlichtHome string
+}
+
+// envKeptDuringScrub names the environment variables the scratch home leaves
+// alone. Everything else is emptied.
+//
+// An ALLOW-list, not a deny-list, and that is the whole point. A deny-list has
+// to enumerate every override an adapter might honour — CODEX_HOME,
+// COPILOT_HOME, KIRO_HOME, VIBE_HOME, XDG_CONFIG_HOME, CLAUDE_CONFIG_DIR today
+// — and the day a new adapter reads a new one, its Apply writes to the
+// developer's real config while this test believes it is sandboxed. Emptying
+// everything means an unknown override resolves to "" and the adapter falls
+// back to its $HOME-relative default, which IS the scratch home.
+func envKeptDuringScrub(name string) bool {
+	switch name {
+	case "PATH", "TMPDIR", "TMP", "TEMP":
+		return true
+	}
+	// The go tooling's own variables. No adapter path resolution reads one, and
+	// clearing them buys nothing.
+	return strings.HasPrefix(name, "GO")
+}
+
+// scrubCanary is set, then swept up by the scrub itself, so "the scrub ran" is
+// observed rather than assumed. Without it a scrub loop that silently did
+// nothing would leave the developer's real overrides in place and the test
+// would report on their real config.
+const scrubCanary = "IRRLICHT_MANAGEDWRITES_SCRUB_CANARY"
+
+// newScratchHome builds the tree and points the process at it.
+func newScratchHome(t *testing.T) scratchHome {
+	t.Helper()
+	root := t.TempDir()
+	sh := scratchHome{
+		Root:         root,
+		Home:         filepath.Join(root, "home"),
+		IrrlichtHome: filepath.Join(root, "irrlicht-home"),
+	}
+	for _, dir := range []string{sh.Home, sh.IrrlichtHome} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("creating %s: %v", dir, err)
+		}
+	}
+
+	t.Setenv(scrubCanary, filepath.Join(string(filepath.Separator), "definitely", "not", "the", "scratch", "home"))
+	for _, kv := range os.Environ() {
+		name, _, ok := strings.Cut(kv, "=")
+		if !ok || envKeptDuringScrub(name) {
+			continue
+		}
+		t.Setenv(name, "")
+	}
+	if got := os.Getenv(scrubCanary); got != "" {
+		t.Fatalf("the environment scrub left %s=%q — it did not run, so every per-agent home "+
+			"override the developer exports is still in effect and the closures below would "+
+			"write to their real config", scrubCanary, got)
+	}
+
+	t.Setenv("HOME", sh.Home)
+	t.Setenv("IRRLICHT_HOME", sh.IrrlichtHome)
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatalf("os.UserHomeDir after pointing HOME at the scratch home: %v", err)
+	}
+	if home != sh.Home {
+		t.Fatalf("os.UserHomeDir() = %q, want the scratch home %q — every $HOME-anchored "+
+			"resolver below would land in the developer's real home", home, sh.Home)
+	}
+	return sh
+}
+
+// ---------------------------------------------------------------------------
+// Snapshot / diff / grading — the pure half, driven by the corpus
+// ---------------------------------------------------------------------------
+
+// fileState is what one walk records for one path. Content AND mtime AND size:
+// a rewrite that happens to produce identical bytes still moves mtime, so
+// hashing alone would miss it, and hashing is what tells two same-sized
+// same-second writes apart.
+type fileState struct {
+	Size    int64
+	ModNano int64
+	Sum     string
+	Mode    fs.FileMode
+}
+
+// walkScratch records every non-directory entry under root, keyed relative to
+// it. Symlinks are recorded by their target rather than followed: a closure
+// that plants a link into the user's home has written something, and following
+// it would hash whatever it points at instead.
+func walkScratch(t *testing.T, root string) map[string]fileState {
+	t.Helper()
+	out := map[string]fileState{}
+	err := filepath.WalkDir(root, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		rel, relErr := filepath.Rel(root, p)
+		if relErr != nil {
+			return relErr
+		}
+		info, infoErr := d.Info()
+		if infoErr != nil {
+			return infoErr
+		}
+		st := fileState{Size: info.Size(), ModNano: info.ModTime().UnixNano(), Mode: info.Mode()}
+		if d.Type()&fs.ModeSymlink != 0 {
+			target, linkErr := os.Readlink(p)
+			if linkErr != nil {
+				return linkErr
+			}
+			st.Sum = "-> " + target
+		} else if d.Type().IsRegular() {
+			data, readErr := os.ReadFile(p) // #nosec G304 -- path comes from walking a t.TempDir()
+			if readErr != nil {
+				return readErr
+			}
+			sum := sha256.Sum256(data)
+			st.Sum = hex.EncodeToString(sum[:])
+		}
+		out[rel] = st
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking the scratch home %s: %v — a walk that cannot read the tree reports "+
+			"the same empty diff as a closure that wrote nothing", root, err)
+	}
+	return out
+}
+
+// treeDiff returns every path whose state differs between two walks — created,
+// modified, or REMOVED. Removal counts: a permission that deletes a shared user
+// file has written to it in every sense this declaration is about.
+func treeDiff(before, after map[string]fileState) []string {
+	changed := map[string]bool{}
+	for p, now := range after {
+		if was, existed := before[p]; !existed || was != now {
+			changed[p] = true
+		}
+	}
+	for p := range before {
+		if _, still := after[p]; !still {
+			changed[p] = true
+		}
+	}
+	out := make([]string, 0, len(changed))
+	for p := range changed {
+		out = append(out, p)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// allowance is a subtree of the scratch home whose contents are not graded.
+type allowance struct {
+	Root   string
+	Reason string
+}
+
+// writeVerdict is what gradeWrites found.
+type writeVerdict struct {
+	// Undeclared are observed paths in neither the declared set nor an
+	// allowance — issue #1741 itself.
+	Undeclared []string
+	// Missing are declared paths nothing wrote — the vacuity direction.
+	Missing []string
+	// Allowed counts, per allowance root, how many observed paths it absorbed,
+	// so a caller that wants to check an allowance is not dead can.
+	Allowed map[string]int
+}
+
+// gradeWrites is the whole judgement, as a pure function so the corpus in
+// managedwrites_shapes_test.go can drive it with inputs the live catalog cannot
+// produce. All three inputs are scratch-relative paths.
+func gradeWrites(observed, declared []string, allowed []allowance) writeVerdict {
+	v := writeVerdict{Allowed: map[string]int{}}
+	for _, a := range allowed {
+		v.Allowed[a.Root] = 0
+	}
+
+	isDeclared := make(map[string]bool, len(declared))
+	for _, d := range declared {
+		isDeclared[d] = true
+	}
+
+	seen := map[string]bool{}
+	for _, p := range observed {
+		if isDeclared[p] {
+			seen[p] = true
+			continue
+		}
+		if root, ok := allowanceFor(p, allowed); ok {
+			v.Allowed[root]++
+			continue
+		}
+		v.Undeclared = append(v.Undeclared, p)
+	}
+	for _, d := range declared {
+		if !seen[d] {
+			v.Missing = append(v.Missing, d)
+		}
+	}
+	sort.Strings(v.Undeclared)
+	sort.Strings(v.Missing)
+	return v
+}
+
+// allowanceFor reports which allowance absorbs p, if any.
+func allowanceFor(p string, allowed []allowance) (string, bool) {
+	for _, a := range allowed {
+		if pathUnderRel(a.Root, p) {
+			return a.Root, true
+		}
+	}
+	return "", false
+}
+
+// pathUnderRel reports whether the relative path p is root itself or lies
+// beneath it. Segment-aware on purpose: a string-prefix test would let an
+// allowance for "Library/App" absorb "Library/Apple.txt", which is a different
+// file entirely.
+func pathUnderRel(root, p string) bool {
+	root = filepath.Clean(root)
+	p = filepath.Clean(p)
+	return p == root || strings.HasPrefix(p, root+string(filepath.Separator))
+}
+
+// pathUnderDir is pathUnderRel for absolute paths, and is the containment rule
+// the fail-closed precondition uses. Deliberately lexical, for the same reason
+// services.pathInsideRoot is: the input is our own resolver's output rather
+// than a caller's, and the only direction this can err in is refusing to run,
+// which is the safe one.
+func pathUnderDir(dir, p string) bool {
+	if !filepath.IsAbs(dir) || !filepath.IsAbs(p) {
+		return false
+	}
+	rel, err := filepath.Rel(filepath.Clean(dir), filepath.Clean(p))
+	if err != nil {
+		return false
+	}
+	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)))
+}
+
+// ---------------------------------------------------------------------------
+// The static arm
+// ---------------------------------------------------------------------------
+
+// TestExternalInstallerPackagesDeclareEveryPathResolver grades the packages the
+// runtime arm refuses to execute: every package-level `func() (string, error)`
+// in one of them must be a resolver the permission's own declaration names, or
+// be named in notAManagedFilePath with why.
+//
+// That signature is what #1741 measured, including its false-positive rate. The
+// reason it is worth running HERE and not catalog-wide is arithmetic: scoped to
+// the external-installer packages it costs one exemption, and catalog-wide it
+// would cost one per adapter while adding nothing the runtime arm does not
+// already cover more strongly.
+//
+// Contract test — it passes by construction; seen red by deleting
+// priorDefaultStatePath from kirocli's Writes.Also (see the PR body), which is
+// #1739 exactly.
+func TestExternalInstallerPackagesDeclareEveryPathResolver(t *testing.T) {
+	catalog := declaredConsentCatalog()
+	permByID := map[string]agent.Permission{}
+	for _, a := range catalog {
+		for _, p := range a.Permissions {
+			permByID[a.Identity.Name+"/"+p.Key] = p
+		}
+	}
+
+	if len(applyRunsAnExternalCLI) == 0 {
+		t.Skip("no permission is exempt from the runtime arm, so there is nothing for the " +
+			"static fallback to grade")
+	}
+
+	usedExemptions := map[string]bool{}
+	for id := range applyRunsAnExternalCLI {
+		p, ok := permByID[id]
+		if !ok {
+			continue // reported by the runtime arm's own key check
+		}
+		t.Run(id, func(t *testing.T) {
+			gradeExternalInstallerPackage(t, id, p, usedExemptions)
+		})
+	}
+
+	for key, reason := range notAManagedFilePath {
+		if !usedExemptions[key] {
+			t.Errorf("notAManagedFilePath names %q (%q), which the walk did not find in any "+
+				"external-installer package — a stale exemption reads as coverage", key, reason)
+		}
+	}
+}
+
+func gradeExternalInstallerPackage(t *testing.T, id string, p agent.Permission, usedExemptions map[string]bool) {
+	t.Helper()
+
+	declared := declaredResolverNames(p)
+	if len(declared) == 0 {
+		t.Fatalf("%s declares no path resolver at all, so this arm has nothing to anchor on", id)
+	}
+	pkgDir, pkgName, err := packageDirOfResolver(declared[0])
+	if err != nil {
+		t.Fatalf("%s: %v", id, err)
+	}
+
+	found, err := packageLevelPathResolvers(pkgDir)
+	if err != nil {
+		t.Fatalf("%s: parsing %s: %v — a walk that cannot read the package reports the same "+
+			"empty result as a package with nothing wrong in it", id, pkgDir, err)
+	}
+	if len(found) == 0 {
+		t.Fatalf("%s: the walk found no package-level (string, error) resolver in %s at all, "+
+			"yet the declaration names %d — the walk is looking at the wrong place",
+			id, pkgDir, len(declared))
+	}
+
+	isDeclared := map[string]bool{}
+	for _, qualified := range declared {
+		name := qualified[strings.LastIndex(qualified, ".")+1:]
+		isDeclared[name] = true
+		// Vacuity guard: every name the declaration reflects out MUST be one
+		// the walk saw, or the two are describing different code.
+		if !containsString(found, name) {
+			t.Errorf("%s declares resolver %q, which the walk did not find in %s — the "+
+				"declaration and the walk disagree about which package this permission "+
+				"lives in, so every verdict below is about the wrong files", id, name, pkgDir)
+		}
+	}
+
+	for _, name := range found {
+		if isDeclared[name] {
+			continue
+		}
+		key := pkgName + "." + name
+		if reason, exempt := notAManagedFilePath[key]; exempt {
+			usedExemptions[key] = true
+			_ = reason
+			continue
+		}
+		t.Errorf("%s.%s is a package-level path resolver that %s declares in neither "+
+			"Writes.Path nor Writes.Also. If its Apply writes that file, it is invisible to "+
+			"--print-managed-files, to the recording rig's backup and to #1449's grant-all "+
+			"refusal (#1739). Declare it, or add %q to notAManagedFilePath with the reason "+
+			"it names no managed file", pkgName, name, id, key)
+	}
+}
+
+// declaredResolverNames reflects the fully qualified function names out of a
+// permission's Writes, so the "declared" side of the static arm is derived from
+// production rather than restated. A closure or method value yields a name the
+// package walk cannot match, which surfaces as the vacuity failure above rather
+// than as silence.
+func declaredResolverNames(p agent.Permission) []string {
+	if p.Writes == nil {
+		return nil
+	}
+	var out []string
+	add := func(f func() (string, error)) {
+		if f == nil {
+			return
+		}
+		fn := runtime.FuncForPC(reflect.ValueOf(f).Pointer())
+		if fn == nil {
+			return
+		}
+		out = append(out, fn.Name())
+	}
+	add(p.Writes.Path)
+	for _, also := range p.Writes.Also {
+		add(also)
+	}
+	return out
+}
+
+// packageDirOfResolver turns "irrlicht/core/adapters/.../kirocli.foo" into the
+// directory holding that package and its short name. The module is
+// "irrlicht/core" rooted at core/, so the import path's first segment is
+// dropped to reach a repo-relative directory.
+func packageDirOfResolver(qualified string) (dir, pkgName string, err error) {
+	dot := strings.LastIndex(qualified, ".")
+	if dot < 0 {
+		return "", "", fmt.Errorf("reflected resolver name %q has no package qualifier", qualified)
+	}
+	importPath := qualified[:dot]
+	const modulePrefix = "irrlicht/"
+	if !strings.HasPrefix(importPath, modulePrefix) {
+		return "", "", fmt.Errorf("reflected resolver name %q is not in this module", qualified)
+	}
+	rel := strings.TrimPrefix(importPath, modulePrefix)
+	// This test's own package is core/cmd/irrlichd.
+	dir = filepath.Join("..", "..", "..", filepath.FromSlash(rel))
+	if _, statErr := os.Stat(dir); statErr != nil {
+		return "", "", fmt.Errorf("resolver %q maps to %s, which does not exist: %w", qualified, dir, statErr)
+	}
+	return dir, path7Base(rel), nil
+}
+
+func path7Base(importPath string) string {
+	if i := strings.LastIndex(importPath, "/"); i >= 0 {
+		return importPath[i+1:]
+	}
+	return importPath
+}
+
+// packageLevelPathResolvers returns the names of every package-level
+// `func() (string, error)` declared in dir's non-test files, sorted.
+//
+// FuncDecls only, and with no receiver: a method is not something a
+// ManagedUserFile can name, and a func literal in a package-level var hangs off
+// a ValueSpec rather than a FuncDecl. Both are pinned as want:false rows in the
+// corpus rather than left as folklore.
+func packageLevelPathResolvers(dir string) ([]string, error) {
+	fset := token.NewFileSet()
+	pkgs, err := parser.ParseDir(fset, dir, func(fi os.FileInfo) bool {
+		return !strings.HasSuffix(fi.Name(), "_test.go")
+	}, 0)
+	if err != nil {
+		return nil, err
+	}
+	var out []string
+	for _, pkg := range pkgs {
+		for _, file := range pkg.Files {
+			for _, decl := range file.Decls {
+				fn, ok := decl.(*ast.FuncDecl)
+				if !ok || fn.Recv != nil {
+					continue
+				}
+				if isPathResolverSignature(fn.Type) {
+					out = append(out, fn.Name.Name)
+				}
+			}
+		}
+	}
+	sort.Strings(out)
+	return out, nil
+}
+
+// isPathResolverSignature reports whether ft is exactly `() (string, error)`.
+func isPathResolverSignature(ft *ast.FuncType) bool {
+	if ft == nil || ft.Results == nil {
+		return false
+	}
+	if ft.Params != nil && len(ft.Params.List) != 0 {
+		return false
+	}
+	if ft.TypeParams != nil && len(ft.TypeParams.List) > 0 {
+		return false
+	}
+	var results []string
+	for _, f := range ft.Results.List {
+		id, ok := f.Type.(*ast.Ident)
+		if !ok {
+			return false
+		}
+		n := 1
+		if len(f.Names) > 1 {
+			n = len(f.Names)
+		}
+		for i := 0; i < n; i++ {
+			results = append(results, id.Name)
+		}
+	}
+	return len(results) == 2 && results[0] == "string" && results[1] == "error"
+}
+
+func containsString(haystack []string, needle string) bool {
+	for _, s := range haystack {
+		if s == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/core/cmd/irrlichd/managedwrites_test.go
+++ b/core/cmd/irrlichd/managedwrites_test.go
@@ -325,21 +325,31 @@ func gradablePermissions(t *testing.T, catalog []agent.Agent) []gradablePermissi
 
 	seen := map[string]bool{}
 	var out []gradablePermission
-	for _, a := range catalog {
-		for _, p := range a.Permissions {
-			if p.Apply == nil {
-				continue
-			}
-			id := a.Identity.Name + "/" + p.Key
-			seen[id] = true
-			if ext, skip := applyRunsAnExternalCLI[id]; skip {
-				assertExternalInstallerAgrees(t, id, ext, p)
-				continue
-			}
-			out = append(out, gradablePermission{id: id, perm: p, declared: resolveDeclared(p)})
+	for id, p := range permissionsByID(catalog) {
+		if p.Apply == nil {
+			continue
 		}
+		seen[id] = true
+		if ext, skip := applyRunsAnExternalCLI[id]; skip {
+			assertExternalInstallerAgrees(t, id, ext, p)
+			continue
+		}
+		out = append(out, gradablePermission{id: id, perm: p, declared: resolveDeclared(p)})
 	}
+	// Map iteration is unordered; the sub-tests below are named per permission
+	// and a stable order keeps a failure reproducible.
+	sort.Slice(out, func(i, j int) bool { return out[i].id < out[j].id })
 
+	assertNoStaleExternalInstallerKeys(t, seen)
+	return out
+}
+
+// assertNoStaleExternalInstallerKeys is applyRunsAnExternalCLI's existence
+// check: an entry for a permission that has no Apply closure — or does not
+// exist — is an exemption from an obligation nobody had, which reads as
+// coverage.
+func assertNoStaleExternalInstallerKeys(t *testing.T, seen map[string]bool) {
+	t.Helper()
 	for id := range applyRunsAnExternalCLI {
 		if !seen[id] {
 			t.Errorf("applyRunsAnExternalCLI names %q, which is not a permission with an Apply "+
@@ -347,7 +357,6 @@ func gradablePermissions(t *testing.T, catalog []agent.Agent) []gradablePermissi
 				"exist reads as coverage", id)
 		}
 	}
-	return out
 }
 
 // assertExternalInstallerAgrees ties an exemption to the permission's own
@@ -489,9 +498,7 @@ type fileState struct {
 }
 
 // walkScratch records every non-directory entry under root, keyed relative to
-// it. Symlinks are recorded by their target rather than followed: a closure
-// that plants a link into the user's home has written something, and following
-// it would hash whatever it points at instead.
+// it. See stateOf for what one entry's record holds.
 func walkScratch(t *testing.T, root string) map[string]fileState {
 	t.Helper()
 	out := map[string]fileState{}
@@ -506,24 +513,9 @@ func walkScratch(t *testing.T, root string) map[string]fileState {
 		if relErr != nil {
 			return relErr
 		}
-		info, infoErr := d.Info()
-		if infoErr != nil {
-			return infoErr
-		}
-		st := fileState{Size: info.Size(), ModNano: info.ModTime().UnixNano(), Mode: info.Mode()}
-		if d.Type()&fs.ModeSymlink != 0 {
-			target, linkErr := os.Readlink(p)
-			if linkErr != nil {
-				return linkErr
-			}
-			st.Sum = "-> " + target
-		} else if d.Type().IsRegular() {
-			data, readErr := os.ReadFile(p) // #nosec G304 -- path comes from walking a t.TempDir()
-			if readErr != nil {
-				return readErr
-			}
-			sum := sha256.Sum256(data)
-			st.Sum = hex.EncodeToString(sum[:])
+		st, stErr := stateOf(p, d)
+		if stErr != nil {
+			return stErr
 		}
 		out[rel] = st
 		return nil
@@ -533,6 +525,33 @@ func walkScratch(t *testing.T, root string) map[string]fileState {
 			"the same empty diff as a closure that wrote nothing", root, err)
 	}
 	return out
+}
+
+// stateOf records one entry. A symlink is recorded by its TARGET rather than
+// followed: a closure that plants a link into the user's home has written
+// something, and following it would hash whatever it points at instead.
+func stateOf(p string, d fs.DirEntry) (fileState, error) {
+	info, err := d.Info()
+	if err != nil {
+		return fileState{}, err
+	}
+	st := fileState{Size: info.Size(), ModNano: info.ModTime().UnixNano(), Mode: info.Mode()}
+	switch {
+	case d.Type()&fs.ModeSymlink != 0:
+		target, linkErr := os.Readlink(p)
+		if linkErr != nil {
+			return fileState{}, linkErr
+		}
+		st.Sum = "-> " + target
+	case d.Type().IsRegular():
+		data, readErr := os.ReadFile(p) // #nosec G304 -- path comes from walking a t.TempDir()
+		if readErr != nil {
+			return fileState{}, readErr
+		}
+		sum := sha256.Sum256(data)
+		st.Sum = hex.EncodeToString(sum[:])
+	}
+	return st, nil
 }
 
 // treeDiff returns every path whose state differs between two walks — created,

--- a/core/cmd/irrlichd/managedwrites_test.go
+++ b/core/cmd/irrlichd/managedwrites_test.go
@@ -224,6 +224,24 @@ func TestEveryModifyPermissionDeclaresEveryFileItsApplyWrites(t *testing.T) {
 	// needs it without an IRRLICHT_ALLOW_SHARED_CONFIG_WRITES escape hatch in
 	// reach.
 	graded := gradablePermissions(t, catalog)
+	assertEveryDeclaredPathIsContained(t, sh, graded)
+
+	allowed := scratchAllowances(sh)
+	for _, g := range graded {
+		t.Run(g.id, func(t *testing.T) { applyAndGrade(t, sh, g, allowed) })
+	}
+
+	if len(graded) == 0 {
+		t.Fatal("no permission was executed — every modify permission is exempt, so this " +
+			"check graded nothing")
+	}
+}
+
+// assertEveryDeclaredPathIsContained is the fail-closed precondition, and it
+// runs over the WHOLE set before any closure does — see the call site for why
+// #1449's per-Apply guard is not what runs here.
+func assertEveryDeclaredPathIsContained(t *testing.T, sh scratchHome, graded []gradablePermission) {
+	t.Helper()
 	for _, g := range graded {
 		for _, f := range g.declared {
 			if f.err != nil {
@@ -237,46 +255,36 @@ func TestEveryModifyPermissionDeclaresEveryFileItsApplyWrites(t *testing.T) {
 			}
 		}
 	}
+}
 
-	allowed := scratchAllowances(sh)
-	executed := 0
-	for _, g := range graded {
-		t.Run(g.id, func(t *testing.T) {
-			before := walkScratch(t, sh.Root)
-			applyErr := g.perm.Apply()
-			after := walkScratch(t, sh.Root)
+// applyAndGrade runs one permission's Apply and reports both directions.
+func applyAndGrade(t *testing.T, sh scratchHome, g gradablePermission, allowed []allowance) {
+	t.Helper()
+	before := walkScratch(t, sh.Root)
+	applyErr := g.perm.Apply()
+	after := walkScratch(t, sh.Root)
 
-			if applyErr != nil {
-				t.Fatalf("Apply returned %v — the closure was cut short, so the file set below "+
-					"is whatever it managed before failing and grading it would report a "+
-					"partial sweep as a clean one. If this permission's install genuinely "+
-					"cannot complete in a scratch home, name it in applyRunsAnExternalCLI "+
-					"with the reason", applyErr)
-			}
-
-			observed := treeDiff(before, after)
-			v := gradeWrites(observed, g.declaredRel(sh.Root), allowed)
-
-			for _, p := range v.Undeclared {
-				t.Errorf("Apply wrote %q, which %s declares in neither Writes.Path nor "+
-					"Writes.Also. That file is invisible to --print-managed-files, so the "+
-					"recording rig never backs it up and #1449's grant-all refusal never sees "+
-					"it (#1741). Declare it, or explain it as an allowance", p, g.id)
-			}
-			for _, p := range v.Missing {
-				t.Errorf("%s declares %q but running Apply changed nothing there. Either the "+
-					"declaration resolves to the wrong file, or the closure no longer writes "+
-					"it — and if NEITHER is true, the scratch home is not where the writes "+
-					"went, which makes every 'no undeclared write' result above meaningless",
-					g.id, p)
-			}
-		})
-		executed++
+	if applyErr != nil {
+		t.Fatalf("Apply returned %v — the closure was cut short, so the file set below "+
+			"is whatever it managed before failing and grading it would report a "+
+			"partial sweep as a clean one. If this permission's install genuinely "+
+			"cannot complete in a scratch home, name it in applyRunsAnExternalCLI "+
+			"with the reason", applyErr)
 	}
 
-	if executed == 0 {
-		t.Fatal("no permission was executed — every modify permission is exempt, so this " +
-			"check graded nothing")
+	v := gradeWrites(treeDiff(before, after), g.declaredRel(sh.Root), allowed)
+	for _, p := range v.Undeclared {
+		t.Errorf("Apply wrote %q, which %s declares in neither Writes.Path nor "+
+			"Writes.Also. That file is invisible to --print-managed-files, so the "+
+			"recording rig never backs it up and #1449's grant-all refusal never sees "+
+			"it (#1741). Declare it, or explain it as an allowance", p, g.id)
+	}
+	for _, p := range v.Missing {
+		t.Errorf("%s declares %q but running Apply changed nothing there. Either the "+
+			"declaration resolves to the wrong file, or the closure no longer writes "+
+			"it — and if NEITHER is true, the scratch home is not where the writes "+
+			"went, which makes every 'no undeclared write' result above meaningless",
+			g.id, p)
 	}
 }
 
@@ -819,19 +827,28 @@ func packageLevelPathResolvers(dir string) ([]string, error) {
 	var out []string
 	for _, pkg := range pkgs {
 		for _, file := range pkg.Files {
-			for _, decl := range file.Decls {
-				fn, ok := decl.(*ast.FuncDecl)
-				if !ok || fn.Recv != nil {
-					continue
-				}
-				if isPathResolverSignature(fn.Type) {
-					out = append(out, fn.Name.Name)
-				}
-			}
+			out = append(out, pathResolversIn(file)...)
 		}
 	}
 	sort.Strings(out)
 	return out, nil
+}
+
+// pathResolversIn names the package-level `func() (string, error)` FuncDecls in
+// one file. A receiver disqualifies: a method is not something a
+// ManagedUserFile field can hold.
+func pathResolversIn(file *ast.File) []string {
+	var out []string
+	for _, decl := range file.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Recv != nil {
+			continue
+		}
+		if isPathResolverSignature(fn.Type) {
+			out = append(out, fn.Name.Name)
+		}
+	}
+	return out
 }
 
 // isPathResolverSignature reports whether ft is exactly `() (string, error)`.

--- a/core/cmd/irrlichd/managedwrites_test.go
+++ b/core/cmd/irrlichd/managedwrites_test.go
@@ -667,19 +667,12 @@ func pathUnderDir(dir, p string) bool {
 // priorDefaultStatePath from kirocli's Writes.Also (see the PR body), which is
 // #1739 exactly.
 func TestExternalInstallerPackagesDeclareEveryPathResolver(t *testing.T) {
-	catalog := declaredConsentCatalog()
-	permByID := map[string]agent.Permission{}
-	for _, a := range catalog {
-		for _, p := range a.Permissions {
-			permByID[a.Identity.Name+"/"+p.Key] = p
-		}
-	}
-
 	if len(applyRunsAnExternalCLI) == 0 {
 		t.Skip("no permission is exempt from the runtime arm, so there is nothing for the " +
 			"static fallback to grade")
 	}
 
+	permByID := permissionsByID(declaredConsentCatalog())
 	usedExemptions := map[string]bool{}
 	for id := range applyRunsAnExternalCLI {
 		p, ok := permByID[id]
@@ -690,9 +683,27 @@ func TestExternalInstallerPackagesDeclareEveryPathResolver(t *testing.T) {
 			gradeExternalInstallerPackage(t, id, p, usedExemptions)
 		})
 	}
+	assertNoStaleResolverExemptions(t, usedExemptions)
+}
 
+// permissionsByID indexes the catalog by "<adapter>/<key>".
+func permissionsByID(catalog []agent.Agent) map[string]agent.Permission {
+	out := map[string]agent.Permission{}
+	for _, a := range catalog {
+		for _, p := range a.Permissions {
+			out[a.Identity.Name+"/"+p.Key] = p
+		}
+	}
+	return out
+}
+
+// assertNoStaleResolverExemptions is notAManagedFilePath's existence check: an
+// entry the walk never reached is an exemption for something that is no longer
+// there, which reads as coverage.
+func assertNoStaleResolverExemptions(t *testing.T, used map[string]bool) {
+	t.Helper()
 	for key, reason := range notAManagedFilePath {
-		if !usedExemptions[key] {
+		if !used[key] {
 			t.Errorf("notAManagedFilePath names %q (%q), which the walk did not find in any "+
 				"external-installer package — a stale exemption reads as coverage", key, reason)
 		}
@@ -862,21 +873,31 @@ func isPathResolverSignature(ft *ast.FuncType) bool {
 	if ft.TypeParams != nil && len(ft.TypeParams.List) > 0 {
 		return false
 	}
-	var results []string
-	for _, f := range ft.Results.List {
-		id, ok := f.Type.(*ast.Ident)
-		if !ok {
-			return false
+	results, ok := resultTypeNames(ft.Results)
+	return ok && len(results) == 2 && results[0] == "string" && results[1] == "error"
+}
+
+// resultTypeNames flattens a result list into one type name per RESULT, not per
+// field: `(a, b string)` is two results sharing one field, and counting fields
+// would read it as one. Reports false for any result whose type is not a plain
+// identifier — a pointer, a selector or a generic instantiation is not
+// `(string, error)` and must not be guessed at.
+func resultTypeNames(results *ast.FieldList) ([]string, bool) {
+	var out []string
+	for _, f := range results.List {
+		id, isIdent := f.Type.(*ast.Ident)
+		if !isIdent {
+			return nil, false
 		}
-		n := 1
-		if len(f.Names) > 1 {
-			n = len(f.Names)
+		n := len(f.Names)
+		if n == 0 {
+			n = 1 // an unnamed result is still one result
 		}
 		for i := 0; i < n; i++ {
-			results = append(results, id.Name)
+			out = append(out, id.Name)
 		}
 	}
-	return len(results) == 2 && results[0] == "string" && results[1] == "error"
+	return out, true
 }
 
 func containsString(haystack []string, needle string) bool {

--- a/core/cmd/irrlichd/managedwrites_test.go
+++ b/core/cmd/irrlichd/managedwrites_test.go
@@ -732,9 +732,8 @@ func gradeExternalInstallerPackage(t *testing.T, id string, p agent.Permission, 
 			continue
 		}
 		key := pkgName + "." + name
-		if reason, exempt := notAManagedFilePath[key]; exempt {
+		if _, exempt := notAManagedFilePath[key]; exempt {
 			usedExemptions[key] = true
-			_ = reason
 			continue
 		}
 		t.Errorf("%s.%s is a package-level path resolver that %s declares in neither "+

--- a/docs/testing-contracts.md
+++ b/docs/testing-contracts.md
@@ -510,6 +510,64 @@ below.
   `applyWritesNoUserFile` with its reason rather than falling out silently.
   `agent.ControlPermission` needs no entry: its `Apply` is nil, which is the
   shape to prefer.
+  That tripwire asks whether a declaration EXISTS, and #1741 is the other half
+  — whether it **covers every file `Apply` actually writes**. Two defects came
+  through that gap, the second after the first was supposedly the lesson:
+  #1718/#1731 (a second shared file, fixed by adding `Also`) and #1739
+  (`$KIRO_HOME/.irrlicht-prior-default.json`, still undeclared *after* `Also`
+  existed, and not inert — `recordPriorDefaultAgentOnce` deliberately never
+  overwrites, so a copy a recording leaves behind is what a later real grant
+  reads instead of the operator's own `chat.defaultAgent`). The completeness
+  tripwire is `core/cmd/irrlichd/managedwrites_test.go`, and it is **two arms
+  because one mechanism cannot reach every permission**.
+  `TestEveryModifyPermissionDeclaresEveryFileItsApplyWrites` is the one that
+  carries the weight: it runs each `Apply` against a scratch `$HOME` and grades
+  the files that actually CHANGED, which is the only thing that sees a path
+  built inline with `filepath.Join` inside `Apply` — the shape #1741 measured
+  the obvious static rule to miss entirely. Three properties are load-bearing.
+  The environment is scrubbed to an **allow-list** (`envKeptDuringScrub`), not
+  a deny-list of known overrides: an unknown `FOO_HOME` a future adapter reads
+  resolves to `""` and falls back to its `$HOME`-relative default, i.e. into
+  the sandbox, where a deny-list would have pointed that install at the
+  developer's real config while the test believed itself sandboxed. A canary
+  variable is set and then swept up by the scrub, so "the scrub ran" is
+  observed rather than assumed. And it **fails closed**: every declared path in
+  the whole catalog is resolved and proven inside the scratch tree before a
+  single closure runs — deliberately not by routing through #1449's
+  `sharedConfigRefusal`, which refuses one `Apply` at a time and would let
+  eight closures execute before the ninth's escape was noticed, and whose
+  `IRRLICHT_ALLOW_SHARED_CONFIG_WRITES` escape hatch is the last thing that
+  should be in reach of a test that runs installers. It grades **both**
+  directions, and the second is why a broken sandbox is loud: an undeclared
+  write is #1741 itself, while a DECLARED file nothing wrote means the writes
+  did not land where the test is looking — without it, a sandbox that never
+  took would report a flawless sweep.
+  `TestExternalInstallerPackagesDeclareEveryPathResolver` is the fallback for
+  the one permission the runtime arm must not execute. kiro-cli's `Apply`
+  shells out to the real CLI, and running it in `go test ./core/...` was
+  measured non-deterministic in two independent ways: with the binary absent
+  (any CI runner) the closure fails at its first step and writes NOTHING, so
+  the arm would grade an empty set; with it present the CHILD writes its own
+  state — `$HOME/Library/Application Support/kiro-cli/data.sqlite3`, measured
+  2026-08-22 — and how much more depends on whether the developer is logged in.
+  So that permission is named in `applyRunsAnExternalCLI` with the reason, its
+  `Binary` cross-checked against the permission's own `Writes.Version.Probe[0]`
+  so the exemption cannot claim a shellout the declaration does not
+  corroborate, and its package is graded statically instead: every
+  package-level `func() (string, error)` there must be one the declaration
+  names (**derived by reflecting the function names out of `Writes`**, so it
+  cannot drift from a hand-kept list) or be named in `notAManagedFilePath`.
+  That rule is scoped to the external-installer packages rather than run
+  catalog-wide for a measured reason: #1741 put it at roughly one false
+  positive per adapter — every adapter has a home-ROOT resolver with that exact
+  signature — so scoped it costs one exemption and catalog-wide it would cost
+  one per adapter while adding nothing the runtime arm does not already cover
+  more strongly. The committed mutation evidence, and the declared limits
+  (a hard-coded absolute path outside `$HOME`; a write that restores size,
+  mtime AND content; a directory-only creation; a resolver held in a
+  package-level `var`, which is the same `ast.FuncDecl` limit
+  `architecture_hookbody_test.go` and `seam_walk_corpus_test.go` carry), are in
+  `managedwrites_shapes_test.go`.
   Since #1449 the declaration is also what a **grant-all daemon refuses to
   write**. `PermissionService.sharedConfigRefusal` — the same call site as
   #1365's version gate, so #1362's "granted but NOT applied" surfacing and the


### PR DESCRIPTION
Closes #1741.

`TestEveryModifyPermissionDeclaresTheFileItWrites` asks whether a `modify`
permission with a non-nil `Apply` **has** a `Writes` declaration. It never asked
whether the declaration **covers every file `Apply` actually writes** — the gap
that produced #1718/#1731 and then #1739, the second one *after* the first was
supposedly the lesson.

## What I built, and what decided it

Two arms, in `core/cmd/irrlichd/managedwrites_test.go`. The split is not
symmetry — it is one mechanism plus a fallback for the one permission that
mechanism must not touch.

### 1. Runtime arm — `TestEveryModifyPermissionDeclaresEveryFileItsApplyWrites`

Runs each modify permission's `Apply` against a scratch `$HOME` and grades the
files that actually **changed**. This is the arm that carries the weight: it is
the only thing that sees a path built inline with `filepath.Join` inside
`Apply`, which #1741 measured the obvious static rule to miss entirely, and it
needs no per-adapter knowledge — a new modify permission is graded by existing.

Covers 8 of the 9 `Apply` closures in the consent catalog: claude-code
hooks/statusline/instructions, codex, gemini-cli, mistral-vibe, copilot,
kitty, plus gastown/state (which declares nothing).

Three properties are load-bearing:

- **The environment is scrubbed to an ALLOW-list** (`envKeptDuringScrub`), not
  a deny-list of `CODEX_HOME`/`COPILOT_HOME`/`KIRO_HOME`/`VIBE_HOME`/
  `XDG_CONFIG_HOME`/`CLAUDE_CONFIG_DIR`. A deny-list has to enumerate every
  override an adapter *might* honour, and the day a new adapter reads a new one,
  its `Apply` writes to the developer's real config while the test believes it
  is sandboxed. Emptying everything means an unknown override resolves to `""`
  and the adapter falls back to its `$HOME`-relative default — which *is* the
  scratch home. A canary variable is set and then swept up by the scrub itself,
  so "the scrub ran" is observed rather than assumed (mutation M6 below).
- **It fails closed.** Every declared path in the *whole* catalog is resolved and
  proven inside the scratch tree before a single closure runs (M5). Deliberately
  *not* by routing through #1449's `sharedConfigRefusal`: that guard refuses one
  `Apply` at a time from inside the service, so eight closures would have run
  before the ninth's escape was noticed — and its
  `IRRLICHT_ALLOW_SHARED_CONFIG_WRITES` escape hatch is the last thing that
  should be within reach of a test that executes installers. (`IRRLICHT_HOME` is
  still pointed at the sandbox, so the guard is armed if a future refactor does
  route through it.)
- **Both directions are graded.** An undeclared write is #1741 itself. A
  *declared* file nothing wrote is the vacuity guard, and it is the one that
  makes a broken sandbox loud: if `$HOME` had not taken, every closure would
  write to the real home, the scratch diff would be EMPTY, and an
  undeclared-writes-only check would report a flawless sweep (M3).

### 2. Static arm — `TestExternalInstallerPackagesDeclareEveryPathResolver`

kiro-cli's `Apply` shells out to the real CLI. **Measured, not assumed**, on
2026-08-22 — this is why the runtime arm must not execute it:

```
--- kiro-cli/hooks
  declared: [Path=/.kiro/agents/irrlicht.json Also[0]=/.kiro/settings/cli.json Also[1]=/.kiro/.irrlicht-prior-default.json]
  applyErr: kirocli: kiro-cli agent create irrlicht --from kiro_default: exit status 1: error: You are not logged in, please log in with kiro-cli login
  wrote:    [/.kiro/settings/cli.json  /Library/Application Support/kiro-cli/data.sqlite3]
```

- With the binary **absent** (any CI runner) `EnsureHooksInstalled` fails at its
  first step and writes **nothing** — the arm would grade an empty set, which is
  exactly "inability to look reads as a clean result".
- With it **present** the CHILD writes its own state
  (`$HOME/Library/Application Support/kiro-cli/data.sqlite3` above), and how much
  more it writes depends on whether the developer is logged in. Either way the
  verdict stops being a property of this repo.

So `kiro-cli/hooks` is named in `applyRunsAnExternalCLI` with that reason, its
`Binary` cross-checked against the permission's own `Writes.Version.Probe[0]`
so the exemption cannot claim a shellout the declaration does not corroborate
(M9), and its package is graded statically: every package-level
`func() (string, error)` there must be one the declaration names — **derived by
reflecting the function names out of `Writes.Path`/`Writes.Also`**, so it cannot
drift from a hand-kept list — or be named in `notAManagedFilePath` (M8).

That is the rule #1741 measured at ~1 false positive per adapter. Scoping it to
the packages the runtime arm cannot execute is what makes it shippable:
**one** exemption (`kirocli.kiroHome`, the `$KIRO_HOME` root every other
resolver joins onto) instead of one per adapter, and it adds nothing the runtime
arm does not already cover more strongly.

## Mutation evidence — actual red output

Each was applied and reverted in its own foreground call, and each run was
scoped to the new test so "the arm failed" and "THIS obligation failed" are not
confused.

**M1 — remove `priorDefaultStatePath` from kirocli's `Writes.Also` (this is #1739):**
```
--- FAIL: TestExternalInstallerPackagesDeclareEveryPathResolver/kiro-cli/hooks
    managedwrites_test.go:682: kirocli.priorDefaultStatePath is a package-level path resolver
    that kiro-cli/hooks declares in neither Writes.Path nor Writes.Also. If its Apply writes
    that file, it is invisible to --print-managed-files, to the recording rig's backup and to
    #1449's grant-all refusal (#1739). Declare it, or add "kirocli.priorDefaultStatePath" to
    notAManagedFilePath with the reason it names no managed file
```

**M2 — remove `vibeConfigTomlPath` from mistral-vibe's `Writes.Also` (this is #1718/#1731):**
```
--- FAIL: TestEveryModifyPermissionDeclaresEveryFileItsApplyWrites/mistral-vibe/hooks
    managedwrites_test.go:261: Apply wrote "home/.vibe/config.toml", which mistral-vibe/hooks
    declares in neither Writes.Path nor Writes.Also. That file is invisible to
    --print-managed-files, so the recording rig never backs it up and #1449's grant-all refusal
    never sees it (#1741). Declare it, or explain it as an allowance
```

**M3 — kitty's `EnsureKittyConfigPatched` reports a write and performs none (the vacuity direction / broken-sandbox shape):**
```
--- FAIL: TestEveryModifyPermissionDeclaresEveryFileItsApplyWrites/kitty/remote-control
    managedwrites_test.go:267: kitty/remote-control declares "home/.config/kitty/kitty.conf" but
    running Apply changed nothing there. Either the declaration resolves to the wrong file, or
    the closure no longer writes it — and if NEITHER is true, the scratch home is not where the
    writes went, which makes every 'no undeclared write' result above meaningless
```

**M4 — an undeclared write built INLINE inside vibe's `Apply` (`filepath.Join(home, "irrlicht-state.json")`), the shape the static rule cannot see:**
```
--- FAIL: TestEveryModifyPermissionDeclaresEveryFileItsApplyWrites/mistral-vibe/hooks
    managedwrites_test.go:261: Apply wrote "home/.vibe/irrlicht-state.json", which
    mistral-vibe/hooks declares in neither Writes.Path nor Writes.Also. ...
```
The static arm was in the same run and stayed **green** — which is the porosity
#1741 measured, demonstrated rather than asserted.

**M5 — `kittyConfigDir` returns `/etc/xdg/kitty` (a resolver that ignores `$HOME`):**
```
--- FAIL: TestEveryModifyPermissionDeclaresEveryFileItsApplyWrites
    managedwrites_test.go:234: kitty/remote-control declares Writes.Path = "/etc/xdg/kitty/kitty.conf",
    which is OUTSIDE the scratch home "/var/folders/.../001". Refusing to run any Apply: this test
    would be writing to a shared config the developer actually uses
```
Note there are **no sub-test lines** in that output: it aborted before the first
closure ran, which is the fail-closed property.

**M6 — `envKeptDuringScrub` returns true for everything (the scrub does nothing):**
```
--- FAIL: TestEveryModifyPermissionDeclaresEveryFileItsApplyWrites
    managedwrites_test.go:205: the environment scrub left
    IRRLICHT_MANAGEDWRITES_SCRUB_CANARY="/definitely/not/the/scratch/home" — it did not run, so
    every per-agent home override the developer exports is still in effect and the closures below
    would write to their real config
```

**M7 — `applyRunsAnExternalCLI` names a permission that does not exist:**
```
    managedwrites_test.go:226: applyRunsAnExternalCLI names "kiro-cli/no-such-permission", which
    is not a permission with an Apply closure in the consent catalog — an exemption for an
    obligation that does not exist reads as coverage
```
The same run also shows the other half working: with kiro-cli no longer exempt,
its `Apply` ran and failed loudly (`Apply returned … not logged in`) rather than
grading an empty set.

**M8 — `notAManagedFilePath` key renamed (stale exemption):**
```
    managedwrites_test.go:682: kirocli.kiroHome is a package-level path resolver that
    kiro-cli/hooks declares in neither Writes.Path nor Writes.Also. ...
    managedwrites_test.go:688: notAManagedFilePath names "kirocli.kiroHomeRenamedUpstream" (...),
    which the walk did not find in any external-installer package — a stale exemption reads as
    coverage
```

**M9 — the exemption's `Binary` disagrees with the permission's own probe:**
```
    managedwrites_test.go:226: applyRunsAnExternalCLI["kiro-cli/hooks"] names binary "kiro", but
    the permission's own version probe runs "kiro-cli" — one of the two is stale and a reader
    cannot tell which
```

### The corpus's own mutations

`managedwrites_shapes_test.go` is the committed evidence for the pure grading
functions — one row per shape, each carrying **both** verdicts, because a
detector that reports everything and one that reports correctly are
indistinguishable without the cases that must stay silent.

**M10 — allowance containment by plain string prefix instead of path segments:**
```
--- FAIL: .../a_sibling_that_merely_shares_the_allowance_root's_prefix_is_reported
    Undeclared = [], want [irrlicht-home-backup/leak.json]
    allowance "irrlicht-home" absorbed 1 paths, want 0
```

**M11 — `treeDiff` blind to removals (a permission that DELETES a user file):**
```
--- FAIL: .../a_removed_file          treeDiff = [], want [home/.codex/hooks.json]
--- FAIL: .../everything_at_once,_sorted   treeDiff = [home/.a], want [home/.a home/.zshrc]
```

**M12 — the walk counts a METHOD as a package-level resolver:**
```
--- FAIL: .../a_method_with_the_same_signature    resolvers = [settingsPath], want []
```

## Proof nothing touches the real home

Beyond the fail-closed precondition and the scrub canary, measured directly:
snapshot `~/.claude/settings.json`, `~/.claude/CLAUDE.md`, `~/.codex/hooks.json`,
`~/.gemini/settings.json`, `~/.config/kitty/kitty.conf`, `~/.kiro`, `~/.vibe`,
`~/.copilot` and `~/Library/Application Support/kiro-cli` (mtime + size, plus a
2-deep `find` of `~/.kiro` and `~/.vibe`), run the two new tests, snapshot again
— `diff` reports **IDENTICAL**.

## A finding this turned up, NOT fixed here

`kiro-cli/hooks`'s `Apply` causes `~/Library/Application Support/kiro-cli/data.sqlite3`
to be created/modified in whichever `$HOME` the daemon runs under — it is the
child `kiro-cli` process's own state DB, undeclared by anything. It is
deliberately **not** added to `Writes.Also`: it holds no irrlicht content, so
`ManagedUserFile`'s uninstall semantics are meaningless for it, its location is
macOS-specific and unverified on Linux, and having the recording rig restore a
sqlite DB under a possibly-running kiro-cli is a worse outcome than not. Flagged
rather than buried; worth its own issue if the rig's snapshot set should grow to
cover an agent CLI's own store.

## What this does NOT cover

Stated in the file header and pinned as corpus rows wherever a row can express it:

- A write to an absolute path following neither `$HOME` nor any env var
  (a hard-coded `/etc/...`) lands outside the walked tree. The static arm sees it
  only if it goes through a package-level resolver.
- A write that restores size, mtime AND content byte-identically is invisible to
  any snapshot diff (pinned as a want:none row).
- A permission creating only a DIRECTORY is not reported — the walk records
  non-directory entries.
- `gastown/state`'s `Apply` is the no-op `declaredConsentCatalog` passes, not the
  watcher the daemon wires, so running it grades the no-op.
- The static arm reads `ast.FuncDecl`s, so a resolver held in a package-level
  `var` is not seen. That direction reads as "no undeclared resolver", i.e. it is
  a hole rather than a loud refusal, which is exactly why it is a pinned
  want:false row — the same declared limit `architecture_hookbody_test.go` and
  `contracttesting/seam_walk_corpus_test.go` carry.
- Whether a permission genuinely spawns an external CLI is a declared claim, not
  a derived one. "Does this package contain `exec.Command`" is derivable and
  wrong — `processlifecycle` contains several and kitty's `Apply` spawns none, so
  the derived version would wave through the one permission in that package a
  scratch home *can* grade.


## Advisory checks

`SonarCloud` is **green** after two follow-up commits: two `go:S3776`
cognitive-complexity findings (19 and 16 vs the 15 allowed) split along seams
the doc comments already drew, and the one duplicated block — 10 repeated
`file: "a.go"` fields in the resolver corpus — defaulted away. Every mutation
was re-verified red after each refactor; M5 in particular still aborts before
any sub-test runs.

`CodeScene` is **red and I stopped chasing it**, per AGENTS.md ("a red result is
a prompt to look closer, not something to chase to green before merging"). I
looked closer twice: code-health impact went 8.01 -> 8.12 -> 8.96 and "Overall
Code Complexity" dropped off, but each round it re-flags a different pair of
small functions — now `treeDiff` (Bumpy Road Ahead) and
`isPathResolverSignature` (Complex Method). `treeDiff` is 12 lines with exactly
two sequential loops because a snapshot diff has exactly two directions
(created-or-modified, and removed), and `isPathResolverSignature` is three
guards and a call. Splitting either further would cost the reader more than it
buys. Flagging rather than suppressing.

## Gates

- `go test ./core/... -race -count=1` — PASS
- `tools/preflight.sh --only go` — all 6 gates PASS
- `tools/preflight.sh --only arch` — PASS (composite 7.9163 -> 7.9166, no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
