### PR TITLE
test(hooks): drop version-gate tests the shared contract strictly dominates

### DIFF
--- a/core/adapters/inbound/agents/claudecode/hookversion_test.go
+++ b/core/adapters/inbound/agents/claudecode/hookversion_test.go
@@ -3,7 +3,6 @@ package claudecode
 import (
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 	"time"
 
@@ -39,36 +38,40 @@ func hooksVersionGate(t *testing.T) *agent.VersionGate {
 	return nil
 }
 
-// TestHooksGate_RefusesTooOldClaudeCode pins the boundary in real terms. 2.1.121
-// is the version one patch below the floor, and the reason it is refused is not
-// tidiness: below 2.1.122 a hooks entry Claude Code cannot parse invalidates the
-// user's whole settings.json (upstream changelog 2.1.122, "Fixed a malformed
-// hooks entry in settings.json no longer invalidating the entire file"), and
-// below 2.1.101 an unrecognized event name does the same.
-func TestHooksGate_RefusesTooOldClaudeCode(t *testing.T) {
-	gate := hooksVersionGate(t)
-
-	allowed, why := gate.Permits("2.1.121 (Claude Code)")
-	if allowed {
-		t.Fatalf("gate permits Claude Code 2.1.121, below the %s floor", minCLIVersion)
-	}
-	if !strings.Contains(why, minCLIVersion) {
-		t.Errorf("refusal %q never names the required version", why)
-	}
-}
-
-// TestHooksGate_AllowsCurrentClaudeCode is a LOCK against the floor being set
-// so high that ordinary users stop getting hooks. The banner form is the one
-// `claude --version` actually prints, so this also pins that the parser copes
-// with the suffix.
-func TestHooksGate_AllowsCurrentClaudeCode(t *testing.T) {
-	gate := hooksVersionGate(t)
-	for _, v := range []string{minCLIVersion, "2.1.122 (Claude Code)", "2.1.226 (Claude Code)", "3.0.0"} {
-		if allowed, why := gate.Permits(v); !allowed {
-			t.Errorf("gate refuses Claude Code %q: %s", v, why)
-		}
-	}
-}
+// What is deliberately NOT here: RefusesTooOldClaudeCode and
+// AllowsCurrentClaudeCode, formerly a hand-picked "2.1.121 (Claude Code)"
+// below-floor refusal and a hand-picked list of at-or-above values, both
+// driven straight through gate.Permits with no Observed/transcript
+// involvement — the same shape #1762 found and removed in five sibling
+// adapters (issue #1721 / PR #1758 did the first, for pi).
+// AssertHookVersionGate already runs both obligations more thoroughly:
+//
+//   - assertFloorRefusesOlder refuses THREE field-wise predecessors of the
+//     real floor (major/minor/patch decremented independently — the patch
+//     predecessor of 2.1.122 is the exact 2.1.121 the deleted test picked by
+//     hand), each refusal checked to name both versions, PLUS a vacuity guard
+//     a floor with nothing below it fails outright, which the deleted lock had
+//     no equivalent of.
+//   - The "(Claude Code)" banner-suffix format the deleted tests exercised
+//     is independently pinned at the shared cliversion package
+//     (cliversion_test.go: "2.1.226 (Claude Code)"), so nothing about this
+//     adapter's parsing was uniquely covered here.
+//
+// Proven by mutation, not by inspection: weakening minCLIVersion to 0.0.0
+// reddens the contract —
+//
+//	--- FAIL: .../floor_refuses_an_older_cli
+//	    hook_version.go:62: declared floor 0.0.0 has no version below it, so this
+//	    obligation asserts nothing — a floor of 0.0.0 permits every CLI and is not a gate
+//
+// — while AllowsCurrentClaudeCode (the vacuity-blind lock) stayed GREEN under
+// the same mutation, which is exactly the coverage gap deleting it closes.
+//
+// TestHooksGate_DeclaresBothVersionSources stays: the contract only requires
+// Observed OR Probe, never both, and this adapter's floor is decorative
+// without Observed (see its own doc comment). The four
+// TestNewestObservedCLIVersion_* tests below it are untouched — they pin the
+// transcript-parsing AssertHookVersionGate never reaches at all.
 
 // TestHooksGate_DeclaresBothVersionSources is the regression guard for the
 // review finding that nearly shipped: with only a Probe declared, this gate is

--- a/core/adapters/inbound/agents/codex/hookversion_test.go
+++ b/core/adapters/inbound/agents/codex/hookversion_test.go
@@ -89,19 +89,37 @@ func TestHooksGate_BelowFloorSaysWhy(t *testing.T) {
 	}
 }
 
