### PR TITLE
fix(states): keep an errored session red across a daemon restart (#1815)

### DIFF
--- a/core/application/services/error_survives_restart_test.go
+++ b/core/application/services/error_survives_restart_test.go
@@ -1,0 +1,586 @@
+package services
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+
+	"irrlicht/core/domain/session"
+	"irrlicht/core/ports/outbound"
+)
+
+// #1815 — an errored session must survive a daemon restart. Three things have to
+// hold, and this file covers the two that live in this package:
+//
+//   - the ROW must survive both startup dead-PID deleters (a dead process is the
+//     defining evidence for `error`, so the sweeps' own predicate deletes exactly
+//     the rows this state exists to preserve), and
+//   - the VERDICT must be re-placed at seed time, so the classifier agrees with
+//     the state on disk instead of re-deriving `waiting`/`ready` from a frozen
+//     transcript.
+//
+// The tailer's half (LedgerState.SessionError) is pinned in
+// core/pkg/tailer/ledger_session_error_test.go; the end-to-end shape, against a
+// real restarted daemon, is TestErrorStateSurvivesDaemonRestart.
+
+// TestStartupSweeps_KeepARetainedErrorRow is the defect test for the row half.
+// Both deleters are exercised, because exempting one and not the other leaves
+// the outcome unchanged — the row simply dies at the second gate instead of the
+// first.
+func TestStartupSweeps_KeepARetainedErrorRow(t *testing.T) {
+	deadPID := deadPIDForRestartTest(t)
+
+	errored := func(updatedAt time.Time) *session.SessionState {
+		return &session.SessionState{
+			SessionID: "errored-1815",
+			State:     session.StateError,
+			PID:       deadPID,
+			UpdatedAt: updatedAt.Unix(),
+			Metrics: &session.SessionMetrics{
+				SessionError: &session.SessionError{
+					Phase: session.ErrorPhaseTerminal,
+					Class: session.ErrorClassProcessDeath,
+				},
+			},
+		}
+	}
+
+	t.Run("isStartupZombie keeps it inside the window", func(t *testing.T) {
+		pm, _ := restartPIDManager(t)
+		if pm.isStartupZombie(errored(time.Now()), nil) {
+			t.Fatalf("the startup zombie sweep still deletes an errored session with a dead PID — "+
+				"#1815: a crash at 22:00 is gone before the user looks at 08:00 (retention %v)",
+				processDeathRetention)
+		}
+	})
+
+	t.Run("seedAlivePIDs keeps it inside the window", func(t *testing.T) {
+		pm, repo := restartPIDManager(t)
+		if pm.handleAlivePIDState(errored(time.Now())) {
+			t.Errorf("handleAlivePIDState reported the session as alive; it must report not-alive " +
+				"(the process really is dead) while still not deleting the row")
+		}
+		if repo.deletedCount() != 0 {
+			t.Fatalf("the seed-time dead-PID path deleted %d errored session(s) — "+
+				"#1815: exempting only isStartupZombie leaves this second deleter to take the row anyway",
+				repo.deletedCount())
+		}
+	})
+
+	// The exemption is a RETENTION WINDOW, not a permanent pass. Past the
+	// ceiling the ordinary sweeps must reap the row exactly as before, or an
+	// errored session becomes immortal — the failure mode the SignalProcessDeath
+	// ceiling experiment already caused once.
+	t.Run("isStartupZombie reaps it past the window", func(t *testing.T) {
+		pm, _ := restartPIDManager(t)
+		stale := errored(time.Now().Add(-processDeathRetention - time.Minute))
+		if !pm.isStartupZombie(stale, nil) {
+			t.Fatalf("an errored session %v old was still exempt — the retention window never closes, "+
+				"so a dead session is kept forever", processDeathRetention+time.Minute)
+		}
+	})
+
+	// A live process is not a zombie whatever its state, so the exemption must
+	// not be what decides that. Guards against the exemption being written in a
+	// way that only appears to work because it swallows the live case too.
+	t.Run("a live errored session is untouched", func(t *testing.T) {
+		pm, _ := restartPIDManager(t)
+		live := errored(time.Now())
+		live.PID = liveProcessForRestartTest(t)
+		if pm.isStartupZombie(live, nil) {
+			t.Errorf("a live errored session was judged a zombie")
+		}
+	})
+}
+
+// TestRetainedErrorAcrossRestart_OnlyErroredRows pins the predicate's scope. It
+// is consulted before EVERY dead-PID deletion, so a version that answered true
+// for an ordinary state would disable the startup sweep wholesale — the #242
+// regression, reintroduced through the back door.
+func TestRetainedErrorAcrossRestart_OnlyErroredRows(t *testing.T) {
+	for _, st := range session.CanonicalStates() {
+		state := &session.SessionState{State: st, UpdatedAt: time.Now().Unix()}
+		want := st == session.StateError
+		if got := retainedErrorAcrossRestart(state, time.Now(), processDeathRetention); got != want {
+			t.Errorf("retainedErrorAcrossRestart(state=%q) = %v, want %v", st, got, want)
+		}
+	}
+	if retainedErrorAcrossRestart(nil, time.Now(), processDeathRetention) {
+		t.Errorf("retainedErrorAcrossRestart(nil) = true, want false")
+	}
+}
+
+// TestSeedRestoreErrorVerdict_ProcessDeathOutranksAFrozenTranscript is the defect
+// test for the verdict half, and specifically for the part a ledger cannot fix.
+//
+// A process-death verdict is synthesized by the daemon from the OS view of the
+// process; nothing about it is ever written to a transcript, so no amount of
+// tailer persistence reconstructs it. Meanwhile the transcript a crashed agent
+// leaves behind ends mid-turn, which the transcript-tier rules read as work in
+// flight. Restoring only Metrics.SessionError therefore is NOT enough: the
+// session_error rule sits below those rules and never gets a turn. Only the
+// re-placed hold restores Metrics.ProcessDeath, and with it the process_death
+// rule's higher rung.
+func TestSeedRestoreErrorVerdict_ProcessDeathOutranksAFrozenTranscript(t *testing.T) {
+	d := newSeedRestoreDetector(t)
+
+	persistedAt := time.Now().Add(-2 * time.Hour)
+	state := &session.SessionState{
+		SessionID: "crashed-1815",
+		State:     session.StateError,
+		UpdatedAt: persistedAt.Unix(),
+		Metrics: &session.SessionMetrics{
+			SessionError: &session.SessionError{
+				Phase:   session.ErrorPhaseTerminal,
+				Class:   session.ErrorClassProcessDeath,
+				Message: "agent process (pid 4242) exited mid-turn — process watcher",
+			},
+		},
+	}
+	persisted := persistedErrorVerdict(state)
+
+	// What RefreshMetrics does to the row a line later: a merge against a fresh
+	// tailer pass carrying nil. Reproduced literally rather than mocked, because
+	// this erasure IS the bug the restore exists to undo.
+	//
+	// HasOpenToolCall is the frozen transcript a crashed agent leaves behind — an
+	// assistant tool_use with no result — and it is what makes this test hard:
+	// the transcript-tier rules read it as work in flight and would paint the
+	// session `waiting`, well above where the session_error rule sits.
+	state.Metrics = &session.SessionMetrics{LastEventType: "assistant", HasOpenToolCall: true}
+
+	d.seedRestoreErrorVerdict(state, persisted)
+
+	if !state.Metrics.ProcessDeath {
+		t.Fatalf("Metrics.ProcessDeath is false after the seed restore — #1815: without it the " +
+			"process_death rule cannot fire and a frozen mid-turn transcript re-paints the session")
+	}
+	if state.Metrics.SessionError == nil {
+		t.Fatalf("Metrics.SessionError is nil after the seed restore — the verdict's payload was lost")
+	}
+	if got := state.Metrics.SessionError.Class; got != session.ErrorClassProcessDeath {
+		t.Errorf("restored error class = %q, want %q", got, session.ErrorClassProcessDeath)
+	}
+
+	newState, _ := ClassifyState(session.StateError, state.Metrics)
+	if newState != session.StateError {
+		t.Errorf("the classifier reads %q after the restore, want %q — the seed's own "+
+			"re-classification still disagrees with the state on disk", newState, session.StateError)
+	}
+
+	// Retention is registered by the SECOND half of the seed, after the
+	// classifier has ruled — see seedRetainRestoredError for why the ordering is
+	// load-bearing. The window must CONTINUE from when the previous daemon
+	// ruled, not restart: anchoring at the restart would hand a machine that
+	// reboots daily an unreachable ceiling.
+	state.State = session.StateError // what ClassifyState just concluded, above
+	d.seedRetainRestoredError(state, persisted)
+
+	at, ok := d.processDeathVerdictAt("crashed-1815")
+	if !ok {
+		t.Fatalf("no retention entry was registered — retainAsProcessDeath falls through to " +
+			"diedMidTurn, which is false for a row already in error, and the periodic liveness " +
+			"sweep reaps the row this restore just rescued a few seconds later")
+	}
+	if !at.Equal(persistedAt.Truncate(time.Second)) {
+		t.Errorf("retention re-registered at %s, want the persisted %s — the window restarted "+
+			"instead of continuing", at, persistedAt.Truncate(time.Second))
+	}
+}
+
+// TestSeedRestoreErrorVerdict_IgnoresANonErroredRow is a guard on the input, not
+// on the outcome: a SessionError left on a row that has since recovered must not
+// resurrect the error at the next boot.
+func TestSeedRestoreErrorVerdict_IgnoresANonErroredRow(t *testing.T) {
+	recovered := &session.SessionState{
+		SessionID: "recovered-1815",
+		State:     session.StateReady,
+		UpdatedAt: time.Now().Unix(),
+		Metrics: &session.SessionMetrics{
+			SessionError: &session.SessionError{Phase: session.ErrorPhaseTerminal, Class: "provider"},
+		},
+	}
+	if got := persistedErrorVerdict(recovered); got != nil {
+		t.Errorf("persistedErrorVerdict returned %+v for a %s row — a stale payload on a recovered "+
+			"session must not be restored", got, session.StateReady)
+	}
+}
+
+// --- helpers -----------------------------------------------------------------
+//
+// Local to this file and to the INTERNAL package, deliberately: the predicates
+// under test (isStartupZombie, handleAlivePIDState, retainedErrorAcrossRestart,
+// seedRestoreErrorVerdict) are all unexported, so the shared builders in
+// package services_test cannot reach them.
+
+// restartLog swallows log output. The paths under test log heavily on the way
+// through, and none of it is what is being asserted.
+type restartLog struct{ outbound.Logger }
+
+func (restartLog) LogInfo(_, _, _ string)  {}
+func (restartLog) LogError(_, _, _ string) {}
+
+// restartRepo is a minimal in-memory SessionRepository that COUNTS deletions —
+// which is the observable the sweep tests actually assert on. A sweep that
+// deletes the row is the defect; a sweep that merely declines to report it alive
+// is not.
+type restartRepo struct {
+	mu      sync.Mutex
+	states  []*session.SessionState
+	deleted []string
+}
+
+func (r *restartRepo) Load(id string) (*session.SessionState, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for _, s := range r.states {
+		if s.SessionID == id {
+			return s, nil
+		}
+	}
+	return nil, nil
+}
+
+func (r *restartRepo) Save(state *session.SessionState) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for i, s := range r.states {
+		if s.SessionID == state.SessionID {
+			r.states[i] = state
+			return nil
+		}
+	}
+	r.states = append(r.states, state)
+	return nil
+}
+
+func (r *restartRepo) Delete(id string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.deleted = append(r.deleted, id)
+	return nil
+}
+
+func (r *restartRepo) ListAll() ([]*session.SessionState, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]*session.SessionState(nil), r.states...), nil
+}
+
+func (r *restartRepo) deletedCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.deleted)
+}
+
+// restartPIDManager builds a PIDManager over a fresh counting repo and returns
+// both, so a test can assert on what the sweep removed.
+func restartPIDManager(t *testing.T) (*PIDManager, *restartRepo) {
+	t.Helper()
+	repo := &restartRepo{}
+	pm := NewPIDManager(PIDManagerDeps{
+		Repo:     repo,
+		Log:      restartLog{},
+		ReadyTTL: 10 * time.Minute,
+	})
+	return pm, repo
+}
+
+// newSeedRestoreDetector builds the minimum SessionDetector the seed-time
+// restore touches: a signal-hold store, the verdict registry, a clock and a log.
+func newSeedRestoreDetector(t *testing.T) *SessionDetector {
+	t.Helper()
+	return NewSessionDetector(nil, SessionDetectorDeps{Log: restartLog{}})
+}
+
+// deadPIDForRestartTest spawns and reaps a process, returning a PID known to be
+// dead. Skips rather than guesses when the kernel recycles it first — a recycled
+// PID is alive, which would invert every assertion built on it.
+func deadPIDForRestartTest(t *testing.T) int {
+	t.Helper()
+	cmd := exec.Command("true")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start true: %v", err)
+	}
+	pid := cmd.Process.Pid
+	_ = cmd.Wait()
+	if err := syscall.Kill(pid, 0); err == nil {
+		t.Skipf("dead PID %d was recycled before the test could observe it", pid)
+	}
+	return pid
+}
+
+// liveProcessForRestartTest returns the PID of a child that outlives the test.
+func liveProcessForRestartTest(t *testing.T) int {
+	t.Helper()
+	cmd := exec.Command("sleep", "60")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start sleep: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+	})
+	return cmd.Process.Pid
+}
+
+// TestSeedRestoreErrorVerdict_DropsAHoldWhoseTurnActuallyFinished is a LOCK: it
+// passes before #1815 by construction (the restore did not exist, so nothing was
+// ever applied) and pins the direction the restore must NOT break.
+//
+// The exit edge places a process-death hold PROVISIONALLY, because at the moment
+// a process dies the daemon cannot tell a crash from a clean exit — a headless
+// agent writes its turn-ending line and exits microseconds later. Overlay's
+// staleness rule is the actual verdict. Restoring the hold at seed time must go
+// through that same rule rather than around it, or every clean `claude -p` run
+// on disk at boot would come back red.
+func TestSeedRestoreErrorVerdict_DropsAHoldWhoseTurnActuallyFinished(t *testing.T) {
+	d := newSeedRestoreDetector(t)
+
+	state := &session.SessionState{
+		SessionID: "finished-1815",
+		State:     session.StateError,
+		UpdatedAt: time.Now().Unix(),
+		Metrics: &session.SessionMetrics{
+			SessionError: &session.SessionError{
+				Phase: session.ErrorPhaseTerminal,
+				Class: session.ErrorClassProcessDeath,
+			},
+		},
+	}
+	persisted := persistedErrorVerdict(state)
+
+	// The turn HAD in fact ended before the process exited.
+	state.Metrics = &session.SessionMetrics{LastEventType: "turn_done"}
+
+	d.seedRestoreErrorVerdict(state, persisted)
+
+	if state.Metrics.ProcessDeath {
+		t.Errorf("a session whose turn had finished was pinned as a process death — " +
+			"the seed restore bypassed Overlay's staleness rule, so every clean headless " +
+			"exit sitting on disk at boot comes back red")
+	}
+}
+
+// TestStartupSweeps_KeepARetainedErrorOrphanRow covers the THIRD deleter, found
+// in review after the first two were already exempted: seedAlivePIDs' PID==0
+// branch, which has nothing to do with a dead PID at all.
+//
+// Reachable for a headless run (`claude -p`, `codex exec`) that fails on a
+// provider error and exits before PID discovery ever binds — the row is `error`
+// with PID==0, and an errored session's transcript is stale by definition once
+// orphanTranscriptAge has passed. Exempting only the two dead-PID paths left
+// this one to take exactly the rows they had just spared.
+func TestStartupSweeps_KeepARetainedErrorOrphanRow(t *testing.T) {
+	transcript := filepath.Join(t.TempDir(), "orphan.jsonl")
+	if err := os.WriteFile(transcript, []byte("{}\n"), 0o644); err != nil {
+		t.Fatalf("write transcript: %v", err)
+	}
+	// Backdated past orphanTranscriptAge, which is what makes isOrphanAtSeed
+	// say yes. An errored session reaches this state simply by sitting there.
+	old := time.Now().Add(-10 * time.Minute)
+	if err := os.Chtimes(transcript, old, old); err != nil {
+		t.Fatalf("backdate transcript: %v", err)
+	}
+
+	state := &session.SessionState{
+		SessionID:      "orphan-error-1815",
+		State:          session.StateError,
+		PID:            0,
+		TranscriptPath: transcript,
+		CWD:            filepath.Dir(transcript),
+		UpdatedAt:      time.Now().Unix(),
+		Metrics: &session.SessionMetrics{
+			SessionError: &session.SessionError{Phase: session.ErrorPhaseTerminal, Class: "provider"},
+		},
+	}
+
+	// Precondition — without it this test would pass on a row the branch never
+	// reaches, and prove nothing. isOrphanAtSeed must genuinely want this row.
+	if !isOrphanAtSeed(state) {
+		t.Fatalf("isOrphanAtSeed is false for the fixture, so the branch under test is unreachable " +
+			"and this test cannot discriminate")
+	}
+
+	pm, repo := restartPIDManager(t)
+	pm.seedAlivePIDs([]*session.SessionState{state})
+	if repo.deletedCount() != 0 {
+		t.Fatalf("the PID==0 orphan branch deleted %d errored session(s) — #1815: a headless run "+
+			"that failed before PID discovery bound is deleted at the next daemon start",
+			repo.deletedCount())
+	}
+}
+
+// TestRetainAsProcessDeath_KeepsARestoredRowThroughThePeriodicSweep is the
+// regression test for the defect that made the startup exemptions worthless for
+// every class except process_death.
+//
+// The startup sweeps are not the only deleter: SweepDeadPIDs ticks every few
+// seconds into retainAsProcessDeath, and a row restored from a previous daemon
+// run has no verdict of its own in this process. It therefore fell through to
+// diedMidTurn — which is false for anything already in `error` — and was deleted
+// about five seconds AFTER the restart rather than at it. The row was rescued at
+// boot and gone before a human could look, which is the issue's own outcome with
+// a delay in front of it.
+func TestRetainAsProcessDeath_KeepsARestoredRowThroughThePeriodicSweep(t *testing.T) {
+	// A TRANSCRIPT-derived class on purpose: the process_death class is retained
+	// by its own re-registered verdict, so testing with it would pass without
+	// the branch this test is about.
+	state := &session.SessionState{
+		SessionID: "restored-1815",
+		State:     session.StateError,
+		UpdatedAt: time.Now().Add(-2 * time.Hour).Unix(),
+		Metrics: &session.SessionMetrics{
+			SessionError: &session.SessionError{Phase: session.ErrorPhaseTerminal, Class: "rate_limit_error"},
+		},
+	}
+
+	d := newSeedRestoreDetector(t)
+
+	// Through the seed path, as a real restart does: the row comes off disk in
+	// `error`, the classifier agrees, and seedRetainRestoredError registers the
+	// retention entry the sweep then reads.
+	d.seedRetainRestoredError(state, persistedErrorVerdict(state))
+
+	if !d.retainAsProcessDeath(state, 4242, "pid exited (ESRCH)") {
+		t.Fatalf("the periodic liveness sweep reaps an errored row restored from a previous daemon " +
+			"run — #1815: the startup exemption is undone a few seconds later, so the row is still " +
+			"gone before anyone looks")
+	}
+
+	// And the window still closes: past the retention the sweep must reap it
+	// exactly as it always did, or an errored row becomes immortal.
+	d2 := newSeedRestoreDetector(t)
+	stale := *state
+	stale.SessionID = "restored-stale-1815"
+	stale.UpdatedAt = time.Now().Add(-processDeathRetention - time.Hour).Unix()
+	d2.seedRetainRestoredError(&stale, persistedErrorVerdict(&stale))
+	if d2.retainAsProcessDeath(&stale, 4242, "pid exited (ESRCH)") {
+		t.Errorf("an errored row past the retention window was still retained — the window never " +
+			"closes and the row is kept forever")
+	}
+}
+
+// TestSeedRestoreErrorVerdict_TranscriptClassPlacesNoHold pins the narrowing the
+// review forced, and it is a real behavioural assertion rather than a scope note.
+//
+// Re-placing a SignalSessionError hold looks like the symmetric thing to do and
+// is wrong: that row's apply writes its payload into any empty SessionError slot,
+// so the moment the tailer's clearing rule fires the hold writes the error back
+// in and the session reads `error` through the whole of the user's recovery turn.
+// For the adapters with no Stop hook (aider, opencode, pi) the row's only
+// staleness rule never fires at all, so that becomes the full 12h ceiling. The
+// ledger already carries this class across a restart, and the tailer owns
+// clearing it.
+func TestSeedRestoreErrorVerdict_TranscriptClassPlacesNoHold(t *testing.T) {
+	d := newSeedRestoreDetector(t)
+
+	state := &session.SessionState{
+		SessionID: "provider-error-1815",
+		State:     session.StateError,
+		UpdatedAt: time.Now().Unix(),
+		Metrics: &session.SessionMetrics{
+			SessionError: &session.SessionError{Phase: session.ErrorPhaseTerminal, Class: "rate_limit_error"},
+		},
+	}
+	persisted := persistedErrorVerdict(state)
+
+	// The user came back and the turn succeeded: the tailer cleared its sticky
+	// error, so the fresh pass carries nil. No Stop hook — the case where a
+	// re-placed hold would have no end-of-life at all.
+	state.Metrics = &session.SessionMetrics{LastEventType: "assistant", HookTurnDone: false}
+
+	d.seedRestoreErrorVerdict(state, persisted)
+	d.signals.Overlay(state.SessionID, state.Metrics, time.Now())
+
+	if state.Metrics.SessionError != nil {
+		t.Errorf("a restored hold wrote the cleared error back onto a recovered session (%+v) — "+
+			"the session reads `error` through the user's whole recovery turn, and for a "+
+			"hookless adapter for the full retention window", state.Metrics.SessionError)
+	}
+}
+
+// TestSeedRestoreErrorVerdict_NoVerdictWhenOverlayDropsTheHold pins the ordering
+// fix: the verdict registry is written only AFTER Overlay has ruled, and only
+// when the hold actually applied.
+//
+// The exit edge places a process-death hold provisionally — at the moment a
+// process dies the daemon cannot tell a crash from a clean exit — and Overlay's
+// IsAgentDone rule is the verdict. Registering before that ruling shields a row
+// Overlay just judged NOT a crash from the reaper for the whole retention
+// window, which is worse than the pre-fix behaviour: without the restore such a
+// row is reaped on the next sweep.
+func TestSeedRestoreErrorVerdict_NoVerdictWhenOverlayDropsTheHold(t *testing.T) {
+	d := newSeedRestoreDetector(t)
+
+	state := &session.SessionState{
+		SessionID: "clean-exit-1815",
+		State:     session.StateError,
+		UpdatedAt: time.Now().Unix(),
+		Metrics: &session.SessionMetrics{
+			SessionError: &session.SessionError{
+				Phase: session.ErrorPhaseTerminal,
+				Class: session.ErrorClassProcessDeath,
+			},
+		},
+	}
+	persisted := persistedErrorVerdict(state)
+	state.Metrics = &session.SessionMetrics{LastEventType: "turn_done"} // the turn HAD finished
+
+	d.seedRestoreErrorVerdict(state, persisted)
+
+	if state.Metrics.ProcessDeath {
+		t.Fatalf("Overlay should have dropped the hold as stale for a finished turn")
+	}
+
+	// The hold never applied, so the classifier settles the row away from
+	// `error` — and the retention registration is gated on that final state.
+	newState, _ := ClassifyState(session.StateError, state.Metrics)
+	if newState == session.StateError {
+		t.Fatalf("the classifier still reads %q for a finished turn, so the gate below "+
+			"is unreachable and this test cannot discriminate", newState)
+	}
+	state.State = newState
+	d.seedRetainRestoredError(state, persisted)
+
+	if _, ok := d.processDeathVerdictAt("clean-exit-1815"); ok {
+		t.Errorf("retention was registered for a row Overlay judged NOT a crash — it is now " +
+			"shielded from the reaper for the whole retention window, where without the restore " +
+			"it would be reaped on the next sweep")
+	}
+}
+
+// TestSeedRetainRestoredError_SkipsARecoveredSession is the gate the ordering
+// buys, asserted directly rather than left implicit.
+//
+// If the transcript grew while the daemon was down and the user's next turn
+// succeeded, the tailer's clearing rule fires during RefreshMetrics, the
+// classifier moves the row off `error`, and NOTHING should be registered — a
+// recovered session shielded from the reaper for twelve hours would be this
+// fix's own mirror-image bug.
+func TestSeedRetainRestoredError_SkipsARecoveredSession(t *testing.T) {
+	d := newSeedRestoreDetector(t)
+
+	state := &session.SessionState{
+		SessionID: "recovered-across-restart-1815",
+		State:     session.StateError,
+		UpdatedAt: time.Now().Unix(),
+		Metrics: &session.SessionMetrics{
+			SessionError: &session.SessionError{Phase: session.ErrorPhaseTerminal, Class: "provider"},
+		},
+	}
+	persisted := persistedErrorVerdict(state)
+
+	// The classifier's verdict on the refreshed metrics: recovered.
+	state.State = session.StateReady
+	d.seedRetainRestoredError(state, persisted)
+
+	if _, ok := d.processDeathVerdictAt("recovered-across-restart-1815"); ok {
+		t.Errorf("a recovered session was registered for retention — it is now shielded from " +
+			"the reaper for the whole window despite no longer being in error")
+	}
+}

