### PR TITLE
chore(tools): commit a mutation harness — three agents re-improvised the same one

### DIFF
--- a/tools/lib/mutate_test.sh
+++ b/tools/lib/mutate_test.sh
@@ -166,17 +166,24 @@ assert_eq "exits 0 against an anchor containing [ ] and *" "0" "$MUTATE_RC"
 assert_contains "the glob-metacharacter mutation actually landed and was observed" $'\n1\n' $'\n'"$MUTATE_OUTPUT"$'\n'
 
 echo ""
-echo "== every content-reading awk invocation is pinned to LC_ALL=C (static regression pin) =="
+echo "== every content read goes through byte_awk(), which is the ONLY place LC_ALL=C is set (static regression pin) =="
 # Review finding (#1750): under a UTF-8 locale, GNU awk's length()/index()/
 # substr() count Unicode CODEPOINTS, not bytes, so any awk invocation that
 # measures or matches file content by byte must run under LC_ALL=C to agree
-# with `wc -c`. This assertion is deliberately environment-INDEPENDENT (it
-# greps the source, it does not run anything) so it catches a regression on
-# every machine regardless of which `awk` happens to be on PATH — the live
-# gawk-forced case right below this one is the version that can only run
-# where gawk is actually installed.
+# with `wc -c`. Centralised in byte_awk() (not repeated per call site) so a
+# future content-reading awk call added to this file inherits the fix rather
+# than needing to remember it — this pin asserts that centralisation holds:
+# exactly ONE `LC_ALL=C ... awk` (byte_awk's own definition), and exactly
+# THREE call sites actually going through byte_awk (byte-count, count-guard,
+# apply-splice). Deliberately environment-INDEPENDENT (it greps the source,
+# it does not run anything) so it catches a regression on every machine
+# regardless of which `awk` happens to be on PATH — the live gawk-forced case
+# right below this one is the version that can only run where gawk is
+# actually installed.
 lc_all_c_awk_count=$(grep -v '^[[:space:]]*#' "$MUTATE_SH" | grep -c 'LC_ALL=C.*awk')
-assert_eq "exactly 3 content-reading awk calls are pinned to LC_ALL=C (byte count, count-guard, apply)" "3" "$lc_all_c_awk_count"
+assert_eq "LC_ALL=C is set in exactly ONE place (byte_awk's own definition)" "1" "$lc_all_c_awk_count"
+byte_awk_call_sites=$(grep -v '^[[:space:]]*#' "$MUTATE_SH" | grep -c "byte_awk '")
+assert_eq "exactly 3 call sites go through byte_awk (byte count, count-guard, apply)" "3" "$byte_awk_call_sites"
 
 echo ""
 echo "== the same LC_ALL=C fix, exercised live under a real gawk + UTF-8 locale =="
@@ -210,40 +217,32 @@ else
 fi
 
 echo ""
-echo "== TOCTOU: the file changing between the count-read and the apply-read is refused, not silently corrupted =="
-# Review finding (#1750): the apply step re-reads the file independently of
-# the count guard, and originally spliced on whatever it found with no check
-# — if the anchor had stopped matching in between (a real concurrent writer),
-# it would have silently written `replacement` onto the file's content MINUS
-# its own first len(anchor) bytes. Reproducing a genuine data race would be a
-# flaky, timing-dependent test (this repo's own convention is to poll, never
-# sleep-and-hope, for exactly this reason) — so instead this fakes the COUNT
-# read lying, which produces the identical observable state (count says 1,
-# the real file has 0 matches) without any timing dependency at all. Only the
-# count-guard's own awk PROGRAM is intercepted (matched by its distinctive
-# `print n` tail); the byte-parity check and the apply step's real awk both
-# still run for real, so this exercises mutate.sh's actual apply-time guard,
-# not a stub standing in for it.
-real_awk="$(command -v awk)"
-fake_awk_dir="$(mktemp -d "${TMPDIR:-/tmp}/mutate-test-fakeawk.XXXXXX")"
-SCRATCH_DIRS+=("$fake_awk_dir")
-cat > "$fake_awk_dir/awk" <<EOF
+echo "== TOCTOU (guard #10): a live file that no longer matches its own snapshot is refused, not silently corrupted =="
+# Review finding (#1750): mutate.sh takes ONE snapshot and counts/splices
+# against it, then must confirm the LIVE file still matches that snapshot
+# before writing back — otherwise a file that changed underneath it (a real
+# concurrent writer) could be overwritten with a mutation computed from bytes
+# that are no longer there. Reproducing a genuine data race would be a flaky,
+# timing-dependent test (this repo's own convention is to poll, never
+# sleep-and-hope, for exactly this reason) — so instead this fakes the ONE
+# seam that decides this guard: `cmp`, made to always report "different"
+# regardless of its actual arguments. Every other command (awk, git, cp)
+# still runs for real, so this exercises mutate.sh's real guard, not a stub
+# standing in for it.
+fake_cmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/mutate-test-fakecmp.XXXXXX")"
+SCRATCH_DIRS+=("$fake_cmp_dir")
+cat > "$fake_cmp_dir/cmp" <<'EOF'
 #!/usr/bin/env bash
-for a in "\$@"; do
-  case "\$a" in
-    *'print n'*) echo 1; exit 0 ;;
-  esac
-done
-exec "$real_awk" "\$@"
+exit 1
 EOF
-chmod +x "$fake_awk_dir/awk"
+chmod +x "$fake_cmp_dir/cmp"
 
 repo="$(new_repo)"
-MUTATE_OUTPUT="$(cd "$repo" && PATH="$fake_awk_dir:$PATH" \
-  "$MUTATE_SH" sample.go "text truly absent from sample.go" "replacement" true 2>&1)"
+MUTATE_OUTPUT="$(cd "$repo" && PATH="$fake_cmp_dir:$PATH" \
+  "$MUTATE_SH" sample.go "$THE_IF_ANCHOR" "$THE_IF_REPLACED" true 2>&1)"
 MUTATE_RC=$?
 assert_eq "refuses with the dedicated TOCTOU exit code" "10" "$MUTATE_RC"
-assert_contains "names the two-read discrepancy" "no longer matches while applying" "$MUTATE_OUTPUT"
+assert_contains "names the snapshot/live-file discrepancy" "changed after this tool read it" "$MUTATE_OUTPUT"
 assert_eq "wrote nothing — the file is untouched" "$(git -C "$repo" show HEAD:sample.go)" "$(cat "$repo/sample.go")"
 assert_eq "left the repo clean" "" "$(cd "$repo" && git status --porcelain)"
 
@@ -252,8 +251,7 @@ echo "== precondition: outside a git repo reports THAT, not a false 'dirty tree'
 non_repo_dir="$(mktemp -d "${TMPDIR:-/tmp}/mutate-test-norepo.XXXXXX")"
 SCRATCH_DIRS+=("$non_repo_dir")
 echo "package foo" > "$non_repo_dir/sample.go"
-MUTATE_OUTPUT="$(cd "$non_repo_dir" && "$MUTATE_SH" sample.go "package foo" "package bar" true 2>&1)"
-MUTATE_RC=$?
+run_mutate "$non_repo_dir" "package foo" "package bar" true
 assert_contains "names the real cause (not a git repository), not a dirty-tree misdiagnosis" "not inside a git repository" "$MUTATE_OUTPUT"
 [[ "$MUTATE_RC" -ne 0 ]] && pass "refuses (nonzero exit)" || fail "refuses (nonzero exit)" "nonzero" "0"
 
@@ -261,7 +259,7 @@ echo ""
 echo "== STALE: a deliberate no-match row must be reported as STALE, never pass silently (#1390, #1450) =="
 repo="$(new_repo)"
 run_mutate "$repo" "this text does not occur anywhere in sample.go" "replacement" true
-assert_eq "refuses (nonzero)" "1" "$([[ "$MUTATE_RC" -ne 0 ]] && echo 1 || echo 0)"
+[[ "$MUTATE_RC" -ne 0 ]] && pass "refuses (nonzero exit)" || fail "refuses (nonzero exit)" "nonzero" "0"
 assert_contains "the refusal literally says STALE" "STALE" "$MUTATE_OUTPUT"
 assert_contains "...and names the guard it is enforcing" "occurs 0 times" "$MUTATE_OUTPUT"
 assert_eq "left the repo clean — a refused run must not leave partial state" "" "$(cd "$repo" && git status --porcelain)"
@@ -320,8 +318,7 @@ assert_contains "names the byte-count mismatch" "could not read" "$MUTATE_OUTPUT
 echo ""
 echo "== usage: refuses when the test command is missing entirely =="
 repo="$(new_repo)"