-// TestHooksGate_AtOrAboveFloorInstalls is a LOCK: it pins that the gate does
-// not become a blanket refusal. It passes by construction and is here because
-// a floor that rejects everything looks identical, from the log, to a floor
-// that works.
-func TestHooksGate_AtOrAboveFloorInstalls(t *testing.T) {
-	for _, v := range []string{minCLIVersion, "0.146.1", "rust-v0.120.3"} {
-		writeCodexSessionWithVersion(t, v)
-		gate := hooksVersionGate(t)
-		if allowed, why := gate.Permits(gate.Observed()); !allowed {
-			t.Errorf("gate refuses Codex %s, at or above the %s floor: %s", v, minCLIVersion, why)
-		}
-	}
-}
+// What is deliberately NOT here: TestHooksGate_AtOrAboveFloorInstalls, a
+// hand-picked list of at-or-above versions (including "rust-v0.120.3", Codex's
+// own banner format) run through writeCodexSessionWithVersion + Observed(),
+// asserted a LOCK against the gate becoming a blanket refusal. The same shape
+// was removed from five other adapters by #1721/#1758 and #1762.
+//
+// It added nothing AssertHookVersionGate doesn't already cover more
+// thoroughly: Permits(gate.Min) allowed, PLUS a vacuity guard a floor with
+// nothing below it fails outright, which this lock had no equivalent of.
+// newestObservedCLIVersion has no format-dependent branching — it is a bare
+// JSON field read (hookinstaller.go) — so re-exercising it against three
+// different version strings proved nothing beyond what
+// TestHooksGate_BelowFloorSaysWhy below already proves once; the
+// "rust-v0.120.3" banner format itself is independently pinned at the shared
+// cliversion package (cliversion_test.go).
+//
+// Proven by mutation, not by inspection: weakening minCLIVersion to 0.0.0
+// reddens the contract —
+//
+//	--- FAIL: .../floor_refuses_an_older_cli
+//	    hook_version.go:62: declared floor 0.0.0 has no version below it, so this
+//	    obligation asserts nothing — a floor of 0.0.0 permits every CLI and is not a gate
+//
+// — while TestHooksGate_AtOrAboveFloorInstalls stayed GREEN under the same
+// mutation (its own value list also reads the mutated minCLIVersion, so every
+// check in it still "passed"), which is exactly the coverage gap deleting it
+// closes. TestHooksGate_BelowFloorSaysWhy and
+// TestHooksGate_NoTranscriptFallsThroughToProbe stay: each is the ONLY test
+// exercising newestObservedCLIVersion's real transcript-reading path (a
+// written cli_version, and the zero-sessions fallback to ""), which the
+// shared contract never reaches at all.
 
 // TestHooksGate_NoTranscriptFallsThroughToProbe pins that a machine with no
 // Codex sessions yet does not resolve to "version 0" — Observed returns "",

--- a/core/adapters/inbound/agents/copilot/hookversion_test.go
+++ b/core/adapters/inbound/agents/copilot/hookversion_test.go
@@ -81,17 +81,33 @@ func TestHooksGate_BelowFloorSaysWhy(t *testing.T) {
 	}
 }
 
