### PR TITLE
test(factory): harden driver teardown checker

### DIFF
--- a/tools/lib/driverteardown-checker-mutations_test.sh
+++ b/tools/lib/driverteardown-checker-mutations_test.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+# Permanent checker-side mutation evidence for driverteardown (#1829).
+#
+# The package fixtures mutate drivers. These rows mutate the checker itself.
+# Each exact source mutation must make the focused Go test fail and name the
+# behavior that the mutation removed. tools/mutate.sh owns exact-once matching,
+# byte-safe restoration, and the clean-tree proof.
+set -uo pipefail
+
+DIR=$(cd "$(dirname "$0")" && pwd)
+REPO_ROOT=$(cd "$DIR/../.." && pwd)
+MUTATE_SH=$REPO_ROOT/tools/mutate.sh
+PACKAGE=./tools/onboarding-factory/internal/driverteardown/...
+
+need() { command -v "$1" >/dev/null 2>&1 || { echo "FAIL: driverteardown-checker-mutations — $1 not found" >&2; exit 1; }; }
+need bash
+need git
+need go
+need grep
+
+if [[ ! -x "$MUTATE_SH" ]]; then
+  echo "FAIL: driverteardown-checker-mutations — $MUTATE_SH is missing or not executable" >&2
+  exit 1
+fi
+
+if [[ -n "$(git -C "$REPO_ROOT" status --porcelain)" ]]; then
+  echo "driverteardown-checker-mutations: CANNOT RUN — tools/mutate.sh needs a clean worktree" >&2
+  echo "  Commit or clean up, then run: bash tools/lib/driverteardown-checker-mutations_test.sh" >&2
+  if [[ -n "${CI:-}" || -n "${MUTATION_FIXTURES_STRICT:-}" ]]; then
+    echo "FAIL: driverteardown-checker-mutations — dirty worktree in CI/strict mode" >&2
+    exit 1
+  fi
+  exit 0
+fi
+
+baseline=$(cd "$REPO_ROOT" && go test "$PACKAGE" -count=1 2>&1)
+baseline_rc=$?
+if [[ $baseline_rc -ne 0 ]]; then
+  echo "FAIL: driverteardown-checker-mutations — unmutated package failed; mutation results would prove nothing" >&2
+  echo "$baseline" | sed 's/^/      | /'
+  exit 1
+fi
+
+fails=0
+
+# assert_mutation_red <label> <file> <anchor> <replacement> <test-regex> <expected-output>
+assert_mutation_red() {
+  local label=$1 file=$2 anchor=$3 replacement=$4 test_regex=$5 expected=$6
+  local out rc
+
+  out=$(cd "$REPO_ROOT" && "$MUTATE_SH" "$file" "$anchor" "$replacement" \
+    go test "$PACKAGE" -run "$test_regex" -count=1 -v 2>&1)
+  rc=$?
+  if [[ $rc -ne 0 ]]; then
+    echo "FAIL: $label — tools/mutate.sh refused with exit $rc" >&2
+    echo "$out" | sed 's/^/      | /'
+    fails=$((fails + 1))
+    return
+  fi
+  if ! grep -qE ' exit=[1-9][0-9]* ===$' <<<"$out"; then
+    echo "FAIL: $label — the focused Go test stayed green under the mutation" >&2
+    echo "$out" | sed 's/^/      | /'
+    fails=$((fails + 1))
+    return
+  fi
+  if ! grep -qF -- "$expected" <<<"$out"; then
+    echo "FAIL: $label — the Go test failed for the wrong reason; expected $expected" >&2
+    echo "$out" | sed 's/^/      | /'
+    fails=$((fails + 1))
+    return
+  fi
+  echo "ok  $label"
+}
+
+CHECKER=tools/onboarding-factory/internal/driverteardown/driverteardown.go
+NAMEFLOW=tools/onboarding-factory/internal/driverteardown/nameflow.go
+SHELLSOURCE=tools/onboarding-factory/internal/driverteardown/shellsource.go
+
+assert_mutation_red \
+  'INV-1 step-dispatch narrowing' \
+  "$CHECKER" \
+  'case st.Func == "" && isStepDispatchArm(st):' \
+  'case false:' \
+  '^TestCheckerGradesEveryFixture$/^inv1_step_dispatch_case_arm_ok\.sh$' \
+  '--- FAIL: TestCheckerGradesEveryFixture/inv1_step_dispatch_case_arm_ok.sh'
+
+assert_mutation_red \
+  'INV-1 top-level kill-site recognition' \
+  "$CHECKER" \
+  'return "this top-level teardown", true' \
+  'return "", false' \
+  '^TestCheckerGradesEveryFixture$/^inv1_gated_final_sweep\.sh$' \
+  '--- FAIL: TestCheckerGradesEveryFixture/inv1_gated_final_sweep.sh'
+
+assert_mutation_red \
+  'INV-3 positions keyed by function definition' \
+  "$NAMEFLOW" \
+  'f.markPos(funcRef{file: path, name: st.Func}, positional)' \
+  'f.markPos(funcRef{name: st.Func}, positional)' \
+  '^TestCheckerGradesEveryFixture$/^inv3_shadowed_alloc_slot_ok\.sh$' \
+  '--- FAIL: TestCheckerGradesEveryFixture/inv3_shadowed_alloc_slot_ok.sh'
+
+assert_mutation_red \
+  'unterminated quote refusal' \
+  "$SHELLSOURCE" \
+  $'\tif open != 0 {\n\t\treturn "", nil, 0, fmt.Errorf(' \
+  $'\tif false {\n\t\treturn "", nil, 0, fmt.Errorf(' \
+  '^TestCheckerRefusesRatherThanReportingClean$/^vacuous_unterminated_quote\.sh$' \
+  '--- FAIL: TestCheckerRefusesRatherThanReportingClean/vacuous_unterminated_quote.sh'
+
+assert_mutation_red \
+  'INV-4 fail-closed shape remains graded' \
+  "$CHECKER" \
+  $'func (q staleVerdict) failsClosed() bool {\n\tfor _, a := range q.ep.assigns(q.src, q.write.v) {' \
+  $'func (q staleVerdict) failsClosed() bool {\n\treturn true\n\tfor _, a := range q.ep.assigns(q.src, q.write.v) {' \
+  '^TestCheckerGradesEveryFixture$/^inv4_unconditional_write\.sh$' \
+  '--- FAIL: TestCheckerGradesEveryFixture/inv4_unconditional_write.sh'
+
+assert_mutation_red \
+  'graded refusal keeps prior findings' \
+  "$CHECKER" \
+  'return refuse(findings, err)' \
+  'return nil, err' \
+  '^TestARefusalStillNamesTheFindingThatCausedIt$' \
+  '--- FAIL: TestARefusalStillNamesTheFindingThatCausedIt'
+
+assert_mutation_red \
+  'INV-4 guarded-sentinel shape remains accepted' \
+  "$CHECKER" \
+  'case q.ep.setsAny(q.src, others):' \
+  'case false:' \
+  '^TestCheckerGradesEveryFixture$/^inv4_renamed_sentinel_ok\.sh$' \
+  '--- FAIL: TestCheckerGradesEveryFixture/inv4_renamed_sentinel_ok.sh'
+
+assert_mutation_red \
+  'INV-3 mint-site recognition' \
+  "$NAMEFLOW" \
+  $'func composedLiteral(word string) (string, bool) {\n\tif _, _, isVar := soleVar(word); isVar {' \
+  $'func composedLiteral(word string) (string, bool) {\n\treturn "", false\n\tif _, _, isVar := soleVar(word); isVar {' \
+  '^TestCheckerGradesEveryFixture$/^good_driver\.sh$' \
+  '--- FAIL: TestCheckerGradesEveryFixture/good_driver.sh'
+
+# The comment guard is a separate obligation from the eight checker mutations.
+assert_mutation_red \
+  'cross-file shell line-number comment guard' \
+  "$CHECKER" \
+  $'// a tidy-up. Locate that reader with:\n//' \
+  $'// a tidy-up. The reader is at run-cell.sh:443. Locate it with:\n//' \
+  '^TestPackageCommentsDoNotUseCrossFileLineNumbers$' \
+  'hard-coded cross-file shell line'
+
+assert_mutation_red \
+  'inline shell line-number comment guard' \
+  'tools/onboarding-factory/internal/driverteardown/testdata/good_driver.sh' \
+  '  tmux kill-session -t "$SESSION" 2>/dev/null || true' \
+  '  tmux kill-session -t "$SESSION" 2>/dev/null || true;# run-cell.sh:443' \
+  '^TestPackageCommentsDoNotUseCrossFileLineNumbers$' \
+  'hard-coded cross-file shell line'
+
+if [[ $fails -gt 0 ]]; then
+  echo "driverteardown-checker-mutations: $fails FAILED" >&2
+  exit 1
+fi
+echo 'driverteardown-checker-mutations: ALL PASS'

