### PR TITLE
fix(claudecode): derive HTTPStatus and Class from structured terminal API-error fields

### DIFF
--- a/core/adapters/inbound/agents/claudecode/sessionerror.go
+++ b/core/adapters/inbound/agents/claudecode/sessionerror.go
@@ -25,16 +25,17 @@ const (
 	// systemSubtypeAPIError is the `system` subtype carrying a provider error.
 	systemSubtypeAPIError = "api_error"
 
-	// terminalAPIErrorClass is the class recorded for the isApiErrorMessage
-	// shape.
-	//
-	// It is a constant rather than a field read because the only classification
-	// claudecode offers on this shape is a top-level `"error"` whose recorded
-	// value is the string "unknown" — the absence of a class rather than one.
-	// (Both occurrences in replaydata carry it: reproduce with
-	// `grep -rh '"isApiErrorMessage":true' replaydata/agents/claudecode/ | jq -c .error`.)
-	// "provider" is the generic bucket from session.SessionError.Class's
-	// vocabulary; the real information is in Message, which is carried verbatim.
+	// terminalAPIErrorClass is the fallback class recorded for the
+	// isApiErrorMessage shape when the transcript's own top-level `"error"`
+	// token is either absent or the literal string "unknown" — claude-code's
+	// own spelling of "no classification offered," true of every recording
+	// before 2.1.245. From 2.1.245 on, that same field carries a real machine
+	// token (`server_error`, `authentication_failed`, ...) that
+	// terminalAPIErrorMessageClass prefers over this constant. Reproduce the
+	// split with `grep -rh '"isApiErrorMessage":true' replaydata/agents/claudecode/
+	// | jq -c .error`. "provider" is the generic bucket from
+	// session.SessionError.Class's vocabulary; the real information is in
+	// Message, which is carried verbatim.
 	terminalAPIErrorClass = "provider"
 )
 
