### PR TITLE
refactor(macos): make compact a modifier on every menu bar style, not a fourth style

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,17 +106,35 @@ first:
 1. **Cmd-drag it somewhere you can see.** Hold ⌘ and drag the icon along the
    menu bar. Irrlicht asks macOS to remember the spot, so it should still be
    there after a quit and a relaunch.
-2. **Switch to a narrower icon style.** Settings → *Menu Bar Icon*. **Compact**
-   collapses every project into one dot with a session count and drops the
-   quota bars, so its width stays the same no matter how many projects you
-   have open — from two projects on it is the narrowest style (measured:
-   18.5pt, against 90pt for Lights and 117pt for Combined at six projects).
-   **Lights** (the default) draws one dot-group per project and grows with
-   them; **Combined** is the widest, adding quota bars on the right.
+2. **Turn on Compact.** Settings → *Menu Bar Icon* → **Compact**. It is a
+   toggle on whichever style you already use, not a style of its own, so you
+   keep the content you picked and only change how densely it is drawn: every
+   project collapses into one dot with a session count, and on *Usage* the
+   quota bars switch to the narrow, label-less layout *Combined* already uses.
+   Its width then stops growing with your project count.
+
+   Measured in points, by `cd platforms/macos && swift test --filter
+   testMeasuredWidthOfEachStyle` (a committed test, not numbers typed by
+   hand) — `+C` is Compact on:
+
+   | projects | Lights | Lights+C | Usage | Usage+C | Combined | Combined+C |
+   |---|---|---|---|---|---|---|
+   | 1 | 10.00 | 18.50 | 50.00 | 20.80 | 36.80 | 45.30 |
+   | 2 | 26.00 | 18.50 | 50.00 | 20.80 | 52.80 | 45.30 |
+   | 3 | 42.00 | 18.50 | 50.00 | 20.80 | 68.80 | 45.30 |
+   | 5 | 74.00 | 18.50 | 50.00 | 20.80 | 100.80 | 45.30 |
+   | 6 | 90.00 | 18.50 | 50.00 | 20.80 | 116.80 | 45.30 |
+   | 8 | 90.00 | 18.50 | 50.00 | 20.80 | 116.80 | 45.30 |
+
+   Lights plateaus at 90.00 because only five dot-groups plus an overflow
+   marker are ever drawn. Compact costs width only in the trivial
+   one-project case (18.50 against 10.00) and wins from two projects on,
+   which is the crowded menu bar this section is about. With Compact **off**,
+   every style renders exactly what it always did.
 3. **Mind the notch.** On a notched Mac the menu bar has a dead zone in the
    middle. macOS does not flow icons around it — an icon pushed into that
