### PR TITLE
fix(rig): scope grant-all's auto-grant to the adapter(s) actually recorded

### DIFF
--- a/core/adapters/inbound/agents/claudecode/hooks_recordadapters_test.go
+++ b/core/adapters/inbound/agents/claudecode/hooks_recordadapters_test.go
@@ -1,0 +1,178 @@
+package claudecode
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"irrlicht/core/application/services"
+	"irrlicht/core/domain/agent"
+	"irrlicht/core/domain/config"
+	"irrlicht/core/domain/permission"
+	"irrlicht/core/ports/inbound"
+	"irrlicht/core/ports/outbound"
+)
+
+// This file is the literal acceptance evidence for issue #1769: a rig daemon
+// recording some OTHER adapter must not accept a claudecode-shaped hook POST
+// at all. lib/spawn-record-daemon.sh:87 sets
+// IRRLICHT_PERMISSION_MODE=grant-all unconditionally for every recording, and
+// claudecode is one of righome.Unisolatable's structurally unrelocatable
+// adapters (claudeSettingsPath joins os.UserHomeDir() unconditionally) — so,
+// before this fix, recording e.g. a mistral-vibe cell repointed the
+// operator's REAL ~/.claude/settings.json at the recording daemon, and any
+// claudecode session on the machine (this one included, since Claude Code
+// reloads its settings file live rather than snapshotting it at session
+// start) would have its hook traffic accepted and turned into a recorded
+// session, whatever cell was actually being recorded.
+//
+// This test wires the REAL claudecode.NewHookHandler to a REAL
+// *services.PermissionService running in grant-all mode with
+// RecordAdapters naming some other adapter, then POSTs a claudecode Stop
+// hook payload and asserts the target — standing in for the recorder — is
+// never called. It was seen red before PermissionService.Start's
+// scopedOutByRecordAdapters check existed: the same POST reached
+// target.HandleStopHook once.
+//
+// Importing services from an adapter's _test.go file runs opposite to the
+// hexagonal layering (adapters -> application/services) that
+// core/architecture_test.go statically enforces for non-test code — but
+// that check walks only non-test imports (see its own header comment: "a
+// pkg/**/*_test.go importing an adapter would [pass]"), and
+// permission_shared_config_gate_test.go already sets the mirror-image
+// precedent (a services test importing the kirocli adapter, with the same
+// justification). This is the one place claudecode's real hook receiver and
+// a real PermissionService's grant-all auto-grant meet.
+
+// noopPermStore, noopPush, noopLogger and noopRegistrar are the minimal
+// PermissionService dependencies this test needs — a fresh, empty consent
+// store, no broadcast/log observation, and no watcher registration. None of
+// PermissionService's behavior under test (grant-all auto-grant scoping)
+// depends on what these do, only that they satisfy the ports.
+type noopPermStore struct{}
+
+func (noopPermStore) Load() (permission.Set, error) { return permission.Set{}, nil }
+func (noopPermStore) Save(permission.Set) error     { return nil }
+
+type noopPush struct{}
+
+func (noopPush) Broadcast(outbound.PushMessage)       {}
+func (noopPush) Subscribe() chan outbound.PushMessage { return nil }
+func (noopPush) Unsubscribe(chan outbound.PushMessage) {
+}
+
+type noopLogger struct{}
+
+func (noopLogger) LogInfo(string, string, string)                       {}
+func (noopLogger) LogError(string, string, string)                      {}
+func (noopLogger) LogProcessingTime(string, string, int64, int, string) {}
+func (noopLogger) Close() error                                         { return nil }
+
+type noopRegistrar struct{}
+
+func (noopRegistrar) AddWatcher(context.Context, inbound.Watcher) {}
+
+// fakeOtherAdapter is a minimal second agent standing in for "whichever
+// adapter this recording run is actually for" — anything with a modify
+// permission declaring a managed file would do; only its NAME (referenced by
+// RecordAdapters below) matters to this test.
+func fakeOtherAdapter() agent.Agent {
+	return agent.Agent{
+		Identity: agent.Identity{Name: "other-adapter", DisplayName: "Other Adapter"},
+		Process:  agent.Process{Match: agent.ExactName{Name: "other-adapter"}},
+		Permissions: []agent.Permission{
+			{
+				Key:    "hooks",
+				Kind:   permission.KindModify,
+				Title:  "Install status hooks",
+				Apply:  func() error { return nil },
+				Remove: func() error { return nil },
+				Writes: &agent.ManagedUserFile{
+					Path:      func() (string, error) { return "/tmp/irr-1769-other-adapter.json", nil },
+					Uninstall: func() (bool, error) { return false, nil },
+				},
+			},
+		},
+	}
+}
+
+// recordAdaptersGate boots a real PermissionService in grant-all mode scoped
+// to recordAdapters — the exact shape a rig daemon runs in — and returns it
+// as the ConsentGranter NewHookHandler is wired with in production
+// (registerHookRoutes passes the daemon's own PermissionService).
+func recordAdaptersGate(t *testing.T, recordAdapters []string) *services.PermissionService {
+	t.Helper()
+	svc := services.NewPermissionService(services.PermissionServiceDeps{
+		Agents: []agent.Agent{Agent(), fakeOtherAdapter()},
+		Store:  noopPermStore{},
+		Push:   noopPush{},
+		Log:    noopLogger{},
+		Mode:   config.PermissionModeGrantAll,
+		// Mirrors the rig setting IRRLICHT_ALLOW_SHARED_CONFIG_WRITES=1
+		// unconditionally (#1449) — this test is about #1769's
+		// adapter-scoping gate, not the separate isolated-home guard.
+		AllowSharedConfigWrites: true,
+		Registrar:               noopRegistrar{},
+		RecordAdapters:          recordAdapters,
+	})
+	svc.Start(context.Background())
+	return svc
+}
+
+// TestClaudeCodeHookRejectedWhenClaudeCodeIsNotTheRecordedAdapter is the
+// literal #1769 acceptance evidence: a claudecode-shaped Stop hook POST,
+// naming a session this daemon otherwise knows nothing about, must not reach
+// the recorder when the daemon is scoped to record a DIFFERENT adapter.
+func TestClaudeCodeHookRejectedWhenClaudeCodeIsNotTheRecordedAdapter(t *testing.T) {
+	dir := claudeProjectsRoot(t)
+	transcriptPath := writeContractTranscript(t, dir)
+	gate := recordAdaptersGate(t, []string{"other-adapter"}) // recording "other-adapter", NOT claudecode
+
+	target := &mockTarget{}
+	handler := NewHookHandler(target, nil, gate, noopLogger{})
+
+	req := httptest.NewRequest(http.MethodPost, HookEndpointPath,
+		bytes.NewBufferString(contractPayload(transcriptPath, HookStop)))
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (a consent-denied hook is dropped quietly, not answered with an error)", rr.Code)
+	}
+	if calls := target.getCalls(); len(calls) != 0 {
+		t.Errorf("HandlePermissionHook was called %d time(s); want 0", len(calls))
+	}
+	// stopCalls has no getter (nothing else needed one before this test);
+	// read it directly — same package, and the request above has already
+	// returned, so there is no concurrent writer left to race.
+	if n := len(target.stopCalls); n != 0 {
+		t.Errorf("HandleStopHook was called %d time(s) — the hook landed in the recording despite claudecode not being the recorded adapter (issue #1769)", n)
+	}
+}
+
+// TestClaudeCodeHookAcceptedWhenClaudeCodeIsTheRecordedAdapter is the vacuity
+// guard: the gate above must not refuse claudecode's OWN hook traffic when
+// claudecode is (or is among) the recorded adapter(s) — otherwise the
+// restriction would break the very recordings it exists to protect.
+func TestClaudeCodeHookAcceptedWhenClaudeCodeIsTheRecordedAdapter(t *testing.T) {
+	dir := claudeProjectsRoot(t)
+	transcriptPath := writeContractTranscript(t, dir)
+	gate := recordAdaptersGate(t, []string{AdapterName})
+
+	target := &mockTarget{}
+	handler := NewHookHandler(target, nil, gate, noopLogger{})
+
+	req := httptest.NewRequest(http.MethodPost, HookEndpointPath,
+		bytes.NewBufferString(contractPayload(transcriptPath, HookStop)))
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rr.Code)
+	}
+	if n := len(target.stopCalls); n != 1 {
+		t.Fatalf("HandleStopHook was called %d time(s); want 1 — claudecode's own hook must still land when claudecode IS the recorded adapter", n)
+	}
+}

