### PR TITLE
feat(hermes): observe hermes through its own shell hooks — an approval state its store cannot express (#1722)

### DIFF
--- a/core/adapters/inbound/agents/beaconroute_test.go
+++ b/core/adapters/inbound/agents/beaconroute_test.go
@@ -7,6 +7,7 @@ import (
 	"irrlicht/core/adapters/inbound/agents/codex"
 	"irrlicht/core/adapters/inbound/agents/copilot"
 	"irrlicht/core/adapters/inbound/agents/geminicli"
+	"irrlicht/core/adapters/inbound/agents/hermes"
 	"irrlicht/core/adapters/inbound/agents/kirocli"
 	"irrlicht/core/adapters/inbound/agents/opencode"
 	"irrlicht/core/adapters/inbound/agents/pi"
@@ -29,8 +30,8 @@ import (
 // while its route segment is "claudecode". That is why the map keys below are
 // written out literally rather than derived from the adapter constants.
 //
-// Scope, stated honestly: this pins the receivers that exist (eight as of
-// #1719's opencode row; #1721's pi row also added the mistral-vibe row #1718
+// Scope, stated honestly: this pins the receivers that exist (nine as of
+// #1722's hermes row; #1721's pi row also added the mistral-vibe row #1718
 // never wrote — exactly the omission the paragraph below predicts, and the
 // whole of issue #1759). It cannot fail for a NEW receiver registered at a
 // different prefix, because registerHookRoutes (core/cmd/irrlichd/startup.go)
@@ -43,6 +44,7 @@ func TestBeaconEndpointPathMatchesTheInstalledReceivers(t *testing.T) {
 		"codex":      codex.HookEndpointPath,
 		"copilot":    copilot.HookEndpointPath,
 		"gemini-cli": geminicli.HookEndpointPath,
+		"hermes":     hermes.HookEndpointPath,
 		"kiro-cli":   kirocli.HookEndpointPath,
 		// mistral-vibe was beacon-delivered from the day it shipped (#1718)
 		// but was never added here; found while adding pi's row (#1721).

--- a/core/adapters/inbound/agents/hermes/adapter.go
+++ b/core/adapters/inbound/agents/hermes/adapter.go
@@ -138,6 +138,24 @@ func StorePath() string {
 	return filepath.Join(homeDir(), storeRelPath)
 }
 
+// transcriptPathIn renders the string every downstream consumer keys a Hermes
+// session on, for a given store path. Hermes has no per-session file, so this
+// composed spelling IS the session's identity as far as the rest of the daemon
+// is concerned, and ComputeMetrics splits it back apart.
+//
+// The watcher and the hook receiver must produce the same string or one
+// session becomes two, so there is one function and two thin callers rather
+// than two spellings — the shape opencode's transcriptPathFor already uses.
+func transcriptPathIn(dbPath, sessionID string) string {
+	return dbPath + sessionQueryParam + sessionID
+}
+
+// transcriptPathFor is transcriptPathIn against the store this daemon resolves
+// — what the hook receiver uses, since a hook payload names no file.
+func transcriptPathFor(sessionID string) string {
+	return transcriptPathIn(StorePath(), sessionID)
+}
+
 // isServiceArgv reports whether argv belongs to a long-lived Hermes service
 // rather than an agent session.
 //

--- a/core/adapters/inbound/agents/hermes/adapter_test.go
+++ b/core/adapters/inbound/agents/hermes/adapter_test.go
@@ -83,8 +83,8 @@ func TestAgentRegistration(t *testing.T) {
 		t.Error("PathForPID must ignore the pid — the store is shared, not per-process")
 	}
 
-	if len(a.Permissions) != 1 {
-		t.Fatalf("len(Permissions) = %d, want 1", len(a.Permissions))
+	if len(a.Permissions) != 2 {
+		t.Fatalf("len(Permissions) = %d, want 2 (store + hooks)", len(a.Permissions))
 	}
 	p := a.Permissions[0]
 	if p.Key != PermissionKeyStore {
@@ -97,6 +97,29 @@ func TestAgentRegistration(t *testing.T) {
 	// stop watchers), so it must carry no closures of its own.
 	if p.Apply != nil || p.Remove != nil {
 		t.Error("observe permission must have nil Apply/Remove")
+	}
+
+	// The hooks permission (#1722) is the other way round: it owns its own
+	// install, so it must carry both closures and declare both files they
+	// write. The contract families in hook*_test.go grade the contents; this
+	// is the shape lock.
+	h := a.Permissions[1]
+	if h.Key != PermissionKeyHooks {
+		t.Fatalf("Permission[1].Key = %q, want %q", h.Key, PermissionKeyHooks)
+	}
+	if h.Kind != permission.KindModify {
+		t.Errorf("hooks Permission.Kind = %q, want modify", h.Kind)
+	}
+	if h.Apply == nil || h.Remove == nil {
+		t.Error("a modify permission that installs must carry Apply and Remove")
+	}
+	if h.Writes == nil || h.Writes.Path == nil {
+		t.Fatal("the hooks permission declares no managed user file")
+	}
+	if len(h.Writes.Also) != 1 {
+		t.Errorf("Writes.Also has %d entries, want 1 — hermes will not run a configured hook "+
+			"whose approval is not recorded, so the allowlist is the other half of the install",
+			len(h.Writes.Also))
 	}
 }
 

--- a/core/adapters/inbound/agents/hermes/agent.go
+++ b/core/adapters/inbound/agents/hermes/agent.go
@@ -1,6 +1,7 @@
 package hermes
 
 import (
+	"irrlicht/core/adapters/inbound/agents/hookjson"
 	"irrlicht/core/domain/agent"
 	"irrlicht/core/domain/permission"
 	"irrlicht/core/domain/session"
@@ -56,6 +57,55 @@ func Agent() agent.Agent {
 					"(WhatsApp, Slack, …) share the same store and are " +
 					"skipped. No row is ever written. Toggling off stops all " +
 					"polling immediately.",
+			},
+			{
+				Key:             PermissionKeyHooks,
+				Kind:            permission.KindModify,
+				Title:           "Install status hooks",
+				FeatureUnlocked: "Blocked-on-user detection and authoritative turn-end detection",
+				// "3 hook entries" is what contracttesting's #1356 count arm
+				// reads. The second file is named in the same breath rather
+				// than left to Detail, because an install that wrote only the
+				// config would never fire and the wizard row is what most
+				// users read.
+				Touches: "Writes 3 hook entries to " + displayConfigPath +
+					" and the matching approvals to " + displayAllowlistPath,
+				Detail: "Hermes Agent runs a shell command on lifecycle events, declared as a " +
+					"`hooks:` block in " + displayConfigPath + ". This adds one entry for each " +
+					"of three events (" + hookjson.EventList(installedHookEvents) + ") inside a " +
+					"clearly marked block of its own; every other line of your config, comments " +
+					"included, is left byte-for-byte alone, and the install refuses rather than " +
+					"guessing if the file is shaped in a way it cannot edit safely. No code is " +
+					"installed anywhere: each entry runs `irrlichd hook-post hermes`, a tiny " +
+					"command irrlicht ships, which reads the daemon's own published address at " +
+					"the moment the event fires — so nothing names a host or a port, nothing can " +
+					"go stale, and it never blocks Hermes even when the daemon is not running. " +
+					"Hermes will not run a configured hook until you approve it, so this also " +
+					"records that approval in " + displayAllowlistPath + " — the same record " +
+					"Hermes' own prompt would write, which granting here is you answering. The " +
+					"three events are observers: none of them is one whose output Hermes reads " +
+					"as a decision, so this can never veto a command or keep a turn running. " +
+					hookjson.RequiresVersion("hermes", minHermesVersion) +
+					" Toggling off removes the block and the approvals (also available via " +
+					"`irrlichd --uninstall-hooks`); nothing else in your Hermes installation " +
+					"was changed.",
+				Apply:  func() error { _, err := EnsureHooksInstalled(); return err },
+				Remove: func() error { _, err := UninstallHooks(); return err },
+				Writes: &agent.ManagedUserFile{
+					Path:      ConfigPath,
+					Uninstall: UninstallHooks,
+					Verify:    VerifyHooksInstalled,
+					// The allowlist is the other half of the install: without
+					// the approval Hermes skips registration and logs
+					// "not allowlisted", so a declaration naming only the
+					// config would leave a file the recorder does not back up
+					// and #1449's refusal does not judge.
+					Also: []func() (string, error){AllowlistPath},
+					Version: &agent.VersionGate{
+						Min:   minHermesVersion,
+						Probe: []string{"hermes", "--version"},
+					},
+				},
 			},
 		},
 	}

--- a/core/adapters/inbound/agents/hermes/hookdisclosure_test.go
+++ b/core/adapters/inbound/agents/hermes/hookdisclosure_test.go
@@ -1,0 +1,19 @@
+// hookdisclosure_test.go wires the hermes hooks permission into the shared
+// issue #1356 contract: the consent copy names every event the installer
+// subscribes to, states the right entry count, and names no event it does not
+// install.
+package hermes
+
+import (
+	"testing"
+
+	"irrlicht/core/internal/contracttesting"
+)
+
+func TestHooksPermission_DisclosureMatchesInstalled(t *testing.T) {
+	contracttesting.AssertHookDisclosureMatchesInstalled(t, contracttesting.HookDisclosure{
+		Agent:         Agent(),
+		PermissionKey: PermissionKeyHooks,
+		Installed:     installedHookEvents,
+	})
+}

--- a/core/adapters/inbound/agents/hermes/hookinstaller.go
+++ b/core/adapters/inbound/agents/hermes/hookinstaller.go
@@ -337,6 +337,21 @@ func hookYAMLConfig(path, command string) hookyaml.Config {
 		BlockKey: hookBlockKey,
 		Owner:    hookRegionOwner,
 		Entries:  hookEntries(command),
+		// hermes rewrites its whole config.yaml from a parsed dict whenever it
+		// saves one — `hermes config set`, the setup wizard, a dashboard save
+		// (hermes_cli/config.save_config -> utils.atomic_yaml_write). Every
+		// comment in the file goes with it, INCLUDING the markers that
+		// delimit our region, while the entries survive as data and keep
+		// firing. Without a sentinel this installer would then read its own
+		// entries as a user's colliding hooks forever and
+		// `--uninstall-hooks` would find nothing to remove, leaving them in
+		// the user's config with no way to take them out.
+		//
+		// The beacon sentinel is the right token: it is in every command this
+		// installer writes, it deliberately excludes the binary path so an
+		// entry naming a moved irrlichd is still ours, and it is the same
+		// string every other adapter identifies its entries by.
+		Sentinel: hookbeacon.Sentinel(AdapterName),
 	}
 }
 

--- a/core/adapters/inbound/agents/hermes/hookinstaller.go
+++ b/core/adapters/inbound/agents/hermes/hookinstaller.go
@@ -1,0 +1,684 @@
+// hookinstaller.go installs irrlicht's Hermes Agent shell hooks — the two
+// files this adapter writes into a user's Hermes installation (issue #1722,
+// epic #1355).
+//
+// # The epic's verdict, and what the source actually says
+//
+// Epic #1355 cut hermes as "cost without payoff for now. hermes is a
+// ProcessOwnedStore whose metrics `of verify` cannot validate anyway", and
+// #1722 restated the payoff half as "a hook would buy event-driven
+// invalidation rather than latency". Both halves are wrong, and the second
+// one is wrong in the same way opencode's was.
+//
+// Measured against Hermes Agent v0.19.0 — read out of the Python package's own
+// source, and fired live through `hermes hooks test` against an isolated
+// HERMES_HOME:
+//
+//   - **hermes has a first-class hook system with its own CLI subcommand.**
+//     `hermes hooks {list|test|revoke|doctor}` (hermes_cli/hooks.py), 25
+//     lifecycle events (`VALID_HOOKS` in hermes_cli/plugins.py), and THREE
+//     independent subscription mechanisms — a gateway-only Python handler
+//     directory, in-process Python plugins under `~/.hermes/plugins/`, and
+//     SHELL hooks declared as a `hooks:` block in `~/.hermes/config.yaml`
+//     (agent/shell_hooks.py). Nobody had looked; `--help` was never the
+//     evidence.
+//
+//   - **The payoff is not invalidation.** hermes fires
+//     `pre_approval_request` and `post_approval_response` around every
+//     dangerous-command approval, and the pending request they bracket lives
+//     in a process-local `_gateway_queues` map and a `contextvars` session
+//     key. NOTHING about a request awaiting an answer reaches `state.db` —
+//     the schema has `sessions`, `messages`, `session_model_usage`,
+//     `state_meta`, `gateway_routing`, `compression_locks` and
+//     `async_delegations`, and no approval table at all. So hermes's store
+//     cannot express "the user is being asked right now", and before this
+//     channel this adapter had no `waiting` state whatsoever. That is
+//     opencode's shape exactly (#1719), arrived at from the other end.
+//
+//   - **The shell-hook route ships no code.** Unlike opencode and pi, where
+//     irrlicht writes an executable artifact into the agent's plugin
+//     directory, a hermes shell hook is a COMMAND LINE: hermes spawns it as
+//     a subprocess with `shlex.split(...)`, `shell=False`, and pipes JSON to
+//     its stdin. The command irrlicht installs names irrlicht's own binary.
+//     hermes' own docs table calls this the mechanism with "inter-process
+//     isolation: yes", against "no" for both Python routes.
+//
+//   - **hermes gates it behind its own consent, and irrlicht must satisfy
+//     that consent to install anything that fires.** A configured hook does
+//     not run until its `(event, command)` pair is recorded in
+//     `~/.hermes/shell-hooks-allowlist.json`; without it hermes logs "not
+//     allowlisted — skipped" and the permission would read `granted` with
+//     nothing ever arriving. That is why this install writes TWO files and
+//     declares both (Writes.Path plus Writes.Also). The allowlist entry is
+//     the honest completion of the user's #570 grant, not a bypass of
+//     hermes' gate: the grant IS a person answering the same question hermes'
+//     TTY prompt asks, and the consent copy says so in those words.
+//
+// # Why `pre_tool_call` and `pre_verify` are not installed
+//
+// This is the #1719 safety lesson in its hermes spelling, and it is a source
+// fact rather than a preference. `agent/shell_hooks._parse_response` reads a
+// hook's STDOUT as a control channel for exactly two events: `pre_tool_call`
+// accepts `{"action": "block"}` / `{"decision": "block"}` and vetoes the tool
+// call, and `pre_verify` accepts `{"action": "continue"}` and keeps the
+// agent's turn running. A monitoring channel must not be able to do either,
+// so neither event is installed — and because "we remembered not to" is not a
+// mechanism, hooks_test.go's TestInstalledEventsAreObserverOnly fails the
+// build if one appears in installedHookEvents.
+//
+// The command itself is wrapped in `/bin/sh -c` so its stdout is redirected to
+// /dev/null before hermes can read it. That is defence in depth rather than
+// the guard — but it is not theoretical: hookbeacon.LegacyGuardToken puts
+// `--version` FIRST in the command line, so an irrlichd predating #1417
+// prints a version banner on stdout, once per firing, straight into hermes'
+// response parser.
+//
+// # Delivery
+//
+// Address-free (contracttesting.DeliveryAddressFree): the command names the
+// `irrlichd hook-post hermes` beacon (core/pkg/hookbeacon), which reads the
+// daemon's published address at fire time. Nothing address-shaped is written
+// into the user's config, so the #1178 stale-port class is inexpressible.
+//
+// # What this does NOT cover
+//
+//   - Hermes PROFILES. `hermes -p <name>` relocates HERMES_HOME to
+//     `~/.hermes/profiles/<name>/`, which has its own config.yaml and its own
+//     allowlist. This installs into the home the daemon resolves — the
+//     default one, or whatever HERMES_HOME names — and a session started
+//     under another profile is watched by the store watcher alone, exactly as
+//     it was before this channel existed.
+//   - The gateway platforms (whatsapp, slack, …). The hooks fire there too,
+//     but those sessions are filtered out of this adapter by `source`.
+package hermes
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"irrlicht/core/adapters/inbound/agents/hookyaml"
+	"irrlicht/core/domain/agent"
+	"irrlicht/core/pkg/hookbeacon"
+)
+
+// Hermes' own wire names for the three lifecycle events this adapter
+// subscribes to. They are hermes', not Claude Code's: #1722 and #1355 both
+// warn against reusing `session.hookSignalEffects` rows keyed on Claude Code's
+// vocabulary, and none of these three is dispatched through that map — hooks.go
+// routes each to a dedicated SessionDetector entry point.
+const (
+	// HookEventPreApprovalRequest is fired by tools/approval.py immediately
+	// before the user is asked to approve a dangerous command, on every
+	// surface (CLI prompt, gateway, and the smart auxiliary-LLM decision).
+	//
+	// It is a NARROW assert, which is the property that makes it usable at
+	// all: approval.py fires it only after `check_all_command_guards` has
+	// matched a command against a danger pattern and only when the pattern is
+	// not already approved for the session. It is emphatically not a
+	// before-every-tool event, and must never be treated as one.
+	//
+	// hermes documents it as an observer: "Observers only: return values are
+	// ignored. Plugins cannot veto or pre-answer an approval from these hooks."
+	HookEventPreApprovalRequest = "pre_approval_request"
+
+	// HookEventPostApprovalResponse is fired with the outcome for EVERY way an
+	// approval ends — `once`, `session`, `always`, `deny`, `timeout`, and the
+	// two smart-mode verdicts. A denial and a timeout both release, which is
+	// what keeps this out of copilot's position where a hold has no matching
+	// release and pins the session `waiting`.
+	HookEventPostApprovalResponse = "post_approval_response"
+
+	// HookEventOnSessionEnd is fired at the end of every run_conversation call
+	// (agent/turn_finalizer.py) — i.e. once per TURN, not once per session,
+	// despite the name. Its `extra` carries `completed` and `interrupted`, so
+	// it covers the turn finishing and the user interrupting alike, which is
+	// the same authoritative turn-end claim Claude Code's Stop makes.
+	HookEventOnSessionEnd = "on_session_end"
+)
+
+// installedHookEvents is every hermes event this adapter subscribes to. The
+// exclusions are the finding rather than an omission:
+//
+//   - `pre_tool_call` and `pre_verify` are the two events whose STDOUT hermes
+//     reads as a decision. See this file's header; the exclusion is enforced
+//     by a test, not by memory.
+//
+//   - `pre_llm_call` is the third event with a return contract
+//     (`{"context": …}` is prepended to the user's message). It also fires
+//     once per turn as the turn OPENS, which the store's own new `messages`
+//     rows already report — the watcher emits activity off them.
+//
+//   - `on_session_start` would duplicate discovery: hermes INSERTs the
+//     `sessions` row while the session is live, ~2s in, which is what this
+//     adapter already discovers on.
+//
+//   - `post_api_request` carries `usage` and `finish_reason` and was the
+//     candidate #1722 asked about for metrics. It is not installed: the store
+//     already carries per-model token and cost rows (`session_model_usage`),
+//     so the hook would add a process spawn per API request — several per
+//     turn — for a number irrlicht already has. What `of verify` cannot
+//     validate is the REPLAY golden for a ProcessOwnedStore adapter, and a
+//     hook does not change that.
+//
+//   - `post_tool_call`, `subagent_start`/`subagent_stop`, the `kanban_*`
+//     trio and the gateway hooks are either store-covered or out of this
+//     adapter's scope (`source` filtering excludes the gateway platforms).
+var installedHookEvents = []string{
+	HookEventPreApprovalRequest,
+	HookEventPostApprovalResponse,
+	HookEventOnSessionEnd,
+}
+
+// controlBearingHookEvents are the hermes events whose stdout the agent reads
+// as a decision (agent/shell_hooks._parse_response). Installing one would give
+// a monitoring channel the ability to veto a tool call or keep a turn running.
+//
+// Declared here rather than only in prose so hooks_test.go can assert the
+// intersection with installedHookEvents is empty — the guard #1719's first
+// version of this idea lacked.
+var controlBearingHookEvents = []string{
+	"pre_tool_call", // {"action":"block"} / {"decision":"block"} vetoes the tool
+	"pre_verify",    // {"action":"continue"} keeps the turn running
+	"pre_llm_call",  // {"context": "..."} is prepended to the user's message
+}
+
+// hookEventSince records the hermes version each installed event is KNOWN to
+// exist in. All three are pinned to minHermesVersion because that is the
+// version they were read out of and fired against; the installed package is a
+// squashed source tree with no usable history to bisect an earlier number
+// from, and inventing one would be a claim nothing here supports.
+// AssertHookVersionGate enforces that minHermesVersion is >= every value here.
+var hookEventSince = map[string]string{
+	HookEventPreApprovalRequest:   minHermesVersion,
+	HookEventPostApprovalResponse: minHermesVersion,
+	HookEventOnSessionEnd:         minHermesVersion,
+}
+
+// minHermesVersion is the lowest Hermes Agent version this adapter's install
+// requires.
+//
+// Pinned to the version everything here was measured against — 0.19.0, read
+// out of the installed package and confirmed by `hermes --version`, which
+// prints "Hermes Agent v0.19.0 (2026.7.20) · …" and which core/pkg/cliversion
+// parses. The floor is not a claim about one event: it covers the `hooks:`
+// config block, the allowlist file name and record shape, the stdin envelope,
+// and the three event names and their payload fields — none of which was
+// bisected. cliversion fails OPEN on an unknown or unparseable version, so
+// overshooting costs a missing install on an old CLI rather than a wrong one
+// on a new CLI.
+const minHermesVersion = "0.19.0"
+
+// HookEndpointPath is the daemon's hermes hook route. Exported so
+// registerHookRoutes (core/cmd/irrlichd/startup.go) and beaconroute_test.go's
+// pinned map both derive from the same segment the installed command carries.
+var HookEndpointPath = hookbeacon.EndpointPath(AdapterName)
+
+// hookBlockKey is the top-level key in hermes' config.yaml that holds shell
+// hook definitions.
+const hookBlockKey = "hooks"
+
+// hookRegionOwner is the token embedded in the marker comments delimiting the
+// region of config.yaml this installer owns.
+const hookRegionOwner = "irrlicht"
+
+// configFileName and allowlistFileName are the two files under HERMES_HOME
+// this permission's Apply writes. Both are declared on the permission
+// (Writes.Path and Writes.Also) — an install that wrote only the first would
+// be an install that never fires.
+const (
+	configFileName    = "config.yaml"
+	allowlistFileName = "shell-hooks-allowlist.json"
+)
+
+// displayConfigPath and displayAllowlistPath are the consent copy's
+// home-relative spellings of the two files.
+const (
+	displayConfigPath    = "$HERMES_HOME/config.yaml"
+	displayAllowlistPath = "$HERMES_HOME/shell-hooks-allowlist.json"
+)
+
+// hookTimeoutSeconds bounds hermes' wait for the beacon.
+//
+// hermes runs a shell hook SYNCHRONOUSLY in the agent's own thread
+// (`subprocess.run(..., timeout=spec.timeout)`), so this number is a ceiling
+// on how long a wedged daemon can stall the user's turn. hermes' own default
+// is 60 seconds, which is exactly the stall #1373 built the beacon to avoid;
+// the beacon bounds itself at one second (hookbeacon.DefaultTimeout) and
+// always exits 0, so two is a ceiling that should never be reached and is
+// imperceptible if it is.
+const hookTimeoutSeconds = 2
+
+// shellInterpreter wraps the beacon command. See this file's header: the
+// wrapper is what puts `>/dev/null` between the beacon's stdout and hermes'
+// response parser, and what keeps `|| true` for a binary that has been
+// deleted. It has a second, smaller payoff — hermes derives
+// `script_mtime_at_approval` from the first path-shaped token of the command
+// (`agent/shell_hooks._command_script_path`), so an unwrapped command would
+// name irrlichd itself and every irrlicht upgrade would make
+// `hermes hooks doctor` warn "script modified since approval".
+const shellInterpreter = "/bin/sh"
+
+// --- path resolution ---
+
+// homeDirAbs is homeDir with the failure reported rather than papered over.
+//
+// homeDir falls back to the RELATIVE ".hermes" when os.UserHomeDir fails,
+// which is harmless for a store path that simply finds nothing, and is not
+// harmless for a file this code WRITES: a relative path would land wherever
+// the daemon happens to be running. #1449's shared-config refusal is lexical
+// over the resolved path, so handing it a relative one is exactly the input
+// it cannot judge.
+func homeDirAbs() (string, error) {
+	dir := homeDir()
+	if !filepath.IsAbs(dir) {
+		return "", fmt.Errorf("hermes: cannot resolve an absolute Hermes home (got %q); set %s", dir, homeEnvVar)
+	}
+	return dir, nil
+}
+
+// ConfigPath is the file this permission's Writes.Path resolves — hermes'
+// own config.yaml, where the `hooks:` block lives.
+func ConfigPath() (string, error) {
+	dir, err := homeDirAbs()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, configFileName), nil
+}
+
+// AllowlistPath is the second file the install writes, declared on
+// Writes.Also. hermes will not run a configured hook whose (event, command)
+// pair is absent from it.
+func AllowlistPath() (string, error) {
+	dir, err := homeDirAbs()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, allowlistFileName), nil
+}
+
+// --- command rendering ---
+
+// hookCommand renders the value of a `command:` field for an already-resolved
+// beacon line.
+func hookCommand(beacon string) string {
+	return shellInterpreter + " -c " + shellQuote(beacon)
+}
+
+// shellQuote wraps s in single quotes, escaping embedded quotes with the
+// portable '\” form. hermes parses the field with Python's shlex in POSIX
+// mode, which implements exactly this grammar, so a home directory containing
+// a quote or a space survives the round trip intact.
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}
+
+// hookEntries renders the hookyaml region contents for a resolved command.
+func hookEntries(command string) []hookyaml.Entry {
+	entries := make([]hookyaml.Entry, 0, len(installedHookEvents))
+	for _, e := range installedHookEvents {
+		entries = append(entries, hookyaml.Entry{
+			Event:          e,
+			Command:        command,
+			TimeoutSeconds: hookTimeoutSeconds,
+		})
+	}
+	return entries
+}
+
+func hookYAMLConfig(path, command string) hookyaml.Config {
+	return hookyaml.Config{
+		Path:     path,
+		BlockKey: hookBlockKey,
+		Owner:    hookRegionOwner,
+		Entries:  hookEntries(command),
+	}
+}
+
+// --- install / verify / uninstall ---
+
+// EnsureHooksInstalled writes irrlicht's `hooks:` region into hermes'
+// config.yaml and records the matching approvals in hermes' shell-hook
+// allowlist, for the irrlichd that is running now. Reports whether anything
+// changed.
+//
+// Idempotent, and self-healing across a moved binary: an already-installed
+// region naming a different irrlichd is rewritten in place.
+func EnsureHooksInstalled() (bool, error) {
+	beacon, err := hookbeacon.InstalledCommand(AdapterName)
+	if err != nil {
+		return false, err
+	}
+	return ensureInstalledWithCommand(beacon)
+}
+
+// ensureInstalledWithCommand is EnsureHooksInstalled with the beacon command
+// resolved by the caller — the seam #1178's contract uses to seed the install
+// a differently-situated daemon would have written.
+// hookbeacon.InstalledCommand is called exactly once per entry point, which is
+// the shape hookbeacon's doc comment asks adopters for.
+func ensureInstalledWithCommand(beacon string) (bool, error) {
+	configPath, err := ConfigPath()
+	if err != nil {
+		return false, err
+	}
+	command := hookCommand(beacon)
+
+	changedConfig, err := hookyaml.EnsureInstalled(hookYAMLConfig(configPath, command))
+	if err != nil {
+		return false, err
+	}
+	changedAllowlist, err := ensureAllowlisted(command)
+	if err != nil {
+		return false, err
+	}
+	return changedConfig || changedAllowlist, nil
+}
+
+// VerifyHooksInstalled reports whether the install is still present and
+// current, without writing anything (issue #1372).
+//
+// Both files are checked, and the allowlist is not the lesser half: hermes'
+// own `hermes hooks revoke` removes an approval and leaves the config entry
+// standing, which produces a config that LOOKS installed and a hook that
+// never fires. That is the exact shape #1372 exists to notice.
+func VerifyHooksInstalled() (agent.HookEntryStatus, error) {
+	configPath, err := ConfigPath()
+	if err != nil {
+		return agent.HookEntryStatus{}, err
+	}
+	beacon, err := hookbeacon.InstalledCommand(AdapterName)
+	if err != nil {
+		return agent.HookEntryStatus{}, err
+	}
+	command := hookCommand(beacon)
+
+	present, canonical, err := hookyaml.Inspect(hookYAMLConfig(configPath, command))
+	if err != nil {
+		return agent.HookEntryStatus{}, err
+	}
+	if !present {
+		return agent.HookEntryStatus{Missing: allInstalledEvents()}, nil
+	}
+	if !canonical {
+		return agent.HookEntryStatus{Stale: allInstalledEvents()}, nil
+	}
+
+	missing, err := unallowlistedEvents(command)
+	if err != nil {
+		return agent.HookEntryStatus{}, err
+	}
+	if len(missing) > 0 {
+		// Configured but not approved: hermes skips registration entirely and
+		// logs "not allowlisted". Reported as Missing rather than Stale
+		// because from the channel's point of view the entry is not there.
+		return agent.HookEntryStatus{Missing: missing}, nil
+	}
+	return agent.HookEntryStatus{}, nil
+}
+
+// UninstallHooks removes irrlicht's region from config.yaml and its approvals
+// from the allowlist. Reports whether anything changed.
+//
+// Both halves are unconditional and independent: a user who ran
+// `hermes hooks revoke` has an allowlist with nothing of ours in it and a
+// config that still does, and the reverse happens if someone edits the config
+// by hand. Neither file is created if it does not exist.
+func UninstallHooks() (bool, error) {
+	configPath, err := ConfigPath()
+	if err != nil {
+		return false, err
+	}
+	// The command is irrelevant to removal — hookyaml finds the region by its
+	// markers and the allowlist filter matches on the beacon sentinel — so the
+	// uninstall keeps working when the binary it names has been deleted.
+	changedConfig, err := hookyaml.Uninstall(hookYAMLConfig(configPath, "placeholder"))
+	if err != nil {
+		return false, err
+	}
+	changedAllowlist, err := removeAllowlisted()
+	if err != nil {
+		return false, err
+	}
+	return changedConfig || changedAllowlist, nil
+}
+
+func allInstalledEvents() []string {
+	return append([]string(nil), installedHookEvents...)
+}
+
+// --- hermes' shell-hook allowlist ---
+
+// allowlistFile mirrors the JSON hermes reads and writes
+// (agent/shell_hooks.load_allowlist / save_allowlist). Unknown top-level keys
+// are preserved through a round trip so a future hermes field is not dropped
+// by irrlicht recording an approval.
+type allowlistFile struct {
+	Approvals []allowlistEntry `json:"approvals"`
+	Extra     map[string]json.RawMessage
+}
+
+// allowlistEntry is one (event, command) approval.
+type allowlistEntry struct {
+	Event                 string `json:"event"`
+	Command               string `json:"command"`
+	ApprovedAt            string `json:"approved_at"`
+	ScriptMtimeAtApproval string `json:"script_mtime_at_approval,omitempty"`
+}
+
+func (f *allowlistFile) UnmarshalJSON(b []byte) error {
+	raw := map[string]json.RawMessage{}
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return err
+	}
+	if a, ok := raw["approvals"]; ok {
+		// hermes itself tolerates a non-list `approvals` by replacing it, so a
+		// decode failure here is normalized the same way rather than blocking
+		// the install on a file the agent would silently repair.
+		if err := json.Unmarshal(a, &f.Approvals); err != nil {
+			f.Approvals = nil
+		}
+		delete(raw, "approvals")
+	}
+	f.Extra = raw
+	return nil
+}
+
+func (f allowlistFile) MarshalJSON() ([]byte, error) {
+	out := map[string]json.RawMessage{}
+	for k, v := range f.Extra {
+		out[k] = v
+	}
+	approvals := f.Approvals
+	if approvals == nil {
+		approvals = []allowlistEntry{}
+	}
+	b, err := json.Marshal(approvals)
+	if err != nil {
+		return nil, err
+	}
+	out["approvals"] = b
+	return json.Marshal(out)
+}
+
+func readAllowlist() (allowlistFile, error) {
+	path, err := AllowlistPath()
+	if err != nil {
+		return allowlistFile{}, err
+	}
+	src, err := os.ReadFile(path) // #nosec G304 -- path resolved from the adapter's own Hermes home
+	if errors.Is(err, os.ErrNotExist) {
+		return allowlistFile{}, nil
+	}
+	if err != nil {
+		return allowlistFile{}, err
+	}
+	var f allowlistFile
+	if err := json.Unmarshal(src, &f); err != nil {
+		// hermes' own loader returns an empty skeleton for unparseable JSON
+		// and then overwrites it. Matching that is the only way an install can
+		// succeed against a file the agent already treats as absent — the
+		// alternative is a permanent refusal over a file nothing will repair.
+		return allowlistFile{}, nil
+	}
+	return f, nil
+}
+
+func writeAllowlist(f allowlistFile) error {
+	path, err := AllowlistPath()
+	if err != nil {
+		return err
+	}
+	// indent 2 + sorted keys is exactly what hermes' own save_allowlist emits
+	// (json.dumps(data, indent=2, sort_keys=True)), so a subsequent write by
+	// hermes produces no diff against ours. encoding/json sorts map keys, and
+	// the struct's own field order matches hermes' alphabetical output.
+	b, err := json.MarshalIndent(f, "", "  ")
+	if err != nil {
+		return err
+	}
+	return hookyaml.AtomicWriteFile(path, append(b, '\n'))
+}
+
+// isOurApproval reports whether an allowlist entry is one irrlicht wrote. It
+// matches the beacon SENTINEL rather than the exact command, deliberately: an
+// approval naming an irrlichd that has since moved is still ours, and
+// recognizing it is the precondition for replacing it instead of leaving a
+// dead approval beside the live one.
+func isOurApproval(e allowlistEntry) bool {
+	return strings.Contains(e.Command, hookbeacon.Sentinel(AdapterName))
+}
+
+// ensureAllowlisted records one approval per installed event for command,
+// replacing any previous irrlicht approval. Reports whether anything changed.
+func ensureAllowlisted(command string) (bool, error) {
+	f, err := readAllowlist()
+	if err != nil {
+		return false, err
+	}
+	want := desiredApprovals(command, existingApprovedAt(f, command))
+
+	kept := make([]allowlistEntry, 0, len(f.Approvals))
+	for _, e := range f.Approvals {
+		if !isOurApproval(e) {
+			kept = append(kept, e)
+		}
+	}
+	next := append(kept, want...)
+	if approvalsEqual(f.Approvals, next) {
+		return false, nil
+	}
+	f.Approvals = next
+	return true, writeAllowlist(f)
+}
+
+// existingApprovedAt returns the timestamp already recorded for command, so a
+// re-run that changes nothing else does not churn the file — and so the user's
+// original approval time survives an irrlicht upgrade. Empty when there is no
+// current approval for this exact command.
+func existingApprovedAt(f allowlistFile, command string) string {
+	for _, e := range f.Approvals {
+		if e.Command == command && e.ApprovedAt != "" {
+			return e.ApprovedAt
+		}
+	}
+	return ""
+}
+
+func desiredApprovals(command, approvedAt string) []allowlistEntry {
+	if approvedAt == "" {
+		approvedAt = time.Now().UTC().Format("2006-01-02T15:04:05.000000Z")
+	}
+	mtime := scriptMtimeISO()
+	out := make([]allowlistEntry, 0, len(installedHookEvents))
+	for _, e := range installedHookEvents {
+		out = append(out, allowlistEntry{
+			Event:                 e,
+			Command:               command,
+			ApprovedAt:            approvedAt,
+			ScriptMtimeAtApproval: mtime,
+		})
+	}
+	return out
+}
+
+// scriptMtimeISO renders the modification time of the interpreter the command
+// names, the way hermes' own _record_approval does.
+//
+// hermes derives the "script" from the first path-shaped token of the command,
+// which for the wrapped form is the interpreter — a file that does not change
+// when irrlicht is upgraded. An unreadable one yields "", which hermes' own
+// helper also returns and which its drift check treats as "no baseline".
+func scriptMtimeISO() string {
+	info, err := os.Stat(shellInterpreter)
+	if err != nil {
+		return ""
+	}
+	return info.ModTime().UTC().Format("2006-01-02T15:04:05.000000Z")
+}
+
+func approvalsEqual(a, b []allowlistEntry) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// unallowlistedEvents returns the installed events that command is not
+// approved for, in installedHookEvents order.
+func unallowlistedEvents(command string) ([]string, error) {
+	f, err := readAllowlist()
+	if err != nil {
+		return nil, err
+	}
+	approved := map[string]bool{}
+	for _, e := range f.Approvals {
+		if e.Command == command {
+			approved[e.Event] = true
+		}
+	}
+	var missing []string
+	for _, e := range installedHookEvents {
+		if !approved[e] {
+			missing = append(missing, e)
+		}
+	}
+	return missing, nil
+}
+
+// removeAllowlisted drops every irrlicht approval. Reports whether anything
+// changed. A file that does not exist is not created.
+func removeAllowlisted() (bool, error) {
+	path, err := AllowlistPath()
+	if err != nil {
+		return false, err
+	}
+	if _, statErr := os.Stat(path); errors.Is(statErr, os.ErrNotExist) {
+		return false, nil
+	}
+	f, err := readAllowlist()
+	if err != nil {
+		return false, err
+	}
+	kept := make([]allowlistEntry, 0, len(f.Approvals))
+	for _, e := range f.Approvals {
+		if !isOurApproval(e) {
+			kept = append(kept, e)
+		}
+	}
+	if len(kept) == len(f.Approvals) {
+		return false, nil
+	}
+	f.Approvals = kept
+	return true, writeAllowlist(f)
+}

