### PR TITLE
feat(skills): make ir:test-mac a script; the skill only links it

### DIFF
--- a/.claude/skills/ir:test-mac/SKILL.md
+++ b/.claude/skills/ir:test-mac/SKILL.md
@@ -2,463 +2,139 @@
 name: ir:test-mac
 description: >
   Build and run a dev irrlicht daemon and/or macOS Swift app for local
-  testing. Two independent axes: MODE (replace, default — takes over
-  production on port 7837/production state; separate — coexists on port
-  7838/isolated state) and TARGET (full, default — daemon + app; daemon —
-  just rebuild+restart irrlichd, leave the running app to reconnect; macos —
-  just rebuild+relaunch the Swift app against whatever daemon is already up).
+  testing, by invoking this skill's own test-mac.sh. Two independent axes:
+  MODE (replace, default — takes over production on port 7837/production
+  state; separate — coexists on port 7838/isolated state) and TARGET (full,
+  default — daemon + app; daemon — just rebuild+restart irrlichd, leave the
+  running app to reconnect; macos — just rebuild+relaunch the Swift app
+  against whatever daemon is already up).
   Use when the user says "test mac", "restart mac", "rebuild mac",
   "restart just the daemon", "rebuild the mac app only", or "/ir:test-mac".
 ---
 
-# Build & Run macOS Dev Stack (replace by default; componentized restart)
+# Build & Run the macOS Dev Stack
 
-Build the irrlicht daemon and/or Swift app, then run them, governed by two
-independent axes:
+**The procedure is a script. Run it — do not reimplement it inline.**
 
-- **MODE** — `replace` (default) or `separate`:
-  - **replace** — take over from production. Kill the running production
-    app + daemon (and any dev instance), then run the freshly built dev
-    binaries on the **production port 7837** with the **production state
-    dir** (no `IRRLICHT_HOME` override). Because it's on 7837 it receives the
-    statusline quota feed and sees the same on-disk sessions/cost data —
-    i.e. it behaves like production but runs your dev code. There is only
-    one instance afterward, and the Swift app is installed **directly into
-    `/Applications/Irrlicht.app`** (see TARGET below) rather than a separate
-    bundle, since a human only ever looks at one running app.
-  - **separate** — a dev instance that **coexists with production**. The dev
-    daemon binds port **7838** and stores its state under a worktree-local
-    `IRRLICHT_HOME`; the dev app is assembled at `/tmp/IrrlichtDev.app` and
-    connects to 7838 via `IRRLICHT_DAEMON_PORT`. Production stays up
-    untouched on 7837. Since #1178 the Claude Code hooks and statusline feed
-    follow the daemon's own bind address, so the dev daemon receives them —
-    but it installs them into the shared `~/.claude/settings.json`, which
-    repoints production's hooks at 7838 until production restarts.
-- **TARGET** — `full` (default), `daemon`, or `macos`:
-  - **full** — rebuild and restart both the daemon and the app. Today's only
-    behavior before this axis existed.
-  - **daemon** — rebuild + restart just `irrlichd`; skip the Swift
-    build/install/relaunch steps entirely and leave whatever app is
-    currently running to reconnect to the fresh daemon.
-  - **macos** — rebuild + relaunch just the Swift app, pointed at whatever
-    daemon is already up (adopts it — same adoption behavior `full` relies
-    on). Requires a daemon to already be reachable on the target port; it
-    does not start one.
+```bash
+.claude/skills/ir:test-mac/test-mac.sh [MODE] [TARGET]     # defaults: replace full
+.claude/skills/ir:test-mac/test-mac.sh --help              # the full contract
+```
 
-  These compose: e.g. "replace, daemon only" tests a Go-only change against
-  the currently-open production-replacing app; "separate, macos only"
-  iterates on Swift UI against an already-running isolated dev daemon.
+Both arguments are optional and may be given in either order. This file says
+*which* arguments to pass and what they cost; `test-mac.sh` is the only place
+the steps themselves live, and `restore-prod.sh` beside it is the teardown
+half of the same workflow.
 
-## Steps
+Why a script and not fenced blocks to copy out (#1855): every step branches on
+`MODE`/`TARGET`/`PORT`/`DEV_HOME`/`SOCK`, and each fenced block an agent copies
+out runs in a **fresh shell**. A value dropped between blocks failed silently —
+an empty `$PORT` made the daemon bind `127.0.0.1:` (invalid), an empty `$SOCK`
+turned the socket cleanup into a no-op that reported nothing. One script is one
+variable scope, and that whole class is gone.
 
-0. **Set the run config.** Default to `MODE=replace` and `TARGET=full` —
-   don't ask. Only change `MODE` to `separate` when the user explicitly
-   requested it (e.g. `/ir:test-mac separate`, or "alongside production" /
-   "don't touch production"). Only change `TARGET` when the user asked to
-   restart just one component (e.g. "just restart the daemon", "rebuild the
-   mac app only"). Note that replace is destructive (it kills production and
-   lets a dev binary read/write production state, and — for `TARGET=macos`
-   or `full` — overwrites `/Applications/Irrlicht.app`'s executable in
-   place); that's the intended default, but it's why the final teardown step
-   is required to get production back.
+## Picking the arguments
 
-   Every later step branches on `$MODE`/`$TARGET`/`$PORT`/`$DEV_HOME`/`$SOCK`.
-   **These are shell variables, and each fenced block runs in a fresh
-   shell**, so when you execute a later step you must carry the step-0
-   values forward (re-declare them, or inline the literal port/path) — an
-   empty `$PORT` makes the daemon bind `127.0.0.1:` (invalid) and an empty
-   `$SOCK` turns the socket cleanup into a no-op.
-   ```bash
-   REPO_ROOT="$(git rev-parse --show-toplevel)"        # worktree root if in a worktree, else main repo
-   IRRLICHTD_BIN="/Users/ingo/projects/irrlicht/core/bin/irrlichd"  # stable path: build target == launch target
-   PROD_APP="/Applications/Irrlicht.app"                            # replace mode installs directly here
-   PROD_BACKUP="/Users/ingo/projects/irrlicht/.build/irrlicht-prod-backup/Irrlicht.app"  # untouched-original copy, made once
-   DEV_APP="/tmp/IrrlichtDev.app"                                   # separate mode only
-   MODE="replace"         # default; set to "separate" only if the user explicitly asked for it
-   TARGET="full"          # default; set to "daemon" or "macos" to restart just one component
+**Default to `replace full` — don't ask.** Change an axis only when the user
+actually asked for it.
 
-   # Every later gate is an exact-string check with no default branch — a
-   # typo here (e.g. "seperate") would otherwise silently no-op every step
-   # instead of erroring, so validate the two literals up front.
-   case "$MODE" in
-     replace|separate) ;;
-     *) echo "ERROR: MODE must be 'replace' or 'separate' (got '$MODE')" >&2; exit 1 ;;
-   esac
-   case "$TARGET" in
-     daemon|macos|full) ;;
-     *) echo "ERROR: TARGET must be 'daemon', 'macos', or 'full' (got '$TARGET')" >&2; exit 1 ;;
-   esac
+- **MODE=`separate`** only on an explicit request: `/ir:test-mac separate`,
+  "alongside production", "don't touch production".
+- **TARGET=`daemon`/`macos`** only when the user asked to restart one
+  component: "just restart the daemon", "rebuild the mac app only".
 
-   if [ "$MODE" = "replace" ]; then
-     PORT=7837                                          # production port
-     DEV_HOME=""                                        # no IRRLICHT_HOME override → production state dir
-     SOCK="$HOME/.local/share/irrlicht/irrlichd.sock"   # production socket
-     APP_TARGET="$PROD_APP"
-   else
-     PORT=7838                                          # isolated dev port
-     DEV_HOME="$REPO_ROOT/.build/irrlicht-home"         # isolated state dir (IRRLICHT_HOME)
-     SOCK="$DEV_HOME/irrlichd.sock"
-     APP_TARGET="$DEV_APP"
-     mkdir -p "$DEV_HOME"
-   fi
-   echo "MODE=$MODE TARGET=$TARGET PORT=$PORT DEV_HOME=${DEV_HOME:-<production>}"
-   ```
-   `$IRRLICHTD_BIN` is the main repo's bin (a stable absolute path) so the
-   build and launch steps always agree even when `$REPO_ROOT` is a worktree
-   — the source compiled is still the worktree's (`go build` runs in
-   `$REPO_ROOT/core`). `$PROD_BACKUP` is likewise a stable main-repo path
-   (not worktree-relative) so it survives across worktree runs and removals.
+### MODE
 
-1. **Build the Go daemon** — the daemon resolves the dashboard from
-   `platforms/web/index.html` at runtime via a walk-up search from its own
-   executable; no embed, no codegen. Skipped when `TARGET=macos` (no daemon
-   change requested).
-   ```bash
-   if [ "$TARGET" = "daemon" ] || [ "$TARGET" = "full" ]; then
-     cd "$REPO_ROOT/core" && go build -o "$IRRLICHTD_BIN" ./cmd/irrlichd
-   fi
-   ```
-   Note: the binary is built from the worktree's source but placed at the
-   stable `$IRRLICHTD_BIN` path that the start-daemon step launches.
+- **`replace`** (default) — take over from production. Kills the running
+  production app + daemon (and any dev instance), then runs the freshly built
+  dev binaries on the **production port 7837** with the **production state
+  dir** (no `IRRLICHT_HOME` override). Because it is on 7837 it receives the
+  statusline quota feed and sees the same on-disk sessions/cost data — it
+  behaves like production but runs your dev code. There is one instance
+  afterward, and the Swift app is installed **directly into
+  `/Applications/Irrlicht.app`** rather than a separate bundle, since a human
+  only ever looks at one running app. **Destructive — see Tearing down.**
+- **`separate`** — a dev instance that **coexists with production**. The dev
+  daemon binds port **7838** and stores its state under a worktree-local
+  `IRRLICHT_HOME`; the dev app is assembled at `/tmp/IrrlichtDev.app` and
+  connects to 7838 via `IRRLICHT_DAEMON_PORT`. Production stays up untouched on
+  7837. Since #1178 the Claude Code hooks and statusline feed follow the
+  daemon's own bind address, so the dev daemon receives them — but it installs
+  them into the shared `~/.claude/settings.json`, which repoints production's
+  hooks at 7838 until production restarts.
 
-2. **Build the Swift app** (compile only — no bundle mutation yet). Skipped
-   when `TARGET=daemon` (no app change requested). Building is safe to do
-   before killing anything since it only writes into `.build/`; the actual
-   install into a live bundle happens after the kill step below.
-   ```bash
-   if [ "$TARGET" = "macos" ] || [ "$TARGET" = "full" ]; then
-     cd "$REPO_ROOT/platforms/macos" && swift build 2>&1 | tail -5
-   fi
-   ```
+### TARGET
 
