### PR TITLE
fix(tools): name mutate.sh's confirmed NUL-refusal cause; root-cause #1816

### DIFF
--- a/tools/lib/mutate_test.sh
+++ b/tools/lib/mutate_test.sh
@@ -314,6 +314,55 @@ MUTATE_OUTPUT="$(cd "$repo" && "$MUTATE_SH" embedded-nul.bin "abc" "xyz" true 2>
 MUTATE_RC=$?
 assert_contains "names the byte-count mismatch" "could not read" "$MUTATE_OUTPUT"
 [[ "$MUTATE_RC" -ne 0 ]] && pass "refuses (nonzero exit)" || fail "refuses (nonzero exit)" "nonzero" "0"
+# #1816: the refusal must name the CONFIRMED cause (measured by an independent
+# byte read) rather than a guess between "NUL or this tool's own sentinel" —
+# this NUL is at byte offset 3 ("abc" is 3 bytes), and the message must say so.
+assert_contains "names the confirmed cause, not a guess between two possibilities" \
+  "confirmed: an embedded NUL byte (0x00) at offset 3" "$MUTATE_OUTPUT"
+
+echo ""
+echo "== root-cause regression (#1816): a NUL deep inside a large file is confirmed at its EXACT offset =="
+# platforms/web/irrlicht.js carries exactly one literal NUL, used as a string
+# separator, at byte offset 67966 in a 117644-byte file — this reproduces
+# that shape (a single embedded NUL far past any small-fixture edge case) in
+# a throwaway repo rather than pointing mutate.sh at this repo's own tree.
+repo="$(new_repo)"
+python3 -c "
+import sys
+data = bytearray((i % 250) + 2 for i in range(120000))  # never 0x00 or 0x01
+data[67966] = 0  # the one confirmed offset from #1816's investigation
+with open('$repo/large-with-nul.bin', 'wb') as f:
+    f.write(data)
+"
+git -C "$repo" add large-with-nul.bin
+git -C "$repo" commit -q -m "add a large file with one NUL at a known offset"
+MUTATE_OUTPUT="$(cd "$repo" && "$MUTATE_SH" large-with-nul.bin "abc" "xyz" true 2>&1)"
+MUTATE_RC=$?
+[[ "$MUTATE_RC" -ne 0 ]] && pass "refuses (nonzero exit)" || fail "refuses (nonzero exit)" "nonzero" "0"
+assert_contains "names the true file size (120000), not a truncated one" "120000 bytes" "$MUTATE_OUTPUT"
+assert_contains "confirms the NUL at its exact offset (67966), not a guess and not a buffer-boundary number" \
+  "confirmed: an embedded NUL byte (0x00) at offset 67966" "$MUTATE_OUTPUT"
+assert_eq "left the repo clean — a refusal must never look like a survived mutation" \
+  "" "$(cd "$repo" && git status --porcelain)"
+assert_eq "left the file byte-for-byte untouched" \
+  "$(git -C "$repo" show HEAD:large-with-nul.bin | wc -c)" "$(wc -c < "$repo/large-with-nul.bin")"
+
+echo ""
+echo "== the other confirmed cause: an embedded 0x01 (this tool's own sentinel) is named as such, not as a NUL =="
+# RS=\"\\x01\" can only ever produce MORE than one record by splitting on a
+# literal 0x01 byte, so this branch of the confirmed-cause guard is reached a
+# different way than the NUL branch above — exercise it for real rather than
+# trusting it by inspection.
+repo="$(new_repo)"
+printf 'abc\x01def\n' > "$repo/embedded-sentinel.bin"
+git -C "$repo" add embedded-sentinel.bin
+git -C "$repo" commit -q -m "add a file with this tool's own 0x01 sentinel byte"
+MUTATE_OUTPUT="$(cd "$repo" && "$MUTATE_SH" embedded-sentinel.bin "abc" "xyz" true 2>&1)"
+MUTATE_RC=$?
+[[ "$MUTATE_RC" -ne 0 ]] && pass "refuses (nonzero exit)" || fail "refuses (nonzero exit)" "nonzero" "0"
+assert_contains "names the 0x01 sentinel specifically, not a NUL" \
+  "confirmed: one or more embedded 0x01 bytes (this tool's own record-separator sentinel) split the read into multiple records" \
+  "$MUTATE_OUTPUT"
 
 echo ""
 echo "== usage: refuses when the test command is missing entirely =="

