### PR TITLE
fix(tools,skills): loud failure for three silent verification skips

### DIFF
--- a/.claude/skills/ir:exec/SKILL.md
+++ b/.claude/skills/ir:exec/SKILL.md
@@ -401,14 +401,22 @@ Nobody is gating on the plan, so skip the HTML artifact and the wait entirely:
     tools/preflight.sh --only tools
     tools/preflight.sh --only skills
     tools/preflight.sh --only posix
+    tools/preflight.sh --only bash
     tools/preflight.sh --only security
+    tools/preflight.sh --only swift     # only when the change touches platforms/macos/
     ```
-    (`tools/preflight.sh --help` lists the current group set — `--only linux`
-    is separately opt-in and needs Docker; skip it unless the change is
-    Linux-specific.) Every gate still runs; chunking only changes how many
-    `Bash` calls it takes. If `--only go` alone is close to timing out here,
-    that's expected — it's the long pole and there's no finer selector to fall
-    back to. AGENTS.md's Local CI parity section carries the same recipe.
+    (`tools/preflight.sh --help` lists the current group set — this list runs
+    every one of them except `--only linux`, which stays opt-in and needs
+    Docker; skip it unless the change is Linux-specific. This list previously
+    omitted `swift` and `bash` — #1823 — so an agent following it on a
+    `platforms/macos/` change skipped the whole macOS gate without either side
+    saying so; `tools/lib/preflight-groups-skill_test.sh` now derives the
+    canonical set from `--help` and fails loudly if this list and it disagree,
+    so that can't silently recur.) Every gate still runs; chunking only
+    changes how many `Bash` calls it takes. If `--only go` alone is close to
+    timing out here, that's expected — it's the long pole and there's no
+    finer selector to fall back to. AGENTS.md's Local CI parity section
+    carries the same recipe.
 
     **Never end a turn waiting on your own background or monitored work** — not
     `run_in_background: true`, not `Monitor`, not tailing a log file. A
@@ -876,8 +884,34 @@ either step.
     the review fixes went in. For **Medium/Large** diffs run the `/simplify`
     skill with the same explicit base (`/simplify origin/main...HEAD`, for the
     reason in step 13); for **Trivial/Small** diffs skip its 4-agent fan-out
-    and do the reuse/simplification/efficiency/altitude review inline, stating
-    what you checked. Push any cleanup.
+    and do the four-angle review yourself, inline.
+
+    **Whichever path this diff takes, the same four angles and the same
+    discipline apply: reuse, simplification, efficiency, altitude.** Before
+    treating the phase as complete, confirm each of the four was actually
+    considered and account for it by name — a finding, or an explicit
+    "clean" — reading `/simplify`'s own report on the Medium/Large path, or
+    your own inline pass on the Trivial/Small one. A silent angle — one
+    `/simplify`'s report never mentions, or one an inline "looked simple,
+    nothing to do" glance skipped without saying so — is indistinguishable
+    from never having been checked at all: on the Medium/Large path because
+    `/simplify` is a built-in this repo does not own and cannot edit or
+    instrument, and its own fan-out can silently drop a subagent while the
+    phase still reads as "done" (#1823); on the Trivial/Small path because an
+    inline pass with no per-angle accounting is exactly as easy to shortcut.
+    Nothing on our side can make the built-in itself fail loudly, and no lint
+    can watch an inline pass happen — `tools/lib/simplify-angle-guard_test.sh`
+    guards this paragraph's own wording against eroding out of the file, the
+    same way `tools/skill-lint.sh` guards other skill prose, but unlike step
+    13's `test -f` precondition it cannot observe whether a given run actually
+    did the confirming — so on both paths the obligation moves to
+    the same place: treat a silent angle the same as step 13's `MISSING`
+    reviewer — **surface it and pause** rather than pushing on. An aggregate
+    "no findings"/"done", or a vague "looked simple", does not stand in for
+    four individually-accounted-for ones. State in the transcript which of
+    the four you confirmed and what each found (or "clean"), the same way
+    step 13 requires an explicit "no findings" for the review subagent. Push
+    any cleanup.
 14a. **Clear the WIP marker** — active work on this branch is over, and the PR
     should stop saying otherwise before you hand it to a human. Do this only
     once step 13's findings are applied and step 14's cleanup is pushed; a run

--- a/tools/lib/go-vet-copylocks_test.sh
+++ b/tools/lib/go-vet-copylocks_test.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+# go-vet-copylocks_test.sh — the committed mutation fixture for #1823's
+# `go vet` addition to tools/preflight.sh's `go` group (the "go vet (core)"
+# and "go vet (onboarding-factory)" gates).
+#
+# WHY THIS FILE EXISTS. Those gates are a check the #1823 fix ADDS: it has
+# no "before the fix" to run red, so per AGENTS.md and
+# docs/testing-philosophy.md it earns its place only by being seen to fail
+# when the thing it protects is broken.
+#
+# The specific claim being proven is narrower than "go vet catches bugs" —
+# it is that `go vet` catches something `go test` (even under `-race`, which
+# is what tools/preflight.sh's own core module tests run) does NOT, so
+# adding `go vet` as its own gate is not redundant with the test suite
+# already there. `go test` runs a small "high confidence" subset of vet
+# automatically before compiling test binaries (atomic, bool, buildtags,
+# directive, errorsas, ifaceassert, nilfunc, printf, stringintconv) and that
+# subset excludes copylocks — passing or copying a value that contains a
+# sync.Mutex (or any sync.Locker). A copylocks violation is dead-simple to
+# introduce (a function declaring a by-value parameter of a lock-bearing
+# struct type) and needs no runtime exercise to be wrong: `go vet` flags it
+# at the declaration site, `go test` compiles and runs it clean regardless.
+#
+# The mutation adds exactly that: a never-called function taking
+# ConcurrencyTracker (which embeds resolveMu sync.Mutex) by value, into
+# core/adapters/outbound/filesystem/concurrency_tracker.go. Both checks run
+# under the SAME mutation in one tools/mutate.sh call, so the contrast is
+# read from a single, simultaneous snapshot rather than two separate runs
+# that could each have drifted:
+#   - `go vet ./core/adapters/outbound/filesystem/...`  MUST go red
+#   - `go test ./core/adapters/outbound/filesystem/... -count=1`  MUST stay green
+#
+# Scoped to the one package rather than the whole core module (unlike the
+# "go vet (core)" gate itself, which covers ./core/...) purely for fixture
+# runtime — this runs on every `tools/preflight.sh --only tools`, and the package-level
+# `go test` here is ~1s against core module tests' multi-minute full run.
+# The scope of the PROOF (one package) is independent of the scope of the
+# GUARD it backs (the whole module); the guard covers everything, the fixture
+# only needs one reachable example.
+#
+# tools/mutate.sh owns the mechanics this file must not re-improvise: the
+# stale-anchor guard, the no-op replacement refusal, and the byte-for-byte
+# restore that never touches git state (worktrees share the parent repo's
+# .git dir, so `git checkout --` / `git restore` / `git reset --hard` are
+# banned repo-wide).
+
+set -uo pipefail
+
+DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$DIR/../.." && pwd)"
+MUTATE_SH="$REPO_ROOT/tools/mutate.sh"
+TARGET_FILE="core/adapters/outbound/filesystem/concurrency_tracker.go"
+PKG="./core/adapters/outbound/filesystem/..."
+
+# A missing tool is a hard failure, not a skip — exiting 0 here would read as
+# a PASS to preflight's shell_lib_tests, so the gate would go green having
+# asserted nothing.
+need() { command -v "$1" >/dev/null 2>&1 || { echo "FAIL: go-vet-copylocks — $1 not found" >&2; exit 1; }; }
+need go
+need git
+
+if [[ ! -x "$MUTATE_SH" ]]; then
+  echo "FAIL: go-vet-copylocks — $MUTATE_SH is missing or not executable" >&2
+  exit 1
+fi
+if [[ ! -f "$REPO_ROOT/$TARGET_FILE" ]]; then
+  echo "FAIL: go-vet-copylocks — $TARGET_FILE not found" >&2
+  exit 1
+fi
+
+# mutate.sh refuses (exit 4) against an already-dirty tree, because its
+# post-restore emptiness check could prove nothing then.
+#
+# A DIRTY TREE MUST NOT SILENTLY PASS. This suite's runner (shell-lib-suite.sh)
+# judges a script by its EXIT STATUS and has no self-skip protocol, so an
+# `exit 0` here would make "the guard was verified" and "the guard could not
+# be checked at all" produce byte-identical results at the gate — exactly the
+# shape AGENTS.md forbids, and the same shape as the tripwire blind spot this
+# fixture exists to prevent regressing.
+#
+# So it is a HARD FAILURE wherever the answer is load-bearing (CI, and any
+# caller that sets MUTATION_FIXTURES_STRICT=1), and a loud, non-silent skip on
+# a developer's dirty worktree, where failing would only train people to
+# delete the fixture.
+if [[ -n "$(git -C "$REPO_ROOT" status --porcelain)" ]]; then
+  echo "go-vet-copylocks: CANNOT RUN — the worktree is dirty, and mutate.sh needs a" >&2
+  echo "  clean tree for its post-restore check to mean anything. Commit or clean up, then:" >&2
+  echo "    bash tools/lib/go-vet-copylocks_test.sh" >&2
+  if [[ -n "${CI:-}" || -n "${MUTATION_FIXTURES_STRICT:-}" ]]; then
+    echo "  (failing rather than skipping: CI/strict mode, where a skip is indistinguishable" >&2
+    echo "   from a pass and this gate is the only thing re-running this mutation)" >&2
+    exit 1
+  fi
+  echo "  (skipped locally; set MUTATION_FIXTURES_STRICT=1 to make this a failure)" >&2
+  exit 0
+fi
+
+ANCHOR='const unresolvedTTL = 30 * time.Second
+'
+REPLACEMENT='const unresolvedTTL = 30 * time.Second
+
+// copylocksViolationFixture is injected by
+// tools/lib/go-vet-copylocks_test.sh (#1823) to prove `go vet` flags passing
+// a lock by value where `go test` alone does not. Dead code, never called —
+// a pure static vet finding, not a behavior change. tools/mutate.sh restores
+// this file byte-for-byte immediately after the fixture runs.
+func copylocksViolationFixture(t ConcurrencyTracker) { _ = t }
+'
+
+out="$(cd "$REPO_ROOT" && "$MUTATE_SH" "$TARGET_FILE" "$ANCHOR" "$REPLACEMENT" \
+  bash -c "go vet $PKG; echo GO_VET_RC=\$?; go test $PKG -count=1; echo GO_TEST_RC=\$?" 2>&1)"
+rc=$?
+
+fails=0
+
+# mutate.sh exits 0 when the mutation applied and the tree was restored,
+# WHATEVER the inner commands did — their results are in the captured text.
+# A non-zero rc is mutate.sh itself refusing (STALE anchor, dirty tree, ...),
+# which is a fixture bug, not a finding about the guard.
+if [[ $rc -ne 0 ]]; then
+  echo "FAIL: go-vet-copylocks — mutate.sh refused (exit $rc). A STALE anchor means the"
+  echo "      surrounding text moved and this fixture needs its anchor updated; it does"
+  echo "      NOT mean the go vet gates are fine."
+  echo "$out" | sed 's/^/      | /'
+  fails=$((fails + 1))
+else
+  # go vet MUST go red, naming the copylocks violation specifically — not
+  # merely a non-zero exit, which a compile error or a different vet check
+  # could also produce and would read as success for the wrong reason.
+  if ! grep -q 'GO_VET_RC=[1-9]' <<<"$out"; then
+    echo "FAIL: go-vet-copylocks — go vet stayed GREEN (exit 0) under a copylocks violation;"
+    echo "      the go vet (core) gate does not reach what it claims to cover."
+    echo "$out" | sed 's/^/      | /'
+    fails=$((fails + 1))
+  elif ! grep -qF 'passes lock by value' <<<"$out" || ! grep -qF 'contains sync.Mutex' <<<"$out"; then
+    echo "FAIL: go-vet-copylocks — go vet failed, but not with a copylocks message."
+    echo "$out" | sed 's/^/      | /'
+    fails=$((fails + 1))
+  else
+    echo "ok  go vet goes RED on a copylocks violation"
+  fi
+
+  # go test MUST stay green under the identical mutation — this is the other
+  # half of the claim: the existing `-race` test suite does not reach this
+  # class of defect at all, so `go vet` is not redundant with it.
+  if ! grep -q 'GO_TEST_RC=0' <<<"$out"; then
+    echo "FAIL: go-vet-copylocks — go test did NOT stay green under the same mutation, so"
+    echo "      this fixture no longer demonstrates the contrast it exists to prove."
+    echo "$out" | sed 's/^/      | /'
+    fails=$((fails + 1))
+  else
+    echo "ok  go test stays GREEN on the same copylocks violation"
+  fi
+fi
+
+if [[ $fails -gt 0 ]]; then
+  echo "go-vet-copylocks: $fails FAILED"
+  exit 1
+fi
+echo "go-vet-copylocks: ALL PASS"

--- a/tools/lib/mutation-assert.sh
+++ b/tools/lib/mutation-assert.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# mutation-assert.sh — the shared `assert_mutation_is_red` helper for
+# tools/mutate.sh-based mutation-fixture tests whose lock test reports its
+# failures as `^FAIL: ` lines containing a specific message (#1823 review
+# finding: this exact ~40-line function was copy-pasted byte-for-byte into
+# two new fixture files added by the same diff; a third pre-existing fixture,
+# tools/lib/error-retention-mutations_test.sh, hand-rolls a DIFFERENT 6-arg
+# variant built around `go test -run <name>` rather than a lock-test script,
+# so it is left as-is here rather than forced into this shape).
+#
+# Sourced, not executed:
+#
+#   . tools/lib/mutation-assert.sh
+#   fails=0
+#   assert_mutation_is_red "<label>" "<file>" "<anchor>" "<replacement>" "<want_match>"
+#   [[ $fails -gt 0 ]] && exit 1
+#
+# Requires the caller to have already set (both are per-caller, not
+# per-mutation, so they stay caller-side rather than becoming two more
+# parameters every call site has to repeat):
+#   REPO_ROOT   — passed to `cd` before invoking mutate.sh, so <file> and
+#                 LOCK_TEST are read relative to the repo root regardless of
+#                 the caller's own cwd.
+#   MUTATE_SH   — path to tools/mutate.sh.
+#   LOCK_TEST   — the lock-test script (repo-relative) that must go red
+#                 under the mutation.
+#   fails       — a plain integer the caller declared with `fails=0`; this
+#                 function increments it in the caller's own shell (no
+#                 subshell), so results accumulate across every call the
+#                 caller makes before checking `$fails` once at the end.
+set -uo pipefail
+
+# assert_mutation_is_red <label> <file> <anchor> <replacement> <want_match>
+#
+# Applies one mutation via tools/mutate.sh and requires LOCK_TEST to FAIL
+# under it, and to name `want_match` in its output.
+#
+# Both halves matter. A mutation that leaves the lock test green means the
+# guard does not reach what it claims to cover. A mutation that goes red for
+# the WRONG reason (a shell syntax error, a missing file) would otherwise
+# read as success — so the expected failure text is asserted too, not just
+# the exit status.
+assert_mutation_is_red() {
+  local label="$1" file="$2" anchor="$3" replacement="$4" want_match="$5"
+  local out rc
+
+  out="$(cd "$REPO_ROOT" && "$MUTATE_SH" "$file" "$anchor" "$replacement" \
+    bash "$LOCK_TEST" 2>&1)"
+  rc=$?
+
+  # mutate.sh exits 0 when the mutation applied and the tree was restored,
+  # WHATEVER the inner command did — the inner result is in the captured
+  # text. A non-zero rc is mutate.sh itself refusing (STALE anchor, dirty
+  # tree, ...), which is a fixture bug, not a finding about the guard.
+  if [[ $rc -ne 0 ]]; then
+    echo "FAIL: $label — mutate.sh refused (exit $rc). A STALE anchor means the surrounding text"
+    echo "      moved and this fixture needs its anchor updated; it does NOT mean the guard is fine."
+    echo "$out" | sed 's/^/      | /'
+    fails=$((fails + 1))
+    return
+  fi
+
+  # The mutation must make the lock test fail...
+  if ! grep -qE '^FAIL:' <<<"$out"; then
+    echo "FAIL: $label — $LOCK_TEST stayed GREEN under the mutation, so the guard does not reach"
+    echo "      what it claims to protect."
+    echo "$out" | sed 's/^/      | /'
+    fails=$((fails + 1))
+    return
+  fi
+
+  # ...and fail for the RIGHT reason.
+  if ! grep -qF "$want_match" <<<"$out"; then
+    echo "FAIL: $label — $LOCK_TEST failed, but not with the expected message."
+    echo "      wanted to find: $want_match"
+    echo "$out" | sed 's/^/      | /'
+    fails=$((fails + 1))
+    return
+  fi
+
+  echo "ok  $label"
+}

--- a/tools/lib/preflight-groups-skill-mutations_test.sh
+++ b/tools/lib/preflight-groups-skill-mutations_test.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# preflight-groups-skill-mutations_test.sh — the committed mutation fixtures
+# for tools/lib/preflight-groups-skill_test.sh (#1823).
+#
+# WHY THIS FILE EXISTS. preflight-groups-skill_test.sh is a check the #1823
+# fix ADDS: it has no "before the fix" to run red, so per AGENTS.md and
+# docs/testing-philosophy.md it earns its place only by being seen to fail
+# when the thing it protects is broken. Two independent breakages, proven
+# separately because a single combined mutation could pass while one of them
+# was actually unguarded:
+#
+#   1. THE SKILL DROPS A GROUP — .claude/skills/ir:exec/SKILL.md's chunk list
+#      loses a line (the actual #1823 defect: `swift` and `bash` were both
+#      missing). Removing `bash` here stands in for either.
+#
+#   2. PREFLIGHT GAINS A GROUP the skill never mentions — tools/preflight.sh's
+#      VALID_GROUPS array gains a new entry, and the skill's list is never
+#      updated to match. This is the direction a hand-corrected list (rather
+#      than a derived one) cannot catch: fixing today's omission does
+#      nothing for tomorrow's addition.
+#
+# Every row drives the real tools/mutate.sh, which owns the mechanics this
+# file must not re-improvise: the stale-anchor guard, the no-op replacement
+# refusal, and the byte-for-byte restore that never touches git state
+# (worktrees share the parent repo's .git dir, so `git checkout --` /
+# `git restore` / `git reset --hard` are banned repo-wide).
+#
+# The `assert_mutation_is_red` mechanics live in tools/lib/mutation-assert.sh,
+# shared with tools/lib/simplify-angle-guard-mutations_test.sh (#1823 review:
+# the two were originally byte-identical copies in this diff). Convention for
+# the rest follows tools/lib/error-retention-mutations_test.sh: plain bash, a
+# `fails` counter, "ALL PASS" / "N FAILED" at the end — that file keeps its
+# own DIFFERENT 6-arg `go test -run` variant rather than being folded in here,
+# since its shape genuinely differs, not just its wording.
+
+set -uo pipefail
+
+DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$DIR/../.." && pwd)"
+MUTATE_SH="$REPO_ROOT/tools/mutate.sh"
+# shellcheck disable=SC2034  # read by assert_mutation_is_red in the sourced mutation-assert.sh, not here
+LOCK_TEST="tools/lib/preflight-groups-skill_test.sh"
+
+# shellcheck source=tools/lib/mutation-assert.sh
+. "$DIR/mutation-assert.sh"
+
+# A missing tool is a hard failure, not a skip — exiting 0 here would read as
+# a PASS to preflight's shell_lib_tests, so the gate would go green having
+# asserted nothing.
+need() { command -v "$1" >/dev/null 2>&1 || { echo "FAIL: preflight-groups-skill-mutations — $1 not found" >&2; exit 1; }; }
+need bash
+need git
+
+if [[ ! -x "$MUTATE_SH" ]]; then
+  echo "FAIL: preflight-groups-skill-mutations — $MUTATE_SH is missing or not executable" >&2
+  exit 1
+fi
+
+# mutate.sh refuses (exit 4) against an already-dirty tree, because its
+# post-restore emptiness check could prove nothing then.
+#
+# A DIRTY TREE MUST NOT SILENTLY PASS. This suite's runner (shell-lib-suite.sh)
+# judges a script by its EXIT STATUS and has no self-skip protocol, so an
+# `exit 0` here would make "the guard was verified" and "the guard could not
+# be checked at all" produce byte-identical results at the gate — exactly the
+# shape AGENTS.md forbids, and the same shape as the tripwire blind spot this
+# fixture exists to prevent regressing.
+#
+# So it is a HARD FAILURE wherever the answer is load-bearing (CI, and any
+# caller that sets MUTATION_FIXTURES_STRICT=1), and a loud, non-silent skip on
+# a developer's dirty worktree, where failing would only train people to
+# delete the fixture.
+if [[ -n "$(git -C "$REPO_ROOT" status --porcelain)" ]]; then
+  echo "preflight-groups-skill-mutations: CANNOT RUN — the worktree is dirty, and mutate.sh needs a" >&2
+  echo "  clean tree for its post-restore check to mean anything. Commit or clean up, then:" >&2
+  echo "    bash tools/lib/preflight-groups-skill-mutations_test.sh" >&2
+  if [[ -n "${CI:-}" || -n "${MUTATION_FIXTURES_STRICT:-}" ]]; then
+    echo "  (failing rather than skipping: CI/strict mode, where a skip is indistinguishable" >&2
+    echo "   from a pass and this gate is the only thing re-running these mutations)" >&2
+    exit 1
+  fi
+  echo "  (skipped locally; set MUTATION_FIXTURES_STRICT=1 to make this a failure)" >&2
+  exit 0
+fi
+
+fails=0
+
+# ── 1. The skill DROPS a group (the actual #1823 defect) ────────────────────
+# Removing `--only bash` from the chunk list must be caught even though every
+# other line still matches.
+assert_mutation_is_red \
+  "lock test catches SKILL.md dropping a group from its chunk list" \
+  ".claude/skills/ir:exec/SKILL.md" \
+  $'    tools/preflight.sh --only posix\n    tools/preflight.sh --only bash\n' \
+  $'    tools/preflight.sh --only posix\n' \
+  'only in VALID_GROUPS: bash'
+
+# ── 2. preflight.sh's VALID_GROUPS GAINS a group the skill never mentions ───
+# A future new group added to VALID_GROUPS but never added to the skill's
+# chunk list is the direction a one-time hand correction cannot catch; only
+# a derived comparison does.
+assert_mutation_is_red \
+  "lock test catches VALID_GROUPS gaining a group the skill omits" \
+  "tools/preflight.sh" \
+  $'VALID_GROUPS=(go web arch tools skills posix bash security swift linux)' \
+  $'VALID_GROUPS=(go web arch tools skills posix bash security swift linux wasm)' \
+  'only in VALID_GROUPS: wasm'
+
+if [[ $fails -gt 0 ]]; then
+  echo "preflight-groups-skill-mutations: $fails FAILED"
+  exit 1
+fi
+echo "preflight-groups-skill-mutations: ALL PASS"

--- a/tools/lib/preflight-groups-skill_test.sh
+++ b/tools/lib/preflight-groups-skill_test.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# preflight-groups-skill_test.sh — hold ir:exec SKILL.md's preflight `--only`
+# chunk list against tools/preflight.sh's own VALID_GROUPS array (#1823).
+#
+# WHY THIS EXISTS. `.claude/skills/ir:exec/SKILL.md`'s Phase 4 step 11 tells
+# every agent chunking `tools/preflight.sh` by `--only <group>` which groups
+# to run. That list is hand-typed prose, not derived from anything — and it
+# drifted: it named seven groups and silently omitted `swift` and `bash`,
+# which `tools/preflight.sh` has accepted all along. An agent following only
+# the skill on a `platforms/macos/` change skipped the whole macOS gate, and
+# nothing said so — the skill's list and the real group set disagreed and
+# both looked equally authoritative. A corrected hand-typed list fixes
+# today's drift and guarantees a future one: the failure mode is the list
+# itself, not any one omission from it.
+#
+# So this derives the canonical group set from `VALID_GROUPS` — the array at
+# tools/preflight.sh's own `--only` argument-parsing site that actually
+# DECIDES which values are accepted (an unrecognised one is refused, exit 2)
+# — rather than from `--help`'s free-text Usage comment, which is a second,
+# independently hand-maintained description of the same set with nothing
+# tying it back to `VALID_GROUPS` either. Deriving from the Usage comment
+# would only move #1823's failure mode one hop down the chain: a group added
+# to `VALID_GROUPS` without a matching Usage line would still read as
+# "canonical" and this lock would stay green while the real behavior drifted
+# out from under it. `VALID_GROUPS` is the one place a wrong answer is
+# actually unreachable — `--only` itself refuses anything not in it.
+#
+# Read as a literal via `sed`, not by sourcing tools/preflight.sh (which
+# would run its whole argument-parsing/gate machinery) — the same technique
+# tools/lib/module-list_test.sh already uses to read `WEB_TREES=(...)` out of
+# tools/security-scan.sh without executing it.
+#
+# It compares against what the skill's own chunk-list code block actually
+# names. `linux` is excluded on both sides: both AGENTS.md and the skill
+# document it as deliberately opt-in (needs Docker) and carve it out of the
+# chunk list in prose right next to it, so its absence from the list is a
+# documented decision, not the drift this test exists to catch.
+#
+# This is a LOCK: it passes today by construction, because the fix above just
+# made the two sides agree. Its value is that it CAN fail — proven by
+# tools/lib/preflight-groups-skill-mutations_test.sh, which mutates one side
+# with tools/mutate.sh and asserts this file goes red, then restores.
+set -uo pipefail
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+# Every path below is repo-relative, so a failed cd would compare whatever
+# happens to sit in the caller's cwd instead of the repo — most likely
+# nothing on either side, which reads as a match. Exit instead (SC2164).
+cd "$REPO_ROOT" || { echo "FAIL: cannot cd to repo root $REPO_ROOT" >&2; exit 1; }
+
+SKILL_FILE=".claude/skills/ir:exec/SKILL.md"
+PREFLIGHT="tools/preflight.sh"
+rc=0
+fail() { echo "FAIL: $1" >&2; rc=1; }
+
+[ -f "$SKILL_FILE" ] || { echo "FAIL: preflight-groups-skill_test — $SKILL_FILE not found" >&2; exit 1; }
+[ -f "$PREFLIGHT" ] || { echo "FAIL: preflight-groups-skill_test — $PREFLIGHT not found" >&2; exit 1; }
+
+# --- derive the canonical group set from preflight.sh's own VALID_GROUPS --
+all_groups=$(sed -n 's/^VALID_GROUPS=(\(.*\))$/\1/p' "$PREFLIGHT" | tr ' ' '\n' | sed '/^$/d' | sort -u)
+if [ -z "$all_groups" ]; then
+  echo "FAIL: preflight-groups-skill_test — could not read a 'VALID_GROUPS=(...)' array literal out of $PREFLIGHT; cannot derive the canonical group list" >&2
+  exit 1
+fi
+
+# The `linux` exclusion is asserted, not assumed: if VALID_GROUPS ever stops
+# naming a `linux` group (renamed, removed), filtering it below would
+# silently do nothing and this test would start comparing against the WRONG
+# canonical set without ever saying so — the same "exclusion stopped
+# matching, gate stays green" shape shell-lib-suite.sh's skip-list
+# validation guards.
+if ! grep -qx 'linux' <<<"$all_groups"; then
+  fail "expected $PREFLIGHT's VALID_GROUPS to list a 'linux' group to exclude (the skill documents omitting it deliberately); it does not — the exclusion is stale or was never valid"
+fi
+canonical_groups=$(printf '%s\n' "$all_groups" | grep -vx 'linux')
+
+# --- extract the group list from SKILL.md's own chunk-list code block -----
+# Anchored on the sentence introducing the fenced block, not on a line
+# number — line numbers drift on every unrelated edit above this point.
+skill_block=$(awk '
+  /chunk: run each/ { armed = 1 }
+  armed && /^[[:space:]]*```bash/ { infence = 1; next }
+  infence && /^[[:space:]]*```/ { exit }
+  infence { print }
+' "$SKILL_FILE")
+
+if [ -z "$skill_block" ]; then
+  echo "FAIL: preflight-groups-skill_test — could not find the chunk-list code block in $SKILL_FILE (the anchor text may have moved); cannot verify anything" >&2
+  exit 1
+fi
+
+skill_groups=$(printf '%s\n' "$skill_block" | grep -oE -- '--only [a-z]+' | awk '{print $2}' | sort -u)
+if [ -z "$skill_groups" ]; then
+  echo "FAIL: preflight-groups-skill_test — the chunk-list code block in $SKILL_FILE names no '--only <group>' line" >&2
+  exit 1
+fi
+
+if [ "$canonical_groups" != "$skill_groups" ]; then
+  fail "$SKILL_FILE's preflight chunk list disagrees with $PREFLIGHT's VALID_GROUPS (excluding the deliberately-omitted linux group)"
+  diff <(echo "$canonical_groups") <(echo "$skill_groups") \
+    | sed 's/^/  /; s/^  < /  only in VALID_GROUPS: /; s/^  > /  only in SKILL.md: /' >&2
+fi
+
+if [ "$rc" -eq 0 ]; then
+  echo "OK: preflight-groups-skill_test — $SKILL_FILE's chunk list matches $PREFLIGHT's VALID_GROUPS ($(printf '%s' "$canonical_groups" | tr '\n' ' '))"
+fi
+exit "$rc"

--- a/tools/lib/shell-lib-errexit_test.sh
+++ b/tools/lib/shell-lib-errexit_test.sh
@@ -523,12 +523,16 @@ row 'swift-suite.sh::_swift_suite_witness_domain_verdict' '_swift_suite_witness_
 # ACTIVE on this host, so an entry that stops naming a real function fails
 # rather than quietly doing nothing. tw_exempt_reason returns non-zero when the
 # function is drivable here, in which case its recipe runs normally.
-TW_EXEMPT_KEYS='swift-suite.sh::swift_suite_run'
+TW_EXEMPT_KEYS='swift-suite.sh::swift_suite_run mutation-assert.sh::assert_mutation_is_red'
 tw_exempt_reason() {
   case "$1" in
     'swift-suite.sh::swift_suite_run')
       [[ "$(uname -s)" == "Darwin" ]] && return 1
       echo "needs BSD script(1) for its pty; the spelling and argument order differ on $(uname -s), and the only production caller is a Darwin-guarded gate. Driven on macOS, which is where test.yml runs this suite."
+      return 0
+      ;;
+    'mutation-assert.sh::assert_mutation_is_red')
+      echo "drives tools/mutate.sh against a REAL tracked file and requires a clean git worktree as mutate.sh's own precondition (exit 4 otherwise) — the fixture-dependency category this file's own header names as exempt-worthy (#1823), not something safe to blind-call from a generic per-function walk. Its two callers (preflight-groups-skill-mutations_test.sh, simplify-angle-guard-mutations_test.sh) already exercise it directly and run under CI; both run under 'set -uo pipefail', never '-e', so the errexit contract this tripwire checks is not live for it in production use either."
       return 0
       ;;
   esac

--- a/tools/lib/simplify-angle-guard-mutations_test.sh
+++ b/tools/lib/simplify-angle-guard-mutations_test.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# simplify-angle-guard-mutations_test.sh — the committed mutation fixtures for
+# tools/lib/simplify-angle-guard_test.sh (#1823).
+#
+# WHY THIS FILE EXISTS. simplify-angle-guard_test.sh is a check the #1823 fix
+# ADDS: it has no "before the fix" to run red, so per AGENTS.md and
+# docs/testing-philosophy.md it earns its place only by being seen to fail
+# when the thing it protects is broken. Two independent breakages, proven
+# separately because a single combined mutation could pass while one of them
+# was actually unguarded:
+#
+#   1. AN ANGLE NAME IS DROPPED from step 14's own text — an agent reading
+#      only this step would no longer know that angle exists to check for.
+#      Dropping `altitude` stands in for any of the four.
+#
+#   2. THE LOUD-FAILURE INSTRUCTION IS SOFTENED — "surface it and pause"
+#      (this skill's own established stop-the-run idiom) replaced with a
+#      "be careful" style caveat that nothing enforces. This is the exact
+#      shape AGENTS.md calls out by name: "do not paper over it by simply
+#      telling agents to be careful" — a softened instruction still LOOKS
+#      like guidance and would pass a casual re-read.
+#
+# Every row drives the real tools/mutate.sh, which owns the mechanics this
+# file must not re-improvise: the stale-anchor guard, the no-op replacement
+# refusal, and the byte-for-byte restore that never touches git state
+# (worktrees share the parent repo's .git dir, so `git checkout --` /
+# `git restore` / `git reset --hard` are banned repo-wide).
+#
+# The `assert_mutation_is_red` mechanics live in tools/lib/mutation-assert.sh,
+# shared with tools/lib/preflight-groups-skill-mutations_test.sh (#1823
+# review: the two were originally byte-identical copies in this diff).
+# Convention for the rest follows tools/lib/error-retention-mutations_test.sh:
+# plain bash, a `fails` counter, "ALL PASS" / "N FAILED" at the end.
+
+set -uo pipefail
+
+DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$DIR/../.." && pwd)"
+MUTATE_SH="$REPO_ROOT/tools/mutate.sh"
+# shellcheck disable=SC2034  # read by assert_mutation_is_red in the sourced mutation-assert.sh, not here
+LOCK_TEST="tools/lib/simplify-angle-guard_test.sh"
+SKILL_FILE=".claude/skills/ir:exec/SKILL.md"
+
+# shellcheck source=tools/lib/mutation-assert.sh
+. "$DIR/mutation-assert.sh"
+
+need() { command -v "$1" >/dev/null 2>&1 || { echo "FAIL: simplify-angle-guard-mutations — $1 not found" >&2; exit 1; }; }
+need bash
+need git
+
+if [[ ! -x "$MUTATE_SH" ]]; then
+  echo "FAIL: simplify-angle-guard-mutations — $MUTATE_SH is missing or not executable" >&2
+  exit 1
+fi
+
+# mutate.sh refuses (exit 4) against an already-dirty tree, because its
+# post-restore emptiness check could prove nothing then.
+#
+# A DIRTY TREE MUST NOT SILENTLY PASS — see error-retention-mutations_test.sh
+# for the full reasoning; this file repeats the same guard rather than
+# sourcing it, matching the convention every fixture in this directory uses.
+if [[ -n "$(git -C "$REPO_ROOT" status --porcelain)" ]]; then
+  echo "simplify-angle-guard-mutations: CANNOT RUN — the worktree is dirty, and mutate.sh needs a" >&2
+  echo "  clean tree for its post-restore check to mean anything. Commit or clean up, then:" >&2
+  echo "    bash tools/lib/simplify-angle-guard-mutations_test.sh" >&2
+  if [[ -n "${CI:-}" || -n "${MUTATION_FIXTURES_STRICT:-}" ]]; then
+    echo "  (failing rather than skipping: CI/strict mode, where a skip is indistinguishable" >&2
+    echo "   from a pass and this gate is the only thing re-running these mutations)" >&2
+    exit 1
+  fi
+  echo "  (skipped locally; set MUTATION_FIXTURES_STRICT=1 to make this a failure)" >&2
+  exit 0
+fi
+
+fails=0
+
+# ── 1. An angle name is dropped from step 14's own text ─────────────────────
+assert_mutation_is_red \
+  "lock test catches step 14 dropping the 'altitude' angle" \
+  "$SKILL_FILE" \
+  $'discipline apply: reuse, simplification, efficiency, altitude.** Before' \
+  $'discipline apply: reuse, simplification, efficiency.** Before' \
+  "no longer enumerates all four angles"
+
+# ── 2. The loud-failure instruction is softened ──────────────────────────────
+assert_mutation_is_red \
+  "lock test catches step 14 softening 'surface it and pause' into a caveat" \
+  "$SKILL_FILE" \
+  $'    reviewer — **surface it and pause** rather than pushing on. An aggregate\n    "no findings"/"done", or a vague "looked simple", does not stand in for' \
+  $'    reviewer — proceed carefully rather than pushing on. An aggregate\n    "no findings"/"done", or a vague "looked simple", does not stand in for' \
+  "no longer pairs the four-angle check with a 'surface it and pause' instruction"
+
+if [[ $fails -gt 0 ]]; then
+  echo "simplify-angle-guard-mutations: $fails FAILED"
+  exit 1
+fi
+echo "simplify-angle-guard-mutations: ALL PASS"

--- a/tools/lib/simplify-angle-guard_test.sh
+++ b/tools/lib/simplify-angle-guard_test.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# simplify-angle-guard_test.sh — hold ir:exec SKILL.md's step 14 to a
+# mechanical requirement: it must instruct the agent to confirm all four of
+# `/simplify`'s review angles reported back, and to fail LOUDLY (surface and
+# pause) rather than silently when one didn't (#1823).
+#
+# WHY THIS EXISTS. `/simplify` is a built-in skill — `ls .claude/skills/`
+# lists only `ir:*` skills, so it cannot be edited or instrumented from this
+# repo. Its own fan-out silently dropped three of four review angles in a
+# real run while the phase still reported success; nothing on our side can
+# make the BUILT-IN itself fail loudly. The only lever this repo has is the
+# instruction the calling skill gives the agent that invokes it — so the fix
+# had to land in .claude/skills/ir:exec/SKILL.md's own step 14, not in
+# `/simplify`.
+#
+# A prose fix on its own is exactly the failure this issue is about: none of
+# the three instances #1823 reports were caught by review, because a
+# verification step that silently stopped mattering reads identically to one
+# that never needed to fire. So the requirement itself needs a mechanical
+# check that can go stale-and-caught rather than stale-and-silent — this is
+# that check. It is a LOCK (passes today by construction, since the fix above
+# just added the text) proven capable of failing by
+# tools/lib/simplify-angle-guard-mutations_test.sh, which deletes the
+# requirement with tools/mutate.sh and confirms this goes red, then restores.
+#
+# What is (and isn't) checked. This cannot verify that a running agent
+# actually reads `/simplify`'s report and confirms all four angles — no
+# static check can enforce runtime behavior of a black-box built-in. What it
+# CAN verify, and does: the instruction to do so is present, names all four
+# angles by their real names (reuse, simplification, efficiency, altitude —
+# `/simplify`'s own skill description uses the same four words), and pairs
+# them with this skill's own established loud-failure idiom ("surface it and
+# pause", already used for step 13's MISSING reviewer and step 9's failed
+# self-assign) rather than a softer "be careful" phrasing that nothing
+# enforces. That is the same class of guarantee tools/skill-lint.sh and
+# tools/state-vocabulary-lint.sh already give this repo's other skill
+# prose: not proof of compliance, but proof the instruction cannot silently
+# erode out of the file the way the underlying defect did.
+set -uo pipefail
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+cd "$REPO_ROOT" || { echo "FAIL: cannot cd to repo root $REPO_ROOT" >&2; exit 1; }
+
+SKILL_FILE=".claude/skills/ir:exec/SKILL.md"
+rc=0
+fail() { echo "FAIL: $1" >&2; rc=1; }
+
+[ -f "$SKILL_FILE" ] || { echo "FAIL: simplify-angle-guard_test — $SKILL_FILE not found" >&2; exit 1; }
+
+# Anchored on step 14's own heading text through the next numbered step (14a)
+# — not a line range, which drifts on every unrelated edit above this point.
+step14=$(awk '
+  /^14\. \*\*Simplify per the tier\.\*\*/ { armed = 1 }
+  armed && /^14a\./ { exit }
+  armed { print }
+' "$SKILL_FILE")
+
+if [ -z "$step14" ]; then
+  echo "FAIL: simplify-angle-guard_test — could not find step 14 (the /simplify step) in $SKILL_FILE; its heading text may have moved. Cannot verify anything." >&2
+  exit 1
+fi
+
+# Both checks below match against a whitespace-joined copy, not $step14
+# directly: markdown's own line wrap can legitimately split either phrase
+# across two source lines without changing what a reader sees rendered, and
+# a literal multi-line grep would then report the phrase missing when it
+# plainly isn't — the exact "absence of a finding and inability to look
+# produce the same output" shape this whole issue is about, one layer down
+# in this test itself. Computed once and reused by both checks below, since
+# neither mutates $step14 in between.
+step14_joined=$(printf '%s' "$step14" | tr '\n' ' ')
+
+# All four angle names, together, in the enumeration that introduces the
+# verification requirement — not a bare substring search for each word.
+# Step 14 already said "reuse/simplification/efficiency/altitude" in its
+# pre-#1823 Trivial/Small inline-review sentence (slash-separated), so a
+# per-word `grep -qF "$angle"` would stay green even after the #1823
+# verification sentence itself lost one — it would just be reading the OLD
+# mention and calling it proof. The comma-separated form below is unique to
+# the new sentence, so dropping an angle from THAT enumeration is what this
+# must catch.
+if ! grep -qF 'reuse, simplification, efficiency, altitude' <<<"$step14_joined"; then
+  fail "$SKILL_FILE step 14 no longer enumerates all four angles (reuse, simplification, efficiency, altitude) together in its verification sentence — an agent reading only this step has no complete list to check /simplify's report against"
+fi
+
+# The loud-failure idiom itself: silence on an angle must read as a stop, not
+# a caveat. "surface it and pause" is this skill's own established phrase for
+# exactly this class of gate (step 9's failed self-assign, step 13's MISSING
+# reviewer) — reusing it, rather than inventing new wording, is what keeps a
+# future reader's grep for the idiom complete.
+if ! grep -qF 'surface it and pause' <<<"$step14_joined"; then
+  fail "$SKILL_FILE step 14 no longer pairs the four-angle check with a 'surface it and pause' instruction — a dropped angle would read as a caveat, not a stop"
+fi
+
+if [ "$rc" -eq 0 ]; then
+  echo "OK: simplify-angle-guard_test — $SKILL_FILE step 14 names all four /simplify angles and requires surfacing a silent one"
+fi
+exit "$rc"

--- a/tools/preflight.sh
+++ b/tools/preflight.sh
@@ -321,6 +321,39 @@ gofmt_check() {
   fi
 }
 
+# go vet — deliberately NOT the small "high confidence" subset (atomic,
+# bool, buildtags, directive, errorsas, ifaceassert, nilfunc, printf,
+# stringintconv) that `go test` runs automatically before compiling test
+# binaries. That subset EXCLUDES copylocks, the check that flags a struct
+# holding a sync.Mutex (or any other sync.Locker) getting copied by value —
+# a real defect `go test`, even under `-race`, does not reach unless the
+# copy happens to be exercised concurrently at runtime. #1823: nothing in
+# this repo ran full `go vet` anywhere before this (`git grep -n "go vet"
+# -- tools/preflight.sh tools/lib` returned nothing), so every agent that
+# ran it during the #1796 epic did so only because a human typed it into
+# their prompt. tools/lib/go-vet-copylocks_test.sh carries the committed
+# proof: a copylocks violation that leaves `go test` green and this red.
+#
+# Scoped and placed alongside `core_module_tests`/the onboarding-factory
+# `go test` call below (Phase 2, same trigger regexes), not unscoped in
+# Phase 1 next to gofmt: unlike gofmt, `go vet` has no CI-parity gate to
+# mirror (`.github/workflows/test.yml` runs gofmt but never vet) and costs
+# 10-100x gofmt's ~0.1s (measured ~9.3s cold-cache for `./core/...` alone),
+# so running it unconditionally under `--changed` broke that mode's own
+# documented contract (line 73-74: "scope every gate to the packages/trees
+# this branch changes") for no CI-parity reason. Two independent gates,
+# not one chained with `&&`: a chain would let a core/ vet failure
+# short-circuit past an unrelated onboarding-factory violation and hide it
+# until the first one is fixed and the gate re-run.
+#
+# `go_vet_core` (below `core_module_tests`) goes one level further than the
+# trigger regex: it reuses `changed_core_packages` so a single-package
+# `--changed` diff vets that one package, not `./core/...` whole — matching
+# `core_module_tests`'s own scoping exactly, not just its trigger. The
+# onboarding-factory `go test` gate was already unscoped to its own module
+# before this change, so `go vet (onboarding-factory)` matches its sibling
+# as-is with no equivalent helper needed.
+
 # changed_core_packages — import paths of the changed core/ packages that
 # still exist (renames/deletions are dropped by the `go list` guard), plus the
 # module-root package irrlicht/core that hosts architecture_test.go. Including
