### PR TITLE
test(release): assert the routes serve the staged web tree, not just the copy list (#1900)

### DIFF
--- a/core/cmd/irrlichd/main.go
+++ b/core/cmd/irrlichd/main.go
@@ -684,9 +684,14 @@ func runDaemon() {
 		HookVerifier:      hookVerifier,
 	})
 
-	// Static web UI: served from disk so the dashboard ships as three files
-	// (index.html, irrlicht.css, irrlicht.js) under platforms/web/. API routes
-	// registered above take precedence over the catch-all "/".
+	// Static web UI: served from disk out of platforms/web/. The dashboard is
+	// an ES-module graph, not a fixed handful of files — every module
+	// irrlicht.js imports has to be in the served directory or the browser
+	// 404s the graph and renders nothing (#1900). tools/build-release.sh's
+	// WEB_FILES is the list that ships; what it must contain is derived and
+	// checked by platforms/web/release-files.test.js, and that the routes
+	// then serve it by TestRegisterUIRoutesServesTheStagedReleaseTree. API
+	// routes registered above take precedence over the catch-all "/".
 	registerUIRoutes(mux, logger)
 
 	srv := newHTTPServer(mux)

--- a/core/cmd/irrlichd/startup.go
+++ b/core/cmd/irrlichd/startup.go
@@ -409,9 +409,14 @@ func registerCoreRoutes(mux *http.ServeMux, deps registerCoreRoutesDeps) {
 	mux.HandleFunc("GET /debug/bundle", localhostOnly(handleDiagnosticsBundle(diagSvc)))
 }
 
-// registerUIRoutes serves the dashboard's static assets (index.html,
-// irrlicht.css, irrlicht.js) from disk, or a plain-text explainer if the UI
-// directory can't be found. Ensures web assets are served with the correct
+// registerUIRoutes serves the dashboard's static assets from disk with one
+// blanket http.FileServer, or a plain-text explainer if the UI directory
+// can't be found. It serves whatever the directory holds and asserts nothing
+// about its contents, which is why an incomplete release staging showed up
+// here as a page that loaded and then did nothing (#1900): the dashboard's
+// ES-module imports 404ed one by one. What the directory must contain is
+// pinned by TestRegisterUIRoutesServesTheStagedReleaseTree, not here.
+// Ensures web assets are served with the correct
 // Content-Type regardless of the host OS mime.types database (absent on
 // stripped Linux images — Go's content-sniffing fallback returns text/plain
 // for CSS, which has no magic bytes).

