### PR TITLE
WIP: fix(release): stage the whole dashboard web tree by rule, not a three-file list

### DIFF
--- a/.claude/skills/ir:release/SKILL.md
+++ b/.claude/skills/ir:release/SKILL.md
@@ -416,7 +416,9 @@ from `gh api`, the token is missing the `security_events` scope:
 > `killStaleDaemons` skip the pkill. The app's embedded daemon spawn can be
 > flaky under a bare exec; if so, validate the bundle's daemon directly:
 > `IRRLICHT_BIND_ADDR=127.0.0.1:7839 IRRLICHT_HOME=… .build/Irrlicht.app/Contents/MacOS/irrlichd`
-> then `curl 127.0.0.1:7839/ | grep '<title>'` (covers the v0.4.4 missing-web bug).
+> then `curl 127.0.0.1:7839/ | grep '<title>'` (covers the v0.4.4 missing-web
+> bug) **and** `curl -fsS 127.0.0.1:7839/irrlicht.js >/dev/null` plus one of its
+> sibling modules (covers #1900, which the `<title>` check alone cannot see).
 
 ### Go daemon (universal binary + tarball)
 The daemon reads `platforms/web/index.html` from disk at runtime; no embed.
@@ -432,7 +434,11 @@ lipo -create /tmp/irrlichd-arm64 /tmp/irrlichd-amd64 -output /tmp/irrlichd-darwi
 # Tarball for the curl --daemon-only installer
 rm -rf /tmp/irrlichd-tarball && mkdir -p /tmp/irrlichd-tarball/web
 cp /tmp/irrlichd-darwin-universal /tmp/irrlichd-tarball/irrlichd
-cp /Users/ingo/projects/irrlicht/platforms/web/index.html /tmp/irrlichd-tarball/web/index.html
+# The dashboard is staged BY RULE, never by a hand-written file list — see
+# tools/lib/stage-web.sh. #1900: a three-file list here shipped a blank
+# dashboard to every install once irrlicht.js grew sibling modules.
+( cd /Users/ingo/projects/irrlicht && . tools/lib/stage-web.sh &&
+  stage_web platforms/web /tmp/irrlichd-tarball/web )
 tar -czf /tmp/irrlichd-darwin-universal.tar.gz -C /tmp/irrlichd-tarball .
 ```
 
@@ -441,8 +447,9 @@ tar -czf /tmp/irrlichd-darwin-universal.tar.gz -C /tmp/irrlichd-tarball .
 These ship the Linux curl install path (`site/install.sh` auto-detects Linux
 and downloads `irrlichd-linux-<arch>.tar.gz`). Pure cross-compile from macOS,
 no cgo. **Required** — omitting them makes every Linux `curl … | sh` 404 on
-the asset. Each Linux tarball carries all three web files (index.html + css +
-js), because the Linux installer installs all three.
+the asset. Each Linux tarball carries the whole dashboard — `index.html`, the
+stylesheet and every ES module `irrlicht.js` imports — staged by
+`stage_web`, because on Linux the web dashboard is the only UI there is.
 
 ```bash
 cd /Users/ingo/projects/irrlicht/core
@@ -451,10 +458,8 @@ for arch in amd64 arm64; do
     -o "/tmp/irrlichd-linux-$arch" ./cmd/irrlichd
   rm -rf "/tmp/irrlichd-linux-tarball-$arch" && mkdir -p "/tmp/irrlichd-linux-tarball-$arch/web"
   cp "/tmp/irrlichd-linux-$arch" "/tmp/irrlichd-linux-tarball-$arch/irrlichd"
-  cp /Users/ingo/projects/irrlicht/platforms/web/index.html \
-     /Users/ingo/projects/irrlicht/platforms/web/irrlicht.css \
-     /Users/ingo/projects/irrlicht/platforms/web/irrlicht.js \
-     "/tmp/irrlichd-linux-tarball-$arch/web/"
+  ( cd /Users/ingo/projects/irrlicht && . tools/lib/stage-web.sh &&
+    stage_web platforms/web "/tmp/irrlichd-linux-tarball-$arch/web" )
   tar -czf "/tmp/irrlichd-linux-$arch.tar.gz" -C "/tmp/irrlichd-linux-tarball-$arch" .
 done
 ```
@@ -547,18 +552,23 @@ PKG, and ZIP land in `/tmp/` as before — only the *assembly* path moves.
 1. Copy Swift binary → `$APP_STAGING/Contents/MacOS/Irrlicht` (from path above).
 2. Copy universal daemon → `$APP_STAGING/Contents/MacOS/irrlichd`.
 3. Copy `AppIcon.icns` → `$APP_STAGING/Contents/Resources/AppIcon.icns`.
-4. **Copy the dashboard UI** → `$APP_STAGING/Contents/Resources/web/index.html`.
+4. **Stage the dashboard UI** → `$APP_STAGING/Contents/Resources/web/`.
    The daemon resolves it at runtime via `<exe>/../Resources/web/`
-   (`resolveUIDir` in `core/cmd/irrlichd/paths.go`). Without this copy,
+   (`resolveUIDir` in `core/cmd/irrlichd/paths.go`). Without it,
    `GET /` returns the 503 "Dashboard UI not found" fallback — every
-   v0.4.4 install shipped without this file and the dashboard at
+   v0.4.4 install shipped without `index.html` and the dashboard at
    `http://127.0.0.1:7837/` was unreachable until v0.4.5 re-spun the assets.
-   The smoke test at step 8 asserts the dashboard responds; do not skip it.
+   **`index.html` alone is not enough**, and this is not a hypothetical:
+   v0.6.0–v0.6.2 shipped `index.html` + css + js and nothing else, so every
+   ES-module import 404'd and the dashboard rendered a blank page on every
+   install (#1900). Stage by rule, never by a file list:
    ```bash
-   mkdir -p "$APP_STAGING/Contents/Resources/web"
-   cp /Users/ingo/projects/irrlicht/platforms/web/index.html \
-      "$APP_STAGING/Contents/Resources/web/index.html"
+   ( cd /Users/ingo/projects/irrlicht && . tools/lib/stage-web.sh &&
+     stage_web platforms/web "$APP_STAGING/Contents/Resources/web" )
    ```
+   The smoke test at step 8 asserts every one of those assets is served; do
+   not skip it, and do not weaken it back to a check on `index.html` alone —
+   that is the check both defects walked straight through.
 5. **Write a resolved `Info.plist`** to `$APP_STAGING/Contents/Info.plist`.
    This is a hand-written file, *not* a copy of `platforms/macos/Irrlicht/Resources/Info.plist`
    (which contains unresolved Xcode variables like `$(PRODUCT_NAME)`). Use
@@ -840,6 +850,32 @@ PKG, and ZIP land in `/tmp/` as before — only the *assembly* path moves.
      exit 1
    fi
    echo "OK dashboard served on $SMOKE_PORT"
+
+   # ...and every asset the page actually loads (#1900). The <title> check
+   # above passes on an index.html served entirely alone, which is precisely
+   # what v0.6.0-v0.6.2 shipped: the page returned 200, every ES-module import
+   # 404'd, and the dashboard rendered blank. The asset list is DERIVED from
+   # the import graph by the same walker the packaging gate uses, so a module
+   # added later is covered without editing this block.
+   ASSETS=$( cd /Users/ingo/projects/irrlicht &&
+             . tools/web-release-assets-guard.sh &&
+             web_assets_closure platforms/web )
+   if [ -z "$ASSETS" ]; then
+     echo "FAIL: could not derive the dashboard's asset list — DO NOT SHIP (this check cannot run, which is not the same as passing)"
+     pkill -f "$APP/Contents/MacOS/Irrlicht" 2>/dev/null
+     exit 1
+   fi
+   MISSING=0
+   for asset in $ASSETS; do
+     CODE=$(curl -sS -o /dev/null -w '%{http_code}' "http://127.0.0.1:$SMOKE_PORT/$asset")
+     [ "$CODE" = 200 ] || { echo "FAIL: /$asset -> HTTP $CODE"; MISSING=$((MISSING + 1)); }
+   done
+   if [ "$MISSING" -ne 0 ]; then
+     echo "FAIL: $MISSING dashboard asset(s) not served — the bundle's web/ tree is incomplete. DO NOT SHIP"
+     pkill -f "$APP/Contents/MacOS/Irrlicht" 2>/dev/null
+     exit 1
+   fi
+   echo "OK all $(echo "$ASSETS" | wc -l | tr -d ' ') dashboard assets served on $SMOKE_PORT"
 
    pkill -f "$APP/Contents/MacOS/Irrlicht" 2>/dev/null; sleep 0.3
    ```
@@ -1279,6 +1315,15 @@ without `--push`; the verification will report a mismatch you can ignore.
      exit 1
    fi
    curl -fsS --max-time 3 http://127.0.0.1:7839/ | grep -q '<title>' && echo "OK canary dashboard on 7839"
+   # ...and one ES module, because index.html alone answered this check for
+   # all of v0.6.0-v0.6.2 while the dashboard rendered blank (#1900).
+   CANARY_MOD=$( cd /Users/ingo/projects/irrlicht &&
+                 . tools/web-release-assets-guard.sh &&
+                 web_assets_closure platforms/web | grep -m1 '\.js$' )
+   [ -n "$CANARY_MOD" ] || { echo "FAIL: could not derive a module to canary — this check cannot run"; exit 1; }
+   curl -fsS --max-time 3 "http://127.0.0.1:7839/$CANARY_MOD" >/dev/null \
+     || { echo "FAIL: canary /$CANARY_MOD did not load — the installed web/ tree is incomplete"; exit 1; }
+   echo "OK canary module /$CANARY_MOD served on 7839"
    pkill -f '/Applications/Irrlicht.app/Contents/MacOS/Irrlicht' 2>/dev/null; sleep 0.5
    lsof -ti tcp:7839 | xargs kill 2>/dev/null
    echo "OK canary: v$INSTALLED installed, spctl accepted, get-task-allow not true, runs"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -151,6 +151,15 @@ Before marking a ticket done, run the full suite — every layer must pass:
   time, so a partition split across lines — a `switch` with two arms and a
   `default` — is invisible to it: it complements review rather than replacing
   it. `tools/lib/state-vocabulary-lint_test.sh` carries the mutation fixtures.
+- Release packaging: `tools/web-release-assets-guard.sh` (#1900) executes
+  `tools/lib/stage-web.sh` — the one definition of which `platforms/web/`
+  files a release ships — and asserts every asset reachable from
+  `index.html` is staged and nothing dev-only is. It walks the ES-module
+  import graph transitively and cycle-tolerantly, because the module that
+  broke was reachable only at depth 3. Both `tools/build-release.sh` and
+  `/ir:release`'s manual fallback blocks must stage via `stage_web`; a
+  hand-written `cp` list in either fails the gate. That list is how a blank
+  dashboard shipped to every install on macOS and Linux.
 - Skill files: `tools/skill-lint.sh` (`.claude/skills/**/*.md`). AGENTS.md's
   own 400-line budget (#1742 — this file is force-injected into every agent
   session via CLAUDE.md's `@AGENTS.md` import, so it never gets to just grow):

--- a/core/cmd/irrlichd/startup.go
+++ b/core/cmd/irrlichd/startup.go
@@ -409,12 +409,22 @@ func registerCoreRoutes(mux *http.ServeMux, deps registerCoreRoutesDeps) {
 	mux.HandleFunc("GET /debug/bundle", localhostOnly(handleDiagnosticsBundle(diagSvc)))
 }
 
-// registerUIRoutes serves the dashboard's static assets (index.html,
-// irrlicht.css, irrlicht.js) from disk, or a plain-text explainer if the UI
-// directory can't be found. Ensures web assets are served with the correct
-// Content-Type regardless of the host OS mime.types database (absent on
-// stripped Linux images — Go's content-sniffing fallback returns text/plain
-// for CSS, which has no magic bytes).
+// registerUIRoutes serves the dashboard's static assets from disk, or a
+// plain-text explainer if the UI directory can't be found. Ensures web assets
+// are served with the correct Content-Type regardless of the host OS
+// mime.types database (absent on stripped Linux images — Go's
+// content-sniffing fallback returns text/plain for CSS, which has no magic
+// bytes).
+//
+// It serves WHATEVER resolveUIDir returns, as one http.FileServer — it does
+// not enumerate files, and no file count belongs in this comment. The
+// enumeration that used to sit here ("index.html, irrlicht.css, irrlicht.js")
+// was the recorded form of the assumption that broke in #1900: the same three
+// names were a hand-written copy list in tools/build-release.sh, and once
+// irrlicht.js became an ES module importing ten siblings, every release
+// artifact shipped a tree whose imports 404'd here. What ships is now decided
+// by a rule (tools/lib/stage-web.sh) and gated by
+// tools/web-release-assets-guard.sh.
 func registerUIRoutes(mux *http.ServeMux, logger outbound.Logger) {
 	_ = mime.AddExtensionType(".js", "application/javascript")
 	_ = mime.AddExtensionType(".css", "text/css")

--- a/core/cmd/irrlichd/ui_release_tree_test.go
+++ b/core/cmd/irrlichd/ui_release_tree_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -125,10 +126,15 @@ func stageReleaseWebTree(t *testing.T, stageLib, webSrc string) string {
 // webSrc/index.html.
 func reachableWebAssets(t *testing.T, guard, webSrc string) []string {
 	t.Helper()
-	out, err := exec.Command("bash", "-c",
-		`set -uo pipefail; . "$1"; web_assets_closure "$2"`, "bash", guard, webSrc).Output()
+	cmd := exec.Command("bash", "-c",
+		`set -uo pipefail; . "$1"; web_assets_closure "$2"`, "bash", guard, webSrc)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
 	if err != nil {
-		t.Fatalf("cannot run: the import-graph walk refused on %s: %v", webSrc, err)
+		// The walk's whole design is that every refusal explains itself, so its
+		// explanation is reported rather than reduced to "exit status 2".
+		t.Fatalf("cannot run: the import-graph walk refused on %s: %v\n%s", webSrc, err, stderr.String())
 	}
 	var names []string
 	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {

--- a/core/cmd/irrlichd/ui_release_tree_test.go
+++ b/core/cmd/irrlichd/ui_release_tree_test.go
@@ -1,0 +1,180 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// TestRegisterUIRoutesServesTheStagedReleaseTree is the served-side half of
+// #1900, and the direct inversion of the evidence in that issue: on the
+// released 0.6.2 daemon every one of the dashboard's ES-module imports
+// returned 404, because tools/build-release.sh staged three files out of
+// thirteen. registerUIRoutes was never at fault — it registers one blanket
+// http.FileServer — but "the daemon serves what the release stages" was
+// nobody's assertion, so the gap between the two was invisible until a user
+// reported a blank page.
+//
+// The two sides are deliberately derived from DIFFERENT sources, because a
+// test that asked the staged directory what to request could never reproduce
+// the defect — whatever shipped would be exactly what it looked for, and three
+// files would pass as readily as thirteen:
+//
+//   - what is REQUESTED comes from tools/web-release-assets-guard.sh's walk of
+//     the import graph rooted at platforms/web/index.html — what the browser
+//     will actually fetch;
+//   - what is SERVED comes from executing the same tools/lib/stage-web.sh that
+//     tools/build-release.sh sources — what a release will actually contain.
+//
+// Both are the shipping implementations, not copies of them: a copy here would
+// prove something about this file and nothing about the release.
+//
+// It runs in-process against httptest rather than booting a daemon — the
+// packaging rule is graded by the shell guard, and what is left to prove here
+// is only that the routes serve the staged directory.
+//
+// Seen red before the fix existed, and reproducible on demand: restoring
+// origin/main's three-file staging rule makes it report 404 for all ten
+// modules — the same ten the issue measured against the released daemon.
+//
+//	tools/mutate.sh tools/lib/stage-web.sh \
+//	  '    for f in "$src"/*.html "$src"/*.css "$src"/*.js; do' \
+//	  '    for f in "$src"/index.html "$src"/irrlicht.css "$src"/irrlicht.js; do' \
+//	  bash -c 'cd core && go test ./cmd/irrlichd/ -run TestRegisterUIRoutesServesTheStagedReleaseTree -count=1'
+//
+// The equivalent property is re-run on every push by
+// tools/lib/web-release-assets-guard-mutations_test.sh, which drops a module
+// from the staging rule and requires the shell guard to go red; that fixture
+// lives in the `tools` gate rather than here so the cheap phase-1 gates do not
+// have to build Go.
+func TestRegisterUIRoutesServesTheStagedReleaseTree(t *testing.T) {
+	repoRoot := repoRootFromWorkingDir(t)
+	stageLib := filepath.Join(repoRoot, "tools", "lib", "stage-web.sh")
+	guard := filepath.Join(repoRoot, "tools", "web-release-assets-guard.sh")
+	webSrc := filepath.Join(repoRoot, "platforms", "web")
+	for _, p := range []string{stageLib, guard, filepath.Join(webSrc, "index.html")} {
+		if _, err := os.Stat(p); err != nil {
+			t.Fatalf("cannot run: %s is missing (%v) — the release tooling this test executes is gone", p, err)
+		}
+	}
+
+	staged := filepath.Join(t.TempDir(), "web")
+	cmd := exec.Command("bash", "-c",
+		`set -euo pipefail; . "$1"; stage_web "$2" "$3"`, "bash", stageLib, webSrc, staged)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("cannot run: stage_web refused to stage %s: %v\n%s", webSrc, err, out)
+	}
+
+	closureOut, err := exec.Command("bash", "-c",
+		`set -uo pipefail; . "$1"; web_assets_closure "$2"`, "bash", guard, webSrc).Output()
+	if err != nil {
+		t.Fatalf("cannot run: the import-graph walk refused on %s: %v", webSrc, err)
+	}
+	var names []string
+	for _, line := range strings.Split(strings.TrimSpace(string(closureOut)), "\n") {
+		if line = strings.TrimSpace(line); line != "" {
+			names = append(names, line)
+		}
+	}
+	sort.Strings(names)
+	// Inability to look must not read as success: an empty or near-empty
+	// closure would satisfy every 200 assertion below by having nothing to
+	// assert. The dashboard has been over ten files since #820.
+	if len(names) < 10 {
+		t.Fatalf("cannot run: the import-graph walk found only %d asset(s) (%v) — it did not read the dashboard", len(names), names)
+	}
+
+	if entries, derr := os.ReadDir(staged); derr != nil {
+		t.Fatalf("cannot run: staged tree unreadable: %v", derr)
+	} else {
+		for _, e := range entries {
+			if e.IsDir() {
+				t.Errorf("the staged release tree contains a directory (%s) — it must be flat", e.Name())
+			}
+		}
+	}
+
+	t.Setenv(envUIDir, staged)
+	mux := http.NewServeMux()
+	registerUIRoutes(mux, e2eLog{})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	for _, name := range names {
+		resp, err := http.Get(srv.URL + "/" + name)
+		if err != nil {
+			t.Errorf("GET /%s: %v", name, err)
+			continue
+		}
+		body, _ := readAllAndClose(resp)
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("GET /%s = %d, want 200 — this is exactly the 404 every released dashboard served for its ES modules (#1900)", name, resp.StatusCode)
+			continue
+		}
+		if len(body) == 0 {
+			t.Errorf("GET /%s returned 200 with an empty body", name)
+		}
+	}
+
+	// The two Content-Types registerUIRoutes exists to pin: a stripped Linux
+	// image has no mime.types, and Go's sniffing returns text/plain for CSS,
+	// which a browser then refuses to apply.
+	for name, wantPrefix := range map[string]string{
+		"irrlicht.css": "text/css",
+		"irrlicht.js":  "application/javascript",
+	} {
+		resp, err := http.Get(srv.URL + "/" + name)
+		if err != nil {
+			t.Errorf("GET /%s: %v", name, err)
+			continue
+		}
+		got := resp.Header.Get("Content-Type")
+		_, _ = readAllAndClose(resp)
+		if !strings.HasPrefix(got, wantPrefix) {
+			t.Errorf("GET /%s Content-Type = %q, want prefix %q", name, got, wantPrefix)
+		}
+	}
+}
+
+// repoRootFromWorkingDir walks up from the test's working directory to the
+// enclosing repo root (the directory holding tools/lib/stage-web.sh). It fails
+// the test rather than returning a guess, so a relocated package surfaces as
+// "cannot run" instead of as a silent skip.
+func repoRootFromWorkingDir(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("cannot run: %v", err)
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "tools", "lib", "stage-web.sh")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatalf("cannot run: no repo root with tools/lib/stage-web.sh above the working directory")
+		}
+		dir = parent
+	}
+}
+
+func readAllAndClose(resp *http.Response) ([]byte, error) {
+	defer func() { _ = resp.Body.Close() }()
+	buf := make([]byte, 0, 512)
+	tmp := make([]byte, 512)
+	for {
+		n, err := resp.Body.Read(tmp)
+		buf = append(buf, tmp[:n]...)
+		if err != nil {
+			return buf, nil
+		}
+		if len(buf) > 4096 {
+			return buf, nil
+		}
+	}
+}

--- a/core/cmd/irrlichd/ui_release_tree_test.go
+++ b/core/cmd/irrlichd/ui_release_tree_test.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"sort"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -142,12 +142,17 @@ func reachableWebAssets(t *testing.T, guard, webSrc string) []string {
 			names = append(names, line)
 		}
 	}
-	sort.Strings(names)
+	// The shell already emits this sorted; sorting again only pins an order
+	// this test does not depend on. Left unsorted deliberately.
+	//
 	// Inability to look must not read as success: an empty or near-empty
 	// closure would satisfy every 200 assertion by having nothing to assert.
-	// The dashboard has been over ten files since #820.
-	if len(names) < 10 {
-		t.Fatalf("cannot run: the import-graph walk found only %d asset(s) (%v) — it did not read the dashboard", len(names), names)
+	// The floor is the defect itself rather than a number picked here —
+	// v0.6.0-v0.6.2 shipped exactly index.html + irrlicht.css + irrlicht.js,
+	// so a closure that small is the bug wearing the test's clothes.
+	const shippedBroken = 3
+	if len(names) <= shippedBroken {
+		t.Fatalf("cannot run: the import-graph walk found only %d asset(s) (%v) — no more than the %d that shipped blank in #1900, so it did not read the dashboard", len(names), names, shippedBroken)
 	}
 	return names
 }
@@ -170,24 +175,24 @@ func httpGetAsset(t *testing.T, url string) (status int, contentType string, siz
 	return resp.StatusCode, resp.Header.Get("Content-Type"), len(body)
 }
 
-// repoRootFromWorkingDir walks up from the test's working directory to the
-// enclosing repo root (the directory holding tools/lib/stage-web.sh). It fails
-// the test rather than returning a guess, so a relocated package surfaces as
+// repoRootFromWorkingDir returns the repo root. This file's own location is
+// fixed at core/cmd/irrlichd/, so the root is three directories up — the
+// repo's established test idiom (see core/application/replayengine/engine_test.go),
+// rather than a search that could silently land somewhere else. It fails the
+// test rather than returning a guess, so a relocated package surfaces as
 // "cannot run" instead of as a silent skip.
 func repoRootFromWorkingDir(t *testing.T) string {
 	t.Helper()
-	dir, err := os.Getwd()
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("cannot run: runtime.Caller could not locate this test file")
+	}
+	root, err := filepath.Abs(filepath.Join(filepath.Dir(thisFile), "..", "..", ".."))
 	if err != nil {
 		t.Fatalf("cannot run: %v", err)
 	}
-	for {
-		if _, err := os.Stat(filepath.Join(dir, "tools", "lib", "stage-web.sh")); err == nil {
-			return dir
-		}
-		parent := filepath.Dir(dir)
-		if parent == dir {
-			t.Fatalf("cannot run: no repo root with tools/lib/stage-web.sh above the working directory")
-		}
-		dir = parent
+	if _, err := os.Stat(filepath.Join(root, "tools", "lib", "stage-web.sh")); err != nil {
+		t.Fatalf("cannot run: %s is not the repo root (no tools/lib/stage-web.sh): %v", root, err)
 	}
+	return root
 }

--- a/core/cmd/irrlichd/ui_release_tree_test.go
+++ b/core/cmd/irrlichd/ui_release_tree_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -63,41 +64,8 @@ func TestRegisterUIRoutesServesTheStagedReleaseTree(t *testing.T) {
 		}
 	}
 
-	staged := filepath.Join(t.TempDir(), "web")
-	cmd := exec.Command("bash", "-c",
-		`set -euo pipefail; . "$1"; stage_web "$2" "$3"`, "bash", stageLib, webSrc, staged)
-	if out, err := cmd.CombinedOutput(); err != nil {
-		t.Fatalf("cannot run: stage_web refused to stage %s: %v\n%s", webSrc, err, out)
-	}
-
-	closureOut, err := exec.Command("bash", "-c",
-		`set -uo pipefail; . "$1"; web_assets_closure "$2"`, "bash", guard, webSrc).Output()
-	if err != nil {
-		t.Fatalf("cannot run: the import-graph walk refused on %s: %v", webSrc, err)
-	}
-	var names []string
-	for _, line := range strings.Split(strings.TrimSpace(string(closureOut)), "\n") {
-		if line = strings.TrimSpace(line); line != "" {
-			names = append(names, line)
-		}
-	}
-	sort.Strings(names)
-	// Inability to look must not read as success: an empty or near-empty
-	// closure would satisfy every 200 assertion below by having nothing to
-	// assert. The dashboard has been over ten files since #820.
-	if len(names) < 10 {
-		t.Fatalf("cannot run: the import-graph walk found only %d asset(s) (%v) — it did not read the dashboard", len(names), names)
-	}
-
-	if entries, derr := os.ReadDir(staged); derr != nil {
-		t.Fatalf("cannot run: staged tree unreadable: %v", derr)
-	} else {
-		for _, e := range entries {
-			if e.IsDir() {
-				t.Errorf("the staged release tree contains a directory (%s) — it must be flat", e.Name())
-			}
-		}
-	}
+	staged := stageReleaseWebTree(t, stageLib, webSrc)
+	reachable := reachableWebAssets(t, guard, webSrc)
 
 	t.Setenv(envUIDir, staged)
 	mux := http.NewServeMux()
@@ -105,18 +73,12 @@ func TestRegisterUIRoutesServesTheStagedReleaseTree(t *testing.T) {
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
 
-	for _, name := range names {
-		resp, err := http.Get(srv.URL + "/" + name)
-		if err != nil {
-			t.Errorf("GET /%s: %v", name, err)
-			continue
-		}
-		body, _ := readAllAndClose(resp)
-		if resp.StatusCode != http.StatusOK {
-			t.Errorf("GET /%s = %d, want 200 — this is exactly the 404 every released dashboard served for its ES modules (#1900)", name, resp.StatusCode)
-			continue
-		}
-		if len(body) == 0 {
+	for _, name := range reachable {
+		status, _, size := httpGetAsset(t, srv.URL+"/"+name)
+		switch {
+		case status != http.StatusOK:
+			t.Errorf("GET /%s = %d, want 200 — this is exactly the 404 every released dashboard served for its ES modules (#1900)", name, status)
+		case size == 0:
 			t.Errorf("GET /%s returned 200 with an empty body", name)
 		}
 	}
@@ -128,17 +90,78 @@ func TestRegisterUIRoutesServesTheStagedReleaseTree(t *testing.T) {
 		"irrlicht.css": "text/css",
 		"irrlicht.js":  "application/javascript",
 	} {
-		resp, err := http.Get(srv.URL + "/" + name)
-		if err != nil {
-			t.Errorf("GET /%s: %v", name, err)
-			continue
-		}
-		got := resp.Header.Get("Content-Type")
-		_, _ = readAllAndClose(resp)
-		if !strings.HasPrefix(got, wantPrefix) {
+		if _, got, _ := httpGetAsset(t, srv.URL+"/"+name); !strings.HasPrefix(got, wantPrefix) {
 			t.Errorf("GET /%s Content-Type = %q, want prefix %q", name, got, wantPrefix)
 		}
 	}
+}
+
+// stageReleaseWebTree stages webSrc into a fresh temp dir by executing the
+// release's own tools/lib/stage-web.sh, and returns that directory. It also
+// asserts the staged tree is flat: a directory in there is how node_modules
+// ships by accident.
+func stageReleaseWebTree(t *testing.T, stageLib, webSrc string) string {
+	t.Helper()
+	staged := filepath.Join(t.TempDir(), "web")
+	cmd := exec.Command("bash", "-c",
+		`set -euo pipefail; . "$1"; stage_web "$2" "$3"`, "bash", stageLib, webSrc, staged)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("cannot run: stage_web refused to stage %s: %v\n%s", webSrc, err, out)
+	}
+	entries, err := os.ReadDir(staged)
+	if err != nil {
+		t.Fatalf("cannot run: staged tree unreadable: %v", err)
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			t.Errorf("the staged release tree contains a directory (%s) — it must be flat", e.Name())
+		}
+	}
+	return staged
+}
+
+// reachableWebAssets returns every asset the browser will fetch, by running the
+// packaging guard's own transitive walk of the import graph rooted at
+// webSrc/index.html.
+func reachableWebAssets(t *testing.T, guard, webSrc string) []string {
+	t.Helper()
+	out, err := exec.Command("bash", "-c",
+		`set -uo pipefail; . "$1"; web_assets_closure "$2"`, "bash", guard, webSrc).Output()
+	if err != nil {
+		t.Fatalf("cannot run: the import-graph walk refused on %s: %v", webSrc, err)
+	}
+	var names []string
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		if line = strings.TrimSpace(line); line != "" {
+			names = append(names, line)
+		}
+	}
+	sort.Strings(names)
+	// Inability to look must not read as success: an empty or near-empty
+	// closure would satisfy every 200 assertion by having nothing to assert.
+	// The dashboard has been over ten files since #820.
+	if len(names) < 10 {
+		t.Fatalf("cannot run: the import-graph walk found only %d asset(s) (%v) — it did not read the dashboard", len(names), names)
+	}
+	return names
+}
+
+// httpGetAsset fetches url and reports its status, Content-Type and body size.
+// A transport error is reported and returns a zero status, which every caller
+// treats as a failure.
+func httpGetAsset(t *testing.T, url string) (status int, contentType string, size int) {
+	t.Helper()
+	resp, err := http.Get(url)
+	if err != nil {
+		t.Errorf("GET %s: %v", url, err)
+		return 0, "", 0
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Errorf("GET %s: reading body: %v", url, err)
+	}
+	return resp.StatusCode, resp.Header.Get("Content-Type"), len(body)
 }
 
 // repoRootFromWorkingDir walks up from the test's working directory to the
@@ -160,21 +183,5 @@ func repoRootFromWorkingDir(t *testing.T) string {
 			t.Fatalf("cannot run: no repo root with tools/lib/stage-web.sh above the working directory")
 		}
 		dir = parent
-	}
-}
-
-func readAllAndClose(resp *http.Response) ([]byte, error) {
-	defer func() { _ = resp.Body.Close() }()
-	buf := make([]byte, 0, 512)
-	tmp := make([]byte, 512)
-	for {
-		n, err := resp.Body.Read(tmp)
-		buf = append(buf, tmp[:n]...)
-		if err != nil {
-			return buf, nil
-		}
-		if len(buf) > 4096 {
-			return buf, nil
-		}
 	}
 }

--- a/docs/ci-gates.md
+++ b/docs/ci-gates.md
@@ -333,6 +333,34 @@ CI parity section (chunking, the budget, and what it makes visible).
   that needed killing. Nine recordings in one morning each leaked a live
   `claude` and its tmux session.
 
+- Release packaging: `tools/web-release-assets-guard.sh`, in the `tools` gate
+  (#1900). What a release ships out of `platforms/web/` is defined once, as a
+  rule, in `tools/lib/stage-web.sh` — every `*.html`/`*.css`/`*.js` directly in
+  the tree, minus `*.test.js` and `vitest.*`. The guard **executes that
+  library**, into a temp dir, rather than re-describing the rule: a guard that
+  reimplemented it would prove something about itself and nothing about the
+  script that ships. It then walks the ES-module import graph from
+  `index.html`, transitively and with a visited set, and asserts both
+  directions — everything reachable is staged, nothing dev-only is — plus that
+  neither `tools/build-release.sh` nor `/ir:release`'s manual fallback blocks
+  copy the tree by hand.
+
+  Three details are the incident, not decoration. The walk is **transitive**
+  because `collapsedSet.js` is reachable only through `collapsedGroups.js` /
+  `collapsedSummaries.js`, so a scan of `irrlicht.js`'s direct imports finds 9
+  of 10 modules and reports completeness. It is **cycle-tolerant** because
+  `permissionsWizard.js` and `quotaChips.js` import back from `irrlicht.js`.
+  And every read is `grep -a`, because `irrlicht.js` and `sessionIdentity.js`
+  carry literal NUL bytes and a binary-detecting grep answers `Binary file …
+  matches` — an empty closure that passes. A closure with zero import edges
+  therefore REFUSEs rather than reporting success. `#1900` is what all of that
+  is against: a hand-written three-file `cp` list, complete when written in
+  `#418`, silently incomplete after `#712`/`#820`, shipping a blank dashboard
+  to every install on macOS and Linux for three releases. Its `--changed`
+  trigger includes `^platforms/web/` — a commit that extracts a new module
+  touches nothing else, and is exactly the commit shape that caused this.
+  Mutations: `tools/lib/web-release-assets-guard-mutations_test.sh`.
+
 - Sourced shell libraries: not a contract family — a tripwire,
   `tools/lib/shell-lib-errexit_test.sh`, over every `tools/lib/*.sh` that is
   not a `*_test.sh`. Each function it can drive must, under a caller's

--- a/examples/relay/Dockerfile
+++ b/examples/relay/Dockerfile
@@ -22,6 +22,16 @@ COPY core/ ./
 RUN go build -trimpath -ldflags "-X main.Version=${VERSION}" \
     -o /out/irrlichtrelay ./cmd/irrlichtrelay
 
+# Stage the dashboard by the SAME rule the release uses, never by a file list.
+# These COPYs sit after the go build so a web edit does not invalidate it.
+# tools/lib/stage-web.sh is the one definition of the runtime asset set; a
+# hand-written list here is exactly what shipped a blank dashboard to every
+# install for three releases (#1900), and it went stale the same way this
+# image's own "only the three runtime files" comment had.
+COPY tools/lib/stage-web.sh /stage-web.sh
+COPY platforms/web/ /src/webtree/
+RUN bash -c '. /stage-web.sh && stage_web /src/webtree /out/web'
+
 # ---- runtime: the binary + a baked-in dashboard snapshot ----
 FROM debian:bookworm-slim AS runtime
 # Run as a non-root user rather than the image's root default (docker:S6471)
@@ -30,8 +40,9 @@ RUN useradd --no-create-home --uid 10001 relay
 COPY --from=build /out/irrlichtrelay /usr/local/bin/irrlichtrelay
 # Bake the live dashboard so http://<host>:7839 serves it. NOTE: this is a
 # snapshot — unlike the daemon's live disk-serve, web edits need an image
-# rebuild. Only the three runtime files (no tests / node_modules).
-COPY --chown=relay:relay platforms/web/index.html platforms/web/irrlicht.css platforms/web/irrlicht.js /web/
+# rebuild. The tree comes from the build stage, already reduced to the runtime
+# set by stage_web (no tests, no vitest config, no node_modules, no snapshots).
+COPY --from=build --chown=relay:relay /out/web/ /web/
 ENV IRRLICHT_UI_DIR=/web
 USER relay
 EXPOSE 7839

--- a/site/install.sh
+++ b/site/install.sh
@@ -397,9 +397,28 @@ if [ "$DAEMON_ONLY" -eq 1 ]; then
     mkdir -p "$(dirname "$DEST")"
     install -m 755 "$TMPDIR/extract/irrlichd" "$DEST"
     mkdir -p "$UI_DIR"
-    install -m 644 "$TMPDIR/extract/web/index.html" "$UI_DIR/index.html"
-    install -m 644 "$TMPDIR/extract/web/irrlicht.css" "$UI_DIR/irrlicht.css"
-    install -m 644 "$TMPDIR/extract/web/irrlicht.js"  "$UI_DIR/irrlicht.js"
+    # The dashboard is installed as a WHOLE TREE, never as a file list. The
+    # tarball's web/ dir is already exactly the runtime set — the build staged
+    # it by rule (tools/lib/stage-web.sh) — so anything this side re-lists can
+    # only go stale. It did: these three names were the entire dashboard when
+    # they were written, and after irrlicht.js became an ES module importing
+    # ten siblings they installed 3 of 13 files, so every import 404'd and the
+    # dashboard rendered blank on every Linux install, where it is the only UI
+    # there is (#1900).
+    web_installed=0
+    for web_asset in "$TMPDIR"/extract/web/*; do
+        [ -f "$web_asset" ] || continue
+        install -m 644 "$web_asset" "$UI_DIR/$(basename "$web_asset")" ||
+            fail "Could not install $(basename "$web_asset") into $UI_DIR"
+        web_installed=$((web_installed + 1))
+    done
+    # An empty web/ must not read like a successful install: the daemon would
+    # come up and serve the 503 "Dashboard UI not found" page, which is what
+    # this step exists to prevent.
+    [ "$web_installed" -gt 0 ] ||
+        fail "The downloaded archive carried no dashboard files — aborting"
+    [ -f "$UI_DIR/index.html" ] ||
+        fail "The downloaded archive carried no index.html — aborting"
     ok
 
     # On Linux, install a systemd user unit so the autostart command we print

--- a/tools/build-release.sh
+++ b/tools/build-release.sh
@@ -8,10 +8,11 @@ ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 cd "$ROOT_DIR"
 
 # The dashboard's runtime asset set is defined ONCE, as a rule, in
-# tools/lib/stage-web.sh, and staged from there into all three release
-# artifacts below. It used to be a hand-written three-file `cp` list repeated
-# at each site, which stopped being the whole dashboard in #712/#820 and
-# shipped a blank page to every installed user (#1900).
+# tools/lib/stage-web.sh, and staged from there at the three call sites below
+# — which cover four artifacts, since the Linux one runs per-arch. It used to
+# be a hand-written three-file `cp` list repeated at each site, which stopped
+# being the whole dashboard in #712/#820 and shipped a blank page to every
+# installed user (#1900). tools/web-release-assets-guard.sh keeps it that way.
 # shellcheck source=lib/stage-web.sh
 . "$SCRIPT_DIR/lib/stage-web.sh"
 

--- a/tools/build-release.sh
+++ b/tools/build-release.sh
@@ -7,6 +7,14 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 cd "$ROOT_DIR"
 
+# The dashboard's runtime asset set is defined ONCE, as a rule, in
+# tools/lib/stage-web.sh, and staged from there into all three release
+# artifacts below. It used to be a hand-written three-file `cp` list repeated
+# at each site, which stopped being the whole dashboard in #712/#820 and
+# shipped a blank page to every installed user (#1900).
+# shellcheck source=lib/stage-web.sh
+. "$SCRIPT_DIR/lib/stage-web.sh"
+
 # Read version from version.json (single source of truth). build-release.sh
 # always uses the BARE base version — release artifacts must not carry git
 # sha or .dirty markers in the binary's --version output, since the tagged
@@ -62,7 +70,7 @@ TARBALL_STAGING="$BUILD_DIR/tarball-staging"
 rm -rf "$TARBALL_STAGING"
 mkdir -p "$TARBALL_STAGING/web"
 cp "$BUILD_DIR/${DAEMON_NAME}-darwin-universal" "$TARBALL_STAGING/${DAEMON_NAME}"
-cp platforms/web/index.html platforms/web/irrlicht.css platforms/web/irrlicht.js "$TARBALL_STAGING/web/"
+stage_web platforms/web "$TARBALL_STAGING/web"
 tar -czf "$BUILD_DIR/${DAEMON_NAME}-darwin-universal.tar.gz" -C "$TARBALL_STAGING" .
 rm -rf "$TARBALL_STAGING"
 echo "  Created $BUILD_DIR/${DAEMON_NAME}-darwin-universal.tar.gz"
@@ -84,7 +92,7 @@ build_linux_tarball() {
     rm -rf "$staging"
     mkdir -p "$staging/web"
     cp "$BUILD_DIR/${DAEMON_NAME}-linux-${arch}" "$staging/${DAEMON_NAME}"
-    cp platforms/web/index.html platforms/web/irrlicht.css platforms/web/irrlicht.js "$staging/web/"
+    stage_web platforms/web "$staging/web"
     tar -czf "$BUILD_DIR/${DAEMON_NAME}-linux-${arch}.tar.gz" -C "$staging" .
     rm -rf "$staging"
     echo "  Created $BUILD_DIR/${DAEMON_NAME}-linux-${arch}.tar.gz"
@@ -120,8 +128,8 @@ mkdir -p "$APP_CONTENTS/Resources/web"
 cp "$SWIFT_BIN" "$APP_CONTENTS/MacOS/${APP_NAME}"
 
 # Web UI lives next to the daemon — resolved by irrlichd at runtime via
-# <exe>/../Resources/web (see resolveUIDir in core/cmd/irrlichd/main.go).
-cp platforms/web/index.html platforms/web/irrlicht.css platforms/web/irrlicht.js "$APP_CONTENTS/Resources/web/"
+# <exe>/../Resources/web (see resolveUIDir in core/cmd/irrlichd/paths.go).
+stage_web platforms/web "$APP_CONTENTS/Resources/web"
 
 # AppIcon — required for menu bar / Finder display.
 cp platforms/macos/Irrlicht/Resources/AppIcon.icns "$APP_CONTENTS/Resources/AppIcon.icns"

--- a/tools/lib/shell-lib-errexit_test.sh
+++ b/tools/lib/shell-lib-errexit_test.sh
@@ -407,6 +407,32 @@ row 'rebase-conflict-check.sh::rebase_conflict_check' 'rebase_conflict_check (re
     '. tools/lib/rebase-conflict-check.sh' \
     'rebase_conflict_check 2>/dev/null'
 
+# stage-web.sh is sourced by tools/build-release.sh, which runs under `set -e`
+# from its first line — so a refusal that aborted the caller instead of
+# returning would take down a release build mid-flight rather than reporting
+# which asset tree it could not read. Its distinctive statuses are 2 (bad
+# arguments / unreadable tree) and 3 (the rule matched nothing); the success
+# path is driven against the real dashboard tree, which is what
+# build-release.sh actually passes it.
+row 'stage-web.sh::stage_web_is_dev_only' 'stage_web_is_dev_only (a runtime asset)' 1 \
+    '. tools/lib/stage-web.sh' \
+    'stage_web_is_dev_only irrlicht.js'
+row 'stage-web.sh::stage_web_list' 'stage_web_list (the real dashboard tree)' 0 \
+    '. tools/lib/stage-web.sh' \
+    'stage_web_list platforms/web >/dev/null'
+row 'stage-web.sh::stage_web_list' 'stage_web_list (refuses a tree that is not there)' 2 \
+    '. tools/lib/stage-web.sh' \
+    'stage_web_list "$TW_TMP/stage-web-absent" 2>/dev/null'
+row 'stage-web.sh::stage_web_list' 'stage_web_list (refuses a tree with no runtime asset)' 3 \
+    '. tools/lib/stage-web.sh; mkdir -p "$TW_TMP/stage-web-empty"' \
+    'stage_web_list "$TW_TMP/stage-web-empty" 2>/dev/null'
+row 'stage-web.sh::stage_web' 'stage_web (stages the real dashboard tree)' 0 \
+    '. tools/lib/stage-web.sh' \
+    'stage_web platforms/web "$TW_TMP/stage-web-out"'
+row 'stage-web.sh::stage_web' 'stage_web (refuses without a destination)' 2 \
+    '. tools/lib/stage-web.sh' \
+    'stage_web platforms/web "" 2>/dev/null'
+
 # Driven against a THROWAWAY corpus, never against tools/lib itself: this
 # function runs every `*_test.sh` it finds, and this file is one of them, so
 # pointing it at the real directory would re-enter the whole suite (and this

--- a/tools/lib/stage-web.sh
+++ b/tools/lib/stage-web.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# stage-web.sh — the single definition of WHICH files of the web dashboard
+# tree belong in a release artifact.
+#
+# This file is sourced, not executed: it defines functions and returns.
+#
+#   . "$SCRIPT_DIR/lib/stage-web.sh"
+#   stage_web platforms/web "$TARBALL_STAGING/web"
+#
+# ---------------------------------------------------------------------------
+# Why this is a library and not three `cp` lines (#1900)
+#
+# tools/build-release.sh staged the dashboard from a hand-written three-file
+# list — index.html, irrlicht.css, irrlicht.js — written in #418, when those
+# three WERE the whole dashboard. Since #712 and #820, irrlicht.js is an ES
+# module that imports ten siblings, and none of them were on the list. Every
+# import 404'd in every release artifact (the macOS .app, the darwin daemon
+# tarball, both Linux daemon tarballs), the module graph never evaluated, and
+# the shipped dashboard rendered a blank page for every installed user on both
+# platforms until someone reported it.
+#
+# A hand-written list cannot notice a new module. A rule can. And a rule that
+# lives in ONE place can be EXECUTED by a guard
+# (tools/web-release-assets-guard.sh) rather than re-described by it — a guard
+# that reimplements the rule proves nothing about the script that ships.
+#
+# It lives here, in tools/lib/, rather than inside build-release.sh, because
+# build-release.sh runs a full signed universal build at top level under
+# `set -e`: it cannot be sourced, so a guard could only re-parse its text.
+# tools/lib/ is where this repo keeps its sourced shell libraries, and
+# tools/lib/shell-lib-errexit_test.sh grades every function in it by
+# discovering it.
+#
+# ---------------------------------------------------------------------------
+# THE RULE
+#
+# Every *.html, *.css and *.js directly inside the web tree, minus the
+# dev-only files (`*.test.js`, `vitest.config.js`, `vitest.setup.js`).
+#
+# The glob does not recurse, so `node_modules/` and `snapshots/` cannot be
+# swept in no matter how large they get, and `package.json` /
+# `package-lock.json` are not matched at all. Naming the runtime set by
+# extension and subtracting the dev files — rather than listing the runtime
+# files — is the half that makes a newly extracted module ship by default.
+
+# stage_web_is_dev_only <basename> — 0 when the file is dev-only tooling that
+# must never reach a release artifact, 1 when it is a runtime asset.
+stage_web_is_dev_only() {
+    case "$1" in
+        *.test.js|vitest.config.js|vitest.setup.js) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+# stage_web_list <src> — one runtime-asset basename per line, sorted.
+#
+# Refuses loudly rather than emitting an empty list: "the tree has no runtime
+# assets" and "I could not look at the tree" must not print the same thing.
+#   2  <src> is empty or is not a directory
+#   3  the rule matched nothing at all
+#   4  the matched set has no index.html, so this is not a dashboard tree
+stage_web_list() {
+    local src="$1" f base out=""
+    if [[ -z "$src" || ! -d "$src" ]]; then
+        echo "stage_web: source tree not found: ${src:-<empty>}" >&2
+        return 2
+    fi
+    for f in "$src"/*.html "$src"/*.css "$src"/*.js; do
+        [[ -f "$f" ]] || continue
+        base=${f##*/}
+        stage_web_is_dev_only "$base" && continue
+        out="$out$base"$'\n'
+    done
+    if [[ -z "$out" ]]; then
+        echo "stage_web: no runtime asset matched in $src — the staging rule found nothing to ship" >&2
+        return 3
+    fi
+    case $'\n'"$out" in
+        *$'\n'index.html$'\n'*) : ;;
+        *)
+            echo "stage_web: $src has no index.html — this is not a dashboard tree" >&2
+            return 4
+            ;;
+    esac
+    printf '%s' "$out" | LC_ALL=C sort
+}
+
+# stage_web <src> <dest> — copy the runtime asset set from <src> into <dest>,
+# creating <dest>. Returns stage_web_list's status when the rule refuses, plus:
+#   2  no destination given
+#   5  <dest> could not be created
+#   6  a matched file could not be copied
+stage_web() {
+    local src="$1" dest="$2" list base
+    if [[ -z "$dest" ]]; then
+        echo "stage_web: no destination given" >&2
+        return 2
+    fi
+    list=$(stage_web_list "$src") || return $?
+    if ! mkdir -p "$dest"; then
+        echo "stage_web: could not create $dest" >&2
+        return 5
+    fi
+    while IFS= read -r base; do
+        [[ -n "$base" ]] || continue
+        if ! cp "$src/$base" "$dest/$base"; then
+            echo "stage_web: could not copy $base into $dest" >&2
+            return 6
+        fi
+    done <<<"$list"
+    return 0
+}

