### PR TITLE
fix(web): give the quota strip its own header row so it stops overlapping the controls

### DIFF
--- a/platforms/web/headerLayout.test.js
+++ b/platforms/web/headerLayout.test.js
@@ -1,0 +1,115 @@
+// Header layout contract. The quota strip must stay on a row of its OWN,
+// under the title/controls row.
+//
+// The defect this pins: the chips shipped inside `.header-left`, on the same
+// non-wrapping flex row as the History/Context/theme/settings controls. The
+// chips are the one header element whose width grows with how many providers
+// are signed in, and `.header-right` is `flex-shrink: 0`, so past a certain
+// width the two simply painted on top of each other — "56% / 40%" underneath
+// the History button, "6 sessions" underneath the gear. Reported against
+// v0.6.2 at roughly 870px wide.
+//
+// jsdom has no layout engine, so this cannot assert geometry — every
+// getBoundingClientRect here would be zeroes. It asserts the two things that
+// CAUSE the geometry instead, both of which a future edit could undo without
+// noticing: the DOM places the strip outside the control row, and the CSS
+// makes the header a column so that placement means "below" rather than
+// "beside". The geometry itself was verified in a real browser at 1137 / 870 /
+// 500 / 420 / 360 px — chips below the row, no overlap, no horizontal page
+// scroll at any of them.
+//
+// Fail-loud (house rule: a verifier that cannot run must never read as a
+// pass): an unreadable file, an index.html with no <header>, and a stylesheet
+// with no `header {` block each FAIL rather than vacuously satisfying the
+// assertions below.
+
+import { describe, expect, test } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { JSDOM } from 'jsdom';
+import { WEB_DIR } from './shippedFiles.testutil.js';
+
+function read(name) {
+  const body = readFileSync(join(WEB_DIR, name), 'utf8');
+  if (body.trim().length === 0) {
+    throw new Error(`fail-loud: ${name} is empty — nothing below can be trusted`);
+  }
+  return body;
+}
+
+const html = read('index.html');
+const css = read('irrlicht.css');
+
+function headerElement() {
+  const header = new JSDOM(html).window.document.querySelector('header');
+  if (!header) {
+    throw new Error('fail-loud: index.html has no <header> — the parse found nothing to assert on');
+  }
+  return header;
+}
+
+// The declaration block of the first CSS rule whose selector list is exactly
+// `selector`. Throws rather than returning '' so a renamed selector fails
+// loudly instead of satisfying every "does not contain" assertion.
+function ruleBody(selector) {
+  // Anchored to a line start so `header` cannot match inside `.header-row`,
+  // and so a rule introduced by a comment block (rather than by the previous
+  // rule's `}`) is still found.
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const m = new RegExp('(?:^|\\n)[ \\t]*' + escaped + '\\s*\\{([^}]*)\\}').exec(css);
+  if (!m) {
+    throw new Error(`fail-loud: irrlicht.css has no \`${selector} { … }\` rule — the parse found nothing to assert on`);
+  }
+  return m[1];
+}
+
+describe('the quota strip sits on its own header row', () => {
+  test('index.html puts #quota-chips outside the title/controls row', () => {
+    const header = headerElement();
+    const chips = header.querySelector('#quota-chips');
+    expect(chips, '#quota-chips must live inside <header>').not.toBeNull();
+
+    // The whole point: not inside the row that holds the controls.
+    expect(chips.closest('.header-row'), '#quota-chips must not be inside .header-row').toBeNull();
+    expect(chips.closest('.header-left'), '#quota-chips must not be inside .header-left').toBeNull();
+    expect(chips.closest('.header-right'), '#quota-chips must not be inside .header-right').toBeNull();
+    expect(chips.parentElement.tagName.toLowerCase()).toBe('header');
+  });
+
+  test('the strip comes after the control row, so a column puts it below', () => {
+    const header = headerElement();
+    const row = header.querySelector('.header-row');
+    expect(row, '<header> must hold a .header-row').not.toBeNull();
+    const chips = header.querySelector('#quota-chips');
+    // Node.DOCUMENT_POSITION_FOLLOWING === 4
+    expect(row.compareDocumentPosition(chips) & 4).toBeTruthy();
+  });
+
+  test('the controls still share one row with the title', () => {
+    const row = headerElement().querySelector('.header-row');
+    expect(row.querySelector('.header-left'), '.header-left belongs in .header-row').not.toBeNull();
+    expect(row.querySelector('.header-right'), '.header-right belongs in .header-row').not.toBeNull();
+  });
+
+  test('the header stacks its rows, so "after" renders as "below"', () => {
+    expect(ruleBody('header')).toMatch(/flex-direction:\s*column/);
+    expect(ruleBody('.header-row')).toMatch(/display:\s*flex/);
+  });
+
+  test('the title is no longer hidden to make room for the chips', () => {
+    // The chips used to REPLACE the version line, because there was only one
+    // row to put either in. With a row each, both are visible at once.
+    expect(css).not.toMatch(/header\.has-quota-chips\s+\.app-title\s*\{[^}]*display:\s*none/);
+  });
+
+  test('a long left side shrinks rather than overflowing into the controls', () => {
+    // A flex item's default min-width is its content, which is what let the
+    // two halves overlap instead of clip.
+    expect(ruleBody('.header-left')).toMatch(/min-width:\s*0/);
+    expect(ruleBody('.header-right')).toMatch(/min-width:\s*0/);
+  });
+
+  test('more chips than fit scroll inside the strip, never widening the header', () => {
+    expect(ruleBody('.quota-chips')).toMatch(/overflow-x:\s*auto/);
+  });
+});

