### PR TITLE
fix(hermes): correct gateway-exclusion mechanism claims, pin it with locks

### DIFF
--- a/core/adapters/inbound/agents/hermes/hookinstaller.go
+++ b/core/adapters/inbound/agents/hermes/hookinstaller.go
@@ -15,8 +15,11 @@
 // HERMES_HOME:
 //
 //   - **hermes has a first-class hook system with its own CLI subcommand.**
-//     `hermes hooks {list|test|revoke|doctor}` (hermes_cli/hooks.py), 25
-//     lifecycle events (`VALID_HOOKS` in hermes_cli/plugins.py), and THREE
+//     `hermes hooks {list|test|revoke|doctor}` (hermes_cli/hooks.py) and a
+//     growing set of lifecycle events (`VALID_HOOKS` in
+//     hermes_cli/plugins.py — 23 at v0.19.0, 37 at v0.20.5 five weeks later;
+//     #1773. No single count is asserted here because nothing in this
+//     adapter re-derives it, and one already went stale), and THREE
 //     independent subscription mechanisms — a gateway-only Python handler
 //     directory, in-process Python plugins under `~/.hermes/plugins/`, and
 //     SHELL hooks declared as a `hooks:` block in `~/.hermes/config.yaml`
@@ -89,7 +92,12 @@
 //     under another profile is watched by the store watcher alone, exactly as
 //     it was before this channel existed.
 //   - The gateway platforms (whatsapp, slack, …). The hooks fire there too,