--- a/tools/lib/web-release-assets-guard-mutations_test.sh
+++ b/tools/lib/web-release-assets-guard-mutations_test.sh
@@ -7,28 +7,37 @@
 # the thing it protects is broken. This one is unusual in also having a real
 # "before the fix" — the defect was live on main, and the guard's closure run
 # against origin/main's own `cp` line names all ten missing modules — but that
-# red is a one-off nobody re-runs. These six mutations are the part that keeps
-# re-running, each breaking ONE property, because a single combined mutation
-# could go red while one of the properties was in fact unguarded:
+# red is a one-off nobody re-runs. The rows below are the part that keeps
+# re-running. Each breaks ONE property, because a single combined mutation
+# could go red while one of the properties was in fact unguarded. The
+# properties, not the row count — the count drifts, the list is the file:
 #
-#   1. THE WALK IS TRANSITIVE. collapsedSet.js is imported by
-#      collapsedGroups.js and collapsedSummaries.js and by nothing else, so a
-#      scan of irrlicht.js's DIRECT imports finds 9 of the 10 modules and
-#      reports completeness. Dropping collapsedSet.js from the staged set is
-#      the mutation that a direct-only scan would sail straight past.
-#   2. ...AND IT COVERS THE DIRECT EDGES TOO. Dropping formatters.js, a
-#      first-hop import, so 1's pass cannot be an accident of depth.
-#   3. THE DEV-ONLY HALF IS REAL. Without it, `cp -R platforms/web/` —
-#      node_modules and all — satisfies every "nothing is missing" assertion.
-#   4. THE SCAN CAN ACTUALLY READ THE TREE. irrlicht.js and sessionIdentity.js
-#      carry literal NUL bytes; a grep without `-a` answers "Binary file …
-#      matches" and yields no edges. This is the exact shape of vacuity the
-#      guard exists to refuse, so it is mutated rather than trusted.
-#   5. ...AND SAYS SO WHEN IT CANNOT. Disabling the zero-edge refusal, so an
-#      unreadable tree would report success instead.
-#   6. THE SHIPPING SCRIPT STAYS ATTACHED TO THE RULE. 1-5 all grade
-#      tools/lib/stage-web.sh; this one puts a hand-written `cp` back into
-#      tools/build-release.sh, which is what actually shipped the bug.
+#   THE WALK IS TRANSITIVE. collapsedSet.js is imported by collapsedGroups.js
+#     and collapsedSummaries.js and by nothing else, so a scan of irrlicht.js's
+#     DIRECT imports finds 9 of the 10 modules and reports completeness.
+#     Dropping collapsedSet.js is the mutation a direct-only scan sails past.
+#   ...AND IT COVERS THE DIRECT EDGES TOO. Dropping formatters.js, a first-hop
+#     import, so the transitive row's pass cannot be an accident of depth.
+#   THE DEV-ONLY HALF IS REAL. Without it, `cp -R platforms/web/` —
+#     node_modules and all — satisfies every "nothing is missing" assertion.
+#   THE SCAN CAN ACTUALLY READ THE TREE. irrlicht.js and sessionIdentity.js
+#     carry literal NUL bytes; a grep without `-a` answers "Binary file …
+#     matches" and yields no edges. That is the exact shape of vacuity the
+#     guard exists to refuse, so it is mutated rather than trusted — and the
+#     fixture's own NUL is mutated away too, because the first spelling of
+#     that check used `$'\000'`, which bash expands to the empty string.
+#   ...AND SAYS SO WHEN IT CANNOT. The zero-edge refusal disarmed, so an
+#     unreadable tree would report success instead.
+#   EVERY DISTRIBUTABLE STAYS ATTACHED TO THE RULE. Four separate sites:
+#     tools/build-release.sh, the release skill's manual fallback blocks,
+#     site/install.sh and examples/relay/Dockerfile. The last two were live
+#     misses found in review — the installer laid down 3 files out of a
+#     13-file tarball, so fixing only the producer would have left the Linux
+#     dashboard blank, which is the platform the issue is about.
+#   THE GATE KEEPS FIRING. `^platforms/web/` removed from either preflight
+#     trigger, so a diff that extracts a new module SKIPs the gate silently.
+#   CSS REFERENCES ARE REFUSED, NOT IGNORED. The walk follows HTML and JS, so
+#     a stylesheet that grows an @import must fail rather than pass unseen.
 #
 # Every row drives the real tools/mutate.sh, which owns the mechanics this file
 # must not re-improvise: the stale-anchor guard, the no-op replacement refusal,