--- a/platforms/web/index.html
+++ b/platforms/web/index.html
@@ -25,31 +25,39 @@
 </head>
 <body>
   <header>
-    <div class="header-left">
-      <div class="app-title">
-        <span class="app-name">Irrlicht</span>
-        <span class="app-version" id="app-version"></span>
-        <span class="app-sep">—</span>
+    <div class="header-row">
+      <div class="header-left">
+        <div class="app-title">
+          <span class="app-name">Irrlicht</span>
+          <span class="app-version" id="app-version"></span>
+          <span class="app-sep">—</span>
+        </div>
+        <div class="app-state-icons" id="app-state-icons" aria-label="Active sessions"></div>
       </div>
-      <div class="quota-chips" id="quota-chips" aria-label="Provider quota"></div>
-      <div class="app-state-icons" id="app-state-icons" aria-label="Active sessions"></div>
+      <div class="header-right">
+        <button class="view-mode-cycle" id="history-tab-toggle" type="button"
+                title="Show historical cost analytics">History</button>
+        <button class="view-mode-cycle" id="view-mode-cycle" type="button"
+                title="Cycle Context / 1 Min / 10 Min / 60 Min">Context</button>
+        <button class="theme-toggle" id="summary-collapse-all" type="button"
+                title="Collapse all pending questions" aria-label="Collapse all pending questions">⊟</button>
+        <button class="theme-toggle" id="theme-toggle" type="button"
+                title="Toggle light/dark theme" aria-label="Toggle theme">☾</button>
+        <button class="theme-toggle" id="settings-toggle" type="button"
+                title="Settings" aria-label="Settings">⚙</button>
+        <output class="ws-status" aria-live="polite">
+          <span class="ws-dot connecting" id="ws-dot"></span>
+          <span id="ws-label">connecting</span>
+        </output>
+      </div>
     </div>
