### PR TITLE
fix(macos): usage menu bar style honors itself strictly on error (#1862)

### DIFF
--- a/platforms/macos/Irrlicht/App/MenuBarImageBuilder.swift
+++ b/platforms/macos/Irrlicht/App/MenuBarImageBuilder.swift
@@ -25,44 +25,24 @@ enum MenuBarImageBuilder {
         return .off
     }
 
-    /// Whether any session that will actually be DRAWN as a dot is errored.
-    ///
-    /// The filter has to match what `MenuBarStatusRenderer` draws, or the icon
-    /// widens to point at a red circle that is not in it. Subagents are the
-    /// trap: they live in `sessionManager.sessions` but
-    /// `MenuBarStatusRenderer` excludes them from every render path (its
-    /// `topLevelSessions` filter), so a failed CHILD would otherwise widen
-    /// the icon while adding no red dot anywhere.
-    ///
-    /// Still an over-approximation in one known case: a group past
-    /// `maxVisibleGroups` collapses into the grey overflow ellipsis, so an
-    /// error only in the sixth project widens the icon without adding a dot.
-    /// Narrowing that would mean re-deriving the whole grouping here, and the
-    /// cost is one ellipsis rather than a missed error.
-    ///
-    /// Pure, so it is testable without a SessionManager — the same reason
-    /// `iconState` and `shouldShowDotsInUsageStyle` are.
-    static func hasErroredDot(in sessions: [SessionState]) -> Bool {
-        sessions.contains { $0.parentSessionId == nil && $0.state == .error }
-    }
-
     /// Whether `.usage` style should render the session dots after all.
     ///
-    /// Two independent reasons, both of which end with the icon lying about
-    /// the world if the dots stay hidden:
+    /// One reason, and it is the case where hiding the dots would make the
+    /// icon lie about the world: **no renderable quota yet** (fresh daemon
+    /// start, or the selected provider hasn't ticked a statusline sample).
+    /// With both halves nil the caller falls through to
+    /// `OffFlameImage.menuBar`, the "no sessions running" icon, while
+    /// sessions are in fact active.
     ///
-    ///   - **No renderable quota yet** (fresh daemon start, or the selected
-    ///     provider hasn't ticked a statusline sample). With both halves nil
-    ///     the caller falls through to `OffFlameImage.menuBar`, the "no
-    ///     sessions running" icon, while sessions are in fact active.
-    ///   - **A session is errored** (#1802). `.usage` suppresses the dots
-    ///     outright, so the red circle this feature exists to show would be
-    ///     invisible for every user on that style — the feature would silently
-    ///     do nothing for them. Here the dots are ADDED rather than
-    ///     substituted: `composeSideBySide` renders both halves, so the user's
-    ///     chosen quota bars are kept and the red dot appears beside them. The
-    ///     icon widens while an error stands, which is the intended cost — an
-    ///     alert that never changes the icon's footprint is one nobody notices.
+    /// #1802 added a second arm — bring the dots back whenever a session is
+    /// errored, so `.usage` would still show the red circle. #1862 removed
+    /// it: the caller re-adds the WHOLE dot bank (`computedDotsImage` in
+    /// `iconImage`), not just the errored project, and an `error` state does
+    /// not clear on a timer — so the escalation had become the normal view
+    /// for every `.usage` user rather than a rare alert. `.usage` now honors
+    /// its own style strictly: quota bars only, error or not. That leaves
+    /// #1802's error signal with no surface on this style (tracked as a
+    /// follow-up to #1862).
     ///
     /// Takes the already-built dots image rather than a raw session count: a
     /// non-zero session count doesn't guarantee `buildStatusImage` succeeds
@@ -74,11 +54,10 @@ enum MenuBarImageBuilder {
     static func shouldShowDotsInUsageStyle(
         appearance: MenuBarAppearance,
         quotaImage: NSImage?,
-        dotsImage: NSImage?,
-        hasErroredSession: Bool
+        dotsImage: NSImage?
     ) -> Bool {
         guard appearance.hidesDotsWhenQuotaIsRenderable, dotsImage != nil else { return false }
-        return quotaImage == nil || hasErroredSession
+        return quotaImage == nil
     }
 
     /// Whether the dot half is drawn at all — the WHOLE decision, not just the
@@ -96,15 +75,13 @@ enum MenuBarImageBuilder {
     static func showsDots(
         appearance: MenuBarAppearance,
         quotaImage: NSImage?,
-        dotsImage: NSImage?,
-        hasErroredSession: Bool
+        dotsImage: NSImage?
     ) -> Bool {
         guard appearance.hidesDotsWhenQuotaIsRenderable else { return true }
         return shouldShowDotsInUsageStyle(
             appearance: appearance,
             quotaImage: quotaImage,
-            dotsImage: dotsImage,
-            hasErroredSession: hasErroredSession
+            dotsImage: dotsImage
         )
     }
 
@@ -205,21 +182,17 @@ enum MenuBarImageBuilder {
             providerKey: providerKey,
             now: now
         )
-        // .usage style hides the dots by default. Two conditions bring them
-        // back — no renderable quota, or an errored session that would
-        // otherwise have nowhere to be red. See showsDots.
-        //
-        // `sessions` has already dropped Gas Town sessions; hasErroredDot
-        // drops subagents. Both filters are needed — see its doc.
+        // .usage style hides the dots by default, and brings them back only
+        // when there is no renderable quota to show instead — see
+        // shouldShowDotsInUsageStyle. (#1862: an errored session used to
+        // bring them back too; that arm is gone — see that function's doc.)
         //
         // The locals are named `built…`/`shown…` rather than reusing the
         // helpers' own names: `let quotaImage = quotaImage(...)` compiles, but
         // it gives one identifier two meanings inside a single function and
         // reads like recursion at a glance.
-        let hasErroredSession = hasErroredDot(in: sessions)
         let shownDotsImage = showsDots(
-            appearance: appearance, quotaImage: builtQuotaImage, dotsImage: computedDotsImage,
-            hasErroredSession: hasErroredSession
+            appearance: appearance, quotaImage: builtQuotaImage, dotsImage: computedDotsImage
         ) ? computedDotsImage : nil
         // Dots first (left), quota bars last (right) — closest to the
         // system status icons (WiFi/battery/clock), matching issue #909's

--- a/platforms/macos/Tests/MenuBarImageBuilderTests.swift
+++ b/platforms/macos/Tests/MenuBarImageBuilderTests.swift
@@ -72,17 +72,7 @@ final class MenuBarImageBuilderTests: XCTestCase {
         XCTAssertEqual(result?.size.height, 18) // max(18, 12)
     }
 
-    private func makeSession(
-        id: String, state: SessionState.State, parentSessionId: String? = nil
-    ) -> SessionState {
-        SessionState(
-            id: id, state: state, model: "m", cwd: "/tmp/p", projectName: "p",
-            firstSeen: Date(timeIntervalSince1970: 1_700_000_000),
-            updatedAt: Date(timeIntervalSince1970: 1_700_000_000),
-            parentSessionId: parentSessionId)
-    }
-
-    // MARK: - shouldShowDotsInUsageStyle (issue #909 review fix; #1802's error arm)
+    // MARK: - shouldShowDotsInUsageStyle (issue #909 review fix)
 
     /// The appearance these tests exercise. `isCompact` defaults to false so
     /// every assertion below keeps meaning exactly what it meant before #1852
@@ -95,23 +85,25 @@ final class MenuBarImageBuilderTests: XCTestCase {
 
     /// `.usage` style with a renderable dots image but no quota yet must
     /// not collapse to the "no sessions" icon — see the comment in
-    /// `combinedImage`. LOCK: pre-#1802 behaviour that must not change.
+    /// `combinedImage`. LOCK: the one arm #1862 kept — without it a
+    /// `.usage` user with active sessions and no renderable quota yet would
+    /// fall through to the "no sessions running" icon while sessions are in
+    /// fact running.
     func testFallsBackToDotsWhenUsageStyleHasNoQuotaButDotsRendered() {
         let dots = NSImage(size: NSSize(width: 10, height: 18))
         XCTAssertTrue(MenuBarImageBuilder.shouldShowDotsInUsageStyle(
-            appearance: appearance(.usage), quotaImage: nil, dotsImage: dots,
-            hasErroredSession: false
+            appearance: appearance(.usage), quotaImage: nil, dotsImage: dots
         ))
     }
 
-    /// LOCK: with quota renderable and nothing wrong, `.usage` still means
-    /// quota only.
+    /// LOCK: with quota renderable, `.usage` means quota only — including
+    /// while a session is errored (#1862 removed the arm that used to make
+    /// an exception here).
     func testDoesNotFallBackWhenUsageStyleHasQuotaImage() {
         let quota = NSImage(size: NSSize(width: 10, height: 18))
         let dots = NSImage(size: NSSize(width: 10, height: 18))
         XCTAssertFalse(MenuBarImageBuilder.shouldShowDotsInUsageStyle(
-            appearance: appearance(.usage), quotaImage: quota, dotsImage: dots,
-            hasErroredSession: false
+            appearance: appearance(.usage), quotaImage: quota, dotsImage: dots
         ))
     }
 
@@ -121,50 +113,55 @@ final class MenuBarImageBuilderTests: XCTestCase {
     /// not a raw session count that doesn't guarantee dots render.
     func testDoesNotFallBackWhenUsageStyleHasNoRenderableDotsEither() {
         XCTAssertFalse(MenuBarImageBuilder.shouldShowDotsInUsageStyle(
-            appearance: appearance(.usage), quotaImage: nil, dotsImage: nil,
-            hasErroredSession: false
+            appearance: appearance(.usage), quotaImage: nil, dotsImage: nil
         ))
     }
 
     func testDoesNotFallBackForLightsOrCombinedStyles() {
         let dots = NSImage(size: NSSize(width: 10, height: 18))
         XCTAssertFalse(MenuBarImageBuilder.shouldShowDotsInUsageStyle(
-            appearance: appearance(.lights), quotaImage: nil, dotsImage: dots,
-            hasErroredSession: false
+            appearance: appearance(.lights), quotaImage: nil, dotsImage: dots
         ))
         XCTAssertFalse(MenuBarImageBuilder.shouldShowDotsInUsageStyle(
-            appearance: appearance(.combined), quotaImage: nil, dotsImage: dots,
-            hasErroredSession: false
+            appearance: appearance(.combined), quotaImage: nil, dotsImage: dots
         ))
     }
 
-    // MARK: - #1802: `.usage` must not swallow the red circle
+    // MARK: - #1862: `.usage` honors its style strictly, even while errored
 
-    /// The reason the error arm exists. `.usage` suppresses the dots outright,
-    /// so without this the red circle is invisible for every user on that
-    /// style and the feature silently does nothing for them. The dots are
-    /// ADDED here, not substituted — `composeSideBySide` renders both halves,
-    /// so the user's chosen quota bars are kept.
+    /// #1802 added an arm to `shouldShowDotsInUsageStyle` so an errored
+    /// session would bring the dots back on `.usage`. #1862 removed it:
+    /// `iconImage` re-adds the WHOLE dot bank (`computedDotsImage`), not
+    /// just the errored project, and an `error` state does not clear on a
+    /// timer — so the escalation had become the normal view for every
+    /// `.usage` user, not a rare alert. `.usage` now means quota bars only,
+    /// error or not.
     ///
-    /// A check the change ADDS, so there is no "before the fix" run.
-    /// Mutation-proved: dropping `|| hasErroredSession` from
-    /// `shouldShowDotsInUsageStyle` turns this red while the four LOCKs above
-    /// stay green.
-    func testUsageStyleShowsDotsWhenASessionIsErrored() {
-        let quota = NSImage(size: NSSize(width: 20, height: 18))
-        let dots = NSImage(size: NSSize(width: 10, height: 18))
-        XCTAssertTrue(MenuBarImageBuilder.shouldShowDotsInUsageStyle(
-            appearance: appearance(.usage), quotaImage: quota, dotsImage: dots,
-            hasErroredSession: true
-        ))
+    /// This is the reporter's exact repro from #1862: a top-level session
+    /// in `.error` state, sitting alongside a renderable quota. Exercised
+    /// end-to-end through `iconImage` (rather than the removed
+    /// `hasErroredSession` parameter, which no longer exists) so the
+    /// assertion reflects what a real session list produces.
+    func testUsageStyleKeepsDotsHiddenWhenASessionIsErrored() throws {
+        let sessions = [
+            MenuBarFixtures.session(id: "e1", state: .error, project: "alpha"),
+            MenuBarFixtures.sessionWithQuota(),
+        ]
+        let usage = MenuBarAppearance(style: .usage, isCompact: false)
+        let quota = try XCTUnwrap(MenuBarImageBuilder.quotaImage(
+            appearance: usage, sessions: sessions, providerKey: nil, now: fixedNow
+        ), "the fixture must have a renderable quota, or this test proves nothing")
+        let composed = try XCTUnwrap(icon(usage, sessions: sessions))
+        XCTAssertEqual(composed.size.width, quota.size.width, accuracy: 0.01,
+                       "an errored top-level session must not widen .usage past its quota-only width")
     }
 
-    /// An error cannot conjure dots that do not render.
-    func testNoDotsImageMeansNoDotsEvenWithAnError() {
+    /// LOCK: without a renderable dots image, `.usage` can never show dots —
+    /// the guard short-circuits before `quotaImage` is even inspected.
+    func testNoDotsImageMeansNoDotsRegardlessOfQuota() {
         let quota = NSImage(size: NSSize(width: 20, height: 18))
         XCTAssertFalse(MenuBarImageBuilder.shouldShowDotsInUsageStyle(
-            appearance: appearance(.usage), quotaImage: quota, dotsImage: nil,
-            hasErroredSession: true
+            appearance: appearance(.usage), quotaImage: quota, dotsImage: nil
         ))
     }
 
@@ -187,13 +184,12 @@ final class MenuBarImageBuilderTests: XCTestCase {
         for style in MenuBarStyle.allCases {
             for compact in [false, true] {
                 // Only `.usage` ever withholds its dots, and only while the
-                // quota is renderable and nothing is errored. Density never
-                // enters into it.
+                // quota is renderable. Density never enters into it.
                 let expected = style != .usage
                 XCTAssertEqual(
                     MenuBarImageBuilder.showsDots(
                         appearance: appearance(style, compact: compact),
-                        quotaImage: quota, dotsImage: dots, hasErroredSession: false
+                        quotaImage: quota, dotsImage: dots
                     ),
                     expected,
                     "\(style) compact=\(compact) with a renderable quota"
@@ -202,17 +198,9 @@ final class MenuBarImageBuilderTests: XCTestCase {
                 XCTAssertTrue(
                     MenuBarImageBuilder.showsDots(
                         appearance: appearance(style, compact: compact),
-                        quotaImage: nil, dotsImage: dots, hasErroredSession: false
+                        quotaImage: nil, dotsImage: dots
                     ),
                     "\(style) compact=\(compact) with no renderable quota"
-                )
-                // And an errored session always brings them back (#1802).
-                XCTAssertTrue(
-                    MenuBarImageBuilder.showsDots(
-                        appearance: appearance(style, compact: compact),
-                        quotaImage: quota, dotsImage: dots, hasErroredSession: true
-                    ),
-                    "\(style) compact=\(compact) with an errored session"
                 )
             }
         }
@@ -343,61 +331,12 @@ final class MenuBarImageBuilderTests: XCTestCase {
                        "the icon must compose dots first, quota bars second")
     }
 
-    /// LOCK: every style OTHER than `.usage` never routes through this
-    /// decision at all, error or not — at either density.
-    ///
-    /// Derived from `allCases` rather than the hand-written
-    /// `[MenuBarStyle.lights, .combined]` this used to be: that array was
-    /// complete when written and silently stale the moment a case was added
-    /// (#1845), which is the same failure mode
-    /// `MenuBarStatusRenderer.segmentOrder` documents for state lists (#1797).
-    /// Since #1852 it also crosses the compact modifier, so a density choice
-    /// cannot quietly become a content one.
-    func testOtherStylesAreUnaffectedByAnError() {
-        let quota = NSImage(size: NSSize(width: 20, height: 18))
-        let dots = NSImage(size: NSSize(width: 10, height: 18))
-        let others = MenuBarStyle.allCases.filter { $0 != .usage }
-        XCTAssertFalse(others.isEmpty, "allCases must yield at least one non-.usage style")
-        for style in others {
-            for compact in [false, true] {
-                XCTAssertFalse(MenuBarImageBuilder.shouldShowDotsInUsageStyle(
-                    appearance: appearance(style, compact: compact), quotaImage: quota,
-                    dotsImage: dots, hasErroredSession: true
-                ), "\(style) compact=\(compact) must not be changed by an errored session")
-            }
-        }
-    }
-
-    // MARK: - #1802 review round: only a session that will be DRAWN may widen
-
-    /// A failed SUBAGENT must not widen the `.usage` icon. Subagents live in
-    /// `sessionManager.sessions` but `MenuBarStatusRenderer.orderedProjectGroups`
-    /// excludes them (`where session.parentSessionId == nil`), so counting one
-    /// here widens the status item to point at a red circle that is not in it.
-    ///
-    /// Mutation check (verified): drop `$0.parentSessionId == nil` from
-    /// `hasErroredDot` and this goes red.
-    func testErroredSubagentDoesNotCountAsADot() {
-        let child = makeSession(id: "c", state: .error, parentSessionId: "p")
-        XCTAssertFalse(MenuBarImageBuilder.hasErroredDot(in: [child]),
-                       "a subagent is never drawn as a dot, so it cannot make one red")
-    }
-
-    func testErroredTopLevelSessionCountsAsADot() {
-        let top = makeSession(id: "t", state: .error)
-        XCTAssertTrue(MenuBarImageBuilder.hasErroredDot(in: [top]))
-    }
-
-    func testHealthySessionsProduceNoErroredDot() {
-        XCTAssertFalse(MenuBarImageBuilder.hasErroredDot(in: [
-            makeSession(id: "a", state: .working),
-            makeSession(id: "b", state: .ready),
-        ]))
-    }
+    // MARK: - iconState priority order (untouched by #1862)
 
     /// An errored session must NOT promote the icon to `.attention`, which is
-    /// a FULL REPLACEMENT of the dots and would hide the very circle #1802
-    /// adds. LOCK on `iconState`'s untouched priority order.
+    /// a FULL REPLACEMENT of the dots. `iconState` never inspects session
+    /// state at all — this LOCKs its untouched priority order, unaffected by
+    /// either #1802 or #1862.
     func testErrorDoesNotPromoteToTheAttentionIcon() {
         XCTAssertEqual(MenuBarImageBuilder.iconState(pendingConsentCount: 0, sessionCount: 3), .dots)
         XCTAssertEqual(MenuBarImageBuilder.iconState(pendingConsentCount: 1, sessionCount: 3), .attention)


### PR DESCRIPTION
## Summary

Fixes #1862. Implements the maintainer's chosen option (Option 1, "honor the
style strictly"): on the `.usage` menu bar style, an errored session no
longer brings the session dots back. `.usage` now always means quota bars
only.

**This removes #1802's menu-bar error signal for Usage-style users, with no
replacement surface.** #1802 added an arm to `shouldShowDotsInUsageStyle`
that re-showed the dots whenever any top-level session was errored. Two
properties made that louder than #1802 intended: `iconImage` re-adds the
WHOLE dot bank (every project group, not just the errored one), and an
`error` state does not clear on a timer — so the escalation had become the
*normal* view for every `.usage` user, which is the bug reported in #1862.
Honoring the style strictly means Usage-style users get no menu-bar signal
at all when a session errors, until a narrower surface is designed — see the
tracked follow-up issue linked below.

## Changes

`platforms/macos/Irrlicht/App/MenuBarImageBuilder.swift`:
- `shouldShowDotsInUsageStyle` no longer takes `hasErroredSession` or checks
  it; it now returns dots only when `quotaImage == nil` (kept — load-bearing,
  see below).
- `showsDots` no longer takes/forwards `hasErroredSession`.
- `hasErroredDot` removed — its only caller was the arm just removed. A
  repo-wide grep (`git grep -n "hasErroredDot" -- .`) confirmed nothing else
  in `platforms/macos` (or elsewhere) called it.
- Doc comments on `shouldShowDotsInUsageStyle` and in `iconImage` rewritten
  to describe current behavior and record why the arm was removed.

**Not touched:** `.lights`/`.combined` styles, the compact modifier,
`MenuBarStyle.swift`, `SettingsView.swift`, `QuotaMenuBarRenderer`.

The kept arm (`quotaImage == nil` → show dots) is untouched and still
load-bearing: without it, a `.usage` user with active sessions and no
renderable quota yet would fall through to the "no sessions running" icon
while sessions are in fact running. That's a separate correctness condition
from this issue.

## Test evidence (red-first)

`platforms/macos/Tests/MenuBarImageBuilderTests.swift:152`
(`testUsageStyleShowsDotsWhenASessionIsErrored`) locked the behavior being
removed. Per this repo's testing philosophy, inverted it *before* touching
source, confirmed it failed red against the unmodified code, then applied
the fix and confirmed green:

**Before the fix** (`swift test --filter MenuBarImageBuilderTests`):
```
Test Case '-[IrrlichtTests.MenuBarImageBuilderTests testUsageStyleKeepsDotsHiddenWhenASessionIsErrored]' started.
.../MenuBarImageBuilderTests.swift:152: error: -[IrrlichtTests.MenuBarImageBuilderTests testUsageStyleKeepsDotsHiddenWhenASessionIsErrored] : XCTAssertFalse failed
Test Case '-[IrrlichtTests.MenuBarImageBuilderTests testUsageStyleKeepsDotsHiddenWhenASessionIsErrored]' failed (0.733 seconds).
Test Suite 'MenuBarImageBuilderTests' failed ...
	 Executed 24 tests, with 1 failure (0 unexpected) in 0.858 (0.863) seconds
```

**After the fix** (full suite):
```
	 Executed 547 tests, with 0 failures (0 unexpected) in 5.388 (5.450) seconds
```

Also audited every other test exercising `hasErroredSession`/`hasErroredDot`:
removed the three `hasErroredDot`-only tests and `testOtherStylesAreUnaffectedByAnError`
(the quantity they pinned no longer exists at this API level), rewrote
`testNoDotsImageMeansNoDotsEvenWithAnError` → `testNoDotsImageMeansNoDotsRegardlessOfQuota`
(dropped the now-meaningless error framing), trimmed the error-arm block out of
`testShowsDotsAcrossEveryStyleAndDensity`, and added a new end-to-end
regression (`testUsageStyleKeepsDotsHiddenWhenASessionIsErrored`) that
reproduces the reporter's exact scenario — a real top-level `SessionState`
in `.error` alongside a renderable quota, asserted through `iconImage`
itself rather than the removed parameter.
`testComposedIconForEveryStyleAndModifier` and
`testUsageComposesDotsWhenNoQuotaIsRenderable` (the arm this PR keeps) were
confirmed unaffected — their fixtures carry no errored sessions — and were
left unchanged.

- `swift build && swift test --skip LauncherTestHarness --skip LauncherHarnessTests`:
  547 tests, 0 failures. The seven image-snapshot suites (host-gated) ran
  and passed on this machine rather than skipping.
- `tools/preflight.sh --only swift`: PASS.
- Only `platforms/macos/` was touched, so the Go, web, and replay gates are
  out of scope for this PR and were not run.

## Related

- Fixes #1862
- Removes the menu-bar signal added in #1802 (linked so the trade-off stays
  visible)
- Follow-up tracked in #1864: "#1802's error signal has no surface for
  Usage-style menu bar users"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018TtzBGKFskBE5VwGXeqsJw