--- a/tools/lib/mutate_test.sh
+++ b/tools/lib/mutate_test.sh
@@ -344,8 +344,16 @@ assert_contains "confirms the NUL at its exact offset (67966), not a guess and n
   "confirmed: an embedded NUL byte (0x00) at offset 67966" "$MUTATE_OUTPUT"
 assert_eq "left the repo clean — a refusal must never look like a survived mutation" \
   "" "$(cd "$repo" && git status --porcelain)"
-assert_eq "left the file byte-for-byte untouched" \
-  "$(git -C "$repo" show HEAD:large-with-nul.bin | wc -c)" "$(wc -c < "$repo/large-with-nul.bin")"
+# BYTE-IDENTICAL via cmp, not just byte-COUNT via wc -c (review finding,
+# #1816): the same idiom already used above for the small fixture — a
+# length-preserving content corruption would pass a wc -c comparison but
+# not this one. cmp is exactly as NUL-safe as wc -c (both are byte-stream
+# tools with no C-string semantics of their own).
+if cmp -s <(git -C "$repo" show HEAD:large-with-nul.bin) "$repo/large-with-nul.bin"; then
+  pass "left the file byte-for-byte untouched"
+else
+  fail "left the file byte-for-byte untouched" "no diff" "cmp reported a difference"
+fi
 
 echo ""
 echo "== the other confirmed cause: an embedded 0x01 (this tool's own sentinel) is named as such, not as a NUL =="
@@ -362,6 +370,25 @@ MUTATE_RC=$?
 [[ "$MUTATE_RC" -ne 0 ]] && pass "refuses (nonzero exit)" || fail "refuses (nonzero exit)" "nonzero" "0"
 assert_contains "names the 0x01 sentinel specifically, not a NUL" \
   "confirmed: one or more embedded 0x01 bytes (this tool's own record-separator sentinel) split the read into multiple records" \
+  "$MUTATE_OUTPUT"
+
+echo ""
+echo "== the 0x01 sentinel AS THE FILE'S LAST BYTE: only ONE record, so confirmation goes through the dd/od single-byte read, not the multi-record heuristic (review finding, #1816) =="
+# RS="\x01" does not emit a trailing empty record when the separator is the
+# file's final byte (verified: neither macOS's system awk nor gawk does) —
+# so this is the ONLY way to reach the dd/od branch (mutate.sh's `elif`) with
+# a 0x01 byte rather than a NUL, exercising the one case the review found
+# untested: a regression in the dd `skip=` arithmetic, or the two case arms
+# (00/01) getting swapped, would ship undetected without this.
+repo="$(new_repo)"
+printf 'abc\x01' > "$repo/trailing-sentinel.bin"
+git -C "$repo" add trailing-sentinel.bin
+git -C "$repo" commit -q -m "add a file whose last byte is this tool's own 0x01 sentinel"
+MUTATE_OUTPUT="$(cd "$repo" && "$MUTATE_SH" trailing-sentinel.bin "abc" "xyz" true 2>&1)"
+MUTATE_RC=$?
+[[ "$MUTATE_RC" -ne 0 ]] && pass "refuses (nonzero exit)" || fail "refuses (nonzero exit)" "nonzero" "0"
+assert_contains "the dd/od single-byte read correctly identifies 0x01 at its exact offset, not a NUL" \
+  "confirmed: this tool's own 0x01 record-separator sentinel at offset 3" \
   "$MUTATE_OUTPUT"
 
 echo ""

--- a/tools/mutate.sh
+++ b/tools/mutate.sh
@@ -70,8 +70,9 @@
 #   1  usage error (wrong number of arguments, or --help).
 #   2  <file> does not exist, is not a regular file, or is not read/writable.
 #   3  could not read <file> byte-for-byte (embedded NUL, or the 0x01 byte
-#      this tool reserves as an internal record separator — measured, not
-#      assumed: file size and what was read disagree).
+#      this tool reserves as an internal record separator — file size and
+#      what was read disagree). Which one is named in the refusal message is
+#      itself confirmed by a direct byte read, never guessed (#1816).
 #   4  precondition refused — not inside a git repository, or `git status
 #      --porcelain` was already non-empty BEFORE mutating. The post-restore
 #      emptiness check could prove nothing against a tree that started dirty
