### PR TITLE
fix(factory): observe driver teardown instead of asserting it

### DIFF
--- a/.claude/skills/ir:onboarding-factory/record/SKILL.md
+++ b/.claude/skills/ir:onboarding-factory/record/SKILL.md
@@ -243,8 +243,23 @@ to Step 2's diagnosis rather than overriding it.
 lazy-transcript nudge or trailing-sleep timing issue). On a second failure, or
 on a classified `cli_not_found` / `cli_too_old` / `auth_failed` /
 daemon-not-running, return `status: infra_fail` (don't loop, don't mark the cell
-un-doable — the environment is the problem). When unsure of the failure class,
-classify the staging dir:
+un-doable — the environment is the problem).
+
+**Never retry `driver_session_leaked` blind (#1825).** The driver returned while
+its agent was still running, so a retry starts a SECOND live agent in the same
+workspace beside the first. Both write into the recording, and the fixture that
+comes out is of two interleaved sessions rather than the scenario. Kill the
+survivor the manifest names — `.tmux_teardown_detail` carries the session name,
+so `tmux kill-session -t <name>` — then retry at most once. A leak that recurs
+is a driver bug: go to that agent's `driver-interactive.sh` teardown, not to a
+third run.
+
+**`driver_teardown_unverifiable` is not evidence the run was clean** — it means
+the check could not look at all (no `tmux` binary, an unreadable session list).
+Return `status: infra_fail` and fix the host rather than promoting the staging
+dir. `daemon_not_ready` and `replay_failed` are `infra_fail` too.
+
+When unsure of the failure class, classify the staging dir:
 
 ```bash
 bash tools/onboarding-factory/scripts/lib/classify-failure.sh <staging-dir>

--- a/docs/ci-gates.md
+++ b/docs/ci-gates.md
@@ -7,7 +7,8 @@ contract family (those live in
 suite (those live in [replay-testing.md](replay-testing.md) and
 [swift-testing.md](swift-testing.md)): the core `go test` + architecture +
 ARS score + CodeScene gates; the skill-file, POSIX-shell, and bash linters and
-the sourced-shell-library and shell-lib-suite-runner tripwires; the
+the recording-driver teardown tripwire and the sourced-shell-library and
+shell-lib-suite-runner tripwires; the
 extract-and-execute harnesses over the ARS badge job, the two other gist
 badge jobs, the replaydata deletion guard, the Swift snapshot-evidence copy
 step, and the Swift test-harness source step; the "which bash a workflow step
@@ -283,6 +284,38 @@ CI parity section (chunking, the budget, and what it makes visible).
   argument. `shell-lib-suite_test.sh` now derives that list from the workflow
   step and existence-checks every name, because the one-file check it had would
   have gone on passing while saying nothing about the new entry.
+
+- Recording-driver teardown: a Go tripwire,
+  `tools/onboarding-factory/internal/driverteardown`, over every
+  `replaydata/agents/*/driver-interactive.sh` enumerated from disk, so a new
+  adapter is covered the day it lands rather than the day someone remembers it.
+  It grades three invariants — an end-of-run `tmux kill-session` is never gated
+  on a liveness flag (INV-1), a driver that launches tmux installs a
+  `trap … EXIT` whose handler tears the session down (INV-2), and every session
+  name it mints carries the driver's own `$$` as a `-`-delimited field (INV-3).
+  It is the STATIC half of a pair: the runtime half is
+  `tools/onboarding-factory/scripts/lib/tmux-teardown-check.sh`, which
+  `run-cell.sh` calls after the driver returns to assert no session carrying
+  that run's `driver.pid` survived. That runtime check matches on the pid
+  alone, so it is only sound while INV-3 holds — which is exactly why INV-3 is
+  enforced rather than assumed, and why the two halves are named in each
+  other's headers.
+  Structure, not text, separates a teardown site from a legitimate step-level
+  guard: both spellings of the gate are byte-identical, so INV-1 grades a
+  `kill-session` inside the EXIT-trap handler or at top level, and leaves one
+  inside an ordinary function alone (kiro-cli's `step_exit_clean` /
+  `step_sigkill` entry guards are correct — `reset_session` aliases a retired
+  slot number onto a live slot's pane). The accepted blind spot is a driver
+  that moves its end-of-run sweep into a helper function; INV-2 still binds
+  there. Every structural assumption is a refusal rather than a best-effort
+  parse — an unclosed function, an unbalanced `if`/`fi`, a `tmux new-session`
+  with no `-s`, an empty file, or a driver where INV-1 graded nothing all
+  return errors, so "found no violation" and "could not look" never produce
+  the same output. #1825 is the incident: `step_exit_clean` signalled a
+  graceful exit, slept a second, and marked the slot dead without observing
+  it; the teardown loop was gated on that flag and skipped the only session
+  that needed killing. Nine recordings in one morning each leaked a live
+  `claude` and its tmux session.
 
 - Sourced shell libraries: not a contract family — a tripwire,
   `tools/lib/shell-lib-errexit_test.sh`, over every `tools/lib/*.sh` that is

--- a/docs/ci-gates.md
+++ b/docs/ci-gates.md
@@ -289,10 +289,26 @@ CI parity section (chunking, the budget, and what it makes visible).
   `tools/onboarding-factory/internal/driverteardown`, over every
   `replaydata/agents/*/driver-interactive.sh` enumerated from disk, so a new
   adapter is covered the day it lands rather than the day someone remembers it.
-  It grades three invariants — an end-of-run `tmux kill-session` is never gated
-  on a liveness flag (INV-1), a driver that launches tmux installs a
-  `trap … EXIT` whose handler tears the session down (INV-2), and every session
-  name it mints carries the driver's own `$$` as a `-`-delimited field (INV-3).
+  It grades four invariants — a `tmux kill-session` in the EXIT-trap handler or
+  at top level is never gated on a liveness flag (INV-1), a driver that launches
+  tmux installs a `trap … EXIT` whose handler tears the session down (INV-2),
+  every session name it mints carries the driver's own `$$` as a `-`-delimited
+  field (INV-3), and a handler that writes `driver.exit-reason` cannot write the
+  verdict variable's INITIAL value on an abort path (INV-4).
+  INV-4 is the one guarding a regression the #1825 fix would otherwise have
+  shipped, so it is the one most easily weakened by accident: before that fix an
+  aborting driver wrote no `driver.exit-reason` at all and `run-cell.sh` read the
+  absence as `unknown`, but a trap writing `"$EXIT_REASON"` unconditionally turns
+  that absence into the initialiser — `ok` — reporting SUCCESS for a run that
+  never formed a verdict. Nine drivers had that hole, six of them before the trap
+  work started. A handler writing a literal rather than a variable has no
+  initial-value hazard and is exempt BY DERIVATION, not by an allowlist
+  (opencode, whose inline trap writes no verdict at all).
+  INV-1 says "at top level", not "the end-of-run sweep", and the two are not the
+  same set: a driver whose step dispatch is a top-level `while … case` — copilot
+  today — has its per-step kills classified as teardown. They are ungated, so it
+  passes; the note matters because a kiro-cli-shaped step guard would read as a
+  violation there.
   It is the STATIC half of a pair: the runtime half is
   `tools/onboarding-factory/scripts/lib/tmux-teardown-check.sh`, which
   `run-cell.sh` calls after the driver returns to assert no session carrying
@@ -363,6 +379,25 @@ CI parity section (chunking, the budget, and what it makes visible).
   `_budget_kill_tree`'s own guard reddens the tripwire and leaves
   `gate-budget_test.sh`'s whole `-e` block green, because that helper is only
   ever reached through a region `budget_run` guards separately.
+- Two defaults for shell logic, both learned the hard way and both re-broken
+  inside the very PR that documented them (#1825, caught at review):
+  - **A suite under a `lib/` directory is DISCOVERED, never listed.**
+    `shell_lib_suite_run <dir>` globs `*_test.sh`, so a hand-written
+    "run this suite" block beside it does not add coverage — it re-runs a suite
+    the glob already found, and it re-creates the membership-by-hand problem the
+    glob exists to remove. #1803 added two suites that a hand-typed list did not
+    notice; #1825 then added two blocks four lines below the glob that had
+    already picked them up, and each of those suites ran twice.
+  - **Shell logic that needs a RUNTIME test gets marker-extracted, not
+    re-implemented in the test.** Wrap the block in `# BEGIN <name>` /
+    `# END <name>`, have the test extract and `eval` it against stubs, and make a
+    missing marker a loud REFUSAL rather than an empty pass — a test that
+    reimplements the code under test passes while the real code is broken, which
+    is the same "graded nothing" failure a vacuity guard exists to catch.
+    `tools/onboarding-factory/scripts/lib/run-cell-multi-teardown_test.sh` is the
+    reference; the drivers' `cleanup()` handlers use it to prove INV-4's guard
+    actually rewrites an aborted verdict, which the static checker cannot see.
+
 - The shell-lib suite runner: `tools/lib/shell-lib-suite.sh` is the ONE
   implementation behind test.yml's "Test the shared shell libs" step and
   `tools/preflight.sh`'s `tools` gate. Before #1639 those were two copies of

--- a/replaydata/_lib/drive/contracts.sh
+++ b/replaydata/_lib/drive/contracts.sh
@@ -10,6 +10,41 @@
 #
 # Sourced as a library; MUST NOT call `set` at top level.
 
+# ONE FILE OF THE STAGING CONTRACT IS NOT WRITTEN BY THE DRIVER (#1825).
+#
+#   <staging>/driver.pid — written by run-cell.sh, before the driver starts, and
+#   never read or written by any driver. Everything else under <staging> that
+#   the contract names is produced by emit_session_contract below; this one is
+#   produced by the caller, about the driver, and that asymmetry is exactly what
+#   makes it easy to break without noticing.
+#
+# WHAT DEPENDS ON IT. run-cell.sh's tmux-teardown gate uses that pid as the
+# RUN'S IDENTITY: after the driver returns, it asks tmux for its session list
+# and fails the cell if any session carries the pid as a '-'-delimited field —
+# which works only because every interactive driver embeds its own `$$` in every
+# session name it creates (`claudecode-onboard-<ts>-<pid>`, `ocdrv-<pid>-<ts>`,
+# `aider-onboard-<uuid8>-<pid>`, …). Two ways to break the gate silently:
+#
+#   1. Change how the driver is INVOKED. run-cell.sh gets the pid by having
+#      `bash -c` write its own `$$` and then `exec` the driver into that same
+#      process, so driver.pid holds the pid the driver will actually run as. Any
+#      wrapper that forks between the write and the driver — a pipeline, a
+#      `( … )`, `nohup`, a `timeout` that does not exec — makes driver.pid name
+#      a DIFFERENT process from the one whose pid is in the session names, and
+#      the gate then passes on every run without ever matching anything.
+#      run-cell-multi.sh does not need the file (it backgrounds its drivers, so
+#      `$!` is that same pid) and therefore does not write one.
+#   2. Change how the driver NAMES its tmux sessions. Drop `$$` from the name,
+#      or bury it inside a larger field (`pid<pid>`, `<ts><pid>`), and the same
+#      thing happens — the gate looks, matches nothing, and reports "clean".
+#      A static per-driver tripwire under tools/onboarding-factory/internal/
+#      asserts the `$$`-as-a-whole-field convention for every adapter, so this
+#      half is caught; the invocation half above is only caught by the wiring
+#      assertions in scripts/lib/tmux-teardown-check_test.sh.
+#
+# Both failure modes are silent PASSES, not errors, which is why they are
+# written down here rather than left to be rediscovered.
+#
 # emit_session_contract <primary_session_uuid>
 #   Finalizes the combined stdout log and writes the staging contract:
 #   driver.exit-reason, session.uuid (=$1) + transcript.path (slot 1), and the

--- a/replaydata/_lib/drive/drive-lib_test.sh
+++ b/replaydata/_lib/drive/drive-lib_test.sh
@@ -8,6 +8,11 @@
 # session/pid-death polls, which touch only bash arrays + the filesystem
 # (tmux/kill calls are faked below) — are the automated net for the
 # extraction. Run directly or via scripts/smoke-test.sh.
+#
+# The last section grades something else: not a shared helper, but the
+# `cleanup()` EXIT trap each interactive driver ships, extracted from the
+# driver's own source text and executed here (#1825). See its banner for why
+# that lives in this file rather than in a new one.
 
 set -uo pipefail   # NOT -e: assertions capture non-zero return codes
 
@@ -264,6 +269,347 @@ assert_eq "empty pid: falls back to a flat sleep" 1 "$SLEEP_CALLS"
 assert_eq "empty pid: sleeps for max_wait"        1 "$SLEEP_ARG"
 
 unset -f kill sleep
+
+# =============================================================================
+# The REACHED_EPILOGUE verdict guard, graded against every shipped cleanup()
+# =============================================================================
+# #1825 gave every interactive driver's EXIT trap a guard that REWRITES the
+# verdict when the driver aborted before its epilogue: such a run never formed
+# one, so EXIT_REASON still holds its initial "ok", and writing that reports
+# SUCCESS for a failed run. Rewriting a verdict is the riskiest behaviour in
+# that change and nothing in the tree executed it. The static tripwire
+# (tools/onboarding-factory/internal/driverteardown, INV-4) checks only that a
+# guard of that SHAPE exists, and says in its own doc comment that it cannot see
+# whether the value written denotes failure or whether the sentinel is set in
+# the right place. Running the handler is what closes that.
+#
+# HOW IT GETS AT THEM. A driver is a top-to-bottom script — sourcing one would
+# launch a real agent under tmux — so each `cleanup()` is delimited in its driver
+# by `# BEGIN cleanup` / `# END cleanup`, EXTRACTED from the driver's source text
+# here, and eval'd against stubs. Same extract-and-execute idiom as
+# scripts/lib/run-cell-multi-teardown_test.sh (run-cell-multi.sh's functions) and
+# tools/lib/*_test.sh (a workflow step's `run:` block), and for the same reason:
+# it stops this section grading a COPY of a handler that has drifted from the one
+# that ships. A handler whose markers moved is a REFUSAL, not a silent pass —
+# every arm below would otherwise grade an empty string.
+#
+# WHAT "DENOTES FAILURE" MEANS HERE, and why it is not a list of reason strings
+# re-typed in a test: each written reason is fed back through `drive_exit` —
+# contracts.sh's own EXIT_REASON→process-exit-code mapping, sourced at the top of
+# this file — and the arms assert the CODE. So "the abort arm recorded a failure"
+# is graded by the rig's own definition of failure.
+#
+# WHY THIS FILE and not a new cleanup-guard_test.sh: scripts/smoke-test.sh (the
+# CI entry point, test.yml) names the replaydata/_lib/drive suites BY HAND, and
+# the only directory it discovers by glob is scripts/lib/. A new file here would
+# be a suite nothing runs — the same absence-reads-as-success shape #1825 is
+# about. This file is already named there and already matches `*_test.sh`, so the
+# section runs today and keeps running if that hand-written list becomes a
+# shell_lib_suite_run over this directory. Split it out the moment it does.
+
+echo ""
+echo "== REACHED_EPILOGUE verdict guard: every driver's real cleanup(), executed (#1825) =="
+
+# extract_block <file> <name> — the lines strictly between `# BEGIN <name>` and
+# `# END <name>`.
+extract_block() {
+  awk -v n="$2" '
+    $0 ~ ("^# BEGIN " n "([ \t]|$)") { inb = 1; next }
+    inb && $0 ~ ("^# END " n "[ \t]*$") { inb = 0; next }
+    inb { print }
+  ' "$1"
+}
+
+# driver_constants <file> — the driver's own top-level LITERAL constant
+# assignments (NONZERO_2='nonzero(2)', EXIT_DRIVER_FAULT="nonzero(2)", …). The
+# fault reason a handler writes must come from the DRIVER, never be re-typed
+# here, or these arms would grade this file's idea of the vocabulary. Two passes
+# so neither pattern has to contain the other quote character; the double-quoted
+# form excludes `$` and a backtick, so nothing eval'd from here can expand or run
+# anything. A constant this misses is not a silent empty string: the arms run
+# under `set -u`, so the handler aborts and the arm reports that nothing was
+# written.
+driver_constants() { # <driver>
+  { grep -E "^[A-Z_][A-Z0-9_]*='[^']*'$" "$1" || true; }
+  { grep -E '^[A-Z_][A-Z0-9_]*="[^"$`]*"$' "$1" || true; }
+}
+
+# run_cleanup_arm <driver> <block-src> <reached-epilogue> <initial-reason>
+#   Executes the extracted handler and echoes the reason it wrote to
+#   driver.exit-reason — or a loud NO-…-WRITTEN token carrying the handler's
+#   stderr, so "the handler recorded nothing" can never read as "the handler
+#   recorded the empty string".
+run_cleanup_arm() {
+  local file="$1" src="$2" reached="$3" initial="$4" dir consts
+  dir="$(mktemp -d "$TMP/arm.XXXXXX")"
+  consts="$(driver_constants "$file")"
+  # shellcheck disable=SC2034  # every assignment in this subshell is read by the
+  # EVAL'd cleanup() extracted from the driver above, which the linter cannot
+  # follow. Deleting one would abort the arm under `set -u`, not weaken it.
+  (
+    set -u   # the drivers run under `set -euo pipefail`; -u is the half that
+             # turns a constant this harness failed to supply into a loud abort
+             # rather than an empty expansion.
+    tmux() { return 0; }               # every handler's kill-session
+    kill_tree() { return 0; }          # gemini-cli
+    restore_settings() { return 0; }   # hermes
+    N_SLOTS=1
+    SES_SESSION=("" "fake-tmux-1")
+    SES_TMUX=("" "fake-tmux-1")        # claudecode names its slot array this
+    SES_PANE_PID=("" "424242")         # gemini-cli
+    SESSION="fake-tmux-1"              # aider has no slot model, just a scalar
+    STAGING="$dir"
+    eval "$consts"
+    eval "$src"
+    REACHED_EPILOGUE="$reached"
+    EXIT_REASON="$initial"
+    cleanup
+  ) >/dev/null 2>"$dir/arm.stderr"
+  if [[ -f "$dir/driver.exit-reason" ]]; then
+    cat "$dir/driver.exit-reason"
+  else
+    printf 'NO-driver.exit-reason-WRITTEN(%s)' "$(tr '\n' ' ' < "$dir/arm.stderr")"
+  fi
+  return 0
+}
+
+# drive_exit_code <reason> — what contracts.sh's OWN mapping turns that reason
+# into. Subshelled because drive_exit never returns; it exits.
+drive_exit_code() {
+  local rc=0
+  # shellcheck disable=SC2034  # EXIT_REASON is drive_exit's only input; the
+  # linter cannot see the read because it lives in the sourced contracts.sh.
+  ( EXIT_REASON="$1"; drive_exit ) || rc=$?
+  echo "$rc"
+  return 0
+}
+
+# strip_guard <block-src> — the MUTATION: delete the guard's `if … fi` so the
+# handler writes "$EXIT_REASON" unconditionally, which is what every driver did
+# before #1825 added the guard.
+strip_guard() {
+  awk '
+    /if \[\[ "\$REACHED_EPILOGUE"/ { drop = 1; next }
+    drop && /^[[:space:]]*fi[[:space:]]*$/ { drop = 0; next }
+    drop { next }
+    { print }
+  ' <<< "$1"
+}
+
+assert_ne() {
+  local label="$1" unexpected="$2" actual="$3"
+  [[ "$actual" != "$unexpected" ]] && pass "$label (got [$actual])" || fail "$label" "anything but [$unexpected]" "$actual"
+  return 0
+}
+assert_nonzero() {
+  local label="$1" actual="$2"
+  [[ "$actual" =~ ^[0-9]+$ && "$actual" -ne 0 ]] && pass "$label (exit $actual)" || fail "$label" "a non-zero exit code" "$actual"
+  return 0
+}
+
+# --- Enumerate the subjects FROM DISK --------------------------------------
+# Not a hand-written list: a driver added tomorrow is graded by this section
+# without anyone remembering to add it, and an enumeration that comes back
+# empty REFUSES rather than reporting a clean run over nothing.
+AGENTS_DIR="$(cd "$DIR/../../agents" && pwd)"
+TEMPLATE="$DIR/../../../tools/onboarding-factory/scripts/templates/drive-interactive.sh.tmpl"
+
+ALL_DRIVERS=()
+for f in "$AGENTS_DIR"/*/driver-interactive.sh; do
+  [[ -e "$f" ]] && ALL_DRIVERS+=("$f")
+done
+if [[ ${#ALL_DRIVERS[@]} -eq 0 ]]; then
+  echo "drive-lib_test: REFUSING — no */driver-interactive.sh under $AGENTS_DIR." >&2
+  echo "  This section would have graded nothing and printed ALL PASS." >&2
+  exit 1
+fi
+
+# The scaffold template mints the NEXT driver, so its handler is graded too — a
+# template that lost the guard would hand it to every adapter onboarded after.
+if [[ ! -r "$TEMPLATE" ]]; then
+  echo "drive-lib_test: REFUSING — cannot read the scaffold template at $TEMPLATE." >&2
+  echo "  If it moved, point this at the new path; a missing scaffold must not read as a clean run." >&2
+  exit 1
+fi
+
+HANDLERS=(); HANDLER_NAMES=(); INLINE_TRAP_NAMES=()
+for f in "${ALL_DRIVERS[@]}"; do
+  agent="$(basename "$(dirname "$f")")"
+  if grep -q '^cleanup() {' "$f"; then
+    HANDLERS+=("$f"); HANDLER_NAMES+=("$agent")
+  else
+    INLINE_TRAP_NAMES+=("$agent")
+  fi
+done
+if [[ ${#HANDLERS[@]} -eq 0 ]]; then
+  echo "drive-lib_test: REFUSING — none of the ${#ALL_DRIVERS[@]} drivers defines a top-level cleanup()." >&2
+  echo "  Either the handlers were renamed or this section stopped being able to find them." >&2
+  exit 1
+fi
+HANDLERS+=("$TEMPLATE"); HANDLER_NAMES+=("scaffold-template")
+
+# The hole this closes: a driver that declares the sentinel but whose handler
+# this section cannot reach would be silently ungraded.
+for f in "${ALL_DRIVERS[@]}"; do
+  if grep -q '^REACHED_EPILOGUE=' "$f" && ! grep -q '^cleanup() {' "$f"; then
+    echo "drive-lib_test: REFUSING — $f declares REACHED_EPILOGUE but defines no cleanup()." >&2
+    echo "  Its guard would be ungraded here. Give it a marked cleanup(), or grade its trap another way." >&2
+    exit 1
+  fi
+done
+
+echo "  census: ${#ALL_DRIVERS[@]} driver-interactive.sh on disk, $(( ${#HANDLERS[@]} - 1 )) with a cleanup() handler, +1 scaffold template = ${#HANDLERS[@]} handlers graded"
+echo "  census: graded: ${HANDLER_NAMES[*]}"
+if [[ ${#INLINE_TRAP_NAMES[@]} -gt 0 ]]; then
+  echo "  census: no cleanup() (inline EXIT trap, no REACHED_EPILOGUE sentinel): ${INLINE_TRAP_NAMES[*]}"
+fi
+
+# --- Three arms per handler, plus its guard-deleted mutant ------------------
+ARMS_GRADED=0
+MUTANTS_GRADED=0
+for idx in "${!HANDLERS[@]}"; do
+  f="${HANDLERS[$idx]}"; agent="${HANDLER_NAMES[$idx]}"
+  src="$(extract_block "$f" cleanup)"
+  if [[ -z "$src" ]]; then
+    echo "drive-lib_test: REFUSING — no '# BEGIN cleanup' … '# END cleanup' block in $f." >&2
+    echo "  Every arm for $agent would have graded an empty string. Restore the markers or rename them here too." >&2
+    exit 1
+  fi
+  if ! grep -q '^cleanup() {' <<< "$src"; then
+    echo "drive-lib_test: REFUSING — the cleanup marker block in $f does not define cleanup()." >&2
+    exit 1
+  fi
+
+  # ARM 1 — aborted before the epilogue, no verdict ever formed. EXIT_REASON is
+  # still its initial "ok"; recording that is the defect #1825 exists to stop.
+  r="$(run_cleanup_arm "$f" "$src" 0 ok)"
+  assert_ne     "$agent: abort with no verdict is NOT recorded as ok" "ok" "$r"
+  assert_nonzero "$agent:   …and drive_exit reads what it wrote as a FAILURE" "$(drive_exit_code "$r")"
+
+  # ARM 2 — aborted, but a verdict WAS formed. The guard must not overwrite it:
+  # a timeout reported as a driver fault misdirects every triage that follows.
+  r="$(run_cleanup_arm "$f" "$src" 0 timeout)"
+  assert_eq "$agent: a verdict already formed survives the abort path" "timeout" "$r"
+  assert_eq "$agent:   …and still maps to timeout's own exit code" "124" "$(drive_exit_code "$r")"
+
+  # ARM 3 — the epilogue ran. EXIT_REASON is this run's real verdict.
+  r="$(run_cleanup_arm "$f" "$src" 1 ok)"
+  assert_eq "$agent: epilogue reached → ok is recorded as-is" "ok" "$r"
+
+  ARMS_GRADED=$((ARMS_GRADED + 3))
+
+  # MUTATION (AGENTS.md: a check a change ADDS has no "before the fix" to run
+  # red, so mutate the thing it protects and COMMIT the mutation). The mutant is
+  # DERIVED from the shipped block on every run rather than pinned as a static
+  # copy, so it cannot drift away from the handler it mutates — and a deletion
+  # that changed nothing is a refusal, because the arm below would then be
+  # grading the unmutated handler and would pass for the wrong reason.
+  mut="$(strip_guard "$src")"
+  if [[ "$mut" == "$src" ]]; then
+    echo "drive-lib_test: REFUSING — deleting the guard changed nothing in $f's cleanup()." >&2
+    echo "  The guard's shape moved, so the counterfactual below would grade the UNMUTATED handler." >&2
+    exit 1
+  fi
+  if grep -q 'REACHED_EPILOGUE' <<< "$mut"; then
+    echo "drive-lib_test: REFUSING — $f's mutant still references REACHED_EPILOGUE; the deletion was partial." >&2
+    exit 1
+  fi
+  r="$(run_cleanup_arm "$f" "$mut" 0 ok)"
+  assert_eq "$agent: MUTANT (guard deleted) records ok for an aborted run" "ok" "$r"
+  assert_eq "$agent:   …which drive_exit reads as SUCCESS — the defect the guard prevents" "0" "$(drive_exit_code "$r")"
+  MUTANTS_GRADED=$((MUTANTS_GRADED + 1))
+done
+
+# The census has to add up: a `continue` or an early `break` added to the loop
+# above would otherwise leave handlers ungraded and this section still green.
+assert_eq "every handler was graded on all three arms" "$(( ${#HANDLERS[@]} * 3 ))" "$ARMS_GRADED"
+assert_eq "every handler was also graded against its guard-deleted mutant" "${#HANDLERS[@]}" "$MUTANTS_GRADED"
+
+# --- The exit_clean cap is ONE number, in one place -------------------------
+# A LOCK, not a defect test: it pins what the #1825 review's finding 3 settled
+# rather than reproducing a bug. Six drivers passed a literal 2 that had been
+# inherited from a pre-#1018 `sleep 2` — free to overrun as a settle, ruinous as
+# the hard deadline the strict poll turned it into. They now pass
+# DRIVE_EXIT_CLEAN_CAP_S, whose definition in teardown.sh carries the
+# justification. A literal creeping back in is a number with no justification
+# attached, and the next one need not match the others.
+echo ""
+echo "== the exit_clean cap is DRIVE_EXIT_CLEAN_CAP_S everywhere, never a literal (#1825) =="
+assert_eq "teardown.sh defines the constant" "15" "${DRIVE_EXIT_CLEAN_CAP_S:-<undefined>}"
+
+CAP_SITES=0
+CAP_LITERAL_SITES=""
+for f in "${ALL_DRIVERS[@]}"; do
+  while IFS= read -r hit; do
+    [[ -z "$hit" ]] && continue
+    lineno="${hit%%:*}"; text="${hit#*:}"
+    # Skip lines that are pure comment — several drivers discuss the poll in
+    # prose. The line-number prefix is stripped FIRST; testing the raw grep -n
+    # output for a leading `#` never matches and would let a real literal hide.
+    trimmed="${text#"${text%%[![:space:]]*}"}"
+    [[ "$trimmed" == '#'* ]] && continue
+    CAP_SITES=$((CAP_SITES + 1))
+    case "$text" in
+      *'require_tmux_session_gone "'*'" "$DRIVE_EXIT_CLEAN_CAP_S"'*) ;;
+      *) CAP_LITERAL_SITES="$CAP_LITERAL_SITES $(basename "$(dirname "$f")"):$lineno" ;;
+    esac
+  done < <(grep -n 'require_tmux_session_gone ' "$f" || true)
+done
+# Zero call sites means the grep stopped matching, not that every site is
+# compliant — the two must not print the same verdict.
+if [[ "$CAP_SITES" -eq 0 ]]; then
+  echo "drive-lib_test: REFUSING — no require_tmux_session_gone call site found in any driver." >&2
+  echo "  The cap check below would have passed over an empty set." >&2
+  exit 1
+fi
+echo "  census: $CAP_SITES require_tmux_session_gone call site(s) across ${#ALL_DRIVERS[@]} drivers"
+assert_eq "no call site passes a literal cap" "" "$CAP_LITERAL_SITES"
+
+# --- Every driver run-cell.sh exec()s is still EXECUTABLE -------------------
+# A LOCK, not a defect test: nothing here is broken, and its green is not
+# evidence of a fix. run-cell.sh:554 already guards
+# (`[[ -x "$DRIVER" ]] || { echo "driver missing: $DRIVER" >&2; exit 1; }`), so a
+# cleared exec bit DOES fail loudly — but only at record time, on a live run that
+# has already spawned a daemon and is about to drive a real agent CLI. This moves
+# the same finding into the suite, where it costs nothing.
+#
+# It earns its place because the failure is reachable by an ORDINARY edit rather
+# than by carelessness: a scripted `awk … > tmp && mv tmp file` is the obvious
+# way to make one change across eleven drivers, and it silently replaces every
+# file it touches with a fresh 0644 one. That happened while the section above
+# was being written and was caught by hand; nothing in the tree would have
+# caught it, and the diff shows a mode change only if you go looking for one.
+#
+# BOTH driver kinds, because run-cell.sh chooses between them on $SCRIPT_JSON
+# and exec()s whichever it picked: driver-interactive.sh for interactive cells,
+# driver.sh for headless `prompt` cells.
+echo ""
+echo "== every driver run-cell.sh exec()s is executable (#1825) =="
+EXEC_CANDIDATES=()
+for f in "$AGENTS_DIR"/*/driver-interactive.sh "$AGENTS_DIR"/*/driver.sh; do
+  [[ -e "$f" ]] && EXEC_CANDIDATES+=("$f")
+done
+# Zero drivers and eleven compliant drivers must not print the same verdict.
+if [[ ${#EXEC_CANDIDATES[@]} -eq 0 ]]; then
+  echo "drive-lib_test: REFUSING — no driver-interactive.sh or driver.sh under $AGENTS_DIR." >&2
+  echo "  A tripwire that finds no drivers and prints ALL PASS is the failure it exists to prevent." >&2
+  exit 1
+fi
+
+NOT_EXEC=""
+N_HEADLESS=0
+for f in "${EXEC_CANDIDATES[@]}"; do
+  [[ "$f" == */driver.sh ]] && N_HEADLESS=$((N_HEADLESS + 1))
+  # The offending PATH, not a count: "one driver is not executable" sends the
+  # reader back through the whole fleet by hand.
+  [[ -x "$f" ]] || NOT_EXEC="$NOT_EXEC $f"
+done
+echo "  census: ${#EXEC_CANDIDATES[@]} driver(s) checked — $(( ${#EXEC_CANDIDATES[@]} - N_HEADLESS )) interactive + $N_HEADLESS headless"
+# Ties this census to the one the guard section already refused on when empty,
+# so the two enumerations cannot silently disagree about what a driver is.
+assert_eq "the interactive census matches the guard section's enumeration" \
+  "${#ALL_DRIVERS[@]}" "$(( ${#EXEC_CANDIDATES[@]} - N_HEADLESS ))"
+assert_eq "no driver has lost its exec bit" "" "$NOT_EXEC"
 
 echo ""
 if [[ "$fails" -eq 0 ]]; then

--- a/replaydata/_lib/drive/drive-lib_test.sh
+++ b/replaydata/_lib/drive/drive-lib_test.sh
@@ -180,8 +180,38 @@ assert_eq "gone after 3 checks: sleeps 3x" 3 "$SLEEP_CALLS"
 assert_eq "gone after 3 checks: checks 4x" 4 "$HAS_SESSION_CALLS"
 
 HAS_SESSION_TRUE_COUNT=999; HAS_SESSION_CALLS=0; SLEEP_CALLS=0
-wait_tmux_session_gone "sess" 1
+wait_tmux_session_gone "sess" 1; rc=$?
 assert_eq "never gone: capped at max_wait*5 ticks" 5 "$SLEEP_CALLS"
+# LOCK, not a defect test (#1018, restated #1825): returning 0 on a capped-out
+# poll is DELIBERATE here — this function is the settle used by callers that
+# already killed the session themselves. The strict sibling below is what a
+# caller with no other evidence must use. Do not "fix" this to return 1.
+assert_eq "never gone: still returns 0 (deliberate best-effort contract)" 0 "$rc"
+
+echo "== require_tmux_session_gone: strict sibling — non-zero when the cap expires =="
+# Same fakes; the difference under test is purely the return contract.
+HAS_SESSION_TRUE_COUNT=0; HAS_SESSION_CALLS=0; SLEEP_CALLS=0
+require_tmux_session_gone "sess" 2; rc=$?
+assert_eq "already gone: returns 0" 0 "$rc"
+assert_eq "already gone: no sleep" 0 "$SLEEP_CALLS"
+assert_eq "already gone: checks once" 1 "$HAS_SESSION_CALLS"
+
+HAS_SESSION_TRUE_COUNT=3; HAS_SESSION_CALLS=0; SLEEP_CALLS=0
+require_tmux_session_gone "sess" 2; rc=$?
+assert_eq "gone after 3 checks: returns 0" 0 "$rc"
+assert_eq "gone after 3 checks: sleeps 3x" 3 "$SLEEP_CALLS"
+assert_eq "gone after 3 checks: checks 4x" 4 "$HAS_SESSION_CALLS"
+
+# The arm the whole of #1825 turns on: the TUI ignored its exit key, the
+# session is still there when the cap expires, and the caller MUST be told.
+HAS_SESSION_TRUE_COUNT=999; HAS_SESSION_CALLS=0; SLEEP_CALLS=0
+require_tmux_session_gone "sess" 1; rc=$?
+[[ $rc -ne 0 ]] && pass "never gone: returns NON-ZERO" \
+  || fail "never gone: returns NON-ZERO" "non-zero" "$rc"
+assert_eq "never gone: same sleep budget as the best-effort poll" 5 "$SLEEP_CALLS"
+# One observation per tick plus the final one that decided the failure — the
+# verdict is a fresh has-session answer, never inferred from the tick counter.
+assert_eq "never gone: verdict comes from an observation, not the counter" 6 "$HAS_SESSION_CALLS"
 
 unset -f tmux sleep
 

--- a/replaydata/_lib/drive/teardown.sh
+++ b/replaydata/_lib/drive/teardown.sh
@@ -34,6 +34,53 @@ wait_tmux_session_gone() { # <session> [max_wait_secs]
   return 0   # best-effort poll: hitting the cap is not a caller-visible failure
 }
 
+# require_tmux_session_gone <session> [max_wait_secs]
+#   STRICT sibling of wait_tmux_session_gone (#1825). Same 0.2s cadence, same
+#   default cap, same worst-case timing — the ONLY difference is the return
+#   contract: 0 exclusively when `tmux has-session` has actually been observed
+#   to fail (the session is gone), NON-ZERO when the cap expired with the
+#   session still present. It never reports success without an observation.
+#
+#   WHY BOTH EXIST, and which to reach for:
+#     * wait_tmux_session_gone is a SETTLE. The caller has already made the
+#       session's death certain by other means — it killed the session itself
+#       (copilot's restart arm, `tmux kill-session` then wait) or the process
+#       is expected to be gone already — and only wants to avoid racing the
+#       next step. Hitting the cap there is genuinely not a failure, which is
+#       why it returns 0 unconditionally, and drive-lib_test.sh locks that.
+#     * require_tmux_session_gone is a VERIFICATION. The caller asked a live
+#       TUI to exit and has no other evidence it obeyed. #1825: claude answers
+#       a single Ctrl-D with "Press Ctrl-D again to exit" and then lets the
+#       confirmation expire, so nine recording runs sent the key, slept, marked
+#       the slot dead and leaked a live process plus its tmux session while
+#       reporting driver.exit-reason=ok. A poll that cannot fail turns "the
+#       exit key stopped working" into "the exit key worked" — the exact shape
+#       AGENTS.md's "a verification mechanism must fail loudly when it cannot
+#       run" forbids. Every graceful-exit site uses THIS one and acts on the
+#       non-zero: log, kill the session explicitly, set a non-zero EXIT_REASON.
+#
+#   Costs one extra `has-session` call versus the best-effort poll in the
+#   timeout case (the cap is checked INSIDE the loop, after an observation,
+#   so the answer is always a fresh observation rather than an inference from
+#   the tick counter). The sleep budget is identical: max_wait*5 ticks.
+#
+#   Assumes `tmux` is on PATH — every driver hard-fails at launch if it is not
+#   (`command -v tmux || exit 1`). A missing tmux binary would make has-session
+#   fail and read as "gone"; that is out of this poll's reach by design, and is
+#   why the post-run assertion in run-cell.sh checks it can look at all.
+require_tmux_session_gone() { # <session> [max_wait_secs]
+  local session="$1" max_wait="${2:-2}"
+  local ticks=$(( max_wait * 5 )) w=0
+  while tmux has-session -t "$session" 2>/dev/null; do
+    if [[ $w -ge $ticks ]]; then
+      return 1   # cap expired and the session is STILL there — a real failure
+    fi
+    sleep 0.2
+    w=$((w + 1))
+  done
+  return 0       # has-session failed: the session is OBSERVED gone
+}
+
 # wait_pid_gone <pid> [max_wait_secs]
 #   Poll every 0.2s until <pid> no longer exists (kill -0 fails), capped at
 #   <max_wait_secs> (default 1). No-op if <pid> is empty — callers that

--- a/replaydata/_lib/drive/teardown.sh
+++ b/replaydata/_lib/drive/teardown.sh
@@ -68,6 +68,10 @@ wait_tmux_session_gone() { # <session> [max_wait_secs]
 #   (`command -v tmux || exit 1`). A missing tmux binary would make has-session
 #   fail and read as "gone"; that is out of this poll's reach by design, and is
 #   why the post-run assertion in run-cell.sh checks it can look at all.
+#
+#   THE CAP CALLERS SHOULD PASS IS DRIVE_EXIT_CLEAN_CAP_S, below — not a literal,
+#   and NOT this function's `max_wait` default of 2, which exists only so the
+#   best-effort sibling's signature stays unchanged.
 require_tmux_session_gone() { # <session> [max_wait_secs]
   local session="$1" max_wait="${2:-2}"
   local ticks=$(( max_wait * 5 )) w=0
@@ -80,6 +84,53 @@ require_tmux_session_gone() { # <session> [max_wait_secs]
   done
   return 0       # has-session failed: the session is OBSERVED gone
 }
+
+# DRIVE_EXIT_CLEAN_CAP_S — the cap every driver's step_exit_clean hands to
+# require_tmux_session_gone. Defined ONCE: this is a figure that documents
+# behaviour, and a number re-typed at eight call sites plus eight log strings
+# drifts away from the justification below (AGENTS.md, "a number typed once and
+# repeated by hand drifts silently away from what it measured").
+#
+# HOW THIS NUMBER WAS ARRIVED AT — it is NOT a measurement, and saying so is the
+# whole point (#1825 review, finding 3).
+#
+# Six drivers carried `2`. That 2 was inherited verbatim from the flat `sleep 2`
+# the #1018 poll extraction replaced — see wait_tmux_session_gone above, whose
+# own doc says "the same duration as the sleep it replaces, so worst-case timing
+# never regresses". Under that sleep, 2s was a SETTLE BUDGET and overrunning it
+# was FREE: a TUI that took 3s to die still died, the wait just ended early, and
+# nothing failed. #1825 gave that same number a second and far harsher meaning —
+# at the cap the driver now SIGHUPs the pane with `tmux kill-session` and sets a
+# non-zero EXIT_REASON, which run-cell-multi.sh escalates into failing the whole
+# cross-adapter run. A duration chosen when overrunning was free had never been
+# justified as a deadline that truncates a transcript and fails a run, and the
+# fleet's own inconsistency was the tell: copilot and mistral-vibe were given 15.
+#
+# WHY NOT A MEASURED PER-ADAPTER TABLE. That needs live recording runs per
+# adapter on a loaded host, repeated enough to see the tail — a recording-rig
+# exercise, not something this change can produce. It would also have holes in
+# exactly the adapters whose slow case is being bounded: gemini-cli cannot be
+# driven on this host at all (its account is tier-ineligible — see that driver's
+# own note at driver-interactive.sh, "gemini-cli is NOT recordable on the machine
+# this was written on"), and it is one of the two Ink/node TUIs whose V8 teardown
+# plus final transcript flush is the latency actually at issue.
+#
+# So the cap is a deliberately GENEROUS bound rather than a fitted one: 15s, the
+# value copilot and mistral-vibe already carried (mistral-vibe's step_exit_clean
+# calls its teardown "the slowest in the fleet"), applied uniformly so that no
+# adapter is held to a tighter deadline than the slowest one anyone has looked
+# at. Raising it is close to free because the poll returns on the FIRST
+# successful observation: a clean exit costs one `tmux has-session` that fails,
+# exactly what `2` cost. The cap only bounds the pathological case — and there
+# the outcome it prevents is a truncated transcript plus a spurious driver fault
+# on an agent that was still flushing.
+#
+# Lowering it again needs the measurement this comment could not take: per
+# adapter, wall-clock from the exit key to `tmux has-session` failing, on a
+# loaded host, over enough runs to see the tail.
+# shellcheck disable=SC2034  # read by the DRIVERS that source this lib (each
+# step_exit_clean), never by this file.
+DRIVE_EXIT_CLEAN_CAP_S=15
 
 # wait_pid_gone <pid> [max_wait_secs]
 #   Poll every 0.2s until <pid> no longer exists (kill -0 fails), capped at

--- a/replaydata/agents/aider/driver-interactive.sh
+++ b/replaydata/agents/aider/driver-interactive.sh
@@ -116,6 +116,42 @@ fi
 SESSION="aider-onboard-${UUID:0:8}-$$"
 DEADLINE=$(( $(date +%s) + TIMEOUT_S ))
 EXIT_REASON="ok"
+# Raised to 1 by the epilogue, immediately before the final exit. cleanup() reads
+# it to tell a run that FINISHED (EXIT_REASON is its verdict) apart from a `set
+# -e` abort that never formed one (#1825) — see cleanup().
+REACHED_EPILOGUE=0
+
+# Always honor the staging contract: tear the tmux session down and write
+# driver.exit-reason on ANY exit, including a `set -e` abort mid-run (#1825).
+# Installed HERE, before the launch below, because everything from `tmux
+# new-session` onward can abort: this driver runs under `set -euo pipefail` and
+# its only other teardown is the `tmux kill-session` at the very bottom, which a
+# failed wait_turn, a failed jq or a timeout `exit` never reaches — leaking both
+# the pane and the live aider process. Same shape as the scaffold template's
+# cleanup (scripts/templates/drive-interactive.sh.tmpl:144-154), reduced to this
+# driver's single scalar SESSION: aider has no slot model and no exit_clean, so
+# there is one session to kill and presence of its NAME is the gate.
+#
+# SINGLE WRITER, deliberately: the epilogue below no longer writes
+# driver.exit-reason — this trap is the only writer, so the staging contract's
+# exit reason comes from exactly one place on every path.
+#
+# The REACHED_EPILOGUE guard below subsumes the template's per-`exit` "set
+# EXIT_REASON before a failing exit" discipline for this driver's launch path,
+# so the launch line stays unchanged.
+cleanup() {
+  # An abort that never reached the epilogue never formed a verdict, so
+  # EXIT_REASON is still its initial "ok". Writing that would report SUCCESS for
+  # a failed run — the exact shape #1825 exists to stop — so record the
+  # driver-fault reason instead. A verdict already formed (timeout, …) stands.
+  if [[ "$REACHED_EPILOGUE" != "1" && "$EXIT_REASON" == "ok" ]]; then
+    EXIT_REASON="nonzero(2)"
+    echo "[driver] aborted before the epilogue — recording exit reason $EXIT_REASON, not ok" >&2
+  fi
+  [[ -n "${SESSION:-}" ]] && tmux kill-session -t "$SESSION" 2>/dev/null || true
+  echo "$EXIT_REASON" > "$STAGING/driver.exit-reason"
+}
+trap cleanup EXIT
 
 # Tear down any stale session with the same name (defensive, shouldn't happen).
 tmux kill-session -t "$SESSION" 2>/dev/null || true
@@ -236,7 +272,9 @@ tmux kill-session -t "$SESSION" 2>/dev/null || true
   echo "=== exit reason: $EXIT_REASON ==="
 } > "$DRIVER_LOG"
 
-echo "$EXIT_REASON" > "$STAGING/driver.exit-reason"
+# driver.exit-reason is written by cleanup() (the EXIT trap), the SINGLE writer
+# — see its comment. Writing it here too would be redundant on this path and
+# would read as authoritative on paths that never reach this line.
 echo "$UUID" > "$STAGING/session.uuid"
 if [[ -f "$TRANSCRIPT" ]]; then
   echo "$TRANSCRIPT" > "$STAGING/transcript.path"
@@ -245,6 +283,10 @@ else
 fi
 
 echo "drive-aider-interactive: $EXIT_REASON (uuid=$UUID, transcript=$TRANSCRIPT)"
+
+# The epilogue completed: EXIT_REASON is this run's real verdict, so cleanup()
+# must record it as-is rather than rewrite it as an abort.
+REACHED_EPILOGUE=1
 
 case "$EXIT_REASON" in
   ok)            exit 0 ;;

--- a/replaydata/agents/aider/driver-interactive.sh
+++ b/replaydata/agents/aider/driver-interactive.sh
@@ -139,6 +139,7 @@ REACHED_EPILOGUE=0
 # The REACHED_EPILOGUE guard below subsumes the template's per-`exit` "set
 # EXIT_REASON before a failing exit" discipline for this driver's launch path,
 # so the launch line stays unchanged.
+# BEGIN cleanup
 cleanup() {
   # An abort that never reached the epilogue never formed a verdict, so
   # EXIT_REASON is still its initial "ok". Writing that would report SUCCESS for
@@ -151,6 +152,7 @@ cleanup() {
   [[ -n "${SESSION:-}" ]] && tmux kill-session -t "$SESSION" 2>/dev/null || true
   echo "$EXIT_REASON" > "$STAGING/driver.exit-reason"
 }
+# END cleanup
 trap cleanup EXIT
 
 # Tear down any stale session with the same name (defensive, shouldn't happen).

--- a/replaydata/agents/antigravity/driver-interactive.sh
+++ b/replaydata/agents/antigravity/driver-interactive.sh
@@ -185,6 +185,7 @@ not_implemented() { # <step-type> [reason]
 # Always honor the staging contract: write driver.exit-reason on ANY exit
 # (including a `set -e` abort mid-launch) and tear tmux down if a session was
 # started. Set EXIT_REASON before a failing `exit` so the reason is accurate.
+# BEGIN cleanup
 cleanup() {
   local i
   for (( i = 1; i <= N_SLOTS; i++ )); do
@@ -200,6 +201,7 @@ cleanup() {
   fi
   echo "$EXIT_REASON" > "$STAGING/driver.exit-reason"
 }
+# END cleanup
 trap cleanup EXIT
 
 # --- AGENT-SPECIFIC SEAM 1: launch the REPL under tmux -----------------------
@@ -467,11 +469,17 @@ step_exit_clean() {
   # even when the cap expires with the session still up, and SES_ALIVE=0 was set
   # regardless — so an exit key that stopped working (as claude's did) read
   # exactly like one that worked, and the run still reported exit-reason=ok.
-  if require_tmux_session_gone "$SESSION" 2; then
+  # Cap: DRIVE_EXIT_CLEAN_CAP_S (_lib/drive/teardown.sh). This site passed 2s
+  # until the #1825 review. That 2 was the pre-#1018 SETTLE budget, where
+  # overrunning was free; the strict poll turned the same number into a hard
+  # deadline that SIGHUPs the pane mid-flush and fails the run. It is now the
+  # fleet-uniform generous bound, and that constant carries how the number was
+  # arrived at: it is a bound, not a measurement.
+  if require_tmux_session_gone "$SESSION" "$DRIVE_EXIT_CLEAN_CAP_S"; then
     SES_ALIVE[$ACTIVE]=0
     echo "[driver] exit_clean[s$ACTIVE]: sent Ctrl-D to $SESSION (session gone)" >&2
   else
-    echo "[driver] exit_clean[s$ACTIVE]: FAILED — $SESSION still alive 2s after Ctrl-D;" \
+    echo "[driver] exit_clean[s$ACTIVE]: FAILED — $SESSION still alive ${DRIVE_EXIT_CLEAN_CAP_S}s after Ctrl-D;" \
          "killing it explicitly. agy did NOT shut down gracefully, so this" \
          "recording has no real clean-exit process_exited." >&2
     tmux kill-session -t "$SESSION" 2>/dev/null || true

--- a/replaydata/agents/antigravity/driver-interactive.sh
+++ b/replaydata/agents/antigravity/driver-interactive.sh
@@ -132,6 +132,10 @@ mkdir -p "$RUN_CWD"
 RUN_CWD="$(cd "$RUN_CWD" && pwd -P)"   # canonicalize (resolve symlinks) for the daemon's cwd match
 DEADLINE=$(( $(date +%s) + TIMEOUT_S ))
 EXIT_REASON="ok"
+# Raised to 1 by the epilogue, immediately before the final exit. cleanup() reads
+# it to tell a run that FINISHED (EXIT_REASON is its verdict) apart from a `set
+# -e` abort that never formed one (#1825) — see cleanup().
+REACHED_EPILOGUE=0
 # Shared exit-reason literal for a bad launch/dispatch error (S1192: defined
 # once here, referenced at every site below instead of repeating the string).
 NONZERO_2='nonzero(2)'
@@ -186,6 +190,14 @@ cleanup() {
   for (( i = 1; i <= N_SLOTS; i++ )); do
     [[ -n "${SES_SESSION[$i]:-}" ]] && tmux kill-session -t "${SES_SESSION[$i]}" 2>/dev/null || true
   done
+  # An abort that never reached the epilogue never formed a verdict, so
+  # EXIT_REASON is still its initial "ok". Writing that would report SUCCESS for
+  # a failed run — the exact shape #1825 exists to stop — so record the
+  # driver-fault reason instead. A verdict already formed (timeout, …) stands.
+  if [[ "$REACHED_EPILOGUE" != "1" && "$EXIT_REASON" == "ok" ]]; then
+    EXIT_REASON="$NONZERO_2"
+    echo "[driver] aborted before the epilogue — recording exit reason $EXIT_REASON, not ok" >&2
+  fi
   echo "$EXIT_REASON" > "$STAGING/driver.exit-reason"
 }
 trap cleanup EXIT
@@ -447,13 +459,25 @@ agy_pid() {
 
 # --- AGENT-SPECIFIC SEAM: exit_clean — Ctrl-D graceful shutdown --------------
 # agy's Ink REPL exits on Ctrl-D; the OS terminates the agy process and the
-# daemon's process scanner emits process_exited. Sleep gives agy time to flush.
+# daemon's process scanner emits process_exited.
 step_exit_clean() {
   resolve_transcript || true
   tmux send-keys -t "$SESSION" C-d
-  wait_tmux_session_gone "$SESSION" 2
-  SES_ALIVE[$ACTIVE]=0
-  echo "[driver] exit_clean[s$ACTIVE]: sent Ctrl-D to $SESSION" >&2
+  # STRICT poll (#1825): the old best-effort wait_tmux_session_gone returns 0
+  # even when the cap expires with the session still up, and SES_ALIVE=0 was set
+  # regardless — so an exit key that stopped working (as claude's did) read
+  # exactly like one that worked, and the run still reported exit-reason=ok.
+  if require_tmux_session_gone "$SESSION" 2; then
+    SES_ALIVE[$ACTIVE]=0
+    echo "[driver] exit_clean[s$ACTIVE]: sent Ctrl-D to $SESSION (session gone)" >&2
+  else
+    echo "[driver] exit_clean[s$ACTIVE]: FAILED — $SESSION still alive 2s after Ctrl-D;" \
+         "killing it explicitly. agy did NOT shut down gracefully, so this" \
+         "recording has no real clean-exit process_exited." >&2
+    tmux kill-session -t "$SESSION" 2>/dev/null || true
+    SES_ALIVE[$ACTIVE]=0
+    EXIT_REASON="$NONZERO_2"
+  fi
 }
 
 # --- AGENT-SPECIFIC SEAM: sigkill — kill -9 the active session's agy PID ------
@@ -597,4 +621,7 @@ emit_session_contract "${SES_UUID[1]}"
 for (( i = 1; i <= N_SLOTS; i++ )); do
   echo "${SES_UUID[$i]}" >> "$STAGING/session.uuids"
 done
+# The epilogue completed: EXIT_REASON is this run's real verdict, so cleanup()
+# must record it as-is rather than rewrite it as an abort.
+REACHED_EPILOGUE=1
 drive_exit

--- a/replaydata/agents/claudecode/driver-interactive.sh
+++ b/replaydata/agents/claudecode/driver-interactive.sh
@@ -71,6 +71,14 @@ SCRIPT_JSON="$5"
 mkdir -p "$STAGING"
 DRIVER_LOG="$STAGING/driver.log"
 
+# claudecode owns its OWN slot bookkeeping (SES_TMUX / CURRENT_TMUX rather than
+# the shared SES_SESSION model), so it deliberately does not source slots.sh.
+# It does source the teardown polls: require_tmux_session_gone is what turns
+# "sent the exit key" into "observed the session die" (#1825).
+_DRIVE_LIB="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../_lib/drive" && pwd)"
+# shellcheck source=../../_lib/drive/teardown.sh
+source "$_DRIVE_LIB/teardown.sh"
+
 # recipe-lint contract (#508 #4): the step types this driver genuinely ELICITS
 # (a subset of its case arms — accepting ≠ producing), and whether slash needs a
 # dedicated step type. recipe-lint reads these directly so the grammar has ONE
@@ -102,6 +110,10 @@ mkdir -p "$RUN_CWD"
 
 DEADLINE=$(( $(date +%s) + TIMEOUT_S ))
 EXIT_REASON="ok"
+# Raised to 1 by the epilogue, immediately before the final exit. cleanup() reads
+# it to tell a run that FINISHED (EXIT_REASON is its verdict) apart from a `set
+# -e` abort that never formed one (#1825) — see cleanup().
+REACHED_EPILOGUE=0
 
 # Active-session view — the step functions read/write these. They are a
 # cache of the active slot's state, kept in sync via save_active /
@@ -122,6 +134,35 @@ SES_EXPECTED=()
 SES_ALIVE=()
 N_SLOTS=0
 ACTIVE=0
+
+# Always honor the staging contract: write driver.exit-reason on ANY exit
+# (including a `set -e` abort mid-launch) and tear down EVERY tmux session this
+# run allocated. Gated on session-name PRESENCE, never on SES_ALIVE (#1825):
+# SES_ALIVE is the driver's INTENT — nothing re-derives it from `tmux
+# has-session` — so a step that wrongly believed it killed a session would
+# otherwise take the last net down with it. kill-session on an already-dead
+# name is a harmless no-op, which is exactly why presence is the right gate.
+# Same shape as scripts/templates/drive-interactive.sh.tmpl:147-154.
+#
+# SINGLE WRITER, deliberately: the straight-line epilogue below no longer
+# writes driver.exit-reason — this trap is the only writer, so there is exactly
+# one place the staging contract's exit reason comes from on every path.
+cleanup() {
+  local i
+  for (( i = 1; i <= N_SLOTS; i++ )); do
+    [[ -n "${SES_TMUX[$i]:-}" ]] && tmux kill-session -t "${SES_TMUX[$i]}" 2>/dev/null || true
+  done
+  # An abort that never reached the epilogue never formed a verdict, so
+  # EXIT_REASON is still its initial "ok". Writing that would report SUCCESS for
+  # a failed run — the exact shape #1825 exists to stop — so record the
+  # driver-fault reason instead. A verdict already formed (timeout, …) stands.
+  if [[ "$REACHED_EPILOGUE" != "1" && "$EXIT_REASON" == "ok" ]]; then
+    EXIT_REASON="nonzero(2)"
+    echo "[driver] aborted before the epilogue — recording exit reason $EXIT_REASON, not ok" >&2
+  fi
+  echo "$EXIT_REASON" > "$STAGING/driver.exit-reason"
+}
+trap cleanup EXIT
 
 # Persist the active-view variables back into the active slot.
 save_active() {
@@ -509,14 +550,42 @@ step_sigkill() {
 }
 
 step_exit_clean() {
-  # claude's TUI binds Ctrl-D to "exit". /exit isn't a recognized
-  # slash command, so send Ctrl-D directly for a graceful shutdown.
-  # Sleep gives claude time to write any final transcript lines
-  # before its process terminates.
-  tmux send-keys -t "$CURRENT_TMUX" C-d
-  sleep 1
-  SES_ALIVE[$ACTIVE]=0
-  echo "[driver] exit_clean: sent Ctrl-D to $CURRENT_TMUX" >&2
+  # claude's TUI binds Ctrl-D to "exit". /exit isn't a recognized slash
+  # command, so send Ctrl-D directly for a graceful shutdown.
+  #
+  # TWO Ctrl-D IN ONE send-keys, AND THAT IS NOT A BELT-AND-BRACES TYPO
+  # (#1825, live-verified on the leaked pane claudecode-onboard-1787641617-95883):
+  # claude answers the FIRST Ctrl-D with "Press Ctrl-D again to exit" and then
+  # lets that confirmation expire. One press left the process alive and the pane
+  # unchanged. A second press sent 1.5s later ALSO did nothing — by then the
+  # confirmation window had closed. Only `send-keys ... C-d C-d` in a single
+  # invocation (both presses inside the window) actually exited the process.
+  # Typing `zz` into the pane between attempts confirmed keystrokes were
+  # reaching the TUI, so this is not a send-keys delivery problem. Do not
+  # "simplify" this back to one press, and do not split the two C-d across two
+  # send-keys calls — the single call is the part that was verified to work.
+  #
+  # The separate C-u before them clears the input line: Ctrl-D does not exit
+  # when the buffer holds text (it deletes forward instead), so a step that left
+  # a half-typed prompt behind would otherwise silently turn the exit into a
+  # no-op. It is its own call so the verified `C-d C-d` invocation stays exactly
+  # as verified.
+  tmux send-keys -t "$CURRENT_TMUX" C-u
+  tmux send-keys -t "$CURRENT_TMUX" C-d C-d
+  # Observe the death rather than asserting it. The old `sleep 1` + unconditional
+  # SES_ALIVE=0 is the whole of #1825: nine runs recorded the slot as dead and
+  # leaked a live claude plus its tmux session while reporting exit-reason=ok.
+  if require_tmux_session_gone "$CURRENT_TMUX" 2; then
+    SES_ALIVE[$ACTIVE]=0
+    echo "[driver] exit_clean: sent Ctrl-D to $CURRENT_TMUX (session gone)" >&2
+  else
+    echo "[driver] exit_clean: FAILED — $CURRENT_TMUX still alive 2s after Ctrl-D Ctrl-D;" \
+         "killing it explicitly. The graceful-exit path did NOT work — this recording" \
+         "does not contain a real process_exited from a clean shutdown." >&2
+    tmux kill-session -t "$CURRENT_TMUX" 2>/dev/null || true
+    SES_ALIVE[$ACTIVE]=0
+    EXIT_REASON="nonzero(2)"
+  fi
 }
 
 step_reset_session() {
@@ -536,6 +605,7 @@ step_reset_session() {
   # Retire the old slot (its uuid is no longer being written) but keep
   # it in the slot list so the epilogue flushes it.
   save_active
+  # shellcheck disable=SC2034  # SES_ALIVE is deliberately write-only in this file since #1825 — both teardown nets (cleanup() and the end-of-run loop) now gate on session-name PRESENCE, because gating them on this flag is exactly what leaked a live claude + tmux session per exit_clean run. It stays as the fleet's shared slot vocabulary (replaydata/_lib/drive/slots.sh:66 sets it; kiro-cli's driver-interactive.sh:552 exit_clean entry guard and antigravity's :505 resume branch do branch on their own copies) and as the per-step record of what the driver BELIEVES about each slot.
   SES_ALIVE[$ACTIVE]=0
   sleep 2
 
@@ -684,9 +754,12 @@ done
 
 sleep 0.5
 
-# Tear down every still-alive session.
+# Tear down every session this run allocated — gated on session-name PRESENCE,
+# not on SES_ALIVE (#1825). SES_ALIVE is what the driver BELIEVES; the whole
+# defect was a step clearing that flag for a session that was still running, at
+# which point this loop skipped the one kill that would have caught it.
 for (( i = 1; i <= N_SLOTS; i++ )); do
-  if [[ "${SES_ALIVE[$i]}" == "1" ]]; then
+  if [[ -n "${SES_TMUX[$i]:-}" ]]; then
     tmux kill-session -t "${SES_TMUX[$i]}" 2>/dev/null || true
   fi
 done
@@ -706,7 +779,11 @@ done
 # Keep a combined .stdout for backward-compat with any tooling that reads it.
 cat "$DRIVER_LOG".stdout.* > "$DRIVER_LOG.stdout" 2>/dev/null || true
 
-echo "$EXIT_REASON" > "$STAGING/driver.exit-reason"
+# driver.exit-reason is written by cleanup() (the EXIT trap), which is the
+# SINGLE writer — see its comment. Writing it here too would be redundant on
+# the happy path and, worse, would read as the authoritative write on a path
+# where it is not: an abort before this line never reaches it, and any step
+# that sets EXIT_REASON after it would not be reflected.
 
 # Primary session = slot 1 (kept for backward-compat with the existing
 # single-session run-cell + curate code paths).
@@ -723,6 +800,10 @@ for (( i = 1; i <= N_SLOTS; i++ )); do
 done
 
 echo "drive-claudecode-interactive: $EXIT_REASON (slots=${N_SLOTS}, primary=${SES_UUID[1]}, transcript=${SES_TRANSCRIPT[1]})"
+
+# The epilogue completed: EXIT_REASON is this run's real verdict, so cleanup()
+# must record it as-is rather than rewrite it as an abort.
+REACHED_EPILOGUE=1
 
 case "$EXIT_REASON" in
   ok)            exit 0 ;;

--- a/replaydata/agents/claudecode/driver-interactive.sh
+++ b/replaydata/agents/claudecode/driver-interactive.sh
@@ -147,6 +147,7 @@ ACTIVE=0
 # SINGLE WRITER, deliberately: the straight-line epilogue below no longer
 # writes driver.exit-reason — this trap is the only writer, so there is exactly
 # one place the staging contract's exit reason comes from on every path.
+# BEGIN cleanup
 cleanup() {
   local i
   for (( i = 1; i <= N_SLOTS; i++ )); do
@@ -162,6 +163,7 @@ cleanup() {
   fi
   echo "$EXIT_REASON" > "$STAGING/driver.exit-reason"
 }
+# END cleanup
 trap cleanup EXIT
 
 # Persist the active-view variables back into the active slot.
@@ -575,11 +577,17 @@ step_exit_clean() {
   # Observe the death rather than asserting it. The old `sleep 1` + unconditional
   # SES_ALIVE=0 is the whole of #1825: nine runs recorded the slot as dead and
   # leaked a live claude plus its tmux session while reporting exit-reason=ok.
-  if require_tmux_session_gone "$CURRENT_TMUX" 2; then
+  # Cap: DRIVE_EXIT_CLEAN_CAP_S (_lib/drive/teardown.sh). This site passed 2s
+  # until the #1825 review. That 2 was the pre-#1018 SETTLE budget, where
+  # overrunning was free; the strict poll turned the same number into a hard
+  # deadline that SIGHUPs the pane mid-flush and fails the run. It is now the
+  # fleet-uniform generous bound, and that constant carries how the number was
+  # arrived at: it is a bound, not a measurement.
+  if require_tmux_session_gone "$CURRENT_TMUX" "$DRIVE_EXIT_CLEAN_CAP_S"; then
     SES_ALIVE[$ACTIVE]=0
     echo "[driver] exit_clean: sent Ctrl-D to $CURRENT_TMUX (session gone)" >&2
   else
-    echo "[driver] exit_clean: FAILED — $CURRENT_TMUX still alive 2s after Ctrl-D Ctrl-D;" \
+    echo "[driver] exit_clean: FAILED — $CURRENT_TMUX still alive ${DRIVE_EXIT_CLEAN_CAP_S}s after Ctrl-D Ctrl-D;" \
          "killing it explicitly. The graceful-exit path did NOT work — this recording" \
          "does not contain a real process_exited from a clean shutdown." >&2
     tmux kill-session -t "$CURRENT_TMUX" 2>/dev/null || true

--- a/replaydata/agents/codex/driver-interactive.sh
+++ b/replaydata/agents/codex/driver-interactive.sh
@@ -230,6 +230,7 @@ source "$_DRIVE_LIB/teardown.sh"
 # normal path; this overwrites it with the same value. That double write is
 # deliberate and idempotent — the trap is the one that covers the abort paths
 # the epilogue never reaches.
+# BEGIN cleanup
 cleanup() {
   local i
   for (( i = 1; i <= N_SLOTS; i++ )); do
@@ -245,6 +246,7 @@ cleanup() {
   fi
   echo "$EXIT_REASON" > "$STAGING/driver.exit-reason"
 }
+# END cleanup
 trap cleanup EXIT
 
 # The four boot gates codex can put on screen, as named predicates over a
@@ -688,11 +690,17 @@ step_exit_clean() {
   # even when the cap expires with the session still up, and SES_ALIVE=0 was set
   # regardless — so an exit key that stopped working (as claude's did) read
   # exactly like one that worked, and the run still reported exit-reason=ok.
-  if require_tmux_session_gone "$SESSION" 2; then
+  # Cap: DRIVE_EXIT_CLEAN_CAP_S (_lib/drive/teardown.sh). This site passed 2s
+  # until the #1825 review. That 2 was the pre-#1018 SETTLE budget, where
+  # overrunning was free; the strict poll turned the same number into a hard
+  # deadline that SIGHUPs the pane mid-flush and fails the run. It is now the
+  # fleet-uniform generous bound, and that constant carries how the number was
+  # arrived at: it is a bound, not a measurement.
+  if require_tmux_session_gone "$SESSION" "$DRIVE_EXIT_CLEAN_CAP_S"; then
     SES_ALIVE[$ACTIVE]=0
     echo "[driver] exit_clean: sent Ctrl-D to $SESSION (session gone)" >&2
   else
-    echo "[driver] exit_clean: FAILED — $SESSION still alive 2s after Ctrl-D;" \
+    echo "[driver] exit_clean: FAILED — $SESSION still alive ${DRIVE_EXIT_CLEAN_CAP_S}s after Ctrl-D;" \
          "killing it explicitly. codex did NOT shut down gracefully, so this" \
          "recording has no real clean-exit process_exited." >&2
     tmux kill-session -t "$SESSION" 2>/dev/null || true

--- a/replaydata/agents/codex/driver-interactive.sh
+++ b/replaydata/agents/codex/driver-interactive.sh
@@ -164,6 +164,10 @@ mkdir -p "$RUN_CWD"
 
 DEADLINE=$(( $(date +%s) + TIMEOUT_S ))
 EXIT_REASON="ok"
+# Raised to 1 by the epilogue, immediately before the final exit. cleanup() reads
+# it to tell a run that FINISHED (EXIT_REASON is its verdict) apart from a `set
+# -e` abort that never formed one (#1825) — see cleanup().
+REACHED_EPILOGUE=0
 
 # Active-session view — the step functions read/write these. They are a
 # cache of the active slot's state, kept in sync via save_active /
@@ -205,12 +209,44 @@ TRUSTED_CWDS=()
 _DRIVE_LIB="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../_lib/drive" && pwd)"
 # shellcheck disable=SC2034  # read by the sourced replaydata/_lib/drive/slots.sh:56 (alloc_slot)
 DRIVE_MARKER_PREFIX="$STAGING/.codex-start-marker"
-# shellcheck source=lib/drive/slots.sh
+# shellcheck source=../../_lib/drive/slots.sh
 source "$_DRIVE_LIB/slots.sh"
-# shellcheck source=lib/drive/contracts.sh
+# shellcheck source=../../_lib/drive/contracts.sh
 source "$_DRIVE_LIB/contracts.sh"
-# shellcheck source=lib/drive/teardown.sh
+# shellcheck source=../../_lib/drive/teardown.sh
 source "$_DRIVE_LIB/teardown.sh"
+
+# Always honor the staging contract: write driver.exit-reason on ANY exit
+# (including a `set -e` abort mid-launch) and tear down EVERY tmux session this
+# run allocated. Gated on session-name PRESENCE, never on SES_ALIVE (#1825):
+# SES_ALIVE is the driver's INTENT — nothing re-derives it from `tmux
+# has-session` — so a step that wrongly believed it killed a session would
+# otherwise take the last net down with it. kill-session on an already-dead
+# name (including the name a swap_after_slash slot shares with its successor)
+# is a harmless no-op, which is exactly why presence is the right gate. Same
+# shape as scripts/templates/drive-interactive.sh.tmpl:147-154.
+#
+# emit_session_contract (contracts.sh) ALSO writes driver.exit-reason on the
+# normal path; this overwrites it with the same value. That double write is
+# deliberate and idempotent — the trap is the one that covers the abort paths
+# the epilogue never reaches.
+cleanup() {
+  local i
+  for (( i = 1; i <= N_SLOTS; i++ )); do
+    [[ -n "${SES_SESSION[$i]:-}" ]] && tmux kill-session -t "${SES_SESSION[$i]}" 2>/dev/null || true
+  done
+  # An abort that never reached the epilogue never formed a verdict, so
+  # EXIT_REASON is still its initial "ok". Writing that would report SUCCESS for
+  # a failed run — the exact shape #1825 exists to stop — so record the
+  # driver-fault reason instead. A verdict already formed (timeout, …) stands.
+  if [[ "$REACHED_EPILOGUE" != "1" && "$EXIT_REASON" == "ok" ]]; then
+    EXIT_REASON="nonzero(2)"
+    echo "[driver] aborted before the epilogue — recording exit reason $EXIT_REASON, not ok" >&2
+  fi
+  echo "$EXIT_REASON" > "$STAGING/driver.exit-reason"
+}
+trap cleanup EXIT
+
 # The four boot gates codex can put on screen, as named predicates over a
 # captured pane, with a committed corpus of real 0.147.0 captures behind them
 # (#1388). Inline greps here could stop matching without failing anything —
@@ -646,11 +682,23 @@ swap_after_slash() {
 step_exit_clean() {
   # codex's TUI binds Ctrl-D to "exit". Ctrl-D triggers a graceful
   # shutdown so codex flushes its rollout and the daemon emits
-  # process_exited. Sleep gives codex time to terminate.
+  # process_exited.
   tmux send-keys -t "$SESSION" C-d
-  wait_tmux_session_gone "$SESSION" 2
-  SES_ALIVE[$ACTIVE]=0
-  echo "[driver] exit_clean: sent Ctrl-D to $SESSION" >&2
+  # STRICT poll (#1825): the old best-effort wait_tmux_session_gone returns 0
+  # even when the cap expires with the session still up, and SES_ALIVE=0 was set
+  # regardless — so an exit key that stopped working (as claude's did) read
+  # exactly like one that worked, and the run still reported exit-reason=ok.
+  if require_tmux_session_gone "$SESSION" 2; then
+    SES_ALIVE[$ACTIVE]=0
+    echo "[driver] exit_clean: sent Ctrl-D to $SESSION (session gone)" >&2
+  else
+    echo "[driver] exit_clean: FAILED — $SESSION still alive 2s after Ctrl-D;" \
+         "killing it explicitly. codex did NOT shut down gracefully, so this" \
+         "recording has no real clean-exit process_exited." >&2
+    tmux kill-session -t "$SESSION" 2>/dev/null || true
+    SES_ALIVE[$ACTIVE]=0
+    EXIT_REASON="nonzero(2)"
+  fi
 }
 
 step_resume() {
@@ -747,6 +795,7 @@ step_restart() {
   # trust state (codex caches trust per directory).
   resolve_transcript || true
   save_active
+  # shellcheck disable=SC2034  # SES_ALIVE is deliberately write-only in this file since #1825 — both teardown nets (cleanup() and the end-of-run loop) now gate on session-name PRESENCE, because gating them on this flag is exactly what leaked a live agent + tmux session per exit_clean run. It stays as the fleet's shared slot vocabulary (the sourced replaydata/_lib/drive/slots.sh:66 sets it; kiro-cli's driver-interactive.sh:552 exit_clean entry guard and antigravity's :505 resume branch do branch on their own copies) and as the per-step record of what the driver BELIEVES about each slot.
   SES_ALIVE[$ACTIVE]=0
   tmux kill-session -t "$SESSION" 2>/dev/null || true
   sleep 1
@@ -880,9 +929,12 @@ done
 
 sleep 0.5
 
-# Tear down every still-alive session.
+# Tear down every session this run allocated — gated on session-name PRESENCE,
+# not on SES_ALIVE (#1825). SES_ALIVE is what the driver BELIEVES; a step that
+# cleared it for a session still running (claudecode's exit_clean did exactly
+# that) made this loop skip the one kill that would have caught the leak.
 for (( i = 1; i <= N_SLOTS; i++ )); do
-  if [[ "${SES_ALIVE[$i]}" == "1" ]]; then
+  if [[ -n "${SES_SESSION[$i]:-}" ]]; then
     tmux kill-session -t "${SES_SESSION[$i]}" 2>/dev/null || true
   fi
 done
@@ -907,4 +959,7 @@ emit_session_contract "$(daemon_sid "${SES_TRANSCRIPT[1]}")"
 
 echo "drive-codex-interactive: $EXIT_REASON (slots=${N_SLOTS}, primary=$(daemon_sid "${SES_TRANSCRIPT[1]}"), transcript=${SES_TRANSCRIPT[1]})"
 
+# The epilogue completed: EXIT_REASON is this run's real verdict, so cleanup()
+# must record it as-is rather than rewrite it as an abort.
+REACHED_EPILOGUE=1
 drive_exit

--- a/replaydata/agents/copilot/driver-interactive.sh
+++ b/replaydata/agents/copilot/driver-interactive.sh
@@ -159,6 +159,7 @@ not_implemented() { # <step-type>
 # Always honor the staging contract: write driver.exit-reason on ANY exit
 # (including a `set -e` abort mid-launch) and tear tmux down if a session was
 # started. Set EXIT_REASON before a failing `exit` so the reason is accurate.
+# BEGIN cleanup
 cleanup() {
   local i
   for (( i = 1; i <= N_SLOTS; i++ )); do
@@ -174,6 +175,7 @@ cleanup() {
   fi
   echo "$EXIT_REASON" > "$STAGING/driver.exit-reason"
 }
+# END cleanup
 trap cleanup EXIT
 
 # --- AGENT-SPECIFIC SEAM 1: launch the REPL under tmux -----------------------
@@ -517,10 +519,14 @@ while IFS= read -r step; do
     # STRICT poll (#1825): wait_tmux_session_gone returns 0 even when the cap
     # expires with the session still up, and SES_ALIVE=0 was set regardless — so
     # a /exit that stopped working would read exactly like one that worked and
-    # the run would still report exit-reason=ok. 15s cap preserved.
+    # the run would still report exit-reason=ok.
     exit_clean)      slash_cmd "/exit"
-                     if ! require_tmux_session_gone "$SESSION" 15; then
-                       echo "[driver] exit_clean: FAILED — $SESSION still alive 15s after /exit;" \
+                     # Cap: DRIVE_EXIT_CLEAN_CAP_S (_lib/drive/teardown.sh) — still 15s, unchanged.
+                     # Named once for the whole fleet rather than typed per driver (#1825 review),
+                     # and the six drivers that passed 2s were raised to it. That constant carries
+                     # how the number was arrived at.
+                     if ! require_tmux_session_gone "$SESSION" "$DRIVE_EXIT_CLEAN_CAP_S"; then
+                       echo "[driver] exit_clean: FAILED — $SESSION still alive ${DRIVE_EXIT_CLEAN_CAP_S}s after /exit;" \
                             "killing it explicitly. copilot did NOT shut down gracefully, so this" \
                             "recording has no real clean-exit process_exited." >&2
                        tmux kill-session -t "$SESSION" 2>/dev/null || true

--- a/replaydata/agents/copilot/driver-interactive.sh
+++ b/replaydata/agents/copilot/driver-interactive.sh
@@ -142,6 +142,10 @@ mkdir -p "$RUN_CWD"
 RUN_CWD="$(cd "$RUN_CWD" && pwd -P)"   # canonicalize (resolve symlinks) for the daemon's cwd match
 DEADLINE=$(( $(date +%s) + TIMEOUT_S ))
 EXIT_REASON="ok"
+# Raised to 1 by the epilogue, immediately before the final exit. cleanup() reads
+# it to tell a run that FINISHED (EXIT_REASON is its verdict) apart from a `set
+# -e` abort that never formed one (#1825) — see cleanup().
+REACHED_EPILOGUE=0
 SESSION=""
 
 remaining_seconds() { local now; now=$(date +%s); (( now >= DEADLINE )) && echo 0 || echo $((DEADLINE - now)); }
@@ -160,6 +164,14 @@ cleanup() {
   for (( i = 1; i <= N_SLOTS; i++ )); do
     [[ -n "${SES_SESSION[$i]:-}" ]] && tmux kill-session -t "${SES_SESSION[$i]}" 2>/dev/null || true
   done
+  # An abort that never reached the epilogue never formed a verdict, so
+  # EXIT_REASON is still its initial "ok". Writing that would report SUCCESS for
+  # a failed run — the exact shape #1825 exists to stop — so record the
+  # driver-fault reason instead. A verdict already formed (timeout, …) stands.
+  if [[ "$REACHED_EPILOGUE" != "1" && "$EXIT_REASON" == "ok" ]]; then
+    EXIT_REASON="nonzero(2)"
+    echo "[driver] aborted before the epilogue — recording exit reason $EXIT_REASON, not ok" >&2
+  fi
   echo "$EXIT_REASON" > "$STAGING/driver.exit-reason"
 }
 trap cleanup EXIT
@@ -502,8 +514,18 @@ while IFS= read -r step; do
     sigkill)         sigkill_and_wait "$(active_pid)" 15 || true
                      SES_ALIVE[$ACTIVE]=0 ;;
     # Copilot exits on /exit; Ctrl-D is not a documented quit path here.
+    # STRICT poll (#1825): wait_tmux_session_gone returns 0 even when the cap
+    # expires with the session still up, and SES_ALIVE=0 was set regardless — so
+    # a /exit that stopped working would read exactly like one that worked and
+    # the run would still report exit-reason=ok. 15s cap preserved.
     exit_clean)      slash_cmd "/exit"
-                     wait_tmux_session_gone "$SESSION" 15 || true
+                     if ! require_tmux_session_gone "$SESSION" 15; then
+                       echo "[driver] exit_clean: FAILED — $SESSION still alive 15s after /exit;" \
+                            "killing it explicitly. copilot did NOT shut down gracefully, so this" \
+                            "recording has no real clean-exit process_exited." >&2
+                       tmux kill-session -t "$SESSION" 2>/dev/null || true
+                       EXIT_REASON="nonzero(2)"
+                     fi
                      # shellcheck disable=SC2034  # part of the shared slot model replaydata/_lib/drive/slots.sh:64 (alloc_slot) initialises; this driver keeps it current but has no branch that reads it, while sibling drivers do (e.g. antigravity's exit summary)
                      SES_ALIVE[$ACTIVE]=0 ;;
     start_session)   save_active
@@ -535,4 +557,7 @@ for _rt in "${RETIRED_TRANSCRIPTS[@]:-}"; do
   echo "$_rt" >> "$STAGING/transcript.paths"
 done
 
+# The epilogue completed: EXIT_REASON is this run's real verdict, so cleanup()
+# must record it as-is rather than rewrite it as an abort.
+REACHED_EPILOGUE=1
 drive_exit

--- a/replaydata/agents/gemini-cli/driver-interactive.sh
+++ b/replaydata/agents/gemini-cli/driver-interactive.sh
@@ -71,6 +71,10 @@ mkdir -p "$RUN_CWD"
 
 DEADLINE=$(( $(date +%s) + TIMEOUT_S ))
 EXIT_REASON="ok"
+# Raised to 1 by the epilogue, immediately before the final exit. cleanup() reads
+# it to tell a run that FINISHED (EXIT_REASON is its verdict) apart from a `set
+# -e` abort that never formed one (#1825) — see cleanup().
+REACHED_EPILOGUE=0
 # Shared exit-reason literal for a bad launch/dispatch error (S1192: defined
 # once here, referenced at every site below instead of repeating the string).
 NONZERO_2='nonzero(2)'
@@ -374,11 +378,28 @@ step_keys() { # <keys>
 step_exit_clean() {
   # Gemini's Ink TUI exits gracefully on Ctrl-D. The OS terminates the
   # `node .../bin/gemini` launcher and the daemon's process scanner emits
-  # process_exited. Sleep gives gemini time to flush final transcript lines.
+  # process_exited.
   tmux send-keys -t "$SESSION" C-d
-  wait_tmux_session_gone "$SESSION" 2
-  SES_ALIVE[$ACTIVE]=0
-  echo "[driver] exit_clean[s$ACTIVE]: sent Ctrl-D to $SESSION" >&2
+  # STRICT poll (#1825): the old best-effort wait_tmux_session_gone returns 0
+  # even when the cap expires with the session still up, and SES_ALIVE=0 was set
+  # regardless — so an exit key that stopped working (as claude's did) read
+  # exactly like one that worked, and the run still reported exit-reason=ok.
+  if require_tmux_session_gone "$SESSION" 2; then
+    SES_ALIVE[$ACTIVE]=0
+    echo "[driver] exit_clean[s$ACTIVE]: sent Ctrl-D to $SESSION (session gone)" >&2
+  else
+    echo "[driver] exit_clean[s$ACTIVE]: FAILED — $SESSION still alive 2s after Ctrl-D;" \
+         "killing its process tree explicitly. gemini did NOT shut down gracefully," \
+         "so this recording has no real clean-exit process_exited." >&2
+    # kill_tree BEFORE kill-session, exactly as the teardown loops do: gemini's
+    # detached `node --max-old-space` worker survives the pane SIGHUP and is
+    # reparented to launchd, so kill-session alone would leave it behind.
+    # (kill_tree is defined further down; bash resolves it at call time.)
+    kill_tree "${SES_PANE_PID[$ACTIVE]:-}"
+    tmux kill-session -t "$SESSION" 2>/dev/null || true
+    SES_ALIVE[$ACTIVE]=0
+    EXIT_REASON="$NONZERO_2"
+  fi
 }
 
 # Find the launcher PID the daemon binds: the lowest-PID `bin/gemini` process
@@ -504,6 +525,7 @@ step_reset_session() {
   # (1s granularity), then re-touch to be safe.
   sleep 1
   alloc_slot "$old_tmux" "$old_cwd"
+  # shellcheck disable=SC2034  # SES_ALIVE is deliberately write-only in this file since #1825 — both teardown nets (cleanup() and the end-of-run loop) now gate on session-name PRESENCE, because gating them on this flag is exactly what leaked a live agent + tmux session per exit_clean run. It stays as the fleet's shared slot vocabulary (the sourced replaydata/_lib/drive/slots.sh:66 sets it; kiro-cli's driver-interactive.sh:552 exit_clean entry guard and antigravity's :505 resume branch do branch on their own copies) and as the per-step record of what the driver BELIEVES about each slot.
   SES_ALIVE[$ACTIVE]=1
   touch "$MARKER"
   echo "[driver] reset_session: new slot #${ACTIVE}, marker bumped, awaiting new chats file" >&2
@@ -546,6 +568,14 @@ cleanup() {
     kill_tree "${SES_PANE_PID[$i]:-}"
     tmux kill-session -t "${SES_SESSION[$i]}" 2>/dev/null || true
   done
+  # An abort that never reached the epilogue never formed a verdict, so
+  # EXIT_REASON is still its initial "ok". Writing that would report SUCCESS for
+  # a failed run — the exact shape #1825 exists to stop — so record the
+  # driver-fault reason instead. A verdict already formed (timeout, …) stands.
+  if [[ "$REACHED_EPILOGUE" != "1" && "$EXIT_REASON" == "ok" ]]; then
+    EXIT_REASON="$NONZERO_2"
+    echo "[driver] aborted before the epilogue — recording exit reason $EXIT_REASON, not ok" >&2
+  fi
   echo "$EXIT_REASON" > "$STAGING/driver.exit-reason"
 }
 trap cleanup EXIT
@@ -609,10 +639,16 @@ done
 
 sleep 0.5
 
-# Tear down every still-alive session (kill the process tree, not just the tmux
-# session — see kill_tree).
+# Tear down every session this run allocated (kill the process tree, not just
+# the tmux session — see kill_tree). Gated on session-name PRESENCE, not on
+# SES_ALIVE (#1825). gemini-cli did not leak even before this — cleanup() at the
+# trap below is ungated and does the same kill_tree + kill-session per slot — but
+# the invariant is stated flat across every adapter ("no end-of-run teardown kill
+# is gated on SES_ALIVE") rather than as "gated is fine IF an ungated trap sits
+# behind it", because the second form is harder to state than to violate. Both
+# nets now gate the same way, and SES_ALIVE stays the driver's INTENT only.
 for (( i = 1; i <= N_SLOTS; i++ )); do
-  if [[ "${SES_ALIVE[$i]}" == "1" ]]; then
+  if [[ -n "${SES_SESSION[$i]:-}" ]]; then
     kill_tree "${SES_PANE_PID[$i]:-}"
     tmux kill-session -t "${SES_SESSION[$i]}" 2>/dev/null || true
   fi
@@ -639,4 +675,7 @@ emit_session_contract "$(daemon_sid "${SES_TRANSCRIPT[1]}")"
 
 echo "drive-gemini-cli-interactive: $EXIT_REASON (slots=${N_SLOTS}, primary=$(daemon_sid "${SES_TRANSCRIPT[1]}"), transcript=${SES_TRANSCRIPT[1]})"
 
+# The epilogue completed: EXIT_REASON is this run's real verdict, so cleanup()
+# must record it as-is rather than rewrite it as an abort.
+REACHED_EPILOGUE=1
 drive_exit

--- a/replaydata/agents/gemini-cli/driver-interactive.sh
+++ b/replaydata/agents/gemini-cli/driver-interactive.sh
@@ -384,11 +384,17 @@ step_exit_clean() {
   # even when the cap expires with the session still up, and SES_ALIVE=0 was set
   # regardless — so an exit key that stopped working (as claude's did) read
   # exactly like one that worked, and the run still reported exit-reason=ok.
-  if require_tmux_session_gone "$SESSION" 2; then
+  # Cap: DRIVE_EXIT_CLEAN_CAP_S (_lib/drive/teardown.sh). This site passed 2s
+  # until the #1825 review. That 2 was the pre-#1018 SETTLE budget, where
+  # overrunning was free; the strict poll turned the same number into a hard
+  # deadline that SIGHUPs the pane mid-flush and fails the run. It is now the
+  # fleet-uniform generous bound, and that constant carries how the number was
+  # arrived at: it is a bound, not a measurement.
+  if require_tmux_session_gone "$SESSION" "$DRIVE_EXIT_CLEAN_CAP_S"; then
     SES_ALIVE[$ACTIVE]=0
     echo "[driver] exit_clean[s$ACTIVE]: sent Ctrl-D to $SESSION (session gone)" >&2
   else
-    echo "[driver] exit_clean[s$ACTIVE]: FAILED — $SESSION still alive 2s after Ctrl-D;" \
+    echo "[driver] exit_clean[s$ACTIVE]: FAILED — $SESSION still alive ${DRIVE_EXIT_CLEAN_CAP_S}s after Ctrl-D;" \
          "killing its process tree explicitly. gemini did NOT shut down gracefully," \
          "so this recording has no real clean-exit process_exited." >&2
     # kill_tree BEFORE kill-session, exactly as the teardown loops do: gemini's
@@ -562,6 +568,7 @@ kill_tree() {
   kill -KILL "$pid" 2>/dev/null || true
 }
 
+# BEGIN cleanup
 cleanup() {
   local i
   for (( i = 1; i <= N_SLOTS; i++ )); do
@@ -578,6 +585,7 @@ cleanup() {
   fi
   echo "$EXIT_REASON" > "$STAGING/driver.exit-reason"
 }
+# END cleanup
 trap cleanup EXIT
 
 require_api_key

--- a/replaydata/agents/hermes/driver-interactive.sh
+++ b/replaydata/agents/hermes/driver-interactive.sh
@@ -130,6 +130,10 @@ mkdir -p "$RUN_CWD"
 RUN_CWD="$(cd "$RUN_CWD" && pwd -P)"   # canonicalize (resolve symlinks) for the daemon's cwd match
 DEADLINE=$(( $(date +%s) + TIMEOUT_S ))
 EXIT_REASON="ok"
+# Raised to 1 by the epilogue, immediately before the final exit. cleanup() reads
+# it to tell a run that FINISHED (EXIT_REASON is its verdict) apart from a `set
+# -e` abort that never formed one (#1825) — see cleanup().
+REACHED_EPILOGUE=0
 SESSION=""
 
 remaining_seconds() { local now; now=$(date +%s); (( now >= DEADLINE )) && echo 0 || echo $((DEADLINE - now)); }
@@ -149,6 +153,14 @@ cleanup() {
     [[ -n "${SES_SESSION[$i]:-}" ]] && tmux kill-session -t "${SES_SESSION[$i]}" 2>/dev/null || true
   done
   restore_settings
+  # An abort that never reached the epilogue never formed a verdict, so
+  # EXIT_REASON is still its initial "ok". Writing that would report SUCCESS for
+  # a failed run — the exact shape #1825 exists to stop — so record the
+  # driver-fault reason instead. A verdict already formed (timeout, …) stands.
+  if [[ "$REACHED_EPILOGUE" != "1" && "$EXIT_REASON" == "ok" ]]; then
+    EXIT_REASON="nonzero(2)"
+    echo "[driver] aborted before the epilogue — recording exit reason $EXIT_REASON, not ok" >&2
+  fi
   echo "$EXIT_REASON" > "$STAGING/driver.exit-reason"
 }
 trap cleanup EXIT
@@ -525,4 +537,7 @@ export_all_transcripts
 # transcript path; switch to the first-line UUID if hermes keys on that (see
 # drive-pi-interactive.sh). drive_exit maps EXIT_REASON → the process exit code.
 emit_session_contract "$(daemon_sid "${SES_TRANSCRIPT[1]}")"
+# The epilogue completed: EXIT_REASON is this run's real verdict, so cleanup()
+# must record it as-is rather than rewrite it as an abort.
+REACHED_EPILOGUE=1
 drive_exit

--- a/replaydata/agents/hermes/driver-interactive.sh
+++ b/replaydata/agents/hermes/driver-interactive.sh
@@ -147,6 +147,7 @@ not_implemented() { # <step-type>
 # Always honor the staging contract: write driver.exit-reason on ANY exit
 # (including a `set -e` abort mid-launch) and tear tmux down if a session was
 # started. Set EXIT_REASON before a failing `exit` so the reason is accurate.
+# BEGIN cleanup
 cleanup() {
   local i
   for (( i = 1; i <= N_SLOTS; i++ )); do
@@ -163,6 +164,7 @@ cleanup() {
   fi
   echo "$EXIT_REASON" > "$STAGING/driver.exit-reason"
 }
+# END cleanup
 trap cleanup EXIT
 
 # --- Scenario settings → <HERMES_HOME>/config.yaml ---------------------------

--- a/replaydata/agents/kiro-cli/driver-interactive.sh
+++ b/replaydata/agents/kiro-cli/driver-interactive.sh
@@ -158,6 +158,10 @@ RUN_CWD="$(cd "$RUN_CWD" && pwd -P)"   # canonicalize (resolve symlinks) for the
 
 DEADLINE=$(( $(date +%s) + TIMEOUT_S ))
 EXIT_REASON="ok"
+# Raised to 1 by the epilogue, immediately before the final exit. cleanup() reads
+# it to tell a run that FINISHED (EXIT_REASON is its verdict) apart from a `set
+# -e` abort that never formed one (#1825) — see cleanup().
+REACHED_EPILOGUE=0
 # Shared exit-reason literal for a bad launch/dispatch error (S1192: defined
 # once here, referenced at every site below instead of repeating the string).
 NONZERO_2='nonzero(2)'
@@ -225,13 +229,31 @@ not_implemented() { # <step-type>
 }
 
 # Always honor the staging contract: write driver.exit-reason on ANY exit
-# (including a `set -e` abort mid-launch) and tear every still-alive tmux session
-# down. Set EXIT_REASON before a failing `exit` so the reason is accurate.
+# (including a `set -e` abort mid-launch) and tear down EVERY tmux session this
+# run allocated. Set EXIT_REASON before a failing `exit` so the reason is
+# accurate.
+#
+# Gated on session-name PRESENCE, never on SES_ALIVE (#1825). This trap used to
+# gate on the same optimistic flag as the end-of-run loop below, so kiro-cli had
+# two teardown nets and BOTH were switched off by whichever step wrongly cleared
+# it — the leak claudecode shipped. SES_ALIVE is the driver's INTENT; nothing
+# re-derives it from `tmux has-session`. kill-session on an already-dead name
+# (including the name a reset_session slot shares with its successor) is a
+# harmless no-op, which is exactly why presence is the right gate. Same shape as
+# scripts/templates/drive-interactive.sh.tmpl:147-154.
 cleanup() {
   local i
   for (( i = 1; i <= N_SLOTS; i++ )); do
-    [[ "${SES_ALIVE[$i]:-0}" == "1" ]] && tmux kill-session -t "${SES_SESSION[$i]}" 2>/dev/null || true
+    [[ -n "${SES_SESSION[$i]:-}" ]] && tmux kill-session -t "${SES_SESSION[$i]}" 2>/dev/null || true
   done
+  # An abort that never reached the epilogue never formed a verdict, so
+  # EXIT_REASON is still its initial "ok". Writing that would report SUCCESS for
+  # a failed run — the exact shape #1825 exists to stop — so record the
+  # driver-fault reason instead. A verdict already formed (timeout, …) stands.
+  if [[ "$REACHED_EPILOGUE" != "1" && "$EXIT_REASON" == "ok" ]]; then
+    EXIT_REASON="$NONZERO_2"
+    echo "[driver] aborted before the epilogue — recording exit reason $EXIT_REASON, not ok" >&2
+  fi
   echo "$EXIT_REASON" > "$STAGING/driver.exit-reason"
 }
 trap cleanup EXIT
@@ -547,9 +569,21 @@ step_exit_clean() {
   tmux send-keys -t "$SESSION" -l -- "/quit"
   sleep 0.3
   tmux send-keys -t "$SESSION" Enter
-  wait_tmux_session_gone "$SESSION" 2
-  SES_ALIVE[$ACTIVE]=0
-  echo "[driver] exit_clean[s$ACTIVE]: sent /quit to $SESSION (uuid=$UUID)" >&2
+  # STRICT poll (#1825): the old best-effort wait_tmux_session_gone returns 0
+  # even when the cap expires with the session still up, and SES_ALIVE=0 was set
+  # regardless — so a /quit that stopped working would read exactly like one
+  # that worked, and the run would still report exit-reason=ok.
+  if require_tmux_session_gone "$SESSION" 2; then
+    SES_ALIVE[$ACTIVE]=0
+    echo "[driver] exit_clean[s$ACTIVE]: sent /quit to $SESSION (uuid=$UUID, session gone)" >&2
+  else
+    echo "[driver] exit_clean[s$ACTIVE]: FAILED — $SESSION still alive 2s after /quit;" \
+         "killing it explicitly. kiro-cli did NOT shut down gracefully, so this" \
+         "recording has no real clean-exit process_exited." >&2
+    tmux kill-session -t "$SESSION" 2>/dev/null || true
+    SES_ALIVE[$ACTIVE]=0
+    EXIT_REASON="$NONZERO_2"
+  fi
 }
 
 # --- TEARDOWN SEAM B: sigkill ------------------------------------------------
@@ -872,9 +906,11 @@ done
 
 sleep 0.5
 
-# Tear down every still-alive session.
+# Tear down every session this run allocated — gated on session-name PRESENCE,
+# not on SES_ALIVE (#1825), for the same reason cleanup() above is. This is the
+# second of the two nets; before #1825 both gated on the same optimistic flag.
 for (( i = 1; i <= N_SLOTS; i++ )); do
-  if [[ "${SES_ALIVE[$i]}" == "1" ]]; then
+  if [[ -n "${SES_SESSION[$i]:-}" ]]; then
     tmux kill-session -t "${SES_SESSION[$i]}" 2>/dev/null || true
   fi
 done
@@ -903,4 +939,7 @@ emit_session_contract "$(daemon_sid "${SES_TRANSCRIPT[1]}")"
 
 echo "drive-kiro-cli-interactive: $EXIT_REASON (slots=${N_SLOTS}, primary=$(daemon_sid "${SES_TRANSCRIPT[1]}"), transcript=${SES_TRANSCRIPT[1]})"
 
+# The epilogue completed: EXIT_REASON is this run's real verdict, so cleanup()
+# must record it as-is rather than rewrite it as an abort.
+REACHED_EPILOGUE=1
 drive_exit

--- a/replaydata/agents/kiro-cli/driver-interactive.sh
+++ b/replaydata/agents/kiro-cli/driver-interactive.sh
@@ -241,6 +241,7 @@ not_implemented() { # <step-type>
 # (including the name a reset_session slot shares with its successor) is a
 # harmless no-op, which is exactly why presence is the right gate. Same shape as
 # scripts/templates/drive-interactive.sh.tmpl:147-154.
+# BEGIN cleanup
 cleanup() {
   local i
   for (( i = 1; i <= N_SLOTS; i++ )); do
@@ -256,6 +257,7 @@ cleanup() {
   fi
   echo "$EXIT_REASON" > "$STAGING/driver.exit-reason"
 }
+# END cleanup
 trap cleanup EXIT
 
 # --- AGENT-SPECIFIC SEAM 1: launch the REPL under tmux -----------------------
@@ -573,11 +575,17 @@ step_exit_clean() {
   # even when the cap expires with the session still up, and SES_ALIVE=0 was set
   # regardless — so a /quit that stopped working would read exactly like one
   # that worked, and the run would still report exit-reason=ok.
-  if require_tmux_session_gone "$SESSION" 2; then
+  # Cap: DRIVE_EXIT_CLEAN_CAP_S (_lib/drive/teardown.sh). This site passed 2s
+  # until the #1825 review. That 2 was the pre-#1018 SETTLE budget, where
+  # overrunning was free; the strict poll turned the same number into a hard
+  # deadline that SIGHUPs the pane mid-flush and fails the run. It is now the
+  # fleet-uniform generous bound, and that constant carries how the number was
+  # arrived at: it is a bound, not a measurement.
+  if require_tmux_session_gone "$SESSION" "$DRIVE_EXIT_CLEAN_CAP_S"; then
     SES_ALIVE[$ACTIVE]=0
     echo "[driver] exit_clean[s$ACTIVE]: sent /quit to $SESSION (uuid=$UUID, session gone)" >&2
   else
-    echo "[driver] exit_clean[s$ACTIVE]: FAILED — $SESSION still alive 2s after /quit;" \
+    echo "[driver] exit_clean[s$ACTIVE]: FAILED — $SESSION still alive ${DRIVE_EXIT_CLEAN_CAP_S}s after /quit;" \
          "killing it explicitly. kiro-cli did NOT shut down gracefully, so this" \
          "recording has no real clean-exit process_exited." >&2
     tmux kill-session -t "$SESSION" 2>/dev/null || true

--- a/replaydata/agents/mistral-vibe/driver-interactive.sh
+++ b/replaydata/agents/mistral-vibe/driver-interactive.sh
@@ -187,6 +187,7 @@ source "$_DRIVE_LIB/slots.sh"
 source "$_DRIVE_LIB/contracts.sh"
 # shellcheck source=/dev/null
 source "$_DRIVE_LIB/dialogs.sh"
+# shellcheck source=/dev/null
 source "$_DRIVE_LIB/teardown.sh"
 
 # Slot state the lib reads/writes (the driver owns these globals). A run starts
@@ -222,6 +223,10 @@ mkdir -p "$RUN_CWD"
 RUN_CWD="$(cd "$RUN_CWD" && pwd -P)"   # canonicalize (resolve symlinks) for the daemon's cwd match
 DEADLINE=$(( $(date +%s) + TIMEOUT_S ))
 EXIT_REASON="ok"
+# Raised to 1 by the epilogue, immediately before the final exit. cleanup() reads
+# it to tell a run that FINISHED (EXIT_REASON is its verdict) apart from a `set
+# -e` abort that never formed one (#1825) — see cleanup().
+REACHED_EPILOGUE=0
 SESSION=""
 # Session dirs that already existed when this run launched. Vibe creates a new
 # ~/.vibe/logs/session/<session-id>/ LAZILY on the first user message, so the
@@ -300,6 +305,14 @@ cleanup() {
   for (( i = 1; i <= N_SLOTS; i++ )); do
     [[ -n "${SES_SESSION[$i]:-}" ]] && tmux kill-session -t "${SES_SESSION[$i]}" 2>/dev/null || true
   done
+  # An abort that never reached the epilogue never formed a verdict, so
+  # EXIT_REASON is still its initial "ok". Writing that would report SUCCESS for
+  # a failed run — the exact shape #1825 exists to stop — so record the
+  # driver-fault reason instead. A verdict already formed (timeout, …) stands.
+  if [[ "$REACHED_EPILOGUE" != "1" && "$EXIT_REASON" == "ok" ]]; then
+    EXIT_REASON="$EXIT_DRIVER_FAULT"
+    echo "[driver] aborted before the epilogue — recording exit reason $EXIT_REASON, not ok" >&2
+  fi
   echo "$EXIT_REASON" > "$STAGING/driver.exit-reason"
 }
 trap cleanup EXIT
@@ -632,9 +645,21 @@ step_interrupt() {
 step_exit_clean() {
   resolve_transcript || true
   type_enter "/exit"
-  wait_tmux_session_gone "$SESSION" 15
-  SES_ALIVE[$ACTIVE]=0
-  echo "[driver] exit_clean[s$ACTIVE]: sent /exit; process exited (sid=$(daemon_sid "$TRANSCRIPT"))" >&2
+  # STRICT poll (#1825): the old best-effort wait_tmux_session_gone returns 0
+  # even when the cap expires with the session still up, and SES_ALIVE=0 was set
+  # regardless — so the log line below claimed "process exited" on the strength
+  # of nothing. 15s cap preserved (vibe's teardown is the slowest in the fleet).
+  if require_tmux_session_gone "$SESSION" 15; then
+    SES_ALIVE[$ACTIVE]=0
+    echo "[driver] exit_clean[s$ACTIVE]: sent /exit; process exited (sid=$(daemon_sid "$TRANSCRIPT"))" >&2
+  else
+    echo "[driver] exit_clean[s$ACTIVE]: FAILED — $SESSION still alive 15s after /exit;" \
+         "killing it explicitly. vibe did NOT shut down gracefully, so this" \
+         "recording has no real clean-exit process_exited." >&2
+    tmux kill-session -t "$SESSION" 2>/dev/null || true
+    SES_ALIVE[$ACTIVE]=0
+    EXIT_REASON="$EXIT_DRIVER_FAULT"
+  fi
 }
 
 # step_restart — end the active session and start a FRESH vibe (new session dir,
@@ -795,4 +820,7 @@ save_active
 # transcript path; switch to the first-line UUID if mistral-vibe keys on that (see
 # drive-pi-interactive.sh). drive_exit maps EXIT_REASON → the process exit code.
 emit_session_contract "$(daemon_sid "${SES_TRANSCRIPT[1]}")"
+# The epilogue completed: EXIT_REASON is this run's real verdict, so cleanup()
+# must record it as-is rather than rewrite it as an abort.
+REACHED_EPILOGUE=1
 drive_exit

--- a/replaydata/agents/mistral-vibe/driver-interactive.sh
+++ b/replaydata/agents/mistral-vibe/driver-interactive.sh
@@ -300,6 +300,7 @@ not_implemented() { # <step-type>
 # Always honor the staging contract: write driver.exit-reason on ANY exit
 # (including a `set -e` abort mid-launch) and tear tmux down if a session was
 # started. Set EXIT_REASON before a failing `exit` so the reason is accurate.
+# BEGIN cleanup
 cleanup() {
   local i
   for (( i = 1; i <= N_SLOTS; i++ )); do
@@ -315,6 +316,7 @@ cleanup() {
   fi
   echo "$EXIT_REASON" > "$STAGING/driver.exit-reason"
 }
+# END cleanup
 trap cleanup EXIT
 
 # --- AGENT-SPECIFIC SEAM 1: launch the REPL under tmux -----------------------
@@ -648,12 +650,16 @@ step_exit_clean() {
   # STRICT poll (#1825): the old best-effort wait_tmux_session_gone returns 0
   # even when the cap expires with the session still up, and SES_ALIVE=0 was set
   # regardless — so the log line below claimed "process exited" on the strength
-  # of nothing. 15s cap preserved (vibe's teardown is the slowest in the fleet).
-  if require_tmux_session_gone "$SESSION" 15; then
+  # of nothing. Vibe's teardown is the slowest in the fleet.
+  # Cap: DRIVE_EXIT_CLEAN_CAP_S (_lib/drive/teardown.sh) — still 15s, unchanged.
+  # Named once for the whole fleet rather than typed per driver (#1825 review),
+  # and the six drivers that passed 2s were raised to it. That constant carries
+  # how the number was arrived at.
+  if require_tmux_session_gone "$SESSION" "$DRIVE_EXIT_CLEAN_CAP_S"; then
     SES_ALIVE[$ACTIVE]=0
     echo "[driver] exit_clean[s$ACTIVE]: sent /exit; process exited (sid=$(daemon_sid "$TRANSCRIPT"))" >&2
   else
-    echo "[driver] exit_clean[s$ACTIVE]: FAILED — $SESSION still alive 15s after /exit;" \
+    echo "[driver] exit_clean[s$ACTIVE]: FAILED — $SESSION still alive ${DRIVE_EXIT_CLEAN_CAP_S}s after /exit;" \
          "killing it explicitly. vibe did NOT shut down gracefully, so this" \
          "recording has no real clean-exit process_exited." >&2
     tmux kill-session -t "$SESSION" 2>/dev/null || true

--- a/replaydata/agents/pi/driver-interactive.sh
+++ b/replaydata/agents/pi/driver-interactive.sh
@@ -118,6 +118,10 @@ mkdir -p "$RUN_CWD"
 
 DEADLINE=$(( $(date +%s) + TIMEOUT_S ))
 EXIT_REASON="ok"
+# Raised to 1 by the epilogue, immediately before the final exit. cleanup() reads
+# it to tell a run that FINISHED (EXIT_REASON is its verdict) apart from a `set
+# -e` abort that never formed one (#1825) — see cleanup().
+REACHED_EPILOGUE=0
 
 # Active-session view — the step functions read/write these. They are a
 # cache of the active slot's state, kept in sync via save_active /
@@ -151,12 +155,42 @@ ACTIVE=0
 _DRIVE_LIB="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../_lib/drive" && pwd)"
 # shellcheck disable=SC2034  # read by the sourced replaydata/_lib/drive/slots.sh:56 (alloc_slot)
 DRIVE_MARKER_PREFIX="$STAGING/.pi-start-marker"
-# shellcheck source=lib/drive/slots.sh
+# shellcheck source=../../_lib/drive/slots.sh
 source "$_DRIVE_LIB/slots.sh"
-# shellcheck source=lib/drive/contracts.sh
+# shellcheck source=../../_lib/drive/contracts.sh
 source "$_DRIVE_LIB/contracts.sh"
-# shellcheck source=lib/drive/teardown.sh
+# shellcheck source=../../_lib/drive/teardown.sh
 source "$_DRIVE_LIB/teardown.sh"
+
+# Always honor the staging contract: write driver.exit-reason on ANY exit
+# (including a `set -e` abort mid-launch) and tear down EVERY tmux session this
+# run allocated. Gated on session-name PRESENCE, never on SES_ALIVE (#1825):
+# SES_ALIVE is the driver's INTENT — nothing re-derives it from `tmux
+# has-session` — so a step that wrongly believed it killed a session would
+# otherwise take the last net down with it. kill-session on an already-dead
+# name is a harmless no-op, which is exactly why presence is the right gate.
+# Same shape as scripts/templates/drive-interactive.sh.tmpl:147-154.
+#
+# emit_session_contract (contracts.sh) ALSO writes driver.exit-reason on the
+# normal path; this overwrites it with the same value. That double write is
+# deliberate and idempotent — the trap is the one that covers the abort paths
+# the epilogue never reaches.
+cleanup() {
+  local i
+  for (( i = 1; i <= N_SLOTS; i++ )); do
+    [[ -n "${SES_SESSION[$i]:-}" ]] && tmux kill-session -t "${SES_SESSION[$i]}" 2>/dev/null || true
+  done
+  # An abort that never reached the epilogue never formed a verdict, so
+  # EXIT_REASON is still its initial "ok". Writing that would report SUCCESS for
+  # a failed run — the exact shape #1825 exists to stop — so record the
+  # driver-fault reason instead. A verdict already formed (timeout, …) stands.
+  if [[ "$REACHED_EPILOGUE" != "1" && "$EXIT_REASON" == "ok" ]]; then
+    EXIT_REASON="nonzero(2)"
+    echo "[driver] aborted before the epilogue — recording exit reason $EXIT_REASON, not ok" >&2
+  fi
+  echo "$EXIT_REASON" > "$STAGING/driver.exit-reason"
+}
+trap cleanup EXIT
 
 # recipe-lint contract (#508 #4): the step types this driver genuinely ELICITS
 # (a subset of its case arms — accepting ≠ producing), read directly by
@@ -322,12 +356,24 @@ step_interrupt() {
 step_exit_clean() {
   # Pi's banner binds ctrl+d to "exit". Ctrl-D triggers a graceful
   # shutdown so pi flushes its transcript and the daemon emits
-  # process_exited. Sleep gives pi time to terminate. (Ctrl-C would only
-  # clear the input buffer on the first press, so it can't be used here.)
+  # process_exited. (Ctrl-C would only clear the input buffer on the
+  # first press, so it can't be used here.)
   tmux send-keys -t "$SESSION" C-d
-  wait_tmux_session_gone "$SESSION" 2
-  SES_ALIVE[$ACTIVE]=0
-  echo "[driver] exit_clean[s$ACTIVE]: sent Ctrl-D to $SESSION" >&2
+  # STRICT poll (#1825): the old best-effort wait_tmux_session_gone returns 0
+  # even when the cap expires with the session still up, and SES_ALIVE=0 was set
+  # regardless — so an exit key that stopped working (as claude's did) read
+  # exactly like one that worked, and the run still reported exit-reason=ok.
+  if require_tmux_session_gone "$SESSION" 2; then
+    SES_ALIVE[$ACTIVE]=0
+    echo "[driver] exit_clean[s$ACTIVE]: sent Ctrl-D to $SESSION (session gone)" >&2
+  else
+    echo "[driver] exit_clean[s$ACTIVE]: FAILED — $SESSION still alive 2s after Ctrl-D;" \
+         "killing it explicitly. pi did NOT shut down gracefully, so this" \
+         "recording has no real clean-exit process_exited." >&2
+    tmux kill-session -t "$SESSION" 2>/dev/null || true
+    SES_ALIVE[$ACTIVE]=0
+    EXIT_REASON="nonzero(2)"
+  fi
 }
 
 step_resume() {
@@ -410,6 +456,7 @@ swap_after_slash() {
   # wait_turn pair counts turns in the UUID-2 file from scratch.
   sleep 1
   alloc_slot "$old_tmux" "$old_cwd"
+  # shellcheck disable=SC2034  # SES_ALIVE is deliberately write-only in this file since #1825 — both teardown nets (cleanup() and the end-of-run loop) now gate on session-name PRESENCE, because gating them on this flag is exactly what leaked a live agent + tmux session per exit_clean run. It stays as the fleet's shared slot vocabulary (the sourced replaydata/_lib/drive/slots.sh:66 sets it; kiro-cli's driver-interactive.sh:552 exit_clean entry guard and antigravity's :505 resume branch do branch on their own copies) and as the per-step record of what the driver BELIEVES about each slot.
   SES_ALIVE[$ACTIVE]=1
   touch "$MARKER"
   echo "[driver] swap ($slash): new slot #${ACTIVE}, marker bumped, awaiting new rollout" >&2
@@ -541,12 +588,15 @@ done
 
 sleep 0.5
 
-# Shutdown: tear down every still-alive session. Mirrors the single-
+# Shutdown: tear down every session this run allocated. Mirrors the single-
 # session path — successful scripts end on wait_turn (or interrupt+turn-
 # done, or exit_clean) so there's nothing in-flight to interrupt; sending
 # /exit or Ctrl-C here would just leave extra noise in the captured pane.
+# Gated on session-name PRESENCE, not on SES_ALIVE (#1825): SES_ALIVE is what
+# the driver BELIEVES, and a step that cleared it for a session still running
+# made this loop skip the one kill that would have caught the leak.
 for (( i = 1; i <= N_SLOTS; i++ )); do
-  if [[ "${SES_ALIVE[$i]}" == "1" ]]; then
+  if [[ -n "${SES_SESSION[$i]:-}" ]]; then
     tmux kill-session -t "${SES_SESSION[$i]}" 2>/dev/null || true
   fi
 done
@@ -573,4 +623,7 @@ emit_session_contract "${SES_UUID[1]}"
 
 echo "drive-pi-interactive: $EXIT_REASON (slots=${N_SLOTS}, primary=${SES_UUID[1]}, transcript=${SES_TRANSCRIPT[1]})"
 
+# The epilogue completed: EXIT_REASON is this run's real verdict, so cleanup()
+# must record it as-is rather than rewrite it as an abort.
+REACHED_EPILOGUE=1
 drive_exit

--- a/replaydata/agents/pi/driver-interactive.sh
+++ b/replaydata/agents/pi/driver-interactive.sh
@@ -175,6 +175,7 @@ source "$_DRIVE_LIB/teardown.sh"
 # normal path; this overwrites it with the same value. That double write is
 # deliberate and idempotent — the trap is the one that covers the abort paths
 # the epilogue never reaches.
+# BEGIN cleanup
 cleanup() {
   local i
   for (( i = 1; i <= N_SLOTS; i++ )); do
@@ -190,6 +191,7 @@ cleanup() {
   fi
   echo "$EXIT_REASON" > "$STAGING/driver.exit-reason"
 }
+# END cleanup
 trap cleanup EXIT
 
 # recipe-lint contract (#508 #4): the step types this driver genuinely ELICITS
@@ -363,11 +365,17 @@ step_exit_clean() {
   # even when the cap expires with the session still up, and SES_ALIVE=0 was set
   # regardless — so an exit key that stopped working (as claude's did) read
   # exactly like one that worked, and the run still reported exit-reason=ok.
-  if require_tmux_session_gone "$SESSION" 2; then
+  # Cap: DRIVE_EXIT_CLEAN_CAP_S (_lib/drive/teardown.sh). This site passed 2s
+  # until the #1825 review. That 2 was the pre-#1018 SETTLE budget, where
+  # overrunning was free; the strict poll turned the same number into a hard
+  # deadline that SIGHUPs the pane mid-flush and fails the run. It is now the
+  # fleet-uniform generous bound, and that constant carries how the number was
+  # arrived at: it is a bound, not a measurement.
+  if require_tmux_session_gone "$SESSION" "$DRIVE_EXIT_CLEAN_CAP_S"; then
     SES_ALIVE[$ACTIVE]=0
     echo "[driver] exit_clean[s$ACTIVE]: sent Ctrl-D to $SESSION (session gone)" >&2
   else
-    echo "[driver] exit_clean[s$ACTIVE]: FAILED — $SESSION still alive 2s after Ctrl-D;" \
+    echo "[driver] exit_clean[s$ACTIVE]: FAILED — $SESSION still alive ${DRIVE_EXIT_CLEAN_CAP_S}s after Ctrl-D;" \
          "killing it explicitly. pi did NOT shut down gracefully, so this" \
          "recording has no real clean-exit process_exited." >&2
     tmux kill-session -t "$SESSION" 2>/dev/null || true

--- a/tools/onboarding-factory/internal/driverteardown/driverteardown.go
+++ b/tools/onboarding-factory/internal/driverteardown/driverteardown.go
@@ -188,6 +188,16 @@ func LaunchCount(src string) int {
 // It returns an error, not an empty finding list, whenever it could not
 // actually look: an empty driver, a structure it cannot parse, a launch with
 // no `-s`, a tmux-launching driver in which it found nothing to grade.
+//
+// A refusal does NOT discard the findings already established, and that is not
+// tidiness. The invariants are not independent: deleting a `trap cleanup EXIT`
+// from a driver whose trap is its ONLY teardown — hermes has no top-level sweep
+// — violates INV-2 AND leaves INV-1 with no site to grade. Returning `nil, err`
+// on the second of those threw the first away, so the gate went red naming INV-1
+// as having "graded nothing" and dropped the one sentence that says what to do
+// about it. The refusal was the consequence; the finding is the cause. See
+// gradedError, which carries both so the diagnosis points at the defect
+// regardless of whether the caller reads findings, the error, or only the error.
 func CheckDriver(driver File, libs []File) ([]Finding, error) {
 	if strings.TrimSpace(driver.Src) == "" {
 		return nil, fmt.Errorf("%s is empty — a driver that cannot be read graded nothing, "+
@@ -215,22 +225,56 @@ func CheckDriver(driver File, libs []File) ([]Finding, error) {
 	findings := checkTrapExists(driver, traps)
 
 	inv1, err := checkTeardownUngated(src, traps)
-	if err != nil {
-		return nil, err
-	}
 	findings = append(findings, inv1...)
+	if err != nil {
+		return refuse(findings, err)
+	}
 
 	inv3, err := checkSessionNamesCarryPID(src, parsedLibs)
-	if err != nil {
-		return nil, err
-	}
 	findings = append(findings, inv3...)
+	if err != nil {
+		return refuse(findings, err)
+	}
 
 	inv4, err := checkVerdictCannotBeStale(src, traps)
+	findings = append(findings, inv4...)
 	if err != nil {
+		return refuse(findings, err)
+	}
+	return findings, nil
+}
+
+// gradedError is a vacuity refusal that still names what was already found.
+//
+// Every caller of CheckDriver treats a non-nil error as fatal and prints it;
+// TestEveryDriverTearsDownEverySession does exactly that. So a refusal that
+// arrives after a real finding has to carry the finding in its own message, or
+// the finding is invisible however carefully the caller was written.
+type gradedError struct {
+	err      error
+	findings []Finding
+}
+
+func (e *gradedError) Error() string {
+	var b strings.Builder
+	b.WriteString(e.err.Error())
+	b.WriteString("\n\n  …and this driver was ALREADY in violation before that refusal. The " +
+		"refusal is downstream of what follows, which is the defect to fix:")
+	for _, f := range e.findings {
+		b.WriteString("\n  " + f.String())
+	}
+	return b.String()
+}
+
+func (e *gradedError) Unwrap() error { return e.err }
+
+// refuse pairs a vacuity error with the findings already established, so a
+// caller that reads only the error still sees them.
+func refuse(findings []Finding, err error) ([]Finding, error) {
+	if len(findings) == 0 {
 		return nil, err
 	}
-	return append(findings, inv4...), nil
+	return findings, &gradedError{err: err, findings: findings}
 }
 
 func parseAll(files []File) ([]*Source, error) {
@@ -368,10 +412,17 @@ func checkTrapExists(driver File, traps []exitTrap) []Finding {
 // The distinction is STRUCTURAL — where the `tmux kill-session` sits — not
 // textual, because both spellings of the gate are byte-identical:
 //
-//	teardown (must be ungated)   : the EXIT-trap handler, and the end-of-run
-//	                               sweep, which every driver writes at TOP
-//	                               LEVEL after the step loop has finished.
-//	step-level (may be gated)    : anything inside an ordinary function.
+//	teardown (must be ungated)   : the EXIT-trap handler, and every kill AT TOP
+//	                               LEVEL that is not inside a `case` arm a loop
+//	                               re-enters.
+//	step-level (may be gated)    : anything inside an ordinary function, and the
+//	                               arms of a top-level step dispatch.
+//
+// The second half of each line is the correction #1827 made. The rule was
+// written as "top level" and DOCUMENTED as "the end-of-run sweep", and those are
+// not the same set: copilot's step dispatch is a top-level `while … case`, so
+// its resume/restart/exit_clean kills sit at Func "" and were graded as the
+// end-of-run sweep. isStepDispatchArm is where that difference now lives.
 //
 // kiro-cli is the case that forces this. Its `step_exit_clean` and
 // `step_sigkill` open with `if [[ "${SES_ALIVE[$ACTIVE]:-0}" != "1" ]]; then
@@ -425,8 +476,12 @@ func checkTeardownUngated(src *Source, traps []exitTrap) ([]Finding, error) {
 		}
 		where := ""
 		switch {
+		case st.Func == "" && isStepDispatchArm(st):
+			// A per-step arm of a top-level dispatch. Step-level work that
+			// happens not to live in a function — see isStepDispatchArm.
+			continue
 		case st.Func == "":
-			where = "this end-of-run teardown"
+			where = "this top-level teardown"
 		case handlerFuncs[st.Func]:
 			where = fmt.Sprintf("this teardown inside the EXIT-trap handler %s()", st.Func)
 		default:
@@ -448,6 +503,63 @@ func checkTeardownUngated(src *Source, traps []exitTrap) ([]Finding, error) {
 			"cannot run must say so", src.Path)
 	}
 	return findings, nil
+}
+
+// isStepDispatchArm reports whether a statement sits in a `case` arm that a
+// loop re-enters — the shape of a per-step dispatch, which is step-level work
+// even when it is written at top level rather than inside a function.
+//
+// copilot is the driver that forces this, and it is the mirror image of the
+// kiro-cli case that forced the structural rule in the first place. Its step
+// dispatch is a top-level `while IFS= read -r step; do … case "$type" in …`,
+// not a function, so the `tmux kill-session` in its resume, restart and
+// exit_clean arms — `grep -n 'tmux kill-session'
+// replaydata/agents/copilot/driver-interactive.sh`, the three inside that
+// `while` — have Func "" and were classified as "this end-of-run teardown".
+// (Line numbers are deliberately not quoted: the drivers are edited often
+// enough that three of them moved while this comment was being written.) They
+// are ungated today, so nothing
+// fired — but the kiro-cli-shaped `SES_ALIVE` entry check this package
+// deliberately ACCEPTS at step level (correct there, because reset_session
+// aliases a retired slot number onto a pane a live slot now owns) would have
+// been a FALSE POSITIVE the moment copilot, hermes, mistral-vibe or antigravity
+// needed one. That is precisely the outcome aliveGate's tradeoff note says gets
+// a rule ignored rather than fixed.
+//
+// BOTH halves of the test are load-bearing, and each was checked against the
+// eleven shipped drivers rather than assumed:
+//
+//   - "inside a loop" alone would excuse the end-of-run sweep itself, which
+//     every slot-model driver writes as `for (( i = 1; i <= N_SLOTS; i++ )); do
+//     … done`. That would gut INV-1; inv1_gated_final_sweep.sh is the row that
+//     holds it.
+//   - "inside a `case`" alone would excuse the trailing `case "$EXIT_REASON"
+//     in` that aider, claudecode and opencode already write at the bottom of
+//     their drivers (`git grep -n 'case "$EXIT_REASON"' -- replaydata/agents`).
+//     A liveness-gated kill in one of those arms IS end-of-run teardown;
+//     inv1_gated_case_at_exit.sh is the row that holds it.
+//
+// Requiring a loop OUTSIDE the `case` keeps both graded and moves only the
+// dispatch. What it still costs: a driver that put its final sweep inside a
+// `case` arm within a loop would have it read as step-level — the same shape,
+// and the same acceptance, as the `final_teardown()` helper named above.
+//
+// The exclusion applies ONLY to the top-level branch. Everything reached
+// through an EXIT-trap handler's name stays teardown by definition, however it
+// is nested inside that handler.
+func isStepDispatchArm(st Statement) bool {
+	loop := false
+	for _, b := range st.Blocks {
+		switch b {
+		case "do":
+			loop = true
+		case "case":
+			if loop {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func inv1Detail(where string) string {
@@ -802,17 +914,52 @@ type mintSite struct {
 	literal string
 }
 
+// funcRef identifies ONE function definition: the file it is written in, plus
+// its name.
+//
+// Keying positional facts on the bare NAME was a defect. LoadDriver globs the
+// whole replaydata/_lib/drive directory and hands every adapter every file in
+// it, sourced or not, and two different `alloc_slot`s exist (`git grep -n
+// 'alloc_slot()' -- replaydata`): the shared _lib/drive/slots.sh takes the tmux
+// session name at argument 1, while claudecode's private one, defined in its own
+// driver, takes it at argument 2. On one bare key
+// both positions get marked, and a literal at the wrong position is then graded
+// as a session name — a false INV-3 against a correct driver.
+//
+// It does not fire today, and that was measured rather than assumed: the flow
+// resolves claudecode to {2} and codex to {1} with no contamination, but only
+// because claudecode never touches SESSION or SES_SESSION, so slots.sh's `sess`
+// never becomes name-carrying in claudecode's pass. One driver that used the
+// shared slot model AND kept a `SESSION` alias would light it.
+// inv3_shadowed_alloc_slot_ok.sh is that driver.
+type funcRef struct {
+	file string
+	name string
+}
+
 // nameFlow is the fixpoint of "what carries a tmux session name".
 type nameFlow struct {
-	vars  map[string]bool         // variable names
-	pos   map[string]map[int]bool // function name -> name-carrying argument positions
-	seeds []mintSite              // names written inline at the launch itself
+	vars  map[string]bool          // variable names
+	pos   map[funcRef]map[int]bool // one DEFINITION -> its name-carrying argument positions
+	def   map[string]string        // function name -> the file whose definition a call resolves to
+	seeds []mintSite               // names written inline at the launch itself
 	all   []*Source
 }
 
 func newNameFlow(src *Source, libs []*Source) (*nameFlow, error) {
-	f := &nameFlow{vars: map[string]bool{}, pos: map[string]map[int]bool{}}
+	f := &nameFlow{vars: map[string]bool{}, pos: map[funcRef]map[int]bool{}, def: map[string]string{}}
 	f.all = append([]*Source{src}, libs...)
+	// Which definition a call resolves to: the driver's own if it has one, else
+	// the first library that defines the name. Same precedence as lookupFunc,
+	// and the same reason — a driver that defines a helper the shared libs also
+	// define is shadowing it, because its definition is sourced last.
+	for _, s := range f.all {
+		for _, fn := range s.funcs {
+			if _, seen := f.def[fn.Name]; !seen {
+				f.def[fn.Name] = s.Path
+			}
+		}
+	}
 	if err := f.seed(src); err != nil {
 		return nil, err
 	}
@@ -883,8 +1030,12 @@ func (f *nameFlow) propagate(src *Source) bool {
 			}
 			switch {
 			case positional > 0:
-				if f.vars[lhs] && st.Func != "" && !f.posHas(st.Func, positional) {
-					f.markPos(st.Func, positional)
+				// Marked against THIS file's definition. Marking a definition no
+				// call resolves to is harmless — nothing reads that key — and
+				// keeping it unconditional keeps the fixpoint a single pass.
+				ref := funcRef{file: src.Path, name: st.Func}
+				if f.vars[lhs] && st.Func != "" && !f.posHas(ref, positional) {
+					f.markPos(ref, positional)
 					changed = true
 				}
 			default:
@@ -899,10 +1050,10 @@ func (f *nameFlow) propagate(src *Source) bool {
 			}
 		}
 		name, args, ok := st.Command()
-		if !ok || len(f.pos[name]) == 0 {
+		if !ok || len(f.posOf(name)) == 0 {
 			continue
 		}
-		for n := range f.pos[name] {
+		for n := range f.posOf(name) {
 			if n > len(args) {
 				continue
 			}
@@ -915,13 +1066,24 @@ func (f *nameFlow) propagate(src *Source) bool {
 	return changed
 }
 
-func (f *nameFlow) posHas(fn string, n int) bool { return f.pos[fn][n] }
+func (f *nameFlow) posHas(fn funcRef, n int) bool { return f.pos[fn][n] }
 
-func (f *nameFlow) markPos(fn string, n int) {
+func (f *nameFlow) markPos(fn funcRef, n int) {
 	if f.pos[fn] == nil {
 		f.pos[fn] = map[int]bool{}
 	}
 	f.pos[fn][n] = true
+}
+
+// posOf gives the name-carrying argument positions of the ONE definition a call
+// to fn resolves to, so a same-named function in a library the driver never
+// sources cannot contribute positions to it.
+func (f *nameFlow) posOf(fn string) map[int]bool {
+	file, ok := f.def[fn]
+	if !ok {
+		return nil
+	}
+	return f.pos[funcRef{file: file, name: fn}]
 }
 
 // mintSites lists every composed literal in ONE file that becomes a tmux
@@ -946,7 +1108,7 @@ func (f *nameFlow) mintSites(src *Source) []mintSite {
 		if !ok {
 			continue
 		}
-		for n := range f.pos[name] {
+		for n := range f.posOf(name) {
 			if n > len(args) {
 				continue
 			}
@@ -988,8 +1150,19 @@ func Adapters(root string) ([]string, error) {
 	return out, nil
 }
 
-// LoadDriver reads one adapter's driver plus every shell library it can source
+// LoadDriver reads one adapter's driver plus every shell library it CAN source
 // — the shared drive libs and the adapter's own sibling scripts.
+//
+// "Can", not "does": the whole _lib/drive directory is globbed for every
+// adapter, because a driver's `source` lines are computed paths
+// (`"$_DRIVE_LIB/slots.sh"`, `"$(dirname "${BASH_SOURCE[0]}")/turn-count.sh"`)
+// and libraries source one another, so resolving the real set statically would
+// itself be a place this package could be wrong — and getting it wrong DOWNWARD
+// turns a resolvable trap handler into a refusal for the whole fleet.
+//
+// The cost is that every adapter is handed definitions it never sources. That
+// is why nameFlow keys positional facts on a funcRef rather than on a bare
+// function name: see funcRef for the two `alloc_slot`s this collides.
 func LoadDriver(root, adapter string) (File, []File, error) {
 	path := filepath.Join(root, AgentsDir, adapter, DriverName)
 	src, err := os.ReadFile(path) // #nosec G304 -- built from the repo root and a scanned adapter slug

--- a/tools/onboarding-factory/internal/driverteardown/driverteardown.go
+++ b/tools/onboarding-factory/internal/driverteardown/driverteardown.go
@@ -178,6 +178,22 @@ func LaunchCount(src string) int {
 	return n
 }
 
+// tmuxArgs reports whether a statement runs `tmux <verb>`, returning the
+// command's arguments (verb included) when it does.
+//
+// It is the ONE place the shape of a tmux invocation is recognised. INV-1 asks
+// for `kill-session` and INV-3 asks for `new-session` from two different places;
+// a third and fourth hand-written spelling of the same test is a place they
+// could come to disagree about what counts as a launch — and INV-3's own vacuity
+// refusal fires precisely when the lexer and the text disagree about that.
+func tmuxArgs(st Statement, verb string) ([]string, bool) {
+	name, args, ok := st.Command()
+	if !ok || name != "tmux" || len(args) == 0 || args[0] != verb {
+		return nil, false
+	}
+	return args, true
+}
+
 // CheckDriver grades one driver against INV-1 through INV-4.
 //
 // libs are the shell libraries the driver sources. They are read for the
@@ -224,22 +240,22 @@ func CheckDriver(driver File, libs []File) ([]Finding, error) {
 	}
 	findings := checkTrapExists(driver, traps)
 
-	inv1, err := checkTeardownUngated(src, traps)
-	findings = append(findings, inv1...)
-	if err != nil {
-		return refuse(findings, err)
-	}
-
-	inv3, err := checkSessionNamesCarryPID(src, parsedLibs)
-	findings = append(findings, inv3...)
-	if err != nil {
-		return refuse(findings, err)
-	}
-
-	inv4, err := checkVerdictCannotBeStale(src, traps)
-	findings = append(findings, inv4...)
-	if err != nil {
-		return refuse(findings, err)
+	// INV-1, INV-3, INV-4 — in that order, each keeping the findings already
+	// established when it refuses. That rule is written ONCE here rather than
+	// once per invariant on purpose: `return nil, err` from any single one of
+	// them discards a finding that is the CAUSE of its own refusal, which is the
+	// defect gradedError was added for, and the shape a fifth invariant spliced
+	// in below would otherwise be free to repeat.
+	for _, grade := range []func() ([]Finding, error){
+		func() ([]Finding, error) { return checkTeardownUngated(src, traps) },
+		func() ([]Finding, error) { return checkSessionNamesCarryPID(src, parsedLibs) },
+		func() ([]Finding, error) { return checkVerdictCannotBeStale(src, traps) },
+	} {
+		found, err := grade()
+		findings = append(findings, found...)
+		if err != nil {
+			return refuse(findings, err)
+		}
 	}
 	return findings, nil
 }
@@ -305,46 +321,68 @@ type exitTrap struct {
 func exitTraps(src *Source, libs []*Source) ([]exitTrap, error) {
 	var out []exitTrap
 	for _, st := range src.Statements() {
-		name, args, ok := st.Command()
-		if !ok || name != "trap" || len(args) < 2 {
+		handler, arms := armedEXITHandler(st)
+		if !arms {
 			continue
 		}
-		if !argsNameEXIT(args[1:]) {
-			continue
+		t, err := resolveHandler(src, libs, st.Line, handler)
+		if err != nil {
+			return nil, err
 		}
-		handler := unquote(args[0])
-		if handler == "-" || handler == "" {
-			continue // `trap - EXIT` disarms; it arms nothing to grade
-		}
-		t := exitTrap{line: st.Line}
-		if isIdentifier(handler) {
-			owner, body, found := lookupFunc(handler, src, libs)
-			if !found {
-				return nil, fmt.Errorf("%s:%d: `trap %s EXIT` names a handler that is defined "+
-					"neither in this driver nor in any library it sources — the trap cannot be "+
-					"graded, and a check that cannot run must say so", src.Path, st.Line, handler)
-			}
-			t.fn, t.body = handler, body
-			for _, s := range owner.Statements() {
-				if s.Func == handler {
-					t.stmts = append(t.stmts, s)
-				}
-			}
-		} else {
-			t.body = handler
-			// An inline handler is one quoted word, so its commands are not
-			// statements of the enclosing file. Parse the word's text as its
-			// own source rather than reading the handler as an opaque string.
-			inline, err := Parse(fmt.Sprintf("%s:%d (inline EXIT trap)", src.Path, st.Line), handler)
-			if err != nil {
-				return nil, err
-			}
-			t.stmts = inline.Statements()
-		}
-		t.tearsDown = strings.Contains(t.body, "tmux kill-session")
 		out = append(out, t)
 	}
 	return out, nil
+}
+
+// armedEXITHandler names the handler a statement ARMS for EXIT, if it arms one.
+// `trap - EXIT` disarms and arms nothing to grade — see the package comment for
+// why a disarm is deliberately left ungraded rather than given a rule that would
+// look like it grades this and does not.
+func armedEXITHandler(st Statement) (string, bool) {
+	name, args, ok := st.Command()
+	if !ok || name != "trap" || len(args) < 2 || !argsNameEXIT(args[1:]) {
+		return "", false
+	}
+	handler := unquote(args[0])
+	if handler == "-" || handler == "" {
+		return "", false
+	}
+	return handler, true
+}
+
+// resolveHandler resolves one armed trap's handler to the body and the
+// statements the invariants read. A handler it cannot resolve is an error:
+// "this driver has no teardown trap" and "the trap's handler could not be found"
+// must not be the same answer.
+func resolveHandler(src *Source, libs []*Source, line int, handler string) (exitTrap, error) {
+	t := exitTrap{line: line}
+	switch {
+	case isIdentifier(handler):
+		owner, body, found := lookupFunc(handler, src, libs)
+		if !found {
+			return exitTrap{}, fmt.Errorf("%s:%d: `trap %s EXIT` names a handler that is defined "+
+				"neither in this driver nor in any library it sources — the trap cannot be "+
+				"graded, and a check that cannot run must say so", src.Path, line, handler)
+		}
+		t.fn, t.body = handler, body
+		for _, s := range owner.Statements() {
+			if s.Func == handler {
+				t.stmts = append(t.stmts, s)
+			}
+		}
+	default:
+		t.body = handler
+		// An inline handler is one quoted word, so its commands are not
+		// statements of the enclosing file. Parse the word's text as its own
+		// source rather than reading the handler as an opaque string.
+		inline, err := Parse(fmt.Sprintf("%s:%d (inline EXIT trap)", src.Path, line), handler)
+		if err != nil {
+			return exitTrap{}, err
+		}
+		t.stmts = inline.Statements()
+	}
+	t.tearsDown = strings.Contains(t.body, "tmux kill-session")
+	return t, nil
 }
 
 func argsNameEXIT(args []string) bool {
@@ -470,22 +508,12 @@ func checkTeardownUngated(src *Source, traps []exitTrap) ([]Finding, error) {
 	}
 
 	for _, st := range src.Statements() {
-		name, args, ok := st.Command()
-		if !ok || name != "tmux" || len(args) == 0 || args[0] != "kill-session" {
+		if _, kills := tmuxArgs(st, "kill-session"); !kills {
 			continue
 		}
-		where := ""
-		switch {
-		case st.Func == "" && isStepDispatchArm(st):
-			// A per-step arm of a top-level dispatch. Step-level work that
-			// happens not to live in a function — see isStepDispatchArm.
+		where, isTeardown := teardownSite(st, handlerFuncs)
+		if !isTeardown {
 			continue
-		case st.Func == "":
-			where = "this top-level teardown"
-		case handlerFuncs[st.Func]:
-			where = fmt.Sprintf("this teardown inside the EXIT-trap handler %s()", st.Func)
-		default:
-			continue // step-level: legitimately allowed to gate on liveness
 		}
 		sites++
 		if !gatedOnLiveness(st) {
@@ -503,6 +531,25 @@ func checkTeardownUngated(src *Source, traps []exitTrap) ([]Finding, error) {
 			"cannot run must say so", src.Path)
 	}
 	return findings, nil
+}
+
+// teardownSite reports whether a `tmux kill-session` statement is END-OF-RUN
+// teardown — the position INV-1 requires to be ungated — and names it for the
+// finding. It is the structural classification checkTeardownUngated documents,
+// stated once: the arms below are that comment's two-line table.
+func teardownSite(st Statement, handlerFuncs map[string]bool) (string, bool) {
+	switch {
+	case st.Func == "" && isStepDispatchArm(st):
+		// A per-step arm of a top-level dispatch. Step-level work that happens
+		// not to live in a function — see isStepDispatchArm.
+		return "", false
+	case st.Func == "":
+		return "this top-level teardown", true
+	case handlerFuncs[st.Func]:
+		return fmt.Sprintf("this teardown inside the EXIT-trap handler %s()", st.Func), true
+	default:
+		return "", false // step-level: legitimately allowed to gate on liveness
+	}
 }
 
 // isStepDispatchArm reports whether a statement sits in a `case` arm that a
@@ -640,74 +687,59 @@ func checkVerdictCannotBeStale(src *Source, traps []exitTrap) ([]Finding, error)
 	lastLaunch := lastLaunchLine(src)
 	var findings []Finding
 	for _, t := range traps {
-		write, idx, v, ok := verdictWrite(t.stmts)
+		write, ok := verdictWrite(t.stmts)
 		if !ok {
 			continue // derived exemption: this handler writes no verdict variable
 		}
-		initial, ok := initialVerdict(src, v, t.line)
+		initial, ok := initialVerdict(src, write.v, t.line)
 		if !ok {
 			return nil, fmt.Errorf("%s:%d: the EXIT-trap handler writes $%s to %s, but %s is "+
 				"never assigned unconditionally at top level before the trap is armed — INV-4 "+
 				"has no initial value to compare against and graded nothing, and a check that "+
-				"cannot run must say so", src.Path, write.Line, v, exitReasonFile, v)
+				"cannot run must say so", src.Path, write.line, write.v, exitReasonFile, write.v)
 		}
-		if f := gradeVerdictGuard(src, t, idx, v, initial, lastLaunch); f != nil {
+		q := staleVerdict{
+			src: src, trap: t, write: write, initial: initial,
+			ep: epilogue{trapLine: t.line, lastLaunch: lastLaunch},
+		}
+		if f := q.grade(); f != nil {
 			findings = append(findings, *f)
 		}
 	}
 	return findings, nil
 }
 
-// gradeVerdictGuard returns the INV-4 finding for one handler, or nil when the
-// handler satisfies either shape. The reason it reports is the most specific
-// one that applies, so the message names what to change rather than restating
-// the rule.
-func gradeVerdictGuard(src *Source, t exitTrap, writeIdx int, v, initial string, lastLaunch int) *Finding {
-	// (b) fail-closed: the success path itself moves the verdict off its
-	// initialiser, so an abort and a completed run write different bytes.
-	for _, a := range epilogueAssignments(src, v, t.line, lastLaunch) {
-		if a != initial {
-			return nil
-		}
-	}
+// staleVerdict is INV-4's question about ONE EXIT-trap handler, with every fact
+// the answer needs in one place instead of threaded through as loose strings and
+// line numbers: which variable the handler writes to the verdict file and where
+// in the handler that write sits, the value the variable holds when the trap
+// arms, and the epilogue window an assignment has to fall in to count as
+// progress through the run.
+type staleVerdict struct {
+	src     *Source
+	trap    exitTrap
+	write   verdictWriteSite
+	initial string
+	ep      epilogue
+}
 
-	reason := ""
-	for _, st := range t.stmts[:writeIdx] {
-		rhs, assigns := assignedValue(st, v)
-		if !assigns {
-			continue
-		}
-		others := condVarsExcept(strings.TrimSpace(st.Prefix+" "+strings.Join(st.Conds, " ")), v)
-		if len(others) == 0 {
-			reason = fmt.Sprintf("the only re-assignment of $%s before the write is guarded by "+
-				"nothing but $%s itself, which is equally true on a run that completed", v, v)
-			continue
-		}
-		if _, _, isVar := soleVar(rhs); !isVar && unquote(rhs) == initial {
-			reason = fmt.Sprintf("the guard on the write assigns $%s its own initial value %q, "+
-				"so it changes nothing", v, initial)
-			continue
-		}
-		set := false
-		for _, o := range others {
-			if len(epilogueAssignments(src, o, t.line, lastLaunch)) > 0 {
-				set = true
-			}
-		}
-		if set {
-			return nil // (a) guard, satisfied
-		}
-		reason = fmt.Sprintf("the guard on the write consults %s, and nothing assigns any of "+
-			"them unconditionally at top level after the trap is armed and after the last "+
-			"`tmux new-session` — so no amount of progress through the run can change what "+
-			"the handler writes", strings.Join(dollarize(others), ", "))
+// grade returns the INV-4 finding for this handler, or nil when it satisfies
+// either shape. The reason it reports is the most specific one that applies, so
+// the message names what to change rather than restating the rule.
+func (q staleVerdict) grade() *Finding {
+	if q.failsClosed() {
+		return nil
+	}
+	reason, guarded := q.guardReason()
+	if guarded {
+		return nil
 	}
 	if reason == "" {
 		reason = fmt.Sprintf("the handler writes $%s unconditionally, and nothing between the "+
-			"trap arming and the write can change it", v)
+			"trap arming and the write can change it", q.write.v)
 	}
 	return &Finding{
-		Invariant: "INV-4", Path: src.Path, Line: t.line, Excerpt: t.body,
+		Invariant: "INV-4", Path: q.src.Path, Line: q.trap.line, Excerpt: q.trap.body,
 		Detail: fmt.Sprintf("this EXIT-trap handler can write %s with $%s still at its initial "+
 			"value %q: %s. Before an EXIT trap existed, an abort wrote NO %s and run-cell.sh:443 "+
 			"read the absence as `unknown`; a handler that writes the initialiser turns that into "+
@@ -715,15 +747,81 @@ func gradeVerdictGuard(src *Source, t exitTrap, writeIdx int, v, initial string,
 			"success while leaking. Either guard the write on a sentinel the epilogue sets "+
 			"unconditionally at top level (aider's `REACHED_EPILOGUE`), or start $%s at a fault "+
 			"and promote it on the success path.",
-			exitReasonFile, v, initial, reason, exitReasonFile, v),
+			exitReasonFile, q.write.v, q.initial, reason, exitReasonFile, q.write.v),
 	}
 }
 
+// failsClosed is shape (b): the epilogue itself moves the verdict variable off
+// its initialiser, so an abort and a completed run write different bytes and no
+// guard is needed. A driver whose verdict starts at a fault and is promoted to
+// success at the end satisfies INV-4 this way — a rule that failed it would be
+// prescribing one implementation rather than the property.
+func (q staleVerdict) failsClosed() bool {
+	for _, a := range q.ep.assigns(q.src, q.write.v) {
+		if a != q.initial {
+			return true
+		}
+	}
+	return false
+}
+
+// guardReason looks for shape (a) among the handler statements that run BEFORE
+// the verdict write: a conditional re-assignment of the verdict variable whose
+// condition consults some OTHER variable the epilogue moves, and which does not
+// assign the initial value straight back.
+//
+// It reports guarded=true the moment it finds one. Otherwise it returns the most
+// specific reason it saw — the LAST one, matching the order the statements run
+// in — so the finding names what to change.
+func (q staleVerdict) guardReason() (reason string, guarded bool) {
+	v := q.write.v
+	for _, st := range q.trap.stmts[:q.write.idx] {
+		rhs, assigns := assignedValue(st, v)
+		if !assigns {
+			continue
+		}
+		others := condVarsExcept(guardCondition(st), v)
+		_, _, rhsIsVar := soleVar(rhs)
+		switch {
+		case len(others) == 0:
+			reason = fmt.Sprintf("the only re-assignment of $%s before the write is guarded by "+
+				"nothing but $%s itself, which is equally true on a run that completed", v, v)
+		case !rhsIsVar && unquote(rhs) == q.initial:
+			reason = fmt.Sprintf("the guard on the write assigns $%s its own initial value %q, "+
+				"so it changes nothing", v, q.initial)
+		case q.ep.setsAny(q.src, others):
+			return "", true // (a) guard, satisfied
+		default:
+			reason = fmt.Sprintf("the guard on the write consults %s, and nothing assigns any of "+
+				"them unconditionally at top level after the trap is armed and after the last "+
+				"`tmux new-session` — so no amount of progress through the run can change what "+
+				"the handler writes", strings.Join(dollarize(others), ", "))
+		}
+	}
+	return reason, false
+}
+
+// guardCondition is the code a statement's execution is conditional on: the
+// `[[ … ]]` earlier in its own logical line, plus every enclosing `if`/`elif`.
+func guardCondition(st Statement) string {
+	return strings.TrimSpace(st.Prefix + " " + strings.Join(st.Conds, " "))
+}
+
+// verdictWriteSite is the handler command that redirects into the staging
+// contract's verdict file: the line it sits on, its index among the handler's
+// statements — so the guard search knows which statements run before it — and
+// the variable whose value it writes.
+type verdictWriteSite struct {
+	line int
+	idx  int
+	v    string
+}
+
 // verdictWrite finds the handler command that redirects into the verdict file
-// and names the variable whose value it writes, with its index in the handler.
-// A handler that writes a literal reports ok=false: there is no initial value
-// for it to be stale at, which is the derived half of INV-4's precondition.
-func verdictWrite(stmts []Statement) (st Statement, idx int, v string, ok bool) {
+// and names the variable whose value it writes. A handler that writes a literal
+// reports ok=false: there is no initial value for it to be stale at, which is
+// the derived half of INV-4's precondition.
+func verdictWrite(stmts []Statement) (verdictWriteSite, bool) {
 	for i, s := range stmts {
 		if !writesVerdictFile(s) {
 			continue
@@ -734,12 +832,12 @@ func verdictWrite(stmts []Statement) (st Statement, idx int, v string, ok bool) 
 		}
 		for _, a := range args {
 			if name, pos, isVar := soleVar(a); isVar && pos == 0 && name != "" {
-				return s, i, name, true
+				return verdictWriteSite{line: s.Line, idx: i, v: name}, true
 			}
 		}
-		return s, i, "", false
+		return verdictWriteSite{}, false
 	}
-	return Statement{}, 0, "", false
+	return verdictWriteSite{}, false
 }
 
 // writesVerdictFile reports whether a command redirects into the staging
@@ -775,14 +873,23 @@ func initialVerdict(src *Source, v string, trapLine int) (string, bool) {
 	return val, found
 }
 
-// epilogueAssignments lists the values assigned to a variable by an
-// unconditional top-level statement placed after the trap arms AND after the
-// driver's last tmux launch — the name-free structural stand-in for "the
-// epilogue set it, once the run's work was behind it".
-func epilogueAssignments(src *Source, v string, trapLine, lastLaunch int) []string {
+// epilogue is the structural window INV-4's "the epilogue set it" rests on: the
+// region of a driver after its EXIT trap arms AND after its last `tmux
+// new-session`. An unconditional top-level assignment placed there is what "the
+// run got far enough to have formed a verdict" looks like with the variable
+// NAMES removed — which is what keeps INV-4 from being satisfiable by naming a
+// sentinel the rule already knows. See checkVerdictCannotBeStale.
+type epilogue struct {
+	trapLine   int
+	lastLaunch int
+}
+
+// assigns lists the values an unconditional top-level statement in the epilogue
+// gives to v.
+func (e epilogue) assigns(src *Source, v string) []string {
 	var out []string
 	for _, st := range src.Statements() {
-		if st.Line <= trapLine || st.Line <= lastLaunch || !isUnconditionalTopLevel(st) {
+		if st.Line <= e.trapLine || st.Line <= e.lastLaunch || !isUnconditionalTopLevel(st) {
 			continue
 		}
 		if rhs, ok := assignedValue(st, v); ok {
@@ -790,6 +897,18 @@ func epilogueAssignments(src *Source, v string, trapLine, lastLaunch int) []stri
 		}
 	}
 	return out
+}
+
+// setsAny reports whether the epilogue assigns any of the named variables — the
+// test that separates a guard consulting a live sentinel from one consulting a
+// variable no amount of progress through the run can move.
+func (e epilogue) setsAny(src *Source, names []string) bool {
+	for _, n := range names {
+		if len(e.assigns(src, n)) > 0 {
+			return true
+		}
+	}
+	return false
 }
 
 // isUnconditionalTopLevel reports whether a statement runs on every path
@@ -811,8 +930,7 @@ func assignedValue(st Statement, v string) (string, bool) {
 func lastLaunchLine(src *Source) int {
 	last := 0
 	for _, st := range src.Statements() {
-		if name, args, ok := st.Command(); ok && name == "tmux" && len(args) > 0 &&
-			args[0] == "new-session" {
+		if _, launches := tmuxArgs(st, "new-session"); launches {
 			last = st.Line
 		}
 	}
@@ -981,8 +1099,8 @@ func newNameFlow(src *Source, libs []*Source) (*nameFlow, error) {
 func (f *nameFlow) seed(src *Source) error {
 	launches := 0
 	for _, st := range src.Statements() {
-		name, args, ok := st.Command()
-		if !ok || name != "tmux" || len(args) == 0 || args[0] != "new-session" {
+		args, launched := tmuxArgs(st, "new-session")
+		if !launched {
 			continue
 		}
 		launches++
@@ -1018,47 +1136,51 @@ func flagValue(args []string, flag string) (string, bool) {
 }
 
 // propagate runs one pass of the closure over one file, reporting whether it
-// learned anything new.
+// learned anything new. The closure grows along two edges, and they are graded
+// separately below because they are different relations: an ASSIGNMENT relates
+// two variables (or a variable and one of its function's parameters), while a
+// CALL relates an argument to the parameter position it lands on.
 func (f *nameFlow) propagate(src *Source) bool {
 	changed := false
 	for _, st := range src.Statements() {
-		for _, a := range st.Assignments() {
-			lhs, rhs := a[0], a[2]
-			v, positional, isVar := soleVar(rhs)
-			if !isVar {
-				continue
-			}
-			switch {
-			case positional > 0:
-				// Marked against THIS file's definition. Marking a definition no
-				// call resolves to is harmless — nothing reads that key — and
-				// keeping it unconditional keeps the fixpoint a single pass.
-				ref := funcRef{file: src.Path, name: st.Func}
-				if f.vars[lhs] && st.Func != "" && !f.posHas(ref, positional) {
-					f.markPos(ref, positional)
-					changed = true
-				}
-			default:
-				if f.vars[lhs] && !f.vars[v] {
-					f.vars[v] = true
-					changed = true
-				}
-				if f.vars[v] && !f.vars[lhs] {
-					f.vars[lhs] = true
-					changed = true
-				}
-			}
+		if f.propagateAssignments(src.Path, st) {
+			changed = true
 		}
-		name, args, ok := st.Command()
-		if !ok || len(f.posOf(name)) == 0 {
+		if f.propagateCallArgs(st) {
+			changed = true
+		}
+	}
+	return changed
+}
+
+// propagateAssignments walks one statement's `LHS=RHS` pairs. `local sess="$1"`
+// inside a function marks that function's PARAMETER position; everything else
+// relates two variables, and the relation runs both ways — a name-carrying
+// variable assigned from another makes that other name-carrying too, which is
+// what walks the closure backwards from the launch to the text that mints it.
+func (f *nameFlow) propagateAssignments(path string, st Statement) bool {
+	changed := false
+	for _, a := range st.Assignments() {
+		lhs, rhs := a[0], a[2]
+		v, positional, isVar := soleVar(rhs)
+		switch {
+		case !isVar:
 			continue
-		}
-		for n := range f.posOf(name) {
-			if n > len(args) {
+		case positional > 0:
+			// Marked against THIS file's definition. Marking a definition no
+			// call resolves to is harmless — nothing reads that key — and
+			// keeping it unconditional keeps the fixpoint a single pass.
+			if !f.vars[lhs] || st.Func == "" {
 				continue
 			}
-			if v, _, isVar := soleVar(args[n-1]); isVar && v != "" && !f.vars[v] {
-				f.vars[v] = true
+			if f.markPos(funcRef{file: path, name: st.Func}, positional) {
+				changed = true
+			}
+		default:
+			if f.vars[lhs] && f.markVar(v) {
+				changed = true
+			}
+			if f.vars[v] && f.markVar(lhs) {
 				changed = true
 			}
 		}
@@ -1066,13 +1188,46 @@ func (f *nameFlow) propagate(src *Source) bool {
 	return changed
 }
 
-func (f *nameFlow) posHas(fn funcRef, n int) bool { return f.pos[fn][n] }
+// propagateCallArgs marks the variable passed at a name-carrying argument
+// position of the ONE definition this call resolves to.
+func (f *nameFlow) propagateCallArgs(st Statement) bool {
+	name, args, ok := st.Command()
+	if !ok {
+		return false
+	}
+	changed := false
+	for n := range f.posOf(name) {
+		if n > len(args) {
+			continue
+		}
+		if v, _, isVar := soleVar(args[n-1]); isVar && v != "" && f.markVar(v) {
+			changed = true
+		}
+	}
+	return changed
+}
 
-func (f *nameFlow) markPos(fn funcRef, n int) {
+// markVar records that a variable carries a tmux session name, reporting whether
+// that was new — which is what drives the fixpoint to a halt.
+func (f *nameFlow) markVar(v string) bool {
+	if f.vars[v] {
+		return false
+	}
+	f.vars[v] = true
+	return true
+}
+
+// markPos records that argument n of one function DEFINITION carries a session
+// name, reporting whether that was new.
+func (f *nameFlow) markPos(fn funcRef, n int) bool {
+	if f.pos[fn][n] {
+		return false
+	}
 	if f.pos[fn] == nil {
 		f.pos[fn] = map[int]bool{}
 	}
 	f.pos[fn][n] = true
+	return true
 }
 
 // posOf gives the name-carrying argument positions of the ONE definition a call
@@ -1091,17 +1246,15 @@ func (f *nameFlow) posOf(fn string) map[int]bool {
 // name-carrying argument position.
 func (f *nameFlow) mintSites(src *Source) []mintSite {
 	out := append([]mintSite(nil), f.seeds...)
+	add := func(line int, word string) {
+		if lit, ok := composedLiteral(word); ok {
+			out = append(out, mintSite{line: line, literal: lit})
+		}
+	}
 	for _, st := range src.Statements() {
 		for _, a := range st.Assignments() {
-			lhs, rhs := a[0], a[2]
-			if !f.vars[lhs] {
-				continue
-			}
-			if _, _, isVar := soleVar(rhs); isVar {
-				continue
-			}
-			if lit := unquote(rhs); strings.TrimSpace(lit) != "" {
-				out = append(out, mintSite{line: st.Line, literal: lit})
+			if lhs, rhs := a[0], a[2]; f.vars[lhs] {
+				add(st.Line, rhs)
 			}
 		}
 		name, args, ok := st.Command()
@@ -1112,17 +1265,30 @@ func (f *nameFlow) mintSites(src *Source) []mintSite {
 			if n > len(args) {
 				continue
 			}
-			arg := args[n-1]
-			if _, _, isVar := soleVar(arg); isVar {
-				continue
-			}
-			if lit := unquote(arg); strings.TrimSpace(lit) != "" {
-				out = append(out, mintSite{line: st.Line, literal: lit})
-			}
+			add(st.Line, args[n-1])
 		}
 	}
 	sort.SliceStable(out, func(i, j int) bool { return out[i].line < out[j].line })
 	return out
+}
+
+// composedLiteral reports the text a word contributes when it MINTS a name
+// rather than merely carrying one: a bare variable expansion is the closure's
+// business and not a mint site, and empty text names nothing.
+//
+// Deliberately not shared with nameFlow.seed, whose test differs: at a launch,
+// `tmux new-session -s "$1"` is a POSITIONAL expansion that soleVar reports as a
+// variable with no name, and seed grades it as a literal — a session name it
+// cannot trace is one INV-3 must still report on, not one it quietly drops.
+func composedLiteral(word string) (string, bool) {
+	if _, _, isVar := soleVar(word); isVar {
+		return "", false
+	}
+	lit := unquote(word)
+	if strings.TrimSpace(lit) == "" {
+		return "", false
+	}
+	return lit, true
 }
 
 // Adapters lists every adapter in the catalog that ships a driver, read from

--- a/tools/onboarding-factory/internal/driverteardown/driverteardown.go
+++ b/tools/onboarding-factory/internal/driverteardown/driverteardown.go
@@ -1,0 +1,1031 @@
+// Package driverteardown grades the onboarding-factory's interactive
+// recording drivers against the four teardown invariants #1825 was opened
+// for. It is a STATIC check over driver source text: it needs no tmux, no
+// agent CLI and no recording, so unlike the rig itself it runs in CI (`tmux`
+// appears nowhere under .github/ — the recording harness has never run there).
+//
+// The failure it exists to catch is a leak that reports success. A driver that
+// marks a slot dead on an optimistic flag and then gates its teardown on that
+// same flag leaves the agent process and its tmux session running while
+// writing driver.exit-reason=ok. #1825 measured nine such runs for claudecode
+// — claude answers a single Ctrl-D with "Press Ctrl-D again to exit" and lets
+// the confirmation expire — and the audit in that issue found the same shape
+// in codex, pi and kiro-cli. Nothing anywhere said why.
+//
+//	INV-1  End-of-run teardown is UNGATED. A `tmux kill-session` that belongs
+//	       to teardown must gate on session-name PRESENCE
+//	       (`-n "${SES_SESSION[$i]:-}"`), never on a liveness flag the driver
+//	       set optimistically and nothing re-derives from `tmux has-session`.
+//	INV-2  Every tmux-launching driver installs a `trap … EXIT` whose handler
+//	       tears sessions down, so a `set -e` abort mid-run still cleans up.
+//	       The reference shape is
+//	       tools/onboarding-factory/scripts/templates/drive-interactive.sh.tmpl.
+//	INV-3  Every tmux session name a driver mints carries the driver process's
+//	       own `$$` as a `-`-delimited field. run-cell.sh has no record of the
+//	       names a driver chose — no staging-contract file carries them — so
+//	       the PID embedded in the name is the ONLY join from a run to the
+//	       sessions it owns, and the post-run leak assertion rests on it.
+//	INV-4  An EXIT-trap handler that writes the staging contract's verdict file
+//	       cannot write it with the verdict variable still at the value it held
+//	       when the trap was armed. Adding a trap to satisfy INV-2 turns "no
+//	       verdict file, read as unknown" into "the initialiser, read as ok",
+//	       so the fix for a leak that reports success can manufacture a
+//	       different driver that reports success. See checkVerdictCannotBeStale.
+//
+// Adapters that never launch tmux are exempt, and the exemption is DERIVED
+// (no `tmux new-session` in the file) rather than listed, so an adapter added
+// tomorrow is graded by existing rather than by whoever adds it remembering
+// this package.
+//
+// # What these invariants deliberately do NOT check
+//
+// Each invariant's own doc comment states its residual gaps. One gap belongs to
+// no single invariant and is recorded here so it lives in the repo rather than
+// in whoever last looked:
+//
+// A `trap - EXIT` that DISARMS the teardown trap is invisible to INV-2. INV-2
+// asks whether an arming trap with a tearing-down handler exists; a trap that
+// is installed and later removed satisfies it. opencode's driver does exactly
+// this, and it is benign there — checked, not assumed: the disarm sits
+// immediately after an unconditional `tmux kill-session`, so no session is
+// alive when the trap goes away. A future driver that disarmed BEFORE its
+// teardown would pass INV-2 while being as exposed as the four adapters #1825
+// started with.
+//
+// No rule for it is shipped, and that is a judgment rather than an oversight.
+// Three candidate rules were considered and each fails in the way that makes a
+// rule worse than a documented gap — it looks like it grades this and does not:
+//
+//   - "flag a disarm not preceded by an unconditional teardown in the same
+//     region" passes a multi-slot driver that unconditionally kills ONE slot
+//     (`tmux kill-session -t "$SESSION"` is the active slot, not all N) and
+//     then disarms with the other slots still live. That is the leak, wearing
+//     the shape the rule accepts.
+//   - "flag a disarm followed by any `tmux new-session`" reads SOURCE order as
+//     EXECUTION order. A disarm inside a function called early and a launch
+//     inside a function defined earlier but called later is a leak the rule
+//     reports clean.
+//   - "forbid `trap - EXIT` outright in a tmux-launching driver" is robust and
+//     trivially expressible, and would fail opencode, which is correct today.
+//     A finding against a driver that is right is the kind that gets a rule
+//     ignored rather than fixed — the same reasoning that shaped aliveGate.
+//
+// Grading it soundly needs reachability and slot-aliasing analysis, which a
+// text checker does not have. Anyone adding a disarm to a driver is on their
+// own; this paragraph is the warning.
+package driverteardown
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// AgentsDir is the catalog directory holding one subdirectory per adapter.
+const AgentsDir = "replaydata/agents"
+
+// DriverName is the file every onboarded adapter carries.
+const DriverName = "driver-interactive.sh"
+
+// libDir holds the shell libraries the drivers source. They participate in the
+// analysis (alloc_slot lives there, and so does the slot bookkeeping a session
+// name flows through) but are never themselves reported: they are shared, so a
+// finding there would be raised once per adapter against a file no adapter owns.
+const libDir = "replaydata/_lib/drive"
+
+// aliveGate names the anti-pattern INV-1 forbids at a teardown site.
+//
+// TRADEOFF, stated plainly: this is a NAMED anti-pattern, not a general
+// "optimistic flag" detector. It matches the substring `alive`, case
+// insensitively, anywhere in the gate. A driver that invented a differently
+// named liveness flag — `SES_RUNNING`, say — would gate its teardown on it and
+// pass. The reason to accept that is that the flag is not per-driver: SES_ALIVE
+// is declared and maintained by the SHARED replaydata/_lib/drive/slots.sh that
+// every slot-model driver sources, and claudecode's private slot scheme uses
+// the same name. Matching the name that exists keeps the rule readable and
+// keeps its false-POSITIVE rate at zero, which matters more here: a finding
+// against a driver that is correct is the kind that gets a rule ignored rather
+// than fixed. The general form of the rule — "teardown must gate on session
+// presence" — is stated in the finding text so the next reader knows what the
+// substring is standing in for.
+var aliveGate = regexp.MustCompile(`(?i)alive`)
+
+// pidField is the `$$` a minted session name must carry as its own
+// `-`-delimited field.
+const pidField = "$$"
+
+// exitReasonFile is the staging contract's verdict file — the one run-cell.sh
+// reads at :443 with `|| echo "unknown"`, which is why an EXIT trap that writes
+// it unconditionally is a behaviour CHANGE and not just a tidy-up.
+//
+// It is a filename, not a variable name, and that is what makes matching it
+// legitimate where matching `SES_ALIVE` was a named-anti-pattern compromise: it
+// is a contract between two files, so a rename has to touch run-cell.sh too.
+// TestVerdictFilenameIsTheOneRunCellReads asserts that it still does.
+const exitReasonFile = "driver.exit-reason"
+
+// condVarRe extracts the variables a shell condition expands.
+var condVarRe = regexp.MustCompile(`\$\{?([A-Za-z_][A-Za-z0-9_]*)`)
+
+// File is one shell source under analysis.
+type File struct {
+	Path string
+	Src  string
+}
+
+// Finding is one violated invariant, anchored to a line of the driver.
+type Finding struct {
+	Invariant string // "INV-1", "INV-2", "INV-3" or "INV-4"
+	Path      string
+	Line      int // 0 when the finding is about the file as a whole
+	Excerpt   string
+	Detail    string
+}
+
+func (f Finding) String() string {
+	loc := f.Path
+	if f.Line > 0 {
+		loc = fmt.Sprintf("%s:%d", f.Path, f.Line)
+	}
+	s := fmt.Sprintf("%s %s: %s", f.Invariant, loc, f.Detail)
+	if f.Excerpt != "" {
+		s += "\n    " + strings.TrimSpace(f.Excerpt)
+	}
+	return s
+}
+
+// LaunchCount counts `tmux new-session` in a driver's CODE. It is the vacuity
+// measurement, kept separate from every verdict so "this driver launches no
+// tmux session" and "every launch this driver makes is fine" can never be
+// confused for one another.
+//
+// Comments are stripped first, and only comments: a driver's prose routinely
+// names the thing it is talking about, and reading "see the tmux new-session
+// above" as a launch would take a genuinely headless driver out of its derived
+// exemption and hard-fail it for having no teardown to grade. Everything else
+// stays counted — over-counting means the driver gets GRADED, which is the
+// safe direction, while under-counting would exempt one silently.
+func LaunchCount(src string) int {
+	n := 0
+	for _, ln := range strings.Split(src, "\n") {
+		if strings.Contains(stripComment(ln), "tmux new-session") {
+			n++
+		}
+	}
+	return n
+}
+
+// CheckDriver grades one driver against INV-1 through INV-4.
+//
+// libs are the shell libraries the driver sources. They are read for the
+// dataflow the invariants need — a session name minted at an `alloc_slot`
+// call site reaches `tmux new-session -s` only through slots.sh — and never
+// reported against.
+//
+// It returns an error, not an empty finding list, whenever it could not
+// actually look: an empty driver, a structure it cannot parse, a launch with
+// no `-s`, a tmux-launching driver in which it found nothing to grade.
+func CheckDriver(driver File, libs []File) ([]Finding, error) {
+	if strings.TrimSpace(driver.Src) == "" {
+		return nil, fmt.Errorf("%s is empty — a driver that cannot be read graded nothing, "+
+			"and a check that cannot run must say so", driver.Path)
+	}
+	src, err := Parse(driver.Path, driver.Src)
+	if err != nil {
+		return nil, err
+	}
+	if LaunchCount(driver.Src) == 0 {
+		// Derived exemption: no `tmux new-session` means no session to leak
+		// and no name to carry a PID. The non-empty check above is what keeps
+		// this from also covering "the file was never read".
+		return nil, nil
+	}
+	parsedLibs, err := parseAll(libs)
+	if err != nil {
+		return nil, err
+	}
+
+	traps, err := exitTraps(src, parsedLibs)
+	if err != nil {
+		return nil, err
+	}
+	findings := checkTrapExists(driver, traps)
+
+	inv1, err := checkTeardownUngated(src, traps)
+	if err != nil {
+		return nil, err
+	}
+	findings = append(findings, inv1...)
+
+	inv3, err := checkSessionNamesCarryPID(src, parsedLibs)
+	if err != nil {
+		return nil, err
+	}
+	findings = append(findings, inv3...)
+
+	inv4, err := checkVerdictCannotBeStale(src, traps)
+	if err != nil {
+		return nil, err
+	}
+	return append(findings, inv4...), nil
+}
+
+func parseAll(files []File) ([]*Source, error) {
+	out := make([]*Source, 0, len(files))
+	for _, f := range files {
+		p, err := Parse(f.Path, f.Src)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, p)
+	}
+	return out, nil
+}
+
+// exitTrap is one armed `trap … EXIT`.
+type exitTrap struct {
+	line      int
+	fn        string      // handler function name, "" for an inline handler
+	body      string      // the handler's source text
+	stmts     []Statement // the handler's commands, in order
+	tearsDown bool
+}
+
+// exitTraps finds every armed EXIT trap and resolves each handler's body,
+// following a named handler into the driver and then into the sourced libs. A
+// handler it cannot resolve is an error: "this driver has no teardown trap"
+// and "the trap's handler could not be found" must not be the same answer.
+func exitTraps(src *Source, libs []*Source) ([]exitTrap, error) {
+	var out []exitTrap
+	for _, st := range src.Statements() {
+		name, args, ok := st.Command()
+		if !ok || name != "trap" || len(args) < 2 {
+			continue
+		}
+		if !argsNameEXIT(args[1:]) {
+			continue
+		}
+		handler := unquote(args[0])
+		if handler == "-" || handler == "" {
+			continue // `trap - EXIT` disarms; it arms nothing to grade
+		}
+		t := exitTrap{line: st.Line}
+		if isIdentifier(handler) {
+			owner, body, found := lookupFunc(handler, src, libs)
+			if !found {
+				return nil, fmt.Errorf("%s:%d: `trap %s EXIT` names a handler that is defined "+
+					"neither in this driver nor in any library it sources — the trap cannot be "+
+					"graded, and a check that cannot run must say so", src.Path, st.Line, handler)
+			}
+			t.fn, t.body = handler, body
+			for _, s := range owner.Statements() {
+				if s.Func == handler {
+					t.stmts = append(t.stmts, s)
+				}
+			}
+		} else {
+			t.body = handler
+			// An inline handler is one quoted word, so its commands are not
+			// statements of the enclosing file. Parse the word's text as its
+			// own source rather than reading the handler as an opaque string.
+			inline, err := Parse(fmt.Sprintf("%s:%d (inline EXIT trap)", src.Path, st.Line), handler)
+			if err != nil {
+				return nil, err
+			}
+			t.stmts = inline.Statements()
+		}
+		t.tearsDown = strings.Contains(t.body, "tmux kill-session")
+		out = append(out, t)
+	}
+	return out, nil
+}
+
+func argsNameEXIT(args []string) bool {
+	for _, a := range args {
+		switch strings.ToUpper(unquote(a)) {
+		case "EXIT", "0":
+			return true
+		}
+	}
+	return false
+}
+
+func isIdentifier(s string) bool {
+	for i, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r == '_':
+		case i > 0 && (r >= '0' && r <= '9' || r == '-'):
+		default:
+			return false
+		}
+	}
+	return s != ""
+}
+
+// lookupFunc finds a function definition, preferring the driver over the
+// libraries it sources, and returns the file it was found in so the caller can
+// read its statements rather than only its text.
+func lookupFunc(name string, src *Source, libs []*Source) (*Source, string, bool) {
+	if b, ok := src.Body(name); ok {
+		return src, b, true
+	}
+	for _, l := range libs {
+		if b, ok := l.Body(name); ok {
+			return l, b, true
+		}
+	}
+	return nil, "", false
+}
+
+// checkTrapExists is INV-2.
+func checkTrapExists(driver File, traps []exitTrap) []Finding {
+	for _, t := range traps {
+		if t.tearsDown {
+			return nil
+		}
+	}
+	detail := "this driver launches the agent under tmux but installs no `trap … EXIT` that " +
+		"tears the session down. Any exit path that does not reach the end of the script — a " +
+		"`set -e` abort mid-launch, a failed jq, an `exit` from a step — then leaves the pane " +
+		"and the agent process alive. See scripts/templates/drive-interactive.sh.tmpl's `cleanup`."
+	line := 0
+	if len(traps) > 0 {
+		line = traps[0].line
+		detail = "this driver's `trap … EXIT` handler contains no `tmux kill-session`, so an " +
+			"abort mid-run leaves the pane and the agent process alive. See " +
+			"scripts/templates/drive-interactive.sh.tmpl's `cleanup`."
+	}
+	return []Finding{{Invariant: "INV-2", Path: driver.Path, Line: line, Detail: detail}}
+}
+
+// checkTeardownUngated is INV-1.
+//
+// HOW A TEARDOWN SITE IS TOLD APART FROM A STEP-LEVEL GUARD, and the tradeoff.
+//
+// The distinction is STRUCTURAL — where the `tmux kill-session` sits — not
+// textual, because both spellings of the gate are byte-identical:
+//
+//	teardown (must be ungated)   : the EXIT-trap handler, and the end-of-run
+//	                               sweep, which every driver writes at TOP
+//	                               LEVEL after the step loop has finished.
+//	step-level (may be gated)    : anything inside an ordinary function.
+//
+// kiro-cli is the case that forces this. Its `step_exit_clean` and
+// `step_sigkill` open with `if [[ "${SES_ALIVE[$ACTIVE]:-0}" != "1" ]]; then
+// return 0; fi`, and those guards are CORRECT: reset_session gives a new slot
+// the SAME tmux pane as an old one, so an already-retired slot number can alias
+// a pane a different, still-live slot now owns, and a recipe re-targeting the
+// old number must not tear the live session down. A textual rule keyed on
+// "SES_ALIVE near a kill-session" would fail those, and a finding against a
+// driver that is right is the kind that gets a rule ignored rather than fixed.
+//
+// The cost of the structural rule is the mirror image: a driver that moved its
+// end-of-run sweep INTO a helper function — `final_teardown() { … }` called
+// once at the bottom — would have that sweep classified as step-level and its
+// gate would go unflagged. That is a real hole and it is worth naming rather
+// than papering over. Two things make it acceptable. The sweep is generated
+// from a shared template that puts it at top level, so a driver moving it is a
+// deliberate act by someone editing teardown; and INV-2 still binds on that
+// driver, so the EXIT trap — whose handler IS a named function, and which this
+// rule follows by name — must still tear down ungated. The alternative,
+// keying on a marker comment the drivers would carry, was rejected because it
+// makes the rule depend on the very line an author editing teardown is most
+// likely to move or drop.
+func checkTeardownUngated(src *Source, traps []exitTrap) ([]Finding, error) {
+	handlerFuncs := map[string]bool{}
+	sites := 0
+	var findings []Finding
+
+	for _, t := range traps {
+		if t.fn != "" {
+			handlerFuncs[t.fn] = true
+			continue
+		}
+		if !t.tearsDown {
+			continue
+		}
+		// An inline handler is one quoted word, so its kill-session is not a
+		// statement of its own; grade the handler text directly.
+		sites++
+		if aliveGate.MatchString(t.body) {
+			findings = append(findings, Finding{
+				Invariant: "INV-1", Path: src.Path, Line: t.line, Excerpt: t.body,
+				Detail: inv1Detail("this inline EXIT-trap handler"),
+			})
+		}
+	}
+
+	for _, st := range src.Statements() {
+		name, args, ok := st.Command()
+		if !ok || name != "tmux" || len(args) == 0 || args[0] != "kill-session" {
+			continue
+		}
+		where := ""
+		switch {
+		case st.Func == "":
+			where = "this end-of-run teardown"
+		case handlerFuncs[st.Func]:
+			where = fmt.Sprintf("this teardown inside the EXIT-trap handler %s()", st.Func)
+		default:
+			continue // step-level: legitimately allowed to gate on liveness
+		}
+		sites++
+		if !gatedOnLiveness(st) {
+			continue
+		}
+		findings = append(findings, Finding{
+			Invariant: "INV-1", Path: src.Path, Line: st.Line, Excerpt: st.Text,
+			Detail: inv1Detail(where),
+		})
+	}
+
+	if sites == 0 {
+		return nil, fmt.Errorf("%s launches the agent under tmux but has no `tmux kill-session` "+
+			"in its EXIT trap or at top level — INV-1 graded nothing here, and a check that "+
+			"cannot run must say so", src.Path)
+	}
+	return findings, nil
+}
+
+func inv1Detail(where string) string {
+	return where + " is gated on a liveness flag. That flag is a driver INTENT, not an " +
+		"observation — nothing anywhere re-derives it from `tmux has-session` — so a step that " +
+		"asked the TUI to exit and was not obeyed clears it, teardown skips the kill, and the " +
+		"pane plus the agent process survive the run while driver.exit-reason still says ok. " +
+		"Gate on session-name PRESENCE instead: `[[ -n \"${SES_SESSION[$i]:-}\" ]]`, the shape " +
+		"scripts/templates/drive-interactive.sh.tmpl already ships."
+}
+
+func gatedOnLiveness(st Statement) bool {
+	if aliveGate.MatchString(st.Prefix) {
+		return true // `[[ "${SES_ALIVE[$i]}" == 1 ]] && tmux kill-session …`
+	}
+	for _, c := range st.Conds {
+		if aliveGate.MatchString(c) {
+			return true
+		}
+	}
+	return false
+}
+
+// checkVerdictCannotBeStale is INV-4: an EXIT-trap handler that writes the
+// staging contract's verdict file must not be able to write it with the verdict
+// variable still at the value it had when the trap was armed.
+//
+// WHY THIS EXISTS, and why it arrived a day after INV-1/INV-2. Before #1825 an
+// aborting driver wrote NO driver.exit-reason at all, and run-cell.sh:443 reads
+// that absence as `unknown`. Adding an EXIT trap to stop a leak — INV-2's whole
+// demand — turns the absence into whatever the verdict variable happens to hold,
+// which on an abort before any step ran is its initialiser: `ok`. So the fix for
+// "a driver that leaks while reporting success" can manufacture "a driver that
+// reports success for a run that never formed a verdict". The agent fixing aider
+// caught themselves about to ship exactly that, and INV-2 alone would have
+// passed the one-line trap they nearly wrote.
+//
+// HOW IT IS STATED SO IT IS NOT TRIVIALLY SATISFIABLE. No variable name is
+// matched — not the verdict variable's, and above all not the sentinel's, which
+// has no shared-library declaration to anchor it the way SES_ALIVE has. The rule
+// is built from one structural primitive instead:
+//
+//	an UNCONDITIONAL TOP-LEVEL assignment, placed after the trap is armed AND
+//	after the driver's last `tmux new-session`.
+//
+// That is what "the epilogue set it" looks like with the names removed: not
+// inside a function, not inside an `if`, and downstream of the work whose
+// completion it is claiming. A driver satisfies INV-4 by either shape:
+//
+//	(a) GUARD — inside the handler, before the write, a conditional assigns the
+//	    verdict variable, its condition consults some OTHER variable that has
+//	    such an assignment, and it does not assign the initial value back. This
+//	    is aider's REACHED_EPILOGUE, and it is graded without knowing that name.
+//	(b) FAIL-CLOSED — the verdict variable itself has such an assignment, to a
+//	    value different from its initialiser. A driver whose verdict starts at a
+//	    fault and is promoted to success at the end needs no guard at all, and a
+//	    rule that failed it would be prescribing one implementation rather than
+//	    the property. inv4_fail_closed_ok.sh is that row.
+//
+// WHAT IT STILL CANNOT SEE, stated rather than implied:
+//   - that the sentinel is set at the RIGHT place. "After the last launch" is a
+//     proxy for "immediately before the final exit"; a driver that set it three
+//     lines later than it should would pass.
+//   - that the value written on the abort path DENOTES failure. The verdict
+//     vocabulary belongs to run-cell.sh, not to the drivers, so a guard that
+//     assigned some other success-shaped token would pass. Only "not the
+//     initialiser" is checked.
+//   - which statements can actually abort. `set -e` reachability is not modelled.
+//
+// The precondition is DERIVED, not assumed: the rule binds only on a handler
+// that redirects into a path ending in the staging contract's verdict filename
+// AND writes a variable's value there. A handler that writes a literal has no
+// initial-value hazard and is exempt by derivation, which is
+// inv4_literal_verdict_ok.sh. The filename that anchors all of it is asserted
+// against run-cell.sh by TestVerdictFilenameIsTheOneRunCellReads, so a rename
+// fails loudly instead of silently switching this whole invariant off.
+func checkVerdictCannotBeStale(src *Source, traps []exitTrap) ([]Finding, error) {
+	lastLaunch := lastLaunchLine(src)
+	var findings []Finding
+	for _, t := range traps {
+		write, idx, v, ok := verdictWrite(t.stmts)
+		if !ok {
+			continue // derived exemption: this handler writes no verdict variable
+		}
+		initial, ok := initialVerdict(src, v, t.line)
+		if !ok {
+			return nil, fmt.Errorf("%s:%d: the EXIT-trap handler writes $%s to %s, but %s is "+
+				"never assigned unconditionally at top level before the trap is armed — INV-4 "+
+				"has no initial value to compare against and graded nothing, and a check that "+
+				"cannot run must say so", src.Path, write.Line, v, exitReasonFile, v)
+		}
+		if f := gradeVerdictGuard(src, t, idx, v, initial, lastLaunch); f != nil {
+			findings = append(findings, *f)
+		}
+	}
+	return findings, nil
+}
+
+// gradeVerdictGuard returns the INV-4 finding for one handler, or nil when the
+// handler satisfies either shape. The reason it reports is the most specific
+// one that applies, so the message names what to change rather than restating
+// the rule.
+func gradeVerdictGuard(src *Source, t exitTrap, writeIdx int, v, initial string, lastLaunch int) *Finding {
+	// (b) fail-closed: the success path itself moves the verdict off its
+	// initialiser, so an abort and a completed run write different bytes.
+	for _, a := range epilogueAssignments(src, v, t.line, lastLaunch) {
+		if a != initial {
+			return nil
+		}
+	}
+
+	reason := ""
+	for _, st := range t.stmts[:writeIdx] {
+		rhs, assigns := assignedValue(st, v)
+		if !assigns {
+			continue
+		}
+		others := condVarsExcept(strings.TrimSpace(st.Prefix+" "+strings.Join(st.Conds, " ")), v)
+		if len(others) == 0 {
+			reason = fmt.Sprintf("the only re-assignment of $%s before the write is guarded by "+
+				"nothing but $%s itself, which is equally true on a run that completed", v, v)
+			continue
+		}
+		if _, _, isVar := soleVar(rhs); !isVar && unquote(rhs) == initial {
+			reason = fmt.Sprintf("the guard on the write assigns $%s its own initial value %q, "+
+				"so it changes nothing", v, initial)
+			continue
+		}
+		set := false
+		for _, o := range others {
+			if len(epilogueAssignments(src, o, t.line, lastLaunch)) > 0 {
+				set = true
+			}
+		}
+		if set {
+			return nil // (a) guard, satisfied
+		}
+		reason = fmt.Sprintf("the guard on the write consults %s, and nothing assigns any of "+
+			"them unconditionally at top level after the trap is armed and after the last "+
+			"`tmux new-session` — so no amount of progress through the run can change what "+
+			"the handler writes", strings.Join(dollarize(others), ", "))
+	}
+	if reason == "" {
+		reason = fmt.Sprintf("the handler writes $%s unconditionally, and nothing between the "+
+			"trap arming and the write can change it", v)
+	}
+	return &Finding{
+		Invariant: "INV-4", Path: src.Path, Line: t.line, Excerpt: t.body,
+		Detail: fmt.Sprintf("this EXIT-trap handler can write %s with $%s still at its initial "+
+			"value %q: %s. Before an EXIT trap existed, an abort wrote NO %s and run-cell.sh:443 "+
+			"read the absence as `unknown`; a handler that writes the initialiser turns that into "+
+			"a verdict the run never formed — on a ticket whose subject is a driver claiming "+
+			"success while leaking. Either guard the write on a sentinel the epilogue sets "+
+			"unconditionally at top level (aider's `REACHED_EPILOGUE`), or start $%s at a fault "+
+			"and promote it on the success path.",
+			exitReasonFile, v, initial, reason, exitReasonFile, v),
+	}
+}
+
+// verdictWrite finds the handler command that redirects into the verdict file
+// and names the variable whose value it writes, with its index in the handler.
+// A handler that writes a literal reports ok=false: there is no initial value
+// for it to be stale at, which is the derived half of INV-4's precondition.
+func verdictWrite(stmts []Statement) (st Statement, idx int, v string, ok bool) {
+	for i, s := range stmts {
+		if !writesVerdictFile(s) {
+			continue
+		}
+		_, args, isCmd := s.Command()
+		if !isCmd {
+			continue
+		}
+		for _, a := range args {
+			if name, pos, isVar := soleVar(a); isVar && pos == 0 && name != "" {
+				return s, i, name, true
+			}
+		}
+		return s, i, "", false
+	}
+	return Statement{}, 0, "", false
+}
+
+// writesVerdictFile reports whether a command redirects into the staging
+// contract's verdict file, in either spacing (`> "$S/f"` and `>"$S/f"`).
+func writesVerdictFile(st Statement) bool {
+	for i, w := range st.Words {
+		if w == ">" || w == ">>" {
+			if i+1 < len(st.Words) && strings.HasSuffix(unquote(st.Words[i+1]), exitReasonFile) {
+				return true
+			}
+			continue
+		}
+		if strings.HasPrefix(w, ">") &&
+			strings.HasSuffix(unquote(strings.TrimLeft(w, ">")), exitReasonFile) {
+			return true
+		}
+	}
+	return false
+}
+
+// initialVerdict is the value the verdict variable holds when the trap arms:
+// the last unconditional top-level assignment to it before the trap statement.
+func initialVerdict(src *Source, v string, trapLine int) (string, bool) {
+	val, found := "", false
+	for _, st := range src.Statements() {
+		if st.Line >= trapLine || !isUnconditionalTopLevel(st) {
+			continue
+		}
+		if rhs, ok := assignedValue(st, v); ok {
+			val, found = unquote(rhs), true
+		}
+	}
+	return val, found
+}
+
+// epilogueAssignments lists the values assigned to a variable by an
+// unconditional top-level statement placed after the trap arms AND after the
+// driver's last tmux launch — the name-free structural stand-in for "the
+// epilogue set it, once the run's work was behind it".
+func epilogueAssignments(src *Source, v string, trapLine, lastLaunch int) []string {
+	var out []string
+	for _, st := range src.Statements() {
+		if st.Line <= trapLine || st.Line <= lastLaunch || !isUnconditionalTopLevel(st) {
+			continue
+		}
+		if rhs, ok := assignedValue(st, v); ok {
+			out = append(out, unquote(rhs))
+		}
+	}
+	return out
+}
+
+// isUnconditionalTopLevel reports whether a statement runs on every path
+// through the script body: outside any function, outside any `if`, and not
+// chained behind a `&&` / `||` test.
+func isUnconditionalTopLevel(st Statement) bool {
+	return st.Func == "" && st.Depth == 0 && strings.TrimSpace(st.Prefix) == ""
+}
+
+func assignedValue(st Statement, v string) (string, bool) {
+	for _, a := range st.Assignments() {
+		if a[0] == v {
+			return a[2], true
+		}
+	}
+	return "", false
+}
+
+func lastLaunchLine(src *Source) int {
+	last := 0
+	for _, st := range src.Statements() {
+		if name, args, ok := st.Command(); ok && name == "tmux" && len(args) > 0 &&
+			args[0] == "new-session" {
+			last = st.Line
+		}
+	}
+	return last
+}
+
+// condVarsExcept names the variables a condition expands, minus one.
+func condVarsExcept(cond, skip string) []string {
+	seen := map[string]bool{skip: true}
+	var out []string
+	for _, m := range condVarRe.FindAllStringSubmatch(cond, -1) {
+		if seen[m[1]] {
+			continue
+		}
+		seen[m[1]] = true
+		out = append(out, m[1])
+	}
+	return out
+}
+
+func dollarize(names []string) []string {
+	out := make([]string, 0, len(names))
+	for _, n := range names {
+		out = append(out, "$"+n)
+	}
+	return out
+}
+
+// checkSessionNamesCarryPID is INV-3.
+//
+// It resolves which text becomes a tmux session name rather than guessing from
+// the shape of a string, because the negative case has to work: a name that
+// carries no `$$` at all must still be recognised AS a name. So the analysis
+// runs backwards from the sink.
+//
+//	seed        : the `-s` argument of every `tmux new-session`.
+//	closure     : a variable assigned from, or to, a name-carrying variable is
+//	              itself name-carrying — which walks through the slot arrays and
+//	              the view variables, and through `local sess="$1"` into the
+//	              POSITIONAL parameters of alloc_slot, wherever alloc_slot is
+//	              defined (slots.sh for the shared slot model, the driver
+//	              itself for claudecode's private one, where the name is the
+//	              SECOND argument rather than the first).
+//	mint sites  : the composed literals that reach a name-carrying variable or
+//	              a name-carrying argument position.
+//
+// Only the driver's own mint sites are reported. The libraries take part in the
+// closure and own no names of their own.
+func checkSessionNamesCarryPID(src *Source, libs []*Source) ([]Finding, error) {
+	flow, err := newNameFlow(src, libs)
+	if err != nil {
+		return nil, err
+	}
+	mints := flow.mintSites(src)
+	if len(mints) == 0 {
+		return nil, fmt.Errorf("%s launches the agent under tmux but no tmux session NAME could "+
+			"be traced back to the text that mints it — INV-3 graded nothing here, and a check "+
+			"that cannot run must say so", src.Path)
+	}
+	var findings []Finding
+	for _, m := range mints {
+		if carriesPIDField(m.literal) {
+			continue
+		}
+		findings = append(findings, Finding{
+			Invariant: "INV-3", Path: src.Path, Line: m.line, Excerpt: m.literal,
+			Detail: "this tmux session name does not carry `$$` as a `-`-delimited field. " +
+				"run-cell.sh keeps no record of the names a driver chose — no staging-contract " +
+				"file carries them, and the driver is backgrounded only so its PID can be " +
+				"captured — so the driver PID embedded in the name is the ONLY join from a run " +
+				"to the sessions it owns, and the post-run leak assertion has nothing to match " +
+				"on without it. A `$$` glued to another token does not count: `-` is the " +
+				"delimiter the assertion splits on, and a glued PID lets a DIFFERENT pid whose " +
+				"digits merely share a prefix match instead.",
+		})
+	}
+	return findings, nil
+}
+
+// carriesPIDField reports whether a session-name literal carries `$$` as its
+// own `-`-delimited field.
+//
+// The split is over the literal SOURCE text, not over an expanded name, so a
+// `-` inside an expansion (`${FOO:-x}`) splits too. That direction is safe:
+// it can only ever break a field APART, never manufacture a bare `$$` field
+// where the author did not write one, so it cannot turn a bad name into a
+// passing one.
+func carriesPIDField(literal string) bool {
+	for _, f := range strings.Split(literal, "-") {
+		if f == pidField {
+			return true
+		}
+	}
+	return false
+}
+
+type mintSite struct {
+	line    int
+	literal string
+}
+
+// nameFlow is the fixpoint of "what carries a tmux session name".
+type nameFlow struct {
+	vars  map[string]bool         // variable names
+	pos   map[string]map[int]bool // function name -> name-carrying argument positions
+	seeds []mintSite              // names written inline at the launch itself
+	all   []*Source
+}
+
+func newNameFlow(src *Source, libs []*Source) (*nameFlow, error) {
+	f := &nameFlow{vars: map[string]bool{}, pos: map[string]map[int]bool{}}
+	f.all = append([]*Source{src}, libs...)
+	if err := f.seed(src); err != nil {
+		return nil, err
+	}
+	for changed := true; changed; {
+		changed = false
+		for _, s := range f.all {
+			if f.propagate(s) {
+				changed = true
+			}
+		}
+	}
+	return f, nil
+}
+
+// seed reads the `-s` argument of every `tmux new-session`. A launch with no
+// `-s` is an error: tmux would name the session itself, which is precisely the
+// state INV-3 exists to forbid, and reading it as "nothing to grade" would let
+// it pass.
+func (f *nameFlow) seed(src *Source) error {
+	launches := 0
+	for _, st := range src.Statements() {
+		name, args, ok := st.Command()
+		if !ok || name != "tmux" || len(args) == 0 || args[0] != "new-session" {
+			continue
+		}
+		launches++
+		arg, found := flagValue(args, "-s")
+		if !found {
+			return fmt.Errorf("%s:%d: `tmux new-session` with no `-s <name>` — tmux would name "+
+				"the session itself, so it could not carry the driver's PID and no post-run "+
+				"assertion could attribute it", src.Path, st.Line)
+		}
+		if v, _, isVar := soleVar(arg); isVar && v != "" {
+			f.vars[v] = true
+			continue
+		}
+		if lit := unquote(arg); strings.TrimSpace(lit) != "" {
+			f.seeds = append(f.seeds, mintSite{line: st.Line, literal: lit})
+		}
+	}
+	if launches == 0 {
+		return fmt.Errorf("%s: `tmux new-session` appears in the text but not as a parsed "+
+			"command — the lexer and the text disagree, so nothing here was actually graded",
+			src.Path)
+	}
+	return nil
+}
+
+func flagValue(args []string, flag string) (string, bool) {
+	for i, a := range args {
+		if a == flag && i+1 < len(args) {
+			return args[i+1], true
+		}
+	}
+	return "", false
+}
+
+// propagate runs one pass of the closure over one file, reporting whether it
+// learned anything new.
+func (f *nameFlow) propagate(src *Source) bool {
+	changed := false
+	for _, st := range src.Statements() {
+		for _, a := range st.Assignments() {
+			lhs, rhs := a[0], a[2]
+			v, positional, isVar := soleVar(rhs)
+			if !isVar {
+				continue
+			}
+			switch {
+			case positional > 0:
+				if f.vars[lhs] && st.Func != "" && !f.posHas(st.Func, positional) {
+					f.markPos(st.Func, positional)
+					changed = true
+				}
+			default:
+				if f.vars[lhs] && !f.vars[v] {
+					f.vars[v] = true
+					changed = true
+				}
+				if f.vars[v] && !f.vars[lhs] {
+					f.vars[lhs] = true
+					changed = true
+				}
+			}
+		}
+		name, args, ok := st.Command()
+		if !ok || len(f.pos[name]) == 0 {
+			continue
+		}
+		for n := range f.pos[name] {
+			if n > len(args) {
+				continue
+			}
+			if v, _, isVar := soleVar(args[n-1]); isVar && v != "" && !f.vars[v] {
+				f.vars[v] = true
+				changed = true
+			}
+		}
+	}
+	return changed
+}
+
+func (f *nameFlow) posHas(fn string, n int) bool { return f.pos[fn][n] }
+
+func (f *nameFlow) markPos(fn string, n int) {
+	if f.pos[fn] == nil {
+		f.pos[fn] = map[int]bool{}
+	}
+	f.pos[fn][n] = true
+}
+
+// mintSites lists every composed literal in ONE file that becomes a tmux
+// session name — assigned to a name-carrying variable, or passed at a
+// name-carrying argument position.
+func (f *nameFlow) mintSites(src *Source) []mintSite {
+	out := append([]mintSite(nil), f.seeds...)
+	for _, st := range src.Statements() {
+		for _, a := range st.Assignments() {
+			lhs, rhs := a[0], a[2]
+			if !f.vars[lhs] {
+				continue
+			}
+			if _, _, isVar := soleVar(rhs); isVar {
+				continue
+			}
+			if lit := unquote(rhs); strings.TrimSpace(lit) != "" {
+				out = append(out, mintSite{line: st.Line, literal: lit})
+			}
+		}
+		name, args, ok := st.Command()
+		if !ok {
+			continue
+		}
+		for n := range f.pos[name] {
+			if n > len(args) {
+				continue
+			}
+			arg := args[n-1]
+			if _, _, isVar := soleVar(arg); isVar {
+				continue
+			}
+			if lit := unquote(arg); strings.TrimSpace(lit) != "" {
+				out = append(out, mintSite{line: st.Line, literal: lit})
+			}
+		}
+	}
+	sort.SliceStable(out, func(i, j int) bool { return out[i].line < out[j].line })
+	return out
+}
+
+// Adapters lists every adapter in the catalog that ships a driver, read from
+// disk so an adapter onboarded tomorrow is graded without being listed here.
+func Adapters(root string) ([]string, error) {
+	entries, err := os.ReadDir(filepath.Join(root, AgentsDir))
+	if err != nil {
+		return nil, fmt.Errorf("reading the adapter catalog: %w", err)
+	}
+	var out []string
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		if _, err := os.Stat(filepath.Join(root, AgentsDir, e.Name(), DriverName)); err != nil {
+			continue
+		}
+		out = append(out, e.Name())
+	}
+	if len(out) == 0 {
+		return nil, fmt.Errorf("no adapter under %s ships a %s — a broken scan and an empty "+
+			"catalog must not be the same answer", filepath.Join(root, AgentsDir), DriverName)
+	}
+	sort.Strings(out)
+	return out, nil
+}
+
+// LoadDriver reads one adapter's driver plus every shell library it can source
+// — the shared drive libs and the adapter's own sibling scripts.
+func LoadDriver(root, adapter string) (File, []File, error) {
+	path := filepath.Join(root, AgentsDir, adapter, DriverName)
+	src, err := os.ReadFile(path) // #nosec G304 -- built from the repo root and a scanned adapter slug
+	if err != nil {
+		return File{}, nil, fmt.Errorf("reading %s's driver: %w", adapter, err)
+	}
+	driver := File{Path: path, Src: string(src)}
+
+	var libs []File
+	for _, dir := range []string{filepath.Join(root, libDir), filepath.Join(root, AgentsDir, adapter)} {
+		found, err := readShellDir(dir, path)
+		if err != nil {
+			return File{}, nil, err
+		}
+		libs = append(libs, found...)
+	}
+	return driver, libs, nil
+}
+
+// readShellDir reads every non-test .sh file in dir except skip.
+func readShellDir(dir, skip string) ([]File, error) {
+	matches, err := filepath.Glob(filepath.Join(dir, "*.sh"))
+	if err != nil {
+		return nil, err
+	}
+	var out []File
+	for _, m := range matches {
+		if m == skip || strings.HasSuffix(m, "_test.sh") {
+			continue
+		}
+		b, err := os.ReadFile(m) // #nosec G304 -- a path returned by Glob over a repo directory
+		if err != nil {
+			return nil, fmt.Errorf("reading %s: %w", m, err)
+		}
+		out = append(out, File{Path: m, Src: string(b)})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Path < out[j].Path })
+	return out, nil
+}

--- a/tools/onboarding-factory/internal/driverteardown/driverteardown_test.go
+++ b/tools/onboarding-factory/internal/driverteardown/driverteardown_test.go
@@ -17,8 +17,13 @@ func repoRoot(t *testing.T) string {
 	return strings.TrimSpace(string(out))
 }
 
-// loadFixture reads one testdata driver plus the one shell library it sources.
-func loadFixture(t *testing.T, name, lib string) (File, []File) {
+// loadFixture reads one testdata driver plus the shell libraries it is HANDED.
+//
+// Handed, not sourced: LoadDriver globs the whole replaydata/_lib/drive
+// directory for every adapter, so a driver is analysed alongside libraries it
+// never sources. inv3_shadowed_alloc_slot_ok.sh is the fixture that depends on
+// that distinction being reproducible here.
+func loadFixture(t *testing.T, name string, libNames ...string) (File, []File) {
 	t.Helper()
 	path := filepath.Join("testdata", name)
 	src, err := os.ReadFile(path) // #nosec G304 -- a literal testdata path
@@ -26,7 +31,7 @@ func loadFixture(t *testing.T, name, lib string) (File, []File) {
 		t.Fatalf("reading fixture %s: %v", name, err)
 	}
 	var libs []File
-	if lib != "" {
+	for _, lib := range libNames {
 		lp := filepath.Join("testdata", "lib", lib)
 		lsrc, err := os.ReadFile(lp) // #nosec G304 -- a literal testdata path
 		if err != nil {
@@ -55,43 +60,74 @@ func loadFixture(t *testing.T, name, lib string) (File, []File) {
 //
 // HOW A TEARDOWN SITE IS TOLD APART FROM A STEP-LEVEL GUARD — and what that
 // choice costs — is written out on checkTeardownUngated. In one line: the
-// distinction is STRUCTURAL (the EXIT-trap handler and the top-level end-of-run
-// sweep are teardown; anything inside an ordinary function is not), because
-// both spellings of the gate are byte-identical, and the cost is that a driver
-// which moved its end-of-run sweep into a helper function would have that
-// sweep read as step-level. The flag NAME the gate is matched on
-// (`aliveGate`) carries its own tradeoff note.
+// distinction is STRUCTURAL (the EXIT-trap handler is teardown, and so is a kill
+// at top level UNLESS it sits in a `case` arm a loop re-enters; anything inside
+// an ordinary function, and every arm of a top-level step dispatch, is not),
+// because both spellings of the gate are byte-identical. The cost is that a
+// driver which moved its end-of-run sweep into a helper function, or into a
+// `case` arm inside a loop, would have that sweep read as step-level. The three
+// rows that hold the two halves of the `case` rule apart are
+// inv1_step_dispatch_case_arm_ok.sh (copilot's dispatch, must stay clean),
+// inv1_gated_case_at_exit.sh (a trailing `case "$EXIT_REASON"`, must fire) and
+// inv1_gated_final_sweep.sh (the `for … do … done` sweep, must fire). The flag
+// NAME the gate is matched on (`aliveGate`) carries its own tradeoff note.
 func TestCheckerGradesEveryFixture(t *testing.T) {
 	cases := []struct {
 		fixture string
-		lib     string
+		libs    []string
 		want    []string // one invariant name per expected finding, in order
 	}{
-		{fixture: "good_driver.sh", lib: "slots.sh"},
-		{fixture: "inv1_step_guard_ok.sh", lib: "slots.sh"},
-		{fixture: "inv3_alloc_arg2_good.sh", lib: "slots_pos2.sh"},
+		{fixture: "good_driver.sh", libs: []string{"slots.sh"}},
+		{fixture: "inv1_step_guard_ok.sh", libs: []string{"slots.sh"}},
+		{fixture: "inv3_alloc_arg2_good.sh", libs: []string{"slots_pos2.sh"}},
 		{fixture: "no_tmux_exempt.sh"},
-		{fixture: "inv4_renamed_sentinel_ok.sh", lib: "slots.sh"},
-		{fixture: "inv4_fail_closed_ok.sh", lib: "slots.sh"},
-		{fixture: "inv4_literal_verdict_ok.sh", lib: "slots.sh"},
+		{fixture: "inv4_renamed_sentinel_ok.sh", libs: []string{"slots.sh"}},
+		{fixture: "inv4_fail_closed_ok.sh", libs: []string{"slots.sh"}},
+		{fixture: "inv4_literal_verdict_ok.sh", libs: []string{"slots.sh"}},
+		// A multi-line `awk '…'` program: the join this package needs, and the
+		// thing a `#`-is-a-comment rule could end early. A LOCK — green before
+		// the shellsource.go fix and after it.
+		{fixture: "quote_multiline_awk_ok.sh", libs: []string{"slots.sh"}},
+		// copilot's top-level `while … case` dispatch, carrying kiro-cli's
+		// legitimate SES_ALIVE entry check. RED before the classification was
+		// narrowed: the arm was graded as "this end-of-run teardown".
+		{fixture: "inv1_step_dispatch_case_arm_ok.sh", libs: []string{"slots.sh"}},
+		// A driver with its OWN alloc_slot (name at argument 2), handed the
+		// shared slots.sh (name at argument 1) that it never sources. RED before
+		// nameFlow keyed positions on a definition instead of a bare name: the
+		// uuid at argument 1 was graded as a session name.
+		{fixture: "inv3_shadowed_alloc_slot_ok.sh", libs: []string{"slots.sh"}},
 
-		{fixture: "inv1_gated_trap.sh", lib: "slots.sh", want: []string{"INV-1"}},
-		{fixture: "inv1_gated_final_sweep.sh", lib: "slots.sh", want: []string{"INV-1"}},
+		{fixture: "inv1_gated_trap.sh", libs: []string{"slots.sh"}, want: []string{"INV-1"}},
+		{fixture: "inv1_gated_final_sweep.sh", libs: []string{"slots.sh"}, want: []string{"INV-1"}},
+		// A comment glued to code, whose apostrophe used to be read as an
+		// unterminated quote: everything below it was swallowed, INV-1 reported
+		// CLEAN, and `sites` stayed non-zero so the vacuity guard saw nothing.
+		{fixture: "inv1_comment_glued_to_code.sh", libs: []string{"slots.sh"}, want: []string{"INV-1"}},
+		// A trailing `case "$EXIT_REASON" in` — a top-level `case` that no loop
+		// re-enters — is teardown, so the step-dispatch narrowing must not
+		// excuse it.
+		{fixture: "inv1_gated_case_at_exit.sh", libs: []string{"slots.sh"}, want: []string{"INV-1"}},
 		{fixture: "inv2_no_trap.sh", want: []string{"INV-2"}},
 		{fixture: "inv2_trap_without_teardown.sh", want: []string{"INV-2"}},
-		{fixture: "inv3_no_pid.sh", lib: "slots.sh", want: []string{"INV-3"}},
-		{fixture: "inv3_glued_pid.sh", lib: "slots.sh", want: []string{"INV-3"}},
-		{fixture: "inv3_alloc_arg2_bad.sh", lib: "slots_pos2.sh", want: []string{"INV-3"}},
-		{fixture: "inv4_unconditional_write.sh", lib: "slots.sh", want: []string{"INV-4"}},
-		{fixture: "inv4_guard_consults_only_itself.sh", lib: "slots.sh", want: []string{"INV-4"}},
-		{fixture: "inv4_sentinel_never_set.sh", lib: "slots.sh", want: []string{"INV-4"}},
-		{fixture: "inv4_guard_reassigns_initial.sh", lib: "slots.sh", want: []string{"INV-4"}},
-		{fixture: "inv4_case_arm_is_not_the_epilogue.sh", lib: "slots.sh", want: []string{"INV-4"}},
+		{fixture: "inv3_no_pid.sh", libs: []string{"slots.sh"}, want: []string{"INV-3"}},
+		{fixture: "inv3_glued_pid.sh", libs: []string{"slots.sh"}, want: []string{"INV-3"}},
+		{fixture: "inv3_alloc_arg2_bad.sh", libs: []string{"slots_pos2.sh"}, want: []string{"INV-3"}},
+		// The shadowed-alloc_slot driver with a genuinely PID-less name at
+		// argument 2. ONE finding: the fix must silence the contaminated
+		// position without silencing the real one, and this row is what tells
+		// those two apart. It reported TWO before the fix.
+		{fixture: "inv3_shadowed_alloc_slot_bad.sh", libs: []string{"slots.sh"}, want: []string{"INV-3"}},
+		{fixture: "inv4_unconditional_write.sh", libs: []string{"slots.sh"}, want: []string{"INV-4"}},
+		{fixture: "inv4_guard_consults_only_itself.sh", libs: []string{"slots.sh"}, want: []string{"INV-4"}},
+		{fixture: "inv4_sentinel_never_set.sh", libs: []string{"slots.sh"}, want: []string{"INV-4"}},
+		{fixture: "inv4_guard_reassigns_initial.sh", libs: []string{"slots.sh"}, want: []string{"INV-4"}},
+		{fixture: "inv4_case_arm_is_not_the_epilogue.sh", libs: []string{"slots.sh"}, want: []string{"INV-4"}},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.fixture, func(t *testing.T) {
-			driver, libs := loadFixture(t, tc.fixture, tc.lib)
+			driver, libs := loadFixture(t, tc.fixture, tc.libs...)
 			got, err := CheckDriver(driver, libs)
 			if err != nil {
 				t.Fatalf("checking %s: %v", tc.fixture, err)
@@ -116,20 +152,30 @@ func TestCheckerGradesEveryFixture(t *testing.T) {
 func TestCheckerRefusesRatherThanReportingClean(t *testing.T) {
 	cases := []struct {
 		fixture string
-		lib     string
+		libs    []string
 		wantErr string // a fragment of the checker's own message
 	}{
 		{fixture: "vacuous_empty.sh", wantErr: "is empty"},
 		{fixture: "vacuous_no_teardown.sh", wantErr: "INV-1 graded nothing here"},
 		{fixture: "vacuous_unnamed_session.sh", wantErr: "with no `-s <name>`"},
 		{fixture: "vacuous_unclosed_function.sh", wantErr: "is never closed by a `}`"},
-		{fixture: "vacuous_uninitialised_verdict.sh", lib: "slots.sh",
+		{fixture: "vacuous_uninitialised_verdict.sh", libs: []string{"slots.sh"},
 			wantErr: "INV-4 has no initial value to compare against"},
+		// A quote still open at end of file: the joiner walks to EOF and the
+		// word scanner swallows every remaining statement into one quoted word.
+		// This is the one shape a single shared scanner CANNOT see — both halves
+		// agree the quote is open — so it is refused rather than graded.
+		{fixture: "vacuous_unterminated_quote.sh",
+			wantErr: "is never closed before the end of the file"},
+		// Refuses AND carries a finding. TestARefusalStillNamesTheFindingThatCausedIt
+		// is where that second half is graded; this row pins that it still refuses.
+		{fixture: "inv2_no_trap_no_sweep.sh", libs: []string{"slots.sh"},
+			wantErr: "INV-1 graded nothing here"},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.fixture, func(t *testing.T) {
-			driver, libs := loadFixture(t, tc.fixture, tc.lib)
+			driver, libs := loadFixture(t, tc.fixture, tc.libs...)
 			got, err := CheckDriver(driver, libs)
 			if err == nil {
 				t.Fatalf("%s returned no error (%d finding(s)) — this input could not be graded, "+
@@ -142,13 +188,137 @@ func TestCheckerRefusesRatherThanReportingClean(t *testing.T) {
 	}
 }
 
+// TestAGluedCommentDoesNotSwallowTheStatementsAfterIt is finding 6's
+// reproduction, kept at the level the defect actually lived at.
+//
+// `bar=1;# the driver's flag` glues a comment to code. Two scanners disagreed
+// about where that comment starts — the line-joiner accepted a `#` only at
+// column 0 or after a space/tab, while the word scanner accepted any `#` that
+// opens a word — so the joiner read the apostrophe in "driver's" as an
+// unterminated quote, joined the rest of the file onto line 3 to close it, and
+// the word scanner then truncated the joined text at the `#`. Lines 4 and 5
+// disappeared with NO error, because the dropped lines took their own `if`/`fi`
+// and `do`/`done` with them and the balance assertions stayed happy.
+//
+// This is not cosmetic. A dropped `trap … EXIT` or `REACHED_EPILOGUE=1` is a
+// false positive and merely noisy; a dropped top-level gated `tmux kill-session`
+// is a false CLEAN on INV-1 with `sites` still non-zero — the one failure this
+// package's vacuity guard cannot see. inv1_comment_glued_to_code.sh is the
+// end-to-end half of the same defect.
+func TestAGluedCommentDoesNotSwallowTheStatementsAfterIt(t *testing.T) {
+	const src = `tmux new-session -d -s "drv-$$" "agent"
+foo() { echo hi; }
+bar=1;# the driver's flag
+baz=2
+trap foo EXIT`
+
+	parsed, err := Parse("glued.sh", src)
+	if err != nil {
+		t.Fatalf("parsing: %v", err)
+	}
+	first := map[int]string{}
+	for _, st := range parsed.Statements() {
+		if len(st.Words) > 0 {
+			if _, seen := first[st.Line]; !seen {
+				first[st.Line] = st.Words[0]
+			}
+		}
+	}
+	for _, want := range []struct {
+		line int
+		word string
+	}{{3, "bar=1"}, {4, "baz=2"}, {5, "trap"}} {
+		if got := first[want.line]; got != want.word {
+			t.Errorf("line %d parsed as %q, want %q — the comment glued to line 3 swallowed it. "+
+				"A `#` must end a line for the joiner and the word scanner identically, which is "+
+				"why there is now one scanner (shellWordsOpen) rather than two.",
+				want.line, got, want.word)
+		}
+	}
+}
+
+// TestShellWordsOpenSettlesCommentsAndQuotesTogether is the boundary rule that
+// finding 6 turned on, graded directly.
+//
+// Every row is a place the two former scanners could disagree, plus the
+// expansions the aligned rule makes newly reachable: a `#` inside `${x#y}` is
+// not a comment, and a `#` glued to the right of a word is not one either.
+func TestShellWordsOpenSettlesCommentsAndQuotesTogether(t *testing.T) {
+	cases := []struct {
+		name string
+		line string
+		open rune
+		last string // the last word the scanner should emit
+	}{
+		{"comment glued to a `;`", `bar=1;# the driver's flag`, 0, ";"},
+		{"comment after a space", `echo hi # don't`, 0, "hi"},
+		{"a whole-line comment", `# the recipe's own note`, 0, ""},
+		{"comment glued to a `&`", `foo &# the driver's flag`, 0, "&"},
+		{"a `#` inside an expansion is not a comment", `echo "${x#y}"`, 0, `"${x#y}"`},
+		{"a `#` glued to the right of a word is not a comment", `echo a#b`, 0, "a#b"},
+		{"an unterminated single quote", `tmux capture-pane | awk '`, '\'', "'"},
+		{"an unterminated double quote", `MSG="unterminated`, '"', `MSG="unterminated`},
+		{"a quote closed on the same line", `echo 'done'`, 0, "'done'"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			words, open := shellWordsOpen(tc.line)
+			if open != tc.open {
+				t.Errorf("shellWordsOpen(%q) left %q open, want %q", tc.line, open, tc.open)
+			}
+			last := ""
+			if len(words) > 0 {
+				last = words[len(words)-1]
+			}
+			if last != tc.last {
+				t.Errorf("shellWordsOpen(%q) ended at word %q, want %q", tc.line, last, tc.last)
+			}
+		})
+	}
+}
+
+// TestARefusalStillNamesTheFindingThatCausedIt is finding 8.
+//
+// The invariants are not independent. Deleting `trap cleanup EXIT` from a driver
+// whose trap is its ONLY teardown — hermes writes no top-level sweep — violates
+// INV-2 and, as a direct consequence, leaves INV-1 with no site to grade.
+// CheckDriver returned `nil, err` on that second event, so the gate went red
+// naming INV-1 as having "graded nothing" and dropped the one sentence that says
+// what to do: install a `trap … EXIT`, see the template's `cleanup`.
+//
+// Both halves are graded here, because a caller may read either: the finding
+// survives in the returned slice, AND the refusal names it in its own message
+// for the callers (TestEveryDriverTearsDownEverySession included) that treat a
+// non-nil error as fatal and print only that.
+func TestARefusalStillNamesTheFindingThatCausedIt(t *testing.T) {
+	driver, libs := loadFixture(t, "inv2_no_trap_no_sweep.sh", "slots.sh")
+	got, err := CheckDriver(driver, libs)
+	if err == nil {
+		t.Fatalf("this driver has no teardown site at all; INV-1 must refuse rather than report "+
+			"clean\n%s", joinFindings(got))
+	}
+	if len(got) != 1 || got[0].Invariant != "INV-2" {
+		t.Errorf("the INV-2 finding did not survive the INV-1 refusal: got %d finding(s)\n%s",
+			len(got), joinFindings(got))
+	}
+	if !strings.Contains(err.Error(), "installs no `trap … EXIT`") {
+		t.Errorf("the refusal does not name the defect that caused it, so the gate goes red "+
+			"pointing at the wrong invariant:\n%v", err)
+	}
+	if !strings.Contains(err.Error(), "INV-1 graded nothing here") {
+		t.Errorf("the refusal no longer says why INV-1 could not run — a check that cannot run "+
+			"must still say so:\n%v", err)
+	}
+}
+
 // TestExemptionIsDerivedNotListed grades the derived exemption on both halves
 // at once: no tmux launch means no findings, AND the file was still read.
 // Without the second half, a driver that failed to load would be indexed as
 // "exempt" — the shape #1423, #1611 and #1684 all took, where a selection rule
 // that silently drops a whole family reads exactly like a gate that passed.
 func TestExemptionIsDerivedNotListed(t *testing.T) {
-	driver, _ := loadFixture(t, "no_tmux_exempt.sh", "")
+	driver, _ := loadFixture(t, "no_tmux_exempt.sh")
 	if strings.TrimSpace(driver.Src) == "" {
 		t.Fatal("the exempt fixture is empty — it proves nothing about exemption")
 	}

--- a/tools/onboarding-factory/internal/driverteardown/driverteardown_test.go
+++ b/tools/onboarding-factory/internal/driverteardown/driverteardown_test.go
@@ -1,0 +1,312 @@
+package driverteardown
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	out, err := exec.Command("git", "rev-parse", "--show-toplevel").Output()
+	if err != nil {
+		t.Fatalf("resolving the repo root: %v", err)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// loadFixture reads one testdata driver plus the one shell library it sources.
+func loadFixture(t *testing.T, name, lib string) (File, []File) {
+	t.Helper()
+	path := filepath.Join("testdata", name)
+	src, err := os.ReadFile(path) // #nosec G304 -- a literal testdata path
+	if err != nil {
+		t.Fatalf("reading fixture %s: %v", name, err)
+	}
+	var libs []File
+	if lib != "" {
+		lp := filepath.Join("testdata", "lib", lib)
+		lsrc, err := os.ReadFile(lp) // #nosec G304 -- a literal testdata path
+		if err != nil {
+			t.Fatalf("reading fixture lib %s: %v", lib, err)
+		}
+		libs = append(libs, File{Path: lp, Src: string(lsrc)})
+	}
+	return File{Path: path, Src: string(src)}, libs
+}
+
+// TestCheckerGradesEveryFixture is the committed mutation evidence this
+// package owes under AGENTS.md.
+//
+// A tripwire is a check the change ADDS, so it has no "before the fix" to run
+// red — the rule is to mutate what it protects and confirm the check goes red,
+// and to commit that mutation as a fixture rather than describing it in a PR
+// body nothing re-runs. Every row below is one such mutation of
+// testdata/good_driver.sh, differing from it in as close to a single line as
+// the invariant allows, so a row that stops firing points at the checker
+// rather than at the fixture.
+//
+// The want-clean rows carry as much weight as the want-red ones.
+// inv1_step_guard_ok.sh is the one this package would be worst without: it is
+// kiro-cli's legitimate step-level SES_ALIVE guard, and a checker that failed
+// it would be a checker nobody keeps.
+//
+// HOW A TEARDOWN SITE IS TOLD APART FROM A STEP-LEVEL GUARD — and what that
+// choice costs — is written out on checkTeardownUngated. In one line: the
+// distinction is STRUCTURAL (the EXIT-trap handler and the top-level end-of-run
+// sweep are teardown; anything inside an ordinary function is not), because
+// both spellings of the gate are byte-identical, and the cost is that a driver
+// which moved its end-of-run sweep into a helper function would have that
+// sweep read as step-level. The flag NAME the gate is matched on
+// (`aliveGate`) carries its own tradeoff note.
+func TestCheckerGradesEveryFixture(t *testing.T) {
+	cases := []struct {
+		fixture string
+		lib     string
+		want    []string // one invariant name per expected finding, in order
+	}{
+		{fixture: "good_driver.sh", lib: "slots.sh"},
+		{fixture: "inv1_step_guard_ok.sh", lib: "slots.sh"},
+		{fixture: "inv3_alloc_arg2_good.sh", lib: "slots_pos2.sh"},
+		{fixture: "no_tmux_exempt.sh"},
+		{fixture: "inv4_renamed_sentinel_ok.sh", lib: "slots.sh"},
+		{fixture: "inv4_fail_closed_ok.sh", lib: "slots.sh"},
+		{fixture: "inv4_literal_verdict_ok.sh", lib: "slots.sh"},
+
+		{fixture: "inv1_gated_trap.sh", lib: "slots.sh", want: []string{"INV-1"}},
+		{fixture: "inv1_gated_final_sweep.sh", lib: "slots.sh", want: []string{"INV-1"}},
+		{fixture: "inv2_no_trap.sh", want: []string{"INV-2"}},
+		{fixture: "inv2_trap_without_teardown.sh", want: []string{"INV-2"}},
+		{fixture: "inv3_no_pid.sh", lib: "slots.sh", want: []string{"INV-3"}},
+		{fixture: "inv3_glued_pid.sh", lib: "slots.sh", want: []string{"INV-3"}},
+		{fixture: "inv3_alloc_arg2_bad.sh", lib: "slots_pos2.sh", want: []string{"INV-3"}},
+		{fixture: "inv4_unconditional_write.sh", lib: "slots.sh", want: []string{"INV-4"}},
+		{fixture: "inv4_guard_consults_only_itself.sh", lib: "slots.sh", want: []string{"INV-4"}},
+		{fixture: "inv4_sentinel_never_set.sh", lib: "slots.sh", want: []string{"INV-4"}},
+		{fixture: "inv4_guard_reassigns_initial.sh", lib: "slots.sh", want: []string{"INV-4"}},
+		{fixture: "inv4_case_arm_is_not_the_epilogue.sh", lib: "slots.sh", want: []string{"INV-4"}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.fixture, func(t *testing.T) {
+			driver, libs := loadFixture(t, tc.fixture, tc.lib)
+			got, err := CheckDriver(driver, libs)
+			if err != nil {
+				t.Fatalf("checking %s: %v", tc.fixture, err)
+			}
+			if len(got) != len(tc.want) {
+				t.Fatalf("%s: got %d finding(s), want %d\n%s",
+					tc.fixture, len(got), len(tc.want), joinFindings(got))
+			}
+			for i, f := range got {
+				if f.Invariant != tc.want[i] {
+					t.Errorf("%s: finding %d is %s, want %s\n%s",
+						tc.fixture, i, f.Invariant, tc.want[i], f)
+				}
+			}
+		})
+	}
+}
+
+// TestCheckerRefusesRatherThanReportingClean pins the failures that make every
+// clean verdict above mean something. AGENTS.md: absence of a finding and
+// inability to look must never produce the same output.
+func TestCheckerRefusesRatherThanReportingClean(t *testing.T) {
+	cases := []struct {
+		fixture string
+		lib     string
+		wantErr string // a fragment of the checker's own message
+	}{
+		{fixture: "vacuous_empty.sh", wantErr: "is empty"},
+		{fixture: "vacuous_no_teardown.sh", wantErr: "INV-1 graded nothing here"},
+		{fixture: "vacuous_unnamed_session.sh", wantErr: "with no `-s <name>`"},
+		{fixture: "vacuous_unclosed_function.sh", wantErr: "is never closed by a `}`"},
+		{fixture: "vacuous_uninitialised_verdict.sh", lib: "slots.sh",
+			wantErr: "INV-4 has no initial value to compare against"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.fixture, func(t *testing.T) {
+			driver, libs := loadFixture(t, tc.fixture, tc.lib)
+			got, err := CheckDriver(driver, libs)
+			if err == nil {
+				t.Fatalf("%s returned no error (%d finding(s)) — this input could not be graded, "+
+					"and a check that cannot run must say so\n%s", tc.fixture, len(got), joinFindings(got))
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Errorf("%s: refusal %q does not contain %q", tc.fixture, err, tc.wantErr)
+			}
+		})
+	}
+}
+
+// TestExemptionIsDerivedNotListed grades the derived exemption on both halves
+// at once: no tmux launch means no findings, AND the file was still read.
+// Without the second half, a driver that failed to load would be indexed as
+// "exempt" — the shape #1423, #1611 and #1684 all took, where a selection rule
+// that silently drops a whole family reads exactly like a gate that passed.
+func TestExemptionIsDerivedNotListed(t *testing.T) {
+	driver, _ := loadFixture(t, "no_tmux_exempt.sh", "")
+	if strings.TrimSpace(driver.Src) == "" {
+		t.Fatal("the exempt fixture is empty — it proves nothing about exemption")
+	}
+	if n := LaunchCount(driver.Src); n != 0 {
+		t.Fatalf("the exempt fixture launches %d tmux session(s) — it is not exempt", n)
+	}
+	got, err := CheckDriver(driver, nil)
+	if err != nil || len(got) != 0 {
+		t.Fatalf("a driver that launches no tmux session must be exempt: err=%v findings=%s",
+			err, joinFindings(got))
+	}
+}
+
+// TestCarriesPIDFieldNamesEverySpelling is the corpus for INV-3's predicate,
+// and the want:false rows are where its value is.
+//
+// "The name carries the driver's PID" is the claim whose FALSE POSITIVE is
+// expensive: run-cell.sh's post-run assertion splits a live session name on
+// `-` and compares fields against the PID it captured, so a glued `$$` is not
+// merely untidy — it never matches, and a name ending in a longer number whose
+// tail happens to equal the PID would match a DIFFERENT run's session. A
+// predicate that accepted a bare substring would report every driver compliant
+// and leave the assertion silently matching nothing.
+func TestCarriesPIDFieldNamesEverySpelling(t *testing.T) {
+	cases := []struct {
+		name    string
+		literal string
+		want    bool
+	}{
+		// --- the spellings the eleven shipped drivers actually use ---
+		{"trailing field", "aider-onboard-${UUID:0:8}-$$", true},
+		{"middle field, before a date", "geminidrv-$$-$(date +%s)-r${ACTIVE}", true},
+		{"middle field, after a date", "codex-onboard-$(date +%s)-$$-r${ACTIVE}", true},
+		{"followed by an arithmetic expansion", "copilotdrv-$$-$(date +%s)-$((N_SLOTS + 1))", true},
+		{"adapter slug that itself contains a dash", "kiro-clidrv-$$-$(date +%s)-${idx}", true},
+
+		// --- want:false ---
+		{"no pid at all", "fixture-onboard-$(date +%s)", false},
+		{"glued to the prefix", "fixture-onboard$$-$(date +%s)", false},
+		{"glued to the suffix", "fixture-onboard-$$$(date +%s)", false},
+		{"underscore is not the delimiter", "fixture_onboard_$$_$(date +%s)", false},
+		{"a single $ is the shell's, not the pid", "fixture-onboard-$-$(date +%s)", false},
+		{"buried inside an expansion", "fixture-onboard-${FOO:-$$}", false},
+		{"the empty name", "", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := carriesPIDField(tc.literal); got != tc.want {
+				t.Errorf("carriesPIDField(%q) = %v, want %v", tc.literal, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestVerdictFilenameIsTheOneRunCellReads anchors INV-4's derived precondition.
+//
+// The whole invariant binds on one literal: a handler that redirects into a
+// path ending in `driver.exit-reason`. That is a filename rather than a
+// variable name, and the reason matching it is defensible is that it is a
+// CONTRACT between the driver and run-cell.sh — a rename would have to touch
+// both. This test is what makes that argument checkable instead of asserted:
+// if run-cell.sh stops reading that name, INV-4 has silently stopped binding on
+// every driver in the fleet, and a whole invariant switching itself off must be
+// a loud failure rather than eleven quiet passes.
+func TestVerdictFilenameIsTheOneRunCellReads(t *testing.T) {
+	path := filepath.Join(repoRoot(t), "tools", "onboarding-factory", "scripts", "run-cell.sh")
+	src, err := os.ReadFile(path) // #nosec G304 -- built from the repo root
+	if err != nil {
+		t.Fatalf("reading run-cell.sh: %v — INV-4's anchor cannot be checked, and a check that "+
+			"cannot run must say so", err)
+	}
+	if !strings.Contains(string(src), exitReasonFile) {
+		t.Fatalf("run-cell.sh no longer mentions %q. INV-4 binds only on a handler that "+
+			"redirects into a path ending in that name, so it is now binding on nothing — "+
+			"update exitReasonFile to whatever the staging contract calls the verdict file.",
+			exitReasonFile)
+	}
+	// The reader is what makes the initialiser dangerous: it turns a MISSING
+	// file into `unknown`, so a handler that writes the initialiser converts a
+	// non-verdict into a verdict. Pin that the fallback still exists.
+	if !strings.Contains(string(src), `|| echo "unknown"`) {
+		t.Errorf("run-cell.sh no longer falls back to \"unknown\" when %s is absent. INV-4's "+
+			"rationale rests on that fallback — re-read run-cell.sh and restate the invariant "+
+			"before assuming it still holds.", exitReasonFile)
+	}
+}
+
+// TestAdaptersRefusesAnEmptyCatalog pins the refusal the live arm below rests
+// on: a tree with no driver in it would satisfy that arm perfectly by having
+// nothing to grade.
+func TestAdaptersRefusesAnEmptyCatalog(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, AgentsDir, "somewhere"), 0o750); err != nil {
+		t.Fatalf("building the empty catalog: %v", err)
+	}
+	if _, err := Adapters(dir); err == nil {
+		t.Fatal("a catalog with no driver in it returned a clean empty list; " +
+			"'no adapter ships a driver' and 'the scan broke' must not be the same answer")
+	}
+}
+
+// TestEveryDriverTearsDownEverySession is the live arm: every adapter that
+// ships a recording driver, read from disk so an adapter onboarded tomorrow is
+// graded by existing rather than by whoever adds it remembering this package.
+//
+// It is a STATIC check on purpose. The recording rig needs tmux and a live
+// agent CLI, and `tmux` appears nowhere under .github/ — the rig has never run
+// in CI and is not going to. This arm reads source text, so it runs everywhere
+// `go test` does, which is the only place a teardown regression can be caught
+// before it costs a recording run.
+//
+// Every per-adapter vacuity guard lives inside CheckDriver, which returns an
+// ERROR rather than an empty list when it found nothing to grade: an empty
+// driver, a `tmux new-session` it could not parse or that carries no `-s`, a
+// tmux-launching driver with no teardown site, one whose session names could
+// not be traced back to the text that mints them. The guard here is the
+// fleet-level one — that at least one adapter launched tmux at all.
+func TestEveryDriverTearsDownEverySession(t *testing.T) {
+	root := repoRoot(t)
+	adapters, err := Adapters(root)
+	if err != nil {
+		t.Fatalf("scanning the adapter catalog: %v — a check that cannot run must say so", err)
+	}
+
+	graded := 0
+	for _, adapter := range adapters {
+		t.Run(adapter, func(t *testing.T) {
+			driver, libs, err := LoadDriver(root, adapter)
+			if err != nil {
+				t.Fatalf("%v — an adapter whose driver cannot be read is not exempt, and a "+
+					"check that cannot run must say so", err)
+			}
+			findings, err := CheckDriver(driver, libs)
+			if err != nil {
+				t.Fatalf("%v", err)
+			}
+			if LaunchCount(driver.Src) == 0 {
+				t.Logf("%s launches no tmux session — exempt by derivation from its source, "+
+					"not by a list", adapter)
+				return
+			}
+			graded++
+			for _, f := range findings {
+				t.Errorf("%s", f)
+			}
+		})
+	}
+	if graded == 0 {
+		t.Errorf("none of the %d adapter driver(s) launches tmux at all — this arm graded nothing",
+			len(adapters))
+	}
+}
+
+func joinFindings(fs []Finding) string {
+	var b strings.Builder
+	for _, f := range fs {
+		b.WriteString("  " + f.String() + "\n")
+	}
+	return b.String()
+}

--- a/tools/onboarding-factory/internal/driverteardown/shellsource.go
+++ b/tools/onboarding-factory/internal/driverteardown/shellsource.go
@@ -209,96 +209,145 @@ func (s *Source) Body(name string) (string, bool) {
 // statement — and attributing "this teardown is gated" wrongly in EITHER
 // direction is the failure mode INV-1 is about.
 func (s *Source) buildStatements(code []bool) error {
-	var conds []string
-	var blocks []string
+	var n nesting
 	for i := 0; i < len(s.lines); i++ {
 		if !code[i] {
 			continue
 		}
 		start := i
-		joined := s.lines[i]
-		words, open := shellWordsOpen(joined)
-		for i+1 < len(s.lines) {
-			if strings.HasSuffix(strings.TrimRight(joined, " \t"), "\\") {
-				joined = strings.TrimSuffix(strings.TrimRight(joined, " \t"), "\\") + " " + s.lines[i+1]
-				i++
-				words, open = shellWordsOpen(joined)
-				continue
-			}
-			// A quote left open at end of line continues onto the next one.
-			// mistral-vibe embeds a multi-line `awk '…'` program whose braces
-			// are DATA; without this they were counted as shell blocks and the
-			// whole file was reported as unreadable.
-			if open == 0 {
-				break
-			}
-			joined += "\n" + s.lines[i+1]
-			i++
-			words, open = shellWordsOpen(joined)
+		joined, words, end, err := s.joinLogicalLine(start)
+		if err != nil {
+			return err
 		}
-		// The joiner ran out of file still looking for the closing quote. Every
-		// remaining line has been swallowed into one quoted word — the sink of
-		// the same class of silent loss the shared scanner closes above, and the
-		// one shape a shared scanner cannot see, because both halves agree the
-		// quote is open. Refuse: an unreadable tail and a clean tail must not be
-		// the same answer.
-		if open != 0 {
-			return fmt.Errorf("%s:%d: a %c quote opened on this line is never closed before the "+
-				"end of the file, so every statement after it is swallowed into one quoted word "+
-				"— this file cannot be read, and a check that cannot run must say so",
-				s.Path, start+1, open)
-		}
+		i = end
 		for _, cmd := range splitCommands(words) {
-			words := cmd.words
-			if len(words) == 0 {
+			if len(cmd.words) == 0 {
 				continue
 			}
-			switch words[0] {
-			case "if", "case", "do", "{":
-				blocks = append(blocks, words[0])
-			case "fi", "esac", "done", "}":
-				if len(blocks) == 0 {
-					return fmt.Errorf("%s:%d: `%s` closes a compound statement that was never "+
-						"opened — this file's block structure cannot be read, and a check that "+
-						"cannot run must say so", s.Path, start+1, words[0])
-				}
-				blocks = blocks[:len(blocks)-1]
-			}
-			switch words[0] {
-			case "if":
-				conds = append(conds, strings.Join(words[1:], " "))
-			case "elif":
-				if len(conds) == 0 {
-					return fmt.Errorf("%s:%d: `elif` with no open `if`", s.Path, start+1)
-				}
-				conds[len(conds)-1] = strings.Join(words[1:], " ")
-			case "fi":
-				if len(conds) == 0 {
-					return fmt.Errorf("%s:%d: `fi` with no open `if` — the if/fi structure "+
-						"cannot be read, and a check that cannot run must say so", s.Path, start+1)
-				}
-				conds = conds[:len(conds)-1]
+			if err := n.track(s.Path, start+1, cmd.words); err != nil {
+				return err
 			}
 			st := Statement{
-				Line: start + 1, Text: joined, Words: words,
-				Prefix: cmd.prefix, Func: s.funcAt(start + 1), Depth: len(blocks),
+				Line: start + 1, Text: joined, Words: cmd.words,
+				Prefix: cmd.prefix, Func: s.funcAt(start + 1),
 			}
-			if len(blocks) > 0 {
-				st.Blocks = append([]string(nil), blocks...)
-			}
-			if len(conds) > 0 {
-				st.Conds = append([]string(nil), conds...)
-			}
+			n.stamp(&st)
 			s.stmts = append(s.stmts, st)
 		}
 	}
-	if len(conds) != 0 {
-		return fmt.Errorf("%s: %d `if` block(s) are never closed by `fi` — the if/fi structure "+
-			"cannot be read, and a check that cannot run must say so", s.Path, len(conds))
+	return n.close(s.Path)
+}
+
+// joinLogicalLine gathers the physical lines that form the logical line starting
+// at index i — those held open by a trailing backslash, and those swallowed by a
+// quote left open at end of line — and returns the joined text, its words, and
+// the index of the last physical line it consumed.
+//
+// The open-quote join is not optional. mistral-vibe embeds a multi-line
+// `awk '…'` program whose braces are DATA; without it they were counted as shell
+// blocks and the whole file was reported as unreadable.
+func (s *Source) joinLogicalLine(i int) (joined string, words []string, end int, err error) {
+	start := i
+	joined = s.lines[i]
+	words, open := shellWordsOpen(joined)
+	for i+1 < len(s.lines) {
+		trimmed := strings.TrimRight(joined, " \t")
+		switch {
+		case strings.HasSuffix(trimmed, "\\"):
+			joined = strings.TrimSuffix(trimmed, "\\") + " " + s.lines[i+1]
+		case open != 0:
+			joined += "\n" + s.lines[i+1]
+		default:
+			return joined, words, i, nil
+		}
+		i++
+		words, open = shellWordsOpen(joined)
 	}
-	if len(blocks) != 0 {
+	// The joiner ran out of file still looking for the closing quote. Every
+	// remaining line has been swallowed into one quoted word — the sink of the
+	// same class of silent loss the shared scanner closes in shellWordsOpen, and
+	// the one shape a shared scanner cannot see, because both halves agree the
+	// quote is open. Refuse: an unreadable tail and a clean tail must not be the
+	// same answer.
+	if open != 0 {
+		return "", nil, 0, fmt.Errorf("%s:%d: a %c quote opened on this line is never closed "+
+			"before the end of the file, so every statement after it is swallowed into one "+
+			"quoted word — this file cannot be read, and a check that cannot run must say so",
+			s.Path, start+1, open)
+	}
+	return joined, words, i, nil
+}
+
+// nesting is the compound-block and `if`-condition stack buildStatements carries
+// down a file. The two live in ONE type because they have to agree: a `fi` that
+// popped a block but not a condition would attribute a gate to the wrong
+// statement, and attributing "this teardown is gated" wrongly in either
+// direction is the failure mode INV-1 is about.
+type nesting struct {
+	blocks []string // kinds of the enclosing compound statements, outermost first
+	conds  []string // the `if`/`elif` conditions enclosing, outermost first
+}
+
+// track updates the stack for one command's leading word, refusing whenever the
+// file's structure does not balance rather than truncating to a best effort.
+func (n *nesting) track(path string, line int, words []string) error {
+	switch words[0] {
+	case "if":
+		n.blocks = append(n.blocks, words[0])
+		n.conds = append(n.conds, strings.Join(words[1:], " "))
+	case "case", "do", "{":
+		n.blocks = append(n.blocks, words[0])
+	case "fi":
+		if err := n.popBlock(path, line, words[0]); err != nil {
+			return err
+		}
+		if len(n.conds) == 0 {
+			return fmt.Errorf("%s:%d: `fi` with no open `if` — the if/fi structure "+
+				"cannot be read, and a check that cannot run must say so", path, line)
+		}
+		n.conds = n.conds[:len(n.conds)-1]
+	case "esac", "done", "}":
+		return n.popBlock(path, line, words[0])
+	case "elif":
+		if len(n.conds) == 0 {
+			return fmt.Errorf("%s:%d: `elif` with no open `if`", path, line)
+		}
+		n.conds[len(n.conds)-1] = strings.Join(words[1:], " ")
+	}
+	return nil
+}
+
+func (n *nesting) popBlock(path string, line int, word string) error {
+	if len(n.blocks) == 0 {
+		return fmt.Errorf("%s:%d: `%s` closes a compound statement that was never "+
+			"opened — this file's block structure cannot be read, and a check that "+
+			"cannot run must say so", path, line, word)
+	}
+	n.blocks = n.blocks[:len(n.blocks)-1]
+	return nil
+}
+
+// stamp records where in the nesting a statement was found. Depth and Blocks are
+// read off the same slice, so the count and the kinds cannot drift apart.
+func (n *nesting) stamp(st *Statement) {
+	st.Depth = len(n.blocks)
+	if len(n.blocks) > 0 {
+		st.Blocks = append([]string(nil), n.blocks...)
+	}
+	if len(n.conds) > 0 {
+		st.Conds = append([]string(nil), n.conds...)
+	}
+}
+
+// close refuses a file whose stacks never emptied.
+func (n *nesting) close(path string) error {
+	if len(n.conds) != 0 {
+		return fmt.Errorf("%s: %d `if` block(s) are never closed by `fi` — the if/fi structure "+
+			"cannot be read, and a check that cannot run must say so", path, len(n.conds))
+	}
+	if len(n.blocks) != 0 {
 		return fmt.Errorf("%s: %d compound statement(s) are never closed — the block structure "+
-			"cannot be read, and a check that cannot run must say so", s.Path, len(blocks))
+			"cannot be read, and a check that cannot run must say so", path, len(n.blocks))
 	}
 	return nil
 }
@@ -417,9 +466,8 @@ func shellWordsOpen(s string) (words []string, open rune) {
 		c := rs[i]
 		switch {
 		case c == '\\' && i+1 < len(rs):
-			cur.WriteRune(c)
+			cur.WriteString(string(rs[i : i+2]))
 			i++
-			cur.WriteRune(rs[i])
 		case c == '#' && cur.Len() == 0:
 			// A comment starts only at a word boundary — and it runs to the end
 			// of the text, so nothing after it can open a quote.
@@ -427,34 +475,20 @@ func shellWordsOpen(s string) (words []string, open rune) {
 			return words, 0
 		case c == ' ' || c == '\t':
 			flush()
-		case c == '\'':
-			j := i + 1
-			for j < len(rs) && rs[j] != '\'' {
-				j++
-			}
-			if j >= len(rs) {
-				j = len(rs) - 1
-				open = '\''
-			}
-			cur.WriteString(string(rs[i : j+1]))
-			i = j
-		case c == '"':
-			j, closed := scanQuotedOK(rs, i)
+		case c == '\'' || c == '"':
+			j, closed := scanQuoted(rs, i)
 			if !closed {
-				open = '"'
+				open = c
 			}
 			cur.WriteString(string(rs[i : j+1]))
 			i = j
-		case c == '$' && i+1 < len(rs) && (rs[i+1] == '(' || rs[i+1] == '{'):
+		case opensExpansion(rs, i):
 			j := scanExpansion(rs, i)
 			cur.WriteString(string(rs[i : j+1]))
 			i = j
 		case c == ';' || c == '|' || c == '&':
 			flush()
-			j := i
-			for j+1 < len(rs) && rs[j+1] == c {
-				j++
-			}
+			j := runEnd(rs, i)
 			words = append(words, string(rs[i:j+1]))
 			i = j
 		case c == '(' || c == ')':
@@ -468,21 +502,68 @@ func shellWordsOpen(s string) (words []string, open rune) {
 	return words, open
 }
 
-// scanQuotedOK returns the index of the `"` closing the one at i, stepping over
-// escapes and over `$( … )` / `${ … }` (which may contain quotes of their own).
-// An unterminated quote yields the last index and closed=false.
-func scanQuotedOK(rs []rune, i int) (int, bool) {
+// scanQuoted returns the index of the quote closing the one at i, and whether it
+// found one. An unterminated quote yields the last index and closed=false.
+//
+// The two quote kinds need different scans — a single-quoted string has no
+// escapes and no expansions — but they report the SAME shape, so shellWordsOpen
+// handles them in one arm and the "which quote is still open" answer cannot come
+// to depend on which quote it was. That is the same unification, for the same
+// reason, that shellWordsOpen's own doc comment sets out.
+func scanQuoted(rs []rune, i int) (int, bool) {
+	if rs[i] == '\'' {
+		return scanSingleQuoted(rs, i)
+	}
+	return scanDoubleQuoted(rs, i)
+}
+
+// scanSingleQuoted returns the index of the `'` closing the one at i. Nothing
+// inside a single-quoted string is special, so the scan is a plain search.
+func scanSingleQuoted(rs []rune, i int) (int, bool) {
+	for j := i + 1; j < len(rs); j++ {
+		if rs[j] == '\'' {
+			return j, true
+		}
+	}
+	return len(rs) - 1, false
+}
+
+// scanDoubleQuoted returns the index of the `"` closing the one at i, stepping
+// over escapes and over `$( … )` / `${ … }` (which may contain quotes of their
+// own).
+func scanDoubleQuoted(rs []rune, i int) (int, bool) {
 	for j := i + 1; j < len(rs); j++ {
 		switch {
 		case rs[j] == '\\':
 			j++
-		case rs[j] == '$' && j+1 < len(rs) && (rs[j+1] == '(' || rs[j+1] == '{'):
+		case opensExpansion(rs, j):
 			j = scanExpansion(rs, j)
 		case rs[j] == '"':
 			return j, true
 		}
 	}
 	return len(rs) - 1, false
+}
+
+// opensExpansion reports whether a `$( … )` or `${ … }` expansion begins at i.
+//
+// One spelling, consulted by both the word scanner and the double-quote scanner.
+// They have to agree about where an expansion starts: a `"` or a `#` inside one
+// is not a quote or a comment, and shellWordsOpen's doc comment is the record of
+// what it cost the last time two scanners in this file disagreed about a
+// boundary.
+func opensExpansion(rs []rune, i int) bool {
+	return rs[i] == '$' && i+1 < len(rs) && (rs[i+1] == '(' || rs[i+1] == '{')
+}
+
+// runEnd returns the last index of the run of the operator character at i, so
+// `&&` and `;;` come out as one word rather than two.
+func runEnd(rs []rune, i int) int {
+	j := i
+	for j+1 < len(rs) && rs[j+1] == rs[i] {
+		j++
+	}
+	return j
 }
 
 // scanExpansion returns the index of the bracket closing the expansion at i.

--- a/tools/onboarding-factory/internal/driverteardown/shellsource.go
+++ b/tools/onboarding-factory/internal/driverteardown/shellsource.go
@@ -53,6 +53,17 @@ type Statement struct {
 	// unconditionally and passed all ten drivers on a fail-closed reading they
 	// had not earned.
 	Depth int
+	// Blocks are the KINDS of those enclosing compound statements, outermost
+	// first: "if", "case", "do" (a loop body), "{" (a group or a function
+	// body). len(Blocks) is Depth — they are maintained as one stack so the
+	// count and the kinds cannot drift apart.
+	//
+	// Depth alone could not tell INV-1's two top-level shapes apart. The
+	// end-of-run sweep every driver writes is `for (( i = 1; i <= N_SLOTS;
+	// i++ )); do … done`, and copilot's step dispatch is `while … case … esac
+	// … done`; both put a `tmux kill-session` at Func "" and a non-zero depth.
+	// The kinds, in order, are what separates them. See isStepDispatchArm.
+	Blocks []string
 	// Func is the name of the top-level function whose body contains this
 	// statement, or "" when the statement is at top level.
 	Func string
@@ -199,44 +210,59 @@ func (s *Source) Body(name string) (string, bool) {
 // direction is the failure mode INV-1 is about.
 func (s *Source) buildStatements(code []bool) error {
 	var conds []string
-	depth := 0
+	var blocks []string
 	for i := 0; i < len(s.lines); i++ {
 		if !code[i] {
 			continue
 		}
 		start := i
 		joined := s.lines[i]
+		words, open := shellWordsOpen(joined)
 		for i+1 < len(s.lines) {
 			if strings.HasSuffix(strings.TrimRight(joined, " \t"), "\\") {
 				joined = strings.TrimSuffix(strings.TrimRight(joined, " \t"), "\\") + " " + s.lines[i+1]
 				i++
+				words, open = shellWordsOpen(joined)
 				continue
 			}
 			// A quote left open at end of line continues onto the next one.
 			// mistral-vibe embeds a multi-line `awk '…'` program whose braces
 			// are DATA; without this they were counted as shell blocks and the
 			// whole file was reported as unreadable.
-			if openQuote(joined) == 0 {
+			if open == 0 {
 				break
 			}
 			joined += "\n" + s.lines[i+1]
 			i++
+			words, open = shellWordsOpen(joined)
 		}
-		for _, cmd := range splitCommands(shellWords(joined)) {
+		// The joiner ran out of file still looking for the closing quote. Every
+		// remaining line has been swallowed into one quoted word — the sink of
+		// the same class of silent loss the shared scanner closes above, and the
+		// one shape a shared scanner cannot see, because both halves agree the
+		// quote is open. Refuse: an unreadable tail and a clean tail must not be
+		// the same answer.
+		if open != 0 {
+			return fmt.Errorf("%s:%d: a %c quote opened on this line is never closed before the "+
+				"end of the file, so every statement after it is swallowed into one quoted word "+
+				"— this file cannot be read, and a check that cannot run must say so",
+				s.Path, start+1, open)
+		}
+		for _, cmd := range splitCommands(words) {
 			words := cmd.words
 			if len(words) == 0 {
 				continue
 			}
 			switch words[0] {
 			case "if", "case", "do", "{":
-				depth++
+				blocks = append(blocks, words[0])
 			case "fi", "esac", "done", "}":
-				depth--
-				if depth < 0 {
+				if len(blocks) == 0 {
 					return fmt.Errorf("%s:%d: `%s` closes a compound statement that was never "+
 						"opened — this file's block structure cannot be read, and a check that "+
 						"cannot run must say so", s.Path, start+1, words[0])
 				}
+				blocks = blocks[:len(blocks)-1]
 			}
 			switch words[0] {
 			case "if":
@@ -255,7 +281,10 @@ func (s *Source) buildStatements(code []bool) error {
 			}
 			st := Statement{
 				Line: start + 1, Text: joined, Words: words,
-				Prefix: cmd.prefix, Func: s.funcAt(start + 1), Depth: depth,
+				Prefix: cmd.prefix, Func: s.funcAt(start + 1), Depth: len(blocks),
+			}
+			if len(blocks) > 0 {
+				st.Blocks = append([]string(nil), blocks...)
 			}
 			if len(conds) > 0 {
 				st.Conds = append([]string(nil), conds...)
@@ -267,9 +296,9 @@ func (s *Source) buildStatements(code []bool) error {
 		return fmt.Errorf("%s: %d `if` block(s) are never closed by `fi` — the if/fi structure "+
 			"cannot be read, and a check that cannot run must say so", s.Path, len(conds))
 	}
-	if depth != 0 {
+	if len(blocks) != 0 {
 		return fmt.Errorf("%s: %d compound statement(s) are never closed — the block structure "+
-			"cannot be read, and a check that cannot run must say so", s.Path, depth)
+			"cannot be read, and a check that cannot run must say so", s.Path, len(blocks))
 	}
 	return nil
 }
@@ -348,10 +377,34 @@ func splitCommands(words []string) []command {
 	return append(out, command{words: cur, prefix: prefix})
 }
 
-// shellWords splits one logical line into shell words, keeping quotes and
-// expansions intact and emitting command separators as their own words.
-func shellWords(s string) []string {
-	var words []string
+// shellWordsOpen splits one logical line into shell words, keeping quotes and
+// expansions intact and emitting command separators as their own words, and
+// reports the quote character left unterminated at the end of s — 0 when the
+// text ends outside any quote, INCLUDING when it ends inside a comment, which
+// cannot open one.
+//
+// WHY ONE FUNCTION ANSWERS BOTH QUESTIONS. It used to be two, and they
+// disagreed about where a comment starts. This scanner's rule is "a `#` that
+// opens a word"; a separate openQuote's rule was "a `#` at column 0 or after a
+// space/tab". A comment glued to code sat in the gap:
+//
+//	bar=1;# the driver's flag
+//
+// openQuote read the apostrophe in "driver's" as an unterminated quote, so
+// buildStatements joined the following lines on to close it, and this scanner
+// then truncated the joined text at the `#` — dropping every statement that had
+// just been joined in. Silently: the dropped lines took their own `if`/`fi` and
+// `do`/`done` with them, so the balance assertions stayed happy. A dropped
+// `trap … EXIT` or `REACHED_EPILOGUE=1` is a false POSITIVE and merely noisy,
+// but a dropped top-level gated `tmux kill-session` is a false CLEAN on INV-1
+// with `sites` still non-zero, which is the one failure the vacuity guard
+// cannot catch.
+//
+// Aligning the two rules would have fixed the shape and left the hazard: two
+// scanners doing the same job drift. Deleting one is what makes the class of
+// defect unreachable, and this file's contract is that every place it can be
+// wrong is a place it refuses instead.
+func shellWordsOpen(s string) (words []string, open rune) {
 	var cur strings.Builder
 	flush := func() {
 		if cur.Len() > 0 {
@@ -368,8 +421,10 @@ func shellWords(s string) []string {
 			i++
 			cur.WriteRune(rs[i])
 		case c == '#' && cur.Len() == 0:
+			// A comment starts only at a word boundary — and it runs to the end
+			// of the text, so nothing after it can open a quote.
 			flush()
-			return words // a comment starts only at a word boundary
+			return words, 0
 		case c == ' ' || c == '\t':
 			flush()
 		case c == '\'':
@@ -379,11 +434,15 @@ func shellWords(s string) []string {
 			}
 			if j >= len(rs) {
 				j = len(rs) - 1
+				open = '\''
 			}
 			cur.WriteString(string(rs[i : j+1]))
 			i = j
 		case c == '"':
-			j := scanQuoted(rs, i)
+			j, closed := scanQuotedOK(rs, i)
+			if !closed {
+				open = '"'
+			}
 			cur.WriteString(string(rs[i : j+1]))
 			i = j
 		case c == '$' && i+1 < len(rs) && (rs[i+1] == '(' || rs[i+1] == '{'):
@@ -406,17 +465,12 @@ func shellWords(s string) []string {
 		}
 	}
 	flush()
-	return words
+	return words, open
 }
 
-// scanQuoted returns the index of the `"` closing the one at i, stepping over
+// scanQuotedOK returns the index of the `"` closing the one at i, stepping over
 // escapes and over `$( … )` / `${ … }` (which may contain quotes of their own).
 // An unterminated quote yields the last index and closed=false.
-func scanQuoted(rs []rune, i int) int {
-	j, _ := scanQuotedOK(rs, i)
-	return j
-}
-
 func scanQuotedOK(rs []rune, i int) (int, bool) {
 	for j := i + 1; j < len(rs); j++ {
 		switch {
@@ -429,37 +483,6 @@ func scanQuotedOK(rs []rune, i int) (int, bool) {
 		}
 	}
 	return len(rs) - 1, false
-}
-
-// openQuote reports the quote character left unterminated at the end of s, or
-// 0 when every quote on the line is closed. Text after an unquoted `#` is a
-// comment and never opens one — an apostrophe in prose is not a shell quote.
-func openQuote(s string) rune {
-	rs := []rune(s)
-	for i := 0; i < len(rs); i++ {
-		switch {
-		case rs[i] == '\\':
-			i++
-		case rs[i] == '#' && (i == 0 || rs[i-1] == ' ' || rs[i-1] == '\t'):
-			return 0
-		case rs[i] == '\'':
-			j := i + 1
-			for j < len(rs) && rs[j] != '\'' {
-				j++
-			}
-			if j >= len(rs) {
-				return '\''
-			}
-			i = j
-		case rs[i] == '"':
-			j, ok := scanQuotedOK(rs, i)
-			if !ok {
-				return '"'
-			}
-			i = j
-		}
-	}
-	return 0
 }
 
 // scanExpansion returns the index of the bracket closing the expansion at i.

--- a/tools/onboarding-factory/internal/driverteardown/shellsource.go
+++ b/tools/onboarding-factory/internal/driverteardown/shellsource.go
@@ -1,0 +1,519 @@
+package driverteardown
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// Source is one shell file parsed far enough to answer the three questions
+// this package asks of a recording driver: where its top-level functions
+// begin and end, which `if` conditions enclose a given statement, and what
+// the words of each statement are.
+//
+// It is deliberately NOT a shell parser. It is a lexer plus two structural
+// passes, and every place it can be wrong is a place it refuses instead:
+// an unterminated function body, an unbalanced `if`/`fi`, a `tmux
+// new-session` with no `-s`. AGENTS.md's rule is that a verification
+// mechanism must fail loudly when it cannot run, and the cheapest way to
+// honour that in a text-matching checker is to make every structural
+// assumption an assertion.
+type Source struct {
+	Path string
+
+	lines []string    // physical lines; lines[n-1] is line n
+	stmts []Statement // logical statements, in file order
+	funcs []Region    // top-level function bodies, in file order
+}
+
+// Statement is one logical shell command: a physical line plus every line
+// joined to it by a trailing backslash, split at the shell operators that
+// separate commands (`;` `&&` `||` `|` `&`).
+type Statement struct {
+	Line  int      // 1-based line of the first physical line it came from
+	Text  string   // the joined logical line this statement belongs to
+	Words []string // shell words; quotes and expansions kept intact
+	// Prefix is the code of the commands earlier in the SAME logical line that
+	// this one is conditional on — the `[[ … ]]` of `[[ … ]] && tmux
+	// kill-session …`. It is comment-free, so a comment NAMING the flag beside
+	// an ungated teardown cannot be read as a gate on it.
+	Prefix string
+	// Conds are the `if`/`elif` conditions enclosing this statement, outermost
+	// first. Empty means no `if` encloses it.
+	Conds []string
+	// Depth is how many COMPOUND statements enclose this one — `if`/`fi`,
+	// `case`/`esac`, a `do`/`done` loop body, a `{ … }` group, and a function
+	// body. Depth 0 with Func "" is the only position that runs on every path
+	// through the script, which is what INV-4's "the epilogue set it" rests on.
+	//
+	// Conds alone was NOT enough, and the gap was measured rather than
+	// imagined: `EXIT_REASON="nonzero(2)"` inside a `case` arm inside the step
+	// loop has no enclosing `if`, so a Conds-only rule read it as running
+	// unconditionally and passed all ten drivers on a fail-closed reading they
+	// had not earned.
+	Depth int
+	// Func is the name of the top-level function whose body contains this
+	// statement, or "" when the statement is at top level.
+	Func string
+}
+
+// Region is one top-level function body, inclusive of its `name() {` line and
+// its closing `}` line.
+type Region struct {
+	Name       string
+	Start, End int
+}
+
+var (
+	funcOpenRe = regexp.MustCompile(`^([A-Za-z_][A-Za-z0-9_-]*)[ \t]*\([ \t]*\)[ \t]*\{`)
+	heredocRe  = regexp.MustCompile(`<<-?[ \t]*(['"]?)([A-Za-z_][A-Za-z0-9_]*)(['"]?)`)
+	assignRe   = regexp.MustCompile(`^([A-Za-z_][A-Za-z0-9_]*)(\[[^\]]*\])?=(.*)$`)
+	// A word that is exactly one variable expansion: "$X", $X, "${X}",
+	// "${X[$i]}", "$1". Anything else is treated as composed text.
+	soleVarRe = regexp.MustCompile(`^\$(?:([A-Za-z_][A-Za-z0-9_]*|[0-9]+)|\{([A-Za-z_][A-Za-z0-9_]*|[0-9]+)(?:\[[^\]]*\])?(?::-[^}]*)?\})$`)
+)
+
+// Parse lexes and structures one shell file. It returns an error rather than a
+// best-effort structure whenever an assumption it rests on does not hold.
+func Parse(path, src string) (*Source, error) {
+	s := &Source{Path: path, lines: strings.Split(src, "\n")}
+	code := codeMask(s.lines)
+	if err := s.findFunctions(code); err != nil {
+		return nil, err
+	}
+	if err := s.buildStatements(code); err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
+// codeMask marks which physical lines are code. Heredoc BODIES are not: a
+// `}` or an `fi` inside one would otherwise close a structure it has nothing
+// to do with. Here-STRINGS (`<<<`) are ordinary code and stay marked.
+func codeMask(lines []string) []bool {
+	code := make([]bool, len(lines))
+	term := ""
+	for i, ln := range lines {
+		if term != "" {
+			code[i] = false
+			if strings.TrimSpace(ln) == term {
+				term = ""
+			}
+			continue
+		}
+		code[i] = true
+		body := stripComment(ln)
+		if strings.Contains(body, "<<<") {
+			continue
+		}
+		if m := heredocRe.FindStringSubmatch(body); m != nil {
+			term = m[2]
+		}
+	}
+	return code
+}
+
+// stripComment drops a trailing `#` comment when the `#` starts a word. It is
+// approximate on purpose: a `#` inside a quoted string is left alone by the
+// word scanner, and the only consumer here is heredoc detection.
+func stripComment(ln string) string {
+	if i := strings.Index(ln, " #"); i >= 0 {
+		return ln[:i]
+	}
+	if strings.HasPrefix(strings.TrimSpace(ln), "#") {
+		return ""
+	}
+	return ln
+}
+
+// findFunctions records every top-level function body. The drivers all write
+// `name() {` at column 0 and close with `}` at column 0 — including the shared
+// scaffolding they were generated from — so the pairing is "the next `}` at
+// column 0". A stray column-0 `}` with no opener before it (a `{ …; } > file`
+// group at top level, which aider's epilogue uses) is simply never consulted.
+//
+// The failure this refuses: an opener with no closer would silently swallow
+// the rest of the file into one region and move every later top-level
+// statement inside a function, which is exactly the classification INV-1
+// rests on.
+func (s *Source) findFunctions(code []bool) error {
+	for i, ln := range s.lines {
+		if !code[i] {
+			continue
+		}
+		m := funcOpenRe.FindStringSubmatch(ln)
+		if m == nil {
+			continue
+		}
+		if len(s.funcs) > 0 && s.funcs[len(s.funcs)-1].End >= i+1 {
+			continue // a nested `name() {` inside a body we already closed over
+		}
+		if strings.HasSuffix(strings.TrimRight(ln, " \t"), "}") {
+			s.funcs = append(s.funcs, Region{Name: m[1], Start: i + 1, End: i + 1})
+			continue
+		}
+		end := -1
+		for j := i + 1; j < len(s.lines); j++ {
+			if code[j] && strings.HasPrefix(s.lines[j], "}") {
+				end = j + 1
+				break
+			}
+		}
+		if end < 0 {
+			return fmt.Errorf("%s:%d: function %s() is never closed by a `}` at column 0 — "+
+				"this file's structure cannot be read, and a check that cannot run must say so",
+				s.Path, i+1, m[1])
+		}
+		s.funcs = append(s.funcs, Region{Name: m[1], Start: i + 1, End: end})
+	}
+	return nil
+}
+
+// funcAt names the top-level function containing line n, or "" for top level.
+func (s *Source) funcAt(n int) string {
+	for _, f := range s.funcs {
+		if n >= f.Start && n <= f.End {
+			return f.Name
+		}
+	}
+	return ""
+}
+
+// Body returns the source text of the named top-level function.
+func (s *Source) Body(name string) (string, bool) {
+	for _, f := range s.funcs {
+		if f.Name == name {
+			return strings.Join(s.lines[f.Start-1:f.End], "\n"), true
+		}
+	}
+	return "", false
+}
+
+// buildStatements joins backslash continuations, splits each logical line into
+// commands, and stamps every command with the `if` conditions enclosing it.
+//
+// The `if` stack must balance across the whole file. It refuses rather than
+// truncating, because an unbalanced stack would attribute a gate to the wrong
+// statement — and attributing "this teardown is gated" wrongly in EITHER
+// direction is the failure mode INV-1 is about.
+func (s *Source) buildStatements(code []bool) error {
+	var conds []string
+	depth := 0
+	for i := 0; i < len(s.lines); i++ {
+		if !code[i] {
+			continue
+		}
+		start := i
+		joined := s.lines[i]
+		for i+1 < len(s.lines) {
+			if strings.HasSuffix(strings.TrimRight(joined, " \t"), "\\") {
+				joined = strings.TrimSuffix(strings.TrimRight(joined, " \t"), "\\") + " " + s.lines[i+1]
+				i++
+				continue
+			}
+			// A quote left open at end of line continues onto the next one.
+			// mistral-vibe embeds a multi-line `awk '…'` program whose braces
+			// are DATA; without this they were counted as shell blocks and the
+			// whole file was reported as unreadable.
+			if openQuote(joined) == 0 {
+				break
+			}
+			joined += "\n" + s.lines[i+1]
+			i++
+		}
+		for _, cmd := range splitCommands(shellWords(joined)) {
+			words := cmd.words
+			if len(words) == 0 {
+				continue
+			}
+			switch words[0] {
+			case "if", "case", "do", "{":
+				depth++
+			case "fi", "esac", "done", "}":
+				depth--
+				if depth < 0 {
+					return fmt.Errorf("%s:%d: `%s` closes a compound statement that was never "+
+						"opened — this file's block structure cannot be read, and a check that "+
+						"cannot run must say so", s.Path, start+1, words[0])
+				}
+			}
+			switch words[0] {
+			case "if":
+				conds = append(conds, strings.Join(words[1:], " "))
+			case "elif":
+				if len(conds) == 0 {
+					return fmt.Errorf("%s:%d: `elif` with no open `if`", s.Path, start+1)
+				}
+				conds[len(conds)-1] = strings.Join(words[1:], " ")
+			case "fi":
+				if len(conds) == 0 {
+					return fmt.Errorf("%s:%d: `fi` with no open `if` — the if/fi structure "+
+						"cannot be read, and a check that cannot run must say so", s.Path, start+1)
+				}
+				conds = conds[:len(conds)-1]
+			}
+			st := Statement{
+				Line: start + 1, Text: joined, Words: words,
+				Prefix: cmd.prefix, Func: s.funcAt(start + 1), Depth: depth,
+			}
+			if len(conds) > 0 {
+				st.Conds = append([]string(nil), conds...)
+			}
+			s.stmts = append(s.stmts, st)
+		}
+	}
+	if len(conds) != 0 {
+		return fmt.Errorf("%s: %d `if` block(s) are never closed by `fi` — the if/fi structure "+
+			"cannot be read, and a check that cannot run must say so", s.Path, len(conds))
+	}
+	if depth != 0 {
+		return fmt.Errorf("%s: %d compound statement(s) are never closed — the block structure "+
+			"cannot be read, and a check that cannot run must say so", s.Path, depth)
+	}
+	return nil
+}
+
+// Statements exposes the parsed commands in file order.
+func (s *Source) Statements() []Statement { return s.stmts }
+
+// Command returns the statement's command name and arguments, skipping leading
+// keywords and variable-assignment prefixes. ok is false for a statement that
+// runs no command (a bare assignment, a `[[ … ]]` test, a keyword).
+func (st Statement) Command() (name string, args []string, ok bool) {
+	w := st.Words
+	for len(w) > 0 {
+		switch {
+		case isKeyword(w[0]), assignRe.MatchString(w[0]):
+			w = w[1:]
+		default:
+			return w[0], w[1:], true
+		}
+	}
+	return "", nil, false
+}
+
+// Assignments returns every `VAR=…` in the statement — both a bare assignment
+// and the several a `local a=… b=…` declares.
+func (st Statement) Assignments() [][3]string {
+	var out [][3]string
+	for _, w := range st.Words {
+		m := assignRe.FindStringSubmatch(w)
+		if m == nil {
+			continue
+		}
+		out = append(out, [3]string{m[1], m[2], m[3]})
+	}
+	return out
+}
+
+func isKeyword(w string) bool {
+	switch w {
+	case "then", "else", "do", "!", "time", "local", "declare", "export", "readonly", "typeset", "{":
+		return true
+	}
+	return false
+}
+
+// command is one shell command plus the code it is conditional on within its
+// own logical line.
+type command struct {
+	words  []string
+	prefix string
+}
+
+// splitCommands cuts a word list at the operators that separate commands, so
+// the `tmux kill-session …` half of `[[ … ]] && tmux kill-session …` is graded
+// as its own command with its own name — while still carrying the `[[ … ]]`
+// that decides whether it runs. `&&` and `||` accumulate into the prefix; the
+// separators that start an unconditional command (`;` `|` `&`) clear it.
+func splitCommands(words []string) []command {
+	var out []command
+	var cur []string
+	prefix := ""
+	for _, w := range words {
+		switch w {
+		case "&&", "||":
+			out = append(out, command{words: cur, prefix: prefix})
+			prefix = strings.TrimSpace(prefix + " " + strings.Join(cur, " "))
+			cur = nil
+		case ";", ";;", "|", "&", "(", ")":
+			out = append(out, command{words: cur, prefix: prefix})
+			prefix = ""
+			cur = nil
+		default:
+			cur = append(cur, w)
+		}
+	}
+	return append(out, command{words: cur, prefix: prefix})
+}
+
+// shellWords splits one logical line into shell words, keeping quotes and
+// expansions intact and emitting command separators as their own words.
+func shellWords(s string) []string {
+	var words []string
+	var cur strings.Builder
+	flush := func() {
+		if cur.Len() > 0 {
+			words = append(words, cur.String())
+			cur.Reset()
+		}
+	}
+	rs := []rune(s)
+	for i := 0; i < len(rs); i++ {
+		c := rs[i]
+		switch {
+		case c == '\\' && i+1 < len(rs):
+			cur.WriteRune(c)
+			i++
+			cur.WriteRune(rs[i])
+		case c == '#' && cur.Len() == 0:
+			flush()
+			return words // a comment starts only at a word boundary
+		case c == ' ' || c == '\t':
+			flush()
+		case c == '\'':
+			j := i + 1
+			for j < len(rs) && rs[j] != '\'' {
+				j++
+			}
+			if j >= len(rs) {
+				j = len(rs) - 1
+			}
+			cur.WriteString(string(rs[i : j+1]))
+			i = j
+		case c == '"':
+			j := scanQuoted(rs, i)
+			cur.WriteString(string(rs[i : j+1]))
+			i = j
+		case c == '$' && i+1 < len(rs) && (rs[i+1] == '(' || rs[i+1] == '{'):
+			j := scanExpansion(rs, i)
+			cur.WriteString(string(rs[i : j+1]))
+			i = j
+		case c == ';' || c == '|' || c == '&':
+			flush()
+			j := i
+			for j+1 < len(rs) && rs[j+1] == c {
+				j++
+			}
+			words = append(words, string(rs[i:j+1]))
+			i = j
+		case c == '(' || c == ')':
+			flush()
+			words = append(words, string(c))
+		default:
+			cur.WriteRune(c)
+		}
+	}
+	flush()
+	return words
+}
+
+// scanQuoted returns the index of the `"` closing the one at i, stepping over
+// escapes and over `$( … )` / `${ … }` (which may contain quotes of their own).
+// An unterminated quote yields the last index and closed=false.
+func scanQuoted(rs []rune, i int) int {
+	j, _ := scanQuotedOK(rs, i)
+	return j
+}
+
+func scanQuotedOK(rs []rune, i int) (int, bool) {
+	for j := i + 1; j < len(rs); j++ {
+		switch {
+		case rs[j] == '\\':
+			j++
+		case rs[j] == '$' && j+1 < len(rs) && (rs[j+1] == '(' || rs[j+1] == '{'):
+			j = scanExpansion(rs, j)
+		case rs[j] == '"':
+			return j, true
+		}
+	}
+	return len(rs) - 1, false
+}
+
+// openQuote reports the quote character left unterminated at the end of s, or
+// 0 when every quote on the line is closed. Text after an unquoted `#` is a
+// comment and never opens one — an apostrophe in prose is not a shell quote.
+func openQuote(s string) rune {
+	rs := []rune(s)
+	for i := 0; i < len(rs); i++ {
+		switch {
+		case rs[i] == '\\':
+			i++
+		case rs[i] == '#' && (i == 0 || rs[i-1] == ' ' || rs[i-1] == '\t'):
+			return 0
+		case rs[i] == '\'':
+			j := i + 1
+			for j < len(rs) && rs[j] != '\'' {
+				j++
+			}
+			if j >= len(rs) {
+				return '\''
+			}
+			i = j
+		case rs[i] == '"':
+			j, ok := scanQuotedOK(rs, i)
+			if !ok {
+				return '"'
+			}
+			i = j
+		}
+	}
+	return 0
+}
+
+// scanExpansion returns the index of the bracket closing the expansion at i.
+func scanExpansion(rs []rune, i int) int {
+	opener, closer := '(', ')'
+	if rs[i+1] == '{' {
+		opener, closer = '{', '}'
+	}
+	depth := 0
+	for j := i + 1; j < len(rs); j++ {
+		switch {
+		case rs[j] == '\\':
+			j++
+		case rs[j] == '\'' || rs[j] == '"':
+			q := rs[j]
+			for j++; j < len(rs) && rs[j] != q; j++ {
+				if rs[j] == '\\' {
+					j++
+				}
+			}
+		case rs[j] == opener:
+			depth++
+		case rs[j] == closer:
+			depth--
+			if depth == 0 {
+				return j
+			}
+		}
+	}
+	return len(rs) - 1
+}
+
+// unquote strips one layer of surrounding double or single quotes.
+func unquote(w string) string {
+	if len(w) >= 2 && (w[0] == '"' || w[0] == '\'') && w[len(w)-1] == w[0] {
+		return w[1 : len(w)-1]
+	}
+	return w
+}
+
+// soleVar names the variable a word expands to when the word is exactly one
+// expansion, and reports whether it is one. `$1` comes back as the positional
+// index 1 with positional true.
+func soleVar(word string) (name string, positional int, ok bool) {
+	m := soleVarRe.FindStringSubmatch(unquote(word))
+	if m == nil {
+		return "", 0, false
+	}
+	v := m[1]
+	if v == "" {
+		v = m[2]
+	}
+	if n, err := strconv.Atoi(v); err == nil {
+		return "", n, true
+	}
+	return v, 0, true
+}

--- a/tools/onboarding-factory/internal/driverteardown/testdata/good_driver.sh
+++ b/tools/onboarding-factory/internal/driverteardown/testdata/good_driver.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# GOOD: the shape scripts/templates/drive-interactive.sh.tmpl ships.
+#   INV-1  both teardown sites gate on session-name PRESENCE
+#   INV-2  an EXIT trap whose handler tears sessions down
+#   INV-3  the minted name carries $$ as its own `-`-delimited field
+set -euo pipefail
+_DRIVE_LIB="$(dirname "${BASH_SOURCE[0]}")/lib"
+source "$_DRIVE_LIB/slots.sh"
+
+SESSION=""
+SES_SESSION=()
+SES_CWD=()
+SES_ALIVE=()
+N_SLOTS=0
+ACTIVE=0
+EXIT_REASON="ok"
+REACHED_EPILOGUE=0
+RUN_CWD="$STAGING/cwd"
+
+cleanup() {
+  # The epilogue sets REACHED_EPILOGUE immediately before the final exit, so a
+  # handler that sees it unset knows the script aborted before forming a
+  # verdict and must not write EXIT_REASON's initialiser as one (INV-4).
+  if [[ "$REACHED_EPILOGUE" != "1" && "$EXIT_REASON" == "ok" ]]; then
+    EXIT_REASON="nonzero(2)"
+  fi
+  local i
+  for (( i = 1; i <= N_SLOTS; i++ )); do
+    [[ -n "${SES_SESSION[$i]:-}" ]] && tmux kill-session -t "${SES_SESSION[$i]}" 2>/dev/null || true
+  done
+  echo "$EXIT_REASON" > "$STAGING/driver.exit-reason"
+}
+trap cleanup EXIT
+
+launch_repl() {
+  alloc_slot "fixture-onboard-$(date +%s)-$$-$((N_SLOTS + 1))" "$RUN_CWD"
+  tmux kill-session -t "$SESSION" 2>/dev/null || true
+  tmux new-session -d -s "$SESSION" -x 200 -y 50 -c "${SES_CWD[$ACTIVE]}" "fixture-agent"
+}
+
+step_exit_clean() {
+  tmux send-keys -t "$SESSION" C-d
+  SES_ALIVE[$ACTIVE]=0
+}
+
+launch_repl
+step_exit_clean
+
+# Tear down every session this run created.
+for (( i = 1; i <= N_SLOTS; i++ )); do
+  if [[ -n "${SES_SESSION[$i]:-}" ]]; then
+    tmux kill-session -t "${SES_SESSION[$i]}" 2>/dev/null || true
+  fi
+done
+
+# The epilogue completed: EXIT_REASON is this run's real verdict.
+REACHED_EPILOGUE=1

--- a/tools/onboarding-factory/internal/driverteardown/testdata/inv1_comment_glued_to_code.sh
+++ b/tools/onboarding-factory/internal/driverteardown/testdata/inv1_comment_glued_to_code.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# MUST BE FLAGGED (INV-1) — and before the shellsource.go fix it was NOT.
+#
+# `RETRY_SWEEP=1;# the driver's own retry flag` glues a comment to code. The
+# apostrophe in "driver's" sits INSIDE that comment, but the line-joiner and the
+# word scanner did not share a `#`-is-a-comment rule: the joiner only accepted a
+# `#` at column 0 or after a space/tab, so it read the apostrophe as an
+# unterminated quote and joined the rest of the file onto this line, and the word
+# scanner then truncated the joined text at the `#`. Every statement below
+# vanished — the gated top-level `tmux kill-session` included — while `sites`
+# stayed non-zero, so INV-1 reported this driver CLEAN and the vacuity guard had
+# nothing to catch.
+set -euo pipefail
+_DRIVE_LIB="$(dirname "${BASH_SOURCE[0]}")/lib"
+source "$_DRIVE_LIB/slots.sh"
+
+SESSION=""
+SES_SESSION=()
+SES_CWD=()
+SES_ALIVE=()
+N_SLOTS=0
+ACTIVE=0
+EXIT_REASON="ok"
+REACHED_EPILOGUE=0
+RUN_CWD="$STAGING/cwd"
+
+cleanup() {
+  if [[ "$REACHED_EPILOGUE" != "1" && "$EXIT_REASON" == "ok" ]]; then
+    EXIT_REASON="nonzero(2)"
+  fi
+  local i
+  for (( i = 1; i <= N_SLOTS; i++ )); do
+    [[ -n "${SES_SESSION[$i]:-}" ]] && tmux kill-session -t "${SES_SESSION[$i]}" 2>/dev/null || true
+  done
+  echo "$EXIT_REASON" > "$STAGING/driver.exit-reason"
+}
+trap cleanup EXIT
+
+launch_repl() {
+  alloc_slot "fixture-onboard-$(date +%s)-$$-$((N_SLOTS + 1))" "$RUN_CWD"
+  tmux new-session -d -s "$SESSION" -x 200 -y 50 -c "${SES_CWD[$ACTIVE]}" "fixture-agent"
+}
+
+launch_repl
+
+# The epilogue completed: EXIT_REASON is this run's real verdict.
+REACHED_EPILOGUE=1
+
+RETRY_SWEEP=1;# the driver's own retry flag
+if [[ "${SES_ALIVE[$ACTIVE]:-0}" == "1" ]]; then
+  tmux kill-session -t "$SESSION" 2>/dev/null || true
+fi

--- a/tools/onboarding-factory/internal/driverteardown/testdata/inv1_gated_case_at_exit.sh
+++ b/tools/onboarding-factory/internal/driverteardown/testdata/inv1_gated_case_at_exit.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# MUST BE FLAGGED (INV-1) — the other side of the step-dispatch narrowing.
+#
+# A top-level `case` that is NOT inside a loop is not a step dispatch; it is the
+# trailing `case "$EXIT_REASON" in` shape aider, claudecode and opencode already
+# write at the bottom of their drivers. A liveness-gated kill in one of those
+# arms is end-of-run teardown and must still be flagged, so the narrowing cannot
+# be "a `case` arm is never teardown".
+set -euo pipefail
+_DRIVE_LIB="$(dirname "${BASH_SOURCE[0]}")/lib"
+source "$_DRIVE_LIB/slots.sh"
+
+SESSION=""
+SES_SESSION=()
+SES_CWD=()
+SES_ALIVE=()
+N_SLOTS=0
+ACTIVE=0
+EXIT_REASON="ok"
+REACHED_EPILOGUE=0
+RUN_CWD="$STAGING/cwd"
+
+cleanup() {
+  if [[ "$REACHED_EPILOGUE" != "1" && "$EXIT_REASON" == "ok" ]]; then
+    EXIT_REASON="nonzero(2)"
+  fi
+  local i
+  for (( i = 1; i <= N_SLOTS; i++ )); do
+    [[ -n "${SES_SESSION[$i]:-}" ]] && tmux kill-session -t "${SES_SESSION[$i]}" 2>/dev/null || true
+  done
+  echo "$EXIT_REASON" > "$STAGING/driver.exit-reason"
+}
+trap cleanup EXIT
+
+launch_repl() {
+  alloc_slot "fixture-onboard-$(date +%s)-$$-$((N_SLOTS + 1))" "$RUN_CWD"
+  tmux new-session -d -s "$SESSION" -x 200 -y 50 -c "${SES_CWD[$ACTIVE]}" "fixture-agent"
+}
+
+launch_repl
+
+case "$EXIT_REASON" in
+  ok)  if [[ "${SES_ALIVE[$ACTIVE]:-0}" == "1" ]]; then
+         tmux kill-session -t "$SESSION" 2>/dev/null || true
+       fi ;;
+  *)   tmux kill-session -t "$SESSION" 2>/dev/null || true ;;
+esac
+
+# The epilogue completed: EXIT_REASON is this run's real verdict.
+REACHED_EPILOGUE=1

--- a/tools/onboarding-factory/internal/driverteardown/testdata/inv1_gated_final_sweep.sh
+++ b/tools/onboarding-factory/internal/driverteardown/testdata/inv1_gated_final_sweep.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# MUTATION of good_driver.sh — the committed proof that INV-1 goes red at the
+# OTHER teardown site. ONE line differs: the top-level end-of-run sweep gates
+# on SES_ALIVE instead of on session-name presence. This is claudecode's,
+# codex's, pi's and gemini-cli's pre-#1825 shape.
+_DRIVE_LIB="$(dirname "${BASH_SOURCE[0]}")/lib"
+source "$_DRIVE_LIB/slots.sh"
+
+SESSION=""
+SES_SESSION=()
+SES_CWD=()
+SES_ALIVE=()
+N_SLOTS=0
+ACTIVE=0
+EXIT_REASON="ok"
+REACHED_EPILOGUE=0
+RUN_CWD="$STAGING/cwd"
+
+cleanup() {
+  # The epilogue sets REACHED_EPILOGUE immediately before the final exit, so a
+  # handler that sees it unset knows the script aborted before forming a
+  # verdict and must not write EXIT_REASON's initialiser as one (INV-4).
+  if [[ "$REACHED_EPILOGUE" != "1" && "$EXIT_REASON" == "ok" ]]; then
+    EXIT_REASON="nonzero(2)"
+  fi
+  local i
+  for (( i = 1; i <= N_SLOTS; i++ )); do
+    [[ -n "${SES_SESSION[$i]:-}" ]] && tmux kill-session -t "${SES_SESSION[$i]}" 2>/dev/null || true
+  done
+  echo "$EXIT_REASON" > "$STAGING/driver.exit-reason"
+}
+trap cleanup EXIT
+
+launch_repl() {
+  alloc_slot "fixture-onboard-$(date +%s)-$$-$((N_SLOTS + 1))" "$RUN_CWD"
+  tmux kill-session -t "$SESSION" 2>/dev/null || true
+  tmux new-session -d -s "$SESSION" -x 200 -y 50 -c "${SES_CWD[$ACTIVE]}" "fixture-agent"
+}
+
+step_exit_clean() {
+  tmux send-keys -t "$SESSION" C-d
+  SES_ALIVE[$ACTIVE]=0
+}
+
+launch_repl
+step_exit_clean
+
+# Tear down every session this run created.
+for (( i = 1; i <= N_SLOTS; i++ )); do
+  if [[ "${SES_ALIVE[$i]}" == "1" ]]; then
+    tmux kill-session -t "${SES_SESSION[$i]}" 2>/dev/null || true
+  fi
+done
+
+# The epilogue completed: EXIT_REASON is this run's real verdict.
+REACHED_EPILOGUE=1

--- a/tools/onboarding-factory/internal/driverteardown/testdata/inv1_gated_trap.sh
+++ b/tools/onboarding-factory/internal/driverteardown/testdata/inv1_gated_trap.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# MUTATION of good_driver.sh — the committed proof that INV-1 goes red.
+# ONE line differs from the good fixture: the EXIT trap's kill-session gates on
+# SES_ALIVE instead of on session-name presence. This is kiro-cli's pre-#1825
+# shape, and it is the leak: a step that asks the TUI to exit clears the flag
+# whether or not the TUI obeyed, so the trap then skips the kill.
+_DRIVE_LIB="$(dirname "${BASH_SOURCE[0]}")/lib"
+source "$_DRIVE_LIB/slots.sh"
+
+SESSION=""
+SES_SESSION=()
+SES_CWD=()
+SES_ALIVE=()
+N_SLOTS=0
+ACTIVE=0
+EXIT_REASON="ok"
+REACHED_EPILOGUE=0
+RUN_CWD="$STAGING/cwd"
+
+cleanup() {
+  # The epilogue sets REACHED_EPILOGUE immediately before the final exit, so a
+  # handler that sees it unset knows the script aborted before forming a
+  # verdict and must not write EXIT_REASON's initialiser as one (INV-4).
+  if [[ "$REACHED_EPILOGUE" != "1" && "$EXIT_REASON" == "ok" ]]; then
+    EXIT_REASON="nonzero(2)"
+  fi
+  local i
+  for (( i = 1; i <= N_SLOTS; i++ )); do
+    [[ "${SES_ALIVE[$i]:-0}" == "1" ]] && tmux kill-session -t "${SES_SESSION[$i]}" 2>/dev/null || true
+  done
+  echo "$EXIT_REASON" > "$STAGING/driver.exit-reason"
+}
+trap cleanup EXIT
+
+launch_repl() {
+  alloc_slot "fixture-onboard-$(date +%s)-$$-$((N_SLOTS + 1))" "$RUN_CWD"
+  tmux kill-session -t "$SESSION" 2>/dev/null || true
+  tmux new-session -d -s "$SESSION" -x 200 -y 50 -c "${SES_CWD[$ACTIVE]}" "fixture-agent"
+}
+
+step_exit_clean() {
+  tmux send-keys -t "$SESSION" C-d
+  SES_ALIVE[$ACTIVE]=0
+}
+
+launch_repl
+step_exit_clean
+
+# Tear down every session this run created.
+for (( i = 1; i <= N_SLOTS; i++ )); do
+  if [[ -n "${SES_SESSION[$i]:-}" ]]; then
+    tmux kill-session -t "${SES_SESSION[$i]}" 2>/dev/null || true
+  fi
+done
+
+# The epilogue completed: EXIT_REASON is this run's real verdict.
+REACHED_EPILOGUE=1

--- a/tools/onboarding-factory/internal/driverteardown/testdata/inv1_step_dispatch_case_arm_ok.sh
+++ b/tools/onboarding-factory/internal/driverteardown/testdata/inv1_step_dispatch_case_arm_ok.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# MUST NOT BE FLAGGED — copilot's shape, and the case that forced INV-1's
+# classification to be narrowed.
+#
+# copilot's step dispatch is a TOP-LEVEL `while … case`, not a function, so its
+# per-step kills sit at Func == "" and a rule reading "top level" as "the
+# end-of-run sweep" graded them as teardown. They are ungated in copilot today
+# so nothing fired — but the kiro-cli-shaped SES_ALIVE entry check that this
+# package deliberately ACCEPTS at step level (correct there, because
+# reset_session aliases a retired slot onto a live pane) would have been a false
+# positive the moment copilot, hermes, mistral-vibe or antigravity needed one.
+# This fixture is that moment: the `restart` arm carries the guard.
+#
+# The end-of-run sweep below is the real teardown and is ungated, so the file is
+# clean — which is only meaningful because inv1_gated_final_sweep.sh and
+# inv1_gated_case_at_exit.sh still fire.
+set -euo pipefail
+_DRIVE_LIB="$(dirname "${BASH_SOURCE[0]}")/lib"
+source "$_DRIVE_LIB/slots.sh"
+
+SESSION=""
+SES_SESSION=()
+SES_CWD=()
+SES_ALIVE=()
+N_SLOTS=0
+ACTIVE=0
+EXIT_REASON="ok"
+REACHED_EPILOGUE=0
+RUN_CWD="$STAGING/cwd"
+
+cleanup() {
+  if [[ "$REACHED_EPILOGUE" != "1" && "$EXIT_REASON" == "ok" ]]; then
+    EXIT_REASON="nonzero(2)"
+  fi
+  local i
+  for (( i = 1; i <= N_SLOTS; i++ )); do
+    [[ -n "${SES_SESSION[$i]:-}" ]] && tmux kill-session -t "${SES_SESSION[$i]}" 2>/dev/null || true
+  done
+  echo "$EXIT_REASON" > "$STAGING/driver.exit-reason"
+}
+trap cleanup EXIT
+
+launch_repl() {
+  alloc_slot "fixture-onboard-$(date +%s)-$$-$((N_SLOTS + 1))" "$RUN_CWD"
+  tmux new-session -d -s "$SESSION" -x 200 -y 50 -c "${SES_CWD[$ACTIVE]}" "fixture-agent"
+}
+
+launch_repl
+while IFS= read -r step; do
+  type="$(jq -r '.type' <<<"$step")"
+  case "$type" in
+    restart)     if [[ "${SES_ALIVE[$ACTIVE]:-0}" == "1" ]]; then
+                   tmux kill-session -t "$SESSION" 2>/dev/null || true
+                 fi
+                 launch_repl ;;
+    send)        tmux send-keys -t "$SESSION" "$(jq -r '.text' <<<"$step")" ;;
+    *)           echo "[driver] unknown step type: $type" >&2 ;;
+  esac
+done < <(jq -c '.[]' <<<"$SCRIPT_JSON")
+
+# Tear down every session this run created.
+for (( i = 1; i <= N_SLOTS; i++ )); do
+  if [[ -n "${SES_SESSION[$i]:-}" ]]; then
+    tmux kill-session -t "${SES_SESSION[$i]}" 2>/dev/null || true
+  fi
+done
+
+# The epilogue completed: EXIT_REASON is this run's real verdict.
+REACHED_EPILOGUE=1

--- a/tools/onboarding-factory/internal/driverteardown/testdata/inv1_step_guard_ok.sh
+++ b/tools/onboarding-factory/internal/driverteardown/testdata/inv1_step_guard_ok.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# MUST NOT BE FLAGGED — kiro-cli's shape, and the reason INV-1 is structural
+# rather than textual.
+#
+# step_exit_clean and step_sigkill open with an SES_ALIVE guard AND kill a
+# session inside it. Those guards are CORRECT: reset_session hands a new slot
+# the SAME tmux pane as an old one, so an already-retired slot NUMBER can alias
+# a pane a different, still-live slot now owns, and a recipe re-targeting the
+# old number must not tear the live session down.
+#
+# Teardown itself — the trap handler and the end-of-run sweep — is ungated, so
+# the file is clean. A rule keyed on "SES_ALIVE near a kill-session" would fail
+# this driver, and a finding against a driver that is right is the kind that
+# gets a rule ignored rather than fixed.
+set -euo pipefail
+_DRIVE_LIB="$(dirname "${BASH_SOURCE[0]}")/lib"
+source "$_DRIVE_LIB/slots.sh"
+
+SESSION=""
+SES_SESSION=()
+SES_CWD=()
+SES_ALIVE=()
+N_SLOTS=0
+ACTIVE=0
+EXIT_REASON="ok"
+REACHED_EPILOGUE=0
+RUN_CWD="$STAGING/cwd"
+
+cleanup() {
+  # The epilogue sets REACHED_EPILOGUE immediately before the final exit, so a
+  # handler that sees it unset knows the script aborted before forming a
+  # verdict and must not write EXIT_REASON's initialiser as one (INV-4).
+  if [[ "$REACHED_EPILOGUE" != "1" && "$EXIT_REASON" == "ok" ]]; then
+    EXIT_REASON="nonzero(2)"
+  fi
+  local i
+  for (( i = 1; i <= N_SLOTS; i++ )); do
+    [[ -n "${SES_SESSION[$i]:-}" ]] && tmux kill-session -t "${SES_SESSION[$i]}" 2>/dev/null || true
+  done
+  echo "$EXIT_REASON" > "$STAGING/driver.exit-reason"
+}
+trap cleanup EXIT
+
+launch_repl() {
+  alloc_slot "fixture-onboard-$(date +%s)-$$-r${ACTIVE}" "$RUN_CWD"
+  tmux new-session -d -s "$SESSION" -x 200 -y 50 -c "${SES_CWD[$ACTIVE]}" "fixture-agent"
+}
+
+step_exit_clean() {
+  if [[ "${SES_ALIVE[$ACTIVE]:-0}" != "1" ]]; then
+    echo "[driver] exit_clean[s$ACTIVE]: slot already retired -- refusing" >&2
+    return 0
+  fi
+  tmux send-keys -t "$SESSION" C-d
+  SES_ALIVE[$ACTIVE]=0
+}
+
+step_sigkill() {
+  if [[ "${SES_ALIVE[$ACTIVE]:-0}" == "1" ]]; then
+    tmux kill-session -t "$SESSION" 2>/dev/null || true
+    SES_ALIVE[$ACTIVE]=0
+  fi
+}
+
+launch_repl
+step_exit_clean
+step_sigkill
+
+# Tear down every session this run created.
+for (( i = 1; i <= N_SLOTS; i++ )); do
+  if [[ -n "${SES_SESSION[$i]:-}" ]]; then
+    tmux kill-session -t "${SES_SESSION[$i]}" 2>/dev/null || true
+  fi
+done
+
+# The epilogue completed: EXIT_REASON is this run's real verdict.
+REACHED_EPILOGUE=1

--- a/tools/onboarding-factory/internal/driverteardown/testdata/inv2_no_trap.sh
+++ b/tools/onboarding-factory/internal/driverteardown/testdata/inv2_no_trap.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# MUTATION — the committed proof that INV-2 goes red when a driver installs no
+# EXIT trap at all. This is aider's, and pre-#1825 claudecode's/codex's/pi's,
+# shape: the final kill-session is reached only when the script runs to the
+# bottom, so any `set -e` abort or early `exit` leaves the pane alive.
+set -euo pipefail
+SESSION="fixture-onboard-$(date +%s)-$$"
+RUN_CWD="$STAGING/cwd"
+
+tmux kill-session -t "$SESSION" 2>/dev/null || true
+tmux new-session -d -s "$SESSION" -c "$RUN_CWD" "fixture-agent"
+
+echo "[driver] running" >&2
+
+tmux kill-session -t "$SESSION" 2>/dev/null || true
+echo "ok" > "$STAGING/driver.exit-reason"

--- a/tools/onboarding-factory/internal/driverteardown/testdata/inv2_no_trap_no_sweep.sh
+++ b/tools/onboarding-factory/internal/driverteardown/testdata/inv2_no_trap_no_sweep.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# MUST BE FLAGGED (INV-2) AND MUST REFUSE (INV-1 graded nothing) — both at once,
+# and the INV-2 finding is the one that names the defect.
+#
+# hermes's shape with `trap cleanup EXIT` deleted. cleanup() still exists and
+# still kills, but nothing arms it, and hermes has no top-level end-of-run sweep
+# — the trap is its ONLY teardown. So INV-1 has no site to grade and refuses,
+# and a CheckDriver that returned `nil, err` threw the INV-2 finding away: the
+# gate went red naming INV-1, which is the consequence, not the cause.
+set -euo pipefail
+_DRIVE_LIB="$(dirname "${BASH_SOURCE[0]}")/lib"
+source "$_DRIVE_LIB/slots.sh"
+
+SESSION=""
+SES_SESSION=()
+SES_CWD=()
+SES_ALIVE=()
+N_SLOTS=0
+ACTIVE=0
+EXIT_REASON="ok"
+RUN_CWD="$STAGING/cwd"
+
+cleanup() {
+  local i
+  for (( i = 1; i <= N_SLOTS; i++ )); do
+    [[ -n "${SES_SESSION[$i]:-}" ]] && tmux kill-session -t "${SES_SESSION[$i]}" 2>/dev/null || true
+  done
+}
+
+launch_repl() {
+  alloc_slot "fixture-onboard-$(date +%s)-$$-$((N_SLOTS + 1))" "$RUN_CWD"
+  tmux new-session -d -s "$SESSION" -x 200 -y 50 -c "${SES_CWD[$ACTIVE]}" "fixture-agent"
+}
+
+step_exit_clean() {
+  tmux send-keys -t "$SESSION" C-d
+  SES_ALIVE[$ACTIVE]=0
+}
+
+launch_repl
+step_exit_clean

--- a/tools/onboarding-factory/internal/driverteardown/testdata/inv2_trap_without_teardown.sh
+++ b/tools/onboarding-factory/internal/driverteardown/testdata/inv2_trap_without_teardown.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# MUTATION — the committed proof that INV-2 goes red for a trap that ARMS but
+# tears nothing down. A trap that only writes driver.exit-reason satisfies a
+# grep for `trap … EXIT` while leaving exactly the leak INV-2 exists to stop,
+# so "there is a trap" and "the trap cleans up" must be different answers.
+set -euo pipefail
+SESSION="fixture-onboard-$(date +%s)-$$"
+RUN_CWD="$STAGING/cwd"
+EXIT_REASON="ok"
+REACHED_EPILOGUE=0
+
+cleanup() {
+  # The epilogue sets REACHED_EPILOGUE immediately before the final exit, so a
+  # handler that sees it unset knows the script aborted before forming a
+  # verdict and must not write EXIT_REASON's initialiser as one (INV-4).
+  if [[ "$REACHED_EPILOGUE" != "1" && "$EXIT_REASON" == "ok" ]]; then
+    EXIT_REASON="nonzero(2)"
+  fi
+  echo "$EXIT_REASON" > "$STAGING/driver.exit-reason"
+}
+trap cleanup EXIT
+
+tmux new-session -d -s "$SESSION" -c "$RUN_CWD" "fixture-agent"
+
+tmux kill-session -t "$SESSION" 2>/dev/null || true
+
+# The epilogue completed: EXIT_REASON is this run's real verdict.
+REACHED_EPILOGUE=1

--- a/tools/onboarding-factory/internal/driverteardown/testdata/inv3_alloc_arg2_bad.sh
+++ b/tools/onboarding-factory/internal/driverteardown/testdata/inv3_alloc_arg2_bad.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# MUTATION — the committed proof that INV-3's argument-position resolution is
+# DERIVED. This driver uses claudecode's private slot scheme, where alloc_slot
+# takes (uuid, tmux-name, cwd): the name is argument TWO. A checker that
+# assumed argument one would grade "$UUID" — an expansion, so nothing — and
+# report this file clean while the real name carries no PID at all.
+set -euo pipefail
+_DRIVE_LIB="$(dirname "${BASH_SOURCE[0]}")/lib"
+source "$_DRIVE_LIB/slots_pos2.sh"
+
+CURRENT_TMUX=""
+SES_TMUX=()
+SES_UUID=()
+SES_CWD=()
+N_SLOTS=0
+ACTIVE=0
+UUID="00000000-0000-0000-0000-000000000000"
+RUN_CWD="$STAGING/cwd"
+
+cleanup() {
+  local i
+  for (( i = 1; i <= N_SLOTS; i++ )); do
+    [[ -n "${SES_TMUX[$i]:-}" ]] && tmux kill-session -t "${SES_TMUX[$i]}" 2>/dev/null || true
+  done
+}
+trap cleanup EXIT
+
+alloc_slot "$UUID" "fixture-onboard-$(date +%s)" "$RUN_CWD"
+tmux new-session -d -s "$CURRENT_TMUX" -c "$CURRENT_CWD" -- "fixture-agent"

--- a/tools/onboarding-factory/internal/driverteardown/testdata/inv3_alloc_arg2_good.sh
+++ b/tools/onboarding-factory/internal/driverteardown/testdata/inv3_alloc_arg2_good.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# GOOD, claudecode's private slot scheme: alloc_slot takes (uuid, tmux-name,
+# cwd) and the name in argument TWO carries $$ as its own field. Paired with
+# inv3_alloc_arg2_bad.sh so the position-2 resolution is shown to grade BOTH
+# ways rather than merely never firing.
+set -euo pipefail
+_DRIVE_LIB="$(dirname "${BASH_SOURCE[0]}")/lib"
+source "$_DRIVE_LIB/slots_pos2.sh"
+
+CURRENT_TMUX=""
+SES_TMUX=()
+SES_UUID=()
+SES_CWD=()
+N_SLOTS=0
+ACTIVE=0
+UUID="00000000-0000-0000-0000-000000000000"
+RUN_CWD="$STAGING/cwd"
+
+cleanup() {
+  local i
+  for (( i = 1; i <= N_SLOTS; i++ )); do
+    [[ -n "${SES_TMUX[$i]:-}" ]] && tmux kill-session -t "${SES_TMUX[$i]}" 2>/dev/null || true
+  done
+}
+trap cleanup EXIT
+
+alloc_slot "$UUID" "fixture-onboard-$(date +%s)-$$" "$RUN_CWD"
+tmux new-session -d -s "$CURRENT_TMUX" -c "$CURRENT_CWD" -- "fixture-agent"

--- a/tools/onboarding-factory/internal/driverteardown/testdata/inv3_glued_pid.sh
+++ b/tools/onboarding-factory/internal/driverteardown/testdata/inv3_glued_pid.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# MUTATION — the committed proof that INV-3 goes red for a $$ that is present
+# but GLUED to another token instead of standing as its own `-`-delimited
+# field. run-cell.sh splits a session name on `-` and compares fields, so
+# `fixture-onboard12345-...` does not match pid 12345 — and worse, a name
+# ending in a longer number whose tail happens to be the pid would match a
+# DIFFERENT run's. Substring-matching a pid is not attribution.
+set -euo pipefail
+_DRIVE_LIB="$(dirname "${BASH_SOURCE[0]}")/lib"
+source "$_DRIVE_LIB/slots.sh"
+
+SESSION=""
+SES_SESSION=()
+SES_CWD=()
+SES_ALIVE=()
+N_SLOTS=0
+ACTIVE=0
+RUN_CWD="$STAGING/cwd"
+
+cleanup() {
+  local i
+  for (( i = 1; i <= N_SLOTS; i++ )); do
+    [[ -n "${SES_SESSION[$i]:-}" ]] && tmux kill-session -t "${SES_SESSION[$i]}" 2>/dev/null || true
+  done
+}
+trap cleanup EXIT
+
+alloc_slot "fixture-onboard$$-$(date +%s)" "$RUN_CWD"
+tmux new-session -d -s "$SESSION" -c "${SES_CWD[$ACTIVE]}" "fixture-agent"

--- a/tools/onboarding-factory/internal/driverteardown/testdata/inv3_no_pid.sh
+++ b/tools/onboarding-factory/internal/driverteardown/testdata/inv3_no_pid.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# MUTATION — the committed proof that INV-3 goes red for a session name that
+# carries no driver PID. run-cell.sh keeps no record of the names a driver
+# chose, so a name without $$ cannot be attributed to the run that made it and
+# the post-run leak assertion has nothing to match on.
+set -euo pipefail
+_DRIVE_LIB="$(dirname "${BASH_SOURCE[0]}")/lib"
+source "$_DRIVE_LIB/slots.sh"
+
+SESSION=""
+SES_SESSION=()
+SES_CWD=()
+SES_ALIVE=()
+N_SLOTS=0
+ACTIVE=0
+RUN_CWD="$STAGING/cwd"
+
+cleanup() {
+  local i
+  for (( i = 1; i <= N_SLOTS; i++ )); do
+    [[ -n "${SES_SESSION[$i]:-}" ]] && tmux kill-session -t "${SES_SESSION[$i]}" 2>/dev/null || true
+  done
+}
+trap cleanup EXIT
+
+alloc_slot "fixture-onboard-$(date +%s)" "$RUN_CWD"
+tmux new-session -d -s "$SESSION" -c "${SES_CWD[$ACTIVE]}" "fixture-agent"

--- a/tools/onboarding-factory/internal/driverteardown/testdata/inv3_shadowed_alloc_slot_bad.sh
+++ b/tools/onboarding-factory/internal/driverteardown/testdata/inv3_shadowed_alloc_slot_bad.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# MUST BE FLAGGED (INV-3, once) — the shadowed-`alloc_slot` collision, with
+# the arg-2 name genuinely missing its `$$`.
+#
+# This driver defines its OWN alloc_slot, whose tmux session name is the SECOND
+# argument (claudecode's private slot scheme). It does NOT source slots.sh — but
+# LoadDriver globs the whole _lib/drive directory and hands every adapter every
+# file in it, so the shared alloc_slot, whose name is the FIRST argument, is
+# parsed alongside this driver regardless.
+#
+# The line that lights the collision is `SESSION="$CURRENT_TMUX"` below: it
+# makes SESSION name-carrying, slots.sh assigns SESSION="$sess", so slots.sh's
+# `local sess="$1"` marks argument position 1 as name-carrying — under a
+# `pos` map keyed by BARE FUNCTION NAME, on the same key this driver's own
+# alloc_slot uses for position 2. Both positions end up marked, and the literal
+# at position 1 is graded as a session name.
+set -euo pipefail
+
+SESSION=""
+SES_UUID=()
+SES_TMUX=()
+SES_CWD=()
+SES_ALIVE=()
+N_SLOTS=0
+ACTIVE=0
+CURRENT_UUID=""
+CURRENT_TMUX=""
+EXIT_REASON="ok"
+REACHED_EPILOGUE=0
+RUN_CWD="$STAGING/cwd"
+
+alloc_slot() {
+  N_SLOTS=$((N_SLOTS + 1))
+  SES_UUID[$N_SLOTS]="$1"
+  SES_TMUX[$N_SLOTS]="$2"
+  SES_CWD[$N_SLOTS]="$3"
+  SES_ALIVE[$N_SLOTS]=1
+  ACTIVE=$N_SLOTS
+  CURRENT_UUID="$1"
+  CURRENT_TMUX="$2"
+}
+
+cleanup() {
+  if [[ "$REACHED_EPILOGUE" != "1" && "$EXIT_REASON" == "ok" ]]; then
+    EXIT_REASON="nonzero(2)"
+  fi
+  local i
+  for (( i = 1; i <= N_SLOTS; i++ )); do
+    [[ -n "${SES_TMUX[$i]:-}" ]] && tmux kill-session -t "${SES_TMUX[$i]}" 2>/dev/null || true
+  done
+  echo "$EXIT_REASON" > "$STAGING/driver.exit-reason"
+}
+trap cleanup EXIT
+
+launch_repl() {
+  alloc_slot "fixture-uuid-0000" "fixture-onboard-$(date +%s)-r${ACTIVE}" "$RUN_CWD"
+  # Legacy alias every step below still reads.
+  SESSION="$CURRENT_TMUX"
+  tmux new-session -d -s "$CURRENT_TMUX" -x 200 -y 50 -c "${SES_CWD[$ACTIVE]}" "fixture-agent"
+}
+
+launch_repl
+
+# Tear down every session this run created.
+for (( i = 1; i <= N_SLOTS; i++ )); do
+  if [[ -n "${SES_TMUX[$i]:-}" ]]; then
+    tmux kill-session -t "${SES_TMUX[$i]}" 2>/dev/null || true
+  fi
+done
+
+# The epilogue completed: EXIT_REASON is this run's real verdict.
+REACHED_EPILOGUE=1

--- a/tools/onboarding-factory/internal/driverteardown/testdata/inv3_shadowed_alloc_slot_ok.sh
+++ b/tools/onboarding-factory/internal/driverteardown/testdata/inv3_shadowed_alloc_slot_ok.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# MUST NOT BE FLAGGED — the shadowed-`alloc_slot` collision.
+#
+# This driver defines its OWN alloc_slot, whose tmux session name is the SECOND
+# argument (claudecode's private slot scheme). It does NOT source slots.sh — but
+# LoadDriver globs the whole _lib/drive directory and hands every adapter every
+# file in it, so the shared alloc_slot, whose name is the FIRST argument, is
+# parsed alongside this driver regardless.
+#
+# The line that lights the collision is `SESSION="$CURRENT_TMUX"` below: it
+# makes SESSION name-carrying, slots.sh assigns SESSION="$sess", so slots.sh's
+# `local sess="$1"` marks argument position 1 as name-carrying — under a
+# `pos` map keyed by BARE FUNCTION NAME, on the same key this driver's own
+# alloc_slot uses for position 2. Both positions end up marked, and the literal
+# at position 1 is graded as a session name.
+set -euo pipefail
+
+SESSION=""
+SES_UUID=()
+SES_TMUX=()
+SES_CWD=()
+SES_ALIVE=()
+N_SLOTS=0
+ACTIVE=0
+CURRENT_UUID=""
+CURRENT_TMUX=""
+EXIT_REASON="ok"
+REACHED_EPILOGUE=0
+RUN_CWD="$STAGING/cwd"
+
+alloc_slot() {
+  N_SLOTS=$((N_SLOTS + 1))
+  SES_UUID[$N_SLOTS]="$1"
+  SES_TMUX[$N_SLOTS]="$2"
+  SES_CWD[$N_SLOTS]="$3"
+  SES_ALIVE[$N_SLOTS]=1
+  ACTIVE=$N_SLOTS
+  CURRENT_UUID="$1"
+  CURRENT_TMUX="$2"
+}
+
+cleanup() {
+  if [[ "$REACHED_EPILOGUE" != "1" && "$EXIT_REASON" == "ok" ]]; then
+    EXIT_REASON="nonzero(2)"
+  fi
+  local i
+  for (( i = 1; i <= N_SLOTS; i++ )); do
+    [[ -n "${SES_TMUX[$i]:-}" ]] && tmux kill-session -t "${SES_TMUX[$i]}" 2>/dev/null || true
+  done
+  echo "$EXIT_REASON" > "$STAGING/driver.exit-reason"
+}
+trap cleanup EXIT
+
+launch_repl() {
+  alloc_slot "fixture-uuid-0000" "fixture-onboard-$(date +%s)-$$-r${ACTIVE}" "$RUN_CWD"
+  # Legacy alias every step below still reads.
+  SESSION="$CURRENT_TMUX"
+  tmux new-session -d -s "$CURRENT_TMUX" -x 200 -y 50 -c "${SES_CWD[$ACTIVE]}" "fixture-agent"
+}
+
+launch_repl
+
+# Tear down every session this run created.
+for (( i = 1; i <= N_SLOTS; i++ )); do
+  if [[ -n "${SES_TMUX[$i]:-}" ]]; then
+    tmux kill-session -t "${SES_TMUX[$i]}" 2>/dev/null || true
+  fi
+done
+
+# The epilogue completed: EXIT_REASON is this run's real verdict.
+REACHED_EPILOGUE=1

--- a/tools/onboarding-factory/internal/driverteardown/testdata/inv4_case_arm_is_not_the_epilogue.sh
+++ b/tools/onboarding-factory/internal/driverteardown/testdata/inv4_case_arm_is_not_the_epilogue.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# MUTATION of good_driver.sh — the committed regression fixture for a FALSE
+# PASS this checker actually had, caught by measuring rather than by reasoning.
+#
+# INV-4's second shape (fail-closed) asks whether the verdict variable is
+# re-assigned by an UNCONDITIONAL TOP-LEVEL statement after the trap arms. The
+# first implementation read "unconditional" as "no enclosing `if`", and every
+# one of the eleven shipped drivers has an `EXIT_REASON="nonzero(2)"` inside a
+# `case` arm in its step loop — no `if` anywhere near it. So all ten bound
+# drivers passed INV-4 on a fail-closed reading they had not earned, and the
+# guard branch was never reached. The invariant was live and grading nothing.
+#
+# This fixture is that shape with the guard removed: the ONLY re-assignment of
+# EXIT_REASON after the trap is inside a `case` arm, which runs on some paths
+# and not others, so an abort still writes the initialiser. It must be RED.
+_DRIVE_LIB="$(dirname "${BASH_SOURCE[0]}")/lib"
+source "$_DRIVE_LIB/slots.sh"
+
+SESSION=""
+SES_SESSION=()
+SES_CWD=()
+SES_ALIVE=()
+N_SLOTS=0
+ACTIVE=0
+EXIT_REASON="ok"
+RUN_CWD="$STAGING/cwd"
+
+cleanup() {
+  local i
+  for (( i = 1; i <= N_SLOTS; i++ )); do
+    [[ -n "${SES_SESSION[$i]:-}" ]] && tmux kill-session -t "${SES_SESSION[$i]}" 2>/dev/null || true
+  done
+  echo "$EXIT_REASON" > "$STAGING/driver.exit-reason"
+}
+trap cleanup EXIT
+
+launch_repl() {
+  alloc_slot "fixture-onboard-$(date +%s)-$$-$((N_SLOTS + 1))" "$RUN_CWD"
+  tmux kill-session -t "$SESSION" 2>/dev/null || true
+  tmux new-session -d -s "$SESSION" -x 200 -y 50 -c "${SES_CWD[$ACTIVE]}" "fixture-agent"
+}
+
+step_exit_clean() {
+  tmux send-keys -t "$SESSION" C-d
+  SES_ALIVE[$ACTIVE]=0
+}
+
+launch_repl
+step_exit_clean
+
+# Tear down every session this run created.
+for (( i = 1; i <= N_SLOTS; i++ )); do
+  if [[ -n "${SES_SESSION[$i]:-}" ]]; then
+    tmux kill-session -t "${SES_SESSION[$i]}" 2>/dev/null || true
+  fi
+done
+
+# The step loop's fault arm. It is at top level and has no enclosing `if`, but
+# it runs only on the paths that reach it — it is not the epilogue.
+case "$STEP_KIND" in
+  known)   : ;;
+  *)       EXIT_REASON="nonzero(2)" ;;
+esac

--- a/tools/onboarding-factory/internal/driverteardown/testdata/inv4_fail_closed_ok.sh
+++ b/tools/onboarding-factory/internal/driverteardown/testdata/inv4_fail_closed_ok.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# MUST NOT BE FLAGGED — a driver that legitimately writes a verdict it did
+# form, by the OTHER correct design. EXIT_REASON starts at a fault and the
+# epilogue promotes it to `ok` on the success path, so an unconditional handler
+# write is already honest: an abort writes `nonzero(2)`, a completed run writes
+# `ok`, and the two are different bytes. There is no sentinel and no guard.
+#
+# This row is what stops INV-4 prescribing one implementation. A rule that
+# demanded aider's guard would fail this driver, which is strictly correct.
+_DRIVE_LIB="$(dirname "${BASH_SOURCE[0]}")/lib"
+source "$_DRIVE_LIB/slots.sh"
+
+SESSION=""
+SES_SESSION=()
+SES_CWD=()
+SES_ALIVE=()
+N_SLOTS=0
+ACTIVE=0
+EXIT_REASON="nonzero(2)"
+RUN_CWD="$STAGING/cwd"
+
+cleanup() {
+  local i
+  for (( i = 1; i <= N_SLOTS; i++ )); do
+    [[ -n "${SES_SESSION[$i]:-}" ]] && tmux kill-session -t "${SES_SESSION[$i]}" 2>/dev/null || true
+  done
+  echo "$EXIT_REASON" > "$STAGING/driver.exit-reason"
+}
+trap cleanup EXIT
+
+launch_repl() {
+  alloc_slot "fixture-onboard-$(date +%s)-$$-$((N_SLOTS + 1))" "$RUN_CWD"
+  tmux kill-session -t "$SESSION" 2>/dev/null || true
+  tmux new-session -d -s "$SESSION" -x 200 -y 50 -c "${SES_CWD[$ACTIVE]}" "fixture-agent"
+}
+
+step_exit_clean() {
+  tmux send-keys -t "$SESSION" C-d
+  SES_ALIVE[$ACTIVE]=0
+}
+
+launch_repl
+step_exit_clean
+
+# Tear down every session this run created.
+for (( i = 1; i <= N_SLOTS; i++ )); do
+  if [[ -n "${SES_SESSION[$i]:-}" ]]; then
+    tmux kill-session -t "${SES_SESSION[$i]}" 2>/dev/null || true
+  fi
+done
+
+# The epilogue completed with no fault: promote the fail-closed initialiser to
+# this run's real verdict. cleanup() writes whatever is here.
+EXIT_REASON="ok"

--- a/tools/onboarding-factory/internal/driverteardown/testdata/inv4_guard_consults_only_itself.sh
+++ b/tools/onboarding-factory/internal/driverteardown/testdata/inv4_guard_consults_only_itself.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# MUTATION of good_driver.sh — the committed proof that INV-4 is not satisfied
+# by a guard SHAPE. This handler has a conditional, and it re-assigns
+# EXIT_REASON, so a rule that only asked "is the write guarded" would pass it.
+# The condition consults nothing but EXIT_REASON itself, which is equally true
+# of a run that completed successfully: every green run would be rewritten as a
+# driver fault. A guard has to consult run PROGRESS, not the verdict.
+_DRIVE_LIB="$(dirname "${BASH_SOURCE[0]}")/lib"
+source "$_DRIVE_LIB/slots.sh"
+
+SESSION=""
+SES_SESSION=()
+SES_CWD=()
+SES_ALIVE=()
+N_SLOTS=0
+ACTIVE=0
+EXIT_REASON="ok"
+REACHED_EPILOGUE=0
+RUN_CWD="$STAGING/cwd"
+
+cleanup() {
+  # The epilogue sets REACHED_EPILOGUE immediately before the final exit, so a
+  # handler that sees it unset knows the script aborted before forming a
+  # verdict and must not write EXIT_REASON's initialiser as one (INV-4).
+  if [[ "$EXIT_REASON" == "ok" ]]; then
+    EXIT_REASON="nonzero(2)"
+  fi
+  local i
+  for (( i = 1; i <= N_SLOTS; i++ )); do
+    [[ -n "${SES_SESSION[$i]:-}" ]] && tmux kill-session -t "${SES_SESSION[$i]}" 2>/dev/null || true
+  done
+  echo "$EXIT_REASON" > "$STAGING/driver.exit-reason"
+}
+trap cleanup EXIT
+
+launch_repl() {
+  alloc_slot "fixture-onboard-$(date +%s)-$$-$((N_SLOTS + 1))" "$RUN_CWD"
+  tmux kill-session -t "$SESSION" 2>/dev/null || true
+  tmux new-session -d -s "$SESSION" -x 200 -y 50 -c "${SES_CWD[$ACTIVE]}" "fixture-agent"
+}
+
+step_exit_clean() {
+  tmux send-keys -t "$SESSION" C-d
+  SES_ALIVE[$ACTIVE]=0
+}
+
+launch_repl
+step_exit_clean
+
+# Tear down every session this run created.
+for (( i = 1; i <= N_SLOTS; i++ )); do
+  if [[ -n "${SES_SESSION[$i]:-}" ]]; then
+    tmux kill-session -t "${SES_SESSION[$i]}" 2>/dev/null || true
+  fi
+done
+
+# The epilogue completed: EXIT_REASON is this run's real verdict.
+REACHED_EPILOGUE=1

--- a/tools/onboarding-factory/internal/driverteardown/testdata/inv4_guard_reassigns_initial.sh
+++ b/tools/onboarding-factory/internal/driverteardown/testdata/inv4_guard_reassigns_initial.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# MUTATION of good_driver.sh — the committed proof that INV-4 grades the VALUE
+# the guard produces, not merely that a guard ran. The sentinel is real and the
+# epilogue sets it, but the guard assigns EXIT_REASON its own initialiser, so
+# the bytes written on an abort are identical to the bytes written by a
+# completed run. A no-op guard is not a guard.
+_DRIVE_LIB="$(dirname "${BASH_SOURCE[0]}")/lib"
+source "$_DRIVE_LIB/slots.sh"
+
+SESSION=""
+SES_SESSION=()
+SES_CWD=()
+SES_ALIVE=()
+N_SLOTS=0
+ACTIVE=0
+EXIT_REASON="ok"
+REACHED_EPILOGUE=0
+RUN_CWD="$STAGING/cwd"
+
+cleanup() {
+  # The epilogue sets REACHED_EPILOGUE immediately before the final exit, so a
+  # handler that sees it unset knows the script aborted before forming a
+  # verdict and must not write EXIT_REASON's initialiser as one (INV-4).
+  if [[ "$REACHED_EPILOGUE" != "1" && "$EXIT_REASON" == "ok" ]]; then
+    EXIT_REASON="ok"
+  fi
+  local i
+  for (( i = 1; i <= N_SLOTS; i++ )); do
+    [[ -n "${SES_SESSION[$i]:-}" ]] && tmux kill-session -t "${SES_SESSION[$i]}" 2>/dev/null || true
+  done
+  echo "$EXIT_REASON" > "$STAGING/driver.exit-reason"
+}
+trap cleanup EXIT
+
+launch_repl() {
+  alloc_slot "fixture-onboard-$(date +%s)-$$-$((N_SLOTS + 1))" "$RUN_CWD"
+  tmux kill-session -t "$SESSION" 2>/dev/null || true
+  tmux new-session -d -s "$SESSION" -x 200 -y 50 -c "${SES_CWD[$ACTIVE]}" "fixture-agent"
+}
+
+step_exit_clean() {
+  tmux send-keys -t "$SESSION" C-d
+  SES_ALIVE[$ACTIVE]=0
+}
+
+launch_repl
+step_exit_clean
+
+# Tear down every session this run created.
+for (( i = 1; i <= N_SLOTS; i++ )); do
+  if [[ -n "${SES_SESSION[$i]:-}" ]]; then
+    tmux kill-session -t "${SES_SESSION[$i]}" 2>/dev/null || true
+  fi
+done
+
+# The epilogue completed: EXIT_REASON is this run's real verdict.
+REACHED_EPILOGUE=1

--- a/tools/onboarding-factory/internal/driverteardown/testdata/inv4_literal_verdict_ok.sh
+++ b/tools/onboarding-factory/internal/driverteardown/testdata/inv4_literal_verdict_ok.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# MUST NOT BE FLAGGED — INV-4's precondition is DERIVED, and this handler does
+# not meet it. It writes a literal fault verdict rather than a variable, so
+# there is no initial value for the write to be stale at: every abort path
+# records the same explicit fault, and the epilogue writes the real verdict
+# itself. Exempt because of what the source says, not because of a list.
+_DRIVE_LIB="$(dirname "${BASH_SOURCE[0]}")/lib"
+source "$_DRIVE_LIB/slots.sh"
+
+SESSION=""
+SES_SESSION=()
+SES_CWD=()
+SES_ALIVE=()
+N_SLOTS=0
+ACTIVE=0
+EXIT_REASON="ok"
+REACHED_EPILOGUE=0
+RUN_CWD="$STAGING/cwd"
+
+cleanup() {
+  local i
+  for (( i = 1; i <= N_SLOTS; i++ )); do
+    [[ -n "${SES_SESSION[$i]:-}" ]] && tmux kill-session -t "${SES_SESSION[$i]}" 2>/dev/null || true
+  done
+  echo "nonzero(2)" > "$STAGING/driver.exit-reason"
+}
+trap cleanup EXIT
+
+launch_repl() {
+  alloc_slot "fixture-onboard-$(date +%s)-$$-$((N_SLOTS + 1))" "$RUN_CWD"
+  tmux kill-session -t "$SESSION" 2>/dev/null || true
+  tmux new-session -d -s "$SESSION" -x 200 -y 50 -c "${SES_CWD[$ACTIVE]}" "fixture-agent"
+}
+
+step_exit_clean() {
+  tmux send-keys -t "$SESSION" C-d
+  SES_ALIVE[$ACTIVE]=0
+}
+
+launch_repl
+step_exit_clean
+
+# Tear down every session this run created.
+for (( i = 1; i <= N_SLOTS; i++ )); do
+  if [[ -n "${SES_SESSION[$i]:-}" ]]; then
+    tmux kill-session -t "${SES_SESSION[$i]}" 2>/dev/null || true
+  fi
+done
+
+# The epilogue writes the real verdict itself, over whatever the trap recorded.
+echo "$EXIT_REASON" > "$STAGING/driver.exit-reason"

--- a/tools/onboarding-factory/internal/driverteardown/testdata/inv4_renamed_sentinel_ok.sh
+++ b/tools/onboarding-factory/internal/driverteardown/testdata/inv4_renamed_sentinel_ok.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# MUST NOT BE FLAGGED — the sentinel idiom spelled with a different variable
+# name throughout. INV-4 matches no variable name at all: it looks for an
+# unconditional top-level assignment placed after the trap arms and after the
+# last `tmux new-session`, which is what "the epilogue set it" looks like with
+# the names removed. If this row ever went red, the rule would have quietly
+# become a check on aider's spelling rather than on the property.
+_DRIVE_LIB="$(dirname "${BASH_SOURCE[0]}")/lib"
+source "$_DRIVE_LIB/slots.sh"
+
+SESSION=""
+SES_SESSION=()
+SES_CWD=()
+SES_ALIVE=()
+N_SLOTS=0
+ACTIVE=0
+EXIT_REASON="ok"
+DRIVER_RAN_TO_COMPLETION=0
+RUN_CWD="$STAGING/cwd"
+
+cleanup() {
+  # The epilogue sets DRIVER_RAN_TO_COMPLETION immediately before the final exit, so a
+  # handler that sees it unset knows the script aborted before forming a
+  # verdict and must not write EXIT_REASON's initialiser as one (INV-4).
+  if [[ "$DRIVER_RAN_TO_COMPLETION" != "1" && "$EXIT_REASON" == "ok" ]]; then
+    EXIT_REASON="nonzero(2)"
+  fi
+  local i
+  for (( i = 1; i <= N_SLOTS; i++ )); do
+    [[ -n "${SES_SESSION[$i]:-}" ]] && tmux kill-session -t "${SES_SESSION[$i]}" 2>/dev/null || true
+  done
+  echo "$EXIT_REASON" > "$STAGING/driver.exit-reason"
+}
+trap cleanup EXIT
+
+launch_repl() {
+  alloc_slot "fixture-onboard-$(date +%s)-$$-$((N_SLOTS + 1))" "$RUN_CWD"
+  tmux kill-session -t "$SESSION" 2>/dev/null || true
+  tmux new-session -d -s "$SESSION" -x 200 -y 50 -c "${SES_CWD[$ACTIVE]}" "fixture-agent"
+}
+
+step_exit_clean() {
+  tmux send-keys -t "$SESSION" C-d
+  SES_ALIVE[$ACTIVE]=0
+}
+
+launch_repl
+step_exit_clean
+
+# Tear down every session this run created.
+for (( i = 1; i <= N_SLOTS; i++ )); do
+  if [[ -n "${SES_SESSION[$i]:-}" ]]; then
+    tmux kill-session -t "${SES_SESSION[$i]}" 2>/dev/null || true
+  fi
+done
+
+# The epilogue completed: EXIT_REASON is this run's real verdict.
+DRIVER_RAN_TO_COMPLETION=1

--- a/tools/onboarding-factory/internal/driverteardown/testdata/inv4_sentinel_never_set.sh
+++ b/tools/onboarding-factory/internal/driverteardown/testdata/inv4_sentinel_never_set.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# MUTATION of good_driver.sh — the committed proof that INV-4 cannot be
+# satisfied by DECLARING a sentinel. Everything is in place except the one
+# assignment that carries the meaning: REACHED_EPILOGUE is initialised in the
+# prologue and never set again, so the guard's condition is a constant and no
+# amount of progress through the run can change what the handler writes. This
+# is the shape a rule that matched the sentinel's NAME would have passed.
+_DRIVE_LIB="$(dirname "${BASH_SOURCE[0]}")/lib"
+source "$_DRIVE_LIB/slots.sh"
+
+SESSION=""
+SES_SESSION=()
+SES_CWD=()
+SES_ALIVE=()
+N_SLOTS=0
+ACTIVE=0
+EXIT_REASON="ok"
+REACHED_EPILOGUE=0
+RUN_CWD="$STAGING/cwd"
+
+cleanup() {
+  # The epilogue sets REACHED_EPILOGUE immediately before the final exit, so a
+  # handler that sees it unset knows the script aborted before forming a
+  # verdict and must not write EXIT_REASON's initialiser as one (INV-4).
+  if [[ "$REACHED_EPILOGUE" != "1" && "$EXIT_REASON" == "ok" ]]; then
+    EXIT_REASON="nonzero(2)"
+  fi
+  local i
+  for (( i = 1; i <= N_SLOTS; i++ )); do
+    [[ -n "${SES_SESSION[$i]:-}" ]] && tmux kill-session -t "${SES_SESSION[$i]}" 2>/dev/null || true
+  done
+  echo "$EXIT_REASON" > "$STAGING/driver.exit-reason"
+}
+trap cleanup EXIT
+
+launch_repl() {
+  alloc_slot "fixture-onboard-$(date +%s)-$$-$((N_SLOTS + 1))" "$RUN_CWD"
+  tmux kill-session -t "$SESSION" 2>/dev/null || true
+  tmux new-session -d -s "$SESSION" -x 200 -y 50 -c "${SES_CWD[$ACTIVE]}" "fixture-agent"
+}
+
+step_exit_clean() {
+  tmux send-keys -t "$SESSION" C-d
+  SES_ALIVE[$ACTIVE]=0
+}
+
+launch_repl
+step_exit_clean
+
+# Tear down every session this run created.
+for (( i = 1; i <= N_SLOTS; i++ )); do
+  if [[ -n "${SES_SESSION[$i]:-}" ]]; then
+    tmux kill-session -t "${SES_SESSION[$i]}" 2>/dev/null || true
+  fi
+done
+

--- a/tools/onboarding-factory/internal/driverteardown/testdata/inv4_unconditional_write.sh
+++ b/tools/onboarding-factory/internal/driverteardown/testdata/inv4_unconditional_write.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# MUTATION of good_driver.sh — the committed proof that INV-4 goes red for the
+# bug this invariant was added for. The handler is the naive one that satisfies
+# INV-2 perfectly: it tears the session down and writes the verdict file. What
+# it does NOT do is distinguish "the script finished and EXIT_REASON is its
+# verdict" from "the script aborted before forming one", so an abort writes the
+# initialiser `ok` where, before any trap existed, it wrote nothing at all and
+# run-cell.sh:443 read the absence as `unknown`.
+_DRIVE_LIB="$(dirname "${BASH_SOURCE[0]}")/lib"
+source "$_DRIVE_LIB/slots.sh"
+
+SESSION=""
+SES_SESSION=()
+SES_CWD=()
+SES_ALIVE=()
+N_SLOTS=0
+ACTIVE=0
+EXIT_REASON="ok"
+RUN_CWD="$STAGING/cwd"
+
+cleanup() {
+  local i
+  for (( i = 1; i <= N_SLOTS; i++ )); do
+    [[ -n "${SES_SESSION[$i]:-}" ]] && tmux kill-session -t "${SES_SESSION[$i]}" 2>/dev/null || true
+  done
+  echo "$EXIT_REASON" > "$STAGING/driver.exit-reason"
+}
+trap cleanup EXIT
+
+launch_repl() {
+  alloc_slot "fixture-onboard-$(date +%s)-$$-$((N_SLOTS + 1))" "$RUN_CWD"
+  tmux kill-session -t "$SESSION" 2>/dev/null || true
+  tmux new-session -d -s "$SESSION" -x 200 -y 50 -c "${SES_CWD[$ACTIVE]}" "fixture-agent"
+}
+
+step_exit_clean() {
+  tmux send-keys -t "$SESSION" C-d
+  SES_ALIVE[$ACTIVE]=0
+}
+
+launch_repl
+step_exit_clean
+
+# Tear down every session this run created.
+for (( i = 1; i <= N_SLOTS; i++ )); do
+  if [[ -n "${SES_SESSION[$i]:-}" ]]; then
+    tmux kill-session -t "${SES_SESSION[$i]}" 2>/dev/null || true
+  fi
+done

--- a/tools/onboarding-factory/internal/driverteardown/testdata/lib/slots.sh
+++ b/tools/onboarding-factory/internal/driverteardown/testdata/lib/slots.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Fixture stand-in for replaydata/_lib/drive/slots.sh. Only the part the
+# checker's dataflow walks is kept: alloc_slot takes the tmux session NAME as
+# its FIRST argument and lands it on both the slot array and the view var.
+# Nothing here is executed — the fixtures are read, never run.
+
+alloc_slot() {
+  local sess="$1" cwd="$2"
+  N_SLOTS=$((N_SLOTS + 1))
+  SES_SESSION[$N_SLOTS]="$sess"
+  SES_CWD[$N_SLOTS]="$cwd"
+  SES_ALIVE[$N_SLOTS]=1
+  ACTIVE=$N_SLOTS
+  SESSION="$sess"
+}

--- a/tools/onboarding-factory/internal/driverteardown/testdata/lib/slots_pos2.sh
+++ b/tools/onboarding-factory/internal/driverteardown/testdata/lib/slots_pos2.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Fixture stand-in for claudecode's PRIVATE slot scheme, where alloc_slot's
+# signature is (uuid, tmux-name, cwd) — the name is the SECOND argument, not
+# the first. It exists so the INV-3 dataflow is proved to DERIVE the
+# name-carrying argument position rather than assuming position 1.
+
+alloc_slot() {
+  N_SLOTS=$((N_SLOTS + 1))
+  SES_UUID[$N_SLOTS]="$1"
+  SES_TMUX[$N_SLOTS]="$2"
+  SES_CWD[$N_SLOTS]="$3"
+  ACTIVE=$N_SLOTS
+  CURRENT_UUID="$1"
+  CURRENT_TMUX="$2"
+  CURRENT_CWD="$3"
+}

--- a/tools/onboarding-factory/internal/driverteardown/testdata/no_tmux_exempt.sh
+++ b/tools/onboarding-factory/internal/driverteardown/testdata/no_tmux_exempt.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# EXEMPT — a headless driver that launches no tmux session at all. The
+# exemption is DERIVED (no `tmux new-session` in the file), never listed, so an
+# adapter that adds a tmux launch tomorrow starts being graded on that edit
+# rather than on someone remembering this package. The non-empty check is what
+# keeps this from also covering "the file could not be read".
+set -euo pipefail
+SESSION_ID=""
+RUN_CWD="$STAGING/cwd"
+
+send_prompt() {
+  fixture-agent run --cwd "$RUN_CWD" --session "$SESSION_ID" "$1"
+}
+
+send_prompt "hello"
+echo "ok" > "$STAGING/driver.exit-reason"

--- a/tools/onboarding-factory/internal/driverteardown/testdata/quote_multiline_awk_ok.sh
+++ b/tools/onboarding-factory/internal/driverteardown/testdata/quote_multiline_awk_ok.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# MUST NOT BE FLAGGED, AND MUST PARSE — mistral-vibe's shape, and the reason the
+# line-joiner exists at all. The `awk '…'` program spans lines, its braces are
+# DATA rather than shell blocks, and it carries awk comments of its own. Without
+# the join the braces are counted as blocks and the whole file is reported
+# unreadable; with a `#` rule the joiner and the word scanner do not share, an
+# awk comment could end the join early. This is a LOCK: it passed before the
+# shellsource.go fix and must keep passing after it.
+set -euo pipefail
+_DRIVE_LIB="$(dirname "${BASH_SOURCE[0]}")/lib"
+source "$_DRIVE_LIB/slots.sh"
+
+SESSION=""
+SES_SESSION=()
+SES_CWD=()
+SES_ALIVE=()
+N_SLOTS=0
+ACTIVE=0
+EXIT_REASON="ok"
+REACHED_EPILOGUE=0
+RUN_CWD="$STAGING/cwd"
+
+cleanup() {
+  if [[ "$REACHED_EPILOGUE" != "1" && "$EXIT_REASON" == "ok" ]]; then
+    EXIT_REASON="nonzero(2)"
+  fi
+  local i
+  for (( i = 1; i <= N_SLOTS; i++ )); do
+    [[ -n "${SES_SESSION[$i]:-}" ]] && tmux kill-session -t "${SES_SESSION[$i]}" 2>/dev/null || true
+  done
+  echo "$EXIT_REASON" > "$STAGING/driver.exit-reason"
+}
+trap cleanup EXIT
+
+turn_count() {
+  tmux capture-pane -p -t "$SESSION" | awk '
+    # awk comment, inside the quotes: the braces below are DATA
+    /^> / { n += 1 }
+    END   { print n + 0 }
+  '
+}
+
+launch_repl() {
+  alloc_slot "fixture-onboard-$(date +%s)-$$-$((N_SLOTS + 1))" "$RUN_CWD"
+  tmux new-session -d -s "$SESSION" -x 200 -y 50 -c "${SES_CWD[$ACTIVE]}" "fixture-agent"
+}
+
+launch_repl
+turn_count
+
+# Tear down every session this run created.
+for (( i = 1; i <= N_SLOTS; i++ )); do
+  if [[ -n "${SES_SESSION[$i]:-}" ]]; then
+    tmux kill-session -t "${SES_SESSION[$i]}" 2>/dev/null || true
+  fi
+done
+
+# The epilogue completed: EXIT_REASON is this run's real verdict.
+REACHED_EPILOGUE=1

--- a/tools/onboarding-factory/internal/driverteardown/testdata/vacuous_no_teardown.sh
+++ b/tools/onboarding-factory/internal/driverteardown/testdata/vacuous_no_teardown.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# VACUITY — launches a tmux session and never kills one anywhere. INV-1 has no
+# teardown site to grade here, and "every teardown site is ungated" must not be
+# the answer a driver with NO teardown site gets: absence of a finding and
+# inability to look have to be different outputs. This must ERROR, not pass.
+set -euo pipefail
+SESSION="fixture-onboard-$(date +%s)-$$"
+RUN_CWD="$STAGING/cwd"
+
+tmux new-session -d -s "$SESSION" -c "$RUN_CWD" "fixture-agent"
+echo "ok" > "$STAGING/driver.exit-reason"

--- a/tools/onboarding-factory/internal/driverteardown/testdata/vacuous_unclosed_function.sh
+++ b/tools/onboarding-factory/internal/driverteardown/testdata/vacuous_unclosed_function.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# VACUITY — a function body that is never closed by a `}` at column 0. Read
+# best-effort, the region would swallow the rest of the file and move the
+# top-level end-of-run sweep INSIDE a function, where INV-1 does not grade it.
+# A validator that cannot parse its input checks MORE, never less: this ERRORs.
+set -euo pipefail
+SESSION="fixture-onboard-$(date +%s)-$$"
+
+cleanup() {
+  tmux kill-session -t "$SESSION" 2>/dev/null || true
+trap cleanup EXIT
+
+tmux new-session -d -s "$SESSION" "fixture-agent"

--- a/tools/onboarding-factory/internal/driverteardown/testdata/vacuous_uninitialised_verdict.sh
+++ b/tools/onboarding-factory/internal/driverteardown/testdata/vacuous_uninitialised_verdict.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# VACUITY — the handler writes $EXIT_REASON, but nothing assigns EXIT_REASON
+# unconditionally at top level before the trap arms. INV-4 has no initial value
+# to compare the write against, so it graded nothing here. "There is no stale
+# verdict" and "I could not find out" must not be the same output: this ERRORs.
+_DRIVE_LIB="$(dirname "${BASH_SOURCE[0]}")/lib"
+source "$_DRIVE_LIB/slots.sh"
+
+SESSION=""
+SES_SESSION=()
+SES_CWD=()
+SES_ALIVE=()
+N_SLOTS=0
+ACTIVE=0
+RUN_CWD="$STAGING/cwd"
+
+cleanup() {
+  local i
+  for (( i = 1; i <= N_SLOTS; i++ )); do
+    [[ -n "${SES_SESSION[$i]:-}" ]] && tmux kill-session -t "${SES_SESSION[$i]}" 2>/dev/null || true
+  done
+  echo "$EXIT_REASON" > "$STAGING/driver.exit-reason"
+}
+trap cleanup EXIT
+
+launch_repl() {
+  alloc_slot "fixture-onboard-$(date +%s)-$$-$((N_SLOTS + 1))" "$RUN_CWD"
+  tmux kill-session -t "$SESSION" 2>/dev/null || true
+  tmux new-session -d -s "$SESSION" -x 200 -y 50 -c "${SES_CWD[$ACTIVE]}" "fixture-agent"
+}
+
+step_exit_clean() {
+  tmux send-keys -t "$SESSION" C-d
+  SES_ALIVE[$ACTIVE]=0
+}
+
+launch_repl
+step_exit_clean
+
+# Tear down every session this run created.
+for (( i = 1; i <= N_SLOTS; i++ )); do
+  if [[ -n "${SES_SESSION[$i]:-}" ]]; then
+    tmux kill-session -t "${SES_SESSION[$i]}" 2>/dev/null || true
+  fi
+done
+
+# The epilogue completed: EXIT_REASON is this run's real verdict.
+REACHED_EPILOGUE=1

--- a/tools/onboarding-factory/internal/driverteardown/testdata/vacuous_unnamed_session.sh
+++ b/tools/onboarding-factory/internal/driverteardown/testdata/vacuous_unnamed_session.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# VACUITY — `tmux new-session` with no `-s`, so tmux names the session itself.
+# The name is then outside the driver's control and cannot carry its PID, which
+# is precisely the state INV-3 exists to forbid. Reading it as "no name to
+# grade" would let it pass, so this must ERROR.
+set -euo pipefail
+RUN_CWD="$STAGING/cwd"
+
+cleanup() {
+  tmux kill-session -t fixture 2>/dev/null || true
+}
+trap cleanup EXIT
+
+tmux new-session -d -c "$RUN_CWD" "fixture-agent"

--- a/tools/onboarding-factory/internal/driverteardown/testdata/vacuous_unterminated_quote.sh
+++ b/tools/onboarding-factory/internal/driverteardown/testdata/vacuous_unterminated_quote.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# MUST REFUSE — a quote that is still open when the file ends.
+#
+# The joiner walks to end of file looking for the closing quote and then simply
+# stops, and the word scanner swallows every remaining line into one quoted
+# word. Both statements below disappear, including the `tmux kill-session`, so
+# without this refusal an unreadable file and a clean file are the same answer.
+set -euo pipefail
+
+SESSION="fixture-onboard-$(date +%s)-$$-1"
+tmux new-session -d -s "$SESSION" -x 200 -y 50 "fixture-agent"
+
+echo 'this quote is never closed
+tmux kill-session -t "$SESSION" 2>/dev/null || true

--- a/tools/onboarding-factory/scripts/lib/classify-failure.sh
+++ b/tools/onboarding-factory/scripts/lib/classify-failure.sh
@@ -6,9 +6,25 @@
 #
 # Outputs JSON to stdout: {"code": "<code>", "summary": "...", "evidence": "..."}
 #
+# It also reads a run-cell-multi.sh staging dir: that rig writes the same
+# run-manifest.json envelope (its own write_error_manifest "mirrors run-cell.sh's
+# contract"), so its error codes are classified here too. Its per-adapter driver
+# logs live one directory down, so only the manifest-driven arms can fire for it
+# — which is exactly why every code it writes needs an arm rather than falling
+# to the log heuristics below.
+#
 # Codes:
-#   cli_not_found, cli_too_old, auth_failed, daemon_dirty,
-#   working_tree_dirty, transcript_missing, timeout, daemon_crashed, unknown
+#   cli_not_found, cli_too_old, auth_failed, daemon_dirty, daemon_not_ready,
+#   working_tree_dirty, transcript_missing, timeout, daemon_crashed,
+#   driver_session_leaked, driver_teardown_unverifiable, replay_failed, unknown
+#
+# THE MANIFEST ARMS ARE KEPT IN SYNC MECHANICALLY (#1825). Every arm label in
+# the `case "$err_code"` block below is a string some OTHER script types into a
+# manifest, and nothing but a matching literal connects the two. That seam had
+# silently parted twice before it was noticed — see the case block's own comment
+# — so lib/classify-failure_test.sh now walks both rigs' write_error_manifest
+# call sites and fails when a code has no arm here, or an arm here names a code
+# no rig writes. Add an arm in the same commit as a new error code.
 
 set -euo pipefail
 
@@ -30,15 +46,71 @@ emit() {
   exit 0
 }
 
-# Manifest-driven classifications first (run-cell.sh wrote them deliberately).
+# Manifest-driven classifications first (the rig wrote them deliberately).
+#
+# WHAT WENT WRONG HERE BEFORE, because these arms are the reason the tripwire in
+# the test exists. Both of the original three arms were DEAD, and both were born
+# that way in 6d24cb14 (2026-04-25), the commit that added this file:
+#
+#   transcript_or_recording_missing — run-cell.sh had been renamed to write
+#     `transcript_recording_or_uuid_missing` seven hours earlier (a511ad11), so
+#     this arm never matched anything, from its first day to 2026-08-25. Every
+#     "the daemon didn't see the agent's session" run for those 4 months was
+#     reported to the record skill as `unknown`, i.e. as "inspect the staging
+#     dir by hand" — and `unknown` is also what a genuinely unrecognized failure
+#     prints, so nothing distinguished "not classified" from "not classifiable".
+#
+#   wall_clock_timeout — never written by ANY script in this repo's history
+#     (`git log -S wall_clock_timeout --all` returns only 6d24cb14, this file).
+#     It made `timeout` an unreachable output while record/SKILL.md's retry
+#     policy keys on exactly that code. Replaced below by reading the field the
+#     rig really does write: driver.exit-reason, which contracts.sh's drive_exit
+#     sets to `timeout` and write_error_manifest copies into the manifest.
+#
+# Neither was a typo anyone could have seen by reading one file, which is the
+# whole point: the writer and the matcher are in different scripts, and a
+# never-matching `case` arm is indistinguishable from a never-taken one.
 if [[ -f "$MANIFEST" ]]; then
   err_code=$(jq -r '.error // empty' "$MANIFEST" 2>/dev/null || echo "")
   case "$err_code" in
-    transcript_or_recording_missing) emit "transcript_missing" "Daemon didn't see the agent's session" "$err_code" ;;
-    wall_clock_timeout)              emit "timeout"            "Scenario timed out"                    "$err_code" ;;
-    no_subagents_spawned)            emit "transcript_missing" "Scenario requires subagents but none spawned" "$err_code" ;;
+    transcript_recording_or_uuid_missing) emit "transcript_missing" "Daemon didn't see the agent's session" "$err_code" ;;
+    no_recording)                         emit "transcript_missing" "Daemon produced no recording for this run" "$err_code" ;;
+    no_subagents_spawned)                 emit "transcript_missing" "Scenario requires subagents but none spawned" "$err_code" ;;
+    daemon_socket_missing)                emit "daemon_not_ready"   "Recording daemon never opened its socket" "$err_code" ;;
+    replay_failed)                        emit "replay_failed"      "Replay produced no report for a staged fixture" "$(jq -r '.failed_adapter // empty' "$MANIFEST" 2>/dev/null || echo "")" ;;
+    # #1825 / AC4. Two codes, two classifications, deliberately NOT collapsed:
+    # a leaked session means a live agent process is still on this host and the
+    # operator has a `tmux kill-session` to run before retrying, while an
+    # unreadable check means nothing was established either way. Printing one
+    # answer for both is the bug #1825 is about, one layer up.
+    driver_tmux_session_survived)   emit "driver_session_leaked" \
+      "Driver returned but a tmux session carrying its pid is still alive — kill it before retrying" \
+      "$(jq -r '.tmux_teardown_detail // empty' "$MANIFEST" 2>/dev/null || echo "")" ;;
+    driver_tmux_teardown_unreadable) emit "driver_teardown_unverifiable" \
+      "The tmux-teardown check could not be made, so whether the driver leaked is UNKNOWN — not a pass" \
+      "$(jq -r '.tmux_teardown_detail // empty' "$MANIFEST" 2>/dev/null || echo "")" ;;
+    # Deliberately no emit: run-cell-multi.sh writes driver_failed when a driver
+    # exited non-zero or resolved no session, which is the least informative
+    # thing known about the failure. The driver-log and daemon-log heuristics
+    # below refine it into cli_not_found / auth_failed / daemon_crashed, so
+    # falling through reaches a better answer than the manifest carries. The arm
+    # exists so the sync tripwire sees a decision rather than an omission.
+    driver_failed) ;;
     *) ;;
   esac
+
+  # Timeout, from the field the rig actually writes. run-cell.sh puts the
+  # driver's own exit reason in .driver_exit_reason; run-cell-multi.sh puts one
+  # per adapter in the .driver_exit_reasons object. This runs AFTER the code
+  # arms on purpose — it can only turn what would have been `unknown` into
+  # `timeout`, never reclassify a code that was matched above.
+  timed_out=$(jq -r '
+      [ (.driver_exit_reason // empty) ] + [ (.driver_exit_reasons // {}) | .[] ]
+      | map(select(. == "timeout")) | length' \
+    "$MANIFEST" 2>/dev/null || echo 0)
+  if [[ "${timed_out:-0}" != "0" ]]; then
+    emit "timeout" "Driver hit its wall-clock timeout" "driver.exit-reason=timeout"
+  fi
 fi
 
 # Precheck refusals.

--- a/tools/onboarding-factory/scripts/lib/classify-failure_test.sh
+++ b/tools/onboarding-factory/scripts/lib/classify-failure_test.sh
@@ -7,11 +7,41 @@
 # checks the emitted JSON's .code field. Added alongside #1018's daemon_crashed
 # branch, which was the first classification to read $STAGING/daemon.log —
 # previously staged but never inspected.
+#
+# #1825 added the second half of this file: THE SYNC TRIPWIRE. Every arm of
+# classify-failure.sh's manifest `case` is a string typed in one script and
+# matched in another, with nothing but the two literals connecting them — and
+# when they part, the classifier reports `unknown`, which is also what it
+# reports for a failure nobody has categorized yet. Absence of a finding and
+# inability to look print the same word, so the drift is invisible from either
+# side. It had happened twice, undetected, for four months:
+#
+#   transcript_or_recording_missing — run-cell.sh was renamed to write
+#     `transcript_recording_or_uuid_missing` in a511ad11 (2026-04-25 07:51) and
+#     6d24cb14 (2026-04-25 14:34) added this classifier matching the pre-rename
+#     spelling. The arm never matched, from the day it was written until
+#     2026-08-25.
+#   wall_clock_timeout — no script in this repo's history ever wrote it
+#     (`git log -S wall_clock_timeout --all` returns only 6d24cb14, the
+#     classifier itself), so `timeout` was an unreachable classification while
+#     record/SKILL.md's retry policy keyed on it.
+#
+# The tripwire is therefore BIDIRECTIONAL, because those are two halves of one
+# defect: a code a rig writes with no arm here is a failure reported as
+# unknown, and an arm here with no writer is an arm that can never fire. Each
+# direction is paired with a MUTATED FIXTURE it must go red against (AGENTS.md:
+# a check a change adds has no "before the fix" to run red, so mutate the thing
+# it protects and commit the mutation), and the extraction itself refuses rather
+# than returning an empty list — a tripwire that graded nothing must not read
+# as a tripwire that found nothing.
 
 set -uo pipefail   # NOT -e: assertions capture non-zero return codes
 
 DIR="$(cd "$(dirname "$0")" && pwd)"
 SCRIPT="$DIR/classify-failure.sh"
+SCRIPTS_DIR="$(cd "$DIR/.." && pwd)"
+RUN_CELL="$SCRIPTS_DIR/run-cell.sh"
+RUN_CELL_MULTI="$SCRIPTS_DIR/run-cell-multi.sh"
 
 command -v jq >/dev/null || { echo "classify-failure_test: jq is required" >&2; exit 2; }
 
@@ -56,6 +86,267 @@ assert_code "daemon already running -> daemon_dirty" "daemon_dirty" "$d"
 echo "== no signal at all -> unknown =="
 d="$TMP/empty"; mkdir -p "$d"
 assert_code "nothing staged -> unknown" "unknown" "$d"
+
+# --- #1825: the manifest codes both rigs actually write ---------------------
+
+assert_code_with() {   # <label> <classifier> <expected> <staging>
+  local label="$1" classifier="$2" expected="$3" staging="$4" got
+  got="$(bash "$classifier" "$staging" | jq -r '.code')"
+  [[ "$got" == "$expected" ]] && pass "$label" || fail "$label" "$expected" "$got"
+  return 0
+}
+
+manifest_dir() {   # <name> <json> → prints the staging dir
+  local d="$TMP/$1"; mkdir -p "$d"; printf '%s\n' "$2" > "$d/run-manifest.json"; echo "$d"
+}
+
+echo "== the renamed code classifies (the arm that was dead for 4 months) =="
+# a511ad11 renamed the WRITER; 6d24cb14 shipped the matcher with the old
+# spelling seven hours later. The RED proof for this case is the mutated
+# classifier further down, which is handed this exact input.
+DRIFT_MANIFEST='{"error":"transcript_recording_or_uuid_missing","transcript_found":false,"recording_found":true,"uuid_resolved":false}'
+DRIFT_DIR="$(manifest_dir drift "$DRIFT_MANIFEST")"
+assert_code "transcript_recording_or_uuid_missing -> transcript_missing" \
+  "transcript_missing" "$DRIFT_DIR"
+
+echo "== the two teardown verdicts classify DIFFERENTLY (#1825 / AC4) =="
+# The whole issue is that "it leaked" and "the check could not be made" must
+# not print the same answer: one has a `tmux kill-session` attached, the other
+# means nothing was established either way.
+LEAK_DIR="$(manifest_dir leak \
+  '{"error":"driver_tmux_session_survived","tmux_teardown":"leaked","tmux_teardown_detail":"claudecode-onboard-1787641617-95883","driver_pid":"95883"}')"
+UNREAD_DIR="$(manifest_dir unread \
+  '{"error":"driver_tmux_teardown_unreadable","tmux_teardown":"unreadable","tmux_teardown_detail":"tmux list-sessions exited 1: lost server"}')"
+assert_code "a survived session -> driver_session_leaked" "driver_session_leaked" "$LEAK_DIR"
+assert_code "an unreadable check -> driver_teardown_unverifiable" "driver_teardown_unverifiable" "$UNREAD_DIR"
+LEAK_EVIDENCE="$(bash "$SCRIPT" "$LEAK_DIR" | jq -r '.evidence')"
+[[ "$LEAK_EVIDENCE" == *"95883"* ]] \
+  && pass "the leak's evidence names the session to kill" \
+  || fail "the leak's evidence names the session to kill" "*95883*" "$LEAK_EVIDENCE"
+
+echo "== run-cell-multi.sh's codes classify too (its driver logs are one dir down) =="
+assert_code "daemon_socket_missing -> daemon_not_ready" "daemon_not_ready" \
+  "$(manifest_dir sock '{"error":"daemon_socket_missing"}')"
+assert_code "no_recording -> transcript_missing" "transcript_missing" \
+  "$(manifest_dir norec '{"error":"no_recording"}')"
+assert_code "replay_failed -> replay_failed" "replay_failed" \
+  "$(manifest_dir replay '{"error":"replay_failed","failed_adapter":"kiro-cli"}')"
+
+echo "== driver_failed deliberately falls THROUGH to the richer log heuristics =="
+# The manifest code is the least informative thing known about the failure, so
+# the arm exists (the tripwire below demands a decision) but does not emit.
+d="$TMP/multi-auth"; mkdir -p "$d"
+printf '{"error":"driver_failed"}\n' > "$d/run-manifest.json"
+printf 'please log in to continue\n' > "$d/driver.log"
+assert_code "driver_failed + an auth-looking driver.log -> auth_failed" "auth_failed" "$d"
+
+echo "== timeout is reachable again, from the field the rigs really write =="
+# wall_clock_timeout was never written by anything. contracts.sh's drive_exit
+# sets EXIT_REASON=timeout and both rigs copy it into the manifest.
+assert_code "run-cell.sh's .driver_exit_reason -> timeout" "timeout" \
+  "$(manifest_dir to1 '{"driver_exit_reason":"timeout"}')"
+assert_code "run-cell-multi.sh's .driver_exit_reasons map -> timeout" "timeout" \
+  "$(manifest_dir to2 '{"error":"driver_failed","driver_exit_reasons":{"pi":"timeout","claudecode":"ok"}}')"
+assert_code "a clean exit reason is NOT a timeout" "unknown" \
+  "$(manifest_dir to3 '{"driver_exit_reason":"ok"}')"
+
+# --- #1825: the writer <-> matcher sync tripwire ---------------------------
+#
+# Both directions are computed by EXTRACTING literals out of source text, so
+# each extractor refuses loudly when it comes back empty. `refused` is the
+# sentinel: a caller that treats it as a list would be treating "I could not
+# look" as "there is nothing there", which is the failure this whole file is
+# about.
+
+# writer_reasons <script> — every error code <script> can put in a manifest's
+# .error field, one per line. An argument it cannot follow is a refusal, not an
+# omission: a call whose code is unquoted, or held in a variable with no literal
+# assignment in the same file, means the tripwire's list is incomplete and it
+# must say so rather than grading the codes it happened to understand.
+writer_reasons() {
+  local script="$1" kind tok var lits out="" n=0
+  [[ -r "$script" ]] || { echo "refused: cannot read $script" >&2; return 1; }
+  while IFS=$'\t' read -r kind tok; do
+    if [[ "$kind" == "UNREADABLE" ]]; then
+      echo "refused: $script has a write_error_manifest call whose code is not a quoted word: $tok" >&2
+      return 1
+    fi
+    case "$tok" in
+      '$'*)
+        var="${tok#$}"
+        var="${var#\{}"; var="${var%\}}"
+        lits="$(awk -v v="$var" '
+          $0 ~ "^[[:space:]]*(local[[:space:]]+)?" v "=\"[a-z0-9_]+\"[[:space:]]*$" {
+            line=$0; sub(/^[^"]*"/, "", line); sub(/".*$/, "", line); print line
+          }' "$script")"
+        if [[ -z "$lits" ]]; then
+          echo "refused: $script passes \$$var to write_error_manifest but assigns it no literal code" >&2
+          return 1
+        fi
+        out+="$lits"$'\n'; n=$((n + 1))
+        ;;
+      [a-z0-9_]*) out+="$tok"$'\n'; n=$((n + 1)) ;;
+      *) echo "refused: $script passes an uninterpretable code to write_error_manifest: [$tok]" >&2; return 1 ;;
+    esac
+  done < <(awk '
+    /^[[:space:]]*#/               { next }
+    /write_error_manifest\(\)/     { next }
+    {
+      s = $0
+      while (match(s, /write_error_manifest[ \t]+"[^"]*"/)) {
+        tok = substr(s, RSTART, RLENGTH)
+        sub(/^write_error_manifest[ \t]+"/, "", tok)
+        sub(/"$/, "", tok)
+        print "ARG\t" tok
+        s = substr(s, RSTART + RLENGTH)
+      }
+      if (match($0, /write_error_manifest[ \t]+[^"\t ]/)) print "UNREADABLE\t" $0
+    }' "$script")
+  # THE VACUITY GUARD. A rig with zero call sites is a rig this tripwire graded
+  # nothing in — the same shape as righome/beacon_test.go:59-61 refusing an
+  # empty corpus. Silence here would make every future drift green.
+  if [[ "$n" -eq 0 ]]; then
+    echo "refused: found no write_error_manifest call sites in $script — this tripwire graded nothing" >&2
+    return 1
+  fi
+  printf '%s' "$out" | sort -u
+  return 0
+}
+
+# classifier_arms <classifier> — every label of the manifest `case` block,
+# which is the set of codes this classifier claims to understand. Same refusal
+# contract as above.
+classifier_arms() {
+  local classifier="$1" arms
+  [[ -r "$classifier" ]] || { echo "refused: cannot read $classifier" >&2; return 1; }
+  arms="$(awk '
+    /case "\$err_code" in/          { inblock = 1; next }
+    inblock && /^[[:space:]]*esac/  { inblock = 0 }
+    inblock && /^[[:space:]]*[a-z0-9_]+\)/ {
+      line = $0; sub(/^[[:space:]]*/, "", line); sub(/\).*$/, "", line)
+      if (line ~ /^[a-z0-9_]+$/) print line
+    }' "$classifier" | sort -u)"
+  if [[ -z "$arms" ]]; then
+    echo "refused: found no manifest case arms in $classifier — this tripwire graded nothing" >&2
+    return 1
+  fi
+  printf '%s\n' "$arms"
+  return 0
+}
+
+# unmatched_codes <classifier> <script…> — codes a rig writes that the
+# classifier has no arm for. Prints `refused` (and returns 1) if either side
+# could not be read.
+unmatched_codes() {
+  local classifier="$1"; shift
+  local arms reasons r missing=""
+  arms="$(classifier_arms "$classifier")" || { echo refused; return 1; }
+  for script in "$@"; do
+    reasons="$(writer_reasons "$script")" || { echo refused; return 1; }
+    while IFS= read -r r; do
+      [[ -n "$r" ]] || continue
+      printf '%s\n' "$arms" | grep -qx -- "$r" || missing="${missing:+$missing }$r"
+    done <<< "$reasons"
+  done
+  printf '%s\n' "$missing"
+  return 0
+}
+
+# dead_arms <classifier> <script…> — arms the classifier carries that no rig
+# writes. This is the direction that would have caught BOTH original defects.
+dead_arms() {
+  local classifier="$1"; shift
+  local arms all="" reasons a dead=""
+  arms="$(classifier_arms "$classifier")" || { echo refused; return 1; }
+  for script in "$@"; do
+    reasons="$(writer_reasons "$script")" || { echo refused; return 1; }
+    all+="$reasons"$'\n'
+  done
+  while IFS= read -r a; do
+    [[ -n "$a" ]] || continue
+    printf '%s\n' "$all" | grep -qx -- "$a" || dead="${dead:+$dead }$a"
+  done <<< "$arms"
+  printf '%s\n' "$dead"
+  return 0
+}
+
+echo "== the tripwire can look at all (no vacuous green) =="
+REAL_REASONS="$(writer_reasons "$RUN_CELL")"
+[[ "$(printf '%s\n' "$REAL_REASONS" | grep -c .)" -ge 3 ]] \
+  && pass "run-cell.sh yields its write_error_manifest codes ($(printf '%s\n' "$REAL_REASONS" | tr '\n' ' '))" \
+  || fail "run-cell.sh yields its write_error_manifest codes" ">=3 codes" "$REAL_REASONS"
+MULTI_REASONS="$(writer_reasons "$RUN_CELL_MULTI")"
+[[ "$(printf '%s\n' "$MULTI_REASONS" | grep -c .)" -ge 4 ]] \
+  && pass "run-cell-multi.sh yields its codes ($(printf '%s\n' "$MULTI_REASONS" | tr '\n' ' '))" \
+  || fail "run-cell-multi.sh yields its codes" ">=4 codes" "$MULTI_REASONS"
+REAL_ARMS="$(classifier_arms "$SCRIPT")"
+[[ "$(printf '%s\n' "$REAL_ARMS" | grep -c .)" -ge 3 ]] \
+  && pass "classify-failure.sh yields its case arms" \
+  || fail "classify-failure.sh yields its case arms" ">=3 arms" "$REAL_ARMS"
+# The variable-argument path is exercised by the real files, not only by a
+# fixture: run-cell.sh:559 and run-cell-multi.sh pass "$TMUX_GATE_ERROR" /
+# "$TMUX_MULTI_ERROR", so if the resolver stopped following those the two #1825
+# codes would silently drop out of the list above.
+printf '%s\n' "$REAL_REASONS" | grep -qx driver_tmux_session_survived \
+  && pass "a code held in a variable is still followed (driver_tmux_session_survived)" \
+  || fail "a code held in a variable is still followed" "driver_tmux_session_survived in list" "$REAL_REASONS"
+
+echo "== every code either rig writes has an arm here =="
+assert_str() { local label="$1" expected="$2" actual="$3"; [[ "$expected" == "$actual" ]] && pass "$label" || fail "$label" "$expected" "$actual"; return 0; }
+assert_str "run-cell.sh: nothing unclassified" "" "$(unmatched_codes "$SCRIPT" "$RUN_CELL")"
+assert_str "run-cell-multi.sh: nothing unclassified" "" "$(unmatched_codes "$SCRIPT" "$RUN_CELL_MULTI")"
+
+echo "== and every arm here is a code some rig writes (no dead arms) =="
+assert_str "no arm without a writer" "" "$(dead_arms "$SCRIPT" "$RUN_CELL" "$RUN_CELL_MULTI")"
+
+echo "== MUTATION — a new writer code with no arm goes RED =="
+MUT_NEW="$TMP/run-cell-with-an-unclassified-code.sh"
+cp "$RUN_CELL" "$MUT_NEW"
+printf '\nwrite_error_manifest "a_code_no_classifier_knows" "{}"\n' >> "$MUT_NEW"
+assert_str "the unmatched code is named" "a_code_no_classifier_knows" \
+  "$(unmatched_codes "$SCRIPT" "$MUT_NEW")"
+
+echo "== MUTATION — the ORIGINAL drift (the pre-rename spelling) goes RED =="
+# This is the arm that was dead from 2026-04-25 to 2026-08-25, reconstructed as
+# a fixture instead of described in a PR body. Both directions must notice it,
+# and the classifier built from it must misclassify the real manifest.
+MUT_OLD="$TMP/classify-failure-with-the-2026-04-spelling.sh"
+sed 's/transcript_recording_or_uuid_missing)/transcript_or_recording_missing)  /' \
+  "$SCRIPT" > "$MUT_OLD"
+assert_str "the mutant really differs from the original" "differs" \
+  "$(cmp -s "$SCRIPT" "$MUT_OLD" && echo same || echo differs)"
+assert_code_with "  …and it misclassifies the real manifest as unknown" \
+  "$MUT_OLD" "unknown" "$DRIFT_DIR"
+assert_str "  …the dead-arm direction names it" "transcript_or_recording_missing" \
+  "$(dead_arms "$MUT_OLD" "$RUN_CELL" "$RUN_CELL_MULTI")"
+assert_str "  …the unmatched-code direction names it too" "transcript_recording_or_uuid_missing" \
+  "$(unmatched_codes "$MUT_OLD" "$RUN_CELL")"
+
+echo "== MUTATION — an extractor that can no longer look REFUSES, never returns empty =="
+MUT_NOCALLS="$TMP/run-cell-with-no-call-sites.sh"
+grep -v 'write_error_manifest "' "$RUN_CELL" > "$MUT_NOCALLS"
+assert_str "a rig with zero call sites is a refusal" "refused" \
+  "$(unmatched_codes "$SCRIPT" "$MUT_NOCALLS" 2>/dev/null)"
+
+MUT_UNQUOTED="$TMP/run-cell-with-an-unquoted-code.sh"
+cp "$RUN_CELL" "$MUT_UNQUOTED"
+printf '\nwrite_error_manifest $SOME_CODE "{}"\n' >> "$MUT_UNQUOTED"
+assert_str "an argument that cannot be followed is a refusal" "refused" \
+  "$(unmatched_codes "$SCRIPT" "$MUT_UNQUOTED" 2>/dev/null)"
+
+MUT_UNRESOLVED="$TMP/run-cell-with-an-unresolvable-variable.sh"
+cp "$RUN_CELL" "$MUT_UNRESOLVED"
+printf '\nwrite_error_manifest "$NEVER_ASSIGNED_ANYWHERE" "{}"\n' >> "$MUT_UNRESOLVED"
+assert_str "a variable with no literal assignment is a refusal" "refused" \
+  "$(unmatched_codes "$SCRIPT" "$MUT_UNRESOLVED" 2>/dev/null)"
+
+MUT_NOARMS="$TMP/classify-failure-with-no-arms.sh"
+awk '/case "\$err_code" in/ { inblock = 1 }
+     inblock && /^[[:space:]]*esac/ { inblock = 0; print; next }
+     inblock { if ($0 ~ /case "\$err_code" in/) print; next }
+     { print }' "$SCRIPT" > "$MUT_NOARMS"
+assert_str "a classifier with zero arms is a refusal" "refused" \
+  "$(unmatched_codes "$MUT_NOARMS" "$RUN_CELL" 2>/dev/null)"
 
 echo ""
 if [[ "$fails" -eq 0 ]]; then

--- a/tools/onboarding-factory/scripts/lib/run-cell-multi-teardown_test.sh
+++ b/tools/onboarding-factory/scripts/lib/run-cell-multi-teardown_test.sh
@@ -1,0 +1,341 @@
+#!/usr/bin/env bash
+# run-cell-multi-teardown_test.sh — the cross-adapter rig's tmux-teardown gate
+# (#1825 / AC4). Plain bash, no framework. Run directly or via smoke-test.sh.
+#
+# lib/tmux-teardown-check_test.sh grades the LIBRARY: does a session carrying a
+# given pid read as a leak, and does a lookup that could not be made refuse.
+# This file grades what run-cell-multi.sh DOES with that verdict, which is a
+# different set of decisions and the one the issue actually turns on:
+#
+#   * a leak is attributed to ONE adapter, by name, out of the several that
+#     were running concurrently in the same workspace;
+#   * one leaking driver fails the WHOLE run rather than that adapter's cell;
+#   * "it leaked" and "the check could not be made" still fail under DIFFERENT
+#     error codes, so the classifier can tell them apart (see
+#     lib/classify-failure_test.sh);
+#   * when both happened, the LEAK names the manifest — it is the finding with
+#     an action attached — and the unreadable adapters stay listed.
+#
+# HOW IT GETS AT THEM. run-cell-multi.sh is a top-to-bottom script: sourcing it
+# would spawn a daemon and launch real agents. So the two functions that carry
+# the decisions are delimited by `# BEGIN <name>` / `# END <name>` markers,
+# EXTRACTED from the script's source text here, and eval'd against a shadowed
+# `tmux` and a stubbed write_error_manifest. That is the same extract-and-
+# execute idiom tools/lib/*_test.sh uses for a workflow step's `run:` block,
+# and it is what stops this suite from testing a copy of the logic that has
+# drifted from the one that ships.
+#
+# The extraction is itself the thing most likely to rot — a renamed function or
+# a dropped marker would leave every case below grading an empty string — so it
+# refuses and exits rather than continuing with nothing, and the last section
+# asserts the extracted functions are actually WIRED into the script's control
+# flow, against a mutated copy with the wiring removed.
+#
+# THE MUTATION FIXTURES (AGENTS.md: a check a change ADDS has no "before the
+# fix" to run red, so mutate what it protects and commit the mutation). Every
+# case marked MUTATION below hands the gate a fake LEAKY DRIVER — a tmux whose
+# session list carries that driver's pid — and asserts the run fails. Each is
+# paired with the same fixture flipped clean, so the red is shown to come from
+# the leak and not from the harness.
+
+set -uo pipefail   # NOT -e: assertions capture non-zero return codes
+
+DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPTS_DIR="$(cd "$DIR/.." && pwd)"
+RUN_CELL_MULTI="$SCRIPTS_DIR/run-cell-multi.sh"
+
+command -v jq >/dev/null || { echo "run-cell-multi-teardown_test: jq is required" >&2; exit 2; }
+
+# shellcheck source=tmux-teardown-check.sh
+source "$DIR/tmux-teardown-check.sh"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+fails=0
+pass() { local label="$1"; echo "  PASS: $label"; return 0; }
+fail() {
+  local label="$1" expected="$2" got="$3"
+  echo "  FAIL: $label — expected [$expected] got [$got]"
+  fails=$((fails + 1))
+  return 0
+}
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  [[ "$expected" == "$actual" ]] && pass "$label" || fail "$label" "$expected" "$actual"
+  return 0
+}
+assert_contains() {
+  local label="$1" needle="$2" haystack="$3"
+  case "$haystack" in
+    *"$needle"*) pass "$label" ;;
+    *) fail "$label" "*$needle*" "$haystack" ;;
+  esac
+  return 0
+}
+
+# Spend no real time between looks. Read by the SOURCED await-gone.sh, which
+# the linter cannot follow from here.
+# shellcheck disable=SC2034
+AWAIT_GONE_POLL_SECONDS=0.02
+
+# --- Extract the two functions under test ----------------------------------
+
+# extract_block <file> <name> — the lines strictly between `# BEGIN <name>` and
+# `# END <name>`.
+extract_block() {
+  awk -v n="$2" '
+    $0 ~ ("^# BEGIN " n "([ \t]|$)") { inb = 1; next }
+    inb && $0 ~ ("^# END " n "[ \t]*$") { inb = 0; next }
+    inb { print }
+  ' "$1"
+}
+
+# load_block <name> — extract, refuse loudly if it came back unusable, eval.
+# "The marker moved" and "the function is fine" must not both produce a green
+# suite, so this exits rather than returning.
+load_block() {
+  local name="$1" src
+  src="$(extract_block "$RUN_CELL_MULTI" "$name")"
+  if [[ -z "$src" ]]; then
+    echo "run-cell-multi-teardown_test: REFUSING — no '# BEGIN $name' … '# END $name' block in $RUN_CELL_MULTI." >&2
+    echo "  Every case in this suite would have graded an empty string. Restore the markers or rename them here too." >&2
+    exit 1
+  fi
+  if ! grep -q "^${name}() {" <<< "$src"; then
+    echo "run-cell-multi-teardown_test: REFUSING — the '$name' marker block does not define ${name}()." >&2
+    exit 1
+  fi
+  eval "$src" || { echo "run-cell-multi-teardown_test: REFUSING — '$name' does not eval" >&2; exit 1; }
+  return 0
+}
+
+load_block record_driver_teardown
+load_block tmux_teardown_verdict
+
+echo "== the suite is grading the shipped functions, not a copy =="
+assert_eq "record_driver_teardown was extracted and defined" "yes" \
+  "$(declare -F record_driver_teardown >/dev/null && echo yes || echo no)"
+assert_eq "tmux_teardown_verdict was extracted and defined" "yes" \
+  "$(declare -F tmux_teardown_verdict >/dev/null && echo yes || echo no)"
+
+# --- Harness ---------------------------------------------------------------
+
+# fake_tmux <mode> [names…] — shadow tmux with one that models a server state.
+# Same idiom (and the same three failure modes) as tmux-teardown-check_test.sh.
+fake_tmux() {
+  local mode="$1"; shift
+  FAKE_TMUX_NAMES=("$@")
+  case "$mode" in
+    sessions) tmux() { printf '%s\n' "${FAKE_TMUX_NAMES[@]}"; return 0; } ;;
+    noserver) tmux() { echo "no server running on /private/tmp/tmux-501/default" >&2; return 1; } ;;
+    broken)   tmux() { echo "lost server" >&2; return 1; } ;;
+    *) echo "fake_tmux: unknown mode $mode" >&2; return 1 ;;
+  esac
+  return 0
+}
+
+# The stub for the one thing the verdict reaches out to. Captures rather than
+# writes, so a case can assert on the error code and the extras the real
+# write_error_manifest would have put in run-manifest.json.
+MANIFEST_CODE=""
+MANIFEST_EXTRAS=""
+MANIFEST_WRITES=0
+write_error_manifest() {
+  MANIFEST_CODE="$1"
+  MANIFEST_EXTRAS="${2:-}"
+  MANIFEST_WRITES=$((MANIFEST_WRITES + 1))
+  return 0
+}
+
+# The run-level state record_driver_teardown accumulates into. Reset per case,
+# exactly as run-cell-multi.sh initializes it before its wait loop.
+reset_run() {
+  TMUX_TEARDOWN_JSON="{}"
+  # shellcheck disable=SC2034  # read and written by the EXTRACTED
+  # record_driver_teardown / tmux_teardown_verdict (run-cell-multi.sh's
+  # "# BEGIN …" blocks, eval'd by load_block above). The linter cannot follow an
+  # eval, so it sees only this assignment — deleting it would leave each case
+  # accumulating the previous case's leaks.
+  TMUX_LEAKED=""
+  # shellcheck disable=SC2034  # see above — a directive covers only the next
+  # command, and this is the other half of the pair.
+  TMUX_UNREADABLE=""
+  MANIFEST_CODE=""
+  MANIFEST_EXTRAS=""
+  MANIFEST_WRITES=0
+  return 0
+}
+
+# A 10s lifetime keeps await_gone_bound's 10:1 wall satisfied at the 1s floor
+# the function computes, so a leaked case costs one second rather than five.
+LIFETIME=10
+PID_A=95883      # kiro-cli's driver
+PID_B=95884      # claudecode's driver
+
+measure() {   # <adapter> <pid> — one wait-loop iteration's worth of the gate
+  record_driver_teardown "$1" "$2" "$LIFETIME" >/dev/null 2>&1
+  return 0
+}
+
+# run_verdict — sets VERDICT to pass / fail-the-run. Deliberately NOT a
+# function whose answer is captured with $(…): the verdict's whole job is the
+# SIDE EFFECT of calling write_error_manifest, and a command substitution runs
+# it in a subshell where the stub's captures are thrown away — which reads as
+# "the gate wrote no manifest" no matter what it did.
+VERDICT=""
+run_verdict() {
+  if tmux_teardown_verdict >/dev/null 2>&1; then VERDICT="pass"; else VERDICT="fail-the-run"; fi
+  return 0
+}
+
+# --- Cases -----------------------------------------------------------------
+
+echo "== both drivers tore their sessions down: the run passes =="
+# Somebody else's sessions are present throughout, so a pass here also shows
+# the gate is scoped to THIS run rather than to "any tmux on the host".
+reset_run
+fake_tmux sessions "irc" "work" "claudecode-onboard-1787641617-11111"
+measure kiro-cli "$PID_A"
+measure claudecode "$PID_B"
+run_verdict
+assert_eq "verdict" "pass" "$VERDICT"
+assert_eq "no ERROR manifest is written" "0" "$MANIFEST_WRITES"
+assert_eq "both adapters recorded clean" "clean clean" \
+  "$(jq -r '[.["kiro-cli"].status, .claudecode.status] | join(" ")' <<< "$TMUX_TEARDOWN_JSON")"
+
+echo "== MUTATION — ONE of two drivers leaks: the WHOLE run fails, and it is named =="
+# The decision this file exists to pin. A cross-adapter run stages one fixture
+# per adapter but curates every one of them over the SHARED workspace, so a
+# still-live agent is inside all of them; there is also only one
+# run-manifest.json, so "adapter A is fine" is not a state this rig can express.
+reset_run
+fake_tmux sessions "work" "kiro-clidrv-$PID_A-1787641617-r1" "irc"
+measure kiro-cli "$PID_A"
+measure claudecode "$PID_B"
+run_verdict
+assert_eq "verdict" "fail-the-run" "$VERDICT"
+assert_eq "exactly one ERROR manifest" "1" "$MANIFEST_WRITES"
+assert_eq "under the leak's own error code" "driver_tmux_session_survived" "$MANIFEST_CODE"
+assert_eq "the leaking adapter is named" "kiro-cli" \
+  "$(jq -r '.tmux_teardown_leaked' <<< "$MANIFEST_EXTRAS")"
+assert_eq "the OTHER adapter is not blamed" "clean" \
+  "$(jq -r '.tmux_teardown.claudecode.status' <<< "$MANIFEST_EXTRAS")"
+assert_contains "the survivor is named so it can be killed" \
+  "kiro-clidrv-$PID_A-1787641617-r1" \
+  "$(jq -r '.tmux_teardown["kiro-cli"].detail' <<< "$MANIFEST_EXTRAS")"
+
+echo "== the same fixture, flipped clean: the run passes (the red came from the leak) =="
+reset_run
+fake_tmux sessions "work" "kiro-clidrv-11111-1787641617-r1" "irc"
+measure kiro-cli "$PID_A"
+measure claudecode "$PID_B"
+run_verdict
+assert_eq "verdict" "pass" "$VERDICT"
+
+echo "== MUTATION — a driver whose teardown CANNOT BE CHECKED fails, under a different code =="
+# Not the same failure and not the same answer: nothing was established either
+# way, so there is no session to go kill. Collapsing the two is the bug #1825
+# is about, one layer up.
+reset_run
+fake_tmux noserver
+measure kiro-cli "$PID_A"
+fake_tmux broken
+measure claudecode "$PID_B"
+run_verdict
+assert_eq "verdict" "fail-the-run" "$VERDICT"
+assert_eq "under the unreadable code, NOT the leak code" "driver_tmux_teardown_unreadable" "$MANIFEST_CODE"
+assert_eq "the unreadable adapter is named" "claudecode" \
+  "$(jq -r '.tmux_teardown_unreadable' <<< "$MANIFEST_EXTRAS")"
+assert_eq "nothing is reported as leaked" "" \
+  "$(jq -r '.tmux_teardown_leaked' <<< "$MANIFEST_EXTRAS")"
+assert_contains "the reason quotes what tmux actually said" "lost server" \
+  "$(jq -r '.tmux_teardown.claudecode.detail' <<< "$MANIFEST_EXTRAS")"
+
+echo "== MUTATION — a leak AND an unreadable check: the LEAK names the manifest =="
+# The leak is the finding with an action attached, so it is the code an operator
+# reads first; the unreadable adapter still has to survive into the detail.
+reset_run
+fake_tmux sessions "kiro-clidrv-$PID_A-1787641617-r1"
+measure kiro-cli "$PID_A"
+fake_tmux broken
+measure claudecode "$PID_B"
+run_verdict
+assert_eq "verdict" "fail-the-run" "$VERDICT"
+assert_eq "the leak wins the error code" "driver_tmux_session_survived" "$MANIFEST_CODE"
+assert_eq "and the unreadable adapter is not lost" "claudecode" \
+  "$(jq -r '.tmux_teardown_unreadable' <<< "$MANIFEST_EXTRAS")"
+assert_eq "a one-line summary carries both" \
+  "leaked=[kiro-cli] unreadable=[claudecode]" \
+  "$(jq -r '.tmux_teardown_detail' <<< "$MANIFEST_EXTRAS")"
+
+echo "== a driver with no usable pid is a refusal, never a pass =="
+# run-cell-multi.sh takes the pid from `$!`, so an empty one means the launch
+# loop changed shape. Every surviving session would then read as somebody
+# else's and the gate would pass vacuously.
+reset_run
+fake_tmux sessions "kiro-clidrv-$PID_A-1787641617-r1"
+measure kiro-cli ""
+run_verdict
+assert_eq "verdict" "fail-the-run" "$VERDICT"
+assert_eq "under the unreadable code" "driver_tmux_teardown_unreadable" "$MANIFEST_CODE"
+
+unset -f tmux
+
+# --- The gate is WIRED into the script's control flow ----------------------
+# Two perfectly-tested functions that nothing calls is the failure mode #1825 is
+# about, one layer out. Each assertion is paired with the same assertion against
+# a MUTATED COPY with the wiring deleted, so a tripwire that has stopped being
+# able to look is red rather than green.
+
+echo "== the gate is WIRED: run-cell-multi.sh actually runs it (#1825) =="
+assert_eq "run-cell-multi.sh is readable at all" "yes" \
+  "$([[ -r "$RUN_CELL_MULTI" && -s "$RUN_CELL_MULTI" ]] && echo yes || echo no)"
+
+wired() { grep -qE "$2" "$1" && echo yes || echo no; }
+
+MUTANT="$TMP/run-cell-multi-without-the-gate.sh"
+grep -v -e 'tmux-teardown-check' -e 'record_driver_teardown ' -e 'tmux_teardown_verdict ||' \
+        -e 'DRV_TIMEOUTS' "$RUN_CELL_MULTI" > "$MUTANT"
+assert_eq "the mutant really is different from the original" "yes" \
+  "$(cmp -s "$RUN_CELL_MULTI" "$MUTANT" && echo no || echo yes)"
+
+assert_eq "sources the library" "yes" "$(wired "$RUN_CELL_MULTI" 'lib/tmux-teardown-check\.sh')"
+assert_eq "  …and the mutant does not" "no" "$(wired "$MUTANT" 'lib/tmux-teardown-check\.sh')"
+
+assert_eq "measures inside the wait loop" "yes" \
+  "$(wired "$RUN_CELL_MULTI" '^[[:space:]]*record_driver_teardown "\$\{DRV_ADAPTERS\[\$i\]\}" "\$\{DRV_PIDS\[\$i\]\}"')"
+assert_eq "  …and the mutant does not" "no" \
+  "$(wired "$MUTANT" '^[[:space:]]*record_driver_teardown "')"
+
+assert_eq "acts on the verdict, and a failure exits" "yes" \
+  "$(wired "$RUN_CELL_MULTI" '^tmux_teardown_verdict \|\| exit 1')"
+assert_eq "  …and the mutant does not" "no" "$(wired "$MUTANT" '^tmux_teardown_verdict \|\| exit 1')"
+
+assert_eq "captures each driver's own timeout for the bound" "yes" \
+  "$(wired "$RUN_CELL_MULTI" 'DRV_TIMEOUTS\+=\("\$timeout_s"\)')"
+assert_eq "  …and the mutant does not" "no" "$(wired "$MUTANT" 'DRV_TIMEOUTS')"
+
+# Both verdicts must be able to fail the run, under DIFFERENT codes — the same
+# pair lib/classify-failure.sh has arms for.
+assert_eq "a survivor fails the run under its own error code" "yes" \
+  "$(wired "$RUN_CELL_MULTI" 'driver_tmux_session_survived')"
+assert_eq "an unreadable lookup fails it under a DIFFERENT one" "yes" \
+  "$(wired "$RUN_CELL_MULTI" 'driver_tmux_teardown_unreadable')"
+
+# The pid this rig matches session names against is `$!`, which is the driver's
+# own `$$` only because the backgrounded command is a SIMPLE command bash execs
+# in the forked child. A pipeline or a `( … )` there would hand back a
+# different process's pid and the gate would match nothing, forever, silently.
+assert_eq "the driver is launched as a simple backgrounded command" "yes" \
+  "$(wired "$RUN_CELL_MULTI" '^[[:space:]]*>"\$sub/driver\.out" 2>&1 &$')"
+assert_eq "and its pid is taken straight from \$!" "yes" \
+  "$(wired "$RUN_CELL_MULTI" '^[[:space:]]*DRV_PIDS\+=\(\$!\)$')"
+
+echo ""
+if [[ "$fails" -eq 0 ]]; then
+  echo "run-cell-multi-teardown_test: ALL PASS"
+  exit 0
+fi
+echo "run-cell-multi-teardown_test: $fails FAILURE(S)" >&2
+exit 1

--- a/tools/onboarding-factory/scripts/lib/tmux-teardown-check.sh
+++ b/tools/onboarding-factory/scripts/lib/tmux-teardown-check.sh
@@ -1,0 +1,238 @@
+#!/usr/bin/env bash
+# tmux-teardown-check.sh — after a recording driver returns, assert that no tmux
+# session belonging to THAT RUN survived it (#1825, AC4).
+#
+# This file is sourced, not executed:
+#
+#   source "$SCRIPT_DIR/lib/tmux-teardown-check.sh"
+#   rc=0
+#   check_tmux_teardown "$DRIVER_PID" "$deadline" "$lifetime" "what bounds it" || rc=$?
+#   case "$rc" in
+#     0) : ;;                                    # nothing of this run's survived
+#     1) fail "$TMUX_TEARDOWN_SURVIVORS" ;;      # it leaked
+#     2) fail "$TMUX_TEARDOWN_REASON" ;;         # the check could not be MADE
+#   esac
+#
+# ---------------------------------------------------------------------------
+# Why this exists
+#
+# #1825: every recording whose recipe ended in `exit_clean` left a live agent
+# process and its detached tmux session behind, for months, because the only
+# thing that ever claimed the session was gone was the driver ASSERTING it —
+# `sleep 1; SES_ALIVE=0`. run-cell.sh then wrote a `complete` manifest over the
+# top. Nothing in the rig ever asked tmux.
+#
+# So this is the same treatment #1333 gave `driver.exit-reason`: the driver's
+# claim about itself is not evidence, and the rig looks for itself. The three
+# rules below are what make the looking worth anything.
+#
+# 1. THE RUN'S IDENTITY IS THE DRIVER'S PID. "Is any tmux session alive?" is the
+#    wrong question — a developer's own tmux, or a concurrent cell, would both
+#    answer yes. Every one of the eleven interactive drivers embeds its own `$$`
+#    as a whole '-'-delimited field of every session name it creates
+#    (`claudecode-onboard-<ts>-<pid>[-<idx>]`, `codex-onboard-<ts>-<pid>-r<n>`,
+#    `geminidrv-<pid>-<ts>-r<n>`, `ocdrv-<pid>-<ts>`,
+#    `aider-onboard-<uuid8>-<pid>`, …), so the driver's pid is exactly the
+#    identity that separates this run's leftovers from everyone else's. The
+#    convention is not assumed: a static per-driver tripwire under
+#    tools/onboarding-factory/internal/ asserts it for every current and future
+#    adapter.
+#
+#    The other '-'-delimited fields cannot collide with a pid: the timestamp
+#    field is `date +%s` (~1.8e9, three orders above any pid on a system whose
+#    pid_max is 99999 on macOS / 4194304 on Linux), the slot suffixes are
+#    `r1`/`resume1`/small integers that would have to be pid 1 or 2 to match,
+#    and aider's is 8 hex characters, which is one character longer than the
+#    widest pid it could be confused with.
+#
+# 2. "COULD NOT LOOK" IS NOT "IT IS GONE" — the rule this repo keeps relearning
+#    (#1485/#1492/#1513/#1524/#1533/#1537, AGENTS.md's "a verification mechanism
+#    must fail loudly when it cannot run"), and the one #1825's AC4 names
+#    explicitly. `tmux list-sessions` has THREE outcomes that a naive
+#    `|| true` collapses into one:
+#
+#      exit 0 + names           → a server is up; match the pid against them.
+#      exit 1 + "no server"     → there are legitimately ZERO sessions. Pass.
+#      anything else            → the lookup FAILED. Loud refusal, never a pass.
+#
+#    …plus the one that is not tmux's at all: no `tmux` on PATH. An interactive
+#    cell cannot have been recorded without it (six of the eleven drivers open
+#    with `command -v tmux || fail`; the other five simply die at their first
+#    `tmux new-session`), so a missing binary at this point is a broken lookup
+#    and not an empty session list. precheck.sh does not check for tmux, so
+#    this is the first place that can notice.
+#
+#    The polling, the "the predicate must say whether it could look at all"
+#    contract, and the refusal-on-a-silent-predicate all come from
+#    tools/lib/await-gone.sh rather than being written a fourth time here; this
+#    file supplies only the predicate and the pid matching. See that file's
+#    header for why a poll that reports through variables (and not stdout)
+#    is what keeps rule 2 whole.
+#
+# 3. GRACE, BOUNDED FROM BOTH ENDS. The driver has already returned, so the
+#    honest expectation is that the session is gone on the first look; the
+#    deadline is slack for a tmux server still winding down, not a latency
+#    being fitted. It is bounded from ABOVE too, by await_gone_bound: if the
+#    grace approached the cell's own driver timeout, an agent that took its
+#    time dying BY ITSELF would read exactly like a driver that tore its
+#    session down, and the check would stop asserting anything.
+
+_tmux_teardown_lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Bounded, loud-when-blind polling. Cross-tree source, same shape as
+# run-cell.sh:204 sourcing replaydata/_lib/assert-staging-path.sh — the rules in
+# await-gone.sh's header are repo-wide and this is their first production
+# caller, so it reuses them rather than growing a fourth copy of the poll.
+# shellcheck source=../../../lib/await-gone.sh
+. "$_tmux_teardown_lib_dir/../../../lib/await-gone.sh"
+
+# What a caller that names no bound gets in a refusal. A variable and not an
+# inline `${4:-…}` default for the reason await-gone.sh:156-160 measured on bash
+# 3.2: an apostrophe inside a parameter expansion's word is read as a QUOTE even
+# when the whole expansion is double-quoted, and the file fails to parse.
+TMUX_TEARDOWN_DEFAULT_WHAT="the cell own driver timeout"
+
+# The run identity the predicate matches session names against. Set by
+# check_tmux_teardown; a module-scope variable and not a predicate argument
+# because await_gone calls its predicate with no arguments by design.
+TMUX_TEARDOWN_PID=""
+
+# Outputs. Set by check_tmux_teardown on every call, read by its caller.
+#
+# shellcheck disable=SC2034  # SURVIVORS/REASON/ELAPSED are this library's
+# OUTPUT, unused within this file by design. Read by
+# tools/onboarding-factory/scripts/run-cell.sh (the tmux-teardown gate after
+# the driver returns) and asserted by lib/tmux-teardown-check_test.sh.
+TMUX_TEARDOWN_SURVIVORS=""
+# shellcheck disable=SC2034  # see above
+TMUX_TEARDOWN_REASON=""
+# shellcheck disable=SC2034  # see above
+TMUX_TEARDOWN_ELAPSED=0
+
+# tmux_teardown_look — the await_gone predicate (see that file's "The
+# predicate"). Takes no arguments; reports through AWAIT_GONE_LOOKED (was I able
+# to look at all) and AWAIT_GONE_ALIVE (what is still there, or why I could
+# not). Its own return status is ignored by await_gone on purpose, so every
+# branch here returns 0 and says what it means in the two variables.
+tmux_teardown_look() {
+  # Start from "I could not look". Every branch below either upgrades this to a
+  # real look or fills in the reason; starting from the permissive answer is how
+  # a branch someone adds later without thinking would default to a pass.
+  AWAIT_GONE_LOOKED=0
+  AWAIT_GONE_ALIVE=""
+
+  if [[ -z "${TMUX_TEARDOWN_PID:-}" ]]; then
+    AWAIT_GONE_ALIVE="no driver pid was recorded, so there is no run identity to match session names against — every surviving session would read as somebody else's"
+    return 0
+  fi
+
+  if ! command -v tmux >/dev/null 2>&1; then
+    AWAIT_GONE_ALIVE="no tmux binary on PATH — an interactive cell's driver cannot have recorded anything without one, so this is a lookup that failed, not an empty session list"
+    return 0
+  fi
+
+  local out status
+  out="$(tmux list-sessions -F '#{session_name}' 2>&1)"
+  status=$?
+
+  if [[ "$status" -ne 0 ]]; then
+    # The ONE legitimate non-zero: tmux's server exits with its last session, so
+    # "no server running" is how tmux spells "there are zero sessions". Every
+    # other non-zero is a lookup that failed and must not read as zero sessions.
+    case "$out" in
+      *"no server running"* | *"no current server"* | *"error connecting to"* | *"failed to connect to server"*)
+        AWAIT_GONE_LOOKED=1
+        AWAIT_GONE_ALIVE=""
+        return 0
+        ;;
+    esac
+    AWAIT_GONE_ALIVE="tmux list-sessions exited $status: ${out:-<no output at all>}"
+    return 0
+  fi
+
+  # Exit 0 with nothing named is NOT "zero sessions": a live server always owns
+  # at least one (it exits with the last), and it is exit 1 + "no server
+  # running" that reports emptiness. Empty output here means something answered
+  # for tmux without listing anything — unparseable, so a refusal.
+  if [[ -z "$out" ]]; then
+    AWAIT_GONE_ALIVE="tmux list-sessions succeeded but named no session — a running server always owns at least one, so this cannot be read as an empty list"
+    return 0
+  fi
+
+  # Match the pid as a WHOLE '-'-delimited field, never as a substring: pid 123
+  # must not match `…-1234-…` or a timestamp that happens to contain it. Padding
+  # both ends with '-' makes the first and last fields match the same way the
+  # middle ones do.
+  local name survivors=""
+  while IFS= read -r name; do
+    [[ -z "$name" ]] && continue
+    case "-${name}-" in
+      *-"$TMUX_TEARDOWN_PID"-*) survivors="${survivors:+$survivors }$name" ;;
+    esac
+  done <<< "$out"
+
+  # shellcheck disable=SC2034  # this pair IS the predicate's return value: the
+  # await_gone loop in tools/lib/await-gone.sh:259-283 reads both after calling
+  # us, and refuses the poll outright if either is left unset. The linter does
+  # not follow the `. …/await-gone.sh` above, so it cannot see the consumer.
+  AWAIT_GONE_LOOKED=1
+  # shellcheck disable=SC2034  # see above — a directive covers only the next
+  # command, and this half of the pair is the one carrying the survivors.
+  AWAIT_GONE_ALIVE="$survivors"
+  return 0
+}
+
+# check_tmux_teardown <driver-pid> <deadline-s> <lifetime-s> [what-the-lifetime-is]
+#
+#   0  no tmux session carrying <driver-pid> survives. TMUX_TEARDOWN_ELAPSED
+#      says how long that took to establish.
+#   1  at least one did. TMUX_TEARDOWN_SURVIVORS names them, so the caller's
+#      failure line can be acted on (`tmux kill-session -t …`) rather than
+#      merely believed.
+#   2  the check could not be MADE — a bad deadline/lifetime pair, or a lookup
+#      that failed. TMUX_TEARDOWN_REASON says which. Distinct from 1 because
+#      "it leaked" and "nothing was checked" are different answers, and the
+#      whole point of #1825 is that they must not print the same thing.
+#
+# <lifetime-s> is the cell's own driver timeout: the upper bound on how long the
+# session it is asking about could have lived. await_gone_bound refuses a
+# deadline that is not an order of magnitude under it — see rule 3 above.
+check_tmux_teardown() {
+  local pid="${1:-}" deadline="${2:-}" lifetime="${3:-}"
+  local what="${4:-$TMUX_TEARDOWN_DEFAULT_WHAT}"
+
+  TMUX_TEARDOWN_SURVIVORS=""
+  TMUX_TEARDOWN_REASON=""
+  TMUX_TEARDOWN_ELAPSED=0
+
+  case "$pid" in
+    '' | *[!0-9]*)
+      TMUX_TEARDOWN_REASON="tmux-teardown: refusing — the driver pid must be a whole number, got '$pid'. Without the run's identity there is nothing to tell this run's leftovers from another run's, and a check that cannot identify its subject must not report it gone"
+      printf '%s\n' "$TMUX_TEARDOWN_REASON" >&2
+      return 2
+      ;;
+  esac
+
+  TMUX_TEARDOWN_PID="$pid"
+
+  local rc=0
+  await_gone "$deadline" "$lifetime" tmux_teardown_look "$what" || rc=$?
+  # shellcheck disable=SC2034  # an OUTPUT, unused in this file by design —
+  # printed by run-cell.sh's tmux-teardown gate and asserted by
+  # lib/tmux-teardown-check_test.sh ("a survivor is polled for, not slept on").
+  TMUX_TEARDOWN_ELAPSED="$AWAIT_GONE_ELAPSED"
+
+  case "$rc" in
+    0) return 0 ;;
+    1)
+      # shellcheck disable=SC2034  # an OUTPUT: run-cell.sh puts it in the
+      # ERROR manifest's tmux_teardown_detail and on stderr, so the operator is
+      # told which session to kill rather than that one exists.
+      TMUX_TEARDOWN_SURVIVORS="$AWAIT_GONE_LAST"
+      return 1
+      ;;
+    *)
+      TMUX_TEARDOWN_REASON="$AWAIT_GONE_REASON"
+      return 2
+      ;;
+  esac
+}

--- a/tools/onboarding-factory/scripts/lib/tmux-teardown-check_test.sh
+++ b/tools/onboarding-factory/scripts/lib/tmux-teardown-check_test.sh
@@ -33,6 +33,11 @@ set -uo pipefail   # NOT -e: assertions capture non-zero return codes
 
 DIR="$(cd "$(dirname "$0")" && pwd)"
 SCRIPTS_DIR="$(cd "$DIR/.." && pwd)"
+# jq is a hard dependency of the run-cell.sh gate section at the bottom (it
+# reads the ERROR manifest the gate writes). Declared, not discovered: a suite
+# that skips its last section on a host without jq reports the same green as one
+# that ran it.
+command -v jq >/dev/null || { echo "tmux-teardown-check_test: jq is required" >&2; exit 2; }
 # shellcheck source=tmux-teardown-check.sh
 source "$DIR/tmux-teardown-check.sh"
 
@@ -272,6 +277,313 @@ assert_eq "an unreadable lookup fails it under a DIFFERENT one" "yes" \
 # disposition — see the comment above the call in run-cell.sh.
 assert_eq "the driver is not backgrounded" "no" \
   "$(wired "$RUN_CELL" '^[[:space:]]*"\$DRIVER".*&[[:space:]]*$')"
+
+# ===========================================================================
+# run-cell.sh's teardown gate: what it DOES with the verdict, and WHEN
+# ===========================================================================
+# Everything above grades the LIBRARY. This section grades run-cell.sh's use of
+# it, which is where #1825's review found the gate could still be skipped: the
+# measurement printed, and the VERDICT — the ERROR manifest, the error code, the
+# "kill the survivor with" line, the exit — sat ~64 lines further down, behind
+# `stop_recipe_mock` and two `recipe_runtime_assert_* || exit 5` gates. A driver
+# that aborts skips its teardown AND never writes its env receipt, so those two
+# fire together; the cell then exited 5 with NO manifest, classify-failure.sh
+# had nothing to read and graded the run `unknown`, and the record skill's
+# "never retry driver_session_leaked blind" rule never fired — the retry started
+# a second live agent beside the leaked one.
+#
+# HOW IT GETS AT IT. run-cell.sh is a top-to-bottom script: sourcing it would
+# spawn a daemon and drive a real agent. So the two spans that carry the
+# decisions are delimited by `# BEGIN <name>` / `# END <name>` markers,
+# EXTRACTED from the script's own source text here, and run in a generated
+# harness against stubs — the same extract-and-execute idiom
+# run-cell-multi-teardown_test.sh uses, and it is what stops this suite from
+# grading a copy that has drifted from the one that ships. The extraction
+# REFUSES loudly rather than grading an empty string.
+#
+# THE MUTATION FIXTURE (AGENTS.md: an ordering a change ADDS has no "before the
+# fix" to run red, so mutate what it protects and commit the mutation). The
+# pre-fix ordering is not described here, it is RECONSTRUCTED: the verdict block
+# is lifted out of the shipped text and re-appended after the two `|| exit 5`
+# gates, and the same leak-plus-failing-receipt fixture is run through it. It
+# exits 5 and writes no manifest, which is exactly the harm — so the shipped
+# block's green is the difference between two orderings of the same lines.
+
+RUN_CELL="$SCRIPTS_DIR/run-cell.sh"
+
+# extract_block <file> <name> — the lines strictly between the markers.
+extract_block() {
+  awk -v n="$2" '
+    $0 ~ ("^# BEGIN " n "([ \t]|$)") { inb = 1; next }
+    inb && $0 ~ ("^# END " n "[ \t]*$") { inb = 0; next }
+    inb { print }
+  ' "$1"
+}
+
+# require_block <name> — extract, or stop the suite. "The marker moved" and "the
+# gate is fine" must not both produce a green run.
+require_block() {
+  local name="$1" src
+  src="$(extract_block "$RUN_CELL" "$name")"
+  if [[ -z "$src" ]]; then
+    echo "tmux-teardown-check_test: REFUSING — no '# BEGIN $name' … '# END $name' block in $RUN_CELL." >&2
+    echo "  Every case below would have graded an empty string. Restore the markers or rename them here too." >&2
+    exit 1
+  fi
+  printf '%s\n' "$src"
+}
+
+PID_BLOCK="$(require_block driver_pid_capture)"
+GATE_BLOCK="$(require_block driver_teardown_gate)"
+
+echo "== the suite is grading the shipped spans, not a copy =="
+assert_eq "the pid-capture span really captures the pid" "yes" \
+  "$(grep -q 'DRIVER_PID=' <<< "$PID_BLOCK" && echo yes || echo no)"
+assert_eq "the gate span really contains the verdict" "yes" \
+  "$(grep -q 'driver_tmux_session_survived' <<< "$GATE_BLOCK" && echo yes || echo no)"
+assert_eq "…and both recipe-runtime gates it must precede" "2" \
+  "$(grep -cE '^recipe_runtime_assert_.* \|\| exit 5$' <<< "$GATE_BLOCK")"
+
+# mutant_block — the PRE-FIX ordering, rebuilt from the shipped lines: the
+# verdict lifted out and re-appended after everything else in the span.
+mutant_block() {
+  awk '
+    /^# BEGIN tmux_teardown_verdict$/ { inv = 1; next }
+    /^# END tmux_teardown_verdict$/   { inv = 0; next }
+    inv { v = v $0 "\n"; next }
+    { print }
+    END { printf "%s", v }
+  ' <<< "$GATE_BLOCK"
+}
+MUTANT_BLOCK="$(mutant_block)"
+assert_eq "the mutant really is a reordering, not a copy" "yes" \
+  "$([[ "$MUTANT_BLOCK" != "$GATE_BLOCK" ]] && echo yes || echo no)"
+assert_eq "…and it kept every line (only their order changed)" "yes" \
+  "$([[ "$(sort <<< "$MUTANT_BLOCK")" == "$(grep -v -e '^# BEGIN tmux_teardown_verdict$' -e '^# END tmux_teardown_verdict$' <<< "$GATE_BLOCK" | sort)" ]] && echo yes || echo no)"
+
+# --- The harness -----------------------------------------------------------
+# Per-case knobs, reset by run_gate's caller. Deliberately globals rather than
+# nine positional arguments: a case reads as the fixture it sets up.
+CASE_ENV_RECEIPT_RC=0    # what recipe_runtime_assert_env_receipt returns
+CASE_DRIVER_BODY=":"     # extra shell the stub driver runs before exiting
+CASE_PIDFILE_PRE=""      # "dir" → pre-create $STAGING/driver.pid AS A DIRECTORY
+CASE_TMUX="clean"        # clean | leak | broken
+
+# Outputs.
+GATE_RC=0
+GATE_OUT=""
+GATE_MANIFEST=""
+GATE_DRIVER_RAN=""
+
+# run_gate <case-name> <block-text> — generate a harness around the SHIPPED
+# span, run it in its own bash so an `exit` inside it is the thing under test
+# rather than the end of this suite, and report through the globals above.
+run_gate() {
+  local name="$1" block="$2"
+  local dir="$TMP/$name" staging
+  rm -rf "$dir"; mkdir -p "$dir/staging"
+  staging="$dir/staging"
+
+  # The stub driver. It always drops a marker, so "the wrapper never ran the
+  # driver" is observed rather than inferred from a missing pid.
+  {
+    echo '#!/usr/bin/env bash'
+    printf 'touch %s\n' "$dir/driver-ran"
+    # The wrapper shifts the pid path off before exec'ing, so the driver's own
+    # $1 is $STAGING. A case that wants to clobber the pid file gets its path
+    # by name instead of guessing at a positional.
+    printf 'PIDFILE=%s\n' "$staging/driver.pid"
+    printf '%s\n' "$CASE_DRIVER_BODY"
+    echo 'exit 0'
+  } > "$dir/driver.sh"
+  chmod +x "$dir/driver.sh"
+
+  [[ "$CASE_PIDFILE_PRE" == "dir" ]] && mkdir -p "$staging/driver.pid"
+
+  {
+    echo '#!/usr/bin/env bash'
+    echo 'set -euo pipefail'
+    printf 'source %s\n' "$DIR/tmux-teardown-check.sh"
+    echo 'AWAIT_GONE_POLL_SECONDS=0.02'
+    printf 'STAGING=%s\n' "$staging"
+    printf 'DRIVER=%s\n' "$dir/driver.sh"
+    echo 'ADAPTER=kiro-cli'
+    echo 'FOLDER=error-exit-nonzero'
+    echo 'UUID=00000000-0000-0000-0000-000000000000'
+    echo 'DRIVER_INPUT=hello'
+    echo 'TIMEOUT_S=10'
+    echo 'SCRIPT_JSON='"'"'[{"send":"hi"}]'"'"''
+    echo 'CELL_JSON='"'"'{}'"'"''
+    echo 'MOCK_ADDR='
+    case "$CASE_TMUX" in
+      leak)   echo 'tmux() { printf "%s\n" "kiro-clidrv-$(tr -d "[:space:]" < "$STAGING/driver.pid" 2>/dev/null)-1787641617-r1"; return 0; }' ;;
+      broken) echo 'tmux() { echo "lost server" >&2; return 1; }' ;;
+      *)      echo 'tmux() { echo "no server running on /private/tmp/tmux-501/default" >&2; return 1; }' ;;
+    esac
+    echo 'stop_recipe_mock() { return 0; }'
+    printf 'recipe_runtime_assert_env_receipt() { echo "runtime_gap: no receipt" >&2; return %s; }\n' "$CASE_ENV_RECEIPT_RC"
+    echo 'recipe_runtime_assert_mock_used() { return 0; }'
+    printf '%s\n' "$PID_BLOCK"
+    printf '%s\n' "$block"
+  } > "$dir/harness.sh"
+
+  GATE_RC=0
+  GATE_OUT="$(bash "$dir/harness.sh" 2>&1)" || GATE_RC=$?
+  GATE_MANIFEST="$(cat "$staging/run-manifest.json" 2>/dev/null || true)"
+  GATE_DRIVER_RAN="$([[ -e "$dir/driver-ran" ]] && echo yes || echo no)"
+  return 0
+}
+
+reset_case() {
+  CASE_ENV_RECEIPT_RC=0
+  CASE_DRIVER_BODY=":"
+  CASE_PIDFILE_PRE=""
+  CASE_TMUX="clean"
+  return 0
+}
+
+manifest_field() { jq -r "$1 // empty" <<< "$GATE_MANIFEST" 2>/dev/null || true; }
+
+# `case` inside a "$( … )" does not parse on the bash 3.2 this repo targets — the
+# pattern's `)` closes the substitution. Both live in functions for that reason.
+contains() { case "$1" in *"$2"*) echo yes ;; *) echo no ;; esac; }
+is_whole_number() { case "$1" in '' | *[!0-9]*) echo no ;; *) echo yes ;; esac; }
+
+echo "== the harness runs the shipped span at all =="
+reset_case
+run_gate healthy "$GATE_BLOCK"
+assert_eq "a clean cell with a clean receipt passes the gate" "0" "$GATE_RC"
+assert_eq "the driver ran" "yes" "$GATE_DRIVER_RAN"
+assert_eq "no ERROR manifest is written" "" "$GATE_MANIFEST"
+assert_contains "and the measurement was printed" "tmux teardown: clean" "$GATE_OUT"
+
+echo "== MUTATION — a leak AND a failing env receipt: the LEAK is what fails the cell =="
+# The exact pairing the review named: one aborting driver skips its teardown and
+# never writes its receipt. Before the reorder this exited 5 with no manifest.
+reset_case
+CASE_TMUX="leak"
+CASE_ENV_RECEIPT_RC=1
+run_gate leak_and_failing_receipt "$GATE_BLOCK"
+assert_eq "the cell fails under the tmux exit, not the recipe-runtime one" "1" "$GATE_RC"
+assert_eq "an ERROR manifest exists at all" "yes" \
+  "$([[ -n "$GATE_MANIFEST" ]] && echo yes || echo no)"
+assert_eq "under the leak's own error code" "driver_tmux_session_survived" "$(manifest_field .error)"
+assert_eq "so classify-failure.sh can read a detail" "leaked" "$(manifest_field .tmux_teardown)"
+assert_contains "the survivor is named so it can be killed" "kiro-clidrv-" "$(manifest_field .tmux_teardown_detail)"
+assert_contains "and the operator is told how" "tmux kill-session -t" "$GATE_OUT"
+
+echo "== MUTATION — the PRE-FIX ordering, on the same fixture: exit 5, no manifest =="
+# The verdict lifted out of the shipped text and re-appended after the two
+# `|| exit 5` gates. Same lines, same fixture, different order — and the leak
+# vanishes. This case is the committed proof that the block above is red when
+# the ordering regresses, not merely green today.
+reset_case
+CASE_TMUX="leak"
+CASE_ENV_RECEIPT_RC=1
+run_gate leak_and_failing_receipt_prefix_order "$MUTANT_BLOCK"
+assert_eq "the recipe-runtime gate exits first" "5" "$GATE_RC"
+assert_eq "and the leak leaves NO manifest for classify-failure.sh to read" "" "$GATE_MANIFEST"
+assert_eq "so nothing names the error" "" "$(manifest_field .error)"
+
+echo "== the same shipped fixture, flipped clean: the red came from the leak =="
+reset_case
+CASE_TMUX="clean"
+CASE_ENV_RECEIPT_RC=1
+run_gate clean_and_failing_receipt "$GATE_BLOCK"
+assert_eq "with no leak the recipe-runtime gate is reached and fails on its own" "5" "$GATE_RC"
+assert_eq "and no tmux manifest is written" "" "$GATE_MANIFEST"
+
+echo "== nothing that can exit sits between the measurement and the verdict =="
+# The static form of the rule the case above proves dynamically: a gate inserted
+# into that span would swallow the leak again, and a reviewer should be told by a
+# red suite rather than by a leaked agent. Comment lines are stripped first —
+# the span is thick with prose about `|| exit 5`.
+span_exits() {   # <file> → the executable `exit` lines between the two
+  awk '
+    /^  echo "tmux teardown: / { ins = 1; next }
+    /^# BEGIN tmux_teardown_verdict$/ { ins = 0 }
+    ins && $0 !~ /^[[:space:]]*#/ && $0 ~ /(^|[^[:alnum:]_])exit([^[:alnum:]_]|$)/ { print }
+  ' "$1"
+}
+assert_eq "the span is empty of exits in the shipped script" "" "$(span_exits "$RUN_CELL")"
+
+SPAN_MUTANT="$TMP/run-cell-with-a-gate-in-the-span.sh"
+awk '
+  { print }
+  /^  echo "tmux teardown: / { print "some_new_gate \"$STAGING\" || exit 7" }
+' "$RUN_CELL" > "$SPAN_MUTANT"
+assert_eq "the mutant really is different" "yes" \
+  "$(cmp -s "$RUN_CELL" "$SPAN_MUTANT" && echo no || echo yes)"
+assert_contains "…and the tripwire SEES it (so its green is not vacuous)" \
+  "exit 7" "$(span_exits "$SPAN_MUTANT")"
+
+# ---------------------------------------------------------------------------
+# driver.pid: a write failure is a driver.pid problem, not a tmux problem
+# ---------------------------------------------------------------------------
+# `bash -c 'printf "%s\n" "$$" > "$1" || exit 1; shift; exec "$@"'` exits 1
+# WITHOUT running the driver when it cannot write its pid file. DRIVER_PID is
+# then empty and the cell used to fail as driver_tmux_teardown_unreadable
+# saying "the driver pid must be a whole number, got ''" — under a heading with
+# the word tmux in it, so the operator goes and looks at tmux. The three ways
+# the pid can be unusable are three different first moves, so they get three
+# different sentences. Each fixture drives the SHIPPED wrapper.
+
+echo "== MUTATION — the pid wrapper cannot write driver.pid: the driver never runs =="
+# The injected failure: driver.pid is a DIRECTORY, so the wrapper's redirect
+# fails exactly as it does on an unwritable $STAGING. Staging itself stays
+# writable, so the manifest can still be written and asserted on.
+reset_case
+CASE_PIDFILE_PRE="dir"
+CASE_TMUX="leak"
+run_gate pidfile_unwritable "$GATE_BLOCK"
+assert_eq "the driver never ran" "no" "$GATE_DRIVER_RAN"
+assert_eq "the cell fails" "1" "$GATE_RC"
+assert_eq "as an unreadable teardown, never as a pass" "driver_tmux_teardown_unreadable" \
+  "$(manifest_field .error)"
+PIDFILE_DETAIL="$(manifest_field .tmux_teardown_detail)"
+assert_contains "the detail names driver.pid" "driver.pid was never written" "$PIDFILE_DETAIL"
+assert_contains "…and says it is not a tmux problem" "NOT a tmux one" "$PIDFILE_DETAIL"
+assert_eq "…and does NOT hand the operator the old tmux-flavoured sentence" "no" \
+  "$(contains "$PIDFILE_DETAIL" "must be a whole number")"
+
+echo "== MUTATION — driver.pid exists but is EMPTY: a different sentence =="
+# The wrapper ran, so the driver DID start; its sessions may be out there under
+# a name nothing can match. Collapsing this into the case above would tell the
+# operator the driver never ran, which is the opposite of true.
+reset_case
+CASE_DRIVER_BODY=': > "$PIDFILE"'
+CASE_TMUX="leak"
+run_gate pidfile_empty "$GATE_BLOCK"
+assert_eq "the driver DID run" "yes" "$GATE_DRIVER_RAN"
+assert_eq "the cell fails" "1" "$GATE_RC"
+assert_eq "as an unreadable teardown" "driver_tmux_teardown_unreadable" "$(manifest_field .error)"
+EMPTY_DETAIL="$(manifest_field .tmux_teardown_detail)"
+assert_contains "the detail says the file is there but unusable" "is empty or unreadable" "$EMPTY_DETAIL"
+assert_contains "…and that the driver may have left sessions behind" "may have left sessions behind" "$EMPTY_DETAIL"
+assert_eq "…and it is NOT the same sentence as the missing-file case" "yes" \
+  "$([[ "$EMPTY_DETAIL" != "$PIDFILE_DETAIL" ]] && echo yes || echo no)"
+
+echo "== MUTATION — driver.pid holds a non-number: a third sentence, quoting it =="
+reset_case
+CASE_DRIVER_BODY='printf "not-a-pid\n" > "$PIDFILE"'
+CASE_TMUX="leak"
+run_gate pidfile_garbage "$GATE_BLOCK"
+assert_eq "the cell fails" "1" "$GATE_RC"
+assert_eq "as an unreadable teardown" "driver_tmux_teardown_unreadable" "$(manifest_field .error)"
+GARBAGE_DETAIL="$(manifest_field .tmux_teardown_detail)"
+assert_contains "the detail quotes the value it could not use" "'not-a-pid'" "$GARBAGE_DETAIL"
+assert_contains "…and still says it is not a tmux problem" "Not a tmux problem" "$GARBAGE_DETAIL"
+assert_eq "…and it is NOT the empty-file sentence" "yes" \
+  "$([[ "$GARBAGE_DETAIL" != "$EMPTY_DETAIL" ]] && echo yes || echo no)"
+
+echo "== the healthy path still reports a real pid, so the three arms are reachable =="
+reset_case
+CASE_TMUX="leak"
+run_gate pidfile_healthy "$GATE_BLOCK"
+assert_eq "a leak with a good pid is still a LEAK, not an unreadable check" \
+  "driver_tmux_session_survived" "$(manifest_field .error)"
+assert_eq "and the pid recorded in the manifest is a whole number" "yes" \
+  "$(is_whole_number "$(manifest_field .driver_pid)")"
 
 echo ""
 if [[ "$fails" -eq 0 ]]; then

--- a/tools/onboarding-factory/scripts/lib/tmux-teardown-check_test.sh
+++ b/tools/onboarding-factory/scripts/lib/tmux-teardown-check_test.sh
@@ -1,0 +1,282 @@
+#!/usr/bin/env bash
+# tmux-teardown-check_test.sh — unit tests for tmux-teardown-check.sh. Plain
+# bash, no framework. Run directly or via scripts/smoke-test.sh.
+#
+# `tmux` is shadowed by a function, the same "shadow the external command" idiom
+# unapplied-grants-check_test.sh uses for curl and spawn-record-daemon_test.sh
+# uses for the kill builtin. What is under test is the DECISION — does a session
+# carrying this run's driver pid fail the cell, and does a lookup that could not
+# be made fail it just as loudly — never tmux's own client/server protocol. A
+# shadowed tmux makes every arm reachable with no server running anywhere, which
+# also means these tests are the only place the "no tmux binary" and "tmux
+# answered but not with a session list" arms are ever exercised: a real recording
+# host always has tmux and always has a server up by the time the gate runs.
+#
+# THE MUTATION FIXTURES (AGENTS.md: a check a change ADDS has no "before the fix"
+# to run red, so mutate what it protects and commit the mutation). This check
+# protects two different things, so there are two families:
+#
+#   the RUNTIME check — the cases below marked "MUTATION". Each one hands the
+#   library a tmux that behaves like the defect #1825 describes (a session that
+#   outlived its driver) or like a lookup that silently fails (no binary, an
+#   error that is not "no server", a success that lists nothing), and asserts a
+#   non-zero verdict. Flip any of them to the healthy fixture and the assertion
+#   goes red, which is what makes the passing green mean something.
+#
+#   the WIRING — the last section. A perfectly unit-tested library wired to
+#   nothing is exactly the failure mode #1825 is about, so run-cell.sh's source
+#   text is asserted to actually call it. That tripwire is itself run against a
+#   MUTATED COPY of run-cell.sh with the call deleted, so it cannot pass
+#   vacuously the day someone removes the call.
+
+set -uo pipefail   # NOT -e: assertions capture non-zero return codes
+
+DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPTS_DIR="$(cd "$DIR/.." && pwd)"
+# shellcheck source=tmux-teardown-check.sh
+source "$DIR/tmux-teardown-check.sh"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+fails=0
+pass() { local label="$1"; echo "  PASS: $label"; return 0; }
+fail() {
+  local label="$1" expected="$2" got="$3"
+  echo "  FAIL: $label — expected [$expected] got [$got]"
+  fails=$((fails + 1))
+  return 0
+}
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  [[ "$expected" == "$actual" ]] && pass "$label" || fail "$label" "$expected" "$actual"
+  return 0
+}
+assert_contains() {
+  local label="$1" needle="$2" haystack="$3"
+  case "$haystack" in
+    *"$needle"*) pass "$label" ;;
+    *) fail "$label" "*$needle*" "$haystack" ;;
+  esac
+  return 0
+}
+
+# Spend no real time between looks. Read by the SOURCED await-gone.sh (its
+# `sleep "$AWAIT_GONE_POLL_SECONDS"`), not by this file — the linter does not
+# follow a source, so it cannot see the consumer.
+# shellcheck disable=SC2034
+AWAIT_GONE_POLL_SECONDS=0.02
+
+# The deadline/lifetime pair every case uses. 1s is await_gone_bound's floor and
+# 10s is the smallest lifetime that clears its 10:1 wall, so the survivor case
+# spends one second and no more.
+DEADLINE=1
+LIFETIME=10
+
+# The pid whose sessions belong to "this run". Not a real process: the check
+# matches session NAMES, and asserting on a live pid would make the suite depend
+# on process scheduling it does not test.
+PID=95883
+
+# fake_tmux <mode> [args…] — shadow tmux with one that models a given server
+# state. Every mode ignores its arguments the way `tmux list-sessions -F …`
+# would be called, because what is graded is how the library reads the RESULT.
+fake_tmux() {
+  local mode="$1"; shift
+  FAKE_TMUX_NAMES=("$@")
+  case "$mode" in
+    sessions)   # a live server naming the sessions it owns
+      tmux() { printf '%s\n' "${FAKE_TMUX_NAMES[@]}"; return 0; } ;;
+    noserver)   # tmux's own spelling of "there are zero sessions"
+      tmux() { echo "no server running on /private/tmp/tmux-501/default" >&2; return 1; } ;;
+    broken)     # any other failure: a lookup that did NOT happen
+      tmux() { echo "lost server" >&2; return 1; } ;;
+    empty0)     # answered 0 but listed nothing — impossible for a live server
+      tmux() { return 0; } ;;
+    *) echo "fake_tmux: unknown mode $mode" >&2; return 1 ;;
+  esac
+  return 0
+}
+
+# run_check — call the library and report its verdict as one word, so a case
+# reads as the answer rather than as a return code.
+run_check() {
+  local rc=0
+  check_tmux_teardown "$@" >/dev/null 2>&1 || rc=$?
+  case "$rc" in
+    0) echo "gone" ;;
+    1) echo "survived" ;;
+    2) echo "cannot-look" ;;
+    *) echo "unexpected-$rc" ;;
+  esac
+  return 0
+}
+
+echo "== the driver's sessions are gone: the cell passes =="
+# Other runs' and the operator's own sessions are present throughout, so a pass
+# here also proves the check is scoped to THIS run rather than to "any tmux".
+fake_tmux sessions "claudecode-onboard-1787641617-11111" "irc" "work"
+assert_eq "a server with only other people's sessions" "gone" "$(run_check "$PID" "$DEADLINE" "$LIFETIME")"
+
+echo "== MUTATION — a session outlives the driver (#1825's defect): the cell FAILS =="
+fake_tmux sessions "work" "claudecode-onboard-1787641617-$PID" "irc"
+assert_eq "verdict" "survived" "$(run_check "$PID" "$DEADLINE" "$LIFETIME")"
+check_tmux_teardown "$PID" "$DEADLINE" "$LIFETIME" >/dev/null 2>&1
+assert_eq "names the survivor so it can be killed" \
+  "claudecode-onboard-1787641617-$PID" "$TMUX_TEARDOWN_SURVIVORS"
+
+echo "== MUTATION — every driver's naming scheme is matched, not just claudecode's =="
+# One session per naming scheme actually in the tree, each carrying $PID as a
+# '-'-delimited field. A scheme that stopped matching would leak silently, which
+# is the failure this whole gate exists to remove.
+for name in \
+  "claudecode-onboard-1787641617-$PID" \
+  "claudecode-onboard-1787641617-$PID-2" \
+  "codex-onboard-1787641617-$PID-r1" \
+  "pi-onboard-1787641617-$PID-r1" \
+  "kiro-clidrv-$PID-1787641617-r1" \
+  "geminidrv-$PID-1787641617-r1" \
+  "antigravitydrv-$PID-1787641617-r1" \
+  "mistral-vibedrv-$PID-1787641617-resume1" \
+  "copilotdrv-$PID-1787641617-1" \
+  "hermesdrv-$PID-1787641617-1" \
+  "ocdrv-$PID-1787641617" \
+  "aider-onboard-deadbeef-$PID"
+do
+  fake_tmux sessions "$name" "some-unrelated-session"
+  assert_eq "$name" "survived" "$(run_check "$PID" "$DEADLINE" "$LIFETIME")"
+done
+
+echo "== the pid matches a whole field only, never a substring =="
+# 958831 and 9588 both CONTAIN 95883. Matching on substrings would fail cells
+# because of a neighbouring run, and a gate that cries wolf gets switched off.
+fake_tmux sessions "codex-onboard-1787641617-958831-r1" "geminidrv-9588-1787641617-r1" "x-95883x-y"
+assert_eq "neighbouring pids do not count as this run" "gone" "$(run_check "$PID" "$DEADLINE" "$LIFETIME")"
+
+echo "== no server running: legitimately ZERO sessions, so the cell passes =="
+fake_tmux noserver
+assert_eq "tmux's exit-1 'no server running' is an empty list, not a failure" \
+  "gone" "$(run_check "$PID" "$DEADLINE" "$LIFETIME")"
+
+echo "== MUTATION — tmux fails for any OTHER reason: cannot look, so the cell FAILS =="
+fake_tmux broken
+assert_eq "verdict" "cannot-look" "$(run_check "$PID" "$DEADLINE" "$LIFETIME")"
+check_tmux_teardown "$PID" "$DEADLINE" "$LIFETIME" >/dev/null 2>&1
+assert_contains "the reason quotes what tmux actually said" "lost server" "$TMUX_TEARDOWN_REASON"
+
+echo "== MUTATION — tmux exits 0 but names nothing: unparseable, so the cell FAILS =="
+# A live server always owns at least one session (it exits with the last), so an
+# empty success is something answering for tmux without listing. Reading it as
+# "zero sessions" is the exact conflation #1825 is about.
+fake_tmux empty0
+assert_eq "verdict" "cannot-look" "$(run_check "$PID" "$DEADLINE" "$LIFETIME")"
+
+echo "== MUTATION — no tmux binary at all: cannot look, so the cell FAILS =="
+# The one arm that needs PATH rather than a shadow: `command -v` finds a shell
+# function whatever PATH says, so the function has to go away for the library to
+# see what a host without tmux sees.
+unset -f tmux
+mkdir -p "$TMP/emptybin"
+SAVED_PATH="$PATH"
+# shellcheck disable=SC2123  # PATH is exactly what this case is manipulating:
+# emptying the search path is the only way to show the library what a host with
+# no tmux sees. Restored four lines down, before anything external runs again.
+PATH="$TMP/emptybin"
+NO_TMUX_VERDICT="$(run_check "$PID" "$DEADLINE" "$LIFETIME")"
+check_tmux_teardown "$PID" "$DEADLINE" "$LIFETIME" >/dev/null 2>&1
+NO_TMUX_REASON="$TMUX_TEARDOWN_REASON"
+PATH="$SAVED_PATH"
+assert_eq "a missing binary is a broken lookup, never an empty session list" \
+  "cannot-look" "$NO_TMUX_VERDICT"
+assert_contains "the reason names the missing binary" "no tmux binary on PATH" "$NO_TMUX_REASON"
+
+echo "== MUTATION — no run identity: cannot look, so the cell FAILS =="
+# run-cell.sh reads the pid out of a file the driver's own process wrote. If that
+# file never appeared, every surviving session would read as somebody else's and
+# the gate would pass vacuously — so an unusable pid is a refusal, not a pass.
+fake_tmux sessions "claudecode-onboard-1787641617-$PID"
+assert_eq "empty pid" "cannot-look" "$(run_check "" "$DEADLINE" "$LIFETIME")"
+assert_eq "non-numeric pid" "cannot-look" "$(run_check "not-a-pid" "$DEADLINE" "$LIFETIME")"
+check_tmux_teardown "" "$DEADLINE" "$LIFETIME" >/dev/null 2>&1
+assert_contains "the reason says why identity matters" "run's identity" "$TMUX_TEARDOWN_REASON"
+
+echo "== MUTATION — a grace as long as the run itself is refused =="
+# await_gone_bound's wall from above. At that ratio a session whose agent died
+# BY ITSELF reads exactly like one the driver tore down, so the poll would stop
+# asserting anything — and a refusal is the honest answer, not a pass.
+fake_tmux sessions "claudecode-onboard-1787641617-$PID"
+assert_eq "deadline not 10x under the driver timeout" "cannot-look" "$(run_check "$PID" 60 120)"
+assert_eq "a zero deadline is not 'look exactly once'" "cannot-look" "$(run_check "$PID" 0 120)"
+
+echo "== a survivor is polled for, not slept on =="
+# The elapsed time is reported so a failure line can say how long it waited, and
+# the poll is bounded by the deadline it was given rather than running on.
+fake_tmux sessions "claudecode-onboard-1787641617-$PID"
+check_tmux_teardown "$PID" "$DEADLINE" "$LIFETIME" >/dev/null 2>&1
+assert_eq "waited the deadline and no longer" "yes" \
+  "$([[ "$TMUX_TEARDOWN_ELAPSED" -ge "$DEADLINE" && "$TMUX_TEARDOWN_ELAPSED" -le $((DEADLINE + 2)) ]] && echo yes || echo no)"
+echo "== a clean run reports at once =="
+fake_tmux sessions "somebody-elses-session"
+check_tmux_teardown "$PID" "$DEADLINE" "$LIFETIME" >/dev/null 2>&1
+assert_eq "no wait at all when the sessions are already gone" "0" "$TMUX_TEARDOWN_ELAPSED"
+
+unset -f tmux
+
+echo "== the gate is WIRED: run-cell.sh actually calls it (#1825) =="
+# A perfectly unit-tested library that nothing calls is the failure mode this
+# issue is about, one layer out. Each assertion below is paired with the same
+# assertion against a MUTATED COPY of run-cell.sh — the mutation is committed
+# here rather than described in a PR body, so a tripwire that stopped being able
+# to look is red instead of green.
+RUN_CELL="$SCRIPTS_DIR/run-cell.sh"
+assert_eq "run-cell.sh is readable at all" "yes" \
+  "$([[ -r "$RUN_CELL" && -s "$RUN_CELL" ]] && echo yes || echo no)"
+
+wired() {   # <file> <pattern> → yes/no
+  grep -qE "$2" "$1" && echo yes || echo no
+}
+
+MUTANT="$TMP/run-cell-without-the-gate.sh"
+# The mutation: delete every line that names the library or its entry point.
+grep -v -e 'tmux-teardown-check' -e 'check_tmux_teardown' -e 'DRIVER_PID_FILE' "$RUN_CELL" > "$MUTANT"
+assert_eq "the mutant really is different from the original" "yes" \
+  "$(cmp -s "$RUN_CELL" "$MUTANT" && echo no || echo yes)"
+
+assert_eq "sources the library" "yes" "$(wired "$RUN_CELL" 'lib/tmux-teardown-check\.sh')"
+assert_eq "  …and the mutant does not (the tripwire can go red)" "no" \
+  "$(wired "$MUTANT" 'lib/tmux-teardown-check\.sh')"
+
+assert_eq "calls check_tmux_teardown" "yes" "$(wired "$RUN_CELL" '^[[:space:]]*check_tmux_teardown ')"
+assert_eq "  …and the mutant does not" "no" "$(wired "$MUTANT" '^[[:space:]]*check_tmux_teardown ')"
+
+assert_eq "passes it the pid it captured from the driver" "yes" \
+  "$(wired "$RUN_CELL" 'check_tmux_teardown "\$DRIVER_PID"')"
+assert_eq "  …and the mutant does not" "no" \
+  "$(wired "$MUTANT" 'check_tmux_teardown "\$DRIVER_PID"')"
+
+assert_eq "captures that pid from the driver's own process" "yes" \
+  "$(wired "$RUN_CELL" 'DRIVER_PID_FILE')"
+assert_eq "  …and the mutant does not" "no" "$(wired "$MUTANT" 'DRIVER_PID_FILE')"
+
+# Both verdicts have to be able to FAIL the cell, and under DIFFERENT error
+# codes: "it leaked" and "nothing was checked" printing the same thing is the
+# bug, not the fix.
+assert_eq "a survivor fails the cell under its own error code" "yes" \
+  "$(wired "$RUN_CELL" 'driver_tmux_session_survived')"
+assert_eq "an unreadable lookup fails it under a DIFFERENT one" "yes" \
+  "$(wired "$RUN_CELL" 'driver_tmux_teardown_unreadable')"
+
+# The pid capture only works because the driver stays in the FOREGROUND and
+# `exec`s into the process whose pid was written. A `&` on the driver line would
+# hand back a pid too, but silently changes the driver's stdin and its SIGINT
+# disposition — see the comment above the call in run-cell.sh.
+assert_eq "the driver is not backgrounded" "no" \
+  "$(wired "$RUN_CELL" '^[[:space:]]*"\$DRIVER".*&[[:space:]]*$')"
+
+echo ""
+if [[ "$fails" -eq 0 ]]; then
+  echo "tmux-teardown-check_test: ALL PASS"
+  exit 0
+fi
+echo "tmux-teardown-check_test: $fails FAILURE(S)" >&2
+exit 1

--- a/tools/onboarding-factory/scripts/run-cell-multi.sh
+++ b/tools/onboarding-factory/scripts/run-cell-multi.sh
@@ -84,6 +84,14 @@ source "$SCRIPT_DIR/lib/completeness-check.sh"
 # CODEX_HOME, i.e. exactly the one-rig-only drift #1214 is about.
 # shellcheck source=lib/agent-home.sh
 source "$SCRIPT_DIR/lib/agent-home.sh"
+# "Did the driver's tmux sessions actually die?" — the same library run-cell.sh
+# sources, wired here for the same reason #1214 made the daemon lifecycle
+# shared: a gate that lands in one rig and not the other is the DEFAULT outcome,
+# not the unlucky one. This rig needs it more, not less: it is coexist-only by
+# construction, so a leaked agent keeps running next to the operator's
+# production daemon, in a shared workspace two adapters were both writing to.
+# shellcheck source=lib/tmux-teardown-check.sh
+source "$SCRIPT_DIR/lib/tmux-teardown-check.sh"
 
 DRY_RUN=0
 positional=()
@@ -303,7 +311,12 @@ spawn_record_daemon "$DAEMON" "$STAGING" "$ONBOARD_BIND" "$ONBOARD_HOME" "$ADAPT
 # --- Launch every adapter's interactive driver CONCURRENTLY -------------
 # All share $SHARED_CWD (the same workspace). Each gets its own staging
 # subdir, fresh preferred-UUID, settings.json, and the cell's script.
-declare -a DRV_PIDS=() DRV_ADAPTERS=()
+# DRV_TIMEOUTS is the third parallel array (bash 3.2 — no associative arrays):
+# each driver's own `timeout_seconds`, which the teardown gate below needs as
+# the upper bound on how long the session it asks about could have lived. It is
+# per-ADAPTER, not per-run — the two agents in a cross-adapter cell routinely
+# declare different timeouts — so it cannot be re-derived after this loop.
+declare -a DRV_PIDS=() DRV_ADAPTERS=() DRV_TIMEOUTS=()
 for a in "${ADAPTERS[@]}"; do
   sub="$STAGING/$a"
   mkdir -p "$sub"
@@ -318,9 +331,123 @@ for a in "${ADAPTERS[@]}"; do
   IRRLICHT_ONBOARD_CWD="$SHARED_CWD" \
     "$driver" "$sub" "$uuid" "$timeout_s" "$sub/settings.json" "$script_json" \
     >"$sub/driver.out" 2>&1 &
+  # `$!` is the RUN IDENTITY the teardown gate matches session names against,
+  # and this rig needs no `driver.pid` file to learn it (run-cell.sh does, since
+  # its call is in the foreground): the command backgrounded above is a simple
+  # command, so bash forks once and execs the driver in that same child — `$!`
+  # and the `$$` the driver goes on to embed in its tmux session names are one
+  # number. Measured on this bash rather than assumed:
+  #     $ FOO=bar ./drv.sh a b c >out 2>&1 & ; echo "parent \$! = $!"; wait; cat out
+  #     parent $! = 81518
+  #     driver sees $$ = 81518
+  # (bash 3.2.57(1)-release, arm64-apple-darwin25 — the recording host.)
   DRV_PIDS+=($!)
   DRV_ADAPTERS+=("$a")
+  DRV_TIMEOUTS+=("$timeout_s")
 done
+
+# --- Did each driver's tmux sessions actually die? (#1825 / AC4) --------
+# Same two-part shape as run-cell.sh:441-489 — MEASURE the instant a driver
+# returns, act on the VERDICT further down — for the same reason: everything
+# after the driver returns (the daemon drain, the recording pick) takes time,
+# and a look taken after it is strictly more lenient than the one this gate is
+# supposed to be taking.
+#
+# Per driver, not per run: each adapter's sessions carry its OWN pid, so the
+# check is scoped to one driver at a time and a survivor can be attributed. The
+# measurement runs inside the wait loop, so driver 0's sessions are inspected
+# while driver 1 may still be live — which is fine and deliberate, because pid
+# scoping is what separates them.
+TMUX_TEARDOWN_JSON="{}"   # adapter -> {status, detail, driver_pid}
+TMUX_LEAKED=""            # space-joined adapters whose sessions outlived them
+TMUX_UNREADABLE=""        # space-joined adapters whose check could not be made
+
+# BEGIN record_driver_teardown — extracted verbatim and executed against a
+# shadowed tmux by lib/run-cell-multi-teardown_test.sh. Keep the markers.
+record_driver_teardown() {
+  local a="$1" pid="$2" lifetime="$3"
+  local deadline status detail rc=0
+  # The deadline/lifetime pair await_gone_bound checks, computed exactly as
+  # run-cell.sh:469-472 computes it (a tenth of the driver timeout, capped at 5s
+  # so a long cell does not buy a long wait for a session that should already be
+  # gone, floored at 1s so it can never become the "look exactly once" deadline
+  # await_gone_bound refuses). Duplicated rather than shared because the pair is
+  # the CALLER's policy, not the library's — but see the note in the report:
+  # a tmux_teardown_deadline_for helper in the lib would be the better home.
+  deadline=$(( lifetime / 10 ))
+  if [[ "$deadline" -gt 5 ]]; then deadline=5; fi
+  if [[ "$deadline" -lt 1 ]]; then deadline=1; fi
+
+  check_tmux_teardown "$pid" "$deadline" "$lifetime" "the cell's own driver timeout" || rc=$?
+  case "$rc" in
+    0) status="clean"
+       detail="no tmux session carries driver pid ${pid:-<unrecorded>} (settled after ${TMUX_TEARDOWN_ELAPSED}s)" ;;
+    1) status="leaked"
+       detail="$TMUX_TEARDOWN_SURVIVORS"
+       TMUX_LEAKED="${TMUX_LEAKED:+$TMUX_LEAKED }$a" ;;
+    *) status="unreadable"
+       detail="$TMUX_TEARDOWN_REASON"
+       TMUX_UNREADABLE="${TMUX_UNREADABLE:+$TMUX_UNREADABLE }$a" ;;
+  esac
+  TMUX_TEARDOWN_JSON="$(jq -n \
+    --argjson o "$TMUX_TEARDOWN_JSON" \
+    --arg k "$a" --arg status "$status" --arg detail "$detail" --arg pid "$pid" \
+    '$o + {($k): {status: $status, detail: $detail, driver_pid: $pid}}')"
+  echo "tmux teardown [$a]: $status — $detail"
+  return 0
+}
+# END record_driver_teardown
+
+# BEGIN tmux_teardown_verdict — same extraction contract as above.
+#
+# ONE LEAKING DRIVER FAILS THE WHOLE RUN. Not "only that adapter's cell", for
+# two reasons that are specific to this rig rather than tidiness:
+#
+#   1. There is no per-adapter verdict to degrade. This rig writes ONE
+#      run-manifest.json for the run and promote-recording.sh takes the staging
+#      dir as a unit; "adapter A's fixture is fine, adapter B's is not" is not a
+#      state it can express.
+#   2. The leak is not confined to the leaker. Every adapter's events.jsonl is
+#      curated over the WHOLE workspace — ALL_SIDS unions every session of every
+#      adapter in — and all of them share one cwd and one daemon. A still-live
+#      agent is therefore inside every fixture this run would stage, not just
+#      its own, so promoting the "unaffected" ones would promote fixtures whose
+#      workspace was still changing while they were cut.
+#
+# When both a leak and an unreadable check happened, the LEAK names the manifest:
+# it is the finding with an action attached (kill the session), and the
+# unreadable adapters are still listed in the per-adapter detail so neither is
+# lost. They stay distinct codes for the same reason run-cell.sh keeps them
+# distinct — "it leaked" and "nothing was checked" must not print the same thing.
+tmux_teardown_verdict() {
+  [[ -n "$TMUX_LEAKED" || -n "$TMUX_UNREADABLE" ]] || return 0
+
+  local TMUX_MULTI_ERROR
+  if [[ -n "$TMUX_LEAKED" ]]; then
+    TMUX_MULTI_ERROR="driver_tmux_session_survived"
+  else
+    TMUX_MULTI_ERROR="driver_tmux_teardown_unreadable"
+  fi
+  write_error_manifest "$TMUX_MULTI_ERROR" \
+    "$(jq -nc \
+        --argjson tmux_teardown "$TMUX_TEARDOWN_JSON" \
+        --arg tmux_teardown_leaked "$TMUX_LEAKED" \
+        --arg tmux_teardown_unreadable "$TMUX_UNREADABLE" \
+        --arg tmux_teardown_detail "leaked=[${TMUX_LEAKED:-none}] unreadable=[${TMUX_UNREADABLE:-none}]" \
+        '{tmux_teardown: $tmux_teardown,
+          tmux_teardown_leaked: $tmux_teardown_leaked,
+          tmux_teardown_unreadable: $tmux_teardown_unreadable,
+          tmux_teardown_detail: $tmux_teardown_detail}')"
+  if [[ -n "$TMUX_LEAKED" ]]; then
+    echo "ERROR: tmux sessions outlived their driver — adapter(s): $TMUX_LEAKED" >&2
+    echo "  kill the survivor(s) with: tmux kill-session -t <name> (names are in run-manifest.json .tmux_teardown)" >&2
+  fi
+  if [[ -n "$TMUX_UNREADABLE" ]]; then
+    echo "ERROR: the tmux-teardown check could not be made — adapter(s): $TMUX_UNREADABLE" >&2
+  fi
+  return 1
+}
+# END tmux_teardown_verdict
 
 # Wait for all drivers; record each exit status.
 DRV_FAIL=0
@@ -332,11 +459,21 @@ for i in "${!DRV_PIDS[@]}"; do
     echo "driver ${DRV_ADAPTERS[$i]}: FAILED (exit $rc)" >&2
     DRV_FAIL=1
   fi
+  # Measured HERE, one statement after this driver returned — see the block
+  # comment above. A driver that FAILED is measured too: a crashed driver is
+  # the likeliest one to have skipped its own teardown.
+  record_driver_teardown "${DRV_ADAPTERS[$i]}" "${DRV_PIDS[$i]}" "${DRV_TIMEOUTS[$i]}"
 done
 
 # --- Drain the daemon ---------------------------------------------------
 stop_record_daemon   # also disarms the EXIT trap it armed
 DAEMON_SHUTDOWN="$(cat "$STAGING/daemon.shutdown" 2>/dev/null || echo unknown)"
+
+# The teardown VERDICT, taken here rather than in the wait loop: this is the
+# first line where DAEMON_SHUTDOWN is known, so the ERROR manifest carries the
+# same envelope as every other failure path instead of a placeholder — and the
+# daemon is drained and the operator's agent config restored before we exit.
+tmux_teardown_verdict || exit 1
 
 # --- Locate the single recording ----------------------------------------
 RECORDING="$(pick_isolated_recording "$STAGING/recordings" '*.jsonl')" || true

--- a/tools/onboarding-factory/scripts/run-cell.sh
+++ b/tools/onboarding-factory/scripts/run-cell.sh
@@ -577,6 +577,7 @@ write_driver_env
 # Ctrl-C on the recording operator's terminal, to learn a pid the exec wrapper
 # hands over for free. The wrapper keeps the call in the foreground, in the same
 # process group, with the same stdin, argv and exit status as before.
+# BEGIN driver_pid_capture
 DRIVER_PID_FILE="$STAGING/driver.pid"
 set +e
 bash -c 'printf "%s\n" "$$" > "$1" || exit 1; shift; exec "$@"' \
@@ -585,14 +586,21 @@ bash -c 'printf "%s\n" "$$" > "$1" || exit 1; shift; exec "$@"' \
 set -e
 DRIVER_REASON="$(cat "$STAGING/driver.exit-reason" 2>/dev/null || echo "unknown")"
 DRIVER_PID="$(tr -d '[:space:]' < "$DRIVER_PID_FILE" 2>/dev/null || true)"
+# END driver_pid_capture
 
+# BEGIN driver_teardown_gate
 # --- Did the driver's tmux sessions actually die? MEASURE (#1825 / AC4) --
 # Measured HERE, one line after the driver returns and before anything else
 # gets a chance to take time — the daemon flush below alone spends 6s on the
 # attach path, and a look taken after it is a strictly more lenient look. The
-# VERDICT is acted on further down, at the first point where
-# write_error_manifest exists, so the failure is a structured manifest like
-# every other hard gate rather than a bare exit.
+# VERDICT is acted on IMMEDIATELY below — the only thing between them is the
+# manifest plumbing the verdict needs, which runs no command that can fail. It
+# used to sit ~64 lines further down, behind `stop_recipe_mock` and two
+# `recipe_runtime_assert_* || exit 5` gates, so a driver that both leaked a
+# session and skipped its env receipt (one abort causes both) exited 5 with no
+# manifest at all: classify-failure.sh had nothing to read, graded the run
+# `unknown`, and the "never retry driver_session_leaked blind" rule never
+# fired — a retry then started a second live agent beside the leaked one.
 #
 # Scoped to interactive cells by the same $SCRIPT_JSON discriminator that chose
 # the driver above, so both halves stay honest: an interactive driver cannot
@@ -602,70 +610,105 @@ DRIVER_PID="$(tr -d '[:space:]' < "$DRIVER_PID_FILE" 2>/dev/null || true)"
 TMUX_GATE_STATUS="skipped"
 TMUX_GATE_DETAIL="headless cell — no interactive driver ran, and no driver.sh uses tmux"
 if [[ -n "$SCRIPT_JSON" ]]; then
-  # The pair await_gone_bound checks (see the lib header's rule 3). The
-  # lifetime is the cell's own driver timeout — the upper bound on how long the
-  # session could have lived; the grace is a tenth of it, capped at 5s so a
-  # 900s cell does not buy a 90s wait for a session that should already be gone,
-  # and floored at 1s so the arithmetic can never produce the "look exactly
-  # once" deadline await_gone_bound refuses. A cell whose timeout is under 10s
-  # therefore fails the bound and is reported LOUDLY as unreadable, which is the
-  # honest answer: at that ratio the check would assert nothing. (Every
-  # applicable cell today declares 60s or more.)
-  TEARDOWN_LIFETIME_S="$TIMEOUT_S"
-  TEARDOWN_DEADLINE_S=$(( TEARDOWN_LIFETIME_S / 10 ))
-  if [[ "$TEARDOWN_DEADLINE_S" -gt 5 ]]; then TEARDOWN_DEADLINE_S=5; fi
-  if [[ "$TEARDOWN_DEADLINE_S" -lt 1 ]]; then TEARDOWN_DEADLINE_S=1; fi
+  # Before tmux is asked anything: is there a run identity to ask ABOUT? The pid
+  # comes from a file the driver's own process wrote (the driver_pid_capture
+  # block above), and the two ways it can be unusable have different first moves
+  # for the operator, so they
+  # get different sentences:
+  #
+  #   no file at all      → the `bash -c` wrapper exited 1 on its own `printf >`
+  #                         before it could `exec` the driver — that write is
+  #                         the only thing between it and the exec, and an
+  #                         unwritable $STAGING is what makes it fail. So the
+  #                         driver almost certainly never ran, and there is
+  #                         nothing of this run's for tmux to be holding.
+  #   a file with garbage → the wrapper DID run, so the driver started, and its
+  #                         sessions may well be out there under a name no pid
+  #                         of ours can match.
+  #
+  # Both are `unreadable` — "could not look" is never "it is gone" — but they
+  # are not the same problem. check_tmux_teardown's own refusal names only the
+  # value ("the driver pid must be a whole number, got ''"), and an operator who
+  # reads that under a heading with the word tmux in it goes and looks at tmux.
+  DRIVER_PID_PROBLEM=""
+  if [[ ! -f "$DRIVER_PID_FILE" ]]; then
+    DRIVER_PID_PROBLEM="driver.pid was never written at $DRIVER_PID_FILE — the pid wrapper exited before it could exec the driver, so the driver almost certainly never ran. This is a staging-writability problem, NOT a tmux one: tmux was not asked anything"
+  elif [[ -z "$DRIVER_PID" ]]; then
+    DRIVER_PID_PROBLEM="driver.pid at $DRIVER_PID_FILE is empty or unreadable — the wrapper ran, so the driver DID start and may have left sessions behind under a name this run can no longer match. Not a tmux problem: tmux was not asked anything"
+  elif [[ -n "${DRIVER_PID//[0-9]/}" ]]; then
+    DRIVER_PID_PROBLEM="driver.pid at $DRIVER_PID_FILE holds '$DRIVER_PID', which is not a whole number — the wrapper ran, so the driver DID start and may have left sessions behind under a name this run can no longer match. Not a tmux problem: tmux was not asked anything"
+  fi
 
-  TMUX_GATE_RC=0
-  check_tmux_teardown "$DRIVER_PID" "$TEARDOWN_DEADLINE_S" "$TEARDOWN_LIFETIME_S" \
-    "the cell's own driver timeout" || TMUX_GATE_RC=$?
-  case "$TMUX_GATE_RC" in
-    0) TMUX_GATE_STATUS="clean"
-       TMUX_GATE_DETAIL="no tmux session carries driver pid ${DRIVER_PID:-<unrecorded>} (settled after ${TMUX_TEARDOWN_ELAPSED}s)" ;;
-    1) TMUX_GATE_STATUS="leaked"
-       TMUX_GATE_DETAIL="$TMUX_TEARDOWN_SURVIVORS" ;;
-    *) TMUX_GATE_STATUS="unreadable"
-       TMUX_GATE_DETAIL="$TMUX_TEARDOWN_REASON" ;;
-  esac
+  if [[ -n "$DRIVER_PID_PROBLEM" ]]; then
+    TMUX_GATE_STATUS="unreadable"
+    TMUX_GATE_DETAIL="$DRIVER_PID_PROBLEM"
+  else
+    # The pair await_gone_bound checks (see the lib header's rule 3). The
+    # lifetime is the cell's own driver timeout — the upper bound on how long the
+    # session could have lived; the grace is a tenth of it, capped at 5s so a
+    # 900s cell does not buy a 90s wait for a session that should already be gone,
+    # and floored at 1s so the arithmetic can never produce the "look exactly
+    # once" deadline await_gone_bound refuses. A cell whose timeout is under 10s
+    # therefore fails the bound and is reported LOUDLY as unreadable, which is the
+    # honest answer: at that ratio the check would assert nothing. (Every
+    # applicable cell today declares 60s or more.)
+    TEARDOWN_LIFETIME_S="$TIMEOUT_S"
+    TEARDOWN_DEADLINE_S=$(( TEARDOWN_LIFETIME_S / 10 ))
+    if [[ "$TEARDOWN_DEADLINE_S" -gt 5 ]]; then TEARDOWN_DEADLINE_S=5; fi
+    if [[ "$TEARDOWN_DEADLINE_S" -lt 1 ]]; then TEARDOWN_DEADLINE_S=1; fi
+
+    TMUX_GATE_RC=0
+    check_tmux_teardown "$DRIVER_PID" "$TEARDOWN_DEADLINE_S" "$TEARDOWN_LIFETIME_S" \
+      "the cell's own driver timeout" || TMUX_GATE_RC=$?
+    case "$TMUX_GATE_RC" in
+      0) TMUX_GATE_STATUS="clean"
+         TMUX_GATE_DETAIL="no tmux session carries driver pid ${DRIVER_PID:-<unrecorded>} (settled after ${TMUX_TEARDOWN_ELAPSED}s)" ;;
+      1) TMUX_GATE_STATUS="leaked"
+         TMUX_GATE_DETAIL="$TMUX_TEARDOWN_SURVIVORS" ;;
+      *) TMUX_GATE_STATUS="unreadable"
+         TMUX_GATE_DETAIL="$TMUX_TEARDOWN_REASON" ;;
+    esac
+  fi
   echo "tmux teardown: $TMUX_GATE_STATUS — $TMUX_GATE_DETAIL"
 fi
 
-# The mock has nothing left to serve; stop it before the daemon so its log is
-# complete in staging when the recorder flushes.
-stop_recipe_mock
-recipe_runtime_assert_env_receipt "$STAGING" "$(basename "$DRIVER")" || exit 5
-recipe_runtime_assert_mock_used "$STAGING" "$CELL_JSON" "$MOCK_ADDR" || exit 5
-
-# Flush the daemon's recorder before we curate.
-#  - isolated: SIGINT and wait for graceful shutdown (flushes on Close).
-#  - attached: just wait 6s — the recorder's 5s periodic flush + 1s
-#    slack is enough to land all writes from this run on disk. The
-#    user's daemon keeps running and the dashboard stays connected.
-if [[ "$ATTACH" == "1" ]]; then
-  echo "attached" > "$STAGING/daemon.shutdown"
-  echo "attach: waiting 6s for recorder flush..."
-  sleep 6
-else
-  stop_record_daemon
-fi
-
-# --- Read driver-resolved transcript + actual UUID ----------------------
+# --- Driver outputs + the ERROR-manifest writer -------------------------
+# Everything the tmux VERDICT below needs, and nothing else. Placed between the
+# measurement and its verdict deliberately: not one line here can exit. Both
+# reads fall back rather than failing, the assignment is a string, and the two
+# definitions run no command at all — so the verdict below really is the first
+# thing that ACTS after the driver returns, and no gate can be inserted above it
+# by accident.
+#
+# transcript.path and session.uuid are DRIVER outputs, written before it
+# returned. They used to be read after the daemon flush, which was simply later
+# than they were available.
 TRANSCRIPT="$(cat "$STAGING/transcript.path" 2>/dev/null || true)"
 ACTUAL_UUID="$(cat "$STAGING/session.uuid" 2>/dev/null || true)"
 
 MANIFEST="$STAGING/run-manifest.json"
-DAEMON_SHUTDOWN="$(cat "$STAGING/daemon.shutdown" 2>/dev/null || echo "unknown")"
+
+# daemon_shutdown_state — how the recorder was stopped, read at CALL time from
+# the file the flush writes. Deliberately NOT snapshotted into a variable here:
+# write_error_manifest can now fire BEFORE the flush (the verdict immediately
+# below), and a value captured before that file exists would be baked into every
+# later manifest too. Read late, it is "unknown" for the pre-flush callers —
+# which is the truth, the daemon is still up — and exact for everyone after.
+daemon_shutdown_state() {
+  cat "$STAGING/daemon.shutdown" 2>/dev/null || echo "unknown"
+}
 
 # Write an ERROR-verdict run-manifest with the standard envelope plus
 # error-specific fields supplied as a JSON object (pass '{}' for none).
 #
-# Defined HERE — at the first line where all of its inputs exist (ACTUAL_UUID
-# and DRIVER_REASON from the driver, DAEMON_SHUTDOWN from the flush above) —
-# rather than further down next to its first caller, so that EVERY hard gate
-# after the driver returns can use it. It used to sit below the recording
-# picker, which meant the picker's own `|| exit 1` left no manifest at all
-# (#1825): a gate placed after it would have been skipped on exactly the runs
-# that had already gone wrong.
+# Defined HERE — the first line where all of its inputs exist (ACTUAL_UUID and
+# DRIVER_REASON from the driver just above, the daemon's shutdown reason read
+# lazily) — rather than further down next to a caller, so that EVERY hard gate
+# after the driver returns can use it. It has been moved up twice for that
+# reason: it sat below the recording picker, whose own `|| exit 1` then left no
+# manifest at all, and it sat below `recipe_runtime_assert_* || exit 5`, which
+# left the tmux gate below unreachable on exactly the runs that had leaked
+# (#1825).
 write_error_manifest() {
   local error_code="$1"
   local extras_json="$2"
@@ -675,7 +718,7 @@ write_error_manifest() {
     --arg session_uuid "$ACTUAL_UUID" \
     --arg error "$error_code" \
     --arg driver_exit_reason "$DRIVER_REASON" \
-    --arg daemon_shutdown "$DAEMON_SHUTDOWN" \
+    --arg daemon_shutdown "$(daemon_shutdown_state)" \
     --arg staging "$STAGING" \
     --argjson extras "$extras_json" \
     '{adapter: $adapter,
@@ -689,14 +732,23 @@ write_error_manifest() {
     > "$MANIFEST"
 }
 
+# BEGIN tmux_teardown_verdict
 # --- Did the driver's tmux sessions actually die? VERDICT (#1825 / AC4) --
-# The measurement was taken the instant the driver returned; this is where it
-# is acted on. A hard gate, not advisory: unlike the completeness check (whose
-# header documents a real ~7% legitimately-incomplete population), a tmux
-# session still carrying THIS run's driver pid has no legitimate population —
-# the driver said it was gone, and it is not. `unreadable` fails just as hard
-# and under its own error code, because #1825 is precisely the bug of an
-# unasked question and an answered one printing the same thing.
+# The measurement was taken the instant the driver returned; this is where it is
+# acted on, and it is the FIRST thing after the driver that can exit. A hard
+# gate, not advisory: unlike the completeness check (whose header documents a
+# real ~7% legitimately-incomplete population), a tmux session still carrying
+# THIS run's driver pid has no legitimate population — the driver said it was
+# gone, and it is not. `unreadable` fails just as hard and under its own error
+# code, because #1825 is precisely the bug of an unasked question and an
+# answered one printing the same thing.
+#
+# Nothing that can `exit` may be placed between the measurement above and this
+# block. A bare exit past it produces no manifest, classify-failure.sh grades
+# the run `unknown`, and the record skill's "never retry driver_session_leaked
+# blind" rule cannot fire — so the retry starts a second live agent beside the
+# one still running. lib/tmux-teardown-check_test.sh pins the order by
+# extracting this marker block and re-composing it the old way.
 case "$TMUX_GATE_STATUS" in
   clean | skipped) ;;
   *)
@@ -718,6 +770,27 @@ case "$TMUX_GATE_STATUS" in
     exit 1
     ;;
 esac
+# END tmux_teardown_verdict
+
+# The mock has nothing left to serve; stop it before the daemon so its log is
+# complete in staging when the recorder flushes.
+stop_recipe_mock
+recipe_runtime_assert_env_receipt "$STAGING" "$(basename "$DRIVER")" || exit 5
+recipe_runtime_assert_mock_used "$STAGING" "$CELL_JSON" "$MOCK_ADDR" || exit 5
+# END driver_teardown_gate
+
+# Flush the daemon's recorder before we curate.
+#  - isolated: SIGINT and wait for graceful shutdown (flushes on Close).
+#  - attached: just wait 6s — the recorder's 5s periodic flush + 1s
+#    slack is enough to land all writes from this run on disk. The
+#    user's daemon keeps running and the dashboard stays connected.
+if [[ "$ATTACH" == "1" ]]; then
+  echo "attached" > "$STAGING/daemon.shutdown"
+  echo "attach: waiting 6s for recorder flush..."
+  sleep 6
+else
+  stop_record_daemon
+fi
 
 # Multi-session: drivers that chain `restart` steps (e.g. claudecode's
 # session-end scenario) write the full UUID + transcript lists to
@@ -931,7 +1004,7 @@ jq -n \
   --argjson committed_fixture_present "$COMMITTED_PRESENT" \
   --arg committed_report "$STAGING/reports/committed.json" \
   --arg driver_exit_reason "$DRIVER_REASON" \
-  --arg daemon_shutdown "$DAEMON_SHUTDOWN" \
+  --arg daemon_shutdown "$(daemon_shutdown_state)" \
   --argjson timeout_seconds "$TIMEOUT_S" \
   '{adapter: $adapter,
     scenario: $scenario,

--- a/tools/onboarding-factory/scripts/run-cell.sh
+++ b/tools/onboarding-factory/scripts/run-cell.sh
@@ -76,6 +76,13 @@ source "$SCRIPT_DIR/lib/unapplied-grants-check.sh"
 # shellcheck source=lib/recipe-runtime.sh
 source "$SCRIPT_DIR/lib/recipe-runtime.sh"
 
+# "Did the driver's tmux sessions actually go away?" — the post-run counterpart
+# to the completeness check, for the same reason (#1825): driver.exit-reason is
+# the driver's claim about ITSELF, and every exit_clean recording for months
+# left a live agent + tmux session behind while reporting `ok`.
+# shellcheck source=lib/tmux-teardown-check.sh
+source "$SCRIPT_DIR/lib/tmux-teardown-check.sh"
+
 RECORDER="off"
 ATTACH=0
 positional=()
@@ -554,10 +561,75 @@ fi
 start_recipe_mock
 write_driver_env
 
+# The driver's pid is this run's IDENTITY for the tmux-teardown gate below
+# (#1825 / AC4): every interactive driver embeds its own `$$` as a field of
+# every tmux session name it creates, so the pid is what separates this run's
+# leftovers from a concurrent cell's or the operator's own tmux. A foreground
+# call never sets `$!`, so the pid is taken from the driver ITSELF: `bash -c`
+# writes the pid it is running under, then `exec`s the driver into that same
+# process — so driver.pid holds exactly the `$$` the driver will go on to see.
+#
+# Deliberately NOT `"$DRIVER" … & DRIVER_PID=$!; wait` (which is what
+# run-cell-multi.sh:297-312 does, because it genuinely needs the concurrency).
+# Measured on this bash: an async child of a NON-interactive shell gets stdin
+# redirected from /dev/null and SIGINT/SIGQUIT set to SIG_IGN — so backgrounding
+# would quietly change what a driver reads from stdin and stop it answering a
+# Ctrl-C on the recording operator's terminal, to learn a pid the exec wrapper
+# hands over for free. The wrapper keeps the call in the foreground, in the same
+# process group, with the same stdin, argv and exit status as before.
+DRIVER_PID_FILE="$STAGING/driver.pid"
 set +e
-"$DRIVER" "$STAGING" "$UUID" "$TIMEOUT_S" "$STAGING/settings.json" "$DRIVER_INPUT"
+bash -c 'printf "%s\n" "$$" > "$1" || exit 1; shift; exec "$@"' \
+  bash "$DRIVER_PID_FILE" \
+  "$DRIVER" "$STAGING" "$UUID" "$TIMEOUT_S" "$STAGING/settings.json" "$DRIVER_INPUT"
 set -e
 DRIVER_REASON="$(cat "$STAGING/driver.exit-reason" 2>/dev/null || echo "unknown")"
+DRIVER_PID="$(tr -d '[:space:]' < "$DRIVER_PID_FILE" 2>/dev/null || true)"
+
+# --- Did the driver's tmux sessions actually die? MEASURE (#1825 / AC4) --
+# Measured HERE, one line after the driver returns and before anything else
+# gets a chance to take time — the daemon flush below alone spends 6s on the
+# attach path, and a look taken after it is a strictly more lenient look. The
+# VERDICT is acted on further down, at the first point where
+# write_error_manifest exists, so the failure is a structured manifest like
+# every other hard gate rather than a bare exit.
+#
+# Scoped to interactive cells by the same $SCRIPT_JSON discriminator that chose
+# the driver above, so both halves stay honest: an interactive driver cannot
+# have recorded anything without tmux (so "no tmux" there is a broken lookup and
+# fails loudly), while a headless `prompt` cell legitimately never starts one —
+# verified: `grep -c tmux replaydata/agents/*/driver.sh` is 0 for all four.
+TMUX_GATE_STATUS="skipped"
+TMUX_GATE_DETAIL="headless cell — no interactive driver ran, and no driver.sh uses tmux"
+if [[ -n "$SCRIPT_JSON" ]]; then
+  # The pair await_gone_bound checks (see the lib header's rule 3). The
+  # lifetime is the cell's own driver timeout — the upper bound on how long the
+  # session could have lived; the grace is a tenth of it, capped at 5s so a
+  # 900s cell does not buy a 90s wait for a session that should already be gone,
+  # and floored at 1s so the arithmetic can never produce the "look exactly
+  # once" deadline await_gone_bound refuses. A cell whose timeout is under 10s
+  # therefore fails the bound and is reported LOUDLY as unreadable, which is the
+  # honest answer: at that ratio the check would assert nothing. (Every
+  # applicable cell today declares 60s or more.)
+  TEARDOWN_LIFETIME_S="$TIMEOUT_S"
+  TEARDOWN_DEADLINE_S=$(( TEARDOWN_LIFETIME_S / 10 ))
+  if [[ "$TEARDOWN_DEADLINE_S" -gt 5 ]]; then TEARDOWN_DEADLINE_S=5; fi
+  if [[ "$TEARDOWN_DEADLINE_S" -lt 1 ]]; then TEARDOWN_DEADLINE_S=1; fi
+
+  TMUX_GATE_RC=0
+  check_tmux_teardown "$DRIVER_PID" "$TEARDOWN_DEADLINE_S" "$TEARDOWN_LIFETIME_S" \
+    "the cell's own driver timeout" || TMUX_GATE_RC=$?
+  case "$TMUX_GATE_RC" in
+    0) TMUX_GATE_STATUS="clean"
+       TMUX_GATE_DETAIL="no tmux session carries driver pid ${DRIVER_PID:-<unrecorded>} (settled after ${TMUX_TEARDOWN_ELAPSED}s)" ;;
+    1) TMUX_GATE_STATUS="leaked"
+       TMUX_GATE_DETAIL="$TMUX_TEARDOWN_SURVIVORS" ;;
+    *) TMUX_GATE_STATUS="unreadable"
+       TMUX_GATE_DETAIL="$TMUX_TEARDOWN_REASON" ;;
+  esac
+  echo "tmux teardown: $TMUX_GATE_STATUS — $TMUX_GATE_DETAIL"
+fi
+
 # The mock has nothing left to serve; stop it before the daemon so its log is
 # complete in staging when the recorder flushes.
 stop_recipe_mock
@@ -580,6 +652,72 @@ fi
 # --- Read driver-resolved transcript + actual UUID ----------------------
 TRANSCRIPT="$(cat "$STAGING/transcript.path" 2>/dev/null || true)"
 ACTUAL_UUID="$(cat "$STAGING/session.uuid" 2>/dev/null || true)"
+
+MANIFEST="$STAGING/run-manifest.json"
+DAEMON_SHUTDOWN="$(cat "$STAGING/daemon.shutdown" 2>/dev/null || echo "unknown")"
+
+# Write an ERROR-verdict run-manifest with the standard envelope plus
+# error-specific fields supplied as a JSON object (pass '{}' for none).
+#
+# Defined HERE — at the first line where all of its inputs exist (ACTUAL_UUID
+# and DRIVER_REASON from the driver, DAEMON_SHUTDOWN from the flush above) —
+# rather than further down next to its first caller, so that EVERY hard gate
+# after the driver returns can use it. It used to sit below the recording
+# picker, which meant the picker's own `|| exit 1` left no manifest at all
+# (#1825): a gate placed after it would have been skipped on exactly the runs
+# that had already gone wrong.
+write_error_manifest() {
+  local error_code="$1"
+  local extras_json="$2"
+  jq -n \
+    --arg adapter "$ADAPTER" \
+    --arg scenario "$FOLDER" \
+    --arg session_uuid "$ACTUAL_UUID" \
+    --arg error "$error_code" \
+    --arg driver_exit_reason "$DRIVER_REASON" \
+    --arg daemon_shutdown "$DAEMON_SHUTDOWN" \
+    --arg staging "$STAGING" \
+    --argjson extras "$extras_json" \
+    '{adapter: $adapter,
+      scenario: $scenario,
+      session_uuid: $session_uuid,
+      verdict: "ERROR",
+      error: $error,
+      driver_exit_reason: $driver_exit_reason,
+      daemon_shutdown: $daemon_shutdown,
+      staging: $staging} + $extras' \
+    > "$MANIFEST"
+}
+
+# --- Did the driver's tmux sessions actually die? VERDICT (#1825 / AC4) --
+# The measurement was taken the instant the driver returned; this is where it
+# is acted on. A hard gate, not advisory: unlike the completeness check (whose
+# header documents a real ~7% legitimately-incomplete population), a tmux
+# session still carrying THIS run's driver pid has no legitimate population —
+# the driver said it was gone, and it is not. `unreadable` fails just as hard
+# and under its own error code, because #1825 is precisely the bug of an
+# unasked question and an answered one printing the same thing.
+case "$TMUX_GATE_STATUS" in
+  clean | skipped) ;;
+  *)
+    if [[ "$TMUX_GATE_STATUS" == "leaked" ]]; then
+      TMUX_GATE_ERROR="driver_tmux_session_survived"
+    else
+      TMUX_GATE_ERROR="driver_tmux_teardown_unreadable"
+    fi
+    write_error_manifest "$TMUX_GATE_ERROR" \
+      "$(jq -nc \
+          --arg tmux_teardown "$TMUX_GATE_STATUS" \
+          --arg tmux_teardown_detail "$TMUX_GATE_DETAIL" \
+          --arg driver_pid "$DRIVER_PID" \
+          '{tmux_teardown: $tmux_teardown, tmux_teardown_detail: $tmux_teardown_detail, driver_pid: $driver_pid}')"
+    echo "ERROR: driver tmux teardown $TMUX_GATE_STATUS (driver pid ${DRIVER_PID:-<unrecorded>}): $TMUX_GATE_DETAIL" >&2
+    if [[ "$TMUX_GATE_STATUS" == "leaked" ]]; then
+      echo "  kill the survivor(s) with: tmux kill-session -t <name>" >&2
+    fi
+    exit 1
+    ;;
+esac
 
 # Multi-session: drivers that chain `restart` steps (e.g. claudecode's
 # session-end scenario) write the full UUID + transcript lists to
@@ -653,34 +791,6 @@ if [[ -n "$RECORDING" && -n "$TRANSCRIPT" ]]; then
     echo "$ACTUAL_UUID" > "$STAGING/session.uuid"
   fi
 fi
-
-MANIFEST="$STAGING/run-manifest.json"
-DAEMON_SHUTDOWN="$(cat "$STAGING/daemon.shutdown" 2>/dev/null || echo "unknown")"
-
-# Write an ERROR-verdict run-manifest with the standard envelope plus
-# error-specific fields supplied as a JSON object (pass '{}' for none).
-write_error_manifest() {
-  local error_code="$1"
-  local extras_json="$2"
-  jq -n \
-    --arg adapter "$ADAPTER" \
-    --arg scenario "$FOLDER" \
-    --arg session_uuid "$ACTUAL_UUID" \
-    --arg error "$error_code" \
-    --arg driver_exit_reason "$DRIVER_REASON" \
-    --arg daemon_shutdown "$DAEMON_SHUTDOWN" \
-    --arg staging "$STAGING" \
-    --argjson extras "$extras_json" \
-    '{adapter: $adapter,
-      scenario: $scenario,
-      session_uuid: $session_uuid,
-      verdict: "ERROR",
-      error: $error,
-      driver_exit_reason: $driver_exit_reason,
-      daemon_shutdown: $daemon_shutdown,
-      staging: $staging} + $extras' \
-    > "$MANIFEST"
-}
 
 if [[ -z "$TRANSCRIPT" || -z "$RECORDING" || -z "$ACTUAL_UUID" ]]; then
   write_error_manifest "transcript_recording_or_uuid_missing" \

--- a/tools/onboarding-factory/scripts/smoke-test.sh
+++ b/tools/onboarding-factory/scripts/smoke-test.sh
@@ -52,6 +52,14 @@ rc2=0
 shell_lib_suite_run "$SCRIPT_DIR/lib" || rc2=$?
 [[ $rc2 -eq 0 ]] || rc=1
 
+echo ""
+echo "== unit tests (lib/tmux-teardown-check_test.sh) =="
+bash "$SCRIPT_DIR/lib/tmux-teardown-check_test.sh" || rc=1
+
+echo ""
+echo "== unit tests (lib/run-cell-multi-teardown_test.sh) =="
+bash "$SCRIPT_DIR/lib/run-cell-multi-teardown_test.sh" || rc=1
+
 # completeness-gate / catalog-drift / consistency gates were retired (#528):
 # `of validate` + `of coverage` (Go) now own schema + referential + coverage
 # integrity, and a per-scenario shard is the single source for a cell, so the

--- a/tools/onboarding-factory/scripts/smoke-test.sh
+++ b/tools/onboarding-factory/scripts/smoke-test.sh
@@ -52,14 +52,6 @@ rc2=0
 shell_lib_suite_run "$SCRIPT_DIR/lib" || rc2=$?
 [[ $rc2 -eq 0 ]] || rc=1
 
-echo ""
-echo "== unit tests (lib/tmux-teardown-check_test.sh) =="
-bash "$SCRIPT_DIR/lib/tmux-teardown-check_test.sh" || rc=1
-
-echo ""
-echo "== unit tests (lib/run-cell-multi-teardown_test.sh) =="
-bash "$SCRIPT_DIR/lib/run-cell-multi-teardown_test.sh" || rc=1
-
 # completeness-gate / catalog-drift / consistency gates were retired (#528):
 # `of validate` + `of coverage` (Go) now own schema + referential + coverage
 # integrity, and a per-scenario shard is the single source for a cell, so the

--- a/tools/onboarding-factory/scripts/templates/drive-interactive.sh.tmpl
+++ b/tools/onboarding-factory/scripts/templates/drive-interactive.sh.tmpl
@@ -131,6 +131,10 @@ mkdir -p "$RUN_CWD"
 RUN_CWD="$(cd "$RUN_CWD" && pwd -P)"   # canonicalize (resolve symlinks) for the daemon's cwd match
 DEADLINE=$(( $(date +%s) + TIMEOUT_S ))
 EXIT_REASON="ok"
+# Raised to 1 by the epilogue, immediately before the final exit. cleanup() reads
+# it to tell a run that FINISHED (EXIT_REASON is its verdict) apart from a `set
+# -e` abort that never formed one (#1825) — see cleanup().
+REACHED_EPILOGUE=0
 SESSION=""
 
 remaining_seconds() { local now; now=$(date +%s); (( now >= DEADLINE )) && echo 0 || echo $((DEADLINE - now)); }
@@ -144,11 +148,38 @@ not_implemented() { # <step-type>
 # Always honor the staging contract: write driver.exit-reason on ANY exit
 # (including a `set -e` abort mid-launch) and tear tmux down if a session was
 # started. Set EXIT_REASON before a failing `exit` so the reason is accurate.
+#
+# THE REACHED_EPILOGUE GUARD IS NOT OPTIONAL, and it is the half that the
+# "set EXIT_REASON before a failing `exit`" sentence above does NOT cover
+# (#1825). That discipline is per-`exit`: it works for the exits this file
+# writes, and says nothing about a `set -e` abort, which is every other command
+# in the driver. A driver with no trap at all wrote NO driver.exit-reason on an
+# abort and run-cell.sh:418 read it as "unknown" — accurate, if unhelpful. A
+# trap that writes "$EXIT_REASON" unconditionally turns that "unknown" into
+# `ok`: the INITIAL value, reported as a verdict by a run that never formed one.
+# That is the same "reports success while it actually failed" shape #1825 was
+# opened for, reintroduced by the fix for it. So an abort that never reached the
+# epilogue, with EXIT_REASON still at its initial `ok`, is recorded as a driver
+# fault instead. A verdict already formed (timeout, readiness_timeout, …) is
+# left exactly as the step that formed it set it.
+#
+# The other half of the contract is the epilogue raising REACHED_EPILOGUE=1
+# immediately before its final exit. Port BOTH halves or neither: the flag
+# without the guard does nothing, and the guard without the flag reports every
+# successful run as a driver fault.
 cleanup() {
   local i
   for (( i = 1; i <= N_SLOTS; i++ )); do
     [[ -n "${SES_SESSION[$i]:-}" ]] && tmux kill-session -t "${SES_SESSION[$i]}" 2>/dev/null || true
   done
+  # An abort that never reached the epilogue never formed a verdict, so
+  # EXIT_REASON is still its initial "ok". Writing that would report SUCCESS for
+  # a failed run — the exact shape #1825 exists to stop — so record the
+  # driver-fault reason instead. A verdict already formed (timeout, …) stands.
+  if [[ "$REACHED_EPILOGUE" != "1" && "$EXIT_REASON" == "ok" ]]; then
+    EXIT_REASON="nonzero(2)"
+    echo "[driver] aborted before the epilogue — recording exit reason $EXIT_REASON, not ok" >&2
+  fi
   echo "$EXIT_REASON" > "$STAGING/driver.exit-reason"
 }
 trap cleanup EXIT
@@ -223,4 +254,7 @@ done < <(jq -c '.[]' <<<"$SCRIPT_JSON")
 # transcript path; switch to the first-line UUID if __AGENT__ keys on that (see
 # drive-pi-interactive.sh). drive_exit maps EXIT_REASON → the process exit code.
 emit_session_contract "$(daemon_sid "${SES_TRANSCRIPT[1]}")"
+# The epilogue completed: EXIT_REASON is this run's real verdict, so cleanup()
+# must record it as-is rather than rewrite it as an abort.
+REACHED_EPILOGUE=1
 drive_exit

--- a/tools/onboarding-factory/scripts/templates/drive-interactive.sh.tmpl
+++ b/tools/onboarding-factory/scripts/templates/drive-interactive.sh.tmpl
@@ -167,6 +167,7 @@ not_implemented() { # <step-type>
 # immediately before its final exit. Port BOTH halves or neither: the flag
 # without the guard does nothing, and the guard without the flag reports every
 # successful run as a driver fault.
+# BEGIN cleanup
 cleanup() {
   local i
   for (( i = 1; i <= N_SLOTS; i++ )); do
@@ -182,6 +183,7 @@ cleanup() {
   fi
   echo "$EXIT_REASON" > "$STAGING/driver.exit-reason"
 }
+# END cleanup
 trap cleanup EXIT
 
 # --- AGENT-SPECIFIC SEAM 1: launch the REPL under tmux -----------------------


### PR DESCRIPTION
Closes #1825.

Nine recordings in one morning each left a live `claude` process and its detached
tmux session behind. All nine showed up as real session rows in the menu bar,
crowding out the two sessions actually in use.

**The daemon was right.** Every leaked PID answered `ps`, and the `readyTTL`
sweep correctly skips a stale `ready` session whose process is alive. Killing one
leaked pane dropped the menu-bar count from 11 rows to 10, so the two numbers
were the same number.

## Root cause

`step_exit_clean` signalled a graceful exit, slept one second, and set
`SES_ALIVE=0` without observing anything. The end-of-run `tmux kill-session` loop
was gated on that flag, so it skipped the only session that needed killing, and
the run wrote `driver.exit-reason=ok`.

Claude Code answers ONE `Ctrl-D` with `Press Ctrl-D again to exit`, then lets the
confirmation expire. Verified live on a fresh v2.1.245 TUI with no API call made:

| Sent | Observed |
|---|---|
| `C-u` on an empty input buffer | no-op, session alive |
| `C-u` after typing text | input line cleared |
| one `C-d` | **still alive** |
| a second `C-d` 1.5 s later | **still alive** — the window had closed |
| `tmux send-keys C-d C-d` in ONE call | **exited**, tmux session gone |

## Scope: six adapters, not one

The issue's original audit reasoned from the recipes that leaked *that morning*,
so it found the adapters whose recipes end in `exit_clean` and stopped. A static
audit of all eleven driver sources found two more:

| adapter | polls? | EXIT trap | leaked |
|---|---|---|---|
| claudecode | no — `sleep 1` | none | yes |
| codex | yes | none | yes |
| pi | yes | none | yes |
| kiro-cli | yes | gated on `SES_ALIVE` | yes |
| gemini-cli | yes | ungated | latent only |
| **aider** | n/a — no `exit_clean` | **none** | **yes, on any `set -e` abort** |

Polling did not rescue codex, pi or kiro-cli: `wait_tmux_session_gone` always
returns `0`, and its own comment calls a capped-out poll *"not a caller-visible
failure"*. aider was invisible to an `exit_clean`-shaped audit precisely because
it has none — its happy-path teardown is correct and deliberate; only its abort
path leaked.

## The fix — make death an observation, at four levels

1. **`require_tmux_session_gone`** — a strict sibling in
   `replaydata/_lib/drive/teardown.sh`, returning non-zero when the cap expires.
   The best-effort original is untouched: it is a *settle* for callers who made
   death certain by other means, the new one is a *verification* for callers who
   asked a live TUI to exit. All eight graceful-exit sites now poll strictly and,
   on failure, log loudly, kill explicitly, and set a non-zero exit reason.
2. **Teardown is unconditional.** No end-of-run `tmux kill-session` is gated on
   `SES_ALIVE` in any adapter, and every driver that launches tmux installs a
   `trap … EXIT`. `SES_ALIVE` was always an intent flag, never an observation —
   nothing anywhere re-derived it from `tmux has-session`.
3. **`run-cell.sh` and `run-cell-multi.sh` assert it afterwards.** Built on
   `tools/lib/await-gone.sh`, whose contract is already exactly this — `0` gone,
   `1` survived, `2` **could not look** — and which refuses a predicate that
   never looked. This is its first production caller.
4. **A Go tripwire**, `internal/driverteardown`, grades four invariants over
   every driver enumerated from disk, so a new adapter is covered the day it
   lands rather than the day someone remembers it.

### How the run identifies its own sessions

`run-cell.sh` had no way to know which tmux sessions a run created: no staging
file records them, and the driver runs in the foreground so `$!` is never set.
Every driver already embeds its own `$$` in every session name, so that is now
the run's identity — and INV-3 enforces the convention rather than assuming it.

Backgrounding the driver to learn its PID was **rejected on measurement**: an
async child of a non-interactive shell gets stdin redirected from `/dev/null` and
`SIGINT`/`SIGQUIT` set to `SIG_IGN`. Instead `bash -c` writes the pid it is
running under, then `exec`s the driver into that same process — same process
group, stdin, argv and exit status as before.

Six conditions stay distinguishable from "legitimately zero sessions", including
`tmux` exiting 0 while naming nothing: a live server always owns at least one
session, so empty-success is unparseable, not clean.

## The regression this fix would otherwise have shipped

An aborting driver previously wrote **no** `driver.exit-reason`, and
`run-cell.sh` read that absence as `unknown`. A trap writing `"$EXIT_REASON"`
unconditionally turns that into the initialiser — **`ok`** — reporting success
for a run that never formed a verdict, on a PR about exactly that.

Nine drivers had the hole: six pre-existing, three introduced by this PR's own
new traps. All now record a driver fault instead, using each file's existing
vocabulary rather than a new one, and the scaffold template carries the guard so
future adapters inherit it.

Ten drivers carry the sentinel today — `grep -l 'REACHED_EPILOGUE=1'
replaydata/agents/*/driver-interactive.sh | wc -l`. The harness grades **11**
handlers: those ten plus the scaffold template, which mints the next adapter.
opencode has neither — its inline trap writes no verdict, so it is exempt by
derivation rather than by an allowlist.

Counterfactual, with only the guard removed from claudecode and the same abort
re-run:

```
MUTANT  exit=1  driver.exit-reason=[ok]
```

## Two dead arms in `classify-failure.sh`

Found while wiring the new codes, both pre-existing:

- `transcript_or_recording_missing` was **born dead**. `a511ad11` renamed the
  writer at 07:51 on 2026-04-25; `6d24cb14` added the classifier carrying the
  pre-rename spelling at 14:34 the same day. It never matched once in 122 days.
- `wall_clock_timeout` has **never been written by any script in this repo's
  history** (`git log -S … --all` returns only the commit that added the arm).
  That made the `timeout` classification unreachable while
  `record/SKILL.md` keyed its retry-once policy on it.

A bidirectional tripwire now fails on a writer with no arm **and** on an arm with
no writer — only the reverse direction catches the second one.

## Evidence

Per AGENTS.md, everything here is a check the change *adds*, so none of it has a
"before" to run red. Each was proven by mutating what it protects:

- **`require_tmux_session_gone`** — made to return 0 unconditionally →
  `FAIL: never gone: returns NON-ZERO — expected [non-zero] got [0]`.
- **The static tripwire** — `ls tools/onboarding-factory/internal/driverteardown/testdata/*.sh
  | wc -l` → 32 fixtures (plus 2 fixture libs), each a one-line mutation of a
  good driver, including the must-**not**-flag rows (kiro-cli's step-level
  guards and copilot's top-level `case` dispatch, both correct) and vacuity
  fixtures where an empty or unparseable driver must ERROR rather than pass.
- **The runtime gate** — a fake leaky driver against a real tmux server:
  `tmux teardown: leaked — claudecode-onboard-1787655880-72834`, exit 1, error
  manifest naming the session. Plus stub arms for no-server, no-binary,
  unreadable, empty-pid and a deadline that would assert nothing.
- **The classifier tripwire** — the 2026-04 spelling restored verbatim → 5
  failures; an unmatched code appended → named in the output; the case block
  gutted → `refused: … this tripwire graded nothing`.
- **Every cleanup handler** — the marked block is extracted from the driver's
  own source and executed against stubs across three arms (abort-with-no-verdict,
  abort-with-verdict-already-formed, epilogue-reached), and the mutant is
  *derived* from that same block on each run, so it cannot drift from what it
  mutates. A deletion that changed nothing is a refusal, not a pass. Whether the
  written reason **denotes** failure is graded by feeding it back through the
  rig's own `drive_exit` map — precisely what INV-4's doc says it cannot see.
  `bash replaydata/_lib/drive/drive-lib_test.sh` → 137 PASS / 0 FAIL.

**One near-miss worth recording.** INV-4 was built, all eleven adapters went
green, and the author did not trust it — dumping *which branch* each driver
satisfied showed all ten passing via a path that is impossible for them. Its
"unconditional" test meant "no enclosing `if`", and every driver sets its fault
verdict inside a `case` arm, so the guard branch had never been reached on a real
driver. Fixed by tracking compound-statement depth, and committed as the fixture
`inv4_case_arm_is_not_the_epilogue.sh` with the incident in its header.

## Deliberately not checked

Written into `driverteardown.go`'s package doc rather than left implicit: a
`trap - EXIT` disarm is **not** graded. Three candidate rules were tried and
rejected — the narrowest passes a multi-slot driver that kills one slot and
disarms with the others live; a source-order rule reads definition order as
execution order; and forbidding it outright fails `opencode`, which is correct
today. Grading it soundly needs reachability analysis a text checker does not
have, and a rule that looks like it grades this and does not is worse than a
documented gap.

Also documented there: INV-4 cannot see that the sentinel is set at the *right*
place, that the value written denotes failure, or which statements can actually
abort.

## Verification

`tools/preflight.sh` by `--only` group, each its own foreground invocation, re-run
after the rebase onto #1819: `go`, `web`, `arch`, `tools`, `skills`, `posix`,
`bash`, `security` — **all PASS**, including the new `state-vocabulary lint`.

The rebase produced three real conflicts in `run-cell.sh` against #1819's recipe
runtime block. All three were additive on both sides; the tmux measurement is
ordered *before* `stop_recipe_mock` so the look stays the earliest thing after
the driver returns.

## Follow-ups, not in this PR

- `SES_ALIVE` is now write-only in four drivers, each needing a
  `shellcheck disable=SC2034` (`git diff origin/main...HEAD --
  'replaydata/agents/*/driver-interactive.sh' | grep -c '^+.*SC2034'`). A `slot_session_alive` helper that asks
  `tmux has-session` would make "alive" an observation fleet-wide and retire both
  the flag and the annotations.
- `smoke-test.sh` discovers suites by glob, but nothing refuses a suite that runs
  **twice** — two did for a full PR cycle here and no gate noticed. The
  `shell-lib-suite` census line is where that belongs.
- A `driver.pid` write failure classifies as `driver_teardown_unverifiable`. The
  message is now correct, but a distinct `driver_pid_unrecorded` arm would let
  the classifier give the right first move.
- The deadline clamp is duplicated between `run-cell.sh` and `run-cell-multi.sh`.
- `DRIVE_EXIT_CLEAN_CAP_S=15` is a bound, not a measurement. A measured
  per-adapter table would need live runs, and gemini-cli is not drivable on this
  host.

## Review round

A `high`-effort review returned 11 findings. All are applied; three were
blocking, and the worst was this PR's own conflict resolution reproducing the
bug it fixes.

- **The teardown verdict was skippable.** The measurement ran early and
  correctly, but the verdict sat 64 lines later behind gates that could exit
  first. A cell that leaked *and* failed its recipe-runtime assertion exited 5
  with no manifest, so `classify-failure.sh` returned `unknown` and the new
  "never retry `driver_session_leaked` blind" rule never fired — a retry would
  have started a second live agent beside the leaked one. **Four** exit sites
  sat in that span, not the two the review named: two `|| exit 5` gates plus two
  `set -e`-implicit exits on the daemon-shutdown write. All are now behind the
  verdict, and a static tripwire asserts the span holds none, with its own mutant
  proving it can see one.
- **The `REACHED_EPILOGUE` guard had no committed test** — the proof lived only
  in this description, which AGENTS.md says is re-run by nothing. Now a
  marker-extraction harness over each driver's real `cleanup()`.
- **`smoke-test.sh` had re-added the hand-listed registration it deleted**, four
  lines below the glob that already found them. Two suites ran twice for a full
  PR cycle and no gate noticed.
- **A 2 s cap had silently changed meaning** from settle budget to hard deadline
  plus forced kill; a 2.1 s Ink/node teardown would have truncated a transcript
  and failed the run.
- **The shell parser dropped statements** when a comment was glued to code —
  fixed by deleting one of the two rules that disagreed rather than aligning
  them.
- **INV-1 fired a false positive** on a top-level `case` step dispatch carrying a
  legitimate liveness guard, so the doc-only fix I proposed was wrong and the
  rule was narrowed instead.

Two conventions came out of it and are now in `docs/ci-gates.md`: a suite under
`lib/` is **discovered, never listed**, and shell logic needing a runtime test is
**marker-extracted, not re-implemented**, with a missing marker a loud refusal.

A near-miss earned one more lock: a scripted fleet edit silently cleared the exec
bit on ten drivers. `run-cell.sh` would have caught it only at record time, on a
live run that had already spawned a daemon. All 15 drivers are now checked
statically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
