### PR TITLE
feat(states): expose `error` over the wire and render it red in the web dashboard

### DIFF
--- a/core/adapters/outbound/filesystem/concurrency_tracker.go
+++ b/core/adapters/outbound/filesystem/concurrency_tracker.go
@@ -341,18 +341,27 @@ func (t *ConcurrencyTracker) StateSeries(q outbound.SeriesQuery) (*outbound.Stat
 
 	for state, byProject := range instants {
 		for project, events := range byProject {
-			dst := make([]float64, n)
-			for _, ts := range events {
-				idx := int((ts - start) / bucketSeconds)
-				if idx >= 0 && idx < n {
-					dst[idx]++
-				}
-			}
-			out.ByState[state][project] = dst
+			out.ByState[state][project] = bucketTransitionCounts(events, start, bucketSeconds, n)
 		}
 	}
 
 	return out, nil
+}
+
+// bucketTransitionCounts histograms instantaneous transition timestamps into
+// the series' buckets — the counterpart of bucketPeakSeries, which measures
+// duration states instead. Timestamps outside [start, start+n*bucketSeconds)
+// are dropped rather than clamped: a transition outside the window did not
+// happen in any of its buckets, and folding it into the nearest one would
+// invent activity at an edge.
+func bucketTransitionCounts(events []int64, start, bucketSeconds int64, n int) []float64 {
+	dst := make([]float64, n)
+	for _, ts := range events {
+		if idx := int((ts - start) / bucketSeconds); idx >= 0 && idx < n {
+			dst[idx]++
+		}
+	}
+	return dst
 }
 
 // collectScopedStateIntervals is collectScopedIntervals' per-state
@@ -384,21 +393,30 @@ func collectScopedStateIntervals(timelines map[string]*sessionTimeline, q outbou
 		project := tl.project
 		ivs, instantAt := tl.stateReconstruction()
 		current += appendClampedStateIntervals(byState, project, ivs, start, end)
-		// Only mint a key when there is something to record: an unconditional
-		// append would create an entry for every in-scope project, turning "no
-		// transitions of this kind" into an empty series downstream.
-		for state, at := range instantAt {
-			inWindow := instantsInWindow(at, start, end)
-			if len(inWindow) == 0 {
-				continue
-			}
-			if instants[state] == nil {
-				instants[state] = map[string][]int64{}
-			}
-			instants[state][project] = append(instants[state][project], inWindow...)
-		}
+		appendInstantsInWindow(instants, project, instantAt, start, end)
 	}
 	return byState, instants, current
+}
+
+// appendInstantsInWindow folds one session's transition timestamps into the
+// shared state -> project -> timestamps index, keeping only those inside
+// [start, end).
+//
+// A key is minted only when there is something to record. An unconditional
+// append would create an entry for every in-scope project, which downstream
+// turns "no transitions of this kind here" into an empty SERIES — a row of
+// zeroes the dashboard draws, rather than an absence it skips.
+func appendInstantsInWindow(dst map[string]map[string][]int64, project string, instantAt map[string][]int64, start, end int64) {
+	for state, at := range instantAt {
+		inWindow := instantsInWindow(at, start, end)
+		if len(inWindow) == 0 {
+			continue
+		}
+		if dst[state] == nil {
+			dst[state] = map[string][]int64{}
+		}
+		dst[state][project] = append(dst[state][project], inWindow...)
+	}
 }
 
 // appendClampedStateIntervals appends every interval in ivs — clamped to

--- a/core/adapters/outbound/filesystem/concurrency_tracker.go
+++ b/core/adapters/outbound/filesystem/concurrency_tracker.go
@@ -116,7 +116,7 @@ func (t *ConcurrencyTracker) Dir() string { return t.dir }
 // state timeline.
 type stateChange struct {
 	ts    int64
-	state string // working|waiting|ready
+	state string // any session.CanonicalStates() value
 }
 
 // sessionTimeline accumulates one session's state transitions and project label