-MUTATE_OUTPUT="$(cd "$repo" && "$MUTATE_SH" sample.go "$THE_IF_ANCHOR" "$THE_IF_REPLACED" 2>&1)"
-MUTATE_RC=$?
+run_mutate "$repo" "$THE_IF_ANCHOR" "$THE_IF_REPLACED"   # no trailing test-cmd args at all
 assert_contains "prints a usage line" "usage:" "$MUTATE_OUTPUT"
 [[ "$MUTATE_RC" -ne 0 ]] && pass "refuses (nonzero exit)" || fail "refuses (nonzero exit)" "nonzero" "0"
 

--- a/tools/lib/mutate_test.sh
+++ b/tools/lib/mutate_test.sh
@@ -1,0 +1,260 @@
+#!/usr/bin/env bash
+# mutate_test.sh — self-test for tools/mutate.sh (#1750).
+#
+# tools/mutate.sh is process tooling: it has no "before the fix" runtime
+# defect of its own to reproduce, so per docs/testing-philosophy.md its own
+# test obligation is to prove each of ITS guards actually triggers its
+# failure mode when deliberately violated, and that a normal successful run
+# genuinely restores the mutated file to byte-identical content. Every
+# assertion below is a guard this change ADDS, so nothing here "passes by
+# construction" in the sense AGENTS.md exempts a lock from red-first proof —
+# each row is itself the deliberate violation.
+#
+# Per #1450 (cited directly in #1750): a deliberate no-match row is included
+# and MUST be reported as STALE — not pass silently — which is the single
+# guard the issue names as "the part that gets forgotten" (#1390).
+#
+# Convention follows tools/lib/changed-files_test.sh: plain bash, hand-rolled
+# asserts, a `fails` counter, "ALL PASS" / "N FAILED" at the end. Run
+# directly, or via tools/preflight.sh's `tools` gate.
+#
+# SAFETY. Every case runs the real tools/mutate.sh as a subprocess against a
+# throwaway git repo built fresh per scenario (new_repo, below) — never
+# against this repo's own tree. mutate.sh's own preconditions (a file that
+# must exist, a tree that must start clean) make that the only sound way to
+# drive it: reusing one repo across scenarios would mean cleaning up between
+# them, and the cleanup this repo bans everywhere (`git checkout --`/`git
+# restore`/`git reset --hard`, since worktrees share the parent's .git dir)
+# is exactly what would be tempting here. A fresh `mktemp -d` + `git init`
+# per scenario needs none of that.
+
+set -uo pipefail
+
+DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$DIR/../.." && pwd)"
+MUTATE_SH="$REPO_ROOT/tools/mutate.sh"
+
+# A missing tool is a hard failure, not a skip — exiting 0 here would read as
+# a PASS to preflight's shell_lib_tests, so the gate would go green having
+# asserted nothing.
+need() { command -v "$1" >/dev/null 2>&1 || { echo "FAIL: mutate_test — $1 not found" >&2; exit 1; }; }
+need git
+need awk
+
+if [[ ! -x "$MUTATE_SH" ]]; then
+  echo "FAIL: mutate_test — $MUTATE_SH is missing or not executable" >&2
+  exit 1
+fi
+
+fails=0
+pass() { echo "  PASS: $1"; return 0; }
+fail() { echo "  FAIL: $1 — expected [$2] got [$3]"; fails=$((fails + 1)); return 0; }
+assert_eq() {
+  if [[ "$2" == "$3" ]]; then pass "$1"; else fail "$1" "$2" "$3"; fi
+}
+# Every refusal is checked by a FRAGMENT of its message, never just the exit
+# code — the same rule tools/lib/await-gone_test.sh follows, so "it exited
+# nonzero" cannot be satisfied by the wrong guard firing.
+assert_contains() {
+  local label="$1" needle="$2" haystack="$3"
+  case "$haystack" in
+    *"$needle"*) pass "$label" ;;
+    *) fail "$label" "output containing: $needle" "${haystack:-nothing was printed}" ;;
+  esac
+}
+
+# Every scratch repo this suite creates, so the EXIT trap can remove them all
+# even if a case fails partway through.
+SCRATCH_DIRS=()
+cleanup() {
+  local d
+  for d in "${SCRATCH_DIRS[@]:-}"; do
+    [[ -n "$d" && -d "$d" ]] && rm -rf "$d"
+  done
+}
+trap cleanup EXIT
+
+# new_repo — create a fresh git repo with one committed fixture file
+# (sample.go, holding an if-block whose braces are a deliberately awkward
+# anchor: `[]int{1, 2, 3}` and `arr[0]` below it exercise `[`/`]`, and `* 2`
+# exercises `*`, all of which are BASH GLOB METACHARACTERS. mutate.sh matches
+# literally through awk's index()/substr(), never through bash's `${var/pat/
+# repl}` — which DOES treat `*`/`?`/`[` as wildcards even when the pattern
+# variable was assigned with quotes, because that expansion's pattern
+# argument is glob-matched regardless. This fixture is what a regression back
+# to that shape would actually break on.) Echoes the repo path.
+new_repo() {
+  local d
+  d="$(mktemp -d "${TMPDIR:-/tmp}/mutate-test.XXXXXX")"
+  SCRATCH_DIRS+=("$d")
+  (
+    cd "$d" || exit 1
+    git init -q
+    git config user.email "test@example.com"
+    git config user.name "mutate_test"
+    cat > sample.go <<'EOF'
+package foo
+
+func Bar() int {
+	if x > 0 {
+		return 1
+	}
+	return 0
+}
+
+func Baz() int {
+	arr := []int{1, 2, 3}
+	return arr[0] * 2
+}
+EOF
+    git add sample.go
+    git commit -q -m init
+  )
+  printf '%s' "$d"
+}
+
+# run_mutate <repo-dir> <anchor> <replacement> <test-cmd...> — runs mutate.sh
+# from inside the repo, capturing combined output in $MUTATE_OUTPUT and the
+# exit code in $MUTATE_RC. A subprocess, deliberately: mutate.sh's own `exit`
+# calls must not tear down this suite.
+MUTATE_OUTPUT=""
+MUTATE_RC=0
+run_mutate() {
+  local repo="$1" anchor="$2" replacement="$3"
+  shift 3
+  MUTATE_OUTPUT="$(cd "$repo" && "$MUTATE_SH" sample.go "$anchor" "$replacement" "$@" 2>&1)"
+  MUTATE_RC=$?
+}
+
+THE_IF_ANCHOR=$'\tif x > 0 {\n\t\treturn 1\n\t}'
+THE_IF_REPLACED=$'\tif x > 0 {\n\t\treturn 999\n\t}'
+GLOBBY_ANCHOR=$'\tarr := []int{1, 2, 3}\n\treturn arr[0] * 2'
+GLOBBY_REPLACED=$'\tarr := []int{1, 2, 3}\n\treturn arr[0] * 99'
+
+echo ""
+echo "== success: mutation applied, test observes it, file restored byte-for-byte =="
+repo="$(new_repo)"
+run_mutate "$repo" "$THE_IF_ANCHOR" "$THE_IF_REPLACED" grep -c 'return 999' "$repo/sample.go"
+assert_eq "exits 0" "0" "$MUTATE_RC"
+assert_contains "banner names the mutated file" "=== mutation applied to sample.go ===" "$MUTATE_OUTPUT"
+assert_contains "captures the test command's own output (grep found the mutated line)" $'\n1\n' $'\n'"$MUTATE_OUTPUT"$'\n'
+assert_contains "reports the test command's exit status" "exit=0" "$MUTATE_OUTPUT"
+assert_contains "reports the tree clean after restore" "git status after restore: ''" "$MUTATE_OUTPUT"
+# BYTE-IDENTICAL, not just "git reports no diff": cmp -s compares the actual
+# bytes on disk against the committed blob directly, independent of git's own
+# diffing (which is what would also read clean if, say, the restore left a
+# trailing-newline difference git happens to ignore under its own settings).
+if cmp -s <(git -C "$repo" show HEAD:sample.go) "$repo/sample.go"; then
+  pass "the file is BYTE-IDENTICAL to before the run"
+else
+  fail "the file is BYTE-IDENTICAL to before the run" "no diff" "cmp reported a difference"
+fi
+assert_eq "git status is genuinely empty, not merely unchecked" "" "$(cd "$repo" && git status --porcelain)"
+
+echo ""
+echo "== success: a FAILING test command is captured and reported, not swallowed =="
+repo="$(new_repo)"
+run_mutate "$repo" "$THE_IF_ANCHOR" "$THE_IF_REPLACED" grep -c 'return 1' "$repo/sample.go"
+assert_eq "mutate.sh itself still exits 0 (the guards passed; the TEST is what went red)" "0" "$MUTATE_RC"
+assert_contains "the red test's own exit status is visible" "exit=1" "$MUTATE_OUTPUT"
+
+echo ""
+echo "== literal multi-line matching survives bash glob metacharacters (*, [, ]) =="
+repo="$(new_repo)"
+run_mutate "$repo" "$GLOBBY_ANCHOR" "$GLOBBY_REPLACED" grep -c '\* 99' "$repo/sample.go"
+assert_eq "exits 0 against an anchor containing [ ] and *" "0" "$MUTATE_RC"
+assert_contains "the glob-metacharacter mutation actually landed and was observed" $'\n1\n' $'\n'"$MUTATE_OUTPUT"$'\n'
+
+echo ""
+echo "== STALE: a deliberate no-match row must be reported as STALE, never pass silently (#1390, #1450) =="
+repo="$(new_repo)"
+run_mutate "$repo" "this text does not occur anywhere in sample.go" "replacement" true
+assert_eq "refuses (nonzero)" "1" "$([[ "$MUTATE_RC" -ne 0 ]] && echo 1 || echo 0)"
+assert_contains "the refusal literally says STALE" "STALE" "$MUTATE_OUTPUT"
+assert_contains "...and names the guard it is enforcing" "occurs 0 times" "$MUTATE_OUTPUT"
+assert_eq "left the repo clean — a refused run must not leave partial state" "" "$(cd "$repo" && git status --porcelain)"
+assert_eq "left the file byte-for-byte untouched" "$(cat "$repo/sample.go")" "$(cd "$repo" && git show HEAD:sample.go)"
+
+echo ""
+echo "== ambiguous: an anchor matching more than once is refused, not applied to the first hit =="
+repo="$(new_repo)"
+run_mutate "$repo" "return" "come back" true
+assert_contains "names the actual count found (return 1 / return 0 / return arr[0] * 2)" "occurs 3 times" "$MUTATE_OUTPUT"
+assert_eq "left the repo clean" "" "$(cd "$repo" && git status --porcelain)"
+
+echo ""
+echo "== refuses a no-op replacement (byte-identical to the anchor) before touching the file =="
+repo="$(new_repo)"
+run_mutate "$repo" "$THE_IF_ANCHOR" "$THE_IF_ANCHOR" true
+assert_contains "names it as a no-op / unchanged" "UNCHANGED" "$MUTATE_OUTPUT"
+assert_eq "left the repo clean" "" "$(cd "$repo" && git status --porcelain)"
+
+echo ""
+echo "== refuses an empty anchor =="
+repo="$(new_repo)"
+run_mutate "$repo" "" "something" true
+assert_contains "names the empty anchor" "anchor is empty" "$MUTATE_OUTPUT"
+
+echo ""
+echo "== refuses a missing file rather than creating or silently skipping one =="
+repo="$(new_repo)"
+MUTATE_OUTPUT="$(cd "$repo" && "$MUTATE_SH" no-such-file.go "$THE_IF_ANCHOR" "$THE_IF_REPLACED" true 2>&1)"
+MUTATE_RC=$?
+assert_contains "names the missing file" "does not exist" "$MUTATE_OUTPUT"
+[[ "$MUTATE_RC" -ne 0 ]] && pass "refuses (nonzero exit)" || fail "refuses (nonzero exit)" "nonzero" "0"
+
+echo ""
+echo "== precondition: refuses to start against an ALREADY-dirty tree =="
+# The postcondition (git status --porcelain empty AFTER restoring) can only
+# mean anything if the tree was clean BEFORE mutate.sh touched it — otherwise
+# a genuine restore failure could hide behind pre-existing mess.
+repo="$(new_repo)"
+echo "uncommitted change" >> "$repo/sample.go"
+run_mutate "$repo" "$THE_IF_ANCHOR" "$THE_IF_REPLACED" true
+assert_contains "refuses, naming the precondition" "already non-empty BEFORE mutating" "$MUTATE_OUTPUT"
+git -C "$repo" checkout -q -- sample.go   # test-harness cleanup of ITS OWN scratch repo, not the tool under test
+
+echo ""
+echo "== refuses a file it cannot read byte-for-byte (embedded NUL) rather than risk a corrupt read =="
+repo="$(new_repo)"
+printf 'abc\x00def\n' > "$repo/embedded-nul.bin"
+git -C "$repo" add embedded-nul.bin
+git -C "$repo" commit -q -m "add a file with an embedded NUL"
+MUTATE_OUTPUT="$(cd "$repo" && "$MUTATE_SH" embedded-nul.bin "abc" "xyz" true 2>&1)"
+MUTATE_RC=$?
+assert_contains "names the byte-count mismatch" "could not read" "$MUTATE_OUTPUT"
+[[ "$MUTATE_RC" -ne 0 ]] && pass "refuses (nonzero exit)" || fail "refuses (nonzero exit)" "nonzero" "0"
+
+echo ""
+echo "== usage: refuses when the test command is missing entirely =="
+repo="$(new_repo)"
+MUTATE_OUTPUT="$(cd "$repo" && "$MUTATE_SH" sample.go "$THE_IF_ANCHOR" "$THE_IF_REPLACED" 2>&1)"
+MUTATE_RC=$?
+assert_contains "prints a usage line" "usage:" "$MUTATE_OUTPUT"
+[[ "$MUTATE_RC" -ne 0 ]] && pass "refuses (nonzero exit)" || fail "refuses (nonzero exit)" "nonzero" "0"
+
+echo ""
+echo "== FATAL: a test command's own side effect leaves the tree dirty — reported LOUDLY, not silently =="
+# mutate.sh restores the FILE it mutated; it cannot undo something the test
+# command itself did to the rest of the tree. That must surface as a hard,
+# named failure — never as a quiet 'git status after restore' that nobody
+# reads. This is guard #9's own deliberate violation.
+repo="$(new_repo)"
+run_mutate "$repo" "$THE_IF_ANCHOR" "$THE_IF_REPLACED" bash -c 'touch side-effect.txt'
+assert_contains "names it FATAL" "FATAL" "$MUTATE_OUTPUT"
+assert_contains "names the leftover file" "side-effect.txt" "$MUTATE_OUTPUT"
+[[ "$MUTATE_RC" -ne 0 ]] && pass "refuses (nonzero exit)" || fail "refuses (nonzero exit)" "nonzero" "0"
+# The mutated FILE itself must still have been restored even though the
+# overall tree is reported dirty — the guard's whole point is telling those
+# two facts apart rather than conflating them.
+assert_eq "the file mutate.sh actually touched IS still restored" \
+  "$(git -C "$repo" show HEAD:sample.go)" "$(cat "$repo/sample.go")"
+rm -f "$repo/side-effect.txt"   # test-harness cleanup, not the tool under test
+
+echo ""
+if [[ "$fails" -eq 0 ]]; then
+  echo "mutate_test: ALL PASS"
+  exit 0
+fi
+echo "mutate_test: $fails FAILED"
+exit 1