-//     but those sessions are filtered out of this adapter by `source`.
+//     but those sessions never reach a dispatch: gateway sessions are minted
+//     `uuid.uuid4().hex[:8]` against the `hex[:6]` sessionIDShape (hooks.go)
+//     actually accepts, so the exclusion is id-shape by hex length — not
+//     `source`, which the shell-hook envelope does not carry at all. See
+//     TestSessionIDShape_RejectsGatewayMintedIDs and
+//     TestHookReceiver_GatewaySurfaceApprovalIsQuiet in hooks_test.go (#1773).
 package hermes
 
 import (
@@ -167,7 +175,8 @@ const (
 //
 //   - `post_tool_call`, `subagent_start`/`subagent_stop`, the `kanban_*`
 //     trio and the gateway hooks are either store-covered or out of this
-//     adapter's scope (`source` filtering excludes the gateway platforms).
+//     adapter's scope (the gateway platforms are excluded by sessionIDShape's
+//     hex length, not by `source` — see hooks.go and the tests named above).
 var installedHookEvents = []string{
 	HookEventPreApprovalRequest,
 	HookEventPostApprovalResponse,

--- a/core/adapters/inbound/agents/hermes/hooks.go
+++ b/core/adapters/inbound/agents/hermes/hooks.go
@@ -115,6 +115,23 @@ const logComponentHookReceiver = "hermes-hook-receiver"
 // session key falls back to the literal "default" when a turn runs without one
 // (`set_current_session_key(self.session_id or "default")`), and gateway
 // surfaces put a platform routing key in the same field.
+//
+// # Gateway sessions, and why hex length is the whole guard (#1773)
+//
+// Gateway sessions are minted the same date/time shape but with 8 hex
+// characters instead of 6 — `uuid.uuid4().hex[:8]`, gateway/session.py:2831
+// and :3354, unchanged since v0.19.0 — against the CLI/TUI mint's
+// `uuid.uuid4().hex[:6]` (agent/agent_init.py:1647, cli.py:5437,
+// tui_gateway/server.py:7359) this regex actually accepts. At v0.19.0 a
+// gateway approval's top-level session_id was empty, so it was rejected
+// before this regex was ever consulted; hermes 0.20.5's
+// tools/approval.py:126-133 now forwards a well-formed session_id for
+// gateway turns too, so the hex-length distinction here is the ONLY thing
+// standing between a gateway approval and a dispatch. See
+// TestSessionIDShape_RejectsGatewayMintedIDs and
+// TestHookReceiver_GatewaySurfaceApprovalIsQuiet (hooks_test.go), and the
+// mutation check in hooks_mutations_test.go that proves the regex — not
+// something else — is what rejects them.
 var sessionIDShape = regexp.MustCompile(`^[0-9]{8}_[0-9]{6}_[0-9a-f]{6}$`)
 
 // hermesHookPayload is the JSON body hermes pipes to a shell hook's stdin,

--- a/core/adapters/inbound/agents/hermes/hooks_mutations_test.go
+++ b/core/adapters/inbound/agents/hermes/hooks_mutations_test.go
@@ -1,0 +1,89 @@
+// hooks_mutations_test.go is the committed mutation evidence for
+// sessionIDShape's exclusion of hermes' messaging-gateway sessions — the
+// fixture docs/testing-philosophy.md and AGENTS.md ask for in place of a
+// paragraph in a PR body that nothing re-runs (#1773).
+//
+// TestSessionIDShape_RejectsGatewayMintedIDs and
+// TestHookReceiver_GatewaySurfaceApprovalIsQuiet (hooks_test.go) are LOCKS:
+// they pin behaviour that must not change, so neither has a "before the fix"
+// to run red. What earns them is the opposite proof — widen the regex by
+// exactly the one-character-class change that would admit a gateway-minted
+// id, and confirm both assertions flip. If they didn't flip, the two tests
+// above would be passing for a reason unrelated to hex length, which is
+// exactly the failure #1773 diagnosed in the comments this same issue fixes:
+// an assertion (or a comment) that looks like it is discriminating on the
+// right thing but isn't.
+package hermes
+
+import (
+	"net/http"
+	"regexp"
+	"testing"
+)
+
+// widenedSessionIDShape is sessionIDShape with the trailing hex run widened
+// from exactly 6 to 6-or-8 — the change that would let a gateway-minted id
+// (`uuid.uuid4().hex[:8]`, gateway/session.py:2831,:3354) through the same
+// gate that today only admits a CLI/TUI-minted id
+// (`uuid.uuid4().hex[:6]`, agent/agent_init.py:1647, cli.py:5437,
+// tui_gateway/server.py:7359).
+var widenedSessionIDShape = regexp.MustCompile(`^[0-9]{8}_[0-9]{6}_[0-9a-f]{6,8}$`)
+
+// gatewayMintedSessionID is a well-formed gateway-shaped id: hermes'
+// date/time prefix plus 8 hex characters, the shape tools/approval.py:126-133
+// forwards for a gateway approval since v0.20.5.
+const gatewayMintedSessionID = "20260802_233614_c97a8d12"
+
+// TestSessionIDShapeMutation_WidenedRegexAdmitsGatewayID is (a)'s mutation
+// half. It first re-asserts the precondition — the shipped regex rejects the
+// gateway mint, which is TestSessionIDShape_RejectsGatewayMintedIDs itself —
+// then requires the widened regex to admit the exact same string. A widened
+// regex that still rejected it would mean this corpus does not model the
+// drift it claims to.
+func TestSessionIDShapeMutation_WidenedRegexAdmitsGatewayID(t *testing.T) {
+	if sessionIDShape.MatchString(gatewayMintedSessionID) {
+		t.Fatalf("precondition failed: the shipped sessionIDShape already accepts %q — "+
+			"TestSessionIDShape_RejectsGatewayMintedIDs is not red-able and this mutation "+
+			"cannot demonstrate anything", gatewayMintedSessionID)
+	}
+	if !widenedSessionIDShape.MatchString(gatewayMintedSessionID) {
+		t.Fatalf("mutation is inert: widening the hex run to {6,8} still rejects %q, so it "+
+			"cannot stand in for the drift this test protects against", gatewayMintedSessionID)
+	}
+}
+
+// TestHookReceiverMutation_WidenedShapeDispatchesGatewayApproval is (b)'s
+// mutation half. It swaps sessionIDShape for the widened regex for the
+// duration of this test only (restored via defer — this package runs no
+// t.Parallel tests, so no other test observes the swap), replays the exact
+// gateway envelope TestHookReceiver_GatewaySurfaceApprovalIsQuiet asserts is
+// quiet, and requires it to dispatch instead.
+//
+// This is the row that proves TestHookReceiver_GatewaySurfaceApprovalIsQuiet
+// is actually pinned on hex length and not passing by accident (e.g. because
+// the routing key in extra.session_key also fails to match some OTHER way):
+// under the widened regex, the top-level gateway id becomes acceptable and
+// payload.sessionID() picks it (it checks session_id before
+// extra.session_key), so the dispatch count must go from 0 to 1.
+func TestHookReceiverMutation_WidenedShapeDispatchesGatewayApproval(t *testing.T) {
+	original := sessionIDShape
+	sessionIDShape = widenedSessionIDShape
+	defer func() { sessionIDShape = original }()
+
+	hermesHome(t)
+	h, target := newReceiver(t)
+
+	body := `{"hook_event_name":"` + HookEventPreApprovalRequest +
+		`","session_id":"` + gatewayMintedSessionID +
+		`","extra":{"session_key":"whatsapp:4915112345678","surface":"gateway"}}`
+	rec := post(t, h, body)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if n := target.totalCalls(); n != 1 {
+		t.Fatalf("dispatched %d times under the widened shape, want exactly 1 — if this is not "+
+			"1, TestHookReceiver_GatewaySurfaceApprovalIsQuiet's zero-dispatch assertion is not "+
+			"actually discriminating on hex length", n)
+	}
+}

--- a/core/adapters/inbound/agents/hermes/hooks_test.go
+++ b/core/adapters/inbound/agents/hermes/hooks_test.go
@@ -442,6 +442,82 @@ func TestHookReceiver_ForeignSessionIDIsQuiet(t *testing.T) {
 	}
 }
 
+// TestSessionIDShape_RejectsGatewayMintedIDs pins the ACTUAL mechanism that
+// keeps hermes' messaging-gateway sessions out of this adapter: sessionIDShape's
+// hex length. hookinstaller.go used to say `source` filtering did this; the
+// shell-hook envelope carries no `source` field at all (#1773).
+//
+// Upstream mint sites (all origin/main @ 261a4efb, v0.20.5 — unchanged since
+// v0.19.0):
+//   - gateway sessions: `uuid.uuid4().hex[:8]` — gateway/session.py:2831, :3354
+//   - CLI/TUI sessions: `uuid.uuid4().hex[:6]` — agent/agent_init.py:1647,
+//     cli.py:5437, tui_gateway/server.py:7359
+//
+// Table-driven so the failure names which rule rejects each row: the gateway
+// mint is rejected specifically on hex length, while "default" (the
+// contextvar fallback, `set_current_session_key(self.session_id or
+// "default")`) and a platform routing key are rejected because they are not
+// date/time-shaped at all.
+//
+// This is a LOCK — it pins behaviour that must not change, not a defect fix —
+// so it has no red-before-green phase. hooks_mutations_test.go's mutation
+// check is what earns it: widening the hex run to {6,8} flips this exact
+// table's gateway-mint row.
+func TestSessionIDShape_RejectsGatewayMintedIDs(t *testing.T) {
+	tests := []struct {
+		name string
+		id   string
+		want bool
+	}{
+		{"cli/tui 6-hex mint is accepted", "20260802_233614_c97a8d", true},
+		{"gateway 8-hex mint is rejected on hex length", "20260802_233614_c97a8d12", false},
+		{"contextvar default fallback is rejected (not date-shaped)", "default", false},
+		{"gateway routing key is rejected (not date-shaped)", "whatsapp:4915112345678", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := sessionIDShape.MatchString(tt.id); got != tt.want {
+				t.Errorf("sessionIDShape.MatchString(%q) = %v, want %v", tt.id, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestHookReceiver_GatewaySurfaceApprovalIsQuiet is a LOCK on the same
+// mechanism as the table above, exercised through the real receiver rather
+// than the regex alone: a 0.20.5-shaped gateway approval — a WELL-FORMED
+// 8-hex top-level session_id (tools/approval.py:126-133 now forwards one for
+// gateway turns too, unlike v0.19.0's empty field) plus a routing key in
+// extra.session_key — must dispatch nothing.
+//
+// This is the row that would have caught the drift: it fails the moment
+// either the gateway mint shape or the receiver's first-field preference
+// (payload.sessionID(), which reads top-level session_id before
+// extra.session_key) moves. TestHookReceiver_ForeignSessionIDIsQuiet does not
+// cover this — its rows share the same malformed string in both fields, never
+// a WELL-FORMED-but-wrong-length top-level id the way 0.20.5 actually sends
+// one.
+func TestHookReceiver_GatewaySurfaceApprovalIsQuiet(t *testing.T) {
+	hermesHome(t)
+	h, target := newReceiver(t)
+
+	const gatewayMintedSessionID = "20260802_233614_c97a8d12" // 8 hex — gateway mint shape
+	body := `{"hook_event_name":"` + HookEventPreApprovalRequest +
+		`","session_id":"` + gatewayMintedSessionID +
+		`","extra":{"session_key":"whatsapp:4915112345678","surface":"gateway"}}`
+
+	rec := post(t, h, body)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200", rec.Code)
+	}
+	if n := target.totalCalls(); n != 0 {
+		t.Fatalf("dispatched %d times for a gateway-surface approval, want 0 — hex length is "+
+			"the only guard left standing since hermes 0.20.5 forwards a well-formed session_id "+
+			"for gateway turns too", n)
+	}
+}
+
 // TestHookReceiver_PermissionGateContract runs the shared #797 contract once
 // per permission this receiver must honour, derived from the receiver's own
 // declaration (issue #1488).


### PR DESCRIPTION
## Summary

Follow-up to #1766 (behavior verified clean at hermes 0.20.5). This is a
documentation/test-correctness fix — no adapter behavior change.

Two wrong claims in `core/adapters/inbound/agents/hermes/`:

1. **`hookinstaller.go:18`** said hermes has "25" lifecycle events. Measured
   directly from `VALID_HOOKS`: 23 at v0.19.0, 37 at v0.20.5 — 25 was never
   right, and nothing re-derives the count. Fixed by stating both
   revision-qualified counts and dropping the bare "25".

2. **`hookinstaller.go:91-92` and `:168-170`** both said hermes' messaging-
   gateway sessions "are filtered out of this adapter by `source`". The hook
   receiver (`hooks.go`) has no `source` filter at all — the shell-hook
   envelope doesn't carry that field. What actually excludes gateway sessions
   is **session-ID hex length**: gateway-minted IDs use `hex[:8]`
   (`gateway/session.py:2831,:3354`), CLI/TUI-minted IDs use `hex[:6]`
   (`agent/agent_init.py:1647`, `cli.py:5437`, `tui_gateway/server.py:7359`),
   and `sessionIDShape` (`hooks.go:118`, `^[0-9]{8}_[0-9]{6}_[0-9a-f]{6}$`)
   only accepts the 6-hex shape. This got sharper at hermes 0.20.5: gateway
   approval events now carry a well-formed top-level `session_id` too
   (`tools/approval.py:126-133`), so hex length is the ONLY thing rejecting
   them today.

   **Note on the issue's own citations:** #1773 named `agent.go:55-58` as the
   second wrong-claim location. I read that text (the `PermissionKeyStore`
   permission's `Detail` string) and it does not say "by `source`" — it's
   about the STORE watcher, which genuinely does filter
   `WHERE source IN ('cli','tui','subagent')` in SQL (`metrics.go:19-25`,
   `watcher.go:284`), a real, different, correctly-described mechanism. The
   second actual occurrence of the wrong claim is
   `hookinstaller.go:168-170`, not `agent.go`. Fixed the two real locations;
   left `agent.go` untouched since its claim is accurate.

## What's new

- `TestSessionIDShape_RejectsGatewayMintedIDs` (table-driven): pins that
  `sessionIDShape` rejects an 8-hex gateway-shaped ID and accepts a 6-hex
  CLI/TUI-shaped ID, plus the `"default"` contextvar fallback and a platform
  routing key, citing upstream mint sites.
- `TestHookReceiver_GatewaySurfaceApprovalIsQuiet`: drives the real
  `NewHookHandler` with a 0.20.5-shaped gateway approval envelope (8-hex
  top-level `session_id`, `extra.session_key` a routing key, `surface:
  "gateway"`) and asserts zero dispatches.
- `hooks_mutations_test.go`: the committed mutation-check fixture. Widens
  `sessionIDShape` to `[0-9a-f]{6,8}` for the duration of two tests and
  confirms both flip — the regex-level accept/reject table, and the
  receiver's dispatch count (0 → 1). Mirrors the existing
  `antigravity/hookinstaller_mutations_test.go` convention for a guard with
  no "before the fix" to run red.
- A cross-referencing note added to `sessionIDShape`'s own doc comment
  (`hooks.go`) spelling out the 0.20.5 sharpening and pointing at both new
  tests.

Explicitly out of scope (per the issue): no adapter behavior change, no
version-floor change, no work on `SHELL_UNSUPPORTED_HOOKS`.

## Verification

- `go test ./core/adapters/inbound/agents/hermes/... -race -count=1` — all
  pass, including with `-count=2` to rule out state leakage from the
  mutation tests' package-var swap.
- `go test ./core/... -race -count=1` (full module) — passes except one
  pre-existing, unrelated flake in `processlifecycle`
  (`TestReadLauncherEnv_Tmux_DetachedResolvesNoHost`), confirmed to pass 5/5
  in isolation and under `-race` in isolation; this branch touches no file
  in that package.
- `tools/preflight.sh` chunks: `go`, `arch`, `tools`, `skills`, `posix`,
  `bash` — all PASS. `web`/`swift` skipped (no files touched in those
  trees). Pre-push hook's own `--changed` run (gofmt, ARS, core tests,
  replay fixtures, security scan) — all PASS.

Closes #1773.

🤖 Generated with [Claude Code](https://claude.com/claude-code)