@@ -84,7 +93,7 @@ fails=0
 
 DEV_ONLY_ANCHOR='        *.test.js|vitest.config.js|vitest.setup.js) return 0 ;;'
 
-# ── 1. The walk is transitive: collapsedSet.js specifically ─────────────────
+# ── The walk is transitive: collapsedSet.js specifically ─────────────────
 assert_mutation_is_red \
   "lock test catches the staging rule dropping collapsedSet.js — the module NO file imports directly" \
   "$STAGE_LIB" \
@@ -92,7 +101,7 @@ assert_mutation_is_red \
   '        *.test.js|vitest.config.js|vitest.setup.js|collapsedSet.js) return 0 ;;' \
   "'collapsedSet.js' is reachable from index.html but tools/build-release.sh would not stage it"
 
-# ── 2. ...and the direct edges are covered too ───────────────────────────────
+# ── ...and the direct edges are covered too ───────────────────────────────
 assert_mutation_is_red \
   "lock test catches the staging rule dropping formatters.js — a first-hop import" \
   "$STAGE_LIB" \
@@ -100,7 +109,7 @@ assert_mutation_is_red \
   '        *.test.js|vitest.config.js|vitest.setup.js|formatters.js) return 0 ;;' \
   "'formatters.js' is reachable from index.html but tools/build-release.sh would not stage it"
 
-# ── 3. The dev-only half is real ────────────────────────────────────────────
+# ── The dev-only half is real ────────────────────────────────────────────
 assert_mutation_is_red \
   "lock test catches the staging rule shipping *.test.js into the release tree" \
   "$STAGE_LIB" \
@@ -108,7 +117,7 @@ assert_mutation_is_red \
   '        vitest.config.js|vitest.setup.js) return 0 ;;' \
   "is dev-only tooling and must not ship in a release artifact"
 
-# ── 4. The scan can actually read a NUL-containing module ────────────────────
+# ── The scan can actually read a NUL-containing module ────────────────────
 #
 # Precondition, asserted rather than assumed: this machine's grep must treat a
 # NUL-containing file as binary, or removing `-a` changes nothing here and the
@@ -134,7 +143,7 @@ else
     "the walk refused on a module containing a NUL byte"
 fi
 
-# ── 5. ...and refuses out loud when it finds nothing ─────────────────────────
+# ── ...and refuses out loud when it finds nothing ─────────────────────────
 assert_mutation_is_red \
   "lock test catches the zero-import-edge refusal being disarmed, so an unreadable tree would pass" \
   "$GUARD" \
@@ -142,15 +151,36 @@ assert_mutation_is_red \
   '    if [[ "$edges" -lt 0 ]]; then' \
   "a module graph with not one import edge — expected REFUSE (2)"
 
-# ── 6. build-release.sh stays attached to the rule ──────────────────────────
+# ── Every distributable stays attached to the rule ───────────────────────
+#
+# Four sites, mutated separately, because the guard's first spelling named two
+# of them explicitly and the sweep that replaced it is what catches the other
+# two. site/install.sh and examples/relay/Dockerfile were BOTH live misses:
+# the installer laid down 3 files out of a 13-file tarball, so fixing only the
+# producer would have left the Linux dashboard blank — which is the platform
+# the issue is about.
 assert_mutation_is_red \
   "lock test catches tools/build-release.sh staging the web tree by hand again" \
   "$BUILD_RELEASE" \
   'stage_web platforms/web "$APP_CONTENTS/Resources/web"' \
   'cp platforms/web/index.html platforms/web/irrlicht.css platforms/web/irrlicht.js "$APP_CONTENTS/Resources/web/"' \