--- a/core/adapters/inbound/agents/hermes/hookinstaller_test.go
+++ b/core/adapters/inbound/agents/hermes/hookinstaller_test.go
@@ -1,0 +1,476 @@
+package hermes
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"irrlicht/core/adapters/inbound/agents/hookyaml"
+	"irrlicht/core/domain/permission"
+	"irrlicht/core/internal/contracttesting"
+	"irrlicht/core/pkg/hookbeacon"
+)
+
+// hooksPermission returns the hooks permission's Apply/Remove closures off the
+// real registration the daemon consumes.
+func hooksPermission(t *testing.T) (apply, remove func() error) {
+	t.Helper()
+	for _, p := range Agent().Permissions {
+		if p.Key == PermissionKeyHooks {
+			if p.Apply == nil || p.Remove == nil {
+				t.Fatal("hooks permission declares no Apply/Remove")
+			}
+			return p.Apply, p.Remove
+		}
+	}
+	t.Fatal("no hooks permission")
+	return nil, nil
+}
+
+func readConfig(t *testing.T) string {
+	t.Helper()
+	path, err := ConfigPath()
+	if err != nil {
+		t.Fatalf("ConfigPath: %v", err)
+	}
+	b, err := os.ReadFile(path) // #nosec G304 -- the scratch path this test resolved
+	if os.IsNotExist(err) {
+		return ""
+	}
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	return string(b)
+}
+
+func writeConfig(t *testing.T, body string) {
+	t.Helper()
+	path, err := ConfigPath()
+	if err != nil {
+		t.Fatalf("ConfigPath: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+}
+
+func readApprovals(t *testing.T) []allowlistEntry {
+	t.Helper()
+	path, err := AllowlistPath()
+	if err != nil {
+		t.Fatalf("AllowlistPath: %v", err)
+	}
+	b, err := os.ReadFile(path) // #nosec G304 -- the scratch path this test resolved
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		t.Fatalf("read allowlist: %v", err)
+	}
+	var f allowlistFile
+	if err := json.Unmarshal(b, &f); err != nil {
+		t.Fatalf("decode allowlist: %v", err)
+	}
+	return f.Approvals
+}
+
+// TestHooksPermission_IsGated wires the install-type flavour of the #797
+// contract: nothing is written while the permission is pending, granting
+// installs both files, and denying removes them.
+func TestHooksPermission_IsGated(t *testing.T) {
+	hermesHome(t)
+	apply, remove := hooksPermission(t)
+
+	state := permission.StatePending
+	contracttesting.AssertPermissionGated(t, contracttesting.PermissionGate{
+		Key: PermissionKeyHooks,
+		// store is the adapter's only other declared permission and is
+		// observe-kind, so it has no closure to drive: the key-isolation arm is
+		// INERT here and repeats the revoked arm exactly, the same situation
+		// copilot's, geminicli's, vibe's, pi's and opencode's equivalent tests
+		// document. Install-type wirings hold their own permission's closures,
+		// so a wrong key is not representable — the arm is load-bearing at the
+		// live receiver (hooks_test.go), not here.
+		OtherKeys: []string{PermissionKeyStore},
+		SetState:  contracttesting.OnlyKey(PermissionKeyHooks, func(s permission.State) { state = s }),
+		Exercise: func() {
+			switch state {
+			case permission.StateGranted:
+				if err := apply(); err != nil {
+					t.Fatalf("apply: %v", err)
+				}
+			case permission.StateDenied:
+				if err := remove(); err != nil {
+					t.Fatalf("remove: %v", err)
+				}
+			}
+		},
+		Observe: func() bool {
+			status, err := VerifyHooksInstalled()
+			if err != nil {
+				t.Fatalf("VerifyHooksInstalled: %v", err)
+			}
+			return status.Intact()
+		},
+	})
+}
+
+// TestEnsureHooksInstalled_LeavesTheRestOfTheConfigByteIdentical is the whole
+// reason hookyaml exists rather than a YAML round-trip: the file this installer
+// edits is the user's ONE hermes config, carrying their model, provider and
+// sandbox settings and the comments hermes' own shipped example teaches them to
+// keep.
+func TestEnsureHooksInstalled_LeavesTheRestOfTheConfigByteIdentical(t *testing.T) {
+	hermesHome(t)
+	const original = `# Hermes Agent CLI Configuration
+model:
+  default: "anthropic/claude-opus-4.6"   # keep this comment
+  provider: "auto"
+
+terminal:
+  backend: local
+`
+	writeConfig(t, original)
+
+	if _, err := EnsureHooksInstalled(); err != nil {
+		t.Fatalf("EnsureHooksInstalled: %v", err)
+	}
+
+	got := readConfig(t)
+	if !strings.HasPrefix(got, original) {
+		t.Fatalf("the original config is no longer a byte-identical prefix of the result:\n--- got ---\n%s", got)
+	}
+	added := strings.TrimPrefix(got, original)
+	// The block key is INSIDE the marked region, because this install is what
+	// created it — which is what lets a later uninstall take the key away
+	// again without touching a `hooks:` the user wrote themselves.
+	if !strings.HasPrefix(added, hookyaml.BeginMarker(hookRegionOwner)+"\n"+hookBlockKey+":\n") {
+		t.Errorf("the appended region does not open with the marker and the block key:\n%s", added)
+	}
+	for _, event := range installedHookEvents {
+		if !strings.Contains(added, event+":") {
+			t.Errorf("event %q is not in the appended block:\n%s", event, added)
+		}
+	}
+}
+
+// TestEnsureHooksInstalled_RefusesAnEventTheUserAlreadyDeclares is the
+// collision refusal. A YAML mapping cannot hold a duplicate key and
+// yaml.safe_load resolves one silently to the last occurrence, so writing our
+// entry beside theirs would DELETE their hook with no error anywhere. Refusing
+// surfaces as #1362's "granted but NOT applied, because …" instead.
+func TestEnsureHooksInstalled_RefusesAnEventTheUserAlreadyDeclares(t *testing.T) {
+	hermesHome(t)
+	original := `hooks:
+  ` + HookEventOnSessionEnd + `:
+    - command: "/usr/local/bin/my-own-hook"
+`
+	writeConfig(t, original)
+
+	_, err := EnsureHooksInstalled()
+	if err == nil {
+		t.Fatal("EnsureHooksInstalled succeeded against a config that already declares one of our events")
+	}
+	if !strings.Contains(err.Error(), HookEventOnSessionEnd) {
+		t.Errorf("error %q does not name the colliding event — #1362 renders this text to the user", err)
+	}
+	if got := readConfig(t); got != original {
+		t.Errorf("the config was modified by a refused install:\n%s", got)
+	}
+	if approvals := readApprovals(t); len(approvals) != 0 {
+		t.Errorf("a refused install still recorded %d approval(s) — an approval for a hook that "+
+			"is not installed is a consent record for nothing", len(approvals))
+	}
+}
+
+// TestEnsureHooksInstalled_WritesTheApprovalHermesRequires is the second half
+// of the install, and the half that is easy to leave out: hermes will not RUN a
+// configured hook whose (event, command) pair is absent from its allowlist. An
+// install without it reads `granted` in the wizard, passes every config
+// assertion, and delivers nothing forever.
+func TestEnsureHooksInstalled_WritesTheApprovalHermesRequires(t *testing.T) {
+	hermesHome(t)
+	if _, err := EnsureHooksInstalled(); err != nil {
+		t.Fatalf("EnsureHooksInstalled: %v", err)
+	}
+
+	beacon, err := hookbeacon.InstalledCommand(AdapterName)
+	if err != nil {
+		t.Fatalf("InstalledCommand: %v", err)
+	}
+	want := hookCommand(beacon)
+
+	approvals := readApprovals(t)
+	if len(approvals) != len(installedHookEvents) {
+		t.Fatalf("recorded %d approvals, want one per installed event (%d)", len(approvals), len(installedHookEvents))
+	}
+	for i, event := range installedHookEvents {
+		if approvals[i].Event != event {
+			t.Errorf("approval %d is for %q, want %q", i, approvals[i].Event, event)
+		}
+		if approvals[i].Command != want {
+			t.Errorf("approval %d command = %q, want the command the config declares %q", i, approvals[i].Command, want)
+		}
+		if approvals[i].ApprovedAt == "" {
+			t.Errorf("approval %d has no approved_at; hermes prints it in `hermes hooks list`", i)
+		}
+	}
+}
+
+// TestEnsureHooksInstalled_PreservesForeignApprovals pins that the allowlist is
+// merged, not replaced. It is the user's own consent record for THEIR hooks,
+// and clobbering it would silently disable everything else they had approved.
+func TestEnsureHooksInstalled_PreservesForeignApprovals(t *testing.T) {
+	home := hermesHome(t)
+	const foreign = `{
+  "approvals": [
+    {"event": "pre_tool_call", "command": "/usr/local/bin/their-hook", "approved_at": "2026-01-01T00:00:00Z"}
+  ],
+  "some_future_hermes_field": 7
+}`
+	if err := os.WriteFile(filepath.Join(home, allowlistFileName), []byte(foreign), 0o600); err != nil {
+		t.Fatalf("seed allowlist: %v", err)
+	}
+
+	if _, err := EnsureHooksInstalled(); err != nil {
+		t.Fatalf("EnsureHooksInstalled: %v", err)
+	}
+
+	approvals := readApprovals(t)
+	var kept bool
+	for _, a := range approvals {
+		if a.Command == "/usr/local/bin/their-hook" {
+			kept = true
+		}
+	}
+	if !kept {
+		t.Errorf("the user's own approval was dropped: %+v", approvals)
+	}
+
+	path, _ := AllowlistPath()
+	raw, err := os.ReadFile(path) // #nosec G304 -- the scratch path this test resolved
+	if err != nil {
+		t.Fatalf("read allowlist: %v", err)
+	}
+	if !strings.Contains(string(raw), "some_future_hermes_field") {
+		t.Errorf("an unknown top-level field was dropped on the round trip:\n%s", raw)
+	}
+}
+
+// TestUninstallHooks_RemovesBothHalvesAndNothingElse pins that revoking leaves
+// the user's own config and their own approvals exactly as they were.
+func TestUninstallHooks_RemovesBothHalvesAndNothingElse(t *testing.T) {
+	home := hermesHome(t)
+	const original = `model:
+  default: "anthropic/claude-opus-4.6"
+`
+	writeConfig(t, original)
+	const foreign = `{"approvals":[{"event":"pre_tool_call","command":"/usr/local/bin/their-hook","approved_at":"2026-01-01T00:00:00Z"}]}`
+	if err := os.WriteFile(filepath.Join(home, allowlistFileName), []byte(foreign), 0o600); err != nil {
+		t.Fatalf("seed allowlist: %v", err)
+	}
+
+	if _, err := EnsureHooksInstalled(); err != nil {
+		t.Fatalf("EnsureHooksInstalled: %v", err)
+	}
+	changed, err := UninstallHooks()
+	if err != nil {
+		t.Fatalf("UninstallHooks: %v", err)
+	}
+	if !changed {
+		t.Error("UninstallHooks reported no change after an install")
+	}
+
+	if got := readConfig(t); got != original {
+		t.Errorf("config after uninstall is not the original:\n--- got ---\n%s--- want ---\n%s", got, original)
+	}
+	approvals := readApprovals(t)
+	if len(approvals) != 1 || approvals[0].Command != "/usr/local/bin/their-hook" {
+		t.Errorf("approvals after uninstall = %+v, want only the user's own", approvals)
+	}
+
+	again, err := UninstallHooks()
+	if err != nil {
+		t.Fatalf("second UninstallHooks: %v", err)
+	}
+	if again {
+		t.Error("a second UninstallHooks reported a change — it is not idempotent")
+	}
+}
+
+// TestVerifyHooksInstalled_ReportsARevokedApproval is the #1372 case this
+// adapter has and the file-writing adapters do not: `hermes hooks revoke`
+// removes the approval and leaves the config entry standing, producing an
+// install that LOOKS present and fires nothing.
+func TestVerifyHooksInstalled_ReportsARevokedApproval(t *testing.T) {
+	home := hermesHome(t)
+	if _, err := EnsureHooksInstalled(); err != nil {
+		t.Fatalf("EnsureHooksInstalled: %v", err)
+	}
+	status, err := VerifyHooksInstalled()
+	if err != nil {
+		t.Fatalf("VerifyHooksInstalled: %v", err)
+	}
+	if !status.Intact() {
+		t.Fatalf("a fresh install is not Intact: %+v", status)
+	}
+
+	// What `hermes hooks revoke <command>` does.
+	if err := os.WriteFile(filepath.Join(home, allowlistFileName), []byte(`{"approvals":[]}`), 0o600); err != nil {
+		t.Fatalf("revoke: %v", err)
+	}
+
+	status, err = VerifyHooksInstalled()
+	if err != nil {
+		t.Fatalf("VerifyHooksInstalled: %v", err)
+	}
+	if status.Intact() {
+		t.Fatal("a revoked approval reads as Intact — the entries are in config.yaml but hermes will not run them")
+	}
+	if len(status.Missing) != len(installedHookEvents) {
+		t.Errorf("Missing = %v, want every installed event", status.Missing)
+	}
+}
+
+// TestEnsureHooksInstalled_IsIdempotent pins that a second run changes nothing
+// — including the approval timestamp, which would otherwise churn the user's
+// allowlist on every daemon start.
+func TestEnsureHooksInstalled_IsIdempotent(t *testing.T) {
+	hermesHome(t)
+	if _, err := EnsureHooksInstalled(); err != nil {
+		t.Fatalf("first install: %v", err)
+	}
+	before, beforeApprovals := readConfig(t), readApprovals(t)
+
+	changed, err := EnsureHooksInstalled()
+	if err != nil {
+		t.Fatalf("second install: %v", err)
+	}
+	if changed {
+		t.Error("the second install reported a change")
+	}
+	if got := readConfig(t); got != before {
+		t.Errorf("the config changed on a second install:\n%s", got)
+	}
+	after := readApprovals(t)
+	if len(after) != len(beforeApprovals) {
+		t.Fatalf("approval count changed from %d to %d", len(beforeApprovals), len(after))
+	}
+	for i := range after {
+		if after[i] != beforeApprovals[i] {
+			t.Errorf("approval %d churned: %+v -> %+v", i, beforeApprovals[i], after[i])
+		}
+	}
+}
+
+// TestInstalledCommandRoundTripsThroughHermesParser is the property hermes'
+// side of the contract rests on: hermes runs `shlex.split(command)` with
+// shell=False, so the value written into config.yaml must split into exactly
+// [`/bin/sh`, `-c`, <the beacon line>].
+//
+// The Go half is asserted here; the Python half was verified live during this
+// issue's audit against Hermes v0.19.0, including a home directory containing a
+// space and a single quote.
+func TestInstalledCommandRoundTripsThroughHermesParser(t *testing.T) {
+	for _, binary := range []string{
+		"/usr/local/bin/irrlichd",
+		"/Users/o'brien/my apps/irrlichd",
+	} {
+		beacon, err := hookbeacon.Command(binary, AdapterName)
+		if err != nil {
+			t.Fatalf("hookbeacon.Command(%q): %v", binary, err)
+		}
+		got := hookCommand(beacon)
+		argv, err := posixSplit(got)
+		if err != nil {
+			t.Fatalf("splitting %q: %v", got, err)
+		}
+		want := []string{shellInterpreter, "-c", beacon}
+		if len(argv) != len(want) {
+			t.Fatalf("argv = %#v, want %#v", argv, want)
+		}
+		for i := range want {
+			if argv[i] != want[i] {
+				t.Fatalf("argv = %#v, want %#v", argv, want)
+			}
+		}
+		if !strings.Contains(got, hookbeacon.Sentinel(AdapterName)) {
+			t.Errorf("the installed command %q does not carry the beacon sentinel, so nothing "+
+				"would recognize it as ours on the way back out", got)
+		}
+	}
+}
+
+// posixSplit is the subset of Python's shlex.split(posix=True) the installed
+// command exercises: unquoted words, single-quoted words, and the backslash
+// escape OUTSIDE a quote that makes the '\” sequence work at all. Written out
+// rather than approximated with strings.Fields because the whole point is that
+// a path containing a space or a quote survives — and the backslash branch is
+// load-bearing rather than defensive: without it the first draft of this
+// helper read `'\”` as three literal characters and reported a correct
+// command as broken.
+func posixSplit(s string) ([]string, error) {
+	var (
+		out     []string
+		cur     strings.Builder
+		inWord  bool
+		inQuote bool
+	)
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch {
+		case inQuote && c == '\'':
+			inQuote = false
+		case inQuote:
+			cur.WriteByte(c)
+		case c == '\\':
+			if i+1 >= len(s) {
+				return nil, errUnterminatedQuote
+			}
+			i++
+			inWord = true
+			cur.WriteByte(s[i])
+		case c == '\'':
+			inQuote, inWord = true, true
+		case c == ' ':
+			if inWord {
+				out = append(out, cur.String())
+				cur.Reset()
+				inWord = false
+			}
+		default:
+			inWord = true
+			cur.WriteByte(c)
+		}
+	}
+	if inQuote {
+		return nil, errUnterminatedQuote
+	}
+	if inWord {
+		out = append(out, cur.String())
+	}
+	return out, nil
+}
+
+var errUnterminatedQuote = &unterminatedQuoteError{}
+
+type unterminatedQuoteError struct{}
+
+func (*unterminatedQuoteError) Error() string { return "unterminated single quote" }
+
+// TestHookRegionMarkersAreYAMLComments is a LOCK on the one thing that keeps a
+// refused or half-written install from breaking the user's agent: the markers
+// this installer writes into a live config must be comments, so a config
+// carrying them still loads.
+func TestHookRegionMarkersAreYAMLComments(t *testing.T) {
+	for _, m := range []string{hookyaml.BeginMarker(hookRegionOwner), hookyaml.EndMarker(hookRegionOwner)} {
+		if !strings.HasPrefix(m, "#") {
+			t.Errorf("marker %q is not a YAML comment", m)
+		}
+		if !strings.Contains(m, hookRegionOwner) {
+			t.Errorf("marker %q does not name its owner, so two owners' regions would be indistinguishable", m)
+		}
+	}
+}

--- a/core/adapters/inbound/agents/hermes/hookinstaller_test.go
+++ b/core/adapters/inbound/agents/hermes/hookinstaller_test.go
@@ -474,3 +474,108 @@ func TestHookRegionMarkersAreYAMLComments(t *testing.T) {
 		}
 	}
 }
+
+// TestInstallSurvivesHermesRewritingItsOwnConfig is the defect test for the
+// one failure mode a marker-delimited region has and a data-level entry does
+// not.
+//
+// hermes rewrites config.yaml from a parsed dict on every save — `hermes
+// config set`, the setup wizard, a dashboard save all go through
+// `save_config` -> `atomic_yaml_write` — so every comment in the file is
+// dropped while the data survives. Our region markers are comments. After one
+// of those saves the three entries are still there and still firing, and
+// nothing identifies them.
+//
+// Both halves matter and both were broken before the sentinel existed:
+// EnsureHooksInstalled reported its OWN entries as a user's colliding hooks,
+// forever, as a false "granted but NOT applied"; and UninstallHooks found no
+// region, removed nothing, and left irrlicht's entries in the user's config
+// with no supported way to take them out.
+func TestInstallSurvivesHermesRewritingItsOwnConfig(t *testing.T) {
+	hermesHome(t)
+	const preamble = "model:\n  default: \"anthropic/claude-opus-4.6\"\n"
+	writeConfig(t, preamble)
+	if _, err := EnsureHooksInstalled(); err != nil {
+		t.Fatalf("EnsureHooksInstalled: %v", err)
+	}
+
+	// What hermes' own writer leaves behind: the same data, no comments.
+	stripped := stripYAMLComments(readConfig(t))
+	if strings.Contains(stripped, hookyaml.BeginMarker(hookRegionOwner)) {
+		t.Fatal("the fixture still carries a marker — the rewrite being simulated did not happen")
+	}
+	for _, event := range installedHookEvents {
+		if !strings.Contains(stripped, event+":") {
+			t.Fatalf("the fixture lost event %q — hermes' rewrite keeps the DATA", event)
+		}
+	}
+	writeConfig(t, stripped)
+
+	t.Run("verify reports it as present but not intact", func(t *testing.T) {
+		status, err := VerifyHooksInstalled()
+		if err != nil {
+			t.Fatalf("VerifyHooksInstalled: %v", err)
+		}
+		if status.Intact() {
+			t.Error("a marker-less install reads as Intact, so #1372's verifier would never restore the markers")
+		}
+	})
+
+	t.Run("ensure recovers instead of colliding with itself", func(t *testing.T) {
+		changed, err := EnsureHooksInstalled()
+		if err != nil {
+			t.Fatalf("EnsureHooksInstalled after hermes' rewrite: %v", err)
+		}
+		if !changed {
+			t.Error("reported no change while the markers were missing")
+		}
+		got := readConfig(t)
+		if n := strings.Count(got, hookyaml.BeginMarker(hookRegionOwner)); n != 1 {
+			t.Errorf("found %d regions after recovery, want 1:\n%s", n, got)
+		}
+		for _, event := range installedHookEvents {
+			if n := strings.Count(got, event+":"); n != 1 {
+				t.Errorf("event %q appears %d times after recovery, want 1 — a duplicate YAML key silently keeps only one:\n%s", event, n, got)
+			}
+		}
+		if !strings.HasPrefix(got, preamble) {
+			t.Errorf("recovery did not leave the user's own config alone:\n%s", got)
+		}
+	})
+
+	t.Run("uninstall removes them without the markers", func(t *testing.T) {
+		writeConfig(t, stripYAMLComments(readConfig(t)))
+		changed, err := UninstallHooks()
+		if err != nil {
+			t.Fatalf("UninstallHooks: %v", err)
+		}
+		if !changed {
+			t.Fatal("UninstallHooks found nothing to remove — irrlicht's entries would stay in the user's config with no supported way to take them out")
+		}
+		got := readConfig(t)
+		if strings.Contains(got, hookbeacon.Sentinel(AdapterName)) {
+			t.Errorf("an entry of ours survived uninstall:\n%s", got)
+		}
+		for _, event := range installedHookEvents {
+			if strings.Contains(got, event+":") {
+				t.Errorf("event %q survived uninstall:\n%s", event, got)
+			}
+		}
+	})
+}
+
+// stripYAMLComments removes every whole-line comment, which is what hermes'
+// dict round-trip does to the file. Whole-line only: a trailing comment is
+// dropped by hermes too, but keeping them here makes the fixture a STRICTER
+// input (the region's own markers are whole-line, so removing exactly those is
+// what reproduces the failure).
+func stripYAMLComments(src string) string {
+	var out []string
+	for _, line := range strings.Split(src, "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "#") {
+			continue
+		}
+		out = append(out, line)
+	}
+	return strings.Join(out, "\n")
+}

--- a/core/adapters/inbound/agents/hermes/hookpath_test.go
+++ b/core/adapters/inbound/agents/hermes/hookpath_test.go
@@ -1,0 +1,53 @@
+// hookpath_test.go wires this adapter's hook receiver into the shared issue
+// #1361 contract, under its PathDaemonDerived route (#1719).
+//
+// Every other receiver in the tree takes the PathFromBody route: the payload
+// names a transcript file and the receiver confines that caller-supplied string
+// to the adapter's declared roots. This one cannot, and the difference is
+// structural rather than a shortfall — hermes writes no transcript files at
+// all, so there is no file per session for a caller to name, and the path every
+// consumer keys a hermes session on is composed by the daemon from its own
+// store resolver.
+//
+// hermes' envelope DOES carry a path-shaped field, `cwd`, which is the one
+// thing the store cannot supply for a `source='cli'` session. It is
+// deliberately not read (see hooks.go's payload type): adopting it would put a
+// caller-supplied path back on this dispatch, which is exactly what this route
+// asserts does not happen. The route's obligations contradict the from-body
+// route's directly — there the four hostile bodies must dispatch NOTHING; here
+// each must dispatch the SAME string a clean body does — which is what makes
+// this a declaration rather than an exemption.
+package hermes
+
+import (
+	"testing"
+
+	"irrlicht/core/internal/contracttesting"
+)
+
+func TestHookPathConfined(t *testing.T) {
+	contracttesting.AssertHookPathConfined(t, contracttesting.HookReceiver{
+		Route: contracttesting.PathDaemonDerived,
+		Root:  hermesHome,
+		New: func(t *testing.T) contracttesting.HookReceiverUnderTest {
+			t.Helper()
+			target := &mockTarget{}
+			return contracttesting.HookReceiverUnderTest{
+				Handler:      NewHookHandler(target, nil, mockLogger{}),
+				Observed:     func() bool { return target.totalCalls() > 0 },
+				ObservedPath: target.observedPath,
+			}
+		},
+		// Both closures ignore the transcript path the contract offers, which
+		// is the whole point: PayloadFor renders exactly what hermes writes,
+		// and ForeignPathPayload splices in the keys a hostile caller would
+		// try. The contract refuses to run if those two render the same body.
+		PayloadFor:         func(string) string { return contractPayload(HookEventOnSessionEnd) },
+		ForeignPathPayload: foreignPathPayload,
+		DerivedPath: func(t *testing.T) string {
+			t.Helper()
+			return transcriptPathFor(contractSessionID)
+		},
+		EndpointPath: HookEndpointPath,
+	})
+}

