### PR TITLE
fix(skills): tick the parent epic on close; derive triage milestones from version.json

### DIFF
--- a/.claude/skills/ir:exec/SKILL.md
+++ b/.claude/skills/ir:exec/SKILL.md
@@ -1063,6 +1063,55 @@ Phase 6.
     draft at all.
 19. **Merge**: `gh pr merge --squash` (no `--delete-branch` — keep the remote
     branch, per existing repo convention).
+19a. **Tick the parent epic's checkbox** for the issue that just closed. An epic
+    tracks its phases as a checklist of `- [ ] #<child>` lines in its body, and
+    closing a child does not tick them — so a fully delivered epic keeps reading
+    as in-flight. (Real incident, #1796: all eight phases #1797–#1804 closed and
+    every PR merged, and the epic body still showed eight empty boxes.) This is
+    **not a gate** — the merge already happened, so nothing here may block or
+    reverse it; on any failure, report and move to step 20.
+
+    ```bash
+    REPO=ingo-eichhorst/Irrlicht
+    N=<issue just closed>
+    # Bounded: one search, at most 10 candidates. Never iterate every open issue.
+    if ! parents=$(timeout 90 gh issue list --repo "$REPO" --state open \
+                     --search "$N in:body" --limit 10 --json number --jq '.[].number' 2>err); then
+      echo "PARENT-TICK: COULD NOT LOOK — gh issue list failed: $(cat err)"
+      # stop here — an empty $parents from an error must not read as "no parent"
+    fi
+    ```
+
+    Then for each candidate `$p` (skip `$p == $N`), fetch the body and decide on
+    the **exact** checklist line:
+
+    ```bash
+    timeout 90 gh issue view "$p" --repo "$REPO" --json body --jq .body > body.md  # never a blind sed
+    hits=$(grep -cE "^[[:space:]]*- \[ \] #$N([^0-9]|$)" body.md || true)  # grep -c exits 1 on zero
+    awk -v n="$N" '$0 ~ "^[[:space:]]*- \\[ \\] #" n "([^0-9]|$)" { sub(/- \[ \]/, "- [x]") } { print }' \
+      body.md > body.new
+    gh issue edit "$p" --repo "$REPO" --body-file body.new   # only when hits == 1
+    ```
+
+    The `([^0-9]|$)` is load-bearing: without it `#179` ticks the `#1796` line.
+    Verified by hand against #1796's real body — `179`, `17`, `1796`, `1790` and
+    `1797` each match only their own line, and a number with no line yields
+    `hits=0`.
+
+    **Four outcomes, four distinct messages** — absence of a finding and inability
+    to look must never print the same thing (AGENTS.md, Testing):
+    - search returned nothing → *"no parent epic references #N — nothing to tick"*.
+      Say it once, quietly; this is the common case and a legitimate no-op.
+    - search or `gh issue view` **errored** → *"COULD NOT LOOK — …"* with the error
+      text. Never fold this into the line above.
+    - body fetched, `hits == 1` → tick it and report `#<parent>` ticked. Re-diff
+      `body.md` vs `body.new` first and confirm exactly `hits` lines changed; if
+      not, say so and leave the body untouched.
+    - body fetched, `hits == 0` → the candidate mentions `#N` in prose but carries
+      no unticked line for it. If a `- [x] #N` line is already there, say
+      *"already ticked"*; otherwise say plainly that the expected line was **not
+      found** in `#<parent>`, naming it. A body you read and could not match is a
+      finding, not silence.
 20. **Clean up the local worktree**: `git -C <main-repo> worktree remove <path>`,
     and move the session back to the main repo.
 21. **Confirm final state** (`git worktree list`) and report the merged PR link.

--- a/.claude/skills/ir:exec/SKILL.md
+++ b/.claude/skills/ir:exec/SKILL.md
@@ -1074,29 +1074,47 @@ Phase 6.
     ```bash
     REPO=ingo-eichhorst/Irrlicht
     N=<issue just closed>
+    TMP=$(mktemp -d)                # scratch lives outside the repo, never in it
     # Bounded: one search, at most 10 candidates. Never iterate every open issue.
+    # `2>&1` keeps the error text in the variable; never `2>err`, which drops a
+    # stray file into whatever worktree this phase happens to be standing in.
     if ! parents=$(timeout 90 gh issue list --repo "$REPO" --state open \
-                     --search "$N in:body" --limit 10 --json number --jq '.[].number' 2>err); then
-      echo "PARENT-TICK: COULD NOT LOOK — gh issue list failed: $(cat err)"
-      # stop here — an empty $parents from an error must not read as "no parent"
+                     --search "$N in:body" --limit 10 --json number --jq '.[].number' 2>&1); then
+      echo "PARENT-TICK: COULD NOT LOOK — gh issue list failed: $parents"
+      exit 0   # a REAL stop, not a comment: go to step 20. An empty $parents left
+    fi         # over from an error must never fall through and read as "no parent".
+    if [ -z "$parents" ]; then
+      echo "PARENT-TICK: no parent epic references #$N — nothing to tick."
+      exit 0
     fi
     ```