-// TestHooksGate_AtOrAboveFloorInstalls is a LOCK: it pins that the gate has not
-// become a blanket refusal, which from a log looks identical to one that works.
-func TestHooksGate_AtOrAboveFloorInstalls(t *testing.T) {
-	for _, v := range []string{minCLIVersion, "1.0.78", "1.1.0", "2.0.0"} {
-		writeCopilotSessionWithVersion(t, v)
-		gate := hooksVersionGate(t)
-		if allowed, why := gate.Permits(gate.Observed()); !allowed {
-			t.Errorf("gate refuses Copilot %s, at or above the %s floor: %s", v, minCLIVersion, why)
-		}
-	}
-}
+// What is deliberately NOT here: TestHooksGate_AtOrAboveFloorInstalls, a
+// hand-picked list of at-or-above versions run through
+// writeCopilotSessionWithVersion + Observed(), asserted a LOCK against the
+// gate becoming a blanket refusal. The same shape was removed from five other
+// adapters by #1721/#1758 and #1762.
+//
+// It added nothing AssertHookVersionGate doesn't already cover more
+// thoroughly: Permits(gate.Min) allowed, PLUS a vacuity guard a floor with
+// nothing below it fails outright, which this lock had no equivalent of.
+// newestObservedCLIVersion/sessionStartVersion have no format-dependent
+// branching — a bare JSON field read (hookinstaller.go) — so re-exercising it
+// against four different version strings proved nothing beyond what
+// TestHooksGate_BelowFloorSaysWhy below already proves once.
+//
+// Proven by mutation, not by inspection: weakening notificationGuaranteeSince
+// (== minCLIVersion) to 0.0.0 reddens the contract —
+//
+//	--- FAIL: .../floor_refuses_an_older_cli
+//	    hook_version.go:62: declared floor 0.0.0 has no version below it, so this
+//	    obligation asserts nothing — a floor of 0.0.0 permits every CLI and is not a gate
+//
+// — while TestHooksGate_AtOrAboveFloorInstalls stayed GREEN under the same
+// mutation, which is exactly the coverage gap deleting it closes.
+// TestHooksGate_BelowFloorSaysWhy and TestHooksGate_NoTranscriptFallsThroughToProbe
+// stay: each is the ONLY test exercising the real transcript-reading path (a
+// written copilotVersion, and the zero-transcripts fallback to ""), which the
+// shared contract never reaches at all.
 
 // TestHooksGate_NoTranscriptFallsThroughToProbe pins that a machine with no
 // Copilot sessions yet resolves to "unknown", not to "version 0" — an unread

