### PR TITLE
fix(claudecode): keep background completions working

### DIFF
--- a/core/adapters/inbound/agents/claudecode/background_process_test.go
+++ b/core/adapters/inbound/agents/claudecode/background_process_test.go
@@ -294,6 +294,9 @@ func TestParser_TaskNotification_TerminatesBackgroundProcess(t *testing.T) {
 	p := &Parser{}
 	// origin.kind shape, terminal → emits the bg task-id
 	done := p.ParseLine(taskNotifOriginEvent("bc1h56v8v", "completed"))
+	if !done.OriginTaskNotification {
+		t.Error("origin shape must set OriginTaskNotification")
+	}
 	if len(done.TerminatedBackgroundTaskIDs) != 1 || done.TerminatedBackgroundTaskIDs[0] != "bc1h56v8v" {
 		t.Errorf("origin shape: TerminatedBackgroundTaskIDs = %v, want [bc1h56v8v]", done.TerminatedBackgroundTaskIDs)
 	}
@@ -304,6 +307,12 @@ func TestParser_TaskNotification_TerminatesBackgroundProcess(t *testing.T) {
 	}
 	// queued_command attachment shape, terminal → emits the bg task-id
 	att := p.ParseLine(taskNotifAttachmentEvent("bc1h56v8v", "completed"))
+	if !att.Skip {
+		t.Error("attachment shape must stay passive")
+	}
+	if att.OriginTaskNotification {
+		t.Error("attachment shape must not set OriginTaskNotification")
+	}
 	if len(att.TerminatedBackgroundTaskIDs) != 1 || att.TerminatedBackgroundTaskIDs[0] != "bc1h56v8v" {
 		t.Errorf("attachment shape: TerminatedBackgroundTaskIDs = %v, want [bc1h56v8v]", att.TerminatedBackgroundTaskIDs)
 	}
@@ -312,16 +321,18 @@ func TestParser_TaskNotification_TerminatesBackgroundProcess(t *testing.T) {
 func TestTailer_BackgroundProcessCount_ClearedByTaskNotification(t *testing.T) {
 	spawnResult := "Command running in background with ID: bc1h56v8v. Output is being written to: /tmp/x/tasks/bc1h56v8v.output. You will be notified when it completes. To check interim output, use Read on that file path."
 	for _, tc := range []struct {
-		name      string
-		completed map[string]interface{}
+		name          string
+		completed     map[string]interface{}
+		wantLastEvent string
 	}{
-		{"origin.kind shape", taskNotifOriginEvent("bc1h56v8v", "completed")},
-		{"queued_command attachment shape", taskNotifAttachmentEvent("bc1h56v8v", "completed")},
+		{"origin.kind shape", taskNotifOriginEvent("bc1h56v8v", "completed"), "agent_continuation"},
+		{"queued_command attachment shape", taskNotifAttachmentEvent("bc1h56v8v", "completed"), "turn_done"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			path := writeBgTranscript(t, []map[string]interface{}{
 				bashToolUse("toolu_1", "Bash", map[string]interface{}{"command": "sleep 100", "run_in_background": true}),
 				bgSpawnResult("toolu_1", "bc1h56v8v", spawnResult),
+				{"type": "system", "subtype": "turn_duration"},
 				tc.completed,
 			})
 			m, err := tailer.NewTranscriptTailer(path, &Parser{}, "claude-code").TailAndProcess()
@@ -331,6 +342,32 @@ func TestTailer_BackgroundProcessCount_ClearedByTaskNotification(t *testing.T) {
 			if m.BackgroundProcessCount != 0 {
 				t.Fatalf("BackgroundProcessCount = %d, want 0 after task-notification completion", m.BackgroundProcessCount)
 			}
+			if m.LastEventType != tc.wantLastEvent {
+				t.Errorf("LastEventType = %q, want %q", m.LastEventType, tc.wantLastEvent)
+			}
 		})
+	}
+}
+
+// A task-notification for a subagent has no matching Bash background-process
+// entry. It must preserve the preceding turn_done anchor. The background-agent
+// scenario ends with killed subagent notifications and no resumed assistant
+// event, so treating origin.kind alone as a continuation leaves it working
+// forever. This is a lock for the structural ledger-match discriminator in
+// issue #1899.
+func TestTailer_UnmatchedTaskNotification_RemainsPassive(t *testing.T) {
+	path := writeBgTranscript(t, []map[string]interface{}{
+		{"type": "system", "subtype": "turn_duration"},
+		taskNotifOriginEvent("subagent-aecb65d9", "killed"),
+	})
+	m, err := tailer.NewTranscriptTailer(path, &Parser{}, "claude-code").TailAndProcess()
+	if err != nil {
+		t.Fatalf("TailAndProcess: %v", err)
+	}
+	if m.LastEventType != "turn_done" {
+		t.Errorf("LastEventType = %q, want turn_done for unmatched subagent notification", m.LastEventType)
+	}
+	if len(m.SubagentCompletions) != 1 {
+		t.Fatalf("SubagentCompletions = %d, want 1", len(m.SubagentCompletions))
 	}
 }

--- a/core/adapters/inbound/agents/claudecode/background_process_test.go
+++ b/core/adapters/inbound/agents/claudecode/background_process_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
 
 	"irrlicht/core/pkg/tailer"
@@ -292,29 +293,28 @@ func taskNotifAttachmentEvent(taskID, status string) map[string]interface{} {
 
 func TestParser_TaskNotification_TerminatesBackgroundProcess(t *testing.T) {
 	p := &Parser{}
-	// origin.kind shape, terminal → emits the bg task-id
-	done := p.ParseLine(taskNotifOriginEvent("bc1h56v8v", "completed"))
-	if !done.OriginTaskNotification {
-		t.Error("origin shape must set OriginTaskNotification")
+	type result struct {
+		Skip                   bool
+		OriginTaskNotification bool
+		TerminatedIDs          []string
 	}
-	if len(done.TerminatedBackgroundTaskIDs) != 1 || done.TerminatedBackgroundTaskIDs[0] != "bc1h56v8v" {
-		t.Errorf("origin shape: TerminatedBackgroundTaskIDs = %v, want [bc1h56v8v]", done.TerminatedBackgroundTaskIDs)
+	tests := []struct {
+		name  string
+		event map[string]interface{}
+		want  result
+	}{
+		{"terminal origin", taskNotifOriginEvent("bc1h56v8v", "completed"), result{true, true, []string{"bc1h56v8v"}}},
+		{"running origin", taskNotifOriginEvent("bc1h56v8v", "running"), result{true, true, nil}},
+		{"terminal attachment", taskNotifAttachmentEvent("bc1h56v8v", "completed"), result{true, false, []string{"bc1h56v8v"}}},
 	}
-	// running → not terminal
-	running := p.ParseLine(taskNotifOriginEvent("bc1h56v8v", "running"))
-	if len(running.TerminatedBackgroundTaskIDs) != 0 {
-		t.Errorf("running status must not terminate, got %v", running.TerminatedBackgroundTaskIDs)
-	}
-	// queued_command attachment shape, terminal → emits the bg task-id
-	att := p.ParseLine(taskNotifAttachmentEvent("bc1h56v8v", "completed"))
-	if !att.Skip {
-		t.Error("attachment shape must stay passive")
-	}
-	if att.OriginTaskNotification {
-		t.Error("attachment shape must not set OriginTaskNotification")
-	}
-	if len(att.TerminatedBackgroundTaskIDs) != 1 || att.TerminatedBackgroundTaskIDs[0] != "bc1h56v8v" {
-		t.Errorf("attachment shape: TerminatedBackgroundTaskIDs = %v, want [bc1h56v8v]", att.TerminatedBackgroundTaskIDs)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ev := p.ParseLine(tc.event)
+			got := result{ev.Skip, ev.OriginTaskNotification, ev.TerminatedBackgroundTaskIDs}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("task-notification result = %+v, want %+v", got, tc.want)
+			}
+		})
 	}
 }
 

--- a/core/adapters/inbound/agents/claudecode/parser.go
+++ b/core/adapters/inbound/agents/claudecode/parser.go
@@ -393,7 +393,12 @@ func isAgentResumeOrigin(raw map[string]interface{}) bool {
 
 // handleTaskNotification captures subagent-completion signals from the parent
 // transcript's task-notification events. Returns true when the event was a
-// task-notification and the caller should skip it. See issue #134.
+// task-notification and the caller should skip its message content.
+//
+// OriginTaskNotification preserves the structural difference from the passive
+// queued_command attachment handled above. The tailer uses it only when the
+// notification terminates an entry in its background-process ledger; plain
+// subagent notifications remain passive. See issues #134 and #1899.
 func handleTaskNotification(raw map[string]interface{}, ev *tailer.ParsedEvent) bool {
 	if originKind(raw) != "task-notification" {
 		return false
@@ -415,6 +420,7 @@ func handleTaskNotification(raw map[string]interface{}, ev *tailer.ParsedEvent) 
 			}
 		}
 	}
+	ev.OriginTaskNotification = true
 	ev.Skip = true
 	return true
 }

--- a/core/adapters/inbound/agents/claudecode/parser_test.go
+++ b/core/adapters/inbound/agents/claudecode/parser_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -1480,32 +1481,35 @@ func TestParser_TaskNotification_EmitsSubagentCompletion(t *testing.T) {
 	if ev == nil {
 		t.Fatal("expected non-nil event")
 	}
-	if !ev.Skip {
-		t.Error("task-notification must stay out of message-event tracking")
+	type result struct {
+		Skip                   bool
+		OriginTaskNotification bool
+		ClearToolNames         bool
+		StartsNewUserTurn      bool
+		IsUserInterrupt        bool
+		IsToolDenial           bool
+		SubagentCompletions    []tailer.SubagentCompletion
 	}
-	if !ev.OriginTaskNotification {
-		t.Error("task-notification must preserve its origin shape for ledger matching")
+	got := result{
+		Skip:                   ev.Skip,
+		OriginTaskNotification: ev.OriginTaskNotification,
+		ClearToolNames:         ev.ClearToolNames,
+		StartsNewUserTurn:      ev.StartsNewUserTurn(),
+		IsUserInterrupt:        ev.IsUserInterrupt,
+		IsToolDenial:           ev.IsToolDenial,
+		SubagentCompletions:    ev.SubagentCompletions,
 	}
-	if ev.ClearToolNames || ev.StartsNewUserTurn() {
-		t.Error("task-notification must not run genuine-user-turn resets")
+	want := result{
+		Skip:                   true,
+		OriginTaskNotification: true,
+		SubagentCompletions: []tailer.SubagentCompletion{{
+			AgentID:   "af7bf8be5a1b511e4",
+			ToolUseID: "toolu_01WfKzuNdE9j8zVUsTE7twbF",
+			Status:    "completed",
+		}},
 	}
-	if ev.IsUserInterrupt {
-		t.Error("task-notification must not be classified as a user interrupt")
-	}
-	if ev.IsToolDenial {
-		t.Error("task-notification must not be classified as a tool denial")
-	}
-	if len(ev.SubagentCompletions) != 1 {
-		t.Fatalf("expected 1 SubagentCompletion, got %d", len(ev.SubagentCompletions))
-	}
-	got := ev.SubagentCompletions[0]
-	want := tailer.SubagentCompletion{
-		AgentID:   "af7bf8be5a1b511e4",
-		ToolUseID: "toolu_01WfKzuNdE9j8zVUsTE7twbF",
-		Status:    "completed",
-	}
-	if got != want {
-		t.Errorf("SubagentCompletion = %+v, want %+v", got, want)
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("task-notification result = %+v, want %+v", got, want)
 	}
 }
 

--- a/core/adapters/inbound/agents/claudecode/parser_test.go
+++ b/core/adapters/inbound/agents/claudecode/parser_test.go
@@ -1460,8 +1460,8 @@ func TestTranscript_ExitPlanMode_SplitMessage_DetectedAsWaiting(t *testing.T) {
 // TestParser_TaskNotification_EmitsSubagentCompletion is the issue #134
 // regression: parent user line with origin.kind="task-notification" must
 // emit a single SubagentCompletion (parsed task-id, tool-use-id, status),
-// be marked Skip=true so it doesn't pollute LastEventType, and must NOT
-// set IsUserInterrupt or IsToolDenial.
+// preserve its origin marker without genuine-user resets, and must NOT set
+// IsUserInterrupt or IsToolDenial. See issue #1899.
 func TestParser_TaskNotification_EmitsSubagentCompletion(t *testing.T) {
 	p := &Parser{}
 	xmlPayload := "<task-notification>\n" +
@@ -1481,7 +1481,13 @@ func TestParser_TaskNotification_EmitsSubagentCompletion(t *testing.T) {
 		t.Fatal("expected non-nil event")
 	}
 	if !ev.Skip {
-		t.Error("task-notification line must be Skip=true so it doesn't feed LastEventType")
+		t.Error("task-notification must stay out of message-event tracking")
+	}
+	if !ev.OriginTaskNotification {
+		t.Error("task-notification must preserve its origin shape for ledger matching")
+	}
+	if ev.ClearToolNames || ev.StartsNewUserTurn() {
+		t.Error("task-notification must not run genuine-user-turn resets")
 	}
 	if ev.IsUserInterrupt {
 		t.Error("task-notification must not be classified as a user interrupt")

--- a/core/application/services/task_notification_continuation_test.go
+++ b/core/application/services/task_notification_continuation_test.go
@@ -1,0 +1,138 @@
+package services_test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"irrlicht/core/adapters/inbound/agents/claudecode"
+	"irrlicht/core/application/replayengine"
+	"irrlicht/core/application/services"
+	"irrlicht/core/domain/session"
+	"irrlicht/core/pkg/tailer"
+)
+
+// TestClassifyState_TaskNotificationStartsAgentContinuation is the issue #1899
+// regression. Claude Code writes the completed background command as a
+// user-role task-notification, then starts a new inference turn. The
+// notification must replace the preceding turn_done lifecycle anchor while it
+// removes the completed process from the background ledger. Otherwise the
+// classifier sees the stale turn_done and emits a false ready transition.
+func TestClassifyState_TaskNotificationStartsAgentContinuation(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "transcript.jsonl")
+	if err := os.WriteFile(path, nil, 0o644); err != nil {
+		t.Fatalf("create transcript: %v", err)
+	}
+
+	tail := tailer.NewTranscriptTailer(path, &claudecode.Parser{}, "claude-code")
+	appendEvents := func(events ...map[string]interface{}) {
+		t.Helper()
+		f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)
+		if err != nil {
+			t.Fatalf("open transcript: %v", err)
+		}
+		defer f.Close()
+		enc := json.NewEncoder(f)
+		for _, event := range events {
+			if err := enc.Encode(event); err != nil {
+				t.Fatalf("append transcript event: %v", err)
+			}
+		}
+	}
+	readMetrics := func() *session.SessionMetrics {
+		t.Helper()
+		m, err := tail.TailAndProcess()
+		if err != nil {
+			t.Fatalf("TailAndProcess: %v", err)
+		}
+		return replayengine.TailerToDomain(m)
+	}
+	classify := func(m *session.SessionMetrics, want string) {
+		t.Helper()
+		got, _ := services.ClassifyState(session.StateWorking, m)
+		if got != want {
+			t.Fatalf("ClassifyState() = %q, want %q (last event %q, background count %d)",
+				got, want, m.LastEventType, m.BackgroundProcessCount)
+		}
+	}
+
+	const (
+		bashID    = "bkymfen4l"
+		toolUseID = "toolu_background"
+	)
+	appendEvents(
+		map[string]interface{}{
+			"type": "assistant",
+			"message": map[string]interface{}{
+				"stop_reason": "tool_use",
+				"content": []interface{}{map[string]interface{}{
+					"type": "tool_use", "id": toolUseID, "name": "Bash",
+					"input": map[string]interface{}{"command": "sleep 100", "run_in_background": true},
+				}},
+			},
+		},
+		map[string]interface{}{
+			"type":          "user",
+			"toolUseResult": map[string]interface{}{"backgroundTaskId": bashID},
+			"message": map[string]interface{}{
+				"content": []interface{}{map[string]interface{}{
+					"type": "tool_result", "tool_use_id": toolUseID,
+					"content": "Command running in background with ID: " + bashID + ". Output is being written to: /tmp/tasks/" + bashID + ".output. You will be notified when it completes.",
+				}},
+			},
+		},
+	)
+	spawned := readMetrics()
+	if spawned.BackgroundProcessCount != 1 {
+		t.Fatalf("spawn pass background count = %d, want 1", spawned.BackgroundProcessCount)
+	}
+
+	appendEvents(map[string]interface{}{"type": "system", "subtype": "turn_duration"})
+	priorTurnDone := readMetrics()
+	priorTurnDone.HasLiveBackgroundProcess = true // the detector's liveness-probe overlay
+	classify(priorTurnDone, session.StateWorking)
+
+	appendEvents(map[string]interface{}{
+		"type":   "user",
+		"origin": map[string]interface{}{"kind": "task-notification"},
+		"message": map[string]interface{}{
+			"role": "user",
+			"content": "<task-notification><task-id>" + bashID + "</task-id>" +
+				"<tool-use-id>" + toolUseID + "</tool-use-id><status>completed</status></task-notification>",
+		},
+	})
+	continued := readMetrics()
+	if continued.BackgroundProcessCount != 0 {
+		t.Fatalf("notification pass background count = %d, want 0", continued.BackgroundProcessCount)
+	}
+	if len(continued.SubagentCompletions) != 1 {
+		t.Fatalf("notification pass completions = %d, want 1", len(continued.SubagentCompletions))
+	}
+	classify(continued, session.StateWorking)
+
+	appendEvents(map[string]interface{}{
+		"type": "assistant",
+		"message": map[string]interface{}{
+			"stop_reason": "tool_use",
+			"content": []interface{}{map[string]interface{}{
+				"type": "tool_use", "id": "toolu_resumed", "name": "Bash",
+				"input": map[string]interface{}{"command": "git status --short"},
+			}},
+		},
+	})
+	classify(readMetrics(), session.StateWorking)
+
+	appendEvents(map[string]interface{}{
+		"type": "user",
+		"message": map[string]interface{}{
+			"content": []interface{}{map[string]interface{}{
+				"type": "tool_result", "tool_use_id": "toolu_resumed", "content": "clean",
+			}},
+		},
+	})
+	classify(readMetrics(), session.StateWorking)
+
+	appendEvents(map[string]interface{}{"type": "system", "subtype": "turn_duration"})
+	classify(readMetrics(), session.StateReady)
+}

--- a/core/application/services/task_notification_continuation_test.go
+++ b/core/application/services/task_notification_continuation_test.go
@@ -13,56 +13,71 @@ import (
 	"irrlicht/core/pkg/tailer"
 )
 
-// TestClassifyState_TaskNotificationStartsAgentContinuation is the issue #1899
-// regression. Claude Code writes the completed background command as a
-// user-role task-notification, then starts a new inference turn. The
-// notification must replace the preceding turn_done lifecycle anchor while it
-// removes the completed process from the background ledger. Otherwise the
-// classifier sees the stale turn_done and emits a false ready transition.
-func TestClassifyState_TaskNotificationStartsAgentContinuation(t *testing.T) {
+type taskNotificationContinuationFixture struct {
+	t    *testing.T
+	path string
+	tail *tailer.TranscriptTailer
+}
+
+func newTaskNotificationContinuationFixture(t *testing.T) *taskNotificationContinuationFixture {
+	t.Helper()
 	path := filepath.Join(t.TempDir(), "transcript.jsonl")
 	if err := os.WriteFile(path, nil, 0o644); err != nil {
 		t.Fatalf("create transcript: %v", err)
 	}
+	return &taskNotificationContinuationFixture{
+		t:    t,
+		path: path,
+		tail: tailer.NewTranscriptTailer(path, &claudecode.Parser{}, "claude-code"),
+	}
+}
 
-	tail := tailer.NewTranscriptTailer(path, &claudecode.Parser{}, "claude-code")
-	appendEvents := func(events ...map[string]interface{}) {
-		t.Helper()
-		f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)
-		if err != nil {
-			t.Fatalf("open transcript: %v", err)
-		}
-		defer f.Close()
-		enc := json.NewEncoder(f)
-		for _, event := range events {
-			if err := enc.Encode(event); err != nil {
-				t.Fatalf("append transcript event: %v", err)
-			}
+func (f *taskNotificationContinuationFixture) append(events ...map[string]interface{}) {
+	f.t.Helper()
+	file, err := os.OpenFile(f.path, os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		f.t.Fatalf("open transcript: %v", err)
+	}
+	defer file.Close()
+	encoder := json.NewEncoder(file)
+	for _, event := range events {
+		if err := encoder.Encode(event); err != nil {
+			f.t.Fatalf("append transcript event: %v", err)
 		}
 	}
-	readMetrics := func() *session.SessionMetrics {
-		t.Helper()
-		m, err := tail.TailAndProcess()
-		if err != nil {
-			t.Fatalf("TailAndProcess: %v", err)
-		}
-		return replayengine.TailerToDomain(m)
-	}
-	classify := func(m *session.SessionMetrics, want string) {
-		t.Helper()
-		got, _ := services.ClassifyState(session.StateWorking, m)
-		if got != want {
-			t.Fatalf("ClassifyState() = %q, want %q (last event %q, background count %d)",
-				got, want, m.LastEventType, m.BackgroundProcessCount)
-		}
-	}
+}
 
-	const (
-		bashID    = "bkymfen4l"
-		toolUseID = "toolu_background"
-	)
-	appendEvents(
-		map[string]interface{}{
+func (f *taskNotificationContinuationFixture) metrics() *session.SessionMetrics {
+	f.t.Helper()
+	metrics, err := f.tail.TailAndProcess()
+	if err != nil {
+		f.t.Fatalf("TailAndProcess: %v", err)
+	}
+	return replayengine.TailerToDomain(metrics)
+}
+
+func assertTaskNotificationState(t *testing.T, metrics *session.SessionMetrics, want string) {
+	t.Helper()
+	got, _ := services.ClassifyState(session.StateWorking, metrics)
+	if got != want {
+		t.Fatalf("ClassifyState() = %q, want %q (last event %q, background count %d)",
+			got, want, metrics.LastEventType, metrics.BackgroundProcessCount)
+	}
+}
+
+func assertTaskNotificationCounts(t *testing.T, metrics *session.SessionMetrics, wantBackground, wantCompletions int) {
+	t.Helper()
+	if metrics.BackgroundProcessCount != wantBackground {
+		t.Errorf("background count = %d, want %d", metrics.BackgroundProcessCount, wantBackground)
+	}
+	if len(metrics.SubagentCompletions) != wantCompletions {
+		t.Errorf("completion count = %d, want %d", len(metrics.SubagentCompletions), wantCompletions)
+	}
+}
+
+func backgroundCommandEvents(bashID, toolUseID string) []map[string]interface{} {
+	return []map[string]interface{}{
+		{
 			"type": "assistant",
 			"message": map[string]interface{}{
 				"stop_reason": "tool_use",
@@ -72,7 +87,7 @@ func TestClassifyState_TaskNotificationStartsAgentContinuation(t *testing.T) {
 				}},
 			},
 		},
-		map[string]interface{}{
+		{
 			"type":          "user",
 			"toolUseResult": map[string]interface{}{"backgroundTaskId": bashID},
 			"message": map[string]interface{}{
@@ -82,18 +97,11 @@ func TestClassifyState_TaskNotificationStartsAgentContinuation(t *testing.T) {
 				}},
 			},
 		},
-	)
-	spawned := readMetrics()
-	if spawned.BackgroundProcessCount != 1 {
-		t.Fatalf("spawn pass background count = %d, want 1", spawned.BackgroundProcessCount)
 	}
+}
 
-	appendEvents(map[string]interface{}{"type": "system", "subtype": "turn_duration"})
-	priorTurnDone := readMetrics()
-	priorTurnDone.HasLiveBackgroundProcess = true // the detector's liveness-probe overlay
-	classify(priorTurnDone, session.StateWorking)
-
-	appendEvents(map[string]interface{}{
+func taskNotificationEvent(bashID, toolUseID string) map[string]interface{} {
+	return map[string]interface{}{
 		"type":   "user",
 		"origin": map[string]interface{}{"kind": "task-notification"},
 		"message": map[string]interface{}{
@@ -101,17 +109,11 @@ func TestClassifyState_TaskNotificationStartsAgentContinuation(t *testing.T) {
 			"content": "<task-notification><task-id>" + bashID + "</task-id>" +
 				"<tool-use-id>" + toolUseID + "</tool-use-id><status>completed</status></task-notification>",
 		},
-	})
-	continued := readMetrics()
-	if continued.BackgroundProcessCount != 0 {
-		t.Fatalf("notification pass background count = %d, want 0", continued.BackgroundProcessCount)
 	}
-	if len(continued.SubagentCompletions) != 1 {
-		t.Fatalf("notification pass completions = %d, want 1", len(continued.SubagentCompletions))
-	}
-	classify(continued, session.StateWorking)
+}
 
-	appendEvents(map[string]interface{}{
+func assistantToolUseEvent() map[string]interface{} {
+	return map[string]interface{}{
 		"type": "assistant",
 		"message": map[string]interface{}{
 			"stop_reason": "tool_use",
@@ -120,19 +122,52 @@ func TestClassifyState_TaskNotificationStartsAgentContinuation(t *testing.T) {
 				"input": map[string]interface{}{"command": "git status --short"},
 			}},
 		},
-	})
-	classify(readMetrics(), session.StateWorking)
+	}
+}
 
-	appendEvents(map[string]interface{}{
+func toolResultEvent() map[string]interface{} {
+	return map[string]interface{}{
 		"type": "user",
 		"message": map[string]interface{}{
 			"content": []interface{}{map[string]interface{}{
 				"type": "tool_result", "tool_use_id": "toolu_resumed", "content": "clean",
 			}},
 		},
-	})
-	classify(readMetrics(), session.StateWorking)
+	}
+}
 
-	appendEvents(map[string]interface{}{"type": "system", "subtype": "turn_duration"})
-	classify(readMetrics(), session.StateReady)
+// TestClassifyState_TaskNotificationStartsAgentContinuation is the issue #1899
+// regression. Claude Code writes the completed background command as a
+// user-role task-notification, then starts a new inference turn. The
+// notification must replace the preceding turn_done lifecycle anchor while it
+// removes the completed process from the background ledger. Otherwise the
+// classifier sees the stale turn_done and emits a false ready transition.
+func TestClassifyState_TaskNotificationStartsAgentContinuation(t *testing.T) {
+	const (
+		bashID    = "bkymfen4l"
+		toolUseID = "toolu_background"
+	)
+	fixture := newTaskNotificationContinuationFixture(t)
+	fixture.append(backgroundCommandEvents(bashID, toolUseID)...)
+	spawned := fixture.metrics()
+	assertTaskNotificationCounts(t, spawned, 1, 0)
+
+	fixture.append(map[string]interface{}{"type": "system", "subtype": "turn_duration"})
+	priorTurnDone := fixture.metrics()
+	priorTurnDone.HasLiveBackgroundProcess = true // the detector's liveness-probe overlay
+	assertTaskNotificationState(t, priorTurnDone, session.StateWorking)
+
+	fixture.append(taskNotificationEvent(bashID, toolUseID))
+	continued := fixture.metrics()
+	assertTaskNotificationCounts(t, continued, 0, 1)
+	assertTaskNotificationState(t, continued, session.StateWorking)
+
+	fixture.append(assistantToolUseEvent())
+	assertTaskNotificationState(t, fixture.metrics(), session.StateWorking)
+
+	fixture.append(toolResultEvent())
+	assertTaskNotificationState(t, fixture.metrics(), session.StateWorking)
+
+	fixture.append(map[string]interface{}{"type": "system", "subtype": "turn_duration"})
+	assertTaskNotificationState(t, fixture.metrics(), session.StateReady)
 }

--- a/core/pkg/tailer/parser.go
+++ b/core/pkg/tailer/parser.go
@@ -227,6 +227,14 @@ type ParsedEvent struct {
 	// non-background id (e.g. a subagent's) is a harmless no-op. See issue #445.
 	TerminatedBackgroundTaskIDs []string
 
+	// OriginTaskNotification is true only for Claude Code's user-role
+	// origin.kind="task-notification" shape. The tailer combines this flag
+	// with a TerminatedBackgroundTaskID that matches its open-process ledger:
+	// that pair starts a new inference turn. A subagent notification has no
+	// matching process entry, and a queued_command attachment leaves this
+	// false, so both remain passive. See issue #1899.
+	OriginTaskNotification bool
+
 	// TaskSnapshot, when non-nil, is the authoritative list of tasks Claude
 	// Code is currently tracking, parsed from a task_reminder attachment.
 	// Pointer-to-slice so an empty list (legitimate "nothing active" signal)

--- a/core/pkg/tailer/tailer.go
+++ b/core/pkg/tailer/tailer.go
@@ -15,6 +15,11 @@ import (
 	"irrlicht/core/pkg/capacity"
 )
 
+// eventTypeAgentContinuation is the lifecycle anchor written when an adapter
+// reports that a machine event started a new inference turn. It is not a user
+// event, so it cannot trigger genuine-user-turn cleanup. See issue #1899.
+const eventTypeAgentContinuation = "agent_continuation"
+
 // MessageEvent represents a single message event from transcript
 type MessageEvent struct {
 	Timestamp time.Time `json:"timestamp"`
@@ -796,8 +801,17 @@ func (t *TranscriptTailer) applySkippedEvent(parsed *ParsedEvent) bool {
 	// (origin.kind or queued_command attachment) — drain it here so the count
 	// drops and the pass is substantive enough for the detector to
 	// re-classify and release the hold. See issue #445.
+	//
+	// An origin notification that matches an open process also starts Claude's
+	// next inference turn. Replace the stale turn_done lifecycle anchor only
+	// after the map lookup proves this is a background-command completion.
+	// Subagent notifications do not match this ledger, and attachment-form
+	// notifications do not carry OriginTaskNotification. See issue #1899.
 	if len(parsed.TerminatedBackgroundTaskIDs) > 0 {
 		for _, id := range parsed.TerminatedBackgroundTaskIDs {
+			if _, tracked := t.openBackgroundProcs[id]; tracked && parsed.OriginTaskNotification {
+				t.metrics.LastEventType = eventTypeAgentContinuation
+			}
 			delete(t.openBackgroundProcs, id)
 		}
 		substantive = true

--- a/core/pkg/tailer/tailer.go
+++ b/core/pkg/tailer/tailer.go
@@ -797,23 +797,7 @@ func (t *TranscriptTailer) applySkippedEvent(parsed *ParsedEvent) bool {
 		t.metrics.SubagentCompletions = append(t.metrics.SubagentCompletions, parsed.SubagentCompletions...)
 		substantive = true
 	}
-	// Background-process completion arrives on a Skip=true task-notification
-	// (origin.kind or queued_command attachment) — drain it here so the count
-	// drops and the pass is substantive enough for the detector to
-	// re-classify and release the hold. See issue #445.
-	//
-	// An origin notification that matches an open process also starts Claude's
-	// next inference turn. Replace the stale turn_done lifecycle anchor only
-	// after the map lookup proves this is a background-command completion.
-	// Subagent notifications do not match this ledger, and attachment-form
-	// notifications do not carry OriginTaskNotification. See issue #1899.
-	if len(parsed.TerminatedBackgroundTaskIDs) > 0 {
-		for _, id := range parsed.TerminatedBackgroundTaskIDs {
-			if _, tracked := t.openBackgroundProcs[id]; tracked && parsed.OriginTaskNotification {
-				t.metrics.LastEventType = eventTypeAgentContinuation
-			}
-			delete(t.openBackgroundProcs, id)
-		}
+	if t.applyBackgroundProcessTerminations(parsed) {
 		substantive = true
 	}
 	if parsed.TaskSnapshot != nil {
@@ -869,6 +853,20 @@ func (t *TranscriptTailer) applySkippedEvent(parsed *ParsedEvent) bool {
 	}
 	t.reconcileTaskSnapshot(parsed)
 	return substantive
+}
+
+// applyBackgroundProcessTerminations drains completed background commands.
+// An origin notification that matches an open process also starts Claude's
+// next inference turn. Subagent notifications do not match this ledger, and
+// attachment-form notifications do not carry OriginTaskNotification.
+func (t *TranscriptTailer) applyBackgroundProcessTerminations(parsed *ParsedEvent) bool {
+	for _, id := range parsed.TerminatedBackgroundTaskIDs {
+		if _, tracked := t.openBackgroundProcs[id]; tracked && parsed.OriginTaskNotification {
+			t.metrics.LastEventType = eventTypeAgentContinuation
+		}
+		delete(t.openBackgroundProcs, id)
+	}
+	return len(parsed.TerminatedBackgroundTaskIDs) > 0
 }
 
 // forceIdleFlushDuration is passed to IdleFlush from FlushIdle. Any

--- a/replaydata/agents/claudecode/regressions/06-cost-calculation-07f5cca9/recordings/2026-04-07-19-57-20_irrlichd-unknown/transcript.jsonl.replay.json.golden
+++ b/replaydata/agents/claudecode/regressions/06-cost-calculation-07f5cca9/recordings/2026-04-07-19-57-20_irrlichd-unknown/transcript.jsonl.replay.json.golden
@@ -10,14 +10,14 @@
   "summary": {
     "total_events": 1194,
     "consumed_events": 1194,
-    "total_transitions": 39,
+    "total_transitions": 37,
     "first_event_time": "2026-04-07T19:57:20.99Z",
     "last_event_time": "2026-04-07T23:15:42.607Z",
     "wall_clock_session_duration": 11901617000000,
     "state_durations": {
-      "ready": 2869896000000,
+      "ready": 2857936000000,
       "waiting": 1482105000000,
-      "working": 7549616000000
+      "working": 7561576000000
     },
     "flicker_count": 1,
     "flickers_by_category": {
@@ -475,36 +475,6 @@
     },
     {
       "index": 30,
-      "event_index": 1026,
-      "virtual_time": "2026-04-07T22:56:08.058Z",
-      "cause": "debounce_coalesce",
-      "prev_state": "working",
-      "new_state": "ready",
-      "reason": "agent finished turn → ready",
-      "last_event_type": "turn_done",
-      "has_open_tool": false,
-      "is_agent_done": true,
-      "needs_user_attention": false,
-      "waiting_for_user_input": false,
-      "last_assistant_text_head": "…ew flicker-prone sessions across all three adapters\nbash scripts/find-flicker…"
-    },
-    {
-      "index": 31,
-      "event_index": 1028,
-      "virtual_time": "2026-04-07T22:56:20.018Z",
-      "cause": "debounce_coalesce",
-      "prev_state": "ready",
-      "new_state": "working",
-      "reason": "force ready→working on first activity",
-      "last_event_type": "assistant",
-      "has_open_tool": false,
-      "is_agent_done": true,
-      "needs_user_attention": false,
-      "waiting_for_user_input": true,
-      "last_assistant_text_head": "…ow-up issue for the Codex stale-timer signal (14 flickers + 29 stale fires on…"
-    },
-    {
-      "index": 32,
       "event_index": 1028,
       "virtual_time": "2026-04-07T22:56:20.018Z",
       "cause": "debounce_coalesce",
@@ -519,7 +489,7 @@
       "last_assistant_text_head": "…ow-up issue for the Codex stale-timer signal (14 flickers + 29 stale fires on…"
     },
     {
-      "index": 33,
+      "index": 31,
       "event_index": 1029,
       "virtual_time": "2026-04-07T22:56:57.379Z",
       "cause": "event",
@@ -533,7 +503,7 @@
       "waiting_for_user_input": false
     },
     {
-      "index": 34,
+      "index": 32,
       "event_index": 1050,
       "virtual_time": "2026-04-07T22:59:25.656Z",
       "cause": "debounce_coalesce",
@@ -548,7 +518,7 @@
       "last_assistant_text_head": "…y harness paid for itself on its first cross-adapter run.\n\nThe two \"suspiciou…"
     },
     {
-      "index": 35,
+      "index": 33,
       "event_index": 1052,
       "virtual_time": "2026-04-07T23:01:26.331Z",
       "cause": "debounce_coalesce",
@@ -562,7 +532,7 @@
       "waiting_for_user_input": false
     },
     {
-      "index": 36,
+      "index": 34,
       "event_index": 1072,
       "virtual_time": "2026-04-07T23:02:57.351Z",
       "cause": "debounce_coalesce",
@@ -577,7 +547,7 @@
       "last_assistant_text_head": "…done with it.\n\nIssue **#102** is fully resolved, issue **#105** (Codex Bug A …"
     },
     {
-      "index": 37,
+      "index": 35,
       "event_index": 1075,
       "virtual_time": "2026-04-07T23:03:48.874Z",
       "cause": "debounce_coalesce",
@@ -591,7 +561,7 @@
       "waiting_for_user_input": false
     },
     {
-      "index": 38,
+      "index": 36,
       "event_index": 1192,
       "virtual_time": "2026-04-07T23:11:12.805Z",
       "cause": "debounce_coalesce",


### PR DESCRIPTION
## Summary

- Keep a Claude Code session in `working` when a tracked Bash background command emits a terminal origin task notification.
- Add an explicit parser marker for origin-form task notifications.
- Promote the lifecycle anchor only when the notification ID matches the background-process ledger.
- Keep queued-command attachments and unmatched subagent notifications passive.

## Root cause

The skipped task notification removed the completed process from the background-process ledger. It did not replace the stale `turn_done` lifecycle anchor. The empty ledger then made `IsAgentDone()` return true. The classifier emitted `ready` until the next assistant event restored `working`.

Session `80006e3c-c072-40f1-b299-2a0f27e48ecc` showed this sequence. The false `ready` interval lasted about 4.20 seconds.

## Red-first evidence

Before the fix:

```
go test ./core/application/services -run "^TestClassifyState_TaskNotificationStartsAgentContinuation$" -count=1
```

The test failed with `ClassifyState() = "ready", want "working" (last event "turn_done", background count 0)`.

## Replay evidence

The affected Claude Code replay changed from 39 to 37 transitions. The replay removed the false `working -> ready -> working` pair. It moved 11.960 seconds from `ready` to `working`. Event, token, and cost counts did not change.

The `3-2_background-subagent` replay did not change. This result confirms that unmatched subagent notifications remain passive.

## Verification

- `tools/preflight.sh --only go`
- `tools/preflight.sh --only arch`
- `tools/preflight.sh --only tools`
- `tools/preflight.sh --only skills`
- `tools/preflight.sh --only posix`
- `tools/preflight.sh --only bash`
- `tools/preflight.sh --only security`
- Changed-scope pre-push gate

All gates passed. The security gate reported only the existing non-blocking Go toolchain warnings.

An independent review found no correctness, architecture, or regression findings. The selected implementation preserves skipped-event message accounting.

## Residual risk

An incomplete transcript can omit the background-process ledger entry. In that case, the notification stays passive. This behavior is conservative.

Closes #1899

🤖 Generated with Codex