### PR TITLE
refactor(hooks): extract a shared single-file-artifact installer for pi and opencode

### DIFF
--- a/core/adapters/inbound/agents/hookartifact/hookartifact.go
+++ b/core/adapters/inbound/agents/hookartifact/hookartifact.go
@@ -1,0 +1,276 @@
+// Package hookartifact installs, verifies, and uninstalls a single
+// executable file artifact that an upstream agent auto-discovers from a
+// plain directory glob — the shape pi's extensions/irrlicht.js (#1721) and
+// opencode's plugin/irrlicht.js (#1719) both turned out to share (issue
+// #1764).
+//
+// Both adapters landed within a day of each other, independently, and
+// SonarCloud measured 105 duplicated lines between their two
+// hookinstaller.go files. That was not a coincidence of two authors writing
+// similar code: both upstream loaders resolve extensions the same way (a
+// directory glob accepting a bare .js file, no registry, no package manager,
+// no config-file entry), so both installers do the same four things —
+// resolve the artifact's path, write one file atomically, decide whether an
+// existing file at that path is still ours, and remove it on uninstall. This
+// package is that shared logic, extracted once both adapters were merged and
+// green rather than riding behind either feature review (see #1764 for why
+// that sequencing was deliberate).
+//
+// # What stays with the adapter
+//
+// The artifact's CONTENT does not move here. pi's extension.js and
+// opencode's plugin.js are different files subscribing to different upstream
+// events, each graded by its own adapter-local test suite
+// (extension_test.go, plugin_test.go) that has nothing to do with the
+// install mechanism — those tests mutate the embedded template directly and
+// must keep compiling unchanged. So an Installer takes a Render function
+// (the adapter's own renderExtension/renderPlugin, which already owns the
+// template, the placeholder token, and the beacon-command substitution) and
+// only orchestrates WHEN to call it: on a fresh install, on a rewrite of a
+// stale one, and to compute what "current" looks like for Verify.
+//
+// Likewise, this package never imports core/pkg/hookbeacon itself — every
+// other shared installer of this repo's (hookjson/hooktoml/hookyaml, each
+// living under core/adapters/inbound/agents/ beside this one) takes
+// hookbeacon-derived values as plain data from the declaring adapter rather
+// than reaching for hookbeacon on its own; hermes's hookyaml wiring is the
+// precedent (`Sentinel: hookbeacon.Sentinel(segment)` computed by the
+// adapter, handed in as a field). Installer follows the same shape:
+// Sentinel and ResolveCommand are supplied by the adapter's own
+// hookinstaller.go, which already imports hookbeacon for other reasons
+// (HookEndpointPath, the beacon route). That keeps this package a plain
+// consumer of pre-resolved data — consistent with its siblings, and the
+// reason it can live beside them rather than needing a placement exception.
+//
+// # The one property that matters most
+//
+// IsOurs (the decision inside EnsureInstalledWithCommand, Verify, and
+// Uninstall) is the one place this package can get subtly wrong in the
+// permissive direction: mistaking a user's own same-named file for one of
+// ours would make an install overwrite it, and mistaking one for a stale
+// copy of ours would make an uninstall delete it. It is deliberately the
+// same test every adapter of this shape already used before this
+// extraction — a substring check for the adapter-supplied Sentinel (see
+// hookbeacon.Sentinel's own doc for why it excludes the binary path: a copy
+// naming an irrlichd that has since moved is still recognized as ours)
+// while never matching a file that does not carry it. Getting this right is
+// the whole justification for the extraction: two independent copies of
+// this check existing side by side is exactly the shape that lets them
+// drift apart silently, in code that deletes files from a user's own
+// directory.
+package hookartifact
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"irrlicht/core/domain/agent"
+	"irrlicht/core/pkg/atomicfile"
+)
+
+// Installer owns the install/verify/uninstall lifecycle of one single-file
+// artifact. Every field is required; a zero-value Installer will fail loudly
+// (a nil Path, Render, or ResolveCommand panics on first call, which is
+// preferable to a silent no-op — an adapter that forgets to wire one of
+// these has a bug worth surfacing at the earliest possible point).
+type Installer struct {
+	// AdapterName identifies the upstream agent for error text only (e.g.
+	// the "pi: " / "opencode: " prefix on a refusal-to-overwrite message).
+	// Ownership recognition itself is Sentinel's job, not this field's.
+	AdapterName string
+
+	// Sentinel is the substring that marks a file as this installer's own —
+	// e.g. hookbeacon.Sentinel(AdapterName), computed once by the declaring
+	// adapter and handed in as plain data (see the package doc for why this
+	// package does not compute it itself).
+	Sentinel string
+
+	// ResolveCommand resolves the beacon command to install or compare
+	// against for the CURRENT irrlichd — e.g.
+	// func() (string, error) { return hookbeacon.InstalledCommand(AdapterName) }.
+	// Called on every operation rather than cached, so a long-lived process
+	// always compares against what it would install right now.
+	ResolveCommand func() (string, error)
+
+	// Path resolves the absolute path of the file this installer owns —
+	// e.g. pi's ExtensionPath or opencode's PluginPath. Called on every
+	// operation rather than cached, so it always reflects the current
+	// environment (an env-var override honored at call time, not at
+	// Installer-construction time).
+	Path func() (string, error)
+
+	// Render produces the exact bytes to install for a given, already-
+	// resolved beacon command. Owned by the caller because the artifact's
+	// content is adapter-specific; this package only decides when to call
+	// it (fresh install, rewrite of a stale copy, or to compute what
+	// "current" looks like for Verify) and never inspects what it returns
+	// beyond a byte-for-byte comparison.
+	Render func(command string) ([]byte, error)
+
+	// Events is every hook event this install represents, reported back
+	// verbatim in HookEntryStatus.Missing/Stale — never inspected or
+	// filtered by this package, since the artifact carries exactly one file
+	// covering all of them at once (unlike a config-entry install, there is
+	// no per-event grain to check independently).
+	Events []string
+}
+
+// IsOurs reports whether a file on disk is an artifact this installer would
+// have written — see the package doc for why this is the load-bearing
+// decision.
+//
+// Exported so a caller that already has the bytes in hand (an adapter's own
+// test asserting a freshly-written file carries the sentinel) can ask
+// without going through inspect/Uninstall's file I/O.
+func (in Installer) IsOurs(src []byte) bool {
+	return strings.Contains(string(src), in.Sentinel)
+}
+
+// installState classifies the file at Path against the bytes Render would
+// produce for a given command — the ONE place that classification happens,
+// so EnsureInstalledWithCommand and VerifyInstalled can never independently
+// drift on what "current" means. Before this was split out, both functions
+// re-derived the same read-and-compare logic separately; a change to one
+// (e.g. a normalization tweak) could silently stop matching the other,
+// which is exactly the kind of divergence issue #1764 extracted this
+// package to prevent.
+type installState int
+
+const (
+	installAbsent  installState = iota // nothing at Path
+	installForeign                     // present, but IsOurs is false
+	installStale                       // ours, but not byte-identical to want
+	installCurrent                     // ours and byte-identical to want
+)
+
+// inspect resolves Path, renders the bytes this Installer would write for
+// command, and classifies whatever is currently on disk against them. want
+// is always returned (even when the file is absent or foreign) so a caller
+// that decides to write never re-renders.
+func (in Installer) inspect(command string) (path string, state installState, want []byte, err error) {
+	path, err = in.Path()
+	if err != nil {
+		return "", 0, nil, err
+	}
+	want, err = in.Render(command)
+	if err != nil {
+		return "", 0, nil, err
+	}
+
+	existing, readErr := os.ReadFile(path)
+	switch {
+	case errors.Is(readErr, os.ErrNotExist):
+		return path, installAbsent, want, nil
+	case readErr != nil:
+		return "", 0, nil, readErr
+	case !in.IsOurs(existing):
+		return path, installForeign, want, nil
+	case string(existing) == string(want):
+		return path, installCurrent, want, nil
+	default:
+		// Ours, but stale — a moved irrlichd, or a template change.
+		return path, installStale, want, nil
+	}
+}
+
+// EnsureInstalled writes the artifact for the irrlichd that is running now,
+// creating the parent directory if it does not exist. Returns true if
+// anything changed.
+//
+// Idempotent, and self-healing across a moved binary: an already-installed
+// copy whose beacon command names a different irrlichd is rewritten IN
+// PLACE (same path, one file), never duplicated.
+func (in Installer) EnsureInstalled() (bool, error) {
+	command, err := in.ResolveCommand()
+	if err != nil {
+		return false, err
+	}
+	return in.EnsureInstalledWithCommand(command)
+}
+
+// EnsureInstalledWithCommand is EnsureInstalled with the beacon command
+// resolved by the caller — the seam the #1178 contract's ForeignInstall uses
+// to seed the install a DIFFERENTLY-situated daemon would have written.
+func (in Installer) EnsureInstalledWithCommand(command string) (bool, error) {
+	path, state, want, err := in.inspect(command)
+	if err != nil {
+		return false, err
+	}
+	switch state {
+	case installCurrent:
+		return false, nil
+	case installForeign:
+		// A file we did not write occupies the path we install to.
+		// Overwriting it would destroy a user's own file for the sake of
+		// monitoring, which is never the right trade; refusing surfaces as
+		// "granted but NOT applied" in the wizard (issue #1362) with this
+		// message, which is the honest outcome.
+		return false, fmt.Errorf("%s: %s exists and was not written by irrlicht; refusing to overwrite it", in.AdapterName, path)
+	}
+	// installAbsent or installStale: write it.
+	if err := atomicfile.WriteFile(path, want); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// VerifyInstalled reports whether the installed artifact is still present
+// and current, without writing anything (issue #1372). This is what
+// services.HookEntryVerifier re-checks a granted install with on a timer.
+func (in Installer) VerifyInstalled() (agent.HookEntryStatus, error) {
+	command, err := in.ResolveCommand()
+	if err != nil {
+		return agent.HookEntryStatus{}, err
+	}
+	_, state, _, err := in.inspect(command)
+	if err != nil {
+		return agent.HookEntryStatus{}, err
+	}
+	switch state {
+	case installAbsent, installForeign:
+		// A foreign file is reported as Missing rather than Stale: "stale"
+		// means EnsureInstalled would rewrite it, and it deliberately will
+		// not.
+		return agent.HookEntryStatus{Missing: append([]string(nil), in.Events...)}, nil
+	case installStale:
+		return agent.HookEntryStatus{Stale: append([]string(nil), in.Events...)}, nil
+	default: // installCurrent
+		return agent.HookEntryStatus{}, nil
+	}
+}
+
+// Uninstall removes the artifact. Returns true if anything changed.
+//
+// Removes the FILE, because the file is the entire install — nothing else
+// was touched, so there is nothing else to undo. A file at our path that is
+// not ours is left alone, the same "leave a foreign entry alone" rule every
+// hook uninstall in this codebase follows — see the package doc for why
+// this is the direction that matters most to get right.
+//
+// The parent directory is deliberately NOT removed when it empties out, even
+// if this install is what created it: an empty extensions/plugin directory
+// is an ordinary state for the upstream agent, and removing a directory a
+// user's editor or shell may have open is a worse surprise than leaving one
+// behind.
+func (in Installer) Uninstall() (bool, error) {
+	path, err := in.Path()
+	if err != nil {
+		return false, err
+	}
+	existing, readErr := os.ReadFile(path)
+	if errors.Is(readErr, os.ErrNotExist) {
+		return false, nil
+	}
+	if readErr != nil {
+		return false, readErr
+	}
+	if !in.IsOurs(existing) {
+		return false, nil
+	}
+	if err := os.Remove(path); err != nil {
+		return false, err
+	}
+	return true, nil
+}

--- a/core/adapters/inbound/agents/hookartifact/hookartifact_test.go
+++ b/core/adapters/inbound/agents/hookartifact/hookartifact_test.go
@@ -1,0 +1,437 @@
+// hookartifact_test.go carries forward, as permanent locks against this
+// package, both adapters' pre-existing mutation tests for the shape this
+// package extracted from pi/hookinstaller.go and opencode/hookinstaller.go
+// (issue #1764). Per docs/testing-philosophy.md, a rewrite that replaces an
+// existing implementation owes its predecessors' cases on top of its own —
+// TestSourceScanCatchesEveryKnownShape (core/application/services/
+// construction_test.go) is the cautionary precedent the issue names: a
+// rewrite there silently dropped a case the original caught while eighteen
+// new probes all passed. Every test below is traceable to a specific
+// pre-existing test in pi/hookinstaller_test.go or
+// opencode/hookinstaller_test.go, named in its doc comment, so a reader can
+// check nothing was dropped in translation.
+//
+// These fixtures use a synthetic adapter identity rather than pi's or
+// opencode's real one, so this package's own test suite proves the shared
+// mechanism correct independently of either adapter's continued existence —
+// pi's and opencode's own (unmodified) hookinstaller_test.go files are the
+// second, end-to-end proof that the real wiring still behaves identically
+// after the extraction.
+package hookartifact
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"irrlicht/core/pkg/hookbeacon"
+)
+
+// fixtureAdapter is a real adapter segment (hookbeacon validates the shape)
+// scoped so it can never collide with an actual adapter's own sentinel.
+const fixtureAdapter = "hookartifact-fixture"
+
+// foreignFixtureBinary is the irrlichd a differently-situated daemon would
+// have named — deliberately nonexistent, the same pattern pi's and
+// opencode's own hookport_test.go use for the identical reason: an absolute
+// path that has stopped existing is exactly the drift beacon delivery
+// admits, and it needs no second executable to arrange.
+const foreignFixtureBinary = "/nonexistent-hookartifact-1764/bin/irrlichd"
+
+// fixtureRender stands in for a real adapter's renderExtension/renderPlugin:
+// it embeds the beacon command verbatim, which is enough to carry
+// hookbeacon.Sentinel(fixtureAdapter) — the same substring isOurs looks for
+// in a real installed extension.js/plugin.js — without needing either
+// adapter's actual JS template or placeholder-substitution machinery, which
+// stays adapter-local (see the package doc).
+func fixtureRender(command string) ([]byte, error) {
+	if command == "" {
+		return nil, errors.New("hookartifact fixture: refusing to render an empty beacon command")
+	}
+	return []byte("// fixture artifact — DO NOT EDIT\nconst BEACON = " + strconv.Quote(command) + ";\n"), nil
+}
+
+// fixtureInstaller builds an Installer against a fresh temp directory.
+// Sentinel/ResolveCommand are computed the same way a real adapter's
+// hookinstaller.go computes them — hookbeacon stays a TEST-only dependency
+// here, never a production import of this package (see the package doc).
+func fixtureInstaller(t *testing.T) (in Installer, path string) {
+	t.Helper()
+	dir := t.TempDir()
+	path = filepath.Join(dir, "artifact.js")
+	return Installer{
+		AdapterName: fixtureAdapter,
+		Sentinel:    hookbeacon.Sentinel(fixtureAdapter),
+		ResolveCommand: func() (string, error) {
+			return hookbeacon.InstalledCommand(fixtureAdapter)
+		},
+		Path:   func() (string, error) { return path, nil },
+		Render: fixtureRender,
+		Events: []string{"turn_end"},
+	}, path
+}
+
+// TestEnsureInstalled_CreatesArtifactAndIsIdempotent carries forward pi's
+// TestEnsureInstalled_CreatesTheExtensionAndIsIdempotent and opencode's
+// TestEnsureHooksInstalled_IsIdempotent: the base case (a fresh install
+// writes a file carrying the sentinel) and the idempotency property (a
+// second call changes nothing — the permission service re-runs Apply on
+// every daemon start, so a non-idempotent installer would rewrite the
+// user's file forever).
+func TestEnsureInstalled_CreatesArtifactAndIsIdempotent(t *testing.T) {
+	in, path := fixtureInstaller(t)
+
+	modified, err := in.EnsureInstalled()
+	if err != nil {
+		t.Fatalf("EnsureInstalled: %v", err)
+	}
+	if !modified {
+		t.Error("first install reported no modification")
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading the installed artifact: %v", err)
+	}
+	if !in.IsOurs(data) {
+		t.Error("the installed file does not carry the beacon sentinel")
+	}
+
+	modified, err = in.EnsureInstalled()
+	if err != nil {
+		t.Fatalf("second EnsureInstalled: %v", err)
+	}
+	if modified {
+		t.Error("second install reported a modification; the install is not idempotent")
+	}
+}
+
+// TestEnsureInstalled_RefusesToOverwriteAForeignFile carries forward pi's
+// TestEnsureInstalled_RefusesToOverwriteAFileItDidNotWrite and opencode's
+// TestEnsureHooksInstalled_RefusesToOverwriteAForeignFile, including the
+// latter's assertion that the refusal names the file — the wizard surfaces
+// that string verbatim as "granted but NOT applied" (#1362).
+//
+// This is the guard on the one genuinely destructive thing an install of
+// this shape could do on the WRITE side: the path is a name irrlicht chose
+// inside a directory the user owns, and overwriting whatever is already
+// there for the sake of monitoring is never the right trade.
+func TestEnsureInstalled_RefusesToOverwriteAForeignFile(t *testing.T) {
+	in, path := fixtureInstaller(t)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	const theirs = "export default function () { /* someone else's file */ }\n"
+	if err := os.WriteFile(path, []byte(theirs), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	modified, err := in.EnsureInstalled()
+	if err == nil {
+		t.Error("EnsureInstalled overwrote a foreign file without complaint")
+	}
+	if modified {
+		t.Error("EnsureInstalled reported a modification while refusing")
+	}
+	if err != nil && !strings.Contains(err.Error(), path) {
+		t.Errorf("the refusal %q does not name the file — the wizard surfaces this string as \"granted but NOT applied\" (#1362)", err)
+	}
+	got, readErr := os.ReadFile(path)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if string(got) != theirs {
+		t.Error("the foreign file was modified")
+	}
+}
+
+// TestUninstall_RemovesOursAndLeavesForeignAlone carries forward pi's
+// TestUninstall_RemovesOursAndLeavesForeignAlone and opencode's
+// TestUninstallHooks_LeavesAForeignFileAlone — the "foreign-file clobber"
+// case issue #1764 names explicitly as opencode's committed mutation for
+// exactly this hazard. Getting this wrong in the permissive direction means
+// uninstall deletes a user's own file, which is the single worst thing this
+// package could do.
+func TestUninstall_RemovesOursAndLeavesForeignAlone(t *testing.T) {
+	in, path := fixtureInstaller(t)
+	if _, err := in.EnsureInstalled(); err != nil {
+		t.Fatalf("EnsureInstalled: %v", err)
+	}
+
+	modified, err := in.Uninstall()
+	if err != nil {
+		t.Fatalf("Uninstall: %v", err)
+	}
+	if !modified {
+		t.Error("uninstall of an installed artifact reported no modification")
+	}
+	if _, statErr := os.Stat(path); !os.IsNotExist(statErr) {
+		t.Errorf("the artifact survived uninstall (stat err = %v)", statErr)
+	}
+
+	// A second uninstall is a no-op, not an error (opencode's
+	// TestUninstallHooks_OnNothingIsQuiet covers the "never installed" leg
+	// of the same rule separately, below).
+	if modified, err = in.Uninstall(); err != nil || modified {
+		t.Errorf("second uninstall = (%v, %v), want (false, nil)", modified, err)
+	}
+
+	// And a foreign file written to our path afterward survives Uninstall
+	// byte-for-byte — the clobber case.
+	const theirs = "export default function () {}\n"
+	if err := os.WriteFile(path, []byte(theirs), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if modified, err = in.Uninstall(); err != nil || modified {
+		t.Errorf("uninstall over a foreign file = (%v, %v), want (false, nil)", modified, err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil || string(got) != theirs {
+		t.Error("uninstall removed or altered a file it did not write")
+	}
+}
+
+// TestUninstall_OnNothingIsQuiet carries forward opencode's
+// TestUninstallHooks_OnNothingIsQuiet: PermissionService runs Remove
+// whenever the answer is "denied", including the first time the wizard is
+// ever answered, so a revoke with nothing installed must not be an error.
+func TestUninstall_OnNothingIsQuiet(t *testing.T) {
+	in, _ := fixtureInstaller(t)
+	modified, err := in.Uninstall()
+	if err != nil {
+		t.Fatalf("Uninstall with nothing installed: %v", err)
+	}
+	if modified {
+		t.Error("Uninstall reported a change with nothing installed")
+	}
+}
+
+// TestUninstall_LeavesParentDirectoryBehind carries forward opencode's
+// TestUninstallHooks_LeavesThePluginDirectoryBehind: an empty parent
+// directory is an ordinary state for the upstream agent, and removing a
+// directory a user's editor or shell may have open is a worse surprise than
+// leaving one behind.
+func TestUninstall_LeavesParentDirectoryBehind(t *testing.T) {
+	in, path := fixtureInstaller(t)
+	if _, err := in.EnsureInstalled(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := in.Uninstall(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("the artifact survived uninstall: %v", err)
+	}
+	if _, err := os.Stat(filepath.Dir(path)); err != nil {
+		t.Errorf("the parent directory was removed too: %v", err)
+	}
+}
+
+// TestVerifyInstalled_ReportsTheThreeStates carries forward opencode's
+// TestVerifyHooksInstalled_ReportsTheThreeStates: Missing (nothing there, or
+// a foreign file at our path — Verify must not report a foreign file as
+// "Stale", since Stale promises EnsureInstalled would rewrite it in place,
+// which it deliberately will not), Stale (ours, but naming a different
+// irrlichd — the moved-binary case), and Intact (current). The companion
+// property pi's TestVerifyAgreesWithEnsureInstalled pins — that these two
+// readers of the same file never disagree — is
+// TestVerifyInstalled_AgreesWithEnsureInstalled, below.
+func TestVerifyInstalled_ReportsTheThreeStates(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		seed func(t *testing.T, in Installer, path string)
+		want string // "missing", "stale", or "intact"
+	}{
+		{
+			name: "nothing_installed",
+			seed: func(*testing.T, Installer, string) {},
+			want: "missing",
+		},
+		{
+			name: "fresh_install",
+			seed: func(t *testing.T, in Installer, _ string) {
+				if _, err := in.EnsureInstalled(); err != nil {
+					t.Fatal(err)
+				}
+			},
+			want: "intact",
+		},
+		{
+			// Ours, but written for a daemon that lived somewhere else.
+			name: "ours_but_naming_another_binary",
+			seed: func(t *testing.T, in Installer, _ string) {
+				foreignCommand, err := hookbeacon.Command(foreignFixtureBinary, fixtureAdapter)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if _, err := in.EnsureInstalledWithCommand(foreignCommand); err != nil {
+					t.Fatal(err)
+				}
+			},
+			want: "stale",
+		},
+		{
+			// Not ours at all. Missing rather than Stale: Stale promises
+			// EnsureInstalled would rewrite it in place, and it deliberately
+			// will not.
+			name: "foreign_file",
+			seed: func(t *testing.T, in Installer, path string) {
+				if err := os.WriteFile(path, []byte("export default function () {}\n"), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			},
+			want: "missing",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			in, path := fixtureInstaller(t)
+			tc.seed(t, in, path)
+
+			status, err := in.VerifyInstalled()
+			if err != nil {
+				t.Fatalf("VerifyInstalled: %v", err)
+			}
+			switch tc.want {
+			case "intact":
+				if !status.Intact() {
+					t.Errorf("status = %+v, want intact", status)
+				}
+			case "stale":
+				if len(status.Stale) != len(in.Events) {
+					t.Errorf("status = %+v, want all %d events Stale", status, len(in.Events))
+				}
+			case "missing":
+				if len(status.Missing) != len(in.Events) {
+					t.Errorf("status = %+v, want all %d events Missing", status, len(in.Events))
+				}
+			}
+		})
+	}
+}
+
+// TestVerifyInstalled_AgreesWithEnsureInstalled carries forward pi's
+// TestVerifyAgreesWithEnsureInstalled as a property rather than as three
+// hand-picked cases: for every state the file can be in, VerifyInstalled
+// reports work outstanding exactly when EnsureInstalled would do some.
+//
+// It exists because those are two separate readers of the same file (before
+// this package's own inspect helper unified them, they were two independent
+// implementations), and the failure mode of a disagreement is invisible in
+// both directions — a verifier that under-reports leaves a dead channel
+// green forever, and one that over-reports makes the repair timer rewrite a
+// correct file on every tick. TestVerifyInstalled_ReportsTheThreeStates
+// above pins the three states by name; this pins that Verify and Ensure can
+// never read one of them differently.
+func TestVerifyInstalled_AgreesWithEnsureInstalled(t *testing.T) {
+	foreignCommand, err := hookbeacon.Command(foreignFixtureBinary, fixtureAdapter)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stale, err := fixtureRender(foreignCommand)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tc := range []struct {
+		name            string
+		seed            func(t *testing.T, in Installer, path string)
+		wantOutstanding bool
+	}{
+		{name: "absent", seed: func(*testing.T, Installer, string) {}, wantOutstanding: true},
+		{
+			name: "ours_but_naming_another_binary",
+			seed: func(t *testing.T, in Installer, path string) {
+				if err := os.WriteFile(path, stale, 0o600); err != nil {
+					t.Fatal(err)
+				}
+			},
+			wantOutstanding: true,
+		},
+		{
+			name: "current",
+			seed: func(t *testing.T, in Installer, _ string) {
+				if _, err := in.EnsureInstalled(); err != nil {
+					t.Fatal(err)
+				}
+			},
+			wantOutstanding: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			in, path := fixtureInstaller(t)
+			tc.seed(t, in, path)
+
+			status, err := in.VerifyInstalled()
+			if err != nil {
+				t.Fatalf("VerifyInstalled: %v", err)
+			}
+			reported := len(status.Missing) > 0 || len(status.Stale) > 0
+			if reported != tc.wantOutstanding {
+				t.Errorf("verify reported outstanding=%v (missing=%v stale=%v), want %v",
+					reported, status.Missing, status.Stale, tc.wantOutstanding)
+			}
+
+			modified, err := in.EnsureInstalled()
+			if err != nil {
+				t.Fatalf("EnsureInstalled: %v", err)
+			}
+			if modified != reported {
+				t.Errorf("verify says outstanding=%v but ensure modified=%v — the two "+
+					"readers of the same file disagree", reported, modified)
+			}
+		})
+	}
+}
+
+// TestVerifyInstalled_ForeignFileIsOutstandingButEnsureRefuses is the fourth
+// state pi's original property test predates and never covered: a foreign
+// file. There "outstanding" and "modified" cannot be compared as two bools
+// the way TestVerifyInstalled_AgreesWithEnsureInstalled's other three states
+// can — Ensure legitimately REFUSES (an error, not a silent no-op) rather
+// than writing, which is itself the correct way of not reconciling what
+// Verify reports outstanding (see EnsureInstalledWithCommand's
+// installForeign case). Split into its own test, rather than a branch
+// inside the table above, so neither test carries the other's shape.
+//
+// It is included because the extraction is exactly what makes checking this
+// state cheap now — a foreign file is the highest-stakes state #1764's own
+// text names.
+func TestVerifyInstalled_ForeignFileIsOutstandingButEnsureRefuses(t *testing.T) {
+	in, path := fixtureInstaller(t)
+	if err := os.WriteFile(path, []byte("export default function () {}\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	status, err := in.VerifyInstalled()
+	if err != nil {
+		t.Fatalf("VerifyInstalled: %v", err)
+	}
+	if status.Intact() {
+		t.Error("verify reported a foreign file as intact")
+	}
+
+	modified, err := in.EnsureInstalled()
+	if err == nil {
+		t.Error("EnsureInstalled succeeded against a foreign file; want a refusal")
+	}
+	if modified {
+		t.Error("EnsureInstalled reported a modification while refusing")
+	}
+}
+
+// TestVerifyInstalled_DoesNotWrite carries forward pi's
+// TestVerify_DoesNotWrite: the verifier is read-only by construction
+// (#1372) — it runs on a timer against a granted install, and a verifier
+// that materialized what it was checking for would report health it had
+// just created.
+func TestVerifyInstalled_DoesNotWrite(t *testing.T) {
+	in, path := fixtureInstaller(t)
+	if _, err := in.VerifyInstalled(); err != nil {
+		t.Fatalf("VerifyInstalled: %v", err)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("verify created the artifact it was asked to check (stat err = %v)", err)
+	}
+}

--- a/core/adapters/inbound/agents/opencode/hookinstaller.go
+++ b/core/adapters/inbound/agents/opencode/hookinstaller.go
@@ -80,15 +80,14 @@ import (
 	_ "embed"
 	"errors"
 	"fmt"
-	"os"
 	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
 
 	"irrlicht/core/adapters/inbound/agents/agentpaths"
+	"irrlicht/core/adapters/inbound/agents/hookartifact"
 	"irrlicht/core/domain/agent"
-	"irrlicht/core/pkg/atomicfile"
 	"irrlicht/core/pkg/hookbeacon"
 )
 
@@ -267,15 +266,6 @@ func beaconCommandOf(src []byte) (string, bool) {
 	return command, true
 }
 
-// isOurs reports whether a file on disk is an irrlicht-installed plugin — by
-// the beacon sentinel, which deliberately excludes the binary path, so a copy
-// naming an irrlichd that has since moved is still recognized as ours.
-// Recognizing it is the precondition for rewriting it in place instead of
-// leaving a second one beside it.
-func isOurs(src []byte) bool {
-	return strings.Contains(string(src), hookbeacon.Sentinel(AdapterName))
-}
-
 // --- path resolution ---
 
 // configHomeEnvVar is the XDG variable opencode resolves its config directory
@@ -310,6 +300,30 @@ func PluginPath() (string, error) {
 }
 
 // --- install / verify / uninstall ---
+//
+// The install/verify/uninstall lifecycle itself is shared with pi (issue
+// #1764) — both adapters install a single executable artifact that their
+// upstream agent auto-discovers from a directory glob, and the four
+// operations that shape (resolve path, write atomically, recognize "is this
+// ours", remove on uninstall) requires are identical modulo the artifact's
+// own content. See hookartifact's package doc for the shared mechanism and
+// why "is this ours" is the property that matters most to keep in one place.
+
+// installer is the opencode plugin's hookartifact.Installer. A package-level
+// var, not constructed per call, so every entry point below shares the same
+// wiring — but every field it holds is itself a function, so nothing here is
+// resolved (a path, an environment override, the running binary) until the
+// moment an operation actually runs.
+var installer = hookartifact.Installer{
+	AdapterName: AdapterName,
+	Sentinel:    hookbeacon.Sentinel(AdapterName),
+	ResolveCommand: func() (string, error) {
+		return hookbeacon.InstalledCommand(AdapterName)
+	},
+	Path:   PluginPath,
+	Render: renderPlugin,
+	Events: installedHookEvents,
+}
 
 // EnsureHooksInstalled writes irrlicht's opencode plugin for the irrlichd that
 // is running now, creating opencode's plugin directory if it does not exist.
@@ -319,50 +333,14 @@ func PluginPath() (string, error) {
 // copy whose beacon command names a different irrlichd is rewritten IN PLACE
 // (same path, one file), never duplicated.
 func EnsureHooksInstalled() (bool, error) {
-	command, err := hookbeacon.InstalledCommand(AdapterName)
-	if err != nil {
-		return false, err
-	}
-	return ensureInstalledWithCommand(command)
+	return installer.EnsureInstalled()
 }
 
 // ensureInstalledWithCommand is EnsureHooksInstalled with the beacon command
 // resolved by the caller — the seam the #1178 contract's ForeignInstall uses to
 // seed the install a DIFFERENTLY-situated daemon would have written.
-// hookbeacon.InstalledCommand is called exactly once per entry point, which is
-// the shape hookbeacon's own doc comment asks adopters for.
 func ensureInstalledWithCommand(command string) (bool, error) {
-	path, err := PluginPath()
-	if err != nil {
-		return false, err
-	}
-	want, err := renderPlugin(command)
-	if err != nil {
-		return false, err
-	}
-
-	existing, readErr := os.ReadFile(path)
-	switch {
-	case readErr == nil && isOurs(existing):
-		if string(existing) == string(want) {
-			return false, nil
-		}
-		// Ours, but stale — a moved irrlichd, or a template change.
-	case readErr == nil:
-		// A file we did not write occupies the path we install to.
-		// Overwriting it would destroy a user's own plugin for the sake of
-		// monitoring, which is never the right trade; refusing surfaces as
-		// "granted but NOT applied" in the wizard (issue #1362) with this
-		// message, which is the honest outcome.
-		return false, fmt.Errorf("opencode: %s exists and was not written by irrlicht; refusing to overwrite it", path)
-	case !errors.Is(readErr, os.ErrNotExist):
-		return false, readErr
-	}
-
-	if err := atomicfile.WriteFile(path, want); err != nil {
-		return false, err
-	}
-	return true, nil
+	return installer.EnsureInstalledWithCommand(command)
 }
 
 // VerifyHooksInstalled reports whether the installed plugin is still present
@@ -373,36 +351,7 @@ func ensureInstalledWithCommand(command string) (bool, error) {
 // the background `@opencode-ai/plugin` dependency install opencode runs against
 // every config directory all operate in the same tree.
 func VerifyHooksInstalled() (agent.HookEntryStatus, error) {
-	path, err := PluginPath()
-	if err != nil {
-		return agent.HookEntryStatus{}, err
-	}
-	command, err := hookbeacon.InstalledCommand(AdapterName)
-	if err != nil {
-		return agent.HookEntryStatus{}, err
-	}
-	want, err := renderPlugin(command)
-	if err != nil {
-		return agent.HookEntryStatus{}, err
-	}
-
-	existing, readErr := os.ReadFile(path)
-	if errors.Is(readErr, os.ErrNotExist) {
-		return agent.HookEntryStatus{Missing: append([]string(nil), installedHookEvents...)}, nil
-	}
-	if readErr != nil {
-		return agent.HookEntryStatus{}, readErr
-	}
-	if !isOurs(existing) {
-		// Something else owns the path now. Reported as Missing rather than
-		// Stale: "stale" means EnsureHooksInstalled would rewrite it, and it
-		// deliberately will not.
-		return agent.HookEntryStatus{Missing: append([]string(nil), installedHookEvents...)}, nil
-	}
-	if string(existing) != string(want) {
-		return agent.HookEntryStatus{Stale: append([]string(nil), installedHookEvents...)}, nil
-	}
-	return agent.HookEntryStatus{}, nil
+	return installer.VerifyInstalled()
 }
 
 // UninstallHooks removes irrlicht's opencode plugin. Returns true if anything
@@ -419,22 +368,5 @@ func VerifyHooksInstalled() (agent.HookEntryStatus, error) {
 // state for an opencode installation, and removing a directory a user's editor
 // or shell may have open is a worse surprise than leaving one behind.
 func UninstallHooks() (bool, error) {
-	path, err := PluginPath()
-	if err != nil {
-		return false, err
-	}
-	existing, readErr := os.ReadFile(path)
-	if errors.Is(readErr, os.ErrNotExist) {
-		return false, nil
-	}
-	if readErr != nil {
-		return false, readErr
-	}
-	if !isOurs(existing) {
-		return false, nil
-	}
-	if err := os.Remove(path); err != nil {
-		return false, err
-	}
-	return true, nil
+	return installer.Uninstall()
 }

--- a/core/adapters/inbound/agents/pi/hookinstaller.go
+++ b/core/adapters/inbound/agents/pi/hookinstaller.go
@@ -71,15 +71,14 @@ import (
 	_ "embed"
 	"errors"
 	"fmt"
-	"os"
 	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
 
 	"irrlicht/core/adapters/inbound/agents/agentpaths"
+	"irrlicht/core/adapters/inbound/agents/hookartifact"
 	"irrlicht/core/domain/agent"
-	"irrlicht/core/pkg/atomicfile"
 	"irrlicht/core/pkg/hookbeacon"
 )
 
@@ -229,13 +228,12 @@ func beaconCommandOf(src []byte) (string, bool) {
 	return command, true
 }
 
-// isOurs reports whether a file on disk is an irrlicht-installed extension —
-// by the beacon sentinel, which deliberately excludes the binary path, so a
-// copy naming an irrlichd that has since moved is still recognized as ours.
-// Recognizing it is the precondition for rewriting it in place instead of
-// appending a second one beside it.
+// isOurs reports whether a file on disk is an irrlicht-installed extension.
+// See hookartifact's package doc for why this check (a beacon-sentinel
+// substring test that deliberately excludes the binary path) is the one
+// this adapter shares with opencode rather than reimplementing.
 func isOurs(src []byte) bool {
-	return strings.Contains(string(src), hookbeacon.Sentinel(AdapterName))
+	return installer.IsOurs(src)
 }
 
 // --- path resolution ---
@@ -266,6 +264,30 @@ func ExtensionPath() (string, error) {
 }
 
 // --- install / verify / uninstall ---
+//
+// The install/verify/uninstall lifecycle itself is shared with opencode
+// (issue #1764) — both adapters install a single executable artifact that
+// their upstream agent auto-discovers from a directory glob, and the four
+// operations that shape (resolve path, write atomically, recognize "is this
+// ours", remove on uninstall) requires are identical modulo the artifact's
+// own content. See hookartifact's package doc for the shared mechanism and
+// why "is this ours" is the property that matters most to keep in one place.
+
+// installer is the pi extension's hookartifact.Installer. A package-level
+// var, not constructed per call, so every entry point below shares the same
+// wiring — but every field it holds is itself a function, so nothing here is
+// resolved (a path, an environment override, the running binary) until the
+// moment an operation actually runs.
+var installer = hookartifact.Installer{
+	AdapterName: AdapterName,
+	Sentinel:    hookbeacon.Sentinel(AdapterName),
+	ResolveCommand: func() (string, error) {
+		return hookbeacon.InstalledCommand(AdapterName)
+	},
+	Path:   ExtensionPath,
+	Render: renderExtension,
+	Events: installedHookEvents,
+}
 
 // EnsureHooksInstalled writes irrlicht's pi extension for the irrlichd that
 // is running now, creating pi's extensions directory if it does not exist.
@@ -275,50 +297,14 @@ func ExtensionPath() (string, error) {
 // copy whose beacon command names a different irrlichd is rewritten IN PLACE
 // (same path, one file), never duplicated.
 func EnsureHooksInstalled() (bool, error) {
-	command, err := hookbeacon.InstalledCommand(AdapterName)
-	if err != nil {
-		return false, err
-	}
-	return ensureInstalledWithCommand(command)
+	return installer.EnsureInstalled()
 }
 
 // ensureInstalledWithCommand is EnsureHooksInstalled with the beacon command
 // resolved by the caller — the seam the #1178 contract's ForeignInstall uses
 // to seed the install a DIFFERENTLY-situated daemon would have written.
-// hookbeacon.InstalledCommand is called exactly once per entry point, which
-// is the shape hookbeacon's own doc comment asks adopters for.
 func ensureInstalledWithCommand(command string) (bool, error) {
-	path, err := ExtensionPath()
-	if err != nil {
-		return false, err
-	}
-	want, err := renderExtension(command)
-	if err != nil {
-		return false, err
-	}
-
-	existing, readErr := os.ReadFile(path)
-	switch {
-	case readErr == nil && isOurs(existing):
-		if string(existing) == string(want) {
-			return false, nil
-		}
-		// Ours, but stale — a moved irrlichd, or a template change.
-	case readErr == nil:
-		// A file we did not write occupies the path we install to.
-		// Overwriting it would destroy a user's own extension for the sake
-		// of monitoring, which is never the right trade; refusing surfaces
-		// as "granted but NOT applied" in the wizard (issue #1362) with this
-		// message, which is the honest outcome.
-		return false, fmt.Errorf("pi: %s exists and was not written by irrlicht; refusing to overwrite it", path)
-	case !errors.Is(readErr, os.ErrNotExist):
-		return false, readErr
-	}
-
-	if err := atomicfile.WriteFile(path, want); err != nil {
-		return false, err
-	}
-	return true, nil
+	return installer.EnsureInstalledWithCommand(command)
 }
 
 // VerifyHooksInstalled reports whether the installed extension is still
@@ -328,36 +314,7 @@ func ensureInstalledWithCommand(command string) (bool, error) {
 // `pi install` / `pi remove` and any manual tidy of the extensions directory
 // can remove this file with the permission still reading granted.
 func VerifyHooksInstalled() (agent.HookEntryStatus, error) {
-	path, err := ExtensionPath()
-	if err != nil {
-		return agent.HookEntryStatus{}, err
-	}
-	command, err := hookbeacon.InstalledCommand(AdapterName)
-	if err != nil {
-		return agent.HookEntryStatus{}, err
-	}
-	want, err := renderExtension(command)
-	if err != nil {
-		return agent.HookEntryStatus{}, err
-	}
-
-	existing, readErr := os.ReadFile(path)
-	if errors.Is(readErr, os.ErrNotExist) {
-		return agent.HookEntryStatus{Missing: append([]string(nil), installedHookEvents...)}, nil
-	}
-	if readErr != nil {
-		return agent.HookEntryStatus{}, readErr
-	}
-	if !isOurs(existing) {
-		// Something else owns the path now. Reported as Missing rather than
-		// Stale: "stale" means EnsureHooksInstalled would rewrite it, and it
-		// deliberately will not.
-		return agent.HookEntryStatus{Missing: append([]string(nil), installedHookEvents...)}, nil
-	}
-	if string(existing) != string(want) {
-		return agent.HookEntryStatus{Stale: append([]string(nil), installedHookEvents...)}, nil
-	}
-	return agent.HookEntryStatus{}, nil
+	return installer.VerifyInstalled()
 }
 
 // UninstallHooks removes irrlicht's pi extension. Returns true if anything
@@ -374,22 +331,5 @@ func VerifyHooksInstalled() (agent.HookEntryStatus, error) {
 // ordinary state for a pi installation, and removing a directory a user's
 // editor or shell may have open is a worse surprise than leaving one behind.
 func UninstallHooks() (bool, error) {
-	path, err := ExtensionPath()
-	if err != nil {
-		return false, err
-	}
-	existing, readErr := os.ReadFile(path)
-	if errors.Is(readErr, os.ErrNotExist) {
-		return false, nil
-	}
-	if readErr != nil {
-		return false, readErr
-	}
-	if !isOurs(existing) {
-		return false, nil
-	}
-	if err := os.Remove(path); err != nil {
-		return false, err
-	}
-	return true, nil
+	return installer.Uninstall()
 }


### PR DESCRIPTION
## Summary

pi (#1721) and opencode (#1719) shipped within a day of each other and are the first two adapters that install a single executable artifact into a directory (rather than splicing an entry into a config file). Their `hookinstaller.go` files were near-identical — SonarCloud measured 105 duplicated lines between them.

This extracts the shared logic into `core/adapters/inbound/agents/hookartifact.Installer`: resolve the artifact's path, write it atomically, decide whether an existing file at that path is still "ours", and remove it on uninstall.

- **What stays adapter-local**: the artifact's own content (`extension.js` / `plugin.js`), the placeholder-substitution `renderExtension`/`renderPlugin`, and their JS-level test suites (`extension_test.go`/`plugin_test.go`) — all untouched, byte-for-byte.
- **What moved**: `EnsureHooksInstalled` / `VerifyHooksInstalled` / `UninstallHooks` / `isOurs` now delegate to a package-level `hookartifact.Installer{AdapterName, Sentinel, ResolveCommand, Path, Render, Events}` value. Each adapter's own function signatures are unchanged, so `agent.go`'s `Permission.Apply`/`Remove`/`Writes.*` wiring needed zero changes.
- `EnsureInstalledWithCommand` and `VerifyInstalled` share one internal `inspect` classifier (absent/foreign/stale/current), so the two can never independently drift on what "current" means — before this, each function re-derived the same read-and-compare logic separately.
- **Atomicity**: uses `core/pkg/atomicfile.WriteFile` (#1761), not a ninth hand-rolled copy.
- **No `core/pkg/hookbeacon` dependency**: `Sentinel` and `ResolveCommand` are precomputed by each adapter's own `hookinstaller.go` (which already imports `hookbeacon` for its `HookEndpointPath` route) and handed in as plain data — the same shape `hookyaml`'s hermes wiring already uses. This keeps `hookartifact` a plain consumer of pre-resolved values, consistent with its `hookjson`/`hooktoml`/`hookyaml` siblings, and lets it live beside them under `core/adapters/inbound/agents/` rather than needing a placement exception: an earlier version of this PR had `hookartifact` call `hookbeacon` directly and live under `core/pkg` to dodge `tools/onboarding-factory/internal/righome`'s beacon scan (which treats any directory under `core/adapters/inbound/agents/` whose production code imports `hookbeacon` as a catalogued adapter requiring its own `const AdapterName`) — a review pass correctly flagged that as routing around the scanner instead of removing the actual cause, so the dependency was removed instead.

## Testing (locks, not defect tests — see docs/testing-philosophy.md)

This is a refactor with no intended behaviour change, so the obligation is to show the shared version reddens on **both adapters' pre-existing installer mutations**, not merely to pass its own new tests (the `TestSourceScanCatchesEveryKnownShape` precedent the issue names).

- `core/adapters/inbound/agents/hookartifact/hookartifact_test.go` carries forward every case from `pi/hookinstaller_test.go` and `opencode/hookinstaller_test.go` as permanent locks against a synthetic adapter identity: idempotent install, refuse-to-overwrite-a-foreign-file-on-install (naming the path in the error, per opencode's test), **the foreign-file-clobber-on-uninstall case opencode's PR committed** (`TestUninstall_RemovesOursAndLeavesForeignAlone`), uninstall-on-nothing-is-quiet, the parent directory surviving uninstall, Verify's three states (Missing/Stale/Intact), Verify never writing, and the Verify/Ensure agreement property pi's test pinned (extended with a fourth, foreign-file state pi's original never covered).
- `pi/hookinstaller_test.go` and `opencode/hookinstaller_test.go` are **completely unmodified** and still pass — they now exercise the shared package transitively through the real production wiring.
- **Red-first proof** (not committed as broken code — reverted after verifying, per the mutate-and-confirm-red pattern): temporarily removed the `IsOurs` guard from `Uninstall` → `hookartifact`'s own new lock, pi's `TestUninstall_RemovesOursAndLeavesForeignAlone`, and opencode's `TestUninstallHooks_LeavesAForeignFileAlone` all failed for the right reason (foreign file deleted). Separately, temporarily removed the foreign-file refusal branch from `EnsureInstalledWithCommand` → the refuse-to-overwrite tests in all three packages (including the new Verify/Ensure agreement property's `foreign_file` subtest) failed for the right reason (foreign file silently overwritten). Both reverted; final diff is clean. Re-verified against the final code shape after the hookbeacon-removal redesign.
- `TestEveryModifyPermissionDeclaresEveryFileItsApplyWrites` and `TestExternalInstallerPackagesDeclareEveryPathResolver` (the two registry tests the issue names) pass unmodified — both grade at the `agent.Permission` level and are indifferent to which Go package implements `Apply`/`Path`.
- `tools/onboarding-factory/internal/righome`'s beacon scan (`TestEveryBeaconAdapterDriverPassesTheDaemonAddress`/`TestBeaconAdaptersFindsTheRealOnes`) passes without any special-casing, since `hookartifact` no longer imports `hookbeacon` in production code at all.

### Review process
- A dedicated review subagent (medium effort) found and I fixed: a confirmed test-coverage gap (the Verify/Ensure agreement property claimed to be carried forward but wasn't), and a dead `isOurs` wrapper in opencode.
- Four parallel `/simplify` passes (reuse, simplification, efficiency, altitude) found and I fixed: a redundant private/exported `isOurs`/`IsOurs` split inside `hookartifact` itself, and — the substantive one — the altitude pass's finding that placing `hookartifact` under `core/pkg` to dodge the righome scanner was a workaround rather than a fix; removing the `hookbeacon` dependency (as described above) was the deeper correction.

### Verification run
- `go test ./core/adapters/inbound/agents/hookartifact/... ./core/adapters/inbound/agents/pi/... ./core/adapters/inbound/agents/opencode/... -race -count=1` — PASS
- `go test ./tools/onboarding-factory/internal/righome/... -race -count=1` — PASS (beacon scan)
- `go test ./core/cmd/irrlichd/... -race -count=1 -run 'TestEveryModifyPermissionDeclaresEveryFileItsApplyWrites|TestExternalInstallerPackagesDeclareEveryPathResolver'` — PASS
- `go test ./core/ -run TestArchitectureLayerImportDirection` — PASS
- `tools/preflight.sh --only go` — PASS (gofmt, core module tests, onboarding-factory tests, replaydata validate, recording-rig smoke test, replay fixtures)
- `tools/preflight.sh --only arch` — PASS (ARS composite 7.897 → 7.901, no regression — a slight improvement)
- `tools/preflight.sh --only tools` — PASS
- `tools/preflight.sh --only security` — PASS

Closes #1764.

🤖 Generated with [Claude Code](https://claude.com/claude-code)