### PR TITLE
fix(classifier): keep terminal errors after idle prompts

### DIFF
--- a/core/application/services/state_classifier.go
+++ b/core/application/services/state_classifier.go
@@ -262,9 +262,18 @@ var stateRules = []stateRule{
 		// ready. Live-only — the hold is only ever placed while the finished
 		// turn is still idle (and never under replay), so this rule is inert
 		// for every non-hook path.
+		//
+		// This notification must not mask a terminal session error (#1871). The
+		// agent stopped because the turn failed, not because it awaits user
+		// input. ErrorPhaseTerminal also says that only the next user turn can
+		// clear the failure, so idle_prompt must not mask it in the meantime.
+		// Retrying and unknown-phase errors keep the prior hook precedence: they
+		// do not carry that terminal verdict.
 		id:     string(session.SignalIdlePrompt),
 		signal: session.SignalIdlePrompt,
-		when:   func(_ string, m *session.SessionMetrics) bool { return m.IdlePromptPending },
+		when: func(_ string, m *session.SessionMetrics) bool {
+			return m.IdlePromptPending && !hasTerminalSessionError(m)
+		},
 		decide: toState(session.StateWaiting, "idle prompt hook → waiting"),
 	},
 	{
@@ -278,10 +287,12 @@ var stateRules = []stateRule{
 		// reads true and agent_done would route it to ready — a session that
 		// failed, reported as finished, painted green. That is the exact
 		// defect the fourth state exists to fix, so the failure verdict has to
-		// outrank the finished-turn verdict. Below the five waiting rules
-		// above, because a session blocked on a human is actionable now while
-		// a past failure is not, and because those rules include hook-tier
-		// rows a transcript-tier rule must never preempt.
+		// outrank the finished-turn verdict. Below the waiting rules above,
+		// because a session blocked on a human is actionable now while a past
+		// failure is not, and because those rules include hook-tier rows a
+		// transcript-tier rule must never preempt. The idle_prompt rule is
+		// mutually exclusive with this one for terminal failures: an idle
+		// notification cannot recover them.
 		//
 		// WHY THE HookTurnDone GUARD, rather than a bare nil check. An
 		// authoritative Stop hook means a turn completed, so the failure is
@@ -434,6 +445,13 @@ func ClassifyStateTiered(currentState string, metrics *session.SessionMetrics) S
 	// future edit that removes it degrades to "no transition" rather than to
 	// an out-of-range panic.
 	return StateVerdict{State: currentState}
+}
+
+// hasTerminalSessionError reports whether the adapter said that the current
+// failure ended the turn. It uses ErrorPhase rather than an adapter-specific
+// Class value because the phase owns recovery semantics across adapters.
+func hasTerminalSessionError(metrics *session.SessionMetrics) bool {
+	return metrics.SessionError != nil && metrics.SessionError.Phase == session.ErrorPhaseTerminal
 }
 
 // transitionTo returns (target, reason) when currentState differs from

--- a/core/application/services/state_classifier_error_idle_prompt_test.go
+++ b/core/application/services/state_classifier_error_idle_prompt_test.go
@@ -1,0 +1,31 @@
+package services
+
+import (
+	"testing"
+
+	"irrlicht/core/domain/session"
+)
+
+// TestClassify_TerminalUsageLimitOutranksIdlePrompt is the regression test
+// for #1871. Claude Code reports the terminal HTTP 429 first, then sends an
+// idle_prompt notification about a minute later. That notification is not a
+// recovery event, so it must not mask the standing failure with waiting.
+func TestClassify_TerminalUsageLimitOutranksIdlePrompt(t *testing.T) {
+	status := 429
+	v := ClassifyStateTiered(session.StateError, &session.SessionMetrics{
+		LastEventType:     "turn_done",
+		IdlePromptPending: true,
+		SessionError: &session.SessionError{
+			Phase:      session.ErrorPhaseTerminal,
+			Class:      "rate_limit",
+			HTTPStatus: &status,
+		},
+	})
+
+	if v.State != session.StateError {
+		t.Errorf("state = %q, want error — idle_prompt is not recovery from a terminal usage limit", v.State)
+	}
+	if v.Rule != string(session.SignalSessionError) {
+		t.Errorf("rule = %q, want %q", v.Rule, session.SignalSessionError)
+	}
+}


### PR DESCRIPTION
## Summary

Keep a terminal session error visible when a later Claude Code `idle_prompt` hook arrives. The error remains red until a real recovery event occurs.

## Changes

- Exclude terminal session errors from the `idle_prompt → waiting` classifier rule.
- Use the cross-adapter `ErrorPhaseTerminal` value instead of the Claude-specific `rate_limit` class.
- Add a named regression test for the live HTTP 429 transition shape.

## Red-first evidence

The new regression test failed before the classifier change:

```text
--- FAIL: TestClassify_TerminalUsageLimitOutranksIdlePrompt (0.00s)
    state_classifier_test.go:869: state = "waiting", want error — idle_prompt is not recovery from a terminal usage limit
    state_classifier_test.go:872: rule = "idle_prompt", want "session_error"
FAIL
FAIL    irrlicht/core/application/services
```

## Test plan

- [x] Focused classifier regression tests
- [x] Full `core/application/services` package
- [x] `tools/preflight.sh --only go`
- [x] `tools/preflight.sh --only web`
- [x] `tools/preflight.sh --only arch`
- [x] `tools/preflight.sh --only tools`
- [x] `tools/preflight.sh --only skills`
- [x] `tools/preflight.sh --only posix`
- [x] `tools/preflight.sh --only bash`
- [x] `tools/preflight.sh --only security`
- [x] Scoped pre-push checks

The security scan reported seven existing Go toolchain warnings. It found no blocking application result.

## Scope

No frontend change is required. The macOS app and web dashboard already render the domain `error` state.

## Related issues

Closes #1871

🤖 Generated with [Claude Code](https://claude.com/claude-code)