### PR TITLE
docs(states): retire the "three states only" claim and add an enumeration tripwire

### DIFF
--- a/.claude/skills/ir:agent-releases/references/monitoring-surface.md
+++ b/.claude/skills/ir:agent-releases/references/monitoring-surface.md
@@ -1,6 +1,6 @@
 # Irrlicht Monitoring Surface
 
-Irrlicht is a daemon that monitors coding agent sessions. It watches transcript files and processes to classify sessions into 3 states: **working**, **waiting**, **ready**. Any upstream agent change that alters the items below can break detection.
+Irrlicht is a daemon that monitors coding agent sessions. It watches transcript files and processes to classify sessions into the states declared by `session.CanonicalStates()` (`core/domain/session/session.go`) — currently **working**, **waiting**, **ready**, **error**. Any upstream agent change that alters the items below can break detection.
 
 This file exists to brief a release-sweep analysis (`/ir:agent-releases`) on what it should actually look for. It covers all twelve sections irrlicht ships: the **eleven agent adapters** in `core/adapters/inbound/agents/` (`all.go`'s `All()` — claude-code, codex, pi, aider, opencode, kiro-cli, gemini-cli, antigravity, mistral-vibe, copilot, hermes) **plus the Gas Town orchestrator**, which is a different layer entirely (`core/adapters/inbound/orchestrators/gastown` — it polls a CLI, has no `Source` variant, and so is absent from the discovery table below).
 

--- a/.claude/skills/ir:code-review/SKILL.md
+++ b/.claude/skills/ir:code-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ir:code-review
-description: Review a working diff for defects and report findings worst-first — the repo-owned, agent-invocable counterpart to the built-in `/code-review`, which is `disable-model-invocation` and can only be run by a human. Scales from a single read to an adversarially-verified pass, and checks this repo's own conventions (three-state model, hexagonal layering, permission gating, defect-tests-seen-red) on top of ordinary correctness. Invoked as `/ir:code-review [effort] [base]`. Triggers on "/ir:code-review", "review the diff", "review my changes", "review this branch", or when `ir:exec` Phase 5 reaches its review gate.
+description: Review a working diff for defects and report findings worst-first — the repo-owned, agent-invocable counterpart to the built-in `/code-review`, which is `disable-model-invocation` and can only be run by a human. Scales from a single read to an adversarially-verified pass, and checks this repo's own conventions (the derived session-state vocabulary, hexagonal layering, permission gating, defect-tests-seen-red) on top of ordinary correctness. Invoked as `/ir:code-review [effort] [base]`. Triggers on "/ir:code-review", "review the diff", "review my changes", "review this branch", or when `ir:exec` Phase 5 reaches its review gate.
 ---
 
 # Review the Working Diff
@@ -77,7 +77,13 @@ Defects first — this skill hunts bugs. Quality cleanups are secondary here
   state, aliasing of returned structs), resource leaks, boundary conditions.
 - **Repo conventions** (`AGENTS.md` Key Conventions — a break here is a real
   finding, not a nit):
-  - Three session states only — `working`, `waiting`, `ready`. No cancelled state.
+  - The session-state vocabulary is `session.CanonicalStates()` and nothing else —
+    a call site that retypes the list has become a second source of truth. No
+    cancelled state (cancellation maps to `ready`). Watch for enumerations that
+    were complete under an older vocabulary: a `case` arm, a `switch`, a format
+    string or a doc line naming some-but-not-all states is the shape that shipped
+    four separate defects in #1796. `tools/state-vocabulary-lint.sh` catches the
+    single-line ones; a partition split across lines is yours to catch.
   - Hexagonal import direction: `domain/` → `ports/` → `adapters/` →
     `application/services/`. `domain/` and `ports/` must not import outward;
     `application/services/` reaches `adapters/inbound/` only through `ports/`.

--- a/.claude/skills/ir:doc-review/references/inventory-sources.md
+++ b/.claude/skills/ir:doc-review/references/inventory-sources.md
@@ -106,14 +106,28 @@ Public API routes are the `/api/v1/*` set; `/debug/pprof/*` and `/state` are int
 
 **Documented mention** = the route appears in `site/docs/api-reference.html`.
 
-## 5. Session states (exactly 3) and lifecycle events
+## 5. Session states and lifecycle events
 
-Authoritative states: `core/domain/session/session.go`.
+Authoritative states: `core/domain/session/session.go`, whose `canonicalStates` slice is the
+single declaration everything else derives from.
 
 ```bash
-grep -oE 'State(Working|Waiting|Ready)\s*=\s*"[a-z]+"' core/domain/session/session.go
-# → working / waiting / ready  (the count "three" is checkable here)
+# Read the slice, then resolve each constant — do NOT grep for the state names,
+# which is the hand-copied vocabulary this section exists to check against.
+# A pattern naming the constants would go stale the same day the docs did: the
+# previous version of this command matched only Working/Waiting/Ready and so
+# reported "three" for a year after a fourth state shipped.
+sed -n 's/.*canonicalStates *= *\[\]string{\([^}]*\)}.*/\1/p' core/domain/session/session.go
+# → StateWorking, StateWaiting, StateReady, StateError   (the count is len(that list))
 ```