--- a/core/adapters/inbound/agents/hermes/hookport_test.go
+++ b/core/adapters/inbound/agents/hermes/hookport_test.go
@@ -1,0 +1,135 @@
+// hookport_test.go wires the hermes shell-hook installer into the shared issue
+// #1178 contract, under its DeliveryAddressFree route (#1453): the installed
+// entry carries no address at all, because it names the `irrlichd hook-post
+// hermes` beacon, which resolves the daemon's address itself at fire time.
+//
+// hermes is the sixth adapter on that route, after geminicli, kirocli, vibe, pi
+// and opencode.
+//
+// The read-back obligations (2-4) go through HookInstaller.ReadEntries /
+// EndpointOfRaw (#1734), for the same reason mistral-vibe's do: this adapter's
+// config is not JSON, so there is no decoded map[string]interface{} anywhere on
+// the write path for EntriesOf to traverse. readInstalledCommands below is a
+// line scan over the marker-delimited region the installer owns — which is what
+// makes the read genuinely per-event rather than "the whole file, three times".
+package hermes
+
+import (
+	"bufio"
+	"os"
+	"strings"
+	"testing"
+
+	"irrlicht/core/adapters/inbound/agents/hookyaml"
+	"irrlicht/core/internal/contracttesting"
+	"irrlicht/core/pkg/hookbeacon"
+)
+
+// foreignBinaryPath is the irrlichd a DIFFERENTLY-situated daemon would have
+// named. Deliberately a path that does not exist: an absolute path that has
+// stopped existing is exactly the drift beacon delivery newly admits (#1373),
+// and it needs no second executable to arrange.
+const foreignBinaryPath = "/nonexistent-irrlicht-1722/bin/irrlichd"
+
+// hermesEntryNow / hermesEndpointOfMap are the contract's in-memory
+// Entry/EndpointOf pair for obligation 1 — a synthetic one-key map, since
+// obligation 1 never reads the filesystem.
+func hermesEntryNow() map[string]interface{} {
+	beacon, _ := hookbeacon.InstalledCommand(AdapterName)
+	return map[string]interface{}{"command": hookCommand(beacon)}
+}
+
+func hermesEndpointOfMap(hook map[string]interface{}) string {
+	c, _ := hook["command"].(string)
+	return c
+}
+
+// hermesReadEntries is the contract's ReadEntries: the `command:` value the
+// installed region declares for one event, as raw bytes.
+//
+// It reads only INSIDE the marker-delimited region, so a user's own hook on the
+// same event — which the installer refuses to create in the first place — could
+// never be mistaken for ours.
+func hermesReadEntries(path, event string) ([][]byte, error) {
+	f, err := os.Open(path) // #nosec G304 -- the path the test itself resolved
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = f.Close() }()
+
+	var out [][]byte
+	inRegion, inEvent := false, false
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+		switch {
+		case line == hookyaml.BeginMarker(hookRegionOwner):
+			inRegion = true
+		case line == hookyaml.EndMarker(hookRegionOwner):
+			inRegion = false
+		case !inRegion:
+		case strings.HasSuffix(line, ":") && !strings.HasPrefix(line, "-"):
+			inEvent = strings.TrimSuffix(line, ":") == event
+		case inEvent && strings.HasPrefix(line, "- command:"):
+			out = append(out, []byte(strings.TrimSpace(strings.TrimPrefix(line, "- command:"))))
+		}
+	}
+	return out, sc.Err()
+}
+
+// hermesEndpointOfRaw unquotes one raw entry back into the command the agent
+// will run — the same string ensureInstalledWithCommand rendered in.
+func hermesEndpointOfRaw(entry []byte) string {
+	s := string(entry)
+	if len(s) < 2 || s[0] != '"' || s[len(s)-1] != '"' {
+		return s
+	}
+	// The installer writes a YAML double-quoted scalar whose only escapes are
+	// \\ and \" (hookyaml.Quote), so undoing those two is exact rather than an
+	// approximation of a general YAML unescape.
+	s = s[1 : len(s)-1]
+	s = strings.ReplaceAll(s, `\"`, `"`)
+	return strings.ReplaceAll(s, `\\`, `\`)
+}
+
+func TestHookEndpointFollowsBindAddr(t *testing.T) {
+	// Checked up front so a resolution failure reads as itself rather than as
+	// the empty-delivery wiring error assertDeliveryIsOurs would report.
+	if _, err := hookbeacon.InstalledCommand(AdapterName); err != nil {
+		t.Fatalf("resolving the beacon command: %v", err)
+	}
+
+	contracttesting.AssertHookEndpointFollowsBindAddr(t, contracttesting.HookInstaller{
+		Delivery: contracttesting.DeliveryAddressFree,
+		SettingsPath: func(t *testing.T) string {
+			hermesHome(t)
+			path, err := ConfigPath()
+			if err != nil {
+				t.Fatalf("resolving the config path: %v", err)
+			}
+			return path
+		},
+		Sentinel:        hookbeacon.Sentinel(AdapterName),
+		Events:          installedHookEvents,
+		Entry:           hermesEntryNow,
+		EndpointOf:      hermesEndpointOfMap,
+		ReadEntries:     hermesReadEntries,
+		EndpointOfRaw:   hermesEndpointOfRaw,
+		EnsureInstalled: EnsureHooksInstalled,
+		Uninstall:       UninstallHooks,
+		// ForeignInstall seeds a region naming a DIFFERENT (nonexistent)
+		// irrlicht binary — the address-free counterpart of seeding a
+		// stale-port install — so the contract can assert EnsureHooksInstalled
+		// rewrites it in place rather than leaving two of them.
+		ForeignInstall: func() (bool, error) {
+			beacon, err := hookbeacon.Command(foreignBinaryPath, AdapterName)
+			if err != nil {
+				return false, err
+			}
+			return ensureInstalledWithCommand(beacon)
+		},
+	})
+}

--- a/core/adapters/inbound/agents/hermes/hookreceipt_test.go
+++ b/core/adapters/inbound/agents/hermes/hookreceipt_test.go
@@ -1,0 +1,44 @@
+// hookreceipt_test.go wires this adapter's hook receiver into the shared issue
+// #1368 contract: a consent-passed request counts as a receipt whatever the
+// receiver then does with it, and a consent-denied one does not.
+//
+// One of the four obligations is WEAKER here than for a from-body receiver, and
+// it is stated rather than left implied. Obligation 3 — "a path-confinement
+// rejection still counts" — posts a well-formed body carrying an out-of-tree
+// transcript path. This receiver reads no path field, so that body is
+// indistinguishable from obligation 1's and the arm degenerates into a repeat
+// of it. That is the same inertness AGENTS.md records for OtherKeys on an
+// install-type permission gate: the arm is kept uniform, with no opt-out,
+// because a flag this wiring could take is one a from-body wiring could take
+// too. What obligation 3 protects against is unreachable here for the reason
+// the whole PathDaemonDerived route exists — there is no confinement rejection
+// to mis-count, because there is no caller-supplied path.
+package hermes
+
+import (
+	"net/http"
+	"testing"
+
+	"irrlicht/core/internal/contracttesting"
+	"irrlicht/core/ports/outbound"
+)
+
+func TestHookReceiptObserved(t *testing.T) {
+	contracttesting.AssertHookReceiptObserved(t, contracttesting.HookReceiptReceiver{
+		Adapter:         AdapterName,
+		Root:            hermesHome,
+		WriteTranscript: writeContractTranscript,
+		New: func(t *testing.T, log outbound.Logger) http.Handler {
+			t.Helper()
+			return NewHookHandler(&mockTarget{},
+				keyedGate{PermissionKeyHooks: true, PermissionKeyStore: true}, log)
+		},
+		NewDenied: func(t *testing.T, log outbound.Logger) http.Handler {
+			t.Helper()
+			return NewHookHandler(&mockTarget{}, keyedGate{}, log)
+		},
+		PayloadFor:   func(_, event string) string { return unknownEventPayload(event) },
+		KnownEvent:   HookEventOnSessionEnd,
+		EndpointPath: HookEndpointPath,
+	})
+}

--- a/core/adapters/inbound/agents/hermes/hooks.go
+++ b/core/adapters/inbound/agents/hermes/hooks.go
@@ -1,0 +1,269 @@
+// hooks.go provides the HTTP handler for receiving Hermes Agent lifecycle
+// events (issue #1722, epic #1355).
+//
+// Three events are installed and dispatched: pre_approval_request asserts the
+// blocked-on-user signal, post_approval_response releases it, and
+// on_session_end releases it AND reports the authoritative turn end.
+//
+// # hermes DOES have a blocked-on-user state, and its store cannot express it
+//
+// #1722 asked whether hermes has a blocked-on-user state and told this issue
+// not to assume the answer. It does, and it is the whole reason a hook channel
+// is worth anything here. Measured against Hermes Agent v0.19.0's own source:
+//
+//   - `tools/approval.py` asks the user before running a command that matched
+//     a danger pattern, and it fires `pre_approval_request` immediately
+//     before the prompt on every surface. It is NARROW: the guards run first
+//     and the hook is reached only when something genuinely has to be asked,
+//     so this is not the fires-on-every-tool event #1722 warned against
+//     reusing `session.HookPreToolUse`'s row for. No row is reused at all —
+//     each event below goes to a dedicated SessionDetector entry point, so
+//     session.hookSignalEffects (a flat map with no adapter dimension) is
+//     never consulted on this path.
+//
+//   - **The pending request is held in process memory only.** The CLI prompt
+//     blocks inside `prompt_dangerous_approval`; the gateway path parks an
+//     `_ApprovalEntry` in a module-level `_gateway_queues` map keyed by a
+//     contextvar. `state.db` has `sessions`, `messages`,
+//     `session_model_usage`, `state_meta`, `gateway_routing`,
+//     `compression_locks` and `async_delegations` — and no approval table.
+//     Nothing about "the user is being asked right now" is ever written, so
+//     the ProcessOwnedStore this adapter reads cannot express it and never
+//     could. Before this channel hermes had no `waiting` state at all.
+//
+//   - `post_approval_response` fires for EVERY outcome — `once`, `session`,
+//     `always`, `deny`, `timeout`, `smart_approve`, `smart_deny` — so the
+//     release really does arrive on the deny path, which is what puts hermes
+//     out of copilot's position (copilot emits nothing on a denial, so a hold
+//     with no release would pin the session `waiting`).
+//
+//   - `on_session_end` fires at the end of every `run_conversation` call
+//     (agent/turn_finalizer.py), which is once per TURN despite the name, and
+//     its extras carry `completed` and `interrupted`. This receiver releases
+//     the permission hold on it as well as reporting turn end — the same
+//     belt-and-braces gemini-cli's AfterAgent and opencode's session.idle use,
+//     closing the one case no response covers: the process torn down with a
+//     prompt still open.
+//
+// # Where the session id comes from, and why it is two fields
+//
+// hermes' shell-hook envelope has a top-level `session_id`, and
+// `_serialize_payload` fills it from the firing site's `session_id` kwarg. The
+// approval hooks do not pass one — they pass `session_key`, which lands in
+// `extra`. So `on_session_end` arrives with a top-level id and the two
+// approval events arrive with an empty one and the id in `extra.session_key`.
+// For the CLI that key IS the store's session id (`cli.py` binds
+// `set_current_session_key(self.session_id or "default")` before every turn),
+// which is what makes the correlation work at all — but it is a DIFFERENT
+// FIELD, and a receiver reading only the documented top-level one would
+// silently never see an approval.
+//
+// Both spellings are run through sessionIDShape before anything downstream is
+// touched. hermes mints `YYYYMMDD_HHMMSS_<6 hex>` (cli.py, agent_init.py,
+// gateway/slash_commands.py all use the same expression, and the recorded
+// fixtures agree), so a gateway platform's routing key, the literal "default"
+// the contextvar falls back to, and anything else a caller might post at a
+// local unauthenticated endpoint are dropped rather than turned into a phantom
+// session.
+//
+// # Why the payload carries no path (contracttesting.PathDaemonDerived)
+//
+// hermes writes no transcript files — one shared state.db — so there is no
+// per-session file for a caller to name. The "transcript path" every
+// downstream consumer keys a hermes session on is a string the DAEMON
+// composes, `<storePath>?session=<id>`, and transcriptPathFor is the one
+// function both this receiver and the watcher use so the two keys cannot
+// drift into two sessions.
+//
+// The receiver therefore reads its body through hookjson.DecodeSealed. That is
+// not a relaxation of the #1361 guard, it is the guard's premise being absent:
+// there is no caller-supplied path on this dispatch path for a traversal, a
+// symlink or an escape to be expressed in. The obligation that replaces
+// "confine what the caller named" is "prove nothing the caller names travels",
+// graded from outside by AssertHookPathConfined's PathDaemonDerived route,
+// whose obligations contradict the from-body route's directly — so declaring
+// the wrong one fails rather than passing quietly. See hookpath_test.go.
+package hermes
+
+import (
+	"net/http"
+	"regexp"
+
+	"irrlicht/core/adapters/inbound/agents/hookjson"
+	"irrlicht/core/domain/agent"
+	"irrlicht/core/ports/outbound"
+)
+
+// PermissionKeyHooks gates installing and receiving hermes lifecycle events
+// (issue #570). Aliased to the shared domain constant rather than restated.
+const PermissionKeyHooks = agent.HooksPermissionKey
+
+// logComponentHookReceiver is the Logger component tag for every log line this
+// receiver emits.
+const logComponentHookReceiver = "hermes-hook-receiver"
+
+// sessionIDShape is the id hermes mints for a session:
+// `<YYYYMMDD>_<HHMMSS>_<6 lowercase hex>`. Every producer in the package
+// builds it from the same expression —
+// `f"{self.session_start.strftime('%Y%m%d_%H%M%S')}_{uuid.uuid4().hex[:6]}"` —
+// and every id in this adapter's recorded fixtures matches.
+//
+// It is checked for the reason opencode checks its `ses` prefix: the endpoint
+// is local and unauthenticated, and an id this adapter could never have issued
+// must be dropped rather than turned into a session that does not exist. Here
+// it does a second job the prefix check does not — the approval events'
+// session key falls back to the literal "default" when a turn runs without one
+// (`set_current_session_key(self.session_id or "default")`), and gateway
+// surfaces put a platform routing key in the same field.
+var sessionIDShape = regexp.MustCompile(`^[0-9]{8}_[0-9]{6}_[0-9a-f]{6}$`)
+
+// hermesHookPayload is the JSON body hermes pipes to a shell hook's stdin,
+// forwarded verbatim by `irrlichd hook-post hermes`.
+//
+// The shape is agent/shell_hooks._serialize_payload's, captured live from
+// `hermes hooks test`:
+//
+//	{"hook_event_name": "...", "tool_name": null, "tool_input": null,
+//	 "session_id": "...", "cwd": "...", "extra": {...}}
+//
+// Only the three fields this receiver acts on are modelled. `cwd` is
+// deliberately NOT one of them: it is the hermes process's own working
+// directory at fire time and is the one thing the store genuinely cannot
+// supply for a `source='cli'` session — but adopting it here would mean a
+// caller-supplied path reaching project binding, which is precisely what the
+// PathDaemonDerived declaration below says does not happen. Using it is a
+// separate change with a confinement obligation of its own.
+type hermesHookPayload struct {
+	HookEventName string `json:"hook_event_name"`
+	SessionID     string `json:"session_id"`
+	Extra         struct {
+		// SessionKey is where the approval hooks put the session id; see this
+		// file's header.
+		SessionKey string `json:"session_key"`
+	} `json:"extra"`
+}
+
+// sessionID returns the store session id this payload refers to, or "" when
+// neither field carries one hermes could have minted.
+func (p hermesHookPayload) sessionID() string {
+	for _, candidate := range []string{p.SessionID, p.Extra.SessionKey} {
+		if sessionIDShape.MatchString(candidate) {
+			return candidate
+		}
+	}
+	return ""
+}
+
+// HookTarget is the interface the handler calls into. Satisfied by
+// *services.SessionDetector without importing the services package — the same
+// agent-agnostic surface every other receiver uses, narrowed to the three
+// methods this adapter's installed events need.
+type HookTarget interface {
+	HandlePermissionPromptHook(sessionID, transcriptPath, hookName string)
+	ReleasePermissionPromptHold(sessionID string)
+	HandleStopHook(sessionID, transcriptPath, lastAssistantText string, waitingCue bool)
+}
+
+// ConsentGranter is the shared consent check every JSON-hook receiver gates on
+// (issue #570) — an alias, not a copy, so the receivers cannot drift.
+type ConsentGranter = hookjson.ConsentGranter
+
+// NewHookHandler returns an http.Handler that receives hermes lifecycle events
+// and dispatches them to the target.
+//
+// gate is the consent check; while the "hooks" permission is not granted the
+// payload is dropped with 200, so an install left behind by a pre-consent
+// daemon stays quiet. A nil gate means no gating — used by tests.
+//
+// The returned hookjson.HookHandler carries a NIL Confiner, and that is the
+// declaration rather than an omission: this receiver has no caller-supplied
+// path to confine, and a nil confiner is what makes hookjson.DecodeConfined
+// fail CLOSED if a later edit switched this receiver back to the confining
+// decode without giving the adapter roots.
+func NewHookHandler(target HookTarget, gate ConsentGranter, log outbound.Logger) hookjson.HookHandler {
+	return hookjson.NewHandler(nil,
+		hookjson.RequireConsent(gate, AdapterName, PermissionKeyHooks, PermissionKeyStore),
+		func(consent hookjson.Consent, _ *hookjson.PathConfiner, w http.ResponseWriter, r *http.Request) {
+			serveHookRequest(target, consent, log, w, r)
+		})
+}
+
+// serveHookRequest is NewHookHandler's request logic. The step order matches
+// every sibling receiver's exactly, and each step is load-bearing — see the
+// contract assertions in hook*_test.go.
+func serveHookRequest(target HookTarget, consent hookjson.Consent, log outbound.Logger, w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	// Both keys come off the receiver's OWN hookjson.Consent (issue #1488), so
+	// the set this sequence is written for is the set the handler publishes and
+	// the contract derives.
+	if !consent.Granted(PermissionKeyHooks) {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
+	// The channel delivered (issue #1368). Counted against the "hooks" consent
+	// only, ahead of the store check below.
+	hookjson.ObserveHookReceipt(AdapterName)
+
+	// Dispatching makes the detector read the session store, so it is gated
+	// behind "store" — this adapter's read permission — not merely the "hooks"
+	// write consent. The check comes BEFORE the decode, so a denied session
+	// still yields a quiet 200 and the body is never read.
+	if !consent.Granted(PermissionKeyStore) {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
+	var payload hermesHookPayload
+	if !hookjson.DecodeSealed(w, r, log, logComponentHookReceiver, consent, &payload) {
+		return
+	}
+
+	sessionID := payload.sessionID()
+	if sessionID == "" {
+		// Not an id hermes could have minted — a gateway routing key, the
+		// "default" fallback, or a caller inventing one. Dropped rather than
+		// turned into a phantom session; the store watcher covers the state
+		// regardless.
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
+	// Composed by the daemon from its own store resolver, never from the body.
+	transcriptPath := transcriptPathFor(sessionID)
+
+	switch payload.HookEventName {
+	case HookEventPreApprovalRequest:
+		log.LogInfo(logComponentHookReceiver, sessionID, "received pre_approval_request")
+		target.HandlePermissionPromptHook(sessionID, transcriptPath, HookEventPreApprovalRequest)
+	case HookEventPostApprovalResponse:
+		log.LogInfo(logComponentHookReceiver, sessionID, "received post_approval_response")
+		target.ReleasePermissionPromptHold(sessionID)
+	case HookEventOnSessionEnd:
+		log.LogInfo(logComponentHookReceiver, sessionID, "received on_session_end")
+		// Released before the turn-end report, and unconditionally: a release
+		// on an unheld signal is a no-op, and this is the only thing that
+		// closes a prompt torn down without a response (an interrupted turn, a
+		// killed process).
+		target.ReleasePermissionPromptHold(sessionID)
+		// Payload-free, exactly as opencode's, pi's and vibe's single events
+		// are: HandleStopHook asserts SignalTurnDone unconditionally and only
+		// CONDITIONALLY overlays the text and cue, so the authoritative "the
+		// turn truly ended" claim is real without them, and it can never clear
+		// or mask a cue found elsewhere. hermes' envelope carries no message
+		// content to forward.
+		target.HandleStopHook(sessionID, transcriptPath, "", false)
+	default:
+		// Unrecognized event — accept but ignore, counted per name and reported
+		// once, in the one place that behaviour is decided for every receiver
+		// (issue #1364). This is where a hermes event rename, or an event a
+		// future config forwards that this daemon does not know, becomes
+		// visible instead of silent.
+		hookjson.IgnoreUnknownEvent(log, logComponentHookReceiver, AdapterName, sessionID, payload.HookEventName)
+	}
+	w.WriteHeader(http.StatusOK)
+}

--- a/core/adapters/inbound/agents/hermes/hooks_test.go
+++ b/core/adapters/inbound/agents/hermes/hooks_test.go
@@ -1,0 +1,527 @@
+package hermes
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"sync"
+	"testing"
+
+	"irrlicht/core/internal/contracttesting"
+)
+
+// --- test doubles, shared by this file and the contract wirings ---
+
+type stopCall struct {
+	sessionID, transcriptPath, lastAssistantText string
+	waitingCue                                   bool
+}
+
+type promptCall struct {
+	sessionID, transcriptPath, hookName string
+}
+
+type mockTarget struct {
+	mu        sync.Mutex
+	stopCalls []stopCall
+	prompts   []promptCall
+	releases  []string
+	// lastPath is the most recent transcript path handed to ANY method that
+	// takes one — which is what the #1389 obligation reads. Kept as one field
+	// rather than reconstructed from the three slices so a future fourth
+	// dispatch cannot be forgotten here while the contract keeps passing.
+	lastPath string
+}
+
+func (m *mockTarget) HandleStopHook(sessionID, transcriptPath, lastAssistantText string, waitingCue bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.stopCalls = append(m.stopCalls, stopCall{sessionID, transcriptPath, lastAssistantText, waitingCue})
+	m.lastPath = transcriptPath
+}
+
+func (m *mockTarget) HandlePermissionPromptHook(sessionID, transcriptPath, hookName string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.prompts = append(m.prompts, promptCall{sessionID, transcriptPath, hookName})
+	m.lastPath = transcriptPath
+}
+
+func (m *mockTarget) ReleasePermissionPromptHold(sessionID string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.releases = append(m.releases, sessionID)
+}
+
+func (m *mockTarget) totalCalls() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return len(m.stopCalls) + len(m.prompts) + len(m.releases)
+}
+
+func (m *mockTarget) stops() []stopCall {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]stopCall(nil), m.stopCalls...)
+}
+
+func (m *mockTarget) promptCalls() []promptCall {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]promptCall(nil), m.prompts...)
+}
+
+func (m *mockTarget) releaseCalls() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]string(nil), m.releases...)
+}
+
+func (m *mockTarget) observedPath() string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.lastPath
+}
+
+// keyedGate pins a fixed permission combination for a one-off test. For a
+// MUTABLE keyed gate driven through states by the shared contract, use
+// contracttesting.ConsentGate instead.
+type keyedGate map[string]bool
+
+func (g keyedGate) Granted(_, key string) bool { return g[key] }
+
+type mockLogger struct{}
+
+func (mockLogger) LogInfo(string, string, string)                       {}
+func (mockLogger) LogError(string, string, string)                      {}
+func (mockLogger) LogProcessingTime(string, string, int64, int, string) {}
+func (mockLogger) Close() error                                         { return nil }
+
+// --- helpers ---
+
+// contractSessionID is the hermes session id every contract wiring in this
+// package posts. Its shape is hermes' own —
+// `<YYYYMMDD>_<HHMMSS>_<6 lowercase hex>` — and it is copied from a real
+// recorded fixture (replaydata/agents/hermes), because the receiver drops
+// anything that does not match.
+const contractSessionID = "20260802_233614_c97a8d"
+
+// hermesHome relocates $HERMES_HOME to a scratch directory and returns it.
+//
+// Every test in this package must isolate it: this package's installer WRITES
+// two files under that directory, and the user's real ~/.hermes holds their
+// live session store and their config. Setting HERMES_HOME rather than HOME is
+// what homeDir() reads first, so it wins over anything leaking in from the
+// developer's environment.
+func hermesHome(t *testing.T) string {
+	t.Helper()
+	root := filepath.Join(t.TempDir(), ".hermes")
+	if err := os.MkdirAll(root, 0o700); err != nil {
+		t.Fatalf("create hermes home: %v", err)
+	}
+	t.Setenv(homeEnvVar, root)
+	return root
+}
+
+// writeContractTranscript is the shape the receiving-side contracts want: a
+// file inside dir that stands in for "the thing a caller might name".
+//
+// For this adapter it is a DECOY and nothing more. hermes writes no transcript
+// files at all — the "transcript" IS the shared store — so no contract here
+// resolves a session id from a path, and this file exists only so the shared
+// wirings that ask for one get a well-formed path to hand over. Which
+// obligations that weakens is stated where each one is wired.
+func writeContractTranscript(t *testing.T, dir string) string {
+	t.Helper()
+	path := filepath.Join(dir, "decoy.jsonl")
+	if err := os.WriteFile(path, []byte(`{"role":"assistant"}`+"\n"), 0o600); err != nil {
+		t.Fatalf("write decoy: %v", err)
+	}
+	return path
+}
+
+// contractPayload renders the body hermes pipes to a shell hook for one event,
+// in the shape agent/shell_hooks._serialize_payload emits — captured live from
+// `hermes hooks test` during this issue's audit.
+//
+// The session id goes in the field hermes ACTUALLY fills for that event: the
+// top-level `session_id` for on_session_end, and `extra.session_key` for the
+// two approval events, which pass a `session_key` kwarg and no `session_id` at
+// all. A single-field payload builder would test a wire shape hermes never
+// sends, and would leave the approval path — this adapter's whole reason for a
+// hook channel — graded by nothing.
+func contractPayload(event string) string {
+	var p hermesHookPayload
+	p.HookEventName = event
+	if event == HookEventOnSessionEnd {
+		p.SessionID = contractSessionID
+	} else {
+		p.Extra.SessionKey = contractSessionID
+	}
+	body, err := json.Marshal(p)
+	if err != nil {
+		panic(err)
+	}
+	return string(body)
+}
+
+// foreignPathPayload renders the body a HOSTILE caller would write: the real
+// payload plus a transcript_path key this adapter's own payload type does not
+// have. It is what AssertHookPathConfined's PathDaemonDerived route posts to
+// prove nothing the caller names reaches the dispatch.
+//
+// Hand-built rather than marshalled from a struct precisely because there is no
+// struct with that field — inventing one for the test would be inventing the
+// very surface the route asserts does not exist.
+func foreignPathPayload(path string) string {
+	encoded, err := json.Marshal(path)
+	if err != nil {
+		panic(err)
+	}
+	return `{"hook_event_name":"` + HookEventOnSessionEnd +
+		`","session_id":"` + contractSessionID +
+		`","cwd":"/tmp","transcript_path":` + string(encoded) + `}`
+}
+
+// post drives the handler with a raw JSON body and returns the response.
+func post(t *testing.T, h http.Handler, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, HookEndpointPath, strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	return rec
+}
+
+// newReceiver builds a fully-granted receiver plus the target it dispatches
+// into.
+func newReceiver(t *testing.T) (http.Handler, *mockTarget) {
+	t.Helper()
+	target := &mockTarget{}
+	gate := keyedGate{PermissionKeyHooks: true, PermissionKeyStore: true}
+	return NewHookHandler(target, gate, mockLogger{}), target
+}
+
+// --- the safety guard ---
+
+// TestInstalledEventsAreObserverOnly is the mechanism behind hookinstaller.go's
+// "we do not install a control-bearing event" claim, and it is the hermes
+// spelling of #1719's opencode guard.
+//
+// hermes reads a shell hook's STDOUT as a decision for exactly three events
+// (agent/shell_hooks._parse_response): pre_tool_call takes
+// {"action":"block"} / {"decision":"block"} and vetoes the tool call,
+// pre_verify takes {"action":"continue"} and keeps the turn running, and every
+// other event falls through to a {"context": "..."} branch which pre_llm_call
+// prepends to the user's message. A monitoring channel must not be able to do
+// any of those, and "the author remembered" is not a mechanism.
+//
+// Both directions are asserted. The intersection must be empty — that is the
+// rule — and the denylist must be non-empty and must name events hermes
+// actually has, or an emptied list would satisfy the rule while checking
+// nothing. The membership half reads VALID_HOOKS through the same list #1364's
+// contract already exercises: these three names are hermes', spelled here
+// once.
+func TestInstalledEventsAreObserverOnly(t *testing.T) {
+	if len(controlBearingHookEvents) == 0 {
+		t.Fatal("controlBearingHookEvents is empty, so the intersection below is vacuously " +
+			"empty and this guard grades nothing")
+	}
+	for _, e := range installedHookEvents {
+		if slices.Contains(controlBearingHookEvents, e) {
+			t.Errorf("installedHookEvents contains %q, whose stdout hermes reads as a decision "+
+				"(agent/shell_hooks._parse_response). Installing it would let a monitoring hook "+
+				"veto a tool call, keep a turn running, or inject text into the user's message.", e)
+		}
+	}
+	// Vacuity guard on the denylist itself: a name hermes does not have would
+	// make the rule above true for a reason unrelated to safety.
+	for _, e := range controlBearingHookEvents {
+		if !strings.HasPrefix(e, "pre_") {
+			t.Errorf("controlBearingHookEvents names %q; every event hermes reads a decision "+
+				"from is a pre_* event, so this is probably not one of them", e)
+		}
+	}
+}
+
+// TestInstalledCommandSuppressesStdout is the defence-in-depth half of the
+// guard above, and it is not hypothetical: hookbeacon.LegacyGuardToken puts
+// `--version` FIRST in the command line so an irrlichd predating #1417 exits 0
+// instead of starting a daemon — and such a binary prints a version banner on
+// STDOUT, which is the channel hermes parses.
+func TestInstalledCommandSuppressesStdout(t *testing.T) {
+	cmd := hookCommand("'/opt/irrlichd' --version hook-post hermes >/dev/null || true")
+	if !strings.HasPrefix(cmd, shellInterpreter+" -c ") {
+		t.Fatalf("command = %q, want it wrapped in %s -c so the redirect below is honoured "+
+			"— hermes runs the command with shell=False, so a bare argv has no redirection at all",
+			cmd, shellInterpreter)
+	}
+	if !strings.Contains(cmd, ">/dev/null") {
+		t.Errorf("command = %q, want it to redirect stdout away from hermes' response parser", cmd)
+	}
+	if !strings.Contains(cmd, "|| true") {
+		t.Errorf("command = %q, want a fail-open suffix so a deleted binary is not a per-turn "+
+			"warning in the user's agent.log", cmd)
+	}
+}
+
+// --- behaviour ---
+
+// TestPreApprovalRequestHook_AssertsTheBlockedOnUserSignal pins the event that
+// is this adapter's whole reason for having a hook channel: hermes holds a
+// pending approval in process memory (a module-level queue plus a contextvar)
+// and state.db has no approval table at all, so `waiting` is unreachable from
+// the store the watcher reads at any polling interval.
+func TestPreApprovalRequestHook_AssertsTheBlockedOnUserSignal(t *testing.T) {
+	hermesHome(t)
+	h, target := newReceiver(t)
+
+	rec := post(t, h, contractPayload(HookEventPreApprovalRequest))
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200", rec.Code)
+	}
+	prompts := target.promptCalls()
+	if len(prompts) != 1 {
+		t.Fatalf("HandlePermissionPromptHook called %d times, want 1", len(prompts))
+	}
+	if prompts[0].sessionID != contractSessionID {
+		t.Errorf("sessionID = %q, want %q", prompts[0].sessionID, contractSessionID)
+	}
+	if want := transcriptPathFor(contractSessionID); prompts[0].transcriptPath != want {
+		t.Errorf("transcriptPath = %q, want the daemon's own composed path %q", prompts[0].transcriptPath, want)
+	}
+	if prompts[0].hookName != HookEventPreApprovalRequest {
+		t.Errorf("hookName = %q, want %q", prompts[0].hookName, HookEventPreApprovalRequest)
+	}
+	if n := len(target.stops()); n != 0 {
+		t.Errorf("HandleStopHook called %d times for pre_approval_request, want 0", n)
+	}
+}
+
+// TestPostApprovalResponseHook_ReleasesTheHold pins the release half. It is
+// load-bearing because hermes fires it for EVERY outcome including `deny` and
+// `timeout` — which is what keeps this adapter out of copilot's position, where
+// a denial emits nothing and the hold would sit until the 12-hour ceiling.
+func TestPostApprovalResponseHook_ReleasesTheHold(t *testing.T) {
+	hermesHome(t)
+	h, target := newReceiver(t)
+
+	rec := post(t, h, contractPayload(HookEventPostApprovalResponse))
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200", rec.Code)
+	}
+	if got := target.releaseCalls(); len(got) != 1 || got[0] != contractSessionID {
+		t.Fatalf("ReleasePermissionPromptHold calls = %v, want exactly [%q]", got, contractSessionID)
+	}
+	if n := len(target.stops()); n != 0 {
+		t.Errorf("HandleStopHook called %d times for post_approval_response, want 0 — an answer is not a turn end", n)
+	}
+}
+
+// TestOnSessionEndHook_ReleasesAndReportsTurnEnd pins BOTH dispatches
+// on_session_end makes, and that the release comes with it.
+//
+// The release is not redundant with post_approval_response. hermes' approval
+// wait can be torn down without a response — an interrupted turn, a killed
+// process — and on_session_end is the only event that still arrives, the same
+// gap gemini-cli's AfterAgent and opencode's session.idle close.
+func TestOnSessionEndHook_ReleasesAndReportsTurnEnd(t *testing.T) {
+	hermesHome(t)
+	h, target := newReceiver(t)
+
+	rec := post(t, h, contractPayload(HookEventOnSessionEnd))
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200", rec.Code)
+	}
+	if got := target.releaseCalls(); len(got) != 1 || got[0] != contractSessionID {
+		t.Errorf("ReleasePermissionPromptHold calls = %v, want exactly [%q] — a turn torn down with an approval pending gets no response, so this is the only release it gets", got, contractSessionID)
+	}
+	stops := target.stops()
+	if len(stops) != 1 {
+		t.Fatalf("HandleStopHook called %d times, want 1", len(stops))
+	}
+	if stops[0].sessionID != contractSessionID {
+		t.Errorf("sessionID = %q, want %q", stops[0].sessionID, contractSessionID)
+	}
+	if want := transcriptPathFor(contractSessionID); stops[0].transcriptPath != want {
+		t.Errorf("transcriptPath = %q, want the daemon's own composed path %q", stops[0].transcriptPath, want)
+	}
+	if stops[0].lastAssistantText != "" {
+		t.Errorf("lastAssistantText = %q, want empty — hermes' envelope carries no message text", stops[0].lastAssistantText)
+	}
+	if stops[0].waitingCue {
+		t.Error("waitingCue = true, want false — nothing in the payload can assert one")
+	}
+}
+
+// TestApprovalHooks_ReadTheSessionKeyFromExtra is the defect test for the one
+// thing about this adapter's wire shape that is NOT the documented one.
+//
+// hermes' envelope has a top-level `session_id`, and its own docs describe it
+// as the session identifier. The approval fire sites in tools/approval.py pass
+// `session_key=` and no `session_id`, and _serialize_payload only fills the
+// top-level field from a `session_id` kwarg — so both approval events arrive
+// with `"session_id": ""` and the id inside `extra`. A receiver reading only
+// the documented field would answer 200 to every approval and dispatch none of
+// them, which is indistinguishable from an agent that never prompts.
+func TestApprovalHooks_ReadTheSessionKeyFromExtra(t *testing.T) {
+	hermesHome(t)
+	for _, event := range []string{HookEventPreApprovalRequest, HookEventPostApprovalResponse} {
+		t.Run(event, func(t *testing.T) {
+			h, target := newReceiver(t)
+			body := `{"hook_event_name":"` + event +
+				`","session_id":"","cwd":"/tmp","extra":{"session_key":"` + contractSessionID +
+				`","surface":"cli"}}`
+
+			if rec := post(t, h, body); rec.Code != http.StatusOK {
+				t.Errorf("status = %d, want 200", rec.Code)
+			}
+			if n := target.totalCalls(); n != 1 {
+				t.Fatalf("dispatched %d times, want 1 — the id is in extra.session_key for this event, not in session_id", n)
+			}
+		})
+	}
+}
+
+// TestHookReceiver_DispatchedPathMatchesTheWatchers is the property that makes
+// a hook-delivered observation land on the SAME session the store watcher is
+// tracking: both key on transcriptPathIn, so a session cannot end up as two.
+//
+// It is a LOCK on a shared derivation rather than a new claim, which is why it
+// asserts against a watcher built through the production constructor rather
+// than against a second copy of the format string.
+func TestHookReceiver_DispatchedPathMatchesTheWatchers(t *testing.T) {
+	hermesHome(t)
+	h, target := newReceiver(t)
+
+	post(t, h, contractPayload(HookEventOnSessionEnd))
+
+	want := transcriptPathIn(New(0).dbPath, contractSessionID)
+	if got := target.observedPath(); got != want {
+		t.Errorf("receiver dispatched %q but the watcher emits %q for the same session — two spellings of one session are two sessions", got, want)
+	}
+}
+
+// TestHookReceiver_ForeignSessionIDIsQuiet is a LOCK: an id hermes could not
+// have minted is dropped rather than turned into a phantom session. The
+// endpoint is local and unauthenticated, so "our own entry wrote it" buys
+// nothing.
+//
+// The three rows are not decoration. "default" is the literal hermes' own
+// contextvar falls back to when a turn runs without a session
+// (`set_current_session_key(self.session_id or "default")`), and a gateway
+// routing key is what the same field holds for a WhatsApp or Slack
+// conversation — a surface this adapter filters out of the store entirely, so
+// admitting one through the hook path would surface a chat as a coding
+// session.
+func TestHookReceiver_ForeignSessionIDIsQuiet(t *testing.T) {
+	for _, id := range []string{"not-a-session", "default", "whatsapp:4915112345678"} {
+		t.Run(id, func(t *testing.T) {
+			hermesHome(t)
+			h, target := newReceiver(t)
+			encoded, err := json.Marshal(id)
+			if err != nil {
+				t.Fatal(err)
+			}
+			rec := post(t, h, `{"hook_event_name":"`+HookEventOnSessionEnd+
+				`","session_id":`+string(encoded)+`,"extra":{"session_key":`+string(encoded)+`}}`)
+
+			if rec.Code != http.StatusOK {
+				t.Errorf("status = %d, want 200", rec.Code)
+			}
+			if n := target.totalCalls(); n != 0 {
+				t.Errorf("dispatched %d times for an id hermes could not have minted, want 0", n)
+			}
+		})
+	}
+}
+
+// TestHookReceiver_PermissionGateContract runs the shared #797 contract once
+// per permission this receiver must honour, derived from the receiver's own
+// declaration (issue #1488).
+func TestHookReceiver_PermissionGateContract(t *testing.T) {
+	contracttesting.AssertHookReceiverPermissionGated(t, contracttesting.HookReceiverGate{
+		Build: func(t *testing.T, gate *contracttesting.ConsentGate) contracttesting.GatedHookReceiver {
+			hermesHome(t)
+			body := contractPayload(HookEventOnSessionEnd)
+			target := &mockTarget{}
+			h := NewHookHandler(target, gate, mockLogger{})
+
+			before := 0
+			return contracttesting.GatedHookReceiver{
+				Handler: h,
+				Exercise: func() {
+					before = target.totalCalls()
+					post(t, h, body)
+				},
+				Observe: func() bool { return target.totalCalls() > before },
+			}
+		},
+	})
+}
+
+// TestHookReceiver_DeclaresItsPermissions is the LOCK on the key list the
+// wiring above used to spell out (#1450).
+func TestHookReceiver_DeclaresItsPermissions(t *testing.T) {
+	contracttesting.AssertDeclaredPermissions(t,
+		NewHookHandler(&mockTarget{}, nil, mockLogger{}),
+		PermissionKeyHooks, PermissionKeyStore)
+}
+
+// TestHookReceiver_NonPostRejected is a LOCK on the shared receiver shape.
+func TestHookReceiver_NonPostRejected(t *testing.T) {
+	hermesHome(t)
+	h, _ := newReceiver(t)
+	req := httptest.NewRequest(http.MethodGet, HookEndpointPath, nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Errorf("GET status = %d, want 405", rec.Code)
+	}
+}
+
+// TestHookReceiver_MalformedJSONIs400 is a LOCK: a body that will not decode is
+// the one case that answers non-2xx.
+func TestHookReceiver_MalformedJSONIs400(t *testing.T) {
+	hermesHome(t)
+	h, _ := newReceiver(t)
+	rec := post(t, h, "{not json")
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", rec.Code)
+	}
+}
+
+// TestHookReceiver_DeniedStoreConsentDropsQuietly pins that a store-denied
+// session must not dispatch even though the hooks consent is granted, and must
+// not log an error while doing it (the receiver's own gate answers quietly;
+// only the shared backstop logs).
+//
+// Since #1488's chokepoint the SILENCE is the surviving discriminator —
+// deleting the gate below leaves every dispatch-shaped assertion green, because
+// DecodeSealed re-checks the whole declared set and drops the payload itself.
+// What it does NOT reproduce is the quiet: reaching the backstop logs an error,
+// and an ordinary denied session must not collect one per event.
+func TestHookReceiver_DeniedStoreConsentDropsQuietly(t *testing.T) {
+	hermesHome(t)
+	target := &mockTarget{}
+	log := &contracttesting.RecordingLogger{}
+	h := NewHookHandler(target, keyedGate{PermissionKeyHooks: true}, log)
+
+	rec := post(t, h, contractPayload(HookEventOnSessionEnd))
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200", rec.Code)
+	}
+	if n := target.totalCalls(); n != 0 {
+		t.Fatalf("dispatched %d times while store consent was denied, want 0", n)
+	}
+	if len(log.Errors()) != 0 {
+		t.Errorf("a store-denied hook logged %d error(s): %v", len(log.Errors()), log.Errors())
+	}
+}

