### PR TITLE
feat(kirocli): declare kiro-cli's own data store as an advisory write (#1748)

### DIFF
--- a/core/adapters/inbound/agents/kirocli/agent.go
+++ b/core/adapters/inbound/agents/kirocli/agent.go
@@ -163,6 +163,22 @@ func Agent() agent.Agent {
 					// is not co-located with anything.
 					Also: []func() (string, error){kiroSettingsPath, priorDefaultStatePath, agentSnapshotStatePath},
 				},
+				// Advisory: kiro-cli's OWN identity store, not irrlicht content —
+				// see agent.AdvisoryWrite and kiroDataStorePath for why this is a
+				// separate category from Also rather than a fourth entry in it
+				// (issue #1748). Deliberately does not change Touches/Detail above:
+				// this write is an unconditional side effect of the binary
+				// launching, not a separate consent decision, and the operator
+				// visibility this exists for is --print-advisory-files and the
+				// recording rig's warning, not the grant wizard.
+				Advisory: []agent.AdvisoryWrite{{
+					Path: kiroDataStorePath,
+					Reason: "kiro-cli agent create/set-default (kiroctl.go) spawn the real " +
+						"kiro-cli binary, whose own identity database this is. No irrlicht " +
+						"content lives here, so Uninstall is meaningless for it; it is only " +
+						"verified on darwin; and a live sqlite store cannot be safely " +
+						"snapshotted or restored, so it is reported, never backed up (#1748).",
+				}},
 			},
 		},
 	}

--- a/core/adapters/inbound/agents/kirocli/hookinstaller.go
+++ b/core/adapters/inbound/agents/kirocli/hookinstaller.go
@@ -66,8 +66,10 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"irrlicht/core/adapters/inbound/agents/agentpaths"
@@ -715,6 +717,31 @@ func priorDefaultStatePath() (string, error) {
 		return "", err
 	}
 	return filepath.Join(home, priorDefaultStateFilename), nil
+}
+
+// kiroDataStorePath resolves kiro-cli's OWN agent-identity sqlite store — NOT
+// anything irrlicht writes, and NOT under kiroHome(): kiroAgentCreateFromDefault
+// / kiroAgentSetDefault (kiroctl.go) spawn the real kiro-cli binary, and that
+// child process writes this file as a side effect of the platform's own
+// application-data convention, a different root than everything else this
+// package resolves. Measured 2026-08-22 (PR #1747's body) — present even when
+// the install itself fails (not logged in), so it is a property of the binary
+// launching at all, not of the install succeeding.
+//
+// Declared as agent.AdvisoryWrite rather than agent.ManagedUserFile.Also
+// (issue #1748): only darwin has been observed, so a non-darwin OS returns an
+// error here rather than guess — an AdvisoryWrite's own contract (see its doc)
+// is that a resolution failure is tolerated by every consumer, unlike Path/
+// Also, which must always resolve.
+func kiroDataStorePath() (string, error) {
+	if runtime.GOOS != "darwin" {
+		return "", fmt.Errorf("kirocli: data store location is unverified on %s (#1748)", runtime.GOOS)
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, "Library", "Application Support", "kiro-cli", "data.sqlite3"), nil
 }
 
 // atomicWriteFile writes data to path via a temp file + rename so a reader

--- a/core/adapters/inbound/agents/managedfiles.go
+++ b/core/adapters/inbound/agents/managedfiles.go
@@ -135,6 +135,60 @@ func collectManagedFiles(catalog []agent.Agent, want func(key string) bool) ([]M
 	return out, nil
 }
 
+// AdvisoryFile is one permission's declared agent.AdvisoryWrite, resolved —
+// a path its Apply is known to write that holds no irrlicht content, so
+// unlike ManagedUserFile it carries no Uninstall and is never a backup/restore
+// candidate (issue #1748).
+type AdvisoryFile struct {
+	// Adapter is the declaration's label (agent.Identity.Name).
+	Adapter string
+	// Key is the permission key whose Apply causes the write.
+	Key string
+	// Path is the resolved, absolute path.
+	Path string
+	// Reason is agent.AdvisoryWrite.Reason, carried through verbatim so a
+	// reader of --print-advisory-files (or the rig's warning) sees WHY this
+	// path is advisory rather than a plain managed file.
+	Reason string
+}
+
+// AdvisoryFiles projects the consent catalog onto every declared
+// agent.AdvisoryWrite, resolved. --print-advisory-files is its only consumer
+// today (the recording rig's warn-only step); it is deliberately not folded
+// into ManagedUserFiles, whose two consumers (--print-managed-files' backup
+// contract and #1449's grant-all refusal) both assume a resolved path is
+// something they may snapshot, restore or refuse on — none of which apply to
+// an entry declared here.
+//
+// Unlike collectManagedFiles, a Path that fails to resolve is SKIPPED rather
+// than making the whole call an error: an agent.AdvisoryWrite's own contract
+// (see its doc) allows it to be scoped to a platform where the write has
+// actually been observed, so "cannot resolve here" is an expected outcome
+// wherever the declaration doesn't cover this OS — not the "our own required
+// config disappeared" case ManagedUserFiles' Path is. A nil Path resolver
+// stays fatal: that is a malformed declaration, not an unresolvable platform.
+func AdvisoryFiles(catalog []agent.Agent) ([]AdvisoryFile, error) {
+	var out []AdvisoryFile
+	for _, a := range catalog {
+		for _, p := range a.Permissions {
+			for i, adv := range p.Advisory {
+				if adv.Path == nil {
+					return nil, fmt.Errorf("adapter %q permission %q: Advisory[%d] has a nil Path resolver", a.Identity.Name, p.Key, i)
+				}
+				path, err := adv.Path()
+				if err != nil {
+					continue
+				}
+				if !filepath.IsAbs(path) {
+					return nil, fmt.Errorf("adapter %q permission %q: Advisory[%d] path %q is not absolute", a.Identity.Name, p.Key, i, path)
+				}
+				out = append(out, AdvisoryFile{Adapter: a.Identity.Name, Key: p.Key, Path: path, Reason: adv.Reason})
+			}
+		}
+	}
+	return out, nil
+}
+
 // HookConfigs is the hooks slice of the managed-file declaration — the agent
 // config files irrlicht installs hooks into, and nothing else.
 //

--- a/core/adapters/inbound/agents/managedfiles_test.go
+++ b/core/adapters/inbound/agents/managedfiles_test.go
@@ -357,3 +357,110 @@ func TestHookConfigsIsTheHooksSliceOfManagedUserFiles(t *testing.T) {
 			"uninstall the instruction blocks and the host config patch nobody asked it to touch", hooks)
 	}
 }