-    <div class="header-right">
-      <button class="view-mode-cycle" id="history-tab-toggle" type="button"
-              title="Show historical cost analytics">History</button>
-      <button class="view-mode-cycle" id="view-mode-cycle" type="button"
-              title="Cycle Context / 1 Min / 10 Min / 60 Min">Context</button>
-      <button class="theme-toggle" id="summary-collapse-all" type="button"
-              title="Collapse all pending questions" aria-label="Collapse all pending questions">⊟</button>
-      <button class="theme-toggle" id="theme-toggle" type="button"
-              title="Toggle light/dark theme" aria-label="Toggle theme">☾</button>
-      <button class="theme-toggle" id="settings-toggle" type="button"
-              title="Settings" aria-label="Settings">⚙</button>
-      <output class="ws-status" aria-live="polite">
-        <span class="ws-dot connecting" id="ws-dot"></span>
-        <span id="ws-label">connecting</span>
-      </output>
-    </div>
+    <!-- Provider quota strip. Its own row UNDER the title/controls row, not
+         beside them: the chips are the one header element whose width grows
+         with the number of providers signed in, so on the same row they push
+         into the right-hand controls and the two paint on top of each other
+         (reported against v0.6.2 at ~870px). A row of its own has the whole
+         width to itself and cannot collide with anything. -->
+    <div class="quota-chips" id="quota-chips" aria-label="Provider quota"></div>
   </header>
 
   <dialog class="settings-modal-backdrop" id="settings-backdrop" aria-modal="true" aria-label="Settings">

--- a/platforms/web/irrlicht.css
+++ b/platforms/web/irrlicht.css
@@ -170,18 +170,35 @@
       position: sticky;
       top: 0;
       z-index: 10;
+      /* A COLUMN of rows, not one row. The quota strip is the second row (see
+         .quota-chips): it is the only header element whose width grows with
+         how many providers are signed in, and beside the controls it pushed
+         into them until the two painted on top of each other. Everything that
+         was the header's single row now lives in .header-row, which keeps the
+         old layout exactly. */
       display: flex;
-      align-items: center;
-      justify-content: space-between;
-      padding: 12px 20px;
+      flex-direction: column;
+      align-items: stretch;
+      gap: 8px;
+      padding: 10px 20px;
       border-bottom: 1px solid var(--border-subtle);
       background: var(--header-bg);
       backdrop-filter: blur(12px);
       -webkit-backdrop-filter: blur(12px);
     }
 
