### PR TITLE
feat(opencode): observe opencode through a plugin irrlicht installs, not a config entry (#1719)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,7 +98,7 @@ Before marking a ticket done, run the full suite — every layer must pass:
   under `t.TempDir()`, so it never touches the production daemon). Also runs
   `core/architecture_test.go` (hexagonal import-direction, statically
   enforced) and `core/architecture_hookbody_test.go` (which inbound hook
-  body reads are confined to `hookjson.DecodeConfined`).
+  body reads are confined to `hookjson`'s single decode).
 - Architecture score (advisory, not a merge gate): `tools/ars-gate.sh` /
   `tools/preflight.sh`'s `arch` gate — flags a regression in the Agent
   Readiness Score (composite or any category) vs `origin/main`.

--- a/core/adapters/inbound/agents/beaconroute_test.go
+++ b/core/adapters/inbound/agents/beaconroute_test.go
@@ -8,6 +8,7 @@ import (
 	"irrlicht/core/adapters/inbound/agents/copilot"
 	"irrlicht/core/adapters/inbound/agents/geminicli"
 	"irrlicht/core/adapters/inbound/agents/kirocli"
+	"irrlicht/core/adapters/inbound/agents/opencode"
 	"irrlicht/core/adapters/inbound/agents/pi"
 	"irrlicht/core/adapters/inbound/agents/vibe"
 	"irrlicht/core/pkg/hookbeacon"
@@ -28,9 +29,10 @@ import (
 // while its route segment is "claudecode". That is why the map keys below are
 // written out literally rather than derived from the adapter constants.
 //
-// Scope, stated honestly: this pins the receivers that exist (seven as of
-// #1721's pi row, which also added the mistral-vibe row #1718 never wrote —
-// exactly the omission the paragraph below predicts). It cannot fail for a NEW receiver registered at a
+// Scope, stated honestly: this pins the receivers that exist (eight as of
+// #1719's opencode row; #1721's pi row also added the mistral-vibe row #1718
+// never wrote — exactly the omission the paragraph below predicts, and the
+// whole of issue #1759). It cannot fail for a NEW receiver registered at a
 // different prefix, because registerHookRoutes (core/cmd/irrlichd/startup.go)
 // is hand-wired with no registry to enumerate and this map is hand-written.
 // Whoever adds the next receiver adds its row here; until then the
@@ -45,6 +47,7 @@ func TestBeaconEndpointPathMatchesTheInstalledReceivers(t *testing.T) {
 		// mistral-vibe was beacon-delivered from the day it shipped (#1718)
 		// but was never added here; found while adding pi's row (#1721).
 		"mistral-vibe": vibe.HookEndpointPath,
+		"opencode":     opencode.HookEndpointPath,
 		"pi":           pi.HookEndpointPath,
 	} {
 		if got := hookbeacon.EndpointPath(segment); got != want {

--- a/core/adapters/inbound/agents/hookjson/decode.go
+++ b/core/adapters/inbound/agents/hookjson/decode.go
@@ -102,6 +102,120 @@ func DecodeConfined[T any](
 	get func(*T) string,
 	set func(*T, string),
 ) bool {
+	if !consentAllowsRead(w, log, component, consent) {
+		return false
+	}
+
+	// Fail closed on a receiver wired without a confiner. Returning "not
+	// decoded" drops the payload with a 2xx, the same shape every other refusal
+	// takes, rather than dispatching an unconfined path because the guard
+	// itself was missing.
+	//
+	// Checked AFTER consent and BEFORE the read, so the three refusals keep the
+	// order TestDecodeConfined_RefusesBeforeReadingAnything pins: a denied
+	// request costs no decode, no path resolution and no confiner counter.
+	if c == nil {
+		log.LogError(component, "", "hook body dropped: receiver has no path confiner")
+		w.WriteHeader(http.StatusOK)
+		return false
+	}
+
+	if !readBody(w, r, p) {
+		return false
+	}
+
+	raw := get(p)
+	confined, reason := c.Confine(raw)
+	if reason != RejectNone {
+		RejectPath(w, log, component, raw, reason)
+		return false
+	}
+	set(p, confined)
+
+	// Postcondition: get and set must name the SAME location, or the payload
+	// still holds the caller's raw string while this function reports success.
+	//
+	// This is not defensive clutter — it is the one failure this design could
+	// otherwise not detect, and it was found green by review. Passing behaviour
+	// as two closures puts the obligation at each call site, where no checker
+	// can see it: a receiver whose set writes a field its get never reads (or a
+	// no-op set, which is a one-character edit away) forwards the unconfined
+	// path, and every test in the tree still passes — including
+	// AssertHookPathConfined, which asserts THAT the receiver dispatched, never
+	// WHICH spelling it dispatched. Verifying it here fails closed once, for
+	// every present and future receiver, instead of asking four contract
+	// wirings to each notice.
+	if got := get(p); got != confined {
+		log.LogError(component, "", fmt.Sprintf(
+			"hook body dropped: payload still names %q after confinement to %q — "+
+				"this receiver's get/set pair do not address the same field", got, confined))
+		w.WriteHeader(http.StatusOK)
+		return false
+	}
+	return true
+}
+
+// DecodeSealed decodes an inbound hook body that names NO filesystem path at
+// all, into p.
+//
+// It reports whether the payload survived, on the same terms as DecodeConfined:
+// on false the response has ALREADY been written and the caller must return
+// without dispatching.
+//
+// # Why a second entry point rather than a confiner over an empty string
+//
+// It exists for issue #1719's opencode receiver, whose Source is an
+// agent.ProcessOwnedStore: session state lives in one SQLite database, there is
+// no file per session, and the "transcript path" the daemon keys a session on
+// is a string the daemon COMPOSES from its own store resolver
+// (<db>-wal?session=<id>). There is nothing a caller could name that the daemon
+// would open, so the honest payload carries a session id and stops there.
+//
+// Handing DecodeConfined an empty path instead would not be the same thing. It
+// would answer RejectEmptyPath, drop every hook, and log a confinement refusal
+// for traffic that is behaving correctly — a mechanism reporting a defect it
+// invented. And a confiner over a self-derived path would be worse still: the
+// input is our own resolver's output, not a caller's, so resolution could only
+// fail (a store not yet created, a WAL checkpointed away between events) and
+// each failure would silently drop a legitimate hook to satisfy a guard that
+// was protecting nothing.
+//
+// # What is NOT relaxed
+//
+// Everything on this path except the confinement is identical to
+// DecodeConfined, and deliberately so: the same consent backstop in the same
+// place (#1488), the same 1 MiB bound on an unauthenticated local endpoint, and
+// the same single body-reading function — readBody, which
+// core/architecture_hookbody_test.go pins as the ONE place under
+// core/adapters/inbound/agents/... an inbound body may be read. That rule is
+// what makes this a second ENTRY POINT rather than a second door: a receiver
+// still cannot reach a payload without going through the chokepoint, and a
+// receiver that DOES carry a caller-supplied path still cannot reach it without
+// supplying a confiner.
+//
+// The obligation this shifts rather than removes is "prove nothing
+// caller-supplied travels", and it is graded from outside by
+// contracttesting.AssertHookPathConfined's PathDaemonDerived route: the two
+// routes make contradictory assertions about the same two strings, so a
+// receiver that declares the wrong one cannot pass quietly.
+func DecodeSealed[T any](
+	w http.ResponseWriter,
+	r *http.Request,
+	log outbound.Logger,
+	component string,
+	consent Consent,
+	p *T,
+) bool {
+	if !consentAllowsRead(w, log, component, consent) {
+		return false
+	}
+	return readBody(w, r, p)
+}
+
+// consentAllowsRead is the #1488 backstop both entry points run before the body
+// is touched. It reports whether reading may proceed; on false the response has
+// already been written.
+func consentAllowsRead(w http.ResponseWriter, log outbound.Logger, component string, consent Consent) bool {
 	// Fail closed on a receiver that named no permission. Every hook receiver
 	// acts under at least one (#570), so an empty declaration is a wiring that
 	// went through Consent{} rather than RequireConsent — it cannot be typed
@@ -133,56 +247,25 @@ func DecodeConfined[T any](
 		w.WriteHeader(http.StatusOK)
 		return false
 	}
+	return true
+}
 
-	// Fail closed on a receiver wired without a confiner. Returning "not
-	// decoded" drops the payload with a 2xx, the same shape every other refusal
-	// takes, rather than dispatching an unconfined path because the guard
-	// itself was missing.
-	if c == nil {
-		log.LogError(component, "", "hook body dropped: receiver has no path confiner")
-		w.WriteHeader(http.StatusOK)
-		return false
-	}
-
-	// Bound the body. These endpoints are unauthenticated and local, so an
-	// unbounded decode is a local process's way to make the daemon allocate
-	// without limit. The daemon's other inbound decoders already do this; the
-	// hook receivers now share one decode, so they get it in one place and a
-	// fifth receiver inherits it. 1 MiB is far above any real hook envelope —
-	// the largest field is a truncated last_assistant_message.
+// readBody is the single place an inbound hook body is read.
+//
+// It is unexported and both entry points funnel through it, which is what keeps
+// core/architecture_hookbody_test.go's Arm B — "this package reads a request
+// body in exactly ONE function" — true across #1719's second entry point. A
+// second body-reading function here would be a second way to skip whatever the
+// entry points are enforcing, which is the #1389 hazard restated.
+//
+// The bound is the reason this is not simply inlined twice. These endpoints are
+// unauthenticated and local, so an unbounded decode is a local process's way to
+// make the daemon allocate without limit. 1 MiB is far above any real hook
+// envelope — the largest field is a truncated last_assistant_message.
+func readBody[T any](w http.ResponseWriter, r *http.Request, p *T) bool {
 	r.Body = http.MaxBytesReader(w, r.Body, maxHookBodyBytes)
-
 	if err := json.NewDecoder(r.Body).Decode(p); err != nil {
 		http.Error(w, "bad request: invalid JSON", http.StatusBadRequest)
-		return false
-	}
-
-	raw := get(p)
-	confined, reason := c.Confine(raw)
-	if reason != RejectNone {
-		RejectPath(w, log, component, raw, reason)
-		return false
-	}
-	set(p, confined)
-
-	// Postcondition: get and set must name the SAME location, or the payload
-	// still holds the caller's raw string while this function reports success.
-	//
-	// This is not defensive clutter — it is the one failure this design could
-	// otherwise not detect, and it was found green by review. Passing behaviour
-	// as two closures puts the obligation at each call site, where no checker
-	// can see it: a receiver whose set writes a field its get never reads (or a
-	// no-op set, which is a one-character edit away) forwards the unconfined
-	// path, and every test in the tree still passes — including
-	// AssertHookPathConfined, which asserts THAT the receiver dispatched, never
-	// WHICH spelling it dispatched. Verifying it here fails closed once, for
-	// every present and future receiver, instead of asking four contract
-	// wirings to each notice.
-	if got := get(p); got != confined {
-		log.LogError(component, "", fmt.Sprintf(
-			"hook body dropped: payload still names %q after confinement to %q — "+
-				"this receiver's get/set pair do not address the same field", got, confined))
-		w.WriteHeader(http.StatusOK)
 		return false
 	}
 	return true

--- a/core/adapters/inbound/agents/opencode/adapter.go
+++ b/core/adapters/inbound/agents/opencode/adapter.go
@@ -12,6 +12,12 @@
 // provides role context (user vs. assistant) for state transitions.
 package opencode
 
+import (
+	"log"
+	"os"
+	"path/filepath"
+)
+
 // AdapterName identifies sessions originating from OpenCode.
 const AdapterName = "opencode"
 
@@ -22,3 +28,39 @@ const ProcessName = "opencode"
 // dbRelPath is the path relative to $HOME where OpenCode stores its SQLite
 // database. Follows XDG Base Directory conventions on macOS/Linux.
 const dbRelPath = ".local/share/opencode/opencode.db"
+
+// StorePath is the absolute path of the OpenCode SQLite database the daemon
+// reads — the ONE resolver both the watcher (which tails it) and the hook
+// receiver (which composes a session key from it) go through.
+//
+// A single function rather than two `filepath.Join(home, dbRelPath)` call sites
+// for the same reason pi's Source() is a function: the hook receiver's key and
+// the watcher's key must be the same string or they are two sessions, and a
+// second, independently-written composition is exactly the drift #1361 records.
+//
+// Known limitation, stated rather than left to be discovered: this does NOT
+// honour $XDG_DATA_HOME, which opencode's own Global.Path.data does
+// (`join(process.env.XDG_DATA_HOME || join(homedir(), ".local", "share"),
+// "opencode")`). That gap predates #1719 and is not introduced by it — a user
+// with XDG_DATA_HOME set has never been observed by this adapter at all,
+// because the watcher would find no database. It is stated here because this is
+// now the one place to fix it.
+func StorePath() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		log.Printf("opencode: $HOME not set, using relative path: %v", err)
+	}
+	return filepath.Join(home, dbRelPath)
+}
+
+// transcriptPathFor renders the string every downstream consumer keys an
+// OpenCode session on: the write-ahead log beside the database, with the
+// session id carried in a query parameter (metrics.go's parseTranscriptPath
+// reads it back out).
+//
+// The WAL rather than the database itself is deliberate and predates #1719:
+// isStaleTranscript() stats whatever this names, and OpenCode flushes every
+// write to the WAL while the main file only moves on checkpoint.
+func transcriptPathFor(sessionID string) string {
+	return StorePath() + "-wal" + sessionQueryParam + sessionID
+}

--- a/core/adapters/inbound/agents/opencode/agent.go
+++ b/core/adapters/inbound/agents/opencode/agent.go
@@ -1,6 +1,7 @@
 package opencode
 
 import (
+	"irrlicht/core/adapters/inbound/agents/hookjson"
 	"irrlicht/core/domain/agent"
 	"irrlicht/core/domain/permission"
 	"irrlicht/core/domain/session"
@@ -62,6 +63,53 @@ func Agent() agent.Agent {
 					"~/.local/share/opencode/opencode.db in read-only mode to derive " +
 					"session state, cost, and token metrics. No row is ever written. " +
 					"Toggling off stops all polling immediately.",
+			},
+			{
+				Key:             PermissionKeyHooks,
+				Kind:            permission.KindModify,
+				Title:           "Install status hooks",
+				FeatureUnlocked: "Blocked-on-user detection and authoritative turn-end detection",
+				// "3 hook entries" is what contracttesting's #1356 count arm
+				// reads, and it is the honest number: three event
+				// subscriptions. They live in ONE file, which is the unusual
+				// part, so Touches names the shape in the same breath rather
+				// than leaving it to Detail — the wizard row is what most users
+				// read.
+				Touches: "Writes 3 hook entries to " + displayPluginPath +
+					" — a small JavaScript file that opencode loads and runs",
+				Detail: "opencode has no hooks section in its config: its experimental " +
+					"settings carry no hook key, and the only way to observe its lifecycle " +
+					"is a plugin, so this permission installs one. That is a single " +
+					"JavaScript file at " + displayPluginPath + ", which opencode " +
+					"auto-discovers and executes inside every opencode session with your " +
+					"own permissions. It is code irrlicht ships in its own binary, not a " +
+					"package fetched from anywhere — no npm, no git, no build step — and " +
+					"opencode's own config file is not touched at all. The file imports " +
+					"only node:child_process, subscribes to exactly three opencode events " +
+					"(" + hookjson.EventList(installedHookEvents) + ") and does one thing " +
+					"with each: runs `irrlichd hook-post opencode`, a tiny command " +
+					"irrlicht ships, handing it the session id. That command reads the " +
+					"daemon's own published address at the moment the event fires, so " +
+					"nothing in the file names a host or a port and it cannot go stale; it " +
+					"also never blocks opencode, even when the daemon is not running. The " +
+					"file deliberately registers only opencode's read-only event tap, " +
+					"never a hook that could answer a permission prompt for you or change " +
+					"what opencode does. " +
+					hookjson.RequiresVersion("opencode", minOpenCodeVersion) +
+					" Toggling off deletes the file (also available via " +
+					"`irrlichd --uninstall-hooks`); nothing else in your opencode " +
+					"installation was changed, so there is nothing else to undo.",
+				Apply:  func() error { _, err := EnsureHooksInstalled(); return err },
+				Remove: func() error { _, err := UninstallHooks(); return err },
+				Writes: &agent.ManagedUserFile{
+					Path:      PluginPath,
+					Uninstall: UninstallHooks,
+					Verify:    VerifyHooksInstalled,
+					Version: &agent.VersionGate{
+						Min:   minOpenCodeVersion,
+						Probe: []string{"opencode", "--version"},
+					},
+				},
 			},
 		},
 	}

--- a/core/adapters/inbound/agents/opencode/hookdisclosure_test.go
+++ b/core/adapters/inbound/agents/opencode/hookdisclosure_test.go
@@ -1,0 +1,26 @@
+// hookdisclosure_test.go wires the opencode hooks permission into the shared
+// issue #1356 contract: the consent copy names every event the installer
+// subscribes to, states the right entry count, and names no event it does not
+// install.
+package opencode
+
+import (
+	"testing"
+
+	"irrlicht/core/internal/contracttesting"
+)
+
+func TestHooksPermission_DisclosureMatchesInstalled(t *testing.T) {
+	contracttesting.AssertHookDisclosureMatchesInstalled(t, contracttesting.HookDisclosure{
+		Agent:         Agent(),
+		PermissionKey: PermissionKeyHooks,
+		Installed:     installedHookEvents,
+		// "JavaScript" is a two-hump CamelCase word, so the over-promise arm
+		// reads it as an event-shaped token. It is exempted rather than avoided
+		// because naming the artifact's LANGUAGE is the single most load-bearing
+		// sentence in this permission's copy: what is installed is executable
+		// code rather than a config entry, and the #570 contract is that the
+		// user reads what is actually done.
+		NonEventTerms: []string{"JavaScript"},
+	})
+}

--- a/core/adapters/inbound/agents/opencode/hookinstaller.go
+++ b/core/adapters/inbound/agents/opencode/hookinstaller.go
@@ -1,0 +1,470 @@
+// hookinstaller.go installs irrlicht's opencode plugin — the ONE file this
+// adapter writes into a user's opencode installation (issue #1719, epic
+// #1355).
+//
+// # The epic's verdict, and what the source actually says
+//
+// Epic #1355 cut opencode with the verdict that "a shipped TS plugin is the
+// only route: a distribution and supply-chain problem (npm package? vendored
+// file?), not a config write". Half of that survives contact with the
+// installed package and half does not. Measured against opencode 1.14.50 — the
+// bun-compiled binary at ~/.opencode/bin/opencode, read out of the bundle it
+// carries, not out of rendered docs:
+//
+//   - **The config-file route really is closed.** The `experimental` struct in
+//     the live config schema carries exactly six keys —
+//     disable_paste_summary, batch_tool, openTelemetry, primary_tools,
+//     continue_loop_on_deny, mcp_timeout — and no `hook`. That half of #1719
+//     is confirmed.
+//
+//   - **The distribution problem does not exist.** opencode auto-discovers
+//     plugins with a plain directory glob:
+//     `ConfigPlugin.load(dir)` is `for (const f of await Glob.scan(
+//     "{plugin,plugins}/*.{ts,js}", {cwd: dir, absolute: true, dot: true,
+//     symlink: true})) out.push(pathToFileURL(f).href)`, and
+//     `Config.loadInstanceState` calls it for EVERY directory
+//     `ConfigPaths.directories` returns — the first of which is
+//     `Global.Path.config`, i.e. `$XDG_CONFIG_HOME/opencode` or
+//     `~/.config/opencode`. So there is no registry, no npm resolution, no git,
+//     no build step, no toolchain, and no config entry: a `.js` file in
+//     `<config>/plugin/` is loaded, globally, for every session.
+//     The `plugin: [...]` config array and `opencode plugin install` — the
+//     npm-spec route #1355 was reasoning about — are a SECOND, separate
+//     mechanism. This installer does not use it, does not touch
+//     opencode.json, and does not resolve, fetch, build or version any
+//     package. It writes one file.
+//     This is exactly the correction #1721 made for pi, arrived at
+//     independently and from the other end: pi's `pi install` was the red
+//     herring there, `plugin: [...]` is the red herring here.
+//
+//   - **No toolchain, and no dependency.** The glob accepts `.js` as well as
+//     `.ts`, and a plugin whose directory has no package.json resolves to the
+//     file itself (`resolveEntry` returns the target unchanged when
+//     `readManifest` finds nothing). The shipped file imports only
+//     node:child_process and does not import @opencode-ai/plugin, so the
+//     package opencode background-installs into each config directory is
+//     irrelevant to it.
+//
+//   - **Uninstall is `os.Remove`.** Nothing else was touched.
+//
+//   - **Blast radius is bounded by what the plugin registers.** opencode wraps
+//     plugin LOADING in try/catch and reports a failing plugin as an error
+//     while the agent continues. It does NOT wrap hook DISPATCH: Plugin.trigger
+//     iterates `for (const h of hooks) await h[name](input, output)` with no
+//     catch, and several of those hooks receive a mutable `output` the handler
+//     is expected to change — `permission.ask`'s `output.status` can be set to
+//     "allow" or "deny". plugin.js therefore registers exactly one hook,
+//     `event`, which is the read-only bus tap: it receives an event and
+//     returns nothing anyone reads. See plugin.js for the rest of that
+//     reasoning.
+//
+// The honest residue, stated in the consent copy rather than only here: it is
+// still code, running in-process in the user's agent with the user's own
+// permissions, and #570's contract is what makes that the user's decision.
+//
+// # Delivery
+//
+// Address-free (contracttesting.DeliveryAddressFree): the file names the
+// `irrlichd hook-post opencode` beacon (core/pkg/hookbeacon), which reads the
+// daemon's published address at fire time. Nothing address-shaped is written
+// into the user's opencode installation, so the #1178 stale-port class is
+// inexpressible here. It also keeps the shipped artifact small, which is the
+// whole argument above: the JavaScript does not speak HTTP and does not know
+// what a port is — it spawns one command and writes JSON to its stdin.
+package opencode
+
+import (
+	// embed backs the //go:embed of plugin.js below: the artifact this
+	// installer writes ships inside the irrlichd binary rather than being
+	// fetched, which is the claim the consent copy makes.
+	_ "embed"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"irrlicht/core/adapters/inbound/agents/agentpaths"
+	"irrlicht/core/domain/agent"
+	"irrlicht/core/pkg/hookbeacon"
+)
+
+// opencode's own wire names for the three bus events this adapter subscribes
+// to. They are opencode's, not Claude Code's: session.hookSignalEffects is a
+// flat map keyed by the literal wire string with no adapter dimension, and
+// none of these three is dispatched through it — hooks.go routes each one to a
+// dedicated SessionDetector entry point instead, so no name-keyed lookup is
+// involved on this path and no row can leak into another adapter's dispatch.
+const (
+	// HookEventPermissionAsked is published by Permission.ask when — and only
+	// when — a pattern actually needs asking. Permission.ask evaluates every
+	// pattern against the ruleset first and returns EARLY, publishing nothing,
+	// if all of them already resolve to "allow". That narrowness is what makes
+	// it usable as a blocked-on-user assert: it is not a before-every-tool
+	// event, and it must never be confused for one. hooks.go's header carries
+	// the measurement.
+	HookEventPermissionAsked = "permission.asked"
+
+	// HookEventPermissionReplied is published by Permission.reply for EVERY
+	// reply, including "reject", and is additionally cascaded to that session's
+	// other pending requests when one is rejected. That is what puts opencode
+	// out of copilot's position (copilot emits nothing on a denial, so a hold
+	// with no release would pin the session waiting) — the release really does
+	// arrive on the deny path.
+	HookEventPermissionReplied = "permission.replied"
+
+	// HookEventSessionIdle is published by SessionStatus.set when a session's
+	// runner reports idle — SessionRunState.runner wires it as the runner's
+	// onIdle, and SessionRunState.cancel sets it directly. So it covers the
+	// turn ending, being cancelled, and being interrupted, which is the same
+	// authoritative turn-end claim Claude Code's Stop makes.
+	HookEventSessionIdle = "session.idle"
+)
+
+// installedHookEvents is every opencode bus event this adapter subscribes to.
+// The exclusions are the finding rather than an omission:
+//
+//   - `permission.ask` — the HOOK, not the bus event — is excluded on a source
+//     fact, not a preference: opencode dispatches named hooks without a
+//     try/catch, and this one's `output.status` is a writable "allow" | "deny"
+//     | "ask". A monitoring plugin must not be able to answer a permission
+//     prompt for the user, or to throw inside the agent loop. The
+//     `permission.asked` BUS event above carries the same fact as an
+//     observation.
+//
+//   - `session.status` (busy) was considered as the turn-START signal and
+//     rejected for the reason copilot's, gemini-cli's and pi's analogous
+//     exclusions cite: the store's own rows already open the turn — the
+//     watcher emits EventActivity off new `part` rows — so a hook duplicating
+//     it buys nothing irrlicht's three-state model needs, at the cost of a
+//     process spawn per turn.
+//
+//   - `tool.execute.before` / `tool.execute.after` were considered as the
+//     assert/release pair gemini-cli's BeforeTool/AfterTool forms, and
+//     rejected: they fire for EVERY tool call, so a broad ASSERT would hold
+//     `waiting` on every tool call — the exact hazard #1719 named — while a
+//     broad RELEASE is only useful paired with a narrow assert on the same
+//     signal, which permission.asked/permission.replied already are.
+//     They are also hooks rather than bus events, so they carry the dispatch
+//     hazard above.
+//
+//   - `message.part.updated` and the other 29 bus events are excluded because
+//     the store carries them already and several fire per streamed chunk.
+var installedHookEvents = []string{
+	HookEventPermissionAsked,
+	HookEventPermissionReplied,
+	HookEventSessionIdle,
+}
+
+// hookEventSince records the opencode version each installed event is KNOWN to
+// exist in. All three are pinned to minOpenCodeVersion because that is the
+// version they were read out of — the binary is bun-compiled and carries no
+// per-feature changelog this could be bisected against, and inventing an
+// earlier number would be a claim nothing here supports. minOpenCodeVersion
+// must be >= every value here, which AssertHookVersionGate enforces; equal is
+// the honest answer when the floor is "the version this was measured at".
+var hookEventSince = map[string]string{
+	HookEventPermissionAsked:   minOpenCodeVersion,
+	HookEventPermissionReplied: minOpenCodeVersion,
+	HookEventSessionIdle:       minOpenCodeVersion,
+}
+
+// minOpenCodeVersion is the lowest opencode version this adapter's install
+// requires.
+//
+// Pinned to the version everything here was measured against — 1.14.50, read
+// out of the installed binary's own bundle — rather than bisected backward.
+// The floor is not a claim about one event: it covers `.js` auto-discovery
+// (ConfigPlugin.load's glob), the `{plugin,plugins}` directory layout, the
+// plugin export shape the loader accepts, and the three bus event names and
+// their payload fields — none of which was bisected. core/pkg/cliversion fails
+// OPEN on an unknown or unparseable version, so overshooting costs a missing
+// install on an old CLI rather than a wrong one on a new CLI, which is the
+// safe direction (the same reasoning pi's, kiro-cli's and gemini-cli's floors
+// document).
+const minOpenCodeVersion = "1.14.50"
+
+// HookEndpointPath is the daemon's opencode hook route. Exported so
+// registerHookRoutes (core/cmd/irrlichd/startup.go) and beaconroute_test.go's
+// pinned map both derive from the same segment this installer renders into the
+// beacon command it writes.
+//
+// A var, not a const, because hookbeacon.EndpointPath composes the route from
+// its own unexported prefix — deriving it here keeps this constant from
+// drifting away from the beacon's own routing convention. A mismatch is a
+// permanent silent 404: the beacon exits 0 by design, so nothing anywhere
+// reports it.
+var HookEndpointPath = hookbeacon.EndpointPath(AdapterName)
+
+// pluginDirName is the config-dir-relative directory opencode auto-discovers
+// plugins from. opencode's glob accepts BOTH "plugin" and "plugins"
+// ("{plugin,plugins}/*.{ts,js}"); this installer owns exactly one of them, so
+// a user's own file in the other is untouched.
+const pluginDirName = "plugin"
+
+// pluginFilename is the file this adapter owns inside that directory. The .js
+// suffix is load-bearing twice over: opencode's glob accepts only .ts and .js,
+// and .js is the spelling that involves no transform between the bytes written
+// here and the code opencode runs.
+const pluginFilename = "irrlicht.js"
+
+// displayPluginPath is the consent copy's home-relative spelling of the file
+// PluginPath resolves absolutely.
+const displayPluginPath = "~/.config/opencode/plugin/irrlicht.js"
+
+//go:embed plugin.js
+var pluginTemplate string // mutated by plugin_test.go's loud-failure guard, restored in t.Cleanup
+
+// beaconCommandPlaceholder is the token renderPlugin substitutes. It appears
+// exactly once in plugin.js, inside a JavaScript string literal, and
+// plugin_test.go fails if that stops being true — a template whose placeholder
+// silently stopped matching would render a file that runs the literal
+// placeholder as a shell command.
+const beaconCommandPlaceholder = `"__IRRLICHT_BEACON_COMMAND__"`
+
+// beaconLineRE reads the rendered command back out of an installed file. It
+// anchors on the whole assignment line rather than searching for the command
+// text, so a command that happens to appear in a comment cannot be mistaken
+// for the live one.
+var beaconLineRE = regexp.MustCompile(`(?m)^const IRRLICHT_BEACON = (".*");$`)
+
+// renderPlugin produces the exact bytes to install for a given, already-
+// resolved beacon command.
+//
+// strconv.Quote, not fmt.Sprintf("%q") by habit and not string concatenation:
+// the command embeds an absolute filesystem path the user chose, and a path
+// containing a quote or a backslash must not be able to terminate the
+// JavaScript string literal it lands in. Go's quoted-string escapes are a
+// subset of JavaScript's for every byte Quote can emit.
+func renderPlugin(command string) ([]byte, error) {
+	if command == "" {
+		return nil, errors.New("opencode: refusing to render a plugin with an empty beacon command")
+	}
+	if !strings.Contains(pluginTemplate, beaconCommandPlaceholder) {
+		// The embedded template stopped carrying the token this function
+		// substitutes. Failing loudly here is the difference between "no
+		// install" and "an install that shells out to the placeholder".
+		return nil, fmt.Errorf("opencode: embedded plugin template no longer contains %s", beaconCommandPlaceholder)
+	}
+	return []byte(strings.Replace(pluginTemplate, beaconCommandPlaceholder, strconv.Quote(command), 1)), nil
+}
+
+// beaconCommandOf extracts the beacon command an installed file carries.
+// Reports false for a file that is not ours, or whose assignment line has been
+// edited into something that is not a quoted string.
+func beaconCommandOf(src []byte) (string, bool) {
+	m := beaconLineRE.FindSubmatch(src)
+	if m == nil {
+		return "", false
+	}
+	command, err := strconv.Unquote(string(m[1]))
+	if err != nil {
+		return "", false
+	}
+	return command, true
+}
+
+// isOurs reports whether a file on disk is an irrlicht-installed plugin — by
+// the beacon sentinel, which deliberately excludes the binary path, so a copy
+// naming an irrlichd that has since moved is still recognized as ours.
+// Recognizing it is the precondition for rewriting it in place instead of
+// leaving a second one beside it.
+func isOurs(src []byte) bool {
+	return strings.Contains(string(src), hookbeacon.Sentinel(AdapterName))
+}
+
+// --- path resolution ---
+
+// configHomeEnvVar is the XDG variable opencode resolves its config directory
+// from. opencode composes Global.Path.config as
+// join(process.env.XDG_CONFIG_HOME || join(homedir(), ".config"), "opencode").
+const configHomeEnvVar = "XDG_CONFIG_HOME"
+
+// defaultConfigDirName is the $HOME-relative opencode config directory used
+// when XDG_CONFIG_HOME is unset.
+const defaultConfigDirName = ".config/opencode"
+
+// opencodeConfigDir resolves the absolute opencode config directory the way
+// opencode's own Global.Path does.
+//
+// $OPENCODE_CONFIG_DIR is deliberately NOT consulted. It ADDS a directory to
+// ConfigPaths.directories rather than replacing Global.Path.config, which is
+// scanned unconditionally — so installing here is discovered whether or not
+// the user has set it, and honouring it would mean choosing between two
+// directories opencode reads from both.
+func opencodeConfigDir() (string, error) {
+	return agentpaths.AbsRoot(agentpaths.FromEnv(AdapterName, configHomeEnvVar, defaultConfigDirName, AdapterName))
+}
+
+// PluginPath is the single file this permission's Writes.Path resolves — the
+// plugin opencode auto-discovers and runs.
+func PluginPath() (string, error) {
+	dir, err := opencodeConfigDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, pluginDirName, pluginFilename), nil
+}
+
+// --- install / verify / uninstall ---
+
+// EnsureHooksInstalled writes irrlicht's opencode plugin for the irrlichd that
+// is running now, creating opencode's plugin directory if it does not exist.
+// Returns true if anything changed.
+//
+// Idempotent, and self-healing across a moved binary: an already-installed
+// copy whose beacon command names a different irrlichd is rewritten IN PLACE
+// (same path, one file), never duplicated.
+func EnsureHooksInstalled() (bool, error) {
+	command, err := hookbeacon.InstalledCommand(AdapterName)
+	if err != nil {
+		return false, err
+	}
+	return ensureInstalledWithCommand(command)
+}
+
+// ensureInstalledWithCommand is EnsureHooksInstalled with the beacon command
+// resolved by the caller — the seam the #1178 contract's ForeignInstall uses to
+// seed the install a DIFFERENTLY-situated daemon would have written.
+// hookbeacon.InstalledCommand is called exactly once per entry point, which is
+// the shape hookbeacon's own doc comment asks adopters for.
+func ensureInstalledWithCommand(command string) (bool, error) {
+	path, err := PluginPath()
+	if err != nil {
+		return false, err
+	}
+	want, err := renderPlugin(command)
+	if err != nil {
+		return false, err
+	}
+
+	existing, readErr := os.ReadFile(path)
+	switch {
+	case readErr == nil && isOurs(existing):
+		if string(existing) == string(want) {
+			return false, nil
+		}
+		// Ours, but stale — a moved irrlichd, or a template change.
+	case readErr == nil:
+		// A file we did not write occupies the path we install to.
+		// Overwriting it would destroy a user's own plugin for the sake of
+		// monitoring, which is never the right trade; refusing surfaces as
+		// "granted but NOT applied" in the wizard (issue #1362) with this
+		// message, which is the honest outcome.
+		return false, fmt.Errorf("opencode: %s exists and was not written by irrlicht; refusing to overwrite it", path)
+	case !errors.Is(readErr, os.ErrNotExist):
+		return false, readErr
+	}
+
+	if err := atomicWriteFile(path, want); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// VerifyHooksInstalled reports whether the installed plugin is still present
+// and current, without writing anything (issue #1372). This is what
+// services.HookEntryVerifier re-checks a granted install with on a timer —
+// which matters more here than for a config-entry adapter, because opencode's
+// own `opencode plugin install`, any manual tidy of the plugin directory, and
+// the background `@opencode-ai/plugin` dependency install opencode runs against
+// every config directory all operate in the same tree.
+func VerifyHooksInstalled() (agent.HookEntryStatus, error) {
+	path, err := PluginPath()
+	if err != nil {
+		return agent.HookEntryStatus{}, err
+	}
+	command, err := hookbeacon.InstalledCommand(AdapterName)
+	if err != nil {
+		return agent.HookEntryStatus{}, err
+	}
+	want, err := renderPlugin(command)
+	if err != nil {
+		return agent.HookEntryStatus{}, err
+	}
+
+	existing, readErr := os.ReadFile(path)
+	if errors.Is(readErr, os.ErrNotExist) {
+		return agent.HookEntryStatus{Missing: append([]string(nil), installedHookEvents...)}, nil
+	}
+	if readErr != nil {
+		return agent.HookEntryStatus{}, readErr
+	}
+	if !isOurs(existing) {
+		// Something else owns the path now. Reported as Missing rather than
+		// Stale: "stale" means EnsureHooksInstalled would rewrite it, and it
+		// deliberately will not.
+		return agent.HookEntryStatus{Missing: append([]string(nil), installedHookEvents...)}, nil
+	}
+	if string(existing) != string(want) {
+		return agent.HookEntryStatus{Stale: append([]string(nil), installedHookEvents...)}, nil
+	}
+	return agent.HookEntryStatus{}, nil
+}
+
+// UninstallHooks removes irrlicht's opencode plugin. Returns true if anything
+// changed.
+//
+// Removes the FILE, because the file is the entire install — nothing was added
+// to opencode.json, no package was installed, and opencode's own
+// auto-discovery is what loaded it. A file at our path that is not ours is
+// left alone, the same "leave a foreign entry alone" rule every hook uninstall
+// in this codebase follows.
+//
+// opencode's plugin directory is deliberately NOT removed when it empties out,
+// even if this install is what created it: an empty plugin/ is an ordinary
+// state for an opencode installation, and removing a directory a user's editor
+// or shell may have open is a worse surprise than leaving one behind.
+func UninstallHooks() (bool, error) {
+	path, err := PluginPath()
+	if err != nil {
+		return false, err
+	}
+	existing, readErr := os.ReadFile(path)
+	if errors.Is(readErr, os.ErrNotExist) {
+		return false, nil
+	}
+	if readErr != nil {
+		return false, readErr
+	}
+	if !isOurs(existing) {
+		return false, nil
+	}
+	if err := os.Remove(path); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// atomicWriteFile writes data to path via a temp file + rename so opencode
+// never loads a half-written plugin. Creates the parent directory. Matches
+// every sibling hook-installing adapter's own atomic writer.
+func atomicWriteFile(path string, data []byte) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(dir, ".irrlicht-*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer func() { _ = os.Remove(tmpName) }()
+
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	// 0o600, matching pi's installer: opencode runs as the same user that
+	// installed this, so nothing needs to read it but the owner, and the file
+	// is executable code inside the user's agent.
+	if err := os.Chmod(tmpName, 0o600); err != nil {
+		return err
+	}
+	return os.Rename(tmpName, path)
+}

--- a/core/adapters/inbound/agents/opencode/hookinstaller_test.go
+++ b/core/adapters/inbound/agents/opencode/hookinstaller_test.go
@@ -1,0 +1,300 @@
+// hookinstaller_test.go grades the Go side of the install: where the file
+// lands, what happens when one is already there, and that nothing is written
+// until the user has consented.
+package opencode
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"irrlicht/core/domain/permission"
+	"irrlicht/core/internal/contracttesting"
+	"irrlicht/core/pkg/hookbeacon"
+)
+
+// opencodeHome relocates $HOME and clears $XDG_CONFIG_HOME, returning the temp
+// home. Every test in this file WRITES, so isolation is not optional.
+func opencodeHome(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv(configHomeEnvVar, "")
+	return home
+}
+
+// hooksPermission returns the declared Apply/Remove closures, read off the real
+// registration the daemon consumes rather than a copy.
+func hooksPermission(t *testing.T) (apply, remove func() error) {
+	t.Helper()
+	for _, p := range Agent().Permissions {
+		if p.Key == PermissionKeyHooks {
+			if p.Apply == nil || p.Remove == nil {
+				t.Fatal("hooks permission declares no Apply/Remove")
+			}
+			return p.Apply, p.Remove
+		}
+	}
+	t.Fatal("no hooks permission")
+	return nil, nil
+}
+
+// TestHooksPermission_IsGated wires the install-type flavour of the #797
+// contract: nothing is written while the permission is pending, granting
+// installs the plugin, and denying removes it.
+//
+// The stake here is higher than for a config-entry adapter and worth naming.
+// What this permission's Apply writes is EXECUTABLE CODE that opencode loads
+// into every session, so "nothing is exercised while pending or denied" is not
+// only a consent rule — a pre-consent daemon that ran Apply would have put code
+// inside the user's agent before the wizard was ever answered.
+func TestHooksPermission_IsGated(t *testing.T) {
+	opencodeHome(t)
+	apply, remove := hooksPermission(t)
+
+	state := permission.StatePending
+	contracttesting.AssertPermissionGated(t, contracttesting.PermissionGate{
+		Key: PermissionKeyHooks,
+		// database is the adapter's only other declared permission and is
+		// observe-kind, so it has no closure to drive: the key-isolation arm is
+		// INERT here and repeats the revoked arm exactly, the same situation
+		// copilot's, geminicli's, vibe's and pi's equivalent tests document.
+		// Install-type wirings hold their own permission's closures, so a wrong
+		// key is not representable — the arm is load-bearing at the live
+		// receiver (hooks_test.go), not here.
+		OtherKeys: []string{PermissionKeyDatabase},
+		SetState:  contracttesting.OnlyKey(PermissionKeyHooks, func(s permission.State) { state = s }),
+		Exercise: func() {
+			switch state {
+			case permission.StateGranted:
+				if err := apply(); err != nil {
+					t.Fatalf("apply: %v", err)
+				}
+			case permission.StateDenied:
+				if err := remove(); err != nil {
+					t.Fatalf("remove: %v", err)
+				}
+			}
+		},
+		Observe: func() bool {
+			status, err := VerifyHooksInstalled()
+			if err != nil {
+				t.Fatalf("VerifyHooksInstalled: %v", err)
+			}
+			return status.Intact()
+		},
+	})
+}
+
+// TestPluginPath_LandsInOpenCodesGlobalConfigDir pins WHERE the file goes, in
+// both spellings opencode's own Global.Path.config resolves.
+//
+// The XDG leg is not decoration: opencode composes its config directory as
+// join(process.env.XDG_CONFIG_HOME || join(homedir(), ".config"), "opencode"),
+// so a user with that variable set has their plugin directory somewhere else
+// entirely — and an installer that ignored it would write a file opencode never
+// loads, with the permission still reading granted and nothing to look at.
+func TestPluginPath_LandsInOpenCodesGlobalConfigDir(t *testing.T) {
+	home := opencodeHome(t)
+
+	got, err := PluginPath()
+	if err != nil {
+		t.Fatalf("PluginPath: %v", err)
+	}
+	if want := filepath.Join(home, ".config", "opencode", "plugin", "irrlicht.js"); got != want {
+		t.Errorf("PluginPath() = %q, want %q", got, want)
+	}
+
+	xdg := t.TempDir()
+	t.Setenv(configHomeEnvVar, xdg)
+	got, err = PluginPath()
+	if err != nil {
+		t.Fatalf("PluginPath with %s set: %v", configHomeEnvVar, err)
+	}
+	if want := filepath.Join(xdg, "opencode", "plugin", "irrlicht.js"); got != want {
+		t.Errorf("PluginPath() with %s=%q = %q, want %q", configHomeEnvVar, xdg, got, want)
+	}
+}
+
+// TestEnsureHooksInstalled_IsIdempotent pins that a second call changes
+// nothing. The permission service re-runs Apply on every daemon start, so a
+// non-idempotent installer would rewrite the user's plugin file forever.
+func TestEnsureHooksInstalled_IsIdempotent(t *testing.T) {
+	opencodeHome(t)
+
+	changed, err := EnsureHooksInstalled()
+	if err != nil {
+		t.Fatalf("first install: %v", err)
+	}
+	if !changed {
+		t.Fatal("first install reported no change")
+	}
+
+	changed, err = EnsureHooksInstalled()
+	if err != nil {
+		t.Fatalf("second install: %v", err)
+	}
+	if changed {
+		t.Error("second install reported a change — Apply runs on every daemon start")
+	}
+}
+
+// TestEnsureHooksInstalled_RefusesToOverwriteAForeignFile is the rule every
+// hook uninstall and install in this codebase follows, and it matters more here
+// than anywhere: `plugin/irrlicht.js` is a path a user could plausibly have
+// written themselves, and overwriting it would destroy their own plugin for the
+// sake of monitoring.
+func TestEnsureHooksInstalled_RefusesToOverwriteAForeignFile(t *testing.T) {
+	opencodeHome(t)
+	path, err := PluginPath()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	const theirs = "export default async () => ({})\n"
+	if err := os.WriteFile(path, []byte(theirs), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	changed, err := EnsureHooksInstalled()
+	if err == nil {
+		t.Fatal("EnsureHooksInstalled overwrote a file irrlicht did not write")
+	}
+	if changed {
+		t.Error("EnsureHooksInstalled reported a change while refusing")
+	}
+	got, readErr := os.ReadFile(path)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if string(got) != theirs {
+		t.Error("the user's own plugin file was modified")
+	}
+	if !strings.Contains(err.Error(), path) {
+		t.Errorf("the refusal %q does not name the file — the wizard surfaces this string as \"granted but NOT applied\" (#1362)", err)
+	}
+}
+
+// TestUninstallHooks_LeavesAForeignFileAlone is the mirror of the above.
+func TestUninstallHooks_LeavesAForeignFileAlone(t *testing.T) {
+	opencodeHome(t)
+	path, err := PluginPath()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("export default async () => ({})\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	changed, err := UninstallHooks()
+	if err != nil {
+		t.Fatalf("UninstallHooks: %v", err)
+	}
+	if changed {
+		t.Error("UninstallHooks reported a change for a file irrlicht did not write")
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("the user's own plugin file was removed: %v", err)
+	}
+}
+
+// TestUninstallHooks_OnNothingIsQuiet pins that a revoke with no install is not
+// an error. PermissionService runs Remove whenever the answer is "denied",
+// including the first time the wizard is answered.
+func TestUninstallHooks_OnNothingIsQuiet(t *testing.T) {
+	opencodeHome(t)
+	changed, err := UninstallHooks()
+	if err != nil {
+		t.Fatalf("UninstallHooks with nothing installed: %v", err)
+	}
+	if changed {
+		t.Error("UninstallHooks reported a change with nothing installed")
+	}
+}
+
+// TestVerifyHooksInstalled_ReportsTheThreeStates is the #1372 half: the
+// verifier re-reads a granted install on a timer, so it has to tell "gone" from
+// "stale" from "intact". A file that is not ours is Missing rather than Stale,
+// because "stale" means EnsureHooksInstalled would rewrite it and it
+// deliberately will not.
+func TestVerifyHooksInstalled_ReportsTheThreeStates(t *testing.T) {
+	opencodeHome(t)
+	path, err := PluginPath()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	status, err := VerifyHooksInstalled()
+	if err != nil {
+		t.Fatalf("verify with nothing installed: %v", err)
+	}
+	if len(status.Missing) != len(installedHookEvents) {
+		t.Errorf("nothing installed: Missing = %v, want all %d events", status.Missing, len(installedHookEvents))
+	}
+
+	if _, err := EnsureHooksInstalled(); err != nil {
+		t.Fatal(err)
+	}
+	if status, err = VerifyHooksInstalled(); err != nil {
+		t.Fatalf("verify after install: %v", err)
+	}
+	if !status.Intact() {
+		t.Errorf("after a fresh install: %+v, want intact", status)
+	}
+
+	// Ours, but written by a daemon that lived somewhere else.
+	foreign, err := hookbeacon.Command(foreignBinaryPath, AdapterName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ensureInstalledWithCommand(foreign); err != nil {
+		t.Fatal(err)
+	}
+	if status, err = VerifyHooksInstalled(); err != nil {
+		t.Fatalf("verify after a foreign-binary install: %v", err)
+	}
+	if len(status.Stale) != len(installedHookEvents) {
+		t.Errorf("a copy naming another irrlichd: %+v, want all %d events Stale", status, len(installedHookEvents))
+	}
+
+	// Not ours at all.
+	if err := os.WriteFile(path, []byte("export default async () => ({})\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if status, err = VerifyHooksInstalled(); err != nil {
+		t.Fatalf("verify against a foreign file: %v", err)
+	}
+	if len(status.Missing) != len(installedHookEvents) {
+		t.Errorf("a foreign file at our path: %+v, want all %d events Missing (not Stale — Ensure will not rewrite it)", status, len(installedHookEvents))
+	}
+}
+
+// TestUninstallHooks_LeavesThePluginDirectoryBehind pins the deliberate
+// omission recorded on UninstallHooks: an empty plugin/ is an ordinary state
+// for an opencode installation, and removing a directory a user's editor or
+// shell may have open is a worse surprise than leaving one behind.
+func TestUninstallHooks_LeavesThePluginDirectoryBehind(t *testing.T) {
+	opencodeHome(t)
+	if _, err := EnsureHooksInstalled(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := UninstallHooks(); err != nil {
+		t.Fatal(err)
+	}
+	path, err := PluginPath()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("the plugin file survived uninstall: %v", err)
+	}
+	if _, err := os.Stat(filepath.Dir(path)); err != nil {
+		t.Errorf("the plugin directory was removed too: %v", err)
+	}
+}

--- a/core/adapters/inbound/agents/opencode/hookpath_test.go
+++ b/core/adapters/inbound/agents/opencode/hookpath_test.go
@@ -1,0 +1,51 @@
+// hookpath_test.go wires this adapter's hook receiver into the shared issue
+// #1361 contract, under its PathDaemonDerived route (#1719).
+//
+// Every other receiver in the tree takes the PathFromBody route: the payload
+// names a transcript file and the receiver confines that caller-supplied string
+// to the adapter's declared roots. This one cannot, and the difference is
+// structural rather than a shortfall — opencode's Source is an
+// agent.ProcessOwnedStore, so there is no file per session for a caller to
+// name, and the path every consumer keys an opencode session on is composed by
+// the daemon from its own store resolver.
+//
+// So the obligation the route runs is the mirror image: nothing the caller
+// writes may reach the dispatch. Its three obligations contradict the from-body
+// route's directly (there the four hostile bodies must dispatch NOTHING; here
+// each must dispatch the SAME string a clean body does), which is what makes
+// this a declaration rather than an exemption — declaring the wrong route
+// fails, it does not pass quietly.
+package opencode
+
+import (
+	"testing"
+
+	"irrlicht/core/internal/contracttesting"
+)
+
+func TestHookPathConfined(t *testing.T) {
+	contracttesting.AssertHookPathConfined(t, contracttesting.HookReceiver{
+		Route: contracttesting.PathDaemonDerived,
+		Root:  opencodeStoreRoot,
+		New: func(t *testing.T) contracttesting.HookReceiverUnderTest {
+			t.Helper()
+			target := &mockTarget{}
+			return contracttesting.HookReceiverUnderTest{
+				Handler:      NewHookHandler(target, nil, mockLogger{}),
+				Observed:     func() bool { return target.totalCalls() > 0 },
+				ObservedPath: target.observedPath,
+			}
+		},
+		// Both closures ignore the transcript path the contract offers, which
+		// is the whole point: PayloadFor renders exactly what plugin.js writes,
+		// and ForeignPathPayload splices in the key a hostile caller would try.
+		// The contract refuses to run if those two render the same body.
+		PayloadFor:         func(string) string { return contractPayload(HookEventSessionIdle) },
+		ForeignPathPayload: foreignPathPayload,
+		DerivedPath: func(t *testing.T) string {
+			t.Helper()
+			return transcriptPathFor(contractSessionID)
+		},
+		EndpointPath: HookEndpointPath,
+	})
+}

--- a/core/adapters/inbound/agents/opencode/hookport_test.go
+++ b/core/adapters/inbound/agents/opencode/hookport_test.go
@@ -1,0 +1,112 @@
+// hookport_test.go wires the opencode plugin installer into the shared issue
+// #1178 contract, under its DeliveryAddressFree route (#1453): the installed
+// artifact carries no address at all, because it names the `irrlichd hook-post
+// opencode` beacon, which resolves the daemon's address itself at fire time.
+//
+// opencode is the fifth adapter on that route, after geminicli, kirocli, vibe
+// and pi.
+//
+// The read-back obligations (2-4) go through HookInstaller.ReadEntries /
+// EndpointOfRaw (#1734), for the same reason pi's do: this adapter's "entry" is
+// not a document node of any kind. It is a JavaScript file, and the whole file
+// is the entry. There is one, it carries all three of this adapter's event
+// subscriptions, and the delivery it carries is the one beacon command line
+// inside it — which openCodeEndpointOfRaw reads back with the same anchored
+// regexp the installer uses to decide whether an installed copy is current.
+// Entry/EndpointOf (obligation 1, in-memory only) stay
+// map[string]interface{} regardless: nothing downstream of them touches the
+// filesystem, so a synthetic one-key map answers that question honestly.
+package opencode
+
+import (
+	"os"
+	"testing"
+
+	"irrlicht/core/internal/contracttesting"
+	"irrlicht/core/pkg/hookbeacon"
+)
+
+// foreignBinaryPath is the irrlichd a DIFFERENTLY-situated daemon would have
+// named. Deliberately a path that does not exist: an absolute path that has
+// stopped existing is exactly the drift beacon delivery newly admits (#1373),
+// and it needs no second executable to arrange.
+const foreignBinaryPath = "/nonexistent-irrlicht-1719/bin/irrlichd"
+
+// openCodeEntryNow / openCodeEndpointOfMap are the contract's in-memory
+// Entry/EndpointOf pair for obligation 1 — a synthetic one-key map, since
+// obligation 1 never reads the filesystem.
+func openCodeEntryNow() map[string]interface{} {
+	command, _ := hookbeacon.InstalledCommand(AdapterName)
+	return map[string]interface{}{"command": command}
+}
+
+func openCodeEndpointOfMap(hook map[string]interface{}) string {
+	c, _ := hook["command"].(string)
+	return c
+}
+
+// openCodeReadEntries is the contract's ReadEntries: the installed plugin file,
+// raw, as a single entry — or nothing at all when the file is absent or is not
+// ours. event is ignored; this adapter writes one file carrying every
+// subscription, so there is nothing to filter, which HookInstaller.ReadEntries's
+// own doc comment records as a supported shape rather than a gap.
+func openCodeReadEntries(path, _ string) ([][]byte, error) {
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return [][]byte{data}, nil
+}
+
+// openCodeEndpointOfRaw extracts the beacon command from one raw entry — the
+// same value ensureInstalledWithCommand renders in and VerifyHooksInstalled
+// compares, read back through the production helper rather than a second parser
+// written for the test.
+func openCodeEndpointOfRaw(entry []byte) string {
+	command, _ := beaconCommandOf(entry)
+	return command
+}
+
+func TestHookEndpointFollowsBindAddr(t *testing.T) {
+	// Checked up front so a resolution failure reads as itself rather than as
+	// the empty-delivery wiring error assertDeliveryIsOurs would report.
+	if _, err := hookbeacon.InstalledCommand(AdapterName); err != nil {
+		t.Fatalf("resolving the beacon command: %v", err)
+	}
+
+	contracttesting.AssertHookEndpointFollowsBindAddr(t, contracttesting.HookInstaller{
+		Delivery: contracttesting.DeliveryAddressFree,
+		SettingsPath: func(t *testing.T) string {
+			home := t.TempDir()
+			t.Setenv("HOME", home)
+			t.Setenv(configHomeEnvVar, "")
+			path, err := PluginPath()
+			if err != nil {
+				t.Fatalf("resolving the plugin path: %v", err)
+			}
+			return path
+		},
+		Sentinel:        hookbeacon.Sentinel(AdapterName),
+		Events:          installedHookEvents,
+		Entry:           openCodeEntryNow,
+		EndpointOf:      openCodeEndpointOfMap,
+		ReadEntries:     openCodeReadEntries,
+		EndpointOfRaw:   openCodeEndpointOfRaw,
+		EnsureInstalled: EnsureHooksInstalled,
+		Uninstall:       UninstallHooks,
+		// ForeignInstall seeds a plugin naming a DIFFERENT (nonexistent)
+		// irrlicht binary — the address-free counterpart of seeding a
+		// stale-port install — so the contract can assert EnsureHooksInstalled
+		// rewrites it in place rather than leaving two of them.
+		ForeignInstall: func() (bool, error) {
+			command, err := hookbeacon.Command(foreignBinaryPath, AdapterName)
+			if err != nil {
+				return false, err
+			}
+			return ensureInstalledWithCommand(command)
+		},
+	})
+}

--- a/core/adapters/inbound/agents/opencode/hookreceipt_test.go
+++ b/core/adapters/inbound/agents/opencode/hookreceipt_test.go
@@ -1,0 +1,44 @@
+// hookreceipt_test.go wires this adapter's hook receiver into the shared issue
+// #1368 contract: a consent-passed request counts as a receipt whatever the
+// receiver then does with it, and a consent-denied one does not.
+//
+// One of the four obligations is WEAKER here than for a from-body receiver, and
+// it is stated rather than left implied. Obligation 3 — "a path-confinement
+// rejection still counts" — posts a well-formed body carrying an out-of-tree
+// transcript path. This receiver's payload has no path field, so that body is
+// indistinguishable from obligation 1's and the arm degenerates into a repeat
+// of it. That is the same inertness AGENTS.md records for OtherKeys on an
+// install-type permission gate: the arm is kept uniform, with no opt-out,
+// because a flag this wiring could take is one a from-body wiring could take
+// too. What obligation 3 protects against is unreachable here for the reason
+// the whole PathDaemonDerived route exists — there is no confinement rejection
+// to mis-count, because there is no caller-supplied path.
+package opencode
+
+import (
+	"net/http"
+	"testing"
+
+	"irrlicht/core/internal/contracttesting"
+	"irrlicht/core/ports/outbound"
+)
+
+func TestHookReceiptObserved(t *testing.T) {
+	contracttesting.AssertHookReceiptObserved(t, contracttesting.HookReceiptReceiver{
+		Adapter:         AdapterName,
+		Root:            opencodeStoreRoot,
+		WriteTranscript: writeContractTranscript,
+		New: func(t *testing.T, log outbound.Logger) http.Handler {
+			t.Helper()
+			return NewHookHandler(&mockTarget{},
+				keyedGate{PermissionKeyHooks: true, PermissionKeyDatabase: true}, log)
+		},
+		NewDenied: func(t *testing.T, log outbound.Logger) http.Handler {
+			t.Helper()
+			return NewHookHandler(&mockTarget{}, keyedGate{}, log)
+		},
+		PayloadFor:   func(_, event string) string { return contractPayload(event) },
+		KnownEvent:   HookEventSessionIdle,
+		EndpointPath: HookEndpointPath,
+	})
+}

--- a/core/adapters/inbound/agents/opencode/hooks.go
+++ b/core/adapters/inbound/agents/opencode/hooks.go
@@ -1,0 +1,229 @@
+// hooks.go provides the HTTP handler for receiving opencode bus events
+// (issue #1719, epic #1355).
+//
+// Three events are installed and dispatched: permission.asked asserts the
+// blocked-on-user signal, permission.replied releases it, and session.idle
+// releases it AND reports the authoritative turn end.
+//
+// # opencode DOES have a blocked-on-user state, and it is invisible in the store
+//
+// #1719 asked whether opencode has any genuine blocked-on-user state and told
+// this issue not to assume the answer either way. It does, and it is the whole
+// reason this adapter is worth a hook channel at all. Measured against
+// opencode 1.14.50's own bundle:
+//
+//   - Permission.ask evaluates each requested pattern against the ruleset and
+//     returns EARLY, publishing nothing, when every one of them already
+//     resolves to "allow". It publishes permission.asked only when something
+//     genuinely has to be asked. So this is a narrow assert, not the
+//     fires-for-every-tool event #1719 warned against reusing
+//     session.HookPreToolUse's row for — and note that no row is reused: each
+//     event below goes to a dedicated SessionDetector entry point, so
+//     session.hookSignalEffects (a flat map with no adapter dimension) is never
+//     consulted on this path.
+//
+//   - **That pending request is held in a plain in-memory Map**
+//     (`{pending: new Map, approved: <rows from the permission table>}`). Only
+//     the APPROVED patterns are persisted; a request awaiting an answer is
+//     written nowhere. opencode's store therefore cannot express "the user is
+//     being asked right now", which is exactly what this adapter's Source —
+//     an agent.ProcessOwnedStore over opencode.db — reads. Before this hook
+//     channel, opencode had no `waiting` at all: neither the watcher nor the
+//     parser touches the permission table, because there is nothing there to
+//     touch until after the user has answered.
+//
+//   - Permission.reply publishes permission.replied for EVERY reply INCLUDING
+//     "reject", and cascades a rejection to that session's other pending
+//     requests, publishing one per request. That is what puts opencode out of
+//     copilot's position — copilot emits nothing at all on a denial, so a hold
+//     with no release would pin the session `waiting` until
+//     permissionPromptHoldTimeout's 12-hour ceiling. Here the release really
+//     does arrive on the deny path.
+//
+//   - session.idle is published by SessionStatus.set from the session runner's
+//     onIdle, and directly by SessionRunState.cancel. It therefore covers the
+//     turn ending, being cancelled and being interrupted. This receiver
+//     releases the permission hold on it as well as reporting turn end — the
+//     same belt-and-braces gemini-cli's AfterAgent handling uses, closing the
+//     one case no reply covers: the process being torn down with a request
+//     still pending.
+//
+// # Why the payload carries no path (contracttesting.PathDaemonDerived)
+//
+// Every other hook receiver in this tree confines a caller-supplied
+// transcript_path to its adapter's declared roots. This one cannot, and must
+// not pretend to: opencode has no file per session. Its Source is an
+// agent.ProcessOwnedStore, session state lives in one SQLite database, and the
+// "transcript path" every downstream consumer keys an opencode session on is a
+// string the DAEMON composes — dbPath + "-wal?session=" + id, the same spelling
+// watcher.go emits on every event (transcriptPathFor is the one function both
+// use, so the hook's key and the watcher's key cannot drift into two sessions).
+//
+// So the honest payload is a session id, and the receiver reads it through
+// hookjson.DecodeSealed. That is not a relaxation of the #1361 guard, it is the
+// guard's premise being absent: there is no caller-supplied path on this
+// receiver's dispatch path for a traversal, a symlink or an escape to be
+// expressed in. The obligation that replaces "confine what the caller named" is
+// "prove nothing the caller names travels", and it is graded from outside by
+// AssertHookPathConfined's PathDaemonDerived route, whose obligations
+// contradict the from-body route's directly — so declaring the wrong one fails
+// rather than passing quietly. See hookpath_test.go.
+//
+// What DecodeSealed keeps, unchanged from DecodeConfined: the #1488 consent
+// backstop before the body is read, the 1 MiB bound on an unauthenticated local
+// endpoint, and the single body-reading function core/architecture_hookbody_test.go
+// pins.
+package opencode
+
+import (
+	"net/http"
+	"strings"
+
+	"irrlicht/core/adapters/inbound/agents/hookjson"
+	"irrlicht/core/domain/agent"
+	"irrlicht/core/ports/outbound"
+)
+
+// PermissionKeyHooks gates installing and receiving opencode bus events
+// (issue #570). Aliased to the shared domain constant rather than restated —
+// see agent.HooksPermissionKey's own doc for why two external projections
+// narrow on it.
+const PermissionKeyHooks = agent.HooksPermissionKey
+
+// logComponentHookReceiver is the Logger component tag for every log line this
+// receiver emits.
+const logComponentHookReceiver = "opencode-hook-receiver"
+
+// sessionIDPrefix is what opencode's own PermissionID/SessionID schema
+// enforces for a session id — `Schema.String.check(isStartsWith("ses"))`. It is
+// checked here for the same reason pi checks its transcript's suffix: the
+// endpoint is local and unauthenticated, and an id that is not one this adapter
+// could ever have seen is dropped rather than turned into a phantom session.
+const sessionIDPrefix = "ses"
+
+// openCodeHookPayload is the JSON body irrlicht's own opencode plugin writes to
+// the beacon's stdin (plugin.js), forwarded verbatim by
+// `irrlichd hook-post opencode`.
+//
+// Deliberately minimal, and deliberately carrying NO path — see this file's
+// header. SessionID is opencode's own `ses_...` id, which is the id the watcher
+// keys every session on (it reads it straight out of the `session` table), so
+// there is exactly one spelling of session identity on this adapter and no
+// second one to disagree with it.
+type openCodeHookPayload struct {
+	HookEventName string `json:"hook_event_name"`
+	SessionID     string `json:"session_id"`
+}
+
+// HookTarget is the interface the handler calls into. Satisfied by
+// *services.SessionDetector without importing the services package — the same
+// agent-agnostic surface every other receiver uses, narrowed to the three
+// methods this adapter's installed events need.
+type HookTarget interface {
+	HandlePermissionPromptHook(sessionID, transcriptPath, hookName string)
+	ReleasePermissionPromptHold(sessionID string)
+	HandleStopHook(sessionID, transcriptPath, lastAssistantText string, waitingCue bool)
+}
+
+// ConsentGranter is the shared consent check every JSON-hook receiver gates on
+// (issue #570) — an alias, not a copy, so the receivers cannot drift.
+type ConsentGranter = hookjson.ConsentGranter
+
+// NewHookHandler returns an http.Handler that receives opencode bus events and
+// dispatches them to the target.
+//
+// gate is the consent check; while the "hooks" permission is not granted the
+// payload is dropped with 200, so an install left behind by a pre-consent
+// daemon stays quiet. A nil gate means no gating — used by tests.
+//
+// The returned hookjson.HookHandler carries a NIL Confiner, and that is the
+// declaration rather than an omission: this receiver has no caller-supplied
+// path to confine, and a nil confiner is what makes hookjson.DecodeConfined
+// fail CLOSED if a later edit switched this receiver back to the confining
+// decode without giving the adapter roots. AssertHookPathConfined's
+// PathDaemonDerived route asserts it.
+func NewHookHandler(target HookTarget, gate ConsentGranter, log outbound.Logger) hookjson.HookHandler {
+	return hookjson.NewHandler(nil,
+		hookjson.RequireConsent(gate, AdapterName, PermissionKeyHooks, PermissionKeyDatabase),
+		func(consent hookjson.Consent, _ *hookjson.PathConfiner, w http.ResponseWriter, r *http.Request) {
+			serveHookRequest(target, consent, log, w, r)
+		})
+}
+
+// serveHookRequest is NewHookHandler's request logic. The step order matches
+// every sibling receiver's exactly, and each step is load-bearing — see the
+// contract assertions in hook*_test.go.
+func serveHookRequest(target HookTarget, consent hookjson.Consent, log outbound.Logger, w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	// Both keys come off the receiver's OWN hookjson.Consent (issue #1488), so
+	// the set this sequence is written for is the set the handler publishes and
+	// the contract derives.
+	if !consent.Granted(PermissionKeyHooks) {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
+	// The channel delivered (issue #1368). Counted against the "hooks" consent
+	// only, ahead of the database check below.
+	hookjson.ObserveHookReceipt(AdapterName)
+
+	// Dispatching makes the detector read the session store, so it is gated
+	// behind "database" — this adapter's read permission — not merely the
+	// "hooks" write consent. The check comes BEFORE the decode, so a denied
+	// session still yields a quiet 200 and the body is never read.
+	if !consent.Granted(PermissionKeyDatabase) {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
+	var payload openCodeHookPayload
+	if !hookjson.DecodeSealed(w, r, log, logComponentHookReceiver, consent, &payload) {
+		return
+	}
+
+	sessionID := payload.SessionID
+	if !strings.HasPrefix(sessionID, sessionIDPrefix) {
+		// Not an id this adapter could have issued — drop rather than invent a
+		// session. The store watcher covers the state regardless.
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
+	// Composed by the daemon from its own store resolver, never from the body.
+	transcriptPath := transcriptPathFor(sessionID)
+
+	switch payload.HookEventName {
+	case HookEventPermissionAsked:
+		log.LogInfo(logComponentHookReceiver, sessionID, "received permission.asked")
+		target.HandlePermissionPromptHook(sessionID, transcriptPath, HookEventPermissionAsked)
+	case HookEventPermissionReplied:
+		log.LogInfo(logComponentHookReceiver, sessionID, "received permission.replied")
+		target.ReleasePermissionPromptHold(sessionID)
+	case HookEventSessionIdle:
+		log.LogInfo(logComponentHookReceiver, sessionID, "received session.idle")
+		// Released before the turn-end report, and unconditionally: a release
+		// on an unheld signal is a no-op, and this is the only thing that
+		// closes a prompt torn down without a reply (a killed process, a
+		// cancelled run). Same pairing gemini-cli's AfterAgent uses.
+		target.ReleasePermissionPromptHold(sessionID)
+		// Payload-free, exactly as pi's and vibe's single events are:
+		// HandleStopHook asserts SignalTurnDone unconditionally and only
+		// CONDITIONALLY overlays the text and cue, so the authoritative "the
+		// turn truly ended" claim is real without them, and it can never clear
+		// or mask a cue found elsewhere. opencode's bus event carries no
+		// message content to forward.
+		target.HandleStopHook(sessionID, transcriptPath, "", false)
+	default:
+		// Unrecognized event — accept but ignore, counted per name and reported
+		// once, in the one place that behaviour is decided for every receiver
+		// (issue #1364). This is where an opencode event rename, or an event a
+		// future plugin version forwards that this daemon does not know,
+		// becomes visible instead of silent.
+		hookjson.IgnoreUnknownEvent(log, logComponentHookReceiver, AdapterName, sessionID, payload.HookEventName)
+	}
+	w.WriteHeader(http.StatusOK)
+}

--- a/core/adapters/inbound/agents/opencode/hooks_test.go
+++ b/core/adapters/inbound/agents/opencode/hooks_test.go
@@ -1,0 +1,412 @@
+package opencode
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"irrlicht/core/internal/contracttesting"
+)
+
+// --- test doubles, shared by this file and the contract wirings ---
+
+type stopCall struct {
+	sessionID, transcriptPath, lastAssistantText string
+	waitingCue                                   bool
+}
+
+type promptCall struct {
+	sessionID, transcriptPath, hookName string
+}
+
+type mockTarget struct {
+	mu        sync.Mutex
+	stopCalls []stopCall
+	prompts   []promptCall
+	releases  []string
+	// lastPath is the most recent transcript path handed to ANY method that
+	// takes one — which is what the #1389 obligation reads. Kept as one field
+	// rather than reconstructed from the three slices so a future fourth
+	// dispatch cannot be forgotten here while the contract keeps passing.
+	lastPath string
+}
+
+func (m *mockTarget) HandleStopHook(sessionID, transcriptPath, lastAssistantText string, waitingCue bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.stopCalls = append(m.stopCalls, stopCall{sessionID, transcriptPath, lastAssistantText, waitingCue})
+	m.lastPath = transcriptPath
+}
+
+func (m *mockTarget) HandlePermissionPromptHook(sessionID, transcriptPath, hookName string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.prompts = append(m.prompts, promptCall{sessionID, transcriptPath, hookName})
+	m.lastPath = transcriptPath
+}
+
+func (m *mockTarget) ReleasePermissionPromptHold(sessionID string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.releases = append(m.releases, sessionID)
+}
+
+func (m *mockTarget) totalCalls() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return len(m.stopCalls) + len(m.prompts) + len(m.releases)
+}
+
+func (m *mockTarget) stops() []stopCall {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]stopCall(nil), m.stopCalls...)
+}
+
+func (m *mockTarget) promptCalls() []promptCall {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]promptCall(nil), m.prompts...)
+}
+
+func (m *mockTarget) releaseCalls() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]string(nil), m.releases...)
+}
+
+func (m *mockTarget) observedPath() string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.lastPath
+}
+
+// keyedGate pins a fixed permission combination for a one-off test. For a
+// MUTABLE keyed gate driven through states by the shared contract, use
+// contracttesting.ConsentGate instead.
+type keyedGate map[string]bool
+
+func (g keyedGate) Granted(_, key string) bool { return g[key] }
+
+type mockLogger struct{}
+
+func (mockLogger) LogInfo(string, string, string)                       {}
+func (mockLogger) LogError(string, string, string)                      {}
+func (mockLogger) LogProcessingTime(string, string, int64, int, string) {}
+func (mockLogger) Close() error                                         { return nil }
+
+// --- helpers ---
+
+// contractSessionID is the opencode session id every contract wiring in this
+// package posts. It carries the "ses" prefix opencode's own SessionID schema
+// enforces, because the receiver drops anything else.
+const contractSessionID = "ses_19af5168cffem3E4MnRCcfxkNX"
+
+// opencodeStoreRoot relocates $HOME and clears $XDG_CONFIG_HOME, creates the
+// directory the OpenCode database would live in, and returns it.
+//
+// Every test in this package must isolate opencode's config dir to a
+// t.TempDir(), never the real ~/.config/opencode: this package's installer
+// WRITES a file. Clearing XDG_CONFIG_HOME is not ceremony — opencodeConfigDir
+// reads it, so a value leaking in from the developer's own environment would
+// point the installer at their real opencode installation.
+//
+// The directory it RETURNS is the store root rather than the config dir,
+// because that is what the PathDaemonDerived route plants its decoys in and
+// what StorePath() resolves inside.
+func opencodeStoreRoot(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv(configHomeEnvVar, "")
+	root := filepath.Dir(filepath.Join(home, dbRelPath))
+	if err := os.MkdirAll(root, 0o700); err != nil {
+		t.Fatalf("create store dir: %v", err)
+	}
+	return root
+}
+
+// writeContractTranscript is the shape the receiving-side contracts want: a
+// file inside dir that stands in for "the thing a caller might name".
+//
+// For this adapter it is a DECOY and nothing more. opencode's Source is an
+// agent.ProcessOwnedStore — there is no file per session, so no contract here
+// resolves a session id from a path, and this file exists only so the shared
+// wirings that ask for one get a well-formed path to hand over. Which
+// obligations that weakens is stated where each one is wired.
+func writeContractTranscript(t *testing.T, dir string) string {
+	t.Helper()
+	path := filepath.Join(dir, "decoy.jsonl")
+	if err := os.WriteFile(path, []byte(`{"type":"message"}`+"\n"), 0o600); err != nil {
+		t.Fatalf("write decoy: %v", err)
+	}
+	return path
+}
+
+// contractPayload renders the body irrlicht's own opencode plugin writes for
+// one event name — hook_event_name plus session_id, nothing else, matching
+// plugin.js's own JSON.stringify exactly.
+func contractPayload(event string) string {
+	body, err := json.Marshal(openCodeHookPayload{
+		HookEventName: event,
+		SessionID:     contractSessionID,
+	})
+	if err != nil {
+		panic(err)
+	}
+	return string(body)
+}
+
+// foreignPathPayload renders the body a HOSTILE caller would write: the real
+// payload plus a transcript_path key this adapter's own payload type does not
+// have. It is what AssertHookPathConfined's PathDaemonDerived route posts to
+// prove nothing the caller names reaches the dispatch.
+//
+// Hand-built rather than marshalled from a struct precisely because there is no
+// struct with that field — inventing one for the test would be inventing the
+// very surface the route asserts does not exist.
+func foreignPathPayload(path string) string {
+	encoded, err := json.Marshal(path)
+	if err != nil {
+		panic(err)
+	}
+	return `{"hook_event_name":"` + HookEventSessionIdle +
+		`","session_id":"` + contractSessionID +
+		`","transcript_path":` + string(encoded) + `}`
+}
+
+// post drives the handler with a raw JSON body and returns the response.
+func post(t *testing.T, h http.Handler, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, HookEndpointPath, strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	return rec
+}
+
+// newReceiver builds a fully-granted receiver plus the target it dispatches
+// into.
+func newReceiver(t *testing.T) (http.Handler, *mockTarget) {
+	t.Helper()
+	target := &mockTarget{}
+	gate := keyedGate{PermissionKeyHooks: true, PermissionKeyDatabase: true}
+	return NewHookHandler(target, gate, mockLogger{}), target
+}
+
+// --- behaviour ---
+
+// TestPermissionAskedHook_AssertsTheBlockedOnUserSignal pins the event that is
+// this adapter's whole reason for having a hook channel: opencode holds a
+// pending permission request in an in-memory Map and persists only APPROVED
+// patterns, so `waiting` is unreachable from the store the watcher reads.
+func TestPermissionAskedHook_AssertsTheBlockedOnUserSignal(t *testing.T) {
+	opencodeStoreRoot(t)
+	h, target := newReceiver(t)
+
+	rec := post(t, h, contractPayload(HookEventPermissionAsked))
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200", rec.Code)
+	}
+	prompts := target.promptCalls()
+	if len(prompts) != 1 {
+		t.Fatalf("HandlePermissionPromptHook called %d times, want 1", len(prompts))
+	}
+	if prompts[0].sessionID != contractSessionID {
+		t.Errorf("sessionID = %q, want %q", prompts[0].sessionID, contractSessionID)
+	}
+	if want := transcriptPathFor(contractSessionID); prompts[0].transcriptPath != want {
+		t.Errorf("transcriptPath = %q, want the daemon's own composed path %q", prompts[0].transcriptPath, want)
+	}
+	if prompts[0].hookName != HookEventPermissionAsked {
+		t.Errorf("hookName = %q, want %q", prompts[0].hookName, HookEventPermissionAsked)
+	}
+	if n := len(target.stops()); n != 0 {
+		t.Errorf("HandleStopHook called %d times for permission.asked, want 0", n)
+	}
+}
+
+// TestPermissionRepliedHook_ReleasesTheHold pins the release half. It is
+// load-bearing because opencode publishes permission.replied for a REJECTION
+// too — which is what keeps this adapter out of copilot's position, where a
+// denial emits nothing and the hold would sit until the 12-hour ceiling.
+func TestPermissionRepliedHook_ReleasesTheHold(t *testing.T) {
+	opencodeStoreRoot(t)
+	h, target := newReceiver(t)
+
+	rec := post(t, h, contractPayload(HookEventPermissionReplied))
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200", rec.Code)
+	}
+	if got := target.releaseCalls(); len(got) != 1 || got[0] != contractSessionID {
+		t.Fatalf("ReleasePermissionPromptHold calls = %v, want exactly [%q]", got, contractSessionID)
+	}
+	if n := len(target.stops()); n != 0 {
+		t.Errorf("HandleStopHook called %d times for permission.replied, want 0 — a reply is not a turn end", n)
+	}
+}
+
+// TestSessionIdleHook_ReleasesAndReportsTurnEnd pins BOTH dispatches
+// session.idle makes, and that the release comes with it.
+//
+// The release is not redundant with permission.replied. A run that is killed or
+// cancelled with a request still pending emits no reply at all, and
+// session.idle is the only event that still arrives — the same gap gemini-cli's
+// AfterAgent handler closes by calling ReleasePermissionPromptHold
+// unconditionally.
+func TestSessionIdleHook_ReleasesAndReportsTurnEnd(t *testing.T) {
+	opencodeStoreRoot(t)
+	h, target := newReceiver(t)
+
+	rec := post(t, h, contractPayload(HookEventSessionIdle))
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200", rec.Code)
+	}
+	if got := target.releaseCalls(); len(got) != 1 || got[0] != contractSessionID {
+		t.Errorf("ReleasePermissionPromptHold calls = %v, want exactly [%q] — a run torn down with a request pending emits no reply, so this is the only release it gets", got, contractSessionID)
+	}
+	stops := target.stops()
+	if len(stops) != 1 {
+		t.Fatalf("HandleStopHook called %d times, want 1", len(stops))
+	}
+	if stops[0].sessionID != contractSessionID {
+		t.Errorf("sessionID = %q, want %q", stops[0].sessionID, contractSessionID)
+	}
+	if want := transcriptPathFor(contractSessionID); stops[0].transcriptPath != want {
+		t.Errorf("transcriptPath = %q, want the daemon's own composed path %q", stops[0].transcriptPath, want)
+	}
+	if stops[0].lastAssistantText != "" {
+		t.Errorf("lastAssistantText = %q, want empty — opencode's session.idle carries no message text", stops[0].lastAssistantText)
+	}
+	if stops[0].waitingCue {
+		t.Error("waitingCue = true, want false — nothing in the payload can assert one")
+	}
+}
+
+// TestHookReceiver_DispatchedPathMatchesTheWatchers is the property that makes
+// a hook-delivered observation land on the SAME session the store watcher is
+// tracking: both key on transcriptPathFor, so a session cannot end up as two.
+//
+// It is a LOCK on a shared derivation rather than a new claim, which is why it
+// asserts against a watcher built through the production constructor rather
+// than against a second copy of the format string.
+func TestHookReceiver_DispatchedPathMatchesTheWatchers(t *testing.T) {
+	opencodeStoreRoot(t)
+	h, target := newReceiver(t)
+
+	post(t, h, contractPayload(HookEventSessionIdle))
+
+	want := New(0).transcriptPathFor(contractSessionID)
+	if got := target.observedPath(); got != want {
+		t.Errorf("receiver dispatched %q but the watcher emits %q for the same session — two spellings of one session are two sessions", got, want)
+	}
+}
+
+// TestHookReceiver_ForeignSessionIDIsQuiet is a LOCK: an id that is not one
+// opencode could have issued is dropped rather than turned into a phantom
+// session. The endpoint is local and unauthenticated, so "our own plugin wrote
+// it" buys nothing.
+func TestHookReceiver_ForeignSessionIDIsQuiet(t *testing.T) {
+	opencodeStoreRoot(t)
+	h, target := newReceiver(t)
+
+	rec := post(t, h, `{"hook_event_name":"`+HookEventSessionIdle+`","session_id":"not-a-session"}`)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200", rec.Code)
+	}
+	if n := target.totalCalls(); n != 0 {
+		t.Errorf("dispatched %d times for an id this adapter could not have issued, want 0", n)
+	}
+}
+
+// TestHookReceiver_PermissionGateContract runs the shared #797 contract once
+// per permission this receiver must honour, derived from the receiver's own
+// declaration (issue #1488).
+func TestHookReceiver_PermissionGateContract(t *testing.T) {
+	contracttesting.AssertHookReceiverPermissionGated(t, contracttesting.HookReceiverGate{
+		Build: func(t *testing.T, gate *contracttesting.ConsentGate) contracttesting.GatedHookReceiver {
+			opencodeStoreRoot(t)
+			body := contractPayload(HookEventSessionIdle)
+			target := &mockTarget{}
+			h := NewHookHandler(target, gate, mockLogger{})
+
+			before := 0
+			return contracttesting.GatedHookReceiver{
+				Handler: h,
+				Exercise: func() {
+					before = target.totalCalls()
+					post(t, h, body)
+				},
+				Observe: func() bool { return target.totalCalls() > before },
+			}
+		},
+	})
+}
+
+// TestHookReceiver_DeclaresItsPermissions is the LOCK on the key list the
+// wiring above used to spell out (#1450).
+func TestHookReceiver_DeclaresItsPermissions(t *testing.T) {
+	contracttesting.AssertDeclaredPermissions(t,
+		NewHookHandler(&mockTarget{}, nil, mockLogger{}),
+		PermissionKeyHooks, PermissionKeyDatabase)
+}
+
+// TestHookReceiver_NonPostRejected is a LOCK on the shared receiver shape.
+func TestHookReceiver_NonPostRejected(t *testing.T) {
+	opencodeStoreRoot(t)
+	h, _ := newReceiver(t)
+	req := httptest.NewRequest(http.MethodGet, HookEndpointPath, nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Errorf("GET status = %d, want 405", rec.Code)
+	}
+}
+
+// TestHookReceiver_MalformedJSONIs400 is a LOCK: a body that will not decode is
+// the one case that answers non-2xx.
+func TestHookReceiver_MalformedJSONIs400(t *testing.T) {
+	opencodeStoreRoot(t)
+	h, _ := newReceiver(t)
+	rec := post(t, h, "{not json")
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", rec.Code)
+	}
+}
+
+// TestHookReceiver_DeniedDatabaseConsentDropsQuietly pins that a
+// database-denied session must not dispatch even though the hooks consent is
+// granted, and must not log an error while doing it (the receiver's own gate
+// answers quietly; only the shared backstop logs).
+//
+// Since #1488's chokepoint the SILENCE is the surviving discriminator —
+// deleting the gate below leaves every dispatch-shaped assertion green, because
+// DecodeSealed re-checks the whole declared set and drops the payload itself.
+// What it does NOT reproduce is the quiet: reaching the backstop logs an error,
+// and an ordinary denied session must not collect one per event.
+func TestHookReceiver_DeniedDatabaseConsentDropsQuietly(t *testing.T) {
+	opencodeStoreRoot(t)
+	target := &mockTarget{}
+	log := &contracttesting.RecordingLogger{}
+	h := NewHookHandler(target, keyedGate{PermissionKeyHooks: true}, log)
+
+	rec := post(t, h, contractPayload(HookEventSessionIdle))
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200", rec.Code)
+	}
+	if n := target.totalCalls(); n != 0 {
+		t.Fatalf("dispatched %d times while database consent was denied, want 0", n)
+	}
+	if len(log.Errors()) != 0 {
+		t.Errorf("a database-denied hook logged %d error(s): %v", len(log.Errors()), log.Errors())
+	}
+}

