### PR TITLE
test(rig): enumerate agent.Source's variants in the rig-home tripwire, existence-checked

### DIFF
--- a/tools/onboarding-factory/internal/righome/righome.go
+++ b/tools/onboarding-factory/internal/righome/righome.go
@@ -291,6 +291,244 @@ func truncate(s string) string {
 	return s[:max] + "…"
 }
 
+// SourceVariantCoverage reports every disagreement between agent.Source's
+// declared variants (derived from every non-test file in core/domain/agent,
+// not just source.go — see sourceVariantsIn) and the cases a switch over that
+// type actually names. An empty result means every declared variant has a
+// named case, and every named case still names a variant that exists.
+//
+// This is #1767's fix. Before it, sessionRootsOf's type switch understood
+// only the variants whichever adapter's rig-home row had exercised so far —
+// FilesUnderRoot from day one, ProcessOwnedStore added in #1722/#1765 for
+// hermes — and an unhandled variant surfaced only as that switch's `default`
+// branch fataling inside a DIFFERENT adapter's relocation test, at the moment
+// some later adapter's row happened to use it. That is a runtime accident,
+// not a check: the failure lands on whoever adds the next adapter, unrelated
+// to what they were doing, telling them to extend a mechanism they did not
+// know existed. A guard over a closed, enumerable sum should instead fail the
+// moment the sum itself gains a variant nothing names — which is what calling
+// this with the two AST-derived projections below achieves.
+//
+// Split out as a pure function for the same reason Reconcile is: the real
+// switch cannot be mutated to prove this discriminates (mutating it means
+// adding a fourth variant to core/domain/agent/source.go, a different change
+// with a different blast radius), so the committed mutation evidence
+// (righome_corpus_test.go) drives THIS function directly with deliberately
+// wrong sets instead.
+func SourceVariantCoverage(declared, handled []string) []string {
+	handledSet := make(map[string]bool, len(handled))
+	for _, h := range handled {
+		handledSet[h] = true
+	}
+	declaredSet := make(map[string]bool, len(declared))
+	for _, d := range declared {
+		declaredSet[d] = true
+	}
+
+	var problems []string
+	for _, d := range declared {
+		if !handledSet[d] {
+			problems = append(problems, fmt.Sprintf(
+				"agent.Source variant %q has no case in sessionRootsOf's type switch — a rig-home "+
+					"row for an adapter using it would fall to the default branch and fatal inside "+
+					"whatever unrelated adapter's relocation test first exercised it, instead of "+
+					"failing here, now, by name", d))
+		}
+	}
+	for _, h := range handled {
+		if !declaredSet[h] {
+			problems = append(problems, fmt.Sprintf(
+				"sessionRootsOf names a case for %q, which core/domain/agent/source.go no longer "+
+					"declares — a stale case reads as coverage of a variant that does not exist", h))
+		}
+	}
+	sort.Strings(problems)
+	return problems
+}
+
+// AgentDomainDir is the package that declares agent.Source and its variants,
+// relative to the repo root.
+const AgentDomainDir = "core/domain/agent"
+
+// sourceVariantsIn returns the sorted names of every type anywhere in
+// core/domain/agent that declares the isSource() sealing method — the
+// authoritative, derived-from-source list of agent.Source's variants, rather
+// than a hand-kept one that can drift the moment a variant is added.
+//
+// It scans every non-test .go file in the PACKAGE, not just source.go by
+// name: the three variants all happen to live in one file today, but this
+// repo's own convention for a domain type whose variants multiply per-OS or
+// per-concern is to split them across sibling files in the same package (see
+// core/pkg/ports.ProcessObserver's process_{darwin,linux,other}.go). A scan
+// scoped to one filename would silently stop covering a variant the moment
+// someone followed that convention here, which is exactly the "existence
+// check that quietly checks less than it claims to" this issue exists to
+// avoid — so it reads the whole directory and delegates to sourceVariantsFrom,
+// the same split ScanBeaconPackage/BeaconAdapters already use: a thin
+// disk-reading wrapper around a pure, in-memory function a corpus can drive
+// directly with synthetic packages.
+func sourceVariantsIn(repoRoot string) ([]string, error) {
+	dir := filepath.Join(repoRoot, AgentDomainDir)
+	files, err := goSourcesIn(dir)
+	if err != nil {
+		return nil, err
+	}
+	names, err := sourceVariantsFrom(files)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", AgentDomainDir, err)
+	}
+	return names, nil
+}
+
+// sourceVariantsFrom is sourceVariantsIn's pure half: every type across these
+// sources (a filename → source map, in the shape ScanBeaconPackage already
+// takes) that declares isSource(). Non-test files only — a type declared only
+// in a _test.go file is not a real agent.Source variant.
+func sourceVariantsFrom(files map[string]string) ([]string, error) {
+	fset := token.NewFileSet()
+	var names []string
+	for name, src := range productionSources(files) {
+		f, err := parser.ParseFile(fset, name, src, parser.SkipObjectResolution)
+		if err != nil {
+			return nil, fmt.Errorf("parsing %s: %w", name, err)
+		}
+		for _, decl := range f.Decls {
+			if variant, ok := isSourceReceiverName(decl); ok {
+				names = append(names, variant)
+			}
+		}
+	}
+	if len(names) == 0 {
+		return nil, fmt.Errorf("declares no isSource() method at all — the scan is broken, not " +
+			"the domain type")
+	}
+	sort.Strings(names)
+	return names, nil
+}
+
+// isSourceReceiverName reports the receiver type name of one top-level
+// declaration, if it is a method named isSource — the sealing marker every
+// agent.Source variant declares (core/domain/agent/source.go's own doc
+// comment on the interface names it as such).
+func isSourceReceiverName(decl ast.Decl) (string, bool) {
+	fn, ok := decl.(*ast.FuncDecl)
+	if !ok || fn.Recv == nil || fn.Name.Name != "isSource" || len(fn.Recv.List) != 1 {
+		return "", false
+	}
+	return bareTypeName(fn.Recv.List[0].Type)
+}
+
+// bareTypeName strips a pointer off a receiver's type expression and returns
+// the underlying identifier. Every isSource() today is a value receiver, but
+// a future variant switching to a pointer should not silently vanish from the
+// scan.
+func bareTypeName(expr ast.Expr) (string, bool) {
+	switch t := expr.(type) {
+	case *ast.Ident:
+		return t.Name, true
+	case *ast.StarExpr:
+		return bareTypeName(t.X)
+	default:
+		return "", false
+	}
+}
+
+// switchCasesIn returns the sorted agent.<Name> case types a type switch
+// inside the named function resolves, read from source rather than by
+// importing the package that declares the function — sessionRootsOf lives in
+// a _test.go file this production package cannot import without a cycle.
+//
+// A thin disk-reading wrapper around switchCasesFrom, the pure half a corpus
+// drives directly with synthetic source — same split as sourceVariantsIn.
+func switchCasesIn(repoRoot, relPath, funcName string) ([]string, error) {
+	path := filepath.Join(repoRoot, relPath)
+	// #nosec G304 -- path built from a caller-supplied repo root and a package constant.
+	src, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading %s: %w", relPath, err)
+	}
+	names, err := switchCasesFrom(src, relPath, funcName)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", relPath, err)
+	}
+	return names, nil
+}
+
+// switchCasesFrom parses one Go source file and returns the sorted case
+// types a type switch inside funcName resolves. filename is used only for
+// parser diagnostics.
+func switchCasesFrom(src []byte, filename, funcName string) ([]string, error) {
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, filename, src, parser.SkipObjectResolution)
+	if err != nil {
+		return nil, fmt.Errorf("parsing: %w", err)
+	}
+
+	fn := topLevelFunc(f, funcName)
+	if fn == nil {
+		return nil, fmt.Errorf("declares no func %s — the case scan has nothing to read", funcName)
+	}
+	sw := firstTypeSwitch(fn)
+	if sw == nil {
+		return nil, fmt.Errorf("%s declares no type switch — the case scan has nothing to read", funcName)
+	}
+
+	var names []string
+	for _, stmt := range sw.Body.List {
+		cc, ok := stmt.(*ast.CaseClause)
+		if !ok {
+			continue
+		}
+		for _, expr := range cc.List { // a nil List is `default:` and contributes nothing
+			if name, ok := selectorName(expr); ok {
+				names = append(names, name)
+			}
+		}
+	}
+	if len(names) == 0 {
+		return nil, fmt.Errorf("%s's type switch names no case at all — the scan is broken, not "+
+			"the switch", funcName)
+	}
+	sort.Strings(names)
+	return names, nil
+}
+
+// topLevelFunc finds a package-level (non-method) function by name.
+func topLevelFunc(f *ast.File, name string) *ast.FuncDecl {
+	for _, decl := range f.Decls {
+		if fn, ok := decl.(*ast.FuncDecl); ok && fn.Recv == nil && fn.Name.Name == name {
+			return fn
+		}
+	}
+	return nil
+}
+
+// firstTypeSwitch returns the first type switch statement in fn's body. A
+// function with more than one is not a shape this package's callers produce.
+func firstTypeSwitch(fn *ast.FuncDecl) *ast.TypeSwitchStmt {
+	var found *ast.TypeSwitchStmt
+	ast.Inspect(fn.Body, func(n ast.Node) bool {
+		if found != nil {
+			return false
+		}
+		if sw, ok := n.(*ast.TypeSwitchStmt); ok {
+			found = sw
+			return false
+		}
+		return true
+	})
+	return found
+}
+
+// selectorName reads the `Name` off a `pkg.Name` case expression.
+func selectorName(expr ast.Expr) (string, bool) {
+	sel, ok := expr.(*ast.SelectorExpr)
+	if !ok {
+		return "", false
+	}
+	return sel.Sel.Name, true
+}
+
 // BeaconPackagePath is the package an adapter imports when its hooks are
 // delivered by the beacon rather than by a URL baked into the installed entry.
 const BeaconPackagePath = "irrlicht/core/pkg/hookbeacon"

