### PR TITLE
feat(pi): observe pi through an extension irrlicht installs, not a config entry (#1721)

### DIFF
--- a/core/adapters/inbound/agents/beaconroute_test.go
+++ b/core/adapters/inbound/agents/beaconroute_test.go
@@ -8,6 +8,8 @@ import (
 	"irrlicht/core/adapters/inbound/agents/copilot"
 	"irrlicht/core/adapters/inbound/agents/geminicli"
 	"irrlicht/core/adapters/inbound/agents/kirocli"
+	"irrlicht/core/adapters/inbound/agents/pi"
+	"irrlicht/core/adapters/inbound/agents/vibe"
 	"irrlicht/core/pkg/hookbeacon"
 )
 
@@ -26,8 +28,9 @@ import (
 // while its route segment is "claudecode". That is why the map keys below are
 // written out literally rather than derived from the adapter constants.
 //
-// Scope, stated honestly: this pins the receivers that exist (five as of
-// #1716's kiro-cli row). It cannot fail for a NEW receiver registered at a
+// Scope, stated honestly: this pins the receivers that exist (seven as of
+// #1721's pi row, which also added the mistral-vibe row #1718 never wrote —
+// exactly the omission the paragraph below predicts). It cannot fail for a NEW receiver registered at a
 // different prefix, because registerHookRoutes (core/cmd/irrlichd/startup.go)
 // is hand-wired with no registry to enumerate and this map is hand-written.
 // Whoever adds the next receiver adds its row here; until then the
@@ -39,6 +42,10 @@ func TestBeaconEndpointPathMatchesTheInstalledReceivers(t *testing.T) {
 		"copilot":    copilot.HookEndpointPath,
 		"gemini-cli": geminicli.HookEndpointPath,
 		"kiro-cli":   kirocli.HookEndpointPath,
+		// mistral-vibe was beacon-delivered from the day it shipped (#1718)
+		// but was never added here; found while adding pi's row (#1721).
+		"mistral-vibe": vibe.HookEndpointPath,
+		"pi":           pi.HookEndpointPath,
 	} {
 		if got := hookbeacon.EndpointPath(segment); got != want {
 			t.Errorf("hookbeacon.EndpointPath(%q) = %q, but the receiver is registered at %q — the beacon would post into a route nothing serves", segment, got, want)

--- a/core/adapters/inbound/agents/pi/adapter.go
+++ b/core/adapters/inbound/agents/pi/adapter.go
@@ -21,9 +21,32 @@ const defaultRootDir = ".pi/agent/sessions"
 // directory itself (not a parent).
 const sessionDirEnvVar = "PI_CODING_AGENT_SESSION_DIR"
 
-// sessionsDir returns the directory the Pi adapter should watch —
-// $PI_CODING_AGENT_SESSION_DIR itself when that override is set (it names the
-// session directory, not a root above it), else defaultRootDir.
+// sessionsDir returns the directory the Pi adapter should watch, resolving
+// the same two overrides pi itself does and in the same order.
+//
+// pi composes the sessions directory as getAgentDir() + "/sessions"
+// (dist/config.js's getSessionsDir), where getAgentDir honours
+// $PI_CODING_AGENT_DIR; $PI_CODING_AGENT_SESSION_DIR then overrides the
+// result outright (dist/main.js reads it directly, and pi's own --help
+// describes --session-dir as overriding it).
+//
+// The $PI_CODING_AGENT_DIR leg is issue #1721's: before it, setting only
+// that variable — the documented way to relocate a whole pi installation —
+// moved pi's sessions while irrlicht kept watching ~/.pi/agent/sessions and
+// saw nothing. It matters more now than it did: the hook receiver confines
+// caller-supplied transcript paths to THIS root (hooks.go's
+// transcriptConfiner), so a wrong root does not merely miss transcripts, it
+// rejects every hook the extension delivers.
 func sessionsDir() string {
-	return agentpaths.FromEnv("pi", sessionDirEnvVar, defaultRootDir)
+	// FromEnv with an empty default is how "was this override set to an
+	// absolute path?" is asked without restating the absolute-path check and
+	// its warn-once logging.
+	if dir := agentpaths.FromEnv("pi", sessionDirEnvVar, ""); dir != "" {
+		return dir
+	}
+	return agentpaths.FromEnv("pi", agentDirEnvVar, defaultRootDir, sessionsSubdir)
 }
+
+// sessionsSubdir is the agent-dir-relative directory pi writes transcripts
+// into — the "sessions" in getSessionsDir's join(getAgentDir(), "sessions").
+const sessionsSubdir = "sessions"

--- a/core/adapters/inbound/agents/pi/adapter_test.go
+++ b/core/adapters/inbound/agents/pi/adapter_test.go
@@ -16,10 +16,67 @@ func TestSessionsDir(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(agentDirEnvVar, "")
 			t.Setenv(sessionDirEnvVar, tc.env)
 			if got := sessionsDir(); got != tc.want {
 				t.Errorf("sessionsDir() = %q, want %q", got, tc.want)
 			}
 		})
+	}
+}
+
+// TestSessionsDirFollowsPiCodingAgentDir is issue #1721's defect test.
+//
+// pi composes its sessions directory as getAgentDir() + "/sessions"
+// (dist/config.js), and getAgentDir honours $PI_CODING_AGENT_DIR — the
+// documented way to relocate an entire pi installation, and the one this
+// issue's own live audit used. Before this, irrlicht read only
+// $PI_CODING_AGENT_SESSION_DIR, so a user who relocated pi that way had
+// their sessions moved out from under a watcher still pointed at
+// ~/.pi/agent/sessions, with nothing anywhere reporting it.
+//
+// It matters more now than it did as a pure observation gap: the hook
+// receiver confines caller-supplied transcript paths to THIS root
+// (hooks.go's transcriptConfiner), so a wrong root does not merely miss
+// transcripts — it refuses every hook the installed extension delivers,
+// which reads as "the channel is dead" rather than as a misconfiguration.
+func TestSessionsDirFollowsPiCodingAgentDir(t *testing.T) {
+	t.Setenv(sessionDirEnvVar, "")
+	t.Setenv(agentDirEnvVar, "/tmp/pi-relocated/agent")
+
+	want := "/tmp/pi-relocated/agent/sessions"
+	if got := sessionsDir(); got != want {
+		t.Errorf("sessionsDir() = %q, want %q", got, want)
+	}
+}
+
+// TestSessionDirOverrideBeatsAgentDirOverride pins the PRECEDENCE, which is
+// pi's own: dist/main.js reads $PI_CODING_AGENT_SESSION_DIR directly and
+// uses it in place of the composed path, so the narrower override wins.
+// Without this, "honour both" could mean either order and the wrong one
+// looks identical until someone sets both.
+func TestSessionDirOverrideBeatsAgentDirOverride(t *testing.T) {
+	t.Setenv(agentDirEnvVar, "/tmp/pi-relocated/agent")
+	t.Setenv(sessionDirEnvVar, "/tmp/pi-explicit-sessions")
+
+	want := "/tmp/pi-explicit-sessions"
+	if got := sessionsDir(); got != want {
+		t.Errorf("sessionsDir() = %q, want %q", got, want)
+	}
+}
+
+// TestSessionsDirRejectsARelativeAgentDir pins that the agent-dir leg
+// inherits the same absolute-path rule the session-dir leg has always had —
+// pi's own expandTildePath does no shell expansion either, so a relative or
+// tilde-prefixed value is a misconfiguration to fall back from, not a path
+// to join onto the current working directory.
+func TestSessionsDirRejectsARelativeAgentDir(t *testing.T) {
+	for _, v := range []string{"relative/agent", "~/pi/agent"} {
+		t.Setenv(sessionDirEnvVar, "")
+		t.Setenv(agentDirEnvVar, v)
+		if got := sessionsDir(); got != defaultRootDir {
+			t.Errorf("sessionsDir() with %s=%q = %q, want the default %q",
+				agentDirEnvVar, v, got, defaultRootDir)
+		}
 	}
 }

--- a/core/adapters/inbound/agents/pi/agent.go
+++ b/core/adapters/inbound/agents/pi/agent.go
@@ -1,6 +1,7 @@
 package pi
 
 import (
+	"irrlicht/core/adapters/inbound/agents/hookjson"
 	"irrlicht/core/domain/agent"
 	"irrlicht/core/domain/permission"
 )
@@ -24,6 +25,21 @@ const iconSVGDark = `<svg xmlns="http://www.w3.org/2000/svg" width="14" height="
   <line x1="60" y1="30" x2="64" y2="74" stroke="#E0E0E0" stroke-width="8" stroke-linecap="round"/>
 </svg>`
 
+// Source declares where Pi's transcripts live. A function, not a value, so
+// the hook receiver's confiner (hooks.go's transcriptConfiner) and the
+// daemon's fswatcher resolve the SAME root from the SAME declaration — a
+// second, constants-derived list is exactly the drift issue #1361 was about,
+// and sessionsDir() reads environment overrides that a package-level value
+// would freeze at init time.
+func Source() agent.Source {
+	return agent.FilesUnderRoot{
+		Dir: sessionsDir(),
+		Parser: agent.JSONLineParser{
+			NewParser: func() agent.LineParser { return &Parser{} },
+		},
+	}
+}
+
 // Agent returns the Pi adapter registration.
 func Agent() agent.Agent {
 	return agent.Agent{
@@ -37,12 +53,7 @@ func Agent() agent.Agent {
 			Match:         agent.ExactName{Name: ProcessName},
 			PIDForSession: DiscoverPID,
 		},
-		Source: agent.FilesUnderRoot{
-			Dir: sessionsDir(),
-			Parser: agent.JSONLineParser{
-				NewParser: func() agent.LineParser { return &Parser{} },
-			},
-		},
+		Source:  Source(),
 		Control: agent.Control{SupportsInput: true, Interrupt: agent.InterruptCtrlC},
 		Permissions: []agent.Permission{
 			agent.ControlPermission(),
@@ -56,6 +67,51 @@ func Agent() agent.Agent {
 					"derive session state, cost, and token metrics. Read-only — no " +
 					"file is ever modified. Toggling off stops all reading " +
 					"immediately.",
+			},
+			{
+				Key:             PermissionKeyHooks,
+				Kind:            permission.KindModify,
+				Title:           "Install status hooks",
+				FeatureUnlocked: "Authoritative turn-end detection",
+				// "1 hook entry" is what contracttesting's #1356 count arm
+				// reads, and it is the honest number: one subscription, to
+				// one event. What is unusual is the SHAPE that subscription
+				// takes, which is why Touches names it in the same breath
+				// rather than leaving it to Detail — the wizard row is what
+				// most users read.
+				Touches: "Writes 1 hook entry to " + displayExtensionPath +
+					" — a small JavaScript file that pi loads and runs",
+				Detail: "pi has no hooks section in its settings: the only way to observe " +
+					"its lifecycle is an extension, so this permission installs one. That " +
+					"is a single JavaScript file at " + displayExtensionPath + ", which pi " +
+					"auto-discovers and executes inside every pi session with your own " +
+					"permissions. It is code irrlicht ships in its own binary, not a " +
+					"package fetched from anywhere — no npm, no git, no `pi install` — and " +
+					"pi's own settings.json is not touched at all. The file imports only " +
+					"node:child_process, subscribes to exactly one pi event (agent_settled, " +
+					"which fires when pi will not continue running on its own) and does one " +
+					"thing with it: runs `irrlichd hook-post pi`, a tiny command irrlicht " +
+					"ships, handing it the session's transcript path. That command reads the " +
+					"daemon's own published address at the moment the hook fires, so nothing " +
+					"in the file names a host or a port and it cannot go stale; it also never " +
+					"blocks pi, even when the daemon is not running. The file deliberately " +
+					"does not subscribe to pi's blocking tool_call event, so it cannot " +
+					"interfere with a tool call. " +
+					hookjson.RequiresVersion("pi", minPiVersion) +
+					" Toggling off deletes the file (also available via " +
+					"`irrlichd --uninstall-hooks`); nothing else in your pi installation was " +
+					"changed, so there is nothing else to undo.",
+				Apply:  func() error { _, err := EnsureHooksInstalled(); return err },
+				Remove: func() error { _, err := UninstallHooks(); return err },
+				Writes: &agent.ManagedUserFile{
+					Path:      ExtensionPath,
+					Uninstall: UninstallHooks,
+					Verify:    VerifyHooksInstalled,
+					Version: &agent.VersionGate{
+						Min:   minPiVersion,
+						Probe: []string{"pi", "--version"},
+					},
+				},
 			},
 		},
 	}

--- a/core/adapters/inbound/agents/pi/extension.js
+++ b/core/adapters/inbound/agents/pi/extension.js
@@ -1,0 +1,94 @@
+// irrlicht session-status extension for pi — installed and owned by irrlichd.
+//
+// DO NOT EDIT. This file is rewritten whenever irrlicht's own binary path
+// changes and deleted when the "Install status hooks" permission is revoked
+// (also via `irrlichd --uninstall-hooks`).
+//
+// It exists because pi has no config-file hook mechanism at all: the ONLY
+// way to subscribe to pi's lifecycle is an extension module. See
+// hookinstaller.go's header for the audit that established that, and for why
+// this file is written directly into pi's auto-discovery directory rather
+// than installed with `pi install`.
+//
+// Everything in here is deliberate and narrow:
+//
+//   - It subscribes to exactly ONE event, agent_settled, and does exactly one
+//     thing with it: hand the session's transcript path to the beacon on
+//     stdin. It registers no tool, no command, no provider, no UI, and reads
+//     nothing.
+//
+//   - It never subscribes to `tool_call`. That is not a style preference:
+//     pi's own runner dispatches every OTHER event inside a try/catch and
+//     logs a throwing handler, but emitToolCall (dist/core/extensions/
+//     runner.js) has no catch, and a `tool_call` handler that returns
+//     `{block: true}` — or throws — BLOCKS the user's tool call. A monitoring
+//     extension must not be able to do that. extension_test.go's
+//     TestShippedExtensionSubscribesToNoBlockingEvent is the guard.
+//
+//   - Nothing in here is awaited on I/O. pi awaits each handler, so a
+//     handler that waited for the daemon to answer would stall the agent
+//     whenever irrlicht is slow or down. spawn() returns immediately and
+//     every failure path is swallowed.
+//
+// Plain JavaScript, not TypeScript, and no imports beyond node:child_process.
+// pi's loader accepts both (`isExtensionFile` matches .ts OR .js) and loads
+// through jiti, so no compile step and no toolchain is involved either way —
+// but a file with no types and no third-party import is a file whose whole
+// behaviour is readable in one screen, which is the point when the artifact
+// being installed is code.
+import { spawn } from "node:child_process";
+
+// The command irrlichd renders at install time: `<abs irrlichd> --version
+// >/dev/null && <abs irrlichd> hook-post pi >/dev/null || true`. It carries
+// NO host and NO port — the beacon reads the daemon's published address at
+// the moment the hook fires, so this file never goes stale when the daemon
+// moves. hookinstaller.go substitutes the literal below and reads it back
+// out again to decide whether an installed copy is current.
+const IRRLICHT_BEACON = "__IRRLICHT_BEACON_COMMAND__";
+
+// The single pi lifecycle event this extension subscribes to. agent_settled
+// means "pi will not continue running automatically" — no retry, no
+// auto-compaction, no queued follow-up left — which is the authoritative
+// turn-end signal irrlicht's three-state model wants, and which pi's
+// transcript alone only implies.
+const IRRLICHT_EVENT = "agent_settled";
+
+export default function (pi) {
+	pi.on(IRRLICHT_EVENT, (_event, ctx) => {
+		// getSessionFile() is undefined for an ephemeral session (pi run with
+		// no session file). There is no transcript for irrlicht to correlate
+		// to in that case, so there is nothing to report.
+		let transcriptPath;
+		try {
+			transcriptPath = ctx && ctx.sessionManager && ctx.sessionManager.getSessionFile();
+		} catch {
+			return;
+		}
+		if (!transcriptPath) return;
+		post({ hook_event_name: IRRLICHT_EVENT, transcript_path: transcriptPath });
+	});
+}
+
+// post hands one payload to the beacon on stdin and forgets about it. Every
+// failure is swallowed: this extension runs inside the user's agent, and a
+// monitoring tool that can break a coding session is worse than no
+// monitoring at all.
+//
+// The child is deliberately NOT unref()'d. An unref'd child stops holding
+// the event loop open, and in pi's print mode (`pi -p`) agent_settled is
+// followed almost immediately by process exit — which can tear the pipe down
+// before the payload is flushed. The beacon bounds its own wait and always
+// exits 0, so holding the loop open costs a bounded moment at exit rather
+// than a hang.
+function post(payload) {
+	try {
+		const child = spawn("/bin/sh", ["-c", IRRLICHT_BEACON], {
+			stdio: ["pipe", "ignore", "ignore"],
+		});
+		child.on("error", () => {});
+		child.stdin.on("error", () => {});
+		child.stdin.end(JSON.stringify(payload));
+	} catch {
+		// spawn itself threw (no /bin/sh, resource limits). Nothing to do.
+	}
+}

--- a/core/adapters/inbound/agents/pi/extension_test.go
+++ b/core/adapters/inbound/agents/pi/extension_test.go
@@ -1,0 +1,331 @@
+// extension_test.go grades the ARTIFACT this adapter ships — the JavaScript
+// irrlicht writes into a user's pi installation — rather than the Go code
+// that writes it.
+//
+// It exists because that artifact is the one thing in this repository that
+// no other mechanism can see. `go vet`, `go test`, the architecture tests
+// and every contract family reason about Go; extension.js is an embedded
+// string that compiles no matter what it says. The guards below are what
+// stands between "the Go side is correct" and "the thing that actually runs
+// inside the user's agent is correct", and each one names the specific
+// failure it would catch.
+//
+// What is NOT covered here, stated rather than implied: nothing in this file
+// executes the JavaScript. Running it needs either node (which `go test
+// ./core/...` does not otherwise require, and a gate that could be absent is
+// the failure mode docs/testing-philosophy.md is about) or pi itself (which
+// needs a model call). The end-to-end proof was therefore run by hand during
+// #1721 and reported in the PR: the rendered extension, loaded by pi 0.83.0
+// from an isolated PI_CODING_AGENT_DIR, delivered exactly one payload to a
+// stub beacon at agent_settled. These guards pin the properties that
+// live run confirmed, so a later edit that breaks one of them is caught
+// without re-running it.
+package pi
+
+import (
+	"encoding/json"
+	"reflect"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+
+	"irrlicht/core/pkg/hookbeacon"
+)
+
+// piOnCallRE finds every event subscription in the shipped extension.
+var piOnCallRE = regexp.MustCompile(`pi\.on\(\s*([A-Za-z_][A-Za-z0-9_]*|"[^"]*")`)
+
+// jsPayloadKeyRE finds the keys of the object literal extension.js hands to
+// JSON.stringify — the wire contract between the shipped JavaScript and
+// piHookPayload's json tags.
+var jsPayloadKeyRE = regexp.MustCompile(`(?m)^\s*post\(\{ (.*) \}\);$`)
+
+// importRE finds every module specifier the extension imports.
+var importRE = regexp.MustCompile(`from "([^"]+)"`)
+
+// TestShippedExtensionSubscribesToNoBlockingEvent is the guard with the
+// largest blast radius, and it is not a style rule.
+//
+// pi's runner dispatches every extension event inside a try/catch and logs a
+// throwing handler — every event EXCEPT tool_call. Read
+// dist/core/extensions/runner.js: emitToolCall's loop has no catch, and a
+// handler that returns {block: true} blocks the user's tool call outright.
+// A monitoring extension that could throw there, or that returned the wrong
+// shape, would break coding sessions rather than merely fail to report
+// them. So the shipped file must not mention that event at all.
+func TestShippedExtensionSubscribesToNoBlockingEvent(t *testing.T) {
+	for _, blocking := range []string{"tool_call", "project_trust", "session_before_switch",
+		"session_before_fork", "session_before_compact", "session_before_tree",
+		"user_bash", "input", "before_agent_start", "message_end", "tool_result", "context"} {
+		if strings.Contains(shippedExtensionCode(t), blocking) {
+			t.Errorf("extension.js references pi's %q event, which can block, cancel, "+
+				"replace or rewrite what the agent is doing. A monitoring extension must "+
+				"only observe.", blocking)
+		}
+	}
+}
+
+// TestShippedExtensionSubscribesExactlyToInstalledHookEvents binds the
+// JavaScript to the Go declaration. Without it the two are independent
+// lists: installedHookEvents drives the consent copy, the version floor and
+// every contract family, while the file that actually runs could subscribe
+// to something else entirely and nothing would notice — the disclosure would
+// be a promise about an event nobody subscribed to.
+func TestShippedExtensionSubscribesExactlyToInstalledHookEvents(t *testing.T) {
+	src := shippedExtensionCode(t)
+
+	consts := jsStringConsts(src)
+	var subscribed []string
+	for _, m := range piOnCallRE.FindAllStringSubmatch(src, -1) {
+		arg := m[1]
+		if strings.HasPrefix(arg, `"`) {
+			subscribed = append(subscribed, strings.Trim(arg, `"`))
+			continue
+		}
+		v, ok := consts[arg]
+		if !ok {
+			t.Fatalf("extension.js subscribes via identifier %q, which is not a "+
+				"top-level string constant this test can resolve — the binding to "+
+				"installedHookEvents cannot be checked, which is worse than it failing", arg)
+		}
+		subscribed = append(subscribed, v)
+	}
+	if len(subscribed) == 0 {
+		t.Fatal("found no pi.on(...) call in extension.js; the guard read nothing rather " +
+			"than finding nothing wrong")
+	}
+
+	want := append([]string(nil), installedHookEvents...)
+	sort.Strings(want)
+	sort.Strings(subscribed)
+	if !reflect.DeepEqual(subscribed, want) {
+		t.Errorf("extension.js subscribes to %v, installedHookEvents declares %v — the "+
+			"consent copy, the version floor and every contract family are written "+
+			"against the second list", subscribed, want)
+	}
+}
+
+// TestShippedExtensionPayloadMatchesTheReceiversFields pins the wire
+// contract across the language boundary: every key the JavaScript sends is a
+// field piHookPayload decodes, and every field piHookPayload decodes is a
+// key the JavaScript sends.
+//
+// This is the defect class no Go test can otherwise see. A renamed json tag
+// on the Go side compiles, passes every contract family (they all build
+// their bodies by marshaling piHookPayload itself, so they rename in
+// lockstep), and silently stops decoding the only body that exists in
+// production.
+func TestShippedExtensionPayloadMatchesTheReceiversFields(t *testing.T) {
+	src := shippedExtensionCode(t)
+	m := jsPayloadKeyRE.FindStringSubmatch(src)
+	if m == nil {
+		t.Fatal("could not find extension.js's post({...}) call; the guard read nothing " +
+			"rather than finding nothing wrong")
+	}
+	var sent []string
+	for _, pair := range strings.Split(m[1], ",") {
+		key := strings.TrimSpace(strings.SplitN(pair, ":", 2)[0])
+		if key != "" {
+			sent = append(sent, key)
+		}
+	}
+
+	var decoded []string
+	rt := reflect.TypeOf(piHookPayload{})
+	for i := 0; i < rt.NumField(); i++ {
+		tag := rt.Field(i).Tag.Get("json")
+		name := strings.SplitN(tag, ",", 2)[0]
+		if name == "" || name == "-" {
+			continue
+		}
+		decoded = append(decoded, name)
+	}
+
+	sort.Strings(sent)
+	sort.Strings(decoded)
+	if !reflect.DeepEqual(sent, decoded) {
+		t.Errorf("extension.js sends %v, piHookPayload decodes %v — a field on either "+
+			"side that the other does not have is a silently dropped hook", sent, decoded)
+	}
+}
+
+// TestShippedExtensionImportsOnlyNodeBuiltins is the supply-chain guard.
+// The whole argument for shipping code into a user's agent (hookinstaller.go's
+// header) rests on the artifact having no dependencies: an import of anything
+// resolvable from node_modules would make this an install with a dependency
+// graph, which is the shape epic #1355 cut opencode over.
+func TestShippedExtensionImportsOnlyNodeBuiltins(t *testing.T) {
+	found := importRE.FindAllStringSubmatch(shippedExtensionCode(t), -1)
+	if len(found) == 0 {
+		t.Fatal("found no import in extension.js; the guard read nothing rather than " +
+			"finding nothing wrong (it imports node:child_process)")
+	}
+	for _, m := range found {
+		if !strings.HasPrefix(m[1], "node:") {
+			t.Errorf("extension.js imports %q — only node: builtins may be imported, or "+
+				"this install acquires a dependency graph", m[1])
+		}
+	}
+}
+
+// TestRenderedExtensionCarriesTheCommandAndNothingAddressShaped is the
+// address-free property applied to the artifact itself rather than to a
+// config entry: the whole rendered file must contain nothing that looks like
+// a host or a port, which is a strictly stronger claim than the #1178
+// contract's per-entry one.
+func TestRenderedExtensionCarriesTheCommandAndNothingAddressShaped(t *testing.T) {
+	command, err := hookbeacon.Command("/opt/irrlicht/bin/irrlichd", AdapterName)
+	if err != nil {
+		t.Fatalf("rendering the beacon command: %v", err)
+	}
+	rendered, err := renderExtension(command)
+	if err != nil {
+		t.Fatalf("renderExtension: %v", err)
+	}
+
+	got, ok := beaconCommandOf(rendered)
+	if !ok {
+		t.Fatal("the rendered extension does not carry a readable beacon command")
+	}
+	if got != command {
+		t.Errorf("round-trip: rendered %q, read back %q", command, got)
+	}
+	if !strings.Contains(string(rendered), hookbeacon.Sentinel(AdapterName)) {
+		t.Error("the rendered extension does not carry the beacon sentinel, so uninstall " +
+			"would not recognize it as ours")
+	}
+	if m := regexp.MustCompile(`\d+\.\d+\.\d+\.\d+|:\d{4,5}\b`).FindString(string(rendered)); m != "" {
+		t.Errorf("the rendered extension carries %q, which is address-shaped; beacon "+
+			"delivery exists so nothing address-shaped is ever written into a user's agent", m)
+	}
+}
+
+// TestRenderedExtensionSurvivesAHostilePath is the property the substitution
+// exists for. The beacon command embeds an absolute filesystem path the user
+// chose, and it lands inside a JavaScript string literal — a path containing
+// a quote, a backslash or a newline must not be able to terminate that
+// literal and turn the rest of the file into code.
+func TestRenderedExtensionSurvivesAHostilePath(t *testing.T) {
+	for _, name := range []string{
+		`/tmp/irr"licht/irrlichd`,
+		`/tmp/irr\licht/irrlichd`,
+		"/tmp/irr\nlicht/irrlichd",
+		"/tmp/irr'licht/irrlichd",
+		"/tmp/irr`licht/irrlichd",
+		"/tmp/irrlicht${x}/irrlichd",
+	} {
+		command, err := hookbeacon.Command(name, AdapterName)
+		if err != nil {
+			t.Fatalf("hookbeacon.Command(%q): %v", name, err)
+		}
+		rendered, err := renderExtension(command)
+		if err != nil {
+			t.Fatalf("renderExtension for %q: %v", name, err)
+		}
+		got, ok := beaconCommandOf(rendered)
+		if !ok || got != command {
+			t.Errorf("path %q: round-trip failed (ok=%v, got %q, want %q)", name, ok, got, command)
+		}
+		// The assignment line must still be exactly one line: a raw newline
+		// escaping the literal is the failure this case exists for.
+		if n := strings.Count(beaconLineOf(t, rendered), "\n"); n != 0 {
+			t.Errorf("path %q: the assignment line spans %d newlines", name, n)
+		}
+		// And the literal must be valid JSON-ish, i.e. decodable as a JSON
+		// string — the same grammar a JavaScript string literal follows for
+		// every byte strconv.Quote can emit.
+		var decoded string
+		if err := json.Unmarshal([]byte(beaconLiteralOf(t, rendered)), &decoded); err != nil {
+			t.Errorf("path %q: the rendered literal is not a valid string literal: %v", name, err)
+		}
+	}
+}
+
+// TestRenderExtensionRefusesWhenTheTemplateLostItsPlaceholder is the
+// "fail loudly when it cannot run" guard for the substitution itself. If the
+// embedded template stopped carrying the placeholder, a Replace that silently
+// did nothing would install a file whose beacon command IS the literal
+// placeholder — pi would then run `__IRRLICHT_BEACON_COMMAND__` as a shell
+// command on every settled turn, forever, with the permission reading
+// granted.
+//
+// The mutation is committed rather than described: the template is swapped
+// for one that lost the token, and restored.
+func TestRenderExtensionRefusesWhenTheTemplateLostItsPlaceholder(t *testing.T) {
+	original := extensionTemplate
+	t.Cleanup(func() { extensionTemplate = original })
+
+	extensionTemplate = strings.Replace(original, beaconCommandPlaceholder, `"already-substituted"`, 1)
+	if extensionTemplate == original {
+		t.Fatal("the mutation changed nothing — the template no longer contains the " +
+			"placeholder this test mutates, so it proves nothing")
+	}
+	if _, err := renderExtension("cmd"); err == nil {
+		t.Error("renderExtension accepted a template with no placeholder; it would have " +
+			"installed a file that shells out to the placeholder text")
+	}
+}
+
+// TestRenderExtensionRefusesAnEmptyCommand is the second half of the same
+// rule: an empty command would render a file that runs `sh -c ""` on every
+// turn — silent, harmless-looking, and never reporting anything.
+func TestRenderExtensionRefusesAnEmptyCommand(t *testing.T) {
+	if _, err := renderExtension(""); err == nil {
+		t.Error("renderExtension accepted an empty beacon command")
+	}
+}
+
+// --- helpers ---
+
+// shippedExtensionCode returns the embedded template with its comments
+// stripped, so a guard cannot be satisfied — or defeated — by prose. The
+// comments in extension.js legitimately DISCUSS tool_call; the code must not
+// mention it.
+func shippedExtensionCode(t *testing.T) string {
+	t.Helper()
+	var b strings.Builder
+	for _, line := range strings.Split(extensionTemplate, "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "//") {
+			continue
+		}
+		b.WriteString(line)
+		b.WriteString("\n")
+	}
+	out := b.String()
+	if strings.TrimSpace(out) == "" {
+		t.Fatal("stripping comments left no code; the guards below would read nothing")
+	}
+	return out
+}
+
+// jsStringConsts collects top-level `const NAME = "value";` bindings.
+func jsStringConsts(src string) map[string]string {
+	out := map[string]string{}
+	re := regexp.MustCompile(`(?m)^const ([A-Za-z_][A-Za-z0-9_]*) = "((?:[^"\\]|\\.)*)";$`)
+	for _, m := range re.FindAllStringSubmatch(src, -1) {
+		var v string
+		if err := json.Unmarshal([]byte(`"`+m[2]+`"`), &v); err == nil {
+			out[m[1]] = v
+		}
+	}
+	return out
+}
+
+func beaconLineOf(t *testing.T, rendered []byte) string {
+	t.Helper()
+	m := beaconLineRE.FindString(string(rendered))
+	if m == "" {
+		t.Fatal("no beacon assignment line in the rendered extension")
+	}
+	return m
+}
+
+func beaconLiteralOf(t *testing.T, rendered []byte) string {
+	t.Helper()
+	m := beaconLineRE.FindSubmatch(rendered)
+	if m == nil {
+		t.Fatal("no beacon assignment line in the rendered extension")
+	}
+	return string(m[1])
+}

--- a/core/adapters/inbound/agents/pi/hookdisclosure_test.go
+++ b/core/adapters/inbound/agents/pi/hookdisclosure_test.go
@@ -1,0 +1,27 @@
+// hookdisclosure_test.go wires the pi hooks permission into the shared issue
+// #1356 contract: the consent copy names every event the installer
+// subscribes to, states the right entry count, and names no event it does
+// not install.
+package pi
+
+import (
+	"testing"
+
+	"irrlicht/core/internal/contracttesting"
+)
+
+func TestHooksPermission_DisclosureMatchesInstalled(t *testing.T) {
+	contracttesting.AssertHookDisclosureMatchesInstalled(t, contracttesting.HookDisclosure{
+		Agent:         Agent(),
+		PermissionKey: PermissionKeyHooks,
+		Installed:     installedHookEvents,
+		// "JavaScript" is a two-hump CamelCase word, so the over-promise arm
+		// reads it as an event-shaped token. It is exempted rather than
+		// avoided because naming the artifact's LANGUAGE is the single most
+		// load-bearing sentence in this permission's copy: this is the one
+		// adapter whose install is executable code rather than a config
+		// entry, and the #570 contract is that the user reads what is
+		// actually done.
+		NonEventTerms: []string{"JavaScript"},
+	})
+}

--- a/core/adapters/inbound/agents/pi/hookinstaller.go
+++ b/core/adapters/inbound/agents/pi/hookinstaller.go
@@ -1,0 +1,416 @@
+// hookinstaller.go installs irrlicht's pi extension — the ONE file this
+// adapter writes into a user's pi installation (issue #1721, epic #1355).
+//
+// # Why this adapter ships code where every other one ships a config entry
+//
+// pi has no config-file hook mechanism. Measured against the installed
+// package (@earendil-works/pi-coding-agent 0.83.0), not against rendered
+// docs: `hook` does not appear anywhere in docs/settings.md, settings.json
+// has no hooks key, and the only lifecycle subscription surface pi exposes
+// is `pi.on(...)` inside an extension module. So the choice for pi is not
+// "config entry vs. code" — it is "code, or leave pi at epic #1355's tier
+// 5 with no authoritative turn-end signal at all".
+//
+// That makes this the first adapter where irrlicht installs executable code
+// into a user's agent, which epic #1355 cut opencode (#1719) over. The
+// distinguishing facts, all read out of the installed package's own source
+// rather than its documentation:
+//
+//   - **No package manager is involved.** pi auto-discovers every *.ts and
+//     *.js file directly under `<agent dir>/extensions/`
+//     (dist/core/extensions/loader.js: `discoverExtensionsInDir(path.join(
+//     resolvedAgentDir, "extensions"))`, gated by `isExtensionFile`, which
+//     matches BOTH extensions). `pi install` — the npm:/git:/https:/./local
+//     route the issue was filed around — writes a `packages` or `extensions`
+//     entry to settings.json and is a SECOND, separate mechanism. This
+//     installer does not use it, does not touch settings.json, and does not
+//     resolve, fetch, build or version any package. It writes one file.
+//
+//   - **No toolchain.** The artifact is plain JavaScript with one import of
+//     `node:child_process`. pi loads extensions through jiti, so TypeScript
+//     would need no compile step either — but shipping .js means there is no
+//     transform between the bytes irrlicht writes and the code that runs.
+//
+//   - **Uninstall is `os.Remove`.** Nothing else was touched, so there is
+//     nothing else to undo, and no `pi remove` to be idempotent about.
+//
+//   - **Blast radius is bounded by pi itself.** loader.js wraps the whole
+//     load in try/catch and reports a failing extension as a load error
+//     while the agent continues; runner.js wraps every handler dispatch the
+//     same way — for every event EXCEPT tool_call, which is why extension.js
+//     never subscribes to that one and extension_test.go pins it.
+//
+// The honest residue, stated in the consent copy rather than only here: it
+// is still code, running in-process in the user's agent with the user's own
+// permissions, and #570's contract is what makes that the user's decision.
+//
+// # Delivery
+//
+// Address-free (contracttesting.DeliveryAddressFree): the file names the
+// `irrlichd hook-post pi` beacon (core/pkg/hookbeacon), which reads the
+// daemon's published address at fire time. Nothing address-shaped is written
+// into the user's pi installation, so the #1178 stale-port class is
+// inexpressible here rather than fixed once more. It also makes the shipped
+// artifact smaller, which is the whole argument above: the JavaScript does
+// not speak HTTP, does not parse an addr file, and does not know what a port
+// is — it spawns one command and writes JSON to its stdin.
+//
+// pi is the first adopter of the beacon route outside its own reference
+// wiring (core/internal/contracttesting/hook_endpoint_addressfree_test.go),
+// which #1721 named as the intended outcome.
+package pi
+
+import (
+	_ "embed"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"irrlicht/core/adapters/inbound/agents/agentpaths"
+	"irrlicht/core/domain/agent"
+	"irrlicht/core/pkg/hookbeacon"
+)
+
+// HookEventAgentSettled is pi's own wire name for the one event this adapter
+// subscribes to. pi emits it when the agent will not continue running on its
+// own — no retry, no auto-compaction, no queued follow-up left
+// (docs/extensions.md: "Use agent_settled for status integrations that need
+// to know Pi will not continue running automatically"), which is the same
+// authoritative turn-end claim Claude Code's Stop makes.
+//
+// It is NOT mapped onto session.HookStop or any other existing row in
+// session.hookSignalEffects, and does not need to be: the receiver calls
+// SessionDetector.HandleStopHook directly, exactly as vibe's single event
+// does, so no name-keyed lookup is involved on this path.
+const HookEventAgentSettled = "agent_settled"
+
+// installedHookEvents is every pi lifecycle event this adapter subscribes
+// to. Exactly one, and the exclusions are the finding rather than an
+// omission:
+//
+//   - tool_call is excluded on a source fact, not a preference: pi's
+//     runner dispatches it WITHOUT the try/catch every other event gets, and
+//     a handler returning {block: true} blocks the user's tool call. A
+//     monitoring extension must not be able to break a coding session.
+//
+//   - tool_execution_start / tool_execution_end were considered as the
+//     assert/release pair gemini-cli's BeforeTool/AfterTool and kiro-cli's
+//     preToolUse/postToolUse form, and rejected for the reason vibe's
+//     hooks.go already records for its own after_tool: a broad RELEASE is
+//     only useful paired with a narrow ASSERT on the same signal from the
+//     same adapter. pi has no approval prompt to assert on — it has no
+//     sandbox at all (pi's docs/security.md: tools run with the process's
+//     permissions), and repo-wide session.SignalPermissionPrompt is held
+//     only by hook-derived calls. Installing them would spawn a beacon per
+//     tool call to release a signal nothing ever holds.
+//
+//   - session_start / session_shutdown / turn_start / turn_end / input are
+//     excluded on the same evidence copilot's, gemini-cli's and kiro-cli's
+//     analogous exclusions cite: the transcript's own lines already open the
+//     turn and already record the session, so a hook duplicating them buys
+//     nothing irrlicht's three-state model needs, at the cost of a process
+//     spawn each.
+//
+//   - project_trust is pi's ONE genuine blocked-on-user prompt and is
+//     excluded because it CANNOT be correlated to a session — see
+//     hooks.go's header for the measurement.
+var installedHookEvents = []string{HookEventAgentSettled}
+
+// hookEventSince records the pi version each installed event first shipped
+// in, read from the package's own CHANGELOG.md: agent_settled landed in
+// 0.80.4 (2026-07-09, "Added extension and RPC `agent_settled` events plus
+// session-level idle waiting for fully settled agent runs"). minPiVersion
+// must be >= every value here, which AssertHookVersionGate enforces.
+var hookEventSince = map[string]string{
+	HookEventAgentSettled: "0.80.4",
+}
+
+// minPiVersion is the lowest pi version this adapter's install requires.
+//
+// Pinned to the version everything here was measured against — 0.83.0, live,
+// in an isolated PI_CODING_AGENT_DIR — rather than to the 0.80.4 the
+// CHANGELOG dates agent_settled to. The floor is not a claim about one
+// event: it covers `.js` auto-discovery (`isExtensionFile`), the extensions
+// directory layout, the per-handler try/catch, and the shape of
+// ctx.sessionManager.getSessionFile() on agent_settled — none of which was
+// bisected backward. core/pkg/cliversion fails OPEN on an unknown or
+// unparseable version, so overshooting costs a missing install on an old CLI
+// rather than a wrong one on a new CLI, which is the safe direction (the
+// same reasoning kiro-cli's and gemini-cli's floors document).
+const minPiVersion = "0.83.0"
+
+// HookEndpointPath is the daemon's pi hook route. Exported so
+// registerHookRoutes (core/cmd/irrlichd/startup.go) and beaconroute_test.go's
+// pinned map both derive from the same segment this installer renders into
+// the beacon command it writes.
+//
+// A var, not a const, because hookbeacon.EndpointPath composes the route from
+// its own unexported prefix — deriving it here keeps this constant from
+// drifting away from the beacon's own routing convention. A mismatch is a
+// permanent silent 404: the beacon exits 0 by design, so nothing anywhere
+// reports it.
+var HookEndpointPath = hookbeacon.EndpointPath(AdapterName)
+
+// extensionsDirName is the pi-agent-dir-relative directory pi auto-discovers
+// extensions from (loader.js's discoverAndLoadExtensions).
+const extensionsDirName = "extensions"
+
+// extensionFilename is the file this adapter owns inside that directory. The
+// .js suffix is load-bearing twice over: pi's isExtensionFile accepts only
+// .ts and .js, and .js is the spelling that involves no transform between
+// the bytes written here and the code pi runs.
+const extensionFilename = "irrlicht.js"
+
+// displayExtensionPath is the consent copy's home-relative spelling of the
+// file ExtensionPath resolves absolutely.
+const displayExtensionPath = "~/.pi/agent/extensions/irrlicht.js"
+
+//go:embed extension.js
+var extensionTemplate string
+
+// beaconCommandPlaceholder is the token renderExtension substitutes. It
+// appears exactly once in extension.js, inside a JavaScript string literal,
+// and extension_test.go fails if that stops being true — a template whose
+// placeholder silently stopped matching would render a file that runs the
+// literal placeholder as a shell command.
+const beaconCommandPlaceholder = `"__IRRLICHT_BEACON_COMMAND__"`
+
+// beaconLineRE reads the rendered command back out of an installed file. It
+// anchors on the whole assignment line rather than searching for the command
+// text, so a command that happens to appear in a comment cannot be mistaken
+// for the live one.
+var beaconLineRE = regexp.MustCompile(`(?m)^const IRRLICHT_BEACON = (".*");$`)
+
+// renderExtension produces the exact bytes to install for a given,
+// already-resolved beacon command.
+//
+// strconv.Quote, not fmt.Sprintf("%q") by habit and not string concatenation:
+// the command embeds an absolute filesystem path the user chose, and a path
+// containing a quote or a backslash must not be able to terminate the
+// JavaScript string literal it lands in. Go's quoted-string escapes are a
+// subset of JavaScript's for every byte Quote can emit.
+func renderExtension(command string) ([]byte, error) {
+	if command == "" {
+		return nil, errors.New("pi: refusing to render an extension with an empty beacon command")
+	}
+	if !strings.Contains(extensionTemplate, beaconCommandPlaceholder) {
+		// The embedded template stopped carrying the token this function
+		// substitutes. Failing loudly here is the difference between "no
+		// install" and "an install that shells out to the placeholder".
+		return nil, fmt.Errorf("pi: embedded extension template no longer contains %s", beaconCommandPlaceholder)
+	}
+	return []byte(strings.Replace(extensionTemplate, beaconCommandPlaceholder, strconv.Quote(command), 1)), nil
+}
+
+// beaconCommandOf extracts the beacon command an installed file carries.
+// Reports false for a file that is not ours, or whose assignment line has
+// been edited into something that is not a quoted string.
+func beaconCommandOf(src []byte) (string, bool) {
+	m := beaconLineRE.FindSubmatch(src)
+	if m == nil {
+		return "", false
+	}
+	command, err := strconv.Unquote(string(m[1]))
+	if err != nil {
+		return "", false
+	}
+	return command, true
+}
+
+// isOurs reports whether a file on disk is an irrlicht-installed extension —
+// by the beacon sentinel, which deliberately excludes the binary path, so a
+// copy naming an irrlichd that has since moved is still recognized as ours.
+// Recognizing it is the precondition for rewriting it in place instead of
+// appending a second one beside it.
+func isOurs(src []byte) bool {
+	return strings.Contains(string(src), hookbeacon.Sentinel(AdapterName))
+}
+
+// --- path resolution ---
+
+// agentDirEnvVar is pi's own override for its agent config directory. pi
+// resolves it in dist/config.js's getAgentDir(), which every other agent-dir
+// path — sessions/, settings.json, extensions/ — is composed from.
+const agentDirEnvVar = "PI_CODING_AGENT_DIR"
+
+// defaultAgentDirName is the $HOME-relative pi agent directory.
+const defaultAgentDirName = ".pi/agent"
+
+// piAgentDir resolves the absolute pi agent directory the way pi's own
+// getAgentDir does: $PI_CODING_AGENT_DIR when set and absolute, else
+// $HOME/.pi/agent.
+func piAgentDir() (string, error) {
+	return agentpaths.AbsRoot(agentpaths.FromEnv("pi", agentDirEnvVar, defaultAgentDirName))
+}
+
+// ExtensionPath is the single file this permission's Writes.Path resolves —
+// the extension pi auto-discovers and runs.
+func ExtensionPath() (string, error) {
+	dir, err := piAgentDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, extensionsDirName, extensionFilename), nil
+}
+
+// --- install / verify / uninstall ---
+
+// EnsureHooksInstalled writes irrlicht's pi extension for the irrlichd that
+// is running now, creating pi's extensions directory if it does not exist.
+// Returns true if anything changed.
+//
+// Idempotent, and self-healing across a moved binary: an already-installed
+// copy whose beacon command names a different irrlichd is rewritten IN PLACE
+// (same path, one file), never duplicated.
+func EnsureHooksInstalled() (bool, error) {
+	command, err := hookbeacon.InstalledCommand(AdapterName)
+	if err != nil {
+		return false, err
+	}
+	return ensureInstalledWithCommand(command)
+}
+
+// ensureInstalledWithCommand is EnsureHooksInstalled with the beacon command
+// resolved by the caller — the seam the #1178 contract's ForeignInstall uses
+// to seed the install a DIFFERENTLY-situated daemon would have written.
+// hookbeacon.InstalledCommand is called exactly once per entry point, which
+// is the shape hookbeacon's own doc comment asks adopters for.
+func ensureInstalledWithCommand(command string) (bool, error) {
+	path, err := ExtensionPath()
+	if err != nil {
+		return false, err
+	}
+	want, err := renderExtension(command)
+	if err != nil {
+		return false, err
+	}
+
+	existing, readErr := os.ReadFile(path)
+	switch {
+	case readErr == nil && isOurs(existing):
+		if string(existing) == string(want) {
+			return false, nil
+		}
+		// Ours, but stale — a moved irrlichd, or a template change.
+	case readErr == nil:
+		// A file we did not write occupies the path we install to.
+		// Overwriting it would destroy a user's own extension for the sake
+		// of monitoring, which is never the right trade; refusing surfaces
+		// as "granted but NOT applied" in the wizard (issue #1362) with this
+		// message, which is the honest outcome.
+		return false, fmt.Errorf("pi: %s exists and was not written by irrlicht; refusing to overwrite it", path)
+	case !errors.Is(readErr, os.ErrNotExist):
+		return false, readErr
+	}
+
+	if err := atomicWriteFile(path, want); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// VerifyHooksInstalled reports whether the installed extension is still
+// present and current, without writing anything (issue #1372). This is what
+// services.HookEntryVerifier re-checks a granted install with on a timer —
+// which matters more here than for a config-entry adapter, because pi's own
+// `pi install` / `pi remove` and any manual tidy of the extensions directory
+// can remove this file with the permission still reading granted.
+func VerifyHooksInstalled() (agent.HookEntryStatus, error) {
+	path, err := ExtensionPath()
+	if err != nil {
+		return agent.HookEntryStatus{}, err
+	}
+	command, err := hookbeacon.InstalledCommand(AdapterName)
+	if err != nil {
+		return agent.HookEntryStatus{}, err
+	}
+	want, err := renderExtension(command)
+	if err != nil {
+		return agent.HookEntryStatus{}, err
+	}
+
+	existing, readErr := os.ReadFile(path)
+	if errors.Is(readErr, os.ErrNotExist) {
+		return agent.HookEntryStatus{Missing: append([]string(nil), installedHookEvents...)}, nil
+	}
+	if readErr != nil {
+		return agent.HookEntryStatus{}, readErr
+	}
+	if !isOurs(existing) {
+		// Something else owns the path now. Reported as Missing rather than
+		// Stale: "stale" means EnsureHooksInstalled would rewrite it, and it
+		// deliberately will not.
+		return agent.HookEntryStatus{Missing: append([]string(nil), installedHookEvents...)}, nil
+	}
+	if string(existing) != string(want) {
+		return agent.HookEntryStatus{Stale: append([]string(nil), installedHookEvents...)}, nil
+	}
+	return agent.HookEntryStatus{}, nil
+}
+
+// UninstallHooks removes irrlicht's pi extension. Returns true if anything
+// changed.
+//
+// Removes the FILE, because the file is the entire install — nothing was
+// added to settings.json, no package was installed, and pi's own
+// auto-discovery is what loaded it. A file at our path that is not ours is
+// left alone, the same "leave a foreign entry alone" rule every hook
+// uninstall in this codebase follows.
+//
+// pi's extensions directory is deliberately NOT removed when it empties out,
+// even if this install is what created it: an empty `extensions/` is an
+// ordinary state for a pi installation, and removing a directory a user's
+// editor or shell may have open is a worse surprise than leaving one behind.
+func UninstallHooks() (bool, error) {
+	path, err := ExtensionPath()
+	if err != nil {
+		return false, err
+	}
+	existing, readErr := os.ReadFile(path)
+	if errors.Is(readErr, os.ErrNotExist) {
+		return false, nil
+	}
+	if readErr != nil {
+		return false, readErr
+	}
+	if !isOurs(existing) {
+		return false, nil
+	}
+	if err := os.Remove(path); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// atomicWriteFile writes data to path via a temp file + rename so pi never
+// loads a half-written extension. Creates the parent directory. Matches every
+// sibling hook-installing adapter's own atomic writer.
+func atomicWriteFile(path string, data []byte) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(dir, ".irrlicht-extension-*.js.tmp")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName)
+
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Chmod(0o600); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpName, path)
+}

