### PR TITLE
test(services): isolate hook-repair gate 2's real, independent property (#1751)

### DIFF
--- a/core/application/services/hook_reverify.go
+++ b/core/application/services/hook_reverify.go
@@ -50,9 +50,18 @@
 // and the write that follows may wait on a mutex behind an in-flight wizard
 // answer. A background repair that outlives consent would break #570 more
 // thoroughly than the bug it fixes, so the loop owns no write path of its own —
-// it can only ask the service, and the service can say no. Each of the three
-// has been individually deleted and seen to turn a test red; see
-// hook_reverify_gate_internal_test.go for the one that only a race can reach.
+// it can only ask the service, and the service can say no.
+//
+// Gates 1 and 3 have each been individually deleted and seen to turn a test
+// red — see hook_reverify_gate_internal_test.go for gate 3, the one that only
+// a race can reach. Gate 2 cannot be shown that way: gate 3 re-derives the
+// identical fact from the same recorded state immediately before the closure
+// runs, so no write-observing test can ever tell "gate 2 refused" from "gate 2
+// let it through and gate 3 refused a moment later" (#1751, mutation-verified
+// via tools/mutate.sh). Gate 2's own, independently provable property is
+// contention avoidance, not write safety — see
+// hook_reverify_gate_internal_test.go's header and
+// TestRepairGrantedHookInstall_DoesNotContendForEffectMuWhenNotGranted.
 package services
 
 import (

--- a/core/application/services/hook_reverify_gate_internal_test.go
+++ b/core/application/services/hook_reverify_gate_internal_test.go
@@ -13,15 +13,14 @@ import (
 // The third consent gate on the #1372 repair path, tested where it can actually
 // be reached.
 //
-// RepairGrantedHookInstall has three independent refusals and they cover
-// different windows:
+// RepairGrantedHookInstall has three refusals and they cover different
+// windows:
 //
 //  1. the verifier loop asks Granted before it reads the file (proved in
 //     hook_reverify_test.go, and by deleting that check: the revoke test goes
 //     red);
 //  2. RepairGrantedHookInstall re-reads the recorded state before it queues
-//     anything (proved by deleting it: the on-disk test's direct-call arm goes
-//     red);
+//     anything;
 //  3. runEffects re-reads the state a THIRD time, under effectMu, immediately
 //     before running the closure.
 //
@@ -38,6 +37,38 @@ import (
 // state already denied, and asserts the closure never runs. That is the same
 // stale-effect skip an interactive superseding answer relies on; #1372 reuses
 // it rather than adding a fourth check that could disagree with it.
+//
+// # Gate 2 does NOT independently prove what it looks like it proves (#1751)
+//
+// The header above used to claim gate 2's deletion "is proved by deleting it:
+// the on-disk test's direct-call arm goes red"
+// (TestReverify_RevokedPermissionNeverTouchesTheFileOnDisk in
+// hook_reverify_test.go). That claim was never mutation-checked and is false:
+// tools/mutate.sh, deleting only gate 2's `!granted` refusal, leaves that test
+// — and every other test in core/application/services and
+// core/adapters/inbound/agents/kirocli — green. The reason is structural, not
+// a gap in test-writing: gate 3 re-derives the IDENTICAL fact (is this key
+// currently Granted?) from the same s.set, immediately before the closure
+// runs, against the same hardcoded target (StateGranted) RepairGrantedHookInstall
+// always passes. For every input that would trip gate 2, either gate 3 also
+// trips (state genuinely still not-Granted — the common case) or consent
+// changed to Granted in between (in which case running the effect is correct,
+// not a violation). There is no third case, so no write-observing test —
+// existing or new — can ever separate "gate 2 refused" from "gate 2 let it
+// through and gate 3 refused a moment later". A "hold gate 3 open" test in the
+// shape AssertPermissionGated's fourth arm uses for permission KEYS does not
+// carry over here: that arm's isolation works by driving one axis (a key)
+// independently of another; gates 2 and 3 are not two axes, they are the same
+// axis read twice, so there is nothing to hold open.
+//
+// What gate 2 alone DOES independently buy, and what
+// TestRepairGrantedHookInstall_DoesNotContendForEffectMuWhenNotGranted below
+// pins: a repair for a permission that was never granted never takes
+// effectMu at all. Removing gate 2 is invisible to every write-observing test
+// but changes this — the call instead walks into runEffects and blocks on
+// whatever already holds that lock (an in-flight wizard answer, most likely),
+// which is a real regression (every background repair pass now stalls behind
+// unrelated foreground work) even though it moves zero bytes on disk.
 func TestRunEffects_SkipsAGrantEffectWhoseStateIsNoLongerGranted(t *testing.T) {
 	// The user has revoked. This is the state RepairGrantedHookInstall's own
 	// pre-check would have seen a moment later — but the repair got past it and
@@ -150,6 +181,52 @@ func TestRepairGrantedHookInstall_RevokedWhileWaitingOnTheEffectLockIsNotAttempt
 
 	if applies, _ := f.counts(); applies != 0 {
 		t.Errorf("Apply ran %d times for a revoked permission, want 0", applies)
+	}
+}
+
+// TestRepairGrantedHookInstall_DoesNotContendForEffectMuWhenNotGranted is gate
+// 2's own independently verifiable property (issue #1751). Every test above
+// that watches Apply/Remove counts, attempted, or err cannot tell "gate 2
+// refused" from "gate 2 let it through and gate 3 refused a moment later" —
+// see this file's header for why that is not a testing gap but a structural
+// fact about the two checks. Mutation-verified: deleting gate 2's `!granted`
+// refusal alone leaves the entire core/application/services and
+// core/adapters/inbound/agents/kirocli suites green.
+//
+// What gate 2 alone buys, and the one thing this test can pin, is CONTENTION:
+// RepairGrantedHookInstall must not take effectMu at all for a permission
+// that was never granted. Hold effectMu locked here, standing in for a slow
+// in-flight wizard answer, and call the repair path for a DENIED permission —
+// with gate 2 intact it returns without ever touching effectMu; with gate 2
+// removed it walks straight into runEffects and blocks on the same lock,
+// which this test catches as a timeout rather than a silent pass.
+//
+// Vacuity guard: this fixture IS capable of blocking on effectMu — the
+// GRANTED counterpart above
+// (TestRepairGrantedHookInstall_RevokedWhileWaitingOnTheEffectLockIsNotAttempted)
+// holds the same lock and shows the call parking on it — so a pass here means
+// gate 2 actually short-circuited, not that this fixture never contends for
+// anything.
+func TestRepairGrantedHookInstall_DoesNotContendForEffectMuWhenNotGranted(t *testing.T) {
+	f := newGateFixture(permission.StateDenied)
+
+	f.svc.effectMu.Lock() // stand in for a slow, in-flight wizard answer
+	defer f.svc.effectMu.Unlock()
+
+	done := make(chan struct{})
+	go func() {
+		f.svc.RepairGrantedHookInstall("testagent", "hooks")
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// gate 2 refused before ever touching effectMu — correct.
+	case <-time.After(2 * time.Second):
+		t.Fatal("RepairGrantedHookInstall blocked on effectMu for a permission " +
+			"that was never granted — gate 2's pre-check did not run (or was " +
+			"removed), so an unrelated in-flight wizard answer now stalls every " +
+			"background repair pass, for every adapter, not just this one")
 	}
 }
 

--- a/core/application/services/permission_service.go
+++ b/core/application/services/permission_service.go
@@ -530,10 +530,23 @@ func (s *PermissionService) HookChannelReady(agentName string) bool {
 // declining to write is the correct outcome, not a failure to be retried.
 //
 // There are two consent checks on this path and they cover different windows.
-// The pre-check below is the one that refuses every ordinary revoked caller —
-// it is a real gate, not decoration, and deleting it is visible as a red test.
-// But it can only be as fresh as the instant it was asked, and the write that
-// follows may wait on a mutex first. So the write itself is not performed here:
+// The pre-check below refuses every ordinary revoked caller before it ever
+// queues anything — but that refusal is NOT independently visible in a
+// write-observing test (issue #1751, mutation-verified via tools/mutate.sh):
+// runEffects' re-read below (gate 3) re-derives the identical fact from the
+// same recorded state, immediately before the closure runs, against the same
+// hardcoded target (StateGranted) this function always passes. Deleting the
+// pre-check alone therefore leaves every Apply/Remove/attempted/err assertion
+// in core/application/services and core/adapters/inbound/agents/kirocli green
+// — see hook_reverify_gate_internal_test.go's header for why no test can ever
+// tell the two apart by their output.
+//
+// What the pre-check alone buys, and the one thing a test CAN pin
+// (TestRepairGrantedHookInstall_DoesNotContendForEffectMuWhenNotGranted), is
+// CONTENTION: a repair for a permission that was never granted must never
+// take effectMu at all, because the write that would follow may have to wait
+// on that mutex first — behind an in-flight wizard answer, for however long
+// that answer's own effect takes. So the write itself is not performed here:
 // it goes through runEffects, exactly as a wizard answer does, which means the
 // background repair inherits every guarantee the interactive path already had
 // and cannot drift from it:


### PR DESCRIPTION
Closes #1751.

## What this does

`hook_reverify.go` documents three independent consent refusals on the
#1372 repair path. Issue #1751 (found while QA-ing #1749) asked whether
gate 2 (`RepairGrantedHookInstall`'s own pre-check) and gate 3
(`runEffects`' re-read under `effectMu`) are each individually covered by
a test — a mutation sweep in #1749 found that deleting either ALONE left
the suite green, and only deleting both reddened.

## Investigation, with mutation evidence (`tools/mutate.sh`)

Ran both single-gate mutations against the full
`core/application/services` + `core/adapters/inbound/agents/kirocli`
suites (not just the kiro-cli-scoped test #1749's own check used):

- **Deleting gate 3 alone** already reddens three existing tests in
  `hook_reverify_gate_internal_test.go`
  (`TestRunEffects_SkipsAGrantEffectWhoseStateIsNoLongerGranted`,
  `TestRunEffects_ReportsZeroWhenEveryEffectIsSkipped`,
  `TestRepairGrantedHookInstall_RevokedWhileWaitingOnTheEffectLockIsNotAttempted`).
  Gate 3 was already individually covered — this file's own header just
  didn't say so.
- **Deleting gate 2 alone** leaves *every* write-observing test green,
  including `TestReverify_RevokedPermissionNeverTouchesTheFileOnDisk`,
  which this same file's header claimed ("proved by deleting it: the
  on-disk test's direct-call arm goes red") would catch it. That claim
  was never mutation-checked and is false — verified directly:

  ```
  $ tools/mutate.sh core/application/services/permission_service.go \
      '<gate 2's !granted check>' '<removed>' \
      go test ./core/application/services/... \
      -run TestReverify_RevokedPermissionNeverTouchesTheFileOnDisk -v -count=1
  --- PASS: TestReverify_RevokedPermissionNeverTouchesTheFileOnDisk (0.00s)
  ```

The reason is structural, not a test-writing gap: gate 3 re-derives the
IDENTICAL fact (is this key currently Granted?) from the same `s.set`,
immediately before the closure runs, against the same hardcoded target
(`StateGranted`) `RepairGrantedHookInstall` always passes. For every input
that trips gate 2, either gate 3 also trips (state genuinely still
not-Granted — the common case), or consent changed to Granted in between
(in which case running the effect is correct, not a violation). There is
no third case, so no write-observing test — existing or new — can ever
separate "gate 2 refused" from "gate 2 let it through and gate 3 refused a
moment later".

`AssertPermissionGated`'s fourth-arm shape (hold one axis open, exercise,
observe) doesn't transfer here: that helper isolates a permission KEY from
OTHER keys — two independent axes. Gates 2 and 3 are not two axes; they
read the same state twice. There is nothing to hold open for a
write-observing test.

## What I added instead

Gate 2 DOES have one real, independently-provable effect: it keeps a
non-granted repair from ever taking `effectMu`. Added
`TestRepairGrantedHookInstall_DoesNotContendForEffectMuWhenNotGranted`,
which holds `effectMu` (standing in for a slow in-flight wizard answer)
and asserts a repair for a DENIED permission returns without ever
contending for it.

Mutation-verified this new test in both directions:

- **Gate 2 removed alone** → new test REDDENS (confirmed: "RepairGrantedHookInstall
  blocked on effectMu for a permission that was never granted").
- **Gate 3 removed alone** → new test stays GREEN, while the three
  existing gate-3 tests redden as expected — confirming true isolation
  (the new test is specific to gate 2, unaffected by gate 3's removal).

Also corrected the two docstrings that asserted gate 2's deletion was
"visible as a red test" without that ever having been mutation-checked:
this file's own header, and `RepairGrantedHookInstall`'s docstring in
`permission_service.go`.

No production behavior changes — docstring corrections plus one new test.

## Judgment call (per the issue's own framing)

The issue asked me to decide, and justify, whether the per-gate test
surface was worth it. Given the mutation evidence above, a literal
"gate 2 in isolation, holding gate 3 open" write-observing test is not
just costly, it is not constructible — any such test is either vacuously
satisfied whenever gate 3 is intact, or requires disabling gate 3's
actual mechanism (not a legitimate test wiring). So instead of forcing
the issue's literal ask, I tested what gate 2 actually, independently
provides (contention avoidance) and corrected the two comments that were
making an unverified claim about what removing it would do — the
AGENTS.md "dismissals carry evidence" rule applies to code comments, not
just triage write-ups.

## Files touched

- `core/application/services/hook_reverify_gate_internal_test.go` — new
  test + corrected header comment.
- `core/application/services/permission_service.go` — corrected
  docstring only (no behavior change).

## Gates run

- `go test ./core/application/services/... ./core/adapters/inbound/agents/kirocli/... -race -count=1` — PASS
- `tools/preflight.sh --only go` — PASS
- `tools/preflight.sh --only arch` — PASS (composite 7.893010788442787 → 7.892982424902501, no regression)
- `tools/preflight.sh --only tools` — PASS
- `tools/preflight.sh --only security` — PASS
- pre-push hook (`tools/preflight.sh --changed --budget 540`) — PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)