### PR TITLE
fix(opencode): settle a late turn-done hook that races process-exit teardown

### DIFF
--- a/core/application/services/pid_manager.go
+++ b/core/application/services/pid_manager.go
@@ -115,6 +115,16 @@ type PIDManager struct {
 	// clean up its own tracking structures (e.g. projectSessions map).
 	onSessionDeleted func(sessionID string)
 
+	// onSessionRemoved is called from deleteSession — the single choke point
+	// for an actual repo-row removal — with the session's last known state,
+	// just before that row is deleted. Unlike onSessionDeleted (id-only, and
+	// also fired earlier from HandleProcessExit before any state is loaded),
+	// this exists so a caller can cache the state itself: SessionDetector
+	// uses it to let a hook that authoritatively signals turn-done but loses
+	// the teardown race still settle the session to ready instead of being
+	// silently dropped (issue #1772). Optional; nil disables the cache.
+	onSessionRemoved func(*session.SessionState)
+
 	// onChildDeleted is called when a child session is removed by the
 	// liveness sweep so the SessionDetector can re-evaluate the parent.
 	// Without this the parent can be left stuck in `working` forever
@@ -171,6 +181,7 @@ type PIDManagerDeps struct {
 	ProcessNames     map[string]string
 	LiveCWDs         LiveCWDsFunc
 	OnSessionDeleted func(sessionID string)
+	OnSessionRemoved func(*session.SessionState)
 }
 
 // NewPIDManager creates a PIDManager with the given dependencies.
@@ -185,6 +196,7 @@ func NewPIDManager(deps PIDManagerDeps) *PIDManager {
 		processNames:     deps.ProcessNames,
 		liveCWDs:         deps.LiveCWDs,
 		onSessionDeleted: deps.OnSessionDeleted,
+		onSessionRemoved: deps.OnSessionRemoved,
 		pendingPIDs:      make(map[string]int),
 	}
 }