--- a/tools/lib/mutate_test.sh
+++ b/tools/lib/mutate_test.sh
@@ -166,6 +166,98 @@ assert_eq "exits 0 against an anchor containing [ ] and *" "0" "$MUTATE_RC"
 assert_contains "the glob-metacharacter mutation actually landed and was observed" $'\n1\n' $'\n'"$MUTATE_OUTPUT"$'\n'
 
 echo ""
+echo "== every content-reading awk invocation is pinned to LC_ALL=C (static regression pin) =="
+# Review finding (#1750): under a UTF-8 locale, GNU awk's length()/index()/
+# substr() count Unicode CODEPOINTS, not bytes, so any awk invocation that
+# measures or matches file content by byte must run under LC_ALL=C to agree
+# with `wc -c`. This assertion is deliberately environment-INDEPENDENT (it
+# greps the source, it does not run anything) so it catches a regression on
+# every machine regardless of which `awk` happens to be on PATH — the live
+# gawk-forced case right below this one is the version that can only run
+# where gawk is actually installed.
+lc_all_c_awk_count=$(grep -v '^[[:space:]]*#' "$MUTATE_SH" | grep -c 'LC_ALL=C.*awk')
+assert_eq "exactly 3 content-reading awk calls are pinned to LC_ALL=C (byte count, count-guard, apply)" "3" "$lc_all_c_awk_count"
+
+echo ""
+echo "== the same LC_ALL=C fix, exercised live under a real gawk + UTF-8 locale =="
+if command -v gawk >/dev/null 2>&1; then
+  repo="$(new_repo)"
+  # An em dash is 3 bytes in UTF-8 but ONE Unicode codepoint — measured
+  # directly (gawk 5.4.1, en_US.UTF-8): length() on a string containing one
+  # returns a count 2 SHORTER than `wc -c`, which is exactly what would trip
+  # mutate.sh's byte-parity guard (exit 3, "possible NUL byte") on a
+  # perfectly valid file if any awk call here were missing its LC_ALL=C.
+  printf '// em dash — right here, this repo'"'"'s own prose style\npackage foo\n' > "$repo/prose.go"
+  git -C "$repo" add prose.go
+  git -C "$repo" commit -q -m "add a file styled like this repo's own docs"
+  # A private PATH directory fronts `awk` with a symlink to the real gawk
+  # binary, so mutate.sh's own bare `awk` calls resolve to gawk specifically
+  # — reproducing the exact interpreter the review finding was about,
+  # regardless of which awk happens to be this machine's default.
+  gawk_front_dir="$(mktemp -d "${TMPDIR:-/tmp}/mutate-test-gawk.XXXXXX")"
+  SCRATCH_DIRS+=("$gawk_front_dir")
+  ln -s "$(command -v gawk)" "$gawk_front_dir/awk"
+  MUTATE_OUTPUT="$(cd "$repo" && PATH="$gawk_front_dir:$PATH" LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8 \
+    "$MUTATE_SH" prose.go "package foo" "package bar" true 2>&1)"
+  MUTATE_RC=$?
+  assert_eq "succeeds against a multi-byte file under gawk + a UTF-8 locale" "0" "$MUTATE_RC"
+  if [[ "$MUTATE_RC" -ne 0 ]]; then
+    echo "    (mutate.sh output was: $MUTATE_OUTPUT)"
+  fi
+else
+  echo "  SKIP: gawk not found on PATH — cannot exercise the codepoint-vs-byte bug live on this machine." \
+       "The static pin above still catches a regression in the fix; install gawk to also run this case live."
+fi
+
+echo ""
+echo "== TOCTOU: the file changing between the count-read and the apply-read is refused, not silently corrupted =="
+# Review finding (#1750): the apply step re-reads the file independently of
+# the count guard, and originally spliced on whatever it found with no check
+# — if the anchor had stopped matching in between (a real concurrent writer),
+# it would have silently written `replacement` onto the file's content MINUS
+# its own first len(anchor) bytes. Reproducing a genuine data race would be a
+# flaky, timing-dependent test (this repo's own convention is to poll, never
+# sleep-and-hope, for exactly this reason) — so instead this fakes the COUNT
+# read lying, which produces the identical observable state (count says 1,
+# the real file has 0 matches) without any timing dependency at all. Only the
+# count-guard's own awk PROGRAM is intercepted (matched by its distinctive
+# `print n` tail); the byte-parity check and the apply step's real awk both
+# still run for real, so this exercises mutate.sh's actual apply-time guard,
+# not a stub standing in for it.
+real_awk="$(command -v awk)"
+fake_awk_dir="$(mktemp -d "${TMPDIR:-/tmp}/mutate-test-fakeawk.XXXXXX")"
+SCRATCH_DIRS+=("$fake_awk_dir")
+cat > "$fake_awk_dir/awk" <<EOF
+#!/usr/bin/env bash
+for a in "\$@"; do
+  case "\$a" in
+    *'print n'*) echo 1; exit 0 ;;
+  esac
+done
+exec "$real_awk" "\$@"
+EOF
+chmod +x "$fake_awk_dir/awk"
+
+repo="$(new_repo)"
+MUTATE_OUTPUT="$(cd "$repo" && PATH="$fake_awk_dir:$PATH" \
+  "$MUTATE_SH" sample.go "text truly absent from sample.go" "replacement" true 2>&1)"
+MUTATE_RC=$?
+assert_eq "refuses with the dedicated TOCTOU exit code" "10" "$MUTATE_RC"
+assert_contains "names the two-read discrepancy" "no longer matches while applying" "$MUTATE_OUTPUT"
+assert_eq "wrote nothing — the file is untouched" "$(git -C "$repo" show HEAD:sample.go)" "$(cat "$repo/sample.go")"
+assert_eq "left the repo clean" "" "$(cd "$repo" && git status --porcelain)"
+
+echo ""
+echo "== precondition: outside a git repo reports THAT, not a false 'dirty tree' diagnosis =="
+non_repo_dir="$(mktemp -d "${TMPDIR:-/tmp}/mutate-test-norepo.XXXXXX")"
+SCRATCH_DIRS+=("$non_repo_dir")
+echo "package foo" > "$non_repo_dir/sample.go"
+MUTATE_OUTPUT="$(cd "$non_repo_dir" && "$MUTATE_SH" sample.go "package foo" "package bar" true 2>&1)"
+MUTATE_RC=$?
+assert_contains "names the real cause (not a git repository), not a dirty-tree misdiagnosis" "not inside a git repository" "$MUTATE_OUTPUT"
+[[ "$MUTATE_RC" -ne 0 ]] && pass "refuses (nonzero exit)" || fail "refuses (nonzero exit)" "nonzero" "0"
+
+echo ""
 echo "== STALE: a deliberate no-match row must be reported as STALE, never pass silently (#1390, #1450) =="
 repo="$(new_repo)"
 run_mutate "$repo" "this text does not occur anywhere in sample.go" "replacement" true