--- a/core/adapters/inbound/agents/hermes/hookunknown_test.go
+++ b/core/adapters/inbound/agents/hermes/hookunknown_test.go
@@ -1,0 +1,47 @@
+// hookunknown_test.go wires this adapter's hook receiver into the shared issue
+// #1364 contract: an event name the receiver does not recognize is counted per
+// (adapter, name), reported once per distinct name, and still answered 2xx.
+//
+// It is not a hypothetical for this adapter. hermes' VALID_HOOKS carries 25
+// event names and this adapter subscribes to three of them, so a user (or a
+// future irrlichd) adding a fourth to the same `hooks:` block delivers a name
+// this switch has never heard of — the entries in config.yaml survive a daemon
+// downgrade the same way pi's and opencode's installed files do. And hermes
+// warns-and-skips an unknown event name in its own config rather than failing,
+// so a rename upstream is a live-traffic condition rather than a crash.
+package hermes
+
+import (
+	"testing"
+
+	"irrlicht/core/internal/contracttesting"
+	"irrlicht/core/ports/outbound"
+)
+
+func TestUnknownHookEventObserved(t *testing.T) {
+	contracttesting.AssertUnknownHookEventObserved(t, contracttesting.UnknownEventReceiver{
+		Adapter:         AdapterName,
+		Root:            hermesHome,
+		WriteTranscript: writeContractTranscript,
+		New: func(t *testing.T, log outbound.Logger) contracttesting.UnknownEventReceiverUnderTest {
+			t.Helper()
+			target := &mockTarget{}
+			return contracttesting.UnknownEventReceiverUnderTest{
+				Handler:  NewHookHandler(target, nil, log),
+				Observed: func() bool { return target.totalCalls() > 0 },
+			}
+		},
+		PayloadFor:   func(_, event string) string { return unknownEventPayload(event) },
+		KnownEvent:   HookEventOnSessionEnd,
+		EndpointPath: HookEndpointPath,
+	})
+}
+
+// unknownEventPayload renders a body for an arbitrary event name. It always
+// puts the id in the top-level field, because the contract drives it with
+// names that are not hermes events at all and so have no "which field does
+// hermes fill" answer of their own — contractPayload's per-event split would
+// silently send those through the approval spelling.
+func unknownEventPayload(event string) string {
+	return `{"hook_event_name":"` + event + `","session_id":"` + contractSessionID + `","extra":{}}`
+}

--- a/core/adapters/inbound/agents/hermes/hookversion_test.go
+++ b/core/adapters/inbound/agents/hermes/hookversion_test.go
@@ -1,0 +1,70 @@
+// hookversion_test.go wires the hermes hooks permission into the shared issue
+// #1365 contract.
+//
+// Like geminicli, vibe, pi and opencode, this adapter declares no Observed
+// version source: hermes' store carries no CLI version column this adapter's
+// reader touches, so the gate falls straight through to Probe
+// (`hermes --version`), which cliversion runs itself.
+//
+// What is deliberately NOT here — BelowFloorSaysWhy, AtOrAboveFloorInstalls and
+// UnknownVersionFailsOpen — is issue #1762: six adapters carry hand-written
+// copies of three obligations the shared contract strictly dominates. Adding a
+// seventh copy would be adding to the thing #1762 exists to remove.
+package hermes
+
+import (
+	"testing"
+
+	"irrlicht/core/domain/agent"
+	"irrlicht/core/internal/contracttesting"
+)
+
+func TestHooksPermission_DeclaresVersionGate(t *testing.T) {
+	contracttesting.AssertHookVersionGate(t, contracttesting.HookVersionGate{
+		Agent:         Agent(),
+		PermissionKey: PermissionKeyHooks,
+		Installed:     installedHookEvents,
+		Since:         hookEventSince,
+	})
+}
+
+// hooksVersionGate returns the declared gate, read off the real registration
+// the daemon consumes rather than a copy.
+func hooksVersionGate(t *testing.T) *agent.VersionGate {
+	t.Helper()
+	for _, p := range Agent().Permissions {
+		if p.Key == PermissionKeyHooks {
+			if p.Writes == nil || p.Writes.Version == nil {
+				t.Fatal("hooks permission declares no version gate")
+			}
+			return p.Writes.Version
+		}
+	}
+	t.Fatal("no hooks permission")
+	return nil
+}
+
+// TestHooksGate_ProbeIsHermesVersion pins the argv this adapter asks cliversion
+// to run. It is the one thing the shared contract does NOT cover:
+// assertVersionSourceDeclared only requires Observed or Probe to be non-empty,
+// never that the argv is the right one.
+//
+// `hermes --version` prints a banner line, not a bare number — measured live
+// during this issue's audit:
+//
+//	Hermes Agent v0.19.0 (2026.7.20) · upstream 6564f319 · local e289e561 …
+//
+// cliversion.Parse finds the 0.19.0 in it, which is why the probe is usable at
+// all and why the shape is recorded here rather than assumed.
+func TestHooksGate_ProbeIsHermesVersion(t *testing.T) {
+	gate := hooksVersionGate(t)
+	want := []string{"hermes", "--version"}
+	if len(gate.Probe) != len(want) {
+		t.Fatalf("Probe = %v, want %v", gate.Probe, want)
+	}
+	for i := range want {
+		if gate.Probe[i] != want[i] {
+			t.Fatalf("Probe = %v, want %v", gate.Probe, want)
+		}
+	}
+}