@@ -350,6 +383,26 @@ core_module_tests() {
   echo "scoped to changed packages:"
   printf '  %s\n' $pkgs
   go test $pkgs -race -count=1
+}
+
+# go_vet_core — same package-list scoping as core_module_tests immediately
+# above (same helper, same go.mod/go.sum fallback-to-full rule), so a
+# single-package `--changed` diff pays for one package's vet, not the whole
+# module's. Kept as its own function rather than a parameter to
+# core_module_tests: `go vet` and `go test -race` are different gates with
+# different names in the summary (#1823 review — chaining them with `&&`
+# would let one mask the other's failure), so they stay two call sites that
+# happen to share this one piece of scoping logic.
+go_vet_core() {
+  if [[ "$CHANGED" != 1 ]] || changed_matches '^core/go\.(mod|sum)$'; then
+    go vet ./core/...
+    return
+  fi
+  local pkgs
+  pkgs=$(changed_core_packages)
+  echo "scoped to changed packages:"
+  printf '  %s\n' $pkgs
+  go vet $pkgs
 }
 
 # -- web (mirrors web-test.yml) ---------------------------------------------
@@ -571,7 +624,11 @@ fi
 if want go; then
   CURRENT_GROUP=go
   run_gate_scoped '^core/.*\.go$|^core/go\.(mod|sum)$' \