+
+    (`exit`, `return`, or whatever ends the block in the shell you actually run —
+    the requirement is that nothing below executes, so the two conditions above
+    keep producing their own distinct messages.)
 
     Then for each candidate `$p` (skip `$p == $N`), fetch the body and decide on
     the **exact** checklist line:
 
     ```bash
-    timeout 90 gh issue view "$p" --repo "$REPO" --json body --jq .body > body.md  # never a blind sed
-    hits=$(grep -cE "^[[:space:]]*- \[ \] #$N([^0-9]|$)" body.md || true)  # grep -c exits 1 on zero
-    awk -v n="$N" '$0 ~ "^[[:space:]]*- \\[ \\] #" n "([^0-9]|$)" { sub(/- \[ \]/, "- [x]") } { print }' \
-      body.md > body.new
-    gh issue edit "$p" --repo "$REPO" --body-file body.new   # only when hits == 1
+    for p in $parents; do
+      [ "$p" = "$N" ] && continue
+      if ! body=$(timeout 90 gh issue view "$p" --repo "$REPO" --json body --jq .body 2>&1); then
+        echo "PARENT-TICK: COULD NOT LOOK — could not fetch #$p's body: $body"; continue
+      fi
+      printf '%s\n' "$body" > "$TMP/body.md"
+      hits=$(grep -cE "^[[:space:]]*- \[ \] #$N([^0-9]|$)" "$TMP/body.md" || true)  # grep -c exits 1 on zero
+      [ "$hits" -eq 1 ] || { echo "PARENT-TICK: #$p — $hits matching line(s), not editing"; continue; }
+      awk -v n="$N" '$0 ~ "^[[:space:]]*- \\[ \\] #" n "([^0-9]|$)" { sub(/- \[ \]/, "- [x]") } { print }' \
+        "$TMP/body.md" > "$TMP/body.new"
+      gh issue edit "$p" --repo "$REPO" --body-file "$TMP/body.new"   # never a blind sed
+    done
     ```
 
     The `([^0-9]|$)` is load-bearing: without it `#179` ticks the `#1796` line.
-    Verified by hand against #1796's real body — `179`, `17`, `1796`, `1790` and
-    `1797` each match only their own line, and a number with no line yields
-    `hits=0`.
+    Verified by hand against #1796's eight-phase checklist — `1797` matches
+    exactly one line, while `179`, `17`, `1790` and `1796` match none of it, and
+    a number with no line yields `hits=0`.
 
     **Four outcomes, four distinct messages** — absence of a finding and inability
     to look must never print the same thing (AGENTS.md, Testing):
@@ -1105,13 +1123,14 @@ Phase 6.
     - search or `gh issue view` **errored** → *"COULD NOT LOOK — …"* with the error
       text. Never fold this into the line above.
     - body fetched, `hits == 1` → tick it and report `#<parent>` ticked. Re-diff
-      `body.md` vs `body.new` first and confirm exactly `hits` lines changed; if
+      `$TMP/body.md` vs `$TMP/body.new` first and confirm exactly one line changed; if
       not, say so and leave the body untouched.
-    - body fetched, `hits == 0` → the candidate mentions `#N` in prose but carries
-      no unticked line for it. If a `- [x] #N` line is already there, say
-      *"already ticked"*; otherwise say plainly that the expected line was **not
-      found** in `#<parent>`, naming it. A body you read and could not match is a
-      finding, not silence.
+    - body fetched, `hits != 1` → do not edit. At zero, the candidate mentions
+      `#N` in prose but carries no unticked line for it: if a `- [x] #N` line is
+      already there say *"already ticked"*, otherwise say plainly that the
+      expected line was **not found** in `#<parent>`, naming it. Above one, say
+      how many and leave the body alone rather than guessing. A body you read and
+      could not match is a finding, not silence.
 20. **Clean up the local worktree**: `git -C <main-repo> worktree remove <path>`,
     and move the session back to the main repo.
 21. **Confirm final state** (`git worktree list`) and report the merged PR link.