-  "touches platforms/web outside stage_web"
+  "tools/build-release.sh:"
 
-# ── 7. The gates keep firing on a platforms/web-only diff ───────────────────
+assert_mutation_is_red \
+  "lock test catches site/install.sh installing a hand-written file list again" \
+  "site/install.sh" \
+  '        install -m 644 "$web_asset" "$UI_DIR/$(basename "$web_asset")" ||' \
+  '        install -m 644 "$TMPDIR/extract/web/index.html" "$UI_DIR/index.html" ||' \
+  "site/install.sh:"
+
+assert_mutation_is_red \
+  "lock test catches examples/relay/Dockerfile baking a hand-written file list again" \
+  "examples/relay/Dockerfile" \
+  'COPY --from=build --chown=relay:relay /out/web/ /web/' \
+  'COPY --chown=relay:relay platforms/web/index.html platforms/web/irrlicht.css platforms/web/irrlicht.js /web/' \
+  "examples/relay/Dockerfile:"
+
+# ── The gates keep firing on a platforms/web-only diff ───────────────────
 #
 # The failure this pair pins is silence, not a wrong answer: drop
 # `^platforms/web/` from a trigger and preflight --changed reports SKIP —
@@ -170,7 +200,7 @@ assert_mutation_is_red \
   '^AGENTS\.md$|^\.claude/skills/ir:test-mac/' \
   "'tools/lib shell-lib tests' would be SKIPped by preflight --changed"
 
-# ── 9. The release PROCEDURE stays attached to the rule too ─────────────────
+# ── The release PROCEDURE stays attached to the rule too ─────────────────
 #
 # tools/build-release.sh is not the only thing that assembles a release: the
 # manual per-artifact blocks in .claude/skills/ir:release/SKILL.md are the
@@ -182,12 +212,12 @@ assert_mutation_is_red \
   "lock test catches the release skill copying the web tree by hand again" \
   "$RELEASE_SKILL" \
   '  stage_web platforms/web /tmp/irrlichd-tarball/web )' \
-  '  cp platforms/web/index.html /tmp/irrlichd-tarball/web/ )' \
-  "copies platforms/web by hand"
+  'cp platforms/web/index.html /tmp/irrlichd-tarball/web/ )' \
+  ".claude/skills/ir:release/SKILL.md:"
 
-# ── 10. The NUL fixture's own vacuity guard fires ───────────────────────────
+# ── The NUL fixture's own vacuity guard fires ───────────────────────────
 #
-# Row 4 above is only worth anything while its fixture really carries a NUL.
+# The NUL row is only worth anything while its fixture really carries a NUL.
 # The first spelling of this guard used `grep -q $'\000'`, which bash expands
 # to the empty string — it matched every file and could never fire. So the
 # guard on the fixture is itself mutated: take the NUL out of the fixture and
@@ -199,7 +229,7 @@ assert_mutation_is_red \
   $'printf \'const SEP = "";\\nimport { x } from \'\\\'\'./dep.js\'\\\'\';\\n\' >"$NUL/app.js"' \
   "the NUL fixture carries no NUL byte"
 
-# ── 11. A CSS reference the walker cannot follow is refused ─────────────────
+# ── A CSS reference the walker cannot follow is refused ─────────────────
 #
 # The walk follows HTML and JavaScript references, not CSS ones. That is safe
 # only while the stylesheet has none — so the stylesheet is checked, and this

--- a/tools/lib/web-release-assets-guard-mutations_test.sh
+++ b/tools/lib/web-release-assets-guard-mutations_test.sh
@@ -49,6 +49,7 @@ STAGE_LIB="tools/lib/stage-web.sh"
 GUARD="tools/web-release-assets-guard.sh"
 BUILD_RELEASE="tools/build-release.sh"
 PREFLIGHT="tools/preflight.sh"
+RELEASE_SKILL=".claude/skills/ir:release/SKILL.md"
 
 # shellcheck source=tools/lib/mutation-assert.sh
 . "$DIR/mutation-assert.sh"
@@ -168,6 +169,47 @@ assert_mutation_is_red \
   '^AGENTS\.md$|^platforms/web/|^\.claude/skills/ir:test-mac/' \
   '^AGENTS\.md$|^\.claude/skills/ir:test-mac/' \
   "'tools/lib shell-lib tests' would be SKIPped by preflight --changed"
+
+# ── 9. The release PROCEDURE stays attached to the rule too ─────────────────
+#
+# tools/build-release.sh is not the only thing that assembles a release: the
+# manual per-artifact blocks in .claude/skills/ir:release/SKILL.md are the
+# documented fallback, and every one of them used to `cp` the web tree by hand
+# — two of them copying index.html alone, which is this bug with one file
+# instead of three. Guarding only the script would leave the defect sitting in
+# the document a human reads.
+assert_mutation_is_red \
+  "lock test catches the release skill copying the web tree by hand again" \
+  "$RELEASE_SKILL" \
+  '  stage_web platforms/web /tmp/irrlichd-tarball/web )' \
+  '  cp platforms/web/index.html /tmp/irrlichd-tarball/web/ )' \
+  "copies platforms/web by hand"
+
+# ── 10. The NUL fixture's own vacuity guard fires ───────────────────────────
+#
+# Row 4 above is only worth anything while its fixture really carries a NUL.
+# The first spelling of this guard used `grep -q $'\000'`, which bash expands
+# to the empty string — it matched every file and could never fire. So the
+# guard on the fixture is itself mutated: take the NUL out of the fixture and
+# the lock test must say so.
+assert_mutation_is_red \
+  "lock test notices its own NUL fixture losing its NUL byte" \
+  "$LOCK_TEST" \
+  $'printf \'const SEP = "\\000";\\nimport { x } from \'\\\'\'./dep.js\'\\\'\';\\n\' >"$NUL/app.js"' \
+  $'printf \'const SEP = "";\\nimport { x } from \'\\\'\'./dep.js\'\\\'\';\\n\' >"$NUL/app.js"' \
+  "the NUL fixture carries no NUL byte"
+
+# ── 11. A CSS reference the walker cannot follow is refused ─────────────────
+#
+# The walk follows HTML and JavaScript references, not CSS ones. That is safe
+# only while the stylesheet has none — so the stylesheet is checked, and this
+# row proves the check is real rather than decorative.
+assert_mutation_is_red \
+  "lock test catches a CSS @import the walker does not follow" \
+  "platforms/web/irrlicht.css" \
+  '    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }' \
+  $'@import url(\'./theme/dark.css\');\n    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }' \
+  "carries a CSS reference this walker does not follow"
 
 if [[ $fails -gt 0 ]]; then
   echo "web-release-assets-guard-mutations: $fails FAILED"

--- a/tools/lib/web-release-assets-guard-mutations_test.sh
+++ b/tools/lib/web-release-assets-guard-mutations_test.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+# web-release-assets-guard-mutations_test.sh — the committed mutation fixtures
+# for tools/lib/web-release-assets-guard_test.sh (#1900).
+#
+# WHY THIS FILE EXISTS. The #1900 fix ADDS a guard, and per AGENTS.md and
+# docs/testing-philosophy.md a guard earns its place by being seen to fail when
+# the thing it protects is broken. This one is unusual in also having a real
+# "before the fix" — the defect was live on main, and the guard's closure run
+# against origin/main's own `cp` line names all ten missing modules — but that
+# red is a one-off nobody re-runs. These six mutations are the part that keeps
+# re-running, each breaking ONE property, because a single combined mutation
+# could go red while one of the properties was in fact unguarded:
+#
+#   1. THE WALK IS TRANSITIVE. collapsedSet.js is imported by
+#      collapsedGroups.js and collapsedSummaries.js and by nothing else, so a
+#      scan of irrlicht.js's DIRECT imports finds 9 of the 10 modules and
+#      reports completeness. Dropping collapsedSet.js from the staged set is
+#      the mutation that a direct-only scan would sail straight past.
+#   2. ...AND IT COVERS THE DIRECT EDGES TOO. Dropping formatters.js, a
+#      first-hop import, so 1's pass cannot be an accident of depth.
+#   3. THE DEV-ONLY HALF IS REAL. Without it, `cp -R platforms/web/` —
+#      node_modules and all — satisfies every "nothing is missing" assertion.
+#   4. THE SCAN CAN ACTUALLY READ THE TREE. irrlicht.js and sessionIdentity.js
+#      carry literal NUL bytes; a grep without `-a` answers "Binary file …
+#      matches" and yields no edges. This is the exact shape of vacuity the
+#      guard exists to refuse, so it is mutated rather than trusted.
+#   5. ...AND SAYS SO WHEN IT CANNOT. Disabling the zero-edge refusal, so an
+#      unreadable tree would report success instead.
+#   6. THE SHIPPING SCRIPT STAYS ATTACHED TO THE RULE. 1-5 all grade
+#      tools/lib/stage-web.sh; this one puts a hand-written `cp` back into
+#      tools/build-release.sh, which is what actually shipped the bug.
+#
+# Every row drives the real tools/mutate.sh, which owns the mechanics this file
+# must not re-improvise: the stale-anchor guard, the no-op replacement refusal,
+# and the byte-for-byte restore that never touches git state (worktrees share
+# the parent repo's .git dir, so `git checkout --` / `git restore` /
+# `git reset --hard` are banned repo-wide). `assert_mutation_is_red` lives in
+# tools/lib/mutation-assert.sh. Convention follows
+# tools/lib/simplify-angle-guard-mutations_test.sh.
+
+set -uo pipefail
+
+DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$DIR/../.." && pwd)"
+MUTATE_SH="$REPO_ROOT/tools/mutate.sh"
+# shellcheck disable=SC2034  # read by assert_mutation_is_red in the sourced mutation-assert.sh, not here
+LOCK_TEST="tools/lib/web-release-assets-guard_test.sh"
+STAGE_LIB="tools/lib/stage-web.sh"
+GUARD="tools/web-release-assets-guard.sh"
+BUILD_RELEASE="tools/build-release.sh"
+PREFLIGHT="tools/preflight.sh"
+
+# shellcheck source=tools/lib/mutation-assert.sh
+. "$DIR/mutation-assert.sh"
+
+need() { command -v "$1" >/dev/null 2>&1 || { echo "FAIL: web-release-assets-guard-mutations — $1 not found" >&2; exit 1; }; }
+need bash
+need git
+need grep
+
+if [[ ! -x "$MUTATE_SH" ]]; then
+  echo "FAIL: web-release-assets-guard-mutations — $MUTATE_SH is missing or not executable" >&2
+  exit 1
+fi
+
+# mutate.sh refuses (exit 4) against an already-dirty tree, because its
+# post-restore emptiness check could prove nothing then. A dirty tree must not
+# silently pass — same guard, same wording, as every other fixture here.
+if [[ -n "$(git -C "$REPO_ROOT" status --porcelain)" ]]; then
+  echo "web-release-assets-guard-mutations: CANNOT RUN — the worktree is dirty, and mutate.sh needs a" >&2
+  echo "  clean tree for its post-restore check to mean anything. Commit or clean up, then:" >&2
+  echo "    bash tools/lib/web-release-assets-guard-mutations_test.sh" >&2
+  if [[ -n "${CI:-}" || -n "${MUTATION_FIXTURES_STRICT:-}" ]]; then
+    echo "  (failing rather than skipping: CI/strict mode, where a skip is indistinguishable" >&2
+    echo "   from a pass and this gate is the only thing re-running these mutations)" >&2
+    exit 1
+  fi
+  echo "  (skipped locally; set MUTATION_FIXTURES_STRICT=1 to make this a failure)" >&2
+  exit 0
+fi
+
+fails=0
+
+DEV_ONLY_ANCHOR='        *.test.js|vitest.config.js|vitest.setup.js) return 0 ;;'
+
+# ── 1. The walk is transitive: collapsedSet.js specifically ─────────────────
+assert_mutation_is_red \
+  "lock test catches the staging rule dropping collapsedSet.js — the module NO file imports directly" \
+  "$STAGE_LIB" \
+  "$DEV_ONLY_ANCHOR" \
+  '        *.test.js|vitest.config.js|vitest.setup.js|collapsedSet.js) return 0 ;;' \
+  "'collapsedSet.js' is reachable from index.html but tools/build-release.sh would not stage it"
+
+# ── 2. ...and the direct edges are covered too ───────────────────────────────
+assert_mutation_is_red \
+  "lock test catches the staging rule dropping formatters.js — a first-hop import" \
+  "$STAGE_LIB" \
+  "$DEV_ONLY_ANCHOR" \
+  '        *.test.js|vitest.config.js|vitest.setup.js|formatters.js) return 0 ;;' \
+  "'formatters.js' is reachable from index.html but tools/build-release.sh would not stage it"
+
+# ── 3. The dev-only half is real ────────────────────────────────────────────
+assert_mutation_is_red \
+  "lock test catches the staging rule shipping *.test.js into the release tree" \
+  "$STAGE_LIB" \
+  "$DEV_ONLY_ANCHOR" \
+  '        vitest.config.js|vitest.setup.js) return 0 ;;' \
+  "is dev-only tooling and must not ship in a release artifact"
+
+# ── 4. The scan can actually read a NUL-containing module ────────────────────
+#
+# Precondition, asserted rather than assumed: this machine's grep must treat a
+# NUL-containing file as binary, or removing `-a` changes nothing here and the
+# row below would report a false GREEN. Reported as a failure, not a skip —
+# "the mutation did not go red" and "this machine cannot judge the mutation"
+# must not print the same thing.
+NUL_PROBE=$(mktemp -t wrag-nul-probe) || exit 1
+printf 'a\000\nfrom\n' >"$NUL_PROBE"
+probe_out=$(LC_ALL=C command grep -oE 'from' "$NUL_PROBE" 2>&1)
+rm -f "$NUL_PROBE"
+if [[ "$probe_out" == "from" ]]; then
+  echo "FAIL: the NUL mutation cannot be judged on this machine — $(command -v grep) does not treat a"
+  echo "      NUL-containing file as binary, so dropping \`-a\` from the guard's scan is a no-op here."
+  echo "      The guard still needs \`-a\` (GNU grep in CI does suppress the matches); this fixture"
+  echo "      simply cannot prove it from this host."
+  fails=$((fails + 1))
+else
+  assert_mutation_is_red \
+    "lock test catches the import scan losing \`grep -a\` and reading a NUL-containing module as binary" \
+    "$GUARD" \
+    '_wrag_text_grep() { LC_ALL=C command grep -a "$@"; }' \
+    '_wrag_text_grep() { LC_ALL=C command grep "$@"; }' \
+    "the walk refused on a module containing a NUL byte"
+fi
+
+# ── 5. ...and refuses out loud when it finds nothing ─────────────────────────
+assert_mutation_is_red \
+  "lock test catches the zero-import-edge refusal being disarmed, so an unreadable tree would pass" \
+  "$GUARD" \
+  '    if [[ "$edges" -eq 0 ]]; then' \
+  '    if [[ "$edges" -lt 0 ]]; then' \
+  "a module graph with not one import edge — expected REFUSE (2)"
+
+# ── 6. build-release.sh stays attached to the rule ──────────────────────────
+assert_mutation_is_red \
+  "lock test catches tools/build-release.sh staging the web tree by hand again" \
+  "$BUILD_RELEASE" \
+  'stage_web platforms/web "$APP_CONTENTS/Resources/web"' \
+  'cp platforms/web/index.html platforms/web/irrlicht.css platforms/web/irrlicht.js "$APP_CONTENTS/Resources/web/"' \
+  "touches platforms/web outside stage_web"
+
+# ── 7. The gates keep firing on a platforms/web-only diff ───────────────────
+#
+# The failure this pair pins is silence, not a wrong answer: drop
+# `^platforms/web/` from a trigger and preflight --changed reports SKIP —
+# exit-code-neutral, indistinguishable from "this diff cannot break it" — for
+# exactly the commit that extracts a new module.
+assert_mutation_is_red \
+  "lock test catches ^platforms/web/ leaving the packaging guard's own trigger" \
+  "$PREFLIGHT" \
+  "  run_gate_scoped '^platforms/web/|^tools/lib/stage-web\\.sh\$|^tools/web-release-assets-guard\\.sh\$|^tools/build-release\\.sh\$' \\" \
+  "  run_gate_scoped '^tools/lib/stage-web\\.sh\$|^tools/web-release-assets-guard\\.sh\$|^tools/build-release\\.sh\$' \\" \
+  "'web release assets' would be SKIPped by preflight --changed"
+
+assert_mutation_is_red \
+  "lock test catches ^platforms/web/ leaving the shell-lib tests trigger" \
+  "$PREFLIGHT" \
+  '^AGENTS\.md$|^platforms/web/|^\.claude/skills/ir:test-mac/' \
+  '^AGENTS\.md$|^\.claude/skills/ir:test-mac/' \
+  "'tools/lib shell-lib tests' would be SKIPped by preflight --changed"
+
+if [[ $fails -gt 0 ]]; then
+  echo "web-release-assets-guard-mutations: $fails FAILED"
+  exit 1
+fi
+echo "web-release-assets-guard-mutations: ALL PASS"