+                  "go vet (core)"             go_vet_core
+  run_gate_scoped '^core/.*\.go$|^core/go\.(mod|sum)$' \
                   "core module tests"        core_module_tests
+  run_gate_scoped '^tools/onboarding-factory/.*\.go$' \
+                  "go vet (onboarding-factory)" go vet ./tools/onboarding-factory/...
   run_gate_scoped '^tools/onboarding-factory/.*\.go$' \
                   "onboarding-factory tests" go test ./tools/onboarding-factory/... -count=1
   run_gate_scoped '^replaydata/|^tools/onboarding-factory/' \


### PR DESCRIPTION
## Summary

Three independent instances where a verification step that did NOT run
looked exactly like one that ran and found nothing — the AGENTS.md rule
("a verification mechanism must fail loudly when it cannot run") applied
today to test fixtures and e2e checks, but not to the machinery that runs
them.

- **`/simplify`'s fan-out can silently drop review angles.** `/simplify` is
  a built-in skill (`ls .claude/skills/` lists only `ir:*`), so it can't be
  edited here. The fix lands in `.claude/skills/ir:exec/SKILL.md` step 14
  (the only repo-owned surface that invokes it): before treating the phase
  as complete, the agent must confirm all four angles — reuse,
  simplification, efficiency, altitude — were considered, reading
  `/simplify`'s own report on the Medium/Large path or its own inline pass
  on the Trivial/Small one, and **surface it and pause** (step 13's idiom
  for a `MISSING` reviewer) rather than trust an aggregate "done" when one
  is silent.