--- a/tools/onboarding-factory/internal/driverteardown/catalog.go
+++ b/tools/onboarding-factory/internal/driverteardown/catalog.go
@@ -1,0 +1,107 @@
+package driverteardown
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// AgentsDir is the catalog directory holding one subdirectory per adapter.
+const AgentsDir = "replaydata/agents"
+
+// DriverName is the file every onboarded adapter carries.
+const DriverName = "driver-interactive.sh"
+
+// libDir holds the shell libraries the drivers source. They participate in the
+// analysis (alloc_slot lives there, and so does the slot bookkeeping a session
+// name flows through) but are never themselves reported: they are shared, so a
+// finding there would be raised once per adapter against a file no adapter owns.
+const libDir = "replaydata/_lib/drive"
+
+// Adapters lists every adapter in the catalog that ships a driver, read from
+// disk so an adapter onboarded tomorrow is graded without being listed here.
+func Adapters(root string) ([]string, error) {
+	entries, err := os.ReadDir(filepath.Join(root, AgentsDir))
+	if err != nil {
+		return nil, fmt.Errorf("reading the adapter catalog: %w", err)
+	}
+	var out []string
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		driverPath := filepath.Join(root, AgentsDir, e.Name(), DriverName)
+		if _, err := os.Lstat(driverPath); err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				continue
+			}
+			return nil, fmt.Errorf("checking %s: %w", driverPath, err)
+		}
+		if _, err := os.Stat(driverPath); err != nil {
+			return nil, fmt.Errorf("checking %s: %w", driverPath, err)
+		}
+		out = append(out, e.Name())
+	}
+	if len(out) == 0 {
+		return nil, fmt.Errorf("no adapter under %s ships a %s — a broken scan and an empty "+
+			"catalog must not be the same answer", filepath.Join(root, AgentsDir), DriverName)
+	}
+	sort.Strings(out)
+	return out, nil
+}
+
+// LoadDriver reads one adapter's driver plus every shell library it CAN source
+// — the shared drive libs and the adapter's own sibling scripts.
+//
+// "Can", not "does": the whole _lib/drive directory is globbed for every
+// adapter, because a driver's `source` lines are computed paths
+// (`"$_DRIVE_LIB/slots.sh"`, `"$(dirname "${BASH_SOURCE[0]}")/turn-count.sh"`)
+// and libraries source one another, so resolving the real set statically would
+// itself be a place this package could be wrong — and getting it wrong DOWNWARD
+// turns a resolvable trap handler into a refusal for the whole fleet.
+//
+// The cost is that every adapter is handed definitions it never sources. That
+// is why nameFlow keys positional facts on a funcRef rather than on a bare
+// function name: see funcRef for the two `alloc_slot`s this collides.
+func LoadDriver(root, adapter string) (File, []File, error) {
+	path := filepath.Join(root, AgentsDir, adapter, DriverName)
+	src, err := os.ReadFile(path) // #nosec G304 -- built from the repo root and a scanned adapter slug
+	if err != nil {
+		return File{}, nil, fmt.Errorf("reading %s's driver: %w", adapter, err)
+	}
+	driver := File{Path: path, Src: string(src)}
+
+	var libs []File
+	for _, dir := range []string{filepath.Join(root, libDir), filepath.Join(root, AgentsDir, adapter)} {
+		found, err := readShellDir(dir, path)
+		if err != nil {
+			return File{}, nil, err
+		}
+		libs = append(libs, found...)
+	}
+	return driver, libs, nil
+}
+
+// readShellDir reads every non-test .sh file in dir except skip.
+func readShellDir(dir, skip string) ([]File, error) {
+	matches, err := filepath.Glob(filepath.Join(dir, "*.sh"))
+	if err != nil {
+		return nil, err
+	}
+	var out []File
+	for _, m := range matches {
+		if m == skip || strings.HasSuffix(m, "_test.sh") {
+			continue
+		}
+		b, err := os.ReadFile(m) // #nosec G304 -- a path returned by Glob over a repo directory
+		if err != nil {
+			return nil, fmt.Errorf("reading %s: %w", m, err)
+		}
+		out = append(out, File{Path: m, Src: string(b)})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Path < out[j].Path })
+	return out, nil
+}

--- a/tools/onboarding-factory/internal/driverteardown/catalog_test.go
+++ b/tools/onboarding-factory/internal/driverteardown/catalog_test.go
@@ -1,0 +1,60 @@
+package driverteardown
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestAdaptersRefusesAnUnreadableDriverEntry(t *testing.T) {
+	root := t.TempDir()
+	validDir := filepath.Join(root, AgentsDir, "valid")
+	brokenDir := filepath.Join(root, AgentsDir, "broken")
+	for _, dir := range []string{validDir, brokenDir} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("create adapter directory %s: %v", dir, err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(validDir, DriverName), []byte("#!/bin/sh\n"), 0o644); err != nil {
+		t.Fatalf("write valid driver: %v", err)
+	}
+	brokenDriver := filepath.Join(brokenDir, DriverName)
+	if err := os.Symlink(DriverName, brokenDriver); err != nil {
+		t.Fatalf("create self-referential driver link: %v", err)
+	}
+
+	adapters, err := Adapters(root)
+	if err == nil {
+		t.Fatalf("Adapters returned %v and no error; the broken driver was silently omitted", adapters)
+	}
+	if !strings.Contains(err.Error(), "broken") {
+		t.Fatalf("Adapters error %q does not name the broken adapter", err)
+	}
+}
+
+func TestAdaptersRefusesADanglingDriverEntry(t *testing.T) {
+	root := t.TempDir()
+	validDir := filepath.Join(root, AgentsDir, "valid")
+	brokenDir := filepath.Join(root, AgentsDir, "broken")
+	for _, dir := range []string{validDir, brokenDir} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("create adapter directory %s: %v", dir, err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(validDir, DriverName), []byte("#!/bin/sh\n"), 0o644); err != nil {
+		t.Fatalf("write valid driver: %v", err)
+	}
+	brokenDriver := filepath.Join(brokenDir, DriverName)
+	if err := os.Symlink("missing-driver.sh", brokenDriver); err != nil {
+		t.Fatalf("create dangling driver link: %v", err)
+	}
+
+	adapters, err := Adapters(root)
+	if err == nil {
+		t.Fatalf("Adapters returned %v and no error; the dangling driver was silently omitted", adapters)
+	}
+	if !strings.Contains(err.Error(), "broken") {
+		t.Fatalf("Adapters error %q does not name the broken adapter", err)
+	}
+}

--- a/tools/onboarding-factory/internal/driverteardown/comment_citations_test.go
+++ b/tools/onboarding-factory/internal/driverteardown/comment_citations_test.go
@@ -1,0 +1,162 @@
+package driverteardown
+
+import (
+	"bufio"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+var crossFileShellLine = regexp.MustCompile(
+	`[A-Za-z0-9_./-]+\.sh:[0-9]+|[A-Za-z0-9_./-]+\.sh[^\n]*\n[^\n]*:[0-9]+`,
+)
+
+// TestPackageCommentsDoNotUseCrossFileLineNumbers keeps explanations tied to
+// named shell constructs and reproducible searches. Recording drivers and
+// their callers change often, so a copied line number becomes false without
+// changing the code it describes.
+func TestPackageCommentsDoNotUseCrossFileLineNumbers(t *testing.T) {
+	t.Helper()
+	goFiles, err := filepath.Glob("*.go")
+	if err != nil {
+		t.Fatalf("discover Go files: %v", err)
+	}
+	if len(goFiles) == 0 {
+		t.Fatal("no Go files discovered; the comment guard scanned nothing")
+	}
+
+	comments := 0
+	fset := token.NewFileSet()
+	for _, path := range goFiles {
+		file, err := parser.ParseFile(fset, path, nil, parser.ParseComments)
+		if err != nil {
+			t.Fatalf("parse comments in %s: %v", path, err)
+		}
+		for _, group := range file.Comments {
+			comments++
+			assertNoCrossFileShellLine(t, path, group.Text())
+		}
+	}
+
+	shellFiles, err := filepath.Glob(filepath.Join("testdata", "*.sh"))
+	if err != nil {
+		t.Fatalf("discover fixture shell files: %v", err)
+	}
+	if len(shellFiles) == 0 {
+		t.Fatal("no fixture shell files discovered; the comment guard scanned no shell fixtures")
+	}
+	for _, path := range shellFiles {
+		comments += checkShellCommentBlocks(t, path)
+	}
+	if comments == 0 {
+		t.Fatal("no comments discovered; the comment guard asserted nothing")
+	}
+}
+
+func checkShellCommentBlocks(t *testing.T, path string) int {
+	t.Helper()
+	f, err := os.Open(path) // #nosec G304 -- paths come from the package fixture glob
+	if err != nil {
+		t.Fatalf("open shell fixture %s: %v", path, err)
+	}
+	defer f.Close()
+
+	count := 0
+	var block strings.Builder
+	flush := func() {
+		if block.Len() == 0 {
+			return
+		}
+		count++
+		assertNoCrossFileShellLine(t, path, block.String())
+		block.Reset()
+	}
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if strings.HasPrefix(line, "#") {
+			block.WriteString(strings.TrimSpace(strings.TrimPrefix(line, "#")))
+			block.WriteByte('\n')
+			continue
+		}
+		if comment, ok := shellComment(line); ok {
+			count++
+			assertNoCrossFileShellLine(t, path, comment)
+		}
+		flush()
+	}
+	flush()
+	if err := scanner.Err(); err != nil {
+		t.Fatalf("scan shell fixture %s: %v", path, err)
+	}
+	return count
+}
+
+// shellComment returns an inline comment using the same word-boundary rules as
+// shellWordsOpen. Quoted hashes and hashes inside expansions are shell data.
+func shellComment(line string) (string, bool) {
+	wordOpen := false
+	rs := []rune(line)
+	for i := 0; i < len(rs); i++ {
+		c := rs[i]
+		switch {
+		case c == '\\' && i+1 < len(rs):
+			wordOpen = true
+			i++
+		case c == '#' && !wordOpen:
+			return string(rs[i+1:]), true
+		case c == ' ' || c == '\t':
+			wordOpen = false
+		case c == '\'' || c == '"':
+			j, _ := scanQuoted(rs, i)
+			wordOpen = true
+			i = j
+		case opensExpansion(rs, i):
+			wordOpen = true
+			i = scanExpansion(rs, i)
+		case c == ';' || c == '|' || c == '&' || c == '(' || c == ')':
+			wordOpen = false
+		default:
+			wordOpen = true
+		}
+	}
+	return "", false
+}
+
+func TestShellCommentUsesShellWordBoundaries(t *testing.T) {
+	tests := []struct {
+		name string
+		line string
+		want string
+		ok   bool
+	}{
+		{name: "space boundary", line: "value=1 # run-cell.sh:443", want: " run-cell.sh:443", ok: true},
+		{name: "separator boundary", line: "value=1;# run-cell.sh:443", want: " run-cell.sh:443", ok: true},
+		{name: "open parenthesis boundary", line: "values=(# run-cell.sh:443", want: " run-cell.sh:443", ok: true},
+		{name: "close parenthesis boundary", line: "value=1)# run-cell.sh:443", want: " run-cell.sh:443", ok: true},
+		{name: "single quoted data", line: "value='# run-cell.sh:443'"},
+		{name: "double quoted data", line: `value="# run-cell.sh:443"`},
+		{name: "parameter operator", line: "value=${source#run-cell.sh:443}"},
+		{name: "escaped hash", line: `value=\#run-cell.sh:443`},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, ok := shellComment(test.line)
+			if got != test.want || ok != test.ok {
+				t.Fatalf("shellComment(%q) = %q, %v; want %q, %v", test.line, got, ok, test.want, test.ok)
+			}
+		})
+	}
+}
+
+func assertNoCrossFileShellLine(t *testing.T, path, comment string) {
+	t.Helper()
+	for _, match := range crossFileShellLine.FindAllString(comment, -1) {
+		t.Errorf("%s comment has a hard-coded cross-file shell line %q; name the construct and "+
+			"the git grep command that finds it", path, match)
+	}
+}

--- a/tools/onboarding-factory/internal/driverteardown/driverteardown.go
+++ b/tools/onboarding-factory/internal/driverteardown/driverteardown.go
@@ -77,24 +77,9 @@ package driverteardown
 
 import (
 	"fmt"
-	"os"
-	"path/filepath"
 	"regexp"
-	"sort"
 	"strings"
 )
