### PR TITLE
feat(onboard): validate Claude Desktop evidence

### DIFF
--- a/tools/onboarding-factory/cmd/of/desktop_results_test.go
+++ b/tools/onboarding-factory/cmd/of/desktop_results_test.go
@@ -19,6 +19,19 @@ type desktopFixture struct {
 	record   string
 }
 
+type observedResultFixture struct {
+	scenario string
+	outcome  string
+	reason   string
+}
+
+type nonObservedResultFixture struct {
+	scenario       string
+	outcome        string
+	reason         string
+	missingControl string
+}
+
 // desktopResultsRepo is the positive fixture for the full result vocabulary.
 // It deliberately uses five different cells so completeness, uniqueness, and
 // each outcome are proven together instead of by disconnected partial trees.
@@ -47,17 +60,17 @@ func desktopResultsRepo(t *testing.T, enforce bool) desktopFixture {
 		fixture.cellDirs[scenario] = filepath.Join(root, "replaydata", "agents", "claudecode", "scenarios", folder)
 	}
 
-	writeObservedDesktopResult(t, fixture, "observed-pass", "observed-passing", "")
-	writeObservedDesktopResult(t, fixture, "observed-failure", "observed-failure", "Irrlicht reported the observed failure.")
-	writeNonObservedDesktopResult(t, fixture, "not-applicable", "not-applicable", "The scenario is outside Local Desktop.", "")
-	writeNonObservedDesktopResult(t, fixture, "unobservable", "unobservable", "The local runtime leaves no observable trace.", "")
-	writeNonObservedDesktopResult(t, fixture, "not-runnable", "not-runnable", "The Desktop driver cannot perform this recipe.", "model selector")
+	writeObservedDesktopResult(t, fixture, observedResultFixture{scenario: "observed-pass", outcome: "observed-passing"})
+	writeObservedDesktopResult(t, fixture, observedResultFixture{scenario: "observed-failure", outcome: "observed-failure", reason: "Irrlicht reported the observed failure."})
+	writeNonObservedDesktopResult(t, fixture, nonObservedResultFixture{scenario: "not-applicable", outcome: "not-applicable", reason: "The scenario is outside Local Desktop."})
+	writeNonObservedDesktopResult(t, fixture, nonObservedResultFixture{scenario: "unobservable", outcome: "unobservable", reason: "The local runtime leaves no observable trace."})
+	writeNonObservedDesktopResult(t, fixture, nonObservedResultFixture{scenario: "not-runnable", outcome: "not-runnable", reason: "The Desktop driver cannot perform this recipe.", missingControl: "model selector"})
 	return fixture
 }
 
