### PR TITLE
fix(processlifecycle): retry the tmux client scan through its own timeout under scheduler load

### DIFF
--- a/core/adapters/inbound/agents/processlifecycle/tmuxclient_darwin_test.go
+++ b/core/adapters/inbound/agents/processlifecycle/tmuxclient_darwin_test.go
@@ -4,6 +4,7 @@ package processlifecycle
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -360,6 +361,57 @@ func spawnPaneSleeperWithEnv(t *testing.T, env []string) int {
 // fallbacks, hostIdentity of the client, AdoptHostIdentity's put-back — is the
 // production code.
 
+// hostScanRetryDeadline bounds readLauncherEnvUntilHostKnown's retries. It has
+// to clear clientHostBudget by more than one multiple: a single
+// ReadLauncherEnv call can already spend the whole clientHostBudget when the
+// environment fails to answer inside it (below), so a deadline of
+// clientHostBudget itself — like fixturePollDeadline above, which is exactly
+// that value — would leave no room to ever retry.
+const hostScanRetryDeadline = 5 * clientHostBudget
+
+// readLauncherEnvUntilHostKnown is ReadLauncherEnv with one addition: when the
+// scan comes back unanswered, it clears socket's clientHostMemo entry and
+// retries, up to hostScanRetryDeadline.
+//
+// Measured (#1760): under enough scheduler load — a full
+// `go test ./core/... -race -count=1` run got there once in the wild, and a
+// loaded machine reproduces it in a handful of iterations — forking the fake
+// tmux script these fixtures stand in with can miss its own
+// clientHostBudget/shelloutTimeout ceiling before the script (a deterministic,
+// sub-10ms `/bin/sh -c printf`) ever gets scheduled to run. hostKnown then
+// reads false in exactly the shape #1492/#1529 already document as correct: a
+// scan (or a candidate) that could not be read inside its budget answers
+// (nil, false), never a false detach. That is the code working as designed,
+// not a defect in it — the defect was in this file, which asserted the scan
+// always completes inside one clientHostBudget on whatever machine happens to
+// be running the test, a guarantee the production contract never makes.
+//
+// A same-process retry cannot just call ReadLauncherEnv again: clientHostMemo
+// (#1514) memoizes a non-answer for clientHostCacheTTL (5s, longer than
+// clientHostBudget itself), so a second call within that window would replay
+// the very timeout being retried rather than re-probing. forgetTmuxClientMemo
+// is what makes the retry a retry instead of an echo.
+//
+// This is the same shape as every other awaitOrFail caller in this package
+// (waitForLauncherEnv, waitForReparentToInit, #1586): an environmental
+// precondition a loaded machine can miss on the first try, polled instead of
+// asserted once — applied here to a one-shot probe with a side effect rather
+// than a pure readiness check.
+func readLauncherEnvUntilHostKnown(t *testing.T, pid int, socket string) (l *session.Launcher, hostKnown bool) {
+	t.Helper()
+	awaitOrFail(t, func() (bool, string) {
+		l, hostKnown = ReadLauncherEnv(pid)
+		if !hostKnown {
+			forgetTmuxClientMemo(socket)
+			return false, fmt.Sprintf("pid %d: scan unanswered (killed by, or never scheduled inside, its budget)", pid)
+		}
+		return true, fmt.Sprintf("pid %d: scan answered", pid)
+	}, fixturePollInterval, hostScanRetryDeadline,
+		"the scan is a deterministic fake with nothing to legitimately wait for — an unanswered read here is "+
+			"the OS failing to schedule a trivial subprocess in time, not evidence about the code under test")
+	return l, hostKnown
+}
+
 // TestReadLauncherEnv_Tmux_AttachedClientIsTheHost is the green half of
 // #1501's defect. Measured live before the fix, against a real tmux 3.6a
 // server with a client attached: the pane resolved to
@@ -383,7 +435,7 @@ func TestReadLauncherEnv_Tmux_AttachedClientIsTheHost(t *testing.T) {
 		"TMUX_PANE=%17",
 	})
 
-	l, hostKnown := ReadLauncherEnv(agentPID)
+	l, hostKnown := readLauncherEnvUntilHostKnown(t, agentPID, socket)
 	if l == nil {
 		t.Fatal("expected non-nil launcher")
 	}
@@ -419,7 +471,7 @@ func TestReadLauncherEnv_Tmux_DetachedResolvesNoHost(t *testing.T) {
 		"KITTY_WINDOW_ID=42",
 	})
 
-	l, hostKnown := ReadLauncherEnv(agentPID)
+	l, hostKnown := readLauncherEnvUntilHostKnown(t, agentPID, socket)
 	if l == nil {
 		t.Fatal("expected non-nil launcher (the pane address is still identity)")
 	}