@@ -191,13 +192,36 @@ trap restore_file EXIT
 # ─── Guard: the snapshot can be read byte-for-byte via the RS="\x01" slurp ──
 # Measured, not assumed (AGENTS.md: "a validator that can't parse its input
 # checks MORE, never less"). A mismatch means the file contains a NUL byte
-# (many awk implementations truncate C-style strings there) or literally the
-# 0x01 byte this tool reserves as its own record separator — either way,
-# proceeding would silently operate on a truncated/garbled read.
+# (many awk implementations — including macOS's system /usr/bin/awk, the "one
+# true awk" — represent $0 as a NUL-terminated C string, so length()/index()/
+# substr() silently stop at the first NUL rather than seeing the true byte
+# count; confirmed directly against this repo's own platforms/web/irrlicht.js,
+# #1816) or literally the 0x01 byte this tool reserves as its own record
+# separator — either way, proceeding would silently operate on a
+# truncated/garbled read.
 SNAPSHOT_BYTES="$(LC_ALL=C wc -c < "$BACKUP" | tr -d ' ')"
 SLURPED_LEN="$(byte_awk 'BEGIN{RS="\x01"}{print length($0)}' "$BACKUP")"
 if [[ "$SLURPED_LEN" != "$SNAPSHOT_BYTES" ]]; then
-  refuse 3 "could not read '$FILE' byte-for-byte: it is $SNAPSHOT_BYTES bytes but this tool's exact-byte read measured '$SLURPED_LEN' — likely an embedded NUL byte or this tool's own 0x01 sentinel. Refusing rather than risk a corrupted mutation."
+  # Confirm which of the two known causes it actually was (#1816) instead of
+  # naming both as an unconfirmed guess. Read straight from the byte-safe
+  # $BACKUP snapshot with tools that carry no C-string semantics of their own
+  # (dd/od, never awk — awk is exactly the thing whose C-string read cannot
+  # see past a NUL), so the claim below is measured, not inferred.
+  CAUSE="unconfirmed: the measurement ('$SLURPED_LEN') did not match a recognized shape"
+  if [[ "$SLURPED_LEN" == *$'\n'* ]]; then
+    # RS="\x01" can only ever produce more than one record by actually
+    # splitting on a literal 0x01 byte — so this is confirmed by
+    # construction, not inferred from the byte count alone.
+    CAUSE="confirmed: one or more embedded 0x01 bytes (this tool's own record-separator sentinel) split the read into multiple records instead of one"
+  elif [[ "$SLURPED_LEN" =~ ^[0-9]+$ ]] && [[ "$SLURPED_LEN" -lt "$SNAPSHOT_BYTES" ]]; then
+    STOP_BYTE="$(dd if="$BACKUP" bs=1 skip="$SLURPED_LEN" count=1 2>/dev/null | od -An -tx1 | tr -d ' \n')"
+    case "$STOP_BYTE" in
+      00) CAUSE="confirmed: an embedded NUL byte (0x00) at offset $SLURPED_LEN" ;;
+      01) CAUSE="confirmed: this tool's own 0x01 record-separator sentinel at offset $SLURPED_LEN" ;;
+      *)  CAUSE="unconfirmed: the read stopped at byte 0x$STOP_BYTE (offset $SLURPED_LEN), which is neither a NUL nor this tool's 0x01 sentinel" ;;
+    esac
+  fi
+  refuse 3 "could not read '$FILE' byte-for-byte: it is $SNAPSHOT_BYTES bytes but this tool's exact-byte read measured '$SLURPED_LEN' — $CAUSE. Refusing rather than risk a corrupted mutation."
 fi
 
 # ─── Guard: precondition — a real git repo, and already clean ──────────────


### PR DESCRIPTION
Root-causes and fixes **instance 1** of #1816: `tools/mutate.sh` refuses `platforms/web/irrlicht.js` and could not previously explain why its own byte-parity guard measured `65532` when the original report was filed.

## Root cause