-
-// AgentsDir is the catalog directory holding one subdirectory per adapter.
-const AgentsDir = "replaydata/agents"
-
-// DriverName is the file every onboarded adapter carries.
-const DriverName = "driver-interactive.sh"
-
-// libDir holds the shell libraries the drivers source. They participate in the
-// analysis (alloc_slot lives there, and so does the slot bookkeeping a session
-// name flows through) but are never themselves reported: they are shared, so a
-// finding there would be raised once per adapter against a file no adapter owns.
-const libDir = "replaydata/_lib/drive"
 
 // aliveGate names the anti-pattern INV-1 forbids at a teardown site.
 //
@@ -117,9 +102,12 @@ var aliveGate = regexp.MustCompile(`(?i)alive`)
 // `-`-delimited field.
 const pidField = "$$"
 
-// exitReasonFile is the staging contract's verdict file — the one run-cell.sh
-// reads at :443 with `|| echo "unknown"`, which is why an EXIT trap that writes
-// it unconditionally is a behaviour CHANGE and not just a tidy-up.
+// exitReasonFile is the staging contract's verdict file. The `DRIVER_REASON`
+// assignment in run-cell.sh reads it with `|| echo "unknown"`, which is why an
+// EXIT trap that writes it unconditionally is a behaviour CHANGE and not just
+// a tidy-up. Locate that reader with:
+//
+//	git grep -n 'DRIVER_REASON=.*driver\.exit-reason.*echo "unknown"' -- tools/onboarding-factory/scripts/run-cell.sh
 //
 // It is a filename, not a variable name, and that is what makes matching it
 // legitimate where matching `SES_ALIVE` was a named-anti-pattern compromise: it