--- a/tools/lib/web-release-assets-guard_test.sh
+++ b/tools/lib/web-release-assets-guard_test.sh
@@ -1,0 +1,334 @@
+#!/usr/bin/env bash
+# web-release-assets-guard_test.sh — the lock over tools/web-release-assets-guard.sh
+# and tools/lib/stage-web.sh (#1900).
+#
+# It grades three things:
+#
+#   1. THE REAL REPO. The guard runs clean against this checkout, and the
+#      closure it computes really does contain collapsedSet.js — the module
+#      NOTHING imports directly, which is what separates a transitive walk
+#      from a scan of irrlicht.js's direct imports that merely looks right.
+#      A direct-only scan finds 9 of the 10 modules and calls itself complete.
+#
+#   2. THE STAGING RULE, against synthetic trees: a newly extracted module
+#      ships by default, and dev-only tooling never does.
+#
+#   3. FAIL-LOUDLY. Every way the guard can be unable to look must REFUSE (2),
+#      never report success on an empty answer: no tree, no index.html, an
+#      index.html with no entry point, a module graph with no import edge, a
+#      reference to a file that does not exist, and a reference into a
+#      subdirectory that the non-recursive staging rule would silently drop.
+#      That last pair is not hypothetical bookkeeping — the whole defect this
+#      guard exists for was a staging step that silently dropped nine files.
+#
+# The mutation half — breaking the protected thing and confirming this file
+# goes red — lives in tools/lib/web-release-assets-guard-mutations_test.sh.
+
+set -uo pipefail
+
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || {
+  echo "FAIL: web-release-assets-guard_test — not inside a git repository" >&2
+  exit 1
+}
+cd "$REPO_ROOT" || {
+  echo "FAIL: web-release-assets-guard_test — cannot cd to repo root $REPO_ROOT" >&2
+  exit 1
+}
+
+GUARD=tools/web-release-assets-guard.sh
+for f in "$GUARD" tools/lib/stage-web.sh platforms/web/index.html; do
+  [[ -f "$f" ]] || { echo "FAIL: web-release-assets-guard_test — $f is missing; the subject is gone" >&2; exit 1; }
+done
+
+# shellcheck source=../web-release-assets-guard.sh
+. "$REPO_ROOT/$GUARD"
+# shellcheck source=stage-web.sh
+. "$REPO_ROOT/tools/lib/stage-web.sh"
+
+TMP=$(mktemp -d -t web-release-assets-guard_test) || exit 1
+trap 'rm -rf "$TMP"' EXIT
+
+rc=0
+fail() { echo "FAIL: $1" >&2; rc=1; }
+pass() { echo "  PASS: $1"; }
+
+# expect_refuse <label> <src-dir> <fragment> — the closure must REFUSE (2) and
+# say why. A guard that returned 0 with an empty closure would satisfy every
+# "nothing is missing" assertion in this file, so the status AND the reason
+# are both asserted.
+expect_refuse() {
+  local label="$1" dir="$2" want="$3" out st
+  out=$(web_assets_closure "$dir" 2>&1)
+  st=$?
+  if [[ "$st" -ne 2 ]]; then
+    fail "$label — expected REFUSE (2), got status $st with: $(echo "$out" | tr '\n' ' ')"
+    return
+  fi
+  case "$out" in
+    *"$want"*) pass "$label" ;;
+    *) fail "$label — refused, but not for the stated reason (wanted: $want); got: $(echo "$out" | tr '\n' ' ')" ;;
+  esac
+}
+
+# ---------------------------------------------------------------------------
+# 1. The real repository.
+
+echo "== the guard runs clean against this checkout =="
+guard_out=$(bash "$GUARD" 2>&1)
+guard_st=$?
+if [[ "$guard_st" -ne 0 ]]; then
+  fail "the guard must be green on a correct tree — exit $guard_st"
+  echo "$guard_out" | sed 's/^/      | /' >&2
+else
+  pass "tools/web-release-assets-guard.sh exits 0 on this checkout"
+fi
+
+echo "== the closure over the REAL platforms/web is transitive and non-empty =="
+real_closure=$(web_assets_closure platforms/web 2>&1)
+real_st=$?
+if [[ "$real_st" -ne 0 ]]; then
+  fail "the closure over the real web tree must succeed — exit $real_st: $(echo "$real_closure" | tr '\n' ' ')"
+else
+  n=$(printf '%s\n' "$real_closure" | grep -c . )
+  # A vacuity guard on this file itself: a closure that shrank to a handful of
+  # entries would still satisfy the membership assertions below.
+  if [[ "$n" -lt 10 ]]; then
+    fail "the real closure has only $n entries — this file is no longer examining the real dashboard"
+  else
+    pass "the real closure has $n entries"
+  fi
+  for want in index.html irrlicht.css irrlicht.js collapsedSet.js; do
+    case $'\n'"$real_closure"$'\n' in
+      *$'\n'"$want"$'\n'*) pass "closure contains $want" ;;
+      *) fail "closure over the real tree is missing $want" ;;
+    esac
+  done
+  # The load-bearing one, spelled out: collapsedSet.js is imported by
+  # collapsedGroups.js and collapsedSummaries.js and by nothing else, so it is
+  # present ONLY if the walk is transitive.
+  if ! grep -aq "collapsedSet.js" platforms/web/collapsedGroups.js; then
+    fail "collapsedGroups.js no longer imports collapsedSet.js — this file's transitivity claim rests on an edge that is gone; re-pick the depth-3 module"
+  else
+    pass "collapsedSet.js is still reachable only transitively (via collapsedGroups.js)"
+  fi
+  if grep -aq "from '\./collapsedSet\.js'" platforms/web/irrlicht.js; then
+    fail "irrlicht.js now imports collapsedSet.js directly — a direct-import scan would pass, so this file's transitivity assertion no longer distinguishes anything"
+  else
+    pass "irrlicht.js does not import collapsedSet.js directly"
+  fi
+fi
+
+echo "== the real tree stages exactly the closure, and nothing dev-only =="
+staged=$(stage_web_list platforms/web 2>&1)
+if [[ $? -ne 0 ]]; then
+  fail "stage_web_list refused on the real tree: $(echo "$staged" | tr '\n' ' ')"
+else
+  # platforms/web holds test files today; if it ever stops, this assertion
+  # stops meaning anything and says so rather than passing quietly.
+  if ! ls platforms/web/*.test.js >/dev/null 2>&1; then
+    fail "platforms/web has no *.test.js at all — the dev-only exclusion is no longer being exercised by the real tree"
+  else
+    case $'\n'"$staged"$'\n' in
+      *.test.js*) fail "the staging rule would ship a *.test.js from the real tree" ;;
+      *) pass "no *.test.js in the real staged set" ;;
+    esac
+  fi
+  case $'\n'"$staged"$'\n' in
+    *$'\n'vitest.*) fail "the staging rule would ship a vitest.* file" ;;
+    *) pass "no vitest.* in the real staged set" ;;
+  esac
+fi
+
+# ---------------------------------------------------------------------------
+# 2. The staging rule, on synthetic trees.
+
+echo "== a newly extracted module ships without anyone listing it =="
+NEW="$TMP/newmodule"
+mkdir -p "$NEW"
+printf '<!doctype html>\n<link rel="stylesheet" href="app.css">\n<script type="module" src="app.js"></script>\n' >"$NEW/index.html"
+printf "import { x } from './brandNew.js';\n" >"$NEW/app.js"
+printf 'export const x = 1;\n' >"$NEW/brandNew.js"
+: >"$NEW/app.css"
+new_list=$(stage_web_list "$NEW")
+case $'\n'"$new_list"$'\n' in
+  *$'\n'brandNew.js$'\n'*) pass "a module nobody listed is staged by the rule" ;;
+  *) fail "the staging rule dropped brandNew.js — it is a list again, not a rule" ;;
+esac
+new_closure=$(web_assets_closure "$NEW")
+case $'\n'"$new_closure"$'\n' in
+  *$'\n'brandNew.js$'\n'*) pass "the walk reaches a module through one hop" ;;
+  *) fail "the walk missed brandNew.js: $(echo "$new_closure" | tr '\n' ' ')" ;;
+esac
+
+echo "== dev-only tooling is excluded, and directories cannot be swept in =="
+mkdir -p "$NEW/node_modules" "$NEW/snapshots"
+: >"$NEW/node_modules/pkg.js"
+: >"$NEW/snapshots/serialize.js"
+: >"$NEW/app.test.js"
+: >"$NEW/vitest.config.js"
+: >"$NEW/vitest.setup.js"
+: >"$NEW/package.json"
+dev_list=$(stage_web_list "$NEW")
+for bad in app.test.js vitest.config.js vitest.setup.js package.json pkg.js serialize.js; do
+  case $'\n'"$dev_list"$'\n' in
+    *$'\n'"$bad"$'\n'*) fail "the staging rule would ship dev-only $bad" ;;
+    *) pass "excluded: $bad" ;;
+  esac
+done
+
+echo "== a module carrying a literal NUL byte is still scanned =="
+# Not hypothetical: platforms/web/irrlicht.js and sessionIdentity.js both hold
+# literal NULs (an id separator, `daemonId + '\0' + sessionId`), and a
+# binary-detecting grep answers "Binary file … matches" instead of the matches
+# — exit 0, no usable output. That is the shape of vacuity this whole guard is
+# built against, so it is pinned on a synthetic module whose NUL sits in the
+# first read block, where every grep implementation detects it.
+NUL="$TMP/nulmodule"
+mkdir -p "$NUL"
+printf '<script type="module" src="app.js"></script>\n' >"$NUL/index.html"
+printf 'const SEP = "\000";\nimport { x } from '\''./dep.js'\'';\n' >"$NUL/app.js"
+printf 'export const x = 1;\n' >"$NUL/dep.js"
+if ! LC_ALL=C grep -qU $'\000' "$NUL/app.js" 2>/dev/null && ! LC_ALL=C grep -qaP '\x00' "$NUL/app.js" 2>/dev/null; then
+  # Neither probe could confirm the byte survived the write, so the assertion
+  # below would be testing an ordinary text file and passing for free.
+  fail "the NUL fixture carries no NUL byte — this assertion is vacuous"
+fi
+nul_closure=$(web_assets_closure "$NUL" 2>&1)
+nul_st=$?
+if [[ "$nul_st" -ne 0 ]]; then
+  fail "the walk refused on a module containing a NUL byte (exit $nul_st): $(echo "$nul_closure" | tr '\n' ' ')"
+else
+  case $'\n'"$nul_closure"$'\n' in
+    *$'\n'dep.js$'\n'*) pass "an import inside a NUL-containing module is still found" ;;
+    *) fail "the walk missed dep.js in a NUL-containing module — the scan is reading it as binary: $(echo "$nul_closure" | tr '\n' ' ')" ;;
+  esac
+fi
+
+echo "== the walk terminates on a cyclic graph =="
+CYC="$TMP/cyclic"
+mkdir -p "$CYC"
+printf '<script type="module" src="a.js"></script>\n' >"$CYC/index.html"
+printf '<!doctype html>\n%s' "$(cat "$CYC/index.html")" >"$CYC/index.html.tmp" && mv "$CYC/index.html.tmp" "$CYC/index.html"
+printf "import { b } from './b.js';\n" >"$CYC/a.js"
+printf "import { a } from './a.js';\nimport { c } from './c.js';\n" >"$CYC/b.js"
+printf "import { a } from './a.js';\n" >"$CYC/c.js"
+cyc=$( ( web_assets_closure "$CYC" ) & pid=$!
+  # A walk without a visited set does not terminate; bound it rather than
+  # hanging the suite, and report the timeout as the finding it is.
+  waited=0
+  while kill -0 "$pid" 2>/dev/null && [[ "$waited" -lt 100 ]]; do
+    sleep 0.1; waited=$((waited + 1))
+  done
+  if kill -0 "$pid" 2>/dev/null; then kill -9 "$pid" 2>/dev/null; echo "__TIMEOUT__"; fi
+  wait "$pid" 2>/dev/null )
+case "$cyc" in
+  *__TIMEOUT__*) fail "the walk did not terminate on a cyclic graph within 10s — the visited set is gone" ;;
+  *)
+    for want in a.js b.js c.js; do
+      case $'\n'"$cyc"$'\n' in
+        *$'\n'"$want"$'\n'*) ;;
+        *) fail "the cyclic walk missed $want: $(echo "$cyc" | tr '\n' ' ')" ;;
+      esac
+    done
+    pass "the walk terminates on a cyclic graph and reaches every node"
+    ;;
+esac
+
+# ---------------------------------------------------------------------------
+# 3. Fail-loudly: inability to look never reads as success.
+
+echo "== inability to look REFUSES rather than reporting an empty closure =="
+expect_refuse "a source tree that does not exist" \
+  "$TMP/absent" "source tree not found"
+
+mkdir -p "$TMP/noindex"; : >"$TMP/noindex/app.js"
+expect_refuse "a tree with no index.html" \
+  "$TMP/noindex" "index.html is missing"
+
+mkdir -p "$TMP/noentry"; printf '<!doctype html>\n<p>nothing here</p>\n' >"$TMP/noentry/index.html"
+expect_refuse "an index.html with no <script src> or <link href>" \
+  "$TMP/noentry" "no <script src> or <link href>"
+
+mkdir -p "$TMP/nojs"; printf '<link rel="stylesheet" href="a.css">\n' >"$TMP/nojs/index.html"; : >"$TMP/nojs/a.css"
+expect_refuse "an index.html that reaches no module at all" \
+  "$TMP/nojs" "reached no JavaScript module"
+
+# The vacuity case this guard was written against: a module scan that finds
+# nothing looks byte-identical to a module graph that is fully staged.
+mkdir -p "$TMP/noedge"
+printf '<script type="module" src="app.js"></script>\n' >"$TMP/noedge/index.html"
+printf 'export const x = 1;\n' >"$TMP/noedge/app.js"
+expect_refuse "a module graph with not one import edge" \
+  "$TMP/noedge" "not one import edge"
+
+mkdir -p "$TMP/broken"
+printf '<script type="module" src="app.js"></script>\n' >"$TMP/broken/index.html"
+printf "import { x } from './gone.js';\n" >"$TMP/broken/app.js"
+expect_refuse "an import of a file that does not exist" \
+  "$TMP/broken" "does not exist in"
+
+mkdir -p "$TMP/subdir/sub"
+printf '<script type="module" src="app.js"></script>\n' >"$TMP/subdir/index.html"
+printf "import { x } from './sub/deep.js';\n" >"$TMP/subdir/app.js"
+printf 'export const x = 1;\n' >"$TMP/subdir/sub/deep.js"
+expect_refuse "an import from a subdirectory the non-recursive rule cannot ship" \
+  "$TMP/subdir" "non-recursive"
+
+echo "== stage_web refuses loudly rather than staging an empty tree =="
+out=$(stage_web "$TMP/absent" "$TMP/out" 2>&1); st=$?
+[[ "$st" -eq 2 ]] || fail "stage_web on a missing source must return 2, got $st"
+mkdir -p "$TMP/emptytree"
+out=$(stage_web "$TMP/emptytree" "$TMP/out" 2>&1); st=$?
+[[ "$st" -eq 3 ]] || fail "stage_web on a tree with no runtime asset must return 3, got $st"
+case "$out" in *"found nothing to ship"*) ;; *) fail "stage_web's empty-tree refusal must say so; got: $out" ;; esac
+out=$(stage_web "$TMP/noindex" "$TMP/out" 2>&1); st=$?
+[[ "$st" -eq 4 ]] || fail "stage_web on a tree with no index.html must return 4, got $st"
+out=$(stage_web platforms/web "" 2>&1); st=$?
+[[ "$st" -eq 2 ]] || fail "stage_web with no destination must return 2, got $st"
+[[ "$rc" -eq 0 ]] && pass "stage_web's four refusals are distinguishable by status"
+
+# ---------------------------------------------------------------------------
+# 4. Gate parity: the guard has to FIRE on the commit shape that breaks it.
+#
+# A gate that is silently SKIPped on the relevant diff is this issue one level
+# up — and the relevant diff here is "someone extracted a new module", which
+# touches platforms/web/ and nothing else. tools/preflight.sh --changed decides
+# with `grep -qE <regex>` over the changed set, so the assertion below runs
+# exactly that grep against exactly the regexes preflight.sh carries.
+
+echo "== preflight --changed selects these gates for a platforms/web-only diff =="
+# preflight_regex <name-fragment> — the single-quoted first argument of the
+# run_gate_scoped call whose gate name contains <name-fragment>.
+preflight_regex() {
+  awk -v want="$1" '
+    /run_gate_scoped/ { pending = $0; next }
+    pending != "" {
+      if (index($0, want)) {
+        line = pending
+        sub(/^[^\x27]*\x27/, "", line)
+        sub(/\x27[^\x27]*$/, "", line)
+        print line
+        exit
+      }
+      pending = ""
+    }
+  ' tools/preflight.sh
+}
+for gate in "tools/lib shell-lib tests" "web release assets"; do
+  re=$(preflight_regex "$gate")
+  if [[ -z "$re" ]]; then
+    # Could not look: the gate was renamed or the call reshaped. That is not
+    # the same as "the trigger is wrong", and must not read as either a pass
+    # or as the finding below.
+    fail "could not extract a trigger regex for the '$gate' gate from tools/preflight.sh — this assertion cannot judge anything"
+    continue
+  fi
+  if printf '%s\n' 'platforms/web/newlyExtractedModule.js' | grep -qE "$re"; then
+    pass "'$gate' fires on a diff that only adds platforms/web/newlyExtractedModule.js"
+  else
+    fail "'$gate' would be SKIPped by preflight --changed for a diff touching only platforms/web/ — the trigger regex is missing ^platforms/web/, so the gate stops firing on exactly the commit shape that caused #1900. regex: $re"
+  fi
+done
+
+[[ "$rc" -eq 0 ]] && echo "OK: web-release-assets-guard_test — the release web tree is staged by rule, complete under a transitive cycle-tolerant walk, free of dev-only files, every inability to look refuses out loud, and both gates fire on a platforms/web-only diff"
+exit "$rc"

--- a/tools/lib/web-release-assets-guard_test.sh
+++ b/tools/lib/web-release-assets-guard_test.sh
@@ -52,23 +52,37 @@ rc=0
 fail() { echo "FAIL: $1" >&2; rc=1; }
 pass() { echo "  PASS: $1"; }
 
-# expect_refuse <label> <src-dir> <fragment> — the closure must REFUSE (2) and
-# say why. A guard that returned 0 with an empty closure would satisfy every
-# "nothing is missing" assertion in this file, so the status AND the reason
-# are both asserted.
-expect_refuse() {
-  local label="$1" dir="$2" want="$3" out st
+# has_line <haystack> <needle> — is <needle> one whole line of <haystack>?
+# The newline-fencing is fiddly enough to be worth writing once.
+has_line() {
+  case $'\n'"$1"$'\n' in *$'\n'"$2"$'\n'*) return 0 ;; esac
+  return 1
+}
+
+# expect_closure <want-status> <label> <src-dir> <fragment> — the closure must
+# exit with <want-status> AND say why. The status alone is not enough: a walk
+# that returned 0 with an empty closure would satisfy every "nothing is
+# missing" assertion in this file, and a walk that failed for an unrelated
+# reason (a shell error, a missing fixture) would read as success here.
+#
+# 2 is REFUSE ("I could not judge this tree") and 1 is FAIL ("I judged it and
+# it is broken"). Keeping them apart is the point — see the guard's exit table.
+expect_closure() {
+  local want="$1" label="$2" dir="$3" frag="$4" out st word
+  case "$want" in 2) word=REFUSE ;; 1) word=FAIL ;; *) word="status $want" ;; esac
   out=$(web_assets_closure "$dir" 2>&1)
   st=$?
-  if [[ "$st" -ne 2 ]]; then
-    fail "$label — expected REFUSE (2), got status $st with: $(echo "$out" | tr '\n' ' ')"
+  if [[ "$st" -ne "$want" ]]; then
+    fail "$label — expected $word ($want), got status $st with: $(echo "$out" | tr '\n' ' ')"
     return
   fi
   case "$out" in
-    *"$want"*) pass "$label" ;;
-    *) fail "$label — refused, but not for the stated reason (wanted: $want); got: $(echo "$out" | tr '\n' ' ')" ;;
+    *"$frag"*) pass "$label" ;;
+    *) fail "$label — exited $want, but not for the stated reason (wanted: $frag); got: $(echo "$out" | tr '\n' ' ')" ;;
   esac
 }
+expect_refuse() { expect_closure 2 "$@"; }
+expect_finding() { expect_closure 1 "$@"; }
 
 # ---------------------------------------------------------------------------
 # 1. The real repository.
@@ -98,10 +112,9 @@ else
     pass "the real closure has $n entries"
   fi
   for want in index.html irrlicht.css irrlicht.js collapsedSet.js; do
-    case $'\n'"$real_closure"$'\n' in
-      *$'\n'"$want"$'\n'*) pass "closure contains $want" ;;
-      *) fail "closure over the real tree is missing $want" ;;
-    esac
+    has_line "$real_closure" "$want" \
+      && pass "closure contains $want" \
+      || fail "closure over the real tree is missing $want"
   done
   # The load-bearing one, spelled out: collapsedSet.js is imported by
   # collapsedGroups.js and collapsedSummaries.js and by nothing else, so it is
@@ -150,15 +163,13 @@ printf "import { x } from './brandNew.js';\n" >"$NEW/app.js"
 printf 'export const x = 1;\n' >"$NEW/brandNew.js"
 : >"$NEW/app.css"
 new_list=$(stage_web_list "$NEW")
-case $'\n'"$new_list"$'\n' in
-  *$'\n'brandNew.js$'\n'*) pass "a module nobody listed is staged by the rule" ;;
-  *) fail "the staging rule dropped brandNew.js — it is a list again, not a rule" ;;
-esac
+has_line "$new_list" brandNew.js \
+  && pass "a module nobody listed is staged by the rule" \
+  || fail "the staging rule dropped brandNew.js — it is a list again, not a rule"
 new_closure=$(web_assets_closure "$NEW")
-case $'\n'"$new_closure"$'\n' in
-  *$'\n'brandNew.js$'\n'*) pass "the walk reaches a module through one hop" ;;
-  *) fail "the walk missed brandNew.js: $(echo "$new_closure" | tr '\n' ' ')" ;;
-esac
+has_line "$new_closure" brandNew.js \
+  && pass "the walk reaches a module through one hop" \
+  || fail "the walk missed brandNew.js: $(echo "$new_closure" | tr '\n' ' ')"
 
 echo "== dev-only tooling is excluded, and directories cannot be swept in =="
 mkdir -p "$NEW/node_modules" "$NEW/snapshots"
@@ -170,10 +181,9 @@ mkdir -p "$NEW/node_modules" "$NEW/snapshots"
 : >"$NEW/package.json"
 dev_list=$(stage_web_list "$NEW")
 for bad in app.test.js vitest.config.js vitest.setup.js package.json pkg.js serialize.js; do
-  case $'\n'"$dev_list"$'\n' in
-    *$'\n'"$bad"$'\n'*) fail "the staging rule would ship dev-only $bad" ;;
-    *) pass "excluded: $bad" ;;
-  esac
+  has_line "$dev_list" "$bad" \
+    && fail "the staging rule would ship dev-only $bad" \
+    || pass "excluded: $bad"
 done
 
 echo "== a module carrying a literal NUL byte is still scanned =="
@@ -202,41 +212,37 @@ nul_st=$?
 if [[ "$nul_st" -ne 0 ]]; then
   fail "the walk refused on a module containing a NUL byte (exit $nul_st): $(echo "$nul_closure" | tr '\n' ' ')"
 else
-  case $'\n'"$nul_closure"$'\n' in
-    *$'\n'dep.js$'\n'*) pass "an import inside a NUL-containing module is still found" ;;
-    *) fail "the walk missed dep.js in a NUL-containing module — the scan is reading it as binary: $(echo "$nul_closure" | tr '\n' ' ')" ;;
-  esac
+  has_line "$nul_closure" dep.js \
+    && pass "an import inside a NUL-containing module is still found" \
+    || fail "the walk missed dep.js in a NUL-containing module — the scan is reading it as binary: $(echo "$nul_closure" | tr '\n' ' ')"
 fi
 
 echo "== the walk terminates on a cyclic graph =="
 CYC="$TMP/cyclic"
 mkdir -p "$CYC"
-printf '<script type="module" src="a.js"></script>\n' >"$CYC/index.html"
-printf '<!doctype html>\n%s' "$(cat "$CYC/index.html")" >"$CYC/index.html.tmp" && mv "$CYC/index.html.tmp" "$CYC/index.html"
+printf '<!doctype html>\n<script type="module" src="a.js"></script>\n' >"$CYC/index.html"
 printf "import { b } from './b.js';\n" >"$CYC/a.js"
 printf "import { a } from './a.js';\nimport { c } from './c.js';\n" >"$CYC/b.js"
 printf "import { a } from './a.js';\n" >"$CYC/c.js"
-cyc=$( ( web_assets_closure "$CYC" ) & pid=$!
-  # A walk without a visited set does not terminate; bound it rather than
-  # hanging the suite, and report the timeout as the finding it is.
-  waited=0
-  while kill -0 "$pid" 2>/dev/null && [[ "$waited" -lt 100 ]]; do
-    sleep 0.1; waited=$((waited + 1))
+# A walk without a visited set does not terminate, so this is bounded rather
+# than allowed to hang the suite. budget_run is the repo's bounded runner
+# (tools/lib/gate-budget.sh) — `timeout(1)` is not on a stock macOS, and a
+# hand-rolled `kill -0` poll re-adopts the pitfall that file documents.
+# shellcheck source=gate-budget.sh
+. "$REPO_ROOT/tools/lib/gate-budget.sh"
+cyc=$(budget_run 10 bash -c '. "$1"; web_assets_closure "$2"' bash "$REPO_ROOT/$GUARD" "$CYC" 2>/dev/null)
+cyc_rc=$?
+if [[ "${BUDGET_LAST_TIMED_OUT:-0}" -eq 1 ]]; then
+  fail "the walk did not terminate on a cyclic graph within 10s — the visited set is gone"
+elif [[ "$cyc_rc" -ne 0 ]]; then
+  fail "the cyclic walk exited $cyc_rc: $(echo "$cyc" | tr '\n' ' ')"
+else
+  cyc_ok=1
+  for want in a.js b.js c.js; do
+    has_line "$cyc" "$want" || { fail "the cyclic walk missed $want: $(echo "$cyc" | tr '\n' ' ')"; cyc_ok=0; }
   done
-  if kill -0 "$pid" 2>/dev/null; then kill -9 "$pid" 2>/dev/null; echo "__TIMEOUT__"; fi
-  wait "$pid" 2>/dev/null )
-case "$cyc" in
-  *__TIMEOUT__*) fail "the walk did not terminate on a cyclic graph within 10s — the visited set is gone" ;;
-  *)
-    for want in a.js b.js c.js; do
-      case $'\n'"$cyc"$'\n' in
-        *$'\n'"$want"$'\n'*) ;;
-        *) fail "the cyclic walk missed $want: $(echo "$cyc" | tr '\n' ' ')" ;;
-      esac
-    done
-    pass "the walk terminates on a cyclic graph and reaches every node"
-    ;;
-esac
+  [[ "$cyc_ok" -eq 1 ]] && pass "the walk terminates on a cyclic graph and reaches every node"
+fi
 
 # ---------------------------------------------------------------------------
 # 3. Fail-loudly: inability to look never reads as success.
@@ -266,23 +272,6 @@ expect_refuse "a module graph with not one import edge" \
   "$TMP/noedge" "not one import edge"
 
 echo "== a defect IN the tree is a finding (1), not an inability to look (2) =="
-# expect_finding <label> <src-dir> <fragment> — the walk read the tree fine and
-# found something wrong with it. Reported as 1, so a caller can tell "your tree
-# is broken" from "I could not read your tree".
-expect_finding() {
-  local label="$1" dir="$2" want="$3" out st
-  out=$(web_assets_closure "$dir" 2>&1)
-  st=$?
-  if [[ "$st" -ne 1 ]]; then
-    fail "$label — expected FAIL (1), got status $st with: $(echo "$out" | tr '\n' ' ')"
-    return
-  fi
-  case "$out" in
-    *"$want"*) pass "$label" ;;
-    *) fail "$label — failed, but not for the stated reason (wanted: $want); got: $(echo "$out" | tr '\n' ' ')" ;;
-  esac
-}
-
 mkdir -p "$TMP/broken"
 printf '<script type="module" src="app.js"></script>\n' >"$TMP/broken/index.html"
 printf "import { x } from './gone.js';\n" >"$TMP/broken/app.js"
@@ -315,10 +304,9 @@ cmt_st=$?
 if [[ "$cmt_st" -ne 0 ]]; then
   fail "a commented-out import turned the walk red (exit $cmt_st): $(echo "$cmt_out" | tr '\n' ' ')"
 else
-  case $'\n'"$cmt_out"$'\n' in
-    *$'\n'real.js$'\n'*) pass "the live import is still found beside the commented-out ones" ;;
-    *) fail "the walk lost the live import while ignoring comments: $(echo "$cmt_out" | tr '\n' ' ')" ;;
-  esac
+  has_line "$cmt_out" real.js \
+    && pass "the live import is still found beside the commented-out ones" \
+    || fail "the walk lost the live import while ignoring comments: $(echo "$cmt_out" | tr '\n' ' ')"
 fi
 
 echo "== the scanner sees the edge forms it claims to =="
@@ -344,10 +332,7 @@ if [[ $? -ne 0 ]]; then
   fail "the walk refused on the edge-form fixture: $(echo "$forms_out" | tr '\n' ' ')"
 else
   for m in a b c d e f g h i; do
-    case $'\n'"$forms_out"$'\n' in
-      *$'\n'"$m.js"$'\n'*) ;;
-      *) fail "the scanner missed the edge to $m.js" ;;
-    esac
+    has_line "$forms_out" "$m.js" || fail "the scanner missed the edge to $m.js"
   done
   pass "default, namespace, multi-line, side-effect, re-export, export-*, dynamic, template-literal and new URL() edges are all seen"
 fi

--- a/tools/lib/web-release-assets-guard_test.sh
+++ b/tools/lib/web-release-assets-guard_test.sh
@@ -188,10 +188,14 @@ mkdir -p "$NUL"
 printf '<script type="module" src="app.js"></script>\n' >"$NUL/index.html"
 printf 'const SEP = "\000";\nimport { x } from '\''./dep.js'\'';\n' >"$NUL/app.js"
 printf 'export const x = 1;\n' >"$NUL/dep.js"
-if ! LC_ALL=C grep -qU $'\000' "$NUL/app.js" 2>/dev/null && ! LC_ALL=C grep -qaP '\x00' "$NUL/app.js" 2>/dev/null; then
-  # Neither probe could confirm the byte survived the write, so the assertion
-  # below would be testing an ordinary text file and passing for free.
-  fail "the NUL fixture carries no NUL byte — this assertion is vacuous"
+# Probe by BYTES, never with a bash-quoted NUL: bash cannot hold NUL in a word,
+# so `grep -q $'\000' file` is `grep -q '' file`, which matches every non-empty
+# file and can therefore never fire. `tr -d -c` counts the NULs directly and
+# works identically on BSD and GNU.
+if [[ "$(LC_ALL=C tr -d -c '\000' <"$NUL/app.js" | wc -c | tr -d ' ')" -eq 0 ]]; then
+  # The byte did not survive the write, so the assertion below would be
+  # examining an ordinary text file and passing for free.
+  fail "the NUL fixture carries no NUL byte — the assertion below is vacuous"
 fi
 nul_closure=$(web_assets_closure "$NUL" 2>&1)
 nul_st=$?
@@ -261,18 +265,92 @@ printf 'export const x = 1;\n' >"$TMP/noedge/app.js"
 expect_refuse "a module graph with not one import edge" \
   "$TMP/noedge" "not one import edge"
 
+echo "== a defect IN the tree is a finding (1), not an inability to look (2) =="
+# expect_finding <label> <src-dir> <fragment> — the walk read the tree fine and
+# found something wrong with it. Reported as 1, so a caller can tell "your tree
+# is broken" from "I could not read your tree".
+expect_finding() {
+  local label="$1" dir="$2" want="$3" out st
+  out=$(web_assets_closure "$dir" 2>&1)
+  st=$?
+  if [[ "$st" -ne 1 ]]; then
+    fail "$label — expected FAIL (1), got status $st with: $(echo "$out" | tr '\n' ' ')"
+    return
+  fi
+  case "$out" in
+    *"$want"*) pass "$label" ;;
+    *) fail "$label — failed, but not for the stated reason (wanted: $want); got: $(echo "$out" | tr '\n' ' ')" ;;
+  esac
+}
+
 mkdir -p "$TMP/broken"
 printf '<script type="module" src="app.js"></script>\n' >"$TMP/broken/index.html"
 printf "import { x } from './gone.js';\n" >"$TMP/broken/app.js"
-expect_refuse "an import of a file that does not exist" \
+expect_finding "an import of a file that does not exist" \
   "$TMP/broken" "does not exist in"
 
 mkdir -p "$TMP/subdir/sub"
 printf '<script type="module" src="app.js"></script>\n' >"$TMP/subdir/index.html"
 printf "import { x } from './sub/deep.js';\n" >"$TMP/subdir/app.js"
 printf 'export const x = 1;\n' >"$TMP/subdir/sub/deep.js"
-expect_refuse "an import from a subdirectory the non-recursive rule cannot ship" \
+expect_finding "an import from a subdirectory the non-recursive rule cannot ship" \
   "$TMP/subdir" "non-recursive"
+
+echo "== a commented-out import is not read as a live edge =="
+# A doc comment naming a retired sibling is an ordinary thing to leave behind
+# during a refactor. Read as an edge it would turn the release gate red — on a
+# pre-push hook — with a message that reads like a real packaging defect.
+CMT="$TMP/commented"
+mkdir -p "$CMT"
+printf '<script type="module" src="app.js"></script>\n' >"$CMT/index.html"
+cat >"$CMT/app.js" <<'JS'
+import { y } from './real.js';
+// this used to import { z } from './retired.js'
+/* and briefly from './alsoRetired.js' too */
+const docs = 'https://example.invalid/from/nowhere';
+JS
+printf 'export const y = 1;\n' >"$CMT/real.js"
+cmt_out=$(web_assets_closure "$CMT" 2>&1)
+cmt_st=$?
+if [[ "$cmt_st" -ne 0 ]]; then
+  fail "a commented-out import turned the walk red (exit $cmt_st): $(echo "$cmt_out" | tr '\n' ' ')"
+else
+  case $'\n'"$cmt_out"$'\n' in
+    *$'\n'real.js$'\n'*) pass "the live import is still found beside the commented-out ones" ;;
+    *) fail "the walk lost the live import while ignoring comments: $(echo "$cmt_out" | tr '\n' ' ')" ;;
+  esac
+fi
+
+echo "== the scanner sees the edge forms it claims to =="
+FORMS="$TMP/forms"
+mkdir -p "$FORMS"
+printf '<script type="module" src="app.js"></script>\n' >"$FORMS/index.html"
+cat >"$FORMS/app.js" <<'JS'
+import defaultExport from './a.js';
+import * as ns from './b.js';
+import {
+  thing,
+} from './c.js';
+import './d.js';
+export { e } from './e.js';
+export * from './f.js';
+const lazy = () => import('./g.js');
+const tmpl = () => import(`./h.js`);
+const worker = new URL('./i.js', import.meta.url);
+JS
+for m in a b c d e f g h i; do printf 'export const x = 1;\n' >"$FORMS/$m.js"; done
+forms_out=$(web_assets_closure "$FORMS" 2>&1)
+if [[ $? -ne 0 ]]; then
+  fail "the walk refused on the edge-form fixture: $(echo "$forms_out" | tr '\n' ' ')"
+else
+  for m in a b c d e f g h i; do
+    case $'\n'"$forms_out"$'\n' in
+      *$'\n'"$m.js"$'\n'*) ;;
+      *) fail "the scanner missed the edge to $m.js" ;;
+    esac
+  done
+  pass "default, namespace, multi-line, side-effect, re-export, export-*, dynamic, template-literal and new URL() edges are all seen"
+fi
 
 echo "== stage_web refuses loudly rather than staging an empty tree =="
 out=$(stage_web "$TMP/absent" "$TMP/out" 2>&1); st=$?