@@ -588,6 +600,9 @@ func (pm *PIDManager) deleteSession(s *session.SessionState, reason string) {
 	})
 	if pm.onSessionDeleted != nil {
 		pm.onSessionDeleted(s.SessionID)
+	}
+	if pm.onSessionRemoved != nil {
+		pm.onSessionRemoved(s)
 	}
 	_ = pm.repo.Delete(s.SessionID)
 	pm.log.LogInfo("session-cleanup", s.SessionID,

--- a/core/application/services/session_detector.go
+++ b/core/application/services/session_detector.go
@@ -136,6 +136,20 @@ type SessionDetector struct {
 	// --continue, not ghost events from a dying process.
 	deletedSessions map[string]int64
 
+	// deletedStates caches the last known *session.SessionState for a session
+	// removed via PIDManager.deleteSession (process exit, the ready-TTL/
+	// liveness sweep), keyed the same as deletedSessions and cleared at the
+	// same points. It exists so an authoritative turn-done hook (opencode's
+	// session.idle, hermes' on_session_end — anything that sets
+	// agent.Event.Terminal) that loses the race with that exact teardown
+	// still has a session to classify against instead of a repo row that is
+	// simply gone (issue #1772). Not populated for /clear or the dedup/
+	// supersession reconciliation paths, which delete the repo row directly
+	// without going through deleteSession — reviving those would be exactly
+	// the ghost-session class deletedCooldown exists to prevent. See
+	// cacheDeletedSnapshot and processActivity's Terminal branch.
+	deletedStates map[string]*session.SessionState
+
 	// hostGateRejected tracks session IDs the host-ancestry admission gate
 	// (issue #784) has already rejected. No cooldown/expiry, unlike
 	// deletedSessions — a rejected PID's process ancestry (e.g. CodexBar,
@@ -298,6 +312,7 @@ func newSessionDetector() *SessionDetector {
 		merged:                   make(chan identifiedEvent, 16),
 		projectSessions:          make(map[string]string),
 		deletedSessions:          make(map[string]int64),
+		deletedStates:            make(map[string]*session.SessionState),
 		hostGateRejected:         make(map[string]struct{}),
 		debounce:                 make(map[string]*debounceEntry),
 		debouncedEvents:          make(chan agent.Event, 64),
@@ -346,6 +361,7 @@ func NewSessionDetector(watchers []inbound.Watcher, deps SessionDetectorDeps) *S
 		ProcessNames:     deps.ProcessNames,
 		LiveCWDs:         deps.LiveCWDs,
 		OnSessionDeleted: det.removeFromProjectSessions,
+		OnSessionRemoved: det.cacheDeletedSnapshot,
 	})
 	det.pidMgr.SetChildDeletedHandler(det.reevaluateParent)
 	return det

--- a/core/application/services/session_detector_activity.go
+++ b/core/application/services/session_detector_activity.go
@@ -634,6 +634,11 @@ func (d *SessionDetector) processActivity(id agent.Identity, ev agent.Event) {
 		if deleted && ev.Terminal {
 			revive = d.deletedStates[ev.SessionID]
 			if revive != nil {
+				// Only the one-shot snapshot is consumed here. deletedSessions
+				// itself is deliberately left in place: the row this pass is
+				// about to re-save makes repo.Load succeed again, so nothing
+				// downstream ever consults the tombstone for this id again
+				// until a fresh deletion re-timestamps it.
 				delete(d.deletedStates, ev.SessionID)
 			}
 		}

--- a/core/application/services/session_detector_activity.go
+++ b/core/application/services/session_detector_activity.go
@@ -157,6 +157,7 @@ func (d *SessionDetector) recentlyDeleted(ev agent.Event) bool {
 		return true
 	}
 	delete(d.deletedSessions, ev.SessionID)
+	delete(d.deletedStates, ev.SessionID)
 	d.log.LogInfo(logComponentSessionDetector, ev.SessionID,
 		"previously deleted session has fresh activity (--continue), allowing re-creation")
 	return false
@@ -610,12 +611,41 @@ func (d *SessionDetector) processActivity(id agent.Identity, ev agent.Event) {
 		deletedAt, deleted := d.deletedSessions[ev.SessionID]
 		if deleted && time.Since(time.Unix(deletedAt, 0)) >= d.deletedCooldown && !isStaleTranscript(ev.TranscriptPath) {
 			delete(d.deletedSessions, ev.SessionID)
+			delete(d.deletedStates, ev.SessionID)
 			deleted = false
 			d.log.LogInfo(logComponentSessionDetector, ev.SessionID,
 				"previously deleted session has fresh activity (--continue), allowing re-creation")
 		}
+		// An authoritative turn-done hook (ev.Terminal — opencode's
+		// session.idle, hermes' on_session_end) racing this exact teardown
+		// still within the cooldown gets one more chance: PIDManager's own
+		// process-exit/liveness-sweep teardown cached the session's last
+		// known state (cacheDeletedSnapshot) before deleting its repo row.
+		// Reviving from that snapshot and running it through the normal
+		// classify pass settles it to ready instead of silently dropping the
+		// hook against a session that has already been torn down (issue
+		// #1772). One-shot: the snapshot is consumed here so a duplicate or
+		// later hook for the same id falls through to the ordinary paths —
+		// repo.Load succeeds once this pass has re-saved the state.
+		// Ordinary (non-Terminal) activity is NOT granted this exception: a
+		// plain transcript write racing teardown is exactly the ghost
+		// resurrection deletedCooldown exists to block.
+		var revive *session.SessionState
+		if deleted && ev.Terminal {
+			revive = d.deletedStates[ev.SessionID]
+			if revive != nil {
+				delete(d.deletedStates, ev.SessionID)
+			}
+		}
 		d.mu.Unlock()
 		if deleted {
+			if revive != nil {
+				d.log.LogInfo(logComponentSessionDetector, ev.SessionID,
+					"turn-done hook arrived after teardown — settling cached snapshot to ready")
+				d.pidMgr.WithSessionStateLock(func() {
+					d.processActivityLocked(id, revive, ev)
+				})
+			}
 			return
 		}
 		// Session not tracked yet — treat as new (startup race where activity

--- a/core/application/services/session_detector_helpers.go
+++ b/core/application/services/session_detector_helpers.go
@@ -29,6 +29,34 @@ func (d *SessionDetector) removeFromProjectSessions(sessionID string) {
 	d.forgetSessionScopedState(sessionID)
 }
 
+// cacheDeletedSnapshot stashes state's last known in-memory value, keyed by
+// session ID, alongside the deletedSessions tombstone removeFromProjectSessions
+// writes for the same id. It exists so a hook that authoritatively signals
+// turn-done (opencode's session.idle, hermes' on_session_end — anything that
+// dispatches an agent.Event with Terminal set) but loses the race with THIS
+// exact teardown — HandleProcessExit records ProcessExited and the repo row
+// is gone before the plugin's own HTTP beacon can land — still has a session
+// to classify against instead of nothing at all. See processActivity's
+// Terminal branch and issue #1772.
+//
+// Wired as PIDManagerDeps.OnSessionRemoved, fired only from deleteSession —
+// the single choke point every actual repo-row removal routes through
+// (process exit, the ready-TTL/liveness sweep, the startup zombie sweep).
+// Deliberately NOT fired from HandleProcessExit's own early onSessionDeleted
+// call (no state is loaded yet at that point) and NOT fired by the /clear
+// cleanup or dedup/supersession paths, which call repo.Delete directly
+// without going through deleteSession — reviving a session removed on
+// purpose would be exactly the ghost-session class deletedCooldown exists to
+// prevent.
+func (d *SessionDetector) cacheDeletedSnapshot(state *session.SessionState) {
+	if state == nil {
+		return
+	}
+	d.mu.Lock()
+	d.deletedStates[state.SessionID] = state
+	d.mu.Unlock()
+}
+
 // forgetSessionScopedState drops the per-session bookkeeping that only the
 // session itself gives meaning to. It exists because there are TWO teardown
 // paths and they are not the same one:

--- a/core/application/services/session_detector_lifecycle.go
+++ b/core/application/services/session_detector_lifecycle.go
@@ -300,6 +300,14 @@ func (d *SessionDetector) HandlePermissionHook(sessionID, transcriptPath, hookEv
 // (PreToolUse fires before the write) — while a real fswatcher pass with no
 // transcript growth (e.g. mistral-vibe's content-less slash-command touch)
 // does not force the bounce. See issue #905.
+//
+// It is also marked Terminal exactly when hookName is session.HookStop — the
+// one hook name in this shared dispatch that means "the turn is authoritatively
+// done," as opposed to a permission prompt or compaction signal. processActivity
+// reads Terminal to decide whether a hook arriving for an already-tombstoned
+// session (this call racing PIDManager's own teardown) still deserves a
+// classify pass against the cached snapshot rather than being dropped
+// (issue #1772).
 func (d *SessionDetector) dispatchHookActivity(sessionID, transcriptPath, hookName string) {
 	d.record(lifecycle.Event{
 		Kind:      lifecycle.KindHookReceived,
@@ -313,6 +321,7 @@ func (d *SessionDetector) dispatchHookActivity(sessionID, transcriptPath, hookNa
 		SessionID:      sessionID,
 		TranscriptPath: transcriptPath,
 		Synthetic:      true,
+		Terminal:       hookName == session.HookStop,
 	}:
 	default:
 		d.log.LogError("hook-receiver", sessionID,
@@ -578,7 +587,9 @@ func (d *SessionDetector) seedBackfillMetadata(states []*session.SessionState) {
 
 // pruneDeletedSessionsCache drops deletedSessions entries older than 1 hour,
 // left over from a previous daemon run. Entries that old serve no purpose —
-// the re-creation cooldown they guard is only 10 seconds.
+// the re-creation cooldown they guard is only 10 seconds. deletedStates is
+// keyed identically and pruned in lockstep — it never outlives the tombstone
+// that gates whether anything ever reads it back (issue #1772).
 func (d *SessionDetector) pruneDeletedSessionsCache() {
 	d.mu.Lock()
 	defer d.mu.Unlock()
@@ -586,6 +597,7 @@ func (d *SessionDetector) pruneDeletedSessionsCache() {
 	for id, ts := range d.deletedSessions {
 		if ts < pruneThreshold {
 			delete(d.deletedSessions, id)
+			delete(d.deletedStates, id)
 		}
 	}
 }

--- a/core/application/services/session_detector_teardown_race_test.go
+++ b/core/application/services/session_detector_teardown_race_test.go
@@ -1,0 +1,103 @@
+package services_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"irrlicht/core/domain/session"
+)
+
+// TestSessionDetector_LateStopHookAfterProcessExit_SettlesToReady is issue
+// #1772's acceptance evidence.
+//
+// A headless opencode run (`opencode run`) exits so quickly after the store
+// write that ends its turn that the daemon's own process-exit teardown —
+// HandleProcessExit records process_exited and deletes the session's repo
+// row — routinely wins the race against the plugin's session.idle beacon
+// POST. Measured against three real recordings while onboarding opencode's
+// first hook-bearing fixture (#1770/#1771): the process exits roughly 115ms
+// after the turn-ending store write, and the beacon lands only about 2ms
+// after teardown has already run. hook_received is still recorded — the
+// HTTP handler doesn't know the session is gone — but before this fix the
+// state transition it exists to drive was silently dropped: the repo row is
+// already deleted, deletedSessions tombstones the id for the next 10
+// seconds, and processActivity's cooldown branch just returns. Three
+// recorded attempts at the 2-1_basic-turn scenario came back
+// "unsettled_session … still working" as a direct result.
+//
+// Reproduced here without opencode's own SQLite store or HTTP plugin, both
+// incidental to the race: the daemon-side sequence that matters is
+// HandleProcessExit(pid, sid, …) immediately followed by
+// HandleStopHook(sid, …) for the same sid, inside the 10s cooldown — exactly
+// what a same-process kqueue callback racing a slightly slower HTTP handler
+// produces in production, compressed to (near) zero wall-clock gap here
+// because the fix depends only on landing inside the cooldown window, not on
+// the gap's exact size. Confirmed red against pre-fix behavior: reverting
+// the fix (the deletedStates cache in session_detector.go/
+// session_detector_helpers.go, the OnSessionRemoved wiring in
+// pid_manager.go, dispatchHookActivity's Terminal flag, and processActivity's
+// revive branch) while keeping this test makes it fail with "last saved
+// state = "", want "ready"" — the Stop hook is dropped and repo.Save is never
+// called for this session again.
+func TestSessionDetector_LateStopHookAfterProcessExit_SettlesToReady(t *testing.T) {
+	tw := newMockAgentWatcher()
+	pw := newMockProcessWatcher()
+	repo := newMockRepo()
+
+	const sid = "oc-headless-1"
+	const path = "/tmp/opencode-test.db-wal?session=oc-headless-1"
+
+	repo.states[sid] = &session.SessionState{
+		SessionID:      sid,
+		State:          session.StateWorking,
+		PID:            54321,
+		Adapter:        "opencode",
+		TranscriptPath: path,
+		FirstSeen:      time.Now().Unix(),
+		UpdatedAt:      time.Now().Unix(),
+		// LastEventType deliberately does NOT say the turn is done. Every bit
+		// of "this settled to ready" below must come from the Stop hook's
+		// SignalTurnDone hold — not from re-reading transcript content, which
+		// wouldn't exist to re-read for a torn-down opencode DB session
+		// anyway (issue #1772's whole point: the daemon's own repo row is
+		// gone, there is nothing left to re-derive state from except the
+		// hook's payload).
+		Metrics: &session.SessionMetrics{LastEventType: "assistant_message"},
+	}
+
+	det := newDetector(tw, pw, repo)
+	// Keep the default 10s cooldown: the race this reproduces falls inside a
+	// single-digit-millisecond window, nowhere near the 10s boundary.
+
+	// The daemon's own teardown wins the race: process exit is handled — and
+	// the repo row deleted — before the hook lands.
+	det.HandleProcessExit(54321, sid, "test: pid exited (ESRCH)")
+
+	if state, _ := repo.Load(sid); state != nil {
+		t.Fatal("precondition: session should be deleted by HandleProcessExit")
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- det.Run(ctx) }()
+	defer func() { cancel(); <-done }()
+
+	time.Sleep(20 * time.Millisecond) // let seedFromDisk finish
+
+	// The plugin's beacon lands a couple of milliseconds too late in
+	// production; here it lands right after teardown, well inside the 10s
+	// cooldown — the scenario issue #1772 asks to be proven red, then green.
+	det.HandleStopHook(sid, path, "Done. All tests pass.", false)
+
+	waitForSessionState(repo, sid, session.StateReady, 2*time.Second)
+
+	repo.mu.Lock()
+	got := repo.lastSavedState[sid]
+	repo.mu.Unlock()
+	if got != session.StateReady {
+		t.Fatalf("after a Stop hook racing process-exit teardown: last saved state = %q, want %q — "+
+			"the turn-done signal was dropped against an already-torn-down session (issue #1772)",
+			got, session.StateReady)
+	}
+}


### PR DESCRIPTION
## Summary

`opencode run` (headless) exits so quickly after its final store write that the daemon's own process-exit teardown — `HandleProcessExit` records `process_exited` and deletes the session's repo row — routinely wins the race against the plugin's `session.idle` beacon POST (measured at #1770/#1771: ~115ms process exit after the turn-ending write, ~2ms further for the beacon). `hook_received` was still recorded, but the `ready` transition it exists to drive was silently dropped once the repo row was gone — headless opencode sessions got permanently stuck at "working".

## Fix chosen

Of the three options the issue laid out, this implements **(1) a short grace mechanism on teardown**, using the repo's *existing* bounded, self-expiring `deletedSessions` tombstone (10s cooldown, already used to prevent ghost-session resurrection from late transcript writes) rather than inventing a second grace window:

- `PIDManager.deleteSession` (the single choke point for an actual repo-row removal — process exit, the ready-TTL/liveness sweep) now hands its last known `*session.SessionState` to a new optional `OnSessionRemoved` callback.
- `SessionDetector` uses it to cache a one-shot snapshot (`deletedStates`) alongside the existing tombstone, cleared at every point the tombstone itself is cleared.
- `dispatchHookActivity` marks its injected event `Terminal` exactly when the hook is `session.HookStop` — the one hook name in that shared dispatch that authoritatively means "the turn is done" (as opposed to a permission prompt or compaction signal).
- When a `Terminal` hook arrives for an already-tombstoned session within the cooldown, `processActivity` revives the cached snapshot through the *ordinary* classify-and-transition path (`processActivityLocked`) instead of dropping it — settling the session to `ready` exactly as it would have while still alive. Ordinary (non-`Terminal`) activity is unaffected: a plain late transcript write still can't resurrect a deleted session.

**Why this doesn't reintroduce the ghost-session class:** no new session state is added (still exactly working/waiting/ready), and a revived session is an *ordinary* `ready` session — reaped by the same pre-existing `SweepDeadPIDs`/`CheckPIDLiveness` dead-PID sweep (5-15s cadence) that cleans up any other completed session with a dead PID. `/clear` and the dedup/supersession reconciliation paths delete their repo rows directly, bypassing `deleteSession`, so they're deliberately **not** covered by this — reviving a session removed on purpose would be exactly the ghost class the cooldown exists to prevent.

The mechanism is adapter-agnostic (keyed on the shared Stop-hook dispatch, not an adapter name), so it also covers hermes' `on_session_end`, which the investigation found is very likely exposed to the identical race (unverified live, but structurally identical: same `dispatchHookActivity`/`HandleStopHook` path).

## Acceptance evidence (issue's ask)

`core/application/services/session_detector_teardown_race_test.go` — `TestSessionDetector_LateStopHookAfterProcessExit_SettlesToReady` — drives `SessionDetector.HandleProcessExit` immediately followed by `HandleStopHook` for the same session id, within the 10s cooldown, and asserts the session reaches `ready`.

**Confirmed red before the fix**: reverting the fix files (keeping the test) and running it gives:
```
last saved state = "", want "ready" — the turn-done signal was dropped against an already-torn-down session (issue #1772)
```
Restoring the fix makes it green. Full `go test ./core/application/services/...` and `go test ./core/...` both pass with the fix in place (one unrelated pre-existing flake in `core/e2e`'s `TestFSWatcher_EmitsEventsForTranscriptCreateAndModify` was observed once under heavy concurrent load and confirmed to pass 3/3 in isolation — unrelated package, not touched by this diff).

## Verification run

- `go test ./core/... -race -count=1` — pass (full suite, including architecture tests)
- `go test ./tools/onboarding-factory/... -race -count=1` — pass (no golden drift from this change)
- `tools/preflight.sh --only arch` — ARS gate pass, no composite/category regression
- `tools/preflight.sh --only go/tools/skills/posix/bash/security` — all pass
- Pre-push hook (`tools/preflight.sh --changed --budget 540`) — pass

## Risks / follow-ups for a reviewer

- This only fixes the **hook-channel** race for the Stop/idle signal. The issue's own framing treats headless opencode's transcript-inferred fallback (`step-finish reason=stop → turn_done`, still present in `parser.go`) as the pre-existing baseline; I have **not** verified live whether that transcript-polling path independently loses the identical race against `HandleProcessExit`'s kqueue-driven teardown (it's a separate, DB-polling-interval-based channel). Worth a live re-record of the `2-1_basic-turn` scenario to confirm; out of scope here since it needs a live opencode CLI + local LM Studio model.
- hermes is very likely exposed to the identical race (same shared dispatch path) but this PR does not add a hermes-specific regression test — only observed structurally, not reproduced live.

Closes #1772

🤖 Generated with [Claude Code](https://claude.com/claude-code)