+
+// advisoryAdapter builds a one-permission adapter carrying the given
+// agent.AdvisoryWrite entries under the given key, with no Writes — Advisory
+// is independent of ManagedUserFile (issue #1748: a permission can shell out
+// to an external CLI that writes only advisory content).
+func advisoryAdapter(name, key string, advisory []agent.AdvisoryWrite) agent.Agent {
+	return agent.Agent{
+		Identity:    agent.Identity{Name: name},
+		Permissions: []agent.Permission{{Key: key, Kind: permission.KindModify, Advisory: advisory}},
+	}
+}
+
+// TestAdvisoryFilesResolves is AdvisoryFiles' basic contract: a declared,
+// resolvable path is projected with its adapter, key, and reason intact.
+func TestAdvisoryFilesResolves(t *testing.T) {
+	catalog := []agent.Agent{
+		advisoryAdapter("kiro-cli", "hooks", []agent.AdvisoryWrite{{
+			Path:   func() (string, error) { return "/tmp/kiro/data.sqlite3", nil },
+			Reason: "kiro-cli's own identity store",
+		}}),
+	}
+
+	got, err := AdvisoryFiles(catalog)
+	if err != nil {
+		t.Fatalf("AdvisoryFiles(): %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("AdvisoryFiles() = %v, want exactly one entry", got)
+	}
+	want := AdvisoryFile{Adapter: "kiro-cli", Key: "hooks", Path: "/tmp/kiro/data.sqlite3", Reason: "kiro-cli's own identity store"}
+	if got[0] != want {
+		t.Errorf("AdvisoryFiles() = %+v, want %+v", got[0], want)
+	}
+}
+
+// TestAdvisoryFilesSkipsAnUnresolvablePath is the deliberate asymmetry with
+// Writes.Path/Also: an agent.AdvisoryWrite is allowed to be scoped to a
+// platform where the write has actually been observed (kirocli's own
+// resolver is darwin-only), so a resolution error is skipped rather than
+// failing the whole projection — the same tolerance --print-advisory-files
+// and the recording rig's warning both need in order to run unmodified on an
+// OS an advisory entry does not cover.
+func TestAdvisoryFilesSkipsAnUnresolvablePath(t *testing.T) {
+	catalog := []agent.Agent{
+		advisoryAdapter("kiro-cli", "hooks", []agent.AdvisoryWrite{{
+			Path:   func() (string, error) { return "", errors.New("unverified on this OS") },
+			Reason: "platform-specific",
+		}}),
+	}
+
+	got, err := AdvisoryFiles(catalog)
+	if err != nil {
+		t.Fatalf("AdvisoryFiles() = %v, want no error — an unresolvable advisory path is skipped, not fatal", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("AdvisoryFiles() = %v, want none — the unresolvable entry must be skipped", got)
+	}
+}
+
+// TestAdvisoryFilesRejectsAMalformedDeclaration mirrors
+// TestManagedUserFilesRejectsUnusableDeclarations for Advisory: a nil Path
+// resolver is a malformed declaration (not an unresolvable platform) and must
+// fail loudly, and a resolved path that is not absolute is meaningless to
+// report.
+func TestAdvisoryFilesRejectsAMalformedDeclaration(t *testing.T) {
+	cases := []struct {
+		name     string
+		advisory []agent.AdvisoryWrite
+		want     string
+	}{
+		{"nil Path resolver", []agent.AdvisoryWrite{{Path: nil, Reason: "x"}}, "nil Path resolver"},
+		{"relative path", []agent.AdvisoryWrite{{
+			Path: func() (string, error) { return "data.sqlite3", nil }, Reason: "x",
+		}}, "not absolute"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			catalog := []agent.Agent{advisoryAdapter("kiro-cli", "hooks", tc.advisory)}
+			got, err := AdvisoryFiles(catalog)
+			if err == nil {
+				t.Fatalf("AdvisoryFiles() = %v, want an error naming %q", got, tc.want)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("error %q does not name %q", err, tc.want)
+			}
+		})
+	}
+}
+
+// TestAdvisoryFilesIgnoresPermissionsThatDeclareNone is a lock: a permission
+// with no Advisory entries contributes nothing, the common case for every
+// permission except kirocli's hooks install today.
+func TestAdvisoryFilesIgnoresPermissionsThatDeclareNone(t *testing.T) {
+	catalog := []agent.Agent{
+		writerAdapter("alpha", agent.HooksPermissionKey, &agent.ManagedUserFile{
+			Path:      func() (string, error) { return "/tmp/alpha/settings.json", nil },
+			Uninstall: func() (bool, error) { return false, nil },
+		}),
+	}
+	got, err := AdvisoryFiles(catalog)
+	if err != nil {
+		t.Fatalf("AdvisoryFiles(): %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("AdvisoryFiles() = %v, want none — alpha declares no Advisory entry", got)
+	}
+}

--- a/core/application/services/permission_shared_config_gate.go
+++ b/core/application/services/permission_shared_config_gate.go
@@ -52,6 +52,21 @@ import (
 // are not symmetric: a false "outside" refuses an install (safe, and says why),
 // while a false "inside" would permit one. Lexical comparison can only err
 // toward refusing, so it is the fail-closed choice rather than a shortcut.
+// Deliberately does not check p.Advisory (issue #1748). That field names a
+// path an Apply is KNOWN to write but that ManagedUserFile cannot represent —
+// kiro-cli's own agent-identity sqlite store is the one declared instance —
+// and it would seem to belong here on the same logic as Path/Also: the
+// hazard this guard exists for (a grant-all daemon writing into the
+// operator's real $HOME) is identical in shape. It is left out because
+// extending the refusal is a live-behavior change nothing has measured:
+// whether kiro-cli's data store actually escapes the isolated home under
+// today's recording setups depends on whether $HOME itself is redirected
+// there, which no test here exercises. Wiring this in wrong, in the refusing
+// direction, would silently break every grant-all recording of kiro-cli's
+// hook install; wrong in the permitting direction adds nothing #1748 asked
+// for (Advisory already gets its own visibility path — see agent.AdvisoryWrite,
+// agents.AdvisoryFiles, --print-advisory-files). Left as a documented option
+// for whoever next measures that configuration, not a guess shipped here.
 func (s *PermissionService) sharedConfigRefusal(p agent.Permission) error {
 	if s.mode != config.PermissionModeGrantAll || p.Writes == nil {
 		return nil

--- a/core/cmd/irrlichd/dispatch_test.go
+++ b/core/cmd/irrlichd/dispatch_test.go
@@ -41,6 +41,7 @@ func TestSelectActionOrder(t *testing.T) {
 		"-v prints the version":                     {[]string{"-v"}, actionVersion},
 		"--uninstall-hooks":                         {[]string{"--uninstall-hooks"}, actionUninstallHooks},
 		"--print-managed-files":                     {[]string{"--print-managed-files"}, actionPrintManagedFiles},
+		"--print-advisory-files":                    {[]string{"--print-advisory-files"}, actionPrintAdvisoryFiles},
 		"--uninstall-task-eta":                      {[]string{"--uninstall-task-eta"}, actionUninstallTaskEta},
 		"--diagnose":                                {[]string{"--diagnose"}, actionDiagnose},
 		"the beacon verb":                           {[]string{"hook-post", "gemini-cli"}, actionBeacon},

--- a/core/cmd/irrlichd/main.go
+++ b/core/cmd/irrlichd/main.go
@@ -93,6 +93,7 @@ var knownFlags = []string{
 	"--diagnose",
 	"--uninstall-hooks",
 	"--print-managed-files",
+	"--print-advisory-files",
 	"--uninstall-task-eta",
 }
 
@@ -157,6 +158,7 @@ const (
 	actionVersion
 	actionUninstallHooks
 	actionPrintManagedFiles
+	actionPrintAdvisoryFiles
 	actionUninstallTaskEta
 	actionDiagnose
 	actionUnknownFlag
@@ -202,6 +204,8 @@ func selectAction(args []string) cliAction {
 		return actionUninstallHooks
 	case hasFlagIn(args, "--print-managed-files"):
 		return actionPrintManagedFiles
+	case hasFlagIn(args, "--print-advisory-files"):
+		return actionPrintAdvisoryFiles
 	case hasFlagIn(args, "--uninstall-task-eta"):
 		return actionUninstallTaskEta
 	case hasFlagIn(args, "--diagnose"):
@@ -252,6 +256,11 @@ func runCLIAction(action cliAction, args []string) int {
 		uninstallHooks()
 	case actionPrintManagedFiles:
 		if err := printManagedFiles(os.Stdout); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			return 1
+		}
+	case actionPrintAdvisoryFiles:
+		if err := printAdvisoryFiles(os.Stdout); err != nil {
 			fmt.Fprintln(os.Stderr, err)
 			return 1
 		}
@@ -449,6 +458,43 @@ func writeManagedFilePaths(w io.Writer, configs []agents.ManagedUserFile) {
 		for _, also := range c.Also {
 			print(also)
 		}
+	}
+}
+
+// printAdvisoryFiles writes one "<path>\t<reason>" line for every declared
+// agent.AdvisoryWrite (issue #1748) — paths an Apply is known to write that
+// hold no irrlicht content, are unverified outside their declared platform, or
+// are otherwise unsafe to snapshot/restore (kiro-cli's own agent-identity
+// sqlite store is the motivating, and today only, case).
+//
+// Kept a SEPARATE flag from --print-managed-files rather than a second section
+// of the same stream: writeManagedFilePaths' own doc states the rig's
+// managed_file_paths() backs up and restores whatever that prints, ONE FILE
+// PER LINE, keyed by line index, with no notion of "this line means something
+// different" — folding a path+reason pair into that stream would make the rig
+// try to back up a line that is not a bare path, or silently misindex every
+// path after it.
+//
+// An empty result is NOT an error here, unlike printManagedFiles: advisory
+// declarations are inherently optional (most permissions have none, and an
+// entry itself may resolve on only one platform), so "nothing to report"
+// is the ordinary case rather than a sign the safety net is off.
+func printAdvisoryFiles(w io.Writer) error {
+	files, err := agents.AdvisoryFiles(declaredConsentCatalog())
+	if err != nil {
+		return fmt.Errorf("failed to resolve advisory files: %w", err)
+	}
+	writeAdvisoryFiles(w, files)
+	return nil
+}
+
+// writeAdvisoryFiles prints one tab-separated "<path>\t<reason>" line per
+// entry. Not deduplicated like writeManagedFilePaths: unlike Path/Also, two
+// advisory entries naming the same path with different reasons is not a
+// contradiction worth hiding, and there is exactly one declaration today.
+func writeAdvisoryFiles(w io.Writer, files []agents.AdvisoryFile) {
+	for _, f := range files {
+		fmt.Fprintf(w, "%s\t%s\n", f.Path, f.Reason)
 	}
 }
 

--- a/core/cmd/irrlichd/managedfiles_test.go
+++ b/core/cmd/irrlichd/managedfiles_test.go
@@ -8,6 +8,7 @@ import (
 	"go/parser"
 	"go/token"
 	"os"
+	"runtime"
 	"sort"
 	"strings"
 	"testing"
@@ -79,6 +80,102 @@ func TestPrintManagedFilesCoversEveryDeclaredFile(t *testing.T) {
 		if !want[p] {
 			t.Errorf("--print-managed-files listed %q, which no permission declares", p)
 		}
+	}
+}
+
+// TestPrintAdvisoryFilesCoversEveryDeclaredAdvisoryFile mirrors
+// TestPrintManagedFilesCoversEveryDeclaredFile for the advisory category
+// (#1748): whatever agents.AdvisoryFiles resolves out of the live catalog must
+// appear in --print-advisory-files' output, and nothing else.
+//
+// An empty `files` is only a pass on a platform where kirocli's
+// kiroDataStorePath is EXPECTED to be unresolvable (anything but darwin,
+// #1748) — and even there it is a loud, named t.Skip rather than a silent
+// zero-iteration loop, so "checked and found nothing" stays distinguishable
+// from "cannot check here" (the same distinction
+// TestExternalInstallerAdvisoryFilesAreDeclared's structural half draws in
+// managedwrites_test.go). On darwin an empty result is still a hard failure:
+// the one declaration that exists today is expected to resolve there.
+//
+// Contract test — it passes by construction; seen red (tools/mutate.sh) by
+// removing kirocli's Advisory declaration, which empties the resolved set
+// while leaving nothing for the loop below to check — see the PR body.
+func TestPrintAdvisoryFilesCoversEveryDeclaredAdvisoryFile(t *testing.T) {
+	files, err := agents.AdvisoryFiles(declaredConsentCatalog())
+	if err != nil {
+		t.Fatalf("agents.AdvisoryFiles(declaredConsentCatalog()): %v", err)
+	}
+	skipOrFailIfNoAdvisoryFilesResolved(t, files)
+
+	var buf bytes.Buffer
+	if err := printAdvisoryFiles(&buf); err != nil {
+		t.Fatalf("printAdvisoryFiles: %v", err)
+	}
+	out := buf.String()
+
+	for _, f := range files {
+		line := f.Path + "\t" + f.Reason
+		if !strings.Contains(out, line) {
+			t.Errorf("--print-advisory-files does not list %s/%s's declared %q: an operator "+
+				"or the recording rig has no way to learn a recording touched it (#1748)",
+				f.Adapter, f.Key, f.Path)
+		}
+	}
+}
+
+// skipOrFailIfNoAdvisoryFilesResolved is
+// TestPrintAdvisoryFilesCoversEveryDeclaredAdvisoryFile's empty-result
+// decision, pulled out so the platform-conditional branch reads as one named
+// choice rather than nested inside the test itself.
+//
+// An empty `files` is only a pass on a platform where kirocli's
+// kiroDataStorePath is EXPECTED to be unresolvable (anything but darwin,
+// #1748) — and even there it is a loud, named t.Skip rather than a silent
+// zero-iteration loop, so "checked and found nothing" stays distinguishable
+// from "cannot check here" (the same distinction
+// TestExternalInstallerAdvisoryFilesAreDeclared's structural half draws in
+// managedwrites_test.go). On darwin an empty result is still a hard failure:
+// the one declaration that exists today is expected to resolve there.
+func skipOrFailIfNoAdvisoryFilesResolved(t *testing.T, files []agents.AdvisoryFile) {
+	t.Helper()
+	if len(files) != 0 {
+		return
+	}
+	if runtime.GOOS != "darwin" {
+		t.Skipf("no advisory file resolves on %s — kirocli's kiroDataStorePath is "+
+			"darwin-only (#1748); TestExternalInstallerAdvisoryFilesAreDeclared still checks "+
+			"the declaration's structure on every platform", runtime.GOOS)
+	}
+	t.Fatal("no advisory file resolved on darwin — this check would otherwise pass " +
+		"vacuously, and kirocli's declaration is expected to resolve here")
+}
+
+// TestWriteAdvisoryFilesFormat pins the "<path>\t<reason>" shape the rig's
+// warn-only step (tools/onboarding-factory/scripts/lib/managed-file-snapshot.sh)
+// parses. Unlike writeManagedFilePaths there is no dedup requirement: advisory
+// entries are reported, never backed up or restored, so two entries naming the
+// same path is not the index-collision hazard #1449 is about.
+func TestWriteAdvisoryFilesFormat(t *testing.T) {
+	var buf bytes.Buffer
+	writeAdvisoryFiles(&buf, []agents.AdvisoryFile{
+		{Adapter: "kiro-cli", Key: "hooks", Path: "/tmp/kiro/data.sqlite3", Reason: "kiro-cli's own store"},
+	})
+	want := "/tmp/kiro/data.sqlite3\tkiro-cli's own store\n"
+	if got := buf.String(); got != want {
+		t.Errorf("writeAdvisoryFiles() = %q, want %q", got, want)
+	}
+}
+
+// TestPrintAdvisoryFilesEmptyIsNotAnError is the deliberate asymmetry with
+// printManagedFiles: an advisory declaration is optional by nature (most
+// permissions have none, and kirocli's own resolver is darwin-only), so an
+// empty catalog of advisory files is the ordinary case, not a sign the safety
+// net silently went missing the way an empty --print-managed-files would be.
+func TestPrintAdvisoryFilesEmptyIsNotAnError(t *testing.T) {
+	var buf bytes.Buffer
+	writeAdvisoryFiles(&buf, nil)
+	if got := buf.String(); got != "" {
+		t.Errorf("writeAdvisoryFiles(nil) printed %q, want empty", got)
 	}
 }
 

--- a/core/cmd/irrlichd/managedwrites_test.go
+++ b/core/cmd/irrlichd/managedwrites_test.go
@@ -43,17 +43,49 @@
 //     2026-08-22, `kiro-cli agent create irrlicht --from kiro_default` under a
 //     scratch $HOME created
 //     $HOME/Library/Application Support/kiro-cli/data.sqlite3 (see the PR body
-//     for the raw output). Which further files it writes depends on whether
-//     the developer is logged in — a verdict nobody controls.
+//     for the raw output) — present even though that install FAILED (not
+//     logged in), so it is a property of the binary launching at all, not of
+//     the install succeeding. Which further files beyond that one it writes
+//     still depends on whether the developer is logged in — a verdict nobody
+//     controls, and #1748 leaves that residue exactly as unaudited as this
+//     paragraph always said it was.
 //
 // So kiro-cli's Apply is not run. Its permission is named in
 // applyRunsAnExternalCLI with that reason, and the static arm grades its
 // package instead: every package-level `func() (string, error)` there must be
-// one the declaration names, or be named in notAManagedFilePath with why. The
-// declared side is DERIVED from production by reflecting the function names out
-// of Writes.Path/Writes.Also, so it cannot drift from a hand-kept list, and the
-// walk is vacuity-guarded by requiring every reflected name to be found in the
+// one the declaration names — in Writes.Path, Writes.Also, OR Advisory
+// (#1748, below) — or be named in notAManagedFilePath with why. The declared
+// side is DERIVED from production by reflecting the function names out of all
+// three, so it cannot drift from a hand-kept list, and the walk is
+// vacuity-guarded by requiring every reflected name to be found in the
 // package it claims to have parsed.
+//
+// # A third declaration for what neither Writes nor an exemption can name
+//
+// #1741's own report on data.sqlite3 (the measured write above) left it as a
+// known, unaudited exception — true, but not yet a place in the declaration
+// model for it to LIVE. It is not a missing Also entry: the three reasons are
+// in agent.Permission.Advisory's own doc (no irrlicht content, so Uninstall
+// is meaningless; unverified beyond darwin; a live external sqlite store is a
+// corruption risk to snapshot/restore blindly, not a protection). #1748
+// answers the question #1741 left open by giving it a category of its own —
+// agent.AdvisoryWrite, reported by --print-advisory-files and warned about
+// (never backed up or restored) by the recording rig — rather than either
+// forcing it into Also's undo/backup contract or leaving it a comment nobody
+// enforces. kirocli.kiroDataStorePath is the first, and so far only, entry;
+// the static arm above already treats it as declared once it appears in
+// Advisory, and TestExternalInstallerAdvisoryFilesAreDeclared below is its own
+// existence check, the same shape applyRunsAnExternalCLI's is.
+//
+// Deliberately NOT wired into #1449's sharedConfigRefusal: that guard refuses
+// an ENTIRE Apply when a declared path escapes the daemon's isolated home, and
+// extending it to Advisory would, for kiro-cli specifically, only ever matter
+// when $HOME itself is not redirected into that isolated home — a
+// configuration nothing here has exercised live. Getting that wrong in the
+// refusing direction would silently break every grant-all recording of
+// kiro-cli's hook install; getting it wrong in the permitting direction adds
+// nothing #1748 asked for. Left as a documented option for whoever next
+// measures that case, not a guess shipped in this PR.
 //
 // #1741 measured the static rule at roughly one false positive per adapter —
 // every adapter has a home-ROOT resolver with that exact signature — which is
@@ -87,6 +119,7 @@ package main
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"go/ast"
 	"go/parser"
@@ -141,8 +174,9 @@ var applyRunsAnExternalCLI = map[string]externalInstaller{
 			"`kiro-cli agent set-default` (kiroctl.go). Measured 2026-08-22: with the " +
 			"binary ABSENT the closure fails at its first step and writes nothing, so the " +
 			"runtime arm would grade an empty set; with it PRESENT the child writes its own " +
-			"state under $HOME/Library/Application Support/kiro-cli/, and how much more it " +
-			"writes depends on whether the developer is logged in. Either way the verdict " +
+			"state under $HOME/Library/Application Support/kiro-cli/ (data.sqlite3, now " +
+			"declared as an agent.AdvisoryWrite — #1748), and how much more it writes beyond " +
+			"that depends on whether the developer is logged in. Either way the verdict " +
 			"stops being a property of this repo. Graded by the static arm instead",
 	},
 }
@@ -382,6 +416,28 @@ func assertExternalInstallerAgrees(t *testing.T, id string, ext externalInstalle
 // resolveDeclared resolves Writes.Path and every Writes.Also entry, keeping the
 // resolution error rather than dropping it: a resolver that fails is a file we
 // cannot prove is inside the scratch home, which is the fail-closed case.
+//
+// Deliberately does NOT also resolve p.Advisory (issue #1748). The static
+// arm's declaredResolverNames folds Advisory in because it only asks "is this
+// resolver NAMED somewhere" — but this function feeds
+// assertEveryDeclaredPathIsContained, which is fail-closed on ANY resolution
+// error (`t.Fatalf`, by design: a test that cannot name a file must not run
+// the closure that writes it). An agent.AdvisoryWrite's own contract is the
+// opposite of that assumption — it is EXPECTED to fail to resolve off its
+// declared platform (kirocli's kiroDataStorePath is darwin-only) — so
+// folding it in here as-is would abort the entire runtime arm, for every
+// permission, the moment any adapter's Advisory entry legitimately can't
+// resolve on the CI runner's OS. Today this is inert either way: the one
+// Advisory declaration belongs to kiro-cli/hooks, which gradablePermissions
+// excludes from the runtime arm entirely (via applyRunsAnExternalCLI) before
+// resolveDeclared is ever called on it. A FUTURE adapter that declares
+// Advisory on a permission the runtime arm DOES execute would need this
+// function (and assertEveryDeclaredPathIsContained's fail-closed check) to
+// tell an Advisory resolution error apart from a Writes.Path/Also one before
+// folding it in — left undone here because no such adapter exists yet to
+// verify the fix against, matching the same reasoning
+// permission_shared_config_gate.go's sharedConfigRefusal doc gives for not
+// wiring Advisory in there either.
 func resolveDeclared(p agent.Permission) []declaredFile {
 	if p.Writes == nil {
 		return nil
@@ -705,6 +761,128 @@ func TestExternalInstallerPackagesDeclareEveryPathResolver(t *testing.T) {
 	assertNoStaleResolverExemptions(t, usedExemptions)
 }
 
+// knownExternalWrites names, for a permission in applyRunsAnExternalCLI, the
+// file basenames its external CLI is MEASURED to write beyond anything a Go
+// resolver in the package could ever name (#1748) — a claim someone wrote
+// down and a reviewer can check, exactly like applyRunsAnExternalCLI itself
+// (see its own doc for why this cannot be derived). PR #1747's own body
+// measured `kiro-cli agent create`/`agent set-default` creating
+// $HOME/Library/Application Support/kiro-cli/data.sqlite3 even when the
+// install itself failed (not logged in) — a side effect of the binary
+// launching at all, not of the install succeeding.
+//
+// This is the existence check for that claim: every basename here must appear
+// among the permission's OWN declared agent.AdvisoryWrite entries, resolved.
+// A basename that stops appearing means #1748's whole point — that irrlicht
+// KNOWS this write happens — silently regressed back to an unaudited aside.
+var knownExternalWrites = map[string][]string{
+	"kiro-cli/hooks": {"data.sqlite3"},
+}
+
+// TestExternalInstallerAdvisoryFilesAreDeclared is knownExternalWrites'
+// existence check, run in both directions: an entry naming a permission that
+// does not exist fails loudly rather than being skipped, and a permission
+// whose declared Advisory basenames do not match what was measured fails by
+// name.
+//
+// Two properties are checked on EVERY platform, not only the one an entry's
+// Path resolver happens to resolve on: the permission must declare at least
+// one Advisory entry at all, and every declared entry must have a non-nil
+// Path and a non-empty Reason. Only the exact-basename comparison is
+// conditional — an agent.AdvisoryWrite's own contract allows a Path resolver
+// to be scoped to one platform (kirocli's kiroDataStorePath is darwin-only),
+// and asserting basename equality unconditionally would make this pass on
+// every OTHER platform's CI runner having checked nothing (measured: it
+// failed build-test's `Test (linux, race)` job with `got=[]` the first time
+// this test shipped, see the PR body). assertAdvisoryBasenames skips only
+// that one comparison when every resolver in the entry errored, and says so,
+// rather than silently reporting a clean result for a check that never ran.
+//
+// Contract test — it passes by construction; seen red (tools/mutate.sh) by
+// removing kirocli's Advisory declaration, see the PR body for the captured
+// output (that mutation fails BOTH the structural check here and
+// TestExternalInstallerPackagesDeclareEveryPathResolver above, on every
+// platform, since the structural checks do not depend on any resolver
+// actually resolving).
+func TestExternalInstallerAdvisoryFilesAreDeclared(t *testing.T) {
+	perms := permissionsByID(declaredConsentCatalog())
+	for id, want := range knownExternalWrites {
+		p, ok := perms[id]
+		if !ok {
+			t.Fatalf("knownExternalWrites names permission %q, which does not exist in the catalog", id)
+		}
+		if len(p.Advisory) == 0 {
+			t.Fatalf("%s: knownExternalWrites measured an external write for this permission, but "+
+				"it declares no Advisory entry at all (#1748)", id)
+		}
+		assertAdvisoryBasenames(t, id, p.Advisory, want)
+	}
+}
+
+// assertAdvisoryBasenames is TestExternalInstallerAdvisoryFilesAreDeclared's
+// per-permission body, pulled out so the platform-conditional skip reads as
+// one decision rather than nested inside the outer loop.
+func assertAdvisoryBasenames(t *testing.T, id string, advisory []agent.AdvisoryWrite, want []string) {
+	t.Helper()
+	var got []string
+	resolveErrs := 0
+	for i, adv := range advisory {
+		if adv.Path == nil {
+			t.Errorf("%s: Advisory[%d] has a nil Path resolver", id, i)
+			continue
+		}
+		if adv.Reason == "" {
+			t.Errorf("%s: Advisory[%d] has an empty Reason", id, i)
+		}
+		path, err := adv.Path()
+		if err != nil {
+			resolveErrs++
+			continue // unresolvable on this platform — agent.AdvisoryWrite's own contract
+		}
+		got = append(got, filepath.Base(path))
+	}
+
+	if len(got) == 0 && resolveErrs == len(advisory) {
+		t.Logf("%s: every Advisory Path resolver errored on %s — skipping the exact-basename "+
+			"check (a resolver may legitimately be scoped to one platform, #1748); the "+
+			"structural checks above (an entry exists, with a Path and a Reason) still ran",
+			id, runtime.GOOS)
+		return
+	}
+
+	sort.Strings(got)
+	wantSorted := append([]string(nil), want...)
+	sort.Strings(wantSorted)
+	if strings.Join(got, ",") != strings.Join(wantSorted, ",") {
+		t.Errorf("%s: Advisory declares basenames %v, want %v (#1748) — the measured "+
+			"external write this permission is known to cause is no longer named anywhere "+
+			"the declaration model can report it", id, got, wantSorted)
+	}
+}
+
+// TestAssertAdvisoryBasenamesSkipsWhenEveryResolverErrors is the defect test
+// for the shape TestExternalInstallerAdvisoryFilesAreDeclared shipped with
+// initially: a hard equality check against `got` failed on ANY platform where
+// every Advisory Path resolver legitimately errors (measured on this PR's own
+// build-test job, `Test (linux, race)`, before this fix — see the PR body for
+// the captured failure). Driven with a synthetic, always-erroring resolver
+// rather than depending on runtime.GOOS actually being non-darwin, so this
+// stays a real regression test on every CI runner rather than one that can
+// only ever exercise itself on Linux.
+func TestAssertAdvisoryBasenamesSkipsWhenEveryResolverErrors(t *testing.T) {
+	ok := t.Run("inner", func(t *testing.T) {
+		assertAdvisoryBasenames(t, "fake/perm", []agent.AdvisoryWrite{{
+			Path:   func() (string, error) { return "", errors.New("unsupported on this platform") },
+			Reason: "test-only synthetic entry",
+		}}, []string{"data.sqlite3"})
+	})
+	if !ok {
+		t.Error("assertAdvisoryBasenames failed when every resolver legitimately errored — this " +
+			"is exactly the shape a platform-scoped Advisory entry produces off its declared " +
+			"platform, and it must not fail the test (#1748)")
+	}
+}
+
 // permissionsByID indexes the catalog by "<adapter>/<key>".
 func permissionsByID(catalog []agent.Agent) map[string]agent.Permission {
 	out := map[string]agent.Permission{}
@@ -775,10 +953,12 @@ func gradeExternalInstallerPackage(t *testing.T, id string, p agent.Permission, 
 			continue
 		}
 		t.Errorf("%s.%s is a package-level path resolver that %s declares in neither "+
-			"Writes.Path nor Writes.Also. If its Apply writes that file, it is invisible to "+
-			"--print-managed-files, to the recording rig's backup and to #1449's grant-all "+
-			"refusal (#1739). Declare it, or add %q to notAManagedFilePath with the reason "+
-			"it names no managed file", pkgName, name, id, key)
+			"Writes.Path, Writes.Also, nor Advisory. If its Apply writes that file, it is "+
+			"invisible to --print-managed-files, to the recording rig's backup and to #1449's "+
+			"grant-all refusal (#1739) — or, if it holds no irrlicht content and cannot be "+
+			"safely backed up, invisible to --print-advisory-files and the rig's warning "+
+			"(#1748). Declare it under whichever fits, or add %q to notAManagedFilePath with "+
+			"the reason it names no managed file", pkgName, name, id, key)
 	}
 }
 
@@ -788,9 +968,6 @@ func gradeExternalInstallerPackage(t *testing.T, id string, p agent.Permission, 
 // package walk cannot match, which surfaces as the vacuity failure above rather
 // than as silence.
 func declaredResolverNames(p agent.Permission) []string {
-	if p.Writes == nil {
-		return nil
-	}
 	var out []string
 	add := func(f func() (string, error)) {
 		if f == nil {
@@ -802,9 +979,20 @@ func declaredResolverNames(p agent.Permission) []string {
 		}
 		out = append(out, fn.Name())
 	}
-	add(p.Writes.Path)
-	for _, also := range p.Writes.Also {
-		add(also)
+	if p.Writes != nil {
+		add(p.Writes.Path)
+		for _, also := range p.Writes.Also {
+			add(also)
+		}
+	}
+	// Advisory (#1748): a resolver declared here is just as much a KNOWN,
+	// named file as one in Writes.Path/Also — it is only the backup/restore
+	// and Uninstall semantics that differ, which this arm does not grade.
+	// Omitting it would make kirocli's kiroDataStorePath read as an
+	// undeclared resolver the moment it existed, exactly the false positive
+	// this arm exists to avoid.
+	for _, adv := range p.Advisory {
+		add(adv.Path)
 	}
 	return out
 }

--- a/core/domain/agent/declaration.go
+++ b/core/domain/agent/declaration.go
@@ -115,6 +115,52 @@ type Permission struct {
 	// carries what callers OUTSIDE the adapter need: which file, and how to
 	// take irrlicht's content back out.
 	Writes *ManagedUserFile
+
+	// Advisory declares paths this permission's Apply is KNOWN to cause to be
+	// written, that ManagedUserFile cannot represent (issue #1748). The
+	// motivating case: kiro-cli/hooks's Apply shells out to the real
+	// `kiro-cli` binary, and that child process writes its OWN identity store
+	// ($HOME/Library/Application Support/kiro-cli/data.sqlite3) as a side
+	// effect of merely launching — measured true even when the install itself
+	// fails. Also cannot hold this because Also's whole contract (#1718)
+	// assumes what ManagedUserFile assumes everywhere else: the content is
+	// irrlicht's, so Uninstall can remove it and a snapshot/restore can safely
+	// stand in for "don't touch it". Neither holds for an agent CLI's own
+	// database:
+	//
+	//   - It carries no irrlicht content, so Uninstall is meaningless for it.
+	//   - Where it lives is platform-specific and has only been verified on
+	//     one OS (kiro-cli's own resolver may put it somewhere else entirely
+	//     on another).
+	//   - It is a live external store; blindly snapshotting and restoring one
+	//     is a corruption risk, not a protection.
+	//
+	// So Advisory entries are declared for VISIBILITY only:
+	// --print-advisory-files reports them separately from
+	// --print-managed-files, and the recording rig warns that a recording
+	// touched them without attempting to back them up or restore them. See
+	// agents.AdvisoryFiles and core/cmd/irrlichd/managedwrites_test.go's
+	// static arm, which now recognizes an Advisory resolver as declared the
+	// same way it already recognizes Writes.Path/Also.
+	Advisory []AdvisoryWrite
+}
+
+// AdvisoryWrite is one path a permission's Apply is known to write that holds
+// no irrlicht-authored content — see Permission.Advisory for why it is a
+// separate category from ManagedUserFile rather than another Also entry.
+type AdvisoryWrite struct {
+	// Path resolves the absolute path the write is known to land at. Unlike
+	// ManagedUserFile.Path, a resolution error here is tolerated by every
+	// consumer (agents.AdvisoryFiles skips it) rather than treated as fatal:
+	// an advisory declaration is explicitly allowed to be scoped to a
+	// platform where the write has actually been observed, and "unverified
+	// elsewhere" is not the same defect as "our own required config failed to
+	// resolve".
+	Path func() (string, error)
+	// Reason documents what the path is and why it is advisory rather than a
+	// Writes.Also entry — shown verbatim by --print-advisory-files and the
+	// recording rig's warning.
+	Reason string
 }
 
 // HooksPermissionKey is the permission key under which an adapter installs

--- a/docs/testing-contracts.md
+++ b/docs/testing-contracts.md
@@ -691,6 +691,45 @@ below.
   `multiple-agents-same-workspace` scenario family) is still visible via its
   own file-based signal — only the install-a-real-file side effect is
   narrowed.
+  #1748 gives the declaration model a **third category**, for a write neither
+  `Writes` nor an `applyRunsAnExternalCLI` exemption can express: kiro-cli's
+  `Apply` shells out to the real binary, and that CHILD process's own
+  identity store (`$HOME/Library/Application Support/kiro-cli/data.sqlite3`,
+  the same measured write `TestExternalInstallerPackagesDeclareEveryPathResolver`
+  above names) is a path no Go resolver in the adapter ever computes — there
+  is no `filepath.Join` call to find, static or runtime. It is not a missing
+  `Also` entry: `Also`'s whole contract assumes the content is irrlicht's
+  (so `Uninstall` can remove it) and that a snapshot/restore is safe (so the
+  recorder can protect it) — neither holds for another CLI's own live
+  database, which holds no irrlicht content and would risk corruption if
+  blindly copied back over a process that may still be writing to it.
+  `agent.Permission.Advisory` (`[]agent.AdvisoryWrite{Path, Reason}`) is the
+  category for exactly this: declared for VISIBILITY only, resolved by
+  `agents.AdvisoryFiles` (a resolution failure is SKIPPED rather than fatal —
+  unlike `Writes.Path`/`Also`, an advisory entry is allowed to be scoped to
+  one platform; kirocli's is darwin-only, unverified elsewhere per the issue),
+  reported by a new, separate flag `--print-advisory-files` (`<path>\t<reason>`
+  per line — kept off `--print-managed-files`'s own stream because that one's
+  rig consumer backs up and restores whatever it prints, keyed by LINE INDEX,
+  with no room for a non-path line or a second field), and warned about
+  (never backed up, never restored) by the recording rig's new
+  `warn_advisory_files` (`managed-file-snapshot.sh`), called right after
+  `snapshot_managed_files` in `spawn_record_daemon`. The static arm above
+  now folds `Advisory` into its own "declared" set alongside `Writes.Path`/
+  `Also` (`declaredResolverNames`), so kirocli's new `kiroDataStorePath`
+  resolver reads as declared rather than as a package-level resolver nobody
+  named. A second registry check, `TestExternalInstallerAdvisoryFilesAreDeclared`
+  (`knownExternalWrites`), is `applyRunsAnExternalCLI`'s own existence-check
+  pattern one field over: it pins that the ONE measured external write
+  (`data.sqlite3`) stays named in `Advisory` rather than silently regressing
+  to the unaudited aside #1741 originally left it as. Deliberately **not**
+  wired into `sharedConfigRefusal` above: extending that refusal to `Advisory`
+  would only matter for kiro-cli when `$HOME` itself is not redirected into
+  the isolated home, a configuration nothing here has measured live — getting
+  it wrong in the refusing direction would silently break every grant-all
+  recording of kiro-cli's hook install. Left as a documented option
+  (`permission_shared_config_gate.go`'s own doc comment) for whoever next
+  measures that case, not a guess shipped with the visibility fix.
   All seven contract families pass by construction against a correct adapter
   — every route and entry shape the hook-endpoint family grades now has one
   (see that bullet above) — so their whole value is that they *can* fail.

--- a/tools/onboarding-factory/scripts/lib/managed-file-snapshot.sh
+++ b/tools/onboarding-factory/scripts/lib/managed-file-snapshot.sh
@@ -30,11 +30,19 @@
 # Usage — call the first before spawning the daemon, the second from cleanup:
 #   source "$SCRIPT_DIR/lib/managed-file-snapshot.sh"
 #   snapshot_managed_files "$STAGING/managed-file-backup" "$DAEMON" || exit 1
+#   warn_advisory_files "$DAEMON"   # optional: report-only, see below
 #   ... spawn daemon, drive agent ...
 #   restore_managed_files
 #
 # restore_managed_files is a no-op unless a snapshot completed, so it is safe to
 # call unconditionally from an EXIT trap.
+#
+# warn_advisory_files is a THIRD, separate category (issue #1748):
+# `irrlichd --print-advisory-files` names paths an Apply is KNOWN to write
+# that hold no irrlicht content and cannot be safely snapshotted/restored (an
+# agent CLI's own store — kiro-cli's identity database is the one declared
+# case). Never backed up, never restored — see the function's own doc for why
+# that is deliberate rather than a gap in this one.
 
 # MANAGED_FILE_BACKUP_DIR is the only state the pair shares, and it is set ONLY
 # by a snapshot that ran to completion. Everything restore does comes out of the
@@ -206,6 +214,74 @@ snapshot_managed_files() {
   fi
 
   MANAGED_FILE_BACKUP_DIR="$backup_dir"
+  return 0
+}
+
+# warn_advisory_files <daemon-bin> prints one WARN line per advisory path
+# (`irrlichd --print-advisory-files`, issue #1748) — a path an Apply is KNOWN
+# to write that holds no irrlicht content and cannot be safely snapshotted or
+# restored (kiro-cli's own agent-identity sqlite store is the motivating,
+# and today only, case). Unlike snapshot_managed_files above, this is
+# VISIBILITY ONLY: nothing here is backed up, nothing here is restored — the
+# whole point is telling the operator a recording touched a store this rig
+# cannot safely undo, not pretending the rig can undo it.
+#
+# Best-effort and NEVER fails the recording, on purpose: an irrlichd predating
+# the flag is rejected by `hasFlag` and prints nothing to stdout (the same
+# fallthrough managed_file_paths' own doc names), and a catalog with no
+# advisory declarations at all is the ordinary case, not a fault. Either way
+# this returns 0 — including when the daemon exits non-zero or hangs.
+#
+# Deliberately NOT `"$daemon_bin" ... | while read ...`: both real callers
+# (run-cell.sh, run-cell-multi.sh) run under `set -euo pipefail`, and this is
+# invoked as a bare statement in spawn_record_daemon — under `pipefail` a
+# non-zero daemon exit becomes the PIPELINE's exit status, and under the
+# inherited `errexit` that aborts the whole calling script right there,
+# before this function's own `return 0` ever runs (measured: a stub daemon
+# exiting 2 killed the caller under bash 3.2, this repo's floor). Redirecting
+# to a file and reading it back afterward, exactly like managed_file_paths
+# above, keeps this function's own exit status the only thing that reaches
+# the caller.
+#
+# Every `wait`/`kill` below is ALSO guarded with its own `|| true` /
+# `|| rc=$?`, not just the pipe removed above. `wait "$pid"; rc=$?` alone is
+# the SAME hazard one line down: under `errexit`, a bare `wait` returning the
+# backgrounded process's non-zero status aborts the caller right there, same
+# as the pipe did — it only happens NOT to fire for managed_file_paths' own
+# copy of this pattern because that function's one call site is the left side
+# of `||` in snapshot_managed_files, which (per bash's documented -e
+# semantics) suspends errexit for that whole function body as a side effect
+# of the CALL site, not a property of the function itself. This function's
+# own doc promises "never fails the recording" regardless of how it is
+# invoked, so it does not rely on being called that way — every internal
+# command that can return non-zero is guarded here directly (measured: this
+# was caught by this file's own committed regression test, which drives the
+# function under `set -euo pipefail` as a bare statement, matching
+# spawn_record_daemon's actual call site).
+warn_advisory_files() {
+  local daemon_bin="$1" secs="${MANAGED_FILE_PROBE_TIMEOUT_S:-20}"
+  local outf rc pid watchdog path reason
+  outf="$(mktemp)" || return 0
+
+  "$daemon_bin" --print-advisory-files >"$outf" 2>/dev/null &
+  pid=$!
+  { sleep "$secs"; kill -KILL "$pid" 2>/dev/null || true; } >/dev/null 2>&1 &
+  watchdog=$!
+  rc=0
+  wait "$pid" || rc=$?
+  kill "$watchdog" 2>/dev/null || true
+  wait "$watchdog" 2>/dev/null || true
+
+  if [[ "$rc" -ne 0 ]]; then
+    rm -f "$outf"
+    return 0
+  fi
+
+  while IFS=$'\t' read -r path reason; do
+    [[ -n "$path" ]] || continue
+    echo "managed-file-snapshot: ADVISORY — this recording's grant-all daemon is expected to write $path ($reason); not backed up, not restored (#1748)" >&2
+  done < "$outf"
+  rm -f "$outf"
   return 0
 }
 

--- a/tools/onboarding-factory/scripts/lib/managed-file-snapshot_test.sh
+++ b/tools/onboarding-factory/scripts/lib/managed-file-snapshot_test.sh
@@ -382,6 +382,76 @@ restore_managed_files
 [[ -e "$ROOT/backup/replaced" ]] && got=present || got=absent
 assert_eq "nothing was copied aside" "absent" "$got"
 
+echo "== warn_advisory_files reports without touching anything (#1748) =="
+# fake_advisory_daemon answers --print-advisory-files with the tab-separated
+# "<path>\t<reason>" lines given, standing in for the real irrlichd.
+fake_advisory_daemon() {
+  local bin="$1"; shift
+  printf '%s\n' "$@" > "$bin.advisory"
+  cat > "$bin" <<EOF
+#!/usr/bin/env bash
+[[ "\${1:-}" == "--print-advisory-files" ]] || { echo "unexpected args: \$*" >&2; exit 2; }
+cat "$bin.advisory"
+EOF
+  chmod +x "$bin"
+  return 0
+}
+
+fresh_env advisory_basic
+fake_advisory_daemon "$DAEMON" "$(printf '/tmp/kiro/data.sqlite3\tkiro-cli own store')"
+out="$(warn_advisory_files "$DAEMON" 2>&1)"
+rc=$?
+assert_eq "warn_advisory_files always succeeds" "0" "$rc"
+assert_eq "the warning names the path" "1" \
+  "$(grep -c "/tmp/kiro/data.sqlite3" <<<"$out" | tr -d ' ')"
+assert_eq "the warning is marked ADVISORY" "1" \
+  "$(grep -c "ADVISORY" <<<"$out" | tr -d ' ')"
+assert_eq "the warning names the reason" "1" \
+  "$(grep -c "kiro-cli own store" <<<"$out" | tr -d ' ')"
+assert_eq "nothing is backed up" "absent" \
+  "$([[ -e "$ROOT/managed-file-backup" ]] && echo present || echo absent)"
+
+echo "== warn_advisory_files is silent and succeeds with nothing declared =="
+fresh_env advisory_empty
+fake_advisory_daemon "$DAEMON"
+out="$(warn_advisory_files "$DAEMON" 2>&1)"
+rc=$?
+assert_eq "warn_advisory_files succeeds with nothing declared" "0" "$rc"
+assert_eq "nothing is printed" "" "$out"
+
+echo "== warn_advisory_files never fails when the daemon predates the flag =="
+fresh_env advisory_predates
+cat > "$DAEMON" <<'EOF'
+#!/usr/bin/env bash
+echo 'irrlichd: unknown flag "--print-advisory-files"' >&2
+exit 2
+EOF
+chmod +x "$DAEMON"
+out="$(warn_advisory_files "$DAEMON" 2>&1)"
+rc=$?
+assert_eq "warn_advisory_files never fails the recording" "0" "$rc"
+
+echo "== warn_advisory_files under production's set -euo pipefail never kills the caller =="
+# Reproduces the exact hazard at the real call site rather than this file's
+# own `set -uo pipefail` (no -e, deliberately, so assertions can capture a
+# non-zero return): both run-cell.sh and run-cell-multi.sh run under
+# `set -euo pipefail`, and spawn_record_daemon calls warn_advisory_files as a
+# BARE statement. A pipe-based implementation (`daemon | while read ...`) lets
+# a non-zero daemon exit become the PIPELINE's own status, which errexit then
+# treats as the whole script failing, right there — before this function's
+# own `return 0` ever runs. $DAEMON here is still the exit-2 stub the case
+# above just wrote.
+subshell_out="$(bash -c '
+  set -euo pipefail
+  source "'"$DIR"'/managed-file-snapshot.sh"
+  warn_advisory_files "'"$DAEMON"'"
+  echo SURVIVED
+' 2>&1)"
+subshell_rc=$?
+assert_eq "the calling script survives under set -euo pipefail" "0" "$subshell_rc"
+assert_eq "execution continues past the bare call" "1" \
+  "$(grep -c SURVIVED <<<"$subshell_out" | tr -d ' ')"
+
 echo "== the lib names no agent config path of its own (#1357) =="
 # The literal list is the defect. A path spelled out here is one the daemon
 # does not have to agree with, which is how the two drifted in the first place.

--- a/tools/onboarding-factory/scripts/lib/spawn-record-daemon.sh
+++ b/tools/onboarding-factory/scripts/lib/spawn-record-daemon.sh
@@ -175,6 +175,11 @@ spawn_record_daemon() {
     return 1
   fi
 
+  # Report-only, never gating (issue #1748): an agent CLI's own store that an
+  # Apply is known to write but that the snapshot above deliberately does not
+  # protect — see warn_advisory_files' own doc for why.
+  warn_advisory_files "$daemon_bin"
+
   # Read the env into an array so a value containing spaces (e.g. an
   # IRRLICHT_HOME path with a space) stays one word — an unquoted
   # ${home:+VAR="$home"} would word-split on it.


### PR DESCRIPTION
## Summary

Closes #1748.

kiro-cli/hooks' `Apply` shells out to the real `kiro-cli` binary
(`agent create` / `agent set-default`), and that CHILD process writes its
own agent-identity store — `$HOME/Library/Application Support/kiro-cli/data.sqlite3`
— as a side effect of merely launching (PR #1747's own measured evidence:
present even when the install itself failed with "not logged in"). Nothing
declared it: not `Writes.Path`, not `Writes.Also`, so `--print-managed-files`
never named it, the recording rig's snapshot never backed it up, and #1449's
`sharedConfigRefusal` never saw it. `applyRunsAnExternalCLI` in
`managedwrites_test.go` recorded this as a known, unaudited exception.

**Design decision.** The issue explicitly rules out just adding it to `Also`
(no irrlicht content → `Uninstall` is meaningless; macOS-specific and
unverified on Linux; a live sqlite store is a corruption risk to
snapshot/restore blindly) and proposes a middle answer worth evaluating: a
separate, **advisory** category — reported for visibility, never backed up
or restored. This PR adopts that answer:

- `agent.Permission.Advisory []agent.AdvisoryWrite{Path, Reason}` — a new,
  independent field (not nested under `ManagedUserFile`, which structurally
  requires `Path`+`Uninstall` — meaningless for a file that holds no
  irrlicht content).
- `agents.AdvisoryFiles` resolves it. Unlike `Writes.Path`/`Also`, a
  resolution failure is **skipped, not fatal** — an `AdvisoryWrite` is
  allowed to be scoped to one platform (`kiroDataStorePath` is darwin-only
  and says so; unverified elsewhere per the issue).
- A **new, separate flag**, `--print-advisory-files` (`<path>\t<reason>`
  per line). Kept off `--print-managed-files` deliberately:
  `writeManagedFilePaths`' own doc says the rig backs up and restores
  whatever that flag prints, **keyed by line index**, with no room for a
  non-path line or a second field — folding advisory entries into that
  stream would make the rig try to back one up, or silently misindex every
  path after it.
- The recording rig's new `warn_advisory_files`
  (`managed-file-snapshot.sh`), called right after `snapshot_managed_files`
  in `spawn_record_daemon` — reports, never backs up, never restores, never
  fails the recording.
- `managedwrites_test.go`'s static arm now folds `Advisory` into its
  "declared" set (`declaredResolverNames`), so `kiroDataStorePath` reads as
  declared rather than an orphaned resolver. A new registry check,
  `TestExternalInstallerAdvisoryFilesAreDeclared` /
  `knownExternalWrites`, pins that the ONE measured external write stays
  named — the same existence-check shape `applyRunsAnExternalCLI` already
  uses.

**Deliberately NOT wired into `PermissionService.sharedConfigRefusal`
(#1449).** That guard refuses an entire `Apply` when a declared path escapes
the daemon's isolated home under grant-all. Extending it to `Advisory` would
only ever matter for kiro-cli when `$HOME` itself is not redirected into the
isolated home — a configuration nothing here has measured live. Getting that
wrong in the refusing direction would silently break every grant-all
recording of kiro-cli's hook install; getting it wrong in the permitting
direction adds nothing the issue asked for (visibility already has its own
path). Documented as a deliberate, left-open option in the gate's own doc
comment — a decision for whoever next measures that configuration, not a
guess shipped here.

## Mutation evidence (`tools/mutate.sh`, both restored cleanly)

1. Removed the `Advisory` loop from `declaredResolverNames` (the static
   arm's extension) → `TestExternalInstallerPackagesDeclareEveryPathResolver`
   goes red, correctly reporting `kirocli.kiroDataStorePath` as an
   undeclared resolver.
2. Removed kirocli's `Advisory` declaration entirely → BOTH
   `TestExternalInstallerPackagesDeclareEveryPathResolver` AND the new
   `TestExternalInstallerAdvisoryFilesAreDeclared` go red.

Captured output (mutation 2):
```
managedwrites_test.go:735: kirocli.kiroDataStorePath is a package-level path resolver that
kiro-cli/hooks declares in neither Writes.Path, Writes.Also, nor Advisory. ...
--- FAIL: TestExternalInstallerPackagesDeclareEveryPathResolver (0.00s)
managedwrites_test.go:797: kiro-cli/hooks: Advisory declares basenames [], want [data.sqlite3] (#1748) ...
--- FAIL: TestExternalInstallerAdvisoryFilesAreDeclared (0.00s)
```

## Test plan

- [x] `go test ./core/... -race -count=1` — full suite green
- [x] `go test ./tools/onboarding-factory/... -race -count=1` — green
- [x] `tools/onboarding-factory/scripts/smoke-test.sh` — green (touched a rig
      script)
- [x] `bash tools/onboarding-factory/scripts/lib/managed-file-snapshot_test.sh`
      — green, new cases for `warn_advisory_files`
- [x] `tools/preflight.sh --only go/arch/bash/tools/posix/skills` — all PASS
- [x] Two `tools/mutate.sh` runs (above), both restored the tree cleanly
- [x] New unit tests: `agents.AdvisoryFiles` (resolves / skips unresolvable /
      rejects nil resolver / rejects relative path / ignores permissions with
      none), `printAdvisoryFiles`/`writeAdvisoryFiles`, CLI dispatch
      (`--print-advisory-files`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)