--- a/tools/onboarding-factory/internal/righome/righome_corpus_test.go
+++ b/tools/onboarding-factory/internal/righome/righome_corpus_test.go
@@ -186,7 +186,94 @@ func assertReported(t *testing.T, got string, want []string, names string) {
 // Reconcile that complains about everything.
 func assertSilentOnEverythingElse(t *testing.T, got string, claimed []string) {
 	t.Helper()
-	for _, frag := range allFragments {
+	assertSilentOnFragmentsExcept(t, got, allFragments, claimed)
+}
+
+func containsString(hay []string, needle string) bool {
+	for _, h := range hay {
+		if h == needle {
+			return true
+		}
+	}
+	return false
+}
+
+// sourceVariantFragments is every distinguishing phrase SourceVariantCoverage
+// can produce. As with allFragments above, a case names the ones it expects
+// and everything else in this list must be absent — otherwise a mutation
+// wrong in one way could be "satisfied" by an unrelated complaint.
+var sourceVariantFragments = []string{
+	"has no case in sessionRootsOf's type switch",
+	"no longer declares",
+}
+
+// TestSourceVariantCoverageNamesEveryWrongShape is the committed mutation
+// evidence for SourceVariantCoverage (#1767), in the same shape as
+// TestReconcileNamesEveryWrongShape above and for the same reason: the real
+// switch cannot be mutated to prove this discriminates without adding a
+// fourth variant to core/domain/agent/source.go, a different change with a
+// different blast radius, so the evidence drives the pure function directly
+// with deliberately wrong sets instead.
+//
+// This is also the proof that #1767's fix actually changes behaviour: before
+// SourceVariantCoverage existed, the "declared variant with no case" row
+// below is exactly the shape that used to fall silently to sessionRootsOf's
+// default branch and fatal only if some adapter's row ever exercised it —
+// this test instead reddens on the missing case directly, with the variant
+// named, independent of any adapter.
+func TestSourceVariantCoverageNamesEveryWrongShape(t *testing.T) {
+	cases := []struct {
+		name     string
+		declared []string
+		handled  []string
+		reports  []string // fragments that MUST appear; empty means "silent"
+		names    string   // a variant name the report must also carry, when relevant
+	}{
+		{
+			name:     "the real shape reports nothing",
+			declared: []string{"FilesUnderCWD", "FilesUnderRoot", "ProcessOwnedStore"},
+			handled:  []string{"FilesUnderCWD", "FilesUnderRoot", "ProcessOwnedStore"},
+		},
+		{
+			// The shape this issue is about: a variant source.go declares that
+			// sessionRootsOf names no case for — before #1767, this fell to
+			// `default` and was indistinguishable from a Source that simply
+			// cannot be resolved.
+			name:     "a declared variant with no case",
+			declared: []string{"FilesUnderCWD", "FilesUnderRoot", "ProcessOwnedStore", "RemoteAPISession"},
+			handled:  []string{"FilesUnderCWD", "FilesUnderRoot", "ProcessOwnedStore"},
+			reports:  []string{"has no case in sessionRootsOf's type switch"},
+			names:    "RemoteAPISession",
+		},
+		{
+			// The mirror direction: a case naming a variant source.go no
+			// longer declares. Reconcile's checkExemptions guards the same
+			// direction for its own exemption map, for the same reason — a
+			// stale entry reads as coverage of something that is not there.
+			name:     "a case naming a variant that no longer exists",
+			declared: []string{"FilesUnderRoot", "ProcessOwnedStore"},
+			handled:  []string{"FilesUnderCWD", "FilesUnderRoot", "ProcessOwnedStore"},
+			reports:  []string{"no longer declares"},
+			names:    "FilesUnderCWD",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := strings.Join(SourceVariantCoverage(tc.declared, tc.handled), "\n")
+			assertReported(t, got, tc.reports, tc.names)
+			assertSilentOnFragmentsExcept(t, got, sourceVariantFragments, tc.reports)
+		})
+	}
+}
+
+// assertSilentOnFragmentsExcept generalizes assertSilentOnEverythingElse over
+// an explicit fragment universe, so this corpus and Reconcile's can each pin
+// their own set of distinguishing phrases without one silently checking the
+// other's.
+func assertSilentOnFragmentsExcept(t *testing.T, got string, universe, claimed []string) {
+	t.Helper()
+	for _, frag := range universe {
 		if containsString(claimed, frag) {
 			continue
 		}
@@ -200,13 +287,141 @@ func assertSilentOnEverythingElse(t *testing.T, got string, claimed []string) {
 	}
 }
 
-func containsString(hay []string, needle string) bool {
-	for _, h := range hay {
-		if h == needle {
-			return true
-		}
+// TestSourceVariantsFromNamesEveryWrongShape is the committed evidence for
+// sourceVariantsFrom, in the same map[string]string-driven shape
+// TestScanBeaconPackageNamesEveryWrongShape (beacon_test.go) already uses for
+// ScanBeaconPackage — the split exists so a corpus can drive the scan with
+// synthetic packages instead of the real repo tree.
+//
+// The two-file case is the regression test for a review finding against this
+// PR: an earlier version of this scan read core/domain/agent/source.go by
+// name, so a variant declared in any OTHER file in the package (a real
+// pattern this repo already uses for a type that varies per platform or
+// concern — see ports.ProcessObserver's process_{darwin,linux,other}.go
+// split) would have been silently invisible to
+// TestSessionRootsOfCoversEveryAgentSourceVariant, undermining the very
+// existence-check guarantee #1767 added. Scanning the whole non-test package
+// is what closes that gap; this case is what proves it stays closed.
+func TestSourceVariantsFromNamesEveryWrongShape(t *testing.T) {
+	cases := []struct {
+		name    string
+		files   map[string]string
+		want    []string
+		wantErr string
+	}{
+		{
+			// The regression case above: a variant per file, plus a pointer
+			// receiver (bareTypeName's StarExpr branch), plus a same-named
+			// type that only exists in a _test.go file — which must NOT
+			// count, the same rule ScanBeaconPackage applies to a
+			// test-only beacon import.
+			name: "a variant in every file of the package is found, a _test.go-only one is not",
+			files: map[string]string{
+				"source.go": "package agent\n\ntype FilesUnderRoot struct{}\nfunc (FilesUnderRoot) isSource() {}\n",
+				"source_remote.go": "package agent\n\ntype RemoteAPISession struct{}\n" +
+					"func (*RemoteAPISession) isSource() {}\n",
+				"source_test.go": "package agent\n\ntype testOnlyVariant struct{}\nfunc (testOnlyVariant) isSource() {}\n",
+			},
+			want: []string{"FilesUnderRoot", "RemoteAPISession"},
+		},
+		{
+			name:    "no isSource() anywhere is an error, not an empty list",
+			files:   map[string]string{"source.go": "package agent\n\ntype FilesUnderRoot struct{}\n"},
+			wantErr: "declares no isSource() method at all",
+		},
+		{
+			name:    "unparseable source is an error, not a quiet miss",
+			files:   map[string]string{"source.go": "package agent\n\nfunc (\n"},
+			wantErr: "parsing source.go",
+		},
 	}
-	return false
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := sourceVariantsFrom(tc.files)
+			assertNamesOrErr(t, got, err, tc.want, tc.wantErr)
+		})
+	}
+}
+
+// assertNamesOrErr is the shared verdict for the two corpora below: either an
+// error containing wantErr, or a clean result equal to want. Split out
+// because sourceVariantsFrom and switchCasesFrom return the same ([]string,
+// error) shape and their two corpora were asserting it identically —
+// the same move this file already made once for
+// assertSilentOnEverythingElse/assertSilentOnFragmentsExcept.
+func assertNamesOrErr(t *testing.T, got []string, err error, want []string, wantErr string) {
+	t.Helper()
+	if wantErr != "" {
+		if err == nil || !strings.Contains(err.Error(), wantErr) {
+			t.Fatalf("got (%v, %v), want an error containing %q", got, err, wantErr)
+		}
+		return
+	}
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+// TestSwitchCasesFromNamesEveryWrongShape is switchCasesFrom's counterpart to
+// the corpus above, driving it with synthetic function bodies instead of the
+// real sessionRootsOf.
+func TestSwitchCasesFromNamesEveryWrongShape(t *testing.T) {
+	const funcName = "resolve"
+
+	cases := []struct {
+		name    string
+		src     string
+		want    []string
+		wantErr string
+	}{
+		{
+			// Proves the loop over cc.List: a single case clause naming TWO
+			// types at once (`case agent.A, agent.B:`) must contribute both,
+			// not just the first — a shape switchCasesIn's one real caller
+			// does not currently use, so nothing else in this diff would
+			// have caught a scanner that silently took only cc.List[0].
+			name: "a case naming two types at once contributes both",
+			src: "package p\nimport \"irrlicht/core/domain/agent\"\n" +
+				"func resolve(a agent.Agent) ([]string, error) {\n" +
+				"\tswitch v := a.Source.(type) {\n" +
+				"\tcase agent.FilesUnderRoot, agent.FilesUnderCWD:\n\t\t_ = v\n" +
+				"\tcase agent.ProcessOwnedStore:\n\t\t_ = v\n" +
+				"\tdefault:\n\t}\n\treturn nil, nil\n}\n",
+			want: []string{"FilesUnderCWD", "FilesUnderRoot", "ProcessOwnedStore"},
+		},
+		{
+			name:    "no func with that name is an error",
+			src:     "package p\nfunc other() {}\n",
+			wantErr: "declares no func resolve",
+		},
+		{
+			name:    "a func with no type switch at all is an error",
+			src:     "package p\nfunc resolve() { _ = 1 }\n",
+			wantErr: "declares no type switch",
+		},
+		{
+			name: "a type switch with only a default clause names no case",
+			src: "package p\nfunc resolve(a interface{}) {\n" +
+				"\tswitch a.(type) {\n\tdefault:\n\t}\n}\n",
+			wantErr: "names no case at all",
+		},
+		{
+			name:    "unparseable source is an error, not a quiet miss",
+			src:     "package p\nfunc (\n",
+			wantErr: "parsing",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := switchCasesFrom([]byte(tc.src), "input.go", funcName)
+			assertNamesOrErr(t, got, err, tc.want, tc.wantErr)
+		})
+	}
 }
 
 // TestTableRefusesRatherThanReturningAShortList covers the reader. Every check

--- a/tools/onboarding-factory/internal/righome/righome_test.go
+++ b/tools/onboarding-factory/internal/righome/righome_test.go
@@ -158,9 +158,25 @@ func assertSessionRootRelocates(t *testing.T, row Row, home string, a agent.Agen
 // per-process), which is why passing a placeholder is honest rather than a
 // stand-in for something the test could not arrange.
 //
+// The FilesUnderCWD branch is #1767's: aider is the only adapter using this
+// variant today, has no rig-home row (its transcript lives under the
+// project's own working directory, not a directory a HOME-style env var can
+// relocate), and so this arm has never actually run against it. It is named
+// here anyway, with the reason recorded, rather than left to fall through to
+// default the way it did before #1767 — the same "one branch per variant,
+// with a recorded reason where there is genuinely no sensible answer" shape
+// applyWritesNoUserFile and notAManagedFilePath use in core/cmd/irrlichd. A
+// future FilesUnderCWD adapter that DOES earn a row gets a clear, named
+// failure here instead of the generic one below.
+//
 // The default case stays a hard failure rather than an empty result: an
 // unresolvable Source and a Source with nothing to relocate must not read the
-// same way.
+// same way. It should now be unreachable —
+// TestSessionRootsOfCoversEveryAgentSourceVariant asserts every agent.Source
+// variant declared in core/domain/agent/source.go has a named case above,
+// derived from source rather than hand-kept, so a fourth variant fails that
+// dedicated, existence-checked test the moment it is introduced rather than
+// waiting for some future adapter's relocation test to trip over it.
 func sessionRootsOf(a agent.Agent) ([]string, error) {
 	switch src := a.Source.(type) {
 	case agent.FilesUnderRoot:
@@ -170,9 +186,41 @@ func sessionRootsOf(a agent.Agent) ([]string, error) {
 			return nil, fmt.Errorf("declares ProcessOwnedStore with no PathForPID, so there is no store path to grade")
 		}
 		return []string{src.PathForPID(0)}, nil
+	case agent.FilesUnderCWD:
+		return nil, fmt.Errorf("declares FilesUnderCWD — session data lives under the process's " +
+			"own working directory, not a directory a HOME-style env var can relocate, so there is " +
+			"no session root here to grade; an adapter using this variant needs its own isolation " +
+			"story (see righome.Unisolatable) rather than a rig-home row")
 	default:
-		return nil, fmt.Errorf("declares Source %T, which this arm cannot resolve — a row for it "+
-			"needs its own half-one check rather than being waved through", a.Source)
+		return nil, fmt.Errorf("declares Source %T, which this arm cannot resolve — "+
+			"TestSessionRootsOfCoversEveryAgentSourceVariant should have failed before this ever "+
+			"ran; if it did not, that test's own scan has a bug", a.Source)
+	}
+}
+
+// TestSessionRootsOfCoversEveryAgentSourceVariant is the existence-checked
+// backstop #1767 asks for: it fires the moment core/domain/agent/source.go
+// gains a new Source variant, whether or not any adapter using it has earned
+// a rig-home row yet — rather than waiting for sessionRootsOf's default
+// branch to fatal inside some later adapter's relocation test the way it did
+// for hermes (#1722/#1765).
+//
+// declared and handled are each derived from an AST scan (righome.go), never
+// hand-kept, so the two projections cannot silently drift apart the way a
+// hand-maintained list could.
+func TestSessionRootsOfCoversEveryAgentSourceVariant(t *testing.T) {
+	root := repoRoot(t)
+	declared, err := sourceVariantsIn(root)
+	if err != nil {
+		t.Fatalf("deriving agent.Source's declared variants: %v", err)
+	}
+	handled, err := switchCasesIn(root,
+		"tools/onboarding-factory/internal/righome/righome_test.go", "sessionRootsOf")
+	if err != nil {
+		t.Fatalf("deriving sessionRootsOf's handled variants: %v", err)
+	}
+	for _, p := range SourceVariantCoverage(declared, handled) {
+		t.Error(p)
 	}
 }
 


### PR DESCRIPTION
## Problem

`sessionRootsOf` (`tools/onboarding-factory/internal/righome/righome_test.go`) type-switches over `agent.Source`'s three variants but only named two — `FilesUnderRoot` and `ProcessOwnedStore` (the latter added in #1765 for hermes/#1722). The third, `FilesUnderCWD`, fell to a generic `default:` branch that `t.Fatalf`s.

That `default` only fires when some future adapter's rig-home row happens to use an unhandled variant — at which point the failure lands inside a completely unrelated adapter's relocation test (`TestEveryRigHomeRowRelocatesBothHalves`), telling the author to extend a mechanism they didn't know existed. `agent.Source` is a closed, enumerable sum (sealed by an unexported `isSource()` marker) — a guard over a closed set we control should have one branch per variant, and should fail the moment the set itself changes, not whenever some later adapter trips over it.

## Approach

- Added the missing `case agent.FilesUnderCWD:` to `sessionRootsOf`, with the reason recorded (CWD-based storage isn't relocatable via a HOME-style env var — the same "one branch per variant, reason recorded where there's genuinely no sensible answer" shape `applyWritesNoUserFile`/`notAManagedFilePath` already use in `core/cmd/irrlichd`).
- Added a new pure function `righome.SourceVariantCoverage(declared, handled []string) []string`, mirroring the existing `Reconcile` pattern in the same file: it reports any declared variant with no case, and any case naming a variant that no longer exists.
- Added AST-derivation helpers that read the *real* `core/domain/agent` package and the *real* `sessionRootsOf` switch from source (mirroring `ScanBeaconPackage`'s AST-walking style already in this file), each split into a thin disk-reading wrapper (`sourceVariantsIn`, `switchCasesIn`) and a pure, corpus-testable half (`sourceVariantsFrom`, `switchCasesFrom`) — the same split `ScanBeaconPackage`/`BeaconAdapters` already use.
- New test `TestSessionRootsOfCoversEveryAgentSourceVariant` wires the two together against the real repo tree. This is the existence-checked backstop: it now fails the moment `core/domain/agent` gains a fourth variant, independent of whether any adapter's row exercises it yet.
- `default:` stays as a belt-and-suspenders fallback (Go can't statically prove exhaustiveness), with an updated message noting the new test should have caught it first.

## Files touched

- `tools/onboarding-factory/internal/righome/righome.go` (new: `SourceVariantCoverage`, `sourceVariantsIn`/`sourceVariantsFrom`, `switchCasesIn`/`switchCasesFrom`, small AST helpers)
- `tools/onboarding-factory/internal/righome/righome_test.go` (new `FilesUnderCWD` case; new `TestSessionRootsOfCoversEveryAgentSourceVariant`)
- `tools/onboarding-factory/internal/righome/righome_corpus_test.go` (new committed mutation evidence: `TestSourceVariantCoverageNamesEveryWrongShape`, `TestSourceVariantsFromNamesEveryWrongShape`, `TestSwitchCasesFromNamesEveryWrongShape`; generalized the existing silent-fragment helper and a new shared `assertNamesOrErr` helper)

## Testing

This is a guard the change *adds* — per `docs/testing-philosophy.md` it has no "before the fix" state to run red, so it owes a mutation instead:

**Committed mutation evidence (corpus, in the diff):**
- `TestSourceVariantCoverageNamesEveryWrongShape` drives `SourceVariantCoverage` directly with synthetic wrong `declared`/`handled` sets — a declared variant with no case, and a stale case naming a variant that no longer exists — and asserts it reddens with the right, and only the right, fragment.
- `TestSourceVariantsFromNamesEveryWrongShape` and `TestSwitchCasesFromNamesEveryWrongShape` drive the two AST scanners directly with synthetic Go source (a variant per sibling file, a pointer receiver, a `_test.go`-only variant that must not count, a multi-type case clause, unparseable source, missing function/switch) and assert each error/result shape.

This mirrors `TestReconcileNamesEveryWrongShape`'s and `TestScanBeaconPackageNamesEveryWrongShape`'s existing idiom exactly (the real switch/package can't be mutated to prove discrimination without a different, larger change).

**Live proof against the real production code (not committed, run during development, reported here as the evidence):**
- Removed the `case agent.FilesUnderCWD:` branch from the real `sessionRootsOf` → `TestSessionRootsOfCoversEveryAgentSourceVariant` **FAILS**, naming `FilesUnderCWD` by name, while every other existing test in the package (`TestEveryRigHomeRowRelocatesBothHalves`, `TestRigHomeTableMatchesTheAdapterRegistry`) **stayed green** — confirming this exact mutation was previously invisible to the whole suite (aider, the one adapter using `FilesUnderCWD`, has no rig-home row), the blind spot #1767 is about.
- Separately, scoped `sourceVariantsFrom` back down to a single file (reproducing the pre-review-finding single-file scan) → the new multi-file corpus subtest **FAILS** for exactly that reason.
- Both mutations restored afterward; full suite green again.

**Locks** (pin existing behavior, pass by construction, not red-before-green evidence of anything): `TestRigHomeTableMatchesTheAdapterRegistry`, `TestEveryRigHomeRowRelocatesBothHalves`, `TestEveryRigHomeRowsDriverPassesTheHomeThroughTmux`, `TestReconcileNamesEveryWrongShape`, `TestTableRefusesRatherThanReturningAShortList`, all beacon tests — untouched, still pass, cited here only to say they were not affected.

**Suites run:** `go build ./tools/onboarding-factory/...`; `go test ./tools/onboarding-factory/... -race -count=1` (all green); `tools/preflight.sh --only {go,arch,tools,skills,posix,bash,security}` (all PASS, re-run after the review-fix round below); pre-push hook (`tools/preflight.sh --changed --budget 540`) passed on both pushes. `--only web` and `--only swift` were not run — this diff touches no `platforms/web/`, no `tools/onboarding-factory/internal/viewer/web/`, and no `platforms/macos/` file, so those gates are inapplicable rather than skipped-without-looking. `--only linux` (opt-in, needs Docker) was not run either; the change is pure Go AST-parsing logic with no OS-specific behavior, and `--only go` already runs the replay-fixtures step that is this repo's cross-platform-goldens check.

## Review round (applied)

A dedicated review subagent (medium effort, `.claude/skills/ir:code-review/SKILL.md`) found two real gaps in the first version of this fix, both addressed:

1. **Scan scoped to one hardcoded file, not the package.** `sourceVariantsIn` originally read only `core/domain/agent/source.go` by name — a fourth `Source` variant declared in a sibling file (this repo's own convention for a type that varies per platform/concern, e.g. `ports.ProcessObserver`'s `process_{darwin,linux,other}.go`) would have been silently invisible to the new existence check. **Fixed**: it now scans every non-test file in `core/domain/agent` via the existing `goSourcesIn`/`productionSources` helpers, proven by the new multi-file corpus case and its live-mutation counter-test above.
2. **The AST scanners themselves had no synthetic-input test** — only the pure comparator (`SourceVariantCoverage`) did. **Fixed**: split `sourceVariantsIn`/`switchCasesIn` each into a thin disk-reading wrapper plus a pure function (`sourceVariantsFrom`, `switchCasesFrom`), matching this file's own pre-existing `ScanBeaconPackage`/`BeaconAdapters` split, and added a corpus test for each covering the pointer-receiver branch, the multi-type case-clause branch, and every error path.

## Simplify pass (applied)

Four parallel review agents (reuse / simplification / efficiency / altitude) ran against the final diff:
- **Simplification** found one real duplication: the two new AST-scanner corpus tests asserted their `([]string, error)` result identically, copy-pasted. **Fixed**: extracted a shared `assertNamesOrErr` helper (the same move this file already made once for `assertSilentOnFragmentsExcept`).
- **Reuse**: no violation found; noted (not fixed, per the reviewers' own qualification as a non-issue) two minor inline map-building loops in `SourceVariantCoverage` with no existing "slice→set" helper to call instead.
- **Efficiency**: no findings (test-only code, single small parse per run).
- **Altitude**: no findings — confirmed the AST-scan approach matches this repo's own established convention (`ScanBeaconPackage`, `core/cmd/irrlichd/managedwrites_test.go`) rather than being a special case.

## Scope note (assumed, flagged per AGENTS.md)

The issue's author corrected their own prediction that antigravity (#1723) would hit this tripwire next — it's `FilesUnderRoot` with `ExtraDirs`, already handled. So there was no known adapter waiting on this fix; it closes a latent design concern (confirmed live: the pre-fix scan would have silently missed a real gap, `FilesUnderCWD`, indefinitely). I did not open any new GitHub issues for anything encountered along the way, per instruction.

**Follow-up suggestion for a human** (not filed as an issue, per instruction — noted per AGENTS.md's "make improvement suggestions" convention): the altitude review observed that `core/cmd/irrlichd/wiring_test.go`'s `assertWatcherCountsForSource` has the same class of latent gap this issue fixed — its exhaustiveness over `agent.Source` is contingent on which adapters are currently registered (`agents.All()`), not derived from the domain type's true variant set. It would benefit from the same AST-derived-coverage treatment, replicated locally in the `core` module (it can't import `righome` across the module boundary — `core` and `tools/onboarding-factory` are separate Go modules).

Closes #1767

🤖 Generated with [Claude Code](https://claude.com/claude-code)