- **`ir:exec`'s preflight chunk list omitted `swift` and `bash`** from its
  seven-group list (of ten), so an agent following only the skill on a
  `platforms/macos/` change skipped the whole macOS gate. Fixed, and now
  backed by `tools/lib/preflight-groups-skill_test.sh`, which derives the
  canonical group set from `tools/preflight.sh`'s `VALID_GROUPS` array (the
  actual source `--only` validates against) instead of re-typing it.
- **Nothing in this repo ran full `go vet` anywhere** — `go test` only
  runs vet's small "high confidence" subset, which excludes `copylocks`
  (a struct holding a `sync.Mutex` copied by value). Added two scoped
  `go vet` gates ("go vet (core)", "go vet (onboarding-factory)") in the
  `go` preflight group, next to their `go test` counterparts.

## Review round (one subagent pass, effort medium)

Three findings, all fixed:
- `go vet (core)` ran unconditionally under `--changed`, unlike its sibling
  `core module tests` gate — fixed by giving it the same
  `changed_core_packages` scoping (verified live: a single-package diff now
  vets only that package).
- The two `go vet` calls were chained with `&&`, so a core/ failure could
  mask an unrelated onboarding-factory one — split into two independent
  gates.
- Step 14's four-angle discipline read as `/simplify`-only, silent on the
  Trivial/Small inline-review path — reworded to cover both paths
  explicitly.