-func writeObservedDesktopResult(t *testing.T, fixture desktopFixture, scenario, outcome, reason string) {
+func writeObservedDesktopResult(t *testing.T, fixture desktopFixture, spec observedResultFixture) {
 	t.Helper()
-	cellDir := fixture.cellDirs[scenario]
+	cellDir := fixture.cellDirs[spec.scenario]
 	recDir := filepath.Join(cellDir, "recordings", fixture.record)
 	recording(t, fixture.root, "claudecode", filepath.Base(cellDir), fixture.record, true)
 	write(t, filepath.Join(recDir, "manifest.json"), `{
@@ -79,12 +92,12 @@ func writeObservedDesktopResult(t *testing.T, fixture desktopFixture, scenario, 
 			desktopHookReceipt+"\n")
 	write(t, filepath.Join(recDir, "hooks.jsonl"), desktopHookReceipt+"\n")
 	write(t, filepath.Join(recDir, "process.json"), `{"pid":4242,"command":"claude"}`+"\n")
-	writeExpectedOutcome(t, cellDir, scenario, outcome)
+	writeExpectedOutcome(t, cellDir, spec.scenario, spec.outcome)
 
 	result := map[string]any{
-		"scenario_id":       scenario,
+		"scenario_id":       spec.scenario,
 		"execution_profile": "desktop-local",
-		"outcome":           outcome,
+		"outcome":           spec.outcome,
 		"recording":         fixture.record,
 		"evidence": map[string]string{
 			"desktop_registry": "desktop-registry.json",
@@ -95,28 +108,28 @@ func writeObservedDesktopResult(t *testing.T, fixture desktopFixture, scenario, 
 			"environment":      "desktop-environment.json",
 		},
 	}
-	if reason != "" {
-		result["reason"] = reason
+	if spec.reason != "" {
+		result["reason"] = spec.reason
 	}
 	writeExecutionResults(t, cellDir, []any{result})
 }
 
-func writeNonObservedDesktopResult(t *testing.T, fixture desktopFixture, scenario, outcome, reason, missingControl string) {
+func writeNonObservedDesktopResult(t *testing.T, fixture desktopFixture, spec nonObservedResultFixture) {
 	t.Helper()
-	cellDir := fixture.cellDirs[scenario]
-	evidencePath := filepath.Join(cellDir, "desktop-evidence", scenario+".md")
-	write(t, evidencePath, "Desktop campaign evidence for "+scenario+".\n")
+	cellDir := fixture.cellDirs[spec.scenario]
+	evidencePath := filepath.Join(cellDir, "desktop-evidence", spec.scenario+".md")
+	write(t, evidencePath, "Desktop campaign evidence for "+spec.scenario+".\n")
 	result := map[string]any{
-		"scenario_id":       scenario,
+		"scenario_id":       spec.scenario,
 		"execution_profile": "desktop-local",
-		"outcome":           outcome,
-		"reason":            reason,
+		"outcome":           spec.outcome,
+		"reason":            spec.reason,
 		"evidence_refs": []string{
 			filepath.ToSlash(strings.TrimPrefix(evidencePath, fixture.root+string(filepath.Separator))),
 		},
 	}
-	if missingControl != "" {
-		result["missing_control"] = missingControl
+	if spec.missingControl != "" {
+		result["missing_control"] = spec.missingControl
 	}
 	writeExecutionResults(t, cellDir, []any{result})
 }
@@ -441,7 +454,7 @@ func TestValidateDesktopExactRecordingCompletenessMutation(t *testing.T) {
 	}
 	newer := fixture
 	newer.record = "desktop-r2"
-	writeObservedDesktopResult(t, newer, "observed-pass", "observed-passing", "")
+	writeObservedDesktopResult(t, newer, observedResultFixture{scenario: "observed-pass", outcome: "observed-passing"})
 	path := filepath.Join(cellDir, desktopResultsFile)
 	mutateFirstResult(t, path, func(result map[string]any) { result["recording"] = fixture.record })
 	requireDesktopFinding(t, fixture.root, "observed-pass", "recording completeness")

--- a/tools/onboarding-factory/cmd/of/desktop_results_test.go
+++ b/tools/onboarding-factory/cmd/of/desktop_results_test.go
@@ -8,7 +8,10 @@ import (
 	"testing"
 )
 
-const desktopResultsFile = "execution-results.json"
+const (
+	desktopResultsFile = "execution-results.json"
+	desktopHookReceipt = `{"seq":2,"ts":"2026-05-01T00:00:01Z","kind":"hook_received","session_id":"transcript-1","hook_name":"Stop"}`
+)
 
 type desktopFixture struct {
 	root     string
@@ -71,7 +74,10 @@ func writeObservedDesktopResult(t *testing.T, fixture desktopFixture, scenario, 
 	write(t, filepath.Join(recDir, "irrlicht-session.json"), `{"session_id":"transcript-1","cwd":"/workspace","pid":4242,"launcher":{"host_bundle_id":"com.anthropic.claudefordesktop"}}`+"\n")
 	// hooks.jsonl preserves the exact hook-receipt rows extracted from the
 	// recording's events.jsonl. It is not the raw inbound Claude hook payload.
-	write(t, filepath.Join(recDir, "hooks.jsonl"), `{"kind":"hook_received","session_id":"transcript-1","hook_name":"Stop"}`+"\n")
+	write(t, filepath.Join(recDir, "events.jsonl"),
+		`{"seq":1,"ts":"2026-05-01T00:00:00Z","kind":"transcript_new","session_id":"transcript-1","adapter":"claudecode"}`+"\n"+
+			desktopHookReceipt+"\n")
+	write(t, filepath.Join(recDir, "hooks.jsonl"), desktopHookReceipt+"\n")
 	write(t, filepath.Join(recDir, "process.json"), `{"pid":4242,"command":"claude"}`+"\n")
 	writeExpectedOutcome(t, cellDir, scenario, outcome)
 
@@ -379,6 +385,26 @@ func TestValidateDesktopIdentityMutations(t *testing.T) {
 		write(t, filepath.Join(recDir, "hooks.jsonl"), `{"kind":"hook_received","session_id":"transcript-1"}`+"\n")
 		requireDesktopFinding(t, fixture.root, "observed-pass", "hooks.hook_name")
 	})
+}
+
+func TestValidateDesktopHookReceiptProvenanceMutations(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+	}{
+		{"changed hook name", strings.Replace(desktopHookReceipt, `"hook_name":"Stop"`, `"hook_name":"PostToolUse"`, 1) + "\n"},
+		{"changed session", strings.Replace(desktopHookReceipt, `"session_id":"transcript-1"`, `"session_id":"other"`, 1) + "\n"},
+		{"invented extra field", strings.TrimSuffix(desktopHookReceipt, "}") + `,"source":"invented"}` + "\n"},
+		{"invented duplicate", desktopHookReceipt + "\n" + desktopHookReceipt + "\n"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fixture := desktopResultsRepo(t, false)
+			recDir := filepath.Join(fixture.cellDirs["observed-pass"], "recordings", fixture.record)
+			write(t, filepath.Join(recDir, "hooks.jsonl"), tc.body)
+			requireDesktopFinding(t, fixture.root, "observed-pass", "hooks.events_jsonl")
+		})
+	}
 }
 
 func TestValidateDesktopObservedOutcomeMutations(t *testing.T) {

--- a/tools/onboarding-factory/cmd/of/desktop_results_test.go
+++ b/tools/onboarding-factory/cmd/of/desktop_results_test.go
@@ -65,11 +65,13 @@ func writeObservedDesktopResult(t *testing.T, fixture desktopFixture, scenario, 
   "desktop_app_version":"1.44121.4"
 }`)
 	write(t, filepath.Join(recDir, "transcript.jsonl"), `{"type":"user","sessionId":"transcript-1","cwd":"/workspace","entrypoint":"claude-desktop"}`+"\n")
-	write(t, filepath.Join(recDir, "desktop-registry.json"), `{"sessionId":"local_desktop-1","cliSessionId":"transcript-1","cwd":"/workspace","envScopeId":null}`+"\n")
+	// A measured project-local Claude Desktop registry row omits envScopeId.
+	write(t, filepath.Join(recDir, "desktop-registry.json"), `{"sessionId":"local_desktop-1","cliSessionId":"transcript-1","cwd":"/workspace"}`+"\n")
 	write(t, filepath.Join(recDir, "desktop-environment.json"), `{"selected_environment":"Local","requested_workspace":"/workspace"}`+"\n")
 	write(t, filepath.Join(recDir, "irrlicht-session.json"), `{"session_id":"transcript-1","cwd":"/workspace","pid":4242,"launcher":{"host_bundle_id":"com.anthropic.claudefordesktop"}}`+"\n")
 	write(t, filepath.Join(recDir, "hooks.jsonl"), `{"session_id":"transcript-1","hook_event_name":"Stop"}`+"\n")
 	write(t, filepath.Join(recDir, "process.json"), `{"pid":4242,"command":"claude"}`+"\n")
+	writeExpectedOutcome(t, cellDir, scenario, outcome)
 
 	result := map[string]any{
 		"scenario_id":       scenario,
@@ -94,19 +96,31 @@ func writeObservedDesktopResult(t *testing.T, fixture desktopFixture, scenario, 
 func writeNonObservedDesktopResult(t *testing.T, fixture desktopFixture, scenario, outcome, reason, missingControl string) {
 	t.Helper()
 	cellDir := fixture.cellDirs[scenario]
+	evidencePath := filepath.Join(cellDir, "desktop-evidence", scenario+".md")
+	write(t, evidencePath, "Desktop campaign evidence for "+scenario+".\n")
 	result := map[string]any{
 		"scenario_id":       scenario,
 		"execution_profile": "desktop-local",
 		"outcome":           outcome,
 		"reason":            reason,
 		"evidence_refs": []string{
-			filepath.ToSlash(strings.TrimPrefix(filepath.Join(cellDir, "metadata.json"), fixture.root+string(filepath.Separator))),
+			filepath.ToSlash(strings.TrimPrefix(evidencePath, fixture.root+string(filepath.Separator))),
 		},
 	}
 	if missingControl != "" {
 		result["missing_control"] = missingControl
 	}
 	writeExecutionResults(t, cellDir, []any{result})
+}
+
+func writeExpectedOutcome(t *testing.T, cellDir, scenario, outcome string) {
+	t.Helper()
+	phase := `{"phase":"birth","kind":"transcript_new","relative_to":"start","max_delay_ms":1000,"text":"the recording contains a transcript"}`
+	if outcome == "observed-failure" {
+		phase = `{"phase":"failure","expected_state":"error","relative_to":"start","max_delay_ms":1000,"text":"the expected failure is visible"}`
+	}
+	write(t, filepath.Join(cellDir, "expected.jsonl"),
+		`{"schema_version":1,"scenario_id":"`+scenario+`","source":"desktop fixture"}`+"\n"+phase+"\n")
 }
 
 func writeExecutionResults(t *testing.T, cellDir string, results []any) {
@@ -170,7 +184,7 @@ func TestValidateDesktopCompletenessMutations(t *testing.T) {
 		}
 		requireDesktopFinding(t, fixture.root, "unobservable", "missing desktop-local result")
 	})
-	t.Run("catalog addition is required dynamically", func(t *testing.T) {
+	t.Run("Claude Code cell addition is required dynamically", func(t *testing.T) {
 		fixture := desktopResultsRepo(t, true)
 		path := filepath.Join(fixture.root, "replaydata", "agents", "scenarios.json")
 		var catalog map[string]any
@@ -179,7 +193,22 @@ func TestValidateDesktopCompletenessMutations(t *testing.T) {
 			"id": "1.6", "name": "new-current-cell", "description": "d", "process": "p", "acceptance_criteria": "a",
 		})
 		writeJSONFixture(t, path, catalog)
+		cell(t, fixture.root, "claudecode", "1-6_new-current-cell", "yes", "full", "ready")
 		requireDesktopFinding(t, fixture.root, "new-current-cell", "missing desktop-local result")
+	})
+	t.Run("other adapter scenario does not create a Claude Code requirement", func(t *testing.T) {
+		fixture := desktopResultsRepo(t, true)
+		path := filepath.Join(fixture.root, "replaydata", "agents", "scenarios.json")
+		var catalog map[string]any
+		mustReadJSON(t, path, &catalog)
+		catalog["scenarios"] = append(catalog["scenarios"].([]any), map[string]any{
+			"id": "1.6", "name": "other-adapter-only", "description": "d", "process": "p", "acceptance_criteria": "a",
+		})
+		writeJSONFixture(t, path, catalog)
+		cell(t, fixture.root, "aider", "1-6_other-adapter-only", "yes", "full", "ready")
+		if code, _, stderr := runOf("validate", "--repo-root", fixture.root); code != exitOK {
+			t.Fatalf("other-adapter-only scenario created a Claude Desktop requirement: exit=%d stderr=%s", code, stderr)
+		}
 	})
 	t.Run("duplicate", func(t *testing.T) {
 		fixture := desktopResultsRepo(t, true)
@@ -294,10 +323,10 @@ func TestValidateDesktopIdentityMutations(t *testing.T) {
 		body  string
 	}{
 		{"CLI transcript entrypoint", "transcript.entrypoint", "transcript.jsonl", `{"type":"user","sessionId":"transcript-1","cwd":"/workspace","entrypoint":"cli"}` + "\n"},
-		{"registry mapping", "desktop_registry.cliSessionId", "desktop-registry.json", `{"sessionId":"local_desktop-1","cliSessionId":"other","cwd":"/workspace","envScopeId":null}` + "\n"},
-		{"registry Desktop ID", "desktop_registry.sessionId", "desktop-registry.json", `{"sessionId":"remote_desktop-1","cliSessionId":"transcript-1","cwd":"/workspace","envScopeId":null}` + "\n"},
-		{"registry workspace", "desktop_registry.cwd", "desktop-registry.json", `{"sessionId":"local_desktop-1","cliSessionId":"transcript-1","cwd":"/other","envScopeId":null}` + "\n"},
-		{"non-Local registry", "desktop_registry.envScopeId", "desktop-registry.json", `{"sessionId":"local_desktop-1","cliSessionId":"transcript-1","cwd":"/workspace","envScopeId":"remote"}` + "\n"},
+		{"registry mapping", "desktop_registry.cliSessionId", "desktop-registry.json", `{"sessionId":"local_desktop-1","cliSessionId":"other","cwd":"/workspace"}` + "\n"},
+		{"registry Desktop ID", "desktop_registry.sessionId", "desktop-registry.json", `{"sessionId":"remote_desktop-1","cliSessionId":"transcript-1","cwd":"/workspace"}` + "\n"},
+		{"registry workspace", "desktop_registry.cwd", "desktop-registry.json", `{"sessionId":"local_desktop-1","cliSessionId":"transcript-1","cwd":"/other"}` + "\n"},
+		{"built-in Local registry scope", "desktop_registry.envScopeId", "desktop-registry.json", `{"sessionId":"local_desktop-1","cliSessionId":"transcript-1","cwd":"/workspace","envScopeId":"builtin_local"}` + "\n"},
 		{"transcript workspace", "transcript.cwd", "transcript.jsonl", `{"type":"user","sessionId":"transcript-1","cwd":"/other","entrypoint":"claude-desktop"}` + "\n"},
 		{"selected environment", "environment.selected_environment", "desktop-environment.json", `{"selected_environment":"Remote","requested_workspace":"/workspace"}` + "\n"},
 		{"requested workspace", "environment.requested_workspace", "desktop-environment.json", `{"selected_environment":"Local","requested_workspace":"/other"}` + "\n"},
@@ -321,6 +350,52 @@ func TestValidateDesktopIdentityMutations(t *testing.T) {
 		write(t, filepath.Join(recDir, "hooks.jsonl"), `{"session_id":"transcript-1"}`+"\n"+`{"session_id":"other"}`+"\n")
 		requireDesktopFinding(t, fixture.root, "observed-pass", "hooks.session_id")
 	})
+	t.Run("hook event name is required", func(t *testing.T) {
+		fixture := desktopResultsRepo(t, false)
+		recDir := filepath.Join(fixture.cellDirs["observed-pass"], "recordings", fixture.record)
+		write(t, filepath.Join(recDir, "hooks.jsonl"), `{"session_id":"transcript-1"}`+"\n")
+		requireDesktopFinding(t, fixture.root, "observed-pass", "hooks.hook_event_name")
+	})
+}
+
+func TestValidateDesktopObservedOutcomeMutations(t *testing.T) {
+	t.Run("passing recording cannot be labelled failure", func(t *testing.T) {
+		fixture := desktopResultsRepo(t, false)
+		path := filepath.Join(fixture.cellDirs["observed-pass"], desktopResultsFile)
+		mutateFirstResult(t, path, func(result map[string]any) {
+			result["outcome"] = "observed-failure"
+			result["reason"] = "Synthetic failure label."
+		})
+		requireDesktopFinding(t, fixture.root, "observed-pass", "outcome")
+	})
+	t.Run("failing recording cannot be labelled passing", func(t *testing.T) {
+		fixture := desktopResultsRepo(t, false)
+		path := filepath.Join(fixture.cellDirs["observed-failure"], desktopResultsFile)
+		mutateFirstResult(t, path, func(result map[string]any) { result["outcome"] = "observed-passing" })
+		requireDesktopFinding(t, fixture.root, "observed-failure", "outcome")
+	})
+	t.Run("expected report is required", func(t *testing.T) {
+		fixture := desktopResultsRepo(t, false)
+		if err := os.Remove(filepath.Join(fixture.cellDirs["observed-pass"], "expected.jsonl")); err != nil {
+			t.Fatal(err)
+		}
+		requireDesktopFinding(t, fixture.root, "observed-pass", "outcome")
+	})
+}
+
+func TestValidateDesktopExactRecordingCompletenessMutation(t *testing.T) {
+	fixture := desktopResultsRepo(t, false)
+	cellDir := fixture.cellDirs["observed-pass"]
+	oldRecording := filepath.Join(cellDir, "recordings", fixture.record)
+	if err := os.Remove(filepath.Join(oldRecording, "events.jsonl")); err != nil {
+		t.Fatal(err)
+	}
+	newer := fixture
+	newer.record = "desktop-r2"
+	writeObservedDesktopResult(t, newer, "observed-pass", "observed-passing", "")
+	path := filepath.Join(cellDir, desktopResultsFile)
+	mutateFirstResult(t, path, func(result map[string]any) { result["recording"] = fixture.record })
+	requireDesktopFinding(t, fixture.root, "observed-pass", "recording completeness")
 }
 
 func TestValidateDesktopEvidenceReferenceMutations(t *testing.T) {
@@ -372,6 +447,21 @@ func TestValidateDesktopEvidenceReferenceMutations(t *testing.T) {
 		manifest := filepath.Join(fixture.cellDirs["observed-pass"], "recordings", fixture.record, "manifest.json")
 		write(t, manifest, `{"execution_profile":"desktop-local","entrypoint":"cli","daemon_version":"0.6.2","agent_cli_version":"2.1.258","desktop_app_version":"1.44121.4"}`+"\n")
 		requireDesktopFinding(t, fixture.root, "observed-pass", "manifest.entrypoint")
+	})
+	t.Run("non-observed circular reference", func(t *testing.T) {
+		fixture := desktopResultsRepo(t, false)
+		path := filepath.Join(fixture.cellDirs["unobservable"], desktopResultsFile)
+		mutateFirstResult(t, path, func(result map[string]any) {
+			result["evidence_refs"] = []any{filepath.ToSlash(strings.TrimPrefix(path, fixture.root+string(filepath.Separator)))}
+		})
+		requireDesktopFinding(t, fixture.root, "unobservable", "evidence_refs[0]")
+	})
+	t.Run("non-observed reference outside allowed evidence scope", func(t *testing.T) {
+		fixture := desktopResultsRepo(t, false)
+		write(t, filepath.Join(fixture.root, "unrelated.txt"), "not campaign evidence\n")
+		path := filepath.Join(fixture.cellDirs["unobservable"], desktopResultsFile)
+		mutateFirstResult(t, path, func(result map[string]any) { result["evidence_refs"] = []any{"unrelated.txt"} })
+		requireDesktopFinding(t, fixture.root, "unobservable", "evidence_refs[0]")
 	})
 }
 

--- a/tools/onboarding-factory/cmd/of/desktop_results_test.go
+++ b/tools/onboarding-factory/cmd/of/desktop_results_test.go
@@ -132,13 +132,13 @@ func writeExecutionResults(t *testing.T, cellDir string, results []any) {
 	write(t, filepath.Join(cellDir, desktopResultsFile), string(b)+"\n")
 }
 
-func requireDesktopFinding(t *testing.T, root, scenario, field string) {
+func requireDesktopFinding(t *testing.T, root, scenario string, fields ...string) {
 	t.Helper()
 	code, _, stderr := runOf("validate", "--repo-root", root)
 	if code != exitFail {
 		t.Fatalf("of validate accepted the Desktop evidence mutation; exit=%d stderr=%s", code, stderr)
 	}
-	for _, want := range []string{scenario, field} {
+	for _, want := range append([]string{scenario}, fields...) {
 		if !strings.Contains(stderr, want) {
 			t.Fatalf("finding must name %q; stderr:\n%s", want, stderr)
 		}
@@ -245,7 +245,7 @@ func TestValidateDesktopCompletenessMutations(t *testing.T) {
 		offPath := filepath.Join(fixture.root, "replaydata", "agents", "claudecode", "regressions", "copied-result")
 		write(t, filepath.Join(offPath, "metadata.json"), `{"scenario_id":"unobservable"}`+"\n")
 		write(t, filepath.Join(offPath, desktopResultsFile), string(body))
-		requireDesktopFinding(t, fixture.root, "unobservable", "missing desktop-local result")
+		requireDesktopFinding(t, fixture.root, "unobservable", "missing desktop-local result", "document location")
 	})
 }
 

--- a/tools/onboarding-factory/cmd/of/desktop_results_test.go
+++ b/tools/onboarding-factory/cmd/of/desktop_results_test.go
@@ -232,6 +232,21 @@ func TestValidateDesktopCompletenessMutations(t *testing.T) {
 		write(t, filepath.Join(variant, desktopResultsFile), string(body))
 		requireDesktopFinding(t, fixture.root, "not-applicable", "duplicate desktop-local result")
 	})
+	t.Run("off-path result cannot satisfy a canonical cell", func(t *testing.T) {
+		fixture := desktopResultsRepo(t, true)
+		canonical := filepath.Join(fixture.cellDirs["unobservable"], desktopResultsFile)
+		body, err := os.ReadFile(canonical)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Remove(canonical); err != nil {
+			t.Fatal(err)
+		}
+		offPath := filepath.Join(fixture.root, "replaydata", "agents", "claudecode", "regressions", "copied-result")
+		write(t, filepath.Join(offPath, "metadata.json"), `{"scenario_id":"unobservable"}`+"\n")
+		write(t, filepath.Join(offPath, desktopResultsFile), string(body))
+		requireDesktopFinding(t, fixture.root, "unobservable", "missing desktop-local result")
+	})
 }
 
 func TestValidateDesktopResultShapeMutations(t *testing.T) {
@@ -461,6 +476,15 @@ func TestValidateDesktopEvidenceReferenceMutations(t *testing.T) {
 		write(t, filepath.Join(fixture.root, "unrelated.txt"), "not campaign evidence\n")
 		path := filepath.Join(fixture.cellDirs["unobservable"], desktopResultsFile)
 		mutateFirstResult(t, path, func(result map[string]any) { result["evidence_refs"] = []any{"unrelated.txt"} })
+		requireDesktopFinding(t, fixture.root, "unobservable", "evidence_refs[0]")
+	})
+	t.Run("unrelated repository doc is not Desktop evidence", func(t *testing.T) {
+		fixture := desktopResultsRepo(t, false)
+		write(t, filepath.Join(fixture.root, "docs", "testing-philosophy.md"), "general test guidance\n")
+		path := filepath.Join(fixture.cellDirs["unobservable"], desktopResultsFile)
+		mutateFirstResult(t, path, func(result map[string]any) {
+			result["evidence_refs"] = []any{"docs/testing-philosophy.md"}
+		})
 		requireDesktopFinding(t, fixture.root, "unobservable", "evidence_refs[0]")
 	})
 }

--- a/tools/onboarding-factory/cmd/of/desktop_results_test.go
+++ b/tools/onboarding-factory/cmd/of/desktop_results_test.go
@@ -1,0 +1,404 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const desktopResultsFile = "execution-results.json"
+
+type desktopFixture struct {
+	root     string
+	cellDirs map[string]string
+	record   string
+}
+
+// desktopResultsRepo is the positive fixture for the full result vocabulary.
+// It deliberately uses five different cells so completeness, uniqueness, and
+// each outcome are proven together instead of by disconnected partial trees.
+func desktopResultsRepo(t *testing.T, enforce bool) desktopFixture {
+	t.Helper()
+	root := t.TempDir()
+	meta := `"min_versions":{"claudecode":"2.0.0"}`
+	if enforce {
+		meta += `,"required_execution_profiles_by_agent":{"claudecode":["desktop-local"]}`
+	}
+	write(t, filepath.Join(root, "replaydata", "agents", "scenarios.json"), `{
+  "meta": {`+meta+`},
+  "scenarios": [
+    {"id":"1.1","name":"observed-pass","description":"d","process":"p","acceptance_criteria":"a"},
+    {"id":"1.2","name":"observed-failure","description":"d","process":"p","acceptance_criteria":"a"},
+    {"id":"1.3","name":"not-applicable","description":"d","process":"p","acceptance_criteria":"a"},
+    {"id":"1.4","name":"unobservable","description":"d","process":"p","acceptance_criteria":"a"},
+    {"id":"1.5","name":"not-runnable","description":"d","process":"p","acceptance_criteria":"a"}
+  ]
+}`)
+
+	fixture := desktopFixture{root: root, cellDirs: map[string]string{}, record: "desktop-r1"}
+	for i, scenario := range []string{"observed-pass", "observed-failure", "not-applicable", "unobservable", "not-runnable"} {
+		folder := "1-" + string(rune('1'+i)) + "_" + scenario
+		cell(t, root, "claudecode", folder, "yes", "full", "ready")
+		fixture.cellDirs[scenario] = filepath.Join(root, "replaydata", "agents", "claudecode", "scenarios", folder)
+	}
+
+	writeObservedDesktopResult(t, fixture, "observed-pass", "observed-passing", "")
+	writeObservedDesktopResult(t, fixture, "observed-failure", "observed-failure", "Irrlicht reported the observed failure.")
+	writeNonObservedDesktopResult(t, fixture, "not-applicable", "not-applicable", "The scenario is outside Local Desktop.", "")
+	writeNonObservedDesktopResult(t, fixture, "unobservable", "unobservable", "The local runtime leaves no observable trace.", "")
+	writeNonObservedDesktopResult(t, fixture, "not-runnable", "not-runnable", "The Desktop driver cannot perform this recipe.", "model selector")
+	return fixture
+}
+
+func writeObservedDesktopResult(t *testing.T, fixture desktopFixture, scenario, outcome, reason string) {
+	t.Helper()
+	cellDir := fixture.cellDirs[scenario]
+	recDir := filepath.Join(cellDir, "recordings", fixture.record)
+	recording(t, fixture.root, "claudecode", filepath.Base(cellDir), fixture.record, true)
+	write(t, filepath.Join(recDir, "manifest.json"), `{
+  "execution_profile":"desktop-local",
+  "entrypoint":"claude-desktop",
+  "daemon_version":"0.6.2+fixture",
+  "agent_cli_version":"2.1.258",
+  "desktop_app_version":"1.44121.4"
+}`)
+	write(t, filepath.Join(recDir, "transcript.jsonl"), `{"type":"user","sessionId":"transcript-1","cwd":"/workspace","entrypoint":"claude-desktop"}`+"\n")
+	write(t, filepath.Join(recDir, "desktop-registry.json"), `{"sessionId":"local_desktop-1","cliSessionId":"transcript-1","cwd":"/workspace","envScopeId":null}`+"\n")
+	write(t, filepath.Join(recDir, "desktop-environment.json"), `{"selected_environment":"Local","requested_workspace":"/workspace"}`+"\n")
+	write(t, filepath.Join(recDir, "irrlicht-session.json"), `{"session_id":"transcript-1","cwd":"/workspace","pid":4242,"launcher":{"host_bundle_id":"com.anthropic.claudefordesktop"}}`+"\n")
+	write(t, filepath.Join(recDir, "hooks.jsonl"), `{"session_id":"transcript-1","hook_event_name":"Stop"}`+"\n")
+	write(t, filepath.Join(recDir, "process.json"), `{"pid":4242,"command":"claude"}`+"\n")
+
+	result := map[string]any{
+		"scenario_id":       scenario,
+		"execution_profile": "desktop-local",
+		"outcome":           outcome,
+		"recording":         fixture.record,
+		"evidence": map[string]string{
+			"desktop_registry": "desktop-registry.json",
+			"transcript":       "transcript.jsonl",
+			"hooks":            "hooks.jsonl",
+			"process":          "process.json",
+			"irrlicht_session": "irrlicht-session.json",
+			"environment":      "desktop-environment.json",
+		},
+	}
+	if reason != "" {
+		result["reason"] = reason
+	}
+	writeExecutionResults(t, cellDir, []any{result})
+}
+
+func writeNonObservedDesktopResult(t *testing.T, fixture desktopFixture, scenario, outcome, reason, missingControl string) {
+	t.Helper()
+	cellDir := fixture.cellDirs[scenario]
+	result := map[string]any{
+		"scenario_id":       scenario,
+		"execution_profile": "desktop-local",
+		"outcome":           outcome,
+		"reason":            reason,
+		"evidence_refs": []string{
+			filepath.ToSlash(strings.TrimPrefix(filepath.Join(cellDir, "metadata.json"), fixture.root+string(filepath.Separator))),
+		},
+	}
+	if missingControl != "" {
+		result["missing_control"] = missingControl
+	}
+	writeExecutionResults(t, cellDir, []any{result})
+}
+
+func writeExecutionResults(t *testing.T, cellDir string, results []any) {
+	t.Helper()
+	b, err := json.MarshalIndent(map[string]any{"schema_version": 1, "results": results}, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	write(t, filepath.Join(cellDir, desktopResultsFile), string(b)+"\n")
+}
+
+func requireDesktopFinding(t *testing.T, root, scenario, field string) {
+	t.Helper()
+	code, _, stderr := runOf("validate", "--repo-root", root)
+	if code != exitFail {
+		t.Fatalf("of validate accepted the Desktop evidence mutation; exit=%d stderr=%s", code, stderr)
+	}
+	for _, want := range []string{scenario, field} {
+		if !strings.Contains(stderr, want) {
+			t.Fatalf("finding must name %q; stderr:\n%s", want, stderr)
+		}
+	}
+}
+
+func TestValidateDesktopResultsAcceptsAllOutcomes(t *testing.T) {
+	fixture := desktopResultsRepo(t, true)
+	if code, _, stderr := runOf("validate", "--repo-root", fixture.root); code != exitOK {
+		t.Fatalf("complete Desktop result fixture failed: exit=%d stderr:\n%s", code, stderr)
+	}
+}
+
+// These are compatibility locks. The first protects today's CLI-only tree.
+// The second lets independent campaign PRs add partial Desktop results before
+// the catalog explicitly enables the exact-set completeness gate.
+func TestValidateDesktopResultsCompatibilityBeforeEnablement(t *testing.T) {
+	if code, _, stderr := runOf("validate", "--repo-root", validRepo(t)); code != exitOK {
+		t.Fatalf("CLI-only repository must stay valid: exit=%d stderr=%s", code, stderr)
+	}
+	fixture := desktopResultsRepo(t, false)
+	delete(fixture.cellDirs, "not-runnable")
+	write(t, filepath.Join(fixture.root, "replaydata", "agents", "claudecode", "scenarios", "1-5_not-runnable", desktopResultsFile), "")
+	// Remove the empty placeholder entirely: an absent result file is allowed
+	// in draft mode, while a present malformed file must still fail.
+	if err := os.Remove(filepath.Join(fixture.root, "replaydata", "agents", "claudecode", "scenarios", "1-5_not-runnable", desktopResultsFile)); err != nil {
+		t.Fatal(err)
+	}
+	if code, _, stderr := runOf("validate", "--repo-root", fixture.root); code != exitOK {
+		t.Fatalf("partial Desktop results before enablement failed: exit=%d stderr=%s", code, stderr)
+	}
+}
+
+// TestValidateDesktopCompletenessMutations is committed mutation evidence for
+// the dynamic exact-set gate. Each mutation starts from the valid five-outcome
+// fixture, breaks one set property, and requires the exact scenario identity.
+func TestValidateDesktopCompletenessMutations(t *testing.T) {
+	t.Run("missing current cell", func(t *testing.T) {
+		fixture := desktopResultsRepo(t, true)
+		path := filepath.Join(fixture.cellDirs["unobservable"], desktopResultsFile)
+		if err := os.Remove(path); err != nil {
+			t.Fatal(err)
+		}
+		requireDesktopFinding(t, fixture.root, "unobservable", "missing desktop-local result")
+	})
+	t.Run("catalog addition is required dynamically", func(t *testing.T) {
+		fixture := desktopResultsRepo(t, true)
+		path := filepath.Join(fixture.root, "replaydata", "agents", "scenarios.json")
+		var catalog map[string]any
+		mustReadJSON(t, path, &catalog)
+		catalog["scenarios"] = append(catalog["scenarios"].([]any), map[string]any{
+			"id": "1.6", "name": "new-current-cell", "description": "d", "process": "p", "acceptance_criteria": "a",
+		})
+		writeJSONFixture(t, path, catalog)
+		requireDesktopFinding(t, fixture.root, "new-current-cell", "missing desktop-local result")
+	})
+	t.Run("duplicate", func(t *testing.T) {
+		fixture := desktopResultsRepo(t, true)
+		path := filepath.Join(fixture.cellDirs["not-applicable"], desktopResultsFile)
+		var doc map[string]any
+		mustReadJSON(t, path, &doc)
+		results := doc["results"].([]any)
+		doc["results"] = append(results, results[0])
+		writeJSONFixture(t, path, doc)
+		requireDesktopFinding(t, fixture.root, "not-applicable", "duplicate desktop-local result")
+	})
+	t.Run("duplicate across cell folders before enablement", func(t *testing.T) {
+		fixture := desktopResultsRepo(t, false)
+		original := fixture.cellDirs["not-applicable"]
+		variant := filepath.Join(fixture.root, "replaydata", "agents", "claudecode", "scenarios", "1-3_not-applicable-variant")
+		body, err := os.ReadFile(filepath.Join(original, desktopResultsFile))
+		if err != nil {
+			t.Fatal(err)
+		}
+		write(t, filepath.Join(variant, "metadata.json"), `{"scenario_id":"not-applicable"}`)
+		write(t, filepath.Join(variant, desktopResultsFile), string(body))
+		requireDesktopFinding(t, fixture.root, "not-applicable", "duplicate desktop-local result")
+	})
+}
+
+func TestValidateDesktopResultShapeMutations(t *testing.T) {
+	cases := []struct {
+		name   string
+		field  string
+		mutate func(map[string]any)
+	}{
+		{"unknown profile", "execution_profile", func(r map[string]any) { r["execution_profile"] = "remote" }},
+		{"unknown outcome", "outcome", func(r map[string]any) { r["outcome"] = "maybe" }},
+		{"scenario mismatch", "scenario_id", func(r map[string]any) { r["scenario_id"] = "other" }},
+		{"blank reason", "reason", func(r map[string]any) { r["reason"] = "  " }},
+		{"missing evidence refs", "evidence_refs", func(r map[string]any) { delete(r, "evidence_refs") }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fixture := desktopResultsRepo(t, false)
+			path := filepath.Join(fixture.cellDirs["unobservable"], desktopResultsFile)
+			mutateFirstResult(t, path, tc.mutate)
+			requireDesktopFinding(t, fixture.root, "unobservable", tc.field)
+		})
+	}
+	t.Run("not runnable needs the missing control", func(t *testing.T) {
+		fixture := desktopResultsRepo(t, false)
+		path := filepath.Join(fixture.cellDirs["not-runnable"], desktopResultsFile)
+		mutateFirstResult(t, path, func(r map[string]any) { delete(r, "missing_control") })
+		requireDesktopFinding(t, fixture.root, "not-runnable", "missing_control")
+	})
+	t.Run("unknown top-level field", func(t *testing.T) {
+		fixture := desktopResultsRepo(t, false)
+		path := filepath.Join(fixture.cellDirs["not-applicable"], desktopResultsFile)
+		var doc map[string]any
+		mustReadJSON(t, path, &doc)
+		doc["surprise"] = true
+		writeJSONFixture(t, path, doc)
+		requireDesktopFinding(t, fixture.root, "not-applicable", "unknown field")
+	})
+}
+
+func TestValidateDesktopCompletenessSwitchMutations(t *testing.T) {
+	cases := []struct {
+		name  string
+		value any
+	}{
+		{"null", nil},
+		{"empty object", map[string]any{}},
+		{"empty profile list", map[string]any{"claudecode": []any{}}},
+		{"unknown profile", map[string]any{"claudecode": []any{"remote"}}},
+		{"wrong agent", map[string]any{"codex": []any{"desktop-local"}}},
+		{"duplicate profile", map[string]any{"claudecode": []any{"desktop-local", "desktop-local"}}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fixture := desktopResultsRepo(t, false)
+			path := filepath.Join(fixture.root, "replaydata", "agents", "scenarios.json")
+			var catalog map[string]any
+			mustReadJSON(t, path, &catalog)
+			catalog["meta"].(map[string]any)["required_execution_profiles_by_agent"] = tc.value
+			writeJSONFixture(t, path, catalog)
+			requireDesktopFinding(t, fixture.root, "catalog", "required_execution_profiles_by_agent")
+		})
+	}
+}
+
+func TestValidateDesktopResultScanDoesNotTrustMetadata(t *testing.T) {
+	t.Run("malformed sibling metadata", func(t *testing.T) {
+		fixture := desktopResultsRepo(t, false)
+		write(t, filepath.Join(fixture.cellDirs["unobservable"], "metadata.json"), "{")
+		path := filepath.Join(fixture.cellDirs["unobservable"], desktopResultsFile)
+		mutateFirstResult(t, path, func(result map[string]any) { result["outcome"] = "unknown" })
+		requireDesktopFinding(t, fixture.root, "unobservable", "outcome")
+	})
+	t.Run("orphan result file", func(t *testing.T) {
+		fixture := desktopResultsRepo(t, false)
+		orphan := filepath.Join(fixture.root, "replaydata", "agents", "claudecode", "scenarios", "9-9_orphan")
+		write(t, filepath.Join(orphan, desktopResultsFile), `{"schema_version":1,"results":[{"scenario_id":"ghost","execution_profile":"desktop-local","outcome":"maybe"}]}`)
+		requireDesktopFinding(t, fixture.root, "ghost", "outcome")
+	})
+}
+
+// TestValidateDesktopIdentityMutations is the committed false-identity corpus.
+// Each row changes raw evidence while the manifest and result summary stay
+// correct. A validator that trusts those summaries will accept every row.
+func TestValidateDesktopIdentityMutations(t *testing.T) {
+	cases := []struct {
+		name  string
+		field string
+		file  string
+		body  string
+	}{
+		{"CLI transcript entrypoint", "transcript.entrypoint", "transcript.jsonl", `{"type":"user","sessionId":"transcript-1","cwd":"/workspace","entrypoint":"cli"}` + "\n"},
+		{"registry mapping", "desktop_registry.cliSessionId", "desktop-registry.json", `{"sessionId":"local_desktop-1","cliSessionId":"other","cwd":"/workspace","envScopeId":null}` + "\n"},
+		{"registry Desktop ID", "desktop_registry.sessionId", "desktop-registry.json", `{"sessionId":"remote_desktop-1","cliSessionId":"transcript-1","cwd":"/workspace","envScopeId":null}` + "\n"},
+		{"registry workspace", "desktop_registry.cwd", "desktop-registry.json", `{"sessionId":"local_desktop-1","cliSessionId":"transcript-1","cwd":"/other","envScopeId":null}` + "\n"},
+		{"non-Local registry", "desktop_registry.envScopeId", "desktop-registry.json", `{"sessionId":"local_desktop-1","cliSessionId":"transcript-1","cwd":"/workspace","envScopeId":"remote"}` + "\n"},
+		{"transcript workspace", "transcript.cwd", "transcript.jsonl", `{"type":"user","sessionId":"transcript-1","cwd":"/other","entrypoint":"claude-desktop"}` + "\n"},
+		{"selected environment", "environment.selected_environment", "desktop-environment.json", `{"selected_environment":"Remote","requested_workspace":"/workspace"}` + "\n"},
+		{"requested workspace", "environment.requested_workspace", "desktop-environment.json", `{"selected_environment":"Local","requested_workspace":"/other"}` + "\n"},
+		{"Irrlicht bundle", "irrlicht_session.launcher.host_bundle_id", "irrlicht-session.json", `{"session_id":"transcript-1","cwd":"/workspace","pid":4242,"launcher":{"host_bundle_id":"com.apple.Terminal"}}` + "\n"},
+		{"Irrlicht session", "irrlicht_session.session_id", "irrlicht-session.json", `{"session_id":"other","cwd":"/workspace","pid":4242,"launcher":{"host_bundle_id":"com.anthropic.claudefordesktop"}}` + "\n"},
+		{"Irrlicht workspace", "irrlicht_session.cwd", "irrlicht-session.json", `{"session_id":"transcript-1","cwd":"/other","pid":4242,"launcher":{"host_bundle_id":"com.anthropic.claudefordesktop"}}` + "\n"},
+		{"hook session", "hooks.session_id", "hooks.jsonl", `{"session_id":"other","hook_event_name":"Stop"}` + "\n"},
+		{"process PID", "process.pid", "process.json", `{"pid":9999,"command":"claude"}` + "\n"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fixture := desktopResultsRepo(t, false)
+			recDir := filepath.Join(fixture.cellDirs["observed-pass"], "recordings", fixture.record)
+			write(t, filepath.Join(recDir, tc.file), tc.body)
+			requireDesktopFinding(t, fixture.root, "observed-pass", tc.field)
+		})
+	}
+	t.Run("mixed hook sessions", func(t *testing.T) {
+		fixture := desktopResultsRepo(t, false)
+		recDir := filepath.Join(fixture.cellDirs["observed-pass"], "recordings", fixture.record)
+		write(t, filepath.Join(recDir, "hooks.jsonl"), `{"session_id":"transcript-1"}`+"\n"+`{"session_id":"other"}`+"\n")
+		requireDesktopFinding(t, fixture.root, "observed-pass", "hooks.session_id")
+	})
+}
+
+func TestValidateDesktopEvidenceReferenceMutations(t *testing.T) {
+	for _, field := range []string{"desktop_registry", "transcript", "hooks", "process", "irrlicht_session", "environment"} {
+		t.Run(field, func(t *testing.T) {
+			fixture := desktopResultsRepo(t, false)
+			path := filepath.Join(fixture.cellDirs["observed-pass"], desktopResultsFile)
+			mutateFirstResult(t, path, func(result map[string]any) {
+				result["evidence"].(map[string]any)[field] = "missing.json"
+			})
+			requireDesktopFinding(t, fixture.root, "observed-pass", "evidence."+field)
+		})
+	}
+	t.Run("recording profile", func(t *testing.T) {
+		fixture := desktopResultsRepo(t, false)
+		manifest := filepath.Join(fixture.cellDirs["observed-pass"], "recordings", fixture.record, "manifest.json")
+		write(t, manifest, `{"execution_profile":"cli-local","entrypoint":"claude-desktop"}`+"\n")
+		requireDesktopFinding(t, fixture.root, "observed-pass", "manifest.execution_profile")
+	})
+	t.Run("recording traversal", func(t *testing.T) {
+		fixture := desktopResultsRepo(t, false)
+		path := filepath.Join(fixture.cellDirs["observed-pass"], desktopResultsFile)
+		mutateFirstResult(t, path, func(result map[string]any) { result["recording"] = "../desktop-r1" })
+		requireDesktopFinding(t, fixture.root, "observed-pass", "recording")
+	})
+	t.Run("evidence traversal", func(t *testing.T) {
+		fixture := desktopResultsRepo(t, false)
+		path := filepath.Join(fixture.cellDirs["observed-pass"], desktopResultsFile)
+		mutateFirstResult(t, path, func(result map[string]any) {
+			result["evidence"].(map[string]any)["hooks"] = "nested/../hooks.jsonl"
+		})
+		requireDesktopFinding(t, fixture.root, "observed-pass", "evidence.hooks")
+	})
+	t.Run("symlink escape", func(t *testing.T) {
+		fixture := desktopResultsRepo(t, false)
+		outside := filepath.Join(fixture.root, "outside-hooks.jsonl")
+		write(t, outside, `{"session_id":"transcript-1"}`+"\n")
+		recordingDir := filepath.Join(fixture.cellDirs["observed-pass"], "recordings", fixture.record)
+		if err := os.Remove(filepath.Join(recordingDir, "hooks.jsonl")); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Symlink(outside, filepath.Join(recordingDir, "hooks.jsonl")); err != nil {
+			t.Fatal(err)
+		}
+		requireDesktopFinding(t, fixture.root, "observed-pass", "evidence.hooks")
+	})
+	t.Run("manifest entrypoint", func(t *testing.T) {
+		fixture := desktopResultsRepo(t, false)
+		manifest := filepath.Join(fixture.cellDirs["observed-pass"], "recordings", fixture.record, "manifest.json")
+		write(t, manifest, `{"execution_profile":"desktop-local","entrypoint":"cli","daemon_version":"0.6.2","agent_cli_version":"2.1.258","desktop_app_version":"1.44121.4"}`+"\n")
+		requireDesktopFinding(t, fixture.root, "observed-pass", "manifest.entrypoint")
+	})
+}
+
+func mutateFirstResult(t *testing.T, path string, mutate func(map[string]any)) {
+	t.Helper()
+	var doc map[string]any
+	mustReadJSON(t, path, &doc)
+	mutate(doc["results"].([]any)[0].(map[string]any))
+	writeJSONFixture(t, path, doc)
+}
+
+func mustReadJSON(t *testing.T, path string, out any) {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(b, out); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func writeJSONFixture(t *testing.T, path string, value any) {
+	t.Helper()
+	b, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	write(t, path, string(b)+"\n")
+}

--- a/tools/onboarding-factory/cmd/of/desktop_results_test.go
+++ b/tools/onboarding-factory/cmd/of/desktop_results_test.go
@@ -69,7 +69,9 @@ func writeObservedDesktopResult(t *testing.T, fixture desktopFixture, scenario, 
 	write(t, filepath.Join(recDir, "desktop-registry.json"), `{"sessionId":"local_desktop-1","cliSessionId":"transcript-1","cwd":"/workspace"}`+"\n")
 	write(t, filepath.Join(recDir, "desktop-environment.json"), `{"selected_environment":"Local","requested_workspace":"/workspace"}`+"\n")
 	write(t, filepath.Join(recDir, "irrlicht-session.json"), `{"session_id":"transcript-1","cwd":"/workspace","pid":4242,"launcher":{"host_bundle_id":"com.anthropic.claudefordesktop"}}`+"\n")
-	write(t, filepath.Join(recDir, "hooks.jsonl"), `{"session_id":"transcript-1","hook_event_name":"Stop"}`+"\n")
+	// hooks.jsonl preserves the exact hook-receipt rows extracted from the
+	// recording's events.jsonl. It is not the raw inbound Claude hook payload.
+	write(t, filepath.Join(recDir, "hooks.jsonl"), `{"kind":"hook_received","session_id":"transcript-1","hook_name":"Stop"}`+"\n")
 	write(t, filepath.Join(recDir, "process.json"), `{"pid":4242,"command":"claude"}`+"\n")
 	writeExpectedOutcome(t, cellDir, scenario, outcome)
 
@@ -348,7 +350,7 @@ func TestValidateDesktopIdentityMutations(t *testing.T) {
 		{"Irrlicht bundle", "irrlicht_session.launcher.host_bundle_id", "irrlicht-session.json", `{"session_id":"transcript-1","cwd":"/workspace","pid":4242,"launcher":{"host_bundle_id":"com.apple.Terminal"}}` + "\n"},
 		{"Irrlicht session", "irrlicht_session.session_id", "irrlicht-session.json", `{"session_id":"other","cwd":"/workspace","pid":4242,"launcher":{"host_bundle_id":"com.anthropic.claudefordesktop"}}` + "\n"},
 		{"Irrlicht workspace", "irrlicht_session.cwd", "irrlicht-session.json", `{"session_id":"transcript-1","cwd":"/other","pid":4242,"launcher":{"host_bundle_id":"com.anthropic.claudefordesktop"}}` + "\n"},
-		{"hook session", "hooks.session_id", "hooks.jsonl", `{"session_id":"other","hook_event_name":"Stop"}` + "\n"},
+		{"hook session", "hooks.session_id", "hooks.jsonl", `{"kind":"hook_received","session_id":"other","hook_name":"Stop"}` + "\n"},
 		{"process PID", "process.pid", "process.json", `{"pid":9999,"command":"claude"}` + "\n"},
 	}
 	for _, tc := range cases {
@@ -362,14 +364,20 @@ func TestValidateDesktopIdentityMutations(t *testing.T) {
 	t.Run("mixed hook sessions", func(t *testing.T) {
 		fixture := desktopResultsRepo(t, false)
 		recDir := filepath.Join(fixture.cellDirs["observed-pass"], "recordings", fixture.record)
-		write(t, filepath.Join(recDir, "hooks.jsonl"), `{"session_id":"transcript-1"}`+"\n"+`{"session_id":"other"}`+"\n")
+		write(t, filepath.Join(recDir, "hooks.jsonl"), `{"kind":"hook_received","session_id":"transcript-1","hook_name":"Stop"}`+"\n"+`{"kind":"hook_received","session_id":"other","hook_name":"Stop"}`+"\n")
 		requireDesktopFinding(t, fixture.root, "observed-pass", "hooks.session_id")
 	})
-	t.Run("hook event name is required", func(t *testing.T) {
+	t.Run("session-only row is not a hook receipt", func(t *testing.T) {
 		fixture := desktopResultsRepo(t, false)
 		recDir := filepath.Join(fixture.cellDirs["observed-pass"], "recordings", fixture.record)
 		write(t, filepath.Join(recDir, "hooks.jsonl"), `{"session_id":"transcript-1"}`+"\n")
-		requireDesktopFinding(t, fixture.root, "observed-pass", "hooks.hook_event_name")
+		requireDesktopFinding(t, fixture.root, "observed-pass", "hooks.kind")
+	})
+	t.Run("hook name is required", func(t *testing.T) {
+		fixture := desktopResultsRepo(t, false)
+		recDir := filepath.Join(fixture.cellDirs["observed-pass"], "recordings", fixture.record)
+		write(t, filepath.Join(recDir, "hooks.jsonl"), `{"kind":"hook_received","session_id":"transcript-1"}`+"\n")
+		requireDesktopFinding(t, fixture.root, "observed-pass", "hooks.hook_name")
 	})
 }
 

--- a/tools/onboarding-factory/cmd/of/validate.go
+++ b/tools/onboarding-factory/cmd/of/validate.go
@@ -64,9 +64,7 @@ func runValidate(args []string, stdout, stderr io.Writer) int {
 	names := validateCatalog(*repoRoot, add)
 	validateRecordingProfiles(*repoRoot, add)
 	validateCells(*repoRoot, names, add)
-	for _, resultFinding := range desktopresults.ValidateRepo(*repoRoot) {
-		add(resultFinding.Path, resultFinding.Message)
-	}
+	validateDesktopResults(*repoRoot, add)
 	validateMaturityModel(*repoRoot, names, add)
 
 	sort.Slice(findings, func(i, j int) bool {
@@ -94,6 +92,12 @@ func runValidate(args []string, stdout, stderr io.Writer) int {
 		return exitFail
 	}
 	return exitOK
+}
+
+func validateDesktopResults(repoRoot string, add func(path, msg string)) {
+	for _, resultFinding := range desktopresults.ValidateRepo(repoRoot) {
+		add(resultFinding.Path, resultFinding.Message)
+	}
 }
 
 // validateRecordingProfiles scans every recording directory independently of

--- a/tools/onboarding-factory/cmd/of/validate.go
+++ b/tools/onboarding-factory/cmd/of/validate.go
@@ -10,6 +10,7 @@ import (
 	"regexp"
 	"sort"
 
+	"irrlicht/tools/onboarding-factory/internal/desktopresults"
 	"irrlicht/tools/onboarding-factory/internal/matrix"
 	"irrlicht/tools/onboarding-factory/internal/shard"
 	"irrlicht/tools/onboarding-factory/internal/validate"
@@ -63,6 +64,9 @@ func runValidate(args []string, stdout, stderr io.Writer) int {
 	names := validateCatalog(*repoRoot, add)
 	validateRecordingProfiles(*repoRoot, add)
 	validateCells(*repoRoot, names, add)
+	for _, resultFinding := range desktopresults.ValidateRepo(*repoRoot) {
+		add(resultFinding.Path, resultFinding.Message)
+	}
 	validateMaturityModel(*repoRoot, names, add)
 
 	sort.Slice(findings, func(i, j int) bool {

--- a/tools/onboarding-factory/internal/desktopresults/identity.go
+++ b/tools/onboarding-factory/internal/desktopresults/identity.go
@@ -370,55 +370,66 @@ func (v *validation) readIrrlichtSession(rel, scenario, path string) (irrlichtSe
 }
 
 func (v *validation) validateHooks(rel, scenario, path, sessionID string) bool {
-	matched, consistent, named, err := scanHookSessions(path, sessionID)
+	matched, consistent, receipts, named, err := scanHookReceipts(path, sessionID)
 	if err != nil {
 		v.add(rel, scenario, "hooks", err.Error())
 		return false
 	}
 	if !matched {
-		v.add(rel, scenario, "hooks.session_id", "contains no raw hook for transcript.sessionId")
+		v.add(rel, scenario, "hooks.session_id", "contains no hook receipt for transcript.sessionId")
 	}
 	if !consistent {
-		v.add(rel, scenario, "hooks.session_id", "contains a hook from another session")
+		v.add(rel, scenario, "hooks.session_id", "contains a hook receipt from another session")
+	}
+	if !receipts {
+		v.add(rel, scenario, "hooks.kind", `must be "hook_received" on every row`)
 	}
 	if !named {
-		v.add(rel, scenario, "hooks.hook_event_name", "must be nonblank on every raw hook")
+		v.add(rel, scenario, "hooks.hook_name", "must be nonblank on every hook receipt")
 	}
-	return matched && consistent && named
+	return matched && consistent && receipts && named
 }
 
-func scanHookSessions(path, sessionID string) (bool, bool, bool, error) {
+// scanHookReceipts validates unmodified hook_received rows extracted from the
+// recording's events.jsonl. These rows are lifecycle receipts. They are not
+// the raw inbound Claude hook payload.
+func scanHookReceipts(path, sessionID string) (bool, bool, bool, bool, error) {
 	f, err := os.Open(path)
 	if err != nil {
-		return false, false, false, err
+		return false, false, false, false, err
 	}
 	defer f.Close()
 	decoder := json.NewDecoder(f)
 	matched := false
 	consistent := true
+	receipts := true
 	named := true
 	for {
 		var row struct {
-			SessionID     string `json:"session_id"`
-			HookEventName string `json:"hook_event_name"`
+			Kind      string `json:"kind"`
+			SessionID string `json:"session_id"`
+			HookName  string `json:"hook_name"`
 		}
 		err := decoder.Decode(&row)
 		if err == io.EOF {
 			break
 		}
 		if err != nil {
-			return false, false, false, fmt.Errorf("invalid JSONL: %w", err)
+			return false, false, false, false, fmt.Errorf("invalid JSONL: %w", err)
 		}
-		if sessionID != "" && row.SessionID == sessionID {
+		if row.Kind != "hook_received" {
+			receipts = false
+		}
+		if row.Kind == "hook_received" && sessionID != "" && row.SessionID == sessionID {
 			matched = true
 		} else {
 			consistent = false
 		}
-		if strings.TrimSpace(row.HookEventName) == "" {
+		if strings.TrimSpace(row.HookName) == "" {
 			named = false
 		}
 	}
-	return matched, consistent, named, nil
+	return matched, consistent, receipts, named, nil
 }
 
 func (v *validation) readProcess(rel, scenario, path string) (processEvidence, bool) {

--- a/tools/onboarding-factory/internal/desktopresults/identity.go
+++ b/tools/onboarding-factory/internal/desktopresults/identity.go
@@ -22,9 +22,28 @@ type evidenceFiles struct {
 	registry    string
 	transcript  string
 	hooks       string
+	events      string
 	process     string
 	irrlicht    string
 	environment string
+}
+
+type hookReceiptScan struct {
+	matchedSession     bool
+	consistentSessions bool
+	correctKinds       bool
+	named              bool
+	preserved          bool
+}
+
+type hookReceipt struct {
+	Kind      string `json:"kind"`
+	SessionID string `json:"session_id"`
+	HookName  string `json:"hook_name"`
+}
+
+func (scan hookReceiptScan) valid() bool {
+	return scan.matchedSession && scan.consistentSessions && scan.correctKinds && scan.named && scan.preserved
 }
 
 type transcriptIdentity struct {
@@ -123,7 +142,7 @@ func (v *validation) readObservedIdentity(rel, scenario string, files evidenceFi
 	identity.environment, identity.environmentOK = v.readEnvironment(rel, scenario, files.environment)
 	identity.irrlicht, identity.irrlichtOK = v.readIrrlichtSession(rel, scenario, files.irrlicht)
 	identity.process, identity.processOK = v.readProcess(rel, scenario, files.process)
-	v.validateHooks(rel, scenario, files.hooks, identity.transcript.SessionID)
+	v.validateHooks(rel, scenario, files.hooks, files.events, identity.transcript.SessionID)
 	return identity
 }
 
@@ -191,6 +210,13 @@ func (v *validation) resolveEvidenceFiles(rel, recordingDir string, result *Resu
 			continue
 		}
 		*item.dst = resolved
+	}
+	eventsPath, eventsErr := resolveFile(recordingDir, "events.jsonl")
+	if eventsErr != nil {
+		v.add(rel, result.ScenarioID, "events", eventsErr.Error())
+		ok = false
+	} else {
+		files.events = eventsPath
 	}
 	return files, ok
 }
@@ -369,67 +395,106 @@ func (v *validation) readIrrlichtSession(rel, scenario, path string) (irrlichtSe
 	return state, ok
 }
 
-func (v *validation) validateHooks(rel, scenario, path, sessionID string) bool {
-	matched, consistent, receipts, named, err := scanHookReceipts(path, sessionID)
+func (v *validation) validateHooks(rel, scenario, path, eventsPath, sessionID string) bool {
+	scan, err := scanHookReceipts(path, eventsPath, sessionID)
 	if err != nil {
 		v.add(rel, scenario, "hooks", err.Error())
 		return false
 	}
-	if !matched {
+	v.reportHookReceiptFindings(rel, scenario, scan)
+	return scan.valid()
+}
+
+func (v *validation) reportHookReceiptFindings(rel, scenario string, scan hookReceiptScan) {
+	if !scan.matchedSession {
 		v.add(rel, scenario, "hooks.session_id", "contains no hook receipt for transcript.sessionId")
 	}
-	if !consistent {
+	if !scan.consistentSessions {
 		v.add(rel, scenario, "hooks.session_id", "contains a hook receipt from another session")
 	}
-	if !receipts {
+	if !scan.correctKinds {
 		v.add(rel, scenario, "hooks.kind", `must be "hook_received" on every row`)
 	}
-	if !named {
+	if !scan.named {
 		v.add(rel, scenario, "hooks.hook_name", "must be nonblank on every hook receipt")
 	}
-	return matched && consistent && receipts && named
+	if !scan.preserved {
+		v.add(rel, scenario, "hooks.events_jsonl", "each row must occur byte-for-byte in this recording's events.jsonl")
+	}
 }
 
 // scanHookReceipts validates unmodified hook_received rows extracted from the
 // recording's events.jsonl. These rows are lifecycle receipts. They are not
 // the raw inbound Claude hook payload.
-func scanHookReceipts(path, sessionID string) (bool, bool, bool, bool, error) {
-	f, err := os.Open(path)
+func scanHookReceipts(path, eventsPath, sessionID string) (hookReceiptScan, error) {
+	eventLines, err := readJSONLLines(eventsPath)
 	if err != nil {
-		return false, false, false, false, err
+		return hookReceiptScan{}, fmt.Errorf("read events.jsonl: %w", err)
 	}
-	defer f.Close()
-	decoder := json.NewDecoder(f)
-	matched := false
-	consistent := true
-	receipts := true
-	named := true
-	for {
-		var row struct {
-			Kind      string `json:"kind"`
-			SessionID string `json:"session_id"`
-			HookName  string `json:"hook_name"`
-		}
-		err := decoder.Decode(&row)
-		if err == io.EOF {
-			break
-		}
-		if err != nil {
-			return false, false, false, false, fmt.Errorf("invalid JSONL: %w", err)
-		}
-		if row.Kind != "hook_received" {
-			receipts = false
-		}
-		if row.Kind == "hook_received" && sessionID != "" && row.SessionID == sessionID {
-			matched = true
-		} else {
-			consistent = false
-		}
-		if strings.TrimSpace(row.HookName) == "" {
-			named = false
+	hookLines, err := readJSONLLines(path)
+	if err != nil {
+		return hookReceiptScan{}, err
+	}
+	remaining := countLines(eventLines)
+	scan := hookReceiptScan{consistentSessions: true, correctKinds: true, named: true, preserved: true}
+	for _, line := range hookLines {
+		if err := applyHookReceipt(&scan, line, sessionID, remaining); err != nil {
+			return hookReceiptScan{}, fmt.Errorf("invalid JSONL: %w", err)
 		}
 	}
-	return matched, consistent, receipts, named, nil
+	return scan, nil
+}
+
+func countLines(lines []string) map[string]int {
+	counts := make(map[string]int, len(lines))
+	for _, line := range lines {
+		counts[line]++
+	}
+	return counts
+}
+
+func applyHookReceipt(scan *hookReceiptScan, line, sessionID string, remaining map[string]int) error {
+	var row hookReceipt
+	if err := json.Unmarshal([]byte(line), &row); err != nil {
+		return err
+	}
+	correctKind := row.Kind == "hook_received"
+	sessionMatches := hookSessionMatches(row, sessionID)
+	scan.correctKinds = scan.correctKinds && correctKind
+	scan.matchedSession = scan.matchedSession || sessionMatches
+	scan.consistentSessions = scan.consistentSessions && sessionMatches
+	scan.named = scan.named && strings.TrimSpace(row.HookName) != ""
+	scan.preserved = scan.preserved && claimLine(remaining, line)
+	return nil
+}
+
+func hookSessionMatches(row hookReceipt, sessionID string) bool {
+	return row.Kind == "hook_received" && sessionID != "" && row.SessionID == sessionID
+}
+
+func claimLine(remaining map[string]int, line string) bool {
+	if remaining[line] == 0 {
+		return false
+	}
+	remaining[line]--
+	return true
+}
+
+func readJSONLLines(path string) ([]string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	lines := strings.Split(string(data), "\n")
+	if len(lines) > 0 && lines[len(lines)-1] == "" {
+		lines = lines[:len(lines)-1]
+	}
+	for _, line := range lines {
+		if strings.TrimSpace(line) == "" {
+			return nil, fmt.Errorf("invalid JSONL: blank row")
+		}
+	}
+	return lines, nil
 }
 
 func (v *validation) readProcess(rel, scenario, path string) (processEvidence, bool) {

--- a/tools/onboarding-factory/internal/desktopresults/identity.go
+++ b/tools/onboarding-factory/internal/desktopresults/identity.go
@@ -47,11 +47,66 @@ type hookReceipt struct {
 }
 
 type hookValidation struct {
-	rel        string
-	scenario   string
+	target     findingTarget
 	path       string
 	eventsPath string
 	sessionID  string
+}
+
+type recordingValidationContext struct {
+	target       findingTarget
+	cellDir      string
+	recordingDir string
+	result       *Result
+}
+
+type identityValidation struct {
+	target   findingTarget
+	identity observedIdentity
+}
+
+type evidenceRead struct {
+	target findingTarget
+	path   string
+}
+
+type transcriptRow struct {
+	SessionID  string `json:"sessionId"`
+	CWD        string `json:"cwd"`
+	Entrypoint string `json:"entrypoint"`
+}
+
+type hookScanInput struct {
+	path       string
+	eventsPath string
+	sessionID  string
+}
+
+type hookReceiptInput struct {
+	scan      *hookReceiptScan
+	line      string
+	sessionID string
+	remaining map[string]int
+}
+
+type hookSessionCheck struct {
+	row       hookReceipt
+	sessionID string
+}
+
+type lineClaim struct {
+	remaining map[string]int
+	line      string
+}
+
+type jsonRead struct {
+	path  string
+	value any
+}
+
+type identityMerge struct {
+	current *string
+	next    string
 }
 
 func (scan hookReceiptScan) valid() bool {
@@ -104,59 +159,64 @@ type observedIdentity struct {
 	processOK     bool
 }
 
-func (v *validation) validateObservedEvidence(rel, cellDir string, result *Result) {
-	recordingsRoot := filepath.Join(cellDir, "recordings")
-	recordingDir, err := resolveDirectory(recordingsRoot, result.Recording)
+func (v *validation) validateObservedEvidence(context resultValidationContext) {
+	recordingsRoot := filepath.Join(context.cellDir, "recordings")
+	recordingDir, err := resolveDirectory(pathReference{root: recordingsRoot, reference: context.result.Recording})
 	if err != nil {
-		v.add(rel, result.ScenarioID, "recording", err.Error())
+		v.add(context.target, "recording", err.Error())
 		return
 	}
-	v.validateRecordingCompleteness(rel, result.ScenarioID, recordingDir)
-	v.validateObservedOutcome(rel, cellDir, recordingDir, result)
-	files, ok := v.resolveEvidenceFiles(rel, recordingDir, result)
-	manifest, manifestOK := v.validateManifest(rel, recordingDir, result.ScenarioID)
+	recording := recordingValidationContext{
+		target:       context.target,
+		cellDir:      context.cellDir,
+		recordingDir: recordingDir,
+		result:       context.result,
+	}
+	v.validateRecordingCompleteness(recording)
+	v.validateObservedOutcome(recording)
+	files, ok := v.resolveEvidenceFiles(recording)
+	manifest, manifestOK := v.validateManifest(recording)
 	if !ok || !manifestOK {
 		return
 	}
-	identity := v.readObservedIdentity(rel, result.ScenarioID, files, manifest)
-	v.compareObservedIdentity(rel, result.ScenarioID, identity)
+	identity := v.readObservedIdentity(context.target, files, manifest)
+	v.compareObservedIdentity(identityValidation{target: context.target, identity: identity})
 }
 
-func (v *validation) validateRecordingCompleteness(rel, scenario, recordingDir string) {
-	for _, finding := range expectedvalidate.RecordingComplete(recordingDir) {
-		v.add(rel, scenario, "recording completeness", finding)
+func (v *validation) validateRecordingCompleteness(context recordingValidationContext) {
+	for _, finding := range expectedvalidate.RecordingComplete(context.recordingDir) {
+		v.add(context.target, "recording completeness", finding)
 	}
 }
 
-func (v *validation) validateObservedOutcome(rel, cellDir, recordingDir string, result *Result) {
+func (v *validation) validateObservedOutcome(context recordingValidationContext) {
 	report, err := expectedvalidate.ValidateExpectedAgainst(
-		filepath.Join(cellDir, "expected.jsonl"),
-		filepath.Join(recordingDir, "events.jsonl"),
+		filepath.Join(context.cellDir, "expected.jsonl"),
+		filepath.Join(context.recordingDir, "events.jsonl"),
 	)
 	if err != nil {
-		v.add(rel, result.ScenarioID, "outcome", "cannot validate the exact recording: "+err.Error())
+		v.add(context.target, "outcome", "cannot validate the exact recording: "+err.Error())
 		return
 	}
 	if report == nil {
-		v.add(rel, result.ScenarioID, "outcome", "exact recording has no expected-result report")
+		v.add(context.target, "outcome", "exact recording has no expected-result report")
 		return
 	}
-	wantPass := result.Outcome == OutcomeObservedPassing
+	wantPass := context.result.Outcome == OutcomeObservedPassing
 	if report.Pass != wantPass {
-		v.add(rel, result.ScenarioID, "outcome", fmt.Sprintf("got %q for an expected-result pass value of %t", result.Outcome, report.Pass))
+		v.add(context.target, "outcome", fmt.Sprintf("got %q for an expected-result pass value of %t", context.result.Outcome, report.Pass))
 	}
 }
 
-func (v *validation) readObservedIdentity(rel, scenario string, files evidenceFiles, manifest matrix.RecordingManifest) observedIdentity {
+func (v *validation) readObservedIdentity(target findingTarget, files evidenceFiles, manifest matrix.RecordingManifest) observedIdentity {
 	identity := observedIdentity{manifest: manifest}
-	identity.transcript, identity.transcriptOK = v.readTranscript(rel, scenario, files.transcript)
-	identity.registry, identity.registryOK = v.readRegistry(rel, scenario, files.registry)
-	identity.environment, identity.environmentOK = v.readEnvironment(rel, scenario, files.environment)
-	identity.irrlicht, identity.irrlichtOK = v.readIrrlichtSession(rel, scenario, files.irrlicht)
-	identity.process, identity.processOK = v.readProcess(rel, scenario, files.process)
+	identity.transcript, identity.transcriptOK = v.readTranscript(evidenceRead{target: target, path: files.transcript})
+	identity.registry, identity.registryOK = v.readRegistry(evidenceRead{target: target, path: files.registry})
+	identity.environment, identity.environmentOK = v.readEnvironment(evidenceRead{target: target, path: files.environment})
+	identity.irrlicht, identity.irrlichtOK = v.readIrrlichtSession(evidenceRead{target: target, path: files.irrlicht})
+	identity.process, identity.processOK = v.readProcess(evidenceRead{target: target, path: files.process})
 	v.validateHooks(hookValidation{
-		rel:        rel,
-		scenario:   scenario,
+		target:     target,
 		path:       files.hooks,
 		eventsPath: files.events,
 		sessionID:  identity.transcript.SessionID,
@@ -164,48 +224,51 @@ func (v *validation) readObservedIdentity(rel, scenario string, files evidenceFi
 	return identity
 }
 
-func (v *validation) compareObservedIdentity(rel, scenario string, identity observedIdentity) {
-	v.compareTranscriptIdentity(rel, scenario, identity)
-	v.compareEnvironmentIdentity(rel, scenario, identity)
-	v.compareProcessIdentity(rel, scenario, identity)
+func (v *validation) compareObservedIdentity(context identityValidation) {
+	v.compareTranscriptIdentity(context)
+	v.compareEnvironmentIdentity(context)
+	v.compareProcessIdentity(context)
 }
 
-func (v *validation) compareTranscriptIdentity(rel, scenario string, identity observedIdentity) {
+func (v *validation) compareTranscriptIdentity(context identityValidation) {
+	identity := context.identity
 	if !identity.transcriptOK {
 		return
 	}
-	v.compareManifestTranscript(rel, scenario, identity.manifest, identity.transcript)
+	v.compareManifestTranscript(context)
 	if identity.registryOK {
-		v.compareSessionMapping(rel, scenario, identity.transcript, identity.registry)
+		v.compareSessionMapping(context)
 	}
 	if identity.registryOK && identity.environmentOK {
-		v.compareWorkspaceIdentity(rel, scenario, identity)
+		v.compareWorkspaceIdentity(context)
 	}
 	if identity.irrlichtOK {
-		v.compareIrrlichtIdentity(rel, scenario, identity.transcript, identity.irrlicht)
+		v.compareIrrlichtIdentity(context)
 	}
 }
 
-func (v *validation) compareEnvironmentIdentity(rel, scenario string, identity observedIdentity) {
+func (v *validation) compareEnvironmentIdentity(context identityValidation) {
+	identity := context.identity
 	if !identity.environmentOK || !identity.irrlichtOK {
 		return
 	}
 	if !samePath(identity.environment.RequestedWorkspace, identity.irrlicht.CWD) {
-		v.add(rel, scenario, fieldIrrlichtCWD, mismatchEnvironmentCWD)
+		v.add(context.target, fieldIrrlichtCWD, mismatchEnvironmentCWD)
 	}
 }
 
-func (v *validation) compareProcessIdentity(rel, scenario string, identity observedIdentity) {
+func (v *validation) compareProcessIdentity(context identityValidation) {
+	identity := context.identity
 	if !identity.processOK || !identity.irrlichtOK {
 		return
 	}
 	if identity.process.PID != identity.irrlicht.PID {
-		v.add(rel, scenario, "process.pid", "does not match irrlicht_session.pid")
+		v.add(context.target, "process.pid", "does not match irrlicht_session.pid")
 	}
 }
 
-func (v *validation) resolveEvidenceFiles(rel, recordingDir string, result *Result) (evidenceFiles, bool) {
-	evidence := result.Evidence
+func (v *validation) resolveEvidenceFiles(context recordingValidationContext) (evidenceFiles, bool) {
+	evidence := context.result.Evidence
 	refs := []struct {
 		field string
 		ref   string
@@ -227,17 +290,17 @@ func (v *validation) resolveEvidenceFiles(rel, recordingDir string, result *Resu
 	refs[5].dst = &files.environment
 	ok := true
 	for _, item := range refs {
-		resolved, err := resolveFile(recordingDir, item.ref)
+		resolved, err := resolveFile(pathReference{root: context.recordingDir, reference: item.ref})
 		if err != nil {
-			v.add(rel, result.ScenarioID, "evidence."+item.field, err.Error())
+			v.add(context.target, "evidence."+item.field, err.Error())
 			ok = false
 			continue
 		}
 		*item.dst = resolved
 	}
-	eventsPath, eventsErr := resolveFile(recordingDir, "events.jsonl")
+	eventsPath, eventsErr := resolveFile(pathReference{root: context.recordingDir, reference: "events.jsonl"})
 	if eventsErr != nil {
-		v.add(rel, result.ScenarioID, "events", eventsErr.Error())
+		v.add(context.target, "events", eventsErr.Error())
 		ok = false
 	} else {
 		files.events = eventsPath
@@ -245,22 +308,22 @@ func (v *validation) resolveEvidenceFiles(rel, recordingDir string, result *Resu
 	return files, ok
 }
 
-func (v *validation) validateManifest(rel, recordingDir, scenario string) (matrix.RecordingManifest, bool) {
-	manifestPath, err := resolveFile(recordingDir, "manifest.json")
+func (v *validation) validateManifest(context recordingValidationContext) (matrix.RecordingManifest, bool) {
+	manifestPath, err := resolveFile(pathReference{root: context.recordingDir, reference: "manifest.json"})
 	if err != nil {
-		v.add(rel, scenario, "manifest", err.Error())
+		v.add(context.target, "manifest", err.Error())
 		return matrix.RecordingManifest{}, false
 	}
 	manifest, err := matrix.LoadRecordingManifest(manifestPath)
 	if err != nil {
-		v.add(rel, scenario, "manifest", err.Error())
+		v.add(context.target, "manifest", err.Error())
 		return manifest, false
 	}
 	if manifest.ExecutionProfile != matrix.ProfileDesktopLocal {
-		v.add(rel, scenario, "manifest.execution_profile", fmt.Sprintf("got %q; want %q", manifest.ExecutionProfile, matrix.ProfileDesktopLocal))
+		v.add(context.target, "manifest.execution_profile", fmt.Sprintf("got %q; want %q", manifest.ExecutionProfile, matrix.ProfileDesktopLocal))
 	}
 	if manifest.Entrypoint != desktopEntrypoint {
-		v.add(rel, scenario, "manifest.entrypoint", fmt.Sprintf("got %q; want %q", manifest.Entrypoint, desktopEntrypoint))
+		v.add(context.target, "manifest.entrypoint", fmt.Sprintf("got %q; want %q", manifest.Entrypoint, desktopEntrypoint))
 	}
 	for field, value := range map[string]string{
 		"manifest.daemon_version":      manifest.DaemonVersion,
@@ -268,22 +331,22 @@ func (v *validation) validateManifest(rel, recordingDir, scenario string) (matri
 		"manifest.desktop_app_version": manifest.DesktopAppVersion,
 	} {
 		if blankOrUnknown(value) {
-			v.add(rel, scenario, field, "must contain the measured version")
+			v.add(context.target, field, "must contain the measured version")
 		}
 	}
 	return manifest, true
 }
 
-func (v *validation) readTranscript(rel, scenario, path string) (transcriptIdentity, bool) {
-	identity, conflicts, err := scanTranscript(path)
+func (v *validation) readTranscript(input evidenceRead) (transcriptIdentity, bool) {
+	identity, conflicts, err := scanTranscript(input.path)
 	if err != nil {
-		v.add(rel, scenario, "transcript", err.Error())
+		v.add(input.target, "transcript", err.Error())
 		return identity, false
 	}
 	for _, field := range conflicts {
-		v.add(rel, scenario, "transcript."+field, "contains conflicting values")
+		v.add(input.target, "transcript."+field, "contains conflicting values")
 	}
-	ok := v.validateTranscriptFields(rel, scenario, identity)
+	ok := v.validateTranscriptFields(identityValidation{target: input.target, identity: observedIdentity{transcript: identity}})
 	return identity, ok && len(conflicts) == 0
 }
 
@@ -297,11 +360,7 @@ func scanTranscript(path string) (transcriptIdentity, []string, error) {
 	identity := transcriptIdentity{}
 	var conflicts []string
 	for {
-		var row struct {
-			SessionID  string `json:"sessionId"`
-			CWD        string `json:"cwd"`
-			Entrypoint string `json:"entrypoint"`
-		}
+		var row transcriptRow
 		err := decoder.Decode(&row)
 		if err == io.EOF {
 			break
@@ -309,26 +368,27 @@ func scanTranscript(path string) (transcriptIdentity, []string, error) {
 		if err != nil {
 			return identity, conflicts, fmt.Errorf("invalid JSONL: %w", err)
 		}
-		conflicts = append(conflicts, mergeTranscriptRow(&identity, row.SessionID, row.CWD, row.Entrypoint)...)
+		conflicts = append(conflicts, mergeTranscriptRow(&identity, row)...)
 	}
 	return identity, conflicts, nil
 }
 
-func mergeTranscriptRow(identity *transcriptIdentity, sessionID, cwd, entrypoint string) []string {
+func mergeTranscriptRow(identity *transcriptIdentity, row transcriptRow) []string {
 	var conflicts []string
-	if !mergeIdentity(&identity.SessionID, sessionID) {
+	if !mergeIdentity(identityMerge{current: &identity.SessionID, next: row.SessionID}) {
 		conflicts = append(conflicts, "sessionId")
 	}
-	if !mergeIdentity(&identity.CWD, cwd) {
+	if !mergeIdentity(identityMerge{current: &identity.CWD, next: row.CWD}) {
 		conflicts = append(conflicts, "cwd")
 	}
-	if !mergeIdentity(&identity.Entrypoint, entrypoint) {
+	if !mergeIdentity(identityMerge{current: &identity.Entrypoint, next: row.Entrypoint}) {
 		conflicts = append(conflicts, "entrypoint")
 	}
 	return conflicts
 }
 
-func (v *validation) validateTranscriptFields(rel, scenario string, identity transcriptIdentity) bool {
+func (v *validation) validateTranscriptFields(context identityValidation) bool {
+	identity := context.identity.transcript
 	ok := true
 	for field, value := range map[string]string{
 		"sessionId":  identity.SessionID,
@@ -336,21 +396,21 @@ func (v *validation) validateTranscriptFields(rel, scenario string, identity tra
 		"entrypoint": identity.Entrypoint,
 	} {
 		if strings.TrimSpace(value) == "" {
-			v.add(rel, scenario, "transcript."+field, "is absent from the raw transcript")
+			v.add(context.target, "transcript."+field, "is absent from the raw transcript")
 			ok = false
 		}
 	}
 	if identity.Entrypoint != "" && identity.Entrypoint != desktopEntrypoint {
-		v.add(rel, scenario, "transcript.entrypoint", fmt.Sprintf("got %q; want %q", identity.Entrypoint, desktopEntrypoint))
+		v.add(context.target, "transcript.entrypoint", fmt.Sprintf("got %q; want %q", identity.Entrypoint, desktopEntrypoint))
 		ok = false
 	}
 	return ok
 }
 
-func (v *validation) readRegistry(rel, scenario, path string) (registryIdentity, bool) {
+func (v *validation) readRegistry(input evidenceRead) (registryIdentity, bool) {
 	var registry registryIdentity
-	if err := readJSON(path, &registry); err != nil {
-		v.add(rel, scenario, "desktop_registry", err.Error())
+	if err := readJSON(jsonRead{path: input.path, value: &registry}); err != nil {
+		v.add(input.target, "desktop_registry", err.Error())
 		return registry, false
 	}
 	ok := true
@@ -360,109 +420,109 @@ func (v *validation) readRegistry(rel, scenario, path string) (registryIdentity,
 		fieldDesktopRegistryCWD:         registry.CWD,
 	} {
 		if strings.TrimSpace(value) == "" {
-			v.add(rel, scenario, field, mustNotBeBlank)
+			v.add(input.target, field, mustNotBeBlank)
 			ok = false
 		}
 	}
 	if registry.SessionID != "" && !strings.HasPrefix(registry.SessionID, "local_") {
-		v.add(rel, scenario, "desktop_registry.sessionId", "must start with local_")
+		v.add(input.target, "desktop_registry.sessionId", "must start with local_")
 		ok = false
 	}
 	if len(registry.EnvScopeID) > 0 && string(registry.EnvScopeID) != "null" {
-		v.add(rel, scenario, "desktop_registry.envScopeId", "must be absent or null for the project-local environment")
+		v.add(input.target, "desktop_registry.envScopeId", "must be absent or null for the project-local environment")
 		ok = false
 	}
 	return registry, ok
 }
 
-func (v *validation) readEnvironment(rel, scenario, path string) (environmentReceipt, bool) {
+func (v *validation) readEnvironment(input evidenceRead) (environmentReceipt, bool) {
 	var receipt environmentReceipt
-	if err := decodeStrict(path, &receipt); err != nil {
-		v.add(rel, scenario, "environment", "invalid or unknown field: "+err.Error())
+	if err := decodeStrict(input.path, &receipt); err != nil {
+		v.add(input.target, "environment", "invalid or unknown field: "+err.Error())
 		return receipt, false
 	}
 	ok := true
 	if receipt.SelectedEnvironment != localEnvironment {
-		v.add(rel, scenario, "environment.selected_environment", fmt.Sprintf("got %q; want %q", receipt.SelectedEnvironment, localEnvironment))
+		v.add(input.target, "environment.selected_environment", fmt.Sprintf("got %q; want %q", receipt.SelectedEnvironment, localEnvironment))
 		ok = false
 	}
 	if strings.TrimSpace(receipt.RequestedWorkspace) == "" {
-		v.add(rel, scenario, "environment.requested_workspace", mustNotBeBlank)
+		v.add(input.target, "environment.requested_workspace", mustNotBeBlank)
 		ok = false
 	}
 	return receipt, ok
 }
 
-func (v *validation) readIrrlichtSession(rel, scenario, path string) (irrlichtSession, bool) {
+func (v *validation) readIrrlichtSession(input evidenceRead) (irrlichtSession, bool) {
 	var state irrlichtSession
-	if err := readJSON(path, &state); err != nil {
-		v.add(rel, scenario, "irrlicht_session", err.Error())
+	if err := readJSON(jsonRead{path: input.path, value: &state}); err != nil {
+		v.add(input.target, "irrlicht_session", err.Error())
 		return state, false
 	}
 	ok := true
 	if strings.TrimSpace(state.SessionID) == "" {
-		v.add(rel, scenario, "irrlicht_session.session_id", mustNotBeBlank)
+		v.add(input.target, "irrlicht_session.session_id", mustNotBeBlank)
 		ok = false
 	}
 	if strings.TrimSpace(state.CWD) == "" {
-		v.add(rel, scenario, fieldIrrlichtCWD, mustNotBeBlank)
+		v.add(input.target, fieldIrrlichtCWD, mustNotBeBlank)
 		ok = false
 	}
 	if state.PID <= 0 {
-		v.add(rel, scenario, "irrlicht_session.pid", "must be positive")
+		v.add(input.target, "irrlicht_session.pid", "must be positive")
 		ok = false
 	}
 	if state.Launcher.HostBundleID != desktopBundleID {
-		v.add(rel, scenario, "irrlicht_session.launcher.host_bundle_id", fmt.Sprintf("got %q; want %q", state.Launcher.HostBundleID, desktopBundleID))
+		v.add(input.target, "irrlicht_session.launcher.host_bundle_id", fmt.Sprintf("got %q; want %q", state.Launcher.HostBundleID, desktopBundleID))
 		ok = false
 	}
 	return state, ok
 }
 
 func (v *validation) validateHooks(input hookValidation) bool {
-	scan, err := scanHookReceipts(input.path, input.eventsPath, input.sessionID)
+	scan, err := scanHookReceipts(hookScanInput{path: input.path, eventsPath: input.eventsPath, sessionID: input.sessionID})
 	if err != nil {
-		v.add(input.rel, input.scenario, "hooks", err.Error())
+		v.add(input.target, "hooks", err.Error())
 		return false
 	}
-	v.reportHookReceiptFindings(input.rel, input.scenario, scan)
+	v.reportHookReceiptFindings(input.target, scan)
 	return scan.valid()
 }
 
-func (v *validation) reportHookReceiptFindings(rel, scenario string, scan hookReceiptScan) {
+func (v *validation) reportHookReceiptFindings(target findingTarget, scan hookReceiptScan) {
 	if !scan.matchedSession {
-		v.add(rel, scenario, "hooks.session_id", "contains no hook receipt for transcript.sessionId")
+		v.add(target, "hooks.session_id", "contains no hook receipt for transcript.sessionId")
 	}
 	if !scan.consistentSessions {
-		v.add(rel, scenario, "hooks.session_id", "contains a hook receipt from another session")
+		v.add(target, "hooks.session_id", "contains a hook receipt from another session")
 	}
 	if !scan.correctKinds {
-		v.add(rel, scenario, "hooks.kind", `must be "hook_received" on every row`)
+		v.add(target, "hooks.kind", `must be "hook_received" on every row`)
 	}
 	if !scan.named {
-		v.add(rel, scenario, "hooks.hook_name", "must be nonblank on every hook receipt")
+		v.add(target, "hooks.hook_name", "must be nonblank on every hook receipt")
 	}
 	if !scan.preserved {
-		v.add(rel, scenario, "hooks.events_jsonl", "each row must occur byte-for-byte in this recording's events.jsonl")
+		v.add(target, "hooks.events_jsonl", "each row must occur byte-for-byte in this recording's events.jsonl")
 	}
 }
 
 // scanHookReceipts validates unmodified hook_received rows extracted from the
 // recording's events.jsonl. These rows are lifecycle receipts. They are not
 // the raw inbound Claude hook payload.
-func scanHookReceipts(path, eventsPath, sessionID string) (hookReceiptScan, error) {
-	eventLines, err := readJSONLLines(eventsPath)
+func scanHookReceipts(input hookScanInput) (hookReceiptScan, error) {
+	eventLines, err := readJSONLLines(input.eventsPath)
 	if err != nil {
 		return hookReceiptScan{}, fmt.Errorf("read events.jsonl: %w", err)
 	}
-	hookLines, err := readJSONLLines(path)
+	hookLines, err := readJSONLLines(input.path)
 	if err != nil {
 		return hookReceiptScan{}, err
 	}
 	remaining := countLines(eventLines)
 	scan := hookReceiptScan{consistentSessions: true, correctKinds: true, named: true, preserved: true}
 	for _, line := range hookLines {
-		if err := applyHookReceipt(&scan, line, sessionID, remaining); err != nil {
+		if err := applyHookReceipt(hookReceiptInput{scan: &scan, line: line, sessionID: input.sessionID, remaining: remaining}); err != nil {
 			return hookReceiptScan{}, fmt.Errorf("invalid JSONL: %w", err)
 		}
 	}
@@ -477,30 +537,30 @@ func countLines(lines []string) map[string]int {
 	return counts
 }
 
-func applyHookReceipt(scan *hookReceiptScan, line, sessionID string, remaining map[string]int) error {
+func applyHookReceipt(input hookReceiptInput) error {
 	var row hookReceipt
-	if err := json.Unmarshal([]byte(line), &row); err != nil {
+	if err := json.Unmarshal([]byte(input.line), &row); err != nil {
 		return err
 	}
 	correctKind := row.Kind == "hook_received"
-	sessionMatches := hookSessionMatches(row, sessionID)
-	scan.correctKinds = scan.correctKinds && correctKind
-	scan.matchedSession = scan.matchedSession || sessionMatches
-	scan.consistentSessions = scan.consistentSessions && sessionMatches
-	scan.named = scan.named && strings.TrimSpace(row.HookName) != ""
-	scan.preserved = scan.preserved && claimLine(remaining, line)
+	sessionMatches := hookSessionMatches(hookSessionCheck{row: row, sessionID: input.sessionID})
+	input.scan.correctKinds = input.scan.correctKinds && correctKind
+	input.scan.matchedSession = input.scan.matchedSession || sessionMatches
+	input.scan.consistentSessions = input.scan.consistentSessions && sessionMatches
+	input.scan.named = input.scan.named && strings.TrimSpace(row.HookName) != ""
+	input.scan.preserved = input.scan.preserved && claimLine(lineClaim{remaining: input.remaining, line: input.line})
 	return nil
 }
 
-func hookSessionMatches(row hookReceipt, sessionID string) bool {
-	return row.Kind == "hook_received" && sessionID != "" && row.SessionID == sessionID
+func hookSessionMatches(input hookSessionCheck) bool {
+	return input.row.Kind == "hook_received" && input.sessionID != "" && input.row.SessionID == input.sessionID
 }
 
-func claimLine(remaining map[string]int, line string) bool {
-	if remaining[line] == 0 {
+func claimLine(input lineClaim) bool {
+	if input.remaining[input.line] == 0 {
 		return false
 	}
-	remaining[line]--
+	input.remaining[input.line]--
 	return true
 }
 
@@ -521,77 +581,78 @@ func readJSONLLines(path string) ([]string, error) {
 	return lines, nil
 }
 
-func (v *validation) readProcess(rel, scenario, path string) (processEvidence, bool) {
+func (v *validation) readProcess(input evidenceRead) (processEvidence, bool) {
 	var process processEvidence
-	if err := readJSON(path, &process); err != nil {
-		v.add(rel, scenario, "process", err.Error())
+	if err := readJSON(jsonRead{path: input.path, value: &process}); err != nil {
+		v.add(input.target, "process", err.Error())
 		return process, false
 	}
 	ok := true
 	if process.PID <= 0 {
-		v.add(rel, scenario, "process.pid", "must be positive")
+		v.add(input.target, "process.pid", "must be positive")
 		ok = false
 	}
 	if strings.TrimSpace(process.Command) == "" {
-		v.add(rel, scenario, "process.command", mustNotBeBlank)
+		v.add(input.target, "process.command", mustNotBeBlank)
 		ok = false
 	}
 	return process, ok
 }
 
-func (v *validation) compareManifestTranscript(rel, scenario string, manifest matrix.RecordingManifest, transcript transcriptIdentity) {
-	if manifest.Entrypoint != transcript.Entrypoint {
-		v.add(rel, scenario, "manifest.entrypoint", "does not match transcript.entrypoint")
+func (v *validation) compareManifestTranscript(context identityValidation) {
+	if context.identity.manifest.Entrypoint != context.identity.transcript.Entrypoint {
+		v.add(context.target, "manifest.entrypoint", "does not match transcript.entrypoint")
 	}
 }
 
-func (v *validation) compareWorkspaceIdentity(rel, scenario string, identity observedIdentity) {
+func (v *validation) compareWorkspaceIdentity(context identityValidation) {
+	identity := context.identity
 	if !samePath(identity.registry.CWD, identity.transcript.CWD) {
-		v.add(rel, scenario, fieldDesktopRegistryCWD, "does not match transcript.cwd")
+		v.add(context.target, fieldDesktopRegistryCWD, "does not match transcript.cwd")
 	}
 	if !samePath(identity.registry.CWD, identity.environment.RequestedWorkspace) {
-		v.add(rel, scenario, fieldDesktopRegistryCWD, mismatchEnvironmentCWD)
+		v.add(context.target, fieldDesktopRegistryCWD, mismatchEnvironmentCWD)
 	}
 	if !samePath(identity.transcript.CWD, identity.environment.RequestedWorkspace) {
-		v.add(rel, scenario, "transcript.cwd", mismatchEnvironmentCWD)
+		v.add(context.target, "transcript.cwd", mismatchEnvironmentCWD)
 	}
 }
 
-func (v *validation) compareSessionMapping(rel, scenario string, transcript transcriptIdentity, registry registryIdentity) {
-	if registry.CLISessionID != transcript.SessionID {
-		v.add(rel, scenario, "desktop_registry.cliSessionId", "does not match transcript.sessionId")
+func (v *validation) compareSessionMapping(context identityValidation) {
+	if context.identity.registry.CLISessionID != context.identity.transcript.SessionID {
+		v.add(context.target, "desktop_registry.cliSessionId", "does not match transcript.sessionId")
 	}
 }
 
-func (v *validation) compareIrrlichtIdentity(rel, scenario string, transcript transcriptIdentity, state irrlichtSession) {
-	if state.SessionID != transcript.SessionID {
-		v.add(rel, scenario, "irrlicht_session.session_id", "does not match transcript.sessionId")
+func (v *validation) compareIrrlichtIdentity(context identityValidation) {
+	if context.identity.irrlicht.SessionID != context.identity.transcript.SessionID {
+		v.add(context.target, "irrlicht_session.session_id", "does not match transcript.sessionId")
 	}
-	if !samePath(state.CWD, transcript.CWD) {
-		v.add(rel, scenario, fieldIrrlichtCWD, "does not match transcript.cwd")
+	if !samePath(context.identity.irrlicht.CWD, context.identity.transcript.CWD) {
+		v.add(context.target, fieldIrrlichtCWD, "does not match transcript.cwd")
 	}
 }
 
-func readJSON(path string, value any) error {
-	b, err := os.ReadFile(path)
+func readJSON(input jsonRead) error {
+	b, err := os.ReadFile(input.path)
 	if err != nil {
 		return err
 	}
-	if err := json.Unmarshal(b, value); err != nil {
+	if err := json.Unmarshal(b, input.value); err != nil {
 		return fmt.Errorf("invalid JSON: %w", err)
 	}
 	return nil
 }
 
-func mergeIdentity(current *string, next string) bool {
-	if next == "" {
+func mergeIdentity(input identityMerge) bool {
+	if input.next == "" {
 		return true
 	}
-	if *current == "" {
-		*current = next
+	if *input.current == "" {
+		*input.current = input.next
 		return true
 	}
-	return *current == next
+	return *input.current == input.next
 }
 
 func samePath(left, right string) bool {

--- a/tools/onboarding-factory/internal/desktopresults/identity.go
+++ b/tools/onboarding-factory/internal/desktopresults/identity.go
@@ -13,9 +13,13 @@ import (
 )
 
 const (
-	desktopEntrypoint = "claude-desktop"
-	desktopBundleID   = "com.anthropic.claudefordesktop"
-	localEnvironment  = "Local"
+	desktopEntrypoint       = "claude-desktop"
+	desktopBundleID         = "com.anthropic.claudefordesktop"
+	localEnvironment        = "Local"
+	fieldIrrlichtCWD        = "irrlicht_session.cwd"
+	fieldDesktopRegistryCWD = "desktop_registry.cwd"
+	mustNotBeBlank          = "must not be blank"
+	mismatchEnvironmentCWD  = "does not match environment.requested_workspace"
 )
 
 type evidenceFiles struct {
@@ -40,6 +44,14 @@ type hookReceipt struct {
 	Kind      string `json:"kind"`
 	SessionID string `json:"session_id"`
 	HookName  string `json:"hook_name"`
+}
+
+type hookValidation struct {
+	rel        string
+	scenario   string
+	path       string
+	eventsPath string
+	sessionID  string
 }
 
 func (scan hookReceiptScan) valid() bool {
@@ -142,7 +154,13 @@ func (v *validation) readObservedIdentity(rel, scenario string, files evidenceFi
 	identity.environment, identity.environmentOK = v.readEnvironment(rel, scenario, files.environment)
 	identity.irrlicht, identity.irrlichtOK = v.readIrrlichtSession(rel, scenario, files.irrlicht)
 	identity.process, identity.processOK = v.readProcess(rel, scenario, files.process)
-	v.validateHooks(rel, scenario, files.hooks, files.events, identity.transcript.SessionID)
+	v.validateHooks(hookValidation{
+		rel:        rel,
+		scenario:   scenario,
+		path:       files.hooks,
+		eventsPath: files.events,
+		sessionID:  identity.transcript.SessionID,
+	})
 	return identity
 }
 
@@ -161,7 +179,7 @@ func (v *validation) compareTranscriptIdentity(rel, scenario string, identity ob
 		v.compareSessionMapping(rel, scenario, identity.transcript, identity.registry)
 	}
 	if identity.registryOK && identity.environmentOK {
-		v.compareWorkspaceIdentity(rel, scenario, identity.transcript, identity.registry, identity.environment)
+		v.compareWorkspaceIdentity(rel, scenario, identity)
 	}
 	if identity.irrlichtOK {
 		v.compareIrrlichtIdentity(rel, scenario, identity.transcript, identity.irrlicht)
@@ -169,13 +187,19 @@ func (v *validation) compareTranscriptIdentity(rel, scenario string, identity ob
 }
 
 func (v *validation) compareEnvironmentIdentity(rel, scenario string, identity observedIdentity) {
-	if identity.environmentOK && identity.irrlichtOK && !samePath(identity.environment.RequestedWorkspace, identity.irrlicht.CWD) {
-		v.add(rel, scenario, "irrlicht_session.cwd", "does not match environment.requested_workspace")
+	if !identity.environmentOK || !identity.irrlichtOK {
+		return
+	}
+	if !samePath(identity.environment.RequestedWorkspace, identity.irrlicht.CWD) {
+		v.add(rel, scenario, fieldIrrlichtCWD, mismatchEnvironmentCWD)
 	}
 }
 
 func (v *validation) compareProcessIdentity(rel, scenario string, identity observedIdentity) {
-	if identity.processOK && identity.irrlichtOK && identity.process.PID != identity.irrlicht.PID {
+	if !identity.processOK || !identity.irrlichtOK {
+		return
+	}
+	if identity.process.PID != identity.irrlicht.PID {
 		v.add(rel, scenario, "process.pid", "does not match irrlicht_session.pid")
 	}
 }
@@ -333,10 +357,10 @@ func (v *validation) readRegistry(rel, scenario, path string) (registryIdentity,
 	for field, value := range map[string]string{
 		"desktop_registry.sessionId":    registry.SessionID,
 		"desktop_registry.cliSessionId": registry.CLISessionID,
-		"desktop_registry.cwd":          registry.CWD,
+		fieldDesktopRegistryCWD:         registry.CWD,
 	} {
 		if strings.TrimSpace(value) == "" {
-			v.add(rel, scenario, field, "must not be blank")
+			v.add(rel, scenario, field, mustNotBeBlank)
 			ok = false
 		}
 	}
@@ -363,7 +387,7 @@ func (v *validation) readEnvironment(rel, scenario, path string) (environmentRec
 		ok = false
 	}
 	if strings.TrimSpace(receipt.RequestedWorkspace) == "" {
-		v.add(rel, scenario, "environment.requested_workspace", "must not be blank")
+		v.add(rel, scenario, "environment.requested_workspace", mustNotBeBlank)
 		ok = false
 	}
 	return receipt, ok
@@ -377,11 +401,11 @@ func (v *validation) readIrrlichtSession(rel, scenario, path string) (irrlichtSe
 	}
 	ok := true
 	if strings.TrimSpace(state.SessionID) == "" {
-		v.add(rel, scenario, "irrlicht_session.session_id", "must not be blank")
+		v.add(rel, scenario, "irrlicht_session.session_id", mustNotBeBlank)
 		ok = false
 	}
 	if strings.TrimSpace(state.CWD) == "" {
-		v.add(rel, scenario, "irrlicht_session.cwd", "must not be blank")
+		v.add(rel, scenario, fieldIrrlichtCWD, mustNotBeBlank)
 		ok = false
 	}
 	if state.PID <= 0 {
@@ -395,13 +419,13 @@ func (v *validation) readIrrlichtSession(rel, scenario, path string) (irrlichtSe
 	return state, ok
 }
 
-func (v *validation) validateHooks(rel, scenario, path, eventsPath, sessionID string) bool {
-	scan, err := scanHookReceipts(path, eventsPath, sessionID)
+func (v *validation) validateHooks(input hookValidation) bool {
+	scan, err := scanHookReceipts(input.path, input.eventsPath, input.sessionID)
 	if err != nil {
-		v.add(rel, scenario, "hooks", err.Error())
+		v.add(input.rel, input.scenario, "hooks", err.Error())
 		return false
 	}
-	v.reportHookReceiptFindings(rel, scenario, scan)
+	v.reportHookReceiptFindings(input.rel, input.scenario, scan)
 	return scan.valid()
 }
 
@@ -509,7 +533,7 @@ func (v *validation) readProcess(rel, scenario, path string) (processEvidence, b
 		ok = false
 	}
 	if strings.TrimSpace(process.Command) == "" {
-		v.add(rel, scenario, "process.command", "must not be blank")
+		v.add(rel, scenario, "process.command", mustNotBeBlank)
 		ok = false
 	}
 	return process, ok
@@ -521,15 +545,15 @@ func (v *validation) compareManifestTranscript(rel, scenario string, manifest ma
 	}
 }
 
-func (v *validation) compareWorkspaceIdentity(rel, scenario string, transcript transcriptIdentity, registry registryIdentity, environment environmentReceipt) {
-	if !samePath(registry.CWD, transcript.CWD) {
-		v.add(rel, scenario, "desktop_registry.cwd", "does not match transcript.cwd")
+func (v *validation) compareWorkspaceIdentity(rel, scenario string, identity observedIdentity) {
+	if !samePath(identity.registry.CWD, identity.transcript.CWD) {
+		v.add(rel, scenario, fieldDesktopRegistryCWD, "does not match transcript.cwd")
 	}
-	if !samePath(registry.CWD, environment.RequestedWorkspace) {
-		v.add(rel, scenario, "desktop_registry.cwd", "does not match environment.requested_workspace")
+	if !samePath(identity.registry.CWD, identity.environment.RequestedWorkspace) {
+		v.add(rel, scenario, fieldDesktopRegistryCWD, mismatchEnvironmentCWD)
 	}
-	if !samePath(transcript.CWD, environment.RequestedWorkspace) {
-		v.add(rel, scenario, "transcript.cwd", "does not match environment.requested_workspace")
+	if !samePath(identity.transcript.CWD, identity.environment.RequestedWorkspace) {
+		v.add(rel, scenario, "transcript.cwd", mismatchEnvironmentCWD)
 	}
 }
 
@@ -544,7 +568,7 @@ func (v *validation) compareIrrlichtIdentity(rel, scenario string, transcript tr
 		v.add(rel, scenario, "irrlicht_session.session_id", "does not match transcript.sessionId")
 	}
 	if !samePath(state.CWD, transcript.CWD) {
-		v.add(rel, scenario, "irrlicht_session.cwd", "does not match transcript.cwd")
+		v.add(rel, scenario, fieldIrrlichtCWD, "does not match transcript.cwd")
 	}
 }
 

--- a/tools/onboarding-factory/internal/desktopresults/identity.go
+++ b/tools/onboarding-factory/internal/desktopresults/identity.go
@@ -1,0 +1,405 @@
+package desktopresults
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"irrlicht/tools/onboarding-factory/internal/matrix"
+)
+
+const (
+	desktopEntrypoint = "claude-desktop"
+	desktopBundleID   = "com.anthropic.claudefordesktop"
+	localEnvironment  = "Local"
+)
+
+type evidenceFiles struct {
+	registry    string
+	transcript  string
+	hooks       string
+	process     string
+	irrlicht    string
+	environment string
+}
+
+type transcriptIdentity struct {
+	SessionID  string
+	CWD        string
+	Entrypoint string
+}
+
+type registryIdentity struct {
+	SessionID    string          `json:"sessionId"`
+	CLISessionID string          `json:"cliSessionId"`
+	CWD          string          `json:"cwd"`
+	EnvScopeID   json.RawMessage `json:"envScopeId"`
+}
+
+type environmentReceipt struct {
+	SelectedEnvironment string `json:"selected_environment"`
+	RequestedWorkspace  string `json:"requested_workspace"`
+}
+
+type irrlichtSession struct {
+	SessionID string `json:"session_id"`
+	CWD       string `json:"cwd"`
+	PID       int    `json:"pid"`
+	Launcher  struct {
+		HostBundleID string `json:"host_bundle_id"`
+	} `json:"launcher"`
+}
+
+type processEvidence struct {
+	PID     int    `json:"pid"`
+	Command string `json:"command"`
+}
+
+func (v *validation) validateObservedEvidence(rel, cellDir string, result *Result) {
+	recordingsRoot := filepath.Join(cellDir, "recordings")
+	recordingDir, err := resolveDirectory(recordingsRoot, result.Recording)
+	if err != nil {
+		v.add(rel, result.ScenarioID, "recording", err.Error())
+		return
+	}
+	files, ok := v.resolveEvidenceFiles(rel, recordingDir, result)
+	manifest, manifestOK := v.validateManifest(rel, recordingDir, result.ScenarioID)
+	if !ok || !manifestOK {
+		return
+	}
+
+	transcript, transcriptOK := v.readTranscript(rel, result.ScenarioID, files.transcript)
+	registry, registryOK := v.readRegistry(rel, result.ScenarioID, files.registry)
+	environment, environmentOK := v.readEnvironment(rel, result.ScenarioID, files.environment)
+	irrlicht, irrlichtOK := v.readIrrlichtSession(rel, result.ScenarioID, files.irrlicht)
+	hooksOK := v.validateHooks(rel, result.ScenarioID, files.hooks, transcript.SessionID)
+	process, processOK := v.readProcess(rel, result.ScenarioID, files.process)
+
+	if transcriptOK {
+		v.compareManifestTranscript(rel, result.ScenarioID, manifest, transcript)
+	}
+	if transcriptOK && registryOK && environmentOK {
+		v.compareWorkspaceIdentity(rel, result.ScenarioID, transcript, registry, environment)
+	}
+	if transcriptOK && registryOK {
+		v.compareSessionMapping(rel, result.ScenarioID, transcript, registry)
+	}
+	if transcriptOK && irrlichtOK {
+		v.compareIrrlichtIdentity(rel, result.ScenarioID, transcript, irrlicht)
+	}
+	if environmentOK && irrlichtOK && !samePath(environment.RequestedWorkspace, irrlicht.CWD) {
+		v.add(rel, result.ScenarioID, "irrlicht_session.cwd", "does not match environment.requested_workspace")
+	}
+	if processOK && irrlichtOK && process.PID != irrlicht.PID {
+		v.add(rel, result.ScenarioID, "process.pid", "does not match irrlicht_session.pid")
+	}
+	_ = hooksOK // validation reports its own finding; no later join depends on it.
+}
+
+func (v *validation) resolveEvidenceFiles(rel, recordingDir string, result *Result) (evidenceFiles, bool) {
+	evidence := result.Evidence
+	refs := []struct {
+		field string
+		ref   string
+		dst   *string
+	}{
+		{"desktop_registry", evidence.DesktopRegistry, nil},
+		{"transcript", evidence.Transcript, nil},
+		{"hooks", evidence.Hooks, nil},
+		{"process", evidence.Process, nil},
+		{"irrlicht_session", evidence.IrrlichtSession, nil},
+		{"environment", evidence.Environment, nil},
+	}
+	var files evidenceFiles
+	refs[0].dst = &files.registry
+	refs[1].dst = &files.transcript
+	refs[2].dst = &files.hooks
+	refs[3].dst = &files.process
+	refs[4].dst = &files.irrlicht
+	refs[5].dst = &files.environment
+	ok := true
+	for _, item := range refs {
+		resolved, err := resolveFile(recordingDir, item.ref)
+		if err != nil {
+			v.add(rel, result.ScenarioID, "evidence."+item.field, err.Error())
+			ok = false
+			continue
+		}
+		*item.dst = resolved
+	}
+	return files, ok
+}
+
+func (v *validation) validateManifest(rel, recordingDir, scenario string) (matrix.RecordingManifest, bool) {
+	manifestPath, err := resolveFile(recordingDir, "manifest.json")
+	if err != nil {
+		v.add(rel, scenario, "manifest", err.Error())
+		return matrix.RecordingManifest{}, false
+	}
+	manifest, err := matrix.LoadRecordingManifest(manifestPath)
+	if err != nil {
+		v.add(rel, scenario, "manifest", err.Error())
+		return manifest, false
+	}
+	if manifest.ExecutionProfile != matrix.ProfileDesktopLocal {
+		v.add(rel, scenario, "manifest.execution_profile", fmt.Sprintf("got %q; want %q", manifest.ExecutionProfile, matrix.ProfileDesktopLocal))
+	}
+	if manifest.Entrypoint != desktopEntrypoint {
+		v.add(rel, scenario, "manifest.entrypoint", fmt.Sprintf("got %q; want %q", manifest.Entrypoint, desktopEntrypoint))
+	}
+	for field, value := range map[string]string{
+		"manifest.daemon_version":      manifest.DaemonVersion,
+		"manifest.agent_cli_version":   manifest.AgentCLIVersion,
+		"manifest.desktop_app_version": manifest.DesktopAppVersion,
+	} {
+		if blankOrUnknown(value) {
+			v.add(rel, scenario, field, "must contain the measured version")
+		}
+	}
+	return manifest, true
+}
+
+func (v *validation) readTranscript(rel, scenario, path string) (transcriptIdentity, bool) {
+	f, err := os.Open(path)
+	if err != nil {
+		v.add(rel, scenario, "transcript", err.Error())
+		return transcriptIdentity{}, false
+	}
+	defer f.Close()
+	decoder := json.NewDecoder(f)
+	identity := transcriptIdentity{}
+	for {
+		var row struct {
+			SessionID  string `json:"sessionId"`
+			CWD        string `json:"cwd"`
+			Entrypoint string `json:"entrypoint"`
+		}
+		err := decoder.Decode(&row)
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			v.add(rel, scenario, "transcript", "invalid JSONL: "+err.Error())
+			return identity, false
+		}
+		if !mergeIdentity(&identity.SessionID, row.SessionID) {
+			v.add(rel, scenario, "transcript.sessionId", "contains conflicting values")
+		}
+		if !mergeIdentity(&identity.CWD, row.CWD) {
+			v.add(rel, scenario, "transcript.cwd", "contains conflicting values")
+		}
+		if !mergeIdentity(&identity.Entrypoint, row.Entrypoint) {
+			v.add(rel, scenario, "transcript.entrypoint", "contains conflicting values")
+		}
+	}
+	ok := true
+	for field, value := range map[string]string{
+		"transcript.sessionId":  identity.SessionID,
+		"transcript.cwd":        identity.CWD,
+		"transcript.entrypoint": identity.Entrypoint,
+	} {
+		if strings.TrimSpace(value) == "" {
+			v.add(rel, scenario, field, "is absent from the raw transcript")
+			ok = false
+		}
+	}
+	if identity.Entrypoint != "" && identity.Entrypoint != desktopEntrypoint {
+		v.add(rel, scenario, "transcript.entrypoint", fmt.Sprintf("got %q; want %q", identity.Entrypoint, desktopEntrypoint))
+		ok = false
+	}
+	return identity, ok
+}
+
+func (v *validation) readRegistry(rel, scenario, path string) (registryIdentity, bool) {
+	var registry registryIdentity
+	if err := readJSON(path, &registry); err != nil {
+		v.add(rel, scenario, "desktop_registry", err.Error())
+		return registry, false
+	}
+	ok := true
+	for field, value := range map[string]string{
+		"desktop_registry.sessionId":    registry.SessionID,
+		"desktop_registry.cliSessionId": registry.CLISessionID,
+		"desktop_registry.cwd":          registry.CWD,
+	} {
+		if strings.TrimSpace(value) == "" {
+			v.add(rel, scenario, field, "must not be blank")
+			ok = false
+		}
+	}
+	if registry.SessionID != "" && !strings.HasPrefix(registry.SessionID, "local_") {
+		v.add(rel, scenario, "desktop_registry.sessionId", "must start with local_")
+		ok = false
+	}
+	if string(registry.EnvScopeID) != "null" {
+		v.add(rel, scenario, "desktop_registry.envScopeId", "must be explicit null for the Local environment")
+		ok = false
+	}
+	return registry, ok
+}
+
+func (v *validation) readEnvironment(rel, scenario, path string) (environmentReceipt, bool) {
+	var receipt environmentReceipt
+	if err := decodeStrict(path, &receipt); err != nil {
+		v.add(rel, scenario, "environment", "invalid or unknown field: "+err.Error())
+		return receipt, false
+	}
+	ok := true
+	if receipt.SelectedEnvironment != localEnvironment {
+		v.add(rel, scenario, "environment.selected_environment", fmt.Sprintf("got %q; want %q", receipt.SelectedEnvironment, localEnvironment))
+		ok = false
+	}
+	if strings.TrimSpace(receipt.RequestedWorkspace) == "" {
+		v.add(rel, scenario, "environment.requested_workspace", "must not be blank")
+		ok = false
+	}
+	return receipt, ok
+}
+
+func (v *validation) readIrrlichtSession(rel, scenario, path string) (irrlichtSession, bool) {
+	var state irrlichtSession
+	if err := readJSON(path, &state); err != nil {
+		v.add(rel, scenario, "irrlicht_session", err.Error())
+		return state, false
+	}
+	ok := true
+	if strings.TrimSpace(state.SessionID) == "" {
+		v.add(rel, scenario, "irrlicht_session.session_id", "must not be blank")
+		ok = false
+	}
+	if strings.TrimSpace(state.CWD) == "" {
+		v.add(rel, scenario, "irrlicht_session.cwd", "must not be blank")
+		ok = false
+	}
+	if state.PID <= 0 {
+		v.add(rel, scenario, "irrlicht_session.pid", "must be positive")
+		ok = false
+	}
+	if state.Launcher.HostBundleID != desktopBundleID {
+		v.add(rel, scenario, "irrlicht_session.launcher.host_bundle_id", fmt.Sprintf("got %q; want %q", state.Launcher.HostBundleID, desktopBundleID))
+		ok = false
+	}
+	return state, ok
+}
+
+func (v *validation) validateHooks(rel, scenario, path, sessionID string) bool {
+	f, err := os.Open(path)
+	if err != nil {
+		v.add(rel, scenario, "hooks", err.Error())
+		return false
+	}
+	defer f.Close()
+	decoder := json.NewDecoder(f)
+	matched := false
+	consistent := true
+	for {
+		var row struct {
+			SessionID string `json:"session_id"`
+		}
+		err := decoder.Decode(&row)
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			v.add(rel, scenario, "hooks", "invalid JSONL: "+err.Error())
+			return false
+		}
+		if sessionID != "" && row.SessionID == sessionID {
+			matched = true
+		} else {
+			consistent = false
+		}
+	}
+	if !matched {
+		v.add(rel, scenario, "hooks.session_id", "contains no raw hook for transcript.sessionId")
+	}
+	if !consistent {
+		v.add(rel, scenario, "hooks.session_id", "contains a hook from another session")
+	}
+	return matched && consistent
+}
+
+func (v *validation) readProcess(rel, scenario, path string) (processEvidence, bool) {
+	var process processEvidence
+	if err := readJSON(path, &process); err != nil {
+		v.add(rel, scenario, "process", err.Error())
+		return process, false
+	}
+	ok := true
+	if process.PID <= 0 {
+		v.add(rel, scenario, "process.pid", "must be positive")
+		ok = false
+	}
+	if strings.TrimSpace(process.Command) == "" {
+		v.add(rel, scenario, "process.command", "must not be blank")
+		ok = false
+	}
+	return process, ok
+}
+
+func (v *validation) compareManifestTranscript(rel, scenario string, manifest matrix.RecordingManifest, transcript transcriptIdentity) {
+	if manifest.Entrypoint != transcript.Entrypoint {
+		v.add(rel, scenario, "manifest.entrypoint", "does not match transcript.entrypoint")
+	}
+}
+
+func (v *validation) compareWorkspaceIdentity(rel, scenario string, transcript transcriptIdentity, registry registryIdentity, environment environmentReceipt) {
+	if !samePath(registry.CWD, transcript.CWD) {
+		v.add(rel, scenario, "desktop_registry.cwd", "does not match transcript.cwd")
+	}
+	if !samePath(registry.CWD, environment.RequestedWorkspace) {
+		v.add(rel, scenario, "desktop_registry.cwd", "does not match environment.requested_workspace")
+	}
+	if !samePath(transcript.CWD, environment.RequestedWorkspace) {
+		v.add(rel, scenario, "transcript.cwd", "does not match environment.requested_workspace")
+	}
+}
+
+func (v *validation) compareSessionMapping(rel, scenario string, transcript transcriptIdentity, registry registryIdentity) {
+	if registry.CLISessionID != transcript.SessionID {
+		v.add(rel, scenario, "desktop_registry.cliSessionId", "does not match transcript.sessionId")
+	}
+}
+
+func (v *validation) compareIrrlichtIdentity(rel, scenario string, transcript transcriptIdentity, state irrlichtSession) {
+	if state.SessionID != transcript.SessionID {
+		v.add(rel, scenario, "irrlicht_session.session_id", "does not match transcript.sessionId")
+	}
+	if !samePath(state.CWD, transcript.CWD) {
+		v.add(rel, scenario, "irrlicht_session.cwd", "does not match transcript.cwd")
+	}
+}
+
+func readJSON(path string, value any) error {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	if err := json.Unmarshal(b, value); err != nil {
+		return fmt.Errorf("invalid JSON: %w", err)
+	}
+	return nil
+}
+
+func mergeIdentity(current *string, next string) bool {
+	if next == "" {
+		return true
+	}
+	if *current == "" {
+		*current = next
+		return true
+	}
+	return *current == next
+}
+
+func samePath(left, right string) bool {
+	return left != "" && right != "" && filepath.Clean(left) == filepath.Clean(right)
+}
+
+func blankOrUnknown(value string) bool {
+	value = strings.TrimSpace(value)
+	return value == "" || value == "unknown"
+}

--- a/tools/onboarding-factory/internal/desktopresults/identity.go
+++ b/tools/onboarding-factory/internal/desktopresults/identity.go
@@ -58,6 +58,20 @@ type processEvidence struct {
 	Command string `json:"command"`
 }
 
+type observedIdentity struct {
+	manifest      matrix.RecordingManifest
+	transcript    transcriptIdentity
+	registry      registryIdentity
+	environment   environmentReceipt
+	irrlicht      irrlichtSession
+	process       processEvidence
+	transcriptOK  bool
+	registryOK    bool
+	environmentOK bool
+	irrlichtOK    bool
+	processOK     bool
+}
+
 func (v *validation) validateObservedEvidence(rel, cellDir string, result *Result) {
 	recordingsRoot := filepath.Join(cellDir, "recordings")
 	recordingDir, err := resolveDirectory(recordingsRoot, result.Recording)
@@ -70,33 +84,53 @@ func (v *validation) validateObservedEvidence(rel, cellDir string, result *Resul
 	if !ok || !manifestOK {
 		return
 	}
+	identity := v.readObservedIdentity(rel, result.ScenarioID, files, manifest)
+	v.compareObservedIdentity(rel, result.ScenarioID, identity)
+}
 
-	transcript, transcriptOK := v.readTranscript(rel, result.ScenarioID, files.transcript)
-	registry, registryOK := v.readRegistry(rel, result.ScenarioID, files.registry)
-	environment, environmentOK := v.readEnvironment(rel, result.ScenarioID, files.environment)
-	irrlicht, irrlichtOK := v.readIrrlichtSession(rel, result.ScenarioID, files.irrlicht)
-	hooksOK := v.validateHooks(rel, result.ScenarioID, files.hooks, transcript.SessionID)
-	process, processOK := v.readProcess(rel, result.ScenarioID, files.process)
+func (v *validation) readObservedIdentity(rel, scenario string, files evidenceFiles, manifest matrix.RecordingManifest) observedIdentity {
+	identity := observedIdentity{manifest: manifest}
+	identity.transcript, identity.transcriptOK = v.readTranscript(rel, scenario, files.transcript)
+	identity.registry, identity.registryOK = v.readRegistry(rel, scenario, files.registry)
+	identity.environment, identity.environmentOK = v.readEnvironment(rel, scenario, files.environment)
+	identity.irrlicht, identity.irrlichtOK = v.readIrrlichtSession(rel, scenario, files.irrlicht)
+	identity.process, identity.processOK = v.readProcess(rel, scenario, files.process)
+	v.validateHooks(rel, scenario, files.hooks, identity.transcript.SessionID)
+	return identity
+}
 
-	if transcriptOK {
-		v.compareManifestTranscript(rel, result.ScenarioID, manifest, transcript)
+func (v *validation) compareObservedIdentity(rel, scenario string, identity observedIdentity) {
+	v.compareTranscriptIdentity(rel, scenario, identity)
+	v.compareEnvironmentIdentity(rel, scenario, identity)
+	v.compareProcessIdentity(rel, scenario, identity)
+}
+
+func (v *validation) compareTranscriptIdentity(rel, scenario string, identity observedIdentity) {
+	if !identity.transcriptOK {
+		return
 	}
-	if transcriptOK && registryOK && environmentOK {
-		v.compareWorkspaceIdentity(rel, result.ScenarioID, transcript, registry, environment)
+	v.compareManifestTranscript(rel, scenario, identity.manifest, identity.transcript)
+	if identity.registryOK {
+		v.compareSessionMapping(rel, scenario, identity.transcript, identity.registry)
 	}
-	if transcriptOK && registryOK {
-		v.compareSessionMapping(rel, result.ScenarioID, transcript, registry)
+	if identity.registryOK && identity.environmentOK {
+		v.compareWorkspaceIdentity(rel, scenario, identity.transcript, identity.registry, identity.environment)
 	}
-	if transcriptOK && irrlichtOK {
-		v.compareIrrlichtIdentity(rel, result.ScenarioID, transcript, irrlicht)
+	if identity.irrlichtOK {
+		v.compareIrrlichtIdentity(rel, scenario, identity.transcript, identity.irrlicht)
 	}
-	if environmentOK && irrlichtOK && !samePath(environment.RequestedWorkspace, irrlicht.CWD) {
-		v.add(rel, result.ScenarioID, "irrlicht_session.cwd", "does not match environment.requested_workspace")
+}
+
+func (v *validation) compareEnvironmentIdentity(rel, scenario string, identity observedIdentity) {
+	if identity.environmentOK && identity.irrlichtOK && !samePath(identity.environment.RequestedWorkspace, identity.irrlicht.CWD) {
+		v.add(rel, scenario, "irrlicht_session.cwd", "does not match environment.requested_workspace")
 	}
-	if processOK && irrlichtOK && process.PID != irrlicht.PID {
-		v.add(rel, result.ScenarioID, "process.pid", "does not match irrlicht_session.pid")
+}
+
+func (v *validation) compareProcessIdentity(rel, scenario string, identity observedIdentity) {
+	if identity.processOK && identity.irrlichtOK && identity.process.PID != identity.irrlicht.PID {
+		v.add(rel, scenario, "process.pid", "does not match irrlicht_session.pid")
 	}
-	_ = hooksOK // validation reports its own finding; no later join depends on it.
 }
 
 func (v *validation) resolveEvidenceFiles(rel, recordingDir string, result *Result) (evidenceFiles, bool) {
@@ -163,14 +197,27 @@ func (v *validation) validateManifest(rel, recordingDir, scenario string) (matri
 }
 
 func (v *validation) readTranscript(rel, scenario, path string) (transcriptIdentity, bool) {
-	f, err := os.Open(path)
+	identity, conflicts, err := scanTranscript(path)
 	if err != nil {
 		v.add(rel, scenario, "transcript", err.Error())
-		return transcriptIdentity{}, false
+		return identity, false
+	}
+	for _, field := range conflicts {
+		v.add(rel, scenario, "transcript."+field, "contains conflicting values")
+	}
+	ok := v.validateTranscriptFields(rel, scenario, identity)
+	return identity, ok && len(conflicts) == 0
+}
+
+func scanTranscript(path string) (transcriptIdentity, []string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return transcriptIdentity{}, nil, err
 	}
 	defer f.Close()
 	decoder := json.NewDecoder(f)
 	identity := transcriptIdentity{}
+	var conflicts []string
 	for {
 		var row struct {
 			SessionID  string `json:"sessionId"`
@@ -182,27 +229,36 @@ func (v *validation) readTranscript(rel, scenario, path string) (transcriptIdent
 			break
 		}
 		if err != nil {
-			v.add(rel, scenario, "transcript", "invalid JSONL: "+err.Error())
-			return identity, false
+			return identity, conflicts, fmt.Errorf("invalid JSONL: %w", err)
 		}
-		if !mergeIdentity(&identity.SessionID, row.SessionID) {
-			v.add(rel, scenario, "transcript.sessionId", "contains conflicting values")
-		}
-		if !mergeIdentity(&identity.CWD, row.CWD) {
-			v.add(rel, scenario, "transcript.cwd", "contains conflicting values")
-		}
-		if !mergeIdentity(&identity.Entrypoint, row.Entrypoint) {
-			v.add(rel, scenario, "transcript.entrypoint", "contains conflicting values")
-		}
+		conflicts = append(conflicts, mergeTranscriptRow(&identity, row.SessionID, row.CWD, row.Entrypoint)...)
 	}
+	return identity, conflicts, nil
+}
+
+func mergeTranscriptRow(identity *transcriptIdentity, sessionID, cwd, entrypoint string) []string {
+	var conflicts []string
+	if !mergeIdentity(&identity.SessionID, sessionID) {
+		conflicts = append(conflicts, "sessionId")
+	}
+	if !mergeIdentity(&identity.CWD, cwd) {
+		conflicts = append(conflicts, "cwd")
+	}
+	if !mergeIdentity(&identity.Entrypoint, entrypoint) {
+		conflicts = append(conflicts, "entrypoint")
+	}
+	return conflicts
+}
+
+func (v *validation) validateTranscriptFields(rel, scenario string, identity transcriptIdentity) bool {
 	ok := true
 	for field, value := range map[string]string{
-		"transcript.sessionId":  identity.SessionID,
-		"transcript.cwd":        identity.CWD,
-		"transcript.entrypoint": identity.Entrypoint,
+		"sessionId":  identity.SessionID,
+		"cwd":        identity.CWD,
+		"entrypoint": identity.Entrypoint,
 	} {
 		if strings.TrimSpace(value) == "" {
-			v.add(rel, scenario, field, "is absent from the raw transcript")
+			v.add(rel, scenario, "transcript."+field, "is absent from the raw transcript")
 			ok = false
 		}
 	}
@@ -210,7 +266,7 @@ func (v *validation) readTranscript(rel, scenario, path string) (transcriptIdent
 		v.add(rel, scenario, "transcript.entrypoint", fmt.Sprintf("got %q; want %q", identity.Entrypoint, desktopEntrypoint))
 		ok = false
 	}
-	return identity, ok
+	return ok
 }
 
 func (v *validation) readRegistry(rel, scenario, path string) (registryIdentity, bool) {
@@ -286,10 +342,24 @@ func (v *validation) readIrrlichtSession(rel, scenario, path string) (irrlichtSe
 }
 
 func (v *validation) validateHooks(rel, scenario, path, sessionID string) bool {
-	f, err := os.Open(path)
+	matched, consistent, err := scanHookSessions(path, sessionID)
 	if err != nil {
 		v.add(rel, scenario, "hooks", err.Error())
 		return false
+	}
+	if !matched {
+		v.add(rel, scenario, "hooks.session_id", "contains no raw hook for transcript.sessionId")
+	}
+	if !consistent {
+		v.add(rel, scenario, "hooks.session_id", "contains a hook from another session")
+	}
+	return matched && consistent
+}
+
+func scanHookSessions(path, sessionID string) (bool, bool, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return false, false, err
 	}
 	defer f.Close()
 	decoder := json.NewDecoder(f)
@@ -304,8 +374,7 @@ func (v *validation) validateHooks(rel, scenario, path, sessionID string) bool {
 			break
 		}
 		if err != nil {
-			v.add(rel, scenario, "hooks", "invalid JSONL: "+err.Error())
-			return false
+			return false, false, fmt.Errorf("invalid JSONL: %w", err)
 		}
 		if sessionID != "" && row.SessionID == sessionID {
 			matched = true
@@ -313,13 +382,7 @@ func (v *validation) validateHooks(rel, scenario, path, sessionID string) bool {
 			consistent = false
 		}
 	}
-	if !matched {
-		v.add(rel, scenario, "hooks.session_id", "contains no raw hook for transcript.sessionId")
-	}
-	if !consistent {
-		v.add(rel, scenario, "hooks.session_id", "contains a hook from another session")
-	}
-	return matched && consistent
+	return matched, consistent, nil
 }
 
 func (v *validation) readProcess(rel, scenario, path string) (processEvidence, bool) {

--- a/tools/onboarding-factory/internal/desktopresults/identity.go
+++ b/tools/onboarding-factory/internal/desktopresults/identity.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"irrlicht/tools/onboarding-factory/internal/matrix"
+	expectedvalidate "irrlicht/tools/onboarding-factory/internal/validate"
 )
 
 const (
@@ -79,6 +80,8 @@ func (v *validation) validateObservedEvidence(rel, cellDir string, result *Resul
 		v.add(rel, result.ScenarioID, "recording", err.Error())
 		return
 	}
+	v.validateRecordingCompleteness(rel, result.ScenarioID, recordingDir)
+	v.validateObservedOutcome(rel, cellDir, recordingDir, result)
 	files, ok := v.resolveEvidenceFiles(rel, recordingDir, result)
 	manifest, manifestOK := v.validateManifest(rel, recordingDir, result.ScenarioID)
 	if !ok || !manifestOK {
@@ -86,6 +89,31 @@ func (v *validation) validateObservedEvidence(rel, cellDir string, result *Resul
 	}
 	identity := v.readObservedIdentity(rel, result.ScenarioID, files, manifest)
 	v.compareObservedIdentity(rel, result.ScenarioID, identity)
+}
+
+func (v *validation) validateRecordingCompleteness(rel, scenario, recordingDir string) {
+	for _, finding := range expectedvalidate.RecordingComplete(recordingDir) {
+		v.add(rel, scenario, "recording completeness", finding)
+	}
+}
+
+func (v *validation) validateObservedOutcome(rel, cellDir, recordingDir string, result *Result) {
+	report, err := expectedvalidate.ValidateExpectedAgainst(
+		filepath.Join(cellDir, "expected.jsonl"),
+		filepath.Join(recordingDir, "events.jsonl"),
+	)
+	if err != nil {
+		v.add(rel, result.ScenarioID, "outcome", "cannot validate the exact recording: "+err.Error())
+		return
+	}
+	if report == nil {
+		v.add(rel, result.ScenarioID, "outcome", "exact recording has no expected-result report")
+		return
+	}
+	wantPass := result.Outcome == OutcomeObservedPassing
+	if report.Pass != wantPass {
+		v.add(rel, result.ScenarioID, "outcome", fmt.Sprintf("got %q for an expected-result pass value of %t", result.Outcome, report.Pass))
+	}
 }
 
 func (v *validation) readObservedIdentity(rel, scenario string, files evidenceFiles, manifest matrix.RecordingManifest) observedIdentity {
@@ -290,8 +318,8 @@ func (v *validation) readRegistry(rel, scenario, path string) (registryIdentity,
 		v.add(rel, scenario, "desktop_registry.sessionId", "must start with local_")
 		ok = false
 	}
-	if string(registry.EnvScopeID) != "null" {
-		v.add(rel, scenario, "desktop_registry.envScopeId", "must be explicit null for the Local environment")
+	if len(registry.EnvScopeID) > 0 && string(registry.EnvScopeID) != "null" {
+		v.add(rel, scenario, "desktop_registry.envScopeId", "must be absent or null for the project-local environment")
 		ok = false
 	}
 	return registry, ok
@@ -342,7 +370,7 @@ func (v *validation) readIrrlichtSession(rel, scenario, path string) (irrlichtSe
 }
 
 func (v *validation) validateHooks(rel, scenario, path, sessionID string) bool {
-	matched, consistent, err := scanHookSessions(path, sessionID)
+	matched, consistent, named, err := scanHookSessions(path, sessionID)
 	if err != nil {
 		v.add(rel, scenario, "hooks", err.Error())
 		return false
@@ -353,36 +381,44 @@ func (v *validation) validateHooks(rel, scenario, path, sessionID string) bool {
 	if !consistent {
 		v.add(rel, scenario, "hooks.session_id", "contains a hook from another session")
 	}
-	return matched && consistent
+	if !named {
+		v.add(rel, scenario, "hooks.hook_event_name", "must be nonblank on every raw hook")
+	}
+	return matched && consistent && named
 }
 
-func scanHookSessions(path, sessionID string) (bool, bool, error) {
+func scanHookSessions(path, sessionID string) (bool, bool, bool, error) {
 	f, err := os.Open(path)
 	if err != nil {
-		return false, false, err
+		return false, false, false, err
 	}
 	defer f.Close()
 	decoder := json.NewDecoder(f)
 	matched := false
 	consistent := true
+	named := true
 	for {
 		var row struct {
-			SessionID string `json:"session_id"`
+			SessionID     string `json:"session_id"`
+			HookEventName string `json:"hook_event_name"`
 		}
 		err := decoder.Decode(&row)
 		if err == io.EOF {
 			break
 		}
 		if err != nil {
-			return false, false, fmt.Errorf("invalid JSONL: %w", err)
+			return false, false, false, fmt.Errorf("invalid JSONL: %w", err)
 		}
 		if sessionID != "" && row.SessionID == sessionID {
 			matched = true
 		} else {
 			consistent = false
 		}
+		if strings.TrimSpace(row.HookEventName) == "" {
+			named = false
+		}
 	}
-	return matched, consistent, nil
+	return matched, consistent, named, nil
 }
 
 func (v *validation) readProcess(rel, scenario, path string) (processEvidence, bool) {

--- a/tools/onboarding-factory/internal/desktopresults/schema.go
+++ b/tools/onboarding-factory/internal/desktopresults/schema.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"io"
 	"os"
+
+	"irrlicht/tools/onboarding-factory/internal/matrix"
 )
 
 const (
@@ -16,25 +18,18 @@ const (
 	// SchemaVersion is the only accepted result artifact version.
 	SchemaVersion = 1
 
-	DesktopRegistryFile = "desktop-registry.json"
-	EnvironmentFile     = "desktop-environment.json"
-	HooksFile           = "hooks.jsonl"
-	ProcessFile         = "process.json"
-	IrrlichtSessionFile = "irrlicht-session.json"
-	TranscriptFile      = "transcript.jsonl"
+	DesktopRegistryFile = matrix.DesktopRegistryFile
+	EnvironmentFile     = matrix.DesktopEnvironmentFile
+	HooksFile           = matrix.DesktopHooksFile
+	ProcessFile         = matrix.DesktopProcessFile
+	IrrlichtSessionFile = matrix.DesktopIrrlichtSessionFile
+	TranscriptFile      = matrix.DesktopTranscriptFile
 )
 
 // RequiredRecordingFiles returns the raw evidence files every Desktop Local
 // recording must preserve, in stable order.
 func RequiredRecordingFiles() []string {
-	return []string{
-		DesktopRegistryFile,
-		EnvironmentFile,
-		HooksFile,
-		ProcessFile,
-		IrrlichtSessionFile,
-		TranscriptFile,
-	}
+	return matrix.DesktopEvidenceFiles()
 }
 
 type Outcome string

--- a/tools/onboarding-factory/internal/desktopresults/schema.go
+++ b/tools/onboarding-factory/internal/desktopresults/schema.go
@@ -1,0 +1,122 @@
+// Package desktopresults validates the explicit per-cell evidence contract for
+// Claude Code Desktop Local. It does not change the profile-neutral matrix: the
+// viewer and status commands can consume this contract in later issues.
+package desktopresults
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+)
+
+const (
+	// FileName is the result artifact stored beside metadata.json in each cell.
+	FileName = "execution-results.json"
+	// SchemaVersion is the only accepted result artifact version.
+	SchemaVersion = 1
+
+	DesktopRegistryFile = "desktop-registry.json"
+	EnvironmentFile     = "desktop-environment.json"
+	HooksFile           = "hooks.jsonl"
+	ProcessFile         = "process.json"
+	IrrlichtSessionFile = "irrlicht-session.json"
+	TranscriptFile      = "transcript.jsonl"
+)
+
+// RequiredRecordingFiles returns the raw evidence files every Desktop Local
+// recording must preserve, in stable order.
+func RequiredRecordingFiles() []string {
+	return []string{
+		DesktopRegistryFile,
+		EnvironmentFile,
+		HooksFile,
+		ProcessFile,
+		IrrlichtSessionFile,
+		TranscriptFile,
+	}
+}
+
+type Outcome string
+
+const (
+	OutcomeObservedPassing Outcome = "observed-passing"
+	OutcomeObservedFailure Outcome = "observed-failure"
+	OutcomeNotApplicable   Outcome = "not-applicable"
+	OutcomeUnobservable    Outcome = "unobservable"
+	OutcomeNotRunnable     Outcome = "not-runnable"
+)
+
+// Evidence names raw files within one exact recording directory. These are
+// references, not copied identity claims: validation reads every named file.
+type Evidence struct {
+	DesktopRegistry string `json:"desktop_registry"`
+	Transcript      string `json:"transcript"`
+	Hooks           string `json:"hooks"`
+	Process         string `json:"process"`
+	IrrlichtSession string `json:"irrlicht_session"`
+	Environment     string `json:"environment"`
+}
+
+// Result is one execution-profile answer for the cell named by ScenarioID.
+type Result struct {
+	ScenarioID       string    `json:"scenario_id"`
+	ExecutionProfile string    `json:"execution_profile"`
+	Outcome          Outcome   `json:"outcome"`
+	Recording        string    `json:"recording,omitempty"`
+	Reason           string    `json:"reason,omitempty"`
+	MissingControl   string    `json:"missing_control,omitempty"`
+	Evidence         *Evidence `json:"evidence,omitempty"`
+	EvidenceRefs     []string  `json:"evidence_refs,omitempty"`
+}
+
+// Document is one versioned per-cell execution-results.json artifact.
+type Document struct {
+	SchemaVersion int      `json:"schema_version"`
+	Results       []Result `json:"results"`
+}
+
+// Load reads one result artifact with its closed schema.
+func Load(path string) (Document, error) {
+	var doc Document
+	if err := decodeStrict(path, &doc); err != nil {
+		return Document{}, err
+	}
+	return doc, nil
+}
+
+func decodeStrict(path string, value any) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	decoder := json.NewDecoder(f)
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(value); err != nil {
+		return err
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); err != io.EOF {
+		if err == nil {
+			return fmt.Errorf("multiple JSON values")
+		}
+		return fmt.Errorf("trailing data: %w", err)
+	}
+	return nil
+}
+
+func knownOutcome(outcome Outcome) bool {
+	switch outcome {
+	case OutcomeObservedPassing, OutcomeObservedFailure, OutcomeNotApplicable,
+		OutcomeUnobservable, OutcomeNotRunnable:
+		return true
+	default:
+		return false
+	}
+}
+
+func observedOutcome(outcome Outcome) bool {
+	return outcome == OutcomeObservedPassing || outcome == OutcomeObservedFailure
+}

--- a/tools/onboarding-factory/internal/desktopresults/validate.go
+++ b/tools/onboarding-factory/internal/desktopresults/validate.go
@@ -277,6 +277,11 @@ func (v *validation) validateCanonicalEvidenceNames(rel string, result *Result) 
 }
 
 func (v *validation) validateNonObservedShape(rel string, result *Result) {
+	v.validateNonObservedEvidence(rel, result)
+	v.validateNonObservedExclusions(rel, result)
+}
+
+func (v *validation) validateNonObservedEvidence(rel string, result *Result) {
 	if strings.TrimSpace(result.Reason) == "" {
 		v.add(rel, result.ScenarioID, "reason", "must contain an evidence-based reason")
 	}
@@ -289,6 +294,9 @@ func (v *validation) validateNonObservedShape(rel string, result *Result) {
 			v.add(rel, result.ScenarioID, field, err.Error())
 		}
 	}
+}
+
+func (v *validation) validateNonObservedExclusions(rel string, result *Result) {
 	if result.Recording != "" {
 		v.add(rel, result.ScenarioID, "recording", "is only valid for an observed result")
 	}
@@ -338,12 +346,66 @@ func safeSegment(value string) bool {
 	return value != "" && value != "." && value != ".." && filepath.Base(value) == value
 }
 
+type resolvedPath struct {
+	path string
+	info os.FileInfo
+}
+
 // resolveFile accepts only an existing, non-empty regular file below root.
 // EvalSymlinks makes a repository-relative reference unable to escape through
 // a committed or locally-created symlink.
 func resolveFile(root, reference string) (string, error) {
+	resolved, err := resolveExisting(root, reference)
+	if err != nil {
+		return "", err
+	}
+	if !resolved.info.Mode().IsRegular() || resolved.info.Size() == 0 {
+		return "", fmt.Errorf("reference %q must name a non-empty regular file", reference)
+	}
+	return resolved.path, nil
+}
+
+func resolveDirectory(root, reference string) (string, error) {
+	if !safeSegment(reference) {
+		return "", fmt.Errorf("must be one safe directory name")
+	}
+	resolved, err := resolveExisting(root, reference)
+	if err != nil {
+		return "", fmt.Errorf("cannot resolve recording %q: %w", reference, err)
+	}
+	if !resolved.info.IsDir() {
+		return "", fmt.Errorf("recording %q must name a directory", reference)
+	}
+	return resolved.path, nil
+}
+
+func resolveExisting(root, reference string) (resolvedPath, error) {
+	clean, err := cleanReference(reference)
+	if err != nil {
+		return resolvedPath{}, err
+	}
+	rootResolved, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		return resolvedPath{}, fmt.Errorf("cannot resolve evidence root: %w", err)
+	}
+	resolved, err := filepath.EvalSymlinks(filepath.Join(root, clean))
+	if err != nil {
+		return resolvedPath{}, fmt.Errorf("cannot read %q: %w", reference, err)
+	}
+	rel, err := filepath.Rel(rootResolved, resolved)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return resolvedPath{}, fmt.Errorf("reference %q escapes its evidence root", reference)
+	}
+	info, err := os.Stat(resolved)
+	if err != nil {
+		return resolvedPath{}, fmt.Errorf("cannot read %q: %w", reference, err)
+	}
+	return resolvedPath{path: resolved, info: info}, nil
+}
+
+func cleanReference(reference string) (string, error) {
 	if reference == "" || filepath.IsAbs(reference) {
-		return "", fmt.Errorf("must be a non-empty relative file path")
+		return "", fmt.Errorf("must be a non-empty relative path")
 	}
 	native := filepath.FromSlash(reference)
 	clean := filepath.Clean(native)
@@ -353,48 +415,5 @@ func resolveFile(root, reference string) (string, error) {
 	if clean != native {
 		return "", fmt.Errorf("must not contain traversal or redundant path components")
 	}
-	rootResolved, err := filepath.EvalSymlinks(root)
-	if err != nil {
-		return "", fmt.Errorf("cannot resolve evidence root: %w", err)
-	}
-	path := filepath.Join(root, clean)
-	resolved, err := filepath.EvalSymlinks(path)
-	if err != nil {
-		return "", fmt.Errorf("cannot read %q: %w", reference, err)
-	}
-	rel, err := filepath.Rel(rootResolved, resolved)
-	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
-		return "", fmt.Errorf("reference %q escapes its evidence root", reference)
-	}
-	info, err := os.Stat(resolved)
-	if err != nil {
-		return "", fmt.Errorf("cannot read %q: %w", reference, err)
-	}
-	if !info.Mode().IsRegular() || info.Size() == 0 {
-		return "", fmt.Errorf("reference %q must name a non-empty regular file", reference)
-	}
-	return resolved, nil
-}
-
-func resolveDirectory(root, reference string) (string, error) {
-	if !safeSegment(reference) {
-		return "", fmt.Errorf("must be one safe directory name")
-	}
-	rootResolved, err := filepath.EvalSymlinks(root)
-	if err != nil {
-		return "", fmt.Errorf("cannot resolve recordings directory: %w", err)
-	}
-	resolved, err := filepath.EvalSymlinks(filepath.Join(root, reference))
-	if err != nil {
-		return "", fmt.Errorf("cannot read recording %q: %w", reference, err)
-	}
-	rel, err := filepath.Rel(rootResolved, resolved)
-	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
-		return "", fmt.Errorf("recording %q escapes the recordings directory", reference)
-	}
-	info, err := os.Stat(resolved)
-	if err != nil || !info.IsDir() {
-		return "", fmt.Errorf("recording %q must name a directory", reference)
-	}
-	return resolved, nil
+	return clean, nil
 }

--- a/tools/onboarding-factory/internal/desktopresults/validate.go
+++ b/tools/onboarding-factory/internal/desktopresults/validate.go
@@ -36,6 +36,7 @@ type validation struct {
 	repoRoot       string
 	catalog        map[string]bool
 	claudeCells    map[string]bool
+	canonicalCells map[string]string
 	resultCount    map[string]int
 	requireDesktop bool
 	findings       []Finding
@@ -46,10 +47,11 @@ type validation struct {
 // exactly one result for every current catalog scenario.
 func ValidateRepo(repoRoot string) []Finding {
 	v := &validation{
-		repoRoot:    repoRoot,
-		catalog:     map[string]bool{},
-		claudeCells: map[string]bool{},
-		resultCount: map[string]int{},
+		repoRoot:       repoRoot,
+		catalog:        map[string]bool{},
+		claudeCells:    map[string]bool{},
+		canonicalCells: map[string]string{},
+		resultCount:    map[string]int{},
 	}
 	v.loadCatalog()
 	v.scanResultFiles()
@@ -134,6 +136,7 @@ func (v *validation) validateRequiredProfileList(adapter string, profiles []stri
 
 func (v *validation) scanResultFiles() {
 	root := filepath.Join(v.repoRoot, "replaydata", "agents", claudeAdapter)
+	var resultFiles []string
 	err := filepath.WalkDir(root, func(path string, entry iofs.DirEntry, walkErr error) error {
 		if walkErr != nil {
 			v.add(v.rel(path), "unknown", "scan", walkErr.Error())
@@ -146,12 +149,15 @@ func (v *validation) scanResultFiles() {
 		case "metadata.json":
 			v.registerClaudeCell(root, path)
 		case FileName:
-			v.validateResultFile(path)
+			resultFiles = append(resultFiles, path)
 		}
 		return nil
 	})
 	if err != nil && !os.IsNotExist(err) {
 		v.add(v.rel(root), "unknown", "scan", err.Error())
+	}
+	for _, path := range resultFiles {
+		v.validateResultFile(path)
 	}
 }
 
@@ -167,39 +173,60 @@ func (v *validation) registerClaudeCell(root, path string) {
 	scenario := metadataScenarioID(filepath.Dir(path))
 	if v.catalog[scenario] {
 		v.claudeCells[scenario] = true
+		v.canonicalCells[filepath.Clean(filepath.Dir(path))] = scenario
 	}
 }
 
 func (v *validation) validateResultFile(path string) {
 	rel := v.rel(path)
-	expectedScenario := metadataScenarioID(filepath.Dir(path))
-	if _, err := resolveFile(v.repoRoot, rel); err != nil {
-		v.add(rel, expectedScenario, "document", err.Error())
+	cellDir := filepath.Clean(filepath.Dir(path))
+	expectedScenario := metadataScenarioID(cellDir)
+	canonicalScenario, canonical := v.canonicalCells[cellDir]
+	if !canonical {
+		v.add(rel, expectedScenario, "document location", "must be the direct child of a current Claude Code cell")
+	}
+	doc, ok := v.loadResultDocument(path, rel, expectedScenario)
+	if !ok {
 		return
+	}
+	v.validateResults(rel, cellDir, expectedScenario, canonicalScenario, canonical, doc.Results)
+}
+
+func (v *validation) loadResultDocument(path, rel, scenario string) (Document, bool) {
+	if _, err := resolveFile(v.repoRoot, rel); err != nil {
+		v.add(rel, scenario, "document", err.Error())
+		return Document{}, false
 	}
 	doc, err := Load(path)
 	if err != nil {
-		v.add(rel, expectedScenario, "document", "invalid or unknown field: "+err.Error())
-		return
+		v.add(rel, scenario, "document", "invalid or unknown field: "+err.Error())
+		return Document{}, false
 	}
 	if doc.SchemaVersion != SchemaVersion {
-		v.add(rel, expectedScenario, "schema_version", fmt.Sprintf("got %d; want %d", doc.SchemaVersion, SchemaVersion))
+		v.add(rel, scenario, "schema_version", fmt.Sprintf("got %d; want %d", doc.SchemaVersion, SchemaVersion))
 	}
 	if len(doc.Results) == 0 {
-		v.add(rel, expectedScenario, "results", "must contain at least one result")
-		return
+		v.add(rel, scenario, "results", "must contain at least one result")
+		return doc, false
 	}
+	return doc, true
+}
+
+func (v *validation) validateResults(rel, cellDir, expectedScenario, canonicalScenario string, canonical bool, results []Result) {
 	seenProfile := map[string]bool{}
-	for i := range doc.Results {
-		result := &doc.Results[i]
-		v.validateResult(rel, filepath.Dir(path), expectedScenario, result)
-		if result.ExecutionProfile == string(matrix.ProfileDesktopLocal) {
-			v.resultCount[result.ScenarioID]++
-			if seenProfile[result.ExecutionProfile] {
-				v.add(rel, result.ScenarioID, "results", "duplicate desktop-local result")
-			}
-			seenProfile[result.ExecutionProfile] = true
+	for i := range results {
+		result := &results[i]
+		v.validateResult(rel, cellDir, expectedScenario, result)
+		if result.ExecutionProfile != string(matrix.ProfileDesktopLocal) {
+			continue
 		}
+		if canonical && result.ScenarioID == canonicalScenario {
+			v.resultCount[result.ScenarioID]++
+		}
+		if seenProfile[result.ExecutionProfile] {
+			v.add(rel, result.ScenarioID, "results", "duplicate desktop-local result")
+		}
+		seenProfile[result.ExecutionProfile] = true
 	}
 }
 
@@ -325,15 +352,14 @@ func (v *validation) validateNonObservedEvidence(rel, cellDir string, result *Re
 
 // allowedNonObservedEvidence checks only a reference's stable scope. It does
 // not claim that prose proves the result. Campaign evidence must be the cell's
-// metadata, a file under its desktop-evidence directory, a repository doc, or
-// a shared raw probe under replaydata/agents/claudecode/desktop-evidence.
+// metadata, a file under its desktop-evidence directory, or a shared raw probe
+// under replaydata/agents/claudecode/desktop-evidence.
 func (v *validation) allowedNonObservedEvidence(cellDir, resolved string) bool {
 	if sameResolvedFile(resolved, filepath.Join(cellDir, "metadata.json")) {
 		return true
 	}
 	for _, root := range []string{
 		filepath.Join(cellDir, "desktop-evidence"),
-		filepath.Join(v.repoRoot, "docs"),
 		filepath.Join(v.repoRoot, "replaydata", "agents", claudeAdapter, "desktop-evidence"),
 	} {
 		if resolvedWithinExisting(root, resolved) {

--- a/tools/onboarding-factory/internal/desktopresults/validate.go
+++ b/tools/onboarding-factory/internal/desktopresults/validate.go
@@ -15,6 +15,7 @@ import (
 const (
 	claudeAdapter = "claudecode"
 	resultsSwitch = "required_execution_profiles_by_agent"
+	metadataFile  = "metadata.json"
 )
 
 // Finding locates one invalid result or one broken evidence edge.
@@ -30,6 +31,30 @@ type catalogScenario struct {
 type catalogDocument struct {
 	Meta      map[string]json.RawMessage `json:"meta"`
 	Scenarios []catalogScenario          `json:"scenarios"`
+}
+
+type requiredProfilesInput struct {
+	raw  json.RawMessage
+	path string
+}
+
+type requiredProfileList struct {
+	adapter  string
+	profiles []string
+	path     string
+}
+
+type cellCandidate struct {
+	root string
+	path string
+}
+
+type resultFileContext struct {
+	rel               string
+	cellDir           string
+	expectedScenario  string
+	canonicalScenario string
+	canonical         bool
 }
 
 type validation struct {
@@ -87,46 +112,60 @@ func (v *validation) loadCatalog() {
 			v.catalog[scenario.Name] = true
 		}
 	}
-	v.validateRequiredProfiles(catalog.Meta[resultsSwitch], path)
+	v.validateRequiredProfiles(requiredProfilesInput{raw: catalog.Meta[resultsSwitch], path: path})
 }
 
-func (v *validation) validateRequiredProfiles(raw json.RawMessage, path string) {
-	if len(raw) == 0 {
+func (v *validation) validateRequiredProfiles(input requiredProfilesInput) {
+	if len(input.raw) == 0 {
 		return // absence is the legacy CLI-only compatibility contract.
 	}
-	var required map[string][]string
-	if string(raw) == "null" || json.Unmarshal(raw, &required) != nil || len(required) == 0 {
-		v.add(v.rel(path), "catalog", "meta."+resultsSwitch, "must be a non-empty object")
+	required, err := decodeRequiredProfiles(input.raw)
+	if err != nil {
+		v.add(v.rel(input.path), "catalog", "meta."+resultsSwitch, err.Error())
 		return
 	}
 	for adapter, profiles := range required {
-		v.validateRequiredProfileList(adapter, profiles, path)
+		v.validateRequiredProfileList(requiredProfileList{adapter: adapter, profiles: profiles, path: input.path})
 	}
 }
 
-func (v *validation) validateRequiredProfileList(adapter string, profiles []string, path string) {
-	field := "meta." + resultsSwitch + "." + adapter
-	if adapter != claudeAdapter {
-		v.add(v.rel(path), "catalog", field, "Desktop result completeness is only supported for claudecode")
+func decodeRequiredProfiles(raw json.RawMessage) (map[string][]string, error) {
+	if string(raw) == "null" {
+		return nil, fmt.Errorf("must be a non-empty object")
+	}
+	var required map[string][]string
+	if err := json.Unmarshal(raw, &required); err != nil {
+		return nil, fmt.Errorf("must be a non-empty object")
+	}
+	if len(required) == 0 {
+		return nil, fmt.Errorf("must be a non-empty object")
+	}
+	return required, nil
+}
+
+func (v *validation) validateRequiredProfileList(input requiredProfileList) {
+	field := "meta." + resultsSwitch + "." + input.adapter
+	if input.adapter != claudeAdapter {
+		v.add(v.rel(input.path), "catalog", field, "Desktop result completeness is only supported for claudecode")
 		return
 	}
-	if len(profiles) == 0 {
-		v.add(v.rel(path), "catalog", field, "must contain at least one profile")
+	if len(input.profiles) == 0 {
+		v.add(v.rel(input.path), "catalog", field, "must contain at least one profile")
 		return
 	}
 	seen := map[matrix.ExecutionProfile]bool{}
-	for _, value := range profiles {
+	for _, value := range input.profiles {
 		profile, err := matrix.ParseExecutionProfile(value)
 		if err != nil {
-			v.add(v.rel(path), "catalog", field, err.Error())
+			v.add(v.rel(input.path), "catalog", field, err.Error())
 			continue
 		}
 		if profile != matrix.ProfileDesktopLocal {
-			v.add(v.rel(path), "catalog", field, "only desktop-local can be required by this result contract")
+			v.add(v.rel(input.path), "catalog", field, "only desktop-local can be required by this result contract")
 			continue
 		}
 		if seen[profile] {
-			v.add(v.rel(path), "catalog", field, "contains duplicate desktop-local")
+			v.add(v.rel(input.path), "catalog", field, "contains duplicate desktop-local")
 			continue
 		}
 		seen[profile] = true
@@ -146,8 +185,8 @@ func (v *validation) scanResultFiles() {
 			return nil
 		}
 		switch entry.Name() {
-		case "metadata.json":
-			v.registerClaudeCell(root, path)
+		case metadataFile:
+			v.registerClaudeCell(cellCandidate{root: root, path: path})
 		case FileName:
 			resultFiles = append(resultFiles, path)
 		}
@@ -161,20 +200,30 @@ func (v *validation) scanResultFiles() {
 	}
 }
 
-func (v *validation) registerClaudeCell(root, path string) {
-	rel, err := filepath.Rel(root, path)
+func (v *validation) registerClaudeCell(candidate cellCandidate) {
+	rel, err := filepath.Rel(candidate.root, candidate.path)
 	if err != nil {
 		return
 	}
 	parts := strings.Split(filepath.ToSlash(rel), "/")
-	if len(parts) != 3 || parts[0] != "scenarios" || parts[2] != "metadata.json" {
+	if !isCanonicalCellMetadata(parts) {
 		return
 	}
-	scenario := metadataScenarioID(filepath.Dir(path))
+	scenario := metadataScenarioID(filepath.Dir(candidate.path))
 	if v.catalog[scenario] {
 		v.claudeCells[scenario] = true
-		v.canonicalCells[filepath.Clean(filepath.Dir(path))] = scenario
+		v.canonicalCells[filepath.Clean(filepath.Dir(candidate.path))] = scenario
 	}
+}
+
+func isCanonicalCellMetadata(parts []string) bool {
+	if len(parts) != 3 {
+		return false
+	}
+	if parts[0] != "scenarios" {
+		return false
+	}
+	return parts[2] == metadataFile
 }
 
 func (v *validation) validateResultFile(path string) {
@@ -189,7 +238,14 @@ func (v *validation) validateResultFile(path string) {
 	if !ok {
 		return
 	}
-	v.validateResults(rel, cellDir, expectedScenario, canonicalScenario, canonical, doc.Results)
+	context := resultFileContext{
+		rel:               rel,
+		cellDir:           cellDir,
+		expectedScenario:  expectedScenario,
+		canonicalScenario: canonicalScenario,
+		canonical:         canonical,
+	}
+	v.validateResults(context, doc.Results)
 }
 
 func (v *validation) loadResultDocument(path, rel, scenario string) (Document, bool) {
@@ -212,26 +268,26 @@ func (v *validation) loadResultDocument(path, rel, scenario string) (Document, b
 	return doc, true
 }
 
-func (v *validation) validateResults(rel, cellDir, expectedScenario, canonicalScenario string, canonical bool, results []Result) {
+func (v *validation) validateResults(context resultFileContext, results []Result) {
 	seenProfile := map[string]bool{}
 	for i := range results {
 		result := &results[i]
-		v.validateResult(rel, cellDir, expectedScenario, result)
+		v.validateResult(context, result)
 		if result.ExecutionProfile != string(matrix.ProfileDesktopLocal) {
 			continue
 		}
-		if canonical && result.ScenarioID == canonicalScenario {
+		if context.canonical && result.ScenarioID == context.canonicalScenario {
 			v.resultCount[result.ScenarioID]++
 		}
 		if seenProfile[result.ExecutionProfile] {
-			v.add(rel, result.ScenarioID, "results", "duplicate desktop-local result")
+			v.add(context.rel, result.ScenarioID, "results", "duplicate desktop-local result")
 		}
 		seenProfile[result.ExecutionProfile] = true
 	}
 }
 
 func metadataScenarioID(cellDir string) string {
-	b, err := os.ReadFile(filepath.Join(cellDir, "metadata.json"))
+	b, err := os.ReadFile(filepath.Join(cellDir, metadataFile))
 	if err != nil {
 		return ""
 	}
@@ -244,24 +300,24 @@ func metadataScenarioID(cellDir string) string {
 	return metadata.ScenarioID
 }
 
-func (v *validation) validateResult(rel, cellDir, expectedScenario string, result *Result) {
+func (v *validation) validateResult(context resultFileContext, result *Result) {
 	scenario := result.ScenarioID
-	v.validateScenario(rel, expectedScenario, scenario)
+	v.validateScenario(context.rel, context.expectedScenario, scenario)
 	profile, err := matrix.ParseExecutionProfile(result.ExecutionProfile)
 	if err != nil {
-		v.add(rel, scenario, "execution_profile", err.Error())
+		v.add(context.rel, scenario, "execution_profile", err.Error())
 	} else if profile != matrix.ProfileDesktopLocal {
-		v.add(rel, scenario, "execution_profile", "result files support only desktop-local")
+		v.add(context.rel, scenario, "execution_profile", "result files support only desktop-local")
 	}
 	if !knownOutcome(result.Outcome) {
-		v.add(rel, scenario, "outcome", fmt.Sprintf("unknown outcome %q", result.Outcome))
+		v.add(context.rel, scenario, "outcome", fmt.Sprintf("unknown outcome %q", result.Outcome))
 		return
 	}
 	if observedOutcome(result.Outcome) {
-		v.validateObservedShape(rel, cellDir, result)
+		v.validateObservedShape(context.rel, context.cellDir, result)
 		return
 	}
-	v.validateNonObservedShape(rel, cellDir, result)
+	v.validateNonObservedShape(context.rel, context.cellDir, result)
 }
 
 func (v *validation) validateScenario(rel, expected, actual string) {
@@ -355,7 +411,7 @@ func (v *validation) validateNonObservedEvidence(rel, cellDir string, result *Re
 // metadata, a file under its desktop-evidence directory, or a shared raw probe
 // under replaydata/agents/claudecode/desktop-evidence.
 func (v *validation) allowedNonObservedEvidence(cellDir, resolved string) bool {
-	if sameResolvedFile(resolved, filepath.Join(cellDir, "metadata.json")) {
+	if sameResolvedFile(resolved, filepath.Join(cellDir, metadataFile)) {
 		return true
 	}
 	for _, root := range []string{
@@ -386,25 +442,31 @@ func (v *validation) validateNonObservedExclusions(rel string, result *Result) {
 }
 
 func (v *validation) validateCompleteness() {
+	v.validateDuplicateResults()
+	if v.requireDesktop {
+		v.validateRequiredResults()
+	}
+}
+
+func (v *validation) validateDuplicateResults() {
 	for scenario, count := range v.resultCount {
 		if count > 1 {
-			path := filepath.Join("replaydata", "agents", claudeAdapter, "scenarios")
-			v.add(path, scenario, "completeness", fmt.Sprintf("duplicate desktop-local result: found %d entries", count))
+			v.add(resultCellsPath(), scenario, "completeness", fmt.Sprintf("duplicate desktop-local result: found %d entries", count))
 		}
 	}
-	if !v.requireDesktop {
-		return
-	}
+}
+
+func (v *validation) validateRequiredResults() {
 	for scenario := range v.claudeCells {
 		count := v.resultCount[scenario]
-		if count == 1 {
-			continue
-		}
-		path := filepath.Join("replaydata", "agents", claudeAdapter, "scenarios")
 		if count == 0 {
-			v.add(path, scenario, "completeness", "missing desktop-local result")
+			v.add(resultCellsPath(), scenario, "completeness", "missing desktop-local result")
 		}
 	}
+}
+
+func resultCellsPath() string {
+	return filepath.Join("replaydata", "agents", claudeAdapter, "scenarios")
 }
 
 func sameResolvedFile(left, right string) bool {
@@ -480,7 +542,10 @@ func resolveExisting(root, reference string) (resolvedPath, error) {
 		return resolvedPath{}, fmt.Errorf("cannot read %q: %w", reference, err)
 	}
 	rel, err := filepath.Rel(rootResolved, resolved)
-	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+	if err != nil {
+		return resolvedPath{}, fmt.Errorf("cannot compare evidence root and reference: %w", err)
+	}
+	if escapesRoot(rel) {
 		return resolvedPath{}, fmt.Errorf("reference %q escapes its evidence root", reference)
 	}
 	info, err := os.Stat(resolved)
@@ -490,13 +555,26 @@ func resolveExisting(root, reference string) (resolvedPath, error) {
 	return resolvedPath{path: resolved, info: info}, nil
 }
 
+func escapesRoot(rel string) bool {
+	if rel == ".." {
+		return true
+	}
+	return strings.HasPrefix(rel, ".."+string(filepath.Separator))
+}
+
 func cleanReference(reference string) (string, error) {
-	if reference == "" || filepath.IsAbs(reference) {
+	if reference == "" {
+		return "", fmt.Errorf("must be a non-empty relative path")
+	}
+	if filepath.IsAbs(reference) {
 		return "", fmt.Errorf("must be a non-empty relative path")
 	}
 	native := filepath.FromSlash(reference)
 	clean := filepath.Clean(native)
-	if clean == "." || clean == ".." || strings.HasPrefix(clean, ".."+string(filepath.Separator)) {
+	if clean == "." {
+		return "", fmt.Errorf("must not traverse outside its evidence root")
+	}
+	if escapesRoot(clean) {
 		return "", fmt.Errorf("must not traverse outside its evidence root")
 	}
 	if clean != native {

--- a/tools/onboarding-factory/internal/desktopresults/validate.go
+++ b/tools/onboarding-factory/internal/desktopresults/validate.go
@@ -1,0 +1,400 @@
+package desktopresults
+
+import (
+	"encoding/json"
+	"fmt"
+	iofs "io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"irrlicht/tools/onboarding-factory/internal/matrix"
+)
+
+const (
+	claudeAdapter = "claudecode"
+	resultsSwitch = "required_execution_profiles_by_agent"
+)
+
+// Finding locates one invalid result or one broken evidence edge.
+type Finding struct {
+	Path    string
+	Message string
+}
+
+type catalogScenario struct {
+	Name string `json:"name"`
+}
+
+type catalogDocument struct {
+	Meta      map[string]json.RawMessage `json:"meta"`
+	Scenarios []catalogScenario          `json:"scenarios"`
+}
+
+type validation struct {
+	repoRoot       string
+	catalog        map[string]bool
+	resultCount    map[string]int
+	requireDesktop bool
+	findings       []Finding
+}
+
+// ValidateRepo validates every present Claude Desktop result independently of
+// cell metadata. If the catalog enables Desktop completeness, it also requires
+// exactly one result for every current catalog scenario.
+func ValidateRepo(repoRoot string) []Finding {
+	v := &validation{
+		repoRoot:    repoRoot,
+		catalog:     map[string]bool{},
+		resultCount: map[string]int{},
+	}
+	v.loadCatalog()
+	v.scanResultFiles()
+	v.validateCompleteness()
+	sort.Slice(v.findings, func(i, j int) bool {
+		if v.findings[i].Path != v.findings[j].Path {
+			return v.findings[i].Path < v.findings[j].Path
+		}
+		return v.findings[i].Message < v.findings[j].Message
+	})
+	return v.findings
+}
+
+func (v *validation) add(path, scenario, field, message string) {
+	if scenario == "" {
+		scenario = "unknown"
+	}
+	v.findings = append(v.findings, Finding{
+		Path:    filepath.ToSlash(path),
+		Message: fmt.Sprintf("scenario_id %q: %s: %s", scenario, field, message),
+	})
+}
+
+func (v *validation) loadCatalog() {
+	path := filepath.Join(v.repoRoot, "replaydata", "agents", "scenarios.json")
+	var catalog catalogDocument
+	b, err := os.ReadFile(path)
+	if err != nil || json.Unmarshal(b, &catalog) != nil {
+		return // cmd/of's catalog validator owns this primary parse failure.
+	}
+	for _, scenario := range catalog.Scenarios {
+		if scenario.Name != "" {
+			v.catalog[scenario.Name] = true
+		}
+	}
+	v.validateRequiredProfiles(catalog.Meta[resultsSwitch], path)
+}
+
+func (v *validation) validateRequiredProfiles(raw json.RawMessage, path string) {
+	if len(raw) == 0 {
+		return // absence is the legacy CLI-only compatibility contract.
+	}
+	var required map[string][]string
+	if string(raw) == "null" || json.Unmarshal(raw, &required) != nil || len(required) == 0 {
+		v.add(v.rel(path), "catalog", "meta."+resultsSwitch, "must be a non-empty object")
+		return
+	}
+	for adapter, profiles := range required {
+		v.validateRequiredProfileList(adapter, profiles, path)
+	}
+}
+
+func (v *validation) validateRequiredProfileList(adapter string, profiles []string, path string) {
+	field := "meta." + resultsSwitch + "." + adapter
+	if adapter != claudeAdapter {
+		v.add(v.rel(path), "catalog", field, "Desktop result completeness is only supported for claudecode")
+		return
+	}
+	if len(profiles) == 0 {
+		v.add(v.rel(path), "catalog", field, "must contain at least one profile")
+		return
+	}
+	seen := map[matrix.ExecutionProfile]bool{}
+	for _, value := range profiles {
+		profile, err := matrix.ParseExecutionProfile(value)
+		if err != nil {
+			v.add(v.rel(path), "catalog", field, err.Error())
+			continue
+		}
+		if profile != matrix.ProfileDesktopLocal {
+			v.add(v.rel(path), "catalog", field, "only desktop-local can be required by this result contract")
+			continue
+		}
+		if seen[profile] {
+			v.add(v.rel(path), "catalog", field, "contains duplicate desktop-local")
+			continue
+		}
+		seen[profile] = true
+		v.requireDesktop = true
+	}
+}
+
+func (v *validation) scanResultFiles() {
+	root := filepath.Join(v.repoRoot, "replaydata", "agents", claudeAdapter)
+	err := filepath.WalkDir(root, func(path string, entry iofs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			v.add(v.rel(path), "unknown", "scan", walkErr.Error())
+			return nil
+		}
+		if entry.IsDir() || entry.Name() != FileName {
+			return nil
+		}
+		v.validateResultFile(path)
+		return nil
+	})
+	if err != nil && !os.IsNotExist(err) {
+		v.add(v.rel(root), "unknown", "scan", err.Error())
+	}
+}
+
+func (v *validation) validateResultFile(path string) {
+	rel := v.rel(path)
+	expectedScenario := metadataScenarioID(filepath.Dir(path))
+	if _, err := resolveFile(v.repoRoot, rel); err != nil {
+		v.add(rel, expectedScenario, "document", err.Error())
+		return
+	}
+	doc, err := Load(path)
+	if err != nil {
+		v.add(rel, expectedScenario, "document", "invalid or unknown field: "+err.Error())
+		return
+	}
+	if doc.SchemaVersion != SchemaVersion {
+		v.add(rel, expectedScenario, "schema_version", fmt.Sprintf("got %d; want %d", doc.SchemaVersion, SchemaVersion))
+	}
+	if len(doc.Results) == 0 {
+		v.add(rel, expectedScenario, "results", "must contain at least one result")
+		return
+	}
+	seenProfile := map[string]bool{}
+	for i := range doc.Results {
+		result := &doc.Results[i]
+		v.validateResult(rel, filepath.Dir(path), expectedScenario, result)
+		if result.ExecutionProfile == string(matrix.ProfileDesktopLocal) {
+			v.resultCount[result.ScenarioID]++
+			if seenProfile[result.ExecutionProfile] {
+				v.add(rel, result.ScenarioID, "results", "duplicate desktop-local result")
+			}
+			seenProfile[result.ExecutionProfile] = true
+		}
+	}
+}
+
+func metadataScenarioID(cellDir string) string {
+	b, err := os.ReadFile(filepath.Join(cellDir, "metadata.json"))
+	if err != nil {
+		return ""
+	}
+	var metadata struct {
+		ScenarioID string `json:"scenario_id"`
+	}
+	if json.Unmarshal(b, &metadata) != nil {
+		return ""
+	}
+	return metadata.ScenarioID
+}
+
+func (v *validation) validateResult(rel, cellDir, expectedScenario string, result *Result) {
+	scenario := result.ScenarioID
+	v.validateScenario(rel, expectedScenario, scenario)
+	profile, err := matrix.ParseExecutionProfile(result.ExecutionProfile)
+	if err != nil {
+		v.add(rel, scenario, "execution_profile", err.Error())
+	} else if profile != matrix.ProfileDesktopLocal {
+		v.add(rel, scenario, "execution_profile", "result files support only desktop-local")
+	}
+	if !knownOutcome(result.Outcome) {
+		v.add(rel, scenario, "outcome", fmt.Sprintf("unknown outcome %q", result.Outcome))
+		return
+	}
+	if observedOutcome(result.Outcome) {
+		v.validateObservedShape(rel, cellDir, result)
+		return
+	}
+	v.validateNonObservedShape(rel, result)
+}
+
+func (v *validation) validateScenario(rel, expected, actual string) {
+	if strings.TrimSpace(actual) == "" {
+		v.add(rel, expected, "scenario_id", "must not be blank")
+		return
+	}
+	if !v.catalog[actual] {
+		v.add(rel, actual, "scenario_id", "does not name a current catalog scenario")
+	}
+	if expected == "" {
+		v.add(rel, actual, "scenario_id", "cannot match result to a valid sibling metadata.json")
+	} else if actual != expected {
+		v.add(rel, actual, "scenario_id", fmt.Sprintf("does not match cell metadata scenario_id %q", expected))
+	}
+}
+
+func (v *validation) validateObservedShape(rel, cellDir string, result *Result) {
+	if !safeSegment(result.Recording) {
+		v.add(rel, result.ScenarioID, "recording", "must be one safe recording directory name")
+		return
+	}
+	if result.Evidence == nil {
+		v.add(rel, result.ScenarioID, "evidence", "is required for an observed result")
+		return
+	}
+	v.validateCanonicalEvidenceNames(rel, result)
+	if len(result.EvidenceRefs) > 0 {
+		v.add(rel, result.ScenarioID, "evidence_refs", "is only valid for a non-observed result")
+	}
+	if strings.TrimSpace(result.MissingControl) != "" {
+		v.add(rel, result.ScenarioID, "missing_control", "is only valid for not-runnable")
+	}
+	if result.Outcome == OutcomeObservedFailure && strings.TrimSpace(result.Reason) == "" {
+		v.add(rel, result.ScenarioID, "reason", "is required for observed-failure")
+	}
+	v.validateObservedEvidence(rel, cellDir, result)
+}
+
+func (v *validation) validateCanonicalEvidenceNames(rel string, result *Result) {
+	actual := map[string]string{
+		"desktop_registry": result.Evidence.DesktopRegistry,
+		"transcript":       result.Evidence.Transcript,
+		"hooks":            result.Evidence.Hooks,
+		"process":          result.Evidence.Process,
+		"irrlicht_session": result.Evidence.IrrlichtSession,
+		"environment":      result.Evidence.Environment,
+	}
+	expected := map[string]string{
+		"desktop_registry": DesktopRegistryFile,
+		"transcript":       TranscriptFile,
+		"hooks":            HooksFile,
+		"process":          ProcessFile,
+		"irrlicht_session": IrrlichtSessionFile,
+		"environment":      EnvironmentFile,
+	}
+	for field, want := range expected {
+		if actual[field] != want {
+			v.add(rel, result.ScenarioID, "evidence."+field, fmt.Sprintf("got %q; want canonical %q", actual[field], want))
+		}
+	}
+}
+
+func (v *validation) validateNonObservedShape(rel string, result *Result) {
+	if strings.TrimSpace(result.Reason) == "" {
+		v.add(rel, result.ScenarioID, "reason", "must contain an evidence-based reason")
+	}
+	if len(result.EvidenceRefs) == 0 {
+		v.add(rel, result.ScenarioID, "evidence_refs", "must contain at least one repository evidence reference")
+	}
+	for i, ref := range result.EvidenceRefs {
+		field := fmt.Sprintf("evidence_refs[%d]", i)
+		if _, err := resolveFile(v.repoRoot, ref); err != nil {
+			v.add(rel, result.ScenarioID, field, err.Error())
+		}
+	}
+	if result.Recording != "" {
+		v.add(rel, result.ScenarioID, "recording", "is only valid for an observed result")
+	}
+	if result.Evidence != nil {
+		v.add(rel, result.ScenarioID, "evidence", "is only valid for an observed result")
+	}
+	missing := strings.TrimSpace(result.MissingControl)
+	if result.Outcome == OutcomeNotRunnable && missing == "" {
+		v.add(rel, result.ScenarioID, "missing_control", "must name the unavailable Desktop control")
+	}
+	if result.Outcome != OutcomeNotRunnable && missing != "" {
+		v.add(rel, result.ScenarioID, "missing_control", "is only valid for not-runnable")
+	}
+}
+
+func (v *validation) validateCompleteness() {
+	for scenario, count := range v.resultCount {
+		if count > 1 {
+			path := filepath.Join("replaydata", "agents", claudeAdapter, "scenarios")
+			v.add(path, scenario, "completeness", fmt.Sprintf("duplicate desktop-local result: found %d entries", count))
+		}
+	}
+	if !v.requireDesktop {
+		return
+	}
+	for scenario := range v.catalog {
+		count := v.resultCount[scenario]
+		if count == 1 {
+			continue
+		}
+		path := filepath.Join("replaydata", "agents", claudeAdapter, "scenarios")
+		if count == 0 {
+			v.add(path, scenario, "completeness", "missing desktop-local result")
+		}
+	}
+}
+
+func (v *validation) rel(path string) string {
+	rel, err := filepath.Rel(v.repoRoot, path)
+	if err != nil {
+		return path
+	}
+	return rel
+}
+
+func safeSegment(value string) bool {
+	return value != "" && value != "." && value != ".." && filepath.Base(value) == value
+}
+
+// resolveFile accepts only an existing, non-empty regular file below root.
+// EvalSymlinks makes a repository-relative reference unable to escape through
+// a committed or locally-created symlink.
+func resolveFile(root, reference string) (string, error) {
+	if reference == "" || filepath.IsAbs(reference) {
+		return "", fmt.Errorf("must be a non-empty relative file path")
+	}
+	native := filepath.FromSlash(reference)
+	clean := filepath.Clean(native)
+	if clean == "." || clean == ".." || strings.HasPrefix(clean, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("must not traverse outside its evidence root")
+	}
+	if clean != native {
+		return "", fmt.Errorf("must not contain traversal or redundant path components")
+	}
+	rootResolved, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		return "", fmt.Errorf("cannot resolve evidence root: %w", err)
+	}
+	path := filepath.Join(root, clean)
+	resolved, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		return "", fmt.Errorf("cannot read %q: %w", reference, err)
+	}
+	rel, err := filepath.Rel(rootResolved, resolved)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("reference %q escapes its evidence root", reference)
+	}
+	info, err := os.Stat(resolved)
+	if err != nil {
+		return "", fmt.Errorf("cannot read %q: %w", reference, err)
+	}
+	if !info.Mode().IsRegular() || info.Size() == 0 {
+		return "", fmt.Errorf("reference %q must name a non-empty regular file", reference)
+	}
+	return resolved, nil
+}
+
+func resolveDirectory(root, reference string) (string, error) {
+	if !safeSegment(reference) {
+		return "", fmt.Errorf("must be one safe directory name")
+	}
+	rootResolved, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		return "", fmt.Errorf("cannot resolve recordings directory: %w", err)
+	}
+	resolved, err := filepath.EvalSymlinks(filepath.Join(root, reference))
+	if err != nil {
+		return "", fmt.Errorf("cannot read recording %q: %w", reference, err)
+	}
+	rel, err := filepath.Rel(rootResolved, resolved)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("recording %q escapes the recordings directory", reference)
+	}
+	info, err := os.Stat(resolved)
+	if err != nil || !info.IsDir() {
+		return "", fmt.Errorf("recording %q must name a directory", reference)
+	}
+	return resolved, nil
+}

--- a/tools/onboarding-factory/internal/desktopresults/validate.go
+++ b/tools/onboarding-factory/internal/desktopresults/validate.go
@@ -35,6 +35,7 @@ type catalogDocument struct {
 type validation struct {
 	repoRoot       string
 	catalog        map[string]bool
+	claudeCells    map[string]bool
 	resultCount    map[string]int
 	requireDesktop bool
 	findings       []Finding
@@ -47,6 +48,7 @@ func ValidateRepo(repoRoot string) []Finding {
 	v := &validation{
 		repoRoot:    repoRoot,
 		catalog:     map[string]bool{},
+		claudeCells: map[string]bool{},
 		resultCount: map[string]int{},
 	}
 	v.loadCatalog()
@@ -137,14 +139,34 @@ func (v *validation) scanResultFiles() {
 			v.add(v.rel(path), "unknown", "scan", walkErr.Error())
 			return nil
 		}
-		if entry.IsDir() || entry.Name() != FileName {
+		if entry.IsDir() {
 			return nil
 		}
-		v.validateResultFile(path)
+		switch entry.Name() {
+		case "metadata.json":
+			v.registerClaudeCell(root, path)
+		case FileName:
+			v.validateResultFile(path)
+		}
 		return nil
 	})
 	if err != nil && !os.IsNotExist(err) {
 		v.add(v.rel(root), "unknown", "scan", err.Error())
+	}
+}
+
+func (v *validation) registerClaudeCell(root, path string) {
+	rel, err := filepath.Rel(root, path)
+	if err != nil {
+		return
+	}
+	parts := strings.Split(filepath.ToSlash(rel), "/")
+	if len(parts) != 3 || parts[0] != "scenarios" || parts[2] != "metadata.json" {
+		return
+	}
+	scenario := metadataScenarioID(filepath.Dir(path))
+	if v.catalog[scenario] {
+		v.claudeCells[scenario] = true
 	}
 }
 
@@ -212,7 +234,7 @@ func (v *validation) validateResult(rel, cellDir, expectedScenario string, resul
 		v.validateObservedShape(rel, cellDir, result)
 		return
 	}
-	v.validateNonObservedShape(rel, result)
+	v.validateNonObservedShape(rel, cellDir, result)
 }
 
 func (v *validation) validateScenario(rel, expected, actual string) {
@@ -276,12 +298,12 @@ func (v *validation) validateCanonicalEvidenceNames(rel string, result *Result) 
 	}
 }
 
-func (v *validation) validateNonObservedShape(rel string, result *Result) {
-	v.validateNonObservedEvidence(rel, result)
+func (v *validation) validateNonObservedShape(rel, cellDir string, result *Result) {
+	v.validateNonObservedEvidence(rel, cellDir, result)
 	v.validateNonObservedExclusions(rel, result)
 }
 
-func (v *validation) validateNonObservedEvidence(rel string, result *Result) {
+func (v *validation) validateNonObservedEvidence(rel, cellDir string, result *Result) {
 	if strings.TrimSpace(result.Reason) == "" {
 		v.add(rel, result.ScenarioID, "reason", "must contain an evidence-based reason")
 	}
@@ -290,10 +312,35 @@ func (v *validation) validateNonObservedEvidence(rel string, result *Result) {
 	}
 	for i, ref := range result.EvidenceRefs {
 		field := fmt.Sprintf("evidence_refs[%d]", i)
-		if _, err := resolveFile(v.repoRoot, ref); err != nil {
+		resolved, err := resolveFile(v.repoRoot, ref)
+		if err != nil {
 			v.add(rel, result.ScenarioID, field, err.Error())
+			continue
+		}
+		if !v.allowedNonObservedEvidence(cellDir, resolved) {
+			v.add(rel, result.ScenarioID, field, "must name same-cell Desktop evidence or an explicit repository Desktop evidence source")
 		}
 	}
+}
+
+// allowedNonObservedEvidence checks only a reference's stable scope. It does
+// not claim that prose proves the result. Campaign evidence must be the cell's
+// metadata, a file under its desktop-evidence directory, a repository doc, or
+// a shared raw probe under replaydata/agents/claudecode/desktop-evidence.
+func (v *validation) allowedNonObservedEvidence(cellDir, resolved string) bool {
+	if sameResolvedFile(resolved, filepath.Join(cellDir, "metadata.json")) {
+		return true
+	}
+	for _, root := range []string{
+		filepath.Join(cellDir, "desktop-evidence"),
+		filepath.Join(v.repoRoot, "docs"),
+		filepath.Join(v.repoRoot, "replaydata", "agents", claudeAdapter, "desktop-evidence"),
+	} {
+		if resolvedWithinExisting(root, resolved) {
+			return true
+		}
+	}
+	return false
 }
 
 func (v *validation) validateNonObservedExclusions(rel string, result *Result) {
@@ -322,7 +369,7 @@ func (v *validation) validateCompleteness() {
 	if !v.requireDesktop {
 		return
 	}
-	for scenario := range v.catalog {
+	for scenario := range v.claudeCells {
 		count := v.resultCount[scenario]
 		if count == 1 {
 			continue
@@ -332,6 +379,20 @@ func (v *validation) validateCompleteness() {
 			v.add(path, scenario, "completeness", "missing desktop-local result")
 		}
 	}
+}
+
+func sameResolvedFile(left, right string) bool {
+	resolved, err := filepath.EvalSymlinks(right)
+	return err == nil && resolved == left
+}
+
+func resolvedWithinExisting(root, path string) bool {
+	resolvedRoot, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		return false
+	}
+	rel, err := filepath.Rel(resolvedRoot, path)
+	return err == nil && rel != "." && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
 }
 
 func (v *validation) rel(path string) string {

--- a/tools/onboarding-factory/internal/desktopresults/validate.go
+++ b/tools/onboarding-factory/internal/desktopresults/validate.go
@@ -49,12 +49,49 @@ type cellCandidate struct {
 	path string
 }
 
+type findingTarget struct {
+	path     string
+	scenario string
+}
+
 type resultFileContext struct {
-	rel               string
+	target            findingTarget
 	cellDir           string
 	expectedScenario  string
 	canonicalScenario string
 	canonical         bool
+}
+
+type resultValidationContext struct {
+	target  findingTarget
+	cellDir string
+	result  *Result
+}
+
+type resultDocumentLocation struct {
+	path   string
+	target findingTarget
+}
+
+type scenarioValidation struct {
+	target   findingTarget
+	expected string
+	actual   string
+}
+
+type evidenceBoundary struct {
+	cellDir  string
+	resolved string
+}
+
+type pathReference struct {
+	root      string
+	reference string
+}
+
+type pathPair struct {
+	left  string
+	right string
 }
 
 type validation struct {
@@ -90,13 +127,13 @@ func ValidateRepo(repoRoot string) []Finding {
 	return v.findings
 }
 
-func (v *validation) add(path, scenario, field, message string) {
-	if scenario == "" {
-		scenario = "unknown"
+func (v *validation) add(target findingTarget, field, message string) {
+	if target.scenario == "" {
+		target.scenario = "unknown"
 	}
 	v.findings = append(v.findings, Finding{
-		Path:    filepath.ToSlash(path),
-		Message: fmt.Sprintf("scenario_id %q: %s: %s", scenario, field, message),
+		Path:    filepath.ToSlash(target.path),
+		Message: fmt.Sprintf("scenario_id %q: %s: %s", target.scenario, field, message),
 	})
 }
 
@@ -121,7 +158,7 @@ func (v *validation) validateRequiredProfiles(input requiredProfilesInput) {
 	}
 	required, err := decodeRequiredProfiles(input.raw)
 	if err != nil {
-		v.add(v.rel(input.path), "catalog", "meta."+resultsSwitch, err.Error())
+		v.add(findingTarget{path: v.rel(input.path), scenario: "catalog"}, "meta."+resultsSwitch, err.Error())
 		return
 	}
 	for adapter, profiles := range required {
@@ -145,27 +182,28 @@ func decodeRequiredProfiles(raw json.RawMessage) (map[string][]string, error) {
 
 func (v *validation) validateRequiredProfileList(input requiredProfileList) {
 	field := "meta." + resultsSwitch + "." + input.adapter
+	target := findingTarget{path: v.rel(input.path), scenario: "catalog"}
 	if input.adapter != claudeAdapter {
-		v.add(v.rel(input.path), "catalog", field, "Desktop result completeness is only supported for claudecode")
+		v.add(target, field, "Desktop result completeness is only supported for claudecode")
 		return
 	}
 	if len(input.profiles) == 0 {
-		v.add(v.rel(input.path), "catalog", field, "must contain at least one profile")
+		v.add(target, field, "must contain at least one profile")
 		return
 	}
 	seen := map[matrix.ExecutionProfile]bool{}
 	for _, value := range input.profiles {
 		profile, err := matrix.ParseExecutionProfile(value)
 		if err != nil {
-			v.add(v.rel(input.path), "catalog", field, err.Error())
+			v.add(target, field, err.Error())
 			continue
 		}
 		if profile != matrix.ProfileDesktopLocal {
-			v.add(v.rel(input.path), "catalog", field, "only desktop-local can be required by this result contract")
+			v.add(target, field, "only desktop-local can be required by this result contract")
 			continue
 		}
 		if seen[profile] {
-			v.add(v.rel(input.path), "catalog", field, "contains duplicate desktop-local")
+			v.add(target, field, "contains duplicate desktop-local")
 			continue
 		}
 		seen[profile] = true
@@ -178,7 +216,7 @@ func (v *validation) scanResultFiles() {
 	var resultFiles []string
 	err := filepath.WalkDir(root, func(path string, entry iofs.DirEntry, walkErr error) error {
 		if walkErr != nil {
-			v.add(v.rel(path), "unknown", "scan", walkErr.Error())
+			v.add(findingTarget{path: v.rel(path), scenario: "unknown"}, "scan", walkErr.Error())
 			return nil
 		}
 		if entry.IsDir() {
@@ -193,7 +231,7 @@ func (v *validation) scanResultFiles() {
 		return nil
 	})
 	if err != nil && !os.IsNotExist(err) {
-		v.add(v.rel(root), "unknown", "scan", err.Error())
+		v.add(findingTarget{path: v.rel(root), scenario: "unknown"}, "scan", err.Error())
 	}
 	for _, path := range resultFiles {
 		v.validateResultFile(path)
@@ -230,16 +268,17 @@ func (v *validation) validateResultFile(path string) {
 	rel := v.rel(path)
 	cellDir := filepath.Clean(filepath.Dir(path))
 	expectedScenario := metadataScenarioID(cellDir)
+	target := findingTarget{path: rel, scenario: expectedScenario}
 	canonicalScenario, canonical := v.canonicalCells[cellDir]
 	if !canonical {
-		v.add(rel, expectedScenario, "document location", "must be the direct child of a current Claude Code cell")
+		v.add(target, "document location", "must be the direct child of a current Claude Code cell")
 	}
-	doc, ok := v.loadResultDocument(path, rel, expectedScenario)
+	doc, ok := v.loadResultDocument(resultDocumentLocation{path: path, target: target})
 	if !ok {
 		return
 	}
 	context := resultFileContext{
-		rel:               rel,
+		target:            target,
 		cellDir:           cellDir,
 		expectedScenario:  expectedScenario,
 		canonicalScenario: canonicalScenario,
@@ -248,21 +287,21 @@ func (v *validation) validateResultFile(path string) {
 	v.validateResults(context, doc.Results)
 }
 
-func (v *validation) loadResultDocument(path, rel, scenario string) (Document, bool) {
-	if _, err := resolveFile(v.repoRoot, rel); err != nil {
-		v.add(rel, scenario, "document", err.Error())
+func (v *validation) loadResultDocument(location resultDocumentLocation) (Document, bool) {
+	if _, err := resolveFile(pathReference{root: v.repoRoot, reference: location.target.path}); err != nil {
+		v.add(location.target, "document", err.Error())
 		return Document{}, false
 	}
-	doc, err := Load(path)
+	doc, err := Load(location.path)
 	if err != nil {
-		v.add(rel, scenario, "document", "invalid or unknown field: "+err.Error())
+		v.add(location.target, "document", "invalid or unknown field: "+err.Error())
 		return Document{}, false
 	}
 	if doc.SchemaVersion != SchemaVersion {
-		v.add(rel, scenario, "schema_version", fmt.Sprintf("got %d; want %d", doc.SchemaVersion, SchemaVersion))
+		v.add(location.target, "schema_version", fmt.Sprintf("got %d; want %d", doc.SchemaVersion, SchemaVersion))
 	}
 	if len(doc.Results) == 0 {
-		v.add(rel, scenario, "results", "must contain at least one result")
+		v.add(location.target, "results", "must contain at least one result")
 		return doc, false
 	}
 	return doc, true
@@ -280,7 +319,9 @@ func (v *validation) validateResults(context resultFileContext, results []Result
 			v.resultCount[result.ScenarioID]++
 		}
 		if seenProfile[result.ExecutionProfile] {
-			v.add(context.rel, result.ScenarioID, "results", "duplicate desktop-local result")
+			target := context.target
+			target.scenario = result.ScenarioID
+			v.add(target, "results", "duplicate desktop-local result")
 		}
 		seenProfile[result.ExecutionProfile] = true
 	}
@@ -302,62 +343,68 @@ func metadataScenarioID(cellDir string) string {
 
 func (v *validation) validateResult(context resultFileContext, result *Result) {
 	scenario := result.ScenarioID
-	v.validateScenario(context.rel, context.expectedScenario, scenario)
+	target := context.target
+	target.scenario = scenario
+	resultContext := resultValidationContext{target: target, cellDir: context.cellDir, result: result}
+	v.validateScenario(scenarioValidation{target: target, expected: context.expectedScenario, actual: scenario})
 	profile, err := matrix.ParseExecutionProfile(result.ExecutionProfile)
 	if err != nil {
-		v.add(context.rel, scenario, "execution_profile", err.Error())
+		v.add(target, "execution_profile", err.Error())
 	} else if profile != matrix.ProfileDesktopLocal {
-		v.add(context.rel, scenario, "execution_profile", "result files support only desktop-local")
+		v.add(target, "execution_profile", "result files support only desktop-local")
 	}
 	if !knownOutcome(result.Outcome) {
-		v.add(context.rel, scenario, "outcome", fmt.Sprintf("unknown outcome %q", result.Outcome))
+		v.add(target, "outcome", fmt.Sprintf("unknown outcome %q", result.Outcome))
 		return
 	}
 	if observedOutcome(result.Outcome) {
-		v.validateObservedShape(context.rel, context.cellDir, result)
+		v.validateObservedShape(resultContext)
 		return
 	}
-	v.validateNonObservedShape(context.rel, context.cellDir, result)
+	v.validateNonObservedShape(resultContext)
 }
 
-func (v *validation) validateScenario(rel, expected, actual string) {
-	if strings.TrimSpace(actual) == "" {
-		v.add(rel, expected, "scenario_id", "must not be blank")
+func (v *validation) validateScenario(input scenarioValidation) {
+	if strings.TrimSpace(input.actual) == "" {
+		input.target.scenario = input.expected
+		v.add(input.target, "scenario_id", "must not be blank")
 		return
 	}
-	if !v.catalog[actual] {
-		v.add(rel, actual, "scenario_id", "does not name a current catalog scenario")
+	if !v.catalog[input.actual] {
+		v.add(input.target, "scenario_id", "does not name a current catalog scenario")
 	}
-	if expected == "" {
-		v.add(rel, actual, "scenario_id", "cannot match result to a valid sibling metadata.json")
-	} else if actual != expected {
-		v.add(rel, actual, "scenario_id", fmt.Sprintf("does not match cell metadata scenario_id %q", expected))
+	if input.expected == "" {
+		v.add(input.target, "scenario_id", "cannot match result to a valid sibling metadata.json")
+	} else if input.actual != input.expected {
+		v.add(input.target, "scenario_id", fmt.Sprintf("does not match cell metadata scenario_id %q", input.expected))
 	}
 }
 
-func (v *validation) validateObservedShape(rel, cellDir string, result *Result) {
+func (v *validation) validateObservedShape(context resultValidationContext) {
+	result := context.result
 	if !safeSegment(result.Recording) {
-		v.add(rel, result.ScenarioID, "recording", "must be one safe recording directory name")
+		v.add(context.target, "recording", "must be one safe recording directory name")
 		return
 	}
 	if result.Evidence == nil {
-		v.add(rel, result.ScenarioID, "evidence", "is required for an observed result")
+		v.add(context.target, "evidence", "is required for an observed result")
 		return
 	}
-	v.validateCanonicalEvidenceNames(rel, result)
+	v.validateCanonicalEvidenceNames(context)
 	if len(result.EvidenceRefs) > 0 {
-		v.add(rel, result.ScenarioID, "evidence_refs", "is only valid for a non-observed result")
+		v.add(context.target, "evidence_refs", "is only valid for a non-observed result")
 	}
 	if strings.TrimSpace(result.MissingControl) != "" {
-		v.add(rel, result.ScenarioID, "missing_control", "is only valid for not-runnable")
+		v.add(context.target, "missing_control", "is only valid for not-runnable")
 	}
 	if result.Outcome == OutcomeObservedFailure && strings.TrimSpace(result.Reason) == "" {
-		v.add(rel, result.ScenarioID, "reason", "is required for observed-failure")
+		v.add(context.target, "reason", "is required for observed-failure")
 	}
-	v.validateObservedEvidence(rel, cellDir, result)
+	v.validateObservedEvidence(context)
 }
 
-func (v *validation) validateCanonicalEvidenceNames(rel string, result *Result) {
+func (v *validation) validateCanonicalEvidenceNames(context resultValidationContext) {
+	result := context.result
 	actual := map[string]string{
 		"desktop_registry": result.Evidence.DesktopRegistry,
 		"transcript":       result.Evidence.Transcript,
@@ -376,32 +423,33 @@ func (v *validation) validateCanonicalEvidenceNames(rel string, result *Result) 
 	}
 	for field, want := range expected {
 		if actual[field] != want {
-			v.add(rel, result.ScenarioID, "evidence."+field, fmt.Sprintf("got %q; want canonical %q", actual[field], want))
+			v.add(context.target, "evidence."+field, fmt.Sprintf("got %q; want canonical %q", actual[field], want))
 		}
 	}
 }
 
-func (v *validation) validateNonObservedShape(rel, cellDir string, result *Result) {
-	v.validateNonObservedEvidence(rel, cellDir, result)
-	v.validateNonObservedExclusions(rel, result)
+func (v *validation) validateNonObservedShape(context resultValidationContext) {
+	v.validateNonObservedEvidence(context)
+	v.validateNonObservedExclusions(context)
 }
 
-func (v *validation) validateNonObservedEvidence(rel, cellDir string, result *Result) {
+func (v *validation) validateNonObservedEvidence(context resultValidationContext) {
+	result := context.result
 	if strings.TrimSpace(result.Reason) == "" {
-		v.add(rel, result.ScenarioID, "reason", "must contain an evidence-based reason")
+		v.add(context.target, "reason", "must contain an evidence-based reason")
 	}
 	if len(result.EvidenceRefs) == 0 {
-		v.add(rel, result.ScenarioID, "evidence_refs", "must contain at least one repository evidence reference")
+		v.add(context.target, "evidence_refs", "must contain at least one repository evidence reference")
 	}
 	for i, ref := range result.EvidenceRefs {
 		field := fmt.Sprintf("evidence_refs[%d]", i)
-		resolved, err := resolveFile(v.repoRoot, ref)
+		resolved, err := resolveFile(pathReference{root: v.repoRoot, reference: ref})
 		if err != nil {
-			v.add(rel, result.ScenarioID, field, err.Error())
+			v.add(context.target, field, err.Error())
 			continue
 		}
-		if !v.allowedNonObservedEvidence(cellDir, resolved) {
-			v.add(rel, result.ScenarioID, field, "must name same-cell Desktop evidence or an explicit repository Desktop evidence source")
+		if !v.allowedNonObservedEvidence(evidenceBoundary{cellDir: context.cellDir, resolved: resolved}) {
+			v.add(context.target, field, "must name same-cell Desktop evidence or an explicit repository Desktop evidence source")
 		}
 	}
 }
@@ -410,34 +458,35 @@ func (v *validation) validateNonObservedEvidence(rel, cellDir string, result *Re
 // not claim that prose proves the result. Campaign evidence must be the cell's
 // metadata, a file under its desktop-evidence directory, or a shared raw probe
 // under replaydata/agents/claudecode/desktop-evidence.
-func (v *validation) allowedNonObservedEvidence(cellDir, resolved string) bool {
-	if sameResolvedFile(resolved, filepath.Join(cellDir, metadataFile)) {
+func (v *validation) allowedNonObservedEvidence(boundary evidenceBoundary) bool {
+	if sameResolvedFile(pathPair{left: boundary.resolved, right: filepath.Join(boundary.cellDir, metadataFile)}) {
 		return true
 	}
 	for _, root := range []string{
-		filepath.Join(cellDir, "desktop-evidence"),
+		filepath.Join(boundary.cellDir, "desktop-evidence"),
 		filepath.Join(v.repoRoot, "replaydata", "agents", claudeAdapter, "desktop-evidence"),
 	} {
-		if resolvedWithinExisting(root, resolved) {
+		if resolvedWithinExisting(pathPair{left: root, right: boundary.resolved}) {
 			return true
 		}
 	}
 	return false
 }
 
-func (v *validation) validateNonObservedExclusions(rel string, result *Result) {
+func (v *validation) validateNonObservedExclusions(context resultValidationContext) {
+	result := context.result
 	if result.Recording != "" {
-		v.add(rel, result.ScenarioID, "recording", "is only valid for an observed result")
+		v.add(context.target, "recording", "is only valid for an observed result")
 	}
 	if result.Evidence != nil {
-		v.add(rel, result.ScenarioID, "evidence", "is only valid for an observed result")
+		v.add(context.target, "evidence", "is only valid for an observed result")
 	}
 	missing := strings.TrimSpace(result.MissingControl)
 	if result.Outcome == OutcomeNotRunnable && missing == "" {
-		v.add(rel, result.ScenarioID, "missing_control", "must name the unavailable Desktop control")
+		v.add(context.target, "missing_control", "must name the unavailable Desktop control")
 	}
 	if result.Outcome != OutcomeNotRunnable && missing != "" {
-		v.add(rel, result.ScenarioID, "missing_control", "is only valid for not-runnable")
+		v.add(context.target, "missing_control", "is only valid for not-runnable")
 	}
 }
 
@@ -451,7 +500,7 @@ func (v *validation) validateCompleteness() {
 func (v *validation) validateDuplicateResults() {
 	for scenario, count := range v.resultCount {
 		if count > 1 {
-			v.add(resultCellsPath(), scenario, "completeness", fmt.Sprintf("duplicate desktop-local result: found %d entries", count))
+			v.add(findingTarget{path: resultCellsPath(), scenario: scenario}, "completeness", fmt.Sprintf("duplicate desktop-local result: found %d entries", count))
 		}
 	}
 }
@@ -460,7 +509,7 @@ func (v *validation) validateRequiredResults() {
 	for scenario := range v.claudeCells {
 		count := v.resultCount[scenario]
 		if count == 0 {
-			v.add(resultCellsPath(), scenario, "completeness", "missing desktop-local result")
+			v.add(findingTarget{path: resultCellsPath(), scenario: scenario}, "completeness", "missing desktop-local result")
 		}
 	}
 }
@@ -469,17 +518,17 @@ func resultCellsPath() string {
 	return filepath.Join("replaydata", "agents", claudeAdapter, "scenarios")
 }
 
-func sameResolvedFile(left, right string) bool {
-	resolved, err := filepath.EvalSymlinks(right)
-	return err == nil && resolved == left
+func sameResolvedFile(paths pathPair) bool {
+	resolved, err := filepath.EvalSymlinks(paths.right)
+	return err == nil && resolved == paths.left
 }
 
-func resolvedWithinExisting(root, path string) bool {
-	resolvedRoot, err := filepath.EvalSymlinks(root)
+func resolvedWithinExisting(paths pathPair) bool {
+	resolvedRoot, err := filepath.EvalSymlinks(paths.left)
 	if err != nil {
 		return false
 	}
-	rel, err := filepath.Rel(resolvedRoot, path)
+	rel, err := filepath.Rel(resolvedRoot, paths.right)
 	return err == nil && rel != "." && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
 }
 
@@ -503,54 +552,54 @@ type resolvedPath struct {
 // resolveFile accepts only an existing, non-empty regular file below root.
 // EvalSymlinks makes a repository-relative reference unable to escape through
 // a committed or locally-created symlink.
-func resolveFile(root, reference string) (string, error) {
-	resolved, err := resolveExisting(root, reference)
+func resolveFile(input pathReference) (string, error) {
+	resolved, err := resolveExisting(input)
 	if err != nil {
 		return "", err
 	}
 	if !resolved.info.Mode().IsRegular() || resolved.info.Size() == 0 {
-		return "", fmt.Errorf("reference %q must name a non-empty regular file", reference)
+		return "", fmt.Errorf("reference %q must name a non-empty regular file", input.reference)
 	}
 	return resolved.path, nil
 }
 
-func resolveDirectory(root, reference string) (string, error) {
-	if !safeSegment(reference) {
+func resolveDirectory(input pathReference) (string, error) {
+	if !safeSegment(input.reference) {
 		return "", fmt.Errorf("must be one safe directory name")
 	}
-	resolved, err := resolveExisting(root, reference)
+	resolved, err := resolveExisting(input)
 	if err != nil {
-		return "", fmt.Errorf("cannot resolve recording %q: %w", reference, err)
+		return "", fmt.Errorf("cannot resolve recording %q: %w", input.reference, err)
 	}
 	if !resolved.info.IsDir() {
-		return "", fmt.Errorf("recording %q must name a directory", reference)
+		return "", fmt.Errorf("recording %q must name a directory", input.reference)
 	}
 	return resolved.path, nil
 }
 
-func resolveExisting(root, reference string) (resolvedPath, error) {
-	clean, err := cleanReference(reference)
+func resolveExisting(input pathReference) (resolvedPath, error) {
+	clean, err := cleanReference(input.reference)
 	if err != nil {
 		return resolvedPath{}, err
 	}
-	rootResolved, err := filepath.EvalSymlinks(root)
+	rootResolved, err := filepath.EvalSymlinks(input.root)
 	if err != nil {
 		return resolvedPath{}, fmt.Errorf("cannot resolve evidence root: %w", err)
 	}
-	resolved, err := filepath.EvalSymlinks(filepath.Join(root, clean))
+	resolved, err := filepath.EvalSymlinks(filepath.Join(input.root, clean))
 	if err != nil {
-		return resolvedPath{}, fmt.Errorf("cannot read %q: %w", reference, err)
+		return resolvedPath{}, fmt.Errorf("cannot read %q: %w", input.reference, err)
 	}
 	rel, err := filepath.Rel(rootResolved, resolved)
 	if err != nil {
 		return resolvedPath{}, fmt.Errorf("cannot compare evidence root and reference: %w", err)
 	}
 	if escapesRoot(rel) {
-		return resolvedPath{}, fmt.Errorf("reference %q escapes its evidence root", reference)
+		return resolvedPath{}, fmt.Errorf("reference %q escapes its evidence root", input.reference)
 	}
 	info, err := os.Stat(resolved)
 	if err != nil {
-		return resolvedPath{}, fmt.Errorf("cannot read %q: %w", reference, err)
+		return resolvedPath{}, fmt.Errorf("cannot read %q: %w", input.reference, err)
 	}
 	return resolvedPath{path: resolved, info: info}, nil
 }

--- a/tools/onboarding-factory/internal/matrix/recording.go
+++ b/tools/onboarding-factory/internal/matrix/recording.go
@@ -18,7 +18,28 @@ type ExecutionProfile string
 const (
 	ProfileCLILocal     ExecutionProfile = "cli-local"
 	ProfileDesktopLocal ExecutionProfile = "desktop-local"
+
+	DesktopRegistryFile        = "desktop-registry.json"
+	DesktopEnvironmentFile     = "desktop-environment.json"
+	DesktopHooksFile           = "hooks.jsonl"
+	DesktopProcessFile         = "process.json"
+	DesktopIrrlichtSessionFile = "irrlicht-session.json"
+	DesktopTranscriptFile      = "transcript.jsonl"
 )
+
+// DesktopEvidenceFiles returns the raw evidence files required in each
+// Desktop Local recording. This lower recording-layer list is shared by the
+// general completeness check and the Desktop result validator.
+func DesktopEvidenceFiles() []string {
+	return []string{
+		DesktopRegistryFile,
+		DesktopEnvironmentFile,
+		DesktopHooksFile,
+		DesktopProcessFile,
+		DesktopIrrlichtSessionFile,
+		DesktopTranscriptFile,
+	}
+}
 
 // ExecutionProfiles returns every accepted manifest value in stable order.
 func ExecutionProfiles() []ExecutionProfile {

--- a/tools/onboarding-factory/internal/validate/desktop_recording_test.go
+++ b/tools/onboarding-factory/internal/validate/desktop_recording_test.go
@@ -1,0 +1,57 @@
+package validate
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestRecordingCompleteDesktopEvidenceMutations proves the generic recording
+// completeness gate cannot accept a Desktop manifest whose raw identity chain
+// is incomplete. Each required file is removed once from a complete fixture.
+func TestRecordingCompleteDesktopEvidenceMutations(t *testing.T) {
+	// This list is deliberately independent of RequiredRecordingFiles. Deriving
+	// the mutation corpus from production made removing one required filename
+	// remove its test too, so that mutation reported "no tests to run".
+	desktopEvidenceFiles := []string{
+		"desktop-registry.json",
+		"desktop-environment.json",
+		"hooks.jsonl",
+		"process.json",
+		"irrlicht-session.json",
+		"transcript.jsonl",
+	}
+	base := []string{"events.jsonl", "manifest.json", "transcript.jsonl", "transcript.jsonl.replay.json.golden"}
+	files := append(base, desktopEvidenceFiles...)
+	// TranscriptFile appears in both lists. writeRecordingFiles safely rewrites
+	// the same fixture path, so the duplicate keeps the two contracts explicit.
+	dir := writeRecordingFiles(t, "complete desktop", files)
+	writeDesktopManifest(t, dir)
+	if got := RecordingComplete(dir); len(got) != 0 {
+		t.Fatalf("complete Desktop recording has findings: %v", got)
+	}
+	for _, name := range desktopEvidenceFiles {
+		if name == "transcript.jsonl" {
+			continue // the generic missing-transcript row already mutates this file.
+		}
+		t.Run(name, func(t *testing.T) {
+			mutated := writeRecordingFiles(t, name, files)
+			writeDesktopManifest(t, mutated)
+			if err := os.Remove(filepath.Join(mutated, name)); err != nil {
+				t.Fatal(err)
+			}
+			findings := strings.Join(RecordingComplete(mutated), " | ")
+			if !strings.Contains(findings, "missing "+name) {
+				t.Fatalf("missing %s was accepted: %s", name, findings)
+			}
+		})
+	}
+}
+
+func writeDesktopManifest(t *testing.T, dir string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, "manifest.json"), []byte(`{"execution_profile":"desktop-local"}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/tools/onboarding-factory/internal/validate/expected.go
+++ b/tools/onboarding-factory/internal/validate/expected.go
@@ -271,12 +271,19 @@ func RecordingComplete(recDir string) []string {
 	if hasJSONL && !exists("transcript.jsonl.replay.json.golden") {
 		findings = append(findings, "missing transcript.jsonl.replay.json.golden (required for a jsonl transcript)")
 	}
+	findings = append(findings, desktopEvidenceCompleteness(recDir, exists)...)
+	return findings
+}
+
+func desktopEvidenceCompleteness(recDir string, exists func(string) bool) []string {
 	manifest, err := matrix.LoadRecordingManifest(filepath.Join(recDir, "manifest.json"))
-	if err == nil && manifest.ExecutionProfile == matrix.ProfileDesktopLocal {
-		for _, name := range desktopresults.RequiredRecordingFiles() {
-			if !exists(name) {
-				findings = append(findings, "missing "+name+" (required for desktop-local evidence)")
-			}
+	if err != nil || manifest.ExecutionProfile != matrix.ProfileDesktopLocal {
+		return nil
+	}
+	var findings []string
+	for _, name := range desktopresults.RequiredRecordingFiles() {
+		if !exists(name) {
+			findings = append(findings, "missing "+name+" (required for desktop-local evidence)")
 		}
 	}
 	return findings

--- a/tools/onboarding-factory/internal/validate/expected.go
+++ b/tools/onboarding-factory/internal/validate/expected.go
@@ -50,6 +50,7 @@ import (
 	"strings"
 	"time"
 
+	"irrlicht/tools/onboarding-factory/internal/desktopresults"
 	"irrlicht/tools/onboarding-factory/internal/matrix"
 )
 
@@ -269,6 +270,14 @@ func RecordingComplete(recDir string) []string {
 	// replay test pins them); markdown-transcript adapters (aider) have none.
 	if hasJSONL && !exists("transcript.jsonl.replay.json.golden") {
 		findings = append(findings, "missing transcript.jsonl.replay.json.golden (required for a jsonl transcript)")
+	}
+	manifest, err := matrix.LoadRecordingManifest(filepath.Join(recDir, "manifest.json"))
+	if err == nil && manifest.ExecutionProfile == matrix.ProfileDesktopLocal {
+		for _, name := range desktopresults.RequiredRecordingFiles() {
+			if !exists(name) {
+				findings = append(findings, "missing "+name+" (required for desktop-local evidence)")
+			}
+		}
 	}
 	return findings
 }

--- a/tools/onboarding-factory/internal/validate/expected.go
+++ b/tools/onboarding-factory/internal/validate/expected.go
@@ -50,7 +50,6 @@ import (
 	"strings"
 	"time"
 
-	"irrlicht/tools/onboarding-factory/internal/desktopresults"
 	"irrlicht/tools/onboarding-factory/internal/matrix"
 )
 
@@ -281,7 +280,7 @@ func desktopEvidenceCompleteness(recDir string, exists func(string) bool) []stri
 		return nil
 	}
 	var findings []string
-	for _, name := range desktopresults.RequiredRecordingFiles() {
+	for _, name := range matrix.DesktopEvidenceFiles() {
 		if !exists(name) {
 			findings = append(findings, "missing "+name+" (required for desktop-local evidence)")
 		}

--- a/tools/onboarding-factory/internal/validate/expected_test.go
+++ b/tools/onboarding-factory/internal/validate/expected_test.go
@@ -594,52 +594,6 @@ func TestRecordingComplete(t *testing.T) {
 	}
 }
 
-// TestRecordingCompleteDesktopEvidenceMutations proves the generic recording
-// completeness gate cannot accept a Desktop manifest whose raw identity chain
-// is incomplete. Each required file is removed once from a complete fixture.
-func TestRecordingCompleteDesktopEvidenceMutations(t *testing.T) {
-	// This list is deliberately independent of RequiredRecordingFiles. Deriving
-	// the mutation corpus from production made removing one required filename
-	// remove its test too, so that mutation reported "no tests to run".
-	desktopEvidenceFiles := []string{
-		"desktop-registry.json",
-		"desktop-environment.json",
-		"hooks.jsonl",
-		"process.json",
-		"irrlicht-session.json",
-		"transcript.jsonl",
-	}
-	base := []string{"events.jsonl", "manifest.json", "transcript.jsonl", "transcript.jsonl.replay.json.golden"}
-	files := append(base, desktopEvidenceFiles...)
-	// TranscriptFile appears in both lists. writeRecordingFiles safely rewrites
-	// the same fixture path, so the duplicate keeps the two contracts explicit.
-	dir := writeRecordingFiles(t, "complete desktop", files)
-	if err := os.WriteFile(filepath.Join(dir, "manifest.json"), []byte(`{"execution_profile":"desktop-local"}`+"\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	if got := RecordingComplete(dir); len(got) != 0 {
-		t.Fatalf("complete Desktop recording has findings: %v", got)
-	}
-	for _, name := range desktopEvidenceFiles {
-		if name == "transcript.jsonl" {
-			continue // the generic missing-transcript row already mutates this file.
-		}
-		t.Run(name, func(t *testing.T) {
-			mutated := writeRecordingFiles(t, name, files)
-			if err := os.WriteFile(filepath.Join(mutated, "manifest.json"), []byte(`{"execution_profile":"desktop-local"}`+"\n"), 0o644); err != nil {
-				t.Fatal(err)
-			}
-			if err := os.Remove(filepath.Join(mutated, name)); err != nil {
-				t.Fatal(err)
-			}
-			findings := strings.Join(RecordingComplete(mutated), " | ")
-			if !strings.Contains(findings, "missing "+name) {
-				t.Fatalf("missing %s was accepted: %s", name, findings)
-			}
-		})
-	}
-}
-
 // writeRecordingFiles creates t.TempDir()/name/ populated with the given
 // empty-JSON files, mimicking a recording directory's on-disk shape for
 // RecordingComplete.

--- a/tools/onboarding-factory/internal/validate/expected_test.go
+++ b/tools/onboarding-factory/internal/validate/expected_test.go
@@ -594,6 +594,52 @@ func TestRecordingComplete(t *testing.T) {
 	}
 }
 
+// TestRecordingCompleteDesktopEvidenceMutations proves the generic recording
+// completeness gate cannot accept a Desktop manifest whose raw identity chain
+// is incomplete. Each required file is removed once from a complete fixture.
+func TestRecordingCompleteDesktopEvidenceMutations(t *testing.T) {
+	// This list is deliberately independent of RequiredRecordingFiles. Deriving
+	// the mutation corpus from production made removing one required filename
+	// remove its test too, so that mutation reported "no tests to run".
+	desktopEvidenceFiles := []string{
+		"desktop-registry.json",
+		"desktop-environment.json",
+		"hooks.jsonl",
+		"process.json",
+		"irrlicht-session.json",
+		"transcript.jsonl",
+	}
+	base := []string{"events.jsonl", "manifest.json", "transcript.jsonl", "transcript.jsonl.replay.json.golden"}
+	files := append(base, desktopEvidenceFiles...)
+	// TranscriptFile appears in both lists. writeRecordingFiles safely rewrites
+	// the same fixture path, so the duplicate keeps the two contracts explicit.
+	dir := writeRecordingFiles(t, "complete desktop", files)
+	if err := os.WriteFile(filepath.Join(dir, "manifest.json"), []byte(`{"execution_profile":"desktop-local"}`+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := RecordingComplete(dir); len(got) != 0 {
+		t.Fatalf("complete Desktop recording has findings: %v", got)
+	}
+	for _, name := range desktopEvidenceFiles {
+		if name == "transcript.jsonl" {
+			continue // the generic missing-transcript row already mutates this file.
+		}
+		t.Run(name, func(t *testing.T) {
+			mutated := writeRecordingFiles(t, name, files)
+			if err := os.WriteFile(filepath.Join(mutated, "manifest.json"), []byte(`{"execution_profile":"desktop-local"}`+"\n"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.Remove(filepath.Join(mutated, name)); err != nil {
+				t.Fatal(err)
+			}
+			findings := strings.Join(RecordingComplete(mutated), " | ")
+			if !strings.Contains(findings, "missing "+name) {
+				t.Fatalf("missing %s was accepted: %s", name, findings)
+			}
+		})
+	}
+}
+
 // writeRecordingFiles creates t.TempDir()/name/ populated with the given
 // empty-JSON files, mimicking a recording directory's on-disk shape for
 // RecordingComplete.

--- a/tools/onboarding-factory/scripts/lib/recording-profile-manifest_test.sh
+++ b/tools/onboarding-factory/scripts/lib/recording-profile-manifest_test.sh
@@ -94,10 +94,10 @@ else
   fail "CLI manifest keeps entrypoint and version identity" "writer output did not match the staged transcript"
 fi
 
-if check_manifest desktop-local sdk-cli 1.0.10; then
-  pass "Desktop manifest keeps sdk-cli, app version, and raw evidence"
+if check_manifest desktop-local claude-desktop 1.0.10; then
+  pass "Desktop manifest keeps claude-desktop, app version, and raw evidence"
 else
-  fail "Desktop manifest keeps sdk-cli, app version, and raw evidence" "writer output did not match the staged evidence"
+  fail "Desktop manifest keeps claude-desktop, app version, and raw evidence" "writer output did not match the staged evidence"
 fi
 
 echo ""

--- a/tools/onboarding-factory/scripts/lib/recording-profile-manifest_test.sh
+++ b/tools/onboarding-factory/scripts/lib/recording-profile-manifest_test.sh
@@ -43,6 +43,11 @@ check_manifest() (
   mkdir -p "$staged" "$dst"
   printf '%s\n' '{"seq":1,"ts":"2026-09-04T00:00:00Z"}' > "$staged/events.jsonl"
   printf '{"entrypoint":"%s"}\n' "$transcript_entrypoint" > "$staged/transcript.jsonl"
+  if [[ "$profile" == "desktop-local" ]]; then
+    for evidence_file in desktop-registry.json desktop-environment.json hooks.jsonl process.json irrlicht-session.json; do
+      printf 'raw %s\n' "$evidence_file" > "$staged/$evidence_file"
+    done
+  fi
 
   # Export because the extracted production blocks read these values through
   # eval. The export also makes that indirect use visible to shellcheck.
@@ -75,6 +80,9 @@ check_manifest() (
   fi
   if [[ "$profile" == "desktop-local" ]]; then
     [[ "$(jq -r '.desktop_app_version' "$dst/manifest.json")" == "$desktop_version" ]] || exit 13
+    for evidence_file in desktop-registry.json desktop-environment.json hooks.jsonl process.json irrlicht-session.json; do
+      cmp -s "$staged/$evidence_file" "$dst/$evidence_file" || exit 15
+    done
   elif jq -e 'has("desktop_app_version")' "$dst/manifest.json" >/dev/null; then
     exit 14
   fi
@@ -87,9 +95,9 @@ else
 fi
 
 if check_manifest desktop-local sdk-cli 1.0.10; then
-  pass "Desktop manifest keeps sdk-cli and adds the app version"
+  pass "Desktop manifest keeps sdk-cli, app version, and raw evidence"
 else
-  fail "Desktop manifest keeps sdk-cli and adds the app version" "writer output did not match the staged transcript"
+  fail "Desktop manifest keeps sdk-cli, app version, and raw evidence" "writer output did not match the staged evidence"
 fi
 
 echo ""

--- a/tools/promote-recording.sh
+++ b/tools/promote-recording.sh
@@ -245,7 +245,12 @@ NEW_STARTED_AT="$NEW_TS"
 # BEGIN recording_manifest_population
 populate_recording() {
   local dst="$1" f
-  for f in events.jsonl transcript.jsonl transcript.md transcript.json; do
+  # Desktop Local recordings preserve the raw identity chain that
+  # `of validate` reads. CLI staging does not create these files, so the same
+  # allow-list remains a no-op for every existing recording profile.
+  for f in events.jsonl transcript.jsonl transcript.md transcript.json \
+    desktop-registry.json desktop-environment.json hooks.jsonl process.json \
+    irrlicht-session.json; do
     if [[ -f "$STAGED_DIR/$f" ]]; then
       cp "$STAGED_DIR/$f" "$dst/$f"
     fi


### PR DESCRIPTION
Closes #1886

## Summary

- Add a strict, versioned `execution-results.json` contract for each Claude Code scenario cell.
- Validate every present result file independently of shard metadata parsing.
- Let the catalog require `desktop-local` results for the exact current Claude Code cell set.
- Validate observed results against the exact named recording and its expected-result verdict.
- Join Desktop registry, environment, transcript, Irrlicht session, process, and hook evidence.
- Require each preserved hook receipt to occur byte-for-byte in the same recording's `events.jsonl`, with multiset counts.
- Extend Desktop recording completeness and recording promotion to preserve the six evidence files.
- Keep default CLI status, matrix, and viewer behavior unchanged.

## Contract

A result document has `schema_version: 1` and a closed `results` array. Each entry has the exact cell `scenario_id`, `execution_profile: "desktop-local"`, and one of five outcomes.

Observed outcomes name one exact recording and six typed evidence files. Non-observed outcomes need a nonblank reason and a narrow evidence reference. `not-runnable` also needs `missing_control`.

The catalog switch is `meta.required_execution_profiles_by_agent.claudecode: ["desktop-local"]`. Its absence keeps legacy repositories and partial campaigns valid. When present, it requires exactly one Desktop result for every current Claude Code cell.

## Verification

All required preflight groups passed before the remote quality correction:

- `tools/preflight.sh --only go`
- `tools/preflight.sh --only web`
- `tools/preflight.sh --only arch`
- `tools/preflight.sh --only tools`
- `tools/preflight.sh --only skills`
- `tools/preflight.sh --only posix`
- `tools/preflight.sh --only bash`
- `tools/preflight.sh --only security`

Post-rebase checks passed:

- `go test ./cmd/of ./internal/desktopresults ./internal/validate ./internal/matrix -race -count=1`
- `go run ./tools/onboarding-factory/cmd/of validate`
- `tools/replay-fixtures.sh`
- `bash tools/onboarding-factory/scripts/lib/recording-profile-manifest_test.sh`
- `tools/preflight.sh --only arch`
- `gocyclo -over 8 tools/onboarding-factory/internal/desktopresults tools/onboarding-factory/cmd/of/desktop_results_test.go` produced no findings.

Post-CodeScene structural checks passed:

- `go test ./tools/onboarding-factory/cmd/of ./tools/onboarding-factory/internal/desktopresults ./tools/onboarding-factory/internal/validate ./tools/onboarding-factory/internal/matrix -race -count=1`
- `go test ./tools/onboarding-factory/... -race -count=1`
- `go run ./tools/onboarding-factory/cmd/of validate`
- `tools/preflight.sh --only arch` kept the composite score at 7.929214229633245.
- `gocyclo -over 8 internal/desktopresults/identity.go internal/desktopresults/validate.go` produced no findings.

One direct unscoped `tools/preflight.sh --only go` run after the first CodeScene refactor returned 1. All subgates passed except four tests in the unchanged Kiro package. Their fake commands reached the fixed five-second timeout under machine load. The direct isolated rerun `go test ./core/adapters/inbound/agents/kirocli -race -count=1` passed in 49.735s. The changed onboarding-factory packages and replay fixtures passed in that unscoped run and in the later direct commands above.

Swift is not applicable because this diff does not change `platforms/macos/`. The optional local Linux Docker gate was not run. Remote Linux CI covers that platform.

The bounded pre-push hook passed each completed check. Its 540-second total budget expired while it repeated replay. On the first push it reached 156 seconds of replay. On the CodeScene correction push it reached 96 seconds. Security did not start after the second timeout. Replay had already passed in the direct unbounded Go preflight. Security passed in its direct preflight group before these structural, dependency-free refactors. The documented `--no-verify` push preserved this exact evidence.

Security details: gosec found no High/High findings, and both npm audits found no High/Critical advisories. govulncheck reported only the gate's non-blocking Go standard-library advisories, which require a Go toolchain update.

## Red-first and mutation evidence

The initial validator test corpus failed before production code because the repository accepted missing results, malformed schemas, false identity claims, unsafe paths, and invalid outcome evidence.

Committed mutations cover:

- all five outcomes, absent-switch compatibility, partial campaigns, and enforced completeness;
- duplicate, unknown, malformed, orphan, off-path, and variant-folder result documents;
- dynamic Claude Code cell additions and other-adapter-only scenarios;
- missing reasons, evidence references, and missing controls;
- path traversal, symlink escape, circular evidence, and unrelated documentation;
- exact recording, profile, completeness, expected-result report, and both outcome-label swaps;
- registry mapping and scope, all workspace joins, transcript entrypoint, bundle ID, session ID, and PID;
- hook kind, name, session, exact same-recording bytes, extra fields, and duplicate counts;
- the promotion whitelist and the independent recording-completeness corpus.

The final hook provenance tests were red before the join existed. Changed hook name, added field, and duplicate count were accepted. A changed session lacked the required provenance finding. These cases pass after the fix.

## Review and remote analysis

Independent high behavioral review found and verified corrections for:

- measured project-local registry rows that omit `envScopeId`;
- completeness based on actual Claude Code cells only;
- hook receipt shape and hook provenance;
- exact recording completeness and outcome joins;
- narrow non-observed evidence scope;
- canonical-cell-only completeness counting;
- explicit off-path result findings.

That independent behavioral review is clean at `e2133ec3`. Later commits `625140d4` and `3bb17e52` contain structural CodeScene and Sonar refactors. They do not change the validation contract. The named post-CodeScene tests above reverified the behavior. CodeScene report 7453769 passes with zero negative findings and gives every added file a 10.0 score. SonarCloud passes with zero unresolved PR issues.

## Simplify pass

- **reuse:** Reuse `matrix.DesktopEvidenceFiles`, `validate.RecordingComplete`, and `validate.ValidateExpectedAgainst`.
- **simplification:** Split schema, path, identity, outcome, completeness, and hook-receipt checks into focused helpers.
- **efficiency:** Walk the repository once to register canonical cells and collect result documents. Resolve and read only the exact named recording.
- **altitude:** Keep command orchestration in `cmd/of`. Keep the strict evidence contract and typed validation contexts in `internal/desktopresults`.

## Design notes

This PR uses per-cell result documents. This layout supports parallel Desktop campaign branches. It does not add campaign results or enable the catalog completeness switch. A later campaign PR can add those artifacts and enable enforcement.

The validator uses the measured Desktop transcript entrypoint `claude-desktop`. It does not synthesize entrypoint identity from the execution profile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