--- a/core/adapters/inbound/agents/geminicli/hookversion_test.go
+++ b/core/adapters/inbound/agents/geminicli/hookversion_test.go
@@ -12,7 +12,6 @@
 package geminicli
 
 import (
-	"strings"
 	"testing"
 
 	"irrlicht/core/domain/agent"
@@ -44,44 +43,37 @@ func hooksVersionGate(t *testing.T) *agent.VersionGate {
 	return nil
 }
 
-// TestHooksGate_BelowFloorSaysWhy pins that a Gemini CLI older than the
-// declared floor is refused WITH a reason naming both versions.
-func TestHooksGate_BelowFloorSaysWhy(t *testing.T) {
-	gate := hooksVersionGate(t)
-
-	allowed, why := gate.Permits("0.53.9")
-	if allowed {
-		t.Fatal("gate permits installing into Gemini CLI 0.53.9, below the declared floor")
-	}
-	if !strings.Contains(why, "0.53.9") || !strings.Contains(why, minCLIVersion) {
-		t.Errorf("refusal %q names neither the installed version nor the required one; "+
-			"the reason has to tell the user what to upgrade", why)
-	}
-}
-
-// TestHooksGate_AtOrAboveFloorInstalls is a LOCK: it pins that the gate has
-// not become a blanket refusal, which from a log looks identical to one that
-// works.
-func TestHooksGate_AtOrAboveFloorInstalls(t *testing.T) {
-	gate := hooksVersionGate(t)
-	for _, v := range []string{minCLIVersion, "0.54.4", "0.56.0", "1.0.0"} {
-		if allowed, why := gate.Permits(v); !allowed {
-			t.Errorf("gate refuses Gemini CLI %s, at or above the %s floor: %s", v, minCLIVersion, why)
-		}
-	}
-}
-
-// TestHooksGate_UnknownVersionFailsOpen pins the documented direction
-// (core/pkg/cliversion): an unparseable or unknown version must not block an
-// install. The daemon runs under launchd with a minimal PATH and routinely
-// cannot see the user's CLI at all, so "unknown" must read as "not proven
-// old", not as "assume the worst".
-func TestHooksGate_UnknownVersionFailsOpen(t *testing.T) {
-	gate := hooksVersionGate(t)
-	if allowed, why := gate.Permits(""); !allowed {
-		t.Errorf("gate refuses on an unknown version: %s", why)
-	}
-}
+// What is deliberately NOT here: BelowFloorSaysWhy, AtOrAboveFloorInstalls
+// and UnknownVersionFailsOpen — each a hand-picked restatement of an
+// obligation AssertHookVersionGate already runs, strictly more weakly, the
+// same pattern issue #1721 / PR #1758 found and removed from pi, and #1762
+// removes here and from claudecode, codex, copilot, kirocli and vibe:
+//
+//   - assertFloorRefusesOlder checks gate.Permits(gate.Min) is ALLOWED (the
+//     at-or-above lock), then refuses THREE field-wise predecessors — major,
+//     minor and patch decremented independently, because a single synthetic
+//     "just below" value exercises only the borrow path — and requires each
+//     refusal's reason to name both versions. The hand-written copy picked
+//     ONE older version by hand.
+//   - It also carries a vacuity guard the copies had no equivalent of: a
+//     floor with nothing below it fails, rather than passing having asserted
+//     only that the gate permits itself.
+//   - assertUnknownFailsOpen drives THREE unreadable spellings ("",
+//     "not a version", "2.1"). The hand-written copy drove one.
+//
+// Proven by mutation, not by inspection: weakening minCLIVersion to 0.0.0
+// reddens the contract —
+//
+//	--- FAIL: .../floor_refuses_an_older_cli
+//	    hook_version.go:62: declared floor 0.0.0 has no version below it, so this
+//	    obligation asserts nothing — a floor of 0.0.0 permits every CLI and is not a gate
+//
+// — while AtOrAboveFloorInstalls (the vacuity-blind lock) stayed GREEN under
+// the same mutation, which is exactly the coverage gap deleting it closes.
+//
+// TestHooksGate_ProbeIsGeminiVersion below stays, because it is the one thing
+// the contract does NOT cover: assertVersionSourceDeclared only requires
+// Observed or Probe to be non-empty, never that the argv is the right one.
 
 // TestHooksGate_ProbeIsGeminiVersion pins the argv this adapter asks
 // cliversion to run — gemini --version prints a bare number (e.g. "0.56.0",

--- a/core/adapters/inbound/agents/kirocli/hookversion_test.go
+++ b/core/adapters/inbound/agents/kirocli/hookversion_test.go
@@ -11,7 +11,6 @@
 package kirocli
 
 import (
-	"strings"
 	"testing"
 
 	"irrlicht/core/domain/agent"
@@ -43,44 +42,39 @@ func hooksVersionGate(t *testing.T) *agent.VersionGate {
 	return nil
 }
 
-// TestHooksGate_BelowFloorSaysWhy pins that a kiro-cli older than the
-// declared floor is refused WITH a reason naming both versions.
-func TestHooksGate_BelowFloorSaysWhy(t *testing.T) {
-	gate := hooksVersionGate(t)
-
-	allowed, why := gate.Permits("2.5.9")
-	if allowed {
-		t.Fatal("gate permits installing into kiro-cli 2.5.9, below the declared floor")
-	}
-	if !strings.Contains(why, "2.5.9") || !strings.Contains(why, minCLIVersion) {
-		t.Errorf("refusal %q names neither the installed version nor the required one; "+
-			"the reason has to tell the user what to upgrade", why)
-	}
-}
-
-// TestHooksGate_AtOrAboveFloorInstalls is a LOCK: it pins that the gate has
-// not become a blanket refusal, which from a log looks identical to one that
-// works.
-func TestHooksGate_AtOrAboveFloorInstalls(t *testing.T) {
-	gate := hooksVersionGate(t)
-	for _, v := range []string{minCLIVersion, "2.6.1", "2.7.0", "3.0.0"} {
-		if allowed, why := gate.Permits(v); !allowed {
-			t.Errorf("gate refuses kiro-cli %s, at or above the %s floor: %s", v, minCLIVersion, why)
-		}
-	}
-}
-
-// TestHooksGate_UnknownVersionFailsOpen pins the documented direction
-// (core/pkg/cliversion): an unparseable or unknown version must not block an
-// install. The daemon runs under launchd with a minimal PATH and routinely
-// cannot see the user's CLI at all, so "unknown" must read as "not proven
-// old", not as "assume the worst".
-func TestHooksGate_UnknownVersionFailsOpen(t *testing.T) {
-	gate := hooksVersionGate(t)
-	if allowed, why := gate.Permits(""); !allowed {
-		t.Errorf("gate refuses on an unknown version: %s", why)
-	}
-}
+// What is deliberately NOT here: BelowFloorSaysWhy, AtOrAboveFloorInstalls
+// and UnknownVersionFailsOpen — each a hand-picked restatement of an
+// obligation AssertHookVersionGate already runs, strictly more weakly, the
+// same pattern issue #1721 / PR #1758 found and removed from pi, and #1762
+// removes here and from claudecode, codex, copilot, geminicli and vibe:
+//
+//   - assertFloorRefusesOlder checks gate.Permits(gate.Min) is ALLOWED (the
+//     at-or-above lock), then refuses THREE field-wise predecessors — major,
+//     minor and patch decremented independently, because a single synthetic
+//     "just below" value exercises only the borrow path — and requires each
+//     refusal's reason to name both versions. The hand-written copy picked
+//     ONE older version by hand.
+//   - It also carries a vacuity guard the copies had no equivalent of: a
+//     floor with nothing below it fails, rather than passing having asserted
+//     only that the gate permits itself.
+//   - assertUnknownFailsOpen drives THREE unreadable spellings ("",
+//     "not a version", "2.1"). The hand-written copy drove one.
+//
+// Proven by mutation, not by inspection: weakening minCLIVersion to 0.0.0
+// reddens the contract —
+//
+//	--- FAIL: .../floor_refuses_an_older_cli
+//	    hook_version.go:62: declared floor 0.0.0 has no version below it, so this
+//	    obligation asserts nothing — a floor of 0.0.0 permits every CLI and is not a gate
+//
+// — while AtOrAboveFloorInstalls (the vacuity-blind lock) stayed GREEN under
+// the same mutation, which is exactly the coverage gap deleting it closes.
+//
+// TestHooksGate_ProbeIsKiroCLIVersion below stays, because it is the one
+// thing the contract does NOT cover: assertVersionSourceDeclared only
+// requires Observed or Probe to be non-empty, never that the argv is the
+// right one — and here specifically that it is `kiro-cli`, not the unrelated
+// Kiro IDE `kiro` binary.
 
 // TestHooksGate_ProbeIsKiroCLIVersion pins the argv this adapter asks
 // cliversion to run — kiro-cli --version prints "kiro-cli 2.6.0" (verified

--- a/core/adapters/inbound/agents/vibe/hookversion_test.go
+++ b/core/adapters/inbound/agents/vibe/hookversion_test.go
@@ -8,7 +8,6 @@
 package vibe
 
 import (
-	"strings"
 	"testing"
 
 	"irrlicht/core/domain/agent"
@@ -40,44 +39,37 @@ func hooksVersionGate(t *testing.T) *agent.VersionGate {
 	return nil
 }
 
-// TestHooksGate_BelowFloorSaysWhy pins that a Vibe older than the declared
-// floor is refused WITH a reason naming both versions.
-func TestHooksGate_BelowFloorSaysWhy(t *testing.T) {
-	gate := hooksVersionGate(t)
-
-	allowed, why := gate.Permits("2.18.0")
-	if allowed {
-		t.Fatal("gate permits installing into Vibe 2.18.0, below the declared floor")
-	}
-	if !strings.Contains(why, "2.18.0") || !strings.Contains(why, minVibeVersion) {
-		t.Errorf("refusal %q names neither the installed version nor the required one; "+
-			"the reason has to tell the user what to upgrade", why)
-	}
-}
-
-// TestHooksGate_AtOrAboveFloorInstalls is a LOCK: it pins that the gate has
-// not become a blanket refusal, which from a log looks identical to one
-// that works.
-func TestHooksGate_AtOrAboveFloorInstalls(t *testing.T) {
-	gate := hooksVersionGate(t)
-	for _, v := range []string{minVibeVersion, "2.20.0", "3.0.0"} {
-		if allowed, why := gate.Permits(v); !allowed {
-			t.Errorf("gate refuses Vibe %s, at or above the %s floor: %s", v, minVibeVersion, why)
-		}
-	}
-}
-
-// TestHooksGate_UnknownVersionFailsOpen pins the documented direction
-// (core/pkg/cliversion): an unparseable or unknown version must not block
-// an install. The daemon runs under launchd with a minimal PATH and
-// routinely cannot see the user's CLI at all, so "unknown" must read as
-// "not proven old", not as "assume the worst".
-func TestHooksGate_UnknownVersionFailsOpen(t *testing.T) {
-	gate := hooksVersionGate(t)
-	if allowed, why := gate.Permits(""); !allowed {
-		t.Errorf("gate refuses on an unknown version: %s", why)
-	}
-}
+// What is deliberately NOT here: BelowFloorSaysWhy, AtOrAboveFloorInstalls
+// and UnknownVersionFailsOpen — each a hand-picked restatement of an
+// obligation AssertHookVersionGate already runs, strictly more weakly, the
+// same pattern issue #1721 / PR #1758 found and removed from pi, and #1762
+// removes here and from claudecode, codex, copilot, geminicli and kirocli:
+//
+//   - assertFloorRefusesOlder checks gate.Permits(gate.Min) is ALLOWED (the
+//     at-or-above lock), then refuses THREE field-wise predecessors — major,
+//     minor and patch decremented independently, because a single synthetic
+//     "just below" value exercises only the borrow path — and requires each
+//     refusal's reason to name both versions. The hand-written copy picked
+//     ONE older version by hand.
+//   - It also carries a vacuity guard the copies had no equivalent of: a
+//     floor with nothing below it fails, rather than passing having asserted
+//     only that the gate permits itself.
+//   - assertUnknownFailsOpen drives THREE unreadable spellings ("",
+//     "not a version", "2.1"). The hand-written copy drove one.
+//
+// Proven by mutation, not by inspection: weakening minVibeVersion to 0.0.0
+// reddens the contract —
+//
+//	--- FAIL: .../floor_refuses_an_older_cli
+//	    hook_version.go:62: declared floor 0.0.0 has no version below it, so this
+//	    obligation asserts nothing — a floor of 0.0.0 permits every CLI and is not a gate
+//
+// — while AtOrAboveFloorInstalls (the vacuity-blind lock) stayed GREEN under
+// the same mutation, which is exactly the coverage gap deleting it closes.
+//
+// TestHooksGate_ProbeIsVibeVersion below stays, because it is the one thing
+// the contract does NOT cover: assertVersionSourceDeclared only requires
+// Observed or Probe to be non-empty, never that the argv is the right one.
 
 // TestHooksGate_ProbeIsVibeVersion pins the argv this adapter asks
 // cliversion to run — `vibe --version` prints "vibe X.Y.Z" (live-fired


### PR DESCRIPTION
Closes #1762. Part of #1355.

## What

#1758 found that pi's `hookversion_test.go` carried three hand-written tests
restating obligations `contracttesting.AssertHookVersionGate` already runs —
strictly more weakly — and deleted them, proven by mutation (weakening the
declared floor to `0.0.0` reddens the contract's vacuity guard). #1762 asked
whether the same three tests are redundant in the six sibling adapters that
also wire `AssertHookVersionGate`: claudecode, codex, copilot, geminicli,
kirocli, vibe.

**Per adapter, checked each hand-written test against what the contract now
asserts, and deleted only the ones the contract strictly dominates — proven
by mutation, not by inspection**, per adapter:

| Adapter | Deleted | Kept | Why kept |
|---|---|---|---|
| claudecode | `RefusesTooOldClaudeCode`, `AllowsCurrentClaudeCode` | `DeclaresBothVersionSources`, 4× `TestNewestObservedCLIVersion_*` | contract only requires Observed OR Probe, never both; the `TestNewestObservedCLIVersion_*` tests exercise transcript-parsing the contract never reaches |
| codex | `AtOrAboveFloorInstalls` only | `BelowFloorSaysWhy`, `NoTranscriptFallsThroughToProbe` | these two are the *only* tests exercising `newestObservedCLIVersion`'s real transcript-read path (confirmed via grep — no other test file references it) |
| copilot | `AtOrAboveFloorInstalls` only | `BelowFloorSaysWhy`, `NoTranscriptFallsThroughToProbe` | same reasoning as codex, for `sessionStartVersion` |
| geminicli | `BelowFloorSaysWhy`, `AtOrAboveFloorInstalls`, `UnknownVersionFailsOpen` | `ProbeIsGeminiVersion` | exact pi shape (pure `gate.Permits(literal)`, no Observed involved); contract doesn't check argv |
| kirocli | same three | `ProbeIsKiroCLIVersion` | same |
| vibe | same three | `ProbeIsVibeVersion` | same |

**codex and copilot needed a closer read than claudecode/geminicli/kirocli/vibe.**
Their `BelowFloorSaysWhy` and `AtOrAboveFloorInstalls`-shaped tests don't call
`gate.Permits` with a bare literal — they write a real transcript
(`writeCodexSessionWithVersion` / `writeCopilotSessionWithVersion`) and read it
back through `gate.Observed()`, which is the *only* test coverage
`newestObservedCLIVersion`/`sessionStartVersion` have (verified by grepping
every other test file in each package for those names). Deleting those two
wholesale would have silently dropped that coverage — the exact trap the issue
warns about ("a deletion justified by reading is how a real case gets
dropped"). Only `AtOrAboveFloorInstalls` turned out to be purely redundant in
both adapters (it re-exercises the same passthrough JSON-field read with no
format-dependent branching, adding nothing `BelowFloorSaysWhy` doesn't already
prove once).

## Mutation evidence (all six adapters, evidence kept, mutation reverted)

Same recipe as #1758: weaken the declared floor constant to `0.0.0`, run the
adapter's test package, confirm the shared contract's `floor_refuses_an_older_cli`
subtest goes red with the vacuity message, and confirm the corresponding
deleted lock-style test (`AllowsCurrentClaudeCode` /
`AtOrAboveFloorInstalls`) stays green under the same mutation — i.e. it would
have missed exactly the bug the contract catches. Then `git checkout --` to
revert; `git status --porcelain` confirmed clean after every one.

<details><summary>claudecode (minCLIVersion 2.1.122 → 0.0.0)</summary>

```
--- FAIL: TestHooksPermission_DeclaresVersionGate/floor_refuses_an_older_cli
    hook_version.go:62: declared floor 0.0.0 has no version below it, so this obligation
    asserts nothing — a floor of 0.0.0 permits every CLI and is not a gate
--- PASS: TestHooksGate_AllowsCurrentClaudeCode   (stayed green — missed it)
--- FAIL: TestHooksGate_RefusesTooOldClaudeCode   (also caught it — deleted anyway per the
    superset argument: the contract's 3 field-wise predecessors already include this exact
    patch-decrement value, and the "(Claude Code)" suffix format is independently pinned at
    the shared cliversion package)
```
</details>

<details><summary>codex (minCLIVersion 0.114.0 → 0.0.0)</summary>

```
--- FAIL: TestHooksPermission_DeclaresVersionGate/floor_refuses_an_older_cli
    hook_version.go:62: ...floor of 0.0.0 permits every CLI and is not a gate
--- PASS: TestHooksGate_AtOrAboveFloorInstalls   (stayed green — missed it)
--- FAIL: TestHooksGate_BelowFloorSaysWhy         (kept test also caught it — correct, it's
    exercising the real Observed() path, not a pure duplicate)
--- PASS: TestHooksGate_NoTranscriptFallsThroughToProbe (unaffected — kept, unrelated to floor value)
```
</details>

<details><summary>copilot (notificationGuaranteeSince 1.0.26 → 0.0.0)</summary>

Identical shape to codex.
</details>

<details><summary>geminicli / kirocli / vibe (floor → 0.0.0)</summary>

```
--- FAIL: TestHooksPermission_DeclaresVersionGate/floor_refuses_an_older_cli
    hook_version.go:62: ...floor of 0.0.0 permits every CLI and is not a gate
--- PASS: TestHooksGate_AtOrAboveFloorInstalls   (stayed green — missed it; deleted)
--- FAIL: TestHooksGate_BelowFloorSaysWhy         (also caught it; deleted anyway per the
    superset argument — pure literal, no Observed involved)
--- PASS: TestHooksGate_UnknownVersionFailsOpen   (unaffected by this mutation — domination
    here rests on the counting argument: contract drives 3 unreadable spellings vs 1)
--- PASS: TestHooksGate_ProbeIs*Version           (unaffected — kept, contract doesn't check argv)
```
</details>

## Test classification

- **Locks** (pin existing behavior, pass by construction, not red-before-green
  evidence): all the *kept* tests — `DeclaresBothVersionSources`,
  `TestNewestObservedCLIVersion_*`, `BelowFloorSaysWhy`/
  `NoTranscriptFallsThroughToProbe` (codex/copilot), and every `ProbeIsXVersion`
  test.
- **This PR adds no new test** — it is a deletion PR. The evidence a deletion
  is safe is the mutation runs above (each one genuinely reddened the contract
  and genuinely left the to-be-deleted test green), not a red-before-green
  defect test, per AGENTS.md's "anything a change adds... mutate the thing it
  protects" rule applied to the removal side: the thing being "protected" here
  is coverage itself, and the mutation is the proof coverage didn't drop.

## Verification run

- `go build ./...` (from `core/`) — clean.
- `go test ./adapters/inbound/agents/{claudecode,codex,copilot,geminicli,kirocli,vibe}/... ./internal/contracttesting/... -race -count=1` — all PASS.
- `gofmt -l` on all six touched files — clean.
- `tools/preflight.sh --only go` — PASS (gofmt, core module tests, onboarding-factory tests, replaydata validate, recording-rig smoke test, replay fixtures).
- `tools/preflight.sh --only arch` — PASS (ARS composite 7.893563527052358 → 7.89353124126886, no regression).
- `tools/preflight.sh --only tools/skills/posix/bash` — all PASS.
- `--only web` / `--only swift` / `--only security` / `--only linux` not run standalone: this diff touches only `core/adapters/inbound/agents/*/hookversion_test.go` (no web, no macOS, no shell scripts), and the pre-push hook's `--changed` scoping (which does run security) confirms this — see its output below.
- Pre-push hook (`tools/preflight.sh --changed --budget 540`) ran on push: gofmt/ARS/core-tests/replay-fixtures/security-scan **PASS**, everything else correctly **SKIP** (no changed files in scope).

## Not in scope

`antigravity`, `hermes` and `opencode` also call `AssertHookVersionGate` now
(hook-gate support landed in those three after #1762 was filed — the issue's
own `git grep` snapshot lists only 7 adapters, not today's 10). This PR
follows the coordinator's explicit scope (the six named in the issue) and
does not touch those three. Worth a look as a follow-up, but not filed as a
new issue per this run's constraints — noting it here instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)