-   range is simply not drawn. Removing any other status item, or using a
-   narrower style, moves Irrlicht back out.
+   range is simply not drawn. Removing any other status item, or turning on
+   Compact, moves Irrlicht back out.
 4. **Use a menu bar manager** if you run a lot of status items:
    [Ice](https://github.com/jordanbaird/Ice) (free, open source),
    [Bartender](https://www.macbartender.com/), or

--- a/platforms/macos/Irrlicht/App/MenuBarController.swift
+++ b/platforms/macos/Irrlicht/App/MenuBarController.swift
@@ -39,13 +39,20 @@ final class MenuBarController: NSObject {
     private var escapeMonitor: Any?
     private var resignObserver: NSObjectProtocol?
 
-    // Last-seen values for the menu-bar quota settings (issue #909), so the
-    // broad UserDefaults.didChangeNotification (fires for *any* default,
-    // mirroring the pattern SessionManager.init uses for sourcesSettingsChanged)
-    // only triggers a rebuild when one of these three actually changed.
-    private var lastMenuBarStyle = UserDefaults.standard.string(forKey: MenuBarStyle.storageKey) ?? ""
-    private var lastMenuBarQuotaProvider = UserDefaults.standard.string(forKey: MenuBarQuotaProvider.storageKey) ?? ""
-    private var lastMenuBarQuotaVisual = UserDefaults.standard.string(forKey: QuotaVisualStyle.storageKey) ?? ""
+    // Last-seen menu-bar icon settings (issue #909), so the broad
+    // UserDefaults.didChangeNotification (fires for *any* default, mirroring
+    // the pattern SessionManager.init uses for sourcesSettingsChanged) only
+    // triggers a rebuild when one of them actually changed.
+    //
+    // One Equatable value rather than one field per setting (#1852): the
+    // compact modifier was the fourth setting, and the old shape needed it
+    // added in four separate places, where forgetting any one leaves the icon
+    // stale until an unrelated event repaints it and nothing fails.
+    //
+    // Assigned in `init` rather than here, because the property initialiser
+    // would run BEFORE init's body — capturing the pre-migration style and
+    // making the first post-upgrade launch report a spurious change.
+    private var lastIconSettings: MenuBarIconSettings
 
     private static let escapeKeyCode: UInt16 = 53
 
@@ -64,6 +71,14 @@ final class MenuBarController: NSObject {
         // assignment is what makes AppKit look the new key up, so the value
         // has to be there first. See MenuBarStatusItemIdentity (#1845).
         MenuBarStatusItemIdentity.migrateLegacyPreferredPosition(in: UserDefaults.standard)
+        // Carry a user off #1849's Compact *style* onto the equivalent style
+        // plus modifier, BEFORE anything reads either key: an unmigrated
+        // `menuBarStyle = "compact"` does not parse, so it would fall back to
+        // Lights with the modifier off and silently discard the choice.
+        // See MenuBarAppearance.migrateLegacyCompactStyle (#1852).
+        MenuBarAppearance.migrateLegacyCompactStyle(in: UserDefaults.standard)
+        // Only now is the store settled enough to snapshot as "last seen".
+        self.lastIconSettings = MenuBarIconSettings.current(in: .standard)
 
         self.statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
         // Declaring the name is what makes the user's Cmd-drag position a
@@ -157,21 +172,14 @@ final class MenuBarController: NSObject {
             // (what SessionManager's sourcesSettingsChanged observer actually
             // uses), a plain Combine publisher delivers on whatever thread
             // posted the notification. Hop to main before the compactMap
-            // below mutates lastMenuBarStyle/etc — those are plain, non-atomic
-            // properties read/written elsewhere on the main thread.
+            // below mutates lastIconSettings — a plain, non-atomic property
+            // read/written elsewhere on the main thread.
             .receive(on: RunLoop.main)
             .compactMap { [weak self] _ -> Void? in
                 guard let self else { return nil }
-                let style = UserDefaults.standard.string(forKey: MenuBarStyle.storageKey) ?? ""
-                let provider = UserDefaults.standard.string(forKey: MenuBarQuotaProvider.storageKey) ?? ""
-                let visual = UserDefaults.standard.string(forKey: QuotaVisualStyle.storageKey) ?? ""
-                guard style != self.lastMenuBarStyle
-                    || provider != self.lastMenuBarQuotaProvider
-                    || visual != self.lastMenuBarQuotaVisual
-                else { return nil }
-                self.lastMenuBarStyle = style
-                self.lastMenuBarQuotaProvider = provider
-                self.lastMenuBarQuotaVisual = visual
+                let settings = MenuBarIconSettings.current(in: .standard)
+                guard settings != self.lastIconSettings else { return nil }
+                self.lastIconSettings = settings
                 return ()
             }
             .eraseToAnyPublisher()

--- a/platforms/macos/Irrlicht/App/MenuBarImageBuilder.swift
+++ b/platforms/macos/Irrlicht/App/MenuBarImageBuilder.swift
@@ -72,29 +72,60 @@ enum MenuBarImageBuilder {
     /// second time. Pure decision, extracted for testability without a
     /// SessionManager, mirroring `iconState`.
     static func shouldShowDotsInUsageStyle(
-        style: MenuBarStyle,
+        appearance: MenuBarAppearance,
         quotaImage: NSImage?,
         dotsImage: NSImage?,
         hasErroredSession: Bool
     ) -> Bool {
-        guard style.hidesDotsWhenQuotaIsRenderable, dotsImage != nil else { return false }
+        guard appearance.hidesDotsWhenQuotaIsRenderable, dotsImage != nil else { return false }
         return quotaImage == nil || hasErroredSession
     }
 
-    /// The dot half of the icon, for a given style.
+    /// Whether the dot half is drawn at all — the WHOLE decision, not just the
+    /// `.usage` arm of it.
     ///
-    /// Extracted from `combinedImage` so the style-to-renderer routing is
+    /// Extracted from `combinedImage` (#1852) for the same reason `dotsImage`
+    /// and `quotaImage` were extracted in #1849, and for a reason that was
+    /// measured rather than assumed: spelled inline, swapping the first
+    /// predicate for its neighbour left the suite green while making `.usage`
+    /// draw its dots unconditionally. `combinedImage` is private and needs a
+    /// live `SessionManager`, so only the extracted form is reachable from a
+    /// test — see
+    /// `MenuBarImageBuilderTests.testShowsDotsAcrossEveryStyleAndDensity`,
+    /// which carries the exact mutation.
+    static func showsDots(
+        appearance: MenuBarAppearance,
+        quotaImage: NSImage?,
+        dotsImage: NSImage?,
+        hasErroredSession: Bool
+    ) -> Bool {
+        guard appearance.hidesDotsWhenQuotaIsRenderable else { return true }
+        return shouldShowDotsInUsageStyle(
+            appearance: appearance,
+            quotaImage: quotaImage,
+            dotsImage: dotsImage,
+            hasErroredSession: hasErroredSession
+        )
+    }
+
+    /// The dot half of the icon, for a given appearance.
+    ///
+    /// Extracted from `combinedImage` so the appearance-to-renderer routing is
     /// reachable from a test without a `SessionManager` — the same reason
     /// `iconState` and `shouldShowDotsInUsageStyle` are pure. Review of
     /// #1849 measured that this wiring was the one part of the change no
     /// test could see: inverting the condition here left all 527 tests
     /// green while collapsing every shipped style to a single dot.
+    ///
+    /// Since #1852 the aggregate path is reachable from every style, not just
+    /// the one that hard-coded it — `aggregatesSessionDots` is the modifier,
+    /// not a property of what the icon shows.
     static func dotsImage(
-        style: MenuBarStyle,
+        appearance: MenuBarAppearance,
         sessions: [SessionState],
         projectGroupOrder: [String]
     ) -> NSImage? {
-        style.aggregatesSessionDots
+        appearance.aggregatesSessionDots
             ? MenuBarStatusRenderer.buildAggregateStatusImage(sessions: sessions)
             : MenuBarStatusRenderer.buildStatusImage(
                 sessions: sessions,
@@ -102,23 +133,105 @@ enum MenuBarImageBuilder {
             )
     }
 
-    /// The quota half of the icon, for a given style — nil when the style
+    /// The quota half of the icon, for a given appearance — nil when the style
     /// carries no quota bars at all. Extracted for the same reason as
     /// `dotsImage`: swapping `usesNarrowQuotaBars` for `showsQuotaBars` in
     /// the `compact:` argument is a one-word slip that silently re-lays-out
     /// every `.usage` user's icon, and nothing could see it.
     static func quotaImage(
-        style: MenuBarStyle,
+        appearance: MenuBarAppearance,
         sessions: [SessionState],
         providerKey: String?,
         now: Date
     ) -> NSImage? {
-        guard style.showsQuotaBars else { return nil }
+        guard appearance.showsQuotaBars else { return nil }
         return QuotaMenuBarRenderer.imageForSelectedProvider(
             sessions: sessions,
             providerKey: providerKey,
-            compact: style.usesNarrowQuotaBars,
+            compact: appearance.usesNarrowQuotaBars,
             now: now
+        )
+    }
+
+    /// The whole icon for one appearance: both halves, the `.usage` dot
+    /// fallback, and the order they are composed in.
+    ///
+    /// **Why this is a separate function from `combinedImage`.** #1849
+    /// extracted `dotsImage` and `quotaImage`, and #1852 extracted `showsDots`,
+    /// each so the *decision* it makes could be reached by a test. But
+    /// `combinedImage` needs a live `SessionManager` and a `GasTownProvider`,
+    /// so no test can call it — which left everything the extracted seams were
+    /// handed to, and everything done with what they returned, as unreachable
+    /// as before. Review of #1852 measured that gap: four separate mutations
+    /// inside the old inline composition survived the full suite. A
+    /// source-text pin cannot see any of them, because it matches the call and
+    /// not what the call is given or what is done with the result. So the
+    /// composition moved here, where a test can assert the composed image
+    /// itself. Each mutation, and the test that kills it, is recorded on
+    /// `MenuBarImageBuilderTests.testComposedIconForEveryStyleAndModifier`,
+    /// `...testUsageComposesDotsWhenNoQuotaIsRenderable` and
+    /// `...testComposedIconPutsTheDotsBeforeTheQuotaBars`.
+    ///
+    /// `sessions` must already have Gas Town's sessions filtered out; the
+    /// badge is composed by the caller.
+    static func iconImage(
+        appearance: MenuBarAppearance,
+        sessions: [SessionState],
+        projectGroupOrder: [String],
+        providerKey: String?,
+        now: Date
+    ) -> NSImage? {
+        // Computed once regardless of appearance so the .usage fallback below
+        // can check its actual success/failure instead of re-deriving it from
+        // a raw session count (see shouldShowDotsInUsageStyle's doc).
+        //
+        // The compact modifier (#1845, reshaped by #1852) collapses every
+        // project into ONE aggregate dot, so the dot half's width stops
+        // growing with the project count — on whichever style is selected.
+        let computedDotsImage = dotsImage(
+            appearance: appearance,
+            sessions: sessions,
+            projectGroupOrder: projectGroupOrder
+        )
+        // Combined style shares its width budget with the dots, so the
+        // quota bars render in a narrower, label-less layout there — see
+        // QuotaMenuBarRenderer.buildSVG's `compact` handling. Since #1852 the
+        // Usage style reaches that same narrow layout via the compact
+        // modifier; Combined stays narrow either way, which is the
+        // compatibility bound (MenuBarAppearance.usesNarrowQuotaBars).
+        let builtQuotaImage = quotaImage(
+            appearance: appearance,
+            sessions: sessions,
+            providerKey: providerKey,
+            now: now
+        )
+        // .usage style hides the dots by default. Two conditions bring them
+        // back — no renderable quota, or an errored session that would
+        // otherwise have nowhere to be red. See showsDots.
+        //
+        // `sessions` has already dropped Gas Town sessions; hasErroredDot
+        // drops subagents. Both filters are needed — see its doc.
+        //
+        // The locals are named `built…`/`shown…` rather than reusing the
+        // helpers' own names: `let quotaImage = quotaImage(...)` compiles, but
+        // it gives one identifier two meanings inside a single function and
+        // reads like recursion at a glance.
+        let hasErroredSession = hasErroredDot(in: sessions)
+        let shownDotsImage = showsDots(
+            appearance: appearance, quotaImage: builtQuotaImage, dotsImage: computedDotsImage,
+            hasErroredSession: hasErroredSession
+        ) ? computedDotsImage : nil
+        // Dots first (left), quota bars last (right) — closest to the
+        // system status icons (WiFi/battery/clock), matching issue #909's
+        // mockup ordering. Uses the same gap as between dot-groups
+        // themselves (MenuBarStatusRenderer.groupGap) so the dots-to-quota
+        // seam in Combined style reads as "one more group," not a wider gap.
+        //
+        // Either half may be nil (no sessions for .usage-only, or no
+        // rate_limit data yet) without collapsing the whole icon —
+        // composeSideBySide degrades to whichever half exists.
+        return composeSideBySide(
+            shownDotsImage, builtQuotaImage, gap: MenuBarStatusRenderer.groupGap
         )
     }
 
@@ -151,62 +264,18 @@ enum MenuBarImageBuilder {
             ? sessionManager.sessions.filter { !gasTownProvider.ownsSession($0) }
             : sessionManager.sessions
 
-        // Issue #909: which content the icon shows is a user choice (default
-        // .lights = today's behavior, unchanged for existing users). Either
-        // half can come back nil (no sessions for .usage-only, or no
-        // rate_limit data yet for .usage/.combined) without collapsing the
-        // whole icon — composeSideBySide degrades to whichever half exists.
-        let style = MenuBarStyle.current
-        // Computed once regardless of style so the .usage fallback below can
-        // check its actual success/failure instead of re-deriving it from a
-        // raw session count (see shouldShowDotsInUsageStyle's doc).
-        //
-        // The Compact style (#1845) collapses every project into ONE
-        // aggregate dot, so its width does not grow with the project count.
-        let computedDotsImage = dotsImage(
-            style: style,
+        let baseImage = iconImage(
+            appearance: MenuBarAppearance.current,
             sessions: nonGtSessions,
-            projectGroupOrder: sessionManager.projectGroupOrder
-        )
-        // Combined style shares its width budget with the dots, so the
-        // quota bars render in a narrower, label-less layout there — see
-        // QuotaMenuBarRenderer.buildSVG's `compact` handling.
-        //
-        // `now:` is the menu-bar icon's one wall-clock read (#1675). The icon is
-        // rasterised into an `NSStatusItem`, not rendered by SwiftUI, so
-        // `\.formatNow` cannot reach it — the clock has to be read somewhere and
-        // this is that place, once, visibly, rather than twice inside
-        // `rowSVG` where the 5h and 7d rows could be paced against two
-        // different instants.
-        let builtQuotaImage = quotaImage(
-            style: style,
-            sessions: nonGtSessions,
+            projectGroupOrder: sessionManager.projectGroupOrder,
             providerKey: MenuBarQuotaProvider.current,
+            // `now:` is the menu-bar icon's one wall-clock read (#1675). The
+            // icon is rasterised into an `NSStatusItem`, not rendered by
+            // SwiftUI, so `\.formatNow` cannot reach it — the clock has to be
+            // read somewhere and this is that place, once, visibly, rather
+            // than twice inside `rowSVG` where the 5h and 7d rows could be
+            // paced against two different instants.
             now: Date()
-        )
-        // .usage style hides the dots by default. Two conditions bring them
-        // back — no renderable quota, or an errored session that would
-        // otherwise have nowhere to be red. See shouldShowDotsInUsageStyle.
-        //
-        // `nonGtSessions` has already dropped Gas Town sessions; hasErroredDot
-        // drops subagents. Both filters are needed — see its doc.
-        //
-        // The locals are named `built…`/`shown…` rather than reusing the
-        // helpers' own names: `let quotaImage = quotaImage(...)` compiles, but
-        // it gives one identifier two meanings inside a single function and
-        // reads like recursion at a glance.
-        let hasErroredSession = hasErroredDot(in: nonGtSessions)
-        let shownDotsImage = !style.hidesDotsWhenQuotaIsRenderable || shouldShowDotsInUsageStyle(
-            style: style, quotaImage: builtQuotaImage, dotsImage: computedDotsImage,
-            hasErroredSession: hasErroredSession
-        ) ? computedDotsImage : nil
-        // Dots first (left), quota bars last (right) — closest to the
-        // system status icons (WiFi/battery/clock), matching issue #909's
-        // mockup ordering. Uses the same gap as between dot-groups
-        // themselves (MenuBarStatusRenderer.groupGap) so the dots-to-quota
-        // seam in Combined style reads as "one more group," not a wider gap.
-        let baseImage = composeSideBySide(
-            shownDotsImage, builtQuotaImage, gap: MenuBarStatusRenderer.groupGap
         )
 
         guard gasTownProvider.isDaemonRunning else { return baseImage }

--- a/platforms/macos/Irrlicht/Managers/SessionManager.swift
+++ b/platforms/macos/Irrlicht/Managers/SessionManager.swift
@@ -289,7 +289,7 @@ class SessionManager: ObservableObject {
     /// `summaryDisplayMode`, `projectGroupOrder`, the Sources flags, the
     /// notification toggles and the `register(defaults:)` seed. Preferences
     /// read elsewhere (`MenuBarController`, `LoginItemManager`,
-    /// `ContextPressureThreshold.current`, `MenuBarStyle.current`) still
+    /// `ContextPressureThreshold.current`, `MenuBarAppearance.current`) still
     /// resolve `.standard`; the views' own `@AppStorage` reads are covered by
     /// `PinnedSnapshotHost`'s `defaultAppStorage` pin instead.
     let defaults: UserDefaults

--- a/platforms/macos/Irrlicht/Models/MenuBarStyle.swift
+++ b/platforms/macos/Irrlicht/Models/MenuBarStyle.swift
@@ -4,16 +4,17 @@ import Foundation
 /// per-project session-state dots, the subscription quota mini-bars, or
 /// both side by side. Stored in @AppStorage("menuBarStyle"); defaults to
 /// `.lights` so existing users see no visual change until they opt in.
+///
+/// **WHAT the icon shows, and nothing else.** How densely it shows it is an
+/// independent choice — `MenuBarAppearance.isCompact` (issue #1852). #1849
+/// briefly made density a fourth case here, which forced the two choices into
+/// one enum: "narrow" was then reachable in exactly one combination
+/// (aggregate dots, no quota bars), and the crowded-menu-bar user who wanted
+/// quota bars *and* a narrow icon had nothing to pick at all.
 enum MenuBarStyle: String, CaseIterable, Identifiable {
     case lights
     case usage
     case combined
-    /// One aggregate dot for every project at once, and no quota bars — the
-    /// only style whose width does not grow with the number of projects
-    /// (issue #1845). Appended LAST on purpose: `allCases` drives the
-    /// Settings segmented control's order, so a new case anywhere else would
-    /// move the three segments an existing user already knows.
-    case compact
 
     var id: String { rawValue }
 
@@ -22,57 +23,6 @@ enum MenuBarStyle: String, CaseIterable, Identifiable {
         case .lights: return "Lights"
         case .usage: return "Usage"
         case .combined: return "Combined"
-        case .compact: return "Compact"
-        }
-    }
-
-    // MARK: - What each style renders
-    //
-    // These three are `switch`es rather than the `style == .lights` /
-    // `style == .combined` / `style != .usage` comparisons that used to live
-    // in MenuBarImageBuilder, because a comparison silently answers for a
-    // case that did not exist when it was written. Adding `.compact` (#1845)
-    // had to answer three separate questions, and each one defaulted into
-    // some other style's branch with nothing failing to build. A `switch`
-    // over the enum is the one reader the Swift compiler forces to be
-    // exhaustive — the same reasoning MenuBarStatusRenderer.segmentOrder
-    // gives for deriving from `allCases` instead of hand-listing (#1797).
-
-    /// Whether the icon carries the subscription quota bars at all.
-    var showsQuotaBars: Bool {
-        switch self {
-        case .lights, .compact: return false
-        case .usage, .combined: return true
-        }
-    }
-
-    /// Whether those quota bars render in the narrow, label-less layout
-    /// (`QuotaMenuBarRenderer`'s `compact:` flag — a different, older concept
-    /// than the `.compact` *style*, which shows no quota bars at all).
-    var usesNarrowQuotaBars: Bool {
-        switch self {
-        case .lights, .usage, .compact: return false
-        case .combined: return true
-        }
-    }
-
-    /// Whether the session dots collapse into ONE aggregate dot spanning
-    /// every project, instead of one dot-group per project.
-    var aggregatesSessionDots: Bool {
-        switch self {
-        case .lights, .usage, .combined: return false
-        case .compact: return true
-        }
-    }
-
-    /// Whether the dots give way to the quota bars when those are
-    /// renderable. Only `.usage` does; see
-    /// `MenuBarImageBuilder.shouldShowDotsInUsageStyle` for the two
-    /// conditions that bring them back anyway.
-    var hidesDotsWhenQuotaIsRenderable: Bool {
-        switch self {
-        case .lights, .combined, .compact: return false
-        case .usage: return true
         }
     }
 
@@ -80,9 +30,203 @@ enum MenuBarStyle: String, CaseIterable, Identifiable {
 
     /// Read the persisted style. Falls back to `.lights` for an unset or
     /// unparseable value, matching ProviderModePreference's fallback shape.
-    static var current: MenuBarStyle {
-        let raw = UserDefaults.standard.string(forKey: storageKey) ?? ""
+    ///
+    /// `"compact"` — the raw value #1849's fourth case persisted — is one of
+    /// those unparseable values, so it would land on `.lights` with the
+    /// modifier OFF and silently discard the choice. See
+    /// `MenuBarAppearance.migrateLegacyCompactStyle`, which runs at launch to
+    /// carry it over before anything reads this.
+    ///
+    /// Takes the store rather than offering a `.standard` convenience: the
+    /// render path reads `MenuBarAppearance.current`, which needs both keys,
+    /// and a no-argument overload here had no callers left after #1852.
+    static func current(in defaults: UserDefaults) -> MenuBarStyle {
+        let raw = defaults.string(forKey: storageKey) ?? ""
         return MenuBarStyle(rawValue: raw) ?? .lights
+    }
+}
+
+/// What the menu bar icon renders, as the two independent choices it actually
+/// is (issue #1852): `style` — WHAT is shown — and `isCompact` — HOW DENSELY.
+///
+/// **Why the four predicates live here rather than on `MenuBarStyle`.** What
+/// the icon renders is now a function of BOTH fields. Answering half the
+/// questions on the enum and half here would rebuild, one layer down, exactly
+/// the conflation this issue removes. Moving all four also turns every
+/// existing `style.showsQuotaBars`-shaped call site into a compile error
+/// instead of a silent behaviour change — and in a refactor the risk sits at
+/// the call sites, not at the definitions.
+///
+/// The three `style`-dependent predicates still `switch` exhaustively over
+/// `style` rather than comparing against a case, which is the reasoning
+/// `MenuBarStyle` carried before #1852 and `MenuBarStatusRenderer.segmentOrder`
+/// gives for deriving from `allCases` (#1797): a comparison silently answers
+/// for a case that did not exist when it was written. `aggregatesSessionDots`
+/// is the exception and needs no switch — it IS the modifier.
+struct MenuBarAppearance: Equatable {
+    /// Which content the icon carries.
+    var style: MenuBarStyle
+    /// Whether it is drawn in the narrow, space-saving form.
+    var isCompact: Bool
+
+    // MARK: - What this appearance renders
+
+    /// Whether the icon carries the subscription quota bars at all.
+    ///
+    /// A `style` question only: `isCompact` changes how densely the bars are
+    /// drawn, never whether they are drawn. `lights` + compact is precisely
+    /// what #1849 shipped as the Compact *style* — one aggregate dot, no
+    /// quota half.
+    var showsQuotaBars: Bool {
+        switch style {
+        case .lights: return false
+        case .usage, .combined: return true
+        }
+    }
+
+    /// Whether those quota bars render in the narrow, label-less layout
+    /// (`QuotaMenuBarRenderer`'s `compact:` flag — an older, lower-level
+    /// concept than this type's `isCompact`, and the thing `isCompact`
+    /// selects).
+    ///
+    /// **`combined` is narrow whether or not `isCompact` is set, and that is
+    /// permanent, not a temporary shim.** The reason is structural: `combined`
+    /// draws two things in one menu-bar-width budget, so its quota half has
+    /// been the narrow layout since #909 and would have to be narrow whatever
+    /// this modifier did. Compatibility follows from that rather than causing
+    /// it — making narrowness track `isCompact` would *widen* every existing
+    /// Combined user's icon on the first launch after upgrading, which #1845's
+    /// acceptance criterion 4 forbids and #1852 restates as its one hard
+    /// constraint. So on `combined`, `isCompact` aggregates the dots and leaves
+    /// the quota half alone; `usage` is where it selects the narrow layout
+    /// `combined` was already using.
+    var usesNarrowQuotaBars: Bool {
+        switch style {
+        case .lights: return false
+        case .usage: return isCompact
+        case .combined: return true
+        }
+    }
+
+    /// Whether the session dots collapse into ONE aggregate dot spanning every
+    /// project, instead of one dot-group per project. This is what `isCompact`
+    /// means for the dot half, and it means the same thing on every style that
+    /// draws dots — which is the whole point of #1852.
+    var aggregatesSessionDots: Bool { isCompact }
+
+    /// Whether the dots give way to the quota bars when those are renderable.
+    /// Only `.usage` does; see `MenuBarImageBuilder.shouldShowDotsInUsageStyle`
+    /// for the two conditions that bring them back anyway. A `style` question
+    /// only — compacting the dots does not change whether they yield.
+    var hidesDotsWhenQuotaIsRenderable: Bool {
+        switch style {
+        case .lights, .combined: return false
+        case .usage: return true
+        }
+    }
+
+    // MARK: - Persistence
+
+    static let compactStorageKey = "menuBarCompact"
+
+    static var current: MenuBarAppearance {
+        current(in: .standard)
+    }
+
+    static func current(in defaults: UserDefaults) -> MenuBarAppearance {
+        MenuBarAppearance(
+            style: MenuBarStyle.current(in: defaults),
+            isCompact: defaults.bool(forKey: compactStorageKey)
+        )
+    }
+
+    // MARK: - Migration off #1849's fourth case
+
+    /// The raw `menuBarStyle` value #1849 persisted for its Compact style.
+    static let legacyCompactStyleRawValue = "compact"
+
+    /// Carry a user who picked #1849's Compact *style* over to the equivalent
+    /// style-plus-modifier, once.
+    ///
+    /// Without it `MenuBarStyle.current` sees a raw value this build cannot
+    /// parse, falls back to `.lights` with the modifier OFF, and silently
+    /// widens the icon of the one group of users who had explicitly asked for
+    /// a narrow one.
+    ///
+    /// **The carry-over is exact, not approximate.** `lights` + compact answers
+    /// all four predicates above the way `.compact` did at #1849's merge —
+    /// `showsQuotaBars` false, `usesNarrowQuotaBars` false,
+    /// `aggregatesSessionDots` true, `hidesDotsWhenQuotaIsRenderable` false
+    /// (`MenuBarStyle.swift:44/54/64/74` on that commit) — so the icon renders
+    /// identically across the upgrade rather than merely similarly. That claim
+    /// is re-run rather than only asserted here:
+    /// `testMigratedCompactStyleUsersKeepTheirRendering` drives this migration
+    /// and renders what falls out.
+    ///
+    /// Idempotent by construction: it fires only while the persisted style
+    /// still reads `"compact"`, and rewriting that value is what stops it
+    /// firing again. It therefore needs none of
+    /// `migrateLegacyPreferredPosition`'s "has the new key already been
+    /// written" guard — there is no second key whose absence means "not yet
+    /// migrated".
+    ///
+    /// **Unlike that sibling, this one is destructive, and deliberately so.**
+    /// `migrateLegacyPreferredPosition` leaves its legacy key in place so a
+    /// downgrade still finds the position it expects. Here the legacy value
+    /// lives in the *same* key the new value must occupy, so carrying it over
+    /// means overwriting it. The consequence, traced: a user who upgrades and
+    /// then downgrades to a `.compact`-era build lands on Lights with a wide
+    /// icon, because that build cannot read `menuBarCompact`. Re-upgrading
+    /// restores the compact rendering by itself — `menuBarCompact` is still
+    /// `true` and the old build never touched it — so the choice is
+    /// temporarily invisible on the older build rather than lost.
+    ///
+    /// Takes the store for the same reason
+    /// `MenuBarStatusItemIdentity.migrateLegacyPreferredPosition` does.
+    ///
+    /// - Returns: whether a choice was actually carried over, so a caller (or
+    ///   a test) can tell "migrated" apart from "nothing to migrate".
+    @discardableResult
+    static func migrateLegacyCompactStyle(in defaults: UserDefaults) -> Bool {
+        guard defaults.string(forKey: MenuBarStyle.storageKey)
+            == legacyCompactStyleRawValue else { return false }
+
+        defaults.set(MenuBarStyle.lights.rawValue, forKey: MenuBarStyle.storageKey)
+        defaults.set(true, forKey: compactStorageKey)
+        return true
+    }
+}
+
+/// Every stored default the menu bar icon's appearance depends on, read in one
+/// place and compared as one value.
+///
+/// `MenuBarController` repaints the icon when one of these changes, and
+/// `UserDefaults.didChangeNotification` fires for *any* write — so something
+/// has to answer "did a menu-bar setting actually change". Before #1852 that
+/// was three hand-listed reads compared against three hand-listed last-seen
+/// fields, so adding a fourth setting meant editing four separate places and
+/// forgetting any one of them left the icon stale until an unrelated event
+/// repainted it, with nothing failing. Synthesised `Equatable` over one value
+/// makes the comparison total by construction: a field added here is compared
+/// whether or not anyone remembered to compare it.
+///
+/// Its limit, stated rather than implied: this is total over the fields it
+/// HOLDS, not over every default the icon can depend on. `QuotaVisualStyle` is
+/// read again deeper in the render path (`QuotaMenuBarRenderer`), and is
+/// mirrored here by hand — so a fifth key introduced down there would still
+/// need adding. The forget-to-add failure moved from four sites to one; it did
+/// not disappear.
+struct MenuBarIconSettings: Equatable {
+    var appearance: MenuBarAppearance
+    var quotaProvider: String
+    var quotaVisual: String
+
+    static func current(in defaults: UserDefaults) -> MenuBarIconSettings {
+        MenuBarIconSettings(
+            appearance: MenuBarAppearance.current(in: defaults),
+            quotaProvider: defaults.string(forKey: MenuBarQuotaProvider.storageKey) ?? "",
+            quotaVisual: defaults.string(forKey: QuotaVisualStyle.storageKey) ?? ""
+        )
     }
 }
 

--- a/platforms/macos/Irrlicht/Views/SettingsView.swift
+++ b/platforms/macos/Irrlicht/Views/SettingsView.swift
@@ -42,6 +42,10 @@ struct SettingsView: View {
     // Menu bar icon content (issue #909): dots / quota bars / both. Default
     // .lights keeps today's icon unchanged for existing users.
     @AppStorage(MenuBarStyle.storageKey) private var menuBarStyle: String = MenuBarStyle.lights.rawValue
+    // How densely that content is drawn (issue #1852) — orthogonal to the
+    // style above, so all six combinations are reachable. Defaults to false,
+    // which is byte-identical to what each style rendered before it existed.
+    @AppStorage(MenuBarAppearance.compactStorageKey) private var menuBarCompact: Bool = false
     @AppStorage(MenuBarQuotaProvider.storageKey) private var menuBarQuotaProvider: String = ""
     @AppStorage(QuotaVisualStyle.storageKey) private var menuBarQuotaVisual: String = QuotaVisualStyle.bars.rawValue
     // Master gate (issue #940): collapses the whole Notifications section
@@ -150,7 +154,7 @@ struct SettingsView: View {
                                 .font(.caption)
                                 .fontWeight(.medium)
                                 .foregroundColor(.secondary)
-                            InfoIcon(text: "Lights shows session-state dots (today's default). Usage replaces them with reported subscription quota bars. Combined shows both side by side. Compact collapses every project into one dot and drops the quota bars, so its width does not grow with your project count — for a crowded menu bar.")
+                            InfoIcon(text: "Lights shows session-state dots (today's default). Usage replaces them with reported subscription quota bars. Combined shows both side by side.")
                             Spacer()
                         }
                         // A real Picker(pickerStyle: .segmented) only centers
@@ -167,14 +171,23 @@ struct SettingsView: View {
                         )
                         .frame(maxWidth: .infinity, minHeight: 22)
 
-                        // Ask the style whether it renders quota bars at all,
-                        // rather than testing "is not Lights" — Compact is the
-                        // second style with no quota half, and a `!=` here
-                        // would have offered it two settings it ignores
-                        // (#1845). Parsed from the @AppStorage string, never
-                        // from MenuBarStyle.current, so this stays readable
-                        // under a pinned store.
-                        if (MenuBarStyle(rawValue: menuBarStyle) ?? .lights).showsQuotaBars {
+                        // Compact is a modifier on whichever style is
+                        // selected, not a style of its own (#1852) — that is
+                        // what makes "quota bars AND a narrow icon" reachable,
+                        // which #1845's fourth enum case could not express.
+                        LeadingToggle(
+                            isOn: $menuBarCompact,
+                            label: "Compact",
+                            info: "Collapses every project into one dot with a session count, so the icon's width stops growing with your project count. On Usage it also switches to the narrower, label-less quota bars. For a crowded menu bar."
+                        )
+
+                        // Ask the appearance whether it renders quota bars at
+                        // all, rather than testing "is not Lights" — a `!=`
+                        // here would offer two settings to a style that
+                        // ignores them (#1845). Parsed from the @AppStorage
+                        // values, never from MenuBarAppearance.current, so
+                        // this stays readable under a pinned store.
+                        if menuBarAppearance.showsQuotaBars {
                             HStack(spacing: 6) {
                                 Text("Quota provider")
                                     .font(.caption)
@@ -656,6 +669,23 @@ struct SettingsView: View {
             .fixedSize()
             Spacer()
         }
+    }
+
+    /// The menu bar appearance this view is currently editing, assembled from
+    /// the two `@AppStorage` values rather than read through
+    /// `MenuBarAppearance.current` (#1852).
+    ///
+    /// That distinction is load-bearing, not stylistic: `current` reads
+    /// `UserDefaults.standard`, which a pinned-store test cannot reach, and
+    /// `PersistentDefaultsLintTests` forbids a `UserDefaults.standard`
+    /// receiver anywhere under `Irrlicht/Views/` for exactly that reason.
+    /// Going through the property wrappers keeps the Settings UI readable
+    /// under `.defaultAppStorage`.
+    private var menuBarAppearance: MenuBarAppearance {
+        MenuBarAppearance(
+            style: MenuBarStyle(rawValue: menuBarStyle) ?? .lights,
+            isCompact: menuBarCompact
+        )
     }
 
     /// Provider keys with a rate_limit-carrying session right now, for the

--- a/platforms/macos/Tests/MenuBarCompactStyleTests.swift
+++ b/platforms/macos/Tests/MenuBarCompactStyleTests.swift
@@ -1,98 +1,60 @@
 import XCTest
 @testable import Irrlicht
 
-/// Issue #1845 — the Compact menu bar style and the status item's declared
-/// autosave name.
+/// Issue #1845 — the compact menu bar rendering and the status item's declared
+/// autosave name — as reshaped by issue #1852, which turned Compact from a
+/// fourth `MenuBarStyle` case into an orthogonal modifier on all three styles.
 ///
-/// Nothing here is a regression test: #1845 is an enhancement, so there is no
-/// defect that ran red on `main`. Every assertion is therefore one of two
+/// Nothing here is a regression test: both issues are enhancements, so there is
+/// no defect that ran red on `main`. Every assertion is therefore one of two
 /// kinds, and each one says which:
 ///
 /// - **LOCK** — pins behavior that must NOT change. Passes on `main` by
-///   construction wherever the symbol it names already exists there.
+///   construction wherever the symbol it names already exists there. The
+///   load-bearing one for #1852 is
+///   `testShippedStylesRenderExactlyWhatTheyDidBeforeWhenCompactIsOff`: an
+///   existing install must render byte-identically until the user opts in.
 /// - **Mutation-proved** — a check this change ADDS, which has no "before".
 ///   The doc comment names the exact source mutation that turns it red, per
 ///   AGENTS.md's Testing section.
+///
+/// The file keeps its name so the reshape reads as a diff rather than as a
+/// delete-and-add. Two blocks in it are about neither compactness nor styles —
+/// the `MenuBarStatusRenderer` geometry tests and the whole NSStatusItem
+/// autosave/position-migration block — and would read better as their own
+/// suites; that split is deliberately not bundled into #1852.
 @MainActor
 final class MenuBarCompactStyleTests: XCTestCase {
 
     // MARK: - Fixtures
+    //
+    // Shared with MenuBarImageBuilderTests via MenuBarFixtures: both suites
+    // assert the same derived widths, so they must assert them against the
+    // same sessions (see that file's doc).
 
     private func makeSession(
-        id: String,
-        state: SessionState.State = .working,
-        project: String,
-        parentSessionId: String? = nil
+        id: String, state: SessionState.State = .working,
+        project: String, parentSessionId: String? = nil
     ) -> SessionState {
-        SessionState(
-            id: "sess_\(id)",
-            state: state,
-            model: "claude-3.7-sonnet",
-            cwd: "/Users/test/projects/\(project)",
-            projectName: project,
-            firstSeen: Date(),
-            updatedAt: Date(),
-            parentSessionId: parentSessionId
-        )
+        MenuBarFixtures.session(id: id, state: state, project: project,
+                                parentSessionId: parentSessionId)
     }
 
-    /// `count` sessions spread one-per-project, which is the layout that makes
-    /// the per-project renderer widest for a given session count.
     private func sessionsAcrossProjects(_ count: Int) -> [SessionState] {
-        (0..<count).map { makeSession(id: "s\($0)", project: "p\($0)") }
+        MenuBarFixtures.acrossProjects(count)
     }
 
-    private let now = Date(timeIntervalSince1970: 1_700_000_000)
+    private let now = MenuBarFixtures.now
 
-    /// A session carrying a renderable rate-limit snapshot, so the quota half
-    /// of the icon has something to draw. Same shape
-    /// `QuotaMenuBarRendererTests` uses.
-    private func sessionWithQuota() -> SessionState {
-        let metrics = SessionMetrics(
-            elapsedSeconds: 0,
-            totalTokens: 0,
-            modelName: "claude-sonnet",
-            contextWindow: nil,
-            contextUtilization: 0,
-            pressureLevel: "safe",
-            contextWindowUnknown: nil,
-            estimatedCostUSD: nil,
-            lastAssistantText: nil,
-            tasks: nil,
-            rateLimit: RateLimitInfo(
-                windows: [
-                    RateLimitWindowInfo(
-                        usedPercent: 20, windowMinutes: 300,
-                        resetsAt: now.addingTimeInterval(3600)
-                    ),
-                    RateLimitWindowInfo(
-                        usedPercent: 40, windowMinutes: 10080,
-                        resetsAt: now.addingTimeInterval(3 * 86400)
-                    ),
-                ],
-                sampledAt: now
-            )
-        )
-        return SessionState(
-            id: "sess_quota",
-            state: .working,
-            model: "claude-sonnet",
-            cwd: "/Users/test/projects/quota",
-            projectName: "quota",
-            firstSeen: now,
-            updatedAt: now,
-            metrics: metrics,
-            adapter: "claude-code"
-        )
-    }
+    private func sessionWithQuota() -> SessionState { MenuBarFixtures.sessionWithQuota() }
 
-    // MARK: - The style exists and is opt-in
+    // MARK: - The styles, and the modifier that is not one of them
 
     /// LOCK on the compatibility rule: the three shipped styles keep their
     /// raw values and their order, and the default stays `.lights`. A user
     /// who never opens Settings must render exactly as before.
     func testExistingStylesAndDefaultAreUnchanged() {
-        XCTAssertEqual(MenuBarStyle.allCases.prefix(3).map(\.rawValue), ["lights", "usage", "combined"])
+        XCTAssertEqual(MenuBarStyle.allCases.map(\.rawValue), ["lights", "usage", "combined"])
         XCTAssertEqual(MenuBarStyle(rawValue: "lights"), .lights)
         XCTAssertEqual(MenuBarStyle(rawValue: "usage"), .usage)
         XCTAssertEqual(MenuBarStyle(rawValue: "combined"), .combined)
@@ -103,56 +65,105 @@ final class MenuBarCompactStyleTests: XCTestCase {
         XCTAssertEqual(MenuBarStyle(rawValue: "no-such-style") ?? .lights, .lights)
     }
 
-    /// Mutation-proved: delete `case compact` (and its `label` arm) and this
-    /// fails to compile — the strongest red available for a new enum case.
-    func testCompactStyleIsAvailableAndLast() {
-        XCTAssertEqual(MenuBarStyle.compact.rawValue, "compact")
-        XCTAssertEqual(MenuBarStyle.compact.label, "Compact")
-        XCTAssertEqual(MenuBarStyle.allCases.last, .compact,
-                       "Compact must stay last so the existing segments keep their positions")
+    /// Compact is a modifier on every style, not a fourth style (#1852).
+    ///
+    /// Mutation-proved: re-add `case compact` to `MenuBarStyle` and the
+    /// `allCases` assertion goes red; change `compactStorageKey` and the key
+    /// assertion goes red.
+    func testCompactIsAModifierAndNotAStyle() {
+        XCTAssertEqual(MenuBarStyle.allCases.count, 3,
+                       "compact is a modifier — it must not come back as a style")
+        XCTAssertNil(MenuBarStyle(rawValue: MenuBarAppearance.legacyCompactStyleRawValue),
+                     "\"compact\" must no longer parse as a style")
+        XCTAssertEqual(MenuBarAppearance.compactStorageKey, "menuBarCompact")
+        // Off unless asked for: an empty store must produce the pre-#1852
+        // appearance, which is what the compatibility bound rests on.
+        let fresh = MenuBarAppearance.current(in: InMemoryDefaults())
+        XCTAssertEqual(fresh.style, .lights)
+        XCTAssertFalse(fresh.isCompact, "the modifier must default to off")
     }
 
-    // MARK: - What each style renders
+    // MARK: - What each appearance renders
 
-    /// LOCK on all three shipped styles, plus the new case's answers.
+    /// The full behaviour matrix — every style × the modifier, which is the
+    /// table issue #1852 specifies.
     ///
-    /// Mutation-proved for `.compact`: flip any `.compact` arm in
-    /// `MenuBarStyle.showsQuotaBars` / `.usesNarrowQuotaBars` /
+    /// The `compact: false` half is a **LOCK**: those twelve values are what
+    /// `MenuBarStyle`'s four predicates returned on `main`
+    /// (`MenuBarStyle.swift:44/54/64/74` at #1849's merge), and they must not
+    /// move. The `compact: true` half is new behaviour, mutation-proved:
+    /// flip any arm of `MenuBarAppearance.usesNarrowQuotaBars` or
     /// `.aggregatesSessionDots` and the matching row goes red.
-    func testStyleRenderingDecisions() {
-        // (style, showsQuotaBars, usesNarrowQuotaBars, aggregatesSessionDots,
-        //  hidesDotsWhenQuotaIsRenderable)
-        let expected: [(MenuBarStyle, Bool, Bool, Bool, Bool)] = [
-            (.lights, false, false, false, false),
-            (.usage, true, false, false, true),
-            (.combined, true, true, false, false),
-            (.compact, false, false, true, false),
+    func testAppearanceRenderingDecisions() {
+        // (style, isCompact, showsQuotaBars, usesNarrowQuotaBars,
+        //  aggregatesSessionDots, hidesDotsWhenQuotaIsRenderable)
+        let expected: [(MenuBarStyle, Bool, Bool, Bool, Bool, Bool)] = [
+            // ---- LOCK: byte-identical to what each style rendered before ----
+            (.lights, false, false, false, false, false),
+            (.usage, false, true, false, false, true),
+            (.combined, false, true, true, false, false),
+            // ---- new: the modifier turned on ----
+            // lights + compact reproduces #1849's Compact style exactly.
+            (.lights, true, false, false, true, false),
+            // usage + compact reaches the narrow bars combined already used —
+            // the combination #1845's fourth case could not express at all.
+            (.usage, true, true, true, true, true),
+            // combined + compact aggregates the dots and leaves the quota
+            // half alone; it was already narrow.
+            (.combined, true, true, true, true, false),
         ]
-        XCTAssertEqual(expected.count, MenuBarStyle.allCases.count,
-                       "a style was added without an expectation row here")
-        for (style, quota, narrow, aggregate, hidesDots) in expected {
-            XCTAssertEqual(style.showsQuotaBars, quota, "\(style).showsQuotaBars")
-            XCTAssertEqual(style.usesNarrowQuotaBars, narrow, "\(style).usesNarrowQuotaBars")
-            XCTAssertEqual(style.aggregatesSessionDots, aggregate, "\(style).aggregatesSessionDots")
-            XCTAssertEqual(style.hidesDotsWhenQuotaIsRenderable, hidesDots,
-                           "\(style).hidesDotsWhenQuotaIsRenderable")
+        XCTAssertEqual(expected.count, MenuBarStyle.allCases.count * 2,
+                       "a style was added without both of its modifier rows here")
+        for (style, compact, quota, narrow, aggregate, hidesDots) in expected {
+            let appearance = MenuBarAppearance(style: style, isCompact: compact)
+            XCTAssertEqual(appearance.showsQuotaBars, quota, "\(style) compact=\(compact) showsQuotaBars")
+            XCTAssertEqual(appearance.usesNarrowQuotaBars, narrow,
+                           "\(style) compact=\(compact) usesNarrowQuotaBars")
+            XCTAssertEqual(appearance.aggregatesSessionDots, aggregate,
+                           "\(style) compact=\(compact) aggregatesSessionDots")
+            XCTAssertEqual(appearance.hidesDotsWhenQuotaIsRenderable, hidesDots,
+                           "\(style) compact=\(compact) hidesDotsWhenQuotaIsRenderable")
         }
+    }
 
-        // Across today's four styles `hidesDotsWhenQuotaIsRenderable` happens
-        // to equal `showsQuotaBars && !usesNarrowQuotaBars`. It is kept as its
-        // own exhaustive switch anyway, for the reason the enum's own comment
-        // gives: a DERIVED answer would silently decide for a fifth style that
-        // nobody thought about, which is the exact failure the switches
-        // replaced. Asserting the coincidence here means the day it stops
-        // holding is a deliberate, visible decision rather than a surprise.
+    /// Two of the four predicates answer a `style` question only — the
+    /// modifier must not move them. That is what keeps "compact" a question
+    /// about DENSITY rather than a second way to choose content, which is the
+    /// distinction #1852 exists to restore.
+    ///
+    /// Mutation-proved: make `showsQuotaBars` or
+    /// `hidesDotsWhenQuotaIsRenderable` read `isCompact` and this goes red.
+    func testTheModifierChangesDensityOnlyNeverContent() {
         for style in MenuBarStyle.allCases {
-            XCTAssertEqual(
-                style.hidesDotsWhenQuotaIsRenderable,
-                style.showsQuotaBars && !style.usesNarrowQuotaBars,
-                "\(style): the derived-equivalence note above no longer holds — "
-                    + "decide deliberately whether that is intended"
-            )
+            let off = MenuBarAppearance(style: style, isCompact: false)
+            let on = MenuBarAppearance(style: style, isCompact: true)
+            XCTAssertEqual(off.showsQuotaBars, on.showsQuotaBars,
+                           "\(style): the modifier must not change WHETHER quota bars are drawn")
+            XCTAssertEqual(off.hidesDotsWhenQuotaIsRenderable, on.hidesDotsWhenQuotaIsRenderable,
+                           "\(style): the modifier must not change whether dots yield to quota")
         }
+    }
+
+    /// Before #1852, `hidesDotsWhenQuotaIsRenderable` happened to equal
+    /// `showsQuotaBars && !usesNarrowQuotaBars` across all four styles, and
+    /// `testStyleRenderingDecisions` asserted that coincidence so that the day
+    /// it stopped holding would be a deliberate, visible decision rather than
+    /// a surprise. **This is that day**, and this test is the decision:
+    /// `usage` + compact is the counterexample, because it is the first
+    /// appearance that both hides its dots and draws narrow bars.
+    ///
+    /// Kept as an assertion rather than deleted so the derived form cannot
+    /// quietly be reintroduced as a "simplification" of the two switches.
+    func testTheDerivedEquivalenceNoLongerHolds() {
+        let usageCompact = MenuBarAppearance(style: .usage, isCompact: true)
+        XCTAssertTrue(usageCompact.hidesDotsWhenQuotaIsRenderable)
+        XCTAssertTrue(usageCompact.usesNarrowQuotaBars)
+        XCTAssertNotEqual(
+            usageCompact.hidesDotsWhenQuotaIsRenderable,
+            usageCompact.showsQuotaBars && !usageCompact.usesNarrowQuotaBars,
+            "usage+compact must remain the counterexample that keeps "
+                + "hidesDotsWhenQuotaIsRenderable its own exhaustive switch"
+        )
     }
 
     // MARK: - The WIRING of those decisions into the icon
@@ -167,20 +178,27 @@ final class MenuBarCompactStyleTests: XCTestCase {
 
     /// Mutation-proved: invert the condition in
     /// `MenuBarImageBuilder.dotsImage` and this goes red.
-    func testDotsImageRoutesCompactToTheAggregateRendererAndNothingElse() {
+    ///
+    /// Since #1852 the loop crosses the modifier as well as the style — the
+    /// aggregate path is reachable from all three styles, not just the one
+    /// that used to hard-code it.
+    func testDotsImageRoutesTheModifierToTheAggregateRendererAndNothingElse() {
         let sessions = sessionsAcrossProjects(6)
         for style in MenuBarStyle.allCases {
-            let image = MenuBarImageBuilder.dotsImage(
-                style: style, sessions: sessions, projectGroupOrder: []
-            )
-            XCTAssertNotNil(image, "\(style) must still render dots")
-            let width = image?.size.width ?? -1
-            if style.aggregatesSessionDots {
-                XCTAssertEqual(width, 18.5, accuracy: 0.01,
-                               "\(style) must use the constant-width aggregate dot")
-            } else {
-                XCTAssertEqual(width, 90.0, accuracy: 0.01,
-                               "\(style) must keep the per-project layout it shipped with")
+            for compact in [false, true] {
+                let appearance = MenuBarAppearance(style: style, isCompact: compact)
+                let image = MenuBarImageBuilder.dotsImage(
+                    appearance: appearance, sessions: sessions, projectGroupOrder: []
+                )
+                XCTAssertNotNil(image, "\(style) compact=\(compact) must still render dots")
+                let width = image?.size.width ?? -1
+                if appearance.aggregatesSessionDots {
+                    XCTAssertEqual(width, 18.5, accuracy: 0.01,
+                                   "\(style) compact=\(compact) must use the aggregate dot")
+                } else {
+                    XCTAssertEqual(width, 90.0, accuracy: 0.01,
+                                   "\(style) compact=\(compact) must keep the per-project layout")
+                }
             }
         }
     }
@@ -198,25 +216,36 @@ final class MenuBarCompactStyleTests: XCTestCase {
         let narrow = QuotaMenuBarRenderer.barWidth * QuotaMenuBarRenderer.compactBarWidthFactor
 
         for style in MenuBarStyle.allCases {
-            let image = MenuBarImageBuilder.quotaImage(
-                style: style, sessions: sessions, providerKey: nil, now: now
-            )
-            guard style.showsQuotaBars else {
-                XCTAssertNil(image, "\(style) carries no quota bars")
-                continue
+            for compact in [false, true] {
+                let appearance = MenuBarAppearance(style: style, isCompact: compact)
+                let image = MenuBarImageBuilder.quotaImage(
+                    appearance: appearance, sessions: sessions, providerKey: nil, now: now
+                )
+                guard appearance.showsQuotaBars else {
+                    XCTAssertNil(image, "\(style) compact=\(compact) carries no quota bars")
+                    continue
+                }
+                XCTAssertNotNil(image, "\(style) compact=\(compact) must render quota bars")
+                let expected = appearance.usesNarrowQuotaBars ? narrow : full
+                XCTAssertEqual(image?.size.width ?? -1, expected, accuracy: 0.01,
+                               "\(style) compact=\(compact) quota layout")
             }
-            XCTAssertNotNil(image, "\(style) must render quota bars")
-            let expected = style.usesNarrowQuotaBars ? narrow : full
-            XCTAssertEqual(image?.size.width ?? -1, expected, accuracy: 0.01,
-                           "\(style) quota layout")
         }
     }
 
-    /// LOCK on the hard constraint, stated as one table: what each SHIPPED
-    /// style renders must be exactly what it rendered before `.compact`
-    /// existed. `.lights` dots-only, `.usage` full-width bars, `.combined`
-    /// dots plus narrow bars.
-    func testShippedStylesRenderExactlyWhatTheyDidBefore() {
+    /// **LOCK — the hard constraint of #1852, and the one criterion inherited
+    /// from #1845 that is not negotiable.** An existing install renders
+    /// byte-identically until the user turns the modifier on.
+    ///
+    /// This is a lock, not a defect test: it passes on `main` by construction
+    /// for the shipped styles, and its whole job is to keep passing. What it
+    /// pins is the *numbers*, in points, straight out of the two render
+    /// seams — so any reshaping of how those numbers are selected has to
+    /// arrive at the same pixels. Note in particular the `.combined` row:
+    /// narrow quota bars with the modifier OFF is exactly the behaviour that
+    /// would have been lost had `isCompact` been made to control bar
+    /// narrowness on `combined` (see `MenuBarAppearance.usesNarrowQuotaBars`).
+    func testShippedStylesRenderExactlyWhatTheyDidBeforeWhenCompactIsOff() {
         let sessions = sessionsAcrossProjects(6) + [sessionWithQuota()]
         // Derived from QuotaMenuBarRenderer's constants, not restated — the
         // same rule the per-half tests follow, so a change there surfaces
@@ -230,15 +259,18 @@ final class MenuBarCompactStyleTests: XCTestCase {
             (.usage, 90.0, full),
             (.combined, 90.0, narrow),
         ]
+        XCTAssertEqual(expectations.count, MenuBarStyle.allCases.count,
+                       "a style was added without a compatibility row here")
         for (style, dots, quota) in expectations {
+            let appearance = MenuBarAppearance(style: style, isCompact: false)
             XCTAssertEqual(
                 MenuBarImageBuilder.dotsImage(
-                    style: style, sessions: sessions, projectGroupOrder: []
+                    appearance: appearance, sessions: sessions, projectGroupOrder: []
                 )?.size.width ?? -1,
                 dots ?? -1, accuracy: 0.01, "\(style) dots"
             )
             let quotaImage = MenuBarImageBuilder.quotaImage(
-                style: style, sessions: sessions, providerKey: nil, now: now
+                appearance: appearance, sessions: sessions, providerKey: nil, now: now
             )
             if let quota {
                 XCTAssertEqual(quotaImage?.size.width ?? -1, quota, accuracy: 0.01, "\(style) quota")
@@ -248,45 +280,109 @@ final class MenuBarCompactStyleTests: XCTestCase {
         }
     }
 
+    /// LOCK on the migration's *rendering* promise, end to end: a user who had
+    /// picked #1849's Compact style must keep an equivalent icon.
+    ///
+    /// Drives the real migration over a real store and renders whatever
+    /// appearance falls out, rather than hand-building `lights` + compact and
+    /// asserting two numbers. An earlier version did the latter, which meant it
+    /// could not have detected a migration that wrote the wrong style or the
+    /// wrong flag — the very thing it is named for (#1852 review).
+    func testMigratedCompactStyleUsersKeepTheirRendering() throws {
+        let defaults = InMemoryDefaults()
+        defaults.set(MenuBarAppearance.legacyCompactStyleRawValue,
+                     forKey: MenuBarStyle.storageKey)
+        XCTAssertTrue(MenuBarAppearance.migrateLegacyCompactStyle(in: defaults))
+
+        let migrated = MenuBarAppearance.current(in: defaults)
+        let sessions = MenuBarFixtures.acrossProjectsWithQuota(7)
+        // 18.50 / nil are what `.compact` produced at #1849's merge.
+        XCTAssertEqual(
+            MenuBarImageBuilder.dotsImage(
+                appearance: migrated, sessions: sessions, projectGroupOrder: []
+            )?.size.width ?? -1,
+            18.5, accuracy: 0.01,
+            "the migrated appearance must still draw the constant-width aggregate dot"
+        )
+        XCTAssertNil(
+            MenuBarImageBuilder.quotaImage(
+                appearance: migrated, sessions: sessions, providerKey: nil, now: now
+            ),
+            "the migrated appearance must still draw no quota half"
+        )
+        // And the whole icon, not just the halves.
+        XCTAssertEqual(
+            MenuBarImageBuilder.iconImage(
+                appearance: migrated, sessions: sessions,
+                projectGroupOrder: [], providerKey: nil, now: now
+            )?.size.width ?? -1,
+            18.5, accuracy: 0.01,
+            "the migrated icon must be the aggregate dot alone"
+        )
+    }
+
     // MARK: - Width (acceptance criterion 2)
 
     /// The measurement the issue asks for. Not an assertion — it prints the
-    /// rendered width of every style so the figure in the PR body has a
-    /// command behind it rather than being typed by hand.
+    /// rendered width of every style × modifier combination so the figure in
+    /// the PR body has a command behind it rather than being typed by hand.
     ///
     ///     cd platforms/macos && swift test --filter testMeasuredWidthOfEachStyle
+    ///
+    /// #1852 extends #1849's four columns to all six combinations rather than
+    /// adding a second measurement, so one command still produces every
+    /// number the issue quotes.
+    ///
+    /// Each cell is **derived from the appearance's own predicates**, not
+    /// hand-composed per column the way #1849's four were. That is what stops
+    /// the printed table and the shipped behaviour drifting apart: change
+    /// `usesNarrowQuotaBars` and the table moves with it, instead of the
+    /// arithmetic here quietly continuing to describe the old rules.
     func testMeasuredWidthOfEachStyle() throws {
-        // Read from QuotaMenuBarRenderer rather than restated, so these
-        // cannot drift away from what it actually renders.
+        // Read from QuotaMenuBarRenderer rather than restated, so the trailing
+        // note cannot drift away from what it actually renders.
         let fullQuota = QuotaMenuBarRenderer.labelWidth + QuotaMenuBarRenderer.gap
             + QuotaMenuBarRenderer.barWidth
         let narrowQuota = QuotaMenuBarRenderer.barWidth
             * QuotaMenuBarRenderer.compactBarWidthFactor
-        let gap = MenuBarStatusRenderer.groupGap
 
-        print("=== #1845 measured menu bar icon widths, in points ===")
-        print("projects | Lights | Usage | Combined | Compact")
-        for projects in [1, 2, 3, 5, 6, 8] {
-            let sessions = sessionsAcrossProjects(projects)
-            // XCTUnwrap, not `?? 0`: a renderer that regressed to nil would
-            // otherwise print 0.00 and pass, making "could not measure" and
-            // "measured zero" the same output — the exact failure this file
-            // guards against for its source reader.
-            let dots = try XCTUnwrap(MenuBarStatusRenderer.buildStatusSVG(
-                sessions: sessions, projectGroupOrder: []
-            )).width
-            let aggregate = try XCTUnwrap(MenuBarStatusRenderer.buildAggregateStatusSVG(
-                sessions: sessions
-            )).width
-            // Usage hides the dots unless the quota is unrenderable; Combined
-            // shows dots + gap + narrow quota; Compact is dots only.
-            print(String(
-                format: "%8d | %6.2f | %5.2f | %8.2f | %7.2f",
-                projects, dots, fullQuota, dots + gap + narrowQuota, aggregate
-            ))
+        let columns: [(String, MenuBarAppearance)] = MenuBarStyle.allCases.flatMap { style in
+            [false, true].map { compact in
+                ("\(style.label)\(compact ? "+C" : "")",
+                 MenuBarAppearance(style: style, isCompact: compact))
+            }
         }
-        print(String(format: "=== dot half measured from the renderers; quota half "
-                     + "from QuotaMenuBarRenderer's constants (full %.2f, narrow %.2f) ===",
+        XCTAssertEqual(columns.count, MenuBarStyle.allCases.count * 2,
+                       "every style × modifier combination must be measured")
+
+        print("=== #1852 measured menu bar icon widths, in points ===")
+        print("projects | " + columns.map { $0.0.padded(to: 8) }.joined(separator: " | "))
+        for projects in [1, 2, 3, 5, 6, 8] {
+            // Exactly one project carries a renderable quota, so the styles
+            // that draw quota bars actually have one to draw. The earlier
+            // fixture here carried NO rate-limit data at all, which meant the
+            // Usage and Combined columns described a scenario the fixture did
+            // not contain (#1852 review).
+            let sessions = MenuBarFixtures.acrossProjectsWithQuota(projects)
+            let cells = try columns.map { column -> String in
+                // XCTUnwrap, not `?? 0`: an icon that regressed to nil would
+                // otherwise print 0.00 and pass, making "could not measure"
+                // and "measured zero" the same output — the exact failure this
+                // file guards against for its source reader.
+                let icon = try XCTUnwrap(
+                    MenuBarImageBuilder.iconImage(
+                        appearance: column.1, sessions: sessions,
+                        projectGroupOrder: [], providerKey: nil, now: now
+                    ),
+                    "\(column.0) at \(projects) projects rendered no icon"
+                )
+                return String(format: "%.2f", icon.size.width).padded(to: 8)
+            }
+            print(String(format: "%8d | ", projects) + cells.joined(separator: " | "))
+        }
+        print(String(format: "=== measured from MenuBarImageBuilder.iconImage — the same "
+                     + "composition the app ships; quota halves are %.2f full / %.2f narrow "
+                     + "per QuotaMenuBarRenderer's constants; +C = compact modifier on ===",
                      fullQuota, narrowQuota))
     }
 
@@ -518,6 +614,116 @@ final class MenuBarCompactStyleTests: XCTestCase {
         XCTAssertNil(defaults.object(forKey: newKey))
     }
 
+    // MARK: - Migrating off #1849's Compact style (acceptance criterion 4)
+
+    /// Mutation-proved: delete either `defaults.set(...)` line in
+    /// `MenuBarAppearance.migrateLegacyCompactStyle` and this goes red.
+    ///
+    /// Why it matters: `"compact"` does not parse as a style in this build, so
+    /// `MenuBarStyle.current(in:)` falls back to `.lights` with the modifier OFF.
+    /// Without the migration, the one group of users who had explicitly asked
+    /// for a narrow icon would silently get the widest per-project layout back.
+    func testLegacyCompactStyleIsCarriedOverToTheModifier() {
+        let defaults = InMemoryDefaults()
+        defaults.set(MenuBarAppearance.legacyCompactStyleRawValue,
+                     forKey: MenuBarStyle.storageKey)
+
+        XCTAssertTrue(MenuBarAppearance.migrateLegacyCompactStyle(in: defaults),
+                      "a persisted Compact style must be carried over")
+
+        let migrated = MenuBarAppearance.current(in: defaults)
+        XCTAssertEqual(migrated.style, .lights,
+                       "Compact showed dots and no quota bars — that is Lights")
+        XCTAssertTrue(migrated.isCompact, "and the modifier must be turned on")
+        // The stored value is the parseable one, not left as "compact".
+        XCTAssertEqual(defaults.string(forKey: MenuBarStyle.storageKey),
+                       MenuBarStyle.lights.rawValue)
+        XCTAssertTrue(defaults.bool(forKey: MenuBarAppearance.compactStorageKey))
+    }
+
+    /// Mutation-proved: drop the `guard` in `migrateLegacyCompactStyle` and
+    /// this goes red — the migration would then force the modifier on for
+    /// every user on every launch, overwriting a deliberate "off".
+    func testCompactStyleMigrationIsIdempotentAndLeavesOtherChoicesAlone() {
+        let defaults = InMemoryDefaults()
+        defaults.set(MenuBarAppearance.legacyCompactStyleRawValue,
+                     forKey: MenuBarStyle.storageKey)
+        XCTAssertTrue(MenuBarAppearance.migrateLegacyCompactStyle(in: defaults))
+
+        // Second launch: nothing left to carry over.
+        XCTAssertFalse(MenuBarAppearance.migrateLegacyCompactStyle(in: defaults),
+                       "the migration must not run twice")
+
+        // And a user who then turns the modifier back off keeps it off.
+        defaults.set(false, forKey: MenuBarAppearance.compactStorageKey)
+        XCTAssertFalse(MenuBarAppearance.migrateLegacyCompactStyle(in: defaults))
+        XCTAssertFalse(defaults.bool(forKey: MenuBarAppearance.compactStorageKey),
+                       "a deliberate off must survive every later launch")
+    }
+
+    /// Mutation-proved: drop the `guard` and this goes red for every row —
+    /// a fresh install and a user on any shipped style must be untouched,
+    /// which is the same compatibility bound the render lock states.
+    func testCompactStyleMigrationIsANoOpForEveryoneElse() {
+        // Fresh install: no keys invented.
+        let fresh = InMemoryDefaults()
+        XCTAssertFalse(MenuBarAppearance.migrateLegacyCompactStyle(in: fresh))
+        XCTAssertNil(fresh.object(forKey: MenuBarStyle.storageKey))
+        XCTAssertNil(fresh.object(forKey: MenuBarAppearance.compactStorageKey))
+
+        // A user on any shipped style keeps it, with the modifier untouched.
+        for style in MenuBarStyle.allCases {
+            let defaults = InMemoryDefaults()
+            defaults.set(style.rawValue, forKey: MenuBarStyle.storageKey)
+            XCTAssertFalse(MenuBarAppearance.migrateLegacyCompactStyle(in: defaults),
+                           "\(style) is not a legacy value")
+            XCTAssertEqual(defaults.string(forKey: MenuBarStyle.storageKey), style.rawValue)
+            XCTAssertNil(defaults.object(forKey: MenuBarAppearance.compactStorageKey),
+                         "\(style): the migration must not invent a modifier key")
+        }
+    }
+
+    // MARK: - The icon repaints when a menu-bar setting changes
+
+    /// `MenuBarController` rebuilds the icon when `MenuBarIconSettings`
+    /// changes, and `UserDefaults.didChangeNotification` fires for every write
+    /// — so a setting missing from that snapshot leaves the icon stale until
+    /// something unrelated repaints it, with nothing failing. Before #1852 the
+    /// comparison was three hand-listed fields; the compact modifier was the
+    /// fourth setting, and this is what makes forgetting it impossible.
+    ///
+    /// Mutation-proved: drop any field from `MenuBarIconSettings.current` (or
+    /// hard-code `isCompact: false` there) and the matching row goes red.
+    func testEveryMenuBarSettingIsVisibleToTheChangeCheck() {
+        // (key, a value that differs from the unset default)
+        let mutations: [(String, Any)] = [
+            (MenuBarStyle.storageKey, MenuBarStyle.combined.rawValue),
+            (MenuBarAppearance.compactStorageKey, true),
+            (MenuBarQuotaProvider.storageKey, "anthropic"),
+            (QuotaVisualStyle.storageKey, QuotaVisualStyle.circle.rawValue),
+        ]
+        for (key, value) in mutations {
+            let defaults = InMemoryDefaults()
+            let before = MenuBarIconSettings.current(in: defaults)
+            defaults.set(value, forKey: key)
+            let after = MenuBarIconSettings.current(in: defaults)
+            XCTAssertNotEqual(before, after,
+                              "writing \(key) must be visible to the icon's change check")
+        }
+    }
+
+    /// The counterpart: an unrelated default must NOT repaint the icon.
+    /// Without it the test above would still pass against a snapshot that
+    /// simply reported "changed" every time, which would busy-rebuild the
+    /// icon on every write in the app.
+    func testAnUnrelatedDefaultDoesNotRepaintTheIcon() {
+        let defaults = InMemoryDefaults()
+        let before = MenuBarIconSettings.current(in: defaults)
+        defaults.set(true, forKey: "showQuotaForecast")
+        XCTAssertEqual(before, MenuBarIconSettings.current(in: defaults),
+                       "only menu-bar icon settings may trigger a repaint")
+    }
+
     // MARK: - The wiring, pinned by source
 
     /// `MenuBarController` is the only place a real `NSStatusItem` is created,
@@ -559,8 +765,33 @@ final class MenuBarCompactStyleTests: XCTestCase {
                       "the migration must run BEFORE the status item is created")
     }
 
+    /// The compact-style migration has its own deadline, and it is a different
+    /// one: it must run before the controller snapshots `MenuBarIconSettings`
+    /// as "last seen". Snapshotting first would capture the pre-migration
+    /// style, so the very next unrelated defaults write would read as a change
+    /// and repaint — harmless, but it means the ordering is load-bearing and
+    /// nothing else would notice it being wrong.
+    ///
+    /// Pinned by source for the same reason as the identity wiring above: no
+    /// test constructs a real `MenuBarController`.
+    ///
+    /// Mutation-proved: delete the `migrateLegacyCompactStyle` call from
+    /// `MenuBarController.swift`, or move it below the `lastIconSettings`
+    /// assignment, and this goes red.
+    func testMenuBarControllerMigratesTheLegacyCompactStyleBeforeSnapshotting() throws {
+        let code = try Self.codeLines(at: Self.menuBarControllerPath)
+        XCTAssertTrue(
+            code.contains("MenuBarAppearance.migrateLegacyCompactStyle(in: UserDefaults.standard)"),
+            "MenuBarController must carry a legacy Compact style over at launch"
+        )
+        let migrate = try XCTUnwrap(code.range(of: "migrateLegacyCompactStyle"))
+        let snapshot = try XCTUnwrap(code.range(of: "self.lastIconSettings = MenuBarIconSettings"))
+        XCTAssertTrue(migrate.lowerBound < snapshot.lowerBound,
+                      "the migration must run BEFORE the settings snapshot is taken")
+    }
+
     /// The Settings gate that decides whether the quota sub-pickers appear
-    /// now asks the style (`showsQuotaBars`) instead of testing `!= .lights`.
+    /// asks the appearance (`showsQuotaBars`) instead of testing `!= .lights`.
     /// `SettingsViewTests` renders the view but samples only corner-pixel
     /// opacity, and there is no Settings snapshot suite — so swapping
     /// `showsQuotaBars` for its neighbour `usesNarrowQuotaBars` would silently
@@ -570,36 +801,150 @@ final class MenuBarCompactStyleTests: XCTestCase {
     /// Mutation-proved: change the property named at `SettingsView.swift`'s
     /// quota-section gate and this goes red.
     func testSettingsGatesTheQuotaSubPickersOnShowsQuotaBars() throws {
-        let source = try Self.source(at: "platforms/macos/Irrlicht/Views/SettingsView.swift")
+        let code = try Self.codeLines(at: Self.settingsViewPath)
         XCTAssertTrue(
-            source.contains("if (MenuBarStyle(rawValue: menuBarStyle) ?? .lights).showsQuotaBars {"),
-            "the quota sub-pickers must be gated on the style's own showsQuotaBars"
+            code.contains("if menuBarAppearance.showsQuotaBars {"),
+            "the quota sub-pickers must be gated on the appearance's own showsQuotaBars"
         )
         // And the property means what the gate needs it to mean: exactly the
-        // two styles that shipped with those pickers visible.
+        // two styles that shipped with those pickers visible, on both settings
+        // of the modifier — it is a content question, not a density one.
         for style in MenuBarStyle.allCases {
-            XCTAssertEqual(style.showsQuotaBars, style == .usage || style == .combined,
-                           "\(style) quota-picker visibility")
+            for compact in [false, true] {
+                XCTAssertEqual(
+                    MenuBarAppearance(style: style, isCompact: compact).showsQuotaBars,
+                    style == .usage || style == .combined,
+                    "\(style) compact=\(compact) quota-picker visibility"
+                )
+            }
         }
     }
 
-    /// Mutation-proved: invert or swap either condition in
-    /// `MenuBarImageBuilder`'s two extracted seams and this goes red. Pins
-    /// that `combinedImage` actually ROUTES through them rather than
-    /// re-deciding inline — the behavioral tests above cannot see a copy of
-    /// the logic left behind at the call site.
+    /// The Settings surface actually offers the modifier, and offers it as one
+    /// control rather than as a fourth segment. Nothing else can see this: the
+    /// segmented control is built from `MenuBarStyle.allCases`, so a missing
+    /// toggle leaves a perfectly valid three-segment picker and a setting the
+    /// user can never reach.
+    ///
+    /// Mutation-proved: delete the `LeadingToggle` for `$menuBarCompact` from
+    /// `SettingsView.swift` and this goes red.
+    func testSettingsOffersTheCompactModifierAsAToggle() throws {
+        let code = try Self.codeLines(at: Self.settingsViewPath)
+        XCTAssertTrue(code.contains("isOn: $menuBarCompact"),
+                      "Settings must offer the compact modifier as its own toggle")
+        XCTAssertTrue(
+            code.contains("@AppStorage(MenuBarAppearance.compactStorageKey)"),
+            "and bind it to the modifier's own storage key"
+        )
+        // The styles keep their own control: three segments, not four.
+        XCTAssertTrue(code.contains("labels: MenuBarStyle.allCases.map(\\.label)"),
+                      "the style picker must stay derived from allCases")
+    }
+
+    /// **This pin covers ROUTING only, and that limit is itself a finding.**
+    ///
+    /// Review of #1852 measured what a source-text pin cannot do. An earlier
+    /// version of this test tried to cover `combinedImage`'s call sites by
+    /// pinning their text — because `combinedImage` needs a live
+    /// `SessionManager` and no test can call it — and four mutations walked
+    /// straight through: `.init(…)` evaded a ban on the literal
+    /// `MenuBarAppearance(`; a hand-off count taken over the whole file was
+    /// satisfied by an unrelated fourth occurrence; and a ternary inversion
+    /// and a same-typed argument swap were invisible to both. A `contains`
+    /// check sees the call, never what the call is *given* or what is *done
+    /// with* the result.
+    ///
+    /// The composition moved into `MenuBarImageBuilder.iconImage`, and the
+    /// semantics now live in
+    /// `MenuBarImageBuilderTests.testComposedIconForEveryStyleAndModifier` and
+    /// `…testComposedIconPutsTheDotsBeforeTheQuotaBars`, which call it and
+    /// assert the composed image. What remains here is the cheap structural
+    /// claim those cannot make: the decisions still live in the named seams
+    /// rather than being re-derived inline.
+    ///
+    /// Mutation-proved: delete any of the three seam calls from
+    /// `MenuBarImageBuilder.iconImage` and this goes red.
     func testImageBuilderRoutesBothHalvesThroughTheExtractedSeams() throws {
-        let source = try Self.source(at: "platforms/macos/Irrlicht/App/MenuBarImageBuilder.swift")
-        XCTAssertTrue(source.contains("let computedDotsImage = dotsImage("),
-                      "combinedImage must route the dot half through dotsImage(style:...)")
-        XCTAssertTrue(source.contains("let quotaImage = quotaImage("),
-                      "combinedImage must route the quota half through quotaImage(style:...)")
-        XCTAssertFalse(source.contains("style == .lights"),
-                       "no style decision may go back to a non-exhaustive comparison")
-        XCTAssertFalse(source.contains("style == .combined"),
-                       "no style decision may go back to a non-exhaustive comparison")
-        XCTAssertFalse(source.contains("style != .usage"),
-                       "no style decision may go back to a non-exhaustive comparison")
+        let code = try Self.codeLines(at: Self.imageBuilderPath)
+        XCTAssertTrue(code.contains("let computedDotsImage = dotsImage("),
+                      "iconImage must route the dot half through dotsImage(appearance:...)")
+        XCTAssertTrue(code.contains("let builtQuotaImage = quotaImage("),
+                      "iconImage must route the quota half through quotaImage(appearance:...)")
+        XCTAssertTrue(code.contains("let shownDotsImage = showsDots("),
+                      "iconImage must route the dot-visibility decision through showsDots")
+        XCTAssertTrue(code.contains("appearance: MenuBarAppearance.current"),
+                      "combinedImage must read the appearance once, from one place")
+
+        // Negative pins read the RAW source, never the comment-stripped form.
+        // `codeLines` is a naive stripper — it also truncates a line at a `//`
+        // inside a string literal — and for a "must NOT appear" assertion,
+        // losing text can only turn a real hit into a silent PASS. A banned
+        // construct sitting in a comment is a false positive somebody can see;
+        // one hidden by an over-strip is a false negative nobody can. AGENTS.md:
+        // a validator that cannot parse its input checks MORE, never less.
+        //
+        // Derived from `allCases` × both operators rather than hand-listing the
+        // three spellings that happened to exist before #1845 — the same
+        // reasoning the enum's own doc gives for switching instead of
+        // comparing, applied to the test that enforces it.
+        let raw = try Self.source(at: Self.imageBuilderPath)
+        for style in MenuBarStyle.allCases {
+            for op in ["==", "!="] {
+                let comparison = "style \(op) .\(style.rawValue)"
+                XCTAssertFalse(raw.contains(comparison),
+                               "no style decision may go back to the non-exhaustive "
+                                   + "`\(comparison)` — switch over MenuBarAppearance instead")
+            }
+        }
+    }
+
+    /// The vacuity guard for `codeLines`, and the reason it exists.
+    ///
+    /// On `main` the seam pin above asserted `"let quotaImage = quotaImage("`
+    /// — a string that appears in `MenuBarImageBuilder.swift` exactly once,
+    /// **inside a comment** explaining why the local is NOT named that. The
+    /// real call site is `let builtQuotaImage = quotaImage(`. So the
+    /// assertion passed while proving nothing about the call site: deleting
+    /// the routing entirely would have left it green as long as the
+    /// explanatory comment stayed. (Verified on 183a7222 with
+    /// `git show …:MenuBarImageBuilder.swift | grep -n`: one hit, at the
+    /// comment.)
+    ///
+    /// `codeLines` strips `//` comments so a source pin cannot be satisfied by
+    /// prose. Mutation-proved: make `stripComments` return its input unchanged
+    /// and the comment-only assertion below goes red.
+    ///
+    /// The fixture is a literal rather than a real file. An earlier version
+    /// asserted against the actual comment in `MenuBarImageBuilder.swift` that
+    /// #1849's pin had matched, which made rewording an explanatory comment
+    /// break an unrelated test — a loud failure, but a needless coupling.
+    func testSourcePinsCannotBeSatisfiedByAComment() throws {
+        // The shape of #1849's defect: the searched-for text present ONLY
+        // inside a comment, with different real code on the same line.
+        let fixture = """
+            let builtQuotaImage = quotaImage(  // unlike let quotaImage = quotaImage(
+            static func quotaImage(
+            """
+        let stripped = MenuBarCompactStyleTests.strippedForTesting(fixture)
+
+        XCTAssertTrue(fixture.contains("let quotaImage = quotaImage("),
+                      "the fixture must contain the comment-only string, "
+                          + "or this test exercises nothing")
+        XCTAssertFalse(stripped.contains("let quotaImage = quotaImage("),
+                       "a source pin must not be satisfiable by a string that only "
+                           + "appears inside a comment")
+        // And stripping must not have eaten the code: "could not look" and
+        // "found nothing" must stay distinguishable.
+        XCTAssertTrue(stripped.contains("let builtQuotaImage = quotaImage("),
+                      "stripComments must keep the code before the comment")
+        XCTAssertTrue(stripped.contains("static func quotaImage("),
+                      "stripComments must keep comment-free lines intact")
+
+        // The real file still parses to real code, so the positive pins above
+        // are reading something.
+        let code = try Self.codeLines(at: Self.imageBuilderPath)
+        XCTAssertTrue(code.contains("static func quotaImage("),
+                      "codeLines must still return the actual code")
     }
 
     /// A source file this suite cannot read is a FAILURE, never a quiet pass.
@@ -618,6 +963,50 @@ final class MenuBarCompactStyleTests: XCTestCase {
 
     private static let menuBarControllerPath =
         "platforms/macos/Irrlicht/App/MenuBarController.swift"
+    private static let imageBuilderPath =
+        "platforms/macos/Irrlicht/App/MenuBarImageBuilder.swift"
+    private static let settingsViewPath =
+        "platforms/macos/Irrlicht/Views/SettingsView.swift"
+
+    /// The source with `//` comment text removed. **For POSITIVE pins only.**
+    ///
+    /// A pin that greps the raw file can be satisfied by a comment that merely
+    /// *mentions* the code it is looking for, which is not a hypothetical:
+    /// #1849's pin for the quota seam matched only an explanatory comment and
+    /// never the call site (see `testSourcePinsCannotBeSatisfiedByAComment`).
+    ///
+    /// Deliberately naive: it strips from the first `//` on a line to the end
+    /// of that line, and knows nothing about `/* */` or about `//` inside a
+    /// string literal. That last case is live rather than theoretical — in one
+    /// of the three files pinned here, `SettingsView.swift`'s
+    /// `"ws://localhost:7839"` placeholder is truncated at `= "ws:` — so the
+    /// stripper really does eat code sometimes.
+    ///
+    /// Which is exactly why **negative pins must read `source(at:)` instead.**
+    /// For a positive pin, over-stripping can only cause a spurious FAILURE,
+    /// which somebody sees and fixes. For a `XCTAssertFalse(contains(…))` pin
+    /// it would cause a silent PASS — the check quietly doing less, which is
+    /// the direction AGENTS.md rules out: a validator that cannot parse its
+    /// input checks MORE, never less.
+    private static func codeLines(at relativePath: String) throws -> String {
+        stripComments(from: try source(at: relativePath))
+    }
+
+    /// Test-visible alias, so `testSourcePinsCannotBeSatisfiedByAComment` can
+    /// exercise the stripper against a literal.
+    static func strippedForTesting(_ source: String) -> String { stripComments(from: source) }
+
+    /// Split out from `codeLines` so the guard above can exercise it against a
+    /// literal, without making a comment in shipped source load-bearing.
+    private static func stripComments(from source: String) -> String {
+        source
+            .split(separator: "\n", omittingEmptySubsequences: false)
+            .map { line -> Substring in
+                guard let comment = line.range(of: "//") else { return line }
+                return line[line.startIndex..<comment.lowerBound]
+            }
+            .joined(separator: "\n")
+    }
 
     private static func source(at relativePath: String) throws -> String {
         let url = repoRoot().appendingPathComponent(relativePath)
@@ -635,6 +1024,14 @@ final class MenuBarCompactStyleTests: XCTestCase {
             .deletingLastPathComponent()          // .../platforms/macos
             .deletingLastPathComponent()          // .../platforms
             .deletingLastPathComponent()          // repo root
+    }
+}
+
+private extension String {
+    /// Right-align into a fixed-width column so the measured width table
+    /// prints as a table rather than as ragged text.
+    func padded(to width: Int) -> String {
+        count >= width ? self : String(repeating: " ", count: width - count) + self
     }
 }
 

--- a/platforms/macos/Tests/MenuBarFixtures.swift
+++ b/platforms/macos/Tests/MenuBarFixtures.swift
@@ -1,0 +1,106 @@
+import Foundation
+@testable import Irrlicht
+
+/// The session fixtures the two menu-bar suites both build icons from.
+///
+/// `MenuBarCompactStyleTests` and `MenuBarImageBuilderTests` assert the SAME
+/// derived widths — 18.50 for the aggregate dot, 90.00 for the per-project
+/// layout, and the quota half's own constants — one through the extracted
+/// seams and one through the composed icon. Two private copies of the fixture
+/// is how those two suites quietly stop testing the same thing:
+/// `TestAgentBranding`'s own doc states the rule this file follows, that "a
+/// change applied to one copy and not the other would leave one suite green
+/// against a fixture the other no longer uses".
+///
+/// That risk is not hypothetical here. `testShippedStylesRenderExactlyWhatThey`
+/// `DidBeforeWhenCompactIsOff` is #1852's named compatibility LOCK and
+/// `testComposedIconForEveryStyleAndModifier` is the composed-icon check that
+/// closed four surviving mutations; both pin the same numbers, and they must be
+/// pinning them against the same sessions.
+enum MenuBarFixtures {
+
+    /// The instant every fixture here is built relative to.
+    /// `PinnedNowSnapshot.referenceNow` rather than a local literal, so these
+    /// sessions sit at the same place on the timeline as
+    /// `QuotaMenuBarRendererTests`' — the suite whose constants these widths
+    /// are derived from.
+    static let now = PinnedNowSnapshot.referenceNow
+
+    static func session(
+        id: String,
+        state: SessionState.State = .working,
+        project: String,
+        parentSessionId: String? = nil
+    ) -> SessionState {
+        SessionState(
+            id: "sess_\(id)",
+            state: state,
+            model: "claude-3.7-sonnet",
+            cwd: "/Users/test/projects/\(project)",
+            projectName: project,
+            firstSeen: now,
+            updatedAt: now,
+            parentSessionId: parentSessionId
+        )
+    }
+
+    /// `count` sessions spread one-per-project, which is the layout that makes
+    /// the per-project renderer widest for a given session count.
+    ///
+    /// None of them carries rate-limit data, so the quota half cannot render —
+    /// which is exactly what makes this the fixture for the `.usage` fallback
+    /// case, and what makes it the WRONG fixture for measuring an icon that is
+    /// supposed to have a quota half.
+    static func acrossProjects(_ count: Int) -> [SessionState] {
+        (0..<count).map { session(id: "s\($0)", project: "p\($0)") }
+    }
+
+    /// A session carrying a renderable rate-limit snapshot, so the quota half
+    /// of the icon has something to draw. Same shape `QuotaMenuBarRendererTests`
+    /// uses.
+    static func sessionWithQuota() -> SessionState {
+        let metrics = SessionMetrics(
+            elapsedSeconds: 0,
+            totalTokens: 0,
+            modelName: "claude-sonnet",
+            contextWindow: nil,
+            contextUtilization: 0,
+            pressureLevel: "safe",
+            contextWindowUnknown: nil,
+            estimatedCostUSD: nil,
+            lastAssistantText: nil,
+            tasks: nil,
+            rateLimit: RateLimitInfo(
+                windows: [
+                    RateLimitWindowInfo(
+                        usedPercent: 20, windowMinutes: 300,
+                        resetsAt: now.addingTimeInterval(3600)
+                    ),
+                    RateLimitWindowInfo(
+                        usedPercent: 40, windowMinutes: 10080,
+                        resetsAt: now.addingTimeInterval(3 * 86400)
+                    ),
+                ],
+                sampledAt: now
+            )
+        )
+        return SessionState(
+            id: "sess_quota",
+            state: .working,
+            model: "claude-sonnet",
+            cwd: "/Users/test/projects/quota",
+            projectName: "quota",
+            firstSeen: now,
+            updatedAt: now,
+            metrics: metrics,
+            adapter: "claude-code"
+        )
+    }
+
+    /// `projects` projects in total, exactly one of which carries a renderable
+    /// quota — so BOTH halves of the icon have something to draw and the
+    /// per-project dot count is still `projects`.
+    static func acrossProjectsWithQuota(_ projects: Int) -> [SessionState] {
+        acrossProjects(projects - 1) + [sessionWithQuota()]
+    }
+}

--- a/platforms/macos/Tests/MenuBarImageBuilderTests.swift
+++ b/platforms/macos/Tests/MenuBarImageBuilderTests.swift
@@ -84,13 +84,23 @@ final class MenuBarImageBuilderTests: XCTestCase {
 
     // MARK: - shouldShowDotsInUsageStyle (issue #909 review fix; #1802's error arm)
 
+    /// The appearance these tests exercise. `isCompact` defaults to false so
+    /// every assertion below keeps meaning exactly what it meant before #1852
+    /// made the modifier a separate axis — the LOCKs stay locks.
+    private func appearance(
+        _ style: MenuBarStyle, compact: Bool = false
+    ) -> MenuBarAppearance {
+        MenuBarAppearance(style: style, isCompact: compact)
+    }
+
     /// `.usage` style with a renderable dots image but no quota yet must
     /// not collapse to the "no sessions" icon — see the comment in
     /// `combinedImage`. LOCK: pre-#1802 behaviour that must not change.
     func testFallsBackToDotsWhenUsageStyleHasNoQuotaButDotsRendered() {
         let dots = NSImage(size: NSSize(width: 10, height: 18))
         XCTAssertTrue(MenuBarImageBuilder.shouldShowDotsInUsageStyle(
-            style: .usage, quotaImage: nil, dotsImage: dots, hasErroredSession: false
+            appearance: appearance(.usage), quotaImage: nil, dotsImage: dots,
+            hasErroredSession: false
         ))
     }
 
@@ -100,7 +110,8 @@ final class MenuBarImageBuilderTests: XCTestCase {
         let quota = NSImage(size: NSSize(width: 10, height: 18))
         let dots = NSImage(size: NSSize(width: 10, height: 18))
         XCTAssertFalse(MenuBarImageBuilder.shouldShowDotsInUsageStyle(
-            style: .usage, quotaImage: quota, dotsImage: dots, hasErroredSession: false
+            appearance: appearance(.usage), quotaImage: quota, dotsImage: dots,
+            hasErroredSession: false
         ))
     }
 
@@ -110,17 +121,20 @@ final class MenuBarImageBuilderTests: XCTestCase {
     /// not a raw session count that doesn't guarantee dots render.
     func testDoesNotFallBackWhenUsageStyleHasNoRenderableDotsEither() {
         XCTAssertFalse(MenuBarImageBuilder.shouldShowDotsInUsageStyle(
-            style: .usage, quotaImage: nil, dotsImage: nil, hasErroredSession: false
+            appearance: appearance(.usage), quotaImage: nil, dotsImage: nil,
+            hasErroredSession: false
         ))
     }
 
     func testDoesNotFallBackForLightsOrCombinedStyles() {
         let dots = NSImage(size: NSSize(width: 10, height: 18))
         XCTAssertFalse(MenuBarImageBuilder.shouldShowDotsInUsageStyle(
-            style: .lights, quotaImage: nil, dotsImage: dots, hasErroredSession: false
+            appearance: appearance(.lights), quotaImage: nil, dotsImage: dots,
+            hasErroredSession: false
         ))
         XCTAssertFalse(MenuBarImageBuilder.shouldShowDotsInUsageStyle(
-            style: .combined, quotaImage: nil, dotsImage: dots, hasErroredSession: false
+            appearance: appearance(.combined), quotaImage: nil, dotsImage: dots,
+            hasErroredSession: false
         ))
     }
 
@@ -140,7 +154,8 @@ final class MenuBarImageBuilderTests: XCTestCase {
         let quota = NSImage(size: NSSize(width: 20, height: 18))
         let dots = NSImage(size: NSSize(width: 10, height: 18))
         XCTAssertTrue(MenuBarImageBuilder.shouldShowDotsInUsageStyle(
-            style: .usage, quotaImage: quota, dotsImage: dots, hasErroredSession: true
+            appearance: appearance(.usage), quotaImage: quota, dotsImage: dots,
+            hasErroredSession: true
         ))
     }
 
@@ -148,27 +163,208 @@ final class MenuBarImageBuilderTests: XCTestCase {
     func testNoDotsImageMeansNoDotsEvenWithAnError() {
         let quota = NSImage(size: NSSize(width: 20, height: 18))
         XCTAssertFalse(MenuBarImageBuilder.shouldShowDotsInUsageStyle(
-            style: .usage, quotaImage: quota, dotsImage: nil, hasErroredSession: true
+            appearance: appearance(.usage), quotaImage: quota, dotsImage: nil,
+            hasErroredSession: true
         ))
     }
 
+    /// The WHOLE dot-visibility decision, across every style × the modifier.
+    ///
+    /// `combinedImage` used to spell this inline as
+    /// `!appearance.hidesDotsWhenQuotaIsRenderable || shouldShowDotsInUsageStyle(…)`,
+    /// where nothing could reach it: `combinedImage` is private and needs a
+    /// live `SessionManager`. Measured during #1852's mutation battery —
+    /// swapping that first predicate for its neighbour `aggregatesSessionDots`
+    /// left all 543 tests green while making `.usage` draw its dots
+    /// unconditionally. `showsDots` is the extraction that closes it.
+    ///
+    /// Mutation-proved: replace `hidesDotsWhenQuotaIsRenderable` in
+    /// `MenuBarImageBuilder.showsDots` with any other predicate and this goes
+    /// red.
+    func testShowsDotsAcrossEveryStyleAndDensity() {
+        let quota = NSImage(size: NSSize(width: 20, height: 18))
+        let dots = NSImage(size: NSSize(width: 10, height: 18))
+        for style in MenuBarStyle.allCases {
+            for compact in [false, true] {
+                // Only `.usage` ever withholds its dots, and only while the
+                // quota is renderable and nothing is errored. Density never
+                // enters into it.
+                let expected = style != .usage
+                XCTAssertEqual(
+                    MenuBarImageBuilder.showsDots(
+                        appearance: appearance(style, compact: compact),
+                        quotaImage: quota, dotsImage: dots, hasErroredSession: false
+                    ),
+                    expected,
+                    "\(style) compact=\(compact) with a renderable quota"
+                )
+                // With no quota to show, every style draws its dots.
+                XCTAssertTrue(
+                    MenuBarImageBuilder.showsDots(
+                        appearance: appearance(style, compact: compact),
+                        quotaImage: nil, dotsImage: dots, hasErroredSession: false
+                    ),
+                    "\(style) compact=\(compact) with no renderable quota"
+                )
+                // And an errored session always brings them back (#1802).
+                XCTAssertTrue(
+                    MenuBarImageBuilder.showsDots(
+                        appearance: appearance(style, compact: compact),
+                        quotaImage: quota, dotsImage: dots, hasErroredSession: true
+                    ),
+                    "\(style) compact=\(compact) with an errored session"
+                )
+            }
+        }
+    }
+
+    // MARK: - The composed icon (#1852 review)
+
+    // Fixtures come from MenuBarFixtures, shared with MenuBarCompactStyleTests:
+    // both suites assert the same derived widths, so a private second copy is
+    // how they would quietly stop testing the same thing (see that file).
+
+    private let fixedNow = MenuBarFixtures.now
+
+    private func icon(_ appearance: MenuBarAppearance, sessions: [SessionState]) -> NSImage? {
+        MenuBarImageBuilder.iconImage(
+            appearance: appearance, sessions: sessions, projectGroupOrder: [],
+            providerKey: nil, now: fixedNow
+        )
+    }
+
+    /// The WHOLE composed icon, for every style × the modifier.
+    ///
+    /// This is the test the #1852 review asked for. Four mutations inside the
+    /// old inline composition survived the entire suite, because every existing
+    /// test called the extracted seams DIRECTLY and nothing exercised what the
+    /// seams were handed or what was done with their results. Asserting the
+    /// composed width closes three of the four; the ordering assertion below
+    /// closes the fourth.
+    ///
+    /// The `compact: false` column is a **LOCK** — those three widths are what
+    /// each style composed before #1852 existed.
+    ///
+    /// Mutation-proved: invert `? computedDotsImage : nil`, or swap the
+    /// `quotaImage:`/`dotsImage:` arguments to `showsDots`, in
+    /// `MenuBarImageBuilder.iconImage` — either turns this red.
+    func testComposedIconForEveryStyleAndModifier() throws {
+        let sessions = MenuBarFixtures.acrossProjectsWithQuota(7)
+        let full = QuotaMenuBarRenderer.labelWidth + QuotaMenuBarRenderer.gap
+            + QuotaMenuBarRenderer.barWidth
+        let narrow = QuotaMenuBarRenderer.barWidth * QuotaMenuBarRenderer.compactBarWidthFactor
+        let gap = MenuBarStatusRenderer.groupGap
+        // 7 projects (6 + the quota carrier) exceeds maxVisibleGroups, so the
+        // per-project half is at its 90.00 plateau; the aggregate is constant.
+        let dots: CGFloat = 90.0
+        let aggregate: CGFloat = 18.5
+
+        // (style, isCompact, expected composed width)
+        let expected: [(MenuBarStyle, Bool, CGFloat)] = [
+            (.lights, false, dots),                    // LOCK: dots only
+            (.usage, false, full),                     // LOCK: quota only, dots hidden
+            (.combined, false, dots + gap + narrow),   // LOCK: dots + narrow quota
+            (.lights, true, aggregate),
+            (.usage, true, narrow),
+            (.combined, true, aggregate + gap + narrow),
+        ]
+        XCTAssertEqual(expected.count, MenuBarStyle.allCases.count * 2,
+                       "every style × modifier combination must be composed here")
+        for (style, compact, width) in expected {
+            let composed = try XCTUnwrap(
+                icon(MenuBarAppearance(style: style, isCompact: compact), sessions: sessions),
+                "\(style) compact=\(compact) must compose an icon"
+            )
+            XCTAssertEqual(composed.size.width, width, accuracy: 0.01,
+                           "\(style) compact=\(compact) composed width")
+        }
+    }
+
+    /// `.usage` with sessions running but NO renderable quota composes to the
+    /// dots, never to nothing (#909's fallback, at both densities).
+    ///
+    /// **This is the case that discriminates the two `NSImage?` arguments of
+    /// `showsDots`.** With both halves present, swapping `quotaImage:` and
+    /// `dotsImage:` at the call site changes nothing — both are non-nil, so
+    /// both spellings answer the same. Only when exactly one is nil do they
+    /// diverge, which is why `testComposedIconForEveryStyleAndModifier` (whose
+    /// fixture always carries quota) could not see it: that swap survived the
+    /// full suite during #1852's review and again after the first fix.
+    ///
+    /// Mutation-proved: swap the `quotaImage:`/`dotsImage:` arguments to
+    /// `showsDots` in `MenuBarImageBuilder.iconImage` and this goes red —
+    /// `.usage` collapses to the "no sessions" icon while sessions run.
+    func testUsageComposesDotsWhenNoQuotaIsRenderable() throws {
+        // No rate-limit data anywhere, so the quota half cannot render.
+        let sessions = MenuBarFixtures.acrossProjects(6)
+        for compact in [false, true] {
+            let appearance = MenuBarAppearance(style: .usage, isCompact: compact)
+            let quota = MenuBarImageBuilder.quotaImage(
+                appearance: appearance, sessions: sessions, providerKey: nil, now: fixedNow
+            )
+            XCTAssertNil(quota, "the fixture must have no renderable quota, "
+                             + "or this test proves nothing about the fallback")
+            let composed = try XCTUnwrap(
+                icon(appearance, sessions: sessions),
+                "usage compact=\(compact) must fall back to the dots, not to nothing"
+            )
+            XCTAssertEqual(composed.size.width, compact ? 18.5 : 90.0, accuracy: 0.01,
+                           "usage compact=\(compact) fallback must be the dot half alone")
+        }
+    }
+
+    /// The dots go on the LEFT of the quota bars (#909's mockup ordering).
+    ///
+    /// Width cannot see this — `composeSideBySide` is commutative in width — so
+    /// this compares the composed icon's pixels against both orderings. The
+    /// first assertion is the vacuity guard: if the two orderings rendered
+    /// identically, the second would prove nothing.
+    ///
+    /// Mutation-proved: swap the two arguments to `composeSideBySide` in
+    /// `MenuBarImageBuilder.iconImage` and this goes red.
+    func testComposedIconPutsTheDotsBeforeTheQuotaBars() throws {
+        let sessions = MenuBarFixtures.acrossProjectsWithQuota(2)
+        let appearance = MenuBarAppearance(style: .combined, isCompact: false)
+        let dots = try XCTUnwrap(MenuBarImageBuilder.dotsImage(
+            appearance: appearance, sessions: sessions, projectGroupOrder: []
+        ))
+        let quota = try XCTUnwrap(MenuBarImageBuilder.quotaImage(
+            appearance: appearance, sessions: sessions, providerKey: nil, now: fixedNow
+        ))
+        let gap = MenuBarStatusRenderer.groupGap
+        let dotsFirst = try XCTUnwrap(MenuBarImageBuilder.composeSideBySide(dots, quota, gap: gap))
+        let quotaFirst = try XCTUnwrap(MenuBarImageBuilder.composeSideBySide(quota, dots, gap: gap))
+
+        XCTAssertNotEqual(dotsFirst.tiffRepresentation, quotaFirst.tiffRepresentation,
+                          "the two orderings must render differently, or the check below "
+                              + "cannot distinguish them")
+        let composed = try XCTUnwrap(icon(appearance, sessions: sessions))
+        XCTAssertEqual(composed.tiffRepresentation, dotsFirst.tiffRepresentation,
+                       "the icon must compose dots first, quota bars second")
+    }
+
     /// LOCK: every style OTHER than `.usage` never routes through this
-    /// decision at all, error or not.
+    /// decision at all, error or not — at either density.
     ///
     /// Derived from `allCases` rather than the hand-written
     /// `[MenuBarStyle.lights, .combined]` this used to be: that array was
-    /// complete when written and silently stale the moment `.compact` was
-    /// added (#1845), which is the same failure mode
+    /// complete when written and silently stale the moment a case was added
+    /// (#1845), which is the same failure mode
     /// `MenuBarStatusRenderer.segmentOrder` documents for state lists (#1797).
+    /// Since #1852 it also crosses the compact modifier, so a density choice
+    /// cannot quietly become a content one.
     func testOtherStylesAreUnaffectedByAnError() {
         let quota = NSImage(size: NSSize(width: 20, height: 18))
         let dots = NSImage(size: NSSize(width: 10, height: 18))
         let others = MenuBarStyle.allCases.filter { $0 != .usage }
         XCTAssertFalse(others.isEmpty, "allCases must yield at least one non-.usage style")
         for style in others {
-            XCTAssertFalse(MenuBarImageBuilder.shouldShowDotsInUsageStyle(
-                style: style, quotaImage: quota, dotsImage: dots, hasErroredSession: true
-            ), "\(style) must not be changed by an errored session")
+            for compact in [false, true] {
+                XCTAssertFalse(MenuBarImageBuilder.shouldShowDotsInUsageStyle(
+                    appearance: appearance(style, compact: compact), quotaImage: quota,
+                    dotsImage: dots, hasErroredSession: true
+                ), "\(style) compact=\(compact) must not be changed by an errored session")
+            }
         }
     }
 

--- a/platforms/macos/Tests/PersistentDefaultsLintTests.swift
+++ b/platforms/macos/Tests/PersistentDefaultsLintTests.swift
@@ -84,7 +84,7 @@ import XCTest
 ///
 /// Its declared limit is the same one a directory scan always has: a view
 /// calling a helper that reads the process domain for it is invisible here
-/// (`MenuBarStyle` and `ContextPressureThreshold` both contain such reads).
+/// (`MenuBarAppearance` and `ContextPressureThreshold` both contain such reads).
 /// That is a false NEGATIVE, so it cannot make the rule wrong — only incomplete
 /// — and closing it would need a call-graph, which is what the behavioural half
 /// (`PinnedAppStorageSnapshotTests`) covers for the sites that matter.

--- a/platforms/macos/Tests/PinnedAppStorageSnapshotTests.swift
+++ b/platforms/macos/Tests/PinnedAppStorageSnapshotTests.swift
@@ -182,6 +182,7 @@ final class PinnedAppStorageSnapshotTests: XCTestCase {
         @AppStorage("advancedSettingsExpanded") private var advancedSettingsExpanded: Bool = false
         @AppStorage("backchannelActivation") private var backchannelActivation: Bool = false
         @AppStorage(MenuBarStyle.storageKey) private var menuBarStyle: String = MenuBarStyle.lights.rawValue
+        @AppStorage(MenuBarAppearance.compactStorageKey) private var menuBarCompact: Bool = false
         @AppStorage(NotificationSettings.masterEnabledKey) private var notificationsEnabled: Bool = false
         @AppStorage(NotificationEvent.contextPressure.enabledKey) private var notifyOnContextPressure: Bool = false
         @AppStorage(NotificationEvent.ready.enabledKey) private var notifyOnReady: Bool = false
@@ -202,6 +203,7 @@ final class PinnedAppStorageSnapshotTests: XCTestCase {
                 "advancedSettingsExpanded": String(advancedSettingsExpanded),
                 "backchannelActivation": String(backchannelActivation),
                 MenuBarStyle.storageKey: menuBarStyle,
+                MenuBarAppearance.compactStorageKey: String(menuBarCompact),
                 NotificationSettings.masterEnabledKey: String(notificationsEnabled),
                 NotificationEvent.contextPressure.enabledKey: String(notifyOnContextPressure),
                 NotificationEvent.ready.enabledKey: String(notifyOnReady),
@@ -228,6 +230,7 @@ final class PinnedAppStorageSnapshotTests: XCTestCase {
         "advancedSettingsExpanded": true,
         "backchannelActivation": true,
         MenuBarStyle.storageKey: MenuBarStyle.combined.rawValue,
+        MenuBarAppearance.compactStorageKey: true,
         NotificationSettings.masterEnabledKey: true,
         NotificationEvent.contextPressure.enabledKey: true,
         NotificationEvent.ready.enabledKey: true,

--- a/tools/lib/mutate-rebuild-guard_test.sh
+++ b/tools/lib/mutate-rebuild-guard_test.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# mutate-rebuild-guard_test.sh — mutate.sh must not restore a source file with
+# a PRE-mutation mtime.
+#
+# WHY THIS FILE EXISTS (#1852). `restore_file` used `cp -p "$BACKUP" "$FILE"`.
+# `-p` preserves the backup's timestamps, so a byte-perfect restore stamped the
+# source as OLDER than any build product compiled from the mutated source while
+# the mutation was applied. Every mtime-driven build system then treats that
+# product as up to date and refuses to rebuild it — so the mutated binary
+# outlives the mutation, while the source, the test suite and
+# `git status --porcelain` are all clean and correct. Nothing in the harness's
+# own post-conditions can see it: they all check CONTENT.
+#
+# The incident: during #1852 a `swift build` under an applied mutation left
+# `platforms/macos/.build/debug/Irrlicht` carrying the mutated
+# `MenuBarAppearance.usesNarrowQuotaBars`. It was installed 22 seconds after
+# the restore and reported as a shipped product defect. Disassembling the
+# installed binary against a fresh build of the same commit differed by exactly
+# one instruction out of 1,003,608 — the mutated `switch` arm. Correct code was
+# nearly "fixed" on the strength of it.
+#
+# This is a guard the change ADDS, so it has no "before the fix" to run red
+# against — the mutation is `touch "$FILE"` -> removed, which is exactly the
+# pre-#1852 code (AGENTS.md, Testing).
+#
+# Convention follows tools/lib/mutate_test.sh: plain bash, hand-rolled asserts,
+# a `fails` counter, "ALL PASS" / "N FAILED" at the end.
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+MUTATE="$REPO_ROOT/tools/mutate.sh"
+fails=0
+
+fail() { echo "  FAIL: $*"; fails=$((fails + 1)); }
+pass() { echo "  ok: $*"; }
+
+if [[ ! -x "$MUTATE" ]]; then
+  echo "COULD NOT LOOK — $MUTATE is missing or not executable" >&2
+  exit 1
+fi
+
+# A throwaway git repo, so mutate.sh's own clean-tree preconditions hold and
+# nothing touches the real worktree.
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/mutate-rebuild.XXXXXX")"
+trap 'rm -rf "$WORK"' EXIT
+cd "$WORK" || exit 1
+git init -q .
+git config user.email t@example.com
+git config user.name t
+printf 'alpha\nbravo\n' > subject.txt
+# The build product must be ignored: mutate.sh refuses (exit 9) if the tree is
+# dirty after restoring, and an untracked artifact would look like a failed
+# restore rather than like the thing the mutation was supposed to produce.
+printf 'product.bin\n' > .gitignore
+git add -A
+git commit -qm init
+
+# Backdate the source well past any filesystem timestamp granularity, so
+# "unchanged" and "bumped" cannot be confused by a coarse clock.
+touch -t 200109090146.40 subject.txt
+before=$(stat -f %m subject.txt 2>/dev/null || stat -c %Y subject.txt)
+
+# Only that it landed far in the past matters, not the exact epoch: `touch -t`
+# reads local time, so pinning a literal epoch would make this fail by timezone
+# rather than by defect. A year is many orders of magnitude past any filesystem
+# timestamp granularity, which is all the margin this needs.
+now_epoch=$(date +%s)
+if [[ -z "$before" || $((now_epoch - before)) -lt 31536000 ]]; then
+  echo "COULD NOT LOOK — backdating subject.txt did not take (mtime=$before, now=$now_epoch)" >&2
+  exit 1
+fi
+
+# A build product compiled WHILE the mutation is applied: newer than the
+# backdated source, which is the whole hazard.
+"$MUTATE" subject.txt 'bravo' 'BRAVO' \
+  sh -c 'cp subject.txt product.bin' >/dev/null 2>&1
+mutate_rc=$?
+
+if [[ ! -f product.bin ]]; then
+  echo "COULD NOT LOOK — the test command never ran, so nothing was proved" >&2
+  exit 1
+fi
+if [[ "$mutate_rc" -ne 0 ]]; then
+  echo "COULD NOT LOOK — mutate.sh exited $mutate_rc on a mutation expected to succeed" >&2
+  exit 1
+fi
+
+after=$(stat -f %m subject.txt 2>/dev/null || stat -c %Y subject.txt)
+
+# 1. The product really was built from the MUTATED source — otherwise this
+#    test would pass for the wrong reason.
+if grep -q 'BRAVO' product.bin; then
+  pass "the build product captured the mutated source"
+else
+  fail "product.bin does not contain the mutation — the hazard was not reproduced"
+fi
+
+# 2. Content is restored byte-for-byte (mutate.sh's existing promise).
+if [[ "$(cat subject.txt)" == "$(printf 'alpha\nbravo\n')" ]]; then
+  pass "source content restored byte-for-byte"
+else
+  fail "source content was NOT restored"
+fi
+
+# 3. THE GUARD. The restored source must be NEWER than the product built while
+#    the mutation was applied, so an mtime-driven build rebuilds it away.
+product_mtime=$(stat -f %m product.bin 2>/dev/null || stat -c %Y product.bin)
+if [[ "$after" -gt "$before" ]]; then
+  pass "restore bumped the source mtime ($before -> $after)"
+else
+  fail "restore left the PRE-mutation mtime ($after): a build product compiled from the mutated source stays 'up to date' and is never rebuilt"
+fi
+if [[ "$after" -ge "$product_mtime" ]]; then
+  pass "restored source is not older than the contaminated product"
+else
+  fail "restored source ($after) is OLDER than the product built under mutation ($product_mtime) — the stale binary survives the next build"
+fi
+
+if [[ "$fails" -eq 0 ]]; then
+  echo "ALL PASS"
+  exit 0
+fi
+echo "$fails FAILED"
+exit 1

--- a/tools/mutate.sh
+++ b/tools/mutate.sh
@@ -183,6 +183,28 @@ restore_file() {
   # net even after the main flow already restored explicitly).
   if [[ "$RESTORED" -eq 0 && -f "$BACKUP" ]]; then
     cp -p "$BACKUP" "$FILE"
+    # `cp -p` preserves the BACKUP's mtime, which is the file's PRE-mutation
+    # mtime — so a correct restore would stamp the source as older than any
+    # build product compiled from the mutated source while it was applied.
+    # An mtime-driven build system then considers that product up to date and
+    # will not rebuild it: the mutated binary outlives the mutation, silently,
+    # and disagrees with both the source and the test suite that just passed.
+    #
+    # That is not hypothetical. During #1852 a `swift build` run against an
+    # applied mutation left `platforms/macos/.build/debug/Irrlicht` carrying
+    # `MenuBarAppearance.usesNarrowQuotaBars`'s `.combined` arm returning
+    # `isCompact` instead of `true`; the binary was installed 22 seconds after
+    # the restore and QA'd as a real product defect. Disassembly of the shipped
+    # binary against a fresh build differed by exactly ONE instruction out of
+    # 1,003,608 — that arm — while the source, the tests and `git status` were
+    # all clean and correct.
+    #
+    # Bumping the mtime is what makes the contamination self-healing: the next
+    # build of any mtime-driven toolchain rebuilds. Content is still restored
+    # byte-for-byte (that is what the caller is promised, and what the
+    # post-restore `cmp` and `git status` checks verify); only the timestamp
+    # differs, which git does not track.
+    touch "$FILE"
     rm -f "$BACKUP"
     RESTORED=1
   fi


### PR DESCRIPTION
Closes #1852.

#1849 shipped `compact` as a **fourth `MenuBarStyle` case**, which conflated two
independent choices: *what* the icon shows (dots / quota bars / both) and *how
densely* it shows it. Because they were one enum, "narrow" was reachable in
exactly one combination — aggregate dots, no quota bars — so the user who
wanted quota bars **and** a narrow icon, which is the crowded-menu-bar case
#1845 was filed for, had nothing to pick.

Three styles again. One orthogonal modifier.

| style | compact off | compact on |
|---|---|---|
| `lights` | one dot group per project | one aggregate dot for all projects |
| `usage` | full-width quota bars | the narrow quota bars |
| `combined` | dots per project + narrow quota | aggregate dot + narrow quota |

## The one decision the issue delegated

**Does `compact` also control quota-bar narrowness for `combined`, or only dot
aggregation?** Resolved: **only dot aggregation.** `combined` renders narrow
bars whether the modifier is on or off.

Narrowness on `combined` is a property of the **style**, not of the modifier: it
has split one width budget between two halves since #909, and has rendered
narrow bars that whole time. Making narrowness follow `isCompact` would *widen*
every existing Combined user's icon on the first launch after upgrading —
20.80pt to 50.00pt — which #1845's acceptance criterion 4 forbids and #1852
restates as its one hard constraint. `usage` is where the modifier selects the
narrow layout `combined` was already using, which is exactly the "reuse the
smaller display element from combined" the issue asked for.

That bound is a **lock test**, not an argument:
`testShippedStylesRenderExactlyWhatTheyDidBeforeWhenCompactIsOff`. Mutating
`usesNarrowQuotaBars`' `.combined` arm to `return isCompact` produces:

```
XCTAssertEqualWithAccuracy failed: ("50.0") is not equal to ("20.8")
  +/- ("0.01") - combined quota
```

## Measured widths — every style × modifier

Produced by `cd platforms/macos && swift test --filter testMeasuredWidthOfEachStyle`,
a committed test, not numbers typed by hand (acceptance criterion 3). #1849's
four columns were **extended** to all six rather than a second measurement being
added, so one command still produces every number quoted anywhere — and since
the simplify pass each cell is measured from `MenuBarImageBuilder.iconImage`,
the composition the app actually ships, rather than re-derived arithmetic.

```
projects |   Lights | Lights+C |    Usage |  Usage+C | Combined | Combined+C
       1 |    10.00 |    18.50 |    50.00 |    20.80 |    36.80 |    45.30
       2 |    26.00 |    18.50 |    50.00 |    20.80 |    52.80 |    45.30
       3 |    42.00 |    18.50 |    50.00 |    20.80 |    68.80 |    45.30
       5 |    74.00 |    18.50 |    50.00 |    20.80 |   100.80 |    45.30
       6 |    90.00 |    18.50 |    50.00 |    20.80 |   116.80 |    45.30
       8 |    90.00 |    18.50 |    50.00 |    20.80 |   116.80 |    45.30
```

The three **compact-off** columns are byte-identical to #1849's Lights / Usage /
Combined columns, and `Lights+C` is byte-identical to its Compact column — which
is what makes the migration below render-exact rather than merely equivalent.

Each cell is now **derived from the appearance's own predicates** instead of
hand-composed per column, so the printed table cannot drift away from what ships.

## What changed

**1. `MenuBarStyle` answers *what*; `MenuBarAppearance` answers *what × how*.**
The three-case enum keeps its raw values and order. The four render predicates
move onto `MenuBarAppearance {style, isCompact}`.

Moving **all four** (not just the two that depend on the modifier) is deliberate:
what the icon renders is now a function of both fields, and answering half the
questions on the enum would rebuild the same conflation one layer down. It also
turns every existing `style.showsQuotaBars`-shaped call site into a **compile
error** — and in a refactor the risk is at the call sites, not the definitions.
Each predicate still `switch`es exhaustively over `style`, per the reasoning the
file already carried.

**2. A migration off the fourth case.** `"compact"` does not parse in this build,
so `MenuBarStyle.current` would fall back to `.lights` with the modifier **off** —
silently widening the icon of the one group who had explicitly asked for a narrow
one. `MenuBarAppearance.migrateLegacyCompactStyle(in:)` carries it to
`lights` + compact-on at launch, following
`MenuBarStatusItemIdentity.migrateLegacyPreferredPosition`'s shape (takes the
store, so it is testable and satisfies `PersistentDefaultsLintTests`).

Idempotent *by construction* — it fires only while the stored style still reads
`"compact"`, and rewriting that value is what stops it firing again — so it needs
none of the position migration's "has the new key been written" guard.

**Affected population, verified rather than assumed:** the issue marked this
"assumed, needs checking". `git tag --contains 183a7222` (#1849's merge) returns
**empty**, and the newest release `v0.6.1` was cut 2026-08-26 against #1849's
merge on 2026-08-28. So **no tagged release ever shipped the Compact style** —
the affected population is dev installs built off `main` in that window. The
migration is still worth having (this repo's own `/Applications/Irrlicht.app` is
in it), but nobody on a release build is exposed.

**3. `MenuBarIconSettings` — one Equatable snapshot for change detection.**
`MenuBarController` repainted the icon by comparing three hand-listed defaults
against three hand-listed last-seen fields. The modifier was the fourth setting,
and that shape needs it added in four separate places; forgetting one leaves the
icon stale until an unrelated event repaints it, with nothing failing. Synthesised
`Equatable` over one value makes the comparison total by construction.

The snapshot is taken in `init` **after** the migration, not in a property
initialiser (which would run first and capture the pre-migration style).

**4. Settings offers a `Compact` toggle** under the unchanged three-segment style
picker.

## Evidence

Nothing here can run red on `main`: every check is either new behaviour or a
lock. So the red-first rule is satisfied by **mutation**, per AGENTS.md.

**Locks** (pass on `main` by construction — their green is not red-first proof):
`testShippedStylesRenderExactlyWhatTheyDidBeforeWhenCompactIsOff`,
`testExistingStylesAndDefaultAreUnchanged`, the `compact: false` half of
`testAppearanceRenderingDecisions`, and the pre-existing
`shouldShowDotsInUsageStyle` LOCKs in `MenuBarImageBuilderTests`.

**19 mutations, 18 red, 1 equivalent.** Mechanics via the repo's own
`tools/mutate.sh` (stale-anchor guard, byte-for-byte restore). Every run asserted
that tests actually executed — an early version of the harness ran `swift test`
from the wrong directory and recorded *every* mutation as RED on
"Could not find Package.swift", which is a harness reporting red when it could
not look at all.

| # | kind | mutation | result |
|---|---|---|---|
| D1 | definition | `usesNarrowQuotaBars` `.combined` → `isCompact` | RED — the compatibility lock |
| D2 | definition | `aggregatesSessionDots` → `false` | RED ×2 |
| D3 | definition | `usesNarrowQuotaBars` `.usage` → `false` | RED ×2 |
| D4 | definition | `showsQuotaBars` reads `isCompact` | RED ×3 |
| D5 | definition | drop the modifier write in the migration | RED |
| D6 | definition | drop the migration's `guard` | RED ×2 |
| D7 | definition | `MenuBarIconSettings.current` hard-codes `isCompact: false` | RED ×2 |
| C1 | **call site** | `combinedImage` rebuilds the appearance for `dotsImage` | RED |
| C2 | **call site** | same for `quotaImage` | RED |
| C3 | **call site** | `compact: usesNarrowQuotaBars` → `isCompact` | RED ×2 |
| C4 | **call site** | dot-routing predicate → `false` | RED ×2 |
| C5 | **call site** | quota guard → `usesNarrowQuotaBars` | RED ×2 |
| C6 | **call site** | dot-visibility predicate → `aggregatesSessionDots` | **SURVIVED, then fixed** |
| C6b | **call site** | composition stops routing through `showsDots` | RED |
| C7 | **call site** | Settings toggle unbound | RED |
| C8 | **call site** | Settings gate → `usesNarrowQuotaBars` | RED |
| C9 | **call site** | `SettingsView.menuBarAppearance` hard-codes `isCompact: false` | **equivalent — see below** |
| C10 | **call site** | migration never called | RED |
| C11 | **call site** | snapshot taken before the migration | RED |

### Review round: four more call-site mutations, all of which survived

The review subagent ran its own battery at `high` effort and found **four
surviving mutations, every one inside `combinedImage`** — the private function
that needs a live `SessionManager`, which no test can construct. My source-text
pins had given false confidence: a `contains` check matches the *call*, never
what the call is **given** or what is **done with** the result.

| mutation | what shipped green | now |
|---|---|---|
| invert `? computedDotsImage : nil` | every Lights user's icon collapses to the "no sessions" flame while sessions run | RED |
| `appearance: .init(style:isCompact: !isCompact)` — evades a ban on the literal `MenuBarAppearance(`; the whole-file hand-off count was satisfied by an unrelated 4th occurrence | Usage renders full bars compacted and narrow bars uncompacted — a direct breach of the compatibility bound | RED |
| swap `quotaImage:`/`dotsImage:` at the `showsDots` call (same type, adjacent labels) | `.usage` with no renderable quota loses its dots and collapses to the "no sessions" icon | RED |
| swap the two halves in `composeSideBySide` (pre-existing line, in blast radius) | quota bars render left of the dots, contradicting #909's ordering | RED |

**The fix was structural, not another pin.** The composition moved into
`MenuBarImageBuilder.iconImage(appearance:sessions:projectGroupOrder:providerKey:now:)`,
which a test *can* call, and three tests now assert the composed image:
`testComposedIconForEveryStyleAndModifier` (all six widths),
`testUsageComposesDotsWhenNoQuotaIsRenderable`, and
`testComposedIconPutsTheDotsBeforeTheQuotaBars` (compares against both
orderings, with a vacuity guard that they differ at all — width cannot see
order, since `composeSideBySide` is commutative in width).

The third mutation deserves a note: it **survived the first fix too**. With both
halves non-nil the swap is invisible, because both spellings answer the same.
Only the nil-quota case discriminates, which is why
`testUsageComposesDotsWhenNoQuotaIsRenderable` exists as a separate test with a
deliberately quota-free fixture.

Also fixed from that review: the negative source pins now read raw source rather
than comment-stripped source (over-stripping can only turn a real hit into a
silent PASS — the direction AGENTS.md rules out), the banned-comparison list is
derived from `allCases` × both operators instead of hand-listing three
pre-#1845 spellings, and the now-dead no-argument `MenuBarStyle.current` was
removed with its three doc references updated.

**C6 was a real gap and is the reason this diff grew.** `combinedImage` spelled
its dot-visibility decision inline as
`!appearance.hidesDotsWhenQuotaIsRenderable || shouldShowDotsInUsageStyle(…)`.
`combinedImage` is private and needs a live `SessionManager`, so **nothing could
reach that expression** — swapping the first predicate for its neighbour left all
543 tests green while making `.usage` draw its dots unconditionally. Fixed by
extracting `MenuBarImageBuilder.showsDots`, the same move #1849 made for the
other three seams, plus `testShowsDotsAcrossEveryStyleAndDensity`. The same
mutation now yields 7 failures, including the one that matters:

```
XCTAssertEqual failed: ("true") is not equal to ("false")
  - usage compact=false with a renderable quota
```

**C9 is equivalent, not a coverage gap** — and that claim carries evidence rather
than being asserted. `menuBarAppearance` is consumed at exactly one place in
`SettingsView.swift` (line 190, `.showsQuotaBars`); `showsQuotaBars` is
style-only, which is itself locked by
`testTheModifierChangesDensityOnlyNeverContent`. So `isCompact` cannot affect
behaviour there. The toggle's own binding is a separate line, pinned by C7. The
field is kept correct rather than hard-coded so the next density-dependent
question asked of that value gets a true answer.

**A latent bug in one of #1849's own pins, found and fixed.**
`testImageBuilderRoutesBothHalvesThroughTheExtractedSeams` asserted the source
contained `"let quotaImage = quotaImage("`. On `main` that string occurs **once,
inside a comment** explaining why the local is *not* named that; the real call
site is `let builtQuotaImage = quotaImage(`. Verified:
`git show 183a7222:…/MenuBarImageBuilder.swift | grep -n` returns the comment at
line 195 and the call site at line 181. The pin passed while proving nothing —
deleting the routing would have left it green as long as the comment stayed.
Source pins now run against comment-stripped source (`codeLines`), guarded by
`testSourcePinsCannotBeSatisfiedByAComment`.

## Simplify pass

Four angles, each accounted for:

- **Reuse** — *fixed.* `MenuBarCompactStyleTests` and `MenuBarImageBuilderTests`
  had grown two private copies of the same session fixture while both asserting
  the same derived widths — the failure `TestAgentBranding`'s own doc describes
  ("a change applied to one copy and not the other would leave one suite green
  against a fixture the other no longer uses"), and the two tests involved are
  this issue's compatibility LOCK and its composed-icon check. Extracted to
  `Tests/MenuBarFixtures.swift`, using `PinnedNowSnapshot.referenceNow` instead
  of a repeated `1_700_000_000` literal, matching what `QuotaMenuBarRendererTests`
  already does. *Skipped:* folding this file's comment-stripper into
  `PersistentDefaultsLintTests.commentsBlanked` — a real 4th copy, but the
  extraction touches three other lint suites and belongs in its own PR.
- **Simplification** — *fixed.* Deleted one test fully subsumed by
  `testShowsDotsAcrossEveryStyleAndDensity`; made
  `testMigratedCompactStyleUsersKeepTheirRendering` drive the real migration
  instead of hand-building the appearance it was named for; trimmed three doc
  comments that restated their tests' contract. *Skipped:* four further
  "subsumed test" candidates — each is individually implied by the predicate
  matrix, but each also names the invariant it protects, and deleting tests to
  shorten a compatibility-critical PR is the wrong trade.
- **Efficiency** — *clean, measured.* +1 `UserDefaults.bool` per icon build and
  +2 per launch, against an SVG parse and an offscreen compose per repaint. The
  new tests add ~0.08s to a suite whose run-to-run spread is ~1s. The change is
  net-negative on work for compact users: the aggregate dot is a smaller SVG to
  build and parse than the per-project layout, on every style.
- **Altitude** — *fixed, partially.* `testMeasuredWidthOfEachStyle` was
  re-implementing the composition rather than calling it, **and its fixture
  carried no rate-limit data at all** — so the printed Usage and Combined
  columns described a scenario the fixture did not contain. It now measures
  `MenuBarImageBuilder.iconImage` directly against a quota-carrying fixture. The
  table above is byte-identical either way, which is the point: the numbers were
  right, the derivation was not the app's. Also corrected two overstated doc
  claims (`MenuBarIconSettings` is total over the fields it holds, not over
  every default the icon can reach; `combined`'s narrowness is structural rather
  than a temporary compatibility shim).

## Deliberately not done, with reasons

- **Moving `showsQuotaBars` / `hidesDotsWhenQuotaIsRenderable` back onto
  `MenuBarStyle`.** The strongest dissenting design opinion from the simplify
  pass: those two are total functions of `style`, so hoisting them onto a struct
  that has `isCompact` in scope makes writing the wrong thing *possible*, and
  the PR buys the guarantee back with a test
  (`testTheModifierChangesDensityOnlyNeverContent`) rather than with the
  compiler. Worth a maintainer's opinion; I kept one vocabulary at the call
  sites because half the questions on one type and half on another is the
  conflation this issue removes, one layer down.
- **Collapsing the two launch migrations into `MenuBarIconSettings.prepared(in:)`.**
  Would replace the byte-offset ordering pin with a behavioural test. Not done
  because it moves `migrateLegacyPreferredPosition` out of `MenuBarController.swift`
  and so breaks a pre-existing #1849 lock test that greps for it there.
- **Splitting `MenuBarCompactStyleTests.swift`.** CodeScene flags it for Low
  Cohesion (10.00 → 8.03) and it is right: the file holds compact/style
  behaviour, `MenuBarStatusRenderer` geometry, and the unrelated NSStatusItem
  autosave/position block. But the reshape renamed most of the surviving tests,
  and interleaving moves with renames would leave a reviewer unable to tell
  "moved" from "changed" on the one change where *did any behaviour move* is the
  whole question. Better as a follow-up whose diff is pure moves.

## QA follow-up: a reported render bug, traced to a contaminated build artifact

QA reported that the running app rendered `combined` + compact **off** with the
wide, labelled quota bars — contradicting this PR's lock test and the
maintainer's decision that uncompacted Combined must use the small bars.

**The app code is correct; the installed binary was not.** Disassembling
`/Applications/Irrlicht.app`'s binary against a fresh build of the same commit:

```
$ otool -tV <fresh> > a; otool -tV <installed> > b; diff a b
1,003,608 instructions each — differing lines: 1 (plus 2 filename headers)

  0x10016b728   fresh:      mov  w8, #0x1        ← .combined returns `true`
  0x10016b728   installed:  ldr  w8, [sp, #0x8]  ← .combined returns `isCompact`
```

`[sp,#0x8]` is `isCompact`. The shipped binary computed
`case .combined: return isCompact` — exactly this PR's D1 mutation, compiled in
— and that single instruction reproduces all three reported observations,
including `usage`+off being pixel-equivalent to `combined`+off.

**Root cause: `tools/mutate.sh` restored the source with `cp -p`, which
preserves the PRE-mutation mtime.** A build product compiled while the mutation
was applied is therefore *newer* than the restored source, so every mtime-driven
build treats it as up to date and never rebuilds it. The mutated binary outlives
the mutation while the source, the suite and `git status` are all clean —
nothing in the harness could see it, because every post-condition checks
*content*. Measured: mtime `16:59:08` identical before and after a restore, and
that is 22 seconds before the installed binary's `16:59:30`.

Fixed by `touch`ing the file after the copy-back, so the contamination is
self-healing. Guarded by `tools/lib/mutate-rebuild-guard_test.sh` (runs in the
`tools` gate — confirmed discovered, not vacuous), which builds a product under
an applied mutation and asserts the restored source is newer. Red against the
pre-fix harness:

```
  FAIL: restore left the PRE-mutation mtime (999992800): a build product
        compiled from the mutated source stays 'up to date' and is never rebuilt
  FAIL: restored source (999992800) is OLDER than the product built under
        mutation (1787930033) — the stale binary survives the next build
2 FAILED
```

**No number in the width table changes**, and no menu-bar code changed: with the
live defaults (`menuBarStyle=combined`, no `menuBarCompact` key)
`MenuBarAppearance.current` is `{combined, isCompact: false}` and
`quotaImage` measures **20.80** — the narrow, label-less layout, with
`buildSVG(compact:true)` carrying no `5h`/`7d` label.

## Gates

`tools/preflight.sh` by `--only` group, each in the foreground: **swift, go,
arch, tools, skills, posix, bash, web, security — all PASS.** `--only linux` not
run: opt-in, needs Docker, and this is a macOS-only Swift change.

`cd platforms/macos && swift test --skip LauncherTestHarness --skip
LauncherHarnessTests` → **546 passed, 0 failures**, against **531 passed** at the
branch point (183a7222). Both measured with that command, counting
`^Test Case .* passed` lines; the +15 is this PR's new tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
