### PR TITLE
fix(hermes): live-verify #1773's re-audit against a repaired v0.19.0 CLI

### DIFF
--- a/core/adapters/inbound/agents/hermes/hookinstaller.go
+++ b/core/adapters/inbound/agents/hermes/hookinstaller.go
@@ -81,7 +81,7 @@
 //     `session_key` field in `<f>`. Fired live this way, `_serialize_payload`
 //     (agent/shell_hooks.py, unchanged from the source #1773 read) puts it
 //     under the response's `extra.session_key`, top-level `session_id`
-//     absent — exactly the shape sessionID() above reads.
+//     absent — exactly the shape hooks.go's sessionID() reads.
 //   - **`hermes hooks doctor` against a real installed entry** — this
 //     machine's actual `~/.hermes` (all three events installed, allowlisted,
 //     and firing) — found all three hooks "ran clean … observer-only", but
@@ -719,6 +719,16 @@ func scriptMtimeISO() string {
 // `was 2026-04-30T19:33:17.000000Z, now 2026-04-30T19:33:17Z` for an
 // UNCHANGED mtime, the ".000000Z" half written by the pre-fix version of
 // this function and the "Z"-only half computed live by hermes itself.
+//
+// This closes the digit-COUNT gap (0 vs 6), which is what the live evidence
+// above actually exercises and the only thing #1766 found broken. It does
+// NOT chase digit-VALUE agreement for a nonzero fraction: hermes derives its
+// microseconds from Python's `round()` on a float-seconds mtime (round half
+// to even), while this truncates the integer nanosecond value — a
+// pre-existing gap, unchanged by this fix, that could in principle still
+// misalign a sub-microsecond-boundary mtime. Not fixed here because nothing
+// live observed it; flagged so a future report of drift on a NONZERO
+// fraction is not mistaken for a regression of this fix.
 func formatScriptMtimeISO(t time.Time) string {
 	t = t.UTC()
 	if t.Nanosecond() == 0 {

--- a/core/adapters/inbound/agents/hermes/hookinstaller.go
+++ b/core/adapters/inbound/agents/hermes/hookinstaller.go
@@ -57,6 +57,57 @@
 //     hermes' gate: the grant IS a person answering the same question hermes'
 //     TTY prompt asks, and the consent copy says so in those words.
 //
+// # Live re-verification against a repaired v0.19.0 install (#1766)
+//
+// #1765's audit ran against a hermes checkout that turned out to be stale
+// (`_old/`, ~4 weeks behind) because the installed CLI was a broken shim;
+// #1773 re-derived the same claims from upstream's git history instead
+// (source-read only, HEAD vs origin/main, no CLI). #1766 repaired the local
+// install — `hermes --version` now prints "Hermes Agent v0.19.0 (2026.7.20)
+// · upstream 13f4cfeb · local e289e561" — and this section is what actually
+// running it, live, against a working v0.19.0, confirmed or corrected:
+//
+//   - **The 23-event count.** `hermes hooks test <unknown-event>` prints
+//     `VALID_HOOKS` verbatim in its "Valid events:" error line. Run live it
+//     names exactly 23 events, including all three installed here and all
+//     three of the control-bearing ones this file excludes — the same
+//     number #1773 read out of the source tree, now shown by the CLI itself
+//     rather than inferred from a set literal.
+//   - **`extra.session_key`.** hermes ships no synthetic default payload for
+//     either approval event (`hermes_cli/hooks.py`'s `_DEFAULT_PAYLOADS` has
+//     no `pre_approval_request` / `post_approval_response` entry — a gap in
+//     hermes' OWN test tooling, not this adapter), so reproducing the real
+//     shape needs `hermes hooks test <event> --payload-file <f>` with a
+//     `session_key` field in `<f>`. Fired live this way, `_serialize_payload`
+//     (agent/shell_hooks.py, unchanged from the source #1773 read) puts it
+//     under the response's `extra.session_key`, top-level `session_id`
+//     absent — exactly the shape sessionID() above reads.
+//   - **`hermes hooks doctor` against a real installed entry** — this
+//     machine's actual `~/.hermes` (all three events installed, allowlisted,
+//     and firing) — found all three hooks "ran clean … observer-only", but
+//     also flagged all three with a false "script modified since approval"
+//     on every run. That finding was real and is now fixed: see
+//     formatScriptMtimeISO's doc comment below for the root cause (a
+//     lexicographic-vs-parsed timestamp mismatch with hermes' own
+//     zero-microsecond isoformat spelling) and
+//     TestFormatScriptMtimeISO_MatchesHermesConditionalMicroseconds /
+//     TestFormatScriptMtimeISO_NoFalseDriftAcrossAZeroMicrosecondRoundTrip
+//     (hookinstaller_test.go) for the regression coverage.
+//   - **The three subscription mechanisms.** Shell hooks (this adapter's
+//     route) are confirmed live end-to-end above. The other two — hermes'
+//     plugin loader (`hermes_cli/plugins.py`: bundled/user
+//     `~/.hermes/plugins/`/project/pip sources) and the gateway-only handler
+//     path — are unchanged in the installed source and this adapter uses
+//     neither, so nothing here re-verifies them beyond confirming their code
+//     is still present; #1773 already covered gateway exclusion in depth via
+//     source, and nothing in that area is CLI-reachable to re-check live.
+//
+// Nothing in the event mapping or the `minHermesVersion` floor moved: this
+// is a confirmation of #1773's source-read claims by a different method
+// (a working CLI instead of git history), plus one genuine, previously
+// undiscovered adapter-side bug the CLI surfaced that source-reading alone
+// would not have — the mtime format mismatch above.
+//
 // # Why `pre_tool_call` and `pre_verify` are not installed
 //
 // This is the #1719 safety lesson in its hermes spelling, and it is a source
@@ -643,7 +694,37 @@ func scriptMtimeISO() string {
 	if err != nil {
 		return ""
 	}
-	return info.ModTime().UTC().Format("2006-01-02T15:04:05.000000Z")
+	return formatScriptMtimeISO(info.ModTime())
+}
+
+// formatScriptMtimeISO renders t the way hermes' own script_mtime_iso
+// (agent/shell_hooks.py) renders a Python datetime: via
+// datetime.isoformat().replace("+00:00", "Z"), which OMITS the
+// fractional-seconds component entirely when microseconds are exactly zero
+// and otherwise always emits exactly 6 digits — never any other precision.
+//
+// This is not a cosmetic choice: `hermes hooks doctor` (hermes_cli/hooks.py)
+// compares its own freshly-recomputed mtime against the ScriptMtimeAtApproval
+// this function writes with a LEXICOGRAPHIC `mtime_now > mtime_at` on these
+// strings, not a parsed-time comparison. A format that always appends
+// ".000000Z" disagrees with hermes' own zero-microsecond spelling even when
+// the two instants are identical: "...17Z" sorts AFTER "...17.000000Z"
+// because 'Z' (0x5A) is greater than '.' (0x2E) in a byte-wise compare — a
+// permanent false "script modified since approval" on every doctor run
+// against a file (like /bin/sh) whose mtime carries no fractional component.
+//
+// Verified live (issue #1766): this machine's `/bin/sh` has a
+// zero-nanosecond mtime, and before this fix `hermes hooks doctor` reported
+// all three installed hooks as drifted despite nothing having changed —
+// `was 2026-04-30T19:33:17.000000Z, now 2026-04-30T19:33:17Z` for an
+// UNCHANGED mtime, the ".000000Z" half written by the pre-fix version of
+// this function and the "Z"-only half computed live by hermes itself.
+func formatScriptMtimeISO(t time.Time) string {
+	t = t.UTC()
+	if t.Nanosecond() == 0 {
+		return t.Format("2006-01-02T15:04:05Z")
+	}
+	return t.Format("2006-01-02T15:04:05.000000Z")
 }
 
 func approvalsEqual(a, b []allowlistEntry) bool {

--- a/core/adapters/inbound/agents/hermes/hookinstaller_test.go
+++ b/core/adapters/inbound/agents/hermes/hookinstaller_test.go
@@ -612,27 +612,43 @@ func TestFormatScriptMtimeISO_MatchesHermesConditionalMicroseconds(t *testing.T)
 }
 
 // TestFormatScriptMtimeISO_NoFalseDriftAcrossAZeroMicrosecondRoundTrip pins
-// the actual property `hermes hooks doctor` relies on: recording an
-// approval's ScriptMtimeAtApproval and then recomputing the "current" mtime
-// for the SAME zero-microsecond instant must produce byte-identical strings,
-// so hermes' `mtime_now > mtime_at` lexicographic comparison — the exact
-// mechanism the live doctor run exercised — evaluates false rather than a
-// spurious true.
+// the actual property `hermes hooks doctor` relies on: OUR recorded
+// ScriptMtimeAtApproval (formatScriptMtimeISO's output — the function under
+// test) must agree, byte-for-byte, with hermes' OWN independently-computed
+// "current" mtime string for the identical, unchanged instant, so hermes'
+// `mtime_now > mtime_at` lexicographic comparison evaluates false rather
+// than a spurious true.
+//
+// mtimeNow is deliberately a HARDCODED literal — hermes' own string for this
+// instant, confirmed live via:
+//
+//	python3 -c "from datetime import datetime, timezone; print(
+//	  datetime.fromtimestamp(1777577597.0, tz=timezone.utc)
+//	    .isoformat().replace('+00:00', 'Z'))"
+//	# -> 2026-04-30T19:33:17Z   (1777577597.0 == this machine's real,
+//	#    zero-fractional /bin/sh mtime at the time of the live #1766 run)
+//
+// rather than a second call to formatScriptMtimeISO. Deriving both sides
+// from the function under test would make this test tautological — it
+// would pass for ANY deterministic implementation, buggy or not, because it
+// would only ever compare formatScriptMtimeISO to itself. (This is exactly
+// the shape #1766's review caught: the original version of this test did
+// that, and stayed green against the pre-fix always-".000000Z" formatting
+// — see git history for the corrected version's red/green proof.)
 func TestFormatScriptMtimeISO_NoFalseDriftAcrossAZeroMicrosecondRoundTrip(t *testing.T) {
 	approvedAt := time.Date(2026, 4, 30, 19, 33, 17, 0, time.UTC)
-	recordedAt := approvedAt // the file was never touched between the two reads
+	const mtimeNow = "2026-04-30T19:33:17Z" // hermes' own value; see comment above
 
 	mtimeAtApproval := formatScriptMtimeISO(approvedAt)
-	mtimeNow := formatScriptMtimeISO(recordedAt)
 
 	if mtimeNow != mtimeAtApproval {
-		t.Fatalf("mtimeNow (%q) != mtimeAtApproval (%q) for an unchanged file", mtimeNow, mtimeAtApproval)
+		t.Fatalf("hermes' own mtimeNow (%q) != our recorded mtimeAtApproval (%q) for an unchanged file", mtimeNow, mtimeAtApproval)
 	}
 	// hermes' own doctor check: `if mtime_now and mtime_at and mtime_now >
 	// mtime_at`. Reproduced here as a plain Go string compare, the same
 	// comparison Python's `>` performs on two str operands.
 	if mtimeNow > mtimeAtApproval {
-		t.Fatalf("mtimeNow (%q) lexicographically > mtimeAtApproval (%q) for an unchanged file — this is the false-positive doctor drift warning", mtimeNow, mtimeAtApproval)
+		t.Fatalf("hermes' own mtimeNow (%q) lexicographically > our recorded mtimeAtApproval (%q) for an unchanged file — this is the false-positive doctor drift warning", mtimeNow, mtimeAtApproval)
 	}
 }
 

--- a/core/adapters/inbound/agents/hermes/hookinstaller_test.go
+++ b/core/adapters/inbound/agents/hermes/hookinstaller_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"irrlicht/core/adapters/inbound/agents/hookyaml"
 	"irrlicht/core/domain/permission"
@@ -562,6 +563,77 @@ func TestInstallSurvivesHermesRewritingItsOwnConfig(t *testing.T) {
 			}
 		}
 	})
