### PR TITLE
fix(workflow-step): stop the header read racing its writer, and refuse a record it cannot read

### DIFF
--- a/tools/lib/shell-lib-errexit_test.sh
+++ b/tools/lib/shell-lib-errexit_test.sh
@@ -446,9 +446,24 @@ row 'workflow-step.sh::_workflow_step_record' '_workflow_step_record (refuses an
 row 'workflow-step.sh::_workflow_step_scan' '_workflow_step_scan' 0 \
     ". tools/lib/workflow-step.sh" \
     "_workflow_step_scan $WS_DATA/no-shell.yml 'Plain step' >/dev/null"
+# The field readers are driven off a REAL record — `_workflow_step_scan`'s own
+# output — because a hand-written prefix like `matches 1` is exactly what they
+# now refuse: a record cut short reads fine as far as it goes, and its empty
+# fields are indistinguishable from a step that declares no `shell:`. So the
+# refusal rows below drive that prefix deliberately.
+WS_REC=". tools/lib/workflow-step.sh; WSREC=\$(_workflow_step_scan $WS_DATA/no-shell.yml 'Plain step')"
 row 'workflow-step.sh::_workflow_step_field' '_workflow_step_field' 0 \
+    "$WS_REC" \
+    '_workflow_step_field "$WSREC" matches >/dev/null'
+row 'workflow-step.sh::_workflow_step_field' '_workflow_step_field (refuses a truncated record)' 2 \
     '. tools/lib/workflow-step.sh' \
-    '_workflow_step_field "matches 1" matches >/dev/null'
+    '_workflow_step_field "matches 1" matches >/dev/null 2>&1'
+row 'workflow-step.sh::_workflow_step_field_of' '_workflow_step_field_of' 0 \
+    "$WS_REC" \
+    "_workflow_step_field_of \"\$WSREC\" matches $WS_DATA/no-shell.yml 'Plain step' >/dev/null"
+row 'workflow-step.sh::_workflow_step_field_of' '_workflow_step_field_of (refuses a truncated record)' 2 \
+    '. tools/lib/workflow-step.sh' \
+    "_workflow_step_field_of 'matches 1' matches $WS_DATA/no-shell.yml 'Plain step' >/dev/null 2>&1"
 
 row 'swift-suite.sh::swift_suite_completed' 'swift_suite_completed' 0 \
     '. tools/lib/swift-suite.sh' \

--- a/tools/lib/workflow-step.sh
+++ b/tools/lib/workflow-step.sh
@@ -57,6 +57,13 @@
 #   - MORE than one step carries that name (which one was being graded?)
 #   - the step declares a `shell:` this library does not model
 #   - (body only) the step has no `run: |` block, or an empty one
+#   - the scan record itself could not be read — truncated, or missing a header
+#     key or the `body` marker. Added last and from the inside (see
+#     _workflow_step_field): every refusal above guards the SCAN, and none of
+#     them guarded the reading of what the scan produced, so a record that came
+#     back short was searched without complaint and its empty fields walked to
+#     `bash -e` at status 0 — this list's opening promise broken by the one
+#     code path that never appeared on it.
 #
 # Status 2 rather than 1 throughout, so a refusal is distinguishable from an
 # errexit abort in a caller — the same reason shell-lib-suite.sh separates them.
@@ -208,9 +215,103 @@ _workflow_step_scan() {
   ' "$1"
 }
 