-3. **Kill the instances this mode+target replaces.** Daemon and app are
-   killed independently so a `TARGET=daemon`/`macos`-only run leaves the
-   other component alone. The app is killed *before* the daemon (matching
-   `restore-prod.sh`'s order) so a still-alive app never observes a
-   momentary daemon-less gap and reacts by spawning its own replacement,
-   which could win the port race against the daemon step 6 starts next.
-   ```bash
-   if [ "$TARGET" = "macos" ] || [ "$TARGET" = "full" ]; then
-     if [ "$MODE" = "replace" ]; then
-       APP_KILL_PATTERN="Irrlicht\.app/Contents/MacOS/Irrlicht"  # about to have its executable overwritten in place
-       pkill -f "$APP_KILL_PATTERN" 2>/dev/null
-       pkill -f "IrrlichtDev"       2>/dev/null   # any leftover separate-mode dev app, for tidiness
-     else
-       APP_KILL_PATTERN="IrrlichtDev"   # prior dev app only
-       pkill -f "$APP_KILL_PATTERN" 2>/dev/null
-     fi
-     # step 5 is about to back up / overwrite this same app's on-disk bundle
-     # (replace mode) — wait for the process to actually exit rather than a
-     # flat sleep, so we never copy or overwrite files a dying process still
-     # has open.
-     for _ in 1 2 3 4 5; do
-       pgrep -f "$APP_KILL_PATTERN" >/dev/null 2>&1 || break
-       sleep 1
-     done
-     if [ "$MODE" = "replace" ] && pgrep -f "$APP_KILL_PATTERN" >/dev/null 2>&1; then
-       echo "ABORT: the app process is still running — refusing to overwrite its bundle in step 5." >&2
-       return 1 2>/dev/null || exit 1
-     fi
-   fi
-   if [ "$TARGET" = "daemon" ] || [ "$TARGET" = "full" ]; then
-     if [ "$MODE" = "replace" ]; then
-       pkill -x "irrlichd" 2>/dev/null   # ALL daemons by exact name (prod's bundled one + any standalone dev one)
-     else
-       pkill -f "core/bin/irrlichd" 2>/dev/null   # prior dev daemon only (NOT production)
-     fi
-     PORT_PIDS="$(lsof -ti tcp:$PORT 2>/dev/null)"   # belt-and-suspenders: anything still on the target port
-     [ -n "$PORT_PIDS" ] && kill $PORT_PIDS 2>/dev/null
-     sleep 1
-   fi
-   ```
+- **`full`** (default) — rebuild and restart both the daemon and the app.
+- **`daemon`** — rebuild + restart just `irrlichd`; skip the Swift
+  build/install/relaunch entirely and leave whatever app is currently running
+  to reconnect to the fresh daemon.
+- **`macos`** — rebuild + relaunch just the Swift app, pointed at whatever
+  daemon is already up (adopts it — the same adoption behaviour `full` relies
+  on). Requires a daemon to already be reachable on the target port; it does
+  not start one.
 
-4. **Clean up the stale socket** for the target instance. Only meaningful
-   when the daemon is (re)starting.
-   ```bash
-   if [ "$TARGET" = "daemon" ] || [ "$TARGET" = "full" ]; then
-     rm -f "$SOCK"
-   fi
-   ```
+The axes compose: `replace daemon` tests a Go-only change against the
+currently-open production-replacing app; `separate macos` iterates on Swift UI
+against an already-running isolated dev daemon.
 
-5. **Install the app bundle.** Skipped when `TARGET=daemon`.
-   - **replace** — install straight into `$PROD_APP` (no more parallel
-     `/tmp/IrrlichtDev.app`, since it shares production's bundle identifier
-     and a human only reviews one running app at a time). Back up the
-     **untouched** original bundle as a full directory copy — a full-bundle
-     backup sidesteps any code-signature mismatch between the outer bundle
-     and its nested binaries that a partial-file restore could otherwise
-     leave behind. The teardown step restores from this copy.
+## Tearing down (replace mode) — REQUIRED to get production back
 
-     The backup is refreshed (not just made once-ever) whenever the
-     currently-installed app is still genuinely Developer-ID-signed — never
-     trust an existing backup blindly, since it can predate a newer
-     production release installed since (e.g. via `/ir:release`), which
-     would otherwise make the teardown step silently reinstall a stale
-     build. If the app is *not* currently Developer-ID-signed (a prior
-     replace-mode run's dev build, still installed) and no backup exists
-     either, refuse to proceed rather than overwriting the only remaining
-     copy without a safety net. The build outputs are also checked for
-     existence before anything in the live bundle is touched, so a failed
-     `swift build` aborts here instead of leaving `Sparkle.framework`
-     deleted with nothing to replace it.
-     ```bash
-     if [ "$TARGET" = "macos" ] || [ "$TARGET" = "full" ]; then
-       if [ "$MODE" = "replace" ]; then
-         DEBUG_BIN="$REPO_ROOT/platforms/macos/.build/arm64-apple-macosx/debug/Irrlicht"
-         DEBUG_SPARKLE="$REPO_ROOT/platforms/macos/.build/arm64-apple-macosx/debug/Sparkle.framework"
-         if [ ! -x "$DEBUG_BIN" ] || [ ! -d "$DEBUG_SPARKLE" ]; then
-           echo "ERROR: swift build did not produce $DEBUG_BIN / $DEBUG_SPARKLE — not touching $PROD_APP." >&2
-           exit 1
-         fi
-         if [ ! -d "$PROD_APP" ]; then
-           echo "ERROR: $PROD_APP is not installed — run the DMG/PKG installer first." >&2
-           exit 1
-         fi
-         if codesign -dv --verbose=4 "$PROD_APP" 2>&1 | grep -q "^Authority=Developer ID Application"; then
-           rm -rf "$PROD_BACKUP"
-           mkdir -p "$(dirname "$PROD_BACKUP")"
-           if ! cp -R "$PROD_APP" "$PROD_BACKUP"; then
-             echo "ERROR: backup of $PROD_APP to $PROD_BACKUP failed — not touching $PROD_APP." >&2
-             rm -rf "$PROD_BACKUP"
-             exit 1
-           fi
-           echo "Backed up the untouched production bundle to $PROD_BACKUP (restore-prod.sh restores from this)."
-         elif [ ! -d "$PROD_BACKUP" ]; then
-           echo "ERROR: $PROD_APP isn't Developer-ID-signed (looks like a leftover dev build) and no backup exists — refusing to overwrite it with no safety net. Run the DMG/PKG installer first." >&2
-           exit 1
-         fi
-         cp "$DEBUG_BIN" "$APP_TARGET/Contents/MacOS/Irrlicht"
-         rm -rf "$APP_TARGET/Contents/Frameworks/Sparkle.framework"
-         cp -R "$DEBUG_SPARKLE" "$APP_TARGET/Contents/Frameworks/Sparkle.framework"
-         # Refresh the icon too, so a developer iterating on Resources/ assets
-         # sees the same result in replace mode as in separate mode instead of
-         # a stale production copy.
-         cp "$REPO_ROOT/platforms/macos/Irrlicht/Resources/AppIcon.icns" "$APP_TARGET/Contents/Resources/AppIcon.icns"
-         # Stamp the version string too — otherwise Info.plist still carries
-         # whatever release version was last installed (e.g. "0.5.7"), so
-         # Settings/About would show a stale release version on a dev build
-         # even though the binary itself is freshly compiled from source.
-         # Matches separate mode's hardcoded "dev" (see its Info.plist template
-         # below) so both modes read the same in the UI.
-         /usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString dev" "$APP_TARGET/Contents/Info.plist"
-         /usr/libexec/PlistBuddy -c "Set :CFBundleVersion dev" "$APP_TARGET/Contents/Info.plist"
-         # The SwiftPM debug binary links Sparkle as @rpath/Sparkle.framework but only
-         # carries an @loader_path rpath (= Contents/MacOS) — it lacks the bundle-layout
-         # rpath a release .app build adds. Without this, dyld can't find the embedded
-         # framework and the app crashes at launch. (Must run BEFORE the codesign step
-         # below, since it mutates the binary and invalidates the signature.)
-         install_name_tool -add_rpath @executable_path/../Frameworks "$APP_TARGET/Contents/MacOS/Irrlicht"
-       fi
-     fi
-     ```
-   - **separate** — unchanged: assemble a fresh `/tmp/IrrlichtDev.app` bundle
-     from scratch so `UNUserNotificationCenter` (desktop notifications) works.
-     ```bash
-     if [ "$TARGET" = "macos" ] || [ "$TARGET" = "full" ]; then
-       if [ "$MODE" = "separate" ]; then
-         rm -rf "$APP_TARGET"
-         mkdir -p "$APP_TARGET/Contents/MacOS" "$APP_TARGET/Contents/Resources"
-         cp "$REPO_ROOT/platforms/macos/.build/arm64-apple-macosx/debug/Irrlicht" "$APP_TARGET/Contents/MacOS/Irrlicht"
-         cp "$REPO_ROOT/platforms/macos/Irrlicht/Resources/AppIcon.icns" "$APP_TARGET/Contents/Resources/AppIcon.icns"
-         # Embed Sparkle.framework (required since v0.4.7 auto-update integration)
-         mkdir -p "$APP_TARGET/Contents/Frameworks"
-         cp -R "$REPO_ROOT/platforms/macos/.build/arm64-apple-macosx/debug/Sparkle.framework" "$APP_TARGET/Contents/Frameworks/"
-         install_name_tool -add_rpath @executable_path/../Frameworks "$APP_TARGET/Contents/MacOS/Irrlicht"
-     cat > "$APP_TARGET/Contents/Info.plist" << 'PLIST'
-     <?xml version="1.0" encoding="UTF-8"?>
-     <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-     <plist version="1.0">
-     <dict>
-         <key>CFBundleExecutable</key>
-         <string>Irrlicht</string>
-         <key>CFBundleIdentifier</key>
-         <string>io.irrlicht.app</string>
-         <key>CFBundleIconFile</key>
-         <string>AppIcon</string>
-         <key>CFBundleName</key>
-         <string>Irrlicht Dev</string>
-         <key>CFBundlePackageType</key>
-         <string>APPL</string>
-         <key>CFBundleShortVersionString</key>
-         <string>dev</string>
-         <key>LSUIElement</key>
-         <true/>
-         <key>NSAppleEventsUsageDescription</key>
-         <string>Irrlicht uses AppleScript to bring the correct iTerm2 or Terminal.app window and tab to the front when you click a session row.</string>
-         <key>NSFocusStatusUsageDescription</key>
-         <string>Irrlicht uses macOS Focus status to silence notification sounds and spoken alerts while you're in Do Not Disturb, Sleep, or any other Focus mode.</string>
-     </dict>
-     </plist>
-     PLIST
-       fi
-     fi
-     ```
-   - **codesign (both modes, identical).** Sign with the persistent
-     "Irrlicht Dev" identity if it exists; otherwise fall back to ad-hoc (TCC
-     permissions will need to be re-granted each rebuild). Run
-     `tools/dev-sign-setup.sh` once to install the identity. Uses the
-     dev-only entitlements file (no `com.apple.developer.*` entries — Apple
-     gates those to its own certificates and launchd will refuse to spawn a
-     self-signed/ad-hoc binary that claims them).
-     ```bash
-     if [ "$TARGET" = "macos" ] || [ "$TARGET" = "full" ]; then
-       ENTITLEMENTS="$REPO_ROOT/platforms/macos/Irrlicht/Resources/Irrlicht-dev.entitlements"
-       if security find-identity -v -p codesigning 2>/dev/null | grep -q "Irrlicht Dev"; then
-           codesign --force --deep --sign "Irrlicht Dev" --entitlements "$ENTITLEMENTS" "$APP_TARGET" 2>&1
-       else
-           codesign --force --deep --sign - --entitlements "$ENTITLEMENTS" "$APP_TARGET" 2>&1
-       fi
-     fi
-     ```
-     Heads up for **replace** mode specifically: since the dev build is now
-     signed and launched at production's own path, expect one extra
-     Accessibility/Automation re-grant prompt the first time this runs after
-     picking up this change (TCC keys grants off path + code identity, and
-     the dev identity is new at this path) — the stable "Irrlicht Dev"
-     identity should keep that grant across subsequent dev rebuilds, and
-     production's original grant (tied to its own Developer ID signature) is
-     unaffected once restored.
+Quitting the app is **not** enough, for two independent reasons:
 
-6. **Start the daemon** with `--record` for lifecycle event capture. Skipped
-   when `TARGET=macos`. In **separate** mode it gets `IRRLICHT_HOME`
-   (isolated state) plus `IRRLICHT_PERMISSION_MODE=grant-all` — a fresh
-   isolated state dir has no consent answers (#570), so without it the
-   daemon monitors nothing until the permission wizard is answered. Drop
-   that variable when the point of the session is to test the wizard
-   itself. In **replace** mode `IRRLICHT_HOME` is omitted so it reads/writes
-   the production state dir — including the user's real permission answers
-   (no grant-all there).
+- **The daemon**: in replace mode the app only *adopted* the daemon the script
+  started (it never owns the process — `DaemonManager.start()` returns early on
+  a reachable daemon without recording it, so its `terminateProcess()` is a
+  no-op), and that daemon was `nohup`'d, so it keeps running on 7837 after the
+  app exits. A relaunched production app would find it reachable and **adopt
+  it** — you would be running the production UI against the dev `--record`
+  daemon without realising it.
+- **The app itself** (after a `TARGET=macos`/`full` run): its executable +
+  `Sparkle.framework` inside `/Applications/Irrlicht.app` were overwritten with
+  the dev build, so relaunching that bundle launches the **dev** binary.
 
-   **Separate mode does NOT install hooks, by design (#1449).** `IRRLICHT_HOME`
-   isolates daemon state; it does not move `~/.claude/settings.json`,
-   `~/.codex/hooks.json` or `~/.config/kitty/kitty.conf`, which follow `$HOME`.
-   A grant-all daemon on port 7838 that installed hooks would repoint your
-   REAL config at 7838 and leave it there when the dev daemon dies — that is
-   the incident #1449 was filed for, and it had already happened three times.
-   So those installs are now refused, with an error naming each file, and the
-   permission shows as "granted but NOT applied" in the wizard. Everything not
-   backed by a shared config file (transcripts, watchers, control) works
-   normally. To test hook installation itself, back the files up
-   (`irrlichd --print-managed-files` lists them) and add
-   `IRRLICHT_ALLOW_SHARED_CONFIG_WRITES=1` — then restore them afterwards.
-   ```bash
-   if [ "$TARGET" = "daemon" ] || [ "$TARGET" = "full" ]; then
-     if [ "$MODE" = "replace" ]; then
-       IRRLICHT_BIND_ADDR=127.0.0.1:$PORT \
-         nohup "$IRRLICHTD_BIN" --record > /tmp/irrlichd-dev.log 2>&1 & disown
-     else
-       IRRLICHT_HOME="$DEV_HOME" IRRLICHT_BIND_ADDR=127.0.0.1:$PORT \
-         IRRLICHT_PERMISSION_MODE=grant-all \
-         nohup "$IRRLICHTD_BIN" --record > /tmp/irrlichd-dev.log 2>&1 & disown
-     fi
-   fi
-   ```
+```bash
+.claude/skills/ir:test-mac/restore-prod.sh
+```
 
-7. **Wait for a reachable daemon — and HARD-ABORT if there isn't one.** This
-   is a gate, not a courtesy sleep. In replace mode the app adopts an
-   already-reachable daemon on 7837 and skips its own spawn/pkill; if no
-   `--record` daemon is up when the app launches, the app (port 7837 ⇒
-   `isCustomPort` false) runs `pkill -x irrlichd` — killing whatever daemon
-   is there — and respawns one **without** `--record`, silently defeating
-   the whole point. So if `/state` never answers, stop here and do not
-   launch the app.
-   ```bash
-   if [ "$TARGET" = "daemon" ] || [ "$TARGET" = "full" ]; then
-     # We just (re)started this daemon above — poll for it to come up.
-     READY=""
-     for i in 1 2 3 4 5 6 7 8; do
-       curl -fsS --max-time 1 "http://127.0.0.1:$PORT/state" >/dev/null 2>&1 && { READY=1; break; }
-       sleep 1
-     done
-     if [ -z "$READY" ]; then
-       echo "ABORT: daemon never became reachable on $PORT — not launching the app." >&2
-       echo "       (Launching now would let the app pkill our daemon and respawn one without --record.)" >&2
-       echo "       Check /tmp/irrlichd-dev.log." >&2
-       return 1 2>/dev/null || exit 1
-     fi
-   else
-     # TARGET=macos: we didn't (re)start a daemon — one must already be
-     # reachable for the app to adopt, or it will spawn its own (without
-     # --record, in replace mode).
-     if ! curl -fsS --max-time 1 "http://127.0.0.1:$PORT/state" >/dev/null 2>&1; then
-       echo "ABORT: no daemon reachable on $PORT and TARGET=macos doesn't start one." >&2
-       echo "       Run with TARGET=daemon or TARGET=full first." >&2
-       return 1 2>/dev/null || exit 1
-     fi
-   fi
-   lsof -iTCP:$PORT -sTCP:LISTEN -P -n 2>/dev/null
-   ```
+It does the whole sequence: kill the app + daemon → restore the backed-up
+production bundle if a dev overwrite ever happened → **gate** on 7837 actually
+freeing → launch `/Applications/Irrlicht.app` → confirm production's own daemon
+comes up. Running the DMG/PKG installer is **not** a substitute: it replaces the
+app bundle but leaves the dev daemon on 7837, which the freshly installed app
+would still adopt.
 
-8. **Start the app** — launched via LaunchServices so `Bundle.main` resolves
-   correctly. Skipped when `TARGET=daemon`. In **separate** mode,
-   `IRRLICHT_DAEMON_PORT`/`IRRLICHT_HOME` point it at the isolated dev
-   daemon. In **replace** mode, no env overrides are passed: the app uses
-   the default port 7837 + production state and, finding the daemon already
-   reachable, adopts it instead of spawning its own.
-   ```bash
-   if [ "$TARGET" = "macos" ] || [ "$TARGET" = "full" ]; then
-     if [ "$MODE" = "replace" ]; then
-       open --stdout /tmp/irrlicht-app-dev.log --stderr /tmp/irrlicht-app-dev.log "$APP_TARGET"
-     else
-       open --env IRRLICHT_DAEMON_PORT=$PORT --env IRRLICHT_HOME="$DEV_HOME" \
-         --stdout /tmp/irrlicht-app-dev.log --stderr /tmp/irrlicht-app-dev.log "$APP_TARGET"
-     fi
-   fi
-   ```
+## What the script refuses to do
 
-9. **Verify** — whichever components this run touched are up, and the
-   daemon is serving sessions. In replace mode, also confirm quota data is
-   present (the whole point of 7837).
-   ```bash
-   if [ "$TARGET" = "daemon" ] || [ "$TARGET" = "full" ]; then
-     pgrep -f "bin/irrlichd" && curl -s http://127.0.0.1:$PORT/api/v1/sessions | head -c 200
-   fi
-   if [ "$TARGET" = "macos" ] || [ "$TARGET" = "full" ]; then
-     if [ "$MODE" = "replace" ]; then
-       pgrep -f "Irrlicht\.app/Contents/MacOS/Irrlicht"
-     else
-       pgrep -f "IrrlichtDev"
-     fi
-   fi
-   if [ "$MODE" = "replace" ]; then
-     # 0 is normal right after launch — quota data only appears once Claude Code's
-     # statusline posts its next tick to 7837 (seconds to a minute). Re-run to confirm.
-     echo; echo "rate-limit mentions (0 now is fine; should climb after the next statusline tick):" \
-       "$(curl -s http://127.0.0.1:$PORT/api/v1/sessions | grep -o 'rate_limit\|used_percent' | wc -l | tr -d ' ')"
-   fi
-   ```
+These gates are load-bearing and each one's failure mode is silence rather than
+an error. `tools/lib/test-mac-script_test.sh` drives the script against stubs
+and asserts every one of them;
+`tools/lib/test-mac-script-mutations_test.sh` breaks each in turn and requires
+that lock test to go red. Both run inside `tools/preflight.sh --only tools`.
 
-10. **Tearing down (replace mode) — REQUIRED to get production back.**
-    Quitting the app is NOT enough, for two independent reasons:
-    - **The daemon**: in replace mode the app only *adopted* the daemon
-      started in step 6 (it never owns the process —
-      `DaemonManager.start()` returns early on a reachable daemon without
-      recording it, so its `terminateProcess()` is a no-op), and that
-      daemon was `nohup`/`disown`'d, so it keeps running on 7837 after the
-      app exits. A relaunched production app would find it still reachable
-      and **adopt it** — you'd be running the production UI against the dev
-      `--record` daemon without realizing it.
-    - **The app itself** (only if a `TARGET=macos`/`full` run happened): its
-      executable + Sparkle.framework inside `/Applications/Irrlicht.app`
-      were overwritten with the dev build. Relaunching that bundle launches
-      the **dev** binary, not production, until it's restored.
-
-    Use the bundled **`restore-prod.sh`** — it does the whole sequence (kill
-    the app + daemon → restore the backed-up production bundle if one was
-    ever overwritten → GATE on 7837 actually freeing → launch
-    `/Applications/Irrlicht.app` → confirm prod's own daemon comes up). Note:
-    the installer does NOT substitute for this teardown by itself — it
-    replaces the app bundle, but leaves the dev daemon running on 7837 (which
-    the freshly-installed app would still adopt), so run this script (or at
-    least the `pkill -x irrlichd`) regardless.
-    ```bash
-    "$(git rev-parse --show-toplevel)/.claude/skills/ir:test-mac/restore-prod.sh"
-    ```
+- An unrecognised `MODE`/`TARGET` is refused, not defaulted — a typo like
+  `seperate` would otherwise no-op every later step instead of erroring.
+- The app is killed **before** the daemon, so a live app never observes a
+  daemon-less gap and races to spawn its own replacement.
+- It waits for the app process to actually exit before touching its bundle, and
+  hard-aborts if it outlives the wait.
+- It refuses to install a build product that is missing, stale (any `.swift`
+  source newer than the built binary), or produced by a failed `swift build`.
+- It refreshes the production backup whenever `/Applications/Irrlicht.app` is
+  still Developer-ID-signed, and **refuses to proceed** when the app is
+  dev-signed and no backup exists.
+- It hard-aborts rather than launching the app when no daemon answers on the
+  target port — a gate, not a courtesy sleep. If the app starts with nothing
+  reachable on 7837 it runs `pkill -x irrlichd` and respawns a daemon **without**
+  `--record`, silently defeating the run.
 
 ## Notes
-- **separate mode — production keeps running.** The production Irrlicht.app (from DMG) and its bundled daemon stay on port 7837 with state under `~/.local/share/irrlicht/` + `~/Library/Application Support/Irrlicht/`. The dev instance binds port 7838 and routes its WRITTEN state — socket, recordings, history, session store, ledgers, and cost store — beneath `IRRLICHT_HOME=$DEV_HOME`, so it never prunes or mutates production's session/cost data. The dev app reaches the dev daemon because `IRRLICHT_DAEMON_PORT` (via `open --env`) overrides the hardcoded default; `DaemonManager` also skips its global `pkill` when a custom port is set, so it can't take production down.
+
+- **separate mode — production keeps running.** The production Irrlicht.app (from DMG) and its bundled daemon stay on port 7837 with state under `~/.local/share/irrlicht/` + `~/Library/Application Support/Irrlicht/`. The dev instance binds port 7838 and routes its WRITTEN state — socket, recordings, history, session store, ledgers, and cost store — beneath `IRRLICHT_HOME`, so it never prunes or mutates production's session/cost data. The dev app reaches the dev daemon because `IRRLICHT_DAEMON_PORT` (via `open --env`) overrides the hardcoded default; `DaemonManager` also skips its global `pkill` when a custom port is set, so it can't take production down.
 - **separate mode shares with production:** it reads the same `~/.claude` transcripts (so the dev UI shows the same live sessions) and appends to the same `~/Library/Application Support/Irrlicht/logs/events.log`. It does NOT share the on-disk session/ledger/cost stores. It DOES receive the hook + statusline quota feed since #1178 (both follow `IRRLICHT_BIND_ADDR`), at the cost of repointing the shared `~/.claude/settings.json` at 7838 for as long as the dev daemon is the last one to have installed — production picks its own port back up on its next start.
-- **replace mode — single instance on production's footprint.** Runs the dev binaries on port 7837 with the production state dir (no `IRRLICHT_HOME`), so the statusline quota feed and the production session/cost/ledger stores all apply, and (for `TARGET=macos`/`full`) the Swift app is installed directly into `/Applications/Irrlicht.app` rather than a parallel bundle. Because the dev daemon runs with `--record`, recordings land in the production recordings dir (`~/.local/share/irrlicht/recordings/`). **⚠️ The dev daemon mutates production data.** Without `IRRLICHT_HOME` its startup sweeps (`PruneStale` / dead-proc / orphan-ledger / cost prune) run against the real `~/.local/share/irrlicht/` + `~/Library/Application Support/Irrlicht/` stores — this is exactly the isolation #448 added, deliberately removed here. Only use replace mode when the dev build's on-disk schema matches the installed production build; a dev branch mid-migration can prune or rewrite production sessions/ledgers/cost rows that the production binary then misreads. **Returning to production requires the teardown step** (run `restore-prod.sh`) — quitting the app does NOT stop the adopted daemon, and a relaunched (or freshly *reinstalled*) production app will silently adopt the leftover dev daemon on 7837 if you skip it. Running the installer is not a substitute: it replaces the app bundle, not the running daemon.
-- **Backup freshness.** `PROD_BACKUP` is refreshed automatically whenever step 5 finds `$PROD_APP` still Developer-ID-signed (i.e. a genuine, untouched production build) — so installing a *new* production release via the DMG/PKG installer, then running replace mode again, correctly captures the new release as the restore baseline instead of reinstalling a stale one. If `$PROD_APP` is already dev-signed (mid-test) and `PROD_BACKUP` is missing (e.g. `.build` was wiped), step 5 refuses to proceed rather than overwriting the last remaining copy with no safety net — reinstall via the DMG/PKG installer to recover.
+- **separate mode does NOT install hooks, by design (#1449).** `IRRLICHT_HOME` isolates daemon state; it does not move `~/.claude/settings.json`, `~/.codex/hooks.json` or `~/.config/kitty/kitty.conf`, which follow `$HOME`. A grant-all daemon on 7838 that installed hooks would repoint your REAL config at 7838 and leave it there when the dev daemon dies — the incident #1449 was filed for, which had already happened three times. Those installs are refused with an error naming each file, and the permission shows as "granted but NOT applied" in the wizard. Everything not backed by a shared config file (transcripts, watchers, control) works normally. To test hook installation itself, back the files up (`irrlichd --print-managed-files` lists them) and add `IRRLICHT_ALLOW_SHARED_CONFIG_WRITES=1` — then restore them afterwards.
+- **separate mode gets `IRRLICHT_PERMISSION_MODE=grant-all`**, because a fresh isolated state dir has no consent answers (#570) and the daemon would otherwise monitor nothing until the permission wizard is answered. Drop that variable (edit the script for the run) when the point of the session *is* the wizard. replace mode omits it, reading the user's real answers instead.
+- **replace mode — single instance on production's footprint.** Runs the dev binaries on port 7837 with the production state dir (no `IRRLICHT_HOME`), so the statusline quota feed and the production session/cost/ledger stores all apply, and (for `TARGET=macos`/`full`) the Swift app is installed directly into `/Applications/Irrlicht.app`. Because the dev daemon runs with `--record`, recordings land in the production recordings dir (`~/.local/share/irrlicht/recordings/`). **⚠️ The dev daemon mutates production data.** Without `IRRLICHT_HOME` its startup sweeps (`PruneStale` / dead-proc / orphan-ledger / cost prune) run against the real `~/.local/share/irrlicht/` + `~/Library/Application Support/Irrlicht/` stores — exactly the isolation #448 added, deliberately removed here. Only use replace mode when the dev build's on-disk schema matches the installed production build; a dev branch mid-migration can prune or rewrite production sessions/ledgers/cost rows that the production binary then misreads.
+- **Backup freshness.** The production backup at `.build/irrlicht-prod-backup/Irrlicht.app` is refreshed automatically whenever `/Applications/Irrlicht.app` is still Developer-ID-signed (a genuine, untouched production build) — so installing a *new* production release via the DMG/PKG installer, then running replace mode again, captures the new release as the restore baseline instead of reinstalling a stale one. If the app is already dev-signed (mid-test) and the backup is missing (e.g. `.build` was wiped), the script refuses rather than overwriting the last remaining copy with no safety net — reinstall via the DMG/PKG installer to recover.
+- **TCC in replace mode.** The dev build is signed and launched at production's own path, so expect one extra Accessibility/Automation re-grant prompt the first time. Production's own grant (tied to its Developer ID signature) is unaffected once restored. Run `tools/dev-sign-setup.sh` once to install the `"Irrlicht Dev"` self-signed identity — the script signs with it when present, which gives the app a stable designated requirement so grants persist across rebuilds. Without it, every rebuild invalidates TCC.
 - Daemon logs: `/tmp/irrlichd-dev.log` · Swift app logs: `/tmp/irrlicht-app-dev.log`
-- **TCC stability**: run `tools/dev-sign-setup.sh` once to install the `"Irrlicht Dev"` self-signed code signing identity. The skill automatically signs with it when present, giving the app a stable designated requirement so Accessibility/Automation grants persist across rebuilds. Without it, every rebuild invalidates TCC and requires re-granting in System Settings.

--- a/.claude/skills/ir:test-mac/SKILL.md
+++ b/.claude/skills/ir:test-mac/SKILL.md
@@ -17,6 +17,7 @@ description: >
 **The procedure is a script. Run it — do not reimplement it inline.**
 
 ```bash
+cd "$(git rev-parse --show-toplevel)"                      # the paths below are repo-root-relative
 .claude/skills/ir:test-mac/test-mac.sh [MODE] [TARGET]     # defaults: replace full
 .claude/skills/ir:test-mac/test-mac.sh --help              # the full contract
 ```
@@ -94,7 +95,7 @@ Quitting the app is **not** enough, for two independent reasons:
   the dev build, so relaunching that bundle launches the **dev** binary.
 
 ```bash
-.claude/skills/ir:test-mac/restore-prod.sh
+"$(git rev-parse --show-toplevel)/.claude/skills/ir:test-mac/restore-prod.sh"
 ```
 
 It does the whole sequence: kill the app + daemon → restore the backed-up
@@ -127,6 +128,10 @@ that lock test to go red. Both run inside `tools/preflight.sh --only tools`.
   target port — a gate, not a courtesy sleep. If the app starts with nothing
   reachable on 7837 it runs `pkill -x irrlichd` and respawns a daemon **without**
   `--record`, silently defeating the run.
+- If it fails **after** overwriting `/Applications/Irrlicht.app` — the
+  reachability abort above is one such path — it says so and points at
+  `restore-prod.sh`, rather than leaving a silently dev-ified production bundle
+  behind with no hint that a teardown exists.
 
 ## Notes
 
@@ -135,6 +140,6 @@ that lock test to go red. Both run inside `tools/preflight.sh --only tools`.
 - **separate mode does NOT install hooks, by design (#1449).** `IRRLICHT_HOME` isolates daemon state; it does not move `~/.claude/settings.json`, `~/.codex/hooks.json` or `~/.config/kitty/kitty.conf`, which follow `$HOME`. A grant-all daemon on 7838 that installed hooks would repoint your REAL config at 7838 and leave it there when the dev daemon dies — the incident #1449 was filed for, which had already happened three times. Those installs are refused with an error naming each file, and the permission shows as "granted but NOT applied" in the wizard. Everything not backed by a shared config file (transcripts, watchers, control) works normally. To test hook installation itself, back the files up (`irrlichd --print-managed-files` lists them) and add `IRRLICHT_ALLOW_SHARED_CONFIG_WRITES=1` — then restore them afterwards.
 - **separate mode gets `IRRLICHT_PERMISSION_MODE=grant-all`**, because a fresh isolated state dir has no consent answers (#570) and the daemon would otherwise monitor nothing until the permission wizard is answered. Drop that variable (edit the script for the run) when the point of the session *is* the wizard. replace mode omits it, reading the user's real answers instead.
 - **replace mode — single instance on production's footprint.** Runs the dev binaries on port 7837 with the production state dir (no `IRRLICHT_HOME`), so the statusline quota feed and the production session/cost/ledger stores all apply, and (for `TARGET=macos`/`full`) the Swift app is installed directly into `/Applications/Irrlicht.app`. Because the dev daemon runs with `--record`, recordings land in the production recordings dir (`~/.local/share/irrlicht/recordings/`). **⚠️ The dev daemon mutates production data.** Without `IRRLICHT_HOME` its startup sweeps (`PruneStale` / dead-proc / orphan-ledger / cost prune) run against the real `~/.local/share/irrlicht/` + `~/Library/Application Support/Irrlicht/` stores — exactly the isolation #448 added, deliberately removed here. Only use replace mode when the dev build's on-disk schema matches the installed production build; a dev branch mid-migration can prune or rewrite production sessions/ledgers/cost rows that the production binary then misreads.
-- **Backup freshness.** The production backup at `.build/irrlicht-prod-backup/Irrlicht.app` is refreshed automatically whenever `/Applications/Irrlicht.app` is still Developer-ID-signed (a genuine, untouched production build) — so installing a *new* production release via the DMG/PKG installer, then running replace mode again, captures the new release as the restore baseline instead of reinstalling a stale one. If the app is already dev-signed (mid-test) and the backup is missing (e.g. `.build` was wiped), the script refuses rather than overwriting the last remaining copy with no safety net — reinstall via the DMG/PKG installer to recover.
+- **Backup freshness.** The production backup lives at `.build/irrlicht-prod-backup/Irrlicht.app` in the **main checkout** — a stable absolute path, not a worktree-relative one, so it survives a worktree being removed. (The daemon binary at `core/bin/irrlichd` is anchored the same way, so the build and launch steps agree even when you run this from a worktree; the SOURCE compiled is still the worktree's.) It is refreshed automatically whenever `/Applications/Irrlicht.app` is still Developer-ID-signed (a genuine, untouched production build) — so installing a *new* production release via the DMG/PKG installer, then running replace mode again, captures the new release as the restore baseline instead of reinstalling a stale one. If the app is already dev-signed (mid-test) and the backup is missing (e.g. `.build` was wiped), the script refuses rather than overwriting the last remaining copy with no safety net — reinstall via the DMG/PKG installer to recover.
 - **TCC in replace mode.** The dev build is signed and launched at production's own path, so expect one extra Accessibility/Automation re-grant prompt the first time. Production's own grant (tied to its Developer ID signature) is unaffected once restored. Run `tools/dev-sign-setup.sh` once to install the `"Irrlicht Dev"` self-signed identity — the script signs with it when present, which gives the app a stable designated requirement so grants persist across rebuilds. Without it, every rebuild invalidates TCC.
 - Daemon logs: `/tmp/irrlichd-dev.log` · Swift app logs: `/tmp/irrlicht-app-dev.log`

--- a/.claude/skills/ir:test-mac/restore-prod.sh
+++ b/.claude/skills/ir:test-mac/restore-prod.sh
@@ -23,9 +23,12 @@
 # Usage:  .claude/skills/ir:test-mac/restore-prod.sh
 set -euo pipefail
 
-PROD_APP="/Applications/Irrlicht.app"
-PROD_BACKUP="/Users/ingo/projects/irrlicht/.build/irrlicht-prod-backup/Irrlicht.app"
-PORT=7837
+# Env overrides are a TEST SEAM (tools/lib/test-mac-script_test.sh points them
+# at a temp dir), matching test-mac.sh's. Every real run uses the defaults.
+PROD_APP="${IRRLICHT_TESTMAC_PROD_APP:-/Applications/Irrlicht.app}"
+MAIN_REPO="${IRRLICHT_TESTMAC_MAIN_REPO:-/Users/ingo/projects/irrlicht}"
+PROD_BACKUP="$MAIN_REPO/.build/irrlicht-prod-backup/Irrlicht.app"
+PORT="${IRRLICHT_TESTMAC_PORT:-7837}"
 
 APP_PATTERN="Irrlicht\.app/Contents/MacOS/Irrlicht"
 
@@ -72,7 +75,18 @@ elif [[ ! -d "$PROD_APP" ]]; then
   echo "ERROR: $PROD_APP is not installed and no backup exists at $PROD_BACKUP." >&2
   echo "       Run the DMG/PKG installer first, then re-run this script." >&2
   exit 1
-elif codesign -dv --verbose=4 "$PROD_APP" 2>&1 | grep -q "^Authority=Developer ID Application"; then
+elif { CODESIGN_INFO="$(codesign -dv --verbose=4 "$PROD_APP" 2>&1 || true)"
+       printf '%s\n' "$CODESIGN_INFO" | grep -q "^Authority=Developer ID Application"; }; then
+  # CAPTURE FIRST, MATCH SECOND. `codesign … | grep -q` in the condition looks
+  # right and is wrong under this file's own `set -o pipefail`: grep -q exits at
+  # its first match, the real `codesign -dv --verbose=4` is 28 unbuffered lines
+  # with Authority= at line 20, so codesign dies of SIGPIPE (141) and pipefail
+  # makes 141 the pipeline's status — the arm is skipped EXACTLY WHEN THE APP IS
+  # GENUINELY SIGNED (measured 5/5 against a real Developer-ID bundle). This
+  # script would then fall through to the refusal below and tell someone with a
+  # correctly installed production app to reinstall it — after having already
+  # killed their app and daemon (#1855 review F1, found in test-mac.sh; the same
+  # line was here).
   echo "No backup at $PROD_BACKUP — $PROD_APP is already genuinely production-signed; nothing to restore."
 else
   echo "ERROR: $PROD_APP is not Developer-ID-signed (looks like a leftover dev build) and no backup exists at $PROD_BACKUP." >&2

--- a/.claude/skills/ir:test-mac/restore-prod.sh
+++ b/.claude/skills/ir:test-mac/restore-prod.sh
@@ -31,6 +31,7 @@ PROD_BACKUP="$MAIN_REPO/.build/irrlicht-prod-backup/Irrlicht.app"
 PORT="${IRRLICHT_TESTMAC_PORT:-7837}"
 
 APP_PATTERN="Irrlicht\.app/Contents/MacOS/Irrlicht"
+NL=$'\n'   # line-start anchor for the in-shell codesign match below
 
 echo "Stopping dev app + daemon…"
 pkill -f "$APP_PATTERN" 2>/dev/null || true   # the app (production or dev-overwritten)
@@ -76,17 +77,17 @@ elif [[ ! -d "$PROD_APP" ]]; then
   echo "       Run the DMG/PKG installer first, then re-run this script." >&2
   exit 1
 elif { CODESIGN_INFO="$(codesign -dv --verbose=4 "$PROD_APP" 2>&1 || true)"
-       printf '%s\n' "$CODESIGN_INFO" | grep -q "^Authority=Developer ID Application"; }; then
-  # CAPTURE FIRST, MATCH SECOND. `codesign … | grep -q` in the condition looks
-  # right and is wrong under this file's own `set -o pipefail`: grep -q exits at
-  # its first match, the real `codesign -dv --verbose=4` is 28 unbuffered lines
-  # with Authority= at line 20, so codesign dies of SIGPIPE (141) and pipefail
-  # makes 141 the pipeline's status — the arm is skipped EXACTLY WHEN THE APP IS
-  # GENUINELY SIGNED (measured 5/5 against a real Developer-ID bundle). This
-  # script would then fall through to the refusal below and tell someone with a
-  # correctly installed production app to reinstall it — after having already
-  # killed their app and daemon (#1855 review F1, found in test-mac.sh; the same
-  # line was here).
+       [[ "$NL$CODESIGN_INFO" == *"${NL}Authority=Developer ID Application"* ]]; }; then
+  # NO PIPE IN THIS CONDITION. `codesign … | grep -q` looks right and is wrong
+  # under this file's own `set -o pipefail`: grep -q exits at its first match,
+  # codesign is still writing, dies of SIGPIPE (141), and pipefail makes 141 the
+  # pipeline's status — so the arm is skipped EXACTLY WHEN THE APP IS GENUINELY
+  # SIGNED (measured 5/5 against a real Developer-ID bundle). This script would
+  # then fall through to the refusal below and tell someone with a correctly
+  # installed production app to reinstall it, after having already killed their
+  # app and daemon. Capturing and THEN piping into grep -q is the same bug with
+  # more headroom; matching in-shell has no second process and no race
+  # (#1855 review F1, found in test-mac.sh — the same line was here).
   echo "No backup at $PROD_BACKUP — $PROD_APP is already genuinely production-signed; nothing to restore."
 else
   echo "ERROR: $PROD_APP is not Developer-ID-signed (looks like a leftover dev build) and no backup exists at $PROD_BACKUP." >&2

--- a/.claude/skills/ir:test-mac/test-mac.sh
+++ b/.claude/skills/ir:test-mac/test-mac.sh
@@ -124,6 +124,26 @@ fi
 want_daemon() { [[ "$TARGET" == "daemon" || "$TARGET" == "full" ]]; }
 want_app()    { [[ "$TARGET" == "macos"  || "$TARGET" == "full" ]]; }
 
+# ─── Abort safety net ──────────────────────────────────────────────────────
+# Once the replace-mode install has written into $PROD_APP, ANY later failure
+# leaves the PRODUCTION bundle holding a dev build. Several such paths exist and
+# are not hypothetical: step 7's reachability ABORT fires after the install by
+# design, and under `set -e` so do install_name_tool (it exits 1 on a duplicate
+# LC_RPATH), PlistBuddy on a missing key, codesign, and open. Without this the
+# user is left with a silently dev-ified /Applications/Irrlicht.app and no hint
+# that a teardown exists (#1855 review F5).
+BUNDLE_DIRTIED=""
+on_exit() {
+  local rc=$?
+  if [[ $rc -ne 0 && -n "$BUNDLE_DIRTIED" ]]; then
+    echo >&2
+    echo "NOTE: $PROD_APP now holds a DEV build — this run overwrote it and then failed." >&2
+    echo "      Restore production with:  $(dirname "$0")/restore-prod.sh" >&2
+  fi
+  return "$rc"
+}
+trap on_exit EXIT
+
 echo "MODE=$MODE TARGET=$TARGET PORT=$PORT DEV_HOME=${DEV_HOME:-<production>}"
 
 # ─── Step 1: build the Go daemon ───────────────────────────────────────────
@@ -218,7 +238,14 @@ if want_app; then
     echo "       against nothing and pass vacuously. Refusing rather than reporting a green it did not earn." >&2
     exit 1
   fi
-  STALE_SRC="$(find "$SWIFT_SRC_DIR" -name '*.swift' -type f -newer "$DEBUG_BIN" -print 2>/dev/null | head -1)"
+  # `-print -quit` rather than `… -print | head -1`: the pipe is the same
+  # SIGPIPE-under-pipefail trap as the codesign check below, and here it would
+  # abort the script with status 141 and NO MESSAGE — so "the build is fresh"
+  # and "the freshness check could not run" would look identical, which is the
+  # one thing a verification mechanism must never do. Measured: the pipe form
+  # aborts 0/300 against this repo's 80 sources but 40/40 at 500 files, i.e.
+  # correct today only by headroom that shrinks as the target dir grows.
+  STALE_SRC="$(find "$SWIFT_SRC_DIR" -name '*.swift' -type f -newer "$DEBUG_BIN" -print -quit 2>/dev/null)"
   if [[ -n "$STALE_SRC" ]]; then
     echo "ERROR: $STALE_SRC is NEWER than the built binary $DEBUG_BIN." >&2
     echo "       The build output is stale — refusing to install it into $APP_TARGET." >&2
@@ -246,7 +273,17 @@ if want_app; then
     # signed (a prior replace-mode run's dev build, still installed) and no
     # backup exists either, REFUSE rather than overwrite the only remaining
     # copy with no safety net.
-    if codesign -dv --verbose=4 "$PROD_APP" 2>&1 | grep -q "^Authority=Developer ID Application"; then
+    # CAPTURE FIRST, MATCH SECOND — never `codesign … | grep -q` in the
+    # condition. `grep -q` exits at its first match; the real
+    # `codesign -dv --verbose=4` writes 28 unbuffered lines with `Authority=`
+    # at line 20, so it is still writing when the pipe closes and dies of
+    # SIGPIPE (141). Under `set -o pipefail` that 141 IS the pipeline's status,
+    # so the branch is skipped EXACTLY WHEN THE APP IS GENUINELY SIGNED —
+    # measured 5/5 against a real Developer-ID bundle. This gate ran fine as a
+    # fenced block because those had no pipefail; adding it is what broke it
+    # (#1855 review F1).
+    CODESIGN_INFO="$(codesign -dv --verbose=4 "$PROD_APP" 2>&1 || true)"
+    if printf '%s\n' "$CODESIGN_INFO" | grep -q "^Authority=Developer ID Application"; then
       rm -rf "$PROD_BACKUP"
       mkdir -p "$(dirname "$PROD_BACKUP")"
       if ! cp -R "$PROD_APP" "$PROD_BACKUP"; then
@@ -260,6 +297,7 @@ if want_app; then
       exit 1
     fi
 
+    BUNDLE_DIRTIED=1   # point of no return: every failure from here owes the user the teardown hint
     cp "$DEBUG_BIN" "$APP_TARGET/Contents/MacOS/Irrlicht"
     rm -rf "$APP_TARGET/Contents/Frameworks/Sparkle.framework"
     cp -R "$DEBUG_SPARKLE" "$APP_TARGET/Contents/Frameworks/Sparkle.framework"
@@ -323,7 +361,13 @@ PLIST
   # the identity. Uses the dev-only entitlements file — no com.apple.developer.*
   # entries, which Apple gates to its own certificates and which would make
   # launchd refuse to spawn a self-signed/ad-hoc binary that claims them.
-  if security find-identity -v -p codesigning 2>/dev/null | grep -q "Irrlicht Dev"; then
+  # Captured, not piped, for the same reason as the codesign check above: the
+  # real output is short enough to flush today (rc 0, 10/10), but if it ever
+  # grows past a pipe buffer this silently drops to ad-hoc signing and
+  # invalidates TCC on every rebuild — the exact thing the stable identity
+  # exists to prevent.
+  IDENTITIES="$(security find-identity -v -p codesigning 2>/dev/null || true)"
+  if printf '%s\n' "$IDENTITIES" | grep -q "Irrlicht Dev"; then
     codesign --force --deep --sign "Irrlicht Dev" --entitlements "$ENTITLEMENTS" "$APP_TARGET" 2>&1
   else
     codesign --force --deep --sign - --entitlements "$ENTITLEMENTS" "$APP_TARGET" 2>&1

--- a/.claude/skills/ir:test-mac/test-mac.sh
+++ b/.claude/skills/ir:test-mac/test-mac.sh
@@ -1,0 +1,422 @@
+#!/usr/bin/env bash
+# test-mac.sh — build and run the irrlicht dev stack (Go daemon and/or macOS
+# Swift app) for local testing. This is the executable body of the
+# `ir:test-mac` skill; SKILL.md next to this file says WHEN to reach for each
+# axis and what each one costs, and this script is the only place the
+# procedure itself lives.
+#
+# Usage:
+#   .claude/skills/ir:test-mac/test-mac.sh [MODE] [TARGET]
+#   .claude/skills/ir:test-mac/test-mac.sh --help
+#
+# Both arguments are optional, may be given in either order, and default to
+# `replace full`.
+#
+#   MODE    replace  (default) — take over from production: port 7837, the
+#                     production state dir (no IRRLICHT_HOME override), and the
+#                     Swift app installed straight into /Applications/Irrlicht.app.
+#                     DESTRUCTIVE — run restore-prod.sh (same directory) to get
+#                     production back; quitting the app is NOT enough.
+#           separate — coexist with production: port 7838, an isolated
+#                     IRRLICHT_HOME under the repo's .build/, and the app
+#                     assembled at /tmp/IrrlichtDev.app.
+#
+#   TARGET  full     (default) — rebuild and restart both daemon and app.
+#           daemon   — rebuild + restart irrlichd only; leave whatever app is
+#                     running to reconnect.
+#           macos    — rebuild + relaunch the app only, against whatever daemon
+#                     is already up. It does NOT start one.
+#
+# WHY THIS IS A SCRIPT (#1855). The procedure used to live as nine fenced bash
+# blocks in SKILL.md that an agent copied out and ran one at a time. Every step
+# branches on MODE/TARGET/PORT/DEV_HOME/SOCK, and each fenced block runs in a
+# FRESH shell — so a value dropped between blocks failed SILENTLY: an empty
+# $PORT made the daemon bind `127.0.0.1:` (invalid) and an empty $SOCK turned
+# the socket cleanup into a no-op that reported nothing. One script is one
+# variable scope, and that whole class is gone.
+#
+# The gates below are load-bearing; each one names the failure it prevents.
+# tools/lib/test-mac-script_test.sh drives this script against stubs and
+# asserts every one of them, and tools/lib/test-mac-script-mutations_test.sh
+# breaks each gate in turn and requires that lock test to go red.
+set -euo pipefail
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  # Matches tools/bash-lint.sh, tools/mutate.sh, tools/posix-lint.sh,
+  # tools/preflight.sh, tools/security-scan.sh and tools/skill-lint.sh
+  # BYTE-FOR-BYTE, so --help can't drift into a seventh self-help format.
+  awk 'NR>1 && /^#/ {print; next} NR>1 {exit}' "$0"
+  exit 0
+fi
+
+# ─── Step 0a: the two axes, validated against their literal enums ───────────
+# There is NO default branch here on purpose. Before this was a script, every
+# later gate was an exact-string comparison against $MODE/$TARGET, so a typo
+# ("seperate") matched nothing and silently no-opped every step instead of
+# erroring. An unrecognised argument is a hard refusal.
+MODE="replace"
+TARGET="full"
+mode_given=""
+target_given=""
+for arg in "$@"; do
+  case "$arg" in
+    replace|separate)
+      if [[ -n "$mode_given" ]]; then
+        echo "ERROR: MODE given twice ('$mode_given' then '$arg')." >&2
+        exit 2
+      fi
+      MODE="$arg"; mode_given="$arg" ;;
+    full|daemon|macos)
+      if [[ -n "$target_given" ]]; then
+        echo "ERROR: TARGET given twice ('$target_given' then '$arg')." >&2
+        exit 2
+      fi
+      TARGET="$arg"; target_given="$arg" ;;
+    *)
+      echo "ERROR: unrecognised argument '$arg'." >&2
+      echo "       MODE must be 'replace' or 'separate'; TARGET must be 'full', 'daemon' or 'macos'." >&2
+      echo "       usage: test-mac.sh [MODE] [TARGET]   (see --help)" >&2
+      exit 2 ;;
+  esac
+done
+
+# ─── Step 0b: paths ────────────────────────────────────────────────────────
+# Each has an env override so tools/lib/test-mac-script_test.sh can point the
+# whole procedure at a temp dir and exercise the gates without touching the
+# real machine. They are a TEST SEAM, not a supported way to run this by hand:
+# every real run uses the defaults.
+REPO_ROOT="${IRRLICHT_TESTMAC_REPO_ROOT:-$(git rev-parse --show-toplevel)}"
+# $MAIN_REPO is deliberately the main checkout and not $REPO_ROOT: the daemon
+# binary path must be stable so the build and launch steps agree even when
+# $REPO_ROOT is a worktree (the SOURCE compiled is still the worktree's — the
+# `go build` below runs in $REPO_ROOT/core), and the production backup must
+# survive a worktree being removed.
+MAIN_REPO="${IRRLICHT_TESTMAC_MAIN_REPO:-/Users/ingo/projects/irrlicht}"
+PROD_APP="${IRRLICHT_TESTMAC_PROD_APP:-/Applications/Irrlicht.app}"
+DEV_APP="${IRRLICHT_TESTMAC_DEV_APP:-/tmp/IrrlichtDev.app}"
+LOG_DIR="${IRRLICHT_TESTMAC_LOG_DIR:-/tmp}"
+PLISTBUDDY="${IRRLICHT_TESTMAC_PLISTBUDDY:-/usr/libexec/PlistBuddy}"
+
+IRRLICHTD_BIN="$MAIN_REPO/core/bin/irrlichd"
+PROD_BACKUP="$MAIN_REPO/.build/irrlicht-prod-backup/Irrlicht.app"
+SWIFT_SRC_DIR="$REPO_ROOT/platforms/macos/Irrlicht"
+DEBUG_DIR="$REPO_ROOT/platforms/macos/.build/arm64-apple-macosx/debug"
+DEBUG_BIN="$DEBUG_DIR/Irrlicht"
+DEBUG_SPARKLE="$DEBUG_DIR/Sparkle.framework"
+ENTITLEMENTS="$SWIFT_SRC_DIR/Resources/Irrlicht-dev.entitlements"
+
+# ─── Step 0c: everything the two axes derive ───────────────────────────────
+if [[ "$MODE" == "replace" ]]; then
+  PORT=7837                                          # production port
+  DEV_HOME=""                                        # no IRRLICHT_HOME override → production state dir
+  SOCK="$HOME/.local/share/irrlicht/irrlichd.sock"   # production socket
+  APP_TARGET="$PROD_APP"
+  APP_KILL_PATTERN="Irrlicht\.app/Contents/MacOS/Irrlicht"
+else
+  PORT=7838                                          # isolated dev port
+  DEV_HOME="$REPO_ROOT/.build/irrlicht-home"         # isolated state dir (IRRLICHT_HOME)
+  SOCK="$DEV_HOME/irrlichd.sock"
+  APP_TARGET="$DEV_APP"
+  APP_KILL_PATTERN="IrrlichtDev"
+  mkdir -p "$DEV_HOME"
+fi
+
+want_daemon() { [[ "$TARGET" == "daemon" || "$TARGET" == "full" ]]; }
+want_app()    { [[ "$TARGET" == "macos"  || "$TARGET" == "full" ]]; }
+
+echo "MODE=$MODE TARGET=$TARGET PORT=$PORT DEV_HOME=${DEV_HOME:-<production>}"
+
+# ─── Step 1: build the Go daemon ───────────────────────────────────────────
+# The daemon resolves the dashboard from platforms/web/index.html at runtime
+# via a walk-up search from its own executable; no embed, no codegen.
+if want_daemon; then
+  echo "Building irrlichd → $IRRLICHTD_BIN …"
+  ( cd "$REPO_ROOT/core" && go build -o "$IRRLICHTD_BIN" ./cmd/irrlichd )
+fi
+
+# ─── Step 2: build the Swift app (compile only; no bundle mutation yet) ────
+# Safe before killing anything: it only writes into .build/. The install into
+# a live bundle happens after the kill step below.
+if want_app; then
+  echo "Building the Swift app …"
+  # NOT a bare `swift build … | tail -5`: `set -o pipefail` makes the pipeline
+  # report swift's status rather than tail's, and the explicit branch says so
+  # out loud instead of dying with no message.
+  if ! swift build --package-path "$REPO_ROOT/platforms/macos" 2>&1 | tail -5; then
+    echo "ERROR: swift build failed — not touching $APP_TARGET." >&2
+    exit 1
+  fi
+fi
+
+# ─── Step 3: kill the instances this mode+target replaces ──────────────────
+# The APP IS KILLED BEFORE THE DAEMON (matching restore-prod.sh's order) so a
+# still-alive app never observes a momentary daemon-less gap and reacts by
+# spawning its own replacement, which could win the port race against the
+# daemon step 6 starts next. Daemon and app are killed independently so a
+# TARGET=daemon/macos run leaves the other component alone.
+if want_app; then
+  echo "Stopping the app ($APP_KILL_PATTERN) …"
+  pkill -f "$APP_KILL_PATTERN" 2>/dev/null || true
+  if [[ "$MODE" == "replace" ]]; then
+    pkill -f "IrrlichtDev" 2>/dev/null || true   # any leftover separate-mode dev app, for tidiness
+  fi
+  # Step 5 is about to back up / overwrite this same app's on-disk bundle in
+  # replace mode. Wait for the process to ACTUALLY exit rather than sleeping a
+  # flat interval, so we never copy or overwrite files a dying process still
+  # has open — and hard-abort if it outlives the wait.
+  for _ in 1 2 3 4 5; do
+    pgrep -f "$APP_KILL_PATTERN" >/dev/null 2>&1 || break
+    sleep 1
+  done
+  if [[ "$MODE" == "replace" ]] && pgrep -f "$APP_KILL_PATTERN" >/dev/null 2>&1; then
+    echo "ABORT: the app process is still running — refusing to overwrite its bundle in step 5." >&2
+    exit 1
+  fi
+fi
+
+if want_daemon; then
+  echo "Stopping the daemon on $PORT …"
+  if [[ "$MODE" == "replace" ]]; then
+    pkill -x "irrlichd" 2>/dev/null || true          # ALL daemons by exact name (prod's bundled one + any standalone dev one)
+  else
+    pkill -f "core/bin/irrlichd" 2>/dev/null || true # prior dev daemon only (NOT production)
+  fi
+  PORT_PIDS="$(lsof -ti tcp:"$PORT" 2>/dev/null || true)"   # belt-and-suspenders: anything still on the target port
+  if [[ -n "$PORT_PIDS" ]]; then
+    # shellcheck disable=SC2086  # deliberately unquoted: lsof -ti prints one PID per line and kill takes them as separate arguments
+    kill $PORT_PIDS 2>/dev/null || true
+  fi
+  sleep 1
+
+  # ─── Step 4: clean up the stale socket for the target instance ───────────
+  rm -f "$SOCK"
+fi
+
+# ─── Step 5: install the app bundle ────────────────────────────────────────
+if want_app; then
+  # Build-output gates, hoisted ahead of BOTH modes' install so a failed or
+  # stale `swift build` aborts here instead of leaving Sparkle.framework
+  # deleted with nothing to replace it.
+  if [[ ! -x "$DEBUG_BIN" || ! -d "$DEBUG_SPARKLE" ]]; then
+    echo "ERROR: swift build did not produce $DEBUG_BIN / $DEBUG_SPARKLE — not touching $APP_TARGET." >&2
+    exit 1
+  fi
+
+  # FRESHNESS, which existence alone cannot tell you (#1855). A build product
+  # left over from an earlier compile — including one compiled while a
+  # tools/mutate.sh mutation was applied — is byte-for-byte a valid binary and
+  # passes every check above, so installing it means debugging a defect the
+  # source does not have. Compare mtimes and refuse.
+  if [[ ! -d "$SWIFT_SRC_DIR" ]]; then
+    echo "ERROR: $SWIFT_SRC_DIR does not exist, so build freshness cannot be checked at all." >&2
+    echo "       Refusing rather than installing an unverified binary into $APP_TARGET." >&2
+    exit 1
+  fi
+  SWIFT_SRC_COUNT="$(find "$SWIFT_SRC_DIR" -name '*.swift' -type f | wc -l | tr -d ' ')"
+  if [[ "$SWIFT_SRC_COUNT" -eq 0 ]]; then
+    echo "ERROR: no .swift sources found under $SWIFT_SRC_DIR — the freshness check would compare" >&2
+    echo "       against nothing and pass vacuously. Refusing rather than reporting a green it did not earn." >&2
+    exit 1
+  fi
+  STALE_SRC="$(find "$SWIFT_SRC_DIR" -name '*.swift' -type f -newer "$DEBUG_BIN" -print 2>/dev/null | head -1)"
+  if [[ -n "$STALE_SRC" ]]; then
+    echo "ERROR: $STALE_SRC is NEWER than the built binary $DEBUG_BIN." >&2
+    echo "       The build output is stale — refusing to install it into $APP_TARGET." >&2
+    echo "       (Installing a binary that predates the source means debugging a defect the source no longer has.)" >&2
+    exit 1
+  fi
+
+  if [[ "$MODE" == "replace" ]]; then
+    # Install straight into $PROD_APP — no parallel /tmp/IrrlichtDev.app, since
+    # it shares production's bundle identifier and a human only reviews one
+    # running app at a time.
+    if [[ ! -d "$PROD_APP" ]]; then
+      echo "ERROR: $PROD_APP is not installed — run the DMG/PKG installer first." >&2
+      exit 1
+    fi
+
+    # BACKUP FRESHNESS. Back up the UNTOUCHED original as a full directory copy
+    # (a full-bundle backup sidesteps any code-signature mismatch between the
+    # outer bundle and its nested binaries that a partial-file restore could
+    # leave behind). The backup is REFRESHED, not made once-ever, whenever the
+    # installed app is still genuinely Developer-ID-signed — never trust an
+    # existing backup blindly, since it can predate a newer production release
+    # installed since (e.g. via /ir:release), which would make restore-prod.sh
+    # silently reinstall a stale build. And if the app is NOT Developer-ID-
+    # signed (a prior replace-mode run's dev build, still installed) and no
+    # backup exists either, REFUSE rather than overwrite the only remaining
+    # copy with no safety net.
+    if codesign -dv --verbose=4 "$PROD_APP" 2>&1 | grep -q "^Authority=Developer ID Application"; then
+      rm -rf "$PROD_BACKUP"
+      mkdir -p "$(dirname "$PROD_BACKUP")"
+      if ! cp -R "$PROD_APP" "$PROD_BACKUP"; then
+        echo "ERROR: backup of $PROD_APP to $PROD_BACKUP failed — not touching $PROD_APP." >&2
+        rm -rf "$PROD_BACKUP"
+        exit 1
+      fi
+      echo "Backed up the untouched production bundle to $PROD_BACKUP (restore-prod.sh restores from this)."
+    elif [[ ! -d "$PROD_BACKUP" ]]; then
+      echo "ERROR: $PROD_APP isn't Developer-ID-signed (looks like a leftover dev build) and no backup exists — refusing to overwrite it with no safety net. Run the DMG/PKG installer first." >&2
+      exit 1
+    fi
+
+    cp "$DEBUG_BIN" "$APP_TARGET/Contents/MacOS/Irrlicht"
+    rm -rf "$APP_TARGET/Contents/Frameworks/Sparkle.framework"
+    cp -R "$DEBUG_SPARKLE" "$APP_TARGET/Contents/Frameworks/Sparkle.framework"
+    # Refresh the icon too, so a developer iterating on Resources/ assets sees
+    # the same result in replace mode as in separate mode instead of a stale
+    # production copy.
+    cp "$SWIFT_SRC_DIR/Resources/AppIcon.icns" "$APP_TARGET/Contents/Resources/AppIcon.icns"
+    # Stamp the version string too — otherwise Info.plist still carries whatever
+    # release version was last installed (e.g. "0.5.7"), so Settings/About would
+    # show a stale release version on a freshly compiled dev build. Matches
+    # separate mode's hardcoded "dev" below so both read the same in the UI.
+    "$PLISTBUDDY" -c "Set :CFBundleShortVersionString dev" "$APP_TARGET/Contents/Info.plist"
+    "$PLISTBUDDY" -c "Set :CFBundleVersion dev" "$APP_TARGET/Contents/Info.plist"
+  else
+    # separate — assemble a fresh /tmp/IrrlichtDev.app from scratch so
+    # UNUserNotificationCenter (desktop notifications) works.
+    rm -rf "$APP_TARGET"
+    mkdir -p "$APP_TARGET/Contents/MacOS" "$APP_TARGET/Contents/Resources" "$APP_TARGET/Contents/Frameworks"
+    cp "$DEBUG_BIN" "$APP_TARGET/Contents/MacOS/Irrlicht"
+    cp "$SWIFT_SRC_DIR/Resources/AppIcon.icns" "$APP_TARGET/Contents/Resources/AppIcon.icns"
+    # Embed Sparkle.framework (required since v0.4.7 auto-update integration).
+    cp -R "$DEBUG_SPARKLE" "$APP_TARGET/Contents/Frameworks/"
+    cat > "$APP_TARGET/Contents/Info.plist" << 'PLIST'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleExecutable</key>
+    <string>Irrlicht</string>
+    <key>CFBundleIdentifier</key>
+    <string>io.irrlicht.app</string>
+    <key>CFBundleIconFile</key>
+    <string>AppIcon</string>
+    <key>CFBundleName</key>
+    <string>Irrlicht Dev</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleShortVersionString</key>
+    <string>dev</string>
+    <key>LSUIElement</key>
+    <true/>
+    <key>NSAppleEventsUsageDescription</key>
+    <string>Irrlicht uses AppleScript to bring the correct iTerm2 or Terminal.app window and tab to the front when you click a session row.</string>
+    <key>NSFocusStatusUsageDescription</key>
+    <string>Irrlicht uses macOS Focus status to silence notification sounds and spoken alerts while you're in Do Not Disturb, Sleep, or any other Focus mode.</string>
+</dict>
+</plist>
+PLIST
+  fi
+
+  # The SwiftPM debug binary links Sparkle as @rpath/Sparkle.framework but only
+  # carries an @loader_path rpath (= Contents/MacOS) — it lacks the bundle-layout
+  # rpath a release .app build adds. Without this, dyld can't find the embedded
+  # framework and the app crashes at launch. MUST run BEFORE the codesign below,
+  # since it mutates the binary and invalidates the signature.
+  install_name_tool -add_rpath @executable_path/../Frameworks "$APP_TARGET/Contents/MacOS/Irrlicht"
+
+  # codesign (both modes, identical). Sign with the persistent "Irrlicht Dev"
+  # identity if it exists; otherwise fall back to ad-hoc (TCC permissions will
+  # need re-granting each rebuild). Run tools/dev-sign-setup.sh once to install
+  # the identity. Uses the dev-only entitlements file — no com.apple.developer.*
+  # entries, which Apple gates to its own certificates and which would make
+  # launchd refuse to spawn a self-signed/ad-hoc binary that claims them.
+  if security find-identity -v -p codesigning 2>/dev/null | grep -q "Irrlicht Dev"; then
+    codesign --force --deep --sign "Irrlicht Dev" --entitlements "$ENTITLEMENTS" "$APP_TARGET" 2>&1
+  else
+    codesign --force --deep --sign - --entitlements "$ENTITLEMENTS" "$APP_TARGET" 2>&1
+  fi
+fi
+
+# ─── Step 6: start the daemon, with --record for lifecycle event capture ───
+# separate mode also gets IRRLICHT_PERMISSION_MODE=grant-all: a fresh isolated
+# state dir has no consent answers (#570), so without it the daemon monitors
+# nothing until the permission wizard is answered. Drop that variable when the
+# point of the session is to test the wizard itself. replace mode omits
+# IRRLICHT_HOME so it reads/writes the production state dir — including the
+# user's real permission answers (no grant-all there).
+if want_daemon; then
+  echo "Starting irrlichd on 127.0.0.1:$PORT (log: $LOG_DIR/irrlichd-dev.log) …"
+  if [[ "$MODE" == "replace" ]]; then
+    IRRLICHT_BIND_ADDR="127.0.0.1:$PORT" \
+      nohup "$IRRLICHTD_BIN" --record > "$LOG_DIR/irrlichd-dev.log" 2>&1 &
+  else
+    IRRLICHT_HOME="$DEV_HOME" IRRLICHT_BIND_ADDR="127.0.0.1:$PORT" \
+      IRRLICHT_PERMISSION_MODE=grant-all \
+      nohup "$IRRLICHTD_BIN" --record > "$LOG_DIR/irrlichd-dev.log" 2>&1 &
+  fi
+  disown 2>/dev/null || true
+fi
+
+# ─── Step 7: wait for a reachable daemon — and HARD-ABORT if there isn't one ─
+# A GATE, NOT A COURTESY SLEEP. In replace mode the app adopts an already-
+# reachable daemon on 7837 and skips its own spawn/pkill; if no --record daemon
+# is up when the app launches, the app (port 7837 ⇒ isCustomPort false) runs
+# `pkill -x irrlichd` — killing whatever daemon is there — and respawns one
+# WITHOUT --record, silently defeating the whole point of the run. So if
+# /state never answers, stop here and do not launch the app.
+if want_daemon; then
+  READY=""
+  for _ in 1 2 3 4 5 6 7 8; do
+    if curl -fsS --max-time 1 "http://127.0.0.1:$PORT/state" >/dev/null 2>&1; then
+      READY=1
+      break
+    fi
+    sleep 1
+  done
+  if [[ -z "$READY" ]]; then
+    echo "ABORT: daemon never became reachable on $PORT — not launching the app." >&2
+    echo "       (Launching now would let the app pkill our daemon and respawn one without --record.)" >&2
+    echo "       Check $LOG_DIR/irrlichd-dev.log." >&2
+    exit 1
+  fi
+elif want_app; then
+  # TARGET=macos: we didn't (re)start a daemon — one must already be reachable
+  # for the app to adopt, or it will spawn its own (without --record, in
+  # replace mode).
+  if ! curl -fsS --max-time 1 "http://127.0.0.1:$PORT/state" >/dev/null 2>&1; then
+    echo "ABORT: no daemon reachable on $PORT and TARGET=macos doesn't start one." >&2
+    echo "       Run with TARGET=daemon or TARGET=full first." >&2
+    exit 1
+  fi
+fi
+lsof -iTCP:"$PORT" -sTCP:LISTEN -P -n 2>/dev/null || true
+
+# ─── Step 8: start the app ─────────────────────────────────────────────────
+# Launched via LaunchServices so Bundle.main resolves correctly. In separate
+# mode, IRRLICHT_DAEMON_PORT/IRRLICHT_HOME point it at the isolated dev daemon.
+# In replace mode no env overrides are passed: the app uses the default port
+# 7837 + production state and, finding the daemon already reachable, adopts it
+# instead of spawning its own.
+if want_app; then
+  echo "Launching $APP_TARGET (log: $LOG_DIR/irrlicht-app-dev.log) …"
+  if [[ "$MODE" == "replace" ]]; then
+    open --stdout "$LOG_DIR/irrlicht-app-dev.log" --stderr "$LOG_DIR/irrlicht-app-dev.log" "$APP_TARGET"
+  else
+    open --env IRRLICHT_DAEMON_PORT="$PORT" --env IRRLICHT_HOME="$DEV_HOME" \
+      --stdout "$LOG_DIR/irrlicht-app-dev.log" --stderr "$LOG_DIR/irrlicht-app-dev.log" "$APP_TARGET"
+  fi
+fi
+
+# ─── Step 9: verify whichever components this run touched ──────────────────
+echo
+echo "── verify ──"
+if want_daemon; then
+  pgrep -f "bin/irrlichd" || true
+  curl -s "http://127.0.0.1:$PORT/api/v1/sessions" | head -c 200 || true
+  echo
+fi
+if want_app; then
+  pgrep -f "$APP_KILL_PATTERN" || true
+fi
+if [[ "$MODE" == "replace" ]]; then
+  # 0 is normal right after launch — quota data only appears once Claude Code's
+  # statusline posts its next tick to 7837 (seconds to a minute). Re-run to confirm.
+  QUOTA_HITS="$(curl -s "http://127.0.0.1:$PORT/api/v1/sessions" 2>/dev/null | grep -o 'rate_limit\|used_percent' | wc -l | tr -d ' ' || true)"
+  echo "rate-limit mentions (0 now is fine; should climb after the next statusline tick): ${QUOTA_HITS:-0}"
+  echo
+  echo "Teardown when done — REQUIRED to get production back:"
+  echo "  $(dirname "$0")/restore-prod.sh"
+fi

--- a/.claude/skills/ir:test-mac/test-mac.sh
+++ b/.claude/skills/ir:test-mac/test-mac.sh
@@ -104,6 +104,7 @@ DEBUG_DIR="$REPO_ROOT/platforms/macos/.build/arm64-apple-macosx/debug"
 DEBUG_BIN="$DEBUG_DIR/Irrlicht"
 DEBUG_SPARKLE="$DEBUG_DIR/Sparkle.framework"
 ENTITLEMENTS="$SWIFT_SRC_DIR/Resources/Irrlicht-dev.entitlements"
+NL=$'\n'   # line-start anchor for the in-shell codesign match below
 
 # ─── Step 0c: everything the two axes derive ───────────────────────────────
 if [[ "$MODE" == "replace" ]]; then
@@ -273,17 +274,20 @@ if want_app; then
     # signed (a prior replace-mode run's dev build, still installed) and no
     # backup exists either, REFUSE rather than overwrite the only remaining
     # copy with no safety net.
-    # CAPTURE FIRST, MATCH SECOND — never `codesign … | grep -q` in the
-    # condition. `grep -q` exits at its first match; the real
-    # `codesign -dv --verbose=4` writes 28 unbuffered lines with `Authority=`
-    # at line 20, so it is still writing when the pipe closes and dies of
-    # SIGPIPE (141). Under `set -o pipefail` that 141 IS the pipeline's status,
-    # so the branch is skipped EXACTLY WHEN THE APP IS GENUINELY SIGNED —
-    # measured 5/5 against a real Developer-ID bundle. This gate ran fine as a
-    # fenced block because those had no pipefail; adding it is what broke it
-    # (#1855 review F1).
+    # NO PIPE IN THIS CONDITION — not `codesign … | grep -q`, and not a capture
+    # piped into `grep -q` either. `grep -q` exits at its first match, so
+    # anything still writing to that pipe dies of SIGPIPE (141), and under
+    # `set -o pipefail` the 141 IS the pipeline's status — the branch is then
+    # skipped EXACTLY WHEN THE APP IS GENUINELY SIGNED. Both spellings were
+    # shipped and both were wrong (#1855 review F1): the direct pipe fails
+    # 5/5 against a real bundle, and capture-then-pipe only survives because
+    # ~1.5 KiB fits one write into a 64 KiB pipe buffer — it is correct by
+    # headroom, not by construction, and the padded fixture proves it fails.
+    # Matching in-shell has no second process, so there is no race at all.
+    # The leading newline anchors the match to the start of a line, which is
+    # what the old `grep "^Authority=…"` did.
     CODESIGN_INFO="$(codesign -dv --verbose=4 "$PROD_APP" 2>&1 || true)"
-    if printf '%s\n' "$CODESIGN_INFO" | grep -q "^Authority=Developer ID Application"; then
+    if [[ "$NL$CODESIGN_INFO" == *"${NL}Authority=Developer ID Application"* ]]; then
       rm -rf "$PROD_BACKUP"
       mkdir -p "$(dirname "$PROD_BACKUP")"
       if ! cp -R "$PROD_APP" "$PROD_BACKUP"; then
@@ -361,13 +365,13 @@ PLIST
   # the identity. Uses the dev-only entitlements file — no com.apple.developer.*
   # entries, which Apple gates to its own certificates and which would make
   # launchd refuse to spawn a self-signed/ad-hoc binary that claims them.
-  # Captured, not piped, for the same reason as the codesign check above: the
-  # real output is short enough to flush today (rc 0, 10/10), but if it ever
-  # grows past a pipe buffer this silently drops to ad-hoc signing and
-  # invalidates TCC on every rebuild — the exact thing the stable identity
+  # Matched in-shell, not piped, for the same reason as the codesign check
+  # above: a keychain with many identities would eventually outgrow the pipe
+  # buffer, and the failure mode is silent — it drops to ad-hoc signing and
+  # invalidates TCC on every rebuild, the exact thing the stable identity
   # exists to prevent.
   IDENTITIES="$(security find-identity -v -p codesigning 2>/dev/null || true)"
-  if printf '%s\n' "$IDENTITIES" | grep -q "Irrlicht Dev"; then
+  if [[ "$IDENTITIES" == *"Irrlicht Dev"* ]]; then
     codesign --force --deep --sign "Irrlicht Dev" --entitlements "$ENTITLEMENTS" "$APP_TARGET" 2>&1
   else
     codesign --force --deep --sign - --entitlements "$ENTITLEMENTS" "$APP_TARGET" 2>&1

--- a/tools/lib/test-mac-script-mutations_test.sh
+++ b/tools/lib/test-mac-script-mutations_test.sh
@@ -3,7 +3,8 @@
 # tools/lib/test-mac-script_test.sh (#1855).
 #
 # WHY THIS FILE EXISTS. Six gates in .claude/skills/ir:test-mac/test-mac.sh
-# were MOVED there out of SKILL.md's fenced bash blocks; three more were ADDED.
+# were MOVED there out of SKILL.md's fenced bash blocks; four more were ADDED,
+# and the review of this same PR added a further eleven CALL-SITE rows.
 # Either way there is no "before the fix" to run red: the lock test passes the
 # moment it is written. Per AGENTS.md's Testing section and
 # docs/testing-philosophy.md it earns its place only by being seen to fail
@@ -32,10 +33,13 @@
 # tools/lib/checkpoint-idiom-guard-mutations_test.sh.
 #
 # COST. Each row runs the lock test scoped to the ONE case it is about (see
-# red_case below). Running all fifteen cases per row instead cost 194s here and
-# took the whole `tools` gate from 116s to 327s — against a 540s budget the
-# pre-push hook shares with every other gate, which is a regression for every
-# push in the repo, not just this one (measured, #1855).
+# red_case below). Running every case per row instead cost 194s here and took
+# the whole `tools` gate from 116s to 327s — against a 540s budget the pre-push
+# hook shares with every other gate, which is a regression for every push in
+# the repo, not just this one. Measured with:
+#     S=$(date +%s); MUTATION_FIXTURES_STRICT=1 bash tools/lib/test-mac-script-mutations_test.sh >/dev/null 2>&1; echo $(( $(date +%s) - S ))
+#     S=$(date +%s); tools/preflight.sh --only tools >/dev/null 2>&1; echo $(( $(date +%s) - S ))
+# Re-measure rather than trusting these numbers after adding rows.
 
 set -uo pipefail
 
@@ -90,9 +94,9 @@ fails=0
 # red_case <case> <label> <file> <anchor> <replacement> <want_match>
 #
 # Scopes the lock test to the ONE case a mutation is about. Without this every
-# row re-ran all fifteen cases: 194s for this file and 327s for the whole
-# `tools` gate, against a 540s pre-push budget shared with every other gate
-# (measured, #1855). $TESTMAC_CASE is the spelling used because
+# row re-ran every case: 194s for this file and 327s for the whole `tools`
+# gate, against a 540s pre-push budget shared with every other gate (see COST
+# above for the commands). $TESTMAC_CASE is the spelling used because
 # mutation-assert.sh runs the lock test as a bare `bash <path>` and cannot
 # append an argument.
 #

--- a/tools/lib/test-mac-script-mutations_test.sh
+++ b/tools/lib/test-mac-script-mutations_test.sh
@@ -10,7 +10,7 @@
 # when the thing it protects is broken — so each gate is broken here, one at a
 # time, and the lock test is required to go red naming that specific gate.
 #
-# Eleven mutations, applied and asserted SEPARATELY. A single combined mutation
+# Twenty-two mutations, applied and asserted SEPARATELY. A single combined mutation
 # could go red on one gate while another was silently unguarded, which is the
 # exact shape of defect this whole file exists to rule out. Each one is written
 # as the plausible REGRESSION, not as arbitrary damage: the reachability abort
@@ -203,7 +203,101 @@ red_case "swift-status" \
   $'  swift build --package-path "$REPO_ROOT/platforms/macos" 2>&1 | tail -5 || true' \
   'GATE swift-build-status: a failed swift build must abort'
 
-# ── 10. The `tools` gate stops firing on this script's own directory ───────
+# ── 10. F1: the Developer-ID check goes back through a pipe ────────────────
+# The regression this PR's own review found: `codesign … | grep -q` under
+# `set -o pipefail` returns 141 (SIGPIPE — grep -q exits at its first match
+# while the 28-line codesign output is still being written), so the branch is
+# skipped EXACTLY WHEN THE APP IS GENUINELY SIGNED. Measured 5/5 against a real
+# Developer-ID bundle. This row is why the codesign stub emits a realistic line
+# count: a one-line stub cannot reproduce the SIGPIPE and passed regardless.
+red_case "backup-refresh" \
+  "F1: the Developer-ID check is piped into grep -q again" \
+  "$SUBJECT" \
+  $'    CODESIGN_INFO="$(codesign -dv --verbose=4 "$PROD_APP" 2>&1 || true)"\n    if printf \'%s\\n\' "$CODESIGN_INFO" | grep -q "^Authority=Developer ID Application"; then' \
+  $'    if codesign -dv --verbose=4 "$PROD_APP" 2>&1 | grep -q "^Authority=Developer ID Application"; then' \
+  'GATE backup-freshness: the stale backup was NOT refreshed'
+
+# ── 11. ...and the same hazard in the teardown half ───────────────────────
+red_case "restore-signed" \
+  "F1: restore-prod.sh's Developer-ID check is piped into grep -q again" \
+  ".claude/skills/ir:test-mac/restore-prod.sh" \
+  $'elif { CODESIGN_INFO="$(codesign -dv --verbose=4 "$PROD_APP" 2>&1 || true)"\n       printf \'%s\\n\' "$CODESIGN_INFO" | grep -q "^Authority=Developer ID Application"; }; then' \
+  $'elif codesign -dv --verbose=4 "$PROD_APP" 2>&1 | grep -q "^Authority=Developer ID Application"; then' \
+  'restore-prod: a genuine Developer-ID app with no backup'
+
+# ── 12-14. CALL SITES: the daemon launch ──────────────────────────────────
+# `--record` is the single value the reachability gate exists to protect, and
+# the port is the value the whole fresh-shell bug was about. Both survived a
+# mutation battery before the daemon-launch case existed (#1855 review F3).
+red_case "daemon-launch" \
+  "call site: --record is dropped from the daemon launch" \
+  "$SUBJECT" \
+  $'    IRRLICHT_BIND_ADDR="127.0.0.1:$PORT" \\\n      nohup "$IRRLICHTD_BIN" --record > "$LOG_DIR/irrlichd-dev.log" 2>&1 &' \
+  $'    IRRLICHT_BIND_ADDR="127.0.0.1:$PORT" \\\n      nohup "$IRRLICHTD_BIN" > "$LOG_DIR/irrlichd-dev.log" 2>&1 &' \
+  'started WITHOUT --record'
+
+red_case "daemon-launch" \
+  "call site: replace mode binds the wrong port" \
+  "$SUBJECT" \
+  $'  PORT=7837                                          # production port' \
+  $'  PORT=7838                                          # production port' \
+  'did not bind 127.0.0.1:7837'
+
+# ── 15-16. CALL SITES: signing ────────────────────────────────────────────
+red_case "sign-order" \
+  "call site: the rpath fix-up is deleted" \
+  "$SUBJECT" \
+  $'  install_name_tool -add_rpath @executable_path/../Frameworks "$APP_TARGET/Contents/MacOS/Irrlicht"' \
+  $'  : "rpath fix-up removed"' \
+  'COULD NOT LOOK'
+
+red_case "sign-order" \
+  "call site: codesign loses --entitlements" \
+  "$SUBJECT" \
+  $'    codesign --force --deep --sign - --entitlements "$ENTITLEMENTS" "$APP_TARGET" 2>&1' \
+  $'    codesign --force --deep --sign - "$APP_TARGET" 2>&1' \
+  'codesign was called without --entitlements'
+
+# ── 17-18. CALL SITES: separate mode's bundle assembly ────────────────────
+# Half the MODE axis had no case at all before separate-full.
+red_case "separate-full" \
+  "call site: separate mode never copies the built binary in" \
+  "$SUBJECT" \
+  $'    cp "$DEBUG_BIN" "$APP_TARGET/Contents/MacOS/Irrlicht"\n    cp "$SWIFT_SRC_DIR/Resources/AppIcon.icns" "$APP_TARGET/Contents/Resources/AppIcon.icns"\n    # Embed Sparkle.framework' \
+  $'    cp "$SWIFT_SRC_DIR/Resources/AppIcon.icns" "$APP_TARGET/Contents/Resources/AppIcon.icns"\n    # Embed Sparkle.framework' \
+  'is not the built binary'
+
+red_case "separate-full" \
+  "call site: the dev app is launched without its port override" \
+  "$SUBJECT" \
+  $'    open --env IRRLICHT_DAEMON_PORT="$PORT" --env IRRLICHT_HOME="$DEV_HOME" \\' \
+  $'    open \\' \
+  'it would talk to PRODUCTION on 7837'
+
+# ── 19-20. CALL SITES: the two quiet install writes ───────────────────────
+red_case "install-details" \
+  "call site: the icon refresh is dropped" \
+  "$SUBJECT" \
+  $'    cp "$SWIFT_SRC_DIR/Resources/AppIcon.icns" "$APP_TARGET/Contents/Resources/AppIcon.icns"\n    # Stamp the version string too' \
+  $'    # Stamp the version string too' \
+  'still holds the production copy'
+
+red_case "install-details" \
+  "call site: the stale-socket cleanup is dropped" \
+  "$SUBJECT" \
+  $'  rm -f "$SOCK"' \
+  $'  : "socket cleanup removed"' \
+  'the stale socket survived'
+
+# ── 21. F5: the abort safety net stops firing ─────────────────────────────
+red_case "abort-hint" \
+  "F5: a failure after the bundle is overwritten says nothing" \
+  "$SUBJECT" \
+  $'trap on_exit EXIT' \
+  $': "trap not installed"' \
+  'never said so, nor pointed at restore-prod.sh'
+
+# ── 22. The `tools` gate stops firing on this script's own directory ───────
 # Not a gate inside the script, but the gate that RUNS the two files above.
 # Without the trigger alternative added in #1855, a push that changes only
 # test-mac.sh skips the whole `tools` group under `--changed`, and a gate that

--- a/tools/lib/test-mac-script-mutations_test.sh
+++ b/tools/lib/test-mac-script-mutations_test.sh
@@ -1,0 +1,199 @@
+#!/usr/bin/env bash
+# test-mac-script-mutations_test.sh — the committed mutation fixtures for
+# tools/lib/test-mac-script_test.sh (#1855).
+#
+# WHY THIS FILE EXISTS. Every gate in .claude/skills/ir:test-mac/test-mac.sh
+# was MOVED there out of SKILL.md's fenced bash blocks, and two more were
+# ADDED. Either way there is no "before the fix" to run red: the lock test
+# passes the moment it is written. Per AGENTS.md's Testing section and
+# docs/testing-philosophy.md it earns its place only by being seen to fail
+# when the thing it protects is broken — so each gate is broken here, one at a
+# time, and the lock test is required to go red naming that specific gate.
+#
+# Nine mutations, applied and asserted SEPARATELY. A single combined mutation
+# could go red on one gate while another was silently unguarded, which is the
+# exact shape of defect this whole file exists to rule out. Each one is written
+# as the plausible REGRESSION, not as arbitrary damage: the reachability abort
+# demoted to a no-op, the backup refresh demoted to "make it once, ever", the
+# `swift build` status read back through the pipe the way SKILL.md used to.
+#
+# Every row drives the real tools/mutate.sh, which owns the mechanics this file
+# must not re-improvise: the stale-anchor guard, the no-op replacement refusal,
+# and the byte-for-byte restore that never touches git state (worktrees share
+# the parent repo's .git dir, so `git checkout --` / `git restore` /
+# `git reset --hard` are banned repo-wide).
+#
+# The `assert_mutation_is_red` mechanics live in tools/lib/mutation-assert.sh,
+# shared with tools/lib/preflight-groups-skill-mutations_test.sh and
+# tools/lib/checkpoint-idiom-guard-mutations_test.sh.
+#
+# COST. Each row re-runs the whole lock test (~16s), so this file is the
+# slowest thing in the `tools` gate by a wide margin. That is the price of
+# nine independently-proven gates and it is paid deliberately; the alternative
+# — one combined mutation, or a filtered lock test — buys seconds by giving up
+# the thing being bought.
+
+set -uo pipefail
+
+DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$DIR/../.." && pwd)"
+MUTATE_SH="$REPO_ROOT/tools/mutate.sh"
+# shellcheck disable=SC2034  # read by assert_mutation_is_red in the sourced mutation-assert.sh, not here
+LOCK_TEST="tools/lib/test-mac-script_test.sh"
+SUBJECT=".claude/skills/ir:test-mac/test-mac.sh"
+
+# shellcheck source=tools/lib/mutation-assert.sh
+. "$DIR/mutation-assert.sh"
+
+# A missing tool is a hard failure, not a skip — exiting 0 here would read as a
+# PASS to preflight's shell_lib_tests, so the gate would go green having
+# asserted nothing.
+need() { command -v "$1" >/dev/null 2>&1 || { echo "FAIL: test-mac-script-mutations — $1 not found" >&2; exit 1; }; }
+need bash
+need git
+
+if [[ ! -x "$MUTATE_SH" ]]; then
+  echo "FAIL: test-mac-script-mutations — $MUTATE_SH is missing or not executable" >&2
+  exit 1
+fi
+
+# mutate.sh refuses (exit 4) against an already-dirty tree, because its
+# post-restore emptiness check could prove nothing then.
+#
+# A DIRTY TREE MUST NOT SILENTLY PASS. This suite's runner (shell-lib-suite.sh)
+# judges a script by its EXIT STATUS and has no self-skip protocol, so an
+# `exit 0` here would make "the gates were verified" and "the gates could not
+# be checked at all" produce byte-identical results — exactly the shape
+# AGENTS.md forbids. So it is a HARD FAILURE wherever the answer is
+# load-bearing (CI, and any caller that sets MUTATION_FIXTURES_STRICT=1), and a
+# loud, non-silent skip on a developer's dirty worktree, where failing would
+# only train people to delete the fixture.
+if [[ -n "$(git -C "$REPO_ROOT" status --porcelain)" ]]; then
+  echo "test-mac-script-mutations: CANNOT RUN — the worktree is dirty, and mutate.sh needs a" >&2
+  echo "  clean tree for its post-restore check to mean anything. Commit or clean up, then:" >&2
+  echo "    bash tools/lib/test-mac-script-mutations_test.sh" >&2
+  if [[ -n "${CI:-}" || -n "${MUTATION_FIXTURES_STRICT:-}" ]]; then
+    echo "  (failing rather than skipping: CI/strict mode, where a skip is indistinguishable" >&2
+    echo "   from a pass and this gate is the only thing re-running these mutations)" >&2
+    exit 1
+  fi
+  echo "  (skipped locally; set MUTATION_FIXTURES_STRICT=1 to make this a failure)" >&2
+  exit 0
+fi
+
+fails=0
+
+# ── 1. The daemon-reachability gate is demoted to a no-op ───────────────────
+# The failure it prevents is silent: the app finds no daemon on 7837, runs
+# `pkill -x irrlichd`, and respawns one WITHOUT --record.
+assert_mutation_is_red \
+  "reachability gate: the abort never fires" \
+  "$SUBJECT" \
+  $'  if [[ -z "$READY" ]]; then\n    echo "ABORT: daemon never became reachable on $PORT' \
+  $'  if false; then\n    echo "ABORT: daemon never became reachable on $PORT' \
+  'GATE daemon-reachability: an unreachable daemon must abort'
+
+# ── 2. The app-exit wait stops hard-aborting ────────────────────────────────
+# The bundle is then overwritten while the process that has those files open is
+# still alive.
+assert_mutation_is_red \
+  "app-exit wait: the hard abort never fires" \
+  "$SUBJECT" \
+  $'  if [[ "$MODE" == "replace" ]] && pgrep -f "$APP_KILL_PATTERN" >/dev/null 2>&1; then' \
+  $'  if false; then' \
+  'GATE app-exit-wait: a still-running app must abort'
+
+# ── 3. Backup freshness becomes "make it once, ever" ────────────────────────
+# The regression that actually threatens this gate is not deleting it, it is
+# adding the natural-looking `[[ ! -d "$PROD_BACKUP" ]] &&` — after which a
+# backup taken before a newer production release is never refreshed, and
+# restore-prod.sh silently reinstalls a stale build.
+assert_mutation_is_red \
+  "backup freshness: an existing backup is trusted blindly" \
+  "$SUBJECT" \
+  $'    if codesign -dv --verbose=4 "$PROD_APP" 2>&1 | grep -q "^Authority=Developer ID Application"; then' \
+  $'    if [[ ! -d "$PROD_BACKUP" ]] && codesign -dv --verbose=4 "$PROD_APP" 2>&1 | grep -q "^Authority=Developer ID Application"; then' \
+  'GATE backup-freshness: the stale backup was NOT refreshed'
+
+# ── 4. The no-safety-net refusal stops refusing ─────────────────────────────
+assert_mutation_is_red \
+  "backup refusal: a dev-signed app with no backup is overwritten anyway" \
+  "$SUBJECT" \
+  $'    elif [[ ! -d "$PROD_BACKUP" ]]; then' \
+  $'    elif false; then' \
+  'GATE backup-refusal: dev-signed app + no backup must refuse'
+
+# ── 5. The build-output existence check stops checking ──────────────────────
+assert_mutation_is_red \
+  "build-output existence: a missing product no longer stops the install" \
+  "$SUBJECT" \
+  $'  if [[ ! -x "$DEBUG_BIN" || ! -d "$DEBUG_SPARKLE" ]]; then' \
+  $'  if false; then' \
+  'GATE build-output-exists:'
+
+# ── 6. The enum gains the default branch it was written without ─────────────
+# A typo like `seperate` then silently runs the DESTRUCTIVE default instead of
+# erroring — the exact hazard SKILL.md's step 0 named.
+assert_mutation_is_red \
+  "enum validation: an unrecognised axis value is silently ignored" \
+  "$SUBJECT" \
+  $'    *)\n      echo "ERROR: unrecognised argument \'$arg\'." >&2' \
+  $'    *)\n      : ;;\n    unreachable)\n      echo "ERROR: unrecognised argument \'$arg\'." >&2' \
+  'would have silently run in replace mode'
+
+# ── 7. The daemon is killed before the app ─────────────────────────────────
+# A still-alive app then observes a daemon-less gap and spawns its own
+# replacement, which can win the port race against the daemon started next.
+assert_mutation_is_red \
+  "kill order: the daemon is killed first" \
+  "$SUBJECT" \
+  $'if want_app; then\n  echo "Stopping the app ($APP_KILL_PATTERN) …"' \
+  $'if want_daemon && [[ "$MODE" == "replace" ]]; then\n  pkill -x "irrlichd" 2>/dev/null || true\nfi\nif want_app; then\n  echo "Stopping the app ($APP_KILL_PATTERN) …"' \
+  'GATE kill-order: the daemon was killed at line'
+
+# ── 8. Build freshness (ADDED by #1855) stops firing ───────────────────────
+assert_mutation_is_red \
+  "build freshness: a stale build product is installed anyway" \
+  "$SUBJECT" \
+  $'  if [[ -n "$STALE_SRC" ]]; then' \
+  $'  if false; then' \
+  'GATE build-freshness: a source newer than the build product must abort'
+
+# ── 8b. ...and its own cannot-run refusal stops refusing ───────────────────
+# A freshness check with nothing to compare against would otherwise report the
+# same green as one that looked and found nothing.
+assert_mutation_is_red \
+  "build freshness: an empty source set passes vacuously" \
+  "$SUBJECT" \
+  $'  if [[ "$SWIFT_SRC_COUNT" -eq 0 ]]; then' \
+  $'  if false; then' \
+  'a vacuous pass'
+
+# ── 9. `swift build`'s status is read back through the pipe ────────────────
+# This is SKILL.md's own pre-#1855 spelling (`swift build 2>&1 | tail -5`),
+# whose exit status is tail's. A failed build reported success and the run
+# walked into the install with whatever binary was lying around.
+assert_mutation_is_red \
+  "swift build status: a failed build is reported as success by the pipe" \
+  "$SUBJECT" \
+  $'  if ! swift build --package-path "$REPO_ROOT/platforms/macos" 2>&1 | tail -5; then\n    echo "ERROR: swift build failed — not touching $APP_TARGET." >&2\n    exit 1\n  fi' \
+  $'  swift build --package-path "$REPO_ROOT/platforms/macos" 2>&1 | tail -5 || true' \
+  'GATE swift-build-status: a failed swift build must abort'
+
+# ── 10. The `tools` gate stops firing on this script's own directory ───────
+# Not a gate inside the script, but the gate that RUNS the two files above.
+# Without the trigger alternative added in #1855, a push that changes only
+# test-mac.sh skips the whole `tools` group under `--changed`, and a gate that
+# never ran is indistinguishable from one that found nothing.
+assert_mutation_is_red \
+  "preflight trigger: the tools gate stops covering .claude/skills/ir:test-mac/" \
+  "tools/preflight.sh" \
+  $'|^\\.claude/skills/ir:test-mac/|^\\.github/workflows/(ars|codescene-badge' \
+  $'|^\\.github/workflows/(ars|codescene-badge' \
+  'the tools gate does NOT fire on a diff touching .claude/skills/ir:test-mac/test-mac.sh'
+
+if [[ $fails -gt 0 ]]; then
+  echo "test-mac-script-mutations: $fails FAILED"
+  exit 1
+fi
+echo "test-mac-script-mutations: ALL PASS"

--- a/tools/lib/test-mac-script-mutations_test.sh
+++ b/tools/lib/test-mac-script-mutations_test.sh
@@ -134,8 +134,8 @@ red_case "app-exit" \
 red_case "backup-refresh" \
   "backup freshness: an existing backup is trusted blindly" \
   "$SUBJECT" \
-  $'    if codesign -dv --verbose=4 "$PROD_APP" 2>&1 | grep -q "^Authority=Developer ID Application"; then' \
-  $'    if [[ ! -d "$PROD_BACKUP" ]] && codesign -dv --verbose=4 "$PROD_APP" 2>&1 | grep -q "^Authority=Developer ID Application"; then' \
+  $'    if printf \'%s\\n\' "$CODESIGN_INFO" | grep -q "^Authority=Developer ID Application"; then' \
+  $'    if [[ ! -d "$PROD_BACKUP" ]] && printf \'%s\\n\' "$CODESIGN_INFO" | grep -q "^Authority=Developer ID Application"; then' \
   'GATE backup-freshness: the stale backup was NOT refreshed'
 
 # ── 4. The no-safety-net refusal stops refusing ─────────────────────────────

--- a/tools/lib/test-mac-script-mutations_test.sh
+++ b/tools/lib/test-mac-script-mutations_test.sh
@@ -138,8 +138,8 @@ red_case "app-exit" \
 red_case "backup-refresh" \
   "backup freshness: an existing backup is trusted blindly" \
   "$SUBJECT" \
-  $'    if printf \'%s\\n\' "$CODESIGN_INFO" | grep -q "^Authority=Developer ID Application"; then' \
-  $'    if [[ ! -d "$PROD_BACKUP" ]] && printf \'%s\\n\' "$CODESIGN_INFO" | grep -q "^Authority=Developer ID Application"; then' \
+  $'    if [[ "$NL$CODESIGN_INFO" == *"${NL}Authority=Developer ID Application"* ]]; then\n      rm -rf "$PROD_BACKUP"' \
+  $'    if [[ ! -d "$PROD_BACKUP" && "$NL$CODESIGN_INFO" == *"${NL}Authority=Developer ID Application"* ]]; then\n      rm -rf "$PROD_BACKUP"' \
   'GATE backup-freshness: the stale backup was NOT refreshed'
 
 # ── 4. The no-safety-net refusal stops refusing ─────────────────────────────

--- a/tools/lib/test-mac-script-mutations_test.sh
+++ b/tools/lib/test-mac-script-mutations_test.sh
@@ -11,7 +11,7 @@
 # when the thing it protects is broken — so each gate is broken here, one at a
 # time, and the lock test is required to go red naming that specific gate.
 #
-# Twenty-two mutations, applied and asserted SEPARATELY. A single combined mutation
+# Twenty-three mutations, applied and asserted SEPARATELY. A single combined mutation
 # could go red on one gate while another was silently unguarded, which is the
 # exact shape of defect this whole file exists to rule out. Each one is written
 # as the plausible REGRESSION, not as arbitrary damage: the reachability abort
@@ -215,17 +215,30 @@ red_case "swift-status" \
 # Developer-ID bundle. This row is why the codesign stub emits a realistic line
 # count: a one-line stub cannot reproduce the SIGPIPE and passed regardless.
 red_case "backup-refresh" \
-  "F1: the Developer-ID check is piped into grep -q again" \
+  "F1a: the Developer-ID check goes straight back through a pipe" \
   "$SUBJECT" \
-  $'    CODESIGN_INFO="$(codesign -dv --verbose=4 "$PROD_APP" 2>&1 || true)"\n    if printf \'%s\\n\' "$CODESIGN_INFO" | grep -q "^Authority=Developer ID Application"; then' \
+  $'    CODESIGN_INFO="$(codesign -dv --verbose=4 "$PROD_APP" 2>&1 || true)"\n    if [[ "$NL$CODESIGN_INFO" == *"${NL}Authority=Developer ID Application"* ]]; then' \
   $'    if codesign -dv --verbose=4 "$PROD_APP" 2>&1 | grep -q "^Authority=Developer ID Application"; then' \
+  'GATE backup-freshness: the stale backup was NOT refreshed'
+
+# ── 10b. ...and the INTERMEDIATE wrong fix, which is the subtle one ────────
+# "Capture first, then pipe the capture into grep -q" looks like it fixes F1
+# and does not: the producer is now `printf` instead of `codesign`, but it is
+# still a producer racing a `grep -q` that exits early. It survives only while
+# the captured text fits one pipe buffer, i.e. by headroom rather than by
+# construction. This row is what forces the match to happen IN-SHELL.
+red_case "backup-refresh" \
+  "F1b: the captured output is piped into grep -q (fix by headroom, not construction)" \
+  "$SUBJECT" \
+  $'    if [[ "$NL$CODESIGN_INFO" == *"${NL}Authority=Developer ID Application"* ]]; then' \
+  $'    if printf \'%s\\n\' "$CODESIGN_INFO" | grep -q "^Authority=Developer ID Application"; then' \
   'GATE backup-freshness: the stale backup was NOT refreshed'
 
 # ── 11. ...and the same hazard in the teardown half ───────────────────────
 red_case "restore-signed" \
   "F1: restore-prod.sh's Developer-ID check is piped into grep -q again" \
   ".claude/skills/ir:test-mac/restore-prod.sh" \
-  $'elif { CODESIGN_INFO="$(codesign -dv --verbose=4 "$PROD_APP" 2>&1 || true)"\n       printf \'%s\\n\' "$CODESIGN_INFO" | grep -q "^Authority=Developer ID Application"; }; then' \
+  $'elif { CODESIGN_INFO="$(codesign -dv --verbose=4 "$PROD_APP" 2>&1 || true)"\n       [[ "$NL$CODESIGN_INFO" == *"${NL}Authority=Developer ID Application"* ]]; }; then' \
   $'elif codesign -dv --verbose=4 "$PROD_APP" 2>&1 | grep -q "^Authority=Developer ID Application"; then' \
   'restore-prod: a genuine Developer-ID app with no backup'
 

--- a/tools/lib/test-mac-script-mutations_test.sh
+++ b/tools/lib/test-mac-script-mutations_test.sh
@@ -2,20 +2,24 @@
 # test-mac-script-mutations_test.sh — the committed mutation fixtures for
 # tools/lib/test-mac-script_test.sh (#1855).
 #
-# WHY THIS FILE EXISTS. Every gate in .claude/skills/ir:test-mac/test-mac.sh
-# was MOVED there out of SKILL.md's fenced bash blocks, and two more were
-# ADDED. Either way there is no "before the fix" to run red: the lock test
-# passes the moment it is written. Per AGENTS.md's Testing section and
+# WHY THIS FILE EXISTS. Six gates in .claude/skills/ir:test-mac/test-mac.sh
+# were MOVED there out of SKILL.md's fenced bash blocks; three more were ADDED.
+# Either way there is no "before the fix" to run red: the lock test passes the
+# moment it is written. Per AGENTS.md's Testing section and
 # docs/testing-philosophy.md it earns its place only by being seen to fail
 # when the thing it protects is broken — so each gate is broken here, one at a
 # time, and the lock test is required to go red naming that specific gate.
 #
-# Nine mutations, applied and asserted SEPARATELY. A single combined mutation
+# Eleven mutations, applied and asserted SEPARATELY. A single combined mutation
 # could go red on one gate while another was silently unguarded, which is the
 # exact shape of defect this whole file exists to rule out. Each one is written
 # as the plausible REGRESSION, not as arbitrary damage: the reachability abort
 # demoted to a no-op, the backup refresh demoted to "make it once, ever", the
 # `swift build` status read back through the pipe the way SKILL.md used to.
+#
+# The last row is not a gate inside the script at all — it is the `tools` gate
+# that RUNS these two files, whose --changed trigger regex must cover the
+# skill directory or a push touching only test-mac.sh skips both of them.
 #
 # Every row drives the real tools/mutate.sh, which owns the mechanics this file
 # must not re-improvise: the stale-anchor guard, the no-op replacement refusal,
@@ -27,11 +31,11 @@
 # shared with tools/lib/preflight-groups-skill-mutations_test.sh and
 # tools/lib/checkpoint-idiom-guard-mutations_test.sh.
 #
-# COST. Each row re-runs the whole lock test (~16s), so this file is the
-# slowest thing in the `tools` gate by a wide margin. That is the price of
-# nine independently-proven gates and it is paid deliberately; the alternative
-# — one combined mutation, or a filtered lock test — buys seconds by giving up
-# the thing being bought.
+# COST. Each row runs the lock test scoped to the ONE case it is about (see
+# red_case below). Running all fifteen cases per row instead cost 194s here and
+# took the whole `tools` gate from 116s to 327s — against a 540s budget the
+# pre-push hook shares with every other gate, which is a regression for every
+# push in the repo, not just this one (measured, #1855).
 
 set -uo pipefail
 
@@ -83,10 +87,29 @@ fi
 
 fails=0
 
+# red_case <case> <label> <file> <anchor> <replacement> <want_match>
+#
+# Scopes the lock test to the ONE case a mutation is about. Without this every
+# row re-ran all fifteen cases: 194s for this file and 327s for the whole
+# `tools` gate, against a 540s pre-push budget shared with every other gate
+# (measured, #1855). $TESTMAC_CASE is the spelling used because
+# mutation-assert.sh runs the lock test as a bare `bash <path>` and cannot
+# append an argument.
+#
+# A case name that matches nothing makes the lock test REFUSE (exit 2) rather
+# than pass over zero assertions, so a typo here cannot turn into a mutation
+# that "went red" against a test that checked nothing.
+red_case() {
+  local c="$1"; shift
+  export TESTMAC_CASE="$c"
+  assert_mutation_is_red "$@"
+  unset TESTMAC_CASE
+}
+
 # ── 1. The daemon-reachability gate is demoted to a no-op ───────────────────
 # The failure it prevents is silent: the app finds no daemon on 7837, runs
 # `pkill -x irrlichd`, and respawns one WITHOUT --record.
-assert_mutation_is_red \
+red_case "reachability" \
   "reachability gate: the abort never fires" \
   "$SUBJECT" \
   $'  if [[ -z "$READY" ]]; then\n    echo "ABORT: daemon never became reachable on $PORT' \
@@ -96,7 +119,7 @@ assert_mutation_is_red \
 # ── 2. The app-exit wait stops hard-aborting ────────────────────────────────
 # The bundle is then overwritten while the process that has those files open is
 # still alive.
-assert_mutation_is_red \
+red_case "app-exit" \
   "app-exit wait: the hard abort never fires" \
   "$SUBJECT" \
   $'  if [[ "$MODE" == "replace" ]] && pgrep -f "$APP_KILL_PATTERN" >/dev/null 2>&1; then' \
@@ -108,7 +131,7 @@ assert_mutation_is_red \
 # adding the natural-looking `[[ ! -d "$PROD_BACKUP" ]] &&` — after which a
 # backup taken before a newer production release is never refreshed, and
 # restore-prod.sh silently reinstalls a stale build.
-assert_mutation_is_red \
+red_case "backup-refresh" \
   "backup freshness: an existing backup is trusted blindly" \
   "$SUBJECT" \
   $'    if codesign -dv --verbose=4 "$PROD_APP" 2>&1 | grep -q "^Authority=Developer ID Application"; then' \
@@ -116,7 +139,7 @@ assert_mutation_is_red \
   'GATE backup-freshness: the stale backup was NOT refreshed'
 
 # ── 4. The no-safety-net refusal stops refusing ─────────────────────────────
-assert_mutation_is_red \
+red_case "backup-refuse" \
   "backup refusal: a dev-signed app with no backup is overwritten anyway" \
   "$SUBJECT" \
   $'    elif [[ ! -d "$PROD_BACKUP" ]]; then' \
@@ -124,7 +147,7 @@ assert_mutation_is_red \
   'GATE backup-refusal: dev-signed app + no backup must refuse'
 
 # ── 5. The build-output existence check stops checking ──────────────────────
-assert_mutation_is_red \
+red_case "build-output" \
   "build-output existence: a missing product no longer stops the install" \
   "$SUBJECT" \
   $'  if [[ ! -x "$DEBUG_BIN" || ! -d "$DEBUG_SPARKLE" ]]; then' \
@@ -134,7 +157,7 @@ assert_mutation_is_red \
 # ── 6. The enum gains the default branch it was written without ─────────────
 # A typo like `seperate` then silently runs the DESTRUCTIVE default instead of
 # erroring — the exact hazard SKILL.md's step 0 named.
-assert_mutation_is_red \
+red_case "enum" \
   "enum validation: an unrecognised axis value is silently ignored" \
   "$SUBJECT" \
   $'    *)\n      echo "ERROR: unrecognised argument \'$arg\'." >&2' \
@@ -144,7 +167,7 @@ assert_mutation_is_red \
 # ── 7. The daemon is killed before the app ─────────────────────────────────
 # A still-alive app then observes a daemon-less gap and spawns its own
 # replacement, which can win the port race against the daemon started next.
-assert_mutation_is_red \
+red_case "kill-order" \
   "kill order: the daemon is killed first" \
   "$SUBJECT" \
   $'if want_app; then\n  echo "Stopping the app ($APP_KILL_PATTERN) …"' \
@@ -152,7 +175,7 @@ assert_mutation_is_red \
   'GATE kill-order: the daemon was killed at line'
 
 # ── 8. Build freshness (ADDED by #1855) stops firing ───────────────────────
-assert_mutation_is_red \
+red_case "freshness" \
   "build freshness: a stale build product is installed anyway" \
   "$SUBJECT" \
   $'  if [[ -n "$STALE_SRC" ]]; then' \
@@ -162,7 +185,7 @@ assert_mutation_is_red \
 # ── 8b. ...and its own cannot-run refusal stops refusing ───────────────────
 # A freshness check with nothing to compare against would otherwise report the
 # same green as one that looked and found nothing.
-assert_mutation_is_red \
+red_case "freshness-vacuous" \
   "build freshness: an empty source set passes vacuously" \
   "$SUBJECT" \
   $'  if [[ "$SWIFT_SRC_COUNT" -eq 0 ]]; then' \
@@ -173,7 +196,7 @@ assert_mutation_is_red \
 # This is SKILL.md's own pre-#1855 spelling (`swift build 2>&1 | tail -5`),
 # whose exit status is tail's. A failed build reported success and the run
 # walked into the install with whatever binary was lying around.
-assert_mutation_is_red \
+red_case "swift-status" \
   "swift build status: a failed build is reported as success by the pipe" \
   "$SUBJECT" \
   $'  if ! swift build --package-path "$REPO_ROOT/platforms/macos" 2>&1 | tail -5; then\n    echo "ERROR: swift build failed — not touching $APP_TARGET." >&2\n    exit 1\n  fi' \
@@ -185,7 +208,7 @@ assert_mutation_is_red \
 # Without the trigger alternative added in #1855, a push that changes only
 # test-mac.sh skips the whole `tools` group under `--changed`, and a gate that
 # never ran is indistinguishable from one that found nothing.
-assert_mutation_is_red \
+red_case "preflight-trigger" \
   "preflight trigger: the tools gate stops covering .claude/skills/ir:test-mac/" \
   "tools/preflight.sh" \
   $'|^\\.claude/skills/ir:test-mac/|^\\.github/workflows/(ars|codescene-badge' \

--- a/tools/lib/test-mac-script_test.sh
+++ b/tools/lib/test-mac-script_test.sh
@@ -240,13 +240,25 @@ case "$1" in
     printf 'Authority=Apple Root CA\n' >&2
     # Built in two loops rather than 4000 printfs: ~140 iterations total, so the
     # padding costs milliseconds per call across all cases.
+    #
+    # `|| exit 141` is the part that makes this portable. Volume guarantees the
+    # writer is still writing when a `grep -q` reader exits; it does NOT
+    # guarantee how THIS shell reports that. If SIGPIPE is delivered, the stub
+    # dies 141 on its own; if it is ignored or handled (which varies by /bin/sh
+    # build), write() returns EPIPE, printf reports failure, and without this
+    # the stub would run on to `exit 0` and hand the pipeline a SUCCESS. That
+    # is exactly what happened: the direct-pipe mutation went red on the dev
+    # machine and stayed GREEN on the GitHub macOS runner, while the sibling
+    # mutation whose producer is the script's own printf went red on both.
+    # Reporting the broken pipe explicitly models what the real codesign does
+    # (measured: rc 141) without depending on signal disposition.
     line='Tail=lines after the Authority block, padded so an unread pipe fills and the writer blocks .......'
     block=''
     i=1
     while [ "$i" -le 36 ]; do block="$block$line
 "; i=$((i + 1)); done
     i=1
-    while [ "$i" -le 100 ]; do printf '%s' "$block"; i=$((i + 1)); done >&2
+    while [ "$i" -le 100 ]; do printf '%s' "$block" || exit 141; i=$((i + 1)); done >&2
     ;;
 esac
 exit 0
@@ -663,6 +675,44 @@ case_abort_hint() {
   fi
 }
 
+# ─── The codesign stub must reproduce the hazard it exists to reproduce ────
+# The two most valuable mutation rows (F1a/F1b in the fixtures file) assert
+# that piping codesign into `grep -q` breaks the Developer-ID check. That only
+# proves anything if THIS stub actually reports a broken pipe. The first
+# version could not (one line, no SIGPIPE) and the second could only when
+# SIGPIPE was delivered — which the GitHub runner did not do, so the rows
+# stayed green there while passing here. This case pins the property directly
+# instead of leaving it as an assumption inside a heredoc.
+case_stub_fidelity() {
+  local R rc rc_ignored out
+  R=$(new_env)
+  for mode in default ignored; do
+    if [[ "$mode" == ignored ]]; then pre='trap "" PIPE; '; else pre=''; fi
+    out=$(env -i PATH="/usr/bin:/bin" STUB_LOG="$R/stub.log" \
+            STUB_CODESIGN_AUTHORITY="Authority=Developer ID Application: X" \
+            bash -c "${pre}set -o pipefail; \"\$1\" -dv --verbose=4 x 2>&1 | grep -q '^Authority=Developer ID Application'; echo \$?" \
+            _ "$R/bin/codesign" 2>&1)
+    if [[ "$mode" == default ]]; then rc="$out"; else rc_ignored="$out"; fi
+  done
+  if [[ "$rc" != 141 ]]; then
+    fail "STUB-FIDELITY: piping the codesign stub into grep -q returned '$rc', not 141 — the stub no longer reproduces the SIGPIPE hazard, so the F1 mutation rows prove nothing"
+  elif [[ "$rc_ignored" != 141 ]]; then
+    fail "STUB-FIDELITY: with SIGPIPE IGNORED the stub returned '$rc_ignored', not 141 — it depends on signal delivery, so the F1 rows go green on any host that ignores SIGPIPE (this is exactly what the GitHub runner did)"
+  else
+    pass "STUB-FIDELITY: the codesign stub reports a broken pipe as 141 under both signal dispositions"
+  fi
+  # ...and it must still be MATCHABLE when read whole, or every backup case is
+  # passing for the wrong reason.
+  out=$(env -i PATH="/usr/bin:/bin" STUB_LOG="$R/stub.log" \
+          STUB_CODESIGN_AUTHORITY="Authority=Developer ID Application: X" \
+          bash -c 'C="$("$1" -dv --verbose=4 x 2>&1 || true)"; case "
+$C" in *"
+Authority=Developer ID Application"*) echo MATCH ;; *) echo NOMATCH ;; esac' _ "$R/bin/codesign" 2>&1)
+  [[ "$out" == MATCH ]] \
+    && pass "STUB-FIDELITY: ...and its output still carries a line-anchored Authority= line when read whole" \
+    || fail "STUB-FIDELITY: reading the stub's output whole does not find a line-anchored Authority= line (got '$out') — the backup cases would pass for the wrong reason"
+}
+
 # ─── The seams are honoured BEHAVIOURALLY, not just present as text ────────
 # The text guard at the top would pass on a seam that survives only in a
 # comment, at which point every case silently starts driving the real
@@ -767,7 +817,7 @@ CASES=(happy reachability app-exit backup-refresh backup-refuse build-output
        enum kill-order freshness freshness-vacuous swift-status
        target-daemon target-macos target-macos-nodaemon
        daemon-launch separate-full sign-order install-details abort-hint
-       seams restore-signed restore-refuse preflight-trigger)
+       seams stub-fidelity restore-signed restore-refuse preflight-trigger)
 
 echo "== $NAME: $SCRIPT${CASE_FILTER:+ (case: $CASE_FILTER)} =="
 

--- a/tools/lib/test-mac-script_test.sh
+++ b/tools/lib/test-mac-script_test.sh
@@ -205,15 +205,29 @@ STUB
   # codesign: `-dv` reports the authority under test; anything else is a real
   # signing call and just succeeds.
   #
-  # THE OUTPUT SHAPE IS LOAD-BEARING, not decoration. The real
-  # `codesign -dv --verbose=4` writes 28 unbuffered lines to stderr with the
-  # `Authority=` block at line 20 (measured against
-  # .build/irrlicht-prod-backup/Irrlicht.app). A one-line stub fits a single
-  # write, so `… | grep -q` never SIGPIPEs it and the pipeline returns 0 — which
+  # THE OUTPUT SHAPE IS LOAD-BEARING, not decoration.
+  #
+  # The real `codesign -dv --verbose=4` writes 28 unbuffered lines to stderr
+  # with the `Authority=` block at line 20 (measured against
+  # .build/irrlicht-prod-backup/Irrlicht.app), so the header below mirrors that.
+  # A one-line stub fits a single write, never SIGPIPEs under `… | grep -q`, and
   # made GATE 3a pass against a script whose Developer-ID check could not
-  # succeed at all under `set -o pipefail` (rc 141, 5/5; #1855 review F1/F2).
-  # A stub that cannot reproduce the subject's real I/O shape is a stub that
-  # certifies the wrong thing.
+  # succeed at all under `set -o pipefail` (#1855 review F1/F2).
+  #
+  # THE LARGE TAIL IS WHY THIS IS DETERMINISTIC. `grep -q` exits at its first
+  # match; whether the writer then dies of SIGPIPE is a RACE — it only loses if
+  # it is still writing. The real codesign loses it essentially always because
+  # it is a real binary walking a bundle between writes (rc 141, 5/5 locally).
+  # A shell stub is fast enough to WIN that race, and did: the 28-line version
+  # reproduced the failure on this machine 22/22 but stayed GREEN on the GitHub
+  # macOS runner, so the F1 mutation rows silently proved nothing there.
+  #
+  # Volume replaces the timing hope with a structural guarantee: once the
+  # unread output exceeds the pipe buffer (64 KiB on macOS and Linux) the writer
+  # MUST block in write(), so a reader that has already exited leaves it holding
+  # a broken pipe. ~360 KiB is far past any of them. This is the same rule as
+  # "a fixture that waits by sleeping hasn't observed what it waits for"
+  # (AGENTS.md) — a fixture must not assert a race it merely tends to win.
   cat > "$b/codesign" <<'STUB'
 #!/bin/sh
 printf 'codesign %s\n' "$*" >>"$STUB_LOG"
@@ -224,8 +238,15 @@ case "$1" in
     printf '%s\n' "${STUB_CODESIGN_AUTHORITY:-Authority=Irrlicht Dev}" >&2
     printf 'Authority=Developer ID Certification Authority\n' >&2
     printf 'Authority=Apple Root CA\n' >&2
+    # Built in two loops rather than 4000 printfs: ~140 iterations total, so the
+    # padding costs milliseconds per call across all cases.
+    line='Tail=lines after the Authority block, padded so an unread pipe fills and the writer blocks .......'
+    block=''
     i=1
-    while [ "$i" -le 6 ]; do printf 'Tail-%02d=lines after the Authority block\n' "$i" >&2; i=$((i + 1)); done
+    while [ "$i" -le 36 ]; do block="$block$line
+"; i=$((i + 1)); done
+    i=1
+    while [ "$i" -le 100 ]; do printf '%s' "$block"; i=$((i + 1)); done >&2
     ;;
 esac
 exit 0

--- a/tools/lib/test-mac-script_test.sh
+++ b/tools/lib/test-mac-script_test.sh
@@ -3,17 +3,24 @@
 # .claude/skills/ir:test-mac/test-mac.sh (#1855).
 #
 # WHAT THIS IS. #1855 turned nine fenced bash blocks in that skill's SKILL.md
-# into one script. Six gates were MOVED across in that extraction and three
-# were added; each has an incident behind it and several fail SILENTLY when
-# broken, which is exactly why an extraction is where they get lost. This file
-# drives the real script end to end and asserts each gate still holds.
-# tools/lib/test-mac-script-mutations_test.sh then breaks each gate in turn
-# and requires THIS file to go red — a green that was never red is a claim,
-# not evidence (AGENTS.md, Testing).
+# into one script. Six gates were MOVED across in that extraction and four were
+# added; each has an incident behind it and several fail SILENTLY when broken,
+# which is exactly why an extraction is where they get lost. This file drives
+# both of the skill's scripts end to end and asserts each gate still holds.
+# tools/lib/test-mac-script-mutations_test.sh then breaks each one in turn and
+# requires THIS file to go red — a green that was never red is a claim, not
+# evidence (AGENTS.md, Testing).
 #
-# SAFETY. The script under test kills processes and overwrites
-# /Applications/Irrlicht.app. Four things keep it off this machine, and every
-# one of them is load-bearing:
+# GATES ARE NOT THE WHOLE JOB. A gate says "it refuses correctly"; the CALL-SITE
+# cases below say "it does the right thing when it proceeds". That half exists
+# because a mutation battery over the first draft found eleven survivors and
+# every one was a call site — --record dropped from the daemon launch, the
+# replace-mode port changed, separate mode's whole bundle assembly never
+# executed. A refactor moves risk to call sites, and this ticket is a refactor.
+#
+# SAFETY. The scripts under test kill processes and overwrite (test-mac.sh) or
+# delete and replace (restore-prod.sh) /Applications/Irrlicht.app. Four things
+# keep them off this machine, and every one is load-bearing:
 #   1. IRRLICHT_TESTMAC_PROD_APP / _DEV_APP / _MAIN_REPO / _REPO_ROOT /
 #      _LOG_DIR / _PLISTBUDDY redirect every path it touches into a mktemp -d.
 #   2. HOME is that temp dir too, so the replace-mode socket path under
@@ -32,12 +39,14 @@
 #
 # CASE SELECTION. With no case named every case runs, which is what the `tools`
 # gate does. Naming one (argv, or $TESTMAC_CASE) runs only that one — which is
-# how the mutations fixture keeps its cost sane: it applies eleven mutations,
-# and re-running all fifteen cases for each of them took 194s and pushed the
-# whole `tools` gate from 116s to 327s, well past what the pre-push hook's 540s
-# budget can absorb alongside every other gate (measured, #1855). A NAME THAT
-# MATCHES NOTHING IS A REFUSAL (exit 2), never a quiet zero-case pass: a typo
-# in a fixture row must not produce the same output as a case that ran.
+# how the mutations fixture keeps its cost sane. Re-running every case for each
+# mutation took 194s for that file and pushed the whole `tools` gate from 116s
+# to 327s, past what the pre-push hook's 540s budget can absorb alongside every
+# other gate. Figures measured with:
+#     S=$(date +%s); tools/preflight.sh --only tools >/dev/null 2>&1; echo $(( $(date +%s) - S ))
+# re-run after any change here rather than trusted from this comment. A NAME
+# THAT MATCHES NOTHING IS A REFUSAL (exit 2), never a quiet zero-case pass: a
+# typo in a fixture row must not produce the same output as a case that ran.
 #
 # Convention follows tools/lib/install-uninstall_test.sh and
 # tools/lib/agents-md-lint_test.sh: plain bash, `set -uo pipefail` (never -e —
@@ -70,13 +79,27 @@ if [[ ! -x "$REPO_ROOT/$SCRIPT" ]]; then
 fi
 
 # The isolation seams are what keep every case below off the real machine. If
-# the script stops honouring them, this file would silently start driving the
-# real /Applications/Irrlicht.app — so refuse to run rather than find out.
+# either script stops honouring them, this file would silently start driving
+# the real /Applications/Irrlicht.app — so refuse to run rather than find out.
+#
+# This is a cheap TEXT check and it is deliberately not the only one: a seam
+# that survives only inside a comment would pass it. The `seams` case below is
+# the behavioural one — it points a seam at a fixture path and requires the
+# script's own error to name THAT path. Both exist because this check runs
+# before anything else and must be able to stop the file dead, while the case
+# is what actually proves the redirection works.
 for seam in IRRLICHT_TESTMAC_REPO_ROOT IRRLICHT_TESTMAC_MAIN_REPO IRRLICHT_TESTMAC_PROD_APP \
             IRRLICHT_TESTMAC_DEV_APP IRRLICHT_TESTMAC_LOG_DIR IRRLICHT_TESTMAC_PLISTBUDDY; do
   if ! grep -q "$seam" "$REPO_ROOT/$SCRIPT"; then
     echo "FAIL: $NAME — REFUSING TO RUN: $SCRIPT no longer honours \$$seam." >&2
     echo "      Without it this test drives the real production app and daemon." >&2
+    exit 2
+  fi
+done
+for seam in IRRLICHT_TESTMAC_MAIN_REPO IRRLICHT_TESTMAC_PROD_APP IRRLICHT_TESTMAC_PORT; do
+  if ! grep -q "$seam" "$REPO_ROOT/.claude/skills/ir:test-mac/restore-prod.sh"; then
+    echo "FAIL: $NAME — REFUSING TO RUN: restore-prod.sh no longer honours \$$seam." >&2
+    echo "      Without it the restore cases below delete the real /Applications/Irrlicht.app." >&2
     exit 2
   fi
 done
@@ -103,7 +126,14 @@ trap 'rm -rf "$WORK"' EXIT
 # something on the way past it.
 new_env() {
   local root
-  root="$(mktemp -d "$WORK/env.XXXXXX")" || return 1
+  # A failed mktemp must not yield an empty root: `IRRLICHT_TESTMAC_PROD_APP=`
+  # is an EMPTY override, so the script falls back to its real default and the
+  # case starts driving /Applications/Irrlicht.app. No caller checks new_env's
+  # status (they are all `R=$(new_env)`), so the refusal has to be fatal here.
+  if ! root="$(mktemp -d "$WORK/env.XXXXXX")" || [[ -z "$root" || ! -d "$root" ]]; then
+    echo "FAIL: $NAME — could not create a fixture root under $WORK; refusing to run a case that would fall back to the real machine" >&2
+    exit 2
+  fi
   mkdir -p "$root/home" "$root/bin" "$root/logs"
 
   # --- the worktree the script builds from ---
@@ -612,6 +642,33 @@ case_abort_hint() {
   fi
 }
 
+# ─── The seams are honoured BEHAVIOURALLY, not just present as text ────────
+# The text guard at the top would pass on a seam that survives only in a
+# comment, at which point every case silently starts driving the real
+# /Applications/Irrlicht.app. This case makes the script name the redirected
+# path in its own error: a message naming the fixture root can only come from
+# the override actually being read.
+case_seams() {
+  local R; R=$(new_env)
+  rm -rf "$R/Applications/Irrlicht.app"
+  run_script "$R" -- replace full
+  if [[ $ST -eq 0 ]]; then
+    fail "SEAMS: a missing production bundle must abort, but the script exited 0: $(flat "$OUT")"
+  elif [[ "$OUT" != *"$R/Applications/Irrlicht.app is not installed"* ]]; then
+    fail "SEAMS: the script did not name the FIXTURE bundle ($R/Applications/Irrlicht.app) — it is not reading \$IRRLICHT_TESTMAC_PROD_APP, so every case in this file is pointed at the real machine: $(flat "$OUT")"
+  else
+    pass "SEAMS: test-mac.sh resolves \$IRRLICHT_TESTMAC_PROD_APP to the fixture, not /Applications"
+  fi
+  R=$(new_env)
+  rm -rf "$R/Applications/Irrlicht.app"
+  run_restore "$R"
+  if [[ "$OUT" != *"$R/Applications/Irrlicht.app"* ]]; then
+    fail "SEAMS: restore-prod.sh did not name the FIXTURE bundle — it is not reading \$IRRLICHT_TESTMAC_PROD_APP, so the restore cases operate on the real /Applications/Irrlicht.app: $(flat "$OUT")"
+  else
+    pass "SEAMS: restore-prod.sh does too"
+  fi
+}
+
 # ─── restore-prod.sh — the teardown half, carrying the same F1 hazard ───────
 # It had no test at all. These two cases exist because the identical
 # `codesign … | grep -q` pipeline was in it, under its own `set -o pipefail`.
@@ -689,7 +746,7 @@ CASES=(happy reachability app-exit backup-refresh backup-refuse build-output
        enum kill-order freshness freshness-vacuous swift-status
        target-daemon target-macos target-macos-nodaemon
        daemon-launch separate-full sign-order install-details abort-hint
-       restore-signed restore-refuse preflight-trigger)
+       seams restore-signed restore-refuse preflight-trigger)
 
 echo "== $NAME: $SCRIPT${CASE_FILTER:+ (case: $CASE_FILTER)} =="
 

--- a/tools/lib/test-mac-script_test.sh
+++ b/tools/lib/test-mac-script_test.sh
@@ -598,7 +598,7 @@ case_abort_hint() {
   if [[ $ST -eq 0 ]]; then
     fail "GATE abort-hint: a failing launch after the install must not exit 0 — the bundle now holds a dev build: $(flat "$OUT")"
   elif [[ "$OUT" != *"now holds a DEV build"* || "$OUT" != *"restore-prod.sh"* ]]; then
-    fail "GATE abort-hint: it failed (exit $ST) after overwriting $PROD_APP but never said so, nor pointed at restore-prod.sh — the user is left with a silently dev-ified production bundle: $(flat "$OUT")"
+    fail "GATE abort-hint: it failed (exit $ST) after overwriting the production bundle but never said so, nor pointed at restore-prod.sh — the user is left with a silently dev-ified production bundle: $(flat "$OUT")"
   else
     pass "GATE abort-hint: a failure after the install names the dev-ified bundle and points at restore-prod.sh"
   fi

--- a/tools/lib/test-mac-script_test.sh
+++ b/tools/lib/test-mac-script_test.sh
@@ -125,6 +125,12 @@ new_env() {
   # --- the stable main checkout (daemon binary + production backup live here) ---
   mkdir -p "$root/main/core/bin" "$root/main/.build"
 
+  # The replace-mode socket lives under $HOME; pre-create it so the cleanup
+  # step has something to actually remove and its absence afterwards means
+  # something.
+  mkdir -p "$root/home/.local/share/irrlicht"
+  echo 'stale-socket' > "$root/home/.local/share/irrlicht/irrlichd.sock"
+
   # --- the "installed" production bundle ---
   local app="$root/Applications/Irrlicht.app"
   mkdir -p "$app/Contents/MacOS" "$app/Contents/Frameworks/Sparkle.framework" "$app/Contents/Resources"
@@ -138,9 +144,24 @@ new_env() {
   # Recording stubs: an assertion can prove a call ACTUALLY HAPPENED (and in
   # what order) rather than that the script merely exited without complaining.
   local s
-  for s in pkill open nohup install_name_tool; do
+  for s in pkill install_name_tool; do
     printf '#!/bin/sh\nprintf "%%s %%s\\n" "%s" "$*" >>"$STUB_LOG"\nexit 0\n' "$s" > "$b/$s"
   done
+  # open: STUB_OPEN_RC=1 stands in for any failure AFTER the bundle has been
+  # overwritten, which is what the teardown-hint case needs.
+  printf '#!/bin/sh\nprintf "open %%s\\n" "$*" >>"$STUB_LOG"\nexit "${STUB_OPEN_RC:-0}"\n' > "$b/open"
+  # nohup records the ENVIRONMENT it was handed, not just its argv. Everything
+  # that decides what the daemon actually is — `--record`, the bind address, the
+  # state dir, the permission mode — is passed that way, so an assertion that
+  # cannot see it cannot tell a correct launch from a silently wrong one. Every
+  # one of those was a surviving mutation before this (#1855 review F3).
+  cat > "$b/nohup" <<'STUB'
+#!/bin/sh
+printf 'nohup BIND=%s IRRHOME=%s PERM=%s ARGV=%s\n' \
+  "${IRRLICHT_BIND_ADDR:-<unset>}" "${IRRLICHT_HOME:-<unset>}" \
+  "${IRRLICHT_PERMISSION_MODE:-<unset>}" "$*" >>"$STUB_LOG"
+exit 0
+STUB
   # pgrep: exit 1 = "no such process" (the app died). STUB_PGREP_RC=0 makes it
   # immortal, which is what the app-exit gate is for.
   printf '#!/bin/sh\nprintf "pgrep %%s\\n" "$*" >>"$STUB_LOG"\nexit "${STUB_PGREP_RC:-1}"\n' > "$b/pgrep"
@@ -153,11 +174,29 @@ new_env() {
   printf '#!/bin/sh\nprintf "swift %%s\\n" "$*" >>"$STUB_LOG"\necho "stub swift build"\nexit "${STUB_SWIFT_RC:-0}"\n' > "$b/swift"
   # codesign: `-dv` reports the authority under test; anything else is a real
   # signing call and just succeeds.
+  #
+  # THE OUTPUT SHAPE IS LOAD-BEARING, not decoration. The real
+  # `codesign -dv --verbose=4` writes 28 unbuffered lines to stderr with the
+  # `Authority=` block at line 20 (measured against
+  # .build/irrlicht-prod-backup/Irrlicht.app). A one-line stub fits a single
+  # write, so `… | grep -q` never SIGPIPEs it and the pipeline returns 0 — which
+  # made GATE 3a pass against a script whose Developer-ID check could not
+  # succeed at all under `set -o pipefail` (rc 141, 5/5; #1855 review F1/F2).
+  # A stub that cannot reproduce the subject's real I/O shape is a stub that
+  # certifies the wrong thing.
   cat > "$b/codesign" <<'STUB'
 #!/bin/sh
 printf 'codesign %s\n' "$*" >>"$STUB_LOG"
 case "$1" in
-  -dv) printf '%s\n' "${STUB_CODESIGN_AUTHORITY:-Authority=Irrlicht Dev}" >&2 ;;
+  -dv)
+    i=1
+    while [ "$i" -le 19 ]; do printf 'Filler-%02d=padding to the real tool line count\n' "$i" >&2; i=$((i + 1)); done
+    printf '%s\n' "${STUB_CODESIGN_AUTHORITY:-Authority=Irrlicht Dev}" >&2
+    printf 'Authority=Developer ID Certification Authority\n' >&2
+    printf 'Authority=Apple Root CA\n' >&2
+    i=1
+    while [ "$i" -le 6 ]; do printf 'Tail-%02d=lines after the Authority block\n' "$i" >&2; i=$((i + 1)); done
+    ;;
 esac
 exit 0
 STUB
@@ -451,6 +490,172 @@ case_target_macos_nodaemon() {
   fi
 }
 
+# ─── CALL SITES, not just gate definitions ─────────────────────────────────
+# This change is an EXTRACTION, so the risk moved to the call sites: the values
+# each step passes. A battery of fourteen mutations found eleven survivors and
+# every one was a call site — `--record` dropped from the daemon launch, the
+# replace-mode port changed to 7838, IRRLICHT_BIND_ADDR removed, the whole
+# `separate` bundle assembly never executed, install_name_tool deleted, the
+# socket cleanup deleted (#1855 review F3). Gates say "it refuses correctly";
+# these say "it does the right thing when it proceeds".
+
+# The daemon is the whole point of the run: a daemon without --record, or on
+# the wrong port, silently produces nothing while every gate above stays green.
+case_daemon_launch() {
+  local R L; R=$(new_env); with_backup "$R"
+  run_script "$R" -- replace full
+  L="$(grep '^nohup ' "$R/stub.log" 2>/dev/null | head -1)"
+  if [[ -z "$L" ]]; then
+    fail "CALL-SITE daemon-launch: COULD NOT LOOK — the daemon was never launched, so its arguments prove nothing. Log: $(flat "$(cat "$R/stub.log")")"
+    return
+  fi
+  [[ "$L" == *"--record"* ]] \
+    && pass "CALL-SITE daemon-launch: replace mode passes --record" \
+    || fail "CALL-SITE daemon-launch: the daemon was started WITHOUT --record — the run records nothing, and every reachability gate still passes: $L"
+  [[ "$L" == *"BIND=127.0.0.1:7837"* ]] \
+    && pass "CALL-SITE daemon-launch: ...on the production port, via IRRLICHT_BIND_ADDR" \
+    || fail "CALL-SITE daemon-launch: replace mode did not bind 127.0.0.1:7837 — a missing PORT makes the daemon bind '127.0.0.1:' (invalid), the exact silent failure this script exists to remove: $L"
+  [[ "$L" == *"IRRHOME=<unset>"* ]] \
+    && pass "CALL-SITE daemon-launch: ...with no IRRLICHT_HOME override, so it reads production state" \
+    || fail "CALL-SITE daemon-launch: replace mode passed an IRRLICHT_HOME override, so it would not see production's sessions/cost data: $L"
+}
+
+# separate mode's ENTIRE bundle assembly and its open --env launch had no case
+# at all: the only `separate` run was `separate daemon`, which skips every app
+# step. Half the MODE axis was unexercised.
+case_separate_full() {
+  local R L APP; R=$(new_env)
+  run_script "$R" -- separate full
+  APP="$R/IrrlichtDev.app"
+  if [[ $ST -ne 0 ]]; then
+    fail "CALL-SITE separate-full: the run must complete, but it exited $ST: $(flat "$OUT")"
+    return
+  fi
+  [[ "$(cat "$APP/Contents/MacOS/Irrlicht" 2>/dev/null)" == FRESH-BUILD ]] \
+    && pass "CALL-SITE separate-full: the freshly built binary is installed into the dev bundle" \
+    || fail "CALL-SITE separate-full: $APP/Contents/MacOS/Irrlicht is not the built binary — the dev app would run whatever was there before, or not launch at all"
+  [[ -d "$APP/Contents/Frameworks/Sparkle.framework" ]] \
+    && pass "CALL-SITE separate-full: ...with Sparkle.framework embedded" \
+    || fail "CALL-SITE separate-full: Sparkle.framework is missing from the assembled bundle — dyld cannot resolve it and the app crashes at launch"
+  grep -q 'io.irrlicht.app' "$APP/Contents/Info.plist" 2>/dev/null \
+    && pass "CALL-SITE separate-full: ...and an Info.plist carrying the bundle identifier" \
+    || fail "CALL-SITE separate-full: the assembled Info.plist has no io.irrlicht.app identifier — UNUserNotificationCenter (the reason the bundle is assembled at all) will not work"
+  L="$(grep '^open ' "$R/stub.log" 2>/dev/null | head -1)"
+  if [[ "$L" != *"IRRLICHT_DAEMON_PORT=7838"* ]]; then
+    fail "CALL-SITE separate-full: the dev app was launched without --env IRRLICHT_DAEMON_PORT=7838, so it would talk to PRODUCTION on 7837: ${L:-<no open call>}"
+  else
+    pass "CALL-SITE separate-full: the dev app is pointed at the isolated daemon on 7838"
+  fi
+  L="$(grep '^nohup ' "$R/stub.log" 2>/dev/null | head -1)"
+  if [[ "$L" != *"BIND=127.0.0.1:7838"* || "$L" != *"PERM=grant-all"* || "$L" != *"IRRHOME=$R/repo/.build/irrlicht-home"* ]]; then
+    fail "CALL-SITE separate-full: the isolated daemon was not started on 7838 with an isolated IRRLICHT_HOME and grant-all (#570: without grant-all a fresh state dir monitors nothing): ${L:-<no nohup call>}"
+  else
+    pass "CALL-SITE separate-full: the isolated daemon gets 7838 + its own IRRLICHT_HOME + grant-all"
+  fi
+}
+
+# install_name_tool MUST run before codesign — it mutates the binary and so
+# invalidates any signature applied first. The script says so; nothing checked.
+case_sign_order() {
+  local R IN CS; R=$(new_env); with_backup "$R"
+  run_script "$R" -- replace full
+  IN=$(grep -n '^install_name_tool ' "$R/stub.log" 2>/dev/null | head -1 | cut -d: -f1)
+  CS=$(grep -n '^codesign --force' "$R/stub.log" 2>/dev/null | head -1 | cut -d: -f1)
+  if [[ -z "$IN" || -z "$CS" ]]; then
+    fail "CALL-SITE sign-order: COULD NOT LOOK — install_name_tool (line '${IN:-none}') and/or the signing codesign (line '${CS:-none}') never ran, so their order proves nothing. Log: $(flat "$(cat "$R/stub.log")")"
+  elif [[ "$IN" -ge "$CS" ]]; then
+    fail "CALL-SITE sign-order: codesign ran at line $CS, at or before install_name_tool at line $IN — the rpath edit invalidates the signature just applied"
+  else
+    pass "CALL-SITE sign-order: install_name_tool (line $IN) runs before codesign (line $CS)"
+  fi
+  if grep -q '^codesign --force.*--entitlements' "$R/stub.log" 2>/dev/null; then
+    pass "CALL-SITE sign-order: ...and the signature carries the dev entitlements file"
+  else
+    fail "CALL-SITE sign-order: codesign was called without --entitlements — the dev build loses the entitlements the app needs: $(flat "$(grep '^codesign --force' "$R/stub.log")")"
+  fi
+}
+
+# The two remaining install-time writes, and the socket cleanup — all three
+# were surviving mutations.
+case_install_details() {
+  local R; R=$(new_env); with_backup "$R"
+  run_script "$R" -- replace full
+  [[ "$(cat "$R/Applications/Irrlicht.app/Contents/Resources/AppIcon.icns" 2>/dev/null)" == icns ]] \
+    && pass "CALL-SITE install-details: the icon is refreshed from the worktree's Resources/" \
+    || fail "CALL-SITE install-details: AppIcon.icns still holds the production copy — a developer iterating on Resources/ sees a stale icon in replace mode but not in separate mode"
+  [[ ! -e "$R/home/.local/share/irrlicht/irrlichd.sock" ]] \
+    && pass "CALL-SITE install-details: the stale socket is removed before the daemon restarts" \
+    || fail "CALL-SITE install-details: the stale socket survived — this is the \$SOCK the old fenced blocks dropped, turning cleanup into a silent no-op"
+  grep -q '^plistbuddy .*CFBundleShortVersionString dev' "$R/stub.log" 2>/dev/null \
+    && pass "CALL-SITE install-details: the version string is stamped to 'dev'" \
+    || fail "CALL-SITE install-details: CFBundleShortVersionString was not stamped — Settings/About shows whatever release version was last installed on a freshly compiled dev build"
+}
+
+# ─── F5: an abort AFTER the bundle is overwritten must say how to recover ───
+case_abort_hint() {
+  local R; R=$(new_env); with_backup "$R"
+  run_script "$R" STUB_OPEN_RC=1 -- replace full
+  if [[ $ST -eq 0 ]]; then
+    fail "GATE abort-hint: a failing launch after the install must not exit 0 — the bundle now holds a dev build: $(flat "$OUT")"
+  elif [[ "$OUT" != *"now holds a DEV build"* || "$OUT" != *"restore-prod.sh"* ]]; then
+    fail "GATE abort-hint: it failed (exit $ST) after overwriting $PROD_APP but never said so, nor pointed at restore-prod.sh — the user is left with a silently dev-ified production bundle: $(flat "$OUT")"
+  else
+    pass "GATE abort-hint: a failure after the install names the dev-ified bundle and points at restore-prod.sh"
+  fi
+  # ...and it must NOT cry wolf on a run that never touched the bundle.
+  R=$(new_env); with_backup "$R"
+  run_script "$R" STUB_CURL_RC=1 -- replace daemon
+  if [[ "$OUT" == *"now holds a DEV build"* ]]; then
+    fail "GATE abort-hint: a TARGET=daemon run never touches the bundle, but it still told the user to restore production: $(flat "$OUT")"
+  else
+    pass "GATE abort-hint: ...and stays quiet when the bundle was never written"
+  fi
+}
+
+# ─── restore-prod.sh — the teardown half, carrying the same F1 hazard ───────
+# It had no test at all. These two cases exist because the identical
+# `codesign … | grep -q` pipeline was in it, under its own `set -o pipefail`.
+run_restore() {
+  local root="$1"; shift
+  OUT=$(env -i \
+    HOME="$root/home" \
+    PATH="$root/bin:/usr/bin:/bin:/usr/sbin:/sbin" \
+    STUB_LOG="$root/stub.log" \
+    IRRLICHT_TESTMAC_MAIN_REPO="$root/main" \
+    IRRLICHT_TESTMAC_PROD_APP="$root/Applications/Irrlicht.app" \
+    IRRLICHT_TESTMAC_PORT=7837 \
+    ${1+"$@"} \
+    bash "$REPO_ROOT/.claude/skills/ir:test-mac/restore-prod.sh" 2>&1)
+  ST=$?
+  return 0
+}
+
+case_restore_signed() {
+  local R; R=$(new_env)   # no backup dir; the app is genuinely Developer-ID-signed
+  run_restore "$R" STUB_CODESIGN_AUTHORITY="Authority=Developer ID Application: Ingo"
+  if [[ $ST -ne 0 ]]; then
+    fail "restore-prod: a genuine Developer-ID app with no backup means there is nothing to restore, but it exited $ST — it kills the app and daemon and THEN tells the user to reinstall a correctly installed app: $(flat "$OUT")"
+  elif [[ "$OUT" != *"nothing to restore"* ]]; then
+    fail "restore-prod: exited 0 but did not report 'nothing to restore': $(flat "$OUT")"
+  elif ! logged "$R" 'open '; then
+    fail "restore-prod: it reported success without ever launching production: $(flat "$(cat "$R/stub.log")")"
+  else
+    pass "restore-prod: a genuine production app with no backup ⇒ nothing to restore, and production is relaunched"
+  fi
+}
+
+case_restore_refuse() {
+  local R; R=$(new_env)   # default authority is "Irrlicht Dev", and no backup
+  run_restore "$R"
+  if [[ $ST -eq 0 ]]; then
+    fail "restore-prod: a dev-signed app with no backup cannot be restored and must refuse, but it exited 0: $(flat "$OUT")"
+  elif [[ "$OUT" != *"Cannot confirm production is intact"* ]]; then
+    fail "restore-prod: refused (exit $ST) but not with the cannot-confirm message: $(flat "$OUT")"
+  else
+    pass "restore-prod: a dev-signed app with no backup ⇒ refuse, naming the reinstall path"
+  fi
+}
+
 # ─── The gate that runs this file must fire on this file's SUBJECT ──────────
 # tools/preflight.sh --changed scopes the `tools` gate by a trigger regex. The
 # script under test lives outside tools/, so without an explicit alternative a
@@ -482,7 +687,9 @@ case_preflight_trigger() {
 # ─── dispatch ───────────────────────────────────────────────────────────────
 CASES=(happy reachability app-exit backup-refresh backup-refuse build-output
        enum kill-order freshness freshness-vacuous swift-status
-       target-daemon target-macos target-macos-nodaemon preflight-trigger)
+       target-daemon target-macos target-macos-nodaemon
+       daemon-launch separate-full sign-order install-details abort-hint
+       restore-signed restore-refuse preflight-trigger)
 
 echo "== $NAME: $SCRIPT${CASE_FILTER:+ (case: $CASE_FILTER)} =="
 

--- a/tools/lib/test-mac-script_test.sh
+++ b/tools/lib/test-mac-script_test.sh
@@ -3,10 +3,10 @@
 # .claude/skills/ir:test-mac/test-mac.sh (#1855).
 #
 # WHAT THIS IS. #1855 turned nine fenced bash blocks in that skill's SKILL.md
-# into one script. Six gates were MOVED across in that extraction and one was
-# added; each has an incident behind it and several fail SILENTLY when broken,
-# which is exactly why an extraction is where they get lost. This file drives
-# the real script end to end and asserts each gate still holds.
+# into one script. Six gates were MOVED across in that extraction and three
+# were added; each has an incident behind it and several fail SILENTLY when
+# broken, which is exactly why an extraction is where they get lost. This file
+# drives the real script end to end and asserts each gate still holds.
 # tools/lib/test-mac-script-mutations_test.sh then breaks each gate in turn
 # and requires THIS file to go red — a green that was never red is a claim,
 # not evidence (AGENTS.md, Testing).
@@ -30,11 +30,20 @@
 # run at full fidelity in zero time. The loops are the thing under test; their
 # wall-clock cost is not.
 #
+# CASE SELECTION. With no case named every case runs, which is what the `tools`
+# gate does. Naming one (argv, or $TESTMAC_CASE) runs only that one — which is
+# how the mutations fixture keeps its cost sane: it applies eleven mutations,
+# and re-running all fifteen cases for each of them took 194s and pushed the
+# whole `tools` gate from 116s to 327s, well past what the pre-push hook's 540s
+# budget can absorb alongside every other gate (measured, #1855). A NAME THAT
+# MATCHES NOTHING IS A REFUSAL (exit 2), never a quiet zero-case pass: a typo
+# in a fixture row must not produce the same output as a case that ran.
+#
 # Convention follows tools/lib/install-uninstall_test.sh and
 # tools/lib/agents-md-lint_test.sh: plain bash, `set -uo pipefail` (never -e —
-# a non-zero status from the subject is DATA here, half the cases expect one),
-# a `fails` counter, and "ALL PASS" / "N FAILED" at the end. FAIL lines start
-# at column 0 because tools/lib/mutation-assert.sh greps `^FAIL:` to decide
+# a non-zero status from the subject is DATA here, most cases expect one), a
+# `fails` counter, and "ALL PASS" / "N FAILED" at the end. FAIL lines start at
+# column 0 because tools/lib/mutation-assert.sh greps `^FAIL:` to decide
 # whether a mutation went red.
 set -uo pipefail
 
@@ -43,6 +52,11 @@ REPO_ROOT=$(git rev-parse --show-toplevel) || { echo "FAIL: $NAME — not inside
 cd "$REPO_ROOT" || { echo "FAIL: $NAME — cannot cd to $REPO_ROOT" >&2; exit 2; }
 
 SCRIPT=".claude/skills/ir:test-mac/test-mac.sh"
+# Positional for a human ("run just this one"), $TESTMAC_CASE for the mutations
+# fixture — tools/lib/mutation-assert.sh runs the lock test as a bare
+# `bash <path>` and has no way to append an argument, so the env spelling is
+# the one it can actually reach. Positional wins if both are given.
+CASE_FILTER="${1:-${TESTMAC_CASE:-}}"
 
 # A missing tool is a hard REFUSAL (exit 2), never a skip: exiting 0 here would
 # read as a PASS to shell-lib-suite.sh, so the gate would go green having
@@ -159,9 +173,14 @@ STUB
   echo "$root"
 }
 
+# with_backup <root> — the common precondition for every case that is NOT
+# about the backup gates: a backup exists, so the no-safety-net refusal does
+# not fire first and mask the gate actually under test.
+with_backup() { mkdir -p "$1/main/.build/irrlicht-prod-backup/Irrlicht.app"; }
+
 # run_script <root> [VAR=VAL ...] -- [script args...]
 # Sets OUT and ST. Never aborts: a non-zero status is the expected outcome of
-# half the cases here.
+# most cases here.
 run_script() {
   local root="$1"; shift
   local extra=()
@@ -188,17 +207,16 @@ sentinel_intact() { [[ "$(cat "$1/Applications/Irrlicht.app/Contents/MacOS/Irrli
 sparkle_intact()  { [[ "$(cat "$1/Applications/Irrlicht.app/Contents/Frameworks/Sparkle.framework/marker" 2>/dev/null)" == PRODUCTION ]]; }
 logged()          { grep -qF -- "$2" "$1/stub.log" 2>/dev/null; }
 
-echo "== $NAME: $SCRIPT =="
-
-# ─── 0. The happy path runs clean — the vacuity guard for everything below ──
+# ─── happy: the whole run completes — the vacuity guard for everything else ──
 # Without this, every abort case could be passing because the fixture is
 # broken rather than because a gate fired.
-R=$(new_env)
-mkdir -p "$R/main/.build/irrlicht-prod-backup/Irrlicht.app"   # dev-signed + a backup ⇒ the refusal below does not fire
-run_script "$R" -- replace full
-if [[ $ST -ne 0 ]]; then
-  fail "the happy path (replace full) completes — it exited $ST, so every abort case below proves nothing: $(flat "$OUT")"
-else
+case_happy() {
+  local R; R=$(new_env); with_backup "$R"
+  run_script "$R" -- replace full
+  if [[ $ST -ne 0 ]]; then
+    fail "the happy path (replace full) completes — it exited $ST, so every abort case proves nothing: $(flat "$OUT")"
+    return
+  fi
   pass "the happy path (replace full) completes"
   if logged "$R" 'open '; then pass "...and the app was launched"; else
     fail "the happy path launches the app — no 'open' call was recorded: $(flat "$OUT")"; fi
@@ -207,227 +225,245 @@ else
   else
     fail "the happy path installs the dev build — the bundle executable was not replaced"
   fi
-fi
+}
 
 # ─── GATE 1: daemon reachability, before the app is launched ────────────────
 # If the app starts while no --record daemon answers on 7837, it runs
 # `pkill -x irrlichd` and respawns one WITHOUT --record, silently defeating the
 # whole run. A gate, not a courtesy sleep.
-R=$(new_env)
-mkdir -p "$R/main/.build/irrlicht-prod-backup/Irrlicht.app"
-run_script "$R" STUB_CURL_RC=1 -- replace full
-if [[ $ST -eq 0 ]]; then
-  fail "GATE daemon-reachability: an unreachable daemon must abort, but the script exited 0: $(flat "$OUT")"
-elif [[ "$OUT" != *"never became reachable"* ]]; then
-  fail "GATE daemon-reachability: aborted (exit $ST) but not with the reachability message: $(flat "$OUT")"
-elif logged "$R" 'open '; then
-  fail "GATE daemon-reachability: it aborted, but the app was launched anyway — the app would pkill our daemon and respawn one without --record"
-else
-  pass "GATE daemon-reachability: no reachable daemon ⇒ abort, and the app is never launched"
-fi
+case_reachability() {
+  local R; R=$(new_env); with_backup "$R"
+  run_script "$R" STUB_CURL_RC=1 -- replace full
+  if [[ $ST -eq 0 ]]; then
+    fail "GATE daemon-reachability: an unreachable daemon must abort, but the script exited 0: $(flat "$OUT")"
+  elif [[ "$OUT" != *"never became reachable"* ]]; then
+    fail "GATE daemon-reachability: aborted (exit $ST) but not with the reachability message: $(flat "$OUT")"
+  elif logged "$R" 'open '; then
+    fail "GATE daemon-reachability: it aborted, but the app was launched anyway — the app would pkill our daemon and respawn one without --record"
+  else
+    pass "GATE daemon-reachability: no reachable daemon ⇒ abort, and the app is never launched"
+  fi
+}
 
 # ─── GATE 2: wait for the app to exit before overwriting its bundle ─────────
-R=$(new_env)
-mkdir -p "$R/main/.build/irrlicht-prod-backup/Irrlicht.app"
-run_script "$R" STUB_PGREP_RC=0 -- replace full
-if [[ $ST -eq 0 ]]; then
-  fail "GATE app-exit-wait: a still-running app must abort, but the script exited 0: $(flat "$OUT")"
-elif [[ "$OUT" != *"still running"* ]]; then
-  fail "GATE app-exit-wait: aborted (exit $ST) but not with the still-running message: $(flat "$OUT")"
-elif ! sentinel_intact "$R"; then
-  fail "GATE app-exit-wait: it aborted, but the bundle executable was overwritten while the process was still alive"
-else
-  pass "GATE app-exit-wait: a live app process ⇒ abort, and its bundle is left untouched"
-fi
+case_app_exit() {
+  local R; R=$(new_env); with_backup "$R"
+  run_script "$R" STUB_PGREP_RC=0 -- replace full
+  if [[ $ST -eq 0 ]]; then
+    fail "GATE app-exit-wait: a still-running app must abort, but the script exited 0: $(flat "$OUT")"
+  elif [[ "$OUT" != *"still running"* ]]; then
+    fail "GATE app-exit-wait: aborted (exit $ST) but not with the still-running message: $(flat "$OUT")"
+  elif ! sentinel_intact "$R"; then
+    fail "GATE app-exit-wait: it aborted, but the bundle executable was overwritten while the process was still alive"
+  else
+    pass "GATE app-exit-wait: a live app process ⇒ abort, and its bundle is left untouched"
+  fi
+}
 
 # ─── GATE 3a: backup freshness — refresh a Developer-ID-signed original ─────
 # Never trust an existing backup blindly: it can predate a newer production
 # release installed since, which would make restore-prod.sh silently reinstall
 # a stale build.
-R=$(new_env)
-mkdir -p "$R/main/.build/irrlicht-prod-backup/Irrlicht.app/Contents/MacOS"
-echo 'STALE-BACKUP' > "$R/main/.build/irrlicht-prod-backup/Irrlicht.app/Contents/MacOS/Irrlicht"
-run_script "$R" STUB_CODESIGN_AUTHORITY="Authority=Developer ID Application: Ingo" -- replace full
-BACKED="$(cat "$R/main/.build/irrlicht-prod-backup/Irrlicht.app/Contents/MacOS/Irrlicht" 2>/dev/null)"
-if [[ $ST -ne 0 ]]; then
-  fail "GATE backup-freshness: a Developer-ID-signed app must be backed up and installed over, but it exited $ST: $(flat "$OUT")"
-elif [[ "$BACKED" != PRODUCTION ]]; then
-  fail "GATE backup-freshness: the stale backup was NOT refreshed from the untouched original (backup holds '$BACKED', wanted PRODUCTION) — restore-prod.sh would reinstall a stale build"
-else
-  pass "GATE backup-freshness: a Developer-ID-signed original refreshes the backup before being overwritten"
-fi
+case_backup_refresh() {
+  local R BACKED; R=$(new_env)
+  mkdir -p "$R/main/.build/irrlicht-prod-backup/Irrlicht.app/Contents/MacOS"
+  echo 'STALE-BACKUP' > "$R/main/.build/irrlicht-prod-backup/Irrlicht.app/Contents/MacOS/Irrlicht"
+  run_script "$R" STUB_CODESIGN_AUTHORITY="Authority=Developer ID Application: Ingo" -- replace full
+  BACKED="$(cat "$R/main/.build/irrlicht-prod-backup/Irrlicht.app/Contents/MacOS/Irrlicht" 2>/dev/null)"
+  if [[ $ST -ne 0 ]]; then
+    fail "GATE backup-freshness: a Developer-ID-signed app must be backed up and installed over, but it exited $ST: $(flat "$OUT")"
+  elif [[ "$BACKED" != PRODUCTION ]]; then
+    fail "GATE backup-freshness: the stale backup was NOT refreshed from the untouched original (backup holds '$BACKED', wanted PRODUCTION) — restore-prod.sh would reinstall a stale build"
+  else
+    pass "GATE backup-freshness: a Developer-ID-signed original refreshes the backup before being overwritten"
+  fi
+}
 
 # ─── GATE 3b: backup freshness — refuse dev-signed with NO backup ───────────
-R=$(new_env)   # default authority is "Irrlicht Dev", and no backup dir is created
-run_script "$R" -- replace full
-if [[ $ST -eq 0 ]]; then
-  fail "GATE backup-refusal: dev-signed app + no backup must refuse, but the script exited 0: $(flat "$OUT")"
-elif [[ "$OUT" != *"no backup exists"* ]]; then
-  fail "GATE backup-refusal: aborted (exit $ST) but not with the no-backup message: $(flat "$OUT")"
-elif ! sentinel_intact "$R"; then
-  fail "GATE backup-refusal: it refused, but the only remaining copy of the bundle was overwritten anyway"
-else
-  pass "GATE backup-refusal: dev-signed app with no backup ⇒ refuse, with the last copy left intact"
-fi
+case_backup_refuse() {
+  local R; R=$(new_env)   # default authority is "Irrlicht Dev", and no backup dir is created
+  run_script "$R" -- replace full
+  if [[ $ST -eq 0 ]]; then
+    fail "GATE backup-refusal: dev-signed app + no backup must refuse, but the script exited 0: $(flat "$OUT")"
+  elif [[ "$OUT" != *"no backup exists"* ]]; then
+    fail "GATE backup-refusal: aborted (exit $ST) but not with the no-backup message: $(flat "$OUT")"
+  elif ! sentinel_intact "$R"; then
+    fail "GATE backup-refusal: it refused, but the only remaining copy of the bundle was overwritten anyway"
+  else
+    pass "GATE backup-refusal: dev-signed app with no backup ⇒ refuse, with the last copy left intact"
+  fi
+}
 
 # ─── GATE 4: build-output existence, checked before rm -rf'ing Sparkle ──────
-R=$(new_env)
-mkdir -p "$R/main/.build/irrlicht-prod-backup/Irrlicht.app"
-rm -f "$R/repo/platforms/macos/.build/arm64-apple-macosx/debug/Irrlicht"
-run_script "$R" -- replace full
-if [[ $ST -eq 0 ]]; then
-  fail "GATE build-output-exists: a missing build product must abort, but the script exited 0: $(flat "$OUT")"
-elif [[ "$OUT" != *"did not produce"* ]]; then
-  fail "GATE build-output-exists: aborted (exit $ST) but not with the missing-build-output message: $(flat "$OUT")"
-elif ! sparkle_intact "$R"; then
-  fail "GATE build-output-exists: it aborted, but Sparkle.framework was already deleted with nothing to replace it"
-else
-  pass "GATE build-output-exists: a missing build product ⇒ abort, with Sparkle.framework left in place"
-fi
+case_build_output() {
+  local R; R=$(new_env); with_backup "$R"
+  rm -f "$R/repo/platforms/macos/.build/arm64-apple-macosx/debug/Irrlicht"
+  run_script "$R" -- replace full
+  if [[ $ST -eq 0 ]]; then
+    fail "GATE build-output-exists: a missing build product must abort, but the script exited 0: $(flat "$OUT")"
+  elif [[ "$OUT" != *"did not produce"* ]]; then
+    fail "GATE build-output-exists: aborted (exit $ST) but not with the missing-build-output message: $(flat "$OUT")"
+  elif ! sparkle_intact "$R"; then
+    fail "GATE build-output-exists: it aborted, but Sparkle.framework was already deleted with nothing to replace it"
+  else
+    pass "GATE build-output-exists: a missing build product ⇒ abort, with Sparkle.framework left in place"
+  fi
+}
 
 # ─── GATE 5: MODE/TARGET validated against the literal enum, no default ─────
-R=$(new_env)
-# A backup exists, so a typo that slipped through would run to completion
-# rather than being stopped by a later gate — which is what makes "it exited 0"
-# below the honest description of the hazard.
-mkdir -p "$R/main/.build/irrlicht-prod-backup/Irrlicht.app"
-run_script "$R" -- seperate
-if [[ $ST -eq 0 ]]; then
-  fail "GATE enum-validation: the typo 'seperate' must be refused, but the script exited 0 and would have silently run in replace mode: $(flat "$OUT")"
-elif [[ "$OUT" != *"unrecognised argument"* ]]; then
-  fail "GATE enum-validation: refused (exit $ST) but not with the unrecognised-argument message: $(flat "$OUT")"
-else
-  pass "GATE enum-validation: an unrecognised axis value is refused instead of silently no-opping every step"
-fi
-# Vacuity guard: a validator that rejected EVERYTHING would satisfy the case
-# above while making the script unusable.
-R=$(new_env)
-run_script "$R" -- separate daemon
-if [[ "$OUT" == *"unrecognised argument"* ]]; then
-  fail "GATE enum-validation: the valid pair 'separate daemon' was rejected — the validator rejects everything: $(flat "$OUT")"
-elif [[ "$OUT" != *"MODE=separate TARGET=daemon"* ]]; then
-  fail "GATE enum-validation: 'separate daemon' did not resolve to MODE=separate TARGET=daemon: $(flat "$OUT")"
-else
-  pass "GATE enum-validation: ...and the valid spellings are still accepted, in either order"
-fi
+case_enum() {
+  local R; R=$(new_env)
+  # A backup exists, so a typo that slipped through would run to completion
+  # rather than being stopped by a later gate — which is what makes "it exited
+  # 0" below the honest description of the hazard.
+  with_backup "$R"
+  run_script "$R" -- seperate
+  if [[ $ST -eq 0 ]]; then
+    fail "GATE enum-validation: the typo 'seperate' must be refused, but the script exited 0 and would have silently run in replace mode: $(flat "$OUT")"
+  elif [[ "$OUT" != *"unrecognised argument"* ]]; then
+    fail "GATE enum-validation: refused (exit $ST) but not with the unrecognised-argument message: $(flat "$OUT")"
+  else
+    pass "GATE enum-validation: an unrecognised axis value is refused instead of silently no-opping every step"
+  fi
+  # Vacuity guard: a validator that rejected EVERYTHING would satisfy the case
+  # above while making the script unusable.
+  R=$(new_env)
+  run_script "$R" -- separate daemon
+  if [[ "$OUT" == *"unrecognised argument"* ]]; then
+    fail "GATE enum-validation: the valid pair 'separate daemon' was rejected — the validator rejects everything: $(flat "$OUT")"
+  elif [[ "$OUT" != *"MODE=separate TARGET=daemon"* ]]; then
+    fail "GATE enum-validation: 'separate daemon' did not resolve to MODE=separate TARGET=daemon: $(flat "$OUT")"
+  else
+    pass "GATE enum-validation: ...and the valid spellings are still accepted, in either order"
+  fi
+}
 
 # ─── GATE 6: the app is killed BEFORE the daemon ────────────────────────────
 # So a live app never observes a momentary daemon-less gap and reacts by
 # spawning its own replacement, which could win the port race against the
 # daemon the script starts next.
-R=$(new_env)
-mkdir -p "$R/main/.build/irrlicht-prod-backup/Irrlicht.app"
-run_script "$R" -- replace full
-APP_LINE=$(grep -nF -- 'pkill -f Irrlicht\.app/Contents/MacOS/Irrlicht' "$R/stub.log" 2>/dev/null | head -1 | cut -d: -f1)
-DMN_LINE=$(grep -nF -- 'pkill -x irrlichd' "$R/stub.log" 2>/dev/null | head -1 | cut -d: -f1)
-if [[ -z "$APP_LINE" || -z "$DMN_LINE" ]]; then
-  fail "GATE kill-order: COULD NOT LOOK — the app pkill (line '${APP_LINE:-none}') and/or the daemon pkill (line '${DMN_LINE:-none}') never happened, so their order proves nothing. Log: $(flat "$(cat "$R/stub.log")")"
-elif [[ "$APP_LINE" -ge "$DMN_LINE" ]]; then
-  fail "GATE kill-order: the daemon was killed at line $DMN_LINE, at or before the app at line $APP_LINE — a live app can observe the daemon-less gap and spawn its own replacement"
-else
-  pass "GATE kill-order: the app is killed (line $APP_LINE) before the daemon (line $DMN_LINE)"
-fi
+case_kill_order() {
+  local R APP_LINE DMN_LINE; R=$(new_env); with_backup "$R"
+  run_script "$R" -- replace full
+  APP_LINE=$(grep -nF -- 'pkill -f Irrlicht\.app/Contents/MacOS/Irrlicht' "$R/stub.log" 2>/dev/null | head -1 | cut -d: -f1)
+  DMN_LINE=$(grep -nF -- 'pkill -x irrlichd' "$R/stub.log" 2>/dev/null | head -1 | cut -d: -f1)
+  if [[ -z "$APP_LINE" || -z "$DMN_LINE" ]]; then
+    fail "GATE kill-order: COULD NOT LOOK — the app pkill (line '${APP_LINE:-none}') and/or the daemon pkill (line '${DMN_LINE:-none}') never happened, so their order proves nothing. Log: $(flat "$(cat "$R/stub.log")")"
+  elif [[ "$APP_LINE" -ge "$DMN_LINE" ]]; then
+    fail "GATE kill-order: the daemon was killed at line $DMN_LINE, at or before the app at line $APP_LINE — a live app can observe the daemon-less gap and spawn its own replacement"
+  else
+    pass "GATE kill-order: the app is killed (line $APP_LINE) before the daemon (line $DMN_LINE)"
+  fi
+}
 
 # ─── GATE 7 (ADDED by #1855): build freshness ───────────────────────────────
 # Existence is not freshness. A product left over from an earlier compile —
 # including one compiled while a tools/mutate.sh mutation was applied — is a
 # perfectly valid binary and passes GATE 4, so installing it means debugging a
 # defect the source does not have. That happened on this machine.
-R=$(new_env)
-mkdir -p "$R/main/.build/irrlicht-prod-backup/Irrlicht.app"
-touch -t 202601030101 "$R/repo/platforms/macos/Irrlicht/App.swift"   # source now NEWER than the product
-run_script "$R" -- replace full
-if [[ $ST -eq 0 ]]; then
-  fail "GATE build-freshness: a source newer than the build product must abort, but the script exited 0 and installed a stale binary: $(flat "$OUT")"
-elif [[ "$OUT" != *"NEWER than the built binary"* ]]; then
-  fail "GATE build-freshness: aborted (exit $ST) but not with the staleness message: $(flat "$OUT")"
-elif ! sentinel_intact "$R"; then
-  fail "GATE build-freshness: it aborted, but the stale binary was installed over the bundle anyway"
-else
-  pass "GATE build-freshness: a source newer than the build product ⇒ abort, with the bundle left untouched"
-fi
+case_freshness() {
+  local R; R=$(new_env); with_backup "$R"
+  touch -t 202601030101 "$R/repo/platforms/macos/Irrlicht/App.swift"   # source now NEWER than the product
+  run_script "$R" -- replace full
+  if [[ $ST -eq 0 ]]; then
+    fail "GATE build-freshness: a source newer than the build product must abort, but the script exited 0 and installed a stale binary: $(flat "$OUT")"
+  elif [[ "$OUT" != *"NEWER than the built binary"* ]]; then
+    fail "GATE build-freshness: aborted (exit $ST) but not with the staleness message: $(flat "$OUT")"
+  elif ! sentinel_intact "$R"; then
+    fail "GATE build-freshness: it aborted, but the stale binary was installed over the bundle anyway"
+  else
+    pass "GATE build-freshness: a source newer than the build product ⇒ abort, with the bundle left untouched"
+  fi
+}
+
 # ...and the freshness check must REFUSE when it cannot run, rather than pass
 # vacuously against an empty source set (AGENTS.md: absence of a finding and
 # inability to look must never produce the same output).
-R=$(new_env)
-mkdir -p "$R/main/.build/irrlicht-prod-backup/Irrlicht.app"
-find "$R/repo/platforms/macos/Irrlicht" -name '*.swift' -delete
-run_script "$R" -- replace full
-if [[ $ST -eq 0 ]]; then
-  fail "GATE build-freshness: with no .swift sources the check cannot run, but the script exited 0 — a vacuous pass: $(flat "$OUT")"
-elif [[ "$OUT" != *"no .swift sources found"* ]]; then
-  fail "GATE build-freshness: refused (exit $ST) but not with the cannot-run message: $(flat "$OUT")"
-else
-  pass "GATE build-freshness: ...and it REFUSES when it has nothing to compare against"
-fi
+case_freshness_vacuous() {
+  local R; R=$(new_env); with_backup "$R"
+  find "$R/repo/platforms/macos/Irrlicht" -name '*.swift' -delete
+  run_script "$R" -- replace full
+  if [[ $ST -eq 0 ]]; then
+    fail "GATE build-freshness: with no .swift sources the check cannot run, but the script exited 0 — a vacuous pass: $(flat "$OUT")"
+  elif [[ "$OUT" != *"no .swift sources found"* ]]; then
+    fail "GATE build-freshness: refused (exit $ST) but not with the cannot-run message: $(flat "$OUT")"
+  else
+    pass "GATE build-freshness: ...and it REFUSES when it has nothing to compare against"
+  fi
+}
 
 # ─── GATE 8 (ADDED by #1855): a failed swift build never reaches the bundle ─
 # The pre-script procedure ran `swift build 2>&1 | tail -5`, whose exit status
 # is tail's. A failed build reported success and the run continued into the
 # install with whatever binary happened to be lying around.
-R=$(new_env)
-mkdir -p "$R/main/.build/irrlicht-prod-backup/Irrlicht.app"
-run_script "$R" STUB_SWIFT_RC=1 -- replace full
-if [[ $ST -eq 0 ]]; then
-  fail "GATE swift-build-status: a failed swift build must abort, but the script exited 0 (its status came from the pipe, not from swift): $(flat "$OUT")"
-elif [[ "$OUT" != *"swift build failed"* ]]; then
-  fail "GATE swift-build-status: aborted (exit $ST) but not with the build-failed message: $(flat "$OUT")"
-elif ! sentinel_intact "$R"; then
-  fail "GATE swift-build-status: it aborted, but the bundle was overwritten anyway"
-else
-  pass "GATE swift-build-status: a failed swift build ⇒ abort, with the bundle left untouched"
-fi
+case_swift_status() {
+  local R; R=$(new_env); with_backup "$R"
+  run_script "$R" STUB_SWIFT_RC=1 -- replace full
+  if [[ $ST -eq 0 ]]; then
+    fail "GATE swift-build-status: a failed swift build must abort, but the script exited 0 (its status came from the pipe, not from swift): $(flat "$OUT")"
+  elif [[ "$OUT" != *"swift build failed"* ]]; then
+    fail "GATE swift-build-status: aborted (exit $ST) but not with the build-failed message: $(flat "$OUT")"
+  elif ! sentinel_intact "$R"; then
+    fail "GATE swift-build-status: it aborted, but the bundle was overwritten anyway"
+  else
+    pass "GATE swift-build-status: a failed swift build ⇒ abort, with the bundle left untouched"
+  fi
+}
 
-# ─── TARGET axis: daemon-only and macos-only skip the other component ───────
-R=$(new_env)
-mkdir -p "$R/main/.build/irrlicht-prod-backup/Irrlicht.app"
-run_script "$R" -- replace daemon
-if [[ $ST -ne 0 ]]; then
-  fail "TARGET=daemon completes — it exited $ST: $(flat "$OUT")"
-elif logged "$R" 'open '; then
-  fail "TARGET=daemon must not touch the app, but it launched one: $(flat "$(cat "$R/stub.log")")"
-elif ! sentinel_intact "$R"; then
-  fail "TARGET=daemon must not touch the app bundle, but the executable was overwritten"
-else
-  pass "TARGET=daemon rebuilds the daemon and leaves the app alone"
-fi
+# ─── The TARGET axis actually skips the component it names ──────────────────
+case_target_daemon() {
+  local R; R=$(new_env); with_backup "$R"
+  run_script "$R" -- replace daemon
+  if [[ $ST -ne 0 ]]; then
+    fail "TARGET=daemon completes — it exited $ST: $(flat "$OUT")"
+  elif logged "$R" 'open '; then
+    fail "TARGET=daemon must not touch the app, but it launched one: $(flat "$(cat "$R/stub.log")")"
+  elif ! sentinel_intact "$R"; then
+    fail "TARGET=daemon must not touch the app bundle, but the executable was overwritten"
+  else
+    pass "TARGET=daemon rebuilds the daemon and leaves the app alone"
+  fi
+}
 
-R=$(new_env)
-mkdir -p "$R/main/.build/irrlicht-prod-backup/Irrlicht.app"
-run_script "$R" -- replace macos   # no daemon started; one must already be reachable
-if [[ $ST -ne 0 ]]; then
-  fail "TARGET=macos completes against a reachable daemon — it exited $ST: $(flat "$OUT")"
-elif logged "$R" 'nohup '; then
-  fail "TARGET=macos must not start a daemon, but it did: $(flat "$(cat "$R/stub.log")")"
-else
-  pass "TARGET=macos relaunches the app without starting a daemon"
-fi
+case_target_macos() {
+  local R; R=$(new_env); with_backup "$R"
+  run_script "$R" -- replace macos   # no daemon started; one must already be reachable
+  if [[ $ST -ne 0 ]]; then
+    fail "TARGET=macos completes against a reachable daemon — it exited $ST: $(flat "$OUT")"
+  elif logged "$R" 'nohup '; then
+    fail "TARGET=macos must not start a daemon, but it did: $(flat "$(cat "$R/stub.log")")"
+  else
+    pass "TARGET=macos relaunches the app without starting a daemon"
+  fi
+}
 
-R=$(new_env)
-mkdir -p "$R/main/.build/irrlicht-prod-backup/Irrlicht.app"
-run_script "$R" STUB_CURL_RC=1 -- replace macos
-if [[ $ST -eq 0 ]]; then
-  fail "TARGET=macos with no reachable daemon must abort, but it exited 0: $(flat "$OUT")"
-elif [[ "$OUT" != *"doesn't start one"* ]]; then
-  fail "TARGET=macos aborted (exit $ST) but not with the no-daemon message: $(flat "$OUT")"
-elif logged "$R" 'open '; then
-  fail "TARGET=macos aborted, but launched the app anyway"
-else
-  pass "TARGET=macos with no reachable daemon ⇒ abort, and the app is never launched"
-fi
+case_target_macos_nodaemon() {
+  local R; R=$(new_env); with_backup "$R"
+  run_script "$R" STUB_CURL_RC=1 -- replace macos
+  if [[ $ST -eq 0 ]]; then
+    fail "TARGET=macos with no reachable daemon must abort, but it exited 0: $(flat "$OUT")"
+  elif [[ "$OUT" != *"doesn't start one"* ]]; then
+    fail "TARGET=macos aborted (exit $ST) but not with the no-daemon message: $(flat "$OUT")"
+  elif logged "$R" 'open '; then
+    fail "TARGET=macos aborted, but launched the app anyway"
+  else
+    pass "TARGET=macos with no reachable daemon ⇒ abort, and the app is never launched"
+  fi
+}
 
-# ─── The gate that runs this file must actually fire on this file's SUBJECT ──
+# ─── The gate that runs this file must fire on this file's SUBJECT ──────────
 # tools/preflight.sh --changed scopes the `tools` gate by a trigger regex. The
 # script under test lives outside tools/, so without an explicit alternative a
 # push that changes ONLY that script skips this whole file — and a gate that
 # never ran is indistinguishable from one that found nothing.
-PF=tools/preflight.sh
-tools_re=$(grep -a "run_gate_scoped '\^tools/lib/" "$PF" \
-           | sed -E "s/^[[:space:]]*run_gate_scoped '//; s/'[[:space:]]*\\\\?[[:space:]]*$//")
-if [[ -z "$tools_re" ]]; then
-  fail "preflight-trigger: COULD NOT LOOK — no run_gate_scoped line starting ^tools/lib/ in $PF; the scan has gone blind, not the trigger wrong"
-else
-  probe_fails=0
+case_preflight_trigger() {
+  local PF=tools/preflight.sh tools_re probe probe_fails=0
+  tools_re=$(grep -a "run_gate_scoped '\^tools/lib/" "$PF" \
+             | sed -E "s/^[[:space:]]*run_gate_scoped '//; s/'[[:space:]]*\\\\?[[:space:]]*$//")
+  if [[ -z "$tools_re" ]]; then
+    fail "preflight-trigger: COULD NOT LOOK — no run_gate_scoped line starting ^tools/lib/ in $PF; the scan has gone blind, not the trigger wrong"
+    return
+  fi
   for probe in "$SCRIPT" ".claude/skills/ir:test-mac/restore-prod.sh" "tools/lib/$NAME.sh"; do
     if ! printf '%s\n' "$probe" | grep -qE "$tools_re"; then
       fail "preflight-trigger: the tools gate does NOT fire on a diff touching $probe — this file would be skipped on the very push that changes its subject. Regex: $tools_re"
@@ -441,12 +477,34 @@ else
   elif [[ $probe_fails -eq 0 ]]; then
     pass "preflight-trigger: the tools gate fires on the script, its teardown half and this test, and still scopes"
   fi
+}
+
+# ─── dispatch ───────────────────────────────────────────────────────────────
+CASES=(happy reachability app-exit backup-refresh backup-refuse build-output
+       enum kill-order freshness freshness-vacuous swift-status
+       target-daemon target-macos target-macos-nodaemon preflight-trigger)
+
+echo "== $NAME: $SCRIPT${CASE_FILTER:+ (case: $CASE_FILTER)} =="
+
+ran=0
+for c in "${CASES[@]}"; do
+  [[ -n "$CASE_FILTER" && "$CASE_FILTER" != "$c" ]] && continue
+  "case_${c//-/_}"
+  ran=$((ran + 1))
+done
+
+# A filter that matches nothing must NEVER read as a clean run: a typo in a
+# mutation fixture's case name would otherwise produce an "ALL PASS" over zero
+# assertions, which is the exact shape AGENTS.md forbids.
+if [[ $ran -eq 0 ]]; then
+  echo "FAIL: $NAME — case filter '$CASE_FILTER' matched none of: ${CASES[*]}. Nothing was checked." >&2
+  exit 2
 fi
 
 echo
 if [[ $fails -eq 0 ]]; then
-  echo "$NAME: ALL PASS"
+  echo "$NAME: ALL PASS ($ran case(s))"
   exit 0
 fi
-echo "$NAME: $fails FAILED" >&2
+echo "$NAME: $fails FAILED ($ran case(s))" >&2
 exit 1

--- a/tools/lib/test-mac-script_test.sh
+++ b/tools/lib/test-mac-script_test.sh
@@ -1,0 +1,452 @@
+#!/usr/bin/env bash
+# test-mac-script_test.sh — the LOCK TEST for the gates in
+# .claude/skills/ir:test-mac/test-mac.sh (#1855).
+#
+# WHAT THIS IS. #1855 turned nine fenced bash blocks in that skill's SKILL.md
+# into one script. Six gates were MOVED across in that extraction and one was
+# added; each has an incident behind it and several fail SILENTLY when broken,
+# which is exactly why an extraction is where they get lost. This file drives
+# the real script end to end and asserts each gate still holds.
+# tools/lib/test-mac-script-mutations_test.sh then breaks each gate in turn
+# and requires THIS file to go red — a green that was never red is a claim,
+# not evidence (AGENTS.md, Testing).
+#
+# SAFETY. The script under test kills processes and overwrites
+# /Applications/Irrlicht.app. Four things keep it off this machine, and every
+# one of them is load-bearing:
+#   1. IRRLICHT_TESTMAC_PROD_APP / _DEV_APP / _MAIN_REPO / _REPO_ROOT /
+#      _LOG_DIR / _PLISTBUDDY redirect every path it touches into a mktemp -d.
+#   2. HOME is that temp dir too, so the replace-mode socket path under
+#      ~/.local/share/irrlicht/ resolves inside the fixture.
+#   3. PATH is fronted by stubs for pkill/pgrep/lsof/curl/open/nohup/codesign/
+#      security/install_name_tool/go/swift, so nothing can reach a real
+#      process, port or signing identity.
+#   4. `env -i` means nothing leaks in from this shell.
+# A case that skips any of the four can destroy the machine it runs on. Build
+# every environment through new_env().
+#
+# `sleep` is stubbed too — not for safety but so the script's real polling
+# loops (5 iterations for the app-exit wait, 8 for the daemon readiness gate)
+# run at full fidelity in zero time. The loops are the thing under test; their
+# wall-clock cost is not.
+#
+# Convention follows tools/lib/install-uninstall_test.sh and
+# tools/lib/agents-md-lint_test.sh: plain bash, `set -uo pipefail` (never -e —
+# a non-zero status from the subject is DATA here, half the cases expect one),
+# a `fails` counter, and "ALL PASS" / "N FAILED" at the end. FAIL lines start
+# at column 0 because tools/lib/mutation-assert.sh greps `^FAIL:` to decide
+# whether a mutation went red.
+set -uo pipefail
+
+NAME=test-mac-script_test
+REPO_ROOT=$(git rev-parse --show-toplevel) || { echo "FAIL: $NAME — not inside a git repo" >&2; exit 2; }
+cd "$REPO_ROOT" || { echo "FAIL: $NAME — cannot cd to $REPO_ROOT" >&2; exit 2; }
+
+SCRIPT=".claude/skills/ir:test-mac/test-mac.sh"
+
+# A missing tool is a hard REFUSAL (exit 2), never a skip: exiting 0 here would
+# read as a PASS to shell-lib-suite.sh, so the gate would go green having
+# asserted nothing.
+need() { command -v "$1" >/dev/null 2>&1 || { echo "FAIL: $NAME — $1 not found, so nothing below could be checked" >&2; exit 2; }; }
+need bash; need mktemp; need grep; need sed; need touch; need find; need chmod
+
+if [[ ! -x "$REPO_ROOT/$SCRIPT" ]]; then
+  echo "FAIL: $NAME — $SCRIPT is missing or not executable; the whole corpus is unreachable" >&2
+  exit 2
+fi
+
+# The isolation seams are what keep every case below off the real machine. If
+# the script stops honouring them, this file would silently start driving the
+# real /Applications/Irrlicht.app — so refuse to run rather than find out.
+for seam in IRRLICHT_TESTMAC_REPO_ROOT IRRLICHT_TESTMAC_MAIN_REPO IRRLICHT_TESTMAC_PROD_APP \
+            IRRLICHT_TESTMAC_DEV_APP IRRLICHT_TESTMAC_LOG_DIR IRRLICHT_TESTMAC_PLISTBUDDY; do
+  if ! grep -q "$seam" "$REPO_ROOT/$SCRIPT"; then
+    echo "FAIL: $NAME — REFUSING TO RUN: $SCRIPT no longer honours \$$seam." >&2
+    echo "      Without it this test drives the real production app and daemon." >&2
+    exit 2
+  fi
+done
+
+fails=0
+pass() { echo "  PASS: $1"; }
+fail() { echo "FAIL: $1"; fails=$((fails + 1)); }
+
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/test-mac-script.XXXXXX")" || exit 2
+trap 'rm -rf "$WORK"' EXIT
+
+# new_env — build one hermetic fixture. Echoes its root.
+#
+# The root comes from `mktemp -d` rather than an incrementing counter because
+# every caller is `R=$(new_env)` — a COMMAND SUBSTITUTION, so a counter
+# incremented here lives in a subshell and never reaches the next call. Two
+# cases would then share one directory, and a backup dir created by one would
+# silently satisfy the next one's refusal gate. (Measured: that is exactly what
+# the counter version did, and the backup-refusal case caught it.)
+#
+# The bundle's executable and Sparkle.framework carry a "PRODUCTION" sentinel:
+# every abort case below asserts the sentinel SURVIVED, which is what proves
+# the gate fired BEFORE the destructive write rather than merely printing
+# something on the way past it.
+new_env() {
+  local root
+  root="$(mktemp -d "$WORK/env.XXXXXX")" || return 1
+  mkdir -p "$root/home" "$root/bin" "$root/logs"
+
+  # --- the worktree the script builds from ---
+  mkdir -p "$root/repo/core/cmd/irrlichd"
+  mkdir -p "$root/repo/platforms/macos/Irrlicht/Resources"
+  mkdir -p "$root/repo/platforms/macos/.build/arm64-apple-macosx/debug/Sparkle.framework"
+  echo 'import Foundation' > "$root/repo/platforms/macos/Irrlicht/App.swift"
+  echo 'icns'              > "$root/repo/platforms/macos/Irrlicht/Resources/AppIcon.icns"
+  echo '<plist/>'          > "$root/repo/platforms/macos/Irrlicht/Resources/Irrlicht-dev.entitlements"
+  echo 'FRESH-BUILD'       > "$root/repo/platforms/macos/.build/arm64-apple-macosx/debug/Irrlicht"
+  echo 'sparkle'           > "$root/repo/platforms/macos/.build/arm64-apple-macosx/debug/Sparkle.framework/marker"
+  chmod +x "$root/repo/platforms/macos/.build/arm64-apple-macosx/debug/Irrlicht"
+  # Explicit timestamps, not sleeps: sources OLDER than the build product, so
+  # the freshness gate passes by default and a case that wants it to fire says
+  # so by touching one source forward.
+  touch -t 202601010101 "$root/repo/platforms/macos/Irrlicht/App.swift"
+  touch -t 202601020101 "$root/repo/platforms/macos/.build/arm64-apple-macosx/debug/Irrlicht"
+
+  # --- the stable main checkout (daemon binary + production backup live here) ---
+  mkdir -p "$root/main/core/bin" "$root/main/.build"
+
+  # --- the "installed" production bundle ---
+  local app="$root/Applications/Irrlicht.app"
+  mkdir -p "$app/Contents/MacOS" "$app/Contents/Frameworks/Sparkle.framework" "$app/Contents/Resources"
+  echo 'PRODUCTION' > "$app/Contents/MacOS/Irrlicht"
+  echo 'PRODUCTION' > "$app/Contents/Frameworks/Sparkle.framework/marker"
+  echo 'PRODUCTION' > "$app/Contents/Resources/AppIcon.icns"
+  echo '<plist/>'   > "$app/Contents/Info.plist"
+
+  # --- stubs ---
+  local b="$root/bin"
+  # Recording stubs: an assertion can prove a call ACTUALLY HAPPENED (and in
+  # what order) rather than that the script merely exited without complaining.
+  local s
+  for s in pkill open nohup install_name_tool; do
+    printf '#!/bin/sh\nprintf "%%s %%s\\n" "%s" "$*" >>"$STUB_LOG"\nexit 0\n' "$s" > "$b/$s"
+  done
+  # pgrep: exit 1 = "no such process" (the app died). STUB_PGREP_RC=0 makes it
+  # immortal, which is what the app-exit gate is for.
+  printf '#!/bin/sh\nprintf "pgrep %%s\\n" "$*" >>"$STUB_LOG"\nexit "${STUB_PGREP_RC:-1}"\n' > "$b/pgrep"
+  # lsof: nothing listening, nothing to kill.
+  printf '#!/bin/sh\nexit 1\n' > "$b/lsof"
+  # curl: STUB_CURL_RC=1 = the daemon never answers /state.
+  printf '#!/bin/sh\nprintf "curl %%s\\n" "$*" >>"$STUB_LOG"\nexit "${STUB_CURL_RC:-0}"\n' > "$b/curl"
+  # go / swift: compile nothing. STUB_SWIFT_RC=1 = a failed swift build.
+  printf '#!/bin/sh\nprintf "go %%s\\n" "$*" >>"$STUB_LOG"\nexit 0\n' > "$b/go"
+  printf '#!/bin/sh\nprintf "swift %%s\\n" "$*" >>"$STUB_LOG"\necho "stub swift build"\nexit "${STUB_SWIFT_RC:-0}"\n' > "$b/swift"
+  # codesign: `-dv` reports the authority under test; anything else is a real
+  # signing call and just succeeds.
+  cat > "$b/codesign" <<'STUB'
+#!/bin/sh
+printf 'codesign %s\n' "$*" >>"$STUB_LOG"
+case "$1" in
+  -dv) printf '%s\n' "${STUB_CODESIGN_AUTHORITY:-Authority=Irrlicht Dev}" >&2 ;;
+esac
+exit 0
+STUB
+  # security: no "Irrlicht Dev" identity, so the ad-hoc signing branch is taken.
+  printf '#!/bin/sh\nexit 0\n' > "$b/security"
+  # sleep: instant, so the real polling loops run at full fidelity in no time.
+  printf '#!/bin/sh\nexit 0\n' > "$b/sleep"
+  # PlistBuddy is reached by absolute path, so it gets a seam of its own.
+  printf '#!/bin/sh\nprintf "plistbuddy %%s\\n" "$*" >>"$STUB_LOG"\nexit 0\n' > "$root/plistbuddy"
+  chmod +x "$b"/* "$root/plistbuddy"
+
+  : > "$root/stub.log"
+  echo "$root"
+}
+
+# run_script <root> [VAR=VAL ...] -- [script args...]
+# Sets OUT and ST. Never aborts: a non-zero status is the expected outcome of
+# half the cases here.
+run_script() {
+  local root="$1"; shift
+  local extra=()
+  while [[ $# -gt 0 && "$1" != "--" ]]; do extra+=("$1"); shift; done
+  [[ "${1:-}" == "--" ]] && shift
+  OUT=$(env -i \
+    HOME="$root/home" \
+    PATH="$root/bin:/usr/bin:/bin:/usr/sbin:/sbin" \
+    STUB_LOG="$root/stub.log" \
+    IRRLICHT_TESTMAC_REPO_ROOT="$root/repo" \
+    IRRLICHT_TESTMAC_MAIN_REPO="$root/main" \
+    IRRLICHT_TESTMAC_PROD_APP="$root/Applications/Irrlicht.app" \
+    IRRLICHT_TESTMAC_DEV_APP="$root/IrrlichtDev.app" \
+    IRRLICHT_TESTMAC_LOG_DIR="$root/logs" \
+    IRRLICHT_TESTMAC_PLISTBUDDY="$root/plistbuddy" \
+    ${extra[@]+"${extra[@]}"} \
+    bash "$REPO_ROOT/$SCRIPT" "$@" 2>&1)
+  ST=$?
+  return 0
+}
+
+flat() { printf '%s' "$1" | tr '\n' ' '; }
+sentinel_intact() { [[ "$(cat "$1/Applications/Irrlicht.app/Contents/MacOS/Irrlicht" 2>/dev/null)" == PRODUCTION ]]; }
+sparkle_intact()  { [[ "$(cat "$1/Applications/Irrlicht.app/Contents/Frameworks/Sparkle.framework/marker" 2>/dev/null)" == PRODUCTION ]]; }
+logged()          { grep -qF -- "$2" "$1/stub.log" 2>/dev/null; }
+
+echo "== $NAME: $SCRIPT =="
+
+# ─── 0. The happy path runs clean — the vacuity guard for everything below ──
+# Without this, every abort case could be passing because the fixture is
+# broken rather than because a gate fired.
+R=$(new_env)
+mkdir -p "$R/main/.build/irrlicht-prod-backup/Irrlicht.app"   # dev-signed + a backup ⇒ the refusal below does not fire
+run_script "$R" -- replace full
+if [[ $ST -ne 0 ]]; then
+  fail "the happy path (replace full) completes — it exited $ST, so every abort case below proves nothing: $(flat "$OUT")"
+else
+  pass "the happy path (replace full) completes"
+  if logged "$R" 'open '; then pass "...and the app was launched"; else
+    fail "the happy path launches the app — no 'open' call was recorded: $(flat "$OUT")"; fi
+  if [[ "$(cat "$R/Applications/Irrlicht.app/Contents/MacOS/Irrlicht")" == FRESH-BUILD ]]; then
+    pass "...and the dev build really was installed over the bundle"
+  else
+    fail "the happy path installs the dev build — the bundle executable was not replaced"
+  fi
+fi
+
+# ─── GATE 1: daemon reachability, before the app is launched ────────────────
+# If the app starts while no --record daemon answers on 7837, it runs
+# `pkill -x irrlichd` and respawns one WITHOUT --record, silently defeating the
+# whole run. A gate, not a courtesy sleep.
+R=$(new_env)
+mkdir -p "$R/main/.build/irrlicht-prod-backup/Irrlicht.app"
+run_script "$R" STUB_CURL_RC=1 -- replace full
+if [[ $ST -eq 0 ]]; then
+  fail "GATE daemon-reachability: an unreachable daemon must abort, but the script exited 0: $(flat "$OUT")"
+elif [[ "$OUT" != *"never became reachable"* ]]; then
+  fail "GATE daemon-reachability: aborted (exit $ST) but not with the reachability message: $(flat "$OUT")"
+elif logged "$R" 'open '; then
+  fail "GATE daemon-reachability: it aborted, but the app was launched anyway — the app would pkill our daemon and respawn one without --record"
+else
+  pass "GATE daemon-reachability: no reachable daemon ⇒ abort, and the app is never launched"
+fi
+
+# ─── GATE 2: wait for the app to exit before overwriting its bundle ─────────
+R=$(new_env)
+mkdir -p "$R/main/.build/irrlicht-prod-backup/Irrlicht.app"
+run_script "$R" STUB_PGREP_RC=0 -- replace full
+if [[ $ST -eq 0 ]]; then
+  fail "GATE app-exit-wait: a still-running app must abort, but the script exited 0: $(flat "$OUT")"
+elif [[ "$OUT" != *"still running"* ]]; then
+  fail "GATE app-exit-wait: aborted (exit $ST) but not with the still-running message: $(flat "$OUT")"
+elif ! sentinel_intact "$R"; then
+  fail "GATE app-exit-wait: it aborted, but the bundle executable was overwritten while the process was still alive"
+else
+  pass "GATE app-exit-wait: a live app process ⇒ abort, and its bundle is left untouched"
+fi
+
+# ─── GATE 3a: backup freshness — refresh a Developer-ID-signed original ─────
+# Never trust an existing backup blindly: it can predate a newer production
+# release installed since, which would make restore-prod.sh silently reinstall
+# a stale build.
+R=$(new_env)
+mkdir -p "$R/main/.build/irrlicht-prod-backup/Irrlicht.app/Contents/MacOS"
+echo 'STALE-BACKUP' > "$R/main/.build/irrlicht-prod-backup/Irrlicht.app/Contents/MacOS/Irrlicht"
+run_script "$R" STUB_CODESIGN_AUTHORITY="Authority=Developer ID Application: Ingo" -- replace full
+BACKED="$(cat "$R/main/.build/irrlicht-prod-backup/Irrlicht.app/Contents/MacOS/Irrlicht" 2>/dev/null)"
+if [[ $ST -ne 0 ]]; then
+  fail "GATE backup-freshness: a Developer-ID-signed app must be backed up and installed over, but it exited $ST: $(flat "$OUT")"
+elif [[ "$BACKED" != PRODUCTION ]]; then
+  fail "GATE backup-freshness: the stale backup was NOT refreshed from the untouched original (backup holds '$BACKED', wanted PRODUCTION) — restore-prod.sh would reinstall a stale build"
+else
+  pass "GATE backup-freshness: a Developer-ID-signed original refreshes the backup before being overwritten"
+fi
+
+# ─── GATE 3b: backup freshness — refuse dev-signed with NO backup ───────────
+R=$(new_env)   # default authority is "Irrlicht Dev", and no backup dir is created
+run_script "$R" -- replace full
+if [[ $ST -eq 0 ]]; then
+  fail "GATE backup-refusal: dev-signed app + no backup must refuse, but the script exited 0: $(flat "$OUT")"
+elif [[ "$OUT" != *"no backup exists"* ]]; then
+  fail "GATE backup-refusal: aborted (exit $ST) but not with the no-backup message: $(flat "$OUT")"
+elif ! sentinel_intact "$R"; then
+  fail "GATE backup-refusal: it refused, but the only remaining copy of the bundle was overwritten anyway"
+else
+  pass "GATE backup-refusal: dev-signed app with no backup ⇒ refuse, with the last copy left intact"
+fi
+
+# ─── GATE 4: build-output existence, checked before rm -rf'ing Sparkle ──────
+R=$(new_env)
+mkdir -p "$R/main/.build/irrlicht-prod-backup/Irrlicht.app"
+rm -f "$R/repo/platforms/macos/.build/arm64-apple-macosx/debug/Irrlicht"
+run_script "$R" -- replace full
+if [[ $ST -eq 0 ]]; then
+  fail "GATE build-output-exists: a missing build product must abort, but the script exited 0: $(flat "$OUT")"
+elif [[ "$OUT" != *"did not produce"* ]]; then
+  fail "GATE build-output-exists: aborted (exit $ST) but not with the missing-build-output message: $(flat "$OUT")"
+elif ! sparkle_intact "$R"; then
+  fail "GATE build-output-exists: it aborted, but Sparkle.framework was already deleted with nothing to replace it"
+else
+  pass "GATE build-output-exists: a missing build product ⇒ abort, with Sparkle.framework left in place"
+fi
+
+# ─── GATE 5: MODE/TARGET validated against the literal enum, no default ─────
+R=$(new_env)
+# A backup exists, so a typo that slipped through would run to completion
+# rather than being stopped by a later gate — which is what makes "it exited 0"
+# below the honest description of the hazard.
+mkdir -p "$R/main/.build/irrlicht-prod-backup/Irrlicht.app"
+run_script "$R" -- seperate
+if [[ $ST -eq 0 ]]; then
+  fail "GATE enum-validation: the typo 'seperate' must be refused, but the script exited 0 and would have silently run in replace mode: $(flat "$OUT")"
+elif [[ "$OUT" != *"unrecognised argument"* ]]; then
+  fail "GATE enum-validation: refused (exit $ST) but not with the unrecognised-argument message: $(flat "$OUT")"
+else
+  pass "GATE enum-validation: an unrecognised axis value is refused instead of silently no-opping every step"
+fi
+# Vacuity guard: a validator that rejected EVERYTHING would satisfy the case
+# above while making the script unusable.
+R=$(new_env)
+run_script "$R" -- separate daemon
+if [[ "$OUT" == *"unrecognised argument"* ]]; then
+  fail "GATE enum-validation: the valid pair 'separate daemon' was rejected — the validator rejects everything: $(flat "$OUT")"
+elif [[ "$OUT" != *"MODE=separate TARGET=daemon"* ]]; then
+  fail "GATE enum-validation: 'separate daemon' did not resolve to MODE=separate TARGET=daemon: $(flat "$OUT")"
+else
+  pass "GATE enum-validation: ...and the valid spellings are still accepted, in either order"
+fi
+
+# ─── GATE 6: the app is killed BEFORE the daemon ────────────────────────────
+# So a live app never observes a momentary daemon-less gap and reacts by
+# spawning its own replacement, which could win the port race against the
+# daemon the script starts next.
+R=$(new_env)
+mkdir -p "$R/main/.build/irrlicht-prod-backup/Irrlicht.app"
+run_script "$R" -- replace full
+APP_LINE=$(grep -nF -- 'pkill -f Irrlicht\.app/Contents/MacOS/Irrlicht' "$R/stub.log" 2>/dev/null | head -1 | cut -d: -f1)
+DMN_LINE=$(grep -nF -- 'pkill -x irrlichd' "$R/stub.log" 2>/dev/null | head -1 | cut -d: -f1)
+if [[ -z "$APP_LINE" || -z "$DMN_LINE" ]]; then
+  fail "GATE kill-order: COULD NOT LOOK — the app pkill (line '${APP_LINE:-none}') and/or the daemon pkill (line '${DMN_LINE:-none}') never happened, so their order proves nothing. Log: $(flat "$(cat "$R/stub.log")")"
+elif [[ "$APP_LINE" -ge "$DMN_LINE" ]]; then
+  fail "GATE kill-order: the daemon was killed at line $DMN_LINE, at or before the app at line $APP_LINE — a live app can observe the daemon-less gap and spawn its own replacement"
+else
+  pass "GATE kill-order: the app is killed (line $APP_LINE) before the daemon (line $DMN_LINE)"
+fi
+
+# ─── GATE 7 (ADDED by #1855): build freshness ───────────────────────────────
+# Existence is not freshness. A product left over from an earlier compile —
+# including one compiled while a tools/mutate.sh mutation was applied — is a
+# perfectly valid binary and passes GATE 4, so installing it means debugging a
+# defect the source does not have. That happened on this machine.
+R=$(new_env)
+mkdir -p "$R/main/.build/irrlicht-prod-backup/Irrlicht.app"
+touch -t 202601030101 "$R/repo/platforms/macos/Irrlicht/App.swift"   # source now NEWER than the product
+run_script "$R" -- replace full
+if [[ $ST -eq 0 ]]; then
+  fail "GATE build-freshness: a source newer than the build product must abort, but the script exited 0 and installed a stale binary: $(flat "$OUT")"
+elif [[ "$OUT" != *"NEWER than the built binary"* ]]; then
+  fail "GATE build-freshness: aborted (exit $ST) but not with the staleness message: $(flat "$OUT")"
+elif ! sentinel_intact "$R"; then
+  fail "GATE build-freshness: it aborted, but the stale binary was installed over the bundle anyway"
+else
+  pass "GATE build-freshness: a source newer than the build product ⇒ abort, with the bundle left untouched"
+fi
+# ...and the freshness check must REFUSE when it cannot run, rather than pass
+# vacuously against an empty source set (AGENTS.md: absence of a finding and
+# inability to look must never produce the same output).
+R=$(new_env)
+mkdir -p "$R/main/.build/irrlicht-prod-backup/Irrlicht.app"
+find "$R/repo/platforms/macos/Irrlicht" -name '*.swift' -delete
+run_script "$R" -- replace full
+if [[ $ST -eq 0 ]]; then
+  fail "GATE build-freshness: with no .swift sources the check cannot run, but the script exited 0 — a vacuous pass: $(flat "$OUT")"
+elif [[ "$OUT" != *"no .swift sources found"* ]]; then
+  fail "GATE build-freshness: refused (exit $ST) but not with the cannot-run message: $(flat "$OUT")"
+else
+  pass "GATE build-freshness: ...and it REFUSES when it has nothing to compare against"
+fi
+
+# ─── GATE 8 (ADDED by #1855): a failed swift build never reaches the bundle ─
+# The pre-script procedure ran `swift build 2>&1 | tail -5`, whose exit status
+# is tail's. A failed build reported success and the run continued into the
+# install with whatever binary happened to be lying around.
+R=$(new_env)
+mkdir -p "$R/main/.build/irrlicht-prod-backup/Irrlicht.app"
+run_script "$R" STUB_SWIFT_RC=1 -- replace full
+if [[ $ST -eq 0 ]]; then
+  fail "GATE swift-build-status: a failed swift build must abort, but the script exited 0 (its status came from the pipe, not from swift): $(flat "$OUT")"
+elif [[ "$OUT" != *"swift build failed"* ]]; then
+  fail "GATE swift-build-status: aborted (exit $ST) but not with the build-failed message: $(flat "$OUT")"
+elif ! sentinel_intact "$R"; then
+  fail "GATE swift-build-status: it aborted, but the bundle was overwritten anyway"
+else
+  pass "GATE swift-build-status: a failed swift build ⇒ abort, with the bundle left untouched"
+fi
+
+# ─── TARGET axis: daemon-only and macos-only skip the other component ───────
+R=$(new_env)
+mkdir -p "$R/main/.build/irrlicht-prod-backup/Irrlicht.app"
+run_script "$R" -- replace daemon
+if [[ $ST -ne 0 ]]; then
+  fail "TARGET=daemon completes — it exited $ST: $(flat "$OUT")"
+elif logged "$R" 'open '; then
+  fail "TARGET=daemon must not touch the app, but it launched one: $(flat "$(cat "$R/stub.log")")"
+elif ! sentinel_intact "$R"; then
+  fail "TARGET=daemon must not touch the app bundle, but the executable was overwritten"
+else
+  pass "TARGET=daemon rebuilds the daemon and leaves the app alone"
+fi
+
+R=$(new_env)
+mkdir -p "$R/main/.build/irrlicht-prod-backup/Irrlicht.app"
+run_script "$R" -- replace macos   # no daemon started; one must already be reachable
+if [[ $ST -ne 0 ]]; then
+  fail "TARGET=macos completes against a reachable daemon — it exited $ST: $(flat "$OUT")"
+elif logged "$R" 'nohup '; then
+  fail "TARGET=macos must not start a daemon, but it did: $(flat "$(cat "$R/stub.log")")"
+else
+  pass "TARGET=macos relaunches the app without starting a daemon"
+fi
+
+R=$(new_env)
+mkdir -p "$R/main/.build/irrlicht-prod-backup/Irrlicht.app"
+run_script "$R" STUB_CURL_RC=1 -- replace macos
+if [[ $ST -eq 0 ]]; then
+  fail "TARGET=macos with no reachable daemon must abort, but it exited 0: $(flat "$OUT")"
+elif [[ "$OUT" != *"doesn't start one"* ]]; then
+  fail "TARGET=macos aborted (exit $ST) but not with the no-daemon message: $(flat "$OUT")"
+elif logged "$R" 'open '; then
+  fail "TARGET=macos aborted, but launched the app anyway"
+else
+  pass "TARGET=macos with no reachable daemon ⇒ abort, and the app is never launched"
+fi
+
+# ─── The gate that runs this file must actually fire on this file's SUBJECT ──
+# tools/preflight.sh --changed scopes the `tools` gate by a trigger regex. The
+# script under test lives outside tools/, so without an explicit alternative a
+# push that changes ONLY that script skips this whole file — and a gate that
+# never ran is indistinguishable from one that found nothing.
+PF=tools/preflight.sh
+tools_re=$(grep -a "run_gate_scoped '\^tools/lib/" "$PF" \
+           | sed -E "s/^[[:space:]]*run_gate_scoped '//; s/'[[:space:]]*\\\\?[[:space:]]*$//")
+if [[ -z "$tools_re" ]]; then
+  fail "preflight-trigger: COULD NOT LOOK — no run_gate_scoped line starting ^tools/lib/ in $PF; the scan has gone blind, not the trigger wrong"
+else
+  probe_fails=0
+  for probe in "$SCRIPT" ".claude/skills/ir:test-mac/restore-prod.sh" "tools/lib/$NAME.sh"; do
+    if ! printf '%s\n' "$probe" | grep -qE "$tools_re"; then
+      fail "preflight-trigger: the tools gate does NOT fire on a diff touching $probe — this file would be skipped on the very push that changes its subject. Regex: $tools_re"
+      probe_fails=1
+    fi
+  done
+  # Vacuity guard: a trigger matching everything would satisfy every probe
+  # above while scoping nothing.
+  if printf '%s\n' core/domain/session.go | grep -qE "$tools_re"; then
+    fail "preflight-trigger: the tools-gate regex matches core/domain/session.go too — it has stopped scoping: $tools_re"
+  elif [[ $probe_fails -eq 0 ]]; then
+    pass "preflight-trigger: the tools gate fires on the script, its teardown half and this test, and still scopes"
+  fi
+fi
+
+echo
+if [[ $fails -eq 0 ]]; then
+  echo "$NAME: ALL PASS"
+  exit 0
+fi
+echo "$NAME: $fails FAILED" >&2
+exit 1

--- a/tools/preflight.sh
+++ b/tools/preflight.sh
@@ -568,7 +568,14 @@ if want tools; then
   # import, so a session pays for every line whether or not the task at hand
   # needs it), and a commit editing only AGENTS.md is exactly the one that
   # would otherwise regrow it past that budget unnoticed under `--changed`.
-  run_gate_scoped '^tools/lib/|^tools/[^/]*\.sh$|^tools/git-hooks/|^go\.work$|^\.github/dependabot\.yml$|^site/install\.sh$|^AGENTS\.md$|^\.github/workflows/(ars|codescene-badge|coverage|macos-swift|replaydata-deletion-guard|test)\.yml$' \
+  # .claude/skills/ir:test-mac/ joins the trigger for an eighth reason (#1855):
+  # test-mac-script_test.sh DRIVES test-mac.sh end to end against stubs, and
+  # test-mac-script-mutations_test.sh breaks each of its gates in turn — gates
+  # whose whole failure mode is silence (a daemon started without --record, a
+  # backup that was never refreshed, a bundle overwritten while its process was
+  # still alive). Same story, eighth entry: a commit editing only that script,
+  # or only restore-prod.sh beside it, is exactly the one that breaks them.
+  run_gate_scoped '^tools/lib/|^tools/[^/]*\.sh$|^tools/git-hooks/|^go\.work$|^\.github/dependabot\.yml$|^site/install\.sh$|^AGENTS\.md$|^\.claude/skills/ir:test-mac/|^\.github/workflows/(ars|codescene-badge|coverage|macos-swift|replaydata-deletion-guard|test)\.yml$' \
                   "tools/lib shell-lib tests" shell_lib_tests
 
   # UNSCOPED, deliberately, and the only gate in this group that is (#1804).


### PR DESCRIPTION
Closes #1855

## What

`.claude/skills/ir:test-mac/SKILL.md` was **464 lines with nine fenced bash
blocks** an agent copied out and ran one at a time. The whole procedure is now
one executable script covering both axes, and the skill is a pointer.

| | before | after |
|---|---|---|
| `SKILL.md` | 464 lines | **140 lines** |
| fenced `bash` blocks in `SKILL.md` | 9 (the procedure) | 2 (how to invoke the script; how to invoke the teardown) |
| the procedure | prose | `.claude/skills/ir:test-mac/test-mac.sh` (422 lines) |

```
.claude/skills/ir:test-mac/test-mac.sh [MODE] [TARGET]     # defaults: replace full
```

Both arguments are optional and order-independent. The bug this removes is the
one `SKILL.md` already documented: **each fenced block runs in a fresh shell**,
so a dropped `$PORT` made the daemon bind `127.0.0.1:` (invalid) and a dropped
`$SOCK` turned the socket cleanup into a silent no-op. One script is one
variable scope.

## Where it lives, and why

**`.claude/skills/ir:test-mac/test-mac.sh`, beside `restore-prod.sh`** — the
issue's bound (both halves of one workflow in the *same* directory) is met by
adding to where the teardown half already is, rather than by moving it.

`AGENTS.md` pulls both ways, and the tie-breakers were:

- *"Dev-facing orchestration in skills, not CLIs"* is the rule that actually
  describes this file. The competing rule (*"standalone dev tools go under
  top-level `tools/`"*) is about not putting dev tooling in `core/cmd/` as Go
  binaries; `tools/` in practice holds repo-wide gates that CI and humans
  invoke directly (`preflight.sh`, the linters, `build-*.sh`). This script is
  invoked by exactly one skill and by nobody else.
- `restore-prod.sh` is already referenced by that path from `SKILL.md` and from
  `.claude/skills/ir:release/SKILL.md`. Moving it to satisfy the bound would
  churn three files and break an operator's muscle-memory path for no gain.
- Lint covers both locations identically (`tools/bash-lint.sh` discovers via
  `git ls-files` and excludes only `*/testdata/*`), so it did not drive the
  choice — as the issue said it should not.

## Evidence: every gate mutated, and the red output

Each gate is being **moved**, not introduced, so none has a "before the fix" to
run red. Per `AGENTS.md`'s Testing section the evidence is a mutation, and it is
**committed as a fixture** rather than only described here:

- `tools/lib/test-mac-script_test.sh` — the lock test. Drives the real script
  end to end against PATH stubs in a `mktemp -d`, 15 cases.
- `tools/lib/test-mac-script-mutations_test.sh` — **22** mutations via
  `tools/mutate.sh`, each requiring the lock test to go red **with the message
  naming that specific gate**. Eleven of them were added by this PR's own
  review (see F1–F5 below).

Both are auto-discovered by `tools/preflight.sh --only tools`. Paths elided
below for width; run
`MUTATION_FIXTURES_STRICT=1 bash tools/lib/test-mac-script-mutations_test.sh`
to reproduce.

### The six gates the issue named

**1. Daemon reachability before launching the app** — mutation: the abort is
demoted to a no-op (`if [[ -z "$READY" ]]` → `if false`).

```
FAIL: GATE daemon-reachability: an unreachable daemon must abort, but the script exited 0: …
```

**2. Wait for the app process to exit before overwriting its bundle** —
mutation: the hard abort never fires.

```
FAIL: GATE app-exit-wait: a still-running app must abort, but the script exited 0: …
```

**3a. Backup freshness — refresh a Developer-ID-signed original.** The mutation
is the *plausible regression*, not arbitrary damage: adding the natural-looking
`[[ ! -d "$PROD_BACKUP" ]] &&`, i.e. "make the backup once, ever".

```
FAIL: GATE backup-freshness: the stale backup was NOT refreshed from the untouched original
      (backup holds 'STALE-BACKUP', wanted PRODUCTION) — restore-prod.sh would reinstall a stale build
```

**3b. Refuse when the app is dev-signed and no backup exists** — mutation: the
refusal branch never fires.

```
FAIL: GATE backup-refusal: dev-signed app + no backup must refuse, but the script exited 0: …
```

**4. Build-output existence before `rm -rf`ing `Sparkle.framework`** —
mutation: the existence check never fires.

```
FAIL: GATE build-output-exists: aborted (exit 1) but not with the missing-build-output message: …
```

*(Noting the shape honestly: with the check gone the run still dies — `cp` of a
missing file under `set -e` — but it dies without naming the problem, which is
the branch that went red. The assertion also proves `Sparkle.framework` was
still intact at that point.)*

**5. MODE/TARGET validated against the literal enum, no default branch** —
mutation: the `*)` arm silently accepts.

```
FAIL: GATE enum-validation: the typo 'seperate' must be refused, but the script exited 0
      and would have silently run in replace mode: …
```

**6. The app is killed before the daemon** — mutation: a daemon `pkill` hoisted
ahead of the app block. Asserted on the recorded call order, not on wording.

```
FAIL: GATE kill-order: the daemon was killed at line 3, at or before the app at line 4
      — a live app can observe the daemon-less gap and spawn its own replacement
```

### Three gates this PR ADDS (beyond the issue — called out deliberately)

**7. Build freshness.** Existence is not freshness. A product left over from an
earlier compile — including one compiled while a `tools/mutate.sh` mutation was
applied — is a perfectly valid binary, passes gate 4, and installing it means
debugging a defect the source does not have. **That happened on this machine
today**, and `mutate.sh`'s own header documents the same class from #1852. The
script now refuses if any `.swift` under `platforms/macos/Irrlicht` is newer
than the built binary.

```
FAIL: GATE build-freshness: a source newer than the build product must abort, but the script
      exited 0 and installed a stale binary: …
```

**7b. …and that check refuses when it *cannot* run** — a freshness comparison
against an empty source set would otherwise report the same green as one that
looked and found nothing (`AGENTS.md`: absence of a finding and inability to
look must never produce the same output).

```
FAIL: GATE build-freshness: with no .swift sources the check cannot run, but the script
      exited 0 — a vacuous pass: …
```

**8. `swift build`'s exit status is read from swift, not from the pipe.**
`SKILL.md` step 2 was `swift build 2>&1 | tail -5`, whose status is `tail`'s —
so a failed build reported success and the run walked into the install with
whatever binary was lying around. The mutation restores that exact old
spelling.

```
FAIL: GATE swift-build-status: a failed swift build must abort, but the script exited 0
      (its status came from the pipe, not from swift): …
```

### One more, about the gate that runs the gates

`tools/preflight.sh --changed` scopes the `tools` group by a trigger regex that
did **not** cover `.claude/skills/`. A push touching only `test-mac.sh` would
have skipped both test files — and a gate that never ran is indistinguishable
from one that found nothing. `^\.claude/skills/ir:test-mac/` is now an
alternative (eighth entry in that comment block), and it too is mutated:

```
FAIL: preflight-trigger: the tools gate does NOT fire on a diff touching
      .claude/skills/ir:test-mac/test-mac.sh — this file would be skipped on the very push
      that changes its subject. Regex: ^tools/lib/|^tools/[^/]*\.sh$|…
```

The assertion carries a vacuity guard (the regex must still *not* match
`core/domain/session.go`), so a trigger widened to everything cannot satisfy it.

## What the review found — F1 to F5, and what it cost

The review subagent ran its own mutation battery and it was worth every second.
All five are fixed on this branch; the first two are the reason this PR is
larger than "move some bash".

**F1 (BLOCKING, a regression I introduced).** Adding `set -o pipefail` — which
the fenced blocks never had — silently killed the Developer-ID check:

```
if codesign -dv --verbose=4 "$PROD_APP" 2>&1 | grep -q "^Authority=Developer ID Application"; then
```

`grep -q` exits at its first match. The real `codesign -dv --verbose=4` writes
**28 unbuffered lines with `Authority=` at line 20**, so it is still writing
when the pipe closes, dies of SIGPIPE, and returns **141** — which `pipefail`
makes the pipeline's status. The branch is therefore skipped **exactly when the
app is genuinely production-signed**. Measured against the real backup bundle:

```
$ bash -c 'set -o pipefail; codesign -dv --verbose=4 "$1" 2>&1 | grep -q "^Authority="; echo rc=$?' _ <real bundle>
rc=141          # 5/5 trials; without pipefail: rc=0
```

Consequence: the backup would never be refreshed, and `restore-prod.sh` would
reinstall a stale build. Fixed by capturing first and matching second; verified
**10/10 TAKEN** against the real Developer-ID bundle and correctly negative
against a dev-signed one.

**The same line was in `restore-prod.sh`** (pre-existing, not introduced here —
it has had `set -euo pipefail` since it was written). There the fall-through
tells a user with a correctly installed production app to reinstall it, *after*
having already killed their app and daemon. Fixed identically, and
`restore-prod.sh` now has the two test cases it never had.

**F2 (BLOCKING).** The `codesign` stub emitted **one** line, so it could not
SIGPIPE, so GATE 3a passed against a script whose check could not succeed at
all. A stub that cannot reproduce the subject's real I/O shape certifies the
wrong thing. The stub now emits a realistic 28-line block with `Authority=` at
line 20 — and with that stub alone, against the *unfixed* script, GATE 3a goes
red 3/3. That is the red-first proof for F1's fix.

**F3 (HIGH).** A mutation battery found **eleven surviving mutations, every one
at a call site** — `--record` dropped from the daemon launch, the replace-mode
port changed to 7838, `IRRLICHT_BIND_ADDR` removed, `install_name_tool` and
`--entitlements` deleted, the socket cleanup and icon refresh dropped, and
`separate full`'s entire bundle assembly never executed (the only `separate`
case was `separate daemon`, which skips every app step). Gates say "it refuses
correctly"; nothing said "it does the right thing when it proceeds". Five
CALL-SITE cases and eleven committed mutation rows now cover them.

**F4 (MEDIUM).** Two more `… | grep`/`| head -1` pipelines carrying the same
SIGPIPE-under-pipefail hazard latently. The `find … -print | head -1` one is
the worse of the two: it would abort with status 141 and **no message**, making
"the build is fresh" and "the freshness check could not run" identical. Now
`find … -print -quit`, and `security find-identity` is captured not piped.

**F5 (MEDIUM).** Step 7's reachability ABORT fires *after* the install, so it
left `/Applications/Irrlicht.app` holding a dev build with no hint a teardown
exists. An `on_exit` trap now names the dirtied bundle and points at
`restore-prod.sh` — and a case asserts it stays quiet on runs that never wrote.

**Two more, found by the fixtures themselves** while verifying the F1–F5 fixes:
a mutation anchor left stale by F1's own edit (`mutate.sh` refused with `STALE`
rather than silently mutating nothing), and an unbound `$PROD_APP` inside a
`fail` message in the test — which under `set -u` crashed the case *only on the
failure path*, i.e. precisely where a verification mechanism must not.

## Final tally

| | |
|---|---|
| lock-test cases | **23** (`tools/lib/test-mac-script_test.sh`) |
| committed mutations, each required to go red | **22** (`tools/lib/test-mac-script-mutations_test.sh`) |
| surviving mutations at the end | **0** |
| `tools` gate | 116s baseline → **145–170s** |

## Cost, measured

Running all fifteen lock-test cases per mutation cost **194s** for the fixtures
file and took the whole `tools` gate from **116s to 327s** — against the 540s
budget `tools/preflight.sh --changed` shares with every other gate in the
pre-push hook. That is a regression for every push in the repo, not just this
one. Each mutation now runs only the case it is about (`$TESTMAC_CASE`):

| | all-cases | scoped |
|---|---|---|
| `test-mac-script-mutations_test.sh` | 194s | **22s** |
| whole `tools` gate | 327s | **145s** (baseline 116s) |

A case name matching nothing is a **refusal (exit 2)**, never a quiet zero-case
pass — verified directly: `bash tools/lib/test-mac-script_test.sh nosuchcase`
exits 2. Without that, a typo in a fixture row would produce "ALL PASS" over
zero assertions.

## The real end-to-end run (`replace` / `full`)

Run on this machine at 18:33, from the main checkout, exit 0 in 7s:

```
MODE=replace TARGET=full PORT=7837 DEV_HOME=<production>
Building irrlichd → /Users/ingo/projects/irrlicht/core/bin/irrlichd …
Building the Swift app …
Build complete! (2.70s)
Stopping the app (Irrlicht\.app/Contents/MacOS/Irrlicht) …
Stopping the daemon on 7837 …
/Applications/Irrlicht.app: replacing existing signature
Starting irrlichd on 127.0.0.1:7837 (log: /tmp/irrlichd-dev.log) …
COMMAND    PID USER   FD   TYPE             DEVICE SIZE/OFF NODE NAME
irrlichd 18118 ingo    7u  IPv4 0x2b47ee8671c35f7b      0t0  TCP 127.0.0.1:7837 (LISTEN)
Launching /Applications/Irrlicht.app (log: /tmp/irrlicht-app-dev.log) …

── verify ──
18118
{"groups":[{"name":"irrlicht","agents":[{"version":1,"session_id":"01a03982-…","state":"ready","adapter":"codex",…
18223
rate-limit mentions (0 now is fine; should climb after the next statusline tick): 33

Teardown when done — REQUIRED to get production back:
  …/.claude/skills/ir:test-mac/restore-prod.sh
```

Post-state verified: daemon 18118 carries `--record` and answers `/state` on
7837; app 18223 running; `Info.plist` `CFBundleShortVersionString` = `dev`;
`Sparkle.framework` present in the live bundle; and the backup at
`.build/irrlicht-prod-backup/Irrlicht.app` is still
`Authority=Developer ID Application: Ingo Eichhorst (93Y3GMJAMV)` — the
untouched original, i.e. the safety net survived the run. The dev stack is
deliberately left up; `restore-prod.sh` was **not** run.

## Gates

`tools/preflight.sh --only <group>`, each in its own foreground invocation:

| group | result |
|---|---|
| `tools` | PASS (36 files found, 36 ran, 0 failed) |
| `skills` | PASS (23 files, 0 errors, 0 warnings) |
| `bash` | PASS |
| `posix` | PASS |
| `arch` | PASS (composite 7.887996 → 7.887996) |
| `go` | PASS (all 8 sub-gates) |
| `web` | PASS (both trees) |
| `security` | PASS |
| `swift` | PASS — run by the pre-push hook, twice |
| `linux` | not run: opt-in, needs Docker; nothing here is Linux-specific |

The pre-push hook (`--changed --budget 540`) completed with no `TIMEOUT` and no
`NOT RUN`.

## Notes on what changed beyond a pure move

Called out so they are not mistaken for a faithful extraction:

- **Both build-output gates now cover `separate` mode too.** They were inside
  the `replace` branch; hoisting them ahead of the mode split is what a single
  variable scope makes natural, and it loses nothing.
- **`set -euo pipefail`**, matching `restore-prod.sh`. Every `pkill`/`lsof`
  whose non-zero status is normal carries an explicit `|| true`.
- **Six documented env seams** (`IRRLICHT_TESTMAC_*`) exist so the lock test can
  point the whole procedure at a temp dir. They are a test seam, not a
  supported way to run it by hand, and the lock test **refuses to run** if the
  script stops honouring any of them — without them it would silently start
  driving the real `/Applications/Irrlicht.app`.
- `SKILL.md`'s Notes section is kept nearly verbatim: it is behavioural prose
  (what each mode shares with production, #1449, #570, #448), not procedure.


## What CI found that this machine could not

The F1 fix and its fixtures took three CI rounds, and the round trips were the
point — each one exposed something a local green was hiding.

**Round 1 — the mutation asserted a RACE.** The two F1 rows reintroduce
`codesign … | grep -q` and require the gate to go red. It did, 22/22 here, and
did **not** on the GitHub macOS runner. SIGPIPE is a race: `grep -q` exits at
its first match and the writer only dies *if it is still writing*. Real
codesign loses that race essentially always — it is a binary walking a bundle
between writes. A shell stub is fast enough to win it. Fixed structurally: the
stub now pads ~360 KiB after the `Authority=` line, so once unread output
exceeds the pipe buffer (64 KiB) the writer **must** block. Same rule as
AGENTS.md's ban on sleeping fixtures — do not assert a race you merely tend to
win.

**Round 2 — the padding then failed the UNMUTATED script**, which is how the
F1 *fix* turned out to be wrong too. Capture-then-pipe —

```bash
CODESIGN_INFO="$(codesign … 2>&1 || true)"
if printf '%s
' "$CODESIGN_INFO" | grep -q "^Authority=…"; then   # STILL WRONG
```

— is the same bug with more headroom: the producer is now `printf` instead of
`codesign`, but it is still a producer racing a `grep -q` that exits early. It
survives only while the captured text fits one pipe buffer. Both scripts now
match **in-shell** (`[[ "$NL$CODESIGN_INFO" == *"${NL}Authority=…"* ]]`) — no
second process, no pipe, no race — and a new mutation row (`F1b`) pins that
intermediate wrong fix specifically, so nobody re-lands it.

**Round 3 — the stub still depended on signal disposition.** `F1a` (producer =
the stub) stayed green on the runner while `F1b` (producer = the script's own
`printf`) went red on both. Volume guarantees the writer is still writing; it
does not guarantee how the stub's `/bin/sh` *reports* that. With SIGPIPE
ignored or handled, `write()` returns EPIPE, `printf` fails, and the stub ran
on to its `exit 0` and handed the pipeline a **success**. The stub now exits
141 explicitly on a failed write, so it behaves identically under both
dispositions — verified locally with and without `trap "" PIPE`, which
reproduces the runner's condition.

A **`stub-fidelity`** case now pins the property those two rows silently depend
on: the stub must report 141 under *both* signal dispositions **and** still
carry a line-anchored `Authority=` line when read whole. Without it, shrinking
the stub turns the two most valuable mutation rows into no-ops — which is
exactly how this was missed twice.

**Unrelated flake, checked rather than assumed:** the final `go-test` red was
`state-vocabulary-lint_test.sh` (`platforms/web/irrlicht.js … rejected as
binary`). It runs *before* these files alphabetically, passed on the previous
push at identical content, and a `gh run rerun --failed` on the **same commit**
came back green. Not caused by this diff.

## Final tally (updated)

| | |
|---|---|
| lock-test cases | **24** |
| committed mutations, each required to go red | **23** |
| surviving mutations at the end | **0** |
| CI on `4af47b90` | 14 SUCCESS, 1 SKIPPED, MERGEABLE |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