--- a/tools/mutate.sh
+++ b/tools/mutate.sh
@@ -1,0 +1,246 @@
+#!/usr/bin/env bash
+# mutate.sh — apply one deliberate, reversible mutation to a tracked file, run
+# a test command against it, capture the (expected-red) output, and restore
+# the file byte-for-byte. This is the harness `docs/testing-philosophy.md`
+# requires for anything a change ADDS (a guard, a static rule, a derived
+# count, a schema constraint, ...): mutate the thing it protects, confirm the
+# check goes red, then leave the tree exactly as it was.
+#
+# WHY THIS EXISTS (#1750). Three separate agents, across #1740/#1741/#1736,
+# each hand-wrote the same helper: assert the anchor text matches exactly
+# once, apply, run a test selector, restore, print `git status --porcelain`.
+# One of them wrote it as a Python script and noted it was "the third or
+# fourth time" — the mechanics get re-improvised every run, and the part that
+# gets forgotten is the stale-anchor guard (#1390): a pattern that no longer
+# matches must not silently mutate nothing and let the test's pre-existing
+# state read as "the guard works" (#1450). A committed tool enforces every
+# guard by construction instead of by whoever remembers this time.
+#
+# Usage:
+#   tools/mutate.sh <file> <anchor> <replacement> <test-cmd> [test-cmd-args...]
+#
+#   <file>          path to the tracked file to mutate (repo-relative or
+#                   absolute; run this from wherever <test-cmd>'s own paths
+#                   expect, same as you would run that command directly).
+#   <anchor>        literal text (NOT a regex/glob) that must occur in <file>
+#                   EXACTLY ONCE. May span multiple lines — pass it via a
+#                   variable built with `$'...'` or `"$(cat anchor.txt)"`,
+#                   never typed inline with embedded newlines.
+#   <replacement>   literal text to splice in place of <anchor>. Must differ
+#                   from <anchor> (byte-for-byte) — a replacement identical to
+#                   the anchor is a no-op mutation and is refused.
+#   <test-cmd> ...  the test command's OWN argv, executed directly (no shell
+#                   re-parsing, no injection risk): `go test ./pkg/... -run
+#                   TestFoo -v`, `bash tools/lib/foo_test.sh`, etc. If you need
+#                   shell features (pipes, &&, globbing) inside it, pass
+#                   `bash -c '...'` explicitly as the argv.
+#
+# Example:
+#   ANCHOR=$'if x > 0 {\n\treturn 1\n}'
+#   REPLACEMENT=$'if x > 0 {\n\treturn 999\n}'
+#   tools/mutate.sh core/foo.go "$ANCHOR" "$REPLACEMENT" \
+#     go test ./core/... -run TestBar -v
+#
+# What it does, in order — every one of these is a guard from the issue, not
+# an implementation detail:
+#   1. refuses unless <anchor> occurs EXACTLY ONCE in <file> (#1390) — zero
+#      matches is reported as STALE (a literal, greppable word: #1450 wants a
+#      stale anchor to be loud, never a silent no-op), more than one match is
+#      refused as ambiguous;
+#   2. refuses if <replacement> is byte-identical to <anchor> (the mutation
+#      would leave the file unchanged);
+#   3. applies the mutation, runs <test-cmd>, captures its combined output and
+#      exit status;
+#   4. restores <file> by COPY-BACK from a byte-for-byte backup — never `git
+#      checkout --`/`git restore`/`git reset --hard`, which this repo forbids
+#      everywhere: worktrees share the parent repo's .git dir, so the stash
+#      and (for reset --hard) other shared state are not isolated per
+#      worktree, and a restore must not touch any of it;
+#   5. asserts `git status --porcelain` is empty afterward and fails LOUDLY
+#      (not silently) if it is not;
+#   6. prints the whole thing in the shape already used, by hand, for pasting
+#      into a PR body:
+#        === mutation applied to <file> ===
+#        <captured test output>
+#        === <test-cmd> exit=<rc> ===
+#        git status after restore: '<porcelain output, empty on success>'
+#
+# Exit codes (every refusal explains itself on stderr; nothing here is silent):
+#   0  success — mutation applied, test ran, file restored, tree clean.
+#   1  usage error (wrong number of arguments, or --help).
+#   2  <file> does not exist, is not a regular file, or is not read/writable.
+#   3  could not read <file> byte-for-byte (embedded NUL, or the 0x01 byte
+#      this tool reserves as an internal record separator — measured, not
+#      assumed: file size and what was read disagree).
+#   4  precondition refused — `git status --porcelain` was already non-empty
+#      BEFORE mutating. The post-restore emptiness check could prove nothing
+#      against a tree that started dirty; commit or clean up first.
+#   5  <anchor> is empty. An empty anchor "matches everywhere" and asserts
+#      nothing.
+#   6  <replacement> is byte-identical to <anchor> — a no-op mutation.
+#   7  STALE — <anchor> occurs ZERO times in <file> (#1390/#1450).
+#   8  ambiguous — <anchor> occurs MORE THAN ONCE in <file>.
+#   9  FATAL — `git status --porcelain` is NOT empty after restoring. The
+#      restore itself did not leave the tree clean; this should be
+#      unreachable, and reaching it is reported loudly rather than papered
+#      over.
+#
+# Implementation notes:
+#   - Literal text, not regex/glob. <anchor>/<replacement> are matched and
+#     spliced as exact byte sequences via awk's index()/substr(), reached
+#     through ENVIRON rather than -v — -v applies backslash-escape processing
+#     to its value (so a literal `\n` inside a real anchor would silently
+#     become a newline), ENVIRON does not.
+#   - The whole file is read as ONE awk record via `RS="\x01"` (a byte
+#     practically never present in source text) so a multi-line anchor is
+#     matched as ONE literal string rather than reassembled line by line —
+#     the latter would also silently normalise a missing final newline.
+#     Guard #3 above is what keeps this safe if that byte, or a NUL, actually
+#     shows up: the read is measured against `wc -c`, not assumed correct.
+set -uo pipefail
+
+self_help() {
+  awk 'NR>1 && /^#/ {sub(/^# ?/, ""); print; next} NR>1 {exit}' "$0"
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  self_help
+  exit 0
+fi
+
+if [[ $# -lt 4 ]]; then
+  echo "usage: tools/mutate.sh <file> <anchor> <replacement> <test-cmd> [test-cmd-args...]" >&2
+  echo "       tools/mutate.sh --help" >&2
+  exit 1
+fi
+
+FILE="$1"
+ANCHOR="$2"
+REPLACEMENT="$3"
+shift 3
+TEST_CMD=("$@")
+
+refuse() {
+  local code="$1" msg="$2"
+  echo "mutate: refusing — $msg" >&2
+  exit "$code"
+}
+
+# ─── Guard: the file itself ────────────────────────────────────────────────
+if [[ ! -f "$FILE" ]]; then
+  refuse 2 "'$FILE' does not exist or is not a regular file"
+fi
+if [[ ! -r "$FILE" || ! -w "$FILE" ]]; then
+  refuse 2 "'$FILE' is not both readable and writable"
+fi
+
+# ─── Guard: the file can be read byte-for-byte through the RS="\x01" slurp ──
+# Measured, not assumed (AGENTS.md: "a validator that can't parse its input
+# checks MORE, never less"). A mismatch means the file contains a NUL byte
+# (many awk implementations truncate C-style strings there) or literally the
+# 0x01 byte this tool reserves as its own record separator — either way,
+# proceeding would silently operate on a truncated/garbled read.
+FILE_BYTES="$(LC_ALL=C wc -c < "$FILE" | tr -d ' ')"
+SLURPED_LEN="$(awk 'BEGIN{RS="\x01"}{print length($0)}' "$FILE")"
+if [[ "$SLURPED_LEN" != "$FILE_BYTES" ]]; then
+  refuse 3 "could not read '$FILE' byte-for-byte: it is $FILE_BYTES bytes but this tool's exact-byte read measured '$SLURPED_LEN' — likely an embedded NUL byte or this tool's own 0x01 sentinel. Refusing rather than risk a corrupted mutation."
+fi
+
+# ─── Guard: precondition — the tree must already be clean ──────────────────
+# The postcondition below (git status --porcelain empty AFTER restoring) can
+# only mean something if it was ALSO empty before this run touched anything —
+# otherwise pre-existing changes elsewhere in the tree make the postcondition
+# vacuous, and a genuine restore failure could hide behind them.
+PRE_STATUS="$(git status --porcelain 2>&1)"
+if [[ -n "$PRE_STATUS" ]]; then
+  refuse 4 "git status --porcelain is already non-empty BEFORE mutating anything. Commit or clean up first — a tree that starts dirty can never prove the post-restore emptiness check meant anything:
+$PRE_STATUS"
+fi
+
+# ─── Guard: the anchor and replacement ─────────────────────────────────────
+if [[ -z "$ANCHOR" ]]; then
+  refuse 5 "the anchor is empty — an empty anchor matches everywhere and asserts nothing"
+fi
+if [[ "$ANCHOR" == "$REPLACEMENT" ]]; then
+  refuse 6 "the replacement is byte-identical to the anchor — this mutation would leave '$FILE' UNCHANGED"
+fi
+
+# ─── Guard: the anchor occurs EXACTLY ONCE (#1390) ─────────────────────────
+COUNT="$(MUTATE_ANCHOR="$ANCHOR" awk '
+  BEGIN { RS = "\x01" }
+  {
+    content = $0
+    anchor = ENVIRON["MUTATE_ANCHOR"]
+    alen = length(anchor)
+    n = 0
+    pos = 1
+    while (1) {
+      idx = index(substr(content, pos), anchor)
+      if (idx == 0) break
+      n++
+      pos = pos + idx - 1 + alen
+    }
+    print n
+  }
+' "$FILE")"
+
+if [[ "$COUNT" -eq 0 ]]; then
+  refuse 7 "STALE — the anchor occurs 0 times in '$FILE'. A stale anchor that no longer matches must not silently do nothing (#1390); update the anchor to match the current text."
+fi
+if [[ "$COUNT" -gt 1 ]]; then
+  refuse 8 "the anchor occurs $COUNT times in '$FILE', not exactly once — an ambiguous anchor could mutate the wrong occurrence. Widen it with more surrounding context until it is unique."
+fi
+
+# ─── Backup, apply, and an EXIT trap so a restore always happens ───────────
+BACKUP="$(mktemp "${TMPDIR:-/tmp}/mutate.XXXXXX")"
+cp -p "$FILE" "$BACKUP"
+
+RESTORED=0
+restore_file() {
+  # Idempotent: safe to call more than once (the trap calls it as a safety
+  # net even after the main flow already restored explicitly).
+  if [[ "$RESTORED" -eq 0 && -f "$BACKUP" ]]; then
+    cp -p "$BACKUP" "$FILE"
+    rm -f "$BACKUP"
+    RESTORED=1
+  fi
+}
+trap restore_file EXIT
+
+MUTATE_ANCHOR="$ANCHOR" MUTATE_REPLACEMENT="$REPLACEMENT" awk '
+  BEGIN { RS = "\x01" }
+  {
+    content = $0
+    anchor = ENVIRON["MUTATE_ANCHOR"]
+    repl = ENVIRON["MUTATE_REPLACEMENT"]
+    alen = length(anchor)
+    idx = index(content, anchor)
+    prefix = substr(content, 1, idx - 1)
+    suffix = substr(content, idx + alen)
+    printf "%s", prefix repl suffix
+  }
+' "$FILE" > "$BACKUP.mutated"
+cat "$BACKUP.mutated" > "$FILE"
+rm -f "$BACKUP.mutated"
+
+echo "=== mutation applied to $FILE ==="
+
+# ─── Run the test command, capturing output and exit status ───────────────
+TEST_OUTPUT="$("${TEST_CMD[@]}" 2>&1)"
+TEST_RC=$?
+
+printf '%s\n' "$TEST_OUTPUT"
+printf '=== %s exit=%s ===\n' "$(printf '%q ' "${TEST_CMD[@]}")" "$TEST_RC"
+
+# ─── Restore, then assert the tree is provably clean ───────────────────────
+restore_file
+
+POST_STATUS="$(git status --porcelain 2>&1)"
+echo "git status after restore: '$POST_STATUS'"
+if [[ -n "$POST_STATUS" ]]; then
+  echo "mutate: FATAL — git status --porcelain is NOT empty after restoring '$FILE'. The restore did not leave the tree clean:" >&2
+  echo "$POST_STATUS" >&2
+  exit 9
+fi
+
+exit 0

--- a/tools/mutate.sh
+++ b/tools/mutate.sh
@@ -85,9 +85,10 @@
 #      restore itself did not leave the tree clean; this should be
 #      unreachable, and reaching it is reported loudly rather than papered
 #      over.
-#  10  <file> changed between the count read and the apply read (a narrow
-#      TOCTOU window) — the anchor no longer matched on the second read.
-#      Nothing was written; this should be very rare and is safe to retry.
+#  10  <file> changed after this tool read it — between taking the snapshot
+#      it counts/splices against and writing the mutation back. Checked by a
+#      single direct comparison against the live file immediately before the
+#      write; nothing was written. Should be very rare and is safe to retry.
 #
 # Implementation notes:
 #   - Literal text, not regex/glob. <anchor>/<replacement> are matched and
@@ -95,27 +96,43 @@
 #     through ENVIRON rather than -v — -v applies backslash-escape processing
 #     to its value (so a literal `\n` inside a real anchor would silently
 #     become a newline), ENVIRON does not.
+#   - ONE snapshot, not repeated live reads. The file is copied to a backup
+#     ONCE, immediately after the existence/read-write checks, and every
+#     content-reading guard below (byte-parity, the anchor count, the splice)
+#     reads that same immutable copy — so they cannot disagree with each
+#     other; they are three views of identical bytes, not three independent
+#     looks at a file that could be changing underneath them. The single
+#     place that still reads the LIVE file is one direct `cmp` immediately
+#     before the final write, which is the one point a real concurrent
+#     change actually matters (guard #10). An earlier version re-read the
+#     live file a second time at apply time and re-checked the anchor there;
+#     this replaces that second independent look (and its own copy of the
+#     match logic) with a single explicit comparison at the point that needs
+#     it (review finding, #1750).
 #   - The whole file is read as ONE awk record via `RS="\x01"` (a byte
 #     practically never present in source text) so a multi-line anchor is
 #     matched as ONE literal string rather than reassembled line by line —
 #     the latter would also silently normalise a missing final newline.
 #     Guard #3 above is what keeps this safe if that byte, or a NUL, actually
 #     shows up: the read is measured against `wc -c`, not assumed correct.
-#   - Every awk invocation that measures or matches by BYTE runs under
-#     `LC_ALL=C`, not just the `wc -c` it must agree with. Under a UTF-8
-#     locale, gawk's length()/index()/substr() count Unicode codepoints —
-#     measured: a file with one 3-byte em dash (this repo's own prose style)
-#     reads as 2 bytes short under a UTF-8 locale's gawk, which would trip
-#     guard #3 as a false "possible NUL byte" refusal on a perfectly valid
-#     file. `LC_ALL=C` makes every byte its own "character" again.
+#   - Every awk invocation that measures or matches by BYTE goes through
+#     byte_awk() (below), which centralises `LC_ALL=C` in ONE place rather
+#     than repeating it at each call site — measured (review finding,
+#     #1750): under a UTF-8 locale, gawk's length()/index()/substr() count
+#     Unicode CODEPOINTS, not bytes, so a file containing any multi-byte
+#     character (this repo's own prose uses em dashes throughout) would read
+#     as shorter than `wc -c` and trip guard #3 as a false "possible NUL
+#     byte" refusal. `LC_ALL=C` makes every byte its own "character" again,
+#     and funnelling every content-reading call through byte_awk() means a
+#     future one added here inherits the fix instead of needing to remember
+#     it.
 set -uo pipefail
 
-self_help() {
-  awk 'NR>1 && /^#/ {sub(/^# ?/, ""); print; next} NR>1 {exit}' "$0"
-}
-
 if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
-  self_help
+  # Matches tools/bash-lint.sh, tools/posix-lint.sh, tools/preflight.sh,
+  # tools/security-scan.sh and tools/skill-lint.sh BYTE-FOR-BYTE, so --help
+  # can't drift into a sixth, subtly different self-help format.
+  awk 'NR>1 && /^#/ {print; next} NR>1 {exit}' "$0"
   exit 0
 fi
 
@@ -137,6 +154,13 @@ refuse() {
   exit "$code"
 }
 
+# byte_awk <awk-program> [file...] — the ONLY way this script reads or
+# matches file content. See the implementation notes above for why LC_ALL=C
+# lives here and nowhere else.
+byte_awk() {
+  LC_ALL=C awk "$@"
+}
+
 # ─── Guard: the file itself ────────────────────────────────────────────────
 if [[ ! -f "$FILE" ]]; then
   refuse 2 "'$FILE' does not exist or is not a regular file"
@@ -145,23 +169,35 @@ if [[ ! -r "$FILE" || ! -w "$FILE" ]]; then
   refuse 2 "'$FILE' is not both readable and writable"
 fi
 
-# ─── Guard: the file can be read byte-for-byte through the RS="\x01" slurp ──
+# ─── Snapshot the file ONCE, before anything reads its content ────────────
+# See "ONE snapshot, not repeated live reads" above. Every content-reading
+# guard from here on reads $BACKUP, never $FILE directly, until the single
+# `cmp` right before the final write.
+BACKUP="$(mktemp "${TMPDIR:-/tmp}/mutate.XXXXXX")"
+cp -p "$FILE" "$BACKUP"
+
+RESTORED=0
+restore_file() {
+  # Idempotent: safe to call more than once (the trap calls it as a safety
+  # net even after the main flow already restored explicitly).
+  if [[ "$RESTORED" -eq 0 && -f "$BACKUP" ]]; then
+    cp -p "$BACKUP" "$FILE"
+    rm -f "$BACKUP"
+    RESTORED=1
+  fi
+}
+trap restore_file EXIT
+
+# ─── Guard: the snapshot can be read byte-for-byte via the RS="\x01" slurp ──
 # Measured, not assumed (AGENTS.md: "a validator that can't parse its input
 # checks MORE, never less"). A mismatch means the file contains a NUL byte
 # (many awk implementations truncate C-style strings there) or literally the
 # 0x01 byte this tool reserves as its own record separator — either way,
 # proceeding would silently operate on a truncated/garbled read.
-FILE_BYTES="$(LC_ALL=C wc -c < "$FILE" | tr -d ' ')"
-# LC_ALL=C on every awk invocation below, not just this one — measured
-# (review finding, #1750): under a UTF-8 locale, gawk's length()/index()/
-# substr() count Unicode CODEPOINTS, not bytes, so a file containing any
-# multi-byte character (this repo's own prose uses em dashes throughout)
-# would read as shorter than `wc -c` and trip this guard as a false
-# "possible NUL byte" refusal. `C` makes every byte its own "character",
-# which is what the byte-count comparison above actually needs.
-SLURPED_LEN="$(LC_ALL=C awk 'BEGIN{RS="\x01"}{print length($0)}' "$FILE")"
-if [[ "$SLURPED_LEN" != "$FILE_BYTES" ]]; then
-  refuse 3 "could not read '$FILE' byte-for-byte: it is $FILE_BYTES bytes but this tool's exact-byte read measured '$SLURPED_LEN' — likely an embedded NUL byte or this tool's own 0x01 sentinel. Refusing rather than risk a corrupted mutation."
+SNAPSHOT_BYTES="$(LC_ALL=C wc -c < "$BACKUP" | tr -d ' ')"
+SLURPED_LEN="$(byte_awk 'BEGIN{RS="\x01"}{print length($0)}' "$BACKUP")"
+if [[ "$SLURPED_LEN" != "$SNAPSHOT_BYTES" ]]; then
+  refuse 3 "could not read '$FILE' byte-for-byte: it is $SNAPSHOT_BYTES bytes but this tool's exact-byte read measured '$SLURPED_LEN' — likely an embedded NUL byte or this tool's own 0x01 sentinel. Refusing rather than risk a corrupted mutation."
 fi
 
 # ─── Guard: precondition — a real git repo, and already clean ──────────────
@@ -172,7 +208,7 @@ fi
 #
 # Checked as its OWN step, separately from the porcelain read below: `git
 # status --porcelain` outside a repo prints "fatal: not a git repository..."
-# on stderr, which the original version of this guard folded into the same
+# on stderr, which an earlier version of this guard folded into the same
 # message as a dirty tree — a wrong diagnosis (review finding, #1750): the
 # tree isn't dirty, there IS no tree.
 if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
@@ -192,8 +228,8 @@ if [[ "$ANCHOR" == "$REPLACEMENT" ]]; then
   refuse 6 "the replacement is byte-identical to the anchor — this mutation would leave '$FILE' UNCHANGED"
 fi
 
-# ─── Guard: the anchor occurs EXACTLY ONCE (#1390) ─────────────────────────
-COUNT="$(MUTATE_ANCHOR="$ANCHOR" LC_ALL=C awk '
+# ─── Guard: the anchor occurs EXACTLY ONCE (#1390), counted from the snapshot ──
+COUNT="$(MUTATE_ANCHOR="$ANCHOR" byte_awk '
   BEGIN { RS = "\x01" }
   {
     content = $0
@@ -209,7 +245,7 @@ COUNT="$(MUTATE_ANCHOR="$ANCHOR" LC_ALL=C awk '
     }
     print n
   }
-' "$FILE")"
+' "$BACKUP")"
 
 if [[ "$COUNT" -eq 0 ]]; then
   refuse 7 "STALE — the anchor occurs 0 times in '$FILE'. A stale anchor that no longer matches must not silently do nothing (#1390); update the anchor to match the current text."
@@ -218,29 +254,10 @@ if [[ "$COUNT" -gt 1 ]]; then
   refuse 8 "the anchor occurs $COUNT times in '$FILE', not exactly once — an ambiguous anchor could mutate the wrong occurrence. Widen it with more surrounding context until it is unique."
 fi
 
-# ─── Backup, apply, and an EXIT trap so a restore always happens ───────────
-BACKUP="$(mktemp "${TMPDIR:-/tmp}/mutate.XXXXXX")"
-cp -p "$FILE" "$BACKUP"
-
-RESTORED=0
-restore_file() {
-  # Idempotent: safe to call more than once (the trap calls it as a safety
-  # net even after the main flow already restored explicitly).
-  if [[ "$RESTORED" -eq 0 && -f "$BACKUP" ]]; then
-    cp -p "$BACKUP" "$FILE"
-    rm -f "$BACKUP"
-    RESTORED=1
-  fi
-}
-trap restore_file EXIT
-
-# Re-checks idx == 0 rather than trusting the COUNT guard above: this reads
-# the file a SECOND time, independently, and a review finding (#1750) noted
-# that a file changing between the two reads (a narrow but real TOCTOU
-# window) would otherwise splice `replacement` onto `substr(content, alen)`
-# with no warning — silently dropping the file's own first `alen` bytes.
-# Fails closed instead: refuses rather than writing anything.
-if ! MUTATE_ANCHOR="$ANCHOR" MUTATE_REPLACEMENT="$REPLACEMENT" LC_ALL=C awk '
+# ─── Splice against the SAME snapshot just counted — guaranteed to agree ───
+# with COUNT above by construction (one immutable read, not a second
+# independent look that could see something different).
+MUTATE_ANCHOR="$ANCHOR" MUTATE_REPLACEMENT="$REPLACEMENT" byte_awk '
   BEGIN { RS = "\x01" }
   {
     content = $0
@@ -248,18 +265,21 @@ if ! MUTATE_ANCHOR="$ANCHOR" MUTATE_REPLACEMENT="$REPLACEMENT" LC_ALL=C awk '
     repl = ENVIRON["MUTATE_REPLACEMENT"]
     alen = length(anchor)
     idx = index(content, anchor)
-    if (idx == 0) {
-      print "mutate: internal — the anchor no longer matches on the apply read (the file changed between reads)" > "/dev/stderr"
-      exit 1
-    }
     prefix = substr(content, 1, idx - 1)
     suffix = substr(content, idx + alen)
     printf "%s", prefix repl suffix
   }
-' "$FILE" > "$BACKUP.mutated"; then
+' "$BACKUP" > "$BACKUP.mutated"
+
+# ─── The ONE point that still reads the LIVE file (guard #10) ─────────────
+# Has it changed since the snapshot was taken? A single direct comparison
+# right before the write, rather than a second independent read-and-recount
+# reconciled after the fact.
+if ! cmp -s "$BACKUP" "$FILE"; then
   rm -f "$BACKUP.mutated"
-  refuse 10 "the anchor matched exactly once while counting but no longer matches while applying — '$FILE' changed between the two reads. Nothing was written; run again."
+  refuse 10 "'$FILE' changed after this tool read it — between taking the snapshot and applying the mutation. Refusing to write a mutation computed from bytes that are no longer there; run again."
 fi
+
 cat "$BACKUP.mutated" > "$FILE"
 rm -f "$BACKUP.mutated"
 

--- a/tools/mutate.sh
+++ b/tools/mutate.sh
@@ -72,9 +72,10 @@
 #   3  could not read <file> byte-for-byte (embedded NUL, or the 0x01 byte
 #      this tool reserves as an internal record separator — measured, not
 #      assumed: file size and what was read disagree).
-#   4  precondition refused — `git status --porcelain` was already non-empty
-#      BEFORE mutating. The post-restore emptiness check could prove nothing
-#      against a tree that started dirty; commit or clean up first.
+#   4  precondition refused — not inside a git repository, or `git status
+#      --porcelain` was already non-empty BEFORE mutating. The post-restore
+#      emptiness check could prove nothing against a tree that started dirty
+#      (or wasn't a tree at all); commit or clean up first.
 #   5  <anchor> is empty. An empty anchor "matches everywhere" and asserts
 #      nothing.
 #   6  <replacement> is byte-identical to <anchor> — a no-op mutation.
@@ -84,6 +85,9 @@
 #      restore itself did not leave the tree clean; this should be
 #      unreachable, and reaching it is reported loudly rather than papered
 #      over.
+#  10  <file> changed between the count read and the apply read (a narrow
+#      TOCTOU window) — the anchor no longer matched on the second read.
+#      Nothing was written; this should be very rare and is safe to retry.
 #
 # Implementation notes:
 #   - Literal text, not regex/glob. <anchor>/<replacement> are matched and
@@ -97,6 +101,13 @@
 #     the latter would also silently normalise a missing final newline.
 #     Guard #3 above is what keeps this safe if that byte, or a NUL, actually
 #     shows up: the read is measured against `wc -c`, not assumed correct.
+#   - Every awk invocation that measures or matches by BYTE runs under
+#     `LC_ALL=C`, not just the `wc -c` it must agree with. Under a UTF-8
+#     locale, gawk's length()/index()/substr() count Unicode codepoints —
+#     measured: a file with one 3-byte em dash (this repo's own prose style)
+#     reads as 2 bytes short under a UTF-8 locale's gawk, which would trip
+#     guard #3 as a false "possible NUL byte" refusal on a perfectly valid
+#     file. `LC_ALL=C` makes every byte its own "character" again.
 set -uo pipefail
 
 self_help() {
@@ -141,16 +152,32 @@ fi
 # 0x01 byte this tool reserves as its own record separator — either way,
 # proceeding would silently operate on a truncated/garbled read.
 FILE_BYTES="$(LC_ALL=C wc -c < "$FILE" | tr -d ' ')"
-SLURPED_LEN="$(awk 'BEGIN{RS="\x01"}{print length($0)}' "$FILE")"
+# LC_ALL=C on every awk invocation below, not just this one — measured
+# (review finding, #1750): under a UTF-8 locale, gawk's length()/index()/
+# substr() count Unicode CODEPOINTS, not bytes, so a file containing any
+# multi-byte character (this repo's own prose uses em dashes throughout)
+# would read as shorter than `wc -c` and trip this guard as a false
+# "possible NUL byte" refusal. `C` makes every byte its own "character",
+# which is what the byte-count comparison above actually needs.
+SLURPED_LEN="$(LC_ALL=C awk 'BEGIN{RS="\x01"}{print length($0)}' "$FILE")"
 if [[ "$SLURPED_LEN" != "$FILE_BYTES" ]]; then
   refuse 3 "could not read '$FILE' byte-for-byte: it is $FILE_BYTES bytes but this tool's exact-byte read measured '$SLURPED_LEN' — likely an embedded NUL byte or this tool's own 0x01 sentinel. Refusing rather than risk a corrupted mutation."
 fi
 
-# ─── Guard: precondition — the tree must already be clean ──────────────────
+# ─── Guard: precondition — a real git repo, and already clean ──────────────
 # The postcondition below (git status --porcelain empty AFTER restoring) can
 # only mean something if it was ALSO empty before this run touched anything —
 # otherwise pre-existing changes elsewhere in the tree make the postcondition
 # vacuous, and a genuine restore failure could hide behind them.
+#
+# Checked as its OWN step, separately from the porcelain read below: `git
+# status --porcelain` outside a repo prints "fatal: not a git repository..."
+# on stderr, which the original version of this guard folded into the same
+# message as a dirty tree — a wrong diagnosis (review finding, #1750): the
+# tree isn't dirty, there IS no tree.
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  refuse 4 "'$PWD' is not inside a git repository — this tool needs one, to assert git status --porcelain is empty before and after mutating"
+fi
 PRE_STATUS="$(git status --porcelain 2>&1)"
 if [[ -n "$PRE_STATUS" ]]; then
   refuse 4 "git status --porcelain is already non-empty BEFORE mutating anything. Commit or clean up first — a tree that starts dirty can never prove the post-restore emptiness check meant anything:
@@ -166,7 +193,7 @@ if [[ "$ANCHOR" == "$REPLACEMENT" ]]; then
 fi
 
 # ─── Guard: the anchor occurs EXACTLY ONCE (#1390) ─────────────────────────
-COUNT="$(MUTATE_ANCHOR="$ANCHOR" awk '
+COUNT="$(MUTATE_ANCHOR="$ANCHOR" LC_ALL=C awk '
   BEGIN { RS = "\x01" }
   {
     content = $0
@@ -207,7 +234,13 @@ restore_file() {
 }
 trap restore_file EXIT
 
-MUTATE_ANCHOR="$ANCHOR" MUTATE_REPLACEMENT="$REPLACEMENT" awk '
+# Re-checks idx == 0 rather than trusting the COUNT guard above: this reads
+# the file a SECOND time, independently, and a review finding (#1750) noted
+# that a file changing between the two reads (a narrow but real TOCTOU
+# window) would otherwise splice `replacement` onto `substr(content, alen)`
+# with no warning — silently dropping the file's own first `alen` bytes.
+# Fails closed instead: refuses rather than writing anything.
+if ! MUTATE_ANCHOR="$ANCHOR" MUTATE_REPLACEMENT="$REPLACEMENT" LC_ALL=C awk '
   BEGIN { RS = "\x01" }
   {
     content = $0
@@ -215,11 +248,18 @@ MUTATE_ANCHOR="$ANCHOR" MUTATE_REPLACEMENT="$REPLACEMENT" awk '
     repl = ENVIRON["MUTATE_REPLACEMENT"]
     alen = length(anchor)
     idx = index(content, anchor)
+    if (idx == 0) {
+      print "mutate: internal — the anchor no longer matches on the apply read (the file changed between reads)" > "/dev/stderr"
+      exit 1
+    }
     prefix = substr(content, 1, idx - 1)
     suffix = substr(content, idx + alen)
     printf "%s", prefix repl suffix
   }
-' "$FILE" > "$BACKUP.mutated"
+' "$FILE" > "$BACKUP.mutated"; then
+  rm -f "$BACKUP.mutated"
+  refuse 10 "the anchor matched exactly once while counting but no longer matches while applying — '$FILE' changed between the two reads. Nothing was written; run again."
+fi
 cat "$BACKUP.mutated" > "$FILE"
 rm -f "$BACKUP.mutated"
 


### PR DESCRIPTION
Closes #1750.

## Why

`docs/testing-philosophy.md` requires that anything a change *adds* (a guard,
a derived check) lands with a deliberate mutation seen red, applied and
reverted one per foreground call, tree provably clean afterward. That rule
works — it has caught real gaps repeatedly. But the *mechanics* get
re-improvised every time: three separate agents, across #1740/#1741/#1736,
each hand-wrote the same helper (assert the anchor matches exactly once,
apply, run a test selector, restore, print `git status --porcelain`). One
wrote it as a Python script and noted it was "the third or fourth time."

The part that gets forgotten is the stale-anchor guard (#1390): a pattern
that no longer matches must not silently mutate nothing and let the test's
pre-existing state read as "the guard works" (#1450 added a deliberate
no-match row for exactly this reason).

## What this adds

`tools/mutate.sh <file> <anchor> <replacement> <test-cmd> [test-cmd-args...]`

- refuses unless `<anchor>` occurs **exactly once** in `<file>` (#1390) — zero
  matches is reported as **STALE** (a literal, greppable word, per #1450),
  more than one match is refused as ambiguous;
- refuses if `<replacement>` is byte-identical to `<anchor>` (a no-op
  mutation);
- takes ONE immutable snapshot of the file, counts and splices the mutation
  against that same snapshot (so those two steps cannot disagree by
  construction), then does a single explicit `cmp` against the live file
  immediately before writing — refusing (exit 10) if the file changed
  underneath it since the snapshot was taken;
- runs `<test-cmd>`'s own argv **directly** (no shell re-parsing — safer than
  `eval`/`bash -c`, and avoids requiring the caller to quote a compound
  command), captures its output and exit status;
- restores the file by **copy-back from that snapshot** — never `git
  checkout --`/`git restore`/`git reset --hard`, which this repo bans
  everywhere because worktrees share the parent repo's `.git` dir;
- asserts `git status --porcelain` is empty afterward and fails **loudly**
  (exit 9, `FATAL`) if it is not;
- prints the whole run in the shape multiple prior PRs already used by hand
  for pasting into a PR body:
  ```
  === mutation applied to <file> ===
  <captured test output>
  === <test-cmd> exit=<rc> ===
  git status after restore: '<porcelain output>'
  ```

Implementation note: `<anchor>`/`<replacement>` are matched and spliced as
**literal** text via awk's `index()`/`substr()`, reached through `ENVIRON`
(not `-v`, which backslash-escape-processes its value) — never through bash's
`${var/pattern/repl}`, which treats `*`/`?`/`[` as glob wildcards even when
the pattern variable was built with quotes. Source code routinely contains
all three (`[]int{...}`, `arr[0]`, `x * 2`); `tools/lib/mutate_test.sh` pins
a fixture containing all three as a regression guard. Every content read goes
through one `byte_awk()` helper (centralising `LC_ALL=C` — see review history
below).

## Review + simplify history (both gates run, both applied)

**Dedicated review subagent** (`.claude/skills/ir:code-review`, medium
effort) found 3 issues, all fixed and pushed:
- **HIGH**: every awk call measuring/matching file content needed `LC_ALL=C`
  — under a UTF-8 locale, gawk's `length()`/`index()`/`substr()` count
  Unicode codepoints, not bytes, so a file with one multi-byte character
  (this repo's own prose style — em dashes throughout) would falsely trip the
  byte-parity guard as "possible NUL byte" on a perfectly valid file.
- **MEDIUM**: the apply step re-read the file independently of the count
  guard with no check that the anchor still matched — a narrow TOCTOU
  window that could silently corrupt the file.
- **LOW**: the precondition guard misdiagnosed "not a git repository" as "the
  tree is dirty."

**`/simplify`** (4 parallel agents — reuse, simplification, efficiency,
altitude) found and fixed:
- reuse: `--help` reimplemented the established "print the header comment"
  one-liner already copied byte-for-byte into 5 other `tools/*.sh` scripts,
  but with a different awk program — now uses the identical one.
- altitude: `LC_ALL=C` was repeated at 3 call sites (a milder version of the
  same "whoever remembers this time" problem the tool exists to solve for
  its callers) — centralized into `byte_awk()`.
- altitude (deeper): restructured to the single-snapshot design described
  above, replacing the review's TOCTOU fix's second live re-read with one
  immutable read + one explicit live-vs-snapshot `cmp` right before the
  write. Same protection, narrower window, no duplicated match logic.
- simplification: two test scenarios bypassed the `run_mutate` test helper
  for no reason, and one assertion didn't match this file's own idiom — all
  three fixed.
- **Skipped, noted rather than argued with**: simplification's suggestion to
  fold exit codes 2/5/6 into the same generic code as 4. Kept distinct —
  altitude's review judged the current one-code-per-guard structure the
  right depth, and the TOCTOU code (10) is already asserted by exact value
  in the test suite.
- efficiency: no changes — both the multi-read pattern and the ~15
  fresh-scratch-repo test fixtures were measured and found negligible/
  correctly justified (isolation avoids the `git reset --hard`/stash hazard
  this repo bans repo-wide).

## Self-test evidence

This is process tooling with no "before the fix" runtime defect to
reproduce, so per `docs/testing-philosophy.md` its own obligation is a
self-test: every guard is deliberately violated and shown to trigger its own
named failure mode, plus a normal run is shown to restore the file
byte-identical (via direct `cmp`, not just "no git diff"). Committed as
`tools/lib/mutate_test.sh`, auto-discovered by `tools/preflight.sh`'s `tools`
gate.

Verified locally, all green (re-verified after each round of fixes):
```
$ bash tools/lib/mutate_test.sh
...
mutate_test: ALL PASS
```
Covered rows: success + byte-identical restore, a failing test command's red
output surfacing without being swallowed, a glob-metacharacter anchor, STALE
(0 matches), ambiguous (>1 matches), no-op replacement, empty anchor, missing
file, dirty-tree precondition, not-a-git-repo (distinct from dirty-tree),
embedded-NUL byte-parity refusal, a live multi-byte-UTF-8 file under a real
gawk + `en_US.UTF-8` (skips loudly if gawk isn't installed; a static source
pin still catches a regression either way), the TOCTOU guard (deterministic,
via a faked `cmp`), missing test command, and the post-restore-dirty FATAL
guard.

```
$ tools/preflight.sh --only tools   → PASS (shell-lib-suite: found 23, ran 23, failed 0)
$ tools/preflight.sh --only bash    → PASS (tools/mutate.sh, tools/lib/mutate_test.sh both clean)
$ tools/preflight.sh --only posix   → PASS (unaffected — both files are #!/usr/bin/env bash)
$ tools/preflight.sh --only skills  → PASS (unaffected)
```

`go`/`web`/`arch`/`swift`/`security` gates are untouched by this diff (no Go,
Swift, or web files changed); the pre-push hook's `--changed` scoping ran and
passed on every push.

## Interface note for #1748/#1751/#1754/#1756

This is the CLI shape those four issues should assume:

```
tools/mutate.sh <file> <anchor> <replacement> <test-cmd> [test-cmd-args...]
```

`<test-cmd>` is the test command's own argv (e.g. `go test ./core/foo/... -run
TestBar -v`), executed directly — not a single shell string. For compound
shell behavior (pipes, `&&`), pass `bash -c '...'` explicitly as the argv.
`tools/mutate.sh --help` prints the full usage, exit-code table (0 success,
1 usage, 2–10 one per named guard), and rationale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)