@@ -635,9 +623,10 @@ func gatedOnLiveness(st Statement) bool {
 // variable still at the value it had when the trap was armed.
 //
 // WHY THIS EXISTS, and why it arrived a day after INV-1/INV-2. Before #1825 an
-// aborting driver wrote NO driver.exit-reason at all, and run-cell.sh:443 reads
-// that absence as `unknown`. Adding an EXIT trap to stop a leak — INV-2's whole
-// demand — turns the absence into whatever the verdict variable happens to hold,
+// aborting driver wrote NO driver.exit-reason at all, and the `DRIVER_REASON`
+// reader described at exitReasonFile reads that absence as `unknown`. Adding an
+// EXIT trap to stop a leak — INV-2's whole demand — turns the absence into
+// whatever the verdict variable happens to hold,
 // which on an abort before any step ran is its initialiser: `ok`. So the fix for
 // "a driver that leaks while reporting success" can manufacture "a driver that
 // reports success for a run that never formed a verdict". The agent fixing aider
@@ -741,8 +730,8 @@ func (q staleVerdict) grade() *Finding {
 	return &Finding{
 		Invariant: "INV-4", Path: q.src.Path, Line: q.trap.line, Excerpt: q.trap.body,
 		Detail: fmt.Sprintf("this EXIT-trap handler can write %s with $%s still at its initial "+
-			"value %q: %s. Before an EXIT trap existed, an abort wrote NO %s and run-cell.sh:443 "+
-			"read the absence as `unknown`; a handler that writes the initialiser turns that into "+
+			"value %q: %s. Before an EXIT trap existed, an abort wrote NO %s and run-cell.sh's "+
+			"`DRIVER_REASON` reader read the absence as `unknown`; a handler that writes the initialiser turns that into "+
 			"a verdict the run never formed — on a ticket whose subject is a driver claiming "+
 			"success while leaking. Either guard the write on a sentinel the epilogue sets "+
 			"unconditionally at top level (aider's `REACHED_EPILOGUE`), or start $%s at a fault "+
@@ -1025,346 +1014,4 @@ func carriesPIDField(literal string) bool {
 		}
 	}
 	return false
-}
-
-type mintSite struct {
-	line    int
-	literal string
-}
-
-// funcRef identifies ONE function definition: the file it is written in, plus
-// its name.
-//
-// Keying positional facts on the bare NAME was a defect. LoadDriver globs the
-// whole replaydata/_lib/drive directory and hands every adapter every file in
-// it, sourced or not, and two different `alloc_slot`s exist (`git grep -n
-// 'alloc_slot()' -- replaydata`): the shared _lib/drive/slots.sh takes the tmux
-// session name at argument 1, while claudecode's private one, defined in its own
-// driver, takes it at argument 2. On one bare key
-// both positions get marked, and a literal at the wrong position is then graded
-// as a session name — a false INV-3 against a correct driver.
-//
-// It does not fire today, and that was measured rather than assumed: the flow
-// resolves claudecode to {2} and codex to {1} with no contamination, but only
-// because claudecode never touches SESSION or SES_SESSION, so slots.sh's `sess`
-// never becomes name-carrying in claudecode's pass. One driver that used the
-// shared slot model AND kept a `SESSION` alias would light it.
-// inv3_shadowed_alloc_slot_ok.sh is that driver.
-type funcRef struct {
-	file string
-	name string
-}
-
-// nameFlow is the fixpoint of "what carries a tmux session name".
-type nameFlow struct {
-	vars  map[string]bool          // variable names
-	pos   map[funcRef]map[int]bool // one DEFINITION -> its name-carrying argument positions
-	def   map[string]string        // function name -> the file whose definition a call resolves to
-	seeds []mintSite               // names written inline at the launch itself
-	all   []*Source
-}
-
-func newNameFlow(src *Source, libs []*Source) (*nameFlow, error) {
-	f := &nameFlow{vars: map[string]bool{}, pos: map[funcRef]map[int]bool{}, def: map[string]string{}}
-	f.all = append([]*Source{src}, libs...)
-	// Which definition a call resolves to: the driver's own if it has one, else
-	// the first library that defines the name. Same precedence as lookupFunc,
-	// and the same reason — a driver that defines a helper the shared libs also
-	// define is shadowing it, because its definition is sourced last.
-	for _, s := range f.all {
-		for _, fn := range s.funcs {
-			if _, seen := f.def[fn.Name]; !seen {
-				f.def[fn.Name] = s.Path
-			}
-		}
-	}
-	if err := f.seed(src); err != nil {
-		return nil, err
-	}
-	for changed := true; changed; {
-		changed = false
-		for _, s := range f.all {
-			if f.propagate(s) {
-				changed = true
-			}
-		}
-	}
-	return f, nil
-}
-
-// seed reads the `-s` argument of every `tmux new-session`. A launch with no
-// `-s` is an error: tmux would name the session itself, which is precisely the
-// state INV-3 exists to forbid, and reading it as "nothing to grade" would let
-// it pass.
-func (f *nameFlow) seed(src *Source) error {
-	launches := 0
-	for _, st := range src.Statements() {
-		args, launched := tmuxArgs(st, "new-session")
-		if !launched {
-			continue
-		}
-		launches++
-		arg, found := flagValue(args, "-s")
-		if !found {
-			return fmt.Errorf("%s:%d: `tmux new-session` with no `-s <name>` — tmux would name "+
-				"the session itself, so it could not carry the driver's PID and no post-run "+
-				"assertion could attribute it", src.Path, st.Line)
-		}
-		if v, _, isVar := soleVar(arg); isVar && v != "" {
-			f.vars[v] = true
-			continue
-		}
-		if lit := unquote(arg); strings.TrimSpace(lit) != "" {
-			f.seeds = append(f.seeds, mintSite{line: st.Line, literal: lit})
-		}
-	}
-	if launches == 0 {
-		return fmt.Errorf("%s: `tmux new-session` appears in the text but not as a parsed "+
-			"command — the lexer and the text disagree, so nothing here was actually graded",
-			src.Path)
-	}
-	return nil
-}
-
-func flagValue(args []string, flag string) (string, bool) {
-	for i, a := range args {
-		if a == flag && i+1 < len(args) {
-			return args[i+1], true
-		}
-	}
-	return "", false
-}
-
-// propagate runs one pass of the closure over one file, reporting whether it
-// learned anything new. The closure grows along two edges, and they are graded
-// separately below because they are different relations: an ASSIGNMENT relates
-// two variables (or a variable and one of its function's parameters), while a
-// CALL relates an argument to the parameter position it lands on.
-func (f *nameFlow) propagate(src *Source) bool {
-	changed := false
-	for _, st := range src.Statements() {
-		if f.propagateAssignments(src.Path, st) {
-			changed = true
-		}
-		if f.propagateCallArgs(st) {
-			changed = true
-		}
-	}
-	return changed
-}
-
-// propagateAssignments walks one statement's `LHS=RHS` pairs. `local sess="$1"`
-// inside a function marks that function's PARAMETER position; everything else
-// relates two variables, and the relation runs both ways — a name-carrying
-// variable assigned from another makes that other name-carrying too, which is
-// what walks the closure backwards from the launch to the text that mints it.
-func (f *nameFlow) propagateAssignments(path string, st Statement) bool {
-	changed := false
-	for _, a := range st.Assignments() {
-		lhs, rhs := a[0], a[2]
-		v, positional, isVar := soleVar(rhs)
-		switch {
-		case !isVar:
-			continue
-		case positional > 0:
-			// Marked against THIS file's definition. Marking a definition no
-			// call resolves to is harmless — nothing reads that key — and
-			// keeping it unconditional keeps the fixpoint a single pass.
-			if !f.vars[lhs] || st.Func == "" {
-				continue
-			}
-			if f.markPos(funcRef{file: path, name: st.Func}, positional) {
-				changed = true
-			}
-		default:
-			if f.vars[lhs] && f.markVar(v) {
-				changed = true
-			}
-			if f.vars[v] && f.markVar(lhs) {
-				changed = true
-			}
-		}
-	}
-	return changed
-}
-
-// propagateCallArgs marks the variable passed at a name-carrying argument
-// position of the ONE definition this call resolves to.
-func (f *nameFlow) propagateCallArgs(st Statement) bool {
-	name, args, ok := st.Command()
-	if !ok {
-		return false
-	}
-	changed := false
-	for n := range f.posOf(name) {
-		if n > len(args) {
-			continue
-		}
-		if v, _, isVar := soleVar(args[n-1]); isVar && v != "" && f.markVar(v) {
-			changed = true
-		}
-	}
-	return changed
-}
-
-// markVar records that a variable carries a tmux session name, reporting whether
-// that was new — which is what drives the fixpoint to a halt.
-func (f *nameFlow) markVar(v string) bool {
-	if f.vars[v] {
-		return false
-	}
-	f.vars[v] = true
-	return true
-}
-
-// markPos records that argument n of one function DEFINITION carries a session
-// name, reporting whether that was new.
-func (f *nameFlow) markPos(fn funcRef, n int) bool {
-	if f.pos[fn][n] {
-		return false
-	}
-	if f.pos[fn] == nil {
-		f.pos[fn] = map[int]bool{}
-	}
-	f.pos[fn][n] = true
-	return true
-}
-
-// posOf gives the name-carrying argument positions of the ONE definition a call
-// to fn resolves to, so a same-named function in a library the driver never
-// sources cannot contribute positions to it.
-func (f *nameFlow) posOf(fn string) map[int]bool {
-	file, ok := f.def[fn]
-	if !ok {
-		return nil
-	}
-	return f.pos[funcRef{file: file, name: fn}]
-}
-
-// mintSites lists every composed literal in ONE file that becomes a tmux
-// session name — assigned to a name-carrying variable, or passed at a
-// name-carrying argument position.
-func (f *nameFlow) mintSites(src *Source) []mintSite {
-	out := append([]mintSite(nil), f.seeds...)
-	add := func(line int, word string) {
-		if lit, ok := composedLiteral(word); ok {
-			out = append(out, mintSite{line: line, literal: lit})
-		}
-	}
-	for _, st := range src.Statements() {
-		for _, a := range st.Assignments() {
-			if lhs, rhs := a[0], a[2]; f.vars[lhs] {
-				add(st.Line, rhs)
-			}
-		}
-		name, args, ok := st.Command()
-		if !ok {
-			continue
-		}
-		for n := range f.posOf(name) {
-			if n > len(args) {
-				continue
-			}
-			add(st.Line, args[n-1])
-		}
-	}
-	sort.SliceStable(out, func(i, j int) bool { return out[i].line < out[j].line })
-	return out
-}
-
-// composedLiteral reports the text a word contributes when it MINTS a name
-// rather than merely carrying one: a bare variable expansion is the closure's
-// business and not a mint site, and empty text names nothing.
-//
-// Deliberately not shared with nameFlow.seed, whose test differs: at a launch,
-// `tmux new-session -s "$1"` is a POSITIONAL expansion that soleVar reports as a
-// variable with no name, and seed grades it as a literal — a session name it
-// cannot trace is one INV-3 must still report on, not one it quietly drops.
-func composedLiteral(word string) (string, bool) {
-	if _, _, isVar := soleVar(word); isVar {
-		return "", false
-	}
-	lit := unquote(word)
-	if strings.TrimSpace(lit) == "" {
-		return "", false
-	}
-	return lit, true
-}
-
-// Adapters lists every adapter in the catalog that ships a driver, read from
-// disk so an adapter onboarded tomorrow is graded without being listed here.
-func Adapters(root string) ([]string, error) {
-	entries, err := os.ReadDir(filepath.Join(root, AgentsDir))
-	if err != nil {
-		return nil, fmt.Errorf("reading the adapter catalog: %w", err)
-	}
-	var out []string
-	for _, e := range entries {
-		if !e.IsDir() {
-			continue
-		}
-		if _, err := os.Stat(filepath.Join(root, AgentsDir, e.Name(), DriverName)); err != nil {
-			continue
-		}
-		out = append(out, e.Name())
-	}
-	if len(out) == 0 {
-		return nil, fmt.Errorf("no adapter under %s ships a %s — a broken scan and an empty "+
-			"catalog must not be the same answer", filepath.Join(root, AgentsDir), DriverName)
-	}
-	sort.Strings(out)
-	return out, nil
-}
-
-// LoadDriver reads one adapter's driver plus every shell library it CAN source
-// — the shared drive libs and the adapter's own sibling scripts.
-//
-// "Can", not "does": the whole _lib/drive directory is globbed for every
-// adapter, because a driver's `source` lines are computed paths
-// (`"$_DRIVE_LIB/slots.sh"`, `"$(dirname "${BASH_SOURCE[0]}")/turn-count.sh"`)
-// and libraries source one another, so resolving the real set statically would
-// itself be a place this package could be wrong — and getting it wrong DOWNWARD
-// turns a resolvable trap handler into a refusal for the whole fleet.
-//
-// The cost is that every adapter is handed definitions it never sources. That
-// is why nameFlow keys positional facts on a funcRef rather than on a bare
-// function name: see funcRef for the two `alloc_slot`s this collides.
-func LoadDriver(root, adapter string) (File, []File, error) {
-	path := filepath.Join(root, AgentsDir, adapter, DriverName)
-	src, err := os.ReadFile(path) // #nosec G304 -- built from the repo root and a scanned adapter slug
-	if err != nil {
-		return File{}, nil, fmt.Errorf("reading %s's driver: %w", adapter, err)
-	}
-	driver := File{Path: path, Src: string(src)}
-
-	var libs []File
-	for _, dir := range []string{filepath.Join(root, libDir), filepath.Join(root, AgentsDir, adapter)} {
-		found, err := readShellDir(dir, path)
-		if err != nil {
-			return File{}, nil, err
-		}
-		libs = append(libs, found...)
-	}
-	return driver, libs, nil
-}
-
-// readShellDir reads every non-test .sh file in dir except skip.
-func readShellDir(dir, skip string) ([]File, error) {
-	matches, err := filepath.Glob(filepath.Join(dir, "*.sh"))
-	if err != nil {
-		return nil, err
-	}
-	var out []File
-	for _, m := range matches {
-		if m == skip || strings.HasSuffix(m, "_test.sh") {
-			continue
-		}
-		b, err := os.ReadFile(m) // #nosec G304 -- a path returned by Glob over a repo directory
-		if err != nil {
-			return nil, fmt.Errorf("reading %s: %w", m, err)
-		}
-		out = append(out, File{Path: m, Src: string(b)})
-	}
-	sort.Slice(out, func(i, j int) bool { return out[i].Path < out[j].Path })
-	return out, nil
 }

--- a/tools/onboarding-factory/internal/driverteardown/driverteardown_test.go
+++ b/tools/onboarding-factory/internal/driverteardown/driverteardown_test.go
@@ -42,6 +42,22 @@ func loadFixture(t *testing.T, name string, libNames ...string) (File, []File) {
 	return File{Path: path, Src: string(src)}, libs
 }
 
+// fixtureLibs is the single catalog of libraries handed to each fixture. Most
+// fixtures use the shared slot model. The exceptions either need no library or
+// define the name at argument two.
+func fixtureLibs(name string) []string {
+	switch name {
+	case "inv3_alloc_arg2_bad.sh", "inv3_alloc_arg2_good.sh":
+		return []string{"slots_pos2.sh"}
+	case "inv2_no_trap.sh", "inv2_trap_without_teardown.sh", "no_tmux_exempt.sh",
+		"vacuous_empty.sh", "vacuous_no_teardown.sh", "vacuous_unclosed_function.sh",
+		"vacuous_unnamed_session.sh", "vacuous_unterminated_quote.sh":
+		return nil
+	default:
+		return []string{"slots.sh"}
+	}
+}
+
 // TestCheckerGradesEveryFixture is the committed mutation evidence this
 // package owes under AGENTS.md.
 //
@@ -74,60 +90,63 @@ func loadFixture(t *testing.T, name string, libNames ...string) (File, []File) {
 func TestCheckerGradesEveryFixture(t *testing.T) {
 	cases := []struct {
 		fixture string
-		libs    []string
 		want    []string // one invariant name per expected finding, in order
 	}{
-		{fixture: "good_driver.sh", libs: []string{"slots.sh"}},
-		{fixture: "inv1_step_guard_ok.sh", libs: []string{"slots.sh"}},
-		{fixture: "inv3_alloc_arg2_good.sh", libs: []string{"slots_pos2.sh"}},
+		{fixture: "good_driver.sh"},
+		{fixture: "inv1_step_guard_ok.sh"},
+		{fixture: "inv3_alloc_arg2_good.sh"},
+		// $0 is positional index zero, not a named variable. RED before the
+		// empty-name guard: nameFlow linked both $0 assignments through vars[""]
+		// and graded NOT_A_SESSION's unrelated literal as a session name.
+		{fixture: "inv3_positional_zero_assignment_ok.sh"},
 		{fixture: "no_tmux_exempt.sh"},
-		{fixture: "inv4_renamed_sentinel_ok.sh", libs: []string{"slots.sh"}},
-		{fixture: "inv4_fail_closed_ok.sh", libs: []string{"slots.sh"}},
-		{fixture: "inv4_literal_verdict_ok.sh", libs: []string{"slots.sh"}},
+		{fixture: "inv4_renamed_sentinel_ok.sh"},
+		{fixture: "inv4_fail_closed_ok.sh"},
+		{fixture: "inv4_literal_verdict_ok.sh"},
 		// A multi-line `awk '…'` program: the join this package needs, and the
 		// thing a `#`-is-a-comment rule could end early. A LOCK — green before
 		// the shellsource.go fix and after it.
-		{fixture: "quote_multiline_awk_ok.sh", libs: []string{"slots.sh"}},
+		{fixture: "quote_multiline_awk_ok.sh"},
 		// copilot's top-level `while … case` dispatch, carrying kiro-cli's
 		// legitimate SES_ALIVE entry check. RED before the classification was
 		// narrowed: the arm was graded as "this end-of-run teardown".
-		{fixture: "inv1_step_dispatch_case_arm_ok.sh", libs: []string{"slots.sh"}},
+		{fixture: "inv1_step_dispatch_case_arm_ok.sh"},
 		// A driver with its OWN alloc_slot (name at argument 2), handed the
 		// shared slots.sh (name at argument 1) that it never sources. RED before
 		// nameFlow keyed positions on a definition instead of a bare name: the
 		// uuid at argument 1 was graded as a session name.
-		{fixture: "inv3_shadowed_alloc_slot_ok.sh", libs: []string{"slots.sh"}},
+		{fixture: "inv3_shadowed_alloc_slot_ok.sh"},
 
-		{fixture: "inv1_gated_trap.sh", libs: []string{"slots.sh"}, want: []string{"INV-1"}},
-		{fixture: "inv1_gated_final_sweep.sh", libs: []string{"slots.sh"}, want: []string{"INV-1"}},
+		{fixture: "inv1_gated_trap.sh", want: []string{"INV-1"}},
+		{fixture: "inv1_gated_final_sweep.sh", want: []string{"INV-1"}},
 		// A comment glued to code, whose apostrophe used to be read as an
 		// unterminated quote: everything below it was swallowed, INV-1 reported
 		// CLEAN, and `sites` stayed non-zero so the vacuity guard saw nothing.
-		{fixture: "inv1_comment_glued_to_code.sh", libs: []string{"slots.sh"}, want: []string{"INV-1"}},
+		{fixture: "inv1_comment_glued_to_code.sh", want: []string{"INV-1"}},
 		// A trailing `case "$EXIT_REASON" in` — a top-level `case` that no loop
 		// re-enters — is teardown, so the step-dispatch narrowing must not
 		// excuse it.
-		{fixture: "inv1_gated_case_at_exit.sh", libs: []string{"slots.sh"}, want: []string{"INV-1"}},
+		{fixture: "inv1_gated_case_at_exit.sh", want: []string{"INV-1"}},
 		{fixture: "inv2_no_trap.sh", want: []string{"INV-2"}},
 		{fixture: "inv2_trap_without_teardown.sh", want: []string{"INV-2"}},
-		{fixture: "inv3_no_pid.sh", libs: []string{"slots.sh"}, want: []string{"INV-3"}},
-		{fixture: "inv3_glued_pid.sh", libs: []string{"slots.sh"}, want: []string{"INV-3"}},
-		{fixture: "inv3_alloc_arg2_bad.sh", libs: []string{"slots_pos2.sh"}, want: []string{"INV-3"}},
+		{fixture: "inv3_no_pid.sh", want: []string{"INV-3"}},
+		{fixture: "inv3_glued_pid.sh", want: []string{"INV-3"}},
+		{fixture: "inv3_alloc_arg2_bad.sh", want: []string{"INV-3"}},
 		// The shadowed-alloc_slot driver with a genuinely PID-less name at
 		// argument 2. ONE finding: the fix must silence the contaminated
 		// position without silencing the real one, and this row is what tells
 		// those two apart. It reported TWO before the fix.
-		{fixture: "inv3_shadowed_alloc_slot_bad.sh", libs: []string{"slots.sh"}, want: []string{"INV-3"}},
-		{fixture: "inv4_unconditional_write.sh", libs: []string{"slots.sh"}, want: []string{"INV-4"}},
-		{fixture: "inv4_guard_consults_only_itself.sh", libs: []string{"slots.sh"}, want: []string{"INV-4"}},
-		{fixture: "inv4_sentinel_never_set.sh", libs: []string{"slots.sh"}, want: []string{"INV-4"}},
-		{fixture: "inv4_guard_reassigns_initial.sh", libs: []string{"slots.sh"}, want: []string{"INV-4"}},
-		{fixture: "inv4_case_arm_is_not_the_epilogue.sh", libs: []string{"slots.sh"}, want: []string{"INV-4"}},
+		{fixture: "inv3_shadowed_alloc_slot_bad.sh", want: []string{"INV-3"}},
+		{fixture: "inv4_unconditional_write.sh", want: []string{"INV-4"}},
+		{fixture: "inv4_guard_consults_only_itself.sh", want: []string{"INV-4"}},
+		{fixture: "inv4_sentinel_never_set.sh", want: []string{"INV-4"}},
+		{fixture: "inv4_guard_reassigns_initial.sh", want: []string{"INV-4"}},
+		{fixture: "inv4_case_arm_is_not_the_epilogue.sh", want: []string{"INV-4"}},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.fixture, func(t *testing.T) {
-			driver, libs := loadFixture(t, tc.fixture, tc.libs...)
+			driver, libs := loadFixture(t, tc.fixture, fixtureLibs(tc.fixture)...)
 			got, err := CheckDriver(driver, libs)
 			if err != nil {
 				t.Fatalf("checking %s: %v", tc.fixture, err)
@@ -152,14 +171,13 @@ func TestCheckerGradesEveryFixture(t *testing.T) {
 func TestCheckerRefusesRatherThanReportingClean(t *testing.T) {
 	cases := []struct {
 		fixture string
-		libs    []string
 		wantErr string // a fragment of the checker's own message
 	}{
 		{fixture: "vacuous_empty.sh", wantErr: "is empty"},
 		{fixture: "vacuous_no_teardown.sh", wantErr: "INV-1 graded nothing here"},
 		{fixture: "vacuous_unnamed_session.sh", wantErr: "with no `-s <name>`"},
 		{fixture: "vacuous_unclosed_function.sh", wantErr: "is never closed by a `}`"},
-		{fixture: "vacuous_uninitialised_verdict.sh", libs: []string{"slots.sh"},
+		{fixture: "vacuous_uninitialised_verdict.sh",
 			wantErr: "INV-4 has no initial value to compare against"},
 		// A quote still open at end of file: the joiner walks to EOF and the
 		// word scanner swallows every remaining statement into one quoted word.
@@ -169,13 +187,13 @@ func TestCheckerRefusesRatherThanReportingClean(t *testing.T) {
 			wantErr: "is never closed before the end of the file"},
 		// Refuses AND carries a finding. TestARefusalStillNamesTheFindingThatCausedIt
 		// is where that second half is graded; this row pins that it still refuses.
-		{fixture: "inv2_no_trap_no_sweep.sh", libs: []string{"slots.sh"},
+		{fixture: "inv2_no_trap_no_sweep.sh",
 			wantErr: "INV-1 graded nothing here"},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.fixture, func(t *testing.T) {
-			driver, libs := loadFixture(t, tc.fixture, tc.libs...)
+			driver, libs := loadFixture(t, tc.fixture, fixtureLibs(tc.fixture)...)
 			got, err := CheckDriver(driver, libs)
 			if err == nil {
 				t.Fatalf("%s returned no error (%d finding(s)) — this input could not be graded, "+

--- a/tools/onboarding-factory/internal/driverteardown/nameflow.go
+++ b/tools/onboarding-factory/internal/driverteardown/nameflow.go
@@ -1,0 +1,275 @@
+package driverteardown
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+type mintSite struct {
+	line    int
+	literal string
+}
+
+// funcRef identifies ONE function definition: the file it is written in, plus
+// its name.
+//
+// Keying positional facts on the bare NAME was a defect. LoadDriver globs the
+// whole replaydata/_lib/drive directory and hands every adapter every file in
+// it, sourced or not, and two different `alloc_slot`s exist (`git grep -n
+// 'alloc_slot()' -- replaydata`): the shared _lib/drive/slots.sh takes the tmux
+// session name at argument 1, while claudecode's private one, defined in its own
+// driver, takes it at argument 2. On one bare key
+// both positions get marked, and a literal at the wrong position is then graded
+// as a session name — a false INV-3 against a correct driver.
+//
+// It does not fire today, and that was measured rather than assumed: the flow
+// resolves claudecode to {2} and codex to {1} with no contamination, but only
+// because claudecode never touches SESSION or SES_SESSION, so slots.sh's `sess`
+// never becomes name-carrying in claudecode's pass. One driver that used the
+// shared slot model AND kept a `SESSION` alias would light it.
+// inv3_shadowed_alloc_slot_ok.sh is that driver.
+type funcRef struct {
+	file string
+	name string
+}
+
+// nameFlow is the fixpoint of "what carries a tmux session name".
+type nameFlow struct {
+	vars  map[string]bool          // variable names
+	pos   map[funcRef]map[int]bool // one DEFINITION -> its name-carrying argument positions
+	def   map[string]string        // function name -> the file whose definition a call resolves to
+	seeds []mintSite               // names written inline at the launch itself
+	all   []*Source
+}
+
+func newNameFlow(src *Source, libs []*Source) (*nameFlow, error) {
+	f := &nameFlow{vars: map[string]bool{}, pos: map[funcRef]map[int]bool{}, def: map[string]string{}}
+	f.all = append([]*Source{src}, libs...)
+	// Which definition a call resolves to: the driver's own if it has one, else
+	// the first library that defines the name. Same precedence as lookupFunc,
+	// and the same reason — a driver that defines a helper the shared libs also
+	// define is shadowing it, because its definition is sourced last.
+	for _, s := range f.all {
+		for _, fn := range s.funcs {
+			if _, seen := f.def[fn.Name]; !seen {
+				f.def[fn.Name] = s.Path
+			}
+		}
+	}
+	if err := f.seed(src); err != nil {
+		return nil, err
+	}
+	for changed := true; changed; {
+		changed = false
+		for _, s := range f.all {
+			if f.propagate(s) {
+				changed = true
+			}
+		}
+	}
+	return f, nil
+}
+
+// seed reads the `-s` argument of every `tmux new-session`. A launch with no
+// `-s` is an error: tmux would name the session itself, which is precisely the
+// state INV-3 exists to forbid, and reading it as "nothing to grade" would let
+// it pass.
+func (f *nameFlow) seed(src *Source) error {
+	launches := 0
+	for _, st := range src.Statements() {
+		args, launched := tmuxArgs(st, "new-session")
+		if !launched {
+			continue
+		}
+		launches++
+		arg, found := flagValue(args, "-s")
+		if !found {
+			return fmt.Errorf("%s:%d: `tmux new-session` with no `-s <name>` — tmux would name "+
+				"the session itself, so it could not carry the driver's PID and no post-run "+
+				"assertion could attribute it", src.Path, st.Line)
+		}
+		if v, _, isVar := soleVar(arg); isVar && v != "" {
+			f.vars[v] = true
+			continue
+		}
+		if lit := unquote(arg); strings.TrimSpace(lit) != "" {
+			f.seeds = append(f.seeds, mintSite{line: st.Line, literal: lit})
+		}
+	}
+	if launches == 0 {
+		return fmt.Errorf("%s: `tmux new-session` appears in the text but not as a parsed "+
+			"command — the lexer and the text disagree, so nothing here was actually graded",
+			src.Path)
+	}
+	return nil
+}
+
+func flagValue(args []string, flag string) (string, bool) {
+	for i, a := range args {
+		if a == flag && i+1 < len(args) {
+			return args[i+1], true
+		}
+	}
+	return "", false
+}
+
+// propagate runs one pass of the closure over one file, reporting whether it
+// learned anything new. The closure grows along two edges, and they are graded
+// separately below because they are different relations: an ASSIGNMENT relates
+// two variables (or a variable and one of its function's parameters), while a
+// CALL relates an argument to the parameter position it lands on.
+func (f *nameFlow) propagate(src *Source) bool {
+	changed := false
+	for _, st := range src.Statements() {
+		if f.propagateAssignments(src.Path, st) {
+			changed = true
+		}
+		if f.propagateCallArgs(st) {
+			changed = true
+		}
+	}
+	return changed
+}
+
+// propagateAssignments walks one statement's `LHS=RHS` pairs. `local sess="$1"`
+// inside a function marks that function's PARAMETER position; everything else
+// relates two variables, and the relation runs both ways — a name-carrying
+// variable assigned from another makes that other name-carrying too, which is
+// what walks the closure backwards from the launch to the text that mints it.
+func (f *nameFlow) propagateAssignments(path string, st Statement) bool {
+	changed := false
+	for _, a := range st.Assignments() {
+		lhs, rhs := a[0], a[2]
+		v, positional, isVar := soleVar(rhs)
+		switch {
+		case !isVar:
+			continue
+		case positional == 0 && v == "":
+			// $0 names the current script. It is a positional expansion, but it
+			// is not a function argument and it is not a named shell variable.
+			continue
+		case positional > 0:
+			// Marked against THIS file's definition. Marking a definition no
+			// call resolves to is harmless — nothing reads that key — and
+			// keeping it unconditional keeps the fixpoint a single pass.
+			if !f.vars[lhs] || st.Func == "" {
+				continue
+			}
+			if f.markPos(funcRef{file: path, name: st.Func}, positional) {
+				changed = true
+			}
+		default:
+			if f.vars[lhs] && f.markVar(v) {
+				changed = true
+			}
+			if f.vars[v] && f.markVar(lhs) {
+				changed = true
+			}
+		}
+	}
+	return changed
+}
+
+// propagateCallArgs marks the variable passed at a name-carrying argument
+// position of the ONE definition this call resolves to.
+func (f *nameFlow) propagateCallArgs(st Statement) bool {
+	name, args, ok := st.Command()
+	if !ok {
+		return false
+	}
+	changed := false
+	for n := range f.posOf(name) {
+		if n > len(args) {
+			continue
+		}
+		if v, _, isVar := soleVar(args[n-1]); isVar && v != "" && f.markVar(v) {
+			changed = true
+		}
+	}
+	return changed
+}
+
+// markVar records that a variable carries a tmux session name, reporting whether
+// that was new — which is what drives the fixpoint to a halt.
+func (f *nameFlow) markVar(v string) bool {
+	if f.vars[v] {
+		return false
+	}
+	f.vars[v] = true
+	return true
+}
+
+// markPos records that argument n of one function DEFINITION carries a session
+// name, reporting whether that was new.
+func (f *nameFlow) markPos(fn funcRef, n int) bool {
+	if f.pos[fn][n] {
+		return false
+	}
+	if f.pos[fn] == nil {
+		f.pos[fn] = map[int]bool{}
+	}
+	f.pos[fn][n] = true
+	return true
+}
+
+// posOf gives the name-carrying argument positions of the ONE definition a call
+// to fn resolves to, so a same-named function in a library the driver never
+// sources cannot contribute positions to it.
+func (f *nameFlow) posOf(fn string) map[int]bool {
+	file, ok := f.def[fn]
+	if !ok {
+		return nil
+	}
+	return f.pos[funcRef{file: file, name: fn}]
+}
+
+// mintSites lists every composed literal in ONE file that becomes a tmux
+// session name — assigned to a name-carrying variable, or passed at a
+// name-carrying argument position.
+func (f *nameFlow) mintSites(src *Source) []mintSite {
+	out := append([]mintSite(nil), f.seeds...)
+	add := func(line int, word string) {
+		if lit, ok := composedLiteral(word); ok {
+			out = append(out, mintSite{line: line, literal: lit})
+		}
+	}
+	for _, st := range src.Statements() {
+		for _, a := range st.Assignments() {
+			if lhs, rhs := a[0], a[2]; f.vars[lhs] {
+				add(st.Line, rhs)
+			}
+		}
+		name, args, ok := st.Command()
+		if !ok {
+			continue
+		}
+		for n := range f.posOf(name) {
+			if n > len(args) {
+				continue
+			}
+			add(st.Line, args[n-1])
+		}
+	}
+	sort.SliceStable(out, func(i, j int) bool { return out[i].line < out[j].line })
+	return out
+}
+
+// composedLiteral reports the text a word contributes when it MINTS a name
+// rather than merely carrying one: a bare variable expansion is the closure's
+// business and not a mint site, and empty text names nothing.
+//
+// Deliberately not shared with nameFlow.seed, whose test differs: at a launch,
+// `tmux new-session -s "$1"` is a POSITIONAL expansion that soleVar reports as a
+// variable with no name, and seed grades it as a literal — a session name it
+// cannot trace is one INV-3 must still report on, not one it quietly drops.
+func composedLiteral(word string) (string, bool) {
+	if _, _, isVar := soleVar(word); isVar {
+		return "", false
+	}
+	lit := unquote(word)
+	if strings.TrimSpace(lit) == "" {
+		return "", false
+	}
+	return lit, true
+}

--- a/tools/onboarding-factory/internal/driverteardown/testdata/inv3_positional_zero_assignment_ok.sh
+++ b/tools/onboarding-factory/internal/driverteardown/testdata/inv3_positional_zero_assignment_ok.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TMUX_NAME="fixture-onboard-$$"
+SESSION="$TMUX_NAME"
+
+cleanup() {
+  [[ -n "$SESSION" ]] && tmux kill-session -t "$SESSION" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+tmux new-session -d -s "$TMUX_NAME" "fixture-agent"
+
+# $0 is a positional expansion with index zero, not a named shell variable.
+# Neither assignment can make NOT_A_SESSION carry the tmux session name.
+TMUX_NAME=$0
+NOT_A_SESSION=$0
+NOT_A_SESSION="not-a-session"
+
+tmux kill-session -t "$SESSION" 2>/dev/null || true

--- a/tools/onboarding-factory/internal/driverteardown/testdata/inv4_unconditional_write.sh
+++ b/tools/onboarding-factory/internal/driverteardown/testdata/inv4_unconditional_write.sh
@@ -5,7 +5,7 @@
 # it does NOT do is distinguish "the script finished and EXIT_REASON is its
 # verdict" from "the script aborted before forming one", so an abort writes the
 # initialiser `ok` where, before any trap existed, it wrote nothing at all and
-# run-cell.sh:443 read the absence as `unknown`.
+# run-cell.sh's `DRIVER_REASON` assignment read the absence as `unknown`.
 _DRIVE_LIB="$(dirname "${BASH_SOURCE[0]}")/lib"
 source "$_DRIVE_LIB/slots.sh"
 

--- a/tools/onboarding-factory/internal/driverteardown/testdata/verdicts.golden
+++ b/tools/onboarding-factory/internal/driverteardown/testdata/verdicts.golden
@@ -1,0 +1,200 @@
+=== fixture/good_driver.sh ===
+CLEAN
+
+=== fixture/inv1_comment_glued_to_code.sh ===
+INV-1 testdata/inv1_comment_glued_to_code.sh:51: this top-level teardown is gated on a liveness flag. That flag is a driver INTENT, not an observation — nothing anywhere re-derives it from `tmux has-session` — so a step that asked the TUI to exit and was not obeyed clears it, teardown skips the kill, and the pane plus the agent process survive the run while driver.exit-reason still says ok. Gate on session-name PRESENCE instead: `[[ -n "${SES_SESSION[$i]:-}" ]]`, the shape scripts/templates/drive-interactive.sh.tmpl already ships.
+    tmux kill-session -t "$SESSION" 2>/dev/null || true
+
+=== fixture/inv1_gated_case_at_exit.sh ===
+INV-1 testdata/inv1_gated_case_at_exit.sh:44: this top-level teardown is gated on a liveness flag. That flag is a driver INTENT, not an observation — nothing anywhere re-derives it from `tmux has-session` — so a step that asked the TUI to exit and was not obeyed clears it, teardown skips the kill, and the pane plus the agent process survive the run while driver.exit-reason still says ok. Gate on session-name PRESENCE instead: `[[ -n "${SES_SESSION[$i]:-}" ]]`, the shape scripts/templates/drive-interactive.sh.tmpl already ships.
+    tmux kill-session -t "$SESSION" 2>/dev/null || true
+
+=== fixture/inv1_gated_final_sweep.sh ===
+INV-1 testdata/inv1_gated_final_sweep.sh:51: this top-level teardown is gated on a liveness flag. That flag is a driver INTENT, not an observation — nothing anywhere re-derives it from `tmux has-session` — so a step that asked the TUI to exit and was not obeyed clears it, teardown skips the kill, and the pane plus the agent process survive the run while driver.exit-reason still says ok. Gate on session-name PRESENCE instead: `[[ -n "${SES_SESSION[$i]:-}" ]]`, the shape scripts/templates/drive-interactive.sh.tmpl already ships.
+    tmux kill-session -t "${SES_SESSION[$i]}" 2>/dev/null || true
+
+=== fixture/inv1_gated_trap.sh ===
+INV-1 testdata/inv1_gated_trap.sh:29: this teardown inside the EXIT-trap handler cleanup() is gated on a liveness flag. That flag is a driver INTENT, not an observation — nothing anywhere re-derives it from `tmux has-session` — so a step that asked the TUI to exit and was not obeyed clears it, teardown skips the kill, and the pane plus the agent process survive the run while driver.exit-reason still says ok. Gate on session-name PRESENCE instead: `[[ -n "${SES_SESSION[$i]:-}" ]]`, the shape scripts/templates/drive-interactive.sh.tmpl already ships.
+    [[ "${SES_ALIVE[$i]:-0}" == "1" ]] && tmux kill-session -t "${SES_SESSION[$i]}" 2>/dev/null || true
+
+=== fixture/inv1_step_dispatch_case_arm_ok.sh ===
+CLEAN
+
+=== fixture/inv1_step_guard_ok.sh ===
+CLEAN
+
+=== fixture/inv2_no_trap.sh ===
+INV-2 testdata/inv2_no_trap.sh: this driver launches the agent under tmux but installs no `trap … EXIT` that tears the session down. Any exit path that does not reach the end of the script — a `set -e` abort mid-launch, a failed jq, an `exit` from a step — then leaves the pane and the agent process alive. See scripts/templates/drive-interactive.sh.tmpl's `cleanup`.
+
+=== fixture/inv2_no_trap_no_sweep.sh ===
+INV-2 testdata/inv2_no_trap_no_sweep.sh: this driver launches the agent under tmux but installs no `trap … EXIT` that tears the session down. Any exit path that does not reach the end of the script — a `set -e` abort mid-launch, a failed jq, an `exit` from a step — then leaves the pane and the agent process alive. See scripts/templates/drive-interactive.sh.tmpl's `cleanup`.
+REFUSED: testdata/inv2_no_trap_no_sweep.sh launches the agent under tmux but has no `tmux kill-session` in its EXIT trap or at top level — INV-1 graded nothing here, and a check that cannot run must say so
+
+  …and this driver was ALREADY in violation before that refusal. The refusal is downstream of what follows, which is the defect to fix:
+  INV-2 testdata/inv2_no_trap_no_sweep.sh: this driver launches the agent under tmux but installs no `trap … EXIT` that tears the session down. Any exit path that does not reach the end of the script — a `set -e` abort mid-launch, a failed jq, an `exit` from a step — then leaves the pane and the agent process alive. See scripts/templates/drive-interactive.sh.tmpl's `cleanup`.
+
+=== fixture/inv2_trap_without_teardown.sh ===
+INV-2 testdata/inv2_trap_without_teardown.sh:21: this driver's `trap … EXIT` handler contains no `tmux kill-session`, so an abort mid-run leaves the pane and the agent process alive. See scripts/templates/drive-interactive.sh.tmpl's `cleanup`.
+
+=== fixture/inv3_alloc_arg2_bad.sh ===
+INV-3 testdata/inv3_alloc_arg2_bad.sh:28: this tmux session name does not carry `$$` as a `-`-delimited field. run-cell.sh keeps no record of the names a driver chose — no staging-contract file carries them, and the driver is backgrounded only so its PID can be captured — so the driver PID embedded in the name is the ONLY join from a run to the sessions it owns, and the post-run leak assertion has nothing to match on without it. A `$$` glued to another token does not count: `-` is the delimiter the assertion splits on, and a glued PID lets a DIFFERENT pid whose digits merely share a prefix match instead.
+    fixture-onboard-$(date +%s)
+
+=== fixture/inv3_alloc_arg2_good.sh ===
+CLEAN
+
+=== fixture/inv3_glued_pid.sh ===
+INV-3 testdata/inv3_glued_pid.sh:28: this tmux session name does not carry `$$` as a `-`-delimited field. run-cell.sh keeps no record of the names a driver chose — no staging-contract file carries them, and the driver is backgrounded only so its PID can be captured — so the driver PID embedded in the name is the ONLY join from a run to the sessions it owns, and the post-run leak assertion has nothing to match on without it. A `$$` glued to another token does not count: `-` is the delimiter the assertion splits on, and a glued PID lets a DIFFERENT pid whose digits merely share a prefix match instead.
+    fixture-onboard$$-$(date +%s)
+
+=== fixture/inv3_no_pid.sh ===
+INV-3 testdata/inv3_no_pid.sh:26: this tmux session name does not carry `$$` as a `-`-delimited field. run-cell.sh keeps no record of the names a driver chose — no staging-contract file carries them, and the driver is backgrounded only so its PID can be captured — so the driver PID embedded in the name is the ONLY join from a run to the sessions it owns, and the post-run leak assertion has nothing to match on without it. A `$$` glued to another token does not count: `-` is the delimiter the assertion splits on, and a glued PID lets a DIFFERENT pid whose digits merely share a prefix match instead.
+    fixture-onboard-$(date +%s)
+
+=== fixture/inv3_positional_zero_assignment_ok.sh ===
+CLEAN
+
+=== fixture/inv3_shadowed_alloc_slot_bad.sh ===
+INV-3 testdata/inv3_shadowed_alloc_slot_bad.sh:56: this tmux session name does not carry `$$` as a `-`-delimited field. run-cell.sh keeps no record of the names a driver chose — no staging-contract file carries them, and the driver is backgrounded only so its PID can be captured — so the driver PID embedded in the name is the ONLY join from a run to the sessions it owns, and the post-run leak assertion has nothing to match on without it. A `$$` glued to another token does not count: `-` is the delimiter the assertion splits on, and a glued PID lets a DIFFERENT pid whose digits merely share a prefix match instead.
+    fixture-onboard-$(date +%s)-r${ACTIVE}
+
+=== fixture/inv3_shadowed_alloc_slot_ok.sh ===
+CLEAN
+
+=== fixture/inv4_case_arm_is_not_the_epilogue.sh ===
+INV-4 testdata/inv4_case_arm_is_not_the_epilogue.sh:35: this EXIT-trap handler can write driver.exit-reason with $EXIT_REASON still at its initial value "ok": the handler writes $EXIT_REASON unconditionally, and nothing between the trap arming and the write can change it. Before an EXIT trap existed, an abort wrote NO driver.exit-reason and run-cell.sh's `DRIVER_REASON` reader read the absence as `unknown`; a handler that writes the initialiser turns that into a verdict the run never formed — on a ticket whose subject is a driver claiming success while leaking. Either guard the write on a sentinel the epilogue sets unconditionally at top level (aider's `REACHED_EPILOGUE`), or start $EXIT_REASON at a fault and promote it on the success path.
+    cleanup() {
+  local i
+  for (( i = 1; i <= N_SLOTS; i++ )); do
+    [[ -n "${SES_SESSION[$i]:-}" ]] && tmux kill-session -t "${SES_SESSION[$i]}" 2>/dev/null || true
+  done
+  echo "$EXIT_REASON" > "$STAGING/driver.exit-reason"
+}
+
+=== fixture/inv4_fail_closed_ok.sh ===
+CLEAN
+
+=== fixture/inv4_guard_consults_only_itself.sh ===
+INV-4 testdata/inv4_guard_consults_only_itself.sh:34: this EXIT-trap handler can write driver.exit-reason with $EXIT_REASON still at its initial value "ok": the only re-assignment of $EXIT_REASON before the write is guarded by nothing but $EXIT_REASON itself, which is equally true on a run that completed. Before an EXIT trap existed, an abort wrote NO driver.exit-reason and run-cell.sh's `DRIVER_REASON` reader read the absence as `unknown`; a handler that writes the initialiser turns that into a verdict the run never formed — on a ticket whose subject is a driver claiming success while leaking. Either guard the write on a sentinel the epilogue sets unconditionally at top level (aider's `REACHED_EPILOGUE`), or start $EXIT_REASON at a fault and promote it on the success path.
+    cleanup() {
+  # The epilogue sets REACHED_EPILOGUE immediately before the final exit, so a
+  # handler that sees it unset knows the script aborted before forming a
+  # verdict and must not write EXIT_REASON's initialiser as one (INV-4).
+  if [[ "$EXIT_REASON" == "ok" ]]; then
+    EXIT_REASON="nonzero(2)"
+  fi
+  local i
+  for (( i = 1; i <= N_SLOTS; i++ )); do
+    [[ -n "${SES_SESSION[$i]:-}" ]] && tmux kill-session -t "${SES_SESSION[$i]}" 2>/dev/null || true
+  done
+  echo "$EXIT_REASON" > "$STAGING/driver.exit-reason"
+}
+
+=== fixture/inv4_guard_reassigns_initial.sh ===
+INV-4 testdata/inv4_guard_reassigns_initial.sh:33: this EXIT-trap handler can write driver.exit-reason with $EXIT_REASON still at its initial value "ok": the guard on the write assigns $EXIT_REASON its own initial value "ok", so it changes nothing. Before an EXIT trap existed, an abort wrote NO driver.exit-reason and run-cell.sh's `DRIVER_REASON` reader read the absence as `unknown`; a handler that writes the initialiser turns that into a verdict the run never formed — on a ticket whose subject is a driver claiming success while leaking. Either guard the write on a sentinel the epilogue sets unconditionally at top level (aider's `REACHED_EPILOGUE`), or start $EXIT_REASON at a fault and promote it on the success path.
+    cleanup() {
+  # The epilogue sets REACHED_EPILOGUE immediately before the final exit, so a
+  # handler that sees it unset knows the script aborted before forming a
+  # verdict and must not write EXIT_REASON's initialiser as one (INV-4).
+  if [[ "$REACHED_EPILOGUE" != "1" && "$EXIT_REASON" == "ok" ]]; then
+    EXIT_REASON="ok"
+  fi
+  local i
+  for (( i = 1; i <= N_SLOTS; i++ )); do
+    [[ -n "${SES_SESSION[$i]:-}" ]] && tmux kill-session -t "${SES_SESSION[$i]}" 2>/dev/null || true
+  done
+  echo "$EXIT_REASON" > "$STAGING/driver.exit-reason"
+}
+
+=== fixture/inv4_literal_verdict_ok.sh ===
+CLEAN
+
+=== fixture/inv4_renamed_sentinel_ok.sh ===
+CLEAN
+
+=== fixture/inv4_sentinel_never_set.sh ===
+INV-4 testdata/inv4_sentinel_never_set.sh:34: this EXIT-trap handler can write driver.exit-reason with $EXIT_REASON still at its initial value "ok": the guard on the write consults $REACHED_EPILOGUE, and nothing assigns any of them unconditionally at top level after the trap is armed and after the last `tmux new-session` — so no amount of progress through the run can change what the handler writes. Before an EXIT trap existed, an abort wrote NO driver.exit-reason and run-cell.sh's `DRIVER_REASON` reader read the absence as `unknown`; a handler that writes the initialiser turns that into a verdict the run never formed — on a ticket whose subject is a driver claiming success while leaking. Either guard the write on a sentinel the epilogue sets unconditionally at top level (aider's `REACHED_EPILOGUE`), or start $EXIT_REASON at a fault and promote it on the success path.
+    cleanup() {
+  # The epilogue sets REACHED_EPILOGUE immediately before the final exit, so a
+  # handler that sees it unset knows the script aborted before forming a
+  # verdict and must not write EXIT_REASON's initialiser as one (INV-4).
+  if [[ "$REACHED_EPILOGUE" != "1" && "$EXIT_REASON" == "ok" ]]; then
+    EXIT_REASON="nonzero(2)"
+  fi
+  local i
+  for (( i = 1; i <= N_SLOTS; i++ )); do
+    [[ -n "${SES_SESSION[$i]:-}" ]] && tmux kill-session -t "${SES_SESSION[$i]}" 2>/dev/null || true
+  done
+  echo "$EXIT_REASON" > "$STAGING/driver.exit-reason"
+}
+
+=== fixture/inv4_unconditional_write.sh ===
+INV-4 testdata/inv4_unconditional_write.sh:28: this EXIT-trap handler can write driver.exit-reason with $EXIT_REASON still at its initial value "ok": the handler writes $EXIT_REASON unconditionally, and nothing between the trap arming and the write can change it. Before an EXIT trap existed, an abort wrote NO driver.exit-reason and run-cell.sh's `DRIVER_REASON` reader read the absence as `unknown`; a handler that writes the initialiser turns that into a verdict the run never formed — on a ticket whose subject is a driver claiming success while leaking. Either guard the write on a sentinel the epilogue sets unconditionally at top level (aider's `REACHED_EPILOGUE`), or start $EXIT_REASON at a fault and promote it on the success path.
+    cleanup() {
+  local i
+  for (( i = 1; i <= N_SLOTS; i++ )); do
+    [[ -n "${SES_SESSION[$i]:-}" ]] && tmux kill-session -t "${SES_SESSION[$i]}" 2>/dev/null || true
+  done
+  echo "$EXIT_REASON" > "$STAGING/driver.exit-reason"
+}
+
+=== fixture/no_tmux_exempt.sh ===
+CLEAN
+
+=== fixture/quote_multiline_awk_ok.sh ===
+CLEAN
+
+=== fixture/vacuous_empty.sh ===
+REFUSED: testdata/vacuous_empty.sh is empty — a driver that cannot be read graded nothing, and a check that cannot run must say so
+
+=== fixture/vacuous_no_teardown.sh ===
+INV-2 testdata/vacuous_no_teardown.sh: this driver launches the agent under tmux but installs no `trap … EXIT` that tears the session down. Any exit path that does not reach the end of the script — a `set -e` abort mid-launch, a failed jq, an `exit` from a step — then leaves the pane and the agent process alive. See scripts/templates/drive-interactive.sh.tmpl's `cleanup`.
+REFUSED: testdata/vacuous_no_teardown.sh launches the agent under tmux but has no `tmux kill-session` in its EXIT trap or at top level — INV-1 graded nothing here, and a check that cannot run must say so
+
+  …and this driver was ALREADY in violation before that refusal. The refusal is downstream of what follows, which is the defect to fix:
+  INV-2 testdata/vacuous_no_teardown.sh: this driver launches the agent under tmux but installs no `trap … EXIT` that tears the session down. Any exit path that does not reach the end of the script — a `set -e` abort mid-launch, a failed jq, an `exit` from a step — then leaves the pane and the agent process alive. See scripts/templates/drive-interactive.sh.tmpl's `cleanup`.
+
+=== fixture/vacuous_unclosed_function.sh ===
+REFUSED: testdata/vacuous_unclosed_function.sh:9: function cleanup() is never closed by a `}` at column 0 — this file's structure cannot be read, and a check that cannot run must say so
+
+=== fixture/vacuous_uninitialised_verdict.sh ===
+REFUSED: testdata/vacuous_uninitialised_verdict.sh:22: the EXIT-trap handler writes $EXIT_REASON to driver.exit-reason, but EXIT_REASON is never assigned unconditionally at top level before the trap is armed — INV-4 has no initial value to compare against and graded nothing, and a check that cannot run must say so
+
+=== fixture/vacuous_unnamed_session.sh ===
+REFUSED: testdata/vacuous_unnamed_session.sh:14: `tmux new-session` with no `-s <name>` — tmux would name the session itself, so it could not carry the driver's PID and no post-run assertion could attribute it
+
+=== fixture/vacuous_unterminated_quote.sh ===
+REFUSED: testdata/vacuous_unterminated_quote.sh:13: a ' quote opened on this line is never closed before the end of the file, so every statement after it is swallowed into one quoted word — this file cannot be read, and a check that cannot run must say so
+
+=== driver/aider ===
+CLEAN
+
+=== driver/antigravity ===
+CLEAN
+
+=== driver/claudecode ===
+CLEAN
+
+=== driver/codex ===
+CLEAN
+
+=== driver/copilot ===
+CLEAN
+
+=== driver/gemini-cli ===
+CLEAN
+
+=== driver/hermes ===
+CLEAN
+
+=== driver/kiro-cli ===
+CLEAN
+
+=== driver/mistral-vibe ===
+CLEAN
+
+=== driver/opencode ===
+CLEAN
+
+=== driver/pi ===
+CLEAN

--- a/tools/onboarding-factory/internal/driverteardown/verdicts_golden_test.go
+++ b/tools/onboarding-factory/internal/driverteardown/verdicts_golden_test.go
@@ -1,0 +1,139 @@
+package driverteardown
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+)
+
+const verdictsGolden = "testdata/verdicts.golden"
+
+// TestVerdictsGolden pins the complete public verdict of every committed
+// fixture and every real recording driver. The focused tests in
+// driverteardown_test.go pin which invariant fires; this golden also pins the
+// Detail and refusal text that tells a driver author what to fix.
+//
+// Refresh with:
+//
+//	UPDATE_REPLAY_GOLDENS=1 go test ./tools/onboarding-factory/internal/driverteardown/... -run TestVerdictsGolden -count=1
+func TestVerdictsGolden(t *testing.T) {
+	got := renderAllVerdicts(t)
+	if os.Getenv("UPDATE_REPLAY_GOLDENS") == "1" {
+		if err := os.WriteFile(verdictsGolden, got, 0o644); err != nil {
+			t.Fatalf("write golden %s: %v", verdictsGolden, err)
+		}
+		return
+	}
+
+	want, err := os.ReadFile(verdictsGolden)
+	if err != nil {
+		t.Fatalf("read golden %s: %v (run with UPDATE_REPLAY_GOLDENS=1 to create)",
+			verdictsGolden, err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("driver-teardown verdicts differ from %s\n"+
+			"run UPDATE_REPLAY_GOLDENS=1 go test ./tools/onboarding-factory/internal/driverteardown/... -run TestVerdictsGolden -count=1 to refresh\n"+
+			"first difference: %s", verdictsGolden, firstVerdictDiff(got, want))
+	}
+}
+
+func renderAllVerdicts(t *testing.T) []byte {
+	t.Helper()
+	var out strings.Builder
+
+	entries, err := os.ReadDir("testdata")
+	if err != nil {
+		t.Fatalf("read fixture directory: %v", err)
+	}
+	var fixtures []string
+	for _, entry := range entries {
+		if !entry.IsDir() && strings.HasSuffix(entry.Name(), ".sh") {
+			fixtures = append(fixtures, entry.Name())
+		}
+	}
+	sort.Strings(fixtures)
+	if len(fixtures) == 0 {
+		t.Fatal("no driver-teardown fixtures discovered; the golden would grade nothing")
+	}
+	for _, name := range fixtures {
+		driver, libs := loadFixture(t, name, fixtureLibs(name)...)
+		findings, checkErr := CheckDriver(driver, libs)
+		writeVerdict(&out, "fixture/"+name, findings, checkErr)
+	}
+
+	root := repoRoot(t)
+	adapters, err := Adapters(root)
+	if err != nil {
+		t.Fatalf("enumerate real recording drivers: %v", err)
+	}
+	if len(adapters) == 0 {
+		t.Fatal("no real recording drivers discovered; the golden would grade no live inputs")
+	}
+	for _, adapter := range adapters {
+		driver, libs, err := LoadDriver(root, adapter)
+		if err != nil {
+			t.Fatalf("load real recording driver %s: %v", adapter, err)
+		}
+		findings, checkErr := CheckDriver(driver, libs)
+		writeVerdict(&out, "driver/"+adapter, findings, checkErr)
+	}
+
+	// Findings from real drivers carry absolute paths. None exists in the
+	// approved baseline, but normalize the root so a future intentional golden
+	// update cannot commit one developer's checkout path.
+	rendered := strings.TrimSuffix(out.String(), "\n")
+	normalized := strings.ReplaceAll(rendered, root+string(filepath.Separator), "<repo>/")
+	return []byte(normalized)
+}
+
+func writeVerdict(out *strings.Builder, name string, findings []Finding, err error) {
+	fmt.Fprintf(out, "=== %s ===\n", name)
+	if len(findings) == 0 && err == nil {
+		out.WriteString("CLEAN\n\n")
+		return
+	}
+	for _, finding := range findings {
+		out.WriteString(finding.String())
+		out.WriteByte('\n')
+	}
+	if err != nil {
+		out.WriteString("REFUSED: ")
+		out.WriteString(err.Error())
+		out.WriteByte('\n')
+	}
+	out.WriteByte('\n')
+}
+
+func firstVerdictDiff(got, want []byte) string {
+	limit := len(got)
+	if len(want) < limit {
+		limit = len(want)
+	}
+	for i := 0; i < limit; i++ {
+		if got[i] != want[i] {
+			return fmt.Sprintf("%s, byte %d: got %q, want %q",
+				verdictHeaderAt(got, i), i, got[i], want[i])
+		}
+	}
+	return fmt.Sprintf("%s, length: got %d bytes, want %d",
+		verdictHeaderAt(got, limit), len(got), len(want))
+}
+
+func verdictHeaderAt(rendered []byte, offset int) string {
+	if offset > len(rendered) {
+		offset = len(rendered)
+	}
+	start := bytes.LastIndex(rendered[:offset], []byte("=== "))
+	if start < 0 {
+		return "before the first verdict header"
+	}
+	end := bytes.IndexByte(rendered[start:], '\n')
+	if end < 0 {
+		return string(rendered[start:])
+	}
+	return string(rendered[start : start+end])
+}


### PR DESCRIPTION
## Summary

- Add a deterministic verdict golden for every fixture and real driver.
- Add 10 permanent mutation checks for the eight checker mutations from #1827 and two comment-citation cases.
- Add a comment citation guard for unstable cross-file shell line numbers.
- Fix `$0` propagation so the script name cannot mark the empty variable as a session name.
- Make the driver catalog fail loudly for unreadable and dangling entries.
- Split the checker into invariant, name-flow, and catalog files.

## Evidence

- Red first: `inv3_positional_zero_assignment_ok.sh` produced a false `INV-3` finding before the `$0` fix. The targeted test passed after the fix.
- Red first: the driver catalog silently omitted a self-linked entry and a dangling entry. It now returns an error for both.
- Golden guard: mutations to a finding detail and a refusal message both failed at the named fixture header.
- Mutation guard: all 10 permanent mutation rows pass. Each row requires its exact target subtest to fail.
- Comment guard: real line-number comments fail. Quoted, escaped, expansion, and parenthesis cases have lock tests.
- Split lock: the package race test and the verdict golden passed before and after the file split.
- High-effort review found catalog and shell-comment boundary gaps. The final review of `8b52261b` found no remaining issue after three independent refutation attempts.
- Full local gates passed: `go`, `web`, `arch`, `tools`, `skills`, `posix`, `bash`, and `security`.
- GitHub passed Linux, Go, web, Swift, architecture, CodeQL, and SonarCloud checks.
- CodeScene failed its advisory profile. It reports that `driverteardown.go` improved from 6.34 to 8.12. Two flagged methods already exist on `main`. The new golden helper has a 9.61 score.
- The bounded pre-push hook passed its completed checks. It reached the 540-second limit in the recording smoke test. The unbounded `go` and `security` groups had already passed in full.

## Design note

The issue states 45 verdicts. The source corpus had 32 fixtures and 11 real drivers, which is 43 input cases. The new `$0` fixture makes 44 input cases. The golden test now derives the corpus from disk, so the count cannot drift by hand.

Closes #1829

🤖 Generated with [Claude Code](https://claude.com/claude-code)