--- a/tools/preflight.sh
+++ b/tools/preflight.sh
@@ -575,8 +575,30 @@ if want tools; then
   # backup that was never refreshed, a bundle overwritten while its process was
   # still alive). Same story, eighth entry: a commit editing only that script,
   # or only restore-prod.sh beside it, is exactly the one that breaks them.
-  run_gate_scoped '^tools/lib/|^tools/[^/]*\.sh$|^tools/git-hooks/|^go\.work$|^\.github/dependabot\.yml$|^site/install\.sh$|^AGENTS\.md$|^\.claude/skills/ir:test-mac/|^\.github/workflows/(ars|codescene-badge|coverage|macos-swift|replaydata-deletion-guard|test)\.yml$' \
+  # platforms/web/ joins the trigger for a ninth reason (#1900), and it is the
+  # one entry here whose absence had already shipped. Every release artifact
+  # staged the dashboard from a hand-written three-file `cp` list; the list was
+  # complete when it was written and stopped being complete the moment
+  # irrlicht.js became an ES module importing ten siblings, so the released
+  # dashboard rendered a blank page on macOS and Linux. web-release-assets-guard_test.sh
+  # walks that import graph out of platforms/web/ and asserts the staging rule
+  # covers all of it — so a commit that EXTRACTS A NEW MODULE, precisely the
+  # commit shape that caused this twice, has to select this gate. Without the
+  # entry, a diff touching only platforms/web/ matches nothing in this regex
+  # and the one gate that would catch it is SKIPped: the #1209 failure mode,
+  # arrived at from the other side.
+  run_gate_scoped '^tools/lib/|^tools/[^/]*\.sh$|^tools/git-hooks/|^go\.work$|^\.github/dependabot\.yml$|^site/install\.sh$|^AGENTS\.md$|^platforms/web/|^\.claude/skills/ir:test-mac/|^\.github/workflows/(ars|codescene-badge|coverage|macos-swift|replaydata-deletion-guard|test)\.yml$' \
                   "tools/lib shell-lib tests" shell_lib_tests
+
+  # The release-packaging guard (#1900). Same corpus as the trigger above minus
+  # the workflow files: the web tree it walks, the rule it executes
+  # (tools/lib/stage-web.sh) and the script it holds to that rule
+  # (tools/build-release.sh). Scoped rather than unscoped because that corpus
+  # really is nameable — but it must include ^platforms/web/, for the reason
+  # spelled out above.
+  run_gate_scoped '^platforms/web/|^tools/lib/stage-web\.sh$|^tools/web-release-assets-guard\.sh$|^tools/build-release\.sh$' \
+                  "web release assets (every module index.html reaches is staged)" \
+                  tools/web-release-assets-guard.sh
 
   # UNSCOPED, deliberately, and the only gate in this group that is (#1804).
   #

--- a/tools/web-release-assets-guard.sh
+++ b/tools/web-release-assets-guard.sh
@@ -57,10 +57,15 @@ set -uo pipefail
 # function a sourcing caller may have.
 _wrag_text_grep() { LC_ALL=C command grep -a "$@"; }
 