--- a/core/application/services/construction_test.go
+++ b/core/application/services/construction_test.go
@@ -140,6 +140,10 @@ func guardedConstructions() []guardedConstruction {
 			nilTolerant: map[string]string{
 				"factories": "dependency-supplied (nil means demo mode: no watcher ever starts) " +
 					"and only ever read — startWatching does one lookup, and a nil-map read is legal",
+				"recordAdapters": "nil IS the sentinel for 'no restriction' (issue #1769) — " +
+					"NewPermissionService only ever REPLACES it wholesale, via recordAdapterSet(deps.RecordAdapters) " +
+					"(which itself returns nil for an empty/absent list rather than an allocated empty map), " +
+					"and scopedOutByRecordAdapters only ever READS it (len() and index-read on a nil map are both legal)",
 			},
 			mustBeNonZero: map[string]string{
 				"detectInterval": "Start's time.NewTicker panics outright on a non-positive interval, " +

--- a/core/application/services/permission_record_adapters_test.go
+++ b/core/application/services/permission_record_adapters_test.go
@@ -1,0 +1,165 @@
+package services_test
+
+import (
+	"context"
+	"testing"
+
+	"irrlicht/core/application/services"
+	"irrlicht/core/domain/agent"
+	"irrlicht/core/domain/config"
+	"irrlicht/core/domain/permission"
+)
+
+// This file covers issue #1769: lib/spawn-record-daemon.sh:87 sets
+// IRRLICHT_PERMISSION_MODE=grant-all unconditionally for every recording,
+// whatever adapter the run is actually about. Before this fix,
+// PermissionService.Start auto-granted EVERY agent's permissions under
+// grant-all, which ran EVERY adapter's Apply closure — including hook
+// installers for adapters the run had nothing to do with. claudecode is the
+// sharpest case: it is one of righome.Unisolatable's structurally
+// unrelocatable adapters (claudeSettingsPath joins os.UserHomeDir()
+// unconditionally), so recording e.g. a mistral-vibe cell repointed the
+// operator's REAL ~/.claude/settings.json at the recording daemon for the
+// run's whole duration — and, since Claude Code reloads its settings file
+// live rather than snapshotting it at session start (per upstream docs,
+// quoted in the issue thread — not measured on this machine, since measuring
+// it means rewriting the operator's real settings.json), every
+// already-running Claude Code session on the machine picked up the rig's
+// endpoint too, for as long as the recording ran.
+//
+// IRRLICHT_RECORD_ADAPTERS (config.Config.RecordAdapters) narrows Start's
+// grant-all auto-grant to the adapter(s) a run actually names, for
+// modify-kind permissions that declare a managed user file. Left unset,
+// behaviour is byte-for-byte what it was before this issue (see
+// TestRecordAdaptersUnset_PreservesExistingGrantAllBehavior, a LOCK).
+
+// writingAgent builds a minimal agent declaring one modify-kind permission
+// with a managed user file (the shape every hook installer has) plus one
+// observe-kind permission (the shape a transcript-reading permission has).
+// applied records whether the modify permission's Apply closure ran.
+func writingAgent(name string, applied *bool) agent.Agent {
+	return agent.Agent{
+		Identity: agent.Identity{Name: name, DisplayName: name},
+		Process:  agent.Process{Match: agent.ExactName{Name: name}},
+		Permissions: []agent.Permission{
+			{
+				Key:    "hooks",
+				Kind:   permission.KindModify,
+				Title:  "Install status hooks",
+				Apply:  func() error { *applied = true; return nil },
+				Remove: func() error { *applied = false; return nil },
+				Writes: &agent.ManagedUserFile{
+					Path:      func() (string, error) { return "/tmp/irr-1769-" + name + "-settings.json", nil },
+					Uninstall: func() (bool, error) { return false, nil },
+				},
+			},
+			{
+				Key:   "transcripts",
+				Kind:  permission.KindObserve,
+				Title: "Read session transcripts",
+			},
+		},
+	}
+}
+
+// TestRecordAdapters_ScopesGrantAllApplyAndGrantedToTheNamedAdapter is the
+// #1769 defect test. Seen red before PermissionService.Start's
+// scopedOutByRecordAdapters check existed: both assertions on the foreign
+// adapter failed (its Apply ran, and Granted read true) because grant-all
+// auto-granted every agent unconditionally.
+func TestRecordAdapters_ScopesGrantAllApplyAndGrantedToTheNamedAdapter(t *testing.T) {
+	recordedApplied, foreignApplied := false, false
+	recorded := writingAgent("recorded-adapter", &recordedApplied)
+	foreign := writingAgent("foreign-adapter", &foreignApplied)
+
+	svc := services.NewPermissionService(services.PermissionServiceDeps{
+		Agents: []agent.Agent{recorded, foreign},
+		Store:  &mockPermStore{},
+		Push:   &mockPush{},
+		Log:    &mockLogger{},
+		Mode:   config.PermissionModeGrantAll,
+		// AllowSharedConfigWrites mirrors the rig setting
+		// IRRLICHT_ALLOW_SHARED_CONFIG_WRITES=1 unconditionally (#1449): this
+		// test is about #1769's adapter-scoping gate specifically, not the
+		// separate isolated-home guard, so lift the latter the way the rig
+		// does rather than let it refuse both agents for an unrelated reason.
+		AllowSharedConfigWrites: true,
+		Registrar:               &mockRegistrar{},
+		RecordAdapters:          []string{"recorded-adapter"},
+	})
+	svc.Start(context.Background())
+
+	if !recordedApplied {
+		t.Error("the recorded adapter's hooks Apply never ran — grant-all should still auto-grant the adapter this run is actually recording")
+	}
+	if !svc.Granted("recorded-adapter", "hooks") {
+		t.Error("the recorded adapter's hooks permission reads as not granted")
+	}
+	if foreignApplied {
+		t.Error("the foreign adapter's hooks Apply ran anyway — grant-all wrote a real shared config for an adapter this run was never recording (issue #1769)")
+	}
+	if svc.Granted("foreign-adapter", "hooks") {
+		t.Error("the foreign adapter's hooks permission reads as granted — a hook POST for this adapter would still be accepted by the consent gate and could land in the recording")
+	}
+}
+
+// TestRecordAdapters_ObserveKindStaysGrantedForEveryAdapter proves the
+// restriction does NOT silence a co-resident agent's own transcript/process
+// visibility — only the install-a-real-file side effect (and the consent
+// state gating its hook endpoint) is narrowed. This is what keeps a
+// "multiple-agents-same-workspace" style scenario, where a second agent is
+// deliberately present, from losing its OWN file-based signal.
+func TestRecordAdapters_ObserveKindStaysGrantedForEveryAdapter(t *testing.T) {
+	recordedApplied, foreignApplied := false, false
+	recorded := writingAgent("recorded-adapter", &recordedApplied)
+	foreign := writingAgent("foreign-adapter", &foreignApplied)
+
+	svc := services.NewPermissionService(services.PermissionServiceDeps{
+		Agents:                  []agent.Agent{recorded, foreign},
+		Store:                   &mockPermStore{},
+		Push:                    &mockPush{},
+		Log:                     &mockLogger{},
+		Mode:                    config.PermissionModeGrantAll,
+		AllowSharedConfigWrites: true,
+		Registrar:               &mockRegistrar{},
+		RecordAdapters:          []string{"recorded-adapter"},
+	})
+	svc.Start(context.Background())
+
+	if !svc.Granted("foreign-adapter", "transcripts") {
+		t.Error("the foreign adapter's OBSERVE-kind transcripts permission reads as not granted — " +
+			"the restriction must not silence a co-resident agent's own file-based visibility")
+	}
+	if !svc.Granted("recorded-adapter", "transcripts") {
+		t.Error("the recorded adapter's transcripts permission reads as not granted")
+	}
+}
+
+// TestRecordAdapters_UnsetPreservesExistingGrantAllBehavior is a LOCK: with
+// RecordAdapters unset (nil), grant-all behaves exactly as it did before
+// #1769 — every declared permission is granted and applied, matching a dev
+// daemon or any rig caller that has not been updated to pass the new env var.
+func TestRecordAdapters_UnsetPreservesExistingGrantAllBehavior(t *testing.T) {
+	oneApplied, twoApplied := false, false
+	one := writingAgent("agent-one", &oneApplied)
+	two := writingAgent("agent-two", &twoApplied)
+
+	svc := services.NewPermissionService(services.PermissionServiceDeps{
+		Agents:                  []agent.Agent{one, two},
+		Store:                   &mockPermStore{},
+		Push:                    &mockPush{},
+		Log:                     &mockLogger{},
+		Mode:                    config.PermissionModeGrantAll,
+		AllowSharedConfigWrites: true,
+		Registrar:               &mockRegistrar{},
+		// RecordAdapters intentionally omitted (nil).
+	})
+	svc.Start(context.Background())
+
+	if !oneApplied || !twoApplied {
+		t.Fatalf("expected both agents' Apply to run with RecordAdapters unset; applied=%v/%v", oneApplied, twoApplied)
+	}
+	if !svc.Granted("agent-one", "hooks") || !svc.Granted("agent-two", "hooks") {
+		t.Fatal("expected both agents' hooks permission granted with RecordAdapters unset")
+	}
+}

--- a/core/application/services/permission_service.go
+++ b/core/application/services/permission_service.go
@@ -188,6 +188,27 @@ type PermissionService struct {
 	isolatedHome            string
 	allowSharedConfigWrites bool
 
+	// recordAdapters is the set IRRLICHT_RECORD_ADAPTERS names (issue #1769),
+	// or nil when unset. Only consulted in grant-all mode, by Start: it
+	// narrows the auto-grant of hook-install-shaped permissions
+	// (Kind==KindModify with a declared Writes) to the adapter(s) this run is
+	// actually recording, so a rig daemon spawned to record one adapter's
+	// cell no longer auto-grants — and therefore never runs the Apply that
+	// rewrites — every OTHER adapter's real shared config too. claudecode is
+	// the sharpest case (see config.Config.RecordAdapters for the full
+	// mechanism), but the restriction is adapter-agnostic: it applies to
+	// whichever agent's permission it is asked about.
+	//
+	// Deliberately scoped to modify-kind Writes-bearing permissions only:
+	// observe-kind permissions (transcript reading) are granted for every
+	// agent regardless of this set, so a co-resident agent that happens to
+	// be present in the same workspace stays visible via its own
+	// transcript/process signals — only the install-a-real-file side effect,
+	// and the consent state that gates its hook HTTP endpoint, are narrowed.
+	// nil (the zero value) means no restriction, matching every daemon that
+	// predates this field.
+	recordAdapters map[string]bool
+
 	factories map[string]WatcherFactory
 	hasLive   HasLiveProcessFunc
 
@@ -274,6 +295,11 @@ type PermissionServiceDeps struct {
 	// feed the grant-all shared-config guard (#1449) and are inert in ask mode.
 	IsolatedHome            string
 	AllowSharedConfigWrites bool
+
+	// RecordAdapters is config.Config.RecordAdapters, forwarded verbatim
+	// (issue #1769). Inert outside grant-all mode. See the recordAdapters
+	// field for the mechanism.
+	RecordAdapters []string
 }
 
 // newPermissionService allocates a PermissionService with every field the
@@ -320,6 +346,7 @@ func NewPermissionService(deps PermissionServiceDeps) *PermissionService {
 	s.hasLive = deps.HasLive
 	s.isolatedHome = deps.IsolatedHome
 	s.allowSharedConfigWrites = deps.AllowSharedConfigWrites
+	s.recordAdapters = recordAdapterSet(deps.RecordAdapters)
 	// permission.Set is itself map-backed and Put writes to it, so a nil Set —
 	// which a store may return alongside a nil error — is the same nil-map trap
 	// one level down. Keep the allocator's empty one rather than adopting it.
@@ -332,6 +359,21 @@ func NewPermissionService(deps PermissionServiceDeps) *PermissionService {
 // effectKey is the composite key for the effectErrs map.
 func effectKey(agentName, permKey string) string {
 	return agentName + "/" + permKey
+}
+
+// recordAdapterSet turns IRRLICHT_RECORD_ADAPTERS's name list into a lookup
+// set, or nil for an empty list. nil is the sentinel every recordAdapters
+// consumer reads as "no restriction" (issue #1769) — named here so that
+// contract lives in one place rather than being re-derived at each call site.
+func recordAdapterSet(names []string) map[string]bool {
+	if len(names) == 0 {
+		return nil
+	}
+	set := make(map[string]bool, len(names))
+	for _, n := range names {
+		set[n] = true
+	}
+	return set
 }
 
 // SetDetectionProbe overrides process-matcher detection for one agent —
@@ -359,12 +401,22 @@ func (s *PermissionService) Start(ctx context.Context) {
 	s.mu.Lock()
 	s.parent = ctx
 	if s.mode == config.PermissionModeGrantAll {
+		granted, scopedOut := 0, 0
 		for _, a := range s.agents {
 			for _, p := range a.Permissions {
+				if s.scopedOutByRecordAdapters(a.Identity.Name, p) {
+					scopedOut++
+					continue
+				}
 				s.set.Put(a.Identity.Name, p.Key, permission.StateGranted)
+				granted++
 			}
 		}
-		s.log.LogInfo("permissions", "", "IRRLICHT_PERMISSION_MODE=grant-all — all permissions granted, wizard suppressed")
+		msg := "IRRLICHT_PERMISSION_MODE=grant-all — all permissions granted, wizard suppressed"
+		if scopedOut > 0 {
+			msg = fmt.Sprintf("IRRLICHT_PERMISSION_MODE=grant-all — %d permission(s) granted, %d scoped out by IRRLICHT_RECORD_ADAPTERS (not this run's adapter), wizard suppressed", granted, scopedOut)
+		}
+		s.log.LogInfo("permissions", "", msg)
 	}
 	var effects []pendingEffect
 	for _, a := range s.agents {
@@ -382,6 +434,29 @@ func (s *PermissionService) Start(ctx context.Context) {
 	if runPoller {
 		go s.runDetectionLoop(ctx)
 	}
+}
+
+// scopedOutByRecordAdapters reports whether p, declared by agentName, must be
+// excluded from grant-all's auto-grant because IRRLICHT_RECORD_ADAPTERS names
+// a narrower set of adapters than agentName (issue #1769).
+//
+// Narrowed to the shape every hook installer, the CLAUDE.md instruction
+// block, and the kitty remote-control patch share — Kind==KindModify with a
+// declared Writes (a real, shared, user-owned file) — so an observe-kind
+// permission (transcript reading) or a modify permission that writes nothing
+// shared (agent.ControlPermission) is never scoped out: those don't repoint
+// anything at the recording daemon, and gating them would silence a
+// co-resident agent's own transcript/process visibility for no protective
+// gain (the "multiple-agents-same-workspace" scenario family this is
+// deliberately safe against).
+func (s *PermissionService) scopedOutByRecordAdapters(agentName string, p agent.Permission) bool {
+	if len(s.recordAdapters) == 0 {
+		return false
+	}
+	if p.Kind != permission.KindModify || p.Writes == nil {
+		return false
+	}
+	return !s.recordAdapters[agentName]
 }
 
 // anyPendingLocked reports whether any declared permission is still

--- a/core/cmd/irrlichd/startup.go
+++ b/core/cmd/irrlichd/startup.go
@@ -748,10 +748,13 @@ func setupPermissionService(mux *http.ServeMux, deps setupPermissionServiceDeps)
 		Registrar: detector,
 		Factories: deps.WatcherFactories,
 		HasLive:   hasLive,
-		// #1449: in grant-all these two decide whether an Apply may write the
-		// user's real agent configs. Nothing here is consulted in ask mode.
+		// #1449: the first two decide whether an Apply may write the user's
+		// real agent configs. #1769: RecordAdapters additionally narrows WHICH
+		// agent's grant-all auto-grant runs at all. Nothing here is consulted
+		// in ask mode.
 		IsolatedHome:            isolatedHome(),
 		AllowSharedConfigWrites: deps.Cfg.AllowSharedConfigWrites,
+		RecordAdapters:          deps.Cfg.RecordAdapters,
 	})
 	// Gas Town is detected by root-directory presence (stat-only), not by
 	// a live process matcher.

--- a/core/domain/config/config.go
+++ b/core/domain/config/config.go
@@ -4,6 +4,7 @@ package config
 import (
 	"os"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -153,6 +154,27 @@ type Config struct {
 	// default here too would be a second copy of 5m in a second package that
 	// has to agree with the first forever.
 	HookReverifyInterval time.Duration
+
+	// RecordAdapters narrows grant-all's auto-grant to these adapter identity
+	// names, via IRRLICHT_RECORD_ADAPTERS (comma-separated, e.g. "claudecode"
+	// or "claudecode,codex" for a cross-adapter cell). nil (unset) means no
+	// restriction — every declared permission is granted, matching behaviour
+	// before this existed.
+	//
+	// It exists because grant-all is otherwise all-or-nothing (issue #1769):
+	// lib/spawn-record-daemon.sh:87 sets IRRLICHT_PERMISSION_MODE=grant-all
+	// unconditionally for every recording, whatever adapter the run is
+	// actually about, and PermissionService.Start used to auto-grant EVERY
+	// agent's permissions — including hook installers for adapters this run
+	// has nothing to do with. claudecode is the sharpest case: it is one of
+	// righome.Unisolatable's structurally unrelocatable adapters (its
+	// claudeSettingsPath joins os.UserHomeDir() unconditionally), so recording
+	// e.g. a mistral-vibe cell repointed the operator's REAL
+	// ~/.claude/settings.json at the recording daemon for the run's whole
+	// duration — and since Claude Code reloads its settings file live rather
+	// than snapshotting it at session start, every already-running Claude
+	// Code session on the machine picked up the rig's endpoint too.
+	RecordAdapters []string
 }
 
 // Default returns a Config populated with production defaults, with every
@@ -178,6 +200,8 @@ func Default() Config {
 
 		HookSilentTurns:      envInt("IRRLICHT_HOOK_SILENT_TURNS", defaultHookSilentTurns),
 		HookReverifyInterval: envDuration("IRRLICHT_HOOK_REVERIFY_INTERVAL", 0, minHookReverifyInterval),
+
+		RecordAdapters: envStringList("IRRLICHT_RECORD_ADAPTERS"),
 	}
 }
 
@@ -223,4 +247,23 @@ func envFloat(key string, def float64) float64 {
 		}
 	}
 	return def
+}
+
+// envStringList reads a comma-separated env var into a trimmed, non-empty
+// slice. Unset, empty, or all-whitespace entries yield nil — the sentinel
+// RecordAdapters documents as "no restriction" — rather than an empty
+// non-nil slice, so callers can test len()==0 either way without caring
+// which one they got.
+func envStringList(key string) []string {
+	raw := os.Getenv(key)
+	if raw == "" {
+		return nil
+	}
+	var out []string
+	for _, part := range strings.Split(raw, ",") {
+		if trimmed := strings.TrimSpace(part); trimmed != "" {
+			out = append(out, trimmed)
+		}
+	}
+	return out
 }

--- a/core/domain/config/config.go
+++ b/core/domain/config/config.go
@@ -156,8 +156,12 @@ type Config struct {
 	HookReverifyInterval time.Duration
 
 	// RecordAdapters narrows grant-all's auto-grant to these adapter identity
-	// names, via IRRLICHT_RECORD_ADAPTERS (comma-separated, e.g. "claudecode"
-	// or "claudecode,codex" for a cross-adapter cell). nil (unset) means no
+	// names — agent.Identity.Name, e.g. "codex" or "claude-code" (NOT the
+	// onboarding-factory slug: claudecode's registry spelling is hyphenated
+	// and differs from its "claudecode" replaydata/rig-CLI slug; every other
+	// adapter's slug matches its identity verbatim) — via
+	// IRRLICHT_RECORD_ADAPTERS (comma-separated, e.g. "claude-code" or
+	// "claude-code,codex" for a cross-adapter cell). nil (unset) means no
 	// restriction — every declared permission is granted, matching behaviour
 	// before this existed.
 	//

--- a/docs/testing-contracts.md
+++ b/docs/testing-contracts.md
@@ -630,6 +630,31 @@ below.
   `spawn-record-daemon.sh`, immediately beside the `snapshot_managed_files`
   call that earns the entitlement. **`ir:test-mac`'s separate mode therefore no
   longer installs hooks** — that was the damage, not a regression.
+  `IRRLICHT_ALLOW_SHARED_CONFIG_WRITES` is all-or-nothing across every
+  adapter, though, and that used to be the whole story: recording ANY
+  adapter's cell ran EVERY adapter's `Apply` under grant-all, including
+  claudecode's — which is one of `righome.Unisolatable`'s structurally
+  unrelocatable adapters, so it repointed the operator's real
+  `~/.claude/settings.json` at the recording daemon whatever the run was
+  actually about (issue #1769). `IRRLICHT_RECORD_ADAPTERS` (comma-separated
+  adapter names, `config.Config.RecordAdapters`) narrows `Start`'s grant-all
+  auto-grant itself — via `PermissionService.scopedOutByRecordAdapters`, a
+  sibling check to `sharedConfigRefusal` rather than a change to it — to only
+  the adapter(s) a run actually names, for modify-kind permissions that
+  declare a `Writes` file. Left unset it is a no-op (every daemon that
+  predates it is unaffected); `run-cell.sh` and `run-cell-multi.sh` set it
+  from their own `$ADAPTER` / `$ADAPTERS`. Because the same consent state
+  gates the hook HTTP endpoint (`admitHookRequest`), withholding a foreign
+  adapter's auto-grant also drops its hook POSTs rather than letting them
+  land in the recording —
+  `core/adapters/inbound/agents/claudecode/hooks_recordadapters_test.go`
+  proves that directly against the real hook handler. It is deliberately
+  scoped to modify-kind `Writes`-bearing permissions only: an observe-kind
+  permission (transcript reading) stays granted for every agent regardless,
+  so a co-resident agent that happens to share the workspace (the
+  `multiple-agents-same-workspace` scenario family) is still visible via its
+  own file-based signal — only the install-a-real-file side effect is
+  narrowed.
   All seven contract families pass by construction against a correct adapter
   — every route and entry shape the hook-endpoint family grades now has one
   (see that bullet above) — so their whole value is that they *can* fail.

--- a/tools/onboarding-factory/scripts/lib/spawn-record-daemon.sh
+++ b/tools/onboarding-factory/scripts/lib/spawn-record-daemon.sh
@@ -76,8 +76,53 @@ record_daemon_sock() {
 # down in spawn_record_daemon: snapshot_managed_files backs up every one of
 # those files first and the EXIT trap hands them back. Keep the two together —
 # if the snapshot ever stops running, this must stop being set.
+# adapter_slug_to_daemon_name <slug> prints the daemon's registered
+# agent.Identity.Name for an onboarding-factory adapter SLUG ($ADAPTER, the
+# replaydata/agents/<slug> directory name). Every adapter's slug matches its
+# daemon identity verbatim EXCEPT claudecode: the pre-#319 registry spelling
+# "claude-code" survives (mirrors
+# tools/onboarding-factory/internal/shard/shard.go's SlugForAdapter, which
+# maps the same divergence in the OPPOSITE direction — identity to slug).
+#
+# This is not cosmetic: record_adapter_names feeds straight into
+# PermissionService.Start's EXACT-STRING recordAdapters lookup
+# (permission_service.go, scopedOutByRecordAdapters), so a mismatched name
+# doesn't fail loudly — it silently scopes OUT the very adapter the run is
+# recording. A first cut of #1769 shipped IRRLICHT_RECORD_ADAPTERS=claudecode
+# unmodified and was caught only by a review subagent driving the real
+# PermissionService end to end: recording a claudecode cell would have
+# withheld claudecode's OWN hooks/statusline/instructions grants, breaking
+# every hook-delivered signal in that adapter's recordings — the one adapter
+# this issue exists to protect.
+adapter_slug_to_daemon_name() {
+  case "$1" in
+    claudecode) printf '%s' "claude-code" ;;
+    *) printf '%s' "$1" ;;
+  esac
+}
+
+# record_adapter_names <comma-separated-slugs> translates each onboarding-
+# factory adapter slug to its daemon identity name (adapter_slug_to_daemon_name
+# above) and rejoins with commas, for IRRLICHT_RECORD_ADAPTERS. Empty input
+# prints nothing.
+record_adapter_names() {
+  local slugs="$1" out="" slug
+  [[ -z "$slugs" ]] && return 0
+  local IFS=','
+  # shellcheck disable=SC2206  # word-splitting on IFS=',' is the point: each
+  # element is a bare adapter slug (no spaces, no glob metacharacters).
+  local parts=($slugs)
+  for slug in "${parts[@]}"; do
+    [[ -z "$slug" ]] && continue
+    if [[ -z "$out" ]]; then out="$(adapter_slug_to_daemon_name "$slug")"
+    else out="$out,$(adapter_slug_to_daemon_name "$slug")"; fi
+  done
+  printf '%s' "$out"
+}
+
 # IRRLICHT_RECORD_ADAPTERS is emitted only when the caller names adapters
-# (comma-separated). Since #1449's ALLOW_SHARED_CONFIG_WRITES lifts the
+# (comma-separated, translated to daemon identity names by
+# record_adapter_names). Since #1449's ALLOW_SHARED_CONFIG_WRITES lifts the
 # shared-config guard for EVERY adapter, not just the one this call is
 # recording, grant-all used to auto-grant and Apply every OTHER adapter's
 # hook installer too — including claudecode's, which is one of
@@ -98,7 +143,9 @@ record_daemon_env() {
   printf '%s\n' "IRRLICHT_PERMISSION_MODE=grant-all"
   printf '%s\n' "IRRLICHT_ALLOW_SHARED_CONFIG_WRITES=1"
   [[ -n "$home" ]] && printf '%s\n' "IRRLICHT_HOME=$home"
-  [[ -n "$adapters" ]] && printf '%s\n' "IRRLICHT_RECORD_ADAPTERS=$adapters"
+  if [[ -n "$adapters" ]]; then
+    printf '%s\n' "IRRLICHT_RECORD_ADAPTERS=$(record_adapter_names "$adapters")"
+  fi
   [[ -n "${IRRLICHT_READY_SESSION_TTL:-}" ]] && printf '%s\n' "IRRLICHT_READY_SESSION_TTL=$IRRLICHT_READY_SESSION_TTL"
   return 0
 }

--- a/tools/onboarding-factory/scripts/lib/spawn-record-daemon.sh
+++ b/tools/onboarding-factory/scripts/lib/spawn-record-daemon.sh
@@ -13,7 +13,7 @@
 #
 # Usage — one call to start, one to stop:
 #   source "$SCRIPT_DIR/lib/spawn-record-daemon.sh"
-#   spawn_record_daemon "$DAEMON" "$STAGING" "$BIND_ADDR" "$ONBOARD_HOME" || exit 1
+#   spawn_record_daemon "$DAEMON" "$STAGING" "$BIND_ADDR" "$ONBOARD_HOME" "$ADAPTERS" || exit 1
 #   ... drive the agent ...
 #   stop_record_daemon                   # drain before reading the recording
 #
@@ -76,28 +76,42 @@ record_daemon_sock() {
 # down in spawn_record_daemon: snapshot_managed_files backs up every one of
 # those files first and the EXIT trap hands them back. Keep the two together —
 # if the snapshot ever stops running, this must stop being set.
+# IRRLICHT_RECORD_ADAPTERS is emitted only when the caller names adapters
+# (comma-separated). Since #1449's ALLOW_SHARED_CONFIG_WRITES lifts the
+# shared-config guard for EVERY adapter, not just the one this call is
+# recording, grant-all used to auto-grant and Apply every OTHER adapter's
+# hook installer too — including claudecode's, which is one of
+# righome.Unisolatable's structurally unrelocatable adapters and so
+# repointed the operator's REAL ~/.claude/settings.json at this daemon for
+# the run's whole duration, whatever adapter was actually being recorded
+# (#1769). Naming the adapter(s) here narrows PermissionService's grant-all
+# auto-grant to them, closing that window; run-cell.sh and run-cell-multi.sh
+# are the callers, threading their own $ADAPTER / $ADAPTERS through.
 # IRRLICHT_HOME is emitted only in coexist mode; IRRLICHT_READY_SESSION_TTL only
 # when the caller set one (idle-survival cells shrink the 30-min production
 # default to a recordable window), because an explicit env array would otherwise
 # drop the inherited override.
 record_daemon_env() {
-  local recordings="$1" bind="$2" home="${3:-}"
+  local recordings="$1" bind="$2" home="${3:-}" adapters="${4:-}"
   printf '%s\n' "IRRLICHT_RECORDINGS_DIR=$recordings"
   printf '%s\n' "IRRLICHT_BIND_ADDR=$bind"
   printf '%s\n' "IRRLICHT_PERMISSION_MODE=grant-all"
   printf '%s\n' "IRRLICHT_ALLOW_SHARED_CONFIG_WRITES=1"
   [[ -n "$home" ]] && printf '%s\n' "IRRLICHT_HOME=$home"
+  [[ -n "$adapters" ]] && printf '%s\n' "IRRLICHT_RECORD_ADAPTERS=$adapters"
   [[ -n "${IRRLICHT_READY_SESSION_TTL:-}" ]] && printf '%s\n' "IRRLICHT_READY_SESSION_TTL=$IRRLICHT_READY_SESSION_TTL"
   return 0
 }
 
 # spawn_record_daemon <daemon-bin> <staging-dir> <bind-addr> [<irrlicht-home>]
-# snapshots the shared agent config, starts the daemon, arms the EXIT trap, and
-# waits for its socket. Returns non-zero (after reporting to stderr) if the
-# socket never appears, so the caller can add its own failure bookkeeping —
-# run-cell-multi.sh writes an ERROR run-manifest — before exiting.
+# [<adapters>] snapshots the shared agent config, starts the daemon, arms the
+# EXIT trap, and waits for its socket. adapters (comma-separated) narrows
+# grant-all's auto-grant to those adapters (#1769) — see record_daemon_env.
+# Returns non-zero (after reporting to stderr) if the socket never appears,
+# so the caller can add its own failure bookkeeping — run-cell-multi.sh
+# writes an ERROR run-manifest — before exiting.
 spawn_record_daemon() {
-  local daemon_bin="$1" staging="$2" bind="$3" home="${4:-}"
+  local daemon_bin="$1" staging="$2" bind="$3" home="${4:-}" adapters="${5:-}"
 
   RECORD_DAEMON_STAGING="$staging"
   RECORD_DAEMON_SOCK="$(record_daemon_sock "$home")"
@@ -119,7 +133,7 @@ spawn_record_daemon() {
   # ${home:+VAR="$home"} would word-split on it.
   local daemon_env=() kv
   while IFS= read -r kv; do daemon_env+=("$kv"); done \
-    < <(record_daemon_env "$staging/recordings" "$bind" "$home")
+    < <(record_daemon_env "$staging/recordings" "$bind" "$home" "$adapters")
 
   env "${daemon_env[@]}" "$daemon_bin" --record >"$staging/daemon.log" 2>&1 &
   RECORD_DAEMON_PID=$!

--- a/tools/onboarding-factory/scripts/lib/spawn-record-daemon_test.sh
+++ b/tools/onboarding-factory/scripts/lib/spawn-record-daemon_test.sh
@@ -144,6 +144,17 @@ while IFS= read -r _; do entries=$((entries + 1)); done \
   < <(record_daemon_env "/s/recordings" "127.0.0.1:7838" "/tmp/my onboard home")
 assert_eq "five entries, not six" "5" "$entries"
 
+echo "== naming adapters forwards IRRLICHT_RECORD_ADAPTERS, absent otherwise =="
+# #1769: naming the adapter(s) this call is recording narrows PermissionService's
+# grant-all auto-grant to them, so a cell recording e.g. mistral-vibe no longer
+# auto-grants (and Applies) every OTHER adapter's hook installer too.
+assert_eq "adapters forwarded" "IRRLICHT_RECORD_ADAPTERS=mistral-vibe" \
+  "$(record_daemon_env /s/recordings 127.0.0.1:7837 "" mistral-vibe | grep RECORD_ADAPTERS)"
+assert_eq "comma-joined pair forwarded verbatim" "IRRLICHT_RECORD_ADAPTERS=hermes,kiro-cli" \
+  "$(record_daemon_env /s/recordings 127.0.0.1:7837 "" hermes,kiro-cli | grep RECORD_ADAPTERS)"
+assert_eq "absent when no adapters given" "" \
+  "$(record_daemon_env /s/recordings 127.0.0.1:7837 "" | grep RECORD_ADAPTERS)"
+
 echo "== a caller-set ready-session TTL is forwarded, absent otherwise =="
 # shellcheck disable=SC2034  # not read by this file: it is set so
 # record_daemon_env picks it out of the ENVIRONMENT and forwards it, which is

--- a/tools/onboarding-factory/scripts/lib/spawn-record-daemon_test.sh
+++ b/tools/onboarding-factory/scripts/lib/spawn-record-daemon_test.sh
@@ -155,6 +155,23 @@ assert_eq "comma-joined pair forwarded verbatim" "IRRLICHT_RECORD_ADAPTERS=herme
 assert_eq "absent when no adapters given" "" \
   "$(record_daemon_env /s/recordings 127.0.0.1:7837 "" | grep RECORD_ADAPTERS)"
 
+echo "== the claudecode SLUG is translated to the daemon's hyphenated identity =="
+# claudecode is the one adapter whose replaydata/rig-CLI slug ("claudecode")
+# differs from its daemon agent.Identity.Name ("claude-code") — see
+# shard.go's SlugForAdapter for the same divergence in the opposite direction.
+# Forwarding the slug unmodified would feed PermissionService.Start's
+# exact-string recordAdapters lookup a name that never matches claudecode's
+# OWN identity, silently scoping claudecode itself OUT of its own recording
+# (caught in review, not by an earlier version of this test).
+assert_eq "bare claudecode slug -> claude-code" "IRRLICHT_RECORD_ADAPTERS=claude-code" \
+  "$(record_daemon_env /s/recordings 127.0.0.1:7837 "" claudecode | grep RECORD_ADAPTERS)"
+assert_eq "claudecode translated inside a comma-joined pair" "IRRLICHT_RECORD_ADAPTERS=claude-code,kiro-cli" \
+  "$(record_daemon_env /s/recordings 127.0.0.1:7837 "" claudecode,kiro-cli | grep RECORD_ADAPTERS)"
+assert_eq "claudecode translated as the SECOND half of a pair too" "IRRLICHT_RECORD_ADAPTERS=kiro-cli,claude-code" \
+  "$(record_daemon_env /s/recordings 127.0.0.1:7837 "" kiro-cli,claudecode | grep RECORD_ADAPTERS)"
+assert_eq "an adapter whose slug already matches its identity passes through" "IRRLICHT_RECORD_ADAPTERS=codex" \
+  "$(record_daemon_env /s/recordings 127.0.0.1:7837 "" codex | grep RECORD_ADAPTERS)"
+
 echo "== a caller-set ready-session TTL is forwarded, absent otherwise =="
 # shellcheck disable=SC2034  # not read by this file: it is set so
 # record_daemon_env picks it out of the ENVIRONMENT and forwards it, which is

--- a/tools/onboarding-factory/scripts/run-cell-multi.sh
+++ b/tools/onboarding-factory/scripts/run-cell-multi.sh
@@ -270,7 +270,11 @@ done
 # return means the socket never appeared (it has already said so on stderr); the
 # trap still drains the daemon and restores the config on the way out, so all
 # that is left here is the ERROR manifest the implement skill reads.
-spawn_record_daemon "$DAEMON" "$STAGING" "$ONBOARD_BIND" "$ONBOARD_HOME" \
+# ADAPTERS_CSV narrows grant-all's auto-grant to this run's own pair, so a
+# cross-adapter cell no longer auto-grants — and never Applies — every OTHER
+# adapter's hook installer too (claudecode chief among them: #1769).
+ADAPTERS_CSV="$(IFS=,; echo "${ADAPTERS[*]}")"
+spawn_record_daemon "$DAEMON" "$STAGING" "$ONBOARD_BIND" "$ONBOARD_HOME" "$ADAPTERS_CSV" \
   || { write_error_manifest "daemon_socket_missing"; exit 1; }
 
 # --- Launch every adapter's interactive driver CONCURRENTLY -------------

--- a/tools/onboarding-factory/scripts/run-cell.sh
+++ b/tools/onboarding-factory/scripts/run-cell.sh
@@ -374,7 +374,11 @@ else
   # stop_record_daemon as the EXIT trap, and waits for its socket. A non-zero
   # return means the socket never appeared (it has already said so on stderr);
   # the trap still drains the daemon and restores the config on the way out.
-  spawn_record_daemon "$DAEMON" "$STAGING" "$ONBOARD_BIND" "$ONBOARD_HOME" || exit 1
+  # $ADAPTER narrows grant-all's auto-grant to this run's own adapter, so a
+  # cell recording e.g. mistral-vibe no longer auto-grants — and never Applies
+  # — every OTHER adapter's hook installer too (claudecode chief among them:
+  # #1769).
+  spawn_record_daemon "$DAEMON" "$STAGING" "$ONBOARD_BIND" "$ONBOARD_HOME" "$ADAPTER" || exit 1
 fi
 
 # The daemon's socket is bound BEFORE its grant-all Apply closures have written


### PR DESCRIPTION
## Summary

`lib/spawn-record-daemon.sh:87` (now `tools/onboarding-factory/scripts/lib/spawn-record-daemon.sh`) sets `IRRLICHT_PERMISSION_MODE=grant-all` unconditionally for every recording, whatever adapter the run is actually about. `PermissionService.Start` used to auto-grant EVERY agent's permissions under grant-all, running EVERY adapter's `Apply` closure -- including hook installers for adapters the run had nothing to do with. claudecode is the sharpest case: it is one of `righome.Unisolatable`'s structurally unrelocatable adapters (`claudeSettingsPath` joins `os.UserHomeDir()` unconditionally), so recording e.g. a mistral-vibe cell repointed the operator's real `~/.claude/settings.json` at the recording daemon for the run's whole duration -- and, since Claude Code reloads its settings file live rather than snapshotting it at session start (confirmed against upstream docs in the issue thread; not measured on this machine, since measuring it means rewriting the operator's real settings.json), every already-running Claude Code session on the machine picked up the rig's endpoint too, for as long as the recording ran.

## Fix chosen

The issue's own thread converged on candidate (1) -- "don't install claudecode's hooks in the rig daemon unless claudecode is the adapter actually being recorded" -- as load-bearing, since the settled snapshot-vs-reread question removes any procedural mitigation. This PR implements it generically (adapter-agnostic, not claudecode-special-cased):

- `IRRLICHT_RECORD_ADAPTERS` (comma-separated adapter identity names; `config.Config.RecordAdapters`) is a new, opt-in env var. `run-cell.sh` / `run-cell-multi.sh` set it from their own `$ADAPTER` / `$ADAPTERS`.
- `PermissionService.Start`'s grant-all auto-grant loop now consults a new `scopedOutByRecordAdapters` check: when `RecordAdapters` is non-empty, a *modify*-kind permission that declares a `Writes` (managed user file) is skipped -- not granted, not Applied -- for any agent not in that set.
- Left unset, behaviour is byte-for-byte unchanged (a LOCK test pins this).
- Deliberately scoped to modify-kind `Writes`-bearing permissions only: observe-kind permissions (transcript reading) stay granted for every agent regardless, so a co-resident agent in a `multiple-agents-same-workspace` cell keeps its own file-based visibility.

This also happens to close the literal acceptance-evidence gap the issue asked for, via an existing mechanism rather than a new one: the same consent state (`Granted`) gates the hook HTTP endpoint (`admitHookRequest`), so withholding a foreign adapter's auto-grant makes the hook receiver drop its POSTs with a quiet 200 instead of dispatching them to the recorder -- proven directly against the real `claudecode.NewHookHandler` in `core/adapters/inbound/agents/claudecode/hooks_recordadapters_test.go`.

Candidate (2) ("reject hook posts for sessions the daemon never discovered", generically at the session-admission layer) was considered and deliberately **not** implemented as a separate mechanism: `core/application/services/helpers.go`'s `isStaleTranscript` explicitly and correctly treats a not-yet-existing transcript file as *not* stale (a documented, tested accommodation for legitimate startup races), so a generic "reject sessions the daemon never independently discovered" gate risks breaking that race and the existing `admitNewSession` admission path. The adapter-scoped gate above achieves the same practical effect for the concrete threat this issue documents, without touching that machinery.

Candidate (3) (attribute at ingest, populate the lifecycle event's `adapter` field) is explicitly out of scope here -- shared with #1768, being fixed in parallel.

## A review finding that changed the shipped fix

A dedicated review subagent (high effort, per this repo's `ir:code-review` skill) caught a critical regression in the first version of this PR: `run-cell.sh`/`run-cell-multi.sh` were threading the raw onboarding-factory adapter **slug** (`$ADAPTER`, e.g. `"claudecode"`) straight into `IRRLICHT_RECORD_ADAPTERS`, but `PermissionService` matches on `agent.Identity.Name`, which for claudecode is the hyphenated `"claude-code"` (a pre-#319 spelling that already diverges from its slug elsewhere in this codebase -- see `tools/onboarding-factory/internal/shard/shard.go`'s `SlugForAdapter`, which maps the same divergence in the opposite direction). The exact-string mismatch meant recording a claudecode cell would have silently scoped **claudecode's own** hooks/statusline/instructions permissions **out** of its own recording -- the opposite of the fix, for the one adapter this issue is about. Fixed by adding `adapter_slug_to_daemon_name` / `record_adapter_names` to `spawn-record-daemon.sh`, applied inside `record_daemon_env` so both callers get the translation for free. Verified red-before-green with new `spawn-record-daemon_test.sh` cases (bare `claudecode` slug, and as either half of a comma-joined pair).

## Red-before-green evidence

- `core/application/services/permission_record_adapters_test.go` -- `TestRecordAdapters_ScopesGrantAllApplyAndGrantedToTheNamedAdapter` seen red (both assertions on the foreign adapter failed) with `scopedOutByRecordAdapters` temporarily neutralized to `return false`; green after restoring it. Sibling tests pin the vacuity guard (observe-kind stays granted) and the unset-default lock.
- `core/adapters/inbound/agents/claudecode/hooks_recordadapters_test.go` -- `TestClaudeCodeHookRejectedWhenClaudeCodeIsNotTheRecordedAdapter` is the literal acceptance-evidence fixture: spawns a real `*services.PermissionService` in grant-all mode scoped to a different adapter, POSTs a claudecode-shaped Stop hook via the real `NewHookHandler`, and asserts `HandleStopHook` is never called. Seen red the same way; a sibling vacuity-guard test confirms claudecode's own hook still lands when claudecode IS the recorded adapter (using the Go constant `AdapterName`, so this test was unaffected by the shell-layer bug above).
- `tools/onboarding-factory/scripts/lib/spawn-record-daemon_test.sh` -- cases assert `IRRLICHT_RECORD_ADAPTERS` is forwarded (single and comma-joined-pair), absent when no adapters are named, and -- added after the review finding -- that the `claudecode` slug is translated to `claude-code` whether it's the only adapter or either half of a comma-joined pair, while an adapter whose slug already matches its identity (`codex`) passes through untouched. All four seen red against a temporarily-neutralized passthrough translator.

## Verification

- `go build ./...`, `go vet ./...` clean.
- `go test ./core/... -race -count=1`: all packages pass except `core/adapters/inbound/agents/processlifecycle`, which flaked on a **different** test each of three runs (`TestReadLauncherEnv_Tmux_*`, then `TestReadLauncherEnv_Herdr_UnprobableClientReportsHostUnknown` + `TestHerdrClientLauncher_MemoizedNonAnswerIsStillANonAnswer`) -- real tmux/herdr socket-server fixtures under load, untouched by this diff (isolated `-run` reruns pass reliably, and a subsequent full run passed cleanly). Pre-existing, unrelated to this change.
- `tools/preflight.sh --only go/arch/tools/skills/bash/posix`: all PASS (run twice, after each fix).
- The pre-push hook's `preflight.sh --changed --budget 540` ran clean on both pushes (core module tests, ARS, security scan, replay fixtures, bash/posix lint all PASS; web/skills/tools/swift correctly SKIP as untouched).
- `shellcheck --shell=bash --severity=warning` clean on both modified/added shell files.

Closes #1769

🤖 Generated with [Claude Code](https://claude.com/claude-code)