### PR TITLE
chore(rig): drop the vibe scratch-seed array-collapsing workaround

### DIFF
--- a/tools/onboarding-factory/scripts/lib/agent-home.sh
+++ b/tools/onboarding-factory/scripts/lib/agent-home.sh
@@ -102,8 +102,8 @@
 #                  irrlicht git repo and is untrusted whichever home is in use
 #                  (see launch_repl in the mistral-vibe driver). Relocating the
 #                  home loses nothing there that a fresh cwd had not lost.
-#                  TWO MORE SEEDING GOTCHAS, both measured in #1735 and both
-#                  invisible until a run has already been spent.
+#                  ONE MORE SEEDING GOTCHA, measured in #1735 and invisible
+#                  until a run has already been spent.
 #                  [session_logging].save_dir in config.toml is an ABSOLUTE path
 #                  and OVERRIDES the VIBE_HOME-derived default, so a config.toml
 #                  copied from the operator's real home relocates everything
@@ -112,17 +112,15 @@
 #                  scratch one and timed out. Point it inside the scratch home
 #                  or delete the line; the driver reads the key and refuses
 #                  rather than recording half-isolated.
-#                  A real config.toml also DEFEATS the hooks install outright,
-#                  which is an adapter bug rather than a seeding one and is
-#                  noted here only because it is what a recording operator runs
-#                  into: hooktoml's splicer refuses any document containing a
-#                  multi-line array, vibe writes twelve of them by default
+#                  A real config.toml used to DEFEAT the hooks install outright
+#                  (#1753): hooktoml's splicer refused any document containing
+#                  a multi-line array, vibe writes twelve of them by default
 #                  (applied_migrations plus the [tools.*] allow/deny lists), and
-#                  Apply then fails with "contains a construct this splicer does
-#                  not model safely". The permission still reads granted and the
-#                  refusal surfaces only in unapplied_grants. Collapsing every
-#                  multi-line array onto one line in the SEED is what unblocked
-#                  the recording. That is a workaround, not a fix.
+#                  Apply then failed with "contains a construct this splicer
+#                  does not model safely" — permission still read granted, and
+#                  the refusal surfaced only in unapplied_grants. #1753 is fixed
+#                  (#1755, hooktoml models multi-line arrays), so the seed is a
+#                  real, unedited config.toml — no collapsing.
 #     pi           CREDENTIALS, the same rule codex's row states. pi resolves
 #                  every agent-dir path from getAgentDir()
 #                  (dist/config.js) — sessions/, settings.json, extensions/


### PR DESCRIPTION
## Summary

- Removes the "collapse every multi-line array onto one line in the SEED"
  workaround note from `tools/onboarding-factory/scripts/lib/agent-home.sh`'s
  mistral-vibe row. The underlying defect (#1753 — hooktoml's splicer refusing
  any document containing a multi-line array) is fixed by #1755, so nothing in
  the rig should keep telling an operator to hand-collapse a real config.toml
  before seeding VIBE_HOME with it. Leaving the note in place after its cause
  was fixed would have been a live blind spot: a *regression* of #1753 would
  still install fine into a hand-collapsed seed and never be caught by a
  recording run — the exact mechanism that found the original bug.

## Live verification (not just the unit test)

The unit-level proof already existed
(`TestEnsureHooksInstalled_IntoAConfigVibeItselfWrote` in
`core/adapters/inbound/agents/vibe/hookinstaller_realconfig_test.go`, against
the committed `testdata/real-config-2.19.1.toml` fixture) — but per the issue,
the **rig path** is what regressed, so the rig path needed to demonstrate the
fix, not just the Go test.

I ran the actual recording rig end-to-end:

1. Seeded a scratch `VIBE_HOME` with a **real, byte-identical, unedited copy**
   of my own `~/.vibe/config.toml` (12 top-level multi-line arrays intact —
   `applied_migrations` plus the `[tools.*]` allow/deny lists), only relocating
   `[session_logging].save_dir` to point inside the scratch home (per the
   driver's own documented isolation requirement).
2. Ran `of record run --agent mistral-vibe --scenario basic-turn` in coexist
   mode (`IRRLICHT_ONBOARD_HOME`, port 127.0.0.1:7838,
   `IRRLICHT_PERMISSION_MODE=grant-all`) — production `irrlichd` on :7837 was
   never touched.
3. Confirmed, directly from the run's managed-file backups (not inferred):
   - The install added **exactly one line** to the real config —
     `enable_experimental_hooks = true` — and all 12 multi-line arrays survived
     byte-identical (392 → 393 lines).
   - `hooks.toml` was created with a real `post_agent_turn` entry.
   - A real `hook_received{Stop}` event fired and was captured in
     `events.jsonl`.
   - `driver_exit_reason=ok`, `completeness=complete`, no refusals or warnings
     anywhere in the run log.
4. Compared the resulting recording's event shape against the currently
   committed `2-1_basic-turn` recording (made under the old collapsed-seed
   workaround): both show exactly one `hook_received`, one settled session,
   ending `ready`. The only difference was one extra transcript-tier settle
   cycle ahead of the hook-tier one — ordinary hook-arrival timing jitter for a
   live external API call, not a structural change tied to the array shape.

**Decision: no promotion.** Since the new recording is structurally equivalent
to what's already committed, I did not promote it as a replacement — nothing
in `replaydata/` changes, no golden regeneration is needed, and no pinned
census figures move. `tools/preflight.sh --only go` (core + onboarding-factory
tests, `of validate`, recording-rig smoke test, replay fixtures) all pass
unchanged.

## Test plan

- [x] `bash tools/onboarding-factory/scripts/lib/agent-home_test.sh` — all pass
      (comment-only change; behavior unaffected)
- [x] `shellcheck --shell=bash --severity=warning` on the edited file — clean
- [x] `go test ./tools/onboarding-factory/internal/righome/... -race -count=1` — pass
- [x] `go test ./core/adapters/inbound/agents/vibe/... ./core/adapters/inbound/agents/hooktoml/... -race -count=1` — pass (includes `TestEnsureHooksInstalled_IntoAConfigVibeItselfWrote`)
- [x] `tools/preflight.sh --only go/bash/tools/arch/posix/security` — all pass
- [x] Live recording rig run against a real, uncollapsed `VIBE_HOME` seed — see evidence above

Closes #1757.

🤖 Generated with [Claude Code](https://claude.com/claude-code)