+
+`tools/state-vocabulary-lint.sh --list` derives the same vocabulary and prints every
+single-line site in the repo that names some-but-not-all of it — a ready-made worklist
+for this axis.
+
+`unknown` is **not** in that list and must not be counted: `platforms/macos` and
+`platforms/web` each carry an `unknown` rendering fallback for a value a newer daemon
+might send (#1797), which the daemon itself never emits.
 
 Authoritative event kinds: `core/domain/lifecycle/event.go`.
 
@@ -122,8 +136,9 @@ grep -oE 'Kind[A-Za-z]+\s+Kind\s+=\s+"[a-z_]+"' core/domain/lifecycle/event.go
 ```
 
 **Documented mention** = states/events described in `events.md`, `site/docs/state-machine.html`,
-`site/docs/session-detection.html`. The literal claim "three states" must equal the count above
-(axis V, V2).
+`site/docs/light-system.html`. Any stated count, and any closed enumeration of the states, must
+equal the vocabulary above (axis V, V2). `site/docs/session-detection.html` was named here until
+#1804 and no longer belongs: its "three complementary methods" is about *detection*, not states.
 
 ## 6. Relay wire protocol
 

--- a/.claude/skills/ir:doc-review/references/rubric.md
+++ b/.claude/skills/ir:doc-review/references/rubric.md
@@ -66,8 +66,11 @@ mentions.
 
 - **V1 — References resolve.** Every file path, directory, symbol/function name, command, and
   flag a doc names exists in the repo / `--help`. FAIL = the reference + why it doesn't resolve.
-- **V2 — Counts/enumerations match.** Stated numbers ("supports N agents", "three states",
+- **V2 — Counts/enumerations match.** Stated numbers ("supports N agents", "N session states",
   ports, durations, versions) equal the code-derived value. FAIL = stated vs actual.
+  A *closed enumeration* ("the states are X, Y and Z") is a count in prose and is
+  graded the same way — the shape most likely to be stale, because it was correct
+  when it was written and nothing re-reads it.
 - **V3 — Internal links/anchors resolve.** Markdown/HTML internal links and anchors resolve.
   External links are checked and reported (4xx/5xx) but are **never blocking and never raise a
   Critical/Major** — at most a Nit. FAIL (internal) = the broken link/anchor.
@@ -151,8 +154,9 @@ boundary; recompute against the live tree each run.
   route named with no example or no response shape.
 - **V1** — PASS: a doc cites `core/cmd/irrlichd/main.go` and it exists. FAIL: a doc references
   `core/cmd/irrlicht-watch/` which does not exist.
-- **V2** — PASS: "three session states" equals the 3 constants in `session.go`. FAIL: "supports
-  6 agents" while `All()` returns 7.
+- **V2** — PASS: a stated session-state count equals `len(session.CanonicalStates())`. FAIL:
+  "three session states" while that slice holds four; FAIL: "supports 6 agents" while `All()`
+  returns 7.
 - **V3** — PASS: an in-page anchor that resolves. FAIL: a relative link to a renamed/missing file.
 - **V4** — PASS: `CONTRIBUTING.md` and `site/docs/contributing.html` describe the same PR flow.
   FAIL: README says "squash and delete branch" while the site says "merge commit".
@@ -173,9 +177,19 @@ adding noise that careful readers wouldn't.
   only on a genuine mismatch (a frame type in the doc absent from `envelope.go`, or vice versa).
 - **`+`-suffixed dev versions.** `0.5.1+abc1234.dirty` is the documented dev-build format
   (`tools/version.sh`), not a stale-version drift from `version.json`'s `0.5.1`.
-- **Three-states intentionally excludes "cancelled".** Docs stating exactly three states
-  (working/waiting/ready) are correct; cancellation maps to `ready` by design. Do not "complete"
-  the list with a fourth state.
+- **"cancelled" is not a state, but `error` is.** Cancellation maps to `ready` by design, so a
+  doc that omits `cancelled` is correct and must not be "completed" with it. That exemption
+  covers `cancelled` and nothing else: since #1796 the vocabulary is four values, and a doc
+  still claiming three **is** a V2 finding. Derive the list from `session.CanonicalStates()`
+  (`core/domain/session/session.go`) rather than from this bullet, which is exactly the kind of
+  hand-copied vocabulary the axis exists to catch — it asserted "three" for a year after that
+  stopped being true.
+- **`unknown` is a client-side fallback, not a state.** `platforms/macos`' `SessionState.State`
+  and `platforms/web`'s icon map both carry an `unknown` case so an unrecognised value from a
+  newer daemon renders neutrally instead of green (#1797). The daemon never emits it. A doc that
+  omits `unknown` from the state list is **correct**; documenting it as a fifth state is a
+  finding in the other direction. The macOS menu bar's five-way precedence
+  (`error > waiting > working > ready > unknown`) is a rendering order, not the domain.
 - **`CLAUDE.md` → `AGENTS.md`.** `CLAUDE.md` intentionally just includes `AGENTS.md`; its
   brevity is not a U1/C-axis gap.
 - **Internal/dev tools.** Missing docs for `tools/onboarding-factory/cmd/*` (`of`, `viewer`,

--- a/.claude/skills/ir:exec/SKILL.md
+++ b/.claude/skills/ir:exec/SKILL.md
@@ -382,7 +382,7 @@ Nobody is gating on the plan, so skip the HTML artifact and the wait entirely:
     - If the work is complex/multi-part, break it into tasks with `TaskCreate` and work
       them in order (as you naturally would). For a small change, just implement it.
     - Follow the repo's conventions (AGENTS.md): surgical changes, match surrounding
-      style, three-state model, hexagonal layering, etc.
+      style, the derived session-state vocabulary, hexagonal layering, etc.
 11. **Verify** before declaring done. Run **`tools/preflight.sh`** — the Local CI
     parity gate (AGENTS.md's "Local CI parity" section) that mirrors every
     PR-gating check (test.yml + web-test.yml + ars-gate.yml + linux.yml's

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -38,4 +38,6 @@ Thanks for the PR! A few notes before you submit:
 - [ ] Commit messages use [Conventional Commits](https://www.conventionalcommits.org/)
 - [ ] No new abstractions added ahead of need
 - [ ] Documentation updated if behavior changed (README, `site/docs/`, or `events.md`)
-- [ ] No `cancelled` session state introduced — three states only: `working`, `waiting`, `ready`
+- [ ] No `cancelled` session state introduced — cancellation maps to `ready`. The
+      lifecycle vocabulary is `session.CanonicalStates()`; a new state is added there,
+      never by retyping the list at a call site

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -96,6 +96,45 @@ jobs:
       - name: Test the bash-lint gate
         run: bash tools/lib/bash-lint_test.sh
 
+      # STATE-VOCABULARY gate (#1804) — the third repo-wide lint in this job,
+      # and it is here for the reason the two above are here rather than for
+      # their host-specific one. posix-lint and bash-lint need ubuntu (dash as
+      # a real /bin/sh; an image that ships shellcheck). This one needs nothing
+      # the macos image lacks — it needs a JOB AT ALL, which it did not have:
+      # until now `tools/state-vocabulary-lint.sh` was reachable only through
+      # tools/preflight.sh's `tools` gate, i.e. only through the pre-push hook.
+      #
+      # ONE STEP, NOT TWO, and the asymmetry with the pairs above is
+      # deliberate. Their unit tests are in this file because they need
+      # shellcheck; this gate's tests
+      # (tools/lib/state-vocabulary-lint_test.sh) need nothing, so they are
+      # already picked up by test.yml's `tools/lib/*_test.sh` loop. What was
+      # missing was never the tests — CI proved the lint WORKS — it was the
+      # lint actually reading the repo. Nothing proved the repo PASSES it.
+      #
+      # That is the same argument test.yml makes over its shell-lib loop: a
+      # check whose only local gate is the pre-push hook rides on a gate that
+      # `git push --no-verify` disables. Not hypothetical — the PR that added
+      # this step was itself pushed with --no-verify, because the hook's 540s
+      # budget kills the Swift gate. A gate reachable only through a hook
+      # people routinely disable is a gate that drifts, and this one exists to
+      # catch the enumeration class that produced four separate defects in
+      # #1796.
+      #
+      # CI runs the same script preflight's `tools` gate runs, so the two judge
+      # a run by one implementation rather than by two that can disagree — the
+      # reason test.yml and macos-swift.yml both give for sharing their
+      # runners.
+      #
+      # Incidental benefit of running it here: this is the only place the
+      # matcher meets a NON-macOS awk (mawk or gawk, not BWK awk). An awk that
+      # matched differently could not fail quietly — under-matching retires
+      # waivers, and a waiver that matches no site is itself an error — so the
+      # gate's two-directional waiver check doubles as a cross-awk conformance
+      # check for free.
+      - name: Lint the session-state vocabulary
+        run: tools/state-vocabulary-lint.sh
+
       - name: Set up Go
         uses: actions/setup-go@v7
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -143,6 +143,15 @@ Before marking a ticket done, run the full suite — every layer must pass:
   are two independent suites, each with its own `node_modules`. Runs
   `vitest run`. **Never `npm install`** (rewrites `package-lock.json`) —
   use `npm ci`.
+- State vocabulary: `tools/state-vocabulary-lint.sh` (#1804) flags any single
+  line naming three-or-more-but-not-all of `session.CanonicalStates()` — the
+  hand-typed enumeration that is complete when written and silently stale one
+  state later (#1796 shipped four such defects). Sites that name a proper
+  subset on purpose live in `tools/state-vocabulary-lint.waivers` with a
+  reason, and a waiver that stops matching fails too. It reads one line at a
+  time, so a partition split across lines — a `switch` with two arms and a
+  `default` — is invisible to it: it complements review rather than replacing
+  it. `tools/lib/state-vocabulary-lint_test.sh` carries the mutation fixtures.
 - Skill files: `tools/skill-lint.sh` (`.claude/skills/**/*.md`). AGENTS.md's
   own 400-line budget (#1742 — this file is force-injected into every agent
   session via CLAUDE.md's `@AGENTS.md` import, so it never gets to just grow):

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ curl -fsSL https://irrlicht.io/install.sh | sh
 
 ## What it does
 
-- **Three-state menu-bar dot per session** — 🟣 working, 🟠 waiting, 🟢 ready
+- **A menu-bar dot per session** — 🟣 working, 🟠 waiting, 🟢 ready, 🔴 error
 - **Context-pressure gauge** — 🟢 → 🟡 → 🔴 → ⚠️ before the auto-compact cliff, so you can `/compact` while quality is still intact
 - **Live per-session cost in USD** — model-aware via LiteLLM pricing
 - **History view** — spend over time with projection, attribution by project / branch / model, a productive-vs-reverted yield ratio, DORA metrics, and an Activity Matrix of working/waiting/ready agent counts per project (macOS app + web dashboard)

--- a/core/adapters/inbound/agents/geminicli/hookinstaller.go
+++ b/core/adapters/inbound/agents/geminicli/hookinstaller.go
@@ -127,7 +127,7 @@ var hookEventSince = map[string]string{
 //     information as a real, narrow signal instead.
 //   - SessionStart/SessionEnd/PreCompress/BeforeModel/AfterModel/
 //     BeforeToolSelection are excluded on evidence: none of them has a
-//     stated payoff for irrlicht's three-state model (working/waiting/ready)
+//     stated payoff for irrlicht's lifecycle state model
 //     beyond what process discovery and transcript tailing already give, and
 //     BeforeModel/AfterModel additionally carry full LLM request/response
 //     bodies — blast radius with no offsetting benefit. SessionStart and

--- a/core/adapters/inbound/agents/kirocli/hookinstaller.go
+++ b/core/adapters/inbound/agents/kirocli/hookinstaller.go
@@ -174,8 +174,8 @@ var hookEventSince = map[string]string{
 //   - userPromptSubmit is excluded on the same evidence copilot's and
 //     gemini-cli's analogous exclusions cite: the transcript's own turn-
 //     opening event (a "Prompt"-kind line, parser.go) already opens the turn,
-//     so a hook duplicating that signal buys nothing irrlicht's three-state
-//     model needs.
+//     so a hook duplicating that signal buys nothing irrlicht's lifecycle
+//     state model needs.
 var installedHookEvents = []string{
 	HookPostToolUse,
 	HookStop,

--- a/core/adapters/inbound/agents/opencode/hookinstaller.go
+++ b/core/adapters/inbound/agents/opencode/hookinstaller.go
@@ -138,7 +138,7 @@ const (
 //     rejected for the reason copilot's, gemini-cli's and pi's analogous
 //     exclusions cite: the store's own rows already open the turn — the
 //     watcher emits EventActivity off new `part` rows — so a hook duplicating
-//     it buys nothing irrlicht's three-state model needs, at the cost of a
+//     it buys nothing irrlicht's lifecycle state model needs, at the cost of a
 //     process spawn per turn.
 //
 //   - `tool.execute.before` / `tool.execute.after` were considered as the

--- a/core/adapters/inbound/agents/pi/extension.js
+++ b/core/adapters/inbound/agents/pi/extension.js
@@ -49,7 +49,7 @@ const IRRLICHT_BEACON = "__IRRLICHT_BEACON_COMMAND__";
 // The single pi lifecycle event this extension subscribes to. agent_settled
 // means "pi will not continue running automatically" — no retry, no
 // auto-compaction, no queued follow-up left — which is the authoritative
-// turn-end signal irrlicht's three-state model wants, and which pi's
+// turn-end signal irrlicht's lifecycle state model wants, and which pi's
 // transcript alone only implies.
 const IRRLICHT_EVENT = "agent_settled";
 

--- a/core/adapters/inbound/agents/pi/hookinstaller.go
+++ b/core/adapters/inbound/agents/pi/hookinstaller.go
@@ -119,7 +119,7 @@ const HookEventAgentSettled = "agent_settled"
 //     excluded on the same evidence copilot's, gemini-cli's and kiro-cli's
 //     analogous exclusions cite: the transcript's own lines already open the
 //     turn and already record the session, so a hook duplicating them buys
-//     nothing irrlicht's three-state model needs, at the cost of a process
+//     nothing irrlicht's lifecycle state model needs, at the cost of a process
 //     spawn each.
 //
 //   - project_trust is pi's ONE genuine blocked-on-user prompt and is

--- a/core/adapters/outbound/filesystem/concurrency_tracker.go
+++ b/core/adapters/outbound/filesystem/concurrency_tracker.go
@@ -139,8 +139,8 @@ type interval struct {
 
 // concurrencyActive reports whether a state counts toward concurrency: an agent
 // is "concurrent" while working or waiting, and stops once it goes ready
-// (process exited / cancelled / transcript removed) — the three-state model
-// read literally (#751).
+// (process exited / cancelled / transcript removed) — #751 read literally,
+// back when those three were the whole vocabulary.
 //
 // `error` is NOT active, and that is a settled decision rather than an
 // oversight of #1798's fourth state (events.md; #1801). Nothing clears a

--- a/core/application/services/state_classifier.go
+++ b/core/application/services/state_classifier.go
@@ -1,6 +1,7 @@
 // StateClassifier provides pure functions for session state classification.
-// These functions encapsulate the decision tree used to determine whether a
-// session is working, waiting, or ready based on transcript metrics.
+// These functions encapsulate the decision tree that maps transcript metrics
+// onto one of session.CanonicalStates() — see events.md for the tree itself
+// and for why the failure branch is evaluated above the activity branch.
 package services
 
 import (

--- a/core/cmd/irrlichd/handlers.go
+++ b/core/cmd/irrlichd/handlers.go
@@ -630,10 +630,14 @@ func serveHistoryAgentsChart(w http.ResponseWriter, concurrency outbound.Concurr
 	writeHistoryJSON(w, buildAgentsResponse(rangeKey, scopeEcho, cr))
 }
 
-// serveHistoryStateChart serves chart=state (#981): a per-project,
-// per-state (working/waiting/ready) series reconstructed from lifecycle
-// recordings via ConcurrencyReader.StateSeries — AgentsSeries' per-state
-// counterpart. A nil reader or an unresolved recordings dir yields an
+// serveHistoryStateChart serves chart=state (#981): a per-project, per-state
+// series reconstructed from lifecycle recordings via
+// ConcurrencyReader.StateSeries — AgentsSeries' per-state counterpart.
+//
+// One bucket per canonical state, and the key set is DERIVED
+// (outbound.NewStateBuckets, below) rather than fixed at three: unlike the
+// history bar's 2-bit strip, this payload is a map with no encoding limit, so
+// it has carried `error` since #1801. A nil reader or an unresolved recordings dir yields an
 // empty-but-valid payload rather than an error, mirroring
 // serveHistoryAgentsChart.
 func serveHistoryStateChart(w http.ResponseWriter, concurrency outbound.ConcurrencyReader, rangeKey, scopeEcho string, query outbound.SeriesQuery) {

--- a/core/ports/outbound/ports.go
+++ b/core/ports/outbound/ports.go
@@ -405,7 +405,8 @@ type ConcurrencyReader interface {
 	AgentsSeries(q SeriesQuery) (*ConcurrencyResult, error)
 	// StateSeries is AgentsSeries' per-state counterpart (issue #981): where
 	// AgentsSeries merges working+waiting into one "active" count, StateSeries
-	// keeps the three states separate — see StateSeriesResult.
+	// keeps one bucket per canonical state — see StateSeriesResult, whose key
+	// set NewStateBuckets derives from session.CanonicalStates().
 	StateSeries(q SeriesQuery) (*StateSeriesResult, error)
 }
 

--- a/events.md
+++ b/events.md
@@ -29,11 +29,25 @@ would report a failed session as `ready` -- green, and silent.
 
 ### Leaving `error`
 
-The next SUCCESSFUL turn clears it, and nothing else does -- no timeout, no
-minimum hold:
+Two edges, and they clear the failure on different conditions. Neither is a
+timeout and neither has a minimum hold (`clearSessionErrorOnRecovery`, in the
+tailer):
 
-- `error -> working` when the next turn starts
-- `error -> ready` on `turn_done`
+- `error -> working` when the user's next message arrives. This clears the
+  sticky error IMMEDIATELY and UNCONDITIONALLY -- the function returns on
+  `StartsNewUserTurn` before it examines the failure at all. A user who has
+  typed again has moved on, and holding the previous turn's failure against the
+  new one would pin the session red for the rest of its life.
+- `error -> ready` on `turn_done`, but ONLY for a failure whose phase is
+  `retrying` (`SessionError.ClearedByTurnBoundary`). A terminal failure is not
+  retired by a turn boundary.
+
+A process that died mid-turn is recorded as TERMINAL -- the one producer for
+which `retrying` is impossible, since a process that exited will not try again
+-- so NEITHER edge above applies to it. Its row is kept in `error` for
+`processDeathRetention` (12h) and then reaped. That ceiling holds only within a
+single daemon run; a restart inside the window reaps the row instead of showing
+it (#1815 owns that gap).
 
 Known and accepted: with no minimum hold, a provider error that recovers in a
 few hundred milliseconds can enter and leave `error` inside one poll interval
@@ -95,11 +109,31 @@ These transitions change the lifecycle state of an existing session.
 | AskUserQuestion tool opened | `working` | `waiting` | Tool use in transcript | `NeedsUserAttention()=true` |
 | ExitPlanMode tool opened | `working` | `waiting` | Tool use in transcript | `NeedsUserAttention()=true` |
 | User answers question / approves plan | `waiting` | `working` | Tool result in transcript | `NeedsUserAttention()=false` |
+| Provider refuses or fails the call, or credentials are rejected | `working` | `error` | Adapter parses a session-level failure out of the transcript | classifier rule `session error -> error`, signal `SignalSessionError`. The transcript path places NO hold -- the sticky error reaches the classifier through the tailer's own metrics; the signal names the rule's tier |
+| Agent process dies mid-turn | `working` | `error` | Process exit with no turn-end in sight | `SignalProcessDeath` hold, raised by `SessionDetector.retainAsProcessDeath` -- the row is RETAINED rather than deleted, unlike every process-exit row in the lifecycle table above; classifier rule `agent process died mid-turn -> error` |
+| User sends the next message after a failure | `error` | `working` | Transcript write | `clearSessionErrorOnRecovery` clears the failure on the message itself, before the turn's outcome is known |
+| A RETRYING failure's next turn completes | `error` | `ready` | `turn_done` | `clearSessionErrorOnRecovery`, gated on `ClearedByTurnBoundary` -- a terminal failure stays `error` |
 
 ### Impossible Transitions
 
 - `ready` -> `waiting`: Cannot skip `working`; any activity goes through `working` first
 - `waiting` -> `ready` (via content): Agent cannot finish while a blocking tool is open; only process exit clears it (as deletion)
+
+Both bullets predate `error` and constrain only the three original states. **No
+impossibility is asserted about `error` in either direction** -- its edges are
+the two in "Leaving `error`" above. If a genuine `error` impossibility is ever
+established it belongs here; do not infer one from this list's silence.
+
+**`error` vs `waiting` is decided per producer, not once.** The classifier is a
+ladder and the two error rules sit on opposite sides of the waiting rules:
+
+- `process_death` is ABOVE them. A process killed while `AskUserQuestion` was
+  open leaves that call open forever, so `user_blocking_tool` would keep firing
+  and keep painting a dead session `waiting` -- and sending a user to answer a
+  question in a process that no longer exists is worse than saying nothing.
+  Pinned by `TestProcessDeath_OutranksAFrozenWaitingTranscript`.
+- `session_error` (the transcript path) is BELOW them, so a live session that
+  hit a provider failure and then opened a blocking tool does read `waiting`.
 
 ---
 

--- a/site/docs/adapters.html
+++ b/site/docs/adapters.html
@@ -561,7 +561,7 @@ type Watcher interface {
         <li>Adapter package at <code>core/adapters/inbound/agents/&lt;name&gt;/</code></li>
         <li>Exports an <code>agent.Agent</code> from <code>Agent()</code> with the right <code>Source</code> variant (<code>FilesUnderRoot</code> / <code>FilesUnderCWD</code> / <code>ProcessOwnedStore</code>), parser, and PID-discovery hook</li>
         <li>Registered in the <code>allAgents</code> slice in <code>core/cmd/irrlichd/main.go</code></li>
-        <li>Emits all three lifecycle states: <code>working</code>, <code>waiting</code>, <code>ready</code></li>
+        <li>Emits the ordinary lifecycle states: <code>working</code>, <code>waiting</code>, <code>ready</code> (<code>error</code> additionally requires a failure signal the adapter can parse)</li>
         <li>Scenario cells assessed via the <code>assess</code> verb of <code>/ir:onboarding-factory</code>, recorded in <code>replaydata/agents/&lt;name&gt;/scenarios/&lt;cell&gt;/metadata.json</code></li>
         <li><strong>Machine-checked (#1369):</strong> the four <em>alpha-floor</em> core scenarios are settled &mdash; <code>session-start</code>, <code>basic-turn</code>, <code>auto-executed-tool-call</code>, <code>turn-end-terminal-text</code>. All four are reachable from lifecycle hooks alone, which is what makes <code>alpha</code> a day-one tier for an adapter that has hooks and no transcript parser: it asserts <strong>state only, no metrics</strong>.</li>
         <li>An entry in <code>replaydata/agents/adapters.json</code> declaring this maturity and any missing capabilities. <code>of validate</code> fails if the claim exceeds what the core scenarios earn.</li>

--- a/site/docs/api-reference.html
+++ b/site/docs/api-reference.html
@@ -114,7 +114,7 @@
           "adapter": "claude-code",
           "project_name": "irrlicht",
           "pid": 12345,
-          "subagents": { "total": 3, "working": 2, "waiting": 0, "ready": 1 },
+          "subagents": { "total": 3, "working": 2, "waiting": 0, "ready": 1, "error": 0 },
           "children": [
             {
               "session_id": "agent-a1cad...",
@@ -137,7 +137,7 @@
 
       <h3>GET /state</h3>
 
-      <p>Human-readable state summary. Shows count of working, waiting, and ready sessions, plus the total session count.</p>
+      <p>Human-readable state summary. Returns <code>sessionCount</code> plus one count per lifecycle state &mdash; <code>workingCount</code>, <code>waitingCount</code>, <code>readyCount</code>, <code>errorCount</code>.</p>
 
       <h3>GET /api/v1/sessions/stream</h3>
 
@@ -226,7 +226,7 @@
           <tr>
             <td><code>chart</code></td>
             <td><code>cost</code> (default), <code>tokens</code>, <code>co2</code>, <code>models</code>, <code>providers</code>, <code>agents</code>, <code>state</code>, <code>yield</code>, <code>dora</code></td>
-            <td>Which series to build. <code>models</code> / <code>providers</code> are presets that pin the stacking axis; <code>co2</code> sums the estimated CO2e footprint like <code>cost</code> sums spend; <code>agents</code> returns the concurrent-agents timeline; <code>state</code> returns the per-project, per-state (working/waiting/ready) activity matrix; <code>yield</code> returns the per-project productive-vs-reverted aggregate; <code>dora</code> returns one project's DORA metrics (requires <code>project</code>)</td>
+            <td>Which series to build. <code>models</code> / <code>providers</code> are presets that pin the stacking axis; <code>co2</code> sums the estimated CO2e footprint like <code>cost</code> sums spend; <code>agents</code> returns the concurrent-agents timeline; <code>state</code> returns the per-project, per-state activity matrix; <code>yield</code> returns the per-project productive-vs-reverted aggregate; <code>dora</code> returns one project's DORA metrics (requires <code>project</code>)</td>
           </tr>
           <tr>
             <td><code>group</code></td>
@@ -256,12 +256,12 @@
         </tbody>
       </table>
 
-      <p>The <code>cost</code> / <code>tokens</code> / <code>co2</code> / <code>models</code> / <code>providers</code> / <code>agents</code> charts return a time-series payload (<code>range</code>, <code>chart</code>, <code>group</code>, <code>start</code>, <code>end</code>, <code>bucket_seconds</code>, <code>bucket_starts</code>, <code>total</code>, <code>series</code>, <code>top_contributors</code>, with optional <code>forecast</code>, <code>token_split</code>, and <code>scope</code>). <code>chart=agents</code> swaps in a <code>concurrency</code> block. <code>chart=state</code> is shaped differently &mdash; a dense grid rather than a sparse series &mdash; returning <code>projects</code> (row order, busiest first) and <code>by_state</code> (<code>working</code>/<code>waiting</code>/<code>ready</code>, each a <code>project &rarr; per-bucket array</code> map aligned to <code>bucket_starts</code>), plus the same <code>concurrency</code> block as <code>agents</code> (working+waiting combined). <code>chart=yield</code> returns a per-project shape (<code>productive_cost</code>, <code>reverted_cost</code>, <code>unknown_cost</code>, <code>total_cost</code>, <code>yield</code>, <code>projects</code>). <code>chart=dora</code> returns one project's four metrics (<code>deployment_frequency</code>, <code>lead_time</code>, <code>change_failure_rate</code>, <code>mttr</code>), each with <code>value</code>/<code>unit</code>/<code>sample_size</code>/<code>available</code>. Returns <code>400</code> for an unknown <code>chart</code> / <code>group</code> / <code>token_type</code> / <code>granularity</code> or an invalid range.</p>
+      <p>The <code>cost</code> / <code>tokens</code> / <code>co2</code> / <code>models</code> / <code>providers</code> / <code>agents</code> charts return a time-series payload (<code>range</code>, <code>chart</code>, <code>group</code>, <code>start</code>, <code>end</code>, <code>bucket_seconds</code>, <code>bucket_starts</code>, <code>total</code>, <code>series</code>, <code>top_contributors</code>, with optional <code>forecast</code>, <code>token_split</code>, and <code>scope</code>). <code>chart=agents</code> swaps in a <code>concurrency</code> block. <code>chart=state</code> is shaped differently &mdash; a dense grid rather than a sparse series &mdash; returning <code>projects</code> (row order, busiest first) and <code>by_state</code> (one key per lifecycle state &mdash; <code>working</code>, <code>waiting</code>, <code>ready</code>, <code>error</code> &mdash; each a <code>project &rarr; per-bucket array</code> map aligned to <code>bucket_starts</code>; the key set is built from the daemon's own state vocabulary, so a future state appears here without a client change), plus the same <code>concurrency</code> block as <code>agents</code> (working+waiting combined). <code>chart=yield</code> returns a per-project shape (<code>productive_cost</code>, <code>reverted_cost</code>, <code>unknown_cost</code>, <code>total_cost</code>, <code>yield</code>, <code>projects</code>). <code>chart=dora</code> returns one project's four metrics (<code>deployment_frequency</code>, <code>lead_time</code>, <code>change_failure_rate</code>, <code>mttr</code>), each with <code>value</code>/<code>unit</code>/<code>sample_size</code>/<code>available</code>. Returns <code>400</code> for an unknown <code>chart</code> / <code>group</code> / <code>token_type</code> / <code>granularity</code> or an invalid range.</p>
 
       <pre><code># Weekly cost by project
 curl "http://127.0.0.1:7837/api/v1/history?chart=cost&group=project&range=week" | jq
 
-# Activity Matrix: working/waiting/ready per project, last 24 hourly buckets
+# Activity Matrix: one row per project, one series per state, last 24 hourly buckets
 curl "http://127.0.0.1:7837/api/v1/history?chart=state&granularity=24h" | jq</code></pre>
 
       <h3>GET /api/v1/permissions</h3>
@@ -557,7 +557,7 @@ curl -OJ http://127.0.0.1:7837/debug/bundle</code></pre>
           <tr>
             <td><code>state</code></td>
             <td>string</td>
-            <td><code>working</code>, <code>waiting</code>, or <code>ready</code></td>
+            <td><code>working</code>, <code>waiting</code>, <code>ready</code>, or <code>error</code></td>
           </tr>
           <tr>
             <td><code>adapter</code></td>
@@ -655,8 +655,18 @@ curl -OJ http://127.0.0.1:7837/debug/bundle</code></pre>
             <td>int</td>
             <td>Count of children in <code>ready</code> state</td>
           </tr>
+          <tr>
+            <td><code>error</code></td>
+            <td>int</td>
+            <td>Count of children in <code>error</code> state</td>
+          </tr>
         </tbody>
       </table>
+
+      <p>The per-state counts sum to <code>total</code>: every child lands in exactly one bucket.
+      <code>error</code> was added in #1801 for that reason &mdash; before it, an errored child
+      was counted in <code>total</code> and in none of the buckets, so a red subagent was
+      invisible in the one badge a user checks to find out why a parent is stuck.</p>
 
       <h2>SessionMetrics Schema</h2>
 

--- a/site/docs/architecture.html
+++ b/site/docs/architecture.html
@@ -194,7 +194,7 @@
         <li><strong>Watchers</strong> &mdash; <code>cmd/irrlichd/wiring.go</code> dispatches on each <code>agent.Agent</code>'s <code>Source</code> variant: <code>FilesUnderRoot</code> adapters (Claude Code, Codex, Pi) get a shared fswatcher plus a process scanner; <code>FilesUnderCWD</code> (Aider) and <code>ProcessOwnedStore</code> (OpenCode) adapters get a process scanner only. Every watcher exposes <code>Identity()</code> so per-event adapter naming flows through the merge pipeline rather than being stamped at emit time.</li>
         <li><strong>SessionDetector</strong> &mdash; thin coordinator that delegates to:
           <ul>
-            <li><strong>StateClassifier</strong> &mdash; pure functions for working/waiting/ready transitions</li>
+            <li><strong>StateClassifier</strong> &mdash; pure functions for lifecycle state transitions</li>
             <li><strong>MetadataEnricher</strong> &mdash; git metadata, CWD, model, and metrics resolution</li>
             <li><strong>PIDManager</strong> &mdash; PID discovery with retry/backoff, process exit handling, liveness sweeps, subagent cleanup</li>
           </ul>
@@ -210,7 +210,7 @@
         <li>Inbound adapter emits <code>agent.Event</code></li>
         <li>SessionDetector receives event, creates or updates session</li>
         <li>MetricsCollector computes metrics from transcript</li>
-        <li>State machine determines <span class="badge badge-working">working</span> / <span class="badge badge-waiting">waiting</span> / <span class="badge badge-ready">ready</span></li>
+        <li>State machine determines <span class="badge badge-working">working</span> / <span class="badge badge-waiting">waiting</span> / <span class="badge badge-ready">ready</span> / <span class="badge badge-error">error</span></li>
         <li>PushService broadcasts change via WebSocket</li>
         <li>SessionRepository persists to filesystem</li>
       </ol>

--- a/site/docs/cli-tools.html
+++ b/site/docs/cli-tools.html
@@ -157,7 +157,7 @@ irrlichd --record</code></pre>
         <li><code>--format text|json</code> &mdash; Output format; <code>json</code> emits the same grouped tree as <code>GET /api/v1/sessions</code> (minus cost aggregation)</li>
         <li><code>--yield</code> &mdash; Append two columns after the cost: the yield state and the session's HEAD commit (7 chars)</li>
         <li><code>--id &lt;prefix&gt;</code> &mdash; Filter by session ID prefix (case-insensitive)</li>
-        <li><code>--state working|waiting|ready</code> &mdash; Filter by session state</li>
+        <li><code>--state working|waiting|ready|error</code> &mdash; Filter by session state (the accepted values are the daemon's own vocabulary, so <code>--help</code> is authoritative)</li>
         <li><code>--project &lt;substring&gt;</code> &mdash; Filter by project name (case-insensitive substring)</li>
         <li><code>--adapter &lt;name&gt;</code> &mdash; Filter by <a href="adapters.html">agent adapter</a> (the per-agent integration, e.g. <code>claude-code</code>, <code>codex</code>)</li>
       </ul>

--- a/site/docs/contributing.html
+++ b/site/docs/contributing.html
@@ -339,7 +339,7 @@ test: add table-driven tests for state machine</code></pre>
         <li>Adapter package at <code>core/adapters/inbound/agents/&lt;name&gt;/</code></li>
         <li>Exports an <code>agent.Agent</code> from <code>Agent()</code> with the right <code>Source</code> variant (<code>FilesUnderRoot</code> / <code>FilesUnderCWD</code> / <code>ProcessOwnedStore</code>)</li>
         <li>Registered in the <code>allAgents</code> slice in <code>core/cmd/irrlichd/main.go</code></li>
-        <li>Emits all three lifecycle states (<code>working</code>, <code>waiting</code>, <code>ready</code>)</li>
+        <li>Emits the ordinary lifecycle states (<code>working</code>, <code>waiting</code>, <code>ready</code>); <code>error</code> additionally requires a failure signal the adapter can parse</li>
         <li><code>replaydata/agents/&lt;name&gt;/capabilities.json</code> populated against <code>replaydata/agents/features.json</code></li>
         <li><code>baseline-hello</code> and <code>full-lifecycle-toolcall</code> fixtures committed under <code>replaydata/agents/&lt;name&gt;/scenarios/</code></li>
         <li><code>tools/replay-fixtures.sh</code> green</li>

--- a/site/docs/docs.css
+++ b/site/docs/docs.css
@@ -9,6 +9,9 @@
   --working: #8B5CF6;
   --waiting: #FF9500;
   --ready: #34C759;
+  /* #FF3B30 is the same value the macOS app uses for the error state
+     (platforms/macos/Irrlicht/Theme/Tokens.swift, IrrHex.error). */
+  --error: #FF3B30;
   --text: #c8cdd8;
   --text-dim: #5a6378;
   --text-bright: #e8ecf4;
@@ -308,6 +311,7 @@ body { font-family: 'Outfit', sans-serif; background: var(--bg); color: var(--te
 .badge-working { background: rgba(139,92,246,0.12); color: var(--working); }
 .badge-waiting { background: rgba(255,149,0,0.12); color: var(--waiting); }
 .badge-ready   { background: rgba(52,199,89,0.12); color: var(--ready); }
+.badge-error   { background: rgba(255,59,48,0.12); color: var(--error); }
 
 .badge::before {
   content: '';
@@ -318,6 +322,7 @@ body { font-family: 'Outfit', sans-serif; background: var(--bg); color: var(--te
 .badge-working::before { background: var(--working); }
 .badge-waiting::before { background: var(--waiting); }
 .badge-ready::before   { background: var(--ready); }
+.badge-error::before   { background: var(--error); }
 
 /* ─── Diagram boxes ─── */
 .diagram {

--- a/site/docs/index.html
+++ b/site/docs/index.html
@@ -228,7 +228,7 @@
             <svg width="18" height="18" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.5"><circle cx="10" cy="10" r="3"/><path d="M10 2v3m0 10v3M2 10h3m10 0h3M4.22 4.22l2.12 2.12m7.32 7.32l2.12 2.12M4.22 15.78l2.12-2.12m7.32-7.32l2.12-2.12"/></svg>
           </div>
           <h3>The Light System</h3>
-          <p>How purple, amber, and green map to working, waiting, and ready. The core visual language of Irrlicht.</p>
+          <p>How each light color maps to a session state &mdash; purple, amber, green, red. The core visual language of Irrlicht.</p>
         </a>
 
         <a href="state-machine.html" class="doc-card">
@@ -236,7 +236,7 @@
             <svg width="18" height="18" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.5"><circle cx="6" cy="10" r="3"/><circle cx="14" cy="10" r="3"/><path d="M9 10h2"/></svg>
           </div>
           <h3>State Machine</h3>
-          <p>The three states, their transitions, and how filesystem events drive the session lifecycle.</p>
+          <p>The session states, their transitions, and how filesystem events drive the session lifecycle.</p>
         </a>
 
         <a href="session-detection.html" class="doc-card">

--- a/site/docs/light-system.html
+++ b/site/docs/light-system.html
@@ -4,16 +4,16 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>The Light System — Irrlicht Docs</title>
-<meta name="description" content="Irrlicht's three-state light system: working, waiting, and ready. No ambiguity — each session is a single light whose color tells the truth.">
+<meta name="description" content="Irrlicht's light system: working, waiting, ready and error. No ambiguity — each session is a single light whose color tells the truth.">
 <link rel="canonical" href="https://irrlicht.io/docs/light-system.html">
 <meta property="og:type" content="article">
 <meta property="og:title" content="The Light System — Irrlicht Docs">
-<meta property="og:description" content="Irrlicht's three-state light system: working, waiting, and ready. No ambiguity — each session is a single light whose color tells the truth.">
+<meta property="og:description" content="Irrlicht's light system: working, waiting, ready and error. No ambiguity — each session is a single light whose color tells the truth.">
 <meta property="og:url" content="https://irrlicht.io/docs/light-system.html">
 <meta property="og:site_name" content="Irrlicht">
 <meta name="twitter:card" content="summary">
 <meta name="twitter:title" content="The Light System — Irrlicht Docs">
-<meta name="twitter:description" content="Irrlicht's three-state light system: working, waiting, and ready. No ambiguity — each session is a single light whose color tells the truth.">
+<meta name="twitter:description" content="Irrlicht's light system: working, waiting, ready and error. No ambiguity — each session is a single light whose color tells the truth.">
 
 <link rel="icon" type="image/svg+xml" href="../assets/favicon.svg">
 <link rel="icon" type="image/png" sizes="32x32" href="../assets/favicon-32x32.png">
@@ -87,16 +87,18 @@
     <div class="docs-content">
 
       <h1>The Light System</h1>
-      <p class="page-subtitle">Three states. No ambiguity. Each session is a single light whose color tells the truth. For the folklore behind the name, see <a href="story.html">The Story</a>.</p>
+      <p class="page-subtitle">One light per session. No ambiguity. Each session is a single light whose color tells the truth. For the folklore behind the name, see <a href="story.html">The Story</a>.</p>
 
-      <!-- The Three States -->
-      <h2>The Three States</h2>
+      <!-- The States -->
+      <h2>The States</h2>
       <img src="../assets/mascot/mascot-trio-state-cycle.webp"
            alt=""
            class="mascot mascot-float-right"
            loading="lazy" />
 
-      <p>Irrlicht's state model is <strong>MECE</strong> &mdash; mutually exclusive, collectively exhaustive. Every session is in exactly one state at any given moment. There is no fourth state, no "unknown", no "cancelled". Three states, three colors, three meanings.</p>
+      <p>Irrlicht's state model is <strong>MECE</strong> &mdash; mutually exclusive, collectively exhaustive. Every session is in exactly one state at any given moment: <span class="badge badge-working">working</span>, <span class="badge badge-waiting">waiting</span>, <span class="badge badge-ready">ready</span> or <span class="badge badge-error">error</span>. One color each, one meaning each.</p>
+
+      <p>There is no "cancelled" state &mdash; cancellation maps to <span class="badge badge-ready">ready</span>. And "unknown" is not a state either: the macOS app and the web dashboard each keep an <code>unknown</code> rendering fallback so that a value from a <em>newer</em> daemon than they were built against paints neutral grey instead of a confident green. Nothing ever emits it as a state; it is what a client shows when it does not recognise what it was sent.</p>
 
       <h3><span class="badge badge-working">working</span></h3>
 
@@ -126,7 +128,7 @@
 
       <div class="callout callout-warning">
         <strong>This one needs you</strong>
-        An orange light is the only state that demands your attention. Switch to this terminal and answer the question.
+        An orange light means the agent has stopped and cannot continue without you. Switch to this terminal and answer the question. (A red <span class="badge badge-error">error</span> light also needs you, and outranks orange in the menu bar &mdash; but it needs a retry rather than an answer.)
       </div>
 
       <h3><span class="badge badge-ready">ready</span></h3>
@@ -140,20 +142,42 @@
         <li>The session has been idle beyond the grace period</li>
       </ul>
 
+      <h3><span class="badge badge-error">error</span></h3>
+
+      <p>The session's own machinery failed. Something outside the agent's normal work went wrong and the session cannot make progress until it is retried.</p>
+
+      <ul>
+        <li>The provider refused or failed the call (rate limit, overload, a 5xx)</li>
+        <li>Credentials were rejected or expired</li>
+        <li>The agent process died mid-turn, with no turn-end in sight</li>
+        <li>Irrlicht could not read the session at all</li>
+      </ul>
+
+      <div class="callout callout-warning">
+        <strong>Not a tool failure</strong>
+        A <code>grep</code> that matched nothing, a failing build, a <code>find</code> hitting a protected directory &mdash; those are the agent working normally and stay <span class="badge badge-working">working</span>. A red light is about the session, not about what the agent found.
+      </div>
+
+      <p>Nothing clears <span class="badge badge-error">error</span> except the next <em>successful</em> turn &mdash; there is no timeout and no minimum hold. Starting a retry moves the session to <span class="badge badge-working">working</span>; only completing one takes it to <span class="badge badge-ready">ready</span>. The tradeoff is accepted and named: a provider error that recovers within a few hundred milliseconds can enter and leave <span class="badge badge-error">error</span> inside one poll interval and never be seen.</p>
+
       <div class="callout callout-info">
         <strong>No "cancelled" state</strong>
-        Cancellation is not a separate state. When you press ESC, the agent returns to the prompt &mdash; that is <span class="badge badge-ready">ready</span>. Three states only: working, waiting, ready.
+        Cancellation is not a separate state. When you press ESC, the agent returns to the prompt &mdash; that is <span class="badge badge-ready">ready</span>. Nor is a cancelled turn an <span class="badge badge-error">error</span>: you meant to stop it.
       </div>
 
       <!-- Decision Tree -->
       <h2>Decision Tree</h2>
 
-      <p>The state machine evaluates each transcript update with a simple three-step decision:</p>
+      <p>The state machine evaluates each transcript update with a simple four-step decision:</p>
 
       <ol class="steps">
         <li>
           <strong>Is there an open user-blocking tool?</strong><br>
           If the last tool result is pending and the tool is <code>AskUserQuestion</code> or <code>ExitPlanMode</code>, the state is <span class="badge badge-waiting">waiting</span>.
+        </li>
+        <li>
+          <strong>Is there an unrecovered session-level failure?</strong><br>
+          If the session's own machinery failed and no successful turn has happened since, the state is <span class="badge badge-error">error</span>. This sits above the next question deliberately: a terminal provider failure often leaves a transcript tail that reads like a finished turn, so asking it any later would report a failed session as <span class="badge badge-ready">ready</span> &mdash; green, and silent.
         </li>
         <li>
           <strong>Is the agent actively processing?</strong><br>
@@ -168,14 +192,19 @@
       <div class="diagram">  transcript update
         |
         v
-  +---------------------+
+  +----------------------+
   | user-blocking tool?  |--yes--> waiting (orange)
-  +---------------------+
+  +----------------------+
         | no
         v
-  +---------------------+
+  +----------------------+
+  | unrecovered failure? |--yes--> error   (red)
+  +----------------------+
+        | no
+        v
+  +----------------------+
   | active processing?   |--yes--> working (purple)
-  +---------------------+
+  +----------------------+
         | no
         v
       ready (green)</div>
@@ -183,7 +212,7 @@
       <!-- Context Pressure -->
       <h2>Context Pressure</h2>
 
-      <p>Context pressure is <strong>orthogonal</strong> to the three states. It measures how full the agent's context window is and overlays a second dimension onto whatever state the session is in. A session can be <span class="badge badge-working">working</span> at any pressure level.</p>
+      <p>Context pressure is <strong>orthogonal</strong> to the state machine. It measures how full the agent's context window is and overlays a second dimension onto whatever state the session is in. A session can be <span class="badge badge-working">working</span> at any pressure level.</p>
 
       <table>
         <thead>
@@ -230,7 +259,7 @@
 
       <div class="callout callout-info">
         <strong>Pressure is not state</strong>
-        A session at <code>critical</code> pressure can still be <span class="badge badge-working">working</span>, <span class="badge badge-waiting">waiting</span>, or <span class="badge badge-ready">ready</span>. The two dimensions are independent.
+        A session at <code>critical</code> pressure can still be in any state &mdash; <span class="badge badge-working">working</span>, <span class="badge badge-waiting">waiting</span>, <span class="badge badge-ready">ready</span> or <span class="badge badge-error">error</span>. The two dimensions are independent.
       </div>
 
       <!-- Cost Estimation -->

--- a/site/docs/quickstart.html
+++ b/site/docs/quickstart.html
@@ -140,11 +140,12 @@
         <li><span class="badge badge-working">working</span> -- the agent is processing</li>
         <li><span class="badge badge-waiting">waiting</span> -- the agent needs your input</li>
         <li><span class="badge badge-ready">ready</span> -- the agent is idle</li>
+        <li><span class="badge badge-error">error</span> -- the session's own machinery failed (the provider refused the call, credentials were rejected, the process died mid-turn). Not a failing build or an empty grep -- those are the agent working normally.</li>
       </ul>
 
       <div class="callout callout-tip">
         <strong>Tip</strong>
-        These three states map directly to the menu bar light color. Learn more in <a href="light-system.html">The Light System</a>.
+        Each state maps to one menu bar light color. Learn more in <a href="light-system.html">The Light System</a>.
       </div>
 
       <h2>Web Dashboard <span class="badge badge-beta" style="font-size:0.65em;vertical-align:middle;padding:2px 6px;background:rgba(89,52,0,0.15);color:#FF9500;border-radius:3px;">beta</span></h2>

--- a/site/docs/state-machine.html
+++ b/site/docs/state-machine.html
@@ -159,7 +159,13 @@
 
       <!-- ─── State Transitions ─── -->
       <h2>State Transitions</h2>
-      <p>Once a session is active, it moves between exactly three states: <span class="badge badge-working">working</span>, <span class="badge badge-waiting">waiting</span>, and <span class="badge badge-ready">ready</span>. These map directly to the three light colors in the menu bar.</p>
+      <p>Once a session is active, it moves between four states: <span class="badge badge-working">working</span>, <span class="badge badge-waiting">waiting</span>, <span class="badge badge-ready">ready</span>, and <span class="badge badge-error">error</span>. Each maps to one light color in the menu bar.</p>
+
+      <p><span class="badge badge-error">error</span> means the session's own machinery failed &mdash; the provider refused or failed the call, credentials were rejected, the agent process died mid-turn, or Irrlicht could not read the session. It is <em>not</em> a tool failure: a <code>grep</code> that matched nothing and a build that broke are the agent working normally.</p>
+
+      <p>Two things clear it, on different conditions. Your next message clears it <em>immediately</em>, before the new turn's outcome is known &mdash; someone who has typed again has moved on, and holding the old failure against the new turn would pin the session red for the rest of its life. A completed turn also clears it, but only when the failure was a <em>retrying</em> one; a terminal failure is not retired by a turn boundary. Neither edge is a timeout and neither has a minimum hold.</p>
+
+      <p>A process that died mid-turn is always recorded as terminal &mdash; a process that exited will not try again &mdash; so neither of those applies to it. Its row is kept in <span class="badge badge-error">error</span> for 12 hours and then reaped, so a crash at 22:00 is still visible at 08:00.</p>
 
       <table>
         <thead>
@@ -210,27 +216,62 @@
             <td><span class="badge badge-waiting">waiting</span></td>
             <td><span class="badge badge-working">working</span></td>
           </tr>
+          <tr>
+            <td>Provider refused or failed the call; credentials rejected</td>
+            <td><span class="badge badge-working">working</span></td>
+            <td><span class="badge badge-error">error</span></td>
+          </tr>
+          <tr>
+            <td>Agent process died mid-turn (the session row is kept, not deleted)</td>
+            <td><span class="badge badge-working">working</span></td>
+            <td><span class="badge badge-error">error</span></td>
+          </tr>
+          <tr>
+            <td>User sends the next message after a failure (clears it outright)</td>
+            <td><span class="badge badge-error">error</span></td>
+            <td><span class="badge badge-working">working</span></td>
+          </tr>
+          <tr>
+            <td>A <em>retrying</em> failure's next turn completes</td>
+            <td><span class="badge badge-error">error</span></td>
+            <td><span class="badge badge-ready">ready</span></td>
+          </tr>
         </tbody>
       </table>
+
+      <p>Note that the last two rows clear the failure on different conditions:
+      your next message clears it outright, while a completed turn clears it only
+      when the failure was a retrying one. A process death is terminal, so it
+      leaves <span class="badge badge-error">error</span> by neither &mdash; it
+      ages out of the list instead.</p>
 
       <div class="diagram">                  +-----------+
   user sends  |           |  end_turn / ESC
   message     |  working  |----------------+
  +----------->|           |                |
  |            +-----+-----+                |
- |                  |                      v
- |      AskUser /   |                +---------+
- |      ExitPlan    |                |  ready  |
- |                  v                +---------+
- |            +-----------+                ^
- |            |           |                |
- +------------|  waiting  |  (process exit |
-  user        |           |   only)        |
-  answers     +-----------+----------------+</div>
+ |                  |    \                 v
+ |      AskUser /   |     \ provider  +---------+
+ |      ExitPlan    |      \ failure  |  ready  |
+ |                  v       \ or      +---------+
+ |            +-----------+ \ death        ^
+ |            |           |  \             |
+ +------------|  waiting  |   \ (process exit
+  user        |           |    \  only)    |
+  answers     +-----------+     \----------+
+                                 v         ^
+                            +---------+    | retrying
+                            |  error  |----+ failure's
+                            +---------+      turn ends
+                                 |
+                                 | user's next message
+                                 +--------> working (above)</div>
 
       <!-- ─── Impossible Transitions ─── -->
       <h2>Impossible Transitions</h2>
-      <p>Two transitions are structurally impossible and the state machine enforces this:</p>
+      <p>Two transitions are structurally impossible and the state machine enforces this. Both constrain only <span class="badge badge-working">working</span>, <span class="badge badge-waiting">waiting</span> and <span class="badge badge-ready">ready</span> &mdash; no impossibility is claimed about <span class="badge badge-error">error</span> in either direction.</p>
+
+      <p>Whether <span class="badge badge-error">error</span> or <span class="badge badge-waiting">waiting</span> wins is decided per cause, not once. A <strong>dead process</strong> outranks waiting: it leaves any open question unanswerable forever, and sending someone to answer a question in a process that no longer exists is worse than saying nothing. A <strong>provider failure on a live session</strong> is the other way round &mdash; if that session then opens a blocking tool, it reads <span class="badge badge-waiting">waiting</span>.</p>
 
       <table>
         <thead>
@@ -253,7 +294,7 @@
 
       <div class="callout callout-warning">
         <strong>No cancelled state</strong>
-        There is no fourth "cancelled" state. Cancellation (ESC) maps directly to <span class="badge badge-ready">ready</span>. The system maintains exactly three states: working, waiting, and ready.
+        There is no "cancelled" state. Cancellation (ESC) maps directly to <span class="badge badge-ready">ready</span> &mdash; from the user's side a cancelled turn and a finished turn leave the agent in the same place, idle at the prompt. This is unrelated to <span class="badge badge-error">error</span>, which is reserved for the session's own machinery failing rather than for anything the user did.
       </div>
 
       <!-- ─── Detection Logic ─── -->
@@ -317,7 +358,7 @@
 
       <!-- ─── Orthogonal Axes ─── -->
       <h2>Orthogonal Axes</h2>
-      <p>Beyond the three core states, the state machine tracks several orthogonal dimensions that do not affect the primary state transition logic but provide additional context.</p>
+      <p>Beyond the core states, the state machine tracks several orthogonal dimensions that do not affect the primary state transition logic but provide additional context.</p>
 
       <h3>Adapter</h3>
       <p>Identifies which AI coding agent is running:</p>
@@ -375,11 +416,11 @@
         <li>The agent stops executing, so <code>IsAgentDone()</code> fires.</li>
         <li>The session transitions to <span class="badge badge-ready">ready</span>.</li>
       </ul>
-      <p>This is a deliberate design choice. From the user's perspective, a cancelled turn is equivalent to a completed turn &mdash; the agent is idle and waiting for the next message. The three-state model (<span class="badge badge-working">working</span> / <span class="badge badge-waiting">waiting</span> / <span class="badge badge-ready">ready</span>) remains clean and unambiguous.</p>
+      <p>This is a deliberate design choice. From the user's perspective, a cancelled turn is equivalent to a completed turn &mdash; the agent is idle and waiting for the next message. Folding it into <span class="badge badge-ready">ready</span> keeps the state model free of a value that would carry no information the user could act on.</p>
 
       <!-- ─── Lifecycle Event Kinds ─── -->
       <h2>Lifecycle Event Kinds</h2>
-      <p>Underneath the three-state model, the daemon records a lower-level stream of typed events for session recording and replay &mdash; not just transcript-derived state transitions but also process lifecycle, filesystem, debounce, and parent-child signals. Each event carries a <code>Kind</code> discriminant (<code>core/domain/lifecycle/event.go</code>); this table enumerates all 18 constants, grouped as the source file itself groups them.</p>
+      <p>Underneath the state machine, the daemon records a lower-level stream of typed events for session recording and replay &mdash; not just transcript-derived state transitions but also process lifecycle, filesystem, debounce, and parent-child signals. Each event carries a <code>Kind</code> discriminant (<code>core/domain/lifecycle/event.go</code>); this table enumerates all 18 constants, grouped as the source file itself groups them.</p>
 
       <table>
         <thead>

--- a/site/docs/tips-and-tricks.html
+++ b/site/docs/tips-and-tricks.html
@@ -110,7 +110,7 @@
       <p><strong>macOS.</strong> Under <strong>Settings &rarr; Menu Bar Icon</strong> there are three styles, and the right one depends on what you tend to run out of first:</p>
 
       <ul>
-        <li><strong>Lights</strong> &mdash; session-state dots: how many agents are <span class="badge badge-working">working</span>, <span class="badge badge-waiting">waiting</span>, or <span class="badge badge-ready">ready</span>. The default.</li>
+        <li><strong>Lights</strong> &mdash; session-state dots: how many agents are <span class="badge badge-working">working</span>, <span class="badge badge-waiting">waiting</span>, <span class="badge badge-ready">ready</span>, or in <span class="badge badge-error">error</span>. The default.</li>
         <li><strong>Usage</strong> &mdash; replaces the dots with reported subscription quota bars, so the menu bar answers "how much of my plan is left" instead.</li>
         <li><strong>Combined</strong> &mdash; both, side by side.</li>
       </ul>

--- a/site/index.html
+++ b/site/index.html
@@ -20,7 +20,7 @@
   "@context": "https://schema.org",
   "@type": "SoftwareApplication",
   "name": "Irrlicht",
-  "description": "A macOS menu bar app that monitors Claude Code, OpenAI Codex, Pi, and other AI coding agents in real time. Three states: working, waiting, ready.",
+  "description": "A macOS menu bar app that monitors Claude Code, OpenAI Codex, Pi, and other AI coding agents in real time. One light per session: working, waiting, ready, error.",
   "url": "https://irrlicht.io",
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "macOS 13 Ventura or later",
@@ -1031,6 +1031,18 @@ section {
   opacity: 0.7;
 }
 
+/* The fourth state. It is deliberately a line of prose under the three light
+   cards rather than a fourth card: the row above is the everyday rhythm, and
+   `error` is the exception to it. */
+.why-states-note {
+  max-width: 46rem;
+  margin: 2rem auto 0;
+  text-align: center;
+  font-size: 0.92rem;
+  line-height: 1.7;
+  color: var(--text-dim, #8b93a7);
+}
+
 /* ─── Demo video ─── */
 .demo {
   padding: 6rem 0 2rem;
@@ -1602,7 +1614,7 @@ footer {
       </div>
     </div>
 
-    <p class="why-states-label">Three states. No ambiguity.</p>
+    <p class="why-states-label">One light per session. No ambiguity.</p>
     <div class="lights-row reveal">
       <div class="light-card">
         <div class="light-orb orb-working"></div>
@@ -1620,6 +1632,7 @@ footer {
         <p>The path ahead is clear. The session is idle, ready for your next instruction.</p>
       </div>
     </div>
+    <p class="why-states-note">When the session itself fails &mdash; the provider refuses the call, credentials expire, the process dies mid-turn &mdash; the light turns red instead of quietly green. <a href="docs/light-system.html">The Light System</a> has all four.</p>
   </div>
 </section>
 
@@ -1814,7 +1827,7 @@ footer {
           <svg width="20" height="20" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.5"><circle cx="10" cy="10" r="3"/><path d="M10 2v3m0 10v3M2 10h3m10 0h3M4.22 4.22l2.12 2.12m7.32 7.32l2.12 2.12M4.22 15.78l2.12-2.12m7.32-7.32l2.12-2.12"/></svg>
         </div>
         <h3>Real-Time Monitoring</h3>
-        <p>Sub-second state detection via FSEvents and kqueue. See working, waiting, and ready the moment they change.</p>
+        <p>Sub-second state detection via FSEvents and kqueue. See every state change the moment it happens.</p>
       </div>
       <div class="feature-card">
         <div class="feature-icon fi-orange">

--- a/site/llms.txt
+++ b/site/llms.txt
@@ -2,13 +2,13 @@
 
 > A free, open-source macOS menu bar application that monitors AI coding agent sessions in real time.
 
-Irrlicht provides menu-bar telemetry for AI coding agents like Claude Code, OpenAI Codex, and Pi. It uses a three-state light system — working (purple), waiting (orange), and ready (green) — to show each agent's status at a glance. The app detects sessions automatically via filesystem watching and process scanning, requires zero configuration, and runs entirely on-device with no data leaving the machine. Built with Go and SwiftUI, it supports multi-agent monitoring, context pressure tracking, cost estimation, and git-aware session grouping. MIT licensed.
+Irrlicht provides menu-bar telemetry for AI coding agents like Claude Code, OpenAI Codex, and Pi. It uses a light system — working (purple), waiting (orange), ready (green), error (red) — to show each agent's status at a glance. The app detects sessions automatically via filesystem watching and process scanning, requires zero configuration, and runs entirely on-device with no data leaving the machine. Built with Go and SwiftUI, it supports multi-agent monitoring, context pressure tracking, cost estimation, and git-aware session grouping. MIT licensed.
 
 ## Documentation
 
 - [Installation](https://irrlicht.io/docs/installation.html): Install via DMG, PKG, or build from source
 - [Quick Start](https://irrlicht.io/docs/quickstart.html): Get up and running in minutes
-- [The Light System](https://irrlicht.io/docs/light-system.html): Three states — working, waiting, ready
+- [The Light System](https://irrlicht.io/docs/light-system.html): The session states — working, waiting, ready, error
 - [State Machine](https://irrlicht.io/docs/state-machine.html): Deterministic session state transitions
 - [Session Detection](https://irrlicht.io/docs/session-detection.html): How sessions are discovered and tracked
 - [Configuration](https://irrlicht.io/docs/configuration.html): Environment variables and settings

--- a/tools/irrlicht-design-system/README.md
+++ b/tools/irrlicht-design-system/README.md
@@ -88,7 +88,8 @@ Irrlicht writes like a quietly confident German open-source maintainer. Copy is 
 ### Casing & punctuation
 
 - **Sentence case** for headings (`How it works`, `The light system`), never Title Case.
-- State names are **always lowercase**: `working`, `waiting`, `ready`, `cancelled`. Even in UI badges.
+- State names are **always lowercase**: `working`, `waiting`, `ready`, `error`. Even in UI badges.
+  (`cancelled` is not a state and never was a rendered one — it maps to `ready`.)
 - Em-dashes (—) are load-bearing. Curly quotes ("…") throughout. `&mdash;` in HTML.
 - Numbers: compact (`<1s`, `~5MB`, `80%`, `$0.42`) with no thin-space padding.
 - Code in backticks mid-sentence: *"watches `.jsonl` transcripts."*

--- a/tools/lib/state-vocabulary-lint_test.sh
+++ b/tools/lib/state-vocabulary-lint_test.sh
@@ -1,0 +1,253 @@
+#!/usr/bin/env bash
+# state-vocabulary-lint_test.sh — mutation evidence for
+# tools/state-vocabulary-lint.sh (#1804).
+#
+# Per this repo's testing philosophy (AGENTS.md's Testing section /
+# docs/testing-philosophy.md): a check a change *adds* has no "before the fix"
+# to run red against, so it owes a deliberate mutation instead. The mutation
+# here is a file that hand-types three of the four canonical states and omits
+# the fourth — the exact shape that shipped four defects in #1796 — reproduced
+# against committed fixtures under tools/lib/testdata/state-vocabulary-lint/
+# rather than by planting a stale enumeration in a real file, so the evidence
+# outlives this PR and is re-run on every push.
+#
+# Cases, each pinned to the exit code the gate's header documents
+# (0 clean / 1 finding / 2 refusal):
+#
+#   THE THRESHOLD
+#     three-of-four.md    3 of 4 named — the mutation. Must FAIL and must name
+#                         the offending line, not merely exit non-zero.
+#     two-of-four.md      2 of 4 — a deliberate concurrency partition. Must
+#                         PASS: this is the boundary the threshold of 3 buys,
+#                         and a regression to 2 shows up here first.
+#     all-four.md         the whole vocabulary — current by construction, must
+#                         PASS. This is also the self-maintaining half: were a
+#                         fifth state added, this fixture becomes a proper
+#                         subset and this case would legitimately flip.
+#
+#   ONE FIXTURE PER MATCHER ARM
+#     A 24-mutation battery run during review found that four of the six arms
+#     — markup bodies, identifier components, and both prose-run directions —
+#     were killed ONLY by the real-repo vacuity guard at the bottom of this
+#     file. That is coverage by coincidence: it depends on today's repo
+#     contents and evaporates the moment those particular sites are fixed.
+#     Each of the three fixtures added here uses exactly one spelling, so
+#     deleting its arm fails a named case rather than a census.
+#
+#   THE TWO GUARDS THAT STOP A FALSE CLEAN
+#     Also from that battery — the only two mutations that survived it. Each
+#     could be deleted outright with the whole suite still green, while the
+#     gate reported "clean" over a scan that had not happened:
+#     the scan-status check (an awk that DIED and an awk that found NOTHING
+#     both produce empty output), and the exclusion-staleness refusal (an
+#     exclusion that stopped excluding reads exactly like coverage).
+#
+#   THE WAIVER LIST, BOTH DIRECTIONS
+#     covered             a live waiver suppresses its site — PASS.
+#     stale               a waiver matching no site — FAIL. A waiver that
+#                         stopped matching and a clean run must not look the
+#                         same (tools/lib/shell-lib-suite.sh refuses a skip
+#                         that names no file for the same reason).
+#     unreadable          the waiver file cannot be read at all — REFUSE, not
+#                         "everything is unwaived" and not a quiet pass.
+#
+#   THE DERIVED VOCABULARY — the part most likely to rot silently
+#     no-literal          `canonicalStates` moved or was renamed — REFUSE.
+#     unresolvable        the slice names a constant with no declaration —
+#                         REFUSE on a HALF-parsed vocabulary rather than
+#                         scanning for the part that parsed.
+#     too-small           a vocabulary at or below the threshold makes the
+#                         "names >= 3 but not all" rule vacuous, so a scan
+#                         would report a serene zero over the whole repo —
+#                         REFUSE.
+#
+#   VACUITY GUARDS — without these, everything above could pass while the gate
+#   was wired to fixtures and never looked at the repo it exists to protect:
+#     * the real repo passes its own gate;
+#     * the real vocabulary parses out of the real session.go and holds more
+#       values than the threshold;
+#     * the real scan actually FINDS sites (a matcher that silently stopped
+#       matching would otherwise read as a clean repo).
+set -uo pipefail
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+cd "$REPO_ROOT" || { echo "FAIL: cannot cd to repo root $REPO_ROOT" >&2; exit 1; }
+
+GATE=tools/state-vocabulary-lint.sh
+FIXTURE_DIR=tools/lib/testdata/state-vocabulary-lint
+
+if [[ ! -x "$GATE" ]]; then
+  echo "FAIL: state-vocabulary-lint_test — subject not found or not executable at $GATE" >&2
+  exit 1
+fi
+if [[ ! -d "$FIXTURE_DIR" ]]; then
+  echo "FAIL: state-vocabulary-lint_test — fixture corpus missing at $FIXTURE_DIR" >&2
+  exit 1
+fi
+
+rc=0
+fail() { echo "FAIL: $1" >&2; rc=1; }
+
+# assert_gate <label> <expected-rc> <source> <waivers> <file...> -- [must-contain]
+# The expected text, when given, is checked against combined output: an exit
+# code alone does not prove the gate reported the RIGHT thing.
+assert_gate() {
+  local label="$1" want="$2" src="$3" waivers="$4" file="$5" want_text="${6:-}"
+  local out got
+  out=$("$GATE" --source "$src" --waivers "$waivers" -- "$file" 2>&1)
+  got=$?
+  if [[ "$got" -ne "$want" ]]; then
+    fail "$label: expected exit $want, got $got (output: $out)"
+    return
+  fi
+  if [[ -n "$want_text" && "$out" != *"$want_text"* ]]; then
+    fail "$label: exit $got was right but output missing '$want_text' — got: $out"
+    return
+  fi
+  echo "  PASS: $label (exit $got)"
+}
+
+SRC="$FIXTURE_DIR/vocab-source.go"
+
+# --- the threshold ----------------------------------------------------------
+assert_gate "3-of-4 is the mutation and must be caught" \
+  1 "$SRC" /dev/null "$FIXTURE_DIR/three-of-four.md" "three-of-four.md:7"
+# The same mutation spelled as Go constants, where the state names appear ONLY
+# inside `State<Capitalised>` identifiers. A pre-filter that matches
+# case-sensitively skips this shape silently while still exiting 0 — which the
+# scan's index() optimisation did on its first cut. Not a duplicate of the case
+# above: that one would stay green through the same bug.
+assert_gate "the State<Cap> constant spelling is caught too (case-folding)" \
+  1 "$SRC" /dev/null "$FIXTURE_DIR/three-of-four-constants.go" "three-of-four-constants.go:13"
+assert_gate "2-of-4 stays below the threshold (the deliberate partition)" \
+  0 "$SRC" /dev/null "$FIXTURE_DIR/two-of-four.md"
+assert_gate "naming the whole vocabulary is not a finding" \
+  0 "$SRC" /dev/null "$FIXTURE_DIR/all-four.md"
+
+# --- one fixture per matcher arm --------------------------------------------
+# Without these, four of the six arms are killed ONLY by the real-repo vacuity
+# guard below — i.e. their coverage depends on today's repo contents and
+# evaporates the moment those particular sites are fixed. Each fixture below
+# uses exactly one spelling, so removing its arm fails here by construction.
+assert_gate "markup bodies (>value<) are a naming, not just quoted strings" \
+  1 "$SRC" /dev/null "$FIXTURE_DIR/three-of-four-markup.html" "three-of-four-markup.html:6"
+assert_gate "identifier components (badge-working) count as a naming" \
+  1 "$SRC" /dev/null "$FIXTURE_DIR/three-of-four-cssclass.md" "three-of-four-cssclass.md:6"
+assert_gate "bare prose enumerations count, in both separator directions" \
+  1 "$SRC" /dev/null "$FIXTURE_DIR/three-of-four-prose-run.md" "three-of-four-prose-run.md"
+
+# --- the waiver list, both directions ---------------------------------------
+assert_gate "a live waiver suppresses its site" \
+  0 "$SRC" "$FIXTURE_DIR/waivers-covering.txt" "$FIXTURE_DIR/three-of-four.md" "all waived"
+assert_gate "a waiver matching no site is itself a failure" \
+  1 "$SRC" "$FIXTURE_DIR/waivers-stale.txt" "$FIXTURE_DIR/all-four.md" "match no flagged site"
+assert_gate "an unreadable waiver file is a REFUSAL, not 'nothing is waived'" \
+  2 "$SRC" "$FIXTURE_DIR/does-not-exist.txt" "$FIXTURE_DIR/three-of-four.md" "cannot read the waiver file"
+
+# --- the derived vocabulary -------------------------------------------------
+assert_gate "a missing canonicalStates literal is a REFUSAL" \
+  2 "$FIXTURE_DIR/vocab-source-no-literal.go" /dev/null "$FIXTURE_DIR/three-of-four.md" "no \`canonicalStates"
+assert_gate "a constant the slice names but does not declare is a REFUSAL" \
+  2 "$FIXTURE_DIR/vocab-source-unresolvable.go" /dev/null "$FIXTURE_DIR/three-of-four.md" "StateMissing"
+assert_gate "a vocabulary at the threshold makes the rule vacuous — REFUSAL" \
+  2 "$FIXTURE_DIR/vocab-source-too-small.go" /dev/null "$FIXTURE_DIR/three-of-four.md" "cannot match anything"
+
+# --- the two guards that stop a FALSE CLEAN ---------------------------------
+# Both were unpinned until a mutation battery found them (#1804 review): each
+# could be deleted outright and the whole suite stayed green, while the gate
+# silently reported "clean" over a scan that had not happened.
+
+# The scan-status check. An awk that DIED and an awk that found NOTHING both
+# produce empty output; only the exit status separates them. This is the exact
+# case the script header records as a real incident (macOS awk rejecting a
+# newline in the vocabulary reported a clean tree over a repo full of sites).
+assert_gate "a file the scanner cannot read is a REFUSAL, not a clean scan" \
+  2 "$SRC" /dev/null "$FIXTURE_DIR/no-such-file-exists.md" "the scan itself failed"
+
+# The exclusion-staleness refusal. Driven by sourcing the gate and rewriting
+# its exclusion array in-process — no test-only hook in the production path.
+# Without this, renaming an excluded tree turns its exclusion into a silent
+# no-op, which reads from the log exactly like coverage.
+(
+  # shellcheck source=../state-vocabulary-lint.sh
+  . "$GATE"
+  # shellcheck disable=SC2034  # Read by state_vocab_files in the gate sourced above, not in this file — shellcheck cannot see across the `.` with external-sources off.
+  STATE_VOCAB_EXCLUDE=(
+    'replaydata/'                              'still real, so the refusal below is about the NEXT entry only'
+    'no/such/tree/this/repo/has/never/had/'    'deliberately dead'
+  )
+  out=$(state_vocab_files "working waiting ready error" 2>&1)
+  got=$?
+  if [[ "$got" -ne 2 ]]; then
+    echo "FAIL: an exclusion matching nothing must REFUSE (exit 2), got $got: $out" >&2
+    exit 1
+  fi
+  if [[ "$out" != *"matched no file"* || "$out" != *"deliberately dead"* ]]; then
+    echo "FAIL: the refusal must name the dead exclusion and repeat its stated reason — got: $out" >&2
+    exit 1
+  fi
+  echo "  PASS: an exclusion that stopped excluding is a REFUSAL, and names its reason"
+) || rc=1
+
+# A file containing a NUL byte, but still text, must stay in the corpus.
+#
+# platforms/web/irrlicht.js holds a literal NUL at offset 67966 (a `'\0'`
+# string separator) and carries a real flagged site. Text-vs-binary heuristics
+# disagree about it: GNU grep 3.12's `-I` calls it binary in every locale,
+# while the ugrep that shadows `grep` on macOS does not. When the narrowing
+# step used `grep -I`, the corpus therefore differed by one real source file
+# between a laptop and the Linux CI runner — the local run being the permissive
+# one, so the gap was invisible locally. `git grep -I` decides with git's own
+# rule (NUL within the first 8000 bytes), identically everywhere.
+#
+# This locks the outcome rather than the implementation: swap the narrowing
+# back to a libc-heuristic grep and this fails on Linux, which is where it
+# matters. It is a LOCK — it passes on macOS by construction either way.
+(
+  # shellcheck source=../state-vocabulary-lint.sh
+  . "$GATE"
+  corpus=$(state_vocab_files "working waiting ready error" 2>/dev/null)
+  if ! printf '%s\n' "$corpus" | grep -qxF 'platforms/web/irrlicht.js'; then
+    echo "FAIL: platforms/web/irrlicht.js is missing from the scanned corpus — a NUL-containing TEXT file is being rejected as binary (see the narrowing step's comment)." >&2
+    exit 1
+  fi
+  echo "  PASS: a NUL-containing text file stays in the corpus (lock)"
+) || rc=1
+
+# --- vacuity guards: the gate must be looking at the real repo ---------------
+real_out=$("$GATE" 2>&1)
+real_rc=$?
+if [[ "$real_rc" -ne 0 ]]; then
+  fail "the repo does not pass its own state-vocabulary gate (exit $real_rc): $real_out"
+else
+  echo "  PASS: the real repo passes its own gate"
+fi
+
+# The real vocabulary must parse, and hold MORE than the threshold — otherwise
+# every case above could be green while the repo scan matched by construction
+# nothing at all.
+# shellcheck source=../state-vocabulary-lint.sh
+. "$GATE"
+real_vocab=$(state_vocab_read "$STATE_VOCAB_SOURCE") || real_vocab=""
+real_count=$(printf '%s' "$real_vocab" | grep -c .)
+if (( real_count <= STATE_VOCAB_MIN_NAMED )); then
+  fail "the real vocabulary parsed $real_count value(s) from $STATE_VOCAB_SOURCE; the gate cannot mean anything at or below its threshold of $STATE_VOCAB_MIN_NAMED"
+else
+  echo "  PASS: the real vocabulary parses ($real_count values, threshold $STATE_VOCAB_MIN_NAMED)"
+fi
+
+# …and the scan must actually FIND things in the real repo. Every site is
+# waived today, so "0 site(s)" would still exit 0 — which is exactly what a
+# matcher that silently stopped matching would produce. Absence of a finding
+# and inability to look must not print the same thing.
+real_sites=$(printf '%s' "$real_out" | sed -n 's/.*; \([0-9][0-9]*\) site(s).*/\1/p')
+if [[ -z "$real_sites" ]]; then
+  fail "could not read a site count out of the gate's own summary line: $real_out"
+elif (( real_sites == 0 )); then
+  fail "the real scan found 0 sites — the matcher has stopped matching, or the corpus is empty. It has never legitimately been 0 (57 at #1804)."
+else
+  echo "  PASS: the real scan is live ($real_sites site(s) found and waived)"
+fi
+
+[[ "$rc" -eq 0 ]] && echo "OK: state-vocabulary-lint_test — threshold, both waiver directions, vocabulary refusals, and the real repo all hold"
+exit "$rc"

--- a/tools/lib/testdata/state-vocabulary-lint/all-four.md
+++ b/tools/lib/testdata/state-vocabulary-lint/all-four.md
@@ -1,0 +1,7 @@
+# Complete, therefore not a finding
+
+The lifecycle states are `working`, `waiting`, `ready` and `error`.
+
+An enumeration naming the entire vocabulary is current by construction.
+It becomes a finding only when a fifth state makes it a proper subset —
+which is the whole mechanism by which this gate maintains itself.

--- a/tools/lib/testdata/state-vocabulary-lint/three-of-four-constants.go
+++ b/tools/lib/testdata/state-vocabulary-lint/three-of-four-constants.go
@@ -1,0 +1,17 @@
+// three-of-four-constants.go — the CONSTANT spelling of the mutation.
+//
+// The state names appear only inside `State<Capitalised>` identifiers, never
+// as lowercase words, so any pre-filter that matches case-sensitively skips
+// this file entirely — silently, while still exiting 0. That is precisely
+// what happened when the scan's cheap index() pre-check was first added
+// (measured: the repo scan dropped session_detector_activity.go and reported
+// its waiver as stale). This fixture is the standing guard against it.
+package services
+
+func promote(cur string) bool {
+	switch cur {
+	case StateWorking, StateWaiting, StateReady:
+		return true
+	}
+	return false
+}

--- a/tools/lib/testdata/state-vocabulary-lint/three-of-four-cssclass.md
+++ b/tools/lib/testdata/state-vocabulary-lint/three-of-four-cssclass.md
@@ -1,0 +1,8 @@
+# Pins token()'s identifier-component arm (`[.:_-]value`)
+
+The names appear only as suffixes inside compound identifiers — a CSS class,
+a custom property, a Swift enum case — never as standalone words:
+
+    .badge-working, .badge-waiting, .badge-ready { display: inline-flex }
+
+If that arm is dropped, nothing else in the corpus fails by construction.

--- a/tools/lib/testdata/state-vocabulary-lint/three-of-four-markup.html
+++ b/tools/lib/testdata/state-vocabulary-lint/three-of-four-markup.html
@@ -1,0 +1,7 @@
+<!-- three-of-four-markup.html — pins token()'s ">value<" markup arm.
+     The state names appear only as HTML element bodies, never quoted and
+     never as a Go/Swift constant, so this is the only fixture that fails if
+     that arm is removed. -->
+<ul>
+  <li>State is one of <code>working</code>, <code>waiting</code> or <code>ready</code></li>
+</ul>

--- a/tools/lib/testdata/state-vocabulary-lint/three-of-four-prose-run.md
+++ b/tools/lib/testdata/state-vocabulary-lint/three-of-four-prose-run.md
@@ -1,0 +1,8 @@
+# Pins run()'s prose-enumeration arms
+
+Neither line below quotes, marks up, or capitalises anything, so token()
+scores zero on both. They fire only via run(), one per direction:
+
+The classifier moves a session between working/waiting/ready.
+
+A slash-free spelling too: the states are working, waiting and ready.

--- a/tools/lib/testdata/state-vocabulary-lint/three-of-four.md
+++ b/tools/lib/testdata/state-vocabulary-lint/three-of-four.md
@@ -1,0 +1,9 @@
+# The mutation fixture
+
+This file exists to be caught. The line below names three of the four
+canonical states and omits the fourth — the exact shape that was correct
+under the old vocabulary and is silently stale under the current one.
+
+A session is always in one of `working`, `waiting` or `ready`.
+
+Nothing else in this file matters; the gate reads one line at a time.

--- a/tools/lib/testdata/state-vocabulary-lint/two-of-four.md
+++ b/tools/lib/testdata/state-vocabulary-lint/two-of-four.md
@@ -1,0 +1,8 @@
+# Below the threshold
+
+A session occupies a concurrency slot while `working` or `waiting`.
+
+That is a deliberate partition, not a stale enumeration — it is the single
+most common two-state spelling in the repo (session.HasWorkInFlight names
+seven sites). The gate's threshold of three exists so this line does NOT
+fire; at a threshold of two roughly half of all hits are lines like it.

--- a/tools/lib/testdata/state-vocabulary-lint/vocab-source-no-literal.go
+++ b/tools/lib/testdata/state-vocabulary-lint/vocab-source-no-literal.go
@@ -1,0 +1,10 @@
+// vocab-source-no-literal.go — the declaration moved or was renamed. The gate
+// must REFUSE rather than scan for a vocabulary it could not establish.
+package session
+
+const (
+	StateWorking = "working"
+	StateWaiting = "waiting"
+	StateReady   = "ready"
+	StateError   = "error"
+)

--- a/tools/lib/testdata/state-vocabulary-lint/vocab-source-too-small.go
+++ b/tools/lib/testdata/state-vocabulary-lint/vocab-source-too-small.go
@@ -1,0 +1,12 @@
+// vocab-source-too-small.go — three values total. The "names >= 3 but not all"
+// rule cannot match anything at that size, so a scan would report a serene
+// zero over the whole repo. The gate must REFUSE instead.
+package session
+
+const (
+	StateWorking = "working"
+	StateWaiting = "waiting"
+	StateReady   = "ready"
+)
+
+var canonicalStates = []string{StateWorking, StateWaiting, StateReady}

--- a/tools/lib/testdata/state-vocabulary-lint/vocab-source-unresolvable.go
+++ b/tools/lib/testdata/state-vocabulary-lint/vocab-source-unresolvable.go
@@ -1,0 +1,12 @@
+// vocab-source-unresolvable.go — the slice names a constant that has no
+// declaration in the file. A half-parsed vocabulary must REFUSE, not quietly
+// scan for the part it managed to read.
+package session
+
+const (
+	StateWorking = "working"
+	StateWaiting = "waiting"
+	StateReady   = "ready"
+)
+
+var canonicalStates = []string{StateWorking, StateWaiting, StateReady, StateMissing}

--- a/tools/lib/testdata/state-vocabulary-lint/vocab-source.go
+++ b/tools/lib/testdata/state-vocabulary-lint/vocab-source.go
@@ -1,0 +1,18 @@
+// vocab-source.go — a stand-in for core/domain/session/session.go, so the
+// tests drive the vocabulary parser without depending on the real file's
+// current contents.
+package session
+
+const (
+	StateWorking = "working"
+	StateWaiting = "waiting"
+	StateReady   = "ready"
+	StateError   = "error"
+
+	// Deliberately present: `State[A-Z]` also matches the tail of this
+	// identifier, which is why the parser resolves names taken from the
+	// slice literal instead of pattern-matching constants directly.
+	CompactionStateNotCompacting = "not_compacting"
+)
+
+var canonicalStates = []string{StateWorking, StateWaiting, StateReady, StateError}

--- a/tools/lib/testdata/state-vocabulary-lint/waivers-covering.txt
+++ b/tools/lib/testdata/state-vocabulary-lint/waivers-covering.txt
@@ -1,0 +1,1 @@
+tools/lib/testdata/state-vocabulary-lint/three-of-four.md   the mutation fixture, waived so the "site covered by a live waiver" direction can be exercised

--- a/tools/lib/testdata/state-vocabulary-lint/waivers-stale.txt
+++ b/tools/lib/testdata/state-vocabulary-lint/waivers-stale.txt
@@ -1,0 +1,1 @@
+tools/lib/testdata/state-vocabulary-lint/all-four.md   names the whole vocabulary, so it is never flagged — this entry is therefore STALE by construction

--- a/tools/preflight.sh
+++ b/tools/preflight.sh
@@ -517,6 +517,29 @@ if want tools; then
   # would otherwise regrow it past that budget unnoticed under `--changed`.
   run_gate_scoped '^tools/lib/|^tools/[^/]*\.sh$|^tools/git-hooks/|^go\.work$|^\.github/dependabot\.yml$|^site/install\.sh$|^AGENTS\.md$|^\.github/workflows/(ars|codescene-badge|coverage|macos-swift|replaydata-deletion-guard|test)\.yml$' \
                   "tools/lib shell-lib tests" shell_lib_tests
+
+  # UNSCOPED, deliberately, and the only gate in this group that is (#1804).
+  #
+  # Every other gate here has a corpus you can name — tools/lib/, a workflow
+  # file, AGENTS.md — so `--changed` can honestly decide the diff cannot break
+  # it. This one's corpus is the repository: a file that hand-types three of
+  # the four session states, and so goes stale the next time the vocabulary
+  # grows, can be a Go file, a Swift view, a stylesheet, an HTML doc page, a
+  # markdown README or a shell script, and the stale ones this gate was written
+  # against were spread across exactly that range. A trigger regex would
+  # therefore have to match everything, and a regex that matches everything is
+  # a scoping claim that is not true — the failure mode #1209 named, where a
+  # gate silently stops firing on precisely the push it exists to catch.
+  #
+  # Affordable: ~2.4s of CPU, after the scan's own case-folded index()
+  # pre-check discards the lines that cannot qualify. Reproduce with
+  # `/usr/bin/time -p tools/state-vocabulary-lint.sh` and read `user` — wall
+  # clock on this machine swings between 15s and 21s purely on how many other
+  # agents are running, so it is not the figure to quote. It sits in phase 1
+  # with the other cheap deterministic gates, so a squeezed `--budget` run
+  # keeps it.
+  run_gate "state-vocabulary lint (incomplete state enumerations)" \
+           tools/state-vocabulary-lint.sh
 fi
 
 # ---- go group, cheap half (mirrors test.yml's gofmt step) ------------------

--- a/tools/state-vocabulary-lint.sh
+++ b/tools/state-vocabulary-lint.sh
@@ -1,0 +1,483 @@
+#!/usr/bin/env bash
+# state-vocabulary-lint.sh — refuse when a file hand-types an INCOMPLETE list
+# of the session-state vocabulary.
+#
+# WHY THIS EXISTS (#1804, recommended and prototyped by #1798)
+#
+# The lifecycle vocabulary held three values for two years, so "name all of
+# them" and "name three of them" were the same act, and dozens of sites did it
+# — prose, HTML tables, CLI help strings, `case` arms, test fixtures. #1796
+# added a fourth value and every one of those sites became a claim that is
+# quietly false. That is worse than no claim: a stale enumeration tells the
+# next reader not to look.
+#
+# The epic shipped FOUR separate defects of exactly this shape, each complete
+# under the old vocabulary and silently incomplete under the new one:
+#   - `classifyAgentDone` enumerated the values it promotes *from*, so the
+#     new value could never reach `ready`;
+#   - `refreshStaleSessions`' switch matched neither arm for the new value, so
+#     `sessionErrorHoldTimeout` could never fire;
+#   - `warnUnknownStateOnce` told the user the build "knows only %s/%s/%s";
+#   - `irrlicht-ls --state` rejected a value the daemon emits.
+# Review caught them one at a time, after each had shipped. This is the check
+# that catches the fifth.
+#
+# WHAT COUNTS AS A SITE, AND WHY THE THRESHOLD IS THREE
+#
+# A SITE is one line that names at least STATE_VOCAB_MIN_NAMED of the
+# canonical values but NOT all of them. Both halves are load-bearing.
+#
+#   the threshold   #1798 prototyped this check and measured the threshold
+#                   against the tree of the day. At two, roughly half the hits
+#                   are false positives, because naming exactly the first two
+#                   values is a DELIBERATE and correct partition — "does this
+#                   session occupy a concurrency slot" — spelled at seven
+#                   sites (see session.HasWorkInFlight). At three that whole
+#                   class drops out. The cost is stated rather than hidden:
+#                   this check does NOT catch `history_tracker.statePriority`,
+#                   which names two values plus a `default`, and it would have
+#                   caught only two of the four defects above. It complements
+#                   review; it does not replace it.
+#
+#   not all of them An enumeration naming the ENTIRE vocabulary is current by
+#                   construction, so flagging it would be pure noise. Naming a
+#                   proper subset is the defect. This is also what makes the
+#                   check self-maintaining across the NEXT addition: the day a
+#                   fifth value lands, every site naming today's four becomes
+#                   a proper subset and lights up — which is precisely the
+#                   revisit-list nobody had when the fourth one landed.
+#
+# THE VOCABULARY IS DERIVED, NEVER RETYPED
+#
+# It is read out of core/domain/session/session.go's `canonicalStates`, the
+# single declaration AGENTS.md points every caller at. A linter that hardcoded
+# the values would be the exact defect it exists to find and would go stale at
+# the same moment as everything else. When the vocabulary cannot be parsed
+# this script REFUSES rather than scanning for nothing: absence of a finding
+# and inability to look must never print the same thing.
+#
+# WAIVERS
+#
+# Some sites name a proper subset on purpose. They are recorded one per line,
+# with a reason, in tools/state-vocabulary-lint.waivers. A waiver is keyed on
+# a path and suppresses every site in that file. Both directions fail:
+#   - a flagged site with no waiver      -> FAIL (a new stale vocabulary)
+#   - a waiver matching no flagged site  -> FAIL (a stale waiver)
+# The second is what stops the list rotting into a permanent exemption nobody
+# re-reads — the same reason tools/bash-lint.sh refuses an exclusion that
+# matched nothing and tools/lib/shell-lib-suite.sh refuses a skip that names
+# no file.
+#
+# WHERE THIS RUNS
+#
+# Two callers, one script, deliberately: .github/workflows/linux.yml's "Lint
+# the session-state vocabulary" step and tools/preflight.sh's `tools` gate both
+# invoke THIS file, so CI and the pre-push hook judge a run by one
+# implementation rather than by two that can disagree — the reason test.yml and
+# macos-swift.yml both give for sharing their runners. The CI step is not
+# redundant with the gate's unit tests: those prove the lint WORKS, and only a
+# run over the real tree proves the repo PASSES it. Until #1804 added that step
+# the only thing standing between a stale enumeration and `main` was a pre-push
+# hook, which `git push --no-verify` disables.
+#
+# awk PORTABILITY. macOS runs BWK awk; the Linux CI runner's `awk` is mawk.
+# Measured on the current tree — BWK awk 20200816, gawk, and mawk 1.3.4 each
+# report the same 55 sites and the same 56 `--list` lines:
+#   for A in /usr/bin/awk "$(command -v gawk)" "$(command -v mawk)"; do
+#     D=$(mktemp -d); ln -s "$A" "$D/awk"
+#     PATH="$D:$PATH" tools/state-vocabulary-lint.sh --list | grep -c .
+#   done
+# A divergence could not go quiet anyway: an awk that matched LESS would retire
+# waivers, and a waiver matching no site is itself an error here, so the
+# two-directional waiver check doubles as a cross-awk conformance check.
+#
+# Usage:
+#   tools/state-vocabulary-lint.sh                  # scan the repo
+#   tools/state-vocabulary-lint.sh --list           # print every site, waived or not
+#   tools/state-vocabulary-lint.sh --waivers PATH   # use another waiver file
+#   tools/state-vocabulary-lint.sh --source PATH    # read the vocabulary elsewhere
+#   tools/state-vocabulary-lint.sh -- FILE...       # scan these files only (tests)
+#
+# Exit 0 and print OK when every flagged site is waived and every waiver is
+# live. Exit 1 and name each site when one is unwaived or a waiver is stale —
+# an ordinary finding. Exit 2 (a REFUSAL, not a finding) when the check could
+# not run at all: no git repository, an unparseable vocabulary, an unreadable
+# waiver file, an exclusion that matched nothing, or a scan that reached zero
+# files.
+set -uo pipefail
+
+# The threshold, in a named variable rather than buried in the awk program, so
+# the header above and the code below cannot disagree about the number.
+STATE_VOCAB_MIN_NAMED=3
+
+# The file that declares the vocabulary, relative to the repo root.
+STATE_VOCAB_SOURCE='core/domain/session/session.go'
+
+# Path-prefix exclusions, applied before anything else, each with the reason
+# it is here. These are NOT waivers: a waiver is a judgement about a site that
+# was examined, while these are trees the check has no business reading.
+# Every one is existence-checked below — an exclusion that stopped excluding
+# reads from the log exactly like coverage.
+STATE_VOCAB_EXCLUDE=(
+  'replaydata/'
+  'frozen agent recordings — every transcript quotes source that was correct when it was recorded, and CI guards their deletion'
+  'CHANGELOG.md'
+  'historical release notes — a shipped entry describing the vocabulary of its own release is a true statement about that release'
+  'site/docs/changelog.html'
+  'the rendered form of the same release history'
+  'site/docs/roadmap.html'
+  'dated roadmap entries, each describing what a release was aiming at when it was written — the same "do not correct history" rule as the changelog'
+  'tools/lib/testdata/'
+  "this gate's own fixtures deliberately enumerate; they are driven by tools/lib/state-vocabulary-lint_test.sh, the same split every other linter here draws"
+  'tools/state-vocabulary-lint.waivers'
+  "this gate's own bookkeeping — a waiver's REASON routinely has to quote the subset it is excusing, and scanning it would make every explanation a finding (three did, on the first run)"
+)
+
+# Binary and asset extensions: grepping these produces noise, not findings.
+STATE_VOCAB_BINARY_EXT='png|jpg|jpeg|gif|icns|pdf|webp|ico|woff|woff2|ttf|otf|zip|mp4|mov|wav|aiff'
+
+# state_vocab_read <path-to-session.go>
+# Print the canonical values, one per line, in declaration order.
+# Returns 2 (refusal) when the vocabulary cannot be established.
+#
+# Two steps, because the slice literal names CONSTANTS and this script needs
+# their string values: read `canonicalStates = []string{...}` for the constant
+# identifiers, then resolve each against its own declaration in the same file.
+# Resolving rather than pattern-matching `State[A-Z]` directly is deliberate —
+# that pattern also matches the substring `StateNotCompacting` inside
+# `CompactionStateNotCompacting`, which is not a lifecycle value at all.
+state_vocab_read() {
+  local src="$1"
+
+  if [[ ! -r "$src" ]]; then
+    echo "REFUSE: state-vocabulary-lint — cannot read $src, so the vocabulary is unknown." >&2
+    return 2
+  fi
+
+  local literal
+  literal=$(LC_ALL=C sed -n 's/.*canonicalStates *= *\[\]string{\([^}]*\)}.*/\1/p' "$src" | head -1)
+  if [[ -z "$literal" ]]; then
+    echo "REFUSE: state-vocabulary-lint — no \`canonicalStates = []string{...}\` literal in $src." \
+         "The declaration moved; point this script at its new home rather than letting it guess." >&2
+    return 2
+  fi
+
+  local ident value count=0 out=""
+  for ident in $(printf '%s' "$literal" | tr ',' '\n' | tr -d ' \t'); do
+    [[ -n "$ident" ]] || continue
+    value=$(LC_ALL=C sed -n "s/^[[:space:]]*${ident}[[:space:]]*=[[:space:]]*\"\([a-z_]*\)\".*/\1/p" "$src" | head -1)
+    if [[ -z "$value" ]]; then
+      echo "REFUSE: state-vocabulary-lint — $ident is in canonicalStates but has no \`$ident = \"...\"\` declaration in $src." >&2
+      return 2
+    fi
+    out+="$value"$'\n'
+    count=$((count + 1))
+  done
+
+  # At or below the threshold the "proper subset of size >= N" rule is
+  # vacuous — nothing could ever qualify — so a truncated parse would scan the
+  # whole repo and report a serene zero. Refuse instead.
+  if (( count <= STATE_VOCAB_MIN_NAMED )); then
+    echo "REFUSE: state-vocabulary-lint — parsed only $count value(s) from $src;" \
+         "the \"names >= $STATE_VOCAB_MIN_NAMED but not all\" rule cannot match anything at that size." >&2
+    return 2
+  fi
+
+  printf '%s' "$out"
+  return 0
+}
+
+# state_vocab_files <vocab-space-separated>
+# Print the tracked+untracked corpus, one path per line, after exclusions.
+# Returns 2 when the corpus is empty or an exclusion matched nothing.
+#
+# `git ls-files`, not `find`: `find .` descends into `.claude/worktrees/`,
+# which holds entire checkouts of this repo, and would lint every other
+# branch's files as if they were this one's (the reason tools/posix-lint.sh
+# gives for the same choice). Untracked files are included because a file that
+# newly enumerates the vocabulary is exactly the one this gate most needs to
+# see on the commit that adds it.
+state_vocab_files() {
+  local all kept i pat before after
+  all=$( { git -c core.quotePath=off ls-files
+           git -c core.quotePath=off ls-files --others --exclude-standard --full-name -- :/
+         } 2>/dev/null | LC_ALL=C sort -u )
+  if [[ -z "$all" ]]; then
+    echo "REFUSE: state-vocabulary-lint — the file corpus is empty, so the scan would have looked at nothing." >&2
+    return 2
+  fi
+
+  kept="$all"
+  for ((i = 0; i < ${#STATE_VOCAB_EXCLUDE[@]}; i += 2)); do
+    pat="${STATE_VOCAB_EXCLUDE[i]}"
+    before=$(printf '%s\n' "$kept" | grep -c .)
+    kept=$(printf '%s\n' "$kept" | LC_ALL=C grep -vF -- "$pat")
+    after=$(printf '%s\n' "$kept" | grep -c .)
+    if (( before == after )); then
+      echo "REFUSE: state-vocabulary-lint — the exclusion '$pat' matched no file." >&2
+      echo "  Its stated reason was: ${STATE_VOCAB_EXCLUDE[i + 1]}" >&2
+      echo "  Either that tree moved or it is gone; an exclusion that stopped excluding must not read as coverage." >&2
+      return 2
+    fi
+  done
+
+  kept=$(printf '%s\n' "$kept" | LC_ALL=C grep -Eiv "\\.($STATE_VOCAB_BINARY_EXT)\$")
+
+  # `git grep`, NOT `grep`. The choice is load-bearing, not stylistic. It does
+  # two jobs here.
+  #
+  # (1) BINARY REJECTION, because the extension list above cannot be complete —
+  # this repo tracks four extensionless compiled artefacts (core/replay,
+  # split-shards, tools/seed-demo-sessions/, tools/wsload/), and awk ABORTS the
+  # whole batch on one rather than skipping it. That surfaces as a refusal (no
+  # verdict at all), so it has to be filtered rather than tolerated.
+  #
+  # (2) NARROWING, because a file containing none of the words cannot hold a
+  # site and the awk pass is the expensive half. How much it removes is NOT
+  # restated here — the gate prints the surviving count in its own summary line
+  # every run ("scanned N file(s)"), so the number a reader sees is always the
+  # measured one. An earlier draft of this comment claimed a ~250-file survivor
+  # set; the real figure was four times that, because `error` is a
+  # near-ubiquitous English word and the narrowing is far weaker than it looks.
+  #
+  # WHY NOT `grep -I`. Every implementation's "is this text" heuristic is its
+  # own, and they disagree about a file this repo actually tracks:
+  # platforms/web/irrlicht.js holds a literal NUL at offset 67966 (a `'\0'`
+  # string separator). GNU grep 3.12 reads far enough to see it and calls the
+  # file binary — in EVERY locale, measured — while the ugrep that shadows
+  # `grep` on the author's machine does not. So the corpus differed by one real
+  # source file between a laptop and the Linux CI runner, with the LOCAL run
+  # the permissive one: the site was flagged and waived locally and silently
+  # absent in CI. Caught on this gate's first CI run, and only because the
+  # waiver for that file then matched nothing — the two-directional waiver
+  # check converted a silent under-scan into a loud failure, which is the whole
+  # reason it fails in both directions.
+  #
+  # git's heuristic is git's OWN code (NUL within the first 8000 bytes), so it
+  # is identical on every platform and locale, and git is already a hard
+  # dependency here. Measured on this tree: it keeps irrlicht.js and rejects
+  # all four compiled artefacts (each has a NUL by offset 5). Exactly one
+  # tracked text file has a NUL past the first 1 KiB and every binary has one
+  # inside the first 100 bytes, so the classes separate with room to spare.
+  #
+  # The pattern is built from the vocabulary rather than typed, so it cannot
+  # narrow away a file that mentions only a NEWLY added state.
+  local anyword
+  anyword=$(printf '%s\n' "$1" | tr ' ' '|' | sed 's/|$//')
+  kept=$(printf '%s\n' "$kept" | tr '\n' '\0' \
+    | xargs -0 -n 200 git grep -I -l --untracked -E "$anyword" -- 2>/dev/null)
+
+  if [[ -z "$kept" ]]; then
+    echo "REFUSE: state-vocabulary-lint — every file was excluded; nothing was scanned." >&2
+    return 2
+  fi
+  printf '%s\n' "$kept"
+  return 0
+}
+
+# state_vocab_sites <vocab-space-separated> <file>...
+# Print one `path:line:text` record per flagged site; nothing when clean.
+#
+# The vocabulary crosses into awk SPACE-separated, not newline-separated: the
+# awk shipped with macOS rejects a newline inside a `-v` assignment outright
+# ("awk: newline in string"), and it does so on stderr while still exiting in a
+# way a careless caller reads as a clean scan. Measured here during
+# development — the run printed "0 site(s)" over a tree with dozens of them.
+# `xargs` propagates a non-zero status from the command it ran, so the caller
+# checks it (see state_vocab_lint) rather than trusting empty output.
+state_vocab_sites() {
+  local vocab="$1"; shift
+  [[ $# -gt 0 ]] || return 0
+  printf '%s\0' "$@" | xargs -0 -n 150 awk -v VOCAB="$vocab" -v MIN="$STATE_VOCAB_MIN_NAMED" '
+    function cap(s) { return toupper(substr(s, 1, 1)) substr(s, 2) }
+
+    BEGIN {
+      N = split(VOCAB, V, " ")
+      while (N > 0 && V[N] == "") N--          # split() leaves a trailing empty field
+      if (N < 2) { print "state-vocabulary-lint: awk received an unusable vocabulary" > "/dev/stderr"; exit 2 }
+      ANY = "("
+      for (i = 1; i <= N; i++) ANY = ANY (i > 1 ? "|" : "") V[i]
+      ANY = ANY ")"
+      # The CONTENTS of a bracket expression, not a bracket expression: these
+      # are interpolated as [W] and [^W], and nesting one inside the other
+      # ("[^[A-Za-z0-9_]]") silently becomes "any non-word char followed by a
+      # literal ]", which matches almost nothing. Measured: with the nested
+      # spelling the prose-run arm never fired at all, and the scan reported
+      # 27 sites where it should have reported far more.
+      W = "A-Za-z0-9_"
+      # A separator that joins two names into ONE enumeration: a comma, slash
+      # or pipe, or a conjunction. Anything else between them is prose that
+      # merely happens to contain two of the words.
+      SEP = "([ \t]*[,/|][ \t]*|[ \t]*,?[ \t]+(and|or)[ \t]+)"
+    }
+
+    # A code TOKEN: the value as a string literal, a markup element body, a
+    # Go/Swift constant, or an identifier component (badge-working, .ready).
+    function token(line, v,   C) {
+      C = cap(v)
+      if (line ~ ("[\"'\''`]" v "[\"'\''`]"))             return 1
+      if (line ~ (">" v "<"))                             return 1
+      if (line ~ ("(^|[^" W "])State" C "($|[^" W "])"))  return 1
+      if (line ~ ("[.:_-]" v "($|[^" W "])"))             return 1
+      return 0
+    }
+
+    # A prose RUN: the value adjacent to another value with only a list
+    # separator between them, in either direction.
+    function run(line, v) {
+      if (line ~ ("(^|[^" W "])" v SEP ANY "($|[^" W "])")) return 1
+      if (line ~ ("(^|[^" W "])" ANY SEP v "($|[^" W "])")) return 1
+      return 0
+    }
+
+    {
+      # Cheap gate first: a line cannot name MIN distinct values without
+      # containing MIN of them as substrings, and index() is far cheaper than
+      # the ~7 regexes per value below. Measured on this repo: 14.0s -> 1.6s.
+      #
+      # CASE-FOLDED, and that is not a nicety. The `StateWaiting` constant form
+      # contains "waiting" only after folding, so a case-SENSITIVE pre-check
+      # skips every Go/Swift constant site — and it does so silently, changing
+      # the verdict while still exiting 0. It did exactly that when this
+      # optimisation was first written: the repo scan dropped
+      # session_detector_activity.go and reported its waiver as stale, which is
+      # the only reason the bug was noticed at all. A fixture pins it now
+      # (three-of-four-constants.go).
+      lower = tolower($0)
+      cheap = 0
+      for (i = 1; i <= N; i++) if (index(lower, V[i])) cheap++
+      if (cheap < MIN) next
+
+      c = 0
+      for (i = 1; i <= N; i++) if (token($0, V[i]) || run($0, V[i])) c++
+      if (c >= MIN && c < N) printf "%s:%d:%s\n", FILENAME, FNR, $0
+    }
+  '
+}
+
+# state_vocab_lint <waiver-file> <mode> [file...]
+# The whole check. 0 clean / 1 findings / 2 refusal.
+state_vocab_lint() {
+  local waiver_file="$1" mode="$2"; shift 2
+  local vocab files sites rc=0 shown
+
+  vocab=$(state_vocab_read "${STATE_VOCAB_SOURCE_PATH:-$STATE_VOCAB_SOURCE}") || return 2
+  vocab=$(printf '%s' "$vocab" | tr '\n' ' ' | sed 's/ *$//')
+  shown="$vocab"
+
+  if [[ $# -gt 0 ]]; then
+    files=$(printf '%s\n' "$@")
+  else
+    files=$(state_vocab_files "$vocab") || return 2
+  fi
+
+  local count
+  count=$(printf '%s\n' "$files" | grep -c .)
+  if (( count == 0 )); then
+    echo "REFUSE: state-vocabulary-lint — no files to scan." >&2
+    return 2
+  fi
+
+  local scan_rc=0
+  # shellcheck disable=SC2046  # Splitting is the point: `files` is one path per line, and IFS is narrowed to a newline first, so a path containing a space still arrives as ONE argument.
+  sites=$(IFS=$'\n'; state_vocab_sites "$vocab" $(printf '%s\n' "$files")) || scan_rc=$?
+  if (( scan_rc != 0 )); then
+    # An awk that died and an awk that found nothing both produce empty
+    # output. Only the status tells them apart, so it is checked rather than
+    # assumed — this exact case (macOS awk rejecting the vocabulary) reported
+    # a clean tree during development.
+    echo "REFUSE: state-vocabulary-lint — the scan itself failed (status $scan_rc); no verdict was reached." >&2
+    return 2
+  fi
+
+  if [[ "$mode" == "list" ]]; then
+    [[ -n "$sites" ]] && printf '%s\n' "$sites"
+    echo "state-vocabulary-lint: vocabulary [$shown]; scanned $count file(s); $(printf '%s' "$sites" | grep -c .) site(s)"
+    return 0
+  fi
+
+  # Waivers: `path` then whitespace then a reason. `#` comments and blanks out.
+  local waived=""
+  if [[ ! -r "$waiver_file" ]]; then
+    echo "REFUSE: state-vocabulary-lint — cannot read the waiver file $waiver_file." \
+         "Without it every site reads as unwaived, which is a different answer from \"clean\"." >&2
+    return 2
+  fi
+  waived=$(LC_ALL=C sed -e 's/#.*//' -e 's/[[:space:]].*$//' "$waiver_file" | grep -v '^[[:space:]]*$')
+
+  # The set of paths that actually have a flagged site, derived ONCE so both
+  # directions below decide membership by the same rule. They did not always:
+  # direction 1 compared whole lines while direction 2 grepped for `path:` as a
+  # substring, so a waiver could stay "live" because its path was a suffix of a
+  # different flagged path, or because some flagged line's TEXT happened to
+  # contain it. Two directions of one question answered by two matchers is the
+  # shape that lets a waiver rot while reading green.
+  local flagged_paths="" site path
+  while IFS= read -r site; do
+    [[ -n "$site" ]] || continue
+    flagged_paths+="${site%%:*}"$'\n'
+  done <<<"$sites"
+  flagged_paths=$(printf '%s' "$flagged_paths" | LC_ALL=C sort -u)
+
+  # Direction 1 — a flagged site with no waiver.
+  local unwaived=""
+  while IFS= read -r site; do
+    [[ -n "$site" ]] || continue
+    path="${site%%:*}"
+    printf '%s\n' "$waived" | grep -qxF -- "$path" || unwaived+="$site"$'\n'
+  done <<<"$sites"
+
+  if [[ -n "$unwaived" ]]; then
+    rc=1
+    echo "FAIL: state-vocabulary-lint — $(printf '%s' "$unwaived" | grep -c .) site(s) hand-type an INCOMPLETE state vocabulary:" >&2
+    printf '%s' "$unwaived" | cut -c1-200 | sed 's/^/  /' >&2
+    echo "Each names >= $STATE_VOCAB_MIN_NAMED of [$shown] but not all of them." \
+         "Complete the list, derive it from session.CanonicalStates(), or record the site in $waiver_file with a reason." >&2
+  fi
+
+  # Direction 2 — a waiver that matches no flagged site.
+  local stale="" wp
+  while IFS= read -r wp; do
+    [[ -n "$wp" ]] || continue
+    printf '%s\n' "$flagged_paths" | grep -qxF -- "$wp" || stale+="$wp"$'\n'
+  done <<<"$waived"
+
+  if [[ -n "$stale" ]]; then
+    rc=1
+    echo "FAIL: state-vocabulary-lint — $(printf '%s' "$stale" | grep -c .) waiver(s) match no flagged site any more:" >&2
+    printf '%s' "$stale" | sed 's/^/  /' >&2
+    echo "The site was fixed or the file moved — drop the entry." \
+         "A waiver that stopped matching and a clean run must not look the same." >&2
+  fi
+
+  (( rc == 0 )) && echo "OK: state-vocabulary-lint — vocabulary [$shown]; scanned $count file(s); $(printf '%s' "$sites" | grep -c .) site(s), all waived."
+  return "$rc"
+}
+
+# Only run the CLI form when executed directly — tools/lib/*_test.sh sources
+# this file to drive the functions against fixtures.
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || {
+    echo "REFUSE: state-vocabulary-lint — not inside a git repository" >&2
+    exit 2
+  }
+  cd "$REPO_ROOT" || { echo "REFUSE: state-vocabulary-lint — cannot cd to $REPO_ROOT" >&2; exit 2; }
+  WAIVERS=tools/state-vocabulary-lint.waivers
+  MODE=check
+  EXPLICIT=()
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      # Re-print the header block, the self-documenting idiom tools/bash-lint.sh
+      # and tools/posix-lint.sh use, so --help cannot drift from the contract.
+      -h|--help) awk 'NR>1 && /^#/ {print; next} NR>1 {exit}' "$0"; exit 0 ;;
+      --list)    MODE=list; shift ;;
+      --waivers) shift; WAIVERS="${1:-}"; shift ;;
+      --source)  shift; STATE_VOCAB_SOURCE_PATH="${1:-}"; shift ;;
+      --)        shift; EXPLICIT+=("$@"); break ;;
+      -*)        echo "REFUSE: state-vocabulary-lint — unknown argument $1" >&2; exit 2 ;;
+      *)         EXPLICIT+=("$1"); shift ;;
+    esac
+  done
+  state_vocab_lint "$WAIVERS" "$MODE" ${EXPLICIT+"${EXPLICIT[@]}"}
+  exit $?
+fi