--- a/core/adapters/inbound/agents/opencode/hookunknown_test.go
+++ b/core/adapters/inbound/agents/opencode/hookunknown_test.go
@@ -1,0 +1,38 @@
+// hookunknown_test.go wires this adapter's hook receiver into the shared issue
+// #1364 contract: an event name the receiver does not recognize is counted per
+// (adapter, name), reported once per distinct name, and still answered 2xx.
+//
+// It is not a hypothetical for this adapter, and for two independent reasons.
+// opencode's plugin API forwards its whole 30-plus-member bus through a single
+// `event` hook, so an upstream rename is a live-traffic event name this switch
+// does not know rather than a missing subscription. And, like pi, irrlicht's
+// own installed plugin can be NEWER than the daemon reading it — the file on
+// disk survives a daemon downgrade — so a future plugin that forwards a fourth
+// event delivers a name this switch has never heard of.
+package opencode
+
+import (
+	"testing"
+
+	"irrlicht/core/internal/contracttesting"
+	"irrlicht/core/ports/outbound"
+)
+
+func TestUnknownHookEventObserved(t *testing.T) {
+	contracttesting.AssertUnknownHookEventObserved(t, contracttesting.UnknownEventReceiver{
+		Adapter:         AdapterName,
+		Root:            opencodeStoreRoot,
+		WriteTranscript: writeContractTranscript,
+		New: func(t *testing.T, log outbound.Logger) contracttesting.UnknownEventReceiverUnderTest {
+			t.Helper()
+			target := &mockTarget{}
+			return contracttesting.UnknownEventReceiverUnderTest{
+				Handler:  NewHookHandler(target, nil, log),
+				Observed: func() bool { return target.totalCalls() > 0 },
+			}
+		},
+		PayloadFor:   func(_, event string) string { return contractPayload(event) },
+		KnownEvent:   HookEventSessionIdle,
+		EndpointPath: HookEndpointPath,
+	})
+}

