### PR TITLE
fix(hookcov): attribute hook_received events by session, not cell directory

### DIFF
--- a/tools/onboarding-factory/cmd/of/fixture_test.go
+++ b/tools/onboarding-factory/cmd/of/fixture_test.go
@@ -111,11 +111,14 @@ func scenarioNameOf(folder string) string {
 }
 
 // recording writes one complete recording under a cell. withHook adds a
-// hook_received event, which is what `of coverage --hooks` counts.
+// hook_received event, which is what `of coverage --hooks` counts — attributed
+// to session "s", which the transcript_new line below tags adapter:agent, so
+// hookcov's session_id cross-reference (#1768) resolves it as agent's own
+// rather than dropping it as unattributable.
 func recording(t *testing.T, root, agent, folder, name string, withHook bool) {
 	t.Helper()
 	rec := filepath.Join(root, "replaydata", "agents", agent, "scenarios", folder, "recordings", name)
-	events := `{"seq":1,"ts":"2026-05-01T00:00:00Z","kind":"pid_discovered","session_id":"s"}` + "\n"
+	events := `{"seq":1,"ts":"2026-05-01T00:00:00Z","kind":"transcript_new","session_id":"s","adapter":"` + agent + `"}` + "\n"
 	if withHook {
 		events += `{"seq":2,"ts":"2026-05-01T00:00:01Z","kind":"hook_received","session_id":"s","hook_name":"PostToolUse"}` + "\n"
 	}

--- a/tools/onboarding-factory/internal/hookcov/hookcov.go
+++ b/tools/onboarding-factory/internal/hookcov/hookcov.go
@@ -25,12 +25,28 @@
 //
 // # Attribution
 //
-// A recording counts toward the adapter whose cell directory holds it.
-// Per-event attribution is not possible: lifecycle events carry an `adapter`
-// field, but the hook_received events actually present in the corpus leave it
-// empty, so a multi-agent scenario credits its owning adapter even when a
-// co-resident agent produced the hook. Recorded here because the number is
-// otherwise quietly wrong for exactly those cells.
+// A hook_received event is credited to the adapter its OWN session belongs
+// to, not to the cell directory the recording happens to live under (#1768).
+// The two agree everywhere except a co-resident-agent scenario, where they
+// can disagree: replaydata/agents/hermes/scenarios/4-2_multiple-agents-same-workspace
+// is a hermes/claude-code coexistence cell whose one hook_received event is
+// Claude Code's own Stop hook, not hermes's — hermes has none of its own in
+// that recording.
+//
+// hook_name cannot make that distinction: every adapter's turn-done hook
+// dispatches through the same handful of canonical wire names
+// (session.HookStop = "Stop" chief among them; see
+// core/application/services/session_detector_lifecycle.go), so an adapter's
+// OWN hook_received event and a co-resident adapter's carry the identical
+// hook_name. hook_received also never carries its own `adapter` field — every
+// hook_received event actually present in the corpus leaves it empty. But
+// every OTHER event kind for that same session_id (transcript_new,
+// transcript_activity, ...) does carry `adapter`, in the SAME sidecar — so
+// hasOwnHookEvent cross-references a hook_received event's session_id against
+// its sibling events to find whose session it actually is. A session_id with
+// no sibling carrying an adapter at all is unattributable and counts for
+// nobody: never defaulted to the cell's own adapter, which would silently
+// launder the exact bug this join exists to catch.
 //
 // # Scope
 //
@@ -195,7 +211,7 @@ func coverageFor(repoRoot, adapter string, declaresHooks bool) AdapterCoverage {
 		}
 		row.Cells++
 		cellDir := shard.AgentCellDir(repoRoot, adapter, cell.Folder)
-		withHooks, total := hookBearingRecordings(cellDir)
+		withHooks, total := hookBearingRecordings(cellDir, adapter)
 		row.Recordings += total
 		row.WithHooks += withHooks
 	}
