### PR TITLE
test(macos): lock #1862 across both densities and its kept fallback

### DIFF
--- a/platforms/macos/Tests/MenuBarImageBuilderTests.swift
+++ b/platforms/macos/Tests/MenuBarImageBuilderTests.swift
@@ -156,6 +156,82 @@ final class MenuBarImageBuilderTests: XCTestCase {
                        "an errored top-level session must not widen .usage past its quota-only width")
     }
 
+    /// #1862's guarantee has to hold at BOTH densities, and the LOCK above
+    /// pins only `isCompact: false`.
+    ///
+    /// Compact is a modifier on HOW DENSELY the icon draws, never on WHAT it
+    /// draws — that separation is the whole point of #1852. An error arm
+    /// re-added under an `!isCompact` guard would therefore be a content
+    /// decision wearing a density costume, and it would slip past the
+    /// single-density LOCK above without anything going red. Crossing the
+    /// modifier here closes that.
+    ///
+    /// Two errored projects rather than one, so the aggregate (`compact`) and
+    /// per-project (`!compact`) dot layouts differ in width from each other —
+    /// a fixture where both layouts happened to be the same width would pass
+    /// this test for the wrong reason.
+    ///
+    /// Mutation-proved: replacing `shouldShowDotsInUsageStyle`'s
+    /// `return quotaImage == nil` with `return true` — which is #1862's bug,
+    /// re-expressed — turns this red at both densities while
+    /// `testUsageStyleStillShowsDotsWhenErroredAndNoQuotaIsRenderable` below
+    /// stays green.
+    func testUsageStyleKeepsDotsHiddenWhenErroredAtBothDensities() throws {
+        let sessions = [
+            MenuBarFixtures.session(id: "e1", state: .error, project: "alpha"),
+            MenuBarFixtures.session(id: "e2", state: .error, project: "beta"),
+            MenuBarFixtures.sessionWithQuota(),
+        ]
+        for compact in [false, true] {
+            let usage = MenuBarAppearance(style: .usage, isCompact: compact)
+            let quota = try XCTUnwrap(MenuBarImageBuilder.quotaImage(
+                appearance: usage, sessions: sessions, providerKey: nil, now: fixedNow
+            ), "compact=\(compact): the fixture must render a quota, or this proves nothing")
+            let composed = try XCTUnwrap(icon(usage, sessions: sessions))
+            XCTAssertEqual(
+                composed.size.width, quota.size.width, accuracy: 0.01,
+                "compact=\(compact): errored sessions must not widen .usage past quota-only"
+            )
+        }
+    }
+
+    /// LOCK on the arm #1862 KEPT, in the one combination where a later
+    /// change is most likely to drop it by accident: a session is errored AND
+    /// no quota is renderable.
+    ///
+    /// "`.usage` never shows dots" is the wrong summary of #1862, and it is
+    /// the summary someone reads off the test above. Applied here it would
+    /// collapse the icon to `OffFlameImage.menuBar` — the "no sessions
+    /// running" icon — while sessions are in fact running and one of them has
+    /// failed, which is a worse lie about the world than the widening #1862
+    /// removed.
+    ///
+    /// Mutation-proved: replacing that same `return quotaImage == nil` with
+    /// `return false` turns this red while the two width LOCKs above stay
+    /// green.
+    func testUsageStyleStillShowsDotsWhenErroredAndNoQuotaIsRenderable() throws {
+        // acrossProjects carries no rate-limit data, so the quota half cannot
+        // render — see its doc, which names this as its intended use.
+        var sessions = MenuBarFixtures.acrossProjects(2)
+        sessions.append(MenuBarFixtures.session(id: "e1", state: .error, project: "gamma"))
+        let usage = MenuBarAppearance(style: .usage, isCompact: false)
+        XCTAssertNil(
+            MenuBarImageBuilder.quotaImage(
+                appearance: usage, sessions: sessions, providerKey: nil, now: fixedNow
+            ),
+            "this fixture must render NO quota, or the fallback under test never runs"
+        )
+        let dots = try XCTUnwrap(MenuBarImageBuilder.dotsImage(
+            appearance: usage, sessions: sessions, projectGroupOrder: []
+        ))
+        let composed = try XCTUnwrap(
+            icon(usage, sessions: sessions),
+            "an errored session with no renderable quota must not collapse the icon"
+        )
+        XCTAssertEqual(composed.size.width, dots.size.width, accuracy: 0.01,
+                       "with no quota to show, .usage falls back to its dots")
+    }
+
     /// LOCK: without a renderable dots image, `.usage` can never show dots —
     /// the guard short-circuits before `quotaImage` is even inspected.
     func testNoDotsImageMeansNoDotsRegardlessOfQuota() {


### PR DESCRIPTION
## Summary

#1863 fixed #1862 and shipped one regression test:
`testUsageStyleKeepsDotsHiddenWhenASessionIsErrored`. It pins a single point —
`.usage`, `isCompact: false`, one errored session, quota renderable.

Two ways the fix can silently come undone are outside that point. This PR
locks both. **Tests only; no source change.**

### 1. The compact modifier is not crossed

#1852's whole point is that density decides HOW DENSELY the icon draws, never
WHAT it draws. An error arm re-added under an `!isCompact` guard would be a
content decision wearing a density costume, and the single-density LOCK would
stay green through it.

`testUsageStyleKeepsDotsHiddenWhenErroredAtBothDensities` crosses the
modifier. It uses **two** errored projects rather than one, so the aggregate
(`compact`) and per-project (`!compact`) layouts differ in width from each
other — a fixture where both happened to measure the same would pass for the
wrong reason.

### 2. The arm #1862 KEPT is not pinned against an error

"`.usage` never shows dots" is the wrong summary of #1862, and it is the
summary a reader takes from the existing test. Applied to the
no-renderable-quota case it collapses the icon to `OffFlameImage.menuBar` —
the "no sessions running" icon — while sessions are in fact running and one of
them has failed. That is a worse lie about the world than the widening #1862
removed.

`testUsageStyleStillShowsDotsWhenErroredAndNoQuotaIsRenderable` pins the
fallback in exactly the combination a later change is most likely to drop it:
errored **and** no quota.

## Test evidence — mutation-proved, not merely green

Both are LOCKs on shipped behaviour, so neither has a "before the fix" to run
red. Per AGENTS.md ("anything a change *adds* … mutate the thing it protects
instead"), I mutated `shouldShowDotsInUsageStyle` and confirmed each test
kills a **distinct** mutation.

**Mutation A** — `return quotaImage == nil` → `return true`, which is #1862's
bug re-expressed:

```
MenuBarImageBuilderTests.swift:191: error: ...testUsageStyleKeepsDotsHiddenWhenErroredAtBothDensities :
  XCTAssertEqualWithAccuracy failed: ("98.0") is not equal to ("50.0") +/- ("0.01")
  - compact=false: errored sessions must not widen .usage past quota-only
MenuBarImageBuilderTests.swift:191: error: ...testUsageStyleKeepsDotsHiddenWhenErroredAtBothDensities :
  XCTAssertEqualWithAccuracy failed: ("45.3") is not equal to ("20.8") +/- ("0.01")
  - compact=true: errored sessions must not widen .usage past quota-only
```

Both densities fail, at different widths — which also demonstrates the two
fixtures are genuinely distinct. The fallback LOCK stayed green.

**Mutation B** — the same line → `return false`:

```
MenuBarImageBuilderTests.swift:227: error: ...testUsageStyleStillShowsDotsWhenErroredAndNoQuotaIsRenderable :
  XCTUnwrap failed: expected non-nil value of type "NSImage"
  - an errored session with no renderable quota must not collapse the icon
```

The icon collapses to nil — the exact failure described above. Both width
LOCKs stayed green.

Each mutation was reverted immediately; `git diff` against the source file is
empty on this branch.

## Fixtures fail loudly rather than vacuously

AGENTS.md: "a verification mechanism must fail loudly when it cannot run."
Each test asserts its own fixture is valid before asserting the behaviour —
`XCTUnwrap` on a quota that must render, `XCTAssertNil` on one that must not.
A fixture that drifts (stops carrying rate-limit data, or starts carrying it)
fails by name instead of passing for a reason nobody checked.

## Gates

- `swift build && swift test --skip LauncherTestHarness --skip LauncherHarnessTests`:
  **549 tests, 0 failures** (547 before, +2 here).
- `tools/preflight.sh --only swift`: **PASS**.
- Only `platforms/macos/Tests/` is touched, so the Go, web, and replay gates
  are out of scope for this PR and were not run.

## Related

- Locks the fix from #1863 (issue #1862)
- Does not address #1864, which tracks the missing error surface for Usage users

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018TtzBGKFskBE5VwGXeqsJw