+}
+
+// TestFormatScriptMtimeISO_MatchesHermesConditionalMicroseconds is a
+// regression test for #1766's live finding: hermes' own script_mtime_iso
+// (agent/shell_hooks.py) renders via Python's datetime.isoformat(), which
+// omits the fractional-seconds component entirely when microseconds are
+// exactly zero. A Go formatter that ALWAYS appends ".000000Z" (the
+// pre-#1766 code) disagrees with hermes' own string for a zero-microsecond
+// instant, and hermes' `hooks doctor` compares the two LEXICOGRAPHICALLY
+// (mtime_now > mtime_at) rather than as parsed times — so the mismatch
+// reads as "script modified" forever, for a file (like /bin/sh, this
+// adapter's fixed interpreter) whose mtime never changes.
+//
+// Live-verified against this machine's real /bin/sh (zero-nanosecond
+// mtime) and a real `hermes hooks doctor` run: before this fix, all three
+// installed hooks were reported drifted on every run despite nothing having
+// changed.
+func TestFormatScriptMtimeISO_MatchesHermesConditionalMicroseconds(t *testing.T) {
+	tests := []struct {
+		name string
+		in   time.Time
+		want string
+	}{
+		{
+			name: "zero nanoseconds — hermes omits the fraction entirely",
+			in:   time.Date(2026, 4, 30, 19, 33, 17, 0, time.UTC),
+			want: "2026-04-30T19:33:17Z",
+		},
+		{
+			name: "nonzero nanoseconds — hermes emits exactly 6 digits",
+			in:   time.Date(2026, 4, 30, 19, 33, 17, 123456000, time.UTC),
+			want: "2026-04-30T19:33:17.123456Z",
+		},
+		{
+			name: "non-UTC input is normalized to UTC before formatting",
+			in:   time.Date(2026, 4, 30, 21, 33, 17, 0, time.FixedZone("CEST", 2*3600)),
+			want: "2026-04-30T19:33:17Z",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := formatScriptMtimeISO(tt.in); got != tt.want {
+				t.Errorf("formatScriptMtimeISO(%v) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestFormatScriptMtimeISO_NoFalseDriftAcrossAZeroMicrosecondRoundTrip pins
+// the actual property `hermes hooks doctor` relies on: recording an
+// approval's ScriptMtimeAtApproval and then recomputing the "current" mtime
+// for the SAME zero-microsecond instant must produce byte-identical strings,
+// so hermes' `mtime_now > mtime_at` lexicographic comparison — the exact
+// mechanism the live doctor run exercised — evaluates false rather than a
+// spurious true.
+func TestFormatScriptMtimeISO_NoFalseDriftAcrossAZeroMicrosecondRoundTrip(t *testing.T) {
+	approvedAt := time.Date(2026, 4, 30, 19, 33, 17, 0, time.UTC)
+	recordedAt := approvedAt // the file was never touched between the two reads
+
+	mtimeAtApproval := formatScriptMtimeISO(approvedAt)
+	mtimeNow := formatScriptMtimeISO(recordedAt)
+
+	if mtimeNow != mtimeAtApproval {
+		t.Fatalf("mtimeNow (%q) != mtimeAtApproval (%q) for an unchanged file", mtimeNow, mtimeAtApproval)
+	}
+	// hermes' own doctor check: `if mtime_now and mtime_at and mtime_now >
+	// mtime_at`. Reproduced here as a plain Go string compare, the same
+	// comparison Python's `>` performs on two str operands.
+	if mtimeNow > mtimeAtApproval {
+		t.Fatalf("mtimeNow (%q) lexicographically > mtimeAtApproval (%q) for an unchanged file — this is the false-positive doctor drift warning", mtimeNow, mtimeAtApproval)
+	}
 }
 
 // stripYAMLComments removes every whole-line comment, which is what hermes'


### PR DESCRIPTION
## Summary

Issue #1766 asked for #1765's stale hermes-hook audit to be re-verified **live**, now that the local `hermes` CLI (previously a broken shim pointing at a missing venv binary) is repaired to a working v0.19.0 install. #1773/#1778 already did a **source-only** re-derivation against a newer upstream checkout (0.20.5, via git history — no working CLI at the time). This PR does the part #1773 explicitly could not: actually running the repaired v0.19.0 CLI and inspecting its output on the wire.

## What was live-verified (v0.19.0, `/Users/ingo/.local/bin/hermes`)

- **`hermes --version`** now works: `Hermes Agent v0.19.0 (2026.7.20) · upstream 13f4cfeb · local e289e561 (+1 carried commit)`.
- **VALID_HOOKS event count** — `hermes hooks test <unknown-event>` prints the set verbatim in its error message. Live count: **23 events**, matching #1773's source-read count at 0.19.0 exactly (and distinct from 0.20.5's 37 — #1773 already covered that delta from source).
- **Approval-event payload shape** — hermes ships no synthetic default payload for either approval event in its own `_DEFAULT_PAYLOADS` table (a gap in hermes' own test tooling), so a realistic shape was reproduced via `hermes hooks test pre_approval_request --payload-file <f>` with a `session_key` field. Confirmed live: it lands under **`extra.session_key`**, with the top-level `session_id` field absent/placeholder — exactly the shape this adapter's `hermesHookPayload.sessionID()` already reads (dual read of `SessionID` then `Extra.SessionKey`).
- **`hermes hooks doctor` against a real installed entry** — this machine's actual `~/.hermes` config (irrlicht's 3 hooks installed and allowlisted by a prior run) — reported all three hooks allowlisted and "ran clean … observer-only" (confirming the observer-only property live), **and** flagged a false **"script modified since approval"** on all three, every run.

## The bug this surfaced, and the fix

The doctor warning was real, not a version-drift artifact. Root cause: hermes' own `script_mtime_iso` (`agent/shell_hooks.py`) formats a timestamp via Python's `datetime.isoformat()`, which **omits the fractional-seconds component entirely when microseconds are exactly zero** (true for this machine's `/bin/sh`, the fixed interpreter every install of this adapter stats). irrlicht's `scriptMtimeISO()` always appended `.000000Z` regardless. hermes' `doctor` compares the two strings **lexicographically** (`mtime_now > mtime_at`), not as parsed times — and `"...17Z"` sorts *after* `"...17.000000Z"` because `'Z'` (0x5A) > `'.'` (0x2E), so the two representations of the **same instant** register as drift. Since `/bin/sh` never changes, this was a **permanent** false positive on every `hermes hooks doctor` run for any user of this adapter.

Fixed in `formatScriptMtimeISO` by matching hermes' conditional-microseconds format (a scoped fix: it closes the digit-*count* gap this bug actually is, not a separate pre-existing digit-*value* rounding-vs-truncation gap for nonzero-fraction mtimes, called out explicitly in the function's doc comment as unchanged and out of scope).

## Review round

This PR's own review subagent (Phase 5) caught a real issue with the first version of the fix: one of the two new regression tests, `TestFormatScriptMtimeISO_NoFalseDriftAcrossAZeroMicrosecondRoundTrip`, derived **both sides** of its comparison from `formatScriptMtimeISO` itself, so it passed against the pre-fix always-`.000000Z` code too — a green that was never red. Fixed by rewriting it so the "hermes side" is a hardcoded literal (hermes' own independently-computed isoformat string for the identical instant, confirmed via a live `python3 -c "...datetime.isoformat()..."` call) compared against the function under test. Re-verified red-before-fix / green-after-fix for **both** regression tests this time (`TestFormatScriptMtimeISO_MatchesHermesConditionalMicroseconds` and the corrected round-trip test).

## What did NOT move

Event mapping, the three installed events, and `minHermesVersion` (0.19.0) are unchanged — nothing here contradicts #1773's findings. Full commands and evidence are recorded in `hookinstaller.go`'s header comment ("Live re-verification against a repaired v0.19.0 install (#1766)").

## Verification

- `go test ./core/adapters/inbound/agents/hermes/... -race -count=1` — PASS (includes both regression tests, proven red-first, re-verified after the review fix).
- `go build ./...` (core module) — PASS, `go vet` clean.
- `tools/preflight.sh --only {go,web,arch,tools,skills,posix,bash,security}` — all PASS.
- Live commands run against the real, repaired hermes v0.19.0 CLI: `hermes --version`, `hermes hooks --help`, `hermes hooks list`, `hermes hooks doctor` (both against the real `~/.hermes` and an isolated scratch `HERMES_HOME`), `hermes hooks test <event> [--payload-file ...]`.

Closes #1766.

🤖 Generated with [Claude Code](https://claude.com/claude-code)