-# _wrag_unquote — strip one layer of surrounding single or double quotes from
-# the LAST quoted run on the line, which is where a module specifier and an
-# HTML attribute value both sit.
-_wrag_unquote() { sed -E "s/^.*['\"]([^'\"]*)['\"][^'\"]*\$/\1/"; }
+# _wrag_unquote — strip one layer of surrounding single, double or back quotes
+# from the LAST quoted run on the line, which is where a module specifier and
+# an HTML attribute value both sit.
+_wrag_unquote() { sed -E "s/^.*['\"\`]([^'\"\`]*)['\"\`][^'\"\`]*\$/\1/"; }
+
+# _wrag_decomment — drop single-line /* */ blocks and // line comments. A `//`
+# only counts at the start of a line or after whitespace, so the `//` inside a
+# `https://…` string literal survives.
+_wrag_decomment() { LC_ALL=C sed -E -e 's,/\*.*\*/,,g' -e 's,(^|[[:space:]])//.*$,\1,'; }
 
 # web_assets_html_refs <index.html> — one local asset reference per line, from
 # <script … src=…> and <link … href=…>. External (`scheme://`), root-relative
@@ -81,24 +86,59 @@ web_assets_html_refs() {
 }
 
 # web_assets_js_edges <file> — one module specifier per line, for every
-# `from '…'`, `import '…'` and `import('…')` in <file>.
+# `from '…'`, `import '…'`, `import('…')` and `new URL('…', import.meta.url)`
+# in <file>. Single, double and back quotes are all read.
 #
 # The `from` anchor is the one that matters: 5 of this tree's 15 edges are
 # multi-line import lists whose `from` clause sits on its own line, so a
 # pattern anchored on `^import` would miss a third of the graph.
+#
+# Two stages, and the split is load-bearing in both directions. Stage 1 reads
+# the FILE with `-a`, so a module carrying a literal NUL still yields its lines
+# (property 3 in the header) — without it a NUL-containing module answers
+# "Binary file … matches" and contributes nothing. Stage 2 strips comments from
+# those few candidate lines before the specifier is extracted, so a
+# commented-out import — an ordinary thing to leave behind during a refactor —
+# is not read as a live edge and does not turn the release gate red for a file
+# nobody actually loads.
 web_assets_js_edges() {
     local file="$1"
-    _wrag_text_grep -oE "(^|[^[:alnum:]_$.])(from|import)[[:space:]]*\(?[[:space:]]*('[^']*'|\"[^\"]*\")" "$file" |
+    _wrag_text_grep -E "(^|[^[:alnum:]_\$.])(from|import|URL)[[:space:]]*\(?[[:space:]]*['\"\`]" "$file" |
+        LC_ALL=C tr -d '\000' |
+        _wrag_decomment |
+        LC_ALL=C command grep -oE "(^|[^[:alnum:]_\$.])(from|import|new[[:space:]]+URL)[[:space:]]*\(?[[:space:]]*('[^']*'|\"[^\"]*\"|\`[^\`]*\`)" |
         _wrag_unquote
+}
+
+# web_assets_css_refuses_unfollowable <file> — this walker follows HTML and
+# JavaScript references, not CSS ones. That is fine only while the dashboard's
+# stylesheet has none, so rather than ignoring CSS silently — which is how a
+# `@import './theme/dark.css'` would ship a 404 through a green gate — the one
+# stylesheet is checked for references the walker could not follow. `data:` and
+# external URLs are not references to anything this tree stages.
+# Returns 0 when there is nothing unfollowable, 1 when there is.
+web_assets_css_refuses_unfollowable() {
+    local file="$1" hits
+    hits=$(_wrag_text_grep -oE "(@import[[:space:]]*[^;]*|url\([^)]*\))" "$file" |
+        LC_ALL=C command grep -vE "url\([[:space:]]*['\"]?(data:|https?:|#)" || :)
+    [[ -z "$hits" ]] && return 0
+    echo "FAIL: $file carries a CSS reference this walker does not follow, so its target is not in the closure and could ship as a 404:" >&2
+    printf '%s\n' "$hits" | sed 's/^/       /' >&2
+    return 1
 }
 
 # web_assets_closure <src-dir> — every file reachable from <src-dir>/index.html,
 # one basename per line, sorted, index.html included.
 #