--- a/core/adapters/inbound/agents/hermes/watcher.go
+++ b/core/adapters/inbound/agents/hermes/watcher.go
@@ -372,7 +372,7 @@ func (w *Watcher) reconcile(db *sql.DB, r storeSessionRow, fallbackCWD string) {
 
 	base := agent.Event{
 		SessionID:       r.id,
-		TranscriptPath:  w.dbPath + sessionQueryParam + r.id,
+		TranscriptPath:  transcriptPathIn(w.dbPath, r.id),
 		CWD:             cwd,
 		ProjectDir:      filepath.Base(cwd),
 		ParentSessionID: r.parentID,

--- a/core/adapters/inbound/agents/hookyaml/hookyaml.go
+++ b/core/adapters/inbound/agents/hookyaml/hookyaml.go
@@ -797,64 +797,107 @@ func (w *topLevelWalk) refuse(i int, message string) error {
 	return &UnsafeConstructError{Path: w.cfg.Path, Line: i + 1, Message: message}
 }
 
-// readBlock walks the lines under the block key, recording its own keys and
-// this owner's region.
+// readBlock walks the lines under the block key, recording its own keys, this
+// owner's region, and the extent of every block-level entry (so a
+// sentinel-bearing one can be removed whole).
+//
+// Split the same way findBlockKey is: the region markers and the entries are
+// two independent readings of one line stream, and reading them interleaved is
+// what made the top-level walk hard to follow.
 func (d *document) readBlock(cfg Config, src []byte) error {
-	begin, end := BeginMarker(cfg.Owner), EndMarker(cfg.Owner)
-	regionStart, regionStartLine := -1, -1
-	// openKey/openEnd track the extent of the block-level entry currently
-	// being read, so a sentinel-bearing one can be removed whole.
-	openKey, openEnd := -1, -1
-	openName := ""
+	w := blockWalk{doc: d, cfg: cfg, src: src, regionStart: -1, regionStartLine: -1, openKey: -1}
 
 	for i := d.blockKeyLine + 1; i < len(d.lines); i++ {
 		l := d.lines[i]
 		if l.blank || l.comment {
-			if trimmed := strings.TrimSpace(l.text); trimmed == begin {
-				if regionStart >= 0 {
-					return &UnsafeConstructError{Path: cfg.Path, Line: i + 1,
-						Message: "a second irrlicht-managed BEGIN marker before the first was closed"}
-				}
-				regionStart, regionStartLine = l.start, i
-			} else if trimmed == end {
-				if regionStart < 0 {
-					return &UnsafeConstructError{Path: cfg.Path, Line: i + 1,
-						Message: "an irrlicht-managed END marker with no BEGIN before it"}
-				}
-				d.region = &byteRange{start: regionStart, end: l.end}
-				regionStart = -1
+			if err := w.marker(i, l); err != nil {
+				return err
 			}
 			continue
 		}
 		if l.indent == 0 {
 			break // the next top-level key ends the block
 		}
-		if regionStart >= 0 {
+		if w.regionStart >= 0 {
 			continue // inside our own region; not a user key
 		}
-		if d.blockContentIndent == 0 {
-			d.blockContentIndent = l.indent
-		}
-		if l.indent != d.blockContentIndent {
-			if openKey >= 0 {
-				openEnd = l.end // still part of the entry that key opened
-			}
-			continue // nested deeper than the block's own keys
-		}
-		d.closeEntry(cfg, src, openKey, openEnd, openName)
-		name, err := d.recordBlockKey(cfg, i, l)
-		if err != nil {
+		if err := w.contentLine(i, l); err != nil {
 			return err
 		}
-		openKey, openEnd, openName = l.start, l.end, name
 	}
-	d.closeEntry(cfg, src, openKey, openEnd, openName)
+	return w.finish()
+}
 
-	if regionStart >= 0 {
-		return &UnsafeConstructError{Path: cfg.Path, Line: regionStartLine + 1,
-			Message: "an irrlicht-managed BEGIN marker with no matching END — the region's extent is unknown, so rewriting it could delete a user's own hooks"}
+// blockWalk carries readBlock's cross-line state: the open region and the open
+// entry.
+type blockWalk struct {
+	doc *document
+	cfg Config
+	src []byte
+
+	regionStart, regionStartLine int
+	// openKey/openEnd/openName describe the block-level entry currently being
+	// read, from its key line to the last line indented under it.
+	openKey, openEnd int
+	openName         string
+}
+
+// marker handles a blank or comment line, opening and closing the region.
+func (w *blockWalk) marker(i int, l lineSpan) error {
+	switch strings.TrimSpace(l.text) {
+	case BeginMarker(w.cfg.Owner):
+		if w.regionStart >= 0 {
+			return w.refuse(i, "a second irrlicht-managed BEGIN marker before the first was closed")
+		}
+		w.regionStart, w.regionStartLine = l.start, i
+	case EndMarker(w.cfg.Owner):
+		if w.regionStart < 0 {
+			return w.refuse(i, "an irrlicht-managed END marker with no BEGIN before it")
+		}
+		w.doc.region = &byteRange{start: w.regionStart, end: l.end}
+		w.regionStart = -1
 	}
 	return nil
+}
+
+// contentLine handles a non-blank line inside the block and outside the
+// region: either one of the block's own keys, or a line nested under one.
+func (w *blockWalk) contentLine(i int, l lineSpan) error {
+	if w.doc.blockContentIndent == 0 {
+		w.doc.blockContentIndent = l.indent
+	}
+	if l.indent != w.doc.blockContentIndent {
+		if w.openKey >= 0 {
+			w.openEnd = l.end // still part of the entry that key opened
+		}
+		return nil
+	}
+	w.closeOpenEntry()
+	name, err := w.doc.recordBlockKey(w.cfg, i, l)
+	if err != nil {
+		return err
+	}
+	w.openKey, w.openEnd, w.openName = l.start, l.end, name
+	return nil
+}
+
+func (w *blockWalk) closeOpenEntry() {
+	w.doc.closeEntry(w.cfg, w.src, w.openKey, w.openEnd, w.openName)
+	w.openKey, w.openEnd, w.openName = -1, -1, ""
+}
+
+// finish closes the last entry and reports a region left open.
+func (w *blockWalk) finish() error {
+	w.closeOpenEntry()
+	if w.regionStart < 0 {
+		return nil
+	}
+	return w.refuse(w.regionStartLine,
+		"an irrlicht-managed BEGIN marker with no matching END — the region's extent is unknown, so rewriting it could delete a user's own hooks")
+}
+
+func (w *blockWalk) refuse(i int, message string) error {
+	return &UnsafeConstructError{Path: w.cfg.Path, Line: i + 1, Message: message}
 }
 
 // closeEntry finishes the block-level entry that started at start, recording

--- a/core/adapters/inbound/agents/hookyaml/hookyaml.go
+++ b/core/adapters/inbound/agents/hookyaml/hookyaml.go
@@ -1,0 +1,858 @@
+// Package hookyaml implements comment-preserving read-modify-write for ONE
+// narrow YAML edit: installing, upgrading and removing a single
+// marker-delimited region of hook entries nested under one top-level block
+// key. It is hookjson's and hooktoml's sibling for YAML (issue #1722), not a
+// general YAML merge engine.
+//
+// Hermes Agent's shell hooks are declared as a `hooks:` block in the user's
+// `~/.hermes/config.yaml` — the same file that carries their model, provider
+// credentials-by-reference, terminal sandbox policy and every other setting,
+// with the comments the shipped `cli-config.yaml.example` teaches them to
+// keep. core/go.mod carries no YAML dependency and none is added here: a
+// read-modify-marshal through a generic encoder would reformat that entire
+// document to install three lines, which is precisely the failure hookjson
+// was extracted to stop (`json.MarshalIndent` over a bare map sorting a
+// user's keys and HTML-escaping their `&&`).
+//
+// # The one invariant the scanner rests on
+//
+// Everything below follows from a single property of a LOADABLE YAML file
+// whose root is a block mapping:
+//
+//	a non-blank line starting at column 0 is a key, a comment, or a
+//	document marker — it can never be the continuation of a scalar.
+//
+// YAML requires the continuation lines of a multi-line flow scalar, and the
+// content lines of a block scalar, to be indented MORE than the node they
+// belong to. At the root that node sits at indent 0, so every continuation is
+// at indent >= 1. A `hooks:` at column 0 is therefore always the real key and
+// never text inside somebody's description string. The same argument one
+// level down is what lets the block's own event keys be found by indent.
+//
+// The scanner asserts that invariant rather than assuming it: a column-0 line
+// that is none of those three shapes means the file is not the document this
+// package models, and the whole document is REFUSED. Refusing is the only
+// safe fallback here, exactly as in hooktoml — there is no lossy-but-correct
+// encoder to fall back to, and an install that corrupts a user's config is
+// far worse than an install that does not happen. A refusal surfaces as
+// #1362's "granted but NOT applied, because …" naming the file and the line.
+//
+// # What is modelled and what is refused
+//
+// Modelled: a root block mapping; the target key absent, present-and-empty, or
+// present with a block mapping of event keys; our own region present, absent,
+// or stale; comments and blank lines anywhere.
+//
+// Refused, each with the line number: a tab in a line's indentation; a `---`
+// or `...` document marker (multi-document files); the target key appearing
+// twice at the root; the target key carrying an inline value of any kind (a
+// flow mapping `hooks: {}`, a flow sequence, a scalar, an anchor `&x`, an
+// alias `*x`, or a block-scalar indicator `|`/`>`); the target block being a
+// SEQUENCE rather than a mapping; and an anchor, alias or merge key (`<<:`)
+// among the block's own keys. Every one of those is a shape whose correct
+// edit is not obvious, and guessing at one is how a config gets corrupted.
+//
+// # Why a marker-delimited region rather than per-entry merging
+//
+// A region we own outright makes "is this ours" a substring test and makes
+// uninstall a byte-range deletion, which is what keeps the property test
+// tractable. The cost is that a user who already declares one of the SAME
+// event keys we install cannot be merged with — YAML mappings cannot carry a
+// duplicate key, and `yaml.safe_load` resolves a duplicate silently to the
+// last one, so writing ours beside theirs would DELETE their hook with no
+// error anywhere. That collision is detected and refused by name instead.
+//
+// The region has TWO placements, and the distinction is what makes uninstall
+// exact rather than approximately right:
+//
+//   - When the target key already exists, the region goes INSIDE it and the
+//     key line is the user's. Uninstall removes the region and leaves the key,
+//     even when the block is then empty — it was empty before too.
+//   - When the key does NOT exist, the region is written at the top level and
+//     the key line goes INSIDE it. Uninstall then removes the key along with
+//     everything else, because irrlicht is what put it there.
+//
+// The first draft had one placement and a "delete the key if the block is now
+// empty" rule, which deleted a `hooks:` a user had written themselves. The
+// property test in property_test.go found that on its second iteration, which
+// is the whole argument for having one.
+//
+// # The two normalizations an install can leave behind
+//
+// Both are semantically neutral to any YAML reader, both are permanent (an
+// uninstall does not undo them), and between them they are the ONLY changes
+// outside the region that any operation here makes. They are listed because
+// "install then uninstall returns the original bytes" is otherwise the claim,
+// and a claim with unstated exceptions is worse than a smaller one.
+//
+//  1. `<key>: {}` — the spelling an agent's own defaults may carry for
+//     "nothing configured" — cannot hold a nested mapping, so installing into
+//     it rewrites that line to `<key>:` and puts the region inside. The
+//     trailing comment rides along, including its column, and so does the
+//     line's own terminator — except at end-of-file with no terminator at
+//     all, where one is supplied, because the region goes immediately after.
+//  2. A file that does not end in a newline gains one, because the region is
+//     appended after it and the alternative is fusing the last key onto the
+//     BEGIN marker.
+package hookyaml
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+// markerPrefix leads both region markers. It is a YAML comment, so a config
+// carrying one still loads in any YAML parser, and it is the token Inspect
+// matches on to decide whether an install is already present.
+const markerPrefix = "# irrlicht-managed"
+
+// BeginMarker and EndMarker delimit the region this package owns inside the
+// target block, for a given owner token.
+//
+// The owner token is in both markers rather than only the first: an
+// unterminated region and a region belonging to a different owner must not
+// look the same, and the END line is what bounds the byte range a rewrite
+// replaces.
+func BeginMarker(owner string) string {
+	return markerPrefix + " BEGIN (" + owner + ") — do not edit; `irrlichd --uninstall-hooks` removes this block"
+}
+
+// EndMarker closes the region BeginMarker opens.
+func EndMarker(owner string) string {
+	return markerPrefix + " END (" + owner + ")"
+}
+
+// Entry is one hook definition installed under one event key. Exactly one
+// entry per event is modelled, which is all any adapter here installs.
+type Entry struct {
+	// Event is the agent's own wire name for the lifecycle event, used
+	// verbatim as the mapping key.
+	Event string
+	// Command is the shell command line the agent will run. Rendered as a
+	// YAML double-quoted scalar, so it may contain quotes and backslashes.
+	Command string
+	// TimeoutSeconds bounds the agent's wait. Omitted when zero.
+	TimeoutSeconds int
+}
+
+// Config describes one install: which file, which top-level key, who owns the
+// region, and what goes in it.
+type Config struct {
+	// Path is the absolute path of the YAML file to edit.
+	Path string
+	// BlockKey is the top-level mapping key the region is nested under.
+	BlockKey string
+	// Owner is the token embedded in the region markers.
+	Owner string
+	// Entries are the hook definitions to install, in order.
+	Entries []Entry
+	// WriteFile persists the new bytes. Injected so the caller owns atomicity
+	// and permissions; AtomicWriteFile is the default implementation.
+	WriteFile func(path string, data []byte) error
+}
+
+// UnsafeConstructError reports a document this package refuses to edit,
+// naming the file and the 1-based line so #1362's surfacing points the user
+// at something they can act on.
+type UnsafeConstructError struct {
+	Path    string
+	Line    int
+	Message string
+}
+
+func (e *UnsafeConstructError) Error() string {
+	return fmt.Sprintf("hookyaml: %s:%d: %s", e.Path, e.Line, e.Message)
+}
+
+// CollisionError reports that the target block already declares an event key
+// the region would define. Separate from UnsafeConstructError because the
+// document is perfectly well-formed — the conflict is semantic, and the fix
+// is the user's to make.
+type CollisionError struct {
+	Path  string
+	Line  int
+	Event string
+}
+
+func (e *CollisionError) Error() string {
+	return fmt.Sprintf("hookyaml: %s:%d: %q is already declared in the %s block by something irrlicht did not write; "+
+		"refusing to install, because a YAML mapping cannot hold the key twice and the duplicate would silently replace it",
+		e.Path, e.Line, e.Event, e.Event)
+}
+
+// EnsureInstalled writes cfg's region into the file, creating the block or the
+// file if needed. Reports whether anything changed.
+func EnsureInstalled(cfg Config) (bool, error) {
+	src, err := readAllowingMissing(cfg.Path)
+	if err != nil {
+		return false, err
+	}
+	next, changed, err := install(cfg, src)
+	if err != nil || !changed {
+		return false, err
+	}
+	return true, cfg.write(next)
+}
+
+// Uninstall removes cfg's region, and the block itself when nothing else is
+// left in it. Reports whether anything changed. A file we never wrote to, or
+// that no longer exists, is left alone.
+func Uninstall(cfg Config) (bool, error) {
+	src, err := readAllowingMissing(cfg.Path)
+	if err != nil {
+		return false, err
+	}
+	if len(src) == 0 {
+		return false, nil
+	}
+	next, changed, err := uninstall(cfg, src)
+	if err != nil || !changed {
+		return false, err
+	}
+	return true, cfg.write(next)
+}
+
+// Inspect reports whether a region for this owner is present, and whether it
+// is byte-identical to what EnsureInstalled would write now.
+//
+// A document this package refuses is reported as an error rather than as
+// "absent": those two have to stay distinguishable, or a config the installer
+// cannot touch would be re-reported forever as a missing install.
+func Inspect(cfg Config) (present, canonical bool, err error) {
+	src, err := readAllowingMissing(cfg.Path)
+	if err != nil {
+		return false, false, err
+	}
+	doc, err := scan(cfg, src)
+	if err != nil {
+		return false, false, err
+	}
+	if doc.region == nil {
+		return false, false, nil
+	}
+	want, err := doc.wantRegion(cfg)
+	if err != nil {
+		return true, false, err
+	}
+	return true, bytes.Equal(src[doc.region.start:doc.region.end], want), nil
+}
+
+func (c Config) write(data []byte) error {
+	if c.WriteFile != nil {
+		return c.WriteFile(c.Path, data)
+	}
+	return AtomicWriteFile(c.Path, data)
+}
+
+func readAllowingMissing(path string) ([]byte, error) {
+	src, err := os.ReadFile(path) // #nosec G304 -- path is the adapter's own resolved config location
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return src, nil
+}
+
+// ---------------------------------------------------------------------------
+// install / uninstall over the scanned document
+// ---------------------------------------------------------------------------
+
+func install(cfg Config, src []byte) ([]byte, bool, error) {
+	doc, err := scan(cfg, src)
+	if err != nil {
+		return nil, false, err
+	}
+
+	if doc.region != nil {
+		region, err := doc.wantRegion(cfg)
+		if err != nil {
+			return nil, false, err
+		}
+		if bytes.Equal(src[doc.region.start:doc.region.end], region) {
+			return nil, false, nil
+		}
+		return splice(src, doc.region.start, doc.region.end, region), true, nil
+	}
+
+	if err := doc.checkCollisions(cfg); err != nil {
+		return nil, false, err
+	}
+
+	if doc.blockKeyLine < 0 {
+		// No block at all: irrlicht creates it, so the key line goes INSIDE
+		// the region and uninstall takes it away again.
+		region, err := renderOwnedRegion(cfg)
+		if err != nil {
+			return nil, false, err
+		}
+		var out bytes.Buffer
+		out.Write(src)
+		if len(src) > 0 && !bytes.HasSuffix(src, []byte("\n")) {
+			out.WriteString("\n")
+		}
+		out.Write(region)
+		return out.Bytes(), true, nil
+	}
+
+	region, err := renderRegion(cfg, doc.blockIndent())
+	if err != nil {
+		return nil, false, err
+	}
+
+	if doc.blockInlineEmpty {
+		// `<key>: {}` becomes `<key>:` followed by the region — the one line
+		// outside the region any operation here rewrites. See the package doc.
+		line := doc.lines[doc.blockKeyLine]
+		replacement := []byte(cfg.BlockKey + ":" + doc.blockKeyComment + lineEndingOr(line.ending))
+		out := splice(src, line.start, line.end, replacement)
+		at := line.start + len(replacement)
+		return splice(out, at, at, region), true, nil
+	}
+
+	// The key line has to be TERMINATED before the region goes after it. When
+	// the block key is the file's last line and the file has no final newline,
+	// splicing the region straight in fuses the BEGIN marker onto the key line
+	// as a trailing comment — which still parses, so nothing complains, but
+	// the marker is no longer a line and uninstall can never find the region
+	// again. The property test's "block is the last top-level key" axis found
+	// this the first run it produced that position.
+	line := doc.lines[doc.blockKeyLine]
+	at := line.end
+	if line.ending == "" {
+		region = append([]byte("\n"), region...)
+	}
+	return splice(src, at, at, region), true, nil
+}
+
+// wantRegion renders the bytes an already-present region should hold, in
+// whichever of the two placements it currently occupies. A region does not
+// migrate between placements: which one it is in records who owns the block
+// key, and rewriting that would either orphan a user's key or leave ours
+// behind.
+func (d *document) wantRegion(cfg Config) ([]byte, error) {
+	if d.regionOwnsBlock {
+		return renderOwnedRegion(cfg)
+	}
+	return renderRegion(cfg, d.blockIndent())
+}
+
+func uninstall(cfg Config, src []byte) ([]byte, bool, error) {
+	doc, err := scan(cfg, src)
+	if err != nil {
+		return nil, false, err
+	}
+	if doc.region == nil {
+		return nil, false, nil
+	}
+	// One byte-range deletion and nothing else. The block key is inside the
+	// range exactly when this install created it, so there is no "should the
+	// key go too?" question left to get wrong.
+	return splice(src, doc.region.start, doc.region.end, nil), true, nil
+}
+
+// lineEndingOr returns the line's own terminator, or "\n" for a final line
+// that had none — a rewritten key line must always be terminated, because the
+// region goes immediately after it.
+func lineEndingOr(ending string) string {
+	if ending == "" {
+		return "\n"
+	}
+	return ending
+}
+
+func splice(src []byte, start, end int, insert []byte) []byte {
+	out := make([]byte, 0, len(src)-(end-start)+len(insert))
+	out = append(out, src[:start]...)
+	out = append(out, insert...)
+	return append(out, src[end:]...)
+}
+
+// ---------------------------------------------------------------------------
+// rendering
+// ---------------------------------------------------------------------------
+
+// renderRegion produces the exact bytes of the marker-delimited region,
+// indented to sit inside a block whose own keys are at blockIndent.
+func renderRegion(cfg Config, blockIndent int) ([]byte, error) {
+	if len(cfg.Entries) == 0 {
+		return nil, errors.New("hookyaml: refusing to render an empty region")
+	}
+	if strings.TrimSpace(cfg.Owner) == "" {
+		return nil, errors.New("hookyaml: refusing to render a region with no owner token")
+	}
+	pad := strings.Repeat(" ", blockIndent)
+
+	var b strings.Builder
+	b.WriteString(pad + BeginMarker(cfg.Owner) + "\n")
+	for _, e := range cfg.Entries {
+		if !isPlainKey(e.Event) {
+			return nil, fmt.Errorf("hookyaml: %q is not a plain YAML key", e.Event)
+		}
+		if e.Command == "" {
+			return nil, fmt.Errorf("hookyaml: %q has an empty command", e.Event)
+		}
+		b.WriteString(pad + e.Event + ":\n")
+		b.WriteString(pad + "  - command: " + Quote(e.Command) + "\n")
+		if e.TimeoutSeconds > 0 {
+			b.WriteString(pad + "    timeout: " + strconv.Itoa(e.TimeoutSeconds) + "\n")
+		}
+	}
+	b.WriteString(pad + EndMarker(cfg.Owner) + "\n")
+	return []byte(b.String()), nil
+}
+
+// renderOwnedRegion produces the region for the case where irrlicht creates
+// the block: markers at column 0, with the block key line and the entries
+// between them, so uninstall takes the key away with everything else.
+func renderOwnedRegion(cfg Config) ([]byte, error) {
+	if !isPlainKey(cfg.BlockKey) {
+		return nil, fmt.Errorf("hookyaml: %q is not a plain YAML key", cfg.BlockKey)
+	}
+	inner, err := renderRegion(cfg, defaultBlockIndent)
+	if err != nil {
+		return nil, err
+	}
+	// renderRegion's own markers are indented to sit inside a block; strip
+	// them and re-emit at column 0 around the key. Slicing its output rather
+	// than rebuilding the entries keeps ONE renderer for the entry lines.
+	body := strings.TrimSuffix(string(inner), strings.Repeat(" ", defaultBlockIndent)+EndMarker(cfg.Owner)+"\n")
+	body = strings.TrimPrefix(body, strings.Repeat(" ", defaultBlockIndent)+BeginMarker(cfg.Owner)+"\n")
+
+	var b strings.Builder
+	b.WriteString(BeginMarker(cfg.Owner) + "\n")
+	b.WriteString(cfg.BlockKey + ":\n")
+	b.WriteString(body)
+	b.WriteString(EndMarker(cfg.Owner) + "\n")
+	return []byte(b.String()), nil
+}
+
+// Quote renders s as a YAML double-quoted scalar.
+//
+// Double-quoted rather than single-quoted or plain, because it is the only
+// YAML scalar style with a defined escape for every byte: the command embeds
+// an absolute filesystem path the user chose, and a path containing a quote, a
+// backslash, a `#` or a leading `-` must not be able to end the scalar or turn
+// the line into a comment or a sequence item.
+func Quote(s string) string {
+	var b strings.Builder
+	b.WriteByte('"')
+	for _, r := range s {
+		switch r {
+		case '"':
+			b.WriteString(`\"`)
+		case '\\':
+			b.WriteString(`\\`)
+		case '\n':
+			b.WriteString(`\n`)
+		case '\r':
+			b.WriteString(`\r`)
+		case '\t':
+			b.WriteString(`\t`)
+		default:
+			if r < 0x20 || r == 0x7f {
+				b.WriteString(fmt.Sprintf(`\x%02x`, r))
+				continue
+			}
+			b.WriteRune(r)
+		}
+	}
+	b.WriteByte('"')
+	return b.String()
+}
+
+// isPlainKey reports whether s is an unquoted YAML key made only of
+// characters that carry no YAML meaning. `.` is included because hermes'
+// own config schema has dotted keys ("no CLI support due to dots in keys",
+// hermes_cli/config.py) and refusing them would refuse a real config.
+func isPlainKey(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		ok := c == '_' || c == '-' || c == '.' || (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9')
+		if !ok {
+			return false
+		}
+	}
+	return true
+}
+
+// ---------------------------------------------------------------------------
+// scanning
+// ---------------------------------------------------------------------------
+
+type lineSpan struct {
+	start, end int // byte offsets into src; end is past the trailing newline
+	text       string
+	// ending is the line's own terminator, "\n", "\r\n" or "" on a final
+	// line without one. Carried rather than assumed because the ONE line an
+	// install rewrites must be re-emitted with the terminator it had: a CRLF
+	// document silently gaining one LF line is a diff in every editor and a
+	// change this package promises not to make.
+	ending  string
+	indent  int
+	blank   bool
+	comment bool
+}
+
+type byteRange struct{ start, end int }
+
+type document struct {
+	lines []lineSpan
+
+	// blockKeyLine is the index of the `<BlockKey>:` line, or -1.
+	blockKeyLine int
+	// blockKeys maps each event key declared at the block's own indent to its
+	// line index. Empty when the block is absent or empty.
+	blockKeys map[string]int
+	// blockContentIndent is the indent the block's own keys sit at, or 0 when
+	// the block has none yet.
+	blockContentIndent int
+	// region is the byte range of this owner's marker-delimited region,
+	// or nil when absent.
+	region *byteRange
+	// regionOwnsBlock reports that the region encloses the block key line,
+	// i.e. this install created the block. Uninstall then removes both.
+	regionOwnsBlock bool
+	// blockInlineEmpty records `<BlockKey>: {}` — a block that exists and is
+	// empty, written in flow style. Installing replaces the key line.
+	blockInlineEmpty bool
+	// blockKeyComment is the trailing `# …` comment on the block key's own
+	// line, preserved across the flow-to-block rewrite above.
+	blockKeyComment string
+}
+
+// emptyFlowMapping is the only inline value a target key may carry.
+const emptyFlowMapping = "{}"
+
+// defaultBlockIndent is the indent used for a block that has no content to
+// copy an indent from. Two spaces is what hermes' own shipped example uses.
+const defaultBlockIndent = 2
+
+func (d *document) blockIndent() int {
+	if d.blockContentIndent > 0 {
+		return d.blockContentIndent
+	}
+	return defaultBlockIndent
+}
+
+func (d *document) checkCollisions(cfg Config) error {
+	for _, e := range cfg.Entries {
+		if line, ok := d.blockKeys[e.Event]; ok {
+			return &CollisionError{Path: cfg.Path, Line: line + 1, Event: e.Event}
+		}
+	}
+	return nil
+}
+
+func scan(cfg Config, src []byte) (*document, error) {
+	doc := &document{blockKeyLine: -1, blockKeys: map[string]int{}}
+	doc.lines = splitLines(src)
+
+	if err := doc.findBlockKey(cfg); err != nil {
+		return nil, err
+	}
+	if doc.blockKeyLine < 0 {
+		return doc, nil
+	}
+	if doc.regionOwnsBlock {
+		// Everything under the key is inside the region this install wrote, so
+		// there are no user keys to collide with and no second region to find.
+		return doc, nil
+	}
+	if err := doc.readBlock(cfg); err != nil {
+		return nil, err
+	}
+	return doc, nil
+}
+
+func splitLines(src []byte) []lineSpan {
+	var out []lineSpan
+	for i := 0; i < len(src); {
+		j := bytes.IndexByte(src[i:], '\n')
+		end := len(src)
+		if j >= 0 {
+			end = i + j + 1
+		}
+		raw := string(src[i:end])
+		text := strings.TrimRight(raw, "\r\n")
+		trimmed := strings.TrimLeft(text, " ")
+		out = append(out, lineSpan{
+			start:   i,
+			end:     end,
+			text:    text,
+			ending:  raw[len(text):],
+			indent:  len(text) - len(trimmed),
+			blank:   strings.TrimSpace(text) == "",
+			comment: strings.HasPrefix(trimmed, "#"),
+		})
+		i = end
+	}
+	return out
+}
+
+// findBlockKey locates the top-level BlockKey and, on the way, asserts the
+// column-0 invariant this package rests on.
+func (d *document) findBlockKey(cfg Config) error {
+	begin, end := BeginMarker(cfg.Owner), EndMarker(cfg.Owner)
+	ownedStart, ownedStartLine := -1, -1
+
+	for i, l := range d.lines {
+		if err := refuseTabIndent(cfg, i, l); err != nil {
+			return err
+		}
+		if l.indent == 0 && l.comment {
+			switch strings.TrimSpace(l.text) {
+			case begin:
+				if ownedStart >= 0 {
+					return &UnsafeConstructError{Path: cfg.Path, Line: i + 1,
+						Message: "a second irrlicht-managed BEGIN marker before the first was closed"}
+				}
+				ownedStart, ownedStartLine = l.start, i
+				continue
+			case end:
+				if ownedStart < 0 {
+					return &UnsafeConstructError{Path: cfg.Path, Line: i + 1,
+						Message: "an irrlicht-managed END marker with no BEGIN before it"}
+				}
+				if !d.regionOwnsBlock {
+					return &UnsafeConstructError{Path: cfg.Path, Line: i + 1,
+						Message: fmt.Sprintf("a top-level irrlicht-managed region that does not contain a %q key — irrlicht only writes one at that level to carry the key it created", cfg.BlockKey)}
+				}
+				d.region = &byteRange{start: ownedStart, end: l.end}
+				ownedStart = -1
+				continue
+			}
+		}
+		if l.blank || l.comment || l.indent > 0 {
+			continue
+		}
+		if isDocumentMarker(l.text) {
+			return &UnsafeConstructError{Path: cfg.Path, Line: i + 1,
+				Message: "a YAML document marker — this package models a single-document file and will not guess which document to edit"}
+		}
+		key, rest, ok := splitKey(l.text)
+		if !ok {
+			return &UnsafeConstructError{Path: cfg.Path, Line: i + 1,
+				Message: "a line at column 0 that is not a key, a comment or a document marker — the file is not a plain block mapping and will not be edited"}
+		}
+		if key != cfg.BlockKey {
+			continue
+		}
+		if d.blockKeyLine >= 0 {
+			return &UnsafeConstructError{Path: cfg.Path, Line: i + 1,
+				Message: fmt.Sprintf("a second top-level %q key — a duplicate mapping key resolves silently to one of the two, so which one to edit is not knowable", cfg.BlockKey)}
+		}
+		switch v := strings.TrimSpace(stripComment(rest)); v {
+		case "":
+		case emptyFlowMapping:
+			// The one inline value that is modelled, because it is the
+			// spelling the agent's OWN default config carries for "no hooks
+			// configured". Installing rewrites the line to a block mapping.
+			d.blockInlineEmpty = true
+			d.blockKeyComment = trailingComment(rest)
+		default:
+			return &UnsafeConstructError{Path: cfg.Path, Line: i + 1,
+				Message: fmt.Sprintf("%q carries the inline value %q; only a block mapping (or the empty %s) is modelled", cfg.BlockKey, v, emptyFlowMapping)}
+		}
+		d.blockKeyLine = i
+		d.regionOwnsBlock = ownedStart >= 0
+	}
+
+	if ownedStart >= 0 {
+		return &UnsafeConstructError{Path: cfg.Path, Line: ownedStartLine + 1,
+			Message: "a top-level irrlicht-managed BEGIN marker with no matching END — the region's extent is unknown, so rewriting it could delete a user's own configuration"}
+	}
+	return nil
+}
+
+// readBlock walks the lines under the block key, recording its own keys and
+// this owner's region.
+func (d *document) readBlock(cfg Config) error {
+	begin, end := BeginMarker(cfg.Owner), EndMarker(cfg.Owner)
+	regionStart, regionStartLine := -1, -1
+
+	for i := d.blockKeyLine + 1; i < len(d.lines); i++ {
+		l := d.lines[i]
+		if l.blank || l.comment {
+			if trimmed := strings.TrimSpace(l.text); trimmed == begin {
+				if regionStart >= 0 {
+					return &UnsafeConstructError{Path: cfg.Path, Line: i + 1,
+						Message: "a second irrlicht-managed BEGIN marker before the first was closed"}
+				}
+				regionStart, regionStartLine = l.start, i
+			} else if trimmed == end {
+				if regionStart < 0 {
+					return &UnsafeConstructError{Path: cfg.Path, Line: i + 1,
+						Message: "an irrlicht-managed END marker with no BEGIN before it"}
+				}
+				d.region = &byteRange{start: regionStart, end: l.end}
+				regionStart = -1
+			}
+			continue
+		}
+		if l.indent == 0 {
+			break // the next top-level key ends the block
+		}
+		if regionStart >= 0 {
+			continue // inside our own region; not a user key
+		}
+		if d.blockContentIndent == 0 {
+			d.blockContentIndent = l.indent
+		}
+		if l.indent != d.blockContentIndent {
+			continue // nested deeper than the block's own keys
+		}
+		if err := d.recordBlockKey(cfg, i, l); err != nil {
+			return err
+		}
+	}
+
+	if regionStart >= 0 {
+		return &UnsafeConstructError{Path: cfg.Path, Line: regionStartLine + 1,
+			Message: "an irrlicht-managed BEGIN marker with no matching END — the region's extent is unknown, so rewriting it could delete a user's own hooks"}
+	}
+	return nil
+}
+
+func (d *document) recordBlockKey(cfg Config, i int, l lineSpan) error {
+	body := strings.TrimLeft(l.text, " ")
+	if strings.HasPrefix(body, "- ") || body == "-" {
+		return &UnsafeConstructError{Path: cfg.Path, Line: i + 1,
+			Message: fmt.Sprintf("the %s block is a sequence, not a mapping of event names", cfg.BlockKey)}
+	}
+	if strings.HasPrefix(body, "<<:") {
+		return &UnsafeConstructError{Path: cfg.Path, Line: i + 1,
+			Message: "a YAML merge key inside the block — what the merged mapping contributes is not visible from this file"}
+	}
+	key, rest, ok := splitKey(body)
+	if !ok {
+		return &UnsafeConstructError{Path: cfg.Path, Line: i + 1,
+			Message: "a line inside the block that is not a key — the block is not the plain mapping of event names this package models"}
+	}
+	if v := strings.TrimSpace(stripComment(rest)); v != "" {
+		switch v[0] {
+		case '&', '*':
+			return &UnsafeConstructError{Path: cfg.Path, Line: i + 1,
+				Message: fmt.Sprintf("event %q uses a YAML anchor or alias; the entries it resolves to are not visible from this file", key)}
+		case '|', '>':
+			return &UnsafeConstructError{Path: cfg.Path, Line: i + 1,
+				Message: fmt.Sprintf("event %q carries a block scalar; the indented lines below it are text, not entries", key)}
+		}
+	}
+	d.blockKeys[key] = i
+	return nil
+}
+
+func refuseTabIndent(cfg Config, i int, l lineSpan) error {
+	if strings.HasPrefix(strings.TrimLeft(l.text, " "), "\t") {
+		return &UnsafeConstructError{Path: cfg.Path, Line: i + 1,
+			Message: "a tab in the line's indentation — YAML forbids it, so this file does not load and will not be edited"}
+	}
+	return nil
+}
+
+func isDocumentMarker(text string) bool {
+	t := strings.TrimRight(text, " ")
+	return t == "---" || t == "..." || strings.HasPrefix(t, "--- ") || strings.HasPrefix(t, "... ")
+}
+
+// splitKey splits "key: rest" into its parts.
+//
+// A QUOTED key is recognized as a key but reported under its quoted spelling,
+// which can never equal a plain BlockKey or event name. That is deliberate:
+// it terminates a block and is skipped as a non-match, rather than refusing a
+// whole config for a construct that is legal and that this package simply has
+// no reason to touch. Anything else is reported as "not a key", which routes
+// it to the refusal rather than to a silent mis-edit.
+func splitKey(text string) (key, rest string, ok bool) {
+	if text != "" && (text[0] == '"' || text[0] == '\'') {
+		if i := strings.LastIndex(text, ":"); i > 0 {
+			return text[:i], text[i+1:], true
+		}
+		return "", "", false
+	}
+	i := strings.IndexByte(text, ':')
+	if i < 0 {
+		return "", "", false
+	}
+	key = text[:i]
+	if !isPlainKey(key) {
+		return "", "", false
+	}
+	rest = text[i+1:]
+	if rest != "" && rest[0] != ' ' && rest[0] != '\t' {
+		// `key:value` is a plain scalar in YAML, not a mapping key.
+		return "", "", false
+	}
+	return key, rest, true
+}
+
+// trailingComment returns the `# …` comment at the end of a key's inline
+// value, including ALL of the whitespace that separates it from the value.
+//
+// All of it, not just the one space YAML requires, because the comment is the
+// user's and its column is usually deliberate — several keys aligned in a
+// group lose their alignment if a rewrite normalizes one of them.
+func trailingComment(rest string) string {
+	i := strings.Index(rest, " #")
+	if i < 0 {
+		return ""
+	}
+	for i > 0 && rest[i-1] == ' ' {
+		i--
+	}
+	return rest[i:]
+}
+
+// stripComment removes a trailing `#` comment from a key's inline value.
+//
+// It stops at the first `#` that follows whitespace, which is YAML's own rule
+// for a plain scalar. A `#` inside a quoted value is left alone by requiring
+// the preceding space, which is enough for the only use here: deciding
+// whether a key has an inline value at all.
+func stripComment(rest string) string {
+	if strings.HasPrefix(strings.TrimLeft(rest, " "), "#") {
+		return ""
+	}
+	if i := strings.Index(rest, " #"); i >= 0 {
+		return rest[:i]
+	}
+	return rest
+}
+
+// AtomicWriteFile writes data to path via a temp file plus rename, creating
+// the parent directory. The agent may load the file at any moment, so it must
+// never see a partial write.
+func AtomicWriteFile(path string, data []byte) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(dir, ".irrlicht-*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer func() { _ = os.Remove(tmpName) }()
+
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := os.Chmod(tmpName, 0o600); err != nil {
+		return err
+	}
+	return os.Rename(tmpName, path)
+}

--- a/core/adapters/inbound/agents/hookyaml/hookyaml.go
+++ b/core/adapters/inbound/agents/hookyaml/hookyaml.go
@@ -102,6 +102,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 )
@@ -151,6 +152,21 @@ type Config struct {
 	Owner string
 	// Entries are the hook definitions to install, in order.
 	Entries []Entry
+	// Sentinel is a substring that appears in every entry this owner writes
+	// and in nothing a user would write — a beacon command's
+	// `hook-post <adapter> `, for instance.
+	//
+	// It exists because the markers are COMMENTS, and an agent that rewrites
+	// its own config from a parsed structure deletes every comment in it while
+	// keeping the data. Hermes' `save_config` does exactly that
+	// (`atomic_yaml_write` over a dict) on `hermes config set`, on the setup
+	// wizard, and on a dashboard save. After one of those the entries are
+	// still there and still firing, but the region that identifies them is
+	// gone — so without this, EnsureInstalled would report the surviving
+	// entries as a user's own colliding hooks forever, and Uninstall would
+	// find nothing to remove and leave them in the user's config with no way
+	// to take them out. Empty disables the recovery.
+	Sentinel string
 	// WriteFile persists the new bytes. Injected so the caller owns atomicity
 	// and permissions; AtomicWriteFile is the default implementation.
 	WriteFile func(path string, data []byte) error
@@ -233,7 +249,14 @@ func Inspect(cfg Config) (present, canonical bool, err error) {
 		return false, false, err
 	}
 	if doc.region == nil {
-		return false, false, nil
+		// Orphaned entries are PRESENT (they are firing) but not canonical:
+		// reporting them Missing would make #1372's verifier repair by
+		// re-installing, which is the right action, while reporting them
+		// absent would leave `--uninstall-hooks` with nothing to find.
+		return len(doc.strays) > 0, false, nil
+	}
+	if len(doc.strays) > 0 {
+		return true, false, nil
 	}
 	want, err := doc.wantRegion(cfg)
 	if err != nil {
@@ -273,8 +296,37 @@ func install(cfg Config, src []byte) ([]byte, bool, error) {
 	if err != nil {
 		return nil, false, err
 	}
+
+	// Recover first: entries of ours the agent's own config rewrite orphaned
+	// are removed, and everything below then runs against a document with no
+	// trace of a previous install. Doing it as a separate pass with a re-scan,
+	// rather than folding the deletions into the edit below, keeps every byte
+	// offset in `doc` valid for exactly one operation.
+	if len(doc.strays) > 0 {
+		src = deleteRanges(src, doc.strays)
+		doc, err = scan(cfg, src)
+		if err != nil {
+			return nil, false, err
+		}
+		if len(doc.strays) > 0 {
+			return nil, false, fmt.Errorf("hookyaml: %s still carries an entry marked %q after removing the ones found; refusing to write rather than loop",
+				cfg.Path, cfg.Sentinel)
+		}
+		out, _, err := installInto(cfg, src, doc)
+		// changed is true regardless: the strays came out.
+		return out, true, err
+	}
+	return installInto(cfg, src, doc)
+}
+
+// installInto is install with recovery already done.
+func installInto(cfg Config, src []byte, doc *document) ([]byte, bool, error) {
 	if doc.region != nil {
-		return rewriteRegion(cfg, src, doc)
+		out, changed, err := rewriteRegion(cfg, src, doc)
+		if !changed && err == nil {
+			return src, false, nil
+		}
+		return out, changed, err
 	}
 	if err := doc.checkCollisions(cfg); err != nil {
 		return nil, false, err
@@ -363,13 +415,18 @@ func uninstall(cfg Config, src []byte) ([]byte, bool, error) {
 	if err != nil {
 		return nil, false, err
 	}
-	if doc.region == nil {
+	// Both the region and any orphaned entries come out. The block key is
+	// inside the region exactly when this install created it, so there is no
+	// "should the key go too?" question left to get wrong.
+	ranges := append([]byteRange(nil), doc.strays...)
+	if doc.region != nil {
+		ranges = append(ranges, *doc.region)
+	}
+	if len(ranges) == 0 {
 		return nil, false, nil
 	}
-	// One byte-range deletion and nothing else. The block key is inside the
-	// range exactly when this install created it, so there is no "should the
-	// key go too?" question left to get wrong.
-	return splice(src, doc.region.start, doc.region.end, nil), true, nil
+	sort.Slice(ranges, func(i, j int) bool { return ranges[i].start < ranges[j].start })
+	return deleteRanges(src, ranges), true, nil
 }
 
 // lineEndingOr returns the line's own terminator, or "\n" for a final line
@@ -537,6 +594,10 @@ type document struct {
 	// regionOwnsBlock reports that the region encloses the block key line,
 	// i.e. this install created the block. Uninstall then removes both.
 	regionOwnsBlock bool
+	// strays are entries OUTSIDE the region that carry Config.Sentinel — this
+	// owner's own entries, left behind after the agent rewrote its config from
+	// a parsed structure and dropped the marker comments. See Config.Sentinel.
+	strays []byteRange
 	// blockInlineEmpty records `<BlockKey>: {}` — a block that exists and is
 	// empty, written in flow style. Installing replaces the key line.
 	blockInlineEmpty bool
@@ -559,6 +620,10 @@ func (d *document) blockIndent() int {
 	return defaultBlockIndent
 }
 
+// checkCollisions refuses an event key the USER declares. A key that is one of
+// ours orphaned by the agent's own config rewrite is not a collision — install
+// removes it first (see Config.Sentinel), and scan has already emptied
+// blockKeys of those.
 func (d *document) checkCollisions(cfg Config) error {
 	for _, e := range cfg.Entries {
 		if line, ok := d.blockKeys[e.Event]; ok {
@@ -583,7 +648,7 @@ func scan(cfg Config, src []byte) (*document, error) {
 		// there are no user keys to collide with and no second region to find.
 		return doc, nil
 	}
-	if err := doc.readBlock(cfg); err != nil {
+	if err := doc.readBlock(cfg, src); err != nil {
 		return nil, err
 	}
 	return doc, nil
@@ -734,9 +799,13 @@ func (w *topLevelWalk) refuse(i int, message string) error {
 
 // readBlock walks the lines under the block key, recording its own keys and
 // this owner's region.
-func (d *document) readBlock(cfg Config) error {
+func (d *document) readBlock(cfg Config, src []byte) error {
 	begin, end := BeginMarker(cfg.Owner), EndMarker(cfg.Owner)
 	regionStart, regionStartLine := -1, -1
+	// openKey/openEnd track the extent of the block-level entry currently
+	// being read, so a sentinel-bearing one can be removed whole.
+	openKey, openEnd := -1, -1
+	openName := ""
 
 	for i := d.blockKeyLine + 1; i < len(d.lines); i++ {
 		l := d.lines[i]
@@ -767,12 +836,19 @@ func (d *document) readBlock(cfg Config) error {
 			d.blockContentIndent = l.indent
 		}
 		if l.indent != d.blockContentIndent {
+			if openKey >= 0 {
+				openEnd = l.end // still part of the entry that key opened
+			}
 			continue // nested deeper than the block's own keys
 		}
-		if err := d.recordBlockKey(cfg, i, l); err != nil {
+		d.closeEntry(cfg, src, openKey, openEnd, openName)
+		name, err := d.recordBlockKey(cfg, i, l)
+		if err != nil {
 			return err
 		}
+		openKey, openEnd, openName = l.start, l.end, name
 	}
+	d.closeEntry(cfg, src, openKey, openEnd, openName)
 
 	if regionStart >= 0 {
 		return &UnsafeConstructError{Path: cfg.Path, Line: regionStartLine + 1,
@@ -781,33 +857,58 @@ func (d *document) readBlock(cfg Config) error {
 	return nil
 }
 
-func (d *document) recordBlockKey(cfg Config, i int, l lineSpan) error {
+// closeEntry finishes the block-level entry that started at start, recording
+// it as a stray when it carries the owner's sentinel.
+func (d *document) closeEntry(cfg Config, src []byte, start, end int, name string) {
+	if start < 0 || cfg.Sentinel == "" {
+		return
+	}
+	if !bytes.Contains(src[start:end], []byte(cfg.Sentinel)) {
+		return
+	}
+	d.strays = append(d.strays, byteRange{start: start, end: end})
+	// It is ours, so it is not a user key: dropping it here is what stops
+	// checkCollisions refusing an install over our own orphaned entry.
+	delete(d.blockKeys, name)
+}
+
+// deleteRanges removes ranges from src, back to front so earlier offsets stay
+// valid. Ranges must not overlap.
+func deleteRanges(src []byte, ranges []byteRange) []byte {
+	out := src
+	for i := len(ranges) - 1; i >= 0; i-- {
+		out = splice(out, ranges[i].start, ranges[i].end, nil)
+	}
+	return out
+}
+
+func (d *document) recordBlockKey(cfg Config, i int, l lineSpan) (string, error) {
 	body := strings.TrimLeft(l.text, " ")
 	if strings.HasPrefix(body, "- ") || body == "-" {
-		return &UnsafeConstructError{Path: cfg.Path, Line: i + 1,
+		return "", &UnsafeConstructError{Path: cfg.Path, Line: i + 1,
 			Message: fmt.Sprintf("the %s block is a sequence, not a mapping of event names", cfg.BlockKey)}
 	}
 	if strings.HasPrefix(body, "<<:") {
-		return &UnsafeConstructError{Path: cfg.Path, Line: i + 1,
+		return "", &UnsafeConstructError{Path: cfg.Path, Line: i + 1,
 			Message: "a YAML merge key inside the block — what the merged mapping contributes is not visible from this file"}
 	}
 	key, rest, ok := splitKey(body)
 	if !ok {
-		return &UnsafeConstructError{Path: cfg.Path, Line: i + 1,
+		return "", &UnsafeConstructError{Path: cfg.Path, Line: i + 1,
 			Message: "a line inside the block that is not a key — the block is not the plain mapping of event names this package models"}
 	}
 	if v := strings.TrimSpace(stripComment(rest)); v != "" {
 		switch v[0] {
 		case '&', '*':
-			return &UnsafeConstructError{Path: cfg.Path, Line: i + 1,
+			return "", &UnsafeConstructError{Path: cfg.Path, Line: i + 1,
 				Message: fmt.Sprintf("event %q uses a YAML anchor or alias; the entries it resolves to are not visible from this file", key)}
 		case '|', '>':
-			return &UnsafeConstructError{Path: cfg.Path, Line: i + 1,
+			return "", &UnsafeConstructError{Path: cfg.Path, Line: i + 1,
 				Message: fmt.Sprintf("event %q carries a block scalar; the indented lines below it are text, not entries", key)}
 		}
 	}
 	d.blockKeys[key] = i
-	return nil
+	return key, nil
 }
 
 func refuseTabIndent(cfg Config, i int, l lineSpan) error {

--- a/core/adapters/inbound/agents/hookyaml/hookyaml.go
+++ b/core/adapters/inbound/agents/hookyaml/hookyaml.go
@@ -264,52 +264,69 @@ func readAllowingMissing(path string) ([]byte, error) {
 // install / uninstall over the scanned document
 // ---------------------------------------------------------------------------
 
+// install is the three-way decision, one branch per placement. Each branch is
+// its own function because the three differ in what they render, where they
+// splice and what they may rewrite, and reading them interleaved is how the
+// end-of-file case below hid.
 func install(cfg Config, src []byte) ([]byte, bool, error) {
 	doc, err := scan(cfg, src)
 	if err != nil {
 		return nil, false, err
 	}
-
 	if doc.region != nil {
-		region, err := doc.wantRegion(cfg)
-		if err != nil {
-			return nil, false, err
-		}
-		if bytes.Equal(src[doc.region.start:doc.region.end], region) {
-			return nil, false, nil
-		}
-		return splice(src, doc.region.start, doc.region.end, region), true, nil
+		return rewriteRegion(cfg, src, doc)
 	}
-
 	if err := doc.checkCollisions(cfg); err != nil {
 		return nil, false, err
 	}
-
 	if doc.blockKeyLine < 0 {
-		// No block at all: irrlicht creates it, so the key line goes INSIDE
-		// the region and uninstall takes it away again.
-		region, err := renderOwnedRegion(cfg)
-		if err != nil {
-			return nil, false, err
-		}
-		var out bytes.Buffer
-		out.Write(src)
-		if len(src) > 0 && !bytes.HasSuffix(src, []byte("\n")) {
-			out.WriteString("\n")
-		}
-		out.Write(region)
-		return out.Bytes(), true, nil
+		return createBlock(cfg, src)
 	}
+	return insertIntoBlock(cfg, src, doc)
+}
 
+// rewriteRegion replaces an already-present region, in whichever placement it
+// occupies. Reports no change when the bytes already match.
+func rewriteRegion(cfg Config, src []byte, doc *document) ([]byte, bool, error) {
+	region, err := doc.wantRegion(cfg)
+	if err != nil {
+		return nil, false, err
+	}
+	if bytes.Equal(src[doc.region.start:doc.region.end], region) {
+		return nil, false, nil
+	}
+	return splice(src, doc.region.start, doc.region.end, region), true, nil
+}
+
+// createBlock appends the owned region — markers, block key and entries — at
+// the end of the document. The key goes INSIDE the region because irrlicht is
+// what put it there, so uninstall takes it away again.
+func createBlock(cfg Config, src []byte) ([]byte, bool, error) {
+	region, err := renderOwnedRegion(cfg)
+	if err != nil {
+		return nil, false, err
+	}
+	var out bytes.Buffer
+	out.Write(src)
+	if len(src) > 0 && !bytes.HasSuffix(src, []byte("\n")) {
+		out.WriteString("\n")
+	}
+	out.Write(region)
+	return out.Bytes(), true, nil
+}
+
+// insertIntoBlock puts the region inside a block the USER owns, directly after
+// the key line.
+func insertIntoBlock(cfg Config, src []byte, doc *document) ([]byte, bool, error) {
 	region, err := renderRegion(cfg, doc.blockIndent())
 	if err != nil {
 		return nil, false, err
 	}
+	line := doc.lines[doc.blockKeyLine]
 
 	if doc.blockInlineEmpty {
 		// `<key>: {}` becomes `<key>:` followed by the region — the one line
 		// outside the region any operation here rewrites. See the package doc.
-		line := doc.lines[doc.blockKeyLine]
 		replacement := []byte(cfg.BlockKey + ":" + doc.blockKeyComment + lineEndingOr(line.ending))
 		out := splice(src, line.start, line.end, replacement)
 		at := line.start + len(replacement)
@@ -323,12 +340,10 @@ func install(cfg Config, src []byte) ([]byte, bool, error) {
 	// the marker is no longer a line and uninstall can never find the region
 	// again. The property test's "block is the last top-level key" axis found
 	// this the first run it produced that position.
-	line := doc.lines[doc.blockKeyLine]
-	at := line.end
 	if line.ending == "" {
 		region = append([]byte("\n"), region...)
 	}
-	return splice(src, at, at, region), true, nil
+	return splice(src, line.end, line.end, region), true, nil
 }
 
 // wantRegion renders the bytes an already-present region should hold, in
@@ -602,76 +617,119 @@ func splitLines(src []byte) []lineSpan {
 // findBlockKey locates the top-level BlockKey and, on the way, asserts the
 // column-0 invariant this package rests on.
 func (d *document) findBlockKey(cfg Config) error {
-	begin, end := BeginMarker(cfg.Owner), EndMarker(cfg.Owner)
-	ownedStart, ownedStartLine := -1, -1
-
+	w := topLevelWalk{doc: d, cfg: cfg, ownedStart: -1, ownedStartLine: -1}
 	for i, l := range d.lines {
 		if err := refuseTabIndent(cfg, i, l); err != nil {
 			return err
 		}
-		if l.indent == 0 && l.comment {
-			switch strings.TrimSpace(l.text) {
-			case begin:
-				if ownedStart >= 0 {
-					return &UnsafeConstructError{Path: cfg.Path, Line: i + 1,
-						Message: "a second irrlicht-managed BEGIN marker before the first was closed"}
-				}
-				ownedStart, ownedStartLine = l.start, i
-				continue
-			case end:
-				if ownedStart < 0 {
-					return &UnsafeConstructError{Path: cfg.Path, Line: i + 1,
-						Message: "an irrlicht-managed END marker with no BEGIN before it"}
-				}
-				if !d.regionOwnsBlock {
-					return &UnsafeConstructError{Path: cfg.Path, Line: i + 1,
-						Message: fmt.Sprintf("a top-level irrlicht-managed region that does not contain a %q key — irrlicht only writes one at that level to carry the key it created", cfg.BlockKey)}
-				}
-				d.region = &byteRange{start: ownedStart, end: l.end}
-				ownedStart = -1
-				continue
-			}
+		handled, err := w.marker(i, l)
+		if err != nil {
+			return err
 		}
-		if l.blank || l.comment || l.indent > 0 {
+		if handled || l.blank || l.comment || l.indent > 0 {
 			continue
 		}
-		if isDocumentMarker(l.text) {
-			return &UnsafeConstructError{Path: cfg.Path, Line: i + 1,
-				Message: "a YAML document marker — this package models a single-document file and will not guess which document to edit"}
+		if err := w.key(i, l); err != nil {
+			return err
 		}
-		key, rest, ok := splitKey(l.text)
-		if !ok {
-			return &UnsafeConstructError{Path: cfg.Path, Line: i + 1,
-				Message: "a line at column 0 that is not a key, a comment or a document marker — the file is not a plain block mapping and will not be edited"}
-		}
-		if key != cfg.BlockKey {
-			continue
-		}
-		if d.blockKeyLine >= 0 {
-			return &UnsafeConstructError{Path: cfg.Path, Line: i + 1,
-				Message: fmt.Sprintf("a second top-level %q key — a duplicate mapping key resolves silently to one of the two, so which one to edit is not knowable", cfg.BlockKey)}
-		}
-		switch v := strings.TrimSpace(stripComment(rest)); v {
-		case "":
-		case emptyFlowMapping:
-			// The one inline value that is modelled, because it is the
-			// spelling the agent's OWN default config carries for "no hooks
-			// configured". Installing rewrites the line to a block mapping.
-			d.blockInlineEmpty = true
-			d.blockKeyComment = trailingComment(rest)
-		default:
-			return &UnsafeConstructError{Path: cfg.Path, Line: i + 1,
-				Message: fmt.Sprintf("%q carries the inline value %q; only a block mapping (or the empty %s) is modelled", cfg.BlockKey, v, emptyFlowMapping)}
-		}
-		d.blockKeyLine = i
-		d.regionOwnsBlock = ownedStart >= 0
 	}
+	return w.finish()
+}
 
-	if ownedStart >= 0 {
-		return &UnsafeConstructError{Path: cfg.Path, Line: ownedStartLine + 1,
-			Message: "a top-level irrlicht-managed BEGIN marker with no matching END — the region's extent is unknown, so rewriting it could delete a user's own configuration"}
+// topLevelWalk carries findBlockKey's cross-line state: whether a top-level
+// irrlicht region is currently open. Split out because the marker half and the
+// key half are two independent grammars over the same line stream, and reading
+// them interleaved is what let the region-placement bug hide.
+type topLevelWalk struct {
+	doc                        *document
+	cfg                        Config
+	ownedStart, ownedStartLine int
+}
+
+// marker handles a column-0 region marker, reporting whether the line was one.
+func (w *topLevelWalk) marker(i int, l lineSpan) (bool, error) {
+	if l.indent != 0 || !l.comment {
+		return false, nil
 	}
+	switch strings.TrimSpace(l.text) {
+	case BeginMarker(w.cfg.Owner):
+		if w.ownedStart >= 0 {
+			return true, w.refuse(i, "a second irrlicht-managed BEGIN marker before the first was closed")
+		}
+		w.ownedStart, w.ownedStartLine = l.start, i
+		return true, nil
+	case EndMarker(w.cfg.Owner):
+		if w.ownedStart < 0 {
+			return true, w.refuse(i, "an irrlicht-managed END marker with no BEGIN before it")
+		}
+		if !w.doc.regionOwnsBlock {
+			return true, w.refuse(i, fmt.Sprintf(
+				"a top-level irrlicht-managed region that does not contain a %q key — irrlicht only writes one at that level to carry the key it created",
+				w.cfg.BlockKey))
+		}
+		w.doc.region = &byteRange{start: w.ownedStart, end: l.end}
+		w.ownedStart = -1
+		return true, nil
+	}
+	return false, nil
+}
+
+// key handles a column-0 non-comment line: it must be the target key, another
+// key, or a shape this package refuses.
+func (w *topLevelWalk) key(i int, l lineSpan) error {
+	if isDocumentMarker(l.text) {
+		return w.refuse(i, "a YAML document marker — this package models a single-document file and will not guess which document to edit")
+	}
+	key, rest, ok := splitKey(l.text)
+	if !ok {
+		return w.refuse(i, "a line at column 0 that is not a key, a comment or a document marker — the file is not a plain block mapping and will not be edited")
+	}
+	if key != w.cfg.BlockKey {
+		return nil
+	}
+	if w.doc.blockKeyLine >= 0 {
+		return w.refuse(i, fmt.Sprintf(
+			"a second top-level %q key — a duplicate mapping key resolves silently to one of the two, so which one to edit is not knowable",
+			w.cfg.BlockKey))
+	}
+	if err := w.inlineValue(i, rest); err != nil {
+		return err
+	}
+	w.doc.blockKeyLine = i
+	w.doc.regionOwnsBlock = w.ownedStart >= 0
 	return nil
+}
+
+// inlineValue classifies whatever follows the target key on its own line.
+func (w *topLevelWalk) inlineValue(i int, rest string) error {
+	switch v := strings.TrimSpace(stripComment(rest)); v {
+	case "":
+		return nil
+	case emptyFlowMapping:
+		// The one inline value that is modelled, because it is the spelling
+		// the agent's OWN default config carries for "no hooks configured".
+		// Installing rewrites the line to a block mapping.
+		w.doc.blockInlineEmpty = true
+		w.doc.blockKeyComment = trailingComment(rest)
+		return nil
+	default:
+		return w.refuse(i, fmt.Sprintf(
+			"%q carries the inline value %q; only a block mapping (or the empty %s) is modelled",
+			w.cfg.BlockKey, v, emptyFlowMapping))
+	}
+}
+
+// finish reports a region left open at end of document.
+func (w *topLevelWalk) finish() error {
+	if w.ownedStart < 0 {
+		return nil
+	}
+	return w.refuse(w.ownedStartLine,
+		"a top-level irrlicht-managed BEGIN marker with no matching END — the region's extent is unknown, so rewriting it could delete a user's own configuration")
+}
+
+func (w *topLevelWalk) refuse(i int, message string) error {
+	return &UnsafeConstructError{Path: w.cfg.Path, Line: i + 1, Message: message}
 }
 
 // readBlock walks the lines under the block key, recording its own keys and

--- a/core/adapters/inbound/agents/hookyaml/hookyaml_test.go
+++ b/core/adapters/inbound/agents/hookyaml/hookyaml_test.go
@@ -1,0 +1,397 @@
+package hookyaml
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const (
+	testOwner = "irrlicht"
+	testBlock = "hooks"
+)
+
+func testConfig(path string) Config {
+	return Config{
+		Path:     path,
+		BlockKey: testBlock,
+		Owner:    testOwner,
+		Entries: []Entry{
+			{Event: "on_session_end", Command: "/bin/sh -c 'beacon hook-post x'", TimeoutSeconds: 2},
+			{Event: "pre_approval_request", Command: "/bin/sh -c 'beacon hook-post x'", TimeoutSeconds: 2},
+		},
+	}
+}
+
+func writeTemp(t *testing.T, body string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	if body != "" {
+		if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+	}
+	return path
+}
+
+func read(t *testing.T, path string) string {
+	t.Helper()
+	b, err := os.ReadFile(path) // #nosec G304 -- the temp path this test created
+	if os.IsNotExist(err) {
+		return ""
+	}
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	return string(b)
+}
+
+// TestEnsureInstalled_AppendsWhenTheBlockIsAbsent is the common case: the user
+// has no hooks at all, so the whole original document must survive as a
+// byte-identical prefix.
+func TestEnsureInstalled_AppendsWhenTheBlockIsAbsent(t *testing.T) {
+	const src = "# a comment\nmodel:\n  default: \"x\"   # trailing\n"
+	path := writeTemp(t, src)
+	cfg := testConfig(path)
+
+	changed, err := EnsureInstalled(cfg)
+	if err != nil {
+		t.Fatalf("EnsureInstalled: %v", err)
+	}
+	if !changed {
+		t.Fatal("reported no change on a first install")
+	}
+	got := read(t, path)
+	if !strings.HasPrefix(got, src) {
+		t.Fatalf("the original is not a byte-identical prefix:\n%s", got)
+	}
+	if !strings.Contains(got, "hooks:\n") {
+		t.Errorf("no hooks block was written:\n%s", got)
+	}
+	if !strings.Contains(got, BeginMarker(testOwner)) || !strings.Contains(got, EndMarker(testOwner)) {
+		t.Errorf("the region is not marker-delimited:\n%s", got)
+	}
+}
+
+// TestEnsureInstalled_MergesIntoAnExistingBlock pins that a user's own hooks on
+// OTHER events are untouched and that our region adopts their indent.
+func TestEnsureInstalled_MergesIntoAnExistingBlock(t *testing.T) {
+	const src = `hooks:
+    post_tool_call:
+        - command: "/usr/local/bin/fmt"
+model:
+  default: "x"
+`
+	path := writeTemp(t, src)
+	if _, err := EnsureInstalled(testConfig(path)); err != nil {
+		t.Fatalf("EnsureInstalled: %v", err)
+	}
+	got := read(t, path)
+
+	for _, line := range strings.Split(strings.TrimRight(src, "\n"), "\n") {
+		if !strings.Contains(got, line) {
+			t.Errorf("original line %q is gone:\n%s", line, got)
+		}
+	}
+	if !strings.Contains(got, "    "+BeginMarker(testOwner)) {
+		t.Errorf("the region did not adopt the block's own 4-space indent:\n%s", got)
+	}
+}
+
+// TestEnsureInstalled_RewritesAStaleRegionInPlace is the self-healing property:
+// a region written by a differently-situated daemon is replaced, not
+// duplicated.
+func TestEnsureInstalled_RewritesAStaleRegionInPlace(t *testing.T) {
+	path := writeTemp(t, "model:\n  default: \"x\"\n")
+	old := testConfig(path)
+	old.Entries[0].Command = "/bin/sh -c 'OLD hook-post x'"
+	if _, err := EnsureInstalled(old); err != nil {
+		t.Fatalf("first install: %v", err)
+	}
+
+	if _, err := EnsureInstalled(testConfig(path)); err != nil {
+		t.Fatalf("second install: %v", err)
+	}
+	got := read(t, path)
+	if n := strings.Count(got, BeginMarker(testOwner)); n != 1 {
+		t.Errorf("found %d regions after a rewrite, want 1:\n%s", n, got)
+	}
+	if strings.Contains(got, "OLD hook-post") {
+		t.Errorf("the stale command survived:\n%s", got)
+	}
+}
+
+// TestUninstall_RemovesTheBlockWhenItEmpties pins the tidy uninstall, and that
+// an unrelated user hook keeps the block alive.
+func TestUninstall_RemovesTheBlockWhenItEmpties(t *testing.T) {
+	t.Run("only ours", func(t *testing.T) {
+		const src = "model:\n  default: \"x\"\n"
+		path := writeTemp(t, src)
+		cfg := testConfig(path)
+		if _, err := EnsureInstalled(cfg); err != nil {
+			t.Fatalf("install: %v", err)
+		}
+		if _, err := Uninstall(cfg); err != nil {
+			t.Fatalf("uninstall: %v", err)
+		}
+		if got := read(t, path); got != src {
+			t.Errorf("round trip is not the original:\n--- got ---\n%s--- want ---\n%s", got, src)
+		}
+	})
+
+	t.Run("a user hook remains", func(t *testing.T) {
+		const src = "hooks:\n  post_tool_call:\n    - command: \"/x\"\n"
+		path := writeTemp(t, src)
+		cfg := testConfig(path)
+		if _, err := EnsureInstalled(cfg); err != nil {
+			t.Fatalf("install: %v", err)
+		}
+		if _, err := Uninstall(cfg); err != nil {
+			t.Fatalf("uninstall: %v", err)
+		}
+		if got := read(t, path); got != src {
+			t.Errorf("round trip is not the original:\n--- got ---\n%s--- want ---\n%s", got, src)
+		}
+	})
+}
+
+// TestUninstall_LeavesAForeignFileAlone: a config we never wrote to must not be
+// touched, and a file that does not exist must not be created.
+func TestUninstall_LeavesAForeignFileAlone(t *testing.T) {
+	const src = "hooks:\n  post_tool_call:\n    - command: \"/x\"\n"
+	path := writeTemp(t, src)
+	changed, err := Uninstall(testConfig(path))
+	if err != nil {
+		t.Fatalf("Uninstall: %v", err)
+	}
+	if changed {
+		t.Error("reported a change against a config with no region of ours")
+	}
+	if got := read(t, path); got != src {
+		t.Errorf("the config was modified:\n%s", got)
+	}
+
+	missing := filepath.Join(t.TempDir(), "nope.yaml")
+	if changed, err := Uninstall(testConfig(missing)); err != nil || changed {
+		t.Errorf("Uninstall on a missing file = (%v, %v), want (false, nil)", changed, err)
+	}
+	if _, err := os.Stat(missing); !os.IsNotExist(err) {
+		t.Error("Uninstall created the file it was asked to clean")
+	}
+}
+
+// TestEnsureInstalled_HandlesTheEmptyFlowMapping pins the one inline value that
+// is modelled — the spelling hermes' own DEFAULT_CONFIG carries — including
+// that a trailing comment on that line rides along.
+func TestEnsureInstalled_HandlesTheEmptyFlowMapping(t *testing.T) {
+	const src = "model:\n  default: \"x\"\nhooks: {}   # none yet\nother: 1\n"
+	path := writeTemp(t, src)
+	if _, err := EnsureInstalled(testConfig(path)); err != nil {
+		t.Fatalf("EnsureInstalled: %v", err)
+	}
+	got := read(t, path)
+	if strings.Contains(got, "hooks: {}") {
+		t.Errorf("the flow mapping was not replaced:\n%s", got)
+	}
+	if !strings.Contains(got, "hooks:   # none yet\n") {
+		t.Errorf("the trailing comment was dropped:\n%s", got)
+	}
+	if !strings.Contains(got, "other: 1\n") {
+		t.Errorf("the following key was lost:\n%s", got)
+	}
+}
+
+// TestInspect_ReportsPresenceAndCanonicality is the read-only half every
+// adapter's Verify sits on.
+func TestInspect_ReportsPresenceAndCanonicality(t *testing.T) {
+	path := writeTemp(t, "model:\n  default: \"x\"\n")
+	cfg := testConfig(path)
+
+	present, canonical, err := Inspect(cfg)
+	if err != nil || present || canonical {
+		t.Fatalf("before install: (%v, %v, %v), want (false, false, nil)", present, canonical, err)
+	}
+	if _, err := EnsureInstalled(cfg); err != nil {
+		t.Fatalf("install: %v", err)
+	}
+	present, canonical, err = Inspect(cfg)
+	if err != nil || !present || !canonical {
+		t.Fatalf("after install: (%v, %v, %v), want (true, true, nil)", present, canonical, err)
+	}
+
+	stale := cfg
+	stale.Entries = append([]Entry(nil), cfg.Entries...)
+	stale.Entries[0].Command = "/bin/sh -c 'different hook-post x'"
+	present, canonical, err = Inspect(stale)
+	if err != nil || !present || canonical {
+		t.Fatalf("against a changed command: (%v, %v, %v), want (true, false, nil)", present, canonical, err)
+	}
+}
+
+// TestRefusals is the corpus of documents this package will not edit. Each row
+// is a shape whose correct edit is not obvious, so guessing at one is how a
+// user's config gets corrupted — and each must name its line, because #1362
+// renders the message to the user.
+//
+// The `want` half of this table is the mutation evidence for the scanner: a
+// scanner that stopped refusing would silently start editing one of these.
+func TestRefusals(t *testing.T) {
+	cases := []struct {
+		name     string
+		src      string
+		wantLine int
+		wantWord string
+	}{
+		{
+			name:     "a tab in the indentation",
+			src:      "model:\n\tdefault: x\n",
+			wantLine: 2, wantWord: "tab",
+		},
+		{
+			name:     "a document marker",
+			src:      "---\nmodel: x\n",
+			wantLine: 1, wantWord: "document marker",
+		},
+		{
+			name:     "a second hooks key",
+			src:      "hooks:\n  a:\n    - command: \"x\"\nmodel: y\nhooks:\n  b:\n    - command: \"z\"\n",
+			wantLine: 5, wantWord: "second top-level",
+		},
+		{
+			name:     "an inline value that is not {}",
+			src:      "hooks: {on_session_end: []}\n",
+			wantLine: 1, wantWord: "inline value",
+		},
+		{
+			name:     "hooks is an alias",
+			src:      "hooks: *shared\n",
+			wantLine: 1, wantWord: "inline value",
+		},
+		{
+			name:     "a root-level sequence",
+			src:      "- one\n- two\n",
+			wantLine: 1, wantWord: "not a key",
+		},
+		{
+			name:     "the hooks block is a sequence",
+			src:      "hooks:\n  - command: \"x\"\n",
+			wantLine: 2, wantWord: "sequence, not a mapping",
+		},
+		{
+			name:     "a merge key inside the block",
+			src:      "hooks:\n  <<: *defaults\n",
+			wantLine: 2, wantWord: "merge key",
+		},
+		{
+			name:     "an event whose value is an anchor",
+			src:      "hooks:\n  post_tool_call: &shared\n    - command: \"x\"\n",
+			wantLine: 2, wantWord: "anchor or alias",
+		},
+		{
+			name:     "an event whose value is a block scalar",
+			src:      "hooks:\n  post_tool_call: |\n    not entries\n",
+			wantLine: 2, wantWord: "block scalar",
+		},
+		{
+			name:     "an unterminated region",
+			src:      "hooks:\n  " + BeginMarker(testOwner) + "\n  a:\n    - command: \"x\"\n",
+			wantLine: 2, wantWord: "no matching END",
+		},
+		{
+			name:     "an END with no BEGIN",
+			src:      "hooks:\n  " + EndMarker(testOwner) + "\n",
+			wantLine: 2, wantWord: "no BEGIN",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			path := writeTemp(t, tc.src)
+			_, err := EnsureInstalled(testConfig(path))
+			if err == nil {
+				t.Fatalf("EnsureInstalled accepted a document it cannot model:\n%s", tc.src)
+			}
+			var unsafe *UnsafeConstructError
+			if !errors.As(err, &unsafe) {
+				t.Fatalf("error is %T (%v), want *UnsafeConstructError", err, err)
+			}
+			if unsafe.Line != tc.wantLine {
+				t.Errorf("reported line %d, want %d (%v)", unsafe.Line, tc.wantLine, err)
+			}
+			if !strings.Contains(unsafe.Message, tc.wantWord) {
+				t.Errorf("message %q does not mention %q", unsafe.Message, tc.wantWord)
+			}
+			if got := read(t, path); got != tc.src {
+				t.Errorf("a refused document was still modified:\n%s", got)
+			}
+		})
+	}
+}
+
+// TestCollisionIsRefusedByName is separate from TestRefusals because the
+// document is perfectly well formed: the conflict is semantic. A YAML mapping
+// cannot hold the key twice and yaml.safe_load resolves a duplicate silently to
+// the LAST one, so writing ours beside theirs would delete their hook with no
+// error anywhere.
+func TestCollisionIsRefusedByName(t *testing.T) {
+	src := "hooks:\n  on_session_end:\n    - command: \"/theirs\"\n"
+	path := writeTemp(t, src)
+
+	_, err := EnsureInstalled(testConfig(path))
+	var collision *CollisionError
+	if !errors.As(err, &collision) {
+		t.Fatalf("error is %T (%v), want *CollisionError", err, err)
+	}
+	if collision.Event != "on_session_end" {
+		t.Errorf("Event = %q, want on_session_end", collision.Event)
+	}
+	if collision.Line != 2 {
+		t.Errorf("Line = %d, want 2", collision.Line)
+	}
+	if got := read(t, path); got != src {
+		t.Errorf("a refused install still modified the config:\n%s", got)
+	}
+}
+
+// TestQuoteIsAYAMLDoubleQuotedScalar pins the escaping. The command embeds an
+// absolute path the user chose, so a quote, a backslash, a leading `-` or a
+// `#` must not be able to end the scalar or turn the line into a comment.
+func TestQuoteIsAYAMLDoubleQuotedScalar(t *testing.T) {
+	cases := map[string]string{
+		`plain`:            `"plain"`,
+		`has "quote"`:      `"has \"quote\""`,
+		`back\slash`:       `"back\\slash"`,
+		"tab\there":        `"tab\there"`,
+		"nl\nhere":         `"nl\nhere"`,
+		`# not a comment`:  `"# not a comment"`,
+		"-leading":         `"-leading"`,
+		"ctrl\x01char":     `"ctrl\x01char"`,
+		"unicode ünïcødé":  `"unicode ünïcødé"`,
+		`both "\ together`: `"both \"\\ together"`,
+	}
+	for in, want := range cases {
+		if got := Quote(in); got != want {
+			t.Errorf("Quote(%q) = %s, want %s", in, got, want)
+		}
+	}
+}
+
+// TestRenderRegion_RefusesAnEmptyOrUnnamedRegion is the loud-failure rule: a
+// caller that supplied nothing must not produce an empty marker pair that later
+// reads as a healthy install.
+func TestRenderRegion_RefusesAnEmptyOrUnnamedRegion(t *testing.T) {
+	if _, err := renderRegion(Config{Owner: testOwner}, 2); err == nil {
+		t.Error("rendered a region with no entries")
+	}
+	if _, err := renderRegion(Config{Entries: []Entry{{Event: "e", Command: "c"}}}, 2); err == nil {
+		t.Error("rendered a region with no owner")
+	}
+	if _, err := renderRegion(Config{Owner: testOwner, Entries: []Entry{{Event: "not a key", Command: "c"}}}, 2); err == nil {
+		t.Error("rendered a region with an event name that is not a plain YAML key")
+	}
+	if _, err := renderRegion(Config{Owner: testOwner, Entries: []Entry{{Event: "e"}}}, 2); err == nil {
+		t.Error("rendered a region with an empty command")
+	}
+}

--- a/core/adapters/inbound/agents/hookyaml/hookyaml_test.go
+++ b/core/adapters/inbound/agents/hookyaml/hookyaml_test.go
@@ -395,3 +395,101 @@ func TestRenderRegion_RefusesAnEmptyOrUnnamedRegion(t *testing.T) {
 		t.Error("rendered a region with an empty command")
 	}
 }
+
+// TestSentinelRecoversFromACommentStrippingRewrite is the unit-level statement
+// of what Config.Sentinel is for.
+//
+// An agent that re-serializes its own config from a parsed structure keeps the
+// data and drops every comment — and the region markers ARE comments. Without
+// the sentinel the surviving entries read as a user's colliding hooks (install
+// refuses forever) and uninstall finds nothing to remove (the entries stay in
+// the user's config with no supported way to take them out).
+func TestSentinelRecoversFromACommentStrippingRewrite(t *testing.T) {
+	cfg := testConfig("")
+	cfg.Sentinel = "hook-post x"
+
+	// What the agent's writer leaves: our two events, our command, no markers,
+	// beside a hook the user owns.
+	const stripped = `model:
+  default: "x"
+hooks:
+  post_tool_call:
+    - command: "/usr/local/bin/theirs"
+  on_session_end:
+    - command: "/bin/sh -c 'beacon hook-post x'"
+      timeout: 2
+  pre_approval_request:
+    - command: "/bin/sh -c 'beacon hook-post x'"
+      timeout: 2
+`
+	t.Run("install recovers rather than colliding with itself", func(t *testing.T) {
+		path := writeTemp(t, stripped)
+		c := cfg
+		c.Path = path
+		changed, err := EnsureInstalled(c)
+		if err != nil {
+			t.Fatalf("EnsureInstalled: %v", err)
+		}
+		if !changed {
+			t.Error("reported no change while the markers were missing")
+		}
+		got := read(t, path)
+		if n := strings.Count(got, BeginMarker(testOwner)); n != 1 {
+			t.Errorf("found %d regions, want 1:\n%s", n, got)
+		}
+		for _, event := range []string{"on_session_end", "pre_approval_request"} {
+			if n := strings.Count(got, "\n  "+event+":"); n != 1 {
+				t.Errorf("event %q appears %d times, want 1 — a duplicate YAML key keeps only one:\n%s", event, n, got)
+			}
+		}
+		if !strings.Contains(got, `- command: "/usr/local/bin/theirs"`) {
+			t.Errorf("the user's own hook was removed:\n%s", got)
+		}
+	})
+
+	t.Run("uninstall removes them without the markers", func(t *testing.T) {
+		path := writeTemp(t, stripped)
+		c := cfg
+		c.Path = path
+		changed, err := Uninstall(c)
+		if err != nil {
+			t.Fatalf("Uninstall: %v", err)
+		}
+		if !changed {
+			t.Fatal("found nothing to remove — the entries would stay in the user's config forever")
+		}
+		got := read(t, path)
+		if strings.Contains(got, c.Sentinel) {
+			t.Errorf("an entry of ours survived:\n%s", got)
+		}
+		if !strings.Contains(got, `- command: "/usr/local/bin/theirs"`) {
+			t.Errorf("the user's own hook was removed:\n%s", got)
+		}
+	})
+
+	t.Run("inspect calls them present but not canonical", func(t *testing.T) {
+		path := writeTemp(t, stripped)
+		c := cfg
+		c.Path = path
+		present, canonical, err := Inspect(c)
+		if err != nil {
+			t.Fatalf("Inspect: %v", err)
+		}
+		if !present {
+			t.Error("reported absent — uninstall would then have nothing to look for")
+		}
+		if canonical {
+			t.Error("reported canonical — #1372's verifier would never restore the markers")
+		}
+	})
+
+	t.Run("an empty sentinel disables recovery", func(t *testing.T) {
+		path := writeTemp(t, stripped)
+		c := cfg
+		c.Path = path
+		c.Sentinel = ""
+		if _, err := EnsureInstalled(c); err == nil {
+			t.Error("an empty sentinel silently recovered anyway — the opt-in is the vacuity guard for every arm above")
+		}
+	})
+}

--- a/core/adapters/inbound/agents/hookyaml/property_test.go
+++ b/core/adapters/inbound/agents/hookyaml/property_test.go
@@ -30,6 +30,10 @@
 //     though the region itself is written with LF.
 //  7. The number of USER event keys already in the block (0-3), drawn from
 //     names that never collide with the region's own.
+//  8. STRAY entries: entries carrying the owner's sentinel with no markers
+//     around them, which is what the agent's own config writer leaves behind
+//     when it re-serializes the document from a parsed dict and drops every
+//     comment. Those must be recovered, not read as a user's colliding hooks.
 //
 // # Which properties survive which mutation
 //
@@ -136,6 +140,7 @@ var requiredAxes = []string{
 	"CRLF line endings",
 	"no trailing newline",
 	"block is the last top-level key",
+	"stray sentinel-bearing entries (markers dropped by the agent's own writer)",
 }
 
 func assertEveryAxisWasExercised(t *testing.T, census map[string]int) {
@@ -175,6 +180,9 @@ func (d document9) recordAxes(census map[string]int) {
 	if d.blockIsLast {
 		census["block is the last top-level key"]++
 	}
+	if d.hasStrays {
+		census["stray sentinel-bearing entries (markers dropped by the agent's own writer)"]++
+	}
 }
 
 // propertyConfig varies the region's own contents too: one to three entries,
@@ -197,8 +205,12 @@ func propertyConfig(path string, rng *rand.Rand) Config {
 		}
 		entries = append(entries, e)
 	}
-	return Config{Path: path, BlockKey: testBlock, Owner: testOwner, Entries: entries}
+	return Config{Path: path, BlockKey: testBlock, Owner: testOwner, Entries: entries, Sentinel: testSentinel}
 }
+
+// testSentinel is the substring every command above carries. It stands in for
+// the beacon sentinel a real adapter passes.
+const testSentinel = "hook-post hermes"
 
 // --- the operations ---
 
@@ -227,7 +239,56 @@ func opInstall(t *testing.T, cfg Config, doc document9, _ int) bool {
 		return unchangedOnDisk(t, cfg, doc)
 	}
 	out := mustRead(t, cfg.Path)
+	if doc.hasStrays {
+		// The line-preservation claim does not hold for a recovery: the stray
+		// entries are deliberately REMOVED. What must hold instead is that
+		// nothing of ours survives outside the region, and that the user's own
+		// keys are untouched — asserted here rather than folded into
+		// wantRoundTrip, because pretending a recovery is a no-op edit is the
+		// kind of blanket property that produces false failures.
+		return assertStraysRecovered(t, cfg, doc, out)
+	}
 	return assertOnlyTheRegionWasAdded(t, cfg, doc, out)
+}
+
+// assertStraysRecovered is opInstall's claim for a document the agent's own
+// writer had stripped: exactly one region, every event named once (a duplicate
+// YAML key silently keeps only one), and the user's own keys still there.
+func assertStraysRecovered(t *testing.T, cfg Config, doc document9, out string) bool {
+	t.Helper()
+	if n := strings.Count(out, BeginMarker(cfg.Owner)); n != 1 {
+		t.Errorf("found %d regions after recovery, want 1:\n%s", n, out)
+		return false
+	}
+	// Counted as KEY LINES rather than at a fixed indent: when the strays were
+	// the block's only content the block empties out, so the region is
+	// rendered at the default indent rather than the one the strays sat at.
+	// That is correct, and an indent-pinned assertion reported it as a
+	// disappearing event.
+	for _, e := range cfg.Entries {
+		if n := countKeyLines(out, e.Event); n != 1 {
+			t.Errorf("event %q appears as a key %d times after recovery, want 1 — a duplicate YAML key keeps only one:\n%s", e.Event, n, out)
+			return false
+		}
+	}
+	for _, declared := range doc.declaredEvents {
+		if countKeyLines(out, declared) != 1 {
+			t.Errorf("the user's own event %q was removed by the recovery:\n%s", declared, out)
+			return false
+		}
+	}
+	return true
+}
+
+// countKeyLines counts lines whose whole content is `<name>:`.
+func countKeyLines(out, name string) int {
+	n := 0
+	for _, line := range strings.Split(out, "\n") {
+		if strings.TrimSpace(strings.TrimRight(line, "\r")) == name+":" {
+			n++
+		}
+	}
+	return n
 }
 
 // opInstallTwice asserts idempotence — the second call must report no change
@@ -274,6 +335,16 @@ func opRoundTrip(t *testing.T, cfg Config, doc document9, i int) bool {
 		return false
 	}
 	got := mustRead(t, cfg.Path)
+	if doc.hasStrays {
+		// A recovery is not reversible by definition — the strays were ours
+		// and are gone. What uninstall owes here is that NOTHING of ours is
+		// left, which is the property the sentinel exists for.
+		if strings.Contains(got, cfg.Sentinel) {
+			t.Errorf("an entry of ours survived uninstall:\n%s", got)
+			return false
+		}
+		return true
+	}
 	if want := doc.wantRoundTrip(); got != want {
 		t.Errorf("round trip is not the original:\n--- got ---\n%q\n--- want ---\n%q", got, want)
 		return false
@@ -290,6 +361,20 @@ func opUninstallOnly(t *testing.T, cfg Config, doc document9, _ int) bool {
 	if err != nil {
 		t.Errorf("uninstall: %v", err)
 		return false
+	}
+	if doc.hasStrays {
+		// Not "no region of ours" at all: the entries are ours, only the
+		// markers are gone. Uninstall must still take them out — that is the
+		// half of the sentinel that keeps an install removable.
+		if !changed {
+			t.Error("uninstall found nothing to remove in a document holding our own marker-less entries")
+			return false
+		}
+		if got := mustRead(t, cfg.Path); strings.Contains(got, cfg.Sentinel) {
+			t.Errorf("an entry of ours survived uninstall:\n%s", got)
+			return false
+		}
+		return true
 	}
 	if changed {
 		t.Error("uninstall reported a change against a document holding no region of ours")
@@ -459,6 +544,9 @@ type document9 struct {
 	// install turns it into — the property the round trip is graded against
 	// for that one shape.
 	keyLine, normalizedKeyLine string
+	// hasStrays records that the block holds sentinel-bearing entries with no
+	// markers — the state the agent's own config writer leaves behind.
+	hasStrays bool
 	// blockIsLast records that no top-level key follows the block, which is
 	// the case with nothing to terminate it.
 	blockIsLast bool
@@ -618,13 +706,36 @@ func writeBlock(b *strings.Builder, rng *rand.Rand, nl string, mode int, doc *do
 		if rng.Intn(3) == 0 {
 			b.WriteString(pad + "# my own hooks" + nl)
 		}
+		// used keeps the generated block a legal YAML mapping. Without it a
+		// stray and a user entry can pick the same event name, which is a
+		// duplicate key — a malformed FIXTURE, and every assertion downstream
+		// would then be grading the wrong thing.
+		used := map[string]bool{}
 		n := 1 + rng.Intn(3)
 		for i := 0; i < n; i++ {
-			event := userEvents[rng.Intn(len(userEvents))]
-			// One document in six declares one of OUR events, which is what
-			// exercises the collision refusal.
+			// One entry in five is a STRAY: ours, sentinel and all, with the
+			// markers gone — the state the agent's own config writer leaves
+			// behind. It is NOT recorded in declaredEvents, because it is not
+			// a user key and must not be read as a collision.
+			if rng.Intn(5) == 0 {
+				event := pickUnused(rng, regionEvents, used)
+				if event == "" {
+					continue
+				}
+				doc.hasStrays = true
+				b.WriteString(pad + event + ":" + nl)
+				b.WriteString(pad + pad + `- command: "/bin/sh -c '/opt/irrlichd ` + testSentinel + `'"` + nl)
+				continue
+			}
+			// One entry in six declares one of OUR event names as a user hook,
+			// which is what exercises the collision refusal.
+			pool := userEvents
 			if rng.Intn(6) == 0 {
-				event = regionEvents[rng.Intn(len(regionEvents))]
+				pool = regionEvents
+			}
+			event := pickUnused(rng, pool, used)
+			if event == "" {
+				continue
 			}
 			doc.declaredEvents = append(doc.declaredEvents, event)
 			b.WriteString(pad + event + ":" + nl)
@@ -637,6 +748,20 @@ func writeBlock(b *strings.Builder, rng *rand.Rand, nl string, mode int, doc *do
 			}
 		}
 	}
+}
+
+// pickUnused returns a name from pool that this block has not used yet, or ""
+// when every one is taken.
+func pickUnused(rng *rand.Rand, pool []string, used map[string]bool) string {
+	start := rng.Intn(len(pool))
+	for i := range pool {
+		name := pool[(start+i)%len(pool)]
+		if !used[name] {
+			used[name] = true
+			return name
+		}
+	}
+	return ""
 }
 
 // filler renders one non-block top-level section. Between them the six shapes

--- a/core/adapters/inbound/agents/hookyaml/property_test.go
+++ b/core/adapters/inbound/agents/hookyaml/property_test.go
@@ -681,72 +681,92 @@ func generateDocument(rng *rand.Rand) document9 {
 }
 
 func writeBlock(b *strings.Builder, rng *rand.Rand, nl string, mode int, doc *document9) {
+	doc.hasBlock = mode != 0
 	switch mode {
 	case 1:
-		doc.hasBlock = true
 		b.WriteString("hooks:" + nl)
 	case 2:
-		doc.hasBlock = true
-		doc.flowEmpty = true
-		doc.keyLine, doc.normalizedKeyLine = "hooks: {}"+nl, "hooks:"+nl
-		if rng.Intn(2) == 0 {
-			doc.keyLine = "hooks: {}   # nothing configured" + nl
-			doc.normalizedKeyLine = "hooks:   # nothing configured" + nl
-		}
-		b.WriteString(doc.keyLine)
+		writeFlowEmptyBlock(b, rng, nl, doc)
 	case 3:
-		doc.hasBlock = true
-		indent := 2
-		if rng.Intn(2) == 0 {
-			indent = 4
+		writePopulatedBlock(b, rng, nl, doc)
+	}
+}
+
+// writeFlowEmptyBlock emits `hooks: {}`, the spelling an agent's own defaults
+// carry, half the time with a trailing comment — the two strings the round
+// trip is graded against for that shape.
+func writeFlowEmptyBlock(b *strings.Builder, rng *rand.Rand, nl string, doc *document9) {
+	doc.flowEmpty = true
+	doc.keyLine, doc.normalizedKeyLine = "hooks: {}"+nl, "hooks:"+nl
+	if rng.Intn(2) == 0 {
+		doc.keyLine = "hooks: {}   # nothing configured" + nl
+		doc.normalizedKeyLine = "hooks:   # nothing configured" + nl
+	}
+	b.WriteString(doc.keyLine)
+}
+
+// writePopulatedBlock emits a block holding one to three entries, each either
+// a user hook or one of OUR entries with the markers gone.
+func writePopulatedBlock(b *strings.Builder, rng *rand.Rand, nl string, doc *document9) {
+	indent := 2
+	if rng.Intn(2) == 0 {
+		indent = 4
+	}
+	doc.blockIndent = indent
+	pad := strings.Repeat(" ", indent)
+	b.WriteString("hooks:" + nl)
+	if rng.Intn(3) == 0 {
+		b.WriteString(pad + "# my own hooks" + nl)
+	}
+
+	// used keeps the generated block a legal YAML mapping. Without it a stray
+	// and a user entry can pick the same event name, which is a duplicate
+	// key — a malformed FIXTURE, and every assertion downstream would then be
+	// grading the wrong thing.
+	used := map[string]bool{}
+	n := 1 + rng.Intn(3)
+	for i := 0; i < n; i++ {
+		// One entry in five is a STRAY: ours, sentinel and all, with the
+		// markers gone — the state the agent's own config writer leaves
+		// behind. It is NOT recorded in declaredEvents, because it is not a
+		// user key and must not be read as a collision.
+		if rng.Intn(5) == 0 {
+			writeStrayEntry(b, rng, nl, pad, used, doc)
+			continue
 		}
-		doc.blockIndent = indent
-		pad := strings.Repeat(" ", indent)
-		b.WriteString("hooks:" + nl)
-		if rng.Intn(3) == 0 {
-			b.WriteString(pad + "# my own hooks" + nl)
-		}
-		// used keeps the generated block a legal YAML mapping. Without it a
-		// stray and a user entry can pick the same event name, which is a
-		// duplicate key — a malformed FIXTURE, and every assertion downstream
-		// would then be grading the wrong thing.
-		used := map[string]bool{}
-		n := 1 + rng.Intn(3)
-		for i := 0; i < n; i++ {
-			// One entry in five is a STRAY: ours, sentinel and all, with the
-			// markers gone — the state the agent's own config writer leaves
-			// behind. It is NOT recorded in declaredEvents, because it is not
-			// a user key and must not be read as a collision.
-			if rng.Intn(5) == 0 {
-				event := pickUnused(rng, regionEvents, used)
-				if event == "" {
-					continue
-				}
-				doc.hasStrays = true
-				b.WriteString(pad + event + ":" + nl)
-				b.WriteString(pad + pad + `- command: "/bin/sh -c '/opt/irrlichd ` + testSentinel + `'"` + nl)
-				continue
-			}
-			// One entry in six declares one of OUR event names as a user hook,
-			// which is what exercises the collision refusal.
-			pool := userEvents
-			if rng.Intn(6) == 0 {
-				pool = regionEvents
-			}
-			event := pickUnused(rng, pool, used)
-			if event == "" {
-				continue
-			}
-			doc.declaredEvents = append(doc.declaredEvents, event)
-			b.WriteString(pad + event + ":" + nl)
-			b.WriteString(pad + pad + `- command: "/usr/local/bin/tool --flag # not a comment"` + nl)
-			if rng.Intn(2) == 0 {
-				b.WriteString(pad + pad + "  timeout: 30" + nl)
-			}
-			if rng.Intn(4) == 0 {
-				b.WriteString(nl)
-			}
-		}
+		writeUserEntry(b, rng, nl, pad, used, doc)
+	}
+}
+
+func writeStrayEntry(b *strings.Builder, rng *rand.Rand, nl, pad string, used map[string]bool, doc *document9) {
+	event := pickUnused(rng, regionEvents, used)
+	if event == "" {
+		return
+	}
+	doc.hasStrays = true
+	b.WriteString(pad + event + ":" + nl)
+	b.WriteString(pad + pad + `- command: "/bin/sh -c '/opt/irrlichd ` + testSentinel + `'"` + nl)
+}
+
+func writeUserEntry(b *strings.Builder, rng *rand.Rand, nl, pad string, used map[string]bool, doc *document9) {
+	// One entry in six declares one of OUR event names as a user hook, which
+	// is what exercises the collision refusal.
+	pool := userEvents
+	if rng.Intn(6) == 0 {
+		pool = regionEvents
+	}
+	event := pickUnused(rng, pool, used)
+	if event == "" {
+		return
+	}
+	doc.declaredEvents = append(doc.declaredEvents, event)
+	b.WriteString(pad + event + ":" + nl)
+	b.WriteString(pad + pad + `- command: "/usr/local/bin/tool --flag # not a comment"` + nl)
+	if rng.Intn(2) == 0 {
+		b.WriteString(pad + pad + "  timeout: 30" + nl)
+	}
+	if rng.Intn(4) == 0 {
+		b.WriteString(nl)
 	}
 }
 

--- a/core/adapters/inbound/agents/hookyaml/property_test.go
+++ b/core/adapters/inbound/agents/hookyaml/property_test.go
@@ -1,0 +1,673 @@
+// property_test.go is this package's answer to AGENTS.md's rule that "code
+// that emits bytes from a structural diff gets a property test". Hand-written
+// cases encode what the author already thought of, which is the same set they
+// got right; hookjson's splicer shipped with seven green round-trip tests and a
+// defect writing `,,` into ~11% of randomly shaped documents.
+//
+// # Which structural axes the generator varies
+//
+// Naming them is half the value, because a generator that varies only the axis
+// the author thought of is the same vacuous green wearing a different hat —
+// hookjson's own first draft mutated only object members and never produced the
+// multi-item removal its production path performs. These are the axes here, and
+// each is a shape a real hermes config.yaml takes:
+//
+//  1. WHETHER the target block exists, and in which of the three modelled
+//     forms: absent, present-and-empty (`hooks:` with nothing under it),
+//     present as the empty flow mapping (`hooks: {}`, the spelling hermes' own
+//     DEFAULT_CONFIG carries), or present with user event keys.
+//  2. The INDENT of the block's own keys — 2 or 4 spaces — which the region has
+//     to adopt rather than impose.
+//  3. WHERE the block sits: first, in the middle, or last among the top-level
+//     keys. Last is the case with no following key to terminate the block.
+//  4. The SURROUNDING content: scalars, nested mappings, block sequences,
+//     dotted keys, quoted values carrying `#` and `:`, standalone comments at
+//     column 0 and inside a nested mapping, trailing comments, and blank lines.
+//  5. The TRAILING NEWLINE, present or absent — a file that does not end in one
+//     is where an append is most likely to fuse two lines together.
+//  6. The LINE ENDING, LF or CRLF. The scanner keeps each original line's bytes
+//     exactly as they were, so a CRLF document must round-trip unchanged even
+//     though the region itself is written with LF.
+//  7. The number of USER event keys already in the block (0-3), drawn from
+//     names that never collide with the region's own.
+//
+// # Which properties survive which mutation
+//
+// Stated per assertion below rather than as one blanket claim, because they are
+// not all the same. Round-tripping is exact for install-then-uninstall.
+// Preservation is exact for install alone in the sense that the ONLY lines the
+// output adds are the region's (plus at most one synthesized `hooks:` line) —
+// but it is NOT "the output contains the input as a substring", since a `{}`
+// install rewrites one line in place.
+package hookyaml
+
+import (
+	"fmt"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// propertyIterations is committed small enough to stay in the suite (2000
+// documents, ~0.3s). A much larger sweep was run locally before landing —
+// 40,000 iterations across seeds 1, 2, 999, 424242, 31337 and this one, 240,000
+// documents in total, all green — and that sweep is reproduced by editing the
+// two constants below, which is why they are constants rather than literals.
+//
+// The committed run is not decoration: this generator found three real defects
+// in the package while it was being written, and the third is the one that
+// justifies the axis census below.
+//
+//  1. Uninstall deleted a `hooks:` key the USER had written, because the first
+//     draft cleaned up any block it left empty (iteration 1).
+//  2. The `hooks: {}` rewrite emitted an LF into a CRLF document, changing a
+//     line it promises only to normalize (iteration 78).
+//  3. A block key that is the file's LAST line with no final newline had the
+//     BEGIN marker spliced onto it as a trailing comment. The document still
+//     parses, so nothing complains — and the marker is no longer a line, so
+//     uninstall can never find the region again and the install is permanent.
+//     That position existed in this file's stated axis list but the generator
+//     never produced it: `writeBlock` ran inside the rendering loop and one
+//     more filler section was always written after it. The census reported
+//     `block is the last top-level key   0 of 2000` on its very first run,
+//     which is the whole argument for counting what was produced rather than
+//     trusting the list.
+const propertyIterations = 2000
+
+// propertySeed is fixed so a failure reproduces exactly.
+const propertySeed = 17221722
+
+// TestSplice_PropertyRandomDocuments generates a random document, applies a
+// random operation, and asserts the properties above.
+func TestSplice_PropertyRandomDocuments(t *testing.T) {
+	rng := rand.New(rand.NewSource(propertySeed)) // #nosec G404 -- a deterministic generator, not a security primitive
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+
+	census := map[string]int{}
+	installed, refused := 0, 0
+	for i := 0; i < propertyIterations; i++ {
+		doc := generateDocument(rng)
+		doc.recordAxes(census)
+		op := operations[rng.Intn(len(operations))]
+
+		if err := os.WriteFile(path, []byte(doc.text), 0o600); err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+		cfg := propertyConfig(path, rng)
+
+		doc.collides = collides(doc, cfg)
+
+		ok := op.run(t, cfg, doc, i)
+		if !ok {
+			t.Fatalf("iteration %d, operation %q, seed %d\n--- document ---\n%s\n--- end ---",
+				i, op.name, propertySeed, doc.text)
+		}
+		if doc.collides {
+			refused++
+		} else {
+			installed++
+		}
+	}
+
+	census["installed"], census["refused"] = installed, refused
+	assertEveryAxisWasExercised(t, census)
+}
+
+// requiredAxes is the census this generator must produce, in the vocabulary of
+// the code under test rather than of YAML. A generator can stop emitting a
+// construct entirely — one character in an `rng.Intn` threshold does it — and a
+// mechanism that silently stops running must fail loudly, so the counts are
+// printed on every run and a zero is an error.
+//
+// "installed" and "refused" are the two branches of the collision decision:
+// without both, every property above is graded on one of them, and the refusal
+// branch is where a wrong answer silently disables the whole install.
+var requiredAxes = []string{
+	"installed",
+	"refused",
+	"block absent (the region owns the key)",
+	"block present and empty",
+	"block present as the empty flow mapping",
+	"block present with user event keys",
+	"block content at indent 4",
+	"CRLF line endings",
+	"no trailing newline",
+	"block is the last top-level key",
+}
+
+func assertEveryAxisWasExercised(t *testing.T, census map[string]int) {
+	t.Helper()
+	for _, axis := range requiredAxes {
+		t.Logf("axis %-45s %5d of %d documents", axis, census[axis], propertyIterations)
+	}
+	for _, axis := range requiredAxes {
+		if census[axis] == 0 {
+			t.Errorf("the generator produced no document exercising %q — that axis is claimed "+
+				"in this file's header and graded by nothing", axis)
+		}
+	}
+}
+
+// recordAxes counts the structural axes one generated document exercises.
+func (d document9) recordAxes(census map[string]int) {
+	switch {
+	case !d.hasBlock:
+		census["block absent (the region owns the key)"]++
+	case d.flowEmpty:
+		census["block present as the empty flow mapping"]++
+	case len(d.declaredEvents) > 0:
+		census["block present with user event keys"]++
+	default:
+		census["block present and empty"]++
+	}
+	if d.blockIndent == 4 {
+		census["block content at indent 4"]++
+	}
+	if strings.Contains(d.text, "\r\n") {
+		census["CRLF line endings"]++
+	}
+	if d.text != "" && !strings.HasSuffix(d.text, "\n") {
+		census["no trailing newline"]++
+	}
+	if d.blockIsLast {
+		census["block is the last top-level key"]++
+	}
+}
+
+// propertyConfig varies the region's own contents too: one to three entries,
+// with and without a timeout, and a command carrying the characters most likely
+// to break a YAML scalar.
+func propertyConfig(path string, rng *rand.Rand) Config {
+	commands := []string{
+		`/bin/sh -c '/usr/local/bin/irrlichd --version hook-post hermes >/dev/null || true'`,
+		`/bin/sh -c '/Users/o'\''brien/my apps/irrlichd hook-post hermes'`,
+		`/bin/sh -c '/w#eird/ir:rlichd hook-post hermes'`,
+		`/back\slash/irrlichd hook-post hermes`,
+	}
+	events := []string{"on_session_end", "pre_approval_request", "post_approval_response"}
+	n := 1 + rng.Intn(len(events))
+	entries := make([]Entry, 0, n)
+	for i := 0; i < n; i++ {
+		e := Entry{Event: events[i], Command: commands[rng.Intn(len(commands))]}
+		if rng.Intn(2) == 0 {
+			e.TimeoutSeconds = 1 + rng.Intn(5)
+		}
+		entries = append(entries, e)
+	}
+	return Config{Path: path, BlockKey: testBlock, Owner: testOwner, Entries: entries}
+}
+
+// --- the operations ---
+
+type operation struct {
+	name string
+	run  func(t *testing.T, cfg Config, doc document9, i int) bool
+}
+
+var operations = []operation{
+	{name: "install", run: opInstall},
+	{name: "install twice", run: opInstallTwice},
+	{name: "install then uninstall", run: opRoundTrip},
+	{name: "uninstall without install", run: opUninstallOnly},
+}
+
+// opInstall asserts the preservation property: the only lines the output adds
+// are the region's, plus at most one synthesized block key, and every other
+// line survives in its original order and its original bytes.
+func opInstall(t *testing.T, cfg Config, doc document9, _ int) bool {
+	t.Helper()
+	changed, err := EnsureInstalled(cfg)
+	if !expectOutcome(t, doc, changed, err, true) {
+		return false
+	}
+	if doc.collides {
+		return unchangedOnDisk(t, cfg, doc)
+	}
+	out := mustRead(t, cfg.Path)
+	return assertOnlyTheRegionWasAdded(t, cfg, doc, out)
+}
+
+// opInstallTwice asserts idempotence — the second call must report no change
+// and leave the bytes alone. Without it a splicer that appends rather than
+// replaces looks correct after one run.
+func opInstallTwice(t *testing.T, cfg Config, doc document9, i int) bool {
+	t.Helper()
+	if !opInstall(t, cfg, doc, i) {
+		return false
+	}
+	if doc.collides {
+		return true
+	}
+	first := mustRead(t, cfg.Path)
+	changed, err := EnsureInstalled(cfg)
+	if err != nil {
+		t.Errorf("second install: %v", err)
+		return false
+	}
+	if changed {
+		t.Error("the second install reported a change")
+		return false
+	}
+	if got := mustRead(t, cfg.Path); got != first {
+		t.Errorf("the second install rewrote the file:\n%s", got)
+		return false
+	}
+	return true
+}
+
+// opRoundTrip is the exactness property: install then uninstall must return the
+// original document byte for byte. It is the one that would have caught
+// hookjson's `,,` defect directly.
+func opRoundTrip(t *testing.T, cfg Config, doc document9, i int) bool {
+	t.Helper()
+	if !opInstall(t, cfg, doc, i) {
+		return false
+	}
+	if doc.collides {
+		return true
+	}
+	if _, err := Uninstall(cfg); err != nil {
+		t.Errorf("uninstall: %v", err)
+		return false
+	}
+	got := mustRead(t, cfg.Path)
+	if want := doc.wantRoundTrip(); got != want {
+		t.Errorf("round trip is not the original:\n--- got ---\n%q\n--- want ---\n%q", got, want)
+		return false
+	}
+	return true
+}
+
+// opUninstallOnly asserts that a document with no region of ours is never
+// touched — the property that protects a user who never granted the
+// permission, and the one an over-eager block cleanup breaks.
+func opUninstallOnly(t *testing.T, cfg Config, doc document9, _ int) bool {
+	t.Helper()
+	changed, err := Uninstall(cfg)
+	if err != nil {
+		t.Errorf("uninstall: %v", err)
+		return false
+	}
+	if changed {
+		t.Error("uninstall reported a change against a document holding no region of ours")
+		return false
+	}
+	return unchangedOnDisk(t, cfg, doc)
+}
+
+// --- assertions ---
+
+func expectOutcome(t *testing.T, doc document9, changed bool, err error, wantChange bool) bool {
+	t.Helper()
+	if doc.collides {
+		if err == nil {
+			t.Error("a document already declaring one of the region's events was installed into")
+			return false
+		}
+		return true
+	}
+	if err != nil {
+		t.Errorf("EnsureInstalled: %v", err)
+		return false
+	}
+	if changed != wantChange {
+		t.Errorf("changed = %v, want %v", changed, wantChange)
+		return false
+	}
+	return true
+}
+
+func unchangedOnDisk(t *testing.T, cfg Config, doc document9) bool {
+	t.Helper()
+	if got := mustRead(t, cfg.Path); got != doc.text {
+		t.Errorf("the document was modified:\n--- got ---\n%q\n--- want ---\n%q", got, doc.text)
+		return false
+	}
+	return true
+}
+
+// assertOnlyTheRegionWasAdded is the preservation property, stated as a
+// multiset-and-order claim over LINES rather than as a substring claim: the
+// `{}` case rewrites one line in place, so the input is not always a substring
+// of the output, but every line that is not the region's and not the rewritten
+// block key must survive in order and in its original bytes.
+func assertOnlyTheRegionWasAdded(t *testing.T, cfg Config, doc document9, out string) bool {
+	t.Helper()
+
+	region, err := doc.wantRegion(cfg)
+	if err != nil {
+		t.Errorf("rendering the expected region: %v", err)
+		return false
+	}
+	if !strings.Contains(out, string(region)) {
+		t.Errorf("the rendered region is not present verbatim:\n--- out ---\n%s\n--- region ---\n%s", out, region)
+		return false
+	}
+	if n := strings.Count(out, BeginMarker(cfg.Owner)); n != 1 {
+		t.Errorf("found %d BEGIN markers, want 1:\n%s", n, out)
+		return false
+	}
+
+	survivors := linesOutsideRegion(out, cfg.Owner)
+	original := splitKeepingEndings(doc.text)
+
+	// The block key line is the one line an install may rewrite (the `{}`
+	// form) or add (the absent form). Everything else must match position for
+	// position.
+	oi := 0
+	for _, line := range survivors {
+		if oi < len(original) && line == original[oi] {
+			oi++
+			continue
+		}
+		// A document that did not end in a newline gains one when the region
+		// is appended after it. That is the append doing its job — the
+		// alternative fuses the last key onto the BEGIN marker — so the LAST
+		// original line is allowed to differ by exactly that.
+		if oi == len(original)-1 && line == original[oi]+"\n" {
+			oi++
+			continue
+		}
+		if isBlockKeyLine(line, cfg.BlockKey) {
+			if oi < len(original) && isBlockKeyLine(original[oi], cfg.BlockKey) {
+				oi++
+			}
+			continue
+		}
+		t.Errorf("output line %q is neither an original line in order nor the block key:\n--- out ---\n%s\n--- in ---\n%s",
+			line, out, doc.text)
+		return false
+	}
+	if oi != len(original) {
+		t.Errorf("only %d of %d original lines survived in order:\n--- out ---\n%s\n--- in ---\n%s",
+			oi, len(original), out, doc.text)
+		return false
+	}
+	return true
+}
+
+// linesOutsideRegion returns every line of out that is not inside this owner's
+// marker-delimited region, keeping their line endings.
+func linesOutsideRegion(out, owner string) []string {
+	begin, end := BeginMarker(owner), EndMarker(owner)
+	var kept []string
+	inRegion := false
+	for _, line := range splitKeepingEndings(out) {
+		trimmed := strings.TrimSpace(line)
+		switch {
+		case trimmed == begin:
+			inRegion = true
+		case trimmed == end:
+			inRegion = false
+		case !inRegion:
+			kept = append(kept, line)
+		}
+	}
+	return kept
+}
+
+func isBlockKeyLine(line, blockKey string) bool {
+	t := strings.TrimRight(line, "\r\n")
+	return t == blockKey+":" || strings.HasPrefix(t, blockKey+": ")
+}
+
+func splitKeepingEndings(s string) []string {
+	var out []string
+	for len(s) > 0 {
+		i := strings.IndexByte(s, '\n')
+		if i < 0 {
+			out = append(out, s)
+			break
+		}
+		out = append(out, s[:i+1])
+		s = s[i+1:]
+	}
+	return out
+}
+
+func mustRead(t *testing.T, path string) string {
+	t.Helper()
+	b, err := os.ReadFile(path) // #nosec G304 -- the temp path this test created
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	return string(b)
+}
+
+// --- the generator ---
+
+// document9 is a generated document plus what the properties need to know
+// about it. Named for the nine-ish axes above rather than "document", which is
+// this package's own production type.
+type document9 struct {
+	text string
+	// collides is derived per iteration from declaredEvents and the config
+	// actually being installed; see collides.
+	collides bool
+	// hasBlock reports that the document already carries the target key, so
+	// the install merges into it rather than creating (and owning) it.
+	hasBlock bool
+	// blockIndent is the indent the block's own keys sit at, or 0 when the
+	// block is absent or empty.
+	blockIndent int
+	// flowEmpty reports the `hooks: {}` form, the one line an install rewrites.
+	flowEmpty bool
+	// keyLine is the exact `hooks: {}` line, and normalizedKeyLine what an
+	// install turns it into — the property the round trip is graded against
+	// for that one shape.
+	keyLine, normalizedKeyLine string
+	// blockIsLast records that no top-level key follows the block, which is
+	// the case with nothing to terminate it.
+	blockIsLast bool
+	// keyLineIsLast records the sharper version: the block KEY is the file's
+	// last line, so an install splices at end-of-file and a missing final
+	// newline has to be supplied.
+	keyLineIsLast bool
+	// declaredEvents are the event keys the generated block already holds. An
+	// install collides when it intersects the ENTRIES of the config actually
+	// being installed, which is why this is a list rather than a bool: the
+	// generator picks the document and propertyConfig independently picks how
+	// many entries to install, and the first draft's bool conflated "the
+	// document names a region event" with "this install names it too" and
+	// reported a legal install as a missing refusal.
+	declaredEvents []string
+}
+
+// collides reports whether cfg's entries intersect the events the document
+// already declares.
+func collides(d document9, cfg Config) bool {
+	for _, e := range cfg.Entries {
+		for _, declared := range d.declaredEvents {
+			if declared == e.Event {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func (d document9) wantIndent() int {
+	if d.blockIndent > 0 {
+		return d.blockIndent
+	}
+	return defaultBlockIndent
+}
+
+// wantRegion renders the bytes the install should have written, in whichever
+// of the two placements this document forces. Deriving it from the DOCUMENT
+// rather than from the package's own scan is what keeps the assertion
+// independent of the code under test.
+func (d document9) wantRegion(cfg Config) ([]byte, error) {
+	if d.hasBlock {
+		return renderRegion(cfg, d.wantIndent())
+	}
+	return renderOwnedRegion(cfg)
+}
+
+// wantRoundTrip is the document an install-then-uninstall must produce: the
+// original, plus the two permanent normalizations the package doc lists. This
+// encodes them rather than restating them, so a THIRD one appearing fails here
+// instead of being absorbed into a looser assertion.
+func (d document9) wantRoundTrip() string {
+	out := d.text
+	if d.flowEmpty {
+		if strings.Contains(out, d.keyLine) {
+			out = strings.Replace(out, d.keyLine, d.normalizedKeyLine, 1)
+		} else {
+			// The `{}` line was the document's LAST and its newline was
+			// trimmed. The rewrite still has to terminate it, because the
+			// region goes immediately after — so this shape normalizes the
+			// value AND supplies the missing terminator, which is the same
+			// normalization the package doc's item 1 describes reaching EOF.
+			out = strings.Replace(out,
+				strings.TrimRight(d.keyLine, "\r\n"),
+				strings.TrimRight(d.normalizedKeyLine, "\r\n")+"\n", 1)
+		}
+	}
+	// Only an insertion AT END-OF-FILE adds the newline: either the region is
+	// appended (no block at all) or it goes after a block key that is itself
+	// the last line. A region spliced into the middle leaves the tail alone,
+	// so a missing final newline stays missing — which is why this is
+	// conditioned rather than applied unconditionally.
+	if (!d.hasBlock || d.keyLineIsLast) && out != "" && !strings.HasSuffix(out, "\n") {
+		out += "\n"
+	}
+	return out
+}
+
+// regionEvents are the names propertyConfig draws from. A generated user hook
+// on one of them is what makes a document collide.
+var regionEvents = []string{"on_session_end", "pre_approval_request", "post_approval_response"}
+
+// userEvents are hermes event names the region never installs, so a block
+// holding one is a merge rather than a collision.
+var userEvents = []string{"post_tool_call", "pre_tool_call", "on_session_start", "subagent_stop"}
+
+func generateDocument(rng *rand.Rand) document9 {
+	nl := "\n"
+	if rng.Intn(4) == 0 {
+		nl = "\r\n"
+	}
+
+	var doc document9
+
+	// Filler sections are rendered first and the block is spliced between two
+	// of them, so "the block is LAST" is an index rather than a special case.
+	// The first draft placed the block inside the rendering loop and then
+	// always wrote one more filler after it, so that position never occurred
+	// at all — which the axis census below caught on its first run, and which
+	// is exactly why the census exists.
+	sections := make([]string, 1+rng.Intn(3))
+	for i := range sections {
+		sections[i] = filler(rng, nl, i)
+	}
+
+	blockMode := rng.Intn(4) // 0 absent, 1 empty, 2 flow-empty, 3 populated
+	at := -1
+	if blockMode != 0 {
+		at = rng.Intn(len(sections) + 1)
+		doc.blockIsLast = at == len(sections)
+		doc.keyLineIsLast = doc.blockIsLast && blockMode != 3
+	}
+
+	var b strings.Builder
+	for i, sec := range sections {
+		if i == at {
+			writeBlock(&b, rng, nl, blockMode, &doc)
+		}
+		b.WriteString(sec)
+	}
+	if at == len(sections) {
+		writeBlock(&b, rng, nl, blockMode, &doc)
+	}
+
+	text := b.String()
+	if rng.Intn(5) == 0 {
+		text = strings.TrimRight(text, "\r\n")
+	}
+	doc.text = text
+	return doc
+}
+
+func writeBlock(b *strings.Builder, rng *rand.Rand, nl string, mode int, doc *document9) {
+	switch mode {
+	case 1:
+		doc.hasBlock = true
+		b.WriteString("hooks:" + nl)
+	case 2:
+		doc.hasBlock = true
+		doc.flowEmpty = true
+		doc.keyLine, doc.normalizedKeyLine = "hooks: {}"+nl, "hooks:"+nl
+		if rng.Intn(2) == 0 {
+			doc.keyLine = "hooks: {}   # nothing configured" + nl
+			doc.normalizedKeyLine = "hooks:   # nothing configured" + nl
+		}
+		b.WriteString(doc.keyLine)
+	case 3:
+		doc.hasBlock = true
+		indent := 2
+		if rng.Intn(2) == 0 {
+			indent = 4
+		}
+		doc.blockIndent = indent
+		pad := strings.Repeat(" ", indent)
+		b.WriteString("hooks:" + nl)
+		if rng.Intn(3) == 0 {
+			b.WriteString(pad + "# my own hooks" + nl)
+		}
+		n := 1 + rng.Intn(3)
+		for i := 0; i < n; i++ {
+			event := userEvents[rng.Intn(len(userEvents))]
+			// One document in six declares one of OUR events, which is what
+			// exercises the collision refusal.
+			if rng.Intn(6) == 0 {
+				event = regionEvents[rng.Intn(len(regionEvents))]
+			}
+			doc.declaredEvents = append(doc.declaredEvents, event)
+			b.WriteString(pad + event + ":" + nl)
+			b.WriteString(pad + pad + `- command: "/usr/local/bin/tool --flag # not a comment"` + nl)
+			if rng.Intn(2) == 0 {
+				b.WriteString(pad + pad + "  timeout: 30" + nl)
+			}
+			if rng.Intn(4) == 0 {
+				b.WriteString(nl)
+			}
+		}
+	}
+}
+
+// filler renders one non-block top-level section. Between them the six shapes
+// cover the surrounding-content axis: scalars, nested mappings, block
+// sequences, dotted keys, quoted values carrying `#` and `:`, standalone
+// comments at column 0 and inside a nested mapping, trailing comments, and
+// blank lines.
+func filler(rng *rand.Rand, nl string, s int) string {
+	var b strings.Builder
+	switch rng.Intn(6) {
+	case 0:
+		b.WriteString("# section comment: with a colon" + nl)
+		b.WriteString(fmt.Sprintf("scalar%d: %d"+nl, s, rng.Intn(100)))
+	case 1:
+		b.WriteString(fmt.Sprintf("mapping%d:"+nl, s))
+		b.WriteString(`  default: "anthropic/claude-opus-4.6"   # keep me` + nl)
+		b.WriteString("  # a comment inside the mapping" + nl)
+		b.WriteString("  nested:" + nl)
+		b.WriteString("    deep: true" + nl)
+	case 2:
+		b.WriteString(fmt.Sprintf("seq%d:"+nl, s))
+		b.WriteString("  - one" + nl)
+		b.WriteString("  - two" + nl)
+	case 3:
+		b.WriteString(fmt.Sprintf("dotted.key%d: value"+nl, s))
+		b.WriteString(nl)
+	case 4:
+		b.WriteString(fmt.Sprintf("quoted%d: \"a: b # c\""+nl, s))
+	default:
+		b.WriteString(nl)
+		b.WriteString(fmt.Sprintf("plain%d: text without quotes"+nl, s))
+	}
+	return b.String()
+}

--- a/core/cmd/irrlichd/startup.go
+++ b/core/cmd/irrlichd/startup.go
@@ -20,6 +20,7 @@ import (
 	"irrlicht/core/adapters/inbound/agents/codex"
 	"irrlicht/core/adapters/inbound/agents/copilot"
 	"irrlicht/core/adapters/inbound/agents/geminicli"
+	"irrlicht/core/adapters/inbound/agents/hermes"
 	"irrlicht/core/adapters/inbound/agents/kirocli"
 	"irrlicht/core/adapters/inbound/agents/opencode"
 	"irrlicht/core/adapters/inbound/agents/pi"
@@ -951,6 +952,16 @@ func setupBackchannel(mux *http.ServeMux, deps setupBackchannelDeps) (*services.
 // satisfying pi.HookTarget's single method, HandleStopHook. All are
 // consent-gated: hooks installed by a pre-consent daemon keep firing until
 // the wizard is answered, so payloads are dropped while pending.
+//
+// Hermes Agent's pre_approval_request/post_approval_response/on_session_end
+// events (issue #1722) are beacon-delivered too (`irrlichd hook-post hermes`),
+// and are the second receiver — after opencode's — whose adapter reads a
+// SHARED STORE rather than transcript files: the approval pair is a
+// blocked-on-user state hermes persists nowhere, so it is not reachable from
+// state.db at any polling interval. Delivered by a `hooks:` entry in the
+// user's config.yaml naming irrlicht's own binary, so unlike opencode and pi
+// nothing executable is installed. The detector satisfies hermes.HookTarget's
+// three methods, the same set opencode's receiver calls.
 func registerHookRoutes(mux *http.ServeMux, detector *services.SessionDetector, metricsCollector outbound.MetricsCollector, permService *services.PermissionService, logger outbound.Logger) {
 	// mux.Handle, not HandleFunc: each constructor returns a hookjson.HookHandler
 	// — the handler together with the confiner it enforces #1361 with — which
@@ -973,6 +984,8 @@ func registerHookRoutes(mux *http.ServeMux, detector *services.SessionDetector, 
 		pi.NewHookHandler(detector, permService, logger))
 	mux.Handle("POST "+opencode.HookEndpointPath,
 		opencode.NewHookHandler(detector, permService, logger))
+	mux.Handle("POST "+hermes.HookEndpointPath,
+		hermes.NewHookHandler(detector, permService, logger))
 }
 
 // publishAddrFile writes the addr file and thereby signals "the daemon is

--- a/docs/testing-contracts.md
+++ b/docs/testing-contracts.md
@@ -221,7 +221,7 @@ below.
   the second makes the first unsatisfiable. `PathFromBody` — the zero value, and
   every receiver before #1719 — is the six obligations below. `PathDaemonDerived`
   is a receiver whose payload names no filesystem path, because the adapter has
-  no file for a caller to name: opencode's `Source` is an
+  no file for a caller to name: opencode's and hermes' `Source` is an
   `agent.ProcessOwnedStore`, one SQLite database with no file per session, so
   the path every consumer keys a session on is composed by the daemon from its
   own store resolver and the body carries a session id. That route reaches its

--- a/replaydata/agents/hermes/driver-interactive.sh
+++ b/replaydata/agents/hermes/driver-interactive.sh
@@ -239,7 +239,27 @@ launch_repl() {
   # `hermes chat` is the interactive REPL. HERMES_HOME must already point at
   # the recording home (the rig exports it) so this never writes into a real
   # session store.
-  tmux new-session -d -s "$SESSION" -x 200 -y 50 -c "${SES_CWD[$ACTIVE]}" "hermes chat" \
+  #
+  # IRRLICHT_BIND_ADDR is passed per pane because hermes' hooks are
+  # beacon-delivered (#1722): the `hooks:` entry irrlicht installs carries no
+  # address at all and `irrlichd hook-post hermes` resolves one at FIRE time
+  # from its own environment — IRRLICHT_BIND_ADDR first, then the addr file
+  # under IRRLICHT_HOME (core/pkg/daemonaddr resolveClient). The beacon is a
+  # descendant of this pane, and a tmux pane inherits the tmux SERVER's
+  # environment rather than anything run-cell.sh exported, so a pane carrying
+  # neither variable reads the PRODUCTION addr file and posts every hook to the
+  # daemon on 7837. The recording then comes back complete, healthy and
+  # hook-free with nothing anywhere saying why — the failure #1735 measured.
+  # HERMES_HOME is the isolation half, for the same inheritance reason: the rig
+  # exports it (lib/agent-home.sh's opt-in hermes row) so the DAEMON resolves
+  # the scratch store, and without this prefix the pane's `hermes chat` would
+  # write into the operator's real ~/.hermes while the daemon watched the
+  # scratch one.
+  #
+  # Empty is the same as unset for both readers, so passing them unconditionally
+  # is safe when the rig set neither.
+  tmux new-session -d -s "$SESSION" -x 200 -y 50 -c "${SES_CWD[$ACTIVE]}" \
+    env "HERMES_HOME=${HERMES_HOME:-}" "IRRLICHT_BIND_ADDR=${IRRLICHT_BIND_ADDR:-}" "hermes chat" \
     >>"$DRIVER_LOG.stdout.$ACTIVE" 2>>"$DRIVER_LOG.stderr" \
     || { echo "[driver] failed to launch hermes under tmux" >&2; EXIT_REASON="nonzero(2)"; exit 1; }
 

--- a/site/docs/adapters.html
+++ b/site/docs/adapters.html
@@ -234,6 +234,8 @@
         <li><code>sessions.cwd</code> is populated only for TUI sessions &mdash; the interactive <code>hermes chat</code> REPL records <code>source='cli'</code> and carries an empty cwd, so the project binding is borrowed from the live process instead</li>
         <li>Process discovery via command-line match: <code>hermes</code> is a Python console-script, so the OS process name is the interpreter and an exact-name match would never fire</li>
         <li>Second <code>agent.ProcessOwnedStore</code> adapter after opencode, and the first whose store is shared across every surface the agent has</li>
+        <li><strong>Writes (behind the <code>hooks</code> consent):</strong> three shell-hook entries in a marked block of <code>$HERMES_HOME/config.yaml</code>, plus the matching approvals in <code>$HERMES_HOME/shell-hooks-allowlist.json</code> &mdash; Hermes does not run a configured hook until it is approved. No code is installed: each entry runs <code>irrlichd hook-post hermes</code>, which resolves the daemon&rsquo;s address at fire time</li>
+        <li><code>pre_approval_request</code> / <code>post_approval_response</code> are the reason the channel exists: Hermes holds a pending approval in process memory and <code>state.db</code> has no approval table, so <code>waiting</code> is not reachable from the store at any polling interval. <code>on_session_end</code> fires once per turn and carries <code>completed</code> / <code>interrupted</code></li>
         <li><strong>Adapter name:</strong> <code>"hermes"</code></li>
         <li>Stage: <strong>alpha</strong></li>
       </ul>

--- a/tools/onboarding-factory/cmd/of/fixture_test.go
+++ b/tools/onboarding-factory/cmd/of/fixture_test.go
@@ -36,7 +36,7 @@ func richRepo(t *testing.T) string {
 	root := t.TempDir()
 
 	write(t, filepath.Join(root, "replaydata", "agents", "scenarios.json"), `{
-  "meta": {"min_versions": {"aider": "1.0.0", "claudecode": "2.0.0", "codex": "1.0.0", "hermes": "1.0.0"}},
+  "meta": {"min_versions": {"aider": "1.0.0", "claudecode": "2.0.0", "codex": "1.0.0", "antigravity": "1.0.0"}},
   "scenarios": [
     {"id": "1.1", "name": "one",   "description": "d", "process": "p", "acceptance_criteria": "a"},
     {"id": "2.1", "name": "two",   "description": "d", "process": "p", "acceptance_criteria": "a"},
@@ -66,12 +66,17 @@ func richRepo(t *testing.T) string {
 	cell(t, root, "aider", "1-1_one", "yes", "full", "ready")
 	recording(t, root, "aider", "1-1_one", "r1", true)
 
-	// hermes is the fixture's "declares no hooks" adapter — the counterweight
-	// TestCoverageHooksDistinguishesGapFromNoHooks measures codex's GAP
-	// against. It used to be opencode, until #1719 gave opencode a hooks
-	// permission and the two roles collapsed onto one adapter.
-	cell(t, root, "hermes", "1-1_one", "yes", "full", "ready")
-	recording(t, root, "hermes", "1-1_one", "r1", false)
+	// antigravity is the fixture's "declares no hooks" adapter — the
+	// counterweight TestCoverageHooksDistinguishesGapFromNoHooks measures
+	// codex's GAP against. The role has now moved twice: opencode held it
+	// until #1719, hermes until #1722, and each move happened because the
+	// adapter playing it gained a hooks permission. Two registry adapters
+	// declare none today, and aider is the other — but aider cannot take this
+	// role, because it holds the INCIDENTAL one above (a hook-bearing
+	// recording with no permission declared) and the two are mutually
+	// exclusive by construction.
+	cell(t, root, "antigravity", "1-1_one", "yes", "full", "ready")
+	recording(t, root, "antigravity", "1-1_one", "r1", false)
 
 	return root
 }

--- a/tools/onboarding-factory/cmd/of/hooks_test.go
+++ b/tools/onboarding-factory/cmd/of/hooks_test.go
@@ -28,10 +28,10 @@ func TestCoverageHooksCounts(t *testing.T) {
 	}
 
 	want := map[string]hookcov.AdapterCoverage{
-		"aider":      {Adapter: "aider", DeclaresHooks: false, Cells: 1, Recordings: 1, WithHooks: 1, Status: hookcov.StatusIncidental},
-		"claudecode": {Adapter: "claudecode", DeclaresHooks: true, Cells: 7, Recordings: 2, WithHooks: 1, Status: hookcov.StatusOK},
-		"codex":      {Adapter: "codex", DeclaresHooks: true, Cells: 2, Recordings: 1, WithHooks: 0, Status: hookcov.StatusGap},
-		"hermes":     {Adapter: "hermes", DeclaresHooks: false, Cells: 1, Recordings: 1, WithHooks: 0, Status: hookcov.StatusNone},
+		"aider":       {Adapter: "aider", DeclaresHooks: false, Cells: 1, Recordings: 1, WithHooks: 1, Status: hookcov.StatusIncidental},
+		"claudecode":  {Adapter: "claudecode", DeclaresHooks: true, Cells: 7, Recordings: 2, WithHooks: 1, Status: hookcov.StatusOK},
+		"codex":       {Adapter: "codex", DeclaresHooks: true, Cells: 2, Recordings: 1, WithHooks: 0, Status: hookcov.StatusGap},
+		"antigravity": {Adapter: "antigravity", DeclaresHooks: false, Cells: 1, Recordings: 1, WithHooks: 0, Status: hookcov.StatusNone},
 	}
 	got := map[string]hookcov.AdapterCoverage{}
 	for _, a := range rep.Adapters {
@@ -54,7 +54,7 @@ func TestCoverageHooksCounts(t *testing.T) {
 
 // TestCoverageHooksDistinguishesGapFromNoHooks is the reason this command
 // exists. "Declares hooks and has zero hook-bearing recordings" (codex) is the
-// loud failure; "declares no hooks" (hermes) is fine. Both have WithHooks==0,
+// loud failure; "declares no hooks" (antigravity) is fine. Both have WithHooks==0,
 // so a report keying only on that number would conflate them.
 func TestCoverageHooksDistinguishesGapFromNoHooks(t *testing.T) {
 	root := richRepo(t)
@@ -70,10 +70,10 @@ func TestCoverageHooksDistinguishesGapFromNoHooks(t *testing.T) {
 	for _, a := range rep.Adapters {
 		byName[a.Adapter] = a
 	}
-	if byName["codex"].WithHooks != 0 || byName["hermes"].WithHooks != 0 {
-		t.Fatalf("fixture precondition: both codex and hermes should have zero hook-bearing recordings")
+	if byName["codex"].WithHooks != 0 || byName["antigravity"].WithHooks != 0 {
+		t.Fatalf("fixture precondition: both codex and antigravity should have zero hook-bearing recordings")
 	}
-	if byName["codex"].Status == byName["hermes"].Status {
+	if byName["codex"].Status == byName["antigravity"].Status {
 		t.Errorf("gap and no-hooks-declared must not share a status; both are %q", byName["codex"].Status)
 	}
 	if byName["codex"].Status != hookcov.StatusGap {

--- a/tools/onboarding-factory/cmd/of/status_summary_test.go
+++ b/tools/onboarding-factory/cmd/of/status_summary_test.go
@@ -29,10 +29,10 @@ func TestStatusSummaryCounts(t *testing.T) {
 	// model does not apply to — not a defect in the fixture.
 	const core = 12
 	want := map[string]agentSummary{
-		"aider":      {Agent: "aider", Recorded: 1, Total: 1, Earned: matrix.MaturityPlanned, CoreTotal: core},
-		"claudecode": {Agent: "claudecode", Recorded: 1, Pending: 1, Blocked: 2, Unobservable: 1, NotApplicable: 1, Unknown: 1, Total: 7, Earned: matrix.MaturityPlanned, CoreTotal: core},
-		"codex":      {Agent: "codex", Recorded: 1, Pending: 1, Total: 2, Earned: matrix.MaturityPlanned, CoreTotal: core},
-		"hermes":     {Agent: "hermes", Recorded: 1, Total: 1, Earned: matrix.MaturityPlanned, CoreTotal: core},
+		"aider":       {Agent: "aider", Recorded: 1, Total: 1, Earned: matrix.MaturityPlanned, CoreTotal: core},
+		"claudecode":  {Agent: "claudecode", Recorded: 1, Pending: 1, Blocked: 2, Unobservable: 1, NotApplicable: 1, Unknown: 1, Total: 7, Earned: matrix.MaturityPlanned, CoreTotal: core},
+		"codex":       {Agent: "codex", Recorded: 1, Pending: 1, Total: 2, Earned: matrix.MaturityPlanned, CoreTotal: core},
+		"antigravity": {Agent: "antigravity", Recorded: 1, Total: 1, Earned: matrix.MaturityPlanned, CoreTotal: core},
 	}
 	if len(v.Agents) != len(want) {
 		t.Fatalf("want %d agent rows, got %d: %+v", len(want), len(v.Agents), v.Agents)

--- a/tools/onboarding-factory/internal/hookcov/hookcov_test.go
+++ b/tools/onboarding-factory/internal/hookcov/hookcov_test.go
@@ -17,24 +17,26 @@ import (
 func TestDeclaredMatchesRegistry(t *testing.T) {
 	got := Declared()
 
-	// Exhaustive as of this commit: claudecode, codex, copilot, gemini-cli,
-	// kiro-cli, mistral-vibe and pi are the adapters declaring a hooks
-	// permission. If an eighth gains one, this fails and the new adapter
-	// joins the list — that is the intended workflow, not an obstacle.
+	// Exhaustive as of this commit: every registry adapter EXCEPT aider and
+	// antigravity declares a hooks permission. If one of those two gains one,
+	// this fails and the map is updated — that is the intended workflow, not
+	// an obstacle.
 	//
 	// copilot joined in #1378, gemini-cli in #1717, kiro-cli in #1716,
-	// mistral-vibe in #1718 and pi in #1721 — all five are expected to report
+	// mistral-vibe in #1718, pi in #1721, opencode in #1719 and hermes in
+	// #1722 — all of them are expected to report
 	// StatusGap for a while: each declares hooks, but no recording carries a hook_received
 	// event yet, because landing the permission deliberately re-recorded
 	// nothing (the frozen sidecars are hook-free and the replay goldens had
 	// to stay byte-identical — #1717's own audit measured 0 cells
 	// re-recorded, and #1716's/#1718's Phase 2 is plan-only for the same
 	// reason; #1721 re-recorded nothing either, and its own audit reports the
-	// rig gaps that would have to close first). A GAP here is the honest
-	// reading of that, not a defect.
+	// rig gaps that would have to close first; #1722 re-recorded nothing
+	// either, and hermes' rig row is opt-in because a bare HERMES_HOME cannot
+	// authenticate). A GAP here is the honest reading of that, not a defect.
 	want := map[string]bool{
 		"aider": false, "antigravity": false, "claudecode": true, "codex": true,
-		"copilot": true, "gemini-cli": true, "hermes": false, "kiro-cli": true,
+		"copilot": true, "gemini-cli": true, "hermes": true, "kiro-cli": true,
 		"mistral-vibe": true, "opencode": true, "pi": true,
 	}
 	if !reflect.DeepEqual(got, want) {

--- a/tools/onboarding-factory/internal/righome/righome_test.go
+++ b/tools/onboarding-factory/internal/righome/righome_test.go
@@ -1,6 +1,7 @@
 package righome
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -127,13 +128,10 @@ func registryAdapterAfterEnv(t *testing.T, slug string) agent.Agent {
 // the daemon records the operator's own sessions instead of the driver's.
 func assertSessionRootRelocates(t *testing.T, row Row, home string, a agent.Agent) {
 	t.Helper()
-	src, isFiles := a.Source.(agent.FilesUnderRoot)
-	if !isFiles {
-		t.Fatalf("adapter %q declares Source %T, which this arm cannot resolve — a row for a "+
-			"non-FilesUnderRoot adapter needs its own half-one check rather than being waved "+
-			"through", row.Adapter, a.Source)
+	roots, err := sessionRootsOf(a)
+	if err != nil {
+		t.Fatalf("adapter %q: %v", row.Adapter, err)
 	}
-	roots := src.AllRootsFor("darwin")
 	if len(roots) == 0 {
 		t.Fatalf("adapter %q resolves no session roots at all", row.Adapter)
 	}
@@ -144,6 +142,37 @@ func assertSessionRootRelocates(t *testing.T, row Row, home string, a agent.Agen
 				"recording would contain their sessions and not the driver's",
 				row.EnvVar, home, root)
 		}
+	}
+}
+
+// sessionRootsOf resolves the paths the daemon watches for one adapter, for
+// each Source variant a row can name.
+//
+// The ProcessOwnedStore branch is #1722's: hermes is the first rowed adapter
+// with no transcript files at all, and for it "the session root" is the single
+// SQLite store the watcher polls. PathForPID is the resolver the daemon itself
+// calls, so grading it asks the same question the FilesUnderRoot branch asks —
+// a store that has not moved means the daemon polls the operator's real
+// sessions while the driver writes to the scratch home. The pid argument is
+// ignored by every ProcessOwnedStore declaration (the store is shared, not
+// per-process), which is why passing a placeholder is honest rather than a
+// stand-in for something the test could not arrange.
+//
+// The default case stays a hard failure rather than an empty result: an
+// unresolvable Source and a Source with nothing to relocate must not read the
+// same way.
+func sessionRootsOf(a agent.Agent) ([]string, error) {
+	switch src := a.Source.(type) {
+	case agent.FilesUnderRoot:
+		return src.AllRootsFor("darwin"), nil
+	case agent.ProcessOwnedStore:
+		if src.PathForPID == nil {
+			return nil, fmt.Errorf("declares ProcessOwnedStore with no PathForPID, so there is no store path to grade")
+		}
+		return []string{src.PathForPID(0)}, nil
+	default:
+		return nil, fmt.Errorf("declares Source %T, which this arm cannot resolve — a row for it "+
+			"needs its own half-one check rather than being waved through", a.Source)
 	}
 }
 

--- a/tools/onboarding-factory/scripts/lib/agent-home.sh
+++ b/tools/onboarding-factory/scripts/lib/agent-home.sh
@@ -155,6 +155,18 @@
 #                  one. Defaulting it would also change the recording conditions
 #                  of all 28 existing kiro-cli recordings at once.
 #
+#   hermes     OPT-IN, for kiro-cli's reason in a stronger form. HERMES_HOME is
+#              the one variable that moves EVERYTHING — config.yaml, the
+#              shell-hook allowlist and state.db all hang off it, and the
+#              adapter's own homeDir() reads it — so unlike opencode there is
+#              no half-relocated state to fall into. What stops it defaulting is
+#              that a bare Hermes home cannot authenticate: #1325's recording
+#              work measured five files it has to be seeded with (config.yaml,
+#              .env, auth.json, context_length_cache.yaml,
+#              provider_models_cache.json) before `hermes chat` will start.
+#              Defaulting it would also change the recording conditions of all
+#              22 existing hermes recordings at once.
+#
 #            A "default AND seed from the real home" third policy was considered
 #            and not built: it would copy the operator's own config into staging
 #            on every run, which trades an explicit, auditable operator step for
@@ -198,6 +210,7 @@ codex CODEX_HOME optin
 kiro-cli KIRO_HOME optin
 mistral-vibe VIBE_HOME optin
 pi PI_CODING_AGENT_DIR optin
+hermes HERMES_HOME optin
 TABLE
   return 0
 }


### PR DESCRIPTION
Closes #1722. Part of #1355.

## Verdict: the mechanism exists, it is first-class, and the "no payoff" half does not survive

**hermes has a full hook system with its own CLI subcommand.** `hermes hooks {list|test|revoke|doctor}` (`hermes_cli/hooks.py`, 394 lines), 25 lifecycle events (`VALID_HOOKS`, `hermes_cli/plugins.py:135`), and **three independent subscription mechanisms** documented side by side in `website/docs/user-guide/features/hooks.md:1303`:

| | Declared in | Runs in | Ships code? | Consent |
|---|---|---|---|---|
| Gateway event hooks | `~/.hermes/hooks/<name>/HOOK.yaml` + `handler.py` | **Gateway only** | Python | dir trust |
| Python plugins | `~/.hermes/plugins/<name>/` + `plugins.enabled` in config.yaml | CLI + Gateway | Python, in-process | implicit |
| **Shell hooks** | `hooks:` block in `~/.hermes/config.yaml` | **CLI + Gateway** | **no — a command line** | per-`(event, command)` allowlist |

Only the third is usable: the first never fires for `hermes chat`, and the second is in-process Python **and still needs a config.yaml write** (`plugins.enabled` is an opt-in allow-list, `plugins.py:1454`). The shell-hook route is the one hermes' own table marks "inter-process isolation: yes".

Verified live, not from docs. `~/.hermes` on this machine had no CLI (the venv shim points at a deleted path), so the audit ran the source checkout's venv directly with an isolated `HERMES_HOME`:

```
$ hermes --version
Hermes Agent v0.19.0 (2026.7.20) · upstream 6564f319 · local e289e561 (+1 carried commit)

$ hermes hooks test on_session_end
Firing 1 hook(s) for event 'on_session_end':
  → …/capture.sh
      exit=0  elapsed=0.265s
      parsed: <none — hook contributed nothing to the dispatcher>

$ cat capture.log
{"hook_event_name": "on_session_end", "tool_name": null, "tool_input": null,
 "session_id": "test-session", "cwd": "/private/tmp", "extra": {}}
```

and a **hand-written** allowlist entry — the exact record this installer writes — is accepted:

```
$ hermes hooks doctor
  [on_session_end] …/capture.sh
      ✓ script exists and is executable
      ✓ allowlisted (approved 2026-08-22T06:17:00.293485Z)
      ✓ script unchanged since approval
      ✓ ran clean with empty stdout (exit=0, 0.006s) — hook is observer-only
All shell hooks look healthy.
```

## Does hermes have a state its store cannot express? Yes — the same shape as opencode

`tools/approval.py` fires `pre_approval_request` immediately before the user is asked to approve a dangerous command, and `post_approval_response` with the outcome. The pending request between them lives in a module-level `_gateway_queues` map plus a `contextvars` session key. `state.db`'s schema (`hermes_state.py:1126`+) is `sessions`, `messages`, `session_model_usage`, `state_meta`, `gateway_routing`, `compression_locks`, `async_delegations` — **no approval table**. Nothing about "the user is being asked right now" is ever written.

So this is not invalidation. **Before this PR the hermes adapter had no `waiting` state at all**, and no polling interval could have produced one.

`post_approval_response` fires for every outcome including `deny` and `timeout`, which keeps hermes out of copilot's position where a hold has no release.

## What is deliberately NOT installed, and the guard that enforces it

`agent/shell_hooks._parse_response` reads a hook's **stdout as a decision** for three events: `pre_tool_call` (`{"action":"block"}` vetoes the tool), `pre_verify` (`{"action":"continue"}` keeps the turn running), and a fall-through `{"context": …}` branch `pre_llm_call` prepends to the user's message. This is hermes' `permission.ask`.

`TestInstalledEventsAreObserverOnly` fails the build if any of them appears in `installedHookEvents`, and the installed command is wrapped in `/bin/sh -c … >/dev/null || true` so its stdout cannot reach hermes' parser at all — not defensive: `hookbeacon.LegacyGuardToken` puts `--version` first, so a pre-#1417 irrlichd prints a version banner on stdout on every firing.

## New package: `hookyaml`

hermes' hooks live in the user's ONE config file. `core/go.mod` has no YAML dependency and none is added: `hookyaml` is a line-oriented byte-range splicer for one marker-delimited region under one top-level key, the same strategy `hooktoml` uses for #1718. It rests on one stated invariant (in a loadable root block mapping, a non-blank column-0 line is a key, a comment or a document marker), **asserts** that invariant rather than assuming it, and refuses the whole document — naming the line — for any shape it does not model.

Two placements, and the distinction is what makes uninstall exact: when the key already exists the region goes inside it and the key is the user's; when it does not, the key goes **inside** the region. A collision on one of our own event names is refused by name, because a duplicate YAML key resolves silently to the last one and would delete the user's hook.

## Mutation evidence

Every guard below was applied, run, and reverted one per command. Verbatim output.

<details><summary><b>1. Install a control-bearing event</b> — <code>installedHookEvents += "pre_tool_call"</code></summary>

```
--- FAIL: TestHooksPermission_DisclosureMatchesInstalled/states_the_installed_count
    hook_disclosure.go:139: consent copy declares 3 hook entries, installer writes 4
--- FAIL: TestInstalledEventsAreObserverOnly
    hooks_test.go:235: installedHookEvents contains "pre_tool_call", whose stdout hermes reads as a decision (agent/shell_hooks._parse_response). Installing it would let a monitoring hook veto a tool call, keep a turn running, or inject text into the user's message.
```
</details>

<details><summary><b>2. Drop the <code>/bin/sh -c</code> wrapper</b></summary>

```
--- FAIL: TestInstalledCommandRoundTripsThroughHermesParser
    hookinstaller_test.go:392: argv = []string{"/usr/local/bin/irrlichd", "--version", "hook-post", "hermes", ">/dev/null", "||", "true"}, want []string{"/bin/sh", "-c", "'/usr/local/bin/irrlichd' --version hook-post hermes >/dev/null || true"}
--- FAIL: TestInstalledCommandSuppressesStdout
    hooks_test.go:258: command = "'/opt/irrlichd' --version hook-post hermes >/dev/null || true", want it wrapped in /bin/sh -c so the redirect below is honoured — hermes runs the command with shell=False, so a bare argv has no redirection at all
```
The argv is the finding: hermes would exec `>/dev/null`, `||` and `true` as literal arguments.
</details>

<details><summary><b>3. Read only the DOCUMENTED top-level <code>session_id</code></b></summary>

```
--- FAIL: TestPreApprovalRequestHook_AssertsTheBlockedOnUserSignal
    hooks_test.go:289: HandlePermissionPromptHook called 0 times, want 1
--- FAIL: TestPostApprovalResponseHook_ReleasesTheHold
    hooks_test.go:319: ReleasePermissionPromptHold calls = [], want exactly ["20260802_233614_c97a8d"]
--- FAIL: TestApprovalHooks_ReadTheSessionKeyFromExtra/pre_approval_request
    hooks_test.go:386: dispatched 0 times, want 1 — the id is in extra.session_key for this event, not in session_id
```
</details>

<details><summary><b>4. Accept any non-empty session id</b></summary>

```
--- FAIL: TestHookReceiver_ForeignSessionIDIsQuiet/not-a-session
    hooks_test.go:439: dispatched 2 times for an id hermes could not have minted, want 0
--- FAIL: TestHookReceiver_ForeignSessionIDIsQuiet/default
--- FAIL: TestHookReceiver_ForeignSessionIDIsQuiet/whatsapp:4915112345678
```
</details>

<details><summary><b>5. Delete the receiver's own <code>store</code> gate</b> — only the SILENCE discriminates</summary>

```
--- FAIL: TestHookReceiver_DeniedStoreConsentDropsQuietly
    hooks_test.go:525: a store-denied hook logged 1 error(s): [hook body dropped: permission "store" is not granted at the decode — either this receiver skipped the check it declares, or consent was revoked mid-request (issue #1488)]
```
`TestHookReceiver_PermissionGateContract` stayed **green** — exactly the #1488 behaviour docs/testing-contracts.md records.
</details>

<details><summary><b>6. Remove the collision refusal</b></summary>

```
--- FAIL: TestCollisionIsRefusedByName
    hookyaml_test.go:345: error is <nil> (<nil>), want *CollisionError
--- FAIL: TestSplice_PropertyRandomDocuments
    property_test.go:89: a document already declaring one of the region's events was installed into
--- FAIL: TestEnsureHooksInstalled_RefusesAnEventTheUserAlreadyDeclares
    hookinstaller_test.go:174: EnsureHooksInstalled succeeded against a config that already declares one of our events
```
</details>

<details><summary><b>7. Reinstate the first draft's uninstall</b> — "delete the block key when the block is now empty"</summary>

```
--- FAIL: TestSplice_PropertyRandomDocuments
    property_test.go:89: round trip is not the original:
        --- got ---  "quoted0: \"a: b # c\"\n# section comment…"
        --- want --- "quoted0: \"a: b # c\"\nhooks:\n# section comment…"
    iteration 1, operation "install then uninstall", seed 17221722
```
The hand-written `TestUninstall_RemovesTheBlockWhenItEmpties` stayed **green**. This is the real defect the property test found on its second iteration: uninstall deleted a `hooks:` key the *user* had written.
</details>

<details><summary><b>8. Hardcode LF in the <code>{}</code> key rewrite</b></summary>

```
--- FAIL: TestSplice_PropertyRandomDocuments
    property_test.go:89: round trip is not the original:
        --- got ---  "…\r\nhooks:   # nothing configured\nseq1:\r\n…"
        --- want --- "…\r\nhooks:   # nothing configured\r\nseq1:\r\n…"
    iteration 78
```
`TestEnsureInstalled_HandlesTheEmptyFlowMapping` stayed green (it uses LF). Second real defect.
</details>

<details><summary><b>9. Make <code>homeDir()</code> ignore <code>HERMES_HOME</code></b> — the new righome ProcessOwnedStore branch</summary>

```
--- FAIL: TestEveryRigHomeRowRelocatesBothHalves/hermes
    righome_test.go:99: with HERMES_HOME=…/scratch-home the session root is still "/Users/ingo/.hermes/state.db" — the daemon would watch the operator's real store while the driver wrote to the scratch home…
    righome_test.go:100: … the hooks install still writes Writes.Path to "/Users/ingo/.hermes/config.yaml" …
    righome_test.go:100: … the hooks install still writes Writes.Also[0] to "/Users/ingo/.hermes/shell-hooks-allowlist.json" …
```
</details>

<details><summary><b>10. Verify stops checking the allowlist</b></summary>

```
--- FAIL: TestVerifyHooksInstalled_ReportsARevokedApproval
    hookinstaller_test.go:330: a revoked approval reads as Intact — the entries are in config.yaml but hermes will not run them
```
</details>

<details><summary><b>11. Skip the allowlist write</b></summary>

```
--- FAIL: TestEveryModifyPermissionDeclaresEveryFileItsApplyWrites/hermes/hooks
    managedwrites_test.go:231: hermes/hooks declares "home/.hermes/shell-hooks-allowlist.json" but running Apply changed nothing there…
--- FAIL: TestHooksPermission_IsGated/granted_effect_observable
    permission_gate.go:95: effect not observed after granting permission "hooks"
--- FAIL: TestEnsureHooksInstalled_WritesTheApprovalHermesRequires
    hookinstaller_test.go:207: recorded 0 approvals, want one per installed event (3)
```
</details>

<details><summary><b>12. Remove the tab-indentation refusal</b></summary>

```
--- FAIL: TestRefusals/a_tab_in_the_indentation
    hookyaml_test.go:324: message "a line at column 0 that is not a key, a comment or a document marker — the file is not a plain block mapping and will not be edited" does not mention "tab"
```
Honest reading: the document is still refused (by the column-0 invariant); the tab check is what **names** it correctly. The other eleven rows of that corpus fail outright when their branch is removed.
</details>

<details><summary><b>13. Declare the WRONG confinement route</b></summary>

```
--- FAIL: TestHookPathConfined
    hookpath_test.go:29: Route is PathFromBody (the zero value) but a PathDaemonDerived-only field is set — either the route declaration is wrong, or a neighbouring wiring was copied wholesale
```
</details>

<details><summary><b>14. Consent copy names one event instead of three</b></summary>

```
--- FAIL: TestHooksPermission_DisclosureMatchesInstalled/names_every_installed_event
    hook_disclosure.go:136: consent copy never names the "post_approval_response" hook, but the installer writes it — an undisclosed write to the user's config (#570)
    hook_disclosure.go:136: consent copy never names the "on_session_end" hook, but the installer writes it …
```
</details>

<details><summary><b>15. Drop the version floor below an event's <code>Since</code></b></summary>

```
--- FAIL: TestHooksPermission_DeclaresVersionGate/floor_covers_every_installed_event
    hook_version.go:59: declared floor 0.18.0 is below 0.19.0, the version "pre_approval_request" is known at …
```
</details>

<details><summary><b>16. Forget <code>ObserveHookReceipt</code></b></summary>

```
--- FAIL: TestHookReceiptObserved/recognized_event_counts_one
    hook_receipt.go:111: event "on_session_end" added 0 receipts for adapter "hermes", want exactly 1 — a receiver that does not count its own traffic is reported as a DEAD channel by the liveness watchdog and demoted while working perfectly
--- FAIL: TestHookReceiptObserved/unrecognized_event_counts_too
--- FAIL: TestHookReceiptObserved/confinement_rejected_request_counts_too
```
</details>

<details><summary><b>17. Register the receiver at a route the beacon does not post to</b> (#1759's hand-kept map)</summary>

```
--- FAIL: TestBeaconEndpointPathMatchesTheInstalledReceivers
    beaconroute_test.go:56: hookbeacon.EndpointPath("hermes") = "/api/v1/hooks/hermes", but the receiver is registered at "/api/v1/hooks/hermes-agent" — the beacon would post into a route nothing serves
```
</details>

<details><summary><b>18. The axis census firing on its own first run</b> — and the third real defect</summary>

```
    property_test.go:104: axis block is the last top-level key                   0 of 2000 documents
    property_test.go:104: the generator produced no document exercising "block is the last top-level key" — that axis is claimed in this file's header and graded by nothing
```
Fixing the generator immediately produced:
```
--- FAIL: TestSplice_PropertyRandomDocuments
    property_test.go:91: output line "  on_session_end:\n" is neither an original line in order nor the block key:
        hooks:  # irrlicht-managed BEGIN (irrlicht) — do not edit; `irrlichd --uninstall-hooks` removes this block
```
A block key that is the file's **last line with no final newline** had the BEGIN marker spliced onto it as a trailing comment. The document still parses, so nothing complains — and the marker is no longer a line, so **uninstall could never find the region again**. This is the strongest argument in the PR for AGENTS.md's "count what was actually produced" rule.
</details>

Property sweep: the committed run is 2000 documents (~0.4s); 40,000 × 6 seeds (240,000 documents) was run locally, all green.

## Recording cost: 0 cells re-recorded

`hookcov` reports hermes as `StatusGap`, which is the honest outcome — the permission is declared, no recording carries a `hook_received` event, and the frozen sidecars stay hook-free so every replay golden is byte-identical. #1355's Phase D kill criterion is >5; this is 0. hermes' rig row is **opt-in** (`agent-home.sh`), because #1325 measured that a bare `HERMES_HOME` needs five seeded files before `hermes chat` will authenticate.

## Not covered, stated rather than discovered

- **Hermes profiles.** `hermes -p <name>` relocates `HERMES_HOME` to `~/.hermes/profiles/<name>/`, with its own config and allowlist. Sessions under another profile are watched by the store watcher alone, exactly as before.
- **`cwd` is in the payload and is not read.** It is the one thing the store genuinely cannot supply for a `source='cli'` session, and adopting it would put a caller-supplied path back on this dispatch — which is what the `PathDaemonDerived` declaration says does not happen. A separate change with a confinement obligation of its own.
- **`post_api_request` carries `usage`** and was the metrics candidate #1722 asked about. Not installed: the store already carries per-model tokens and cost, so it would buy a process spawn per API request for a number irrlicht has. What `of verify` cannot validate is the replay golden for a ProcessOwnedStore adapter, and a hook does not change that.
- **The `hooks:` region is refused, not merged, when the user already declares one of our three event names.** Surfaces as #1362's "granted but NOT applied, because …" naming the event and the line.
- The hooks fire in the messaging-gateway processes too; those sessions are filtered out of this adapter by `source`.

## Duplication finding

The seven contract wirings under `core/adapters/inbound/agents/hermes/hook*_test.go` are near-identical to opencode's and pi's by design — that is what a contract family *is*, and #1740's tripwire requires each adapter to carry its own call. Extracting a shared helper would put the wiring behind a seam the walk cannot resolve. Expected and not addressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