-# _workflow_step_field <record> <key> — the value of one header line.
+# _workflow_step_field <record> <key> — the value of one header line on stdout,
+# 0 if it was read, 2 if the record could not be read at all.
+#
+# ---------------------------------------------------------------------------
+# Why this reads the record to EOF instead of stopping at the answer
+#
+# It used to be one line:
+#
+#     printf '%s\n' "$1" | awk -v k="$2" '$1 == k { …; print; exit } $1 == "body" { exit }'
+#
+# and both `exit`s are a reader closing a pipe while the writer is still inside
+# write(2). Whether that is survivable depends on a disposition NOBODY here
+# sets: with SIGPIPE at SIG_DFL the writer is killed without a word, and with
+# SIGPIPE ignored — inherited, unchanged, from any parent that ignores it —
+# write returns EPIPE and bash reports it. On stderr. In the middle of a
+# derivation that then succeeds.
+#
+# Which is how it surfaced: test.yml's "Test the shared shell libs" step on the
+# Linux runner, comparing a value its harness had captured with `2>&1` the way
+# every caller in tools/lib/ does:
+#
+#   expected [bash -e] got [status 0 :: tools/lib/workflow-step.sh: line 213:
+#                           printf: write error: Broken pipe bash -e ]
+#
+# A right answer with a diagnostic welded to the front of it, at status 0. The
+# record is a few hundred bytes for a real step, so this raced on scheduling
+# and passed everywhere it was run by hand.
+#
+# So the answer is no longer taken early: the whole record is consumed and the
+# value emitted from END. There is nothing to save by stopping — the record is
+# one step's header plus one step's body — and a reader that never closes early
+# cannot signal its writer at all.
+#
+# ---------------------------------------------------------------------------
+# ...and why a read that fails is a refusal rather than an empty string
+#
+# The second defect is the one that outlives the pipe. Every field read here
+# returned its value and NOTHING else — no status a caller could act on — so
+# "this step declares no `shell:`" and "the record could not be read" arrived
+# identically, as the empty string. workflow_step_shell then walked its three
+# empty fields to `WORKFLOW_STEP_SHELL_DEFAULT` and returned 0.
+#
+# That is `bash -e`: the loosest invocation GitHub has, no `-o pipefail`, handed
+# out as a derivation by a function that had just failed to read its input. It
+# is precisely the fallback this file's header opens by forbidding — arrived at
+# from the inside, past every refusal above, because the refusals all guard the
+# scan and none of them guarded the reading of what the scan produced.
+#
+# So the record is now VALIDATED, not merely searched: every header key the scan
+# emits must be present, ahead of a `body` marker that must be there. A prefix
+# of a record parses fine as far as it goes, and an empty `step_shell` in one is
+# indistinguishable from a step declaring nothing — the truncation has to be
+# caught structurally or not at all. awk exits 3 on any of it; any non-zero at
+# all (including awk being killed) is a refusal here.
+#
+# `|| st=$?` and not a bare assignment: under a caller's `-e` a command
+# substitution that exits non-zero aborts on that line, which would leak awk's
+# 3 out of a function this repo's shell-lib-errexit_test.sh requires to RETURN
+# its documented status. Measured — it caught exactly that here.
 _workflow_step_field() {
-  printf '%s\n' "$1" | awk -v k="$2" '$1 == k { $1 = ""; sub(/^ /, ""); print; exit } $1 == "body" { exit }'
+  local val st=0
+  val=$(printf '%s\n' "$1" | awk -v k="$2" '
+    !inbody && $1 == "body" && NF == 1 { inbody = 1; next }
+    inbody { next }
+    {
+      seen[$1] = 1
+      if (!found && $1 == k) { $1 = ""; sub(/^ /, ""); val = $0; found = 1 }
+    }
+    END {
+      if (!inbody) exit 3
+      n = split("matches step_shell job_shell wf_shell has_run", need, " ")
+      for (i = 1; i <= n; i++) { if (!(need[i] in seen)) exit 3 }
+      if (!found) exit 3
+      printf "%s\n", val
+    }
+  ') || st=$?
+  if [ "$st" -ne 0 ]; then
+    printf 'workflow-step: refusing — the scan record could not be read (field `%s`, reader exited %d). A truncated or unparseable record must not be answered from: an unreadable field is empty, and an empty field is how "this step declares no `shell:`" looks, so answering would return `%s` as a derivation.\n' \
+      "$2" "$st" "$WORKFLOW_STEP_SHELL_DEFAULT" >&2
+    return 2
+  fi
+  printf '%s\n' "$val"
+  return 0
+}
+
+# _workflow_step_field_of <record> <key> <workflow-file> <step-name> — the same
+# read, with the file and step named in the refusal. Reading a header line is
+# the one operation both public functions do repeatedly, and none of them may
+# carry on with an empty string when it fails.
+_workflow_step_field_of() {
+  local val
+  val=$(_workflow_step_field "$1" "$2") || {
+    printf 'workflow-step: refusing — %s: nothing about the "%s" step could be derived, because the scan record for it could not be read.\n' "$3" "$4" >&2
+    return 2
+  }
+  printf '%s\n' "$val"
+  return 0
 }
 
 # _workflow_step_record <workflow-file> <step-name> — the scan, with the two
@@ -225,7 +326,7 @@ _workflow_step_record() {
     printf 'workflow-step: refusing — the scan of %s failed, so nothing about the "%s" step could be derived.\n' "$wf" "$name" >&2
     return 2
   }
-  matches=$(_workflow_step_field "$rec" matches)
+  matches=$(_workflow_step_field_of "$rec" matches "$wf" "$name") || return 2
   if [ "${matches:-0}" -eq 0 ]; then
     printf 'workflow-step: refusing — %s has no step named "%s". A harness cannot grade a step that is not there, and falling back to a default would grade an empty body as a clean run.\n' "$wf" "$name" >&2
     return 2
@@ -252,12 +353,18 @@ workflow_step_shell() {
   local wf="${1:-}" name="${2:-}" rec want src
   rec=$(_workflow_step_record "$wf" "$name") || return 2
 
-  want=$(_workflow_step_field "$rec" step_shell); src="the step's own \`shell:\`"
+  # Each read is `|| return 2`, not a bare assignment: the fall-through below
+  # treats an empty value as "not declared at this level", so a read that FAILED
+  # would walk straight to WORKFLOW_STEP_SHELL_DEFAULT and return it at status 0.
+  want=$(_workflow_step_field_of "$rec" step_shell "$wf" "$name") || return 2
+  src="the step's own \`shell:\`"
   if [ -z "$want" ]; then
-    want=$(_workflow_step_field "$rec" job_shell); src="the job's \`defaults: run: shell:\`"
+    want=$(_workflow_step_field_of "$rec" job_shell "$wf" "$name") || return 2
+    src="the job's \`defaults: run: shell:\`"
   fi
   if [ -z "$want" ]; then
-    want=$(_workflow_step_field "$rec" wf_shell); src="the workflow's \`defaults: run: shell:\`"
+    want=$(_workflow_step_field_of "$rec" wf_shell "$wf" "$name") || return 2
+    src="the workflow's \`defaults: run: shell:\`"
   fi
 
   case "$want" in
@@ -277,10 +384,11 @@ workflow_step_shell() {
 # body exits 0 under every invocation and is indistinguishable from a step that
 # passes.
 workflow_step_body() {
-  local wf="${1:-}" name="${2:-}" rec body lines
+  local wf="${1:-}" name="${2:-}" rec body lines has_run
   rec=$(_workflow_step_record "$wf" "$name") || return 2
 
-  if [ "$(_workflow_step_field "$rec" has_run)" != "1" ]; then
+  has_run=$(_workflow_step_field_of "$rec" has_run "$wf" "$name") || return 2
+  if [ "$has_run" != "1" ]; then
     printf 'workflow-step: refusing — %s: step "%s" has no `run: |` block to extract (a `uses:` step, or a single-line `run:` this library does not model).\n' "$wf" "$name" >&2
     return 2
   fi

--- a/tools/lib/workflow-step_test.sh
+++ b/tools/lib/workflow-step_test.sh
@@ -328,6 +328,115 @@ real_row .github/workflows/macos-swift.yml                'Test (bounded, stream
 real_row .github/workflows/macos-swift.yml                "Collect the skipped suites' pixels"          "$BASH"
 
 # ---------------------------------------------------------------------------
+# Obligation 7 — reading one header line out of the scan record can neither
+# corrupt the answer nor quietly decay into the default.
+#
+# Both halves are one CI failure, seen on the Linux runner of test.yml's
+# "Test the shared shell libs" step:
+#
+#   FAIL: .github/workflows/ars.yml :: Run ARS scan — expected [bash -e]
+#     got [status 0 :: tools/lib/workflow-step.sh: line 213:
+#          printf: write error: Broken pipe bash -e ]
+#
+# `_workflow_step_field` wrote the whole record into a pipe whose awk `exit`ed
+# at the first matching line. A reader that closes the pipe while the writer is
+# still inside write(2) is a SIGPIPE: where SIGPIPE is at SIG_DFL the writer is
+# killed silently, and where it is IGNORED bash reports the failed write on
+# STDERR instead. The runner's log is itself the evidence for which of the two
+# it was — bash only ever reaches that message on an EPIPE *return*, which a
+# process whose SIGPIPE is fatal cannot observe.
+#
+# And every harness here, like every caller in tools/lib/, captures a
+# derivation with `2>&1`. So the diagnostic became part of the VALUE: a string
+# still ending in `bash -e`, still carrying status 0 — an answer that happens
+# to contain the right substring. Hence two arms:
+#
+#   a. a successful derivation is SILENT, and survives a record far larger than
+#      a pipe will hold. Driven with SIGPIPE ignored, because that is the
+#      disposition under which the defect is visible rather than fatal — under
+#      SIG_DFL the writer dies without a word and this arm cannot see it.
+#   b. a record that cannot be read is a REFUSAL. This is the dangerous half:
+#      `bash -e` is exactly what an empty field read decays to, so a reader
+#      that fails quietly hands every harness the loosest invocation GitHub has
+#      and calls it a derivation — the "never fall back to a default" rule this
+#      library's own header is built on, broken from the inside.
+echo ""
+echo "== a header-line read cannot race its own writer =="
+
+# A body far past any pipe's capacity (64KiB on Linux, less on macOS), so the
+# writer MUST still be in write(2) when an early-exiting reader closes the pipe.
+# Generated rather than committed: the shape is what matters, not the bytes.
+BIG_WF="$TMP/oversized.yml"
+{
+  printf 'name: oversized\n'
+  printf 'jobs:\n  j:\n    runs-on: ubuntu-latest\n    steps:\n'
+  printf '      - name: Plain step\n        run: |\n'
+  awk 'BEGIN { for (i = 0; i < 8000; i++) printf "          echo %d aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n", i }'
+} >"$BIG_WF"
+big_bytes=$(wc -c <"$BIG_WF" | tr -d ' ')
+if [[ "${big_bytes:-0}" -lt 262144 ]]; then
+  fail "the oversized fixture really is oversized" ">= 262144 bytes" "${big_bytes:-0} bytes — the arms below would not have raced anything"
+else
+  pass "the oversized fixture is $big_bytes bytes (>= 262144)"
+
+  # The merged capture — byte for byte what real_row/want_shell above do, and
+  # what CI compared.
+  merged=$( ( trap '' PIPE; workflow_step_shell "$BIG_WF" 'Plain step' ) 2>&1 ); m_st=$?
+  if [[ "$m_st" -eq 0 && "$merged" == "$DEFAULT" ]]; then
+    pass "an oversized record derives \`$DEFAULT\` with nothing else in the value"
+  else
+    fail "an oversized record derives \`$DEFAULT\` and nothing else" "$DEFAULT" "status $m_st :: $(flat "$merged")"
+  fi
+
+  # ...and the same thing said as a property, so a future diagnostic on a
+  # SUCCESS path is caught whatever it says: stderr is empty when the answer is
+  # an answer.
+  s_err=$( ( trap '' PIPE; workflow_step_shell "$BIG_WF" 'Plain step' >/dev/null ) 2>&1 )
+  if [[ -z "$s_err" ]]; then
+    pass "...and wrote nothing to stderr while succeeding"
+  else
+    fail "a successful derivation writes nothing to stderr" "no stderr" "$(flat "$s_err")"
+  fi
+
+  b_err=$( ( trap '' PIPE; workflow_step_body "$BIG_WF" 'Plain step' >/dev/null ) 2>&1 ); b_st=$?
+  if [[ "$b_st" -eq 0 && -z "$b_err" ]]; then
+    pass "...and so does the body extraction on the same record"
+  else
+    fail "the body extraction is silent on success" "status 0 and no stderr" "status $b_st :: $(flat "$b_err")"
+  fi
+fi
+
+echo ""
+echo "== a record that cannot be read is a refusal, never the default =="
+# The mutation: the scan is replaced by one that returns a record cut short —
+# what a writer killed mid-record leaves behind. Both prefixes below are
+# READABLE as far as they go, which is the trap: `matches 1` parses, and an
+# empty `step_shell` is indistinguishable from "this step declares no shell".
+scan_saved=$(declare -f _workflow_step_scan)
+if [[ -z "$scan_saved" ]]; then
+  fail "the scan function could be captured for the mutation" "a definition" "declare -f produced nothing — the arms below could not run"
+else
+  pass "captured _workflow_step_scan for the mutation"
+
+  _workflow_step_scan() { printf 'matches 1\nstep_shell \n'; }
+  want_refusal "a record cut short mid-header" "could not be read" \
+    workflow_step_shell "$DATA/no-shell.yml" 'Plain step'
+  want_refusal "a record cut short mid-header (body)" "could not be read" \
+    workflow_step_body "$DATA/no-shell.yml" 'Plain step'
+
+  # ...and one cut at the boundary: every header key present, the `body` marker
+  # gone. Nothing above this line distinguishes it from a complete record.
+  _workflow_step_scan() { printf 'matches 1\nstep_shell \njob_shell \nwf_shell \nhas_run 1\n'; }
+  want_refusal "a record missing its \`body\` marker" "could not be read" \
+    workflow_step_shell "$DATA/no-shell.yml" 'Plain step'
+
+  eval "$scan_saved"
+  # The restore is asserted, not assumed: a mutation harness that leaves its
+  # stub in place grades every row after it against the stub (#1390).
+  want_shell no-shell.yml 'Plain step' "$DEFAULT"
+fi
+
+# ---------------------------------------------------------------------------
 # ...and preflight's `tools` gate has to FIRE on a diff touching this library,
 # its corpus, or any workflow it reads — or under --changed (the pre-push
 # hook's path) every assertion above is skipped on precisely the commit that


### PR DESCRIPTION
Fixes the `go-test` job's "Test the shared shell libs" step, which is red on the Linux runner:

```
FAIL: .github/workflows/ars.yml :: Run ARS scan — expected [bash -e] got [status 0 ::
  tools/lib/workflow-step.sh: line 213: printf: write error: Broken pipe bash -e ]
workflow-step_test: FAILURES
shell-lib-suite: FAILED: workflow-step_test.sh
```

## Confirmed diagnosis

`_workflow_step_field` was one line:

```sh
printf '%s\n' "$1" | awk -v k="$2" '$1 == k { …; print; exit } $1 == "body" { exit }'
```

Both `exit`s are a **reader closing a pipe while the writer is still inside `write(2)`** — a SIGPIPE. Whether that is survivable depends on a disposition nothing here sets:

| SIGPIPE disposition | what happens to `printf` | measured |
|---|---|---|
| `SIG_DFL` | killed by the signal, silently | **0/10** broken-pipe messages |
| ignored (inherited) | `write` returns `EPIPE`; bash **reports it on stderr** | **10/10** broken-pipe messages |

Measured with a 139,947-byte record driving `_workflow_step_field … matches` ten times per arm. The runner's log is itself the evidence for which of the two it was: bash only reaches `write error: Broken pipe` on an `EPIPE` *return*, which a process whose SIGPIPE is fatal cannot observe.

And every harness in `tools/lib/` captures a derivation with `2>&1`. So the diagnostic became part of the **value** — a string still ending in `bash -e`, still at status 0.

## Two separable defects, both fixed

**1 — the broken pipe itself.** The answer is no longer taken early: the record is consumed to EOF and the value emitted from `END`, with an `inbody` flag replacing the `$1 == "body" { exit }` guard. A reader that never closes early cannot signal its writer, and there was nothing to save by stopping — the record is one step's header plus one step's body.

**2 — the corrupted value being readable as an answer at all.** This is the half that outlives the pipe. A field read returned its value and *no status*, so "this step declares no `shell:`" and "the record could not be read" both arrived as the empty string — and `workflow_step_shell` walked its three empty fields to `WORKFLOW_STEP_SHELL_DEFAULT` and returned **0**. That is `bash -e`: the loosest invocation GitHub has, no `-o pipefail`, handed out as a derivation by a function that had just failed to read its input. It is precisely the fallback [the file's own header](tools/lib/workflow-step.sh) opens by forbidding, reached from the inside, because every refusal guarded the **scan** and none guarded the reading of what the scan produced.

The record is now **validated rather than searched** — every header key the scan emits must be present, ahead of a `body` marker that must be there, since a prefix of a record parses fine as far as it goes. A read that fails is a named refusal at status 2, propagated by all three call sites (`_workflow_step_field_of` names the file and step).

## Red before green

New obligation 7 in `tools/lib/workflow-step_test.sh`, **seen red against the unfixed library**:

```
  FAIL: an oversized record derives `bash -e` and nothing else — expected [bash -e] got [status 0 ::
    tools/lib/workflow-step.sh: line 213: printf: write error: Broken pipe … bash -e ]
  FAIL: a successful derivation writes nothing to stderr — expected [no stderr] got [… Broken pipe …]
  FAIL: the body extraction is silent on success — expected [status 0 and no stderr] got [… Broken pipe …]
  FAIL: a record cut short mid-header — expected [status 2 …] got [status 0 :: bash -e ]
  FAIL: a record cut short mid-header (body) — expected [a refusal naming: could not be read] got [… no `run: |` block …]
  FAIL: a record missing its `body` marker — expected [status 2 …] got [status 0 :: bash -e ]
workflow-step_test: FAILURES
```

Note `status 0 :: bash -e` on the last three: defect 2 in isolation, the default returned from a record that could not be read.

- **a** generates a 470,995-byte workflow body so the writer *must* still be in `write(2)` when the reader closes — deterministic everywhere, rather than depending on runner load — and drives it under `trap '' PIPE`, the disposition that makes the failure visible instead of fatal. It also asserts the general property: **a successful derivation writes nothing to stderr.**
- **b** replaces `_workflow_step_scan` with one returning a record cut short (mid-header, and at the `body` marker) and asserts a refusal. The restore is asserted too, so a stub cannot silently grade the rows after it.

After the fix: `workflow-step_test: ALL PASS`.

## The errexit defect the fix itself introduced

`shell-lib-errexit_test.sh` caught it immediately:

```
FAIL: _workflow_step_field: in a bare statement under `bash --noprofile --norc -e -o pipefail`
  it returned 3, not the documented 0 — it aborted the caller instead of returning
FAIL: recipes and the walk disagree — expected [a bijection] got
  [UNDRIVEN workflow-step.sh::_workflow_step_field_of — no driving recipe …]
```

Under a caller's `-e`, `val=$(… | awk …)` aborts on that line, leaking awk's 3. Now `|| st=$?`. The recipe table gains rows for both readers — driven off a **real** record from `_workflow_step_scan`, because the old hand-written `matches 1` prefix is exactly what they now refuse — plus a refusal row each.

## Verification

| check | result |
|---|---|
| `bash tools/lib/workflow-step_test.sh` | ALL PASS |
| `bash tools/lib/shell-lib-errexit_test.sh` | ALL PASS |
| the CI step's own `run:` body under `bash -e` | exit 0 — `found 39, skipped 2, ran 37, failed 0` |
| the same, under `trap '' PIPE` (the runner's disposition) | exit 0, **0** occurrences of `Broken pipe` in the whole log |
| `tools/preflight.sh --only tools` | PASS (`found 39, ran 39, failed 0`) + state-vocabulary lint PASS |
| `tools/preflight.sh --only bash` | PASS |
| `tools/preflight.sh --only posix` | PASS |

Not run: `--only linux` (Docker is not running on this host), so the Linux-native reproduction of the *small*-record instance is unverified here — the mechanism is reproduced deterministically at a size that removes the scheduling dependency, and the fix removes the early `exit` that is the mechanism's only precondition.

## Observed, not fixed

Three more writer-into-early-exiting-reader pipelines, all in `*_test.sh` failure-reporting paths rather than in a value a gate compares, so none is this bug — flagging rather than touching, since each would need its own red-first evidence:

- `tools/lib/install-uninstall_test.sh:76,82` — `printf '%s' "$haystack" | head -c 400`, where `$haystack` is unbounded
- `tools/lib/swift-suite_test.sh:863` — `printf '%s\n' "$_real_snapshot" | head -1`
- `tools/lib/ars-badge-push_test.sh:488` — `echo "$ARS_BADGE" | grep -o … | head -1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MaJ55MEzQicokNRg86K8vc
