### PR TITLE
chore(landscape): refresh agent landscape data and add missing live adapters

### DIFF
--- a/.claude/skills/ir:agent-landscape/SKILL.md
+++ b/.claude/skills/ir:agent-landscape/SKILL.md
@@ -93,7 +93,7 @@ An agent is "NEW" only if both:
 
 The canonical source of truth is `core/adapters/inbound/agents/` (registered in `all.go`'s `All()`) + `core/adapters/inbound/orchestrators/`. As of this writing:
 
-- `live`: Claude Code (`anthropics/claude-code`), OpenAI Codex (`openai/codex`), Pi (`earendil-works/pi`, renamed from `badlogic/pi-mono` in v0.74), Aider (`Aider-AI/aider`), OpenCode (`anomalyco/opencode`), Kiro (adapter targets Kiro CLI specifically, `AdapterName "kiro-cli"`; product repo `kirodotdev/Kiro`), Gemini CLI (`google-gemini/gemini-cli`), Antigravity (closed-source, no public repo), Mistral Vibe (`mistralai/mistral-vibe`), GitHub Copilot CLI (`github/copilot-cli`, `AdapterName "copilot"`), Gas Town (`gastownhall/gastown`).
+- `live`: Claude Code (`anthropics/claude-code`), OpenAI Codex (`openai/codex`), Pi (`earendil-works/pi`, renamed from `badlogic/pi-mono` in v0.74), Aider (`Aider-AI/aider`), OpenCode (`anomalyco/opencode`), Kiro (adapter targets Kiro CLI specifically, `AdapterName "kiro-cli"`; product repo `kirodotdev/Kiro`), Gemini CLI (`google-gemini/gemini-cli`), Antigravity (closed-source, no public repo), Mistral Vibe (`mistralai/mistral-vibe`), GitHub Copilot CLI (`github/copilot-cli`, `AdapterName "copilot"`), Hermes Agent (`NousResearch/hermes-agent`, `core/adapters/inbound/agents/hermes`), Gas Town (`gastownhall/gastown`).
 - `planned`: Cursor, Claude Squad, Qwen Code, Crush, Continue, Goose, Kilo Code, Paperclip, Ruflo, Multiclaude, SWE-agent.
 - Everything else: `none`.
 

--- a/.claude/skills/ir:agent-landscape/references/agent-data.json
+++ b/.claude/skills/ir:agent-landscape/references/agent-data.json
@@ -1,36 +1,24 @@
 {
-  "last_updated": "2026-07-05",
+  "last_updated": "2026-08-22",
   "agents": [
     {
-      "name": "Claw Code",
-      "github_repo": "ultraworkers/claw-code",
+      "name": "Hermes Agent",
+      "github_repo": "NousResearch/hermes-agent",
       "category": "agent",
-      "website": "https://github.com/ultraworkers/claw-code",
-      "description": "An agent-managed museum exhibit, built in Rust with Gajae-Code / LazyCodex — developed and maintained with no human intervention.",
-      "stars": 194570,
-      "language": "Rust",
+      "website": "https://hermes-agent.nousresearch.com",
+      "description": "The agent that grows with you",
+      "stars": 234263,
+      "language": "Python",
       "license": "MIT",
       "interface": "CLI",
       "pricing": "Free (open source)",
-      "irrlicht_support": "none",
-      "first_seen": "2026-04-05",
+      "irrlicht_support": "live",
+      "first_seen": "2026-08-22",
       "alternative_metrics": null,
       "stars_history": [
         {
-          "date": "2026-07-05",
-          "stars": 194570
-        },
-        {
-          "date": "2026-05-15",
-          "stars": 191505
-        },
-        {
-          "date": "2026-04-24",
-          "stars": 188050
-        },
-        {
-          "date": "2026-04-12",
-          "stars": 182111
+          "date": "2026-08-22",
+          "stars": 234263
         }
       ]
     },
@@ -40,7 +28,7 @@
       "category": "agent",
       "website": "https://opencode.ai",
       "description": "The open source coding agent.",
-      "stars": 182478,
+      "stars": 200227,
       "language": "TypeScript",
       "license": "MIT",
       "interface": "CLI",
@@ -49,6 +37,10 @@
       "first_seen": "2026-04-05",
       "alternative_metrics": null,
       "stars_history": [
+        {
+          "date": "2026-08-22",
+          "stars": 200227
+        },
         {
           "date": "2026-07-05",
           "stars": 182478
@@ -68,12 +60,49 @@
       ]
     },
     {
+      "name": "Claw Code",
+      "github_repo": "ultraworkers/claw-code",
+      "category": "agent",
+      "website": "https://github.com/ultraworkers/claw-code",
+      "description": "An agent-managed museum exhibit, built in Rust with Gajae-Code / LazyCodex \u2014 developed and maintained with no human intervention.",
+      "stars": 195112,
+      "language": "Rust",
+      "license": "MIT",
+      "interface": "CLI",
+      "pricing": "Free (open source)",
+      "irrlicht_support": "none",
+      "first_seen": "2026-04-05",
+      "alternative_metrics": null,
+      "stars_history": [
+        {
+          "date": "2026-08-22",
+          "stars": 195112
+        },
+        {
+          "date": "2026-07-05",
+          "stars": 194570
+        },
+        {
+          "date": "2026-05-15",
+          "stars": 191505
+        },
+        {
+          "date": "2026-04-24",
+          "stars": 188050
+        },
+        {
+          "date": "2026-04-12",
+          "stars": 182111
+        }
+      ]
+    },
+    {
       "name": "Claude Code",
       "github_repo": "anthropics/claude-code",
       "category": "agent",
       "website": "https://www.anthropic.com/claude-code",
       "description": "Claude Code is an agentic coding tool that lives in your terminal, understands your codebase, and helps you code faster by executing routine tasks, explaining complex code, and handling git workflows - all through natural language commands.",
-      "stars": 136132,
+      "stars": 142402,
       "language": "Python",
       "license": null,
       "interface": "CLI",
@@ -82,6 +111,10 @@
       "first_seen": "2026-04-05",
       "alternative_metrics": null,
       "stars_history": [
+        {
+          "date": "2026-08-22",
+          "stars": 142402
+        },
         {
           "date": "2026-07-05",
           "stars": 136132
@@ -101,45 +134,12 @@
       ]
     },
     {
-      "name": "Gemini CLI",
-      "github_repo": "google-gemini/gemini-cli",
-      "category": "agent",
-      "website": "https://github.com/google-gemini/gemini-cli",
-      "description": "An open-source AI agent that brings the power of Gemini directly into your terminal.",
-      "stars": 105752,
-      "language": "TypeScript",
-      "license": "Apache-2.0",
-      "interface": "CLI",
-      "pricing": "Free (open source)",
-      "irrlicht_support": "live",
-      "first_seen": "2026-04-05",
-      "alternative_metrics": null,
-      "stars_history": [
-        {
-          "date": "2026-07-05",
-          "stars": 105752
-        },
-        {
-          "date": "2026-05-15",
-          "stars": 104022
-        },
-        {
-          "date": "2026-04-24",
-          "stars": 102304
-        },
-        {
-          "date": "2026-04-12",
-          "stars": 100994
-        }
-      ]
-    },
-    {
       "name": "OpenAI Codex",
       "github_repo": "openai/codex",
       "category": "agent",
       "website": "https://github.com/openai/codex",
       "description": "Lightweight coding agent that runs in your terminal",
-      "stars": 95588,
+      "stars": 112507,
       "language": "Rust",
       "license": "Apache-2.0",
       "interface": "CLI",
@@ -148,6 +148,10 @@
       "first_seen": "2026-04-05",
       "alternative_metrics": null,
       "stars_history": [
+        {
+          "date": "2026-08-22",
+          "stars": 112507
+        },
         {
           "date": "2026-07-05",
           "stars": 95588
@@ -167,35 +171,39 @@
       ]
     },
     {
-      "name": "OpenHands",
-      "github_repo": "OpenHands/OpenHands",
+      "name": "Gemini CLI",
+      "github_repo": "google-gemini/gemini-cli",
       "category": "agent",
-      "website": "https://github.com/OpenHands/OpenHands",
-      "description": "🙌 OpenHands: AI-Driven Development",
-      "stars": 79471,
-      "language": "Python",
-      "license": "NOASSERTION",
-      "interface": "CLI / Web",
+      "website": "https://github.com/google-gemini/gemini-cli",
+      "description": "An open-source AI agent that brings the power of Gemini directly into your terminal.",
+      "stars": 106611,
+      "language": "TypeScript",
+      "license": "Apache-2.0",
+      "interface": "CLI",
       "pricing": "Free (open source)",
-      "irrlicht_support": "none",
+      "irrlicht_support": "live",
       "first_seen": "2026-04-05",
       "alternative_metrics": null,
       "stars_history": [
         {
+          "date": "2026-08-22",
+          "stars": 106611
+        },
+        {
           "date": "2026-07-05",
-          "stars": 79471
+          "stars": 105752
         },
         {
           "date": "2026-05-15",
-          "stars": 73613
+          "stars": 104022
         },
         {
           "date": "2026-04-24",
-          "stars": 71985
+          "stars": 102304
         },
         {
           "date": "2026-04-12",
-          "stars": 71060
+          "stars": 100994
         }
       ]
     },
@@ -205,7 +213,7 @@
       "category": "agent",
       "website": "https://github.com/earendil-works/pi",
       "description": "AI agent toolkit: unified LLM API, agent loop, TUI, coding agent CLI",
-      "stars": 67727,
+      "stars": 95386,
       "language": "TypeScript",
       "license": "MIT",
       "interface": "CLI",
@@ -214,6 +222,10 @@
       "first_seen": "2026-04-05",
       "alternative_metrics": null,
       "stars_history": [
+        {
+          "date": "2026-08-22",
+          "stars": 95386
+        },
         {
           "date": "2026-07-05",
           "stars": 67727
@@ -233,12 +245,49 @@
       ]
     },
     {
+      "name": "OpenHands",
+      "github_repo": "OpenHands/OpenHands",
+      "category": "agent",
+      "website": "https://github.com/OpenHands/OpenHands",
+      "description": "\ud83d\ude4c OpenHands: AI-Driven Development",
+      "stars": 84783,
+      "language": "TypeScript",
+      "license": "MIT",
+      "interface": "CLI / Web",
+      "pricing": "Free (open source)",
+      "irrlicht_support": "none",
+      "first_seen": "2026-04-05",
+      "alternative_metrics": null,
+      "stars_history": [
+        {
+          "date": "2026-08-22",
+          "stars": 84783
+        },
+        {
+          "date": "2026-07-05",
+          "stars": 79471
+        },
+        {
+          "date": "2026-05-15",
+          "stars": 73613
+        },
+        {
+          "date": "2026-04-24",
+          "stars": 71985
+        },
+        {
+          "date": "2026-04-12",
+          "stars": 71060
+        }
+      ]
+    },
+    {
       "name": "Cline",
       "github_repo": "cline/cline",
       "category": "agent",
       "website": "https://cline.bot",
       "description": "Autonomous coding agent as an SDK, IDE extension, or CLI assistant.",
-      "stars": 64294,
+      "stars": 66653,
       "language": "TypeScript",
       "license": "Apache-2.0",
       "interface": "IDE extension (VS Code)",
@@ -247,6 +296,10 @@
       "first_seen": "2026-04-05",
       "alternative_metrics": null,
       "stars_history": [
+        {
+          "date": "2026-08-22",
+          "stars": 66653
+        },
         {
           "date": "2026-07-05",
           "stars": 64294
@@ -271,7 +324,7 @@
       "category": "agent",
       "website": "https://www.warp.dev",
       "description": "Warp is an agentic development environment, born out of the terminal.",
-      "stars": 62818,
+      "stars": 64441,
       "language": "Rust",
       "license": "AGPL-3.0",
       "interface": "Desktop app (Terminal)",
@@ -280,6 +333,10 @@
       "first_seen": "2026-04-05",
       "alternative_metrics": null,
       "stars_history": [
+        {
+          "date": "2026-08-22",
+          "stars": 64441
+        },
         {
           "date": "2026-07-05",
           "stars": 62818
@@ -304,7 +361,7 @@
       "category": "agent",
       "website": "https://block.github.io/goose/",
       "description": "an open source, extensible AI agent that goes beyond code suggestions - install, execute, edit, and test with any LLM",
-      "stars": 50663,
+      "stars": 53235,
       "language": "Rust",
       "license": "Apache-2.0",
       "interface": "CLI / Desktop app",
@@ -313,6 +370,10 @@
       "first_seen": "2026-04-05",
       "alternative_metrics": null,
       "stars_history": [
+        {
+          "date": "2026-08-22",
+          "stars": 53235
+        },
         {
           "date": "2026-07-05",
           "stars": 50663
@@ -337,7 +398,7 @@
       "category": "agent",
       "website": "https://aider.chat",
       "description": "aider is AI pair programming in your terminal",
-      "stars": 47065,
+      "stars": 48399,
       "language": "Python",
       "license": "Apache-2.0",
       "interface": "CLI",
@@ -346,6 +407,10 @@
       "first_seen": "2026-04-05",
       "alternative_metrics": null,
       "stars_history": [
+        {
+          "date": "2026-08-22",
+          "stars": 48399
+        },
         {
           "date": "2026-07-05",
           "stars": 47065
@@ -370,7 +435,7 @@
       "category": "agent",
       "website": "https://continue.dev",
       "description": "open-source coding agent",
-      "stars": 34690,
+      "stars": 35589,
       "language": "TypeScript",
       "license": "Apache-2.0",
       "interface": "IDE extension / CLI",
@@ -379,6 +444,10 @@
       "first_seen": "2026-04-05",
       "alternative_metrics": null,
       "stars_history": [
+        {
+          "date": "2026-08-22",
+          "stars": 35589
+        },
         {
           "date": "2026-07-05",
           "stars": 34690
@@ -402,8 +471,8 @@
       "github_repo": "cursor/cursor",
       "category": "agent",
       "website": "https://cursor.com",
-      "description": "Proprietary AI-first code editor (the GitHub repo hosts issues only; editor source is closed).",
-      "stars": 33006,
+      "description": null,
+      "stars": 33156,
       "language": null,
       "license": null,
       "interface": "Desktop app (IDE)",
@@ -412,6 +481,10 @@
       "first_seen": "2026-04-05",
       "alternative_metrics": null,
       "stars_history": [
+        {
+          "date": "2026-08-22",
+          "stars": 33156
+        },
         {
           "date": "2026-07-05",
           "stars": 33006
@@ -435,8 +508,8 @@
       "github_repo": "charmbracelet/crush",
       "category": "agent",
       "website": "https://charm.land/crush",
-      "description": "Glamourous agentic coding for all 💘",
-      "stars": 26077,
+      "description": "Glamourous agentic coding for all \ud83d\udc98",
+      "stars": 27573,
       "language": "Go",
       "license": "NOASSERTION",
       "interface": "CLI",
@@ -445,6 +518,10 @@
       "first_seen": "2026-04-10",
       "alternative_metrics": null,
       "stars_history": [
+        {
+          "date": "2026-08-22",
+          "stars": 27573
+        },
         {
           "date": "2026-07-05",
           "stars": 26077
@@ -469,7 +546,7 @@
       "category": "agent",
       "website": "https://qwen.ai/qwencode",
       "description": "An open-source AI coding agent that lives in your terminal.",
-      "stars": 25787,
+      "stars": 27288,
       "language": "TypeScript",
       "license": "Apache-2.0",
       "interface": "CLI",
@@ -478,6 +555,10 @@
       "first_seen": "2026-04-10",
       "alternative_metrics": null,
       "stars_history": [
+        {
+          "date": "2026-08-22",
+          "stars": 27288
+        },
         {
           "date": "2026-07-05",
           "stars": 25787
@@ -502,7 +583,7 @@
       "category": "agent",
       "website": "https://kilo.ai",
       "description": "Kilo is the all-in-one agentic engineering platform. Build, ship, and iterate faster with the most popular open source coding agent.",
-      "stars": 25591,
+      "stars": 26973,
       "language": "TypeScript",
       "license": "MIT",
       "interface": "IDE extension / CLI",
@@ -511,6 +592,10 @@
       "first_seen": "2026-04-05",
       "alternative_metrics": null,
       "stars_history": [
+        {
+          "date": "2026-08-22",
+          "stars": 26973
+        },
         {
           "date": "2026-07-05",
           "stars": 25591
@@ -534,8 +619,8 @@
       "github_repo": "SWE-agent/SWE-agent",
       "category": "agent",
       "website": "https://swe-agent.com",
-      "description": "SWE-agent takes a GitHub issue and tries to automatically fix it, using your LM of choice. It can also be employed for offensive cybersecurity or competitive coding challenges. [NeurIPS 2024]",
-      "stars": 19705,
+      "description": "SWE-agent takes a GitHub issue and tries to automatically fix it, using your LM of choice. It can also be employed for offensive cybersecurity or competitive coding challenges. [NeurIPS 2024] ",
+      "stars": 20106,
       "language": "Python",
       "license": "MIT",
       "interface": "CLI",
@@ -544,6 +629,10 @@
       "first_seen": "2026-04-05",
       "alternative_metrics": null,
       "stars_history": [
+        {
+          "date": "2026-08-22",
+          "stars": 20106
+        },
         {
           "date": "2026-07-05",
           "stars": 19705
@@ -568,7 +657,7 @@
       "category": "agent",
       "website": "https://plandex.ai",
       "description": "Open source AI coding agent. Designed for large projects and real world tasks.",
-      "stars": 15502,
+      "stars": 15590,
       "language": "Go",
       "license": "MIT",
       "interface": "CLI",
@@ -577,6 +666,10 @@
       "first_seen": "2026-04-10",
       "alternative_metrics": null,
       "stars_history": [
+        {
+          "date": "2026-08-22",
+          "stars": 15590
+        },
         {
           "date": "2026-07-05",
           "stars": 15502
@@ -596,12 +689,33 @@
       ]
     },
     {
+      "name": "GitHub Copilot CLI",
+      "github_repo": "github/copilot-cli",
+      "category": "agent",
+      "website": "https://github.com/github/copilot-cli",
+      "description": "GitHub Copilot CLI brings the power of Copilot coding agent directly to your terminal.",
+      "stars": 11111,
+      "language": "Shell",
+      "license": null,
+      "interface": "CLI",
+      "pricing": "Paid (usage-based)",
+      "irrlicht_support": "live",
+      "first_seen": "2026-08-22",
+      "alternative_metrics": null,
+      "stars_history": [
+        {
+          "date": "2026-08-22",
+          "stars": 11111
+        }
+      ]
+    },
+    {
       "name": "Open SWE",
       "github_repo": "langchain-ai/open-swe",
       "category": "agent",
       "website": "https://github.com/langchain-ai/open-swe",
       "description": "An Open-Source Asynchronous Coding Agent",
-      "stars": 10103,
+      "stars": 10586,
       "language": "Python",
       "license": "MIT",
       "interface": "Web",
@@ -610,6 +724,10 @@
       "first_seen": "2026-04-05",
       "alternative_metrics": null,
       "stars_history": [
+        {
+          "date": "2026-08-22",
+          "stars": 10586
+        },
         {
           "date": "2026-07-05",
           "stars": 10103
@@ -634,7 +752,7 @@
       "category": "agent",
       "website": "https://sweep.dev",
       "description": "Sweep: AI coding assistant for JetBrains",
-      "stars": 7700,
+      "stars": 7701,
       "language": "Jupyter Notebook",
       "license": "NOASSERTION",
       "interface": "IDE extension (JetBrains)",
@@ -643,6 +761,10 @@
       "first_seen": "2026-04-05",
       "alternative_metrics": null,
       "stars_history": [
+        {
+          "date": "2026-08-22",
+          "stars": 7701
+        },
         {
           "date": "2026-07-05",
           "stars": 7700
@@ -667,7 +789,7 @@
       "category": "agent",
       "website": "https://forgecode.dev",
       "description": "AI enabled pair programmer for Claude, GPT, O Series, Grok, Deepseek, Gemini and 300+ models",
-      "stars": 7445,
+      "stars": 7499,
       "language": "Rust",
       "license": "Apache-2.0",
       "interface": "CLI",
@@ -676,6 +798,10 @@
       "first_seen": "2026-04-05",
       "alternative_metrics": null,
       "stars_history": [
+        {
+          "date": "2026-08-22",
+          "stars": 7499
+        },
         {
           "date": "2026-07-05",
           "stars": 7445
@@ -695,12 +821,33 @@
       ]
     },
     {
+      "name": "Mistral Vibe",
+      "github_repo": "mistralai/mistral-vibe",
+      "category": "agent",
+      "website": "https://github.com/mistralai/mistral-vibe",
+      "description": "Minimal CLI coding agent by Mistral",
+      "stars": 4861,
+      "language": "Python",
+      "license": "Apache-2.0",
+      "interface": "CLI",
+      "pricing": "Free (open source)",
+      "irrlicht_support": "live",
+      "first_seen": "2026-08-22",
+      "alternative_metrics": null,
+      "stars_history": [
+        {
+          "date": "2026-08-22",
+          "stars": 4861
+        }
+      ]
+    },
+    {
       "name": "Kiro",
       "github_repo": "kirodotdev/Kiro",
       "category": "agent",
       "website": "https://kiro.dev",
       "description": "Kiro is an agentic IDE that works alongside you from prototype to production.",
-      "stars": 3965,
+      "stars": 4215,
       "language": "TypeScript",
       "license": null,
       "interface": "Desktop app (IDE) / CLI",
@@ -709,6 +856,10 @@
       "first_seen": "2026-04-10",
       "alternative_metrics": null,
       "stars_history": [
+        {
+          "date": "2026-08-22",
+          "stars": 4215
+        },
         {
           "date": "2026-07-05",
           "stars": 3965
@@ -721,7 +872,7 @@
       "category": "agent",
       "website": "https://www.ra-aid.ai",
       "description": "Develop software autonomously.",
-      "stars": 2223,
+      "stars": 2222,
       "language": "Python",
       "license": "Apache-2.0",
       "interface": "CLI",
@@ -730,6 +881,10 @@
       "first_seen": "2026-04-05",
       "alternative_metrics": null,
       "stars_history": [
+        {
+          "date": "2026-08-22",
+          "stars": 2222
+        },
         {
           "date": "2026-07-05",
           "stars": 2223
@@ -749,45 +904,12 @@
       ]
     },
     {
-      "name": "Factory",
-      "github_repo": "Factory-AI/factory",
-      "category": "agent",
-      "website": "https://www.factory.ai",
-      "description": "Factory - Agent-Native Software Development",
-      "stars": 1007,
-      "language": null,
-      "license": null,
-      "interface": "Web / CLI",
-      "pricing": "Paid",
-      "irrlicht_support": "none",
-      "first_seen": "2026-04-05",
-      "alternative_metrics": null,
-      "stars_history": [
-        {
-          "date": "2026-07-05",
-          "stars": 1007
-        },
-        {
-          "date": "2026-05-15",
-          "stars": 876
-        },
-        {
-          "date": "2026-04-24",
-          "stars": 794
-        },
-        {
-          "date": "2026-04-12",
-          "stars": 756
-        }
-      ]
-    },
-    {
       "name": "Pear AI",
       "github_repo": "trypear/pearai-app",
       "category": "agent",
       "website": "https://trypear.ai",
       "description": "PearAI: Open Source AI Code Editor (Fork of VSCode). The PearAI Submodule (https://github.com/trypear/pearai-submodule) is a fork of Continue.",
-      "stars": 703,
+      "stars": 706,
       "language": "TypeScript",
       "license": "MIT",
       "interface": "Desktop app (IDE)",
@@ -796,6 +918,10 @@
       "first_seen": "2026-04-05",
       "alternative_metrics": null,
       "stars_history": [
+        {
+          "date": "2026-08-22",
+          "stars": 706
+        },
         {
           "date": "2026-07-05",
           "stars": 703
@@ -815,35 +941,39 @@
       ]
     },
     {
-      "name": "Codegen",
-      "github_repo": "codegen-sh/codegen",
+      "name": "Factory",
+      "github_repo": "Factory-AI/factory",
       "category": "agent",
-      "website": "https://codegen.com",
-      "description": "Python wrapper for the Codegen API - run code agents at scale",
-      "stars": 519,
-      "language": "Python",
-      "license": "Apache-2.0",
-      "interface": "SDK / Web",
+      "website": "https://www.factory.ai",
+      "description": "Factory - Agent-Native Software Development",
+      "stars": 5,
+      "language": null,
+      "license": null,
+      "interface": "Web / CLI",
       "pricing": "Paid",
       "irrlicht_support": "none",
       "first_seen": "2026-04-05",
       "alternative_metrics": null,
       "stars_history": [
         {
+          "date": "2026-08-22",
+          "stars": 5
+        },
+        {
           "date": "2026-07-05",
-          "stars": 519
+          "stars": 1007
         },
         {
           "date": "2026-05-15",
-          "stars": 521
+          "stars": 876
         },
         {
           "date": "2026-04-24",
-          "stars": 521
+          "stars": 794
         },
         {
           "date": "2026-04-12",
-          "stars": 521
+          "stars": 756
         }
       ]
     },
@@ -925,6 +1055,25 @@
       "stars_history": []
     },
     {
+      "name": "CodeGPT",
+      "github_repo": null,
+      "category": "agent",
+      "website": "https://www.codegpt.co",
+      "description": "Full-stack AI agent platform with a codebase knowledge graph.",
+      "stars": null,
+      "language": null,
+      "license": null,
+      "interface": "IDE extension / Web",
+      "pricing": "Freemium",
+      "irrlicht_support": "none",
+      "first_seen": "2026-04-05",
+      "alternative_metrics": {
+        "source": "no public metrics found (checked 2026-07-05)",
+        "measured_date": "2026-07-05"
+      },
+      "stars_history": []
+    },
+    {
       "name": "Codebuff",
       "github_repo": null,
       "category": "agent",
@@ -940,25 +1089,6 @@
       "alternative_metrics": {
         "funding_millions_usd": 1.5,
         "source": "Crunchbase; YC F24 ~$500K seed, ~$1.5M total raised (checked 2026-07-05)",
-        "measured_date": "2026-07-05"
-      },
-      "stars_history": []
-    },
-    {
-      "name": "CodeGPT",
-      "github_repo": null,
-      "category": "agent",
-      "website": "https://www.codegpt.co",
-      "description": "Full-stack AI agent platform with a codebase knowledge graph.",
-      "stars": null,
-      "language": null,
-      "license": null,
-      "interface": "IDE extension / Web",
-      "pricing": "Freemium",
-      "irrlicht_support": "none",
-      "first_seen": "2026-04-05",
-      "alternative_metrics": {
-        "source": "no public metrics found (checked 2026-07-05)",
         "measured_date": "2026-07-05"
       },
       "stars_history": []
@@ -1019,7 +1149,7 @@
       "first_seen": "2026-04-05",
       "alternative_metrics": {
         "estimated_users": "4700000",
-        "source": "Microsoft Jan 28 2026 earnings call: ~4.7M paid GitHub Copilot subscribers. CORRECTION: prior '20000000+' figure conflated this with Microsoft 365 Copilot's ~20M paid seats (disclosed on Microsoft's Apr 29 2026 call) — a different product; do not merge again.",
+        "source": "Microsoft Jan 28 2026 earnings call: ~4.7M paid GitHub Copilot subscribers. CORRECTION: prior '20000000+' figure conflated this with Microsoft 365 Copilot's ~20M paid seats (disclosed on Microsoft's Apr 29 2026 call) \u2014 a different product; do not merge again.",
         "measured_date": "2026-07-05"
       },
       "stars_history": []
@@ -1139,7 +1269,7 @@
       "irrlicht_support": "none",
       "first_seen": "2026-04-05",
       "alternative_metrics": {
-        "source": "no credible new disclosure (checked 2026-07-05). A low-quality aggregator (Signalbase) claim of a '$100K seed' (~Mar 2026, no named investors) was evaluated and rejected as not credible. Last verifiable figure: Scale Venture Partners-led ~$2.1M round (Sep 2025) — not independently reconfirmed this run, so left unset rather than carried forward unverified.",
+        "source": "no credible new disclosure (checked 2026-07-05). A low-quality aggregator (Signalbase) claim of a '$100K seed' (~Mar 2026, no named investors) was evaluated and rejected as not credible. Last verifiable figure: Scale Venture Partners-led ~$2.1M round (Sep 2025) \u2014 not independently reconfirmed this run, so left unset rather than carried forward unverified.",
         "measured_date": "2026-07-05"
       },
       "stars_history": []
@@ -1150,7 +1280,7 @@
       "category": "orchestrator",
       "website": "https://paperclip.ing",
       "description": "The open-source app everyone uses to manage agents at work",
-      "stars": 72750,
+      "stars": 79146,
       "language": "TypeScript",
       "license": "MIT",
       "interface": "Web",
@@ -1159,6 +1289,10 @@
       "first_seen": "2026-04-10",
       "alternative_metrics": null,
       "stars_history": [
+        {
+          "date": "2026-08-22",
+          "stars": 79146
+        },
         {
           "date": "2026-07-05",
           "stars": 72750
@@ -1182,8 +1316,8 @@
       "github_repo": "ruvnet/ruflo",
       "category": "orchestrator",
       "website": "https://github.com/ruvnet/ruflo",
-      "description": "🌊 The leading agent meta-harness. Deploy intelligent multi-player swarms, coordinate autonomous workflows, and build conversational AI systems. Features adaptive memory, self-learning intelligence, RAG integration, and native Claude Code / Codex / Hermes and many more Integrated",
-      "stars": 63063,
+      "description": "\ud83c\udf0a The original agent meta-harness. Deploy intelligent multi-player swarms, coordinate autonomous workflows, and build conversational AI systems. Features adaptive memory, self-learning intelligence, RAG integration, and native Claude Code / Codex / Hermes and many more Integrated",
+      "stars": 68823,
       "language": "TypeScript",
       "license": "MIT",
       "interface": "CLI / SDK",
@@ -1192,6 +1326,10 @@
       "first_seen": "2026-04-05",
       "alternative_metrics": null,
       "stars_history": [
+        {
+          "date": "2026-08-22",
+          "stars": 68823
+        },
         {
           "date": "2026-07-05",
           "stars": 63063
@@ -1216,7 +1354,7 @@
       "category": "orchestrator",
       "website": "https://www.agno.com",
       "description": "Build, run, and manage agent platforms.",
-      "stars": 40999,
+      "stars": 41832,
       "language": "Python",
       "license": "Apache-2.0",
       "interface": "SDK / Web",
@@ -1225,6 +1363,10 @@
       "first_seen": "2026-04-05",
       "alternative_metrics": null,
       "stars_history": [
+        {
+          "date": "2026-08-22",
+          "stars": 41832
+        },
         {
           "date": "2026-07-05",
           "stars": 40999
@@ -1249,7 +1391,7 @@
       "category": "orchestrator",
       "website": "https://github.com/OpenBMB/ChatDev",
       "description": "ChatDev 2.0: Dev All through LLM-powered Multi-Agent Collaboration",
-      "stars": 33658,
+      "stars": 34096,
       "language": "Python",
       "license": "Apache-2.0",
       "interface": "CLI / Web",
@@ -1258,6 +1400,10 @@
       "first_seen": "2026-04-05",
       "alternative_metrics": null,
       "stars_history": [
+        {
+          "date": "2026-08-22",
+          "stars": 34096
+        },
         {
           "date": "2026-07-05",
           "stars": 33658
@@ -1282,7 +1428,7 @@
       "category": "orchestrator",
       "website": "https://github.com/stitionai/devika",
       "description": "Devika is the first open-source implementation of an Agentic Software Engineer. Initially started as an open-source alternative to Devin.",
-      "stars": 19535,
+      "stars": 19558,
       "language": "Python",
       "license": "MIT",
       "interface": "Web",
@@ -1291,6 +1437,10 @@
       "first_seen": "2026-04-05",
       "alternative_metrics": null,
       "stars_history": [
+        {
+          "date": "2026-08-22",
+          "stars": 19558
+        },
         {
           "date": "2026-07-05",
           "stars": 19535
@@ -1315,7 +1465,7 @@
       "category": "orchestrator",
       "website": "https://github.com/gastownhall/gastown",
       "description": "Gas Town - multi-agent workspace manager",
-      "stars": 16235,
+      "stars": 17719,
       "language": "Go",
       "license": "MIT",
       "interface": "CLI",
@@ -1324,6 +1474,10 @@
       "first_seen": "2026-04-05",
       "alternative_metrics": null,
       "stars_history": [
+        {
+          "date": "2026-08-22",
+          "stars": 17719
+        },
         {
           "date": "2026-07-05",
           "stars": 16235
@@ -1343,20 +1497,24 @@
       ]
     },
     {
-      "name": "Composio",
-      "github_repo": "AgentWrapper/agent-orchestrator",
+      "name": "Agent Orchestrator (AO)",
+      "github_repo": "Untrivial-ai/agent-orchestrator",
       "category": "orchestrator",
-      "website": "https://composio.dev",
-      "description": "Agentic orchestrator for parallel coding agents — plans tasks, spawns agents, and autonomously handles CI fixes, merge conflicts, and code reviews.",
-      "stars": 8053,
+      "website": "https://aoagents.dev",
+      "description": "Agent IDE that enables you to manage fleets of coding agents. It comes with an agentic orchestrator that plans tasks, spawns agents, and autonomously handles CI fixes, merge conflicts, and code reviews.",
+      "stars": 9825,
       "language": "Go",
       "license": "Apache-2.0",
-      "interface": "CLI / Web",
-      "pricing": "Freemium",
+      "interface": "Desktop app",
+      "pricing": "Free (open source)",
       "irrlicht_support": "none",
       "first_seen": "2026-04-05",
       "alternative_metrics": null,
       "stars_history": [
+        {
+          "date": "2026-08-22",
+          "stars": 9825
+        },
         {
           "date": "2026-07-05",
           "stars": 8053
@@ -1381,7 +1539,7 @@
       "category": "orchestrator",
       "website": "https://github.com/smtg-ai/claude-squad",
       "description": "Manage multiple AI terminal agents like Claude Code, Codex, OpenCode, and Amp.",
-      "stars": 8023,
+      "stars": 8352,
       "language": "Go",
       "license": "AGPL-3.0",
       "interface": "CLI (tmux)",
@@ -1390,6 +1548,10 @@
       "first_seen": "2026-04-05",
       "alternative_metrics": null,
       "stars_history": [
+        {
+          "date": "2026-08-22",
+          "stars": 8352
+        },
         {
           "date": "2026-07-05",
           "stars": 8023
@@ -1413,8 +1575,8 @@
       "github_repo": "generalaction/emdash",
       "category": "orchestrator",
       "website": "https://github.com/generalaction/emdash",
-      "description": "Emdash is the Open-Source Agentic Development Environment (🧡 YC W26). Run multiple coding agents in parallel. Use any provider.",
-      "stars": 5070,
+      "description": "Emdash is the Open-Source Agentic Development Environment (\ud83e\udde1 YC W26). Run multiple coding agents in parallel. Use any provider.",
+      "stars": 5464,
       "language": "TypeScript",
       "license": "Apache-2.0",
       "interface": "Desktop app (Electron)",
@@ -1423,6 +1585,10 @@
       "first_seen": "2026-05-31",
       "alternative_metrics": null,
       "stars_history": [
+        {
+          "date": "2026-08-22",
+          "stars": 5464
+        },
         {
           "date": "2026-07-05",
           "stars": 5070
@@ -1439,7 +1605,7 @@
       "category": "orchestrator",
       "website": "https://github.com/darrenhinde/OpenAgentsControl",
       "description": "AI agent framework for plan-first development workflows with approval-based execution. Multi-language support (TypeScript, Python, Go, Rust) with automatic testing, code review, and validation built for OpenCode",
-      "stars": 4484,
+      "stars": 4757,
       "language": "TypeScript",
       "license": "MIT",
       "interface": "CLI / SDK",
@@ -1448,6 +1614,10 @@
       "first_seen": "2026-05-31",
       "alternative_metrics": null,
       "stars_history": [
+        {
+          "date": "2026-08-22",
+          "stars": 4757
+        },
         {
           "date": "2026-07-05",
           "stars": 4484
@@ -1463,8 +1633,8 @@
       "github_repo": "sipyourdrink-ltd/bernstein",
       "category": "orchestrator",
       "website": "https://bernstein.run",
-      "description": "Audit-grade multi-agent orchestration for CLI coding agents (Claude Code, Codex, Gemini CLI, +40 more). HMAC-chained audit log, signed agent cards, per-artefact lineage, air-gap deploy. The orchestrator your compliance team will sign off on. https://bernstein.run",
-      "stars": 634,
+      "description": "Deterministic orchestrator for CLI coding agents (Claude Code, Codex, Gemini CLI, +40 more). No model in the coordination loop, so parallel runs in per-task git worktrees replay byte-identically. Signed lineage plus an opt-in HMAC audit chain a reviewer checks offline. Cluster mode, air-gap deploy. Status: beta. https://bernstein.run",
+      "stars": 953,
       "language": "Python",
       "license": "Apache-2.0",
       "interface": "CLI",
@@ -1473,6 +1643,10 @@
       "first_seen": "2026-05-31",
       "alternative_metrics": null,
       "stars_history": [
+        {
+          "date": "2026-08-22",
+          "stars": 953
+        },
         {
           "date": "2026-07-05",
           "stars": 634
@@ -1488,8 +1662,8 @@
       "github_repo": "dlorenc/multiclaude",
       "category": "orchestrator",
       "website": "https://github.com/dlorenc/multiclaude",
-      "description": "Parallel Claude Code instances in tmux with a Brownian-ratchet CI model.",
-      "stars": 555,
+      "description": null,
+      "stars": 563,
       "language": "Go",
       "license": null,
       "interface": "CLI (tmux)",
@@ -1498,6 +1672,10 @@
       "first_seen": "2026-04-05",
       "alternative_metrics": null,
       "stars_history": [
+        {
+          "date": "2026-08-22",
+          "stars": 563
+        },
         {
           "date": "2026-07-05",
           "stars": 555
@@ -1522,7 +1700,7 @@
       "category": "orchestrator",
       "website": "https://stoneforge.ai",
       "description": "A web dashboard and runtime for orchestrating AI coding agents",
-      "stars": 160,
+      "stars": 176,
       "language": "TypeScript",
       "license": "Apache-2.0",
       "interface": "Web",
@@ -1531,6 +1709,10 @@
       "first_seen": "2026-04-05",
       "alternative_metrics": null,
       "stars_history": [
+        {
+          "date": "2026-08-22",
+          "stars": 176
+        },
         {
           "date": "2026-07-05",
           "stars": 160
@@ -1555,15 +1737,19 @@
       "category": "orchestrator",
       "website": "https://forge.nxtg.ai",
       "description": "Forge Orchestrator: Multi-AI task orchestration. File locking, knowledge capture, drift detection. Rust.",
-      "stars": 128,
+      "stars": 158,
       "language": "Rust",
-      "license": null,
+      "license": "NOASSERTION",
       "interface": "CLI",
       "pricing": "Free (open source)",
       "irrlicht_support": "none",
       "first_seen": "2026-04-05",
       "alternative_metrics": null,
       "stars_history": [
+        {
+          "date": "2026-08-22",
+          "stars": 158
+        },
         {
           "date": "2026-07-05",
           "stars": 128
@@ -1585,12 +1771,46 @@
   ],
   "archived": [
     {
+      "name": "Void",
+      "github_repo": "voideditor/void",
+      "category": "agent",
+      "website": "https://voideditor.com",
+      "description": null,
+      "stars": 28831,
+      "language": "TypeScript",
+      "license": "Apache-2.0",
+      "interface": "Desktop app (IDE)",
+      "pricing": "Free (open source)",
+      "irrlicht_support": "none",
+      "first_seen": "2026-04-05",
+      "alternative_metrics": null,
+      "stars_history": [
+        {
+          "date": "2026-08-22",
+          "stars": 28831
+        },
+        {
+          "date": "2026-05-15",
+          "stars": 28752
+        },
+        {
+          "date": "2026-04-24",
+          "stars": 28644
+        },
+        {
+          "date": "2026-04-12",
+          "stars": 28553
+        }
+      ],
+      "archived_reason": "Repo archived by owner 2026-06-02; team paused active development to \"explore novel coding ideas\" per GitHub issue #926 discussion. Not replaced by a named successor. Last release remains usable."
+    },
+    {
       "name": "Roo Code",
       "github_repo": "RooCodeInc/Roo-Code",
       "category": "agent",
       "website": "https://roocode.com",
       "description": "Roo Code gives you a whole dev team of AI agents in your code editor.",
-      "stars": 24304,
+      "stars": 24328,
       "language": "TypeScript",
       "license": "Apache-2.0",
       "interface": "IDE extension (VS Code)",
@@ -1599,6 +1819,10 @@
       "first_seen": "2026-04-05",
       "alternative_metrics": null,
       "stars_history": [
+        {
+          "date": "2026-08-22",
+          "stars": 24328
+        },
         {
           "date": "2026-05-15",
           "stars": 24073
@@ -1615,34 +1839,42 @@
       "archived_reason": "Repo archived by owner 2026-05-15 after hitting 3M installs; original team is \"going all-in on Roomote\" per project changelog, and a community team is arranging an official handoff to keep the VS Code extension maintained."
     },
     {
-      "name": "Void",
-      "github_repo": "voideditor/void",
+      "name": "Codegen",
+      "github_repo": "codegen-sh/codegen",
       "category": "agent",
-      "website": "https://voideditor.com",
-      "description": "Open-source AI code editor (VS Code fork).",
-      "stars": 28822,
-      "language": "TypeScript",
+      "website": "https://codegen.com",
+      "description": "Python wrapper for the Codegen API - run code agents at scale",
+      "stars": 519,
+      "language": "Python",
       "license": "Apache-2.0",
-      "interface": "Desktop app (IDE)",
-      "pricing": "Free (open source)",
+      "interface": "SDK / Web",
+      "pricing": "Paid",
       "irrlicht_support": "none",
       "first_seen": "2026-04-05",
       "alternative_metrics": null,
       "stars_history": [
         {
+          "date": "2026-08-22",
+          "stars": 519
+        },
+        {
+          "date": "2026-07-05",
+          "stars": 519
+        },
+        {
           "date": "2026-05-15",
-          "stars": 28752
+          "stars": 521
         },
         {
           "date": "2026-04-24",
-          "stars": 28644
+          "stars": 521
         },
         {
           "date": "2026-04-12",
-          "stars": 28553
+          "stars": 521
         }
       ],
-      "archived_reason": "Repo archived by owner 2026-06-02; team paused active development to \"explore novel coding ideas\" per GitHub issue #926 discussion. Not replaced by a named successor. Last release remains usable."
+      "archived_reason": "Codegen was acquired by ClickUp in late 2025; the standalone Codegen service was discontinued 2026-01-09 and fully shut down 2026-04-30. Its agent-orchestration tech (PR Review Agent, sandboxed execution, SOC 2 layer) lives on inside ClickUp's AI coding agent infra under the Codegen name. Source: codegen.com/blog/an-update-on-codegen; clickup.com/blog/clickup-codegen-acquisition."
     }
   ]
 }

--- a/site/landscape/compare/index.html
+++ b/site/landscape/compare/index.html
@@ -122,7 +122,7 @@ footer { padding: 2rem 2.5rem; border-top: 1px solid var(--border); display: fle
   <a href="../" class="back-link">&larr; Back to Landscape</a>
   <div class="page-header">
     <h1>Agent Comparison</h1>
-    <div class="updated">Last updated: 2026-07-05</div>
+    <div class="updated">Last updated: 2026-08-22</div>
     <p class="intro">In-depth comparison of all tracked AI coding agents and orchestrators. Click any column header to sort. Growth figures are measured relative to today using snapshots taken at: today, ~1 month ago, and ~3 months ago.</p>
   </div>
 
@@ -144,10 +144,22 @@ footer { padding: 2rem 2.5rem; border-top: 1px solid var(--border); display: fle
 </tr></thead>
 <tbody>
 <tr>
+  <td class="name" data-sort="hermes agent"><a href="https://hermes-agent.nousresearch.com" target="_blank" rel="noopener">Hermes Agent</a><sup class="badge badge-new">NEW</sup></td>
+  <td><span class="badge badge-cat badge-agent">Agent</span></td>
+  <td class="mono" data-sort="234263">234,263</td>
+  <td class="growth-3m"><span class="growth-na">—</span></td>
+  <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
+  <td>MIT</td>
+  <td>Python</td>
+  <td>CLI</td>
+  <td>Free (open source)</td>
+  <td><span class="badge badge-live">live</span></td>
+</tr>
+<tr>
   <td class="name" data-sort="opencode"><a href="https://opencode.ai" target="_blank" rel="noopener">OpenCode</a></td>
   <td><span class="badge badge-cat badge-agent">Agent</span></td>
-  <td class="mono" data-sort="182478">182,478</td>
-  <td class="growth-3m"><span class="growth-up">+21,905 <span class="growth-pct">(+13.6%)</span></span></td>
+  <td class="mono" data-sort="200227">200,227</td>
+  <td class="growth-3m"><span class="growth-up">+17,749 <span class="growth-pct">(+9.7%)</span></span></td>
   <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
   <td>MIT</td>
   <td>TypeScript</td>
@@ -156,34 +168,10 @@ footer { padding: 2rem 2.5rem; border-top: 1px solid var(--border); display: fle
   <td><span class="badge badge-live">live</span></td>
 </tr>
 <tr>
-  <td class="name" data-sort="claude code"><a href="https://www.anthropic.com/claude-code" target="_blank" rel="noopener">Claude Code</a></td>
-  <td><span class="badge badge-cat badge-agent">Agent</span></td>
-  <td class="mono" data-sort="136132">136,132</td>
-  <td class="growth-3m"><span class="growth-up">+12,371 <span class="growth-pct">(+10.0%)</span></span></td>
-  <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
-  <td>—</td>
-  <td>Python</td>
-  <td>CLI</td>
-  <td>Paid (usage-based)</td>
-  <td><span class="badge badge-live">live</span></td>
-</tr>
-<tr>
-  <td class="name" data-sort="claw code"><a href="https://github.com/ultraworkers/claw-code" target="_blank" rel="noopener">Claw Code</a></td>
-  <td><span class="badge badge-cat badge-agent">Agent</span></td>
-  <td class="mono" data-sort="194570">194,570</td>
-  <td class="growth-3m"><span class="growth-up">+3,065 <span class="growth-pct">(+1.6%)</span></span></td>
-  <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
-  <td>MIT</td>
-  <td>Rust</td>
-  <td>CLI</td>
-  <td>Free (open source)</td>
-  <td><span class="badge badge-none">not tracked</span></td>
-</tr>
-<tr>
   <td class="name" data-sort="openai codex"><a href="https://github.com/openai/codex" target="_blank" rel="noopener">OpenAI Codex</a></td>
   <td><span class="badge badge-cat badge-agent">Agent</span></td>
-  <td class="mono" data-sort="95588">95,588</td>
-  <td class="growth-3m"><span class="growth-up">+12,777 <span class="growth-pct">(+15.4%)</span></span></td>
+  <td class="mono" data-sort="112507">112,507</td>
+  <td class="growth-3m"><span class="growth-up">+16,919 <span class="growth-pct">(+17.7%)</span></span></td>
   <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
   <td>Apache-2.0</td>
   <td>Rust</td>
@@ -194,8 +182,8 @@ footer { padding: 2rem 2.5rem; border-top: 1px solid var(--border); display: fle
 <tr>
   <td class="name" data-sort="pi"><a href="https://github.com/earendil-works/pi" target="_blank" rel="noopener">Pi</a></td>
   <td><span class="badge badge-cat badge-agent">Agent</span></td>
-  <td class="mono" data-sort="67727">67,727</td>
-  <td class="growth-3m"><span class="growth-up">+18,063 <span class="growth-pct">(+36.4%)</span></span></td>
+  <td class="mono" data-sort="95386">95,386</td>
+  <td class="growth-3m"><span class="growth-up">+27,659 <span class="growth-pct">(+40.8%)</span></span></td>
   <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
   <td>MIT</td>
   <td>TypeScript</td>
@@ -204,34 +192,46 @@ footer { padding: 2rem 2.5rem; border-top: 1px solid var(--border); display: fle
   <td><span class="badge badge-live">live</span></td>
 </tr>
 <tr>
-  <td class="name" data-sort="ruflo"><a href="https://github.com/ruvnet/ruflo" target="_blank" rel="noopener">Ruflo</a></td>
-  <td><span class="badge badge-cat badge-orchestrator">Orchestrator</span></td>
-  <td class="mono" data-sort="63063">63,063</td>
-  <td class="growth-3m"><span class="growth-up">+11,802 <span class="growth-pct">(+23.0%)</span></span></td>
+  <td class="name" data-sort="claude code"><a href="https://www.anthropic.com/claude-code" target="_blank" rel="noopener">Claude Code</a></td>
+  <td><span class="badge badge-cat badge-agent">Agent</span></td>
+  <td class="mono" data-sort="142402">142,402</td>
+  <td class="growth-3m"><span class="growth-up">+6,270 <span class="growth-pct">(+4.6%)</span></span></td>
+  <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
+  <td>—</td>
+  <td>Python</td>
+  <td>CLI</td>
+  <td>Paid (usage-based)</td>
+  <td><span class="badge badge-live">live</span></td>
+</tr>
+<tr>
+  <td class="name" data-sort="claw code"><a href="https://github.com/ultraworkers/claw-code" target="_blank" rel="noopener">Claw Code</a></td>
+  <td><span class="badge badge-cat badge-agent">Agent</span></td>
+  <td class="mono" data-sort="195112">195,112</td>
+  <td class="growth-3m"><span class="growth-up">+542 <span class="growth-pct">(+0.3%)</span></span></td>
   <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
   <td>MIT</td>
-  <td>TypeScript</td>
-  <td>CLI / SDK</td>
+  <td>Rust</td>
+  <td>CLI</td>
   <td>Free (open source)</td>
-  <td><span class="badge badge-planned">planned</span></td>
+  <td><span class="badge badge-none">not tracked</span></td>
 </tr>
 <tr>
   <td class="name" data-sort="openhands"><a href="https://github.com/OpenHands/OpenHands" target="_blank" rel="noopener">OpenHands</a></td>
   <td><span class="badge badge-cat badge-agent">Agent</span></td>
-  <td class="mono" data-sort="79471">79,471</td>
-  <td class="growth-3m"><span class="growth-up">+5,858 <span class="growth-pct">(+8.0%)</span></span></td>
+  <td class="mono" data-sort="84783">84,783</td>
+  <td class="growth-3m"><span class="growth-up">+5,312 <span class="growth-pct">(+6.7%)</span></span></td>
   <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
-  <td>NOASSERTION</td>
-  <td>Python</td>
+  <td>MIT</td>
+  <td>TypeScript</td>
   <td>CLI / Web</td>
   <td>Free (open source)</td>
   <td><span class="badge badge-none">not tracked</span></td>
 </tr>
 <tr>
-  <td class="name" data-sort="paperclip"><a href="https://paperclip.ing" target="_blank" rel="noopener">Paperclip</a><sup class="badge badge-new">NEW</sup></td>
+  <td class="name" data-sort="paperclip"><a href="https://paperclip.ing" target="_blank" rel="noopener">Paperclip</a></td>
   <td><span class="badge badge-cat badge-orchestrator">Orchestrator</span></td>
-  <td class="mono" data-sort="72750">72,750</td>
-  <td class="growth-3m"><span class="growth-up">+7,190 <span class="growth-pct">(+11.0%)</span></span></td>
+  <td class="mono" data-sort="79146">79,146</td>
+  <td class="growth-3m"><span class="growth-up">+6,396 <span class="growth-pct">(+8.8%)</span></span></td>
   <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
   <td>MIT</td>
   <td>TypeScript</td>
@@ -240,10 +240,22 @@ footer { padding: 2rem 2.5rem; border-top: 1px solid var(--border); display: fle
   <td><span class="badge badge-planned">planned</span></td>
 </tr>
 <tr>
+  <td class="name" data-sort="ruflo"><a href="https://github.com/ruvnet/ruflo" target="_blank" rel="noopener">Ruflo</a></td>
+  <td><span class="badge badge-cat badge-orchestrator">Orchestrator</span></td>
+  <td class="mono" data-sort="68823">68,823</td>
+  <td class="growth-3m"><span class="growth-up">+5,760 <span class="growth-pct">(+9.1%)</span></span></td>
+  <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
+  <td>MIT</td>
+  <td>TypeScript</td>
+  <td>CLI / SDK</td>
+  <td>Free (open source)</td>
+  <td><span class="badge badge-planned">planned</span></td>
+</tr>
+<tr>
   <td class="name" data-sort="gemini cli"><a href="https://github.com/google-gemini/gemini-cli" target="_blank" rel="noopener">Gemini CLI</a></td>
   <td><span class="badge badge-cat badge-agent">Agent</span></td>
-  <td class="mono" data-sort="105752">105,752</td>
-  <td class="growth-3m"><span class="growth-up">+1,730 <span class="growth-pct">(+1.7%)</span></span></td>
+  <td class="mono" data-sort="106611">106,611</td>
+  <td class="growth-3m"><span class="growth-up">+859 <span class="growth-pct">(+0.8%)</span></span></td>
   <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
   <td>Apache-2.0</td>
   <td>TypeScript</td>
@@ -252,10 +264,22 @@ footer { padding: 2rem 2.5rem; border-top: 1px solid var(--border); display: fle
   <td><span class="badge badge-live">live</span></td>
 </tr>
 <tr>
+  <td class="name" data-sort="cline"><a href="https://cline.bot" target="_blank" rel="noopener">Cline</a></td>
+  <td><span class="badge badge-cat badge-agent">Agent</span></td>
+  <td class="mono" data-sort="66653">66,653</td>
+  <td class="growth-3m"><span class="growth-up">+2,359 <span class="growth-pct">(+3.7%)</span></span></td>
+  <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
+  <td>Apache-2.0</td>
+  <td>TypeScript</td>
+  <td>IDE extension (VS Code)</td>
+  <td>Freemium</td>
+  <td><span class="badge badge-none">not tracked</span></td>
+</tr>
+<tr>
   <td class="name" data-sort="warp"><a href="https://www.warp.dev" target="_blank" rel="noopener">Warp</a></td>
   <td><span class="badge badge-cat badge-agent">Agent</span></td>
-  <td class="mono" data-sort="62818">62,818</td>
-  <td class="growth-3m"><span class="growth-up">+4,288 <span class="growth-pct">(+7.3%)</span></span></td>
+  <td class="mono" data-sort="64441">64,441</td>
+  <td class="growth-3m"><span class="growth-up">+1,623 <span class="growth-pct">(+2.6%)</span></span></td>
   <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
   <td>AGPL-3.0</td>
   <td>Rust</td>
@@ -266,8 +290,8 @@ footer { padding: 2rem 2.5rem; border-top: 1px solid var(--border); display: fle
 <tr>
   <td class="name" data-sort="goose"><a href="https://block.github.io/goose/" target="_blank" rel="noopener">Goose</a></td>
   <td><span class="badge badge-cat badge-agent">Agent</span></td>
-  <td class="mono" data-sort="50663">50,663</td>
-  <td class="growth-3m"><span class="growth-up">+5,433 <span class="growth-pct">(+12.0%)</span></span></td>
+  <td class="mono" data-sort="53235">53,235</td>
+  <td class="growth-3m"><span class="growth-up">+2,572 <span class="growth-pct">(+5.1%)</span></span></td>
   <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
   <td>Apache-2.0</td>
   <td>Rust</td>
@@ -276,22 +300,10 @@ footer { padding: 2rem 2.5rem; border-top: 1px solid var(--border); display: fle
   <td><span class="badge badge-planned">planned</span></td>
 </tr>
 <tr>
-  <td class="name" data-sort="cline"><a href="https://cline.bot" target="_blank" rel="noopener">Cline</a></td>
-  <td><span class="badge badge-cat badge-agent">Agent</span></td>
-  <td class="mono" data-sort="64294">64,294</td>
-  <td class="growth-3m"><span class="growth-up">+2,485 <span class="growth-pct">(+4.0%)</span></span></td>
-  <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
-  <td>Apache-2.0</td>
-  <td>TypeScript</td>
-  <td>IDE extension (VS Code)</td>
-  <td>Freemium</td>
-  <td><span class="badge badge-none">not tracked</span></td>
-</tr>
-<tr>
   <td class="name" data-sort="aider"><a href="https://aider.chat" target="_blank" rel="noopener">Aider</a></td>
   <td><span class="badge badge-cat badge-agent">Agent</span></td>
-  <td class="mono" data-sort="47065">47,065</td>
-  <td class="growth-3m"><span class="growth-up">+2,223 <span class="growth-pct">(+5.0%)</span></span></td>
+  <td class="mono" data-sort="48399">48,399</td>
+  <td class="growth-3m"><span class="growth-up">+1,334 <span class="growth-pct">(+2.8%)</span></span></td>
   <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
   <td>Apache-2.0</td>
   <td>Python</td>
@@ -300,34 +312,10 @@ footer { padding: 2rem 2.5rem; border-top: 1px solid var(--border); display: fle
   <td><span class="badge badge-live">live</span></td>
 </tr>
 <tr>
-  <td class="name" data-sort="kilo code"><a href="https://kilo.ai" target="_blank" rel="noopener">Kilo Code</a></td>
-  <td><span class="badge badge-cat badge-agent">Agent</span></td>
-  <td class="mono" data-sort="25591">25,591</td>
-  <td class="growth-3m"><span class="growth-up">+6,287 <span class="growth-pct">(+32.6%)</span></span></td>
-  <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
-  <td>MIT</td>
-  <td>TypeScript</td>
-  <td>IDE extension / CLI</td>
-  <td>Freemium</td>
-  <td><span class="badge badge-planned">planned</span></td>
-</tr>
-<tr>
-  <td class="name" data-sort="continue"><a href="https://continue.dev" target="_blank" rel="noopener">Continue</a></td>
-  <td><span class="badge badge-cat badge-agent">Agent</span></td>
-  <td class="mono" data-sort="34690">34,690</td>
-  <td class="growth-3m"><span class="growth-up">+1,494 <span class="growth-pct">(+4.5%)</span></span></td>
-  <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
-  <td>Apache-2.0</td>
-  <td>TypeScript</td>
-  <td>IDE extension / CLI</td>
-  <td>Freemium</td>
-  <td><span class="badge badge-planned">planned</span></td>
-</tr>
-<tr>
   <td class="name" data-sort="agno"><a href="https://www.agno.com" target="_blank" rel="noopener">Agno</a></td>
   <td><span class="badge badge-cat badge-orchestrator">Orchestrator</span></td>
-  <td class="mono" data-sort="40999">40,999</td>
-  <td class="growth-3m"><span class="growth-up">+865 <span class="growth-pct">(+2.2%)</span></span></td>
+  <td class="mono" data-sort="41832">41,832</td>
+  <td class="growth-3m"><span class="growth-up">+833 <span class="growth-pct">(+2.0%)</span></span></td>
   <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
   <td>Apache-2.0</td>
   <td>Python</td>
@@ -336,10 +324,22 @@ footer { padding: 2rem 2.5rem; border-top: 1px solid var(--border); display: fle
   <td><span class="badge badge-none">not tracked</span></td>
 </tr>
 <tr>
-  <td class="name" data-sort="crush"><a href="https://charm.land/crush" target="_blank" rel="noopener">Crush</a><sup class="badge badge-new">NEW</sup></td>
+  <td class="name" data-sort="continue"><a href="https://continue.dev" target="_blank" rel="noopener">Continue</a></td>
   <td><span class="badge badge-cat badge-agent">Agent</span></td>
-  <td class="mono" data-sort="26077">26,077</td>
-  <td class="growth-3m"><span class="growth-up">+1,779 <span class="growth-pct">(+7.3%)</span></span></td>
+  <td class="mono" data-sort="35589">35,589</td>
+  <td class="growth-3m"><span class="growth-up">+899 <span class="growth-pct">(+2.6%)</span></span></td>
+  <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
+  <td>Apache-2.0</td>
+  <td>TypeScript</td>
+  <td>IDE extension / CLI</td>
+  <td>Freemium</td>
+  <td><span class="badge badge-planned">planned</span></td>
+</tr>
+<tr>
+  <td class="name" data-sort="crush"><a href="https://charm.land/crush" target="_blank" rel="noopener">Crush</a></td>
+  <td><span class="badge badge-cat badge-agent">Agent</span></td>
+  <td class="mono" data-sort="27573">27,573</td>
+  <td class="growth-3m"><span class="growth-up">+1,496 <span class="growth-pct">(+5.7%)</span></span></td>
   <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
   <td>NOASSERTION</td>
   <td>Go</td>
@@ -348,10 +348,10 @@ footer { padding: 2rem 2.5rem; border-top: 1px solid var(--border); display: fle
   <td><span class="badge badge-planned">planned</span></td>
 </tr>
 <tr>
-  <td class="name" data-sort="qwen code"><a href="https://qwen.ai/qwencode" target="_blank" rel="noopener">Qwen Code</a><sup class="badge badge-new">NEW</sup></td>
+  <td class="name" data-sort="qwen code"><a href="https://qwen.ai/qwencode" target="_blank" rel="noopener">Qwen Code</a></td>
   <td><span class="badge badge-cat badge-agent">Agent</span></td>
-  <td class="mono" data-sort="25787">25,787</td>
-  <td class="growth-3m"><span class="growth-up">+1,386 <span class="growth-pct">(+5.7%)</span></span></td>
+  <td class="mono" data-sort="27288">27,288</td>
+  <td class="growth-3m"><span class="growth-up">+1,501 <span class="growth-pct">(+5.8%)</span></span></td>
   <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
   <td>Apache-2.0</td>
   <td>TypeScript</td>
@@ -360,10 +360,34 @@ footer { padding: 2rem 2.5rem; border-top: 1px solid var(--border); display: fle
   <td><span class="badge badge-planned">planned</span></td>
 </tr>
 <tr>
+  <td class="name" data-sort="kilo code"><a href="https://kilo.ai" target="_blank" rel="noopener">Kilo Code</a></td>
+  <td><span class="badge badge-cat badge-agent">Agent</span></td>
+  <td class="mono" data-sort="26973">26,973</td>
+  <td class="growth-3m"><span class="growth-up">+1,382 <span class="growth-pct">(+5.4%)</span></span></td>
+  <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
+  <td>MIT</td>
+  <td>TypeScript</td>
+  <td>IDE extension / CLI</td>
+  <td>Freemium</td>
+  <td><span class="badge badge-planned">planned</span></td>
+</tr>
+<tr>
+  <td class="name" data-sort="github copilot cli"><a href="https://github.com/github/copilot-cli" target="_blank" rel="noopener">GitHub Copilot CLI</a><sup class="badge badge-new">NEW</sup></td>
+  <td><span class="badge badge-cat badge-agent">Agent</span></td>
+  <td class="mono" data-sort="11111">11,111</td>
+  <td class="growth-3m"><span class="growth-na">—</span></td>
+  <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
+  <td>—</td>
+  <td>Shell</td>
+  <td>CLI</td>
+  <td>Paid (usage-based)</td>
+  <td><span class="badge badge-live">live</span></td>
+</tr>
+<tr>
   <td class="name" data-sort="chatdev"><a href="https://github.com/OpenBMB/ChatDev" target="_blank" rel="noopener">ChatDev</a></td>
   <td><span class="badge badge-cat badge-orchestrator">Orchestrator</span></td>
-  <td class="mono" data-sort="33658">33,658</td>
-  <td class="growth-3m"><span class="growth-up">+565 <span class="growth-pct">(+1.7%)</span></span></td>
+  <td class="mono" data-sort="34096">34,096</td>
+  <td class="growth-3m"><span class="growth-up">+438 <span class="growth-pct">(+1.3%)</span></span></td>
   <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
   <td>Apache-2.0</td>
   <td>Python</td>
@@ -372,10 +396,22 @@ footer { padding: 2rem 2.5rem; border-top: 1px solid var(--border); display: fle
   <td><span class="badge badge-none">not tracked</span></td>
 </tr>
 <tr>
+  <td class="name" data-sort="gas town"><a href="https://github.com/gastownhall/gastown" target="_blank" rel="noopener">Gas Town</a></td>
+  <td><span class="badge badge-cat badge-orchestrator">Orchestrator</span></td>
+  <td class="mono" data-sort="17719">17,719</td>
+  <td class="growth-3m"><span class="growth-up">+1,484 <span class="growth-pct">(+9.1%)</span></span></td>
+  <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
+  <td>MIT</td>
+  <td>Go</td>
+  <td>CLI</td>
+  <td>Free (open source)</td>
+  <td><span class="badge badge-live">live</span></td>
+</tr>
+<tr>
   <td class="name" data-sort="cursor"><a href="https://cursor.com" target="_blank" rel="noopener">Cursor</a></td>
   <td><span class="badge badge-cat badge-agent">Agent</span></td>
-  <td class="mono" data-sort="33006">33,006</td>
-  <td class="growth-3m"><span class="growth-up">+131 <span class="growth-pct">(+0.4%)</span></span></td>
+  <td class="mono" data-sort="33156">33,156</td>
+  <td class="growth-3m"><span class="growth-up">+150 <span class="growth-pct">(+0.5%)</span></span></td>
   <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
   <td>—</td>
   <td>—</td>
@@ -384,22 +420,10 @@ footer { padding: 2rem 2.5rem; border-top: 1px solid var(--border); display: fle
   <td><span class="badge badge-planned">planned</span></td>
 </tr>
 <tr>
-  <td class="name" data-sort="gas town"><a href="https://github.com/gastownhall/gastown" target="_blank" rel="noopener">Gas Town</a></td>
-  <td><span class="badge badge-cat badge-orchestrator">Orchestrator</span></td>
-  <td class="mono" data-sort="16235">16,235</td>
-  <td class="growth-3m"><span class="growth-up">+1,040 <span class="growth-pct">(+6.8%)</span></span></td>
-  <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
-  <td>MIT</td>
-  <td>Go</td>
-  <td>CLI</td>
-  <td>Free (open source)</td>
-  <td><span class="badge badge-live">live</span></td>
-</tr>
-<tr>
   <td class="name" data-sort="swe-agent"><a href="https://swe-agent.com" target="_blank" rel="noopener">SWE-agent</a></td>
   <td><span class="badge badge-cat badge-agent">Agent</span></td>
-  <td class="mono" data-sort="19705">19,705</td>
-  <td class="growth-3m"><span class="growth-up">+480 <span class="growth-pct">(+2.5%)</span></span></td>
+  <td class="mono" data-sort="20106">20,106</td>
+  <td class="growth-3m"><span class="growth-up">+401 <span class="growth-pct">(+2.0%)</span></span></td>
   <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
   <td>MIT</td>
   <td>Python</td>
@@ -408,46 +432,34 @@ footer { padding: 2rem 2.5rem; border-top: 1px solid var(--border); display: fle
   <td><span class="badge badge-planned">planned</span></td>
 </tr>
 <tr>
-  <td class="name" data-sort="composio"><a href="https://composio.dev" target="_blank" rel="noopener">Composio</a></td>
+  <td class="name" data-sort="agent orchestrator (ao)"><a href="https://aoagents.dev" target="_blank" rel="noopener">Agent Orchestrator (AO)</a></td>
   <td><span class="badge badge-cat badge-orchestrator">Orchestrator</span></td>
-  <td class="mono" data-sort="8053">8,053</td>
-  <td class="growth-3m"><span class="growth-up">+1,006 <span class="growth-pct">(+14.3%)</span></span></td>
+  <td class="mono" data-sort="9825">9,825</td>
+  <td class="growth-3m"><span class="growth-up">+1,772 <span class="growth-pct">(+22.0%)</span></span></td>
   <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
   <td>Apache-2.0</td>
   <td>Go</td>
-  <td>CLI / Web</td>
-  <td>Freemium</td>
+  <td>Desktop app</td>
+  <td>Free (open source)</td>
   <td><span class="badge badge-none">not tracked</span></td>
 </tr>
 <tr>
-  <td class="name" data-sort="plandex"><a href="https://plandex.ai" target="_blank" rel="noopener">Plandex</a><sup class="badge badge-new">NEW</sup></td>
+  <td class="name" data-sort="mistral vibe"><a href="https://github.com/mistralai/mistral-vibe" target="_blank" rel="noopener">Mistral Vibe</a><sup class="badge badge-new">NEW</sup></td>
   <td><span class="badge badge-cat badge-agent">Agent</span></td>
-  <td class="mono" data-sort="15502">15,502</td>
-  <td class="growth-3m"><span class="growth-up">+137 <span class="growth-pct">(+0.9%)</span></span></td>
-  <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
-  <td>MIT</td>
-  <td>Go</td>
-  <td>CLI</td>
-  <td>Freemium</td>
-  <td><span class="badge badge-none">not tracked</span></td>
-</tr>
-<tr>
-  <td class="name" data-sort="kiro"><a href="https://kiro.dev" target="_blank" rel="noopener">Kiro</a><sup class="badge badge-new">NEW</sup></td>
-  <td><span class="badge badge-cat badge-agent">Agent</span></td>
-  <td class="mono" data-sort="3965">3,965</td>
+  <td class="mono" data-sort="4861">4,861</td>
   <td class="growth-3m"><span class="growth-na">—</span></td>
   <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
-  <td>—</td>
-  <td>TypeScript</td>
-  <td>Desktop app (IDE) / CLI</td>
-  <td>Freemium</td>
+  <td>Apache-2.0</td>
+  <td>Python</td>
+  <td>CLI</td>
+  <td>Free (open source)</td>
   <td><span class="badge badge-live">live</span></td>
 </tr>
 <tr>
   <td class="name" data-sort="open swe"><a href="https://github.com/langchain-ai/open-swe" target="_blank" rel="noopener">Open SWE</a></td>
   <td><span class="badge badge-cat badge-agent">Agent</span></td>
-  <td class="mono" data-sort="10103">10,103</td>
-  <td class="growth-3m"><span class="growth-up">+301 <span class="growth-pct">(+3.1%)</span></span></td>
+  <td class="mono" data-sort="10586">10,586</td>
+  <td class="growth-3m"><span class="growth-up">+483 <span class="growth-pct">(+4.8%)</span></span></td>
   <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
   <td>MIT</td>
   <td>Python</td>
@@ -456,10 +468,22 @@ footer { padding: 2rem 2.5rem; border-top: 1px solid var(--border); display: fle
   <td><span class="badge badge-none">not tracked</span></td>
 </tr>
 <tr>
+  <td class="name" data-sort="plandex"><a href="https://plandex.ai" target="_blank" rel="noopener">Plandex</a></td>
+  <td><span class="badge badge-cat badge-agent">Agent</span></td>
+  <td class="mono" data-sort="15590">15,590</td>
+  <td class="growth-3m"><span class="growth-up">+88 <span class="growth-pct">(+0.6%)</span></span></td>
+  <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
+  <td>MIT</td>
+  <td>Go</td>
+  <td>CLI</td>
+  <td>Freemium</td>
+  <td><span class="badge badge-none">not tracked</span></td>
+</tr>
+<tr>
   <td class="name" data-sort="claude squad"><a href="https://github.com/smtg-ai/claude-squad" target="_blank" rel="noopener">Claude Squad</a></td>
   <td><span class="badge badge-cat badge-orchestrator">Orchestrator</span></td>
-  <td class="mono" data-sort="8023">8,023</td>
-  <td class="growth-3m"><span class="growth-up">+548 <span class="growth-pct">(+7.3%)</span></span></td>
+  <td class="mono" data-sort="8352">8,352</td>
+  <td class="growth-3m"><span class="growth-up">+329 <span class="growth-pct">(+4.1%)</span></span></td>
   <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
   <td>AGPL-3.0</td>
   <td>Go</td>
@@ -470,8 +494,8 @@ footer { padding: 2rem 2.5rem; border-top: 1px solid var(--border); display: fle
 <tr>
   <td class="name" data-sort="devika"><a href="https://github.com/stitionai/devika" target="_blank" rel="noopener">Devika</a></td>
   <td><span class="badge badge-cat badge-orchestrator">Orchestrator</span></td>
-  <td class="mono" data-sort="19535">19,535</td>
-  <td class="growth-3m"><span class="growth-up">+28 <span class="growth-pct">(+0.1%)</span></span></td>
+  <td class="mono" data-sort="19558">19,558</td>
+  <td class="growth-3m"><span class="growth-up">+23 <span class="growth-pct">(+0.1%)</span></span></td>
   <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
   <td>MIT</td>
   <td>Python</td>
@@ -482,8 +506,8 @@ footer { padding: 2rem 2.5rem; border-top: 1px solid var(--border); display: fle
 <tr>
   <td class="name" data-sort="emdash"><a href="https://github.com/generalaction/emdash" target="_blank" rel="noopener">Emdash</a><sup class="badge badge-new">NEW</sup></td>
   <td><span class="badge badge-cat badge-orchestrator">Orchestrator</span></td>
-  <td class="mono" data-sort="5070">5,070</td>
-  <td class="growth-3m"><span class="growth-up">+360 <span class="growth-pct">(+7.6%)</span></span></td>
+  <td class="mono" data-sort="5464">5,464</td>
+  <td class="growth-3m"><span class="growth-up">+394 <span class="growth-pct">(+7.8%)</span></span></td>
   <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
   <td>Apache-2.0</td>
   <td>TypeScript</td>
@@ -492,22 +516,10 @@ footer { padding: 2rem 2.5rem; border-top: 1px solid var(--border); display: fle
   <td><span class="badge badge-none">not tracked</span></td>
 </tr>
 <tr>
-  <td class="name" data-sort="forge code"><a href="https://forgecode.dev" target="_blank" rel="noopener">Forge Code</a></td>
-  <td><span class="badge badge-cat badge-agent">Agent</span></td>
-  <td class="mono" data-sort="7445">7,445</td>
-  <td class="growth-3m"><span class="growth-up">+150 <span class="growth-pct">(+2.1%)</span></span></td>
-  <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
-  <td>Apache-2.0</td>
-  <td>Rust</td>
-  <td>CLI</td>
-  <td>Free (open source)</td>
-  <td><span class="badge badge-none">not tracked</span></td>
-</tr>
-<tr>
   <td class="name" data-sort="openagentscontrol"><a href="https://github.com/darrenhinde/OpenAgentsControl" target="_blank" rel="noopener">OpenAgentsControl</a><sup class="badge badge-new">NEW</sup></td>
   <td><span class="badge badge-cat badge-orchestrator">Orchestrator</span></td>
-  <td class="mono" data-sort="4484">4,484</td>
-  <td class="growth-3m"><span class="growth-up">+297 <span class="growth-pct">(+7.1%)</span></span></td>
+  <td class="mono" data-sort="4757">4,757</td>
+  <td class="growth-3m"><span class="growth-up">+273 <span class="growth-pct">(+6.1%)</span></span></td>
   <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
   <td>MIT</td>
   <td>TypeScript</td>
@@ -516,10 +528,34 @@ footer { padding: 2rem 2.5rem; border-top: 1px solid var(--border); display: fle
   <td><span class="badge badge-none">not tracked</span></td>
 </tr>
 <tr>
+  <td class="name" data-sort="forge code"><a href="https://forgecode.dev" target="_blank" rel="noopener">Forge Code</a></td>
+  <td><span class="badge badge-cat badge-agent">Agent</span></td>
+  <td class="mono" data-sort="7499">7,499</td>
+  <td class="growth-3m"><span class="growth-up">+54 <span class="growth-pct">(+0.7%)</span></span></td>
+  <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
+  <td>Apache-2.0</td>
+  <td>Rust</td>
+  <td>CLI</td>
+  <td>Free (open source)</td>
+  <td><span class="badge badge-none">not tracked</span></td>
+</tr>
+<tr>
+  <td class="name" data-sort="kiro"><a href="https://kiro.dev" target="_blank" rel="noopener">Kiro</a></td>
+  <td><span class="badge badge-cat badge-agent">Agent</span></td>
+  <td class="mono" data-sort="4215">4,215</td>
+  <td class="growth-3m"><span class="growth-up">+250 <span class="growth-pct">(+6.3%)</span></span></td>
+  <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
+  <td>—</td>
+  <td>TypeScript</td>
+  <td>Desktop app (IDE) / CLI</td>
+  <td>Freemium</td>
+  <td><span class="badge badge-live">live</span></td>
+</tr>
+<tr>
   <td class="name" data-sort="sweep"><a href="https://sweep.dev" target="_blank" rel="noopener">Sweep</a></td>
   <td><span class="badge badge-cat badge-agent">Agent</span></td>
-  <td class="mono" data-sort="7700">7,700</td>
-  <td class="growth-3m"><span class="growth-down">-13 <span class="growth-pct">(-0.2%)</span></span></td>
+  <td class="mono" data-sort="7701">7,701</td>
+  <td class="growth-3m"><span class="growth-up">+1 <span class="growth-pct">(+0.0%)</span></span></td>
   <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
   <td>NOASSERTION</td>
   <td>Jupyter Notebook</td>
@@ -528,22 +564,10 @@ footer { padding: 2rem 2.5rem; border-top: 1px solid var(--border); display: fle
   <td><span class="badge badge-none">not tracked</span></td>
 </tr>
 <tr>
-  <td class="name" data-sort="factory"><a href="https://www.factory.ai" target="_blank" rel="noopener">Factory</a></td>
-  <td><span class="badge badge-cat badge-agent">Agent</span></td>
-  <td class="mono" data-sort="1007">1,007</td>
-  <td class="growth-3m"><span class="growth-up">+131 <span class="growth-pct">(+15.0%)</span></span></td>
-  <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
-  <td>—</td>
-  <td>—</td>
-  <td>Web / CLI</td>
-  <td>Paid</td>
-  <td><span class="badge badge-none">not tracked</span></td>
-</tr>
-<tr>
   <td class="name" data-sort="bernstein"><a href="https://bernstein.run" target="_blank" rel="noopener">Bernstein</a><sup class="badge badge-new">NEW</sup></td>
   <td><span class="badge badge-cat badge-orchestrator">Orchestrator</span></td>
-  <td class="mono" data-sort="634">634</td>
-  <td class="growth-3m"><span class="growth-up">+104 <span class="growth-pct">(+19.6%)</span></span></td>
+  <td class="mono" data-sort="953">953</td>
+  <td class="growth-3m"><span class="growth-up">+319 <span class="growth-pct">(+50.3%)</span></span></td>
   <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
   <td>Apache-2.0</td>
   <td>Python</td>
@@ -554,7 +578,7 @@ footer { padding: 2rem 2.5rem; border-top: 1px solid var(--border); display: fle
 <tr>
   <td class="name" data-sort="ra.aid"><a href="https://www.ra-aid.ai" target="_blank" rel="noopener">RA.Aid</a></td>
   <td><span class="badge badge-cat badge-agent">Agent</span></td>
-  <td class="mono" data-sort="2223">2,223</td>
+  <td class="mono" data-sort="2222">2,222</td>
   <td class="growth-3m"><span class="growth-down">-1 <span class="growth-pct">(-0.0%)</span></span></td>
   <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
   <td>Apache-2.0</td>
@@ -564,22 +588,10 @@ footer { padding: 2rem 2.5rem; border-top: 1px solid var(--border); display: fle
   <td><span class="badge badge-none">not tracked</span></td>
 </tr>
 <tr>
-  <td class="name" data-sort="pear ai"><a href="https://trypear.ai" target="_blank" rel="noopener">Pear AI</a></td>
-  <td><span class="badge badge-cat badge-agent">Agent</span></td>
-  <td class="mono" data-sort="703">703</td>
-  <td class="growth-3m"><span class="growth-up">+14 <span class="growth-pct">(+2.0%)</span></span></td>
-  <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
-  <td>MIT</td>
-  <td>TypeScript</td>
-  <td>Desktop app (IDE)</td>
-  <td>Freemium</td>
-  <td><span class="badge badge-none">not tracked</span></td>
-</tr>
-<tr>
   <td class="name" data-sort="multiclaude"><a href="https://github.com/dlorenc/multiclaude" target="_blank" rel="noopener">Multiclaude</a></td>
   <td><span class="badge badge-cat badge-orchestrator">Orchestrator</span></td>
-  <td class="mono" data-sort="555">555</td>
-  <td class="growth-3m"><span class="growth-up">+7 <span class="growth-pct">(+1.3%)</span></span></td>
+  <td class="mono" data-sort="563">563</td>
+  <td class="growth-3m"><span class="growth-up">+8 <span class="growth-pct">(+1.4%)</span></span></td>
   <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
   <td>—</td>
   <td>Go</td>
@@ -588,22 +600,34 @@ footer { padding: 2rem 2.5rem; border-top: 1px solid var(--border); display: fle
   <td><span class="badge badge-planned">planned</span></td>
 </tr>
 <tr>
-  <td class="name" data-sort="codegen"><a href="https://codegen.com" target="_blank" rel="noopener">Codegen</a></td>
+  <td class="name" data-sort="pear ai"><a href="https://trypear.ai" target="_blank" rel="noopener">Pear AI</a></td>
   <td><span class="badge badge-cat badge-agent">Agent</span></td>
-  <td class="mono" data-sort="519">519</td>
-  <td class="growth-3m"><span class="growth-down">-2 <span class="growth-pct">(-0.4%)</span></span></td>
+  <td class="mono" data-sort="706">706</td>
+  <td class="growth-3m"><span class="growth-up">+3 <span class="growth-pct">(+0.4%)</span></span></td>
   <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
-  <td>Apache-2.0</td>
-  <td>Python</td>
-  <td>SDK / Web</td>
-  <td>Paid</td>
+  <td>MIT</td>
+  <td>TypeScript</td>
+  <td>Desktop app (IDE)</td>
+  <td>Freemium</td>
+  <td><span class="badge badge-none">not tracked</span></td>
+</tr>
+<tr>
+  <td class="name" data-sort="forge orchestrator"><a href="https://forge.nxtg.ai" target="_blank" rel="noopener">Forge Orchestrator</a></td>
+  <td><span class="badge badge-cat badge-orchestrator">Orchestrator</span></td>
+  <td class="mono" data-sort="158">158</td>
+  <td class="growth-3m"><span class="growth-up">+30 <span class="growth-pct">(+23.4%)</span></span></td>
+  <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
+  <td>NOASSERTION</td>
+  <td>Rust</td>
+  <td>CLI</td>
+  <td>Free (open source)</td>
   <td><span class="badge badge-none">not tracked</span></td>
 </tr>
 <tr>
   <td class="name" data-sort="stoneforge"><a href="https://stoneforge.ai" target="_blank" rel="noopener">Stoneforge</a></td>
   <td><span class="badge badge-cat badge-orchestrator">Orchestrator</span></td>
-  <td class="mono" data-sort="160">160</td>
-  <td class="growth-3m"><span class="growth-up">+17 <span class="growth-pct">(+11.9%)</span></span></td>
+  <td class="mono" data-sort="176">176</td>
+  <td class="growth-3m"><span class="growth-up">+16 <span class="growth-pct">(+10.0%)</span></span></td>
   <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
   <td>Apache-2.0</td>
   <td>TypeScript</td>
@@ -612,15 +636,15 @@ footer { padding: 2rem 2.5rem; border-top: 1px solid var(--border); display: fle
   <td><span class="badge badge-none">not tracked</span></td>
 </tr>
 <tr>
-  <td class="name" data-sort="forge orchestrator"><a href="https://forge.nxtg.ai" target="_blank" rel="noopener">Forge Orchestrator</a></td>
-  <td><span class="badge badge-cat badge-orchestrator">Orchestrator</span></td>
-  <td class="mono" data-sort="128">128</td>
-  <td class="growth-3m"><span class="growth-up">+12 <span class="growth-pct">(+10.3%)</span></span></td>
+  <td class="name" data-sort="factory"><a href="https://www.factory.ai" target="_blank" rel="noopener">Factory</a></td>
+  <td><span class="badge badge-cat badge-agent">Agent</span></td>
+  <td class="mono" data-sort="5">5</td>
+  <td class="growth-3m"><span class="growth-down">-1,002 <span class="growth-pct">(-99.5%)</span></span></td>
   <td data-sort="1"><span class="badge-oss-yes">Yes</span></td>
   <td>—</td>
-  <td>Rust</td>
-  <td>CLI</td>
-  <td>Free (open source)</td>
+  <td>—</td>
+  <td>Web / CLI</td>
+  <td>Paid</td>
   <td><span class="badge badge-none">not tracked</span></td>
 </tr>
 <tr>
@@ -837,10 +861,10 @@ document.addEventListener('DOMContentLoaded', function() {
       var rows = Array.from(tbody.querySelectorAll('tr'));
       rows.sort(function(a, b) {
         var cellA = a.children[idx], cellB = b.children[idx];
-        var valA = (cellA.dataset.sort || cellA.textContent).trim();
-        var valB = (cellB.dataset.sort || cellB.textContent).trim();
-        var numA = Number.parseFloat(valA), numB = Number.parseFloat(valB);
-        if (!Number.isNaN(numA) && !Number.isNaN(numB)) {
+        var valA = (cellA.getAttribute('data-sort') || cellA.textContent).trim();
+        var valB = (cellB.getAttribute('data-sort') || cellB.textContent).trim();
+        var numA = parseFloat(valA), numB = parseFloat(valB);
+        if (!isNaN(numA) && !isNaN(numB)) {
           return sortAsc ? numA - numB : numB - numA;
         }
         if (valA === '\u2014' || valA === '') return 1;

--- a/site/landscape/index.html
+++ b/site/landscape/index.html
@@ -120,13 +120,13 @@ footer { padding: 2rem 2.5rem; border-top: 1px solid var(--border); display: fle
 <div class="container">
   <div class="page-header">
     <h1>AI Coding Agent Landscape</h1>
-    <div class="updated">Last updated: 2026-07-05</div>
+    <div class="updated">Last updated: 2026-08-22</div>
     <p class="intro">A living ranking of AI coding agents and agent orchestrators, sorted by a blend of GitHub popularity and growth momentum. Agents that Irrlicht already monitors are marked <span class="badge badge-live">live</span>, upcoming integrations are <span class="badge badge-planned">planned</span>. Agents first tracked less than 3 months ago are marked <span class="badge badge-new">NEW</span>.</p>
     <a href="compare/" class="compare-link">See detailed comparison with all metrics &rarr;</a>
   </div>
 
   <h2 class="section-title">Coding Agents</h2>
-  <p class="trend-note">Growth measured from snapshots closest to 1 month and 3 months before 2026-07-05.</p>
+  <p class="trend-note">Growth measured from snapshots closest to 1 month and 3 months before 2026-08-22.</p>
   <table class="landscape-table">
 <thead><tr>
   <th class="rank">#</th><th>Name</th><th>Stars</th><th class="growth-3m">Recent growth</th><th>Irrlicht</th><th>Description</th>
@@ -135,211 +135,227 @@ footer { padding: 2rem 2.5rem; border-top: 1px solid var(--border); display: fle
 
   <tr>
     <td class="rank">#1</td>
+    <td class="name"><a href="https://hermes-agent.nousresearch.com" target="_blank" rel="noopener">Hermes Agent</a><sup class="badge badge-new">NEW</sup></td>
+    <td class="stars">234,263</td>
+    <td class="growth growth-3m"><span class="growth-na">—</span></td>
+    <td><span class="badge badge-live">live</span></td>
+    <td class="desc">The agent that grows with you</td>
+  </tr>
+  <tr>
+    <td class="rank">#2</td>
     <td class="name"><a href="https://opencode.ai" target="_blank" rel="noopener">OpenCode</a></td>
-    <td class="stars">182,478</td>
-    <td class="growth growth-3m"><span class="growth-up">+21,905 <span class="growth-pct">(+13.6%)</span></span></td>
+    <td class="stars">200,227</td>
+    <td class="growth growth-3m"><span class="growth-up">+17,749 <span class="growth-pct">(+9.7%)</span></span></td>
     <td><span class="badge badge-live">live</span></td>
     <td class="desc">The open source coding agent.</td>
   </tr>
   <tr>
-    <td class="rank">#2</td>
-    <td class="name"><a href="https://www.anthropic.com/claude-code" target="_blank" rel="noopener">Claude Code</a></td>
-    <td class="stars">136,132</td>
-    <td class="growth growth-3m"><span class="growth-up">+12,371 <span class="growth-pct">(+10.0%)</span></span></td>
-    <td><span class="badge badge-live">live</span></td>
-    <td class="desc">Claude Code is an agentic coding tool that lives in your terminal, understands your codebase, and helps you code faster by executing routine tasks, explaining complex code, and handling git workflows - all through natural language commands.</td>
-  </tr>
-  <tr>
     <td class="rank">#3</td>
-    <td class="name"><a href="https://github.com/ultraworkers/claw-code" target="_blank" rel="noopener">Claw Code</a></td>
-    <td class="stars">194,570</td>
-    <td class="growth growth-3m"><span class="growth-up">+3,065 <span class="growth-pct">(+1.6%)</span></span></td>
-    <td><span class="badge badge-none">not tracked</span></td>
-    <td class="desc">An agent-managed museum exhibit, built in Rust with Gajae-Code / LazyCodex — developed and maintained with no human intervention.</td>
-  </tr>
-  <tr>
-    <td class="rank">#4</td>
     <td class="name"><a href="https://github.com/openai/codex" target="_blank" rel="noopener">OpenAI Codex</a></td>
-    <td class="stars">95,588</td>
-    <td class="growth growth-3m"><span class="growth-up">+12,777 <span class="growth-pct">(+15.4%)</span></span></td>
+    <td class="stars">112,507</td>
+    <td class="growth growth-3m"><span class="growth-up">+16,919 <span class="growth-pct">(+17.7%)</span></span></td>
     <td><span class="badge badge-live">live</span></td>
     <td class="desc">Lightweight coding agent that runs in your terminal</td>
   </tr>
   <tr>
-    <td class="rank">#5</td>
+    <td class="rank">#4</td>
     <td class="name"><a href="https://github.com/earendil-works/pi" target="_blank" rel="noopener">Pi</a></td>
-    <td class="stars">67,727</td>
-    <td class="growth growth-3m"><span class="growth-up">+18,063 <span class="growth-pct">(+36.4%)</span></span></td>
+    <td class="stars">95,386</td>
+    <td class="growth growth-3m"><span class="growth-up">+27,659 <span class="growth-pct">(+40.8%)</span></span></td>
     <td><span class="badge badge-live">live</span></td>
     <td class="desc">AI agent toolkit: unified LLM API, agent loop, TUI, coding agent CLI</td>
   </tr>
   <tr>
+    <td class="rank">#5</td>
+    <td class="name"><a href="https://www.anthropic.com/claude-code" target="_blank" rel="noopener">Claude Code</a></td>
+    <td class="stars">142,402</td>
+    <td class="growth growth-3m"><span class="growth-up">+6,270 <span class="growth-pct">(+4.6%)</span></span></td>
+    <td><span class="badge badge-live">live</span></td>
+    <td class="desc">Claude Code is an agentic coding tool that lives in your terminal, understands your codebase, and helps you code faster by executing routine tasks, explaining complex code, and handling git workflows - all through natural language commands.</td>
+  </tr>
+  <tr>
     <td class="rank">#6</td>
+    <td class="name"><a href="https://github.com/ultraworkers/claw-code" target="_blank" rel="noopener">Claw Code</a></td>
+    <td class="stars">195,112</td>
+    <td class="growth growth-3m"><span class="growth-up">+542 <span class="growth-pct">(+0.3%)</span></span></td>
+    <td><span class="badge badge-none">not tracked</span></td>
+    <td class="desc">An agent-managed museum exhibit, built in Rust with Gajae-Code / LazyCodex — developed and maintained with no human intervention.</td>
+  </tr>
+  <tr>
+    <td class="rank">#7</td>
     <td class="name"><a href="https://github.com/OpenHands/OpenHands" target="_blank" rel="noopener">OpenHands</a></td>
-    <td class="stars">79,471</td>
-    <td class="growth growth-3m"><span class="growth-up">+5,858 <span class="growth-pct">(+8.0%)</span></span></td>
+    <td class="stars">84,783</td>
+    <td class="growth growth-3m"><span class="growth-up">+5,312 <span class="growth-pct">(+6.7%)</span></span></td>
     <td><span class="badge badge-none">not tracked</span></td>
     <td class="desc">🙌 OpenHands: AI-Driven Development</td>
   </tr>
   <tr>
-    <td class="rank">#7</td>
+    <td class="rank">#8</td>
     <td class="name"><a href="https://github.com/google-gemini/gemini-cli" target="_blank" rel="noopener">Gemini CLI</a></td>
-    <td class="stars">105,752</td>
-    <td class="growth growth-3m"><span class="growth-up">+1,730 <span class="growth-pct">(+1.7%)</span></span></td>
+    <td class="stars">106,611</td>
+    <td class="growth growth-3m"><span class="growth-up">+859 <span class="growth-pct">(+0.8%)</span></span></td>
     <td><span class="badge badge-live">live</span></td>
     <td class="desc">An open-source AI agent that brings the power of Gemini directly into your terminal.</td>
   </tr>
   <tr>
-    <td class="rank">#8</td>
-    <td class="name"><a href="https://www.warp.dev" target="_blank" rel="noopener">Warp</a></td>
-    <td class="stars">62,818</td>
-    <td class="growth growth-3m"><span class="growth-up">+4,288 <span class="growth-pct">(+7.3%)</span></span></td>
-    <td><span class="badge badge-none">not tracked</span></td>
-    <td class="desc">Warp is an agentic development environment, born out of the terminal.</td>
-  </tr>
-  <tr>
     <td class="rank">#9</td>
-    <td class="name"><a href="https://block.github.io/goose/" target="_blank" rel="noopener">Goose</a></td>
-    <td class="stars">50,663</td>
-    <td class="growth growth-3m"><span class="growth-up">+5,433 <span class="growth-pct">(+12.0%)</span></span></td>
-    <td><span class="badge badge-planned">planned</span></td>
-    <td class="desc">an open source, extensible AI agent that goes beyond code suggestions - install, execute, edit, and test with any LLM</td>
-  </tr>
-  <tr>
-    <td class="rank">#10</td>
     <td class="name"><a href="https://cline.bot" target="_blank" rel="noopener">Cline</a></td>
-    <td class="stars">64,294</td>
-    <td class="growth growth-3m"><span class="growth-up">+2,485 <span class="growth-pct">(+4.0%)</span></span></td>
+    <td class="stars">66,653</td>
+    <td class="growth growth-3m"><span class="growth-up">+2,359 <span class="growth-pct">(+3.7%)</span></span></td>
     <td><span class="badge badge-none">not tracked</span></td>
     <td class="desc">Autonomous coding agent as an SDK, IDE extension, or CLI assistant.</td>
   </tr>
   <tr>
+    <td class="rank">#10</td>
+    <td class="name"><a href="https://www.warp.dev" target="_blank" rel="noopener">Warp</a></td>
+    <td class="stars">64,441</td>
+    <td class="growth growth-3m"><span class="growth-up">+1,623 <span class="growth-pct">(+2.6%)</span></span></td>
+    <td><span class="badge badge-none">not tracked</span></td>
+    <td class="desc">Warp is an agentic development environment, born out of the terminal.</td>
+  </tr>
+  <tr>
     <td class="rank">#11</td>
+    <td class="name"><a href="https://block.github.io/goose/" target="_blank" rel="noopener">Goose</a></td>
+    <td class="stars">53,235</td>
+    <td class="growth growth-3m"><span class="growth-up">+2,572 <span class="growth-pct">(+5.1%)</span></span></td>
+    <td><span class="badge badge-planned">planned</span></td>
+    <td class="desc">an open source, extensible AI agent that goes beyond code suggestions - install, execute, edit, and test with any LLM</td>
+  </tr>
+  <tr>
+    <td class="rank">#12</td>
     <td class="name"><a href="https://aider.chat" target="_blank" rel="noopener">Aider</a></td>
-    <td class="stars">47,065</td>
-    <td class="growth growth-3m"><span class="growth-up">+2,223 <span class="growth-pct">(+5.0%)</span></span></td>
+    <td class="stars">48,399</td>
+    <td class="growth growth-3m"><span class="growth-up">+1,334 <span class="growth-pct">(+2.8%)</span></span></td>
     <td><span class="badge badge-live">live</span></td>
     <td class="desc">aider is AI pair programming in your terminal</td>
   </tr>
   <tr>
-    <td class="rank">#12</td>
-    <td class="name"><a href="https://kilo.ai" target="_blank" rel="noopener">Kilo Code</a></td>
-    <td class="stars">25,591</td>
-    <td class="growth growth-3m"><span class="growth-up">+6,287 <span class="growth-pct">(+32.6%)</span></span></td>
-    <td><span class="badge badge-planned">planned</span></td>
-    <td class="desc">Kilo is the all-in-one agentic engineering platform. Build, ship, and iterate faster with the most popular open source coding agent.</td>
-  </tr>
-  <tr>
     <td class="rank">#13</td>
     <td class="name"><a href="https://continue.dev" target="_blank" rel="noopener">Continue</a></td>
-    <td class="stars">34,690</td>
-    <td class="growth growth-3m"><span class="growth-up">+1,494 <span class="growth-pct">(+4.5%)</span></span></td>
+    <td class="stars">35,589</td>
+    <td class="growth growth-3m"><span class="growth-up">+899 <span class="growth-pct">(+2.6%)</span></span></td>
     <td><span class="badge badge-planned">planned</span></td>
     <td class="desc">open-source coding agent</td>
   </tr>
   <tr>
     <td class="rank">#14</td>
-    <td class="name"><a href="https://charm.land/crush" target="_blank" rel="noopener">Crush</a><sup class="badge badge-new">NEW</sup></td>
-    <td class="stars">26,077</td>
-    <td class="growth growth-3m"><span class="growth-up">+1,779 <span class="growth-pct">(+7.3%)</span></span></td>
+    <td class="name"><a href="https://charm.land/crush" target="_blank" rel="noopener">Crush</a></td>
+    <td class="stars">27,573</td>
+    <td class="growth growth-3m"><span class="growth-up">+1,496 <span class="growth-pct">(+5.7%)</span></span></td>
     <td><span class="badge badge-planned">planned</span></td>
     <td class="desc">Glamourous agentic coding for all 💘</td>
   </tr>
   <tr>
     <td class="rank">#15</td>
-    <td class="name"><a href="https://qwen.ai/qwencode" target="_blank" rel="noopener">Qwen Code</a><sup class="badge badge-new">NEW</sup></td>
-    <td class="stars">25,787</td>
-    <td class="growth growth-3m"><span class="growth-up">+1,386 <span class="growth-pct">(+5.7%)</span></span></td>
+    <td class="name"><a href="https://qwen.ai/qwencode" target="_blank" rel="noopener">Qwen Code</a></td>
+    <td class="stars">27,288</td>
+    <td class="growth growth-3m"><span class="growth-up">+1,501 <span class="growth-pct">(+5.8%)</span></span></td>
     <td><span class="badge badge-planned">planned</span></td>
     <td class="desc">An open-source AI coding agent that lives in your terminal.</td>
   </tr>
   <tr>
     <td class="rank">#16</td>
-    <td class="name"><a href="https://cursor.com" target="_blank" rel="noopener">Cursor</a></td>
-    <td class="stars">33,006</td>
-    <td class="growth growth-3m"><span class="growth-up">+131 <span class="growth-pct">(+0.4%)</span></span></td>
+    <td class="name"><a href="https://kilo.ai" target="_blank" rel="noopener">Kilo Code</a></td>
+    <td class="stars">26,973</td>
+    <td class="growth growth-3m"><span class="growth-up">+1,382 <span class="growth-pct">(+5.4%)</span></span></td>
     <td><span class="badge badge-planned">planned</span></td>
-    <td class="desc">Proprietary AI-first code editor (the GitHub repo hosts issues only; editor source is closed).</td>
+    <td class="desc">Kilo is the all-in-one agentic engineering platform. Build, ship, and iterate faster with the most popular open source coding agent.</td>
   </tr>
   <tr>
     <td class="rank">#17</td>
-    <td class="name"><a href="https://swe-agent.com" target="_blank" rel="noopener">SWE-agent</a></td>
-    <td class="stars">19,705</td>
-    <td class="growth growth-3m"><span class="growth-up">+480 <span class="growth-pct">(+2.5%)</span></span></td>
-    <td><span class="badge badge-planned">planned</span></td>
-    <td class="desc">SWE-agent takes a GitHub issue and tries to automatically fix it, using your LM of choice. It can also be employed for offensive cybersecurity or competitive coding challenges. [NeurIPS 2024]</td>
+    <td class="name"><a href="https://github.com/github/copilot-cli" target="_blank" rel="noopener">GitHub Copilot CLI</a><sup class="badge badge-new">NEW</sup></td>
+    <td class="stars">11,111</td>
+    <td class="growth growth-3m"><span class="growth-na">—</span></td>
+    <td><span class="badge badge-live">live</span></td>
+    <td class="desc">GitHub Copilot CLI brings the power of Copilot coding agent directly to your terminal.</td>
   </tr>
   <tr>
     <td class="rank">#18</td>
-    <td class="name"><a href="https://plandex.ai" target="_blank" rel="noopener">Plandex</a><sup class="badge badge-new">NEW</sup></td>
-    <td class="stars">15,502</td>
-    <td class="growth growth-3m"><span class="growth-up">+137 <span class="growth-pct">(+0.9%)</span></span></td>
-    <td><span class="badge badge-none">not tracked</span></td>
-    <td class="desc">Open source AI coding agent. Designed for large projects and real world tasks.</td>
+    <td class="name"><a href="https://cursor.com" target="_blank" rel="noopener">Cursor</a></td>
+    <td class="stars">33,156</td>
+    <td class="growth growth-3m"><span class="growth-up">+150 <span class="growth-pct">(+0.5%)</span></span></td>
+    <td><span class="badge badge-planned">planned</span></td>
+    <td class="desc"></td>
   </tr>
   <tr>
     <td class="rank">#19</td>
-    <td class="name"><a href="https://kiro.dev" target="_blank" rel="noopener">Kiro</a><sup class="badge badge-new">NEW</sup></td>
-    <td class="stars">3,965</td>
-    <td class="growth growth-3m"><span class="growth-na">—</span></td>
-    <td><span class="badge badge-live">live</span></td>
-    <td class="desc">Kiro is an agentic IDE that works alongside you from prototype to production.</td>
+    <td class="name"><a href="https://swe-agent.com" target="_blank" rel="noopener">SWE-agent</a></td>
+    <td class="stars">20,106</td>
+    <td class="growth growth-3m"><span class="growth-up">+401 <span class="growth-pct">(+2.0%)</span></span></td>
+    <td><span class="badge badge-planned">planned</span></td>
+    <td class="desc">SWE-agent takes a GitHub issue and tries to automatically fix it, using your LM of choice. It can also be employed for offensive cybersecurity or competitive coding challenges. [NeurIPS 2024] </td>
   </tr>
   <tr>
     <td class="rank">#20</td>
+    <td class="name"><a href="https://github.com/mistralai/mistral-vibe" target="_blank" rel="noopener">Mistral Vibe</a><sup class="badge badge-new">NEW</sup></td>
+    <td class="stars">4,861</td>
+    <td class="growth growth-3m"><span class="growth-na">—</span></td>
+    <td><span class="badge badge-live">live</span></td>
+    <td class="desc">Minimal CLI coding agent by Mistral</td>
+  </tr>
+  <tr>
+    <td class="rank">#21</td>
     <td class="name"><a href="https://github.com/langchain-ai/open-swe" target="_blank" rel="noopener">Open SWE</a></td>
-    <td class="stars">10,103</td>
-    <td class="growth growth-3m"><span class="growth-up">+301 <span class="growth-pct">(+3.1%)</span></span></td>
+    <td class="stars">10,586</td>
+    <td class="growth growth-3m"><span class="growth-up">+483 <span class="growth-pct">(+4.8%)</span></span></td>
     <td><span class="badge badge-none">not tracked</span></td>
     <td class="desc">An Open-Source Asynchronous Coding Agent</td>
   </tr>
   <tr>
-    <td class="rank">#21</td>
+    <td class="rank">#22</td>
+    <td class="name"><a href="https://plandex.ai" target="_blank" rel="noopener">Plandex</a></td>
+    <td class="stars">15,590</td>
+    <td class="growth growth-3m"><span class="growth-up">+88 <span class="growth-pct">(+0.6%)</span></span></td>
+    <td><span class="badge badge-none">not tracked</span></td>
+    <td class="desc">Open source AI coding agent. Designed for large projects and real world tasks.</td>
+  </tr>
+  <tr>
+    <td class="rank">#23</td>
     <td class="name"><a href="https://forgecode.dev" target="_blank" rel="noopener">Forge Code</a></td>
-    <td class="stars">7,445</td>
-    <td class="growth growth-3m"><span class="growth-up">+150 <span class="growth-pct">(+2.1%)</span></span></td>
+    <td class="stars">7,499</td>
+    <td class="growth growth-3m"><span class="growth-up">+54 <span class="growth-pct">(+0.7%)</span></span></td>
     <td><span class="badge badge-none">not tracked</span></td>
     <td class="desc">AI enabled pair programmer for Claude, GPT, O Series, Grok, Deepseek, Gemini and 300+ models</td>
   </tr>
   <tr>
-    <td class="rank">#22</td>
+    <td class="rank">#24</td>
+    <td class="name"><a href="https://kiro.dev" target="_blank" rel="noopener">Kiro</a></td>
+    <td class="stars">4,215</td>
+    <td class="growth growth-3m"><span class="growth-up">+250 <span class="growth-pct">(+6.3%)</span></span></td>
+    <td><span class="badge badge-live">live</span></td>
+    <td class="desc">Kiro is an agentic IDE that works alongside you from prototype to production.</td>
+  </tr>
+  <tr>
+    <td class="rank">#25</td>
     <td class="name"><a href="https://sweep.dev" target="_blank" rel="noopener">Sweep</a></td>
-    <td class="stars">7,700</td>
-    <td class="growth growth-3m"><span class="growth-down">-13 <span class="growth-pct">(-0.2%)</span></span></td>
+    <td class="stars">7,701</td>
+    <td class="growth growth-3m"><span class="growth-up">+1 <span class="growth-pct">(+0.0%)</span></span></td>
     <td><span class="badge badge-none">not tracked</span></td>
     <td class="desc">Sweep: AI coding assistant for JetBrains</td>
   </tr>
   <tr>
-    <td class="rank">#23</td>
-    <td class="name"><a href="https://www.factory.ai" target="_blank" rel="noopener">Factory</a></td>
-    <td class="stars">1,007</td>
-    <td class="growth growth-3m"><span class="growth-up">+131 <span class="growth-pct">(+15.0%)</span></span></td>
-    <td><span class="badge badge-none">not tracked</span></td>
-    <td class="desc">Factory - Agent-Native Software Development</td>
-  </tr>
-  <tr>
-    <td class="rank">#24</td>
+    <td class="rank">#26</td>
     <td class="name"><a href="https://www.ra-aid.ai" target="_blank" rel="noopener">RA.Aid</a></td>
-    <td class="stars">2,223</td>
+    <td class="stars">2,222</td>
     <td class="growth growth-3m"><span class="growth-down">-1 <span class="growth-pct">(-0.0%)</span></span></td>
     <td><span class="badge badge-none">not tracked</span></td>
     <td class="desc">Develop software autonomously.</td>
   </tr>
   <tr>
-    <td class="rank">#25</td>
+    <td class="rank">#27</td>
     <td class="name"><a href="https://trypear.ai" target="_blank" rel="noopener">Pear AI</a></td>
-    <td class="stars">703</td>
-    <td class="growth growth-3m"><span class="growth-up">+14 <span class="growth-pct">(+2.0%)</span></span></td>
+    <td class="stars">706</td>
+    <td class="growth growth-3m"><span class="growth-up">+3 <span class="growth-pct">(+0.4%)</span></span></td>
     <td><span class="badge badge-none">not tracked</span></td>
     <td class="desc">PearAI: Open Source AI Code Editor (Fork of VSCode). The PearAI Submodule (https://github.com/trypear/pearai-submodule) is a fork of Continue.</td>
   </tr>
   <tr>
-    <td class="rank">#26</td>
-    <td class="name"><a href="https://codegen.com" target="_blank" rel="noopener">Codegen</a></td>
-    <td class="stars">519</td>
-    <td class="growth growth-3m"><span class="growth-down">-2 <span class="growth-pct">(-0.4%)</span></span></td>
+    <td class="rank">#28</td>
+    <td class="name"><a href="https://www.factory.ai" target="_blank" rel="noopener">Factory</a></td>
+    <td class="stars">5</td>
+    <td class="growth growth-3m"><span class="growth-down">-1,002 <span class="growth-pct">(-99.5%)</span></span></td>
     <td><span class="badge badge-none">not tracked</span></td>
-    <td class="desc">Python wrapper for the Codegen API - run code agents at scale</td>
+    <td class="desc">Factory - Agent-Native Software Development</td>
   </tr>
   <tr><td colspan="6" style="padding-top:1.2rem; color: var(--text-dim); font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.08em; border-bottom: none;">No public repo — popularity via funding / users</td></tr>
   <tr>
@@ -465,7 +481,7 @@ footer { padding: 2rem 2.5rem; border-top: 1px solid var(--border); display: fle
 </tbody></table>
 
   <h2 class="section-title">Agent Orchestrators</h2>
-  <p class="trend-note">Growth measured from snapshots closest to 1 month and 3 months before 2026-07-05.</p>
+  <p class="trend-note">Growth measured from snapshots closest to 1 month and 3 months before 2026-08-22.</p>
   <table class="landscape-table">
 <thead><tr>
   <th class="rank">#</th><th>Name</th><th>Stars</th><th class="growth-3m">Recent growth</th><th>Irrlicht</th><th>Description</th>
@@ -474,115 +490,115 @@ footer { padding: 2rem 2.5rem; border-top: 1px solid var(--border); display: fle
 
   <tr>
     <td class="rank">#1</td>
-    <td class="name"><a href="https://github.com/ruvnet/ruflo" target="_blank" rel="noopener">Ruflo</a></td>
-    <td class="stars">63,063</td>
-    <td class="growth growth-3m"><span class="growth-up">+11,802 <span class="growth-pct">(+23.0%)</span></span></td>
-    <td><span class="badge badge-planned">planned</span></td>
-    <td class="desc">🌊 The leading agent meta-harness. Deploy intelligent multi-player swarms, coordinate autonomous workflows, and build conversational AI systems. Features adaptive memory, self-learning intelligence, RAG integration, and native Claude Code / Codex / Hermes and many more Integrated</td>
-  </tr>
-  <tr>
-    <td class="rank">#2</td>
-    <td class="name"><a href="https://paperclip.ing" target="_blank" rel="noopener">Paperclip</a><sup class="badge badge-new">NEW</sup></td>
-    <td class="stars">72,750</td>
-    <td class="growth growth-3m"><span class="growth-up">+7,190 <span class="growth-pct">(+11.0%)</span></span></td>
+    <td class="name"><a href="https://paperclip.ing" target="_blank" rel="noopener">Paperclip</a></td>
+    <td class="stars">79,146</td>
+    <td class="growth growth-3m"><span class="growth-up">+6,396 <span class="growth-pct">(+8.8%)</span></span></td>
     <td><span class="badge badge-planned">planned</span></td>
     <td class="desc">The open-source app everyone uses to manage agents at work</td>
   </tr>
   <tr>
+    <td class="rank">#2</td>
+    <td class="name"><a href="https://github.com/ruvnet/ruflo" target="_blank" rel="noopener">Ruflo</a></td>
+    <td class="stars">68,823</td>
+    <td class="growth growth-3m"><span class="growth-up">+5,760 <span class="growth-pct">(+9.1%)</span></span></td>
+    <td><span class="badge badge-planned">planned</span></td>
+    <td class="desc">🌊 The original agent meta-harness. Deploy intelligent multi-player swarms, coordinate autonomous workflows, and build conversational AI systems. Features adaptive memory, self-learning intelligence, RAG integration, and native Claude Code / Codex / Hermes and many more Integrated</td>
+  </tr>
+  <tr>
     <td class="rank">#3</td>
     <td class="name"><a href="https://www.agno.com" target="_blank" rel="noopener">Agno</a></td>
-    <td class="stars">40,999</td>
-    <td class="growth growth-3m"><span class="growth-up">+865 <span class="growth-pct">(+2.2%)</span></span></td>
+    <td class="stars">41,832</td>
+    <td class="growth growth-3m"><span class="growth-up">+833 <span class="growth-pct">(+2.0%)</span></span></td>
     <td><span class="badge badge-none">not tracked</span></td>
     <td class="desc">Build, run, and manage agent platforms.</td>
   </tr>
   <tr>
     <td class="rank">#4</td>
     <td class="name"><a href="https://github.com/OpenBMB/ChatDev" target="_blank" rel="noopener">ChatDev</a></td>
-    <td class="stars">33,658</td>
-    <td class="growth growth-3m"><span class="growth-up">+565 <span class="growth-pct">(+1.7%)</span></span></td>
+    <td class="stars">34,096</td>
+    <td class="growth growth-3m"><span class="growth-up">+438 <span class="growth-pct">(+1.3%)</span></span></td>
     <td><span class="badge badge-none">not tracked</span></td>
     <td class="desc">ChatDev 2.0: Dev All through LLM-powered Multi-Agent Collaboration</td>
   </tr>
   <tr>
     <td class="rank">#5</td>
     <td class="name"><a href="https://github.com/gastownhall/gastown" target="_blank" rel="noopener">Gas Town</a></td>
-    <td class="stars">16,235</td>
-    <td class="growth growth-3m"><span class="growth-up">+1,040 <span class="growth-pct">(+6.8%)</span></span></td>
+    <td class="stars">17,719</td>
+    <td class="growth growth-3m"><span class="growth-up">+1,484 <span class="growth-pct">(+9.1%)</span></span></td>
     <td><span class="badge badge-live">live</span></td>
     <td class="desc">Gas Town - multi-agent workspace manager</td>
   </tr>
   <tr>
     <td class="rank">#6</td>
-    <td class="name"><a href="https://composio.dev" target="_blank" rel="noopener">Composio</a></td>
-    <td class="stars">8,053</td>
-    <td class="growth growth-3m"><span class="growth-up">+1,006 <span class="growth-pct">(+14.3%)</span></span></td>
+    <td class="name"><a href="https://aoagents.dev" target="_blank" rel="noopener">Agent Orchestrator (AO)</a></td>
+    <td class="stars">9,825</td>
+    <td class="growth growth-3m"><span class="growth-up">+1,772 <span class="growth-pct">(+22.0%)</span></span></td>
     <td><span class="badge badge-none">not tracked</span></td>
-    <td class="desc">Agentic orchestrator for parallel coding agents — plans tasks, spawns agents, and autonomously handles CI fixes, merge conflicts, and code reviews.</td>
+    <td class="desc">Agent IDE that enables you to manage fleets of coding agents. It comes with an agentic orchestrator that plans tasks, spawns agents, and autonomously handles CI fixes, merge conflicts, and code reviews.</td>
   </tr>
   <tr>
     <td class="rank">#7</td>
     <td class="name"><a href="https://github.com/smtg-ai/claude-squad" target="_blank" rel="noopener">Claude Squad</a></td>
-    <td class="stars">8,023</td>
-    <td class="growth growth-3m"><span class="growth-up">+548 <span class="growth-pct">(+7.3%)</span></span></td>
+    <td class="stars">8,352</td>
+    <td class="growth growth-3m"><span class="growth-up">+329 <span class="growth-pct">(+4.1%)</span></span></td>
     <td><span class="badge badge-planned">planned</span></td>
     <td class="desc">Manage multiple AI terminal agents like Claude Code, Codex, OpenCode, and Amp.</td>
   </tr>
   <tr>
     <td class="rank">#8</td>
     <td class="name"><a href="https://github.com/stitionai/devika" target="_blank" rel="noopener">Devika</a></td>
-    <td class="stars">19,535</td>
-    <td class="growth growth-3m"><span class="growth-up">+28 <span class="growth-pct">(+0.1%)</span></span></td>
+    <td class="stars">19,558</td>
+    <td class="growth growth-3m"><span class="growth-up">+23 <span class="growth-pct">(+0.1%)</span></span></td>
     <td><span class="badge badge-none">not tracked</span></td>
     <td class="desc">Devika is the first open-source implementation of an Agentic Software Engineer. Initially started as an open-source alternative to Devin.</td>
   </tr>
   <tr>
     <td class="rank">#9</td>
     <td class="name"><a href="https://github.com/generalaction/emdash" target="_blank" rel="noopener">Emdash</a><sup class="badge badge-new">NEW</sup></td>
-    <td class="stars">5,070</td>
-    <td class="growth growth-3m"><span class="growth-up">+360 <span class="growth-pct">(+7.6%)</span></span></td>
+    <td class="stars">5,464</td>
+    <td class="growth growth-3m"><span class="growth-up">+394 <span class="growth-pct">(+7.8%)</span></span></td>
     <td><span class="badge badge-none">not tracked</span></td>
     <td class="desc">Emdash is the Open-Source Agentic Development Environment (🧡 YC W26). Run multiple coding agents in parallel. Use any provider.</td>
   </tr>
   <tr>
     <td class="rank">#10</td>
     <td class="name"><a href="https://github.com/darrenhinde/OpenAgentsControl" target="_blank" rel="noopener">OpenAgentsControl</a><sup class="badge badge-new">NEW</sup></td>
-    <td class="stars">4,484</td>
-    <td class="growth growth-3m"><span class="growth-up">+297 <span class="growth-pct">(+7.1%)</span></span></td>
+    <td class="stars">4,757</td>
+    <td class="growth growth-3m"><span class="growth-up">+273 <span class="growth-pct">(+6.1%)</span></span></td>
     <td><span class="badge badge-none">not tracked</span></td>
     <td class="desc">AI agent framework for plan-first development workflows with approval-based execution. Multi-language support (TypeScript, Python, Go, Rust) with automatic testing, code review, and validation built for OpenCode</td>
   </tr>
   <tr>
     <td class="rank">#11</td>
     <td class="name"><a href="https://bernstein.run" target="_blank" rel="noopener">Bernstein</a><sup class="badge badge-new">NEW</sup></td>
-    <td class="stars">634</td>
-    <td class="growth growth-3m"><span class="growth-up">+104 <span class="growth-pct">(+19.6%)</span></span></td>
+    <td class="stars">953</td>
+    <td class="growth growth-3m"><span class="growth-up">+319 <span class="growth-pct">(+50.3%)</span></span></td>
     <td><span class="badge badge-none">not tracked</span></td>
-    <td class="desc">Audit-grade multi-agent orchestration for CLI coding agents (Claude Code, Codex, Gemini CLI, +40 more). HMAC-chained audit log, signed agent cards, per-artefact lineage, air-gap deploy. The orchestrator your compliance team will sign off on. https://bernstein.run</td>
+    <td class="desc">Deterministic orchestrator for CLI coding agents (Claude Code, Codex, Gemini CLI, +40 more). No model in the coordination loop, so parallel runs in per-task git worktrees replay byte-identically. Signed lineage plus an opt-in HMAC audit chain a reviewer checks offline. Cluster mode, air-gap deploy. Status: beta. https://bernstein.run</td>
   </tr>
   <tr>
     <td class="rank">#12</td>
     <td class="name"><a href="https://github.com/dlorenc/multiclaude" target="_blank" rel="noopener">Multiclaude</a></td>
-    <td class="stars">555</td>
-    <td class="growth growth-3m"><span class="growth-up">+7 <span class="growth-pct">(+1.3%)</span></span></td>
+    <td class="stars">563</td>
+    <td class="growth growth-3m"><span class="growth-up">+8 <span class="growth-pct">(+1.4%)</span></span></td>
     <td><span class="badge badge-planned">planned</span></td>
-    <td class="desc">Parallel Claude Code instances in tmux with a Brownian-ratchet CI model.</td>
+    <td class="desc"></td>
   </tr>
   <tr>
     <td class="rank">#13</td>
-    <td class="name"><a href="https://stoneforge.ai" target="_blank" rel="noopener">Stoneforge</a></td>
-    <td class="stars">160</td>
-    <td class="growth growth-3m"><span class="growth-up">+17 <span class="growth-pct">(+11.9%)</span></span></td>
+    <td class="name"><a href="https://forge.nxtg.ai" target="_blank" rel="noopener">Forge Orchestrator</a></td>
+    <td class="stars">158</td>
+    <td class="growth growth-3m"><span class="growth-up">+30 <span class="growth-pct">(+23.4%)</span></span></td>
     <td><span class="badge badge-none">not tracked</span></td>
-    <td class="desc">A web dashboard and runtime for orchestrating AI coding agents</td>
+    <td class="desc">Forge Orchestrator: Multi-AI task orchestration. File locking, knowledge capture, drift detection. Rust.</td>
   </tr>
   <tr>
     <td class="rank">#14</td>
-    <td class="name"><a href="https://forge.nxtg.ai" target="_blank" rel="noopener">Forge Orchestrator</a></td>
-    <td class="stars">128</td>
-    <td class="growth growth-3m"><span class="growth-up">+12 <span class="growth-pct">(+10.3%)</span></span></td>
+    <td class="name"><a href="https://stoneforge.ai" target="_blank" rel="noopener">Stoneforge</a></td>
+    <td class="stars">176</td>
+    <td class="growth growth-3m"><span class="growth-up">+16 <span class="growth-pct">(+10.0%)</span></span></td>
     <td><span class="badge badge-none">not tracked</span></td>
-    <td class="desc">Forge Orchestrator: Multi-AI task orchestration. File locking, knowledge capture, drift detection. Rust.</td>
+    <td class="desc">A web dashboard and runtime for orchestrating AI coding agents</td>
   </tr>
 </tbody></table>
 </div>


### PR DESCRIPTION
## Summary
- Refreshes GitHub stars/language/license/description for all 40 tracked GitHub agents via `gh api`
- Adds three currently-live irrlicht adapters that were missing from the tracked landscape entirely: Hermes Agent, Mistral Vibe, GitHub Copilot CLI (and adds Hermes to SKILL.md's live-adapter mapping)
- Corrects the "Composio" entry, which had drifted onto an unrelated renamed repo (`Untrivial-ai/agent-orchestrator`, a different product called "AO"); renamed with the correct website
- Moves Codegen into the archived list with a cited reason (acquired by ClickUp, standalone service discontinued 2026-01-09, shut down 2026-04-30)
- Regenerates `site/landscape/index.html` and `site/landscape/compare/index.html`

## Test plan
- [x] `tools/preflight.sh --changed` ran automatically on push (skill-file lint + gofmt passed; all other gates skipped as no matching files changed)
- [x] Spot-checked generated HTML for new entries (NEW badges) and the Composio→AO rename