### PR TITLE
fix(states): tolerate an unknown session state instead of deleting it or painting it green

### DIFF
--- a/core/adapters/outbound/filesystem/repository.go
+++ b/core/adapters/outbound/filesystem/repository.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"irrlicht/core/domain/session"
+	"irrlicht/core/ports/outbound"
 )
 
 const appSupportDir = "Library/Application Support/Irrlicht"
@@ -23,7 +24,21 @@ type SessionRepository struct {
 	// into a log flood (see warnUnknownStateOnce). A sync.Map because ListAll is
 	// reachable from more than one goroutine through CachedRepository.
 	warnedStates sync.Map
+	// logger, when set, receives the unrecognised-state warning. It has to be
+	// the Logger PORT and not stdlib `log`, because in the shipped product the
+	// macOS app spawns irrlichd with both stdout and stderr pointed at
+	// FileHandle.nullDevice (DaemonManager.spawnDaemon) — a `log.Printf` there
+	// reaches nobody, and this warning is the ONLY signal that a session
+	// silently vanished from the list. Set once at startup via SetLogger; nil
+	// for the CLI paths (--diagnose, irrlicht-ls), which keep the stderr
+	// fallback because their stderr is a terminal.
+	logger outbound.Logger
 }
+
+// SetLogger attaches the daemon's structured logger. Safe to leave unset —
+// warnUnknownStateOnce falls back to stderr. Call it before the repository is
+// shared with other goroutines (startup wiring does).
+func (r *SessionRepository) SetLogger(l outbound.Logger) { r.logger = l }
 
 // New returns a SessionRepository rooted at the user's Application Support directory.
 func New() (*SessionRepository, error) {
@@ -138,8 +153,19 @@ func (r *SessionRepository) ListAll() ([]*session.SessionState, error) {
 			// not an option — grouping, the state counters and the state
 			// machine are all written against exactly working/waiting/ready,
 			// so an unknown value would surface as a mis-rendered session
-			// rather than an absent one. Skipping loses only visibility, and
-			// the file is still on disk for the build that does understand it.
+			// rather than an absent one.
+			//
+			// Two consequences of skipping, stated rather than implied:
+			//   - PruneStale iterates ListAll, so these files are exempt from
+			//     MaxSessionAge and accumulate until a build that understands
+			//     the state reaps them. Deliberate: unbounded-but-intact beats
+			//     the data loss this block exists to stop, and age-based
+			//     reaping of states we cannot read is its own decision.
+			//   - Load() does NOT filter by state, so a session this daemon
+			//     still receives events for is loaded normally and the next
+			//     Save() rewrites the state to a canonical one. "Kept for the
+			//     build that understands it" therefore holds for sessions this
+			//     daemon never sees again — not for live ones.
 			r.warnUnknownStateOnce(state.State, name)
 			continue
 		}
@@ -158,9 +184,14 @@ func (r *SessionRepository) warnUnknownStateOnce(state, name string) {
 	if _, seen := r.warnedStates.LoadOrStore(state, struct{}{}); seen {
 		return
 	}
-	log.Printf("filesystem repository: session file %q has unrecognized state %q "+
-		"(this build knows only %s/%s/%s) — keeping the file on disk and skipping the session",
+	msg := fmt.Sprintf("session file %q has unrecognized state %q (this build knows only %s/%s/%s) "+
+		"— keeping the file on disk and skipping the session",
 		name, state, session.StateWorking, session.StateWaiting, session.StateReady)
+	if r.logger != nil {
+		r.logger.LogError("session_state_unrecognized", "", msg)
+		return
+	}
+	log.Printf("filesystem repository: %s", msg)
 }
 
 // PruneStale deletes session files older than maxAge and returns the count.

--- a/core/adapters/outbound/filesystem/repository.go
+++ b/core/adapters/outbound/filesystem/repository.go
@@ -35,9 +35,15 @@ type SessionRepository struct {
 	logger outbound.Logger
 }
 
-// SetLogger attaches the daemon's structured logger. Safe to leave unset —
-// warnUnknownStateOnce falls back to stderr. Call it before the repository is
-// shared with other goroutines (startup wiring does).
+// SetLogger attaches the daemon's structured logger; see the logger field for
+// why the port and not stderr. Safe to leave unset — warnUnknownStateOnce falls
+// back to stderr.
+//
+// A plain field rather than a mutex/atomic, unlike its warnedStates neighbour,
+// because the write is ordered by construction rather than by a lock:
+// initSessionStorage (core/cmd/irrlichd/startup.go) is the only caller and runs
+// it before NewCachedSessionRepository hands the repository to any other
+// goroutine, so the write happens-before every read. Call it there, not later.
 func (r *SessionRepository) SetLogger(l outbound.Logger) { r.logger = l }
 
 // New returns a SessionRepository rooted at the user's Application Support directory.
@@ -158,9 +164,14 @@ func (r *SessionRepository) ListAll() ([]*session.SessionState, error) {
 			// Two consequences of skipping, stated rather than implied:
 			//   - PruneStale iterates ListAll, so these files are exempt from
 			//     MaxSessionAge and accumulate until a build that understands
-			//     the state reaps them. Deliberate: unbounded-but-intact beats
-			//     the data loss this block exists to stop, and age-based
-			//     reaping of states we cannot read is its own decision.
+			//     the state reaps them. The cost is recurring work, not just
+			//     disk: each stuck file is re-read and re-unmarshalled on every
+			//     sweep forever (~1/s under session activity, behind the 3s
+			//     cache), for a session discarded three lines later. Deliberate:
+			//     unbounded-but-intact beats the data loss this block exists to
+			//     stop, and age-based reaping of states we cannot read is its
+			//     own decision. Bounded in practice by how many sessions the
+			//     newer build created.
 			//   - Load() does NOT filter by state, so a session this daemon
 			//     still receives events for is loaded normally and the next
 			//     Save() rewrites the state to a canonical one. "Kept for the

--- a/core/adapters/outbound/filesystem/repository.go
+++ b/core/adapters/outbound/filesystem/repository.go
@@ -3,9 +3,11 @@ package filesystem
 import (
 	"encoding/json"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"irrlicht/core/domain/session"
@@ -16,6 +18,11 @@ const appSupportDir = "Library/Application Support/Irrlicht"
 // SessionRepository implements ports/outbound.SessionRepository using the local filesystem.
 type SessionRepository struct {
 	instancesDir string
+	// warnedStates records which unrecognised state values ListAll has already
+	// logged, so a forward-compatible skip does not turn the daemon's poll loop
+	// into a log flood (see warnUnknownStateOnce). A sync.Map because ListAll is
+	// reachable from more than one goroutine through CachedRepository.
+	warnedStates sync.Map
 }
 
 // New returns a SessionRepository rooted at the user's Application Support directory.
@@ -118,18 +125,42 @@ func (r *SessionRepository) ListAll() ([]*session.SessionState, error) {
 		if err := json.Unmarshal(data, &state); err != nil {
 			continue
 		}
-		validStates := map[string]bool{
-			session.StateWorking: true,
-			session.StateWaiting: true,
-			session.StateReady:   true,
-		}
-		if !validStates[state.State] {
-			os.Remove(filepath.Join(r.instancesDir, name))
+		if !session.IsCanonicalState(state.State) {
+			// #1797: an unrecognised state is a value THIS build does not
+			// understand — a session written by a newer daemon, read after a
+			// downgrade or in a mixed-version install. It is not junk, and it
+			// is never a licence to delete the user's data: this used to
+			// os.Remove the file, which destroyed every such session
+			// irrecoverably on the first sweep.
+			//
+			// What a three-state build does with it, decided here: keep the
+			// file untouched and skip the session. Handing it downstream is
+			// not an option — grouping, the state counters and the state
+			// machine are all written against exactly working/waiting/ready,
+			// so an unknown value would surface as a mis-rendered session
+			// rather than an absent one. Skipping loses only visibility, and
+			// the file is still on disk for the build that does understand it.
+			r.warnUnknownStateOnce(state.State, name)
 			continue
 		}
 		states = append(states, &state)
 	}
 	return states, nil
+}
+
+// warnUnknownStateOnce logs an unrecognised session state the first time this
+// repository sees that value, and stays quiet for every later sighting.
+// ListAll runs on the daemon's poll loop, so logging per occurrence would emit
+// the same line every few seconds for as long as the file exists — which
+// buries the one sighting that carries information (a session state this build
+// has never heard of) under thousands of duplicates.
+func (r *SessionRepository) warnUnknownStateOnce(state, name string) {
+	if _, seen := r.warnedStates.LoadOrStore(state, struct{}{}); seen {
+		return
+	}
+	log.Printf("filesystem repository: session file %q has unrecognized state %q "+
+		"(this build knows only %s/%s/%s) — keeping the file on disk and skipping the session",
+		name, state, session.StateWorking, session.StateWaiting, session.StateReady)
 }
 
 // PruneStale deletes session files older than maxAge and returns the count.

--- a/core/adapters/outbound/filesystem/repository_test.go
+++ b/core/adapters/outbound/filesystem/repository_test.go
@@ -3,6 +3,8 @@ package filesystem_test
 import (
 	"os"
 	"path/filepath"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -246,6 +248,92 @@ func TestRepository_ListAll_KeepsUnknownState(t *testing.T) {
 	}
 	if len(states) != 1 {
 		t.Errorf("ListAll: got %d states, want 1 (the known session)", len(states))
+	}
+}
+
+// recordingLogger captures the Logger port calls the repository makes.
+type recordingLogger struct {
+	mu       sync.Mutex
+	errors   []string
+	eventIDs []string
+}
+
+func (l *recordingLogger) LogInfo(eventType, sessionID, message string) {}
+func (l *recordingLogger) LogError(eventType, sessionID, errorMsg string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.eventIDs = append(l.eventIDs, eventType)
+	l.errors = append(l.errors, errorMsg)
+}
+func (l *recordingLogger) LogProcessingTime(eventType, sessionID string, processingTimeMs int64, payloadSize int, result string) {
+}
+func (l *recordingLogger) Close() error { return nil }
+
+func (l *recordingLogger) snapshot() ([]string, []string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return append([]string(nil), l.eventIDs...), append([]string(nil), l.errors...)
+}
+
+// TestRepository_ListAll_WarnsOncePerUnknownState covers the reporting half of
+// #1797. Skipping a session SILENTLY is its own defect: the session vanishes
+// from the user's list with no artifact anywhere saying why. Two things are
+// asserted, and both matter:
+//
+//   - the warning goes through the Logger PORT, not stdlib log. In the shipped
+//     product the macOS app spawns irrlichd with stdout and stderr on
+//     FileHandle.nullDevice, so a `log.Printf` here reaches nobody.
+//   - it fires ONCE PER DISTINCT VALUE, not once per sighting. ListAll runs on
+//     the poll loop, so per-occurrence logging would repeat the same line every
+//     few seconds for as long as the file exists.
+//
+// Mutation check (this mechanism is added by #1797, so it has no pre-fix state
+// to run red against): drop the `LoadOrStore` early-return and the
+// second-ListAll assertion goes red; drop the `r.logger != nil` branch and the
+// first one does.
+func TestRepository_ListAll_WarnsOncePerUnknownState(t *testing.T) {
+	dir := t.TempDir()
+	repo := filesystem.NewWithDir(dir)
+	logger := &recordingLogger{}
+	repo.SetLogger(logger)
+
+	for name, state := range map[string]string{
+		"a.json": "zzz-unknown",
+		"b.json": "zzz-unknown", // same value, second file
+		"c.json": "yyy-other",   // a different unrecognized value
+	} {
+		payload := []byte(`{"session_id":"` + name + `","state":"` + state + `","updated_at":2}`)
+		if err := os.WriteFile(filepath.Join(dir, name), payload, 0o600); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+
+	if _, err := repo.ListAll(); err != nil {
+		t.Fatalf("ListAll: %v", err)
+	}
+
+	events, msgs := logger.snapshot()
+	if len(msgs) != 2 {
+		t.Fatalf("first ListAll: got %d warnings, want 2 (one per DISTINCT unknown value): %q", len(msgs), msgs)
+	}
+	for _, ev := range events {
+		if ev != "session_state_unrecognized" {
+			t.Errorf("event type: got %q, want session_state_unrecognized", ev)
+		}
+	}
+	joined := strings.Join(msgs, "\n")
+	for _, want := range []string{"zzz-unknown", "yyy-other"} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("warning text does not name the unrecognized value %q: %q", want, joined)
+		}
+	}
+
+	// The poll loop calls ListAll again and again; the warning must not repeat.
+	if _, err := repo.ListAll(); err != nil {
+		t.Fatalf("second ListAll: %v", err)
+	}
+	if _, after := logger.snapshot(); len(after) != 2 {
+		t.Errorf("second ListAll: got %d warnings total, want still 2 (once per value, not per sighting)", len(after))
 	}
 }
 

--- a/core/adapters/outbound/filesystem/repository_test.go
+++ b/core/adapters/outbound/filesystem/repository_test.go
@@ -3,13 +3,14 @@ package filesystem_test
 import (
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
-	"sync"
 	"testing"
 	"time"
 
 	"irrlicht/core/adapters/outbound/filesystem"
 	"irrlicht/core/domain/session"
+	"irrlicht/core/internal/contracttesting"
 )
 
 func TestRepository_SaveAndLoad(t *testing.T) {
@@ -241,38 +242,13 @@ func TestRepository_ListAll_KeepsUnknownState(t *testing.T) {
 	}
 
 	// The lock: it must not reach a three-state consumer.
+	ids := make([]string, 0, len(states))
 	for _, s := range states {
-		if s.SessionID == "unknown" {
-			t.Errorf("ListAll returned the unknown-state session %q; want it skipped", s.State)
-		}
+		ids = append(ids, s.SessionID)
 	}
-	if len(states) != 1 {
-		t.Errorf("ListAll: got %d states, want 1 (the known session)", len(states))
+	if !slices.Equal(ids, []string{"known"}) {
+		t.Errorf("ListAll returned %v; want only the known session (the unknown-state one must be skipped)", ids)
 	}
-}
-
-// recordingLogger captures the Logger port calls the repository makes.
-type recordingLogger struct {
-	mu       sync.Mutex
-	errors   []string
-	eventIDs []string
-}
-
-func (l *recordingLogger) LogInfo(eventType, sessionID, message string) {}
-func (l *recordingLogger) LogError(eventType, sessionID, errorMsg string) {
-	l.mu.Lock()
-	defer l.mu.Unlock()
-	l.eventIDs = append(l.eventIDs, eventType)
-	l.errors = append(l.errors, errorMsg)
-}
-func (l *recordingLogger) LogProcessingTime(eventType, sessionID string, processingTimeMs int64, payloadSize int, result string) {
-}
-func (l *recordingLogger) Close() error { return nil }
-
-func (l *recordingLogger) snapshot() ([]string, []string) {
-	l.mu.Lock()
-	defer l.mu.Unlock()
-	return append([]string(nil), l.eventIDs...), append([]string(nil), l.errors...)
 }
 
 // TestRepository_ListAll_WarnsOncePerUnknownState covers the reporting half of
@@ -280,9 +256,8 @@ func (l *recordingLogger) snapshot() ([]string, []string) {
 // from the user's list with no artifact anywhere saying why. Two things are
 // asserted, and both matter:
 //
-//   - the warning goes through the Logger PORT, not stdlib log. In the shipped
-//     product the macOS app spawns irrlichd with stdout and stderr on
-//     FileHandle.nullDevice, so a `log.Printf` here reaches nobody.
+//   - the warning goes through the Logger PORT, not stdlib log — see
+//     SessionRepository.logger for why stderr reaches nobody in the shipped app.
 //   - it fires ONCE PER DISTINCT VALUE, not once per sighting. ListAll runs on
 //     the poll loop, so per-occurrence logging would repeat the same line every
 //     few seconds for as long as the file exists.
@@ -294,17 +269,19 @@ func (l *recordingLogger) snapshot() ([]string, []string) {
 func TestRepository_ListAll_WarnsOncePerUnknownState(t *testing.T) {
 	dir := t.TempDir()
 	repo := filesystem.NewWithDir(dir)
-	logger := &recordingLogger{}
+	logger := &contracttesting.RecordingLogger{}
 	repo.SetLogger(logger)
 
-	for name, state := range map[string]string{
-		"a.json": "zzz-unknown",
-		"b.json": "zzz-unknown", // same value, second file
-		"c.json": "yyy-other",   // a different unrecognized value
+	// A fixed slice, not a map: map iteration order is randomized, and nothing
+	// here wants that.
+	for _, f := range []struct{ name, state string }{
+		{"a.json", "zzz-unknown"},
+		{"b.json", "zzz-unknown"}, // same value, second file
+		{"c.json", "yyy-other"},   // a different unrecognized value
 	} {
-		payload := []byte(`{"session_id":"` + name + `","state":"` + state + `","updated_at":2}`)
-		if err := os.WriteFile(filepath.Join(dir, name), payload, 0o600); err != nil {
-			t.Fatalf("write %s: %v", name, err)
+		payload := []byte(`{"session_id":"` + f.name + `","state":"` + f.state + `","updated_at":2}`)
+		if err := os.WriteFile(filepath.Join(dir, f.name), payload, 0o600); err != nil {
+			t.Fatalf("write %s: %v", f.name, err)
 		}
 	}
 
@@ -312,11 +289,11 @@ func TestRepository_ListAll_WarnsOncePerUnknownState(t *testing.T) {
 		t.Fatalf("ListAll: %v", err)
 	}
 
-	events, msgs := logger.snapshot()
+	msgs := logger.Errors()
 	if len(msgs) != 2 {
 		t.Fatalf("first ListAll: got %d warnings, want 2 (one per DISTINCT unknown value): %q", len(msgs), msgs)
 	}
-	for _, ev := range events {
+	for _, ev := range logger.EventTypes() {
 		if ev != "session_state_unrecognized" {
 			t.Errorf("event type: got %q, want session_state_unrecognized", ev)
 		}
@@ -332,7 +309,7 @@ func TestRepository_ListAll_WarnsOncePerUnknownState(t *testing.T) {
 	if _, err := repo.ListAll(); err != nil {
 		t.Fatalf("second ListAll: %v", err)
 	}
-	if _, after := logger.snapshot(); len(after) != 2 {
+	if after := logger.Errors(); len(after) != 2 {
 		t.Errorf("second ListAll: got %d warnings total, want still 2 (once per value, not per sighting)", len(after))
 	}
 }

--- a/core/adapters/outbound/filesystem/repository_test.go
+++ b/core/adapters/outbound/filesystem/repository_test.go
@@ -272,18 +272,11 @@ func TestRepository_ListAll_WarnsOncePerUnknownState(t *testing.T) {
 	logger := &contracttesting.RecordingLogger{}
 	repo.SetLogger(logger)
 
-	// A fixed slice, not a map: map iteration order is randomized, and nothing
-	// here wants that.
-	for _, f := range []struct{ name, state string }{
-		{"a.json", "zzz-unknown"},
-		{"b.json", "zzz-unknown"}, // same value, second file
-		{"c.json", "yyy-other"},   // a different unrecognized value
-	} {
-		payload := []byte(`{"session_id":"` + f.name + `","state":"` + f.state + `","updated_at":2}`)
-		if err := os.WriteFile(filepath.Join(dir, f.name), payload, 0o600); err != nil {
-			t.Fatalf("write %s: %v", f.name, err)
-		}
-	}
+	// ListAll walks os.ReadDir, which sorts by filename, so the warnings arrive
+	// a.json-then-c.json. b.json repeats a.json's value and must be deduped away.
+	writeRawStateFile(t, dir, "a.json", "zzz-unknown")
+	writeRawStateFile(t, dir, "b.json", "zzz-unknown") // same value, second file
+	writeRawStateFile(t, dir, "c.json", "yyy-other")   // a different unrecognized value
 
 	if _, err := repo.ListAll(); err != nil {
 		t.Fatalf("ListAll: %v", err)
@@ -293,16 +286,12 @@ func TestRepository_ListAll_WarnsOncePerUnknownState(t *testing.T) {
 	if len(msgs) != 2 {
 		t.Fatalf("first ListAll: got %d warnings, want 2 (one per DISTINCT unknown value): %q", len(msgs), msgs)
 	}
-	for _, ev := range logger.EventTypes() {
-		if ev != "session_state_unrecognized" {
-			t.Errorf("event type: got %q, want session_state_unrecognized", ev)
-		}
+	if !strings.Contains(msgs[0], "zzz-unknown") || !strings.Contains(msgs[1], "yyy-other") {
+		t.Errorf("warnings do not name their unrecognized values, in ReadDir order: %q", msgs)
 	}
-	joined := strings.Join(msgs, "\n")
-	for _, want := range []string{"zzz-unknown", "yyy-other"} {
-		if !strings.Contains(joined, want) {
-			t.Errorf("warning text does not name the unrecognized value %q: %q", want, joined)
-		}
+	wantEvents := []string{"session_state_unrecognized", "session_state_unrecognized"}
+	if got := logger.EventTypes(); !slices.Equal(got, wantEvents) {
+		t.Errorf("event types: got %v, want %v", got, wantEvents)
 	}
 
 	// The poll loop calls ListAll again and again; the warning must not repeat.
@@ -311,6 +300,17 @@ func TestRepository_ListAll_WarnsOncePerUnknownState(t *testing.T) {
 	}
 	if after := logger.Errors(); len(after) != 2 {
 		t.Errorf("second ListAll: got %d warnings total, want still 2 (once per value, not per sighting)", len(after))
+	}
+}
+
+// writeRawStateFile drops a session file with a state value the repository's
+// own Save() would never produce — the point being to simulate a file written
+// by a DIFFERENT (newer) build.
+func writeRawStateFile(t *testing.T, dir, name, state string) {
+	t.Helper()
+	payload := []byte(`{"session_id":"` + name + `","state":"` + state + `","updated_at":2}`)
+	if err := os.WriteFile(filepath.Join(dir, name), payload, 0o600); err != nil {
+		t.Fatalf("write %s: %v", name, err)
 	}
 }
 

--- a/core/adapters/outbound/filesystem/repository_test.go
+++ b/core/adapters/outbound/filesystem/repository_test.go
@@ -195,6 +195,81 @@ func TestRepository_ListAll_SkipsNonJSON(t *testing.T) {
 	}
 }
 
+// TestRepository_ListAll_KeepsUnknownState covers #1797. ListAll used to
+// os.Remove any session file whose state fell outside a hardcoded three-entry
+// allowlist, so a daemon that predates a newly-introduced state DESTROYS every
+// session file carrying it — irrecoverably, on the first sweep after a
+// downgrade or a mixed-version install. Forward compatibility is the point:
+// an unrecognised state is a value this build does not understand yet, never a
+// licence to delete the user's data.
+//
+// The surviving-file assertion is the defect test (seen red on the
+// pre-#1797 tree, where the file is gone by the time ListAll returns). The
+// "not in the returned slice" assertion is a LOCK, not red-first evidence: a
+// three-state build already skipped the state and must keep skipping it, since
+// every downstream consumer (grouping, counts, the state machine) is written
+// against exactly three values.
+func TestRepository_ListAll_KeepsUnknownState(t *testing.T) {
+	dir := t.TempDir()
+	repo := filesystem.NewWithDir(dir)
+
+	known := &session.SessionState{SessionID: "known", State: session.StateWorking, UpdatedAt: time.Now().Unix()}
+	if err := repo.Save(known); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	unknownPath := filepath.Join(dir, "unknown.json")
+	payload := []byte(`{"version":1,"session_id":"unknown","state":"zzz-unknown","first_seen":1,"updated_at":2}`)
+	if err := os.WriteFile(unknownPath, payload, 0o600); err != nil {
+		t.Fatalf("write unknown-state file: %v", err)
+	}
+
+	states, err := repo.ListAll()
+	if err != nil {
+		t.Fatalf("ListAll: %v", err)
+	}
+
+	// The defect: the file must survive the sweep, byte for byte.
+	got, err := os.ReadFile(unknownPath)
+	if err != nil {
+		t.Fatalf("unknown-state file was deleted by ListAll: %v", err)
+	}
+	if string(got) != string(payload) {
+		t.Errorf("unknown-state file was rewritten: got %q, want %q", got, payload)
+	}
+
+	// The lock: it must not reach a three-state consumer.
+	for _, s := range states {
+		if s.SessionID == "unknown" {
+			t.Errorf("ListAll returned the unknown-state session %q; want it skipped", s.State)
+		}
+	}
+	if len(states) != 1 {
+		t.Errorf("ListAll: got %d states, want 1 (the known session)", len(states))
+	}
+}
+
+// TestRepository_ListAll_KeepsUnparseableFile pins the other half of #1797's
+// data-safety property: a file this build cannot decode at all is skipped, not
+// deleted. ListAll's `continue` on a json.Unmarshal error already behaved this
+// way, so this is a LOCK, not a defect test — it exists so a future "tidy up
+// junk on load" change has to break a named test rather than a code comment.
+func TestRepository_ListAll_KeepsUnparseableFile(t *testing.T) {
+	dir := t.TempDir()
+	repo := filesystem.NewWithDir(dir)
+
+	badPath := filepath.Join(dir, "bad.json")
+	if err := os.WriteFile(badPath, []byte("not{json"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if _, err := repo.ListAll(); err != nil {
+		t.Fatalf("ListAll: %v", err)
+	}
+	if _, err := os.Stat(badPath); err != nil {
+		t.Errorf("unparseable file was deleted by ListAll: %v", err)
+	}
+}
+
 func TestRepository_FilePermissions(t *testing.T) {
 	dir := filepath.Join(t.TempDir(), "instances")
 	repo := filesystem.NewWithDir(dir)

--- a/core/cmd/irrlichd/startup.go
+++ b/core/cmd/irrlichd/startup.go
@@ -62,10 +62,9 @@ func initSessionStorage(logger outbound.Logger, cfg config.Config) (*filesystem.
 		os.Exit(1)
 	}
 
-	// Route the unrecognized-state warning (#1797) into the structured log
-	// before the first ListAll. The app spawns irrlichd with stdout/stderr on
-	// nullDevice, so the stderr fallback inside the repository would otherwise
-	// discard the only signal that a session was skipped.
+	// #1797: the port logger, not the stderr fallback — see
+	// SessionRepository.logger for why. Must precede the first ListAll (the
+	// PruneStale below) and any sharing of fsRepo across goroutines.
 	fsRepo.SetLogger(logger)
 
 	pruned, err := fsRepo.PruneStale(cfg.MaxSessionAge)

--- a/core/cmd/irrlichd/startup.go
+++ b/core/cmd/irrlichd/startup.go
@@ -62,6 +62,12 @@ func initSessionStorage(logger outbound.Logger, cfg config.Config) (*filesystem.
 		os.Exit(1)
 	}
 
+	// Route the unrecognized-state warning (#1797) into the structured log
+	// before the first ListAll. The app spawns irrlichd with stdout/stderr on
+	// nullDevice, so the stderr fallback inside the repository would otherwise
+	// discard the only signal that a session was skipped.
+	fsRepo.SetLogger(logger)
+
 	pruned, err := fsRepo.PruneStale(cfg.MaxSessionAge)
 	if err != nil {
 		logger.LogError("startup", "", fmt.Sprintf("failed to prune stale sessions: %v", err))

--- a/core/internal/contracttesting/hook_receiver_gate.go
+++ b/core/internal/contracttesting/hook_receiver_gate.go
@@ -258,15 +258,17 @@ func declaredPermissionsMismatch(t reporter, h hookjson.HookHandler, want ...str
 // three packages had grown the same ten lines, and "what a refusal may log" is
 // a decision about the contract rather than about an adapter.
 type RecordingLogger struct {
-	mu     sync.Mutex
-	errors []string
+	mu         sync.Mutex
+	errors     []string
+	eventTypes []string
 }
 
 // LogError records. The other methods are deliberately inert: only the error
 // channel carries the obligation above.
-func (l *RecordingLogger) LogError(_, _, msg string) {
+func (l *RecordingLogger) LogError(eventType, _, msg string) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
+	l.eventTypes = append(l.eventTypes, eventType)
 	l.errors = append(l.errors, msg)
 }
 
@@ -281,4 +283,15 @@ func (l *RecordingLogger) Errors() []string {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	return slices.Clone(l.errors)
+}
+
+// EventTypes returns the event-type tag of each recorded ERROR, newest last and
+// index-aligned with Errors(). Callers that only care about the message can
+// ignore it; a caller asserting WHICH channel a line was filed under (#1797's
+// unrecognized-state warning is one) needs the tag, and hand-rolling a private
+// double just to see it is what this type exists to stop.
+func (l *RecordingLogger) EventTypes() []string {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return slices.Clone(l.eventTypes)
 }

--- a/platforms/macos/Irrlicht/Models/SessionState.swift
+++ b/platforms/macos/Irrlicht/Models/SessionState.swift
@@ -945,6 +945,12 @@ struct SessionState: Identifiable, Codable {
     /// recognize (#1797), e.g. one written by a newer daemon during a staged
     /// upgrade. Every rendering below therefore has to answer for it, and the
     /// answer is always neutral: grey, a question mark, never green.
+    ///
+    /// ⚠️ `.unknown` must never be WRITTEN BACK to the daemon. It is `Codable`
+    /// only because the enclosing type is, and nothing encodes a SessionState
+    /// today; if something ever does, `"state":"unknown"` is a value the daemon
+    /// does not recognize and would skip on its next load — silently removing
+    /// the session. Encode the original state, or refuse.
     enum State: String, CaseIterable, Codable {
         case working, waiting, ready, unknown
 
@@ -973,6 +979,20 @@ struct SessionState: Identifiable, Codable {
             case .waiting: return IrrSVG.waiting
             case .ready:   return IrrSVG.ready
             case .unknown: return IrrSVG.unknown
+            }
+        }
+
+        /// Ordering key for summaries that lay the states out in a fixed
+        /// sequence (the menu bar's pie dot). A `switch` on purpose: it is the
+        /// mechanism that stops a future 5th state from being silently left out
+        /// of a hand-written array, which is exactly how `.unknown` came to be
+        /// omitted from `segmentOrder` and fall through to green (#1797).
+        var menuBarRank: Int {
+            switch self {
+            case .waiting: return 0
+            case .working: return 1
+            case .ready:   return 2
+            case .unknown: return 3   // last: outranked by anything we can read
             }
         }
 

--- a/platforms/macos/Irrlicht/Models/SessionState.swift
+++ b/platforms/macos/Irrlicht/Models/SessionState.swift
@@ -825,12 +825,20 @@ struct SessionState: Identifiable, Codable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         
         id = try container.decode(String.self, forKey: .id)
-        // Handle backwards compatibility: "finished" -> "ready"
+        // Handle backwards compatibility: "finished" -> "ready". This branch is
+        // a deliberate RENAME shim (the daemon's old spelling of `ready`), not
+        // an unknown state — #1797 leaves it exactly as it was.
         let stateString = try container.decode(String.self, forKey: .state)
         if stateString == "finished" {
             state = .ready
         } else {
-            state = State(rawValue: stateString) ?? .ready
+            // #1797: anything this build does not recognize becomes `.unknown`,
+            // NEVER `.ready`. The old `?? .ready` painted a state we cannot
+            // interpret green — the single worst wrong answer, because green
+            // asserts "this session finished cleanly" at exactly the moment the
+            // app has no idea what the daemon is reporting. `.unknown` renders
+            // neutral grey and says so.
+            state = State(rawValue: stateString) ?? .unknown
         }
         model = try container.decodeIfPresent(String.self, forKey: .model) ?? "unknown"
         cwd = try container.decodeIfPresent(String.self, forKey: .cwd) ?? ""
@@ -930,14 +938,22 @@ struct SessionState: Identifiable, Codable {
         self.yieldState = yieldState
     }
 
+    /// The daemon's three-state lifecycle, plus a fourth case this app owns.
+    ///
+    /// `unknown` is NOT a daemon state and never comes off the wire as itself
+    /// — it is where `init(from:)` puts a state string this build does not
+    /// recognize (#1797), e.g. one written by a newer daemon during a staged
+    /// upgrade. Every rendering below therefore has to answer for it, and the
+    /// answer is always neutral: grey, a question mark, never green.
     enum State: String, CaseIterable, Codable {
-        case working, waiting, ready
+        case working, waiting, ready, unknown
 
         var glyph: String {
             switch self {
             case .working: return "hammer.fill"
             case .waiting: return "hourglass"
             case .ready: return "checkmark.circle.fill"
+            case .unknown: return "questionmark.circle"
             }
         }
 
@@ -946,6 +962,7 @@ struct SessionState: Identifiable, Codable {
             case .working: return IrrColors.working
             case .waiting: return IrrColors.waiting
             case .ready:   return IrrColors.ready
+            case .unknown: return IrrColors.unknown
             }
         }
 
@@ -955,14 +972,22 @@ struct SessionState: Identifiable, Codable {
             case .working: return IrrSVG.working
             case .waiting: return IrrSVG.waiting
             case .ready:   return IrrSVG.ready
+            case .unknown: return IrrSVG.unknown
             }
         }
 
         /// Highest-priority state in a collection (waiting > working > ready).
+        ///
+        /// `unknown` sits below all three: a group that contains even one
+        /// session in a state we can read is better summarized by that. It only
+        /// wins when there is nothing else to say — and then it must win, or a
+        /// group of nothing but unreadable sessions summarizes as green (#1797).
+        /// An EMPTY collection keeps its historical `.ready` answer.
         static func dominant<C: Collection>(in states: C) -> State where C.Element == State {
             if states.contains(.waiting) { return .waiting }
             if states.contains(.working) { return .working }
-            return .ready
+            if states.contains(.ready) { return .ready }
+            return states.isEmpty ? .ready : .unknown
         }
 
         var emoji: String {
@@ -970,6 +995,7 @@ struct SessionState: Identifiable, Codable {
             case .working: return "🟣"   // purple circle
             case .waiting: return "🟠"   // orange circle
             case .ready: return "🟢"  // green circle
+            case .unknown: return "⚪️"  // white circle — neutral, not a verdict
             }
         }
 
@@ -978,6 +1004,7 @@ struct SessionState: Identifiable, Codable {
             case .working: return "Working"
             case .waiting: return "Waiting for input"
             case .ready: return "Ready"
+            case .unknown: return "Unknown state"
             }
         }
     }

--- a/platforms/macos/Irrlicht/Theme/Tokens.swift
+++ b/platforms/macos/Irrlicht/Theme/Tokens.swift
@@ -11,6 +11,11 @@ enum IrrHex {
     static let waiting   = "#FF9500"
     static let ready     = "#34C759"
     static let cancelled = "#8E8E93"
+    // Unrecognized session state (#1797) — a state this build has never heard
+    // of, e.g. one written by a newer daemon. Same neutral grey as `cancelled`
+    // by value, kept as its own token because the two mean different things:
+    // `cancelled` is a state that was retired, `unknown` is one we can't read.
+    static let unknown   = "#8E8E93"
 
     // Pressure scale
     static let pressureLow      = "#34C759"
@@ -32,6 +37,7 @@ enum IrrSVG {
     static let waiting   = "FF9500"
     static let ready     = "34C759"
     static let cancelled = "8E8E93"
+    static let unknown   = "8E8E93"
 }
 
 enum IrrColors {
@@ -39,6 +45,7 @@ enum IrrColors {
     static let waiting   = Color(hex: IrrHex.waiting)
     static let ready     = Color(hex: IrrHex.ready)
     static let cancelled = Color(hex: IrrHex.cancelled)
+    static let unknown   = Color(hex: IrrHex.unknown)
 
     // 12%-alpha soft backgrounds (--working-dim / --waiting-dim / --ready-dim).
     static let workingDim = working.opacity(0.12)

--- a/platforms/macos/Irrlicht/Views/HistoryBarView.swift
+++ b/platforms/macos/Irrlicht/Views/HistoryBarView.swift
@@ -1,11 +1,5 @@
 import SwiftUI
 
-private let stateColors: [String: Color] = [
-    "working": IrrColors.working,
-    "waiting": IrrColors.waiting,
-    "ready":   IrrColors.ready,
-]
-
 /// A compact horizontal bar that visualises per-session state history.
 /// Each bucket is a fixed-width coloured rectangle: purple=working, orange=waiting, green=ready.
 /// Buckets are right-anchored: the newest state always lands in the rightmost
@@ -16,12 +10,32 @@ struct HistoryBarView: View {
 
     /// Bucket name → fill, or nil for "paint nothing here".
     ///
-    /// Extracted from `body` so the #1797 rule is assertable: a `Canvas`
-    /// closure is not reachable from a test, and this decision — which is the
-    /// entire defect — would otherwise be provable only by a rendered image.
+    /// Extracted from `body` so the #1797 rule is assertable at all: a `Canvas`
+    /// closure is not reachable from a test, and the alternative — an image
+    /// snapshot — is reference-host-only (docs/swift-testing.md), so this
+    /// decision would otherwise have had zero gating coverage.
+    ///
+    /// Derived from `SessionState.State` rather than a private lookup table, so
+    /// a bucket and the row's state icon cannot drift apart; the table this
+    /// replaced was a third independent copy of the state→color mapping.
+    ///
+    /// Two non-states reach here, and neither may paint green (#1797):
+    ///   - `""`, the no-data code (`historyPriorityToState` returns it for wire
+    ///     code 3). `trimLeadingNoData` strips only LEADING empties, so a gap
+    ///     anywhere else used to be painted READY GREEN, inventing a finished
+    ///     session out of missing data. The web twin has always skipped it
+    ///     (`irrlicht.js`: `if (!color) continue`), so the two platforms
+    ///     rendered the same ring differently. THIS is the reachable defect.
+    ///   - any other unrecognized name → neutral grey. DEFENSIVE ONLY: every
+    ///     string that can reach `states` comes from `historyPriorityToState`,
+    ///     a 4-way switch over a 2-bit code that returns only
+    ///     ready/working/waiting/"" — so a newer daemon's state arrives here as
+    ///     a priority CODE, not a name, and the encoding has no spare code for
+    ///     it. Widening that wire format is the epic's problem (#1807), not
+    ///     something this branch can fix.
     static func barColor(for state: String) -> Color? {
         if state.isEmpty { return nil }          // no-data slot
-        return stateColors[state] ?? IrrColors.unknown
+        return (SessionState.State(rawValue: state) ?? .unknown).color
     }
 
     var body: some View {
@@ -33,17 +47,8 @@ struct HistoryBarView: View {
             let visible = states.suffix(bucketCount)
             let offset = bucketCount - visible.count
             for (i, state) in visible.enumerated() {
-                // #1797. Two distinct non-states, and neither may paint green:
-                //   - "" is the no-data code (historyPriorityToState returns it
-                //     for wire code 3). trimLeadingNoData strips only LEADING
-                //     empties, so a mid-array one reaches here — and used to be
-                //     painted READY GREEN, inventing a finished session out of
-                //     a gap. Leave the slot unpainted, which is what the doc
-                //     comment on historyPriorityToState already claims happens
-                //     and what the web twin does (irrlicht.js: `if (!color)
-                //     continue`).
-                //   - any other unrecognized name is a state this build cannot
-                //     read: neutral grey, same as the row's state icon.
+                // #1797 — see barColor. A nil means "paint nothing", which also
+                // skips the CGRect/Path/fill entirely for gap buckets.
                 guard let color = Self.barColor(for: state) else { continue }
                 let rect = CGRect(
                     x: CGFloat(offset + i) * colW,

--- a/platforms/macos/Irrlicht/Views/HistoryBarView.swift
+++ b/platforms/macos/Irrlicht/Views/HistoryBarView.swift
@@ -14,6 +14,16 @@ struct HistoryBarView: View {
     let states: [String]     // oldest → newest
     var bucketCount: Int = 150
 
+    /// Bucket name → fill, or nil for "paint nothing here".
+    ///
+    /// Extracted from `body` so the #1797 rule is assertable: a `Canvas`
+    /// closure is not reachable from a test, and this decision — which is the
+    /// entire defect — would otherwise be provable only by a rendered image.
+    static func barColor(for state: String) -> Color? {
+        if state.isEmpty { return nil }          // no-data slot
+        return stateColors[state] ?? IrrColors.unknown
+    }
+
     var body: some View {
         Canvas { context, size in
             guard !states.isEmpty else { return }
@@ -23,7 +33,18 @@ struct HistoryBarView: View {
             let visible = states.suffix(bucketCount)
             let offset = bucketCount - visible.count
             for (i, state) in visible.enumerated() {
-                let color = stateColors[state] ?? stateColors["ready"]!
+                // #1797. Two distinct non-states, and neither may paint green:
+                //   - "" is the no-data code (historyPriorityToState returns it
+                //     for wire code 3). trimLeadingNoData strips only LEADING
+                //     empties, so a mid-array one reaches here — and used to be
+                //     painted READY GREEN, inventing a finished session out of
+                //     a gap. Leave the slot unpainted, which is what the doc
+                //     comment on historyPriorityToState already claims happens
+                //     and what the web twin does (irrlicht.js: `if (!color)
+                //     continue`).
+                //   - any other unrecognized name is a state this build cannot
+                //     read: neutral grey, same as the row's state icon.
+                guard let color = Self.barColor(for: state) else { continue }
                 let rect = CGRect(
                     x: CGFloat(offset + i) * colW,
                     y: 0,

--- a/platforms/macos/Irrlicht/Views/MenuBarStatusRenderer.swift
+++ b/platforms/macos/Irrlicht/Views/MenuBarStatusRenderer.swift
@@ -180,10 +180,15 @@ struct MenuBarStatusRenderer {
         let cy = height / 2
 
         guard segments.count > 1 else {
-            // The `??` fires only when there are no segments at all, which
-            // after #1797's segmentOrder covers every state means an empty
-            // session list. Grey, not green: with nothing to summarize, "all
-            // done" is a claim we have no basis for.
+            // Grey, not green: with nothing to summarize, "all done" is a
+            // claim we have no basis for.
+            //
+            // Note this `??` is currently UNREACHABLE and no test covers it:
+            // once segmentOrder spans every case, stateSegments returns []
+            // only for an empty session list, and renderGroup routes anything
+            // with <= 3 sessions to renderCompactGroup, so this path never
+            // sees fewer than 4. Kept as defensive depth, but do not count it
+            // as a guarded behavior.
             let hex = segments.first?.state.hexColor ?? SessionState.State.unknown.hexColor
             return """
             <circle cx="\(svgNumber(cx))" cy="\(svgNumber(cy))" r="\(svgNumber(radius))" fill="#\(hex)" stroke="rgba(0,0,0,0.25)" stroke-width="0.5"/>

--- a/platforms/macos/Irrlicht/Views/MenuBarStatusRenderer.swift
+++ b/platforms/macos/Irrlicht/Views/MenuBarStatusRenderer.swift
@@ -25,13 +25,21 @@ struct MenuBarStatusRenderer {
     private static let fontSize: CGFloat = 10
     private static let maxVisibleGroups = 5
     private static let overflowFillHex = IrrSVG.cancelled
-    /// Slice order for the per-group pie dot. `.unknown` is last but MUST be
-    /// present (#1797): the fractions are `count / sessions.count`, so a state
-    /// missing from this list is a session counted in the denominator with no
-    /// wedge of its own — the dot renders with a hole. Worse, a group of
-    /// nothing but unrecognized sessions produced NO segments at all and fell
-    /// through `aggregatedCircleElements`' single-segment path to a green dot.
-    private static let segmentOrder: [SessionState.State] = [.waiting, .working, .ready, .unknown]
+    /// Slice order for the per-group pie dot — DERIVED from `allCases`, never
+    /// hand-listed (#1797).
+    ///
+    /// The fractions are `count / sessions.count`, so a state missing from this
+    /// list is a session counted in the denominator with no wedge of its own
+    /// (the dot renders with a hole), and a group of nothing but the missing
+    /// state produced NO segments at all and fell through
+    /// `aggregatedCircleElements`' single-segment path to a green dot. That is
+    /// how `.unknown` broke it, and a literal array would let a 5th state break
+    /// it again in exactly the same way — an array is the one state reader the
+    /// Swift compiler cannot force to be exhaustive. Sorting `allCases` by
+    /// `menuBarRank`, which IS a compiler-forced switch, moves the requirement
+    /// somewhere it cannot be forgotten.
+    private static let segmentOrder: [SessionState.State] =
+        SessionState.State.allCases.sorted { $0.menuBarRank < $1.menuBarRank }
 
     static func buildStatusImage(
         sessions: [SessionState],
@@ -180,18 +188,17 @@ struct MenuBarStatusRenderer {
         let cy = height / 2
 
         guard segments.count > 1 else {
-            // Grey, not green: with nothing to summarize, "all done" is a
-            // claim we have no basis for.
-            //
-            // Note this `??` is currently UNREACHABLE and no test covers it:
-            // once segmentOrder spans every case, stateSegments returns []
-            // only for an empty session list, and renderGroup routes anything
-            // with <= 3 sessions to renderCompactGroup, so this path never
-            // sees fewer than 4. Kept as defensive depth, but do not count it
-            // as a guarded behavior.
-            let hex = segments.first?.state.hexColor ?? SessionState.State.unknown.hexColor
+            // One state covers the whole group: a solid dot in its own hue,
+            // no pie. `segments` cannot be empty here — segmentOrder spans
+            // every case, so it is empty only for an empty session list, and
+            // renderGroup sends anything with <= 3 sessions to
+            // renderCompactGroup. Returning "" rather than inventing a color
+            // for the impossible case: a `?? .ready` here was one of the ways
+            // an unreadable group used to paint green (#1797), and no fallback
+            // hue is better than a wrong one.
+            guard let only = segments.first else { return "" }
             return """
-            <circle cx="\(svgNumber(cx))" cy="\(svgNumber(cy))" r="\(svgNumber(radius))" fill="#\(hex)" stroke="rgba(0,0,0,0.25)" stroke-width="0.5"/>
+            <circle cx="\(svgNumber(cx))" cy="\(svgNumber(cy))" r="\(svgNumber(radius))" fill="#\(only.state.hexColor)" stroke="rgba(0,0,0,0.25)" stroke-width="0.5"/>
             """
         }
 

--- a/platforms/macos/Irrlicht/Views/MenuBarStatusRenderer.swift
+++ b/platforms/macos/Irrlicht/Views/MenuBarStatusRenderer.swift
@@ -25,7 +25,13 @@ struct MenuBarStatusRenderer {
     private static let fontSize: CGFloat = 10
     private static let maxVisibleGroups = 5
     private static let overflowFillHex = IrrSVG.cancelled
-    private static let segmentOrder: [SessionState.State] = [.waiting, .working, .ready]
+    /// Slice order for the per-group pie dot. `.unknown` is last but MUST be
+    /// present (#1797): the fractions are `count / sessions.count`, so a state
+    /// missing from this list is a session counted in the denominator with no
+    /// wedge of its own — the dot renders with a hole. Worse, a group of
+    /// nothing but unrecognized sessions produced NO segments at all and fell
+    /// through `aggregatedCircleElements`' single-segment path to a green dot.
+    private static let segmentOrder: [SessionState.State] = [.waiting, .working, .ready, .unknown]
 
     static func buildStatusImage(
         sessions: [SessionState],
@@ -174,7 +180,11 @@ struct MenuBarStatusRenderer {
         let cy = height / 2
 
         guard segments.count > 1 else {
-            let hex = segments.first?.state.hexColor ?? SessionState.State.ready.hexColor
+            // The `??` fires only when there are no segments at all, which
+            // after #1797's segmentOrder covers every state means an empty
+            // session list. Grey, not green: with nothing to summarize, "all
+            // done" is a claim we have no basis for.
+            let hex = segments.first?.state.hexColor ?? SessionState.State.unknown.hexColor
             return """
             <circle cx="\(svgNumber(cx))" cy="\(svgNumber(cy))" r="\(svgNumber(radius))" fill="#\(hex)" stroke="rgba(0,0,0,0.25)" stroke-width="0.5"/>
             """

--- a/platforms/macos/Irrlicht/Views/SessionStateIcon.swift
+++ b/platforms/macos/Irrlicht/Views/SessionStateIcon.swift
@@ -7,8 +7,10 @@ import SwiftUI
 ///            between 0.55 and 1.0 over 1.4 s.
 /// - waiting: two-bar pause.
 /// - ready:   SF Symbol `checkmark.circle.fill` (unchanged from before).
+/// - unknown: SF Symbol `questionmark.circle` in neutral grey — a state this
+///            build does not recognize (#1797), never painted green.
 ///
-/// All three states occupy the same fixed `size × size` layout box
+/// All four states occupy the same fixed `size × size` layout box
 /// (issue #596): the session row is a leading HStack, so a state whose
 /// icon measured wider — the ready SF Symbol's font-derived box is 14 pt
 /// at size 12 — shifted the agent number, title, and context bar of that
@@ -34,6 +36,14 @@ struct SessionStateIcon: View {
             Image(systemName: "checkmark.circle.fill")
                 .font(.system(size: size))
                 .foregroundColor(IrrColors.ready)
+                .frame(width: size, height: size)
+        case .unknown:
+            // #1797 — a state this build cannot interpret. Neutral grey
+            // question mark, same clamped size × size box as the others so an
+            // unreadable state doesn't reflow the row (issue #596).
+            Image(systemName: "questionmark.circle")
+                .font(.system(size: size))
+                .foregroundColor(IrrColors.unknown)
                 .frame(width: size, height: size)
         }
     }

--- a/platforms/macos/Irrlicht/Views/SessionStateIcon.swift
+++ b/platforms/macos/Irrlicht/Views/SessionStateIcon.swift
@@ -28,22 +28,21 @@ struct SessionStateIcon: View {
             WorkingIcon(size: size)
         case .waiting:
             WaitingIcon(size: size)
-        case .ready:
+        case .ready, .unknown:
+            // Both are SF Symbols, so they share one arm and read their glyph
+            // and hue from the enum rather than re-hardcoding them here — the
+            // enum's `glyph` has a production consumer of its own
+            // (SessionManager's menu-bar summary), and a second copy could
+            // silently disagree with it.
+            //
             // The font keeps the glyph's optical size (the working dot is
             // tuned to match it); the explicit frame clamps the layout box
             // to size × size — without it the symbol's font metrics make
-            // the box wider and push the rest of the row to the right.
-            Image(systemName: "checkmark.circle.fill")
+            // the box wider and push the rest of the row to the right (#596).
+            // That clamp is why `.unknown` can join this arm safely.
+            Image(systemName: state.glyph)
                 .font(.system(size: size))
-                .foregroundColor(IrrColors.ready)
-                .frame(width: size, height: size)
-        case .unknown:
-            // #1797 — a state this build cannot interpret. Neutral grey
-            // question mark, same clamped size × size box as the others so an
-            // unreadable state doesn't reflow the row (issue #596).
-            Image(systemName: "questionmark.circle")
-                .font(.system(size: size))
-                .foregroundColor(IrrColors.unknown)
+                .foregroundColor(state.color)
                 .frame(width: size, height: size)
         }
     }

--- a/platforms/macos/Tests/HistoryBarColorTests.swift
+++ b/platforms/macos/Tests/HistoryBarColorTests.swift
@@ -11,16 +11,21 @@ import XCTest
 ///
 /// Two separate inputs hit that fallback, and both mattered:
 ///
-///   - `""`, the no-data wire code. `historyPriorityToState` returns it for
-///     code 3 and its own doc comment says "HistoryBarView treats it as a blank
-///     slot" — which was false. `trimLeadingNoData` strips only LEADING
-///     empties, so a gap anywhere else in the ring painted a solid green bucket,
-///     inventing a finished session out of missing data. The web twin has always
-///     been right here (`irrlicht.js`: `if (!color) continue`), so before this
-///     fix the two platforms rendered the same ring differently.
-///   - any other unrecognised name — a state written by a newer daemon. After
-///     #1797 the row's state ICON renders neutral grey for these, so leaving the
-///     bar green made a single row contradict itself.
+///   - `""`, the no-data wire code — the REACHABLE one. `historyPriorityToState`
+///     returns it for code 3 and its own doc comment says "HistoryBarView treats
+///     it as a blank slot", which was false. `trimLeadingNoData` strips only
+///     LEADING empties, so a gap anywhere else in the ring painted a solid green
+///     bucket, inventing a finished session out of missing data. The web twin
+///     has always been right here (`irrlicht.js`: `if (!color) continue`), so
+///     before this fix the two platforms rendered the same ring differently.
+///   - any other unrecognised name — DEFENSIVE ONLY, and marked as such rather
+///     than asserted: every string reaching `states` comes from
+///     `historyPriorityToState`, a 4-way switch over a 2-bit code returning only
+///     ready/working/waiting/"", so a newer daemon's state arrives as a priority
+///     CODE and this branch cannot fire in production today. It is pinned
+///     anyway because the epic will widen that encoding (#1807), and because the
+///     row's state ICON already renders neutral grey — a green bar beside it
+///     would make one row tell two stories.
 final class HistoryBarColorTests: XCTestCase {
     func testKnownStatesKeepTheirOwnColors() {
         // LOCK: the three canonical buckets must not move.
@@ -36,7 +41,9 @@ final class HistoryBarColorTests: XCTestCase {
         )
     }
 
-    func testUnrecognizedStatePaintsNeutralNotGreen() {
+    /// Defensive branch — see the type comment: not reachable in production
+    /// today, pinned for when the wire encoding widens.
+    func testUnrecognizedStatePaintsNeutralNotGreen_defensive() {
         let color = HistoryBarView.barColor(for: "zzz-unknown")
         XCTAssertNotNil(color, "an unrecognized state should still render, just not as ready")
         XCTAssertNotEqual(color, IrrColors.ready, "an unrecognized state must never paint ready-green")

--- a/platforms/macos/Tests/HistoryBarColorTests.swift
+++ b/platforms/macos/Tests/HistoryBarColorTests.swift
@@ -1,0 +1,52 @@
+import SwiftUI
+import XCTest
+@testable import Irrlicht
+
+/// #1797 — the per-row history bar was the fourth reader that answered an
+/// unrecognised bucket with READY GREEN:
+///
+/// ```swift
+/// let color = stateColors[state] ?? stateColors["ready"]!
+/// ```
+///
+/// Two separate inputs hit that fallback, and both mattered:
+///
+///   - `""`, the no-data wire code. `historyPriorityToState` returns it for
+///     code 3 and its own doc comment says "HistoryBarView treats it as a blank
+///     slot" — which was false. `trimLeadingNoData` strips only LEADING
+///     empties, so a gap anywhere else in the ring painted a solid green bucket,
+///     inventing a finished session out of missing data. The web twin has always
+///     been right here (`irrlicht.js`: `if (!color) continue`), so before this
+///     fix the two platforms rendered the same ring differently.
+///   - any other unrecognised name — a state written by a newer daemon. After
+///     #1797 the row's state ICON renders neutral grey for these, so leaving the
+///     bar green made a single row contradict itself.
+final class HistoryBarColorTests: XCTestCase {
+    func testKnownStatesKeepTheirOwnColors() {
+        // LOCK: the three canonical buckets must not move.
+        XCTAssertEqual(HistoryBarView.barColor(for: "working"), IrrColors.working)
+        XCTAssertEqual(HistoryBarView.barColor(for: "waiting"), IrrColors.waiting)
+        XCTAssertEqual(HistoryBarView.barColor(for: "ready"), IrrColors.ready)
+    }
+
+    func testNoDataBucketPaintsNothingRatherThanGreen() {
+        XCTAssertNil(
+            HistoryBarView.barColor(for: ""),
+            "the no-data code must leave the slot unpainted, not paint it ready-green"
+        )
+    }
+
+    func testUnrecognizedStatePaintsNeutralNotGreen() {
+        let color = HistoryBarView.barColor(for: "zzz-unknown")
+        XCTAssertNotNil(color, "an unrecognized state should still render, just not as ready")
+        XCTAssertNotEqual(color, IrrColors.ready, "an unrecognized state must never paint ready-green")
+        XCTAssertEqual(color, IrrColors.unknown)
+    }
+
+    /// The bar and the state icon sit in the same row (`SessionRowView`), so a
+    /// disagreement between them is visible to the user as one row telling two
+    /// stories.
+    func testBarAgreesWithTheRowsStateIconForUnknown() {
+        XCTAssertEqual(HistoryBarView.barColor(for: "zzz-unknown"), SessionState.State.unknown.color)
+    }
+}

--- a/platforms/macos/Tests/MenuBarStatusRendererTests.swift
+++ b/platforms/macos/Tests/MenuBarStatusRendererTests.swift
@@ -80,12 +80,32 @@ final class MenuBarStatusRendererTests: XCTestCase {
         XCTAssertTrue(svg.contains(">3</text>"))
     }
 
+    // #1797 — the universal form of the invariant, stated over EVERY state
+    // rather than over `.unknown` specifically: whatever the vocabulary is, the
+    // pie must account for all of it. `segmentOrder` derives from `allCases`
+    // now, so this holds by construction and would catch a 5th state that
+    // arrived with a `menuBarRank` but no wedge.
+    func testStateSegmentsCoverEveryDeclaredState() {
+        let sessions = SessionState.State.allCases.enumerated().map { i, s in
+            makeSession(id: "\(i)", state: s)
+        }
+
+        let segments = MenuBarStatusRenderer.stateSegments(for: sessions)
+
+        XCTAssertEqual(
+            Set(segments.map(\.state)), Set(SessionState.State.allCases),
+            "every declared state needs a wedge, or the dot renders with a hole"
+        )
+        XCTAssertEqual(segments.map(\.fraction).reduce(0, +), 1.0, accuracy: 0.0001)
+    }
+
     // The pie fractions must still sum to the whole circle once unknown
     // sessions are in the mix — otherwise the dot renders with a hole.
     //
-    // This is the test that guards `segmentOrder` (#1797). Mutation check
-    // (verified): drop `.unknown` from segmentOrder and this goes red with
-    // count 2-of-4 and fractions summing to 0.5.
+    // This is the test that guards `segmentOrder`'s coverage of `.unknown`
+    // specifically (#1797). Mutation check (verified): pin segmentOrder back to
+    // a literal `[.waiting, .working, .ready]` and this goes red with count
+    // 2-of-4 and fractions summing to 0.5.
     func testStateSegmentsCoverEveryUnknownStateSession() {
         let sessions = [
             makeSession(id: "1", state: .waiting),

--- a/platforms/macos/Tests/MenuBarStatusRendererTests.swift
+++ b/platforms/macos/Tests/MenuBarStatusRendererTests.swift
@@ -53,6 +53,45 @@ final class MenuBarStatusRendererTests: XCTestCase {
         XCTAssertTrue(svg.contains(">4</text>"))
     }
 
+    // #1797 — `segmentOrder` is the menu bar's state vocabulary, and a state
+    // missing from it is a session counted in the pie's denominator with no
+    // wedge of its own. A group of nothing but unrecognized sessions produced
+    // zero segments and fell through to the solid-circle path, which defaulted
+    // to READY GREEN — the menu bar reporting "all done" for sessions it could
+    // not read. Mutation check for this guard (there is no pre-fix state to run
+    // it against): drop `.unknown` from segmentOrder and this goes red.
+    func testAggregatedGroupSVGNeverPaintsUnknownSessionsGreen() {
+        let sessions = (1...3).map { makeSession(id: "\($0)", state: .unknown) }
+
+        let svg = MenuBarStatusRenderer.aggregatedGroupSVG(for: sessions)
+
+        XCTAssertFalse(
+            svg.contains(IrrSVG.ready),
+            "a group of only unrecognized sessions must not render ready-green: \(svg)"
+        )
+        XCTAssertTrue(svg.contains(IrrSVG.unknown), "expected the neutral hue: \(svg)")
+        XCTAssertTrue(svg.contains(">3</text>"))
+    }
+
+    // The pie fractions must still sum to the whole circle once unknown
+    // sessions are in the mix — otherwise the dot renders with a hole.
+    func testStateSegmentsCoverEveryUnknownStateSession() {
+        let sessions = [
+            makeSession(id: "1", state: .waiting),
+            makeSession(id: "2", state: .unknown),
+            makeSession(id: "3", state: .ready),
+            makeSession(id: "4", state: .unknown)
+        ]
+
+        let segments = MenuBarStatusRenderer.stateSegments(for: sessions)
+
+        XCTAssertEqual(segments.map(\.count).reduce(0, +), sessions.count)
+        XCTAssertEqual(segments.map(\.fraction).reduce(0, +), 1.0, accuracy: 0.0001)
+        // Unknown sorts last, after every state we can actually read.
+        XCTAssertEqual(segments.last?.state, .unknown)
+        XCTAssertEqual(segments.last?.count, 2)
+    }
+
     func testBuildStatusImageReturnsImageForSessions() {
         let image = MenuBarStatusRenderer.buildStatusImage(
             sessions: [makeSession(id: "1", state: .working)],

--- a/platforms/macos/Tests/MenuBarStatusRendererTests.swift
+++ b/platforms/macos/Tests/MenuBarStatusRendererTests.swift
@@ -53,13 +53,20 @@ final class MenuBarStatusRendererTests: XCTestCase {
         XCTAssertTrue(svg.contains(">4</text>"))
     }
 
-    // #1797 — `segmentOrder` is the menu bar's state vocabulary, and a state
-    // missing from it is a session counted in the pie's denominator with no
-    // wedge of its own. A group of nothing but unrecognized sessions produced
-    // zero segments and fell through to the solid-circle path, which defaulted
-    // to READY GREEN — the menu bar reporting "all done" for sessions it could
-    // not read. Mutation check for this guard (there is no pre-fix state to run
-    // it against): drop `.unknown` from segmentOrder and this goes red.
+    // #1797 — a group of nothing but unrecognized sessions must not report
+    // "all done" in the menu bar.
+    //
+    // What this test actually guards is `State.dominant(in:)`, whose final
+    // `return .ready` used to answer green for an all-unknown collection.
+    // Mutation check (verified, not asserted): revert `dominant` to
+    // `return .ready` and this goes red.
+    //
+    // It does NOT guard `segmentOrder` — dropping `.unknown` from that list
+    // leaves this test green, because the single-segment `??` fallback also
+    // routes to `.unknown`. `testStateSegmentsCoverEveryUnknownStateSession`
+    // below is the one that covers `segmentOrder`. Recording the split
+    // explicitly because the obvious reading of these two tests gets it
+    // backwards.
     func testAggregatedGroupSVGNeverPaintsUnknownSessionsGreen() {
         let sessions = (1...3).map { makeSession(id: "\($0)", state: .unknown) }
 
@@ -75,6 +82,10 @@ final class MenuBarStatusRendererTests: XCTestCase {
 
     // The pie fractions must still sum to the whole circle once unknown
     // sessions are in the mix — otherwise the dot renders with a hole.
+    //
+    // This is the test that guards `segmentOrder` (#1797). Mutation check
+    // (verified): drop `.unknown` from segmentOrder and this goes red with
+    // count 2-of-4 and fractions summing to 0.5.
     func testStateSegmentsCoverEveryUnknownStateSession() {
         let sessions = [
             makeSession(id: "1", state: .waiting),

--- a/platforms/macos/Tests/SessionManagerTests.swift
+++ b/platforms/macos/Tests/SessionManagerTests.swift
@@ -144,7 +144,12 @@ final class SessionManagerTests: XCTestCase {
         XCTAssertEqual(SessionState.State.ready.hexColor, "34C759")
     }
 
-    func testUnknownStateFallsBackToReady() throws {
+    // #1797. This test used to be `testUnknownStateFallsBackToReady` and
+    // asserted `.ready` — it locked in the defect: `State(rawValue:) ?? .ready`
+    // painted every state this build had never heard of GREEN, which claims a
+    // session finished cleanly at the exact moment the app cannot interpret
+    // what the daemon said. It now decodes to `.unknown` and renders neutral.
+    func testUnknownStateDecodesToUnknownNotReady() throws {
         let jsonData = """
         {
             "session_id": "sess_unknown123",
@@ -161,7 +166,53 @@ final class SessionManagerTests: XCTestCase {
         let session = try JSONDecoder().decode(SessionState.self, from: jsonData)
 
         XCTAssertEqual(session.id, "sess_unknown123")
+        XCTAssertNotEqual(session.state, .ready, "an unrecognized state must never render as ready/green")
+        XCTAssertEqual(session.state, .unknown)
+    }
+
+    // The `"finished"` -> `.ready` branch is a deliberate RENAME-compatibility
+    // shim, not an unknown state. #1797 must not sweep it up with the rest:
+    // this is a LOCK on behavior that must NOT change, so it passed before the
+    // fix by construction.
+    func testFinishedStillDecodesToReady() throws {
+        let jsonData = """
+        {
+            "session_id": "sess_finished",
+            "state": "finished",
+            "updated_at": 1234567890,
+            "first_seen": 1234567800
+        }
+        """.data(using: .utf8)!
+
+        let session = try JSONDecoder().decode(SessionState.self, from: jsonData)
         XCTAssertEqual(session.state, .ready)
+    }
+
+    // #1797: the neutral rendering has to be neutral all the way down — a
+    // decode that lands on `.unknown` but then borrows ready's green glyph or
+    // hue has fixed nothing the user can see.
+    func testUnknownStateRendersNeutrally() {
+        let unknown = SessionState.State.unknown
+        XCTAssertNotEqual(unknown.hexColor, SessionState.State.ready.hexColor)
+        XCTAssertNotEqual(unknown.glyph, SessionState.State.ready.glyph)
+        XCTAssertNotEqual(unknown.emoji, SessionState.State.ready.emoji)
+        XCTAssertNotEqual(unknown.label, SessionState.State.ready.label)
+        XCTAssertEqual(unknown.hexColor, IrrSVG.unknown)
+    }
+
+    // #1797: the menu-bar summary asks `dominant(in:)` for one state to paint.
+    // A group of nothing but unrecognized sessions used to fall through its
+    // final `return .ready` and paint the menu bar green.
+    func testDominantStateOfAllUnknownIsNotReady() {
+        XCTAssertEqual(SessionState.State.dominant(in: [.unknown, .unknown]), .unknown)
+        // Known states still outrank unknown, and the priority order among
+        // them is unchanged (LOCK).
+        XCTAssertEqual(SessionState.State.dominant(in: [.unknown, .ready]), .ready)
+        XCTAssertEqual(SessionState.State.dominant(in: [.unknown, .working]), .working)
+        XCTAssertEqual(SessionState.State.dominant(in: [.unknown, .waiting]), .waiting)
+        XCTAssertEqual(SessionState.State.dominant(in: [.ready, .working, .waiting]), .waiting)
+        // An empty collection keeps its historical answer (LOCK).
+        XCTAssertEqual(SessionState.State.dominant(in: [SessionState.State]()), .ready)
     }
     
     // MARK: - Display Formatting Tests

--- a/platforms/web/formatters.js
+++ b/platforms/web/formatters.js
@@ -17,9 +17,10 @@ const svgIcons = {
   // Unknown / unrecognized state (#1797) — a session state this build has
   // never heard of, e.g. one written by a newer daemon. Deliberately
   // `currentColor` rather than an inlined hex: the .state-unknown rule in
-  // irrlicht.css points that at var(--muted), so the icon follows the
-  // light-theme palette. (The `cancelled` entry above predates that rule and
-  // does NOT follow it — a known wart, left alone here rather than copied.)
+  // irrlicht.css points that at var(--unknown), a token paired by value with
+  // macOS IrrHex.unknown. (The `cancelled` entry above inlines its hex and so
+  // follows no theme override at all — a known wart, left alone rather than
+  // copied.)
   unknown: '<svg class="state-unknown" viewBox="0 0 16 16" fill="none"><circle cx="8" cy="8" r="6.5" stroke="currentColor" stroke-width="1.5"/><path d="M6.2 6.2a1.85 1.85 0 113 1.5c-.7.5-1.2.85-1.2 1.6" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/><circle cx="8" cy="11.6" r="0.85" fill="currentColor"/></svg>',
 };
 

--- a/platforms/web/formatters.js
+++ b/platforms/web/formatters.js
@@ -14,9 +14,21 @@ const svgIcons = {
   waiting: '<svg viewBox="0 0 16 16" fill="none"><rect x="4" y="3" width="2.5" height="10" rx="1" fill="#FF9500"/><rect x="9.5" y="3" width="2.5" height="10" rx="1" fill="#FF9500"/></svg>',
   ready: '<svg viewBox="0 0 16 16" fill="none"><circle cx="8" cy="8" r="6.5" stroke="#34C759" stroke-width="1.5"/><path d="M5 8.2l2 2 4-4.4" stroke="#34C759" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>',
   cancelled: '<svg viewBox="0 0 16 16" fill="none"><circle cx="8" cy="8" r="6.5" stroke="#8E8E93" stroke-width="1.5"/><path d="M5.5 5.5l5 5M10.5 5.5l-5 5" stroke="#8E8E93" stroke-width="1.5" stroke-linecap="round"/></svg>',
+  // Unknown / unrecognized state (#1797) — a session state this build has
+  // never heard of, e.g. one written by a newer daemon. Deliberately
+  // `currentColor` rather than an inlined hex: the .state-unknown rule in
+  // irrlicht.css points that at var(--muted), so the icon follows the
+  // light-theme palette. (The `cancelled` entry above predates that rule and
+  // does NOT follow it — a known wart, left alone here rather than copied.)
+  unknown: '<svg class="state-unknown" viewBox="0 0 16 16" fill="none"><circle cx="8" cy="8" r="6.5" stroke="currentColor" stroke-width="1.5"/><path d="M6.2 6.2a1.85 1.85 0 113 1.5c-.7.5-1.2.85-1.2 1.6" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/><circle cx="8" cy="11.6" r="0.85" fill="currentColor"/></svg>',
 };
 
-export function stateIcon(state) { return svgIcons[state] || svgIcons.ready; }
+// stateIcon maps a session state to its 12px glyph. An unrecognized state gets
+// the neutral `unknown` icon, NEVER the green ready checkmark (#1797): green
+// reads as "this session finished cleanly", which is the single worst thing to
+// claim at the exact moment the dashboard cannot interpret what the daemon
+// said. A blank/missing state lands here too, for the same reason.
+export function stateIcon(state) { return svgIcons[state] || svgIcons.unknown; }
 
 // --- Helpers ---
 export function shortModel(m) {

--- a/platforms/web/irrlicht.css
+++ b/platforms/web/irrlicht.css
@@ -27,6 +27,13 @@
       --ready-glow: rgba(52, 199, 89, 0.2);
       --cancelled: #8E8E93;
       --cancelled-dim: rgba(142, 142, 147, 0.1);
+      /* Unrecognized session state (#1797) — a state this build has never
+         heard of. Paired by value with macOS IrrHex.unknown; every other state
+         hex matches across the two platforms and this one must too, which is
+         why it is its own token rather than a borrowed --muted (whose value
+         differs per theme AND from the macOS side). Like --cancelled, it is
+         defined once: a mid-grey that reads on both light and dark surfaces. */
+      --unknown: #8E8E93;
       /* Pressure-bar colors — mirror overlay's ContextBarColor / pressure_level mapping:
          safe → low, caution → medium, warning → high, critical → critical. */
       --pressure-low: #34C759;
@@ -580,12 +587,13 @@
 
     /* Unknown/unrecognized session state (#1797) — a session state this build
        has never heard of. Its SVG paints with currentColor, so setting `color`
-       here is what makes it neutral grey AND theme-aware: --muted is redefined
-       by both light-mode blocks at the top of this file, which the older
-       hex-inlined `cancelled` icon never picks up. */
+       here is what colors it. Goes through the --unknown token rather than an
+       inlined hex (which is what leaves the older `cancelled` icon unable to
+       follow any theme override) and rather than --muted (which would drift
+       from the macOS value). */
     .row-state-icon svg.state-unknown,
     .app-state-icon svg.state-unknown {
-      color: var(--muted);
+      color: var(--unknown);
     }
 
     /* Working state — opacity-only "breathe" on a large solid dot.

--- a/platforms/web/irrlicht.css
+++ b/platforms/web/irrlicht.css
@@ -578,6 +578,16 @@
       display: block;
     }
 
+    /* Unknown/unrecognized session state (#1797) — a session state this build
+       has never heard of. Its SVG paints with currentColor, so setting `color`
+       here is what makes it neutral grey AND theme-aware: --muted is redefined
+       by both light-mode blocks at the top of this file, which the older
+       hex-inlined `cancelled` icon never picks up. */
+    .row-state-icon svg.state-unknown,
+    .app-state-icon svg.state-unknown {
+      color: var(--muted);
+    }
+
     /* Working state — opacity-only "breathe" on a large solid dot.
        Footprint is r=7 of 20 viewBox (70 % of cell), so the dot stays
        clearly visible even if the animation is dropped by the renderer

--- a/platforms/web/irrlicht.js
+++ b/platforms/web/irrlicht.js
@@ -727,7 +727,12 @@ import { reconcile, paintRowNum } from './domReconcile.js';
     }
 
     function updateSessionRow(el, agent, isChild) {
-      const state = agent.state || 'ready';
+      // #1797: fall back to 'unknown', never 'ready' — this value reaches
+      // stateIcon via renderRowStateIcon, and 'ready' would re-introduce the
+      // green checkmark that stateIcon's own default was fixed to stop.
+      // isActive is unaffected: 'unknown' is neither working nor waiting,
+      // exactly as 'ready' was.
+      const state = agent.state || 'unknown';
       const metrics = agent.metrics || {};
       const isActive = state === 'working' || state === 'waiting';
 
@@ -1369,7 +1374,7 @@ import { reconcile, paintRowNum } from './domReconcile.js';
       const list = topLevel || [];
       let sig = 'count:' + list.length;
       if (list.length === 0) sig = 'empty';
-      else if (list.length <= 3) sig = 'icons:' + list.map(s => s.state || 'ready').join(',');
+      else if (list.length <= 3) sig = 'icons:' + list.map(s => s.state || 'unknown').join(',');
       if (host.dataset.sig === sig) return;
       host.dataset.sig = sig;
       if (list.length === 0) {
@@ -1379,7 +1384,8 @@ import { reconcile, paintRowNum } from './domReconcile.js';
       if (list.length <= 3) {
         let html = '';
         for (const s of list) {
-          html += '<span class="app-state-icon" title="' + esc(s.state || 'ready') + '">' + stateIcon(s.state || 'ready') + '</span>';
+          // #1797: 'unknown', not 'ready' — see updateSessionRow.
+          html += '<span class="app-state-icon" title="' + esc(s.state || 'unknown') + '">' + stateIcon(s.state || 'unknown') + '</span>';
         }
         host.innerHTML = html;
         return;

--- a/platforms/web/irrlicht.test.js
+++ b/platforms/web/irrlicht.test.js
@@ -1,6 +1,6 @@
 import { describe, test, expect, beforeEach, beforeAll, afterAll } from 'vitest'
 
-import { formatCO2, co2TierTitle } from './formatters.js'
+import { formatCO2, co2TierTitle, stateIcon } from './formatters.js'
 import { readCss } from './snapshots/serialize.js'
 import {
   permissionEffectNotice,
@@ -171,6 +171,62 @@ describe('co2TierTitle', () => {
   test('discloses the fallback approximation for any other tier', () => {
     expect(co2TierTitle('fallback')).toMatch(/cross-model fallback/)
     expect(co2TierTitle(undefined)).toMatch(/cross-model fallback/)
+  })
+})
+
+// #1797 — stateIcon used to answer `svgIcons[state] || svgIcons.ready`, so a
+// state this build has never heard of rendered the GREEN CHECKMARK. Green is
+// the single worst wrong answer: it tells the user a session finished cleanly
+// at exactly the moment the daemon is saying something this dashboard cannot
+// interpret. An unrecognised state gets a neutral icon of its own.
+describe('stateIcon (#1797)', () => {
+  test('known states keep their own icons', () => {
+    expect(stateIcon('working')).toMatch(/#8B5CF6/)
+    expect(stateIcon('waiting')).toMatch(/#FF9500/)
+    expect(stateIcon('ready')).toMatch(/#34C759/)
+  })
+
+  test('an unrecognized state does not render as ready', () => {
+    const icon = stateIcon('zzz-unknown')
+    expect(icon).not.toBe(stateIcon('ready'))
+    expect(icon).not.toBe(stateIcon('working'))
+    expect(icon).not.toBe(stateIcon('waiting'))
+    // Not merely "different markup that happens to be green": the ready
+    // icon's hue must not appear at all.
+    expect(icon).not.toMatch(/#34C759/)
+    expect(icon).not.toMatch(/34C759/i)
+  })
+
+  test('the unknown icon still renders something', () => {
+    const icon = stateIcon('zzz-unknown')
+    expect(icon).toMatch(/^<svg\b/)
+    expect(icon).toMatch(/<\/svg>$/)
+  })
+
+  test('a missing state renders the unknown icon, not ready', () => {
+    expect(stateIcon(undefined)).toBe(stateIcon('zzz-unknown'))
+    expect(stateIcon('')).toBe(stateIcon('zzz-unknown'))
+  })
+
+  // The unknown icon takes its color from the theme rather than inlining a
+  // hex, so it follows the light-mode palette. The `cancelled` entry beside it
+  // predates that rule and is deliberately left alone (out of scope, #1797) —
+  // this asserts the NEW icon didn't copy the mistake.
+  test('the unknown icon is theme-aware, not a hardcoded hex', () => {
+    const icon = stateIcon('zzz-unknown')
+    expect(icon).toMatch(/currentColor/)
+    expect(icon).not.toMatch(/#[0-9a-f]{6}/i)
+  })
+
+  test('the stylesheet gives the unknown icon a muted color', () => {
+    const css = readCss()
+    expect(css).toMatch(/svg\.state-unknown/)
+    // The rule must actually resolve to the theme's muted token — a selector
+    // with no declaration would leave the icon inheriting whatever color the
+    // row happens to have.
+    const rule = css.match(/svg\.state-unknown[^{]*\{[^}]*\}/)
+    expect(rule).not.toBeNull()
+    expect(rule[0]).toMatch(/var\(--muted\)/)
   })
 })
 

--- a/platforms/web/irrlicht.test.js
+++ b/platforms/web/irrlicht.test.js
@@ -180,6 +180,7 @@ describe('co2TierTitle', () => {
 // at exactly the moment the daemon is saying something this dashboard cannot
 // interpret. An unrecognised state gets a neutral icon of its own.
 describe('stateIcon (#1797)', () => {
+  // LOCK — the three canonical icons must not move. Passes by construction.
   test('known states keep their own icons', () => {
     expect(stateIcon('working')).toMatch(/#8B5CF6/)
     expect(stateIcon('waiting')).toMatch(/#FF9500/)
@@ -206,27 +207,43 @@ describe('stateIcon (#1797)', () => {
   test('a missing state renders the unknown icon, not ready', () => {
     expect(stateIcon(undefined)).toBe(stateIcon('zzz-unknown'))
     expect(stateIcon('')).toBe(stateIcon('zzz-unknown'))
+    // The two `toBe`s above are equality checks, and pre-fix BOTH sides were
+    // the ready checkmark — so they were equal and this test passed against
+    // the defect. These are what make the test's name true.
+    expect(stateIcon(undefined)).not.toMatch(/34C759/i)
+    expect(stateIcon('')).not.toMatch(/34C759/i)
   })
 
-  // The unknown icon takes its color from the theme rather than inlining a
-  // hex, so it follows the light-mode palette. The `cancelled` entry beside it
-  // predates that rule and is deliberately left alone (out of scope, #1797) —
-  // this asserts the NEW icon didn't copy the mistake.
-  test('the unknown icon is theme-aware, not a hardcoded hex', () => {
+  // The unknown icon takes its color from a CSS token rather than inlining a
+  // hex. The `cancelled` entry beside it predates that rule and is deliberately
+  // left alone (out of scope, #1797) — this asserts the NEW icon didn't copy
+  // the mistake.
+  test('the unknown icon is token-driven, not a hardcoded hex', () => {
     const icon = stateIcon('zzz-unknown')
     expect(icon).toMatch(/currentColor/)
     expect(icon).not.toMatch(/#[0-9a-f]{6}/i)
   })
 
-  test('the stylesheet gives the unknown icon a muted color', () => {
+  test('the stylesheet points the unknown icon at the --unknown token', () => {
     const css = readCss()
     expect(css).toMatch(/svg\.state-unknown/)
-    // The rule must actually resolve to the theme's muted token — a selector
-    // with no declaration would leave the icon inheriting whatever color the
-    // row happens to have.
+    // The rule must actually carry a declaration — a selector with none would
+    // leave the icon inheriting whatever color the row happens to have.
     const rule = css.match(/svg\.state-unknown[^{]*\{[^}]*\}/)
     expect(rule).not.toBeNull()
-    expect(rule[0]).toMatch(/var\(--muted\)/)
+    expect(rule[0]).toMatch(/var\(--unknown\)/)
+  })
+
+  // #1797 — every state hue is paired by value across the two frontends, and
+  // `unknown` is no exception. macOS holds it in IrrHex.unknown
+  // (platforms/macos/Irrlicht/Theme/Tokens.swift); if that value is changed on
+  // one side only, this fails rather than the two dashboards quietly drifting
+  // to different greys for the same session.
+  test('--unknown is defined and matches the macOS IrrHex.unknown value', () => {
+    const css = readCss()
+    const decl = css.match(/--unknown:\s*([^;]+);/)
+    expect(decl).not.toBeNull()
+    expect(decl[1].trim().toLowerCase()).toBe('#8e8e93')
   })
 })
 

--- a/platforms/web/irrlicht.test.js
+++ b/platforms/web/irrlicht.test.js
@@ -1,7 +1,7 @@
 import { describe, test, expect, beforeEach, beforeAll, afterAll } from 'vitest'
 
 import { formatCO2, co2TierTitle, stateIcon } from './formatters.js'
-import { readCss } from './snapshots/serialize.js'
+import { readCss, readMacosTokens } from './snapshots/serialize.js'
 import {
   permissionEffectNotice,
   anyEffectFailed,
@@ -194,12 +194,8 @@ describe('stateIcon (#1797)', () => {
     expect(icon).not.toBe(stateIcon('waiting'))
     // Not merely "different markup that happens to be green": the ready
     // icon's hue must not appear at all.
-    expect(icon).not.toMatch(/#34C759/)
     expect(icon).not.toMatch(/34C759/i)
-  })
-
-  test('the unknown icon still renders something', () => {
-    const icon = stateIcon('zzz-unknown')
+    // ...and it must still render something rather than an empty string.
     expect(icon).toMatch(/^<svg\b/)
     expect(icon).toMatch(/<\/svg>$/)
   })
@@ -209,9 +205,8 @@ describe('stateIcon (#1797)', () => {
     expect(stateIcon('')).toBe(stateIcon('zzz-unknown'))
     // The two `toBe`s above are equality checks, and pre-fix BOTH sides were
     // the ready checkmark — so they were equal and this test passed against
-    // the defect. These are what make the test's name true.
+    // the defect. This is what makes the test's name true.
     expect(stateIcon(undefined)).not.toMatch(/34C759/i)
-    expect(stateIcon('')).not.toMatch(/34C759/i)
   })
 
   // The unknown icon takes its color from a CSS token rather than inlining a
@@ -235,15 +230,19 @@ describe('stateIcon (#1797)', () => {
   })
 
   // #1797 — every state hue is paired by value across the two frontends, and
-  // `unknown` is no exception. macOS holds it in IrrHex.unknown
-  // (platforms/macos/Irrlicht/Theme/Tokens.swift); if that value is changed on
-  // one side only, this fails rather than the two dashboards quietly drifting
-  // to different greys for the same session.
-  test('--unknown is defined and matches the macOS IrrHex.unknown value', () => {
-    const css = readCss()
-    const decl = css.match(/--unknown:\s*([^;]+);/)
-    expect(decl).not.toBeNull()
-    expect(decl[1].trim().toLowerCase()).toBe('#8e8e93')
+  // `unknown` is no exception. This READS Tokens.swift rather than comparing
+  // against a hand-typed literal: a third copy of the constant could not fail
+  // when the Swift side drifts, which is the only scenario this test exists
+  // for. Both extractions are asserted to have matched, so "could not find the
+  // token" fails loudly instead of silently passing (AGENTS.md).
+  test('--unknown matches the macOS IrrHex.unknown value', () => {
+    const cssDecl = readCss().match(/--unknown:\s*([^;]+);/)
+    expect(cssDecl, 'no --unknown custom property found in irrlicht.css').not.toBeNull()
+
+    const swiftDecl = readMacosTokens().match(/static let unknown\s*=\s*"(#[0-9A-Fa-f]{6})"/)
+    expect(swiftDecl, 'no IrrHex.unknown found in platforms/macos/Irrlicht/Theme/Tokens.swift').not.toBeNull()
+
+    expect(cssDecl[1].trim().toLowerCase()).toBe(swiftDecl[1].toLowerCase())
   })
 })
 

--- a/platforms/web/snapshots/serialize.js
+++ b/platforms/web/snapshots/serialize.js
@@ -9,10 +9,23 @@ import { fileURLToPath } from 'node:url'
 
 const here = dirname(fileURLToPath(import.meta.url))
 const cssPath = join(here, '..', 'irrlicht.css')
+const macosTokensPath = join(here, '..', '..', 'macos', 'Irrlicht', 'Theme', 'Tokens.swift')
 
 /** The dashboard's stylesheet, read from disk so the artifact tracks the real CSS. */
 export function readCss() {
   return readFileSync(cssPath, 'utf8')
+}
+
+/**
+ * The macOS app's design tokens, read from disk. Lets a web test assert that a
+ * state hue defined on both platforms actually agrees, instead of comparing
+ * against a hand-copied literal that cannot fail when the Swift side drifts
+ * (#1797). Path resolution lives here, beside readCss, because this module
+ * resolves from `import.meta.url` in a plain node context — doing the same from
+ * a jsdom-environment test file yields a non-file URL.
+ */
+export function readMacosTokens() {
+  return readFileSync(macosTokensPath, 'utf8')
 }
 
 /**


### PR DESCRIPTION
Phase 0 of #1796. Three readers treated a session state outside the three-state vocabulary as either **"delete it"** or **"it's ready"**. Both are wrong on their own terms, independently of the epic: an unrecognised state is a value *this build* does not understand — a session written by a newer daemon, read after a downgrade or in a mixed-version install — and it is never a licence to destroy the user's data or to claim the session finished cleanly.

Closes #1797

## What changed

### 1. `core/adapters/outbound/filesystem/repository.go` — stopped deleting the file

`ListAll()` `os.Remove`'d any session file whose state fell outside a hardcoded 3-entry allowlist. An older daemon **destroyed every such file on its first sweep, irrecoverably**. It now keeps the file byte-for-byte, skips the session, and logs the unrecognised value **once per distinct value** (`ListAll` runs on the poll loop, so per-occurrence logging would emit the same line every few seconds forever). The inline allowlist is replaced by the domain's own `session.IsCanonicalState`.

**The decision the issue asked to make explicit:** a three-state build **keeps the file and skips the session**. Handing it downstream is not an option — grouping, the state counters and the state machine are all written against exactly `working`/`waiting`/`ready`, so an unknown value would surface as a *mis-rendered* session rather than an absent one. Skipping loses only visibility, and the file is still on disk for the build that does understand it.

### 2. `platforms/macos` — stopped painting it green

`State(rawValue: stateString) ?? .ready` rendered an unknown state **green**. Adds a fourth `case unknown` to `SessionState.State` — an app-owned case that never comes off the wire as itself — with a neutral grey question-mark rendering across all six of `glyph` / `color` / `hexColor` / `emoji` / `label` / `SessionStateIcon`, and routes the decoder's fallback there. The deliberate `"finished" -> .ready` **rename shim is untouched** (it is a rename, not an unknown; locked by a test).

Two follow-on sites carried the identical bug and are fixed with it — both found by reading every `State` consumer, not by the compiler:

- `State.dominant(in:)` fell through its final `return .ready`, so a group of nothing but unreadable sessions summarised as **green**.
- `MenuBarStatusRenderer.segmentOrder` omitted unknown, which did two things: the pie fractions are `count / sessions.count`, so an unknown session was counted in the denominator with **no wedge of its own** (the dot renders with a hole); and an all-unknown group produced *zero* segments, fell through to the solid-circle path, and painted **ready green**.

### 3. `platforms/web/formatters.js` — same shape

`svgIcons[state] || svgIcons.ready`. Adds an `unknown` icon and falls back to it. The new icon paints with `currentColor` against a `.state-unknown` rule pointing at a new `--unknown` custom property — deliberately **not** copying the older `cancelled` entry's inlined hex, which follows no theme override at all (called out in the issue as a wart worth not propagating; left otherwise untouched as out of scope). `unknown` was the only state with no CSS token and the only one whose value differed across the two frontends; `--unknown` is paired by value with macOS `IrrHex.unknown`, and a test reads both files to keep them that way.

## Red-first evidence

Every defect test below was **seen to fail before the fix existed**. Locks and mutation-verified guards are labelled as such rather than presented as red-first proof.

### Go — `TestRepository_ListAll_KeepsUnknownState` (defect, RED on pre-fix tree)

```
=== RUN   TestRepository_ListAll_KeepsUnknownState
    repository_test.go:235: unknown-state file was deleted by ListAll: open
    /var/folders/.../TestRepository_ListAll_KeepsUnknownState3828919295/001/unknown.json:
    no such file or directory
--- FAIL: TestRepository_ListAll_KeepsUnknownState (0.00s)
=== RUN   TestRepository_ListAll_KeepsUnparseableFile
--- PASS: TestRepository_ListAll_KeepsUnparseableFile (0.00s)
FAIL	irrlicht/core/adapters/outbound/filesystem	0.477s
```

The `KeepsUnparseableFile` green above is a **LOCK**, stated as such in its doc comment — `ListAll`'s `continue` on a `json.Unmarshal` error already behaved correctly, and the test exists so a future "tidy up junk on load" change breaks a named test rather than only a code comment. The "not in the returned slice" half of `KeepsUnknownState` is likewise a lock; the surviving-file assertion is the defect.

### Swift — `testUnknownStateDecodesToUnknownNotReady` (defect, RED on pre-fix tree)

This test replaces `testUnknownStateFallsBackToReady`, which **asserted the defect** (`XCTAssertEqual(session.state, .ready)`). Captured by temporarily commenting out the two tests that reference the not-yet-existing `.unknown` symbol, so the assertion — not a compile error — is what fails:

```
Test Case '-[IrrlichtTests.SessionManagerTests testFinishedStillDecodesToReady]' passed (0.005 seconds).
Test Case '-[IrrlichtTests.SessionManagerTests testUnknownStateDecodesToUnknownNotReady]' started.
SessionManagerTests.swift:169: error: -[IrrlichtTests.SessionManagerTests
  testUnknownStateDecodesToUnknownNotReady] : XCTAssertNotEqual failed:
  ("ready") is equal to ("ready") - an unrecognized state must never render as ready/green
Test Case '...testUnknownStateDecodesToUnknownNotReady' failed (0.106 seconds).
	 Executed 2 tests, with 1 failure (0 unexpected)
```

`testFinishedStillDecodesToReady` passing there is the **LOCK** on the rename shim — it must not change, and it passed by construction.

### Swift menu bar — mutation-verified (guards this change *adds*, no "before" to run)

Per AGENTS.md: a guard added alongside a fix has no pre-fix state, so the thing it protects is mutated instead.

**Mutation A** — drop `.unknown` from `segmentOrder` (the pre-#1797 vocabulary):

```
MenuBarStatusRendererTests.swift:88: XCTAssertEqual failed: ("2") is not equal to ("4")
MenuBarStatusRendererTests.swift:89: XCTAssertEqualWithAccuracy failed: ("0.5") is not equal to ("1.0") +/- ("0.0001")
MenuBarStatusRendererTests.swift:91: XCTAssertEqual failed: ("Optional(...State.ready)") is not equal to ("Optional(...State.unknown)")
	 Executed 9 tests, with 4 failures (0 unexpected)
```

**Mutation B** — additionally revert the single-segment fallback to `?? SessionState.State.ready.hexColor`, reproducing the exact pre-#1797 code path:

```
MenuBarStatusRendererTests.swift:68: XCTAssertFalse failed - a group of only unrecognized
  sessions must not render ready-green: <circle cx="5.00" cy="9.00" r="5.00"
  fill="#34C759" stroke="rgba(0,0,0,0.25)" stroke-width="0.5"/>
	 Executed 9 tests, with 5 failures (0 unexpected)
```

The two guards are covered by *different* tests and were verified independently — mutation A alone did not make the green-paint test fail, because the `??` fix covers that case on its own. Both mutations were reverted (`git checkout --`) and the suite re-run green before committing.

### Web — `stateIcon (#1797)` (defect, RED on pre-fix tree)

```
 ❯ irrlicht.test.js (168 tests | 3 failed | 162 skipped)
     × an unrecognized state does not render as ready
     × the unknown icon is theme-aware, not a hardcoded hex
     × the stylesheet gives the unknown icon a muted color

FAIL > stateIcon (#1797) > an unrecognized state does not render as ready
AssertionError: expected '<svg viewBox="0 0 16 16" fill="none">…' not to be
  '<svg viewBox="0 0 16 16" fill="none">…' // Object.is equality

FAIL > stateIcon (#1797) > the unknown icon is theme-aware, not a hardcoded hex
AssertionError: expected '<svg …>' to match /currentColor/
+ Received: "<svg viewBox=\"0 0 16 16\" fill=\"none\"><circle cx=\"8\" cy=\"8\" r=\"6.5\"
  stroke=\"#34C759\" ...  <- the ready checkmark, returned for 'zzz-unknown'

FAIL > stateIcon (#1797) > the stylesheet gives the unknown icon a muted color
AssertionError: expected '    *, *::before, *::after { box-sizi…' to match /svg\.state-unknown/
```

(Two of those tests were later renamed by the simplify pass — `theme-aware` -> `token-driven`, `a muted color` -> `the --unknown token`. The output above is the run as it happened.)

The 4th test in that block (`a missing state renders the unknown icon`) passed pre-fix — pre-fix `stateIcon(undefined)` and `stateIcon('zzz-unknown')` were *both* the ready icon and therefore equal. It is not offered as red-first evidence; the three discriminating tests above are.

## Verification

`tools/preflight.sh` run chunked by `--only` group, each in the foreground. **All nine groups PASS** (re-run after each of the three commits):**

| Gate | Result |
|---|---|
| `go` (gofmt, core tests, onboarding-factory, `of validate`, recording-rig smoke, replay fixtures) | PASS |
| `web` (both trees) | PASS |
| `swift` (build + 462 tests) | PASS |
| `arch` (ARS) | PASS — composite 7.900987 → 7.901105, no category regression |
| `tools` | PASS |
| `skills` | PASS |
| `posix` | PASS |
| `bash` | PASS |
| `security` | PASS |

`SessionStateIconLayoutTests` iterates `SessionState.State.allCases`, so the new `.unknown` case was automatically pulled into the existing `size × size` layout-box assertion (#596) and passes — the new glyph does not reflow the row.

## Review & simplify passes

A `high`-effort review subagent returned **9 findings**; a 4-angle `/simplify` pass returned reuse/simplification/efficiency/altitude findings on top. Both are applied in commits 2 and 3. The ones that changed the shipped behaviour:

**A fourth unknown-state reader was found and fixed.** `platforms/macos/Irrlicht/Views/HistoryBarView.swift` had the identical `?? stateColors["ready"]!` shape — in the *same row* as the state icon this PR fixes, so a session could render a grey `?` icon beside a solid green history bar. Two inputs hit it, and one is reachable **today with no new state**: `""`, the no-data wire code, whose non-leading occurrences `trimLeadingNoData` does not strip, painted a green bucket where there was simply no data. The web twin has always skipped it correctly (`if (!color) continue`), so the two platforms rendered identical input differently. Red-first evidence below.

**The warning went to `/dev/null` in the shipped app.** `log.Printf` writes to stderr, and `DaemonManager.spawnDaemon` spawns `irrlichd` with stdout *and* stderr on `FileHandle.nullDevice`. The only signal that a session had silently vanished reached nobody. Now routed through the `Logger` port (AGENTS.md's convention), wired at `initSessionStorage` where the logger already exists; stderr remains the fallback for the CLI paths, whose stderr is a real terminal.

**`segmentOrder` was a hand-written array — the one state reader Swift cannot force to be exhaustive, and the one that broke.** It now derives from `State.allCases` sorted by a new compiler-forced `State.menuBarRank`, so a 5th state cannot be silently omitted the way `.unknown` was. This is the concrete payoff of `.unknown` being a real enum case.

**Two committed comments made claims that were false when run.** The reviewer executed the mutation a test comment described and the test survived it: the menu-bar green-paint test guards `State.dominant(in:)`, *not* `segmentOrder` — the `??` fallback also routes to `.unknown`, so dropping `.unknown` from `segmentOrder` leaves it green. Both comments now name what each test actually guards. The unreachable `??` is deleted rather than documented.

**A test whose name asserted something it never checked.** The web `a missing state renders the unknown icon, not ready` compared `stateIcon(undefined)` to `stateIcon('zzz-unknown')` — pre-fix *both* were the ready checkmark, so it passed against the defect. It now asserts the hue directly.

**The cross-platform token test hand-typed the constant it claimed to verify.** It now reads `Tokens.swift` and asserts both extractions matched, so "could not find the token" fails loudly instead of passing (AGENTS.md). Verified red by drifting `IrrHex.unknown` to `#AABBCC`:

```
AssertionError: expected '#8e8e93' to be '#aabbcc' // Object.is equality
```

### Additional red-first / mutation evidence from these passes

`HistoryBarColorTests` — `barColor` reverted to its pre-#1797 body:

```
HistoryBarColorTests.swift:33: XCTAssertNil failed: "#34C759FF" - the no-data code
  must leave the slot unpainted, not paint it ready-green
HistoryBarColorTests.swift:42: XCTAssertNotEqual failed: ("Optional(#34C759FF)") is
  equal to ("Optional(#34C759FF)") - an unrecognized state must never paint ready-green
HistoryBarColorTests.swift:50: XCTAssertEqual failed: ("Optional(#34C759FF)") is not
  equal to ("Optional(#8E8E93FF)")
	 Executed 4 tests, with 4 failures (0 unexpected)
```

`TestRepository_ListAll_WarnsOncePerUnknownState` — both halves mutated separately, since it is a mechanism this PR adds and has no "before":

```
# Mutation A — remove the LoadOrStore dedup:
repository_test.go:317: first ListAll: got 3 warnings, want 2 (one per DISTINCT unknown value)

# Mutation B — remove the Logger-port branch (stderr only):
repository_test.go:317: first ListAll: got 0 warnings, want 2 (one per DISTINCT unknown value): []
```

## One CI flake seen, investigated, filed as #1808

`build-test` failed once on commit 3 with `TestGrantAllLeavesAgentConfigsAlone: addr file ... should be removed after shutdown`. Established as a flake rather than a regression, by evidence:

- **A re-run of the byte-identical SHA passed** (same `headSha`, same job re-run, nothing pushed between).
- The same gate passed on commits 1 and 2, one of which already carried this branch's only daemon-startup change.
- That commit's sole non-test file is `core/internal/contracttesting/hook_receiver_gate.go`, and `go list -deps ./core/cmd/irrlichd | grep -c contracttesting` is **0** — it is not linked into the daemon binary, so it cannot affect daemon shutdown.

Reading the code turned up a plausible latent cause worth tracking: `main.go` publishes the addr file at `:804` but does not register `signal.Notify` until `:837`, so a SIGTERM landing in that window gets the default disposition and `os.Remove(addrPath)` never runs. Filed as **#1808** with a suggested one-line reordering. Marked suspected, not proven — the race was not reproduced locally.

## Notes / out of scope

- **A fifth reader is filed as #1807, not fixed here.** `core/application/services/history_tracker.go:41`'s `statePriority` coerces an unrecognised state to `ready` **and `save()` rewrites `history.json` with the coerced value** — so a downgrade both paints green and erases the original. It is not fixed in Phase 0 because the wire format is 2 bits per bucket with all four codes taken (`ready`/`working`/`waiting`/`noData`); a correct fix is a real encoding decision, and #1797 must reach a release quickly. Called out explicitly so Phase 1 does not assume Phase 0 covered every reader.
- **`platforms/web/irrlicht.js`'s `s.state || 'ready'` coercions are now `|| 'unknown'`** (lines ~730, ~1372, ~1382). Initially left alone as out of scope; two independent agents pointed out that leaving them made the app contradict its own new test, since both sites guarantee a falsy state can never reach `stateIcon`. One-token change, same edit already made in `formatters.js`.
- **`svgIcons.cancelled`'s inlined hex** is left as-is per the issue's explicit note. The new `unknown` icon does not copy the pattern — it uses `currentColor` against the new `--unknown` token.
- **The macOS decoder discards the raw unrecognised string** — the tooltip and debug dump can say "unknown" but not *what* the daemon reported (the Go side names the value in its warning). Deferred: it touches the large memberwise init, and the never-green property holds without it.
- **`STATES.md` does not exist.** `core/domain/session/session.go` lines 2 and 13 both cite it as "the formal state machine specification"; `find . -name STATES.md` returns nothing. The decision this issue asked to document lives in the code comment at the `ListAll` skip site instead. Pre-existing dangling reference, not introduced here.
- **A cross-language grep tripwire was considered and declined**, not merely deferred: a regex over `?? .ready` / `|| ready` / `default: …Ready` misses `stateColors[state] ?? stateColors["ready"]!` — the fourth reader this PR actually found — and fails closed on the deliberate `dominant(in: [])` and the `"finished"` rename shim. A tripwire whose known false-negative set includes its own motivating bug is a green that means nothing.
- `tools/irrlicht-design-system/ui_kits/dashboard/SessionRow.jsx` has its own `stateIcons` map with no fallback. It is a design-system kit, not shipped UI — untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
