### PR TITLE
feat(states): add the `error` domain state and plumb error detail through the tailer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,7 +44,8 @@ Use `./.build` for build artifacts.
 ## Key Conventions
 
 - Go code follows hexagonal architecture: `domain/` → `ports/` → `adapters/` → `application/services/`
-- Three session states only: `working`, `waiting`, `ready` — no cancelled state
+- Four session states only: `working`, `waiting`, `ready`, `error` — no cancelled state.
+  The vocabulary is declared once in `session.CanonicalStates()`; derive from it, never retype it
 - Errors are logged via `Logger` interface, not propagated with `fmt.Errorf`
 - Child sessions (subagents and background agents) use `ParentSessionID` for parent-child linking
 - Adapters declare `Permissions` on `agent.Agent` (with Apply/Remove effect closures); every read or modification an adapter performs must be consent-gated behind one of its declared permissions — nothing is exercised while pending or denied

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,8 +105,9 @@ when relevant (`Fixes #42`).
 **Go (daemon).** Follow `gofmt`/`go vet`. Errors are logged via the `Logger`
 interface, not propagated with `fmt.Errorf` for observability-only failures.
 Adapter packages own their format-specific parsers — don't move parsing into
-shared code. Three session states only: `working`, `waiting`, `ready` (no
-`cancelled`).
+shared code. Four session states only: `working`, `waiting`, `ready`, `error`
+(no `cancelled`) — read the vocabulary from `session.CanonicalStates()` rather
+than retyping it.
 
 **Swift (app).** Follow the
 [Swift API Design Guidelines](https://www.swift.org/documentation/api-design-guidelines/).

--- a/core/adapters/outbound/filesystem/concurrency_tracker_test.go
+++ b/core/adapters/outbound/filesystem/concurrency_tracker_test.go
@@ -492,6 +492,14 @@ func TestStateSeries_Empty(t *testing.T) {
 	if res.Peak != 0 || res.Average != 0 || res.Current != 0 {
 		t.Errorf("want zero summary, got peak=%v avg=%v current=%v", res.Peak, res.Average, res.Current)
 	}
+	// The states StateSeries actually declares buckets for. Deliberately NOT
+	// session.CanonicalStates(): the ByState map is a three-key literal in
+	// StateSeries and emptyStateSeriesResult, and #1798's fourth state is not
+	// in it — the Activity Matrix's own widening is #1801's, along with the
+	// web `toEqual({working,waiting,ready})` assertion that pins the same
+	// shape on the client. Reading the domain vocabulary here would make this
+	// test demand a key the production code does not yet emit, i.e. fail for
+	// a gap that is scoped elsewhere rather than for a regression.
 	for _, state := range []string{session.StateWorking, session.StateWaiting, session.StateReady} {
 		if len(res.ByState[state]) != 0 {
 			t.Errorf("by_state[%s] should be empty, got %v", state, res.ByState[state])

--- a/core/adapters/outbound/filesystem/repository.go
+++ b/core/adapters/outbound/filesystem/repository.go
@@ -154,12 +154,15 @@ func (r *SessionRepository) ListAll() ([]*session.SessionState, error) {
 			// os.Remove the file, which destroyed every such session
 			// irrecoverably on the first sweep.
 			//
-			// What a three-state build does with it, decided here: keep the
-			// file untouched and skip the session. Handing it downstream is
-			// not an option — grouping, the state counters and the state
-			// machine are all written against exactly working/waiting/ready,
-			// so an unknown value would surface as a mis-rendered session
-			// rather than an absent one.
+			// What a build that does not know the value does with it,
+			// decided here: keep the file untouched and skip the session.
+			// Handing it downstream is not an option — grouping, the state
+			// counters and the state machine are all written against the
+			// vocabulary this build compiled with, so an unknown value would
+			// surface as a mis-rendered session rather than an absent one.
+			// (#1798 widened that vocabulary to include "error"; the reasoning
+			// is unchanged and deliberately stated without a fixed arity, so
+			// the next state does not make this comment wrong.)
 			//
 			// Two consequences of skipping, stated rather than implied:
 			//   - PruneStale iterates ListAll, so these files are exempt from
@@ -195,9 +198,16 @@ func (r *SessionRepository) warnUnknownStateOnce(state, name string) {
 	if _, seen := r.warnedStates.LoadOrStore(state, struct{}{}); seen {
 		return
 	}
-	msg := fmt.Sprintf("session file %q has unrecognized state %q (this build knows only %s/%s/%s) "+
+	// The vocabulary is read from the domain, never retyped here. This line
+	// used to be a "%s/%s/%s" with three constants passed positionally — a
+	// second, hand-maintained copy of the state list that #1798's fourth state
+	// would have left asserting "this build knows only working/waiting/ready"
+	// while the build knew four. A log line whose whole job is telling a
+	// human which states this build understands is the last place that may
+	// drift from IsCanonicalState, so both now read canonicalStates.
+	msg := fmt.Sprintf("session file %q has unrecognized state %q (this build knows only %s) "+
 		"— keeping the file on disk and skipping the session",
-		name, state, session.StateWorking, session.StateWaiting, session.StateReady)
+		name, state, strings.Join(session.CanonicalStates(), "/"))
 	if r.logger != nil {
 		r.logger.LogError("session_state_unrecognized", "", msg)
 		return

--- a/core/adapters/outbound/filesystem/repository_vocabulary_test.go
+++ b/core/adapters/outbound/filesystem/repository_vocabulary_test.go
@@ -1,22 +1,13 @@
-package filesystem
+package filesystem_test
 
 import (
-	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 
+	"irrlicht/core/adapters/outbound/filesystem"
 	"irrlicht/core/domain/session"
+	"irrlicht/core/internal/contracttesting"
 )
-
-// vocabRecorder captures the unrecognized-state warning so the test can read
-// the message the daemon would actually log.
-type vocabRecorder struct{ msgs []string }
-
-func (r *vocabRecorder) LogInfo(_, _, _ string)                                  {}
-func (r *vocabRecorder) LogError(_, _, msg string)                               { r.msgs = append(r.msgs, msg) }
-func (r *vocabRecorder) LogProcessingTime(_, _ string, _ int64, _ int, _ string) {}
-func (r *vocabRecorder) Close() error                                            { return nil }
 
 // warnOnUnknownState drives ListAll past one session file holding a state this
 // build does not know, and returns the single warning it produced.
@@ -28,15 +19,12 @@ func (r *vocabRecorder) Close() error                                           
 func warnOnUnknownState(t *testing.T) string {
 	t.Helper()
 
-	instances := t.TempDir()
-	const junk = `{"version":1,"session_id":"s1","state":"zzz-not-a-state"}`
-	if err := os.WriteFile(filepath.Join(instances, "s1.json"), []byte(junk), 0o644); err != nil {
-		t.Fatalf("write: %v", err)
-	}
+	dir := t.TempDir()
+	writeRawStateFile(t, dir, "s1.json", "zzz-not-a-state")
 
-	rec := &vocabRecorder{}
-	repo := NewWithDir(instances)
-	repo.SetLogger(rec)
+	logger := &contracttesting.RecordingLogger{}
+	repo := filesystem.NewWithDir(dir)
+	repo.SetLogger(logger)
 
 	states, err := repo.ListAll()
 	if err != nil {
@@ -45,53 +33,39 @@ func warnOnUnknownState(t *testing.T) string {
 	if len(states) != 0 {
 		t.Fatalf("precondition: the unknown-state session must be skipped, got %d", len(states))
 	}
-	if len(rec.msgs) != 1 {
+	errs := logger.Errors()
+	if len(errs) != 1 {
 		t.Fatalf("precondition: expected exactly one warning, got %d (%v) — "+
 			"the assertions below read the message, so no warning means they check nothing",
-			len(rec.msgs), rec.msgs)
+			len(errs), errs)
 	}
-	return rec.msgs[0]
+	// The channel matters as much as the text: this is the tag a human greps
+	// for, and RecordingLogger exposes it precisely so a test can assert it.
+	if got := logger.EventTypes()[0]; got != "session_state_unrecognized" {
+		t.Errorf("warning filed under event type %q, want session_state_unrecognized", got)
+	}
+	return errs[0]
 }
 
-// TestWarnUnknownState_NamesEveryCanonicalState is the #1798 carry-forward
-// finding from #1797's QA, as a test.
+// TestWarnUnknownState_ListsExactlyTheCanonicalVocabulary is the #1798
+// carry-forward finding from #1797's QA, as a test.
 //
-// warnUnknownStateOnce used to build its message from a hand-typed
-// "%s/%s/%s" with three constants passed positionally. That is a second,
-// hand-maintained copy of the state vocabulary: adding a fourth state left the
-// message asserting "this build knows only working/waiting/ready" while the
-// build in fact knew four — a log line lying about the one thing it exists to
-// report, to whoever is debugging a mixed-version install.
+// warnUnknownStateOnce used to build its message from a hand-typed "%s/%s/%s"
+// with three constants passed positionally. That is a second, hand-maintained
+// copy of the state vocabulary: adding a fourth state left the message
+// asserting "this build knows only working/waiting/ready" while the build in
+// fact knew four — a log line lying about the one thing it exists to report,
+// to whoever is debugging a mixed-version install.
 //
-// The fix derives the list from session.CanonicalStates(), so this test is
-// written against the VOCABULARY rather than against any particular spelling:
-// it passes for three states, four, or five, and fails only when the message
-// and the predicate disagree. That is the property, and it is why the
-// assertion does not hardcode the expected sentence.
-func TestWarnUnknownState_NamesEveryCanonicalState(t *testing.T) {
+// The assertion is on the VOCABULARY rather than on any particular spelling,
+// so it passes for three states, four, or five, and fails only when the message
+// and session.CanonicalStates() disagree. Comparing the joined run in one shot
+// is deliberately stronger than checking each state is present somewhere: a
+// message built from a stale hardcoded list that happened to be a SUPERSET
+// would satisfy a per-element check and fail this one.
+func TestWarnUnknownState_ListsExactlyTheCanonicalVocabulary(t *testing.T) {
 	msg := warnOnUnknownState(t)
 
-	for _, state := range session.CanonicalStates() {
-		if !strings.Contains(msg, state) {
-			t.Errorf("warning omits canonical state %q — the message carries a hand-copied\n"+
-				"vocabulary that has drifted from IsCanonicalState.\nmessage: %s", state, msg)
-		}
-	}
-}
-
-// TestWarnUnknownState_ClaimsNoStateItDoesNotKnow is the other half, and the
-// half a "does it contain every state" check cannot catch on its own: a
-// message built by concatenating a stale hardcoded list would still contain
-// every canonical state if the list were merely a SUPERSET.
-//
-// It pins the count of listed states rather than the prose, so the two
-// assertions together say "the message lists exactly the vocabulary" without
-// freezing a sentence that a future edit may legitimately reword.
-func TestWarnUnknownState_ClaimsNoStateItDoesNotKnow(t *testing.T) {
-	msg := warnOnUnknownState(t)
-
-	// The vocabulary is rendered as a single slash-joined run; find it and
-	// compare it element-wise against the domain's own list.
 	want := strings.Join(session.CanonicalStates(), "/")
 	if !strings.Contains(msg, want) {
 		t.Errorf("warning does not carry the vocabulary verbatim as %q — it was built from a\n"+

--- a/core/adapters/outbound/filesystem/repository_vocabulary_test.go
+++ b/core/adapters/outbound/filesystem/repository_vocabulary_test.go
@@ -1,0 +1,100 @@
+package filesystem
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"irrlicht/core/domain/session"
+)
+
+// vocabRecorder captures the unrecognized-state warning so the test can read
+// the message the daemon would actually log.
+type vocabRecorder struct{ msgs []string }
+
+func (r *vocabRecorder) LogInfo(_, _, _ string)                                  {}
+func (r *vocabRecorder) LogError(_, _, msg string)                               { r.msgs = append(r.msgs, msg) }
+func (r *vocabRecorder) LogProcessingTime(_, _ string, _ int64, _ int, _ string) {}
+func (r *vocabRecorder) Close() error                                            { return nil }
+
+// warnOnUnknownState drives ListAll past one session file holding a state this
+// build does not know, and returns the single warning it produced.
+//
+// It asserts the warning was actually emitted rather than returning an empty
+// string on failure: absence of a finding and inability to look must not
+// produce the same output, and every assertion below is on the message's
+// CONTENT — so a silent no-warning path would make them all vacuously pass.
+func warnOnUnknownState(t *testing.T) string {
+	t.Helper()
+
+	instances := t.TempDir()
+	const junk = `{"version":1,"session_id":"s1","state":"zzz-not-a-state"}`
+	if err := os.WriteFile(filepath.Join(instances, "s1.json"), []byte(junk), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	rec := &vocabRecorder{}
+	repo := NewWithDir(instances)
+	repo.SetLogger(rec)
+
+	states, err := repo.ListAll()
+	if err != nil {
+		t.Fatalf("ListAll: %v", err)
+	}
+	if len(states) != 0 {
+		t.Fatalf("precondition: the unknown-state session must be skipped, got %d", len(states))
+	}
+	if len(rec.msgs) != 1 {
+		t.Fatalf("precondition: expected exactly one warning, got %d (%v) — "+
+			"the assertions below read the message, so no warning means they check nothing",
+			len(rec.msgs), rec.msgs)
+	}
+	return rec.msgs[0]
+}
+
+// TestWarnUnknownState_NamesEveryCanonicalState is the #1798 carry-forward
+// finding from #1797's QA, as a test.
+//
+// warnUnknownStateOnce used to build its message from a hand-typed
+// "%s/%s/%s" with three constants passed positionally. That is a second,
+// hand-maintained copy of the state vocabulary: adding a fourth state left the
+// message asserting "this build knows only working/waiting/ready" while the
+// build in fact knew four — a log line lying about the one thing it exists to
+// report, to whoever is debugging a mixed-version install.
+//
+// The fix derives the list from session.CanonicalStates(), so this test is
+// written against the VOCABULARY rather than against any particular spelling:
+// it passes for three states, four, or five, and fails only when the message
+// and the predicate disagree. That is the property, and it is why the
+// assertion does not hardcode the expected sentence.
+func TestWarnUnknownState_NamesEveryCanonicalState(t *testing.T) {
+	msg := warnOnUnknownState(t)
+
+	for _, state := range session.CanonicalStates() {
+		if !strings.Contains(msg, state) {
+			t.Errorf("warning omits canonical state %q — the message carries a hand-copied\n"+
+				"vocabulary that has drifted from IsCanonicalState.\nmessage: %s", state, msg)
+		}
+	}
+}
+
+// TestWarnUnknownState_ClaimsNoStateItDoesNotKnow is the other half, and the
+// half a "does it contain every state" check cannot catch on its own: a
+// message built by concatenating a stale hardcoded list would still contain
+// every canonical state if the list were merely a SUPERSET.
+//
+// It pins the count of listed states rather than the prose, so the two
+// assertions together say "the message lists exactly the vocabulary" without
+// freezing a sentence that a future edit may legitimately reword.
+func TestWarnUnknownState_ClaimsNoStateItDoesNotKnow(t *testing.T) {
+	msg := warnOnUnknownState(t)
+
+	// The vocabulary is rendered as a single slash-joined run; find it and
+	// compare it element-wise against the domain's own list.
+	want := strings.Join(session.CanonicalStates(), "/")
+	if !strings.Contains(msg, want) {
+		t.Errorf("warning does not carry the vocabulary verbatim as %q — it was built from a\n"+
+			"hand-maintained list rather than session.CanonicalStates().\nmessage: %s", want, msg)
+	}
+}

--- a/core/application/replayengine/engine.go
+++ b/core/application/replayengine/engine.go
@@ -272,8 +272,8 @@ func (r *replayer) recordMetricsSnapshot(virtTime time.Time, metrics *tailer.Ses
 	r.result.MetricsTimeline = append(r.result.MetricsTimeline, MetricsSnapshot{
 		VirtualTime:      virtTime,
 		Metrics:          TailerToDomain(metrics),
-		TaskEstimate:     copyTailerTaskEstimate(metrics.TaskEstimate),
-		TaskEstimateBase: copyTailerTaskEstimate(metrics.TaskEstimateBase),
+		TaskEstimate:     copyPtr(metrics.TaskEstimate),
+		TaskEstimateBase: copyPtr(metrics.TaskEstimateBase),
 	})
 }
 

--- a/core/application/replayengine/engine_test.go
+++ b/core/application/replayengine/engine_test.go
@@ -81,6 +81,13 @@ func TestReplayTranscript_producesWaitingFromQuestion(t *testing.T) {
 		t.Errorf("first transition = %+v; want init→ready", got)
 	}
 
+	// "At least one of each was observed", not an exhaustive sweep of the
+	// state universe — so #1798's fourth state is inert here by design. It is
+	// worth saying which of the two this is: the switch has no default, and a
+	// reader could mistake the missing arm for an oversight. A replay of a
+	// healthy fixture must NOT produce an error transition, and the
+	// sawError-style assertion belongs with the error fixtures #1803 records,
+	// not here.
 	var sawWaiting, sawWorking bool
 	var prevTime = res.Transitions[0].VirtualTime
 	for i, tr := range res.Transitions {

--- a/core/application/replayengine/metrics.go
+++ b/core/application/replayengine/metrics.go
@@ -1,6 +1,8 @@
 package replayengine
 
 import (
+	"time"
+
 	"irrlicht/core/domain/session"
 	"irrlicht/core/pkg/tailer"
 	"irrlicht/core/ports/outbound"
@@ -98,6 +100,46 @@ func convertTasks(in []tailer.Task) []session.Task {
 	return out
 }
 
+// convertSessionError maps the tailer's session-error mirror onto the domain
+// type (#1798). Nil in, nil out — a healthy session has no error, and that
+// must stay distinguishable from a zero-valued one.
+//
+// The pointer fields are DEEP-COPIED rather than aliased. The tailer keeps its
+// sticky error across passes, so aliasing would hand the domain a pointer into
+// live tailer state that a later pass can mutate underneath a session snapshot
+// already handed to the API — the same aliasing class as the mockRepo race
+// that produced the recurring services -race flakes.
+func convertSessionError(e *tailer.SessionError) *session.SessionError {
+	if e == nil {
+		return nil
+	}
+	return &session.SessionError{
+		Phase:       session.ErrorPhase(e.Phase),
+		Class:       e.Class,
+		Message:     e.Message,
+		HTTPStatus:  copyIntPtr(e.HTTPStatus),
+		Attempt:     copyIntPtr(e.Attempt),
+		MaxAttempts: copyIntPtr(e.MaxAttempts),
+		RetryIn:     copyDurationPtr(e.RetryIn),
+	}
+}
+
+func copyIntPtr(v *int) *int {
+	if v == nil {
+		return nil
+	}
+	c := *v
+	return &c
+}
+
+func copyDurationPtr(v *time.Duration) *time.Duration {
+	if v == nil {
+		return nil
+	}
+	c := *v
+	return &c
+}
+
 // Convert maps the tailer's metrics struct into the domain type consumed by
 // services.ClassifyState.
 func (mc *MetricsConverter) Convert(m *tailer.SessionMetrics) *session.SessionMetrics {
@@ -142,6 +184,7 @@ func (mc *MetricsConverter) Convert(m *tailer.SessionMetrics) *session.SessionMe
 		SubagentCompletions:               convertSubagentCompletions(m.SubagentCompletions),
 		AppliedTaskDeltas:                 convertAppliedTaskDeltas(m.AppliedTaskDeltas),
 		Tasks:                             convertTasks(m.Tasks),
+		SessionError:                      convertSessionError(m.SessionError),
 	}
 	// Task summary (issue #738): the agent's in-band marker wins; the first
 	// user message is the heuristic fallback for agents that emit none. Both

--- a/core/application/replayengine/metrics.go
+++ b/core/application/replayengine/metrics.go
@@ -122,10 +122,14 @@ func convertSessionError(e *tailer.SessionError) *session.SessionError {
 	}
 }
 
-// copyPtr returns a fresh pointer to the same value, or nil for nil. One
-// generic helper rather than one per pointed-to type, so a field added to
-// SessionError with a new numeric type does not need another near-identical
-// copy of it — the same reasoning as session.eqPtr.
+// copyPtr returns a fresh pointer to the same value, or nil for nil.
+//
+// One generic helper rather than one per pointed-to type: this replaced two
+// SessionError-specific copiers and copyTailerTaskEstimate (#753), which were
+// three token-identical bodies in this one file. Shallow by design — a struct
+// it copies may hold pointers of its own, and every caller so far wants
+// exactly that (tailer.TaskEstimate's Confidence pointer is read-only once
+// parsed, which is why sharing it was already safe).
 func copyPtr[T any](v *T) *T {
 	if v == nil {
 		return nil
@@ -245,18 +249,6 @@ func (mc *MetricsConverter) questionHeadline(source string, markerAuthored bool,
 		return q
 	}
 	return mc.compact(topic+": "+q, outbound.CompactQuestionVerbatim)
-}
-
-// copyTailerTaskEstimate copies a tailer task estimate struct so a timeline
-// snapshot never aliases the tailer's mutable cumulative state (#753). Not a
-// deep clone — the Confidence pointer is shared, which is safe: it's read-only
-// once parsed.
-func copyTailerTaskEstimate(e *tailer.TaskEstimate) *tailer.TaskEstimate {
-	if e == nil {
-		return nil
-	}
-	c := *e
-	return &c
 }
 
 func copyStrings(s []string) []string {

--- a/core/application/replayengine/metrics.go
+++ b/core/application/replayengine/metrics.go
@@ -1,8 +1,6 @@
 package replayengine
 
 import (
-	"time"
-
 	"irrlicht/core/domain/session"
 	"irrlicht/core/pkg/tailer"
 	"irrlicht/core/ports/outbound"
@@ -117,22 +115,18 @@ func convertSessionError(e *tailer.SessionError) *session.SessionError {
 		Phase:       session.ErrorPhase(e.Phase),
 		Class:       e.Class,
 		Message:     e.Message,
-		HTTPStatus:  copyIntPtr(e.HTTPStatus),
-		Attempt:     copyIntPtr(e.Attempt),
-		MaxAttempts: copyIntPtr(e.MaxAttempts),
-		RetryIn:     copyDurationPtr(e.RetryIn),
+		HTTPStatus:  copyPtr(e.HTTPStatus),
+		Attempt:     copyPtr(e.Attempt),
+		MaxAttempts: copyPtr(e.MaxAttempts),
+		RetryIn:     copyPtr(e.RetryIn),
 	}
 }
 
-func copyIntPtr(v *int) *int {
-	if v == nil {
-		return nil
-	}
-	c := *v
-	return &c
-}
-
-func copyDurationPtr(v *time.Duration) *time.Duration {
+// copyPtr returns a fresh pointer to the same value, or nil for nil. One
+// generic helper rather than one per pointed-to type, so a field added to
+// SessionError with a new numeric type does not need another near-identical
+// copy of it — the same reasoning as session.eqPtr.
+func copyPtr[T any](v *T) *T {
 	if v == nil {
 		return nil
 	}

--- a/core/application/replayengine/session_error_convert_test.go
+++ b/core/application/replayengine/session_error_convert_test.go
@@ -1,0 +1,81 @@
+package replayengine
+
+import (
+	"testing"
+	"time"
+
+	"irrlicht/core/pkg/tailer"
+)
+
+// TestConvertSessionError_DeepCopiesPointerFields is the mutation fixture for
+// convertSessionError's deep copy.
+//
+// The copy is a guard the change added, so per AGENTS.md it owes a mutation
+// seen red rather than a comment asserting it matters. Replacing the four
+// copyIntPtr/copyDurationPtr calls with plain aliasing left the suite green,
+// which meant nothing checked it.
+//
+// It is not theoretical. The tailer keeps its SessionError sticky ACROSS
+// passes, so an aliased pointer hands the domain a window into live tailer
+// state that a later pass can rewrite underneath a session snapshot already
+// handed to the API — the same aliasing class as the mockRepo race behind the
+// recurring services -race flakes.
+func TestConvertSessionError_DeepCopiesPointerFields(t *testing.T) {
+	status, attempt, max := 429, 1, 10
+	delay := 616 * time.Millisecond
+	src := &tailer.SessionError{
+		Phase:       tailer.ErrorPhaseRetrying,
+		Class:       "rate_limit",
+		Message:     "slow down",
+		HTTPStatus:  &status,
+		Attempt:     &attempt,
+		MaxAttempts: &max,
+		RetryIn:     &delay,
+	}
+
+	got := convertSessionError(src)
+	if got == nil {
+		t.Fatal("conversion returned nil for a non-nil error")
+	}
+
+	// The next tailer pass climbs the retry ladder, in place.
+	status, attempt, max = 503, 7, 20
+	delay = 9 * time.Second
+
+	if *got.HTTPStatus != 429 || *got.Attempt != 1 || *got.MaxAttempts != 10 {
+		t.Errorf("converted error aliases the tailer's memory: status=%d attempt=%d max=%d, "+
+			"want 429/1/10 — a later pass mutated a snapshot already converted",
+			*got.HTTPStatus, *got.Attempt, *got.MaxAttempts)
+	}
+	if *got.RetryIn != 616*time.Millisecond {
+		t.Errorf("RetryIn aliases the tailer's memory: %v, want 616ms", *got.RetryIn)
+	}
+}
+
+// TestConvertSessionError_NilInNilOut pins that a healthy session stays
+// distinguishable from one carrying a zero-valued error.
+func TestConvertSessionError_NilInNilOut(t *testing.T) {
+	if got := convertSessionError(nil); got != nil {
+		t.Errorf("nil must convert to nil, got %+v", got)
+	}
+}
+
+// TestConvertSessionError_AbsentFieldsStayNil is the terminal shape: no
+// status, no counters, no delay. They must arrive in the domain as nil, not as
+// pointers to zero, or a consumer would render "attempt 0 of 0".
+func TestConvertSessionError_AbsentFieldsStayNil(t *testing.T) {
+	got := convertSessionError(&tailer.SessionError{
+		Phase:   tailer.ErrorPhaseTerminal,
+		Class:   "provider",
+		Message: "API Error: API returned an empty or malformed response (HTTP 200)",
+	})
+	if got == nil {
+		t.Fatal("conversion returned nil for a non-nil error")
+	}
+	if got.HTTPStatus != nil || got.Attempt != nil || got.MaxAttempts != nil || got.RetryIn != nil {
+		t.Errorf("absent numbers must stay nil through the conversion, got %+v", got)
+	}
+	if got.Phase.Known() != true {
+		t.Error("a terminal phase must survive the conversion as a known phase")
+	}
+}

--- a/core/application/services/history_tracker.go
+++ b/core/application/services/history_tracker.go
@@ -38,6 +38,22 @@ func validGranularity(sec int) bool {
 	return false
 }
 
+// statePriority maps a lifecycle state onto the 2-bit code the history bar
+// transports.
+//
+// session.StateError (#1798) HAS NO CODE and falls through to
+// statePriorityReady — an errored bucket paints GREEN on the sparkline, which
+// is precisely the silent-green failure the fourth state exists to remove.
+// That is a known, accepted gap, not an oversight: all four codes of the
+// 2-bit field are already taken (ready/working/waiting/no-data), so carrying a
+// fifth value is a wire-format change across Go, Swift and JS. #1796 cut it
+// from the epic's delivery path for that reason and filed it as #1805/#1807,
+// where this — a red session showing green in its own history — is the
+// concrete symptom to fix rather than "widen the encoding".
+//
+// Deliberately left as `default` rather than an explicit `case StateError`:
+// spelling it out would read as a considered mapping of error onto ready,
+// which it is not.
 func statePriority(s string) int {
 	switch s {
 	case session.StateWaiting:

--- a/core/application/services/session_detector.go
+++ b/core/application/services/session_detector.go
@@ -585,7 +585,7 @@ func classifierInputs(m *session.SessionMetrics) *lifecycle.ClassifierInputs {
 	if m == nil {
 		return nil
 	}
-	return &lifecycle.ClassifierInputs{
+	in := &lifecycle.ClassifierInputs{
 		HasLiveBackgroundProcess:          m.HasLiveBackgroundProcess,
 		PermissionPending:                 m.PermissionPending,
 		CompactInProgress:                 m.CompactInProgress,
@@ -601,6 +601,15 @@ func classifierInputs(m *session.SessionMetrics) *lifecycle.ClassifierInputs {
 		HookTurnDone:                      m.HookTurnDone,
 		IdlePromptPending:                 m.IdlePromptPending,
 	}
+	// #1798: the two facts that make an error transition debuggable from a
+	// recording. Guarded rather than unconditional so a healthy session's
+	// snapshot is byte-identical to what it was before this field existed —
+	// both are omitempty, so a nil error adds nothing to any sidecar.
+	if m.SessionError != nil {
+		in.SessionErrorClass = m.SessionError.Class
+		in.SessionErrorPhase = string(m.SessionError.Phase)
+	}
+	return in
 }
 
 // withProvenance stamps the deciding rule and tier onto a classifier-inputs

--- a/core/application/services/session_detector_activity.go
+++ b/core/application/services/session_detector_activity.go
@@ -1831,7 +1831,19 @@ func (d *SessionDetector) refreshStaleSessions() {
 		switch state.State {
 		case session.StateWorking:
 			d.reclassifyFromTranscript(state, now)
-		case session.StateWaiting, session.StateReady:
+		// #1798: StateError joins the idle arm rather than falling through to
+		// no arm at all. "Idle" here means "not working", and an errored
+		// session is exactly that — it is also, by construction, a session
+		// that has stopped producing transcript activity, so nothing else will
+		// ever bring it back for another look.
+		//
+		// This is load-bearing, not tidiness. shouldRevisitIdleSession is what
+		// asks signals.HasAny, and a classify pass is the ONLY thing that
+		// evaluates a hold's ceiling — so leaving error out of this switch
+		// made sessionErrorHoldTimeout unreachable: a declared ceiling that
+		// could never fire, which is worse than no ceiling because it reads
+		// like a safety net in the policy table.
+		case session.StateWaiting, session.StateReady, session.StateError:
 			d.retryIdleProjectResolution(state, now)
 
 			// Only when something outstanding could make a full pass decide

--- a/core/application/services/session_detector_activity.go
+++ b/core/application/services/session_detector_activity.go
@@ -1276,6 +1276,25 @@ func (d *SessionDetector) applyStateTransition(state *session.SessionState, ev a
 		// Stamp HEAD + yield verdict on the turn-done → ready edge so the
 		// yield sweep can correlate reverts back to it (#373).
 		d.enricher.CaptureYieldOnReady(state)
+	case session.StateError:
+		// #1798, audited deliberately rather than left to the zero case:
+		//
+		//   - WaitingStartTime is NOT set. It measures how long a human has
+		//     been kept waiting on a prompt, and drives the waiting-duration
+		//     display; an errored session is not blocked on the user, so
+		//     starting that clock would report a fabricated wait.
+		//   - WaitingStartTime is NOT cleared either. error is reachable from
+		//     waiting (a session blocked on a prompt whose next call fails),
+		//     and the settled clearing rule sends it back through working or
+		//     ready — both of which own the field above. Clearing it here
+		//     would lose a real, still-running wait on a round trip the user
+		//     never participated in.
+		//   - CaptureYieldOnReady is NOT called. The yield verdict answers
+		//     "did this session's work survive in the repo", which is a
+		//     question about a FINISHED session; a failed turn has not
+		//     finished, and the next successful one will reach ready and
+		//     stamp it then. Stamping here would also record a HEAD for a
+		//     turn that produced nothing.
 	}
 }
 

--- a/core/application/services/session_detector_lifecycle.go
+++ b/core/application/services/session_detector_lifecycle.go
@@ -551,12 +551,19 @@ func (d *SessionDetector) seedReevaluateOne(state *session.SessionState) {
 	// #1798: error is deliberately NOT added to the exclusion. The filter
 	// exists to stop a persisted session being promoted to working on no
 	// evidence — "working" is a claim that something is happening right now,
-	// and at boot nothing is. error is the opposite kind of claim: it is
-	// re-derived from SessionError, which is persisted in the session JSON, so
-	// a session that failed before the daemon restarted still has its failure
-	// on disk and should still read red rather than come back green. Blocking
-	// it here would make a restart quietly clear every error — the silent
-	// direction, and the one the fourth state exists to eliminate.
+	// and at boot nothing is. An error is the opposite kind of claim: it
+	// describes something that already happened, so re-asserting it at boot is
+	// sound in a way re-asserting "working" is not.
+	//
+	// It does not actually fire today, and that is a known gap rather than a
+	// contradiction of the above. RefreshMetrics ran a few lines up, and it
+	// merges against a fresh tailer pass whose SessionError is nil — the tailer
+	// does not persist its sticky error — so the persisted value is gone before
+	// ClassifyState reads it and this path sees a healthy session. The fix is
+	// LedgerState persistence in the tailer, deferred to #1800; see
+	// SessionMetrics.SessionError for the full account. The filter is written
+	// to accept error now so that landing the persistence is a one-file change
+	// rather than also having to notice this line.
 	newState, reason := ClassifyState(state.State, state.Metrics)
 	if newState != state.State && newState != session.StateWorking {
 		if reason != "" {

--- a/core/application/services/session_detector_lifecycle.go
+++ b/core/application/services/session_detector_lifecycle.go
@@ -547,6 +547,16 @@ func (d *SessionDetector) seedReevaluateOne(state *session.SessionState) {
 	// Only apply transitions to waiting or ready (not working promotion)
 	// because seed is re-evaluating persisted state, not responding to
 	// new activity.
+	//
+	// #1798: error is deliberately NOT added to the exclusion. The filter
+	// exists to stop a persisted session being promoted to working on no
+	// evidence — "working" is a claim that something is happening right now,
+	// and at boot nothing is. error is the opposite kind of claim: it is
+	// re-derived from SessionError, which is persisted in the session JSON, so
+	// a session that failed before the daemon restarted still has its failure
+	// on disk and should still read red rather than come back green. Blocking
+	// it here would make a restart quietly clear every error — the silent
+	// direction, and the one the fourth state exists to eliminate.
 	newState, reason := ClassifyState(state.State, state.Metrics)
 	if newState != state.State && newState != session.StateWorking {
 		if reason != "" {

--- a/core/application/services/state_classifier.go
+++ b/core/application/services/state_classifier.go
@@ -194,6 +194,50 @@ var stateRules = []stateRule{
 		decide: toState(session.StateWaiting, "idle prompt hook → waiting"),
 	},
 	{
+		// The session's own machinery failed — provider refusal, rejected
+		// credentials, an aborted turn (#1798) → error.
+		//
+		// WHY HERE, ABOVE agent_done. A give-up and a completed turn look the
+		// same from the transcript tail: claudecode records a terminal API
+		// failure as an ordinary assistant message carrying an
+		// `isApiErrorMessage` flag and a terminal stop_reason, so IsAgentDone
+		// reads true and agent_done would route it to ready — a session that
+		// failed, reported as finished, painted green. That is the exact
+		// defect the fourth state exists to fix, so the failure verdict has to
+		// outrank the finished-turn verdict. Below the five waiting rules
+		// above, because a session blocked on a human is actionable now while
+		// a past failure is not, and because those rules include hook-tier
+		// rows a transcript-tier rule must never preempt.
+		//
+		// WHY THE HookTurnDone GUARD, rather than a bare nil check. It is the
+		// settled clearing rule ("error → ready on turn_done") stated where
+		// the ladder can see it: an authoritative Stop hook means a turn
+		// completed, so the error is over and agent_done should have it. That
+		// also makes this rule and agent_done MUTUALLY EXCLUSIVE at
+		// TierHook — agent_done is hook-tier only when HookTurnDone, which is
+		// exactly the case this guard excludes — so a transcript-tier rule can
+		// never sit above a hook-tier one that would also have fired. The
+		// ladder stays tier-consistent BY CONSTRUCTION rather than by
+		// argument, and TestStateRules_LadderIsTierConsistent proves it
+		// against fixtures that hold both signals at once rather than taking
+		// this comment's word for it.
+		//
+		// The rule's other half — a turn boundary the TRANSCRIPT reported —
+		// never reaches here at all: the tailer clears its sticky error on
+		// that boundary, so SessionError is already nil. Order is why that
+		// half cannot live in this predicate; see clearSessionErrorOnRecovery.
+		//
+		// Tier resolves through the held signal, so #1800's process-death
+		// producer lands at TierProcess by declaring its own policy row rather
+		// than by editing this rule.
+		id:     string(session.SignalSessionError),
+		signal: session.SignalSessionError,
+		when: func(_ string, m *session.SessionMetrics) bool {
+			return m.SessionError != nil && !m.HookTurnDone
+		},
+		decide: toState(session.StateError, "session error → error"),
+	},
+	{
 		// Agent finished turn — check if waiting for user input first. A
 		// hook-delivered Stop (#1161, #1171) is authoritative here: IsAgentDone
 		// consults metrics.HookTurnDone ahead of the transcript-tail heuristic,

--- a/core/application/services/state_classifier.go
+++ b/core/application/services/state_classifier.go
@@ -209,27 +209,47 @@ var stateRules = []stateRule{
 		// a past failure is not, and because those rules include hook-tier
 		// rows a transcript-tier rule must never preempt.
 		//
-		// WHY THE HookTurnDone GUARD, rather than a bare nil check. It is the
-		// settled clearing rule ("error → ready on turn_done") stated where
-		// the ladder can see it: an authoritative Stop hook means a turn
-		// completed, so the error is over and agent_done should have it. That
-		// also makes this rule and agent_done MUTUALLY EXCLUSIVE at
-		// TierHook — agent_done is hook-tier only when HookTurnDone, which is
-		// exactly the case this guard excludes — so a transcript-tier rule can
-		// never sit above a hook-tier one that would also have fired. The
-		// ladder stays tier-consistent BY CONSTRUCTION rather than by
-		// argument, and TestStateRules_LadderIsTierConsistent proves it
-		// against fixtures that hold both signals at once rather than taking
-		// this comment's word for it.
+		// WHY THE HookTurnDone GUARD, rather than a bare nil check. An
+		// authoritative Stop hook means a turn completed, so the failure is
+		// over and agent_done should have the decision. It also makes this
+		// rule and agent_done MUTUALLY EXCLUSIVE at TierHook — agent_done is
+		// hook-tier only when HookTurnDone, which is exactly the case this
+		// guard excludes — so a transcript-tier rule can never sit above a
+		// hook-tier one that would also have fired. The ladder stays
+		// tier-consistent BY CONSTRUCTION, and
+		// TestStateRules_LadderIsTierConsistent proves it against fixtures
+		// that hold both signals at once rather than taking this comment's
+		// word for it.
+		//
+		// IT IS A ONE-PASS SUPPRESSION, NOT A CLEAR, and calling it the latter
+		// would be wrong in a way that matters. SignalTurnDone is
+		// consumeOnce, so HookTurnDone is true for exactly the pass that
+		// consumed it; the tailer's sticky error is untouched by the hook path
+		// (the transcript path places no hold at all). So a hook-triggered
+		// pass that lands BEFORE the transcript's own turn-boundary line
+		// flushes — which is precisely what the hook fast path exists to do —
+		// yields ready on that pass and error again on the next, i.e. a
+		// spurious error→ready→error pair in the UI and the recorded trace.
+		//
+		// Not fixed here, and unreachable in this phase: no adapter emits
+		// SessionError yet, so no session can be in this position until
+		// #1799/#1800. The fix belongs with the first producer — the hook path
+		// needs a way to clear the tailer's sticky error, mirroring
+		// TranscriptTailer.IngestRateLimit — because only the tailer owns that
+		// state. Recorded rather than left to be rediscovered.
 		//
 		// The rule's other half — a turn boundary the TRANSCRIPT reported —
 		// never reaches here at all: the tailer clears its sticky error on
 		// that boundary, so SessionError is already nil. Order is why that
 		// half cannot live in this predicate; see clearSessionErrorOnRecovery.
 		//
-		// Tier resolves through the held signal, so #1800's process-death
-		// producer lands at TierProcess by declaring its own policy row rather
-		// than by editing this rule.
+		// TIER IS PINNED TO TierTranscript by the `signal` field below, which
+		// resolves through TierOf. The PREDICATE is producer-agnostic, but the
+		// tier is not: #1800's process-death evidence is TierProcess (3), and
+		// routing it through this rule would record it as TierTranscript (5).
+		// Understating a tier never trips the ladder invariant, so that would
+		// be silent. #1800 therefore adds its own rule row — or gives this one
+		// a `tierOf` the way agent_done has one — rather than reusing this.
 		id:     string(session.SignalSessionError),
 		signal: session.SignalSessionError,
 		when: func(_ string, m *session.SessionMetrics) bool {
@@ -343,10 +363,20 @@ func classifyAgentDone(currentState string, metrics *session.SessionMetrics) (st
 	if metrics.IsWaitingForUserInput() {
 		return transitionTo(currentState, session.StateWaiting, "turn ended with question or cue → waiting")
 	}
-	if currentState == session.StateWorking || currentState == session.StateWaiting {
-		return session.StateReady, "agent finished turn → ready"
-	}
-	return currentState, ""
+	// #1798: this used to name the states it would promote FROM —
+	// `currentState == StateWorking || currentState == StateWaiting`, falling
+	// through to a no-op for anything else. That was a complete enumeration
+	// when there were three states (the only remainder was ready, which is
+	// already the target), and it silently became an incomplete one the moment
+	// a fourth arrived: a session in `error` fell into the no-op branch and
+	// could NEVER reach ready through this rule, so the settled clearing rule's
+	// hook half — "error → ready on turn_done" — was dead on arrival.
+	//
+	// transitionTo expresses the actual intent, "move to ready unless already
+	// there", without enumerating anything, so a fifth state cannot reintroduce
+	// the bug. Behaviour is identical for all three original states, including
+	// the empty reason from ready, so no replay golden moves.
+	return transitionTo(currentState, session.StateReady, "agent finished turn → ready")
 }
 
 // isUserInterruptReady reports whether the user_interrupt rule of ClassifyState applies: the

--- a/core/application/services/state_classifier_test.go
+++ b/core/application/services/state_classifier_test.go
@@ -712,3 +712,122 @@ func TestShouldSynthesizeCollapsedTurnBoundary(t *testing.T) {
 		})
 	}
 }
+
+// TestClassify_SessionErrorRoutesToError is the direct behavioural test of
+// #1798's rule: a session carrying an unrecovered failure classifies to
+// StateError, and one that does not carry one is unaffected.
+//
+// TestStateRules_LadderIsTierConsistent covers the rule's PLACEMENT as a
+// property; this covers its OUTCOME, which that test deliberately says
+// nothing about — it checks tier ordering, not which state won.
+func TestClassify_SessionErrorRoutesToError(t *testing.T) {
+	tests := []struct {
+		name    string
+		current string
+		metrics *session.SessionMetrics
+		want    string
+	}{
+		{
+			// The headline case: a terminal failure whose transcript tail
+			// reads exactly like a finished turn. Without the rule sitting
+			// above agent_done this is `ready` — a failed session painted
+			// green, which is the defect the fourth state exists to fix.
+			name:    "terminal error on a turn that looks finished → error, not ready",
+			current: session.StateWorking,
+			metrics: &session.SessionMetrics{
+				LastEventType: "turn_done",
+				SessionError:  &session.SessionError{Phase: session.ErrorPhaseTerminal, Class: "provider"},
+			},
+			want: session.StateError,
+		},
+		{
+			name:    "retry in progress → error",
+			current: session.StateWorking,
+			metrics: &session.SessionMetrics{
+				LastEventType: "assistant",
+				SessionError:  &session.SessionError{Phase: session.ErrorPhaseRetrying, Class: "rate_limit"},
+			},
+			want: session.StateError,
+		},
+		{
+			// A failure with no phase reported is still a failure. Real case:
+			// copilot's errorType "query" says nothing about retrying.
+			name:    "unknown phase is still an error",
+			current: session.StateReady,
+			metrics: &session.SessionMetrics{
+				LastEventType: "assistant",
+				SessionError:  &session.SessionError{Class: "query", Message: "could not connect"},
+			},
+			want: session.StateError,
+		},
+		{
+			// The settled clearing rule's hook half. A Stop hook is an
+			// authoritative turn boundary, so the turn completed and the
+			// failure is over — agent_done takes it.
+			name:    "hook-delivered turn done clears the error → ready",
+			current: session.StateError,
+			metrics: &session.SessionMetrics{
+				LastEventType: "assistant_message",
+				HookTurnDone:  true,
+				SessionError:  &session.SessionError{Phase: session.ErrorPhaseTerminal, Class: "provider"},
+			},
+			want: session.StateReady,
+		},
+		{
+			// An open permission prompt outranks a past failure: the session
+			// is blocked on a human right now, which is actionable, while the
+			// error is not.
+			name:    "an open permission prompt still outranks an error",
+			current: session.StateError,
+			metrics: &session.SessionMetrics{
+				LastEventType:     "assistant",
+				PermissionPending: true,
+				SessionError:      &session.SessionError{Phase: session.ErrorPhaseTerminal},
+			},
+			want: session.StateWaiting,
+		},
+		{
+			// The tailer cleared the error (the transcript half of the rule),
+			// so the ladder never sees one and the ordinary verdict stands.
+			name:    "no error → unchanged verdict",
+			current: session.StateWorking,
+			metrics: &session.SessionMetrics{LastEventType: "turn_done"},
+			want:    session.StateReady,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, _ := ClassifyState(tt.current, tt.metrics)
+			if got != tt.want {
+				t.Errorf("ClassifyState(%q) = %q, want %q", tt.current, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestClassify_SessionErrorIsAttributedToItsRule pins the provenance a
+// recorded trace needs: the verdict must name the session_error rule and its
+// tier, not merely land on the right state. Two rules could produce StateError
+// in future (#1800 adds a process-death producer at TierProcess), and a
+// recording has to say which one decided.
+func TestClassify_SessionErrorIsAttributedToItsRule(t *testing.T) {
+	v := ClassifyStateTiered(session.StateWorking, &session.SessionMetrics{
+		LastEventType: "turn_done",
+		SessionError:  &session.SessionError{Phase: session.ErrorPhaseTerminal, Class: "provider"},
+	})
+
+	if v.State != session.StateError {
+		t.Fatalf("state = %q, want error", v.State)
+	}
+	if v.Rule != string(session.SignalSessionError) {
+		t.Errorf("rule = %q, want %q", v.Rule, session.SignalSessionError)
+	}
+	if v.Tier != session.TierTranscript {
+		t.Errorf("tier = %v, want TierTranscript — a transcript-derived failure must not "+
+			"claim hook authority", v.Tier)
+	}
+	if v.Reason == "" {
+		t.Error("an error transition must carry a reason")
+	}
+}

--- a/core/application/services/state_classifier_tier_test.go
+++ b/core/application/services/state_classifier_tier_test.go
@@ -59,8 +59,21 @@ func TestClassify_HookOutranksTranscript(t *testing.T) {
 // a future change let the two co-occur, this test fails rather than the badge
 // silently regressing.
 func TestStateRules_LadderIsTierConsistent(t *testing.T) {
+	// Which rules actually decided something across the whole corpus. A
+	// property test that sweeps a corpus reports "no violations" identically
+	// whether the corpus covers the rule or cannot reach it at all, so the
+	// coverage is asserted below rather than assumed — the same reason this
+	// file's other helpers explain why their fixtures are REACHABLE.
+	won := map[string]bool{}
+
 	for _, base := range reachableMetricFixtures(t) {
-		for _, cur := range []string{session.StateWorking, session.StateWaiting, session.StateReady} {
+		// Every canonical state, read from the domain rather than retyped.
+		// This loop used to name the three states literally, which meant that
+		// #1798's fourth state would have left it compiling, passing, and
+		// silently no longer exhaustive — the ladder invariant would simply
+		// never have been checked for a session currently in error. Reading
+		// CanonicalStates makes a fifth state extend the corpus on its own.
+		for _, cur := range session.CanonicalStates() {
 			// Ask the real classifier who won, rather than re-walking the
 			// ladder here: a private copy of the walk would keep passing if
 			// ClassifyStateTiered ever gained a guard the copy didn't, and the
@@ -70,6 +83,7 @@ func TestStateRules_LadderIsTierConsistent(t *testing.T) {
 			if winnerIdx < 0 {
 				t.Fatalf("%s: no rule fired — the ladder must be total", base.name)
 			}
+			won[winner.Rule] = true
 
 			for i := winnerIdx + 1; i < len(stateRules); i++ {
 				if stateRules[i].when != nil && !stateRules[i].when(cur, base.metrics) {
@@ -81,6 +95,19 @@ func TestStateRules_LadderIsTierConsistent(t *testing.T) {
 				}
 			}
 		}
+	}
+
+	// The corpus must actually reach the session_error rule (#1798). Without
+	// this, deleting the error fixtures — or a future guard that makes them
+	// unreachable — would leave this test passing while the one rule whose
+	// placement is genuinely contentious went unchecked. It is asserted for
+	// this rule specifically rather than for all nine because the other eight
+	// predate the corpus and are covered by named tests of their own.
+	if !won[string(session.SignalSessionError)] {
+		t.Errorf("no fixture reached the %q rule — the ladder-consistency sweep above therefore\n"+
+			"proved nothing about it. Restore the session-error fixtures in\n"+
+			"reachableMetricFixtures, or fix whatever now shadows the rule.",
+			session.SignalSessionError)
 	}
 }
 
@@ -124,6 +151,37 @@ func reachableMetricFixtures(t *testing.T) []metricFixture {
 			LastEventType: "turn_done", HasLiveBackgroundProcess: true,
 		}},
 		{"compacting", &session.SessionMetrics{LastEventType: "assistant", CompactInProgress: true}},
+		// #1798. Three transcript shapes carrying a session-level failure,
+		// crossed below with every hold set — including turn-done, which is
+		// the pair that matters. The session_error rule sits ABOVE agent_done
+		// and is transcript-tier, while agent_done becomes HOOK-tier the
+		// moment a Stop hook lands, so without these rows nothing would ever
+		// check that the two cannot contend. The rule's !HookTurnDone guard is
+		// what makes them exclusive; this corpus is what PROVES it rather than
+		// taking the guard's comment at its word.
+		//
+		// The error is set directly on the fixture rather than through a hold
+		// because the transcript path genuinely writes it that way — the
+		// tailer sets SessionMetrics.SessionError and places no hold, exactly
+		// as it does for TranscriptPermissionPending. The out-of-band path
+		// (SignalSessionError) is crossed in separately via the hold sets.
+		{"session-error-terminal", &session.SessionMetrics{
+			LastEventType: "assistant",
+			SessionError:  &session.SessionError{Phase: session.ErrorPhaseTerminal, Class: "provider"},
+		}},
+		{"session-error-retrying", &session.SessionMetrics{
+			LastEventType: "assistant",
+			SessionError:  &session.SessionError{Phase: session.ErrorPhaseRetrying, Class: "rate_limit"},
+		}},
+		// The dangerous one: a failure whose transcript tail ALSO reads as a
+		// finished turn. This is claudecode's real terminal shape — a
+		// synthetic assistant message with a terminal stop_reason — and it is
+		// the fixture on which agent_done would otherwise paint a failed
+		// session green.
+		{"session-error-on-finished-turn", &session.SessionMetrics{
+			LastEventType: "turn_done",
+			SessionError:  &session.SessionError{Phase: session.ErrorPhaseTerminal, Class: "provider"},
+		}},
 	}
 
 	holdSets := []struct {
@@ -148,10 +206,19 @@ func reachableMetricFixtures(t *testing.T) []metricFixture {
 		{"permission+stalled-edit", []session.SignalKind{
 			session.SignalPermissionPrompt, session.SignalOpenToolStalled,
 		}},
+		// #1798's out-of-band error path, and — the row that earns its place —
+		// that hold crossed with the Stop hook. session_error is transcript
+		// tier and sits above agent_done, which turns hook tier exactly when
+		// SignalTurnDone lands, so this is the combination that would catch
+		// an inversion.
+		{"session-error", []session.SignalKind{session.SignalSessionError}},
+		{"session-error+turn-done", []session.SignalKind{
+			session.SignalSessionError, session.SignalTurnDone,
+		}},
 		{"all", []session.SignalKind{
 			session.SignalPermissionPrompt, session.SignalTurnDone,
 			session.SignalIdlePrompt, session.SignalCompactInProgress,
-			session.SignalOpenToolStalled,
+			session.SignalOpenToolStalled, session.SignalSessionError,
 		}},
 	}
 
@@ -161,13 +228,34 @@ func reachableMetricFixtures(t *testing.T) []metricFixture {
 			m := *tr.metrics // copy: Overlay mutates
 			holds := session.NewSignalHolds()
 			for _, k := range hs.kinds {
-				holds.Hold("s", k, session.SignalPayload{}, armedAt(k))
+				holds.Hold("s", k, payloadFor(k), armedAt(k))
 			}
 			holds.Overlay("s", &m, holdT0)
 			out = append(out, metricFixture{name: tr.name + "/" + hs.name, metrics: &m})
 		}
 	}
 	return out
+}
+
+// payloadFor is the payload a hold of this kind must carry for its policy's
+// apply to do anything.
+//
+// Only SignalSessionError needs one here: its apply is a no-op on an empty
+// payload (there is no error to fold), so a corpus built with a bare
+// SignalPayload{} would place the hold, apply nothing, and produce fixtures
+// indistinguishable from "no error" — the property test would then report a
+// clean ladder having never once exercised the rule it was extended to cover.
+// SignalTurnDone's payload fields are optional by design and left empty.
+func payloadFor(kind session.SignalKind) session.SignalPayload {
+	if kind == session.SignalSessionError {
+		return session.SignalPayload{
+			SessionError: &session.SessionError{
+				Phase: session.ErrorPhaseTerminal,
+				Class: "provider",
+			},
+		}
+	}
+	return session.SignalPayload{}
 }
 
 // armedAt is when a hold of this kind must have been placed for the pass at

--- a/core/application/services/state_classifier_tier_test.go
+++ b/core/application/services/state_classifier_tier_test.go
@@ -85,15 +85,7 @@ func TestStateRules_LadderIsTierConsistent(t *testing.T) {
 			}
 			won[winner.Rule] = true
 
-			for i := winnerIdx + 1; i < len(stateRules); i++ {
-				if stateRules[i].when != nil && !stateRules[i].when(cur, base.metrics) {
-					continue
-				}
-				if lower := stateRules[i].tierFor(base.metrics); lower.Outranks(winner.Tier) {
-					t.Errorf("%s (current=%s): rule %q (tier %v) decided, but lower rule %q (tier %v) outranks it",
-						base.name, cur, winner.Rule, winner.Tier, stateRules[i].id, lower)
-				}
-			}
+			assertNoLowerRuleOutranks(t, base, cur, winner, winnerIdx)
 		}
 	}
 
@@ -108,6 +100,26 @@ func TestStateRules_LadderIsTierConsistent(t *testing.T) {
 			"proved nothing about it. Restore the session-error fixtures in\n"+
 			"reachableMetricFixtures, or fix whatever now shadows the rule.",
 			session.SignalSessionError)
+	}
+}
+
+// assertNoLowerRuleOutranks is the invariant itself: of the rules BELOW the
+// one that decided, none that would also have fired on these metrics may sit
+// on a strictly higher tier.
+//
+// Split out of the sweep above so the property is stated in one place at one
+// level of nesting, rather than as the innermost two branches of a triple
+// loop.
+func assertNoLowerRuleOutranks(t *testing.T, base metricFixture, cur string, winner StateVerdict, winnerIdx int) {
+	t.Helper()
+	for i := winnerIdx + 1; i < len(stateRules); i++ {
+		if stateRules[i].when != nil && !stateRules[i].when(cur, base.metrics) {
+			continue
+		}
+		if lower := stateRules[i].tierFor(base.metrics); lower.Outranks(winner.Tier) {
+			t.Errorf("%s (current=%s): rule %q (tier %v) decided, but lower rule %q (tier %v) outranks it",
+				base.name, cur, winner.Rule, winner.Tier, stateRules[i].id, lower)
+		}
 	}
 }
 
@@ -238,13 +250,18 @@ func reachableMetricFixtures(t *testing.T) []metricFixture {
 }
 
 // payloadFor is the payload a hold of this kind must carry for its policy's
-// apply to do anything.
+// apply to do anything. Only SignalSessionError needs one: its apply is a
+// no-op on an empty payload, since there is no error to fold.
 //
-// Only SignalSessionError needs one here: its apply is a no-op on an empty
-// payload (there is no error to fold), so a corpus built with a bare
-// SignalPayload{} would place the hold, apply nothing, and produce fixtures
-// indistinguishable from "no error" — the property test would then report a
-// clean ladder having never once exercised the rule it was extended to cover.
+// What it buys, stated accurately after review refuted a stronger claim: it
+// widens the corpus so the ladder sweep also covers metrics whose error
+// arrived through the HOLD rather than being set on the fixture directly.
+// Neutralizing it does NOT turn this file red — the three session-error
+// transcript fixtures set the field directly and satisfy the coverage
+// assertion on their own. The hold path's own behaviour is asserted where it
+// belongs, in session.TestSignalSessionError_HoldAppliesItsPayload, which does
+// go red when the policy row is broken.
+//
 // SignalTurnDone's payload fields are optional by design and left empty.
 func payloadFor(kind session.SignalKind) session.SignalPayload {
 	if kind == session.SignalSessionError {

--- a/core/cmd/irrlicht-ls/main.go
+++ b/core/cmd/irrlicht-ls/main.go
@@ -119,8 +119,15 @@ func validateFlags(format, state string) error {
 	if format != "text" && format != "json" {
 		return fmt.Errorf("unknown format %q (want text or json)", format)
 	}
-	if state != "" && state != session.StateWorking && state != session.StateWaiting && state != session.StateReady {
-		return fmt.Errorf("unknown state %q (want working, waiting or ready)", state)
+	// Both halves read the domain rather than restating it — a hand-rolled
+	// IsCanonicalState next to a hand-typed vocabulary in the message is the
+	// same two-part defect #1798 fixed in the filesystem repository's
+	// unrecognized-state warning, and this copy was missed the first time.
+	// Left as it was, `--state error` rejected a state the daemon emits and
+	// told the user the tool knew three.
+	if state != "" && !session.IsCanonicalState(state) {
+		return fmt.Errorf("unknown state %q (want %s)", state,
+			strings.Join(session.CanonicalStates(), ", "))
 	}
 	return nil
 }

--- a/core/domain/lifecycle/event.go
+++ b/core/domain/lifecycle/event.go
@@ -219,6 +219,29 @@ type ClassifierInputs struct {
 	HookTurnDone      bool `json:"hook_turn_done,omitempty"`
 	IdlePromptPending bool `json:"idle_prompt_pending,omitempty"`
 
+	// SessionErrorClass and SessionErrorPhase are the #1798 failure, reduced
+	// to the two facts a recorded trace needs: what kind of failure it was,
+	// and whether the agent was still retrying or had given up.
+	//
+	// The Reason string on an error transition is the fixed "session error →
+	// error", because reason prose is pinned byte-for-byte by the replay
+	// goldens and cannot carry per-session detail. So this is where a
+	// transition becomes debuggable: without it a recording shows a session
+	// going red and gives no way to tell a rate-limit retry storm from
+	// rejected credentials — which is precisely the question anyone opening
+	// the recording is there to answer.
+	//
+	// The human message is deliberately NOT copied here. It is unbounded,
+	// attacker-influenced (it is provider text), and already carried on the
+	// session's own metrics; duplicating it into every transition event would
+	// bloat each sidecar for no extra diagnostic power.
+	//
+	// An empty Phase means the agent reported a failure without saying
+	// whether another attempt follows — a real, recorded case (copilot's
+	// errorType "query"), not a gap in the plumbing.
+	SessionErrorClass string `json:"session_error_class,omitempty"`
+	SessionErrorPhase string `json:"session_error_phase,omitempty"`
+
 	// DecidedByTier is the authority tier of the evidence that decided this
 	// transition ("hook", "transcript", …) and DecidedByRule the id of the
 	// rule that claimed it. Together they are the provenance half of #1288:

--- a/core/domain/session/merge_session_error_test.go
+++ b/core/domain/session/merge_session_error_test.go
@@ -1,6 +1,11 @@
 package session
 
-import "testing"
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
 
 // TestMergeMetrics_CarriesSessionError is the #1256 trap, aimed at #1798's new
 // field.
@@ -104,5 +109,100 @@ func TestSessionError_AbsentNumbersStayAbsent(t *testing.T) {
 	}
 	if unknown.IsRetrying() {
 		t.Error("an unknown phase must not read as retrying")
+	}
+}
+
+// TestSessionError_RetryInSerializesWithItsUnitNamed is #1798's wire contract,
+// and the reason SessionError carries a custom marshaller at all.
+//
+// A bare `*time.Duration` marshals to unlabelled nanoseconds (616452004). The
+// JS and Swift clients that render this field (#1801, #1802) would have to
+// know both the unit and that this is the only field in the payload using it,
+// from nothing in the payload itself — while every other serialized time
+// quantity in this package names its unit in the key.
+func TestSessionError_RetryInSerializesWithItsUnitNamed(t *testing.T) {
+	d := 616452004 * time.Nanosecond // the real recorded 616.452004ms
+	b, err := json.Marshal(&SessionError{
+		Phase:   ErrorPhaseRetrying,
+		Class:   "rate_limit",
+		RetryIn: &d,
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	got := string(b)
+
+	if !strings.Contains(got, `"retry_in_ms"`) {
+		t.Errorf("payload does not name the unit — a consumer cannot tell what the number means.\ngot: %s", got)
+	}
+	if strings.Contains(got, "616452004") {
+		t.Errorf("payload carries raw nanoseconds.\ngot: %s", got)
+	}
+	// Fractional milliseconds must survive: the whole reason RetryIn is a
+	// Duration rather than an int is that the source value has a fraction.
+	if !strings.Contains(got, "616.452004") {
+		t.Errorf("the fractional millisecond value was lost.\ngot: %s", got)
+	}
+}
+
+// TestSessionError_JSONRoundTrips guards against the custom encoder being
+// write-only. Without UnmarshalJSON every reload of a persisted session would
+// silently drop the retry delay — one-directional plumbing, the same class of
+// bug as a field missing from the merge allowlist.
+func TestSessionError_JSONRoundTrips(t *testing.T) {
+	status, attempt, max := 429, 3, 10
+	d := 616452004 * time.Nanosecond
+	original := &SessionError{
+		Phase:       ErrorPhaseRetrying,
+		Class:       "rate_limit",
+		Message:     "slow down",
+		HTTPStatus:  &status,
+		Attempt:     &attempt,
+		MaxAttempts: &max,
+		RetryIn:     &d,
+	}
+
+	b, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var back SessionError
+	if err := json.Unmarshal(b, &back); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if !original.Equal(&back) {
+		t.Errorf("round trip lost or changed data:\n before: %+v\n  after: %+v", original, &back)
+	}
+}
+
+// TestSessionError_JSONRoundTripsWithEverythingAbsent is the other half, and
+// the case the recorded terminal shapes actually produce: no status, no
+// counters, no delay. Absent must come back absent, never as a zero that a
+// consumer would render as "attempt 0 of 0".
+func TestSessionError_JSONRoundTripsWithEverythingAbsent(t *testing.T) {
+	original := &SessionError{
+		Phase:   ErrorPhaseTerminal,
+		Class:   "provider",
+		Message: "API Error: API returned an empty or malformed response (HTTP 200)",
+	}
+
+	b, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(b), "retry_in_ms") || strings.Contains(string(b), "attempt") {
+		t.Errorf("absent optional fields must be omitted entirely, not emitted as zero.\ngot: %s", b)
+	}
+
+	var back SessionError
+	if err := json.Unmarshal(b, &back); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if back.RetryIn != nil || back.Attempt != nil || back.MaxAttempts != nil || back.HTTPStatus != nil {
+		t.Errorf("an absent field came back non-nil: %+v", &back)
+	}
+	if !original.Equal(&back) {
+		t.Errorf("round trip changed data:\n before: %+v\n  after: %+v", original, &back)
 	}
 }

--- a/core/domain/session/merge_session_error_test.go
+++ b/core/domain/session/merge_session_error_test.go
@@ -1,0 +1,108 @@
+package session
+
+import "testing"
+
+// TestMergeMetrics_CarriesSessionError is the #1256 trap, aimed at #1798's new
+// field.
+//
+// newMergedMetrics is an explicit allowlist: a field the literal omits is
+// silently reset to its zero value on every merge, with nothing failing. That
+// is not hypothetical here — it is exactly how TranscriptPermissionPending
+// came to be computed correctly by the parser, carried correctly through
+// replay's separate converter, and dropped on the only path that mattered,
+// while the parser, classifier and replay-fixture suites were all green.
+//
+// SessionError would fail the same way and be even harder to notice, because
+// the field only ever has a value on a session that is already broken.
+func TestMergeMetrics_CarriesSessionError(t *testing.T) {
+	status := 429
+	newM := &SessionMetrics{
+		LastEventType: "assistant",
+		SessionError: &SessionError{
+			Phase:      ErrorPhaseRetrying,
+			Class:      "rate_limit",
+			Message:    "slow down",
+			HTTPStatus: &status,
+		},
+	}
+	oldM := &SessionMetrics{LastEventType: "user"}
+
+	merged := MergeMetrics(newM, oldM)
+
+	if merged.SessionError == nil {
+		t.Fatal("SessionError was dropped by the merge — it is missing from " +
+			"newMergedMetrics' allowlist, so the classifier can never see it on the live path")
+	}
+	if merged.SessionError.Class != "rate_limit" || merged.SessionError.Phase != ErrorPhaseRetrying {
+		t.Errorf("SessionError content mangled: %+v", merged.SessionError)
+	}
+	if merged.SessionError.HTTPStatus == nil || *merged.SessionError.HTTPStatus != 429 {
+		t.Errorf("HTTPStatus lost through the merge: %+v", merged.SessionError.HTTPStatus)
+	}
+}
+
+// TestMergeMetrics_ClearedSessionErrorStaysCleared is the other direction, and
+// the one a carry-forward helper would break.
+//
+// The tailer owns the clearing rule and expresses "cleared" as a nil
+// SessionError on the fresh pass. If the field were ever added to
+// carryForwardOverlayState — which is the natural-looking change, since that
+// helper is where RateLimit and the cache-bloat group live — the old error
+// would be restored on top of the fresh nil and no session could ever leave
+// StateError again.
+//
+// This is a LOCK: it passes by construction against the shipped code and
+// exists to fail on a future edit, not as red-first evidence of a defect.
+func TestMergeMetrics_ClearedSessionErrorStaysCleared(t *testing.T) {
+	oldM := &SessionMetrics{
+		LastEventType: "assistant",
+		SessionError:  &SessionError{Phase: ErrorPhaseTerminal, Class: "provider"},
+	}
+	// The successful next turn: the tailer cleared its sticky error, so the
+	// fresh pass carries none.
+	newM := &SessionMetrics{LastEventType: "turn_done"}
+
+	merged := MergeMetrics(newM, oldM)
+
+	if merged.SessionError != nil {
+		t.Fatalf("a cleared error was resurrected from the previous pass (%+v) — SessionError "+
+			"has been added to a carryForward* helper, which makes the error permanent because "+
+			"the tailer signals 'cleared' with exactly this nil", merged.SessionError)
+	}
+}
+
+// TestSessionError_AbsentNumbersStayAbsent pins the pointer decision that the
+// recorded payloads forced.
+//
+// claudecode's terminal `isApiErrorMessage` event and copilot's
+// errorType:"query" both carry no status and no retry counters at all. With
+// plain ints those absences would read as 0, and any consumer deriving
+// "attempt 0 of 0 → gave up" would be inventing a verdict from data that said
+// nothing. A LOCK on the shape, not a defect test.
+func TestSessionError_AbsentNumbersStayAbsent(t *testing.T) {
+	e := &SessionError{
+		Phase:   ErrorPhaseTerminal,
+		Class:   "provider",
+		Message: "API Error: API returned an empty or malformed response (HTTP 200)",
+	}
+
+	if e.HTTPStatus != nil || e.Attempt != nil || e.MaxAttempts != nil || e.RetryIn != nil {
+		t.Fatalf("a status-free terminal error must leave every numeric field nil, got %+v", e)
+	}
+	if e.IsRetrying() {
+		t.Error("a terminal error must not report as retrying")
+	}
+	// The phase is what says "gave up" — deliberately NOT the counters.
+	if !e.Phase.Known() {
+		t.Error("a terminal error must carry a known phase")
+	}
+
+	// And the genuinely-unknown case stays distinguishable from both.
+	unknown := &SessionError{Class: "query", Message: "could not connect"}
+	if unknown.Phase.Known() {
+		t.Error("an unreported phase must not read as known")
+	}
+	if unknown.IsRetrying() {
+		t.Error("an unknown phase must not read as retrying")
+	}
+}

--- a/core/domain/session/metrics.go
+++ b/core/domain/session/metrics.go
@@ -362,45 +362,49 @@ type SessionMetrics struct {
 	// adapters).
 	Tasks []Task `json:"tasks,omitempty"`
 
-	// RateLimit is the most recent subscription quota snapshot observed for
-	// this session. Populated by the Codex parser (from token_count events)
-	// and by the Claude Code statusline hook. Nil when the underlying
-	// provider doesn't surface quota (API-key Claude Code, Bedrock, Vertex)
-	// or when no snapshot has arrived yet.
 	// SessionError is the session's current unrecovered session-level failure
 	// (#1798), or nil when the session is healthy. It is what the classifier's
 	// session_error rule reads to route a session to StateError, and what the
 	// UIs render on the red error line (#1801, #1802).
 	//
-	// PER-PASS RECOMPUTED, NOT CARRIED FORWARD — an explicit decision the
-	// issue asked for, and the two halves of it matter in opposite
-	// directions. The tailer holds the error sticky across passes and owns the
+	// PER-PASS RECOMPUTED, NOT CARRIED FORWARD — an explicit decision the issue
+	// asked for. The tailer holds the error sticky across passes and owns the
 	// clearing rule (see clearSessionErrorOnRecovery), so by the time metrics
-	// are built this field already IS the current verdict: it is non-nil for
-	// as long as the error stands and nil the moment a successful turn clears
-	// it. It is therefore copied verbatim in newMergedMetrics and deliberately
-	// absent from carryForwardOverlayState.
+	// are built this field already IS the current verdict: non-nil for as long
+	// as the error stands, nil the moment a successful turn clears it. It is
+	// therefore copied verbatim in newMergedMetrics and deliberately absent
+	// from carryForwardOverlayState.
 	//
 	// Adding it to a carry-forward helper would be the natural-looking change
 	// and would break the feature: carry-forward preserves oldM's value when
-	// newM's reads unset, and "unset" is precisely how the tailer says
-	// CLEARED. An error would then resurrect on every subsequent pass and no
-	// session could ever leave StateError.
+	// newM's reads unset, and "unset" is precisely how the tailer says CLEARED.
+	// An error would resurrect on every later pass and no session could ever
+	// leave StateError.
 	//
-	// THE COST, stated precisely rather than left to be discovered, because
-	// it is a half-measure and not a clean either/or. The field IS persisted
-	// (it has a json tag, so a UI can render it and the startup seed pass
-	// re-derives StateError from it), but the TAILER's sticky copy is not in
-	// LedgerState. So after a daemon restart a standing error survives the
-	// seed classification and is then dropped by the first fresh tailer pass,
-	// whose newM carries nil and is copied verbatim by the line above. Net
-	// effect: an errored session comes back red at boot and goes green at the
-	// next poll of its transcript. That is the self-limiting direction, and
-	// the clean fix is ledger persistence — deliberately not built here,
-	// since no adapter emits this field yet and #1800 is where the first
-	// producer and the first real evidence arrive together.
+	// DOES NOT SURVIVE A DAEMON RESTART, and the json tag does not change that.
+	// The value is persisted, but the startup path destroys it before anything
+	// reads it: seedReevaluateOne calls enricher.RefreshMetrics first, which is
+	// MergeMetrics against a fresh tailer pass carrying nil, and the line in
+	// newMergedMetrics copies that nil verbatim — the same behaviour
+	// TestMergeMetrics_ClearedSessionErrorStaysCleared locks in. So a session
+	// that died on a provider error reads GREEN after a restart, which is the
+	// silent direction this state exists to eliminate.
+	//
+	// That is a real gap, recorded here rather than glossed: the fix is to
+	// persist the sticky error in the tailer's LedgerState, exactly as
+	// LastTaskEstimate/FirstTaskEstimate are persisted there and for the
+	// identical reason ("a daemon restart would otherwise blank the ETA chip").
+	// Deliberately not built in this phase — no adapter emits this field yet,
+	// so there is nothing to lose across a restart until #1799/#1800 land, and
+	// that is where the first producer and the first real evidence arrive
+	// together.
 	SessionError *SessionError `json:"session_error,omitempty"`
 
+	// RateLimit is the most recent subscription quota snapshot observed for
+	// this session. Populated by the Codex parser (from token_count events)
+	// and by the Claude Code statusline hook. Nil when the underlying
+	// provider doesn't surface quota (API-key Claude Code, Bedrock, Vertex)
+	// or when no snapshot has arrived yet.
 	RateLimit *RateLimitSnapshot `json:"rate_limit,omitempty"`
 
 	// RateLimitForecastEta is the projected wall-clock time (Unix seconds)

--- a/core/domain/session/metrics.go
+++ b/core/domain/session/metrics.go
@@ -367,6 +367,40 @@ type SessionMetrics struct {
 	// and by the Claude Code statusline hook. Nil when the underlying
 	// provider doesn't surface quota (API-key Claude Code, Bedrock, Vertex)
 	// or when no snapshot has arrived yet.
+	// SessionError is the session's current unrecovered session-level failure
+	// (#1798), or nil when the session is healthy. It is what the classifier's
+	// session_error rule reads to route a session to StateError, and what the
+	// UIs render on the red error line (#1801, #1802).
+	//
+	// PER-PASS RECOMPUTED, NOT CARRIED FORWARD — an explicit decision the
+	// issue asked for, and the two halves of it matter in opposite
+	// directions. The tailer holds the error sticky across passes and owns the
+	// clearing rule (see clearSessionErrorOnRecovery), so by the time metrics
+	// are built this field already IS the current verdict: it is non-nil for
+	// as long as the error stands and nil the moment a successful turn clears
+	// it. It is therefore copied verbatim in newMergedMetrics and deliberately
+	// absent from carryForwardOverlayState.
+	//
+	// Adding it to a carry-forward helper would be the natural-looking change
+	// and would break the feature: carry-forward preserves oldM's value when
+	// newM's reads unset, and "unset" is precisely how the tailer says
+	// CLEARED. An error would then resurrect on every subsequent pass and no
+	// session could ever leave StateError.
+	//
+	// THE COST, stated precisely rather than left to be discovered, because
+	// it is a half-measure and not a clean either/or. The field IS persisted
+	// (it has a json tag, so a UI can render it and the startup seed pass
+	// re-derives StateError from it), but the TAILER's sticky copy is not in
+	// LedgerState. So after a daemon restart a standing error survives the
+	// seed classification and is then dropped by the first fresh tailer pass,
+	// whose newM carries nil and is copied verbatim by the line above. Net
+	// effect: an errored session comes back red at boot and goes green at the
+	// next poll of its transcript. That is the self-limiting direction, and
+	// the clean fix is ledger persistence — deliberately not built here,
+	// since no adapter emits this field yet and #1800 is where the first
+	// producer and the first real evidence arrive together.
+	SessionError *SessionError `json:"session_error,omitempty"`
+
 	RateLimit *RateLimitSnapshot `json:"rate_limit,omitempty"`
 
 	// RateLimitForecastEta is the projected wall-clock time (Unix seconds)
@@ -658,6 +692,15 @@ func newMergedMetrics(newM *SessionMetrics) *SessionMetrics {
 		RateLimitForecastEta:        newM.RateLimitForecastEta,
 		TaskEstimate:                newM.TaskEstimate,
 		TaskCompletionEta:           newM.TaskCompletionEta,
+		// The tailer recomputes this every pass from its own sticky state and
+		// owns the clearing rule, so newM's value — nil included — is the
+		// current verdict and is copied verbatim (#1798). It MUST be listed:
+		// this allowlist silently drops any field it omits, which is how
+		// TranscriptPermissionPending above came to be computed correctly and
+		// thrown away on the only path that mattered. Deliberately NOT in
+		// carryForwardOverlayState — see the field's own comment for why a
+		// carry-forward would make the error unclearable.
+		SessionError: newM.SessionError,
 	}
 }
 

--- a/core/domain/session/session.go
+++ b/core/domain/session/session.go
@@ -1,31 +1,75 @@
-// session.go holds the core lifecycle types: the three-state machine
-// (working/waiting/ready — see STATES.md), the yield verdict recorded once a
-// session goes ready, SessionState itself, and the launcher/background-agent
-// metadata attached to it. Per-pass computed metrics live in metrics.go; the
-// "is the agent waiting on me" text heuristics live in waiting_cue.go.
+// session.go holds the core lifecycle types: the four-state machine
+// (working/waiting/ready/error — see events.md), the yield verdict recorded
+// once a session goes ready, SessionState itself, and the launcher/background-
+// agent metadata attached to it. Per-pass computed metrics live in metrics.go;
+// the "is the agent waiting on me" text heuristics live in waiting_cue.go.
 package session
 
 import (
 	"time"
 )
 
-// State constants — three MECE states for session lifecycle.
-// See STATES.md for the formal state machine specification.
+// State constants — four MECE states for session lifecycle.
+// See events.md for the formal state machine specification.
 const (
 	StateWorking = "working" // Agent actively processing (tools, text generation, hooks, compaction, or a live Bash background process)
 	StateWaiting = "waiting" // Agent finished turn, waiting for user input
 	StateReady   = "ready"   // Session inactive (process exited, transcript removed, cancelled)
+	// StateError is #1796's fourth state: the session's own machinery failed
+	// — the provider refused or failed the call, credentials were rejected,
+	// the agent process died mid-turn, or Irrlicht could not read the
+	// session. It exists so such a session is visibly red instead of
+	// silently green, which is what every one of those cases used to be.
+	//
+	// NOT a tool failure. A grep that matched nothing and a build that broke
+	// are the agent working normally; see ParsedEvent.IsError for that half.
+	//
+	// Cleared by the next SUCCESSFUL turn and by nothing else — error→working
+	// when the next turn starts, error→ready on turn_done. There is
+	// deliberately no minimum hold, so a provider error that recovers in a
+	// few hundred milliseconds may flash too briefly to see; that cost was
+	// accepted when the rule was settled and is measured in #1803's
+	// provider-overloaded-retry recording rather than pre-empted here.
+	StateError = "error"
 )
 
-// IsCanonicalState reports whether s is one of the three valid lifecycle
-// states. Anything else (empty, "cancelled", a typo) is a domain violation.
+// canonicalStates is the lifecycle-state vocabulary, declared exactly once.
+//
+// Order is the ladder's own: the three ordinary states in the sequence a
+// session moves through them, then the failure state. Callers that render the
+// list to a human (see the filesystem repository's unrecognized-state warning)
+// get a stable, readable order for free, and a fifth state cannot desynchronise
+// the check from the message the way a hand-typed "%s/%s/%s" did (#1798).
+var canonicalStates = []string{StateWorking, StateWaiting, StateReady, StateError}
+
+// CanonicalStates returns the lifecycle-state vocabulary, newest-state-last.
+//
+// It returns a copy: the backing array is package state, and a caller that
+// sorted or truncated the slice in place would silently redefine what every
+// other caller — IsCanonicalState included — considers a valid state.
+func CanonicalStates() []string {
+	out := make([]string, len(canonicalStates))
+	copy(out, canonicalStates)
+	return out
+}
+
+// IsCanonicalState reports whether s is one of the valid lifecycle states.
+// Anything else (empty, "cancelled", a typo) is a domain violation.
+//
+// Reads canonicalStates rather than spelling the values out again, so this
+// predicate and every message that lists the vocabulary cannot drift apart.
 func IsCanonicalState(s string) bool {
-	return s == StateWorking || s == StateWaiting || s == StateReady
+	for _, c := range canonicalStates {
+		if s == c {
+			return true
+		}
+	}
+	return false
 }
 
 // Yield state constants — whether a finished session's work survived in the
 // repo or was reverted (#373). An independent dimension from the lifecycle
-// State above: a session is always in one of the three lifecycle states, and
+// State above: a session is always in exactly one of the lifecycle states, and
 // separately carries one of these yield verdicts once it has gone ready.
 const (
 	YieldUnknown    = "unknown"    // not git-tracked, or not yet evaluated

--- a/core/domain/session/session.go
+++ b/core/domain/session/session.go
@@ -6,6 +6,7 @@
 package session
 
 import (
+	"slices"
 	"time"
 )
 
@@ -24,12 +25,10 @@ const (
 	// NOT a tool failure. A grep that matched nothing and a build that broke
 	// are the agent working normally; see ParsedEvent.IsError for that half.
 	//
-	// Cleared by the next SUCCESSFUL turn and by nothing else — error→working
-	// when the next turn starts, error→ready on turn_done. There is
-	// deliberately no minimum hold, so a provider error that recovers in a
-	// few hundred milliseconds may flash too briefly to see; that cost was
-	// accepted when the rule was settled and is measured in #1803's
-	// provider-overloaded-retry recording rather than pre-empted here.
+	// Cleared by the next SUCCESSFUL turn and by nothing else. The rule and
+	// its accepted cost live with the code that implements each half:
+	// clearSessionErrorOnRecovery in the tailer, and graceFor in
+	// state_dwell.go for why neither edge is debounced.
 	StateError = "error"
 )
 
@@ -48,9 +47,7 @@ var canonicalStates = []string{StateWorking, StateWaiting, StateReady, StateErro
 // sorted or truncated the slice in place would silently redefine what every
 // other caller — IsCanonicalState included — considers a valid state.
 func CanonicalStates() []string {
-	out := make([]string, len(canonicalStates))
-	copy(out, canonicalStates)
-	return out
+	return slices.Clone(canonicalStates)
 }
 
 // IsCanonicalState reports whether s is one of the valid lifecycle states.
@@ -59,12 +56,7 @@ func CanonicalStates() []string {
 // Reads canonicalStates rather than spelling the values out again, so this
 // predicate and every message that lists the vocabulary cannot drift apart.
 func IsCanonicalState(s string) bool {
-	for _, c := range canonicalStates {
-		if s == c {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(canonicalStates, s)
 }
 
 // Yield state constants — whether a finished session's work survived in the

--- a/core/domain/session/session_error.go
+++ b/core/domain/session/session_error.go
@@ -1,0 +1,172 @@
+package session
+
+import "time"
+
+// ErrorPhase says whether the agent is still trying, or has given up.
+//
+// This is the distinction StateError alone cannot carry and the one #1803's
+// provider-overloaded-retry and provider-overloaded-terminal scenarios turn
+// on: both sit in StateError, and what separates them is whether another
+// attempt is coming. A user looking at a red session wants to know whether to
+// wait or to intervene, and that is exactly this field.
+//
+// IT IS THE ADAPTER'S VERDICT, NOT A DERIVED ONE — and specifically NOT
+// `Attempt == MaxAttempts`. That equality looks like the obvious derivation
+// and is wrong against the recorded data: across every api_error in
+// replaydata (16 events, claudecode 2-9_token-quota-exhausted), the attempt
+// counter never once reaches maxRetries — the observed range is 1..5 of 10,
+// and the ladder is abandoned when the user intervenes rather than exhausted.
+// Meanwhile the shapes that ARE terminal carry no counters at all: claudecode
+// writes an `isApiErrorMessage` assistant event with no retry fields, and
+// copilot writes `session.error` with none either. Deriving from the counters
+// would therefore report every real give-up as "still retrying" and every real
+// retry as nothing in particular.
+type ErrorPhase string
+
+const (
+	// ErrorPhaseUnknown is the zero value, and an honest answer rather than a
+	// missing one: the transcript reported a failure without saying whether
+	// another attempt follows. Real, not hypothetical — a copilot
+	// `session.error` with errorType "query" is exactly this.
+	ErrorPhaseUnknown ErrorPhase = ""
+
+	// ErrorPhaseRetrying means the agent has another attempt scheduled. The
+	// session is failing but not yet lost, and the informative behaviour is to
+	// sit red for the whole retry window rather than flicker per attempt.
+	ErrorPhaseRetrying ErrorPhase = "retrying"
+
+	// ErrorPhaseTerminal means no further attempt is coming: the turn is over
+	// and it failed. Only the next turn the user starts clears it.
+	ErrorPhaseTerminal ErrorPhase = "terminal"
+)
+
+// Known reports whether p is an actual phase rather than the unknown zero
+// value. Mirrors SignalTier.Known for the same reason: callers must be able to
+// tell "the agent said terminal" from "the agent said nothing", and a bare
+// comparison against ErrorPhaseTerminal silently conflates them.
+func (p ErrorPhase) Known() bool {
+	return p == ErrorPhaseRetrying || p == ErrorPhaseTerminal
+}
+
+// SessionError is one session-level failure: the provider refused or failed
+// the call, credentials were rejected, the agent process died mid-turn, or
+// Irrlicht could not read the session. It is what puts a session in
+// StateError, and what a UI renders on the red error line (#1801, #1802).
+//
+// DISTINCT FROM ParsedEvent.IsError, deliberately and permanently. IsError is
+// a tool_result failure — a grep that matched nothing, a build that broke, a
+// command that exited non-zero. That is the agent working normally and must
+// never turn a session red. Eight adapters set IsError today and nothing reads
+// it; this type is a separate channel rather than an extension of it, so the
+// two can never be confused by a future reader (see #1796's "Why this is
+// cheaper than it looks").
+//
+// EVERY NUMERIC FIELD IS A POINTER, and that is load-bearing rather than
+// stylistic. The recorded shapes disagree about which numbers exist at all:
+//
+//   - claudecode `system`/`api_error` carries status, retryInMs, retryAttempt
+//     and maxRetries — the rich case;
+//   - claudecode's terminal `isApiErrorMessage` assistant event carries NONE
+//     of them; its own text reads "API Error: API returned an empty or
+//     malformed response (HTTP 200)", where even the number in the prose is
+//     the transport's success code, not a failure code;
+//   - copilot `session.error` carries statusCode for errorType "rate_limit"
+//     and omits it entirely for errorType "query".
+//
+// With plain ints, all three absences read as 0 — and "attempt 0 of 0" would
+// derive as a give-up from data that said nothing. This is the same trap
+// ParsedEvent.PendingBackgroundAgentCount documents as "absence must not be
+// read as zero", in a place where getting it wrong invents a verdict instead
+// of losing one.
+type SessionError struct {
+	// Phase is whether another attempt is coming. See ErrorPhase.
+	Phase ErrorPhase `json:"phase,omitempty"`
+
+	// Class is the adapter's normalized failure class — "rate_limit",
+	// "quota", "auth", "context_limit", "provider", "query", "process_death".
+	// Free-form on purpose: the vocabularies genuinely differ per agent
+	// (copilot types its own errorType; claudecode's is nested inside the
+	// error object) and flattening them into a shared enum here would mean
+	// inventing mappings before #1799/#1800 have looked at the payloads.
+	Class string `json:"class,omitempty"`
+
+	// Message is the human-readable failure text, verbatim from the agent.
+	// This is what a user actually reads on the error line, so it is carried
+	// rather than reconstructed — the agents' own wording is better than
+	// anything derived from Class and status.
+	Message string `json:"message,omitempty"`
+
+	// HTTPStatus is the provider's status code, or nil when the transcript
+	// carries none. Nil is common, not exceptional — see the type comment.
+	HTTPStatus *int `json:"http_status,omitempty"`
+
+	// Attempt is the 1-based retry attempt this error belongs to, or nil when
+	// the agent does not report one.
+	//
+	// It counts attempts within ONE API call and resets to 1 for the next
+	// call — verified against the recorded ladder, which runs 1..5, then
+	// restarts at 1 after the user queues a message. It is not a
+	// session-lifetime counter and must not be summed across errors.
+	Attempt *int `json:"attempt,omitempty"`
+
+	// MaxAttempts is the agent's own retry ceiling for this call (claudecode
+	// reports 10), or nil when unreported. Carried for display — "attempt 3
+	// of 10" is far more informative than "attempt 3" — and explicitly NOT as
+	// the input to a terminal/retrying derivation; see ErrorPhase.
+	MaxAttempts *int `json:"max_attempts,omitempty"`
+
+	// RetryIn is how long the agent will wait before the next attempt, or nil
+	// when unreported.
+	//
+	// A duration rather than a number of milliseconds because the source is
+	// fractional: claudecode writes retryInMs as a float (616.4520045919932
+	// in the recordings), so an int field would silently truncate. Nil rather
+	// than zero because "retrying immediately" and "no delay was reported"
+	// are different facts, and a Phase of ErrorPhaseRetrying with a nil
+	// RetryIn is the honest "another attempt is coming, timing unstated".
+	RetryIn *time.Duration `json:"retry_in,omitempty"`
+}
+
+// IsRetrying reports whether another attempt is known to be coming.
+//
+// Deliberately false for ErrorPhaseUnknown: an unknown phase is not a retry,
+// and a caller that wants to distinguish "not retrying" from "we were not told"
+// must read Phase itself. Named as a question about the phase rather than as a
+// general predicate so no caller mistakes it for "is this error still open".
+func (e *SessionError) IsRetrying() bool {
+	return e != nil && e.Phase == ErrorPhaseRetrying
+}
+
+// Equal reports whether two errors carry the same content, treating nil as a
+// value. Used to avoid re-broadcasting a session whose error has not actually
+// changed across a poll — the same reason subagentSummary has an Equal.
+//
+// Compares the POINTED-TO values, not the pointers: two errors parsed from two
+// passes over the same transcript line hold equal-but-distinct *int fields, and
+// a pointer comparison would report every pass as a change.
+func (e *SessionError) Equal(o *SessionError) bool {
+	if e == nil || o == nil {
+		return e == o
+	}
+	if e.Phase != o.Phase || e.Class != o.Class || e.Message != o.Message {
+		return false
+	}
+	return eqIntPtr(e.HTTPStatus, o.HTTPStatus) &&
+		eqIntPtr(e.Attempt, o.Attempt) &&
+		eqIntPtr(e.MaxAttempts, o.MaxAttempts) &&
+		eqDurPtr(e.RetryIn, o.RetryIn)
+}
+
+func eqIntPtr(a, b *int) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return *a == *b
+}
+
+func eqDurPtr(a, b *time.Duration) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return *a == *b
+}

--- a/core/domain/session/session_error.go
+++ b/core/domain/session/session_error.go
@@ -1,6 +1,9 @@
 package session
 
-import "time"
+import (
+	"encoding/json"
+	"time"
+)
 
 // ErrorPhase says whether the agent is still trying, or has given up.
 //
@@ -118,13 +121,86 @@ type SessionError struct {
 	// RetryIn is how long the agent will wait before the next attempt, or nil
 	// when unreported.
 	//
-	// A duration rather than a number of milliseconds because the source is
-	// fractional: claudecode writes retryInMs as a float (616.4520045919932
-	// in the recordings), so an int field would silently truncate. Nil rather
-	// than zero because "retrying immediately" and "no delay was reported"
-	// are different facts, and a Phase of ErrorPhaseRetrying with a nil
-	// RetryIn is the honest "another attempt is coming, timing unstated".
-	RetryIn *time.Duration `json:"retry_in,omitempty"`
+	// A time.Duration rather than a number because the source is fractional:
+	// claudecode writes retryInMs as a float (616.4520045919932 in the
+	// recordings), so an int-milliseconds field would silently truncate. Nil
+	// rather than zero because "retrying immediately" and "no delay was
+	// reported" are different facts, and ErrorPhaseRetrying with a nil RetryIn
+	// is the honest "another attempt is coming, timing unstated".
+	//
+	// It is deliberately NOT serialized as a bare Duration. Go marshals one as
+	// unlabelled nanoseconds (616452004), and every other serialized time
+	// quantity in this package names its unit — ElapsedSeconds,
+	// RateLimitWindow.WindowMinutes, RateLimitForecastEta. The JS and Swift
+	// clients that render this (#1801, #1802) would have to know, from nothing
+	// in the payload, both the unit and that it is the only field using it. So
+	// SessionError carries explicit Marshal/UnmarshalJSON emitting
+	// `retry_in_ms` as a fractional number, which is also the unit the agents
+	// themselves report.
+	//
+	// No struct tag: the custom marshaller owns this field's wire form, and a
+	// tag here would be dead code that reads like the source of truth.
+	RetryIn *time.Duration `json:"-"`
+}
+
+// sessionErrorJSON is SessionError's wire form. Split out rather than hand-
+// writing the encoder so the field list stays a struct — a hand-rolled
+// json.Marshal would have to be edited in two places every time a field is
+// added, which is the drift newMergedMetrics' allowlist already demonstrates
+// the cost of.
+//
+// Only RetryIn differs from the Go shape; everything else is copied by name so
+// the two cannot disagree about a tag.
+type sessionErrorJSON struct {
+	Phase       ErrorPhase `json:"phase,omitempty"`
+	Class       string     `json:"class,omitempty"`
+	Message     string     `json:"message,omitempty"`
+	HTTPStatus  *int       `json:"http_status,omitempty"`
+	Attempt     *int       `json:"attempt,omitempty"`
+	MaxAttempts *int       `json:"max_attempts,omitempty"`
+	RetryInMs   *float64   `json:"retry_in_ms,omitempty"`
+}
+
+// MarshalJSON emits RetryIn as fractional milliseconds under an explicitly
+// unit-named key. See the RetryIn field for why.
+func (e SessionError) MarshalJSON() ([]byte, error) {
+	out := sessionErrorJSON{
+		Phase:       e.Phase,
+		Class:       e.Class,
+		Message:     e.Message,
+		HTTPStatus:  e.HTTPStatus,
+		Attempt:     e.Attempt,
+		MaxAttempts: e.MaxAttempts,
+	}
+	if e.RetryIn != nil {
+		ms := float64(*e.RetryIn) / float64(time.Millisecond)
+		out.RetryInMs = &ms
+	}
+	return json.Marshal(out)
+}
+
+// UnmarshalJSON is MarshalJSON's inverse, so a persisted session state round-
+// trips. Without it the custom encoder would be write-only and every reload
+// would silently drop the retry delay — the same class of one-directional
+// plumbing bug as a field missing from the merge allowlist.
+func (e *SessionError) UnmarshalJSON(b []byte) error {
+	var in sessionErrorJSON
+	if err := json.Unmarshal(b, &in); err != nil {
+		return err
+	}
+	*e = SessionError{
+		Phase:       in.Phase,
+		Class:       in.Class,
+		Message:     in.Message,
+		HTTPStatus:  in.HTTPStatus,
+		Attempt:     in.Attempt,
+		MaxAttempts: in.MaxAttempts,
+	}
+	if in.RetryInMs != nil {
+		d := time.Duration(*in.RetryInMs * float64(time.Millisecond))
+		e.RetryIn = &d
+	}
+	return nil
 }
 
 // IsRetrying reports whether another attempt is known to be coming.
@@ -138,33 +214,37 @@ func (e *SessionError) IsRetrying() bool {
 }
 
 // Equal reports whether two errors carry the same content, treating nil as a
-// value. Used to avoid re-broadcasting a session whose error has not actually
-// changed across a poll — the same reason subagentSummary has an Equal.
+// value.
 //
 // Compares the POINTED-TO values, not the pointers: two errors parsed from two
-// passes over the same transcript line hold equal-but-distinct *int fields, and
-// a pointer comparison would report every pass as a change.
+// passes over the same transcript line hold equal-but-distinct *int fields, so
+// a pointer comparison would report every pass as a change. That is the whole
+// reason it cannot be `==`.
+//
+// NO PRODUCTION CALLER YET — it is used by this package's tests and is here
+// for #1801, which needs it to avoid re-broadcasting a session whose error has
+// not actually changed across a poll (the job subagentSummary.Equal does at
+// session_detector_activity.go's re-broadcast check). Said plainly rather than
+// implied, so nobody reads this comment as a description of behaviour that
+// exists. The same holds for IsRetrying above.
 func (e *SessionError) Equal(o *SessionError) bool {
 	if e == nil || o == nil {
 		return e == o
 	}
-	if e.Phase != o.Phase || e.Class != o.Class || e.Message != o.Message {
-		return false
-	}
-	return eqIntPtr(e.HTTPStatus, o.HTTPStatus) &&
-		eqIntPtr(e.Attempt, o.Attempt) &&
-		eqIntPtr(e.MaxAttempts, o.MaxAttempts) &&
-		eqDurPtr(e.RetryIn, o.RetryIn)
+	return e.Phase == o.Phase &&
+		e.Class == o.Class &&
+		e.Message == o.Message &&
+		eqPtr(e.HTTPStatus, o.HTTPStatus) &&
+		eqPtr(e.Attempt, o.Attempt) &&
+		eqPtr(e.MaxAttempts, o.MaxAttempts) &&
+		eqPtr(e.RetryIn, o.RetryIn)
 }
 
-func eqIntPtr(a, b *int) bool {
-	if a == nil || b == nil {
-		return a == b
-	}
-	return *a == *b
-}
-
-func eqDurPtr(a, b *time.Duration) bool {
+// eqPtr compares two optional values by what they point AT, treating nil as a
+// value: two nils are equal, a nil and a non-nil are not. One generic helper
+// rather than one per pointed-to type, so a field added to SessionError with a
+// new numeric type does not need a fourth near-identical copy of it.
+func eqPtr[T comparable](a, b *T) bool {
 	if a == nil || b == nil {
 		return a == b
 	}

--- a/core/domain/session/session_error.go
+++ b/core/domain/session/session_error.go
@@ -143,61 +143,47 @@ type SessionError struct {
 	RetryIn *time.Duration `json:"-"`
 }
 
-// sessionErrorJSON is SessionError's wire form. Split out rather than hand-
-// writing the encoder so the field list stays a struct — a hand-rolled
-// json.Marshal would have to be edited in two places every time a field is
-// added, which is the drift newMergedMetrics' allowlist already demonstrates
-// the cost of.
+// sessionErrorAlias strips SessionError's methods (so json does not recurse
+// into MarshalJSON) while keeping every struct tag, RetryIn's `json:"-"`
+// included.
+type sessionErrorAlias SessionError
+
+// sessionErrorWire is the on-the-wire shape: everything SessionError already
+// tags, plus the one field whose Go type and JSON form differ.
 //
-// Only RetryIn differs from the Go shape; everything else is copied by name so
-// the two cannot disagree about a tag.
-type sessionErrorJSON struct {
-	Phase       ErrorPhase `json:"phase,omitempty"`
-	Class       string     `json:"class,omitempty"`
-	Message     string     `json:"message,omitempty"`
-	HTTPStatus  *int       `json:"http_status,omitempty"`
-	Attempt     *int       `json:"attempt,omitempty"`
-	MaxAttempts *int       `json:"max_attempts,omitempty"`
-	RetryInMs   *float64   `json:"retry_in_ms,omitempty"`
+// Embedding rather than restating the field list is the point. A mirror struct
+// would have to be edited every time SessionError gains a field — three edit
+// sites for one addition — which is the drift a custom codec is supposed to
+// avoid, not introduce. Here a new field is picked up by both directions for
+// free.
+type sessionErrorWire struct {
+	sessionErrorAlias
+	RetryInMs *float64 `json:"retry_in_ms,omitempty"`
 }
 
 // MarshalJSON emits RetryIn as fractional milliseconds under an explicitly
-// unit-named key. See the RetryIn field for why.
+// unit-named key. See the RetryIn field for why it is not a bare Duration.
 func (e SessionError) MarshalJSON() ([]byte, error) {
-	out := sessionErrorJSON{
-		Phase:       e.Phase,
-		Class:       e.Class,
-		Message:     e.Message,
-		HTTPStatus:  e.HTTPStatus,
-		Attempt:     e.Attempt,
-		MaxAttempts: e.MaxAttempts,
-	}
+	w := sessionErrorWire{sessionErrorAlias: sessionErrorAlias(e)}
 	if e.RetryIn != nil {
 		ms := float64(*e.RetryIn) / float64(time.Millisecond)
-		out.RetryInMs = &ms
+		w.RetryInMs = &ms
 	}
-	return json.Marshal(out)
+	return json.Marshal(w)
 }
 
 // UnmarshalJSON is MarshalJSON's inverse, so a persisted session state round-
-// trips. Without it the custom encoder would be write-only and every reload
-// would silently drop the retry delay — the same class of one-directional
-// plumbing bug as a field missing from the merge allowlist.
+// trips. Without it the codec would be write-only and every reload would
+// silently drop the retry delay — the same class of one-directional plumbing
+// bug as a field missing from the merge allowlist.
 func (e *SessionError) UnmarshalJSON(b []byte) error {
-	var in sessionErrorJSON
-	if err := json.Unmarshal(b, &in); err != nil {
+	var w sessionErrorWire
+	if err := json.Unmarshal(b, &w); err != nil {
 		return err
 	}
-	*e = SessionError{
-		Phase:       in.Phase,
-		Class:       in.Class,
-		Message:     in.Message,
-		HTTPStatus:  in.HTTPStatus,
-		Attempt:     in.Attempt,
-		MaxAttempts: in.MaxAttempts,
-	}
-	if in.RetryInMs != nil {
-		d := time.Duration(*in.RetryInMs * float64(time.Millisecond))
+	*e = SessionError(w.sessionErrorAlias)
+	if w.RetryInMs != nil {
+		d := time.Duration(*w.RetryInMs * float64(time.Millisecond))
 		e.RetryIn = &d
 	}
 	return nil

--- a/core/domain/session/session_error_guards_test.go
+++ b/core/domain/session/session_error_guards_test.go
@@ -1,0 +1,100 @@
+package session
+
+import (
+	"testing"
+	"time"
+)
+
+// TestCanonicalStates_ReturnsACopy is the mutation fixture for the defensive
+// copy in CanonicalStates.
+//
+// AGENTS.md: a guard a change ADDS has no "before" to run red, so the thing it
+// protects gets mutated instead. Removing the copy (`return canonicalStates`)
+// left the entire suite green, which meant the copy was justified only by its
+// own comment. This is that mutation, committed as a test rather than
+// described in a PR body nothing re-runs.
+//
+// The stakes are not stylistic: canonicalStates backs IsCanonicalState, so a
+// caller that sorted or truncated the returned slice in place would redefine
+// what the whole daemon considers a valid state — and the filesystem
+// repository deletes nothing but SKIPS sessions whose state fails that
+// predicate, so every affected session would silently vanish from the UI.
+func TestCanonicalStates_ReturnsACopy(t *testing.T) {
+	first := CanonicalStates()
+	if len(first) == 0 {
+		t.Fatal("precondition: the vocabulary must be non-empty")
+	}
+
+	// A caller mangling what it was handed, as clumsily as possible.
+	original := first[0]
+	first[0] = "clobbered"
+	first = first[:1]
+	_ = first
+
+	if got := CanonicalStates(); got[0] != original {
+		t.Errorf("CanonicalStates()[0] = %q after a caller overwrote its result, want %q — "+
+			"the function hands out the package's own backing array", got[0], original)
+	}
+	if len(CanonicalStates()) < 4 {
+		t.Errorf("the vocabulary shrank to %d after a caller re-sliced its result",
+			len(CanonicalStates()))
+	}
+	for _, s := range []string{StateWorking, StateWaiting, StateReady, StateError} {
+		if !IsCanonicalState(s) {
+			t.Errorf("IsCanonicalState(%q) is false after a caller mutated a CanonicalStates result "+
+				"— the predicate and the vocabulary share a backing array", s)
+		}
+	}
+}
+
+// TestSignalSessionError_HoldAppliesItsPayload is the direct test of the
+// SignalSessionError policy row, and exists because the ladder property test
+// cannot stand in for it.
+//
+// Review found that neutralizing that test's payload helper left the whole
+// suite green: its three transcript fixtures set SessionError directly, so
+// they satisfy its coverage assertion on their own and the out-of-band HOLD
+// path contributed no *verified* coverage at all. This asserts the row itself
+// — that a held error reaches metrics, and that a hook-delivered turn end
+// retires it.
+func TestSignalSessionError_HoldAppliesItsPayload(t *testing.T) {
+	now := time.Date(2026, 8, 25, 12, 0, 0, 0, time.UTC)
+	const sid = "s"
+
+	holds := NewSignalHolds()
+	holds.Hold(sid, SignalSessionError, SignalPayload{
+		SessionError: &SessionError{Phase: ErrorPhaseTerminal, Class: "process_death"},
+	}, now)
+
+	m := &SessionMetrics{LastEventType: "assistant"}
+	holds.Overlay(sid, m, now)
+
+	if m.SessionError == nil {
+		t.Fatal("a held session error did not reach the metrics — the policy row's apply " +
+			"never ran, so nothing out-of-band can ever put a session in StateError")
+	}
+	if m.SessionError.Class != "process_death" {
+		t.Errorf("Class = %q, want process_death", m.SessionError.Class)
+	}
+
+	// Persistent, not consume-once: an error stands until the session
+	// recovers, and an errored session produces no further transcript activity
+	// to re-derive it from.
+	again := &SessionMetrics{LastEventType: "assistant"}
+	holds.Overlay(sid, again, now)
+	if again.SessionError == nil {
+		t.Error("the hold was consumed on first use — an errored session would leave " +
+			"StateError on the very next pass")
+	}
+
+	// The clearing rule's hook half: a Stop hook is an authoritative turn
+	// boundary, so the turn completed and the hold must retire.
+	recovered := &SessionMetrics{LastEventType: "assistant", HookTurnDone: true}
+	holds.Overlay(sid, recovered, now)
+	if recovered.SessionError != nil {
+		t.Errorf("a hook-delivered turn end must retire the error hold, got %+v", recovered.SessionError)
+	}
+	if holds.Held(sid, SignalSessionError) {
+		t.Error("the hold must be dropped, not merely skipped for one pass")
+	}
+}

--- a/core/domain/session/session_error_guards_test.go
+++ b/core/domain/session/session_error_guards_test.go
@@ -1,9 +1,6 @@
 package session
 
-import (
-	"testing"
-	"time"
-)
+import "testing"
 
 // TestCanonicalStates_ReturnsACopy is the mutation fixture for the defensive
 // copy in CanonicalStates.
@@ -58,8 +55,10 @@ func TestCanonicalStates_ReturnsACopy(t *testing.T) {
 // — that a held error reaches metrics, and that a hook-delivered turn end
 // retires it.
 func TestSignalSessionError_HoldAppliesItsPayload(t *testing.T) {
-	now := time.Date(2026, 8, 25, 12, 0, 0, 0, time.UTC)
-	const sid = "s"
+	// holdT0 / holdSID: the package's shared hold fixtures, so this test moves
+	// with the other ~20 TestSignalHolds_* cases rather than pinning a second
+	// time origin nobody would think to update.
+	now, sid := holdT0, holdSID
 
 	holds := NewSignalHolds()
 	holds.Hold(sid, SignalSessionError, SignalPayload{

--- a/core/domain/session/signal_hold.go
+++ b/core/domain/session/signal_hold.go
@@ -65,10 +65,16 @@ const (
 	// terminal `isApiErrorMessage` event, copilot's `session.error`. #1800
 	// adds process death, whose evidence is the OS view of the agent process
 	// rather than anything written down, and which therefore belongs at
-	// TierProcess. A policy row declares exactly one tier, so that arrives as
-	// its own kind rather than by widening this one — and the classifier rule
-	// below is written to read whichever of them is present, so adding it does
-	// not restructure the ladder.
+	// TierProcess.
+	//
+	// A policy row declares exactly one tier, so that arrives as its own kind
+	// rather than by widening this one. The classifier's session_error rule
+	// reads SessionError directly, so its PREDICATE already covers a
+	// process-death producer — but its TIER resolves through this row via
+	// TierOf, so routing #1800's evidence through it would record TierProcess
+	// evidence as TierTranscript. Understating a tier never trips the ladder
+	// invariant, so nothing would catch it. #1800 adds a second rule row (or a
+	// `tierOf` override) rather than reusing this one.
 	//
 	// Named for the condition rather than the producer, matching the two rows
 	// above it, so the string is also the classifier rule id.

--- a/core/domain/session/signal_hold.go
+++ b/core/domain/session/signal_hold.go
@@ -54,6 +54,25 @@ const (
 	// for the condition rather than the producer, so the string matches the
 	// classifier rule id that reads it.
 	SignalOpenToolStalled SignalKind = "open_tool_stalled"
+
+	// SignalSessionError is #1798's fourth-state signal: the session's own
+	// machinery failed — the provider refused or failed the call, credentials
+	// were rejected, the agent process died mid-turn — and the session must
+	// read StateError rather than a silently green ready.
+	//
+	// TierTranscript, because the only producer this phase can have reads the
+	// failure out of the transcript: claudecode's `system`/`api_error` and its
+	// terminal `isApiErrorMessage` event, copilot's `session.error`. #1800
+	// adds process death, whose evidence is the OS view of the agent process
+	// rather than anything written down, and which therefore belongs at
+	// TierProcess. A policy row declares exactly one tier, so that arrives as
+	// its own kind rather than by widening this one — and the classifier rule
+	// below is written to read whichever of them is present, so adding it does
+	// not restructure the ladder.
+	//
+	// Named for the condition rather than the producer, matching the two rows
+	// above it, so the string is also the classifier rule id.
+	SignalSessionError SignalKind = "session_error"
 )
 
 // compactHoldTimeout bounds the SignalCompactInProgress hold (#657). Normally
@@ -144,6 +163,32 @@ const permissionPromptHoldTimeout = 12 * time.Hour
 // stopped being parsed, not the expected path.
 const idlePromptHoldTimeout = 12 * time.Hour
 
+// sessionErrorHoldTimeout bounds the SignalSessionError hold (#1798).
+//
+// A ceiling is not strictly required here — TestSignalPolicies_HookPersistentHolds
+// DeclareACeiling only compels one for persistent TierHook rows, and this row
+// is TierTranscript. It is declared anyway because the argument that made that
+// test exist applies with more force, not less: TierTranscript is the BOTTOM
+// of the ladder, so there is no lower tier left to correct a stuck hold. The
+// hold's own staleness rule is its only other end-of-life, and that rule reads
+// a hook signal — so a session whose hook channel goes away (an uninstalled
+// hook, a port change, a daemon restart mid-turn) would hold an error hold
+// with nothing able to retire it.
+//
+// Twelve hours, matching permissionPromptHoldTimeout and idlePromptHoldTimeout
+// rather than picking a third number, because the governing workflow is the
+// same one: an agent left running overnight and reviewed the next morning. A
+// session that died on a provider error at 22:00 must still read red at 08:00
+// — that is the entire point of the state — and a shorter ceiling would turn
+// the failure green again while the user slept, which is the silent direction.
+//
+// It stays a separate constant from the other two despite the identical value
+// because the coverage stories differ: those rows are corrected from below by
+// a transcript-tier fallback (partly, and not at all, respectively), while
+// this one has no tier beneath it. Collapsing them would let a future retune
+// of one silently move the others.
+const sessionErrorHoldTimeout = 12 * time.Hour
+
 // stalledEditToolThreshold is how long a permission-gated file-edit tool
 // (Edit/Write/MultiEdit/NotebookEdit) may stay open before it is read as a held
 // permission prompt and SignalOpenToolStalled applies — the transcript-based
@@ -181,6 +226,14 @@ type SignalPayload struct {
 	// hook's *full* message text, rather than the 200-rune transcript tail
 	// the classifier would otherwise see (#1150).
 	WaitingCue bool
+
+	// SessionError is the failure a SignalSessionError hold is asserting
+	// (#1798). Only that row reads it, and only an out-of-band producer sets
+	// it — the transcript path writes SessionMetrics.SessionError directly
+	// from the tailer and places no hold at all, exactly as the transcript
+	// permission signal writes TranscriptPermissionPending rather than going
+	// through SignalPermissionPrompt.
+	SessionError *SessionError
 }
 
 // holdContext is everything a staleness rule may read: the metrics the signal
@@ -476,6 +529,39 @@ var signalPolicies = []signalPolicy{
 		stale:   func(c holdContext) bool { return c.Metrics.SawManualCompactBoundary },
 		ceiling: compactHoldTimeout,
 		apply:   func(c holdContext) { c.Metrics.CompactInProgress = true },
+	},
+
+	{
+		kind: SignalSessionError,
+		tier: TierTranscript,
+		// Persistent: a failure stands until the session recovers, and the
+		// hold must survive every poll in between — which for an errored
+		// session is most of them, since a failed turn produces no further
+		// transcript activity to re-derive it from.
+		//
+		// POSITION: after SignalTurnDone, whose apply sets the HookTurnDone
+		// this row's staleness reads — the same one-directional dependency
+		// SignalIdlePrompt has on the same row, and for the same reason.
+		// Reverse them and a Stop hook arriving alongside a held error would
+		// be evaluated against metrics that do not yet know the turn ended, so
+		// the error would survive a turn that actually completed. Before
+		// SignalOpenToolStalled, which must stay last (it reads the
+		// PermissionPending that the first row writes).
+		//
+		// STALE = the settled clearing rule's hook half: "error → ready on
+		// turn_done". A Stop hook is an authoritative turn boundary, so a turn
+		// completed and the failure is over. The transcript half of the same
+		// rule lives in the tailer, which is the only layer that sees whether
+		// the boundary arrived before or after the error — see
+		// clearSessionErrorOnRecovery. Neither half is a timeout: there is no
+		// minimum hold and no decay, by decision (#1796).
+		stale:   func(c holdContext) bool { return c.Metrics.HookTurnDone },
+		ceiling: sessionErrorHoldTimeout,
+		apply: func(c holdContext) {
+			if c.Payload.SessionError != nil {
+				c.Metrics.SessionError = c.Payload.SessionError
+			}
+		},
 	},
 
 	{

--- a/core/domain/session/signal_hold.go
+++ b/core/domain/session/signal_hold.go
@@ -563,8 +563,16 @@ var signalPolicies = []signalPolicy{
 		// minimum hold and no decay, by decision (#1796).
 		stale:   func(c holdContext) bool { return c.Metrics.HookTurnDone },
 		ceiling: sessionErrorHoldTimeout,
+		// Applies only into an EMPTY slot. Overlay runs after the metrics are
+		// rebuilt, so an unconditional write would let this row silently
+		// outrank the transcript path — two writers at the same tier, with the
+		// winner decided by call order rather than by anything declared. The
+		// transcript is the fresher observation (it was just re-read this
+		// pass), so it keeps the slot; a hold fills in only when the
+		// transcript reports nothing, which is exactly the process-death case
+		// #1800 adds it for.
 		apply: func(c holdContext) {
-			if c.Payload.SessionError != nil {
+			if c.Metrics.SessionError == nil && c.Payload.SessionError != nil {
 				c.Metrics.SessionError = c.Payload.SessionError
 			}
 		},

--- a/core/domain/session/signal_hold_test.go
+++ b/core/domain/session/signal_hold_test.go
@@ -268,6 +268,16 @@ func TestSignalHolds_StaleIsCheckedOnTheFirstPass(t *testing.T) {
 //     ripe rule reads PermissionPending, which the permission row's apply
 //     sets. Reversed, the transcript fallback fires alongside the hook it is
 //     supposed to defer to.
+//   - SignalTurnDone before SignalSessionError (#1798): the error row's
+//     staleness reads HookTurnDone, which turn_done's apply sets on the same
+//     pass — the same dependency idle_prompt has, for the same reason.
+//     Reversed, a Stop hook arriving alongside a held error is evaluated
+//     against metrics that do not yet know the turn ended, so a failure
+//     survives a turn that actually completed and the session stays red.
+//
+// SignalSessionError sits before SignalOpenToolStalled only because that row
+// must stay last; nothing reads what the error row writes, so its position is
+// otherwise free.
 //
 // Pinned as the exact full sequence rather than as two pairwise checks so that
 // adding a row is a deliberate act — the test names the position, and whoever
@@ -278,6 +288,7 @@ func TestSignalPolicies_OrderIsPinned(t *testing.T) {
 		SignalTurnDone,
 		SignalIdlePrompt,
 		SignalCompactInProgress,
+		SignalSessionError,
 		SignalOpenToolStalled,
 	}
 

--- a/core/domain/session/state_dwell.go
+++ b/core/domain/session/state_dwell.go
@@ -72,6 +72,29 @@ const waitingExitDwell = 6 * time.Second
 //   - ready→working. Reversing it wrongly would hide a finished turn, which is
 //     the same silent class of error as a dropped waiting.
 //
+// ERROR (#1798) IS NOT DEBOUNCED IN EITHER DIRECTION. This is a decision, not
+// an omission — the issue required one to be made and written down here.
+//
+//   - INTO error: raising a come-look cue, and the most urgent one in the
+//     system. Delaying it spends the grace in the expensive direction, which
+//     is the same argument that leaves working→ready undebounced. A session
+//     whose provider call just failed should say so on the pass that decides
+//     it.
+//   - OUT OF error: the only thing that clears an error is a successful turn
+//     (error→working when the next one starts, error→ready on turn_done).
+//     Both are real events rather than flaps, so there is nothing to
+//     suppress; debouncing them would just hold a stale red over a session
+//     that has demonstrably recovered, and error→working in particular is the
+//     user having typed, which must never look ignored.
+//
+// The known cost, accepted when the clearing rule was settled and deliberately
+// NOT mitigated here: with no minimum hold, a provider error that recovers in
+// a few hundred milliseconds can enter and leave error inside one poll
+// interval and never be seen. Adding a floor here is the obvious fix and is
+// premature — #1803 measures the real dwell in the provider-overloaded-retry
+// recording, and that measurement is what a hold should be calibrated against
+// if one is added at all.
+//
 // The residual, stated plainly rather than left to be discovered: the
 // working→ready→waiting sequence a late idle_prompt produces still reaches the
 // UI as two transitions. #1366 does not claim to remove it.

--- a/core/e2e/crash_test.go
+++ b/core/e2e/crash_test.go
@@ -15,8 +15,15 @@ import (
 
 // TestSession_NoCancelledState_OnSIGKILL verifies that when an agent process
 // is killed with SIGKILL mid-session, the resulting session never enters a
-// "cancelled" (or any non-canonical) state. Per project convention there are
-// only three states: working, waiting, ready.
+// "cancelled" (or any non-canonical) state.
+//
+// The invariant is membership of the canonical vocabulary, not a count of it,
+// which is why the assertion below delegates to session.IsCanonicalState and
+// keeps holding as the vocabulary grows: #1798 widened it to four
+// (working/waiting/ready/error) and this test needed no change to its logic.
+// "cancelled" specifically is still forbidden — a killed process resolves to
+// ready, and #1796's new error state is for a session whose machinery FAILED,
+// which a deliberate SIGKILL from the user is not.
 //
 // Concretely: the scanner-tracked pre-session must either remain in a
 // canonical state or be deleted entirely — but never end up in a forbidden

--- a/core/pkg/tailer/parser.go
+++ b/core/pkg/tailer/parser.go
@@ -279,6 +279,65 @@ type ParsedEvent struct {
 	// heuristic-fallback task summary (issue #738). Adapters that don't set
 	// it simply have no heuristic fallback (the marker still works).
 	UserText string
+
+	// SessionError, when non-nil, reports that this event is a SESSION-LEVEL
+	// failure: the provider refused or failed the call, credentials were
+	// rejected, the turn was aborted (issue #1798). The tailer holds it as
+	// the session's current unrecovered error until the next successful turn
+	// clears it, and the classifier routes such a session to
+	// session.StateError.
+	//
+	// KEPT STRICTLY DISTINCT FROM IsError above, which is a tool_result
+	// failure. A grep that matched nothing, a failing build, a command
+	// exiting non-zero — those are the agent working normally and must never
+	// turn a session red. The precedent is IsUserInterrupt, which is kept
+	// distinct from IsError for exactly the same reason ("so the classifier
+	// can tell an ESC apart from a normal tool failure"); this is that
+	// argument applied to the other end of the severity scale.
+	//
+	// The one existing adapter that already conflates the two is geminicli,
+	// which sets IsError=true on a top-level type:"error" event and smuggles
+	// the reason out through AssistantText because IsError has no readers.
+	// #1800 moves it onto this field.
+	//
+	// Nil for the overwhelming majority of events, so the pointer costs
+	// nothing and keeps "no error on this event" distinguishable from a
+	// zero-valued error — the same shape as RateLimit, TaskEstimate and
+	// AwaySummary above.
+	SessionError *SessionError
+}
+
+// ErrorPhase mirrors session.ErrorPhase inside the tailer package. See that
+// type for why terminal-ness is the adapter's verdict and never derived from
+// Attempt == MaxAttempts.
+type ErrorPhase string
+
+const (
+	ErrorPhaseUnknown  ErrorPhase = ""
+	ErrorPhaseRetrying ErrorPhase = "retrying"
+	ErrorPhaseTerminal ErrorPhase = "terminal"
+)
+
+// SessionError mirrors session.SessionError inside the tailer package so
+// parsers can report a session-level failure without importing the domain —
+// the same boundary RateLimitSnapshot, TaskEstimate and AwaySummary sit on,
+// converted by the adapter glue (core/application/replayengine/metrics.go).
+//
+// Every numeric field is a pointer because the recorded payloads disagree
+// about which numbers exist: claudecode's retrying `api_error` carries all of
+// them, its terminal `isApiErrorMessage` event carries none, and copilot's
+// `session.error` carries a statusCode for "rate_limit" but not for "query".
+// With plain ints all three absences would read as 0, and "attempt 0 of 0"
+// would derive a give-up from data that said nothing. See
+// session.SessionError for the full argument and the fixture evidence.
+type SessionError struct {
+	Phase       ErrorPhase
+	Class       string
+	Message     string
+	HTTPStatus  *int
+	Attempt     *int
+	MaxAttempts *int
+	RetryIn     *time.Duration
 }
 
 // RateLimitSnapshot mirrors session.RateLimitSnapshot inside the tailer

--- a/core/pkg/tailer/parser.go
+++ b/core/pkg/tailer/parser.go
@@ -324,12 +324,8 @@ const (
 // converted by the adapter glue (core/application/replayengine/metrics.go).
 //
 // Every numeric field is a pointer because the recorded payloads disagree
-// about which numbers exist: claudecode's retrying `api_error` carries all of
-// them, its terminal `isApiErrorMessage` event carries none, and copilot's
-// `session.error` carries a statusCode for "rate_limit" but not for "query".
-// With plain ints all three absences would read as 0, and "attempt 0 of 0"
-// would derive a give-up from data that said nothing. See
-// session.SessionError for the full argument and the fixture evidence.
+// about which numbers exist at all. See session.SessionError for the argument
+// and the fixture evidence.
 type SessionError struct {
 	Phase       ErrorPhase
 	Class       string
@@ -338,6 +334,30 @@ type SessionError struct {
 	Attempt     *int
 	MaxAttempts *int
 	RetryIn     *time.Duration
+}
+
+// StartsNewUserTurn reports whether this event begins a GENUINE new user turn
+// — a fresh prompt, an ESC, an answer to a question — as opposed to a tool
+// round-trip.
+//
+// The distinction exists because several transcript formats deliver tool
+// results on USER-ROLE lines. Claude Code is the one that bites: its parser
+// raises ClearToolNames for every `user` event, so a bare ClearToolNames check
+// reads every tool result as a new turn. #558 is what that costs — the
+// task-estimate chip was reset on each tool call and vanished mid-task until
+// the agent emitted another marker.
+//
+// Named once here rather than re-spelled per caller: before this the same
+// expression appeared verbatim at three sites in tailer.go plus a fourth in
+// tailer_metrics.go, each re-explaining #558 in its own words, and the #1798
+// session-error clearing rule was written as the fourth copy. A concept that
+// four callers agree on is a method on the event, not a convention.
+//
+// Note tailer.go's assistant-text reset deliberately does NOT use this: it
+// clears on a bare ClearToolNames, tool results included. That is an exception
+// on purpose, and it reads as one now that the shared rule has a name.
+func (e *ParsedEvent) StartsNewUserTurn() bool {
+	return e.ClearToolNames && len(e.ToolResultIDs) == 0
 }
 
 // RateLimitSnapshot mirrors session.RateLimitSnapshot inside the tailer

--- a/core/pkg/tailer/session_error_test.go
+++ b/core/pkg/tailer/session_error_test.go
@@ -87,19 +87,11 @@ func newSessionErrorTailer(path string, skipErrors bool) *TranscriptTailer {
 	return tl
 }
 
-// TestSessionError_RecordedOnBothRoutingPaths is the #1256-shaped defect this
-// design exists to avoid, made explicit.
-//
-// scanParsedLine routes an event down exactly one of two mutually exclusive
-// paths — applySkippedEvent for Skip=true, processParsedEvent otherwise — and
-// the two error shapes that matter land on OPPOSITE sides of that fork:
-// claudecode's `system`/`api_error` is Skip=true (it falls through
-// handleSystemEvent's catch-all), while copilot's `session.error` is an
-// ordinary event. Folding the error in processParsedEvent alone would work for
-// one adapter, silently drop the other, and pass every test written against
-// the adapter that happened to work.
-//
-// So this runs the identical transcript twice, differing only in Skip.
+// TestSessionError_RecordedOnBothRoutingPaths runs the identical transcript
+// twice, differing only in Skip — because the two error shapes that matter
+// land on opposite sides of scanParsedLine's fork, and folding the error into
+// only one arm would work for one adapter and silently drop the other. See
+// applySessionError for why that is the #1256 shape.
 func TestSessionError_RecordedOnBothRoutingPaths(t *testing.T) {
 	for _, tc := range []struct {
 		name       string

--- a/core/pkg/tailer/session_error_test.go
+++ b/core/pkg/tailer/session_error_test.go
@@ -1,0 +1,336 @@
+package tailer
+
+import (
+	"testing"
+	"time"
+
+	"irrlicht/core/pkg/capacity"
+)
+
+// sessionErrorTestParser is a parser written for these tests rather than a
+// reuse of testParser, and that is deliberate.
+//
+// testParser's handleTestSystemEvent is a stub: it reads a fixed handful of
+// subtypes and knows nothing about session errors, so a test routed through it
+// would drive the tailer with a ParsedEvent whose SessionError is always nil
+// and would pass no matter what the production code did. That is the #1076
+// failure exactly — seven acceptance criteria written against this package
+// whose stub never read the field under test, so every one of them would have
+// passed on main while the bug shipped.
+//
+// This parser maps the transcript shapes below onto the two things the
+// clearing rule turns on — a session error, and a turn boundary — and nothing
+// else:
+//
+//	{"kind":"error", ...}  → SessionError, Skip as configured
+//	{"kind":"turn_done"}   → EventType "turn_done"
+//	{"kind":"user"}        → a real user turn boundary (ClearToolNames)
+//	{"kind":"assistant"}   → ordinary mid-turn activity
+type sessionErrorTestParser struct {
+	// skipErrors mirrors claudecode's real routing: its `system`/`api_error`
+	// event is Skip=true, so it reaches applySkippedEvent and never
+	// processParsedEvent. Making this configurable is the whole point of the
+	// fixture — see TestSessionError_RecordedOnBothRoutingPaths.
+	skipErrors bool
+}
+
+func (p *sessionErrorTestParser) ParseLine(raw map[string]interface{}) *ParsedEvent {
+	ev := &ParsedEvent{Timestamp: ParseTimestamp(raw)}
+	kind, _ := raw["kind"].(string)
+
+	switch kind {
+	case "error":
+		ev.EventType = "system"
+		ev.Skip = p.skipErrors
+		se := &SessionError{Class: "rate_limit", Message: "slow down"}
+		if phase, ok := raw["phase"].(string); ok {
+			se.Phase = ErrorPhase(phase)
+		}
+		if status, ok := raw["status"].(float64); ok {
+			s := int(status)
+			se.HTTPStatus = &s
+		}
+		if attempt, ok := raw["attempt"].(float64); ok {
+			a := int(attempt)
+			se.Attempt = &a
+		}
+		if retryMs, ok := raw["retry_in_ms"].(float64); ok {
+			d := time.Duration(retryMs * float64(time.Millisecond))
+			se.RetryIn = &d
+		}
+		ev.SessionError = se
+	case "turn_done":
+		ev.EventType = "turn_done"
+	case "user":
+		ev.EventType = "user"
+		ev.ClearToolNames = true
+	default:
+		ev.EventType = "assistant"
+	}
+	return ev
+}
+
+func newSessionErrorTailer(path string, skipErrors bool) *TranscriptTailer {
+	tl := NewTranscriptTailer(path, &sessionErrorTestParser{skipErrors: skipErrors}, "test-adapter")
+	tl.capacityMgr = capacity.NewForTest(testCapacityFixture)
+	return tl
+}
+
+// TestSessionError_RecordedOnBothRoutingPaths is the #1256-shaped defect this
+// design exists to avoid, made explicit.
+//
+// scanParsedLine routes an event down exactly one of two mutually exclusive
+// paths — applySkippedEvent for Skip=true, processParsedEvent otherwise — and
+// the two error shapes that matter land on OPPOSITE sides of that fork:
+// claudecode's `system`/`api_error` is Skip=true (it falls through
+// handleSystemEvent's catch-all), while copilot's `session.error` is an
+// ordinary event. Folding the error in processParsedEvent alone would work for
+// one adapter, silently drop the other, and pass every test written against
+// the adapter that happened to work.
+//
+// So this runs the identical transcript twice, differing only in Skip.
+func TestSessionError_RecordedOnBothRoutingPaths(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		skipErrors bool
+	}{
+		{"skipped-event (claudecode system/api_error)", true},
+		{"ordinary event (copilot session.error)", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			path := writeTranscriptLines(t, []map[string]interface{}{
+				{"kind": "user", "timestamp": ts(0)},
+				{"kind": "assistant", "timestamp": ts(1)},
+				{"kind": "error", "phase": "retrying", "status": 429, "attempt": 1, "retry_in_ms": 616.45, "timestamp": ts(2)},
+			})
+
+			m, err := newSessionErrorTailer(path, tc.skipErrors).TailAndProcess()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if m.SessionError == nil {
+				t.Fatalf("SessionError is nil — the error was dropped on the %s path. "+
+					"The fold must live in applyMetadata, the only function BOTH routing "+
+					"paths call.", tc.name)
+			}
+			if m.SessionError.Phase != ErrorPhaseRetrying {
+				t.Errorf("Phase = %q, want retrying", m.SessionError.Phase)
+			}
+			if m.SessionError.HTTPStatus == nil || *m.SessionError.HTTPStatus != 429 {
+				t.Errorf("HTTPStatus = %v, want 429", m.SessionError.HTTPStatus)
+			}
+			// The fractional retry delay must survive: claudecode writes
+			// retryInMs as a float (616.4520045919932 in the recordings), so a
+			// millisecond-int field would silently truncate it.
+			if m.SessionError.RetryIn == nil {
+				t.Fatal("RetryIn is nil")
+			}
+			if got := *m.SessionError.RetryIn; got <= 616*time.Millisecond || got >= 617*time.Millisecond {
+				t.Errorf("RetryIn = %v, want a fractional ~616.45ms — an int-milliseconds "+
+					"field would have truncated this", got)
+			}
+		})
+	}
+}
+
+// TestSessionError_ClearedByTurnDone is the settled clearing rule's retry half
+// (#1796): the session sits in error for the whole retry window and settles on
+// the eventual turn boundary. This is what makes provider-overloaded-retry end
+// green instead of staying red forever.
+func TestSessionError_ClearedByTurnDone(t *testing.T) {
+	path := writeTranscriptLines(t, []map[string]interface{}{
+		{"kind": "user", "timestamp": ts(0)},
+		{"kind": "error", "phase": "retrying", "attempt": 1, "timestamp": ts(1)},
+		{"kind": "error", "phase": "retrying", "attempt": 2, "timestamp": ts(2)},
+		{"kind": "error", "phase": "retrying", "attempt": 3, "timestamp": ts(3)},
+		{"kind": "assistant", "timestamp": ts(4)}, // the retry finally succeeded
+		{"kind": "turn_done", "timestamp": ts(5)},
+	})
+
+	m, err := newSessionErrorTailer(path, true).TailAndProcess()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if m.SessionError != nil {
+		t.Fatalf("the turn completed, so the error must be cleared; got %+v", m.SessionError)
+	}
+}
+
+// TestSessionError_ClearedByNextUserTurn is the other half: error→working when
+// the next turn starts.
+//
+// It is the ONLY thing that clears a terminal give-up, because a give-up
+// produces no turn boundary of its own — so without it a session that failed
+// once would read red for the rest of its life.
+func TestSessionError_ClearedByNextUserTurn(t *testing.T) {
+	path := writeTranscriptLines(t, []map[string]interface{}{
+		{"kind": "user", "timestamp": ts(0)},
+		{"kind": "error", "phase": "terminal", "timestamp": ts(1)},
+		{"kind": "user", "timestamp": ts(2)}, // the user tries again
+	})
+
+	m, err := newSessionErrorTailer(path, true).TailAndProcess()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if m.SessionError != nil {
+		t.Fatalf("a new user turn must clear the previous turn's failure; got %+v", m.SessionError)
+	}
+}
+
+// TestSessionError_SurvivesMidTurnActivity is the guard against clearing too
+// eagerly, and the reason clearSessionErrorOnRecovery keys on ClearToolNames
+// rather than on a user-role event type.
+//
+// Tool results arrive on user-role events in several transcript formats. If
+// those counted as "the next turn started", a mid-turn error would be cleared
+// by the next tool round-trip — roughly one second later — which is
+// indistinguishable from never having shown it at all.
+func TestSessionError_SurvivesMidTurnActivity(t *testing.T) {
+	path := writeTranscriptLines(t, []map[string]interface{}{
+		{"kind": "user", "timestamp": ts(0)},
+		{"kind": "error", "phase": "retrying", "attempt": 1, "timestamp": ts(1)},
+		{"kind": "assistant", "timestamp": ts(2)},
+		{"kind": "assistant", "timestamp": ts(3)},
+	})
+
+	m, err := newSessionErrorTailer(path, true).TailAndProcess()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if m.SessionError == nil {
+		t.Fatal("ordinary mid-turn activity must NOT clear a standing error — " +
+			"only a completed turn or a new user turn does")
+	}
+}
+
+// TestSessionError_SurvivesEmptyMessageHistory is why the surfacing lives in
+// surfaceSporadicMetrics rather than in the body of computeMetrics.
+//
+// computeMetrics returns early when MessageHistory is empty, and everything
+// below that return is skipped. surfaceSporadicMetrics is called ABOVE it,
+// alongside the other "must run even on an empty pass" bookkeeping.
+//
+// The case where that distinction bites is not exotic — it is the headline
+// provider-overloaded shape. Skipped events never reach addMessageEvent, and
+// claudecode's `system`/`api_error` is Skip=true, so a session whose newly
+// observed transcript content is nothing but retry errors has an EMPTY
+// MessageHistory and takes that early return. Surfacing the error below it
+// would drop it on exactly the session that has one.
+//
+// The fixture is therefore a transcript of only skipped error events, which
+// is what the recorded token-quota ladder looks like between one turn and the
+// next.
+func TestSessionError_SurvivesEmptyMessageHistory(t *testing.T) {
+	path := writeTranscriptLines(t, []map[string]interface{}{
+		{"kind": "error", "phase": "retrying", "attempt": 1, "timestamp": ts(0)},
+		{"kind": "error", "phase": "retrying", "attempt": 2, "timestamp": ts(1)},
+	})
+
+	tl := newSessionErrorTailer(path, true)
+	m, err := tl.TailAndProcess()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// The precondition IS the test's premise: assert the early-return path was
+	// actually taken, so this can never quietly become a test of the ordinary
+	// path that proves nothing about the placement.
+	if len(m.MessageHistory) != 0 {
+		t.Fatalf("precondition: skipped events must not enter MessageHistory (got %d) — "+
+			"without an empty history computeMetrics does not take its early return and "+
+			"this test no longer discriminates where SessionError is surfaced",
+			len(m.MessageHistory))
+	}
+
+	if m.SessionError == nil {
+		t.Fatal("the error was dropped on a pass whose MessageHistory is empty — it is " +
+			"surfaced from below computeMetrics' early return instead of from " +
+			"surfaceSporadicMetrics, which runs above it")
+	}
+}
+
+// TestSessionError_SurvivesAnIdlePoll is the everyday half: once a session has
+// message history, every later poll that reads no new bytes must still report
+// the standing error rather than flickering it away.
+func TestSessionError_SurvivesAnIdlePoll(t *testing.T) {
+	path := writeTranscriptLines(t, []map[string]interface{}{
+		{"kind": "user", "timestamp": ts(0)},
+		{"kind": "error", "phase": "terminal", "timestamp": ts(1)},
+	})
+
+	tl := newSessionErrorTailer(path, true)
+	first, err := tl.TailAndProcess()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.SessionError == nil {
+		t.Fatal("precondition: the first pass must observe the error")
+	}
+
+	second, err := tl.TailAndProcess()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if second.SessionError == nil {
+		t.Fatal("an idle poll dropped the standing error")
+	}
+}
+
+// TestSessionError_LatestErrorWins pins that a retry ladder reports its most
+// recent rung rather than its first.
+//
+// A user watching a red session wants "attempt 5", not "attempt 1" — and the
+// recorded ladders climb (1..5 of 10 in claudecode's token-quota recording),
+// so keeping the first would freeze the display at the least informative
+// value.
+func TestSessionError_LatestErrorWins(t *testing.T) {
+	path := writeTranscriptLines(t, []map[string]interface{}{
+		{"kind": "user", "timestamp": ts(0)},
+		{"kind": "error", "phase": "retrying", "attempt": 1, "timestamp": ts(1)},
+		{"kind": "error", "phase": "retrying", "attempt": 2, "timestamp": ts(2)},
+		{"kind": "error", "phase": "retrying", "attempt": 3, "timestamp": ts(3)},
+	})
+
+	m, err := newSessionErrorTailer(path, true).TailAndProcess()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if m.SessionError == nil || m.SessionError.Attempt == nil {
+		t.Fatalf("expected a retrying error carrying an attempt, got %+v", m.SessionError)
+	}
+	if got := *m.SessionError.Attempt; got != 3 {
+		t.Errorf("Attempt = %d, want 3 (the latest rung of the ladder)", got)
+	}
+}
+
+// TestSessionError_TurnDoneAndErrorOnOneEventKeepsTheError covers the ordering
+// inside applySessionError.
+//
+// A parser that reports BOTH a failure and a turn boundary on one event is
+// describing a turn that ENDED IN FAILURE — claudecode's terminal
+// `isApiErrorMessage` message is exactly that shape, a synthesized assistant
+// message carrying a terminal stop_reason. Clearing after recording would make
+// that shape self-erasing and paint the session green, which is the precise
+// defect the fourth state exists to fix.
+func TestSessionError_TurnDoneAndErrorOnOneEventKeepsTheError(t *testing.T) {
+	tl := newSessionErrorTailer(writeTranscriptLines(t, []map[string]interface{}{
+		{"kind": "user", "timestamp": ts(0)},
+	}), true)
+	if _, err := tl.TailAndProcess(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Drive one event carrying both facts straight through the fold, which is
+	// the only way to construct the simultaneity — a transcript line can only
+	// produce one ParsedEvent, and no shipped parser emits this pair yet.
+	tl.applySessionError(&ParsedEvent{
+		EventType:    "turn_done",
+		SessionError: &SessionError{Phase: ErrorPhaseTerminal, Class: "provider"},
+	})
+
+	if tl.sessionError == nil {
+		t.Fatal("an event reporting a failure AND a turn boundary describes a turn that " +
+			"ended in failure; the error must survive it")
+	}
+}

--- a/core/pkg/tailer/session_error_test.go
+++ b/core/pkg/tailer/session_error_test.go
@@ -64,6 +64,17 @@ func (p *sessionErrorTestParser) ParseLine(raw map[string]interface{}) *ParsedEv
 	case "user":
 		ev.EventType = "user"
 		ev.ClearToolNames = true
+	case "tool_result":
+		// Claude Code delivers a tool result as a user-ROLE line, and its
+		// parser raises ClearToolNames for every `user` event — so a tool
+		// result carries BOTH ClearToolNames and ToolResultIDs. Modelling that
+		// faithfully is the whole point: the first version of this fixture set
+		// ClearToolNames only on real user turns, which quietly encoded the
+		// author's assumption instead of the adapter's behaviour and let a
+		// clear-on-every-tool-call bug through.
+		ev.EventType = "user"
+		ev.ClearToolNames = true
+		ev.ToolResultIDs = []string{"toolu_1"}
 	default:
 		ev.EventType = "assistant"
 	}
@@ -179,19 +190,25 @@ func TestSessionError_ClearedByNextUserTurn(t *testing.T) {
 }
 
 // TestSessionError_SurvivesMidTurnActivity is the guard against clearing too
-// eagerly, and the reason clearSessionErrorOnRecovery keys on ClearToolNames
-// rather than on a user-role event type.
+// eagerly.
 //
-// Tool results arrive on user-role events in several transcript formats. If
-// those counted as "the next turn started", a mid-turn error would be cleared
-// by the next tool round-trip — roughly one second later — which is
-// indistinguishable from never having shown it at all.
+// The tool_result line is the one that matters, and it is why
+// clearSessionErrorOnRecovery carries a `len(ToolResultIDs) == 0` guard rather
+// than reading ClearToolNames alone. Claude Code delivers tool results as
+// user-role lines whose parser raises ClearToolNames, so without the guard a
+// mid-turn error is cleared by the very next tool round-trip — roughly one
+// second later, which is indistinguishable from never having shown it. #558
+// hit precisely this with the task-estimate chip.
+//
+// Found by review: the first version of this test used a fixture whose tool
+// results did not raise ClearToolNames, so it passed against the broken code.
 func TestSessionError_SurvivesMidTurnActivity(t *testing.T) {
 	path := writeTranscriptLines(t, []map[string]interface{}{
 		{"kind": "user", "timestamp": ts(0)},
 		{"kind": "error", "phase": "retrying", "attempt": 1, "timestamp": ts(1)},
 		{"kind": "assistant", "timestamp": ts(2)},
-		{"kind": "assistant", "timestamp": ts(3)},
+		{"kind": "tool_result", "timestamp": ts(3)}, // user-ROLE, raises ClearToolNames
+		{"kind": "assistant", "timestamp": ts(4)},
 	})
 
 	m, err := newSessionErrorTailer(path, true).TailAndProcess()
@@ -199,8 +216,9 @@ func TestSessionError_SurvivesMidTurnActivity(t *testing.T) {
 		t.Fatal(err)
 	}
 	if m.SessionError == nil {
-		t.Fatal("ordinary mid-turn activity must NOT clear a standing error — " +
-			"only a completed turn or a new user turn does")
+		t.Fatal("mid-turn activity cleared a standing error. A tool_result arrives as a " +
+			"user-role line that raises ClearToolNames, so clearSessionErrorOnRecovery must " +
+			"also require len(ToolResultIDs) == 0 — otherwise every tool call wipes the error")
 	}
 }
 

--- a/core/pkg/tailer/tailer.go
+++ b/core/pkg/tailer/tailer.go
@@ -968,7 +968,7 @@ func (t *TranscriptTailer) applyToolCallDeltas(parsed *ParsedEvent, sawUserBlock
 		}
 		delete(t.openToolCalls, id)
 	}
-	if parsed.ClearToolNames && len(parsed.ToolResultIDs) == 0 {
+	if parsed.StartsNewUserTurn() {
 		t.openToolCalls = make(map[string]string)
 	}
 }
@@ -1209,7 +1209,7 @@ func (t *TranscriptTailer) applyAssistantTextAndMarkers(parsed *ParsedEvent) {
 	if t.firstUserText == "" && parsed.UserText != "" {
 		t.firstUserText = cleanSummaryText(parsed.UserText)
 	}
-	if parsed.ClearToolNames && len(parsed.ToolResultIDs) == 0 {
+	if parsed.StartsNewUserTurn() {
 		// A REAL user message (new prompt, ESC, answer) starts a new task or
 		// redirects the current one — the previous estimate no longer
 		// describes what the agent is doing, so reset it like

--- a/core/pkg/tailer/tailer.go
+++ b/core/pkg/tailer/tailer.go
@@ -218,6 +218,13 @@ type SessionMetrics struct {
 	// Nil for sessions that have not called TaskCreate.
 	Tasks []Task `json:"tasks,omitempty"`
 
+	// SessionError is the session's current unrecovered session-level failure
+	// (issue #1798), or nil when the session is healthy. Recomputed from the
+	// tailer's sticky sessionError on every pass, so it appears and
+	// disappears exactly as the clearing rule says (see
+	// clearSessionErrorOnRecovery) rather than accumulating.
+	SessionError *SessionError `json:"session_error,omitempty"`
+
 	// RateLimit is the most recent rate-limit snapshot observed for this
 	// session. Populated by parsers that surface subscription quota (codex
 	// from token_count events) and by the Claude Code statusline hook
@@ -363,6 +370,24 @@ type TranscriptTailer struct {
 	// Kept distinct from lastWasUserInterrupt so the cancellation rule
 	// only fires on real ESC, not on denials (which don't end the turn).
 	lastWasToolDenial bool
+
+	// sessionError is the session's current UNRECOVERED session-level failure
+	// (issue #1798), or nil. Sticky across passes by design: the clearing rule
+	// settled in #1796 is "the next successful turn clears the error", so it
+	// must survive every intervening poll — unlike the per-pass transients
+	// above, and like lastWasUserInterrupt, which it is modelled on.
+	//
+	// THE TAILER OWNS THE CLEARING RULE because the tailer is the only layer
+	// that sees event ORDER. "The next successful turn" means a turn boundary
+	// that arrives AFTER the error, and by the time metrics reach the
+	// classifier the whole pass has collapsed into a single snapshot in which
+	// "turn_done then error" and "error then turn_done" are indistinguishable.
+	// Those two orderings mean opposite things — a turn that failed after
+	// finishing versus a turn that recovered — so the discrimination has to
+	// happen here, while the events are still in sequence.
+	//
+	// See clearSessionErrorOnRecovery for the two events that clear it.
+	sessionError *SessionError
 
 	// lastCWD tracks the most recent working directory seen in transcript lines.
 	lastCWD string

--- a/core/pkg/tailer/tailer_metrics.go
+++ b/core/pkg/tailer/tailer_metrics.go
@@ -71,17 +71,24 @@ func (t *TranscriptTailer) applySessionError(parsed *ParsedEvent) {
 //     would pin a terminal error red for the rest of the session, since a
 //     give-up produces no turn boundary of its own to clear it.
 //
-// A tool result is NOT a recovery even though it arrives on a user-role event
-// in some formats, which is why this reads ClearToolNames — the flag parsers
-// already set for exactly "this is a real user turn boundary, reset open tool
-// state" — rather than matching on the event type. Getting that wrong would
-// clear a mid-turn error on the next tool round-trip, i.e. after roughly one
-// second, which is indistinguishable from never showing it.
+// A TOOL RESULT IS NOT A RECOVERY, and the `len(ToolResultIDs) == 0` guard is
+// what makes that true rather than aspirational. Claude Code delivers tool
+// results as user-ROLE lines, and its parser raises ClearToolNames for every
+// `user` event — so a bare ClearToolNames check clears the error on the next
+// tool round-trip, roughly a second later, which is indistinguishable from
+// never having shown it. This is the identical trap #558 hit with the
+// task-estimate chip (it vanished mid-task on every tool call); the guard here
+// is deliberately spelled the same way as the one in applyAssistantTextAndMarkers
+// so the two read as instances of one rule.
 func (t *TranscriptTailer) clearSessionErrorOnRecovery(parsed *ParsedEvent) {
 	if t.sessionError == nil {
 		return
 	}
-	if parsed.EventType == "turn_done" || parsed.ClearToolNames {
+	if parsed.EventType == "turn_done" {
+		t.sessionError = nil
+		return
+	}
+	if parsed.ClearToolNames && len(parsed.ToolResultIDs) == 0 {
 		t.sessionError = nil
 	}
 }

--- a/core/pkg/tailer/tailer_metrics.go
+++ b/core/pkg/tailer/tailer_metrics.go
@@ -71,15 +71,9 @@ func (t *TranscriptTailer) applySessionError(parsed *ParsedEvent) {
 //     would pin a terminal error red for the rest of the session, since a
 //     give-up produces no turn boundary of its own to clear it.
 //
-// A TOOL RESULT IS NOT A RECOVERY, and the `len(ToolResultIDs) == 0` guard is
-// what makes that true rather than aspirational. Claude Code delivers tool
-// results as user-ROLE lines, and its parser raises ClearToolNames for every
-// `user` event — so a bare ClearToolNames check clears the error on the next
-// tool round-trip, roughly a second later, which is indistinguishable from
-// never having shown it. This is the identical trap #558 hit with the
-// task-estimate chip (it vanished mid-task on every tool call); the guard here
-// is deliberately spelled the same way as the one in applyAssistantTextAndMarkers
-// so the two read as instances of one rule.
+// A TOOL RESULT IS NOT A RECOVERY. That is what StartsNewUserTurn encodes —
+// see it for why a bare ClearToolNames check would clear the error on the next
+// tool round-trip, i.e. within about a second.
 func (t *TranscriptTailer) clearSessionErrorOnRecovery(parsed *ParsedEvent) {
 	if t.sessionError == nil {
 		return
@@ -88,7 +82,7 @@ func (t *TranscriptTailer) clearSessionErrorOnRecovery(parsed *ParsedEvent) {
 		t.sessionError = nil
 		return
 	}
-	if parsed.ClearToolNames && len(parsed.ToolResultIDs) == 0 {
+	if parsed.StartsNewUserTurn() {
 		t.sessionError = nil
 	}
 }

--- a/core/pkg/tailer/tailer_metrics.go
+++ b/core/pkg/tailer/tailer_metrics.go
@@ -24,6 +24,66 @@ func (t *TranscriptTailer) applyMetadata(parsed *ParsedEvent) {
 	if parsed.PendingBackgroundAgentCount != nil {
 		t.lastPendingBackgroundAgentCount = *parsed.PendingBackgroundAgentCount
 	}
+	t.applySessionError(parsed)
+}
+
+// applySessionError maintains the sticky session-level error (issue #1798):
+// it records a failure the parser reported on this event, and clears a
+// standing one once the session recovers.
+//
+// IT LIVES IN applyMetadata ON PURPOSE, and that is the single most important
+// line in this function. scanParsedLine routes an event down one of two
+// mutually exclusive paths — applySkippedEvent for Skip=true, processParsedEvent
+// otherwise — and applyMetadata is the ONLY thing both of them call. The two
+// error shapes this exists for currently land on opposite sides of that fork:
+// claudecode's `system`/`api_error` is Skip=true (it falls through
+// handleSystemEvent's catch-all skip), while copilot's `session.error` would
+// naturally be parsed as an ordinary event. Folding this in processParsedEvent
+// alone would therefore work for one adapter, silently drop the other, and pass
+// every test written against the adapter that worked — the exact shape of the
+// TranscriptPermissionPending defect (#1256), which was correct in the parser,
+// correct under replay, and dropped on the only path that mattered.
+//
+// Ordering within the event is deliberate: a parser reporting BOTH a failure
+// and a turn boundary on one event is reporting a turn that ended in failure,
+// so the error is recorded after the clear and survives.
+func (t *TranscriptTailer) applySessionError(parsed *ParsedEvent) {
+	t.clearSessionErrorOnRecovery(parsed)
+	if parsed.SessionError != nil {
+		t.sessionError = parsed.SessionError
+	}
+}
+
+// clearSessionErrorOnRecovery implements the settled clearing rule from #1796:
+// THE NEXT SUCCESSFUL TURN CLEARS THE ERROR, and nothing else does. There is
+// no minimum hold and no timeout.
+//
+// Two events count as that next successful turn, and they are the two halves
+// of the settled statement "error→working when the next turn starts,
+// error→ready on turn_done":
+//
+//   - a turn boundary (EventType "turn_done") — the retry case. The session
+//     sat red for the whole retry window; the turn then completed, so the
+//     failure is over and the session settles to ready. This is what makes
+//     provider-overloaded-retry end green rather than staying red forever.
+//   - a genuine user message — the next turn starting. A user who types again
+//     has moved on; holding the previous turn's failure against the new one
+//     would pin a terminal error red for the rest of the session, since a
+//     give-up produces no turn boundary of its own to clear it.
+//
+// A tool result is NOT a recovery even though it arrives on a user-role event
+// in some formats, which is why this reads ClearToolNames — the flag parsers
+// already set for exactly "this is a real user turn boundary, reset open tool
+// state" — rather than matching on the event type. Getting that wrong would
+// clear a mid-turn error on the next tool round-trip, i.e. after roughly one
+// second, which is indistinguishable from never showing it.
+func (t *TranscriptTailer) clearSessionErrorOnRecovery(parsed *ParsedEvent) {
+	if t.sessionError == nil {
+		return
+	}
+	if parsed.EventType == "turn_done" || parsed.ClearToolNames {
+		t.sessionError = nil
+	}
 }
 
 // IngestRateLimit accepts an externally-sourced snapshot (the Claude Code
@@ -408,6 +468,17 @@ func (t *TranscriptTailer) surfaceSporadicMetrics() {
 	t.metrics.PendingWaitingCue = t.lastPendingWaitingCue
 	t.metrics.AwaySummary = t.lastAwaySummary
 	t.metrics.PendingBackgroundAgentCount = t.lastPendingBackgroundAgentCount
+
+	// Surfaced HERE rather than in computeMetrics, and that placement is the
+	// behaviour: computeMetrics returns early on a pass that read no new
+	// transcript bytes, so an errored session polled while idle — which is
+	// every poll between the failure and the user noticing it — would surface
+	// a nil error and flip straight back out of StateError. This function runs
+	// unconditionally, which is why the sporadic fields above live in it too.
+	//
+	// Copied verbatim rather than merged: the sticky field IS the current
+	// verdict, including when it is nil because the clearing rule just fired.
+	t.metrics.SessionError = t.sessionError
 }
 
 // computeBackgroundProcessMetrics surfaces background-process bookkeeping.

--- a/events.md
+++ b/events.md
@@ -1,24 +1,51 @@
 # Irrlicht Session State Machine
 
-## States (3, MECE)
+## States (4, MECE)
 
 | State | Definition |
 |-------|-----------|
 | **`working`** | Agent actively processing (tools, text generation, hooks, compaction, API retries) |
 | **`waiting`** | User-blocking tool open -- agent needs user to respond (AskUserQuestion, ExitPlanMode) |
 | **`ready`** | Agent idle at prompt, waiting for next user message |
+| **`error`** | The session's own machinery failed -- provider refused or failed the call, credentials rejected, agent process died mid-turn, or Irrlicht could not read the session (#1796) |
+
+`error` is NOT a tool failure. A grep that matched nothing or a build that
+broke is the agent working normally and stays `working`.
+
+The vocabulary is declared once, in `session.CanonicalStates()`; the daemon
+derives both `IsCanonicalState` and every message that lists the states from
+it, so this table is documentation rather than a second source of truth.
 
 ### Decision Tree
 
 1. Is there an open user-blocking tool? **Yes** -> `waiting`
-2. Is the agent actively processing? **Yes** -> `working`
-3. Otherwise -> `ready`
+2. Is there an unrecovered session-level failure? **Yes** -> `error`
+3. Is the agent actively processing? **Yes** -> `working`
+4. Otherwise -> `ready`
+
+Step 2 sits above step 3 deliberately: a terminal provider failure often
+leaves a transcript tail that reads like a finished turn, so a lower placement
+would report a failed session as `ready` -- green, and silent.
+
+### Leaving `error`
+
+The next SUCCESSFUL turn clears it, and nothing else does -- no timeout, no
+minimum hold:
+
+- `error -> working` when the next turn starts
+- `error -> ready` on `turn_done`
+
+Known and accepted: with no minimum hold, a provider error that recovers in a
+few hundred milliseconds can enter and leave `error` inside one poll interval
+and never be seen.
+
+An errored session does not count toward concurrency, the same as `ready`.
 
 ---
 
 ## Application Lifecycle Events
 
-These events manage the existence of sessions -- creation and deletion. They are independent of the working/waiting/ready state machine.
+These events manage the existence of sessions -- creation and deletion. They are independent of the lifecycle state machine.
 
 | User Scenario | Before | After | Technical Trigger | Detection |
 |--------------|--------|-------|-------------------|-----------|
@@ -56,7 +83,7 @@ Pre-sessions (`proc-<pid>`) are synthetic sessions created by the process scanne
 
 ## Session State Transitions
 
-These transitions change the working/waiting/ready state of an existing session.
+These transitions change the lifecycle state of an existing session.
 
 | User Scenario | Before | After | Technical Trigger | Detection |
 |--------------|--------|-------|-------------------|-----------|
@@ -130,7 +157,7 @@ Parent-child relationships are derived from the transcript path: Claude Code wri
 subagentSummary { total, working, waiting, ready int }
 ```
 
-Subagent sessions run independent state machines with the same 3 states.
+Subagent sessions run independent state machines with the same states.
 
 ---
 


### PR DESCRIPTION
Phase 1 of #1796. Adds the fourth session state `error` and the plumbing that will feed it, so a session whose provider call fails, whose credentials are rejected, or whose turn aborts is visibly red instead of silently green.

**No adapter emits the new signal yet** — that is #1799 (claude-code + copilot) and #1800 (the rest + process death). So `error` is **expressible but not yet reachable** in production. That is the scope line, and it is why every replay golden is byte-identical and why the downstream three-way consumers listed at the bottom are not yet wrong.

## What landed

### 1. The state
- `StateError`, plus `CanonicalStates()` as the **single declaration** of the vocabulary. `IsCanonicalState` derives from it.
- **The #1798 carry-forward finding from #1797's QA is fixed**: `warnUnknownStateOnce` built its message from a hand-typed `%s/%s/%s` with three constants passed positionally. It now reads `CanonicalStates()`, so the check and the message cannot drift.
- The dangling `STATES.md` doc reference is repointed at `events.md`, which is where the spec actually lives. (`STATES.md` has never existed in this repo.)

### 2. The detail — `ParsedEvent.SessionError` / `session.SessionError`

The field names later issues consume:

| Field | Type | Notes |
|---|---|---|
| `Phase` | `ErrorPhase` | `""` (unknown) / `"retrying"` / `"terminal"`, with `.Known()` |
| `Class` | `string` | adapter-normalized: `rate_limit`, `quota`, `auth`, `query`, `provider`, … |
| `Message` | `string` | human text, verbatim from the agent |
| `HTTPStatus` | `*int` | nil when the transcript carries none |
| `Attempt` | `*int` | 1-based, resets per API call |
| `MaxAttempts` | `*int` | the agent's own ceiling |
| `RetryIn` | `*time.Duration` | Go type; serializes as `retry_in_ms` (fractional) |

Helpers: `SessionError.IsRetrying()`, `SessionError.Equal()`, `ErrorPhase.Known()`. Signal: `session.SignalSessionError`. Metrics: `SessionMetrics.SessionError`. Trace: `ClassifierInputs.SessionErrorClass` / `.SessionErrorPhase`.

**Kept strictly distinct from the existing `IsError`**, which is a tool_result failure — a grep that matched nothing must never turn a session red.

**Every number is a pointer, and that is load-bearing.** The recorded payloads disagree about which numbers exist at all:
- claudecode retrying `api_error`: `error.status` 429, `retryInMs` 616.4520045919932 (**a float**), `retryAttempt`, `maxRetries` — all present
- claudecode terminal `isApiErrorMessage`: **none** of them; its text is literally `API Error: API returned an empty or malformed response (HTTP 200)`, where the only number in the prose is the transport's *success* code
- copilot `session.error`: `statusCode` for `errorType:"rate_limit"`, **absent** for `errorType:"query"`

With plain ints all three absences read as `0`, and "attempt 0 of 0" would derive a give-up from data that said nothing.

**Terminal-ness is the adapter's verdict, never `Attempt == MaxAttempts`.** Across all 16 recorded `api_error` events the counter never once reaches `maxRetries` (observed range 1..5 of 10; the ladder is abandoned when the user intervenes, not exhausted), while the shapes that *are* terminal carry no counters at all. Deriving from that equality would report every real give-up as "still retrying".

### 3. The pipe
- The fold lives in **`applyMetadata`** — the only function both of the tailer's mutually exclusive routing paths call. claudecode's `api_error` is `Skip=true` (→ `applySkippedEvent`); copilot's `session.error` is an ordinary event (→ `processParsedEvent`). Folding in one alone works for one adapter and silently drops the other.
- Surfaced from **`surfaceSporadicMetrics`**, above `computeMetrics`' early return. That return is guarded on `len(MessageHistory)==0`, and skipped events never enter MessageHistory — so a transcript of only retry errors takes it, which is exactly the provider-overloaded shape.
- Added to **`newMergedMetrics`' allowlist** and deliberately **not** to any `carryForward*` helper: carry-forward restores `oldM` when `newM` reads unset, and unset is precisely how the tailer says *cleared*, so it would make the error unclearable.

### 4. Where the rule sits in the ladder, and why

Immediately **above `agent_done`**, guarded on `!m.HookTurnDone`:

```go
id:     string(session.SignalSessionError),
signal: session.SignalSessionError,
when: func(_ string, m *session.SessionMetrics) bool {
    return m.SessionError != nil && !m.HookTurnDone
},
decide: toState(session.StateError, "session error → error"),
```

- **Above `agent_done`**, because a terminal failure and a completed turn look identical from the transcript tail — claudecode records a give-up as an ordinary assistant message with a terminal `stop_reason`, so `IsAgentDone()` reads true and `agent_done` would route it to `ready`. That *is* the defect the fourth state exists to fix.
- **Below the five waiting rules**, because a session blocked on a human is actionable now while a past failure is not, and because those include hook-tier rows a transcript-tier rule must never preempt.
- **The `!HookTurnDone` guard** is the settled clearing rule ("error → ready on turn_done") stated where the ladder can see it. It also makes this rule and `agent_done` **mutually exclusive at TierHook** — `agent_done` is hook-tier *only* when `HookTurnDone` — so the ladder stays tier-consistent **by construction** rather than by argument.
- The clearing rule's **transcript half never reaches the ladder at all**: the tailer clears its sticky error on that boundary, because the tailer is the only layer that sees whether the boundary arrived *before* or *after* the error. Those two orderings mean opposite things and collapse into one indistinguishable snapshot by the time metrics reach the classifier.

### 5. Dwell (§6) — decided, not skipped
`error` is debounced in **neither** direction, written into `graceFor`'s comment. Into `error`: it raises a come-look cue, so delaying it spends the grace in the expensive direction. Out of `error`: only a genuine successful turn clears it, so there is no flap to suppress.

### 6. Audited direct `.State` writes (§7)
`applyStateTransition` gained an explicit `case session.StateError` recording three decisions rather than leaving them to the zero case: `WaitingStartTime` is neither set (the session is not blocked on the user) nor cleared (`error` is reachable *from* `waiting` and the clearing rule routes back through working/ready, which own the field), and `CaptureYieldOnReady` is not called (yield asks whether a *finished* session's work survived; a failed turn has not finished).

`seedReevaluateOne`'s `newState != StateWorking` filter deliberately does **not** exclude `error`: the filter stops an unevidenced promotion to working, whereas `error` is re-derived from a persisted `SessionError` and should survive a restart rather than come back green.

## Red-first evidence

**1. The carry-forward finding — a real defect test, seen red before the fix.** Test written first, run against the hardcoded message:

```
--- FAIL: TestWarnUnknownState_NamesEveryCanonicalState (0.00s)
    warning omits canonical state "error" — the message carries a hand-copied
    vocabulary that has drifted from IsCanonicalState.
    message: session file "s1.json" has unrecognized state "zzz-not-a-state"
             (this build knows only working/waiting/ready) — keeping the file...
--- FAIL: TestWarnUnknownState_ClaimsNoStateItDoesNotKnow (0.00s)
    warning does not carry the vocabulary verbatim as "working/waiting/ready/error"
```

**2. Everything else this change ADDS has no "before" — so it was mutated.** Each mutation applied, seen red, reverted:

| # | Mutation | Went red |
|---|---|---|
| A | fold moved out of `applyMetadata` into `processParsedEvent` only | `TestSessionError_RecordedOnBothRoutingPaths/skipped-event` |
| B | surfacing moved below `computeMetrics`' early return | `TestSessionError_SurvivesEmptyMessageHistory` |
| C | `applySessionError` order flipped (clear *after* record) | `TestSessionError_TurnDoneAndErrorOnOneEventKeepsTheError` |
| D | clearing widened to any assistant event | `TestSessionError_SurvivesMidTurnActivity` |
| E | `SessionError` dropped from the `newMergedMetrics` allowlist | `TestMergeMetrics_CarriesSessionError` |
| F | the `!HookTurnDone` guard removed from the classifier rule | `TestStateRules_LadderIsTierConsistent` |

F is the one that matters most, and its output is the placement argument made mechanical:

```
--- FAIL: TestStateRules_LadderIsTierConsistent
  session-error-terminal/turn-done (current=working): rule "session_error" (tier transcript)
    decided, but lower rule "agent_done" (tier hook) outranks it
  ... 20+ rows across session-error+turn-done, session-error-retrying,
      session-error-on-finished-turn × current=working/waiting/ready/error
```

**The mutations are committed as fixtures**, not just described: the corpus rows `session-error-terminal`, `session-error-retrying`, `session-error-on-finished-turn` and the hold sets `session-error`, `session-error+turn-done` in `reachableMetricFixtures`, plus a `payloadFor` helper (without it the hold applies nothing and the fixtures would be indistinguishable from "no error").

**A mutation caught a false green in my own test.** My first `idle pass` test passed mutation B — i.e. proved nothing. Root cause: `computeMetrics`' early return is guarded on `len(MessageHistory)==0`, **not** on "this pass read no new bytes", and MessageHistory accumulates across passes. The discriminating case is a transcript whose events are *all* `Skip=true` — which is the real provider-overloaded shape. Rewritten to that, plus an explicit precondition asserting MessageHistory is empty so it can never silently degrade again.

**`TestStateRules_LadderIsTierConsistent` now asserts its own coverage.** A corpus sweep reports "no violations" identically whether it covers the rule or cannot reach it, so the test fails if no fixture reached the `session_error` rule.

**Locks — these pass by construction and are NOT red-first proof:**
- `TestMergeMetrics_ClearedSessionErrorStaysCleared` (guards a future `carryForward*` addition)
- `TestSessionError_AbsentNumbersStayAbsent` (pins the pointer shape)
- `core/e2e/crash_test.go`'s SIGKILL test — logic unchanged; it delegates to `IsCanonicalState` and widened for free. Only its prose was updated.

**Loudly-firing existing gate** (an invariant test doing its job, not red-first proof): `TestSignalPolicies_OrderIsPinned` failed with *"signalPolicies has 6 rows, want 5"*; `want` updated and the new `turn_done → session_error` ordering dependency documented.

## "Exactly three states" tests — updated, not deleted
- `state_classifier_tier_test.go:63` — the `cur` loop now reads `session.CanonicalStates()` instead of three literals, so it stays exhaustive as the vocabulary grows (it would otherwise have compiled, passed, and silently stopped checking the invariant for `current=error`).
- `crash_test.go` — prose only; the assertion already delegated to `IsCanonicalState`.
- `concurrency_tracker_test.go:495` — deliberately kept at three, with the reason inline: `ByState` is a three-key literal in production and its widening is #1801's, along with the web `toEqual({working,waiting,ready})` that pins the same shape. Reading the domain vocabulary here would fail for a gap scoped elsewhere.
- `replayengine/engine_test.go:86` — inert by design (an "at least one of each" check, not a universe sweep); noted so the missing `default` arm doesn't read as an oversight.

## Gates

| Gate | Result |
|---|---|
| `--only go` (core + factory + replaydata validate + rig smoke + **replay fixtures**) | PASS |
| `--only arch` (ARS) | PASS — composite 7.9012 → 7.9020, no regression |
| `--only web` (both trees) | PASS |
| `--only tools` / `--only skills` | PASS |
| `--only posix` / `--only bash` | PASS |
| `--only swift` | PASS |
| `--only security` | PASS |
| `go vet ./core/...` (explicit — `copylocks` is outside `go test`'s subset) | PASS |

Replay fixtures passing is the evidence for the scope claim: no adapter emits the field, so no golden moved.

## Deliberately out of scope, flagged for the epic
Not yet wrong, because `error` is unreachable until #1799/#1800 — but they must land before it becomes reachable:
- `concurrency_tracker.go:305,415` + `handlers.go:628` — three copies of a hardcoded 3-key `ByState` literal (#1801)
- `diagnostics_service.go:1157`, `grouped.go:293` — 3-arm switches with no `default`; counts would stop summing to the total (#1801/#1802)
- `history_tracker.go:43,174` — `statePriority` defaults to `ready`, so an errored bucket paints green on the history bar. The 2-bit wire format has all four codes taken; #1796 explicitly cuts this to #1805/#1807
- `irrlicht-ls/main.go:122` — `--state` validator + help text hardcode three values; should call `IsCanonicalState`
- `backchannel/rule.go:11` + `backchannel_service.go:282` — a parallel, independently-spelled state vocabulary
- `site/docs/light-system.html` — *"There is no fourth state"* is now false, in several places

**Free consequence, stated rather than re-implemented:** `concurrency_tracker.go` gates timeline intake on `IsCanonicalState` and `concurrencyActive` returns `working || waiting`, so widening the vocabulary automatically makes an errored session **not active** for concurrency — which is #1796's settled decision, implemented explicitly in #1801. This branch inherits it and does not touch it.

## Known limitation
The tailer's sticky error is not in `LedgerState`. The field *is* persisted in the session JSON, so a standing error survives a restart through the startup seed pass — but the first fresh tailer pass carries nil and the allowlist copies it verbatim, so it clears at the next poll of that transcript. Self-limiting direction; the clean fix is ledger persistence, deliberately deferred to #1800 where the first real producer arrives.

---

## Review and simplify rounds (after the first commit)

A `high`-effort review subagent returned **12 findings, all actioned**, and found **two real defects** that the first commit shipped. The `/simplify` fan-out then returned four more reports. Full detail is in the commit messages; the load-bearing parts:

### Two real defects, both caught after the first commit

**A Claude Code tool result wiped the standing error.** `clearSessionErrorOnRecovery` read a bare `ClearToolNames` — but claudecode's parser raises that flag for every *user-role* event, and tool results arrive as user-role lines. A mid-turn error was cleared by the next tool round-trip, about a second later. The repo already documents this exact trap at `tailer.go:1212` (#558, where it made the task-estimate chip vanish mid-task). My comment described the hazard and the code walked into it; **my own test missed it because its purpose-built parser set `ClearToolNames` only on real user turns — it encoded my model of the adapter rather than the adapter.** Red-first evidence against the original guard:

```
--- FAIL: TestSessionError_SurvivesMidTurnActivity
    mid-turn activity cleared a standing error. A tool_result arrives as a user-role
    line that raises ClearToolNames, so clearSessionErrorOnRecovery must also require
    len(ToolResultIDs) == 0 — otherwise every tool call wipes the error
```

**`error → ready on turn_done` was unreachable.** `classifyAgentDone` enumerated the states it promotes *from* (`working || waiting`), falling through to a no-op otherwise. Complete over three states, silently incomplete over four — so a session in `error` could never reach `ready` and the settled clearing rule's primary half was dead on arrival. Found by a test added only because CodeScene noted `state_classifier.go` usually changes with `state_classifier_test.go`:

```
--- FAIL: TestClassify_SessionErrorRoutesToError/hook-delivered_turn_done_clears_the_error
    ClassifyState("error") = "error", want "ready"
```

Replaced with `transitionTo`, which has no enumeration to go stale and produces identical output for all three original states — so no golden moved.

### A third instance of the same bug class

Acting on the reviewer's process point turned up one more: `refreshStaleSessions`' switch matched `StateWorking` and `StateWaiting, StateReady` — and **`StateError` matched neither arm**. `shouldRevisitIdleSession` is the only thing that asks `signals.HasAny`, and a classify pass is the only thing that evaluates a hold's ceiling, so **`sessionErrorHoldTimeout` could never fire** — a declared ceiling that reads like a safety net in the policy table and is not one. Fixed.

**Tally: four hardcoded three-state enumerations. This PR fixed one deliberately (`warnUnknownStateOnce`, with a test), then shipped two more and found a third.** The altitude agent prototyped a static tripwire for this class and measured it against the current tree: at "≥3 of the 4 constants named directly" it reports **6 sites with 0 false positives**, four of which need the wire widening already tracked as #1805/#1807. It also honestly reports that it would **not** catch `history_tracker.statePriority` (2 states plus a `default`), and that lowering the threshold to ≥2 gives ~50% false positives. Recommended for **#1804** (docs + gates), not built here.

### Comments that asserted what the code did not do

The review's sharpest process finding: *"the ones here that were checkable turned out wrong at a materially higher rate than the code did."* Four were, and all are corrected:

- The **restart story was inverted.** `seedReevaluateOne` calls `RefreshMetrics` (a `MergeMetrics` against a fresh nil) *before* `ClassifyState`, so the persisted error is destroyed before the seed classifier reads it. It does **not** survive a restart at all — the comment claimed the opposite. `LedgerState` persistence is the fix, deferred to #1800 where the first producer lands.
- The **`!HookTurnDone` guard is a one-pass suppression, not a clear** — `SignalTurnDone` is `consumeOnce`. A hook-triggered pass landing before the transcript flush yields a spurious `error→ready→error` pair. Unreachable in this phase (no producer); named, with the mechanism, for #1799.
- **The rule's tier is pinned** by its `signal` field, so #1800's `TierProcess` evidence would be recorded as `TierTranscript`. Understating a tier never trips the ladder invariant, so nothing would catch it — #1800 adds its own row.
- **`Equal` and `IsRetrying` have no production caller yet.**

### Guards that had no mutation fixture

Per AGENTS.md, a check the change *adds* owes a mutation seen red. Three did not have one — removing `CanonicalStates`' defensive copy, aliasing instead of deep-copying in `convertSessionError`, and breaking the `SignalSessionError` policy row all left the suite **green**. Each now has a committed test, each verified red under its mutation.

### Efficiency: measured, nothing regressed

`IsCanonicalState` went from three comparisons to a 4-element scan: **+2.2 ns/call, still zero-alloc, 0.01% of the ~21.8 µs `ListAll` already spends per session file.** `CanonicalStates()` allocates (64 B) but its only production caller is behind `warnUnknownStateOnce`'s once-per-value guard. `applySessionError` **inlines** (confirmed via `-gcflags=-m`) and is two field reads on the nil path. The tier property test's corpus grew 2.10× and its runtime 2.1× — **+0.12 ms**, 0.05% of the package run.

### Simplify pass

- **`irrlicht-ls --state error` was rejecting a state the daemon now emits**, and telling the user the tool knew three — the same two-part defect as `warnUnknownStateOnce`, one directory over. Fixed.
- The vocabulary test hand-rolled a Logger double; `contracttesting.RecordingLogger` exists for exactly this and **its doc comment names this caller**. Now reused, and asserts the event-type tag it previously could not see.
- `ClearToolNames && len(ToolResultIDs) == 0` was hand-spelled at four sites, each re-explaining #558. Now `ParsedEvent.StartsNewUserTurn()`.
- `copyPtr` absorbed `copyTailerTaskEstimate` (#753) — the pre-existing third token-identical copier in the same file.
- The JSON codec embeds a method-stripped alias instead of a mirror struct, so a new field needs zero encoder edits.
- The `SignalSessionError` row now applies only into an **empty slot**: two writers at one tier with the winner decided by call order is not arbitration.
- Four arguments were each restated in 2–6 places; each now has one owner and one-line cross-references.

### One more consequence for the epic

Seven sites re-derive "which states count as active" inline (`concurrencyActive`, `hasActiveChildren`, `isOrphanedChild`, …). Every one silently acquired a verdict about `error` when the state landed. It is currently *correct* for concurrency (an errored session is not active — #1796's settled decision, which this branch inherits for free and does not touch), but **a session in `error` with `Phase == retrying` is by construction still working**, and `hasActiveChildren` would let a parent go ready while such a child is still trying. Nothing reaches that today because no adapter emits the field; **#1799 makes it reachable.** Worth deciding in #1801 alongside `concurrencyActive`.

Closes #1798

🤖 Generated with [Claude Code](https://claude.com/claude-code)
