### PR TITLE
fix(history): keep an unencodable state out of the green bucket and on disk

### DIFF
--- a/core/application/services/history_tracker.go
+++ b/core/application/services/history_tracker.go
@@ -94,6 +94,18 @@ func validGranularity(sec int) bool {
 //     WIN the merge would need the clients to accept a downgrade, which their
 //     priority-based merge cannot express — i.e. a client change, which is
 //     precisely what this fix is scoped to avoid.
+//   - WHAT A USER SEES, stated because it is a real change and the only
+//     alternatives are lies: that carry-forward protection covers the single
+//     open bucket, not the strip. tick() seals each new bucket from lastState,
+//     so a session that STAYS unencodable blanks its whole strip within one
+//     ring (60 buckets: 60 s at 1 s, 1 h at 60 s) and both clients then render
+//     an empty track, having trimmed the leading no-data slots away. Since
+//     #1812/#1813 put real sessions into `error`, that is the common case, not
+//     a corner. It is still the right trade: the 2-bit field's only other
+//     codes are ready/working/waiting, so anything but no-data would paint a
+//     colour the session is not in — which is the bug being fixed. The row's
+//     state icon beside the strip is red throughout, so the user is not
+//     misled, and #1805 is what makes the strip itself say `error`.
 func statePriority(s string) int {
 	switch s {
 	case session.StateWaiting:
@@ -172,8 +184,13 @@ func (rb *ringBuffer) upgrade(newState string) {
 	} else {
 		cur := rb.current()
 		// An unencodable state carries bucketNoData, which is negative and so
-		// never wins here — the open bucket keeps the activity it observed.
-		if p > rb.buckets[cur] {
+		// never wins the strict comparison — the open bucket keeps the activity
+		// it observed. The one exception is a bucket holding no activity
+		// either: recording the verbatim string there overwrites nothing and is
+		// what stops a live `error` from being dropped purely because of which
+		// tick phase it arrived in (#1807). Among successive unencodable states
+		// in one bucket the last one wins, matching "most recent state seen".
+		if p > rb.buckets[cur] || (p == bucketNoData && rb.buckets[cur] == bucketNoData) {
 			rb.setBucket(cur, newState)
 		}
 	}
@@ -211,8 +228,12 @@ func (rb *ringBuffer) snapshot() []string {
 	for i := 0; i < rb.size; i++ {
 		idx := (start + i) % HistoryBucketCount
 		// A state this build cannot encode round-trips verbatim, so save()
-		// writes back what it read rather than a coerced value (#1807).
-		if s, ok := rb.unencodable[idx]; ok {
+		// writes back what it read rather than a coerced value (#1807). The
+		// priority is re-checked rather than trusted: setBucket is the only
+		// writer that maintains both, so gating here means a future write
+		// straight to buckets[] degrades to a blank bucket instead of silently
+		// resurrecting a dead state string into a live one.
+		if s, ok := rb.unencodable[idx]; ok && rb.buckets[idx] == bucketNoData {
 			out[i] = s
 			continue
 		}

--- a/core/application/services/history_tracker.go
+++ b/core/application/services/history_tracker.go
@@ -23,8 +23,17 @@ const (
 	statePriorityWorking = 1
 	statePriorityWaiting = 2
 	// statePriorityNoData encodes empty/unfilled buckets on the wire. Stored
-	// in-memory as int8(-1); only surfaces when bit-packing for transport.
+	// in-memory as int8(bucketNoData); only surfaces when bit-packing for
+	// transport.
 	statePriorityNoData = 3
+
+	// bucketNoData is the IN-MEMORY sentinel for a bucket with no renderable
+	// state — an unfilled slot, or a state this build cannot encode (see
+	// statePriority). Deliberately negative rather than reusing the wire code
+	// 3: a negative value loses every max-merge in upgrade(), so an
+	// unencodable transition can never overwrite activity the bucket already
+	// observed, whereas 3 would outrank waiting and blank it.
+	bucketNoData = -1
 )
 
 var validGranularities = []int{1, 10, 60}
@@ -39,48 +48,112 @@ func validGranularity(sec int) bool {
 }
 
 // statePriority maps a lifecycle state onto the 2-bit code the history bar
-// transports.
+// transports. Anything without a code becomes bucketNoData — a blank slot on
+// both clients, never green (#1807).
 //
-// session.StateError (#1798) HAS NO CODE and falls through to
-// statePriorityReady — an errored bucket paints GREEN on the sparkline, which
-// is precisely the silent-green failure the fourth state exists to remove.
-// That is a known, accepted gap, not an oversight: all four codes of the
-// 2-bit field are already taken (ready/working/waiting/no-data), so carrying a
-// fifth value is a wire-format change across Go, Swift and JS. #1796 cut it
-// from the epic's delivery path for that reason and filed it as #1805/#1807,
-// where this — a red session showing green in its own history — is the
-// concrete symptom to fix rather than "widen the encoding".
+// The cases below are the ENCODABLE set, which is deliberately NOT
+// session.CanonicalStates(): they differ by exactly session.StateError, which
+// is canonical (#1798) yet has no code, because all four slots of the 2-bit
+// field are spent (ready/working/waiting/no-data). Widening the field is a
+// wire-format change across Go, Swift and JS and belongs to #1805; this
+// function must therefore not be rewritten as a session.IsCanonicalState
+// check, which would classify `error` as encodable and hand a 5th value to
+// packPriorities' 2-bit mask. A canonical state added later lands on
+// bucketNoData too, which is the safe direction: blank, not a wrong colour.
 //
-// Deliberately left as `default` rather than an explicit `case StateError`:
-// spelling it out would read as a considered mapping of error onto ready,
-// which it is not.
+// #1807 — THE DECISION, AND ITS WIRE CONSEQUENCE.
+//
+// Before this, the default arm returned statePriorityReady, so `error` and any
+// name written by a newer daemon both painted GREEN, and save() then rewrote
+// history.json with the coerced value — the same destroy-the-user's-data shape
+// #1797/#1806 removed from the session-file reader, one file over.
+//
+// The choice made here is PRESERVE, not downgrade: an unencodable bucket keeps
+// its verbatim state string in ringBuffer.unencodable, so snapshot() — and
+// therefore save() — writes back exactly what was read. Only the RENDERED
+// value degrades. Consequences, stated because they are the part a reader
+// needs and #1815 exists for the case that was neither handled nor mentioned:
+//
+//   - The wire format is UNCHANGED: still 60 buckets × 2 bits = 15 bytes = 20
+//     base64 chars, still four codes. No client decoder moves, and neither
+//     does the length assertion in SessionManager+History.swift, irrlicht.js
+//     or decodeHistoryString. An unencodable bucket ships as
+//     statePriorityNoData, which Swift's historyPriorityToState and the web's
+//     HISTORY_PRIORITY_TO_STATE already map to "" and both render as a blank
+//     slot rather than a colour.
+//   - history.json can therefore now contain a state string this build cannot
+//     render. That is intentional — it is what makes a downgrade
+//     non-destructive, and #1805 will be able to display those buckets once
+//     the encoding widens. A build OLDER than this fix reads such a bucket as
+//     ready/green, exactly as it already did with the value it wrote itself,
+//     so nothing regresses for it.
+//   - Aggregation is unaffected: bucketNoData is negative, so an unencodable
+//     transition loses upgrade()'s max-merge and the activity already recorded
+//     in the open bucket survives (#1805's documented interim behaviour — the
+//     strip shows what the session was doing, not that it errored). Making it
+//     WIN the merge would need the clients to accept a downgrade, which their
+//     priority-based merge cannot express — i.e. a client change, which is
+//     precisely what this fix is scoped to avoid.
 func statePriority(s string) int {
 	switch s {
 	case session.StateWaiting:
 		return statePriorityWaiting
 	case session.StateWorking:
 		return statePriorityWorking
-	default:
+	case session.StateReady:
 		return statePriorityReady
+	default:
+		return bucketNoData
 	}
+}
+
+// wireCode maps an in-memory bucket priority onto the 2-bit code clients
+// decode, so nothing outside this file ever sees the negative sentinel.
+func wireCode(p int8) int8 {
+	if p < 0 {
+		return statePriorityNoData
+	}
+	return p
 }
 
 // ringBuffer is a fixed-size circular buffer of state strings.
 type ringBuffer struct {
-	buckets   [HistoryBucketCount]int8
-	head      int
-	size      int
-	tickMod   int
-	tickAcc   int
-	lastState string
+	buckets [HistoryBucketCount]int8
+	// unencodable holds the verbatim state string for those buckets whose
+	// priority is bucketNoData BECAUSE the state has no 2-bit code — keyed by
+	// bucket index, nil until one appears (#1807). It is what lets save()
+	// write back a value this build cannot render instead of erasing it.
+	// Genuinely empty slots are absent from the map, not stored as "".
+	unencodable map[int]string
+	head        int
+	size        int
+	tickMod     int
+	tickAcc     int
+	lastState   string
 }
 
 func newRingBuffer(granularitySec int) *ringBuffer {
 	rb := &ringBuffer{tickMod: granularitySec}
 	for i := range rb.buckets {
-		rb.buckets[i] = -1
+		rb.buckets[i] = bucketNoData
 	}
 	return rb
+}
+
+// setBucket writes bucket i from a state string, keeping the verbatim value
+// when the state has no 2-bit code. Every write to buckets[] goes through here
+// so buckets and unencodable cannot drift apart.
+func (rb *ringBuffer) setBucket(i int, state string) {
+	p := statePriority(state)
+	rb.buckets[i] = int8(p)
+	if p == bucketNoData && state != "" {
+		if rb.unencodable == nil {
+			rb.unencodable = make(map[int]string, 1)
+		}
+		rb.unencodable[i] = state
+		return
+	}
+	delete(rb.unencodable, i) // no-op on a nil map
 }
 
 func (rb *ringBuffer) current() int {
@@ -93,13 +166,15 @@ func (rb *ringBuffer) current() int {
 func (rb *ringBuffer) upgrade(newState string) {
 	p := int8(statePriority(newState))
 	if rb.size == 0 {
-		rb.buckets[rb.head] = p
+		rb.setBucket(rb.head, newState)
 		rb.head = (rb.head + 1) % HistoryBucketCount
 		rb.size = 1
 	} else {
 		cur := rb.current()
+		// An unencodable state carries bucketNoData, which is negative and so
+		// never wins here — the open bucket keeps the activity it observed.
 		if p > rb.buckets[cur] {
-			rb.buckets[cur] = p
+			rb.setBucket(cur, newState)
 		}
 	}
 	rb.lastState = newState
@@ -115,13 +190,16 @@ func (rb *ringBuffer) tick() (bool, int8) {
 	}
 	rb.tickAcc = 0
 
-	p := int8(statePriority(rb.lastState))
-	rb.buckets[rb.head] = p
+	rb.setBucket(rb.head, rb.lastState)
+	p := rb.buckets[rb.head]
 	rb.head = (rb.head + 1) % HistoryBucketCount
 	if rb.size < HistoryBucketCount {
 		rb.size++
 	}
-	return true, p
+	// The caller ships this straight to clients, so hand back the wire code:
+	// a sealed bucket carrying an unencodable state (or a session that has not
+	// reported one yet) is no-data, which both decoders render blank.
+	return true, wireCode(p)
 }
 
 func (rb *ringBuffer) snapshot() []string {
@@ -131,7 +209,14 @@ func (rb *ringBuffer) snapshot() []string {
 	out := make([]string, rb.size)
 	start := (rb.head - rb.size + HistoryBucketCount) % HistoryBucketCount
 	for i := 0; i < rb.size; i++ {
-		out[i] = priorityToState(rb.buckets[(start+i)%HistoryBucketCount])
+		idx := (start + i) % HistoryBucketCount
+		// A state this build cannot encode round-trips verbatim, so save()
+		// writes back what it read rather than a coerced value (#1807).
+		if s, ok := rb.unencodable[idx]; ok {
+			out[i] = s
+			continue
+		}
+		out[i] = priorityToState(rb.buckets[idx])
 	}
 	return out
 }
@@ -151,12 +236,7 @@ func (rb *ringBuffer) encodePriorities() [HistoryBucketCount]uint8 {
 	start := (rb.head - rb.size + HistoryBucketCount) % HistoryBucketCount
 	dst := HistoryBucketCount - rb.size
 	for i := 0; i < rb.size; i++ {
-		p := rb.buckets[(start+i)%HistoryBucketCount]
-		if p < 0 {
-			out[dst+i] = statePriorityNoData
-		} else {
-			out[dst+i] = uint8(p)
-		}
+		out[dst+i] = uint8(wireCode(rb.buckets[(start+i)%HistoryBucketCount]))
 	}
 	return out
 }
@@ -170,10 +250,11 @@ func (rb *ringBuffer) restore(states []string) {
 		states = states[len(states)-HistoryBucketCount:]
 	}
 	for i := range rb.buckets {
-		rb.buckets[i] = -1
+		rb.buckets[i] = bucketNoData
 	}
+	rb.unencodable = nil
 	for i, s := range states {
-		rb.buckets[i] = int8(statePriority(s))
+		rb.setBucket(i, s)
 	}
 	n := len(states)
 	rb.head = n % HistoryBucketCount
@@ -181,14 +262,27 @@ func (rb *ringBuffer) restore(states []string) {
 	rb.lastState = states[n-1]
 }
 
+// priorityToState is snapshot()'s half of the pair: it names the state a
+// bucket's 2-bit code stands for, and is used only to build the []string that
+// save() persists and Snapshot() returns — never to decode the wire, which the
+// Swift and JS clients do themselves.
+//
+// Everything that is not one of the three encodable codes — an unfilled slot,
+// or a bucket whose unencodable string has already been consumed by snapshot()
+// — yields "" (no data). It must NOT fall back to session.StateReady: that is
+// the mirror half of #1807's bug, where a blank bucket was persisted as `ready`
+// and came back green on the next Load. "" is the same no-data spelling both
+// client decoders already use.
 func priorityToState(p int8) string {
 	switch p {
 	case statePriorityWaiting:
 		return session.StateWaiting
 	case statePriorityWorking:
 		return session.StateWorking
-	default:
+	case statePriorityReady:
 		return session.StateReady
+	default:
+		return ""
 	}
 }
 
@@ -335,7 +429,13 @@ func (h *HistoryTracker) OnTransition(sessionID, newState string, _ time.Time) {
 	}
 	sb.mu.Unlock()
 
-	if emit != nil {
+	// An unencodable state produces no upgrade message. Both clients merge an
+	// upgrade by priority and no-data is their lowest, so such a message could
+	// only ever be discarded — and the ring above did not change either, for
+	// the same reason (see upgrade()). Sending nothing keeps client and server
+	// in step without putting a value on the wire that means "downgrade this
+	// bucket", which the 2-bit contract has no way to say (#1807).
+	if emit != nil && statePriority(newState) != bucketNoData {
 		emit(HistoryEvent{
 			Kind:      HistoryEventUpgrade,
 			SessionID: sessionID,

--- a/core/application/services/history_tracker.go
+++ b/core/application/services/history_tracker.go
@@ -87,13 +87,13 @@ func validGranularity(sec int) bool {
 //     the encoding widens. A build OLDER than this fix reads such a bucket as
 //     ready/green, exactly as it already did with the value it wrote itself,
 //     so nothing regresses for it.
-//   - Aggregation is unaffected: bucketNoData is negative, so an unencodable
-//     transition loses upgrade()'s max-merge and the activity already recorded
-//     in the open bucket survives (#1805's documented interim behaviour — the
-//     strip shows what the session was doing, not that it errored). Making it
-//     WIN the merge would need the clients to accept a downgrade, which their
-//     priority-based merge cannot express — i.e. a client change, which is
-//     precisely what this fix is scoped to avoid.
+//   - Aggregation is unaffected — the activity already recorded in the open
+//     bucket survives, which is #1805's documented interim behaviour ("the
+//     strip shows what the session was doing, not that it errored"). See
+//     upgrade()'s merge comment for the mechanism. Making an unencodable state
+//     WIN that merge instead would need the clients to accept a downgrade,
+//     which their priority-based merge cannot express — i.e. a client change,
+//     which is precisely what this fix is scoped to avoid.
 //   - WHAT A USER SEES, stated because it is a real change and the only
 //     alternatives are lies: that carry-forward protection covers the single
 //     open bucket, not the strip. tick() seals each new bucket from lastState,
@@ -121,6 +121,13 @@ func statePriority(s string) int {
 
 // wireCode maps an in-memory bucket priority onto the 2-bit code clients
 // decode, so nothing outside this file ever sees the negative sentinel.
+//
+// A sign test rather than `== bucketNoData` on purpose: the wire contract is
+// "0..3 and nothing else", so any negative belongs on the no-data code,
+// including one a later sentinel might add. That is the whole invariant —
+// TestHistoryTracker_NoNegativePriorityReachesTheWire pins it end to end,
+// because PushMessage.Buckets/.Priority are plain int8 and neither the hub nor
+// json.Marshal would object to a -1 going out.
 func wireCode(p int8) int8 {
 	if p < 0 {
 		return statePriorityNoData
@@ -165,7 +172,14 @@ func (rb *ringBuffer) setBucket(i int, state string) {
 		rb.unencodable[i] = state
 		return
 	}
-	delete(rb.unencodable, i) // no-op on a nil map
+	// Guarded rather than unconditional: this is the common path (every
+	// encodable tick, for every session, every second), and `delete` on a nil
+	// map is a real out-of-line runtime call — ~1.0 ns/op unguarded vs
+	// ~0.25 ns/op behind this len check (measured, go test -bench, go1.25
+	// darwin/arm64), which is most of the per-tick cost this field added.
+	if len(rb.unencodable) > 0 {
+		delete(rb.unencodable, i)
+	}
 }
 
 func (rb *ringBuffer) current() int {
@@ -183,14 +197,16 @@ func (rb *ringBuffer) upgrade(newState string) {
 		rb.size = 1
 	} else {
 		cur := rb.current()
-		// An unencodable state carries bucketNoData, which is negative and so
-		// never wins the strict comparison — the open bucket keeps the activity
-		// it observed. The one exception is a bucket holding no activity
-		// either: recording the verbatim string there overwrites nothing and is
-		// what stops a live `error` from being dropped purely because of which
-		// tick phase it arrived in (#1807). Among successive unencodable states
-		// in one bucket the last one wins, matching "most recent state seen".
-		if p > rb.buckets[cur] || (p == bucketNoData && rb.buckets[cur] == bucketNoData) {
+		// `>=`, not `>`, and the difference is load-bearing (#1807). An
+		// unencodable state carries bucketNoData, which is below every real
+		// priority, so it still cannot displace activity the bucket observed.
+		// What the equal case buys is bucketNoData meeting bucketNoData: the
+		// bucket holds nothing, so recording the verbatim string overwrites
+		// nothing, and a live `error` stops being dropped purely because of
+		// which tick phase it arrived in. A tie between two REAL priorities is
+		// a no-op write — each code maps to exactly one state name, so the
+		// value is the one already there.
+		if p >= rb.buckets[cur] {
 			rb.setBucket(cur, newState)
 		}
 	}
@@ -228,14 +244,17 @@ func (rb *ringBuffer) snapshot() []string {
 	for i := 0; i < rb.size; i++ {
 		idx := (start + i) % HistoryBucketCount
 		// A state this build cannot encode round-trips verbatim, so save()
-		// writes back what it read rather than a coerced value (#1807). The
-		// priority is re-checked rather than trusted: setBucket is the only
-		// writer that maintains both, so gating here means a future write
-		// straight to buckets[] degrades to a blank bucket instead of silently
-		// resurrecting a dead state string into a live one.
-		if s, ok := rb.unencodable[idx]; ok && rb.buckets[idx] == bucketNoData {
-			out[i] = s
-			continue
+		// writes back what it read rather than a coerced value (#1807). Only a
+		// no-data bucket can carry one, and asking that first is deliberate
+		// twice over: it gates on the priority rather than trusting the map, so
+		// a future write straight to buckets[] degrades to a blank bucket
+		// instead of resurrecting a dead state name into a live one — and it
+		// skips the map lookup entirely for every encodable bucket.
+		if rb.buckets[idx] == bucketNoData {
+			if s, ok := rb.unencodable[idx]; ok {
+				out[i] = s
+				continue
+			}
 		}
 		out[i] = priorityToState(rb.buckets[idx])
 	}
@@ -452,15 +471,16 @@ func (h *HistoryTracker) OnTransition(sessionID, newState string, _ time.Time) {
 
 	// An unencodable state produces no upgrade message. Both clients merge an
 	// upgrade by priority and no-data is their lowest, so such a message could
-	// only ever be discarded — and the ring above did not change either, for
+	// only ever be discarded — and the ring above kept whatever it held, for
 	// the same reason (see upgrade()). Sending nothing keeps client and server
 	// in step without putting a value on the wire that means "downgrade this
 	// bucket", which the 2-bit contract has no way to say (#1807).
-	if emit != nil && statePriority(newState) != bucketNoData {
+	p := statePriority(newState)
+	if emit != nil && p != bucketNoData {
 		emit(HistoryEvent{
 			Kind:      HistoryEventUpgrade,
 			SessionID: sessionID,
-			Priority:  int8(statePriority(newState)),
+			Priority:  int8(p),
 		})
 	}
 }

--- a/core/application/services/history_tracker_test.go
+++ b/core/application/services/history_tracker_test.go
@@ -774,6 +774,49 @@ func TestHistoryTracker_UnencodableSurvivesOntoABlankOpenBucket(t *testing.T) {
 	assertWireBucketsNoData(t, ht, sid, HistoryBucketCount-1)
 }
 
+// TestHistoryTracker_NoNegativePriorityReachesTheWire pins the one invariant
+// nothing downstream re-checks: PushMessage.Buckets/.Priority are plain int8
+// and historyEventBroadcaster copies them field-for-field into json.Marshal,
+// so a leaked bucketNoData (-1) would serialize as literal -1 to clients that
+// expect a 2-bit code. wireCode() in tick() and OnTransition's encodability
+// gate are the only two things standing between the sentinel and the socket;
+// break either and this goes red.
+func TestHistoryTracker_NoNegativePriorityReachesTheWire(t *testing.T) {
+	ht := NewHistoryTracker()
+	var events []HistoryEvent
+	ht.SetEmitFunc(func(ev HistoryEvent) { events = append(events, ev) })
+
+	// A workload mixing encodable and unencodable states across every ring.
+	states := []string{"working", "error", "waiting", "quarantined", "ready", ""}
+	for i := 0; i < 120; i++ {
+		ht.OnTransition("mixed", states[i%len(states)], epoch)
+		ht.tick()
+	}
+
+	sawTick, sawUpgrade := 0, 0
+	for _, ev := range events {
+		switch ev.Kind {
+		case HistoryEventTick:
+			for sid, p := range ev.Buckets {
+				sawTick++
+				if p < 0 || p > statePriorityNoData {
+					t.Fatalf("tick bucket for %q = %d, outside the 2-bit contract 0..%d", sid, p, statePriorityNoData)
+				}
+			}
+		case HistoryEventUpgrade:
+			sawUpgrade++
+			if ev.Priority < 0 || ev.Priority > statePriorityWaiting {
+				t.Fatalf("upgrade priority = %d, outside 0..%d", ev.Priority, statePriorityWaiting)
+			}
+		case HistoryEventSnapshot:
+			// carries base64, already masked to 2 bits by packPriorities
+		}
+	}
+	if sawTick == 0 || sawUpgrade == 0 {
+		t.Fatalf("observed %d tick bucket(s) and %d upgrade(s) — the assertions above never ran", sawTick, sawUpgrade)
+	}
+}
+
 // TestHistoryTracker_UnencodableDoesNotClobberObservedActivity is a GUARD this
 // change adds, not a defect test: it passes by construction both before and
 // after the fix. It pins the aggregation half of #1807's decision — an

--- a/core/application/services/history_tracker_test.go
+++ b/core/application/services/history_tracker_test.go
@@ -643,6 +643,58 @@ func TestHistoryTracker_LoadUnencodableStateIsNotReady(t *testing.T) {
 	}
 }
 
+// assertNoUpgradeEmitted fails if any event is an upgrade — an unencodable
+// state has no 2-bit code, so there is nothing a client could merge.
+func assertNoUpgradeEmitted(t *testing.T, events []HistoryEvent) {
+	t.Helper()
+	for _, ev := range events {
+		if ev.Kind == HistoryEventUpgrade {
+			t.Errorf("unencodable transition emitted an upgrade (priority %d): %+v", ev.Priority, ev)
+		}
+	}
+}
+
+// assertWireBucketsNoData decodes sid's 1s strip and checks the named bucket
+// indices carry the no-data code rather than a colour.
+func assertWireBucketsNoData(t *testing.T, ht *HistoryTracker, sid string, idx ...int) {
+	t.Helper()
+	enc, ok := ht.Encode(sid)
+	if !ok {
+		t.Fatal("Encode failed")
+	}
+	buckets := decodeHistoryString(t, enc.History["1"])
+	for _, i := range idx {
+		if buckets[i] != statePriorityNoData {
+			t.Errorf("wire bucket[%d] = %d, want %d (no-data); %d is ready/green",
+				i, buckets[i], statePriorityNoData, statePriorityReady)
+		}
+	}
+}
+
+// assertTickBucketNoData checks the 1s tick events carry the no-data code for
+// sid, and fails if no such event was observed at all — absence of a finding
+// and inability to look must not read the same.
+func assertTickBucketNoData(t *testing.T, events []HistoryEvent, sid string) {
+	t.Helper()
+	saw := false
+	for _, ev := range events {
+		if ev.Kind != HistoryEventTick || ev.GranularitySec != 1 {
+			continue
+		}
+		p, ok := ev.Buckets[sid]
+		if !ok {
+			continue
+		}
+		saw = true
+		if p != statePriorityNoData {
+			t.Errorf("tick bucket = %d, want %d (no-data)", p, statePriorityNoData)
+		}
+	}
+	if !saw {
+		t.Fatal("no 1s tick event carried this session — the assertion never ran")
+	}
+}
+
 // TestHistoryTracker_UnencodableTransitionNeverSealsReady covers #1807's live
 // half: a session that transitions into an unencodable state seals its
 // following buckets as no-data rather than green, and emits nothing a client
@@ -654,39 +706,72 @@ func TestHistoryTracker_UnencodableTransitionNeverSealsReady(t *testing.T) {
 	sid := "errored"
 
 	ht.OnTransition(sid, "error", epoch)
-	for _, ev := range events {
-		if ev.Kind == HistoryEventUpgrade {
-			t.Errorf("unencodable transition emitted an upgrade (priority %d): %+v", ev.Priority, ev)
-		}
-	}
+	assertNoUpgradeEmitted(t, events)
 
 	events = nil
 	ht.tick() // seals a bucket carrying lastState == "error"
 
-	enc, ok := ht.Encode(sid)
+	assertWireBucketsNoData(t, ht, sid, HistoryBucketCount-2, HistoryBucketCount-1)
+	assertTickBucketNoData(t, events, sid)
+}
+
+// TestHistoryTracker_UnencodableIsPurgedWhenItsBucketIsReused pins the
+// invariant setBucket's doc comment promises: the verbatim string is dropped
+// the moment its bucket takes an encodable value, so a reused ring slot can
+// never resurrect a dead state name into a live bucket — or into history.json.
+func TestHistoryTracker_UnencodableIsPurgedWhenItsBucketIsReused(t *testing.T) {
+	ht := NewHistoryTracker()
+	sid := "reuse"
+	ht.OnTransition(sid, "error", epoch)
+	ht.OnTransition(sid, "waiting", epoch) // outranks no-data, takes the bucket
+
+	rb := ht.sessions[sid].bufs[0]
+	if n := len(rb.unencodable); n != 0 {
+		t.Errorf("unencodable retained %d entr(ies) after the bucket was reused: %v", n, rb.unencodable)
+	}
+	snap, ok := ht.Snapshot(sid, 1)
 	if !ok {
-		t.Fatal("Encode failed")
+		t.Fatal("snapshot missing")
 	}
-	buckets := decodeHistoryString(t, enc.History["1"])
-	for _, i := range []int{HistoryBucketCount - 2, HistoryBucketCount - 1} {
-		if buckets[i] != statePriorityNoData {
-			t.Errorf("wire bucket[%d] = %d, want %d (no-data); %d is ready/green",
-				i, buckets[i], statePriorityNoData, statePriorityReady)
-		}
+	if got := snap[len(snap)-1]; got != "waiting" {
+		t.Errorf("open bucket = %q, want waiting", got)
 	}
-	sawTick := false
-	for _, ev := range events {
-		if ev.Kind != HistoryEventTick || ev.GranularitySec != 1 {
-			continue
-		}
-		sawTick = true
-		if p, ok := ev.Buckets[sid]; ok && p != statePriorityNoData {
-			t.Errorf("tick bucket = %d, want %d (no-data)", p, statePriorityNoData)
-		}
+
+	// A full wrap must drain the map rather than accumulate one entry per slot.
+	ht.OnTransition(sid, "error", epoch)
+	for i := 0; i < HistoryBucketCount; i++ {
+		ht.tick()
 	}
-	if !sawTick {
-		t.Fatal("no 1s tick event observed — the assertion above never ran")
+	ht.OnTransition(sid, "working", epoch)
+	for i := 0; i < HistoryBucketCount; i++ {
+		ht.tick()
 	}
+	if n := len(rb.unencodable); n != 0 {
+		t.Errorf("unencodable held %d entr(ies) after a full wrap of encodable ticks", n)
+	}
+}
+
+// TestHistoryTracker_UnencodableSurvivesOntoABlankOpenBucket covers the tick
+// phase where an unencodable transition lands on a bucket that holds no
+// observed activity either. Nothing is overwritten, so the verbatim string
+// must be recorded — otherwise whether a live `error` reaches history.json
+// depends on when in the second it arrived.
+func TestHistoryTracker_UnencodableSurvivesOntoABlankOpenBucket(t *testing.T) {
+	ht := NewHistoryTracker()
+	sid := "blank-open"
+	ht.EmitSnapshot(sid) // creates the session with no reported state
+	ht.tick()            // seals a blank bucket (lastState is still "")
+	ht.OnTransition(sid, "error", epoch)
+
+	snap, ok := ht.Snapshot(sid, 1)
+	if !ok {
+		t.Fatal("snapshot missing")
+	}
+	if got := snap[len(snap)-1]; got != "error" {
+		t.Errorf("open bucket = %q, want %q preserved onto an otherwise blank bucket", got, "error")
+	}
+	// Rendering is unchanged: preserved, still not painted.
+	assertWireBucketsNoData(t, ht, sid, HistoryBucketCount-1)
 }
 
 // TestHistoryTracker_UnencodableDoesNotClobberObservedActivity is a GUARD this

--- a/core/application/services/history_tracker_test.go
+++ b/core/application/services/history_tracker_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -572,6 +573,140 @@ func TestHistoryTracker_EmitSnapshot(t *testing.T) {
 		if p != statePriorityNoData {
 			t.Errorf("fresh snapshot bucket[%d] = %d, want no-data", i, p)
 		}
+	}
+}
+
+// --- #1807: states the 2-bit history strip cannot encode --------------------
+
+// unencodableStates are the two shapes that reach statePriority without a
+// 2-bit code. `error` is canonical (#1798) but has no slot left (#1805);
+// "quarantined" stands in for a state a NEWER daemon wrote into history.json
+// that this build has never heard of — the downgrade/mixed-version path.
+var unencodableStates = []string{"error", "quarantined"}
+
+func readHistoryFile(t *testing.T, dir string) string {
+	t.Helper()
+	b, err := os.ReadFile(filepath.Join(dir, "history.json"))
+	if err != nil {
+		t.Fatalf("read history.json: %v", err)
+	}
+	return string(b)
+}
+
+// TestHistoryTracker_LoadUnencodableStateIsNotReady is #1807's defect test.
+// A history.json bucket holding a state this build cannot encode must (a) not
+// restore as `ready`, (b) not reach either client as the green `ready` code,
+// and (c) survive the next save() with its original value intact.
+func TestHistoryTracker_LoadUnencodableStateIsNotReady(t *testing.T) {
+	for _, state := range unencodableStates {
+		t.Run(state, func(t *testing.T) {
+			dir := t.TempDir()
+			payload := `{"version":1,"sessions":{"s":{"1":["working","` + state + `","waiting"]}}}`
+			if err := os.WriteFile(filepath.Join(dir, "history.json"), []byte(payload), 0600); err != nil {
+				t.Fatal(err)
+			}
+			ht := NewHistoryTrackerWithDir(dir)
+			ht.Load()
+
+			snap, ok := ht.Snapshot("s", 1)
+			if !ok {
+				t.Fatal("snapshot missing after Load")
+			}
+			if len(snap) != 3 {
+				t.Fatalf("len(snap) = %d, want 3 (%v)", len(snap), snap)
+			}
+			if snap[1] == "ready" {
+				t.Errorf("bucket[1] = %q — an unencodable state must never restore as ready", snap[1])
+			}
+			if snap[1] != state {
+				t.Errorf("bucket[1] = %q, want %q preserved verbatim", snap[1], state)
+			}
+
+			// On the wire it must be the no-data code, which both client
+			// decoders render as a blank slot — never the code that paints green.
+			enc, ok := ht.Encode("s")
+			if !ok {
+				t.Fatal("Encode failed")
+			}
+			buckets := decodeHistoryString(t, enc.History["1"])
+			if got := buckets[HistoryBucketCount-2]; got != statePriorityNoData {
+				t.Errorf("wire bucket = %d, want %d (no-data); %d is ready/green",
+					got, statePriorityNoData, statePriorityReady)
+			}
+
+			// ...and save() must write the original value back, not a coerced one.
+			ht.save()
+			if raw := readHistoryFile(t, dir); !strings.Contains(raw, `"`+state+`"`) {
+				t.Errorf("save() erased the unencodable bucket %q: %s", state, raw)
+			}
+		})
+	}
+}
+
+// TestHistoryTracker_UnencodableTransitionNeverSealsReady covers #1807's live
+// half: a session that transitions into an unencodable state seals its
+// following buckets as no-data rather than green, and emits nothing a client
+// could merge into a green bucket.
+func TestHistoryTracker_UnencodableTransitionNeverSealsReady(t *testing.T) {
+	ht := NewHistoryTracker()
+	var events []HistoryEvent
+	ht.SetEmitFunc(func(ev HistoryEvent) { events = append(events, ev) })
+	sid := "errored"
+
+	ht.OnTransition(sid, "error", epoch)
+	for _, ev := range events {
+		if ev.Kind == HistoryEventUpgrade {
+			t.Errorf("unencodable transition emitted an upgrade (priority %d): %+v", ev.Priority, ev)
+		}
+	}
+
+	events = nil
+	ht.tick() // seals a bucket carrying lastState == "error"
+
+	enc, ok := ht.Encode(sid)
+	if !ok {
+		t.Fatal("Encode failed")
+	}
+	buckets := decodeHistoryString(t, enc.History["1"])
+	for _, i := range []int{HistoryBucketCount - 2, HistoryBucketCount - 1} {
+		if buckets[i] != statePriorityNoData {
+			t.Errorf("wire bucket[%d] = %d, want %d (no-data); %d is ready/green",
+				i, buckets[i], statePriorityNoData, statePriorityReady)
+		}
+	}
+	sawTick := false
+	for _, ev := range events {
+		if ev.Kind != HistoryEventTick || ev.GranularitySec != 1 {
+			continue
+		}
+		sawTick = true
+		if p, ok := ev.Buckets[sid]; ok && p != statePriorityNoData {
+			t.Errorf("tick bucket = %d, want %d (no-data)", p, statePriorityNoData)
+		}
+	}
+	if !sawTick {
+		t.Fatal("no 1s tick event observed — the assertion above never ran")
+	}
+}
+
+// TestHistoryTracker_UnencodableDoesNotClobberObservedActivity is a GUARD this
+// change adds, not a defect test: it passes by construction both before and
+// after the fix. It pins the aggregation half of #1807's decision — an
+// unencodable transition LOSES the open bucket's max-merge, so the activity
+// actually observed in that second survives instead of being blanked. Mutate
+// bucketNoData to a value above statePriorityWaiting to see it go red.
+func TestHistoryTracker_UnencodableDoesNotClobberObservedActivity(t *testing.T) {
+	ht := NewHistoryTracker()
+	sid := "merge"
+	ht.OnTransition(sid, "working", epoch)
+	ht.OnTransition(sid, "error", epoch)
+
+	snap, ok := ht.Snapshot(sid, 1)
+	if !ok {
+		t.Fatal("snapshot missing")
+	}
+	if got := snap[len(snap)-1]; got != "working" {
+		t.Errorf("open bucket = %q, want working — an unencodable state must not erase observed activity", got)
 	}
 }
 

--- a/core/application/services/history_tracker_test.go
+++ b/core/application/services/history_tracker_test.go
@@ -795,26 +795,44 @@ func TestHistoryTracker_NoNegativePriorityReachesTheWire(t *testing.T) {
 
 	sawTick, sawUpgrade := 0, 0
 	for _, ev := range events {
-		switch ev.Kind {
-		case HistoryEventTick:
-			for sid, p := range ev.Buckets {
-				sawTick++
-				if p < 0 || p > statePriorityNoData {
-					t.Fatalf("tick bucket for %q = %d, outside the 2-bit contract 0..%d", sid, p, statePriorityNoData)
-				}
-			}
-		case HistoryEventUpgrade:
-			sawUpgrade++
-			if ev.Priority < 0 || ev.Priority > statePriorityWaiting {
-				t.Fatalf("upgrade priority = %d, outside 0..%d", ev.Priority, statePriorityWaiting)
-			}
-		case HistoryEventSnapshot:
-			// carries base64, already masked to 2 bits by packPriorities
-		}
+		sawTick += assertTickCodesInRange(t, ev)
+		sawUpgrade += assertUpgradeCodeInRange(t, ev)
 	}
 	if sawTick == 0 || sawUpgrade == 0 {
 		t.Fatalf("observed %d tick bucket(s) and %d upgrade(s) — the assertions above never ran", sawTick, sawUpgrade)
 	}
+}
+
+// assertTickCodesInRange checks every bucket a tick event carries is a valid
+// 2-bit code, returning how many it checked. Non-tick events check nothing and
+// return 0. (Snapshot events carry base64, already masked by packPriorities.)
+func assertTickCodesInRange(t *testing.T, ev HistoryEvent) int {
+	t.Helper()
+	if ev.Kind != HistoryEventTick {
+		return 0
+	}
+	n := 0
+	for sid, p := range ev.Buckets {
+		n++
+		if p < 0 || p > statePriorityNoData {
+			t.Fatalf("tick bucket for %q = %d, outside the 2-bit contract 0..%d", sid, p, statePriorityNoData)
+		}
+	}
+	return n
+}
+
+// assertUpgradeCodeInRange checks an upgrade event's priority is one of the
+// three encodable codes, returning 1 if it checked and 0 otherwise. No-data is
+// out of range here on purpose: an upgrade to no-data is never emitted.
+func assertUpgradeCodeInRange(t *testing.T, ev HistoryEvent) int {
+	t.Helper()
+	if ev.Kind != HistoryEventUpgrade {
+		return 0
+	}
+	if ev.Priority < 0 || ev.Priority > statePriorityWaiting {
+		t.Fatalf("upgrade priority = %d, outside 0..%d", ev.Priority, statePriorityWaiting)
+	}
+	return 1
 }
 
 // TestHistoryTracker_UnencodableDoesNotClobberObservedActivity is a GUARD this

--- a/platforms/web/irrlicht.js
+++ b/platforms/web/irrlicht.js
@@ -1617,17 +1617,18 @@ import { reconcile, paintRowNum } from './domReconcile.js';
     // The strip's wire format is 2 bits per bucket and all four codes are
     // taken: HISTORY_PRIORITY_TO_STATE above maps 0=ready, 1=working,
     // 2=waiting, 3=no-data. There is no fifth value to spend, so `error` cannot
-    // be carried without widening the daemon's packing — deferred to #1805/
-    // #1807, which own the strip.
+    // be carried without widening the daemon's packing — deferred to #1805,
+    // which owns the strip's encoding.
     //
-    // What that costs today, stated plainly: the daemon's history_tracker maps
-    // `error` to the ready priority (statePriority's default arm, named as this
-    // exact symptom in #1798's own commit), so an errored bucket paints GREEN
-    // on the sparkline while the row's state icon beside it is red. That is a
-    // real inconsistency in the shipped UI, not a hypothetical, and it is
-    // #1805/#1807's to fix rather than something this map can paper over —
-    // adding a key here would do nothing, because no bucket can ever decode to
-    // 'error' in the first place.
+    // What that costs today, stated plainly: #1807 stopped the daemon coercing
+    // `error` to the ready priority, so an errored bucket no longer paints
+    // GREEN — it decodes to 3 (no-data) and falls through the `if (!color)
+    // continue` guard in paintRowHistory, painting nothing. A session that
+    // STAYS errored therefore blanks its whole strip within one ring while the
+    // row's state icon beside it is red. That is the honest reading of a field
+    // with no code to spare, not the end state: adding a key to this map still
+    // does nothing, because no bucket can decode to 'error' until #1805 widens
+    // the packing.
     const HISTORY_BAR_COLORS = {
       working: '#8B5CF6',
       waiting: '#FF9500',

--- a/tools/state-vocabulary-lint.waivers
+++ b/tools/state-vocabulary-lint.waivers
@@ -22,9 +22,15 @@
 # The history bar packs each bucket's state into a 2-bit field whose four codes
 # are already spent (ready/working/waiting/no-data), so every producer,
 # consumer and test along THAT path is three-state by construction rather than
-# by oversight.  #1805 tracks widening the encoding; #1807 tracks history.json
-# coercing an unrecognised state to `ready`.  When either lands, these are the
-# sites it has to touch.
+# by oversight.  #1805 tracks widening the encoding, and when it lands these
+# are the sites it has to touch.
+#
+# #1807 has LANDED and did not widen anything: a state with no code now maps to
+# the no-data code instead of `ready`, and its verbatim string is preserved in
+# history.json rather than rewritten.  So an errored bucket paints blank, not
+# green — but the field is still 2 bits and these sites still enumerate exactly
+# the three states it can carry.  The waivers below therefore stand as written;
+# they are #1805's checklist alone now.
 #
 # Scope note, because the first draft of this section got it wrong and a wrong
 # dismissal is the one error class that stops anyone re-checking: this covers


### PR DESCRIPTION
Closes #1807 — the fourth unknown-state reader of the #1796 arc, and the only one that destroys data on disk.

## The bug

`statePriority()`'s `default:` arm mapped every state with no 2-bit code — `session.StateError` (canonical since #1798) and any name a **newer** daemon wrote into `history.json` — onto `statePriorityReady`. `priorityToState()` mirrored it, so `snapshot()` named those buckets `"ready"` and `save()` rewrote `history.json` with the coerced value every 60 ticks and on shutdown. The bucket painted **green** on both clients *and* the original value was gone from disk — the same destroy-the-user's-data shape #1797/#1806 removed from the session-file reader, one file over.

## The delegated decision: PRESERVE, not downgrade

An unencodable bucket now carries `bucketNoData` (a negative **in-memory** sentinel that encodes to the existing `statePriorityNoData` wire code), and its **verbatim state string is kept** in `ringBuffer.unencodable`, so `snapshot()` — and therefore `save()` — writes back exactly what was read. Only the *rendered* value degrades.

The choice and its wire consequence are documented **in the code**, on `statePriority` (`history_tracker.go`), per acceptance item 2 — not only here:

- **The wire format is UNCHANGED.** Still 60 buckets × 2 bits = 15 bytes = 20 base64 chars, still four codes. No client decoder moves and neither does any length assertion (`SessionManager+History.swift:62`, `irrlicht.js:288`, `decodeHistoryString`). Widening stays #1805's job.
- An unencodable bucket ships as `statePriorityNoData`, which Swift's `historyPriorityToState` and the web's `HISTORY_PRIORITY_TO_STATE` **already** map to `""`, and which `HistoryBarView.barColor` (`return nil`) and `paintRowHistory` (`if (!color) continue`) both render as a blank slot — never a colour.
- `history.json` can now contain a state string this build cannot render. That is what makes a downgrade non-destructive, and #1805 can display those buckets once the encoding widens. A build **older** than this fix reads such a bucket as ready/green — exactly as it already did with the value it wrote itself, so nothing regresses for it.
- `bucketNoData` is negative on purpose: an unencodable transition **loses** `upgrade()`'s max-merge, so activity already observed in the open bucket survives (#1805's documented interim behaviour). Making it *win* would require the clients to accept a downgrade, which their priority-based merge cannot express — i.e. a client change, which this fix is scoped to avoid.
- `HistoryEventUpgrade` is **suppressed** for an unencodable state: both clients would discard it (no-data is their lowest priority) and the server's own ring did not change either.

`priorityToState`'s `default:` now yields `""` rather than `session.StateReady` — the mirror half of the bug, where a blank bucket was persisted as `ready` and came back green on the next `Load`.

Deliberately **not** rewritten as a `session.IsCanonicalState` check: that would classify `error` as encodable and hand a 5th value to `packPriorities`' 2-bit mask.

## Red-first evidence

`go test ./core/application/services/ -run 'TestHistoryTracker_(LoadUnencodableStateIsNotReady|UnencodableTransitionNeverSealsReady|UnencodableDoesNotClobberObservedActivity)' -count=1 -v`, run on the **pre-fix** tree:

```
=== RUN   TestHistoryTracker_LoadUnencodableStateIsNotReady/error
    history_tracker_test.go:619: bucket[1] = "ready" — an unencodable state must never restore as ready
    history_tracker_test.go:622: bucket[1] = "ready", want "error" preserved verbatim
    history_tracker_test.go:633: wire bucket = 0, want 3 (no-data); 0 is ready/green
    history_tracker_test.go:640: save() erased the unencodable bucket "error": {"version":1,"sessions":{"s":{"1":["working","ready","waiting"]}}}
=== RUN   TestHistoryTracker_LoadUnencodableStateIsNotReady/quarantined
    history_tracker_test.go:619: bucket[1] = "ready" — an unencodable state must never restore as ready
    history_tracker_test.go:622: bucket[1] = "ready", want "quarantined" preserved verbatim
    history_tracker_test.go:633: wire bucket = 0, want 3 (no-data); 0 is ready/green
    history_tracker_test.go:640: save() erased the unencodable bucket "quarantined": {"version":1,"sessions":{"s":{"1":["working","ready","waiting"]}}}
--- FAIL: TestHistoryTracker_LoadUnencodableStateIsNotReady (0.00s)
=== RUN   TestHistoryTracker_UnencodableTransitionNeverSealsReady
    history_tracker_test.go:659: unencodable transition emitted an upgrade (priority 0): {Kind:2 SessionID:errored ... Priority:0}
    history_tracker_test.go:673: wire bucket[58] = 0, want 3 (no-data); 0 is ready/green
    history_tracker_test.go:673: wire bucket[59] = 0, want 3 (no-data); 0 is ready/green
    history_tracker_test.go:684: tick bucket = 0, want 3 (no-data)
--- FAIL: TestHistoryTracker_UnencodableTransitionNeverSealsReady (0.00s)
=== RUN   TestHistoryTracker_UnencodableDoesNotClobberObservedActivity
--- PASS: TestHistoryTracker_UnencodableDoesNotClobberObservedActivity (0.00s)
FAIL	irrlicht/core/application/services	0.375s
```

The `save() erased the unencodable bucket` line is the data-destruction half of the issue, reproduced verbatim: `"error"` in, `"ready"` on disk.

`TestHistoryTracker_LoadUnencodableStateIsNotReady` is table-driven over two shapes: `"error"` (canonical, uncarryable) and `"quarantined"` (a fifth state a newer daemon wrote — the actual downgrade path).

### The one test that is NOT red-first

`TestHistoryTracker_UnencodableDoesNotClobberObservedActivity` is a **GUARD this change adds**, and it passes by construction on both trees (see the green above) — it pins the aggregation half of the decision. Per AGENTS.md it was **mutation-verified** instead: `bucketNoData = -1` → `3` (above `statePriorityWaiting`), which makes an unencodable transition win the max-merge:

```
=== RUN   TestHistoryTracker_UnencodableDoesNotClobberObservedActivity
    history_tracker_test.go:709: open bucket = "error", want working — an unencodable state must not erase observed activity
--- FAIL: TestHistoryTracker_UnencodableDoesNotClobberObservedActivity (0.00s)
```

The mutation was reverted (`git status --porcelain` empty afterwards).

### Locks — pass by construction, not evidence

Every pre-existing `TestHistoryTracker_*` is a lock on unchanged behaviour for the three encodable states: `SaveLoadRoundTrip`, `SnapshotOldestNewest`, `PriorityAggregation`, `BucketRollover`, `EncodePartialFillPadsFront`, `EncodeFullRing`, `EncodeBitOrder`, `EmitOnTransitionAndTick`, `GenerationsMatchBuckets`, `EmitSnapshot`. All green, unmodified.

## Verification

`tools/preflight.sh` chunked by group, each in the foreground: **go PASS** (gofmt, core module tests, onboarding-factory, replaydata validate, recording-rig smoke, replay fixtures), **arch PASS** (ARS 7.891921 → 7.892021, no regression), **tools PASS** (incl. state-vocabulary lint: 50 sites, all waived), **skills PASS**, **posix PASS**, **bash PASS**, **security PASS**. `web`/`swift` not run and not applicable — the diff is two Go files.

`go test ./core/application/services/ -race -count=1` — ok, 26.8s.

## Behaviour change worth naming

A session that has been created but has not reported a state yet (`EmitSnapshot` lazy-creates it; `lastState == ""`) previously sealed **green `ready`** buckets on every tick. It now seals no-data. That falls out of the same `default:` arm and is strictly more honest — it also matches what `EmitSnapshot`'s own doc comment says a fresh session should render ("an all-no-data snapshot"). No test depended on the old behaviour.

## Review and simplify passes

The `ir:code-review` pass (medium) returned **5 findings, all applied** — commit `4ab8dccb`:

1. `platforms/web/irrlicht.js`'s `HISTORY_BAR_COLORS` comment asserted, as shipped fact, the exact green-bucket defect this PR removes ("an errored bucket paints GREEN … it is #1805/#1807's to fix"). Rewritten. **Comment only** — no decoder, no length assertion, no colour-map entry moves, so intent is intact. The web tree was skipped in the first pass on the reasoning "the diff is two Go files"; `tools/state-vocabulary-lint.waivers` section 1 names that exact file as a site #1807 has to touch, and it is prose no tool reads.
2. The whole-strip blanking is now disclosed at the decision (see "Behaviour change worth naming" below), not just the never-reported-state case.
3. `snapshot()` re-checks the bucket's priority before trusting `unencodable[idx]`, so a future write straight to `buckets[]` degrades to a blank bucket rather than resurrecting a dead state name. Pinned by a new test that also fails on an unbounded map.
4. **Real defect found:** `upgrade()`'s strict `>` dropped an unencodable state that landed on an *already-blank* open bucket, so whether a live `error` reached `history.json` depended on tick phase. Now recorded — it overwrites nothing.
5. `tools/state-vocabulary-lint.waivers` section 1 described #1807 as open.

The `/simplify` pass (4 agents) — commit `49245fda`: collapsed `upgrade()`'s three-term condition to `p >= rb.buckets[cur]` (identical truth table), guarded `setBucket`'s `delete` with `len()` (~1.0 ns/op → ~0.25 ns/op, measured; it runs once per session per second), reordered `snapshot()`'s lookup, de-duplicated a `statePriority` call in `OnTransition`, trimmed one restated comment paragraph, and added the missing wire-contract test. Reuse angle: no findings. **Declined:** inlining the two single-use test helpers (they exist to flatten the CodeScene Bumpy Road finding) and dropping `snapshot()`'s drift gate (that gate *is* finding 3).

### Additional red-first / mutation evidence

`TestHistoryTracker_UnencodableSurvivesOntoABlankOpenBucket` — defect test for review finding 4, red with the pre-fix `>` condition:
```
    history_tracker_test.go:771: open bucket = "", want "error" preserved onto an otherwise blank bucket
--- FAIL: TestHistoryTracker_UnencodableSurvivesOntoABlankOpenBucket (0.00s)
```

`TestHistoryTracker_UnencodableIsPurgedWhenItsBucketIsReused` — a guard; mutation = remove `delete(rb.unencodable, i)` from `setBucket`:
```
    history_tracker_test.go:730: unencodable retained 1 entr(ies) after the bucket was reused: map[0:error]
    history_tracker_test.go:750: unencodable held 60 entr(ies) after a full wrap of encodable ticks
```

`TestHistoryTracker_NoNegativePriorityReachesTheWire` — a guard; mutation = drop `wireCode()` from `tick()`'s return:
```
    history_tracker_test.go:803: tick bucket for "mixed" = -1, outside the 2-bit contract 0..3
```

Every mutation was reverted; `git status --porcelain` empty and `grep -n MUTATION` clean afterwards.

## Not fixed here

The `/simplify` altitude pass makes a deeper argument worth recording: the ring stores `[60]int8` priorities plus a sidecar `map[int]string`, and the two are kept consistent by convention (`setBucket` is the only writer). Storing `[60]string` directly and deriving priorities on demand would delete the field, `setBucket`, `priorityToState`, and the invariant itself — every symbol involved is file-local, so the blast radius is one file. Declined here as a representation change to a hot path on a Priority-High fix that needs to land before #1796 Phase 1; worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
