### PR TITLE
fix(vibe): model multi-line arrays in hooktoml, so hooks install into a config vibe itself wrote (#1753)

### DIFF
--- a/core/adapters/inbound/agents/hooktoml/hooktoml.go
+++ b/core/adapters/inbound/agents/hooktoml/hooktoml.go
@@ -191,6 +191,41 @@ loop:
 // a fragment and nothing else.
 func stripComment(line []byte) []byte { return scanLine(line).stripped }
 
+// refusalFor reports the refusal one scanned line earns, or nil. depthAfter is
+// the bracket depth this line leaves behind.
+//
+// Shared by BOTH scanners in this file — scanDocument and topLevelKeyLine —
+// because they must agree on exactly which documents are refusable and are
+// reached through different public entry points, so a drift between them would
+// show up as one operation succeeding while its sibling refuses the same file,
+// with nothing anywhere comparing the two. TestScannerRefusals_Corpus drives
+// every row through both, which is the assertion this function makes cheap to
+// keep true.
+func refusalFor(path string, lineNo int, sc lineScan, depthAfter int) error {
+	switch {
+	case sc.unterminated:
+		return unsafeAt(path, lineNo, "an unterminated quote")
+	case sc.braces != 0:
+		return unsafeAt(path, lineNo, "an inline table spanning more than one line")
+	case depthAfter < 0:
+		return unsafeAt(path, lineNo, "an unbalanced ']'")
+	}
+	return nil
+}
+
+// headerOf classifies a comment-stripped, trimmed line as a [[array]] or
+// [table] header. Callers must only ask it about a line at bracket depth
+// ZERO — inside a multi-line array a header-shaped line is an ELEMENT.
+func headerOf(trimmed []byte) (kind byte, name string, ok bool) {
+	switch {
+	case isArrayHeaderLine(trimmed):
+		return 2, string(bytes.TrimSpace(trimmed[2 : len(trimmed)-2])), true
+	case isTableHeaderLine(trimmed):
+		return 1, string(bytes.TrimSpace(trimmed[1 : len(trimmed)-1])), true
+	}
+	return 0, "", false
+}
+
 func isArrayHeaderLine(t []byte) bool {
 	return len(t) >= 4 && bytes.HasPrefix(t, []byte("[[")) && bytes.HasSuffix(t, []byte("]]"))
 }
@@ -288,37 +323,26 @@ func scanDocument(path string, src []byte) ([]scannedLine, error) {
 		lineNo++
 		raw := src[pos:end]
 		sc := scanLine(raw)
-		if sc.unterminated {
-			return nil, unsafeAt(path, lineNo, "an unterminated quote")
-		}
-		if sc.braces != 0 {
-			return nil, unsafeAt(path, lineNo, "an inline table spanning more than one line")
+		if err := refusalFor(path, lineNo, sc, depth+sc.brackets); err != nil {
+			return nil, err
 		}
 
 		li := scannedLine{start: pos, continuation: depth > 0}
 		if depth == 0 {
 			trimmed := bytes.TrimSpace(sc.stripped)
-			switch {
-			case isArrayHeaderLine(trimmed):
-				li.isHeader, li.headerKind = true, 2
-				li.headerName = string(bytes.TrimSpace(trimmed[2 : len(trimmed)-2]))
-			case isTableHeaderLine(trimmed):
-				li.isHeader, li.headerKind = true, 1
-				li.headerName = string(bytes.TrimSpace(trimmed[1 : len(trimmed)-1]))
-			default:
+			if kind, name, ok := headerOf(trimmed); ok {
+				li.isHeader, li.headerKind, li.headerName = true, kind, name
+			} else {
 				rawTrimmed := bytes.TrimSpace(raw)
 				li.isCommentOnly = len(rawTrimmed) > 0 && rawTrimmed[0] == '#'
+			}
+			if sc.brackets > 0 {
+				openedAt = lineNo
 			}
 		}
 		lines = append(lines, li)
 
-		if depth == 0 && sc.brackets > 0 {
-			openedAt = lineNo
-		}
 		depth += sc.brackets
-		if depth < 0 {
-			return nil, unsafeAt(path, lineNo, "an unbalanced ']'")
-		}
 		if end >= len(src) {
 			break
 		}
@@ -699,28 +723,22 @@ func topLevelKeyLine(path string, src []byte, key string) (start, end int, found
 		}
 		lineNo++
 		sc := scanLine(src[pos:lineEnd])
-		if sc.unterminated {
-			return 0, 0, false, unsafeAt(path, lineNo, "an unterminated quote")
-		}
-		if sc.braces != 0 {
-			return 0, 0, false, unsafeAt(path, lineNo, "an inline table spanning more than one line")
+		if err := refusalFor(path, lineNo, sc, depth+sc.brackets); err != nil {
+			return 0, 0, false, err
 		}
 		if depth == 0 {
 			trimmed := bytes.TrimSpace(sc.stripped)
-			if isArrayHeaderLine(trimmed) || isTableHeaderLine(trimmed) {
+			if _, _, isHeader := headerOf(trimmed); isHeader {
 				return 0, 0, false, nil
 			}
 			logicalStart = pos
 			k, _, ok := bytes.Cut(trimmed, []byte("="))
 			matching = ok && string(bytes.TrimSpace(k)) == key
-		}
-		if depth == 0 && sc.brackets > 0 {
-			openedAt = lineNo
+			if sc.brackets > 0 {
+				openedAt = lineNo
+			}
 		}
 		depth += sc.brackets
-		if depth < 0 {
-			return 0, 0, false, unsafeAt(path, lineNo, "an unbalanced ']'")
-		}
 		if depth == 0 && matching {
 			return logicalStart, lineEnd, true, nil
 		}

--- a/core/adapters/inbound/agents/hooktoml/hooktoml.go
+++ b/core/adapters/inbound/agents/hooktoml/hooktoml.go
@@ -26,45 +26,120 @@
 // comments the same way json.MarshalIndent over a bare map did before
 // hookjson existed.
 //
-// Anything the scanner cannot confidently classify — a triple-quoted
-// string, a multi-line array, an unterminated single-line string — makes it
-// refuse the WHOLE document rather than guess. Unlike hookjson, which falls
-// back to a lossy whole-document re-encode when a splice is not safe, there
-// is no safe fallback encoder here: a generic map[string]interface{}-style
-// TOML dump is precisely the read-modify-marshal this package exists to
-// avoid, so it is never reached for as a fallback. "Cannot splice safely"
-// therefore means "do not write," not "write something worse" — refusing an
-// install into an exotic hand-crafted hooks.toml is the safe direction; a
-// corrupted one is not.
+// A MULTI-LINE ARRAY is modelled (issue #1753); a triple-quoted string, an
+// unterminated single-line string and a multi-line inline table are not, and
+// make the scanner refuse the WHOLE document rather than guess. The
+// multi-line array had to move from the second list to the first because it
+// is not exotic at all: mistral-vibe's OWN writer emits them — twelve in the
+// config.toml measured when #1753 was filed — so refusing them meant refusing
+// every realistic user config, with the hooks permission still reading
+// `granted` and no hook ever firing. Modelling one costs a single integer of
+// state carried across lines (see scanDocument): a logical line continues
+// while its bracket depth is above zero, and NOTHING inside it is classified
+// as a header, a comment or a key.
+//
+// Unlike hookjson, which falls back to a lossy whole-document re-encode when
+// a splice is not safe, there is no safe fallback encoder here: a generic
+// map[string]interface{}-style TOML dump is precisely the read-modify-marshal
+// this package exists to avoid, so it is never reached for as a fallback.
+// "Cannot splice safely" therefore means "do not write," not "write something
+// worse" — refusing an install into an exotic hand-crafted hooks.toml is the
+// safe direction; a corrupted one is not. What #1753 changed is WHICH
+// documents land in that bucket, not what happens to the ones that do — and
+// for those, the refusal now names the file and the line (UnsafeConstructError)
+// so the "granted but NOT applied, because …" the wizards already render
+// (#1362) points at something the user can act on.
 package hooktoml
 
 import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"strconv"
 	"strings"
 )
 
-// ErrUnsafe means this document contains a construct the line-oriented
-// scanner does not model with confidence — a triple-quoted string, an
-// unterminated single-line string, or a multi-line array. The caller must
-// not write; there is no lossy fallback (see the package doc).
-var ErrUnsafe = errors.New("hooktoml: file contains a construct this splicer does not model safely (multi-line string, multi-line array, or unterminated quote) — refusing rather than guessing")
+// ErrUnsafe is the sentinel every refusal in this package wraps: the document
+// contains a construct the line-oriented scanner does not model with
+// confidence — a triple-quoted string, an unterminated single-line string, or
+// a multi-line inline table. The caller must not write; there is no lossy
+// fallback (see the package doc).
+//
+// Callers test it with errors.Is. The value a caller actually receives is an
+// *UnsafeConstructError, which names the file, the line and the construct.
+var ErrUnsafe = errors.New("hooktoml: file contains a construct this splicer does not model safely")
+
+// UnsafeConstructError is the error every refusal in this package returns —
+// ErrUnsafe with the three facts a user needs to act on it.
+//
+// It exists because of the way this class of failure reaches a user. The
+// consent effect's error is recorded verbatim by
+// services.PermissionService.runClosureEffect and rendered by both wizards as
+// "granted but NOT applied, because <reason>" (#1362), and re-answering the
+// permission re-runs the effect — so the reason string IS the instruction,
+// and the gesture that reads it is the gesture that retries it (#1365
+// established the shape for a version floor). A reason naming neither the
+// file nor the line, as this package's original single sentinel did, tells a
+// user their vibe hooks are dead and nothing else.
+type UnsafeConstructError struct {
+	// Path is the file that could not be scanned, "" for a document handed
+	// to this package in memory.
+	Path string
+	// Line is the 1-based line the refusal was decided on, 0 when the
+	// construct is document-wide.
+	Line int
+	// Construct names what was found, in words a user can search their own
+	// file for.
+	Construct string
+}
+
+func (e *UnsafeConstructError) Error() string {
+	where := e.Path
+	if where == "" {
+		where = "the file"
+	}
+	if e.Line > 0 {
+		where = fmt.Sprintf("%s:%d", where, e.Line)
+	}
+	return fmt.Sprintf("hooktoml: %s contains %s, which this splicer does not model safely — "+
+		"refusing rather than guessing; simplify that line (or make the edit by hand) and grant again",
+		where, e.Construct)
+}
+
+func (e *UnsafeConstructError) Unwrap() error { return ErrUnsafe }
+
+func unsafeAt(path string, line int, construct string) error {
+	return &UnsafeConstructError{Path: path, Line: line, Construct: construct}
+}
 
 // --- line-level scanning primitives ---
 
-// lineSafety scans one line (no embedded '\n'), respecting single-line basic
+// lineScan is what one physical line tells the scanner. brackets and braces
+// are net counts OUTSIDE strings and comments; unterminated means a quote was
+// still open when the line ended, which in TOML can only be a multi-line
+// string this package does not model.
+type lineScan struct {
+	stripped     []byte
+	unterminated bool
+	brackets     int
+	braces       int
+}
+
+// scanLine scans one line (no embedded '\n'), respecting single-line basic
 // ("...") and literal ('...') strings, and reports the comment-stripped
-// content plus whether the line looks like it continues onto the next one —
-// an unterminated quote (the start of some multi-line construct this
-// scanner does not model) or an unbalanced '['/']' count outside strings
-// (a multi-line array). continues is the signal every caller in this
-// package refuses on rather than guesses through.
-func lineSafety(line []byte) (stripped []byte, continues bool) {
+// content plus the three facts scanDocument carries across lines.
+//
+// Bracket and brace counts are reported SEPARATELY and are not symmetric in
+// how callers treat them: a bracket run that stays open is a multi-line
+// array, which #1753 taught this package to model, while an open brace is a
+// multi-line inline table, which it does not — TOML 1.0 does not permit one,
+// so a document containing it is malformed or written to a dialect this
+// scanner has never seen, and either way is the last place to start guessing.
+func scanLine(line []byte) lineScan {
 	inBasic, inLiteral := false, false
-	depth := 0
+	var sc lineScan
 	commentAt := -1
 loop:
 	for i := 0; i < len(line); i++ {
@@ -92,19 +167,29 @@ loop:
 				commentAt = i
 				break loop
 			case '[':
-				depth++
+				sc.brackets++
 			case ']':
-				depth--
+				sc.brackets--
+			case '{':
+				sc.braces++
+			case '}':
+				sc.braces--
 			}
 		}
 	}
 	if commentAt >= 0 {
-		stripped = line[:commentAt]
+		sc.stripped = line[:commentAt]
 	} else {
-		stripped = line
+		sc.stripped = line
 	}
-	return stripped, inBasic || inLiteral || depth != 0
+	sc.unterminated = inBasic || inLiteral
+	return sc
 }
+
+// stripComment returns line's comment-stripped content — scanLine's first
+// result, for the two readers (scalarValue, FieldValue) that want the text of
+// a fragment and nothing else.
+func stripComment(line []byte) []byte { return scanLine(line).stripped }
 
 func isArrayHeaderLine(t []byte) bool {
 	return len(t) >= 4 && bytes.HasPrefix(t, []byte("[[")) && bytes.HasSuffix(t, []byte("]]"))
@@ -138,46 +223,109 @@ type scannedLine struct {
 	headerKind    byte
 	headerName    string
 	isCommentOnly bool // the whole line (leading whitespace aside) is a '#' comment
-	continues     bool
+	// continuation is true when this line is INSIDE a multi-line array
+	// opened on an earlier line. Such a line is deliberately classified as
+	// nothing at all: a `[[x]]`-shaped or `#`-shaped element of an array is
+	// an element, not a header and not a standalone comment, and treating it
+	// as either is how a scanner that merely stopped refusing multi-line
+	// arrays would start CORRUPTING them.
+	continuation bool
 }
 
-// classifyLines splits src into scannedLines, refusing (ErrUnsafe) rather
-// than guessing at any construct lineSafety cannot classify — including a
-// document-wide check for triple-quoted strings, which lineSafety's
-// single-line model cannot see at all (three isolated double quotes in a
-// row look, one line at a time, like an empty string followed by an opening
-// quote).
-func classifyLines(src []byte) ([]scannedLine, error) {
-	if bytes.Contains(src, []byte(`"""`)) || bytes.Contains(src, []byte(`'''`)) {
-		return nil, ErrUnsafe
+// tripleQuoteAt reports the byte offset of the first triple-quote in src, or
+// -1. Checked document-wide because scanLine's single-line model cannot see
+// one at all: three isolated double quotes in a row look, one line at a time,
+// like an empty string followed by an opening quote.
+func tripleQuoteAt(src []byte) int {
+	basic := bytes.Index(src, []byte(`"""`))
+	literal := bytes.Index(src, []byte(`'''`))
+	switch {
+	case basic < 0:
+		return literal
+	case literal < 0:
+		return basic
+	case basic < literal:
+		return basic
+	default:
+		return literal
+	}
+}
+
+// lineNumberAt returns the 1-based line number of byte offset off in src.
+func lineNumberAt(src []byte, off int) int {
+	if off < 0 || off > len(src) {
+		return 0
+	}
+	return 1 + bytes.Count(src[:off], []byte("\n"))
+}
+
+// scanDocument splits src into scannedLines, carrying ONE integer of state
+// across lines — the open-bracket depth — so a multi-line array reads as a
+// single logical line rather than as a refusal (issue #1753). Everything it
+// still cannot model makes it refuse the whole document, now naming the file
+// and the line: a triple-quoted string, a quote left open at end of line, a
+// brace left open at end of line (a multi-line inline table, which TOML 1.0
+// does not permit), a stray `]` that drives the depth negative, and an array
+// still open at end of file.
+//
+// path is used only to build that error; it is never opened here.
+func scanDocument(path string, src []byte) ([]scannedLine, error) {
+	if off := tripleQuoteAt(src); off >= 0 {
+		return nil, unsafeAt(path, lineNumberAt(src, off), "a multi-line (triple-quoted) string")
 	}
 	var lines []scannedLine
-	pos := 0
+	pos, lineNo, depth := 0, 0, 0
+	// openedAt is the line the currently-open array started on, so an array
+	// that is never closed is reported at its OPENING line rather than at end
+	// of file: the opener is the line a user has to go and look at, and in a
+	// 392-line config the two are nowhere near each other.
+	openedAt := 0
 	for pos <= len(src) {
 		end := pos
 		for end < len(src) && src[end] != '\n' {
 			end++
 		}
+		lineNo++
 		raw := src[pos:end]
-		stripped, continues := lineSafety(raw)
-		trimmed := bytes.TrimSpace(stripped)
-		li := scannedLine{start: pos, continues: continues}
-		switch {
-		case isArrayHeaderLine(trimmed):
-			li.isHeader, li.headerKind = true, 2
-			li.headerName = string(bytes.TrimSpace(trimmed[2 : len(trimmed)-2]))
-		case isTableHeaderLine(trimmed):
-			li.isHeader, li.headerKind = true, 1
-			li.headerName = string(bytes.TrimSpace(trimmed[1 : len(trimmed)-1]))
-		default:
-			rawTrimmed := bytes.TrimSpace(raw)
-			li.isCommentOnly = len(rawTrimmed) > 0 && rawTrimmed[0] == '#'
+		sc := scanLine(raw)
+		if sc.unterminated {
+			return nil, unsafeAt(path, lineNo, "an unterminated quote")
+		}
+		if sc.braces != 0 {
+			return nil, unsafeAt(path, lineNo, "an inline table spanning more than one line")
+		}
+
+		li := scannedLine{start: pos, continuation: depth > 0}
+		if depth == 0 {
+			trimmed := bytes.TrimSpace(sc.stripped)
+			switch {
+			case isArrayHeaderLine(trimmed):
+				li.isHeader, li.headerKind = true, 2
+				li.headerName = string(bytes.TrimSpace(trimmed[2 : len(trimmed)-2]))
+			case isTableHeaderLine(trimmed):
+				li.isHeader, li.headerKind = true, 1
+				li.headerName = string(bytes.TrimSpace(trimmed[1 : len(trimmed)-1]))
+			default:
+				rawTrimmed := bytes.TrimSpace(raw)
+				li.isCommentOnly = len(rawTrimmed) > 0 && rawTrimmed[0] == '#'
+			}
 		}
 		lines = append(lines, li)
+
+		if depth == 0 && sc.brackets > 0 {
+			openedAt = lineNo
+		}
+		depth += sc.brackets
+		if depth < 0 {
+			return nil, unsafeAt(path, lineNo, "an unbalanced ']'")
+		}
 		if end >= len(src) {
 			break
 		}
 		pos = end + 1
+	}
+	if depth != 0 {
+		return nil, unsafeAt(path, openedAt, "an array that is never closed")
 	}
 	return lines, nil
 }
@@ -193,8 +341,8 @@ func classifyLines(src []byte) ([]scannedLine, error) {
 // that comment behind as an orphan — caught by
 // TestEnsureAndUninstall_PropertyRandomMutations, which is why every
 // generated sentinel block in that test carries one.
-func scanSections(src []byte) ([]section, error) {
-	lines, err := classifyLines(src)
+func scanSections(path string, src []byte) ([]section, error) {
+	lines, err := scanDocument(path, src)
 	if err != nil {
 		return nil, err
 	}
@@ -214,9 +362,6 @@ func scanSections(src []byte) ([]section, error) {
 	var sections []section
 	cur := section{kind: 0, start: 0}
 	for idx, li := range lines {
-		if li.continues {
-			return nil, ErrUnsafe
-		}
 		if li.isHeader {
 			cur.end = headerTrueStart[idx]
 			sections = append(sections, cur)
@@ -232,8 +377,8 @@ func scanSections(src []byte) ([]section, error) {
 // array-of-tables header line in src, or len(src) if there is none —
 // the only place a NEW top-level scalar may be inserted, since TOML
 // requires every bare key/value pair to precede all table sections.
-func firstHeaderOffset(src []byte) (int, error) {
-	sections, err := scanSections(src)
+func firstHeaderOffset(path string, src []byte) (int, error) {
+	sections, err := scanSections(path, src)
 	if err != nil {
 		return 0, err
 	}
@@ -357,7 +502,7 @@ func EnsureInstalled(cfg HookConfig) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	sections, err := scanSections(orig)
+	sections, err := scanSections(cfg.Path, orig)
 	if err != nil {
 		return false, err
 	}
@@ -383,7 +528,7 @@ func Uninstall(cfg HookConfig) (bool, error) {
 	if len(orig) == 0 {
 		return false, nil
 	}
-	sections, err := scanSections(orig)
+	sections, err := scanSections(cfg.Path, orig)
 	if err != nil {
 		return false, err
 	}
@@ -405,7 +550,7 @@ func Inspect(cfg HookConfig) (present, canonical bool, err error) {
 	if err != nil {
 		return false, false, err
 	}
-	sections, err := scanSections(orig)
+	sections, err := scanSections(cfg.Path, orig)
 	if err != nil {
 		return false, false, err
 	}
@@ -426,7 +571,7 @@ func HasAnyHooksBlock(path string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	sections, err := scanSections(orig)
+	sections, err := scanSections(path, orig)
 	if err != nil {
 		return false, err
 	}
@@ -463,7 +608,7 @@ func HookBlocks(path string) ([][]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	sections, err := scanSections(orig)
+	sections, err := scanSections(path, orig)
 	if err != nil {
 		return nil, err
 	}
@@ -489,7 +634,7 @@ func HookBlocks(path string) ([][]byte, error) {
 // instead of the whole block.
 func FieldValue(fragment []byte, key string) (string, bool) {
 	for _, raw := range bytes.Split(fragment, []byte("\n")) {
-		stripped, _ := lineSafety(raw)
+		stripped := stripComment(raw)
 		line := bytes.TrimSpace(stripped)
 		k, v, ok := bytes.Cut(line, []byte("="))
 		if !ok || string(bytes.TrimSpace(k)) != key {
@@ -522,32 +667,70 @@ func unquoteBasicString(v []byte) (string, bool) {
 // --- top-level scalar operations ---
 
 // topLevelKeyLine finds a `key = value` assignment before the first table
-// header, returning its line's byte range. The search stops at the first
-// [table] or [[array]] header, matching TOML's own rule that top-level
+// header, returning its LOGICAL line's byte range. The search stops at the
+// first [table] or [[array]] header, matching TOML's own rule that top-level
 // key/value pairs must precede every table section — so a same-named key
 // INSIDE some unrelated table is correctly never matched.
-func topLevelKeyLine(src []byte, key string) (start, end int, found bool, err error) {
-	pos := 0
+//
+// "Logical" is what #1753 changed and it is load-bearing twice over. Skipping
+// a preceding multi-line array is what lets this function reach a header at
+// all in a config vibe wrote — `applied_migrations = [` sits at the TOP level
+// of one, before every header, so the scan used to refuse on line 44 of 392
+// and the experimental-hooks gate was never written. And returning the range
+// through the value's CLOSING line is what keeps the caller's splice honest
+// if the key it is asked about ever holds a multi-line value itself:
+// replacing only the opening line would leave the remaining elements behind
+// as orphaned syntax.
+//
+// A triple-quoted string anywhere in the document is refused here exactly as
+// scanDocument refuses it, so the two entry points into this file agree on
+// which documents are scannable; without it a `"""` inside a table would be
+// invisible to this preamble-only scan.
+func topLevelKeyLine(path string, src []byte, key string) (start, end int, found bool, err error) {
+	if off := tripleQuoteAt(src); off >= 0 {
+		return 0, 0, false, unsafeAt(path, lineNumberAt(src, off), "a multi-line (triple-quoted) string")
+	}
+	pos, lineNo, depth := 0, 0, 0
+	logicalStart, matching, openedAt := 0, false, 0
 	for pos <= len(src) {
 		lineEnd := pos
 		for lineEnd < len(src) && src[lineEnd] != '\n' {
 			lineEnd++
 		}
-		stripped, continues := lineSafety(src[pos:lineEnd])
-		trimmed := bytes.TrimSpace(stripped)
-		if isArrayHeaderLine(trimmed) || isTableHeaderLine(trimmed) {
-			return 0, 0, false, nil
+		lineNo++
+		sc := scanLine(src[pos:lineEnd])
+		if sc.unterminated {
+			return 0, 0, false, unsafeAt(path, lineNo, "an unterminated quote")
 		}
-		if continues {
-			return 0, 0, false, ErrUnsafe
+		if sc.braces != 0 {
+			return 0, 0, false, unsafeAt(path, lineNo, "an inline table spanning more than one line")
 		}
-		if k, _, ok := bytes.Cut(trimmed, []byte("=")); ok && string(bytes.TrimSpace(k)) == key {
-			return pos, lineEnd, true, nil
+		if depth == 0 {
+			trimmed := bytes.TrimSpace(sc.stripped)
+			if isArrayHeaderLine(trimmed) || isTableHeaderLine(trimmed) {
+				return 0, 0, false, nil
+			}
+			logicalStart = pos
+			k, _, ok := bytes.Cut(trimmed, []byte("="))
+			matching = ok && string(bytes.TrimSpace(k)) == key
+		}
+		if depth == 0 && sc.brackets > 0 {
+			openedAt = lineNo
+		}
+		depth += sc.brackets
+		if depth < 0 {
+			return 0, 0, false, unsafeAt(path, lineNo, "an unbalanced ']'")
+		}
+		if depth == 0 && matching {
+			return logicalStart, lineEnd, true, nil
 		}
 		if lineEnd >= len(src) {
 			break
 		}
 		pos = lineEnd + 1
+	}
+	if depth != 0 {
+		return 0, 0, false, unsafeAt(path, openedAt, "an array that is never closed")
 	}
 	return 0, 0, false, nil
 }
@@ -560,7 +743,7 @@ func scalarValue(src []byte, start, end int) string {
 	if !ok {
 		return ""
 	}
-	stripped, _ := lineSafety(eq)
+	stripped := stripComment(eq)
 	return strings.TrimSpace(string(stripped))
 }
 
@@ -576,9 +759,9 @@ func setTopLevelBool(path, key string, want bool, writeFile func(string, []byte)
 	if want {
 		wantStr = "true"
 	}
-	start, end, found, err := topLevelKeyLine(orig, key)
+	start, end, found, err := topLevelKeyLine(path, orig, key)
 	if err != nil {
-		return false, err
+		return false, namingTheEditItWanted(err, key, wantStr)
 	}
 	if found {
 		if scalarValue(orig, start, end) == wantStr {
@@ -592,9 +775,9 @@ func setTopLevelBool(path, key string, want bool, writeFile func(string, []byte)
 		// there is nothing to clear.
 		return false, nil
 	}
-	insertAt, err := firstHeaderOffset(orig)
+	insertAt, err := firstHeaderOffset(path, orig)
 	if err != nil {
-		return false, err
+		return false, namingTheEditItWanted(err, key, wantStr)
 	}
 	line := key + " = " + wantStr + "\n"
 	// A guard appendBlock also needs and gets, for the identical reason:
@@ -609,6 +792,23 @@ func setTopLevelBool(path, key string, want bool, writeFile func(string, []byte)
 	}
 	out := spliceReplace(orig, insertAt, insertAt, []byte(line))
 	return true, writeFile(path, out)
+}
+
+// namingTheEditItWanted appends the edit this package was ASKED to make to a
+// refusal, and leaves every other error alone.
+//
+// "Simplify that line and grant again" tells a user where to look but not what
+// the daemon was trying to do there — and for the one scalar this package
+// writes, that is the whole instruction: a user who knows irrlicht wanted
+// `enable_experimental_hooks = true` can make the one-line edit themselves and
+// have working hooks without touching the construct at all. The wrap keeps
+// errors.Is(ErrUnsafe) and errors.As(*UnsafeConstructError) working, so no
+// caller has to learn about it.
+func namingTheEditItWanted(err error, key, wantStr string) error {
+	if !errors.Is(err, ErrUnsafe) {
+		return err
+	}
+	return fmt.Errorf("%w — the edit it wanted to make is `%s = %s`", err, key, wantStr)
 }
 
 // EnsureBoolTrue sets `key = true` at the top level of the file at path,
@@ -634,7 +834,7 @@ func TopLevelBool(path, key string) (value, found bool, err error) {
 	if err != nil {
 		return false, false, err
 	}
-	start, end, ok, err := topLevelKeyLine(orig, key)
+	start, end, ok, err := topLevelKeyLine(path, orig, key)
 	if err != nil {
 		return false, false, err
 	}

--- a/core/adapters/inbound/agents/hooktoml/hooktoml_test.go
+++ b/core/adapters/inbound/agents/hooktoml/hooktoml_test.go
@@ -1,6 +1,7 @@
 package hooktoml
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -526,7 +527,14 @@ func TestEnsureInstalled_RefusesOnTripleQuotedString(t *testing.T) {
 	}
 }
 
-func TestEnsureInstalled_RefusesOnMultiLineArray(t *testing.T) {
+// TestEnsureInstalled_ModelsAMultiLineArray replaces
+// TestEnsureInstalled_RefusesOnMultiLineArray, which pinned the OPPOSITE
+// verdict on this exact seed until #1753. The behaviour it locked was wrong:
+// mistral-vibe's own writer emits multi-line arrays, so refusing them refused
+// every realistic user config. The seed is kept byte-for-byte from the
+// predecessor so the change of verdict is visible as a change of verdict
+// rather than as a test that quietly stopped existing.
+func TestEnsureInstalled_ModelsAMultiLineArray(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "hooks.toml")
 	seed := "tags = [\n  \"a\",\n  \"b\",\n]\n"
@@ -535,9 +543,238 @@ func TestEnsureInstalled_RefusesOnMultiLineArray(t *testing.T) {
 	}
 	cfg := testConfig(t, path, "irrlichd hook-post mistral-vibe >/dev/null || true")
 
-	_, err := EnsureInstalled(cfg)
+	modified, err := EnsureInstalled(cfg)
+	if err != nil {
+		t.Fatalf("EnsureInstalled refused a document containing a multi-line array: %v", err)
+	}
+	if !modified {
+		t.Fatal("EnsureInstalled reported no modification")
+	}
+	got, _ := os.ReadFile(path)
+	if !strings.HasPrefix(string(got), seed) {
+		t.Errorf("the pre-existing multi-line array did not survive verbatim:\n%s", got)
+	}
+	present, canonical, err := Inspect(cfg)
+	if err != nil || !present || !canonical {
+		t.Errorf("Inspect after install: present=%v canonical=%v err=%v", present, canonical, err)
+	}
+}
+
+// TestScannerRefusals_Corpus is the committed mutation evidence for every
+// construct the scanner still refuses after #1753 widened it, and — the half
+// that carries the value — for the documents it must NOT refuse. A scanner
+// that refused everything and one that refuses correctly are
+// indistinguishable without the must-accept rows, and that is not a
+// hypothetical here: refusing too much is precisely the defect this ticket
+// exists to fix.
+//
+// Both entry points are driven for every row, because they are two separate
+// scanners over the same bytes (scanDocument for the [[hooks]] operations,
+// topLevelKeyLine for the top-level scalar) and #1753 is the ticket where one
+// of them refusing while the other did not would have been invisible.
+func TestScannerRefusals_Corpus(t *testing.T) {
+	cases := []struct {
+		name string
+		doc  string
+		// refuseNaming is the fragment the refusal must name; "" means the
+		// document must be ACCEPTED by both entry points.
+		refuseNaming string
+		// line, when non-zero, is the 1-based line the refusal must point at.
+		line int
+	}{
+		// --- still refused ---
+		{"triple-quoted basic string", "a = \"\"\"\nx\n\"\"\"\n", "triple-quoted", 1},
+		{"triple-quoted literal string", "k = 1\nb = '''\nx\n'''\n", "triple-quoted", 2},
+		{"unterminated basic quote", "k = 1\nname = \"oops\nother = 2\n", "unterminated quote", 2},
+		{"unterminated literal quote", "name = 'oops\n", "unterminated quote", 1},
+		{"multi-line inline table", "k = 1\npoint = { x = 1,\n  y = 2 }\n", "inline table spanning", 2},
+		{"stray closing bracket", "k = 1\n]\n", "unbalanced ']'", 2},
+		{"array never closed (reported at its OPENING line)", "k = 1\ntags = [\n  \"a\",\n", "never closed", 2},
+
+		// --- must be accepted (the vacuity guard) ---
+		{"empty document", "", "", 0},
+		{"single-line array", "tags = [\"a\", \"b\"]\n", "", 0},
+		{"multi-line array at the top level", "tags = [\n  \"a\",\n]\n", "", 0},
+		{"multi-line array inside a table", "[t]\ntags = [\n  \"a\",\n]\n", "", 0},
+		{"multi-line array of single-line inline tables", "t = [\n  { a = 1 },\n  { b = 2 },\n]\n", "", 0},
+		{"nested multi-line array", "m = [\n  [1, 2],\n  [\n    3,\n  ],\n]\n", "", 0},
+		{"brackets and braces inside strings", "s = \"[ { ] }\"\nl = '] } ['\n", "", 0},
+		{"array opener carrying a comment", "tags = [  # why\n  \"a\",\n]\n", "", 0},
+		{"a header-shaped string inside an array", "tags = [\n  \"[[hooks]]\",\n]\n[[hooks]]\nname = \"x\"\n", "", 0},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "doc.toml")
+			if err := os.WriteFile(path, []byte(tc.doc), 0o600); err != nil {
+				t.Fatal(err)
+			}
+
+			// Entry point 1: the [[hooks]] scanner, reached read-only so an
+			// accepted document is not rewritten under the next assertion.
+			_, blocksErr := HookBlocks(path)
+			// Entry point 2: the top-level scalar scanner.
+			_, _, scalarErr := TopLevelBool(path, "enable_experimental_hooks")
+
+			for label, err := range map[string]error{"HookBlocks": blocksErr, "TopLevelBool": scalarErr} {
+				if tc.refuseNaming == "" {
+					if err != nil {
+						t.Errorf("%s refused a document it must accept: %v", label, err)
+					}
+					continue
+				}
+				if err == nil {
+					t.Errorf("%s accepted a document it must refuse", label)
+					continue
+				}
+				if !errors.Is(err, ErrUnsafe) {
+					t.Errorf("%s: error %v does not wrap ErrUnsafe", label, err)
+				}
+				var unsafe *UnsafeConstructError
+				if !errors.As(err, &unsafe) {
+					t.Fatalf("%s: error %v is not an *UnsafeConstructError", label, err)
+				}
+				if !strings.Contains(unsafe.Construct, tc.refuseNaming) {
+					t.Errorf("%s: refusal names %q, want it to mention %q", label, unsafe.Construct, tc.refuseNaming)
+				}
+				if unsafe.Path != path {
+					t.Errorf("%s: refusal names path %q, want %q", label, unsafe.Path, path)
+				}
+				if tc.line != 0 && unsafe.Line != tc.line {
+					t.Errorf("%s: refusal points at line %d, want %d", label, unsafe.Line, tc.line)
+				}
+				if !strings.Contains(err.Error(), path) {
+					t.Errorf("%s: rendered message %q does not name the file — it is what the wizard shows", label, err.Error())
+				}
+			}
+		})
+	}
+}
+
+// --- continuation lines are classified as NOTHING ---
+//
+// The two tests below are the committed mutation evidence for the single
+// rule that makes #1753's widening safe rather than merely permissive:
+// inside a multi-line array, no line is a header, a comment or a key.
+//
+// They exist because the property test did NOT catch it. Deleting
+// scanDocument's `if depth == 0` guard left the entire suite — 4000 generated
+// documents included — green, because every adversarial array element the
+// generator emitted was a QUOTED string, and `"[[hooks]]"` starts with a
+// quote and is header-shaped to nobody. The shape that bites is a bare nested
+// array written as the last element without a trailing comma: its line reads
+// `[1, 2]`, which is precisely what isTableHeaderLine matches. The generator
+// now emits that too (property_test.go), and these two pin it deterministically
+// at the two places a spurious header actually changes bytes.
+
+// TestHookBlocks_HeaderShapedArrayElementDoesNotSplitABlock: a spurious
+// header inside an array truncates the block it sits in, so the block's own
+// later fields silently stop being part of it.
+func TestHookBlocks_HeaderShapedArrayElementDoesNotSplitABlock(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "hooks.toml")
+	seed := "[[hooks]]\nname = \"a\"\nmatrix = [\n  [1, 2]\n]\ncommand = \"eslint .\"\n\n[[hooks]]\nname = \"b\"\n"
+	if err := os.WriteFile(path, []byte(seed), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	blocks, err := HookBlocks(path)
+	if err != nil {
+		t.Fatalf("HookBlocks: %v", err)
+	}
+	if len(blocks) != 2 {
+		t.Fatalf("HookBlocks returned %d blocks, want 2:\n%s", len(blocks), blocks)
+	}
+	if !strings.Contains(string(blocks[0]), `command = "eslint ."`) {
+		t.Errorf("block 0 lost the field below its multi-line array — a line inside the array "+
+			"was classified as a section header:\n%s", blocks[0])
+	}
+}
+
+// TestEnsureBoolTrue_InsertsAfterAPreambleArrayNotInsideIt: a spurious header
+// inside a PREAMBLE array is what firstHeaderOffset returns, so the new
+// assignment is spliced into the middle of the user's array.
+func TestEnsureBoolTrue_InsertsAfterAPreambleArrayNotInsideIt(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	seed := "matrix = [\n  [1, 2]\n]\n\n[session_logging]\nenabled = true\n"
+	if err := os.WriteFile(path, []byte(seed), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := EnsureBoolTrue(path, "enable_experimental_hooks", AtomicWriteFile); err != nil {
+		t.Fatalf("EnsureBoolTrue: %v", err)
+	}
+	got, _ := os.ReadFile(path)
+	if !strings.HasPrefix(string(got), "matrix = [\n  [1, 2]\n]\n") {
+		t.Errorf("the flag was spliced INSIDE the user's preamble array:\n%s", got)
+	}
+	if !strings.Contains(string(got), "enable_experimental_hooks = true\n[session_logging]") {
+		t.Errorf("the flag did not land immediately before the first header:\n%s", got)
+	}
+}
+
+// TestEnsureBoolTrue_ReplacesTheWholeOfAMultiLineValue is the evidence for
+// the second half of topLevelKeyLine's #1753 change — that it returns the
+// LOGICAL line's range, through the closing bracket, not just the physical
+// opening line.
+//
+// The property test cannot reach this: its generator always renders the flag
+// as a bool, which is the only shape vibe or this daemon ever writes. So the
+// state is constructed by hand — a user (or a botched hand-edit) who left the
+// gate key holding an array. Replacing only the opening line would leave
+// `enable_experimental_hooks = true` followed by two lines of orphaned array
+// syntax, which is a corrupted config.toml: the outcome hooktoml's whole
+// refuse-rather-than-guess posture exists to prevent.
+func TestEnsureBoolTrue_ReplacesTheWholeOfAMultiLineValue(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	seed := "a = 1\nenable_experimental_hooks = [\n  \"nonsense\",\n]\nb = 2\n"
+	if err := os.WriteFile(path, []byte(seed), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	modified, err := EnsureBoolTrue(path, "enable_experimental_hooks", AtomicWriteFile)
+	if err != nil {
+		t.Fatalf("EnsureBoolTrue: %v", err)
+	}
+	if !modified {
+		t.Fatal("EnsureBoolTrue reported no modification")
+	}
+	got, _ := os.ReadFile(path)
+	want := "a = 1\nenable_experimental_hooks = true\nb = 2\n"
+	if string(got) != want {
+		t.Errorf("EnsureBoolTrue left orphaned array syntax behind:\ngot:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+// TestEnsureBoolTrue_RefusalNamesTheFileAndLine is #1753's route-3 half. The
+// SURFACING already existed (#1362 records the effect error verbatim and both
+// wizards render "granted but NOT applied, because <reason>"), so nothing new
+// is built for it; what did not exist was a reason a user could act on. This
+// pins the three facts that make it actionable.
+func TestEnsureBoolTrue_RefusalNamesTheFileAndLine(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.toml")
+	// The construct is on line 3, after two perfectly ordinary lines.
+	seed := "a = 1\nb = 2\nbanner = \"\"\"\nhi\n\"\"\"\n"
+	if err := os.WriteFile(path, []byte(seed), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := EnsureBoolTrue(path, "enable_experimental_hooks", AtomicWriteFile)
 	if err == nil {
-		t.Fatal("EnsureInstalled did not refuse a document containing a multi-line array")
+		t.Fatal("EnsureBoolTrue did not refuse a document containing a triple-quoted string")
+	}
+	msg := err.Error()
+	for _, want := range []string{path, ":3", "triple-quoted", "grant again", "`enable_experimental_hooks = true`"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("refusal %q does not mention %q", msg, want)
+		}
+	}
+	if got, _ := os.ReadFile(path); string(got) != seed {
+		t.Errorf("file was modified despite the refusal:\n%s", got)
 	}
 }
 

--- a/core/adapters/inbound/agents/hooktoml/property_test.go
+++ b/core/adapters/inbound/agents/hooktoml/property_test.go
@@ -1,10 +1,12 @@
 package hooktoml
 
 import (
+	"bytes"
 	"fmt"
 	"math/rand"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 	"testing"
@@ -39,7 +41,30 @@ import (
 //     BEFORE, BETWEEN and AFTER the generated blocks (hookjson's first
 //     draft varied only the tail — see its own postmortem in AGENTS.md);
 //   - presence or absence of a final trailing newline;
-//   - which operation runs: EnsureInstalled or Uninstall.
+//   - which operation runs: EnsureInstalled or Uninstall;
+//   - MULTI-LINE ARRAYS (#1753), the construct the scanner used to refuse
+//     outright and now has to walk THROUGH. This is the axis the paragraph
+//     in docs/testing-philosophy.md is about: without it the generator
+//     produces only documents the pre-#1753 scanner already modelled, and a
+//     widening whose whole content is "one more construct" would be graded
+//     by a generator that never emits it. Varied on five sub-axes of its
+//     own, because a multi-line array is not one shape:
+//     its ELEMENT COUNT (0-3, including the empty `[\n]`); its POSITION
+//     (inside a generated [[hooks]] block, inside an unrelated [table],
+//     and — the case the real defect lived in — in the document PREAMBLE
+//     above every header, which is the only region topLevelKeyLine scans);
+//     NESTING (an element that is itself a multi-line array); DECORATION
+//     (a trailing comment on an element line, and a comment-only line
+//     inside the array, neither of which may be mistaken for a section-
+//     leading comment); and ADVERSARIAL ELEMENT TEXT — quoted strings
+//     spelling `[[hooks]]`, `[table]`, `#`, `]` and `"""`-free bracket
+//     soup, each of which reads as a header, a comment or a delimiter to
+//     any scanner that classifies continuation lines — including, as the
+//     LAST element and written without a trailing comma, a bare nested
+//     array (`[1, 2]`, `[[1], [2]]`) whose rendered line is byte-for-byte
+//     what isTableHeaderLine and isArrayHeaderLine match. That last shape
+//     is the only one of the pool that a quoted string cannot stand in
+//     for, and it is what the mutation run showed was missing.
 //
 // Which properties survive which mutation:
 //   - "every UNRELATED block's bytes survive verbatim" holds for BOTH
@@ -58,13 +83,33 @@ import (
 //   - "the operation is idempotent" holds for every state/op combination:
 //     running the SAME operation again on the result reports no further
 //     modification and produces byte-identical output.
+//   - "no document this generator emits is REFUSED" is a property in its own
+//     right (fail("unexpected refusal")), and it is the one the multi-line-
+//     array axis exists to exercise: before #1753 every iteration carrying
+//     one failed there. It survives every mutation because the generator
+//     emits only constructs the scanner is claimed to model — the ones it
+//     still refuses are pinned separately, by name and line, in
+//     TestScannerRefusals_Corpus, since a generator that emitted them would
+//     be asserting the opposite property in the same loop.
+//   - "an unrelated block's bytes survive verbatim" is the property a
+//     multi-line array is most likely to break, and it holds for both
+//     operations: a scanner that mis-attributed an array's closing `]` line
+//     to the NEXT section would move that byte out of the block it belongs
+//     to, and the substring check catches it.
 func TestEnsureAndUninstall_PropertyRandomMutations(t *testing.T) {
 	const iterations = 2000
 	const seed = int64(17180001)
 	rng := rand.New(rand.NewSource(seed))
+	arraysSeen, preambleArraysSeen := 0, 0
 
 	for i := 0; i < iterations; i++ {
 		unrelated, ourState, ourComment, doc := genHooksDoc(rng)
+		if total, preamble := countGeneratedArrays(doc); total > 0 {
+			arraysSeen++
+			if preamble > 0 {
+				preambleArraysSeen++
+			}
+		}
 		op := "ensure"
 		if rng.Intn(2) == 0 {
 			op = "uninstall"
@@ -175,6 +220,60 @@ func TestEnsureAndUninstall_PropertyRandomMutations(t *testing.T) {
 			fail("second %s changed bytes:\nfirst:\n%s\nsecond:\n%s", op, result, result2)
 		}
 	}
+
+	assertArrayAxisWasExercised(t, iterations, arraysSeen, preambleArraysSeen)
+}
+
+// assertArrayAxisWasExercised fails when the generator produced too few
+// documents carrying the #1753 construct for the run to have graded it. The
+// floors are a tenth and a fiftieth of the iteration count — far below what
+// the committed seeds produce, so this fires on a generator that BROKE, not
+// on ordinary variance.
+func assertArrayAxisWasExercised(t *testing.T, iterations, arrays, preambleArrays int) {
+	t.Helper()
+	t.Logf("multi-line-array axis: %d/%d documents carried one, %d of those in the preamble",
+		arrays, iterations, preambleArrays)
+	if arrays < iterations/10 {
+		t.Errorf("only %d of %d generated documents carried a multi-line array — "+
+			"the #1753 axis is not being exercised", arrays, iterations)
+	}
+	if preambleArrays < iterations/50 {
+		t.Errorf("only %d of %d generated documents carried a multi-line array in the PREAMBLE — "+
+			"the region topLevelKeyLine walks, and where #1753's own input had one",
+			preambleArrays, iterations)
+	}
+}
+
+// multiLineArrayOpener is what a generated multi-line array looks like in a
+// rendered document: an assignment whose line ends at the open bracket, or at
+// a comment after it. countGeneratedArrays is the VACUITY GUARD both property
+// tests below run: a generator that silently stopped emitting the construct
+// its whole reason for existing is the construct — a one-character typo in a
+// rng.Intn threshold does it — would leave both tests green while covering
+// exactly what they covered before #1753. Absence of a finding and inability
+// to look must not produce the same output.
+var multiLineArrayOpener = regexp.MustCompile(`(?m)^[ \t]*[A-Za-z0-9_.-]*[ \t]*=[ \t]*\[[ \t]*(#.*)?$`)
+
+// countGeneratedArrays reports how many multi-line arrays doc opens in total
+// and how many of those sit in the PREAMBLE, above every [table] or [[array]]
+// header — the region only topLevelKeyLine walks, and where #1753's real
+// input had its own.
+func countGeneratedArrays(doc []byte) (total, preamble int) {
+	firstHeader := len(doc)
+	for _, line := range bytes.SplitAfter(doc, []byte("\n")) {
+		trimmed := bytes.TrimSpace(line)
+		if len(trimmed) >= 2 && trimmed[0] == '[' && bytes.HasSuffix(trimmed, []byte("]")) {
+			firstHeader = bytes.Index(doc, line)
+			break
+		}
+	}
+	for _, loc := range multiLineArrayOpener.FindAllIndex(doc, -1) {
+		total++
+		if loc[0] < firstHeader {
+			preamble++
+		}
+	}
+	return total, preamble
 }
 
 // canonicalTestCommand is the one canonical beacon command every hooktoml
@@ -221,6 +320,14 @@ func genHooksDoc(rng *rand.Rand) (unrelated []string, ourState, ourComment strin
 	}
 
 	var out strings.Builder
+	// A preamble ABOVE every header: the only region topLevelKeyLine scans,
+	// and where the real #1753 defect lived (vibe's own applied_migrations
+	// sits at line 44 of a 392-line config, before the first header).
+	if rng.Intn(2) == 0 {
+		pre := randomMultiLineArray(rng, fmt.Sprintf("preamble_arr_%d", rng.Intn(100000)), 1)
+		unrelated = append(unrelated, strings.TrimSuffix(pre, "\n"))
+		out.WriteString(pre)
+	}
 	out.WriteString(randomGlue(rng))
 	for i, s := range slots {
 		out.WriteString(s)
@@ -233,6 +340,71 @@ func genHooksDoc(rng *rand.Rand) (unrelated []string, ourState, ourComment strin
 		rendered = strings.TrimSuffix(rendered, "\n")
 	}
 	return unrelated, ourState, ourComment, []byte(rendered)
+}
+
+// randomMultiLineArray renders one multi-line array assignment named key,
+// varying every sub-axis the doc comment above lists. Returned WITH its
+// trailing newline; the caller decides where it goes.
+//
+// Element text is drawn from a deliberately adversarial pool: every entry is
+// a legal TOML string whose CONTENT looks like something the line scanner
+// classifies — a table header, an array-of-tables header, a comment, a bare
+// closing bracket. A scanner that classified continuation lines would read
+// them as structure and either split a section in the wrong place or refuse.
+func randomMultiLineArray(rng *rand.Rand, key string, depth int) string {
+	adversarial := []string{
+		"[[hooks]]",
+		"[session_logging]",
+		"# not a comment",
+		"]",
+		"[",
+		"a \\\" quoted ] bracket",
+		"plain-value",
+		"/Users/x/.vibe/logs/session/*",
+	}
+	// headerShaped elements are the ones that matter most, and they are
+	// deliberately NOT strings: a QUOTED "[[hooks]]" starts with a quote and
+	// is header-shaped to nobody. A bare nested array written without a
+	// trailing comma — legal TOML for the last element — renders a line whose
+	// trimmed text is `[1, 2]` or `[[1], [2]]`, which is EXACTLY what
+	// isTableHeaderLine and isArrayHeaderLine match. This distinction was
+	// found by mutation: with only the quoted pool above, deleting the
+	// scanner's "classify nothing inside an array" guard left the whole
+	// suite green.
+	headerShaped := []string{"[1, 2]", "[[1], [2]]", "[\"x\"]"}
+	var b strings.Builder
+	b.WriteString(key + " = [")
+	if rng.Intn(4) == 0 {
+		b.WriteString("  # why this array exists")
+	}
+	b.WriteString("\n")
+	n := rng.Intn(4)
+	for i := 0; i < n; i++ {
+		if rng.Intn(5) == 0 {
+			b.WriteString("    # a comment line INSIDE the array\n")
+		}
+		if depth > 0 && rng.Intn(4) == 0 {
+			// A nested multi-line array element, indented one level.
+			nested := randomMultiLineArray(rng, "", depth-1)
+			nested = strings.TrimPrefix(nested, " = ")
+			for _, line := range strings.Split(strings.TrimSuffix(nested, "\n"), "\n") {
+				b.WriteString("    " + line + "\n")
+			}
+			continue
+		}
+		if i == n-1 && rng.Intn(2) == 0 {
+			// Last element, no trailing comma, header-shaped.
+			b.WriteString("    " + headerShaped[rng.Intn(len(headerShaped))] + "\n")
+			continue
+		}
+		b.WriteString("    " + Quote(adversarial[rng.Intn(len(adversarial))]) + ",")
+		if rng.Intn(5) == 0 {
+			b.WriteString("  # trailing comment on an element")
+		}
+		b.WriteString("\n")
+	}
+	b.WriteString("]\n")
+	return b.String()
 }
 
 func randomUnrelatedHookBlock(rng *rand.Rand, i int) string {
@@ -255,6 +427,9 @@ func randomUnrelatedHookBlock(rng *rand.Rand, i int) string {
 	if rng.Intn(2) == 0 {
 		b.WriteString("timeout = " + strconv.Itoa(10+rng.Intn(50)) + ".0\n")
 	}
+	if rng.Intn(2) == 0 {
+		b.WriteString(randomMultiLineArray(rng, "match_any", 1))
+	}
 	return b.String()
 }
 
@@ -264,6 +439,9 @@ func randomUnrelatedTable(rng *rand.Rand, i int) string {
 	var b strings.Builder
 	b.WriteString("[" + name + "]\n")
 	b.WriteString("save_dir = " + Quote(fmt.Sprintf("/tmp/x%d", rng.Intn(100000))) + "\n")
+	if rng.Intn(2) == 0 {
+		b.WriteString(randomMultiLineArray(rng, "allowlist", 1))
+	}
 	return b.String()
 }
 
@@ -281,16 +459,28 @@ func randomGlue(rng *rand.Rand) string {
 // --- TestSetTopLevelBool_PropertyRandomMutations (top-level scalar) ---
 //
 // Structural axes: the flag key ABSENT, present-true, or present-false in a
-// random preamble carrying 0-3 unrelated scalar assignments (each with an
-// optional trailing comment) and 0-2 standalone comment/blank lines; a
-// random SUFFIX of 0-2 unrelated [table] sections after the preamble
+// random preamble carrying 0-3 unrelated top-level assignments — each of
+// which is EITHER a scalar (with an optional trailing comment) OR a
+// multi-line array (#1753), varied on the five sub-axes randomMultiLineArray
+// lists — plus an optional further array AFTER the flag; 0-2 standalone
+// comment/blank lines; a random SUFFIX of 0-2 unrelated [table] sections
+// after the preamble, themselves optionally carrying a multi-line array
 // (present precisely to prove the scanner never inserts INSIDE a table);
 // presence or absence of a trailing newline; and which operation runs —
 // EnsureBoolTrue or ClearBoolIfPresent.
 //
-// Which properties survive which mutation: every unrelated scalar line and
-// every table section survives verbatim under BOTH operations and every
-// starting state — there is no analogue of hookjson's "the deleted
+// The array axis matters most on THIS generator, not the sibling one: the
+// top-level scan is a second, independent walk over the bytes
+// (topLevelKeyLine, not scanDocument), it is the walk EnsureBoolTrue takes,
+// and it is where #1753's own defect fired — vibe's config opens a
+// multi-line array 4 lines before its first header, so the scan refused
+// without ever reaching one.
+//
+// Which properties survive which mutation: no document this generator emits
+// is refused (the property the array axis exists for — every iteration
+// carrying an array failed here before #1753), and every unrelated scalar
+// line, every unrelated ARRAY and every table section survives verbatim
+// under BOTH operations and every starting state — there is no analogue of hookjson's "the deleted
 // subtree's comments go with it" here, because a scalar set/clear never
 // deletes a LINE, only rewrites the one line it targets (or adds one), so
 // nothing this generator places is ever a casualty the way an unrelated
@@ -301,8 +491,15 @@ func TestSetTopLevelBool_PropertyRandomMutations(t *testing.T) {
 	rng := rand.New(rand.NewSource(seed))
 	const key = "enable_experimental_hooks"
 
+	arraysSeen, preambleArraysSeen := 0, 0
 	for i := 0; i < iterations; i++ {
 		unrelated, startState, doc := genScalarDoc(rng, key)
+		if total, preamble := countGeneratedArrays(doc); total > 0 {
+			arraysSeen++
+			if preamble > 0 {
+				preambleArraysSeen++
+			}
+		}
 		op := "ensure"
 		if rng.Intn(2) == 0 {
 			op = "clear"
@@ -384,17 +581,28 @@ func TestSetTopLevelBool_PropertyRandomMutations(t *testing.T) {
 			fail("second %s changed bytes", op)
 		}
 	}
+
+	assertArrayAxisWasExercised(t, iterations, arraysSeen, preambleArraysSeen)
 }
 
 func genScalarDoc(rng *rand.Rand, key string) (unrelated []string, startState string, doc []byte) {
 	nScalars := rng.Intn(4)
 	var preamble strings.Builder
 	for i := 0; i < nScalars; i++ {
-		line := fmt.Sprintf("some_key_%d = %s", i, Quote(fmt.Sprintf("v%d", rng.Intn(100000))))
+		var line string
 		if rng.Intn(2) == 0 {
-			line += "  # a comment"
+			// A TOP-LEVEL multi-line array: the exact construct that made
+			// topLevelKeyLine refuse a config vibe itself wrote (#1753), and
+			// the one this scanner has to walk THROUGH to reach either the
+			// flag or the first header.
+			line = randomMultiLineArray(rng, fmt.Sprintf("some_arr_%d", i), 1)
+		} else {
+			line = fmt.Sprintf("some_key_%d = %s", i, Quote(fmt.Sprintf("v%d", rng.Intn(100000))))
+			if rng.Intn(2) == 0 {
+				line += "  # a comment"
+			}
+			line += "\n"
 		}
-		line += "\n"
 		unrelated = append(unrelated, strings.TrimRight(line, "\n"))
 		preamble.WriteString(line)
 		if rng.Intn(3) == 0 {
@@ -406,6 +614,14 @@ func genScalarDoc(rng *rand.Rand, key string) (unrelated []string, startState st
 	startState = states[rng.Intn(len(states))]
 	if startState != "absent" {
 		preamble.WriteString(key + " = " + startState + "\n")
+	}
+	// An array AFTER the flag as well as before it: the scan must resume
+	// classifying top-level keys once an array closes, not stop at the first
+	// one it walked through.
+	if rng.Intn(3) == 0 {
+		after := randomMultiLineArray(rng, fmt.Sprintf("tail_arr_%d", rng.Intn(100000)), 1)
+		unrelated = append(unrelated, strings.TrimSuffix(after, "\n"))
+		preamble.WriteString(after)
 	}
 
 	nTables := rng.Intn(3)

--- a/core/adapters/inbound/agents/vibe/hookinstaller_realconfig_test.go
+++ b/core/adapters/inbound/agents/vibe/hookinstaller_realconfig_test.go
@@ -1,0 +1,269 @@
+// hookinstaller_realconfig_test.go grades this adapter's hooks install
+// against a config.toml MISTRAL VIBE ITSELF WROTE, committed verbatim under
+// testdata/ (one redaction, see below), rather than against a document one of
+// these tests constructed.
+//
+// That distinction is the whole ticket (#1753). Every other test in this
+// package builds its own config.toml, and every one of them was green while
+// the shipped install (#1718/#1733) could not write into a realistic user
+// config at all: vibe's own writer emits multi-line arrays, hooktoml's
+// splicer refused any document containing one, so Apply returned ErrUnsafe,
+// enable_experimental_hooks was never set, vibe never read hooks.toml, and no
+// hook ever fired — while the permission continued to read `granted`. A
+// hand-minimised fixture is exactly what hid it, so the fixture here is not
+// minimised and TestRealVibeConfigFixture_StillCarriesTheConstructThatBrokeIt
+// fails loudly if someone ever minimises it.
+package vibe
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"irrlicht/core/adapters/inbound/agents/hooktoml"
+)
+
+// realConfigFixture is the committed copy of the maintainer's own
+// $VIBE_HOME/config.toml as written by mistral-vibe 2.19.1. It is byte-for-
+// byte upstream output except for ONE redaction — [experiments].client_key,
+// a telemetry SDK key, replaced with a placeholder. The whole file was
+// scanned for secret-shaped values before committing
+// (api_key_env_var names an env var, not a key; [[providers]] carries no
+// credential).
+const realConfigFixture = "testdata/real-config-2.19.1.toml"
+
+// multiLineArrayOpen matches an assignment whose value opens a multi-line
+// array: `key = [` with nothing but whitespace (or a comment) after the
+// bracket. It is deliberately the SAME shape #1753's own measurement used, so
+// the count this file asserts and the count the issue quotes are produced by
+// the same rule rather than by two people's eyeballs.
+var multiLineArrayOpen = regexp.MustCompile(`(?m)^[ \t]*[A-Za-z0-9_.-]+[ \t]*=[ \t]*\[[ \t]*(#.*)?$`)
+
+// countMultiLineArrayOpens reports how many multi-line arrays src opens in
+// total, and how many of those are at the TOP level — before the first
+// [table] or [[array]] header. The split matters: hooktoml has two
+// independent scanners, and the top-level one (topLevelKeyLine, the path
+// EnsureBoolTrue takes) never even reaches a header, so a fixture whose only
+// multi-line arrays sat inside tables would exercise one of the two refusals
+// and read as covering both.
+//
+// Extracted as a function, rather than inlined into the guard below, so
+// countMultiLineArrayOpensCorpus can grade it against documents whose answers
+// are known by construction — the mutation evidence for a guard that
+// otherwise passes the moment it is written.
+func countMultiLineArrayOpens(src []byte) (total, topLevel int) {
+	firstHeader := len(src)
+	for _, line := range bytes.SplitAfter(src, []byte("\n")) {
+		trimmed := bytes.TrimSpace(line)
+		if len(trimmed) > 0 && trimmed[0] == '[' {
+			firstHeader = bytes.Index(src, line)
+			break
+		}
+	}
+	for _, loc := range multiLineArrayOpen.FindAllIndex(src, -1) {
+		total++
+		if loc[0] < firstHeader {
+			topLevel++
+		}
+	}
+	return total, topLevel
+}
+
+// TestRealVibeConfigFixture_StillCarriesTheConstructThatBrokeIt is the
+// vacuity guard for every test in this file: a fixture quietly collapsed (the
+// exact workaround PR #1752 applied to its scratch SEED, and documented there
+// as a workaround) would leave the tests below green while covering nothing.
+//
+// The numbers are the ones measured on the real config when #1753 was filed —
+// 12 multi-line arrays, at least one of them top-level — and the assertion is
+// ">=", not "==": a later re-capture of the maintainer's config may carry
+// more, and only FEWER means the fixture stopped carrying the defect's input.
+func TestRealVibeConfigFixture_StillCarriesTheConstructThatBrokeIt(t *testing.T) {
+	src, err := os.ReadFile(realConfigFixture)
+	if err != nil {
+		t.Fatalf("reading the committed fixture: %v", err)
+	}
+	total, topLevel := countMultiLineArrayOpens(src)
+	if total < 12 {
+		t.Errorf("fixture opens %d multi-line arrays, want >= 12 — it has been minimised, "+
+			"which is exactly what hid #1753", total)
+	}
+	if topLevel < 1 {
+		t.Errorf("fixture opens %d TOP-LEVEL multi-line arrays (before the first header), want >= 1 — "+
+			"without one, EnsureBoolTrue's own scanner is never reached", topLevel)
+	}
+	if bytes.Contains(src, []byte("sdk-OE8")) {
+		t.Error("the fixture still carries the unredacted telemetry client_key")
+	}
+}
+
+// countMultiLineArrayOpensCorpus is the committed mutation evidence for the
+// guard above: one document per shape, pinned to the answer the counter must
+// return. Without it a counter that returned a large constant, or that never
+// found a header and called everything top-level, would satisfy the guard and
+// read as excellent coverage.
+func TestCountMultiLineArrayOpens_Corpus(t *testing.T) {
+	cases := []struct {
+		name            string
+		doc             string
+		total, topLevel int
+	}{
+		{"empty", "", 0, 0},
+		{"single-line array only", "a = []\nb = [1, 2]\n", 0, 0},
+		{"one top-level, no headers at all", "a = [\n  1,\n]\n", 1, 1},
+		{"one top-level before a header", "a = [\n  1,\n]\n\n[t]\nb = 2\n", 1, 1},
+		{"one inside a table only", "[t]\na = [\n  1,\n]\n", 1, 0},
+		{"one each side of the first header", "a = [\n  1,\n]\n[t]\nb = [\n  2,\n]\n", 2, 1},
+		{"opener carrying a trailing comment", "a = [  # why\n  1,\n]\n", 1, 1},
+		// The collapsed shape PR #1752's scratch seed used: the same content
+		// on one line. A guard blind to this is a guard that would not notice
+		// the fixture being minimised.
+		{"collapsed to one line", "a = [ 1 ]\n[t]\nb = [ 2 ]\n", 0, 0},
+	}
+	for _, tc := range cases {
+		total, topLevel := countMultiLineArrayOpens([]byte(tc.doc))
+		if total != tc.total || topLevel != tc.topLevel {
+			t.Errorf("%s: got total=%d topLevel=%d, want total=%d topLevel=%d",
+				tc.name, total, topLevel, tc.total, tc.topLevel)
+		}
+	}
+}
+
+// seedRealConfig points VIBE_HOME at a fresh temp dir holding a copy of the
+// committed real config, and returns that dir. HOME is redirected too so
+// nothing can fall back to the developer's own ~/.vibe.
+func seedRealConfig(t *testing.T) (home, configPath string) {
+	t.Helper()
+	src, err := os.ReadFile(realConfigFixture)
+	if err != nil {
+		t.Fatalf("reading the committed fixture: %v", err)
+	}
+	home = t.TempDir()
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv(vibeHomeEnvVar, home)
+	configPath = filepath.Join(home, configFilename)
+	if err := os.WriteFile(configPath, src, 0o600); err != nil {
+		t.Fatalf("seeding config.toml: %v", err)
+	}
+	return home, configPath
+}
+
+// TestEnsureHooksInstalled_IntoAConfigVibeItselfWrote is #1753's defect test.
+// Before the fix it fails on the very first assertion, with hooktoml's
+// ErrUnsafe: the install cannot write the gate at all.
+func TestEnsureHooksInstalled_IntoAConfigVibeItselfWrote(t *testing.T) {
+	home, configPath := seedRealConfig(t)
+	before, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("reading the seeded config: %v", err)
+	}
+
+	modified, err := EnsureHooksInstalled()
+	if err != nil {
+		t.Fatalf("EnsureHooksInstalled into a config vibe itself wrote: %v", err)
+	}
+	if !modified {
+		t.Fatal("EnsureHooksInstalled reported no modification")
+	}
+
+	// The gate is on — the fact whose absence means no hook ever fires.
+	on, found, err := hooktoml.TopLevelBool(configPath, experimentalHooksFlag)
+	if err != nil {
+		t.Fatalf("TopLevelBool after install: %v", err)
+	}
+	if !found || !on {
+		t.Fatalf("%s: found=%v value=%v, want true/true", experimentalHooksFlag, found, on)
+	}
+
+	// The entry is live, by the adapter's own definition of intact.
+	status, err := VerifyHooksInstalled()
+	if err != nil {
+		t.Fatalf("VerifyHooksInstalled: %v", err)
+	}
+	if !status.Intact() {
+		t.Fatalf("VerifyHooksInstalled reports %+v, want intact", status)
+	}
+	if _, err := os.Stat(filepath.Join(home, hooksFilename)); err != nil {
+		t.Fatalf("hooks.toml: %v", err)
+	}
+
+	// Every byte of the user's own config survives except the one line the
+	// install adds. This is the property a splicer exists for, and the reason
+	// hooktoml refuses rather than re-encoding: a read-modify-marshal through
+	// a generic TOML encoder would reformat all twelve arrays and drop every
+	// comment.
+	after, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("reading the rewritten config: %v", err)
+	}
+	assertOnlyAddedTheFlagLine(t, before, after)
+}
+
+// assertOnlyAddedTheFlagLine checks that after differs from before by exactly
+// one added line, and that the added line is the flag assignment.
+func assertOnlyAddedTheFlagLine(t *testing.T, before, after []byte) {
+	t.Helper()
+	wantLine := experimentalHooksFlag + " = true"
+
+	beforeLines := strings.Split(string(before), "\n")
+	afterLines := strings.Split(string(after), "\n")
+	if len(afterLines) != len(beforeLines)+1 {
+		t.Fatalf("config gained %d lines, want exactly 1", len(afterLines)-len(beforeLines))
+	}
+
+	var added []string
+	i, j := 0, 0
+	for i < len(beforeLines) && j < len(afterLines) {
+		if beforeLines[i] == afterLines[j] {
+			i, j = i+1, j+1
+			continue
+		}
+		added = append(added, afterLines[j])
+		j++
+	}
+	added = append(added, afterLines[j:]...)
+	if len(added) != 1 || strings.TrimSpace(added[0]) != wantLine {
+		t.Fatalf("config changed by %d line(s) %q, want exactly one added line %q", len(added), added, wantLine)
+	}
+}
+
+// TestUninstallHooks_FromAConfigVibeItselfWrote is the other half of the round
+// trip: the flag added to a real config is cleared again, and the user's own
+// twelve arrays are still byte-identical to what vibe wrote.
+func TestUninstallHooks_FromAConfigVibeItselfWrote(t *testing.T) {
+	_, configPath := seedRealConfig(t)
+	before, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("reading the seeded config: %v", err)
+	}
+
+	if _, err := EnsureHooksInstalled(); err != nil {
+		t.Fatalf("EnsureHooksInstalled: %v", err)
+	}
+	if _, err := UninstallHooks(); err != nil {
+		t.Fatalf("UninstallHooks: %v", err)
+	}
+
+	on, _, err := hooktoml.TopLevelBool(configPath, experimentalHooksFlag)
+	if err != nil {
+		t.Fatalf("TopLevelBool after uninstall: %v", err)
+	}
+	if on {
+		t.Errorf("%s is still true after UninstallHooks", experimentalHooksFlag)
+	}
+
+	after, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("reading the config after uninstall: %v", err)
+	}
+	// The flag line survives as `= false` — ClearBoolIfPresent rewrites the
+	// line it added rather than deleting it, which is the documented
+	// behaviour. Everything else must be untouched.
+	stripped := strings.Replace(string(after), experimentalHooksFlag+" = false\n", "", 1)
+	if stripped != string(before) {
+		t.Errorf("uninstall did not restore the user's own bytes:\n--- want ---\n%s\n--- got ---\n%s", before, stripped)
+	}
+}

--- a/core/adapters/inbound/agents/vibe/testdata/real-config-2.19.1.toml
+++ b/core/adapters/inbound/agents/vibe/testdata/real-config-2.19.1.toml
@@ -1,0 +1,392 @@
+active_model = "mistral-medium-3.5"
+theme = "ansi-dark"
+disable_welcome_banner_animation = false
+autocopy_to_clipboard = true
+file_watcher_for_autocomplete = false
+ask_confirmation_on_exit = true
+displayed_workdir = ""
+context_warnings = false
+voice_mode_enabled = false
+narrator_enabled = false
+active_transcribe_model = "voxtral-realtime"
+active_tts_model = "voxtral-tts"
+bypass_tool_permissions = false
+raise_on_compaction_failure = false
+enable_telemetry = true
+system_prompt_id = "cli"
+compaction_prompt_id = "compact"
+include_commit_signature = true
+include_model_info = true
+include_project_context = true
+include_prompt_detail = true
+enable_update_checks = true
+enable_notifications = true
+enable_system_trust_store = false
+api_timeout = 720.0
+api_retry_max_elapsed_time = 300.0
+auto_compact_threshold = 200000
+experimental_bash_tool = false
+tool_paths = []
+mcp_servers = []
+enable_connectors = true
+connectors = []
+enabled_tools = []
+disabled_tools = []
+agent_paths = []
+enabled_agents = []
+disabled_agents = []
+installed_agents = []
+default_agent = "default"
+skill_paths = []
+enabled_skills = []
+disabled_skills = []
+experimental_enable_registry_skills = false
+applied_migrations = [
+    "bash_read_only_defaults_v1",
+]
+
+[experiment_overrides]
+
+[[providers]]
+name = "mistral"
+api_base = "https://api.mistral.ai/v1"
+api_key_env_var = "MISTRAL_API_KEY"
+browser_auth_base_url = "https://console.mistral.ai"
+browser_auth_api_base_url = "https://console.mistral.ai/api"
+api_style = "openai"
+backend = "mistral"
+reasoning_field_name = "reasoning_content"
+project_id = ""
+region = ""
+
+[providers.extra_headers]
+
+[[providers]]
+name = "llamacpp"
+api_base = "http://127.0.0.1:8080/v1"
+api_key_env_var = ""
+api_style = "openai"
+backend = "generic"
+reasoning_field_name = "reasoning_content"
+project_id = ""
+region = ""
+
+[providers.extra_headers]
+
+[[models]]
+name = "mistral-vibe-cli-latest"
+provider = "mistral"
+alias = "mistral-medium-3.5"
+temperature = 1.0
+input_price = 1.5
+output_price = 7.5
+thinking = "high"
+supports_images = true
+auto_compact_threshold = 200000
+
+[[models]]
+name = "devstral-small-latest"
+provider = "mistral"
+alias = "devstral-small"
+temperature = 0.2
+input_price = 0.1
+output_price = 0.3
+thinking = "off"
+supports_images = false
+auto_compact_threshold = 200000
+
+[[models]]
+name = "devstral"
+provider = "llamacpp"
+alias = "local"
+temperature = 0.2
+input_price = 0.0
+output_price = 0.0
+thinking = "off"
+supports_images = false
+auto_compact_threshold = 200000
+
+[[transcribe_providers]]
+name = "mistral"
+api_base = "wss://api.mistral.ai"
+api_key_env_var = "MISTRAL_API_KEY"
+client = "mistral"
+
+[[transcribe_models]]
+name = "voxtral-mini-transcribe-realtime-2602"
+provider = "mistral"
+alias = "voxtral-realtime"
+sample_rate = 16000
+encoding = "pcm_s16le"
+language = "en"
+target_streaming_delay_ms = 500
+
+[[tts_providers]]
+name = "mistral"
+api_base = "https://api.mistral.ai"
+api_key_env_var = "MISTRAL_API_KEY"
+client = "mistral"
+
+[[tts_models]]
+name = "voxtral-mini-tts-latest"
+provider = "mistral"
+alias = "voxtral-tts"
+voice = "gb_jane_neutral"
+response_format = "wav"
+
+[project_context]
+default_commit_count = 5
+timeout_seconds = 2.0
+
+[experiments]
+enable = true
+api_host = "https://experiments.mistral.services/"
+client_key = "sdk-REDACTED-BY-IRRLICHT-FIXTURE"
+
+[session_logging]
+save_dir = "/Users/ingo/.vibe/logs/session"
+session_prefix = "session"
+enabled = true
+
+[tools.skill]
+permission = "always"
+allowlist = []
+denylist = []
+sensitive_patterns = []
+
+[tools.exit_plan_mode]
+permission = "always"
+allowlist = []
+denylist = []
+sensitive_patterns = []
+
+[tools.task]
+permission = "ask"
+allowlist = [
+    "explore",
+]
+denylist = []
+sensitive_patterns = []
+
+[tools.web_fetch]
+permission = "ask"
+allowlist = []
+denylist = []
+sensitive_patterns = []
+default_timeout = 30
+max_timeout = 120
+max_content_bytes = 120000
+user_agent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+
+[tools.bash]
+permission = "ask"
+allowlist = [
+    "/Users/ingo/.local/share/uv/tools/mistral-vibe/lib/python3.12/site-packages/vibe/core/prompts/*",
+    "/Users/ingo/.vibe/logs/session/*",
+    "/Users/ingo/.vibe/skills/*",
+    "basename",
+    "cat",
+    "cd",
+    "comm",
+    "cut",
+    "date",
+    "diff",
+    "dirname",
+    "du",
+    "echo",
+    "file",
+    "find",
+    "find . -name \"*.md\" -path \"*/.github/*\" -exec grep -l \"974\" {} \\;",
+    "find . -name \"*.md\" -type f -exec grep -l \"974\" {} \\;",
+    "find . -type f \\( -name \"*.md\" -o -name \"*.txt\" -o -name \"*.json\" \\) -exec grep -l \"974\" {} \\;",
+    "fmt",
+    "fold",
+    "git diff",
+    "git log",
+    "git show",
+    "git status",
+    "grep",
+    "head",
+    "join",
+    "less",
+    "ls",
+    "md5sum",
+    "more",
+    "nl",
+    "od",
+    "paste",
+    "pwd",
+    "python3",
+    "readlink",
+    "sha1sum",
+    "sha256sum",
+    "shasum",
+    "sort",
+    "stat",
+    "sum",
+    "tac",
+    "tail",
+    "tr",
+    "tree",
+    "uname",
+    "uniq",
+    "vibe",
+    "wc",
+    "which",
+    "whoami",
+]
+denylist = [
+    "gdb",
+    "pdb",
+    "passwd",
+    "nano",
+    "vim",
+    "vi",
+    "emacs",
+    "bash -i",
+    "sh -i",
+    "zsh -i",
+    "fish -i",
+    "dash -i",
+    "screen",
+    "tmux",
+]
+sensitive_patterns = [
+    "sudo",
+]
+max_output_bytes = 16000
+default_timeout = 300
+denylist_standalone = [
+    "python",
+    "python3",
+    "ipython",
+    "bash",
+    "sh",
+    "nohup",
+    "vi",
+    "vim",
+    "emacs",
+    "nano",
+    "su",
+]
+max_timeout_seconds = 600.0
+max_inline_bytes = 30000
+
+[tools.edit]
+permission = "ask"
+allowlist = []
+denylist = []
+sensitive_patterns = [
+    "**/.env",
+    "**/.env.*",
+]
+
+[tools.grep]
+permission = "always"
+allowlist = []
+denylist = []
+sensitive_patterns = [
+    "**/.env",
+    "**/.env.*",
+]
+max_output_bytes = 64000
+default_max_matches = 100
+default_timeout = 60
+exclude_patterns = [
+    ".venv/",
+    "venv/",
+    ".env/",
+    "env/",
+    "node_modules/",
+    ".git/",
+    "__pycache__/",
+    ".pytest_cache/",
+    ".mypy_cache/",
+    ".tox/",
+    ".nox/",
+    ".coverage/",
+    "htmlcov/",
+    "dist/",
+    "build/",
+    ".idea/",
+    ".vscode/",
+    "*.egg-info",
+    "*.pyc",
+    "*.pyo",
+    "*.pyd",
+    ".DS_Store",
+    "Thumbs.db",
+]
+codeignore_file = ".vibeignore"
+
+[tools.ask_user_question]
+permission = "always"
+allowlist = []
+denylist = []
+sensitive_patterns = []
+
+[tools.read_file]
+permission = "always"
+allowlist = [
+    "/Users/ingo/.vibe/*",
+]
+denylist = []
+sensitive_patterns = [
+    "**/.env",
+    "**/.env.*",
+]
+max_read_bytes = 51200
+
+[tools.bash_output]
+permission = "always"
+allowlist = []
+denylist = []
+sensitive_patterns = []
+max_poll_seconds = 300.0
+max_inline_bytes = 30000
+
+[tools.bash_stdin]
+permission = "always"
+allowlist = []
+denylist = []
+sensitive_patterns = []
+
+[tools.bash_sessions]
+permission = "always"
+allowlist = []
+denylist = []
+sensitive_patterns = []
+max_inline_bytes = 30000
+
+[tools.bash_log_file]
+permission = "ask"
+allowlist = []
+denylist = []
+sensitive_patterns = []
+max_inline_bytes = 30000
+
+[tools.web_search]
+permission = "ask"
+allowlist = []
+denylist = []
+sensitive_patterns = []
+timeout = 120
+model = "mistral-vibe-cli-with-tools"
+
+[tools.todo]
+permission = "always"
+allowlist = []
+denylist = []
+sensitive_patterns = []
+max_todos = 100
+
+[tools.write_file]
+permission = "ask"
+allowlist = []
+denylist = []
+sensitive_patterns = [
+    "**/.env",
+    "**/.env.*",
+]
+max_write_bytes = 64000
+create_parent_dirs = true

--- a/docs/testing-philosophy.md
+++ b/docs/testing-philosophy.md
@@ -151,3 +151,24 @@ generator was widened. And **which properties survive which mutation** — "ever
 comment is preserved" is false for a deletion, since the deleted subtree's comments
 go with it, and asserting it anyway produces false failures that erode the test.
 
+**Varying an axis means varying the SPELLING the code classifies on, not the axis's
+name — and the generator itself needs a vacuity guard.** Both halves were earned in
+one run, on `hooktoml`'s splicer (#1753), which had to be widened to model the
+multi-line arrays mistral-vibe's own writer emits. The generator was extended to
+place multi-line arrays in five positions with an adversarial element pool spelling
+`[[hooks]]`, `[table]`, `#` and `]` — a widening that reads as thorough and produced
+arrays in 1539 of 2000 documents. Then deleting the one line that makes the widening
+safe (the guard that classifies NOTHING inside an array as a header, a comment or a
+key) left the whole suite, those 2000 documents included, **green**: every
+adversarial element was a *quoted string*, and `"[[hooks]]"` starts with a quote and
+is header-shaped to nobody. The shape that bites is a bare nested array written as
+the last element with no trailing comma — its line reads `[1, 2]`, which is exactly
+what the header matcher matches. The generator now emits that too and the same
+mutation reddens three tests. So state the axis in the vocabulary of the code under
+test (what the scanner *matches on*), not of the format. And because a generator can
+also stop emitting the construct entirely — one character in an `rng.Intn` threshold
+does it — count what was actually produced and fail when it drops, the same way any
+other mechanism must fail loudly when it cannot run: `assertArrayAxisWasExercised`
+(`core/adapters/inbound/agents/hooktoml/property_test.go`) prints the census on every
+run and is itself seen red by disabling the four call sites.
+


### PR DESCRIPTION
Fixes #1753.

## The defect, reproduced

`hooktoml`'s splicer refused any document containing a multi-line array. mistral-vibe's own writer emits twelve of them in the maintainer's `config.toml` — and the first, `applied_migrations`, sits at **line 44 of 392, above every header**, which is the only region `topLevelKeyLine` ever scans. So the hooks permission's `Apply` returned `ErrUnsafe`, `enable_experimental_hooks` was never written, vibe never read `hooks.toml`, and no hook ever fired — with the permission still reading `granted`.

**Red before the fix**, against a `config.toml` vibe itself wrote (committed verbatim as `core/adapters/inbound/agents/vibe/testdata/real-config-2.19.1.toml`, one redaction — a telemetry `client_key`):

```
=== RUN   TestRealVibeConfigFixture_StillCarriesTheConstructThatBrokeIt
--- PASS: TestRealVibeConfigFixture_StillCarriesTheConstructThatBrokeIt (0.00s)
=== RUN   TestCountMultiLineArrayOpens_Corpus
--- PASS: TestCountMultiLineArrayOpens_Corpus (0.00s)
=== RUN   TestEnsureHooksInstalled_IntoAConfigVibeItselfWrote
    hookinstaller_realconfig_test.go:166: EnsureHooksInstalled into a config vibe itself wrote: hooktoml: file contains a construct this splicer does not model safely (multi-line string, multi-line array, or unterminated quote) — refusing rather than guessing
--- FAIL: TestEnsureHooksInstalled_IntoAConfigVibeItselfWrote (0.00s)
=== RUN   TestUninstallHooks_FromAConfigVibeItselfWrote
    hookinstaller_realconfig_test.go:244: EnsureHooksInstalled: hooktoml: file contains a construct this splicer does not model safely (multi-line string, multi-line array, or unterminated quote) — refusing rather than guessing
--- FAIL: TestUninstallHooks_FromAConfigVibeItselfWrote (0.00s)
```

## Routes taken, and rejected

**Route 1 — teach the splicer multi-line arrays. Taken.** `scanDocument` now carries one integer of bracket depth across lines, so a multi-line array reads as a single logical line. The rule that makes it safe rather than merely permissive: **nothing inside an array is classified as a header, a comment or a key.** `topLevelKeyLine` returns the **logical** range, through the value's closing line, so a splice can never leave orphaned array syntax behind.

**Route 2 — write the flag without splicing. Rejected.** A blind append cannot honour "set an *existing* key" (vibe writes `enable_experimental_hooks` itself once it has been touched in the UI, and appending a second top-level assignment is what TOML forbids), and appending without modelling the document is exactly the guess this package exists to refuse. It also buys nothing that route 1 does not: the same scan is needed to know where the preamble ends.

**Route 3 — a consent-time refusal with an actionable reason. Half of it was already there, and I disagree with the issue's framing on which half.** The *surfacing* exists and needs nothing new: `PermissionService.runClosureEffect` records `err.Error()` verbatim into `effectErrs`, `PermissionView.EffectError` and `PermissionsSnapshot.UnappliedGrants[].Reason` carry it, both wizards render "granted but NOT applied, because `<reason>`", and `planAnswerLocked` re-runs a previously-failed effect on a re-answer. #1365's version gate rides that same path. What was missing was purely the **content** of the reason: the old sentinel named neither the file, nor the line, nor what the daemon was trying to do. So refusals are now `*UnsafeConstructError` (wrapping `ErrUnsafe`, so `errors.Is` still works) carrying path, 1-based line and construct, plus the edit the caller wanted:

```
hooktoml: /Users/x/.vibe/config.toml:3 contains a multi-line (triple-quoted) string, which
this splicer does not model safely — refusing rather than guessing; simplify that line (or
make the edit by hand) and grant again — the edit it wanted to make is `enable_experimental_hooks = true`
```

Also newly refused: a **multi-line inline table**. TOML 1.0 does not permit one, and the old scanner did not refuse it — it silently mis-read the second line as a fresh top-level key. Same class of "cannot model", now honest about it.

## Property test — which axes the generator varies

Both generators in `hooktoml/property_test.go` gained the multi-line-array axis, varied on five sub-axes: **element count** (0-3, including empty `[\n]`); **position** (inside a `[[hooks]]` block, inside a `[table]`, and — the case the real defect lived in — in the document PREAMBLE above every header, plus after the flag key as well as before it); **nesting** (an element that is itself a multi-line array); **decoration** (a trailing comment on an element line, a comment-only line inside the array, a comment on the opener); and **adversarial element text**.

Census, printed on every run: 1539/2000 documents carry an array (994 in the preamble) for the `[[hooks]]` generator; 1636/2000 (1365 in the preamble) for the scalar one. Local sweep before landing: 5 seeds × 20 000 iterations × both tests, all clean.

**Which properties survive which mutation:** "no document this generator emits is refused" (the property the axis exists for — every array-carrying iteration failed here before this change); "every unrelated block/array/table survives verbatim" under both operations; idempotence and byte-equality on a second run. The refusals are pinned *separately*, in `TestScannerRefusals_Corpus`, since a generator emitting them would be asserting the opposite property inside the same loop.

## The mutation that came back green, and what it taught

The first version of the widened generator produced arrays in 1539/2000 documents and **still** did not grade the rule that makes the widening safe. Deleting `scanDocument`'s `if depth == 0` guard — so lines *inside* an array get classified as headers — left the entire suite green, because every adversarial element was a **quoted string**, and `"[[hooks]]"` starts with a quote and is header-shaped to nobody. The shape that bites is a bare nested array written as the last element with no trailing comma: its line reads `[1, 2]`, which is exactly what `isTableHeaderLine` matches. The generator now emits that, and two deterministic tests pin it at the two places a spurious header actually changes bytes. `docs/testing-philosophy.md` gained a paragraph: state a generator's axis in the vocabulary of *what the code matches on*, not of the format.

## Mutations, applied and reverted one at a time

| Mutation | Result |
|---|---|
| A. `scanDocument` classifies continuation lines (`if depth == 0` → `if true`) | **RED** — `TestHookBlocks_HeaderShapedArrayElementDoesNotSplitABlock`, `TestEnsureBoolTrue_InsertsAfterAPreambleArrayNotInsideIt`, `TestSetTopLevelBool_PropertyRandomMutations` |
| B. `topLevelKeyLine` classifies continuation lines | **RED** — `TestEnsureBoolTrue_ReplacesTheWholeOfAMultiLineValue`, scalar property test |
| C. drop the multi-line-inline-table refusal | **RED** — corpus row `multi-line_inline_table`, both entry points |
| D. drop the unbalanced-`]` refusal | **RED** — corpus row `stray_closing_bracket` |
| E. drop the array-never-closed refusal | **RED** — corpus row `array_never_closed` |
| F. report an unclosed array at EOF instead of its opening line | **RED** — corpus line assertion (`points at line 4, want 2`) |
| G. `topLevelKeyLine` returns the physical opening line, not the logical range | **RED** — `enable_experimental_hooks = true` left with two orphaned array lines below it |
| H. minimise the committed fixture (collapse all 12 arrays) | **RED** — `TestRealVibeConfigFixture_StillCarriesTheConstructThatBrokeIt` (`opens 0 multi-line arrays, want >= 12`) |
| I. the generator stops emitting arrays | **RED** — `assertArrayAxisWasExercised` (`only 0 of 2000 …`) |
| J. the refusal stops naming the file and the line | **RED** — `TestScannerRefusals_Corpus`, every refusing row |

Two guards go red under A and would have shipped without it, which is the whole reason the mutation is run rather than described.

Selected actual output:

```
=== MUTATION A (re-run): scanDocument classifies continuation lines ===
--- FAIL: TestEnsureBoolTrue_InsertsAfterAPreambleArrayNotInsideIt (0.00s)
    hooktoml_test.go:711: the flag was spliced INSIDE the user's preamble array:
        matrix = [
        enable_experimental_hooks = true
          [1, 2]
        ]

=== MUTATION G: topLevelKeyLine returns the physical opening line only ===
--- FAIL: TestEnsureBoolTrue_ReplacesTheWholeOfAMultiLineValue (0.00s)
    hooktoml_test.go:748: EnsureBoolTrue left orphaned array syntax behind:
        got:
        a = 1
        enable_experimental_hooks = true
          "nonsense",
        ]
        b = 2

=== MUTATION H: the committed fixture is minimised (arrays collapsed) ===
--- FAIL: TestRealVibeConfigFixture_StillCarriesTheConstructThatBrokeIt (0.00s)
    fixture opens 0 multi-line arrays, want >= 12 — it has been minimised, which is exactly what hid #1753

=== MUTATION I: the generator stops emitting multi-line arrays ===
--- FAIL: TestEnsureAndUninstall_PropertyRandomMutations (0.64s)
    multi-line-array axis: 0/2000 documents carried one, 0 of those in the preamble
    only 0 of 2000 generated documents carried a multi-line array — the #1753 axis is not being exercised
```

## A lock changed on purpose

`TestEnsureInstalled_RefusesOnMultiLineArray` pinned the OPPOSITE verdict on its seed. It is replaced by `TestEnsureInstalled_ModelsAMultiLineArray`, **keeping the seed byte-for-byte**, so the reversal reads as a reversal rather than as a test that quietly stopped existing.

## What is NOT covered

- **The recording.** PR #1752's scratch seed still collapses its arrays; this PR does not re-record. With the splicer widened that workaround is no longer needed, and removing it (plus the `agent-home.sh` note that documents it as a workaround) is a follow-up that needs a real recording run.
- **`run-cell.sh` checks `unapplied_grants` only on the attach path** — the separate gap #1752 noted. Untouched here.
- **No contract-family assertion grades "the install works on a config the agent itself wrote."** This PR proves it for vibe with a committed fixture, but a second TOML adapter would have to remember to do the same. A registry tripwire over "every hook adapter declares a real-world config fixture" is the shape that would make it assertable rather than remembered — deliberately not built here.
- **Multi-line inline tables are refused, not modelled.** No adapter needs them and TOML 1.0 forbids them; if a dialect ever emits one, this becomes the same ticket again.
- **The `[[hooks]]` operations were never the failing half** — `hooks.toml` is written only by us, so its documents were always ones the scanner modelled. The widening covers them too, but the evidence there is the property test, not a real-world file.

## Gates

`go test ./core/... -race -count=1` clean (one `TestFSWatcher_EmitsEventsForTranscriptCreateAndModify` flake on the first run, green on re-run ×3 and on a full re-run — the known fsnotify re-Add flake, untouched by this diff). `tools/preflight.sh --only go` all PASS. `tools/preflight.sh --only arch` PASS (composite 7.9175 → 7.9177, no category regression). Pre-push hook gates PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