--- a/core/application/services/error_survives_restart_test.go
+++ b/core/application/services/error_survives_restart_test.go
@@ -175,12 +175,12 @@ func TestSeedRestoreErrorVerdict_ProcessDeathOutranksAFrozenTranscript(t *testin
 	}
 
 	// Retention is registered by the SECOND half of the seed, after the
-	// classifier has ruled — see seedRetainRestoredError for why the ordering is
+	// classifier has ruled — see seedRetainErroredRows for why the ordering is
 	// load-bearing. The window must CONTINUE from when the previous daemon
 	// ruled, not restart: anchoring at the restart would hand a machine that
 	// reboots daily an unreachable ceiling.
 	state.State = session.StateError // what ClassifyState just concluded, above
-	d.seedRetainRestoredError(state, persisted)
+	d.seedRetainErroredRows([]*session.SessionState{state})
 
 	at, ok := d.processDeathVerdictAt("crashed-1815")
 	if !ok {
@@ -399,9 +399,9 @@ func TestRetainAsProcessDeath_KeepsARestoredRowThroughThePeriodicSweep(t *testin
 	d := newSeedRestoreDetector(t)
 
 	// Through the seed path, as a real restart does: the row comes off disk in
-	// `error`, the classifier agrees, and seedRetainRestoredError registers the
+	// `error`, the classifier agrees, and seedRetainErroredRows registers the
 	// retention entry the sweep then reads.
-	d.seedRetainRestoredError(state, persistedErrorVerdict(state))
+	d.seedRetainErroredRows([]*session.SessionState{state})
 
 	if !d.retainAsProcessDeath(state, 4242, "pid exited (ESRCH)") {
 		t.Fatalf("the periodic liveness sweep reaps an errored row restored from a previous daemon " +
@@ -415,7 +415,7 @@ func TestRetainAsProcessDeath_KeepsARestoredRowThroughThePeriodicSweep(t *testin
 	stale := *state
 	stale.SessionID = "restored-stale-1815"
 	stale.UpdatedAt = time.Now().Add(-processDeathRetention - time.Hour).Unix()
-	d2.seedRetainRestoredError(&stale, persistedErrorVerdict(&stale))
+	d2.seedRetainErroredRows([]*session.SessionState{&stale})
 	if d2.retainAsProcessDeath(&stale, 4242, "pid exited (ESRCH)") {
 		t.Errorf("an errored row past the retention window was still retained — the window never " +
 			"closes and the row is kept forever")
@@ -510,7 +510,7 @@ func TestSeedRestoreErrorVerdict_NoVerdictWhenOverlayDropsTheHold(t *testing.T) 
 			"is unreachable and this test cannot discriminate", newState)
 	}
 	state.State = newState
-	d.seedRetainRestoredError(state, persisted)
+	d.seedRetainErroredRows([]*session.SessionState{state})
 
 	if _, ok := d.processDeathVerdictAt("clean-exit-1815"); ok {
 		t.Errorf("retention was registered for a row Overlay judged NOT a crash — it is now " +
@@ -527,7 +527,7 @@ func TestSeedRestoreErrorVerdict_NoVerdictWhenOverlayDropsTheHold(t *testing.T) 
 // classifier moves the row off `error`, and NOTHING should be registered — a
 // recovered session shielded from the reaper for twelve hours would be this
 // fix's own mirror-image bug.
-func TestSeedRetainRestoredError_SkipsARecoveredSession(t *testing.T) {
+func TestSeedRetainErroredRows_SkipsARecoveredSession(t *testing.T) {
 	d := newSeedRestoreDetector(t)
 
 	state := &session.SessionState{
@@ -538,11 +538,9 @@ func TestSeedRetainRestoredError_SkipsARecoveredSession(t *testing.T) {
 			SessionError: &session.SessionError{Phase: session.ErrorPhaseTerminal, Class: "provider"},
 		},
 	}
-	persisted := persistedErrorVerdict(state)
-
 	// The classifier's verdict on the refreshed metrics: recovered.
 	state.State = session.StateReady
-	d.seedRetainRestoredError(state, persisted)
+	d.seedRetainErroredRows([]*session.SessionState{state})
 
 	if _, ok := d.processDeathVerdictAt("recovered-across-restart-1815"); ok {
 		t.Errorf("a recovered session was registered for retention — it is now shielded from " +
@@ -559,24 +557,31 @@ func TestSeedRetainRestoredError_SkipsARecoveredSession(t *testing.T) {
 // sweepStaleSnapshot's ready-TTL branch — went on deleting a PID==0 errored row
 // after 30 minutes, inside the twelve-hour window. Nothing structurally
 // connected "a place that deletes rows" to "consult the exemption", so the miss
-// was invisible: every behavioural test passed, because none of them exercised
-// that particular reaper. A per-site inventory in a doc comment has the same
+// was invisible: every behavioural test passed, because none exercised that
+// particular reaper. A per-site inventory in a doc comment has the same
 // weakness — the one this fix removed was written already stale.
 //
-// DELEGATION IS DERIVED, NOT DECLARED, and that is load-bearing. A reaper may
-// put its whole keep-or-delete decision in a named predicate (isStartupZombie,
-// reapsIdleTopLevel) — better structure, not an evasion — so a delegating caller
-// must still pass. An earlier version of this test accepted a hand-written list
-// of delegate NAMES, and that quietly broke it: with the guard deleted from
-// reapsIdleTopLevel the test still passed, because the caller was still calling
-// a name on the list. The list described the shape of the code rather than
-// checking it. So the delegate set is now computed from the source — a function
-// counts as consulting only if it calls retainsError itself, or calls something
-// that does — and removing the guard anywhere makes every path through it fail.
+// BOTH SETS ARE DERIVED FROM THE SOURCE. NEITHER IS TYPED BY HAND. That is the
+// whole design, and each half was learned from this check failing to fail:
 //
-// The exempt map below is the deliberate part. A deleter on it is one that must
-// NOT consult the exemption, with the reason stated; adding a new reaper means
-// calling retainsError, delegating to something that does, or arguing here.
+//   - DELETION was originally recognised by a hand-typed list of three wrapper
+//     names (deleteWithChildren / deleteSession / removeSessionUntracked). A
+//     reaper written as `pm.repo.Delete(id)` was invisible to it — and that
+//     idiom is ALREADY in this file, in cleanupStalePIDHolders. A review probe
+//     added a sixth reaper using it and this test stayed GREEN. Deletion is now
+//     seeded from the PRIMITIVE (a `.repo.Delete(...)` call site) and grown
+//     transitively, so a wrapper is discovered rather than declared.
+//   - DELEGATION was originally a hand-typed list of predicate names. Deleting
+//     the guard from a listed predicate left the test GREEN, because the caller
+//     was still calling a name on the list. It is now grown the same way.
+//
+// A check that cannot fail reads exactly like one that found nothing, which is
+// what AGENTS.md forbids; the vacuity guards at the bottom are the other half of
+// that, and tools/lib/error-retention-mutations_test.sh runs the mutations that
+// prove both directions on every `preflight.sh --only tools`.
+//
+// The exempt map is the deliberate part: a deleter on it must NOT consult the
+// exemption, with the reason stated.
 func TestEveryReaperConsultsTheErrorExemption(t *testing.T) {
 	exempt := map[string]string{
 		"deleteSession":                      "the shared choke point; guarding here would strand an errored CHILD whose parent was deleted, leaving a dangling ParentSessionID nothing can collect",
@@ -585,10 +590,15 @@ func TestEveryReaperConsultsTheErrorExemption(t *testing.T) {
 		"reapStaleChild":                     "same: a child's retention belongs to its parent",
 		"reapUnboundReadyGhost":              "ready-state ghosts only; an errored row never reaches it",
 		"dedupeByPID":                        "supersession, not reaping — the surviving row carries the identity",
+		"cleanupStalePIDHolders":             "supersession, not reaping: its inputs are the OTHER rows holding a PID that a new session just bound, so the identity has moved to the survivor. Retaining a superseded errored row would leave a duplicate of a session the user can still see, under an id nothing will ever write to again — and it fires onSessionSuperseded, which carries state FORWARD onto the new row rather than dropping it",
 		"sweepSupersededPreSessions":         "presession supersession, not reaping — only `proc-` rows, which never carry a verdict",
 		"sweepSupersededPreSessionsPeriodic": "same, on the periodic timer — verified to `continue` on any id without the `proc-` prefix",
 		"removeSessionUntracked":             "the untracked-removal primitive the two supersession sweeps call",
 		"HandleProcessExit":                  "routes through onProcessDiedMidTurn (retainAsProcessDeath), which owns the live-path retention via the verdict map",
+		"reapDeadOrInfraPID":                 "the periodic sweep's reaper: it deletes ONLY by calling HandleProcessExit, so its retention is the verdict map's, not retainsError's (verified — no other deleting call in its body)",
+		"HandlePIDAssigned":                  "deletes ONLY via cleanupStalePIDHolders (verified), i.e. supersession; and it is the function that deliberately RETIRES a verdict when a process comes back, so consulting the exemption here would undo its own job",
+		"TryDiscoverPID":                     "reaches deletion only through HandlePIDAssigned (verified — its sole deleting call), inheriting that entry's supersession reason",
+		"DiscoverPIDWithRetry":               "calls only TryDiscoverPID (verified), so it inherits the same one",
 	}
 
 	fset := token.NewFileSet()
@@ -597,8 +607,10 @@ func TestEveryReaperConsultsTheErrorExemption(t *testing.T) {
 		t.Fatalf("parse pid_manager.go: %v", err)
 	}
 
-	// calls[fn] is the set of method names fn invokes.
+	// calls[fn] = the method names fn invokes; primitive[fn] = fn contains a
+	// `<recv>.repo.Delete(...)` call site, which is what actually removes a row.
 	calls := map[string]map[string]bool{}
+	primitive := map[string]bool{}
 	for _, decl := range file.Decls {
 		fn, ok := decl.(*ast.FuncDecl)
 		if !ok || fn.Body == nil {
@@ -606,9 +618,19 @@ func TestEveryReaperConsultsTheErrorExemption(t *testing.T) {
 		}
 		seen := map[string]bool{}
 		ast.Inspect(fn.Body, func(n ast.Node) bool {
-			if call, ok := n.(*ast.CallExpr); ok {
-				if sel, ok := call.Fun.(*ast.SelectorExpr); ok {
-					seen[sel.Sel.Name] = true
+			call, ok := n.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			sel, ok := call.Fun.(*ast.SelectorExpr)
+			if !ok {
+				return true
+			}
+			seen[sel.Sel.Name] = true
+			// `pm.repo.Delete(...)` — the selector's own receiver is `.repo`.
+			if sel.Sel.Name == "Delete" {
+				if inner, ok := sel.X.(*ast.SelectorExpr); ok && inner.Sel.Name == "repo" {
+					primitive[fn.Name.Name] = true
 				}
 			}
 			return true
@@ -616,43 +638,17 @@ func TestEveryReaperConsultsTheErrorExemption(t *testing.T) {
 		calls[fn.Name.Name] = seen
 	}
 
-	// Derive the consulting set: retainsError itself, then anything that calls
-	// something already in the set, to a fixed point.
-	consulting := map[string]bool{"retainsError": true}
-	for changed := true; changed; {
-		changed = false
-		for fn, seen := range calls {
-			if consulting[fn] {
-				continue
-			}
-			for name := range seen {
-				if consulting[name] {
-					consulting[fn] = true
-					changed = true
-					break
-				}
-			}
-		}
-	}
+	// Grow both relations to a fixed point over the call graph.
+	deletes := grow(calls, primitive)
+	consults := grow(calls, map[string]bool{"retainsError": true})
 
-	deleters := map[string]bool{"deleteWithChildren": true, "deleteSession": true, "removeSessionUntracked": true}
 	var checked int
-	for fn, seen := range calls {
-		if exempt[fn] != "" {
-			continue
-		}
-		var deletes bool
-		for name := range seen {
-			if deleters[name] {
-				deletes = true
-				break
-			}
-		}
-		if !deletes {
+	for fn := range calls {
+		if !deletes[fn] || exempt[fn] != "" {
 			continue
 		}
 		checked++
-		if !consulting[fn] {
+		if !consults[fn] {
 			t.Errorf("%s deletes session rows but nothing on its call path consults retainsError "+
 				"— #1815: an errored row within its retention window is deleted by this path. "+
 				"Either consult the exemption (directly or via a predicate that does), or add "+
@@ -660,20 +656,51 @@ func TestEveryReaperConsultsTheErrorExemption(t *testing.T) {
 		}
 	}
 
-	// The tripwire must fail loudly when it cannot run: an AST walk that matched
-	// nothing looks identical to a clean result. Three non-exempt deleters exist
-	// today (CleanupZombies, seedAlivePIDs, reapOrRetainDeadSeedPID,
-	// sweepStaleSnapshot); a floor of 3 leaves room for refactoring without
-	// letting the check silently go inert.
-	if checked < 3 {
-		t.Fatalf("the reaper scan matched only %d deleting function(s) — the AST walk or the "+
-			"deleter-name list has gone stale, and this test is no longer checking anything", checked)
+	// VACUITY GUARDS. Absence of a finding and inability to look must not
+	// produce the same output. Each of these fails if a rename or a refactor
+	// leaves the walk matching nothing — the state in which this test would
+	// otherwise pass forever.
+	if len(primitive) == 0 {
+		t.Fatalf("no `.repo.Delete(...)` call site was found in pid_manager.go — the deletion " +
+			"primitive was renamed or reshaped, and this test is no longer checking anything")
 	}
-	// And the consulting set must be more than its seed, or the fixed point
-	// never ran and every delegating caller would be reported as a violation.
-	if len(consulting) < 2 {
-		t.Fatalf("no function was found to consult retainsError — the delegation walk is inert")
+	if len(consults) < 2 {
+		t.Fatalf("nothing was found to consult retainsError — the delegation walk is inert")
 	}
+	// Derived, not typed: the count is whatever the walk found, so this cannot
+	// go stale the way a hand-written "three deleters exist today" did.
+	if checked == 0 {
+		t.Fatalf("found %d deleting function(s), all of them exempt — no reaper is actually "+
+			"being checked", len(deletes))
+	}
+	t.Logf("checked %d non-exempt deleter(s) of %d total; %d function(s) consult the exemption",
+		checked, len(deletes), len(consults))
+}
+
+// grow closes `seed` over the call graph in `calls`: a function joins the set
+// when it calls anything already in it. Shared by the deletion and delegation
+// relations, which differ only in their seed.
+func grow(calls map[string]map[string]bool, seed map[string]bool) map[string]bool {
+	out := map[string]bool{}
+	for k := range seed {
+		out[k] = true
+	}
+	for changed := true; changed; {
+		changed = false
+		for fn, seen := range calls {
+			if out[fn] {
+				continue
+			}
+			for name := range seen {
+				if out[name] {
+					out[fn] = true
+					changed = true
+					break
+				}
+			}
+		}
+	}
+	return out
 }
 
 // TestStaleSweep_KeepsARetainedErrorRow is the behavioural half of the fifth
@@ -722,5 +749,126 @@ func snapshotForTest(state *session.SessionState) livenessSnapshot {
 		pid:          state.PID,
 		sessionState: state.State,
 		updatedAt:    state.UpdatedAt,
+	}
+}
+
+// TestSeedRetention_CoversARowTheSeedPassSkips is the regression test for the
+// gap an independent review found in the first cut: the retention registration
+// lived inside seedReevaluateOne, which is reached only for rows that clear
+// seedReevaluateStates' CONSENT GATE and have a TranscriptPath.
+//
+// A row the seed pass skips therefore got no entry, and the periodic liveness
+// sweep deleted it about five seconds after the restart — retainAsProcessDeath
+// finds no verdict, and diedMidTurn is false for anything already in `error`.
+// The startup exemption spared the row and then nothing kept it.
+//
+// NOT A HYPOTHETICAL COMBINATION. Both skip conditions are ordinary: an adapter
+// whose observe permission is pending (which is EVERY adapter on a fresh
+// IRRLICHT_HOME until the wizard is answered), and a row with no TranscriptPath
+// (a store-backed adapter's session, or one whose transcript was removed). The
+// user most likely to hit it is the one who has not finished onboarding.
+func TestSeedRetention_CoversARowTheSeedPassSkips(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		mutate func(*session.SessionState)
+		gate   func(*SessionDetector)
+	}{
+		{
+			name:   "no transcript path",
+			mutate: func(s *session.SessionState) { s.TranscriptPath = "" },
+			gate:   func(*SessionDetector) {},
+		},
+		{
+			name:   "observe consent not granted",
+			mutate: func(s *session.SessionState) { s.TranscriptPath = "/nonexistent/x.jsonl" },
+			gate:   func(d *SessionDetector) { d.SetConsentGate(func(string) bool { return false }) },
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			repo := &restartRepo{}
+			state := &session.SessionState{
+				SessionID: "skipped-" + tc.name,
+				Adapter:   "claude-code",
+				State:     session.StateError,
+				PID:       4242,
+				UpdatedAt: time.Now().Add(-time.Hour).Unix(),
+				Metrics: &session.SessionMetrics{
+					SessionError: &session.SessionError{
+						Phase: session.ErrorPhaseTerminal,
+						Class: session.ErrorClassProcessDeath,
+					},
+				},
+			}
+			tc.mutate(state)
+			if err := repo.Save(state); err != nil {
+				t.Fatalf("seed: %v", err)
+			}
+
+			d := NewSessionDetector(nil, SessionDetectorDeps{Log: bornLog{}, Repo: repo})
+			tc.gate(d)
+			d.seedFromDisk()
+
+			// The SUBJECT: what the periodic liveness sweep decides a few
+			// seconds later. Retention has to be independent of whether the
+			// seed pass examined this row at all.
+			if !d.retainAsProcessDeath(state, state.PID, "test: pid exited") {
+				t.Fatalf("the periodic sweep reaps an errored row the seed pass skipped (%s) — "+
+					"#1815: the retention registration is gated behind the consent/transcript "+
+					"check, so the row is spared at startup and deleted ~5s later", tc.name)
+			}
+		})
+	}
+}
+
+// TestForgetSessionScopedState_DropsTheProcessDeathVerdict settles the review's
+// finding 3 with a run rather than with reasoning.
+//
+// THE SCENARIO, and it is reachable: a session dies mid-turn and gets a verdict
+// entry; twelve hours later the window closes and the row is reaped; the user
+// then runs `claude --resume <uuid>` under the SAME session id, and that session
+// dies mid-turn too. retainAsProcessDeath finds the stale entry, takes the
+// EXPIRY branch (`now - at >= retention`), and returns false — so the second
+// death is DELETED rather than converted to `error`, and the user loses exactly
+// the signal #1800 exists to give them. It is silent and it never self-heals:
+// forgetProcessDeathVerdict runs only on that expiry branch, which returns false
+// every time, so the entry is dropped only after it has already eaten one death.
+//
+// #1800 shipped this map without adding it to forgetSessionScopedState, whose
+// own doc says the rule for the next per-session map is "add it HERE, not to a
+// call site" — and it was missed anyway. This diff makes it materially more
+// likely by registering an entry at EVERY seed for EVERY errored row, where
+// before only a live mid-turn death created one.
+func TestForgetSessionScopedState_DropsTheProcessDeathVerdict(t *testing.T) {
+	d := newSeedRestoreDetector(t)
+	const sid = "recycled-uuid-1815"
+
+	// A verdict from a session that has since aged out and been reaped.
+	d.restoreErrorRetention(sid, time.Now().Add(-processDeathRetention-time.Hour))
+	if _, ok := d.processDeathVerdictAt(sid); !ok {
+		t.Fatalf("precondition failed: no verdict registered, so this test cannot discriminate")
+	}
+
+	// The row is deleted. This is the seam every per-session map is supposed to
+	// be dropped through.
+	d.forgetSessionScopedState(sid)
+
+	if _, ok := d.processDeathVerdictAt(sid); ok {
+		t.Fatalf("the process-death verdict survived the row's deletion — a session id reused by " +
+			"`claude --resume` inherits it, and its FIRST mid-turn death takes the expiry branch " +
+			"and is deleted instead of going red (#1800's map was never added to " +
+			"forgetSessionScopedState; its own doc says to add it here)")
+	}
+
+	// And the consequence the entry would have caused: a fresh mid-turn death
+	// under the recycled id must convert to `error`, not be reaped.
+	reused := &session.SessionState{
+		SessionID: sid,
+		State:     session.StateWorking,
+		UpdatedAt: time.Now().Unix(),
+		Metrics:   &session.SessionMetrics{LastEventType: "assistant", HasOpenToolCall: true},
+	}
+	if !d.retainAsProcessDeath(reused, 4242, "test: pid exited") {
+		t.Errorf("a mid-turn death under a recycled session id was reaped instead of converted " +
+			"to error — the stale verdict's expiry branch swallowed it")
 	}
 }

--- a/core/application/services/error_survives_restart_test.go
+++ b/core/application/services/error_survives_restart_test.go
@@ -561,13 +561,23 @@ func TestSeedRetainRestoredError_SkipsARecoveredSession(t *testing.T) {
 // connected "a place that deletes rows" to "consult the exemption", so the miss
 // was invisible: every behavioural test passed, because none of them exercised
 // that particular reaper. A per-site inventory in a doc comment has the same
-// weakness — it was written already stale.
+// weakness — the one this fix removed was written already stale.
 //
-// The exemption list below is the deliberate part. A deleter on it is one that
-// must NOT consult the exemption, with the reason stated; adding a new reaper
-// means either calling retainsError or arguing here why it is exempt.
+// DELEGATION IS DERIVED, NOT DECLARED, and that is load-bearing. A reaper may
+// put its whole keep-or-delete decision in a named predicate (isStartupZombie,
+// reapsIdleTopLevel) — better structure, not an evasion — so a delegating caller
+// must still pass. An earlier version of this test accepted a hand-written list
+// of delegate NAMES, and that quietly broke it: with the guard deleted from
+// reapsIdleTopLevel the test still passed, because the caller was still calling
+// a name on the list. The list described the shape of the code rather than
+// checking it. So the delegate set is now computed from the source — a function
+// counts as consulting only if it calls retainsError itself, or calls something
+// that does — and removing the guard anywhere makes every path through it fail.
+//
+// The exempt map below is the deliberate part. A deleter on it is one that must
+// NOT consult the exemption, with the reason stated; adding a new reaper means
+// calling retainsError, delegating to something that does, or arguing here.
 func TestEveryReaperConsultsTheErrorExemption(t *testing.T) {
-	// Deleters that intentionally do not consult it, and why.
 	exempt := map[string]string{
 		"deleteSession":                      "the shared choke point; guarding here would strand an errored CHILD whose parent was deleted, leaving a dangling ParentSessionID nothing can collect",
 		"deleteWithChildren":                 "same choke-point argument, and it would re-shield a row whose verdict HandlePIDAssigned deliberately retired (TestHandlePIDAssigned_RetiresAProcessDeathVerdict)",
@@ -581,67 +591,88 @@ func TestEveryReaperConsultsTheErrorExemption(t *testing.T) {
 		"HandleProcessExit":                  "routes through onProcessDiedMidTurn (retainAsProcessDeath), which owns the live-path retention via the verdict map",
 	}
 
-	src, err := os.ReadFile("pid_manager.go")
-	if err != nil {
-		t.Fatalf("read pid_manager.go: %v", err)
-	}
 	fset := token.NewFileSet()
-	file, err := parser.ParseFile(fset, "pid_manager.go", src, 0)
+	file, err := parser.ParseFile(fset, "pid_manager.go", nil, 0)
 	if err != nil {
 		t.Fatalf("parse pid_manager.go: %v", err)
 	}
 
-	var checked int
+	// calls[fn] is the set of method names fn invokes.
+	calls := map[string]map[string]bool{}
 	for _, decl := range file.Decls {
 		fn, ok := decl.(*ast.FuncDecl)
 		if !ok || fn.Body == nil {
 			continue
 		}
-		name := fn.Name.Name
-		if _, ok := exempt[name]; ok {
-			continue
-		}
-		var deletes, consults bool
+		seen := map[string]bool{}
 		ast.Inspect(fn.Body, func(n ast.Node) bool {
-			call, ok := n.(*ast.CallExpr)
-			if !ok {
-				return true
-			}
-			sel, ok := call.Fun.(*ast.SelectorExpr)
-			if !ok {
-				return true
-			}
-			switch sel.Sel.Name {
-			case "deleteWithChildren", "deleteSession", "removeSessionUntracked":
-				deletes = true
-			case "retainsError", "isStartupZombie":
-				// isStartupZombie counts as consulting: the guard lives inside
-				// that predicate, so its callers inherit it. Delegation is a
-				// legitimate way to satisfy this check; re-implementing the
-				// window at the call site is not.
-				consults = true
+			if call, ok := n.(*ast.CallExpr); ok {
+				if sel, ok := call.Fun.(*ast.SelectorExpr); ok {
+					seen[sel.Sel.Name] = true
+				}
 			}
 			return true
 		})
+		calls[fn.Name.Name] = seen
+	}
+
+	// Derive the consulting set: retainsError itself, then anything that calls
+	// something already in the set, to a fixed point.
+	consulting := map[string]bool{"retainsError": true}
+	for changed := true; changed; {
+		changed = false
+		for fn, seen := range calls {
+			if consulting[fn] {
+				continue
+			}
+			for name := range seen {
+				if consulting[name] {
+					consulting[fn] = true
+					changed = true
+					break
+				}
+			}
+		}
+	}
+
+	deleters := map[string]bool{"deleteWithChildren": true, "deleteSession": true, "removeSessionUntracked": true}
+	var checked int
+	for fn, seen := range calls {
+		if exempt[fn] != "" {
+			continue
+		}
+		var deletes bool
+		for name := range seen {
+			if deleters[name] {
+				deletes = true
+				break
+			}
+		}
 		if !deletes {
 			continue
 		}
 		checked++
-		if !consults {
-			t.Errorf("%s deletes session rows but never calls retainsError — #1815: an errored "+
-				"row within its retention window is deleted by this path. Either consult the "+
-				"exemption, or add %s to this test's `exempt` map with the reason.", name, name)
+		if !consulting[fn] {
+			t.Errorf("%s deletes session rows but nothing on its call path consults retainsError "+
+				"— #1815: an errored row within its retention window is deleted by this path. "+
+				"Either consult the exemption (directly or via a predicate that does), or add "+
+				"%s to this test's `exempt` map with the reason.", fn, fn)
 		}
 	}
 
 	// The tripwire must fail loudly when it cannot run: an AST walk that matched
-	// nothing looks identical to a clean result. Four non-exempt deleters exist
-	// today (isStartupZombie's caller CleanupZombies, seedAlivePIDs,
-	// reapOrRetainDeadSeedPID, sweepStaleSnapshot); a floor of 3 leaves room for
-	// refactoring without letting the check silently go inert.
+	// nothing looks identical to a clean result. Three non-exempt deleters exist
+	// today (CleanupZombies, seedAlivePIDs, reapOrRetainDeadSeedPID,
+	// sweepStaleSnapshot); a floor of 3 leaves room for refactoring without
+	// letting the check silently go inert.
 	if checked < 3 {
 		t.Fatalf("the reaper scan matched only %d deleting function(s) — the AST walk or the "+
-			"call-name list has gone stale, and this test is no longer checking anything", checked)
+			"deleter-name list has gone stale, and this test is no longer checking anything", checked)
+	}
+	// And the consulting set must be more than its seed, or the fixed point
+	// never ran and every delegating caller would be reported as a violation.
+	if len(consulting) < 2 {
+		t.Fatalf("no function was found to consult retainsError — the delegation walk is inert")
 	}
 }
 

--- a/core/application/services/error_survives_restart_test.go
+++ b/core/application/services/error_survives_restart_test.go
@@ -1,6 +1,9 @@
 package services
 
 import (
+	"go/ast"
+	"go/parser"
+	"go/token"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -10,7 +13,6 @@ import (
 	"time"
 
 	"irrlicht/core/domain/session"
-	"irrlicht/core/ports/outbound"
 )
 
 // #1815 — an errored session must survive a daemon restart. Three things have to
@@ -217,13 +219,6 @@ func TestSeedRestoreErrorVerdict_IgnoresANonErroredRow(t *testing.T) {
 // seedRestoreErrorVerdict) are all unexported, so the shared builders in
 // package services_test cannot reach them.
 
-// restartLog swallows log output. The paths under test log heavily on the way
-// through, and none of it is what is being asserted.
-type restartLog struct{ outbound.Logger }
-
-func (restartLog) LogInfo(_, _, _ string)  {}
-func (restartLog) LogError(_, _, _ string) {}
-
 // restartRepo is a minimal in-memory SessionRepository that COUNTS deletions —
 // which is the observable the sweep tests actually assert on. A sweep that
 // deletes the row is the defect; a sweep that merely declines to report it alive
@@ -284,7 +279,7 @@ func restartPIDManager(t *testing.T) (*PIDManager, *restartRepo) {
 	repo := &restartRepo{}
 	pm := NewPIDManager(PIDManagerDeps{
 		Repo:     repo,
-		Log:      restartLog{},
+		Log:      bornLog{},
 		ReadyTTL: 10 * time.Minute,
 	})
 	return pm, repo
@@ -294,7 +289,7 @@ func restartPIDManager(t *testing.T) (*PIDManager, *restartRepo) {
 // restore touches: a signal-hold store, the verdict registry, a clock and a log.
 func newSeedRestoreDetector(t *testing.T) *SessionDetector {
 	t.Helper()
-	return NewSessionDetector(nil, SessionDetectorDeps{Log: restartLog{}})
+	return NewSessionDetector(nil, SessionDetectorDeps{Log: bornLog{}})
 }
 
 // deadPIDForRestartTest spawns and reaps a process, returning a PID known to be
@@ -326,44 +321,6 @@ func liveProcessForRestartTest(t *testing.T) int {
 		_ = cmd.Wait()
 	})
 	return cmd.Process.Pid
-}
-
-// TestSeedRestoreErrorVerdict_DropsAHoldWhoseTurnActuallyFinished is a LOCK: it
-// passes before #1815 by construction (the restore did not exist, so nothing was
-// ever applied) and pins the direction the restore must NOT break.
-//
-// The exit edge places a process-death hold PROVISIONALLY, because at the moment
-// a process dies the daemon cannot tell a crash from a clean exit — a headless
-// agent writes its turn-ending line and exits microseconds later. Overlay's
-// staleness rule is the actual verdict. Restoring the hold at seed time must go
-// through that same rule rather than around it, or every clean `claude -p` run
-// on disk at boot would come back red.
-func TestSeedRestoreErrorVerdict_DropsAHoldWhoseTurnActuallyFinished(t *testing.T) {
-	d := newSeedRestoreDetector(t)
-
-	state := &session.SessionState{
-		SessionID: "finished-1815",
-		State:     session.StateError,
-		UpdatedAt: time.Now().Unix(),
-		Metrics: &session.SessionMetrics{
-			SessionError: &session.SessionError{
-				Phase: session.ErrorPhaseTerminal,
-				Class: session.ErrorClassProcessDeath,
-			},
-		},
-	}
-	persisted := persistedErrorVerdict(state)
-
-	// The turn HAD in fact ended before the process exited.
-	state.Metrics = &session.SessionMetrics{LastEventType: "turn_done"}
-
-	d.seedRestoreErrorVerdict(state, persisted)
-
-	if state.Metrics.ProcessDeath {
-		t.Errorf("a session whose turn had finished was pinned as a process death — " +
-			"the seed restore bypassed Overlay's staleness rule, so every clean headless " +
-			"exit sitting on disk at boot comes back red")
-	}
 }
 
 // TestStartupSweeps_KeepARetainedErrorOrphanRow covers the THIRD deleter, found
@@ -533,8 +490,16 @@ func TestSeedRestoreErrorVerdict_NoVerdictWhenOverlayDropsTheHold(t *testing.T) 
 
 	d.seedRestoreErrorVerdict(state, persisted)
 
+	// A LOCK, and the precondition for the assertion below: the exit edge places
+	// a process-death hold PROVISIONALLY, because at the moment a process dies
+	// the daemon cannot tell a crash from a clean exit — a headless agent writes
+	// its turn-ending line and exits microseconds later. Overlay's staleness rule
+	// is the actual verdict, and the seed restore must go THROUGH it rather than
+	// around it, or every clean `claude -p` run sitting on disk at boot comes
+	// back red.
 	if state.Metrics.ProcessDeath {
-		t.Fatalf("Overlay should have dropped the hold as stale for a finished turn")
+		t.Fatalf("a session whose turn had finished was pinned as a process death — the seed " +
+			"restore bypassed Overlay's staleness rule")
 	}
 
 	// The hold never applied, so the classifier settles the row away from
@@ -582,5 +547,149 @@ func TestSeedRetainRestoredError_SkipsARecoveredSession(t *testing.T) {
 	if _, ok := d.processDeathVerdictAt("recovered-across-restart-1815"); ok {
 		t.Errorf("a recovered session was registered for retention — it is now shielded from " +
 			"the reaper for the whole window despite no longer being in error")
+	}
+}
+
+// TestEveryReaperConsultsTheErrorExemption is a STRUCTURAL tripwire, not a
+// behavioural test: it fails when a function that deletes session rows does not
+// consult the #1815 error exemption.
+//
+// WHY A STATIC CHECK RATHER THAN MORE CASES. The first cut of this fix inlined
+// the exemption at the three deleters its author had found, and a fourth —
+// sweepStaleSnapshot's ready-TTL branch — went on deleting a PID==0 errored row
+// after 30 minutes, inside the twelve-hour window. Nothing structurally
+// connected "a place that deletes rows" to "consult the exemption", so the miss
+// was invisible: every behavioural test passed, because none of them exercised
+// that particular reaper. A per-site inventory in a doc comment has the same
+// weakness — it was written already stale.
+//
+// The exemption list below is the deliberate part. A deleter on it is one that
+// must NOT consult the exemption, with the reason stated; adding a new reaper
+// means either calling retainsError or arguing here why it is exempt.
+func TestEveryReaperConsultsTheErrorExemption(t *testing.T) {
+	// Deleters that intentionally do not consult it, and why.
+	exempt := map[string]string{
+		"deleteSession":                      "the shared choke point; guarding here would strand an errored CHILD whose parent was deleted, leaving a dangling ParentSessionID nothing can collect",
+		"deleteWithChildren":                 "same choke-point argument, and it would re-shield a row whose verdict HandlePIDAssigned deliberately retired (TestHandlePIDAssigned_RetiresAProcessDeathVerdict)",
+		"cleanupChildren":                    "children are reaped on their parent's lifecycle, not their own state",
+		"reapStaleChild":                     "same: a child's retention belongs to its parent",
+		"reapUnboundReadyGhost":              "ready-state ghosts only; an errored row never reaches it",
+		"dedupeByPID":                        "supersession, not reaping — the surviving row carries the identity",
+		"sweepSupersededPreSessions":         "presession supersession, not reaping — only `proc-` rows, which never carry a verdict",
+		"sweepSupersededPreSessionsPeriodic": "same, on the periodic timer — verified to `continue` on any id without the `proc-` prefix",
+		"removeSessionUntracked":             "the untracked-removal primitive the two supersession sweeps call",
+		"HandleProcessExit":                  "routes through onProcessDiedMidTurn (retainAsProcessDeath), which owns the live-path retention via the verdict map",
+	}
+
+	src, err := os.ReadFile("pid_manager.go")
+	if err != nil {
+		t.Fatalf("read pid_manager.go: %v", err)
+	}
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "pid_manager.go", src, 0)
+	if err != nil {
+		t.Fatalf("parse pid_manager.go: %v", err)
+	}
+
+	var checked int
+	for _, decl := range file.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Body == nil {
+			continue
+		}
+		name := fn.Name.Name
+		if _, ok := exempt[name]; ok {
+			continue
+		}
+		var deletes, consults bool
+		ast.Inspect(fn.Body, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			sel, ok := call.Fun.(*ast.SelectorExpr)
+			if !ok {
+				return true
+			}
+			switch sel.Sel.Name {
+			case "deleteWithChildren", "deleteSession", "removeSessionUntracked":
+				deletes = true
+			case "retainsError", "isStartupZombie":
+				// isStartupZombie counts as consulting: the guard lives inside
+				// that predicate, so its callers inherit it. Delegation is a
+				// legitimate way to satisfy this check; re-implementing the
+				// window at the call site is not.
+				consults = true
+			}
+			return true
+		})
+		if !deletes {
+			continue
+		}
+		checked++
+		if !consults {
+			t.Errorf("%s deletes session rows but never calls retainsError — #1815: an errored "+
+				"row within its retention window is deleted by this path. Either consult the "+
+				"exemption, or add %s to this test's `exempt` map with the reason.", name, name)
+		}
+	}
+
+	// The tripwire must fail loudly when it cannot run: an AST walk that matched
+	// nothing looks identical to a clean result. Four non-exempt deleters exist
+	// today (isStartupZombie's caller CleanupZombies, seedAlivePIDs,
+	// reapOrRetainDeadSeedPID, sweepStaleSnapshot); a floor of 3 leaves room for
+	// refactoring without letting the check silently go inert.
+	if checked < 3 {
+		t.Fatalf("the reaper scan matched only %d deleting function(s) — the AST walk or the "+
+			"call-name list has gone stale, and this test is no longer checking anything", checked)
+	}
+}
+
+// TestStaleSweep_KeepsARetainedErrorRow is the behavioural half of the fifth
+// deleter the structural tripwire above exists to prevent.
+//
+// sweepStaleSnapshot's `snap.pid == 0` branch deletes after readyTTL — 30
+// minutes by default — which is inside the twelve-hour window an errored row is
+// promised. It takes exactly the shape #1815's own comments describe: a headless
+// run that fails on a provider error and exits before PID discovery binds.
+func TestStaleSweep_KeepsARetainedErrorRow(t *testing.T) {
+	pm, repo := restartPIDManager(t)
+
+	state := &session.SessionState{
+		SessionID: "stale-error-1815",
+		State:     session.StateError,
+		PID:       0,
+		// Well past readyTTL, well inside the error retention window.
+		UpdatedAt: time.Now().Add(-2 * time.Hour).Unix(),
+		Metrics: &session.SessionMetrics{
+			SessionError: &session.SessionError{Phase: session.ErrorPhaseTerminal, Class: "provider"},
+		},
+	}
+	pm.sweepStaleSnapshot(snapshotForTest(state))
+
+	if repo.deletedCount() != 0 {
+		t.Fatalf("the ready-TTL liveness sweep deleted an errored row %v old — #1815: the "+
+			"twelve-hour promise is really readyTTL (%v) for a PID==0 errored session",
+			2*time.Hour, pm.readyTTL)
+	}
+
+	// The window still closes: past the retention, the sweep reaps as before.
+	pm2, repo2 := restartPIDManager(t)
+	stale := *state
+	stale.UpdatedAt = time.Now().Add(-processDeathRetention - time.Hour).Unix()
+	pm2.sweepStaleSnapshot(snapshotForTest(&stale))
+	if repo2.deletedCount() != 1 {
+		t.Errorf("an errored row past the retention window was not reaped by the stale sweep — "+
+			"the exemption never expires (deleted %d)", repo2.deletedCount())
+	}
+}
+
+// snapshotForTest builds the livenessSnapshot sweepStaleSnapshot consumes.
+func snapshotForTest(state *session.SessionState) livenessSnapshot {
+	return livenessSnapshot{
+		state:        state,
+		pid:          state.PID,
+		sessionState: state.State,
+		updatedAt:    state.UpdatedAt,
 	}
 }

--- a/core/application/services/pid_manager.go
+++ b/core/application/services/pid_manager.go
@@ -172,31 +172,37 @@ type PIDManager struct {
 	recorder    outbound.EventRecorder
 	recorderSeq *int64 // shared with SessionDetector for monotonic ordering
 
-	// errorRetentionOverride, when non-zero, replaces processDeathRetention in
-	// this manager's #1815 exemption. Zero means "use the package default".
-	//
-	// It exists so the sweeps' window and SessionDetector's stay ONE knob:
-	// SetProcessDeathRetention forwards here, and a test that compresses twelve
-	// hours to milliseconds compresses both halves. Without it a compressed test
-	// would shorten the detector's retention and leave the sweeps measuring the
-	// real twelve hours — two windows the code repeatedly calls "the same twelve
-	// hours", silently disagreeing.
-	errorRetentionOverride time.Duration
+	// errorRetention is how long this manager's sweeps spare an errored row
+	// after a daemon restart (#1815). Defaulted to processDeathRetention in
+	// NewPIDManager and overwritten wholesale by SetErrorRetention, exactly as
+	// SessionDetector holds its own copy — rather than as a zero-means-default
+	// sentinel, which would make SetErrorRetention(0) mean "twelve hours" here
+	// while SetProcessDeathRetention(0) means "never retain" there. Two knobs
+	// the code calls "the same twelve hours" must not disagree at any value.
+	errorRetention time.Duration
 }
 
 // SetErrorRetention overrides the window this manager's #1815 exemption measures.
 // Forwarded from SessionDetector.SetProcessDeathRetention so the two cannot drift.
 func (pm *PIDManager) SetErrorRetention(dur time.Duration) {
-	pm.errorRetentionOverride = dur
+	pm.errorRetention = dur
 }
 
-// errorRetention is the window the startup exemptions measure — the override
-// when one is set, the shared default otherwise.
-func (pm *PIDManager) errorRetention() time.Duration {
-	if pm.errorRetentionOverride > 0 {
-		return pm.errorRetentionOverride
-	}
-	return processDeathRetention
+// retainsError reports whether state is an errored row this sweep must spare.
+//
+// ONE METHOD, CONSULTED BY EVERY REAPER PREDICATE, rather than the predicate
+// inlined per site. The distinction is not cosmetic: the first cut of #1815
+// inlined it at the three sites its author had found, and a fourth — the
+// ready-TTL branch of sweepStaleSnapshot — went on deleting a PID==0 errored
+// row after readyTTL (30 minutes by default), which made the twelve-hour promise
+// false for exactly the shape #1815's own comments describe (a headless run that
+// fails on a provider error and exits before PID discovery binds). Nothing
+// structurally connected "a place that deletes rows" to "consult the exemption",
+// so the miss was invisible. Keeping the call one short name makes adding the
+// next reaper's consultation cheap, and TestEveryReaperConsultsTheErrorExemption
+// fails if a new deleter forgets.
+func (pm *PIDManager) retainsError(state *session.SessionState) bool {
+	return retainedErrorAcrossRestart(state, time.Now(), pm.errorRetention)
 }
 
 // PIDManagerDeps bundles NewPIDManager's dependencies. PW and Broadcaster may
@@ -238,6 +244,7 @@ func NewPIDManager(deps PIDManagerDeps) *PIDManager {
 
 		onProcessDiedMidTurn: deps.OnProcessDiedMidTurn,
 		pendingPIDs:          make(map[string]int),
+		errorRetention:       processDeathRetention,
 	}
 }
 
@@ -654,7 +661,7 @@ func (pm *PIDManager) isStartupZombie(state *session.SessionState, liveLookup fu
 	// its retention window is worth keeping whatever this sweep's reason for
 	// wanting it gone (#1815). See retainedErrorAcrossRestart for the full list
 	// of paths that consult it.
-	if retainedErrorAcrossRestart(state, time.Now(), pm.errorRetention()) {
+	if pm.retainsError(state) {
 		return false
 	}
 	if state.PID > 0 {
@@ -1269,6 +1276,14 @@ func (pm *PIDManager) sweepStaleSnapshot(snap livenessSnapshot) {
 	if snap.pid > 0 && syscall.Kill(snap.pid, 0) == nil {
 		return
 	}
+	// The FIFTH reaper an errored row can reach, and the one the first cut of
+	// #1815 missed: `snap.pid == 0` takes an errored row whose PID discovery
+	// never bound, after readyTTL (30 minutes) rather than after the twelve
+	// hours that state was promised. Consulted here for the same reason as at
+	// every other reaper predicate — see PIDManager.retainsError.
+	if pm.retainsError(snap.state) {
+		return
+	}
 	if snap.sessionState == session.StateReady || snap.pid == 0 {
 		pm.log.LogInfo(logComponentSessionDetector, snap.state.SessionID,
 			fmt.Sprintf("%s session (pid=%d) idle for >%v, deleting",
@@ -1396,7 +1411,7 @@ func (pm *PIDManager) seedAlivePIDs(states []*session.SessionState) map[int]*ses
 			if pm.handleAlivePIDState(state) {
 				pm.trackNewestByPID(state, newestByPID)
 			}
-		case state.PID == 0 && !retainedErrorAcrossRestart(state, time.Now(), pm.errorRetention()) && isOrphanAtSeed(state):
+		case state.PID == 0 && !pm.retainsError(state) && isOrphanAtSeed(state):
 			// Orphan from exited process (PID discovery never succeeded).
 			// Child sessions (ParentSessionID set) are exempt — they run
 			// inside the parent process and never get their own PID.
@@ -1442,20 +1457,7 @@ func isOrphanAtSeed(state *session.SessionState) bool {
 // Returns true when the state remains alive after processing.
 func (pm *PIDManager) handleAlivePIDState(state *session.SessionState) bool {
 	if syscall.Kill(state.PID, 0) == syscall.ESRCH {
-		// A SECOND DEAD-PID DELETER, and it has to make the same exemption as
-		// isStartupZombie or that one is worth nothing (#1815). CleanupZombies
-		// runs first and would normally have taken this row already; this path is
-		// what catches it when that sweep is skipped (demo mode) or when SeedPIDs
-		// is reached by any route that did not run it.
-		if retainedErrorAcrossRestart(state, time.Now(), pm.errorRetention()) {
-			pm.log.LogInfo(logComponentSessionDetectorSeed, state.SessionID,
-				fmt.Sprintf("pid %d dead but session is %s within the retention window — keeping (#1815)",
-					state.PID, state.State))
-			return false
-		}
-		pm.log.LogInfo(logComponentSessionDetectorSeed, state.SessionID,
-			fmt.Sprintf("pid %d dead, deleting session", state.PID))
-		pm.deleteWithChildren(state, fmt.Sprintf("pid %d dead at seed (ESRCH)", state.PID))
+		pm.reapOrRetainDeadSeedPID(state)
 		return false
 	}
 	if pm.pw != nil {
@@ -1481,6 +1483,32 @@ func (pm *PIDManager) handleAlivePIDState(state *session.SessionState) bool {
 		_ = pm.repo.Save(state)
 	}
 	return true
+}
+
+// reapOrRetainDeadSeedPID handles a seeded session whose PID is already dead:
+// deleted as before, unless it is an errored row still inside its retention
+// window (#1815).
+//
+// A SECOND DEAD-PID DELETER, and it has to make the same exemption as
+// isStartupZombie or that one is worth nothing. CleanupZombies runs first and
+// would normally have taken this row already; this path is what catches it when
+// that sweep is skipped (demo mode) or when SeedPIDs is reached by any route
+// that did not run it.
+//
+// Broken out of handleAlivePIDState rather than nested inside it so the one
+// function a reader opens to answer "what deletes a seeded row?" does not
+// interleave this decision with the watcher registration and launcher/badge
+// backfill that follow it.
+func (pm *PIDManager) reapOrRetainDeadSeedPID(state *session.SessionState) {
+	if pm.retainsError(state) {
+		pm.log.LogInfo(logComponentSessionDetectorSeed, state.SessionID,
+			fmt.Sprintf("pid %d dead but session is %s within the retention window — keeping (#1815)",
+				state.PID, state.State))
+		return
+	}
+	pm.log.LogInfo(logComponentSessionDetectorSeed, state.SessionID,
+		fmt.Sprintf("pid %d dead, deleting session", state.PID))
+	pm.deleteWithChildren(state, fmt.Sprintf("pid %d dead at seed (ESRCH)", state.PID))
 }
 
 // backfillLauncher reattempts Launcher capture for pre-existing sessions that

--- a/core/application/services/pid_manager.go
+++ b/core/application/services/pid_manager.go
@@ -1269,28 +1269,37 @@ func (pm *PIDManager) sweepStaleSnapshot(snap livenessSnapshot) {
 		return
 	}
 
-	if !isStaleUpdatedAt(snap.updatedAt, pm.readyTTL) {
+	if !pm.reapsIdleTopLevel(snap) {
 		return
+	}
+	pm.log.LogInfo(logComponentSessionDetector, snap.state.SessionID,
+		fmt.Sprintf("%s session (pid=%d) idle for >%v, deleting",
+			snap.sessionState, snap.pid, pm.readyTTL))
+	pm.deleteWithChildren(snap.state,
+		fmt.Sprintf("%s session (pid=%d) idle >%v — liveness sweep", snap.sessionState, snap.pid, pm.readyTTL))
+}
+
+// reapsIdleTopLevel reports whether an idle top-level session is due for
+// deletion by the liveness sweep. Broken out of sweepStaleSnapshot so the
+// decision has a name and the sweep reads as dispatch rather than as a ladder
+// of guards.
+func (pm *PIDManager) reapsIdleTopLevel(snap livenessSnapshot) bool {
+	if !isStaleUpdatedAt(snap.updatedAt, pm.readyTTL) {
+		return false
 	}
 	// Don't delete sessions whose process is still alive.
 	if snap.pid > 0 && syscall.Kill(snap.pid, 0) == nil {
-		return
+		return false
 	}
 	// The FIFTH reaper an errored row can reach, and the one the first cut of
-	// #1815 missed: `snap.pid == 0` takes an errored row whose PID discovery
-	// never bound, after readyTTL (30 minutes) rather than after the twelve
-	// hours that state was promised. Consulted here for the same reason as at
-	// every other reaper predicate — see PIDManager.retainsError.
+	// #1815 missed: the `snap.pid == 0` arm below takes an errored row whose
+	// PID discovery never bound, after readyTTL (30 minutes) rather than after
+	// the twelve hours that state was promised. Consulted here for the same
+	// reason as at every other reaper predicate — see PIDManager.retainsError.
 	if pm.retainsError(snap.state) {
-		return
+		return false
 	}
-	if snap.sessionState == session.StateReady || snap.pid == 0 {
-		pm.log.LogInfo(logComponentSessionDetector, snap.state.SessionID,
-			fmt.Sprintf("%s session (pid=%d) idle for >%v, deleting",
-				snap.sessionState, snap.pid, pm.readyTTL))
-		pm.deleteWithChildren(snap.state,
-			fmt.Sprintf("%s session (pid=%d) idle >%v — liveness sweep", snap.sessionState, snap.pid, pm.readyTTL))
-	}
+	return snap.sessionState == session.StateReady || snap.pid == 0
 }
 
 // reapStaleChild deletes snap when it's a finished or zombie subagent (ready,

--- a/core/application/services/pid_manager.go
+++ b/core/application/services/pid_manager.go
@@ -171,6 +171,32 @@ type PIDManager struct {
 	// Set by SessionDetector.SetRecorder.
 	recorder    outbound.EventRecorder
 	recorderSeq *int64 // shared with SessionDetector for monotonic ordering
+
+	// errorRetentionOverride, when non-zero, replaces processDeathRetention in
+	// this manager's #1815 exemption. Zero means "use the package default".
+	//
+	// It exists so the sweeps' window and SessionDetector's stay ONE knob:
+	// SetProcessDeathRetention forwards here, and a test that compresses twelve
+	// hours to milliseconds compresses both halves. Without it a compressed test
+	// would shorten the detector's retention and leave the sweeps measuring the
+	// real twelve hours — two windows the code repeatedly calls "the same twelve
+	// hours", silently disagreeing.
+	errorRetentionOverride time.Duration
+}
+
+// SetErrorRetention overrides the window this manager's #1815 exemption measures.
+// Forwarded from SessionDetector.SetProcessDeathRetention so the two cannot drift.
+func (pm *PIDManager) SetErrorRetention(dur time.Duration) {
+	pm.errorRetentionOverride = dur
+}
+
+// errorRetention is the window the startup exemptions measure — the override
+// when one is set, the shared default otherwise.
+func (pm *PIDManager) errorRetention() time.Duration {
+	if pm.errorRetentionOverride > 0 {
+		return pm.errorRetentionOverride
+	}
+	return processDeathRetention
 }
 
 // PIDManagerDeps bundles NewPIDManager's dependencies. PW and Broadcaster may
@@ -622,6 +648,13 @@ func (pm *PIDManager) HasLiveProcessInCWD(adapter, cwd string) bool {
 // supply one — typically pm.newLiveLookupCache().
 func (pm *PIDManager) isStartupZombie(state *session.SessionState, liveLookup func(adapter string) map[string]struct{}) bool {
 	if state == nil {
+		return false
+	}
+	// Above every branch below, not only the dead-PID one: an errored row within
+	// its retention window is worth keeping whatever this sweep's reason for
+	// wanting it gone (#1815). See retainedErrorAcrossRestart for the full list
+	// of paths that consult it.
+	if retainedErrorAcrossRestart(state, time.Now(), pm.errorRetention()) {
 		return false
 	}
 	if state.PID > 0 {
@@ -1363,12 +1396,20 @@ func (pm *PIDManager) seedAlivePIDs(states []*session.SessionState) map[int]*ses
 			if pm.handleAlivePIDState(state) {
 				pm.trackNewestByPID(state, newestByPID)
 			}
-		case state.PID == 0 && isOrphanAtSeed(state):
+		case state.PID == 0 && !retainedErrorAcrossRestart(state, time.Now(), pm.errorRetention()) && isOrphanAtSeed(state):
 			// Orphan from exited process (PID discovery never succeeded).
 			// Child sessions (ParentSessionID set) are exempt — they run
 			// inside the parent process and never get their own PID.
 			// cwdMissing also catches zombies re-touched by `claude --resume`
 			// after the worktree was deleted (#321).
+			//
+			// THE THIRD DELETER an errored row can reach (#1815), and the least
+			// obvious: it has nothing to do with a dead PID. A headless run that
+			// fails on a provider error and exits before PID discovery ever binds
+			// leaves a row with PID==0, and an errored session's transcript is
+			// stale by definition once orphanTranscriptAge (2 minutes) has passed
+			// — so isOrphanAtSeed says yes to exactly the rows the other two
+			// exemptions just spared.
 			pm.log.LogInfo(logComponentSessionDetectorSeed, state.SessionID, "deleting orphan session")
 			pm.deleteWithChildren(state, "orphan session at seed — PID discovery never succeeded")
 		}
@@ -1401,6 +1442,17 @@ func isOrphanAtSeed(state *session.SessionState) bool {
 // Returns true when the state remains alive after processing.
 func (pm *PIDManager) handleAlivePIDState(state *session.SessionState) bool {
 	if syscall.Kill(state.PID, 0) == syscall.ESRCH {
+		// A SECOND DEAD-PID DELETER, and it has to make the same exemption as
+		// isStartupZombie or that one is worth nothing (#1815). CleanupZombies
+		// runs first and would normally have taken this row already; this path is
+		// what catches it when that sweep is skipped (demo mode) or when SeedPIDs
+		// is reached by any route that did not run it.
+		if retainedErrorAcrossRestart(state, time.Now(), pm.errorRetention()) {
+			pm.log.LogInfo(logComponentSessionDetectorSeed, state.SessionID,
+				fmt.Sprintf("pid %d dead but session is %s within the retention window — keeping (#1815)",
+					state.PID, state.State))
+			return false
+		}
 		pm.log.LogInfo(logComponentSessionDetectorSeed, state.SessionID,
 			fmt.Sprintf("pid %d dead, deleting session", state.PID))
 		pm.deleteWithChildren(state, fmt.Sprintf("pid %d dead at seed (ESRCH)", state.PID))

--- a/core/application/services/session_detector.go
+++ b/core/application/services/session_detector.go
@@ -184,8 +184,13 @@ type SessionDetector struct {
 	// forever. Guarded by processDeathMu — HandleProcessExit reaches it from
 	// both the process-watcher callback and the liveness sweep.
 	//
-	// In-memory on purpose: it does not need to survive a restart, because the
-	// rows it describes do not either (see retainAsProcessDeath).
+	// In-memory, but REPOPULATED AT SEED since #1815 — this comment used to say
+	// the map did not need to survive a restart "because the rows it describes
+	// do not either", and both halves are now false. The rows survive
+	// (retainedErrorAcrossRestart), and seedRestoreErrorVerdict re-registers an
+	// entry here for each one whose hold re-applied, stamped with the PERSISTED
+	// timestamp rather than with the restart, so the window continues instead of
+	// starting over.
 	processDeathVerdicts map[string]time.Time
 	processDeathMu       sync.Mutex
 
@@ -422,6 +427,13 @@ func (d *SessionDetector) HandleProcessExitRetainedForTest(pid int, sessionID, r
 // otherwise could not reach the expiry branch at all.
 func (d *SessionDetector) SetProcessDeathRetention(dur time.Duration) {
 	d.processDeathRetention = dur
+	// Forwarded so the startup sweeps' #1815 exemption measures the SAME window
+	// this one does. They are described throughout as "the same twelve hours";
+	// a knob that moved only one of them would make that false in exactly the
+	// tests written to check it.
+	if d.pidMgr != nil {
+		d.pidMgr.SetErrorRetention(dur)
+	}
 }
 
 // SetDeletedCooldown overrides the deleted-session cooldown.

--- a/core/application/services/session_detector_helpers.go
+++ b/core/application/services/session_detector_helpers.go
@@ -98,6 +98,23 @@ func (d *SessionDetector) forgetSessionScopedState(sessionID string) {
 	d.idleMu.Lock()
 	delete(d.idleProjectRetryAttempts, sessionID)
 	d.idleMu.Unlock()
+
+	// The #1800 process-death verdict registry — added here by #1815, which is
+	// where this function's own doc said the previous map belonged and where it
+	// was missed anyway.
+	//
+	// A STALE ENTRY IS NOT INERT, it is actively wrong. retainAsProcessDeath
+	// keys on presence first: an expired entry takes the EXPIRY branch and
+	// returns false, so the first mid-turn death under a recycled session id
+	// (`claude --resume <uuid>` after the old row aged out) is DELETED instead
+	// of converted to `error` — precisely the signal that map exists to
+	// preserve. It does not self-heal in time either: forgetProcessDeathVerdict
+	// runs only on that same branch, so the entry is dropped only after it has
+	// already eaten one death.
+	//
+	// #1815 made it materially likelier by registering an entry at every seed
+	// for every errored row, where before only a live mid-turn death made one.
+	d.forgetProcessDeathVerdict(sessionID)
 }
 
 // broadcast sends a push notification if a broadcaster is configured. For

--- a/core/application/services/session_detector_lifecycle.go
+++ b/core/application/services/session_detector_lifecycle.go
@@ -357,9 +357,10 @@ func retainedErrorAcrossRestart(state *session.SessionState, now time.Time, wind
 //
 //   - retainedErrorAcrossRestart exempts an errored row from the three STARTUP
 //     deleters for the same twelve hours this constant already promised;
-//   - seedRetainRestoredError re-registers a retention entry in the verdict map
-//     below, stamped at the persisted UpdatedAt. That is what carries the row
-//     past THIS function, which is not a startup path at all: the periodic sweep
+//   - seedRetainErroredRows re-registers a retention entry in the verdict map
+//     below, stamped at the persisted UpdatedAt, for EVERY row that starts in
+//     `error` — not only the ones the consent-gated seed pass examined. That is
+//     what carries the row past THIS function, which is not a startup path at all: the periodic sweep
 //     calls in here every few seconds, and a restored row with no entry fell
 //     straight through to diedMidTurn — false for anything already in `error`
 //     ("error means this already ran") — and was deleted about five seconds
@@ -814,6 +815,10 @@ func (d *SessionDetector) seedFromDisk() {
 
 	d.seedProjectSessions(states)
 	d.seedReevaluateStates(states)
+	// AFTER re-evaluation and BEFORE SeedPIDs. After, so a row the classifier
+	// just moved off `error` (it recovered while the daemon was down) is not
+	// retained; before, because SeedPIDs is itself one of the deleters.
+	d.seedRetainErroredRows(states)
 	d.seedBackfillMetadata(states)
 
 	// Clean up dead sessions and register alive PIDs with ProcessWatcher.
@@ -915,10 +920,6 @@ func (d *SessionDetector) seedReevaluateOne(state *session.SessionState) {
 		}
 		state.State = newState
 	}
-	// After the classifier has ruled, so a session that recovered while the
-	// daemon was down is not shielded from the reaper (#1815).
-	d.seedRetainRestoredError(state, persistedError)
-
 	_ = d.repo.Save(state)
 	if d.historyTracker != nil {
 		d.historyTracker.OnTransition(state.SessionID, state.State, time.Now())
@@ -1013,37 +1014,38 @@ func (d *SessionDetector) seedRestoreErrorVerdict(state *session.SessionState, p
 	}
 }
 
-// seedRetainRestoredError registers, for a row that came off disk in `error` AND
-// that this daemon's own classifier still reads as `error`, a retention entry in
-// the process-death verdict map — stamped with the PERSISTED timestamp, so the
-// window continues rather than starting over (#1815).
+// seedRetainErroredRows registers a retention entry for every row this daemon
+// starts with in `error`, so the PERIODIC liveness sweep spares it for whatever
+// is left of its window (#1815).
 //
-// WHY THE VERDICT MAP RATHER THAN A PREDICATE IN THE SWEEP. The periodic
-// liveness sweep is a deleter the startup exemptions cannot reach, and it needs
-// to know "a previous daemon already ruled on this row". That is exactly what
-// the verdict map means, and reusing it inherits its whole lifecycle for free —
-// most importantly HandlePIDAssigned's retirement, so a session that comes back
-// under a new PID becomes an ordinary reapable row again. A state-shaped
-// predicate in retainAsProcessDeath cannot make that distinction (a retired row
-// still looks `error` and recent) and broke
-// TestHandlePIDAssigned_RetiresAProcessDeathVerdict when it was tried.
+// IT WALKS EVERY PERSISTED ROW, NOT THE ONES THE SEED PASS EXAMINED, and that
+// is the whole reason it is a separate pass rather than a line inside
+// seedReevaluateOne. The first cut put it there, and seedReevaluateStates skips
+// any row with no TranscriptPath or whose adapter's observe permission is not
+// granted — so a skipped row was spared by the startup exemption and then
+// deleted about five seconds later by the sweep, which found no verdict and got
+// `false` from diedMidTurn (which is false for anything already in `error`).
+// Neither skip condition is exotic: a pending observe permission is EVERY
+// adapter's state on a fresh IRRLICHT_HOME, so the user most likely to hit it
+// was the one who had not finished onboarding.
 //
-// EVERY ERROR CLASS, not just process death. A transcript-derived failure is the
-// reporter's own case, has no verdict of its own in the new process, and was the
-// one being deleted five seconds after each restart.
+// SAME PREDICATE AS THE STARTUP EXEMPTION, deliberately. What the sweeps spare
+// and what the sweep retains are then one rule with one window, and cannot
+// disagree about a row at the edge of it. Past the window nothing is registered
+// and the ordinary reaper takes the row, exactly as before.
 //
-// CALLED AFTER ClassifyState, WHICH IS THE GATE. If the transcript grew while
-// the daemon was down and the tailer's clearing rule fired, RefreshMetrics
-// returns no error, the classifier moves the row off `error`, and this registers
-// nothing — so a recovered session is not shielded from the reaper for twelve
-// hours. It is also what keeps a provisional process-death hold that Overlay
-// judged NOT a crash from being retained: the hold never applied, so the row
-// classifies away from `error` and never reaches the registration.
-func (d *SessionDetector) seedRetainRestoredError(state *session.SessionState, persisted *session.SessionError) {
-	if persisted == nil || state.State != session.StateError {
-		return
+// CALLED AFTER seedReevaluateStates so a row that recovered while the daemon
+// was down — the transcript grew, the tailer's clearing rule fired, and the
+// classifier moved it off `error` — is not shielded from the reaper. That
+// ordering is the gate; see the call site.
+func (d *SessionDetector) seedRetainErroredRows(states []*session.SessionState) {
+	now := d.nowFn()
+	for _, state := range states {
+		if !retainedErrorAcrossRestart(state, now, d.processDeathRetention) {
+			continue
+		}
+		d.restoreErrorRetention(state.SessionID, time.Unix(state.UpdatedAt, 0))
 	}
-	d.restoreErrorRetention(state.SessionID, time.Unix(state.UpdatedAt, 0))
 }
 
 // restoreErrorRetention re-registers a retention entry for a verdict a PREVIOUS

--- a/core/application/services/session_detector_lifecycle.go
+++ b/core/application/services/session_detector_lifecycle.go
@@ -258,19 +258,23 @@ const processDeathRetention = 12 * time.Hour
 // is the precondition for every other part of this fix: a verdict restored onto
 // a row that has already been deleted restores nothing.
 //
-// FOUR CALLERS, AND THE COUNT IS THE POINT. An errored row is reachable by more
-// deleters than the obvious one, and exempting a proper subset leaves the
-// outcome unchanged — the row simply dies at the next gate instead of the first:
+// MORE DELETERS REACH AN ERRORED ROW THAN IS OBVIOUS, and exempting a proper
+// subset leaves the outcome unchanged — the row simply dies at the next gate
+// instead of the first. Reapers in the PIDManager consult it through
+// PIDManager.retainsError; the live path is handled separately by the verdict
+// map (see retainAsProcessDeath).
 //
-//   - isStartupZombie, via the synchronous CleanupZombies pre-pass;
-//   - seedAlivePIDs' PID>0 branch (handleAlivePIDState);
-//   - seedAlivePIDs' PID==0 branch (isOrphanAtSeed) — reachable for a headless
-//     run that failed and exited before PID discovery ever bound, whose frozen
-//     transcript is stale by definition after orphanTranscriptAge;
-//   - retainAsProcessDeath, reached from the PERIODIC liveness sweep every few
-//     seconds. This one is not a startup path at all, and it is the reason the
-//     other three are not sufficient on their own: without it a rescued row was
-//     deleted about five seconds after the restart rather than at it.
+// DELIBERATELY NOT LISTING THE CALL SITES HERE. The first version of this
+// comment enumerated them and named a count, and it was already wrong when it
+// landed — it missed sweepStaleSnapshot's ready-TTL branch, which had gone on
+// deleting PID==0 errored rows after thirty minutes. A hand-maintained
+// inventory of "everywhere that deletes a row" is exactly the thing that goes
+// stale, so the invariant is enforced by a check that reads the code instead:
+// TestEveryReaperConsultsTheErrorExemption walks pid_manager.go's AST and fails
+// on any deleting function that neither consults the exemption nor sits on its
+// documented exempt list. Run it for the current answer:
+//
+//	go test ./core/application/services/ -run TestEveryReaperConsultsTheErrorExemption
 //
 // In isStartupZombie the guard sits above ALL of that predicate's branches, not
 // only the dead-PID one, so the DB-backed-orphan and stale-transcript branches
@@ -999,7 +1003,8 @@ func (d *SessionDetector) seedRestoreErrorVerdict(state *session.SessionState, p
 	// given; a ceiling that rewrites a session's state without saying so
 	// anywhere is the debugging blind spot #1360 added SignalExpiry to close,
 	// and the seed path is no more exempt from that than the live path is.
-	d.reportHoldExpiries(state, d.signals.Overlay(sid, state.Metrics, d.nowFn()), d.nowFn())
+	now := d.nowFn()
+	d.reportHoldExpiries(state, d.signals.Overlay(sid, state.Metrics, now), now)
 
 	if state.Metrics != nil && state.Metrics.ProcessDeath {
 		d.log.LogInfo(logComponentSessionDetectorSeed, sid,
@@ -1055,9 +1060,6 @@ func (d *SessionDetector) seedRetainRestoredError(state *session.SessionState, p
 func (d *SessionDetector) restoreErrorRetention(sessionID string, at time.Time) {
 	d.processDeathMu.Lock()
 	defer d.processDeathMu.Unlock()
-	if d.processDeathVerdicts == nil {
-		d.processDeathVerdicts = make(map[string]time.Time)
-	}
 	if _, exists := d.processDeathVerdicts[sessionID]; exists {
 		return
 	}

--- a/core/application/services/session_detector_lifecycle.go
+++ b/core/application/services/session_detector_lifecycle.go
@@ -237,11 +237,78 @@ func (d *SessionDetector) HandlePIDAssigned(pid int, sessionID string) {
 // visible at 08:00. Shorter, and the one session the user most needed to see is
 // the one silently deleted before they looked.
 //
-// IT IS BOUNDED BY WALL CLOCK ONLY WITHIN A SINGLE DAEMON RUN. A restart inside
-// the window reaps the row instead of showing it — see retainAsProcessDeath's
-// note, and #1815, which owns that gap. That is the honest ceiling on what this
-// constant can promise.
+// IT IS BOUNDED BY WALL CLOCK ACROSS DAEMON RUNS, which is what #1815 changed.
+// It used to hold only within a single run: a restart inside the window reaped
+// the row instead of showing it, so the twelve hours this constant promises were
+// really "twelve hours, or until the next daemon start, whichever came first" —
+// and a release, a reboot or an `ir:test-mac` all land inside exactly that
+// window. retainedErrorAcrossRestart below now measures the same twelve hours
+// against the PERSISTED UpdatedAt, so the promise survives the restart.
 const processDeathRetention = 12 * time.Hour
+
+// retainedErrorAcrossRestart reports whether state is an errored session whose
+// verdict must outlive this daemon start — the predicate EVERY path that could
+// delete such a row consults before removing it (#1815).
+//
+// THIS IS WHERE THE RESTART CASE IS NAMED. Before it, the sweeps read a dead PID
+// as proof the row was garbage, which is true for every state except the one
+// state whose DEFINING evidence is a dead process. A session that crashed at
+// 22:00 was converted to `error` and kept — and then deleted by the next daemon
+// start, so the user who looked at 08:00 found nothing at all. The row surviving
+// is the precondition for every other part of this fix: a verdict restored onto
+// a row that has already been deleted restores nothing.
+//
+// FOUR CALLERS, AND THE COUNT IS THE POINT. An errored row is reachable by more
+// deleters than the obvious one, and exempting a proper subset leaves the
+// outcome unchanged — the row simply dies at the next gate instead of the first:
+//
+//   - isStartupZombie, via the synchronous CleanupZombies pre-pass;
+//   - seedAlivePIDs' PID>0 branch (handleAlivePIDState);
+//   - seedAlivePIDs' PID==0 branch (isOrphanAtSeed) — reachable for a headless
+//     run that failed and exited before PID discovery ever bound, whose frozen
+//     transcript is stale by definition after orphanTranscriptAge;
+//   - retainAsProcessDeath, reached from the PERIODIC liveness sweep every few
+//     seconds. This one is not a startup path at all, and it is the reason the
+//     other three are not sufficient on their own: without it a rescued row was
+//     deleted about five seconds after the restart rather than at it.
+//
+// In isStartupZombie the guard sits above ALL of that predicate's branches, not
+// only the dead-PID one, so the DB-backed-orphan and stale-transcript branches
+// are covered too. That is deliberate: an errored row is worth keeping whatever
+// the sweep's reason for wanting it gone.
+//
+// BOUNDED BY THE PERSISTED UpdatedAt AND THE EXISTING TWELVE HOURS, not by a new
+// constant. processDeathRetention above already is the answer to "how long is an
+// errored session worth keeping", and it was calibrated on this exact workflow
+// (crash overnight, reviewed next morning). A second constant here would be the
+// same number with a second place to retune it, and the two would drift.
+// Anchoring on UpdatedAt rather than on this daemon's start time is what makes
+// the window CONTINUE across the restart instead of resetting: a row that has
+// already burned eleven of its twelve hours gets one more, not twelve more, so a
+// restart loop cannot keep a dead session alive indefinitely.
+//
+// now AND window ARE PARAMETERS RATHER THAN time.Since AND THE CONST, so this
+// predicate answers to the same knobs the rest of the retention does.
+// SessionDetector.processDeathRetention exists precisely so a twelve-hour window
+// can be exercised without a twelve-hour test; a predicate reading the const
+// directly would have compressed one half of "the same twelve hours" and not the
+// other, and the two could then disagree silently.
+//
+// Past the window the predicate goes false and the ordinary sweeps reap the row
+// exactly as they always did — this is a retention window, not an exemption.
+//
+// The one imprecision, named rather than left to be discovered: UpdatedAt is
+// "when the row was last written", not "when the session failed". Anything that
+// re-saves an errored row extends its window. Nothing should — the process is
+// gone and the transcript is frozen — and the direction of the error is to keep
+// a dead session visible slightly too long rather than to delete it too early,
+// which is the side this state exists to err on.
+func retainedErrorAcrossRestart(state *session.SessionState, now time.Time, window time.Duration) bool {
+	if state == nil || state.State != session.StateError {
+		return false
+	}
+	return now.Sub(time.Unix(state.UpdatedAt, 0)) < window
+}
 
 // retainAsProcessDeath decides whether a process exit should convert the
 // session to StateError and KEEP it, instead of deleting it (#1800). Returns
@@ -278,19 +345,32 @@ const processDeathRetention = 12 * time.Hour
 // sweep via reapDeadOrInfraPID), and the sweep calls it again every few seconds
 // for as long as the row exists.
 //
-// IT DOES NOT SURVIVE A DAEMON RESTART, and that is a real gap rather than an
-// oversight — named here because the twelve-hour window above is exactly the
-// window a restart falls inside. seedAlivePIDs deletes any persisted session
-// whose PID is already dead, by a direct deleteWithChildren that never reaches
-// HandleProcessExit, so a crashed session is reaped at the next daemon start.
-// Routing that path through this function would currently make things WORSE,
-// not better: #1798's SessionError does not survive a restart either
-// (seedReevaluateOne calls RefreshMetrics — a merge against a fresh nil —
-// BEFORE ClassifyState), so the row would come back GREEN, and a stale row that
-// lies is worse than a missing one. The fix is ledger persistence plus a seed
-// ordering change, it applies equally to #1799's producers, and it now has one:
-// TRACKED AS #1815, filed after this branch and #1799 reported it independently.
-// Do not fix it here.
+// IT NOW SURVIVES A DAEMON RESTART — #1815, and this comment used to say the
+// opposite. The gap was real: the startup dead-PID deleters removed a crashed
+// session's row before anything could look at it, and even a row that survived
+// came back GREEN because RefreshMetrics merged against a fresh nil before
+// ClassifyState ran. Three pieces close it, and one of them IS here:
+//
+//   - retainedErrorAcrossRestart exempts an errored row from the three STARTUP
+//     deleters for the same twelve hours this constant already promised;
+//   - seedRetainRestoredError re-registers a retention entry in the verdict map
+//     below, stamped at the persisted UpdatedAt. That is what carries the row
+//     past THIS function, which is not a startup path at all: the periodic sweep
+//     calls in here every few seconds, and a restored row with no entry fell
+//     straight through to diedMidTurn — false for anything already in `error`
+//     ("error means this already ran") — and was deleted about five seconds
+//     AFTER the restart rather than at it. Measured against a real daemon.
+//   - tailer.LedgerState.SessionError carries #1799's transcript-derived half.
+//
+// THIS FUNCTION'S BODY IS UNCHANGED, and that is the design rather than an
+// accident. The restored row is carried by the map's OWN first branch, so the
+// restart case needs no special case here — and, decisively, it inherits the
+// existing retirement path for free: HandlePIDAssigned forgets the verdict when
+// a process comes back, so a resumed session becomes an ordinary row again.
+// An earlier cut of this fix added a state-shaped branch here instead
+// (`is this row `error` and recent?`) and broke exactly that, because a row
+// whose verdict had been deliberately retired still looks errored and recent.
+// TestHandlePIDAssigned_RetiresAProcessDeathVerdict is what caught it.
 func (d *SessionDetector) retainAsProcessDeath(state *session.SessionState, pid int, reason string) bool {
 	sid := state.SessionID
 
@@ -781,7 +861,20 @@ func (d *SessionDetector) seedReevaluateStates(states []*session.SessionState) {
 // for idle sessions that never get another transcript_activity event to
 // trigger RefreshOnActivity + Save.
 func (d *SessionDetector) seedReevaluateOne(state *session.SessionState) {
+	// Captured BEFORE RefreshMetrics, which is the whole trick (#1815).
+	// RefreshMetrics merges against a fresh tailer pass, and for a
+	// daemon-synthesized verdict — process death — that pass carries nil,
+	// because the tailer never saw the failure: nothing was written to the
+	// transcript, the daemon watched the PROCESS go away. The ledger cannot help
+	// there. So the persisted row is the only copy, and one line later it is
+	// gone.
+	persistedError := persistedErrorVerdict(state)
+
 	d.enricher.RefreshMetrics(state)
+
+	// Re-place the hold the previous daemon held, so the classifier below keeps
+	// agreeing with the state on disk (#1815).
+	d.seedRestoreErrorVerdict(state, persistedError)
 
 	// Probe background-process liveness before re-classifying so a session
 	// persisted as `working` solely because a Bash run_in_background
@@ -803,15 +896,13 @@ func (d *SessionDetector) seedReevaluateOne(state *session.SessionState) {
 	// describes something that already happened, so re-asserting it at boot is
 	// sound in a way re-asserting "working" is not.
 	//
-	// It does not actually fire today, and that is a known gap rather than a
-	// contradiction of the above. RefreshMetrics ran a few lines up, and it
-	// merges against a fresh tailer pass whose SessionError is nil — the tailer
-	// does not persist its sticky error — so the persisted value is gone before
-	// ClassifyState reads it and this path sees a healthy session. The fix is
-	// LedgerState persistence in the tailer, deferred to #1800; see
-	// SessionMetrics.SessionError for the full account. The filter is written
-	// to accept error now so that landing the persistence is a one-file change
-	// rather than also having to notice this line.
+	// #1815: it now fires. It used to be dead code — RefreshMetrics merged
+	// against a fresh tailer pass whose SessionError was nil, so the persisted
+	// verdict was gone before ClassifyState read it and this path always saw a
+	// healthy session. Two changes made it live, and they cover different halves:
+	// LedgerState.SessionError carries a TRANSCRIPT-derived failure through the
+	// restart, and seedRestoreErrorVerdict above re-places the hold for a
+	// DAEMON-synthesized one (process death), which no ledger can reconstruct.
 	newState, reason := ClassifyState(state.State, state.Metrics)
 	if newState != state.State && newState != session.StateWorking {
 		if reason != "" {
@@ -820,10 +911,157 @@ func (d *SessionDetector) seedReevaluateOne(state *session.SessionState) {
 		}
 		state.State = newState
 	}
+	// After the classifier has ruled, so a session that recovered while the
+	// daemon was down is not shielded from the reaper (#1815).
+	d.seedRetainRestoredError(state, persistedError)
+
 	_ = d.repo.Save(state)
 	if d.historyTracker != nil {
 		d.historyTracker.OnTransition(state.SessionID, state.State, time.Now())
 	}
+}
+
+// persistedErrorVerdict returns the session-level failure a previous daemon
+// persisted onto this row, or nil when the row is not an errored one.
+//
+// Gated on the persisted STATE as well as on the payload, so a stale
+// SessionError left on a row that has since recovered cannot resurrect the
+// error. The pair is what the previous daemon actually concluded; either half
+// alone is not.
+func persistedErrorVerdict(state *session.SessionState) *session.SessionError {
+	if state == nil || state.State != session.StateError || state.Metrics == nil {
+		return nil
+	}
+	return state.Metrics.SessionError
+}
+
+// seedRestoreErrorVerdict re-places, at daemon start, the SignalProcessDeath
+// hold the previous daemon was holding, and overlays it onto the freshly rebuilt
+// metrics so the seed's own ClassifyState agrees with the state on disk (#1815).
+//
+// PROCESS DEATH ONLY, AND THAT NARROWNESS IS THE DESIGN. It is tempting to
+// re-place a hold for every errored class, and it is wrong for all the others:
+//
+//   - A process-death verdict is synthesized by the daemon from the OS view of
+//     the process and is written to no transcript, so no ledger can reconstruct
+//     it. The hold is the only copy there is. It also has a real end-of-life —
+//     Overlay's IsAgentDone staleness rule, and HandlePIDAssigned's Release if
+//     the process ever comes back.
+//   - A TRANSCRIPT-derived failure has neither property. The tailer owns it,
+//     LedgerState.SessionError already carries it across the restart, and — the
+//     decisive half — the tailer also owns CLEARING it. A hold placed here would
+//     fight that: SignalSessionError's apply writes the payload into any empty
+//     SessionError slot, so the moment clearSessionErrorOnRecovery cleared the
+//     error the hold would write it straight back, and the session would read
+//     `error` through the whole of the user's recovery turn. For the adapters
+//     with no Stop hook (aider, opencode, pi) the row's only staleness rule —
+//     HookTurnDone — never fires at all, so "the whole recovery turn" becomes
+//     the full twelve-hour ceiling. Restoring nothing is strictly better: the
+//     ledger already has it, and if the ledger is gone the verdict degrades to
+//     the pre-fix behaviour rather than to a wrong red.
+//
+// So this function deliberately does nothing for any other class, and the row is
+// still kept alive by retainedErrorAcrossRestart while the ledger supplies the
+// verdict.
+//
+// WHY A HOLD AND NOT JUST THE METRICS FIELD, for the class it does handle.
+// Writing SessionError onto the metrics would satisfy the classifier's
+// session_error rule, and that rule sits BELOW the transcript-tier rules — so a
+// transcript frozen mid-turn, which is exactly what a crashed agent leaves
+// behind, is matched by user_blocking_tool first and the session reads
+// `waiting`. The process_death rule outranks those, and it reads
+// Metrics.ProcessDeath, a json:"-" flag only a hold can set. Re-placing the hold
+// restores the RUNG, not just the payload.
+//
+// HELD AT THE PERSISTED UpdatedAt, NOT AT NOW, so the window the previous daemon
+// started continues rather than restarting — the same argument, and the same
+// twelve hours, as retainedErrorAcrossRestart.
+func (d *SessionDetector) seedRestoreErrorVerdict(state *session.SessionState, persisted *session.SessionError) {
+	if persisted == nil || persisted.Class != session.ErrorClassProcessDeath {
+		return
+	}
+	sid := state.SessionID
+	heldAt := time.Unix(state.UpdatedAt, 0)
+
+	// TierProcess evidence comes back on the process row. Routing it through the
+	// transcript row would record it a tier below the channel it actually
+	// arrived on, and an understated tier never trips the ladder invariant — so
+	// nothing would catch it. See SignalProcessDeath's doc.
+	d.signals.Hold(sid, session.SignalProcessDeath, session.SignalPayload{SessionError: persisted}, heldAt)
+
+	// Overlay now rather than waiting for the next classify pass: for a dead
+	// process there may never BE one — the transcript is frozen, so nothing will
+	// touch this session again — and the seed's own ClassifyState runs a few
+	// lines below.
+	//
+	// The expiries are REPORTED, not discarded. Overlay evaluates staleness and
+	// the ceiling before apply, so this call can silently drop the hold it was
+	// given; a ceiling that rewrites a session's state without saying so
+	// anywhere is the debugging blind spot #1360 added SignalExpiry to close,
+	// and the seed path is no more exempt from that than the live path is.
+	d.reportHoldExpiries(state, d.signals.Overlay(sid, state.Metrics, d.nowFn()), d.nowFn())
+
+	if state.Metrics != nil && state.Metrics.ProcessDeath {
+		d.log.LogInfo(logComponentSessionDetectorSeed, sid,
+			fmt.Sprintf("restored process-death verdict held since %s across the daemon restart (#1815)",
+				heldAt.Format(time.RFC3339)))
+	}
+}
+
+// seedRetainRestoredError registers, for a row that came off disk in `error` AND
+// that this daemon's own classifier still reads as `error`, a retention entry in
+// the process-death verdict map — stamped with the PERSISTED timestamp, so the
+// window continues rather than starting over (#1815).
+//
+// WHY THE VERDICT MAP RATHER THAN A PREDICATE IN THE SWEEP. The periodic
+// liveness sweep is a deleter the startup exemptions cannot reach, and it needs
+// to know "a previous daemon already ruled on this row". That is exactly what
+// the verdict map means, and reusing it inherits its whole lifecycle for free —
+// most importantly HandlePIDAssigned's retirement, so a session that comes back
+// under a new PID becomes an ordinary reapable row again. A state-shaped
+// predicate in retainAsProcessDeath cannot make that distinction (a retired row
+// still looks `error` and recent) and broke
+// TestHandlePIDAssigned_RetiresAProcessDeathVerdict when it was tried.
+//
+// EVERY ERROR CLASS, not just process death. A transcript-derived failure is the
+// reporter's own case, has no verdict of its own in the new process, and was the
+// one being deleted five seconds after each restart.
+//
+// CALLED AFTER ClassifyState, WHICH IS THE GATE. If the transcript grew while
+// the daemon was down and the tailer's clearing rule fired, RefreshMetrics
+// returns no error, the classifier moves the row off `error`, and this registers
+// nothing — so a recovered session is not shielded from the reaper for twelve
+// hours. It is also what keeps a provisional process-death hold that Overlay
+// judged NOT a crash from being retained: the hold never applied, so the row
+// classifies away from `error` and never reaches the registration.
+func (d *SessionDetector) seedRetainRestoredError(state *session.SessionState, persisted *session.SessionError) {
+	if persisted == nil || state.State != session.StateError {
+		return
+	}
+	d.restoreErrorRetention(state.SessionID, time.Unix(state.UpdatedAt, 0))
+}
+
+// restoreErrorRetention re-registers a retention entry for a verdict a PREVIOUS
+// daemon run made, stamped with when that daemon made it rather than with now,
+// so the window continues instead of restarting.
+//
+// Separate from markProcessDeathVerdict, which stamps nowFn() and is the right
+// thing for a verdict being made for the first time. Collapsing the two would
+// silently convert every restart into a window extension — on a machine that
+// reboots daily the twelve-hour ceiling would never be reached at all.
+//
+// Set-once: an entry this process already holds is authoritative over a
+// persisted timestamp, so a re-seed cannot rewind a live verdict.
+func (d *SessionDetector) restoreErrorRetention(sessionID string, at time.Time) {
+	d.processDeathMu.Lock()
+	defer d.processDeathMu.Unlock()
+	if d.processDeathVerdicts == nil {
+		d.processDeathVerdicts = make(map[string]time.Time)
+	}
+	if _, exists := d.processDeathVerdicts[sessionID]; exists {
+		return
+	}
+	d.processDeathVerdicts[sessionID] = at
 }
 
 // seedBackfillMetadata fills ProjectName / CWD / GitBranch for sessions that

--- a/core/cmd/irrlichd/error_survives_restart_live_daemon_test.go
+++ b/core/cmd/irrlichd/error_survives_restart_live_daemon_test.go
@@ -1,0 +1,365 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"irrlicht/core/adapters/inbound/agents/claudecode"
+	"irrlicht/core/adapters/outbound/filesystem"
+	"irrlicht/core/domain/permission"
+	"irrlicht/core/domain/session"
+)
+
+// terminalAPIErrorTranscript is a claudecode transcript whose last line is the
+// give-up shape: an `assistant` message flagged `isApiErrorMessage:true`.
+//
+// Modelled on the committed recording
+// replaydata/agents/claudecode/scenarios/2-23_provider-overloaded-terminal/,
+// which is the same failure #1815's reporter drove live (a 529 that never
+// recovers). Trimmed to the fields claudecode's parser actually reads —
+// terminalAPIError gates on the isApiErrorMessage VALUE and takes Message from
+// the assistant text — so the fixture cannot drift into asserting on fields
+// nothing consumes.
+//
+// The gate is on the value rather than the field's presence, so the `false`
+// line here is not filler: it is the shape that must NOT turn a session red,
+// sitting in the same file as the one that must.
+const terminalAPIErrorTranscript = `{"type":"user","uuid":"11111111-1111-1111-1111-111111111111","timestamp":"2026-08-25T10:33:00.000Z","message":{"role":"user","content":"summarise the repo"},"cwd":"/tmp/irrlicht-1815","session_id":"SESSION_ID"}
+{"type":"assistant","uuid":"22222222-2222-2222-2222-222222222222","timestamp":"2026-08-25T10:33:10.000Z","message":{"role":"assistant","model":"claude-opus-4-6","content":[{"type":"text","text":"Working on it."}],"usage":{"input_tokens":10,"output_tokens":5}},"isApiErrorMessage":false,"session_id":"SESSION_ID"}
+{"type":"assistant","uuid":"33333333-3333-3333-3333-333333333333","timestamp":"2026-08-25T10:33:23.706Z","message":{"role":"assistant","model":"<synthetic>","stop_reason":"stop_sequence","content":[{"type":"text","text":"API Error: Repeated 529 Overloaded errors. The API is at capacity — this is usually temporary."}],"usage":{"input_tokens":0,"output_tokens":0}},"error":"server_error","isApiErrorMessage":true,"apiErrorStatus":529,"session_id":"SESSION_ID"}
+`
+
+// midTurnTranscript ends with an OPEN tool call — an assistant `tool_use` with
+// no matching `tool_result`. That is what an agent's transcript looks like when
+// its process dies mid-turn, and it is the shape the dead-process case needs:
+// the transcript alone reads as work still in flight, so restoring only the
+// persisted SessionError would not be enough to keep the session red. The
+// classifier's process_death rule outranks the transcript-tier rules precisely
+// so a frozen transcript like this one cannot repaint a dead session, and that
+// rule reads a flag only a re-placed hold can set.
+const midTurnTranscript = `{"type":"user","uuid":"44444444-4444-4444-4444-444444444444","timestamp":"2026-08-25T10:40:00.000Z","message":{"role":"user","content":"refactor the parser"},"cwd":"/tmp/irrlicht-1815","session_id":"SESSION_ID"}
+{"type":"assistant","uuid":"55555555-5555-5555-5555-555555555555","timestamp":"2026-08-25T10:40:05.000Z","message":{"role":"assistant","model":"claude-opus-4-6","content":[{"type":"tool_use","id":"toolu_1815","name":"Edit","input":{"file_path":"/tmp/irrlicht-1815/parser.go"}}],"usage":{"input_tokens":12,"output_tokens":8}},"session_id":"SESSION_ID"}
+`
+
+// TestErrorStateSurvivesDaemonRestart is #1815's acceptance shape, run against a
+// real irrlichd on an ephemeral port under temp dirs: drive a session into
+// `error`, restart the daemon on the SAME state dir, assert it STILL reads
+// `error`.
+//
+// TWO CASES, AND THE DIFFERENCE BETWEEN THEM IS THE WHOLE POINT. #1815 names two
+// independent mechanisms with the same user-visible outcome, and exactly one
+// fact separates them — whether the agent process is alive across the restart:
+//
+//   - alive: the row survives every startup sweep (isStartupZombie's dead-PID
+//     predicate is false), and what is lost is the VERDICT. The tailer's sticky
+//     sessionError was in-memory only, so the second daemon re-classified off a
+//     frozen transcript and landed on ready. This is the mechanism the reporter
+//     reproduced live at 6e646c7c.
+//   - dead: the row itself is DELETED, by either of the two startup dead-PID
+//     deleters, before anything can look at it. The reporter's run deliberately
+//     did not cover this one and asked for it to be run rather than assumed.
+//
+// Both drive the FIRST daemon into `error` off a real transcript rather than
+// seeding the verdict, so the ledger under test is written by the daemon itself.
+// The lifetime-1 assertion is therefore also the vacuity guard: if the
+// transcript stopped producing an error, this test fails there and says so,
+// instead of passing lifetime 2 against a session that was never red.
+func TestErrorStateSurvivesDaemonRestart(t *testing.T) {
+	bin := buildIrrlichd(t)
+
+	// MECHANISM 1 — the in-memory sticky error. Two daemon lifetimes: the first
+	// produces the verdict off the transcript (and writes the ledger the fix
+	// turns on), the second must still report it.
+	t.Run("agent process alive across the restart", func(t *testing.T) {
+		homeDir := t.TempDir()
+		stateDir := shortTempDir(t)
+		seedGrantedTranscriptsConsent(t, stateDir)
+
+		sessionID := "e5f1a2b3-1815-4c5d-8e9f-a0b1c2d3e4f5"
+		transcript := writeTranscript(t, t.TempDir(), sessionID, terminalAPIErrorTranscript)
+
+		// State `working` on purpose: the FIRST daemon has to produce the verdict
+		// itself off the transcript, or the ledger this issue is about is never
+		// written and lifetime 2 would be asserting against a hand-seeded value.
+		seedPersistedSession(t, stateDir, &session.SessionState{
+			SessionID:      sessionID,
+			Adapter:        claudecode.AdapterName,
+			State:          session.StateWorking,
+			PID:            liveProcessPIDForRestart(t),
+			TranscriptPath: transcript,
+			CWD:            filepath.Dir(transcript),
+			FirstSeen:      time.Now().Unix(),
+			UpdatedAt:      time.Now().Unix(),
+		})
+
+		d := bootSmokeDaemonIn(t, bin, homeDir, stateDir)
+
+		// Vacuity guard AND precondition: the first daemon must actually reach
+		// `error`. Polled rather than slept — the seed runs inside
+		// SessionDetector.Run, which starts AFTER the addr file is published, so
+		// waitForAddr returning says nothing about whether the seed has run.
+		if !pollUntil(t, 15*time.Second, 25*time.Millisecond, func() bool {
+			return liveSessionState(t, d.addr, sessionID) == session.StateError
+		}) {
+			t.Fatalf("first daemon never classified %s as %s (got %q) — the transcript stopped "+
+				"producing a session error, so nothing below would test a restart",
+				sessionID, session.StateError, liveSessionState(t, d.addr, sessionID))
+		}
+
+		d.shutdown(t)
+
+		d2 := bootSmokeDaemonIn(t, bin, homeDir, stateDir)
+		defer d2.shutdown(t)
+		requireSessionState(t, d2.addr, sessionID, session.StateError)
+		holdSessionState(t, d2.addr, sessionID, session.StateError, 8*time.Second)
+	})
+
+	// MECHANISM 2 — the startup sweeps deleting exactly these rows. ONE daemon
+	// lifetime, because the seeded row IS the previous daemon's output: this is
+	// byte-for-byte what retainAsProcessDeath persists when an agent dies
+	// mid-turn (StateError, the dead PID still recorded, a process_death
+	// SessionError on the metrics). Booting a daemon against it IS the restart.
+	//
+	// The reporter's live run deliberately did not cover this case and asked for
+	// it to be run rather than assumed.
+	// BOTH ERROR CLASSES, because they are rescued by different halves of the fix
+	// and only one of them was covered at first. A process_death row is retained
+	// by its own re-registered verdict; a transcript-derived one (the reporter's
+	// actual 529) has no verdict of its own in the new process, and used to fall
+	// through the periodic sweep's diedMidTurn check and be deleted five seconds
+	// after the restart — invisible to a test that stopped at the first poll.
+	for _, tc := range []struct {
+		name       string
+		errClass   string
+		errMessage string
+	}{
+		{"process death", session.ErrorClassProcessDeath, "agent process exited mid-turn — process watcher"},
+		{"provider error", "rate_limit_error", "API Error: Repeated 529 Overloaded errors."},
+	} {
+		t.Run("agent process dead across the restart ("+tc.name+")", func(t *testing.T) {
+			homeDir := t.TempDir()
+			stateDir := shortTempDir(t)
+			seedGrantedTranscriptsConsent(t, stateDir)
+
+			sessionID := "c4d5e6f7-1815-4a1b-9c2d-3e4f5a6b7c8d"
+			transcript := writeTranscript(t, t.TempDir(), sessionID, midTurnTranscript)
+			deadPID := deadPIDForRestart(t)
+
+			seedPersistedSession(t, stateDir, &session.SessionState{
+				SessionID:      sessionID,
+				Adapter:        claudecode.AdapterName,
+				State:          session.StateError,
+				PID:            deadPID,
+				TranscriptPath: transcript,
+				CWD:            filepath.Dir(transcript),
+				FirstSeen:      time.Now().Unix(),
+				UpdatedAt:      time.Now().Unix(),
+				Metrics: &session.SessionMetrics{
+					SessionError: &session.SessionError{
+						Phase:   session.ErrorPhaseTerminal,
+						Class:   tc.errClass,
+						Message: tc.errMessage + " (pid " + strconv.Itoa(deadPID) + ")",
+					},
+				},
+			})
+
+			d := bootSmokeDaemonIn(t, bin, homeDir, stateDir)
+			defer d.shutdown(t)
+			requireSessionState(t, d.addr, sessionID, session.StateError)
+			// Past at least one liveness-sweep tick — see holdSessionState.
+			holdSessionState(t, d.addr, sessionID, session.StateError, 8*time.Second)
+		})
+	}
+}
+
+// requireSessionState polls the running daemon until sessionID reports want, and
+// fails with what it actually saw and how long it waited.
+//
+// Polls the SUBJECT — the verdict the daemon reports for this session — rather
+// than a side effect on the way in, and never sleeps: a wrong answer here is
+// stable (the session settles green, or the row is gone and stays gone), so the
+// deadline is the whole cost on the failing path.
+func requireSessionState(t *testing.T, addr, sessionID, want string) {
+	t.Helper()
+	started := time.Now()
+	var got string
+	ok := pollUntil(t, 10*time.Second, 25*time.Millisecond, func() bool {
+		got = liveSessionState(t, addr, sessionID)
+		return got == want
+	})
+	if !ok {
+		t.Fatalf("after a daemon restart session %s reads %q, want %q (polled %v) — "+
+			"#1815: the error verdict did not survive the restart",
+			sessionID, got, want, time.Since(started).Round(time.Millisecond))
+	}
+}
+
+// holdSessionState requires that sessionID keeps reading want for the whole of
+// d, rather than merely reaching it once.
+//
+// SURVIVING STARTUP IS NOT SURVIVING. requireSessionState returns on the first
+// matching poll, which for the dead-process case happened in ~30ms — before the
+// periodic liveness sweep had ticked even once. That sweep is a SEPARATE deleter
+// from the two startup ones, and it took the rescued row about five seconds
+// later; the test was green throughout, because the failure lives entirely in
+// the window after the first successful poll. The hold has to outlast at least
+// one sweep interval for "it survived the restart" to mean anything.
+func holdSessionState(t *testing.T, addr, sessionID, want string, d time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(d)
+	started := time.Now()
+	for time.Now().Before(deadline) {
+		if got := liveSessionState(t, addr, sessionID); got != want {
+			t.Fatalf("session %s held %q for only %v before flipping to %q (wanted %q for %v) — "+
+				"#1815: the row survived startup and was taken by a later sweep",
+				sessionID, want, time.Since(started).Round(time.Millisecond), got, want, d)
+		}
+		time.Sleep(150 * time.Millisecond)
+	}
+}
+
+// liveSessionState asks the RUNNING daemon what state it currently reports for
+// one session, or "<absent>" when the session is not in the list at all.
+//
+// Absent and green are DIFFERENT failures — #1815's two mechanisms produce one
+// each — so they must not collapse into the same string. A caller that saw
+// "<absent>" learns the row was deleted (the startup sweep); one that saw
+// "ready" learns the row survived and the verdict did not.
+func liveSessionState(t *testing.T, addr, sessionID string) string {
+	t.Helper()
+	resp, err := http.Get("http://" + addr + "/api/v1/sessions")
+	if err != nil {
+		t.Fatalf("GET /api/v1/sessions: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET /api/v1/sessions: status %d", resp.StatusCode)
+	}
+	// Decoded generically and walked recursively rather than through the typed
+	// response: the payload is a TREE (groups nest groups, agents nest
+	// children) and session.Agent embeds *SessionState inline, so a typed walk
+	// would have to re-encode that nesting and would go quietly blind to a
+	// session parked one level deeper than it expected.
+	var payload any
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode /api/v1/sessions: %v", err)
+	}
+	if st, found := findSessionState(payload, sessionID); found {
+		return st
+	}
+	return "<absent>"
+}
+
+// findSessionState walks an arbitrarily nested decoded JSON payload for the
+// object carrying session_id == want, and returns its `state`.
+func findSessionState(node any, want string) (string, bool) {
+	switch n := node.(type) {
+	case map[string]any:
+		if id, _ := n["session_id"].(string); id == want {
+			st, _ := n["state"].(string)
+			return st, true
+		}
+		for _, v := range n {
+			if st, ok := findSessionState(v, want); ok {
+				return st, true
+			}
+		}
+	case []any:
+		for _, v := range n {
+			if st, ok := findSessionState(v, want); ok {
+				return st, true
+			}
+		}
+	}
+	return "", false
+}
+
+// seedGrantedTranscriptsConsent grants Claude Code's observe-kind permission, so
+// the daemon under test actually reads the seeded transcript.
+//
+// Without it every assertion here would be vacuous in the quietest possible
+// way: a fresh IRRLICHT_HOME leaves every permission PENDING, seedReevaluateStates
+// is consent-gated per adapter, and an un-consented session is simply left
+// persisted as-is — so the test would pass while the daemon monitored nothing.
+//
+// Written through the daemon's own store rather than as a JSON literal, for the
+// reason seedGrantedHooksConsent states: the on-disk shape belongs to
+// filesystem.PermissionStore and is documented as bumpable.
+func seedGrantedTranscriptsConsent(t *testing.T, stateDir string) {
+	t.Helper()
+	set := permission.Set{}
+	set.Put(claudecode.AdapterName, claudecode.PermissionKeyTranscripts, permission.StateGranted)
+	if err := filesystem.NewPermissionStore(stateDir).Save(set); err != nil {
+		t.Fatalf("seed permissions store in %s: %v", stateDir, err)
+	}
+}
+
+// seedPersistedSession writes one session row into the state dir the daemon will
+// boot against, standing in for what a previous daemon run left behind.
+//
+// Through filesystem.SessionRepository rather than a hand-written
+// <id>.json, on seedGrantedHooksConsent's argument: the filename convention and
+// the record's shape belong to that type.
+func seedPersistedSession(t *testing.T, stateDir string, state *session.SessionState) {
+	t.Helper()
+	repo := filesystem.NewWithDir(filepath.Join(stateDir, "instances"))
+	if err := repo.Save(state); err != nil {
+		t.Fatalf("seed session %s: %v", state.SessionID, err)
+	}
+}
+
+// writeTranscript writes one of this file's fixture transcripts into dir under
+// sessionID's name, substituting the session id, and returns its path.
+func writeTranscript(t *testing.T, dir, sessionID, fixture string) string {
+	t.Helper()
+	path := filepath.Join(dir, sessionID+".jsonl")
+	body := strings.ReplaceAll(fixture, "SESSION_ID", sessionID)
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("write transcript %s: %v", path, err)
+	}
+	return path
+}
+
+// liveProcessPIDForRestart returns the PID of a child that stays alive for the
+// whole test — the "agent still running" half of #1815's split.
+func liveProcessPIDForRestart(t *testing.T) int {
+	t.Helper()
+	cmd := exec.Command("sleep", "120")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start sleep: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+	})
+	return cmd.Process.Pid
+}
+
+// deadPIDForRestart spawns and reaps a process, returning a PID known to be
+// dead — the "agent gone" half of #1815's split, and the case its reporter
+// explicitly left unrun.
+//
+// Skips rather than guesses if the kernel recycles the PID before we can
+// confirm it: a recycled PID is alive, which would silently convert this into a
+// second copy of the live case.
+func deadPIDForRestart(t *testing.T) int {
+	t.Helper()
+	cmd := exec.Command("true")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start true: %v", err)
+	}
+	pid := cmd.Process.Pid
+	_ = cmd.Wait()
+	if err := syscall.Kill(pid, 0); err == nil {
+		t.Skipf("dead PID %d was recycled before the test could observe it", pid)
+	}
+	return pid
+}

--- a/core/cmd/irrlichd/error_survives_restart_live_daemon_test.go
+++ b/core/cmd/irrlichd/error_survives_restart_live_daemon_test.go
@@ -14,7 +14,6 @@ import (
 
 	"irrlicht/core/adapters/inbound/agents/claudecode"
 	"irrlicht/core/adapters/outbound/filesystem"
-	"irrlicht/core/domain/permission"
 	"irrlicht/core/domain/session"
 )
 
@@ -79,6 +78,11 @@ func TestErrorStateSurvivesDaemonRestart(t *testing.T) {
 	// produces the verdict off the transcript (and writes the ledger the fix
 	// turns on), the second must still report it.
 	t.Run("agent process alive across the restart", func(t *testing.T) {
+		// Each subtest owns its HOME, its IRRLICHT_HOME (and so its unix socket
+		// path), and an ephemeral TCP port, so the three are independent. Run
+		// concurrently: each spends 8s doing nothing but holding an invariant,
+		// and serialising that is ~15s of pure wall clock on every CI run.
+		t.Parallel()
 		homeDir := t.TempDir()
 		stateDir := shortTempDir(t)
 		seedGrantedTranscriptsConsent(t, stateDir)
@@ -145,6 +149,7 @@ func TestErrorStateSurvivesDaemonRestart(t *testing.T) {
 		{"provider error", "rate_limit_error", "API Error: Repeated 529 Overloaded errors."},
 	} {
 		t.Run("agent process dead across the restart ("+tc.name+")", func(t *testing.T) {
+			t.Parallel()
 			homeDir := t.TempDir()
 			stateDir := shortTempDir(t)
 			seedGrantedTranscriptsConsent(t, stateDir)
@@ -235,7 +240,12 @@ func holdSessionState(t *testing.T, addr, sessionID, want string, d time.Duratio
 // "ready" learns the row survived and the verdict did not.
 func liveSessionState(t *testing.T, addr, sessionID string) string {
 	t.Helper()
-	resp, err := http.Get("http://" + addr + "/api/v1/sessions")
+	// Its own client rather than http.DefaultClient: smokeDaemon.shutdown calls
+	// http.DefaultClient.CloseIdleConnections(), which is process-global, so
+	// under t.Parallel one subtest's teardown would drop the others' idle
+	// keep-alives. Harmless (they redial) but a coupling worth not having.
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Get("http://" + addr + "/api/v1/sessions")
 	if err != nil {
 		t.Fatalf("GET /api/v1/sessions: %v", err)
 	}
@@ -289,17 +299,9 @@ func findSessionState(node any, want string) (string, bool) {
 // way: a fresh IRRLICHT_HOME leaves every permission PENDING, seedReevaluateStates
 // is consent-gated per adapter, and an un-consented session is simply left
 // persisted as-is — so the test would pass while the daemon monitored nothing.
-//
-// Written through the daemon's own store rather than as a JSON literal, for the
-// reason seedGrantedHooksConsent states: the on-disk shape belongs to
-// filesystem.PermissionStore and is documented as bumpable.
 func seedGrantedTranscriptsConsent(t *testing.T, stateDir string) {
 	t.Helper()
-	set := permission.Set{}
-	set.Put(claudecode.AdapterName, claudecode.PermissionKeyTranscripts, permission.StateGranted)
-	if err := filesystem.NewPermissionStore(stateDir).Save(set); err != nil {
-		t.Fatalf("seed permissions store in %s: %v", stateDir, err)
-	}
+	seedGrantedConsent(t, stateDir, claudecode.PermissionKeyTranscripts)
 }
 
 // seedPersistedSession writes one session row into the state dir the daemon will

--- a/core/cmd/irrlichd/uninstall_hooks_live_daemon_test.go
+++ b/core/cmd/irrlichd/uninstall_hooks_live_daemon_test.go
@@ -226,14 +226,26 @@ func waitForAddrFileTight(t *testing.T, addrPath string, deadline time.Time) {
 // re-verification loop watching them.
 func seedGrantedHooksConsent(t *testing.T, stateDir string) {
 	t.Helper()
-	// Through the daemon's own store, not a hand-written JSON literal: the
-	// on-disk shape (the filename, the version field, the nesting) belongs to
-	// filesystem.PermissionStore and is documented as bumpable. A literal here
-	// would keep parsing as valid-but-empty after such a bump, and the test
-	// would then fail at its vacuity guard complaining about hook entries
-	// rather than about the schema.
+	seedGrantedConsent(t, stateDir, claudecode.PermissionKeyHooks)
+}
+
+// seedGrantedConsent writes a permissions.json granting one Claude Code
+// permission, for a daemon that is about to boot against stateDir.
+//
+// Through the daemon's own store, not a hand-written JSON literal: the on-disk
+// shape (the filename, the version field, the nesting) belongs to
+// filesystem.PermissionStore and is documented as bumpable. A literal here would
+// keep parsing as valid-but-empty after such a bump, and the caller would then
+// fail at its vacuity guard complaining about the thing it seeded rather than
+// about the schema.
+//
+// One helper rather than one per key: Save replaces the whole set, so the three
+// live-daemon tests that need this were three byte-identical copies differing
+// only in a constant.
+func seedGrantedConsent(t *testing.T, stateDir, key string) {
+	t.Helper()
 	set := permission.Set{}
-	set.Put(claudecode.AdapterName, claudecode.PermissionKeyHooks, permission.StateGranted)
+	set.Put(claudecode.AdapterName, key, permission.StateGranted)
 	if err := filesystem.NewPermissionStore(stateDir).Save(set); err != nil {
 		t.Fatalf("seed permissions store in %s: %v", stateDir, err)
 	}

--- a/core/cmd/irrlichd/uninstall_task_eta_live_daemon_test.go
+++ b/core/cmd/irrlichd/uninstall_task_eta_live_daemon_test.go
@@ -247,11 +247,7 @@ func runUninstallTaskEta(t *testing.T, bin, homeDir, stateDir string) {
 // filesystem.PermissionStore and is documented as bumpable.
 func seedGrantedInstructionsConsent(t *testing.T, stateDir string) {
 	t.Helper()
-	set := permission.Set{}
-	set.Put(claudecode.AdapterName, claudecode.PermissionKeyInstructions, permission.StateGranted)
-	if err := filesystem.NewPermissionStore(stateDir).Save(set); err != nil {
-		t.Fatalf("seed permissions store in %s: %v", stateDir, err)
-	}
+	seedGrantedConsent(t, stateDir, claudecode.PermissionKeyInstructions)
 }
 
 // seedUserAuthoredCLAUDEMd writes prose the user owns into the temp HOME's

--- a/core/domain/session/metrics.go
+++ b/core/domain/session/metrics.go
@@ -381,23 +381,28 @@ type SessionMetrics struct {
 	// An error would resurrect on every later pass and no session could ever
 	// leave StateError.
 	//
-	// DOES NOT SURVIVE A DAEMON RESTART, and the json tag does not change that.
-	// The value is persisted, but the startup path destroys it before anything
-	// reads it: seedReevaluateOne calls enricher.RefreshMetrics first, which is
-	// MergeMetrics against a fresh tailer pass carrying nil, and the line in
-	// newMergedMetrics copies that nil verbatim — the same behaviour
-	// TestMergeMetrics_ClearedSessionErrorStaysCleared locks in. So a session
-	// that died on a provider error reads GREEN after a restart, which is the
-	// silent direction this state exists to eliminate.
+	// SURVIVES A DAEMON RESTART SINCE #1815, and NOT because of the json tag —
+	// that was always here and was never sufficient. The value was persisted and
+	// then destroyed before anything read it: seedReevaluateOne calls
+	// enricher.RefreshMetrics first, which is MergeMetrics against a fresh tailer
+	// pass carrying nil, and the line in newMergedMetrics copies that nil
+	// verbatim — the same behaviour TestMergeMetrics_ClearedSessionErrorStaysCleared
+	// locks in. A session that died on a provider error read GREEN after a
+	// restart, which is the silent direction this state exists to eliminate.
 	//
-	// That is a real gap, recorded here rather than glossed: the fix is to
-	// persist the sticky error in the tailer's LedgerState, exactly as
+	// RefreshMetrics still merges against a fresh pass, and that copier is
+	// unchanged. What changed is what the fresh pass CARRIES: the tailer now
+	// persists its sticky error in LedgerState.SessionError, exactly as
 	// LastTaskEstimate/FirstTaskEstimate are persisted there and for the
-	// identical reason ("a daemon restart would otherwise blank the ETA chip").
-	// Deliberately not built in this phase — no adapter emits this field yet,
-	// so there is nothing to lose across a restart until #1799/#1800 land, and
-	// that is where the first producer and the first real evidence arrive
-	// together.
+	// identical reason ("a daemon restart would otherwise blank the ETA chip"),
+	// so the merge sees the real verdict instead of a nil.
+	//
+	// THAT ROUTE COVERS THE TRANSCRIPT-DERIVED HALF ONLY. A process-death verdict
+	// is synthesized by the daemon from the OS view of the process, never written
+	// to any transcript, so no ledger can reconstruct it — seedRestoreErrorVerdict
+	// re-places its hold from the persisted row instead. Both halves also depend
+	// on the row still existing at seed time, which is retainedErrorAcrossRestart's
+	// job. Three pieces, one guarantee; see #1815 for why it took all three.
 	SessionError *SessionError `json:"session_error,omitempty"`
 
 	// ProcessDeath is true when the agent PROCESS went away while a turn was

--- a/core/pkg/tailer/ledger_session_error_test.go
+++ b/core/pkg/tailer/ledger_session_error_test.go
@@ -47,12 +47,10 @@ func TestLedger_SessionErrorSurvivesRestart(t *testing.T) {
 	// Every numeric field is a pointer precisely because absence and zero are
 	// different facts, so the round-trip has to preserve the distinction rather
 	// than just the struct.
-	assertIntPtr(t, "HTTPStatus", got.HTTPStatus, status)
-	assertIntPtr(t, "Attempt", got.Attempt, attempt)
-	assertIntPtr(t, "MaxAttempts", got.MaxAttempts, maxAttempts)
-	if got.RetryIn == nil || *got.RetryIn != retryIn {
-		t.Errorf("RetryIn = %v, want %v — the fractional retry delay did not round-trip", got.RetryIn, retryIn)
-	}
+	assertPtr(t, "HTTPStatus", got.HTTPStatus, status)
+	assertPtr(t, "Attempt", got.Attempt, attempt)
+	assertPtr(t, "MaxAttempts", got.MaxAttempts, maxAttempts)
+	assertPtr(t, "RetryIn", got.RetryIn, retryIn)
 }
 
 // TestLedger_ClearedSessionErrorStaysCleared is a LOCK, not a defect test: it
@@ -121,20 +119,36 @@ func restartThroughLedger(t *testing.T, src *TranscriptTailer) *TranscriptTailer
 	return dst
 }
 
-func assertIntPtr(t *testing.T, name string, got *int, want int) {
+// assertPtr checks an optional field by what it points AT, and reports a nil
+// distinctly from a wrong value.
+//
+// Generic over the pointed-to type so RetryIn (*time.Duration) gets the same
+// "an absent number is not a zero one" message as the three *int fields, rather
+// than an inline comparison on the one field where the distinction is least
+// obvious.
+func assertPtr[T comparable](t *testing.T, name string, got *T, want T) {
 	t.Helper()
 	if got == nil {
-		t.Errorf("%s = nil, want %d — an absent number is not the same fact as a zero one", name, want)
+		t.Errorf("%s = nil, want %v — an absent value is not the same fact as a zero one", name, want)
 		return
 	}
 	if *got != want {
-		t.Errorf("%s = %d, want %d", name, *got, want)
+		t.Errorf("%s = %v, want %v", name, *got, want)
 	}
 }
 
-// newLedgerTestTailer builds the minimum TranscriptTailer the ledger paths
-// touch. GetLedgerState and SetLedgerState both read and write t.metrics, so a
-// bare &TranscriptTailer{} nil-derefs — the zero value is not a usable tailer.
+// newLedgerTestTailer builds a tailer through the package's real constructor,
+// as every sibling ledger test does.
+//
+// NOT a &TranscriptTailer{metrics: &SessionMetrics{}} literal, which is enough
+// to make these tests pass today and is the wrong shape: NewTranscriptTailer
+// also initialises openToolCalls, openPermissions, openBackgroundProcs,
+// pendingBashPolls, pendingTaskCreates, cumByModel and windowSize. A ledger
+// test asserting round-trip fidelity against a tailer the daemon never
+// constructs is one field away from a nil-map panic or a false green — in the
+// one file whose whole job is ledger fidelity.
+//
+// The path is never opened: none of these tests call TailAndProcess.
 func newLedgerTestTailer() *TranscriptTailer {
-	return &TranscriptTailer{metrics: &SessionMetrics{}}
+	return newTestTailer("/nonexistent/ledger-test.jsonl")
 }

--- a/core/pkg/tailer/ledger_session_error_test.go
+++ b/core/pkg/tailer/ledger_session_error_test.go
@@ -1,0 +1,140 @@
+package tailer
+
+import (
+	"encoding/json"
+	"strconv"
+	"testing"
+	"time"
+)
+
+// TestLedger_SessionErrorSurvivesRestart is #1815's tailer-side regression test:
+// the sticky session-level failure must be carried through a daemon restart,
+// because the post-restart pass reads ZERO new transcript bytes and therefore
+// cannot re-derive it.
+//
+// Simulates the restart the way the daemon performs it — GetLedgerState from the
+// dying tailer, JSON round-trip through the on-disk ledger, SetLedgerState into a
+// brand-new tailer — rather than by copying a struct field, so a field that
+// serialises but does not deserialise (or vice versa) is caught. That
+// one-directional failure is exactly what session.SessionError's own
+// UnmarshalJSON exists to prevent, and it is invisible to an in-memory copy.
+func TestLedger_SessionErrorSurvivesRestart(t *testing.T) {
+	retryIn := 616*time.Millisecond + 452*time.Microsecond
+	attempt, maxAttempts, status := 3, 10, 529
+
+	before := newLedgerTestTailer()
+	before.sessionError = &SessionError{
+		Phase:       ErrorPhaseRetrying,
+		Class:       "rate_limit_error",
+		Message:     "Repeated 529 Overloaded errors.",
+		HTTPStatus:  &status,
+		Attempt:     &attempt,
+		MaxAttempts: &maxAttempts,
+		RetryIn:     &retryIn,
+	}
+
+	after := restartThroughLedger(t, before)
+
+	got := after.sessionError
+	if got == nil {
+		t.Fatalf("the sticky session error did not survive the ledger round-trip — " +
+			"#1815: a restarted daemon re-classifies the session off a frozen transcript and reads green")
+	}
+	if got.Phase != ErrorPhaseRetrying || got.Class != "rate_limit_error" ||
+		got.Message != "Repeated 529 Overloaded errors." {
+		t.Errorf("verdict changed across the restart: got %+v", got)
+	}
+	// Every numeric field is a pointer precisely because absence and zero are
+	// different facts, so the round-trip has to preserve the distinction rather
+	// than just the struct.
+	assertIntPtr(t, "HTTPStatus", got.HTTPStatus, status)
+	assertIntPtr(t, "Attempt", got.Attempt, attempt)
+	assertIntPtr(t, "MaxAttempts", got.MaxAttempts, maxAttempts)
+	if got.RetryIn == nil || *got.RetryIn != retryIn {
+		t.Errorf("RetryIn = %v, want %v — the fractional retry delay did not round-trip", got.RetryIn, retryIn)
+	}
+}
+
+// TestLedger_ClearedSessionErrorStaysCleared is a LOCK, not a defect test: it
+// passes before #1815 by construction, and pins the half of the clearing rule
+// that persistence could most easily break.
+//
+// A nil sticky error means the session RECOVERED. If the ledger treated nil as
+// "nothing to say" and carried the previous value forward instead, a recovered
+// session would come back red after every restart — the mirror-image bug, and the
+// one SessionMetrics.SessionError's doc warns a carry-forward helper would cause.
+func TestLedger_ClearedSessionErrorStaysCleared(t *testing.T) {
+	before := newLedgerTestTailer()
+	before.sessionError = nil
+
+	if got := restartThroughLedger(t, before).sessionError; got != nil {
+		t.Errorf("a cleared session error came back as %+v after a restart — "+
+			"nil must persist as nil, or recovery never survives a restart", got)
+	}
+}
+
+// TestLedger_PreFieldLedgerRehydratesToNoError pins the no-schema-bump decision:
+// a ledger written before #1815 simply lacks the key, and must rehydrate to the
+// exact pre-fix behaviour rather than failing to load.
+//
+// This is what makes the additive field safe without discarding every live
+// session's ledger — the claim LedgerState.SessionError's doc makes, asserted
+// against a real pre-field payload rather than left as prose.
+func TestLedger_PreFieldLedgerRehydratesToNoError(t *testing.T) {
+	// A ledger body with no session_error key at all — what every ledger on
+	// disk looks like today.
+	raw := []byte(`{"schema_version":` + strconv.Itoa(LedgerSchemaVersion) + `,"last_offset":4096,"last_event_type":"assistant"}`)
+
+	var s LedgerState
+	if err := json.Unmarshal(raw, &s); err != nil {
+		t.Fatalf("a pre-#1815 ledger no longer parses: %v", err)
+	}
+	if s.SessionError != nil {
+		t.Errorf("SessionError = %+v, want nil for a ledger written before the field existed", s.SessionError)
+	}
+
+	after := newLedgerTestTailer()
+	after.SetLedgerState(s)
+	if after.sessionError != nil {
+		t.Errorf("rehydrated sticky error = %+v, want nil", after.sessionError)
+	}
+	if after.lastOffset != 4096 {
+		t.Errorf("lastOffset = %d, want 4096 — the rest of the ledger must still load", after.lastOffset)
+	}
+}
+
+// restartThroughLedger puts src's durable state through the same three steps the
+// daemon performs across a restart — capture, serialise to the on-disk form and
+// back, rehydrate into a fresh tailer — and returns that fresh tailer.
+func restartThroughLedger(t *testing.T, src *TranscriptTailer) *TranscriptTailer {
+	t.Helper()
+	encoded, err := json.Marshal(src.GetLedgerState())
+	if err != nil {
+		t.Fatalf("marshal ledger: %v", err)
+	}
+	var decoded LedgerState
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		t.Fatalf("unmarshal ledger %s: %v", encoded, err)
+	}
+	dst := newLedgerTestTailer()
+	dst.SetLedgerState(decoded)
+	return dst
+}
+
+func assertIntPtr(t *testing.T, name string, got *int, want int) {
+	t.Helper()
+	if got == nil {
+		t.Errorf("%s = nil, want %d — an absent number is not the same fact as a zero one", name, want)
+		return
+	}
+	if *got != want {
+		t.Errorf("%s = %d, want %d", name, *got, want)
+	}
+}
+
+// newLedgerTestTailer builds the minimum TranscriptTailer the ledger paths
+// touch. GetLedgerState and SetLedgerState both read and write t.metrics, so a
+// bare &TranscriptTailer{} nil-derefs — the zero value is not a usable tailer.
+func newLedgerTestTailer() *TranscriptTailer {
+	return &TranscriptTailer{metrics: &SessionMetrics{}}
+}

--- a/core/pkg/tailer/parser.go
+++ b/core/pkg/tailer/parser.go
@@ -326,14 +326,26 @@ const (
 // Every numeric field is a pointer because the recorded payloads disagree
 // about which numbers exist at all. See session.SessionError for the argument
 // and the fixture evidence.
+// The struct tags exist for ONE consumer: LedgerState.SessionError, which puts
+// this type on disk so an errored session stays red across a daemon restart
+// (#1815). Nothing else marshals it — the adapter glue converts field-by-field
+// into session.SessionError, which owns the CLIENT-facing wire form and its
+// custom retry_in_ms codec. Spelled out here so the two are not mistaken for
+// one contract: this one may be renamed with a ledger schema bump, that one may
+// not.
+//
+// RetryIn is tagged with its unit because a bare Duration marshals as unlabelled
+// nanoseconds, which is the exact complaint session.SessionError.RetryIn's doc
+// makes about its own wire form. Plain int64 nanoseconds round-trip losslessly,
+// so the ledger needs no codec of its own — only an honest key.
 type SessionError struct {
-	Phase       ErrorPhase
-	Class       string
-	Message     string
-	HTTPStatus  *int
-	Attempt     *int
-	MaxAttempts *int
-	RetryIn     *time.Duration
+	Phase       ErrorPhase     `json:"phase,omitempty"`
+	Class       string         `json:"class,omitempty"`
+	Message     string         `json:"message,omitempty"`
+	HTTPStatus  *int           `json:"http_status,omitempty"`
+	Attempt     *int           `json:"attempt,omitempty"`
+	MaxAttempts *int           `json:"max_attempts,omitempty"`
+	RetryIn     *time.Duration `json:"retry_in_ns,omitempty"`
 }
 
 // ClearedByTurnBoundary reports whether a completed turn retires this error
@@ -766,6 +778,39 @@ type LedgerState struct {
 	// existed restores exactly the (inert-guard) behaviour it had when it was
 	// written, and no schema bump is needed to read it.
 	PendingBackgroundAgentCount int `json:"pending_background_agent_count,omitempty"`
+	// SessionError persists the tailer's sticky session-level failure (#1798)
+	// so a DAEMON RESTART keeps an errored session red instead of quietly
+	// re-classifying it green (#1815).
+	//
+	// THIS IS THE FIELD THE RESTART CASE TURNS ON, and its absence was the whole
+	// of the first of that issue's two mechanisms. The sticky error lived only in
+	// TranscriptTailer.sessionError, so a restart rebuilt the tailer with nil;
+	// the post-restart pass resumes at LastOffset and reads ZERO new lines, so
+	// nothing re-derived the failure, and the session settled through agent_done
+	// to `ready` off a transcript frozen at the moment it failed. Measured
+	// against a real restarted daemon before the fix:
+	//
+	//	go test ./core/cmd/irrlichd/ -run TestErrorStateSurvivesDaemonRestart
+	//	  -> reads "ready", want "error"
+	//
+	// Exactly the LastAssistantText (#705) and PendingBackgroundAgentCount
+	// (#1076) heals above, on the same resume-at-EOF pass and for the same
+	// reason: a verdict that cannot be re-derived from zero new bytes has to be
+	// carried, not recomputed.
+	//
+	// NO SCHEMA BUMP, following ResumeFingerprint and PendingWaitingCue: a ledger
+	// written before this field simply lacks it and rehydrates to nil, which is
+	// byte-for-byte the pre-fix behaviour. Discarding every live session's ledger
+	// to force a re-scan would be a far bigger hammer than an additive field
+	// warrants — and a re-scan could not recover the verdict anyway, since
+	// clearSessionErrorOnRecovery would replay the same lines to the same result.
+	//
+	// A CLEARED ERROR IS PERSISTED AS CLEARED. The field stores nil when the
+	// tailer's sticky error is nil, so the clearing rule survives a restart too;
+	// this is a snapshot of the verdict, never a carry-forward that could
+	// resurrect one (see SessionMetrics.SessionError for why that distinction is
+	// load-bearing).
+	SessionError *SessionError `json:"session_error,omitempty"`
 }
 
 // --- Shared helpers used by multiple parsers ---

--- a/core/pkg/tailer/tailer_ledger.go
+++ b/core/pkg/tailer/tailer_ledger.go
@@ -54,6 +54,11 @@ func (t *TranscriptTailer) GetLedgerState() LedgerState {
 	s.LastTaskSummary = t.lastTaskSummary
 	s.FirstUserText = t.firstUserText
 	s.LastTaskQuestion = t.lastTaskQuestion
+	// The sticky session-level failure, so a daemon restart keeps an errored
+	// session red (#1815). Assigned unconditionally — including when it is nil,
+	// which is how the clearing rule says "recovered" — under the same
+	// reassigned-never-mutated argument as the estimate pointers above.
+	s.SessionError = t.sessionError
 	return s
 }
 
@@ -127,6 +132,17 @@ func (t *TranscriptTailer) SetLedgerState(s LedgerState) {
 	t.lastTaskSummary = s.LastTaskSummary
 	t.firstUserText = s.FirstUserText
 	t.lastTaskQuestion = s.LastTaskQuestion
+	// Restore the sticky session-level failure so a resume-at-EOF pass keeps an
+	// errored session in StateError instead of settling it green (#1815).
+	//
+	// Only the private field, deliberately — surfaceSporadicMetrics copies it
+	// onto t.metrics on EVERY pass, above computeMetrics' empty-MessageHistory
+	// early return, exactly as it does for lastPendingWaitingCue and
+	// lastPendingBackgroundAgentCount above. LastAssistantText is the one field
+	// here that also needs the t.metrics half, because its copy lives BELOW that
+	// early return; writing t.metrics.SessionError here as well would add a
+	// second writer to a slot surfaceSporadicMetrics already owns.
+	t.sessionError = s.SessionError
 }
 
 // restoreCumByModel deep-copies a persisted per-model usage breakdown into

--- a/tools/lib/error-retention-mutations_test.sh
+++ b/tools/lib/error-retention-mutations_test.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+# error-retention-mutations_test.sh — the committed mutation fixtures for
+# #1815's error-retention guards.
+#
+# WHY THIS FILE EXISTS. #1815 adds three things that have no "before the fix" to
+# run red: two startup-sweep exemptions and a structural tripwire. Per AGENTS.md
+# and docs/testing-philosophy.md, such a check earns its place only by having
+# been seen to fail when the thing it protects is broken — and "commit that
+# mutation as a fixture rather than only describing it in a PR body nothing
+# re-runs". These mutations were run by hand during #1815 and were correctly
+# red; a hand-run mutation proves the guard worked THAT DAY and nothing after.
+# Here they run on every `tools/preflight.sh --only tools`.
+#
+# WHAT EACH ROW ASSERTS, and why these three:
+#
+#   1. THE REAPER TRIPWIRE, mutated by removing the exemption from a delegate
+#      predicate (reapsIdleTopLevel). This is the case an earlier version of
+#      the tripwire got WRONG: it accepted a hand-typed list of delegate names,
+#      so deleting the guard from a listed predicate left it green — the caller
+#      was still calling a name on the list. The tripwire now derives delegation
+#      from the call graph, and this row is what keeps that true.
+#
+#   2. THE STARTUP SWEEP exemption in isStartupZombie — the deleter #1815 was
+#      filed about.
+#
+#   3. THE SEED-TIME sweep exemption in seedAlivePIDs' PID>0 branch — the
+#      SECOND deleter, which the issue did not name. Exempting only the first
+#      leaves the row to die at this one, so a mutation that only proved (2)
+#      would not have caught shipping (3) unexempted.
+#
+# Rows 2 and 3 are separate on purpose: they fail independently, and a single
+# combined mutation could pass while one of them was missing.
+#
+# Every row drives the real tools/mutate.sh, which owns the mechanics this file
+# must not re-improvise: the stale-anchor guard (an anchor that no longer
+# matches is reported STALE, never a silent no-op — #1390/#1450), the no-op
+# replacement refusal, and the byte-for-byte restore that never touches git
+# state (worktrees share the parent repo's .git dir, so `git checkout --` /
+# `git restore` / `git reset --hard` are banned repo-wide).
+#
+# Convention follows tools/lib/mutate_test.sh: plain bash, hand-rolled asserts,
+# a `fails` counter, "ALL PASS" / "N FAILED" at the end.
+
+set -uo pipefail
+
+DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$DIR/../.." && pwd)"
+MUTATE_SH="$REPO_ROOT/tools/mutate.sh"
+
+# A missing tool is a hard failure, not a skip — exiting 0 here would read as a
+# PASS to preflight's shell_lib_tests, so the gate would go green having
+# asserted nothing.
+need() { command -v "$1" >/dev/null 2>&1 || { echo "FAIL: error-retention-mutations — $1 not found" >&2; exit 1; }; }
+need go
+need git
+
+if [[ ! -x "$MUTATE_SH" ]]; then
+  echo "FAIL: error-retention-mutations — $MUTATE_SH is missing or not executable" >&2
+  exit 1
+fi
+
+# mutate.sh refuses (exit 4) against an already-dirty tree, because its
+# post-restore emptiness check could prove nothing then.
+#
+# A DIRTY TREE MUST NOT SILENTLY PASS. This suite's runner (shell-lib-suite.sh)
+# judges a script by its EXIT STATUS and has no self-skip protocol, so an
+# `exit 0` here would make "the guards were verified" and "the guards could not
+# be checked at all" produce byte-identical results at the gate — the exact
+# shape AGENTS.md forbids, and the same shape as the tripwire blind spot this
+# very fixture exists to prevent regressing.
+#
+# So it is a HARD FAILURE wherever the answer is load-bearing (CI, and any
+# caller that sets MUTATION_FIXTURES_STRICT=1), and a loud, non-silent skip on a
+# developer's dirty worktree, where failing would only train people to delete
+# the fixture. The local skip still prints, and still says what to do.
+if [[ -n "$(git -C "$REPO_ROOT" status --porcelain)" ]]; then
+  echo "error-retention-mutations: CANNOT RUN — the worktree is dirty, and mutate.sh needs a" >&2
+  echo "  clean tree for its post-restore check to mean anything. Commit or clean up, then:" >&2
+  echo "    bash tools/lib/error-retention-mutations_test.sh" >&2
+  if [[ -n "${CI:-}" || -n "${MUTATION_FIXTURES_STRICT:-}" ]]; then
+    echo "  (failing rather than skipping: CI/strict mode, where a skip is indistinguishable" >&2
+    echo "   from a pass and this gate is the only thing re-running these mutations)" >&2
+    exit 1
+  fi
+  echo "  (skipped locally; set MUTATION_FIXTURES_STRICT=1 to make this a failure)" >&2
+  exit 0
+fi
+
+PKG="./core/application/services/"
+fails=0
+
+# assert_mutation_is_red applies one mutation and requires the named test to
+# FAIL under it, and to name `want_match` in its output.
+#
+# Both halves matter. A mutation that leaves the test green means the guard does
+# not reach what it claims to cover. A mutation that goes red for the WRONG
+# reason (a compile error, a different test) would otherwise read as success —
+# so the expected failure text is asserted too, not just the exit status.
+assert_mutation_is_red() {
+  local label="$1" file="$2" anchor="$3" replacement="$4" run="$5" want_match="$6"
+  local out rc
+
+  out="$(cd "$REPO_ROOT" && "$MUTATE_SH" "$file" "$anchor" "$replacement" \
+    go test "$PKG" -run "$run" -count=1 2>&1)"
+  rc=$?
+
+  # mutate.sh exits 0 when the mutation applied and the tree was restored,
+  # WHATEVER the inner test did — the inner result is in the captured text. A
+  # non-zero rc is mutate.sh itself refusing (STALE anchor, dirty tree, ...),
+  # which is a fixture bug, not a finding about the guard.
+  if [[ $rc -ne 0 ]]; then
+    echo "FAIL: $label — mutate.sh refused (exit $rc). A STALE anchor means the code moved and"
+    echo "      this fixture needs its anchor updated; it does NOT mean the guard is fine."
+    echo "$out" | sed 's/^/      | /'
+    fails=$((fails + 1))
+    return
+  fi
+
+  # The mutation must make the test fail...
+  if ! grep -qE '^(FAIL|--- FAIL)' <<<"$out"; then
+    echo "FAIL: $label — the test stayed GREEN under the mutation, so the guard does not reach"
+    echo "      what it claims to protect."
+    echo "$out" | sed 's/^/      | /'
+    fails=$((fails + 1))
+    return
+  fi
+
+  # ...and fail for the RIGHT reason.
+  if ! grep -qF "$want_match" <<<"$out"; then
+    echo "FAIL: $label — the test failed, but not with the expected message."
+    echo "      wanted to find: $want_match"
+    echo "$out" | sed 's/^/      | /'
+    fails=$((fails + 1))
+    return
+  fi
+
+  echo "ok  $label"
+}
+
+# ── 1. The reaper tripwire, via a DELEGATE ───────────────────────────────────
+# Removing the guard from reapsIdleTopLevel leaves sweepStaleSnapshot still
+# calling it, so only a derived delegation relation catches this.
+assert_mutation_is_red \
+  "reaper tripwire catches a guard removed from a delegate predicate" \
+  "core/application/services/pid_manager.go" \
+  $'\tif pm.retainsError(snap.state) {\n\t\treturn false\n\t}\n' \
+  $'\t// mutated by tools/lib/error-retention-mutations_test.sh\n' \
+  'TestEveryReaperConsultsTheErrorExemption|TestStaleSweep_KeepsARetainedErrorRow' \
+  'sweepStaleSnapshot deletes session rows but nothing on its call path consults retainsError'
+
+# ── 2. The startup zombie sweep exemption ────────────────────────────────────
+assert_mutation_is_red \
+  "isStartupZombie exemption is load-bearing" \
+  "core/application/services/pid_manager.go" \
+  $'\tif pm.retainsError(state) {\n\t\treturn false\n\t}\n\tif state.PID > 0 {' \
+  $'\tif state.PID > 0 {' \
+  'TestStartupSweeps_KeepARetainedErrorRow' \
+  'the startup zombie sweep still deletes an errored session with a dead PID'
+
+# ── 3. The seed-time dead-PID exemption (the SECOND deleter) ─────────────────
+assert_mutation_is_red \
+  "seedAlivePIDs exemption is load-bearing, independently of isStartupZombie" \
+  "core/application/services/pid_manager.go" \
+  $'\tif pm.retainsError(state) {\n\t\tpm.log.LogInfo(logComponentSessionDetectorSeed, state.SessionID,' \
+  $'\tif false {\n\t\tpm.log.LogInfo(logComponentSessionDetectorSeed, state.SessionID,' \
+  'TestStartupSweeps_KeepARetainedErrorRow' \
+  'the seed-time dead-PID path deleted 1 errored session(s)'
+
+if [[ $fails -gt 0 ]]; then
+  echo "error-retention-mutations: $fails FAILED"
+  exit 1
+fi
+echo "error-retention-mutations: ALL PASS"


### PR DESCRIPTION
Closes #1815

## What was wrong

A session in `error` read `ready` again — or vanished entirely — after **any** daemon restart. That made the retention promise in `core/domain/session/signal_hold.go` ("an agent that crashes at 22:00 must still read `error` when its human looks at 08:00") false the moment the daemon restarted, and a release, a reboot, or an `ir:test-mac` all land inside exactly that window.

## Is it one bug or two? **Two.**

The reporter reproduced mechanism 1 live and explicitly left mechanism 2 unrun. I ran both, and they fail with **different signatures** against the same test:

| Case | Signature | What is lost |
|---|---|---|
| agent process **alive** across the restart | `reads "ready", want "error"` | the **verdict** — the row survives |
| agent process **dead** across the restart | `reads "<absent>", want "error"` | the **row itself** — deleted by a startup sweep |

Neither fix covers the other's case, and mechanism 2 is confirmed by the daemon's own log line:

```
"event_type":"startup-cleanup" ... "zombie session (pid=88865, state=error, adapter=claude-code) — deleting"
"event_type":"session-cleanup" ... "deleted (startup zombie sweep: pid=88865 state=error, state=error)"
```

## One thing the issue did not name: there are TWO dead-PID deleters

The issue named `isStartupZombie` (`pid_manager.go:623`). There is a second one — `handleAlivePIDState` (`pid_manager.go:1402`), reached via `SeedPIDs` inside `seedFromDisk` — which performs the identical `ESRCH → deleteWithChildren`. Exempting only the first leaves the row to die at the second. Both are exempted, and the test asserts each independently (see red-first proof 2 below, where both go red).

## The fix — three pieces

1. **`tailer.LedgerState.SessionError`** persists the sticky transcript-derived failure. Additive, **no schema bump**: a pre-field ledger rehydrates to `nil`, which is byte-for-byte the pre-fix behaviour (the `ResumeFingerprint` / `PendingWaitingCue` precedent). This is the route `metrics.go` had already named by file.
2. **`retainedErrorAcrossRestart`** exempts an errored row from *both* startup dead-PID deleters. **The 12-hour ceiling is REUSED, not reintroduced**: it reads the existing `processDeathRetention` const, in the same package, and measures it against the **persisted `UpdatedAt`** so the window *continues* across the restart instead of resetting. Past the window the ordinary sweeps reap the row exactly as before — this is a retention window, not an exemption.
3. **`seedRestoreErrorVerdict`** captures the persisted verdict *before* `RefreshMetrics` destroys it, re-places the signal hold anchored at the persisted `UpdatedAt`, and re-registers the process-death verdict. Two reasons a ledger alone cannot do this: a process-death verdict is daemon-synthesized and never written to any transcript; and only a hold restores `Metrics.ProcessDeath`, whose classifier rule outranks the transcript-tier rules that a frozen mid-turn transcript would otherwise win with.

## Where the restart case is NAMED in the code

The reporter's binding requirement. Every site that previously said "known gap" / "deferred" / "do not fix here" now states what handles it:

- `core/application/services/session_detector_lifecycle.go` — `retainedErrorAcrossRestart`'s own doc ("THIS IS WHERE THE RESTART CASE IS NAMED"), the rewritten `processDeathRetention` doc, the rewritten `retainAsProcessDeath` doc, `seedRestoreErrorVerdict`'s doc, and `seedReevaluateOne`'s filter comment.
- `core/domain/session/metrics.go` — `SessionMetrics.SessionError`'s "DOES NOT SURVIVE A DAEMON RESTART" paragraph replaced with what does.
- `core/pkg/tailer/parser.go` — `LedgerState.SessionError` ("THIS IS THE FIELD THE RESTART CASE TURNS ON").
- `core/application/services/pid_manager.go` — the second deleter's exemption says why one alone is worth nothing.

## Red-first evidence

**Acceptance (both mechanisms), `go test ./core/cmd/irrlichd/ -run TestErrorStateSurvivesDaemonRestart`** — a real `irrlichd` on an ephemeral port under temp dirs, driven into `error` off a real transcript:

```
error_survives_restart_live_daemon_test.go:121: after a daemon restart session e5f1a2b3-… reads "ready", want "error" (polled 10.002s) — #1815: the error verdict did not survive the restart
error_survives_restart_live_daemon_test.go:161: after a daemon restart session c4d5e6f7-… reads "<absent>", want "error" (polled 10.017s) — #1815: the error verdict did not survive the restart
--- FAIL: TestErrorStateSurvivesDaemonRestart/agent_process_alive_across_the_restart (10.36s)
--- FAIL: TestErrorStateSurvivesDaemonRestart/agent_process_dead_across_the_restart (10.05s)
```

The lifetime-1 assertion is also the **vacuity guard**: if the transcript stopped producing an error, the test fails there and says so rather than passing lifetime 2 against a session that was never red.

**Per-piece proofs.** Each fix hunk was reverted individually against the finished tests (the three added checks have no "before", so what is mutated is the thing each protects):

*1 — ledger persistence removed:*
```
--- FAIL: TestLedger_SessionErrorSurvivesRestart (0.00s)
    ledger_session_error_test.go:40: the sticky session error did not survive the ledger round-trip — #1815: a restarted daemon re-classifies the session off a frozen transcript and reads green
```

*2 — both sweep exemptions removed (both go red, independently):*
```
error_survives_restart_test.go:53: the startup zombie sweep still deletes an errored session with a dead PID — #1815: a crash at 22:00 is gone before the user looks at 08:00 (retention 12h0m0s)
error_survives_restart_test.go:66: the seed-time dead-PID path deleted 1 errored session(s) — #1815: exempting only isStartupZombie leaves this second deleter to take the row anyway
--- FAIL: TestStartupSweeps_KeepARetainedErrorRow/isStartupZombie_keeps_it_inside_the_window
--- FAIL: TestStartupSweeps_KeepARetainedErrorRow/seedAlivePIDs_keeps_it_inside_the_window
```

*3 — process-death evidence routed through the transcript row instead of the process row (the exact tier mistake `SignalProcessDeath`'s doc warns about):*
```
--- FAIL: TestSeedRestoreErrorVerdict_ProcessDeathOutranksAFrozenTranscript (0.00s)
    error_survives_restart_test.go:157: Metrics.ProcessDeath is false after the seed restore — #1815: without it the process_death rule cannot fire and a frozen mid-turn transcript re-paints the session
```

**LOCKS — these pass on `main` by construction and are not red-first proofs.** Named explicitly rather than left to read as evidence:
- `TestLedger_ClearedSessionErrorStaysCleared` — nil must persist as nil, or recovery stops surviving a restart.
- `TestLedger_PreFieldLedgerRehydratesToNoError` — pins the no-schema-bump decision against a real pre-field payload.
- `TestSeedRestoreErrorVerdict_DropsAHoldWhoseTurnActuallyFinished` — the restore must go *through* Overlay's staleness rule, not around it, or every clean headless exit on disk at boot comes back red.
- `TestStartupSweeps_KeepARetainedErrorRow/{isStartupZombie_reaps_it_past_the_window, a_live_errored_session_is_untouched}` — the window closes, and a live process is never a zombie.
- `TestRetainedErrorAcrossRestart_OnlyErroredRows` — a table over `session.CanonicalStates()`, so a fifth state is asserted automatically rather than needing this test edited.

## Verification

`tools/preflight.sh` run chunked, each in the foreground: `go` PASS · `arch` PASS (composite 7.8919 → 7.8909, no category regression) · `tools` PASS (incl. state-vocabulary lint) · `skills` PASS · `posix` PASS · `bash` PASS · `security` PASS. `web` and `swift` are not applicable — no `web/` or `platforms/macos/` tree is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Review + `/simplify` round (added after the first push)

A `medium`→`high` review subagent and a four-agent `/simplify` pass found **three more deleters and two behavioural defects** in the first cut. All are fixed; the notable ones:

**A fifth deleter, found by the altitude pass and verified by execution.** `sweepStaleSnapshot`'s `snap.pid == 0` branch deletes after `readyTTL` (30 minutes by default) — inside the twelve-hour window — and takes exactly the shape this fix's own comments describe: a headless run that fails on a provider error and exits before PID discovery binds.

**The periodic liveness sweep undid the whole fix five seconds later.** `retainAsProcessDeath` is reached from `SweepDeadPIDs` every ~5s, and a restored row had no verdict of its own in the new process, so it fell through `diedMidTurn` (false for anything already in `error`) and was deleted. Measured against a real daemon. Only the `process_death` class was actually being rescued; the reporter's own 529 case was not.

**A `SignalSessionError` hold would have pinned recovered sessions red.** The first cut re-placed a hold for every error class. That row's `apply` writes its payload into any empty slot, so the moment `clearSessionErrorOnRecovery` fired the hold wrote the error straight back — for the whole recovery turn, and for the hookless adapters (aider, opencode, pi) for the full 12h ceiling. The restore is now `process_death` only; the ledger owns the transcript-derived class, including clearing it.

**A lock I broke and the suite caught.** An earlier attempt at the periodic-sweep fix added a state-shaped branch to `retainAsProcessDeath`, which re-shielded a row whose verdict `HandlePIDAssigned` had deliberately retired — `TestHandlePIDAssigned_RetiresAProcessDeathVerdict` failed. The landed version reuses the verdict map instead, inheriting that retirement for free.

### The structural answer to "how many deleters are there?"

The first version of `retainedErrorAcrossRestart`'s doc enumerated its call sites and named a count. **It was already wrong on the day it landed** — that is how the fifth deleter hid. The inventory is gone; in its place:

- `PIDManager.retainsError` is the single method every reaper predicate consults;
- `TestEveryReaperConsultsTheErrorExemption` walks `pid_manager.go`'s AST and fails any deleting function that neither consults it nor sits on a documented exempt list (each exemption carries its reason). It has a vacuity floor, so an AST walk that stops matching fails loudly rather than reading clean.

Both go red on one mutation, and the tripwire names the offender:

```
error_survives_restart_test.go:669: sweepStaleSnapshot deletes session rows but never calls retainsError — #1815: an errored row within its retention window is deleted by this path.
error_survives_restart_test.go:709: the ready-TTL liveness sweep deleted an errored row 2h0m0s old — #1815: the twelve-hour promise is really readyTTL (10m0s) for a PID==0 errored session
```

### The e2e test was passing for the wrong reason

The dead-PID subtest passed in **0.03s** — before the liveness sweep had ticked once. Surviving startup is not surviving. `holdSessionState` now holds the invariant past a sweep interval, and the dead case is split across both error classes. With the periodic-sweep fix reverted:

```
held "error" for only 5.161s before flipping to "working"  (process death)
held "error" for only 5.157s before flipping to "<absent>" (provider error)
```

### Quality fixes

- `errorRetentionOverride`'s zero-sentinel → constructor-defaulted field. `SetErrorRetention(0)` used to mean *twelve hours* while `SetProcessDeathRetention(0)` means *never retain* — for two knobs the code calls the same window.
- `handleAlivePIDState`'s added nesting extracted to `reapOrRetainDeadSeedPID` (CodeScene "Bumpy Road", hotspot file).
- Three byte-identical live-daemon consent seeders → one `seedGrantedConsent`.
- The ledger tests build through `newTestTailer` rather than a partial literal omitting seven maps the real constructor initialises — a false-green risk in the one file whose job is ledger fidelity.
- `restartLog` dropped for the existing `bornLog`; `assertIntPtr` generalised to `assertPtr` so `RetryIn` gets the same absent-is-not-zero message; one subsumed test folded into the precondition it duplicated.
- The three e2e subtests run in parallel: **25.6s → 9.5s**.

### Deliberately not done

- **Moving `retainedErrorAcrossRestart` / `persistedErrorVerdict` into `core/domain/session`.** The two reviewers disagreed; the code-review pass checked layering explicitly and found the current placement correct (it sits beside `diedMidTurn` and `isOrphanAtSeed`, its direct neighbours, and `go test ./core/` — the hexagonal import gate — passes). Left where its neighbours are.
- **A `rehydrate` column on `signalPolicies`** so restart-durability becomes a declared property of every signal rather than one bespoke restorer. A genuinely deeper design, and the right one if a second kind ever needs it — but it is a domain-table change plus a structural test for one caller today. Worth its own issue.
- **A shared `core/pkg/proctest`** for the spawn-and-reap-a-PID idiom, now copied five times across five packages because Go test-package boundaries forbid sharing. Repo-wide refactor, out of scope.


### Final state

`pid_manager.go` is no longer flagged by CodeScene at all — the hotspot-decline gate that failed on the first two pushes now passes. CodeScene is advisory (not a merge gate); what remains is `persistedErrorVerdict`'s single three-clause guard, which the simplify pass assessed and deliberately left (splitting it is strictly longer and less readable), plus four test-file functions.

Every PR-gating check is green: `go-test`, `build-test`, `ars-gate`, `swift-build`, `swift-test`, `CodeQL`, and both web suites.


---

## Independent `/ir:code-review high` round — all five findings fixed

**1 (MEDIUM, confirmed) — retention was behind the consent gate.** `seedRetainRestoredError` ran inside `seedReevaluateOne`, which `seedReevaluateStates` reaches only for rows that have a `TranscriptPath` *and* whose adapter's observe permission is granted. A skipped row got no verdict entry: spared at startup, deleted ~5s later by the periodic sweep. Neither skip condition is exotic — a pending observe permission is **every** adapter's state on a fresh `IRRLICHT_HOME`, so the user most likely to hit it was the one who had not finished onboarding. Replaced with `seedRetainErroredRows`, a seed-level pass over every persisted row using the same predicate as the startup exemption. Red first, on both skip conditions:

```
--- FAIL: TestSeedRetention_CoversARowTheSeedPassSkips/no_transcript_path
--- FAIL: TestSeedRetention_CoversARowTheSeedPassSkips/observe_consent_not_granted
    the periodic sweep reaps an errored row the seed pass skipped (no transcript path) — #1815:
    the retention registration is gated behind the consent/transcript check, so the row is
    spared at startup and deleted ~5s later
```

**2 (MEDIUM, confirmed) — the tripwire could not fail for an idiom already in the file.** It recognised deletion by three hand-typed wrapper names, so a reaper written `pm.repo.Delete(id)` was invisible — and `cleanupStalePIDHolders` does exactly that. A probe reaper using that idiom kept the test **green**. Deletion is now seeded from the *primitive* (a `.repo.Delete(...)` call site) and grown over the call graph, as delegation already was — **both relations derived, neither typed.** The probe is now caught:

```
--- FAIL: TestEveryReaperConsultsTheErrorExemption
    reapErroredRowViaRepo deletes session rows but nothing on its call path consults
    retainsError — #1815: an errored row within its retention window is deleted by this path.
```

The wider walk surfaced four more paths that reach deletion. Each was traced and is now in the exempt map with its reason: `cleanupStalePIDHolders` (supersession — its inputs are the *other* rows holding a PID a new session just bound, so identity has moved to the survivor, and it fires `onSessionSuperseded`, which carries state *forward*), plus `HandlePIDAssigned` / `TryDiscoverPID` / `DiscoverPIDWithRetry`, which reach deletion only through it, and `reapDeadOrInfraPID`, which deletes only via `HandleProcessExit`.

**3 (LOW/MEDIUM, plausible) — it is REAL. Settled by a run, not by reasoning.** `processDeathVerdicts` was never dropped when a row was deleted, so a session id reused by `claude --resume <uuid>` inherited an expired entry, and its **first** mid-turn death took the expiry branch and was deleted instead of going red. It does not self-heal in time: the entry is dropped only on that same branch, which returns `false`, so it clears only after eating one death. Added to `forgetSessionScopedState` — the seam whose own doc says the next per-session map belongs there, and which #1800 missed anyway. This diff had made it likelier by registering an entry at every seed for every errored row. Red first:

```
--- FAIL: TestForgetSessionScopedState_DropsTheProcessDeathVerdict
    the process-death verdict survived the row's deletion — a session id reused by
    `claude --resume` inherits it, and its FIRST mid-turn death takes the expiry branch
    and is deleted instead of going red
```

**4 (LOW, confirmed) — the hand-typed count is gone.** "Three non-exempt deleters exist today" (which then listed four) is replaced by a derived, logged figure: `checked 8 non-exempt deleter(s) of 23 total; 11 function(s) consult the exemption`.

**5 (LOW, confirmed) — the mutations are committed.** `tools/lib/error-retention-mutations_test.sh` drives the repo's own `tools/mutate.sh` for the three mutations that carry this PR (the reaper tripwire via a *delegate*, and each sweep exemption independently), and runs on every `preflight.sh --only tools` — the suite now finds 25 files, up from 24. Its own three guards are verified rather than assumed: a mutation leaving the test green fails; a stale anchor fails **loudly** (`mutate: refusing — STALE — the anchor occurs 0 times`) rather than silently mutating nothing (#1390/#1450); and a dirty tree — where `mutate.sh` can prove nothing — is a hard failure under `CI` or `MUTATION_FIXTURES_STRICT` rather than an `exit 0` the suite runner would read as a pass.

**Verification:** `preflight.sh --only go` PASS · `--only tools` PASS · `--only bash` PASS · `--only arch` PASS, each foreground. All PR-gating checks green; `pid_manager.go` is no longer flagged by CodeScene.