--- a/core/adapters/inbound/agents/opencode/hookversion_test.go
+++ b/core/adapters/inbound/agents/opencode/hookversion_test.go
@@ -1,0 +1,64 @@
+// hookversion_test.go wires the opencode hooks permission into the shared issue
+// #1365 contract.
+//
+// Like geminicli, vibe and pi, this adapter declares no Observed version
+// source: opencode's store carries no CLI version column this adapter's reader
+// touches, so the gate falls straight through to Probe (`opencode --version`),
+// which cliversion runs itself.
+//
+// What is deliberately NOT here — BelowFloorSaysWhy, AtOrAboveFloorInstalls and
+// UnknownVersionFailsOpen — is issue #1762: six adapters carry hand-written
+// copies of three obligations the shared contract strictly dominates. Adding a
+// seventh copy would be adding to the thing #1762 exists to remove. pi's
+// hookversion_test.go carries the measurement of why the contract is stronger.
+package opencode
+
+import (
+	"testing"
+
+	"irrlicht/core/domain/agent"
+	"irrlicht/core/internal/contracttesting"
+)
+
+func TestHooksPermission_DeclaresVersionGate(t *testing.T) {
+	contracttesting.AssertHookVersionGate(t, contracttesting.HookVersionGate{
+		Agent:         Agent(),
+		PermissionKey: PermissionKeyHooks,
+		Installed:     installedHookEvents,
+		Since:         hookEventSince,
+	})
+}
+
+// hooksVersionGate returns the declared gate, read off the real registration
+// the daemon consumes rather than a copy.
+func hooksVersionGate(t *testing.T) *agent.VersionGate {
+	t.Helper()
+	for _, p := range Agent().Permissions {
+		if p.Key == PermissionKeyHooks {
+			if p.Writes == nil || p.Writes.Version == nil {
+				t.Fatal("hooks permission declares no version gate")
+			}
+			return p.Writes.Version
+		}
+	}
+	t.Fatal("no hooks permission")
+	return nil
+}
+
+// TestHooksGate_ProbeIsOpenCodeVersion pins the argv this adapter asks
+// cliversion to run. It is the one thing the shared contract does NOT cover:
+// assertVersionSourceDeclared only requires Observed or Probe to be non-empty,
+// never that the argv is the right one. `opencode --version` prints a bare
+// "1.14.50" (live-run against the installed CLI during this issue's audit).
+func TestHooksGate_ProbeIsOpenCodeVersion(t *testing.T) {
+	gate := hooksVersionGate(t)
+	want := []string{"opencode", "--version"}
+	if len(gate.Probe) != len(want) {
+		t.Fatalf("Probe = %v, want %v", gate.Probe, want)
+	}
+	for i := range want {
+		if gate.Probe[i] != want[i] {
+			t.Fatalf("Probe = %v, want %v", gate.Probe, want)
+		}
+	}
+}

