### PR TITLE
docs(agents): never open an issue nobody asked for

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -236,6 +236,13 @@ Linux-only bugs unless you pass `--linux`.
 
 ## Task Management
 - Use github issues to track tickets
+- **Never open an issue nobody asked for.** Filing into the tracker is an
+  outward-facing action, and the maintainer decides what gets tracked. A
+  finding worth recording goes in the final answer, the PR body, or a comment
+  on the issue already in play — name it there and ask before filing. This
+  binds transitively: never put "open a follow-up issue" in a subagent brief
+  unless that issue was requested, or it lands in the tracker without the
+  maintainer ever seeing the instruction that created it.
 - Break down larger tasks into tasks using a task tool (e.g. todowrite in opencode or TaskCreate in claude code)
 - An agent picking up an issue should self-assign before starting work
   (`gh issue edit <N> --add-assignee @me`), so others can see it's actively


### PR DESCRIPTION
## Summary

Adds one rule under `## Task Management`: never open a GitHub issue nobody
asked for.

Filing into the tracker is an outward-facing action, and the maintainer
decides what gets tracked. Nothing in AGENTS.md said so, so an agent that
found something worth recording had no reason not to file it.

The rule binds transitively, which is the half that needs stating: an agent
can satisfy "don't file unasked" itself while putting "open a follow-up
issue" in a subagent brief. The issue then reaches the tracker without the
maintainer ever seeing the instruction that created it.

The rule names where a finding goes instead — the final answer, the PR body,
or a comment on the issue already in play — so it removes a filing route
without removing the ability to record something.

## Gates

- `tools/agents-md-lint.sh`: PASS — **250 of 400 lines** after this change.
- `tools/preflight.sh --changed --budget 540` ran as the pre-push hook: the
  `tools/lib shell-lib tests`, `state-vocabulary lint` and `gofmt` gates PASS;
  every other gate SKIP, since this diff touches one Markdown file.

Documentation only. No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018TtzBGKFskBE5VwGXeqsJw
