### PR TITLE
fix(tailer): bump LedgerSchemaVersion to 6 so pre-#1796 errors heal on upgrade

### DIFF
--- a/core/adapters/outbound/metrics/ledger_test.go
+++ b/core/adapters/outbound/metrics/ledger_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strconv"
 	"testing"
 
 	"irrlicht/core/pkg/tailer"
@@ -22,6 +23,56 @@ func TestLoadLedger_RejectsOldSchema(t *testing.T) {
 	}
 	if s := loadLedger(lp); s != nil {
 		t.Errorf("loadLedger accepted a schema-3 ledger: %+v (must discard → full re-scan)", s)
+	}
+}
+
+// preSessionErrorLedgerVersion is the schema a v0.6.0 daemon stamps: the last
+// version whose parser had NO session-error concept at all (`git show
+// v0.6.0:core/pkg/tailer/parser.go | grep -c SessionError` → 0). Written as a
+// LITERAL on purpose. It is the fixed historical fact the test below is about,
+// and spelling it symbolically would make the test follow the bump it exists to
+// pin — reverting LedgerSchemaVersion to 5 would leave it green.
+const preSessionErrorLedgerVersion = 5
+
+// TestLoadLedger_RejectsPreSessionErrorSchema pins the #1815 bump to 6: a ledger
+// stamped by a daemon that could not derive session errors must be DISCARDED, so
+// the session gets a full transcript re-scan under the current parser.
+//
+// Why the re-scan is the whole point, and why nothing else supplies it: the
+// tailer's sticky error is a pure function of the transcript lines
+// (applySessionError is its only non-ledger writer), so a session that failed
+// under v0.6.0 has its failure sitting in bytes ALREADY PAST LastOffset. Accept
+// that ledger as current and the post-restart pass reads zero new lines, nothing
+// re-derives the failure, and the session stays `ready` forever under a daemon
+// that would have called it `error`.
+//
+// This is a guard, so it has no pre-fix red of its own — the mutation it was
+// verified against is `LedgerSchemaVersion = 5`, i.e. reverting the bump, which
+// makes the payload below current and turns this test red.
+func TestLoadLedger_RejectsPreSessionErrorSchema(t *testing.T) {
+	// Fail loudly rather than vacuously if the bump is ever reverted: with the
+	// two equal, the payload below is a CURRENT ledger and "discarded" would be
+	// asserting the opposite of what this test means.
+	if tailer.LedgerSchemaVersion <= preSessionErrorLedgerVersion {
+		t.Fatalf("LedgerSchemaVersion = %d, must exceed the pre-session-error schema %d — "+
+			"the #1815 bump was reverted, so a v0.6.0 ledger is now accepted as current and "+
+			"every session that failed under it stays green after upgrading",
+			tailer.LedgerSchemaVersion, preSessionErrorLedgerVersion)
+	}
+
+	dir := t.TempDir()
+	lp := filepath.Join(dir, "pre-session-error.ledger.json")
+	// A real v0.6.0 ledger shape: current-looking, mid-session, and carrying no
+	// session_error key because that daemon had no field to write one into.
+	v5 := []byte(`{"schema_version":` + strconv.Itoa(preSessionErrorLedgerVersion) +
+		`,"last_offset":3115960,"last_event_type":"assistant","cum_provider_cost_usd":1.25}`)
+	if err := os.WriteFile(lp, v5, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if s := loadLedger(lp); s != nil {
+		t.Errorf("loadLedger accepted a schema-%d ledger: %+v — a session that errored under "+
+			"v0.6.0 will resume at LastOffset, read zero new lines, and never go red",
+			preSessionErrorLedgerVersion, s)
 	}
 }
 

--- a/core/pkg/tailer/ledger_schema_pin_test.go
+++ b/core/pkg/tailer/ledger_schema_pin_test.go
@@ -1,0 +1,205 @@
+package tailer
+
+import (
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// pinnedLedgerSchemaVersion is the schema version the field set below belongs
+// to. A LITERAL, not the constant — a pin that reads the value it pins cannot
+// notice it moving.
+const pinnedLedgerSchemaVersion = 6
+
+// pinnedLedgerFieldSignature is the wire shape of LedgerState at
+// pinnedLedgerSchemaVersion: one `jsonName:goType` line per field, sorted by
+// json name. Regenerate by running the test and copying the "got" block; it is
+// meant to be updated, just never silently.
+const pinnedLedgerFieldSignature = `agent_version:string
+background_procs:map[string]string
+cum_by_model:map[string]*tailer.UsageBreakdown
+cum_provider_cost_usd:float64
+first_task_estimate:*tailer.TaskEstimate
+first_user_text:string
+last_assistant_text:string
+last_event_type:string
+last_offset:int64
+last_task_estimate:*tailer.TaskEstimate
+last_task_question:*tailer.TaskQuestion
+last_task_summary:*tailer.TaskSummary
+model_name:string
+parser_state:*tailer.ParserLedger
+pending_background_agent_count:int
+pending_bash_polls:map[string]string
+pending_task_creates:map[string]string
+pending_waiting_cue:bool
+resume_fingerprint:uint64
+schema_version:int
+session_error:*tailer.SessionError
+task_seq:int
+tasks:[]tailer.Task`
+
+// TestLedgerState_FieldSetChangeRequiresASchemaDecision is the tripwire that
+// #1815 needed and did not have.
+//
+// THE FAILURE MODE IT CLOSES IS SILENCE, NOT A WRONG ANSWER. Whether a new
+// LedgerState field warrants a LedgerSchemaVersion bump is a genuine judgement
+// call — the constant's doc lays out the rule, and the repo has landed on both
+// sides of it correctly (4/5 bumped, #1104/#1150/#1076 did not). What has never
+// existed is anything that makes the question get ASKED. Nothing pinned the
+// literal version and nothing pinned the field set, so #1796 added SessionError,
+// nobody weighed the bump, and the omission was indistinguishable from a
+// deliberate decline for an entire release cycle.
+//
+// So this test deliberately does NOT try to decide the bump — it cannot, and a
+// version of it that guessed would be worse than nothing. It fails on ANY field
+// set change, and its message hands the next person the rule to apply.
+func TestLedgerState_FieldSetChangeRequiresASchemaDecision(t *testing.T) {
+	if LedgerSchemaVersion != pinnedLedgerSchemaVersion {
+		t.Errorf("LedgerSchemaVersion = %d but the field set below is pinned at %d.\n"+
+			"If you bumped the version, update pinnedLedgerSchemaVersion to match.",
+			LedgerSchemaVersion, pinnedLedgerSchemaVersion)
+	}
+
+	got := ledgerFieldSignature(reflect.TypeOf(LedgerState{}))
+	if got == pinnedLedgerFieldSignature {
+		return
+	}
+
+	added, removed := signatureDiff(pinnedLedgerFieldSignature, got)
+	t.Errorf(`LedgerState's persisted field set changed.
+  added:   %v
+  removed: %v
+
+ANSWER THIS BEFORE UPDATING THE PIN: would the CURRENT parser read the bytes an
+existing ledger has ALREADY CONSUMED differently than the parser that wrote it?
+
+  no  -> the old ledger is degraded, not wrong. Do NOT bump; forcing a re-scan
+         would discard every live session's accumulated cost to reclaim a
+         shortcut. (ResumeFingerprint #1104, PendingWaitingCue #1150,
+         PendingBackgroundAgentCount #1076.)
+  yes -> BUMP LedgerSchemaVersion. The old summary is a verdict from a parser
+         that could not see what this one sees, and the re-scan is the point,
+         not the cost. Note that "it is just an additive omitempty field" does
+         not settle this: versions 4 and 5 are both additive omitempty fields.
+         (#649, #705, #1815.)
+
+Then update pinnedLedgerFieldSignature (and pinnedLedgerSchemaVersion if you
+bumped) to:
+
+%s`, added, removed, got)
+}
+
+// TestLedgerFieldSignature_DetectsAnAddedField is the committed mutation for the
+// tripwire above, which as a guard has no pre-fix red of its own.
+//
+// It builds LedgerState-plus-one-field at run time rather than hand-copying the
+// struct, so the mutant cannot drift out of sync with the real type and quietly
+// stop being "LedgerState + 1" — a hand-written copy would keep passing while
+// testing a shape the daemon stopped using.
+func TestLedgerFieldSignature_DetectsAnAddedField(t *testing.T) {
+	real := reflect.TypeOf(LedgerState{})
+
+	fields := make([]reflect.StructField, 0, real.NumField()+1)
+	for i := 0; i < real.NumField(); i++ {
+		fields = append(fields, real.Field(i))
+	}
+	fields = append(fields, reflect.StructField{
+		Name: "SomeNewlyAddedField",
+		Type: reflect.TypeOf(""),
+		Tag:  `json:"some_newly_added_field,omitempty"`,
+	})
+	mutant := reflect.StructOf(fields)
+
+	baseline := ledgerFieldSignature(real)
+	mutated := ledgerFieldSignature(mutant)
+
+	if mutated == baseline {
+		t.Fatal("adding a field to LedgerState did not change its signature — " +
+			"the tripwire above is inert and would not have caught #1815's missing bump")
+	}
+	added, removed := signatureDiff(baseline, mutated)
+	if len(added) != 1 || added[0] != "some_newly_added_field:string" {
+		t.Errorf("added = %v, want exactly [some_newly_added_field:string]", added)
+	}
+	if len(removed) != 0 {
+		t.Errorf("removed = %v, want empty — nothing was taken away", removed)
+	}
+}
+
+// TestLedgerFieldSignature_DetectsARetypedField covers the mutation the
+// add/remove framing above would miss: a field kept under the same json name
+// but given a different Go type. That is a wire-format change with no field
+// count change at all, and it is exactly the shape most likely to be waved
+// through as a refactor.
+func TestLedgerFieldSignature_DetectsARetypedField(t *testing.T) {
+	real := reflect.TypeOf(LedgerState{})
+
+	fields := make([]reflect.StructField, 0, real.NumField())
+	retyped := false
+	for i := 0; i < real.NumField(); i++ {
+		f := real.Field(i)
+		if f.Name == "PendingWaitingCue" { // bool -> string
+			f.Type = reflect.TypeOf("")
+			retyped = true
+		}
+		fields = append(fields, f)
+	}
+	// The field this mutation targets must still exist, or the test proves
+	// nothing while reporting success.
+	if !retyped {
+		t.Fatal("PendingWaitingCue is gone from LedgerState — this mutation " +
+			"silently stopped mutating anything; retarget it at another field")
+	}
+
+	if ledgerFieldSignature(reflect.StructOf(fields)) == ledgerFieldSignature(real) {
+		t.Error("retyping a field left the signature unchanged — a same-name, " +
+			"different-type field would slip past the tripwire")
+	}
+}
+
+// ledgerFieldSignature renders a struct's persisted shape as sorted
+// `jsonName:goType` lines.
+//
+// Sorted by json name so a pure field REORDER — which changes nothing on the
+// wire — does not trip the tripwire and train people to update the pin without
+// reading it. Type is included because a same-name field with a new type is a
+// schema change the name alone cannot show.
+func ledgerFieldSignature(t reflect.Type) string {
+	lines := make([]string, 0, t.NumField())
+	for i := 0; i < t.NumField(); i++ {
+		f := t.Field(i)
+		name := strings.Split(f.Tag.Get("json"), ",")[0]
+		if name == "" {
+			name = f.Name // no json tag: encoding/json uses the Go name
+		}
+		if name == "-" {
+			continue // never persisted, so not part of the schema
+		}
+		lines = append(lines, name+":"+f.Type.String())
+	}
+	sort.Strings(lines)
+	return strings.Join(lines, "\n")
+}
+
+// signatureDiff reports which lines want has that got lacks, and vice versa.
+func signatureDiff(want, got string) (added, removed []string) {
+	inWant := map[string]bool{}
+	for _, l := range strings.Split(want, "\n") {
+		inWant[l] = true
+	}
+	inGot := map[string]bool{}
+	for _, l := range strings.Split(got, "\n") {
+		inGot[l] = true
+		if !inWant[l] {
+			added = append(added, l)
+		}
+	}
+	for _, l := range strings.Split(want, "\n") {
+		if !inGot[l] {
+			removed = append(removed, l)
+		}
+	}
+	return added, removed
+}

--- a/core/pkg/tailer/ledger_schema_pin_test.go
+++ b/core/pkg/tailer/ledger_schema_pin_test.go
@@ -183,23 +183,27 @@ func ledgerFieldSignature(t reflect.Type) string {
 	return strings.Join(lines, "\n")
 }
 
+// lineSet indexes a signature's lines so membership is one map lookup.
+func lineSet(sig string) map[string]bool {
+	set := map[string]bool{}
+	for _, l := range strings.Split(sig, "\n") {
+		set[l] = true
+	}
+	return set
+}
+
+// linesNotIn returns sig's lines that set does not hold, in sig's own order.
+func linesNotIn(sig string, set map[string]bool) []string {
+	var out []string
+	for _, l := range strings.Split(sig, "\n") {
+		if !set[l] {
+			out = append(out, l)
+		}
+	}
+	return out
+}
+
 // signatureDiff reports which lines want has that got lacks, and vice versa.
 func signatureDiff(want, got string) (added, removed []string) {
-	inWant := map[string]bool{}
-	for _, l := range strings.Split(want, "\n") {
-		inWant[l] = true
-	}
-	inGot := map[string]bool{}
-	for _, l := range strings.Split(got, "\n") {
-		inGot[l] = true
-		if !inWant[l] {
-			added = append(added, l)
-		}
-	}
-	for _, l := range strings.Split(want, "\n") {
-		if !inGot[l] {
-			removed = append(removed, l)
-		}
-	}
-	return added, removed
+	return linesNotIn(got, lineSet(want)), linesNotIn(want, lineSet(got))
 }

--- a/core/pkg/tailer/ledger_session_error_test.go
+++ b/core/pkg/tailer/ledger_session_error_test.go
@@ -71,24 +71,29 @@ func TestLedger_ClearedSessionErrorStaysCleared(t *testing.T) {
 	}
 }
 
-// TestLedger_PreFieldLedgerRehydratesToNoError pins the no-schema-bump decision:
-// a ledger written before #1815 simply lacks the key, and must rehydrate to the
-// exact pre-fix behaviour rather than failing to load.
+// TestLedger_KeylessCurrentLedgerRehydratesToNoError pins the ordinary case that
+// `omitempty` creates: a CURRENT-schema ledger for a session that never failed
+// carries no session_error key at all, and must rehydrate to "no error" rather
+// than to a parse failure.
 //
-// This is what makes the additive field safe without discarding every live
-// session's ledger — the claim LedgerState.SessionError's doc makes, asserted
-// against a real pre-field payload rather than left as prose.
-func TestLedger_PreFieldLedgerRehydratesToNoError(t *testing.T) {
-	// A ledger body with no session_error key at all — what every ledger on
-	// disk looks like today.
+// NOTE THE SCOPE, which narrowed when #1815's bump to 6 landed. This is no longer
+// a statement about OLD ledgers: a pre-#1815 ledger is stamped 5 and loadLedger
+// discards it outright, so it never reaches this code path at all —
+// TestLoadLedger_RejectsPreSessionErrorSchema owns that half, and it has to,
+// because a v0.6.0 ledger's missing key is not "this session was fine" but "the
+// parser that wrote me could not tell". Rehydrating it would assert the former.
+// What survives here is the every-session-every-pass case: absent key → no error.
+func TestLedger_KeylessCurrentLedgerRehydratesToNoError(t *testing.T) {
+	// A ledger body with no session_error key — what a healthy session's ledger
+	// looks like on disk.
 	raw := []byte(`{"schema_version":` + strconv.Itoa(LedgerSchemaVersion) + `,"last_offset":4096,"last_event_type":"assistant"}`)
 
 	var s LedgerState
 	if err := json.Unmarshal(raw, &s); err != nil {
-		t.Fatalf("a pre-#1815 ledger no longer parses: %v", err)
+		t.Fatalf("a keyless current ledger no longer parses: %v", err)
 	}
 	if s.SessionError != nil {
-		t.Errorf("SessionError = %+v, want nil for a ledger written before the field existed", s.SessionError)
+		t.Errorf("SessionError = %+v, want nil for a ledger that carries no session_error key", s.SessionError)
 	}
 
 	after := newLedgerTestTailer()

--- a/core/pkg/tailer/parser.go
+++ b/core/pkg/tailer/parser.go
@@ -669,13 +669,38 @@ type ReplayStoreStager interface {
 // under the current parser. Bump it whenever a LedgerState change (or a parser
 // fix) makes previously persisted state misleading.
 //
+// ADDITIVE-FIELD IS NOT THE TEST, and reading it as one is the mistake #1815
+// made. Versions 4 and 5 are BOTH plain additive `omitempty` fields
+// (last_event_type, last_assistant_text) and both bumped; ResumeFingerprint,
+// PendingWaitingCue and PendingBackgroundAgentCount are also additive
+// `omitempty` fields and correctly did not. The discriminator is what the
+// CURRENT parser would make of the bytes the old ledger already consumed:
+//
+//   - Same reading, missing shortcut → NO BUMP. The old parser classified the
+//     consumed prefix exactly as this one would; the field only spares a
+//     re-derivation. A pre-field ledger is degraded, not wrong, and discarding
+//     every live session's accumulated cost to reclaim a shortcut is the
+//     bigger hammer. (#1104, #1150, #1076.)
+//   - Different reading → BUMP. A parser change makes the old summary a
+//     verdict reached by a parser that could not see what this one sees. The
+//     re-scan is not a cost, it is the point. (#649, #705, #1815.)
+//
+// TestLedgerState_FieldSetChangeRequiresASchemaDecision pins the field set so
+// the next field added has to answer this question rather than inherit an
+// answer by silence — which is exactly how #1815 shipped without one.
+//
 // History: 3 — #615 (authoritative task IDs + TaskSeq);
 // 4 — #649 (LastEventType persisted; the bump also heals sessions stranded
 // in `working` by pre-#642 parsers, since the re-scan reclassifies them);
 // 5 — #705 (LastAssistantText persisted; the bump also heals sessions
 // mis-demoted from `waiting` to `ready` on restart, since the re-scan
-// recovers the question text IsWaitingForUserInput needs).
-const LedgerSchemaVersion = 5
+// recovers the question text IsWaitingForUserInput needs);
+// 6 — #1815 (SessionError persisted; the bump also heals sessions that failed
+// under a pre-#1796 parser, which had NO session-error concept at all — v0.6.0's
+// parser.go contains no SessionError whatsoever — since the re-scan re-derives
+// the failure from lines that parser read as ordinary and settles them `error`
+// instead of leaving them permanently `ready`).
+const LedgerSchemaVersion = 6
 
 // LedgerState is the durable portion of a tailer's accumulation state, written
 // to disk after every TailAndProcess pass so that daemon restarts don't reset
@@ -798,12 +823,28 @@ type LedgerState struct {
 	// reason: a verdict that cannot be re-derived from zero new bytes has to be
 	// carried, not recomputed.
 	//
-	// NO SCHEMA BUMP, following ResumeFingerprint and PendingWaitingCue: a ledger
-	// written before this field simply lacks it and rehydrates to nil, which is
-	// byte-for-byte the pre-fix behaviour. Discarding every live session's ledger
-	// to force a re-scan would be a far bigger hammer than an additive field
-	// warrants — and a re-scan could not recover the verdict anyway, since
-	// clearSessionErrorOnRecovery would replay the same lines to the same result.
+	// SCHEMA BUMP TO 6. #1815 originally shipped this field WITHOUT one, reasoning
+	// from ResumeFingerprint and PendingWaitingCue that an additive field never
+	// needs a bump. That reasoning was wrong twice over, and both corrections are
+	// worth keeping because each was load-bearing on its own:
+	//
+	//   - Additive is not the test. Versions 4 and 5 are additive `omitempty`
+	//     fields that bumped. See LedgerSchemaVersion for the actual rule.
+	//   - "A re-scan could not recover the verdict anyway, since
+	//     clearSessionErrorOnRecovery would replay the same lines to the same
+	//     result" — the original text — has the conclusion backwards. Replaying
+	//     the same lines to the same result IS recovery: this sticky error has
+	//     exactly one non-ledger writer, applySessionError, fed only by
+	//     parsed.SessionError off the transcript, so it is a pure function of the
+	//     consumed lines and a full re-scan re-derives it exactly.
+	//     (session.NewProcessDeathError is NOT a counterexample: it is raised in
+	//     the detector and travels as a signal payload, never through this field.)
+	//
+	// The bump is what makes the re-scan happen at all. Without it a session that
+	// failed under a v0.6.0 daemon — whose parser.go has no SessionError anywhere,
+	// so the failure was never derived once — keeps its v5 ledger, resumes at
+	// LastOffset, reads ZERO new lines, and stays green forever under a daemon
+	// that can now see the failure sitting in bytes it will never re-read.
 	//
 	// A CLEARED ERROR IS PERSISTED AS CLEARED. The field stores nil when the
 	// tailer's sticky error is nil, so the clearing rule survives a restart too;


### PR DESCRIPTION
## The question

Should `tailer.LedgerSchemaVersion` be bumped from 5 to 6 before the next release, given that #1796/#1815 added `LedgerState.SessionError` at version 5?

**Yes** — but not for the reason that prompted the review.

## The argument that does NOT hold

The downgrade story ("a v0.6.0 daemon loads a v5 ledger written by main, silently strips `session_error` via `omitempty`, and writes it back") does not happen for the sessions that carry one. Verified in source, not inferred:

- `v0.6.0:core/adapters/outbound/filesystem/repository.go:121-129` — `ListAll` **hard-deletes** any session file whose state is not one of working/waiting/ready. A session in state `error` is removed on a v0.6.0 daemon's first `ListAll`.
- `startup.go:72` `pruneOrphanLedgers` re-derives orphans from a second `ListAll` and deletes the ledger with it.
- A non-nil `SessionError` always classifies to `StateError` — the `session_error` rule's `!HookTurnDone` guard "no longer changes any outcome; both branches answer error for a standing failure" (`state_classifier.go:319-323`), the other branch being `classifyAgentDone`.

So there is no strip-and-rewrite: both files are deleted, and the next upgrade re-scans from byte 0 anyway. That path already heals, more forcefully than a bump would.

## The argument that does hold

The plain **forward** upgrade. `git show v0.6.0:core/pkg/tailer/parser.go | grep -c SessionError` → `0`: that parser had no session-error concept at all. A session that failed under v0.6.0 keeps its v5 ledger, is accepted as current, resumes at `LastOffset`, reads **zero new lines**, and stays `ready` forever under a daemon that can now see the failure sitting in bytes it will never re-read.

This is precisely the healing effect versions 4 and 5 both cite.

## Why the "additive field" precedent does not cover it

The precedent pointed at (`rotation_reset_test.go:299-304`, `PendingWaitingCue`, `ResumeFingerprint`) is real but is one of *two* lines. **Versions 4 (`last_event_type`, #649) and 5 (`last_assistant_text`, #705) are both plain additive `omitempty` fields, and both bumped.** So "additive → no bump" is not the house rule.

The actual discriminator, now written onto the constant: *would the current parser read the bytes an existing ledger has already consumed differently than the parser that wrote it?*

- **No** → degraded, not wrong. Don't bump. (#1104, #1150, #1076.)
- **Yes** → the old summary is a verdict from a parser that could not see what this one sees; the re-scan is the point, not the cost. (#649, #705, and this.)

`SessionError` is squarely in the second group.

This also corrects a claim in the field's own doc — *"a re-scan could not recover the verdict anyway, since `clearSessionErrorOnRecovery` would replay the same lines to the same result"* — which has the conclusion backwards. Replaying the same lines to the same result **is** recovery. The sticky error has exactly one non-ledger writer (`applySessionError`, fed only by `parsed.SessionError` off the transcript), so it is a pure function of the consumed lines. `session.NewProcessDeathError` is not a counterexample: it is raised in the detector and travels as a signal payload, never through this field.

## Guards, each verified by mutation

Both are guards, so neither has a pre-fix red of its own; each was mutated instead.

**1. `TestLoadLedger_RejectsPreSessionErrorSchema`** pins the literal pre-bump version `5` (symbolic would make it follow the bump it exists to pin). Mutation = revert the bump:

```
--- FAIL: TestLoadLedger_RejectsPreSessionErrorSchema (0.00s)
    ledger_test.go:57: LedgerSchemaVersion = 5, must exceed the pre-session-error
    schema 5 — the #1815 bump was reverted, so a v0.6.0 ledger is now accepted as
    current and every session that failed under it stays green after upgrading
```

**2. `TestLedgerState_FieldSetChangeRequiresASchemaDecision`** — the more valuable half. Nothing previously pinned the literal version or the field set, so the bump question never got *asked*; #1815's omission was indistinguishable from a deliberate decline for a whole release cycle. It deliberately does **not** try to decide the bump (a version that guessed would be worse than nothing) — it fails on any field-set change and hands over the rule. Mutation = add a field without bumping:

```
--- FAIL: TestLedgerState_FieldSetChangeRequiresASchemaDecision (0.00s)
    LedgerState's persisted field set changed.
      added:   [some_new_signal:bool]
      removed: []
    ANSWER THIS BEFORE UPDATING THE PIN: would the CURRENT parser read the bytes
    an existing ledger has ALREADY CONSUMED differently than the parser that
    wrote it? ...
```

Its two committed mutation fixtures build the mutant with `reflect.StructOf` at run time rather than hand-copying the struct, so the mutant cannot drift out of sync and quietly stop being "LedgerState + 1"; one covers an added field, one covers a same-name/different-type field (a wire change with no field-count change), and the retype fixture fails loudly if its target field ever disappears.

## Verification

| command | result |
|---|---|
| `go test ./core/... -race -count=1` | `EXIT=0`, 64 pkgs ok |
| `tools/preflight.sh --only go` | `EXIT=0` |
| `tools/preflight.sh --only arch` | PASS (composite 7.887930 → 7.888004) |
| `tools/replay-fixtures.sh` | `EXIT=0`, **no golden drift** (tree clean; goldens not regenerated) |

Consumers all reference the constant symbolically and were re-verified: `metrics/ledger.go:16-17`, `ledger_test.go`, `ledger_event_type_test.go`, `rotation_reset_test.go:316`, `tailer_ledger.go:9`. The only literal `5` in the tree was the constant itself.

`TestLedger_PreFieldLedgerRehydratesToNoError` was retargeted (and renamed `TestLedger_KeylessCurrentLedgerRehydratesToNoError`): its premise was that a pre-#1815 ledger rehydrates, which the bump makes false — such a ledger is now discarded before reaching that path. What survives is the real every-pass case (absent key → no error).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