--- a/core/adapters/inbound/agents/opencode/plugin.js
+++ b/core/adapters/inbound/agents/opencode/plugin.js
@@ -1,0 +1,110 @@
+// irrlicht session-status plugin for opencode — installed and owned by irrlichd.
+//
+// DO NOT EDIT. This file is rewritten whenever irrlicht's own binary path
+// changes and deleted when the "Install status hooks" permission is revoked
+// (also via `irrlichd --uninstall-hooks`).
+//
+// It exists because opencode has no config-file hook mechanism: `experimental`
+// carries no `hook` key in the version this was measured against, and a plugin
+// is the only subscription surface. See hookinstaller.go's header for the audit
+// that established that, and for why this file is written into opencode's
+// auto-discovery directory rather than registered with npm or a config entry.
+//
+// Everything in here is deliberate and narrow:
+//
+//   - It registers exactly ONE hook, `event`, which is opencode's read-only
+//     bus tap. It registers no tool, no auth, no provider, no command, and
+//     NOTHING that can change what opencode does.
+//
+//   - It never registers `permission.ask`. That is not a style preference:
+//     opencode's Plugin.trigger dispatches named hooks with NO try/catch, and
+//     `permission.ask` receives an `output` object whose `status` field the
+//     handler may set to "allow" or "deny". A monitoring plugin must not be
+//     able to answer a permission prompt on the user's behalf, or to throw
+//     inside the agent loop. The `event` bus carries the same fact
+//     (`permission.asked`) as an observation rather than a decision.
+//
+//   - The `event` hook is called for EVERY bus event, including one per
+//     streamed message part. The switch below is the first thing it does, and
+//     every event that is not one of the three named here costs a string
+//     compare and nothing else. Nothing is spawned, allocated or awaited on
+//     the common path.
+//
+//   - Nothing here is awaited on I/O and every failure path is swallowed.
+//     opencode runs this in-process; a monitoring plugin that can break a
+//     coding session is worse than no monitoring at all.
+//
+// Plain JavaScript, no TypeScript, no imports beyond node:child_process, and
+// no dependency on @opencode-ai/plugin. opencode's loader accepts .ts OR .js
+// (ConfigPlugin.load globs "{plugin,plugins}/*.{ts,js}"), so shipping .js means
+// there is no transform between the bytes irrlichd writes and the code that
+// runs, and no package resolution of any kind.
+import { spawn } from "node:child_process";
+
+// The command irrlichd renders at install time: `<abs irrlichd> --version
+// >/dev/null && <abs irrlichd> hook-post opencode >/dev/null || true`. It
+// carries NO host and NO port — the beacon reads the daemon's published
+// address at the moment the hook fires, so this file never goes stale when the
+// daemon moves. hookinstaller.go substitutes the literal below and reads it
+// back out again to decide whether an installed copy is current.
+const IRRLICHT_BEACON = "__IRRLICHT_BEACON_COMMAND__";
+
+// The three opencode bus events this plugin forwards, and nothing else.
+//
+//   permission.asked   — a permission prompt is open and the user is blocked
+//                        on it. opencode publishes this only when a pattern
+//                        actually needs asking (Permission.ask returns early
+//                        when every pattern already evaluates to "allow"), so
+//                        it is a narrow blocked-on-user signal, not a
+//                        fires-on-every-tool one.
+//   permission.replied — the user answered, including a rejection (opencode
+//                        publishes Replied for reply "reject" too, and
+//                        cascades it to that session's other pending
+//                        requests).
+//   session.idle       — the session's runner went idle: the turn ended, was
+//                        cancelled, or was interrupted. Authoritative turn end.
+const IRRLICHT_EVENTS = new Set(["permission.asked", "permission.replied", "session.idle"]);
+
+export default async function irrlichtPlugin() {
+	return {
+		// Called for every bus event. Async and fully wrapped: opencode
+		// dispatches this inside an Effect.sync with no try/catch of its own,
+		// so a synchronous throw here would tear down the subscription for
+		// every plugin. An async function cannot throw synchronously, and the
+		// try/catch means it cannot reject either.
+		event: async function irrlichtEvent(input) {
+			try {
+				const event = input?.event;
+				if (!event || !IRRLICHT_EVENTS.has(event.type)) return;
+				const sessionID = event.properties?.sessionID;
+				if (!sessionID || typeof sessionID !== "string") return;
+				post({ hook_event_name: event.type, session_id: sessionID });
+			} catch {
+				// Never let a monitoring plugin surface an error into the
+				// user's session.
+			}
+		},
+	};
+}
+
+// post hands one payload to the beacon on stdin and forgets about it. Every
+// failure is swallowed.
+//
+// The child is deliberately NOT unref()'d, for the reason pi's extension
+// records: an unref'd child stops holding the event loop open, and a
+// non-interactive run (`opencode run`) can exit immediately after the last
+// event — tearing the pipe down before the payload is flushed. The beacon
+// bounds its own wait and always exits 0, so holding the loop open costs a
+// bounded moment at exit rather than a hang.
+function post(payload) {
+	try {
+		const child = spawn("/bin/sh", ["-c", IRRLICHT_BEACON], {
+			stdio: ["pipe", "ignore", "ignore"],
+		});
+		child.on("error", () => {});
+		child.stdin.on("error", () => {});
+		child.stdin.end(JSON.stringify(payload));
+	} catch {
+		// spawn itself threw (no /bin/sh, resource limits). Nothing to do.
+	}
+}