@@ -204,11 +220,11 @@ func coverageFor(repoRoot, adapter string, declaresHooks bool) AdapterCoverage {
 }
 
 // hookBearingRecordings counts one cell's recordings and how many of them
-// carry at least one hook_received event.
-func hookBearingRecordings(cellDir string) (withHooks, total int) {
+// carry at least one hook_received event attributable to adapter.
+func hookBearingRecordings(cellDir, adapter string) (withHooks, total int) {
 	for _, recDir := range validate.RecordingDirs(cellDir) {
 		total++
-		if hasHookEvent(filepath.Join(recDir, "events.jsonl")) {
+		if hasOwnHookEvent(filepath.Join(recDir, "events.jsonl"), adapter) {
 			withHooks++
 		}
 	}
@@ -250,18 +266,41 @@ func statusOf(declares bool, withHooks int) Status {
 	}
 }
 
-// hasHookEvent reports whether a recording's events sidecar carries at least
-// one hook_received event. It goes through replay.LoadEvents — the sanctioned
-// reader — rather than scanning bytes, so it cannot disagree with replay about
-// line-length caps or malformed-line handling. A missing or unreadable
-// sidecar counts as "no hooks", the same as an empty one.
-func hasHookEvent(eventsPath string) bool {
+// hasOwnHookEvent reports whether a recording's events sidecar carries at
+// least one hook_received event attributable to adapterSlug — see the
+// package's Attribution section for why hook_name cannot answer this and
+// session_id cross-referencing does. It goes through replay.LoadEvents — the
+// sanctioned reader — rather than scanning bytes, so it cannot disagree with
+// replay about line-length caps or malformed-line handling. A missing or
+// unreadable sidecar counts as "no hooks", the same as an empty one.
+func hasOwnHookEvent(eventsPath, adapterSlug string) bool {
 	events, err := replay.LoadEvents(eventsPath)
 	if err != nil {
 		return false
 	}
+
+	// sessionAdapter is session_id -> the on-disk slug of the adapter a
+	// SIBLING event (never hook_received itself, which carries no Adapter)
+	// tagged that session with. Built once per recording rather than per
+	// hook_received event, so a recording with several hook events pays for
+	// one pass over the file.
+	sessionAdapter := make(map[string]string, len(events))
 	for _, e := range events {
-		if e.Kind == lifecycle.KindHookReceived {
+		if e.Adapter != "" {
+			sessionAdapter[e.SessionID] = slug(e.Adapter)
+		}
+	}
+
+	for _, e := range events {
+		if e.Kind != lifecycle.KindHookReceived {
+			continue
+		}
+		// Comma-ok, not a plain map-read: an unattributed session_id must
+		// read as "no match" via absence, never coincide with adapterSlug=""
+		// (which never occurs here — callers always pass a real on-disk
+		// slug — but the explicit check keeps that an invariant rather than
+		// a map zero-value accident).
+		if owner, ok := sessionAdapter[e.SessionID]; ok && owner == adapterSlug {
 			return true
 		}
 	}

--- a/tools/onboarding-factory/internal/hookcov/hookcov.go
+++ b/tools/onboarding-factory/internal/hookcov/hookcov.go
@@ -278,29 +278,36 @@ func hasOwnHookEvent(eventsPath, adapterSlug string) bool {
 	if err != nil {
 		return false
 	}
+	return anyHookEventOwnedBy(events, sessionAdapters(events), adapterSlug)
+}
 
-	// sessionAdapter is session_id -> the on-disk slug of the adapter a
-	// SIBLING event (never hook_received itself, which carries no Adapter)
-	// tagged that session with. Built once per recording rather than per
-	// hook_received event, so a recording with several hook events pays for
-	// one pass over the file.
-	sessionAdapter := make(map[string]string, len(events))
+// sessionAdapters maps session_id -> the on-disk slug of the adapter a
+// SIBLING event (never hook_received itself, which carries no Adapter)
+// tagged that session with. One pass over the whole recording, built once
+// regardless of how many hook_received events it holds.
+func sessionAdapters(events []lifecycle.Event) map[string]string {
+	owners := make(map[string]string, len(events))
 	for _, e := range events {
 		if e.Adapter != "" {
-			sessionAdapter[e.SessionID] = slug(e.Adapter)
+			owners[e.SessionID] = slug(e.Adapter)
 		}
 	}
+	return owners
+}
 
+// anyHookEventOwnedBy reports whether any hook_received event in events
+// belongs to adapterSlug, per owners (session_id -> adapter slug, from
+// sessionAdapters). Comma-ok on the lookup, not a plain map-read: an
+// unattributed session_id must read as "no match" via absence, never
+// coincide with adapterSlug="" (which never occurs here — callers always
+// pass a real on-disk slug — but the explicit check keeps that an invariant
+// rather than a map zero-value accident).
+func anyHookEventOwnedBy(events []lifecycle.Event, owners map[string]string, adapterSlug string) bool {
 	for _, e := range events {
 		if e.Kind != lifecycle.KindHookReceived {
 			continue
 		}
-		// Comma-ok, not a plain map-read: an unattributed session_id must
-		// read as "no match" via absence, never coincide with adapterSlug=""
-		// (which never occurs here — callers always pass a real on-disk
-		// slug — but the explicit check keeps that an invariant rather than
-		// a map zero-value accident).
-		if owner, ok := sessionAdapter[e.SessionID]; ok && owner == adapterSlug {
+		if owner, ok := owners[e.SessionID]; ok && owner == adapterSlug {
 			return true
 		}
 	}

--- a/tools/onboarding-factory/internal/hookcov/hookcov_test.go
+++ b/tools/onboarding-factory/internal/hookcov/hookcov_test.go
@@ -160,6 +160,32 @@ func TestCoverageRelativeRepoRoot(t *testing.T) {
 	}
 }
 
+// mkFile creates path (and its parent directories) with content — the one
+// low-level write every fixture helper below shares, so directory creation
+// and its error handling live in exactly one place.
+func mkFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// writeSingleRecordingCell lays down one cell —
+// replaydata/agents/<adapter>/scenarios/1-1_one, with one recording (r1)
+// whose events.jsonl is eventsJSONL — the minimum shape Coverage reads.
+// Shared by every hookcov test below that needs exactly one cell with one
+// recording, rather than each re-deriving the same directory-and-metadata
+// boilerplate its own way.
+func writeSingleRecordingCell(t *testing.T, root, adapter, eventsJSONL string) {
+	t.Helper()
+	cell := filepath.Join(root, "replaydata", "agents", adapter, "scenarios", "1-1_one")
+	mkFile(t, filepath.Join(cell, "metadata.json"), `{"scenario_id":"one"}`)
+	mkFile(t, filepath.Join(cell, "recordings", "r1", "events.jsonl"), eventsJSONL)
+}
+
 // writeHookFixture lays down one claudecode cell with one hook-bearing
 // recording — the minimum shape Coverage reads. The hook_received line is
 // preceded by a transcript_new for the same session_id carrying
@@ -170,18 +196,7 @@ func TestCoverageRelativeRepoRoot(t *testing.T) {
 // relativity).
 func writeHookFixture(t *testing.T, root string) {
 	t.Helper()
-	mk := func(path, content string) {
-		t.Helper()
-		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
-			t.Fatal(err)
-		}
-	}
-	cell := filepath.Join(root, "replaydata", "agents", "claudecode", "scenarios", "1-1_one")
-	mk(filepath.Join(cell, "metadata.json"), `{"scenario_id":"one"}`)
-	mk(filepath.Join(cell, "recordings", "r1", "events.jsonl"),
+	writeSingleRecordingCell(t, root, "claudecode",
 		`{"seq":1,"ts":"2026-05-01T00:00:00Z","kind":"transcript_new","session_id":"s","adapter":"claude-code"}`+"\n"+
 			`{"seq":2,"ts":"2026-05-01T00:00:01Z","kind":"hook_received","session_id":"s","hook_name":"PostToolUse"}`+"\n")
 }
@@ -230,18 +245,7 @@ func TestHermesCoexistHookNotCredited(t *testing.T) {
 // launder the exact bug #1768 is about.
 func TestUnattributableHookEventDoesNotCount(t *testing.T) {
 	root := t.TempDir()
-	mk := func(path, content string) {
-		t.Helper()
-		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
-			t.Fatal(err)
-		}
-	}
-	cell := filepath.Join(root, "replaydata", "agents", "hermes", "scenarios", "1-1_one")
-	mk(filepath.Join(cell, "metadata.json"), `{"scenario_id":"one"}`)
-	mk(filepath.Join(cell, "recordings", "r1", "events.jsonl"),
+	writeSingleRecordingCell(t, root, "hermes",
 		`{"seq":1,"ts":"2026-05-01T00:00:00Z","kind":"hook_received","session_id":"orphan","hook_name":"Stop"}`+"\n")
 
 	rep := Coverage(root, []string{"hermes"}, map[string]bool{"hermes": true})
@@ -262,18 +266,7 @@ func TestUnattributableHookEventDoesNotCount(t *testing.T) {
 // not a repaired one.
 func TestOwnHookEventStillCounts(t *testing.T) {
 	root := t.TempDir()
-	mk := func(path, content string) {
-		t.Helper()
-		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
-			t.Fatal(err)
-		}
-	}
-	cell := filepath.Join(root, "replaydata", "agents", "hermes", "scenarios", "1-1_one")
-	mk(filepath.Join(cell, "metadata.json"), `{"scenario_id":"one"}`)
-	mk(filepath.Join(cell, "recordings", "r1", "events.jsonl"),
+	writeSingleRecordingCell(t, root, "hermes",
 		`{"seq":1,"ts":"2026-05-01T00:00:00Z","kind":"transcript_new","session_id":"s1","adapter":"hermes"}`+"\n"+
 			`{"seq":2,"ts":"2026-05-01T00:00:01Z","kind":"hook_received","session_id":"s1","hook_name":"Stop"}`+"\n")
 

--- a/tools/onboarding-factory/internal/hookcov/hookcov_test.go
+++ b/tools/onboarding-factory/internal/hookcov/hookcov_test.go
@@ -4,10 +4,24 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"testing"
 
 	"irrlicht/core/adapters/inbound/agents"
 )
+
+// repoRoot resolves the repository root from this test file's own path, the
+// same pattern replay.repoRoot and righome.repoRoot use — hookcov sits at the
+// same depth (tools/onboarding-factory/internal/<pkg>), so it is also four
+// directories up.
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	return filepath.Join(filepath.Dir(thisFile), "..", "..", "..", "..")
+}
 
 // TestDeclaredMatchesRegistry pins the code→catalog join. This is the part of
 // the report that can rot without anything else noticing: rename the
@@ -147,7 +161,13 @@ func TestCoverageRelativeRepoRoot(t *testing.T) {
 }
 
 // writeHookFixture lays down one claudecode cell with one hook-bearing
-// recording — the minimum shape Coverage reads.
+// recording — the minimum shape Coverage reads. The hook_received line is
+// preceded by a transcript_new for the same session_id carrying
+// adapter:"claude-code" so the event is genuinely attributable to claudecode
+// (see the Attribution doc on hasOwnHookEvent) — without it, this fixture
+// would trip the same unattributable-event exclusion TestUnattributableHookEventDoesNotCount
+// covers, for a reason unrelated to what this test actually checks (repo-root
+// relativity).
 func writeHookFixture(t *testing.T, root string) {
 	t.Helper()
 	mk := func(path, content string) {
@@ -162,7 +182,108 @@ func writeHookFixture(t *testing.T, root string) {
 	cell := filepath.Join(root, "replaydata", "agents", "claudecode", "scenarios", "1-1_one")
 	mk(filepath.Join(cell, "metadata.json"), `{"scenario_id":"one"}`)
 	mk(filepath.Join(cell, "recordings", "r1", "events.jsonl"),
-		`{"seq":1,"ts":"2026-05-01T00:00:00Z","kind":"hook_received","session_id":"s","hook_name":"PostToolUse"}`+"\n")
+		`{"seq":1,"ts":"2026-05-01T00:00:00Z","kind":"transcript_new","session_id":"s","adapter":"claude-code"}`+"\n"+
+			`{"seq":2,"ts":"2026-05-01T00:00:01Z","kind":"hook_received","session_id":"s","hook_name":"PostToolUse"}`+"\n")
+}
+
+// TestHermesCoexistHookNotCredited is the defect test for #1768, run against
+// the already-committed
+// replaydata/agents/hermes/scenarios/4-2_multiple-agents-same-workspace
+// recording — no new fixture needed. That recording is the WHOLE of hermes's
+// hook_received corpus (`grep -c hook_received` on its events.jsonl is 1),
+// and the one event's session_id (8b9025f8-5346-484e-89a6-41e991602e47) is
+// tagged adapter:"claude-code" by every sibling transcript_new /
+// transcript_activity event for that session_id in the SAME sidecar — a
+// co-resident Claude Code session's Stop hook, landed in hermes's cell
+// directory because this is a coexistence scenario, not a hermes hook. hermes's
+// own session in this recording (20260803_011105_d40f63) carries zero
+// hook_received events of its own.
+//
+// Before the fix, hasHookEvent counts any hook_received regardless of whose
+// session it names, so this recording alone flips hermes's row to StatusOK.
+// The fix must read it as StatusGap: hermes declares hooks (#1722) and this
+// corpus supplies none of its own.
+func TestHermesCoexistHookNotCredited(t *testing.T) {
+	rep := Coverage(repoRoot(t), []string{"hermes"}, map[string]bool{"hermes": true})
+	if len(rep.Adapters) != 1 {
+		t.Fatalf("Coverage(hermes) = %d rows, want 1: %+v", len(rep.Adapters), rep.Adapters)
+	}
+	row := rep.Adapters[0]
+	if row.WithHooks != 0 {
+		t.Errorf("hermes WithHooks = %d, want 0 — the one hook_received event in "+
+			"4-2_multiple-agents-same-workspace belongs to session "+
+			"8b9025f8-5346-484e-89a6-41e991602e47, tagged adapter:\"claude-code\" by "+
+			"every sibling event for that session — not hermes's own", row.WithHooks)
+	}
+	if row.Status != StatusGap {
+		t.Errorf("hermes Status = %q, want %q (declares hooks, corpus supplies none of its own)",
+			row.Status, StatusGap)
+	}
+}
+
+// TestUnattributableHookEventDoesNotCount pins the other half of the
+// Attribution rule directly: a hook_received event whose session_id has NO
+// sibling event carrying an Adapter anywhere in the sidecar must not count
+// for anybody — the spec calls this out explicitly ("an unattributable event
+// must NOT count as coverage") precisely so the fix cannot default an
+// unresolvable session to the cell's own adapter, which would silently
+// launder the exact bug #1768 is about.
+func TestUnattributableHookEventDoesNotCount(t *testing.T) {
+	root := t.TempDir()
+	mk := func(path, content string) {
+		t.Helper()
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	cell := filepath.Join(root, "replaydata", "agents", "hermes", "scenarios", "1-1_one")
+	mk(filepath.Join(cell, "metadata.json"), `{"scenario_id":"one"}`)
+	mk(filepath.Join(cell, "recordings", "r1", "events.jsonl"),
+		`{"seq":1,"ts":"2026-05-01T00:00:00Z","kind":"hook_received","session_id":"orphan","hook_name":"Stop"}`+"\n")
+
+	rep := Coverage(root, []string{"hermes"}, map[string]bool{"hermes": true})
+	if got := rep.Adapters[0].WithHooks; got != 0 {
+		t.Errorf("WithHooks = %d, want 0 — session %q has no sibling event naming an adapter, so it must not be credited to hermes (or anyone)", got, "orphan")
+	}
+	if rep.Adapters[0].Status != StatusGap {
+		t.Errorf("Status = %q, want %q", rep.Adapters[0].Status, StatusGap)
+	}
+}
+
+// TestOwnHookEventStillCounts is the vacuity guard: attribution-by-session
+// must not degenerate into "no hook_received event ever counts" — a
+// hook_received event whose session_id IS tagged as the adapter's own by a
+// sibling event in the same sidecar must still count. Without this, the fix
+// for #1768 would make hermes's StatusGap unfalsifiable — permanently GAP no
+// matter what the corpus contains — which is a check with no genuine content,
+// not a repaired one.
+func TestOwnHookEventStillCounts(t *testing.T) {
+	root := t.TempDir()
+	mk := func(path, content string) {
+		t.Helper()
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	cell := filepath.Join(root, "replaydata", "agents", "hermes", "scenarios", "1-1_one")
+	mk(filepath.Join(cell, "metadata.json"), `{"scenario_id":"one"}`)
+	mk(filepath.Join(cell, "recordings", "r1", "events.jsonl"),
+		`{"seq":1,"ts":"2026-05-01T00:00:00Z","kind":"transcript_new","session_id":"s1","adapter":"hermes"}`+"\n"+
+			`{"seq":2,"ts":"2026-05-01T00:00:01Z","kind":"hook_received","session_id":"s1","hook_name":"Stop"}`+"\n")
+
+	rep := Coverage(root, []string{"hermes"}, map[string]bool{"hermes": true})
+	if got := rep.Adapters[0].WithHooks; got != 1 {
+		t.Fatalf("WithHooks = %d, want 1 — session %q is tagged adapter:\"hermes\" by its own transcript_new, so its hook_received event is hermes's own", got, "s1")
+	}
+	if rep.Adapters[0].Status != StatusOK {
+		t.Errorf("Status = %q, want %q", rep.Adapters[0].Status, StatusOK)
+	}
 }
 
 // TestGapsListsOnlyGaps confirms the convenience accessor the CLI shouts with.


### PR DESCRIPTION
## Summary

`of coverage --hooks` credited **hermes** with a hook-bearing recording that
was actually a co-resident Claude Code session's `Stop` hook, landed in
hermes's cell directory because `4-2_multiple-agents-same-workspace` is a
hermes/claude-code coexistence scenario (#1768). hermes has zero hook events
of its own anywhere in the corpus.

The natural repair — require `hook_name` to be one of the names the adapter
installs — turns out not to work, and the issue thread's own later comments
found this out the hard way: every adapter's turn-done hook dispatches
through the same handful of canonical wire names
(`session.HookStop = "Stop"` chief among them,
`core/application/services/session_detector_lifecycle.go`), so an adapter's
own `Stop` hook and a co-resident adapter's `Stop` hook are byte-identical by
name. hermes's raw hook vocabulary (`pre_approval_request`,
`post_approval_response`, `on_session_end`) never appears in a recorded
`hook_name` at all — it's normalized away before the event is written — so
neither direction of a literal name-vocabulary match works.

`hook_received` also never carries its own `adapter` field (empty in every
instance across the corpus). But every *other* event kind for the same
`session_id` in the same sidecar — `transcript_new`, `transcript_activity`,
... — does carry `adapter`. So the fix cross-references a `hook_received`
event's `session_id` against its sibling events in the same recording to find
out whose session it actually is, and only credits the event to that adapter.
A session with no attributable sibling at all counts for nobody — never
defaulted to the cell's own adapter, which would silently launder the exact
bug this join exists to catch.

## Scope note

Kept narrowly to the attribution/session-cross-reference logic in
`hookcov.go`, per the coordinating task's instructions — did not touch
`hookcov`'s `Declared()`/roster shape (that's #1759's territory, and its
current scope is a different file, `beaconroute_test.go`, not this package)
and did not touch the recording-rig side of why foreign hook traffic lands in
recordings at all (#1769, explicitly out of scope here).

**Bonus finding, same defect, no extra code needed to catch it:** the general,
session_id-based fix also flips **copilot**'s row from `ok` to `GAP`. Its own
`4-2_multiple-agents-same-workspace` recording's one `hook_received` event
belongs to session `31e6174f-...`, which every sibling event in that sidecar
tags `adapter:"claude-code"` — the same shape as hermes, not something this
PR went looking for. The issue thread's own corpus sweep had marked copilot
"unsettled" ("nothing attributes them"); this fix resolves it definitively
with the sidecar as evidence. Live corpus output before/after, for the record:

```
before: copilot  yes  46  37  1  ok                              hermes  yes  46  24  1  ok
after:  copilot  yes  46  37  0  GAP — declares hooks, zero ...   hermes  yes  46  24  0  GAP — declares hooks, zero ...
```

## Red-first evidence

Two new tests were written and run against the pre-fix code, and both failed
as expected:

- `TestHermesCoexistHookNotCredited` (real, already-committed
  `replaydata/agents/hermes/scenarios/4-2_multiple-agents-same-workspace`
  recording, no new fixture) — pre-fix: `WithHooks=1, Status="ok"`; wanted
  `WithHooks=0, Status="gap"`.
- `TestUnattributableHookEventDoesNotCount` (synthetic fixture, a
  `hook_received` event with no sibling naming any adapter at all) — pre-fix:
  `WithHooks=1, Status="ok"`; wanted `WithHooks=0, Status="gap"`.

```
=== RUN   TestHermesCoexistHookNotCredited
    hookcov_test.go:213: hermes WithHooks = 1, want 0 — ...
    hookcov_test.go:219: hermes Status = "ok", want "gap" ...
--- FAIL: TestHermesCoexistHookNotCredited (0.01s)
=== RUN   TestUnattributableHookEventDoesNotCount
    hookcov_test.go:249: WithHooks = 1, want 0 ...
    hookcov_test.go:252: Status = "ok", want "gap"
--- FAIL: TestUnattributableHookEventDoesNotCount (0.00s)
```

Both pass after the fix. A third new test, `TestOwnHookEventStillCounts`, is
the vacuity guard the issue asked for (a genuine hermes-tagged hook event must
still count) — it's a **lock**, not a defect test: it already passes against
the pre-fix code too (any `hook_received` counted unconditionally back then),
so it's not red-first evidence, just the guard against the fix collapsing
into "hermes can never be `ok`".

Two existing test fixtures (`hookcov_test.go`'s `writeHookFixture`, `of`'s
`fixture_test.go`'s `recording()` helper) needed a one-line addition — a
sibling `transcript_new` tagging their session with the adapter under test —
so their hook events stay genuinely attributable under the new rule instead
of being incidentally caught by the unattributable-event exclusion for a
reason unrelated to what those tests actually check.

## Verification

- `go test ./tools/onboarding-factory/... -race -count=1` — all green.
- `go run ./tools/onboarding-factory/cmd/of validate` — OK.
- `go vet ./tools/onboarding-factory/...`, `gofmt -l` — clean.
- Pre-push `tools/preflight.sh --changed` (onboarding-factory tests,
  replaydata validate, recording-rig smoke test, replay fixtures, security
  scan) — all PASS.

Closes #1768

🤖 Generated with [Claude Code](https://claude.com/claude-code)