### PR TITLE
fix(daemon): register SIGTERM handler before publishing the addr file

### DIFF
--- a/core/cmd/irrlichd/main.go
+++ b/core/cmd/irrlichd/main.go
@@ -810,7 +810,11 @@ func runDaemon() {
 	// to remove it. Installing the handler first — it costs nothing — closes
 	// the window where a SIGTERM landing between the two got the default
 	// disposition and killed the process before os.Remove(addrPath) below
-	// ever ran (#1808).
+	// ever ran (#1808). Trade-off: a SIGTERM arriving during startup is no
+	// longer fatal — it is buffered in sig and only consumed once <-sig
+	// below runs — so if startup itself hangs before reaching <-sig, SIGTERM
+	// can no longer stop the daemon and SIGKILL is required instead (see
+	// #1815 for the general shape of a startup hang going unhandled).
 	sig := make(chan os.Signal, 1)
 	signal.Notify(sig, syscall.SIGTERM, syscall.SIGINT)
 

--- a/core/cmd/irrlichd/main.go
+++ b/core/cmd/irrlichd/main.go
@@ -805,6 +805,15 @@ func runDaemon() {
 
 	registerHookRoutes(mux, detector, metricsCollector, permService, logger)
 
+	// Registered before publishAddrFile: once the addr file exists, every
+	// reader of it treats the daemon as alive and expects a clean shutdown
+	// to remove it. Installing the handler first — it costs nothing — closes
+	// the window where a SIGTERM landing between the two got the default
+	// disposition and killed the process before os.Remove(addrPath) below
+	// ever ran (#1808).
+	sig := make(chan os.Signal, 1)
+	signal.Notify(sig, syscall.SIGTERM, syscall.SIGINT)
+
 	publishAddrFile(addrPath, resolvedAddr, logger)
 
 	go func() { _ = srv.Serve(unixL) }()
@@ -836,9 +845,8 @@ func runDaemon() {
 
 	logger.LogInfo("startup", "", fmt.Sprintf("irrlichd %s listening on unix:%s and tcp:%s", Version, sockPath, resolvedAddr))
 
-	// Wait for SIGTERM or SIGINT.
-	sig := make(chan os.Signal, 1)
-	signal.Notify(sig, syscall.SIGTERM, syscall.SIGINT)
+	// Wait for SIGTERM or SIGINT (handler installed above, before the addr
+	// file was published).
 	<-sig
 
 	logger.LogInfo("shutdown", "", "signal received, shutting down")

--- a/core/cmd/irrlichd/sigterm_window_test.go
+++ b/core/cmd/irrlichd/sigterm_window_test.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// TestSIGTERMRightAfterAddrPublishLeavesNoAddrFile is the #1808 defect test.
+//
+// main() used to publish the addr file (the "daemon is up" signal) before
+// calling signal.Notify to install the SIGTERM handler. A SIGTERM landing in
+// that window got the default disposition — the process died immediately and
+// os.Remove(addrPath) never ran — even though every reader of the addr file
+// treats its existence as "the daemon is alive and will clean up after
+// itself."
+//
+// This races a SIGTERM in as fast as possible after the addr file appears,
+// bypassing bootSmokeDaemon's 20ms-poll waitForAddr (whose latency alone can
+// be enough to let the window close first) and grant-all's synchronous
+// consent effects (the real work — installing hooks/statuslines across every
+// declared permission, exactly what TestGrantAllLeavesAgentConfigsAlone
+// exercises) so there is something occupying the window for the SIGTERM to
+// land inside, the same shape that produced the flake on a loaded Linux CI
+// runner.
+//
+// Seen red before the fix (`go test -run TestSIGTERMRightAfterAddrPublishLeavesNoAddrFile -race -count=1 -v ./core/cmd/irrlichd/`):
+//
+//	sigterm_window_test.go:88: addr file <dir>/irrlichd.addr should be removed after a SIGTERM landing right after it was published, stat err = <nil>
+func TestSIGTERMRightAfterAddrPublishLeavesNoAddrFile(t *testing.T) {
+	bin := buildIrrlichd(t)
+	// shortTempDir, not t.TempDir(): IRRLICHT_HOME holds the unix socket and a
+	// long test name pushes sun_path past its 104-byte limit — see its comment.
+	homeDir := shortTempDir(t)
+	stateDir := shortTempDir(t)
+
+	cmd := exec.Command(bin)
+	// grant-all, not the smoke test's default "ask": PermService.Start only
+	// does real synchronous work — installing every declared consent
+	// effect — in grant-all mode. That work is what occupies the window
+	// between publishAddrFile and signal.Notify for long enough to hit
+	// reliably; "ask" mode has nothing granted to apply and returns from
+	// startBackgroundLoops almost immediately.
+	cmd.Env = append(sanitizedChildEnv(homeDir, stateDir),
+		"IRRLICHT_BIND_ADDR=127.0.0.1:0", "IRRLICHT_PERMISSION_MODE=grant-all")
+
+	exited := make(chan struct{})
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start daemon: %v", err)
+	}
+	// A single reaper goroutine owns cmd.Wait(), same discipline as
+	// bootSmokeDaemonIn, so `go test -race` never sees Wait called twice.
+	go func() { _ = cmd.Wait(); close(exited) }()
+	t.Cleanup(func() {
+		select {
+		case <-exited:
+		default:
+			_ = cmd.Process.Kill()
+			<-exited
+		}
+	})
+
+	addrPath := filepath.Join(stateDir, "irrlichd.addr")
+	// Deliberately tighter than waitForAddr's 20ms poll: the point is to
+	// detect the addr file, and fire the SIGTERM, as close to the instant
+	// publishAddrFile's os.Rename lands as this process can manage — a
+	// looser poll would let the daemon's remaining startup work finish
+	// before the signal is even sent, which would prove nothing about the
+	// window this test exists to close.
+	deadline := time.Now().Add(15 * time.Second)
+	for {
+		if b, err := os.ReadFile(addrPath); err == nil && strings.TrimSpace(string(b)) != "" {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("daemon never wrote addr file %s within 15s", addrPath)
+		}
+		time.Sleep(100 * time.Microsecond)
+	}
+	if err := cmd.Process.Signal(syscall.SIGTERM); err != nil {
+		t.Fatalf("send SIGTERM: %v", err)
+	}
+
+	select {
+	case <-exited:
+	case <-time.After(6 * time.Second):
+		_ = cmd.Process.Kill()
+		<-exited
+		t.Fatalf("daemon did not exit within 6s of SIGTERM")
+	}
+
+	if _, err := os.Stat(addrPath); !os.IsNotExist(err) {
+		t.Errorf("addr file %s should be removed after a SIGTERM landing right after it was published, stat err = %v", addrPath, err)
+	}
+}

--- a/core/cmd/irrlichd/sigterm_window_test.go
+++ b/core/cmd/irrlichd/sigterm_window_test.go
@@ -4,7 +4,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strings"
 	"syscall"
 	"testing"
 	"time"
@@ -30,7 +29,7 @@ import (
 //
 // Seen red before the fix (`go test -run TestSIGTERMRightAfterAddrPublishLeavesNoAddrFile -race -count=1 -v ./core/cmd/irrlichd/`):
 //
-//	sigterm_window_test.go:88: addr file <dir>/irrlichd.addr should be removed after a SIGTERM landing right after it was published, stat err = <nil>
+//	addr file <dir>/irrlichd.addr should be removed after a SIGTERM landing right after it was published, stat err = <nil>
 func TestSIGTERMRightAfterAddrPublishLeavesNoAddrFile(t *testing.T) {
 	bin := buildIrrlichd(t)
 	// shortTempDir, not t.TempDir(): IRRLICHT_HOME holds the unix socket and a
@@ -65,22 +64,13 @@ func TestSIGTERMRightAfterAddrPublishLeavesNoAddrFile(t *testing.T) {
 	})
 
 	addrPath := filepath.Join(stateDir, "irrlichd.addr")
-	// Deliberately tighter than waitForAddr's 20ms poll: the point is to
+	// waitForAddrFileTight, not waitForAddr's 20ms poll: the point is to
 	// detect the addr file, and fire the SIGTERM, as close to the instant
 	// publishAddrFile's os.Rename lands as this process can manage — a
 	// looser poll would let the daemon's remaining startup work finish
 	// before the signal is even sent, which would prove nothing about the
 	// window this test exists to close.
-	deadline := time.Now().Add(15 * time.Second)
-	for {
-		if b, err := os.ReadFile(addrPath); err == nil && strings.TrimSpace(string(b)) != "" {
-			break
-		}
-		if time.Now().After(deadline) {
-			t.Fatalf("daemon never wrote addr file %s within 15s", addrPath)
-		}
-		time.Sleep(100 * time.Microsecond)
-	}
+	waitForAddrFileTight(t, addrPath, time.Now().Add(15*time.Second))
 	if err := cmd.Process.Signal(syscall.SIGTERM); err != nil {
 		t.Fatalf("send SIGTERM: %v", err)
 	}

--- a/core/cmd/irrlichd/uninstall_hooks_live_daemon_test.go
+++ b/core/cmd/irrlichd/uninstall_hooks_live_daemon_test.go
@@ -201,6 +201,25 @@ func shortTempDir(t *testing.T) string {
 	return dir
 }
 
+// waitForAddrFileTight polls for a non-empty addr file at addrPath with a
+// 100µs cadence — deliberately tighter than waitForAddr's 20ms poll — so a
+// caller racing a signal against the instant the file appears (#1808) loses
+// as little of the window as possible to its own detection latency. Fails
+// the test loudly on deadline rather than returning quietly: a fixture that
+// cannot observe what it waits for must not read as a pass.
+func waitForAddrFileTight(t *testing.T, addrPath string, deadline time.Time) {
+	t.Helper()
+	for {
+		if b, err := os.ReadFile(addrPath); err == nil && strings.TrimSpace(string(b)) != "" {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("daemon never wrote addr file %s before the deadline", addrPath)
+		}
+		time.Sleep(100 * time.Microsecond)
+	}
+}
+
 // seedGrantedHooksConsent writes a permissions.json granting Claude Code's
 // hooks permission, so the daemon under test boots into the only state in
 // which this defect can occur: consent granted, entries installed, a


### PR DESCRIPTION
## Summary

- `core/cmd/irrlichd/main.go` published the addr file (the "daemon is up" signal) at what was line 808 before installing the SIGTERM handler at line 841. A SIGTERM landing in that window got the default disposition — the process died immediately and `os.Remove(addrPath)` never ran — leaving a stale addr file that misleads tooling into connecting to a dead port.
- This is the root cause of the intermittent `TestGrantAllLeavesAgentConfigsAlone` failure on loaded Linux CI runners (#1808): grant-all's synchronous consent-effect installs inside `startBackgroundLoops` are what widen the window enough to hit in practice.
- Fix: move `signal.Notify` (and its channel) above `publishAddrFile` so the handler is always installed first. `<-sig` stays where it was. One statement moved, as the triage brief predicted.

## Red-first evidence

Added `TestSIGTERMRightAfterAddrPublishLeavesNoAddrFile` (`core/cmd/irrlichd/sigterm_window_test.go`), which races a SIGTERM in as fast as possible after the addr file appears — tighter than the existing smoke harness's 20ms `waitForAddr` poll — against a **grant-all** daemon (the same setup `TestGrantAllLeavesAgentConfigsAlone` uses), since grant-all's synchronous consent-effect installs are what occupies the window for the race to land in.

Run against the unfixed ordering (`git stash`-free checkpoint/revert dance — see commit history in the worktree):

```
go test ./core/cmd/irrlichd/ -run TestSIGTERMRightAfterAddrPublishLeavesNoAddrFile -race -count=10 -v
```

9 of 10 runs failed:
```
sigterm_window_test.go:97: addr file /var/folders/.../irrlichd.addr should be removed after a SIGTERM
    landing right after it was published, stat err = <nil>
--- FAIL: TestSIGTERMRightAfterAddrPublishLeavesNoAddrFile (2.07s)
```

After the fix, 20/20 runs passed.

## Test plan

- [x] `go test ./core/cmd/irrlichd/... -race -count=1` — PASS (including the new test, `TestGrantAllLeavesAgentConfigsAlone`, `TestDaemonStartupSmoke`)
- [x] `tools/preflight.sh --only go` — PASS
- [x] `tools/preflight.sh --only arch` — PASS (ARS composite unchanged)
- [x] `tools/preflight.sh --only tools` — PASS
- [x] `tools/preflight.sh --only skills` — PASS
- [x] `tools/preflight.sh --only posix` — PASS
- [x] `tools/preflight.sh --only bash` — PASS
- [x] `tools/preflight.sh --only security` — PASS

Closes #1808

🤖 Generated with [Claude Code](https://claude.com/claude-code)