--- a/core/adapters/inbound/agents/opencode/plugin_test.go
+++ b/core/adapters/inbound/agents/opencode/plugin_test.go
@@ -1,0 +1,324 @@
+// plugin_test.go grades the ARTIFACT this adapter ships — the JavaScript
+// irrlicht writes into a user's opencode installation — rather than the Go code
+// that writes it.
+//
+// It exists because that artifact is the one thing in this repository no other
+// mechanism can see. `go vet`, `go test`, the architecture tests and every
+// contract family reason about Go; plugin.js is an embedded string that
+// compiles no matter what it says. The guards below are what stands between
+// "the Go side is correct" and "the thing that actually runs inside the user's
+// agent is correct", and each one names the specific failure it would catch.
+//
+// What is NOT covered here, stated rather than implied: nothing in this file
+// executes the JavaScript. Running it needs either bun (which `go test
+// ./core/...` does not otherwise require, and a gate that could be absent is
+// the failure mode docs/testing-philosophy.md is about) or opencode itself
+// (which needs a model call). The end-to-end proof was therefore run by hand
+// during #1719 and reported in the PR. These guards pin the properties that run
+// confirmed, so a later edit that breaks one of them is caught without
+// re-running it.
+package opencode
+
+import (
+	"encoding/json"
+	"reflect"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// hookRegistrationRE finds the hook keys the shipped plugin registers on the
+// object it returns. opencode dispatches a hook by looking its NAME up on that
+// object, so the set of keys IS the set of hooks — anchored on the "<key>:"
+// property position rather than searching for the name anywhere in the file, so
+// a name inside a comment cannot read as a registration.
+//
+// The optional quotes are the whole guard, not tidiness. Ten of opencode's
+// fifteen hook names contain a dot ("permission.ask", "tool.execute.before",
+// …), which JavaScript cannot spell as a bare property key — so a pattern
+// matching only bare keys is blind to exactly the registrations that matter,
+// and `permission.ask` is the one this test exists to forbid. Measured: the
+// first draft of this pattern matched only bare keys, and the committed
+// mutation below (adding a `"permission.ask"` handler that writes
+// output.status) passed it.
+var hookRegistrationRE = regexp.MustCompile(`(?m)^\t\t"?([a-z][A-Za-z0-9.]*)"?:`)
+
+// TestShippedPluginRegistersOnlyTheReadOnlyEventTap is the guard with the
+// highest stake in this file.
+//
+// opencode wraps plugin LOADING in try/catch but NOT hook dispatch:
+// Plugin.trigger iterates the registered hooks and awaits each one with no
+// catch, and several of them receive a mutable `output` the handler is expected
+// to change. `permission.ask`'s output.status is a writable "allow" | "deny" |
+// "ask" — a monitoring plugin that registered it could answer a permission
+// prompt on the user's behalf, or throw inside the agent loop.
+//
+// `event` is the one hook that receives an event and returns nothing anyone
+// reads. This test fails if the shipped file ever registers a second one.
+func TestShippedPluginRegistersOnlyTheReadOnlyEventTap(t *testing.T) {
+	var registered []string
+	for _, m := range hookRegistrationRE.FindAllStringSubmatch(pluginTemplate, -1) {
+		registered = append(registered, m[1])
+	}
+	if len(registered) == 0 {
+		t.Fatal("no hook registration found in plugin.js at all — this guard's detector has stopped matching and would pass vacuously")
+	}
+	if !reflect.DeepEqual(registered, []string{"event"}) {
+		t.Errorf("plugin.js registers %v, want exactly [event]\n"+
+			"opencode dispatches named hooks with NO try/catch, and several of them "+
+			"(permission.ask above all) hand the handler a mutable output it can use to "+
+			"change what opencode does. A monitoring plugin must register only the "+
+			"read-only bus tap", registered)
+	}
+}
+
+// TestShippedPluginForwardsExactlyTheInstalledHookEvents binds the artifact to
+// the Go-side declaration.
+//
+// Two failures it catches, and they point in opposite directions: a plugin
+// forwarding an event installedHookEvents does not list delivers a name the
+// receiver's switch answers with IgnoreUnknownEvent forever, and a plugin
+// forwarding fewer means the consent copy — which derives its list and its count
+// from that same slice — over-promises what is installed.
+func TestShippedPluginForwardsExactlyTheInstalledHookEvents(t *testing.T) {
+	const marker = "const IRRLICHT_EVENTS = new Set(["
+	i := strings.Index(pluginTemplate, marker)
+	if i < 0 {
+		t.Fatalf("plugin.js no longer declares %q — this guard cannot run", marker)
+	}
+	rest := pluginTemplate[i+len(marker):]
+	j := strings.Index(rest, "]")
+	if j < 0 {
+		t.Fatal("plugin.js's IRRLICHT_EVENTS array is unterminated — this guard cannot run")
+	}
+
+	var forwarded []string
+	for _, raw := range strings.Split(rest[:j], ",") {
+		raw = strings.TrimSpace(raw)
+		if raw == "" {
+			continue
+		}
+		var name string
+		if err := json.Unmarshal([]byte(raw), &name); err != nil {
+			t.Fatalf("IRRLICHT_EVENTS entry %q is not a JSON string literal: %v", raw, err)
+		}
+		forwarded = append(forwarded, name)
+	}
+
+	want := append([]string(nil), installedHookEvents...)
+	sort.Strings(want)
+	sort.Strings(forwarded)
+	if !reflect.DeepEqual(forwarded, want) {
+		t.Errorf("plugin.js forwards %v but installedHookEvents declares %v — the shipped artifact and the consent copy disagree about what is installed",
+			forwarded, want)
+	}
+}
+
+// TestShippedPluginPayloadMatchesTheReceiversFields pins the wire between the
+// two halves of this feature. The plugin builds its JSON by hand and the
+// receiver decodes it into openCodeHookPayload; nothing in Go's type system
+// connects them, so a renamed field would simply arrive as a zero value and the
+// receiver would drop every hook in silence.
+func TestShippedPluginPayloadMatchesTheReceiversFields(t *testing.T) {
+	typ := reflect.TypeOf(openCodeHookPayload{})
+	for i := 0; i < typ.NumField(); i++ {
+		tag := typ.Field(i).Tag.Get("json")
+		if tag == "" || tag == "-" {
+			continue
+		}
+		name := strings.Split(tag, ",")[0]
+		if !strings.Contains(pluginTemplate, name+":") {
+			t.Errorf("openCodeHookPayload decodes %q but plugin.js never writes it — the receiver would see a zero value and drop the hook", name)
+		}
+	}
+}
+
+// TestShippedPluginImportsOnlyNodeBuiltins is the supply-chain guard, and it is
+// the one this whole adapter's consent copy stakes a claim on: "no npm, no git,
+// no build step". A third-party import would make that sentence false while
+// changing nothing a Go test would otherwise notice.
+//
+// It also pins that @opencode-ai/plugin is NOT imported. opencode
+// background-installs that package into every config directory, so importing it
+// would work — and would make the shipped file depend on a resolution step
+// nobody controls, for types a plain .js file cannot use anyway.
+func TestShippedPluginImportsOnlyNodeBuiltins(t *testing.T) {
+	importRE := regexp.MustCompile(`(?m)^import .* from "([^"]+)"`)
+	found := importRE.FindAllStringSubmatch(pluginTemplate, -1)
+	if len(found) == 0 {
+		t.Fatal("no import found in plugin.js at all — this guard's detector has stopped matching")
+	}
+	for _, m := range found {
+		if !strings.HasPrefix(m[1], "node:") {
+			t.Errorf("plugin.js imports %q, which is not a node: builtin — the consent copy promises no package is fetched from anywhere", m[1])
+		}
+	}
+}
+
+// TestShippedPluginExportsOnlyAFunction pins a loader fact rather than a
+// preference. opencode's loadExternal walks Object.values(module) and throws
+// TypeError("Plugin export is not a function") for any export that is neither a
+// function nor an object carrying server(). A second export of any other shape
+// would make the whole plugin fail to load — and opencode reports that as a
+// logged error while the agent continues, so the symptom would be silence.
+func TestShippedPluginExportsOnlyAFunction(t *testing.T) {
+	exportRE := regexp.MustCompile(`(?m)^export\b.*$`)
+	lines := exportRE.FindAllString(pluginTemplate, -1)
+	if len(lines) != 1 {
+		t.Fatalf("plugin.js has %d top-level export lines, want exactly 1: %v", len(lines), lines)
+	}
+	if !strings.HasPrefix(lines[0], "export default async function") {
+		t.Errorf("plugin.js's only export is %q, want a default async function — opencode calls the export with (input, options) and awaits the Hooks object it returns", lines[0])
+	}
+}
+
+// TestRenderedPluginCarriesTheCommandAndNothingAddressShaped is the
+// DeliveryAddressFree property at the artifact level: the rendered file names
+// the beacon command and contains nothing a daemon on a different port would
+// have to rewrite.
+func TestRenderedPluginCarriesTheCommandAndNothingAddressShaped(t *testing.T) {
+	const command = `/opt/irrlicht/irrlichd --version >/dev/null && /opt/irrlicht/irrlichd hook-post opencode >/dev/null || true`
+	rendered, err := renderPlugin(command)
+	if err != nil {
+		t.Fatalf("renderPlugin: %v", err)
+	}
+	got, ok := beaconCommandOf(rendered)
+	if !ok {
+		t.Fatal("the rendered plugin's beacon line does not read back — an installed copy could never be recognized as current")
+	}
+	if got != command {
+		t.Errorf("read back %q, want %q", got, command)
+	}
+	if strings.Contains(string(rendered), beaconCommandPlaceholder) {
+		t.Error("the rendered plugin still contains the placeholder — substitution did not happen")
+	}
+	for _, addressShaped := range []string{"127.0.0.1", "localhost", "http://", ":7837"} {
+		if strings.Contains(string(rendered), addressShaped) {
+			t.Errorf("the rendered plugin contains %q — a DeliveryAddressFree artifact carries no address, which is what makes the #1178 stale-port class inexpressible", addressShaped)
+		}
+	}
+}
+
+// TestRenderedPluginSurvivesAHostilePath is the property the substitution's use
+// of strconv.Quote exists for: the command embeds an absolute path the user
+// chose, and a path containing a quote or a backslash must not be able to
+// terminate the JavaScript string literal it lands in.
+func TestRenderedPluginSurvivesAHostilePath(t *testing.T) {
+	for _, command := range []string{
+		`/tmp/a"b/irrlichd hook-post opencode`,
+		`/tmp/a\b/irrlichd hook-post opencode`,
+		"/tmp/a\nb/irrlichd hook-post opencode",
+		"/tmp/a\\\"; process.exit(1); //b/irrlichd hook-post opencode",
+	} {
+		rendered, err := renderPlugin(command)
+		if err != nil {
+			t.Fatalf("renderPlugin(%q): %v", command, err)
+		}
+		got, ok := beaconCommandOf(rendered)
+		if !ok {
+			t.Errorf("renderPlugin(%q): the beacon line does not read back", command)
+			continue
+		}
+		if got != command {
+			t.Errorf("renderPlugin(%q) read back %q — the quoting did not round-trip, which means the literal was terminated early", command, got)
+		}
+	}
+}
+
+// TestRenderPluginRefusesWhenTheTemplateLostItsPlaceholder is the loud-failure
+// guard. A template that stopped carrying the token renderPlugin substitutes
+// would otherwise be installed verbatim — and the file would then shell out to
+// the literal string "__IRRLICHT_BEACON_COMMAND__" on every event.
+func TestRenderPluginRefusesWhenTheTemplateLostItsPlaceholder(t *testing.T) {
+	original := pluginTemplate
+	t.Cleanup(func() { pluginTemplate = original })
+	pluginTemplate = strings.Replace(pluginTemplate, beaconCommandPlaceholder, `"gone"`, 1)
+
+	if _, err := renderPlugin("irrlichd hook-post opencode"); err == nil {
+		t.Fatal("renderPlugin succeeded against a template with no placeholder — it would have installed a file that runs the placeholder as a command")
+	}
+}
+
+// TestRenderPluginRefusesAnEmptyCommand is the second half of the same
+// argument: an empty command renders a file that spawns `/bin/sh -c ""` on
+// every event, forever, silently.
+func TestRenderPluginRefusesAnEmptyCommand(t *testing.T) {
+	if _, err := renderPlugin(""); err == nil {
+		t.Fatal("renderPlugin(\"\") succeeded — the installed file would spawn an empty shell command on every opencode event")
+	}
+}
+
+// TestPlaceholderAppearsExactlyOnce pins what renderPlugin's single-replacement
+// substitution assumes. A second occurrence would be left in the installed file
+// verbatim.
+func TestPlaceholderAppearsExactlyOnce(t *testing.T) {
+	if n := strings.Count(pluginTemplate, beaconCommandPlaceholder); n != 1 {
+		t.Errorf("the placeholder appears %d times in plugin.js, want exactly 1 — renderPlugin substitutes only the first", n)
+	}
+}
+
+// TestHookRegistrationDetectorNamesEveryShape is the committed corpus for
+// hookRegistrationRE, in the shape core/architecture_hookbody_shapes_test.go
+// uses: one source per spelling, pinned to the verdict the detector must
+// return.
+//
+// It exists because this detector's first draft shipped with its worst hole,
+// and the hole came with an approved spelling. The pattern matched only BARE
+// property keys — which reads as complete until you notice that ten of
+// opencode's fifteen hook names contain a dot and therefore cannot be spelled
+// bare. Adding a `"permission.ask"` handler to the shipped file passed the
+// guard whose entire purpose is to forbid exactly that.
+//
+// The want:none rows carry most of the remaining value. A hook NAME inside a
+// comment and a key nested one level deeper are both things a looser rule would
+// call a registration, which is how a guard starts producing failures nobody
+// believes.
+func TestHookRegistrationDetectorNamesEveryShape(t *testing.T) {
+	cases := []struct {
+		name string
+		src  string
+		want []string
+	}{
+		{
+			// The vacuity guard: without it, a detector that matched nothing
+			// would satisfy every want:none row below.
+			name: "a bare key is a registration",
+			src:  "\treturn {\n\t\tevent: async () => {},\n\t}",
+			want: []string{"event"},
+		},
+		{
+			// The row this corpus exists for.
+			name: "a QUOTED dotted key is a registration",
+			src:  "\treturn {\n\t\t\"permission.ask\": async (_i, o) => { o.status = \"deny\" },\n\t}",
+			want: []string{"permission.ask"},
+		},
+		{
+			name: "both spellings in one object",
+			src:  "\treturn {\n\t\t\"tool.execute.before\": async () => {},\n\t\tevent: async () => {},\n\t}",
+			want: []string{"tool.execute.before", "event"},
+		},
+		{
+			name: "a hook name inside a comment is not a registration",
+			src:  "\treturn {\n\t\t// never register permission.ask: it can answer for the user\n\t\tevent: async () => {},\n\t}",
+			want: []string{"event"},
+		},
+		{
+			name: "a key nested deeper than the hooks object is not a registration",
+			src:  "\treturn {\n\t\tevent: async () => {\n\t\t\tconst payload = {\n\t\t\t\tsession_id: id,\n\t\t\t}\n\t\t},\n\t}",
+			want: []string{"event"},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			var got []string
+			for _, m := range hookRegistrationRE.FindAllStringSubmatch(c.src, -1) {
+				got = append(got, m[1])
+			}
+			if !reflect.DeepEqual(got, c.want) {
+				t.Errorf("detector returned %v, want %v\nsource:\n%s", got, c.want, c.src)
+			}
+		})
+	}
+}

--- a/core/adapters/inbound/agents/opencode/watcher.go
+++ b/core/adapters/inbound/agents/opencode/watcher.go
@@ -98,14 +98,21 @@ type sessionCursor struct {
 	lastObserved time.Time
 }
 