## `/simplify` pass (4 angles, effort medium — diff is mostly new
shell test/fixture files following established patterns)

All four angles reported back (reuse, simplification, efficiency,
altitude). Fixed:
- `assert_mutation_is_red` was byte-identical in two new fixture files —
  factored into `tools/lib/mutation-assert.sh`, sourced by both.
- A redundant `step14_joined` recomputation in the new lock test.
- `go vet (core)`'s missing per-package `--changed` scoping (also raised in
  the review round; same fix).
- The instance-2 lock test derived its "canonical" set from `--help`'s
  hand-written Usage comment rather than the `VALID_GROUPS` array that
  actually drives `--only`'s behavior — re-derived from `VALID_GROUPS`
  directly (`sed`, same technique `tools/lib/module-list_test.sh` already
  uses for `WEB_TREES`).
- Added an honesty clause to step 14's text: unlike step 13's mechanical
  `test -f` precondition, the four-angle check's own lock test only guards
  the *instruction* against eroding out of the file — it cannot observe
  whether a given run actually did the confirming.

Skipped (noted, not argued): unifying the `need()`/dirty-tree-guard
boilerplate across all four mutation-fixture files, including the
pre-existing `tools/lib/error-retention-mutations_test.sh` — that file's
convention is already established and out of this diff's scope; only the
byte-identical `assert_mutation_is_red` function (unique to this diff's two
new files) was factored out.

