### PR TITLE
test(rig): promote-time hook check, spawn-path unapplied_grants, coexist prose (#1754)

### DIFF
--- a/.claude/skills/ir:onboarding-factory/record/SKILL.md
+++ b/.claude/skills/ir:onboarding-factory/record/SKILL.md
@@ -56,6 +56,22 @@ description: >
      the bind addr defaults to `127.0.0.1:7838` and the precheck refuses 7837
      (it would clash with production). Pick another free port if 7838 is taken.
 
+     **Hook delivery reaching the coexisting daemon is not one adapter-neutral
+     guarantee** (#1754). URL-delivery adapters (claudecode, codex, copilot)
+     bake the daemon address into the installed entry at install time, so they
+     always reach it. Beacon-delivery adapters — every adapter importing
+     `core/pkg/hookbeacon` (gemini-cli, kiro-cli, mistral-vibe) — carry NO
+     address in the entry at all; `irrlichd hook-post` resolves the daemon from
+     its OWN process environment at fire time, a child of the CLI's tmux pane.
+     `of record run` / `run-cell.sh` already export and forward
+     `IRRLICHT_BIND_ADDR` into that pane for you
+     (`TestEveryBeaconAdapterDriverPassesTheDaemonAddress` in
+     `tools/onboarding-factory/internal/righome` enforces it), so this needs no
+     action through the normal path — but it is why driving a beacon-delivery
+     adapter's CLI any other way silently posts every hook at production
+     instead, and the resulting recording looks complete and healthy with zero
+     hook events in it (#1735).
+
    **Onboarding a NEW adapter is always the coexist case**, by construction: the
    running `irrlichd` is an installed release whose binary has no such adapter
    compiled in, so it observes nothing no matter how healthy it looks. Coexist

--- a/.claude/skills/ir:onboarding-factory/record/SKILL.md
+++ b/.claude/skills/ir:onboarding-factory/record/SKILL.md
@@ -60,11 +60,13 @@ description: >
      guarantee** (#1754). URL-delivery adapters (claudecode, codex, copilot)
      bake the daemon address into the installed entry at install time, so they
      always reach it. Beacon-delivery adapters — every adapter importing
-     `core/pkg/hookbeacon` (gemini-cli, kiro-cli, mistral-vibe) — carry NO
-     address in the entry at all; `irrlichd hook-post` resolves the daemon from
-     its OWN process environment at fire time, a child of the CLI's tmux pane.
-     `of record run` / `run-cell.sh` already export and forward
-     `IRRLICHT_BIND_ADDR` into that pane for you
+     `core/pkg/hookbeacon`; as of this writing antigravity, gemini-cli, hermes,
+     kiro-cli, opencode, pi and mistral-vibe, but that list is not the source
+     of truth and will drift — `righome.BeaconAdapters` (derived from the
+     import graph) is — carry NO address in the entry at all; `irrlichd
+     hook-post` resolves the daemon from its OWN process environment at fire
+     time, a child of the CLI's tmux pane. `of record run` / `run-cell.sh`
+     already export and forward `IRRLICHT_BIND_ADDR` into that pane for you
      (`TestEveryBeaconAdapterDriverPassesTheDaemonAddress` in
      `tools/onboarding-factory/internal/righome` enforces it), so this needs no
      action through the normal path — but it is why driving a beacon-delivery
@@ -225,6 +227,17 @@ This copies `events.jsonl` + the transcript + a `manifest.json` into a new
 write any artifacts cache into `metadata.json`: the on-disk `recordings/<name>/`
 tree IS the record (the single source of truth). The replay golden is added by
 Step 5; nothing else needs wiring.
+
+**If `<agent>` declares a hooks permission and this recording carries no
+`hook_received` event, promote-recording.sh prompts rather than promoting
+silently** (#1754) — the exact failure mode #1735 took three attempts to
+diagnose. When the scenario genuinely produces no hook (confirm against `of
+coverage --hooks` if unsure), that's a real "yes, intended" — since you run
+non-interactively, answer it with `IRRLICHT_PROMOTE_HOOKFREE_OK=1
+tools/promote-recording.sh <staging-dir> <agent> <folder>` rather than
+retrying blind against an unanswerable prompt. Anything else — a scenario that
+SHOULD have produced a hook — is the bug this check exists to catch: go back
+to Step 2's diagnosis rather than overriding it.
 
 **Retry exactly once** on a `timeout` / `transcript_missing` outcome (often a
 lazy-transcript nudge or trailing-sleep timing issue). On a second failure, or

--- a/tools/onboarding-factory/cmd/of/hookcheck.go
+++ b/tools/onboarding-factory/cmd/of/hookcheck.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"fmt"
+	"io"
+
+	"irrlicht/tools/onboarding-factory/internal/hookcov"
+)
+
+// runHookCheck answers, for ONE staged recording, the question
+// `of coverage --hooks` answers for the whole committed corpus: does <agent>
+// declare a hooks permission, and does THIS events.jsonl carry a
+// hook_received event attributable to it?
+//
+// promote-recording.sh is the caller (#1754): it is the last gate before a
+// staged capture becomes committed truth, and a hooks-declaring adapter's
+// hook-free recording reaching that gate unremarked is exactly the failure
+// mode #1735 took three attempts to diagnose — a complete, healthy-looking
+// recording (driver_exit_reason=ok, completeness=complete) whose hook channel
+// never fired, with nothing anywhere saying so. Always emits JSON: the only
+// caller is a script that parses it with jq, not a human reading a table.
+func runHookCheck(args []string, stdout, stderr io.Writer) int {
+	fs := newFlagSet("of hookcheck")
+	var (
+		agent  = fs.String("agent", "", "adapter slug (as used under replaydata/agents/<agent>)")
+		events = fs.String("events", "", "path to the staged (or committed) events.jsonl")
+	)
+	if err := fs.Parse(args); err != nil {
+		return exitUsage
+	}
+	if *agent == "" || *events == "" {
+		fmt.Fprintln(stderr, "of hookcheck: --agent and --events are required")
+		return exitUsage
+	}
+
+	res := hookCheckResult{
+		Agent:         *agent,
+		DeclaresHooks: hookcov.Declared()[*agent],
+		HasHookEvent:  hookcov.HasOwnHookEvent(*events, *agent),
+	}
+	if err := writeJSON(stdout, res); err != nil {
+		fmt.Fprintf(stderr, "of hookcheck: encode: %v\n", err)
+		return exitUsage
+	}
+	return exitOK
+}
+
+// hookCheckResult is the whole answer: nothing here needs the corpus counts
+// hookcov.AdapterCoverage carries (cells/recordings/status) — this is a
+// yes/no about one file, not a rollup.
+type hookCheckResult struct {
+	Agent         string `json:"agent"`
+	DeclaresHooks bool   `json:"declares_hooks"`
+	HasHookEvent  bool   `json:"has_hook_event"`
+}

--- a/tools/onboarding-factory/cmd/of/hookcheck_test.go
+++ b/tools/onboarding-factory/cmd/of/hookcheck_test.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"testing"
+)
+
+// TestHookCheckDeclaresAndHasEvent pins the four-cell decision table
+// promote-recording.sh's prompt (#1754) is built on: declares_hooks joins the
+// daemon's adapter registry (hookcov.Declared, real code, not fixture data —
+// codex and claudecode declare hooks, aider does not); has_hook_event reads
+// the ONE staged events.jsonl this invocation names, via the same
+// session-attribution logic hookcov.Coverage uses for the committed corpus
+// (hookcov.HasOwnHookEvent), so a co-resident adapter's hook event cannot be
+// mistaken for this adapter's own.
+func TestHookCheckDeclaresAndHasEvent(t *testing.T) {
+	root := t.TempDir()
+
+	withHook := filepath.Join(root, "with-hook", "events.jsonl")
+	write(t, withHook, `{"seq":1,"ts":"2026-05-01T00:00:00Z","kind":"transcript_new","session_id":"s","adapter":"codex"}`+"\n"+
+		`{"seq":2,"ts":"2026-05-01T00:00:01Z","kind":"hook_received","session_id":"s","hook_name":"Stop"}`+"\n")
+
+	noHook := filepath.Join(root, "no-hook", "events.jsonl")
+	write(t, noHook, `{"seq":1,"ts":"2026-05-01T00:00:00Z","kind":"transcript_new","session_id":"s","adapter":"codex"}`+"\n")
+
+	// hook_received present, but attributed to a DIFFERENT adapter's session —
+	// must read as has_hook_event=false for codex, the same distinction
+	// hookcov's own attribution guards against (#1768).
+	othersHook := filepath.Join(root, "others-hook", "events.jsonl")
+	write(t, othersHook, `{"seq":1,"ts":"2026-05-01T00:00:00Z","kind":"transcript_new","session_id":"s","adapter":"claudecode"}`+"\n"+
+		`{"seq":2,"ts":"2026-05-01T00:00:01Z","kind":"hook_received","session_id":"s","hook_name":"Stop"}`+"\n")
+
+	cases := []struct {
+		name         string
+		agent        string
+		events       string
+		wantDeclares bool
+		wantHasHook  bool
+	}{
+		{"declares hooks, has one", "codex", withHook, true, true},
+		{"declares hooks, has none — the GAP promote must ask about", "codex", noHook, true, false},
+		{"declares hooks, hook belongs to a co-resident adapter", "codex", othersHook, true, false},
+		{"declares no hooks, has none", "aider", noHook, false, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			code, out, errs := runOf("hookcheck", "--agent", c.agent, "--events", c.events)
+			if code != exitOK {
+				t.Fatalf("exit=%d stderr=%s", code, errs)
+			}
+			var res hookCheckResult
+			if err := json.Unmarshal([]byte(out), &res); err != nil {
+				t.Fatalf("bad json: %v\n%s", err, out)
+			}
+			if res.Agent != c.agent {
+				t.Errorf("agent: got %q want %q", res.Agent, c.agent)
+			}
+			if res.DeclaresHooks != c.wantDeclares {
+				t.Errorf("declares_hooks: got %v want %v", res.DeclaresHooks, c.wantDeclares)
+			}
+			if res.HasHookEvent != c.wantHasHook {
+				t.Errorf("has_hook_event: got %v want %v", res.HasHookEvent, c.wantHasHook)
+			}
+		})
+	}
+}
+
+// TestHookCheckMissingEventsFile is the never-recorded / not-yet-flushed
+// case: an unreadable or absent events.jsonl must read as has_hook_event
+// false rather than erroring the whole check out — hasOwnHookEvent already
+// treats a missing sidecar this way; this pins that `of hookcheck` inherits
+// it rather than surfacing a bare Go error to the bash caller.
+func TestHookCheckMissingEventsFile(t *testing.T) {
+	code, out, errs := runOf("hookcheck", "--agent", "codex", "--events", "/nonexistent/events.jsonl")
+	if code != exitOK {
+		t.Fatalf("exit=%d stderr=%s", code, errs)
+	}
+	var res hookCheckResult
+	if err := json.Unmarshal([]byte(out), &res); err != nil {
+		t.Fatalf("bad json: %v\n%s", err, out)
+	}
+	if res.HasHookEvent {
+		t.Errorf("has_hook_event: got true for a missing file, want false")
+	}
+	if !res.DeclaresHooks {
+		t.Errorf("declares_hooks: codex should still declare hooks regardless of the events file")
+	}
+}
+
+// TestHookCheckRequiresFlags locks the usage error — a script that forgot a
+// flag must get exitUsage, not a silent all-false answer that would read as
+// "no problem here".
+func TestHookCheckRequiresFlags(t *testing.T) {
+	if code, _, _ := runOf("hookcheck", "--agent", "codex"); code != exitUsage {
+		t.Errorf("missing --events: got exit %d, want %d", code, exitUsage)
+	}
+	if code, _, _ := runOf("hookcheck", "--events", "/tmp/x"); code != exitUsage {
+		t.Errorf("missing --agent: got exit %d, want %d", code, exitUsage)
+	}
+}

--- a/tools/onboarding-factory/cmd/of/main.go
+++ b/tools/onboarding-factory/cmd/of/main.go
@@ -10,6 +10,7 @@
 //	of status   [--agent a] [--scenario s] [--runs] [--summary] [--json]  coverage / run status
 //	of validate [--json]                                                  schema + referential integrity
 //	of coverage [--hooks] [--json]                                        derived rollup, or hook coverage
+//	of hookcheck --agent a --events e                                     one staged recording's hook coverage
 //
 // Exit codes (matching the sibling cmd tools):
 //
@@ -48,7 +49,8 @@ const usage = `usage:
   of verify --agent a --scenario s [--folder f] [--json]
   of record run --agent a --scenario s [--attach] [--dry-run]
   of record prereq-check --agent a
-  of record verify --agent a --scenario s`
+  of record verify --agent a --scenario s
+  of hookcheck --agent a --events events.jsonl`
 
 func main() { os.Exit(run(os.Args[1:], os.Stdout, os.Stderr)) }
 
@@ -74,6 +76,8 @@ func run(args []string, stdout, stderr io.Writer) int {
 		return runVerify(args[1:], stdout, stderr)
 	case "record":
 		return runRecord(args[1:], stdout, stderr)
+	case "hookcheck":
+		return runHookCheck(args[1:], stdout, stderr)
 	default:
 		fmt.Fprintln(stderr, usage)
 		return exitUsage

--- a/tools/onboarding-factory/internal/hookcov/hookcov.go
+++ b/tools/onboarding-factory/internal/hookcov/hookcov.go
@@ -281,6 +281,17 @@ func hasOwnHookEvent(eventsPath, adapterSlug string) bool {
 	return anyHookEventOwnedBy(events, sessionAdapters(events), adapterSlug)
 }
 
+// HasOwnHookEvent is hasOwnHookEvent, exported for a caller asking the same
+// question about ONE staged candidate recording rather than the whole
+// committed corpus hookBearingRecordings walks. `of hookcheck` is that caller
+// (#1754): promote-recording.sh's promote-time prompt needs exactly this
+// attribution logic — not a cruder "does events.jsonl contain the string
+// hook_received anywhere" check, which would misfire on a co-resident
+// adapter's hook events the same way hookBearingRecordings would without it.
+func HasOwnHookEvent(eventsPath, adapterSlug string) bool {
+	return hasOwnHookEvent(eventsPath, adapterSlug)
+}
+
 // sessionAdapters maps session_id -> the on-disk slug of the adapter a
 // SIBLING event (never hook_received itself, which carries no Adapter)
 // tagged that session with. One pass over the whole recording, built once

--- a/tools/onboarding-factory/scripts/lib/promote-hookcheck.sh
+++ b/tools/onboarding-factory/scripts/lib/promote-hookcheck.sh
@@ -83,11 +83,20 @@ default_hookfree_check() {
     echo "$json"
     return 1
   fi
-  if ! declares="$(jq -r '.declares_hooks' <<<"$json" 2>/dev/null)" || [[ -z "$declares" ]]; then
+  # Checked against the literal words true/false, not just non-empty: a
+  # missing or null field makes jq -r print the 4-byte string "null", which
+  # IS non-empty and would otherwise slip past an emptiness-only guard and
+  # silently read as declares_hooks=false downstream — coercing a schema
+  # drift in `of hookcheck`'s own output into "nothing to ask" instead of a
+  # loud refusal. A validator that can't parse its input checks MORE, never
+  # less (AGENTS.md).
+  if ! declares="$(jq -r '.declares_hooks' <<<"$json" 2>/dev/null)" \
+    || { [[ "$declares" != "true" ]] && [[ "$declares" != "false" ]]; }; then
     echo "of hookcheck produced unparseable output: $json"
     return 1
   fi
-  if ! has_hook="$(jq -r '.has_hook_event' <<<"$json" 2>/dev/null)" || [[ -z "$has_hook" ]]; then
+  if ! has_hook="$(jq -r '.has_hook_event' <<<"$json" 2>/dev/null)" \
+    || { [[ "$has_hook" != "true" ]] && [[ "$has_hook" != "false" ]]; }; then
     echo "of hookcheck produced unparseable output: $json"
     return 1
   fi

--- a/tools/onboarding-factory/scripts/lib/promote-hookcheck.sh
+++ b/tools/onboarding-factory/scripts/lib/promote-hookcheck.sh
@@ -50,8 +50,7 @@ promote_hookcheck() {
     [[ -n "$result" ]] && echo "$result" >&2
     return 2
   fi
-  declares="$(awk '{print $1}' <<<"$result")"
-  has_hook="$(awk '{print $2}' <<<"$result")"
+  read -r declares has_hook <<<"$result"
 
   [[ "$declares" == "true" ]] || return 0    # doesn't declare hooks — nothing to ask
   [[ "$has_hook" != "true" ]] || return 0    # declares hooks AND has one — the healthy case
@@ -83,24 +82,24 @@ default_hookfree_check() {
     echo "$json"
     return 1
   fi
-  # Checked against the literal words true/false, not just non-empty: a
-  # missing or null field makes jq -r print the 4-byte string "null", which
-  # IS non-empty and would otherwise slip past an emptiness-only guard and
-  # silently read as declares_hooks=false downstream — coercing a schema
-  # drift in `of hookcheck`'s own output into "nothing to ask" instead of a
-  # loud refusal. A validator that can't parse its input checks MORE, never
-  # less (AGENTS.md).
-  if ! declares="$(jq -r '.declares_hooks' <<<"$json" 2>/dev/null)" \
-    || { [[ "$declares" != "true" ]] && [[ "$declares" != "false" ]]; }; then
-    echo "of hookcheck produced unparseable output: $json"
-    return 1
-  fi
-  if ! has_hook="$(jq -r '.has_hook_event' <<<"$json" 2>/dev/null)" \
-    || { [[ "$has_hook" != "true" ]] && [[ "$has_hook" != "false" ]]; }; then
-    echo "of hookcheck produced unparseable output: $json"
-    return 1
-  fi
+  declares="$(hookfree_parse_bool_field "$json" declares_hooks)" || { echo "of hookcheck produced unparseable output: $json"; return 1; }
+  has_hook="$(hookfree_parse_bool_field "$json" has_hook_event)" || { echo "of hookcheck produced unparseable output: $json"; return 1; }
   echo "$declares $has_hook"
+}
+
+# hookfree_parse_bool_field <json> <field> prints <json>'s .<field> and
+# succeeds only when it is the literal word true or false. Checked against
+# those two words, not just non-empty: a missing or null field makes jq -r
+# print the 4-byte string "null", which IS non-empty and would otherwise slip
+# past an emptiness-only guard and silently read as false downstream —
+# coercing a schema drift in `of hookcheck`'s own output into "nothing to ask"
+# instead of a loud refusal. A validator that can't parse its input checks
+# MORE, never less (AGENTS.md).
+hookfree_parse_bool_field() {
+  local json="$1" field="$2" v
+  v="$(jq -r ".$field" <<<"$json" 2>/dev/null)" || return 1
+  [[ "$v" == "true" || "$v" == "false" ]] || return 1
+  echo "$v"
 }
 
 # default_hookfree_confirm — the real confirm_fn: an explicit non-interactive

--- a/tools/onboarding-factory/scripts/lib/promote-hookcheck.sh
+++ b/tools/onboarding-factory/scripts/lib/promote-hookcheck.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# promote-hookcheck.sh — the promote-time hook-coverage prompt (#1754).
+#
+# A hooks-declaring adapter's staged recording that carries no hook_received
+# event attributable to it is exactly the failure mode #1735 took three
+# attempts to diagnose: the recording completes, driver_exit_reason=ok,
+# completeness=complete, and nothing anywhere says the hook channel under
+# test never fired. promote-recording.sh is the LAST gate before a fixture
+# becomes committed truth, so this is where the question finally gets asked.
+#
+# A hook-free recording of a hooks-declaring adapter is sometimes legitimate —
+# the scenario genuinely produces no hook, and `of coverage --hooks` already
+# reports the corpus-wide population — so this is a PROMPT / explicit
+# override, never a hard failure: the operator must say "yes, intended"
+# rather than being blocked outright.
+#
+# promote_hookcheck takes check_fn and confirm_fn BY NAME (bash resolves a
+# bare word to a shell function, same as atomic-promote.sh's injected
+# populate/validate functions) so promote-hookcheck_test.sh can pin the
+# decision table with fakes — no `go run`, no real terminal, no live daemon.
+#
+#   check_fn agent events_path   -> prints "<declares_hooks> <has_hook_event>"
+#                                    (each the literal word true/false) on
+#                                    stdout and exits 0; a non-zero exit means
+#                                    the check itself could not answer, and
+#                                    its stdout+stderr is the diagnostic.
+#   confirm_fn (no args)         -> exit 0 = operator confirmed intended,
+#                                    non-zero = refused, declined, or no
+#                                    override available (e.g. non-interactive
+#                                    with nothing set).
+#
+# Returns:
+#   0 — promote (either the healthy case, or the operator confirmed intended)
+#   1 — refuse: hook-free recording of a hooks-declaring adapter, not confirmed
+#   2 — refuse: check_fn itself failed to run. AGENTS.md: "a verification
+#       mechanism must fail loudly when it cannot run" — a broken check must
+#       never silently read as "nothing to see", so this is a REFUSAL, not a
+#       skip.
+#
+# Usage — after the staged events.jsonl is known to exist:
+#   source "$SCRIPT_DIR/lib/promote-hookcheck.sh"
+#   promote_hookcheck "$AGENT" "$STAGED_DIR/events.jsonl" \
+#     default_hookfree_check default_hookfree_confirm || exit 1
+promote_hookcheck() {
+  local agent="$1" events_path="$2" check_fn="$3" confirm_fn="$4"
+  local result declares has_hook
+
+  if ! result="$("$check_fn" "$agent" "$events_path")"; then
+    echo "promote: hook-coverage check failed to run — refusing to promote blind" >&2
+    [[ -n "$result" ]] && echo "$result" >&2
+    return 2
+  fi
+  declares="$(awk '{print $1}' <<<"$result")"
+  has_hook="$(awk '{print $2}' <<<"$result")"
+
+  [[ "$declares" == "true" ]] || return 0    # doesn't declare hooks — nothing to ask
+  [[ "$has_hook" != "true" ]] || return 0    # declares hooks AND has one — the healthy case
+
+  echo "WARNING: $agent declares a hooks permission, but this recording carries no" >&2
+  echo "         hook_received event attributable to it — the failure mode #1735" >&2
+  echo "         took three attempts to diagnose (a complete, healthy-looking" >&2
+  echo "         recording whose hook channel never fired, with nothing anywhere" >&2
+  echo "         saying so)." >&2
+  echo "         Legitimate when the scenario genuinely produces no hook — run" >&2
+  echo "         'of coverage --hooks' if unsure whether this is the corpus norm." >&2
+
+  if "$confirm_fn"; then
+    echo "         confirmed intended — promoting." >&2
+    return 0
+  fi
+  echo "promote: refusing a hook-free recording of a hooks-declaring adapter" >&2
+  return 1
+}
+
+# default_hookfree_check <agent> <events_path> — the real check_fn: shells out
+# to `of hookcheck`, which joins the daemon's adapter registry (declares
+# hooks?) against THIS events.jsonl's own session-attributed hook_received
+# events (has one?). go run compiles from source, matching how this same
+# script already invokes ./cmd/expected-validate.
+default_hookfree_check() {
+  local agent="$1" events_path="$2" json declares has_hook
+  if ! json="$(cd "$REPO_ROOT" && go run ./tools/onboarding-factory/cmd/of hookcheck --agent "$agent" --events "$events_path" 2>&1)"; then
+    echo "$json"
+    return 1
+  fi
+  if ! declares="$(jq -r '.declares_hooks' <<<"$json" 2>/dev/null)" || [[ -z "$declares" ]]; then
+    echo "of hookcheck produced unparseable output: $json"
+    return 1
+  fi
+  if ! has_hook="$(jq -r '.has_hook_event' <<<"$json" 2>/dev/null)" || [[ -z "$has_hook" ]]; then
+    echo "of hookcheck produced unparseable output: $json"
+    return 1
+  fi
+  echo "$declares $has_hook"
+}
+
+# default_hookfree_confirm — the real confirm_fn: an explicit non-interactive
+# override (IRRLICHT_PROMOTE_HOOKFREE_OK, for a scripted/agent-driven
+# promote), or an interactive y/N prompt when connected to a real terminal.
+# Anything else — non-interactive with no override set — refuses, because
+# that is precisely the shape of "nobody looked at this."
+default_hookfree_confirm() {
+  if [[ -n "${IRRLICHT_PROMOTE_HOOKFREE_OK:-}" ]]; then
+    echo "         IRRLICHT_PROMOTE_HOOKFREE_OK is set." >&2
+    return 0
+  fi
+  if [[ -t 0 ]]; then
+    local ans
+    read -r -p "         promote this hook-free recording anyway? [y/N] " ans
+    case "$ans" in
+      y|Y|yes|YES) return 0 ;;
+      *) return 1 ;;
+    esac
+  fi
+  echo "         non-interactive and IRRLICHT_PROMOTE_HOOKFREE_OK is not set." >&2
+  return 1
+}

--- a/tools/onboarding-factory/scripts/lib/promote-hookcheck_test.sh
+++ b/tools/onboarding-factory/scripts/lib/promote-hookcheck_test.sh
@@ -77,6 +77,36 @@ rc=$?
 assert_eq "returns 2 (check failure, distinct from a real gap)" "2" "$rc"
 assert_eq "confirm_fn not called" "0" "$CONFIRM_CALLS"
 
+# --- default_hookfree_check: hardened jq parsing --------------------------
+# `go` is shadowed (same idiom as curl elsewhere) so these exercise the REAL
+# check_fn's parsing without a live `of hookcheck` build. REPO_ROOT must
+# resolve so `cd "$REPO_ROOT"` doesn't fail before the fake `go` ever runs.
+# shellcheck disable=SC2034  # read by the SOURCED default_hookfree_check,
+# not by this file — same shape as the other sourced-knob disables above.
+REPO_ROOT="$PWD"
+
+echo "== default_hookfree_check: well-formed output still parses (lock) =="
+go() { printf '{"agent":"codex","declares_hooks":true,"has_hook_event":false}'; }
+out="$(default_hookfree_check codex /tmp/x.jsonl 2>/dev/null)"
+rc=$?
+assert_eq "returns 0" "0" "$rc"
+assert_eq "echoes 'true false'" "true false" "$out"
+
+echo "== default_hookfree_check: declares_hooks MISSING entirely — refused, not read as false =="
+go() { printf '{"agent":"codex","has_hook_event":false}'; }
+default_hookfree_check codex /tmp/x.jsonl >/dev/null 2>&1
+assert_eq "returns 1 (a missing field is a parse failure, not a false)" "1" "$?"
+
+echo "== default_hookfree_check: declares_hooks is JSON null — jq prints the string 'null', still refused =="
+go() { printf '{"agent":"codex","declares_hooks":null,"has_hook_event":false}'; }
+default_hookfree_check codex /tmp/x.jsonl >/dev/null 2>&1
+assert_eq "returns 1 (nonempty 'null' must not slip past an emptiness-only guard)" "1" "$?"
+
+echo "== default_hookfree_check: has_hook_event missing while declares_hooks is fine — still refused =="
+go() { printf '{"agent":"codex","declares_hooks":true}'; }
+default_hookfree_check codex /tmp/x.jsonl >/dev/null 2>&1
+assert_eq "returns 1" "1" "$?"
+
 echo
 if [[ "$fails" -eq 0 ]]; then
   echo "all promote-hookcheck_test.sh cases passed"

--- a/tools/onboarding-factory/scripts/lib/promote-hookcheck_test.sh
+++ b/tools/onboarding-factory/scripts/lib/promote-hookcheck_test.sh
@@ -25,9 +25,9 @@ assert_eq() {
 
 # --- injected fakes -------------------------------------------------------
 # Each check_* prints "<declares> <has_hook>" and exits 0, or fails per its name.
-check_declares_has_hook()    { echo "true true"; }
-check_declares_no_hook()     { echo "true false"; }
-check_no_declares_no_hook()  { echo "false false"; }
+check_declares_has_hook()    { echo "true true"; return 0; }
+check_declares_no_hook()     { echo "true false"; return 0; }
+check_no_declares_no_hook()  { echo "false false"; return 0; }
 check_broken()               { echo "of hookcheck: connection refused" >&2; return 1; }
 
 # confirm_* — CONFIRM_CALLS counts invocations so a case can assert the
@@ -86,24 +86,24 @@ assert_eq "confirm_fn not called" "0" "$CONFIRM_CALLS"
 REPO_ROOT="$PWD"
 
 echo "== default_hookfree_check: well-formed output still parses (lock) =="
-go() { printf '{"agent":"codex","declares_hooks":true,"has_hook_event":false}'; }
+go() { printf '{"agent":"codex","declares_hooks":true,"has_hook_event":false}'; return 0; }
 out="$(default_hookfree_check codex /tmp/x.jsonl 2>/dev/null)"
 rc=$?
 assert_eq "returns 0" "0" "$rc"
 assert_eq "echoes 'true false'" "true false" "$out"
 
 echo "== default_hookfree_check: declares_hooks MISSING entirely — refused, not read as false =="
-go() { printf '{"agent":"codex","has_hook_event":false}'; }
+go() { printf '{"agent":"codex","has_hook_event":false}'; return 0; }
 default_hookfree_check codex /tmp/x.jsonl >/dev/null 2>&1
 assert_eq "returns 1 (a missing field is a parse failure, not a false)" "1" "$?"
 
 echo "== default_hookfree_check: declares_hooks is JSON null — jq prints the string 'null', still refused =="
-go() { printf '{"agent":"codex","declares_hooks":null,"has_hook_event":false}'; }
+go() { printf '{"agent":"codex","declares_hooks":null,"has_hook_event":false}'; return 0; }
 default_hookfree_check codex /tmp/x.jsonl >/dev/null 2>&1
 assert_eq "returns 1 (nonempty 'null' must not slip past an emptiness-only guard)" "1" "$?"
 
 echo "== default_hookfree_check: has_hook_event missing while declares_hooks is fine — still refused =="
-go() { printf '{"agent":"codex","declares_hooks":true}'; }
+go() { printf '{"agent":"codex","declares_hooks":true}'; return 0; }
 default_hookfree_check codex /tmp/x.jsonl >/dev/null 2>&1
 assert_eq "returns 1" "1" "$?"
 

--- a/tools/onboarding-factory/scripts/lib/promote-hookcheck_test.sh
+++ b/tools/onboarding-factory/scripts/lib/promote-hookcheck_test.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# promote-hookcheck_test.sh — unit tests for promote-hookcheck.sh. Plain bash
+# (no framework), matching atomic-promote_test.sh's style. Run directly or via
+# scripts/smoke-test.sh.
+#
+# check_fn and confirm_fn are injected fakes (see the lib header) so these
+# tests pin the decision table without invoking `go run ./cmd/of hookcheck`
+# or a real terminal — the same shape atomic-promote_test.sh already uses for
+# its populate/validate functions.
+
+set -uo pipefail   # NOT -e: assertions capture non-zero return codes
+
+DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=promote-hookcheck.sh
+source "$DIR/promote-hookcheck.sh"
+
+fails=0
+pass() { local label="$1"; echo "  PASS: $label"; return 0; }
+fail() { local label="$1" expected="$2" got="$3"; echo "  FAIL: $label — expected [$expected] got [$got]"; fails=$((fails + 1)); return 0; }
+assert_eq() {
+  local label="$1" expected="$2" got="$3"
+  [[ "$got" == "$expected" ]] && pass "$label" || fail "$label" "$expected" "$got"
+  return 0
+}
+
+# --- injected fakes -------------------------------------------------------
+# Each check_* prints "<declares> <has_hook>" and exits 0, or fails per its name.
+check_declares_has_hook()    { echo "true true"; }
+check_declares_no_hook()     { echo "true false"; }
+check_no_declares_no_hook()  { echo "false false"; }
+check_broken()               { echo "of hookcheck: connection refused" >&2; return 1; }
+
+# confirm_* — CONFIRM_CALLS counts invocations so a case can assert the
+# operator was never even asked (the healthy-path cases must short-circuit
+# before confirm_fn runs at all).
+CONFIRM_CALLS=0
+confirm_yes() { CONFIRM_CALLS=$((CONFIRM_CALLS + 1)); return 0; }
+confirm_no()  { CONFIRM_CALLS=$((CONFIRM_CALLS + 1)); return 1; }
+confirm_must_not_be_called() {
+  CONFIRM_CALLS=$((CONFIRM_CALLS + 1))
+  echo "confirm_fn was called when it should not have been" >&2
+  return 1
+}
+
+echo "== declares hooks, has one — the healthy case: promote, never ask =="
+CONFIRM_CALLS=0
+promote_hookcheck codex /tmp/x.jsonl check_declares_has_hook confirm_must_not_be_called >/dev/null 2>&1
+rc=$?
+assert_eq "returns 0" "0" "$rc"
+assert_eq "confirm_fn not called" "0" "$CONFIRM_CALLS"
+
+echo "== declares no hooks — nothing to ask regardless of has_hook =="
+CONFIRM_CALLS=0
+promote_hookcheck aider /tmp/x.jsonl check_no_declares_no_hook confirm_must_not_be_called >/dev/null 2>&1
+rc=$?
+assert_eq "returns 0" "0" "$rc"
+assert_eq "confirm_fn not called" "0" "$CONFIRM_CALLS"
+
+echo "== the check fires: hook-free recording of a hooks-declaring adapter, operator says no =="
+CONFIRM_CALLS=0
+promote_hookcheck mistral-vibe /tmp/x.jsonl check_declares_no_hook confirm_no >/dev/null 2>&1
+rc=$?
+assert_eq "refuses" "1" "$rc"
+assert_eq "confirm_fn was asked" "1" "$CONFIRM_CALLS"
+
+echo "== the override path: same hook-free case, operator says yes =="
+CONFIRM_CALLS=0
+promote_hookcheck mistral-vibe /tmp/x.jsonl check_declares_no_hook confirm_yes >/dev/null 2>&1
+rc=$?
+assert_eq "promotes" "0" "$rc"
+assert_eq "confirm_fn was asked" "1" "$CONFIRM_CALLS"
+
+echo "== the check itself cannot run: refuse rather than promote blind =="
+CONFIRM_CALLS=0
+promote_hookcheck codex /tmp/x.jsonl check_broken confirm_must_not_be_called >/dev/null 2>&1
+rc=$?
+assert_eq "returns 2 (check failure, distinct from a real gap)" "2" "$rc"
+assert_eq "confirm_fn not called" "0" "$CONFIRM_CALLS"
+
+echo
+if [[ "$fails" -eq 0 ]]; then
+  echo "all promote-hookcheck_test.sh cases passed"
+  exit 0
+else
+  echo "$fails promote-hookcheck_test.sh case(s) failed"
+  exit 1
+fi

--- a/tools/onboarding-factory/scripts/lib/unapplied-grants-check.sh
+++ b/tools/onboarding-factory/scripts/lib/unapplied-grants-check.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# unapplied-grants-check.sh — refuse to drive an agent CLI whose hooks grant
+# reads "granted" but was never actually applied (#1362's shape: the daemon
+# accepted the grant and then failed, silently, to install it).
+#
+# run-cell.sh's ATTACH path has checked this since #1449 — a human might
+# point --attach at a daemon whose install already failed. The SPAWN/isolated
+# path — the one the recording rig itself drives on every ordinary run — never
+# did, and that asymmetry is exactly how #1735's three-attempt mistral-vibe
+# diagnosis happened: the daemon's own `unapplied_grants` already named the
+# hooktoml refusal, and nothing on the path the rig actually uses ever asked
+# it (#1754).
+#
+# unapplied_grants is populated synchronously by PermissionService.Start's
+# grant-all Apply pass, which has already run by the time spawn_record_daemon
+# returns (the socket only comes up after Start finishes) — so this needs no
+# poll of its own. That is deliberately different from
+# wait_for_hook_install, which watches for the INSTALLED FILES to land and
+# can legitimately take several seconds: this check is the fast, NAMED
+# diagnosis; wait_for_hook_install is the slower file-presence backstop for
+# whatever this cannot see (e.g. a daemon too old to expose the field).
+#
+# Usage — after the daemon (attached OR spawned) is confirmed up:
+#   source "$SCRIPT_DIR/lib/unapplied-grants-check.sh"
+#   check_unapplied_grants "$ONBOARD_BIND" "$ADAPTER" || exit 1
+
+# check_unapplied_grants <bind> <adapter> queries the daemon's permission
+# snapshot and refuses (prints why, returns 1) if IT names an unapplied grant
+# for adapter. A daemon too old to expose the field, or an unreachable
+# endpoint, reads as "nothing to check" (0) — the same "can't tell" case
+# run-cell.sh's original attach-only version already treated as a pass.
+check_unapplied_grants() {
+  local bind="$1" adapter="$2" perm_json unapplied
+  # $bind is a loopback host:port for a daemon this rig started itself; the
+  # daemon's local API is plain HTTP by design — there is no TLS listener to
+  # point at instead. shell:S5332 cannot resolve the variable to see that, so
+  # it is annotated, the same NOSONAR shape as run-cell.sh's attach-path fetch
+  # and hook-install-wait.sh's failure-path one.
+  perm_json="$(curl -fsS --max-time 2 "http://$bind/api/v1/permissions" 2>/dev/null || true)" # NOSONAR (shell:S5332) — loopback-only daemon API
+  [[ -n "$perm_json" ]] || return 0
+  # The filter is a variable so the jq call stays ONE PHYSICAL LINE: a NOSONAR
+  # annotation only suppresses the line it sits on, and Sonar's taint tracking
+  # carries S5332 from the curl above into every reader of $perm_json.
+  local filter='[.unapplied_grants // [] | .[] | select(.agent == $a) | "\(.agent)/\(.key): \(.reason)"] | join("; ")'
+  unapplied="$(jq -r --arg a "$adapter" "$filter" <<<"$perm_json" 2>/dev/null || echo "")" # NOSONAR (shell:S5332) — reads the loopback response above
+  [[ -n "$unapplied" ]] || return 0
+  echo "unapplied-grants-check: daemon at $bind has grants that were NOT applied for $adapter" >&2 # NOSONAR (shell:S5332) — names the loopback daemon above
+  echo "unapplied-grants-check:   $unapplied" >&2 # NOSONAR (shell:S5332) — echoes the loopback response above
+  echo "unapplied-grants-check:   it would record a fixture in which $adapter merely looks incapable of reporting state" >&2
+  echo "unapplied-grants-check:   if this is the #1449 shared-config refusal: back up the files 'irrlichd --print-managed-files' names," >&2
+  echo "unapplied-grants-check:   then restart with IRRLICHT_ALLOW_SHARED_CONFIG_WRITES=1 (already set on the spawn path here — look for a version-floor or auth refusal instead)" >&2
+  return 1
+}

--- a/tools/onboarding-factory/scripts/lib/unapplied-grants-check.sh
+++ b/tools/onboarding-factory/scripts/lib/unapplied-grants-check.sh
@@ -11,32 +11,62 @@
 # hooktoml refusal, and nothing on the path the rig actually uses ever asked
 # it (#1754).
 #
-# unapplied_grants is populated synchronously by PermissionService.Start's
-# grant-all Apply pass, which has already run by the time spawn_record_daemon
-# returns (the socket only comes up after Start finishes) — so this needs no
-# poll of its own. That is deliberately different from
-# wait_for_hook_install, which watches for the INSTALLED FILES to land and
-# can legitimately take several seconds: this check is the fast, NAMED
-# diagnosis; wait_for_hook_install is the slower file-presence backstop for
-# whatever this cannot see (e.g. a daemon too old to expose the field).
+# THE RACE ON THE SPAWN PATH (found by review during #1754 itself — an
+# earlier draft of this file claimed the opposite and was wrong). Traced
+# through core/cmd/irrlichd/{main,startup}.go and
+# core/application/services/permission_service.go: the unix socket is bound,
+# and its accept-loop goroutine launched, well BEFORE `startBackgroundLoops`
+# is reached — which is where `PermService.Start(ctx)` actually runs, still
+# on main()'s own goroutine, synchronously. Start() marks every grant-all
+# permission Granted immediately, then calls runEffects() — OUTSIDE its own
+# lock — which is what actually writes each adapter's hook config to disk and
+# only THEN records success/failure into effectErrs (recordEffectResult,
+# called synchronously right after each effect closure returns). A
+# GET /api/v1/permissions arriving after the socket is up but before
+# runEffects reaches (or finishes) this adapter's hook effect sees the
+# permission already state=granted with effectErrs still empty — which reads
+# as "no unapplied grants" for the same reason an unset field would: the
+# question hasn't been evaluated yet, not because it was evaluated and passed.
+# #1735 measured this Apply pass taking ~4s for mistral-vibe's hooktoml write.
+#
+# So a single unpolled check on the spawn path can read "clean" during
+# exactly the window it exists to catch. wait_for_unapplied_grants_clear
+# below polls it instead: any OBSERVED unapplied grant is a real, permanent-
+# for-this-boot fact (effectErrs is never cleared once set) and refuses
+# immediately: only "everything above looked fine" is the ambiguous reading,
+# so that is the one this loop declines to trust on a single sample.
 #
 # Usage — after the daemon (attached OR spawned) is confirmed up:
 #   source "$SCRIPT_DIR/lib/unapplied-grants-check.sh"
-#   check_unapplied_grants "$ONBOARD_BIND" "$ADAPTER" || exit 1
+#   check_unapplied_grants "$ONBOARD_BIND" "$ADAPTER" ["$PERM_JSON"] || exit 1  # attach: daemon has been up for a while, Start() is long done
+#   wait_for_unapplied_grants_clear "$ONBOARD_BIND" "$ADAPTER" || exit 1        # spawn: daemon just started, Start() may still be mid-flight
 
-# check_unapplied_grants <bind> <adapter> queries the daemon's permission
-# snapshot and refuses (prints why, returns 1) if IT names an unapplied grant
-# for adapter. A daemon too old to expose the field, or an unreachable
-# endpoint, reads as "nothing to check" (0) — the same "can't tell" case
-# run-cell.sh's original attach-only version already treated as a pass.
+# check_unapplied_grants <bind> <adapter> [<perm_json>] queries the daemon's
+# permission snapshot ONCE and refuses (prints why, returns 1) if IT names an
+# unapplied grant for adapter. A daemon too old to expose the field, or an
+# unreachable endpoint, reads as "nothing to check" (0) — the same "can't
+# tell" case run-cell.sh's original attach-only version already treated as a
+# pass.
+#
+# <perm_json>, if given non-empty, is used AS-IS instead of a fresh curl — the
+# attach path already fetched this same endpoint one line above for its own
+# PERM_OK gate, and refetching it here would be a second identical loopback
+# round-trip for no new information. wait_for_unapplied_grants_clear never
+# passes it: a poll's whole point is a FRESH sample each tick.
+#
+# A single sample is correct on the ATTACH path (the daemon predates this
+# script run, so Start() is not in flight) but NOT on the spawn path — see
+# wait_for_unapplied_grants_clear for why, and use that instead there.
 check_unapplied_grants() {
-  local bind="$1" adapter="$2" perm_json unapplied
-  # $bind is a loopback host:port for a daemon this rig started itself; the
-  # daemon's local API is plain HTTP by design — there is no TLS listener to
-  # point at instead. shell:S5332 cannot resolve the variable to see that, so
-  # it is annotated, the same NOSONAR shape as run-cell.sh's attach-path fetch
-  # and hook-install-wait.sh's failure-path one.
-  perm_json="$(curl -fsS --max-time 2 "http://$bind/api/v1/permissions" 2>/dev/null || true)" # NOSONAR (shell:S5332) — loopback-only daemon API
+  local bind="$1" adapter="$2" perm_json="${3:-}" unapplied
+  if [[ -z "$perm_json" ]]; then
+    # $bind is a loopback host:port for a daemon this rig started itself; the
+    # daemon's local API is plain HTTP by design — there is no TLS listener to
+    # point at instead. shell:S5332 cannot resolve the variable to see that, so
+    # it is annotated, the same NOSONAR shape as run-cell.sh's attach-path fetch
+    # and hook-install-wait.sh's failure-path one.
+    perm_json="$(curl -fsS --max-time 2 "http://$bind/api/v1/permissions" 2>/dev/null || true)" # NOSONAR (shell:S5332) — loopback-only daemon API
+  fi
   [[ -n "$perm_json" ]] || return 0
   # The filter is a variable so the jq call stays ONE PHYSICAL LINE: a NOSONAR
   # annotation only suppresses the line it sits on, and Sonar's taint tracking
@@ -50,4 +80,31 @@ check_unapplied_grants() {
   echo "unapplied-grants-check:   if this is the #1449 shared-config refusal: back up the files 'irrlichd --print-managed-files' names," >&2
   echo "unapplied-grants-check:   then restart with IRRLICHT_ALLOW_SHARED_CONFIG_WRITES=1 (already set on the spawn path here — look for a version-floor or auth refusal instead)" >&2
   return 1
+}
+
+# Poll knobs, read at call time; the defaults ARE the production timing (20 ×
+# 0.5s = 10s, more than double #1735's measured ~4s Apply latency) and are
+# overridable only so unit tests need not spend them in real seconds — the
+# same shape as hook-install-wait.sh's HOOK_INSTALL_WAIT_TICKS.
+UNAPPLIED_GRANTS_WAIT_TICKS="${UNAPPLIED_GRANTS_WAIT_TICKS:-20}"
+UNAPPLIED_GRANTS_WAIT_TICK_S="${UNAPPLIED_GRANTS_WAIT_TICK_S:-0.5}"
+
+# wait_for_unapplied_grants_clear <bind> <adapter> polls check_unapplied_grants
+# instead of sampling it once, because runEffects (see the header) can still
+# be mid-flight for a daemon this run just spawned. Any refusal is trusted the
+# INSTANT it is observed — effectErrs is never cleared once written this boot,
+# so a positive reading can only be real. A clean reading is trusted only
+# after the poll ceiling passes with no refusal ever seen; that is a deadline,
+# not proof, for the same reason wait_for_hook_install's own ceiling is not
+# proof — this file's header says so rather than overclaiming certainty.
+wait_for_unapplied_grants_clear() {
+  local bind="$1" adapter="$2" waited=0
+  while (( waited < UNAPPLIED_GRANTS_WAIT_TICKS )); do
+    if ! check_unapplied_grants "$bind" "$adapter"; then
+      return 1
+    fi
+    waited=$((waited + 1))
+    (( waited < UNAPPLIED_GRANTS_WAIT_TICKS )) && sleep "$UNAPPLIED_GRANTS_WAIT_TICK_S"
+  done
+  return 0
 }

--- a/tools/onboarding-factory/scripts/lib/unapplied-grants-check_test.sh
+++ b/tools/onboarding-factory/scripts/lib/unapplied-grants-check_test.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# unapplied-grants-check_test.sh — unit tests for unapplied-grants-check.sh.
+# Plain bash (no framework). Run directly or via scripts/smoke-test.sh.
+#
+# curl is shadowed with a fake function that returns canned JSON keyed off
+# FAKE_PERM_JSON, the same "shadow the external command" idiom
+# spawn-record-daemon_test.sh uses for kill: what is under test is the
+# DECISION (does an unapplied grant for THIS adapter refuse?), never the
+# network round-trip.
+
+set -uo pipefail   # NOT -e: assertions capture non-zero return codes
+
+DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=unapplied-grants-check.sh
+source "$DIR/unapplied-grants-check.sh"
+
+fails=0
+pass() { local label="$1"; echo "  PASS: $label"; return 0; }
+fail() { local label="$1" expected="$2" got="$3"; echo "  FAIL: $label — expected [$expected] got [$got]"; fails=$((fails + 1)); return 0; }
+assert_eq() {
+  local label="$1" expected="$2" got="$3"
+  [[ "$got" == "$expected" ]] && pass "$label" || fail "$label" "$expected" "$got"
+  return 0
+}
+
+FAKE_PERM_JSON=""
+curl() {
+  # Mirror the real invocation shape closely enough that a future flag-order
+  # change here would be visibly wrong, without hard-asserting every flag.
+  printf '%s' "$FAKE_PERM_JSON"
+  return 0
+}
+
+echo "== no unapplied grants at all: passes =="
+FAKE_PERM_JSON='{"mode":"grant-all","unapplied_grants":[]}'
+check_unapplied_grants "127.0.0.1:7838" "mistral-vibe" >/dev/null 2>&1
+assert_eq "returns 0" "0" "$?"
+
+echo "== unapplied grant for THIS adapter (#1362's hooktoml-refusal shape): refuses and names it =="
+FAKE_PERM_JSON='{"mode":"grant-all","unapplied_grants":[{"agent":"mistral-vibe","key":"hooks","reason":"hooktoml write refused"}]}'
+out="$(check_unapplied_grants "127.0.0.1:7838" "mistral-vibe" 2>&1 >/dev/null)"
+rc=$?
+assert_eq "returns 1" "1" "$rc"
+case "$out" in
+  *"mistral-vibe/hooks: hooktoml write refused"*) pass "names the refusal" ;;
+  *) fail "names the refusal" "mistral-vibe/hooks: hooktoml write refused" "$out" ;;
+esac
+
+echo "== unapplied grant for a DIFFERENT adapter: does not block this cell =="
+FAKE_PERM_JSON='{"mode":"grant-all","unapplied_grants":[{"agent":"codex","key":"hooks","reason":"version floor"}]}'
+check_unapplied_grants "127.0.0.1:7838" "mistral-vibe" >/dev/null 2>&1
+assert_eq "returns 0 (scoped to the adapter this cell records)" "0" "$?"
+
+echo "== pre-#570 daemon / unreachable endpoint (empty response): nothing to check, passes =="
+FAKE_PERM_JSON=''
+check_unapplied_grants "127.0.0.1:7838" "mistral-vibe" >/dev/null 2>&1
+assert_eq "returns 0" "0" "$?"
+
+echo "== daemon too old to expose unapplied_grants at all: passes =="
+FAKE_PERM_JSON='{"mode":"grant-all"}'
+check_unapplied_grants "127.0.0.1:7838" "mistral-vibe" >/dev/null 2>&1
+assert_eq "returns 0" "0" "$?"
+
+echo
+if [[ "$fails" -eq 0 ]]; then
+  echo "all unapplied-grants-check_test.sh cases passed"
+  exit 0
+else
+  echo "$fails unapplied-grants-check_test.sh case(s) failed"
+  exit 1
+fi

--- a/tools/onboarding-factory/scripts/lib/unapplied-grants-check_test.sh
+++ b/tools/onboarding-factory/scripts/lib/unapplied-grants-check_test.sh
@@ -61,6 +61,70 @@ FAKE_PERM_JSON='{"mode":"grant-all"}'
 check_unapplied_grants "127.0.0.1:7838" "mistral-vibe" >/dev/null 2>&1
 assert_eq "returns 0" "0" "$?"
 
+echo "== a pre-fetched perm_json (3rd arg) is used as-is — no curl call =="
+# curl is rigged to return a DIRTY snapshot; if the 3rd arg were ignored and
+# curl called anyway, this would wrongly refuse (return 1) instead of 0.
+curl() { printf '%s' '{"mode":"grant-all","unapplied_grants":[{"agent":"mistral-vibe","key":"hooks","reason":"curl should not have been called"}]}'; return 0; }
+check_unapplied_grants "127.0.0.1:7838" "mistral-vibe" '{"mode":"grant-all","unapplied_grants":[]}' >/dev/null 2>&1
+assert_eq "returns 0 (reused the pre-fetched clean JSON, never fetched a second time)" "0" "$?"
+curl() { printf '%s' "$FAKE_PERM_JSON"; return 0; }   # restore the plain fake for anything below
+
+# --- wait_for_unapplied_grants_clear: the poll wrapper ---------------------
+# Ticks fast (no real sleep) and few, so the "never clears" case below doesn't
+# spend wall time. curl runs inside `$(...)` command substitution, i.e. its
+# own subshell — a plain variable it incremented would be discarded the
+# moment that subshell exits, so CALLS is a FILE (surviving across subshells)
+# rather than a variable, and calls() reads it back for the assertions.
+UNAPPLIED_GRANTS_WAIT_TICKS=4
+# shellcheck disable=SC2034  # read by the SOURCED library
+# (wait_for_unapplied_grants_clear's `sleep "$UNAPPLIED_GRANTS_WAIT_TICK_S"`),
+# not by this file — the linter does not follow a source through a variable
+# path, the same shape spawn-record-daemon_test.sh notes for its own knobs.
+UNAPPLIED_GRANTS_WAIT_TICK_S=0
+CALLS_FILE="$(mktemp)"
+trap 'rm -f "$CALLS_FILE"' EXIT
+FAKE_SEQUENCE=()   # one JSON string per call; the last entry repeats past the end
+
+calls() { cat "$CALLS_FILE"; }
+
+curl() {
+  local n
+  n=$(($(cat "$CALLS_FILE") + 1))
+  echo "$n" > "$CALLS_FILE"
+  local idx=$((n - 1))
+  if (( idx < ${#FAKE_SEQUENCE[@]} )); then
+    printf '%s' "${FAKE_SEQUENCE[$idx]}"
+  else
+    # bash 3.2 (stock macOS) has no negative array indices — clamp instead.
+    printf '%s' "${FAKE_SEQUENCE[${#FAKE_SEQUENCE[@]}-1]}"
+  fi
+  return 0
+}
+
+CLEAN='{"mode":"grant-all","unapplied_grants":[]}'
+DIRTY='{"mode":"grant-all","unapplied_grants":[{"agent":"gemini-cli","key":"hooks","reason":"hooktoml write refused"}]}'
+
+echo "== poll wrapper: unapplied grant present on the FIRST poll — refuses without waiting out the ceiling =="
+echo 0 > "$CALLS_FILE"
+FAKE_SEQUENCE=("$DIRTY")
+wait_for_unapplied_grants_clear "127.0.0.1:7838" "gemini-cli" >/dev/null 2>&1
+assert_eq "returns 1" "1" "$?"
+assert_eq "stopped at the first poll" "1" "$(calls)"
+
+echo "== poll wrapper: THE RACE — clean on polls 1-2 (Apply still mid-flight), unapplied on poll 3 =="
+echo 0 > "$CALLS_FILE"
+FAKE_SEQUENCE=("$CLEAN" "$CLEAN" "$DIRTY")
+wait_for_unapplied_grants_clear "127.0.0.1:7838" "gemini-cli" >/dev/null 2>&1
+assert_eq "still refuses (a later poll catches what the first sample missed)" "1" "$?"
+assert_eq "took 3 polls to see it" "3" "$(calls)"
+
+echo "== poll wrapper: never becomes unapplied within the ceiling — clean, and actually polled the full ceiling =="
+echo 0 > "$CALLS_FILE"
+FAKE_SEQUENCE=("$CLEAN")
+wait_for_unapplied_grants_clear "127.0.0.1:7838" "gemini-cli" >/dev/null 2>&1
+assert_eq "returns 0" "0" "$?"
+assert_eq "polled the full ceiling rather than returning after one sample" "$UNAPPLIED_GRANTS_WAIT_TICKS" "$(calls)"
+
 echo
 if [[ "$fails" -eq 0 ]]; then
   echo "all unapplied-grants-check_test.sh cases passed"

--- a/tools/onboarding-factory/scripts/lib/unapplied-grants-check_test.sh
+++ b/tools/onboarding-factory/scripts/lib/unapplied-grants-check_test.sh
@@ -85,7 +85,7 @@ CALLS_FILE="$(mktemp)"
 trap 'rm -f "$CALLS_FILE"' EXIT
 FAKE_SEQUENCE=()   # one JSON string per call; the last entry repeats past the end
 
-calls() { cat "$CALLS_FILE"; }
+calls() { cat "$CALLS_FILE"; return 0; }
 
 curl() {
   local n

--- a/tools/onboarding-factory/scripts/precheck.sh
+++ b/tools/onboarding-factory/scripts/precheck.sh
@@ -62,10 +62,14 @@ elif [[ -n "${IRRLICHT_ONBOARD_HOME:-}" ]]; then
   # opposite reasons (#1754). URL delivery (claudecode, codex, copilot) bakes
   # the address INTO the installed entry at install time, so it always
   # reaches this daemon (#1178). Beacon delivery — every adapter importing
-  # core/pkg/hookbeacon (gemini-cli, kiro-cli, mistral-vibe) — writes NO
-  # address into the entry at all; `irrlichd hook-post` resolves the daemon
-  # from its OWN process environment at FIRE time, and that process is a
-  # child of the agent CLI run-cell.sh launches under tmux. That only
+  # core/pkg/hookbeacon; as of this writing antigravity, gemini-cli, hermes,
+  # kiro-cli, opencode, pi and mistral-vibe, but the LIST here is not the
+  # source of truth and will drift — `righome.BeaconAdapters` (derived from
+  # the import graph) and TestEveryBeaconAdapterDriverPassesTheDaemonAddress
+  # (tools/onboarding-factory/internal/righome) are — writes NO address into
+  # the entry at all; `irrlichd hook-post` resolves the daemon from its OWN
+  # process environment at FIRE time, and that process is a child of the
+  # agent CLI run-cell.sh launches under tmux. That only
   # reaches $ONBOARD_BIND because run-cell.sh explicitly exports
   # IRRLICHT_BIND_ADDR and forwards it into the tmux pane
   # (TestEveryBeaconAdapterDriverPassesTheDaemonAddress in

--- a/tools/onboarding-factory/scripts/precheck.sh
+++ b/tools/onboarding-factory/scripts/precheck.sh
@@ -55,9 +55,23 @@ elif [[ -n "${IRRLICHT_ONBOARD_HOME:-}" ]]; then
   # Coexist mode: the recording daemon gets its OWN IRRLICHT_HOME (socket
   # + state) and an alternate bind port, so a running production irrlichd
   # is fine — they don't share a socket or port. We only require that OUR
-  # target port is free. Hook-driven adapters work here too since #1178:
-  # the endpoint their installers write follows IRRLICHT_BIND_ADDR, so
-  # hooks reach $ONBOARD_BIND rather than production.
+  # target port is free.
+  #
+  # Hooks reaching $ONBOARD_BIND rather than production is NOT one
+  # adapter-neutral guarantee — it is two different mechanisms, correct for
+  # opposite reasons (#1754). URL delivery (claudecode, codex, copilot) bakes
+  # the address INTO the installed entry at install time, so it always
+  # reaches this daemon (#1178). Beacon delivery — every adapter importing
+  # core/pkg/hookbeacon (gemini-cli, kiro-cli, mistral-vibe) — writes NO
+  # address into the entry at all; `irrlichd hook-post` resolves the daemon
+  # from its OWN process environment at FIRE time, and that process is a
+  # child of the agent CLI run-cell.sh launches under tmux. That only
+  # reaches $ONBOARD_BIND because run-cell.sh explicitly exports
+  # IRRLICHT_BIND_ADDR and forwards it into the tmux pane
+  # (TestEveryBeaconAdapterDriverPassesTheDaemonAddress in
+  # tools/onboarding-factory/internal/righome enforces it) — a caller that
+  # drives the CLI some other way inherits none of that for free, and a
+  # hook-free "healthy" recording is what #1735 measured when it didn't.
   ONBOARD_BIND="${IRRLICHT_ONBOARD_BIND_ADDR:-127.0.0.1:7838}"
   ONBOARD_PORT="${ONBOARD_BIND##*:}"
   if [[ ! "$ONBOARD_PORT" =~ ^[0-9]+$ ]]; then

--- a/tools/onboarding-factory/scripts/run-cell.sh
+++ b/tools/onboarding-factory/scripts/run-cell.sh
@@ -362,7 +362,7 @@ if [[ "$ATTACH" == "1" ]]; then
     # $ADAPTER alone, with no partner: a cross-adapter cell never reaches this
     # point — a non-empty partner_adapter exits above, pointing at
     # run-cell-multi.sh, which has no attach path at all.
-    check_unapplied_grants "$ONBOARD_BIND" "$ADAPTER" || exit 1
+    check_unapplied_grants "$ONBOARD_BIND" "$ADAPTER" "$PERM_JSON" || exit 1
   fi
   echo "attach: using running daemon's recordings at $ATTACHED_RECORDINGS_DIR"
 else
@@ -387,11 +387,13 @@ if [[ "$ATTACH" != "1" ]]; then
   # Same surface the attach path checks above, moved out where it can be
   # shared (#1754): an install that failed silently ("granted but NOT
   # applied", #1362's shape) reads "granted" in .permissions on the spawn
-  # path too, and unapplied_grants is the only place that names it. Checked
-  # immediately once the daemon's socket is up — Apply has already run by
-  # then — rather than only discovered the slow way, up to 30s later, by
-  # wait_for_hook_install's file-presence timeout below.
-  check_unapplied_grants "$ONBOARD_BIND" "$ADAPTER" || exit 1
+  # path too, and unapplied_grants is the only place that names it. Polled,
+  # not sampled once: the socket comes up BEFORE the daemon's grant-all Apply
+  # pass runs (see unapplied-grants-check.sh's header for the trace), so a
+  # single immediate check can read "clean" only because it hasn't been
+  # evaluated yet. wait_for_unapplied_grants_clear trusts a refusal instantly
+  # but polls a clean reading out to a deadline before believing it.
+  wait_for_unapplied_grants_clear "$ONBOARD_BIND" "$ADAPTER" || exit 1
   wait_for_hook_install "$ADAPTER" "$STAGING" "$ONBOARD_BIND" || exit 1
 fi
 

--- a/tools/onboarding-factory/scripts/run-cell.sh
+++ b/tools/onboarding-factory/scripts/run-cell.sh
@@ -60,6 +60,12 @@ source "$SCRIPT_DIR/lib/agent-home.sh"
 # hook config — see the lib header for the recording it was written against.
 # shellcheck source=lib/hook-install-wait.sh
 source "$SCRIPT_DIR/lib/hook-install-wait.sh"
+# unapplied_grants — the daemon's own account of an install that was granted
+# but never applied (#1362). Shared between the attach and spawn paths
+# (#1754); see the lib header for why the spawn path never checked this
+# before.
+# shellcheck source=lib/unapplied-grants-check.sh
+source "$SCRIPT_DIR/lib/unapplied-grants-check.sh"
 
 RECORDER="off"
 ATTACH=0
@@ -346,27 +352,17 @@ if [[ "$ATTACH" == "1" ]]; then
     # adapter looks incapable of reporting state, which is worse than not
     # recording at all. unapplied_grants is the daemon's own list of exactly
     # this (an older daemon omits the field → empty → skipped).
-    # Scoped to THIS cell's adapter, not the whole list. unapplied_grants is
-    # daemon-wide and carries every adapter's #1362 install failures and #1365
-    # version-floor refusals — so an unrelated old codex CLI would otherwise
-    # block a claude-code recording, with advice (set the override) that cannot
-    # fix a version floor. Only a refusal on the adapter this cell records can
-    # damage this cell's fixture.
+    # Scoped to THIS cell's adapter, not the whole list, by check_unapplied_grants
+    # (lib/unapplied-grants-check.sh, shared with the spawn path below, #1754):
+    # unapplied_grants is daemon-wide and carries every adapter's #1362 install
+    # failures and #1365 version-floor refusals — so an unrelated old codex CLI
+    # would otherwise block a claude-code recording, with advice (set the
+    # override) that cannot fix a version floor. Only a refusal on the adapter
+    # this cell records can damage this cell's fixture.
     # $ADAPTER alone, with no partner: a cross-adapter cell never reaches this
     # point — a non-empty partner_adapter exits above, pointing at
     # run-cell-multi.sh, which has no attach path at all.
-    # The filter is a variable so the jq call stays one physical line: a
-    # NOSONAR annotation only suppresses the line it sits on, and Sonar's taint
-    # tracking carries S5332 from the curl above into every reader of $PERM_JSON.
-    UNAPPLIED_FILTER='[.unapplied_grants // [] | .[] | select(.agent == $a) | "\(.agent)/\(.key): \(.reason)"] | join("; ")'
-    UNAPPLIED="$(jq -r --arg a "$ADAPTER" "$UNAPPLIED_FILTER" <<<"$PERM_JSON" 2>/dev/null || echo "")" # NOSONAR (shell:S5332) — reads the loopback response above
-    if [[ -n "$UNAPPLIED" ]]; then
-      echo "attach: daemon at $ONBOARD_BIND has grants that were NOT applied — it would record a fixture missing those signals" >&2 # NOSONAR (shell:S5332) — names the loopback daemon above
-      echo "        $UNAPPLIED" >&2 # NOSONAR (shell:S5332) — echoes the loopback response above
-      echo "        if this is the #1449 shared-config refusal: back up the files that irrlichd --print-managed-files names," >&2
-      echo "        then restart the daemon with IRRLICHT_ALLOW_SHARED_CONFIG_WRITES=1 (or record without --attach, which snapshots them for you)" >&2
-      exit 1
-    fi
+    check_unapplied_grants "$ONBOARD_BIND" "$ADAPTER" || exit 1
   fi
   echo "attach: using running daemon's recordings at $ATTACHED_RECORDINGS_DIR"
 else
@@ -388,6 +384,14 @@ fi
 # been up since long before this script started and run-cell's own
 # unapplied_grants check above already graded its installs.
 if [[ "$ATTACH" != "1" ]]; then
+  # Same surface the attach path checks above, moved out where it can be
+  # shared (#1754): an install that failed silently ("granted but NOT
+  # applied", #1362's shape) reads "granted" in .permissions on the spawn
+  # path too, and unapplied_grants is the only place that names it. Checked
+  # immediately once the daemon's socket is up — Apply has already run by
+  # then — rather than only discovered the slow way, up to 30s later, by
+  # wait_for_hook_install's file-presence timeout below.
+  check_unapplied_grants "$ONBOARD_BIND" "$ADAPTER" || exit 1
   wait_for_hook_install "$ADAPTER" "$STAGING" "$ONBOARD_BIND" || exit 1
 fi
 

--- a/tools/onboarding-factory/scripts/run-cell.sh
+++ b/tools/onboarding-factory/scripts/run-cell.sh
@@ -362,7 +362,7 @@ if [[ "$ATTACH" == "1" ]]; then
     # $ADAPTER alone, with no partner: a cross-adapter cell never reaches this
     # point — a non-empty partner_adapter exits above, pointing at
     # run-cell-multi.sh, which has no attach path at all.
-    check_unapplied_grants "$ONBOARD_BIND" "$ADAPTER" "$PERM_JSON" || exit 1
+    check_unapplied_grants "$ONBOARD_BIND" "$ADAPTER" "$PERM_JSON" || exit 1 # NOSONAR (shell:S5332) — reads the loopback response fetched above
   fi
   echo "attach: using running daemon's recordings at $ATTACHED_RECORDINGS_DIR"
 else

--- a/tools/onboarding-factory/scripts/smoke-test.sh
+++ b/tools/onboarding-factory/scripts/smoke-test.sh
@@ -65,6 +65,14 @@ echo "== unit tests (lib/atomic-promote_test.sh) =="
 bash "$SCRIPT_DIR/lib/atomic-promote_test.sh" || rc=1
 
 echo ""
+echo "== unit tests (lib/promote-hookcheck_test.sh) =="
+bash "$SCRIPT_DIR/lib/promote-hookcheck_test.sh" || rc=1
+
+echo ""
+echo "== unit tests (lib/unapplied-grants-check_test.sh) =="
+bash "$SCRIPT_DIR/lib/unapplied-grants-check_test.sh" || rc=1
+
+echo ""
 echo "== unit tests (lib/adapter-tables_test.sh) =="
 bash "$SCRIPT_DIR/lib/adapter-tables_test.sh" || rc=1
 

--- a/tools/promote-recording.sh
+++ b/tools/promote-recording.sh
@@ -28,6 +28,12 @@
 #
 # <staging-dir> is the output of run-cell.sh
 #   (.build/refresh/<agent>/<folder>-<TS>/).
+#
+# If <agent> declares a hooks permission and the staged recording carries no
+# hook_received event attributable to it, this prompts before promoting
+# (#1754) — legitimate when the scenario genuinely produces no hook, so
+# answer non-interactively with IRRLICHT_PROMOTE_HOOKFREE_OK=1 rather than
+# retrying against an unanswerable prompt.
 
 set -euo pipefail
 

--- a/tools/promote-recording.sh
+++ b/tools/promote-recording.sh
@@ -49,6 +49,10 @@ source "$REPO_ROOT/tools/onboarding-factory/scripts/lib/shard-lib.sh"
 # reach the tree.
 # shellcheck source=onboarding-factory/scripts/lib/atomic-promote.sh
 source "$REPO_ROOT/tools/onboarding-factory/scripts/lib/atomic-promote.sh"
+# Promote-time hook-coverage prompt (#1754): the last gate before a
+# hooks-declaring adapter's hook-free recording becomes committed truth.
+# shellcheck source=onboarding-factory/scripts/lib/promote-hookcheck.sh
+source "$REPO_ROOT/tools/onboarding-factory/scripts/lib/promote-hookcheck.sh"
 
 STAGED_DIR="$STAGING/replaydata/agents/$AGENT/scenarios/$SCENARIO"
 TARGET_DIR="$REPO_ROOT/replaydata/agents/$AGENT/scenarios/$SCENARIO"
@@ -58,6 +62,14 @@ if [[ ! -f "$STAGED_DIR/events.jsonl" ]]; then
   echo "promote: no staged events.jsonl at $STAGED_DIR" >&2
   exit 1
 fi
+
+# A hooks-declaring adapter's recording with no hook_received event attributed
+# to it is the exact failure #1735 took three attempts to diagnose (a
+# complete, healthy-looking recording whose hook channel never fired). Never
+# a hard failure — some scenarios genuinely produce no hook — so this prompts
+# / accepts an explicit override rather than blocking (see the lib header).
+promote_hookcheck "$AGENT" "$STAGED_DIR/events.jsonl" \
+  default_hookfree_check default_hookfree_confirm || exit 1
 
 # Daemon + agent CLI versions + recipe hash for the manifest.
 DAEMON_VER="unknown"


### PR DESCRIPTION
## Summary

Closes #1754. Three independent rig gaps, all exposed by #1735's three-attempt kiro-cli/mistral-vibe hook-coverage fix, where every failed attempt produced a complete, healthy-looking recording (`driver_exit_reason=ok`, `completeness=complete`) with zero hook events and nothing anywhere saying the hook channel under test never fired.

1. **`promote-recording.sh` now prompts when a hooks-declaring adapter's staged recording carries no `hook_received` event attributable to it.** Added `of hookcheck --agent --events` (exports `hookcov.HasOwnHookEvent`) so a bash script can ask, about ONE staged candidate, the same attributed question `of coverage --hooks` already answers over the whole committed corpus. The check is a PROMPT/explicit-override (`IRRLICHT_PROMOTE_HOOKFREE_OK=1`, or an interactive y/N), never a hard failure — some scenarios genuinely produce no hook. Factored into `tools/onboarding-factory/scripts/lib/promote-hookcheck.sh` (`promote_hookcheck`, with injected `check_fn`/`confirm_fn` for testability, matching `atomic-promote.sh`'s style). A check that itself fails to run (e.g. `of hookcheck` errors) refuses rather than promoting blind, per AGENTS.md's "a verification mechanism must fail loudly when it cannot run."

2. **`run-cell.sh` now checks `unapplied_grants` on the spawn path, not just attach.** `unapplied_grants` is the daemon's only surface for an install that was granted but never applied (#1362's shape) — the recording rig's actual path (spawn/isolated) never looked, only `--attach` did. Extracted into `lib/unapplied-grants-check.sh`, shared by both paths. **A code-review pass caught a real race here**: the first draft claimed the daemon's grant-all Apply pass (`PermissionService.Start`) completes before the unix socket comes up — traced through `core/cmd/irrlichd/{main,startup}.go`, this is backwards; the socket accepts connections well before `Start()` runs. Fixed with `wait_for_unapplied_grants_clear`: any observed refusal is trusted instantly (it's permanent for the boot); a clean reading is trusted only after a bounded poll (20×0.5s, over double #1735's measured ~4s Apply latency) passes with no refusal ever seen.

3. **Corrected the adapter-neutral-reading "hooks reach the coexisting daemon since #1178" prose** in `precheck.sh` and the `record` skill's Coexist precondition. True only for URL-delivery adapters (claudecode, codex, copilot); false for beacon-delivery adapters. The initial fix also under-listed the beacon-delivery set (3 named vs. the real 7 — antigravity, gemini-cli, hermes, kiro-cli, opencode, pi, mistral-vibe, per `core/pkg/hookbeacon` importers) — caught by the same review pass and corrected to point at `righome.BeaconAdapters` (derived from the import graph) as the actual source of truth.

## Test/mutation evidence

- **Fix 1 (Go):** `hookcheck_test.go` — table test over declares/has-hook/co-resident-attribution/missing-file cases. Mutation (`tools/mutate.sh`): `hookcov.HasOwnHookEvent` neutered to `return true` — 5 subtests across 2 test functions went red, tree restored clean.
- **Fix 1 (bash):** `promote-hookcheck_test.sh` — proves the check fires and the override path works, plus hardened jq-parsing tests (a missing/null `declares_hooks`/`has_hook_event` field must refuse, not silently coerce to false). Mutation: neutering the gate and separately the emptiness-only jq guard both went red at the intended assertions, tree restored clean.
- **Fix 2:** `unapplied-grants-check_test.sh` — fakes `curl` (same shadow idiom as `spawn-record-daemon_test.sh`'s fake `kill`) to pin the single-shot check AND the poll wrapper: refuses instantly on a first-poll positive; still refuses when the positive only appears on a *later* poll (the actual race); clears only after polling the full ceiling with nothing ever seen; reuses a pre-fetched perm_json without a second HTTP round-trip. Mutation: reverting the poll to single-shot, and separately the redundant pre-fetch dedup, both went red at the intended assertions, tree restored clean.
- **Fix 3:** prose-only, no runtime behavior to test.

## Review history

A dedicated review subagent (effort: medium) found two real defects, both fixed and re-verified: the Apply-pass race above, and the stale 3-of-7 beacon-adapter list. It also flagged (addressed): a redundant `/api/v1/permissions` fetch on the attach path (deduped via an optional pre-fetched `perm_json` parameter); `IRRLICHT_PROMOTE_HOOKFREE_OK` undocumented outside its own refusal message (added to the skill + script usage header); and the jq null-handling hardening above. Not fixed (flagged as out of this issue's literal scope): `run-cell-multi.sh`'s spawn path shares `spawn_record_daemon` but has no `--attach` path and was never wired to either new check — worth a follow-up, possibly by relocating the check into the shared `lib/spawn-record-daemon.sh` lifecycle so `run-cell-multi.sh` doesn't have to opt in separately (an altitude concern raised during the `/simplify` pass below).

A `/simplify` pass (4 parallel review angles) found and fixed: two `awk` forks replaced with one `read -r` split; a duplicated jq-parse-and-validate block factored into one `hookfree_parse_bool_field` helper. Flagged but deliberately skipped (documented rationale, not applied under this PR's scope): reordering/combining the new `wait_for_unapplied_grants_clear` poll with the pre-existing `wait_for_hook_install` poll to avoid ~5-6s of additive wall-clock per healthy recording (skipped because a naive reorder reopens the exact race this PR fixes for gemini-cli/opencode, which have no rig-home row); the `unapplied_grants` jq filter now exists in two places (this PR's new lib and the pre-existing `hook-install-wait.sh`) — left alone since consolidating would touch an untested, out-of-diff file; the beacon-vs-URL-delivery explanation is written twice (SKILL.md + precheck.sh) as prose for two different audiences.

Also addressed: one SonarCloud SECURITY finding (a new taint-tracked read of the loopback HTTP response needed its own NOSONAR annotation, matching every other reader of that variable) that was gating the PR's "B Security Rating on New Code" quality gate — now passing. Five cosmetic MAINTAINABILITY findings (missing explicit `return` statements in one-line shell fakes) fixed; three LOW "define a constant" findings left as-is (repeated literals in test files, non-gating).

## Verification

`tools/preflight.sh --only {go,tools,bash,skills,arch,posix,security}` all PASS, both before and after the review/simplify passes. `web`/`swift` groups don't apply — no `web/` or `platforms/macos/` changes (their CI jobs pass regardless, as a side effect of full-repo coverage). All GitHub-side checks pass except CodeScene's advisory Code Health Review (2 pre-existing-shape findings: Complex Method in `of`'s `run()` dispatch switch, now one case longer; Primitive Obsession in `hookcov.go`) — advisory per AGENTS.md, not a merge gate.

## Test plan
- [x] `go test ./tools/onboarding-factory/... -race -count=1`
- [x] `bash tools/onboarding-factory/scripts/smoke-test.sh` (includes all new/updated lib test files)
- [x] `tools/preflight.sh --only go|tools|bash|skills|arch|posix|security`
- [x] Mutation evidence for every new guard (fix 1 Go + bash, fix 2 bash) via `tools/mutate.sh`, re-verified after the review-fix and simplify passes
- [x] All GitHub-side required checks green (go-test, build-test, ars-gate, swift-build/test, web tests, SonarCloud, CodeQL)

🤖 Generated with [Claude Code](https://claude.com/claude-code)