`tools/mutate.sh`'s byte-parity guard slurps the whole file as one `awk` record via `RS="\x01"`, then measures `length($0)`. On macOS's system `awk` — the "one true awk", `awk version 20200816`, which is what `byte_awk()` resolves to via `PATH` on this repo's dev machine — that record is represented internally as a **NUL-terminated C string**, so `length()`/`index()`/`substr()` silently stop at the first embedded `0x00` byte rather than seeing the true byte count. This is a property of BWK awk's string internals, not of the `LC_ALL=C` locale setting (confirmed: identical with/without `LC_ALL=en_US.UTF-8`) and not a fixed buffer-size ceiling (confirmed: the same 117644-byte file, with its one NUL byte neutralized, reads back with full byte parity through the identical code path — no truncation at any ~64 KiB-ish boundary).

Measured directly against `platforms/web/irrlicht.js` on this branch's base:
```
$ wc -c platforms/web/irrlicht.js
117644 platforms/web/irrlicht.js
$ python3 -c "print(open('platforms/web/irrlicht.js','rb').read().find(b'\x00'))"
67966
$ tools/mutate.sh platforms/web/irrlicht.js "no-such-anchor" "x" true
mutate: refusing — ... it is 117644 bytes but this tool's exact-byte read measured '67966' — confirmed: an embedded NUL byte (0x00) at offset 67966. ...
```
`SLURPED_LEN` (67966) exactly equals the file's one confirmed NUL offset — reproduced identically against synthetic fixtures at controlled offsets.

**The original `65532` figure**: the report that filed #1816 was produced *during* PR #1812's own development, against an **uncommitted, mid-edit revision** of the same file (114571 bytes — smaller than the 117576/117644 bytes it grew to by the time that PR merged and since). No artifact of those exact bytes survives anywhere (not committed, not quoted verbatim in any PR/issue comment I could find) to recompute `65532` byte-for-byte. But the mechanism fully explains it without needing a separate cause: on any revision of this file carrying that one embedded NUL, the guard's measured length is always exactly wherever the NUL sits *in that revision* — not a fixed boundary. The "looks like 64 KiB − 4" resemblance in the original report is very likely coincidental: the file was still being edited when that number was captured, so the NUL's offset at that moment was simply wherever it happened to be mid-edit, before later commits moved it to its current, confirmed 67966.

## The delegated decision

Kept `mutate.sh` **refusing** rather than teaching it to mutate NUL-bearing files — a real fix there would mean rewriting the tool's core byte-level string handling off of `awk` entirely (its C-string semantics are fundamentally incompatible with embedded NULs), which is a bigger, riskier change than this issue's bound. Instead, the refusal now **names the confirmed cause** instead of guessing between the two known ones ("likely an embedded NUL byte or this tool's own 0x01 sentinel"): the byte the C-string read actually stopped at is read straight from the byte-safe snapshot via `dd`/`od` — never through `awk`, which is exactly the thing that can't see past it — so the message says which one it confirmed, with the offset.

Asserted in `tools/lib/mutate_test.sh`:
- the existing embedded-NUL case now asserts the confirmed-cause wording (not just "could not read");
- a new case reproduces the #1816 shape exactly (a lone NUL at a known offset inside a 100KB+ file) and asserts the exact offset is named — this is the regression test;
- a new case exercises the *other* confirmed-cause branch (this tool's own `0x01` sentinel, which splits the `RS="\x01"` read into multiple records instead of truncating one) and asserts it's named as the sentinel, not misattributed as a NUL.

## Red-first evidence

Ran the new/extended test cases against `origin/main`'s `tools/mutate.sh` (copied to a scratch location so the working tree's `git status --porcelain` precondition stays untouched) — 3 failures, exactly the 3 new assertions, everything else still passing:
```
FAIL: names the confirmed cause, not a guess between two possibilities — expected [output containing: confirmed: an embedded NUL byte (0x00) at offset 3] got [... likely an embedded NUL byte or this tool's own 0x01 sentinel ...]
FAIL: confirms the NUL at its exact offset (67966), not a guess and not a buffer-boundary number — expected [output containing: confirmed: an embedded NUL byte (0x00) at offset 67966] got [... likely an embedded NUL byte or this tool's own 0x01 sentinel ...]
FAIL: names the 0x01 sentinel specifically, not a NUL — expected [output containing: confirmed: one or more embedded 0x01 bytes ...] got [... likely an embedded NUL byte or this tool's own 0x01 sentinel ...]
mutate_test: 3 FAILED
```
After the fix, `bash tools/lib/mutate_test.sh` → `ALL PASS` (all pre-existing cases plus the 3 new ones).