`tools/lib/shell-lib-errexit_test.sh`'s per-function walk discovered the
new shared helper and required a driving recipe or exemption; exempted with
a reason (mutates a real tracked file behind `tools/mutate.sh`'s clean-tree
precondition — same category as its one existing exemption).

## Evidence (every check above is one this PR ADDS — no "before the fix" to run red)

Per AGENTS.md's testing philosophy, each guard is backed by a committed
`tools/mutate.sh`-based mutation fixture that breaks the thing it protects
and confirms the check goes red, then restores byte-for-byte:

- `tools/lib/simplify-angle-guard_test.sh` (lock) +
  `tools/lib/simplify-angle-guard-mutations_test.sh` (proof: dropping an
  angle name, or softening "surface it and pause", both go red).
- `tools/lib/preflight-groups-skill_test.sh` (lock, derived from
  `VALID_GROUPS`) + `tools/lib/preflight-groups-skill-mutations_test.sh`
  (proof: adding a group to `VALID_GROUPS`, or dropping one from the
  skill, both go red).
- `tools/lib/go-vet-copylocks_test.sh` (proof: a real copylocks violation
  leaves `go test` green and `go vet` red, in the same package, under one
  mutation).

All new `tools/lib/*_test.sh` files run automatically inside
`tools/preflight.sh --only tools`.