+// transcriptPathFor renders this watcher's own spelling of a session key.
+//
+// A method on the watcher rather than a call to the package-level
+// transcriptPathFor, because a watcher built with NewWithDBPath points at a
+// scratch database and must key sessions on THAT one; the package-level
+// function is what a caller with no watcher in hand (the hook receiver) uses,
+// and New() below makes the two agree by resolving through the same StorePath.
+func (w *Watcher) transcriptPathFor(sessionID string) string {
+	return w.dbPath + "-wal" + sessionQueryParam + sessionID
+}
+
 // New creates a Watcher for the OpenCode database relative to $HOME.
 func New(maxAge time.Duration) *Watcher {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		log.Printf("opencode: $HOME not set, using relative path: %v", err)
-	}
 	return &Watcher{
-		dbPath:            filepath.Join(home, dbRelPath),
+		dbPath:            StorePath(),
 		adapter:           AdapterName,
 		maxAge:            maxAge,
 		cursors:           make(map[string]*sessionCursor),
@@ -384,7 +391,7 @@ func (w *Watcher) maybeEmitNewSession(s sessionRow, cur *sessionCursor, live map
 	// parseTranscriptPath. The WAL suffix routes isStaleTranscript()
 	// at the WAL (updated on every write), not the checkpoint-only
 	// main DB.
-	walPath := w.dbPath + "-wal" + sessionQueryParam + s.id
+	walPath := w.transcriptPathFor(s.id)
 	w.broadcast(agent.Event{
 		Type:            agent.EventNewSession,
 		SessionID:       s.id,
@@ -451,7 +458,7 @@ func (w *Watcher) emitRemovedForArchivedSessions(db *sql.DB) {
 		if !known {
 			continue
 		}
-		walPath := w.dbPath + "-wal" + sessionQueryParam + id
+		walPath := w.transcriptPathFor(id)
 		w.broadcast(agent.Event{
 			Type:           agent.EventRemoved,
 			SessionID:      id,
@@ -544,7 +551,7 @@ func (w *Watcher) scanParts(db *sql.DB, sessionID, directory string, cur *sessio
 			Type:           agent.EventActivity,
 			SessionID:      sessionID,
 			ProjectDir:     filepath.Base(directory),
-			TranscriptPath: w.dbPath + "-wal" + sessionQueryParam + sessionID,
+			TranscriptPath: w.transcriptPathFor(sessionID),
 			CWD:            directory,
 			Terminal:       acc.hasTerminal,
 		})

--- a/core/architecture_hookbody_test.go
+++ b/core/architecture_hookbody_test.go
@@ -22,9 +22,22 @@
 //
 // So the obligation is moved from "a contract the next adapter must remember to
 // wire" to "the build fails": inside core/adapters/inbound/agents/..., reading
-// an inbound *http.Request's body is the exclusive privilege of
-// hookjson.DecodeConfined, which cannot decode without being handed a
-// *PathConfiner.
+// an inbound *http.Request's body happens in exactly one function, in one
+// package — hookjson's unexported readBody. Both of hookjson's entry points
+// funnel through it, and the one a receiver carrying a caller-supplied path
+// must use, DecodeConfined, cannot decode without being handed a *PathConfiner.
+//
+// The chokepoint is the unexported helper rather than DecodeConfined itself
+// because #1719 added a second entry point, DecodeSealed, for a receiver whose
+// payload names no filesystem path (opencode's store has no file per session,
+// so there is nothing a caller could name that the daemon would open). Naming
+// the shared helper keeps Arm B's claim EXACTLY as strong as it was — this
+// package reads a body in ONE function — where a second exempt entry-point name
+// would have turned a pin into a two-element list, which is the direction a
+// third one grows from. Which entry point a receiver may use is a different
+// question, graded from outside by contracttesting.AssertHookPathConfined's two
+// routes, whose obligations contradict each other so a wrong declaration cannot
+// pass quietly.
 //
 // # Why the rule in issue #1389 is not the rule implemented here
 //
@@ -94,8 +107,13 @@ const agentAdapterPattern = "./adapters/inbound/agents/..."
 // worse failure mode for a guard whose whole job is to be legible when broken.
 const (
 	chokepointPkg  = "irrlicht/core/adapters/inbound/agents/hookjson"
-	chokepointFunc = "DecodeConfined"
+	chokepointFunc = "readBody"
 )
+
+// chokepointEntryPoints are the exported functions readBody exists to serve.
+// Named only so the failure messages below can point a reader at the call they
+// should be making; the RULE is about chokepointFunc alone.
+const chokepointEntryPoints = "hookjson.DecodeConfined (a payload naming a path) or hookjson.DecodeSealed (a payload naming none)"
 
 // knownAgentPackages are packages the load MUST return. This is the vacuity
 // guard, and it is the one that matters: a pattern typo, a build break confined
@@ -108,6 +126,7 @@ var knownAgentPackages = []string{
 	"irrlicht/core/adapters/inbound/agents/claudecode",
 	"irrlicht/core/adapters/inbound/agents/codex",
 	"irrlicht/core/adapters/inbound/agents/copilot",
+	"irrlicht/core/adapters/inbound/agents/opencode",
 }
 
 // bodyConsumingMethods are *http.Request methods that read the request body
@@ -168,8 +187,8 @@ func TestNoDirectRequestBodyReadsInAgentAdapters(t *testing.T) {
 	// has to argue for itself in a reviewable diff.
 	for _, read := range outside {
 		t.Errorf("hook-body violation: %s reads an inbound *http.Request body at %s\n"+
-			"\tinside %s, an inbound request body may only be read by %s.%s, which cannot decode without a *PathConfiner (issue #1389)\n"+
-			"\tif this is a hook receiver: call hookjson.DecodeConfined instead of decoding r.Body yourself\n"+
+			"\tinside %s, an inbound request body may only be read by %s.%s (issue #1389)\n"+
+			"\tif this is a hook receiver: call "+chokepointEntryPoints+" instead of decoding r.Body yourself\n"+
 			"\tif this is a new kind of endpoint that carries no path: this rule has no exemption list by design — amend the rule, with a test",
 			read.Pkg, read, agentAdapterPattern, chokepointPkg, chokepointFunc)
 	}
@@ -205,7 +224,8 @@ func assertChokepointIsSingular(t *testing.T, inside []requestBodyRead) {
 		}
 		for _, read := range funcs[name] {
 			t.Errorf("hook-body violation: %s reads an inbound *http.Request body at %s\n"+
-				"\t%s is exempt only for %s — the single decode every receiver is forced through.\n"+
+				"\t%s is exempt only for %s — the single decode every receiver is forced through,\n"+
+				"\tbehind "+chokepointEntryPoints+".\n"+
 				"\tA second body-reading function here is a second way to skip confinement (issue #1389)",
 				chokepointPkg, read, chokepointPkg, chokepointFunc)
 		}

--- a/core/cmd/irrlichd/startup.go
+++ b/core/cmd/irrlichd/startup.go
@@ -21,6 +21,7 @@ import (
 	"irrlicht/core/adapters/inbound/agents/copilot"
 	"irrlicht/core/adapters/inbound/agents/geminicli"
 	"irrlicht/core/adapters/inbound/agents/kirocli"
+	"irrlicht/core/adapters/inbound/agents/opencode"
 	"irrlicht/core/adapters/inbound/agents/pi"
 	"irrlicht/core/adapters/inbound/agents/processlifecycle"
 	"irrlicht/core/adapters/inbound/agents/vibe"
@@ -970,6 +971,8 @@ func registerHookRoutes(mux *http.ServeMux, detector *services.SessionDetector, 
 		kirocli.NewHookHandler(detector, permService, logger))
 	mux.Handle("POST "+pi.HookEndpointPath,
 		pi.NewHookHandler(detector, permService, logger))
+	mux.Handle("POST "+opencode.HookEndpointPath,
+		opencode.NewHookHandler(detector, permService, logger))
 }
 
 // publishAddrFile writes the addr file and thereby signals "the daemon is

--- a/core/internal/contracttesting/hook_disclosure.go
+++ b/core/internal/contracttesting/hook_disclosure.go
@@ -47,9 +47,26 @@ var entryCountPattern = regexp.MustCompile(`(\d+) hook entr(?:y|ies)`)
 var eventShapedToken = regexp.MustCompile(`^[A-Z][a-z]+(?:[A-Z][a-z]+)+$`)
 
 // wordPattern splits consent copy into identifier-shaped words. Deliberately
-// includes digits and underscores so "cli_version" is one word rather than two,
-// which keeps a fragment from being mistaken for an event name.
-var wordPattern = regexp.MustCompile(`[A-Za-z][A-Za-z0-9_]*`)
+// whole-word: "PostToolUse" occurs inside "PostToolUseFailure", so a substring
+// test on copy naming only the latter would read as disclosing both.
+//
+// A word may contain INTERNAL dots, and that is #1719's addition rather than
+// laxity. Hook event names are not all single identifiers: opencode's are
+// "permission.asked", "permission.replied" and "session.idle", and under the
+// original pattern a copy naming them correctly tokenized as "permission",
+// "asked", ... so the names-every-installed-event arm could never be satisfied
+// by any wording at all — an adapter whose disclosure was RIGHT would have been
+// reported as undisclosed.
+//
+// A dot is only taken when a letter follows it, so ordinary sentence-final
+// punctuation is still excluded: "…writes the Stop hook." yields "Stop", not
+// "Stop.". What does change for the existing adapters is that a path-shaped
+// token like "settings.json" is now one word instead of two — measured against
+// every adapter's copy in the tree, no arm reads either half (the installed-set
+// arm looks for event names, and the over-promise arm's CamelCase test cannot
+// match a token containing a dot), which is why the widening is safe here and
+// is stated rather than assumed.
+var wordPattern = regexp.MustCompile(`[A-Za-z][A-Za-z0-9_]*(?:\.[A-Za-z][A-Za-z0-9_]*)*`)
 
 // HookDisclosure wires one adapter's hooks permission into
 // AssertHookDisclosureMatchesInstalled. Installed is the same slice the

--- a/core/internal/contracttesting/hook_path_confinement.go
+++ b/core/internal/contracttesting/hook_path_confinement.go
@@ -19,6 +19,7 @@
 package contracttesting
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -61,9 +62,54 @@ type HookReceiverUnderTest struct {
 	ObservedPath func() string
 }
 
+// PathRoute declares HOW a receiver obtains the transcript path it dispatches,
+// and therefore which obligations AssertHookPathConfined can grade it on.
+//
+// It is a DECLARATION, not an exemption, for the same reason
+// HookInstaller.Delivery is one (#1453): the two routes make CONTRADICTORY
+// assertions about the same two strings, so declaring the wrong one cannot pass
+// quietly. PathFromBody requires the dispatched path to VARY with what the
+// caller named — and requires an out-of-tree spelling to be refused outright —
+// while PathDaemonDerived requires it to be INVARIANT across every spelling a
+// caller can put on the wire. A from-body receiver declaring PathDaemonDerived
+// dispatches nothing for the hostile bodies and fails; a daemon-derived
+// receiver declaring PathFromBody dispatches for all of them and fails.
+type PathRoute int
+
+const (
+	// PathFromBody is the zero value and every receiver in the tree before
+	// #1719: the payload names a transcript file, that string is
+	// caller-supplied on a local unauthenticated endpoint, and the receiver
+	// confines it to the adapter's declared roots before anything downstream
+	// opens it. Six obligations.
+	PathFromBody PathRoute = iota
+
+	// PathDaemonDerived is a receiver whose payload names NO filesystem path,
+	// because the adapter has no file for a caller to name. #1719's opencode is
+	// the first: its Source is an agent.ProcessOwnedStore — one SQLite database,
+	// no file per session — so the "transcript path" the daemon keys a session
+	// on is a string the daemon COMPOSES from its own store resolver, and the
+	// hook body carries a session id and stops there.
+	//
+	// This is the confinement family's counterpart to
+	// DeliveryAddressFree: rather than confining the path-traversal class one
+	// more time, the route makes it INEXPRESSIBLE — there is no caller-supplied
+	// path on this receiver's dispatch path at all. So, exactly as the
+	// address-free delivery route does, the obligations assert that the
+	// property was actually OBTAINED (nothing the caller writes reaches the
+	// dispatch, and the receiver holds no confiner because it has nothing to
+	// confine) rather than being skipped.
+	PathDaemonDerived
+)
+
 // HookReceiver wires one adapter's hook receiver into AssertHookPathConfined.
 // Every field is required.
 type HookReceiver struct {
+	// Route declares how this receiver obtains the path it dispatches. The zero
+	// value, PathFromBody, is the caller-supplied-path route every receiver
+	// before #1719 takes; see PathRoute for why declaring the wrong one fails.
+	Route PathRoute
+
 	// Root relocates the adapter's declared transcript root to a
 	// test-controlled directory — by t.Setenv of whatever env var moves it
 	// ($HOME, $CODEX_HOME) — creates it, and returns its absolute path. Called
@@ -98,6 +144,31 @@ type HookReceiver struct {
 
 	// EndpointPath is the adapter's hook route, used to build the request.
 	EndpointPath string
+
+	// DerivedPath returns the exact string a PathDaemonDerived receiver must
+	// dispatch for the payload PayloadFor renders — the daemon's own composed
+	// path, resolved AFTER Root has run so it lands inside the test's scratch
+	// directories.
+	//
+	// Required for PathDaemonDerived and rejected for PathFromBody: a from-body
+	// receiver has no single answer to give here (its dispatched path is a
+	// function of what the caller sent), so a wiring that supplied one would be
+	// declaring the wrong route.
+	DerivedPath func(t *testing.T) string
+
+	// ForeignPathPayload renders a body this receiver WILL dispatch on, with a
+	// caller-supplied path spliced into it under whatever key a hostile caller
+	// would try — i.e. the body a PathDaemonDerived receiver must be indifferent
+	// to. Required for PathDaemonDerived and rejected for PathFromBody.
+	//
+	// The wiring renders it rather than the contract, because "the key a caller
+	// would try" is adapter-shaped: it is the field name the adapter's own
+	// payload struct would have carried had it carried one. The contract does
+	// check that this actually produced a DIFFERENT body from PayloadFor's — a
+	// wiring that ignored its argument would otherwise make the invariance
+	// obligation compare a string to itself, which is the "a mechanism that
+	// cannot run must fail loudly" rule in its local form.
+	ForeignPathPayload func(path string) string
 }
 
 // AssertHookPathConfined runs the issue #1361 contract against r. Six
@@ -151,6 +222,69 @@ type HookReceiver struct {
 // rule rather than leaving each adapter to rediscover it (issues #1361, #1364).
 func AssertHookPathConfined(t *testing.T, r HookReceiver) {
 	t.Helper()
+
+	// The route check and the PathDaemonDerived obligations are INLINE rather
+	// than two helpers, because a helper taking *testing.T first is exactly what
+	// seam_walk_test.go's rule 1 exists to stop: it could not be driven by a
+	// negative self-test, so its own failure would be un-gradeable. The arms it
+	// runs (assertDerivedDispatch, assertNoConfinerHeld) take reporter and ARE
+	// driven, in hook_path_confinement_selftest_test.go.
+	switch r.Route {
+	case PathDaemonDerived:
+		if r.DerivedPath == nil {
+			t.Fatal("Route is PathDaemonDerived but DerivedPath is nil — this route's whole claim is that the daemon composes the path, so there is nothing to compare the dispatch against")
+		}
+		if r.ForeignPathPayload == nil {
+			t.Fatal("Route is PathDaemonDerived but ForeignPathPayload is nil — without a body carrying a caller-supplied path, the invariance obligation would compare a string to itself")
+		}
+		// The PathDaemonDerived route. Three obligations, each independently
+		// failable:
+		//
+		//  1. a well-formed payload IS still dispatched — the vacuity guard, without
+		//     which a receiver that answers nothing at all satisfies 2 and 3 perfectly;
+		//  2. the string dispatched is the daemon's own composed path, and the receiver
+		//     holds no confiner — the two halves of "the property was obtained";
+		//  3. the dispatched string does not move when the body names a path, for each
+		//     of the four escapes the from-body route has to refuse.
+		//
+		// Obligation 3 is the one that makes this a route rather than an exemption: it
+		// contradicts obligations 2-5 of the other route directly. There, each of those
+		// four bodies must dispatch NOTHING; here, each must dispatch the SAME thing a
+		// clean body does.
+		t.Run("well_formed_payload_dispatches", func(t *testing.T) {
+			r.Root(t)
+			assertDerivedDispatch(realT(t), r, r.New(t), r.PayloadFor(""), r.DerivedPath(t), "a well-formed payload")
+		})
+		t.Run("dispatched_path_is_the_daemons_own", func(t *testing.T) {
+			r.Root(t)
+			rut := r.New(t)
+			assertDerivedDispatch(realT(t), r, rut, r.PayloadFor(""), r.DerivedPath(t), "a well-formed payload")
+			assertNoConfinerHeld(realT(t), rut)
+		})
+		for _, spelling := range hostilePathSpellings {
+			t.Run("dispatch_is_indifferent_to_"+spelling.name, func(t *testing.T) {
+				root := r.Root(t)
+				want := r.DerivedPath(t)
+				body := hostileBodyFor(t, r, spelling.path(t, root, t.TempDir()))
+				assertDerivedDispatch(realT(t), r, r.New(t), body, want, "a body naming "+spelling.name)
+			})
+		}
+		return
+	case PathFromBody:
+		// Deliberately a hard failure rather than a skip. The two routes'
+		// required fields are disjoint, so a wiring that supplied a
+		// PathDaemonDerived field on this route has either declared the wrong
+		// route or copied a neighbour's wiring wholesale — and in both cases the
+		// obligations that then run grade something other than what the author
+		// believes. That is the shape #1453 records for the delivery routes and
+		// the same answer applies here.
+		if r.DerivedPath != nil || r.ForeignPathPayload != nil {
+			t.Fatal("Route is PathFromBody (the zero value) but a PathDaemonDerived-only field is set — either the route declaration is wrong, or a neighbouring wiring was copied wholesale")
+		}
+	default:
+		t.Fatalf("unknown PathRoute %d", r.Route)
+	}
+
 	// Every wiring closure — Root, WriteTranscript, New — is called HERE, on
 	// the sub-test's real *testing.T, rather than inside an arm. That is the
 	// split AssertHookEndpointFollowsBindAddr already draws, and it is what
@@ -186,7 +320,7 @@ func AssertHookPathConfined(t *testing.T, r HookReceiver) {
 		outside := r.WriteTranscript(t, t.TempDir())
 		link := filepath.Join(mkSubdir(t, root, "linked"), filepath.Base(outside))
 		if err := os.Symlink(outside, link); err != nil {
-			t.Fatalf("symlink %s -> %s: %v", link, outside, err)
+			t.Fatalf(symlinkFailure, link, outside, err)
 		}
 		assertRefused(realT(t), r, r.New(t), link, whatSymlinkEscape)
 	})
@@ -197,7 +331,7 @@ func AssertHookPathConfined(t *testing.T, r HookReceiver) {
 		target := filepath.Join(t.TempDir(), "planted"+r.TranscriptExt)
 		link := filepath.Join(mkSubdir(t, root, "dangling"), filepath.Base(target))
 		if err := os.Symlink(target, link); err != nil {
-			t.Fatalf("symlink %s -> %s: %v", link, target, err)
+			t.Fatalf(symlinkFailure, link, target, err)
 		}
 		assertRefused(realT(t), r, r.New(t), link, whatDangling)
 	})
@@ -313,4 +447,114 @@ func assertRefused(t reporter, r HookReceiver, rut HookReceiverUnderTest, path, 
 func postHookPath(t reporter, r HookReceiver, rut HookReceiverUnderTest, path string) *httptest.ResponseRecorder {
 	t.Helper()
 	return postHookBody(t, rut.Handler, r.EndpointPath, r.PayloadFor(path))
+}
+
+// --- PathDaemonDerived route ---
+
+// plantedTranscriptName is the leaf every hostile spelling below points at. A
+// constant because five call sites name it and a sixth that misspelled it would
+// still plant a file, just not the one the case describes.
+const plantedTranscriptName = "planted.jsonl"
+
+// symlinkFailure is the fixture-failure message this file reports when a
+// symlink cannot be created. Named once so the three planting sites cannot
+// drift into three different spellings of the same environmental failure.
+const symlinkFailure = "symlink %s -> %s: %v"
+
+// hostilePathSpellings are the four bodies obligation 3 posts at a
+// PathDaemonDerived receiver. They are the SAME four escapes obligations 2-5
+// grade a from-body receiver on, which is the point: on this route each one
+// must be a no-op rather than a refusal, and running them proves the receiver
+// is indifferent to the exact inputs the other route has to defend against.
+var hostilePathSpellings = []struct {
+	name string
+	// path builds the caller-supplied path, given the relocated root and a
+	// scratch directory outside it.
+	path func(t *testing.T, root, outside string) string
+}{
+	{"out_of_tree", func(_ *testing.T, _, outside string) string {
+		return filepath.Join(outside, plantedTranscriptName)
+	}},
+	{"parent_traversal", func(_ *testing.T, root, outside string) string {
+		return root + strings.Repeat("/..", 32) + filepath.Join(outside, plantedTranscriptName)
+	}},
+	{"symlink_escape", func(t *testing.T, root, outside string) string {
+		target := filepath.Join(outside, plantedTranscriptName)
+		if err := os.WriteFile(target, []byte("{}\n"), 0o600); err != nil {
+			t.Fatalf("write %s: %v", target, err)
+		}
+		link := filepath.Join(mkSubdir(t, root, "linked"), plantedTranscriptName)
+		if err := os.Symlink(target, link); err != nil {
+			t.Fatalf(symlinkFailure, link, target, err)
+		}
+		return link
+	}},
+	{"dangling_symlink", func(t *testing.T, root, outside string) string {
+		target := filepath.Join(outside, "never-created.jsonl")
+		link := filepath.Join(mkSubdir(t, root, "dangling"), plantedTranscriptName)
+		if err := os.Symlink(target, link); err != nil {
+			t.Fatalf(symlinkFailure, link, target, err)
+		}
+		return link
+	}},
+}
+
+// hostileBodyFor renders the body one hostile spelling posts, and refuses the
+// run when the wiring's ForeignPathPayload did not actually splice the path in.
+//
+// Fixture machinery, not an obligation, which is why it reports on *testing.T
+// and is named in seam_walk_test.go's deferredToTheSeam: a wiring that ignored
+// its argument would make the invariance obligation compare the clean dispatch
+// to itself, and "this obligation could not run" must be loud rather than
+// recorded as the obligation firing (#1479).
+func hostileBodyFor(t *testing.T, r HookReceiver, hostile string) string {
+	t.Helper()
+	body := r.ForeignPathPayload(hostile)
+	if body == r.PayloadFor("") {
+		t.Fatalf("ForeignPathPayload(%q) rendered the same body as PayloadFor — this obligation cannot run, and would otherwise report a pass having posted nothing hostile", hostile)
+	}
+	if !strings.Contains(body, jsonEscapedFragment(hostile)) {
+		t.Fatalf("ForeignPathPayload(%q) rendered a body that does not contain that path — this obligation cannot run: %s", hostile, body)
+	}
+	return body
+}
+
+// assertDerivedDispatch is the shared grading step of all three obligations: a
+// POST of body must be answered 2xx, must dispatch, and must dispatch exactly
+// want.
+func assertDerivedDispatch(t reporter, r HookReceiver, rut HookReceiverUnderTest, body, want, what string) {
+	t.Helper()
+	rec := postHookBody(t, rut.Handler, r.EndpointPath, body)
+	assertHookStatus2xx(t, rec, what)
+	if !rut.Observed() {
+		t.Fatalf("%s dispatched nothing — on the PathDaemonDerived route every body the receiver understands must dispatch the daemon's own path, so this is either a broken receiver or a wiring that declared the wrong route", what)
+	}
+	if got := rut.ObservedPath(); got != want {
+		t.Errorf("%s dispatched %q, want the daemon's own composed path %q — on this route nothing a caller writes may reach the dispatch, and a path that MOVED with the body is a caller-supplied path travelling under a different name", what, got, want)
+	}
+}
+
+// assertNoConfinerHeld is the structural half of obligation 2. A
+// PathDaemonDerived receiver reaches its payload through
+// hookjson.DecodeSealed, which takes no confiner; a nil Confiner is what makes
+// DecodeConfined fail closed for it, so a later edit that switched the receiver
+// back to the confining decode without giving it roots drops payloads instead
+// of dispatching unconfined ones.
+func assertNoConfinerHeld(t reporter, rut HookReceiverUnderTest) {
+	t.Helper()
+	if rut.Handler.Confiner != nil {
+		t.Errorf("the receiver publishes a PathConfiner (%d rejection(s) so far) while declaring PathDaemonDerived — a receiver that holds a confiner has something to confine, which is the PathFromBody route",
+			rut.Handler.Confiner.RejectionCount())
+	}
+}
+
+// jsonEscapedFragment renders path the way it appears inside a JSON string, so
+// the guard above matches a body built with encoding/json (which escapes
+// backslashes) as well as one built by hand.
+func jsonEscapedFragment(path string) string {
+	b, err := json.Marshal(path)
+	if err != nil {
+		return path
+	}
+	return strings.Trim(string(b), `"`)
 }

--- a/core/internal/contracttesting/hook_path_confinement_derived_selftest_test.go
+++ b/core/internal/contracttesting/hook_path_confinement_derived_selftest_test.go
@@ -1,0 +1,279 @@
+// hook_path_confinement_derived_selftest_test.go is the committed mutation
+// evidence for AssertHookPathConfined's PathDaemonDerived route (#1719), the
+// same lock hook_path_confinement_selftest_test.go is for the PathFromBody one.
+//
+// The route is new, so unlike its sibling there is no recorded matrix to
+// transcribe. The three mutations below are therefore derived from what the
+// route CLAIMS, one per claim, and each names the obligations it must leave
+// SILENT — which is half the evidence: without it, three mutations against
+// three obligations are equally satisfied by three arms that all report on
+// everything.
+//
+// The middle one is the route's whole reason for existing. A receiver that
+// dispatches the daemon's own path for an ordinary body, and the CALLER'S path
+// as soon as one is present, is indistinguishable from a correct receiver on
+// every other assertion in this package — it answers 2xx, it dispatches, it
+// counts its receipts, its consent gating is intact. Only
+// dispatch_is_indifferent_to_* separates them.
+package contracttesting
+
+import (
+	"encoding/json"
+	"net/http"
+	"path/filepath"
+	"testing"
+
+	"irrlicht/core/adapters/inbound/agents/hookjson"
+	"irrlicht/core/ports/outbound"
+)
+
+// sealedBreak names the ways a PathDaemonDerived receiver can be wrong. Its
+// ZERO VALUE is a correct receiver, so a case names what it broke and nothing
+// else — the same shape receiverBreak draws for the from-body route.
+type sealedBreak struct {
+	// silent makes the receiver decode and then dispatch nothing.
+	silent bool
+
+	// echoesTheBody makes the receiver dispatch a transcript_path the caller
+	// supplied, when the body carries one, instead of the daemon's own path.
+	// This is the defect the whole route exists to catch.
+	echoesTheBody bool
+
+	// holdsConfiner publishes a PathConfiner on the handler. A receiver with a
+	// confiner has something to confine, which is the other route.
+	holdsConfiner bool
+}
+
+// sealedEvent is the one event the fixture receiver understands.
+const sealedEvent = "irr.sealed.event"
+
+// sealedSessionID is the id the fixture's payloads carry, and the input its
+// daemon-side path composition is a function of.
+const sealedSessionID = "ses_selftest"
+
+// sealedPayload is the fixture's payload type. It carries transcript_path
+// deliberately — a correct receiver on this route IGNORES it, and a fixture
+// that could not decode it could not express the echoesTheBody mutation at all.
+type sealedPayload struct {
+	HookEventName  string `json:"hook_event_name"`
+	SessionID      string `json:"session_id"`
+	TranscriptPath string `json:"transcript_path"`
+}
+
+// sealedDerivedPath is the "daemon composes it" half: a function of the session
+// id and a root the daemon owns, never of anything on the wire.
+func sealedDerivedPath(root string) string {
+	return filepath.Join(root, "store.db-wal") + "?session=" + sealedSessionID
+}
+
+// silentLogger is the fixture's logger. The arms under test grade dispatch and
+// the handler's fields; nothing here reads log output.
+type silentLogger struct{}
+
+func (silentLogger) LogInfo(string, string, string)                       {}
+func (silentLogger) LogError(string, string, string)                      {}
+func (silentLogger) LogProcessingTime(string, string, int64, int, string) {}
+func (silentLogger) Close() error                                         { return nil }
+
+var _ outbound.Logger = silentLogger{}
+
+// fakeSealedReceiver builds the wiring and the receiver a case drives.
+//
+// The receiver is built the production way — hookjson.NewHandler over
+// hookjson.RequireConsent, decoding through hookjson.DecodeSealed — so a
+// silence here is a silence against production code rather than against a
+// stand-in. The three mutations are all downstream of the decode, which is why
+// this family needs no hand-rolled-but-faithful baseline the way the from-body
+// one does: every case reaches its payload through the same call.
+func fakeSealedReceiver(t *testing.T, brk sealedBreak) (HookReceiver, HookReceiverUnderTest) {
+	t.Helper()
+	root := t.TempDir()
+	want := sealedDerivedPath(root)
+
+	var dispatched string
+	var confiner *hookjson.PathConfiner
+	if brk.holdsConfiner {
+		confiner = hookjson.NewPathConfiner(func() []string { return []string{root} }, "")
+	}
+
+	handler := hookjson.NewHandler(confiner,
+		hookjson.RequireConsent(nil, "selftest", "hooks"),
+		func(consent hookjson.Consent, _ *hookjson.PathConfiner, w http.ResponseWriter, r *http.Request) {
+			var p sealedPayload
+			if !hookjson.DecodeSealed(w, r, silentLogger{}, "selftest", consent, &p) {
+				return
+			}
+			if p.HookEventName == sealedEvent && !brk.silent {
+				if brk.echoesTheBody && p.TranscriptPath != "" {
+					dispatched = p.TranscriptPath
+				} else {
+					dispatched = want
+				}
+			}
+			w.WriteHeader(http.StatusOK)
+		})
+
+	// Assigned and then returned, rather than returned as two composite
+	// literals in one statement: gofmt 1.25 and 1.27 indent that construct
+	// differently, so the second spelling makes the file's formatting depend on
+	// which toolchain last touched it.
+	wiring := HookReceiver{
+		Route: PathDaemonDerived,
+		Root:  func(*testing.T) string { return root },
+		PayloadFor: func(string) string {
+			return sealedBody(sealedPayload{HookEventName: sealedEvent, SessionID: sealedSessionID})
+		},
+		ForeignPathPayload: func(path string) string {
+			return sealedBody(sealedPayload{HookEventName: sealedEvent, SessionID: sealedSessionID, TranscriptPath: path})
+		},
+		DerivedPath:  func(*testing.T) string { return want },
+		EndpointPath: "/api/v1/hooks/selftest",
+	}
+	rut := HookReceiverUnderTest{
+		Handler:      handler,
+		Observed:     func() bool { return dispatched != "" },
+		ObservedPath: func() string { return dispatched },
+	}
+	return wiring, rut
+}
+
+func sealedBody(p sealedPayload) string {
+	b, err := json.Marshal(p)
+	if err != nil {
+		panic(err)
+	}
+	return string(b)
+}
+
+// sealedArmBuilder is this family's obligation table entry. It is local rather
+// than reusing armBuilder because that type is typed on receiverBreak, which is
+// the from-body fixture's break set and cannot express any of the three above.
+type sealedArmBuilder struct {
+	name  string
+	build func(*testing.T, sealedBreak) func(armT)
+}
+
+// sealedArmBuilders mirrors the PathDaemonDerived branch of
+// AssertHookPathConfined, in its order and with its inputs.
+//
+// It restates that branch rather than sharing it, which is the trade every
+// <family>_selftest_test.go in this package makes. The vacuity guard is what
+// keeps the restatement honest: a construction that drifted into something an
+// arm legitimately rejects turns TestDerivedRouteArms_PassACorrectReceiver red,
+// not green.
+//
+// Only ONE of the four hostile spellings is reproduced here, and deliberately.
+// The entry point runs all four; what differs between them is the FIXTURE PATH
+// (an out-of-tree file, a traversal, two symlinks), and on this route the
+// receiver never looks at that string at all, so four cases would grade one
+// behaviour four times. The out-of-tree spelling is the one kept because it is
+// the only one that needs no symlink support to plant.
+func sealedArmBuilders() []sealedArmBuilder {
+	return []sealedArmBuilder{
+		{"well_formed_payload_dispatches", func(t *testing.T, brk sealedBreak) func(armT) {
+			r, rut := fakeSealedReceiver(t, brk)
+			body, want := r.PayloadFor(""), r.DerivedPath(t)
+			return func(at armT) { assertDerivedDispatch(at, r, rut, body, want, "a well-formed payload") }
+		}},
+		{"dispatch_is_indifferent_to_out_of_tree", func(t *testing.T, brk sealedBreak) func(armT) {
+			r, rut := fakeSealedReceiver(t, brk)
+			hostile := filepath.Join(t.TempDir(), "planted.jsonl")
+			body, want := r.ForeignPathPayload(hostile), r.DerivedPath(t)
+			return func(at armT) { assertDerivedDispatch(at, r, rut, body, want, "a body naming out_of_tree") }
+		}},
+		{"no_confiner_held", func(t *testing.T, brk sealedBreak) func(armT) {
+			_, rut := fakeSealedReceiver(t, brk)
+			return func(at armT) { assertNoConfinerHeld(at, rut) }
+		}},
+	}
+}
+
+// driveSealed builds and runs ONE named obligation against a receiver broken by
+// brk, looked up BY NAME so a case cannot silently grade a different obligation
+// than the one it claims to.
+func driveSealed(t *testing.T, brk sealedBreak, obligation string) *recordingT {
+	t.Helper()
+	for _, b := range sealedArmBuilders() {
+		if b.name == obligation {
+			return observe(t, b.build(t, brk))
+		}
+	}
+	t.Fatalf("no obligation named %q — the mutation table and AssertHookPathConfined's PathDaemonDerived branch have drifted apart", obligation)
+	return nil
+}
+
+// sealedMustBeSilentOn drives every obligation in others against brk and
+// asserts none of them reports.
+func sealedMustBeSilentOn(t *testing.T, brk sealedBreak, what string, others ...string) {
+	t.Helper()
+	for _, name := range others {
+		t.Run("silent_on_"+name, func(t *testing.T) {
+			mustBeSilent(t, driveSealed(t, brk, name), what)
+		})
+	}
+}
+
+// TestDerivedRouteArms_PassACorrectReceiver is the family's vacuity guard.
+// Without it, an arm that reported unconditionally would satisfy every mutation
+// below and read as excellent coverage.
+func TestDerivedRouteArms_PassACorrectReceiver(t *testing.T) {
+	for _, b := range sealedArmBuilders() {
+		t.Run(b.name, func(t *testing.T) {
+			mustBeSilent(t, observe(t, b.build(t, sealedBreak{})), "a correct daemon-derived receiver")
+		})
+	}
+}
+
+// TestDerivedRouteObligation1_WellFormedPayloadDispatches is the vacuity
+// obligation of the route itself: a receiver that answers 2xx and dispatches
+// nothing satisfies the two negative-shaped obligations perfectly, exactly as
+// #1446's M1 does on the from-body route.
+func TestDerivedRouteObligation1_WellFormedPayloadDispatches(t *testing.T) {
+	brk := sealedBreak{silent: true}
+
+	rec := driveSealed(t, brk, "well_formed_payload_dispatches")
+	mustReport(t, rec, "a well-formed payload dispatched nothing",
+		"a receiver that decodes the payload and then dispatches nothing")
+
+	sealedMustBeSilentOn(t, brk, "a receiver that dispatches nothing", "no_confiner_held")
+}
+
+// TestDerivedRouteObligation2_DispatchIsIndifferentToTheBody is the route's
+// reason for existing.
+//
+// The mutation is one line — dispatch the caller's transcript_path when the
+// body carries one — and it is invisible to every other assertion in this
+// package: the receiver still answers 2xx, still dispatches, still counts its
+// receipt, still honours its consent. On the from-body route the equivalent
+// receiver is the CORRECT one, which is precisely why the two routes'
+// obligations have to contradict each other.
+//
+// The silence on obligation 1 is what makes this a separate obligation rather
+// than a second spelling of it: a clean body carries no path, so an echoing
+// receiver dispatches the daemon's own string for it and passes.
+func TestDerivedRouteObligation2_DispatchIsIndifferentToTheBody(t *testing.T) {
+	brk := sealedBreak{echoesTheBody: true}
+
+	rec := driveSealed(t, brk, "dispatch_is_indifferent_to_out_of_tree")
+	mustReport(t, rec, "want the daemon's own composed path",
+		"a receiver that dispatches the caller's transcript_path whenever the body carries one")
+
+	sealedMustBeSilentOn(t, brk, "a receiver that echoes a caller-supplied path only when one is present",
+		"well_formed_payload_dispatches", "no_confiner_held")
+}
+
+// TestDerivedRouteObligation3_NoConfinerHeld pins the structural half of "the
+// property was obtained". A receiver holding a confiner has something to
+// confine, which is the PathFromBody route — and a nil confiner is what makes
+// hookjson.DecodeConfined fail CLOSED if a later edit switches such a receiver
+// back to the confining decode without giving the adapter roots.
+func TestDerivedRouteObligation3_NoConfinerHeld(t *testing.T) {
+	brk := sealedBreak{holdsConfiner: true}
+
+	rec := driveSealed(t, brk, "no_confiner_held")
+	mustReport(t, rec, "publishes a PathConfiner",
+		"a receiver that publishes a confiner while declaring PathDaemonDerived")
+
+	sealedMustBeSilentOn(t, brk, "a receiver that holds an unused confiner",
+		"well_formed_payload_dispatches", "dispatch_is_indifferent_to_out_of_tree")
+}

--- a/core/internal/contracttesting/hook_path_confinement_selftest_test.go
+++ b/core/internal/contracttesting/hook_path_confinement_selftest_test.go
@@ -79,7 +79,7 @@ func confinementArmBuilders() []armBuilder {
 			outside := r.WriteTranscript(t, t.TempDir())
 			link := filepath.Join(mkSubdir(t, root, "linked"), filepath.Base(outside))
 			if err := os.Symlink(outside, link); err != nil {
-				t.Fatalf("symlink %s -> %s: %v", link, outside, err)
+				t.Fatalf(symlinkFailure, link, outside, err)
 			}
 			rut := r.New(t)
 			return func(at armT) { assertRefused(at, r, rut, link, whatSymlinkEscape) }
@@ -92,7 +92,7 @@ func confinementArmBuilders() []armBuilder {
 			target := filepath.Join(t.TempDir(), "planted"+r.TranscriptExt)
 			link := filepath.Join(mkSubdir(t, root, "dangling"), filepath.Base(target))
 			if err := os.Symlink(target, link); err != nil {
-				t.Fatalf("symlink %s -> %s: %v", link, target, err)
+				t.Fatalf(symlinkFailure, link, target, err)
 			}
 			rut := r.New(t)
 			return func(at armT) { assertRefused(at, r, rut, link, whatDangling) }

--- a/core/internal/contracttesting/seam_walk_test.go
+++ b/core/internal/contracttesting/seam_walk_test.go
@@ -110,6 +110,9 @@ var deferredToTheSeam = map[string]string{
 	"unknownEventTranscript": "fixture construction, same shape as receiptTranscript (#1479).",
 	"unknownEventName": "derives a per-sub-test, per-invocation event name from t.Name(), which no " +
 		"reporter carries. It decides no verdict; a name it cannot derive is a fixture failure (#1364, #1479).",
+	"hostileBodyFor": "fixture construction: renders the body one PathDaemonDerived case posts and " +
+		"refuses when the wiring's ForeignPathPayload ignored its argument. A fixture that cannot be " +
+		"BUILT must be loud rather than recorded as the obligation firing (#1479, #1719).",
 	"unknownEventHash": "the t.Name() half the two name functions share, so they cannot drift onto " +
 		"different derivations. It decides no verdict (#1512 review).",
 }

--- a/docs/ci-gates.md
+++ b/docs/ci-gates.md
@@ -37,8 +37,9 @@ CI parity section (chunking, the budget, and what it makes visible).
   `NeedSyntax|NeedTypes|NeedTypesInfo` over a narrow pattern rather than
   `NeedName|NeedImports` over the module. It enforces that inside
   `core/adapters/inbound/agents/...` an inbound `*http.Request`'s body may be
-  read only by `hookjson.DecodeConfined` — see "Hook path confinement" below
-  for why. Its corpus is `core/architecture_hookbody_shapes_test.go`: one file
+  read only by `hookjson.readBody`, the single decode both of that package's
+  entry points (`DecodeConfined`, `DecodeSealed`) funnel through — see "Hook
+  path confinement" below for why. Its corpus is `core/architecture_hookbody_shapes_test.go`: one file
   per spelling (decoder in a variable, `io.ReadAll`, an aliased body, a helper
   in another file, `r.FormValue`, a request stashed in a struct field) pinned
   to the verdict the detector must return, plus two `want:false` cases —

--- a/docs/testing-contracts.md
+++ b/docs/testing-contracts.md
@@ -215,7 +215,36 @@ below.
   inbound hook body is caller-supplied on a local, unauthenticated endpoint, so
   a receiver confines it to the adapter's own declared transcript roots
   (`agent.Source`'s `FilesUnderRoot.AllRootsFor`, never a second list that can
-  drift) before anything downstream opens it. Six obligations: an in-tree path
+  drift) before anything downstream opens it.
+  Like the delivery family, it grades against a ROUTE the wiring declares
+  (`HookReceiver.Route`, #1719), because there are two ways to satisfy it and
+  the second makes the first unsatisfiable. `PathFromBody` — the zero value, and
+  every receiver before #1719 — is the six obligations below. `PathDaemonDerived`
+  is a receiver whose payload names no filesystem path, because the adapter has
+  no file for a caller to name: opencode's `Source` is an
+  `agent.ProcessOwnedStore`, one SQLite database with no file per session, so
+  the path every consumer keys a session on is composed by the daemon from its
+  own store resolver and the body carries a session id. That route reaches its
+  payload through `hookjson.DecodeSealed` rather than `DecodeConfined`, and its
+  three obligations assert the property was actually OBTAINED — a well-formed
+  payload still dispatches (the vacuity guard), the dispatched string is the
+  daemon's own composed path, and it does not MOVE when the body names an
+  out-of-tree path, a `..` traversal or a symlink. That is the same move
+  `DeliveryAddressFree` makes: rather than confining the traversal class once
+  more, the route makes it inexpressible. Declaring the wrong route cannot pass
+  quietly, which is why this is a declaration and not an exemption: the two
+  routes make contradictory assertions about the same two strings — from-body
+  requires each hostile spelling to be REFUSED (nothing dispatched) while
+  daemon-derived requires each to dispatch the IDENTICAL string a clean body
+  does — so a from-body receiver that declared `PathDaemonDerived` and a
+  daemon-derived one that declared `PathFromBody` both go red. Note what the
+  route costs elsewhere, stated rather than left implied: `AssertHookReceiptObserved`'s
+  third obligation ("a path-confinement rejection still counts") degenerates
+  into a repeat of its first for such a receiver, since the body it posts is
+  indistinguishable from a clean one. That arm is kept with no opt-out anyway,
+  for the reason `OtherKeys` is on an install-type permission gate — a flag this
+  wiring could take is one a from-body wiring could take too.
+  The from-body route's six obligations: an in-tree path
   is still accepted (the vacuity guard); an out-of-tree path, a `..`
   traversal, a symlink planted inside the root and a *dangling* symlink inside
   the root are each refused, logged and counted; and for a path that IS
@@ -274,11 +303,18 @@ below.
   cannot reach its payload without supplying one), and
   `core/architecture_hookbody_test.go` fails the build if anything else under
   `core/adapters/inbound/agents/...` reads an inbound request body. Two arms:
-  none outside `hookjson`, and **exactly one** inside it, in `DecodeConfined` —
-  the second is what stops the exemption being a hole, and doubles as the
-  vacuity guard. There is deliberately **no exemption list** (neither has
+  none outside `hookjson`, and **exactly one** inside it — the second is what
+  stops the exemption being a hole, and doubles as the vacuity guard. Since
+  #1719 that one function is the unexported `hookjson.readBody` rather than
+  `DecodeConfined` itself, because `DecodeSealed` joined it as a second entry
+  point (see the `PathDaemonDerived` route above) and both funnel through it.
+  Naming the shared helper keeps Arm B's claim EXACTLY as strong as it was —
+  this package reads a body in ONE function — where a second exempt entry-point
+  NAME would have turned a pin into a two-element list, which is the direction a
+  third one grows from. There is deliberately **no exemption list** (neither has
   `architecture_test.go`): an endpoint that genuinely carries no path amends the
-  rule in a reviewable diff. The archaeology — why the rule #1389 proposed
+  rule in a reviewable diff — which is what #1719 did, in one line of that
+  file plus a route on the contract that grades what replaces confinement. The archaeology — why the rule #1389 proposed
   (keying on files referencing a `HookEndpointPath`) selects zero receiver files
   and would have passed against the very bug it was written for, and the four
   things the implemented rule does not cover — is in that file's header, next to
@@ -298,9 +334,9 @@ below.
   accepted path on the adapter's DECLARED root — which on macOS is the `/var`
   spelling of a `/private/var` temp dir, and a naive comparison fails there for
   a reason unrelated to the obligation.
-  `DecodeConfined` also bounds the body (`http.MaxBytesReader`, 1 MiB): these
-  endpoints are unauthenticated and local, and sharing one decode is what lets
-  every receiver, present and future, inherit the bound.
+  `readBody` also bounds the body (`http.MaxBytesReader`, 1 MiB) for both entry
+  points: these endpoints are unauthenticated and local, and sharing one decode
+  is what lets every receiver, present and future, inherit the bound.
 - Hook version floors: `contracttesting.AssertHookVersionGate`
   (`core/internal/contracttesting/hook_version.go`) is the static half of
   #1365 — a hooks permission declares the minimum upstream CLI version its

--- a/replaydata/agents/opencode/driver-interactive.sh
+++ b/replaydata/agents/opencode/driver-interactive.sh
@@ -213,7 +213,25 @@ run_live() {
 
   echo "[driver] live mode: launching opencode TUI (tmux=$session, cwd=$RUN_CWD)" >&2
   tmux kill-session -t "$session" 2>/dev/null || true
-  tmux new-session -d -s "$session" -x 200 -y 50 -c "$RUN_CWD" "opencode" \
+  # IRRLICHT_BIND_ADDR is the beacon half (#1719). opencode's hooks are
+  # delivered by `irrlichd hook-post opencode` (core/pkg/hookbeacon): the
+  # plugin irrlicht installs carries NO address, and the beacon resolves where
+  # to POST at FIRE time from its own environment — IRRLICHT_BIND_ADDR first,
+  # then the addr file under IRRLICHT_HOME (core/pkg/daemonaddr's
+  # resolveClient). The beacon is a child of opencode, which is this pane, so a
+  # pane carrying neither variable reads the PRODUCTION addr file and posts
+  # every hook to the daemon on 7837. The recording then comes back complete,
+  # healthy and hook-free, with nothing anywhere saying why — the exact failure
+  # #1735 measured for mistral-vibe.
+  #
+  # Empty is the same as unset for the beacon (fixedPortOf("") does not match),
+  # so passing it unconditionally is safe when the rig set nothing.
+  #
+  # `env` rather than a wrapper shell on purpose: env execs opencode IN PLACE,
+  # so the pane process is still opencode itself and oc_opencode_pid's primary
+  # lookup below keeps working.
+  tmux new-session -d -s "$session" -x 200 -y 50 -c "$RUN_CWD" \
+    env "IRRLICHT_BIND_ADDR=${IRRLICHT_BIND_ADDR:-}" "opencode" \
     >>"$DRIVER_LOG.stdout" 2>>"$DRIVER_LOG.stderr"
   # Always tear the TUI down, even on an error/timeout exit below.
   trap 'tmux kill-session -t "$session" 2>/dev/null || true' EXIT
@@ -503,9 +521,10 @@ run_live() {
   # while it keeps the parent+child sessions alive.
   oc_opencode_pid() {
     local pid="" p pane_pid comm
-    # Common case: `tmux new-session ... "opencode"` execs the single-word
-    # command directly, so the PANE process IS opencode — exactly the PID the
-    # daemon's DiscoverPIDByCWD tracks. Use it without guessing or scanning.
+    # Common case: the pane command is `env IRRLICHT_BIND_ADDR=... opencode`,
+    # and env execs opencode IN PLACE — so the PANE process IS opencode,
+    # exactly the PID the daemon's DiscoverPIDByCWD tracks. Use it without
+    # guessing or scanning.
     pane_pid=$(tmux list-panes -t "$session" -F '#{pane_pid}' 2>/dev/null | head -1)
     if [[ -n "$pane_pid" ]]; then
       comm=$(ps -o comm= -p "$pane_pid" 2>/dev/null | tr -d ' ')
@@ -570,7 +589,11 @@ run_live() {
     tmux kill-session -t "$session" 2>/dev/null || true
     sleep 1
     echo "[driver] live restart: relaunching opencode TUI (tmux=$session, cwd=$RUN_CWD)" >&2
-    tmux new-session -d -s "$session" -x 200 -y 50 -c "$RUN_CWD" "opencode" \
+    # Same IRRLICHT_BIND_ADDR reasoning as the initial launch above — a
+    # relaunched pane that dropped it would post the rest of the recording's
+    # hooks to the production daemon.
+    tmux new-session -d -s "$session" -x 200 -y 50 -c "$RUN_CWD" \
+      env "IRRLICHT_BIND_ADDR=${IRRLICHT_BIND_ADDR:-}" "opencode" \
       >>"$DRIVER_LOG.stdout" 2>>"$DRIVER_LOG.stderr"
     # Re-wait the input affordance before any subsequent send (same readiness
     # gate as the initial launch; opencode swallows keystrokes during boot).

--- a/tools/onboarding-factory/cmd/of/fixture_test.go
+++ b/tools/onboarding-factory/cmd/of/fixture_test.go
@@ -36,7 +36,7 @@ func richRepo(t *testing.T) string {
 	root := t.TempDir()
 
 	write(t, filepath.Join(root, "replaydata", "agents", "scenarios.json"), `{
-  "meta": {"min_versions": {"aider": "1.0.0", "claudecode": "2.0.0", "codex": "1.0.0", "opencode": "1.0.0"}},
+  "meta": {"min_versions": {"aider": "1.0.0", "claudecode": "2.0.0", "codex": "1.0.0", "hermes": "1.0.0"}},
   "scenarios": [
     {"id": "1.1", "name": "one",   "description": "d", "process": "p", "acceptance_criteria": "a"},
     {"id": "2.1", "name": "two",   "description": "d", "process": "p", "acceptance_criteria": "a"},
@@ -66,8 +66,12 @@ func richRepo(t *testing.T) string {
 	cell(t, root, "aider", "1-1_one", "yes", "full", "ready")
 	recording(t, root, "aider", "1-1_one", "r1", true)
 
-	cell(t, root, "opencode", "1-1_one", "yes", "full", "ready")
-	recording(t, root, "opencode", "1-1_one", "r1", false)
+	// hermes is the fixture's "declares no hooks" adapter — the counterweight
+	// TestCoverageHooksDistinguishesGapFromNoHooks measures codex's GAP
+	// against. It used to be opencode, until #1719 gave opencode a hooks
+	// permission and the two roles collapsed onto one adapter.
+	cell(t, root, "hermes", "1-1_one", "yes", "full", "ready")
+	recording(t, root, "hermes", "1-1_one", "r1", false)
 
 	return root
 }

--- a/tools/onboarding-factory/cmd/of/hooks_test.go
+++ b/tools/onboarding-factory/cmd/of/hooks_test.go
@@ -31,7 +31,7 @@ func TestCoverageHooksCounts(t *testing.T) {
 		"aider":      {Adapter: "aider", DeclaresHooks: false, Cells: 1, Recordings: 1, WithHooks: 1, Status: hookcov.StatusIncidental},
 		"claudecode": {Adapter: "claudecode", DeclaresHooks: true, Cells: 7, Recordings: 2, WithHooks: 1, Status: hookcov.StatusOK},
 		"codex":      {Adapter: "codex", DeclaresHooks: true, Cells: 2, Recordings: 1, WithHooks: 0, Status: hookcov.StatusGap},
-		"opencode":   {Adapter: "opencode", DeclaresHooks: false, Cells: 1, Recordings: 1, WithHooks: 0, Status: hookcov.StatusNone},
+		"hermes":     {Adapter: "hermes", DeclaresHooks: false, Cells: 1, Recordings: 1, WithHooks: 0, Status: hookcov.StatusNone},
 	}
 	got := map[string]hookcov.AdapterCoverage{}
 	for _, a := range rep.Adapters {
@@ -54,7 +54,7 @@ func TestCoverageHooksCounts(t *testing.T) {
 
 // TestCoverageHooksDistinguishesGapFromNoHooks is the reason this command
 // exists. "Declares hooks and has zero hook-bearing recordings" (codex) is the
-// loud failure; "declares no hooks" (opencode) is fine. Both have WithHooks==0,
+// loud failure; "declares no hooks" (hermes) is fine. Both have WithHooks==0,
 // so a report keying only on that number would conflate them.
 func TestCoverageHooksDistinguishesGapFromNoHooks(t *testing.T) {
 	root := richRepo(t)
@@ -70,10 +70,10 @@ func TestCoverageHooksDistinguishesGapFromNoHooks(t *testing.T) {
 	for _, a := range rep.Adapters {
 		byName[a.Adapter] = a
 	}
-	if byName["codex"].WithHooks != 0 || byName["opencode"].WithHooks != 0 {
-		t.Fatalf("fixture precondition: both codex and opencode should have zero hook-bearing recordings")
+	if byName["codex"].WithHooks != 0 || byName["hermes"].WithHooks != 0 {
+		t.Fatalf("fixture precondition: both codex and hermes should have zero hook-bearing recordings")
 	}
-	if byName["codex"].Status == byName["opencode"].Status {
+	if byName["codex"].Status == byName["hermes"].Status {
 		t.Errorf("gap and no-hooks-declared must not share a status; both are %q", byName["codex"].Status)
 	}
 	if byName["codex"].Status != hookcov.StatusGap {

--- a/tools/onboarding-factory/cmd/of/status_summary_test.go
+++ b/tools/onboarding-factory/cmd/of/status_summary_test.go
@@ -32,7 +32,7 @@ func TestStatusSummaryCounts(t *testing.T) {
 		"aider":      {Agent: "aider", Recorded: 1, Total: 1, Earned: matrix.MaturityPlanned, CoreTotal: core},
 		"claudecode": {Agent: "claudecode", Recorded: 1, Pending: 1, Blocked: 2, Unobservable: 1, NotApplicable: 1, Unknown: 1, Total: 7, Earned: matrix.MaturityPlanned, CoreTotal: core},
 		"codex":      {Agent: "codex", Recorded: 1, Pending: 1, Total: 2, Earned: matrix.MaturityPlanned, CoreTotal: core},
-		"opencode":   {Agent: "opencode", Recorded: 1, Total: 1, Earned: matrix.MaturityPlanned, CoreTotal: core},
+		"hermes":     {Agent: "hermes", Recorded: 1, Total: 1, Earned: matrix.MaturityPlanned, CoreTotal: core},
 	}
 	if len(v.Agents) != len(want) {
 		t.Fatalf("want %d agent rows, got %d: %+v", len(want), len(v.Agents), v.Agents)

--- a/tools/onboarding-factory/internal/hookcov/hookcov_test.go
+++ b/tools/onboarding-factory/internal/hookcov/hookcov_test.go
@@ -35,7 +35,7 @@ func TestDeclaredMatchesRegistry(t *testing.T) {
 	want := map[string]bool{
 		"aider": false, "antigravity": false, "claudecode": true, "codex": true,
 		"copilot": true, "gemini-cli": true, "hermes": false, "kiro-cli": true,
-		"mistral-vibe": true, "opencode": false, "pi": true,
+		"mistral-vibe": true, "opencode": true, "pi": true,
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("Declared() = %v\nwant %v", got, want)

--- a/tools/onboarding-factory/internal/righome/righome.go
+++ b/tools/onboarding-factory/internal/righome/righome.go
@@ -69,10 +69,17 @@ type Row struct {
 }
 
 // Unisolatable names every hooks-declaring adapter that has NO row, with the
-// structural reason. Both entries are properties of the adapter's own path
+// structural reason. Each entry is a property of the adapter's own path
 // resolution rather than work nobody has got to yet, which is the difference
 // between an exemption list and a to-do list — if one of these ever became
 // "not done yet", it should move out of here and into agent-home.sh.
+//
+// opencode's entry (#1719) is the one that carries a named remainder rather
+// than being purely structural, and it says so out loud instead of reading as
+// settled: the SPLIT across two XDG variables is opencode's, and no
+// one-variable row can express it — but the reason the second variable would
+// not help either is an irrlicht gap (StorePath ignores $XDG_DATA_HOME), and
+// that half is fixable.
 //
 // The keys are existence-checked in both directions by
 // TestRigHomeTableMatchesTheAdapterRegistry: an entry naming an adapter that
@@ -85,6 +92,7 @@ var Unisolatable = map[string]string{
 		".claude/settings.json unconditionally. A row would move the session store while the " +
 		"install kept landing in the operator's real settings.json, i.e. claim an isolation " +
 		"it does not have.",
+	"opencode": "split across TWO XDG variables, which a one-variable row cannot express, and irrlicht honours neither. opencode resolves its config dir (the plugin irrlicht installs) from $XDG_CONFIG_HOME and its DATA dir (the SQLite store the daemon watches) from $XDG_DATA_HOME (Global.Path: join(XDG_CONFIG_HOME || ~/.config, \"opencode\") and join(XDG_DATA_HOME || ~/.local/share, \"opencode\")). A row naming XDG_CONFIG_HOME would relocate the install while the store stayed real — claudecode's half-relocatable shape in mirror image — and one naming XDG_DATA_HOME would be worse still, because opencode's StorePath() joins $HOME with \".local/share/opencode/opencode.db\" unconditionally: the CLI would move and the daemon would keep watching the operator's real database. Closing this means teaching StorePath() about XDG_DATA_HOME AND giving the table a two-variable row shape; until both, the managed-file snapshot is the whole of the protection, exactly as it is for gemini-cli.",
 	"gemini-cli": "no override exists at all: defaultRootDir is \".gemini/tmp\" under $HOME and " +
 		"geminiHome() is $HOME/.gemini, with no os.Getenv anywhere in " +
 		"core/adapters/inbound/agents/geminicli. Its hook recordings can only run against the " +

--- a/tools/onboarding-factory/scripts/lib/agent-home.sh
+++ b/tools/onboarding-factory/scripts/lib/agent-home.sh
@@ -176,8 +176,20 @@
 #                os.Getenv anywhere in core/adapters/inbound/agents/geminicli.
 #                Its hook recordings can only run against the real home, with
 #                the managed-file snapshot as the whole of the protection.
+#   opencode     SPLIT ACROSS TWO XDG VARIABLES, which a one-variable row
+#                cannot express. opencode resolves its config dir — where
+#                irrlicht installs its plugin — from $XDG_CONFIG_HOME, and its
+#                DATA dir — the SQLite store the daemon watches — from
+#                $XDG_DATA_HOME. A row naming the first relocates the install
+#                while the store stays real (claudecode's problem in mirror
+#                image); a row naming the second is worse, because irrlicht's
+#                own StorePath() joins $HOME with .local/share/opencode
+#                unconditionally, so the CLI would move and the daemon would
+#                keep watching the operator's real database. Closing it needs
+#                BOTH an XDG_DATA_HOME-aware StorePath and a two-variable row
+#                shape here (#1719).
 #
-# Those two are named in righome.Unisolatable with the same reasons, and the
+# Those three are named in righome.Unisolatable with the same reasons, and the
 # tripwire fails if a hooks-declaring adapter is in neither place.
 agent_home_table() {
   cat <<'TABLE'


### PR DESCRIPTION
Closes #1719. Part of #1355.

## The epic's verdict was half right

#1355 cut opencode with: *"its config-file hook path was removed upstream, so a shipped TS plugin is the only route: a distribution and supply-chain problem (npm package? vendored file?), not a config write."*

**Confirmed — the config-file route is closed.** opencode 1.14.50's live config schema declares `experimental` with exactly six keys — `disable_paste_summary`, `batch_tool`, `openTelemetry`, `primary_tools`, `continue_loop_on_deny`, `mcp_timeout` — and no `hook`. Read out of the bun-compiled binary's own bundle, not out of docs.

**Wrong — there is no distribution problem.** opencode auto-discovers plugins with a plain directory glob:

```js
async function ConfigPlugin_load($) {
  let Z = [];
  for (let Y of await Glob.scan("{plugin,plugins}/*.{ts,js}",
        { cwd: $, absolute: true, dot: true, symlink: true }))
    Z.push(pathToFileURL(Y).href);
  return Z;
}
```

`Config.loadInstanceState` calls it for **every** directory `ConfigPaths.directories` returns, and the first is `Global.Path.config`:

```js
ConfigPaths.directories($, Z) => dedupe([
  Global.Path.config,                                    // $XDG_CONFIG_HOME/opencode || ~/.config/opencode
  ...up({targets:[".opencode"], start:$, stop:Z}),
  ...up({targets:[".opencode"], start: home, stop: home}),
  ...(OPENCODE_CONFIG_DIR ? [OPENCODE_CONFIG_DIR] : []),
])
```

So: no registry, no npm resolution, no git, no build step, no toolchain, no `settings.json` write. One `.js` file in `~/.config/opencode/plugin/` is loaded, globally, for every session; uninstall is `os.Remove`. A plugin whose directory has no `package.json` resolves to the file itself (`resolveEntry` returns the target unchanged when `readManifest` finds nothing), and the loader accepts a bare `export default async function`.

`plugin: [...]` and `opencode plugin install` — the npm-spec route the epic was reasoning about — are a **second, separate** mechanism. This installer does not use it. That is the same correction #1721 made for pi, reached from the other end: `pi install` was the red herring there, `plugin: [...]` is the red herring here.

## opencode DOES have a blocked-on-user state, and it is invisible in the store

This is what makes the adapter worth a hook channel rather than a nicety.

- `Permission.ask` evaluates each requested pattern and **returns early, publishing nothing**, when all of them already resolve to `allow`. `permission.asked` therefore fires only on a genuine prompt — a narrow assert, not the fires-for-every-tool event #1719 warned about reusing `PreToolUse`'s row for.
- That pending request lives in a plain in-memory `Map`; only **approved** patterns reach the `permission` table. opencode's store cannot express "the user is being asked right now", which is exactly what this adapter's `ProcessOwnedStore` reads. Before this PR opencode had no `waiting` at all.
- `Permission.reply` publishes `permission.replied` for **every** reply including `"reject"`, and cascades it to the session's other pendings. That puts opencode out of copilot's position, where a denial emits nothing and a hold would sit until the 12-hour ceiling.
- `session.idle` is published by `SessionStatus.set` from the runner's `onIdle` and directly by `SessionRunState.cancel` — turn end, cancel and interrupt.

Canonicalised on semantics, not Claude Code's wire names: each event goes to a dedicated `SessionDetector` entry point, so `session.hookSignalEffects` (a flat map with no adapter dimension) is never consulted and no row can leak into another adapter's dispatch.

**`permission.ask` — the HOOK — is deliberately not registered.** `Plugin.trigger` iterates registered hooks with **no try/catch**, and several receive a mutable `output`; `permission.ask`'s `output.status` is a writable `"allow" | "deny" | "ask"`. A monitoring plugin must not be able to answer a permission prompt for the user or throw inside the agent loop. The `event` bus carries the same fact as an observation.

## Shared machinery: two moves, both because opencode has no file per session

opencode's `Source` is an `agent.ProcessOwnedStore` — one SQLite database, no transcript files — so the path every consumer keys a session on is composed by the daemon (`<db>-wal?session=<id>`, now via one `transcriptPathFor` the watcher and the receiver share). There is nothing a caller could name that the daemon would open, so the honest payload is a session id.

1. **`hookjson.DecodeSealed`** joins `DecodeConfined` as a second entry point. Both funnel through one unexported `readBody`, so `architecture_hookbody_test.go`'s Arm B claim — *this package reads a body in exactly ONE function* — is unchanged. The chokepoint moved; it did not widen into a two-element allowlist.
2. **`AssertHookPathConfined` gains a `PathDaemonDerived` route**, the confinement family's `DeliveryAddressFree`. Rather than confining the traversal class once more, the route makes it inexpressible, and its three obligations assert the property was *obtained*: a well-formed payload still dispatches, the dispatched string is the daemon's own path, and it does not move when the body names an out-of-tree path, a `..` traversal, or either kind of symlink. The two routes make contradictory assertions about the same two strings, so declaring the wrong one fails rather than passing quietly. Committed self-tests: `hook_path_confinement_derived_selftest_test.go`.

Handing `DecodeConfined` an empty path instead was considered and rejected: it would answer `RejectEmptyPath`, drop every hook, and log a confinement refusal for correct traffic. Confining a self-derived path was rejected too — resolution could only fail (a store not yet created, a WAL checkpointed away), silently dropping legitimate hooks to satisfy a guard protecting nothing.

## Mutation evidence — every guard seen red

One mutation per run, applied and reverted, `git status --porcelain` clean between each.

**1. A second body-reading function inside `hookjson`** (the #1389 hazard Arm B exists for):
```
--- FAIL: TestNoDirectRequestBodyReadsInAgentAdapters (0.19s)
    architecture_hookbody_test.go:202: hook-body violation: irrlicht/core/adapters/inbound/agents/hookjson reads an inbound *http.Request body at .../hookjson/decode.go:276:27 (r.Body in decodeUnguarded)
        	irrlicht/core/adapters/inbound/agents/hookjson is exempt only for readBody — the single decode every receiver is forced through,
        	behind hookjson.DecodeConfined (a payload naming a path) or hookjson.DecodeSealed (a payload naming none).
        	A second body-reading function here is a second way to skip confinement (issue #1389)
```

**2. The receiver dispatches a caller-supplied `transcript_path` when the body carries one** — the defect the whole new route exists to catch. All four hostile spellings went red; one shown:
```
--- FAIL: TestHookPathConfined/dispatch_is_indifferent_to_symlink_escape (0.00s)
    hook_path_confinement.go:278: a body naming symlink_escape dispatched ".../001/.local/share/opencode/linked/planted.jsonl", want the daemon's own composed path ".../001/.local/share/opencode/opencode.db-wal?session=ses_19af5168cffem3E4MnRCcfxkNX" — on this route nothing a caller writes may reach the dispatch, and a path that MOVED with the body is a caller-supplied path travelling under a different name
```

**3. Delete the receiver's own `database` consent gate.** Since #1488 the backstop still drops the payload, so every dispatch-shaped assertion stays green; the SILENCE is the discriminator:
```
--- FAIL: TestHookReceiver_DeniedDatabaseConsentDropsQuietly (0.00s)
    hooks_test.go:410: a database-denied hook logged 1 error(s): [hook body dropped: permission "database" is not granted at the decode — either this receiver skipped the check it declares, or consent was revoked mid-request (issue #1488)]
```

**4. Hoist `ObserveHookReceipt` above the channel-consent check:**
```
--- FAIL: TestHookReceiptObserved/consent_denied_request_is_not_counted (0.00s)
    hook_receipt.go:127: a consent-denied request added 1 receipts for adapter "opencode", want 0 — noting that a POST arrived is an observation, and every observation an adapter makes is gated
```

**5. Drop `IgnoreUnknownEvent` from the default arm:**
```
--- FAIL: TestUnknownHookEventObserved/counted_per_adapter_and_name (0.00s)
    unknown_hook_event.go:135: event "IrrUnk5fd19820Renamed" arrived 3 times, counted 0 for adapter "opencode" — an event that keeps arriving is the signature of an upstream rename and has to be countable as such
--- FAIL: TestUnknownHookEventObserved/reported_once_per_distinct_name (0.00s)
    unknown_hook_event.go:141: event "IrrUnkd6ae8a1101Flood" arrived 5 times and produced 0 log line(s), want exactly 1
```

**6. Never rewrite a stale install in place:**
```
--- FAIL: TestHookEndpointFollowsBindAddr/foreign_binary_install_upgraded_in_place (0.00s)
    hook_endpoint.go:267: expected modified=true when repointing an install naming a different irrlichd binary — an install left unrepaired here reports healthy while delivering nothing, and no later daemon start converges on it
```

**7. Consent copy understates the install (the #1173 drift):**
```
--- FAIL: TestHooksPermission_DisclosureMatchesInstalled/names_every_installed_event (0.00s)
    hook_disclosure.go:136: consent copy never names the "session.idle" hook, but the installer writes it — an undisclosed write to the user's config (#570)
--- FAIL: TestHooksPermission_DisclosureMatchesInstalled/states_the_installed_count (0.00s)
    hook_disclosure.go:139: consent copy declares 2 hook entries, installer writes 3
```

**8. Revert the disclosure tokenizer widening** (proves the widening is load-bearing, not cosmetic — without it NO wording could satisfy the arm):
```
--- FAIL: TestHooksPermission_DisclosureMatchesInstalled/names_every_installed_event (0.00s)
    hook_disclosure.go:136: consent copy never names the "permission.asked" hook, but the installer writes it — an undisclosed write to the user's config (#570)
    hook_disclosure.go:136: consent copy never names the "permission.replied" hook, but the installer writes it ...
    hook_disclosure.go:136: consent copy never names the "session.idle" hook, but the installer writes it ...
```

**9. `Writes.Path` names a file `Apply` does not write:**
```
--- FAIL: TestEveryModifyPermissionDeclaresEveryFileItsApplyWrites (0.00s)
    managedwrites_test.go:227: opencode/hooks declares Writes.Path = "/tmp/irrlicht-not-the-file", which is OUTSIDE the scratch home ... Refusing to run any Apply
```

**10. Drop `IRRLICHT_BIND_ADDR` from the driver's RELAUNCH pane only:**
```
--- FAIL: TestEveryBeaconAdapterDriverPassesTheDaemonAddress/opencode (0.00s)
    beacon_test.go:50: .../opencode/driver-interactive.sh:595 launches the agent under tmux without passing IRRLICHT_BIND_ADDR.
```

**11. An installed event's `Since` above the declared floor:**
```
--- FAIL: TestHooksPermission_DeclaresVersionGate/floor_covers_every_installed_event (0.00s)
    hook_version.go:59: declared floor 1.14.50 is below 1.15.0, the version "session.idle" is known at — at a CLI between the two the install writes an entry naming an event that CLI does not have
```

**12. Make the NEW arm stop discriminating** (grade only *that* something dispatched, never *which* string — #1389's defect, inherited by construction). The committed self-test catches it:
```
--- FAIL: TestDerivedRouteObligation2_DispatchIsIndifferentToTheBody (0.00s)
    hook_path_confinement_derived_selftest_test.go:252: mutation "a receiver that dispatches the caller's transcript_path whenever the body carries one": the obligation reported nothing against a fixture that is wrong for it — either the fixture is no longer wrong, or the obligation has stopped discriminating (expected a message containing "want the daemon's own composed path")
```

**13. The mutation that found a real defect in my own guard.** `TestShippedPluginRegistersOnlyTheReadOnlyEventTap` forbids registering `permission.ask`. Adding exactly that to `plugin.js` **passed**:
```
ok  	irrlicht/core/adapters/inbound/agents/opencode	0.321s
```
The detector matched only BARE property keys — and ten of opencode's fifteen hook names contain a dot, which JavaScript cannot spell bare. The guard's biggest hole came with an approved spelling. Fixed (`"?` around the key), mutation re-run:
```
--- FAIL: TestShippedPluginRegistersOnlyTheReadOnlyEventTap (0.00s)
    plugin_test.go:68: plugin.js registers [permission.ask event], want exactly [event]
```
and the shape is now a **committed corpus** (`TestHookRegistrationDetectorNamesEveryShape`) rather than a paragraph here. **14.** Reverting the detector to bare-key-only turns that corpus red:
```
--- FAIL: TestHookRegistrationDetectorNamesEveryShape/a_QUOTED_dotted_key_is_a_registration (0.00s)
    plugin_test.go:320: detector returned [], want [permission.ask]
```

## What is NOT covered

- **No onboarding fixtures were recorded.** `hookcov` now reports `StatusGap` for opencode — declares hooks, zero hook-bearing recordings. That is the honest outcome and is left visible; #1754's rig gaps are still open. Cells re-recorded: **0** (#1355 Phase D's kill criterion was >5).
- **Nothing executes the JavaScript in CI.** `plugin_test.go` grades the artifact statically; running it needs bun or a model call. Its header says so.
- **`AssertHookReceiptObligation 3` degenerates** for this route — the out-of-tree body is indistinguishable from a clean one, so it repeats obligation 1. Stated at the wiring, kept with no opt-out.
- **opencode is `Unisolatable`** for the recording rig, with the reason: its config dir follows `$XDG_CONFIG_HOME` and its data dir `$XDG_DATA_HOME`, which a one-variable row cannot express — and `StorePath()` honours neither, joining `$HOME` with `.local/share/opencode` unconditionally. Closing it needs an XDG-aware `StorePath` **and** a two-variable row shape.
- **The transcript-tail `waiting` heuristic is unchanged**; hooks add a signal, they do not replace anything.

## Notes on adjacent issues

- **#1759** (beaconroute roster missing mistral-vibe) was already fixed by #1721; opencode's row is added and the scope paragraph updated to eight.
- **#1762**: this adapter wires `AssertHookVersionGate` and stops. No seventh copy of the three hand-written obligations — `hookversion_test.go` says so where a reader would look for them.
## The two red advisory checks

**SonarCloud** is red on ONE condition and it is duplication, measured: `new_duplicated_lines_density` 5.8% against a 3% threshold. Every issue it raised is fixed (`total: 0` from the issues API — a `_ "embed"` without a comment, a world-readable temp file, three duplicated string literals, four JS style findings, and a cognitive-complexity 18 on `AssertHookPathConfined` that the `hostileBodyFor` extraction brought under the limit). Security rating, reliability rating and maintainability rating are all **OK**, and there are zero security hotspots.

The duplicated lines are:

| file | duplicated / new |
|---|---|
| `opencode/hookinstaller.go` | 105 / 471 |
| `opencode/hookversion_test.go` | 31 / 65 |
| `opencode/hookinstaller_test.go` | 22 / 301 |
| `opencode/hooks_test.go` | 21 / 413 |

The three test files are **contract wirings**, which #1740's tripwire requires each adapter to make in its OWN test package — extracting a shared helper would defeat the tripwire that exists because "a contract can only fail for an adapter that WIRED it". They stay.

`hookinstaller.go`'s 105 lines are a different thing and worth naming honestly rather than filing under the same heading: they are near-identical to pi's, because both adapters are on the same route — write ONE file, beacon-delivered, refuse to overwrite a foreign one, rewrite a stale one in place, `os.Remove` to uninstall. That is a real extraction candidate (a shared single-file-artifact installer parameterised by path resolver, template, sentinel and event list), and it would make the next adapter on this route ~20 lines instead of ~300. It is deliberately NOT done here: pi merged an hour before this branch opened, and folding "add opencode" together with "refactor pi's installer" would put a cross-adapter refactor behind a feature review. Worth its own issue.

**CodeScene** is red for the same structural reason and is likewise advisory (neither is a required status check; branch protection lists 14 and neither is among them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
