### PR TITLE
feat(macos): add a Compact menu bar style and a stable status-item autosave name

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,37 @@ The **11 onboarded coding agents** below declare their stage in [`replaydata/age
 
 → [Adapters reference](https://ingo-eichhorst.github.io/Irrlicht/docs/adapters.html#maturity-stages) for stage criteria, watch paths, model detection, and roadmap.
 
+## The menu bar icon is hidden
+
+macOS gives every app a slice of the menu bar and hands out what's left in
+launch order. On a 13" or 14" screen — or any screen with a crowded menu bar —
+Irrlicht's icon can end up behind the notch or behind the frontmost app's
+menus, where you can neither see nor click it. Four things to try, cheapest
+first:
+
+1. **Cmd-drag it somewhere you can see.** Hold ⌘ and drag the icon along the
+   menu bar. Irrlicht asks macOS to remember the spot, so it should still be
+   there after a quit and a relaunch.
+2. **Switch to a narrower icon style.** Settings → *Menu Bar Icon*. **Compact**
+   collapses every project into one dot with a session count and drops the
+   quota bars, so its width stays the same no matter how many projects you
+   have open — from two projects on it is the narrowest style (measured:
+   18.5pt, against 90pt for Lights and 117pt for Combined at six projects).
+   **Lights** (the default) draws one dot-group per project and grows with
+   them; **Combined** is the widest, adding quota bars on the right.
+3. **Mind the notch.** On a notched Mac the menu bar has a dead zone in the
+   middle. macOS does not flow icons around it — an icon pushed into that
+   range is simply not drawn. Removing any other status item, or using a
+   narrower style, moves Irrlicht back out.
+4. **Use a menu bar manager** if you run a lot of status items:
+   [Ice](https://github.com/jordanbaird/Ice) (free, open source),
+   [Bartender](https://www.macbartender.com/), or
+   [Hidden Bar](https://github.com/dwarvesf/hidden). All three let you pin
+   Irrlicht to the always-visible section.
+
+If the icon is gone entirely and none of the above brings it back, Irrlicht is
+probably not running — relaunch it from `/Applications`.
+
 ## Posture
 
 Local-first · no telemetry · MIT · ~5 MB RAM · signed Homebrew cask · transcripts read-only.

--- a/platforms/macos/Irrlicht/App/MenuBarController.swift
+++ b/platforms/macos/Irrlicht/App/MenuBarController.swift
@@ -59,7 +59,16 @@ final class MenuBarController: NSObject {
         self.sessionManager = sessionManager
         self.gasTownProvider = gasTownProvider
         self.updateManager = updateManager
+        // Carry any position AppKit persisted under its generated name over to
+        // the declared one BEFORE `autosaveName` is assigned below — that
+        // assignment is what makes AppKit look the new key up, so the value
+        // has to be there first. See MenuBarStatusItemIdentity (#1845).
+        MenuBarStatusItemIdentity.migrateLegacyPreferredPosition(in: UserDefaults.standard)
+
         self.statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
+        // Declaring the name is what makes the user's Cmd-drag position a
+        // property of this app rather than of its startup order (#1845).
+        self.statusItem.autosaveName = MenuBarStatusItemIdentity.autosaveName
 
         let root = SessionListView()
             .environmentObject(daemonManager)

--- a/platforms/macos/Irrlicht/App/MenuBarImageBuilder.swift
+++ b/platforms/macos/Irrlicht/App/MenuBarImageBuilder.swift
@@ -30,9 +30,9 @@ enum MenuBarImageBuilder {
     /// The filter has to match what `MenuBarStatusRenderer` draws, or the icon
     /// widens to point at a red circle that is not in it. Subagents are the
     /// trap: they live in `sessionManager.sessions` but
-    /// `MenuBarStatusRenderer.orderedProjectGroups` excludes them
-    /// (`where session.parentSessionId == nil`), so a failed CHILD would
-    /// otherwise widen the icon while adding no red dot anywhere.
+    /// `MenuBarStatusRenderer` excludes them from every render path (its
+    /// `topLevelSessions` filter), so a failed CHILD would otherwise widen
+    /// the icon while adding no red dot anywhere.
     ///
     /// Still an over-approximation in one known case: a group past
     /// `maxVisibleGroups` collapses into the grey overflow ellipsis, so an
@@ -77,8 +77,49 @@ enum MenuBarImageBuilder {
         dotsImage: NSImage?,
         hasErroredSession: Bool
     ) -> Bool {
-        guard style == .usage, dotsImage != nil else { return false }
+        guard style.hidesDotsWhenQuotaIsRenderable, dotsImage != nil else { return false }
         return quotaImage == nil || hasErroredSession
+    }
+
+    /// The dot half of the icon, for a given style.
+    ///
+    /// Extracted from `combinedImage` so the style-to-renderer routing is
+    /// reachable from a test without a `SessionManager` — the same reason
+    /// `iconState` and `shouldShowDotsInUsageStyle` are pure. Review of
+    /// #1849 measured that this wiring was the one part of the change no
+    /// test could see: inverting the condition here left all 527 tests
+    /// green while collapsing every shipped style to a single dot.
+    static func dotsImage(
+        style: MenuBarStyle,
+        sessions: [SessionState],
+        projectGroupOrder: [String]
+    ) -> NSImage? {
+        style.aggregatesSessionDots
+            ? MenuBarStatusRenderer.buildAggregateStatusImage(sessions: sessions)
+            : MenuBarStatusRenderer.buildStatusImage(
+                sessions: sessions,
+                projectGroupOrder: projectGroupOrder
+            )
+    }
+
+    /// The quota half of the icon, for a given style — nil when the style
+    /// carries no quota bars at all. Extracted for the same reason as
+    /// `dotsImage`: swapping `usesNarrowQuotaBars` for `showsQuotaBars` in
+    /// the `compact:` argument is a one-word slip that silently re-lays-out
+    /// every `.usage` user's icon, and nothing could see it.
+    static func quotaImage(
+        style: MenuBarStyle,
+        sessions: [SessionState],
+        providerKey: String?,
+        now: Date
+    ) -> NSImage? {
+        guard style.showsQuotaBars else { return nil }
+        return QuotaMenuBarRenderer.imageForSelectedProvider(
+            sessions: sessions,
+            providerKey: providerKey,
+            compact: style.usesNarrowQuotaBars,
+            now: now
+        )
     }
 
     static func build(
@@ -119,7 +160,11 @@ enum MenuBarImageBuilder {
         // Computed once regardless of style so the .usage fallback below can
         // check its actual success/failure instead of re-deriving it from a
         // raw session count (see shouldShowDotsInUsageStyle's doc).
-        let computedDotsImage = MenuBarStatusRenderer.buildStatusImage(
+        //
+        // The Compact style (#1845) collapses every project into ONE
+        // aggregate dot, so its width does not grow with the project count.
+        let computedDotsImage = dotsImage(
+            style: style,
             sessions: nonGtSessions,
             projectGroupOrder: sessionManager.projectGroupOrder
         )
@@ -133,10 +178,10 @@ enum MenuBarImageBuilder {
         // this is that place, once, visibly, rather than twice inside
         // `rowSVG` where the 5h and 7d rows could be paced against two
         // different instants.
-        let quotaImage = style == .lights ? nil : QuotaMenuBarRenderer.imageForSelectedProvider(
+        let builtQuotaImage = quotaImage(
+            style: style,
             sessions: nonGtSessions,
             providerKey: MenuBarQuotaProvider.current,
-            compact: style == .combined,
             now: Date()
         )
         // .usage style hides the dots by default. Two conditions bring them
@@ -145,9 +190,14 @@ enum MenuBarImageBuilder {
         //
         // `nonGtSessions` has already dropped Gas Town sessions; hasErroredDot
         // drops subagents. Both filters are needed — see its doc.
+        //
+        // The locals are named `built…`/`shown…` rather than reusing the
+        // helpers' own names: `let quotaImage = quotaImage(...)` compiles, but
+        // it gives one identifier two meanings inside a single function and
+        // reads like recursion at a glance.
         let hasErroredSession = hasErroredDot(in: nonGtSessions)
-        let dotsImage = style != .usage || shouldShowDotsInUsageStyle(
-            style: style, quotaImage: quotaImage, dotsImage: computedDotsImage,
+        let shownDotsImage = !style.hidesDotsWhenQuotaIsRenderable || shouldShowDotsInUsageStyle(
+            style: style, quotaImage: builtQuotaImage, dotsImage: computedDotsImage,
             hasErroredSession: hasErroredSession
         ) ? computedDotsImage : nil
         // Dots first (left), quota bars last (right) — closest to the
@@ -155,7 +205,9 @@ enum MenuBarImageBuilder {
         // mockup ordering. Uses the same gap as between dot-groups
         // themselves (MenuBarStatusRenderer.groupGap) so the dots-to-quota
         // seam in Combined style reads as "one more group," not a wider gap.
-        let baseImage = composeSideBySide(dotsImage, quotaImage, gap: MenuBarStatusRenderer.groupGap)
+        let baseImage = composeSideBySide(
+            shownDotsImage, builtQuotaImage, gap: MenuBarStatusRenderer.groupGap
+        )
 
         guard gasTownProvider.isDaemonRunning else { return baseImage }
 

--- a/platforms/macos/Irrlicht/App/MenuBarStatusItemIdentity.swift
+++ b/platforms/macos/Irrlicht/App/MenuBarStatusItemIdentity.swift
@@ -1,0 +1,83 @@
+import Foundation
+
+/// The menu-bar status item's persisted identity (issue #1845).
+///
+/// macOS has no public API to place a status item at an absolute position.
+/// The user reorders it with a Cmd-drag, and AppKit persists that position in
+/// the app's own defaults domain under
+/// `NSStatusItem Preferred Position <autosaveName>`.
+///
+/// **What the app did before this type existed.** It never set
+/// `NSStatusItem.autosaveName`, so AppKit generated one. Measured on a real
+/// install with `defaults read io.irrlicht.app`, the app's domain carried:
+///
+///     "NSStatusItem Preferred Position Item-0" = 298;
+///
+/// `Item-0` is AppKit's generated name for the first status item an app
+/// creates, and this app creates exactly one (`MenuBarController.swift` holds
+/// the only `NSStatusBar.system.statusItem(...)` call in the tree). So the
+/// position was already being persisted — under a name derived from creation
+/// order rather than from anything this app declares.
+///
+/// **Why that is worth changing.** The generated name is stable only for as
+/// long as this app keeps creating exactly one status item, in the same
+/// order. A second status item added later would renumber it, and the user's
+/// dragged position would be silently orphaned. Naming the item makes the key
+/// a property of the app rather than an accident of its startup sequence.
+///
+/// **Why the migration below is not optional.** Setting an `autosaveName`
+/// changes which key AppKit reads. Without a migration, every existing
+/// install's `Item-0` position would be orphaned on the very first launch
+/// after upgrading, and the icon would jump — exactly the "existing installs
+/// see no change until they opt in" criterion this issue set. So the first
+/// launch under the new name copies the old value across, once.
+enum MenuBarStatusItemIdentity {
+    /// The stable name this app declares for its one status item.
+    static let autosaveName = "IrrlichtStatusItem"
+
+    /// AppKit's defaults key for a named status item's user-dragged position.
+    /// The literal prefix (including the spaces) is AppKit's, not ours.
+    static func preferredPositionKey(forAutosaveName name: String) -> String {
+        "NSStatusItem Preferred Position \(name)"
+    }
+
+    /// The key AppKit generated for this app's status item before it had a
+    /// declared name. Observed on a real install — see the type's doc.
+    static let legacyAutosaveName = "Item-0"
+
+    /// Carry an existing install's dragged position over to the declared
+    /// name, once.
+    ///
+    /// Must run before `autosaveName` is assigned on the status item: that
+    /// assignment is what points AppKit at the new key, so the value has to
+    /// be in place first. (Creating the item is not itself the deadline —
+    /// an unnamed item still reads the generated key — but the two happen
+    /// one line apart, and ordering against the earlier of the two is the
+    /// safer thing to pin.)
+    ///
+    /// Runs only when the new key is absent AND the legacy key is present, so
+    /// it is a no-op on a fresh install (nothing to carry), on every launch
+    /// after the first (the new key now exists), and for a user who never
+    /// dragged the icon at all. It never overwrites a position the user set
+    /// under the new name.
+    ///
+    /// Takes the store rather than reaching for `UserDefaults.standard`, both
+    /// so it is testable against a double and because `PersistentDefaultsLintTests`
+    /// requires exactly that seam for any write in the app target.
+    ///
+    /// - Returns: whether a value was actually carried over, so a caller (or a
+    ///   test) can tell "migrated" apart from "nothing to migrate".
+    @discardableResult
+    static func migrateLegacyPreferredPosition(in defaults: UserDefaults) -> Bool {
+        let currentKey = preferredPositionKey(forAutosaveName: autosaveName)
+        let legacyKey = preferredPositionKey(forAutosaveName: legacyAutosaveName)
+
+        guard defaults.object(forKey: currentKey) == nil,
+              let legacyValue = defaults.object(forKey: legacyKey) else {
+            return false
+        }
+
+        defaults.set(legacyValue, forKey: currentKey)
+        return true
+    }
+}

--- a/platforms/macos/Irrlicht/Models/MenuBarStyle.swift
+++ b/platforms/macos/Irrlicht/Models/MenuBarStyle.swift
@@ -8,6 +8,12 @@ enum MenuBarStyle: String, CaseIterable, Identifiable {
     case lights
     case usage
     case combined
+    /// One aggregate dot for every project at once, and no quota bars — the
+    /// only style whose width does not grow with the number of projects
+    /// (issue #1845). Appended LAST on purpose: `allCases` drives the
+    /// Settings segmented control's order, so a new case anywhere else would
+    /// move the three segments an existing user already knows.
+    case compact
 
     var id: String { rawValue }
 
@@ -16,6 +22,57 @@ enum MenuBarStyle: String, CaseIterable, Identifiable {
         case .lights: return "Lights"
         case .usage: return "Usage"
         case .combined: return "Combined"
+        case .compact: return "Compact"
+        }
+    }
+
+    // MARK: - What each style renders
+    //
+    // These three are `switch`es rather than the `style == .lights` /
+    // `style == .combined` / `style != .usage` comparisons that used to live
+    // in MenuBarImageBuilder, because a comparison silently answers for a
+    // case that did not exist when it was written. Adding `.compact` (#1845)
+    // had to answer three separate questions, and each one defaulted into
+    // some other style's branch with nothing failing to build. A `switch`
+    // over the enum is the one reader the Swift compiler forces to be
+    // exhaustive — the same reasoning MenuBarStatusRenderer.segmentOrder
+    // gives for deriving from `allCases` instead of hand-listing (#1797).
+
+    /// Whether the icon carries the subscription quota bars at all.
+    var showsQuotaBars: Bool {
+        switch self {
+        case .lights, .compact: return false
+        case .usage, .combined: return true
+        }
+    }
+
+    /// Whether those quota bars render in the narrow, label-less layout
+    /// (`QuotaMenuBarRenderer`'s `compact:` flag — a different, older concept
+    /// than the `.compact` *style*, which shows no quota bars at all).
+    var usesNarrowQuotaBars: Bool {
+        switch self {
+        case .lights, .usage, .compact: return false
+        case .combined: return true
+        }
+    }
+
+    /// Whether the session dots collapse into ONE aggregate dot spanning
+    /// every project, instead of one dot-group per project.
+    var aggregatesSessionDots: Bool {
+        switch self {
+        case .lights, .usage, .combined: return false
+        case .compact: return true
+        }
+    }
+
+    /// Whether the dots give way to the quota bars when those are
+    /// renderable. Only `.usage` does; see
+    /// `MenuBarImageBuilder.shouldShowDotsInUsageStyle` for the two
+    /// conditions that bring them back anyway.
+    var hidesDotsWhenQuotaIsRenderable: Bool {
+        switch self {
+        case .lights, .combined, .compact: return false
+        case .usage: return true
         }
     }
 

--- a/platforms/macos/Irrlicht/Views/MenuBarStatusRenderer.swift
+++ b/platforms/macos/Irrlicht/Views/MenuBarStatusRenderer.swift
@@ -24,6 +24,9 @@ struct MenuBarStatusRenderer {
     private static let height: CGFloat = 18
     private static let fontSize: CGFloat = 10
     private static let maxVisibleGroups = 5
+    /// Advance width of one digit of the session count in the aggregate dot's
+    /// Menlo label. Measured against the rendered glyph, not derived.
+    private static let countDigitWidth: CGFloat = 6.5
     private static let overflowFillHex = IrrSVG.cancelled
     /// Slice order for the per-group pie dot — DERIVED from `allCases`, never
     /// hand-listed (#1797).
@@ -45,21 +48,7 @@ struct MenuBarStatusRenderer {
         sessions: [SessionState],
         projectGroupOrder: [String]
     ) -> NSImage? {
-        guard let (svg, totalWidth) = buildStatusSVG(
-            sessions: sessions,
-            projectGroupOrder: projectGroupOrder
-        ) else {
-            return nil
-        }
-
-        guard let data = svg.data(using: .utf8),
-              let image = NSImage(data: data) else {
-            return nil
-        }
-
-        image.isTemplate = false
-        image.size = NSSize(width: totalWidth, height: height)
-        return image
+        image(from: buildStatusSVG(sessions: sessions, projectGroupOrder: projectGroupOrder))
     }
 
     static func buildStatusSVG(
@@ -71,25 +60,75 @@ struct MenuBarStatusRenderer {
         if groups.count > maxVisibleGroups {
             renders.append(renderOverflow())
         }
-        let totalWidth = totalRenderWidth(renders)
+        return assemble(renders)
+    }
 
-        guard totalWidth > 0 else { return nil }
+    // MARK: - Compact style (issue #1845)
 
-        var svg = """
-        <svg xmlns="http://www.w3.org/2000/svg" width="\(Int(totalWidth))" height="\(Int(height))">
-        """
+    /// Render EVERY top-level session as a single aggregate dot, ignoring
+    /// project boundaries entirely.
+    ///
+    /// This is the width fix. `buildStatusSVG` costs one render per project
+    /// plus a `groupGap` between each, so its width grows with the number of
+    /// projects until `maxVisibleGroups` caps it — by which point the icon
+    /// can already be wide enough to sit behind the notch on a 13"/14" screen
+    /// with a crowded menu bar. This function's width depends only on the
+    /// number of DIGITS in the session count, so it is constant at 18.5pt for
+    /// 1-9 sessions and 25pt for 10-99, no matter how many projects are open.
+    static func buildAggregateStatusImage(sessions: [SessionState]) -> NSImage? {
+        image(from: buildAggregateStatusSVG(sessions: sessions))
+    }
 
+    static func buildAggregateStatusSVG(sessions: [SessionState]) -> (svg: String, width: CGFloat)? {
+        let topLevel = topLevelSessions(sessions)
+        guard !topLevel.isEmpty else { return nil }
+        return assemble([aggregateRender(topLevel)])
+    }
+
+    // MARK: - Shared assembly
+
+    /// Lay renders out left to right with `groupGap` between them and wrap
+    /// the result in one `<svg>`. Shared by the per-project and aggregate
+    /// paths so the two cannot drift in how they space or size themselves.
+    /// One loop, deliberately. The layout offsets and the declared total
+    /// width are the same arithmetic, and they used to be computed by two
+    /// separate loops each carrying its own `if index > 0` gap rule. Review
+    /// of #1849 showed that dropping the gap from one of them left the
+    /// declared width at 32 while the content laid out to 38 — clipping the
+    /// last dot off the icon — with the whole suite green. Deriving the
+    /// width from the same walk that places the groups makes that
+    /// divergence unrepresentable.
+    private static func assemble(_ renders: [GroupRender]) -> (svg: String, width: CGFloat)? {
+        var body = ""
         var offsetX: CGFloat = 0
         for (index, render) in renders.enumerated() {
             if index > 0 {
                 offsetX += groupGap
             }
-            svg += "<g transform=\"translate(\(svgNumber(offsetX)),0)\">\(render.elements)</g>"
+            body += "<g transform=\"translate(\(svgNumber(offsetX)),0)\">\(render.elements)</g>"
             offsetX += render.width
         }
-        svg += "</svg>"
+
+        let totalWidth = offsetX
+        guard totalWidth > 0 else { return nil }
+
+        let svg = """
+        <svg xmlns="http://www.w3.org/2000/svg" width="\(Int(totalWidth))" height="\(Int(height))">
+        """ + body + "</svg>"
 
         return (svg, totalWidth)
+    }
+
+    private static func image(from built: (svg: String, width: CGFloat)?) -> NSImage? {
+        guard let (svg, totalWidth) = built,
+              let data = svg.data(using: .utf8),
+              let image = NSImage(data: data) else {
+            return nil
+        }
+
+        image.isTemplate = false
+        image.size = NSSize(width: totalWidth, height: height)
+        return image
     }
 
     static func stateSegments(for sessions: [SessionState]) -> [StateSegment] {
@@ -121,12 +160,19 @@ struct MenuBarStatusRenderer {
         """
     }
 
+    /// The sessions the icon counts: top-level only, never a subagent or a
+    /// background agent (those are linked to a parent via `parentSessionId`
+    /// and are already represented by it).
+    private static func topLevelSessions(_ sessions: [SessionState]) -> [SessionState] {
+        sessions.filter { $0.parentSessionId == nil }
+    }
+
     private static func orderedProjectGroups(
         from sessions: [SessionState],
         projectGroupOrder: [String]
     ) -> [(String, [SessionState])] {
         var groupMap: [String: [SessionState]] = [:]
-        for session in sessions where session.parentSessionId == nil {
+        for session in topLevelSessions(sessions) {
             let key = session.projectName ?? session.cwd
             groupMap[key, default: []].append(session)
         }
@@ -151,8 +197,15 @@ struct MenuBarStatusRenderer {
         if sessions.count <= 3 {
             return renderCompactGroup(sessions)
         }
+        return aggregateRender(sessions)
+    }
 
-        let countWidth = CGFloat(String(sessions.count).count) * 6.5
+    /// One pie dot plus the session count. Used both for a single crowded
+    /// project (>3 sessions) and, by the Compact style, for every project at
+    /// once — so the two share this width arithmetic rather than repeating
+    /// the digit-width constant.
+    private static func aggregateRender(_ sessions: [SessionState]) -> GroupRender {
+        let countWidth = CGFloat(String(sessions.count).count) * countDigitWidth
         let elements = aggregatedGroupSVG(for: sessions)
         let width = radius * 2 + 2 + countWidth
         return GroupRender(elements: elements, width: width)
@@ -191,8 +244,13 @@ struct MenuBarStatusRenderer {
             // One state covers the whole group: a solid dot in its own hue,
             // no pie. `segments` cannot be empty here — segmentOrder spans
             // every case, so it is empty only for an empty session list, and
-            // renderGroup sends anything with <= 3 sessions to
-            // renderCompactGroup. Returning "" rather than inventing a color
+            // neither caller can pass one: renderGroup sends anything with
+            // <= 3 sessions to renderCompactGroup, and buildAggregateStatusSVG
+            // guards on `!topLevel.isEmpty` before it ever gets here (#1845 —
+            // the Compact style is the second caller, and it deliberately
+            // DOES route 1-3 sessions through the aggregate path, so the
+            // first clause alone no longer covers every route in).
+            // Returning "" rather than inventing a color
             // for the impossible case: a `?? .ready` here was one of the ways
             // an unreadable group used to paint green (#1797), and no fallback
             // hue is better than a wrong one.
@@ -253,17 +311,6 @@ struct MenuBarStatusRenderer {
             x: centerX + radius * CGFloat(cos(radians)),
             y: centerY + radius * CGFloat(sin(radians))
         )
-    }
-
-    private static func totalRenderWidth(_ renders: [GroupRender]) -> CGFloat {
-        var totalWidth: CGFloat = 0
-        for (index, render) in renders.enumerated() {
-            if index > 0 {
-                totalWidth += groupGap
-            }
-            totalWidth += render.width
-        }
-        return totalWidth
     }
 
     private static func svgNumber(_ value: CGFloat) -> String {

--- a/platforms/macos/Irrlicht/Views/QuotaMenuBarRenderer.swift
+++ b/platforms/macos/Irrlicht/Views/QuotaMenuBarRenderer.swift
@@ -9,15 +9,18 @@ import Foundation
 enum QuotaMenuBarRenderer {
     private static let height: CGFloat = 18
     private static let rowHeight: CGFloat = height / 2
-    private static let labelWidth: CGFloat = 15
-    private static let barWidth: CGFloat = 32
+    // labelWidth / barWidth / gap / compactBarWidthFactor are non-private so
+    // a test can state the icon's measured width budget by READING them
+    // rather than restating their values, which drift silently (#1845).
+    static let labelWidth: CGFloat = 15
+    static let barWidth: CGFloat = 32
     private static let barHeight: CGFloat = 5
     private static let fontSize: CGFloat = 8
-    private static let gap: CGFloat = 3
+    static let gap: CGFloat = 3
     /// Bars style is narrowed by this factor (35% narrower) in Combined
     /// style specifically, where the icon's width budget is shared with the
     /// dots — see `rowSVG`'s `compact` handling.
-    private static let compactBarWidthFactor: CGFloat = 0.65
+    static let compactBarWidthFactor: CGFloat = 0.65
 
     /// Picks the freshest renderable rate-limit snapshot for `providerKey`
     /// across `sessions` and renders it. `providerKey` nil means "whatever

--- a/platforms/macos/Irrlicht/Views/SettingsView.swift
+++ b/platforms/macos/Irrlicht/Views/SettingsView.swift
@@ -150,13 +150,13 @@ struct SettingsView: View {
                                 .font(.caption)
                                 .fontWeight(.medium)
                                 .foregroundColor(.secondary)
-                            InfoIcon(text: "Lights shows session-state dots (today's default). Usage replaces them with reported subscription quota bars. Combined shows both side by side.")
+                            InfoIcon(text: "Lights shows session-state dots (today's default). Usage replaces them with reported subscription quota bars. Combined shows both side by side. Compact collapses every project into one dot and drops the quota bars, so its width does not grow with your project count — for a crowded menu bar.")
                             Spacer()
                         }
                         // A real Picker(pickerStyle: .segmented) only centers
                         // within extra width instead of stretching into it —
                         // EqualWidthSegmentedControl bridges to NSSegmentedControl
-                        // so the three segments split the full row edge to edge
+                        // so the segments split the full row edge to edge
                         // (issue #940), tinted with the app's accent instead of
                         // the system default blue.
                         EqualWidthSegmentedControl(
@@ -167,7 +167,14 @@ struct SettingsView: View {
                         )
                         .frame(maxWidth: .infinity, minHeight: 22)
 
-                        if menuBarStyle != MenuBarStyle.lights.rawValue {
+                        // Ask the style whether it renders quota bars at all,
+                        // rather than testing "is not Lights" — Compact is the
+                        // second style with no quota half, and a `!=` here
+                        // would have offered it two settings it ignores
+                        // (#1845). Parsed from the @AppStorage string, never
+                        // from MenuBarStyle.current, so this stays readable
+                        // under a pinned store.
+                        if (MenuBarStyle(rawValue: menuBarStyle) ?? .lights).showsQuotaBars {
                             HStack(spacing: 6) {
                                 Text("Quota provider")
                                     .font(.caption)

--- a/platforms/macos/Tests/MenuBarCompactStyleTests.swift
+++ b/platforms/macos/Tests/MenuBarCompactStyleTests.swift
@@ -1,0 +1,652 @@
+import XCTest
+@testable import Irrlicht
+
+/// Issue #1845 — the Compact menu bar style and the status item's declared
+/// autosave name.
+///
+/// Nothing here is a regression test: #1845 is an enhancement, so there is no
+/// defect that ran red on `main`. Every assertion is therefore one of two
+/// kinds, and each one says which:
+///
+/// - **LOCK** — pins behavior that must NOT change. Passes on `main` by
+///   construction wherever the symbol it names already exists there.
+/// - **Mutation-proved** — a check this change ADDS, which has no "before".
+///   The doc comment names the exact source mutation that turns it red, per
+///   AGENTS.md's Testing section.
+@MainActor
+final class MenuBarCompactStyleTests: XCTestCase {
+
+    // MARK: - Fixtures
+
+    private func makeSession(
+        id: String,
+        state: SessionState.State = .working,
+        project: String,
+        parentSessionId: String? = nil
+    ) -> SessionState {
+        SessionState(
+            id: "sess_\(id)",
+            state: state,
+            model: "claude-3.7-sonnet",
+            cwd: "/Users/test/projects/\(project)",
+            projectName: project,
+            firstSeen: Date(),
+            updatedAt: Date(),
+            parentSessionId: parentSessionId
+        )
+    }
+
+    /// `count` sessions spread one-per-project, which is the layout that makes
+    /// the per-project renderer widest for a given session count.
+    private func sessionsAcrossProjects(_ count: Int) -> [SessionState] {
+        (0..<count).map { makeSession(id: "s\($0)", project: "p\($0)") }
+    }
+
+    private let now = Date(timeIntervalSince1970: 1_700_000_000)
+
+    /// A session carrying a renderable rate-limit snapshot, so the quota half
+    /// of the icon has something to draw. Same shape
+    /// `QuotaMenuBarRendererTests` uses.
+    private func sessionWithQuota() -> SessionState {
+        let metrics = SessionMetrics(
+            elapsedSeconds: 0,
+            totalTokens: 0,
+            modelName: "claude-sonnet",
+            contextWindow: nil,
+            contextUtilization: 0,
+            pressureLevel: "safe",
+            contextWindowUnknown: nil,
+            estimatedCostUSD: nil,
+            lastAssistantText: nil,
+            tasks: nil,
+            rateLimit: RateLimitInfo(
+                windows: [
+                    RateLimitWindowInfo(
+                        usedPercent: 20, windowMinutes: 300,
+                        resetsAt: now.addingTimeInterval(3600)
+                    ),
+                    RateLimitWindowInfo(
+                        usedPercent: 40, windowMinutes: 10080,
+                        resetsAt: now.addingTimeInterval(3 * 86400)
+                    ),
+                ],
+                sampledAt: now
+            )
+        )
+        return SessionState(
+            id: "sess_quota",
+            state: .working,
+            model: "claude-sonnet",
+            cwd: "/Users/test/projects/quota",
+            projectName: "quota",
+            firstSeen: now,
+            updatedAt: now,
+            metrics: metrics,
+            adapter: "claude-code"
+        )
+    }
+
+    // MARK: - The style exists and is opt-in
+
+    /// LOCK on the compatibility rule: the three shipped styles keep their
+    /// raw values and their order, and the default stays `.lights`. A user
+    /// who never opens Settings must render exactly as before.
+    func testExistingStylesAndDefaultAreUnchanged() {
+        XCTAssertEqual(MenuBarStyle.allCases.prefix(3).map(\.rawValue), ["lights", "usage", "combined"])
+        XCTAssertEqual(MenuBarStyle(rawValue: "lights"), .lights)
+        XCTAssertEqual(MenuBarStyle(rawValue: "usage"), .usage)
+        XCTAssertEqual(MenuBarStyle(rawValue: "combined"), .combined)
+        // An unset or unknown value still falls back to .lights, so an
+        // install that never opts in is untouched — and so is one that
+        // downgrades after selecting a style this build does not know.
+        XCTAssertEqual(MenuBarStyle(rawValue: "") ?? .lights, .lights)
+        XCTAssertEqual(MenuBarStyle(rawValue: "no-such-style") ?? .lights, .lights)
+    }
+
+    /// Mutation-proved: delete `case compact` (and its `label` arm) and this
+    /// fails to compile — the strongest red available for a new enum case.
+    func testCompactStyleIsAvailableAndLast() {
+        XCTAssertEqual(MenuBarStyle.compact.rawValue, "compact")
+        XCTAssertEqual(MenuBarStyle.compact.label, "Compact")
+        XCTAssertEqual(MenuBarStyle.allCases.last, .compact,
+                       "Compact must stay last so the existing segments keep their positions")
+    }
+
+    // MARK: - What each style renders
+
+    /// LOCK on all three shipped styles, plus the new case's answers.
+    ///
+    /// Mutation-proved for `.compact`: flip any `.compact` arm in
+    /// `MenuBarStyle.showsQuotaBars` / `.usesNarrowQuotaBars` /
+    /// `.aggregatesSessionDots` and the matching row goes red.
+    func testStyleRenderingDecisions() {
+        // (style, showsQuotaBars, usesNarrowQuotaBars, aggregatesSessionDots,
+        //  hidesDotsWhenQuotaIsRenderable)
+        let expected: [(MenuBarStyle, Bool, Bool, Bool, Bool)] = [
+            (.lights, false, false, false, false),
+            (.usage, true, false, false, true),
+            (.combined, true, true, false, false),
+            (.compact, false, false, true, false),
+        ]
+        XCTAssertEqual(expected.count, MenuBarStyle.allCases.count,
+                       "a style was added without an expectation row here")
+        for (style, quota, narrow, aggregate, hidesDots) in expected {
+            XCTAssertEqual(style.showsQuotaBars, quota, "\(style).showsQuotaBars")
+            XCTAssertEqual(style.usesNarrowQuotaBars, narrow, "\(style).usesNarrowQuotaBars")
+            XCTAssertEqual(style.aggregatesSessionDots, aggregate, "\(style).aggregatesSessionDots")
+            XCTAssertEqual(style.hidesDotsWhenQuotaIsRenderable, hidesDots,
+                           "\(style).hidesDotsWhenQuotaIsRenderable")
+        }
+
+        // Across today's four styles `hidesDotsWhenQuotaIsRenderable` happens
+        // to equal `showsQuotaBars && !usesNarrowQuotaBars`. It is kept as its
+        // own exhaustive switch anyway, for the reason the enum's own comment
+        // gives: a DERIVED answer would silently decide for a fifth style that
+        // nobody thought about, which is the exact failure the switches
+        // replaced. Asserting the coincidence here means the day it stops
+        // holding is a deliberate, visible decision rather than a surprise.
+        for style in MenuBarStyle.allCases {
+            XCTAssertEqual(
+                style.hidesDotsWhenQuotaIsRenderable,
+                style.showsQuotaBars && !style.usesNarrowQuotaBars,
+                "\(style): the derived-equivalence note above no longer holds — "
+                    + "decide deliberately whether that is intended"
+            )
+        }
+    }
+
+    // MARK: - The WIRING of those decisions into the icon
+    //
+    // Review of #1849 found that every mutation the first round proved red
+    // landed on a DEFINITION — the enum's properties, the migration, the
+    // renderer. The call sites in `MenuBarImageBuilder` were unpinned, and
+    // three separate inversions there passed all 527 tests while visibly
+    // changing what a shipped install renders. These tests close that: they
+    // exercise the extracted `dotsImage` / `quotaImage` seams, so the routing
+    // is asserted rather than only the values it routes.
+
+    /// Mutation-proved: invert the condition in
+    /// `MenuBarImageBuilder.dotsImage` and this goes red.
+    func testDotsImageRoutesCompactToTheAggregateRendererAndNothingElse() {
+        let sessions = sessionsAcrossProjects(6)
+        for style in MenuBarStyle.allCases {
+            let image = MenuBarImageBuilder.dotsImage(
+                style: style, sessions: sessions, projectGroupOrder: []
+            )
+            XCTAssertNotNil(image, "\(style) must still render dots")
+            let width = image?.size.width ?? -1
+            if style.aggregatesSessionDots {
+                XCTAssertEqual(width, 18.5, accuracy: 0.01,
+                               "\(style) must use the constant-width aggregate dot")
+            } else {
+                XCTAssertEqual(width, 90.0, accuracy: 0.01,
+                               "\(style) must keep the per-project layout it shipped with")
+            }
+        }
+    }
+
+    /// Mutation-proved: swap `usesNarrowQuotaBars` for `showsQuotaBars` in
+    /// the `compact:` argument of `MenuBarImageBuilder.quotaImage`, or invert
+    /// its `showsQuotaBars` guard, and this goes red.
+    ///
+    /// The widths are read from `QuotaMenuBarRenderer`'s own constants rather
+    /// than restated, so they cannot drift away from what it renders.
+    func testQuotaImageRendersOnlyForTheStylesThatCarryItAndInTheRightLayout() {
+        let sessions = [sessionWithQuota()]
+        let full = QuotaMenuBarRenderer.labelWidth + QuotaMenuBarRenderer.gap
+            + QuotaMenuBarRenderer.barWidth
+        let narrow = QuotaMenuBarRenderer.barWidth * QuotaMenuBarRenderer.compactBarWidthFactor
+
+        for style in MenuBarStyle.allCases {
+            let image = MenuBarImageBuilder.quotaImage(
+                style: style, sessions: sessions, providerKey: nil, now: now
+            )
+            guard style.showsQuotaBars else {
+                XCTAssertNil(image, "\(style) carries no quota bars")
+                continue
+            }
+            XCTAssertNotNil(image, "\(style) must render quota bars")
+            let expected = style.usesNarrowQuotaBars ? narrow : full
+            XCTAssertEqual(image?.size.width ?? -1, expected, accuracy: 0.01,
+                           "\(style) quota layout")
+        }
+    }
+
+    /// LOCK on the hard constraint, stated as one table: what each SHIPPED
+    /// style renders must be exactly what it rendered before `.compact`
+    /// existed. `.lights` dots-only, `.usage` full-width bars, `.combined`
+    /// dots plus narrow bars.
+    func testShippedStylesRenderExactlyWhatTheyDidBefore() {
+        let sessions = sessionsAcrossProjects(6) + [sessionWithQuota()]
+        // Derived from QuotaMenuBarRenderer's constants, not restated — the
+        // same rule the per-half tests follow, so a change there surfaces
+        // here as a real disagreement rather than as two numbers drifting.
+        let full = QuotaMenuBarRenderer.labelWidth + QuotaMenuBarRenderer.gap
+            + QuotaMenuBarRenderer.barWidth
+        let narrow = QuotaMenuBarRenderer.barWidth * QuotaMenuBarRenderer.compactBarWidthFactor
+        let expectations: [(MenuBarStyle, CGFloat?, CGFloat?)] = [
+            // style, dots width, quota width (nil = not rendered)
+            (.lights, 90.0, nil),
+            (.usage, 90.0, full),
+            (.combined, 90.0, narrow),
+        ]
+        for (style, dots, quota) in expectations {
+            XCTAssertEqual(
+                MenuBarImageBuilder.dotsImage(
+                    style: style, sessions: sessions, projectGroupOrder: []
+                )?.size.width ?? -1,
+                dots ?? -1, accuracy: 0.01, "\(style) dots"
+            )
+            let quotaImage = MenuBarImageBuilder.quotaImage(
+                style: style, sessions: sessions, providerKey: nil, now: now
+            )
+            if let quota {
+                XCTAssertEqual(quotaImage?.size.width ?? -1, quota, accuracy: 0.01, "\(style) quota")
+            } else {
+                XCTAssertNil(quotaImage, "\(style) quota")
+            }
+        }
+    }
+
+    // MARK: - Width (acceptance criterion 2)
+
+    /// The measurement the issue asks for. Not an assertion — it prints the
+    /// rendered width of every style so the figure in the PR body has a
+    /// command behind it rather than being typed by hand.
+    ///
+    ///     cd platforms/macos && swift test --filter testMeasuredWidthOfEachStyle
+    func testMeasuredWidthOfEachStyle() throws {
+        // Read from QuotaMenuBarRenderer rather than restated, so these
+        // cannot drift away from what it actually renders.
+        let fullQuota = QuotaMenuBarRenderer.labelWidth + QuotaMenuBarRenderer.gap
+            + QuotaMenuBarRenderer.barWidth
+        let narrowQuota = QuotaMenuBarRenderer.barWidth
+            * QuotaMenuBarRenderer.compactBarWidthFactor
+        let gap = MenuBarStatusRenderer.groupGap
+
+        print("=== #1845 measured menu bar icon widths, in points ===")
+        print("projects | Lights | Usage | Combined | Compact")
+        for projects in [1, 2, 3, 5, 6, 8] {
+            let sessions = sessionsAcrossProjects(projects)
+            // XCTUnwrap, not `?? 0`: a renderer that regressed to nil would
+            // otherwise print 0.00 and pass, making "could not measure" and
+            // "measured zero" the same output — the exact failure this file
+            // guards against for its source reader.
+            let dots = try XCTUnwrap(MenuBarStatusRenderer.buildStatusSVG(
+                sessions: sessions, projectGroupOrder: []
+            )).width
+            let aggregate = try XCTUnwrap(MenuBarStatusRenderer.buildAggregateStatusSVG(
+                sessions: sessions
+            )).width
+            // Usage hides the dots unless the quota is unrenderable; Combined
+            // shows dots + gap + narrow quota; Compact is dots only.
+            print(String(
+                format: "%8d | %6.2f | %5.2f | %8.2f | %7.2f",
+                projects, dots, fullQuota, dots + gap + narrowQuota, aggregate
+            ))
+        }
+        print(String(format: "=== dot half measured from the renderers; quota half "
+                     + "from QuotaMenuBarRenderer's constants (full %.2f, narrow %.2f) ===",
+                     fullQuota, narrowQuota))
+    }
+
+    /// Mutation-proved: make `buildAggregateStatusSVG` group by project (drop
+    /// the single `aggregateRender` and call `orderedProjectGroups`) and this
+    /// goes red — the width would start tracking the project count again.
+    ///
+    /// This is the property the issue is actually asking for: not "narrower"
+    /// in one sampled configuration, but *constant* as projects accumulate,
+    /// which is what stops the icon sliding behind the notch.
+    func testCompactWidthDependsOnlyOnTheSessionCountsDigits() throws {
+        // Every one of these is a one-digit count, so all must be identical.
+        let oneDigit = try [1, 2, 3, 5, 9].map { count -> CGFloat in
+            try XCTUnwrap(
+                MenuBarStatusRenderer.buildAggregateStatusSVG(
+                    sessions: sessionsAcrossProjects(count)
+                ),
+                "aggregate render must produce an icon for \(count) sessions"
+            ).width
+        }
+        XCTAssertEqual(Set(oneDigit).count, 1,
+                       "Compact width must not vary with the project count, got \(oneDigit)")
+
+        // Two digits costs exactly one more digit's width, and no more — the
+        // width is a function of the count's DIGITS, not of the project
+        // count. Naming that precisely matters: at 10 projects the width is
+        // legitimately 25.00, and a test claiming "never varies" would read
+        // as a regression the first time someone sampled it.
+        let twoDigits = try [10, 42, 99].map { count -> CGFloat in
+            try XCTUnwrap(MenuBarStatusRenderer.buildAggregateStatusSVG(
+                sessions: sessionsAcrossProjects(count)
+            )).width
+        }
+        XCTAssertEqual(Set(twoDigits).count, 1, "got \(twoDigits)")
+        XCTAssertEqual(twoDigits[0] - oneDigit[0], 6.5, accuracy: 0.01,
+                       "one extra digit costs exactly countDigitWidth")
+
+        // And the per-project renderer, for contrast, DOES grow — if this ever
+        // stops being true the comparison above has lost its meaning.
+        let onePro = MenuBarStatusRenderer.buildStatusSVG(
+            sessions: sessionsAcrossProjects(1), projectGroupOrder: []
+        )?.width ?? 0
+        let fivePro = MenuBarStatusRenderer.buildStatusSVG(
+            sessions: sessionsAcrossProjects(5), projectGroupOrder: []
+        )?.width ?? 0
+        XCTAssertGreaterThan(fivePro, onePro,
+                             "the per-project renderer is supposed to widen with more projects")
+    }
+
+    /// Mutation-proved: same mutation as above. Numeric, in the idiom
+    /// `QuotaMenuBarRendererTests.testBuildSVGCompactIsNarrowerThanDefault`
+    /// uses — anchored to a stated derivation, not a bare magic number.
+    func testCompactIsNarrowerThanLightsOnACrowdedMenuBar() {
+        // Six one-session projects: the case the issue describes.
+        let sessions = sessionsAcrossProjects(6)
+        let lights = MenuBarStatusRenderer.buildStatusSVG(
+            sessions: sessions, projectGroupOrder: []
+        )
+        let compact = MenuBarStatusRenderer.buildAggregateStatusSVG(sessions: sessions)
+        XCTAssertNotNil(lights)
+        XCTAssertNotNil(compact)
+        XCTAssertLessThan(compact!.width, lights!.width)
+
+        // Compact's width is dot + padding + one digit per digit of the count:
+        // radius*2 + 2 + digits*6.5 = 10 + 2 + 6.5 = 18.5 for a 1-digit count.
+        XCTAssertEqual(compact!.width, 18.5, accuracy: 0.01)
+        // Lights at six one-session groups: 5 visible groups of one dot
+        // (1*(10-4)+4 = 10 each) + an overflow marker (10) + 5 gaps of 6
+        // = 50 + 10 + 30 = 90.
+        XCTAssertEqual(lights!.width, 90.0, accuracy: 0.01)
+    }
+
+    /// Mutation-proved: drop the `topLevelSessions` filter from
+    /// `buildAggregateStatusSVG` and this goes red — a subagent would be
+    /// counted in the aggregate dot's number even though the per-project
+    /// renderer has always excluded it.
+    func testCompactCountsTopLevelSessionsOnly() {
+        let sessions = [
+            makeSession(id: "p", project: "a"),
+            makeSession(id: "c", project: "a", parentSessionId: "p"),
+        ]
+        let built = MenuBarStatusRenderer.buildAggregateStatusSVG(sessions: sessions)
+        XCTAssertNotNil(built)
+        XCTAssertTrue(built!.svg.contains(">1<"),
+                      "the aggregate label must count only the top-level session, got: \(built!.svg)")
+    }
+
+    /// Mutation-proved: return a non-nil render for an empty list and this
+    /// goes red. An empty aggregate must collapse to "no icon", the same way
+    /// `buildStatusSVG`'s `totalWidth > 0` guard does, rather than drawing a
+    /// bare "0".
+    func testCompactRendersNothingWithoutSessions() {
+        XCTAssertNil(MenuBarStatusRenderer.buildAggregateStatusSVG(sessions: []))
+        XCTAssertNil(MenuBarStatusRenderer.buildAggregateStatusSVG(sessions: [
+            makeSession(id: "c", project: "a", parentSessionId: "p"),
+        ]), "a lone subagent is not a drawable session")
+    }
+
+    /// LOCK: the per-project renderer is byte-identical after the shared
+    /// `assemble`/`aggregateRender` extraction. This is the hard constraint —
+    /// an existing install must render exactly as it did before.
+    func testPerProjectRenderingIsUnchangedByTheExtraction() throws {
+        let sessions = [
+            makeSession(id: "a1", state: .working, project: "alpha"),
+            makeSession(id: "a2", state: .ready, project: "alpha"),
+            makeSession(id: "b1", state: .error, project: "beta"),
+        ]
+        let built = try XCTUnwrap(MenuBarStatusRenderer.buildStatusSVG(
+            sessions: sessions, projectGroupOrder: ["alpha", "beta"]
+        ))
+        // alpha: 2 overlapping dots = 2*6+4 = 16; beta: 1 dot = 10; gap 6.
+        XCTAssertEqual(built.width, 32.0, accuracy: 0.01)
+
+        // The WHOLE string, not just its ends. The group offsets are the
+        // statements the shared-assembly extraction moved, so asserting only
+        // the prefix/suffix left them unpinned: dropping the `if index > 0`
+        // gap rule laid the content out to 38pt while the declared width
+        // stayed 32 — clipping the last dot — with the suite green.
+        //
+        // Deliberately broader than the `contains(...)` idiom the sibling
+        // MenuBarStatusRendererTests uses. Those assert FEATURES of the
+        // output; this one pins that the extraction changed nothing at all,
+        // which is this PR's hard constraint — so any geometry change
+        // SHOULD fail here and be re-approved on purpose. The state colors
+        // are read from `SessionState.State`, so a palette change does not
+        // make it brittle.
+        XCTAssertEqual(built.svg, """
+        <svg xmlns="http://www.w3.org/2000/svg" width="32" height="18">\
+        <g transform="translate(0.00,0)">\
+        <circle cx="5.00" cy="9.00" r="5.00" fill="#\(SessionState.State.working.hexColor)" stroke="rgba(0,0,0,0.25)" stroke-width="0.5"/>\
+        <circle cx="11.00" cy="9.00" r="5.00" fill="#\(SessionState.State.ready.hexColor)" stroke="rgba(0,0,0,0.25)" stroke-width="0.5"/>\
+        </g>\
+        <g transform="translate(22.00,0)">\
+        <circle cx="5.00" cy="9.00" r="5.00" fill="#\(SessionState.State.error.hexColor)" stroke="rgba(0,0,0,0.25)" stroke-width="0.5"/>\
+        </g></svg>
+        """)
+    }
+
+    /// Mutation-proved: in `MenuBarStatusRenderer.image(from:)`, delete
+    /// `image.isTemplate = false` or change the size it stamps, and this goes
+    /// red. The extraction gave that helper a second caller, which is the
+    /// moment to pin it: a declared size that disagrees with the SVG canvas
+    /// stretches the icon.
+    func testRenderedImageCarriesTheSVGsOwnGeometry() throws {
+        let sessions = sessionsAcrossProjects(6)
+        for (image, expected) in [
+            (MenuBarStatusRenderer.buildStatusImage(sessions: sessions, projectGroupOrder: []), 90.0),
+            (MenuBarStatusRenderer.buildAggregateStatusImage(sessions: sessions), 18.5),
+        ] {
+            let img = try XCTUnwrap(image)
+            XCTAssertEqual(img.size.width, expected, accuracy: 0.01)
+            XCTAssertEqual(img.size.height, 18.0, accuracy: 0.01)
+            XCTAssertFalse(img.isTemplate,
+                           "the icon is drawn in its own state colors, never tinted as a template")
+        }
+    }
+
+    // MARK: - Status item autosave name (acceptance criterion 1)
+
+    /// Mutation-proved: change the literal in
+    /// `MenuBarStatusItemIdentity.autosaveName` and this goes red.
+    ///
+    /// The name is load-bearing rather than cosmetic: it IS the defaults key
+    /// suffix AppKit stores the user's dragged position under, so changing it
+    /// in a later release silently orphans every user's position again.
+    func testAutosaveNameIsStable() {
+        XCTAssertEqual(MenuBarStatusItemIdentity.autosaveName, "IrrlichtStatusItem")
+        XCTAssertEqual(
+            MenuBarStatusItemIdentity.preferredPositionKey(forAutosaveName: "IrrlichtStatusItem"),
+            "NSStatusItem Preferred Position IrrlichtStatusItem"
+        )
+    }
+
+    /// Mutation-proved: delete the `defaults.set(...)` line in
+    /// `migrateLegacyPreferredPosition` and this goes red.
+    ///
+    /// Why it matters: measured on a real install with
+    /// `defaults read io.irrlicht.app`, the app's domain already carried
+    /// `"NSStatusItem Preferred Position Item-0" = 298` — AppKit's generated
+    /// name. Declaring an autosaveName changes which key AppKit reads, so
+    /// without this migration every existing install's icon would jump on the
+    /// first launch after upgrading.
+    func testLegacyPositionIsCarriedOverOnce() {
+        let defaults = InMemoryDefaults()
+        let legacyKey = MenuBarStatusItemIdentity.preferredPositionKey(forAutosaveName: "Item-0")
+        let newKey = MenuBarStatusItemIdentity.preferredPositionKey(
+            forAutosaveName: MenuBarStatusItemIdentity.autosaveName
+        )
+        defaults.set(298, forKey: legacyKey)
+
+        XCTAssertTrue(MenuBarStatusItemIdentity.migrateLegacyPreferredPosition(in: defaults),
+                      "a legacy position with no new key must be carried over")
+        XCTAssertEqual(defaults.object(forKey: newKey) as? Int, 298)
+        // The legacy key is left alone: a downgrade to a build without an
+        // autosaveName then still finds the position it expects.
+        XCTAssertEqual(defaults.object(forKey: legacyKey) as? Int, 298)
+
+        // Second launch: nothing left to do, and nothing overwritten.
+        XCTAssertFalse(MenuBarStatusItemIdentity.migrateLegacyPreferredPosition(in: defaults),
+                       "the migration must not run twice")
+    }
+
+    /// Mutation-proved: drop the `defaults.object(forKey: currentKey) == nil`
+    /// guard and this goes red — a user who dragged the icon under the new
+    /// name would have that position clobbered by a stale legacy value on
+    /// every launch.
+    func testMigrationNeverOverwritesAPositionSetUnderTheNewName() {
+        let defaults = InMemoryDefaults()
+        let legacyKey = MenuBarStatusItemIdentity.preferredPositionKey(forAutosaveName: "Item-0")
+        let newKey = MenuBarStatusItemIdentity.preferredPositionKey(
+            forAutosaveName: MenuBarStatusItemIdentity.autosaveName
+        )
+        defaults.set(298, forKey: legacyKey)
+        defaults.set(42, forKey: newKey)
+
+        XCTAssertFalse(MenuBarStatusItemIdentity.migrateLegacyPreferredPosition(in: defaults))
+        XCTAssertEqual(defaults.object(forKey: newKey) as? Int, 42)
+    }
+
+    /// Mutation-proved: drop the `let legacyValue = ...` guard and this goes
+    /// red. A fresh install has nothing to migrate and must not have a key
+    /// invented for it.
+    func testMigrationIsANoOpOnAFreshInstall() {
+        let defaults = InMemoryDefaults()
+        let newKey = MenuBarStatusItemIdentity.preferredPositionKey(
+            forAutosaveName: MenuBarStatusItemIdentity.autosaveName
+        )
+        XCTAssertFalse(MenuBarStatusItemIdentity.migrateLegacyPreferredPosition(in: defaults))
+        XCTAssertNil(defaults.object(forKey: newKey))
+    }
+
+    // MARK: - The wiring, pinned by source
+
+    /// `MenuBarController` is the only place a real `NSStatusItem` is created,
+    /// and no test constructs one (it would allocate a live status item on
+    /// whatever host runs the suite — the host dependency `docs/swift-testing.md`
+    /// exists to remove). So the two lines that actually apply the identity
+    /// are pinned by reading the source, in the idiom
+    /// `PersistentDefaultsLintTests` / `RealHomePathLintTests` already use.
+    ///
+    /// Mutation-proved: delete either the `autosaveName` assignment or the
+    /// `migrateLegacyPreferredPosition` call from `MenuBarController.swift`
+    /// and this goes red.
+    func testMenuBarControllerAppliesTheStatusItemIdentity() throws {
+        let source = try Self.source(at: Self.menuBarControllerPath)
+
+        XCTAssertTrue(
+            source.contains("statusItem.autosaveName = MenuBarStatusItemIdentity.autosaveName"),
+            "MenuBarController must declare the status item's autosave name"
+        )
+        XCTAssertTrue(
+            source.contains("MenuBarStatusItemIdentity.migrateLegacyPreferredPosition(in: UserDefaults.standard)"),
+            "MenuBarController must carry a legacy position over before creating the item"
+        )
+
+        // Order is the whole point, and the deadline is the `autosaveName`
+        // ASSIGNMENT, not the item's construction: an item with no declared
+        // name still reads AppKit's generated key, so it is the assignment
+        // that points AppKit at the new key and the value has to be there
+        // first. Pinning against construction as well, since the two are one
+        // line apart and the earlier bound is the safer one to hold.
+        let migrate = try XCTUnwrap(source.range(of: "migrateLegacyPreferredPosition"))
+        let create = try XCTUnwrap(source.range(of: "NSStatusBar.system.statusItem"))
+        let assign = try XCTUnwrap(
+            source.range(of: "autosaveName = MenuBarStatusItemIdentity.autosaveName")
+        )
+        XCTAssertTrue(migrate.lowerBound < assign.lowerBound,
+                      "the migration must run BEFORE autosaveName is assigned")
+        XCTAssertTrue(migrate.lowerBound < create.lowerBound,
+                      "the migration must run BEFORE the status item is created")
+    }
+
+    /// The Settings gate that decides whether the quota sub-pickers appear
+    /// now asks the style (`showsQuotaBars`) instead of testing `!= .lights`.
+    /// `SettingsViewTests` renders the view but samples only corner-pixel
+    /// opacity, and there is no Settings snapshot suite — so swapping
+    /// `showsQuotaBars` for its neighbour `usesNarrowQuotaBars` would silently
+    /// strip both sub-pickers from every `.usage` user. Pinned by source, in
+    /// the same idiom as the controller wiring above.
+    ///
+    /// Mutation-proved: change the property named at `SettingsView.swift`'s
+    /// quota-section gate and this goes red.
+    func testSettingsGatesTheQuotaSubPickersOnShowsQuotaBars() throws {
+        let source = try Self.source(at: "platforms/macos/Irrlicht/Views/SettingsView.swift")
+        XCTAssertTrue(
+            source.contains("if (MenuBarStyle(rawValue: menuBarStyle) ?? .lights).showsQuotaBars {"),
+            "the quota sub-pickers must be gated on the style's own showsQuotaBars"
+        )
+        // And the property means what the gate needs it to mean: exactly the
+        // two styles that shipped with those pickers visible.
+        for style in MenuBarStyle.allCases {
+            XCTAssertEqual(style.showsQuotaBars, style == .usage || style == .combined,
+                           "\(style) quota-picker visibility")
+        }
+    }
+
+    /// Mutation-proved: invert or swap either condition in
+    /// `MenuBarImageBuilder`'s two extracted seams and this goes red. Pins
+    /// that `combinedImage` actually ROUTES through them rather than
+    /// re-deciding inline — the behavioral tests above cannot see a copy of
+    /// the logic left behind at the call site.
+    func testImageBuilderRoutesBothHalvesThroughTheExtractedSeams() throws {
+        let source = try Self.source(at: "platforms/macos/Irrlicht/App/MenuBarImageBuilder.swift")
+        XCTAssertTrue(source.contains("let computedDotsImage = dotsImage("),
+                      "combinedImage must route the dot half through dotsImage(style:...)")
+        XCTAssertTrue(source.contains("let quotaImage = quotaImage("),
+                      "combinedImage must route the quota half through quotaImage(style:...)")
+        XCTAssertFalse(source.contains("style == .lights"),
+                       "no style decision may go back to a non-exhaustive comparison")
+        XCTAssertFalse(source.contains("style == .combined"),
+                       "no style decision may go back to a non-exhaustive comparison")
+        XCTAssertFalse(source.contains("style != .usage"),
+                       "no style decision may go back to a non-exhaustive comparison")
+    }
+
+    /// A source file this suite cannot read is a FAILURE, never a quiet pass.
+    /// Without the guard, a renamed or moved `MenuBarController.swift` would
+    /// make every assertion above silently vacuous — "could not look" and
+    /// "found nothing" must not produce the same result (AGENTS.md, Testing).
+    /// `testTheSourceReaderFailsLoudlyWhenItCannotLook` proves the guard fires.
+    func testTheSourceReaderFailsLoudlyWhenItCannotLook() {
+        XCTAssertThrowsError(
+            try Self.source(at: "platforms/macos/Irrlicht/App/NoSuchFile.swift"),
+            "a source file that is not there must throw, not return empty"
+        )
+        XCTAssertNoThrow(try Self.source(at: Self.menuBarControllerPath),
+                         "and the real path must still be readable")
+    }
+
+    private static let menuBarControllerPath =
+        "platforms/macos/Irrlicht/App/MenuBarController.swift"
+
+    private static func source(at relativePath: String) throws -> String {
+        let url = repoRoot().appendingPathComponent(relativePath)
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            throw SourceUnreadable.missing(url.path)
+        }
+        return try String(contentsOf: url, encoding: .utf8)
+    }
+
+    /// Walk up from this source file to the repo root. `#filePath` is the
+    /// checkout that compiled the test, so this works in a worktree too.
+    private static func repoRoot() -> URL {
+        URL(fileURLWithPath: #filePath)          // .../platforms/macos/Tests/<this file>
+            .deletingLastPathComponent()          // .../platforms/macos/Tests
+            .deletingLastPathComponent()          // .../platforms/macos
+            .deletingLastPathComponent()          // .../platforms
+            .deletingLastPathComponent()          // repo root
+    }
+}
+
+/// Deliberately not `XCTSkip`: a source file this suite cannot read is a
+/// failure, and naming it after the skip type would invite exactly the
+/// silent pass the guard exists to prevent.
+private enum SourceUnreadable: Error, CustomStringConvertible {
+    case missing(String)
+
+    var description: String {
+        switch self {
+        case .missing(let path): return "source not found at \(path)"
+        }
+    }
+}

--- a/platforms/macos/Tests/MenuBarImageBuilderTests.swift
+++ b/platforms/macos/Tests/MenuBarImageBuilderTests.swift
@@ -152,12 +152,20 @@ final class MenuBarImageBuilderTests: XCTestCase {
         ))
     }
 