@@ -84,10 +85,18 @@ func apiErrorFromSystemEvent(raw map[string]interface{}) *tailer.SessionError {
 // common interaction in the product. TestParser_ESCInterrupt_IsApiErrorMessage
 // FalseIsNotAnError is the fixture that catches it.
 //
-// No status code is derived. The recorded text is "API Error: API returned an
-// empty or malformed response (HTTP 200)" — the number in the prose is the
-// transport's SUCCESS code, so reading a status out of the message would record
-// 200 as a failure code. HTTPStatus stays nil, which is what the pointer is for.
+// HTTPStatus is read from the top-level `apiErrorStatus` field claude-code
+// 2.1.245 started writing alongside isApiErrorMessage — the real HTTP status
+// (529, 401, ...). It is never derived from the message text: the recorded
+// text can itself read "API Error: API returned an empty or malformed
+// response (HTTP 200)", and the number in THAT prose is the transport's
+// SUCCESS code, not a failure code — apiErrorStatus is a structured sibling
+// field, not a re-parse of the string. Recordings older than 2.1.245 carry no
+// apiErrorStatus key at all, and tailer.OptInt returns nil rather than a
+// fabricated 0 for a missing key, so HTTPStatus stays nil for them — which is
+// what the pointer is for. See TestParser_TerminalAPIErrorMessage_FromRecording
+// for the pre-field fixture and TestParser_TerminalAPIError_StructuredFields
+// for the two post-field ones (#1818).
 func terminalAPIError(raw map[string]interface{}) *tailer.SessionError {
 	// A non-bool or absent value yields false, which is the correct reading:
 	// only an explicit true is claudecode saying this message IS the error.
@@ -95,10 +104,24 @@ func terminalAPIError(raw map[string]interface{}) *tailer.SessionError {
 		return nil
 	}
 	return &tailer.SessionError{
-		Phase:   tailer.ErrorPhaseTerminal,
-		Class:   terminalAPIErrorClass,
-		Message: strings.TrimSpace(tailer.ExtractAssistantFullText(raw)),
+		Phase:      tailer.ErrorPhaseTerminal,
+		Class:      terminalAPIErrorMessageClass(raw),
+		Message:    strings.TrimSpace(tailer.ExtractAssistantFullText(raw)),
+		HTTPStatus: tailer.OptInt(raw, "apiErrorStatus"),
 	}
+}
+
+// terminalAPIErrorMessageClass prefers claudecode's own machine-readable
+// top-level `"error"` token (server_error, authentication_failed, ...) over
+// the generic terminalAPIErrorClass fallback. "unknown" is claudecode's own
+// spelling of "no classification offered" — every occurrence of it in
+// replaydata predates apiErrorStatus/error carrying real values — so it is
+// treated the same as absence rather than surfaced verbatim as a Class.
+func terminalAPIErrorMessageClass(raw map[string]interface{}) string {
+	if e, _ := raw["error"].(string); e != "" && e != "unknown" {
+		return e
+	}
+	return terminalAPIErrorClass
 }
 
 // apiErrorClass prefers the provider's own nested error type over the summary

--- a/core/adapters/inbound/agents/claudecode/sessionerror_test.go
+++ b/core/adapters/inbound/agents/claudecode/sessionerror_test.go
@@ -26,6 +26,10 @@ const (
 		"2026-05-22-15-49-22_irrlichd-unknown/transcript.jsonl"
 	fixtureESCInterrupt = "2-20_user-esc-interrupt/recordings/" +
 		"2026-05-19-00-11-42_irrlichd-0.4.5+898a14f/transcript.jsonl"
+	fixtureProviderOverloadedTerminal = "2-23_provider-overloaded-terminal/recordings/" +
+		"2026-08-25-12-32-35_irrlichd-0.6.0+a036ed9/transcript.jsonl"
+	fixtureAuthCredentialsRejected = "2-24_auth-credentials-rejected/recordings/" +
+		"2026-08-25-09-07-00_irrlichd-0.6.0+c7ace31/transcript.jsonl"
 )
 
 // scenarioFixture resolves a committed claudecode scenario recording.
@@ -184,14 +188,103 @@ func TestParser_TerminalAPIErrorMessage_FromRecording(t *testing.T) {
 		t.Errorf("Message = %q, want the agent's verbatim epilogue", first.Message)
 	}
 	// The recorded text says "(HTTP 200)". Deriving a status from prose would
-	// record the transport's success code as the failure code.
+	// record the transport's success code as the failure code. This recording
+	// (claude-code 2.1.148) predates the `apiErrorStatus` field entirely, so
+	// this also pins that tailer.OptInt leaves HTTPStatus nil for an absent
+	// key rather than a fabricated 0 (#1818).
 	if first.HTTPStatus != nil {
 		t.Errorf("HTTPStatus = %v, want nil — this shape carries no status field, "+
 			"and the 200 in its prose is the transport's success code", *first.HTTPStatus)
 	}
+	// This recording's own `"error"` field reads "unknown" — claude-code's
+	// spelling of "no classification offered" — so Class must fall back to
+	// the generic constant rather than surfacing "unknown" verbatim (#1818).
+	if first.Class != terminalAPIErrorClass {
+		t.Errorf("Class = %q, want %q (the fallback: this recording's own "+
+			"error field is the literal string \"unknown\")", first.Class, terminalAPIErrorClass)
+	}
 	if first.Attempt != nil || first.MaxAttempts != nil || first.RetryIn != nil {
 		t.Errorf("retry fields must stay nil for the terminal shape: attempt=%v max=%v retryIn=%v",
 			first.Attempt, first.MaxAttempts, first.RetryIn)
+	}
+}
+
+// TestParser_TerminalAPIError_StructuredFields_FromRecording is the red-first
+// defect test for #1818: claude-code 2.1.245 started writing two structured
+// top-level fields next to isApiErrorMessage — `apiErrorStatus` (the real
+// HTTP status) and `error` (a machine token) — and the unfixed parser derived
+// neither. Both fixtures were recorded fresh for #1803's four error scenarios
+// and need no re-recording.
+func TestParser_TerminalAPIError_StructuredFields_FromRecording(t *testing.T) {
+	cases := []struct {
+		name       string
+		fixture    string
+		wantStatus int
+		wantClass  string
+		wantPrefix string
+	}{
+		{
+			name:       "provider overloaded (529)",
+			fixture:    fixtureProviderOverloadedTerminal,
+			wantStatus: 529,
+			wantClass:  "server_error",
+			wantPrefix: "API Error: Repeated 529 Overloaded errors",
+		},
+		{
+			name:       "auth credentials rejected (401)",
+			fixture:    fixtureAuthCredentialsRejected,
+			wantStatus: 401,
+			wantClass:  "authentication_failed",
+			wantPrefix: "Invalid API key",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			lines := fixtureLines(t, scenarioFixture(t, tc.fixture))
+
+			p := &Parser{}
+			var first *tailer.SessionError
+			seen := 0
+			for _, raw := range lines {
+				ev := p.ParseLine(raw)
+				flagged, _ := raw["isApiErrorMessage"].(bool)
+				if !flagged {
+					continue
+				}
+				seen++
+				if ev.SessionError == nil {
+					t.Fatalf("isApiErrorMessage:true line %d produced no SessionError", seen)
+				}
+				if first == nil {
+					first = ev.SessionError
+				}
+			}
+			if seen == 0 {
+				t.Fatalf("no isApiErrorMessage:true line found in %s — this test "+
+					"cannot observe the shape it exists to pin", tc.fixture)
+			}
+
+			if first.Phase != tailer.ErrorPhaseTerminal {
+				t.Errorf("Phase = %q, want %q", first.Phase, tailer.ErrorPhaseTerminal)
+			}
+			if first.HTTPStatus == nil || *first.HTTPStatus != tc.wantStatus {
+				t.Errorf("HTTPStatus = %v, want %d — read from the transcript's own "+
+					"`apiErrorStatus` field, not derived from the message text",
+					first.HTTPStatus, tc.wantStatus)
+			}
+			if first.Class != tc.wantClass {
+				t.Errorf("Class = %q, want %q (claude-code's own top-level `error` token)",
+					first.Class, tc.wantClass)
+			}
+			if !strings.HasPrefix(first.Message, tc.wantPrefix) {
+				t.Errorf("Message = %q, want prefix %q", first.Message, tc.wantPrefix)
+			}
+			if first.Attempt != nil || first.MaxAttempts != nil || first.RetryIn != nil {
+				t.Errorf("retry fields must stay nil for the terminal shape: attempt=%v max=%v retryIn=%v",
+					first.Attempt, first.MaxAttempts, first.RetryIn)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

claude-code 2.1.245 writes two structured top-level fields next to `isApiErrorMessage` on the terminal give-up shape: `apiErrorStatus` (the real HTTP status, e.g. 529/401) and `error` (a machine token, e.g. `server_error`, `authentication_failed`). `terminalAPIError` in `core/adapters/inbound/agents/claudecode/sessionerror.go` previously derived neither — `HTTPStatus` stayed permanently nil and `Class` was hardcoded to the generic constant `"provider"`.

- `HTTPStatus` is now read via `tailer.OptInt(raw, "apiErrorStatus")` — the same pattern the retrying sibling (`apiErrorFromSystemEvent`) already uses for `error.status`. Recordings older than 2.1.245 carry no `apiErrorStatus` key at all, so `HTTPStatus` stays `nil` for them, never a fabricated `0`.
- `Class` now prefers the transcript's own `error` token over the constant, **except** when that token is the literal string `"unknown"` — claude-code's own spelling of "no classification offered," true of every pre-2.1.245 recording — which still falls back to `"provider"`.
- Corrected the stale doc comments on `terminalAPIError` and `terminalAPIErrorClass` that claimed no status could ever be derived (true of the old shape, not the current one).

Closes #1818.

## Evidence

Red-first: wrote `TestParser_TerminalAPIError_StructuredFields_FromRecording` against the two already-committed fixtures (`2-23_provider-overloaded-terminal`, `2-24_auth-credentials-rejected`), reverted `sessionerror.go` to its pre-fix state, and confirmed the test failed:

```
HTTPStatus = <nil>, want 529 — read from the transcript's own `apiErrorStatus` field, not derived from the message text
Class = "provider", want "server_error" (claude-code's own top-level `error` token)
HTTPStatus = <nil>, want 401 — ...
Class = "provider", want "authentication_failed" ...
```

Restored the fix; all cases pass. The pre-field guard (absent `apiErrorStatus` on the `2-14_turn-aborted-by-error` recording, predating 2.1.245, still yields `HTTPStatus == nil`) is pinned by the existing `TestParser_TerminalAPIErrorMessage_FromRecording`, to which I added a `Class == "provider"` assertion — that recording's own `error` field reads the literal string `"unknown"`, proving the fallback path via mutation rather than just describing it.

`tools/replay-fixtures.sh` and `go run ./tools/onboarding-factory/cmd/of validate` both pass with no golden drift for either touched scenario (`2-23`/`2-24` both report `ok`); no golden files changed on disk.

## Test plan

- [x] `go test ./core/adapters/inbound/agents/claudecode/... -race -count=1`
- [x] `tools/preflight.sh --only go/arch/tools/skills/posix/bash/security` (all PASS)
- [x] `tools/replay-fixtures.sh` (no golden drift)
- [x] `go run ./tools/onboarding-factory/cmd/of validate` (OK)

🤖 Generated with [Claude Code](https://claude.com/claude-code)