--- a/core/adapters/inbound/agents/pi/hookinstaller.go
+++ b/core/adapters/inbound/agents/pi/hookinstaller.go
@@ -55,9 +55,16 @@
 // not speak HTTP, does not parse an addr file, and does not know what a port
 // is — it spawns one command and writes JSON to its stdin.
 //
-// pi is the first adopter of the beacon route outside its own reference
-// wiring (core/internal/contracttesting/hook_endpoint_addressfree_test.go),
-// which #1721 named as the intended outcome.
+// #1721 records the beacon as "built, contract-covered, and adopted by
+// nobody". That was true when #1373 landed and is not true now — geminicli
+// (#1717), kirocli (#1716) and vibe (#1718) all declare
+// DeliveryAddressFree, as docs/testing-contracts.md's delivery bullet
+// already says. pi is the fourth adopter, not the first, and the reason to
+// pick the route here is its own rather than "nobody has": what it removes
+// is a chunk of the SHIPPED ARTIFACT. A URL-carrying install would need the
+// JavaScript to speak HTTP and to be rewritten in the user's agent every
+// time the daemon's port changed; naming the beacon means the file spawns
+// one command and knows nothing about addresses.
 package pi
 
 import (

--- a/core/adapters/inbound/agents/pi/hookinstaller_test.go
+++ b/core/adapters/inbound/agents/pi/hookinstaller_test.go
@@ -5,8 +5,69 @@ import (
 	"path/filepath"
 	"testing"
 
+	"irrlicht/core/domain/permission"
+	"irrlicht/core/internal/contracttesting"
 	"irrlicht/core/pkg/hookbeacon"
 )
+
+// hooksPermission returns the real declared hooks permission's closures.
+func hooksPermission(t *testing.T) (apply, remove func() error) {
+	t.Helper()
+	for _, p := range Agent().Permissions {
+		if p.Key == PermissionKeyHooks {
+			return p.Apply, p.Remove
+		}
+	}
+	t.Fatal("no hooks permission declared")
+	return nil, nil
+}
+
+// TestHooksPermission_IsGated wires the install-type flavour of the #797
+// contract: nothing is written while the permission is pending, granting
+// installs the extension, and denying removes it.
+//
+// The stake here is higher than for a config-entry adapter and worth naming.
+// What this permission's Apply writes is EXECUTABLE CODE that pi loads into
+// every session, so "nothing is exercised while pending or denied" is not
+// only a consent rule — a pre-consent daemon that ran Apply would have put
+// code inside the user's agent before the wizard was ever answered.
+func TestHooksPermission_IsGated(t *testing.T) {
+	piHome(t)
+	apply, remove := hooksPermission(t)
+
+	state := permission.StatePending
+	contracttesting.AssertPermissionGated(t, contracttesting.PermissionGate{
+		Key: PermissionKeyHooks,
+		// transcripts is the adapter's only other declared permission and is
+		// observe-kind, so it has no closure to drive: the key-isolation arm
+		// is INERT here and repeats the revoked arm exactly, the same
+		// situation copilot's, geminicli's and vibe's equivalent tests
+		// document. Install-type wirings hold their own permission's
+		// closures, so a wrong key is not representable — the arm is
+		// load-bearing at the live receiver (hooks_test.go), not here.
+		OtherKeys: []string{PermissionKeyTranscripts},
+		SetState:  contracttesting.OnlyKey(PermissionKeyHooks, func(s permission.State) { state = s }),
+		Exercise: func() {
+			switch state {
+			case permission.StateGranted:
+				if err := apply(); err != nil {
+					t.Fatalf("apply: %v", err)
+				}
+			case permission.StateDenied:
+				if err := remove(); err != nil {
+					t.Fatalf("remove: %v", err)
+				}
+			}
+		},
+		Observe: func() bool {
+			status, err := VerifyHooksInstalled()
+			if err != nil {
+				t.Fatalf("VerifyHooksInstalled: %v", err)
+			}
+			return status.Intact()
+		},
+	})
+}
 
 // piHome relocates $HOME and clears both pi overrides, returning the temp
 // home. Every test in this file WRITES, so isolation is not optional.

--- a/core/adapters/inbound/agents/pi/hookinstaller_test.go
+++ b/core/adapters/inbound/agents/pi/hookinstaller_test.go
@@ -1,0 +1,329 @@
+package pi
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"irrlicht/core/pkg/hookbeacon"
+)
+
+// piHome relocates $HOME and clears both pi overrides, returning the temp
+// home. Every test in this file WRITES, so isolation is not optional.
+func piHome(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv(agentDirEnvVar, "")
+	t.Setenv(sessionDirEnvVar, "")
+	return home
+}
+
+func extensionPath(t *testing.T) string {
+	t.Helper()
+	p, err := ExtensionPath()
+	if err != nil {
+		t.Fatalf("ExtensionPath: %v", err)
+	}
+	return p
+}
+
+// TestEnsureInstalled_CreatesTheExtensionAndIsIdempotent pins the base case:
+// the file lands in pi's own auto-discovery directory, and a second call is
+// a no-op rather than a rewrite (a daemon restart must not churn the file
+// under a running pi session).
+func TestEnsureInstalled_CreatesTheExtensionAndIsIdempotent(t *testing.T) {
+	home := piHome(t)
+
+	modified, err := EnsureHooksInstalled()
+	if err != nil {
+		t.Fatalf("EnsureHooksInstalled: %v", err)
+	}
+	if !modified {
+		t.Error("first install reported no modification")
+	}
+
+	want := filepath.Join(home, defaultAgentDirName, extensionsDirName, extensionFilename)
+	if got := extensionPath(t); got != want {
+		t.Errorf("ExtensionPath() = %q, want %q — pi auto-discovers only this directory", got, want)
+	}
+	data, err := os.ReadFile(want)
+	if err != nil {
+		t.Fatalf("reading the installed extension: %v", err)
+	}
+	if !isOurs(data) {
+		t.Error("the installed file does not carry the beacon sentinel")
+	}
+
+	modified, err = EnsureHooksInstalled()
+	if err != nil {
+		t.Fatalf("second EnsureHooksInstalled: %v", err)
+	}
+	if modified {
+		t.Error("second install reported a modification; the install is not idempotent")
+	}
+}
+
+// TestEnsureInstalled_RefusesToOverwriteAFileItDidNotWrite is the guard on
+// the one genuinely destructive thing this adapter could do. Our path is a
+// name we chose inside a directory the USER owns and pi shares with every
+// other extension; overwriting whatever is there for the sake of monitoring
+// is never the right trade, and the refusal surfaces as #1362's "granted but
+// NOT applied" with this message rather than as silent data loss.
+func TestEnsureInstalled_RefusesToOverwriteAFileItDidNotWrite(t *testing.T) {
+	piHome(t)
+	path := extensionPath(t)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	const theirs = "export default function () { /* someone else's extension */ }\n"
+	if err := os.WriteFile(path, []byte(theirs), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	modified, err := EnsureHooksInstalled()
+	if err == nil {
+		t.Error("EnsureHooksInstalled overwrote a foreign file without complaint")
+	}
+	if modified {
+		t.Error("EnsureHooksInstalled reported a modification while refusing")
+	}
+	got, readErr := os.ReadFile(path)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if string(got) != theirs {
+		t.Error("the foreign file was modified")
+	}
+}
+
+// TestUninstall_RemovesOursAndLeavesForeignAlone pins both directions of the
+// "leave a foreign entry alone" rule every hook uninstall in this codebase
+// follows, applied to a whole file rather than to an entry inside one.
+func TestUninstall_RemovesOursAndLeavesForeignAlone(t *testing.T) {
+	piHome(t)
+	if _, err := EnsureHooksInstalled(); err != nil {
+		t.Fatalf("EnsureHooksInstalled: %v", err)
+	}
+	path := extensionPath(t)
+
+	modified, err := UninstallHooks()
+	if err != nil {
+		t.Fatalf("UninstallHooks: %v", err)
+	}
+	if !modified {
+		t.Error("uninstall of an installed extension reported no modification")
+	}
+	if _, statErr := os.Stat(path); !os.IsNotExist(statErr) {
+		t.Errorf("the extension file survived uninstall (stat err = %v)", statErr)
+	}
+
+	// A second uninstall is a no-op, not an error.
+	if modified, err = UninstallHooks(); err != nil || modified {
+		t.Errorf("second uninstall = (%v, %v), want (false, nil)", modified, err)
+	}
+
+	// And a foreign file at our path is left alone.
+	const theirs = "export default function () {}\n"
+	if err := os.WriteFile(path, []byte(theirs), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if modified, err = UninstallHooks(); err != nil || modified {
+		t.Errorf("uninstall over a foreign file = (%v, %v), want (false, nil)", modified, err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil || string(got) != theirs {
+		t.Error("uninstall removed or altered a file it did not write")
+	}
+}
+
+// TestVerifyAgreesWithEnsureInstalled is the #1372 obligation as a property
+// rather than as three hand-picked cases: for every state the file can be
+// in, VerifyHooksInstalled reports work outstanding exactly when
+// EnsureHooksInstalled would do some.
+//
+// It exists because those are two separate readers of the same file, and the
+// failure mode of a disagreement is invisible in both directions — a verifier
+// that under-reports leaves a dead channel green forever, and one that
+// over-reports makes the repair timer rewrite a correct file on every tick.
+func TestVerifyAgreesWithEnsureInstalled(t *testing.T) {
+	foreign, err := hookbeacon.Command(foreignBinaryPath, AdapterName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stale, err := renderExtension(foreign)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tc := range []struct {
+		name            string
+		seed            func(t *testing.T, path string)
+		wantOutstanding bool
+	}{
+		{name: "absent", seed: func(*testing.T, string) {}, wantOutstanding: true},
+		{
+			name: "ours_but_naming_another_binary",
+			seed: func(t *testing.T, path string) {
+				if err := atomicWriteFile(path, stale); err != nil {
+					t.Fatal(err)
+				}
+			},
+			wantOutstanding: true,
+		},
+		{
+			name: "current",
+			seed: func(t *testing.T, path string) {
+				if _, err := EnsureHooksInstalled(); err != nil {
+					t.Fatal(err)
+				}
+			},
+			wantOutstanding: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			piHome(t)
+			tc.seed(t, extensionPath(t))
+
+			status, err := VerifyHooksInstalled()
+			if err != nil {
+				t.Fatalf("VerifyHooksInstalled: %v", err)
+			}
+			reported := len(status.Missing) > 0 || len(status.Stale) > 0
+			if reported != tc.wantOutstanding {
+				t.Errorf("verify reported outstanding=%v (missing=%v stale=%v), want %v",
+					reported, status.Missing, status.Stale, tc.wantOutstanding)
+			}
+
+			modified, err := EnsureHooksInstalled()
+			if err != nil {
+				t.Fatalf("EnsureHooksInstalled: %v", err)
+			}
+			if modified != reported {
+				t.Errorf("verify says outstanding=%v but ensure modified=%v — the two "+
+					"readers of the same file disagree", reported, modified)
+			}
+		})
+	}
+}
+
+// TestVerify_DoesNotWrite pins that the verifier is read-only by
+// construction (#1372): it runs on a timer against a granted install, and a
+// verifier that materialized what it was checking for would report health it
+// had just created.
+func TestVerify_DoesNotWrite(t *testing.T) {
+	piHome(t)
+	if _, err := VerifyHooksInstalled(); err != nil {
+		t.Fatalf("VerifyHooksInstalled: %v", err)
+	}
+	if _, err := os.Stat(extensionPath(t)); !os.IsNotExist(err) {
+		t.Errorf("verify created the extension file it was asked to check (stat err = %v)", err)
+	}
+}
+
+// TestInstallLeavesAPiWrittenSettingsFileUntouched is issue #1756's
+// obligation for this adapter: grade the install against a config pi itself
+// wrote, not one the test constructed.
+//
+// The fixture is a verbatim ~/.pi/agent/settings.json from pi 0.83.0
+// (testdata/README.md carries its provenance), and its `packages` array is
+// the load-bearing part — that array is what `pi install` writes, so this is
+// a home where pi's OTHER extension mechanism is already in use. The claim
+// under test is the one the consent copy makes: irrlicht's install adds a
+// file and touches nothing else.
+//
+// The assertion is a whole-tree diff rather than a check on settings.json
+// alone, because "the file I remembered to look at is unchanged" is exactly
+// the shape of the blind spot #1756 was filed about.
+func TestInstallLeavesAPiWrittenSettingsFileUntouched(t *testing.T) {
+	home := piHome(t)
+	agentDir := filepath.Join(home, defaultAgentDirName)
+	if err := os.MkdirAll(filepath.Join(agentDir, extensionsDirName), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	real, err := os.ReadFile(filepath.Join("testdata", "real-pi-settings.json"))
+	if err != nil {
+		t.Fatalf("reading the captured pi settings fixture: %v", err)
+	}
+	settings := filepath.Join(agentDir, "settings.json")
+	if err := os.WriteFile(settings, real, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// A second extension in the same directory, as a `pi install`-populated
+	// home would have.
+	neighbour := filepath.Join(agentDir, extensionsDirName, "someone-elses.ts")
+	if err := os.WriteFile(neighbour, []byte("export default function () {}\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	before := treeSnapshot(t, home)
+	if _, err := EnsureHooksInstalled(); err != nil {
+		t.Fatalf("EnsureHooksInstalled: %v", err)
+	}
+	after := treeSnapshot(t, home)
+
+	ours, err := filepath.Rel(home, extensionPath(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for path, content := range after {
+		if path == ours {
+			continue
+		}
+		if content != before[path] {
+			t.Errorf("install changed %s, which is not the file it declares it writes", path)
+		}
+	}
+	for path := range before {
+		if _, still := after[path]; !still {
+			t.Errorf("install removed %s", path)
+		}
+	}
+	if _, installed := after[ours]; !installed {
+		t.Fatalf("install wrote nothing at %s; the diff above proved nothing", ours)
+	}
+
+	// And uninstall gives the tree back exactly.
+	if _, err := UninstallHooks(); err != nil {
+		t.Fatalf("UninstallHooks: %v", err)
+	}
+	restored := treeSnapshot(t, home)
+	if len(restored) != len(before) {
+		t.Errorf("after uninstall the tree holds %d files, before install it held %d",
+			len(restored), len(before))
+	}
+	for path, content := range before {
+		if restored[path] != content {
+			t.Errorf("after uninstall %s no longer matches what pi wrote", path)
+		}
+	}
+}
+
+// treeSnapshot maps every regular file under root to its content, keyed by
+// its root-relative path.
+func treeSnapshot(t *testing.T, root string) map[string]string {
+	t.Helper()
+	out := map[string]string{}
+	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			return nil
+		}
+		rel, relErr := filepath.Rel(root, path)
+		if relErr != nil {
+			return relErr
+		}
+		data, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return readErr
+		}
+		out[rel] = string(data)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking %s: %v", root, err)
+	}
+	return out
+}

--- a/core/adapters/inbound/agents/pi/hookpath_test.go
+++ b/core/adapters/inbound/agents/pi/hookpath_test.go
@@ -1,0 +1,38 @@
+// hookpath_test.go wires this adapter's hook receiver into the shared issue
+// #1361 contract: a caller-supplied transcript path is confined to the
+// adapter's declared roots, symlinks resolved first, and anything outside
+// is refused, logged, counted — and still answered 2xx.
+package pi
+
+import (
+	"testing"
+
+	"irrlicht/core/internal/contracttesting"
+)
+
+func TestHookPathConfined(t *testing.T) {
+	contracttesting.AssertHookPathConfined(t, contracttesting.HookReceiver{
+		Root: piSessionRoot,
+		New: func(t *testing.T) contracttesting.HookReceiverUnderTest {
+			t.Helper()
+			target := &mockTarget{}
+			return contracttesting.HookReceiverUnderTest{
+				Handler:  NewHookHandler(target, nil, mockLogger{}),
+				Observed: func() bool { return target.totalCalls() > 0 },
+				ObservedPath: func() string {
+					stops := target.stops()
+					if len(stops) == 0 {
+						return ""
+					}
+					return stops[len(stops)-1].transcriptPath
+				},
+			}
+		},
+		WriteTranscript: writeContractTranscript,
+		TranscriptExt:   transcriptExt,
+		PayloadFor: func(transcriptPath string) string {
+			return contractPayload(transcriptPath, HookEventAgentSettled)
+		},
+		EndpointPath: HookEndpointPath,
+	})
+}

--- a/core/adapters/inbound/agents/pi/hookport_test.go
+++ b/core/adapters/inbound/agents/pi/hookport_test.go
@@ -1,0 +1,118 @@
+// hookport_test.go wires the pi extension installer into the shared issue
+// #1178 contract, under its DeliveryAddressFree route (#1453): the installed
+// artifact carries no address at all, because it names the `irrlichd
+// hook-post pi` beacon, which resolves the daemon's address itself at fire
+// time.
+//
+// pi is the first ADAPTER on that route — before this it was exercised only
+// by the contract's own reference wiring
+// (contracttesting/hook_endpoint_addressfree_test.go), which #1721 named as
+// the intended outcome.
+//
+// The read-back obligations (2-4) go through HookInstaller.ReadEntries /
+// EndpointOfRaw (#1734), for a reason one step further out than the TOML
+// adapter that seam was widened for: this adapter's "entry" is not a
+// document node of any kind. It is a JavaScript file, and the whole file is
+// the entry. There is exactly one, it belongs to the one event this adapter
+// subscribes to, and the delivery it carries is the one beacon command line
+// inside it — which piEndpointOfRaw reads back with the same anchored
+// regexp the installer uses to decide whether an installed copy is current.
+// Entry/EndpointOf (obligation 1, in-memory only) stay
+// map[string]interface{} regardless: nothing downstream of them touches the
+// filesystem, so a synthetic one-key map answers that question honestly.
+package pi
+
+import (
+	"os"
+	"testing"
+
+	"irrlicht/core/internal/contracttesting"
+	"irrlicht/core/pkg/hookbeacon"
+)
+
+// foreignBinaryPath is the irrlichd a DIFFERENTLY-situated daemon would have
+// named. Deliberately a path that does not exist: an absolute path that has
+// stopped existing is exactly the drift beacon delivery newly admits
+// (#1373), and it needs no second executable to arrange.
+const foreignBinaryPath = "/nonexistent-irrlicht-1721/bin/irrlichd"
+
+// piEntryNow / piEndpointOfMap are the contract's in-memory Entry/EndpointOf
+// pair for obligation 1 — a synthetic one-key map, since obligation 1 never
+// reads the filesystem.
+func piEntryNow() map[string]interface{} {
+	command, _ := hookbeacon.InstalledCommand(AdapterName)
+	return map[string]interface{}{"command": command}
+}
+
+func piEndpointOfMap(hook map[string]interface{}) string {
+	c, _ := hook["command"].(string)
+	return c
+}
+
+// piReadEntries is the contract's ReadEntries: the installed extension file,
+// raw, as a single entry — or nothing at all when the file is absent or is
+// not ours. event is ignored; this adapter subscribes to exactly one event
+// from one file, so there is nothing to filter, which
+// HookInstaller.ReadEntries's own doc comment records as a supported shape
+// rather than a gap.
+func piReadEntries(path, _ string) ([][]byte, error) {
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return [][]byte{data}, nil
+}
+
+// piEndpointOfRaw extracts the beacon command from one raw entry — the same
+// value ensureInstalledWithCommand renders in and VerifyHooksInstalled
+// compares, read back through the production helper rather than a second
+// parser written for the test.
+func piEndpointOfRaw(entry []byte) string {
+	command, _ := beaconCommandOf(entry)
+	return command
+}
+
+func TestHookEndpointFollowsBindAddr(t *testing.T) {
+	// Checked up front so a resolution failure reads as itself rather than
+	// as the empty-delivery wiring error assertDeliveryIsOurs would report.
+	if _, err := hookbeacon.InstalledCommand(AdapterName); err != nil {
+		t.Fatalf("resolving the beacon command: %v", err)
+	}
+
+	contracttesting.AssertHookEndpointFollowsBindAddr(t, contracttesting.HookInstaller{
+		Delivery: contracttesting.DeliveryAddressFree,
+		SettingsPath: func(t *testing.T) string {
+			home := t.TempDir()
+			t.Setenv("HOME", home)
+			t.Setenv(agentDirEnvVar, "")
+			t.Setenv(sessionDirEnvVar, "")
+			path, err := ExtensionPath()
+			if err != nil {
+				t.Fatalf("resolving the extension path: %v", err)
+			}
+			return path
+		},
+		Sentinel:        hookbeacon.Sentinel(AdapterName),
+		Events:          installedHookEvents,
+		Entry:           piEntryNow,
+		EndpointOf:      piEndpointOfMap,
+		ReadEntries:     piReadEntries,
+		EndpointOfRaw:   piEndpointOfRaw,
+		EnsureInstalled: EnsureHooksInstalled,
+		Uninstall:       UninstallHooks,
+		// ForeignInstall seeds an extension naming a DIFFERENT (nonexistent)
+		// irrlicht binary — the address-free counterpart of seeding a
+		// stale-port install — so the contract can assert EnsureHooksInstalled
+		// rewrites it in place rather than leaving two of them.
+		ForeignInstall: func() (bool, error) {
+			command, err := hookbeacon.Command(foreignBinaryPath, AdapterName)
+			if err != nil {
+				return false, err
+			}
+			return ensureInstalledWithCommand(command)
+		},
+	})
+}

--- a/core/adapters/inbound/agents/pi/hookport_test.go
+++ b/core/adapters/inbound/agents/pi/hookport_test.go
@@ -4,10 +4,8 @@
 // hook-post pi` beacon, which resolves the daemon's address itself at fire
 // time.
 //
-// pi is the first ADAPTER on that route — before this it was exercised only
-// by the contract's own reference wiring
-// (contracttesting/hook_endpoint_addressfree_test.go), which #1721 named as
-// the intended outcome.
+// pi is the fourth adapter on that route, after geminicli, kirocli and vibe
+// — #1721's "adopted by nobody" describes the state at #1373, not today.
 //
 // The read-back obligations (2-4) go through HookInstaller.ReadEntries /
 // EndpointOfRaw (#1734), for a reason one step further out than the TOML

--- a/core/adapters/inbound/agents/pi/hookreceipt_test.go
+++ b/core/adapters/inbound/agents/pi/hookreceipt_test.go
@@ -1,0 +1,33 @@
+// hookreceipt_test.go wires this adapter's hook receiver into the shared
+// issue #1368 contract: a consent-passed request counts as a receipt
+// whatever the receiver then does with it, and a consent-denied one does
+// not.
+package pi
+
+import (
+	"net/http"
+	"testing"
+
+	"irrlicht/core/internal/contracttesting"
+	"irrlicht/core/ports/outbound"
+)
+
+func TestHookReceiptObserved(t *testing.T) {
+	contracttesting.AssertHookReceiptObserved(t, contracttesting.HookReceiptReceiver{
+		Adapter:         AdapterName,
+		Root:            piSessionRoot,
+		WriteTranscript: writeContractTranscript,
+		New: func(t *testing.T, log outbound.Logger) http.Handler {
+			t.Helper()
+			return NewHookHandler(&mockTarget{},
+				keyedGate{PermissionKeyHooks: true, PermissionKeyTranscripts: true}, log)
+		},
+		NewDenied: func(t *testing.T, log outbound.Logger) http.Handler {
+			t.Helper()
+			return NewHookHandler(&mockTarget{}, keyedGate{}, log)
+		},
+		PayloadFor:   contractPayload,
+		KnownEvent:   HookEventAgentSettled,
+		EndpointPath: HookEndpointPath,
+	})
+}

--- a/core/adapters/inbound/agents/pi/hooks.go
+++ b/core/adapters/inbound/agents/pi/hooks.go
@@ -1,0 +1,226 @@
+// hooks.go provides the HTTP handler for receiving pi lifecycle events
+// (issue #1721, epic #1355).
+//
+// Exactly one event is installed and dispatched: agent_settled, routed to
+// HandleStopHook with an empty text and a false waiting cue. See
+// hookinstaller.go's installedHookEvents for what is deliberately NOT
+// installed and why.
+//
+// # The payload-free floor is deliberate, and it is the cheaper half of a
+// # supply-chain trade
+//
+// pi's agent_settled event carries no message content (docs/extensions.md:
+// the handler signature is `(_event, ctx)` and the event object has no
+// message field), and the extension COULD read the last assistant message
+// out of ctx.sessionManager and forward it. It does not, on purpose: every
+// additional line in extension.js is a line of executable code irrlicht
+// ships into a user's agent, and this is exactly the "honest floor"
+// hook_signal.go already documents for a payload-free HookStop —
+// HandleStopHook asserts SignalTurnDone unconditionally and only
+// CONDITIONALLY overlays the text and cue, so the authoritative "the turn
+// truly ended" signal is real without them. What it gives up is a waiting
+// cue sitting outside the transcript tail the parser already scans; it can
+// never clear or mask a cue the transcript found on its own.
+//
+// # pi's one blocked-on-user state, and why it is not here
+//
+// #1721 asked whether pi has any blocked-on-user state at all and told this
+// issue not to assume the answer. Measured against the installed package
+// (0.83.0):
+//
+//   - There is no tool-approval prompt. pi has no sandbox (its own
+//     docs/security.md: tools run with the process's permissions), so
+//     nothing blocks before a tool runs.
+//   - `ask_question` — which pi's README, docs/usage.md and docs/sdk.md all
+//     name as an --exclude-tools example — is NOT in 0.83.0. The string
+//     "ask_question" does not appear as a quoted identifier anywhere under
+//     dist/ (0 files, against 18 for "bash" and 14 for "read"). #1721's own
+//     measurement, reproduced independently here. It is docs drift.
+//   - pi DOES have one genuine built-in blocking prompt: the project trust
+//     prompt (docs/settings.md: "On interactive startup, pi asks before
+//     trusting a project folder..."), surfaced to extensions as the
+//     `project_trust` event.
+//
+// project_trust is nonetheless unusable as a `waiting` signal, and the
+// reason is structural rather than a matter of effort: it fires BEFORE a
+// session exists, and its context is explicitly a reduced one —
+// docs/extensions.md, "ctx has a limited trust context: cwd, mode, hasUI,
+// and select/confirm/input/notify UI helpers". There is no sessionManager
+// and therefore no transcript path, which is the only thing this adapter
+// correlates a session on. A hook irrlicht cannot attribute to a session is
+// a hook irrlicht cannot act on. Live-confirmed by the event walk this issue
+// ran against pi 0.83.0: session_start is the FIRST event carrying a session
+// file at all.
+//
+// So pi is, through hooks, a two-state adapter — working/ready — and that is
+// a measured result rather than a gap left open. `waiting` remains reachable
+// for pi exactly where it already was: the transcript-tail prose cue.
+package pi
+
+import (
+	"net/http"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"irrlicht/core/adapters/inbound/agents/hookjson"
+	"irrlicht/core/domain/agent"
+	"irrlicht/core/ports/outbound"
+)
+
+// PermissionKeyHooks gates installing and receiving pi lifecycle events
+// (issue #570). Aliased to the shared domain constant rather than restated —
+// see agent.HooksPermissionKey's own doc for why two external projections
+// narrow on it.
+const PermissionKeyHooks = agent.HooksPermissionKey
+
+// logComponentHookReceiver is the Logger component tag for every log line
+// this receiver emits.
+const logComponentHookReceiver = "pi-hook-receiver"
+
+// transcriptExt is the file extension the hook receiver confines
+// caller-supplied paths to.
+const transcriptExt = ".jsonl"
+
+// piHookPayload is the JSON body irrlicht's own pi extension writes to the
+// beacon's stdin (extension.js), forwarded verbatim by
+// `irrlichd hook-post pi`.
+//
+// Deliberately minimal, and deliberately carrying no session_id: pi's
+// extension API hands the extension the session's transcript file directly
+// (ctx.sessionManager.getSessionFile(), live-verified to be the absolute
+// path of the .jsonl the fswatcher already tails), and the filename stem of
+// that path IS the id every other part of this adapter keys sessions on. A
+// separate session_id field would be a second spelling of the same fact that
+// could disagree with it — which is not hypothetical: geminicli's hooks.go
+// records a measured case where the agent's own session_id and the
+// filename-stem id were different strings.
+//
+// It arrives on a local, unauthenticated endpoint, so "our own extension
+// wrote it" buys nothing: the path is confined before anything reads it.
+type piHookPayload struct {
+	HookEventName string `json:"hook_event_name"`
+
+	// TranscriptPath is confined and then overwritten with the confined
+	// spelling by DecodeConfined — see NewHookHandler.
+	TranscriptPath string `json:"transcript_path"`
+}
+
+// HookTarget is the interface the handler calls into. Satisfied by
+// *services.SessionDetector without importing the services package — the
+// same agent-agnostic surface every other receiver uses, narrowed to the one
+// method this adapter's single installed event needs.
+type HookTarget interface {
+	HandleStopHook(sessionID, transcriptPath, lastAssistantText string, waitingCue bool)
+}
+
+// ConsentGranter is the shared consent check every JSON-hook receiver gates
+// on (issue #570) — an alias, not a copy, so the receivers cannot drift.
+type ConsentGranter = hookjson.ConsentGranter
+
+// NewHookHandler returns an http.Handler that receives pi lifecycle events
+// and dispatches them to the target. The returned hookjson.HookHandler is
+// the handler together with the confiner it guards caller-supplied
+// transcript paths with (issue #1390).
+//
+// gate is the consent check; while the "hooks" permission is not granted the
+// payload is dropped with 200, so an install left behind by a pre-consent
+// daemon stays quiet. A nil gate means no gating — used by tests.
+func NewHookHandler(target HookTarget, gate ConsentGranter, log outbound.Logger) hookjson.HookHandler {
+	return hookjson.NewHandler(transcriptConfiner(),
+		hookjson.RequireConsent(gate, AdapterName, PermissionKeyHooks, PermissionKeyTranscripts),
+		func(consent hookjson.Consent, c *hookjson.PathConfiner, w http.ResponseWriter, r *http.Request) {
+			serveHookRequest(target, consent, log, c, w, r)
+		})
+}
+
+// transcriptConfiner returns the confiner this adapter's hook receiver
+// guards caller-supplied transcript paths with, rooted in the adapter's own
+// Source declaration (issue #1361) rather than re-derived from the adapter's
+// constants — so the tree the receiver confines to cannot drift from the one
+// the daemon watches.
+func transcriptConfiner() *hookjson.PathConfiner {
+	return hookjson.ConfinerForSource(Source, runtime.GOOS, transcriptExt)
+}
+
+// serveHookRequest is NewHookHandler's request logic. The step order matches
+// every sibling receiver's exactly, and each step is load-bearing — see the
+// contract assertions in hook*_test.go.
+func serveHookRequest(target HookTarget, consent hookjson.Consent, log outbound.Logger, confiner *hookjson.PathConfiner, w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	// Both keys come off the receiver's OWN hookjson.Consent (issue #1488),
+	// so the set this sequence is written for is the set the handler
+	// publishes and the contract derives.
+	if !consent.Granted(PermissionKeyHooks) {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
+	// The channel delivered (issue #1368). Counted against the "hooks"
+	// consent only, ahead of the transcripts check below.
+	hookjson.ObserveHookReceipt(AdapterName)
+
+	// Dispatching makes the detector read the transcript, so it is gated
+	// behind "transcripts", not merely the "hooks" write consent. The check
+	// comes BEFORE the decode, and so before confinement, so a denied
+	// session still yields a quiet 200 and the path is never resolved.
+	if !consent.Granted(PermissionKeyTranscripts) {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
+	var payload piHookPayload
+	if !hookjson.DecodeConfined(w, r, log, logComponentHookReceiver, consent, confiner, &payload,
+		func(p *piHookPayload) string { return p.TranscriptPath },
+		func(p *piHookPayload, confined string) { p.TranscriptPath = confined },
+	) {
+		return
+	}
+	transcriptPath := payload.TranscriptPath
+
+	sessionID := sessionIDFromTranscriptPath(transcriptPath)
+	if sessionID == "" {
+		// Not a path this adapter owns — drop rather than guess an id. The
+		// transcript tailer covers the state regardless.
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
+	switch payload.HookEventName {
+	case HookEventAgentSettled:
+		log.LogInfo(logComponentHookReceiver, sessionID, "received agent_settled")
+		target.HandleStopHook(sessionID, transcriptPath, "", false)
+	default:
+		// Unrecognized hook event — accept but ignore, counted per name and
+		// reported once, in the one place that behaviour is decided for
+		// every receiver (issue #1364). This is where a pi event rename, or
+		// an event a future extension version subscribes to that this daemon
+		// does not know, becomes visible instead of silent.
+		hookjson.IgnoreUnknownEvent(log, logComponentHookReceiver, AdapterName, sessionID, payload.HookEventName)
+	}
+	w.WriteHeader(http.StatusOK)
+}
+
+// sessionIDFromTranscriptPath derives the session ID the SAME way
+// agent.FilesUnderRoot's default does when no SessionIDFromPath override is
+// declared (this adapter declares none — see agent.go): the filename stem.
+//
+// pi's transcripts are <timestamp>_<uuid>.jsonl under a per-cwd directory
+// (sessions/--<cwd-with-dashes>--/), so the stem is the whole
+// "2026-08-22T03-42-52-286Z_01a02790-..." id — live-verified against pi
+// 0.83.0 during this issue's audit.
+func sessionIDFromTranscriptPath(path string) string {
+	base := filepath.Base(path)
+	if !strings.HasSuffix(base, transcriptExt) {
+		return ""
+	}
+	id := strings.TrimSuffix(base, transcriptExt)
+	if id == "" {
+		return ""
+	}
+	return id
+}

--- a/core/adapters/inbound/agents/pi/hooks_test.go
+++ b/core/adapters/inbound/agents/pi/hooks_test.go
@@ -1,0 +1,280 @@
+package pi
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"irrlicht/core/internal/contracttesting"
+)
+
+// --- test doubles, shared by this file and the contract wirings ---
+
+type stopCall struct {
+	sessionID, transcriptPath, lastAssistantText string
+	waitingCue                                   bool
+}
+
+type mockTarget struct {
+	mu        sync.Mutex
+	stopCalls []stopCall
+}
+
+func (m *mockTarget) HandleStopHook(sessionID, transcriptPath, lastAssistantText string, waitingCue bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.stopCalls = append(m.stopCalls, stopCall{sessionID, transcriptPath, lastAssistantText, waitingCue})
+}
+
+func (m *mockTarget) totalCalls() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return len(m.stopCalls)
+}
+
+func (m *mockTarget) stops() []stopCall {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]stopCall(nil), m.stopCalls...)
+}
+
+// keyedGate pins a fixed permission combination for a one-off test. For a
+// MUTABLE keyed gate driven through states by the shared contract, use
+// contracttesting.ConsentGate instead.
+type keyedGate map[string]bool
+
+func (g keyedGate) Granted(_, key string) bool { return g[key] }
+
+type mockLogger struct{}
+
+func (mockLogger) LogInfo(string, string, string)                       {}
+func (mockLogger) LogError(string, string, string)                      {}
+func (mockLogger) LogProcessingTime(string, string, int64, int, string) {}
+func (mockLogger) Close() error                                         { return nil }
+
+// --- helpers ---
+
+// piSessionRoot relocates $HOME and clears BOTH pi overrides, then returns
+// the declared transcript root inside the temp home. Every test in this
+// package must isolate pi's agent dir to a t.TempDir(), never the real
+// ~/.pi/agent — this package's installer WRITES a file.
+//
+// Clearing PI_CODING_AGENT_DIR is not ceremony: since #1721 sessionsDir()
+// reads it, so a leaked value from the developer's own environment would
+// silently point the confiner at a tree the test never wrote into.
+func piSessionRoot(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv(agentDirEnvVar, "")
+	t.Setenv(sessionDirEnvVar, "")
+	root := filepath.Join(home, defaultRootDir)
+	if err := os.MkdirAll(root, 0o700); err != nil {
+		t.Fatalf("create sessions dir: %v", err)
+	}
+	return root
+}
+
+// writeSessionTranscript lays down <root>/<cwd-dir>/<id>.jsonl and returns
+// its path — the shape sessionIDFromTranscriptPath expects (the filename
+// stem is the id; the per-cwd directory pi nests transcripts in is
+// irrelevant to identity but is reproduced so the fixture matches what pi
+// actually writes).
+func writeSessionTranscript(t *testing.T, root, id string) string {
+	t.Helper()
+	dir := filepath.Join(root, "--tmp-project--")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatalf("mkdir session dir: %v", err)
+	}
+	path := filepath.Join(dir, id+transcriptExt)
+	if err := os.WriteFile(path, []byte(`{"type":"message"}`+"\n"), 0o600); err != nil {
+		t.Fatalf("write transcript: %v", err)
+	}
+	return path
+}
+
+// writeContractTranscript is the shape the receiving-side contracts want: a
+// transcript inside dir whose session id the receiver can resolve.
+func writeContractTranscript(t *testing.T, dir string) string {
+	t.Helper()
+	return writeSessionTranscript(t, dir, "sess-contract")
+}
+
+// contractPayload renders the body irrlicht's own pi extension writes for
+// one event name — transcript_path plus hook_event_name, nothing else,
+// matching extension.js's own JSON.stringify exactly.
+func contractPayload(transcriptPath, event string) string {
+	body, err := json.Marshal(piHookPayload{
+		TranscriptPath: transcriptPath,
+		HookEventName:  event,
+	})
+	if err != nil {
+		panic(err)
+	}
+	return string(body)
+}
+
+// post drives the handler with a raw JSON body and returns the response.
+func post(t *testing.T, h http.Handler, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, HookEndpointPath, strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	return rec
+}
+
+// newReceiver builds a fully-granted receiver over the real production
+// confiner, plus the target it dispatches into.
+func newReceiver(t *testing.T) (http.Handler, *mockTarget) {
+	t.Helper()
+	target := &mockTarget{}
+	gate := keyedGate{PermissionKeyHooks: true, PermissionKeyTranscripts: true}
+	return NewHookHandler(target, gate, mockLogger{}), target
+}
+
+// --- behaviour ---
+
+// TestAgentSettledHook_DispatchesToHandleStopHook pins the one event this
+// adapter installs: it fires HandleStopHook with an empty text and a false
+// waitingCue, since pi's agent_settled event carries no message content and
+// extension.js deliberately does not go looking for one (hooks.go's header
+// on why the payload-free floor is the trade being made).
+func TestAgentSettledHook_DispatchesToHandleStopHook(t *testing.T) {
+	root := piSessionRoot(t)
+	tp := writeSessionTranscript(t, root, "2026-08-22T03-42-52-286Z_01a02790")
+	h, target := newReceiver(t)
+
+	rec := post(t, h, contractPayload(tp, HookEventAgentSettled))
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200", rec.Code)
+	}
+	stops := target.stops()
+	if len(stops) != 1 {
+		t.Fatalf("HandleStopHook called %d times, want 1", len(stops))
+	}
+	got := stops[0]
+	if got.sessionID != "2026-08-22T03-42-52-286Z_01a02790" {
+		t.Errorf("sessionID = %q, want the transcript filename stem", got.sessionID)
+	}
+	if got.transcriptPath != tp {
+		t.Errorf("transcriptPath = %q, want %q", got.transcriptPath, tp)
+	}
+	if got.lastAssistantText != "" {
+		t.Errorf("lastAssistantText = %q, want empty — pi's agent_settled carries no message text", got.lastAssistantText)
+	}
+	if got.waitingCue {
+		t.Errorf("waitingCue = true, want false — nothing in the payload can assert one")
+	}
+}
+
+// TestHookReceiver_PermissionGateContract runs the shared #797 contract once
+// per permission this receiver must honour, derived from the receiver's own
+// declaration (issue #1488).
+func TestHookReceiver_PermissionGateContract(t *testing.T) {
+	contracttesting.AssertHookReceiverPermissionGated(t, contracttesting.HookReceiverGate{
+		Build: func(t *testing.T, gate *contracttesting.ConsentGate) contracttesting.GatedHookReceiver {
+			root := piSessionRoot(t)
+			body := contractPayload(writeSessionTranscript(t, root, "sess-gate"), HookEventAgentSettled)
+			target := &mockTarget{}
+			h := NewHookHandler(target, gate, mockLogger{})
+
+			before := 0
+			return contracttesting.GatedHookReceiver{
+				Handler: h,
+				Exercise: func() {
+					before = target.totalCalls()
+					post(t, h, body)
+				},
+				Observe: func() bool { return target.totalCalls() > before },
+			}
+		},
+	})
+}
+
+// TestHookReceiver_DeclaresItsPermissions is the LOCK on the key list the
+// wiring above used to spell out (#1450).
+func TestHookReceiver_DeclaresItsPermissions(t *testing.T) {
+	contracttesting.AssertDeclaredPermissions(t,
+		NewHookHandler(&mockTarget{}, nil, mockLogger{}),
+		PermissionKeyHooks, PermissionKeyTranscripts)
+}
+
+// TestHookReceiver_NonPostRejected is a LOCK on the shared receiver shape.
+func TestHookReceiver_NonPostRejected(t *testing.T) {
+	piSessionRoot(t)
+	h, _ := newReceiver(t)
+	req := httptest.NewRequest(http.MethodGet, HookEndpointPath, nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Errorf("GET status = %d, want 405", rec.Code)
+	}
+}
+
+// TestHookReceiver_MalformedJSONIs400 is a LOCK: a body that will not decode
+// is the one case that answers non-2xx, because nothing about it is a path.
+func TestHookReceiver_MalformedJSONIs400(t *testing.T) {
+	piSessionRoot(t)
+	h, _ := newReceiver(t)
+	rec := post(t, h, "{not json")
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", rec.Code)
+	}
+}
+
+// TestHookReceiver_UnknownSessionIsQuiet is a LOCK: a transcript_path inside
+// the adapter's own root whose filename does not end in .jsonl is dropped
+// rather than guessed at.
+func TestHookReceiver_UnknownSessionIsQuiet(t *testing.T) {
+	root := piSessionRoot(t)
+	dir := filepath.Join(root, "--tmp-project--")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	other := filepath.Join(dir, "notes.txt")
+	if err := os.WriteFile(other, []byte("{}"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	h, target := newReceiver(t)
+
+	rec := post(t, h, contractPayload(other, HookEventAgentSettled))
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200", rec.Code)
+	}
+	if n := target.totalCalls(); n != 0 {
+		t.Errorf("dispatched %d times for a path this adapter does not own, want 0", n)
+	}
+}
+
+// TestHookReceiver_DeniedTranscriptsConsentDropsQuietly pins that a
+// transcripts-denied session must not dispatch even though the hooks
+// consent is granted, and must not log an error while doing it (the
+// receiver's own gate answers quietly; only the shared backstop logs).
+// Since #1488's chokepoint the SILENCE is the surviving discriminator —
+// deleting the gate below leaves dispatch-shaped assertions green.
+func TestHookReceiver_DeniedTranscriptsConsentDropsQuietly(t *testing.T) {
+	root := piSessionRoot(t)
+	tp := writeSessionTranscript(t, root, "sess-denied")
+	target := &mockTarget{}
+	log := &contracttesting.RecordingLogger{}
+	h := NewHookHandler(target, keyedGate{PermissionKeyHooks: true}, log)
+
+	rec := post(t, h, contractPayload(tp, HookEventAgentSettled))
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200", rec.Code)
+	}
+	if n := target.totalCalls(); n != 0 {
+		t.Fatalf("dispatched %d times while transcripts consent was denied, want 0", n)
+	}
+	if len(log.Errors()) != 0 {
+		t.Errorf("a transcripts-denied hook logged %d error(s): %v", len(log.Errors()), log.Errors())
+	}
+}

--- a/core/adapters/inbound/agents/pi/hookunknown_test.go
+++ b/core/adapters/inbound/agents/pi/hookunknown_test.go
@@ -1,0 +1,38 @@
+// hookunknown_test.go wires this adapter's hook receiver into the shared
+// issue #1364 contract: an event name the receiver does not recognize is
+// counted per (adapter, name), reported once per distinct name, and still
+// answered 2xx.
+//
+// It is not a hypothetical for this adapter. Every OTHER receiver's unknown
+// event would come from an upstream rename; pi's can also come from
+// irrlicht's own installed extension being NEWER than the daemon reading
+// it — the file on disk survives a daemon downgrade, so a future extension
+// that subscribes to a second event would deliver a name this switch does
+// not know. #1364's counter is what makes that visible instead of silent.
+package pi
+
+import (
+	"testing"
+
+	"irrlicht/core/internal/contracttesting"
+	"irrlicht/core/ports/outbound"
+)
+
+func TestUnknownHookEventObserved(t *testing.T) {
+	contracttesting.AssertUnknownHookEventObserved(t, contracttesting.UnknownEventReceiver{
+		Adapter:         AdapterName,
+		Root:            piSessionRoot,
+		WriteTranscript: writeContractTranscript,
+		New: func(t *testing.T, log outbound.Logger) contracttesting.UnknownEventReceiverUnderTest {
+			t.Helper()
+			target := &mockTarget{}
+			return contracttesting.UnknownEventReceiverUnderTest{
+				Handler:  NewHookHandler(target, nil, log),
+				Observed: func() bool { return target.totalCalls() > 0 },
+			}
+		},
+		PayloadFor:   contractPayload,
+		KnownEvent:   HookEventAgentSettled,
+		EndpointPath: HookEndpointPath,
+	})
+}

--- a/core/adapters/inbound/agents/pi/hookversion_test.go
+++ b/core/adapters/inbound/agents/pi/hookversion_test.go
@@ -1,0 +1,97 @@
+// hookversion_test.go wires the pi hooks permission into the shared issue
+// #1365 contract.
+//
+// Like geminicli and vibe, this adapter declares no Observed version source:
+// nothing in a pi transcript carries a CLI version field this adapter's
+// parser reads, so the gate falls straight through to Probe
+// (`pi --version`), which cliversion runs itself.
+package pi
+
+import (
+	"strings"
+	"testing"
+
+	"irrlicht/core/domain/agent"
+	"irrlicht/core/internal/contracttesting"
+)
+
+func TestHooksPermission_DeclaresVersionGate(t *testing.T) {
+	contracttesting.AssertHookVersionGate(t, contracttesting.HookVersionGate{
+		Agent:         Agent(),
+		PermissionKey: PermissionKeyHooks,
+		Installed:     installedHookEvents,
+		Since:         hookEventSince,
+	})
+}
+
+// hooksVersionGate returns the declared gate, read off the real registration
+// the daemon consumes rather than a copy.
+func hooksVersionGate(t *testing.T) *agent.VersionGate {
+	t.Helper()
+	for _, p := range Agent().Permissions {
+		if p.Key == PermissionKeyHooks {
+			if p.Writes == nil || p.Writes.Version == nil {
+				t.Fatal("hooks permission declares no version gate")
+			}
+			return p.Writes.Version
+		}
+	}
+	t.Fatal("no hooks permission")
+	return nil
+}
+
+// TestHooksGate_BelowFloorSaysWhy pins that a pi older than the declared
+// floor is refused WITH a reason naming both versions.
+func TestHooksGate_BelowFloorSaysWhy(t *testing.T) {
+	gate := hooksVersionGate(t)
+
+	allowed, why := gate.Permits("0.82.1")
+	if allowed {
+		t.Fatal("gate permits installing into pi 0.82.1, below the declared floor")
+	}
+	if !strings.Contains(why, "0.82.1") || !strings.Contains(why, minPiVersion) {
+		t.Errorf("refusal %q names neither the installed version nor the required one; "+
+			"the reason has to tell the user what to upgrade", why)
+	}
+}
+
+// TestHooksGate_AtOrAboveFloorInstalls is a LOCK: it pins that the gate has
+// not become a blanket refusal, which from a log looks identical to one that
+// works.
+func TestHooksGate_AtOrAboveFloorInstalls(t *testing.T) {
+	gate := hooksVersionGate(t)
+	for _, v := range []string{minPiVersion, "0.84.2", "1.0.0"} {
+		if allowed, why := gate.Permits(v); !allowed {
+			t.Errorf("gate refuses pi %s, at or above the %s floor: %s", v, minPiVersion, why)
+		}
+	}
+}
+
+// TestHooksGate_UnknownVersionFailsOpen pins the documented direction
+// (core/pkg/cliversion): an unparseable or unknown version must not block an
+// install. The daemon runs under launchd with a minimal PATH and routinely
+// cannot see the user's CLI at all — pi in particular is usually an nvm-
+// managed shim outside that PATH — so "unknown" must read as "not proven
+// old", not as "assume the worst".
+func TestHooksGate_UnknownVersionFailsOpen(t *testing.T) {
+	gate := hooksVersionGate(t)
+	if allowed, why := gate.Permits(""); !allowed {
+		t.Errorf("gate refuses on an unknown version: %s", why)
+	}
+}
+
+// TestHooksGate_ProbeIsPiVersion pins the argv this adapter asks cliversion
+// to run — `pi --version` prints a bare "0.83.0" (live-run against the
+// installed CLI during this issue's audit).
+func TestHooksGate_ProbeIsPiVersion(t *testing.T) {
+	gate := hooksVersionGate(t)
+	want := []string{"pi", "--version"}
+	if len(gate.Probe) != len(want) {
+		t.Fatalf("Probe = %v, want %v", gate.Probe, want)
+	}
+	for i := range want {
+		if gate.Probe[i] != want[i] {
+			t.Fatalf("Probe = %v, want %v", gate.Probe, want)
+		}
+	}
+}

--- a/core/adapters/inbound/agents/pi/hookversion_test.go
+++ b/core/adapters/inbound/agents/pi/hookversion_test.go
@@ -8,7 +8,6 @@
 package pi
 
 import (
-	"strings"
 	"testing"
 
 	"irrlicht/core/domain/agent"
@@ -40,45 +39,37 @@ func hooksVersionGate(t *testing.T) *agent.VersionGate {
 	return nil
 }
 
-// TestHooksGate_BelowFloorSaysWhy pins that a pi older than the declared
-// floor is refused WITH a reason naming both versions.
-func TestHooksGate_BelowFloorSaysWhy(t *testing.T) {
-	gate := hooksVersionGate(t)
-
-	allowed, why := gate.Permits("0.82.1")
-	if allowed {
-		t.Fatal("gate permits installing into pi 0.82.1, below the declared floor")
-	}
-	if !strings.Contains(why, "0.82.1") || !strings.Contains(why, minPiVersion) {
-		t.Errorf("refusal %q names neither the installed version nor the required one; "+
-			"the reason has to tell the user what to upgrade", why)
-	}
-}
-
-// TestHooksGate_AtOrAboveFloorInstalls is a LOCK: it pins that the gate has
-// not become a blanket refusal, which from a log looks identical to one that
-// works.
-func TestHooksGate_AtOrAboveFloorInstalls(t *testing.T) {
-	gate := hooksVersionGate(t)
-	for _, v := range []string{minPiVersion, "0.84.2", "1.0.0"} {
-		if allowed, why := gate.Permits(v); !allowed {
-			t.Errorf("gate refuses pi %s, at or above the %s floor: %s", v, minPiVersion, why)
-		}
-	}
-}
-
-// TestHooksGate_UnknownVersionFailsOpen pins the documented direction
-// (core/pkg/cliversion): an unparseable or unknown version must not block an
-// install. The daemon runs under launchd with a minimal PATH and routinely
-// cannot see the user's CLI at all — pi in particular is usually an nvm-
-// managed shim outside that PATH — so "unknown" must read as "not proven
-// old", not as "assume the worst".
-func TestHooksGate_UnknownVersionFailsOpen(t *testing.T) {
-	gate := hooksVersionGate(t)
-	if allowed, why := gate.Permits(""); !allowed {
-		t.Errorf("gate refuses on an unknown version: %s", why)
-	}
-}
+// What is deliberately NOT here: BelowFloorSaysWhy, AtOrAboveFloorInstalls
+// and UnknownVersionFailsOpen.
+//
+// Five sibling adapters (claudecode, codex, geminicli, kirocli, vibe) each
+// carry hand-written versions of those three beside their
+// AssertHookVersionGate call, and #1721 added a sixth copy before measuring
+// what the shared contract already asserts. It asserts all three, and more
+// thoroughly than the copies did:
+//
+//   - assertFloorRefusesOlder checks gate.Permits(gate.Min) is ALLOWED (the
+//     at-or-above lock), then refuses THREE field-wise predecessors — major,
+//     minor and patch decremented independently, because a single synthetic
+//     "just below" value exercises only the borrow path — and requires each
+//     refusal's reason to name both versions. The hand-written copy picked
+//     ONE older version by hand.
+//   - It also carries a vacuity guard the copies had no equivalent of: a
+//     floor with nothing below it fails, rather than passing having asserted
+//     only that the gate permits itself.
+//   - assertUnknownFailsOpen drives THREE unreadable spellings ("",
+//     "not a version", "2.1"). The hand-written copy drove one.
+//
+// So the copies were strictly weaker restatements of obligations already
+// running one call above, which is the hand-maintained restatement this
+// repo's own testing philosophy exists to remove. Deleting them here
+// increases coverage rather than reducing it. The same three are redundant
+// in all five siblings; removing them there is a follow-up rather than
+// something a pi ticket should do to five other adapters' test files.
+//
+// TestHooksGate_ProbeIsPiVersion below stays, because it is the one thing
+// the contract does NOT cover: assertVersionSourceDeclared only requires
+// Observed or Probe to be non-empty, never that the argv is the right one.
 
 // TestHooksGate_ProbeIsPiVersion pins the argv this adapter asks cliversion
 // to run — `pi --version` prints a bare "0.83.0" (live-run against the

--- a/core/adapters/inbound/agents/pi/testdata/README.md
+++ b/core/adapters/inbound/agents/pi/testdata/README.md
@@ -1,0 +1,12 @@
+# pi adapter testdata
+
+`real-pi-settings.json` is a VERBATIM copy of a real `~/.pi/agent/settings.json`
+written by pi 0.83.0 itself, captured on 2026-08-22 (issue #1756: an install
+should be graded against a config the agent actually wrote, not one the test
+constructed). Nothing was redacted because nothing in it is a secret — pi keeps
+credentials in a separate `auth.json`, which is deliberately NOT captured here.
+
+Its `packages` array is the load-bearing part: it is what `pi install` writes,
+so this fixture is a home where the OTHER pi extension mechanism is already in
+use. `TestInstallLeavesAPiWrittenSettingsFileUntouched` asserts irrlicht's
+install does not touch it.

--- a/core/adapters/inbound/agents/pi/testdata/real-pi-settings.json
+++ b/core/adapters/inbound/agents/pi/testdata/real-pi-settings.json
@@ -1,0 +1,21 @@
+{
+  "lastChangelogVersion": "0.83.0",
+  "defaultProvider": "openai-codex",
+  "defaultModel": "gpt-5.6-sol",
+  "defaultThinkingLevel": "xhigh",
+  "packages": [
+    "npm:pi-web-access",
+    "npm:@zenobius/pi-worktrees",
+    "npm:pi-browser-harness"
+  ],
+  "compaction": {
+    "enabled": true
+  },
+  "images": {
+    "autoResize": true
+  },
+  "showHardwareCursor": false,
+  "doubleEscapeAction": "tree",
+  "treeFilterMode": "default",
+  "theme": "dark"
+}

--- a/core/cmd/irrlichd/startup.go
+++ b/core/cmd/irrlichd/startup.go
@@ -21,6 +21,7 @@ import (
 	"irrlicht/core/adapters/inbound/agents/copilot"
 	"irrlicht/core/adapters/inbound/agents/geminicli"
 	"irrlicht/core/adapters/inbound/agents/kirocli"
+	"irrlicht/core/adapters/inbound/agents/pi"
 	"irrlicht/core/adapters/inbound/agents/processlifecycle"
 	"irrlicht/core/adapters/inbound/agents/vibe"
 	backchannelhandler "irrlicht/core/adapters/inbound/backchannel"
@@ -941,7 +942,12 @@ func setupBackchannel(mux *http.ServeMux, deps setupBackchannelDeps) (*services.
 // HandleStopHook, which every other receiver already calls too; plus Kiro
 // CLI's postToolUse/stop events (issue #1716), also beacon-delivered
 // (`irrlichd hook-post kiro-cli`) — the detector satisfies kirocli.HookTarget
-// with the same two methods codex's and copilot's receivers call. All are
+// with the same two methods codex's and copilot's receivers call; plus pi's
+// agent_settled event (issue #1721), also beacon-delivered (`irrlichd
+// hook-post pi`) but delivered by a JavaScript extension irrlicht installs
+// into pi's own auto-discovery directory rather than by a config entry —
+// pi has no config-file hook mechanism at all — with the detector
+// satisfying pi.HookTarget's single method, HandleStopHook. All are
 // consent-gated: hooks installed by a pre-consent daemon keep firing until
 // the wizard is answered, so payloads are dropped while pending.
 func registerHookRoutes(mux *http.ServeMux, detector *services.SessionDetector, metricsCollector outbound.MetricsCollector, permService *services.PermissionService, logger outbound.Logger) {
@@ -962,6 +968,8 @@ func registerHookRoutes(mux *http.ServeMux, detector *services.SessionDetector, 
 		vibe.NewHookHandler(detector, permService, logger))
 	mux.Handle("POST "+kirocli.HookEndpointPath,
 		kirocli.NewHookHandler(detector, permService, logger))
+	mux.Handle("POST "+pi.HookEndpointPath,
+		pi.NewHookHandler(detector, permService, logger))
 }
 
 // publishAddrFile writes the addr file and thereby signals "the daemon is

--- a/docs/testing-contracts.md
+++ b/docs/testing-contracts.md
@@ -164,9 +164,15 @@ below.
   JSON-shaped adapter needs no changes, while `vibe`'s hooks.toml — pure
   byte-range edits, never a decoded generic structure, matched by
   `bytes.Contains` rather than a named field — supplies both directly
-  (`vibe/hookport_test.go`).
+  (`vibe/hookport_test.go`). #1721 took that seam one step further out: pi's
+  install is not a document at all but a JavaScript file irrlicht writes into
+  pi's extension directory, so its `ReadEntries` returns the WHOLE FILE as
+  the single entry and `EndpointOfRaw` reads the beacon command back out of
+  it with the same anchored regexp the installer uses to decide staleness.
+  That an adapter with no config document at all fits the seam unchanged is
+  the strongest evidence #1734 generalised it far enough.
   Real adapters now exercise every route and entry shape this family grades —
-  `DeliveryAddressFree` (geminicli, kirocli, vibe), the flat `EntriesOf` shape
+  `DeliveryAddressFree` (geminicli, kirocli, vibe, pi), the flat `EntriesOf` shape
   kiro-cli's schema needs (#1716), and the raw-bytes TOML shape vibe's
   `hooktoml` needs (#1718) — but none of the three reference-wiring fixtures
   those adoptions were supposed to retire has been touched since. All three

--- a/replaydata/agents/pi/driver-interactive.sh
+++ b/replaydata/agents/pi/driver-interactive.sh
@@ -182,7 +182,32 @@ boot_session() {
   : > "$slot_stdout"
   mkdir -p "$cwd"
   tmux kill-session -t "$sess" 2>/dev/null || true
-  tmux new-session -d -s "$sess" -c "$cwd" "$@"
+  # The pane's command is spawned by the tmux SERVER, whose environment was
+  # fixed when that server started — on a dev machine, long before this
+  # recording. Anything run-cell.sh exported reaches the DAEMON (a direct
+  # child) and not this pane, so both variables are re-applied here, per pane.
+  #
+  # PI_CODING_AGENT_DIR is the isolation half: agent-home.sh's pi row points it
+  # at a staging directory, and without this prefix pi would write its sessions
+  # into the operator's real ~/.pi/agent while the recording daemon watched the
+  # staging tree.
+  #
+  # IRRLICHT_BIND_ADDR is the beacon half (#1721). pi's hooks are delivered by
+  # the JavaScript extension irrlicht installs, which spawns
+  # `irrlichd hook-post pi`; that beacon carries no address at all and resolves
+  # one at FIRE time from its own environment — IRRLICHT_BIND_ADDR first, then
+  # the addr file under IRRLICHT_HOME (core/pkg/daemonaddr resolveClient). The
+  # beacon is a descendant of this pane, so a pane carrying neither variable
+  # reads the PRODUCTION addr file and posts every hook to the daemon on 7837.
+  # The recording then comes back complete, healthy and hook-free, with nothing
+  # anywhere saying why — the exact failure #1735 measured for mistral-vibe.
+  #
+  # Empty is the same as unset for both readers (pi's getAgentDir tests the
+  # value for truthiness; resolveClient's fixedPortOf("") does not match), so
+  # passing them unconditionally is safe when the rig set neither.
+  tmux new-session -d -s "$sess" -c "$cwd" \
+    env "PI_CODING_AGENT_DIR=${PI_CODING_AGENT_DIR:-}" \
+        "IRRLICHT_BIND_ADDR=${IRRLICHT_BIND_ADDR:-}" "$@"
   tmux pipe-pane -t "$sess" -o "cat >> '$slot_stdout'"
   echo "[driver] tmux started: $sess (slot=$ACTIVE, cwd=$cwd, argv: $*)" >&2
 

--- a/tools/onboarding-factory/internal/hookcov/hookcov_test.go
+++ b/tools/onboarding-factory/internal/hookcov/hookcov_test.go
@@ -18,22 +18,24 @@ func TestDeclaredMatchesRegistry(t *testing.T) {
 	got := Declared()
 
 	// Exhaustive as of this commit: claudecode, codex, copilot, gemini-cli,
-	// kiro-cli and mistral-vibe are the adapters declaring a hooks
-	// permission. If a seventh gains one, this fails and the new adapter
+	// kiro-cli, mistral-vibe and pi are the adapters declaring a hooks
+	// permission. If an eighth gains one, this fails and the new adapter
 	// joins the list — that is the intended workflow, not an obstacle.
 	//
-	// copilot joined in #1378, gemini-cli in #1717, kiro-cli in #1716 and
-	// mistral-vibe in #1718 — all four are expected to report StatusGap for a
-	// while: each declares hooks, but no recording carries a hook_received
+	// copilot joined in #1378, gemini-cli in #1717, kiro-cli in #1716,
+	// mistral-vibe in #1718 and pi in #1721 — all five are expected to report
+	// StatusGap for a while: each declares hooks, but no recording carries a hook_received
 	// event yet, because landing the permission deliberately re-recorded
 	// nothing (the frozen sidecars are hook-free and the replay goldens had
 	// to stay byte-identical — #1717's own audit measured 0 cells
 	// re-recorded, and #1716's/#1718's Phase 2 is plan-only for the same
-	// reason). A GAP here is the honest reading of that, not a defect.
+	// reason; #1721 re-recorded nothing either, and its own audit reports the
+	// rig gaps that would have to close first). A GAP here is the honest
+	// reading of that, not a defect.
 	want := map[string]bool{
 		"aider": false, "antigravity": false, "claudecode": true, "codex": true,
 		"copilot": true, "gemini-cli": true, "hermes": false, "kiro-cli": true,
-		"mistral-vibe": true, "opencode": false, "pi": false,
+		"mistral-vibe": true, "opencode": false, "pi": true,
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("Declared() = %v\nwant %v", got, want)

--- a/tools/onboarding-factory/scripts/lib/agent-home.sh
+++ b/tools/onboarding-factory/scripts/lib/agent-home.sh
@@ -123,6 +123,18 @@
 #                  refusal surfaces only in unapplied_grants. Collapsing every
 #                  multi-line array onto one line in the SEED is what unblocked
 #                  the recording. That is a workaround, not a fix.
+#     pi           CREDENTIALS, the same rule codex's row states. pi resolves
+#                  every agent-dir path from getAgentDir()
+#                  (dist/config.js) — sessions/, settings.json, extensions/
+#                  AND auth.json — so PI_CODING_AGENT_DIR relocates the store,
+#                  the hook install and the credentials together. That
+#                  togetherness is what makes the row honest where claudecode's
+#                  would not be (see below): irrlicht's own pi install writes
+#                  ~/.pi/agent/extensions/irrlicht.js, resolved through the
+#                  SAME override (pi/hookinstaller.go's piAgentDir), so an
+#                  isolated home isolates the extension too. It also means an
+#                  isolated home starts with no auth.json, hence optin rather
+#                  than default.
 #     kiro-cli     PERSISTED TRUST-ALL CONSENT — and note this is the one row
 #                  where the credential rule says "safe to default" and the
 #                  answer is still no. kiro-cli's token is at
@@ -173,6 +185,7 @@ copilot COPILOT_HOME default
 codex CODEX_HOME optin
 kiro-cli KIRO_HOME optin
 mistral-vibe VIBE_HOME optin
+pi PI_CODING_AGENT_DIR optin
 TABLE
   return 0
 }


### PR DESCRIPTION
Closes #1721. Part of #1355.

pi moves off epic #1355's "permanent tier-5" verdict. It gets an authoritative turn-end
signal, delivered by a **JavaScript extension irrlicht installs** into pi's own
auto-discovery directory — the first adapter whose install is code rather than a config
entry.

## The audit, and why the answer is "build it" where opencode's was "don't"

Everything below is measured against the installed package
(`@earendil-works/pi-coding-agent` **0.83.0**, `$(npm root -g)/@earendil-works/…`), reading
`dist/` source rather than rendered docs, plus live runs against pi 0.83.0 in an isolated
`PI_CODING_AGENT_DIR`.

**pi has no config-file hook mechanism.** `hook` does not appear in `docs/settings.md`;
`settings.json` has no hooks key. The only lifecycle surface is `pi.on(...)` inside an
extension module. So the choice was not "config vs. code" — it was "code, or leave pi at
tier 5".

**But `pi install` is not the route, and that is the whole finding.** #1721 was written
around `pi install ./local/path`, which writes a `packages`/`extensions` entry into
`settings.json` — a distribution problem. There is a *second*, independent mechanism:
`dist/core/extensions/loader.js`'s `discoverAndLoadExtensions` globs
`<agentDir>/extensions/` directly, gated by `isExtensionFile`, which matches **`.ts` OR
`.js`**. Writing one file there is the entire install.

That is what separates pi from opencode (#1719):

| | opencode (#1719, cut) | pi (this PR) |
|---|---|---|
| distribution | publish/ship an npm plugin package | one file, embedded in the irrlichd binary via `go:embed` |
| registry / network | yes | none |
| dependencies | a graph | one `node:child_process` import |
| build step / toolchain | yes | none (`.js`, and pi loads through jiti anyway) |
| agent config touched | `settings.json` | nothing |
| uninstall | `pi remove` + settings edit | `os.Remove` of one file |

**Blast radius is bounded by pi itself**, source-read: `loader.js` wraps the whole load in
`try/catch` and reports a failing extension as a load error while the agent continues, and
`runner.js` wraps every handler dispatch the same way — for every event **except
`tool_call`**, whose loop has no catch and whose handler can return `{block: true}`. So the
shipped file never subscribes to `tool_call`, and a committed guard enforces that.

The honest residue, which the consent copy states rather than this PR body: it is still
code, running in-process in the user's agent with the user's permissions.

### Does pi have a blocked-on-user state? Measured: effectively no.

- No tool-approval prompt — pi has no sandbox (`docs/security.md`).
- **`ask_question` is docs drift.** `grep -rlo '"ask_question"' dist/` → **0 files**, against
  18 for `"bash"` and 14 for `"read"`. #1721's measurement reproduced independently.
- pi *does* have one built-in blocking prompt: the **project trust** prompt, surfaced as the
  `project_trust` event. It is unusable, structurally rather than for want of effort: it
  fires before a session exists and its context is explicitly reduced —
  "cwd, mode, hasUI, and select/confirm/input/notify UI helpers", no `sessionManager`, so no
  transcript path, so nothing to correlate to. The live event walk confirms `session_start`
  is the first event carrying a session file at all.

**pi is therefore a two-state adapter through hooks (working/ready)** — a legitimate,
useful outcome, as #1721 said it would be. `waiting` stays reachable exactly where it
already was: the transcript-tail prose cue.

### Events installed: exactly one

`agent_settled` → `HandleStopHook`. pi's own docs: "Use `agent_settled` for status
integrations that need to know Pi will not continue running automatically" — no retry, no
auto-compaction, no queued follow-up. Semantically Claude Code's `Stop`, and mapped on that
meaning rather than on a wire name.

Deliberately **not** installed, each with its reason in `installedHookEvents`' doc comment:
`tool_call` (blocking, no catch); `tool_execution_start`/`_end` (a broad release is only
useful paired with a narrow assert on the same signal from the same adapter — pi has no
approval prompt to assert on, so it would spawn a beacon per tool call to release a signal
nothing ever holds — vibe's own reasoning for `after_tool`); `session_start`/`turn_*`/`input`
(the transcript already opens the turn).

## Delivery: address-free (beacon)

`DeliveryAddressFree`. The shipped JavaScript spawns `irrlichd hook-post pi` and knows
nothing about hosts or ports; the beacon resolves the daemon's address at fire time. That
keeps the *artifact* minimal, which is the supply-chain argument: no HTTP client, no
addr-file parsing, and nothing in the user's agent that can go stale when the daemon moves.

**Correction to the issue's framing:** #1721 says the beacon is "adopted by nobody… still a
*reference* wiring". That was true at #1373 and is not true now — geminicli (#1717), kirocli
(#1716) and vibe (#1718) all declare `DeliveryAddressFree`, as `docs/testing-contracts.md`'s
delivery bullet already says. pi is the **fourth** adopter. The comments in this PR say so.

## The `HookInstaller` seam, one step further out

vibe (#1734) widened `ReadEntries`/`EndpointOfRaw` for a config that is never a decoded
generic structure. pi's install is not a *document* at all: `ReadEntries` returns the whole
file as the single entry, and `EndpointOfRaw` reads the beacon command back out with the
same anchored regexp the installer uses to decide staleness. It fits unchanged, which is
decent evidence #1734 generalised far enough. `docs/testing-contracts.md` updated.

## Live end-to-end proof

The production renderer + production installer, into an isolated `PI_CODING_AGENT_DIR`, with
a stub `irrlichd` that logs its argv and stdin; driven by real pi 0.83.0 against a **free
local LM Studio model** (no credits spent):

```
--- real pi 0.83.0 turn, isolated HOME, free local model ---
pi exit=0
hello
--- what the stub beacon received ---
ARGV: --version hook-post pi
STDIN: {"hook_event_name":"agent_settled","transcript_path":"/tmp/pi-e2e-35634/home/.pi/agent/sessions/--private-tmp-pi-e2e-35634-work--/2026-08-22T03-59-41-209Z_01a0279f-d499-7ef2-8b44-c042ea23b74f.jsonl"}
--- transcripts pi actually wrote ---
/tmp/pi-e2e-35634/home/.pi/agent/sessions/--private-tmp-pi-e2e-35634-work--/2026-08-22T03-59-41-209Z_01a0279f-d499-7ef2-8b44-c042ea23b74f.jsonl
```

Exactly one delivery per settled turn, exactly the payload `piHookPayload` decodes, naming
the transcript pi actually wrote — whose filename stem is the id the fswatcher keys on.
Nothing under the operator's real `~/.pi` was written at any point.

## Bug fixed along the way: irrlicht ignored `PI_CODING_AGENT_DIR`

pi composes its sessions dir as `getAgentDir() + "/sessions"`, and `getAgentDir` honours
`$PI_CODING_AGENT_DIR` — the documented way to relocate a whole pi installation, and the one
this audit used. irrlicht read only `$PI_CODING_AGENT_SESSION_DIR`, so a user who relocated
pi that way had their sessions moved out from under a watcher still pointed at
`~/.pi/agent/sessions`. It matters more now: the hook receiver confines caller-supplied paths
to that root, so a wrong root *rejects every hook* rather than merely missing transcripts.

## Mutation evidence — every guard seen red

One mutation per run, applied and reverted; `git status --porcelain` checked each time.

<details><summary><b>1. `sessionsDir` ignores <code>PI_CODING_AGENT_DIR</code> (the pre-#1721 code)</b> — the defect test</summary>

```
--- FAIL: TestSessionsDirFollowsPiCodingAgentDir (0.00s)
    adapter_test.go:49: sessionsDir() = ".pi/agent/sessions", want "/tmp/pi-relocated/agent/sessions"
```
</details>

<details><summary><b>2. shipped extension subscribes to pi's blocking <code>tool_call</code></b></summary>

```
--- FAIL: TestShippedExtensionSubscribesToNoBlockingEvent (0.00s)
    extension_test.go:62: extension.js references pi's "tool_call" event, which can block, cancel, replace or rewrite what the agent is doing. A monitoring extension must only observe.
--- FAIL: TestShippedExtensionSubscribesExactlyToInstalledHookEvents (0.00s)
    extension_test.go:103: extension.js subscribes to [agent_settled tool_call], installedHookEvents declares [agent_settled] — the consent copy, the version floor and every contract family are written against the second list
```
</details>

<details><summary><b>3. JS subscribes to <code>turn_end</code> while Go still declares <code>agent_settled</code></b></summary>

```
--- FAIL: TestShippedExtensionSubscribesExactlyToInstalledHookEvents (0.00s)
    extension_test.go:103: extension.js subscribes to [turn_end], installedHookEvents declares [agent_settled] — the consent copy, the version floor and every contract family are written against the second list
```
</details>

<details><summary><b>4. Go renames the json tag the shipped JS sends</b> — the one only this guard catches</summary>

```
--- FAIL: TestShippedExtensionPayloadMatchesTheReceiversFields (0.00s)
    extension_test.go:148: extension.js sends [hook_event_name transcript_path], piHookPayload decodes [hook_event_name path] — a field on either side that the other does not have is a silently dropped hook

--- and every contract family stays GREEN, which is why the guard exists ---
ok  	irrlicht/core/adapters/inbound/agents/pi	0.206s
```

Every contract family builds its body by marshaling `piHookPayload` itself, so they rename in
lockstep and stay green while production delivery is broken.
</details>

<details><summary><b>5. shipped extension acquires a node_modules dependency</b></summary>

```
--- FAIL: TestShippedExtensionImportsOnlyNodeBuiltins (0.00s)
    extension_test.go:166: extension.js imports "node-fetch" — only node: builtins may be imported, or this install acquires a dependency graph
```
</details>

<details><summary><b>6. <code>renderExtension</code> concatenates the command instead of <code>strconv.Quote</code>ing it</b></summary>

```
--- FAIL: TestRenderedExtensionSurvivesAHostilePath (0.00s)
    extension_test.go:228: path "/tmp/irr\"licht/irrlichd": round-trip failed (ok=false, got "", want "'/tmp/irr\"licht/irrlichd' --version hook-post pi >/dev/null || true")
    extension_test.go:240: path "/tmp/irr\"licht/irrlichd": the rendered literal is not a valid string literal: invalid character 'l' after top-level value
    extension_test.go:228: path "/tmp/irr\\licht/irrlichd": round-trip failed (ok=false, got "", want "'/tmp/irr\\licht/irrlichd' --version hook-post pi >/dev/null || true")
    extension_test.go:240: path "/tmp/irr\\licht/irrlichd": the rendered literal is not a valid string literal: invalid character 'l' in string escape code
    extension_test.go:228: path "/tmp/irr\nlicht/irrlichd": round-trip failed (ok=false, got "", want "'/tmp/irr\nlicht/irrlichd' --version hook-post pi >/dev/null || true")
    extension_test.go:232: no beacon assignment line in the rendered extension
```
</details>

<details><summary><b>7. install overwrites a file irrlicht did not write</b></summary>

```
--- FAIL: TestEnsureInstalled_RefusesToOverwriteAFileItDidNotWrite (0.00s)
    hookinstaller_test.go:147: EnsureHooksInstalled overwrote a foreign file without complaint
```
</details>

<details><summary><b>8. uninstall deletes any file at our path <i>and</i> install also touches pi's <code>settings.json</code></b> — two mutations in one run (deviation, noted)</summary>

```
--- FAIL: TestUninstall_RemovesOursAndLeavesForeignAlone (0.00s)
    hookinstaller_test.go:193: uninstall over a foreign file = (true, <nil>), want (false, nil)
    hookinstaller_test.go:197: uninstall removed or altered a file it did not write
--- FAIL: TestInstallLeavesAPiWrittenSettingsFileUntouched (0.00s)
    hookinstaller_test.go:335: install changed .pi/agent/settings.json, which is not the file it declares it writes
    hookinstaller_test.go:358: after uninstall .pi/agent/settings.json no longer matches what pi wrote
```

The house rule is one mutation per run; these two landed in the same call. Both went red on
their own assertion, so the evidence is readable, but the deviation is stated rather than
smoothed over.
</details>

<details><summary><b>9. adapter declares the WRONG delivery route (<code>DeliveryURL</code>)</b></summary>

```
--- FAIL: TestHookEndpointFollowsBindAddr/endpoint_follows_bind_addr (0.00s)
    hook_endpoint.go:263: delivery is identical on the default and 127.0.0.1:7838 bind addresses ("'…/pi.test' --version hook-post pi >/dev/null || true") — the endpoint does not follow IRRLICHT_BIND_ADDR
--- FAIL: TestHookEndpointFollowsBindAddr/install_writes_resolved_port (0.00s)
    hook_endpoint.go:265: event agent_settled: "'…/pi.test' --version hook-post pi >/dev/null || true" does not carry the resolved port ":7838/"
--- FAIL: TestHookEndpointFollowsBindAddr/default_port_install_upgraded_in_place (0.00s)
    hook_endpoint.go:267: expected modified=true when repointing a default-port install …
```
</details>

<details><summary><b>10. <code>Verify</code> never reports a stale install</b></summary>

```
--- FAIL: TestVerifyAgreesWithEnsureInstalled/ours_but_naming_another_binary (0.00s)
    hookinstaller_test.go:255: verify reported outstanding=false (missing=[] stale=[]), want true
    hookinstaller_test.go:264: verify says outstanding=false but ensure modified=true — the two readers of the same file disagree
```
</details>

<details><summary><b>11. receiver drops its own <code>transcripts</code> consent check</b> — only the silence assertion survives #1488</summary>

```
--- FAIL: TestHookReceiver_DeniedTranscriptsConsentDropsQuietly (0.00s)
    hooks_test.go:278: a transcripts-denied hook logged 1 error(s): [hook body dropped: permission "transcripts" is not granted at the decode — either this receiver skipped the check it declares, or consent was revoked mid-request (issue #1488)]
```

`TestHookReceiver_PermissionGateContract` stayed **green**, exactly as
`docs/testing-contracts.md` documents: the #1488 backstop absorbs the dispatch, so silence is
the surviving discriminator.
</details>

Three registry tripwires also fired unprompted and were fixed rather than worked around —
`TestEveryHookInstallWiresItsContractFamilies` (pi did not wire `AssertPermissionGated`, and
the exclusion's premise re-check caught it), `TestEveryBeaconAdapterDriverPassesTheDaemonAddress`,
`TestRigHomeTableMatchesTheAdapterRegistry`. They worked.

## #1756: graded against a config pi itself wrote

`testdata/real-pi-settings.json` is a verbatim `~/.pi/agent/settings.json` from pi 0.83.0
(nothing redacted — nothing in it is a secret; pi keeps credentials in a separate
`auth.json`, deliberately not captured). Its `packages` array is what `pi install` writes, so
the fixture is a home where pi's *other* extension mechanism is already in use.
`TestInstallLeavesAPiWrittenSettingsFileUntouched` snapshots the **whole tree** before and
after — not just the file someone remembered to look at — installs, diffs, then uninstalls
and asserts the tree is byte-identical to what pi wrote.

## Recording: none, and what one would need

**Zero cells re-recorded** (#1355 Phase D's kill criterion is >5). Every existing pi golden is
byte-identical; `tools/replay-fixtures.sh` passes unchanged. Landing this deliberately records
nothing, so hookcov will report pi as `StatusGap` — the honest reading, same as #1716/#1717/#1718.

A recording would now need: `PI_CODING_AGENT_DIR` staging with a seeded `auth.json` (optin,
because pi keeps credentials under the same override), and `IRRLICHT_BIND_ADDR` reaching the
tmux pane — **both are in this PR**, so the rig gap #1735 measured for mistral-vibe is closed
for pi before the first recording rather than after it. #1754's remaining rig gaps are
untouched.

## Not covered

- **Nothing here executes the JavaScript.** Running it needs node (which `go test ./core/...`
  does not otherwise require — a gate that could be absent is the failure mode
  `docs/testing-philosophy.md` is about) or pi itself (which needs a model call). The
  end-to-end proof above was run by hand; the committed guards pin the properties it
  confirmed. Stated in `extension_test.go`'s header, not left implied.
- **The waiting cue is a payload-free floor.** `agent_settled` carries no message content and
  the extension deliberately does not go reading `ctx.sessionManager` for one — every extra
  line is code shipped into a user's agent. Same trade vibe made; it can never *clear* a cue
  the transcript found.
- **A pi version newer than the daemon** could ship an extension subscribing to a second
  event; that lands in `IgnoreUnknownEvent`'s counter rather than silently.
- `TestReadLauncherEnv_Tmux_DetachedResolvesNoHost` (processlifecycle) flaked once in a full-
  suite run and passes in isolation — pre-existing, unrelated.

## Gates

`go test ./core/... -race -count=1` clean; `tools/preflight.sh --only go` / `--only arch` /
`--only bash` all PASS (ARS composite 7.9179 → 7.9157, not a regression); `of validate` OK;
rig smoke test PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# SonarCloud: 13.2% duplication on new code — what it is, and why most of it must stay

`Failed conditions: 13.2% Duplication on New Code (required ≤ 3%)`.

Measured per file and per block, not guessed:

```
tools/sonarqube-report.sh "measures/component_tree?component=ingo-eichhorst_Irrlicht\
&pullRequest=1758&metricKeys=new_duplicated_lines,new_lines&qualifiers=FIL&ps=100"
tools/sonarqube-report.sh "duplications/show?key=<component>&pullRequest=1758"   # per file
```

| file | dup lines | new lines | dup % |
|---|---:|---:|---:|
| `pi/hooks_test.go` | 106 | 281 | 37.7% |
| `pi/hooks.go` | 68 | 227 | 30.0% |
| `pi/hookversion_test.go` | 42 | 98 | 42.9% |
| `pi/hookinstaller.go` | 30 | 424 | 7.1% |
| `pi/hookinstaller_test.go` | 26 | 391 | 6.6% |
| `pi/hookpath_test.go` | 18 | 39 | 46.2% |
| `pi/agent.go` | 15 | 62 | 24.2% |
| everything else (13 files) | 0 | | 0% |
| **total** | **305** | **2317** | **13.2%** |

**The single most important fact: not one duplicated block has a partner inside this PR.**
Every partner is another adapter — `vibe/hooks.go`, `codex/hookinstaller.go`,
`kirocli/hookversion_test.go`, and so on. There is no copy-paste *within* pi to remove. What
the metric is measuring is that a seventh hook adapter looks like the other six, which is what
`docs/testing-contracts.md` asks for: an adapter "wires one call **instead of porting a test
file**".

## Real, and fixed

**`hookversion_test.go` — three hand-written tests the shared contract already asserts, more
thoroughly than they did.** Found by being made to look at the number, and it is a genuine
defect in the *design* of five other adapters too. `AssertHookVersionGate` runs
`floor_refuses_an_older_cli` and `unknown_version_fails_open` as sub-tests. My
`TestHooksGate_BelowFloorSaysWhy` / `AtOrAboveFloorInstalls` / `UnknownVersionFailsOpen` were
strictly weaker restatements running one call below them:

| | shared contract | the copy I had added |
|---|---|---|
| versions below the floor | **three** field-wise predecessors (major, minor, patch decremented independently — a single synthetic "just below" exercises only the borrow path) | one hand-picked `0.82.1` |
| refusal reason | non-empty **and** names both versions | contains both versions |
| at-or-above the floor | `Permits(Min)` must be allowed, **plus a vacuity guard**: a floor with nothing below it fails outright | `Permits(Min)` allowed |
| unreadable version | **three** spellings (`""`, `"not a version"`, `"2.1"`) | one (`""`) |

Deleted (40 lines), with the reasoning left in the file rather than only here. Coverage went
**up**: the five contract arms still run and now nothing restates them. Proven by mutation
rather than asserted — weakening the floor to a version with nothing below it, the exact case
the deleted `AtOrAboveFloorInstalls` would have passed:

```
--- FAIL: TestHooksPermission_DeclaresVersionGate/floor_covers_every_installed_event
    hook_version.go:59: declared floor 0.0.0 is below 0.80.4, the version "agent_settled" is known at …
--- FAIL: TestHooksPermission_DeclaresVersionGate/floor_refuses_an_older_cli
    hook_version.go:62: declared floor 0.0.0 has no version below it, so this obligation asserts
        nothing — a floor of 0.0.0 permits every CLI and is not a gate
```

`TestHooksGate_ProbeIsPiVersion` **stays**: it is the one thing the contract does not cover —
`assertVersionSourceDeclared` only requires `Observed` or `Probe` to be non-empty, never that
the argv is the right one.

The same three are redundant in claudecode, codex, geminicli, kirocli and vibe. Removing them
there is a follow-up, not something a pi ticket should do to five other adapters' test files.

## Real, but extracting it here would not help — measured, not assumed

**`atomicWriteFile` (30 lines) exists in seven places**: claudecode, codex, copilot,
geminicli, kirocli, processlifecycle and now pi. That is textbook shared-helper boilerplate
and it genuinely wants a home in `core/pkg/`.

It is not done here, for a reason this report itself provides. The duplication data shows
`pi/hookinstaller.go:L401-423` already matching **`hookjson`'s sibling
`hooktoml/hooktoml.go:L879`** — a shared-package file. So moving this code into a shared
package while six copies remain does not remove a duplicate; it adds a seventh partner, and
the metric would be unchanged. The fix has to migrate all seven at once, which is a tree-wide
refactor touching six adapters unrelated to pi. Worth doing; not in a pi PR, and it could not
change this gate's outcome either way (30 of 305 lines).

## Intended, and collapsing it would be worse

Named block by block, so a reader can check rather than take my word.

**`hooks.go` L107-174 ↔ every other receiver.** `NewHookHandler` + `transcriptConfiner` +
`serveHookRequest`'s method check → hooks gate → `ObserveHookReceipt` → transcripts gate →
`DecodeConfined`. The shared parts are *already* extracted — that is what `hookjson` is. What
remains is the **call sequence**, and its order is the thing four contract families grade.
`docs/testing-contracts.md` records which mutation reddens which obligation, including that
hoisting the receipt above the hooks gate reddens
`consent_denied_request_is_not_counted`. Extracting the sequence into a shared function would
mean the receiver no longer *contains* the checks the contracts grade: the contract would
grade the helper once, and a receiver that skipped it would be invisible — the thing under
test and the thing testing it on the same side. #1488 already moved as much of this into a
chokepoint as is safe, and its own note records the cost: the backstop quietened every
dispatch-shaped consent assertion, leaving *silence* as the only discriminator. Mutation 11
above reproduces exactly that.

**`hookpath_test.go` L16-33 ↔ `vibe/hookpath_test.go`.** The file is 39 lines and 18 of them
are the single `AssertHookPathConfined` call. This is the design working. The alternative —
the state before #1361 — is a receiver nobody wired the family for, which is how the
statusline endpoint shipped unconfined.

**`hooks_test.go` L115-138 / L120-138 / L184-209 ↔ vibe, copilot, geminicli, kirocli.** The
`AssertHookReceiverPermissionGated` wiring closure, and the hand-written
denied-consent-logs-no-error test. The latter is hand-written **per receiver on purpose**:
AGENTS.md records that since #1488 "each of the four receivers' hand-written consent tests now
asserts no error was logged, and each was seen red again with its gate deleted". Sharing it
would delete the only per-adapter proof that survives the backstop.

**`hooks_test.go` L3-58 ↔ `vibe/hooks_test.go`.** The test doubles: `mockTarget`, `keyedGate`,
`mockLogger`. `keyedGate` staying local is explicit repo policy — AGENTS.md: "The static
`keyedGate` map literals in the adapter test packages are a different thing and **stay**: they
pin a fixed two-permission combination in one-off tests and were never key-blind."
`mockLogger` (5 lines) has a shared equivalent in `contracttesting.RecordingLogger`, but
swapping only pi's would make one of six adapters spell it differently for 5 lines; that is a
tree-wide consolidation or nothing.

**`hookinstaller_test.go` L36-61 ↔ four adapters.** The install-type `AssertPermissionGated`
wiring — required by `TestEveryHookInstallWiresItsContractFamilies`, which failed this PR
until it was added.

**`agent.go` L34-64 / L49-75 ↔ kirocli, codex.** The `agent.Agent` registration literal. It is
a declaration; two adapters declaring the same *shape* with different values is what a registry
looks like.

## The gate cannot be met, and here is the arithmetic

**Measured after the fix, not estimated** — SonarCloud re-scanned commit `5f94a54`:

```
qualitygates/project_status?projectKey=…&pullRequest=1758
  new_duplicated_lines_density: 12.7 (required GT 3)
```

| file | dup lines (before → after) |
|---|---|
| `pi/hooks_test.go` | 106 → 106 |
| `pi/hooks.go` | 68 → 68 |
| `pi/hookinstaller.go` | 30 → 30 |
| `pi/hookinstaller_test.go` | 26 → 26 |
| `pi/hookpath_test.go` | 18 → 18 |
| `pi/agent.go` | 15 → 15 |
| `pi/hookversion_test.go` | **42 → 31** |
| **density** | **13.2% → 12.7%** |

I predicted ~11.5% in an earlier draft of this section and was wrong; the real move was
0.5pp, not 1.7pp. Correcting it rather than leaving the estimate, because a figure nothing
produces is the drift this repo's own philosophy is about. The reason the deletion moved so
little is worth stating: what remains in `hookversion_test.go` is `L10-40 ↔
claudecode:L3, kirocli:L13, geminicli:L14` — the imports, the `AssertHookVersionGate` call
itself, and the `hooksVersionGate` helper that reads the gate off the real registration. That
is the *contract wiring*, i.e. the intended category. The redundant restatements are gone;
what is left is the one call the docs tell you to write.

That is also the strongest argument in this section. A genuine, coverage-increasing fix moved
the number by half a point, because the mass is structural. Reaching 3% would mean eliminating
roughly **225 of the remaining 294 lines**: the receiver sequence, the test doubles, and every
contract-family wiring. Each is load-bearing for a reason recorded in
`docs/testing-contracts.md`, and collapsing them would trade a metric for the ability of six
contract families to see a seventh adapter.

**So: I am not chasing this one to green.** Recording the reason here, as agreed, rather than
merging over it silently. Reviewers who want to re-derive the split can run the two
`tools/sonarqube-report.sh` calls at the top of this section.

**CodeScene** is also red and advisory. There is no local way to fetch its delta (the
CodeScene GitHub App posts it; this repo has no API token and `/ir:codescene-report` no longer
exists), so I did not read it — stated as an assumption rather than a finding: it is *likely*
reporting the same near-identical-adapter mass, and that is not verified. The deterministic
architecture measure, `ars-gate`, passed with no composite or category regression
(7.9179 → 7.9157).

## Also, in the same pass

`TestReadLauncherEnv_Tmux_DetachedResolvesNoHost` (processlifecycle) fails only under full
`./core/...` load. Characterised rather than waved away: this PR's diff touches **zero files**
in that package (`git diff --stat origin/main...HEAD -- .../processlifecycle/` is empty), and
the test passed 6/6 isolated runs and 3/3 whole-package runs. Load-dependent, pre-existing,
unrelated.

**No pi cells were recorded**, deliberately — `hookcov` reporting `StatusGap` for pi is the
honest outcome and is meant to stay visible.