`go vet`'s measured cost: ~1.0s combined (`core` + `tools/onboarding-factory`,
warm cache), ~2.4s cold — negligible against the `go` group's own ~177s
total measured on this branch (`tools/preflight.sh --only go`, PASS, full
mode).

## Test plan

- [x] `tools/preflight.sh --only go` (full mode) — PASS (gofmt, go vet ×2,
      core module tests, onboarding-factory tests, replaydata validate,
      recording-rig smoke test, replay fixtures) — ~177s
- [x] `tools/preflight.sh --changed --only go` — go vet (core)/core module
      tests correctly SKIP with no core changes, and correctly scope to a
      single package when a scratch core/*.go edit was applied and reverted
- [x] `tools/preflight.sh --only tools` — PASS (30 shell-lib tests, incl.
      the 4 new/refactored fixtures, `MUTATION_FIXTURES_STRICT=1`)
- [x] `tools/preflight.sh --only skills` — PASS
- [x] `tools/preflight.sh --only posix` — PASS
- [x] `tools/preflight.sh --only bash` — PASS
- [x] `tools/preflight.sh --only arch` — PASS
- [x] pre-push hook (`tools/preflight.sh --changed`) — PASS/SKIP, including
      the macOS Swift suite (triggered because this branch touches
      `tools/preflight.sh`)

Closes #1823

🤖 Generated with [Claude Code](https://claude.com/claude-code)