### PR TITLE
fix(skills): spell out the checkpoint-and-restore idiom in ir:exec

### DIFF
--- a/.claude/skills/ir:exec/SKILL.md
+++ b/.claude/skills/ir:exec/SKILL.md
@@ -467,6 +467,40 @@ Nobody is gating on the plan, so skip the HTML artifact and the wait entirely:
     the test, then restore — never `git stash`, whose stack is shared across
     worktrees (AGENTS.md).
 
+    **The checkpoint idiom, precisely** (#1824): commit before mutating —
+    `git add -A && git commit -m wip`, then capture its exact SHA (`git
+    rev-parse HEAD`) and confirm `git status --porcelain` is empty right
+    after. The `git add -A` is not optional: a bare `git commit -m wip`
+    commits only what is already staged, so a new untracked file — an
+    ordinary part of implementing a fix — silently never enters the
+    checkpoint at all, and a later "revert" that deletes it has nothing to
+    read back (`git show <sha>:<path>` fails outright, since the file was
+    never in any commit). Restore *only* by reading the checkpoint back —
+    `git show
+    <checkpoint-sha>:<path> > <path>` per file — never by writing over the
+    tree with `git checkout -- <file>`, `git restore --source=HEAD`, `git
+    reset --hard`, or any command of the same shape. Every one of those
+    resolves against whatever HEAD *currently* is rather than the checkpoint
+    you captured, and this repo already forbids all three everywhere for
+    exactly that reason (`tools/mutate.sh`'s own header: worktrees share the
+    parent repo's `.git` dir, and a restore must not touch shared state that
+    is not isolated per worktree). `git show <sha>:<path>` is a plain read
+    from the checkpoint commit, never a write against ambient state, which
+    is what keeps it off that list. The banned commands silently discard
+    anything sitting uncommitted in the tree — including work made *after*
+    the checkpoint, which is exactly what bit three separate runs here
+    (#1799 and #1801 via `checkout --`; #1817 via `restore --source=HEAD`
+    reverting uncommitted review fixes mid-mutation — same mechanism,
+    different command name). Never mutate a dirty tree either: commit or
+    clean up anything else sitting uncommitted before you checkpoint, so the
+    checkpoint SHA *is* the whole known-good state and reading it back is
+    unambiguous. And never keep the pre-mutation state as a hand-rolled
+    backup in `/tmp` or a scratchpad instead of a commit — the same
+    reasoning as step 2b's base-SHA ban applies: those directories are
+    shared and recycled across concurrent agents, and one run here (#1800)
+    had a `/tmp` backup go stale and silently revert a change, caught only
+    by re-reading the file afterward.
+
     A test that **passes** on `main` is not a regression test. Either the
     diagnosis is wrong, or the test doesn't reach the defect — e.g. it exercises
     a stub that is blind to the field it asserts on. **STOP and report.** Do not
@@ -660,12 +694,24 @@ the rebase (step 2b).
 - **The rebase stops with a conflict** — expected on this path, not an anomaly;
   the incident below hit exactly that. Resolve each conflicted hunk on its merits
   (both sides deliberate, so neither `--ours` nor `--theirs` wholesale is an
-  answer), `git add` and `git rebase --continue`, then apply the semantic re-read
-  above. If you can't resolve it confidently, `git rebase --abort` — which returns
-  the branch intact to its pre-rebase state — and **surface it and pause**. Never
-  walk on to step 12 from inside a stopped rebase: `HEAD` is detached mid-replay,
-  so the `--shortstat` below mis-tiers steps 13–14 and the `git push -u` pushes
-  the wrong ref.
+  answer), `git add` and `git rebase --continue`. **Then check for a marker that
+  survived anyway, before trusting the "continue":**
+  ```bash
+  git diff --name-only -z origin/main...HEAD \
+    | xargs -0 -r bash tools/lib/rebase-conflict-check.sh
+  ```
+  `git rebase --continue` only checks that every conflicted path was `git add`ed
+  — never that the content is actually resolved, so `git add -A` on a hunk that
+  still carries `<<<<<<<`/`=======`/`>>>>>>>` reports success (#1824, instance 3:
+  caught only because `go build` happened to choke on it downstream — nothing in
+  this playbook checked directly until now). A non-empty `CONFLICT:` line means
+  fix the file and amend before continuing further, exactly as for a conflict
+  the rebase itself reported. Then apply the semantic re-read above. If you
+  can't resolve it confidently, `git rebase --abort` — which returns the branch
+  intact to its pre-rebase state — and **surface it and pause**. Never walk on
+  to step 12 from inside a stopped rebase: `HEAD` is detached mid-replay, so the
+  `--shortstat` below mis-tiers steps 13–14 and the `git push -u` pushes the
+  wrong ref.
 
   (Real incident: during #1199 / PR #1204, `origin/main` advanced twice mid-run,
   and PR #1201 landed edits to *both* files that run was in the middle of

--- a/tools/lib/checkpoint-idiom-guard-mutations_test.sh
+++ b/tools/lib/checkpoint-idiom-guard-mutations_test.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# checkpoint-idiom-guard-mutations_test.sh — the committed mutation fixtures
+# for tools/lib/checkpoint-idiom-guard_test.sh (#1824).
+#
+# WHY THIS FILE EXISTS. checkpoint-idiom-guard_test.sh is a check #1824 ADDS:
+# it has no "before the fix" to run red, so per AGENTS.md and
+# docs/testing-philosophy.md it earns its place only by being seen to fail
+# when the thing it protects is broken. Two independent breakages, proven
+# separately because a single combined mutation could pass while one of them
+# was actually unguarded:
+#
+#   1. THE IDIOM LOSES A PIECE — step 11a's own text drops the
+#      never-mutate-a-dirty-tree sentence. An agent reading only this step
+#      would no longer be told the one rule that makes a restore
+#      unambiguous. Dropping this one piece stands in for any of the seven
+#      the lock test names individually.
+#
+#   2. THE STEP HEADING MOVES — step 11a's own heading text changes, so the
+#      lock test's anchor no longer matches anything. This is the direction a
+#      plain substring search over the whole file cannot catch: the text
+#      could still be sitting in the file, correctly worded, just no longer
+#      reachable by the anchor the lock test uses to scope its search — and
+#      the lock test must refuse loudly ("Cannot verify anything") rather
+#      than either silently passing or silently searching the wrong part of
+#      the file.
+#
+# Every row drives the real tools/mutate.sh, which owns the mechanics this
+# file must not re-improvise: the stale-anchor guard, the no-op replacement
+# refusal, and the byte-for-byte restore that never touches git state
+# (worktrees share the parent repo's .git dir, so `git checkout --` /
+# `git restore` / `git reset --hard` are banned repo-wide for THIS tool's own
+# restore — see tools/mutate.sh's header for why it uses a plain filesystem
+# copy-back instead).
+#
+# The `assert_mutation_is_red` mechanics live in tools/lib/mutation-assert.sh,
+# shared with tools/lib/preflight-groups-skill-mutations_test.sh and
+# tools/lib/simplify-angle-guard-mutations_test.sh — reused here rather than
+# copied a third time. Convention for the rest follows
+# tools/lib/error-retention-mutations_test.sh: plain bash, a `fails` counter,
+# "ALL PASS" / "N FAILED" at the end.
+
+set -uo pipefail
+
+DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$DIR/../.." && pwd)"
+MUTATE_SH="$REPO_ROOT/tools/mutate.sh"
+# shellcheck disable=SC2034  # read by assert_mutation_is_red in the sourced mutation-assert.sh, not here
+LOCK_TEST="tools/lib/checkpoint-idiom-guard_test.sh"
+SKILL_FILE=".claude/skills/ir:exec/SKILL.md"
+
+# shellcheck source=tools/lib/mutation-assert.sh
+. "$DIR/mutation-assert.sh"
+
+need() { command -v "$1" >/dev/null 2>&1 || { echo "FAIL: checkpoint-idiom-guard-mutations — $1 not found" >&2; exit 1; }; }
+need bash
+need git
+
+if [[ ! -x "$MUTATE_SH" ]]; then
+  echo "FAIL: checkpoint-idiom-guard-mutations — $MUTATE_SH is missing or not executable" >&2
+  exit 1
+fi
+
+# mutate.sh refuses (exit 4) against an already-dirty tree, because its
+# post-restore emptiness check could prove nothing then.
+#
+# A DIRTY TREE MUST NOT SILENTLY PASS — see error-retention-mutations_test.sh
+# for the full reasoning; this file repeats the same guard rather than
+# sourcing it, matching the convention every fixture in this directory uses.
+if [[ -n "$(git -C "$REPO_ROOT" status --porcelain)" ]]; then
+  echo "checkpoint-idiom-guard-mutations: CANNOT RUN — the worktree is dirty, and mutate.sh needs a" >&2
+  echo "  clean tree for its post-restore check to mean anything. Commit or clean up, then:" >&2
+  echo "    bash tools/lib/checkpoint-idiom-guard-mutations_test.sh" >&2
+  if [[ -n "${CI:-}" || -n "${MUTATION_FIXTURES_STRICT:-}" ]]; then
+    echo "  (failing rather than skipping: CI/strict mode, where a skip is indistinguishable" >&2
+    echo "   from a pass and this gate is the only thing re-running these mutations)" >&2
+    exit 1
+  fi
+  echo "  (skipped locally; set MUTATION_FIXTURES_STRICT=1 to make this a failure)" >&2
+  exit 0
+fi
+
+fails=0
+
+# ── 1. The idiom loses a piece: the never-mutate-a-dirty-tree sentence ──────
+assert_mutation_is_red \
+  "lock test catches step 11a dropping the never-mutate-a-dirty-tree rule" \
+  "$SKILL_FILE" \
+  $'different command name). Never mutate a dirty tree either: commit or\n    clean up anything else sitting uncommitted before you checkpoint, so the' \
+  $'different command name). Proceed carefully with a dirty tree instead: commit or\n    clean up anything else sitting uncommitted before you checkpoint, so the' \
+  "no longer bans mutating a dirty tree"
+
+# ── 2. The step heading moves, so the lock test's own anchor goes stale ─────
+assert_mutation_is_red \
+  "lock test refuses loudly when step 11a's heading moves" \
+  "$SKILL_FILE" \
+  $'11a. **Prove red-first.** For every test asserting a claimed defect, run it' \
+  $'11a. **Prove tests fail first.** For every test asserting a claimed defect, run it' \
+  "Cannot verify anything"
+
+if [[ $fails -gt 0 ]]; then
+  echo "checkpoint-idiom-guard-mutations: $fails FAILED"
+  exit 1
+fi
+echo "checkpoint-idiom-guard-mutations: ALL PASS"

--- a/tools/lib/checkpoint-idiom-guard_test.sh
+++ b/tools/lib/checkpoint-idiom-guard_test.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# checkpoint-idiom-guard_test.sh — hold ir:exec SKILL.md's step 11a to a
+# mechanical requirement: it must state the checkpoint-and-restore idiom
+# explicitly — commit before mutating, restore only against that captured
+# commit, never against a dirty tree, never via a command that targets
+# ambient HEAD, and never via a `/tmp`/scratchpad backup instead of a commit
+# (#1824).
+#
+# WHY THIS EXISTS. Three separate implementing agents (#1799, #1801, #1817)
+# and a fourth incident (#1800) each independently discarded uncommitted work
+# because step 11a said "checkpoint it ... then restore" without ever saying
+# HOW to restore safely. Each agent invented its own answer, and the ones
+# that used `git checkout -- <file>` or `git restore --source=HEAD` against a
+# dirty tree — two different command names, the same ambient-HEAD shape —
+# silently reverted work that was never part of the mutation being undone. A
+# prose fix on its own is exactly the failure this issue is about: none of
+# those four instances were caught by review, because a step that quietly
+# stopped saying enough reads identically to one that never needed to. So the
+# requirement itself needs a mechanical check that can go stale-and-caught
+# rather than stale-and-silent — this is that check. It is a LOCK (passes
+# today by construction, since the fix above just added the text) proven
+# capable of failing by
+# tools/lib/checkpoint-idiom-guard-mutations_test.sh, which deletes pieces of
+# the requirement with tools/mutate.sh and confirms this goes red, then
+# restores.
+#
+# What is (and isn't) checked. This cannot verify that a running agent
+# actually commits before mutating or actually restores against the right
+# SHA — no static check can enforce runtime behavior. What it CAN verify, and
+# does: the instruction to do so is present and names, individually, each
+# piece of the idiom (stage-everything-before-checkpointing plus the
+# post-commit porcelain check — added after this repo's own review
+# subagent caught a bare `git commit -m wip` silently skipping untracked
+# files, #1824 — restore-only-against-the-captured-SHA, the ban on both
+# named ambient-HEAD restore commands plus an explicit generalization to
+# "any command of the same shape," the never-mutate-a-dirty-tree rule, and
+# the extended `/tmp`/scratchpad ban) —
+# the same class of guarantee tools/skill-lint.sh and
+# tools/lib/simplify-angle-guard_test.sh already give this repo's other skill
+# prose: not proof of compliance, but proof the instruction cannot silently
+# erode out of the file the way the underlying defect did.
+set -uo pipefail
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+cd "$REPO_ROOT" || { echo "FAIL: cannot cd to repo root $REPO_ROOT" >&2; exit 1; }
+
+SKILL_FILE=".claude/skills/ir:exec/SKILL.md"
+rc=0
+fail() { echo "FAIL: $1" >&2; rc=1; }
+
+[ -f "$SKILL_FILE" ] || { echo "FAIL: checkpoint-idiom-guard_test — $SKILL_FILE not found" >&2; exit 1; }
+
+# Anchored on step 11a's own heading text through the next numbered step
+# (11b) — not a line range, which drifts on every unrelated edit above this
+# point.
+step11a=$(awk '
+  /^11a\. \*\*Prove red-first\.\*\*/ { armed = 1 }
+  armed && /^11b\./ { exit }
+  armed { print }
+' "$SKILL_FILE")
+
+if [ -z "$step11a" ]; then
+  echo "FAIL: checkpoint-idiom-guard_test — could not find step 11a (the red-first / checkpoint step) in $SKILL_FILE; its heading text may have moved. Cannot verify anything." >&2
+  exit 1
+fi
+
+# Whitespace-joined, not $step11a directly: markdown's own line wrap can
+# legitimately split a phrase across two source lines without changing what a
+# reader sees rendered, and a literal multi-line grep would then report the
+# phrase missing when it plainly isn't — the exact "absence of a finding and
+# inability to look produce the same output" shape this whole issue is about,
+# one layer down in this test itself (same reasoning as
+# tools/lib/simplify-angle-guard_test.sh). Every phrase checked below is
+# picked to sit on one physical source line as of this writing, so the join
+# is a robustness margin against future reflow, not a requirement for today's
+# text to pass.
+step11a_joined=$(printf '%s' "$step11a" | tr '\n' ' ')
+
+check() {
+  local want="$1" msg="$2"
+  if ! grep -qF "$want" <<<"$step11a_joined"; then
+    fail "$SKILL_FILE step 11a $msg"
+  fi
+}
+
+check 'commit before mutating' \
+  "no longer says to commit a checkpoint before mutating — an agent has nothing telling it when to capture one"
+
+check '`git add -A && git commit -m wip`' \
+  "no longer stages everything before checkpointing — a bare \`git commit -m wip\` silently commits only what was already staged, so a new untracked file never enters the checkpoint at all (review finding on this PR itself)"
+
+check 'confirm `git status --porcelain` is empty right' \
+  "no longer confirms the checkpoint commit left the tree empty — the one check that catches an incomplete checkpoint loudly instead of silently"
+
+check '`git checkout -- <file>`' \
+  "no longer bans \`git checkout -- <file>\` as a restore — the exact command that silently discarded uncommitted work in #1799 and #1801"
+
+check '`git restore --source=HEAD`' \
+  "no longer bans \`git restore --source=HEAD\` as a restore — the exact command that silently discarded uncommitted review fixes in #1817"
+
+check 'reset --hard' \
+  "no longer names \`git reset --hard\` among the banned restores — this repo forbids it everywhere for the same ambient-HEAD reason (tools/mutate.sh's header), and it would otherwise read as a permitted third spelling"
+
+check 'or any command of the same shape' \
+  "no longer generalizes the ban beyond the named commands — a fourth ambient-HEAD restore spelling would then read as permitted"
+
+check 'Restore *only* by reading the checkpoint back' \
+  "no longer says to restore only by reading the checkpoint commit back — the one instruction that distinguishes a safe restore from an ambient-HEAD one"
+
+check 'Never mutate a dirty tree' \
+  "no longer bans mutating a dirty tree — without it, a restore has no way to know what it's safe to discard"
+
+check 'in `/tmp` or a scratchpad instead of a commit' \
+  "no longer extends the /tmp ban to mutation/checkpoint backups — the exact gap that let a stale /tmp backup silently revert a change in #1800"
+
+if [ "$rc" -eq 0 ]; then
+  echo "OK: checkpoint-idiom-guard_test — $SKILL_FILE step 11a states the checkpoint idiom (commit before mutating, restore only against the captured SHA, never checkout/restore against ambient HEAD in any shape, never a dirty-tree mutation, never a /tmp backup)"
+fi
+exit "$rc"

--- a/tools/lib/rebase-conflict-check.sh
+++ b/tools/lib/rebase-conflict-check.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# rebase-conflict-check.sh — scan specific files for an unresolved git
+# conflict marker (`^<<<<<<< `) left behind by a `git rebase --continue` that
+# staged a hunk before the marker was actually resolved.
+#
+# WHY THIS EXISTS (#1824, instance 3). During #1824's own implementing batch,
+# an agent's `git add -A` staged a conflicted file that still carried
+# `<<<<<<<`/`=======`/`>>>>>>>` markers; `git rebase --continue` reported
+# success (git only cares that every conflicted path was `git add`ed, never
+# that the content is actually resolved), and the defect was caught only
+# because `go build` happened to choke on it downstream — nothing in
+# `.claude/skills/ir:exec/SKILL.md`'s playbook checked directly. This is the
+# mechanical check that playbook step now runs.
+#
+# Usage:
+#   tools/lib/rebase-conflict-check.sh <file> [file...]
+#
+# Deliberately takes an EXPLICIT file list rather than scanning the whole
+# repo. replaydata/agents/aider/scenarios/**/transcript.md commits aider's own
+# SEARCH/REPLACE diff format verbatim, which also starts a line with
+# `<<<<<<< ` (`<<<<<<< SEARCH`) — a real, intentional recording fixture, not a
+# leftover conflict (confirmed: `git grep -n '^<<<<<<<' -- .` finds dozens of
+# these under replaydata/agents/aider/ on a clean checkout). A blind
+# repo-wide scan would flag those on line one of this check's life. Passing
+# `git diff --name-only origin/main...HEAD` — the files THIS branch actually
+# touches, which Phase 5 already computes this exact list for its own
+# collision probe — keeps the check honest without special-casing aider's
+# format:
+#
+#   git diff --name-only -z origin/main...HEAD | \
+#     xargs -0 -r bash tools/lib/rebase-conflict-check.sh
+#
+# Reuses tools/skill-lint.sh's own conflict-marker semantics
+# (`^<<<<<<<([ \t]|$)` in that file's awk, matching a marker with or without
+# the trailing ref name, e.g. `<<<<<<< HEAD`, but not `<<<<<<<foo`) rather
+# than inventing a second definition of "conflict marker." The character
+# class is spelled `[[:space:]]` here, not `[ \t]`: awk's own `\t` escape is
+# always tab, but measured against this platform's actual `grep -E` (BSD
+# grep, invoked the way this script's own test does — bash executing a
+# script, not the interactive shell's `ugrep`-backed `grep` function/alias),
+# a literal backslash-t in an ERE does NOT match a tab; `[[:space:]]` does,
+# portably.
+#
+# Exit codes:
+#   0  clean — none of the given files contain the marker
+#   1  FINDING — at least one does; each is printed as `file:line:text`
+#   2  REFUSAL — no files were named, or a named file exists but could not be
+#      read (a real I/O problem — NOT "this file was deleted by the diff,"
+#      which is a silent no-op below: a deleted file trivially has no marker
+#      to find, and `git diff --name-only` lists deletions too)
+set -uo pipefail
+
+CONFLICT_MARKER_PATTERN='^<<<<<<<([[:space:]]|$)'
+
+# rebase_conflict_check <file> [file...]
+rebase_conflict_check() {
+  if [ $# -eq 0 ]; then
+    echo "REFUSE: rebase-conflict-check — no files named" >&2
+    return 2
+  fi
+
+  local p found=0 refused=0 out
+  for p in "$@"; do
+    # Not an error: git diff --name-only lists deleted files too, and a
+    # deleted file has nothing left to scan.
+    [ -e "$p" ] || continue
+
+    if [ -d "$p" ]; then
+      echo "REFUSE: rebase-conflict-check — '$p' is a directory, not a file" >&2
+      refused=1
+      continue
+    fi
+    if [ ! -r "$p" ]; then
+      echo "REFUSE: rebase-conflict-check — cannot read '$p'" >&2
+      refused=1
+      continue
+    fi
+
+    out=$(grep -nE "$CONFLICT_MARKER_PATTERN" "$p" 2>/dev/null || true)
+    if [ -n "$out" ]; then
+      found=1
+      while IFS= read -r hit; do
+        echo "CONFLICT: $p:$hit"
+      done <<<"$out"
+    fi
+  done
+
+  if [ "$refused" -eq 1 ]; then
+    return 2
+  fi
+  if [ "$found" -eq 1 ]; then
+    echo "FAIL: rebase-conflict-check — unresolved conflict marker(s) survived the rebase (see CONFLICT lines above)" >&2
+    return 1
+  fi
+
+  echo "OK: rebase-conflict-check — no conflict markers in: $*"
+  return 0
+}
+
+# Only run the CLI form when executed directly — sourcing (the test file does
+# `. tools/lib/rebase-conflict-check.sh`) must define the function and return
+# control, never run the check or exit the caller's shell.
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  rebase_conflict_check "$@"
+  exit $?
+fi

--- a/tools/lib/rebase-conflict-check_test.sh
+++ b/tools/lib/rebase-conflict-check_test.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# rebase-conflict-check_test.sh — proof, both directions, for
+# tools/lib/rebase-conflict-check.sh (#1824).
+#
+# WHY THIS FILE EXISTS. rebase-conflict-check.sh is a check #1824 ADDS: it has
+# no "before the fix" to run red against, so per AGENTS.md and
+# docs/testing-philosophy.md it earns its place only by being seen to fail
+# when the thing it protects is broken, and to pass when it isn't. Both
+# fixtures below are committed under tools/lib/testdata/rebase-conflict-check/
+# rather than generated on the fly, so this evidence outlives the PR that
+# wrote it and re-runs on every future change to the checker.
+set -uo pipefail
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+cd "$REPO_ROOT" || { echo "FAIL: cannot cd to repo root $REPO_ROOT" >&2; exit 1; }
+
+# shellcheck source=./rebase-conflict-check.sh
+. tools/lib/rebase-conflict-check.sh   # defines rebase_conflict_check
+
+FIXTURE_DIR=tools/lib/testdata/rebase-conflict-check
+rc=0
+fail() { echo "FAIL: $1" >&2; rc=1; }
+
+# assert_rc <label> <expected-rc> <arg...> -- <must-contain-in-output>
+# The literal `--` separates the checker's own arguments from the single
+# "must contain" string, so a case can pass more than one file.
+assert_rc() {
+  local label="$1" want="$2"
+  shift 2
+  local args=()
+  while [ "$#" -gt 0 ] && [ "$1" != "--" ]; do
+    args+=("$1")
+    shift
+  done
+  shift   # drop the --
+  local want_text="${1:-}"
+  local out got
+  # "${args[@]+"${args[@]}"}" rather than a bare "${args[@]}": under bash 3.2
+  # (this repo's macOS baseline — AGENTS.md's gate-budget.sh notes the same
+  # constraint), `set -u` treats a truly EMPTY array's `[@]` expansion as an
+  # unbound variable, which the no-arguments refusal case below exercises on
+  # purpose.
+  out=$(rebase_conflict_check "${args[@]+"${args[@]}"}" 2>&1)
+  got=$?
+  if [ "$got" -ne "$want" ]; then
+    fail "$label: expected exit $want, got $got (output: $out)"
+    return
+  fi
+  if [ -n "$want_text" ] && [[ "$out" != *"$want_text"* ]]; then
+    fail "$label: exit $got was right but output missing '$want_text' — got: $out"
+    return
+  fi
+  echo "  PASS: $label (exit $got)"
+}
+
+# --- RED: a file that still carries the marker ------------------------------
+assert_rc "a file with an unresolved <<<<<<< marker is a FINDING (exit 1)" \
+  1 "$FIXTURE_DIR/with-marker.txt" -- \
+  "CONFLICT: $FIXTURE_DIR/with-marker.txt:4:<<<<<<< HEAD"
+
+# --- GREEN: a clean file --------------------------------------------------
+assert_rc "a clean file passes (exit 0)" \
+  0 "$FIXTURE_DIR/clean.txt" -- \
+  "OK: rebase-conflict-check"
+
+# --- mixed set: one clean, one marked — the marker still surfaces ----------
+assert_rc "one clean plus one marked file still FAILS, and names the marked one" \
+  1 "$FIXTURE_DIR/clean.txt" "$FIXTURE_DIR/with-marker.txt" -- \
+  "CONFLICT: $FIXTURE_DIR/with-marker.txt:4:<<<<<<< HEAD"
+
+# --- a path git diff --name-only would list for a DELETE is a silent skip --
+# Not a refusal: a deleted file has nothing left to scan, and `git diff
+# --name-only` lists deletions alongside adds/modifies.
+assert_rc "a path that does not exist (a deletion) is skipped, not refused" \
+  0 "$FIXTURE_DIR/clean.txt" "$FIXTURE_DIR/does-not-exist.txt" -- \
+  "OK: rebase-conflict-check"
+
+# --- refusal: a real I/O problem, not a deletion ----------------------------
+assert_rc "a directory argument is a REFUSAL (exit 2), not a silent pass" \
+  2 "$FIXTURE_DIR" -- \
+  "is a directory, not a file"
+
+assert_rc "no arguments at all is a REFUSAL (exit 2)" \
+  2 -- \
+  "no files named"
+
+# --- vacuity guard: real, current, non-fixture files must pass -------------
+# Without this, every case above could pass while the checker was wired to
+# nothing but its own fixtures. This checker's own source and AGENTS.md are
+# both real tracked files with no conflict markers in the current tree — this
+# must currently PASS.
+assert_rc "the checker's own source file passes its own check" \
+  0 "tools/lib/rebase-conflict-check.sh" -- \
+  "OK: rebase-conflict-check"
+assert_rc "the repo's real, current AGENTS.md passes" \
+  0 "AGENTS.md" -- \
+  "OK: rebase-conflict-check"
+
+[ "$rc" -eq 0 ] && echo "OK: rebase-conflict-check_test — catches an unresolved marker and passes a clean tree, both directions proven"
+exit "$rc"

--- a/tools/lib/shell-lib-errexit_test.sh
+++ b/tools/lib/shell-lib-errexit_test.sh
@@ -392,6 +392,21 @@ row 'gosec-report.sh::gosec_report_check' 'gosec_report_check (a clean report)' 
     '. tools/lib/gosec-report.sh' \
     'gosec_report_check tools/lib/testdata/gosec-report/clean.json tripwire >/dev/null 2>&1'
 
+# rebase_conflict_check documents three statuses (0 clean, 1 FINDING, 2
+# REFUSAL); only 0 and 2 are distinctive here, for the same reason
+# await_gone's and gate-budget's own true-predicate statuses are (above): a
+# documented 1 is indistinguishable from an errexit abort, which also exits
+# 1. The FINDING path — and the exact `CONFLICT:` output it produces — is
+# graded by its own tools/lib/rebase-conflict-check_test.sh, which is not
+# under `-e`; what is asserted here is the errexit/option property on the two
+# statuses a caller under `-e` can actually tell apart.
+row 'rebase-conflict-check.sh::rebase_conflict_check' 'rebase_conflict_check (a clean file)' 0 \
+    '. tools/lib/rebase-conflict-check.sh' \
+    'rebase_conflict_check tools/lib/testdata/rebase-conflict-check/clean.txt >/dev/null'
+row 'rebase-conflict-check.sh::rebase_conflict_check' 'rebase_conflict_check (refuses when no files are named)' 2 \
+    '. tools/lib/rebase-conflict-check.sh' \
+    'rebase_conflict_check 2>/dev/null'
+
 # Driven against a THROWAWAY corpus, never against tools/lib itself: this
 # function runs every `*_test.sh` it finds, and this file is one of them, so
 # pointing it at the real directory would re-enter the whole suite (and this

--- a/tools/lib/testdata/rebase-conflict-check/clean.txt
+++ b/tools/lib/testdata/rebase-conflict-check/clean.txt
@@ -1,0 +1,5 @@
+package example
+
+func Greeting() string {
+	return "hello from feature branch"
+}

--- a/tools/lib/testdata/rebase-conflict-check/with-marker.txt
+++ b/tools/lib/testdata/rebase-conflict-check/with-marker.txt
@@ -1,0 +1,9 @@
+package example
+
+func Greeting() string {
+<<<<<<< HEAD
+	return "hello from main"
+=======
+	return "hello from feature branch"
+>>>>>>> feat/1824-checkpoint-idiom
+}


### PR DESCRIPTION
## Summary

`ir:exec` step 11a told agents to "checkpoint it (\`git commit -m wip\`) ... then restore" without ever saying *how* to restore safely, so three implementing agents invented three different answers and two of them silently discarded uncommitted work:

- **Instance 1** — `git checkout -- <file>` reverts to the last commit, not to a checkpoint; silently discarded uncommitted work for #1799 and #1801.
- **Instance 2** — a `/tmp` mutation backup went stale and silently reverted a change for #1800, caught only by re-reading the file afterward.
- **Instance 3** — `git add -A` during a rebase staged a file that still carried conflict markers; the rebase reported success and only `go build` caught it downstream.
- **Instance 4** (observed same batch) — `git restore --source=HEAD` bit #1817 mid-mutation and reverted uncommitted review fixes — instance 1's mechanism wearing a different command name.

## Changes

- **Step 11a** now states the checkpoint idiom explicitly: commit before mutating, restore *only* by reading the checkpoint commit back (\`git show <sha>:<path>\`, a plain read — never a write against ambient HEAD), never \`git checkout -- <file>\` / \`git restore --source=HEAD\` / \`git reset --hard\` / any command of the same shape against a dirty tree, never mutate a dirty tree, and never park a mutation backup in \`/tmp\` (extends step 2b's existing base-SHA ban to the same failure mode).
- **Phase 5**'s rebase-conflict-resolution step now runs `tools/lib/rebase-conflict-check.sh` against the branch's own changed files (`git diff --name-only origin/main...HEAD`) right after `git rebase --continue`, catching a `git add`ed hunk that still carries `<<<<<<< ` — instance 3's exact gap.
- Both additions are guarded mechanically (AGENTS.md: a check a change *adds* has no "before" to run red against — mutate the thing it protects instead):
  - `tools/lib/checkpoint-idiom-guard_test.sh` + `tools/lib/checkpoint-idiom-guard-mutations_test.sh` prove step 11a's wording goes stale-and-caught both when a piece of the idiom is dropped and when the step 11a heading itself moves (mirroring #1839's `simplify-angle-guard_test.sh` pattern, reusing its `tools/lib/mutation-assert.sh` helper).
  - `tools/lib/rebase-conflict-check.sh` + `tools/lib/rebase-conflict-check_test.sh` prove the marker check itself catches a marker (red, via a committed `testdata/rebase-conflict-check/with-marker.txt` fixture) and passes a clean tree (green).
  - A driving recipe for `rebase_conflict_check` was added to `tools/lib/shell-lib-errexit_test.sh` (the per-function errexit/option-leak tripwire), so the new sourced function isn't left UNDRIVEN.

## Note on `git reset --hard`

`tools/mutate.sh`'s own header, and four other test files, already establish that `git checkout --`/`git restore`/`git reset --hard` are banned repo-wide (worktrees share the parent repo's `.git` dir). An earlier draft of step 11a's wording recommended `git reset --hard <checkpoint-sha>` as the restore mechanism — caught and fixed before this PR was opened, in favor of `git show <sha>:<path>` (a pure read, not a write against ambient state).

## Test plan

- [x] `bash tools/lib/checkpoint-idiom-guard_test.sh` — green against current text
- [x] `bash tools/lib/checkpoint-idiom-guard-mutations_test.sh` — both mutations (dropped wording, moved heading) go RED, tree restores clean
- [x] `bash tools/lib/rebase-conflict-check_test.sh` — RED on a marker, GREEN on a clean tree, plus refusal/skip edge cases
- [x] `bash tools/lib/shell-lib-errexit_test.sh` — ALL PASS (new function driven, no UNDRIVEN)
- [x] `bash tools/skill-lint.sh .claude/skills/ir:exec/SKILL.md --strict` — 0 errors, 0 warnings
- [x] `shellcheck --shell=bash --severity=warning` over all new/changed `tools/lib/*.sh` — clean
- [x] Sibling guards unaffected: `preflight-groups-skill-mutations_test.sh`, `simplify-angle-guard-mutations_test.sh` — still ALL PASS
- [ ] `tools/preflight.sh --only tools/skills/posix/bash` (running next)

Closes #1824

🤖 Generated with [Claude Code](https://claude.com/claude-code)