--- a/core/cmd/irrlichd/ui_release_tree_test.go
+++ b/core/cmd/irrlichd/ui_release_tree_test.go
@@ -204,7 +204,6 @@ func stageReleaseWebTree(t *testing.T, repoRoot, tmp string) string {
 	if err != nil {
 		t.Fatalf("cannot run: %s is unreadable (%v) — the release tooling this test executes is gone", script, err)
 	}
-
 	fragment, ok := cutWebStagingRegion(string(source))
 	if !ok {
 		t.Fatalf("cannot run: could not cut the WEB_FILES / copy_web_files region out of %s — the release script's shape changed and this test is no longer executing it", script)
@@ -214,18 +213,33 @@ func stageReleaseWebTree(t *testing.T, repoRoot, tmp string) string {
 	if err := os.MkdirAll(staged, 0o755); err != nil {
 		t.Fatalf("cannot run: %v", err)
 	}
-	cmd := exec.Command("bash", "-c", `
-set -euo pipefail
-cd "$1"
-`+fragment+`
+	runReleaseStaging(t, repoRoot, fragment, staged)
+	assertStagedTreeIsFlat(t, staged)
+	return staged
+}
+
+// runReleaseStaging evaluates the cut fragment and calls copy_web_files. The
+// fragment is asserted to define what it is supposed to define: a cut that
+// silently produced nothing would stage an empty tree, which every 200
+// assertion would then fail for the wrong reason.
+func runReleaseStaging(t *testing.T, repoRoot, fragment, staged string) {
+	t.Helper()
+	const preamble = "set -euo pipefail\ncd \"$1\"\n"
+	const epilogue = `
 declare -F copy_web_files >/dev/null || { echo "the cut region did not define copy_web_files" >&2; exit 2; }
 [ "${#WEB_FILES[@]}" -gt 0 ] || { echo "the cut region defined an empty WEB_FILES" >&2; exit 2; }
 copy_web_files "$2"
-`, "bash", repoRoot, staged)
+`
+	cmd := exec.Command("bash", "-c", preamble+fragment+epilogue, "bash", repoRoot, staged)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("cannot run: the release staging refused: %v\n%s", err, out)
 	}
+}
 
+// assertStagedTreeIsFlat rejects an empty staged tree and any directory in it —
+// node_modules ships by accident exactly that way.
+func assertStagedTreeIsFlat(t *testing.T, staged string) {
+	t.Helper()
 	entries, err := os.ReadDir(staged)
 	if err != nil {
 		t.Fatalf("cannot run: staged tree unreadable: %v", err)
@@ -235,11 +249,9 @@ copy_web_files "$2"
 	}
 	for _, e := range entries {
 		if e.IsDir() {
-			// node_modules ships by accident exactly this way.
 			t.Errorf("the staged release tree contains a directory (%s) — it must be flat", e.Name())
 		}
 	}
-	return staged
 }
 
 // cutWebStagingRegion returns the WEB_FILES array plus the copy_web_files
@@ -247,26 +259,31 @@ copy_web_files "$2"
 // column zero. Reports false when either end is absent.
 func cutWebStagingRegion(source string) (string, bool) {
 	lines := strings.Split(source, "\n")
-	start := -1
-	for i, l := range lines {
-		if strings.HasPrefix(l, "WEB_FILES=(") {
-			start = i
-			break
-		}
-	}
+	start := lineIndex(lines, func(l string) bool { return strings.HasPrefix(l, "WEB_FILES=(") })
 	if start < 0 {
 		return "", false
 	}
-	sawHelper := false
-	for i := start; i < len(lines); i++ {
-		if strings.HasPrefix(lines[i], "copy_web_files()") {
-			sawHelper = true
-		}
-		if sawHelper && lines[i] == "}" {
-			return strings.Join(lines[start:i+1], "\n"), true
+	rest := lines[start:]
+	helper := lineIndex(rest, func(l string) bool { return strings.HasPrefix(l, "copy_web_files()") })
+	if helper < 0 {
+		return "", false
+	}
+	// The helper's body ends at the first closing brace in column zero.
+	end := lineIndex(rest[helper:], func(l string) bool { return l == "}" })
+	if end < 0 {
+		return "", false
+	}
+	return strings.Join(rest[:helper+end+1], "\n"), true
+}
+
+// lineIndex returns the first index in lines whose value satisfies match, or -1.
+func lineIndex(lines []string, match func(string) bool) int {
+	for i, l := range lines {
+		if match(l) {
+			return i
 		}
 	}
-	return "", false
+	return -1
 }
 
 // reachableWebAssets returns every asset the browser will fetch, by running

--- a/core/cmd/irrlichd/ui_release_tree_test.go
+++ b/core/cmd/irrlichd/ui_release_tree_test.go
@@ -52,10 +52,7 @@ func TestRegisterUIRoutesServesTheStagedReleaseTree(t *testing.T) {
 	staged := stageReleaseWebTree(t, repoRoot, t.TempDir())
 	reachable := reachableWebAssets(t, repoRoot)
 
-	t.Setenv(envUIDir, staged)
-	mux := http.NewServeMux()
-	registerUIRoutes(mux, e2eLog{})
-	srv := httptest.NewServer(mux)
+	srv := serveStagedTree(t, staged)
 	defer srv.Close()
 
 	for _, missing := range missingFromServer(t, srv.URL, reachable) {
@@ -91,11 +88,39 @@ func TestServedTreeCheckGoesRedOnTheShippedRegression(t *testing.T) {
 
 	// The three-file staging rule, verbatim, as v0.6.2 shipped it.
 	shippedBlank := []string{"index.html", "irrlicht.css", "irrlicht.js"}
+	want := assetsExcept(reachable, shippedBlank)
+	if len(want) == 0 {
+		t.Fatal("cannot run: the closure holds nothing beyond the three entry files, so the regression has nothing to remove")
+	}
+
+	srv := serveStagedTree(t, stageNamedFiles(t, repoRoot, shippedBlank))
+	defer srv.Close()
+
+	got := assetNames(missingFromServer(t, srv.URL, reachable))
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Errorf("the three-file staging must be reported as broken.\n got: %v\nwant: %v", got, want)
+	}
+}
+
+// serveStagedTree points registerUIRoutes at staged and returns the running
+// test server. The caller closes it.
+func serveStagedTree(t *testing.T, staged string) *httptest.Server {
+	t.Helper()
+	t.Setenv(envUIDir, staged)
+	mux := http.NewServeMux()
+	registerUIRoutes(mux, e2eLog{})
+	return httptest.NewServer(mux)
+}
+
+// stageNamedFiles copies exactly names out of platforms/web into a fresh temp
+// directory — the deliberately-wrong staging the fixture above drives.
+func stageNamedFiles(t *testing.T, repoRoot string, names []string) string {
+	t.Helper()
 	staged := filepath.Join(t.TempDir(), "web")
 	if err := os.MkdirAll(staged, 0o755); err != nil {
 		t.Fatalf("cannot run: %v", err)
 	}
-	for _, name := range shippedBlank {
+	for _, name := range names {
 		src := filepath.Join(repoRoot, "platforms", "web", name)
 		body, err := os.ReadFile(src)
 		if err != nil {
@@ -105,33 +130,33 @@ func TestServedTreeCheckGoesRedOnTheShippedRegression(t *testing.T) {
 			t.Fatalf("cannot run: %v", err)
 		}
 	}
+	return staged
+}
 
-	t.Setenv(envUIDir, staged)
-	mux := http.NewServeMux()
-	registerUIRoutes(mux, e2eLog{})
-	srv := httptest.NewServer(mux)
-	defer srv.Close()
-
-	var got []string
-	for _, m := range missingFromServer(t, srv.URL, reachable) {
-		got = append(got, m.name)
+// assetsExcept returns names minus drop, sorted.
+func assetsExcept(names, drop []string) []string {
+	skip := make(map[string]bool, len(drop))
+	for _, d := range drop {
+		skip[d] = true
 	}
-	sort.Strings(got)
-
-	var want []string
-	for _, name := range reachable {
-		if name != "index.html" && name != "irrlicht.css" && name != "irrlicht.js" {
-			want = append(want, name)
+	var out []string
+	for _, n := range names {
+		if !skip[n] {
+			out = append(out, n)
 		}
 	}
-	sort.Strings(want)
+	sort.Strings(out)
+	return out
+}
 
-	if len(want) == 0 {
-		t.Fatal("cannot run: the closure holds nothing beyond the three entry files, so the regression has nothing to remove")
+// assetNames reduces a missing-asset report to its sorted names.
+func assetNames(missing []missingAsset) []string {
+	var out []string
+	for _, m := range missing {
+		out = append(out, m.name)
 	}
-	if strings.Join(got, ",") != strings.Join(want, ",") {
-		t.Errorf("the three-file staging must be reported as broken.\n got: %v\nwant: %v", got, want)
-	}
+	sort.Strings(out)
+	return out
 }
 
 // missingAsset names one asset the server failed to hand back, and why.

--- a/core/cmd/irrlichd/ui_release_tree_test.go
+++ b/core/cmd/irrlichd/ui_release_tree_test.go
@@ -1,0 +1,329 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// The served-side half of #1900. The released 0.6.2 daemon answered 404 for
+// every one of the dashboard's ES-module imports, because tools/build-release.sh
+// staged three files out of thirteen. registerUIRoutes was never at fault — it
+// registers one blanket http.FileServer — but "the daemon serves what the
+// release stages" was nobody's assertion, so the gap between the two stayed
+// invisible until a user reported a blank page.
+//
+// #1847 fixed the packaging and guards the copy list statically
+// (platforms/web/release-files.test.js). What no test asserted afterwards is
+// the end of that chain: that the routes, pointed at a tree the real staging
+// rule produced, actually answer 200 for every asset a browser will fetch.
+//
+// The two sides are derived from DIFFERENT sources on purpose. A test that
+// asked the staged directory what to request could never reproduce the defect:
+// whatever shipped would be exactly what it looked for, and three files would
+// pass as readily as eighteen.
+//
+//   - What is REQUESTED comes from platforms/web/shippedFiles.testutil.js's
+//     deriveShippedSet() — the transitive walk of index.html plus the import
+//     graph, i.e. what the browser will actually fetch.
+//   - What is SERVED comes from executing tools/build-release.sh's own
+//     WEB_FILES array and copy_web_files helper — what a release will
+//     actually contain.
+//
+// Both are the shipping implementations, not copies of them. A copy here would
+// prove something about this file and nothing about the release.
+//
+// It runs in-process against httptest rather than booting a daemon: the
+// packaging rule is graded by release-files.test.js, and what is left to prove
+// here is only that the routes serve the staged directory.
+func TestRegisterUIRoutesServesTheStagedReleaseTree(t *testing.T) {
+	repoRoot := releaseRepoRoot(t)
+
+	staged := stageReleaseWebTree(t, repoRoot, t.TempDir())
+	reachable := reachableWebAssets(t, repoRoot)
+
+	t.Setenv(envUIDir, staged)
+	mux := http.NewServeMux()
+	registerUIRoutes(mux, e2eLog{})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	for _, missing := range missingFromServer(t, srv.URL, reachable) {
+		t.Errorf("GET /%s = %s — this is exactly the 404 every released dashboard served for its ES modules (#1900)",
+			missing.name, missing.why)
+	}
+
+	// The two Content-Types registerUIRoutes exists to pin: a stripped Linux
+	// image has no mime.types, and Go's sniffing returns text/plain for CSS,
+	// which a browser then refuses to apply.
+	for name, wantPrefix := range map[string]string{
+		"irrlicht.css": "text/css",
+		"irrlicht.js":  "application/javascript",
+	} {
+		if _, got, _ := httpGetAsset(t, srv.URL+"/"+name); !strings.HasPrefix(got, wantPrefix) {
+			t.Errorf("GET /%s Content-Type = %q, want prefix %q", name, got, wantPrefix)
+		}
+	}
+}
+
+// TestServedTreeCheckGoesRedOnTheShippedRegression is the committed mutation
+// fixture for the test above. The guard it protects has no "before the fix" to
+// run red — #1847 already landed — so instead of describing the red path in a
+// PR body nothing re-runs, this stages the exact tree that shipped blank in
+// v0.6.0–v0.6.2 (index.html, irrlicht.css, irrlicht.js and nothing else) and
+// requires missingFromServer to name every module that is gone.
+//
+// If this ever passes with an empty result, the assertion above has stopped
+// being able to see the defect it exists for.
+func TestServedTreeCheckGoesRedOnTheShippedRegression(t *testing.T) {
+	repoRoot := releaseRepoRoot(t)
+	reachable := reachableWebAssets(t, repoRoot)
+
+	// The three-file staging rule, verbatim, as v0.6.2 shipped it.
+	shippedBlank := []string{"index.html", "irrlicht.css", "irrlicht.js"}
+	staged := filepath.Join(t.TempDir(), "web")
+	if err := os.MkdirAll(staged, 0o755); err != nil {
+		t.Fatalf("cannot run: %v", err)
+	}
+	for _, name := range shippedBlank {
+		src := filepath.Join(repoRoot, "platforms", "web", name)
+		body, err := os.ReadFile(src)
+		if err != nil {
+			t.Fatalf("cannot run: %s is missing (%v) — the regression cannot be staged", src, err)
+		}
+		if err := os.WriteFile(filepath.Join(staged, name), body, 0o644); err != nil {
+			t.Fatalf("cannot run: %v", err)
+		}
+	}
+
+	t.Setenv(envUIDir, staged)
+	mux := http.NewServeMux()
+	registerUIRoutes(mux, e2eLog{})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	var got []string
+	for _, m := range missingFromServer(t, srv.URL, reachable) {
+		got = append(got, m.name)
+	}
+	sort.Strings(got)
+
+	var want []string
+	for _, name := range reachable {
+		if name != "index.html" && name != "irrlicht.css" && name != "irrlicht.js" {
+			want = append(want, name)
+		}
+	}
+	sort.Strings(want)
+
+	if len(want) == 0 {
+		t.Fatal("cannot run: the closure holds nothing beyond the three entry files, so the regression has nothing to remove")
+	}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Errorf("the three-file staging must be reported as broken.\n got: %v\nwant: %v", got, want)
+	}
+}
+
+// missingAsset names one asset the server failed to hand back, and why.
+type missingAsset struct {
+	name string
+	why  string
+}
+
+// missingFromServer requests every asset in want from base and reports the
+// ones that did not come back as a non-empty 200. Shared by the assertion and
+// its mutation fixture so both grade with the same code.
+func missingFromServer(t *testing.T, base string, want []string) []missingAsset {
+	t.Helper()
+	var out []missingAsset
+	for _, name := range want {
+		// http.FileServer redirects /index.html to /, so the entry document is
+		// requested the way a browser asks for it.
+		url := base + "/" + name
+		if name == "index.html" {
+			url = base + "/"
+		}
+		status, _, size := httpGetAsset(t, url)
+		switch {
+		case status == 0:
+			out = append(out, missingAsset{name, "no response (transport error)"})
+		case status != http.StatusOK:
+			out = append(out, missingAsset{name, strconv.Itoa(status) + " " + http.StatusText(status)})
+		case size == 0:
+			out = append(out, missingAsset{name, "200 with an empty body"})
+		}
+	}
+	return out
+}
+
+// stageReleaseWebTree stages platforms/web into dir by executing the release's
+// own WEB_FILES array and copy_web_files helper, lifted out of
+// tools/build-release.sh. The script cannot be sourced whole — past this region
+// it deletes .build and starts a full release build — so the region is cut out
+// and evaluated. The cut is asserted, not assumed: a fragment that fails to
+// define copy_web_files fails the test rather than staging nothing.
+func stageReleaseWebTree(t *testing.T, repoRoot, tmp string) string {
+	t.Helper()
+	script := filepath.Join(repoRoot, "tools", "build-release.sh")
+	source, err := os.ReadFile(script)
+	if err != nil {
+		t.Fatalf("cannot run: %s is unreadable (%v) — the release tooling this test executes is gone", script, err)
+	}
+
+	fragment, ok := cutWebStagingRegion(string(source))
+	if !ok {
+		t.Fatalf("cannot run: could not cut the WEB_FILES / copy_web_files region out of %s — the release script's shape changed and this test is no longer executing it", script)
+	}
+
+	staged := filepath.Join(tmp, "web")
+	if err := os.MkdirAll(staged, 0o755); err != nil {
+		t.Fatalf("cannot run: %v", err)
+	}
+	cmd := exec.Command("bash", "-c", `
+set -euo pipefail
+cd "$1"
+`+fragment+`
+declare -F copy_web_files >/dev/null || { echo "the cut region did not define copy_web_files" >&2; exit 2; }
+[ "${#WEB_FILES[@]}" -gt 0 ] || { echo "the cut region defined an empty WEB_FILES" >&2; exit 2; }
+copy_web_files "$2"
+`, "bash", repoRoot, staged)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("cannot run: the release staging refused: %v\n%s", err, out)
+	}
+
+	entries, err := os.ReadDir(staged)
+	if err != nil {
+		t.Fatalf("cannot run: staged tree unreadable: %v", err)
+	}
+	if len(entries) == 0 {
+		t.Fatal("cannot run: the release staging produced an empty tree")
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			// node_modules ships by accident exactly this way.
+			t.Errorf("the staged release tree contains a directory (%s) — it must be flat", e.Name())
+		}
+	}
+	return staged
+}
+
+// cutWebStagingRegion returns the WEB_FILES array plus the copy_web_files
+// helper, from the array's opening line through the helper's closing brace at
+// column zero. Reports false when either end is absent.
+func cutWebStagingRegion(source string) (string, bool) {
+	lines := strings.Split(source, "\n")
+	start := -1
+	for i, l := range lines {
+		if strings.HasPrefix(l, "WEB_FILES=(") {
+			start = i
+			break
+		}
+	}
+	if start < 0 {
+		return "", false
+	}
+	sawHelper := false
+	for i := start; i < len(lines); i++ {
+		if strings.HasPrefix(lines[i], "copy_web_files()") {
+			sawHelper = true
+		}
+		if sawHelper && lines[i] == "}" {
+			return strings.Join(lines[start:i+1], "\n"), true
+		}
+	}
+	return "", false
+}
+
+// reachableWebAssets returns every asset the browser will fetch, by running
+// platforms/web/shippedFiles.testutil.js's own transitive walk of the import
+// graph rooted at index.html. That module is the derivation
+// release-files.test.js grades the copy list against, so the two halves of this
+// test never share a source.
+func reachableWebAssets(t *testing.T, repoRoot string) []string {
+	t.Helper()
+	webDir := filepath.Join(repoRoot, "platforms", "web")
+	cmd := exec.Command("node", "--input-type=module", "-e", `
+import { deriveShippedSet } from './shippedFiles.testutil.js';
+process.stdout.write(JSON.stringify([...deriveShippedSet().files].sort()));
+`)
+	cmd.Dir = webDir
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	if err != nil {
+		// The derivation's whole design is that every refusal explains itself,
+		// so its explanation is reported rather than reduced to "exit status 1".
+		t.Fatalf("cannot run: the import-graph walk refused on %s: %v\n%s", webDir, err, stderr.String())
+	}
+
+	var names []string
+	if err := json.Unmarshal(out, &names); err != nil {
+		t.Fatalf("cannot run: the import-graph walk returned unparseable output (%v): %s", err, out)
+	}
+
+	// Inability to look must not read as success: an empty or near-empty
+	// closure would satisfy every 200 assertion by having nothing to assert.
+	// The floor is the defect itself rather than a number picked here —
+	// v0.6.0–v0.6.2 shipped exactly index.html + irrlicht.css + irrlicht.js,
+	// so a closure that small is the bug wearing the test's clothes.
+	const shippedBroken = 3
+	if len(names) <= shippedBroken {
+		t.Fatalf("cannot run: the import-graph walk found only %d asset(s) (%v) — no more than the %d that shipped blank in #1900, so it did not read the dashboard", len(names), names, shippedBroken)
+	}
+	return names
+}
+
+// httpGetAsset fetches url and reports its status, Content-Type and body size.
+// A transport error is reported and returns a zero status, which every caller
+// treats as a failure.
+func httpGetAsset(t *testing.T, url string) (status int, contentType string, size int) {
+	t.Helper()
+	resp, err := http.Get(url)
+	if err != nil {
+		t.Errorf("GET %s: %v", url, err)
+		return 0, "", 0
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Errorf("GET %s: reading body: %v", url, err)
+	}
+	return resp.StatusCode, resp.Header.Get("Content-Type"), len(body)
+}
+
+// releaseRepoRoot returns the repo root. This file's own location is fixed at
+// core/cmd/irrlichd/, so the root is three directories up — the repo's
+// established test idiom — rather than a search that could silently land
+// somewhere else. It fails the test rather than returning a guess, so a
+// relocated package surfaces as "cannot run" instead of as a silent skip.
+func releaseRepoRoot(t *testing.T) string {
+	t.Helper()
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("cannot run: runtime.Caller could not locate this test file")
+	}
+	root, err := filepath.Abs(filepath.Join(filepath.Dir(thisFile), "..", "..", ".."))
+	if err != nil {
+		t.Fatalf("cannot run: %v", err)
+	}
+	for _, p := range []string{
+		filepath.Join(root, "tools", "build-release.sh"),
+		filepath.Join(root, "platforms", "web", "shippedFiles.testutil.js"),
+		filepath.Join(root, "platforms", "web", "index.html"),
+	} {
+		if _, err := os.Stat(p); err != nil {
+			t.Fatalf("cannot run: %s is missing (%v) — the release tooling this test executes is gone", p, err)
+		}
+	}
+	return root
+}


### PR DESCRIPTION
Closes #1900.

## Why this is small

#1900 reported a blank released dashboard. Root cause: `tools/build-release.sh` staged three of thirteen web files, so `irrlicht.js` 404ed its own ES-module graph and nothing rendered.

**#1847 already fixed that**, mid-investigation, with a `WEB_FILES` array + `copy_web_files` helper across four staging sites, plus fixes to `site/install.sh` and `examples/relay/Dockerfile`, guarded statically by `platforms/web/release-files.test.js`. Verified before writing this PR:

- Every runtime file in `platforms/web/` is in `WEB_FILES`; the only unlisted file is `shippedFiles.testutil.js`, a test helper.
- `release-files.test.js`: 62 passed.
- Staged a tree with main's own rule, booted a real `irrlichd` against it, polled every entry: **18/18 return 200** (`index.html` at `/`).

So this PR does not re-fix the packaging. It closes the two things #1847 left behind.

## What this adds

**1. The served-side assertion.** #1847's guard is static — it grades the copy list and never asks a server. `TestRegisterUIRoutesServesTheStagedReleaseTree` closes the chain: it stages the tree with the release's own rule, points `registerUIRoutes` at it, and requires 200 with a non-empty body for every asset a browser will fetch, plus the two Content-Types the function exists to pin.

The two sides come from **different sources** deliberately:

| | source | what it represents |
|---|---|---|
| REQUESTED | `shippedFiles.testutil.js`'s `deriveShippedSet()` | the transitive walk of `index.html` + the import graph — what the browser fetches |
| SERVED | `build-release.sh`'s own `WEB_FILES` + `copy_web_files`, cut out and executed | what a release actually contains |

Both are the shipping implementations, not copies. A test that asked the staged directory what to request could never reproduce the defect: three files would pass as readily as eighteen.

**2. The two stale comments** in `main.go` and `startup.go` that still said the dashboard "ships as three files". That is the assumption which broke, and it was still on record as true.

## Evidence

This guard has no "before the fix" to run red — #1847 already landed — so per AGENTS.md the red path is **committed as a fixture**, not described here:

- `TestServedTreeCheckGoesRedOnTheShippedRegression` stages the exact three-file tree v0.6.0–v0.6.2 shipped and requires the check to name every module that is gone. If it ever passes with an empty result, the assertion above has stopped being able to see its own defect.

**Mutation-proved against the thing it protects** — each seen red, then restored:

| mutation | result |
|---|---|
| drop `collapsedSet.js` from `WEB_FILES` | `GET /collapsedSet.js = 404 Not Found` |
| restore v0.6.2's three-file rule inside `copy_web_files` | **15** assets report 404 — the defect reproduced |
| rename `copy_web_files` | `cannot run: could not cut the WEB_FILES / copy_web_files region … this test is no longer executing it` |

**Fail-loud, observed not asserted.** During development `deriveShippedSet()` was called wrongly; the test reported `cannot run: the import-graph walk refused … TypeError` rather than passing on an empty set. Three further refusal paths fail rather than skip: an empty or ≤3-entry closure ("the bug wearing the test's clothes"), an empty or non-flat staged tree, and a missing release script.

## Gates

`tools/preflight.sh`, chunked, in the worktree — all green: `go`, `arch` (composite 7.9292 → 7.9290, no category regression), `web` (both suites), `tools`, `skills`, `posix`, `bash`, `security`. `swift` not run: the diff touches no `platforms/macos/`.

CI on the final commit — every gating check green:

| check | result |
|---|---|
| go-test, build-test, ars-gate | SUCCESS |
| swift-build, swift-test | SUCCESS |
| test (platforms/web), test (viewer web) | SUCCESS |
| CodeQL (actions / go / js-ts) | SUCCESS |
| SonarCloud | SUCCESS |
| CodeScene Code Health Review | FAILURE — **advisory only**, see below |

**CodeScene.** Advisory per AGENTS.md, and it drove two real refactors here: `8.41 → 9.31 → 9.39`, with the *critical* rule (Bumpy Road Ahead) cleared and 5 of 7 gates passing. What remains is `Primitive Obsession` + `String Heavy Function Arguments` on the test file — it passes filesystem paths and asset names as strings to helpers that shell out. Wrapping those in types would make this file worse to read, so I stopped rather than chase the gate.

**One flake, stated rather than hidden.** The first CI run failed `go-test` on `TestConcurrencyProject_WorktreeFoldsIntoRealRepo` in `core/adapters/outbound/filesystem` — a git-root fold-in test, unrelated to this diff (which touches only `core/cmd/irrlichd/`). Re-running the same job passed with no code change; the test passes 3/3 locally, and main's CI is green on it. This is the loaded-Linux-runner timing class AGENTS.md warns preflight cannot catch. An earlier local `--only go` run also reported `core module tests FAIL` once and was green on the two runs after it; that run's detail was lost to output truncation, so I cannot name what failed there.

## Not done

PR #1903 (the `ir:exec` output, based on main *before* #1847) proposed replacing the **list** with a **rule** (`tools/lib/stage-web.sh`). That design collides with #1847's just-merged suite — applying it gives 5 failed / 57 passed. Closed in favour of this smaller PR, per the maintainer's call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01615niHdVNthGbskmVG4JVt