-    /// LOCK: the other two styles never route through this decision at all,
-    /// error or not.
+    /// LOCK: every style OTHER than `.usage` never routes through this
+    /// decision at all, error or not.
+    ///
+    /// Derived from `allCases` rather than the hand-written
+    /// `[MenuBarStyle.lights, .combined]` this used to be: that array was
+    /// complete when written and silently stale the moment `.compact` was
+    /// added (#1845), which is the same failure mode
+    /// `MenuBarStatusRenderer.segmentOrder` documents for state lists (#1797).
     func testOtherStylesAreUnaffectedByAnError() {
         let quota = NSImage(size: NSSize(width: 20, height: 18))
         let dots = NSImage(size: NSSize(width: 10, height: 18))
-        for style in [MenuBarStyle.lights, .combined] {
+        let others = MenuBarStyle.allCases.filter { $0 != .usage }
+        XCTAssertFalse(others.isEmpty, "allCases must yield at least one non-.usage style")
+        for style in others {
             XCTAssertFalse(MenuBarImageBuilder.shouldShowDotsInUsageStyle(
                 style: style, quotaImage: quota, dotsImage: dots, hasErroredSession: true
             ), "\(style) must not be changed by an errored session")


### PR DESCRIPTION
Closes #1845.

On a small or crowded screen the menu bar icon's width grows with the number of
projects until it sits behind the notch or the app menus, where it cannot be
seen or clicked. There was no setting to move it and no setting to shrink it.

## What changed

**1. A `Compact` menu bar style (the width half).**
A fourth `MenuBarStyle` case that collapses every project into one aggregate dot
with a session count, and drops the quota bars. Its width depends only on the
number of *digits* in the session count, so it does not grow with the project
count at all. It reuses the aggregate-dot rendering the per-project renderer
already used for a single crowded project (>3 sessions), rather than adding a
second way to draw a dot.

**Measured widths, in points** — produced by
`cd platforms/macos && swift test --filter testMeasuredWidthOfEachStyle`, a
committed test, not numbers typed by hand (acceptance criterion 2):

```
projects | Lights | Usage | Combined | Compact
       1 |  10.00 | 50.00 |    36.80 |   18.50
       2 |  26.00 | 50.00 |    52.80 |   18.50
       3 |  42.00 | 50.00 |    68.80 |   18.50
       5 |  74.00 | 50.00 |   100.80 |   18.50
       6 |  90.00 | 50.00 |   116.80 |   18.50
       8 |  90.00 | 50.00 |   116.80 |   18.50
```

The dot half is measured from the renderers; the quota half is read from
`QuotaMenuBarRenderer`'s own constants (full `50.00` = labelWidth 15 + gap 3 +
barWidth 32; narrow `20.80` = 32 × 0.65). Lights plateaus at 90.00 because
`maxVisibleGroups` caps it at five groups plus an overflow marker — by which
point the icon is already the width this issue is about. Compact is wider than
Lights only in the trivial one-project case (18.50 vs 10.00); it wins from two
projects on, which is the situation the issue describes, and the README and the
Settings tooltip both say so rather than claiming it is always narrowest.

This confirms the issue's estimate as an estimate: it guessed "past roughly 120
points" for Combined plus the Gas Town badge, and Combined alone measures 116.80
at six projects, before the badge.

**2. `MenuBarStyle` now answers what it renders, exhaustively.**
`MenuBarImageBuilder` decided four separate things with `style == .lights`,
`style == .combined` and `style != .usage`. Every one of those silently answers
for a case that did not exist when it was written. They are now four `switch`es
on the enum (`showsQuotaBars`, `usesNarrowQuotaBars`, `aggregatesSessionDots`,
`hidesDotsWhenQuotaIsRenderable`), which the compiler forces to be exhaustive,
and `combinedImage` routes both halves of the icon through two extracted,
testable seams (`dotsImage`, `quotaImage`). Same reasoning
`MenuBarStatusRenderer.segmentOrder` already gives for deriving from `allCases`
(#1797).

**3. A stable `autosaveName` (the pin half) — plus a migration the issue did not
anticipate.**

The issue states, under "Notes on evidence", that `defaults read io.irrlicht.app`
shows no position key. **That is no longer true, and it changes the fix.** Run
today on a real install:

```
$ defaults read io.irrlicht.app
    "NSStatusItem Preferred Position Item-0" = 298;
```

AppKit *has* generated an autosave name — `Item-0`, its index-based default —
and *is* persisting a position under it. (`git grep -n "autosaveName" --
platforms/macos` returns zero matches, and `git grep -n "statusItem(withLength"`
returns exactly one construction site, so `Item-0` is this app's one status
item.)

The consequence: simply setting `autosaveName = "IrrlichtStatusItem"` changes
which key AppKit reads, orphaning the position every existing install already
has — the icon would jump on the first launch after upgrading, violating
acceptance criterion 4. So `MenuBarStatusItemIdentity` carries the legacy value
across once, before `autosaveName` is assigned. It is guarded on both sides: it
never runs twice, and never overwrites a position set under the new name.

**4. README** gains a "The menu bar icon is hidden" section: Cmd-drag, the
narrower styles, the notch, and menu bar managers (Ice / Bartender / Hidden Bar).

## Evidence

Nothing here is a regression test — #1845 is an enhancement, so no defect ran red
on `main`. Every check is therefore either a **lock** or **mutation-proved**, and
the test file says which for each.

**Round 1 — 8 mutations, all RED** (each reverted from a checkpoint commit):

| # | Mutation | Test | Failure |
|---|---|---|---|
| 1 | aggregate renders per-project again | `testCompactWidthDependsOnlyOnTheSessionCountsDigits`, `testCompactIsNarrowerThanLightsOnACrowdedMenuBar` | `got [10.0, 26.0, 42.0, 74.0, 138.0]`; `("90.0") is not less than ("90.0")` |
| 2 | `.compact` → `aggregatesSessionDots = false` | `testStyleRenderingDecisions` | `("false") is not equal to ("true") - compact.aggregatesSessionDots` |
| 3 | delete `defaults.set()` in the migration | `testLegacyPositionIsCarriedOverOnce` | `("nil") is not equal to ("Optional(298)")` |
| 4 | drop the "new key absent" guard | `testMigrationNeverOverwritesAPositionSetUnderTheNewName` | `("Optional(298)") is not equal to ("Optional(42)")` |
| 5 | remove the `autosaveName` assignment | `testMenuBarControllerAppliesTheStatusItemIdentity` | `must declare the status item's autosave name` |
| 6 | migrate *after* creating the item | same | `the migration must run BEFORE the status item is created` |
| 7 | drop the `topLevelSessions` filter | `testCompactCountsTopLevelSessionsOnly` | subagent counted in the aggregate label |
| 8 | change the `autosaveName` literal | `testAutosaveNameIsStable` | `("SomethingElse") is not equal to ("IrrlichtStatusItem")` |

**Round 2 — the review gate found 8 mutations that SURVIVED all 527 tests, every
one of them at a call site rather than a definition.** That is the real finding
of this PR's review: round 1 proved the new *symbols*, and left the *wiring*
unpinned. All are now closed, and re-run to confirm:

| Mutation | Now |
|---|---|
| `compact: style.usesNarrowQuotaBars` → `showsQuotaBars` (`.usage` silently gets narrow bars) | **RED** — 2 failures / 533 |
| invert `quotaImage`'s `showsQuotaBars` guard | **RED** — 9 failures / 533 |
| invert `dotsImage`'s `aggregatesSessionDots` | **RED** — 7 failures / 533 |
| `assemble`: delete the `if index > 0 { offsetX += groupGap }` rule | **RED** — 10 failures / 533 |
| `assemble`: `offsetX += render.width + 3` | **RED** — 13 failures / 533 |
| SettingsView gate `showsQuotaBars` → `usesNarrowQuotaBars` | **RED** — 1 failure |
| `image(from:)`: stamp `totalWidth + 5` | **RED** — 9 failures / 533 |
| `image(from:)`: delete `image.isTemplate = false` | **EQUIVALENT MUTANT** — see below |

That last one is not a coverage gap and is not claimed as covered: `NSImage`
already reports `isTemplate == false` with no assignment, so deleting the line
changes nothing observable. **Measured**, by asserting the opposite on a fresh
`NSImage(data:)` and watching it fail: `XCTAssertTrue failed - MEASURED: fresh
NSImage(data:) isTemplate == false`. Setting it to `true` *is* caught (red), so
the assertion has teeth; the deletion simply has no effect to catch.

The gap that let round 1 miss all eight was structural, and the fix is
structural: the two style decisions were extracted into `MenuBarImageBuilder.dotsImage`
/ `.quotaImage` so they can be asserted behaviorally, `assemble` now derives the
declared width from the same walk that places the groups (so layout and width
cannot diverge), and the exact-SVG lock pins the offsets the extraction moved.

Locks (green by construction, **not** presented as red-first proof):
`testExistingStylesAndDefaultAreUnchanged` (raw values, order, `?? .lights`
fallback), `testPerProjectRenderingIsUnchangedByTheExtraction` (the per-project
SVG is byte-identical), `testShippedStylesRenderExactlyWhatTheyDidBefore`, and
the three existing style rows in `testStyleRenderingDecisions`.

`MenuBarController` and `SettingsView` are never constructed by these tests —
the former would allocate a live status item on the test host — so their wiring
is pinned by reading the source, in the idiom `PersistentDefaultsLintTests` and
`RealHomePathLintTests` already use. That reader throws rather than returning
empty when a file is missing, and `testTheSourceReaderFailsLoudlyWhenItCannotLook`
proves the guard fires: "could not look" must not read as "found nothing".

## Gates

All run in this worktree, all PASS:

```
tools/preflight.sh --only swift      PASS   (macOS Swift build + test)
tools/preflight.sh --only go         PASS   (8 gates incl. replay fixtures)
tools/preflight.sh --only web        PASS   (both trees)
tools/preflight.sh --only arch       PASS
tools/preflight.sh --only tools      PASS
tools/preflight.sh --only skills     PASS
tools/preflight.sh --only posix      PASS
tools/preflight.sh --only bash       PASS
tools/preflight.sh --only security   PASS
```

`cd platforms/macos && swift test --skip LauncherTestHarness --skip
LauncherHarnessTests` — **533 tests, 0 failures** (baseline at this branch point
was 512; the 21 new ones are this PR's).

**`tools/preflight.sh --only linux` did NOT run** — it is opt-in and needs
Docker. This change is macOS-Swift and Markdown only, so it compiles nothing on
Linux; that is a reason it is unlikely to matter, not evidence that it passes.

## Simplify pass

Four angles, each accounted for: **reuse** — no findings (per-file session
fixtures and `#filePath` source readers are established house style here, and
`aggregateRender` de-duplicates rather than adds); **efficiency** — no findings
(one loop instead of two in `assemble`; the one added array allocation in
`topLevelSessions` is negligible against the `NSImage(data:)` SVG rasterization
already paid per rebuild, which is debounced to 50ms); **altitude** — no
blocking findings, one follow-up noted below; **simplification** — 4 findings,
3 applied (locals no longer shadow the `dotsImage`/`quotaImage` helpers; the
`50.0`/`20.8` literals now derive from `QuotaMenuBarRenderer`'s constants; the
algebraic coincidence in `hidesDotsWhenQuotaIsRenderable` is now asserted so a
future divergence is deliberate). One skipped with reason: the exact-SVG
assertion is deliberately broader than the sibling suite's `contains(...)`
idiom, because it pins "the extraction changed nothing", which is this PR's
hard constraint.

## Not done, deliberately

- **The issue's Track B step 4** (detect the hidden state via
  `statusItem.button?.window?.frame` and notify) is filed as **#1848**. The issue
  itself marked it optional and marked the mechanism assumed; it needs a device
  check before any code is written against it.

- **`maxVisibleGroups` stays hard-coded at 5** for Lights/Usage/Combined, so the
  width growth still recurs for a user who prefers those styles with 6+ projects.
  `.compact` fixes it for anyone willing to give up per-project dots. Generalizing
  it into a user-set width budget every style respects is the deeper fix; the
  issue delegated "which mechanism ships" and fenced the criteria around one, so
  that is a follow-up rather than part of this PR.

- **Acceptance criterion 1 — "the Cmd-drag position survives a quit and a
  relaunch" — is NOT proven by this PR, and I could not prove it.** It needs a
  physical Cmd-drag on a real menu bar followed by a relaunch, which no rig in
  this repo automates. The code ships and the wiring is asserted; the behaviour
  is not. **This needs ~10 minutes from a maintainer at the keyboard:**

  ```bash
  # 1. before — note the value, if any
  defaults read io.irrlicht.app | grep "NSStatusItem Preferred Position"

  # 2. launch this build, Cmd-drag the icon somewhere obvious, then quit it

  # 3. after the drag, before relaunching — a new key should now be present
  defaults read io.irrlicht.app | grep "NSStatusItem Preferred Position"
  #    expect: "NSStatusItem Preferred Position IrrlichtStatusItem" = <x>

  # 4. relaunch, and confirm the icon comes back where you left it
  ```

  Step 3 is also the migration check: on a machine that already has
  `... Position Item-0`, the `IrrlichtStatusItem` key should appear with the
  *same* value on the very first launch, before any drag.

## Unverified

- That AppKit's generated autosave name is `Item-0` for this app is **observed**
  (the key is in `io.irrlicht.app` today) and consistent with there being exactly
  one status item — but the naming scheme is AppKit's, undocumented, and not
  something this PR can pin. If it were ever something else on some machine, the
  migration is a no-op there and that user's icon moves once; it cannot do harm
  beyond that, because it only ever writes when the new key is absent.
- The seven image-snapshot suites are graded on the reference host only and are
  never CI-gated; none cover the menu bar icon (no `MenuBar*` directory under
  `Tests/__Snapshots__/`), so this width change does not touch a golden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)