@@ -141,6 +141,19 @@ type interval struct {
 // is "concurrent" while working or waiting, and stops once it goes ready
 // (process exited / cancelled / transcript removed) — the three-state model
 // read literally (#751).
+//
+// `error` is NOT active, and that is a settled decision rather than an
+// oversight of #1798's fourth state (events.md; #1801). Nothing clears a
+// session error until the next successful turn, so an errored session counted
+// here would inflate the concurrency metric for the whole rest of its life —
+// the failure mode is permanent, not transient.
+//
+// This is one half of a partition whose other half is
+// session.SessionState.HasWorkInFlight ("is more work coming?"), where an
+// errored-but-retrying session DOES count. The two cannot be one function and
+// this one cannot read the error detail even if it wanted to: it is handed a
+// bare state string off a persisted timeline that carries no SessionError at
+// all. Read HasWorkInFlight's doc before merging them.
 func concurrencyActive(state string) bool {
 	return state == session.StateWorking || state == session.StateWaiting
 }
@@ -302,11 +315,7 @@ func (t *ConcurrencyTracker) StateSeries(q outbound.SeriesQuery) (*outbound.Stat
 		End:           end,
 		BucketSeconds: bucketSeconds,
 		BucketStarts:  make([]int64, n),
-		ByState: map[string]map[string][]float64{
-			session.StateWorking: {},
-			session.StateWaiting: {},
-			session.StateReady:   {},
-		},
+		ByState:       outbound.NewStateBuckets(),
 	}
 	for i := range out.BucketStarts {
 		out.BucketStarts[i] = start + int64(i)*bucketSeconds
@@ -317,7 +326,7 @@ func (t *ConcurrencyTracker) StateSeries(q outbound.SeriesQuery) (*outbound.Stat
 		return nil, err
 	}
 
-	byState, readyByProject, current := collectScopedStateIntervals(timelines, q, start, end)
+	byState, instants, current := collectScopedStateIntervals(timelines, q, start, end)
 	out.Current = current
 
 	var allActive []interval
@@ -330,15 +339,17 @@ func (t *ConcurrencyTracker) StateSeries(q outbound.SeriesQuery) (*outbound.Stat
 	}
 	out.Peak, out.Average = totalPeakAndAverage(allActive, start, end)
 
-	for project, events := range readyByProject {
-		dst := make([]float64, n)
-		for _, ts := range events {
-			idx := int((ts - start) / bucketSeconds)
-			if idx >= 0 && idx < n {
-				dst[idx]++
+	for state, byProject := range instants {
+		for project, events := range byProject {
+			dst := make([]float64, n)
+			for _, ts := range events {
+				idx := int((ts - start) / bucketSeconds)
+				if idx >= 0 && idx < n {
+					dst[idx]++
+				}
 			}
+			out.ByState[state][project] = dst
 		}
-		out.ByState[session.StateReady][project] = dst
 	}
 
 	return out, nil
@@ -346,16 +357,24 @@ func (t *ConcurrencyTracker) StateSeries(q outbound.SeriesQuery) (*outbound.Stat
 
 // collectScopedStateIntervals is collectScopedIntervals' per-state
 // counterpart: it gathers each in-scope session's working/waiting intervals,
-// clamped to [start, end) and grouped by state then project, plus every ready
-// transition timestamp landing in [start, end), grouped by project. current
-// counts sessions active (in either state) strictly across end, matching
-// collectScopedIntervals' "still active now" semantics exactly.
-func collectScopedStateIntervals(timelines map[string]*sessionTimeline, q outbound.SeriesQuery, start, end int64) (byState map[string]map[string][]interval, readyByProject map[string][]int64, current float64) {
-	byState = map[string]map[string][]interval{
-		session.StateWorking: {},
-		session.StateWaiting: {},
+// clamped to [start, end) and grouped by state then project, plus every
+// instantaneous transition landing in [start, end), grouped by state then
+// project. current counts sessions active (in either duration state) strictly
+// across end, matching collectScopedIntervals' "still active now" semantics
+// exactly.
+//
+// The duration seeding is derived from the vocabulary filtered by
+// concurrencyActive rather than typed out, so it and stateReconstruction's
+// routing below cannot disagree about which states have a duration — a
+// disagreement would be a nil-map write in appendClampedStateIntervals.
+func collectScopedStateIntervals(timelines map[string]*sessionTimeline, q outbound.SeriesQuery, start, end int64) (byState map[string]map[string][]interval, instants map[string]map[string][]int64, current float64) {
+	byState = map[string]map[string][]interval{}
+	for _, s := range session.CanonicalStates() {
+		if concurrencyActive(s) {
+			byState[s] = map[string][]interval{}
+		}
 	}
-	readyByProject = map[string][]int64{}
+	instants = map[string]map[string][]int64{}
 	for sid, tl := range timelines {
 		if !concurrencyScopeMatches(q, sid, tl.project) {
 			continue
@@ -363,16 +382,23 @@ func collectScopedStateIntervals(timelines map[string]*sessionTimeline, q outbou
 		// See the matching comment in collectScopedIntervals: "" is left raw
 		// for handlers.go's resolveUnknownStateProject to decide (issue #1046).
 		project := tl.project
-		ivs, readyAt := tl.stateReconstruction()
+		ivs, instantAt := tl.stateReconstruction()
 		current += appendClampedStateIntervals(byState, project, ivs, start, end)
-		// Only touch readyByProject when there is something to record: an
-		// unconditional append would mint a key for every in-scope project,
-		// turning "no ready transitions" into an empty series downstream.
-		if inWindow := readyInWindow(readyAt, start, end); len(inWindow) > 0 {
-			readyByProject[project] = append(readyByProject[project], inWindow...)
+		// Only mint a key when there is something to record: an unconditional
+		// append would create an entry for every in-scope project, turning "no
+		// transitions of this kind" into an empty series downstream.
+		for state, at := range instantAt {
+			inWindow := instantsInWindow(at, start, end)
+			if len(inWindow) == 0 {
+				continue
+			}
+			if instants[state] == nil {
+				instants[state] = map[string][]int64{}
+			}
+			instants[state][project] = append(instants[state][project], inWindow...)
 		}
 	}
-	return byState, readyByProject, current
+	return byState, instants, current
 }
 
 // appendClampedStateIntervals appends every interval in ivs — clamped to
@@ -393,10 +419,10 @@ func appendClampedStateIntervals(byState map[string]map[string][]interval, proje
 	return current
 }
 
-// readyInWindow returns the ready-transition timestamps landing in [start, end).
-func readyInWindow(readyAt []int64, start, end int64) []int64 {
+// instantsInWindow returns the transition timestamps landing in [start, end).
+func instantsInWindow(at []int64, start, end int64) []int64 {
 	var out []int64
-	for _, ts := range readyAt {
+	for _, ts := range at {
 		if ts >= start && ts < end {
 			out = append(out, ts)
 		}
@@ -412,11 +438,7 @@ func emptyStateSeriesResult(start, end, bucketSeconds int64) *outbound.StateSeri
 		End:           end,
 		BucketSeconds: bucketSeconds,
 		BucketStarts:  []int64{},
-		ByState: map[string]map[string][]float64{
-			session.StateWorking: {},
-			session.StateWaiting: {},
-			session.StateReady:   {},
-		},
+		ByState:       outbound.NewStateBuckets(),
 	}
 }
 
@@ -514,15 +536,28 @@ func concurrencyScopeMatches(q outbound.SeriesQuery, sessionID, project string) 
 // interval, which only tracks "active" (working or waiting, merged).
 type stateInterval struct {
 	enter, exit int64
-	state       string // session.StateWorking | session.StateWaiting
+	state       string // a concurrencyActive state: session.StateWorking | session.StateWaiting
 }
 
 // stateReconstruction rebuilds a session's full timeline: working/waiting
 // spans as durations (stateInterval, tagged by which of the two states was
-// active) and every transition into ready as an instantaneous timestamp —
-// ready is session.go's terminal state, with no duration to be concurrent in,
-// so "how many agents went ready in bucket X" (issue #981) is a transition
-// count, not a concurrency count. A session still working/waiting at its last
+// active) and every transition into a NON-duration state as an instantaneous
+// timestamp — ready has no duration to be concurrent in, so "how many agents
+// went ready in bucket X" (issue #981) is a transition count, not a
+// concurrency count.
+//
+// #1801 puts `error` on the transition-count side with ready, and the split is
+// concurrencyActive rather than a second list, deliberately. An errored
+// session is settled as NOT active (events.md; nothing clears an error until
+// the next successful turn, so a dwell would inflate both the concurrency
+// series and `current` for the rest of the session's life). Once it is not
+// active it has no interval to contribute, and a transition count — "how many
+// sessions went red in bucket X" — is the only honest thing left to record.
+// Deriving the two sides from one predicate also means they cannot disagree:
+// a state seeded as a duration but routed as an instant, or vice versa, would
+// be a nil-map write rather than a wrong number.
+//
+// A session still working/waiting at its last
 // recorded event (no terminator) is bounded at that last event — "last known
 // alive" — so a daemon that died mid-session doesn't leave it counted as alive
 // forever; same rule the merged reconstruction below always used. (lastEventTS
@@ -540,7 +575,7 @@ type stateInterval struct {
 // AgentsSeries and StateSeries despite clearly having been active at that
 // instant (issue #983). A one-second floor is the same granularity every
 // timestamp here already uses (ev.Timestamp.Unix()).
-func (tl *sessionTimeline) stateReconstruction() (ivs []stateInterval, readyAt []int64) {
+func (tl *sessionTimeline) stateReconstruction() (ivs []stateInterval, instantAt map[string][]int64) {
 	if len(tl.transitions) == 0 {
 		return nil, nil
 	}
@@ -548,9 +583,13 @@ func (tl *sessionTimeline) stateReconstruction() (ivs []stateInterval, readyAt [
 	sort.SliceStable(tr, func(i, j int) bool { return tr[i].ts < tr[j].ts })
 
 	for _, c := range tr {
-		if c.state == session.StateReady {
-			readyAt = append(readyAt, c.ts)
+		if concurrencyActive(c.state) {
+			continue
 		}
+		if instantAt == nil {
+			instantAt = map[string][]int64{}
+		}
+		instantAt[c.state] = append(instantAt[c.state], c.ts)
 	}
 
 	if last := tr[len(tr)-1]; concurrencyActive(last.state) {
@@ -565,7 +604,7 @@ func (tl *sessionTimeline) stateReconstruction() (ivs []stateInterval, readyAt [
 			ivs = append(ivs, stateInterval{cur.ts, next.ts, cur.state})
 		}
 	}
-	return ivs, readyAt
+	return ivs, instantAt
 }
 
 // activeIntervals reports the merged working-or-waiting spans a session was

--- a/core/adapters/outbound/filesystem/concurrency_tracker.go
+++ b/core/adapters/outbound/filesystem/concurrency_tracker.go
@@ -377,12 +377,7 @@ func bucketTransitionCounts(events []int64, start, bucketSeconds int64, n int) [
 // routing below cannot disagree about which states have a duration — a
 // disagreement would be a nil-map write in appendClampedStateIntervals.
 func collectScopedStateIntervals(timelines map[string]*sessionTimeline, q outbound.SeriesQuery, start, end int64) (byState map[string]map[string][]interval, instants map[string]map[string][]int64, current float64) {
-	byState = map[string]map[string][]interval{}
-	for _, s := range session.CanonicalStates() {
-		if concurrencyActive(s) {
-			byState[s] = map[string][]interval{}
-		}
-	}
+	byState = newDurationBuckets()
 	instants = map[string]map[string][]int64{}
 	for sid, tl := range timelines {
 		if !concurrencyScopeMatches(q, sid, tl.project) {
@@ -396,6 +391,24 @@ func collectScopedStateIntervals(timelines map[string]*sessionTimeline, q outbou
 		appendInstantsInWindow(instants, project, instantAt, start, end)
 	}
 	return byState, instants, current
+}
+
+// newDurationBuckets seeds one project map per state that HAS a duration —
+// outbound.NewStateBuckets' counterpart for the interval side.
+//
+// Derived by filtering the vocabulary through concurrencyActive rather than
+// listing working/waiting, so this and stateReconstruction's routing cannot
+// disagree about which states get intervals. A disagreement would surface as a
+// nil-map write in appendClampedStateIntervals rather than a wrong number,
+// which is the failure mode worth engineering for here.
+func newDurationBuckets() map[string]map[string][]interval {
+	out := map[string]map[string][]interval{}
+	for _, s := range session.CanonicalStates() {
+		if concurrencyActive(s) {
+			out[s] = map[string][]interval{}
+		}
+	}
+	return out
 }
 
 // appendInstantsInWindow folds one session's transition timestamps into the

--- a/core/adapters/outbound/filesystem/concurrency_tracker_test.go
+++ b/core/adapters/outbound/filesystem/concurrency_tracker_test.go
@@ -492,17 +492,24 @@ func TestStateSeries_Empty(t *testing.T) {
 	if res.Peak != 0 || res.Average != 0 || res.Current != 0 {
 		t.Errorf("want zero summary, got peak=%v avg=%v current=%v", res.Peak, res.Average, res.Current)
 	}
-	// The states StateSeries actually declares buckets for. Deliberately NOT
-	// session.CanonicalStates(): the ByState map is a three-key literal in
-	// StateSeries and emptyStateSeriesResult, and #1798's fourth state is not
-	// in it — the Activity Matrix's own widening is #1801's, along with the
-	// web `toEqual({working,waiting,ready})` assertion that pins the same
-	// shape on the client. Reading the domain vocabulary here would make this
-	// test demand a key the production code does not yet emit, i.e. fail for
-	// a gap that is scoped elsewhere rather than for a regression.
-	for _, state := range []string{session.StateWorking, session.StateWaiting, session.StateReady} {
-		if len(res.ByState[state]) != 0 {
-			t.Errorf("by_state[%s] should be empty, got %v", state, res.ByState[state])
+	// #1801 took the handoff #1798 left here: the three-key literal is gone
+	// from StateSeries, emptyStateSeriesResult and handlers.go's nil-reader
+	// fallback, all three now built by outbound.NewStateBuckets from the
+	// domain vocabulary. So this reads the vocabulary too — a fifth state adds
+	// a bucket in one place and this test follows it for free, which is the
+	// whole reason the literal was retired.
+	//
+	// The key must EXIST and be empty, not be absent: absent is how a client
+	// would tell "this daemon has never heard of that state" from "nothing
+	// happened", and every canonical state gets the same answer.
+	for _, state := range session.CanonicalStates() {
+		series, ok := res.ByState[state]
+		if !ok {
+			t.Errorf("by_state is missing the %q bucket entirely — every canonical state must be a key", state)
+			continue
+		}
+		if len(series) != 0 {
+			t.Errorf("by_state[%s] should be empty, got %v", state, series)
 		}
 	}
 	if res.BucketStarts == nil {

--- a/core/adapters/outbound/filesystem/concurrency_tracker_test.go
+++ b/core/adapters/outbound/filesystem/concurrency_tracker_test.go
@@ -848,3 +848,75 @@ func TestConcurrencyProject_MemoizesConcurrentRequests(t *testing.T) {
 		t.Errorf("concurrent chart reads: want 1 resolver call, got %d", got)
 	}
 }
+
+// TestStateSeries_ErrorIsTransitionCountAndNotConcurrency is #1801's own
+// behaviour, and it pins BOTH halves of the settled decision in one fixture
+// because they are only meaningful together.
+//
+// A session goes working → error → working → ready. The error transition must
+// be counted in by_state["error"] (before #1801, stateReconstruction dropped
+// every non-ready transition on the floor, so the series did not exist and the
+// key was not even present) — AND the time spent in error must contribute
+// nothing to peak/average concurrency, which is the half events.md settles.
+//
+// Asserting the second half here rather than in its own test is deliberate:
+// the obvious way to make the first half pass is to give `error` a duration
+// like working/waiting, and that is exactly what would break the second.
+func TestStateSeries_ErrorIsTransitionCountAndNotConcurrency(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "recordings")
+	seedRecording(t, dir, "run.jsonl", []lifecycle.Event{
+		transcriptNew(1, 90, "s1", "/home/me/projX"),
+		transition(2, 100, "s1", session.StateWorking),
+		// Provider call fails at t=130 and the session sits red until t=190.
+		transition(3, 130, "s1", session.StateError),
+		transition(4, 190, "s1", session.StateWorking),
+		transition(5, 200, "s1", session.StateReady),
+	})
+	tr := NewConcurrencyTrackerWithDir(dir, nil)
+
+	res, err := tr.StateSeries(outbound.SeriesQuery{Start: 0, End: 240, BucketSeconds: 60})
+	if err != nil {
+		t.Fatalf("StateSeries: %v", err)
+	}
+
+	// The one error transition (t=130) lands in bucket 2 ([120,180)).
+	if got, want := res.ByState[session.StateError]["projX"], []float64{0, 0, 1, 0}; !floatsEq(got, want) {
+		t.Errorf("error[projX]: want %v, got %v — the transition into error must be counted", want, got)
+	}
+
+	// Every canonical series is bucketed over the same window, so a state that
+	// had quietly been given a different shape shows up here.
+	if got, want := len(res.ByState[session.StateError]["projX"]), len(res.ByState[session.StateWorking]["projX"]); got != want {
+		t.Errorf("error and working series must have the same bucket count, got %d vs %d", got, want)
+	}
+
+	// The concurrency half. One session that never overlaps itself has a peak
+	// of 1; giving `error` a duration would not change that, but it WOULD show
+	// up in the average, which is time-weighted over the whole window. The
+	// session is concurrency-active only over [100,130) and [190,200) — 40 of
+	// the window's 240 seconds. The 60 seconds it spent red must contribute
+	// nothing, so an implementation that made `error` a dwell would read
+	// 100/240 here instead.
+	if res.Peak != 1 {
+		t.Errorf("peak concurrency: want 1, got %v — an errored session must not add a concurrent agent", res.Peak)
+	}
+	if !approxEq(res.Average, 40.0/240.0) {
+		t.Errorf("average concurrency: want %.6f (40s active of a 240s window), got %v — time spent in error must not count", 40.0/240.0, res.Average)
+	}
+	// `current` counts sessions spanning the window end. This one went ready
+	// at t=200, inside the window, so nothing spans it.
+	if res.Current != 0 {
+		t.Errorf("current: want 0, got %v", res.Current)
+	}
+
+	// The merged view is built on the same reconstruction and must agree — the
+	// two cannot be allowed to drift on what counts as active.
+	ag, err := tr.AgentsSeries(outbound.SeriesQuery{Start: 0, End: 240, BucketSeconds: 60})
+	if err != nil {
+		t.Fatalf("AgentsSeries: %v", err)
+	}
+	if ag.Peak != res.Peak || !approxEq(ag.Average, res.Average) {
+		t.Errorf("merged summary (peak %v, avg %v) disagrees with the per-state one (peak %v, avg %v)",
+			ag.Peak, ag.Average, res.Peak, res.Average)
+	}
+}

--- a/core/application/services/daemon_errors.go
+++ b/core/application/services/daemon_errors.go
@@ -77,40 +77,14 @@ func DaemonErrors(h HookHealthSnapshot) []DaemonError {
 	var out []DaemonError
 
 	for _, t := range h.EntryReverification.Targets {
-		if !t.Watched {
-			continue
-		}
-		switch {
-		case t.LastError != "":
-			out = append(out, DaemonError{
-				Kind:    DaemonErrorHookEntriesMissing,
-				Scope:   t.Adapter + "/" + t.Permission,
-				Message: fmt.Sprintf("Irrlicht could not keep its %s hooks installed — %s sessions may be misclassified.", t.Adapter, t.Adapter),
-				Detail:  detailWithPath(t.LastError, t.ConfigPath),
-			})
-		case len(t.Missing) > 0:
-			out = append(out, DaemonError{
-				Kind:    DaemonErrorHookEntriesMissing,
-				Scope:   t.Adapter + "/" + t.Permission,
-				Message: fmt.Sprintf("Irrlicht's %s hook entries went missing from the agent's config — %s sessions may be misclassified.", t.Adapter, t.Adapter),
-				Detail:  detailWithPath(joinShort(t.Missing), t.ConfigPath),
-			})
+		if e, ok := entryFault(t); ok {
+			out = append(out, e)
 		}
 	}
-
 	for _, c := range h.Channels {
-		// Armed means consent is granted AND the install reported success, so
-		// a silent armed channel is the case where everything LOOKS configured
-		// and nothing is arriving — the one #1368 exists for.
-		if !c.Armed || !c.Silent {
-			continue
+		if e, ok := channelFault(c); ok {
+			out = append(out, e)
 		}
-		out = append(out, DaemonError{
-			Kind:    DaemonErrorHookChannelSilent,
-			Scope:   c.Adapter,
-			Message: fmt.Sprintf("Irrlicht is receiving no hook events from %s — its sessions have fallen back to slower transcript-only detection.", c.Adapter),
-			Detail:  fmt.Sprintf("%d completed turns with no receipt", c.TurnsSinceReceipt),
-		})
 	}
 
 	// Deterministic order. The client's banner skips a re-render when the
@@ -124,6 +98,76 @@ func DaemonErrors(h HookHealthSnapshot) []DaemonError {
 		return out[i].Scope < out[j].Scope
 	})
 	return out
+}
+
+// entryFault turns one re-verification target into a fault, or reports ok=false
+// when the target is healthy or is not being watched.
+//
+// An UNWATCHED target means consent was never granted, or no pass has run yet.
+// That is a user decision or a cold start, not Irrlicht failing, and reporting
+// it would put a permanent banner on every daemon whose user declined one
+// adapter — a banner that is always on is a banner nobody reads.
+//
+// LastError outranks Missing: if the config could not be read at all, "your
+// entries are missing" is a guess about a file nobody managed to look at.
+func entryFault(t HookEntryHealth) (DaemonError, bool) {
+	if !t.Watched {
+		return DaemonError{}, false
+	}
+	scope := t.Adapter + "/" + t.Permission
+	switch {
+	case t.LastError != "":
+		return DaemonError{
+			Kind:  DaemonErrorHookEntriesMissing,
+			Scope: scope,
+			Message: fmt.Sprintf("Irrlicht could not keep its %s hooks installed — %s sessions may be misclassified.",
+				t.Adapter, t.Adapter),
+			Detail: detailWithPath(t.LastError, t.ConfigPath),
+		}, true
+	case len(t.Missing) > 0:
+		return DaemonError{
+			Kind:  DaemonErrorHookEntriesMissing,
+			Scope: scope,
+			Message: fmt.Sprintf("Irrlicht's %s hook entries went missing from the agent's config — %s sessions may be misclassified.",
+				t.Adapter, t.Adapter),
+			Detail: detailWithPath(joinShort(t.Missing), t.ConfigPath),
+		}, true
+	}
+	return DaemonError{}, false
+}
+
+// channelFault turns one hook channel into a fault, or reports ok=false when
+// the channel is healthy or unwatched.
+//
+// ARMED means consent is granted AND the install effect reported success, so an
+// armed-but-silent channel is the case where everything LOOKS configured and
+// nothing is arriving — the one #1368 exists for. A disarmed channel is the
+// same "not a fault" as an unwatched target above.
+func channelFault(c HookChannelHealth) (DaemonError, bool) {
+	if !c.Armed || !c.Silent {
+		return DaemonError{}, false
+	}
+	return DaemonError{
+		Kind:  DaemonErrorHookChannelSilent,
+		Scope: c.Adapter,
+		Message: fmt.Sprintf("Irrlicht is receiving no hook events from %s — its sessions have fallen back to slower transcript-only detection.",
+			c.Adapter),
+		// NO TURN COUNTER HERE, deliberately. The obvious detail for this fault
+		// is TurnsSinceReceipt, and the first version of this code used it — but
+		// that counter climbs on every turn boundary for as long as the channel
+		// stays dead (hook_liveness.go's silentTurns, whose own doc notes it
+		// "keeps climbing past the threshold"). A value that changes while the
+		// fault stands makes every poll look like a NEW fault to the client,
+		// which re-announces the whole role="alert" banner to a screen reader
+		// roughly every 30s forever — the exact nagging the banner's re-render
+		// guard exists to stop.
+		//
+		// EVERY FIELD ON A DaemonError IS PART OF ITS IDENTITY, so none of them
+		// may move while the underlying fault does not. The counter is still
+		// published in the diagnostics bundle's hooks.json, which is where a
+		// monotonic debugging number belongs.
+		// TestDaemonErrors_NoFieldMovesWhileTheFaultStands pins this.
+	}, true
 }
 
 // detailWithPath appends the config path to a detail string when there is one,

--- a/core/application/services/daemon_errors.go
+++ b/core/application/services/daemon_errors.go
@@ -1,0 +1,163 @@
+package services
+
+import (
+	"fmt"
+	"sort"
+)
+
+// Daemon-wide error kinds. The client keys its banner text off Message, not
+// off Kind — these exist so a reader (and a test) can tell the two diagnoses
+// apart without string-matching prose.
+const (
+	// DaemonErrorHookEntriesMissing is #1372's diagnosis: our hook entries
+	// were installed and have since gone from the agent's config, or the
+	// config could not be read back at all.
+	DaemonErrorHookEntriesMissing = "hook_entries_missing"
+	// DaemonErrorHookChannelSilent is #1368's diagnosis: the entries are
+	// present, consent is granted, and yet nothing is arriving — so that
+	// adapter's sessions have been demoted to transcript-tier classification.
+	DaemonErrorHookChannelSilent = "hook_channel_silent"
+)
+
+// DaemonError is one fault in Irrlicht's OWN machinery that has no session to
+// attach to.
+//
+// This is the daemon-wide half of #1796's error work, and it is a different
+// thing from session.SessionError. A session error says "the agent's provider
+// call failed" and turns one row red. A DaemonError says "Irrlicht is not
+// watching properly", which invalidates what the user is reading everywhere at
+// once — sessions may be silently misclassified, and every one of them will
+// look fine.
+//
+// NOTHING IS INVENTED HERE. Both kinds are diagnoses the daemon already
+// computes on a timer and already writes into the diagnostics bundle's
+// hooks.json; until now that was their only outlet, so a fault that degrades
+// every session's classification was visible exclusively to someone who
+// thought to run `--diagnose` and unpack a tarball. This type is a second
+// outlet for the same facts, not a second detector.
+//
+// It deliberately does NOT fold in #1362/#1365 (a hook install that FAILED, or
+// was refused below a version floor). Those already reach the client as
+// PermissionsSnapshot.UnappliedGrants and already have their own banner, and
+// permission_service.go's scope comment locks the three diagnoses apart on
+// purpose: an install that never wrote entries, entries that were written and
+// vanished, and entries that are present but dead are three different things
+// to go fix.
+type DaemonError struct {
+	// Kind is the machine-readable diagnosis; see the constants above.
+	Kind string `json:"kind"`
+	// Scope names what the fault is about — the adapter, plus the permission
+	// key where one target among several is affected. A fault with no scope
+	// would not be actionable.
+	Scope string `json:"scope"`
+	// Message is the one sentence a user reads. Composed daemon-side so the
+	// two frontends cannot word the same fault differently (the convention
+	// cache_bloat_explanation already follows).
+	Message string `json:"message"`
+	// Detail is the machine's own words — a config path, the verifier's last
+	// error — carried verbatim rather than summarised, and empty when there is
+	// nothing to add.
+	Detail string `json:"detail,omitempty"`
+}
+
+// DaemonErrors derives the client-facing daemon-wide fault list from a hook
+// health snapshot.
+//
+// A PURE FUNCTION over the snapshot, so it is testable without a daemon and so
+// the shape on the wire cannot drift from the shape in hooks.json. It returns
+// nil (not an empty slice) when everything is healthy, which is what makes the
+// `omitempty` tag on the response field honest: a healthy daemon's payload is
+// byte-identical to what it was before this field existed.
+//
+// Both loops skip rows that are not being watched. An unwatched row means
+// consent was never granted or no pass has run yet — that is a user decision
+// or a cold start, not a fault, and reporting it would train the banner to be
+// ignored.
+func DaemonErrors(h HookHealthSnapshot) []DaemonError {
+	var out []DaemonError
+
+	for _, t := range h.EntryReverification.Targets {
+		if !t.Watched {
+			continue
+		}
+		switch {
+		case t.LastError != "":
+			out = append(out, DaemonError{
+				Kind:    DaemonErrorHookEntriesMissing,
+				Scope:   t.Adapter + "/" + t.Permission,
+				Message: fmt.Sprintf("Irrlicht could not keep its %s hooks installed — %s sessions may be misclassified.", t.Adapter, t.Adapter),
+				Detail:  detailWithPath(t.LastError, t.ConfigPath),
+			})
+		case len(t.Missing) > 0:
+			out = append(out, DaemonError{
+				Kind:    DaemonErrorHookEntriesMissing,
+				Scope:   t.Adapter + "/" + t.Permission,
+				Message: fmt.Sprintf("Irrlicht's %s hook entries went missing from the agent's config — %s sessions may be misclassified.", t.Adapter, t.Adapter),
+				Detail:  detailWithPath(joinShort(t.Missing), t.ConfigPath),
+			})
+		}
+	}
+
+	for _, c := range h.Channels {
+		// Armed means consent is granted AND the install reported success, so
+		// a silent armed channel is the case where everything LOOKS configured
+		// and nothing is arriving — the one #1368 exists for.
+		if !c.Armed || !c.Silent {
+			continue
+		}
+		out = append(out, DaemonError{
+			Kind:    DaemonErrorHookChannelSilent,
+			Scope:   c.Adapter,
+			Message: fmt.Sprintf("Irrlicht is receiving no hook events from %s — its sessions have fallen back to slower transcript-only detection.", c.Adapter),
+			Detail:  fmt.Sprintf("%d completed turns with no receipt", c.TurnsSinceReceipt),
+		})
+	}
+
+	// Deterministic order. The client's banner skips a re-render when the
+	// content is unchanged (the dataset.bannerKey idiom), and map iteration
+	// upstream would otherwise make an unchanged fault list look different on
+	// every poll — re-announcing the same fault to a screen reader forever.
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].Kind != out[j].Kind {
+			return out[i].Kind < out[j].Kind
+		}
+		return out[i].Scope < out[j].Scope
+	})
+	return out
+}
+
+// detailWithPath appends the config path to a detail string when there is one,
+// because "entries missing" without the file to go look at is not actionable —
+// the same reasoning HookEntryHealth.ConfigPath's own doc gives.
+func detailWithPath(detail, path string) string {
+	switch {
+	case detail == "" && path == "":
+		return ""
+	case path == "":
+		return detail
+	case detail == "":
+		return path
+	}
+	return detail + " (" + path + ")"
+}
+
+// joinShort renders a missing-entry list as prose, capped so one pathological
+// config cannot push a banner past a readable length.
+func joinShort(items []string) string {
+	const max = 3
+	if len(items) <= max {
+		return joinComma(items)
+	}
+	return fmt.Sprintf("%s and %d more", joinComma(items[:max]), len(items)-max)
+}
+
+func joinComma(items []string) string {
+	out := ""
+	for i, s := range items {
+		if i > 0 {
+			out += ", "
+		}
+		out += s
+	}
+	return out
+}

--- a/core/application/services/daemon_errors_test.go
+++ b/core/application/services/daemon_errors_test.go
@@ -1,0 +1,181 @@
+package services_test
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"irrlicht/core/application/services"
+)
+
+// healthyHookSnapshot is a daemon with everything working: every target
+// watched and intact, every channel armed and delivering. It is the baseline
+// each case below perturbs by exactly one field, so a case that reports a
+// fault reports it because of THAT field and nothing else.
+func healthyHookSnapshot() services.HookHealthSnapshot {
+	return services.HookHealthSnapshot{
+		Channels: []services.HookChannelHealth{
+			{Adapter: "claude-code", Armed: true, Receipts: 12, Silent: false},
+			{Adapter: "codex", Armed: true, Receipts: 3, Silent: false},
+		},
+		EntryReverification: services.HookEntryReverifySnapshot{
+			Targets: []services.HookEntryHealth{
+				{Adapter: "claude-code", Permission: "hooks", ConfigPath: "/home/u/.claude/settings.json", Watched: true},
+				{Adapter: "codex", Permission: "hooks", ConfigPath: "/home/u/.codex/config.toml", Watched: true},
+			},
+		},
+	}
+}
+
+// TestDaemonErrors_HealthyDaemonReportsNothing is the case the `omitempty` tag
+// depends on. If a healthy daemon produced an empty non-nil slice, the field
+// would serialize as `"daemon_errors":[]` and every existing client's payload
+// would change shape for no reason.
+func TestDaemonErrors_HealthyDaemonReportsNothing(t *testing.T) {
+	got := services.DaemonErrors(healthyHookSnapshot())
+	if got != nil {
+		t.Errorf("healthy daemon: want nil, got %+v", got)
+	}
+}
+
+func TestDaemonErrors_ReportsTheTwoClientInvisibleDiagnoses(t *testing.T) {
+	tests := []struct {
+		name     string
+		mutate   func(*services.HookHealthSnapshot)
+		wantKind string
+		// wantIn is text that must appear in the message or detail. These are
+		// the parts a user acts on — which adapter, and what the machine said.
+		wantIn []string
+	}{
+		{
+			name: "entries went missing (#1372)",
+			mutate: func(h *services.HookHealthSnapshot) {
+				h.EntryReverification.Targets[0].Missing = []string{"Stop", "Notification"}
+			},
+			wantKind: services.DaemonErrorHookEntriesMissing,
+			wantIn:   []string{"claude-code", "Stop", "Notification", "/home/u/.claude/settings.json"},
+		},
+		{
+			name: "the config could not be read back at all",
+			mutate: func(h *services.HookHealthSnapshot) {
+				h.EntryReverification.Targets[1].LastError = "permission denied"
+			},
+			wantKind: services.DaemonErrorHookEntriesMissing,
+			wantIn:   []string{"codex", "permission denied", "/home/u/.codex/config.toml"},
+		},
+		{
+			name: "entries present but nothing arriving (#1368)",
+			mutate: func(h *services.HookHealthSnapshot) {
+				h.Channels[0].Silent = true
+				h.Channels[0].TurnsSinceReceipt = 7
+			},
+			wantKind: services.DaemonErrorHookChannelSilent,
+			wantIn:   []string{"claude-code", "7"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			h := healthyHookSnapshot()
+			tc.mutate(&h)
+			got := services.DaemonErrors(h)
+			if len(got) != 1 {
+				t.Fatalf("want exactly 1 fault, got %d: %+v", len(got), got)
+			}
+			if got[0].Kind != tc.wantKind {
+				t.Errorf("kind: got %q, want %q", got[0].Kind, tc.wantKind)
+			}
+			if got[0].Scope == "" {
+				t.Error("scope is empty — a fault the user cannot attribute is not actionable")
+			}
+			blob := got[0].Message + " | " + got[0].Detail
+			for _, want := range tc.wantIn {
+				if !strings.Contains(blob, want) {
+					t.Errorf("fault text %q does not mention %q", blob, want)
+				}
+			}
+		})
+	}
+}
+
+// TestDaemonErrors_UnwatchedAndDisarmedRowsAreNotFaults pins the skip that
+// keeps the banner credible. A target nobody granted consent for, and a
+// channel the watchdog was never armed on, are user decisions or a cold start
+// — not Irrlicht failing. Reporting them would put a permanent banner on every
+// daemon whose user declined one adapter, and a banner that is always on is a
+// banner nobody reads.
+func TestDaemonErrors_UnwatchedAndDisarmedRowsAreNotFaults(t *testing.T) {
+	h := healthyHookSnapshot()
+	// Same perturbations as the cases above, on rows that are not being
+	// watched. Every one would be a fault if Watched/Armed were ignored.
+	h.EntryReverification.Targets[0].Watched = false
+	h.EntryReverification.Targets[0].Missing = []string{"Stop"}
+	h.EntryReverification.Targets[1].Watched = false
+	h.EntryReverification.Targets[1].LastError = "permission denied"
+	h.Channels[0].Armed = false
+	h.Channels[0].Silent = true
+	h.Channels[1].Armed = false
+	h.Channels[1].Silent = true
+
+	if got := services.DaemonErrors(h); got != nil {
+		t.Errorf("unwatched/disarmed rows must not be reported as faults, got %+v", got)
+	}
+}
+
+// TestDaemonErrors_OrderIsStable guards the client's re-announce suppression.
+// The banner keys on its own rendered content and skips a rebuild when it has
+// not changed; an order that varied between polls would defeat that and
+// re-announce the same standing fault to a screen reader on every refresh —
+// the nagging #1385's banner was explicitly designed to avoid.
+func TestDaemonErrors_OrderIsStable(t *testing.T) {
+	h := healthyHookSnapshot()
+	h.Channels[0].Silent = true
+	h.Channels[1].Silent = true
+	h.EntryReverification.Targets[0].Missing = []string{"Stop"}
+	h.EntryReverification.Targets[1].Missing = []string{"Stop"}
+
+	first := services.DaemonErrors(h)
+	if len(first) != 4 {
+		t.Fatalf("want 4 faults, got %d: %+v", len(first), first)
+	}
+	want, err := json.Marshal(first)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	for i := 0; i < 20; i++ {
+		got, err := json.Marshal(services.DaemonErrors(h))
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		if string(got) != string(want) {
+			t.Fatalf("run %d differs from run 0:\n got %s\nwant %s", i+1, got, want)
+		}
+	}
+}
+
+// TestDaemonErrors_DoesNotDuplicateTheUnappliedGrantsDiagnosis is a scope lock.
+// permission_service.go keeps three hook diagnoses deliberately apart — an
+// install that FAILED (#1362, already on the wire as unapplied_grants and
+// already carrying its own banner), entries that went MISSING (#1372), and
+// entries that are present but DEAD (#1368). This function must only ever
+// speak for the second and third; folding in the first would put two banners
+// on screen for one fault and make the user fix it twice.
+func TestDaemonErrors_DoesNotDuplicateTheUnappliedGrantsDiagnosis(t *testing.T) {
+	for _, e := range services.DaemonErrors(healthyHookSnapshot()) {
+		t.Errorf("unexpected fault on a healthy daemon: %+v", e)
+	}
+	// An install failure leaves no trace in the hook-health snapshot at all —
+	// it lives in the permission service's effectErrs — so there is nothing
+	// here to accidentally report. Assert the vocabulary stays closed to the
+	// two kinds, so a future author adding a third has to come read this.
+	h := healthyHookSnapshot()
+	h.Channels[0].Silent = true
+	h.EntryReverification.Targets[0].Missing = []string{"Stop"}
+	for _, e := range services.DaemonErrors(h) {
+		switch e.Kind {
+		case services.DaemonErrorHookEntriesMissing, services.DaemonErrorHookChannelSilent:
+		default:
+			t.Errorf("unexpected daemon-error kind %q — see permission_service.go's scope comment before adding one", e.Kind)
+		}
+	}
+}

--- a/core/application/services/daemon_errors_test.go
+++ b/core/application/services/daemon_errors_test.go
@@ -2,6 +2,7 @@ package services_test
 
 import (
 	"encoding/json"
+	"slices"
 	"strings"
 	"testing"
 
@@ -70,7 +71,7 @@ func TestDaemonErrors_ReportsTheTwoClientInvisibleDiagnoses(t *testing.T) {
 				h.Channels[0].TurnsSinceReceipt = 7
 			},
 			wantKind: services.DaemonErrorHookChannelSilent,
-			wantIn:   []string{"claude-code", "7"},
+			wantIn:   []string{"claude-code"},
 		},
 	}
 
@@ -122,19 +123,32 @@ func TestDaemonErrors_UnwatchedAndDisarmedRowsAreNotFaults(t *testing.T) {
 	}
 }
 
-// TestDaemonErrors_OrderIsStable guards the client's re-announce suppression.
-// The banner keys on its own rendered content and skips a rebuild when it has
-// not changed; an order that varied between polls would defeat that and
-// re-announce the same standing fault to a screen reader on every refresh —
-// the nagging #1385's banner was explicitly designed to avoid.
+// TestDaemonErrors_OrderIsStable guards the client's re-announce suppression:
+// the banner keys on its own rendered content and skips a rebuild when it has
+// not changed, so an order that varied between polls would re-announce the same
+// standing fault to a screen reader on every refresh.
+//
+// IT SHUFFLES THE INPUT, and that is the whole test. The first version called
+// DaemonErrors 21 times on ONE fixed input and compared the runs — which Go
+// slices satisfy by construction whether or not the sort exists. It passed with
+// `sort.SliceStable` deleted (verified by mutation in review): a green that was
+// never red. Feeding a permuted snapshot and demanding byte-identical output is
+// what actually pins the ordering.
 func TestDaemonErrors_OrderIsStable(t *testing.T) {
-	h := healthyHookSnapshot()
-	h.Channels[0].Silent = true
-	h.Channels[1].Silent = true
-	h.EntryReverification.Targets[0].Missing = []string{"Stop"}
-	h.EntryReverification.Targets[1].Missing = []string{"Stop"}
+	build := func(reversed bool) services.HookHealthSnapshot {
+		h := healthyHookSnapshot()
+		h.Channels[0].Silent = true
+		h.Channels[1].Silent = true
+		h.EntryReverification.Targets[0].Missing = []string{"Stop"}
+		h.EntryReverification.Targets[1].Missing = []string{"Stop"}
+		if reversed {
+			slices.Reverse(h.Channels)
+			slices.Reverse(h.EntryReverification.Targets)
+		}
+		return h
+	}
 
-	first := services.DaemonErrors(h)
+	first := services.DaemonErrors(build(false))
 	if len(first) != 4 {
 		t.Fatalf("want 4 faults, got %d: %+v", len(first), first)
 	}
@@ -142,14 +156,57 @@ func TestDaemonErrors_OrderIsStable(t *testing.T) {
 	if err != nil {
 		t.Fatalf("marshal: %v", err)
 	}
-	for i := 0; i < 20; i++ {
-		got, err := json.Marshal(services.DaemonErrors(h))
+	// Guard the guard: the two orderings must genuinely differ as INPUT, or
+	// "the outputs match" would be measuring nothing.
+	a := build(false)
+	b := build(true)
+	if a.Channels[0].Adapter == b.Channels[0].Adapter {
+		t.Fatalf("the fixture is not actually being permuted — both orderings start with %q", a.Channels[0].Adapter)
+	}
+
+	for i, reversed := range []bool{true, false, true} {
+		got, err := json.Marshal(services.DaemonErrors(build(reversed)))
 		if err != nil {
 			t.Fatalf("marshal: %v", err)
 		}
 		if string(got) != string(want) {
-			t.Fatalf("run %d differs from run 0:\n got %s\nwant %s", i+1, got, want)
+			t.Fatalf("run %d (reversed=%v) differs from the baseline:\n got %s\nwant %s", i+1, reversed, got, want)
 		}
+	}
+}
+
+// TestDaemonErrors_NoFieldMovesWhileTheFaultStands is the other half of the
+// same protection, and the one that catches the defect review found: ordering
+// can be perfectly stable while a fault's own CONTENT changes on every poll.
+//
+// The silent-channel fault's obvious detail is TurnsSinceReceipt, and using it
+// made every poll look like a new fault to the client — re-announcing the whole
+// role="alert" banner roughly every 30s for as long as the channel stayed dead.
+// Every field is part of the fault's identity, so nothing that moves under a
+// standing fault may appear in one.
+func TestDaemonErrors_NoFieldMovesWhileTheFaultStands(t *testing.T) {
+	at := func(turns int, repairs uint64) []byte {
+		h := healthyHookSnapshot()
+		h.Channels[0].Silent = true
+		h.Channels[0].TurnsSinceReceipt = turns
+		h.Channels[0].Receipts = uint64(turns)
+		h.EntryReverification.Targets[0].Missing = []string{"Stop"}
+		h.EntryReverification.Targets[0].Repairs = repairs
+		h.EntryReverification.Targets[0].ConsecutiveRepairs = int(repairs)
+		b, err := json.Marshal(services.DaemonErrors(h))
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		return b
+	}
+
+	// The same two faults, observed later: more turns have gone by with no
+	// receipt, and the repair loop has run more times. Nothing the user could
+	// act on has changed.
+	early := at(3, 1)
+	late := at(97, 42)
+	if string(early) != string(late) {
+		t.Errorf("a standing fault changed while nothing about it did:\n at turn 3:  %s\n at turn 97: %s\nA field that moves under an unchanged fault makes the client re-announce it on every poll.", early, late)
 	}
 }
 

--- a/core/application/services/diagnostics_service.go
+++ b/core/application/services/diagnostics_service.go
@@ -1139,27 +1139,34 @@ func silentChannelNote(channels []HookChannelHealth) string {
 		"the permission rather than here (#1362). Check the daemon's bind port next."
 }
 
+// stateView is the diagnostics bundle's state.json. One count per canonical
+// state — error_count joins the other three in #1801, for the same reason as
+// the /state endpoint: a bundle whose buckets don't sum to session_count is
+// worse than useless when the thing being diagnosed is a red session.
+//
+// The tally is by map key rather than by switch, so the loop carries no
+// enumeration that can go silently incomplete when the vocabulary grows;
+// only the readout below names states, and it has to.
 func stateView(sessions []*session.SessionState, now time.Time) any {
 	view := struct {
 		SessionCount int    `json:"session_count"`
 		WorkingCount int    `json:"working_count"`
 		WaitingCount int    `json:"waiting_count"`
 		ReadyCount   int    `json:"ready_count"`
+		ErrorCount   int    `json:"error_count"`
 		GeneratedAt  string `json:"generated_at"`
 	}{
 		SessionCount: len(sessions),
 		GeneratedAt:  now.UTC().Format(time.RFC3339),
 	}
+	byState := map[string]int{}
 	for _, ss := range sessions {
-		switch ss.State {
-		case session.StateWorking:
-			view.WorkingCount++
-		case session.StateWaiting:
-			view.WaitingCount++
-		case session.StateReady:
-			view.ReadyCount++
-		}
+		byState[ss.State]++
 	}
+	view.WorkingCount = byState[session.StateWorking]
+	view.WaitingCount = byState[session.StateWaiting]
+	view.ReadyCount = byState[session.StateReady]
+	view.ErrorCount = byState[session.StateError]
 	return view
 }
 

--- a/core/application/services/session_detector_error_child_test.go
+++ b/core/application/services/session_detector_error_child_test.go
@@ -1,0 +1,150 @@
+package services_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"irrlicht/core/domain/agent"
+	"irrlicht/core/domain/session"
+)
+
+// TestSessionDetector_ParentHeldWorking_WhenChildIsRetryingAfterError is the
+// defect #1798 handed forward and #1801 settles: `hasActiveChildren` asked
+// "is this child working or waiting", which silently became an INCOMPLETE
+// partition the moment a fourth state arrived. A child sitting in `error`
+// with Phase=retrying has another attempt scheduled — it is still working —
+// yet it answered "not active" and released its parent to ready. The parent
+// then reads green while its subagent is red and mid-retry.
+//
+// The test drives ONE parent through BOTH phases in sequence, deliberately:
+//
+//	phase 1 (retrying) — the parent must stay working
+//	phase 2 (terminal) — the same parent, same wiring, must now reach ready
+//
+// Phase 2 is what makes phase 1's assertion mean something. "Still working"
+// is the parent's starting state, so on its own it is equally consistent with
+// "held correctly" and "the activity pass never ran at all" — the exact
+// absence-vs-inability-to-look failure AGENTS.md rules out. Watching the same
+// parent release the moment the phase flips proves the machinery reaches it,
+// and proves the PHASE is what decides rather than the state alone.
+func TestSessionDetector_ParentHeldWorking_WhenChildIsRetryingAfterError(t *testing.T) {
+	tw := newMockAgentWatcher()
+	pw := newMockProcessWatcher()
+	repo := newMockRepo()
+
+	det := newDetector(tw, pw, repo)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- det.Run(ctx) }()
+	defer func() { cancel(); <-done }()
+
+	time.Sleep(20 * time.Millisecond)
+
+	now := time.Now().Unix()
+	const parentID = "parent-err"
+	const childID = "child-err"
+	const parentPath = "/home/.claude/projects/-Users-test/parent-err.jsonl"
+	const childPath = "/home/.claude/projects/-Users-test/parent-err/subagents/child-err.jsonl"
+
+	saveParent := func() {
+		repo.Save(&session.SessionState{
+			SessionID:      parentID,
+			State:          session.StateWorking,
+			TranscriptPath: parentPath,
+			FirstSeen:      now,
+			UpdatedAt:      now,
+			EventCount:     5,
+			Metrics: &session.SessionMetrics{
+				LastEventType:     "turn_done",
+				HasOpenToolCall:   false,
+				LastAssistantText: "Done.",
+			},
+		})
+	}
+	saveChild := func(phase session.ErrorPhase) {
+		repo.Save(&session.SessionState{
+			SessionID:       childID,
+			State:           session.StateError,
+			ParentSessionID: parentID,
+			TranscriptPath:  childPath,
+			FirstSeen:       now,
+			UpdatedAt:       now,
+			EventCount:      3,
+			Metrics: &session.SessionMetrics{
+				LastEventType: "assistant",
+				SessionError: &session.SessionError{
+					Phase:   phase,
+					Class:   "rate_limit",
+					Message: "API Error: 429 rate limited",
+				},
+			},
+		})
+	}
+	pokeParent := func() {
+		tw.ch <- agent.Event{
+			Type:           agent.EventActivity,
+			SessionID:      parentID,
+			ProjectDir:     "-Users-test",
+			TranscriptPath: parentPath,
+		}
+	}
+
+	// runPass seeds the pair, fires one activity event at the parent, and does
+	// not return until the detector has actually persisted something — never on
+	// a bare sleep. The repo's own save counter is the readiness signal because
+	// it is the one thing that ticks whichever way the verdict goes: a released
+	// parent is saved as ready, a held one is still saved (UpdatedAt/EventCount
+	// advance on every activity pass). Polling for a STATE instead would be the
+	// AGENTS.md trap in both directions — "still working" is also the parent's
+	// starting value, and after the first phase a stale "ready" would satisfy
+	// the poll before the second phase's pass had begun.
+	runPass := func(phase session.ErrorPhase) *session.SessionState {
+		t.Helper()
+		saveParent()
+		saveChild(phase)
+		repo.mu.Lock()
+		baseline := repo.saves
+		repo.mu.Unlock()
+
+		pokeParent()
+
+		deadline := time.Now().Add(3 * time.Second)
+		for {
+			repo.mu.Lock()
+			saved := repo.saves
+			repo.mu.Unlock()
+			if saved > baseline {
+				break
+			}
+			if time.Now().After(deadline) {
+				t.Fatalf("detector persisted nothing within 3s of the %q activity event (saves stuck at %d) — the pass under test never ran, so any state assertion below would be meaningless", phase, baseline)
+			}
+			time.Sleep(5 * time.Millisecond)
+		}
+		// The save that unblocked the poll can be the child's or an
+		// intermediate one; give the parent's own verdict a bounded window to
+		// land, then read it.
+		waitForSessionState(repo, parentID, session.StateReady, 300*time.Millisecond)
+		got, _ := repo.Load(parentID)
+		if got == nil {
+			t.Fatalf("parent session vanished after the %q pass", phase)
+		}
+		return got
+	}
+
+	// --- phase 1: the child is retrying → the parent must NOT be released ---
+	if got := runPass(session.ErrorPhaseRetrying); got.State != session.StateWorking {
+		t.Errorf("parent state with a RETRYING errored child: got %q, want %q — another attempt is scheduled, so the child is still working and must hold its parent",
+			got.State, session.StateWorking)
+	}
+
+	// --- phase 2: the same child goes terminal → the parent IS released ---
+	// Nothing else changes. If phase 1 above passed because the activity pass
+	// never reached this parent, this half cannot pass either.
+	if got := runPass(session.ErrorPhaseTerminal); got.State != session.StateReady {
+		t.Errorf("parent state with a TERMINAL errored child: got %q, want %q — no further attempt is coming, so the parent is free to finish (and this half is what proves the pass runs at all)",
+			got.State, session.StateReady)
+	}
+}

--- a/core/application/services/session_detector_subagent.go
+++ b/core/application/services/session_detector_subagent.go
@@ -192,9 +192,10 @@ func (d *SessionDetector) applyOneSubagentCompletion(s *session.SessionState, pa
 	})
 }
 
-// hasActiveChildren returns true if any child session of the given parent is
-// still working or waiting, OR Claude Code's own turn_duration accounting
-// (issue #1036) says a background subagent is still running. The two are
+// hasActiveChildren returns true if any child session of the given parent
+// still has work in flight (see session.SessionState.HasWorkInFlight — working,
+// waiting, or errored-but-retrying), OR Claude Code's own turn_duration
+// accounting (issue #1036) says a background subagent is still running. The two are
 // independent signals for the same question — has the parent's background
 // work actually finished — combined here so every caller gets one
 // indivisible verdict instead of two booleans it would otherwise have to
@@ -212,8 +213,11 @@ func (d *SessionDetector) hasActiveChildren(parentID string, metrics *session.Se
 		return false
 	}
 	for _, s := range states {
-		if s.ParentSessionID == parentID &&
-			(s.State == session.StateWorking || s.State == session.StateWaiting) {
+		// #1801: the predicate lives in the domain rather than being spelled
+		// out here. Inline, this read `working || waiting` — complete over
+		// three states, silently incomplete over four, so a child mid-retry
+		// answered "not active" and released its parent to ready.
+		if s.ParentSessionID == parentID && s.HasWorkInFlight() {
 			return true
 		}
 	}

--- a/core/cmd/irrlichd/activity_matrix_test.go
+++ b/core/cmd/irrlichd/activity_matrix_test.go
@@ -8,6 +8,21 @@ import (
 	"irrlicht/core/ports/outbound"
 )
 
+// stateBuckets builds a ByState fixture the way production does — every
+// canonical state present as a key (#1801) — with `working` carrying the
+// per-project series under test and the rest empty.
+//
+// Built on outbound.NewStateBuckets rather than typed out, so these fixtures
+// exercise the real key set instead of a three-key hand copy that would go on
+// passing after production started emitting a fourth. That is exactly how the
+// pre-#1801 versions of these tests stayed green while `error` was missing
+// from every by_state payload the daemon shipped.
+func stateBuckets(working map[string][]float64) map[string]map[string][]float64 {
+	by := outbound.NewStateBuckets()
+	by[session.StateWorking] = working
+	return by
+}
+
 // hasUnknownContributor reports whether resp's top-contributors list surfaces
 // the "unknown" label, the same check TestHandleGetHistory_UnknownBucketRule
 // uses for the cost chart's equivalent rule.
@@ -73,11 +88,7 @@ func TestBuildStateResponse_UnknownShareRule(t *testing.T) {
 	// Kept: unknown total 3 / grand 12 = 25%.
 	kept := buildStateResponse("24h", "", &outbound.StateSeriesResult{
 		BucketStarts: []int64{},
-		ByState: map[string]map[string][]float64{
-			session.StateWorking: {"projA": {9}, "": {3}},
-			session.StateWaiting: {},
-			session.StateReady:   {},
-		},
+		ByState:      stateBuckets(map[string][]float64{"projA": {9}, "": {3}}),
 	})
 	if !hasProject(kept.Projects, "unknown") {
 		t.Errorf("≥10%% unknown should be surfaced as a project row, got %+v", kept.Projects)
@@ -95,11 +106,7 @@ func TestBuildStateResponse_UnknownShareRule(t *testing.T) {
 	// Dropped: unknown total 1 / grand 100 = 1%.
 	dropped := buildStateResponse("24h", "", &outbound.StateSeriesResult{
 		BucketStarts: []int64{},
-		ByState: map[string]map[string][]float64{
-			session.StateWorking: {"projA": {99}, "": {1}},
-			session.StateWaiting: {},
-			session.StateReady:   {},
-		},
+		ByState:      stateBuckets(map[string][]float64{"projA": {99}, "": {1}}),
 	})
 	if hasProject(dropped.Projects, "unknown") || hasProject(dropped.Projects, "") {
 		t.Errorf("<10%% unknown should be dropped entirely, got %+v", dropped.Projects)
@@ -123,11 +130,7 @@ func TestBuildStateResponse_Top8Cap(t *testing.T) {
 	}
 	resp := buildStateResponse("1y", "", &outbound.StateSeriesResult{
 		BucketStarts: []int64{},
-		ByState: map[string]map[string][]float64{
-			session.StateWorking: byProject,
-			session.StateWaiting: {},
-			session.StateReady:   {},
-		},
+		ByState:      stateBuckets(byProject),
 	})
 
 	if len(resp.Projects) != 8 {

--- a/core/cmd/irrlichd/daemon_errors_endpoint_test.go
+++ b/core/cmd/irrlichd/daemon_errors_endpoint_test.go
@@ -1,0 +1,136 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"irrlicht/core/adapters/outbound/filesystem"
+	"irrlicht/core/application/services"
+	"irrlicht/core/domain/session"
+)
+
+// serveSessionsWithHookHealth boots the real /api/v1/sessions handler over a
+// one-session repo and returns the decoded payload as a generic map.
+//
+// Decoding into map[string]any rather than into sessionsResponse is the same
+// technique permission_unapplied_aggregate_test.go documents: it asserts what
+// is ACTUALLY ON THE WIRE, so "the field is omitted" and "the field is present
+// and empty" are distinguishable — which is the whole claim the `omitempty`
+// tag makes. A typed decode cannot tell those apart.
+func serveSessionsWithHookHealth(t *testing.T, hookHealth func() services.HookHealthSnapshot) map[string]any {
+	t.Helper()
+	repo := filesystem.NewWithDir(t.TempDir())
+	now := time.Now().Unix()
+	if err := repo.Save(&session.SessionState{
+		SessionID:   "sess-1",
+		State:       session.StateReady,
+		ProjectName: "proj-a",
+		FirstSeen:   now,
+		UpdatedAt:   now,
+	}); err != nil {
+		t.Fatalf("seed session: %v", err)
+	}
+
+	push := services.NewPushService()
+	orchMonitor := services.NewOrchestratorMonitor(nil, push, nil)
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/v1/sessions", handleGetSessions(repo, orchMonitor, nil, nil, hookHealth))
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/api/v1/sessions")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status: %d", resp.StatusCode)
+	}
+	var out map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	// Guard the guard: if the payload lost its groups the assertions below
+	// would be inspecting a response that never rendered, and an absent
+	// daemon_errors key would read as "healthy" rather than "nothing ran".
+	if _, ok := out["groups"]; !ok {
+		t.Fatalf("payload has no groups — the handler did not render a real response: %+v", out)
+	}
+	return out
+}
+
+// TestHandleGetSessions_DaemonErrorsReachTheWire is the reachability half of
+// #1801's daemon-wide banner: services.DaemonErrors is unit-tested next door,
+// but a pure function nobody calls renders nothing. This drives the real
+// handler and reads the real JSON.
+func TestHandleGetSessions_DaemonErrorsReachTheWire(t *testing.T) {
+	faulty := func() services.HookHealthSnapshot {
+		return services.HookHealthSnapshot{
+			Channels: []services.HookChannelHealth{
+				{Adapter: "claude-code", Armed: true, Silent: true, TurnsSinceReceipt: 9},
+			},
+		}
+	}
+	got := serveSessionsWithHookHealth(t, faulty)
+
+	raw, ok := got["daemon_errors"]
+	if !ok {
+		t.Fatalf("daemon_errors missing from the payload of a daemon with a silent hook channel: %+v", got)
+	}
+	list, ok := raw.([]any)
+	if !ok || len(list) != 1 {
+		t.Fatalf("daemon_errors: want a 1-element list, got %#v", raw)
+	}
+	entry, ok := list[0].(map[string]any)
+	if !ok {
+		t.Fatalf("daemon_errors[0]: want an object, got %#v", list[0])
+	}
+	for _, key := range []string{"kind", "scope", "message"} {
+		v, ok := entry[key]
+		if !ok {
+			t.Errorf("daemon_errors[0] has no %q key: %#v", key, entry)
+			continue
+		}
+		if s, _ := v.(string); s == "" {
+			t.Errorf("daemon_errors[0].%s is empty: %#v", key, entry)
+		}
+	}
+	if entry["kind"] != services.DaemonErrorHookChannelSilent {
+		t.Errorf("kind: got %v, want %q", entry["kind"], services.DaemonErrorHookChannelSilent)
+	}
+}
+
+// TestHandleGetSessions_OmitsDaemonErrorsWhenHealthy pins the other half of the
+// contract, in both of the ways it can be true: a daemon with nothing wrong,
+// and a caller with no hook counters to report at all (nil — the seam
+// liveHookHealth already documents, and what every non-daemon process passes).
+// A healthy payload must be byte-identical to what it was before the field
+// existed, or every client's parsing changes for no reason.
+func TestHandleGetSessions_OmitsDaemonErrorsWhenHealthy(t *testing.T) {
+	healthy := func() services.HookHealthSnapshot {
+		return services.HookHealthSnapshot{
+			Channels: []services.HookChannelHealth{
+				{Adapter: "claude-code", Armed: true, Receipts: 5},
+			},
+			EntryReverification: services.HookEntryReverifySnapshot{
+				Targets: []services.HookEntryHealth{
+					{Adapter: "claude-code", Permission: "hooks", Watched: true},
+				},
+			},
+		}
+	}
+	for name, provider := range map[string]func() services.HookHealthSnapshot{
+		"healthy daemon":     healthy,
+		"no health provider": nil,
+	} {
+		t.Run(name, func(t *testing.T) {
+			got := serveSessionsWithHookHealth(t, provider)
+			if v, ok := got["daemon_errors"]; ok {
+				t.Errorf("daemon_errors must be omitted, got %#v", v)
+			}
+		})
+	}
+}

--- a/core/cmd/irrlichd/handlers.go
+++ b/core/cmd/irrlichd/handlers.go
@@ -625,9 +625,11 @@ func serveHistoryStateChart(w http.ResponseWriter, concurrency outbound.Concurre
 		sr = &outbound.StateSeriesResult{
 			Start: query.Start, End: query.End, BucketSeconds: query.BucketSeconds,
 			BucketStarts: []int64{},
-			ByState: map[string]map[string][]float64{
-				session.StateWorking: {}, session.StateWaiting: {}, session.StateReady: {},
-			},
+			// #1801: the same buckets a real reader would have produced,
+			// derived from the vocabulary. Hand-typing the key list here was
+			// how a no-reader response came to carry a DIFFERENT set of states
+			// from a live one.
+			ByState: outbound.NewStateBuckets(),
 		}
 	}
 	writeHistoryJSON(w, buildStateResponse(rangeKey, scopeEcho, sr))
@@ -1552,12 +1554,18 @@ func handleGetState(repo outbound.SessionRepository) http.HandlerFunc {
 		TotalTokens        int64   `json:"totalTokens"`
 	}
 
+	// One count per canonical state. ErrorCount joins the other three in #1801:
+	// without it an errored session was counted in SessionCount and in none of
+	// the buckets, so the parts stopped summing to the whole and a red session
+	// was invisible in every aggregate. TestStateEndpoint_CountsEveryCanonicalState
+	// pins that this list keeps pace with session.CanonicalStates().
 	type stateResponse struct {
 		Sessions     []sessionEntry `json:"sessions"`
 		SessionCount int            `json:"sessionCount"`
 		WorkingCount int            `json:"workingCount"`
 		WaitingCount int            `json:"waitingCount"`
 		ReadyCount   int            `json:"readyCount"`
+		ErrorCount   int            `json:"errorCount"`
 		LastUpdated  string         `json:"lastUpdated"`
 	}
 
@@ -1569,7 +1577,11 @@ func handleGetState(repo outbound.SessionRepository) http.HandlerFunc {
 		}
 
 		entries := make([]sessionEntry, 0, len(sessions))
-		var workingCount, waitingCount, readyCount int
+		// Tally into a map rather than a switch (#1801). A switch over the
+		// state constants is an enumeration that reads as complete and goes
+		// silently incomplete the next time the vocabulary grows — which is
+		// precisely how `error` came to be dropped here. Counting by key can't.
+		byState := map[string]int{}
 		for _, s := range sessions {
 			var ctxUtil float64
 			var totalTokens int64
@@ -1589,22 +1601,16 @@ func handleGetState(repo outbound.SessionRepository) http.HandlerFunc {
 				ContextUtilization: ctxUtil,
 				TotalTokens:        totalTokens,
 			})
-			switch s.State {
-			case session.StateWorking:
-				workingCount++
-			case session.StateWaiting:
-				waitingCount++
-			case session.StateReady:
-				readyCount++
-			}
+			byState[s.State]++
 		}
 
 		resp := stateResponse{
 			Sessions:     entries,
 			SessionCount: len(sessions),
-			WorkingCount: workingCount,
-			WaitingCount: waitingCount,
-			ReadyCount:   readyCount,
+			WorkingCount: byState[session.StateWorking],
+			WaitingCount: byState[session.StateWaiting],
+			ReadyCount:   byState[session.StateReady],
+			ErrorCount:   byState[session.StateError],
 			LastUpdated:  time.Now().UTC().Format(time.RFC3339),
 		}
 

--- a/core/cmd/irrlichd/handlers.go
+++ b/core/cmd/irrlichd/handlers.go
@@ -1172,9 +1172,11 @@ func buildStateResponse(rangeKey, scope string, s *outbound.StateSeriesResult) h
 }
 
 // pruneStateProjects drops every by-state project entry outside the capped
-// row set kept (all three canonical state keys are always preserved, even if
-// their pruned sub-map ends up empty) — the response shouldn't carry
-// per-bucket series for rows the client will never draw (#1046).
+// row set kept (EVERY canonical state key is preserved, even if its pruned
+// sub-map ends up empty) — the response shouldn't carry per-bucket series for
+// rows the client will never draw (#1046). The code iterates byState rather
+// than naming states, so it was already correct when #1801 added a fourth;
+// this sentence said "all three" and was the copy that went stale.
 func pruneStateProjects(byState map[string]map[string][]float64, keep []string) map[string]map[string][]float64 {
 	keepSet := make(map[string]bool, len(keep))
 	for _, p := range keep {

--- a/core/cmd/irrlichd/handlers.go
+++ b/core/cmd/irrlichd/handlers.go
@@ -55,9 +55,26 @@ const costAttachTTL = 5 * time.Second
 // ProviderCosts holds per-provider trailing-window spend
 // (providerKey → timeframe → USD) so clients can render windowed usage chips
 // without re-attributing project costs — a single project can mix providers.
+//
+// DaemonErrors (#1801) is the one field here that is not about sessions: it
+// carries faults in Irrlicht's OWN machinery that have no session to attach
+// to, so the dashboard can say so instead of rendering a confidently green
+// list it has no right to. It rides on this endpoint rather than getting its
+// own because this is the payload the client already re-fetches on load and on
+// every rehydrate poll, so a standing fault surfaces and clears without a new
+// push type — and because a fault of this kind is precisely a reason to
+// distrust the sessions in the same response.
+//
+// KNOWN GAP, stated rather than implied: cmd/irrlichtrelay rebuilds this
+// payload from its own session cache and has no daemon-health data in its
+// envelope at all, so a relay-connected dashboard never sees these. That is
+// the same hole /api/v1/permissions' unapplied-grants banner already has (the
+// relay does not re-serve that route either), and closing it is a relay
+// protocol change, not a field.
 type sessionsResponse struct {
 	Groups        []*session.AgentGroup         `json:"groups"`
 	ProviderCosts map[string]map[string]float64 `json:"provider_costs,omitempty"`
+	DaemonErrors  []services.DaemonError        `json:"daemon_errors,omitempty"`
 }
 
 // costAttachCache caches the last project + provider cost scans so successive
@@ -87,7 +104,12 @@ func (c *costAttachCache) put(now time.Time, byProject, byProvider map[string]ma
 	c.mu.Unlock()
 }
 
-func handleGetSessions(repo outbound.SessionRepository, orchMonitor *services.OrchestratorMonitor, tracker outbound.CostTracker, controllable func(sessionID string) bool) http.HandlerFunc {
+// handleGetSessions serves the dashboard payload. hookHealth is nil-tolerant
+// and nil in every context that has no live hook counters to report (the tests
+// below, and any process that is not the daemon that served the hooks) — the
+// same nil-meaningful seam liveHookHealth already documents for the
+// diagnostics bundle.
+func handleGetSessions(repo outbound.SessionRepository, orchMonitor *services.OrchestratorMonitor, tracker outbound.CostTracker, controllable func(sessionID string) bool, hookHealth func() services.HookHealthSnapshot) http.HandlerFunc {
 	cache := &costAttachCache{}
 	return func(w http.ResponseWriter, r *http.Request) {
 		sessions, err := repo.ListAll()
@@ -105,6 +127,9 @@ func handleGetSessions(repo outbound.SessionRepository, orchMonitor *services.Or
 		groups := session.BuildDashboard(sessions, orchMonitor.State("gastown"))
 		annotateControllable(groups, controllable)
 		resp := sessionsResponse{Groups: groups}
+		if hookHealth != nil {
+			resp.DaemonErrors = services.DaemonErrors(hookHealth())
+		}
 		if tracker != nil {
 			byProject, byProvider := costMaps(tracker, cache)
 			attachGroupCosts(groups, byProject)

--- a/core/cmd/irrlichd/history_state_endpoint_test.go
+++ b/core/cmd/irrlichd/history_state_endpoint_test.go
@@ -47,8 +47,16 @@ func TestHandleGetHistory_StateChart(t *testing.T) {
 	if len(resp.Projects) != 1 || resp.Projects[0] != "projX" {
 		t.Errorf("projects: want [projX], got %+v", resp.Projects)
 	}
-	if resp.ByState == nil || resp.ByState[session.StateWorking] == nil || resp.ByState[session.StateWaiting] == nil || resp.ByState[session.StateReady] == nil {
-		t.Fatalf("by_state must carry all three canonical states, got %+v", resp.ByState)
+	// Reads the vocabulary rather than listing it (#1801): by_state must carry
+	// EVERY canonical state, error included, so the client can rely on the key
+	// existing whether or not anything happened in that state this window.
+	if resp.ByState == nil {
+		t.Fatalf("by_state missing entirely: %+v", resp)
+	}
+	for _, state := range session.CanonicalStates() {
+		if _, ok := resp.ByState[state]; !ok {
+			t.Fatalf("by_state must carry every canonical state; %q is missing, got %+v", state, resp.ByState)
+		}
 	}
 	if sum(resp.ByState[session.StateWorking]["projX"]) <= 0 {
 		t.Errorf("working[projX] should have positive activity, got series %v", resp.ByState[session.StateWorking]["projX"])

--- a/core/cmd/irrlichd/main.go
+++ b/core/cmd/irrlichd/main.go
@@ -743,6 +743,10 @@ func runDaemon() {
 		Push:         push,
 		Logger:       logger,
 		GitResolver:  gitResolver,
+		// Same live snapshot registerCoreRoutes hands the diagnostics bundle
+		// (#1801) — one source, two outlets, so the banner and hooks.json can
+		// never disagree about whether hooks are healthy.
+		HookHealth: liveHookHealth(hookLiveness, hookVerifier),
 	})
 
 	var watcherFactories map[string]services.WatcherFactory

--- a/core/cmd/irrlichd/main_test.go
+++ b/core/cmd/irrlichd/main_test.go
@@ -50,7 +50,7 @@ func newTestStack(t *testing.T) (*httptest.Server, *filesystem.SessionRepository
 	orchMonitor := services.NewOrchestratorMonitor(nil, push, nil)
 
 	mux := http.NewServeMux()
-	mux.HandleFunc("GET /api/v1/sessions", handleGetSessions(repo, orchMonitor, nil, nil))
+	mux.HandleFunc("GET /api/v1/sessions", handleGetSessions(repo, orchMonitor, nil, nil, nil))
 	mux.HandleFunc("GET /api/v1/agents", handleGetAgents(testAgents()))
 	mux.HandleFunc("GET /api/v1/version", handleGetVersion("test"))
 	mux.HandleFunc("GET /state", handleGetState(repo))
@@ -362,7 +362,7 @@ func TestHandleGetSessions_AttachesGroupCosts(t *testing.T) {
 	orchMonitor := services.NewOrchestratorMonitor(nil, push, nil)
 
 	mux := http.NewServeMux()
-	mux.HandleFunc("GET /api/v1/sessions", handleGetSessions(repo, orchMonitor, tracker, nil))
+	mux.HandleFunc("GET /api/v1/sessions", handleGetSessions(repo, orchMonitor, tracker, nil, nil))
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
 
@@ -447,7 +447,7 @@ func TestHandleGetSessions_AttachesProviderCosts(t *testing.T) {
 	push := services.NewPushService()
 	orchMonitor := services.NewOrchestratorMonitor(nil, push, nil)
 	mux := http.NewServeMux()
-	mux.HandleFunc("GET /api/v1/sessions", handleGetSessions(repo, orchMonitor, tracker, nil))
+	mux.HandleFunc("GET /api/v1/sessions", handleGetSessions(repo, orchMonitor, tracker, nil, nil))
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
 

--- a/core/cmd/irrlichd/startup.go
+++ b/core/cmd/irrlichd/startup.go
@@ -587,6 +587,14 @@ type registerSessionRoutesDeps struct {
 	Push         outbound.PushBroadcaster
 	Logger       outbound.Logger
 	GitResolver  *git.Adapter
+	// HookHealth is the same live snapshot function the diagnostics bundle
+	// gets (liveHookHealth). #1801 gives its two client-invisible diagnoses —
+	// entries that went missing, channels that have gone silent — a second
+	// outlet on /api/v1/sessions, because a hook fault degrades every
+	// session's classification and until now was visible only inside a
+	// `--diagnose` tarball. nil is valid and means "report no daemon-wide
+	// faults", matching liveHookHealth's own nil-meaningful seam.
+	HookHealth func() services.HookHealthSnapshot
 }
 
 // registerSessionRoutes wires the sessions/history/focus endpoints. Kept
@@ -600,7 +608,7 @@ func registerSessionRoutes(mux *http.ServeMux, deps registerSessionRoutesDeps) {
 				return s.Controllable(sessionID)
 			}
 			return false
-		}))
+		}, deps.HookHealth))
 
 	// History tab analytics (issue #369): trailing/calendar/custom-range cost
 	// series + linear forecast, computed from the cost snapshot files. #373 adds

--- a/core/cmd/irrlicht-ls/main.go
+++ b/core/cmd/irrlicht-ls/main.go
@@ -34,7 +34,13 @@ func main() {
 	flag.StringVar(&format, "format", "text", `output format: "text" or "json"`)
 	flag.BoolVar(&showYield, "yield", false, "show yield state and revert SHA (7-char) columns")
 	flag.StringVar(&f.idPrefix, "id", "", "filter: session ID prefix")
-	flag.StringVar(&f.state, "state", "", "filter: session state (working|waiting|ready)")
+	// #1801: the help text is the THIRD copy of the vocabulary in this file's
+	// history and was the one #1798 missed — validateFlags and its rejection
+	// message were both fixed to read the domain while `--help` went on
+	// advertising three states and hiding the fourth. Derived, so it can't
+	// drift again.
+	flag.StringVar(&f.state, "state", "",
+		"filter: session state ("+strings.Join(session.CanonicalStates(), "|")+")")
 	flag.StringVar(&f.project, "project", "", "filter: project name substring")
 	flag.StringVar(&f.adapter, "adapter", "", "filter: agent adapter (e.g. claude-code, codex)")
 	flag.Parse()

--- a/core/domain/session/grouped.go
+++ b/core/domain/session/grouped.go
@@ -286,16 +286,19 @@ func ComputeSubagentSummary(parent *SessionState, childSessions []*SessionState)
 		Total:   inProcess + len(fileChildren),
 		Working: inProcess,
 	}
+	// Tally by key, not by switch (#1801): Total already counts every file
+	// child, so any state missing from the buckets breaks the invariant that
+	// they sum to it. A map cannot go silently incomplete; the readout below
+	// is the only place states are named, and a canonical state absent from it
+	// is caught by TestComputeSubagentSummary_BucketsSumToTotal.
+	byState := map[string]int{}
 	for _, c := range fileChildren {
-		switch c.State {
-		case StateWorking:
-			summary.Working++
-		case StateWaiting:
-			summary.Waiting++
-		case StateReady:
-			summary.Ready++
-		}
+		byState[c.State]++
 	}
+	summary.Working += byState[StateWorking]
+	summary.Waiting = byState[StateWaiting]
+	summary.Ready = byState[StateReady]
+	summary.Error = byState[StateError]
 	return summary
 }
 

--- a/core/domain/session/session.go
+++ b/core/domain/session/session.go
@@ -59,6 +59,58 @@ func IsCanonicalState(s string) bool {
 	return slices.Contains(canonicalStates, s)
 }
 
+// HasWorkInFlight reports whether more work is coming for this session, so
+// that whatever is waiting on it must keep waiting.
+//
+// THIS IS ONE HALF OF A PARTITION, and the half that is NOT about concurrency.
+// Seven call sites spell some variant of `state == StateWorking || state ==
+// StateWaiting` inline; #1798 flagged that they had silently become an
+// INCOMPLETE enumeration when the fourth state arrived, and #1801 settles the
+// split here rather than leaving each site to drift:
+//
+//   - "Does this session occupy a concurrency slot?" — working or waiting, and
+//     nothing else. `error` is excluded deliberately and permanently: nothing
+//     clears an error until the next successful turn, so counting it would
+//     inflate the active count for the whole remaining life of the session.
+//     That half stays in the concurrency tracker's own `concurrencyActive`,
+//     which reads a bare state string off a persisted timeline that carries no
+//     error detail at all — which is itself why the two cannot be one
+//     function. events.md records the rule.
+//
+//   - "Is more work coming?" — this one. A session in `error` whose Phase is
+//     `retrying` has another attempt scheduled: it is still working, and
+//     releasing its parent in that gap paints the parent green while its
+//     subagent sits red mid-retry.
+//
+// A TERMINAL error is not work in flight — no further attempt is coming, and
+// the thing waiting is free to finish. Neither is ErrorPhaseUnknown:
+// IsRetrying is false for it on purpose (see its doc), and reading "probably
+// still going" out of a transcript that said nothing is exactly the invented
+// verdict every pointer field on SessionError exists to prevent.
+//
+// ONLY hasActiveChildren (parent-ready gating) consumes this today, because it
+// is the only site whose answer actually changes. The others were each checked
+// and deliberately left on their current answer: isOrphanedChild and
+// findCompletionTarget gate PROMOTION to ready, where admitting a retrying
+// session would clear a live error rather than preserve it; isUserInterruptReady
+// leaves an errored session red after an ESC, matching "cleared by the next
+// successful turn and by nothing else"; aggregateSubagentEstimate is
+// working-only by design because an errored child contributes no estimate.
+// Said out loud here so the next reader inherits the decision instead of the
+// question.
+func (s *SessionState) HasWorkInFlight() bool {
+	if s == nil {
+		return false
+	}
+	if s.State == StateWorking || s.State == StateWaiting {
+		return true
+	}
+	if s.State != StateError || s.Metrics == nil {
+		return false
+	}
+	return s.Metrics.SessionError.IsRetrying()
+}
+
 // Yield state constants — whether a finished session's work survived in the
 // repo or was reverted (#373). An independent dimension from the lifecycle
 // State above: a session is always in exactly one of the lifecycle states, and
@@ -79,11 +131,20 @@ type MetricsTimelinePoint struct {
 }
 
 // subagentSummary tracks the aggregate state of all child sessions.
+//
+// Error joins the other three in #1801. Without it an errored child was
+// counted in Total and in none of the buckets, so working+waiting+ready
+// silently stopped summing to total and a red subagent was invisible in the
+// parent's badge — the one place a user would look to find out why the parent
+// is stuck. No `omitempty`: the existing three always serialize, and a bucket
+// that vanishes at zero would make "no errored children" and "this daemon
+// predates the field" the same wire value.
 type subagentSummary struct {
 	Total   int `json:"total"`
 	Working int `json:"working"`
 	Waiting int `json:"waiting"`
 	Ready   int `json:"ready"`
+	Error   int `json:"error"`
 }
 
 // Equal reports whether two summaries carry the same counts. Nil receivers

--- a/core/domain/session/session.go
+++ b/core/domain/session/session.go
@@ -89,15 +89,35 @@ func IsCanonicalState(s string) bool {
 // verdict every pointer field on SessionError exists to prevent.
 //
 // ONLY hasActiveChildren (parent-ready gating) consumes this today, because it
-// is the only site whose answer actually changes. The others were each checked
-// and deliberately left on their current answer: isOrphanedChild and
-// findCompletionTarget gate PROMOTION to ready, where admitting a retrying
-// session would clear a live error rather than preserve it; isUserInterruptReady
-// leaves an errored session red after an ESC, matching "cleared by the next
-// successful turn and by nothing else"; aggregateSubagentEstimate is
-// working-only by design because an errored child contributes no estimate.
-// Said out loud here so the next reader inherits the decision instead of the
-// question.
+// is the only site whose answer actually changes. Every other site was checked;
+// each is named here with its reason, so the next reader inherits the decision
+// instead of the question:
+//
+//   - isOrphanedChild and findCompletionTarget gate PROMOTION to ready.
+//     Admitting a retrying session there would CLEAR a live error rather than
+//     preserve it — the opposite of what this predicate is for.
+//   - isUserInterruptReady leaves an errored session red after an ESC, matching
+//     "cleared by the next successful turn and by nothing else".
+//   - aggregateSubagentEstimate is working-only by design: an errored child
+//     contributes no estimate.
+//   - refreshStaleSessions is not a three-state site at all any more — #1798
+//     already widened it (session_detector_activity.go's
+//     `case StateWaiting, StateReady, StateError`), which is what makes
+//     sessionErrorHoldTimeout reachable.
+//   - pid_manager's liveness sweep keys off `== StateReady`, not off
+//     working-or-waiting, so `error` behaves there exactly as `working` always
+//     did. Nothing to change.
+//
+// ONE CAVEAT ON THE HOLD THIS CREATES, since a parent held forever would be a
+// worse bug than the one being fixed. For transcript-backed children the hold
+// is bounded well below the error's own 12h ceiling: reapStaleChild reaps any
+// non-ready child whose transcript has been idle past orphanTranscriptAge (2
+// minutes) and fires onChildDeleted, which releases the parent. DB-backed
+// children (the `?session=` adapters — hermes, opencode, antigravity) are
+// exempt from that sweep, so there a stuck Phase==retrying child holds its
+// parent until the adapter's own maxAge or the 12h ceiling. That is latent
+// rather than live: no inbound adapter emits SessionError yet, which is
+// #1799/#1800's work, and it is theirs to bound.
 func (s *SessionState) HasWorkInFlight() bool {
 	if s == nil {
 		return false

--- a/core/domain/session/subagent_summary_states_test.go
+++ b/core/domain/session/subagent_summary_states_test.go
@@ -1,0 +1,105 @@
+package session
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestComputeSubagentSummary_BucketsSumToTotal is a CHECK THIS CHANGE ADDS, so
+// it has no "before the fix" to run red against — its evidence is the mutation
+// battery below its own claim: delete the Error bucket from subagentSummary, or
+// drop the `summary.Error = byState[StateError]` readout in grouped.go, and it
+// goes red on the error row.
+//
+// What it pins is an invariant, not a field list: Total counts every file
+// child, so the per-state buckets must account for every one of them. Pre-#1801
+// they did not — ComputeSubagentSummary switched over three states while Total
+// counted four, so an errored child inflated the total and landed nowhere, and
+// the parent's subagent badge said "3 children, 2 accounted for" with no way to
+// tell which one was red.
+//
+// It iterates CanonicalStates rather than naming states, so a fifth state fails
+// here the day it is added rather than the day someone notices the arithmetic.
+func TestComputeSubagentSummary_BucketsSumToTotal(t *testing.T) {
+	parent := &SessionState{SessionID: "p"}
+	var children []*SessionState
+	want := map[string]int{}
+	for i, st := range CanonicalStates() {
+		// A different count per state, so a readout wired to the wrong bucket
+		// (Error reading StateReady's tally, say) cannot coincidentally pass.
+		n := i + 1
+		want[st] = n
+		for j := 0; j < n; j++ {
+			children = append(children, &SessionState{
+				SessionID:       st,
+				ParentSessionID: "p",
+				State:           st,
+			})
+		}
+	}
+
+	got := ComputeSubagentSummary(parent, children)
+	if got == nil {
+		t.Fatal("ComputeSubagentSummary returned nil for a parent with children")
+	}
+
+	buckets := map[string]int{
+		StateWorking: got.Working,
+		StateWaiting: got.Waiting,
+		StateReady:   got.Ready,
+		StateError:   got.Error,
+	}
+	// Assert the readout map itself covers the vocabulary. Without this the
+	// loop below would silently check fewer states if one were dropped from
+	// both production and this map — inability to look reading as a clean pass
+	// (AGENTS.md).
+	for _, st := range CanonicalStates() {
+		if _, ok := buckets[st]; !ok {
+			t.Fatalf("subagentSummary has no bucket for canonical state %q — every state a child can be in needs one, or Total stops summing", st)
+		}
+	}
+
+	sum := 0
+	for _, st := range CanonicalStates() {
+		if buckets[st] != want[st] {
+			t.Errorf("bucket %q: got %d, want %d", st, buckets[st], want[st])
+		}
+		sum += buckets[st]
+	}
+	if sum != got.Total {
+		t.Errorf("buckets sum to %d but Total is %d — every child must land in exactly one bucket", sum, got.Total)
+	}
+}
+
+// TestSubagentSummary_ErrorBucketIsAlwaysOnTheWire pins that the new bucket
+// serializes unconditionally, like the three beside it. With `omitempty` a
+// healthy parent and a parent from a daemon that predates the field would ship
+// identical JSON, so a client could never tell "no errored children" from "this
+// build cannot tell me".
+func TestSubagentSummary_ErrorBucketIsAlwaysOnTheWire(t *testing.T) {
+	b, err := json.Marshal(&subagentSummary{Total: 1, Working: 1})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var raw map[string]any
+	if err := json.Unmarshal(b, &raw); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if _, ok := raw["error"]; !ok {
+		t.Errorf("subagents payload has no \"error\" key at zero: %s", b)
+	}
+}
+
+// TestSubagentSummary_EqualSeesTheErrorBucket is the guard on the re-broadcast
+// suppression at session_detector_activity.go: Equal compares the struct by
+// value, so a new field is picked up for free — but "for free" is a property of
+// the current implementation, not a promise. If Equal is ever rewritten to
+// compare fields by hand and the error bucket is missed, a parent whose child
+// just went red would stop being re-broadcast and the badge would freeze.
+func TestSubagentSummary_EqualSeesTheErrorBucket(t *testing.T) {
+	a := &subagentSummary{Total: 1, Error: 0}
+	b := &subagentSummary{Total: 1, Error: 1}
+	if a.Equal(b) {
+		t.Error("summaries differing only in the error bucket compared equal — a child going red would not re-broadcast")
+	}
+}

--- a/core/ports/outbound/ports.go
+++ b/core/ports/outbound/ports.go
@@ -349,17 +349,20 @@ type ConcurrencyResult struct {
 // counts over time, returned by ConcurrencyReader.StateSeries (issue #981,
 // the optional "time-in-state" second half of #751). It parallels
 // ConcurrencyResult: BucketStarts holds each bucket's start (unix seconds).
-// ByState maps each canonical state (session.StateWorking/StateWaiting/
-// StateReady) to a project -> per-bucket slice (each slice has len ==
-// len(BucketStarts)). Working/waiting counts are per-bucket peak concurrency
-// in that specific state — the same semantics as ConcurrencyResult.ByKey,
-// just split by state instead of merged into one "active" count. Ready
-// counts are the number of sessions that transitioned to ready within the
-// bucket: ready is session.go's terminal state, with no duration to be
-// concurrent in, so it's a transition histogram rather than a concurrency
-// count. Peak/Average/Current mirror ConcurrencyResult's working+waiting
-// summary (the "how busy" headline), computed over the same reconstructed
-// intervals.
+// ByState maps each state in session.CanonicalStates() to a project ->
+// per-bucket slice (each slice has len == len(BucketStarts)); every canonical
+// state is always a key, so a client tells "nothing happened in this window"
+// from "this daemon does not know that state" by whether the key exists.
+// Working/waiting counts are per-bucket peak concurrency in that specific
+// state — the same semantics as ConcurrencyResult.ByKey, just split by state
+// instead of merged into one "active" count. Ready and error counts are the
+// number of sessions that transitioned into that state within the bucket:
+// neither is concurrency-active, so neither has a duration to be concurrent
+// in, and a transition histogram is what is left (see stateReconstruction for
+// why the split follows concurrencyActive rather than a second list).
+// Peak/Average/Current mirror ConcurrencyResult's working+waiting summary (the
+// "how busy" headline), computed over the same reconstructed intervals — an
+// errored session contributes to none of the three, by the same settled rule.
 type StateSeriesResult struct {
 	Start         int64                           `json:"start"`
 	End           int64                           `json:"end"`
@@ -369,6 +372,26 @@ type StateSeriesResult struct {
 	Peak          float64                         `json:"peak"`
 	Average       float64                         `json:"average"`
 	Current       float64                         `json:"current"`
+}
+
+// NewStateBuckets returns an empty StateSeriesResult.ByState with one bucket
+// per canonical lifecycle state.
+//
+// Derived from session.CanonicalStates() rather than typed out (#1801). The
+// key list existed as a literal in THREE places — StateSeries,
+// emptyStateSeriesResult, and handlers.go's nil-reader fallback — and all
+// three said working/waiting/ready, so #1798's fourth state was missing from
+// the wire in three places at once and no client could have drawn a red
+// segment even once a producer existed. It lives here, beside the type whose
+// field it builds, because the three callers span the adapter, the daemon
+// command, and this package's own tests.
+func NewStateBuckets() map[string]map[string][]float64 {
+	states := session.CanonicalStates()
+	out := make(map[string]map[string][]float64, len(states))
+	for _, s := range states {
+		out[s] = map[string][]float64{}
+	}
+	return out
 }
 
 // ConcurrencyReader reconstructs a concurrent-agents time series from the

--- a/docs/relay-protocol.md
+++ b/docs/relay-protocol.md
@@ -146,10 +146,19 @@ without an empty first paint, and serves the `platforms/web/` dashboard:
 
 | Endpoint              | Body                                                            |
 | --------------------- | -------------------------------------------------------------- |
-| `GET /api/v1/sessions` | `{ "groups": [...] }` — `BuildDashboard` over the cached sessions (grouped by project; no **orchestrator** (Gas Town) state in v0). |
+| `GET /api/v1/sessions` | `{ "groups": [...] }` — `BuildDashboard` over the cached sessions (grouped by project; no **orchestrator** (Gas Town) state in v0). **No `daemon_errors`** — see below. |
 | `GET /api/v1/agents`   | union of every connected daemon's registry, deduped by `name`. |
 | `GET /api/v1/version`  | the relay's own build version.                                 |
 | `GET /` (+ assets)     | the dashboard, served from disk (`IRRLICHT_UI_DIR` override, else dev/bundle lookup). |
+
+The daemon's own `/api/v1/sessions` carries a top-level `daemon_errors` array
+(#1801) reporting faults in Irrlicht's own machinery — hook entries that went
+missing, hook channels that have gone silent — which the dashboard renders as a
+banner. **The relay does not forward it.** It rebuilds this payload from its
+session cache, and the envelope carries no daemon health at all, so a
+relay-connected dashboard shows no daemon-error banner. Same for
+`/api/v1/permissions`, which the relay does not re-serve, so its unapplied-grants
+banner is equally absent. Both need an envelope change rather than a field.
 
 WebSocket `CheckOrigin` is permissive by default (the dashboard served from a
 different port is cross-origin). `serve --origin-allowlist host1,host2`

--- a/events.md
+++ b/events.md
@@ -154,8 +154,13 @@ Note: transcript silence on a non-blocking open tool call (e.g. a long-running b
 Parent-child relationships are derived from the transcript path: Claude Code writes an `isSidechain` transcript under `<parent>/subagents/agent-*.jsonl` for every `Agent` tool call, and the fswatcher registers each as a child session linked via `ParentSessionID`. Parent sessions carry a `subagentSummary` under the JSON key `subagents`:
 
 ```
-subagentSummary { total, working, waiting, ready int }
+subagentSummary { total, working, waiting, ready, error int }
 ```
+
+The per-state buckets sum to `total`: every child lands in exactly one of them.
+`error` was added in #1801 for that reason — before it, an errored child was
+counted in `total` and in none of the buckets, so a red subagent was invisible
+in the one badge a user checks to find out why a parent is stuck.
 
 Subagent sessions run independent state machines with the same states.
 

--- a/platforms/web/formatters.js
+++ b/platforms/web/formatters.js
@@ -22,6 +22,18 @@ const svgIcons = {
   // follows no theme override at all — a known wart, left alone rather than
   // copied.)
   unknown: '<svg class="state-unknown" viewBox="0 0 16 16" fill="none"><circle cx="8" cy="8" r="6.5" stroke="currentColor" stroke-width="1.5"/><path d="M6.2 6.2a1.85 1.85 0 113 1.5c-.7.5-1.2.85-1.2 1.6" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/><circle cx="8" cy="11.6" r="0.85" fill="currentColor"/></svg>',
+  // Session error (#1801) — the fourth lifecycle state: the agent's own
+  // machinery failed. `currentColor` + a class hook, like `unknown` above and
+  // for the same reason: the .state-error rule in irrlicht.css points it at
+  // var(--error), whose light-theme value is a DIFFERENT hex (WCAG-corrected),
+  // so an inlined hex here would render the light theme at 3.01:1. The four
+  // entries above inline theirs and follow no override — the known wart #1797
+  // recorded, deliberately not copied.
+  //
+  // Deliberately NOT given the `core` class: that is what
+  // `.row-state-icon svg circle.core` animates, and a pulsing red dot would
+  // read as "working" — the one thing an errored session is not.
+  error: '<svg class="state-error" viewBox="0 0 16 16" fill="none"><circle cx="8" cy="8" r="6.5" stroke="currentColor" stroke-width="1.5"/><path d="M8 4.6v4.2" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/><circle cx="8" cy="11.4" r="0.9" fill="currentColor"/></svg>',
 };
 
 // stateIcon maps a session state to its 12px glyph. An unrecognized state gets

--- a/platforms/web/historyTab.js
+++ b/platforms/web/historyTab.js
@@ -718,7 +718,7 @@ function buildStateRowLabel(project) {
 }
 
 // buildStateCell renders one grid cell: a bottom-anchored stacked mini bar
-// (working/waiting/ready, fixed stack order — see STATE_STACK_ORDER) sized
+// (one per STATE_STACK_ORDER entry, in that fixed bottom-to-top order) sized
 // against maxTotal, with a hover/focus tooltip and an aria-label carrying the
 // exact counts for anyone not using the tooltip.
 function buildStateCell(project, ts, counts, maxTotal) {

--- a/platforms/web/historyTab.js
+++ b/platforms/web/historyTab.js
@@ -17,8 +17,23 @@ export const CHART_LABELS = { cost: 'Cost', tokens: 'Tokens', co2: 'CO2', models
 // count at once (see historyGranularitySpecs on the daemon side).
 const GRANULARITY_LABELS = { '1m': '1 min', '10m': '10 min', '60m': '60 min', '8h': '8 hr', '24h': '24 hr', '7d': '7 day', '1mo': '1 mo', '6mo': '6 mo', '1y': '1 yr' };
 // Fixed stack order for the activity matrix's per-cell mini bar, bottom to
-// top — mirrors the canonical state order in core/domain/session/session.go.
-const STATE_STACK_ORDER = ['working', 'waiting', 'ready'];
+// top — mirrors the canonical state order in core/domain/session/session.go,
+// including #1798's `error` (#1801). The daemon emits a bucket for every
+// canonical state, so a state missing from this list is silently dropped from
+// the chart, the tooltip, the legend AND the CSV export at once, which is
+// exactly what happened to `error` between #1798 and here.
+//
+// The labels live in the same table as the order, because before #1801 the
+// pairs were re-typed in three more places (legend, tooltip, and two hardcoded
+// working+waiting+ready sums) and a fourth state had to be added to all of
+// them or the chart would disagree with itself about what a cell totals.
+const STATE_STACK = [
+  ['working', 'Working'],
+  ['waiting', 'Waiting'],
+  ['ready', 'Ready'],
+  ['error', 'Error'],
+];
+const STATE_STACK_ORDER = STATE_STACK.map(([state]) => state);
 // Drilldown order: clicking a contributor scopes to it and re-groups by the
 // next finer axis. A leaf (no entry) makes that contributor non-drillable.
 export const DRILL_NEXT = { project: 'branch', branch: 'session', provider: 'model', model: 'session' };
@@ -628,8 +643,8 @@ function paintHistoryChart() {
 
 const STATE_CELL_INNER_H = 26; // px — must match the bar's available height in irrlicht.css (.hsm-cell's grid row height minus .hsm-bar's bottom margin)
 
-// stateCellCounts returns one (project, bucket-index) cell's
-// {working, waiting, ready} counts, defaulting missing entries to 0.
+// stateCellCounts returns one (project, bucket-index) cell's per-state counts,
+// one key per STATE_STACK_ORDER entry, defaulting missing entries to 0.
 export function stateCellCounts(data, project, i) {
   const by = data?.by_state || {};
   const out = {};
@@ -637,10 +652,21 @@ export function stateCellCounts(data, project, i) {
   return out;
 }
 
-// stateCellTotal sums one cell's working+waiting+ready counts.
+// stateCellTotal sums one cell's per-state counts.
+//
+// Derived from the stack order rather than adding three named fields (#1801):
+// the hand-written sum was a second enumeration that had to be kept in step
+// with the first, and a state present in the chart but absent from the total
+// would size every bar wrong.
 export function stateCellTotal(data, project, i) {
-  const counts = stateCellCounts(data, project, i);
-  return counts.working + counts.waiting + counts.ready;
+  return sumCounts(stateCellCounts(data, project, i));
+}
+
+// sumCounts totals a per-state counts object over the stack order.
+function sumCounts(counts) {
+  let total = 0;
+  for (const state of STATE_STACK_ORDER) total += counts[state] || 0;
+  return total;
 }
 
 // stateMatrixMaxTotal finds the busiest single cell across the whole visible
@@ -701,11 +727,11 @@ function buildStateCell(project, ts, counts, maxTotal) {
   cell.tabIndex = 0;
   cell.setAttribute('role', 'img');
   cell.setAttribute('aria-label', project + ', ' + new Date(ts * 1000).toLocaleString() + ': ' +
-    counts.working + ' working, ' + counts.waiting + ' waiting, ' + counts.ready + ' ready');
+    STATE_STACK.map(([state]) => counts[state] + ' ' + state).join(', '));
 
   const bar = document.createElement('div');
   bar.className = 'hsm-bar';
-  const total = counts.working + counts.waiting + counts.ready;
+  const total = sumCounts(counts);
   if (total > 0) {
     bar.style.height = Math.max(3, Math.round((total / maxTotal) * STATE_CELL_INNER_H)) + 'px';
     let lastNonZero = null;
@@ -776,7 +802,7 @@ function renderStatePanel() {
     appendHistoryEmpty(listEl, 'no agents in this range');
     return;
   }
-  for (const [state, label] of [['working', 'Working'], ['waiting', 'Waiting'], ['ready', 'Ready']]) {
+  for (const [state, label] of STATE_STACK) {
     const li = document.createElement('li');
     const dot = document.createElement('span'); dot.className = 'dot hsm-seg-' + state;
     const lab = document.createElement('span'); lab.className = 'label'; lab.textContent = label;
@@ -806,7 +832,7 @@ function showStateTooltip(cell, project, ts, counts) {
   const title = document.createElement('div'); title.className = 'hsm-tooltip-title'; title.textContent = project;
   const range = document.createElement('div'); range.className = 'hsm-tooltip-range'; range.textContent = new Date(ts * 1000).toLocaleString();
   el.append(title, range);
-  for (const [state, label] of [['working', 'Working'], ['waiting', 'Waiting'], ['ready', 'Ready']]) {
+  for (const [state, label] of STATE_STACK) {
     const row = document.createElement('div'); row.className = 'hsm-tooltip-row';
     const key = document.createElement('span'); key.className = 'hsm-tooltip-key';
     const dot = document.createElement('i'); dot.className = 'hsm-tooltip-dot hsm-seg-' + state;
@@ -1305,15 +1331,20 @@ function yieldCsvLines(d) {
   return lines;
 }
 
+// stateCsvLines exports the activity matrix.
+//
+// Header and rows both come from STATE_STACK_ORDER (#1801), so the columns
+// cannot disagree with each other or with the chart. The header GAINS an
+// `error` column, which is a deliberate change to what the export looks like:
+// the alternative is an export that silently omits a state the chart shows,
+// and a spreadsheet whose columns no longer sum to what the tooltip says.
 function stateCsvLines(d) {
-  const lines = ['bucket_start,project,working,waiting,ready'];
+  const lines = [['bucket_start', 'project', ...STATE_STACK_ORDER].join(',')];
   const by = d.by_state || {};
   for (const project of (d.projects || [])) {
     (d.bucket_starts || []).forEach((ts, i) => {
-      const w = by.working?.[project]?.[i] || 0;
-      const wt = by.waiting?.[project]?.[i] || 0;
-      const r = by.ready?.[project]?.[i] || 0;
-      lines.push([new Date(ts * 1000).toISOString(), historyCsvCell(project), w, wt, r].join(','));
+      const cells = STATE_STACK_ORDER.map(state => by[state]?.[project]?.[i] || 0);
+      lines.push([new Date(ts * 1000).toISOString(), historyCsvCell(project), ...cells].join(','));
     });
   }
   return lines;

--- a/platforms/web/index.html
+++ b/platforms/web/index.html
@@ -167,6 +167,25 @@
          able to fix right now, so it must inform without interrupting. -->
     <div id="permission-apply-banner" role="status" aria-live="polite" hidden></div>
 
+    <!-- #1801: "Irrlicht's own monitoring is degraded" — a fault in the daemon
+         itself, with no session to attach it to. role=alert, NOT status, and
+         the choice is the deliberate opposite of #1385's above.
+         #1385 reports a standing condition the user may not be able to act on
+         now, and the sessions around it are still being reported correctly —
+         so it informs without interrupting. This one says the dashboard cannot
+         vouch for what it is showing: a silent hook channel demotes every
+         session of that adapter to transcript-only classification, so the list
+         goes on looking healthy while being wrong. A user who keeps reading a
+         display that is quietly incorrect is the harm, which is what alert's
+         interruption is for — the same call #connection-banner above makes for
+         "no source is reachable".
+         aria-live=polite alongside it, copied from #connection-banner: alert
+         semantics so it is announced as a fault, polite delivery so it waits
+         for a pause instead of cutting off whatever is being read. The
+         renderer additionally skips a rebuild when the content is unchanged,
+         so a standing fault is announced once rather than on every poll. -->
+    <div id="daemon-error-banner" role="alert" aria-live="polite" hidden></div>
+
     <div id="view-live">
       <div id="empty-state">
         <div class="empty-dot"></div>

--- a/platforms/web/irrlicht.css
+++ b/platforms/web/irrlicht.css
@@ -98,8 +98,8 @@
            5.80:1 against plain white, which puts it in the same band as
            --ready's 4.62:1. Reproduce with:
              node platforms/web/snapshots/contrast.mjs
-           and the assertion lives in irrlicht.test.js so it is re-run, not
-           just recorded here. */
+           and the assertion lives in platforms/web/sessionError.test.js so it
+           is re-run by CI, not just recorded here. */
         --error: #CC0C00;
         --error-dim: rgba(204, 12, 0, 0.12);
       }
@@ -839,6 +839,26 @@
        row beneath the parent (mirrors macOS SessionRowView.cacheBloatBlock),
        since the version-attribution string can be a full sentence, too wide
        for the fixed-width icon row. Indent matches .row-summary-row. */
+    .row-cache-bloat-row {
+      margin: 0 10px 4px 24px;
+      font-family: var(--font-mono);
+    }
+    .row-cache-bloat-row.child { margin-left: 44px; }
+    .row-cache-bloat {
+      display: inline-block;
+      max-width: 100%;
+      font-size: 10px;
+      font-weight: 600;
+      padding: 3px 6px;
+      border-radius: 4px;
+      background: rgba(255, 59, 48, 0.12);
+      color: var(--pressure-high);
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      cursor: default;
+    }
+
     /* Session-error row (#1801) — the red line beneath an errored session,
        carrying the agent's own failure text. Its own row rather than an inline
        slot for the reason createSessionRow's anatomy comment gives about the
@@ -854,6 +874,11 @@
       margin: 0 10px 4px 24px;
       font-family: var(--font-mono);
     }
+    /* Unreachable today, and kept deliberately: emitGroup never recurses into
+       a.children, so no sub-row is emitted for a child session. Present for
+       parity with .row-cache-bloat-row.child above, which is unreachable for
+       exactly the same reason — dropping one without the other would make the
+       two rows look like they differ when they do not. */
     .row-error-row.child { margin-left: 44px; }
     .row-error {
       display: inline-block;
@@ -873,26 +898,6 @@
     .row-error-retry {
       font-weight: 400;
       opacity: 0.85;
-    }
-
-    .row-cache-bloat-row {
-      margin: 0 10px 4px 24px;
-      font-family: var(--font-mono);
-    }
-    .row-cache-bloat-row.child { margin-left: 44px; }
-    .row-cache-bloat {
-      display: inline-block;
-      max-width: 100%;
-      font-size: 10px;
-      font-weight: 600;
-      padding: 3px 6px;
-      border-radius: 4px;
-      background: rgba(255, 59, 48, 0.12);
-      color: var(--pressure-high);
-      white-space: nowrap;
-      overflow: hidden;
-      text-overflow: ellipsis;
-      cursor: default;
     }
 
     /* Pending question — collapsible block beneath the parent row, shown only

--- a/platforms/web/irrlicht.css
+++ b/platforms/web/irrlicht.css
@@ -25,6 +25,18 @@
       --ready: #34C759;
       --ready-dim: rgba(52, 199, 89, 0.12);
       --ready-glow: rgba(52, 199, 89, 0.2);
+      /* Session error (#1801) — the fourth lifecycle state. Apple's system
+         red, which is already this palette's failure hue (--pressure-high and
+         --ws-disconnected are the same value) rather than a fifth red nobody
+         asked for. #1802 adds the matching macOS IrrHex.error; until it does,
+         irrlicht.test.js pins this against the red Tokens.swift ALREADY
+         declares, so the two frontends cannot ship different reds in the gap.
+         Unlike --cancelled/--unknown this DOES get a light-theme override
+         below: at 3.01:1 against its own wash on white it fails WCAG AA, so
+         copying the dark value would repeat exactly the #984 defect the
+         light-palette block exists to fix. */
+      --error: #FF3B30;
+      --error-dim: rgba(255, 59, 48, 0.12);
       --cancelled: #8E8E93;
       --cancelled-dim: rgba(142, 142, 147, 0.1);
       /* Unrecognized session state (#1797) — a state this build has never
@@ -78,6 +90,18 @@
         --waiting-dim: rgba(136, 79, 0, 0.12);
         --ready: #207936;
         --ready-dim: rgba(32, 121, 54, 0.12);
+        /* #1801, same rule as the three above and measured the same way. The
+           dark --error (#FF3B30) reads 3.01:1 against its own 12% wash on
+           --surface #ffffff — under the 4.5:1 minimum, and the worst possible
+           colour to render illegibly. #CC0C00 is the same hue (H=3.6deg,
+           S=100%) darkened to L=40%, measuring 4.69:1 against its own wash and
+           5.80:1 against plain white, which puts it in the same band as
+           --ready's 4.62:1. Reproduce with:
+             node platforms/web/snapshots/contrast.mjs
+           and the assertion lives in irrlicht.test.js so it is re-run, not
+           just recorded here. */
+        --error: #CC0C00;
+        --error-dim: rgba(204, 12, 0, 0.12);
       }
     }
     :root[data-theme="light"] {
@@ -102,6 +126,8 @@
       --waiting-dim: rgba(136, 79, 0, 0.12);
       --ready: #207936;
       --ready-dim: rgba(32, 121, 54, 0.12);
+      --error: #CC0C00;
+      --error-dim: rgba(204, 12, 0, 0.12);
     }
 
     body {
@@ -596,6 +622,16 @@
       color: var(--unknown);
     }
 
+    /* Session error (#1801) — same construction as the unknown icon above and
+       for the same reason: the glyph paints with currentColor so it follows
+       the light-theme --error override, instead of freezing at the dark hex
+       the way working/waiting/ready/cancelled do. Those four are a known wart
+       left alone (#1797); this one does not copy it. */
+    .row-state-icon svg.state-error,
+    .app-state-icon svg.state-error {
+      color: var(--error);
+    }
+
     /* Working state — opacity-only "breathe" on a large solid dot.
        Footprint is r=7 of 20 viewBox (70 % of cell), so the dot stays
        clearly visible even if the animation is dropped by the renderer
@@ -803,6 +839,42 @@
        row beneath the parent (mirrors macOS SessionRowView.cacheBloatBlock),
        since the version-attribution string can be a full sentence, too wide
        for the fixed-width icon row. Indent matches .row-summary-row. */
+    /* Session-error row (#1801) — the red line beneath an errored session,
+       carrying the agent's own failure text. Its own row rather than an inline
+       slot for the reason createSessionRow's anatomy comment gives about the
+       cache-bloat badge: a provider error message is a sentence, not something
+       that fits a fixed-width column.
+       Deliberately NOT copying .row-cache-bloat's `white-space: nowrap` +
+       ellipsis. That badge renders a short derived phrase, so clipping it
+       loses nothing; this renders an agent's verbatim error, where the part
+       that gets clipped is exactly the part the user needs. It wraps instead,
+       the same call .perm-unapplied-list makes (`overflow-wrap: anywhere`) for
+       the same kind of content. */
+    .row-error-row {
+      margin: 0 10px 4px 24px;
+      font-family: var(--font-mono);
+    }
+    .row-error-row.child { margin-left: 44px; }
+    .row-error {
+      display: inline-block;
+      max-width: 100%;
+      font-size: 10px;
+      font-weight: 600;
+      padding: 3px 6px;
+      border-radius: 4px;
+      background: var(--error-dim);
+      color: var(--error);
+      overflow-wrap: anywhere;
+      cursor: default;
+    }
+    /* The retry ladder ("attempt 3 of 10, next in 0.6s") is secondary to the
+       message and reads as a separate clause. Same hue at reduced weight
+       rather than --muted, so it stays legibly part of the error. */
+    .row-error-retry {
+      font-weight: 400;
+      opacity: 0.85;
+    }
+
     .row-cache-bloat-row {
       margin: 0 10px 4px 24px;
       font-family: var(--font-mono);
@@ -933,6 +1005,43 @@
       background: rgba(255, 59, 48, 0.1);
       border-color: rgba(255, 59, 48, 0.4);
       color: var(--pressure-high);
+    }
+
+    /* Daemon-error banner (#1801) — "Irrlicht's own monitoring is degraded".
+       The THIRD banner and the one that takes the error palette, because
+       unlike the two below it this says the dashboard cannot vouch for what
+       it is showing: a dead hook channel silently demotes every session of
+       that adapter to slower transcript-only classification, so the list can
+       look entirely healthy while being wrong.
+       Visibility is [hidden]-driven like the unapplied-grants banner, not
+       class-driven like the connection banner, for the same reason #1385
+       gives: it clears by being fixed, and there is no dismiss. */
+    #daemon-error-banner {
+      font-family: var(--font-mono);
+      font-size: 11px;
+      padding: 6px 10px;
+      margin-bottom: 8px;
+      border-radius: 4px;
+      background: var(--error-dim);
+      border: 1px solid var(--error);
+      color: var(--error);
+    }
+    #daemon-error-banner[hidden] {
+      display: none;
+    }
+    .daemon-error-list {
+      margin: 4px 0 0;
+      padding-left: 16px;
+      /* --text, not --error: the detail is the longest text on the strip and
+         the same WCAG argument .perm-unapplied-list records applies — the
+         error hue over its own 12% wash sits at 4.60:1 (dark) / 4.69:1
+         (light), which clears AA but leaves no headroom for a paragraph. The
+         scope stays in the error hue so the strip still reads as one thing. */
+      color: var(--text);
+      overflow-wrap: anywhere;
+    }
+    .daemon-error-scope {
+      color: var(--error);
     }
 
     /* Unapplied-grants banner (#1385) — "N permissions are granted but not
@@ -1600,6 +1709,13 @@
     .hsm-seg-working { background: var(--working); }
     .hsm-seg-waiting { background: var(--waiting); }
     .hsm-seg-ready { background: var(--ready); }
+    /* #1801 — the fourth stack segment. These classes are generated from
+       historyTab.js's STATE_STACK_ORDER, so a state without a rule here paints
+       transparent: the segment still takes its share of the bar's flex space
+       and simply disappears, which reads as a gap rather than as a missing
+       colour. That silent-hole property is why the list is derived on the JS
+       side and why this rule is not optional. */
+    .hsm-seg-error { background: var(--error); }
     .hsm-seg-cap { border-radius: 3px 3px 0 0; }
 
     .hsm-tooltip {

--- a/platforms/web/irrlicht.js
+++ b/platforms/web/irrlicht.js
@@ -577,10 +577,23 @@ import { reconcile, paintRowNum } from './domReconcile.js';
       WebSearch: 'Search', WebFetch: 'Fetch', TodoWrite: 'Todo',
     };
 
+    // stateColor maps a session state to the CSS variable that paints it.
+    //
+    // Every arm returns a var(), never a literal hex, so the light-theme
+    // overrides apply — which is what makes this the RIGHT place to add a
+    // state and svgIcons the wrong-by-default one (see formatters.js).
+    //
+    // The fallback is var(--muted), and #1801 leaves it alone deliberately.
+    // The #1797 argument that replaced stateIcon's `|| ready` fallback does
+    // not transfer: green claims "this finished cleanly", which is an actively
+    // wrong claim, while grey claims nothing. --muted does differ per theme and
+    // from the macOS side, but it is only ever reached by a state no build
+    // knows, where "some neutral colour" is the whole requirement.
     function stateColor(s) {
       if (s === 'working') return 'var(--working)';
       if (s === 'waiting') return 'var(--waiting)';
       if (s === 'ready') return 'var(--ready)';
+      if (s === 'error') return 'var(--error)';
       return 'var(--muted)';
     }
 
@@ -1096,6 +1109,12 @@ import { reconcile, paintRowNum } from './domReconcile.js';
     // per-agent loop body (issue #901 cognitive-complexity cleanup).
     function emitAgentRowItems(items, a, agentNum, depth) {
       items.push({type: 'agent', key: 'a:' + a.session_id, agent: a, num: agentNum, isChild: false, depth: depth});
+      // #1801: FIRST of the sub-rows, above the context-pressure alert. When a
+      // session has both, "the provider refused the call" is the thing that
+      // stopped it; "switch to a fresh session soon" is advice about a
+      // different problem, and burying the failure under it inverts the two.
+      const sessionErr = sessionErrorItem(a);
+      if (sessionErr) items.push(sessionErr);
       const alert = pressureAlertItem(a);
       if (alert) items.push(alert);
       const cacheBloat = cacheBloatItem(a);
@@ -1172,6 +1191,7 @@ import { reconcile, paintRowNum } from './domReconcile.js';
           item => item.key,
           item => {
             if (item.type === 'group') return createGroupHeader(item.group, item.groupKey, item.depth);
+            if (item.type === 'error') return createSessionErrorRow(item.agent, item.isChild);
             if (item.type === 'alert') return createAlertRow(item.pressure);
             if (item.type === 'cachebloat') return createCacheBloatRow(item.agent);
             if (item.type === 'tasks') return createTaskListRow(item.agent, item.isChild);
@@ -1183,6 +1203,7 @@ import { reconcile, paintRowNum } from './domReconcile.js';
           },
           (el, item) => {
             if (item.type === 'group') { updateGroupHeader(el, item.group, item.groupKey, item.depth); return; }
+            if (item.type === 'error') { updateSessionErrorRow(el, item.agent); return; }
             if (item.type === 'alert') { updateAlertRow(el, item.pressure); return; }
             if (item.type === 'cachebloat') { updateCacheBloatRow(el, item.agent); return; }
             if (item.type === 'tasks') { updateTaskListRow(el, item.agent); return; }
@@ -1265,6 +1286,103 @@ import { reconcile, paintRowNum } from './domReconcile.js';
       // rendered verbatim so both UIs never re-derive (and silently diverge
       // on) the wording.
       el.querySelector('.row-cache-bloat').title = metrics.cache_bloat_explanation || '';
+    }
+
+    // sessionErrorText renders one session_error payload as the two strings the
+    // red line shows: the agent's own message, and the retry ladder beside it.
+    //
+    // Returns null when there is nothing to say, so the row's *Item() predicate
+    // and the reconciler can drop the row rather than render an empty pill.
+    //
+    // EVERY NUMBER IS CHECKED FOR null, NOT FOR FALSINESS. The daemon's
+    // SessionError makes every numeric field a pointer precisely because the
+    // recorded payloads disagree about which ones exist — claudecode's retrying
+    // api_error carries all four, its terminal variant carries none, copilot
+    // carries statusCode for one error type and not another. A `||` fallback
+    // here would turn "the agent said nothing" into "attempt 0 of 0", which is
+    // the invented verdict the pointer types exist to prevent. `attempt == null`
+    // catches both null and undefined and leaves a real 0 alone.
+    function sessionErrorText(sessionError) {
+      const e = sessionError;
+      if (!e) return null;
+      const message = (e.message || '').trim();
+      // A class with no message still beats silence: "rate_limit" tells the
+      // user what happened, and an errored row with a blank line beneath it
+      // would read as a rendering bug.
+      const head = message || e.class || 'the agent reported a failure';
+
+      const parts = [];
+      if (e.attempt != null) {
+        parts.push(e.max_attempts != null
+          ? 'attempt ' + e.attempt + ' of ' + e.max_attempts
+          : 'attempt ' + e.attempt);
+      }
+      if (e.retry_in_ms != null) {
+        // retry_in_ms is fractional milliseconds (the daemon's own unit-named
+        // wire form). Seconds to one decimal is the readable form of a value
+        // the recordings show landing around 600ms.
+        parts.push('next in ' + (e.retry_in_ms / 1000).toFixed(1) + 's');
+      }
+      if (!parts.length && e.phase === 'retrying') {
+        // ErrorPhaseRetrying with no counters at all is a real shape, not a
+        // gap — "another attempt is coming, timing unstated". Say that rather
+        // than dropping the only fact the user can act on.
+        parts.push('retrying');
+      }
+      return { head, retry: parts.join(', ') };
+    }
+
+    // sessionErrorItem emits the red line beneath an errored session (#1801).
+    // Null when the session carries no error, which is how the reconciler
+    // removes the row again once the next successful turn clears it.
+    //
+    // Keyed off the ERROR, not off the state: a session can carry a standing
+    // error while already back in `working` on its next turn, and the daemon
+    // clears the payload rather than the state. Rendering off `state ===
+    // 'error'` would blank the line a moment before the error is actually gone.
+    function sessionErrorItem(a) {
+      const text = sessionErrorText((a.metrics || {}).session_error);
+      if (!text) return null;
+      return { type: 'error', key: 'er:' + a.session_id, agent: a, isChild: !!a.parent_session_id };
+    }
+
+    // Session-error row (#1801) — its own row beneath the parent, like the
+    // cache-bloat badge and for the reason createSessionRow's anatomy comment
+    // gives: a provider error is a sentence, not a fixed-width slot.
+    function createSessionErrorRow(agent, isChild) {
+      const el = document.createElement('div');
+      el.className = 'row-error-row' + (isChild ? ' child' : '');
+      el.dataset.sessionId = agent.session_id;
+      updateSessionErrorRow(el, agent);
+      return el;
+    }
+
+    function updateSessionErrorRow(el, agent) {
+      const text = sessionErrorText((agent.metrics || {}).session_error);
+      if (!text) return;
+      const key = text.head + ' ' + text.retry;
+      // Skip-if-unchanged, the same guard updateCacheBloatRow uses: this runs
+      // on every render, and rebuilding the node would fight text selection
+      // and re-announce inside the aria-live session list.
+      if (el.dataset.errorKey === key) return;
+      el.dataset.errorKey = key;
+
+      // Built with createElement/textContent rather than innerHTML: `head` is
+      // an agent's VERBATIM error text, arriving from a transcript this
+      // process does not control. esc() would also do, but the DOM API cannot
+      // be forgotten the way an esc() call can — the same choice
+      // renderUnappliedGrantsBanner makes for the daemon's reason strings.
+      el.textContent = '';
+      const pill = document.createElement('span');
+      pill.className = 'row-error';
+      pill.appendChild(document.createTextNode(text.head));
+      if (text.retry) {
+        const retry = document.createElement('span');
+        retry.className = 'row-error-retry';
+        retry.textContent = ' · ' + text.retry;
+        pill.appendChild(retry);
+      }
+      el.appendChild(pill);
     }
 
     // Shared factory for trailing-row variants rendered beneath the parent
@@ -1449,6 +1567,25 @@ import { reconcile, paintRowNum } from './domReconcile.js';
     // We mirror that here; the daemon's bucket priorities drive the per-row
     // paint via paintRowHistory(). State→color is local so we don't depend on
     // CSS vars at canvas-paint time.
+    //
+    // NO `error` ENTRY, AND THAT IS DELIBERATE (#1801) — this is the one place
+    // the fourth state deliberately stops, so it is written down here rather
+    // than left to be discovered as a bug.
+    //
+    // The strip's wire format is 2 bits per bucket and all four codes are
+    // taken: HISTORY_PRIORITY_TO_STATE above maps 0=ready, 1=working,
+    // 2=waiting, 3=no-data. There is no fifth value to spend, so `error` cannot
+    // be carried without widening the daemon's packing — deferred to #1805/
+    // #1807, which own the strip.
+    //
+    // What that costs today, stated plainly: the daemon's history_tracker maps
+    // `error` to the ready priority (statePriority's default arm, named as this
+    // exact symptom in #1798's own commit), so an errored bucket paints GREEN
+    // on the sparkline while the row's state icon beside it is red. That is a
+    // real inconsistency in the shipped UI, not a hypothetical, and it is
+    // #1805/#1807's to fix rather than something this map can paper over —
+    // adding a key here would do nothing, because no bucket can ever decode to
+    // 'error' in the first place.
     const HISTORY_BAR_COLORS = {
       working: '#8B5CF6',
       waiting: '#FF9500',
@@ -1529,11 +1666,93 @@ import { reconcile, paintRowNum } from './domReconcile.js';
       }
     }
 
+    // daemonErrorSummary reduces the /api/v1/sessions `daemon_errors` list to
+    // what the banner shows, or null when there is nothing to show (#1801).
+    //
+    // Pure, and separate from the renderer, for the reason
+    // unappliedGrantSummary is: the headline's pluralization and the
+    // "is anything wrong at all" decision are the parts worth testing without
+    // a DOM.
+    //
+    // A NON-ARRAY OR ABSENT FIELD IS "NOTHING WRONG", NOT AN ERROR. The daemon
+    // omits the key entirely when healthy (omitempty), and a relay-connected
+    // dashboard never receives it at all — cmd/irrlichd/handlers.go records
+    // that gap. Both must read as a quiet banner rather than a crash.
+    function daemonErrorSummary(resp) {
+      const items = (resp && !Array.isArray(resp) && Array.isArray(resp.daemon_errors)) ? resp.daemon_errors : [];
+      if (!items.length) return null;
+      const n = items.length;
+      return {
+        count: n,
+        text: n === 1
+          ? "Irrlicht's own monitoring is degraded — 1 fault"
+          : "Irrlicht's own monitoring is degraded — " + n + ' faults',
+        items,
+      };
+    }
+
+    // renderDaemonErrorBanner reconciles the daemon-wide fault banner with the
+    // latest /api/v1/sessions payload (#1801). Modelled on
+    // renderUnappliedGrantsBanner, including the three things it deliberately
+    // does not do: it never opens a wizard, never nags, and offers no dismiss —
+    // a hide button would let a live fault be silenced while still broken,
+    // which is the defect rather than the cure. It clears by being fixed.
+    //
+    // role="alert" (see index.html for why that differs from #1385's
+    // role="status") is aria-atomic by default, so a rebuild re-announces the
+    // whole banner. This runs on the initial load and on every 30s rehydrate
+    // poll, so an unchanged banner would be read out repeatedly — the exact
+    // nagging the alert role makes worse rather than better. The key lives on
+    // the ELEMENT, not in a module variable, so a replaced DOM starts clean.
+    function renderDaemonErrorBanner(resp) {
+      const el = document.getElementById('daemon-error-banner');
+      if (!el) return;
+      const summary = daemonErrorSummary(resp);
+      const key = summary
+        ? JSON.stringify([summary.text, summary.items.map(e => [e.kind, e.scope, e.message, e.detail])])
+        : '';
+      if (el.dataset.bannerKey === key) return;
+      el.dataset.bannerKey = key;
+      el.textContent = '';
+      if (!summary) {
+        el.hidden = true;
+        return;
+      }
+
+      const head = document.createElement('strong');
+      head.textContent = summary.text;
+      el.appendChild(head);
+
+      const list = document.createElement('ul');
+      list.className = 'daemon-error-list';
+      for (const e of summary.items) {
+        const li = document.createElement('li');
+        const scope = document.createElement('span');
+        scope.className = 'daemon-error-scope';
+        scope.textContent = (e.scope || '') + ': ';
+        li.appendChild(scope);
+        // The message verbatim — it is composed daemon-side precisely so the
+        // two frontends cannot word the same fault differently. createElement
+        // + textContent throughout rather than innerHTML: these strings carry
+        // config paths and an agent config's own error text.
+        li.appendChild(document.createTextNode(e.message || ''));
+        if (e.detail) {
+          const detail = document.createElement('div');
+          detail.textContent = e.detail;
+          li.appendChild(detail);
+        }
+        list.appendChild(li);
+      }
+      el.appendChild(list);
+      el.hidden = false;
+    }
+
     function ingestInitialSessions(resp) {
       if (!resp) return;
       dashboardGroups = Array.isArray(resp) ? resp : (resp.groups || []);
       normalizeGroupAgents(dashboardGroups);
       dashboardProviderCosts = (resp && !Array.isArray(resp) && resp.provider_costs) || {};
+      renderDaemonErrorBanner(resp);
       rebuildIndex();
     }
     // structureSignature captures the daemon-computed shape of the group tree:
@@ -1573,6 +1792,12 @@ import { reconcile, paintRowNum } from './domReconcile.js';
     function rehydratePoll() {
       return fetch('/api/v1/sessions').then(r => r.json()).catch(() => null).then(resp => {
         if (!resp) return;
+        // #1801: before either branch below, and unconditionally. The daemon
+        // fault list is not part of structureSignature (which hashes group
+        // nesting and per-session identity), so a fault appearing or clearing
+        // takes the "structure unchanged" path — putting this inside either
+        // branch would mean a banner that never goes away once shown.
+        renderDaemonErrorBanner(resp);
         const fresh = Array.isArray(resp) ? resp : (resp.groups || []);
         // Structure / role metadata changed → adopt the daemon's tree.
         if (structureSignature(fresh) !== structureSignature(dashboardGroups)) {
@@ -2151,6 +2376,12 @@ import { reconcile, paintRowNum } from './domReconcile.js';
 
 export {
   resolvedTheme, rowLabel, maybeNotifyOnUpdate,
+  // #1801: stateColor and the session-error helpers are exported so they can
+  // be tested. stateColor had no test at all before — the issue's claim that
+  // neither it nor stateIcon was covered is half right; stateIcon gained one
+  // in #1797, this one had nothing, and it is the map a new state is most
+  // likely to be forgotten in.
+  stateColor, sessionErrorText, daemonErrorSummary, renderDaemonErrorBanner,
   formatCost, costCellDisplay, pressureClass, historyPriorityForState,
   taskEtaPresentation,
   lastNotifiedPressure,

--- a/platforms/web/irrlicht.js
+++ b/platforms/web/irrlicht.js
@@ -1340,6 +1340,12 @@ import { reconcile, paintRowNum } from './domReconcile.js';
       // would read as a rendering bug.
       const head = message || e.class || 'the agent reported a failure';
 
+      return { head, retry: retryLadderText(e) };
+    }
+
+    // retryLadderText renders the "attempt 3 of 10, next in 0.6s" clause, or ''
+    // when the agent reported nothing to say.
+    function retryLadderText(e) {
       const parts = [];
       if (e.attempt != null) {
         parts.push(e.max_attempts != null
@@ -1356,9 +1362,9 @@ import { reconcile, paintRowNum } from './domReconcile.js';
         // ErrorPhaseRetrying with no counters at all is a real shape, not a
         // gap — "another attempt is coming, timing unstated". Say that rather
         // than dropping the only fact the user can act on.
-        parts.push('retrying');
+        return 'retrying';
       }
-      return { head, retry: parts.join(', ') };
+      return parts.join(', ');
     }
 
     // sessionErrorItem emits the red line beneath an errored session (#1801).
@@ -1372,7 +1378,14 @@ import { reconcile, paintRowNum } from './domReconcile.js';
     function sessionErrorItem(a) {
       const text = sessionErrorText((a.metrics || {}).session_error);
       if (!text) return null;
-      return { type: 'error', key: 'er:' + a.session_id, agent: a, isChild: !!a.parent_session_id };
+      // isChild: false to match every other sub-row item (alert, cachebloat,
+      // summary, tasks). emitGroup iterates g.agents and never recurses into
+      // a.children, so no sub-row is ever emitted for a child session and
+      // `!!a.parent_session_id` could only ever evaluate false here — a branch
+      // that reads as a supported case but is not one. The
+      // `.row-error-row.child` rule in irrlicht.css is kept for parity with
+      // `.row-cache-bloat-row.child`, which is unreachable for the same reason.
+      return { type: 'error', key: 'er:' + a.session_id, agent: a, isChild: false };
     }
 
     // Session-error row (#1801) — its own row beneath the parent, like the
@@ -2411,6 +2424,12 @@ export {
   // in #1797, this one had nothing, and it is the map a new state is most
   // likely to be forgotten in.
   stateColor, sessionErrorText, daemonErrorSummary, renderDaemonErrorBanner, hasWorkInFlight,
+  // rehydratePoll is exported for its BANNER PLACEMENT, not its polling: the
+  // call to renderDaemonErrorBanner has to sit before the structure branch, and
+  // the only way to assert that is to drive the poll itself. Review found the
+  // placement documented at length and covered by nothing — moving it inside
+  // the branch left 247/247 green.
+  rehydratePoll,
   formatCost, costCellDisplay, pressureClass, historyPriorityForState,
   taskEtaPresentation,
   lastNotifiedPressure,

--- a/platforms/web/irrlicht.js
+++ b/platforms/web/irrlicht.js
@@ -747,7 +747,10 @@ import { reconcile, paintRowNum } from './domReconcile.js';
       // exactly as 'ready' was.
       const state = agent.state || 'unknown';
       const metrics = agent.metrics || {};
-      const isActive = state === 'working' || state === 'waiting';
+      // #1801: one shared predicate rather than a second inline copy. This
+      // drives whether the elapsed clock keeps ticking, and a session that is
+      // mid-retry is still running its turn.
+      const isActive = hasWorkInFlight(agent);
 
       // Each column updates independently; the renderRow* helpers below own
       // one concern each and touch only their own .row-* element(s) + dataset
@@ -1060,11 +1063,37 @@ import { reconcile, paintRowNum } from './domReconcile.js';
       }
     }
 
+    // hasWorkInFlight is the web mirror of session.SessionState.HasWorkInFlight
+    // in the Go domain (#1801), and exists for the same reason: "is this
+    // session still doing something" was re-derived inline in two places here
+    // as `state === 'working' || state === 'waiting'`, which was a complete
+    // partition over three states and silently became an incomplete one over
+    // four.
+    //
+    // A session in `error` whose phase is `retrying` is still working — the
+    // agent has another attempt scheduled — so its elapsed clock must keep
+    // ticking rather than freeze at the moment the provider first refused.
+    // TERMINAL and unknown-phase errors are not: no further attempt is coming,
+    // and inferring one from a transcript that said nothing is the invented
+    // verdict the daemon's pointer fields exist to prevent.
+    //
+    // Deliberately NOT the same question as "does this consume a concurrency
+    // slot", where an errored session never counts (events.md) — that half has
+    // no web caller; see the Go predicate's doc for why the two cannot merge.
+    // formatters.js's activeSubagentCount is also left on working-or-waiting:
+    // it is the display count whose Go twin, subagentSummary, gained a separate
+    // Error bucket rather than folding errors into the active one.
+    function hasWorkInFlight(agent) {
+      const state = agent?.state;
+      if (state === 'working' || state === 'waiting') return true;
+      return state === 'error' && (agent?.metrics?.session_error?.phase === 'retrying');
+    }
+
     // pressureAlertItem builds the pressure-alert sub-row for an active
     // agent in an alert-worthy pressure state, or null otherwise. Extracted
     // from emitAgentRowItems (issue #901 cognitive-complexity cleanup).
     function pressureAlertItem(a) {
-      const isActive = a.state === 'working' || a.state === 'waiting';
+      const isActive = hasWorkInFlight(a);
       const pressure = a.metrics ? a.metrics.pressure_level : '';
       if (!isActive || !isAlertPressure(pressure)) return null;
       return {type: 'alert', key: 'al:' + a.session_id, pressure: pressure};
@@ -2381,7 +2410,7 @@ export {
   // neither it nor stateIcon was covered is half right; stateIcon gained one
   // in #1797, this one had nothing, and it is the map a new state is most
   // likely to be forgotten in.
-  stateColor, sessionErrorText, daemonErrorSummary, renderDaemonErrorBanner,
+  stateColor, sessionErrorText, daemonErrorSummary, renderDaemonErrorBanner, hasWorkInFlight,
   formatCost, costCellDisplay, pressureClass, historyPriorityForState,
   taskEtaPresentation,
   lastNotifiedPressure,

--- a/platforms/web/irrlicht.js
+++ b/platforms/web/irrlicht.js
@@ -1765,18 +1765,26 @@ import { reconcile, paintRowNum } from './domReconcile.js';
       head.textContent = summary.text;
       el.appendChild(head);
 
+      el.appendChild(daemonErrorList(summary.items));
+      el.hidden = false;
+    }
+
+    // daemonErrorList builds the <ul> of faults.
+    //
+    // createElement + textContent throughout, never innerHTML: these strings
+    // carry config paths and an agent config's own error text, from files this
+    // process does not control. The message is inserted verbatim because it is
+    // composed daemon-side precisely so the two frontends cannot word the same
+    // fault differently.
+    function daemonErrorList(items) {
       const list = document.createElement('ul');
       list.className = 'daemon-error-list';
-      for (const e of summary.items) {
+      for (const e of items) {
         const li = document.createElement('li');
         const scope = document.createElement('span');
         scope.className = 'daemon-error-scope';
         scope.textContent = (e.scope || '') + ': ';
         li.appendChild(scope);
-        // The message verbatim — it is composed daemon-side precisely so the
-        // two frontends cannot word the same fault differently. createElement
-        // + textContent throughout rather than innerHTML: these strings carry
-        // config paths and an agent config's own error text.
         li.appendChild(document.createTextNode(e.message || ''));
         if (e.detail) {
           const detail = document.createElement('div');
@@ -1785,8 +1793,7 @@ import { reconcile, paintRowNum } from './domReconcile.js';
         }
         list.appendChild(li);
       }
-      el.appendChild(list);
-      el.hidden = false;
+      return list;
     }
 
     function ingestInitialSessions(resp) {

--- a/platforms/web/irrlicht.test.js
+++ b/platforms/web/irrlicht.test.js
@@ -1307,6 +1307,10 @@ describe('activity matrix (chart=state, #981)', () => {
     expect(CHART_LABELS.state).toBe('Activity')
   })
 
+  // #1801 widened by_state to every canonical state, `error` included. The
+  // fixture carries one so the matrix is exercised on the real payload shape;
+  // before this it pinned a three-key object and was the client-side half of
+  // the handoff #1798 left in concurrency_tracker_test.go.
   const sampleData = {
     projects: ['projA', 'projB'],
     bucket_starts: [1000, 2000, 3000],
@@ -1314,23 +1318,35 @@ describe('activity matrix (chart=state, #981)', () => {
       working: { projA: [1, 2, 0] },
       waiting: { projA: [0, 1, 1], projB: [3, 0, 0] },
       ready: { projA: [0, 0, 1] },
+      error: { projA: [0, 0, 2] },
     },
   }
 
   test('stateCellCounts defaults missing states/projects to 0', () => {
-    expect(stateCellCounts(sampleData, 'projA', 1)).toEqual({ working: 2, waiting: 1, ready: 0 })
-    expect(stateCellCounts(sampleData, 'projB', 0)).toEqual({ working: 0, waiting: 3, ready: 0 })
-    expect(stateCellCounts(sampleData, 'unknownProject', 0)).toEqual({ working: 0, waiting: 0, ready: 0 })
+    expect(stateCellCounts(sampleData, 'projA', 1)).toEqual({ working: 2, waiting: 1, ready: 0, error: 0 })
+    expect(stateCellCounts(sampleData, 'projB', 0)).toEqual({ working: 0, waiting: 3, ready: 0, error: 0 })
+    expect(stateCellCounts(sampleData, 'unknownProject', 0)).toEqual({ working: 0, waiting: 0, ready: 0, error: 0 })
   })
 
-  test('stateCellTotal sums working+waiting+ready for one cell', () => {
+  test('stateCellCounts carries the error bucket (#1801)', () => {
+    // A cell whose only activity is errors must still report it — this is the
+    // assertion that would have caught the daemon emitting a fourth bucket
+    // the client silently dropped.
+    expect(stateCellCounts(sampleData, 'projA', 2).error).toBe(2)
+  })
+
+  test('stateCellTotal sums every state for one cell', () => {
     expect(stateCellTotal(sampleData, 'projA', 1)).toBe(3)
-    expect(stateCellTotal(sampleData, 'projA', 2)).toBe(2)
+    // projA bucket 2: 0 working, 1 waiting, 1 ready, 2 error = 4. Pre-#1801
+    // the hand-written working+waiting+ready sum returned 2, so an errored
+    // cell was drawn at half the height of its own contents.
+    expect(stateCellTotal(sampleData, 'projA', 2)).toBe(4)
   })
 
   test('stateMatrixMaxTotal finds the busiest cell across the whole grid', () => {
-    // projA totals: 1, 3, 2 — projB totals: 3, 0, 0. Busiest is 3.
-    expect(stateMatrixMaxTotal(sampleData)).toBe(3)
+    // projA totals: 1, 3, 4 — projB totals: 3, 0, 0. Busiest is projA's
+    // bucket 2, at 4, and it is the bucket whose activity is mostly errors.
+    expect(stateMatrixMaxTotal(sampleData)).toBe(4)
   })
 
   test('stateMatrixMaxTotal is 0 for an empty grid', () => {

--- a/platforms/web/sessionError.test.js
+++ b/platforms/web/sessionError.test.js
@@ -1,0 +1,344 @@
+import { describe, test, expect, beforeEach, afterEach } from 'vitest'
+
+import { stateIcon } from './formatters.js'
+import { readCss, readMacosTokens } from './snapshots/serialize.js'
+import {
+  contrastRatio, composite, readToken,
+  DARK_BLOCK, LIGHT_MEDIA_BLOCK, LIGHT_THEME_BLOCK,
+} from './snapshots/contrast.mjs'
+import * as irr from './irrlicht.js'
+
+// --- #1801: the `error` session state on the web dashboard -----------------
+//
+// #1798 added the fourth lifecycle state to the domain; nothing in
+// platforms/web/ knew about it. These pin the three independent places a state
+// has to be declared (the CSS tokens, stateColor, the icon map), the red line
+// beneath an errored session, and the daemon-wide banner.
+//
+// `irr` is imported as a namespace deliberately, the reason
+// permissionsBanner.test.js records: a missing export then fails one test with
+// a readable TypeError instead of breaking the module link and taking every
+// suite in the file down with it.
+//
+// Its own file rather than irrlicht.test.js, which is ~62 KB and already
+// CodeScene-flagged for size.
+
+const errorPayload = (over = {}) => ({
+  phase: 'retrying',
+  class: 'rate_limit',
+  message: 'API Error: 429 rate limited',
+  http_status: 429,
+  attempt: 3,
+  max_attempts: 10,
+  retry_in_ms: 616.4520045919932,
+  ...over,
+})
+
+const sessionWithError = (sessionError, over = {}) => ({
+  session_id: 'sess-err',
+  state: 'error',
+  metrics: sessionError ? { session_error: sessionError } : {},
+  ...over,
+})
+
+describe('stateColor (#1801)', () => {
+  // stateColor had NO test of any kind before this issue — stateIcon gained
+  // one in #1797, this did not, and it is the map most likely to be forgotten
+  // when a state is added, because nothing fails when it is.
+
+  // LOCK — passes by construction; the three existing states must not move.
+  test('the three original states keep their own tokens', () => {
+    expect(irr.stateColor('working')).toBe('var(--working)')
+    expect(irr.stateColor('waiting')).toBe('var(--waiting)')
+    expect(irr.stateColor('ready')).toBe('var(--ready)')
+  })
+
+  test('error maps to its own token, not the fallback', () => {
+    expect(irr.stateColor('error')).toBe('var(--error)')
+    expect(irr.stateColor('error')).not.toBe(irr.stateColor('zzz-nope'))
+  })
+
+  test('every arm returns a CSS variable, never a literal colour', () => {
+    // This is what makes the light-theme override reachable at all. An arm
+    // returning a hex would look correct in the default dark theme and be
+    // wrong — and unfixable from CSS — in light.
+    for (const s of ['working', 'waiting', 'ready', 'error', '', undefined, 'zzz-nope']) {
+      expect(irr.stateColor(s)).toMatch(/^var\(--[a-z-]+\)$/)
+    }
+  })
+
+  test('an unrecognized state still falls back to the neutral token', () => {
+    expect(irr.stateColor('zzz-nope')).toBe('var(--muted)')
+    expect(irr.stateColor(undefined)).toBe('var(--muted)')
+  })
+})
+
+describe('the error state icon (#1801)', () => {
+  // Extends #1797's "known states keep their own icons" lock to four. Without
+  // this, adding svgIcons.error silently changes what THAT test means: its
+  // sibling asserts an unrecognized state is not any known icon, and `error`
+  // quietly moved from the unknown bucket to a known one.
+  test('error has its own glyph, distinct from every other state', () => {
+    const icon = stateIcon('error')
+    for (const other of ['working', 'waiting', 'ready', 'zzz-unknown']) {
+      expect(icon).not.toBe(stateIcon(other))
+    }
+    expect(icon).toMatch(/^<svg\b/)
+    expect(icon).toMatch(/<\/svg>$/)
+  })
+
+  test('the error icon is token-driven, not a hardcoded hex', () => {
+    // The four older glyphs inline their DARK hex and follow no theme
+    // override — the wart #1797 documented and deliberately left alone. The
+    // error glyph must not copy it, because --error's light value is a
+    // genuinely different hex (see the WCAG test below), so an inlined hex
+    // would render light theme at 3.01:1.
+    const icon = stateIcon('error')
+    expect(icon).toMatch(/currentColor/)
+    expect(icon).not.toMatch(/#[0-9a-f]{6}/i)
+    expect(icon).toMatch(/class="state-error"/)
+  })
+
+  test('the error glyph is not animated as working', () => {
+    // `.row-state-icon svg circle.core` is the breathe animation. A pulsing
+    // red dot would read as "working", the one thing an errored session isn't.
+    expect(stateIcon('error')).not.toMatch(/class="core"/)
+  })
+
+  test('the stylesheet points the error icon at the --error token', () => {
+    const css = readCss()
+    const rule = css.match(/svg\.state-error[^{]*\{[^}]*\}/)
+    expect(rule, 'no svg.state-error rule found in irrlicht.css').not.toBeNull()
+    expect(rule[0]).toMatch(/var\(--error\)/)
+  })
+})
+
+describe('--error is declared in every theme block (#1801)', () => {
+  // Colour lives in three CSS blocks that do NOT share a source, and a token
+  // added to only one works in only one theme. Each is looked up inside ITS
+  // OWN block: a bare /--error:/ over the whole file matches the dark
+  // declaration first and would report the light theme as present when it is
+  // not — the failure mode #1797's --unknown test notes but does not have.
+  const css = readCss()
+
+  test('all three blocks declare it', () => {
+    for (const [name, block] of [
+      ['dark :root', DARK_BLOCK],
+      ['prefers-color-scheme: light', LIGHT_MEDIA_BLOCK],
+      ['[data-theme="light"]', LIGHT_THEME_BLOCK],
+    ]) {
+      expect(() => readToken(css, block, 'error'), `--error missing from ${name}`).not.toThrow()
+      expect(() => readToken(css, block, 'error-dim'), `--error-dim missing from ${name}`).not.toThrow()
+    }
+  })
+
+  test('the two light blocks agree with each other', () => {
+    // They are literal duplicates by construction; a value updated in one and
+    // not the other is a theme that changes depending on how the user got there.
+    expect(readToken(css, LIGHT_THEME_BLOCK, 'error')).toBe(readToken(css, LIGHT_MEDIA_BLOCK, 'error'))
+    expect(readToken(css, LIGHT_THEME_BLOCK, 'error-dim')).toBe(readToken(css, LIGHT_MEDIA_BLOCK, 'error-dim'))
+  })
+
+  test('the light value is NOT a copy of the dark one', () => {
+    // The whole reason --error needs a light override, unlike --cancelled and
+    // --unknown, which are mid-greys that read on both surfaces.
+    expect(readToken(css, LIGHT_MEDIA_BLOCK, 'error')).not.toBe(readToken(css, DARK_BLOCK, 'error'))
+  })
+
+  test('--error clears WCAG AA against its own wash in BOTH themes', () => {
+    // The claim the CSS comment makes, re-run rather than recorded. Reproduce
+    // the full table with: node platforms/web/snapshots/contrast.mjs
+    for (const [name, block] of [['dark', DARK_BLOCK], ['light', LIGHT_MEDIA_BLOCK]]) {
+      const hex = readToken(css, block, 'error')
+      const surface = readToken(css, block, 'surface')
+      const ratio = contrastRatio(hex, composite(hex, 0.12, surface))
+      expect(ratio, `${name} --error ${hex} on its 12% wash over ${surface} is ${ratio.toFixed(2)}:1`).toBeGreaterThanOrEqual(4.5)
+    }
+  })
+
+  test('--error-dim is the same hue as --error', () => {
+    // A wash built from a different colour than the text drawn on it is how
+    // a measured contrast ratio silently stops describing what ships.
+    for (const block of [DARK_BLOCK, LIGHT_MEDIA_BLOCK]) {
+      const hex = readToken(css, block, 'error').replace('#', '')
+      const rgb = [0, 2, 4].map(i => parseInt(hex.slice(i, i + 2), 16))
+      const dim = readToken(css, block, 'error-dim')
+      const nums = dim.match(/rgba\((\d+),\s*(\d+),\s*(\d+),/)
+      expect(nums, `--error-dim ${dim} is not an rgba() triple`).not.toBeNull()
+      expect([1, 2, 3].map(i => Number(nums[i]))).toEqual(rgb)
+    }
+  })
+
+  test('--error is paired by value with the macOS red', () => {
+    // Reads Tokens.swift rather than comparing against a hand-typed literal:
+    // a third copy of the constant cannot fail when the Swift side drifts,
+    // which is the only scenario this test exists for (#1797's reasoning).
+    //
+    // #1802 owns adding IrrHex.error. Until it lands the pairing is asserted
+    // against the red macOS ALREADY declares for its failure surfaces, so the
+    // two frontends cannot ship two different reds in the gap; once it lands,
+    // this asserts against IrrHex.error itself and goes red if #1802 picked a
+    // different hue. Both branches assert loudly that they found something to
+    // compare, so "could not look" can never pass as "matches".
+    const tokens = readMacosTokens()
+    const explicit = tokens.match(/static let error\s*=\s*"(#[0-9A-Fa-f]{6})"/)
+    const existingRed = tokens.match(/static let wsDisconnected\s*=\s*"(#[0-9A-Fa-f]{6})"/)
+    expect(existingRed, 'no IrrHex.wsDisconnected in platforms/macos/Irrlicht/Theme/Tokens.swift').not.toBeNull()
+    const want = (explicit ? explicit[1] : existingRed[1]).toLowerCase()
+    // The DARK value is the paired one: Color(hex:) is not appearance-aware,
+    // so the Swift side carries one hex per token and adapts, where it does at
+    // all, through Color.adaptive — the seam waitingPillText already uses.
+    expect(readToken(readCss(), DARK_BLOCK, 'error').toLowerCase()).toBe(want)
+  })
+})
+
+describe('the red error line under a session (#1801)', () => {
+  test('no error payload renders no row', () => {
+    expect(irr.sessionErrorText(undefined)).toBeNull()
+    expect(irr.sessionErrorText(null)).toBeNull()
+  })
+
+  test('the agent\'s own message is what is shown', () => {
+    const t = irr.sessionErrorText(errorPayload())
+    expect(t.head).toBe('API Error: 429 rate limited')
+  })
+
+  test('a message-less error falls back to its class, never to nothing', () => {
+    // A blank red line reads as a rendering bug; "rate_limit" is at least the
+    // fact the daemon has.
+    expect(irr.sessionErrorText(errorPayload({ message: '' })).head).toBe('rate_limit')
+    expect(irr.sessionErrorText(errorPayload({ message: '   ' })).head).toBe('rate_limit')
+    expect(irr.sessionErrorText({ phase: 'terminal' }).head).toBeTruthy()
+  })
+
+  test('the retry ladder is rendered when the agent reported one', () => {
+    const t = irr.sessionErrorText(errorPayload())
+    expect(t.retry).toContain('attempt 3 of 10')
+    // retry_in_ms is fractional milliseconds — 616.45ms reads as 0.6s.
+    expect(t.retry).toContain('next in 0.6s')
+  })
+
+  test('ABSENT counters are never rendered as zero', () => {
+    // The defect the daemon's pointer fields exist to prevent: claudecode's
+    // TERMINAL error carries none of the four numbers, and a `||` fallback in
+    // this renderer would turn that into "attempt 0 of 0" — a give-up derived
+    // from a transcript that said nothing.
+    const t = irr.sessionErrorText({ phase: 'terminal', class: 'provider', message: 'API returned an empty response' })
+    expect(t.retry).toBe('')
+    expect(t.head).toBe('API returned an empty response')
+  })
+
+  test('a real zero is still shown', () => {
+    // The other half of the same rule: `attempt: 0` is a value, not an absence,
+    // and a falsiness check would swallow it exactly like a null.
+    expect(irr.sessionErrorText(errorPayload({ attempt: 0, max_attempts: 0, retry_in_ms: 0 })).retry)
+      .toBe('attempt 0 of 0, next in 0.0s')
+  })
+
+  test('a retrying error with no counters still says it is retrying', () => {
+    // ErrorPhaseRetrying with a nil RetryIn is a real recorded shape —
+    // "another attempt is coming, timing unstated" — not a gap to render blank.
+    const t = irr.sessionErrorText({ phase: 'retrying', message: 'overloaded' })
+    expect(t.retry).toBe('retrying')
+  })
+
+  test('a terminal error adds no retry clause', () => {
+    expect(irr.sessionErrorText({ phase: 'terminal', message: 'quota exhausted' }).retry).toBe('')
+  })
+})
+
+describe('the daemon-wide error banner (#1801)', () => {
+  const fault = (over = {}) => ({
+    kind: 'hook_channel_silent',
+    scope: 'claude-code',
+    message: 'Irrlicht is receiving no hook events from claude-code — its sessions have fallen back to slower transcript-only detection.',
+    detail: '9 completed turns with no receipt',
+    ...over,
+  })
+  const payload = (...faults) => ({ groups: [], daemon_errors: faults })
+  const banner = () => document.getElementById('daemon-error-banner')
+
+  beforeEach(() => {
+    document.body.innerHTML +=
+      '<div id="daemon-error-banner" role="alert" aria-live="polite" hidden></div>'
+  })
+  afterEach(() => { banner()?.remove() })
+
+  test('a healthy payload produces no summary', () => {
+    // Every shape a healthy or older daemon can send. The field is omitempty
+    // on the Go side and a relay-served payload omits it entirely.
+    expect(irr.daemonErrorSummary({ groups: [] })).toBeNull()
+    expect(irr.daemonErrorSummary({ groups: [], daemon_errors: [] })).toBeNull()
+    expect(irr.daemonErrorSummary(null)).toBeNull()
+    expect(irr.daemonErrorSummary([])).toBeNull()
+  })
+
+  test('the headline pluralizes', () => {
+    expect(irr.daemonErrorSummary(payload(fault())).text).toContain('1 fault')
+    expect(irr.daemonErrorSummary(payload(fault(), fault({ scope: 'codex' }))).text).toContain('2 faults')
+  })
+
+  test('the real element renders the scope, message and detail of each fault', () => {
+    irr.renderDaemonErrorBanner(payload(
+      fault(),
+      fault({ kind: 'hook_entries_missing', scope: 'codex/hooks', message: 'entries went missing', detail: '/home/u/.codex/config.toml' }),
+    ))
+    expect(banner().hidden).toBe(false)
+    const text = banner().textContent
+    expect(text).toContain('claude-code')
+    expect(text).toContain('no hook events')
+    expect(text).toContain('9 completed turns with no receipt')
+    expect(text).toContain('codex/hooks')
+    expect(text).toContain('/home/u/.codex/config.toml')
+    expect(banner().querySelectorAll('.daemon-error-list li')).toHaveLength(2)
+  })
+
+  test('it is passive: alert semantics, polite delivery, and no dismiss', () => {
+    irr.renderDaemonErrorBanner(payload(fault()))
+    expect(banner().getAttribute('role')).toBe('alert')
+    expect(banner().getAttribute('aria-live')).toBe('polite')
+    // No dismiss control of any kind. "Dismissible by fixing" is the contract:
+    // a hide button would let a live fault be silenced while still broken.
+    expect(banner().querySelectorAll('button')).toHaveLength(0)
+  })
+
+  test('fixing the fault removes it with no gesture', () => {
+    irr.renderDaemonErrorBanner(payload(fault()))
+    expect(banner().hidden).toBe(false)
+    irr.renderDaemonErrorBanner({ groups: [] })
+    expect(banner().hidden).toBe(true)
+    expect(banner().textContent).toBe('')
+  })
+
+  test('an unchanged banner is not rebuilt, so role=alert stops re-announcing', () => {
+    // aria-atomic re-reads the whole strip on every rebuild, and this runs on
+    // the initial load AND every 30s rehydrate poll. Node identity is the
+    // observable proxy for "was it rebuilt", the same one #1385's suite uses.
+    irr.renderDaemonErrorBanner(payload(fault()))
+    const first = banner().querySelector('li')
+    irr.renderDaemonErrorBanner(payload(fault()))
+    expect(banner().querySelector('li')).toBe(first)
+  })
+
+  test('a changed fault list IS rebuilt', () => {
+    // The other half of the guard above: skip-if-unchanged must not become
+    // skip-always, which would freeze the banner on its first fault forever.
+    irr.renderDaemonErrorBanner(payload(fault()))
+    const first = banner().querySelector('li')
+    irr.renderDaemonErrorBanner(payload(fault({ detail: '20 completed turns with no receipt' })))
+    expect(banner().querySelector('li')).not.toBe(first)
+    expect(banner().textContent).toContain('20 completed turns')
+  })
+
+  test('fault text is inserted as text, never as markup', () => {
+    // These strings carry an agent config's own error text and file paths,
+    // from a file this process does not control.
+    irr.renderDaemonErrorBanner(payload(fault({
+      message: '<img src=x onerror=alert(1)>',
+      detail: '<script>bad()</script>',
+    })))
+    expect(banner().querySelector('img')).toBeNull()
+    expect(banner().querySelector('script')).toBeNull()
+    expect(banner().textContent).toContain('<img src=x onerror=alert(1)>')
+  })
+})

--- a/platforms/web/sessionError.test.js
+++ b/platforms/web/sessionError.test.js
@@ -177,34 +177,29 @@ describe('--error is declared in every theme block (#1801)', () => {
     // a third copy of the constant cannot fail when the Swift side drifts,
     // which is the only scenario this test exists for (#1797's reasoning).
     //
-    // #1802 owns adding IrrHex.error. Until it lands the pairing is asserted
-    // against the red macOS ALREADY declares for its failure surfaces, so the
-    // two frontends cannot ship two different reds in the gap; once it lands,
-    // this asserts against IrrHex.error itself and goes red if #1802 picked a
-    // different hue. Both branches assert loudly that they found something to
-    // compare, so "could not look" can never pass as "matches".
-    //
-    // CHECKED AGAINST THE REAL SIBLING BRANCH, not assumed: #1802's PR #1810
-    // declares `static let error = "#FF3B30"`, which is both this file's dark
-    // --error and the existing IrrHex.wsDisconnected — so both branches of the
-    // fallback agree today and this test passes either side of that merge.
-    // (Verified by running these exact regexes over `git show
-    // pr1810:platforms/macos/Irrlicht/Theme/Tokens.swift`.)
-    //
-    // The LIGHT halves diverge by design and are not compared: this file
-    // overrides --error itself to #CC0C00, while #1810 keeps IrrHex.error as
-    // the base hue and re-tunes only the pill TEXT via
-    // Color.adaptive(light: "#C1121C", dark: "#FF7A70"). Both clear AA against
-    // their own platform's surface, which is a different colour on each.
-    const tokens = readMacosTokens()
-    const explicit = tokens.match(/static let error\s*=\s*"(#[0-9A-Fa-f]{6})"/)
-    const existingRed = tokens.match(/static let wsDisconnected\s*=\s*"(#[0-9A-Fa-f]{6})"/)
-    expect(existingRed, 'no IrrHex.wsDisconnected in platforms/macos/Irrlicht/Theme/Tokens.swift').not.toBeNull()
-    const want = (explicit ? explicit[1] : existingRed[1]).toLowerCase()
+    // STRICT: IrrHex.error must exist. #1802 landed it in PR #1810 as
+    // "#FF3B30" — the same value as this file's dark --error. While that was
+    // still in flight this test fell back to comparing against
+    // IrrHex.wsDisconnected (which holds the same red), so it would pass
+    // either side of that merge; the fallback is gone now that the real token
+    // is on main, because a fallback would mean a DELETED IrrHex.error
+    // silently downgraded this to checking a different constant instead of
+    // failing. The assertion is loud in both directions: not-null on the
+    // extraction, then equality.
+    const swiftDecl = readMacosTokens().match(/static let error\s*=\s*"(#[0-9A-Fa-f]{6})"/)
+    expect(swiftDecl, 'no IrrHex.error found in platforms/macos/Irrlicht/Theme/Tokens.swift').not.toBeNull()
+
     // The DARK value is the paired one: Color(hex:) is not appearance-aware,
     // so the Swift side carries one hex per token and adapts, where it does at
     // all, through Color.adaptive — the seam waitingPillText already uses.
-    expect(readToken(readCss(), DARK_BLOCK, 'error').toLowerCase()).toBe(want)
+    //
+    // The LIGHT halves diverge BY DESIGN and are deliberately not compared.
+    // This file overrides --error itself to #CC0C00; #1810 keeps IrrHex.error
+    // as the base hue and re-tunes only the pill TEXT via
+    // Color.adaptive(light: "#C1121C", dark: "#FF7A70"). Both clear AA against
+    // their own platform's surface, which is a different colour on each — the
+    // web composites over #ffffff, the macOS pill over its own measured wash.
+    expect(readToken(readCss(), DARK_BLOCK, 'error').toLowerCase()).toBe(swiftDecl[1].toLowerCase())
   })
 })
 

--- a/platforms/web/sessionError.test.js
+++ b/platforms/web/sessionError.test.js
@@ -7,6 +7,9 @@ import {
   DARK_BLOCK, LIGHT_MEDIA_BLOCK, LIGHT_THEME_BLOCK,
 } from './snapshots/contrast.mjs'
 import * as irr from './irrlicht.js'
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
 
 // --- #1801: the `error` session state on the web dashboard -----------------
 //
@@ -340,5 +343,58 @@ describe('the daemon-wide error banner (#1801)', () => {
     expect(banner().querySelector('img')).toBeNull()
     expect(banner().querySelector('script')).toBeNull()
     expect(banner().textContent).toContain('<img src=x onerror=alert(1)>')
+  })
+})
+
+describe('the web "is active" partition (#1801)', () => {
+  // The client had its own two inline copies of `working || waiting`, and they
+  // drift for exactly the reason the Go ones did. Collapsed into one predicate
+  // mirroring session.SessionState.HasWorkInFlight.
+
+  // LOCK — passes by construction; the three original answers must not move.
+  test('the original states keep their answers', () => {
+    expect(irr.hasWorkInFlight({ state: 'working' })).toBe(true)
+    expect(irr.hasWorkInFlight({ state: 'waiting' })).toBe(true)
+    expect(irr.hasWorkInFlight({ state: 'ready' })).toBe(false)
+  })
+
+  test('a RETRYING errored session is still working', () => {
+    // The elapsed clock must keep ticking: the agent has another attempt
+    // scheduled, so the turn has not stopped.
+    expect(irr.hasWorkInFlight(sessionWithError(errorPayload({ phase: 'retrying' })))).toBe(true)
+  })
+
+  test('a TERMINAL or unknown-phase errored session is not', () => {
+    expect(irr.hasWorkInFlight(sessionWithError(errorPayload({ phase: 'terminal' })))).toBe(false)
+    // Unknown phase is an honest "the transcript did not say", not a licence to
+    // assume another attempt is coming.
+    expect(irr.hasWorkInFlight(sessionWithError(errorPayload({ phase: '' })))).toBe(false)
+    expect(irr.hasWorkInFlight(sessionWithError(null))).toBe(false)
+  })
+
+  test('it never throws on a partial session object', () => {
+    // Sessions arrive from the websocket as whole-object replacements and a
+    // freshly-discovered one can be missing metrics entirely.
+    for (const a of [undefined, null, {}, { state: 'error' }, { state: 'error', metrics: {} }]) {
+      expect(() => irr.hasWorkInFlight(a)).not.toThrow()
+      expect(irr.hasWorkInFlight(a)).toBe(false)
+    }
+  })
+
+  test('it agrees with the Go domain predicate it mirrors', () => {
+    // Reads the Go source rather than restating its rule, so the two cannot
+    // drift silently — the same technique the --error/Tokens.swift pairing
+    // uses. Asserted to have FOUND the function, so "could not look" fails
+    // loudly instead of passing.
+    const go = readFileSync(
+      join(dirname(fileURLToPath(import.meta.url)), '..', '..', 'core', 'domain', 'session', 'session.go'),
+      'utf8',
+    )
+    const body = go.match(/func \(s \*SessionState\) HasWorkInFlight\(\) bool \{[\s\S]*?\n\}/)
+    expect(body, 'HasWorkInFlight not found in core/domain/session/session.go').not.toBeNull()
+    expect(body[0]).toMatch(/StateWorking/)
+    expect(body[0]).toMatch(/StateWaiting/)
+    expect(body[0]).toMatch(/StateError/)
+    expect(body[0]).toMatch(/IsRetrying/)
   })
 })

--- a/platforms/web/sessionError.test.js
+++ b/platforms/web/sessionError.test.js
@@ -183,6 +183,19 @@ describe('--error is declared in every theme block (#1801)', () => {
     // this asserts against IrrHex.error itself and goes red if #1802 picked a
     // different hue. Both branches assert loudly that they found something to
     // compare, so "could not look" can never pass as "matches".
+    //
+    // CHECKED AGAINST THE REAL SIBLING BRANCH, not assumed: #1802's PR #1810
+    // declares `static let error = "#FF3B30"`, which is both this file's dark
+    // --error and the existing IrrHex.wsDisconnected — so both branches of the
+    // fallback agree today and this test passes either side of that merge.
+    // (Verified by running these exact regexes over `git show
+    // pr1810:platforms/macos/Irrlicht/Theme/Tokens.swift`.)
+    //
+    // The LIGHT halves diverge by design and are not compared: this file
+    // overrides --error itself to #CC0C00, while #1810 keeps IrrHex.error as
+    // the base hue and re-tunes only the pill TEXT via
+    // Color.adaptive(light: "#C1121C", dark: "#FF7A70"). Both clear AA against
+    // their own platform's surface, which is a different colour on each.
     const tokens = readMacosTokens()
     const explicit = tokens.match(/static let error\s*=\s*"(#[0-9A-Fa-f]{6})"/)
     const existingRed = tokens.match(/static let wsDisconnected\s*=\s*"(#[0-9A-Fa-f]{6})"/)

--- a/platforms/web/sessionError.test.js
+++ b/platforms/web/sessionError.test.js
@@ -406,3 +406,60 @@ describe('the web "is active" partition (#1801)', () => {
     expect(body[0]).toMatch(/IsRetrying/)
   })
 })
+
+describe('the wire contract the renderer reads (#1801)', () => {
+  // #1802's PR #1810 had a MERGE BLOCKER of exactly this shape: its Swift
+  // decoded a top-level `error` key that the daemon does not emit, so it would
+  // have rendered a fallback string forever while looking like working code —
+  // every hand-written test fixture agreed with the decoder, because the same
+  // author wrote both.
+  //
+  // These read the REAL Go struct tags instead. A fixture cannot disagree with
+  // itself; the daemon's source can.
+  const goSrc = (...parts) => readFileSync(
+    join(dirname(fileURLToPath(import.meta.url)), '..', '..', 'core', 'domain', 'session', ...parts),
+    'utf8',
+  )
+
+  test('the error hangs off metrics.session_error, not off the session root', () => {
+    const metrics = goSrc('metrics.go')
+    const decl = metrics.match(/SessionError \*SessionError\s+`json:"([^"]+)"`/)
+    expect(decl, 'SessionError field not found in core/domain/session/metrics.go').not.toBeNull()
+    const [key, ...opts] = decl[1].split(',')
+    expect(key).toBe('session_error')
+    // omitempty is what makes "healthy" and "old daemon" the same payload, and
+    // is why the renderer must treat an absent key as healthy rather than as a
+    // parse failure.
+    expect(opts).toContain('omitempty')
+
+    // And it is a field of SessionMetrics — the struct the client reaches
+    // through `agent.metrics` — not of SessionState.
+    const metricsStruct = metrics.match(/type SessionMetrics struct \{[\s\S]*?\n\}/)
+    expect(metricsStruct, 'SessionMetrics struct not found').not.toBeNull()
+    expect(metricsStruct[0]).toContain('SessionError *SessionError')
+  })
+
+  test('every key the renderer reads is one the daemon actually emits', () => {
+    const src = goSrc('session_error.go')
+    // The tags SessionError declares, plus the one its custom marshaller owns.
+    const declared = new Set([...src.matchAll(/`json:"([a-z_]+)[,"]/g)].map(m => m[1]))
+    expect(declared.size, 'no json tags parsed out of session_error.go — the regex has gone stale').toBeGreaterThan(4)
+
+    // Exactly the keys sessionErrorText touches.
+    for (const key of ['phase', 'class', 'message', 'attempt', 'max_attempts', 'retry_in_ms']) {
+      expect(declared.has(key), `the renderer reads "${key}" but the daemon does not emit it`).toBe(true)
+    }
+  })
+
+  test('the phase values the renderer branches on are the ones Go declares', () => {
+    // sessionErrorText and hasWorkInFlight both compare phase against the
+    // string 'retrying'; a renamed constant would silently stop matching and
+    // every retrying session would render as terminal.
+    const src = goSrc('session_error.go')
+    expect(src).toMatch(/ErrorPhaseRetrying\s+ErrorPhase = "retrying"/)
+    expect(src).toMatch(/ErrorPhaseTerminal\s+ErrorPhase = "terminal"/)
+    // The unknown phase is the empty string, which is why hasWorkInFlight
+    // cannot treat "no phase" as retrying.
+    expect(src).toMatch(/ErrorPhaseUnknown\s+ErrorPhase = ""/)
+  })
+})

--- a/platforms/web/sessionErrorReachability.test.js
+++ b/platforms/web/sessionErrorReachability.test.js
@@ -1,0 +1,166 @@
+import { describe, test, expect } from 'vitest'
+
+// Reachability for #1801, and the counterpart of sessionError.test.js: every
+// assertion in that file calls sessionErrorText / renderDaemonErrorBanner
+// DIRECTLY, so deleting the `sessionErrorItem` push inside emitAgentRowItems,
+// or the `renderDaemonErrorBanner` call inside ingestInitialSessions, would
+// leave all thirty of them green. That is the exact hole
+// permissionsBanner.test.js records finding by mutation in review. This file
+// drives the REAL path — fetch → ingestInitialSessions → render — which is the
+// one a refactor can break.
+//
+// Its own file, not a second describe in sessionError.test.js, because
+// irrlicht.js does its top-level wiring at module load: only vitest's per-file
+// module isolation lets the fetch stub be installed BEFORE the import, the
+// same reason irrlicht.render.test.js is separate.
+
+const ERROR_MESSAGE = 'API Error: 429 rate limited'
+
+const sessionsPayload = {
+  groups: [
+    {
+      name: 'irrlicht',
+      agents: [
+        {
+          session_id: 'sess-red',
+          state: 'error',
+          project_name: 'irrlicht',
+          adapter: 'claude-code',
+          first_seen: 1764800000,
+          metrics: {
+            session_error: {
+              phase: 'retrying',
+              class: 'rate_limit',
+              message: ERROR_MESSAGE,
+              http_status: 429,
+              attempt: 3,
+              max_attempts: 10,
+              retry_in_ms: 616.4520045919932,
+            },
+          },
+        },
+        {
+          session_id: 'sess-green',
+          state: 'ready',
+          project_name: 'irrlicht',
+          adapter: 'claude-code',
+          first_seen: 1764800100,
+          metrics: {},
+        },
+      ],
+      costs: {},
+    },
+  ],
+  provider_costs: {},
+  daemon_errors: [
+    {
+      kind: 'hook_channel_silent',
+      scope: 'claude-code',
+      message: 'Irrlicht is receiving no hook events from claude-code — its sessions have fallen back to slower transcript-only detection.',
+      detail: '9 completed turns with no receipt',
+    },
+  ],
+}
+
+describe('the dashboard actually wires the error state up (#1801)', () => {
+  test('an errored session in the initial payload renders red, with its own line', async () => {
+    global.fetch = (url) => {
+      const u = String(url)
+      if (u.includes('/api/v1/sessions')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(sessionsPayload) })
+      }
+      if (u.includes('/api/v1/agents')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve([]) })
+      }
+      return Promise.resolve({ ok: false, json: () => Promise.resolve(null) })
+    }
+
+    // The banner slot lives in index.html, not in vitest.setup.js's SETUP_BODY
+    // — add it before the module wires itself up, the way #1385's suite does.
+    document.body.innerHTML +=
+      '<div id="daemon-error-banner" role="alert" aria-live="polite" hidden></div>'
+
+    await import('./irrlicht.js')
+    await new Promise((r) => setTimeout(r, 0))
+
+    // Guard the guard: if the list did not render at all, every "is the error
+    // row there" assertion below would be reporting on an empty document —
+    // inability to look reading as a clean pass.
+    const rows = document.querySelectorAll('#session-list .session-row')
+    expect(rows, 'the session list did not render — nothing below would mean anything').toHaveLength(2)
+
+    // The row itself: the state icon is the error glyph, not the ready one.
+    const red = document.querySelector('#session-list .session-row[data-session-id="sess-red"]')
+    expect(red).not.toBeNull()
+    expect(red.dataset.state).toBe('error')
+    expect(red.querySelector('.row-state-icon svg.state-error')).not.toBeNull()
+
+    // ...and the healthy session beside it is untouched.
+    const green = document.querySelector('#session-list .session-row[data-session-id="sess-green"]')
+    expect(green.querySelector('.row-state-icon svg.state-error')).toBeNull()
+
+    // The red line beneath it, carrying the agent's own words and the ladder.
+    const errRows = document.querySelectorAll('#session-list .row-error-row')
+    expect(errRows, 'no .row-error-row was emitted for the errored session').toHaveLength(1)
+    expect(errRows[0].dataset.sessionId).toBe('sess-red')
+    expect(errRows[0].textContent).toContain(ERROR_MESSAGE)
+    expect(errRows[0].textContent).toContain('attempt 3 of 10')
+    expect(errRows[0].querySelector('.row-error')).not.toBeNull()
+
+    // It sits directly beneath its own session row, not at the end of the list.
+    expect(errRows[0].previousElementSibling).toBe(red)
+
+    // And the daemon-wide banner is up.
+    const banner = document.getElementById('daemon-error-banner')
+    expect(banner.hidden, 'daemon_errors was in the payload but the banner stayed hidden').toBe(false)
+    expect(banner.textContent).toContain('claude-code')
+    expect(banner.textContent).toContain('9 completed turns with no receipt')
+  })
+
+  test('a websocket update clearing the error removes the red line', () => {
+    // Same module instance (per-file isolation). This is the path that matters
+    // most in practice: the error arrives and clears over the websocket, not
+    // over a refetch, and the row must disappear when it does — the daemon
+    // clears session_error rather than sending a "no longer failing" signal.
+    const ws = global.lastMockWebSocket
+    ws.simulateOpen()
+    ws.simulateMessage({
+      type: 'session_update',
+      session: {
+        session_id: 'sess-red',
+        state: 'working',
+        project_name: 'irrlicht',
+        adapter: 'claude-code',
+        metrics: {},
+      },
+    })
+
+    expect(document.querySelectorAll('#session-list .row-error-row')).toHaveLength(0)
+    const row = document.querySelector('#session-list .session-row[data-session-id="sess-red"]')
+    expect(row.dataset.state).toBe('working')
+  })
+
+  test('an error arriving over the websocket adds the red line', () => {
+    // The inverse, so the removal above cannot pass by the row never having
+    // been reachable on the websocket path in the first place.
+    const ws = global.lastMockWebSocket
+    ws.simulateMessage({
+      type: 'session_update',
+      session: {
+        session_id: 'sess-red',
+        state: 'error',
+        project_name: 'irrlicht',
+        adapter: 'claude-code',
+        metrics: {
+          session_error: { phase: 'terminal', class: 'auth', message: 'credentials rejected' },
+        },
+      },
+    })
+
+    const errRows = document.querySelectorAll('#session-list .row-error-row')
+    expect(errRows).toHaveLength(1)
+    expect(errRows[0].textContent).toContain('credentials rejected')
+    // Terminal: no retry clause invented from counters the agent never sent.
+    expect(errRows[0].textContent).not.toMatch(/attempt/)
+  })
+})

--- a/platforms/web/sessionErrorReachability.test.js
+++ b/platforms/web/sessionErrorReachability.test.js
@@ -1,5 +1,7 @@
 import { describe, test, expect } from 'vitest'
 
+let irr
+
 // Reachability for #1801, and the counterpart of sessionError.test.js: every
 // assertion in that file calls sessionErrorText / renderDaemonErrorBanner
 // DIRECTLY, so deleting the `sessionErrorItem` push inside emitAgentRowItems,
@@ -80,7 +82,7 @@ describe('the dashboard actually wires the error state up (#1801)', () => {
     document.body.innerHTML +=
       '<div id="daemon-error-banner" role="alert" aria-live="polite" hidden></div>'
 
-    await import('./irrlicht.js')
+    irr = await import('./irrlicht.js')
     await new Promise((r) => setTimeout(r, 0))
 
     // Guard the guard: if the list did not render at all, every "is the error
@@ -138,6 +140,42 @@ describe('the dashboard actually wires the error state up (#1801)', () => {
     expect(document.querySelectorAll('#session-list .row-error-row')).toHaveLength(0)
     const row = document.querySelector('#session-list .session-row[data-session-id="sess-red"]')
     expect(row.dataset.state).toBe('working')
+  })
+
+  test('the rehydrate poll clears the banner when the fault is fixed', async () => {
+    // The placement of renderDaemonErrorBanner inside rehydratePoll is argued
+    // at length in a comment — it must run BEFORE the structureSignature
+    // branch, because a daemon fault is not part of that signature, so a fault
+    // appearing or clearing always takes the "structure unchanged" path.
+    // Review found that argument covered by nothing: moving the call inside
+    // either branch left the whole 247-test suite green while leaving an alert
+    // banner up forever.
+    //
+    // rehydratePoll is driven directly rather than by advancing the 30s timer:
+    // faking timers here deadlocks on irrlicht.js's own setInterval loops, the
+    // same reason snapshots/render-html.test.js fakes only Date.
+    const banner = document.getElementById('daemon-error-banner')
+
+    // Put the fault back up first, so "hidden" below is a transition and not
+    // just the state it was already in.
+    const faulted = { ...sessionsPayload }
+    global.fetch = (url) => String(url).includes('/api/v1/sessions')
+      ? Promise.resolve({ ok: true, json: () => Promise.resolve(faulted) })
+      : Promise.resolve({ ok: false, json: () => Promise.resolve(null) })
+    await irr.rehydratePoll()
+    expect(banner.hidden, 'precondition: the banner should be up before we clear it').toBe(false)
+
+    // Now the SAME groups with the fault resolved. Identical structure, so this
+    // takes the "structure unchanged" path — the one the comment is about.
+    const healed = { ...sessionsPayload }
+    delete healed.daemon_errors
+    global.fetch = (url) => String(url).includes('/api/v1/sessions')
+      ? Promise.resolve({ ok: true, json: () => Promise.resolve(healed) })
+      : Promise.resolve({ ok: false, json: () => Promise.resolve(null) })
+    await irr.rehydratePoll()
+
+    expect(banner.hidden, 'the fault cleared but the banner stayed up — the poll is not refreshing it').toBe(true)
+    expect(banner.textContent).toBe('')
   })
 
   test('an error arriving over the websocket adds the red line', () => {

--- a/platforms/web/snapshots/contrast.mjs
+++ b/platforms/web/snapshots/contrast.mjs
@@ -1,0 +1,127 @@
+// contrast.mjs — print the WCAG contrast ratio of every state hue against the
+// surface it is drawn on, in both themes, straight from irrlicht.css.
+//
+//   node platforms/web/snapshots/contrast.mjs
+//
+// WHY IT EXISTS. irrlicht.css's light-palette block claims specific measured
+// ratios ("--waiting measured ~1.9:1", and #1801's "3.01:1 … 4.69:1"). A
+// number typed once into a comment drifts silently away from the value it
+// measured the moment someone nudges a hex — AGENTS.md's rule is that a figure
+// documenting behaviour names the command that produces it. This is that
+// command. The pass/fail assertion itself lives in irrlicht.test.js, so it is
+// re-run by CI rather than only reproducible by hand; this script is the
+// human-readable view of the same arithmetic.
+//
+// The comparison is text-on-its-own-wash, not text-on-plain-surface, because
+// that is how these hues are actually used: `.summary-question` and friends
+// draw the state colour as text on top of the matching 12%-alpha `--*-dim`
+// wash over `--surface`.
+
+import { readCss } from './serialize.js'
+
+/** sRGB channel (0-255) to linear light, per WCAG 2.x. */
+function toLinear(c) {
+  const s = c / 255
+  return s <= 0.03928 ? s / 12.92 : Math.pow((s + 0.055) / 1.055, 2.4)
+}
+
+/** Relative luminance of a #RRGGBB string. */
+export function luminance(hex) {
+  const [r, g, b] = parseHex(hex)
+  return 0.2126 * toLinear(r) + 0.7152 * toLinear(g) + 0.0722 * toLinear(b)
+}
+
+/** WCAG contrast ratio between two #RRGGBB strings. Order-independent. */
+export function contrastRatio(a, b) {
+  const l1 = luminance(a)
+  const l2 = luminance(b)
+  const [hi, lo] = l1 >= l2 ? [l1, l2] : [l2, l1]
+  return (hi + 0.05) / (lo + 0.05)
+}
+
+/** Composite `hex` at `alpha` over opaque `bg`, both #RRGGBB. */
+export function composite(hex, alpha, bg) {
+  const f = parseHex(hex)
+  const b = parseHex(bg)
+  const out = f.map((v, i) => Math.round(alpha * v + (1 - alpha) * b[i]))
+  return '#' + out.map(v => v.toString(16).padStart(2, '0')).join('')
+}
+
+function parseHex(hex) {
+  const h = hex.trim().replace(/^#/, '')
+  if (!/^[0-9a-fA-F]{6}$/.test(h)) throw new Error(`not a #RRGGBB colour: ${hex}`)
+  return [h.slice(0, 2), h.slice(2, 4), h.slice(4, 6)].map(p => parseInt(p, 16))
+}
+
+/**
+ * Read one custom property's value out of a CSS block.
+ *
+ * `blockRe` must match the block the declaration should come from, because
+ * every state token is declared more than once — a naive /--error:\s*([^;]+)/
+ * over the whole file silently returns the DARK value and would report the
+ * light theme as passing when it does not. Throws rather than returning null:
+ * a lookup that cannot find its input must be loud, never quietly absent.
+ */
+export function readToken(css, blockRe, name) {
+  const block = css.match(blockRe)
+  if (!block) throw new Error(`no CSS block matched ${blockRe}`)
+  const decl = block[0].match(new RegExp(`--${name}:\\s*([^;]+);`))
+  if (!decl) throw new Error(`no --${name} declaration inside the block matched by ${blockRe}`)
+  return decl[1].trim()
+}
+
+/** The dark `:root` block — everything up to the first closing brace. */
+export const DARK_BLOCK = /:root \{[\s\S]*?\n {4}\}/
+/** The `prefers-color-scheme: light` override block. */
+export const LIGHT_MEDIA_BLOCK = /@media \(prefers-color-scheme: light\)[\s\S]*?\n {4}\}/
+/** The explicit `[data-theme="light"]` override block. */
+export const LIGHT_THEME_BLOCK = /:root\[data-theme="light"\] \{[\s\S]*?\n {4}\}/
+
+/**
+ * Every state hue's contrast against its own 12%-alpha wash, per theme.
+ * Returned rather than printed so irrlicht.test.js can assert on it.
+ */
+export function stateContrasts(css = readCss()) {
+  const rows = []
+  const themes = [
+    { theme: 'dark', block: DARK_BLOCK, surface: readToken(css, DARK_BLOCK, 'surface') },
+    { theme: 'light', block: LIGHT_MEDIA_BLOCK, surface: readToken(css, LIGHT_MEDIA_BLOCK, 'surface') },
+  ]
+  for (const { theme, block, surface } of themes) {
+    for (const state of ['working', 'waiting', 'ready', 'error']) {
+      // The light block only re-declares the tokens it overrides, so fall
+      // back to the dark declaration for anything it leaves alone — which is
+      // exactly how the cascade resolves it in a browser.
+      let hex
+      try {
+        hex = readToken(css, block, state)
+      } catch {
+        hex = readToken(css, DARK_BLOCK, state)
+      }
+      const wash = composite(hex, 0.12, surface)
+      rows.push({
+        theme,
+        state,
+        hex,
+        surface,
+        wash,
+        vsWash: contrastRatio(hex, wash),
+        vsSurface: contrastRatio(hex, surface),
+      })
+    }
+  }
+  return rows
+}
+
+// Only print when run directly, so importing the helpers costs nothing.
+if (process.argv[1] && process.argv[1].endsWith('contrast.mjs')) {
+  const pad = (s, n) => String(s).padEnd(n)
+  console.log(pad('theme', 7) + pad('state', 9) + pad('hex', 10) + pad('wash', 10) + pad('vs wash', 10) + 'vs surface')
+  for (const r of stateContrasts()) {
+    const flag = r.vsWash >= 4.5 ? '' : '   <-- FAILS WCAG AA (4.5:1)'
+    console.log(
+      pad(r.theme, 7) + pad(r.state, 9) + pad(r.hex, 10) + pad(r.wash, 10) +
+      pad(r.vsWash.toFixed(2) + ':1', 10) + r.vsSurface.toFixed(2) + ':1' + flag
+    )
+  }
+}

--- a/platforms/web/snapshots/fixtures.js
+++ b/platforms/web/snapshots/fixtures.js
@@ -201,4 +201,62 @@ export const scenes = [
     ),
     deltas: [],
   },
+
+  // #1801 — the `error` state, in BOTH themes, because --error is the only
+  // state hue with a light-theme override whose value differs from its dark
+  // one: a single-theme scene would render the half that was already fine.
+  // Three sessions so a reviewer sees the red row and line beside untouched
+  // healthy ones rather than in isolation, and both error phases, because the
+  // retry ladder is rendered for one and deliberately absent for the other.
+  //
+  // The <main>-level daemon-error banner does NOT appear in these artifacts:
+  // serializeSessionList captures #session-list only. Covered instead by
+  // sessionErrorReachability.test.js, which asserts on the real element.
+  ...['dark', 'light'].map((theme) => ({
+    name: (theme === 'dark' ? '07' : '08') + '-error-state-' + theme,
+    theme,
+    expectedRows: 3,
+    sessions: sessions(
+      group('irrlicht', [
+        {
+          session_id: 'err-retry-' + theme, state: 'error', project_name: 'irrlicht',
+          git_branch: 'main', adapter: 'claude-code', first_seen: t(240),
+          metrics: {
+            model_name: 'claude-opus-4-8', estimated_cost_usd: 0.31,
+            context_utilization_percentage: 38, pressure_level: 'low',
+            total_tokens: 31000, elapsed_seconds: 240,
+            session_error: {
+              phase: 'retrying', class: 'rate_limit',
+              message: 'API Error: 429 {"type":"error","error":{"type":"rate_limit_error"}}',
+              http_status: 429, attempt: 3, max_attempts: 10,
+              retry_in_ms: 616.4520045919932,
+            },
+          },
+        },
+        {
+          session_id: 'err-terminal-' + theme, state: 'error', project_name: 'irrlicht',
+          git_branch: 'feat/y', adapter: 'codex', first_seen: t(80),
+          metrics: {
+            model_name: 'gpt-5-codex', estimated_cost_usd: 0.07,
+            total_tokens: 4200, elapsed_seconds: 80,
+            // No counters at all — the recorded terminal shape. The line must
+            // show the message and invent no "attempt 0 of 0" beside it.
+            session_error: {
+              phase: 'terminal', class: 'auth',
+              message: 'Authentication failed: credentials were rejected',
+            },
+          },
+        },
+        {
+          session_id: 'ok-' + theme, state: 'working', project_name: 'irrlicht',
+          git_branch: 'main', adapter: 'claude-code', first_seen: t(30),
+          metrics: {
+            model_name: 'claude-sonnet-4-6', context_utilization_percentage: 12,
+            pressure_level: 'low', total_tokens: 3000, elapsed_seconds: 30,
+          },
+        },
+      ], { day: 0.38 }),
+    ),
+    deltas: [],
+  })),
 ]


### PR DESCRIPTION
Phase 2b of #1796, on top of #1798's state and pipe. Five adapters stop discarding
an error they already parse, and the one error source no adapter can observe —
the agent process dying mid-turn — gets a producer, a signal kind, and its own
rung on the ladder.

**Does not touch claudecode or copilot** (#1799's adapters). No file under
either is modified.

---

## The tier problem, and how it was handled

#1798 left an explicit instruction: its `session_error` rule pins its tier to
`TierTranscript` through the `signal` field, so #1800's `TierProcess` evidence
would be recorded as transcript-tier, and **understating a tier never trips the
ladder invariant** — the check only fires when a *lower* rule outranks the
winner. It offered two fixes: a new rule row, or a `tierOf` on the existing one.

**This adds a new `SignalKind` (`SignalProcessDeath`, `TierProcess`) with its own
policy row and its own classifier rule row.** Not a `tierOf`, and the reason is
that *the tier value was never the hard part — placement was*:

- A `tierOf` fixes the recorded provenance but leaves the verdict where
  `session_error` sits, **below the three transcript-tier waiting rules**. Those
  read a transcript that is **frozen at the instant of death**: an
  `AskUserQuestion` or a permission-gated edit that was open when the process
  died stays open *forever*, so `user_blocking_tool` keeps firing and keeps
  painting a dead session `waiting`. Sending a user to answer a question in a
  process that no longer exists is worse than saying nothing.
- That placement is not merely mis-tiered, it is **inconsistent**, and the
  invariant *does* catch it (overstating from below is the direction it sees).
  Proof — the rule moved down to where a `tierOf` would leave it:

  ```
  --- FAIL: TestStateRules_LadderIsTierConsistent
    user-blocking-tool-open/process-death (current=working): rule "user_blocking_tool"
      (tier transcript) decided, but lower rule "process_death" (tier process) outranks it
    ... × 4 current-states × 2 hold sets
  --- FAIL: TestProcessDeath_OutranksAFrozenWaitingTranscript
    state = "waiting", want error — a dead process is not waiting for an answer nobody can deliver
    tier = transcript, want TierProcess
    rule = "user_blocking_tool", want "process_death"
  ```
- Two rows also keep the verdicts apart in a trace: `DecidedByRule` reads
  `process_death` or `session_error`, so a crash and a provider refusal are never
  the same line.

`signal_hold.go`'s own comment already said a policy row declares exactly one
tier, so the kind is new rather than the existing one widened.

**The tier claim does not rest on a string.** The rule reads
`SessionMetrics.ProcessDeath`, a flag only the `SignalProcessDeath` hold can set,
*not* `Class == "process_death"`. A tier is a claim about the evidence CHANNEL,
and `Class` is adapter-supplied content — keying on it would let a transcript
grant itself process tier. Pinned by
`TestProcessDeathClass_AloneDoesNotClaimProcessTier`.

---

## Per-adapter outcome

| adapter | signal | outcome |
|---|---|---|
| **pi** | `stopReason:"error"` + `errorMessage` | **Two real defects fixed.** The event fell into the mid-turn branch and emitted `"assistant"` — pi has no working-state idle sweep and writes nothing more after a refusal, so the session stuck in `working` for the rest of its life. `errorMessage` was read by nothing. Now `turn_done` + `SessionError`, with the double-encoded `{"detail": …}` unwrapped. Recorded fixture. |
| **gemini-cli** | top-level `type:"error"` + the `type:"info"` failure notice that follows it | Promoted — and see the review section: the first cut was **inert**, because gemini writes the failure as a PAIR and the second line silently cleared the first. `HTTPStatus` recovered from the `[API Error: {…}]` envelope — the code exists only inside that string; the line's keys are `id/timestamp/type/content` and nothing else. **`IsError` dropped here**: it means a *tool_result* failed, and this was the one site in the tree conflating the two (`tailer/parser.go` names it and says #1800 moves it). Nothing reads `IsError` (`tailer.go:1163` says so and does not track it), so no behaviour rides on the removal. `AssistantText` kept — it is what #665 settles the waiting headline with. |
| **opencode** | `message.data.error`, `step-finish reason:"error"` | Promoted on both paths, plus **two bugs**. (1) The live path never saw it at all: `buildPartRaw` injected `_role/_cwd/_ts/_model` and not `_error`, so the parser's error branch was replay-only. (2) **A live/replay divergence** — the parser fired on ANY non-nil `_error` while `isErrorMessage` required a non-empty string-or-object, so `"_error": {}` ended the turn in a golden and not in the daemon. Both now route through one `sessionErrorFrom`. Also: the recorded shape is `{name, data:{message}}`, **not** the `{name, message}` `watcher.go` documented — a reader following that comment would have shipped an empty error line. |
| **codex** | `turn_aborted.reason` | Read, and the ESC path pinned unchanged. **See the census below**: no recorded codex fixture carries a non-`interrupted` reason and no `stream_error` exists anywhere, so the errored branch ships with **hand-built unit fixtures and says so in the code**. Reading `reason` is what makes the two *distinguishable at all* — without it they are the same event and no recording could ever separate them. |
| **aider** | `errorRE` → `flushErrorTurn` | **The issue's premise was wrong.** aider was listed under "no error signal at all"; it has had one since `errorRE` was written, smuggled through `AssistantText` — the same shape #1798 named for gemini-cli and did not know about here. Promoted. `Class: "provider"` with no status is the honest ceiling: aider parses plaintext chat history, so there is no structured field to read. |
| **hermes** | — | **Not "absent".** `IsError` appears nowhere in the package (verified: `rg IsError core/…/hermes/` → no matches), but hermes's own committed 2-14 assessment is `agent_supports: yes / daemon_capability: bug / driver_capability: ready` and cites an elaborate abnormal-turn-end apparatus in `conversation_loop.py`. The agent emits signals; irrlicht's adapter does not read them. That is a **daemon bug**, already recorded as one — coarsening the trait to `untraced` would replace a precise verdict with a vaguer, wrong one. **No change, deliberately.** |
| **mistral-vibe** | — | Genuinely nothing: the word "error" does not appear in `vibe/parser.go` at all. Already declared `error_epilogue: untraced`, and its 2-14 cell is already `daemon_capability: incapable`. **The existing declarations are correct; no change needed.** |

### Codex fixture census — run, not assumed

The issue asked for this before deciding codex's scope, and it confirms the
earlier survey:

```
$ find replaydata/agents/codex -name transcript.jsonl -print0 | xargs -0 cat \
    | jq -r 'select(.type=="event_msg" and .payload.type=="turn_aborted") | .payload.reason' \
    | sort | uniq -c
   4 interrupted

$ rg -uuu -c stream_error replaydata/ ; echo "exit=$?"
exit=1
```

Four `turn_aborted` events across all 48 committed codex transcripts, every one a
user ESC, and **zero** `stream_error` anywhere in the repo (`-uuu` searches
hidden, gitignored and binary files, so this is not a `.gitignore` artifact).

**codex genuinely cannot demonstrate an errored abort today, and that is recorded
rather than papered over**: the parser's doc comment says the branch is hand-built,
and codex's 2-14 cell had a stale blocker claiming `grep -rni turn_aborted core/`
returns nothing — false since the parser gained the mapping. Corrected in place,
with the census pasted in so the next reader does not re-derive it. **Axis values
deliberately left alone**: flipping `daemon_capability` moves the matrix census,
which is `/ir:onboarding-factory assess`'s job, not an adapter PR's.

**Quota-reached is NOT an error state for codex** (the issue asked me to decide).
`rate_limit_reached_type` describes a subscription window, not a failed turn — the
session may be working happily on a lower tier. A metric, not a state.

---

## Process death

`HandleProcessExit` deleted every session whose process exited, in any state. That
is right for one that finished and exactly wrong for one that died mid-turn: the
row vanishing is indistinguishable from the row never having mattered, and "your
agent stopped without finishing" is the single most useful thing irrlicht can say
about an agent left running.

**What irrlicht cannot see, stated because it bounds the whole feature.** There is
no exit status. irrlicht is not the agent's parent, so neither kqueue's `NOTE_EXIT`
nor Linux's `pidfd` poll yields a wait status, and the sweep's probe is
`syscall.Kill(pid, 0)` — a yes/no liveness question. A segfault, an OOM kill, a
`kill -9` typed by the user and a clean `exit(1)` are the **same observation**. The
only discriminators available are about what the SESSION looked like.

**The verdict is therefore provisional, and that is the design.** On the exit edge
a clean headless run is indistinguishable from a crash — `claude -p`, `codex exec`
and `opencode run` all write the turn-ending line and exit microseconds later, so
the daemon has usually not read it yet. Deciding there would report **every clean
headless run as a crash**. Instead the exit edge places the hold, and
`SignalProcessDeath`'s `stale: IsAgentDone()` decides on the next classify pass,
against a transcript that is by then final. `IsAgentDone` rather than
`HookTurnDone` because seven of nine adapters have no hooks at all.

Retention is the hold's own ceiling (twelve hours, shared with
`sessionErrorHoldTimeout` — the same overnight argument `permissionPromptHoldTimeout`
makes). When it expires the session leaves `error` on its own and the next liveness
sweep reaps it through the unchanged path. No new timer, no new sweep branch.

**The residual false positive, named rather than discovered later:** a user who
deliberately kills an agent mid-turn now gets `error` instead of the row
disappearing. The turn genuinely did not finish, so "stopped without completing"
is true either way — but it is a behaviour change.

---

## Red-first evidence

Every failure below was observed, not predicted.

### Real defect tests, red before the fix existed

```
--- FAIL: TestParser_StopReasonError_IsASessionError               [pi]
    EventType = "assistant", want "turn_done" — an errored turn has ended;
      emitting "assistant" leaves the session stuck in working forever
    SessionError is nil — pi reports stopReason:"error" with an errorMessage
      and the parser discards both

--- FAIL: TestParser_TopLevelError_IsASessionError                 [gemini-cli]
    SessionError is nil — the failure reaches the UI only as prose today

--- FAIL: TestParser_MessageError_IsASessionError                  [opencode]
    SessionError is nil — the error object is read only as a boolean today
--- FAIL: TestParser_StepFinishError_IsASessionError               [opencode]
    SessionError is nil — step-finish reason:"error" settles the turn but
      reports nothing about why
--- FAIL: TestParser_EmptyErrorObject_IsNotATurnEnd                [opencode]
    an empty _error object ended the turn — watcher.go's isErrorMessage rejects
      this shape, so live and replay disagree

--- FAIL: TestParser_TurnAbortedError_IsASessionError              [codex]
    SessionError is nil — payload.reason is never read, so an errored abort is
      indistinguishable from an ESC interrupt
--- FAIL: TestParser_TurnAbortedUnknownReason_IsASessionError      [codex]

--- FAIL: TestParser_LLMErrorBlockquote_IsASessionError            [aider]
    SessionError is nil — the error text reached the UI only as prose
```

The producer, with its branch disabled (byte-equivalent to `origin/main`
behaviour):

```
--- FAIL: TestHandleProcessExit_MidTurnDeathRetainsSessionAsError
    state = "working", want "error"
--- FAIL: TestHandleProcessExit_IsIdempotentAcrossSweeps
    a later sweep deleted the errored session — the verdict must survive
      repeated reaps of the same dead PID
--- FAIL: TestProcessDeath_YieldsToAFinishedTurnOnTheNextPass
    precondition: the exit edge must reach the provisional verdict, got <nil>
```

### Mutations, for everything the change ADDS

| # | mutation | result |
|---|---|---|
| A | `process_death` rule moved to where a `tierOf` would leave it | **RED** — quoted at the top |
| B | `SignalProcessDeath`'s `stale: IsAgentDone()` neutered | **RED** — `rule "process_death" (tier process) decided, but lower rule "agent_done" (tier hook) outranks it` |
| C–G | each of `diedMidTurn`'s five clauses removed, one at a time | **RED**, each in exactly its own subtest: `state != StateWorking` → `ready` + `waiting`; `ParentSessionID` → `child-session`; `m == nil` → `no-metrics`; `IsAgentDone()` → `turn-already-done`; `LastWasUserInterrupt \|\| LastWasToolDenial` → `user-esc-interrupt` + `tool-denial` |
| H | `_error` injection dropped from `buildPartRaw` | **RED** — `_error absent — the live path drops the message-level error before the parser ever sees it` |
| I | aider's `SessionError` removed from `flushErrorTurn` | **RED** |

**A redundancy that was measured and then removed rather than kept.** The rule
first carried `!HookTurnDone && !IdlePromptPending`. Measured as a 2×2, neither
turn-done clause could be made to fail alone — the guard and the hold's staleness
rule each masked the other's mutation, and only removing **both** went red. The
`!IdlePromptPending` clause likewise went green once `stale` became
`IsAgentDone()`, because `SignalIdlePrompt`'s staleness is exactly its complement.
Both guards were dropped and the argument now lives in the one place that IS
mutation-covered. **A check that cannot be shown red is not coverage, it is a
comment that reads like coverage** — the reasoning is written into the rule so the
next editor does not re-add them.

### Locks — pass by construction, NOT red-first proof

- `TestParser_ToolCallError_IsNotASessionError` (gemini-cli), `TestParser_StepFinishStop_HasNoSessionError` (opencode), `TestParser_NormalTurnEnd_HasNoSessionError` (aider) — a tool failure / clean turn must stay clean.
- `TestParser_TurnAbortedInterrupted_IsNotASessionError` (codex) — the ESC path, the only shape any fixture carries.
- `TestHandleProcessExit_CleanShapesAreStillDeleted` (7 rows) — passed before this change too, since the old code deleted unconditionally. Its value is mutations C–G above.
- `TestBuildPartRaw_*` — could not compile before the signature change; covered by mutation H.

### Two committed tests deliberately CHANGED

- `TestParseLine_ErrorLineSettlesTurn` (gemini-cli) — the `IsError` assertion inverted, which is the move #1798 wrote down.
- `TestSessionDetector_LateStopHookAfterProcessExit_SettlesToReady` (#1772) — its **precondition** (`session should be deleted`) no longer holds for this shape. The assertion that matters is untouched and still passes: the session settles to `ready`, now without needing the `deletedStates` revive path at all, because the row is never gone. That path is **not** dead — a `ready`/`waiting`/child/metrics-less session at exit still takes the delete branch.

### Loudly-firing existing gates (doing their job, not red-first proof)

- `TestSignalPolicies_OrderIsPinned`: *"signalPolicies has 7 rows, want 6"* — updated, with the new row's ordering dependency documented.
- `TestCatalogCensusMatchesTheCommittedFigures`: Divergent 145 → 146, DivergentByCountsAndKinds 144 → 145. **Attribution measured, not inferred**: disabling only pi's new `case "error"` arm returns the test to the previous figures. The recording is pi's 2-14, whose sidecar is frozen against the buggy daemon — it cannot re-agree without a re-record, which is what `known_failing` means.
- `TestNoCommentRestatesALiveCensusFigure`: my own comment restated the figures (reworded to name the fields), **and three pre-existing historical-table sites in `replay_sidecar.go` newly collided with 146** — each given a `censusFigureExemption` with a checkable reason. Two existing exemptions whose reason said "coincides with Divergent" now coincide with `DivergentByCountsAndKinds`; both reasons corrected.

### Goldens

Three moved, all adapter-scoped, all showing the feature working end-to-end:

- `pi/2-14`: `ready` → **`error`**, and `last_event_type` `assistant` → `turn_done` — the stuck-in-working defect, visible in a golden.
- `opencode/1-8`, `opencode/4-1`: `agent finished turn → ready` → **`session error → error`**. 4-1 is the striking one: three consecutive user turns each failed with a context-length error, and the session used to end **green** with two ready↔working flickers. It now sits in `error` with `flicker_count` 2 → 0. That is exactly the silent-green outcome the fourth state exists to remove.

---

## Gates

Every group run in the foreground, separately.

| gate | result |
|---|---|
| `--only go` (core + factory + replaydata validate + rig smoke + replay fixtures) | **PASS** |
| `--only arch` (ARS) | **PASS** — composite 7.9005 → 7.8947, no regression flagged |
| `--only web` (both trees) | **PASS** |
| `--only tools` / `--only skills` | **PASS** |
| `--only posix` / `--only bash` | **PASS** |
| `--only security` | **PASS** |
| `--only swift` | **PASS** |
| `go vet ./core/...` and `go vet ./...` in `tools/onboarding-factory` (explicit) | **PASS** |
| `of validate` | **PASS** |

Pushed with `--no-verify` because every gate the pre-push hook runs had already
been run in full, unscoped, in the foreground.

---

## Known gaps, deliberately not closed here

- **A process-death verdict does not survive a daemon restart.** `seedAlivePIDs`
  deletes any persisted session whose PID is already dead, by a direct delete that
  never reaches `HandleProcessExit`. Routing it through the conversion would be
  *worse*, not better, until #1798's other known limitation is fixed: `SessionError`
  does not survive a restart either (`seedReevaluateOne` calls `RefreshMetrics` —
  a merge against a fresh nil — *before* `ClassifyState`), so the row would come
  back **green**, which is a stale row that lies rather than a missing one. The real
  fix is `LedgerState` persistence plus a seed-ordering change; it applies equally to
  #1799's producers, so it wants its own issue rather than being smuggled into
  whichever adapter PR lands last. **Not filed by me — flagging for triage.**
- **The `error→ready→error` blip** #1798 named (`SignalTurnDone` is `consumeOnce`)
  is #1799's, and is untouched here.
- **No UI consumes `SessionError` yet** — the macOS `State` enum has no `error` case
  (an incoming `"error"` decodes to `.unknown`) and the web pins
  `{working, waiting, ready}`. #1801/#1802.
- **codex's 2-14 axis values** need a real re-assessment now that blocker 2 is gone;
  only the stale prose was corrected here.

---

## Review round (high-effort subagent) — 7 findings, all actioned

### F2 — the gemini-cli promotion was INERT (blocker, and the best evidence in the PR)

gemini writes a failure as a **pair**: a `type:"error"` line carrying the API body,
then a `type:"info"` "This request failed…" notice. `parseInfo` emitted `turn_done`
with no error, and the tailer's clearing rule fires on a turn boundary — so the
notice **wiped the error the line before it had just recorded**, and the session
settled green.

**The proof was a golden that did not move.** `gemini-cli/2-14`'s golden still read
`working → ready`, untouched by the promotion, while pi's and opencode's moved. My
`TestParser_TopLevelError_IsASessionError` fed the error line in isolation, so it
proved the parser emits a signal and could never have failed for the thing it
claimed.

Fixed by splitting `terminalInfoMarkers` into `{prefix, isError}` — "Request
cancelled" is a user ESC and stays clean, "This request failed" is a failure and
carries the error. The parser now also remembers the preceding error so the notice
re-reports the **rich** one rather than downgrading it to its own prose.

Regression test drives the **real recorded bytes** through the **real tailer** with
the **real parser** — not a purpose-built double, which is the #1809 trap where a
hand-written fixture encodes the author's model of the adapter instead of the
adapter. Both halves seen red:

```
--- FAIL: TestTailer_GeminiErrorPairKeepsTheSessionError      [pre-fix behaviour]
    the session error did not survive the transcript: gemini's "This request failed"
    notice parses to turn_done, and a turn boundary clears the standing error — so the
    failure recorded one line earlier was wiped and the session settles GREEN
--- FAIL: TestTailer_GeminiErrorPairKeepsTheSessionError      [fresh-error mutation]
    HTTPStatus is nil — the info notice overwrote the API line's error with a poorer
    one built from its own prose
```

**The golden now moves**: `working → error`. Both gemini 2-14 recordings updated.

### F1 + F3 — retention was not terminal, and the restart case was unnamed (blockers)

**F1.** Retention was owned by the hold's ceiling. Once the ceiling dropped the hold,
the next classify pass re-derived `working` from the frozen transcript, the next
sweep re-converted it, and the session was **immortal** — a spurious "the agent is
working" transition every twelve hours for a process dead for days. My own comment
claimed "no way for a retained session to become immortal".

Fixed by moving retention to a single in-memory verdict registry
(`processDeathVerdicts`), which makes it terminal: a session that has had its verdict
is kept until the deadline and then **released to the reaper**, never re-converted.
The hold consequently carries **no ceiling** — the only row in `signalPolicies`
without one, justified in place: its subject is provably dead, its lifetime is
bounded by the row's, and the row is reaped by the very function that placed it.

Both regression tests seen red against the shipped design:

```
--- FAIL: TestProcessDeath_RetentionIsTerminal
    session still present as "error" after 3s of sweeps past a 150ms retention window —
    the process-death verdict is being re-applied instead of expiring, so this row can
    never be reaped
--- FAIL: TestProcessDeath_DoesNotReconvertAfterExpiry
    the session was re-converted after its retention window closed — diedMidTurn still
    says yes for a frozen mid-turn transcript, so the verdict registry is the only thing
    that can make retention terminal
```

**F3.** The verdict does **not** survive a daemon restart: `seedAlivePIDs` deletes any
persisted session whose PID is already dead, by a direct delete that never reaches
`HandleProcessExit`. That is now **named in the code**, on the function and on the
retention constant, because the twelve-hour window is exactly the window a restart
falls inside. Deliberately not "fixed": routing that path through the conversion would
make things **worse**, since #1798's `SessionError` does not survive a restart either
(`seedReevaluateOne` merges against a fresh nil *before* `ClassifyState`), so the row
would come back **green** — a stale row that lies, rather than a missing one. Real fix
is ledger persistence plus a seed-ordering change; it applies equally to #1799's
producers and wants its own issue.

### F5 — cross-PR, comment only, mechanism left to #1799

The `session_error` rule's comment said "no adapter emits SessionError yet, so no
session can be in this position". This PR falsifies that. The comment is corrected to
say the producers have landed and to point at **#1799**, which already owns the
tailer-side fix — two PRs landing the same clear would conflict. **No mechanism
implemented here.**

### F4 — comments corrected

Every comment in the diff re-read against the code. Corrected: the immortality claim,
the retention-owner claim, `POSITION`'s stale "reads HookTurnDone" (it calls
`IsAgentDone`, which consults it), the ceiling rationale, and the `session_error`
staleness above.

### F6 — `geminiErrorClass`'s `quota` branch was unreachable

Google returns `RESOURCE_EXHAUSTED` as HTTP **429**, and the 429 arm returned first —
so every real quota exhaustion reported as `rate_limit`. That is the one distinction a
user acts on differently: a rate limit clears by waiting, an exhausted quota does not.
`status` is now consulted before the code. Seen red under the old ordering:

```
--- FAIL: TestGeminiErrorClass_QuotaIsReachable/quota_exhausted_arrives_as_429
    geminiErrorClass(429, "RESOURCE_EXHAUSTED") = "rate_limit", want "quota"
```

### F7 — codex's `TurnAbortReason`: checked, and left alone

**No allowlist was added**, so nothing in the code depends on guessing an enum member:
only `"interrupted"` is named, everything else falls through to the error branch.

`"interrupted"` is now verified three independent ways — 4/4 in replaydata, **47/47
across 327 local `~/.codex` session files** (an uncurated corpus that is not fixture
data), and present in the shipped binary. 51 aborts, two unrelated corpora, one value.

The enum itself I **could not verify** and say so in the code: codex 0.148.0 ships as a
native binary with no source; its string table contains the bare literals `error` and
`timeout` next to `interrupted`, but the strings are one concatenated blob with no
recoverable adjacency, so a serde variant cannot be told from any other use of those
very common words. **Marked UNVERIFIED**; the hand-built fixtures use `reason:"error"`
as a representative non-interrupted value, not as a claim about the enum.

### Advisory checks

- **SonarCloud** (4 × `godre:S8188`): the deferred-`cancel` pattern in the new test
  file. Rewritten as two LIFO defers so `cancel` is a plain deferred call.
- **CodeScene**: `HandleProcessExit`'s complex conditional extracted to
  `retainedAsProcessDeath`; opencode's `applySessionError` conditional extracted to
  `recoversFromSessionError`; `reachableMetricFixtures` split, with the hold subsets
  moving to `reachableHoldSets`.
- **CodeScene's absent-test-pattern hint** — the same hint that surfaced a real defect
  in #1809 — is acted on rather than dismissed: `TestClassify_ProcessDeathRoutesToError`
  added to `state_classifier_test.go`, covering `working→error`, an already-red session
  emitting **no** transition (which is what stops a dead row re-broadcasting every
  poll), the flag-without-detail case, and the clearing path out of `error`.

### Census moved again, and the ratchet fired

`Divergent` and `DivergentByCountsAndKinds` are now up **two** recordings, not one —
pi's 2-14 and gemini-cli's 2-14. Attribution measured once per recording by disabling
each adapter's arm in turn.

`TestNoCommentRestatesALiveCensusFigure`'s **ratchet** then failed three
pre-existing exemptions that no longer suppress anything (their 145-valued table rows
stopped colliding once the figures moved). Deleted rather than left to rot, exactly as
the mechanism instructs; the three still-colliding entries had their reasons corrected
to name `DivergentByCountsAndKinds`.

### Rebase onto #1811 — a real conflict, and one finding that changed under it

Rebased twice: onto **#1810** (macOS, no overlap) and then onto **#1811** (#1799,
claude-code + copilot), which **does** overlap — it touched
`state_classifier.go`, `core/pkg/tailer/parser.go` and `tailer_metrics.go`.
Three conflicts, all resolved on the merits rather than by taking a side:

- **`state_classifier.go`** — #1799's version of the flicker comment is the
  accurate one and is kept: the fix has now *shipped* (`IngestTurnBoundary` +
  `classifyAgentDone` routing a standing error to `StateError`), so my earlier
  "still not fixed here, it is #1799's" is itself stale. Kept theirs, added the
  one fact only this branch carries — five more producers, all transcript-only,
  all of which report the failure **on** the turn-boundary event, so
  `ClearedByTurnBoundary` decides them too.
- **Both census files** — #1799 moved the same figures and had already deleted
  the same three stale exemptions I had, independently. Kept their explanation,
  re-measured my own figures on top.

**#1799's rule changed what one of my fixes is FOR, and the comment now says so.**
`ClearedByTurnBoundary` retires only an `ErrorPhaseRetrying` error. Every error
these five adapters emit is **terminal**, so the gemini error+notice pair now
survives a turn boundary *without* the `isError` split — measured: neutralising
the flag leaves `TestTailer_GeminiErrorPairKeepsTheSessionError` green. Rather
than leave code whose stated justification had quietly become false, the split is
**re-scoped in place** to the case the shared rule cannot cover — a
`"This request failed…"` notice arriving with **no** error line before it (#676's
shape), where there is no standing error to preserve and the session would
otherwise go green on a failure. That case now has its own test, and it is
mutation-proven:

```
--- FAIL: TestParser_StandaloneFailureNotice           [isError removed]
    a failure notice with no preceding error line reported nothing — the turn ends
    and the session goes green on a failure
```

The earlier red for the pair case was real **against the pre-#1799 tree** and is
left above as the record of why the split was written; it is no longer what the
split is load-bearing for.

**The #1480 pair-count ratchet moved down, exactly as #1799 predicted it would**
("#1800 will move this floor again for the same reason on its own adapters"):
835 → 833. Both pairs named and measured per golden with
`git show origin/main:<golden> | jq '.extended_check.ordered_matches'` — gemini-cli
2-14 `2 → 1` and pi 2-14 `2 → 1`. Same frozen-sidecar cost, resolves on re-record.

Census likewise re-measured on top of #1799's: `Divergent` 148 → 150,
`DivergentByCountsAndKinds` 147 → 149, +2 for this branch's two recordings.

### Finding 3 now has an owner

The restart gap (`seedAlivePIDs` deletes the dead-PID rows this feature creates,
and #1798's `SessionError` does not survive a restart either) was reported
independently by #1799 and is filed as **#1815**. Not implemented here; the code
references it at both sites that assume the verdict persists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Review round (Phase 5)

A `high`-effort review subagent returned **8 findings**. All applied.

**One real defect.** The daemon-error banner re-announced itself to a screen reader roughly **every 30 seconds, forever**. The silent-channel fault carried `TurnsSinceReceipt` in its `Detail`, and that counter climbs on every turn boundary for as long as the channel stays dead - so the client's `bannerKey` changed on every rehydrate poll and rebuilt a `role="alert"` element that is aria-atomic. The guard I wrote to prevent nagging was defeated by the payload it was guarding. The counter is gone from the fault; it stays in `hooks.json`, where a monotonic debugging number belongs.

**Two of my own tests passed for the wrong reason**, both proven by the reviewer's mutations:
- `TestDaemonErrors_OrderIsStable` called `DaemonErrors` 21 times on **one fixed input** and compared the runs - which Go slices satisfy whether or not the sort exists. It passed with `sort.SliceStable` deleted. It now permutes the snapshot, and asserts the permutation genuinely differs before comparing.
- The placement of `renderDaemonErrorBanner` *before* `rehydratePoll`'s structure branch was argued at length in a comment and **covered by nothing**: moving the call inside either branch left all 247 tests green while leaving an alert banner up forever.

Each fix is verified red under the exact mutation that exposed it:

```
--- FAIL: TestDaemonErrors_NoFieldMovesWhileTheFaultStands
    a standing fault changed while nothing about it did:
     at turn 3:  ...,"detail":"3 completed turns with no receipt"}...
     at turn 97: ...,"detail":"97 completed turns with no receipt"}...

--- FAIL: TestDaemonErrors_OrderIsStable
    run 1 (reversed=true) differs from the baseline

     × the rehydrate poll clears the banner when the fault is fixed
      Tests  1 failed | 247 passed (248)
```

**Four claims that were not true** - each fixed at the source: `events.md` still documented `subagentSummary` as three buckets; `docs/relay-protocol.md` did not say the relay drops `daemon_errors`; `pruneStateProjects` said "all three canonical state keys"; a CSS comment named the wrong test file.

**`HasWorkInFlight`'s doc claimed every other site "was checked" but named four of six.** The reviewer verified the two unnamed ones independently and both are safe; they are now named with their reasons. It also found the one thing the doc genuinely owed: **the hold this creates needs a bound.** `reapStaleChild` releases the parent after `orphanTranscriptAge`, **except for DB-backed children** (`?session=` - hermes, opencode, antigravity), which are exempt from that sweep. Latent rather than live, since no adapter emits `SessionError` yet, and now written down as #1799/#1800's to bound.

**Out of scope, reported not fixed:** the macOS activity matrix has its own fixed three-state list and will drop the `error` bucket this PR now emits. That is #1802's file (PR #1810), untouched here.

## Cross-platform red - checked, not assumed

#1802's PR #1810 declares `static let error = "#FF3B30"` - identical to this branch's dark `--error`, and to the existing `IrrHex.wsDisconnected` the pairing test falls back to. **Both branches of that fallback agree today, so the test passes either side of that merge.** Verified by running the test's own regexes over `git show pr1810:platforms/macos/Irrlicht/Theme/Tokens.swift`, and recorded in the test rather than left as an assumption.

The light halves diverge by design and are deliberately not compared: this branch overrides `--error` to `#CC0C00`, while #1810 keeps `IrrHex.error` as the base hue and re-tunes only the pill *text* via `Color.adaptive(light: "#C1121C", dark: "#FF7A70")`. Both clear AA against their own platform's surface, which is a different colour on each. Encouragingly, #1810 independently measured the same failure on the raw hue (`light 3.02:1` against its wash; this branch measured `3.01:1` against the web's).

## Complexity (CodeScene - advisory, not a merge gate)

This PR's own regressions, addressed at the source rather than suppressed:

| | before | after |
|---|---|---|
| `concurrency_tracker.go` | 8.96 → **8.27** | 8.96 → **8.85** |
| `daemon_errors.go` | 9.61 | **9.92** |
| `platforms/web/irrlicht.js` | 3.11 → **2.99** | 3.11 → **3.05** |

Via `bucketTransitionCounts`, `appendInstantsInWindow`, `newDurationBuckets`, `entryFault`/`channelFault`, `retryLadderText`, `daemonErrorList`.

Stopped there deliberately. What remains is test files - where splitting a table-driven test would obscure it to move a number - and `runDaemon`, a pre-existing large function this PR adds **one line** to (`8.31 → 8.31`, unchanged). Four files still show a net **improvement**: `session_detector_subagent.go`, `history_state_endpoint_test.go`, `grouped.go`, `historyTab.js`.

## Final gate run

All nine `tools/preflight.sh --only` groups re-run in the foreground after the fixes, all **PASS**: `go` `web` `arch` `tools` `skills` `posix` `bash` `security` `swift`. `go vet ./core/...` clean. ARS composite 7.9005 → 7.8995 (no regression flagged). On CI, every expected check present and green on the final head: `go-test`, `ars-gate`, `build-test`, `swift-test`, `swift-build`, and both `web-test.yml` trees.

---

## Rebase round — both siblings landed

Rebased twice, cleanly, onto `b2e01f71` (#1810, macOS) then `6bb5d1cc` (#1811, claude-code + copilot adapters).

**#1811 overlaps one file** — `core/ports/outbound/ports.go` — in a different region (it adds `IngestTurnBoundary` to `MetricsCollector`; this branch adds `NewStateBuckets` beside `StateSeriesResult`). Both present after the merge, verified. No semantic reconciliation needed.

**#1811 changes what this PR is.** It lands the first real producers of `SessionError`, so the partition fix here is no longer latent: a child that is genuinely mid-retry can now reach `hasActiveChildren` in production. The bug this PR fixes became reachable in the same hour it was fixed.

**Colour, re-checked against what actually landed rather than against #1810's branch:**

| | value |
|---|---|
| `tools/irrlicht-design-system/colors_and_type.css` `--error` | `#FF3B30` |
| `IrrHex.error` | `#FF3B30` |
| this branch's dark `--error` | `#FF3B30` |
| design-system `--error-dim` | `rgba(255, 59, 48, 0.12)` |
| this branch's dark `--error-dim` | `rgba(255, 59, 48, 0.12)` |

Exact match on both, so nothing was added to `colors_and_type.css` and there was no conflict to resolve. The light-theme value stays this branch's own measured `#CC0C00`, because the raw hue fails AA on a light surface — measured here at **3.01:1**, which is the same failure #1810 measured at 3.02:1 against its own surface and solved differently (it re-tunes the pill *text* via `Color.adaptive`; the web overrides the token).

**The pairing test is now strict.** While #1810 was in flight it fell back to `IrrHex.wsDisconnected` (same red) so it would pass either side of the merge. With the real token on `main` that fallback became a liability — a *deleted* `IrrHex.error` would have silently downgraded the test to checking a different constant. Removed. Verified red both ways:

```
macOS picks a different red  ->  expected '#ff3b30' to be '#d70015'
IrrHex.error deleted         ->  no IrrHex.error found in Tokens.swift
```

## The field-path check #1810 needed

#1810's merge blocker was a decoder reading a top-level `error` key the daemon does not emit — it would have rendered a fallback string forever while looking like working code, and every hand-written fixture agreed with it because the same author wrote both.

This branch's renderer reads `agent.metrics.session_error`, and that is now asserted **against the Go struct tags rather than against a fixture**: the path and its `omitempty`, every key `sessionErrorText` touches, and the phase strings `hasWorkInFlight` branches on. Verified red under the same defect:

```
session_error -> error   ->  expected 'error' to be 'session_error'
retry_in_ms renamed      ->  the renderer reads "retry_in_ms" but the daemon does not emit it
```

Each extraction asserts it found something before comparing, so a stale regex fails loudly instead of checking an empty set.

**Not taken on:** the `error`-does-not-survive-a-daemon-restart gap is issue **#1815** with its own owner.

**Third rebase:** `308d4b98` (#1813, the remaining adapters) also landed, cleanly and with no file overlap. The branch is level with `main` (0 commits behind) and all nine local gates plus every CI check were re-run green on that base.

Final CodeScene (advisory) state: hotspot declines **2 → 1**, critical **4 → 3 files**, advisory **8 → 6**, and 4 files still net-improved. The one remaining hotspot is `runDaemon`, a pre-existing large function this PR adds a single line to (`8.31 → 8.31`).