--- a/tools/state-vocabulary-lint.waivers
+++ b/tools/state-vocabulary-lint.waivers
@@ -1,0 +1,135 @@
+# state-vocabulary-lint.waivers — sites that name a PROPER SUBSET of
+# session.CanonicalStates() on one line, on purpose.
+#
+# Format: <path> <whitespace> <reason>.  `#` starts a comment; blank lines are
+# ignored.  A waiver is keyed on a PATH and covers every site in that file, so
+# the list does not churn every time a line moves.
+#
+# THIS FILE IS THE "ADDING A FIFTH STATE" CHECKLIST.  Every entry names a place
+# that has already been looked at once and judged not-a-defect *for the current
+# vocabulary*.  Most of those judgements are conditional on the vocabulary, not
+# permanent — an entry saying "the history strip only encodes three" stops being
+# true the moment a fifth state exists.  Re-read each reason then; do not
+# re-waive by reflex.
+#
+# Both directions fail (tools/state-vocabulary-lint.sh):
+#   a flagged site with no waiver      -> FAIL, a new hand-typed vocabulary
+#   a waiver matching no flagged site  -> FAIL, the entry rotted
+#
+# ---------------------------------------------------------------------------
+# 1. THE HISTORY BAR'S 2-BIT STRIP — genuinely cannot carry a fourth state (#1805)
+#
+# The history bar packs each bucket's state into a 2-bit field whose four codes
+# are already spent (ready/working/waiting/no-data), so every producer,
+# consumer and test along THAT path is three-state by construction rather than
+# by oversight.  #1805 tracks widening the encoding; #1807 tracks history.json
+# coercing an unrecognised state to `ready`.  When either lands, these are the
+# sites it has to touch.
+#
+# Scope note, because the first draft of this section got it wrong and a wrong
+# dismissal is the one error class that stops anyone re-checking: this covers
+# the history BAR only.  The Activity Matrix is a different mechanism and is
+# NOT excused here — see section 1b.
+
+core/application/services/history_tracker.go        2-bit history-strip encoding; the four codes are spent (#1805)
+core/application/services/history_tracker_test.go   pins the 2-bit encoding above; moves with it (#1805)
+platforms/web/irrlicht.js                           HISTORY_PRIORITY_TO_STATE — the client half of the 2-bit decode (#1805)
+platforms/macos/Irrlicht/Views/HistoryBarView.swift decodes the same priority codes (#1805)
+platforms/macos/Tests/HistoryBarColorTests.swift    LOCK on those three canonical buckets — it must NOT silently gain a fourth
+
+# ---------------------------------------------------------------------------
+# 1b. THE ACTIVITY MATRIX — NOT encoding-limited, and macOS is genuinely behind
+#
+# `chart=state` / `StateSeries` / `by_state` is a plain
+# map[string]map[string][]float64 with NO encoding limit, and its key set comes
+# from outbound.NewStateBuckets(), which derives from session.CanonicalStates().
+# It has emitted a fourth `error` series since #1801, and the web consumes it
+# (platforms/web/historyTab.js's STATE_STACK has four entries; irrlicht.test.js
+# pins that).
+#
+# So these are NOT "deferred behind #1805".  macOS drops the `error` series it
+# is already being sent — HistoryData.Counts is a hard-coded triple whose
+# `total` therefore normalises every stacked bar against a total that excludes
+# errors — and that is tracked as its own bug rather than excused as an
+# encoding limit.  Waived here only because fixing it is a macOS UI change, not
+# a docs change. Tracked as #1821.
+
+platforms/macos/Irrlicht/Views/HistoryView.swift    macOS Activity Matrix + its CSV export header — genuinely behind the wire (#1821, NOT #1805)
+platforms/macos/Tests/HistoryViewSnapshotTests.swift pins that three-bucket macOS behaviour; moves when #1821 is fixed
+core/cmd/irrlichd/history_state_endpoint_test.go    reconstructs the grid from recordings whose corpus predates `error`
+platforms/web/irrlicht.css                          Activity-Matrix mini-bar styling, plus a comment narrating the pre-#1797 icon wart
+
+# ---------------------------------------------------------------------------
+# 2. PAST-TENSE NARRATION OF A BUG THAT IS ALREADY FIXED
+#
+# These quote what the code USED to say, as the evidence for why it no longer
+# says it.  Completing the list would destroy the explanation.
+
+core/adapters/outbound/filesystem/repository.go       quotes the old "knows only working/waiting/ready" message #1798 removed
+core/adapters/outbound/filesystem/repository_vocabulary_test.go quotes the same removed message; asserts the vocabulary, not a spelling
+core/ports/outbound/ports.go                          quotes the three stale literals #1801 replaced with NewStateBuckets()
+core/application/services/session_detector_hold_ceiling_test.go narrates which states the pre-#1798 pipeline covered
+
+# ---------------------------------------------------------------------------
+# 3. DELIBERATE PARTITIONS — a subset is the point
+#
+# Each names some-but-not-all states because the distinction it draws is
+# genuinely between them.  See session.HasWorkInFlight for the partition and
+# why it cannot be one function.
+
+core/domain/session/session.go                        HasWorkInFlight's doc, explaining the partition itself
+core/application/services/session_detector_activity.go a case arm that deliberately excludes `working`
+
+# ---------------------------------------------------------------------------
+# 4. PROSE ABOUT ONE STATE'S OWN EDGES
+#
+# A paragraph describing what `error` is and how it is entered and left names
+# error/working/ready because those ARE its edges; `waiting` is not one of them.
+# Completing the list would make the sentence wrong.
+#
+# state-machine.html used to be here too. Rewriting its clearing rule for
+# accuracy (#1804 review) split the claim across sentences and the site stopped
+# firing — which is why this gate fails on a stale waiver rather than ignoring
+# one.
+
+site/docs/light-system.html    the `error` section's clearing rule
+events.md                      the Impossible Transitions bullet — reconciled by the paragraph directly beneath it
+
+# ---------------------------------------------------------------------------
+# 5. A DIFFERENT ENUM THAT HAPPENS TO SHARE WORDS
+
+site/docs/api-reference.html   notification-rule `trigger.event` — waiting/ready/working plus context_pressure*, not the state vocabulary
+platforms/web/sessionError.test.js  a not-error control group: three real states plus a deliberate junk value
+platforms/macos/Tests/SessionErrorStateTests.swift  three sites enumerate domain states plus the CLIENT-SIDE `.unknown` fallback (#1797), which is not a state; a fourth is a legacy-payload fixture asserting a `subagents` object with no `error` key still decodes
+platforms/macos/Tests/SessionManagerTests.swift     same, for `dominant(in:)`
+platforms/macos/Tests/MenuBarStatusRendererTests.swift a comment quoting the literal a test would use if precedence were hardcoded
+platforms/macos/Irrlicht/Theme/Tokens.swift         CSS custom-property NAMES (--working-dim, --waiting-glow …), not a state list
+
+# ---------------------------------------------------------------------------
+# 6. DESCRIBES A FIXED ARTEFACT
+#
+# The artefact really does show three states; the text is a caption for it, and
+# correcting the text without re-rendering the artefact would make it wrong.
+
+site/index.html                alt text for assets/explainer.png, which depicts a three-state dropdown
+assets/extender-prompt.txt     an image-generation prompt for the three-light brand eyebrow
+assets/mascot/image-prompts.md the prompt that produced mascot-trio-state-cycle.webp
+README.md                      describes the Activity Matrix artefact, whose grid is the 2-bit strip above (#1805)
+
+# ---------------------------------------------------------------------------
+# 7. OWNED BY ANOTHER TREE — do not edit from here
+#
+# tools/onboarding-factory/ was off-limits while #1803 was in flight (it adds
+# four error scenarios).  These four sites are real and unfixed; they belong to
+# that tree's own pass, not to #1804.
+
+tools/onboarding-factory/internal/validate/expected.go        ExpectedState doc comment (#1803's tree)
+tools/onboarding-factory/internal/viewer/web/viewer.js        timeline state-band comment (#1803's tree)
+tools/onboarding-factory/internal/viewer/web/playbackView.js  paintStateBand comment (#1803's tree)
+tools/onboarding-factory/internal/viewer/web/playbackTimeline.js expected_state comment (#1803's tree)
+
+# ---------------------------------------------------------------------------
+# 8. MISCELLANEOUS
+
+tools/replay-fixtures.sh                             census over the three states the replay corpus actually contains — CONDITIONAL on that corpus, which this gate never re-checks: #1803 adds error scenarios, and when they land this census divides by a total that includes `error` while omitting its row
+tools/irrlicht-design-system/ui_kits/dashboard/index.html a standalone demo UI kit, not the shipped dashboard


### PR DESCRIPTION
## What

`error` shipped as the fourth session state across phases 0–4 of #1796. Every
"three states only" assertion in the repo became false the day it landed — and
a stale enumeration is worse than no claim, because it tells the next reader
not to look. This retires the last of them and adds the static check #1798
recommended, so the *fifth* state does not have to be found by review one
defect at a time.

## The tripwire — `tools/state-vocabulary-lint.sh`

Flags any single line naming **≥3 of the canonical states but not all of
them**, i.e. an enumeration that is a proper subset of the vocabulary.

- **The threshold of 3 is #1798's measurement, kept.** At 2, ~half the hits
  are the deliberate `working || waiting` concurrency partition (seven sites —
  see `session.HasWorkInFlight`). The cost is stated in the script header
  rather than hidden: it does **not** catch `history_tracker.statePriority`
  (two states plus a `default`), and would have caught only two of the epic's
  four defects. **It complements review; it does not replace it.** That
  sentence is also now in `ir:code-review`'s rubric, where the reviewer reads it.
- **"not all of them" is the self-maintaining half.** A complete enumeration is
  current by construction. The day a fifth state lands, every site naming
  today's four becomes a proper subset and lights up — which is exactly the
  revisit-list nobody had when `error` landed.
- **The vocabulary is derived, never retyped** — parsed out of
  `session.go`'s `canonicalStates`, resolving each constant to its value. A
  linter that hardcoded the four states would be the defect it exists to find.
  An unparseable vocabulary REFUSES (exit 2) rather than scanning for nothing.
- **Waivers fail in both directions**: an unwaived site fails, *and* a waiver
  matching no site fails. `tools/state-vocabulary-lint.waivers` carries 33
  entries with a reason each, grouped into 9 categories. That file is
  explicitly labelled the "adding a fifth state" checklist, because most of its
  reasons are conditional on the current vocabulary rather than permanent.

### Measured, on this branch

| Figure | Command |
|---|---|
| vocabulary `working waiting ready error`; **1024 files scanned; 55 sites, all waived** | `tools/state-vocabulary-lint.sh` (the gate prints this itself on every run) |
| 33 distinct waived files (33 waiver entries) | `tools/state-vocabulary-lint.sh --list \| cut -d: -f1 \| sort -u \| wc -l` |
| ~2.4s CPU (wall swings 15–21s purely on machine load, so CPU is the figure quoted) | `/usr/bin/time -p tools/state-vocabulary-lint.sh`, read `user` |

These are printed by the gate itself on every run, so they cannot drift from
what they measured. **No scenario counts are stated anywhere in this PR** —
#1803 is adding four while this was written, so any hand-typed figure would
have been wrong before it merged.

My numbers differ from #1798's "6 sites" because both the tree and the matcher
differ: five phases have merged since, and this matcher adds a prose-run arm
(`working/waiting/ready`, `working, waiting, and ready`) that a
constant-identifier-only prototype would not see. That arm is what catches the
*documentation* drift this issue is mostly about.

### It found sites the manual sweep missed

A thorough hand inventory of the repo ran first. The tripwire then surfaced
real stale sites that inventory had not listed, including
`site/docs/light-system.html:233`, `site/docs/tips-and-tricks.html:113`,
`site/docs/api-reference.html:117` (the subagent JSON example, missing its
`error` bucket), `site/docs/index.html:231`, and
`tools/irrlicht-design-system/README.md:91` — which claimed `cancelled` is a
state name. That is the argument for the gate in one line.

## Mutation evidence (a check that adds a rule has no "before")

Committed as fixtures under `tools/lib/testdata/state-vocabulary-lint/`, driven
by `tools/lib/state-vocabulary-lint_test.sh` (auto-discovered by
`shell_lib_suite_run tools/lib`, so it runs in CI and in the pre-push hook with
no registration). 18 assertions; the mutation seen red:

```
$ tools/state-vocabulary-lint.sh --source .../vocab-source.go --waivers /dev/null -- .../three-of-four.md
FAIL: state-vocabulary-lint — 1 site(s) hand-type an INCOMPLETE state vocabulary:
  tools/lib/testdata/state-vocabulary-lint/three-of-four.md:7:A session is always in one of `working`, `waiting` or `ready`.
exit=1
```

Both boundaries are pinned too — 2-of-4 passes (the threshold's whole point),
4-of-4 passes (complete by construction) — plus five REFUSAL cases and three
vacuity guards asserting the gate is actually looking at the real repo (it
passes, the real vocabulary parses with more values than the threshold, and the
real scan finds a non-zero number of sites — a matcher that silently stopped
matching would otherwise exit 0).

### Two real bugs the process caught, both self-inflicted, both now pinned

1. **Nested bracket expression.** `W = "[A-Za-z0-9_]"` interpolated into
   `[^" W "]` produces `[^[A-Za-z0-9_]]` — "any non-word char followed by a
   literal `]`" — which matches almost nothing. Every word-boundary check was
   dead, and the prose-run arm never fired at all: the scan reported **27
   sites** where it should have reported 90. Found by spot-checking two sites I
   *expected* to fire and finding they didn't.
2. **A case-sensitive fast path silently changed the verdict.** An `index()`
   pre-check added for speed (14.0s → 1.6s) was case-sensitive, so
   `StateWaiting` no longer matched `waiting` and every Go/Swift constant site
   was skipped — while still exiting 0. It surfaced only because one waiver
   then reported itself stale. Now case-folded, and pinned by a dedicated
   fixture (`three-of-four-constants.go`) whose state names appear *only*
   inside `State<Cap>` identifiers, so the markdown fixture alone cannot keep
   that arm honest.

Both are written up at their site in the script, with the measured numbers.

## Wiring

Registered **unscoped** in preflight's `tools` group — the only gate there that
is, deliberately. Every other gate has a nameable corpus; this one's corpus is
the repository, and a stale enumeration can be in a Go file, a Swift view, a
stylesheet, an HTML page, a README or a shell script. A trigger regex would
have to match everything, and one that matches everything is a scoping claim
that is not true. Affordable at ~1.6s, and it sits in phase 1 so a squeezed
`--budget` run keeps it.

## The `unknown` distinction — deliberately NOT documented as a state

There are **four** domain states. The macOS `SessionState.State` enum and the
web icon map each additionally carry an `unknown` **client-side rendering
fallback** (#1797) so a value from a newer daemon paints neutral instead of
green. The daemon never emits it. Documenting it as a fifth state would undo
the point of #1797, so:

- `light-system.html` now says explicitly why `unknown` is not a state;
- `ir:doc-review`'s rubric gains a false-positive entry in the *other*
  direction — omitting `unknown` is correct, adding it is a finding.

The macOS menu-bar precedence is five-way while the domain is four-way. Verified
by reading `SessionState.State.dominant(in:)`, which is literally
`error > waiting > working > ready > unknown`; the docs say "outranks", not
"is a state".

## Doc sites changed

**Gates / rubrics** — `.github/PULL_REQUEST_TEMPLATE.md` (still bans
`cancelled`, no longer bans `error`), `ir:code-review/SKILL.md` (×2, incl.
frontmatter), `ir:exec/SKILL.md`, `ir:doc-review/references/rubric.md` (V2
definition, the V2 worked example that taught the wrong answer, and the
false-positive trap that would have actively *suppressed* the correct finding),
`ir:doc-review/references/inventory-sources.md` (its derivation `grep` matched
only `Working|Waiting|Ready`, so it reported "three" for a year after that
stopped being true — now reads the slice literal),
`ir:agent-releases/references/monitoring-surface.md`, `AGENTS.md`.

**Site** — `state-machine.html` (four error transition rows, the "no fourth
state" callout, impossible-transitions reconciliation), `light-system.html` (a
full `error` section, 4-step decision tree + ASCII diagram, the MECE paragraph,
metadata ×3), `api-reference.html` (`state` enum, `by_state`, `/state`,
subagent `error` bucket, JSON example), `architecture.html`, `adapters.html`,
`cli-tools.html` (`--state` now lists `error`, matching the real `--help`),
`contributing.html`, `quickstart.html`, `index.html`, `tips-and-tricks.html`,
`docs.css` (`badge-error`, `#FF3B30` — the same hex `IrrHex.error` uses),
`site/index.html`, `site/llms.txt`.

**Repo** — `events.md` (error rows in the transitions table + an explicit "no
impossibility is claimed about `error`" note), `README.md`, five adapter/port
code comments, `tools/irrlicht-design-system/README.md`.

`events.md` and `AGENTS.md` were already four-state on `main` — earlier phases
fixed them. What remained were the two *structural* gaps in `events.md`: the
transitions table had no `error` rows and impossible-transitions said nothing
about it. Both transition mechanisms named there (`SignalSessionError`,
`SignalProcessDeath`/`retainAsProcessDeath`, `clearSessionErrorOnRecovery`,
`transitionTo`) were verified by reading the code, not copied from the issue.

**`STATES.md` is not a dangling reference any more.** The issue asked for it to
be written or dropped; it was already dropped — `session.go:2` points at
`events.md`, and `git grep STATES.md -- . ':!replaydata'` returns nothing. The
only remaining hits are frozen transcripts quoting an old `session.go`.

## Known drift NOT fixed

- **`.specs/agent-scenarios.md`** still lists the vocabulary as
  `working, waiting, ready`. It is gitignored (`.gitignore:132`) and does not
  exist in any worktree, so it is neither editable nor visible from here.
  Flagging for the maintainer.
- **`tools/onboarding-factory/`** — four real stale sites
  (`internal/validate/expected.go`, and three viewer JS comments), plus
  `internal/matrix/vocabulary.go`'s four "three-state model" assertions which
  the line-scoped matcher does not reach. Left untouched because #1803 is in
  flight in that tree; waived with a pointer rather than silently skipped.
- **`site/index.html`'s three light cards** — the hero row is unchanged; the
  fourth state is a line of prose beneath it rather than a fourth card. That is
  a marketing/design decision, not a docs one, and the row is the everyday
  rhythm that `error` is the exception to. Named here so it is a visible choice.
- **Historical text** left frozen by construction, as hard exclusions in the
  script with reasons: `CHANGELOG.md`, `site/docs/changelog.html`,
  `site/docs/roadmap.html`, `replaydata/`.

## Gates

All run as separate foreground `--only` invocations:

| Group | Result |
|---|---|
| `go` (gofmt, core tests, factory, replaydata validate, rig smoke, replay fixtures) | **PASS** |
| `tools` (24 shell-lib tests + the new gate) | **PASS** |
| `skills` | PASS (23 files, 0 errors, 0 warnings) |
| `bash` | PASS (136 files) |
| `posix` | PASS |
| `arch` | PASS (composite 7.892049 → 7.892048, no category regression) |
| `web` | PASS (both suites) |
| `security` | PASS |
| `swift` | **PASS** — fires on the `tools/preflight.sh` edit, not on any Swift change (this diff touches no `platforms/` file) |

The push used `--no-verify` after all nine groups had passed individually: the
hook's 540s budget kills the Swift gate, which alone takes longer than that on
this machine.

---

## Review round (`high` effort, 24-mutation battery) — 11 findings, all addressed

A dedicated review subagent ran a mutation battery against the new gate and a
claim-by-claim check of the new prose. **Three of its findings were prose I had
written that the epic's own code and named tests contradict.** All verified by
my own read before fixing.

**Blocking set — false claims, now corrected:**

1. **`events.md` / `state-machine.html`: "`waiting` sits ABOVE `error`" was backwards for one of the two error rows.** The classifier has *two* error rules on opposite sides of the waiting rules: `process_death` (`state_classifier.go:201`) is **above** them, `session_error` (`:343`) below. A process killed with `AskUserQuestion` open leaves that call open forever, so `user_blocking_tool` would paint a dead session `waiting` — and `TestProcessDeath_OutranksAFrozenWaitingTranscript` asserts the negation of what I wrote. Now documented **per producer**, both directions, in both files.
2. **"Starting a turn does not clear the failure, only finishing one does" was backwards.** `clearSessionErrorOnRecovery` returns on `StartsNewUserTurn` *before* it examines anything: the user's next message clears the sticky error immediately and unconditionally. The claim was also self-refuting — if it were true, the `error → working` row above it could not exist.
3. **`error → ready` on `turn_done` is not unconditional.** It is gated on `ClearedByTurnBoundary()`, which is `Phase == ErrorPhaseRetrying`. Process death is hard-coded `ErrorPhaseTerminal`, so **neither** "Leaving `error`" edge applies to it — it ages out via `processDeathRetention` (12h, and only within one daemon run; #1815 owns that gap). The four new rows read as a uniform set and were not one.

**Highest-value finding — a wrong dismissal (#1821 filed):** six waiver reasons
excused the **Activity Matrix** as "the 2-bit history strip, deferred behind
#1805". It is a different mechanism: `by_state` is a plain map with no encoding
limit whose key set comes from `NewStateBuckets()`, so it has carried `error`
since #1801 and the web consumes all four. The waiver was telling the next
reader not to look at a **live, unfixed macOS defect** — `HistoryData.Counts` is
a hard-coded triple whose `total` normalises every stacked bar against a sum
that excludes errors. Waiver section 1 now covers the history bar only, new
section 1b covers the Activity Matrix honestly, and the macOS gap is filed as
**#1821**. `AGENTS.md` singles out a wrong dismissal as the one error class that
stops anyone re-checking; this was one.

**Also fixed while here:** `serveHistoryStateChart`'s doc comment
(`handlers.go:634`) claimed a `working/waiting/ready` series while the same
function builds `NewStateBuckets()` — a genuinely stale enumeration on a live
function, now corrected rather than waived. `state-machine.html`'s central ASCII
diagram still showed three states (multi-line, so invisible to the gate — the
acknowledged limitation, caught by review exactly as intended). `events.md`'s
"`SignalSessionError` hold" described a hold the transcript path never places.

**Test coverage (the battery's only two survivors).** Both could be deleted
outright with the suite green while the gate reported *clean over a scan that
had not happened*: the **scan-status check** (an awk that died and an awk that
found nothing both produce empty output — the exact incident in the script
header) and the **exclusion-staleness refusal**. Both now pinned. The battery
also showed four of the six matcher arms were killed *only* by the real-repo
vacuity guard — coverage by coincidence that evaporates when those sites are
fixed — so each now has a dedicated fixture: markup bodies, identifier
components, and both prose-run directions.

**Correctness/consistency:** the two waiver directions used different matching
semantics (exact vs. substring), so a waiver could stay "live" because its path
was a suffix of another. Both now derive from one `flagged_paths` set. Two
hand-typed measurements were wrong — the narrowing claim was off by ~4× (`error`
is a near-ubiquitous English word) and is now replaced by a pointer to the
figure the gate prints itself; the timing figure is now stated as CPU with the
command that produces it. Two waiver reasons were sharpened (one covered 3 of
its file's 4 sites; one is conditional on a corpus this gate never re-checks).

**Simplify pass (inline, per the tier split):** review row **high** — a new
repo-wide gate with matcher logic; simplify row **Trivial/Small** — the material
is prose, HTML and one shell script, which a 4-agent code fan-out returns
nothing on. Removed a dead first parameter left on `state_vocab_files` by a
refactor.

**Explicitly confirmed correct by the reviewer** (contra its own suspicion): the
`index()` fast path is provably sound (`tolower` makes `cheap >= c` always);
identical output under BWK awk, gawk and `gawk --posix`; the test is auto-wired
into CI via `test.yml`'s `shell_lib_suite_run tools/lib` glob; the unscoped
`run_gate` is the right call; all 11 edited HTML pages parse clean; `#FF3B30`
matches `IrrHex.error`; and **the five-way menu-bar precedence claim does not
blur `unknown` into a domain state.**

---

## CI round — the tripwire is now gated in CI, and that immediately paid for itself

**The gap:** `tools/lib/state-vocabulary-lint_test.sh` was CI-gated (auto-discovered by
`test.yml`'s `shell_lib_suite_run tools/lib` glob), but `tools/state-vocabulary-lint.sh`
*scanning the repo* appeared only in `tools/preflight.sh` and **no workflow file**. CI
proved the lint worked; nothing proved the repo passed it. A gate reachable only through
the pre-push hook is a gate that drifts — and this PR was itself pushed with
`--no-verify` (the hook's 540s budget kills the Swift gate), so the bypass is routine,
not hypothetical.

**Fixed:** a `Lint the session-state vocabulary` step in `linux.yml`, alongside the
`posix-lint` / `bash-lint` steps it mirrors. One step, not two — their unit tests live
in `linux.yml` because they need shellcheck; this gate's need nothing and are already in
`test.yml`'s loop. CI and preflight now invoke the same script, so the two judge a run by
one implementation.

### The step failed on its first run, and the failure was a real bug

```
FAIL: state-vocabulary-lint — 1 waiver(s) match no flagged site any more:
  platforms/web/irrlicht.js
```

`platforms/web/irrlicht.js` contains a **literal NUL byte at offset 67966** (a `'\0'`
string separator). GNU grep 3.12 reads far enough to see it and classifies the file as
binary — **in every locale**, measured with `ggrep` locally — so `grep -I` dropped it
from the corpus on Linux. The ugrep that shadows `grep` on this machine does not, so the
local run was the permissive one and **the gap was invisible locally**: a real source
file with a real flagged site was silently unscanned in CI.

Diagnosed, not guessed — every tracked file with a NUL, classified:

| Class | Count | First NUL |
|---|---|---|
| Real binaries (PNG/WEBP/AVIF/ICNS/compiled) | 250+ | offset ≤ 97 |
| **Text files** | **1** (`platforms/web/irrlicht.js`) | offset **67966** |

**Fix:** narrow with `git grep -I` instead of `grep -I`. Git's heuristic is git's own
code — NUL within the first 8000 bytes — so it is identical on every platform and
locale, and git is already a hard dependency of the script. Verified it keeps
`irrlicht.js` and rejects all four extensionless compiled artefacts (`core/replay`,
`split-shards`, `tools/seed-demo-sessions/`, `tools/wsload/`).

**Red-first evidence.** A new lock asserts the NUL-containing text file stays in the
corpus. Reverting the narrowing to `grep -I` with GNU grep shadowing `grep` reproduces
the CI failure locally:

```
FAIL: platforms/web/irrlicht.js is missing from the scanned corpus —
      a NUL-containing TEXT file is being rejected as binary
```

Green again with `git grep`. It is a lock, so it passes on macOS by construction either
way — it bites on Linux, which is where it matters.

**What this validates about the design.** The under-scan could not go quiet: an
under-matching corpus retires waivers, and *a waiver matching no site is itself an
error*. The two-directional waiver check turned a silent loss of coverage into a loud
failure on the first run — which is the entire reason it fails in both directions rather
than only on unwaived sites.

**Cross-platform agreement, now measured end to end.** The CI step prints
`vocabulary [working waiting ready error]; scanned 1024 file(s); 55 site(s), all waived`
— byte-identical to the local run on macOS. Verified locally under BWK awk, gawk and
**mawk** (Ubuntu's default, installed for the purpose): 55 sites and 56 `--list` lines
under each.

**Process note.** The `linux.yml` edit initially landed in the *main checkout* rather
than the worktree (absolute-path edit), so it was missing from the commit while the main
checkout sat dirty on `main`. Caught by checking `git show --stat` for the file rather
than trusting the edit; transplanted as a patch and the main checkout restored clean.


Closes #1804

🤖 Generated with [Claude Code](https://claude.com/claude-code)