## Step 3 — audit of other repo tools for the same heuristic class

Delegated to a research pass over `tools/*.sh`, `tools/lib/*.sh`, and `.github/workflows/*.yml`, independently spot-verified. Full result:

- **Already known and already fixed, not re-touched here**: plain shell `grep -I` (ugrep locally / GNU grep -I on Linux CI) silently drops `irrlicht.js` — fixed for `tools/state-vocabulary-lint.sh`'s corpus narrowing via `git grep -I` (whose own heuristic, NUL-within-first-8000-bytes, is identical on every platform).
- **`rg`/ripgrep**: zero occurrences anywhere in `tools/` or `.github/workflows/` — not applicable.
- **`git grep` without `-I`**: does not occur anywhere in the repo's tooling.
- **Bare (non-`git`) `grep` over tracked file content**: several `tools/lib/*_test.sh` files grep small hand-authored shell scripts (`site/install.sh`, `replaydata/agents/pi/driver*.sh`, workflow step bodies) — theoretical risk only, none of those targets is remotely likely to carry a NUL. Everything that greps `tools/preflight.sh`'s own content already uses `grep -a`.
- **`awk` with `RS=` slurp, or byte `length()`/`index()`/`substr()` over file content**: `RS=` is set nowhere in this repo's tooling except `tools/mutate.sh` (now protected). `tools/skill-lint.sh` uses the same line-at-a-time `index()`/`substr()`/`match()` shape as `state-vocabulary-lint.sh` below, over `.claude/skills/**/*.md` — no tracked skill file carries a NUL today, so currently a clean negative, but structurally the same latent risk. `tools/agents-md-lint.sh` uses pure `NR` counting only — confirmed safe (`awk 'END{print NR}'` is unaffected by an embedded NUL; verified directly against `irrlicht.js`: 2457, matching `wc -l`).
- **`wc -c`/`wc -l`, `find`/`xargs` + grep**: every other occurrence counts filenames, git-diff paths, or a tool's own generated plain-text output — never a pre-existing tracked file's content. Clean negatives.
- **`.github/workflows/*.yml`**: every `grep`/`awk`/`wc` found parses a *previous step's own process output* (a CI tool's stdout, `go tool cover`'s report, a build-generated manifest, `git diff --name-only`) — never repo source content directly. Clean negatives across `ars.yml`, `coverage.yml`, `macos-swift.yml`, `replaydata-deletion-guard.yml`, `linux.yml`; `ars-gate.yml`/`codescene-badge.yml`/`pages.yml`/`test.yml`/`web-test.yml` have no content-scanning at all.

**One new instance found, independently reproduced, filed separately rather than fixed here**: #1837 — `tools/state-vocabulary-lint.sh`'s *flagging* pass (`state_vocab_sites`, distinct from the already-fixed corpus-narrowing pass) uses the same bare, unprotected `awk` `index()`/regex shape, so a vocabulary word placed on the same physical line *after* an embedded NUL is invisible to it on macOS's system awk while gawk/mawk (Linux CI's default) and `git grep -I` see it correctly:
```
$ awk 'NR==1405{print index($0,"retry")}' platforms/web/irrlicht.js
0
$ gawk 'NR==1405{print index($0,"retry")}' platforms/web/irrlicht.js
42
```
Currently latent (no vocabulary word happens to sit after the NUL today, so `tools/preflight.sh --only tools` passes clean), but it's the identical local-macOS/CI-Linux asymmetry this file's own header already documents for the bug it did fix — filed as #1837 rather than folded into this PR, since a real fix needs its own scoping (force a byte-safe awk implementation, or a dedicated fixture) the way #1816 itself needed one, and mixing two distinct root causes/fixes into one diff isn't warranted here.

## Verification

`tools/preflight.sh --only tools|posix|bash|skills|go` and `--only arch` (advisory) all pass. `tools/mutate.sh` and `tools/lib/mutate_test.sh` both pass `shellcheck --shell=bash --severity=warning` individually.

Closes #1816.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
