### PR TITLE
fix(macos): keep the Settings panel margin constant when notifications expand

### DIFF
--- a/platforms/macos/Irrlicht/Views/SettingsView.swift
+++ b/platforms/macos/Irrlicht/Views/SettingsView.swift
@@ -967,7 +967,11 @@ private struct ContextThresholdRow: View {
 
 /// One row in the Settings notifications section: enable toggle, sound
 /// picker, and a ▶ preview button.
-private struct NotificationEventRow: View {
+///
+/// Internal (not private): `SettingsViewTests` hosts this row directly to
+/// measure its minimum width (#1854) — see the `body` comment for why hosting
+/// the whole panel cannot show it.
+struct NotificationEventRow: View {
     let event: NotificationEvent
     @Binding var enabled: Bool
     let sampleText: String
@@ -1057,12 +1061,24 @@ private struct NotificationEventRow: View {
 
     var body: some View {
         // One row (issue #940): toggle + label + sound picker + preview all
-        // share a line — LeadingToggle's trailing Spacer absorbs the gap
-        // between the label and the fixed-width picker/button, so this
-        // stays a single line regardless of how long `event.displayName` is.
+        // share a line — LeadingToggle absorbs the gap between the label and
+        // the fixed-width picker/button, so this stays a single line
+        // regardless of how long `event.displayName` is.
+        //
+        // `compressibleLabel` is what keeps that promise without a second one
+        // it cannot keep (#1854). The picker's 112pt and the preview button
+        // are fixed, so with a fixed-size label too this row's minimum width
+        // was a constant, and that constant saturated the panel's padded
+        // content box exactly — see `LeadingToggle.compressibleLabel` for what
+        // an overflowing row then does to the margin, and
+        // `testTheWidestRowFitsTheContentBoxUntruncated` for the measurement.
+        //
+        // It is also why the test hosts this row rather than the whole panel:
+        // `SettingsView` pins itself to `panelWidth`, where the row still
+        // fits, so the overflow only appears once something takes width away.
         VStack(alignment: .leading, spacing: IrrSpacing.sp1) {
             HStack(spacing: IrrSpacing.sp2) {
-                LeadingToggle(isOn: $enabled, label: event.displayName)
+                LeadingToggle(isOn: $enabled, label: event.displayName, compressibleLabel: true)
 
                 Picker("", selection: soundBinding) {
                     ForEach(SoundChoice.builtIns, id: \.self) { choice in
@@ -1160,11 +1176,42 @@ struct LeadingToggle: View {
     var info: String? = nil
     /// Flags a still-maturing feature with a "BETA" pill after the label (#694).
     var beta: Bool = false
+    /// Lets the label give width back — truncating — instead of forcing the
+    /// row wider than the box it was handed (#1854).
+    ///
+    /// Off by default, and that default is the behaviour every other caller
+    /// already had. `.fixedSize()` means "never narrower than ideal", so a
+    /// toggle carrying it cannot participate in compression at all; in a row
+    /// whose other parts are fixed too, the row's minimum is a constant, and a
+    /// container narrower than that constant does not clip it — SwiftUI centres
+    /// the overflow, which slides the content sideways and eats the panel's
+    /// horizontal margin. Only `NotificationEventRow` sits that close to the
+    /// edge, so only it opts in.
+    var compressibleLabel: Bool = false
 
     var body: some View {
         HStack(spacing: 6) {
-            Toggle(isOn: $isOn) { Text(label) }
-                .fixedSize()
+            Toggle(isOn: $isOn) {
+                // Scoped to the compressible path rather than applied
+                // unconditionally, so a caller keeping the default gets a
+                // byte-identical render by CONSTRUCTION and not by audit.
+                // "`.fixedSize()` makes a Text one line anyway" is not true:
+                // `.fixedSize()` proposes nil, and a label carrying a newline
+                // answers with two lines, which an unconditional
+                // `.lineLimit(1)` would silently collapse — measured at
+                // (106, 32) -> (87, 18) for "Two\nline label". Every literal
+                // label here is single-line, so nothing observable changed;
+                // `PermissionWizardView` passes a daemon-supplied title, which
+                // is exactly the caller that should not depend on that staying
+                // true.
+                //
+                // No `.truncationMode`: `.tail` is already SwiftUI's default,
+                // so spelling it would be a line that does nothing on either
+                // path.
+                Text(label)
+                    .lineLimit(compressibleLabel ? 1 : nil)
+            }
+            .fixedSize(horizontal: !compressibleLabel, vertical: true)
             if let info {
                 InfoIcon(text: info)
             }

--- a/platforms/macos/Tests/SettingsViewTests.swift
+++ b/platforms/macos/Tests/SettingsViewTests.swift
@@ -35,18 +35,9 @@ final class SettingsViewTests: XCTestCase {
         // SettingsView requires its environment objects (crashes without
         // them). startingUpdater: false keeps Sparkle from starting its
         // update cycle, which would fail outside an app bundle.
-        let store = InMemoryDefaults()
-        let view = SettingsView(isPresented: .constant(true),
-                                showPermissionsReview: .constant(false),
-                                sessionManager: SessionManager(defaults: store))
-            .environmentObject(UpdateManager(startingUpdater: false))
-            .environmentObject(DaemonManager())
         // SettingsView pins its width to SessionListView.panelWidth (issue
         // #940 — shared with History/the session list) and its own 520 height.
-        let hosting = PinnedSnapshotHost(view,
-                                         width: SessionListView.panelWidth,
-                                         height: 520,
-                                         defaults: store).view
+        let hosting = hostedSettingsPanel(height: 520, defaults: InMemoryDefaults())
 
         guard let bitmap = hosting.bitmapImageRepForCachingDisplay(in: hosting.bounds) else {
             XCTFail("bitmapImageRepForCachingDisplay returned nil")
@@ -77,5 +68,266 @@ final class SettingsViewTests: XCTestCase {
                 "SettingsView background must be fully opaque — \(label) alpha was \(color.alphaComponent). Regression of the transparent-panel bleedthrough bug."
             )
         }
+    }
+
+
+    // MARK: - #1854: the notifications section must not eat the panel margin
+
+    /// The half-point of slack every geometry assertion below carries.
+    ///
+    /// Layout lands on integral points on this machine, so this absorbs
+    /// rounding on a future OS rather than weakening a bound. Stated once
+    /// because several of these assertions land exactly ON their bound — the
+    /// row saturates its box by construction, which is the whole subject.
+    private static let layoutTolerance: CGFloat = 0.5
+
+    /// The view class-name fragments the walk below treats as "a control whose
+    /// position is the row's position".
+    ///
+    /// These are SwiftUI's own private class names, so the list is the part of
+    /// this helper most likely to rot. When it does, the walk finds nothing and
+    /// the guards in each test say so by name rather than reporting a
+    /// comfortable pass — which is why those guards assert what was found, not
+    /// merely how much.
+    private static let measurableControlNames = [
+        "PopupButton", "TextField", "SegmentedControl", "FocusRing",
+    ]
+
+    /// Every AppKit-backed control in a laid-out hierarchy, with its frame in
+    /// `root`'s coordinate space.
+    ///
+    /// SwiftUI draws `Text`, `Capsule` and friends into layers, but a `Picker`,
+    /// a `TextField`, a `Button` and a segmented control are each backed by a
+    /// real `NSView`. Those are what this reads, so "where did the row actually
+    /// land" is answered by the rendered hierarchy rather than by adding up
+    /// modifier constants — a sum would just restate the code under test.
+    ///
+    /// The blind spot worth knowing: a `Text` is NOT here, so this cannot see
+    /// the label truncating. `testTheWidestRowFitsTheContentBoxUntruncated`
+    /// covers the width at which truncation would start.
+    private func controlFrames(in root: NSView) -> [(name: String, frame: CGRect)] {
+        var found: [(name: String, frame: CGRect)] = []
+        func walk(_ view: NSView) {
+            let name = String(describing: type(of: view))
+            if Self.measurableControlNames.contains(where: name.contains) {
+                found.append((name: name, frame: view.convert(view.bounds, to: root)))
+            }
+            view.subviews.forEach(walk)
+        }
+        walk(root)
+        return found
+    }
+
+    /// The whole Settings panel, laid out at `panelWidth` and the given height.
+    ///
+    /// One factory rather than a copy per test: the argument list of
+    /// `SettingsView.init` and the two environment objects it crashes without
+    /// are exactly the kind of thing two copies stop agreeing about.
+    private func hostedSettingsPanel(height: CGFloat,
+                                     defaults store: InMemoryDefaults) -> NSView {
+        let view = SettingsView(isPresented: .constant(true),
+                                showPermissionsReview: .constant(false),
+                                sessionManager: SessionManager(defaults: store))
+            .environmentObject(UpdateManager(startingUpdater: false))
+            .environmentObject(DaemonManager())
+        return PinnedSnapshotHost(view,
+                                  width: SessionListView.panelWidth,
+                                  height: height,
+                                  defaults: store).view
+    }
+
+    /// The width a `NotificationEventRow` asks for when nothing constrains it.
+    ///
+    /// Hosted through `PinnedSnapshotHost`, not a bare `NSHostingView`, and
+    /// that is #1672 rather than tidiness: the row carries an `@AppStorage`
+    /// sound choice, so an unpinned host resolves the developer's real
+    /// `com.apple.dt.xctest.tool` domain. A `.speak(voice)` value sitting
+    /// there makes the row render a SECOND line, and this measurement would
+    /// then be taken over a different subtree than the one it reports on.
+    private func idealWidth(ofRowFor event: NotificationEvent) -> CGFloat {
+        let row = NotificationEventRow(event: event,
+                                       enabled: .constant(true),
+                                       sampleText: "",
+                                       onImportError: { _ in })
+            .toggleStyle(IrrlichtSwitchToggleStyle())
+        // Wide enough that nothing constrains the row, so `fittingSize`
+        // reports what it asks for rather than what it was given.
+        return PinnedSnapshotHost(row, width: 1000, height: 200,
+                                  defaults: InMemoryDefaults()).view.fittingSize.width
+    }
+
+    /// The width a legacy scroller ("Show scroll bars: Always") takes off the
+    /// scroll content, asked of AppKit rather than typed: the constant is 15 on
+    /// some releases and 17 on others, and a literal that stopped matching would
+    /// silently relax the very margin this test is defending.
+    private var legacyScrollerWidth: CGFloat {
+        NSScroller.scrollerWidth(for: .regular, scrollerStyle: .legacy)
+    }
+
+    /// #1854 — the defect, measured on the rows that carry it.
+    ///
+    /// `SettingsView` puts `.padding(.horizontal, IrrSpacing.sp4)` on its scroll
+    /// content inside a panel pinned to `SessionListView.panelWidth`, so a row
+    /// gets `380 - 2 × 16 = 348` pt. Before the fix the notification rows were
+    /// built entirely from parts that cannot shrink, so their minimum width was
+    /// a constant that saturated that box — see
+    /// `LeadingToggle.compressibleLabel` for the mechanism, and
+    /// `testTheWidestRowFitsTheContentBoxUntruncated` for the measurement.
+    ///
+    /// A legacy scroller is the everyday thing that takes those points away.
+    /// This hosts the rows in the box they really get in that case —
+    /// `panelWidth` minus the scroller, minus the same horizontal padding — and
+    /// asserts each one stays inside its own padding.
+    ///
+    /// Every event is rendered, not just the widest, because two of the three
+    /// overflowed before the fix. Pinning only the widest would let a future
+    /// label edit push either of the others over while this stayed green.
+    ///
+    /// `ContextThresholdRow`, the fourth child of the production stack, is
+    /// deliberately not here: it ends in a `Spacer()` and so is compressible by
+    /// construction, and it renders 117pt clear of the trailing margin. The
+    /// three rows below are the ones whose width is a constant.
+    func testNotificationSectionStaysInsideAScrollerNarrowedContentBox() throws {
+        let boxWidth = SessionListView.panelWidth - legacyScrollerWidth
+        let inset = IrrSpacing.sp4
+        let slack = Self.layoutTolerance
+
+        let section = VStack(alignment: .leading, spacing: IrrSpacing.sp2) {
+            ForEach(NotificationEvent.allCases, id: \.self) { event in
+                NotificationEventRow(
+                    event: event,
+                    enabled: .constant(true),
+                    // Speech text only — handed to SoundPlayer.preview, it
+                    // contributes nothing to layout. The row's width comes
+                    // from `event.displayName`.
+                    sampleText: "",
+                    onImportError: { _ in }
+                )
+            }
+        }
+        .padding(.horizontal, inset)
+        .frame(width: boxWidth)
+        // SettingsView applies this to the whole panel; the rows' toggles are
+        // drawn by it, so the measurement needs it too.
+        .toggleStyle(IrrlichtSwitchToggleStyle())
+
+        let hosting = PinnedSnapshotHost(section, width: boxWidth, height: 160,
+                                         defaults: InMemoryDefaults()).view
+        let controls = controlFrames(in: hosting)
+        let names = controls.map(\.name)
+
+        // Fail loudly when the measurement could not be taken at all: an empty
+        // walk reports "nothing outside the margin" exactly like a healthy
+        // section would, and that is the one answer this test must never give
+        // by accident (AGENTS.md — a verification mechanism must fail loudly
+        // when it cannot run). Assert WHAT was found, not just how much: a
+        // count alone is met by two pickers while a row is missing entirely.
+        for fragment in ["PopupButton", "FocusRing"] {
+            XCTAssertTrue(
+                names.contains { $0.contains(fragment) },
+                "no \(fragment) in the hosted section — the walk found \(names). SwiftUI's private class names may have changed; see measurableControlNames."
+            )
+        }
+        XCTAssertEqual(
+            names.filter { $0.contains("PopupButton") }.count, NotificationEvent.allCases.count,
+            "expected one sound picker per event (\(NotificationEvent.allCases.count)), walked \(names) — the section did not render every row, so a per-row margin assertion would skip one"
+        )
+
+        for (name, frame) in controls {
+            XCTAssertGreaterThanOrEqual(
+                frame.minX, inset - slack,
+                "#1854: \(name) starts at x=\(frame.minX) in a \(boxWidth)pt box, inside the \(inset)pt margin."
+            )
+            XCTAssertLessThanOrEqual(
+                frame.maxX, boxWidth - inset + slack,
+                "#1854: \(name) ends at x=\(frame.maxX) in a \(boxWidth)pt box, past the \(boxWidth - inset)pt margin."
+            )
+        }
+    }
+
+    /// The widest notification row must fit the panel's padded content box
+    /// without truncating — the cost the fix trades for a correct margin, and
+    /// the one thing `controlFrames` cannot see (a `Text` is not an `NSView`).
+    ///
+    /// Deliberately `<=`, not `==`. The row measuring *exactly* the box is the
+    /// accident that caused #1854, and freezing it as a contract would turn the
+    /// obvious future improvement — giving the row real slack by narrowing the
+    /// 112pt picker or shortening a label — into a red test. `<=` is the
+    /// property the panel actually needs.
+    ///
+    /// The measured widths are printed into the failure message rather than
+    /// typed into a comment, so the "348pt" figure this PR quotes stays derived
+    /// (AGENTS.md — a figure that documents behaviour states what produces it).
+    func testTheWidestRowFitsTheContentBoxUntruncated() throws {
+        let box = SessionListView.panelWidth - 2 * IrrSpacing.sp4
+        let widths = NotificationEvent.allCases.map { (event: $0, width: idealWidth(ofRowFor: $0)) }
+        let widest = try XCTUnwrap(widths.max(by: { $0.width < $1.width }),
+                                   "NotificationEvent.allCases is empty — nothing was measured")
+        let measured = widths.map { "\($0.event) \($0.width)" }.joined(separator: ", ")
+
+        XCTAssertLessThanOrEqual(
+            widest.width, box + Self.layoutTolerance,
+            "the widest notification row asks for \(widest.width)pt against a \(box)pt content box (measured: \(measured)) — its label truncates at the panel's own width."
+        )
+    }
+
+    /// #1854 — the acceptance criterion, stated on the whole panel.
+    ///
+    /// LOCK, not a red-first defect test: at `SessionListView.panelWidth` with
+    /// the overlay scrollers a test process gets, the widest notification row
+    /// fits its box, so this comparison passes on `main` too. It is here to pin
+    /// the criterion the issue asks for — the horizontal inset of every settings
+    /// row is identical with notifications off and on — so a future change that
+    /// reintroduces a sideways shift at the panel's own width is caught.
+    /// `testNotificationSectionStaysInsideAScrollerNarrowedContentBox` is the
+    /// one that was seen red.
+    func testPanelHorizontalInsetIsIdenticalWithNotificationsOffAndOn() throws {
+        // Named `panelControlFrames`, not an overload of `controlFrames`: a
+        // local function of the same name shadows the member, so the body
+        // would resolve its own call recursively.
+        func panelControlFrames(notificationsEnabled: Bool) -> [CGRect] {
+            let store = InMemoryDefaults()
+            store.set(notificationsEnabled, forKey: NotificationSettings.masterEnabledKey)
+            // 603pt is the panel's own measured height (header + the 520pt
+            // scroll cap + footer), so the content fills the host exactly and
+            // nothing is centred or clipped by the frame itself.
+            return controlFrames(in: hostedSettingsPanel(height: 603, defaults: store))
+                .map(\.frame)
+        }
+
+        let collapsed = panelControlFrames(notificationsEnabled: false)
+        let expanded = panelControlFrames(notificationsEnabled: true)
+
+        // Same "could not look" guard as above, on both renders.
+        for (label, frames) in [("collapsed", collapsed), ("expanded", expanded)] {
+            XCTAssertGreaterThanOrEqual(
+                frames.count, 3,
+                "\(label) panel yielded \(frames.count) controls — the hierarchy walk cannot have worked"
+            )
+        }
+        // And that the two renders are genuinely different states, so an
+        // `@AppStorage` seed that silently failed to reach the view cannot make
+        // this pass by comparing a render with itself.
+        XCTAssertGreaterThan(
+            expanded.count, collapsed.count,
+            "enabling notifications added no controls (\(collapsed.count) -> \(expanded.count)) — the section did not expand, so this comparison is vacuous"
+        )
+
+        let collapsedLeading = try XCTUnwrap(collapsed.map(\.minX).min())
+        let expandedLeading = try XCTUnwrap(expanded.map(\.minX).min())
+        let expandedTrailing = try XCTUnwrap(expanded.map(\.maxX).max())
+
+        XCTAssertEqual(
+            collapsedLeading, expandedLeading, accuracy: Self.layoutTolerance,
+            "#1854: the leading inset moved from \(collapsedLeading) to \(expandedLeading) when notifications were enabled. It must not change."
+        )
+        XCTAssertEqual(
+            collapsedLeading, IrrSpacing.sp4, accuracy: Self.layoutTolerance,
+            "#1854: the leading inset is \(collapsedLeading), not the \(IrrSpacing.sp4)pt the scroll content's padding asks for."
+        )
+        XCTAssertLessThanOrEqual(
+            expandedTrailing, SessionListView.panelWidth - IrrSpacing.sp4 + Self.layoutTolerance,
+            "#1854: the expanded section reaches x=\(expandedTrailing), past the \(SessionListView.panelWidth - IrrSpacing.sp4)pt trailing margin."
+        )
     }
 }


### PR DESCRIPTION
Closes #1854.

## Neither candidate cause in the issue is what happens

Both were marked unverified; both are wrong as written, and the reproduction is
what says so.

**Candidate 1 — "row minimum width overflows the padded content width"** has the
right mechanism and the wrong number. The issue estimated the widest row near
**329pt** from a standalone `NSFont` measurement and concluded it was "close to
the limit but not clearly over it". Measured from a rendered `NSHostingView`
instead, the widest row is **exactly 348.0pt** — which is exactly the padded
content box, `SessionListView.panelWidth 380 − 2 × IrrSpacing.sp4 16`. It is not
*under* the limit with 19pt to spare; it is *on* the limit with **zero slack**.
That 19pt error is the whole reason the row looked innocent.

```
row .ready            idealWidth = 284.0   (126 + 8 + 112 + 8 + 30)
row .waiting          idealWidth = 348.0   (190 + 8 + 112 + 8 + 30)   <-- box is 348
row .contextPressure  idealWidth = 345.0   (187 + 8 + 112 + 8 + 30)
```

The rendered panel agrees: at `panelWidth` the preview button's trailing edge
lands on **x = 364.0 = 380 − 16**, flush against the margin, with nothing left
over.

**Candidate 2 — "a scroller appears"** is wrong. It requires the collapsed state
to fit inside the 520pt cap and the expanded state not to. Measured, the panel's
`fittingSize` is **380 × 603 in both states** and the `ScrollView` sits at its
520pt cap in both — the content already overflows when collapsed, so no scroller
*appears* on expansion. A scroller matters here only as one of the things that
can take the missing point of width, never as the trigger.

## What actually happens

`NotificationEventRow` is built entirely from parts that cannot shrink: a
`.fixedSize()` toggle, a `.frame(width: 112)` picker, a bordered preview button,
and two 8pt gaps. So the row's minimum width is a **constant**, and that constant
is exactly the box.

The moment anything takes a point away — a legacy scroller under "Show scroll
bars: Always" takes 15–17pt — the row no longer fits. And SwiftUI does not clip
that overflow, it **centres** it, so the leading inset drops by half the overflow
and the whole scroll content slides sideways. Measured on a faithful mirror of
`SettingsView`'s container (leading `VStack` → capped `ScrollView` → padded
content → `.frame(width: 380)`), with a marker row reporting where the content's
leading edge landed:

```
overflow   0pt -> marker.minX = 18.0
overflow   2pt -> marker.minX = 17.0
overflow  17pt -> marker.minX = 10.0    <-- a legacy scroller
overflow  40pt -> marker.minX = -2.0    <-- content hangs off the left edge
```

That is the report, exactly: *the panel content shifts sideways and the
horizontal margin to the panel edges disappears.* The collapsed state has no such
row, so its inset is untouched — which is why it looks like enabling
notifications caused it.

## The fix

`LeadingToggle` gains an opt-in `compressibleLabel`, and `NotificationEventRow`
is its only caller. `.fixedSize()` means "never narrower than ideal", which is
precisely what makes a row incompressible; dropping it for this one row lets the
label truncate instead of forcing the row wider, so the row's minimum stops
saturating the box and the inset stays exact.

The other twelve `LeadingToggle` call sites (and `PermissionWizardView`'s) keep
`.fixedSize()` and are byte-identical — the `.lineLimit(1)` added alongside is a
no-op under `.fixedSize()`, where a Text is one line by construction.

At `panelWidth` the rendered panel is unchanged: the label still shows in full
and both margins are 16pt. Only in a box narrowed by a scroller does the label
give width back ("Agent waiting for i…") while the preview button stays inside
the margin.

## Red-first evidence

The defect test, run **before** the fix existed:

```
cd platforms/macos && swift test --filter SettingsViewTests
```

```
Test Case '-[IrrlichtTests.SettingsViewTests testNotificationRowStaysInsideAScrollerNarrowedContentBox]' started.
Tests/SettingsViewTests.swift:169: error: -[IrrlichtTests.SettingsViewTests testNotificationRowStaysInsideAScrollerNarrowedContentBox] : XCTAssertLessThanOrEqual failed: ("356.0") is greater than ("347.0") - #1854: _FocusRingView ends at x=356.0 in a 363.0pt box, past the 347.0pt margin. The row cannot compress, so SwiftUI centres its overflow and the panel's horizontal inset collapses.
Test Case '-[IrrlichtTests.SettingsViewTests testNotificationRowStaysInsideAScrollerNarrowedContentBox]' failed (0.201 seconds).
	 Executed 3 tests, with 1 failure (0 unexpected)
```

After the fix: `Executed 3 tests, with 0 failures`.

The test was then broadened, on a review finding, from one row to the whole
section — `.contextPressure` (345pt) was overflowing the 331pt narrowed box
too, so **two of the three rows carried the defect**, not one. Re-run against
the same mutation after the broadening, it goes red twice:

```
XCTAssertLessThanOrEqual failed: ("356.0") is greater than ("347.5") - #1854: _FocusRingView ends at x=356.0 in a 363.0pt box, past the 347.0pt margin.
XCTAssertLessThanOrEqual failed: ("353.0") is greater than ("347.5") - #1854: _FocusRingView ends at x=353.0 in a 363.0pt box, past the 347.0pt margin.
	 Executed 4 tests, with 2 failures (0 unexpected)
```

The mutation used for both proofs is dropping `compressibleLabel: true` at
`NotificationEventRow`'s call site — i.e. the fix itself, removed.

The other new test,
`testPanelHorizontalInsetIsIdenticalWithNotificationsOffAndOn`, is the issue's
acceptance criterion stated on the whole panel — and it is a **LOCK, not a
red-first defect test**. It passes on `main` too, because at `panelWidth` with
the overlay scrollers a test process gets, the row fits its 348pt box exactly.
Its green is not evidence for the fix; it is there so a future change that
reintroduces a sideways shift at the panel's own width is caught. The row-level
test above is the one that was seen red.

Both new tests assert that the hierarchy walk actually found controls before
asserting anything about them — an empty walk would otherwise report "nothing
outside the margin" exactly like a healthy row does (AGENTS.md: a verification
mechanism must fail loudly when it cannot run). The panel test additionally
asserts the expanded render has *more* controls than the collapsed one, so an
`@AppStorage` seed that failed to reach the view cannot make it pass by comparing
a render with itself.

## Scope

Only the margin defect. Deliberately left alone:

- The `ScrollView`'s `.frame(maxHeight: 520)` cap and the fact that the content
  overflows it in both states — real, pre-existing, and not this bug.
- `.fixedSize()` on every other `LeadingToggle` call site.
- The 112pt picker width and the preview button — narrowing them would only move
  the zero-slack line, not remove it.
- Anchoring the scroll content leading (`alignment: .leading`) was considered and
  rejected: it would pin the leading margin but leave the row clipped on the
  right, trading one visible defect for another instead of fixing the cause.

`NotificationEventRow` changed from `private` to internal so the test can measure
the row itself. That measurement cannot be taken through the whole panel:
`SettingsView` pins itself to `panelWidth`, where the row exactly saturates the
box, so the overflow only appears once something takes width away.

## Verification

- `cd platforms/macos && swift build && swift test --skip LauncherTestHarness --skip LauncherHarnessTests` — **551 tests, 0 failures** (includes the seven image-snapshot suites, which run locally; no reference drift).
- `tools/preflight.sh --only <group>` for every group — `go`, `web`, `arch`, `tools`, `skills`, `posix`, `bash`, `security`, `swift`: all **PASS**. (`linux` not run — macOS-only Swift change.)

One flake seen and chased down rather than waved off: `TestBackchannelHerdrE2E`
(`core/cmd/irrlichd`) failed once with `server_not_running … herdr.sock`, and
passed on re-run and on a full re-run of the `go` gate. It drives the external
`herdr` CLI and depends on a herdr server socket; this diff contains no Go
files (`git diff --name-only origin/main...HEAD` is the two `platforms/macos/`
files), and the same gate passed on an earlier commit of this branch.

## Review and simplify passes

A review subagent at `medium` effort returned six findings, all applied: the
section-level test above (its best one), `.lineLimit` scoped to the
compressible path so the "byte-identical for other callers" claim holds by
construction rather than by audit, a derived rather than hand-typed 348pt
figure, layout tolerances on two assertions that landed exactly on their bound,
guards that assert *what* the hierarchy walk found rather than only how much,
and a comment attached to the wrong parameter.

The `/simplify` pass ran all four angles. **Reuse**: `idealWidth` now hosts
through `PinnedSnapshotHost` rather than a bare `NSHostingView` — the row
carries an `@AppStorage` sound choice, so an unpinned host reads the real
`com.apple.dt.xctest.tool` domain, and a `.speak(voice)` sitting there renders
a second line and changes the measurement (#1672's seam); panel-hosting
boilerplate is now one factory. **Simplification**: the mechanism explanation
was stated five times and is now stated once at the fix site; `.truncationMode(.tail)`
dropped as a no-op (it is SwiftUI's default); tuple-with-`.nan`-sentinels
replaced by `XCTUnwrap`; one `layoutTolerance` constant; copy-paste assertion
pairs collapsed. **Efficiency**: no findings — measured, the three new tests add
0.281s to a job dominated by a ~21s compile. **Altitude**: one finding applied —
`testTheWidestRow…` asserted `==` the content box, freezing the zero-slack
accident as a contract, so narrowing the 112pt picker later would have gone red
with a message steering the reader to update the constant instead; it is now
`<=`, which is the property the panel needs.

Two altitude suggestions **not** taken, deliberately:

- *Flip `compressibleLabel` to default true* (i.e. make every `LeadingToggle`
  compressible). The argument is good — `PermissionWizardView` passes a
  daemon-supplied `perm.title`, the one label this repo can lengthen from Go
  without touching Swift, and it has the same panel geometry. But it changes
  horizontal sizing for 13 call sites that are not implicated in this bug, to
  fix a latent risk that currently has ~110pt of slack. Out of scope for a
  margin fix; worth its own issue.
- *Pin the scroll content leading in `SettingsView.body`* so no row can ever
  shift it. Rejected on the reviewer's own reasoning: what it would hold the
  inset with is silent clipping, and the thing clipped here is the ▶ preview
  button — an interactive control. That turns a loud symptom (the panel visibly
  slides, which is how #1854 got reported) into a quiet one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