-    .header-left { display: flex; align-items: center; gap: 10px; min-width: 0; }
-    .header-right { display: flex; align-items: center; gap: 10px; flex-shrink: 0; }
+    .header-row {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 10px;
+    }
+
+    /* min-width:0 on both halves so a long left side SHRINKS instead of
+       overflowing into the right one — a flex item's default min-width is its
+       content, which is what let the two overlap rather than clip. */
+    .header-left { display: flex; align-items: center; gap: 10px; min-width: 0; overflow: hidden; }
+    .header-right { display: flex; align-items: center; gap: 10px; flex-shrink: 0; min-width: 0; }
 
     /* App title — mirrors overlay's "Irrlicht v$VERSION" left of the state icons. */
     .app-title {
@@ -207,10 +224,17 @@
     .quota-chips {
       display: none;
       align-items: flex-start;
-      gap: 10px;
+      gap: 14px;
       font-family: var(--font-mono);
+      /* Its own full-width row under .header-row. More providers than fit
+         scroll sideways inside the strip rather than widening the header, so
+         the row can never push into anything. */
+      overflow-x: auto;
+      scrollbar-width: none;
     }
-    header.has-quota-chips .app-title { display: none; }
+    .quota-chips::-webkit-scrollbar { display: none; }
+    /* The strip no longer REPLACES the version line — it has its own row, so
+       both are visible at once. */
     header.has-quota-chips .quota-chips { display: flex; }
 
     .quota-chip {
@@ -1186,15 +1210,14 @@
     }
 
     @media (max-width: 420px) {
-      header { flex-wrap: wrap; gap: 8px; }
+      .header-row { flex-wrap: wrap; gap: 8px; }
       main { padding: 8px 10px; }
       .row-cost { display: none; }
       .app-state-icons { display: none; }
-      /* Two quota chips at ~108px each + gap + right-side header buttons
-         overflow narrow viewports. Mirror the .app-state-icons rule above:
-         hide the chip strip and restore the version title underneath. */
-      header.has-quota-chips .quota-chips { display: none; }
-      header.has-quota-chips .app-title { display: flex; }
+      /* The chip strip used to be hidden here, because two chips at ~108px
+         each plus the right-side buttons overflowed a narrow viewport. It has
+         had its own row since the overlap fix, so there is nothing left to
+         collide with and it stays visible — it scrolls sideways instead. */
     }
 
     @media (max-width: 360px) {


### PR DESCRIPTION
## The defect

The quota strip shipped inside `.header-left`, on the same non-wrapping flex row as History / Context / ⊟ / ☾ / ⚙ / the connection dot.

The chips are the one header element whose width **grows with how many providers are signed in**, and `.header-right` is `flex-shrink: 0`. Past a certain width the two simply painted on top of each other — reported against v0.6.2 at roughly 870px, with "56% / 40%" under the History button and "6 sessions" under the gear.

## The fix

`<header>` is now a **column of two rows**. Everything that was its single row moves into `.header-row` unchanged; the strip is the second row and has the full width to itself, so it cannot collide with anything.

Three consequences follow:

- **The version line is no longer hidden.** `header.has-quota-chips .app-title { display: none }` existed only because there was one row to put either in. With a row each, both are visible.
- **`.header-left` / `.header-right` get `min-width: 0`.** A flex item's default min-width is its content — that is what let the two halves *overlap* instead of clip.
- **The 420px rule that hid the strip is gone.** It existed only because the strip shared the row with the controls. It doesn't any more, so the strip stays visible and scrolls sideways inside itself (`overflow-x: auto`) rather than widening the header.

No JavaScript changed. `renderHeaderTitle` already located both elements by id/tag, independent of nesting.

## Verified

In a real browser against the live daemon, at five widths. Every pair of header boxes checked for intersection, not eyeballed:

| width | chips below the row | left/right overlap | chips vs controls | page scrolls sideways |
|---|---|---|---|---|
| 1137 | yes | none | none | no |
| 870 (the reported width) | yes | none | none | no |
| 500 | yes | none | none | no — **was yes** |
| 420 | yes | none | none | no |
| 360 | yes | none | none | no |

Both provider chips render at every width, including 420 and 360 where the strip used to be hidden outright.

**One measurement trap worth recording:** the first probe run reported the *old* layout at every width, because the iframes reused the browser-cached `irrlicht.css` while loading the new `index.html`. The probe now swaps in a cache-busted stylesheet and **refuses to measure** unless a `.header-row` rule is actually in force — absence of a finding and inability to look must not produce the same output.

## Regression test

`platforms/web/headerLayout.test.js` (7 tests). jsdom has no layout engine, so it cannot assert geometry — every `getBoundingClientRect` there is zeroes. It asserts the two things that *cause* the geometry, either of which a future edit could undo without noticing: the DOM places the strip outside the control row, and the CSS makes the header a column. Plus the `min-width: 0` and `overflow-x` rules.

Seen red under five mutations, each restored afterwards:

| mutation | result |
|---|---|
| chips back inside `.header-left` | 1 failed |
| header back to a single row | 1 failed |
| the title hidden again for the chips | 1 failed |
| `.header-right` loses `min-width: 0` | 1 failed |
| `index.html` loses its `<header>` | 3 failed — **refuses to measure**, does not pass on nothing |

## Gates

`platforms/web` suite: **496 passed** (25 files). `tools/preflight.sh --only web` / `skills` / `posix` / `bash` / `tools`: all PASS. The served-tree tests from #1906 re-run green against the changed `index.html`.

Not run: `go` (full), `arch`, `swift` — the diff touches only `platforms/web/`.

## Scope

Web dashboard only. The macOS app draws its own quota chips through `QuotaChipParts.swift` / `SessionListView.swift` and is untouched; if the same crowding shows up there it needs its own fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01615niHdVNthGbskmVG4JVt