--- a/.claude/skills/ir:triage/SKILL.md
+++ b/.claude/skills/ir:triage/SKILL.md
@@ -286,18 +286,22 @@ Milestones group issues by release cycle. The convention is `vMAJOR.MINOR` (e.g.
 
 **If the issue already has a maintainer-set milestone, do not change it.** Note the existing milestone in the brief; the maintainer's choice wins.
 
-**Resolution.** At the start of the run (or first single-issue invocation), enumerate open milestones and compute the three buckets from the latest published release:
+**Resolution.** At the start of the run (or first single-issue invocation), enumerate open milestones and compute the three buckets from the version **currently in development** — the repo-root `version.json`:
 
 ```bash
-LATEST_MM=$(gh release view --repo ingo-eichhorst/Irrlicht --json tagName --jq .tagName \
-            | sed -E 's/^v//; s/^([0-9]+\.[0-9]+).*/\1/')
-# 0.4 → ACTIVE=0.5, NEXT=0.6, FUTURE=0.7
-ACTIVE="v$(awk -v v="$LATEST_MM" 'BEGIN{split(v,a,"."); print a[1]"."a[2]+1}')"
-NEXT="v$(awk   -v v="$LATEST_MM" 'BEGIN{split(v,a,"."); print a[1]"."a[2]+2}')"
-FUTURE="v$(awk -v v="$LATEST_MM" 'BEGIN{split(v,a,"."); print a[1]"."a[2]+3}')"
+DEV_MM=$(jq -r .version "$(git rev-parse --show-toplevel)/version.json" \
+         | sed -E 's/^v//; s/^([0-9]+\.[0-9]+).*/\1/')
+# version.json 0.6.0 → ACTIVE=v0.6, NEXT=v0.7, FUTURE=v0.8
+ACTIVE="v$DEV_MM"
+NEXT="v$(awk   -v v="$DEV_MM" 'BEGIN{split(v,a,"."); print a[1]"."a[2]+1}')"
+FUTURE="v$(awk -v v="$DEV_MM" 'BEGIN{split(v,a,"."); print a[1]"."a[2]+2}')"
 
 gh api "repos/ingo-eichhorst/Irrlicht/milestones?state=open" --jq '.[] | .title'
 ```
+
+**Why `version.json` and not the latest release tag** — do not revert this to `gh release view`. The published tag says what **shipped**; `version.json` says what is **being built next** (`tools/build-release.sh` reads it as the base version, `/ir:release` bumps it). Only the second distinguishes a patch inside the current cycle from a new minor. When the maintainer is cutting `0.6.1`, the latest tag is still `v0.6.0`, and a tag-derived formula reads that as "0.6 shipped, so the live cycle must be 0.7" — routing every freshly triaged issue to `v0.7`/`v0.8` and skipping the live milestone entirely. `version.json` still reads `0.6.0`, so `ACTIVE` correctly stays `v0.6`. (Real incident: five issues triaged mid-`0.6.1`, all three `ready-for-agent` ones landed in `v0.8`.)
+
+If `version.json` is missing or its `version` is unparseable, **say so and stop resolving milestones** — apply labels without one and note it in the brief. Silently falling back to the tag reintroduces exactly the bug above.
 
 **Pick by priority:**
 


### PR DESCRIPTION
Two independent skill defects, each of which silently produces wrong state that nothing else notices. No GitHub issue was filed for either (per instruction).

## 1. `ir:exec` never ticks the parent epic's checkbox

`.claude/skills/ir:exec/SKILL.md`, Phase 7 ("Land") — new **step 19a**, between the squash-merge (19) and the worktree cleanup (20).

**Evidence.** Epic #1796 shipped completely: all eight phase issues #1797–#1804 are CLOSED and every PR merged. Its body still reads `- [ ] #1797` … `- [ ] #1804`. A delivered epic looks in-flight, because nothing in `ir:exec` ticks those boxes.

**What the step does.**
- One **bounded** lookup: `gh issue list --repo … --state open --search "<N> in:body" --limit 10`. It never iterates every open issue.
- For each candidate, `gh issue view … --json body` and match the exact line shape `^[[:space:]]*- \[ \] #<N>([^0-9]|$)`. The `([^0-9]|$)` anchor is load-bearing — without it `#179` ticks the `#1796` line.
- Rewrite via `awk` + `gh issue edit --body-file`. Never a blind `sed` over an unread body, and only when exactly one line matched (re-diffed before the edit).

**Fails loudly, per AGENTS.md.** Four outcomes get four distinct messages, so *"no parent epic references #N"* and *"COULD NOT LOOK — gh issue list failed: …"* can never print the same thing. A body that was fetched but carries no matching line is reported as a finding, not as silence. A body that already has `- [x] #N` says "already ticked".

**Not a gate.** The merge has already happened by step 19, so nothing in 19a may block or reverse it — on any failure it reports and moves to step 20.

## 2. `ir:triage`'s milestone formula is patch-release blind

`.claude/skills/ir:triage/SKILL.md`, "Milestone → Resolution".

**Evidence.** The formula derived the three buckets from the latest **published** release tag: `LATEST_MM=0.6 → ACTIVE=v0.7, NEXT=v0.8, FUTURE=v0.9`. The maintainer is currently cutting **0.6.1**, inside the v0.6 cycle, which that formula cannot express — so every freshly triaged issue routed to v0.7/v0.8 and skipped the live milestone. Observed today across five triaged issues; all three `ready-for-agent` ones landed in v0.8 while v0.6 was the live cycle.

**Replacement.** Read the repo-root `version.json` `version` field — the version currently *in development* (`tools/build-release.sh` reads it as the base version, `/ir:release` bumps it). `MAJOR.MINOR` of that is `ACTIVE`; `NEXT` is minor+1, `FUTURE` is minor+2.

The skill now states **why** it reads `version.json` rather than the tag, so it does not get reverted: the published tag says what *shipped*, `version.json` says what is *being built next*, and only the second distinguishes a patch inside the current cycle from a new minor. An unreadable `version.json` stops milestone resolution loudly rather than falling back to the tag.

The "create the milestone if missing" step and the "a maintainer-set milestone always wins" rule are unchanged.

## Verification

**Ran** (results in the run log):

| Check | Result |
|---|---|
| `tools/skill-lint.sh` | PASS — 23 files, 0 errors, 0 warnings |
| `tools/preflight.sh --only skills` (foreground) | PASS |
| `tools/agents-md-lint.sh` | PASS — AGENTS.md 243/400 lines (untouched by this PR) |
| `tools/lib/skill-lint_test.sh` | ALL PASS |
| pre-push hook (`--changed --budget 540`) | PASS: skill-file lint, state-vocabulary lint, gofmt; rest SKIP |

**Change 1's matching logic, hand-run before it was written into the skill** — dry run against the real bodies of #1796 (parent) and #1797 (child), diff printed to stdout, **nothing pushed to GitHub**:

```
### candidates: 1796 1822
### would edit #1796 (1 line(s)); diff:
-- [ ] #1797 — Phase 0: tolerate an unknown session state (**merges first**)
+- [x] #1797 — Phase 0: tolerate an unknown session state (**merges first**)
 - [ ] #1798 — Phase 1: domain + plumbing
 - [ ] #1799 — Phase 2a: claude-code + copilot adapters
### DRY RUN — not calling: gh issue edit 1796 …
### #1822 mentions #1797 but carries no checklist line for it — not a parent epic, skipping.
```

Exactly one box changed. #1822 (which mentions "epic #1796" in prose) was correctly identified as not-a-parent rather than edited.

**False-match test** — a fixture body carrying `- [ ] #179`, `- [ ] #1796`, `- [ ] #1790`, `- [ ] #17` and a nested `- [ ] #1797`:

| N | hits | line ticked |
|---|---|---|
| 179 | 1 | `- [x] #179` only — **not** `#1796`, **not** `#1790` |
| 1796 | 1 | `- [x] #1796` only |
| 17 | 1 | `- [x] #17` only |
| 1797 | 1 | the nested line only (leading indent handled) |
| 1795 | 0 | none — falls into the loud "not found" branch |

**Fail-loud branches, exercised:**
- no parent (`N=99999`) → `PARENT-TICK: no parent epic references #99999 (searched open issues) — nothing to tick.`
- lookup errors (bogus repo) → ``PARENT-TICK: COULD NOT LOOK — `gh issue list` failed: GraphQL: Could not resolve to a Repository …``

Two visibly different outputs, which is the requirement.

**Change 2's formula, run against today's state:** `version.json=0.6.0 → ACTIVE=v0.6 NEXT=v0.7 FUTURE=v0.8`. All three already exist in `gh api …/milestones?state=open` (`v0.4 v0.5 v0.6 v0.7 v0.8`). Simulated bumps: `0.6.1 → v0.6/v0.7/v0.8` (stays in cycle, the bug this fixes), `0.7.0 → v0.7/v0.8/v0.9`.

**Red-first honesty (AGENTS.md).** Both changes are **skill prose**. There is no mechanical check that reads their *semantics*, so there is no green here that was ever red for the behaviour itself — I am not presenting one as if there were. What I did instead:

- The only mechanical gate over these files is `skill-lint.sh`, and I confirmed it is not vacuous *on the file I edited*: appending an unbalanced ``` fence to `.claude/skills/ir:triage/SKILL.md` produced `ERROR odd number of code-fence delimiters … [unbalanced-fence]`, exit 1. Reverted; green again. That mutation is not committed as a fixture because `tools/lib/skill-lint_test.sh` and `tools/lib/preflight-groups-skill-mutations_test.sh` already carry committed mutation fixtures for this linter.
- Change 1's *logic* was executed against real GitHub data and against an adversarial fixture (the table above) **before** being written into the skill, which is the closest thing to red-first available for a prose instruction: the false-match case was run and shown not to fire.

**Read, not run:** `tools/build-release.sh` and `.claude/skills/ir:release/` are cited as the reason `version.json` is the in-development version; I read that claim in AGENTS.md's "Building the daemon" section and did not execute a release build to confirm it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