-# Returns 2 and prints a REFUSE: line rather than an empty or partial answer
-# when it cannot judge: no tree, no index.html, no entry point, a reference
-# that resolves to nothing, a reference the non-recursive staging rule could
-# never ship, or a JS graph with not one import edge in it.
+# Two non-zero statuses, matching the header's exit table rather than blurring
+# into it:
+#   1  FAIL   — the walk read the tree and found a defect in it: a reference
+#              that resolves to nothing, or a reference into a subdirectory /
+#              outside the tree that the non-recursive staging rule could never
+#              ship. The closure is not emitted, because it would be wrong.
+#   2  REFUSE — the walk could not judge: no tree, no index.html, no entry
+#              point, no module reached, or a JS graph with not one import edge
+#              in it (which is what an unreadable tree looks like).
 web_assets_closure() {
     local src="$1" seen="" queue="" cur spec base specs refs bad=0 edges=0 jsfiles=0
 
@@ -173,7 +213,9 @@ web_assets_closure() {
         echo "REFUSE: web asset closure — scanned $jsfiles module(s) and found not one import edge. The scan cannot read this tree (a NUL-containing module read as binary would look exactly like this), so an 'everything is staged' verdict would be vacuous." >&2
         return 2
     fi
-    [[ "$bad" -eq 0 ]] || return 2
+    # A dangling or unstageable reference is a FINDING about the tree, not an
+    # inability to look at it — and _wrag_enqueue already said `FAIL:`.
+    [[ "$bad" -eq 0 ]] || return 1
 
     base=${seen#$'\n'}
     printf '%s' "$base" | LC_ALL=C sort -u
@@ -191,9 +233,16 @@ web_assets_guard() {
     # shellcheck source=lib/stage-web.sh
     . "$root/tools/lib/stage-web.sh"
 
-    closure=$(web_assets_closure "$src") || return 2
+    closure=$(web_assets_closure "$src") || return $?
 
-    tmp=$(mktemp -d -t web-release-assets-guard) || {
+    # The one stylesheet is checked for references this walker cannot follow,
+    # rather than CSS being skipped in silence.
+    web_assets_css_refuses_unfollowable "$src/irrlicht.css" || rc=1
+
+    # An explicit template, not `-t <prefix>`: GNU mktemp requires at least
+    # three trailing X's and errors out on a bare prefix, so the `-t` spelling
+    # would take the REFUSE branch below on every Linux host.
+    tmp=$(mktemp -d "${TMPDIR:-/tmp}/web-release-assets-guard.XXXXXX") || {
         echo "REFUSE: could not create a staging directory" >&2
         return 2
     }
@@ -264,8 +313,27 @@ web_assets_guard() {
         rc=1
     fi
 
+    # (d) ...and neither does the procedure a release is actually DRIVEN from.
+    # .claude/skills/ir:release/SKILL.md carries manual per-artifact build
+    # blocks as a fallback, and every one of them used to `cp` the web tree by
+    # hand — two of them copying index.html alone, which is #1900 with one file
+    # instead of three. Fixing only build-release.sh would leave the defect
+    # sitting in the document the maintainer reads.
+    local skill="$root/.claude/skills/ir:release/SKILL.md"
+    if [[ ! -f "$skill" ]]; then
+        echo "REFUSE: .claude/skills/ir:release/SKILL.md is missing — cannot check the release procedure for a hand-written copy list" >&2
+        return 2
+    fi
+    local skillcp
+    skillcp=$(_wrag_text_grep -nE '(^|[^[:alnum:]_])(cp|rsync|ditto)[[:space:]].*platforms/web' "$skill" || :)
+    if [[ -n "$skillcp" ]]; then
+        echo "FAIL: .claude/skills/ir:release/SKILL.md copies platforms/web by hand — the release procedure must call stage_web, like tools/build-release.sh does:" >&2
+        printf '%s\n' "$skillcp" | sed 's/^/       .claude\/skills\/ir:release\/SKILL.md:/' >&2
+        rc=1
+    fi
+
     if [[ "$rc" -eq 0 ]]; then
-        echo "OK: web-release-assets-guard — $(printf '%s\n' "$closure" | _wrag_text_grep -c .) reachable asset(s) from index.html, all staged by tools/lib/stage-web.sh, no dev-only file in the release tree"
+        echo "OK: web-release-assets-guard — $(printf '%s\n' "$closure" | _wrag_text_grep -c .) reachable asset(s) from index.html, all staged by tools/lib/stage-web.sh, no dev-only file in the release tree, no hand-written copy list in build-release.sh or the release skill"
     fi
     return "$rc"
 }

--- a/tools/web-release-assets-guard.sh
+++ b/tools/web-release-assets-guard.sh
@@ -72,17 +72,11 @@ _wrag_decomment() { LC_ALL=C sed -E -e 's,/\*.*\*/,,g' -e 's,(^|[[:space:]])//.*
 # and in-page references are not assets this tree stages, and are dropped.
 # <a href=…> is deliberately not read: index.html links out to irrlicht.io.
 web_assets_html_refs() {
-    local file="$1" refs
-    refs=$(_wrag_text_grep -oE '<(script|link)[[:space:]][^>]*>' "$file" |
+    local file="$1"
+    _wrag_text_grep -oE '<(script|link)[[:space:]][^>]*>' "$file" |
         _wrag_text_grep -oE '[[:space:]](src|href)[[:space:]]*=[[:space:]]*("[^"]*"|'\''[^'\'']*'\'')' |
-        _wrag_unquote)
-    printf '%s\n' "$refs" | while IFS= read -r r; do
-        [[ -n "$r" ]] || continue
-        case "$r" in
-            *"://"* | /* | \#* | data:* | mailto:*) continue ;;
-        esac
-        printf '%s\n' "$r"
-    done
+        _wrag_unquote |
+        LC_ALL=C command grep -vE '^$|://|^/|^#|^data:|^mailto:'
 }
 
 # web_assets_js_edges <file> — one module specifier per line, for every
@@ -125,6 +119,18 @@ web_assets_css_refuses_unfollowable() {
     echo "FAIL: $file carries a CSS reference this walker does not follow, so its target is not in the closure and could ship as a 404:" >&2
     printf '%s\n' "$hits" | sed 's/^/       /' >&2
     return 1
+}
+
+# _wrag_handwritten_pattern <src-dir> — the ERE matching a copy verb that names
+# a SPECIFIC dashboard asset. The asset names come from the staging rule's own
+# output, never from a list typed here, so the check cannot go stale the way
+# the thing it guards did. Returns 2 if the rule yields nothing to match on.
+_wrag_handwritten_pattern() {
+    local names alt
+    names=$(stage_web_list "$1") || return 2
+    alt=$(printf '%s' "$names" | tr '\n' '|' | sed 's/|$//; s/\./\\./g')
+    [[ -n "$alt" ]] || return 2
+    printf '(^|[;&|(]|&&|\\|\\|)[[:space:]]*(cp|rsync|ditto|install|COPY|ADD)[[:space:]].*(%s)([^A-Za-z0-9]|$)' "$alt"
 }
 
 # web_assets_closure <src-dir> — every file reachable from <src-dir>/index.html,
@@ -303,37 +309,49 @@ web_assets_guard() {
         echo "FAIL: tools/build-release.sh never calls stage_web — nothing stages the dashboard by rule" >&2
         rc=1
     fi
-    local handrolled
-    handrolled=$(_wrag_text_grep -nE 'platforms/web' "$brs" |
-        _wrag_text_grep -vE '^[0-9]+:[[:space:]]*#' |
-        _wrag_text_grep -vE '(^|[^[:alnum:]_])stage_web[[:space:]]' || :)
-    if [[ -n "$handrolled" ]]; then
-        echo "FAIL: tools/build-release.sh touches platforms/web outside stage_web — that is the hand-written list this guard exists to prevent:" >&2
-        printf '%s\n' "$handrolled" | sed 's/^/       tools\/build-release.sh:/' >&2
-        rc=1
-    fi
-
-    # (d) ...and neither does the procedure a release is actually DRIVEN from.
-    # .claude/skills/ir:release/SKILL.md carries manual per-artifact build
-    # blocks as a fallback, and every one of them used to `cp` the web tree by
-    # hand — two of them copying index.html alone, which is #1900 with one file
-    # instead of three. Fixing only build-release.sh would leave the defect
-    # sitting in the document the maintainer reads.
-    local skill="$root/.claude/skills/ir:release/SKILL.md"
-    if [[ ! -f "$skill" ]]; then
-        echo "REFUSE: .claude/skills/ir:release/SKILL.md is missing — cannot check the release procedure for a hand-written copy list" >&2
+    # (d) ...and NOTHING anywhere assembles a distributable from a hand-written
+    # list of dashboard files.
+    #
+    # This used to name build-release.sh and the release skill explicitly, and
+    # that was the same mistake one level up: a hand-written list of the places
+    # that must not keep a hand-written list. It missed two that were live —
+    # site/install.sh installed three files out of a thirteen-file tarball, so
+    # the Linux dashboard would have stayed blank after the producer was fixed,
+    # and examples/relay/Dockerfile baked "only the three runtime files" into
+    # an image. So the check sweeps instead: any copy verb naming a SPECIFIC
+    # dashboard asset, anywhere a distributable could be assembled, fails.
+    # Copying the tree, a directory, or a loop variable is untouched — the
+    # defect is naming the files, not copying them.
+    #
+    # The asset names are DERIVED from the staging rule's own output, so a
+    # module extracted tomorrow is covered without editing anything here.
+    local pat hits scoped
+    pat=$(_wrag_handwritten_pattern "$src") || {
+        echo "REFUSE: could not derive the hand-written-list pattern from the staging rule" >&2
+        return 2
+    }
+    # The sweep must be able to match the line that actually shipped #1900. If
+    # it cannot, a clean result means "I could not look", not "nothing to find".
+    if ! printf '%s\n' 'cp platforms/web/index.html platforms/web/irrlicht.css platforms/web/irrlicht.js "$staging/web/"' |
+        LC_ALL=C command grep -qE "$pat"; then
+        echo "REFUSE: the hand-written-list sweep no longer matches the very line that shipped #1900, so a clean sweep would prove nothing" >&2
         return 2
     fi
-    local skillcp
-    skillcp=$(_wrag_text_grep -nE '(^|[^[:alnum:]_])(cp|rsync|ditto)[[:space:]].*platforms/web' "$skill" || :)
-    if [[ -n "$skillcp" ]]; then
-        echo "FAIL: .claude/skills/ir:release/SKILL.md copies platforms/web by hand — the release procedure must call stage_web, like tools/build-release.sh does:" >&2
-        printf '%s\n' "$skillcp" | sed 's/^/       .claude\/skills\/ir:release\/SKILL.md:/' >&2
+    scoped=$(cd "$root" && git ls-files -- '*.sh' '*Dockerfile*' '.github/workflows/*.yml' '.claude/skills/**/*.md' 'Makefile*' '*.mk')
+    if [[ -z "$scoped" ]]; then
+        echo "REFUSE: the hand-written-list sweep found no files to scan" >&2
+        return 2
+    fi
+    hits=$(cd "$root" && printf '%s\n' "$scoped" | tr '\n' '\0' |
+        (export LC_ALL=C; xargs -0 grep -anE "$pat") || :)
+    if [[ -n "$hits" ]]; then
+        echo "FAIL: a distributable is assembled from a hand-written list of dashboard files. That list is complete the day it is written and silently incomplete the next time a module is extracted — it is exactly how #1900 shipped a blank dashboard to every install. Stage the tree by rule instead (tools/lib/stage-web.sh), or copy the whole staged directory:" >&2
+        printf '%s\n' "$hits" | sed 's/^/       /' >&2
         rc=1
     fi
 
     if [[ "$rc" -eq 0 ]]; then
-        echo "OK: web-release-assets-guard — $(printf '%s\n' "$closure" | _wrag_text_grep -c .) reachable asset(s) from index.html, all staged by tools/lib/stage-web.sh, no dev-only file in the release tree, no hand-written copy list in build-release.sh or the release skill"
+        echo "OK: web-release-assets-guard — $(printf '%s\n' "$closure" | _wrag_text_grep -c .) reachable asset(s) from index.html, all staged by tools/lib/stage-web.sh, no dev-only file in the release tree, and no hand-written dashboard file list in $(printf '%s\n' "$scoped" | _wrag_text_grep -c .) scanned files"
     fi
     return "$rc"
 }

--- a/tools/web-release-assets-guard.sh
+++ b/tools/web-release-assets-guard.sh
@@ -1,0 +1,291 @@
+#!/usr/bin/env bash
+# web-release-assets-guard.sh — the release artifacts carry the WHOLE
+# dashboard, not the part someone remembered to list.
+#
+# Usage:
+#   tools/web-release-assets-guard.sh            # guard the repo's own tree
+#   tools/web-release-assets-guard.sh --help
+#
+# Exit codes:
+#   0  OK      — the staged tree is complete and carries nothing dev-only
+#   1  FAIL    — a finding: a reachable asset is missing, a dev-only file
+#                shipped, or build-release.sh stages by hand again
+#   2  REFUSE  — could not judge (unreadable tree, no entry point, the import
+#                scan found nothing). Never silence: "no finding" and "could
+#                not look" must not print the same thing.
+#
+# ---------------------------------------------------------------------------
+# What it guards, and why it is shaped this way (#1900)
+#
+# tools/build-release.sh staged the dashboard from a hand-written three-file
+# `cp` list. That list was complete in #418 and stopped being complete in #712
+# and #820, when irrlicht.js became an ES module importing ten siblings. Every
+# release artifact after that shipped an irrlicht.js whose imports 404'd, so
+# the dashboard rendered a blank page for every installed user on macOS and
+# Linux — the only UI Linux has — until it was reported by hand.
+#
+# Three properties follow from that history, and each is load-bearing:
+#
+# 1. IT EXECUTES THE REAL STAGING RULE. The guard sources tools/lib/stage-web.sh
+#    and stages into a temp dir, so what it inspects is what build-release.sh
+#    will produce. A guard that re-implemented the rule would prove something
+#    about itself and nothing about the script that ships. It also asserts
+#    build-release.sh still routes every web copy through that function, so
+#    the two cannot drift back apart.
+#
+# 2. IT WALKS THE TRANSITIVE CLOSURE, FROM index.html. A scan of irrlicht.js's
+#    DIRECT imports finds 9 of the 10 modules and calls itself complete:
+#    collapsedSet.js is reachable only through collapsedGroups.js and
+#    collapsedSummaries.js. So the walk starts at index.html's <script
+#    type=module> / <link rel=stylesheet>, follows `from '…'` edges, and keeps
+#    a visited set — permissionsWizard.js and quotaChips.js both import back
+#    from ./irrlicht.js, so the graph has cycles and a naive recursion would
+#    not terminate.
+#
+# 3. IT FAILS LOUDLY WHEN IT CANNOT LOOK. The scan's own failure mode is
+#    silence: irrlicht.js and sessionIdentity.js carry literal NUL bytes (an id
+#    separator, `daemonId + '\0' + sessionId`), and a binary-detecting grep
+#    skips such a file without a word — which would compute an EMPTY closure
+#    and pass. Every read is `grep -a`, and a closure with no import edge in it
+#    REFUSEs rather than reporting success. The same repo-wide hazard is
+#    documented at tools/state-vocabulary-lint.sh:257.
+
+set -uo pipefail
+
+# _wrag_text_grep — grep over files that may contain literal NUL bytes. `-a`
+# is the whole point (see property 3 above); `command` bypasses any grep shell
+# function a sourcing caller may have.
+_wrag_text_grep() { LC_ALL=C command grep -a "$@"; }
+
+# _wrag_unquote — strip one layer of surrounding single or double quotes from
+# the LAST quoted run on the line, which is where a module specifier and an
+# HTML attribute value both sit.
+_wrag_unquote() { sed -E "s/^.*['\"]([^'\"]*)['\"][^'\"]*\$/\1/"; }
+
+# web_assets_html_refs <index.html> — one local asset reference per line, from
+# <script … src=…> and <link … href=…>. External (`scheme://`), root-relative
+# and in-page references are not assets this tree stages, and are dropped.
+# <a href=…> is deliberately not read: index.html links out to irrlicht.io.
+web_assets_html_refs() {
+    local file="$1" refs
+    refs=$(_wrag_text_grep -oE '<(script|link)[[:space:]][^>]*>' "$file" |
+        _wrag_text_grep -oE '[[:space:]](src|href)[[:space:]]*=[[:space:]]*("[^"]*"|'\''[^'\'']*'\'')' |
+        _wrag_unquote)
+    printf '%s\n' "$refs" | while IFS= read -r r; do
+        [[ -n "$r" ]] || continue
+        case "$r" in
+            *"://"* | /* | \#* | data:* | mailto:*) continue ;;
+        esac
+        printf '%s\n' "$r"
+    done
+}
+
+# web_assets_js_edges <file> — one module specifier per line, for every
+# `from '…'`, `import '…'` and `import('…')` in <file>.
+#
+# The `from` anchor is the one that matters: 5 of this tree's 15 edges are
+# multi-line import lists whose `from` clause sits on its own line, so a
+# pattern anchored on `^import` would miss a third of the graph.
+web_assets_js_edges() {
+    local file="$1"
+    _wrag_text_grep -oE "(^|[^[:alnum:]_$.])(from|import)[[:space:]]*\(?[[:space:]]*('[^']*'|\"[^\"]*\")" "$file" |
+        _wrag_unquote
+}
+
+# web_assets_closure <src-dir> — every file reachable from <src-dir>/index.html,
+# one basename per line, sorted, index.html included.
+#
+# Returns 2 and prints a REFUSE: line rather than an empty or partial answer
+# when it cannot judge: no tree, no index.html, no entry point, a reference
+# that resolves to nothing, a reference the non-recursive staging rule could
+# never ship, or a JS graph with not one import edge in it.
+web_assets_closure() {
+    local src="$1" seen="" queue="" cur spec base specs refs bad=0 edges=0 jsfiles=0
+
+    if [[ -z "$src" || ! -d "$src" ]]; then
+        echo "REFUSE: web asset closure — source tree not found: ${src:-<empty>}" >&2
+        return 2
+    fi
+    if [[ ! -f "$src/index.html" ]]; then
+        echo "REFUSE: web asset closure — $src/index.html is missing; there is no entry point to walk from" >&2
+        return 2
+    fi
+
+    _wrag_enqueue() {
+        local ref="$1" from="$2" b
+        b=${ref#./}
+        case "$b" in
+            ../*)
+                echo "FAIL: $from references '$ref', which lives outside the web tree — the staging rule is non-recursive and could never ship it" >&2
+                return 1
+                ;;
+            */*)
+                echo "FAIL: $from references '$ref' in a subdirectory — the staging rule is non-recursive and would silently drop it" >&2
+                return 1
+                ;;
+        esac
+        if [[ ! -f "$src/$b" ]]; then
+            echo "FAIL: $from references '$ref', which does not exist in $src" >&2
+            return 1
+        fi
+        case $'\n'"$seen" in *$'\n'"$b"$'\n'*) return 0 ;; esac
+        seen="$seen$b"$'\n'
+        queue="$queue$b"$'\n'
+        return 0
+    }
+
+    seen=$'\n'"index.html"$'\n'
+    refs=$(web_assets_html_refs "$src/index.html")
+    if [[ -z "$refs" ]]; then
+        echo "REFUSE: web asset closure — $src/index.html yielded no <script src> or <link href> reference; the scan could not read its entry points" >&2
+        return 2
+    fi
+    while IFS= read -r spec; do
+        [[ -n "$spec" ]] || continue
+        _wrag_enqueue "$spec" "index.html" || bad=1
+    done <<<"$refs"
+
+    # Breadth-first over the queue, with `seen` as the visited set: the graph
+    # is cyclic (permissionsWizard.js and quotaChips.js import back from
+    # irrlicht.js), so re-entry has to be cut here, not by recursion depth.
+    while [[ -n "$queue" ]]; do
+        cur=${queue%%$'\n'*}
+        queue=${queue#*$'\n'}
+        [[ -n "$cur" ]] || continue
+        case "$cur" in *.js) ;; *) continue ;; esac
+        jsfiles=$((jsfiles + 1))
+        specs=$(web_assets_js_edges "$src/$cur")
+        while IFS= read -r spec; do
+            [[ -n "$spec" ]] || continue
+            # Non-relative specifiers are bare package / node: builtins. They
+            # do not come from this tree, so they are not this rule's business.
+            case "$spec" in ./* | ../*) ;; *) continue ;; esac
+            edges=$((edges + 1))
+            _wrag_enqueue "$spec" "$cur" || bad=1
+        done <<<"$specs"
+    done
+
+    if [[ "$jsfiles" -eq 0 ]]; then
+        echo "REFUSE: web asset closure — index.html reached no JavaScript module at all" >&2
+        return 2
+    fi
+    if [[ "$edges" -eq 0 ]]; then
+        echo "REFUSE: web asset closure — scanned $jsfiles module(s) and found not one import edge. The scan cannot read this tree (a NUL-containing module read as binary would look exactly like this), so an 'everything is staged' verdict would be vacuous." >&2
+        return 2
+    fi
+    [[ "$bad" -eq 0 ]] || return 2
+
+    base=${seen#$'\n'}
+    printf '%s' "$base" | LC_ALL=C sort -u
+}
+
+# web_assets_guard <repo-root> — the whole check. 0 ok / 1 finding / 2 refuse.
+web_assets_guard() {
+    local root="$1" src="$1/platforms/web" brs="$1/tools/build-release.sh"
+    local closure staged tmp rc=0 f
+
+    if [[ ! -f "$root/tools/lib/stage-web.sh" ]]; then
+        echo "REFUSE: tools/lib/stage-web.sh is missing — the staging rule this guard executes is gone" >&2
+        return 2
+    fi
+    # shellcheck source=lib/stage-web.sh
+    . "$root/tools/lib/stage-web.sh"
+
+    closure=$(web_assets_closure "$src") || return 2
+
+    tmp=$(mktemp -d -t web-release-assets-guard) || {
+        echo "REFUSE: could not create a staging directory" >&2
+        return 2
+    }
+    # shellcheck disable=SC2064  # $tmp is expanded now, on purpose.
+    trap "rm -rf '$tmp'" RETURN
+
+    if ! stage_web "$src" "$tmp/web"; then
+        echo "REFUSE: stage_web refused to stage $src — the release staging rule cannot run" >&2
+        return 2
+    fi
+    staged=$(cd "$tmp/web" && LC_ALL=C ls -A | LC_ALL=C sort)
+    if [[ -z "$staged" ]]; then
+        echo "REFUSE: stage_web reported success but staged nothing" >&2
+        return 2
+    fi
+
+    # (a) every reachable asset ships.
+    while IFS= read -r f; do
+        [[ -n "$f" ]] || continue
+        case $'\n'"$staged"$'\n' in
+            *$'\n'"$f"$'\n'*) ;;
+            *)
+                echo "FAIL: '$f' is reachable from index.html but tools/build-release.sh would not stage it — it will 404 in every release artifact" >&2
+                rc=1
+                ;;
+        esac
+    done <<<"$closure"
+
+    # (b) nothing dev-only ships. Without this half a lazy `cp -R` of the whole
+    # web tree — node_modules and all — would satisfy (a) and read as a fix.
+    while IFS= read -r f; do
+        [[ -n "$f" ]] || continue
+        case "$f" in
+            *.test.js | vitest.* | package.json | package-lock.json | node_modules | snapshots | .* )
+                echo "FAIL: '$f' is dev-only tooling and must not ship in a release artifact" >&2
+                rc=1
+                ;;
+        esac
+        if [[ -d "$tmp/web/$f" ]]; then
+            echo "FAIL: '$f' is a directory — the release web tree is flat, and a recursive copy is how node_modules ships by accident" >&2
+            rc=1
+        fi
+    done <<<"$staged"
+
+    # (c) build-release.sh still routes EVERY web copy through the rule. (a)
+    # and (b) grade tools/lib/stage-web.sh; this is what keeps the shipping
+    # script attached to it, so a fourth artifact cannot reintroduce a
+    # hand-written list beside it.
+    if [[ ! -f "$brs" ]]; then
+        echo "REFUSE: tools/build-release.sh is missing" >&2
+        return 2
+    fi
+    if ! _wrag_text_grep -q 'lib/stage-web\.sh' "$brs"; then
+        echo "FAIL: tools/build-release.sh does not source tools/lib/stage-web.sh" >&2
+        rc=1
+    fi
+    if ! _wrag_text_grep -qE '(^|[^[:alnum:]_])stage_web[[:space:]]' "$brs"; then
+        echo "FAIL: tools/build-release.sh never calls stage_web — nothing stages the dashboard by rule" >&2
+        rc=1
+    fi
+    local handrolled
+    handrolled=$(_wrag_text_grep -nE 'platforms/web' "$brs" |
+        _wrag_text_grep -vE '^[0-9]+:[[:space:]]*#' |
+        _wrag_text_grep -vE '(^|[^[:alnum:]_])stage_web[[:space:]]' || :)
+    if [[ -n "$handrolled" ]]; then
+        echo "FAIL: tools/build-release.sh touches platforms/web outside stage_web — that is the hand-written list this guard exists to prevent:" >&2
+        printf '%s\n' "$handrolled" | sed 's/^/       tools\/build-release.sh:/' >&2
+        rc=1
+    fi
+
+    if [[ "$rc" -eq 0 ]]; then
+        echo "OK: web-release-assets-guard — $(printf '%s\n' "$closure" | _wrag_text_grep -c .) reachable asset(s) from index.html, all staged by tools/lib/stage-web.sh, no dev-only file in the release tree"
+    fi
+    return "$rc"
+}
+
+if [[ "${BASH_SOURCE[0]:-}" == "${0:-}" ]]; then
+    case "${1:-}" in
+        -h | --help)
+            awk 'NR>1 && /^#/ {print; next} NR>1 {exit}' "$0"
+            exit 0
+            ;;
+        "") ;;
+        *)
+            echo "REFUSE: unknown argument '$1' (try --help)" >&2
+            exit 2
+            ;;
+    esac
+    WRAG_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || {
+        echo "REFUSE: not inside a git repository — cannot locate the web tree" >&2
+        exit 2
+    }
+    web_assets_guard "$WRAG_ROOT"
+    exit $?
+fi


### PR DESCRIPTION
> **⚠️ BLOCKED ON A DESIGN DECISION — do not merge as-is.**
>
> While this PR was in review, **#1847** merged and independently fixed the same
> defect with a **different design**: a single `WEB_FILES=( … )` array plus a
> `copy_web_files` helper in `tools/build-release.sh`, a fourth staging site
> (the Linux relay tarball), fixes to `site/install.sh` and
> `examples/relay/Dockerfile`, and a ~400-line vitest guard
> (`platforms/web/release-files.test.js` + `shippedFiles.testutil.js`) with its
> own committed mutation fixtures.
>
> This PR replaces that **list** with a **rule** (`tools/lib/stage-web.sh`), so
> the two cannot both stand. Measured, not assumed: applying this PR's staging
> to `origin/main`'s `build-release.sh` and running main's own suite gives
> **5 failed | 57 passed (62)** — the arms that assert "build-release.sh defines
> a single WEB_FILES list", "every copy site draws from that list", and "the
> relay tarball must inherit WEB_FILES via copy_web_files".
>
> Landing this PR therefore means rewriting #1847's just-merged test suite to
> grade the rule instead of the list. That is a maintainer call, not an
> execution detail, so `ir:exec` stopped here rather than choosing.
>
> Note also that #1847 did **not** close #1900, and #1900 is still open — the
> symptom is fixed on main, the design question is what is open.

---

Closes #1900

## What was broken

`tools/build-release.sh` staged the dashboard from a hand-written three-file `cp` list (lines 65 / 87 / 124) into all four release artifacts. The list was complete when written (#418) and stopped being complete in #712 / #820, when `irrlicht.js` became an ES module importing ten siblings. None were packaged, so every import 404'd, the module graph never evaluated, and the **released** dashboard rendered a blank page for every installed user on macOS and Linux — where the web dashboard is the only UI.

## What changed

- **`tools/lib/stage-web.sh` (new)** — the runtime asset set as a *rule*, defined once: every `*.html` / `*.css` / `*.js` directly in the web tree, minus `*.test.js`, `vitest.config.js`, `vitest.setup.js`. The glob does not recurse, so `node_modules/` and `snapshots/` cannot be swept in, and `package*.json` is not matched. Naming the set by extension and subtracting the dev files — rather than listing the runtime files — is what makes a newly extracted module ship by default.
- **`tools/build-release.sh`** — sources that library and calls `stage_web` at all three staging sites.
- **`tools/web-release-assets-guard.sh` (new)** — *executes* that rule (not a copy) into a temp dir, walks the transitive closure from `index.html`'s `<script type=module>` / `<link rel=stylesheet>` with a visited set, and asserts both directions: everything reachable is staged, and nothing dev-only is. It also asserts `build-release.sh` still routes every `platforms/web` copy through `stage_web`, so the two cannot drift apart again.
- **`core/cmd/irrlichd/ui_release_tree_test.go` (new)** — the served-side half: stage with the real rule, walk the real import graph, require 200 for every reachable asset through `registerUIRoutes`. The two sides come from *different* sources on purpose — a test that asked the staged directory what to request could never reproduce the defect.
- **`core/cmd/irrlichd/startup.go`** — the stale "ships as three files" comment, which is where the broken assumption was recorded. It now states the rule (a blanket `http.FileServer`), not a file count. Also fixes a stale `main.go` → `paths.go` reference beside the staging site.
- **`tools/preflight.sh`** — the guard joins the `tools` group, and `^platforms/web/` joins both that gate's trigger and the shell-lib-tests trigger.

### Three properties are load-bearing

1. **The walk is transitive.** `irrlicht.js` imports 9 siblings directly; `collapsedSet.js` is reachable only via `collapsedGroups.js` / `collapsedSummaries.js`. A direct-import scan finds 9 of 10 and reports completeness.
2. **It is cycle-tolerant.** `permissionsWizard.js` and `quotaChips.js` both import back from `./irrlicht.js`.
3. **It fails loudly when it cannot look.** `irrlicht.js` and `sessionIdentity.js` carry literal NUL bytes; a binary-detecting grep answers `Binary file … matches` and yields no edges, which would compute an empty closure and pass. Every read is `grep -a`, and a closure with zero import edges REFUSEs.

## Test evidence

**Red-first (a real "before the fix" — the defect ships today):**

- The guard's closure run against `origin/main`'s own line 65 `cp` command names all 10 missing modules — the same 10 the issue measured as 404 on the released daemon.
- `TestRegisterUIRoutesServesTheStagedReleaseTree` under `origin/main`'s three-file rule reports `GET /<module>.js = 404, want 200` for all ten. Reproduce (also recorded in the test's doc comment):
  ```
  tools/mutate.sh tools/lib/stage-web.sh \
    '    for f in "$src"/*.html "$src"/*.css "$src"/*.js; do' \
    '    for f in "$src"/index.html "$src"/irrlicht.css "$src"/irrlicht.js; do' \
    bash -c 'cd core && go test ./cmd/irrlichd/ -run TestRegisterUIRoutesServesTheStagedReleaseTree -count=1'
  ```

**Mutation-proved (`tools/lib/web-release-assets-guard-mutations_test.sh`, 8 committed fixtures, all seen red then restored):** the staging rule dropping `collapsedSet.js` (the transitive-only module); dropping `formatters.js` (a first-hop import); shipping `*.test.js`; the scan losing `grep -a` on a NUL-containing module; the zero-import-edge refusal disarmed; `build-release.sh` staging by hand again; and `^platforms/web/` leaving either of the two preflight triggers. The NUL row asserts its own precondition and *fails* — not skips — if the local `grep` cannot binary-detect.

**Locks (green by construction, not evidence):** `tools/lib/web-release-assets-guard_test.sh`'s happy path and its 7 fail-loudly refusal fixtures; `platforms/web/` vitest (no web source is touched); `tools/lib/shell-lib-errexit_test.sh` (extended with 6 rows for the new library — it auto-discovers `tools/lib/*.sh`).

**Gate parity** (the thing this issue is about, one level up): the lock test runs preflight's *own* trigger regexes through the same `grep -qE` against `platforms/web/newlyExtractedModule.js` and fails if either gate would be SKIPped — so a commit that extracts a new module cannot skip the gate that catches it.

**Preflight:** `go`, `web`, `arch`, `tools`, `skills`, `posix`, `bash` all PASS run individually; the pre-push run (`PREPUSH_BUDGET=2400`) reported PASS for every selected gate including `security` and `swift`. An earlier unbounded `--only security` run failed *only* on `npm audit` network timeouts to `registry.npmjs.org` (the gate says so itself: "this is NOT a vulnerability finding"); re-running `npm audit` in both web trees returned `found 0 vulnerabilities`, and this diff touches no `package.json` or lockfile.

## Design deviation from triage

Triage said "a single shell function **in** `tools/build-release.sh`". The function lives in `tools/lib/stage-web.sh` instead, sourced by `build-release.sh`. Evidence: `build-release.sh` runs a full signed universal build at top level under `set -e`, so it cannot be sourced — a guard could only re-parse its text, and triage's own requirement was that the guard execute the *real* rule. `tools/lib/` is this repo's established home for sourced shell libraries, and `tools/lib/shell-lib-errexit_test.sh` grades every function there by discovering it. The loop back to the shipping script is closed by assertion (c) in the guard, which fails if `build-release.sh` touches `platforms/web` outside `stage_web`.

## Human gate

Per triage, the release build + notarization is the maintainer's (`/ir:release`). After merge: `ls "$BUILD_DIR/Irrlicht.app/Contents/Resources/web/"` should show 13 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01615niHdVNthGbskmVG4JVt