--- a/core/adapters/inbound/agents/processlifecycle/tmuxclient_darwin_test.go
+++ b/core/adapters/inbound/agents/processlifecycle/tmuxclient_darwin_test.go
@@ -366,7 +366,13 @@ func spawnPaneSleeperWithEnv(t *testing.T, env []string) int {
 // ReadLauncherEnv call can already spend the whole clientHostBudget when the
 // environment fails to answer inside it (below), so a deadline of
 // clientHostBudget itself — like fixturePollDeadline above, which is exactly
-// that value — would leave no room to ever retry.
+// that value — would leave no room to ever retry. 5x is a deliberately
+// generous, UNMEASURED margin rather than one fitted to an observed worst
+// case — a reproduction loop of 23 full-suite runs under sustained
+// artificial load (#1760) saw the underlying flake at most once in any
+// given run, so even 2x would likely have been enough; the extra headroom
+// is cheap because it is only ever spent on the rare failing path; a
+// passing first attempt costs nothing extra.
 const hostScanRetryDeadline = 5 * clientHostBudget
 
 // readLauncherEnvUntilHostKnown is ReadLauncherEnv with one addition: when the


### PR DESCRIPTION
## Problem

`TestReadLauncherEnv_Tmux_DetachedResolvesNoHost` (`core/adapters/inbound/agents/processlifecycle`) flakes only under full-suite load (`go test ./core/... -race -count=1`), passing in isolation. Its sibling `TestReadLauncherEnv_Tmux_AttachedClientIsTheHost` shares the same exposure.

## Reproduction (before the fix)

Per the issue, a single re-run is not evidence. Reproduced with a loop, not a single run:
- 8 iterations of the **full** `go test ./core/... -race -count=1`, with `NCPU` artificial CPU-spin processes running concurrently to simulate a loaded machine.
- **1 of 8 failed** (iteration 7), with both `TestReadLauncherEnv_Tmux_AttachedClientIsTheHost` and `TestReadLauncherEnv_Tmux_DetachedResolvesNoHost` failing in the same run:

```
--- FAIL: TestReadLauncherEnv_Tmux_AttachedClientIsTheHost (2.09s)
    tmuxclient_darwin_test.go:379: fixture ready after 2 attempts over 5.879791ms: pid 82366 publishes map[...]
    tmuxclient_darwin_test.go:391: the scan ran and answered, so the host was determined
    tmuxclient_darwin_test.go:394: the attached client's window was not adopted: &{TermProgram: ...}
--- FAIL: TestReadLauncherEnv_Tmux_DetachedResolvesNoHost (2.04s)
    tmuxclient_darwin_test.go:410: fixture ready after 2 attempts over 5.869ms: pid 82923 publishes map[...]
    tmuxclient_darwin_test.go:427: an empty client list is an ANSWER: the server was reached
```

50 repeats of the package alone (`-race -count=50`), with **no** artificial load, ran clean (all pass, ~502s) — ruling out shared package state (category 1 in the issue) as the cause: a leaking memo/global would very likely have shown up somewhere across 50 in-process repeats.

## Root cause

Both failing assertions bottom out in `resolveTmuxClientLauncherVia` (`osutil_darwin.go`), which derives a `clientHostBudget`-bounded context (`2s`) for the whole tmux `list-clients` scan + candidate-identify loop. The fixtures fake `tmux` with a deterministic `/bin/sh -c 'printf ...; exit N'` script — but forking *that* trivial script still costs a real `fork`+`exec`, and under enough scheduler contention (a `-race` full-suite run is already CPU-heavy; the loop above adds more) that fork+exec can miss the 2s ceiling before the script ever runs.

When that happens, `tmuxListedClients`/`resolveTmuxClientLauncherVia` correctly report `(nil, false)` — this is the *documented, intentional* behavior from #1492/#1529: a scan or candidate that could not be read inside its budget poisons the answer rather than reporting a false detach. **The production code is working as designed.** The defect was in the tests: they asserted the scan always completes inside one `clientHostBudget` on whatever machine happens to be running them — a guarantee the code's own contract never makes.

This is closest to the issue's category 2 ("a real race the -race detector only surfaces under scheduler load") — though not a data race (`-race` reported nothing in any repro run) so much as a timing assumption that scheduler load defeats.

## Fix

Added `readLauncherEnvUntilHostKnown` in `tmuxclient_darwin_test.go`: retries `ReadLauncherEnv` when `hostKnown` comes back `false`, clearing the socket's `clientHostMemo` entry between attempts (a non-answer is memoized for `clientHostCacheTTL` = 5s, so a naive retry would just replay the cached non-answer rather than re-probing). This is the same "poll instead of assert once" shape this file already uses for other loaded-machine preconditions (`waitForLauncherEnv`, `waitForReparentToInit`, #1586) — applied here to a one-shot probe with a side effect instead of a pure readiness check. Used it in the two vulnerable tests only; the other three tests in the file either expect a non-answer already (`UnreachableServer...`) or never reach the scan at all (`InheritedPane...`, `KittyLaunchedFromAPane...`), so they're untouched.

## Verification (after the fix)

- All 5 `TestReadLauncherEnv_Tmux_*` tests pass in isolation.
- Full-suite reproduction loop re-run under the same synthetic load methodology: **23 iterations, 0 `TestReadLauncherEnv_Tmux_*` failures** (7 + 8 + 8 across three runs — the first run's script was killed by an unrelated harness timeout mid-8th-iteration, counted only through its 7 completed runs).
- `tools/preflight.sh --only go/arch/tools/skills/posix/bash/security` all pass.
- `git push`'s own pre-push hook (`tools/preflight.sh --changed --budget 540`) passed.

### A related, pre-existing, out-of-scope flake found along the way

The same reproduction loop also hit a **different, pre-existing** flake 4 times across the 23 post-fix iterations: `TestHerdrClientLauncher_MemoizedNonAnswerIsStillANonAnswer/detach_is_still_an_answer` and `TestReadLauncherEnv_Herdr_UnprobableClientReportsHostUnknown`, both in the herdr client-indirection path (the `lsof`-based sibling of this tmux path, same `clientHostBudget` ceiling, but exercising a **real** `lsof` subprocess rather than a fake). This is almost certainly the same root-cause category, just on the other client-indirection producer, and is **not fixed by this PR** — it's a different test, not named in #1760, and out of scope for a focused fix. Flagging it here since a human reviewer may want to file it separately (a fresh looked-for reproduction with the same loop methodology, scoped to the herdr tests, is the natural next step — not filed as a new issue per repo convention against opening issues from inside `ir:exec`).

Closes #1760.

🤖 Generated with [Claude Code](https://claude.com/claude-code)