### PR TITLE
feat(history): an Autonomy section — how long runs went without needing a human (#1905)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -60,13 +60,14 @@ updates:
       - /tools/elfdans-drive
       - /tools/eta-research
       - /tools/onboarding-factory
+      - /tools/seed-autonomy-spans
       - /tools/seed-demo-sessions
       - /tools/wsload
     schedule:
       interval: weekly
-    # Above the directory count (7), not at dependabot's default of 5: the
-    # limit is a cap on concurrently-open PRs, so a catch-up week that wants
-    # one grouped PR per module would silently withhold the seventh.
+    # Above the directory count (7 today), not at dependabot's default of 5:
+    # the limit is a cap on concurrently-open PRs, so a catch-up week that
+    # wants one grouped PR per module would silently withhold the last one.
     open-pull-requests-limit: 10
     commit-message:
       prefix: chore(deps)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,6 +70,13 @@ jobs:
       - name: Test onboarding-factory module
         run: go test ./tools/onboarding-factory/... -count=1
 
+      # tools/seed-autonomy-spans writes the synthetic autonomy span log QA
+      # screenshots the Autonomy section against (#1905). Its refuse-to-
+      # clobber guard is only ever exercised by its own tests, so they run
+      # here rather than living where nothing invokes them.
+      - name: Test seed-autonomy-spans module
+        run: go test ./tools/seed-autonomy-spans/... -count=1
+
       # The Desktop helper is a separate macOS-only Swift package. Its script
       # owns the Swift commands and build location. Local preflight calls the
       # same script, so CI and local checks cannot use different procedures.

--- a/core/adapters/outbound/filesystem/autonomy_tracker.go
+++ b/core/adapters/outbound/filesystem/autonomy_tracker.go
@@ -1,0 +1,297 @@
+package filesystem
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"irrlicht/core/ports/outbound"
+)
+
+const (
+	// autonomyDirName is the span log's directory under the data dir, sibling
+	// to costDirName.
+	autonomyDirName = "autonomy"
+
+	// autonomyFileExt is the on-disk extension for one project's per-line
+	// JSONL span log (project+autonomyFileExt under autonomyDirName).
+	autonomyFileExt = ".jsonl"
+
+	// autonomySchemaVersion documents the on-disk row shape. v1 is the
+	// original (#1905). Like costSchemaVersion the constant is documentary —
+	// rows do not carry it — and for the same reason: every field is
+	// omitempty-tolerant JSONL, so a row written by an older or newer daemon
+	// decodes with the fields it does not know left at their zero values, and
+	// there is nothing to migrate.
+	autonomySchemaVersion = 1
+)
+
+// spanRow is the on-disk JSON shape for one closed autonomy span. One row per
+// line (JSONL), append-only, one file per project — deliberately the same
+// shape as the cost log's snapshotRow (#1905), including the omitempty
+// forward-compatibility rule: a reader that meets a field it does not know
+// ignores it, and a field a writer did not set reads back as the zero value
+// rather than as an error.
+//
+// Short JSON keys because the log is the one thing here that grows without
+// bound: at a few hundred spans a day, 400 days of retention is the whole
+// budget this row has to fit in.
+type spanRow struct {
+	Start   int64  `json:"start"`
+	End     int64  `json:"end"`
+	Project string `json:"project,omitempty"` // raw SessionState.ProjectName (the filename is sanitized)
+	Session string `json:"session,omitempty"`
+	Adapter string `json:"adapter,omitempty"`
+	Model   string `json:"model,omitempty"`
+	// Reason is one of session.AutonomyEndReasons() — the state the session
+	// left `working` FOR. "" in a row written by a build that could not name
+	// the state; such a row still carries a real duration, so it is kept and
+	// simply ranks lowest on the strip's collapse ladder.
+	Reason string `json:"reason,omitempty"`
+}
+
+// AutonomySpanTracker persists closed autonomy spans in append-only JSONL
+// files, one file per project, under <dataDir>/autonomy/.
+//
+// It mirrors CostTracker's storage model on purpose (#1905): written
+// unconditionally rather than behind the opt-in --record flag, pruned to the
+// same 400 days at the same startup call site, and rewritten by the same
+// atomic prune helper. The alternative — deriving spans from the lifecycle
+// recordings — silently shows nothing to every user who is not recording,
+// which for this feature is indistinguishable from "you never ran anything".
+type AutonomySpanTracker struct {
+	dir string
+
+	// mu guards fileMus.
+	mu      sync.Mutex
+	fileMus map[string]*sync.Mutex // sanitized project name → per-file write mutex
+}
+
+// NewAutonomySpanTracker returns a tracker rooted at the user's Application
+// Support directory. The directory is created on the first write.
+func NewAutonomySpanTracker() (*AutonomySpanTracker, error) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("cannot determine home directory: %w", err)
+	}
+	return NewAutonomySpanTrackerWithDir(filepath.Join(homeDir, appSupportDir, autonomyDirName)), nil
+}
+
+// NewAutonomySpanTrackerWithDir returns a tracker rooted at the given
+// directory (used by the daemon's IRRLICHT_HOME isolation, by tests, and by
+// tools/seed-autonomy-spans).
+func NewAutonomySpanTrackerWithDir(dir string) *AutonomySpanTracker {
+	return &AutonomySpanTracker{
+		dir:     dir,
+		fileMus: make(map[string]*sync.Mutex),
+	}
+}
+
+// Dir returns the directory where span files live.
+func (t *AutonomySpanTracker) Dir() string { return t.dir }
+
+// fileMu returns (creating if needed) the per-project write mutex.
+func (t *AutonomySpanTracker) fileMu(project string) *sync.Mutex {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	fm, ok := t.fileMus[project]
+	if !ok {
+		fm = &sync.Mutex{}
+		t.fileMus[project] = fm
+	}
+	return fm
+}
+
+// RecordSpan appends one closed span to its project's log.
+//
+// No-ops (without an error) on a span with no project or no positive
+// duration: a span with nothing to file it under cannot be drawn on a
+// per-project strip, and a zero-length span is a transition artefact, not a
+// run. Matches RecordSnapshot's "nothing useful to store" rule.
+func (t *AutonomySpanTracker) RecordSpan(span outbound.AutonomySpan) error {
+	project := projectKey(span.Project)
+	if project == "" || span.Duration() <= 0 {
+		return nil
+	}
+	row := spanRow{
+		Start:   span.Start,
+		End:     span.End,
+		Project: span.Project,
+		Session: span.Session,
+		Adapter: span.Adapter,
+		Model:   span.Model,
+		Reason:  span.Reason,
+	}
+	data, err := json.Marshal(row)
+	if err != nil {
+		return fmt.Errorf("marshal autonomy span: %w", err)
+	}
+	data = append(data, '\n')
+
+	if err := os.MkdirAll(t.dir, 0700); err != nil {
+		return fmt.Errorf("create autonomy dir: %w", err)
+	}
+
+	fm := t.fileMu(project)
+	fm.Lock()
+	defer fm.Unlock()
+	f, err := os.OpenFile(t.filePath(project), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
+	if err != nil {
+		return fmt.Errorf("open autonomy file: %w", err)
+	}
+	defer f.Close()
+	if _, err := f.Write(data); err != nil {
+		return fmt.Errorf("append autonomy span: %w", err)
+	}
+	return nil
+}
+
+// SpansInWindow returns every span that ENDED inside [q.Start, q.End), ordered
+// by start ascending, plus two log-wide facts the honesty rules need: the
+// earliest start on record and the total number of rows.
+//
+// Those two are computed over the WHOLE log, not the window, and that is the
+// point: an empty window is ambiguous on its own ("nothing ran" vs "this
+// feature had not shipped yet"), and only the earliest recorded span
+// disambiguates it (#1905).
+func (t *AutonomySpanTracker) SpansInWindow(q outbound.AutonomySpanQuery) (*outbound.AutonomySpanResult, error) {
+	res := &outbound.AutonomySpanResult{Spans: []outbound.AutonomySpan{}}
+	entries, err := os.ReadDir(t.dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return res, nil
+		}
+		return nil, err
+	}
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), autonomyFileExt) {
+			continue
+		}
+		fallback := strings.TrimSuffix(e.Name(), autonomyFileExt)
+		if err := scanSpanFile(filepath.Join(t.dir, e.Name()), func(r spanRow) {
+			foldSpanRow(r, fallback, q, res)
+		}); err != nil {
+			return nil, err
+		}
+	}
+	sort.Slice(res.Spans, func(i, j int) bool {
+		if res.Spans[i].Start != res.Spans[j].Start {
+			return res.Spans[i].Start < res.Spans[j].Start
+		}
+		return res.Spans[i].Session < res.Spans[j].Session
+	})
+	if q.Limit > 0 && len(res.Spans) > q.Limit {
+		res.Spans = res.Spans[:q.Limit]
+		res.Truncated = true
+	}
+	return res, nil
+}
+
+// foldSpanRow folds one parsed row into the running result: it always counts
+// towards the log-wide total and earliest-start, and joins Spans only when it
+// ended inside the query window.
+func foldSpanRow(r spanRow, fallback string, q outbound.AutonomySpanQuery, res *outbound.AutonomySpanResult) {
+	res.TotalRecorded++
+	if r.Start > 0 && (res.EarliestStart == 0 || r.Start < res.EarliestStart) {
+		res.EarliestStart = r.Start
+	}
+	if r.End < q.Start || r.End >= q.End {
+		return
+	}
+	project := r.Project
+	if project == "" {
+		project = fallback
+	}
+	res.Spans = append(res.Spans, outbound.AutonomySpan{
+		Start:   r.Start,
+		End:     r.End,
+		Project: project,
+		Session: r.Session,
+		Adapter: r.Adapter,
+		Model:   r.Model,
+		Reason:  r.Reason,
+	})
+}
+
+// scanSpanFile streams one span file, invoking perRow for each parsed row. A
+// missing file and malformed lines are skipped — the same policy scanCostFile
+// applies to the cost log, for the same reason: one truncated tail line (a
+// crash mid-append) must not blind the reader to everything before it.
+func scanSpanFile(path string, perRow func(spanRow)) error {
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, jsonlScanBufInitial), jsonlScanBufMax)
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		var r spanRow
+		if err := json.Unmarshal(line, &r); err != nil {
+			continue
+		}
+		perRow(r)
+	}
+	if err := scanner.Err(); err != nil && err != io.EOF {
+		return err
+	}
+	return nil
+}
+
+// Prune rewrites each project file to drop spans that ENDED more than
+// olderThanDays ago. olderThanDays <= 0 is a no-op.
+//
+// Called from the same startup site, with the same 400 days, as the cost
+// log's prune — see initAutonomyTracker.
+func (t *AutonomySpanTracker) Prune(olderThanDays int) error {
+	if olderThanDays <= 0 {
+		return nil
+	}
+	entries, err := os.ReadDir(t.dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	cutoff := time.Now().AddDate(0, 0, -olderThanDays).Unix()
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), autonomyFileExt) {
+			continue
+		}
+		project := strings.TrimSuffix(e.Name(), autonomyFileExt)
+		fm := t.fileMu(project)
+		fm.Lock()
+		err := pruneJSONLFile(filepath.Join(t.dir, e.Name()), func(line []byte) bool {
+			var r spanRow
+			if err := json.Unmarshal(line, &r); err != nil {
+				return false
+			}
+			return r.End >= cutoff
+		})
+		fm.Unlock()
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (t *AutonomySpanTracker) filePath(project string) string {
+	return filepath.Join(t.dir, project+autonomyFileExt)
+}

--- a/core/adapters/outbound/filesystem/autonomy_tracker_test.go
+++ b/core/adapters/outbound/filesystem/autonomy_tracker_test.go
@@ -1,0 +1,268 @@
+package filesystem
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+
+	"irrlicht/core/domain/session"
+	"irrlicht/core/ports/outbound"
+)
+
+func span(start, end int64, project, reason string) outbound.AutonomySpan {
+	return outbound.AutonomySpan{
+		Start: start, End: end, Project: project,
+		Session: "sess", Adapter: "claude-code", Model: "claude-opus-4", Reason: reason,
+	}
+}
+
+func TestAutonomySpanTracker_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	tr := NewAutonomySpanTrackerWithDir(dir)
+	now := time.Now().Unix()
+
+	spans := []outbound.AutonomySpan{
+		span(now-3600, now-3000, "irrlicht", session.StateReady),
+		span(now-2000, now-1900, "articles", session.StateWaiting),
+		span(now-500, now-100, "irrlicht", session.StateError),
+	}
+	for _, s := range spans {
+		if err := tr.RecordSpan(s); err != nil {
+			t.Fatalf("RecordSpan: %v", err)
+		}
+	}
+
+	res, err := tr.SpansInWindow(outbound.AutonomySpanQuery{Start: now - 7200, End: now})
+	if err != nil {
+		t.Fatalf("SpansInWindow: %v", err)
+	}
+	if len(res.Spans) != 3 {
+		t.Fatalf("got %d spans, want 3", len(res.Spans))
+	}
+	if res.EarliestStart != now-3600 {
+		t.Errorf("earliest = %d, want %d", res.EarliestStart, now-3600)
+	}
+	if res.TotalRecorded != 3 {
+		t.Errorf("total = %d, want 3", res.TotalRecorded)
+	}
+	// Ordered by start ascending.
+	for i := 1; i < len(res.Spans); i++ {
+		if res.Spans[i-1].Start > res.Spans[i].Start {
+			t.Fatalf("spans are not ordered by start: %v", res.Spans)
+		}
+	}
+	// Every field survives the round trip.
+	got := res.Spans[0]
+	if got.Project != "irrlicht" || got.Adapter != "claude-code" ||
+		got.Model != "claude-opus-4" || got.Reason != session.StateReady {
+		t.Errorf("round trip lost provenance: %+v", got)
+	}
+	// One file per project, like the cost log.
+	for _, p := range []string{"irrlicht", "articles"} {
+		if _, err := os.Stat(filepath.Join(dir, p+autonomyFileExt)); err != nil {
+			t.Errorf("no span file for project %q: %v", p, err)
+		}
+	}
+}
+
+// TestAutonomySpanTracker_WindowFiltersOnEnd pins which timestamp decides
+// membership. A span is only recorded once it has ended, so its END is the
+// only timestamp the window can filter on without dropping long runs that
+// started before the window opened.
+func TestAutonomySpanTracker_WindowFiltersOnEnd(t *testing.T) {
+	tr := NewAutonomySpanTrackerWithDir(t.TempDir())
+	now := time.Now().Unix()
+	// A four-hour run that STARTED six hours ago and ended two hours ago.
+	if err := tr.RecordSpan(span(now-6*3600, now-2*3600, "irrlicht", session.StateReady)); err != nil {
+		t.Fatalf("RecordSpan: %v", err)
+	}
+	res, err := tr.SpansInWindow(outbound.AutonomySpanQuery{Start: now - 3*3600, End: now})
+	if err != nil {
+		t.Fatalf("SpansInWindow: %v", err)
+	}
+	if len(res.Spans) != 1 {
+		t.Fatalf("got %d spans, want 1 — a run that ended inside the window belongs to it even "+
+			"though it started before", len(res.Spans))
+	}
+	// And one that ended before the window is out.
+	res, err = tr.SpansInWindow(outbound.AutonomySpanQuery{Start: now - 3600, End: now})
+	if err != nil {
+		t.Fatalf("SpansInWindow: %v", err)
+	}
+	if len(res.Spans) != 0 {
+		t.Fatalf("got %d spans, want 0", len(res.Spans))
+	}
+	// …but it still counts towards the log-wide facts, which is what makes
+	// "collecting since <date>" honest.
+	if res.EarliestStart != now-6*3600 || res.TotalRecorded != 1 {
+		t.Errorf("earliest/total = %d/%d, want %d/1 — log-wide facts are not window-scoped",
+			res.EarliestStart, res.TotalRecorded, now-6*3600)
+	}
+}
+
+func TestAutonomySpanTracker_LimitReportsTruncation(t *testing.T) {
+	tr := NewAutonomySpanTrackerWithDir(t.TempDir())
+	now := time.Now().Unix()
+	for i := 0; i < 10; i++ {
+		if err := tr.RecordSpan(span(now-int64(i)*100-50, now-int64(i)*100, "irrlicht", session.StateReady)); err != nil {
+			t.Fatalf("RecordSpan: %v", err)
+		}
+	}
+	res, err := tr.SpansInWindow(outbound.AutonomySpanQuery{Start: now - 10000, End: now + 1, Limit: 4})
+	if err != nil {
+		t.Fatalf("SpansInWindow: %v", err)
+	}
+	if len(res.Spans) != 4 || !res.Truncated {
+		t.Errorf("got %d spans truncated=%v, want 4 and truncated=true", len(res.Spans), res.Truncated)
+	}
+	res, err = tr.SpansInWindow(outbound.AutonomySpanQuery{Start: now - 10000, End: now + 1, Limit: 100})
+	if err != nil {
+		t.Fatalf("SpansInWindow: %v", err)
+	}
+	if res.Truncated {
+		t.Error("truncated=true with a limit nothing hit")
+	}
+}
+
+func TestAutonomySpanTracker_SkipsUnusableSpans(t *testing.T) {
+	dir := t.TempDir()
+	tr := NewAutonomySpanTrackerWithDir(dir)
+	now := time.Now().Unix()
+	cases := map[string]outbound.AutonomySpan{
+		"no project":    span(now-100, now, "", session.StateReady),
+		"zero duration": span(now, now, "irrlicht", session.StateReady),
+		"end before start": {
+			Start: now, End: now - 100, Project: "irrlicht", Reason: session.StateReady,
+		},
+	}
+	for name, s := range cases {
+		if err := tr.RecordSpan(s); err != nil {
+			t.Errorf("%s: RecordSpan returned an error; it should no-op quietly: %v", name, err)
+		}
+	}
+	res, err := tr.SpansInWindow(outbound.AutonomySpanQuery{Start: 0, End: now + 1000})
+	if err != nil {
+		t.Fatalf("SpansInWindow: %v", err)
+	}
+	if len(res.Spans) != 0 {
+		t.Errorf("got %d spans, want 0 — none of these is a run: %v", len(res.Spans), res.Spans)
+	}
+}
+
+func TestAutonomySpanTracker_PruneDropsOldRowsAndKeepsRecent(t *testing.T) {
+	dir := t.TempDir()
+	tr := NewAutonomySpanTrackerWithDir(dir)
+	now := time.Now().Unix()
+	old := now - 500*86400
+	if err := tr.RecordSpan(span(old-600, old, "irrlicht", session.StateReady)); err != nil {
+		t.Fatalf("RecordSpan: %v", err)
+	}
+	if err := tr.RecordSpan(span(now-600, now-60, "irrlicht", session.StateWaiting)); err != nil {
+		t.Fatalf("RecordSpan: %v", err)
+	}
+	if err := tr.Prune(400); err != nil {
+		t.Fatalf("Prune: %v", err)
+	}
+	res, err := tr.SpansInWindow(outbound.AutonomySpanQuery{Start: 0, End: now + 1})
+	if err != nil {
+		t.Fatalf("SpansInWindow: %v", err)
+	}
+	if res.TotalRecorded != 1 {
+		t.Fatalf("total after prune = %d, want 1", res.TotalRecorded)
+	}
+	if res.Spans[0].End != now-60 {
+		t.Errorf("the surviving span ends at %d, want %d — prune kept the wrong row",
+			res.Spans[0].End, now-60)
+	}
+}
+
+// TestAutonomySpanTracker_PruneRemovesAnEmptiedFile pins pruneJSONLFile's
+// contract, shared with the cost log: a file nothing survives in is removed,
+// not left behind as an empty one for every later scan to open.
+func TestAutonomySpanTracker_PruneRemovesAnEmptiedFile(t *testing.T) {
+	dir := t.TempDir()
+	tr := NewAutonomySpanTrackerWithDir(dir)
+	old := time.Now().Unix() - 500*86400
+	if err := tr.RecordSpan(span(old-600, old, "irrlicht", session.StateReady)); err != nil {
+		t.Fatalf("RecordSpan: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "irrlicht"+autonomyFileExt)); err != nil {
+		t.Fatalf("the span file was never written, so this test would pass vacuously: %v", err)
+	}
+	if err := tr.Prune(400); err != nil {
+		t.Fatalf("Prune: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "irrlicht"+autonomyFileExt)); !os.IsNotExist(err) {
+		t.Errorf("an emptied span file was left on disk (stat err = %v)", err)
+	}
+}
+
+func TestAutonomySpanTracker_PruneNoOpsOnZeroOrMissingDir(t *testing.T) {
+	tr := NewAutonomySpanTrackerWithDir(filepath.Join(t.TempDir(), "never-created"))
+	if err := tr.Prune(400); err != nil {
+		t.Errorf("Prune on a missing dir: %v", err)
+	}
+	if err := tr.Prune(0); err != nil {
+		t.Errorf("Prune(0): %v", err)
+	}
+	res, err := tr.SpansInWindow(outbound.AutonomySpanQuery{Start: 0, End: 1})
+	if err != nil {
+		t.Fatalf("SpansInWindow on a missing dir: %v", err)
+	}
+	if len(res.Spans) != 0 {
+		t.Errorf("got %d spans from a missing dir", len(res.Spans))
+	}
+}
+
+// TestAutonomySpanTracker_MalformedLinesAreSkipped mirrors the cost log's
+// policy: one truncated tail line (a crash mid-append) must not blind the
+// reader to everything before it.
+func TestAutonomySpanTracker_MalformedLinesAreSkipped(t *testing.T) {
+	dir := t.TempDir()
+	tr := NewAutonomySpanTrackerWithDir(dir)
+	now := time.Now().Unix()
+	if err := tr.RecordSpan(span(now-600, now-60, "irrlicht", session.StateReady)); err != nil {
+		t.Fatalf("RecordSpan: %v", err)
+	}
+	f, err := os.OpenFile(filepath.Join(dir, "irrlicht"+autonomyFileExt), os.O_APPEND|os.O_WRONLY, 0600)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if _, err := f.WriteString("{\"start\":123,\"end\":\n"); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	f.Close()
+
+	res, err := tr.SpansInWindow(outbound.AutonomySpanQuery{Start: 0, End: now + 1})
+	if err != nil {
+		t.Fatalf("SpansInWindow: %v", err)
+	}
+	if len(res.Spans) != 1 {
+		t.Errorf("got %d spans, want 1 — the good row before the torn one must still be read",
+			len(res.Spans))
+	}
+}
+
+// TestAutonomySpanTracker_ProjectFallsBackToFilename mirrors the cost log:
+// a row written without a project name is attributed to the file it lives in.
+func TestAutonomySpanTracker_ProjectFallsBackToFilename(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	now := time.Now().Unix()
+	line := `{"start":` + strconv.FormatInt(now-600, 10) + `,"end":` + strconv.FormatInt(now-60, 10) + `,"reason":"ready"}` + "\n"
+	if err := os.WriteFile(filepath.Join(dir, "legacy"+autonomyFileExt), []byte(line), 0600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	tr := NewAutonomySpanTrackerWithDir(dir)
+	res, err := tr.SpansInWindow(outbound.AutonomySpanQuery{Start: 0, End: now + 1})
+	if err != nil {
+		t.Fatalf("SpansInWindow: %v", err)
+	}
+	if len(res.Spans) != 1 || res.Spans[0].Project != "legacy" {
+		t.Errorf("got %+v, want one span attributed to the filename \"legacy\"", res.Spans)
+	}
+}

--- a/core/adapters/outbound/filesystem/cost_tracker.go
+++ b/core/adapters/outbound/filesystem/cost_tracker.go
@@ -1101,43 +1101,16 @@ func (t *CostTracker) pruneFile(path, project string, cutoff int64, survivors ma
 	fm.Lock()
 	defer fm.Unlock()
 
-	in, err := os.Open(path)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil
+	// The read-transform-atomic-rename mechanics live in pruneJSONLFile, which
+	// the autonomy span log (#1905) shares — this store keeps only the part
+	// that is its own: which rows survive, and recording their session IDs.
+	return pruneJSONLFile(path, func(line []byte) bool {
+		keep, sid := filterPruneLine(line, cutoff)
+		if keep && sid != "" {
+			survivors[sid] = struct{}{}
 		}
-		return err
-	}
-	defer in.Close()
-
-	tmpPath := fmt.Sprintf("%s.tmp.%d.%d", path, os.Getpid(), time.Now().UnixNano())
-	out, err := os.OpenFile(tmpPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0600)
-	if err != nil {
-		return err
-	}
-	w := bufio.NewWriter(out)
-	scanner := bufio.NewScanner(in)
-	scanner.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
-	kept, err := pruneLines(scanner, w, cutoff, survivors)
-	if err != nil {
-		out.Close()
-		os.Remove(tmpPath)
-		return err
-	}
-	if err := w.Flush(); err != nil {
-		out.Close()
-		os.Remove(tmpPath)
-		return err
-	}
-	if err := out.Close(); err != nil {
-		os.Remove(tmpPath)
-		return err
-	}
-	if kept == 0 {
-		os.Remove(tmpPath)
-		return os.Remove(path)
-	}
-	return os.Rename(tmpPath, path)
+		return keep
+	})
 }
 
 // filterPruneLine reports whether a row survives pruning (parses and is at or
@@ -1151,36 +1124,6 @@ func filterPruneLine(line []byte, cutoff int64) (keep bool, sessionID string) {
 		return false, ""
 	}
 	return true, r.Session
-}
-
-// pruneLines streams scanner, writing surviving rows (at or after cutoff) to
-// w and recording each survivor's session ID, returning the count kept.
-// Factored out of pruneFile so the caller's cleanup-on-error handling stays
-// flat; a write error here is reported to the caller exactly like the
-// post-loop scanner.Err() check, so both cases funnel through the same
-// cleanup path.
-func pruneLines(scanner *bufio.Scanner, w *bufio.Writer, cutoff int64, survivors map[string]struct{}) (kept int, err error) {
-	for scanner.Scan() {
-		line := scanner.Bytes()
-		if len(line) == 0 {
-			continue
-		}
-		keep, sid := filterPruneLine(line, cutoff)
-		if !keep {
-			continue
-		}
-		if _, err := w.Write(line); err != nil {
-			return kept, err
-		}
-		if err := w.WriteByte('\n'); err != nil {
-			return kept, err
-		}
-		if sid != "" {
-			survivors[sid] = struct{}{}
-		}
-		kept++
-	}
-	return kept, scanner.Err()
 }
 
 func (t *CostTracker) filePath(project string) string {

--- a/core/adapters/outbound/filesystem/jsonl_prune.go
+++ b/core/adapters/outbound/filesystem/jsonl_prune.go
@@ -1,0 +1,90 @@
+package filesystem
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"time"
+)
+
+// jsonlScanBuf sizes the line scanner shared by every append-only JSONL store
+// in this package: a 64 KiB starting buffer with a 4 MiB ceiling, so one
+// pathologically long row cannot abort a whole file's scan.
+const (
+	jsonlScanBufInitial = 64 * 1024
+	jsonlScanBufMax     = 4 * 1024 * 1024
+)
+
+// pruneJSONLFile rewrites path keeping only the lines for which keep returns
+// true, via a temp file plus an atomic rename; the file is removed outright
+// when nothing survives. A missing file is not an error.
+//
+// This is the cost log's prune idiom (#369), lifted out of CostTracker so the
+// autonomy span log (#1905) reuses it rather than growing a second, subtly
+// different copy — the two stores share a shape (one append-only JSONL file
+// per project, pruned to the same 400 days at the same startup call site), and
+// the interesting part is exactly the part worth having once: never truncate
+// the live file, write a sibling and rename over it, so a crash mid-prune
+// leaves the original intact.
+//
+// The caller is responsible for holding whatever per-file lock keeps a
+// concurrent appender out; this function does no locking of its own.
+func pruneJSONLFile(path string, keep func(line []byte) bool) error {
+	in, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	defer in.Close()
+
+	tmpPath := fmt.Sprintf("%s.tmp.%d.%d", path, os.Getpid(), time.Now().UnixNano())
+	out, err := os.OpenFile(tmpPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0600)
+	if err != nil {
+		return err
+	}
+	w := bufio.NewWriter(out)
+	scanner := bufio.NewScanner(in)
+	scanner.Buffer(make([]byte, 0, jsonlScanBufInitial), jsonlScanBufMax)
+	kept, err := copyKeptLines(scanner, w, keep)
+	if err == nil {
+		err = w.Flush()
+	}
+	if err != nil {
+		out.Close()
+		os.Remove(tmpPath)
+		return err
+	}
+	if err := out.Close(); err != nil {
+		os.Remove(tmpPath)
+		return err
+	}
+	if kept == 0 {
+		os.Remove(tmpPath)
+		return os.Remove(path)
+	}
+	return os.Rename(tmpPath, path)
+}
+
+// copyKeptLines streams scanner, writing every line keep accepts to w, and
+// returns how many survived. Empty lines are dropped without consulting keep.
+func copyKeptLines(scanner *bufio.Scanner, w *bufio.Writer, keep func(line []byte) bool) (kept int, err error) {
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		if !keep(line) {
+			continue
+		}
+		if _, err := w.Write(line); err != nil {
+			return kept, err
+		}
+		if err := w.WriteByte('\n'); err != nil {
+			return kept, err
+		}
+		kept++
+	}
+	return kept, scanner.Err()
+}

--- a/core/application/services/autonomy_span.go
+++ b/core/application/services/autonomy_span.go
@@ -1,0 +1,185 @@
+package services
+
+import (
+	"time"
+
+	"irrlicht/core/domain/session"
+	"irrlicht/core/ports/outbound"
+)
+
+// Autonomy span capture (#1905).
+//
+// A span is one unbroken stretch of `working`; it is opened and closed on the
+// state transition itself, in applyStateTransition — the single site where a
+// transition and its per-target-state side effects are applied, and where
+// WaitingStartTime is already stamped. Nothing here reads the lifecycle
+// recordings: those are opt-in and the packaged app runs without them, so a
+// recordings-derived span log would be empty for a normal user while looking
+// exactly like "you never ran anything".
+
+// AutonomySpanGrace is how long a session may sit in `ready` before the span
+// it was running is treated as finished. A `working → ready → working` round
+// trip completed inside this window is TOOL-CALL FLICKER — the turn boundary
+// an adapter reports between two halves of the same run — and does NOT close
+// the span.
+//
+// `working → waiting` and `working → error` get NO grace, deliberately, and
+// this is the asymmetry worth stating (#1905 design decision 1):
+//
+//	A grace on `waiting` would merge "it asked me a question and I answered in
+//	four seconds" into ONE long span. That is not a slightly worse number, it
+//	is a fabricated one — the feature exists to measure how long the agent
+//	went WITHOUT needing a human, and the question it asked is precisely the
+//	end of that stretch. The issue's own framing applies: a wrong number here
+//	is worse than no number, because nothing on screen would say it was wrong.
+//	`error` is the same case (see the trade-off on closeAutonomySpan).
+//
+// Ten seconds, not five: it has to cover a slow tool round trip without
+// covering a human. The shortest plausible human answer to a permission prompt
+// is a keystroke, but the prompt itself does not arrive as `ready`, so nothing
+// in the human path is at risk from a ceiling this low.
+const AutonomySpanGrace = 10 * time.Second
+
+// autonomySpanGraceSeconds is AutonomySpanGrace in the unit the session's
+// timestamps are in.
+const autonomySpanGraceSeconds = int64(AutonomySpanGrace / time.Second)
+
+// applyAutonomySpanTransition opens, holds, or closes the session's autonomy
+// span for a state transition that has already been decided. Called from
+// applyStateTransition with the same `now` that stamps the rest of the
+// transition, so a span's edges line up exactly with the transition that
+// caused them.
+func (d *SessionDetector) applyAutonomySpanTransition(state *session.SessionState, newState string, now int64) {
+	switch newState {
+	case session.StateWorking:
+		d.openOrResumeAutonomySpan(state, now)
+	case session.StateReady:
+		// Provisional: the grace decides whether this is the end of a run or
+		// a flicker between two halves of one. Nothing is written yet.
+		if state.AutonomySpanStart == nil {
+			return
+		}
+		end := now
+		state.AutonomySpanPendingEnd = &end
+	default:
+		// Everything else is a state the session left `working` FOR, with no
+		// grace — see AutonomySpanGrace. Named as `default` rather than by
+		// listing the remaining states so a fifth state ends a span under its
+		// own name instead of silently extending one.
+		d.settleAutonomySpanOnLeave(state, newState, now)
+	}
+}
+
+// openOrResumeAutonomySpan handles the `→ working` edge: it resumes a span
+// held open by the flicker grace, and otherwise starts a fresh one (settling
+// whatever was pending first).
+func (d *SessionDetector) openOrResumeAutonomySpan(state *session.SessionState, now int64) {
+	if state.AutonomySpanStart != nil && state.AutonomySpanPendingEnd != nil {
+		if now-*state.AutonomySpanPendingEnd < autonomySpanGraceSeconds {
+			// Flicker: the same run continues, and its start is unchanged.
+			state.AutonomySpanPendingEnd = nil
+			return
+		}
+		d.closeAutonomySpan(state, *state.AutonomySpanPendingEnd, session.StateReady)
+	}
+	start := now
+	state.AutonomySpanStart = &start
+	state.AutonomySpanPendingEnd = nil
+}
+
+// settleAutonomySpanOnLeave closes the span for a transition into a state that
+// gets no grace. A pending `ready` close still WINS: the span ended when the
+// session left `working`, which was to `ready`; whatever happened afterwards
+// is a different stretch of the session's life.
+func (d *SessionDetector) settleAutonomySpanOnLeave(state *session.SessionState, newState string, now int64) {
+	if state.AutonomySpanPendingEnd != nil {
+		d.closeAutonomySpan(state, *state.AutonomySpanPendingEnd, session.StateReady)
+		return
+	}
+	if state.AutonomySpanStart == nil {
+		return
+	}
+	d.closeAutonomySpan(state, now, newState)
+}
+
+// flushExpiredAutonomySpan writes out a pending `ready` close whose grace has
+// run out, and reports whether it changed the session (so the caller can
+// persist it).
+//
+// The event loop's 5s refresh ticker calls this for every session, which is
+// what makes the grace a real ceiling rather than a promise: without it, a run
+// that ended and was never resumed would sit pending forever and never be
+// recorded at all — and "finished the turn and stopped" is the single most
+// common way a span ends.
+func (d *SessionDetector) flushExpiredAutonomySpan(state *session.SessionState, now int64) bool {
+	if state == nil || state.AutonomySpanPendingEnd == nil {
+		return false
+	}
+	if now-*state.AutonomySpanPendingEnd < autonomySpanGraceSeconds {
+		return false
+	}
+	d.closeAutonomySpan(state, *state.AutonomySpanPendingEnd, session.StateReady)
+	return true
+}
+
+// settleAutonomySpanOnTeardown finalizes a still-pending span for a session
+// that is going away. A deleted session can never return to `working`, so the
+// grace has nothing left to decide and the pending close is written
+// immediately rather than waiting for a ticker that will never see this
+// session again.
+func (d *SessionDetector) settleAutonomySpanOnTeardown(state *session.SessionState) {
+	if state == nil || state.AutonomySpanPendingEnd == nil {
+		return
+	}
+	d.closeAutonomySpan(state, *state.AutonomySpanPendingEnd, session.StateReady)
+}
+
+// closeAutonomySpan clears the open span off the session and appends the
+// closed span to the store. Clearing happens even with no store wired, so a
+// daemon running without one cannot accumulate an ever-growing "open since"
+// that the next transition would report as a multi-day run.
+//
+// TRADE-OFF, recorded here because this is where it is made (#1905 design
+// decision 3): `error` ENDS a span rather than pausing it. A usage limit that
+// stalls an agent for ten minutes and then resumes therefore shows up as two
+// runs, not one — which under-reports that agent's autonomy. The alternative
+// under-reports far worse: treating `error` as a pause means an agent that
+// broke at 09:00 and was restarted by hand at 17:00 records a single eight-
+// hour "autonomous run" that a human spent the afternoon rescuing. The reason
+// column keeps the first case legible (two adjacent spans, the first ending in
+// `error`); nothing could make the second case legible after the fact.
+func (d *SessionDetector) closeAutonomySpan(state *session.SessionState, end int64, reason string) {
+	start := state.AutonomySpanStart
+	state.AutonomySpanStart = nil
+	state.AutonomySpanPendingEnd = nil
+	if start == nil || d.autonomySpans == nil {
+		return
+	}
+	span := outbound.AutonomySpan{
+		Start:   *start,
+		End:     end,
+		Project: state.ProjectName,
+		Session: state.SessionID,
+		Adapter: state.Adapter,
+		Model:   autonomySpanModel(state),
+		Reason:  reason,
+	}
+	if err := d.autonomySpans.RecordSpan(span); err != nil {
+		d.log.LogError(logComponentAutonomySpans, state.SessionID, err.Error())
+	}
+}
+
+// logComponentAutonomySpans is the log component for span-capture failures —
+// never propagated, per the repo's Logger convention.
+const logComponentAutonomySpans = "autonomy-spans"
+
+// autonomySpanModel resolves the model to stamp on a span: the live
+// Metrics.ModelName when the tailer has one, else the session's own Model
+// field. Same resolution the cost log's rows use, so the two logs attribute a
+// session to the same model.
+func autonomySpanModel(state *session.SessionState) string {
+	if state.Metrics != nil && state.Metrics.ModelName != "" && state.Metrics.ModelName != "unknown" {
+		return state.Metrics.ModelName
+	}
+	return state.Model
+}

--- a/core/application/services/autonomy_span_test.go
+++ b/core/application/services/autonomy_span_test.go
@@ -303,11 +303,11 @@ func TestAutonomyReasonLadderMatchesHistoryBar(t *testing.T) {
 	}
 	for i := 1; i < len(pairs); i++ {
 		prev, cur := pairs[i-1], pairs[i]
-		if !(prev.historyBar > cur.historyBar) {
+		if prev.historyBar <= cur.historyBar {
 			t.Fatalf("the history bar's ladder no longer ranks %q above %q — this test's premise is gone",
 				prev.state, cur.state)
 		}
-		if !(prev.autonomyBar > cur.autonomyBar) {
+		if prev.autonomyBar <= cur.autonomyBar {
 			t.Errorf("the autonomy strip ranks %q (%d) at or below %q (%d), but the history bar ranks it "+
 				"above — one error in a column must paint the whole column",
 				prev.state, prev.autonomyBar, cur.state, cur.autonomyBar)

--- a/core/application/services/autonomy_span_test.go
+++ b/core/application/services/autonomy_span_test.go
@@ -1,0 +1,339 @@
+package services
+
+import (
+	"testing"
+	"time"
+
+	"irrlicht/core/domain/session"
+	"irrlicht/core/ports/outbound"
+)
+
+// recordingSpanStore captures every span the detector closes.
+type recordingSpanStore struct {
+	spans []outbound.AutonomySpan
+	err   error
+}
+
+func (r *recordingSpanStore) RecordSpan(s outbound.AutonomySpan) error {
+	if r.err != nil {
+		return r.err
+	}
+	r.spans = append(r.spans, s)
+	return nil
+}
+func (r *recordingSpanStore) SpansInWindow(outbound.AutonomySpanQuery) (*outbound.AutonomySpanResult, error) {
+	return &outbound.AutonomySpanResult{}, nil
+}
+func (r *recordingSpanStore) Prune(int) error { return nil }
+
+// spanFixture builds a detector wired to a recording store, plus a session to
+// drive transitions on. Struct-literal detector: the span code touches only
+// the store and the logger.
+func spanFixture() (*SessionDetector, *recordingSpanStore, *session.SessionState) {
+	store := &recordingSpanStore{}
+	// newSessionDetector, not a bare literal: construction_test.go's guard
+	// refuses the literal because it skips every map allocation (#1400/#1450).
+	d := newSessionDetector()
+	d.log = &gateLogger{}
+	d.autonomySpans = store
+	st := &session.SessionState{
+		SessionID:   "sess-1",
+		ProjectName: "irrlicht",
+		Adapter:     "claude-code",
+		Model:       "claude-opus-4",
+	}
+	return d, store, st
+}
+
+// drive applies a script of (state, unix-second) transitions.
+func drive(d *SessionDetector, st *session.SessionState, script ...struct {
+	state string
+	at    int64
+}) {
+	for _, step := range script {
+		d.applyAutonomySpanTransition(st, step.state, step.at)
+		st.State = step.state
+	}
+}
+
+type step = struct {
+	state string
+	at    int64
+}
+
+// TestAutonomySpan_ReadyFlickerInsideGraceDoesNotBreakTheSpan is the
+// grace-period rule (#1905 design decision 1). A working → ready → working
+// round trip completed inside AutonomySpanGrace is tool-call flicker, and the
+// span must survive it as ONE run.
+//
+// Both boundary cases are derived from autonomySpanGraceSeconds rather than
+// typed, so changing the constant moves the test with it instead of leaving a
+// green that no longer measures the constant it names.
+func TestAutonomySpan_ReadyFlickerInsideGraceDoesNotBreakTheSpan(t *testing.T) {
+	const t0 = 1_700_000_000
+	inside := autonomySpanGraceSeconds - 1
+
+	d, store, st := spanFixture()
+	drive(d, st,
+		step{session.StateWorking, t0},
+		step{session.StateReady, t0 + 100},
+		step{session.StateWorking, t0 + 100 + inside},
+		step{session.StateWaiting, t0 + 500},
+	)
+
+	if len(store.spans) != 1 {
+		t.Fatalf("got %d spans, want 1 — a %ds dip through ready is inside the %ds grace and must "+
+			"NOT break the run", len(store.spans), inside, autonomySpanGraceSeconds)
+	}
+	got := store.spans[0]
+	if got.Start != t0 {
+		t.Errorf("span start = %d, want %d — a resumed span keeps its ORIGINAL start", got.Start, t0)
+	}
+	if got.End != t0+500 || got.Reason != session.StateWaiting {
+		t.Errorf("span = [%d,%d] reason %q, want end %d reason %q",
+			got.Start, got.End, got.Reason, t0+500, session.StateWaiting)
+	}
+}
+
+// TestAutonomySpanGrace_IsTenSeconds is a LOCK, not red-first evidence: it
+// passes by construction and exists so that changing the window is a
+// deliberate act with a second line to update, rather than a one-character
+// edit nothing notices. The behavioural tests around it derive their
+// boundaries from the constant, so they follow it wherever it goes — which is
+// exactly why one test has to hold it still.
+func TestAutonomySpanGrace_IsTenSeconds(t *testing.T) {
+	if AutonomySpanGrace != 10*time.Second {
+		t.Errorf("AutonomySpanGrace = %v, want 10s. Changing it is allowed — but it decides whether "+
+			"a dip out of `working` is flicker or the end of a run, so update this lock and say why",
+			AutonomySpanGrace)
+	}
+	if autonomySpanGraceSeconds != 10 {
+		t.Errorf("autonomySpanGraceSeconds = %d, want 10 — it must stay AutonomySpanGrace in seconds",
+			autonomySpanGraceSeconds)
+	}
+}
+
+func TestAutonomySpan_ReadyBeyondGraceClosesTheSpan(t *testing.T) {
+	const t0 = 1_700_000_000
+	outside := autonomySpanGraceSeconds + 1
+
+	d, store, st := spanFixture()
+	drive(d, st,
+		step{session.StateWorking, t0},
+		step{session.StateReady, t0 + 100},
+		step{session.StateWorking, t0 + 100 + outside},
+		step{session.StateReady, t0 + 400},
+	)
+	// The second span is still pending (its grace has not run out), so only
+	// the first is on record at this point.
+	if len(store.spans) != 1 {
+		t.Fatalf("got %d spans, want 1 closed so far", len(store.spans))
+	}
+	first := store.spans[0]
+	if first.Start != t0 || first.End != t0+100 || first.Reason != session.StateReady {
+		t.Fatalf("first span = [%d,%d] reason %q, want [%d,%d] reason %q — a gap of %ds is beyond the "+
+			"%ds grace and ends the run at the moment it went ready",
+			first.Start, first.End, first.Reason, t0, t0+100, session.StateReady,
+			outside, autonomySpanGraceSeconds)
+	}
+
+	// Now let the sweep settle the pending second span.
+	if !d.flushExpiredAutonomySpan(st, t0+400+autonomySpanGraceSeconds) {
+		t.Fatal("flushExpiredAutonomySpan reported no change once the grace had run out")
+	}
+	if len(store.spans) != 2 {
+		t.Fatalf("got %d spans after the flush, want 2", len(store.spans))
+	}
+	second := store.spans[1]
+	if second.Start != t0+100+outside || second.End != t0+400 {
+		t.Errorf("second span = [%d,%d], want [%d,%d]",
+			second.Start, second.End, t0+100+outside, t0+400)
+	}
+}
+
+// TestAutonomySpan_WaitingGetsNoGrace is the asymmetry the grace exists to
+// preserve, and the failure this feature must not ship: an agent that asked a
+// question and got an answer four seconds later has NOT run continuously
+// through the question.
+//
+// wrongTotal below is the committed mutation — the single fabricated span a
+// build that granted `waiting` the same grace would produce. The test names it
+// so the failure says what broke, not merely that a count changed.
+func TestAutonomySpan_WaitingGetsNoGrace(t *testing.T) {
+	const t0 = 1_700_000_000
+	const askedAt = t0 + 600 // ran ten minutes, then asked
+	const answeredAt = askedAt + 4
+	const finishedAt = answeredAt + 300
+
+	d, store, st := spanFixture()
+	drive(d, st,
+		step{session.StateWorking, t0},
+		step{session.StateWaiting, askedAt},
+		step{session.StateWorking, answeredAt},
+		step{session.StateWaiting, finishedAt},
+	)
+
+	if len(store.spans) != 2 {
+		wrongTotal := finishedAt - t0
+		t.Fatalf("got %d spans, want 2 — granting `waiting` the flicker grace would merge a "+
+			"%ds question-and-answer into ONE fabricated %ds run", len(store.spans), answeredAt-askedAt, wrongTotal)
+	}
+	if store.spans[0].End != askedAt || store.spans[0].Reason != session.StateWaiting {
+		t.Errorf("first span ends at %d reason %q, want %d reason %q — the run ends when it needs a human",
+			store.spans[0].End, store.spans[0].Reason, askedAt, session.StateWaiting)
+	}
+	if store.spans[1].Start != answeredAt {
+		t.Errorf("second span starts at %d, want %d — answering starts a NEW run",
+			store.spans[1].Start, answeredAt)
+	}
+}
+
+// TestAutonomySpan_ErrorEndsTheSpan pins design decision 3 and its trade-off:
+// a resumed run after a usage limit is a NEW span, not a continuation.
+func TestAutonomySpan_ErrorEndsTheSpan(t *testing.T) {
+	const t0 = 1_700_000_000
+
+	d, store, st := spanFixture()
+	drive(d, st,
+		step{session.StateWorking, t0},
+		step{session.StateError, t0 + 900},
+		step{session.StateWorking, t0 + 900 + 1}, // resumed immediately, still a new span
+		step{session.StateWaiting, t0 + 2000},
+	)
+	if len(store.spans) != 2 {
+		t.Fatalf("got %d spans, want 2 — `error` ends a span with no grace at all", len(store.spans))
+	}
+	if store.spans[0].Reason != session.StateError {
+		t.Errorf("first span reason = %q, want %q", store.spans[0].Reason, session.StateError)
+	}
+	if store.spans[1].Start != t0+901 {
+		t.Errorf("resumed span start = %d, want %d (a NEW span, not the old one extended)",
+			store.spans[1].Start, t0+901)
+	}
+}
+
+func TestAutonomySpan_PendingSpanSettlesOnTeardown(t *testing.T) {
+	const t0 = 1_700_000_000
+	d, store, st := spanFixture()
+	drive(d, st,
+		step{session.StateWorking, t0},
+		step{session.StateReady, t0 + 120},
+	)
+	if len(store.spans) != 0 {
+		t.Fatalf("a pending ready close must not be written before the grace runs out; got %d spans",
+			len(store.spans))
+	}
+	// The session goes away (process exit): it can never return to working, so
+	// the pending close is filed immediately rather than waiting for a ticker
+	// that will never see it again.
+	d.settleAutonomySpanOnTeardown(st)
+	if len(store.spans) != 1 {
+		t.Fatalf("got %d spans after teardown, want 1 — a finished run must not be lost when the "+
+			"session is reaped inside the grace window", len(store.spans))
+	}
+	if store.spans[0].End != t0+120 || store.spans[0].Reason != session.StateReady {
+		t.Errorf("span = end %d reason %q, want %d/%q",
+			store.spans[0].End, store.spans[0].Reason, t0+120, session.StateReady)
+	}
+}
+
+func TestAutonomySpan_FlushBeforeGraceIsANoOp(t *testing.T) {
+	const t0 = 1_700_000_000
+	d, store, st := spanFixture()
+	drive(d, st,
+		step{session.StateWorking, t0},
+		step{session.StateReady, t0 + 120},
+	)
+	if d.flushExpiredAutonomySpan(st, t0+120+autonomySpanGraceSeconds-1) {
+		t.Error("the sweep settled a span whose grace had not run out")
+	}
+	if len(store.spans) != 0 {
+		t.Errorf("got %d spans, want 0 while the grace is still running", len(store.spans))
+	}
+}
+
+func TestAutonomySpan_CarriesItsProvenance(t *testing.T) {
+	const t0 = 1_700_000_000
+	d, store, st := spanFixture()
+	st.Metrics = &session.SessionMetrics{ModelName: "claude-sonnet-4"}
+	drive(d, st,
+		step{session.StateWorking, t0},
+		step{session.StateWaiting, t0 + 60},
+	)
+	if len(store.spans) != 1 {
+		t.Fatalf("got %d spans, want 1", len(store.spans))
+	}
+	got := store.spans[0]
+	if got.Project != "irrlicht" || got.Session != "sess-1" || got.Adapter != "claude-code" {
+		t.Errorf("span provenance = %+v, want project/session/adapter carried through", got)
+	}
+	if got.Model != "claude-sonnet-4" {
+		t.Errorf("span model = %q, want the live Metrics.ModelName", got.Model)
+	}
+}
+
+func TestAutonomySpan_NoStoreStillClearsTheOpenSpan(t *testing.T) {
+	const t0 = 1_700_000_000
+	d := newSessionDetector() // no store wired
+	d.log = &gateLogger{}
+	st := &session.SessionState{SessionID: "s", ProjectName: "p"}
+	drive(d, st,
+		step{session.StateWorking, t0},
+		step{session.StateWaiting, t0 + 60},
+	)
+	if st.AutonomySpanStart != nil || st.AutonomySpanPendingEnd != nil {
+		t.Error("a detector with no span store must still clear the open span, or the next " +
+			"transition reports a run that started days ago")
+	}
+}
+
+// TestAutonomyReasonLadderMatchesHistoryBar pins the strip's collapse ladder
+// against the session-history strip's (#1805), which is where the order came
+// from. Two hand-written ladders in one repo is one too many; this is what
+// stops them drifting.
+func TestAutonomyReasonLadderMatchesHistoryBar(t *testing.T) {
+	pairs := []struct {
+		state       string
+		historyBar  int8
+		autonomyBar int
+	}{
+		{session.StateError, statePriorityError, session.AutonomyReasonPriority(session.StateError)},
+		{session.StateWaiting, statePriorityWaiting, session.AutonomyReasonPriority(session.StateWaiting)},
+		{session.StateReady, statePriorityReady, session.AutonomyReasonPriority(session.StateReady)},
+	}
+	for i := 1; i < len(pairs); i++ {
+		prev, cur := pairs[i-1], pairs[i]
+		if !(prev.historyBar > cur.historyBar) {
+			t.Fatalf("the history bar's ladder no longer ranks %q above %q — this test's premise is gone",
+				prev.state, cur.state)
+		}
+		if !(prev.autonomyBar > cur.autonomyBar) {
+			t.Errorf("the autonomy strip ranks %q (%d) at or below %q (%d), but the history bar ranks it "+
+				"above — one error in a column must paint the whole column",
+				prev.state, prev.autonomyBar, cur.state, cur.autonomyBar)
+		}
+	}
+	if session.AutonomyReasonPriority("nonsense") >= session.AutonomyReasonPriority(session.StateReady) {
+		t.Error("an unrecognized reason must rank below every real one, or a build that cannot name a " +
+			"state outranks activity it can")
+	}
+}
+
+func TestAutonomyEndReasons_DerivedFromTheVocabulary(t *testing.T) {
+	reasons := session.AutonomyEndReasons()
+	if len(reasons) != len(session.CanonicalStates())-1 {
+		t.Fatalf("AutonomyEndReasons has %d entries, want one fewer than the canonical vocabulary (%d)",
+			len(reasons), len(session.CanonicalStates()))
+	}
+	for _, r := range reasons {
+		if r == session.StateWorking {
+			t.Error("`working` is not an end reason — a span that is still working has not ended")
+		}
+		if !session.IsAutonomyEndReason(r) {
+			t.Errorf("IsAutonomyEndReason(%q) is false for a reason the list itself returned", r)
+		}
+	}
+	if session.IsAutonomyEndReason(session.StateWorking) {
+		t.Error("IsAutonomyEndReason accepted `working`")
+	}
+}

--- a/core/application/services/session_detector.go
+++ b/core/application/services/session_detector.go
@@ -123,10 +123,11 @@ type SessionDetector struct {
 
 	enricher       *metadataEnricher
 	pidMgr         *PIDManager
-	costTracker    outbound.CostTracker    // optional; nil = disabled
-	historyTracker outbound.HistoryTracker // optional; nil = disabled
-	cacheBloat     *CacheBloatDetector     // optional; nil = disabled (#374)
-	hookLiveness   *HookLivenessWatchdog   // optional; nil = disabled (#1368)
+	costTracker    outbound.CostTracker       // optional; nil = disabled
+	autonomySpans  outbound.AutonomySpanStore // optional; nil = disabled (#1905)
+	historyTracker outbound.HistoryTracker    // optional; nil = disabled
+	cacheBloat     *CacheBloatDetector        // optional; nil = disabled (#374)
+	hookLiveness   *HookLivenessWatchdog      // optional; nil = disabled (#1368)
 	metrics        outbound.MetricsCollector
 
 	// projectSessions tracks sessionID → projectDir for pre-session cleanup.
@@ -467,6 +468,14 @@ func (d *SessionDetector) SetRecorder(r outbound.EventRecorder) {
 // queries. Pass nil to disable.
 func (d *SessionDetector) SetCostTracker(c outbound.CostTracker) {
 	d.costTracker = c
+}
+
+// SetAutonomySpanStore wires an optional AutonomySpanStore (#1905); closed
+// autonomy spans are appended to it as sessions leave `working`. Pass nil to
+// disable — the open-span bookkeeping on the session still runs, so a daemon
+// without a store never accumulates a stale "open since".
+func (d *SessionDetector) SetAutonomySpanStore(s outbound.AutonomySpanStore) {
+	d.autonomySpans = s
 }
 
 // SetHistoryTracker wires an optional HistoryTracker that records per-session

--- a/core/application/services/session_detector_activity.go
+++ b/core/application/services/session_detector_activity.go
@@ -1267,6 +1267,15 @@ func (d *SessionDetector) applyStateTransition(state *session.SessionState, ev a
 	state.State = newState
 	state.UpdatedAt = now
 
+	// Autonomy spans (#1905) open and close on this same edge, and read the
+	// state BEFORE the per-target-state switch below rewrites it — see
+	// applyAutonomySpanTransition. Deliberately not folded into that switch:
+	// its `default` arm carries meaning (any state that is not working or
+	// ready ends a span under its own name), while the switch below is an
+	// exhaustive per-state audit with nothing to say about the states it does
+	// not name.
+	d.applyAutonomySpanTransition(state, newState, now)
+
 	switch newState {
 	case session.StateWaiting:
 		state.WaitingStartTime = &now
@@ -1828,6 +1837,15 @@ func (d *SessionDetector) refreshStaleSessions() {
 	}
 	now := d.nowFn()
 	for _, state := range sessions {
+		// An autonomy span held open by the flicker grace (#1905) settles
+		// here: this ticker is the only thing that revisits a session which
+		// finished its turn and then did nothing, which is the most common way
+		// a span ends.
+		if d.flushExpiredAutonomySpan(state, now.Unix()) {
+			if err := d.repo.Save(state); err != nil {
+				d.log.LogError(logComponentAutonomySpans, state.SessionID, err.Error())
+			}
+		}
 		switch state.State {
 		case session.StateWorking:
 			d.reclassifyFromTranscript(state, now)

--- a/core/application/services/session_detector_helpers.go
+++ b/core/application/services/session_detector_helpers.go
@@ -52,6 +52,10 @@ func (d *SessionDetector) cacheDeletedSnapshot(state *session.SessionState) {
 	if state == nil {
 		return
 	}
+	// Last chance to file a still-pending autonomy span (#1905): a deleted
+	// session never returns to `working`, so the flicker grace has nothing
+	// left to decide, and the 5s ticker will never see this session again.
+	d.settleAutonomySpanOnTeardown(state)
 	d.mu.Lock()
 	d.deletedStates[state.SessionID] = state
 	d.mu.Unlock()

--- a/core/cmd/irrlichd/dora_budget_test.go
+++ b/core/cmd/irrlichd/dora_budget_test.go
@@ -64,7 +64,7 @@ func TestHandleGetHistory_DoraHonoursTheRequestContext(t *testing.T) {
 	cancel()
 	req := httptest.NewRequest(http.MethodGet, url, nil).WithContext(gone)
 	rec := httptest.NewRecorder()
-	handleGetHistory(nil, lister, nil, git)(rec, req)
+	handleGetHistory(nil, lister, nil, git, nil)(rec, req)
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("want 200 (an unreadable panel is a well-formed answer, not an error), got %d: %s", rec.Code, rec.Body.String())
@@ -82,7 +82,7 @@ func TestHandleGetHistory_DoraHonoursTheRequestContext(t *testing.T) {
 	// Vacuity guard: the same fixture on a live request MUST produce a panel,
 	// or the assertion above holds for a handler that never computes anything.
 	live := httptest.NewRecorder()
-	handleGetHistory(nil, lister, nil, git)(live, httptest.NewRequest(http.MethodGet, url, nil))
+	handleGetHistory(nil, lister, nil, git, nil)(live, httptest.NewRequest(http.MethodGet, url, nil))
 	var ok historyDoraResponse
 	if err := json.Unmarshal(live.Body.Bytes(), &ok); err != nil {
 		t.Fatalf("decode %q: %v", live.Body.String(), err)

--- a/core/cmd/irrlichd/handlers.go
+++ b/core/cmd/irrlichd/handlers.go
@@ -693,6 +693,55 @@ type historyQuery struct {
 	seriesQuery outbound.SeriesQuery
 }
 
+// resolveHistoryWindow resolves a chart's [start, end) window and bucket width
+// from whichever window selector that chart owns, writing the 400 and returning
+// ok=false on an invalid one.
+//
+// THREE VOCABULARIES, and the split between them is the point (#1905):
+//
+//   - Autonomy's ?window= keys are WINDOW LENGTHS: "24h" IS one day.
+//   - chart=state's ?granularity= keys are BUCKET WIDTHS times a count, so
+//     "24h" there resolves to a THIRTY-DAY window.
+//   - everything else uses ?range=/?start=&end= plus a span-derived bucket.
+//
+// The first two look identical and mean different things, which is why they
+// resolve through separate tables rather than one shared map —
+// TestAutonomyWindows_AreNotHistoryGranularities is the tripwire that keeps a
+// later refactor from merging them.
+func resolveHistoryWindow(w http.ResponseWriter, q url.Values, chart string) (rangeKey string, start, end, bucketSeconds int64, ok bool) {
+	switch {
+	case isAutonomyChart(chart):
+		window := q.Get("window")
+		if window == "" {
+			window = autonomyDefaultWindow(chart)
+		}
+		bs, s, e, known := resolveAutonomyWindow(chart, window)
+		if !known {
+			http.Error(w, autonomyWindowError(chart), http.StatusBadRequest)
+			return "", 0, 0, 0, false
+		}
+		return window, s, e, bs, true
+	case chart == "state":
+		granularity := q.Get("granularity")
+		if granularity == "" {
+			granularity = "24h"
+		}
+		bs, s, e, known := resolveHistoryGranularity(granularity)
+		if !known {
+			http.Error(w, "invalid granularity: use 1m|10m|60m|8h|24h|7d|1mo|6mo|1y", http.StatusBadRequest)
+			return "", 0, 0, 0, false
+		}
+		return granularity, s, e, bs, true
+	default:
+		rk, s, e, valid := resolveHistoryRange(q)
+		if !valid {
+			http.Error(w, "invalid range: use range=day|week|month|year|this-month or start&end (unix seconds)", http.StatusBadRequest)
+			return "", 0, 0, 0, false
+		}
+		return rk, s, e, historyBucketSeconds(q, e-s), true
+	}
+}
+
 // resolveHistoryQuery parses and validates handleGetHistory's query params,
 // writing the appropriate 400 response and returning ok=false on the first
 // invalid one.
@@ -722,44 +771,9 @@ func resolveHistoryQuery(w http.ResponseWriter, q url.Values) (historyQuery, boo
 	scopeField, scopeValue := parseHistoryScope(q.Get("scope"))
 	scopeEcho := historyScopeEcho(scopeField, scopeValue)
 
-	// chart=state (#981) resolves its window from a named ?granularity=
-	// zoom-level instead of the usual ?range=/?bucket= pair — the granularity
-	// picks both the bucket width and the trailing window at once.
-	var rangeKey string
-	var start, end, bucketSeconds int64
-	if isAutonomyChart(chart) {
-		// Autonomy (#1905) resolves its window from ?window=, whose keys are
-		// WINDOW LENGTHS — not the bucket-width-times-count that the
-		// same-looking ?granularity= keys mean below.
-		window := q.Get("window")
-		if window == "" {
-			window = autonomyDefaultWindow(chart)
-		}
-		bs, s, e, wok := resolveAutonomyWindow(chart, window)
-		if !wok {
-			http.Error(w, autonomyWindowError(chart), http.StatusBadRequest)
-			return historyQuery{}, false
-		}
-		rangeKey, start, end, bucketSeconds = window, s, e, bs
-	} else if chart == "state" {
-		granularity := q.Get("granularity")
-		if granularity == "" {
-			granularity = "24h"
-		}
-		bs, s, e, gok := resolveHistoryGranularity(granularity)
-		if !gok {
-			http.Error(w, "invalid granularity: use 1m|10m|60m|8h|24h|7d|1mo|6mo|1y", http.StatusBadRequest)
-			return historyQuery{}, false
-		}
-		rangeKey, start, end, bucketSeconds = granularity, s, e, bs
-	} else {
-		rk, s, e, ok := resolveHistoryRange(q)
-		if !ok {
-			http.Error(w, "invalid range: use range=day|week|month|year|this-month or start&end (unix seconds)", http.StatusBadRequest)
-			return historyQuery{}, false
-		}
-		rangeKey, start, end = rk, s, e
-		bucketSeconds = historyBucketSeconds(q, end-start)
+	rangeKey, start, end, bucketSeconds, wok := resolveHistoryWindow(w, q, chart)
+	if !wok {
+		return historyQuery{}, false
 	}
 
 	seriesQuery := outbound.SeriesQuery{
@@ -783,6 +797,45 @@ func resolveHistoryQuery(w http.ResponseWriter, q url.Values) (historyQuery, boo
 	}, true
 }
 
+// historyChartDeps bundles the readers the non-cost charts need, so the
+// dispatcher below takes one value instead of four positional collaborators
+// (go:S107).
+type historyChartDeps struct {
+	sessions    historySessionLister
+	concurrency outbound.ConcurrencyReader
+	git         historyGitReader
+	autonomy    outbound.AutonomySpanStore
+}
+
+// serveNonCostHistoryChart answers every chart that is not a cost time series
+// and reports whether it did. Each of these reads a different store — completed
+// sessions, git, the lifecycle recordings, the autonomy span log — and none of
+// them touches the group/metric/scope machinery the cost path needs, which is
+// why they resolve here rather than downstream of it.
+func serveNonCostHistoryChart(w http.ResponseWriter, r *http.Request, hq historyQuery, deps historyChartDeps) bool {
+	switch hq.chart {
+	case chartAutonomyDuration:
+		// Autonomy (#1905) reads the always-on span log, never the opt-in
+		// recordings — see outbound.AutonomySpanStore for why that matters.
+		serveHistoryAutonomyDurationChart(w, deps.autonomy, hq.rangeKey, hq.seriesQuery.BucketSeconds, hq.start, hq.end)
+	case chartAutonomySpans:
+		serveHistoryAutonomySpansChart(w, deps.autonomy, hq.rangeKey, hq.start, hq.end)
+	case "yield":
+		// A per-project aggregate over completed sessions, not a time series (#373).
+		writeHistoryJSON(w, buildYieldResponse(hq.rangeKey, hq.group, hq.start, hq.end, deps.sessions))
+	case "dora":
+		// A per-project period summary computed from git on request (#951).
+		serveHistoryDoraChart(r.Context(), w, deps.git, deps.sessions, r.URL.Query().Get("project"), hq.rangeKey, hq.start, hq.end)
+	case "agents":
+		serveHistoryAgentsChart(w, deps.concurrency, hq.rangeKey, hq.scopeEcho, hq.seriesQuery)
+	case "state":
+		serveHistoryStateChart(w, deps.concurrency, hq.rangeKey, hq.scopeEcho, hq.seriesQuery)
+	default:
+		return false
+	}
+	return true
+}
+
 func handleGetHistory(tracker outbound.CostTracker, sessions historySessionLister, concurrency outbound.ConcurrencyReader, git historyGitReader, autonomy outbound.AutonomySpanStore) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		q := r.URL.Query()
@@ -792,38 +845,12 @@ func handleGetHistory(tracker outbound.CostTracker, sessions historySessionListe
 			return
 		}
 
-		// Autonomy (#1905): both elements read the always-on span log and
-		// touch none of the group/metric/scope machinery below.
-		if hq.chart == chartAutonomyDuration {
-			serveHistoryAutonomyDurationChart(w, autonomy, hq.rangeKey, hq.seriesQuery.BucketSeconds, hq.start, hq.end)
-			return
-		}
-		if hq.chart == chartAutonomySpans {
-			serveHistoryAutonomySpansChart(w, autonomy, hq.rangeKey, hq.start, hq.end)
-			return
-		}
-
-		// Yield is a per-project aggregate over completed sessions, not a cost
-		// time series — handle it before the cost-tracker path (#373).
-		if hq.chart == "yield" {
-			writeHistoryJSON(w, buildYieldResponse(hq.rangeKey, hq.group, hq.start, hq.end, sessions))
-			return
-		}
-
-		// DORA metrics are a per-project period summary, not a cost time
-		// series — handle it before the cost-tracker path (#951).
-		if hq.chart == "dora" {
-			serveHistoryDoraChart(r.Context(), w, git, sessions, q.Get("project"), hq.rangeKey, hq.start, hq.end)
-			return
-		}
-
-		if hq.chart == "agents" {
-			serveHistoryAgentsChart(w, concurrency, hq.rangeKey, hq.scopeEcho, hq.seriesQuery)
-			return
-		}
-
-		if hq.chart == "state" {
-			serveHistoryStateChart(w, concurrency, hq.rangeKey, hq.scopeEcho, hq.seriesQuery)
+		// Every chart that is NOT a cost series answers here and returns; only
+		// the cost/tokens/co2/models/providers family falls through to the
+		// cost-tracker path below.
+		if serveNonCostHistoryChart(w, r, hq, historyChartDeps{
+			sessions: sessions, concurrency: concurrency, git: git, autonomy: autonomy,
+		}) {
 			return
 		}
 

--- a/core/cmd/irrlichd/handlers.go
+++ b/core/cmd/irrlichd/handlers.go
@@ -507,6 +507,9 @@ func historyChartKnown(w http.ResponseWriter, chart string) bool {
 	case "state":
 		// implemented (#981, the "Activity Matrix" — time-in-state, the
 		// optional second half of #751) — handled after range resolution below
+	case chartAutonomyDuration, chartAutonomySpans:
+		// implemented (#1905, the Autonomy section's two elements) — each
+		// brings its OWN ?window= vocabulary, resolved in resolveHistoryQuery
 	default:
 		http.Error(w, "unknown chart: "+chart, http.StatusBadRequest)
 		return false
@@ -724,7 +727,21 @@ func resolveHistoryQuery(w http.ResponseWriter, q url.Values) (historyQuery, boo
 	// picks both the bucket width and the trailing window at once.
 	var rangeKey string
 	var start, end, bucketSeconds int64
-	if chart == "state" {
+	if isAutonomyChart(chart) {
+		// Autonomy (#1905) resolves its window from ?window=, whose keys are
+		// WINDOW LENGTHS — not the bucket-width-times-count that the
+		// same-looking ?granularity= keys mean below.
+		window := q.Get("window")
+		if window == "" {
+			window = autonomyDefaultWindow(chart)
+		}
+		bs, s, e, wok := resolveAutonomyWindow(chart, window)
+		if !wok {
+			http.Error(w, autonomyWindowError(chart), http.StatusBadRequest)
+			return historyQuery{}, false
+		}
+		rangeKey, start, end, bucketSeconds = window, s, e, bs
+	} else if chart == "state" {
 		granularity := q.Get("granularity")
 		if granularity == "" {
 			granularity = "24h"
@@ -766,12 +783,23 @@ func resolveHistoryQuery(w http.ResponseWriter, q url.Values) (historyQuery, boo
 	}, true
 }
 
-func handleGetHistory(tracker outbound.CostTracker, sessions historySessionLister, concurrency outbound.ConcurrencyReader, git historyGitReader) http.HandlerFunc {
+func handleGetHistory(tracker outbound.CostTracker, sessions historySessionLister, concurrency outbound.ConcurrencyReader, git historyGitReader, autonomy outbound.AutonomySpanStore) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		q := r.URL.Query()
 
 		hq, ok := resolveHistoryQuery(w, q)
 		if !ok {
+			return
+		}
+
+		// Autonomy (#1905): both elements read the always-on span log and
+		// touch none of the group/metric/scope machinery below.
+		if hq.chart == chartAutonomyDuration {
+			serveHistoryAutonomyDurationChart(w, autonomy, hq.rangeKey, hq.seriesQuery.BucketSeconds, hq.start, hq.end)
+			return
+		}
+		if hq.chart == chartAutonomySpans {
+			serveHistoryAutonomySpansChart(w, autonomy, hq.rangeKey, hq.start, hq.end)
 			return
 		}
 

--- a/core/cmd/irrlichd/history_autonomy.go
+++ b/core/cmd/irrlichd/history_autonomy.go
@@ -1,0 +1,369 @@
+package main
+
+import (
+	"net/http"
+	"sort"
+	"time"
+
+	"irrlicht/core/pkg/stats"
+	"irrlicht/core/ports/outbound"
+)
+
+// Autonomy (#1905) — the History view's own top-level section, two elements
+// over one data source: a percentile line chart of autonomous run duration
+// over time, and a per-project run strip.
+//
+// Both are served from the always-on span log (outbound.AutonomySpanStore),
+// never from the opt-in lifecycle recordings that back chart=agents/state.
+
+const (
+	// chartAutonomyDuration is element 1: one entry per time bucket carrying
+	// p95/p50/p5 plus the true min/max and the sample count.
+	chartAutonomyDuration = "autonomy_duration"
+
+	// chartAutonomySpans is element 2: the individual spans in a trailing
+	// window, for the per-project run strip.
+	chartAutonomySpans = "autonomy_spans"
+)
+
+// autonomySampleFloor is the minimum number of spans a bucket needs before its
+// p95 and p5 are percentiles rather than restatements of its own max and min.
+//
+// It bites harder than a p90 would, which is why it exists at all: at n < 20
+// the R-7 p95 of a bucket interpolates within its top pair and the p5 within
+// its bottom pair, so the two outer lines collapse onto the min/max envelope
+// element 1 explicitly rejected — three lines drawn from what are really two
+// points. A bucket under the floor is MARKED (see historyAutonomyBucket.Thin)
+// and drawn differently by both clients, never hidden and never smoothed:
+// hiding it would turn a low-activity day into a gap, which reads as "no
+// runs", which is a different and false claim.
+const autonomySampleFloor = 20
+
+// autonomySpanLimit caps how many spans one strip request returns. A year of
+// heavy use is tens of thousands of spans, and the strip cannot draw more than
+// its own pixel width anyway; the cap keeps the payload bounded. When it bites
+// the response says so (Truncated), because a strip silently drawn from part
+// of its window is exactly the "wrong number with nothing on screen saying so"
+// this feature is supposed to avoid.
+const autonomySpanLimit = 20000
+
+// autonomyDurationSpec pairs one Range's bucket width with its bucket count.
+//
+// SEPARATE FROM historyGranularitySpecs ON PURPOSE, and the separation is
+// load-bearing (#1905). The keys look alike and mean opposite things: there, a
+// key names a BUCKET WIDTH which is then multiplied by a count, so "24h"
+// resolves to a THIRTY-DAY window. Here and in autonomySpanWindowSeconds a key
+// names the WINDOW ITSELF. Merging the two tables in a later refactor would
+// silently redefine what a user's "24h" means;
+// TestAutonomyWindows_AreNotHistoryGranularities is the tripwire.
+type autonomyDurationSpec struct {
+	bucketSeconds int64
+	buckets       int64
+}
+
+// autonomyDurationSpecs is element 1's Range vocabulary. Two ranges, and 30
+// days is the floor: anything shorter has too few spans per bucket for a
+// percentile to mean anything.
+var autonomyDurationSpecs = map[string]autonomyDurationSpec{
+	"30d": {86400, 30},     // 30 daily buckets
+	"1y":  {7 * 86400, 52}, // 52 weekly buckets
+}
+
+// autonomySpanWindowSeconds is element 2's Span vocabulary — WINDOW LENGTHS,
+// each the whole trailing period the strip draws.
+var autonomySpanWindowSeconds = map[string]int64{
+	"8h":   8 * 3600,
+	"24h":  24 * 3600,
+	"7d":   7 * 86400,
+	"30d":  30 * 86400,
+	"12mo": 365 * 86400,
+}
+
+// isAutonomyChart reports whether a ?chart= value is one of the two autonomy
+// elements — both of which resolve their window from ?window= instead of the
+// usual ?range=/?bucket= pair.
+func isAutonomyChart(chart string) bool {
+	return chart == chartAutonomyDuration || chart == chartAutonomySpans
+}
+
+// autonomyDefaultWindow is the ?window= value assumed when the client sends
+// none, per chart.
+func autonomyDefaultWindow(chart string) string {
+	if chart == chartAutonomySpans {
+		return "24h"
+	}
+	return "30d"
+}
+
+// resolveAutonomyWindow resolves a chart's ?window= into a trailing
+// [start, end) window plus, for the duration chart, its bucket width. ok is
+// false for a window the chart does not offer — the two charts have different
+// vocabularies and neither accepts the other's keys.
+func resolveAutonomyWindow(chart, window string) (bucketSeconds, start, end int64, ok bool) {
+	end = time.Now().Unix()
+	if chart == chartAutonomySpans {
+		secs, known := autonomySpanWindowSeconds[window]
+		if !known {
+			return 0, 0, 0, false
+		}
+		return 0, end - secs, end, true
+	}
+	spec, known := autonomyDurationSpecs[window]
+	if !known {
+		return 0, 0, 0, false
+	}
+	return spec.bucketSeconds, end - spec.bucketSeconds*spec.buckets, end, true
+}
+
+// autonomyWindowError is the 400 body for an unrecognized ?window=, naming the
+// vocabulary the requested chart actually has.
+func autonomyWindowError(chart string) string {
+	if chart == chartAutonomySpans {
+		return "invalid window for chart=autonomy_spans: use 8h|24h|7d|30d|12mo"
+	}
+	return "invalid window for chart=autonomy_duration: use 30d|1y"
+}
+
+// historyAutonomyBucket is one time bucket of element 1. Buckets with no spans
+// are OMITTED from the response entirely rather than sent with zeros — a day
+// with no runs is a gap, not a run of length zero, and a zero would pull the
+// line to the axis (the same rule appendSparsePoints applies to the cost
+// series). Count is therefore always ≥ 1 on a bucket that is present.
+type historyAutonomyBucket struct {
+	TS    int64   `json:"ts"`
+	P95   float64 `json:"p95"`
+	P50   float64 `json:"p50"`
+	P5    float64 `json:"p5"`
+	Min   float64 `json:"min"`
+	Max   float64 `json:"max"`
+	Count int     `json:"count"`
+	// Thin marks a bucket below autonomySampleFloor, whose p95/p5 are its own
+	// max/min. Both clients render such buckets visibly differently.
+	Thin bool `json:"thin,omitempty"`
+}
+
+// historyAutonomySummary is the window-wide figure row under the chart: the
+// drawn envelope's percentiles plus the true extremes, which are figures and
+// deliberately NOT lines (one overnight run would otherwise redraw the whole
+// Y scale and flatten every other bucket onto the floor).
+type historyAutonomySummary struct {
+	P95   float64 `json:"p95"`
+	P50   float64 `json:"p50"`
+	P5    float64 `json:"p5"`
+	Min   float64 `json:"min"`
+	Max   float64 `json:"max"`
+	Count int     `json:"count"`
+}
+
+// historyAutonomyDurationResponse is the chart=autonomy_duration payload.
+type historyAutonomyDurationResponse struct {
+	Window        string                  `json:"window"`
+	Chart         string                  `json:"chart"`
+	Start         int64                   `json:"start"`
+	End           int64                   `json:"end"`
+	BucketSeconds int64                   `json:"bucket_seconds"`
+	BucketStarts  []int64                 `json:"bucket_starts"`
+	Buckets       []historyAutonomyBucket `json:"buckets"`
+	Summary       historyAutonomySummary  `json:"summary"`
+	SampleFloor   int                     `json:"sample_floor"`
+	// EarliestSpan is the earliest span on record across the WHOLE log, not
+	// this window — 0 when nothing has ever been recorded. It is what lets
+	// both clients say "collecting since <date>" instead of leaving an empty
+	// chart to be read as "you did nothing" (#1905).
+	EarliestSpan  int64 `json:"earliest_span"`
+	TotalRecorded int   `json:"total_recorded"`
+}
+
+// historyAutonomySpanRow is one span on the wire for element 2.
+type historyAutonomySpanRow struct {
+	Start   int64  `json:"start"`
+	End     int64  `json:"end"`
+	Project string `json:"project"`
+	Session string `json:"session"`
+	// Reason is one of session.AutonomyEndReasons(); "" for a span recorded
+	// by a build that could not name it.
+	Reason string `json:"reason,omitempty"`
+}
+
+// historyAutonomySpansResponse is the chart=autonomy_spans payload: the spans
+// themselves plus the row order the strip draws them in.
+type historyAutonomySpansResponse struct {
+	Window string                   `json:"window"`
+	Chart  string                   `json:"chart"`
+	Start  int64                    `json:"start"`
+	End    int64                    `json:"end"`
+	Spans  []historyAutonomySpanRow `json:"spans"`
+	// Projects is strip row order — most autonomous seconds first — computed
+	// once here so the two clients cannot order the same strip differently.
+	Projects      []string `json:"projects"`
+	EarliestSpan  int64    `json:"earliest_span"`
+	TotalRecorded int      `json:"total_recorded"`
+	Truncated     bool     `json:"truncated"`
+}
+
+// serveHistoryAutonomyDurationChart serves chart=autonomy_duration. A nil
+// store yields an empty-but-valid payload rather than an error, mirroring
+// serveHistoryAgentsChart.
+func serveHistoryAutonomyDurationChart(w http.ResponseWriter, store outbound.AutonomySpanStore, window string, bucketSeconds, start, end int64) {
+	res, ok := readAutonomySpans(w, store, outbound.AutonomySpanQuery{Start: start, End: end})
+	if !ok {
+		return
+	}
+	writeHistoryJSON(w, buildAutonomyDurationResponse(window, bucketSeconds, start, end, res))
+}
+
+// serveHistoryAutonomySpansChart serves chart=autonomy_spans.
+func serveHistoryAutonomySpansChart(w http.ResponseWriter, store outbound.AutonomySpanStore, window string, start, end int64) {
+	res, ok := readAutonomySpans(w, store, outbound.AutonomySpanQuery{Start: start, End: end, Limit: autonomySpanLimit})
+	if !ok {
+		return
+	}
+	writeHistoryJSON(w, buildAutonomySpansResponse(window, start, end, res))
+}
+
+// readAutonomySpans performs the store read shared by both elements,
+// substituting an empty result for a nil store and writing a 500 on error.
+// ok is false once it has written a response.
+func readAutonomySpans(w http.ResponseWriter, store outbound.AutonomySpanStore, q outbound.AutonomySpanQuery) (*outbound.AutonomySpanResult, bool) {
+	if store == nil {
+		return &outbound.AutonomySpanResult{Spans: []outbound.AutonomySpan{}}, true
+	}
+	res, err := store.SpansInWindow(q)
+	if err != nil {
+		http.Error(w, errInternalErrorMsg, http.StatusInternalServerError)
+		return nil, false
+	}
+	if res == nil {
+		res = &outbound.AutonomySpanResult{Spans: []outbound.AutonomySpan{}}
+	}
+	return res, true
+}
+
+// buildAutonomyDurationResponse buckets the window's spans by the bucket their
+// END falls in, and reduces each bucket to its percentile envelope.
+//
+// Every percentile here is computed ONCE, server-side, with the R-7 convention
+// named in stats.Percentile — not because the clients could not divide, but
+// because "the p95" is ambiguous enough that two independent implementations
+// draw two different lines from the same data (#1905 design decision 5).
+func buildAutonomyDurationResponse(window string, bucketSeconds, start, end int64, res *outbound.AutonomySpanResult) historyAutonomyDurationResponse {
+	n := 0
+	if bucketSeconds > 0 && end > start {
+		n = int((end - start + bucketSeconds - 1) / bucketSeconds)
+	}
+	bucketStarts := make([]int64, n)
+	for i := range bucketStarts {
+		bucketStarts[i] = start + int64(i)*bucketSeconds
+	}
+
+	byBucket := make([][]float64, n)
+	all := make([]float64, 0, len(res.Spans))
+	for _, s := range res.Spans {
+		d := float64(s.Duration())
+		if d <= 0 {
+			continue
+		}
+		all = append(all, d)
+		if n == 0 {
+			continue
+		}
+		idx := int((s.End - start) / bucketSeconds)
+		if idx < 0 || idx >= n {
+			continue
+		}
+		byBucket[idx] = append(byBucket[idx], d)
+	}
+
+	buckets := make([]historyAutonomyBucket, 0, n)
+	for i, samples := range byBucket {
+		// A bucket with no spans is a GAP: omitted, never emitted as a zero.
+		if len(samples) == 0 {
+			continue
+		}
+		buckets = append(buckets, autonomyBucketFrom(bucketStarts[i], samples))
+	}
+
+	return historyAutonomyDurationResponse{
+		Window:        window,
+		Chart:         chartAutonomyDuration,
+		Start:         start,
+		End:           end,
+		BucketSeconds: bucketSeconds,
+		BucketStarts:  bucketStarts,
+		Buckets:       buckets,
+		Summary:       autonomySummaryFrom(all),
+		SampleFloor:   autonomySampleFloor,
+		EarliestSpan:  res.EarliestStart,
+		TotalRecorded: res.TotalRecorded,
+	}
+}
+
+// autonomyBucketFrom reduces one bucket's samples to its envelope. samples is
+// sorted in place, then read five times — one sort per bucket, not per line.
+func autonomyBucketFrom(ts int64, samples []float64) historyAutonomyBucket {
+	sort.Float64s(samples)
+	return historyAutonomyBucket{
+		TS:    ts,
+		P95:   stats.PercentileSorted(samples, 0.95),
+		P50:   stats.PercentileSorted(samples, 0.50),
+		P5:    stats.PercentileSorted(samples, 0.05),
+		Min:   samples[0],
+		Max:   samples[len(samples)-1],
+		Count: len(samples),
+		Thin:  len(samples) < autonomySampleFloor,
+	}
+}
+
+// autonomySummaryFrom reduces the whole window's samples to the figure row.
+func autonomySummaryFrom(samples []float64) historyAutonomySummary {
+	if len(samples) == 0 {
+		return historyAutonomySummary{}
+	}
+	sort.Float64s(samples)
+	return historyAutonomySummary{
+		P95:   stats.PercentileSorted(samples, 0.95),
+		P50:   stats.PercentileSorted(samples, 0.50),
+		P5:    stats.PercentileSorted(samples, 0.05),
+		Min:   samples[0],
+		Max:   samples[len(samples)-1],
+		Count: len(samples),
+	}
+}
+
+// buildAutonomySpansResponse renders the window's spans plus the strip's row
+// order (most autonomous seconds first, then name for a stable tie-break).
+func buildAutonomySpansResponse(window string, start, end int64, res *outbound.AutonomySpanResult) historyAutonomySpansResponse {
+	rows := make([]historyAutonomySpanRow, 0, len(res.Spans))
+	totals := map[string]int64{}
+	for _, s := range res.Spans {
+		rows = append(rows, historyAutonomySpanRow{
+			Start:   s.Start,
+			End:     s.End,
+			Project: s.Project,
+			Session: s.Session,
+			Reason:  s.Reason,
+		})
+		totals[s.Project] += s.Duration()
+	}
+	projects := make([]string, 0, len(totals))
+	for p := range totals {
+		projects = append(projects, p)
+	}
+	sort.Slice(projects, func(i, j int) bool {
+		if totals[projects[i]] != totals[projects[j]] {
+			return totals[projects[i]] > totals[projects[j]]
+		}
+		return projects[i] < projects[j]
+	})
+	return historyAutonomySpansResponse{
+		Window:        window,
+		Chart:         chartAutonomySpans,
+		Start:         start,
+		End:           end,
+		Spans:         rows,
+		Projects:      projects,
+		EarliestSpan:  res.EarliestStart,
+		TotalRecorded: res.TotalRecorded,
+		Truncated:     res.Truncated,
+	}
+}

--- a/core/cmd/irrlichd/history_autonomy_endpoint_test.go
+++ b/core/cmd/irrlichd/history_autonomy_endpoint_test.go
@@ -1,0 +1,431 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"irrlicht/core/ports/outbound"
+)
+
+// fakeAutonomyStore serves a fixed span list, ignoring the window — the
+// handler's bucketing, not the store's filtering, is what these tests are
+// about.
+type fakeAutonomyStore struct {
+	spans     []outbound.AutonomySpan
+	earliest  int64
+	total     int
+	truncated bool
+	err       error
+	lastQuery outbound.AutonomySpanQuery
+}
+
+func (f *fakeAutonomyStore) RecordSpan(outbound.AutonomySpan) error { return nil }
+func (f *fakeAutonomyStore) Prune(int) error                        { return nil }
+func (f *fakeAutonomyStore) SpansInWindow(q outbound.AutonomySpanQuery) (*outbound.AutonomySpanResult, error) {
+	f.lastQuery = q
+	if f.err != nil {
+		return nil, f.err
+	}
+	return &outbound.AutonomySpanResult{
+		Spans:         f.spans,
+		EarliestStart: f.earliest,
+		TotalRecorded: f.total,
+		Truncated:     f.truncated,
+	}, nil
+}
+
+func getAutonomy(t *testing.T, store outbound.AutonomySpanStore, query string) *httptest.ResponseRecorder {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/history?"+query, nil)
+	handleGetHistory(nil, nil, nil, nil, store)(rec, req)
+	return rec
+}
+
+// spanEndingAt builds a span of the given length that ended at `end`.
+func spanEndingAt(end, length int64, project, reason string) outbound.AutonomySpan {
+	return outbound.AutonomySpan{
+		Start:   end - length,
+		End:     end,
+		Project: project,
+		Session: fmt.Sprintf("s-%d", end),
+		Reason:  reason,
+	}
+}
+
+// --- The two window vocabularies must stay distinct -------------------------
+
+// TestAutonomyWindows_AreNotHistoryGranularities is the tripwire for the trap
+// the issue calls out by name: chart=state's ?granularity= keys and the
+// autonomy strip's ?window= keys OVERLAP textually and mean different things.
+// A granularity key is a BUCKET WIDTH times a count; a window key is the
+// WINDOW ITSELF.
+//
+// The committed mutation is mergedResolver below — the refactor this test
+// exists to stop, i.e. "these tables look the same, let's have one". The test
+// asserts production disagrees with it, so the day someone merges them this
+// goes red instead of `24h` silently becoming a 30-day strip.
+func TestAutonomyWindows_AreNotHistoryGranularities(t *testing.T) {
+	// The MUTATION: resolve a strip window by reusing chart=state's table.
+	mergedResolver := func(key string) (seconds int64, ok bool) {
+		spec, known := historyGranularitySpecs[key]
+		if !known {
+			return 0, false
+		}
+		return spec.bucketSeconds * spec.buckets, true
+	}
+
+	shared := []string{"8h", "24h", "7d"}
+	for _, key := range shared {
+		want, ok := autonomySpanWindowSeconds[key]
+		if !ok {
+			t.Fatalf("autonomySpanWindowSeconds is missing %q — the overlap this test guards is gone; "+
+				"re-derive the shared key list rather than deleting the check", key)
+		}
+		merged, ok := mergedResolver(key)
+		if !ok {
+			t.Fatalf("historyGranularitySpecs no longer has %q, so the two tables can no longer collide "+
+				"on it; re-check whether this tripwire still covers the trap", key)
+		}
+		if merged == want {
+			t.Fatalf("window %q resolves to the same %d seconds under both tables — the strip's window "+
+				"vocabulary has been merged into chart=state's granularity vocabulary, which silently "+
+				"redefines what the user's %q means", key, want, key)
+		}
+	}
+
+	// And spell the headline case out, so the failure message names the bug
+	// rather than only the inequality: 24h is one day here, thirty there.
+	if autonomySpanWindowSeconds["24h"] != 24*3600 {
+		t.Errorf("strip window 24h = %ds, want 86400 (one day)", autonomySpanWindowSeconds["24h"])
+	}
+	if merged, _ := mergedResolver("24h"); merged != 30*86400 {
+		t.Errorf("granularity 24h resolves to a %ds window, want 30 days — the trap has changed shape", merged)
+	}
+}
+
+func TestAutonomyWindows_RejectTheOtherElementsVocabulary(t *testing.T) {
+	// The duration chart offers 30d|1y; the strip offers 8h…12mo. Neither
+	// accepts the other's keys, so a client that sends the wrong one is told,
+	// rather than silently served some other window.
+	rec := getAutonomy(t, &fakeAutonomyStore{}, "chart=autonomy_duration&window=8h")
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("chart=autonomy_duration&window=8h → %d, want 400", rec.Code)
+	}
+	rec = getAutonomy(t, &fakeAutonomyStore{}, "chart=autonomy_spans&window=1y")
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("chart=autonomy_spans&window=1y → %d, want 400", rec.Code)
+	}
+}
+
+func TestAutonomyDuration_WindowShapes(t *testing.T) {
+	for _, tc := range []struct {
+		window        string
+		bucketSeconds int64
+		buckets       int
+	}{
+		{"30d", 86400, 30},
+		{"1y", 7 * 86400, 52},
+	} {
+		store := &fakeAutonomyStore{}
+		rec := getAutonomy(t, store, "chart=autonomy_duration&window="+tc.window)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("window=%s → %d, want 200", tc.window, rec.Code)
+		}
+		var resp historyAutonomyDurationResponse
+		if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if resp.BucketSeconds != tc.bucketSeconds {
+			t.Errorf("window=%s bucket_seconds = %d, want %d", tc.window, resp.BucketSeconds, tc.bucketSeconds)
+		}
+		if len(resp.BucketStarts) != tc.buckets {
+			t.Errorf("window=%s has %d buckets, want %d", tc.window, len(resp.BucketStarts), tc.buckets)
+		}
+	}
+}
+
+// --- An empty bucket is a gap, not a zero -----------------------------------
+
+// TestAutonomyDuration_EmptyBucketIsAGapNotAZero pins the honesty rule: a day
+// with no runs must not pull the line to the axis.
+//
+// The committed mutation is denseBuckets below — the "just emit every bucket"
+// build that would draw a zero for every quiet day.
+func TestAutonomyDuration_EmptyBucketIsAGapNotAZero(t *testing.T) {
+	now := time.Now().Unix()
+	// Two spans, both ending today: 29 of the 30 daily buckets are empty.
+	store := &fakeAutonomyStore{
+		spans: []outbound.AutonomySpan{
+			spanEndingAt(now-60, 600, "irrlicht", "ready"),
+			spanEndingAt(now-30, 900, "irrlicht", "waiting"),
+		},
+		earliest: now - 600,
+		total:    2,
+	}
+	rec := getAutonomy(t, store, "chart=autonomy_duration&window=30d")
+	var resp historyAutonomyDurationResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.BucketStarts) != 30 {
+		t.Fatalf("bucket_starts = %d, want 30 (the axis is still fully drawn)", len(resp.BucketStarts))
+	}
+	for _, b := range resp.Buckets {
+		if b.Count == 0 {
+			t.Fatalf("bucket ts=%d was emitted with count 0 — an empty bucket must be OMITTED "+
+				"(a gap), never sent as a zero that pulls the line to the axis", b.TS)
+		}
+	}
+	if len(resp.Buckets) != 1 {
+		t.Fatalf("got %d non-empty buckets, want 1 (both spans ended today)", len(resp.Buckets))
+	}
+
+	// The MUTATION: a builder that emits a point per bucket regardless. It has
+	// to differ from production here, or this test proves nothing.
+	denseBuckets := len(resp.BucketStarts)
+	if denseBuckets == len(resp.Buckets) {
+		t.Fatalf("the dense mutation (%d points) is indistinguishable from production (%d) on this "+
+			"fixture — it cannot show that empty buckets are dropped", denseBuckets, len(resp.Buckets))
+	}
+}
+
+// --- The sample floor -------------------------------------------------------
+
+// TestAutonomyDuration_SampleFloorMarksThinBuckets pins the floor and the fact
+// that a thin bucket is MARKED rather than hidden or smoothed.
+//
+// Both boundary cases are derived from autonomySampleFloor rather than typed,
+// so moving the constant moves the test with it — and the third assertion is
+// the committed mutation: a build that dropped the floor entirely would report
+// thin=false on the under-floor bucket, which is what the second case catches.
+func TestAutonomyDuration_SampleFloorMarksThinBuckets(t *testing.T) {
+	now := time.Now().Unix()
+	// Put everything in "today" so both cases land in one bucket.
+	build := func(n int) *fakeAutonomyStore {
+		spans := make([]outbound.AutonomySpan, 0, n)
+		for i := 0; i < n; i++ {
+			spans = append(spans, spanEndingAt(now-int64(i)-1, int64(60+i*10), "irrlicht", "ready"))
+		}
+		return &fakeAutonomyStore{spans: spans, earliest: now - 86400, total: n}
+	}
+	for _, tc := range []struct {
+		n        int
+		wantThin bool
+	}{
+		{autonomySampleFloor - 1, true},
+		{autonomySampleFloor, false},
+	} {
+		rec := getAutonomy(t, build(tc.n), "chart=autonomy_duration&window=30d")
+		var resp historyAutonomyDurationResponse
+		if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if resp.SampleFloor != autonomySampleFloor {
+			t.Errorf("sample_floor = %d, want %d — clients render the floor, so it travels on the wire",
+				resp.SampleFloor, autonomySampleFloor)
+		}
+		if len(resp.Buckets) == 0 {
+			t.Fatalf("n=%d produced no buckets at all — a thin bucket must be MARKED, never hidden", tc.n)
+		}
+		var thinFound bool
+		var total int
+		for _, b := range resp.Buckets {
+			total += b.Count
+			if b.Thin {
+				thinFound = true
+			}
+		}
+		if total != tc.n {
+			t.Errorf("n=%d: buckets hold %d spans in total, want %d — no sample may be dropped", tc.n, total, tc.n)
+		}
+		if thinFound != tc.wantThin {
+			t.Errorf("n=%d: thin=%v, want %v (floor is %d)", tc.n, thinFound, tc.wantThin, autonomySampleFloor)
+		}
+	}
+}
+
+// TestAutonomyDuration_ThinBucketsOuterLinesAreItsExtremes states the reason
+// the floor exists, as an executable claim rather than a comment: under the
+// floor the p95 IS the max and the p5 IS the min for a small enough sample, so
+// the outer lines stop being percentiles.
+func TestAutonomyDuration_ThinBucketsOuterLinesAreItsExtremes(t *testing.T) {
+	now := time.Now().Unix()
+	spans := []outbound.AutonomySpan{
+		spanEndingAt(now-10, 100, "irrlicht", "ready"),
+		spanEndingAt(now-20, 200, "irrlicht", "ready"),
+		spanEndingAt(now-30, 300, "irrlicht", "waiting"),
+	}
+	rec := getAutonomy(t, &fakeAutonomyStore{spans: spans, total: 3, earliest: now - 300},
+		"chart=autonomy_duration&window=30d")
+	var resp historyAutonomyDurationResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Buckets) != 1 {
+		t.Fatalf("want exactly 1 non-empty bucket, got %d", len(resp.Buckets))
+	}
+	b := resp.Buckets[0]
+	if !b.Thin {
+		t.Fatalf("a 3-sample bucket must be thin (floor %d)", autonomySampleFloor)
+	}
+	// R-7 over {100,200,300}: p95 = 200 + 0.9*100 = 290; p5 = 100 + 0.1*100 = 110.
+	if math.Abs(b.P95-290) > 1e-9 || math.Abs(b.P5-110) > 1e-9 {
+		t.Errorf("p95/p5 = %v/%v, want 290/110 (R-7 over 3 samples)", b.P95, b.P5)
+	}
+	if b.Max != 300 || b.Min != 100 {
+		t.Errorf("max/min = %v/%v, want 300/100", b.Max, b.Min)
+	}
+	if b.P95 <= b.Max*0.9 {
+		t.Errorf("p95 %v is not pinned near the max %v — the reason the floor exists has changed", b.P95, b.Max)
+	}
+}
+
+// --- Percentiles are computed daemon-side -----------------------------------
+
+func TestAutonomyDuration_SummaryPercentilesAreServerComputed(t *testing.T) {
+	now := time.Now().Unix()
+	// The same 12-sample fixture stats' own test uses, so a convention change
+	// fails in both places rather than only the one nobody reads.
+	spans := make([]outbound.AutonomySpan, 0, 12)
+	for i := 1; i <= 12; i++ {
+		spans = append(spans, spanEndingAt(now-int64(i), int64(i*100), "irrlicht", "ready"))
+	}
+	rec := getAutonomy(t, &fakeAutonomyStore{spans: spans, total: 12, earliest: now - 1200},
+		"chart=autonomy_duration&window=30d")
+	var resp historyAutonomyDurationResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.Summary.Count != 12 {
+		t.Fatalf("summary count = %d, want 12", resp.Summary.Count)
+	}
+	if math.Abs(resp.Summary.P95-1145) > 1e-9 {
+		t.Errorf("summary p95 = %v, want 1145 (R-7 — nearest rank would give 1200)", resp.Summary.P95)
+	}
+	if resp.Summary.Min != 100 || resp.Summary.Max != 1200 {
+		t.Errorf("summary min/max = %v/%v, want 100/1200 — the true extremes stay figures, not lines",
+			resp.Summary.Min, resp.Summary.Max)
+	}
+}
+
+// --- "No data" must never read as "you did nothing" -------------------------
+
+func TestAutonomy_EmptyWindowStillReportsWhenCollectionStarted(t *testing.T) {
+	now := time.Now().Unix()
+	// Nothing in the window, but the log has been collecting since yesterday.
+	store := &fakeAutonomyStore{earliest: now - 86400, total: 7}
+	for _, chart := range []string{chartAutonomyDuration, chartAutonomySpans} {
+		rec := getAutonomy(t, store, "chart="+chart)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("chart=%s → %d, want 200", chart, rec.Code)
+		}
+		var probe struct {
+			Earliest int64 `json:"earliest_span"`
+			Total    int   `json:"total_recorded"`
+		}
+		if err := json.Unmarshal(rec.Body.Bytes(), &probe); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if probe.Earliest != now-86400 {
+			t.Errorf("chart=%s earliest_span = %d, want %d — without it an empty view cannot "+
+				"distinguish \"nothing ran\" from \"this feature had not shipped yet\"",
+				chart, probe.Earliest, now-86400)
+		}
+		if probe.Total != 7 {
+			t.Errorf("chart=%s total_recorded = %d, want 7", chart, probe.Total)
+		}
+	}
+}
+
+func TestAutonomy_NilStoreServesEmptyButValid(t *testing.T) {
+	for _, chart := range []string{chartAutonomyDuration, chartAutonomySpans} {
+		rec := getAutonomy(t, nil, "chart="+chart)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("chart=%s with no store → %d, want 200", chart, rec.Code)
+		}
+	}
+}
+
+// --- The strip payload ------------------------------------------------------
+
+func TestAutonomySpans_RowOrderAndFields(t *testing.T) {
+	now := time.Now().Unix()
+	store := &fakeAutonomyStore{
+		spans: []outbound.AutonomySpan{
+			spanEndingAt(now-100, 60, "articles", "ready"),
+			spanEndingAt(now-200, 3600, "irrlicht", "waiting"),
+			spanEndingAt(now-300, 120, "articles", "error"),
+		},
+		earliest: now - 4000,
+		total:    3,
+	}
+	rec := getAutonomy(t, store, "chart=autonomy_spans&window=24h")
+	var resp historyAutonomySpansResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Spans) != 3 {
+		t.Fatalf("spans = %d, want 3", len(resp.Spans))
+	}
+	// irrlicht has 3600 autonomous seconds, articles 180 — busiest row first.
+	if len(resp.Projects) != 2 || resp.Projects[0] != "irrlicht" {
+		t.Errorf("projects = %v, want irrlicht first (most autonomous seconds)", resp.Projects)
+	}
+	if resp.Spans[0].Reason == "" {
+		t.Error("span rows must carry their end reason — it is the signal the strip draws")
+	}
+	if store.lastQuery.Limit != autonomySpanLimit {
+		t.Errorf("strip query Limit = %d, want %d", store.lastQuery.Limit, autonomySpanLimit)
+	}
+	if store.lastQuery.End-store.lastQuery.Start != 24*3600 {
+		t.Errorf("window=24h asked the store for %ds, want 86400",
+			store.lastQuery.End-store.lastQuery.Start)
+	}
+}
+
+func TestAutonomySpans_TruncationIsReported(t *testing.T) {
+	store := &fakeAutonomyStore{truncated: true, total: 99999}
+	rec := getAutonomy(t, store, "chart=autonomy_spans&window=12mo")
+	var resp historyAutonomySpansResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !resp.Truncated {
+		t.Error("a clipped strip must say so — a partial window drawn as if whole is exactly the " +
+			"silent-wrong-number failure this feature exists to avoid")
+	}
+}
+
+func TestAutonomy_DefaultWindows(t *testing.T) {
+	store := &fakeAutonomyStore{}
+	rec := getAutonomy(t, store, "chart=autonomy_spans")
+	var spans historyAutonomySpansResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &spans); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if spans.Window != "24h" {
+		t.Errorf("default strip window = %q, want 24h", spans.Window)
+	}
+	rec = getAutonomy(t, store, "chart=autonomy_duration")
+	var dur historyAutonomyDurationResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &dur); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if dur.Window != "30d" {
+		t.Errorf("default duration window = %q, want 30d", dur.Window)
+	}
+}
+
+func TestAutonomy_StoreErrorIs500(t *testing.T) {
+	store := &fakeAutonomyStore{err: fmt.Errorf("disk on fire")}
+	rec := getAutonomy(t, store, "chart=autonomy_duration&window=30d")
+	if rec.Code != http.StatusInternalServerError {
+		t.Errorf("store error → %d, want 500", rec.Code)
+	}
+}

--- a/core/cmd/irrlichd/history_dora_endpoint_test.go
+++ b/core/cmd/irrlichd/history_dora_endpoint_test.go
@@ -53,7 +53,7 @@ func TestHandleGetHistory_DoraEndpoint(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/history?chart=dora&project=alpha&start=0&end="+strconv.Itoa(14*86400+1), nil)
 	rec := httptest.NewRecorder()
-	handleGetHistory(nil, lister, nil, git)(rec, req)
+	handleGetHistory(nil, lister, nil, git, nil)(rec, req)
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("want 200, got %d: %s", rec.Code, rec.Body.String())
@@ -77,7 +77,7 @@ func TestHandleGetHistory_DoraEndpoint(t *testing.T) {
 func TestHandleGetHistory_DoraEndpoint_MissingProject(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/history?chart=dora", nil)
 	rec := httptest.NewRecorder()
-	handleGetHistory(nil, fakeYieldLister{}, nil, fakeDoraGit{})(rec, req)
+	handleGetHistory(nil, fakeYieldLister{}, nil, fakeDoraGit{}, nil)(rec, req)
 
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("want 400, got %d: %s", rec.Code, rec.Body.String())
@@ -87,7 +87,7 @@ func TestHandleGetHistory_DoraEndpoint_MissingProject(t *testing.T) {
 func TestHandleGetHistory_DoraEndpoint_MultiProjectRejected(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/history?chart=dora&project=a,b", nil)
 	rec := httptest.NewRecorder()
-	handleGetHistory(nil, fakeYieldLister{}, nil, fakeDoraGit{})(rec, req)
+	handleGetHistory(nil, fakeYieldLister{}, nil, fakeDoraGit{}, nil)(rec, req)
 
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("want 400, got %d: %s", rec.Code, rec.Body.String())
@@ -97,7 +97,7 @@ func TestHandleGetHistory_DoraEndpoint_MultiProjectRejected(t *testing.T) {
 func TestHandleGetHistory_DoraEndpoint_ProjectNotFound(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/history?chart=dora&project=nope", nil)
 	rec := httptest.NewRecorder()
-	handleGetHistory(nil, fakeYieldLister{}, nil, fakeDoraGit{})(rec, req)
+	handleGetHistory(nil, fakeYieldLister{}, nil, fakeDoraGit{}, nil)(rec, req)
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("want 200 (well-formed request, nothing to compute), got %d: %s", rec.Code, rec.Body.String())

--- a/core/cmd/irrlichd/history_endpoint_test.go
+++ b/core/cmd/irrlichd/history_endpoint_test.go
@@ -38,7 +38,7 @@ func doHistory(t *testing.T, tracker *filesystem.CostTracker, query string) (*ht
 	t.Helper()
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/history?"+query, nil)
 	rec := httptest.NewRecorder()
-	handleGetHistory(tracker, nil, nil, nil)(rec, req)
+	handleGetHistory(tracker, nil, nil, nil, nil)(rec, req)
 	var resp historyResponse
 	if rec.Code == http.StatusOK {
 		if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
@@ -150,7 +150,7 @@ func TestHandleGetHistory_AgentsConcurrency(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/history?range=day&chart=agents", nil)
 	rec := httptest.NewRecorder()
-	handleGetHistory(cost, nil, conc, nil)(rec, req)
+	handleGetHistory(cost, nil, conc, nil, nil)(rec, req)
 	if rec.Code != http.StatusOK {
 		t.Fatalf("chart=agents: want 200, got %d (%s)", rec.Code, rec.Body.String())
 	}
@@ -181,7 +181,7 @@ func TestHandleGetHistory_AgentsEmpty(t *testing.T) {
 	conc := filesystem.NewConcurrencyTrackerWithDir(filepath.Join(t.TempDir(), "recordings"), nil)
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/history?range=day&chart=agents", nil)
 	rec := httptest.NewRecorder()
-	handleGetHistory(nil, nil, conc, nil)(rec, req)
+	handleGetHistory(nil, nil, conc, nil, nil)(rec, req)
 	if rec.Code != http.StatusOK {
 		t.Fatalf("empty agents: want 200, got %d", rec.Code)
 	}
@@ -369,7 +369,7 @@ func TestHandleGetHistory_BadRequests(t *testing.T) {
 	for _, q := range []string{"chart=bogus", "group=bogus", "range=bogus", "start=abc&end=def", "start=2000&end=1000", "chart=cost&group=token_type", "chart=tokens&token_type=bogus"} {
 		req := httptest.NewRequest(http.MethodGet, "/api/v1/history?"+q, nil)
 		rec := httptest.NewRecorder()
-		handleGetHistory(tr, nil, nil, nil)(rec, req)
+		handleGetHistory(tr, nil, nil, nil, nil)(rec, req)
 		if rec.Code != http.StatusBadRequest {
 			t.Errorf("%q: want 400, got %d", q, rec.Code)
 		}
@@ -433,7 +433,7 @@ func TestHandleGetHistory_CrossFilter(t *testing.T) {
 func TestHandleGetHistory_NilTrackerEmpty(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/history?range=week", nil)
 	rec := httptest.NewRecorder()
-	handleGetHistory(nil, nil, nil, nil)(rec, req)
+	handleGetHistory(nil, nil, nil, nil, nil)(rec, req)
 	if rec.Code != http.StatusOK {
 		t.Fatalf("nil tracker: want 200, got %d", rec.Code)
 	}

--- a/core/cmd/irrlichd/history_state_endpoint_test.go
+++ b/core/cmd/irrlichd/history_state_endpoint_test.go
@@ -30,7 +30,7 @@ func TestHandleGetHistory_StateChart(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/history?chart=state&granularity=24h", nil)
 	rec := httptest.NewRecorder()
-	handleGetHistory(nil, nil, conc, nil)(rec, req)
+	handleGetHistory(nil, nil, conc, nil, nil)(rec, req)
 	if rec.Code != http.StatusOK {
 		t.Fatalf("chart=state: want 200, got %d (%s)", rec.Code, rec.Body.String())
 	}
@@ -78,7 +78,7 @@ func TestHandleGetHistory_StateChartEmpty(t *testing.T) {
 	conc := filesystem.NewConcurrencyTrackerWithDir(filepath.Join(t.TempDir(), "recordings"), nil)
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/history?chart=state", nil)
 	rec := httptest.NewRecorder()
-	handleGetHistory(nil, nil, conc, nil)(rec, req)
+	handleGetHistory(nil, nil, conc, nil, nil)(rec, req)
 	if rec.Code != http.StatusOK {
 		t.Fatalf("empty state chart: want 200, got %d", rec.Code)
 	}
@@ -103,7 +103,7 @@ func TestHandleGetHistory_StateChartBadGranularity(t *testing.T) {
 	conc := filesystem.NewConcurrencyTrackerWithDir(filepath.Join(t.TempDir(), "recordings"), nil)
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/history?chart=state&granularity=fortnight", nil)
 	rec := httptest.NewRecorder()
-	handleGetHistory(nil, nil, conc, nil)(rec, req)
+	handleGetHistory(nil, nil, conc, nil, nil)(rec, req)
 	if rec.Code != http.StatusBadRequest {
 		t.Errorf("bad granularity: want 400, got %d", rec.Code)
 	}
@@ -120,7 +120,7 @@ func TestHandleGetHistory_StateChartGranularitySteps(t *testing.T) {
 	for granularity, bucketSeconds := range want {
 		req := httptest.NewRequest(http.MethodGet, "/api/v1/history?chart=state&granularity="+granularity, nil)
 		rec := httptest.NewRecorder()
-		handleGetHistory(nil, nil, conc, nil)(rec, req)
+		handleGetHistory(nil, nil, conc, nil, nil)(rec, req)
 		if rec.Code != http.StatusOK {
 			t.Fatalf("granularity=%s: want 200, got %d", granularity, rec.Code)
 		}

--- a/core/cmd/irrlichd/history_yield_endpoint_test.go
+++ b/core/cmd/irrlichd/history_yield_endpoint_test.go
@@ -82,7 +82,7 @@ func TestHandleGetHistory_YieldEndpoint(t *testing.T) {
 	}}
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/history?chart=yield&range=day", nil)
 	rec := httptest.NewRecorder()
-	handleGetHistory(nil, lister, nil, nil)(rec, req)
+	handleGetHistory(nil, lister, nil, nil, nil)(rec, req)
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("want 200, got %d: %s", rec.Code, rec.Body.String())

--- a/core/cmd/irrlichd/main.go
+++ b/core/cmd/irrlichd/main.go
@@ -590,6 +590,7 @@ func runDaemon() {
 
 	fsRepo, cachedRepo := initSessionStorage(logger, cfg)
 	costTracker := initCostTracker(logger, fsRepo)
+	autonomySpans := initAutonomySpanStore(logger)
 	historyTracker, historyCancel := startHistoryTracker(logger)
 	defer historyCancel()
 
@@ -717,13 +718,14 @@ func runDaemon() {
 
 	// Register API endpoints that need orchMonitor.
 	registerSessionRoutes(mux, registerSessionRoutesDeps{
-		CachedRepo:  cachedRepo,
-		OrchMonitor: orchMonitor,
-		CostTracker: costTracker,
-		SockPath:    sockPath,
-		Push:        push,
-		Logger:      logger,
-		GitResolver: gitResolver,
+		CachedRepo:    cachedRepo,
+		OrchMonitor:   orchMonitor,
+		CostTracker:   costTracker,
+		AutonomySpans: autonomySpans,
+		SockPath:      sockPath,
+		Push:          push,
+		Logger:        logger,
+		GitResolver:   gitResolver,
 		// Same live snapshot registerCoreRoutes hands the diagnostics bundle
 		// (#1801) — one source, two outlets, so the banner and hooks.json can
 		// never disagree about whether hooks are healthy.
@@ -743,6 +745,7 @@ func runDaemon() {
 		Cfg:              cfg,
 		AllAgents:        allAgents,
 		CostTracker:      costTracker,
+		AutonomySpans:    autonomySpans,
 		HistoryTracker:   historyTracker,
 	})
 

--- a/core/cmd/irrlichd/startup.go
+++ b/core/cmd/irrlichd/startup.go
@@ -189,7 +189,7 @@ func initCostTracker(logger outbound.Logger, fsRepo *filesystem.SessionRepositor
 	costTracker.SetProviderResolver(func(s *session.SessionState) string {
 		return services.ProviderForSession(s, "")
 	})
-	if err := costTracker.Prune(400); err != nil {
+	if err := costTracker.Prune(costRetentionDays); err != nil {
 		logger.LogError("startup", "", fmt.Sprintf("cost tracker prune failed: %v", err))
 	}
 	allSessions, err := fsRepo.ListAll()
@@ -203,6 +203,40 @@ func initCostTracker(logger outbound.Logger, fsRepo *filesystem.SessionRepositor
 	}
 	return costTracker
 }
+
+// initAutonomySpanStore opens the append-only per-project autonomy span JSONL
+// store and prunes rows older than 400 days.
+//
+// Same directory model, same 400 days, and deliberately the same call site as
+// initCostTracker above (#1905): the two logs are the daemon's only unconditional
+// append-only histories, and the one thing that must never drift between them is
+// how long they keep data — a chart whose store prunes on a different schedule
+// than the chart's own longest range silently truncates its own longest view.
+func initAutonomySpanStore(logger outbound.Logger) outbound.AutonomySpanStore {
+	var store *filesystem.AutonomySpanTracker
+	if dir := stateStoreDir(autonomyStateDir); dir != "" {
+		store = filesystem.NewAutonomySpanTrackerWithDir(dir)
+	} else {
+		var err error
+		store, err = filesystem.NewAutonomySpanTracker()
+		if err != nil {
+			logger.LogError("startup", "", fmt.Sprintf("failed to init autonomy span store: %v", err))
+			return nil
+		}
+	}
+	if err := store.Prune(costRetentionDays); err != nil {
+		logger.LogError("startup", "", fmt.Sprintf("autonomy span prune failed: %v", err))
+	}
+	return store
+}
+
+// autonomyStateDir is the span log's subdirectory under the data dir; it
+// mirrors the cost log's "cost".
+const autonomyStateDir = "autonomy"
+
+// costRetentionDays is how long both append-only logs keep rows. 400 days
+// covers the longest range either chart offers (12 months) with room to spare.
+const costRetentionDays = 400
 
 // historyEventBroadcaster maps HistoryEvent (the in-memory tagged union the
 // tracker emits) onto PushMessage envelopes the WebSocket hub already knows
@@ -562,10 +596,13 @@ type registerSessionRoutesDeps struct {
 	CachedRepo  outbound.SessionRepository
 	OrchMonitor *services.OrchestratorMonitor
 	CostTracker outbound.CostTracker
-	SockPath    string
-	Push        outbound.PushBroadcaster
-	Logger      outbound.Logger
-	GitResolver *git.Adapter
+	// AutonomySpans backs the History view's Autonomy section (#1905). nil is
+	// valid and yields empty-but-valid payloads.
+	AutonomySpans outbound.AutonomySpanStore
+	SockPath      string
+	Push          outbound.PushBroadcaster
+	Logger        outbound.Logger
+	GitResolver   *git.Adapter
 	// HookHealth is the same live snapshot function the diagnostics bundle
 	// gets (liveHookHealth). #1801 gives its two client-invisible diagnoses —
 	// entries that went missing, channels that have gone silent — a second
@@ -591,7 +628,9 @@ func registerSessionRoutes(mux *http.ServeMux, deps registerSessionRoutesDeps) {
 	// persistence, no background sweep. The tracker also reuses GitResolver to
 	// fold worktree sessions into their real repo's project name (#1046).
 	concurrencyTracker := filesystem.NewConcurrencyTrackerWithDir(resolveRecordingsDir(deps.SockPath), deps.GitResolver)
-	mux.HandleFunc("GET /api/v1/history", handleGetHistory(deps.CostTracker, deps.CachedRepo, concurrencyTracker, deps.GitResolver))
+	// #1905 adds chart=autonomy_duration / chart=autonomy_spans, served from
+	// the always-on span log rather than the opt-in recordings.
+	mux.HandleFunc("GET /api/v1/history", handleGetHistory(deps.CostTracker, deps.CachedRepo, concurrencyTracker, deps.GitResolver, deps.AutonomySpans))
 
 	focusService := services.NewFocusService(deps.CachedRepo, deps.Push, deps.Logger)
 	mux.HandleFunc("POST /api/v1/sessions/{id}/focus", sessionshandler.NewFocusHandler(focusService, deps.Logger))
@@ -610,6 +649,7 @@ type buildDetectorDeps struct {
 	Cfg              config.Config
 	AllAgents        []agent.Agent
 	CostTracker      outbound.CostTracker
+	AutonomySpans    outbound.AutonomySpanStore
 	HistoryTracker   *services.HistoryTracker
 }
 
@@ -663,6 +703,9 @@ func buildDetector(deps buildDetectorDeps) (*services.SessionDetector, map[strin
 	})
 	if deps.CostTracker != nil {
 		detector.SetCostTracker(deps.CostTracker)
+	}
+	if deps.AutonomySpans != nil {
+		detector.SetAutonomySpanStore(deps.AutonomySpans)
 	}
 	detector.SetHistoryTracker(deps.HistoryTracker)
 

--- a/core/domain/session/autonomy.go
+++ b/core/domain/session/autonomy.go
@@ -1,0 +1,78 @@
+package session
+
+// Autonomy spans (#1905).
+//
+// An autonomy span is one unbroken stretch of `working` before the session
+// left that state. The END REASON — which state it left FOR — is the signal
+// the feature is about:
+//
+//	StateWaiting → it needed a human. The number the feature is really about.
+//	StateReady   → the turn finished on its own.
+//	StateError   → it broke.
+//
+// The duration alone cannot tell those apart, so a span carries both.
+
+// AutonomyEndReasons returns the end-reason vocabulary: every canonical state
+// a session can leave `working` FOR, in canonical order.
+//
+// DERIVED, never retyped. Two reasons, and both are load-bearing:
+//
+//   - The vocabulary IS "the canonical states minus working". A fifth state
+//     joins it here for free, which is the rule AGENTS.md states for every
+//     other consumer of this list.
+//   - tools/state-vocabulary-lint.sh (#1804) fails any single line that names
+//     three-or-more-but-not-all of the canonical values. A hand-typed list of
+//     these three is exactly that shape — the linter would be right to refuse
+//     it, because the day a fifth state lands the list is silently wrong.
+func AutonomyEndReasons() []string {
+	out := make([]string, 0, len(canonicalStates)-1)
+	for _, s := range CanonicalStates() {
+		if s == StateWorking {
+			continue
+		}
+		out = append(out, s)
+	}
+	return out
+}
+
+// IsAutonomyEndReason reports whether reason is a state a span can end in.
+// `working` is not: a span that is still working has not ended.
+func IsAutonomyEndReason(reason string) bool {
+	return IsCanonicalState(reason) && reason != StateWorking
+}
+
+// Autonomy end-reason priorities for the run strip's pixel-collapse rule
+// (#1905, design decision 4). When one device-pixel column of the strip holds
+// several spans, the column paints the HIGHEST-priority reason in it.
+//
+// The order is the session-history strip's own (services.statePriority*,
+// #1805), where one error in a bucket paints the whole bucket red: the failure
+// state outranks the needs-a-human state, which outranks the finished-cleanly
+// state. `TestAutonomyReasonLadderMatchesHistoryBar` in the services package
+// pins the two ladders together so they cannot drift.
+//
+// Declared one value per line rather than as an ordered slice: the ladder is
+// NOT the canonical order (canonical puts `ready` after `waiting`; the ladder
+// puts it below), so it cannot be derived from CanonicalStates and has to be
+// stated. One state per line keeps it out of the vocabulary linter's sights.
+const (
+	autonomyPriorityUnknown = 0
+	autonomyPriorityReady   = 1
+	autonomyPriorityWaiting = 2
+	autonomyPriorityError   = 3
+)
+
+// AutonomyReasonPriority returns a span end reason's rank on the collapse
+// ladder. An unrecognized reason ranks below every real one, so a build that
+// cannot name a reason never outranks activity it can.
+func AutonomyReasonPriority(reason string) int {
+	switch reason {
+	case StateError:
+		return autonomyPriorityError
+	case StateWaiting:
+		return autonomyPriorityWaiting
+	case StateReady:
+		return autonomyPriorityReady
+	}
+	return autonomyPriorityUnknown
+}

--- a/core/domain/session/session.go
+++ b/core/domain/session/session.go
@@ -497,6 +497,21 @@ type SessionState struct {
 	// Transcript monitoring for waiting-state recovery.
 	LastTranscriptSize int64  `json:"last_transcript_size,omitempty"`
 	WaitingStartTime   *int64 `json:"waiting_start_time,omitempty"`
+
+	// AutonomySpanStart is when the session's current unbroken stretch of
+	// `working` began — the OPEN autonomy span (#1905). Nil when no span is
+	// open. Follows WaitingStartTime's precedent exactly: a "when did this
+	// begin" clock lives on the session, and only the CLOSED span is
+	// persisted to the span log.
+	AutonomySpanStart *int64 `json:"autonomy_span_start,omitempty"`
+
+	// AutonomySpanPendingEnd is when an open span provisionally ended by
+	// reaching `ready`, held back by the flicker grace (#1905, design
+	// decision 1). A `ready` that is followed by `working` again within
+	// services.AutonomySpanGrace is tool-call flicker, not the end of a run,
+	// so the row is not written until the grace has passed. Nil whenever
+	// AutonomySpanStart is nil.
+	AutonomySpanPendingEnd *int64 `json:"autonomy_span_pending_end,omitempty"`
 }
 
 // IsStale reports whether the session's last update is older than maxAge.

--- a/core/pkg/stats/percentile.go
+++ b/core/pkg/stats/percentile.go
@@ -1,0 +1,60 @@
+// Package stats holds the small numeric primitives the daemon computes on
+// behalf of its clients, so the two surfaces cannot disagree about a figure
+// they both display.
+package stats
+
+import "sort"
+
+// Percentile returns the p-th percentile (p in [0, 1]) of xs using the R-7
+// convention: LINEAR INTERPOLATION BETWEEN CLOSEST RANKS, the same definition
+// as Excel's PERCENTILE.INC, NumPy's default `percentile`, and R's `type=7`
+// quantile.
+//
+// NAMING THE CONVENTION IS THE POINT (#1905). "The p95" is not one number:
+// over 12 samples, R-7 and the nearest-rank convention differ by a whole
+// sample, and two surfaces each computing "the p95" independently will draw
+// two different lines from the same data and neither will be wrong. The
+// daemon therefore computes these once and ships the result; this function is
+// the single definition, and TestPercentile_UsesR7NotNearestRank pins it
+// against the convention it is most likely to silently become.
+//
+// The definition, for sorted xs of length n:
+//
+//	h    = (n-1) * p
+//	lo   = floor(h)
+//	frac = h - lo
+//	P    = xs[lo] + frac * (xs[lo+1] - xs[lo])
+//
+// so P(0) is the minimum and P(1) the maximum exactly, and every percentile in
+// between moves continuously as a sample is added. xs is sorted in place.
+// An empty xs returns 0.
+func Percentile(xs []float64, p float64) float64 {
+	if len(xs) == 0 {
+		return 0
+	}
+	sort.Float64s(xs)
+	return PercentileSorted(xs, p)
+}
+
+// PercentileSorted is Percentile for input that is already sorted ascending —
+// the form the bucket builders use, which sort each bucket once and then read
+// several percentiles out of it.
+func PercentileSorted(sorted []float64, p float64) float64 {
+	n := len(sorted)
+	if n == 0 {
+		return 0
+	}
+	if p <= 0 {
+		return sorted[0]
+	}
+	if p >= 1 {
+		return sorted[n-1]
+	}
+	h := float64(n-1) * p
+	lo := int(h)
+	if lo >= n-1 {
+		return sorted[n-1]
+	}
+	frac := h - float64(lo)
+	return sorted[lo] + frac*(sorted[lo+1]-sorted[lo])
+}

--- a/core/pkg/stats/percentile_test.go
+++ b/core/pkg/stats/percentile_test.go
@@ -1,0 +1,109 @@
+package stats
+
+import (
+	"math"
+	"sort"
+	"testing"
+)
+
+// nearestRankPercentile is the COMMITTED MUTATION for Percentile's convention
+// (AGENTS.md: a check that a change adds has no "before the fix" to run red,
+// so mutate the thing it protects and confirm the check goes red).
+//
+// It is the other convention "the p95" plausibly means — nearest rank, R-1,
+// the definition every "just take the element at index ceil(p*n)" hand-roll
+// arrives at. The tests below assert that production does NOT agree with it on
+// the fixture, so a future edit that quietly turns Percentile into this
+// function fails here instead of silently redrawing every autonomy chart.
+func nearestRankPercentile(xs []float64, p float64) float64 {
+	if len(xs) == 0 {
+		return 0
+	}
+	s := append([]float64(nil), xs...)
+	sort.Float64s(s)
+	rank := int(math.Ceil(p * float64(len(s))))
+	if rank < 1 {
+		rank = 1
+	}
+	if rank > len(s) {
+		rank = len(s)
+	}
+	return s[rank-1]
+}
+
+// twelveSamples is the fixture the issue calls out: "p95 over 12 samples
+// differs by a whole sample depending on the convention". Values are
+// 100, 200, … 1200 so a whole-sample difference is unmistakable.
+func twelveSamples() []float64 {
+	xs := make([]float64, 12)
+	for i := range xs {
+		xs[i] = float64((i + 1) * 100)
+	}
+	return xs
+}
+
+func TestPercentile_UsesR7NotNearestRank(t *testing.T) {
+	// R-7 by hand: h = (12-1)*0.95 = 10.45, lo = 10, frac = 0.45,
+	// P = xs[10] + 0.45*(xs[11]-xs[10]) = 1100 + 0.45*100 = 1145.
+	const wantR7 = 1145.0
+	got := Percentile(twelveSamples(), 0.95)
+	if math.Abs(got-wantR7) > 1e-9 {
+		t.Fatalf("Percentile(12 samples, 0.95) = %v, want %v (R-7 / PERCENTILE.INC: "+
+			"h=(n-1)p, linear interpolation between closest ranks)", got, wantR7)
+	}
+
+	// The mutation must actually disagree here, or this test proves nothing:
+	// a fixture on which both conventions agree would pass no matter which one
+	// production used (AGENTS.md — absence of a finding and inability to look
+	// must never produce the same output).
+	mutant := nearestRankPercentile(twelveSamples(), 0.95)
+	if math.Abs(mutant-got) < 1e-9 {
+		t.Fatalf("the nearest-rank mutation agrees with production (%v) on this fixture, "+
+			"so the fixture cannot tell the two conventions apart — pick another one", got)
+	}
+	if math.Abs(mutant-1200) > 1e-9 {
+		t.Fatalf("nearest-rank p95 of the fixture = %v, want 1200 — the mutation drifted", mutant)
+	}
+}
+
+func TestPercentile_EdgesAreExactMinAndMax(t *testing.T) {
+	xs := twelveSamples()
+	if got := Percentile(xs, 0); got != 100 {
+		t.Errorf("Percentile(p=0) = %v, want the minimum 100", got)
+	}
+	if got := Percentile(xs, 1); got != 1200 {
+		t.Errorf("Percentile(p=1) = %v, want the maximum 1200", got)
+	}
+}
+
+func TestPercentile_P5AndP50OverTheFixture(t *testing.T) {
+	// h = 11*0.05 = 0.55 → 100 + 0.55*100 = 155.
+	if got := Percentile(twelveSamples(), 0.05); math.Abs(got-155) > 1e-9 {
+		t.Errorf("p5 = %v, want 155", got)
+	}
+	// h = 11*0.5 = 5.5 → 600 + 0.5*100 = 650.
+	if got := Percentile(twelveSamples(), 0.50); math.Abs(got-650) > 1e-9 {
+		t.Errorf("p50 = %v, want 650", got)
+	}
+}
+
+func TestPercentile_EmptyAndSingle(t *testing.T) {
+	if got := Percentile(nil, 0.95); got != 0 {
+		t.Errorf("Percentile(nil) = %v, want 0", got)
+	}
+	if got := Percentile([]float64{42}, 0.95); got != 42 {
+		t.Errorf("Percentile(one sample) = %v, want 42", got)
+	}
+}
+
+func TestPercentileSorted_MatchesPercentile(t *testing.T) {
+	xs := []float64{9, 1, 7, 3, 5}
+	sorted := append([]float64(nil), xs...)
+	sort.Float64s(sorted)
+	for _, p := range []float64{0, 0.05, 0.25, 0.5, 0.95, 1} {
+		want := Percentile(append([]float64(nil), xs...), p)
+		if got := PercentileSorted(sorted, p); math.Abs(got-want) > 1e-9 {
+			t.Errorf("PercentileSorted(p=%v) = %v, Percentile = %v — the two must agree", p, got, want)
+		}
+	}
+}

--- a/core/ports/outbound/ports.go
+++ b/core/ports/outbound/ports.go
@@ -463,6 +463,86 @@ type CostTracker interface {
 	Prune(olderThanDays int) error
 }
 
+// AutonomySpan is one CLOSED autonomy span (#1905): an unbroken stretch of
+// `working` for one session, plus the state it left `working` for.
+//
+// Start/End are unix seconds. Reason is one of session.AutonomyEndReasons().
+type AutonomySpan struct {
+	Start   int64
+	End     int64
+	Project string
+	Session string
+	Adapter string
+	Model   string
+	Reason  string
+}
+
+// Duration is the span's length in seconds, floored at 0 so a clock that
+// stepped backwards can never contribute a negative sample to a percentile.
+func (s AutonomySpan) Duration() int64 {
+	if s.End <= s.Start {
+		return 0
+	}
+	return s.End - s.Start
+}
+
+// AutonomySpanQuery is a trailing-window read over the span log.
+type AutonomySpanQuery struct {
+	// Start/End bound the returned spans (unix seconds). A span is included
+	// when it ENDED inside [Start, End) — a span is only recorded once it has
+	// ended, so its end is the only timestamp guaranteed to exist.
+	Start, End int64
+
+	// Limit caps how many spans are returned (0 = no cap). The result's
+	// Truncated flag says whether the cap bit, so a clipped strip can say so
+	// instead of quietly drawing a partial window as if it were whole.
+	Limit int
+}
+
+// AutonomySpanResult carries one window read plus the two facts the "no data"
+// states need: how far back the log actually goes, and whether the read was
+// clipped.
+type AutonomySpanResult struct {
+	// Spans are the matching spans, ordered by Start ascending.
+	Spans []AutonomySpan
+
+	// EarliestStart is the earliest start over EVERY recorded span, not just
+	// the ones in the window — 0 when the log is empty. It answers "this
+	// feature started collecting on <date>", which is what keeps an empty
+	// 12-month view from reading as "you did nothing" (#1905).
+	EarliestStart int64
+
+	// TotalRecorded is how many spans the log holds in total, across every
+	// project and every date.
+	TotalRecorded int
+
+	// Truncated reports that Limit clipped the result.
+	Truncated bool
+}
+
+// AutonomySpanStore persists closed autonomy spans and reads them back over a
+// trailing window. Implementations must be safe for concurrent use.
+//
+// Deliberately NOT served by the lifecycle recordings that back
+// ConcurrencyReader: those are opt-in (--record / IRRLICHT_RECORD=1) and the
+// packaged app runs without them, so a recordings-derived autonomy chart shows
+// a normal user nothing while looking exactly like a chart of "you did
+// nothing". This store follows the cost log instead — written unconditionally,
+// pruned on the same schedule (#1905).
+type AutonomySpanStore interface {
+	// RecordSpan appends one closed span. Implementations may no-op on a span
+	// with no project or a non-positive duration.
+	RecordSpan(span AutonomySpan) error
+
+	// SpansInWindow returns the spans that ended inside the query window,
+	// plus the log-wide earliest start and total count.
+	SpansInWindow(q AutonomySpanQuery) (*AutonomySpanResult, error)
+
+	// Prune drops span rows older than the given number of days.
+	// Safe to call periodically (e.g. daemon startup).
+	Prune(olderThanDays int) error
+}
+
 // HistoryTracker maintains per-session rolling state buffers for three
 // granularities (1s, 10s, 60s), using priority aggregation waiting>working>ready.
 // Implementations must be safe for concurrent use.

--- a/go.work
+++ b/go.work
@@ -5,6 +5,7 @@ use (
 	./tools/elfdans-drive
 	./tools/eta-research
 	./tools/onboarding-factory
+	./tools/seed-autonomy-spans
 	./tools/seed-demo-sessions
 	./tools/wsload
 )

--- a/platforms/macos/Irrlicht/Models/HistoryAutonomyData.swift
+++ b/platforms/macos/Irrlicht/Models/HistoryAutonomyData.swift
@@ -130,17 +130,6 @@ struct HistoryAutonomyBucket: Codable, Identifiable {
         // `thin` is omitempty on the wire: absent means false.
         thin = try c.decodeIfPresent(Bool.self, forKey: .thin) ?? false
     }
-
-    init(ts: Int64, p95: Double, p50: Double, p5: Double, min: Double, max: Double, count: Int, thin: Bool) {
-        self.ts = ts
-        self.p95 = p95
-        self.p50 = p50
-        self.p5 = p5
-        self.min = min
-        self.max = max
-        self.count = count
-        self.thin = thin
-    }
 }
 
 /// The window-wide figure row under the chart. The true extremes stay FIGURES

--- a/platforms/macos/Irrlicht/Models/HistoryAutonomyData.swift
+++ b/platforms/macos/Irrlicht/Models/HistoryAutonomyData.swift
@@ -1,0 +1,276 @@
+import Foundation
+
+// Codable mirrors of the daemon's Autonomy payloads (#1905) —
+// `chart=autonomy_duration` and `chart=autonomy_spans` in
+// core/cmd/irrlichd/history_autonomy.go — plus the two pickers' vocabularies
+// and the strip's pure collapse rule.
+//
+// An autonomy span is one unbroken stretch of `working` before the session
+// left that state; the state it left FOR is the signal the section is about.
+
+/// Element 1's Range picker. Two ranges, and 30 days is the floor: anything
+/// shorter has too few spans per bucket for a percentile to mean anything.
+///
+/// The raw values are WINDOW LENGTHS sent as `?window=`, not the
+/// bucket-width-times-count that `HistoryGranularity`'s same-looking keys mean.
+enum HistoryAutonomyRange: String, CaseIterable, Identifiable {
+    case days30 = "30d"
+    case year = "1y"
+
+    var id: String { rawValue }
+
+    var label: String {
+        switch self {
+        case .days30: return "30 days"
+        case .year: return "Year"
+        }
+    }
+}
+
+/// Element 2's Span picker — window lengths again, and deliberately a
+/// different set from element 1's.
+enum HistoryAutonomySpanWindow: String, CaseIterable, Identifiable {
+    case hours8 = "8h"
+    case hours24 = "24h"
+    case days7 = "7d"
+    case days30 = "30d"
+    case months12 = "12mo"
+
+    var id: String { rawValue }
+
+    var label: String {
+        switch self {
+        case .hours8: return "8h"
+        case .hours24: return "24h"
+        case .days7: return "7d"
+        case .days30: return "30d"
+        case .months12: return "12mo"
+        }
+    }
+}
+
+/// How a span ended — the state the session left `working` for. Raw values
+/// mirror `session.AutonomyEndReasons()` on the daemon.
+///
+/// One case per line, and one state per line in `priority` below: a single
+/// line naming three of the four canonical states is exactly what
+/// tools/state-vocabulary-lint.sh refuses, because such a list is complete
+/// when written and silently stale one state later.
+enum AutonomyEndReason: String, CaseIterable, Identifiable {
+    case waiting
+    case ready
+    case error
+
+    var id: String { rawValue }
+
+    /// Glyph shown in the strip legend, matching the issue's sketch.
+    var glyph: String {
+        switch self {
+        case .waiting: return "?"
+        case .ready: return "✓"
+        case .error: return "✗"
+        }
+    }
+
+    var label: String {
+        switch self {
+        case .waiting: return "it asked"
+        case .ready: return "turn finished"
+        case .error: return "error"
+        }
+    }
+
+    /// Rank on the strip's pixel-collapse ladder: when one device-pixel column
+    /// holds several spans, the column paints the highest-ranked reason in it.
+    ///
+    /// Same order as the session-history strip's ladder (#1805) — one error in
+    /// a column paints the whole column. `HistoryAutonomyTests` pins this
+    /// against `SessionManager.historyPriorityForState`, which is the other
+    /// hand-written copy of the same ladder.
+    var priority: Int {
+        switch self {
+        case .error: return 3
+        case .waiting: return 2
+        case .ready: return 1
+        }
+    }
+}
+
+/// One bucket of element 1. The daemon OMITS empty buckets, so every bucket
+/// present here has `count >= 1` — a day with no runs is a gap in the line,
+/// never a point on the axis.
+struct HistoryAutonomyBucket: Codable, Identifiable {
+    let ts: Int64
+    let p95: Double
+    let p50: Double
+    let p5: Double
+    let min: Double
+    let max: Double
+    let count: Int
+    /// True when the bucket holds fewer than `sampleFloor` spans, so its p95
+    /// IS its max and its p5 IS its min. Rendered visibly differently (dashed
+    /// + faded), never hidden and never smoothed.
+    let thin: Bool
+
+    var id: Int64 { ts }
+
+    enum CodingKeys: String, CodingKey {
+        case ts, p95, p50, p5, min, max, count, thin
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        ts = try c.decode(Int64.self, forKey: .ts)
+        p95 = try c.decode(Double.self, forKey: .p95)
+        p50 = try c.decode(Double.self, forKey: .p50)
+        p5 = try c.decode(Double.self, forKey: .p5)
+        min = try c.decode(Double.self, forKey: .min)
+        max = try c.decode(Double.self, forKey: .max)
+        count = try c.decode(Int.self, forKey: .count)
+        // `thin` is omitempty on the wire: absent means false.
+        thin = try c.decodeIfPresent(Bool.self, forKey: .thin) ?? false
+    }
+
+    init(ts: Int64, p95: Double, p50: Double, p5: Double, min: Double, max: Double, count: Int, thin: Bool) {
+        self.ts = ts
+        self.p95 = p95
+        self.p50 = p50
+        self.p5 = p5
+        self.min = min
+        self.max = max
+        self.count = count
+        self.thin = thin
+    }
+}
+
+/// The window-wide figure row under the chart. The true extremes stay FIGURES
+/// and are deliberately not lines: one four-hour run left going overnight
+/// would otherwise redraw the whole Y scale and flatten every other bucket.
+struct HistoryAutonomySummary: Codable {
+    let p95: Double
+    let p50: Double
+    let p5: Double
+    let min: Double
+    let max: Double
+    let count: Int
+}
+
+struct HistoryAutonomyDurationResponse: Codable {
+    let window: String
+    let chart: String
+    let start: Int64
+    let end: Int64
+    let bucketSeconds: Int64
+    let bucketStarts: [Int64]
+    let buckets: [HistoryAutonomyBucket]
+    let summary: HistoryAutonomySummary
+    let sampleFloor: Int
+    /// Earliest span on record across the WHOLE log (0 = nothing ever
+    /// recorded). What lets an empty chart say "collecting since <date>"
+    /// instead of being read as "you did nothing".
+    let earliestSpan: Int64
+    let totalRecorded: Int
+
+    enum CodingKeys: String, CodingKey {
+        case window, chart, start, end, buckets, summary
+        case bucketSeconds = "bucket_seconds"
+        case bucketStarts = "bucket_starts"
+        case sampleFloor = "sample_floor"
+        case earliestSpan = "earliest_span"
+        case totalRecorded = "total_recorded"
+    }
+
+    var hasData: Bool { !buckets.isEmpty }
+}
+
+struct HistoryAutonomySpanRow: Codable, Identifiable {
+    let start: Int64
+    let end: Int64
+    let project: String
+    let session: String
+    let reason: String?
+
+    var id: String { "\(project)|\(session)|\(start)|\(end)" }
+
+    var endReason: AutonomyEndReason? { reason.flatMap(AutonomyEndReason.init(rawValue:)) }
+    var duration: Int64 { Swift.max(0, end - start) }
+}
+
+struct HistoryAutonomySpansResponse: Codable {
+    let window: String
+    let chart: String
+    let start: Int64
+    let end: Int64
+    let spans: [HistoryAutonomySpanRow]
+    /// Strip row order, computed daemon-side (most autonomous seconds first)
+    /// so both clients draw the same rows in the same order.
+    let projects: [String]
+    let earliestSpan: Int64
+    let totalRecorded: Int
+    let truncated: Bool
+
+    enum CodingKeys: String, CodingKey {
+        case window, chart, start, end, spans, projects, truncated
+        case earliestSpan = "earliest_span"
+        case totalRecorded = "total_recorded"
+    }
+
+    var hasData: Bool { !spans.isEmpty }
+
+    func spans(for project: String) -> [HistoryAutonomySpanRow] {
+        spans.filter { $0.project == project }
+    }
+}
+
+/// The strip's pixel-collapse rule (#1905 design decision 4), as a pure
+/// function so it can be tested without a view.
+///
+/// TWO HALVES, both load-bearing:
+///
+///   - **Every span draws at a minimum of one column.** At `12mo` a 40-second
+///     run is far under one pixel wide; rounding it to nothing would erase
+///     exactly the short runs the p5 line is about.
+///   - **A column holding several spans takes the HIGHEST-priority end
+///     reason** — error over waiting over ready, `AutonomyEndReason.priority`.
+///     The same ladder the session-history strip uses: one error in a column
+///     paints the whole column, because the thing worth seeing at a glance is
+///     that something broke in there.
+enum AutonomyStripLayout {
+    /// One drawn column of the strip. `occupied` and `reason` are separate
+    /// because a span whose reason this build cannot name STILL HAPPENED: it
+    /// occupies its column (drawn neutral) rather than reading as idle.
+    struct Column: Equatable {
+        var occupied: Bool
+        var reason: AutonomyEndReason?
+    }
+
+    /// Collapse `spans` into `columns` columns covering [start, end).
+    static func collapse(spans: [HistoryAutonomySpanRow],
+                         start: Int64,
+                         end: Int64,
+                         columns: Int) -> [Column] {
+        guard columns > 0, end > start else { return [] }
+        var out = [Column](repeating: Column(occupied: false, reason: nil), count: columns)
+        let width = Double(end - start)
+        for row in spans {
+            var first = Int((Double(row.start - start) / width * Double(columns)).rounded(.down))
+            var last = Int((Double(row.end - start) / width * Double(columns)).rounded(.down))
+            // A span entirely outside the window contributes nothing; one that
+            // straddles an edge is clipped to the visible part.
+            if last < 0 || first > columns - 1 { continue }
+            first = Swift.max(0, first)
+            last = Swift.min(columns - 1, last)
+            // The minimum-one-column rule: a sub-pixel run still draws.
+            if last < first { last = first }
+            let rank = row.endReason?.priority ?? 0
+            for i in first...last {
+                // -1 for an untouched column, so even an unnamed reason (rank
+                // 0) claims it.
+                let existingRank = out[i].occupied ? (out[i].reason?.priority ?? 0) : -1
+                out[i].occupied = true
+                if rank > existingRank { out[i].reason = row.endReason }
+            }
+        }
+        return out
+    }
+}

--- a/platforms/macos/Irrlicht/Views/HistoryAutonomyView.swift
+++ b/platforms/macos/Irrlicht/Views/HistoryAutonomyView.swift
@@ -108,18 +108,55 @@ struct HistoryAutonomyContentView: View {
                 .font(.caption)
                 .foregroundColor(.secondary)
             if spans.hasData {
+                // A header over the value column: the figure at the end of
+                // each row was a bare duration with nothing saying what it
+                // measured.
+                stripHeader
                 ForEach(spans.projects, id: \.self) { project in
                     AutonomyStripRow(project: project,
                                      spans: spans.spans(for: project),
                                      start: spans.start,
                                      end: spans.end)
                 }
+                // …and the window's bounds under it, so a mark can be placed
+                // in time. Two labels, not a tick axis: at 12mo a full axis is
+                // more furniture than the strip is worth, but "from when to
+                // when" is the difference between a timeline and a texture.
+                stripAxis
                 stripLegend
                 if spans.truncated { truncationNote }
             } else {
                 emptyStripText
             }
         }
+    }
+
+    /// Column header for the per-row "longest" figure. Right-aligned by the
+    /// same Spacer the rows use, so it sits over the values it names.
+    private var stripHeader: some View {
+        HStack(spacing: IrrSpacing.sp2) {
+            Text("project")
+            Spacer(minLength: IrrSpacing.sp2)
+            Text("longest")
+        }
+        .font(.caption2)
+        .foregroundColor(.secondary)
+        .accessibilityHidden(true) // each row's own label already says "longest"
+    }
+
+    /// The strip's window bounds: where it starts on the left, `now` on the
+    /// right. The start label coarsens with the window (a time of day at 8h, a
+    /// month at 12mo) — see AutonomyFormat.axisBound.
+    private var stripAxis: some View {
+        HStack(spacing: IrrSpacing.sp2) {
+            Text(AutonomyFormat.axisBound(Date(timeIntervalSince1970: TimeInterval(spans.start)),
+                                          windowSeconds: spans.end - spans.start,
+                                          timeZone: formatTimeZone))
+            Spacer(minLength: IrrSpacing.sp2)
+            Text("now")
+        }
+        .font(.caption2)
+        .foregroundColor(.secondary)
     }
 
     private var stripLegend: some View {
@@ -236,11 +273,11 @@ private struct AutonomyDurationChart: View {
                 .opacity(0.45)
             }
         }
-        .chartForegroundStyleScale([
-            "p95": IrrColors.ready,
-            "p50": IrrColors.working,
-            "p5": IrrColors.waiting,
-        ])
+        // One table for the three lines, read by the scale AND by the legend
+        // Swift Charts derives from it — the web's twin of this is
+        // AUTONOMY_SERIES, and both surfaces must name the lines the same way.
+        .chartForegroundStyleScale(domain: AutonomyPalette.seriesOrder,
+                                   range: AutonomyPalette.seriesRange)
         .chartYScale(domain: yDomain, type: .log)
         .chartYAxis {
             AxisMarks { value in
@@ -320,6 +357,24 @@ private struct AutonomyStripRow: View {
 // MARK: - Palette + formatting
 
 enum AutonomyPalette {
+    /// The three drawn lines, in draw order, and their colours — ONE table,
+    /// read by the chart's style scale and therefore by the legend Swift
+    /// Charts derives from it, so the key and the curves cannot disagree.
+    /// Mirrors the web's AUTONOMY_SERIES, which had to gain the same property
+    /// when QA found three unlabelled curves there.
+    static let seriesOrder = ["p95", "p50", "p5"]
+    static let seriesColors: [String: Color] = [
+        "p95": IrrColors.ready,
+        "p50": IrrColors.working,
+        "p5": IrrColors.waiting,
+    ]
+
+    /// The scale's range in `seriesOrder`. A key with no colour would be a
+    /// line drawn in the fallback grey rather than silently undrawn, which is
+    /// why this cannot crash on a bad key — but `seriesColorsCoverEveryLine`
+    /// in the tests refuses one.
+    static var seriesRange: [Color] { seriesOrder.map { seriesColors[$0] ?? .gray } }
+
     /// A column's fill. An unnamed reason is drawn neutral rather than
     /// skipped: the run happened, this build just cannot say how it ended.
     static func color(for reason: AutonomyEndReason?) -> Color {
@@ -352,12 +407,30 @@ enum AutonomyFormat {
         return h == 0 ? "\(d)d" : "\(d)d\(h)h"
     }
 
+    /// The run strip's left bound, coarsening with the window the way the
+    /// activity matrix's column headers do: an 8h strip needs a time of day, a
+    /// 12mo strip needs a month. In the caller's zone (#1659), never the
+    /// machine's.
+    static func axisBound(_ date: Date, windowSeconds: Int64, timeZone: TimeZone) -> String {
+        if windowSeconds <= 36 * 3600 { return formatted(date, "HH:mm", timeZone) }
+        if windowSeconds <= 60 * 86400 { return formatted(date, "MMM d", timeZone) }
+        return formatted(date, "MMM yyyy", timeZone)
+    }
+
     /// X-axis tick label, in the caller's zone (#1659 — never the machine's).
     static func axisDate(_ date: Date, timeZone: TimeZone) -> String {
+        formatted(date, "MMM d", timeZone)
+    }
+
+    /// POSIX-locale formatter for one pattern in one zone. `locale` is assigned
+    /// before `dateFormat` on purpose: `dateFormat` is interpreted against the
+    /// formatter's current locale, so the reverse order silently re-interprets
+    /// the pattern (the same note HistoryFormat.posix carries).
+    private static func formatted(_ date: Date, _ pattern: String, _ timeZone: TimeZone) -> String {
         let f = DateFormatter()
         f.locale = Locale(identifier: "en_US_POSIX")
         f.timeZone = timeZone
-        f.dateFormat = "MMM d"
+        f.dateFormat = pattern
         return f.string(from: date)
     }
 

--- a/platforms/macos/Irrlicht/Views/HistoryAutonomyView.swift
+++ b/platforms/macos/Irrlicht/Views/HistoryAutonomyView.swift
@@ -1,0 +1,378 @@
+import Charts
+import SwiftUI
+
+// MARK: - Autonomy section (#1905)
+//
+// Two elements over the always-on span log, rendered together because they
+// answer two halves of one question: element 1 is "is this getting better?"
+// (p95/p50/p5 of autonomous run duration over time), element 2 is "who ran
+// long, who kept stopping, and were the stops questions or errors?".
+//
+// Pure inputs (the two decoded responses), so a snapshot test can host this
+// view directly with fixture data.
+
+struct HistoryAutonomyContentView: View {
+    let duration: HistoryAutonomyDurationResponse
+    let spans: HistoryAutonomySpansResponse
+    let range: HistoryAutonomyRange
+    let spanWindow: HistoryAutonomySpanWindow
+
+    /// #1659 — every date this view renders takes its zone as an INPUT rather
+    /// than reading `NSTimeZone.default`.
+    @Environment(\.formatTimeZone) private var formatTimeZone
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: IrrSpacing.sp4) {
+            durationSection
+            Divider()
+            stripSection
+            Divider()
+            collectionProvenance
+        }
+        .padding(.horizontal, IrrSpacing.sp4)
+        .padding(.vertical, IrrSpacing.sp3)
+    }
+
+    // MARK: Element 1 — duration over time
+
+    @ViewBuilder private var durationSection: some View {
+        VStack(alignment: .leading, spacing: IrrSpacing.sp2) {
+            HStack {
+                Text("Autonomous run duration · \(range.label)")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                Spacer()
+                Text("log scale")
+                    .font(.caption2)
+                    .foregroundColor(.secondary)
+            }
+            if duration.hasData {
+                AutonomyDurationChart(data: duration, timeZone: formatTimeZone)
+                    .frame(height: 190)
+                summaryRow
+                if thinCount > 0 { thinNote }
+            } else {
+                emptyDurationText
+            }
+        }
+    }
+
+    /// "p95 1h58m · p50 11m · p5 41s · longest 2h14m · shortest 22s · 312 runs"
+    /// — the true extremes are figures here, deliberately not lines on the
+    /// chart (see HistoryAutonomySummary).
+    private var summaryRow: some View {
+        let s = duration.summary
+        return Text(
+            "p95 \(AutonomyFormat.duration(s.p95)) · p50 \(AutonomyFormat.duration(s.p50)) · "
+            + "p5 \(AutonomyFormat.duration(s.p5)) · longest \(AutonomyFormat.duration(s.max)) · "
+            + "shortest \(AutonomyFormat.duration(s.min)) · \(s.count) runs"
+        )
+        .font(.caption)
+        .monospacedDigit()
+        .foregroundColor(.secondary)
+        .fixedSize(horizontal: false, vertical: true)
+    }
+
+    private var thinCount: Int { duration.buckets.filter(\.thin).count }
+
+    /// Thin buckets are MARKED, never hidden and never smoothed — and the
+    /// marking is explained in words, because a hollow dot means nothing on
+    /// its own.
+    private var thinNote: some View {
+        Text("\(thinCount) of \(duration.buckets.count) buckets hold fewer than \(duration.sampleFloor) runs "
+             + "(hollow points, dashed): there, p95 is that bucket's longest run and p5 its shortest — "
+             + "not percentiles.")
+            .font(.caption2)
+            .foregroundColor(.secondary)
+            .fixedSize(horizontal: false, vertical: true)
+    }
+
+    /// An empty chart with axes drawn is not acceptable (#1905): the empty
+    /// state says, in words, that the feature collects from the day it ships.
+    private var emptyDurationText: some View {
+        Text(duration.totalRecorded == 0
+             ? "No autonomous runs recorded yet. Irrlicht starts measuring them the first time a session runs after this update — an empty chart here means \"nothing recorded\", not \"nothing happened\"."
+             : "No runs in this range. \(duration.totalRecorded) runs are on record outside it.")
+            .font(.callout)
+            .foregroundColor(.secondary)
+            .fixedSize(horizontal: false, vertical: true)
+            .frame(maxWidth: .infinity, minHeight: 150, alignment: .center)
+            .multilineTextAlignment(.center)
+    }
+
+    // MARK: Element 2 — the run strip
+
+    @ViewBuilder private var stripSection: some View {
+        VStack(alignment: .leading, spacing: IrrSpacing.sp2) {
+            Text("Runs · last \(spanWindow.label)")
+                .font(.caption)
+                .foregroundColor(.secondary)
+            if spans.hasData {
+                ForEach(spans.projects, id: \.self) { project in
+                    AutonomyStripRow(project: project,
+                                     spans: spans.spans(for: project),
+                                     start: spans.start,
+                                     end: spans.end)
+                }
+                stripLegend
+                if spans.truncated { truncationNote }
+            } else {
+                emptyStripText
+            }
+        }
+    }
+
+    private var stripLegend: some View {
+        HStack(spacing: IrrSpacing.sp3) {
+            ForEach(AutonomyEndReason.allCases) { reason in
+                HStack(spacing: IrrSpacing.sp1) {
+                    RoundedRectangle(cornerRadius: 1)
+                        .fill(AutonomyPalette.color(for: reason))
+                        .frame(width: 10, height: 8)
+                    Text("\(reason.glyph) \(reason.label)")
+                }
+            }
+            Spacer(minLength: 0)
+        }
+        .font(.caption2)
+        .foregroundColor(.secondary)
+    }
+
+    private var truncationNote: some View {
+        Text("This window holds more runs than one request returns; the strip shows the oldest part of it. "
+             + "Pick a shorter span for a complete picture.")
+            .font(.caption2)
+            .foregroundColor(IrrColors.waiting)
+            .fixedSize(horizontal: false, vertical: true)
+    }
+
+    private var emptyStripText: some View {
+        Text(spans.totalRecorded == 0
+             ? "No runs recorded yet — this strip fills in as sessions run."
+             : "No runs in the last \(spanWindow.label). \(spans.totalRecorded) runs are on record over a longer period.")
+            .font(.callout)
+            .foregroundColor(.secondary)
+            .fixedSize(horizontal: false, vertical: true)
+            .frame(maxWidth: .infinity, minHeight: 90, alignment: .center)
+            .multilineTextAlignment(.center)
+    }
+
+    // MARK: Provenance
+
+    /// States when collection started, so an empty or short history is never
+    /// read as "you did nothing" (#1905).
+    private var collectionProvenance: some View {
+        Text(AutonomyFormat.provenance(earliest: duration.earliestSpan,
+                                       total: duration.totalRecorded,
+                                       timeZone: formatTimeZone))
+            .font(.caption2)
+            .foregroundColor(.secondary)
+            .fixedSize(horizontal: false, vertical: true)
+    }
+}
+
+// MARK: - The percentile chart
+
+private struct AutonomyDurationChart: View {
+    let data: HistoryAutonomyDurationResponse
+    let timeZone: TimeZone
+
+    /// One drawn point. `series` names which of the three lines it belongs to.
+    private struct Datum: Identifiable {
+        let id: String
+        let date: Date
+        let series: String
+        let value: Double
+        let thin: Bool
+    }
+
+    /// Log scales cannot plot 0, and a span shorter than a second is not a
+    /// run — clamp to one second so a degenerate value cannot blank the chart.
+    private func plottable(_ v: Double) -> Double { Swift.max(1, v) }
+
+    private var data3: [Datum] {
+        var out: [Datum] = []
+        for b in data.buckets {
+            let date = Date(timeIntervalSince1970: TimeInterval(b.ts))
+            out.append(Datum(id: "p95-\(b.ts)", date: date, series: "p95", value: plottable(b.p95), thin: b.thin))
+            out.append(Datum(id: "p50-\(b.ts)", date: date, series: "p50", value: plottable(b.p50), thin: b.thin))
+            out.append(Datum(id: "p5-\(b.ts)", date: date, series: "p5", value: plottable(b.p5), thin: b.thin))
+        }
+        return out
+    }
+
+    /// Y domain with a little headroom, floored so a single short run still
+    /// draws inside a readable range.
+    private var yDomain: ClosedRange<Double> {
+        let values = data.buckets.flatMap { [plottable($0.p5), plottable($0.p95)] }
+        let lo = Swift.max(1, (values.min() ?? 1) * 0.8)
+        let hi = Swift.max(lo * 2, (values.max() ?? 60) * 1.25)
+        return lo...hi
+    }
+
+    var body: some View {
+        let points = data3
+        Chart {
+            ForEach(points) { d in
+                LineMark(
+                    x: .value("Date", d.date),
+                    y: .value("Duration", d.value),
+                    series: .value("Series", d.series)
+                )
+                .foregroundStyle(by: .value("Series", d.series))
+                .interpolationMethod(.monotone)
+            }
+            // Thin buckets are marked rather than hidden: a hollow point on
+            // every line at that bucket, so a low-sample day is visibly
+            // different from a well-sampled one without being dropped.
+            ForEach(points.filter(\.thin)) { d in
+                PointMark(
+                    x: .value("Date", d.date),
+                    y: .value("Duration", d.value)
+                )
+                .symbol(.circle)
+                .symbolSize(28)
+                .foregroundStyle(by: .value("Series", d.series))
+                .opacity(0.45)
+            }
+        }
+        .chartForegroundStyleScale([
+            "p95": IrrColors.ready,
+            "p50": IrrColors.working,
+            "p5": IrrColors.waiting,
+        ])
+        .chartYScale(domain: yDomain, type: .log)
+        .chartYAxis {
+            AxisMarks { value in
+                AxisGridLine()
+                AxisValueLabel {
+                    if let v = value.as(Double.self) {
+                        Text(AutonomyFormat.duration(v))
+                    }
+                }
+            }
+        }
+        .chartXAxis {
+            AxisMarks(values: .automatic(desiredCount: 4)) { value in
+                AxisGridLine()
+                AxisValueLabel {
+                    if let d = value.as(Date.self) {
+                        Text(AutonomyFormat.axisDate(d, timeZone: timeZone))
+                    }
+                }
+            }
+        }
+        .chartLegend(position: .bottom, spacing: 4)
+    }
+}
+
+// MARK: - One strip row
+
+private struct AutonomyStripRow: View {
+    let project: String
+    let spans: [HistoryAutonomySpanRow]
+    let start: Int64
+    let end: Int64
+
+    private static let rowHeight: CGFloat = 14
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 1) {
+            HStack(spacing: IrrSpacing.sp2) {
+                Text(project)
+                    .font(.caption2)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                Spacer(minLength: IrrSpacing.sp2)
+                Text(AutonomyFormat.duration(Double(longest)))
+                    .font(.caption2)
+                    .monospacedDigit()
+                    .foregroundColor(.secondary)
+            }
+            Canvas { context, size in
+                // One column per point of width. The collapse rule (minimum
+                // one column per span, highest-priority reason wins a shared
+                // column) lives in AutonomyStripLayout so it is testable
+                // without a view — and so the web draws the same strip.
+                let columns = Swift.max(1, Int(size.width.rounded(.down)))
+                let cells = AutonomyStripLayout.collapse(spans: spans, start: start, end: end, columns: columns)
+                let colWidth = size.width / CGFloat(columns)
+                for (i, cell) in cells.enumerated() where cell.occupied {
+                    let rect = CGRect(x: CGFloat(i) * colWidth, y: 0,
+                                      width: Swift.max(colWidth, 1), height: size.height)
+                    context.fill(Path(rect), with: .color(AutonomyPalette.color(for: cell.reason)))
+                }
+            }
+            .frame(height: Self.rowHeight)
+            .background(Color.secondary.opacity(0.08))
+            .clipShape(RoundedRectangle(cornerRadius: 2))
+            .accessibilityLabel(accessibilityText)
+        }
+    }
+
+    private var longest: Int64 { spans.map(\.duration).max() ?? 0 }
+
+    private var accessibilityText: String {
+        "\(project): \(spans.count) runs, longest \(AutonomyFormat.duration(Double(longest)))"
+    }
+}
+
+// MARK: - Palette + formatting
+
+enum AutonomyPalette {
+    /// A column's fill. An unnamed reason is drawn neutral rather than
+    /// skipped: the run happened, this build just cannot say how it ended.
+    static func color(for reason: AutonomyEndReason?) -> Color {
+        switch reason {
+        case .some(.error): return IrrColors.error
+        case .some(.waiting): return IrrColors.waiting
+        case .some(.ready): return IrrColors.ready
+        case .none: return Color.secondary.opacity(0.55)
+        }
+    }
+}
+
+enum AutonomyFormat {
+    /// Compact run length: "41s", "11m", "1h58m", "2d3h".
+    static func duration(_ seconds: Double) -> String {
+        let s = Int(seconds.rounded())
+        if s < 60 { return "\(s)s" }
+        if s < 3600 {
+            let m = s / 60
+            let rem = s % 60
+            return rem == 0 ? "\(m)m" : "\(m)m\(rem)s"
+        }
+        if s < 86400 {
+            let h = s / 3600
+            let m = (s % 3600) / 60
+            return m == 0 ? "\(h)h" : "\(h)h\(m)m"
+        }
+        let d = s / 86400
+        let h = (s % 86400) / 3600
+        return h == 0 ? "\(d)d" : "\(d)d\(h)h"
+    }
+
+    /// X-axis tick label, in the caller's zone (#1659 — never the machine's).
+    static func axisDate(_ date: Date, timeZone: TimeZone) -> String {
+        let f = DateFormatter()
+        f.locale = Locale(identifier: "en_US_POSIX")
+        f.timeZone = timeZone
+        f.dateFormat = "MMM d"
+        return f.string(from: date)
+    }
+
+    /// The provenance line. Says when collection started — the sentence that
+    /// keeps an empty view from reading as "you did nothing".
+    static func provenance(earliest: Int64, total: Int, timeZone: TimeZone) -> String {
+        guard earliest > 0 else {
+            return "No autonomous runs recorded yet. Irrlicht began measuring them with this update; "
+                + "the charts above fill in as sessions run."
+        }
+        let f = DateFormatter()
+        f.locale = Locale(identifier: "en_US_POSIX")
+        f.timeZone = timeZone
+        f.dateFormat = "MMM d, yyyy"
+        let since = f.string(from: Date(timeIntervalSince1970: TimeInterval(earliest)))
+        return "Collecting since \(since) · \(total) runs recorded."
+    }
+}

--- a/platforms/macos/Irrlicht/Views/HistoryView.swift
+++ b/platforms/macos/Irrlicht/Views/HistoryView.swift
@@ -15,9 +15,11 @@ import SwiftUI
 /// needs: Usage (cost/token time series), Activity (the projects × time
 /// grid of working/waiting/ready counts, #981/#1028), Metrics (a growing set
 /// of derived analytics — Yield's productive-vs-reverted plus DORA, #951),
-/// and Quota (live per-provider subscription rate-limit forecast).
+/// Quota (live per-provider subscription rate-limit forecast), and Autonomy
+/// (how long runs went without needing a human, #1905 — two elements over the
+/// span log, neither of which uses Range, Group, or the drilldown filters).
 enum HistoryTab: String, CaseIterable, Identifiable {
-    case usage, activity, metrics, quota
+    case usage, activity, metrics, quota, autonomy
 
     var id: String { rawValue }
 
@@ -27,6 +29,7 @@ enum HistoryTab: String, CaseIterable, Identifiable {
         case .activity: return "Activity"
         case .metrics: return "Metrics"
         case .quota: return "Quota"
+        case .autonomy: return "Autonomy"
         }
     }
 
@@ -89,6 +92,13 @@ struct HistoryView: View {
     // daemon's own chart=="state" special-case in resolveHistoryQuery).
     @State private var stateGranularity: HistoryGranularity = .hr24
 
+    // Autonomy (#1905) — TWO pickers, because the tab holds two elements with
+    // different windows: a Range for the percentile chart and a Span for the
+    // run strip. Both send ?window=, whose keys are window LENGTHS (unlike
+    // stateGranularity's same-looking keys, which are bucket widths).
+    @State private var autonomyRange: HistoryAutonomyRange = .days30
+    @State private var autonomySpanWindow: HistoryAutonomySpanWindow = .hours24
+
     // Activity is opt-in (#1075): the matrix is reconstructed from recordings,
     // and a bucket that was never recorded looks exactly like an idle one, so
     // without recordings enabled it reads as a grid of misleading blanks.
@@ -100,6 +110,10 @@ struct HistoryView: View {
     @State private var yieldResponse: HistoryYieldResponse?
     @State private var doraResponse: HistoryDoraResponse?
     @State private var stateResponse: HistoryStateResponse?
+    // Autonomy fetches BOTH elements for one tab render, so it keeps two
+    // responses rather than sharing the single-chart slot above.
+    @State private var autonomyDuration: HistoryAutonomyDurationResponse?
+    @State private var autonomySpans: HistoryAutonomySpansResponse?
     @State private var loadFailed = false
 
     init(onClose: @escaping () -> Void, initialTab: HistoryTab = .usage) {
@@ -111,7 +125,7 @@ struct HistoryView: View {
     /// This is the macOS equivalent of the web's manual `historyFetchSeq`
     /// dedup — `.task(id:)` cancels the in-flight request when the key changes.
     private var queryKey: String {
-        let dims = "\(tab.rawValue)-\(fetchChart.rawValue)-\(effectiveGroup.rawValue)-\(scope?.query ?? "")-\(doraProject ?? "")-\(stateGranularity.rawValue)"
+        let dims = "\(tab.rawValue)-\(fetchChart.rawValue)-\(effectiveGroup.rawValue)-\(scope?.query ?? "")-\(doraProject ?? "")-\(stateGranularity.rawValue)-\(autonomyRange.rawValue)-\(autonomySpanWindow.rawValue)"
         if range == .custom {
             return "custom-\(appliedCustomStart ?? 0)-\(appliedCustomEnd ?? 0)-\(dims)"
         }
@@ -227,6 +241,7 @@ struct HistoryView: View {
             case .activity: activityControls
             case .metrics: metricsControls
             case .quota: EmptyView()
+            case .autonomy: autonomyControls
             }
         }
         .padding(.horizontal, IrrSpacing.sp4)
@@ -293,6 +308,31 @@ struct HistoryView: View {
         HStack(spacing: IrrSpacing.sp3) {
             Picker("Granularity", selection: $stateGranularity) {
                 ForEach(HistoryGranularity.allCases) { Text($0.label).tag($0) }
+            }
+            .labelsHidden()
+            .fixedSize()
+            Spacer(minLength: 0)
+        }
+        .pickerStyle(.menu)
+        .controlSize(.small)
+        .font(.caption)
+    }
+
+    /// Autonomy tab (#1905): one picker per element — Range for the duration
+    /// chart, Span for the run strip. Neither is the shared `range`: the two
+    /// elements answer different questions over different windows, and the
+    /// section uses no Group or drilldown at all.
+    @ViewBuilder private var autonomyControls: some View {
+        HStack(spacing: IrrSpacing.sp3) {
+            Text("Range").foregroundColor(.secondary)
+            Picker("Range", selection: $autonomyRange) {
+                ForEach(HistoryAutonomyRange.allCases) { Text($0.label).tag($0) }
+            }
+            .labelsHidden()
+            .fixedSize()
+            Text("Span").foregroundColor(.secondary)
+            Picker("Span", selection: $autonomySpanWindow) {
+                ForEach(HistoryAutonomySpanWindow.allCases) { Text($0.label).tag($0) }
             }
             .labelsHidden()
             .fixedSize()
@@ -385,6 +425,7 @@ struct HistoryView: View {
                 case .activity: activityContent
                 case .metrics: metricsContent
                 case .quota: quotaContent
+                case .autonomy: autonomyContent
                 }
             }
         }
@@ -422,6 +463,20 @@ struct HistoryView: View {
                 onExportCSV: { save(ext: "csv", text: HistoryExport.csvState(s)) },
                 onExportJSON: { save(ext: "json", text: HistoryExport.jsonState(s)) }
             )
+        } else if loadFailed {
+            loadFailedText
+        } else {
+            ProgressView()
+                .frame(maxWidth: .infinity, minHeight: 220)
+        }
+    }
+
+    /// Autonomy tab (#1905): both elements, always together — the percentile
+    /// chart above, the run strip below.
+    @ViewBuilder private var autonomyContent: some View {
+        if let d = autonomyDuration, let s = autonomySpans {
+            HistoryAutonomyContentView(duration: d, spans: s,
+                                       range: autonomyRange, spanWindow: autonomySpanWindow)
         } else if loadFailed {
             loadFailedText
         } else {
@@ -498,6 +553,10 @@ struct HistoryView: View {
 
     private func fetch() async {
         guard tab != .quota else { return }  // quota reads the live snapshot, no fetch
+        if tab == .autonomy {
+            await fetchAutonomy()
+            return
+        }
         // DORA needs exactly one project — with none selected, there's
         // nothing to fetch at all (a distinct empty state, not a load
         // failure or a spinner; see doraContent).
@@ -555,6 +614,44 @@ struct HistoryView: View {
         }
     }
 
+    /// Autonomy (#1905) fetches BOTH elements — the tab shows them together,
+    /// and each has its own window, so neither can be folded into the shared
+    /// single-chart fetch above. A failure in either marks the tab failed
+    /// rather than showing one element beside a spinner that never resolves.
+    private func fetchAutonomy() async {
+        loadFailed = false
+        async let duration: HistoryAutonomyDurationResponse? =
+            fetchAutonomyPart(chart: "autonomy_duration", window: autonomyRange.rawValue)
+        async let spans: HistoryAutonomySpansResponse? =
+            fetchAutonomyPart(chart: "autonomy_spans", window: autonomySpanWindow.rawValue)
+        let (d, s) = await (duration, spans)
+        if Task.isCancelled { return }
+        guard let d, let s else {
+            loadFailed = true
+            return
+        }
+        autonomyDuration = d
+        autonomySpans = s
+    }
+
+    /// One Autonomy request. Returns nil on any failure — the caller decides
+    /// what an incomplete pair means, rather than each half guessing.
+    private func fetchAutonomyPart<T: Decodable>(chart: String, window: String) async -> T? {
+        var comps = URLComponents(string: "\(DaemonEndpoint.httpBase)/api/v1/history")
+        comps?.queryItems = [
+            URLQueryItem(name: "chart", value: chart),
+            URLQueryItem(name: "window", value: window),
+        ]
+        guard let url = comps?.url else { return nil }
+        do {
+            let (data, resp) = try await URLSession.shared.data(from: url)
+            guard (resp as? HTTPURLResponse)?.statusCode == 200 else { return nil }
+            return try JSONDecoder().decode(T.self, from: data)
+        } catch {
+            return nil
+        }
+    }
+
     /// Merges a response's contributor labels into an accumulated project
     /// list, dropping the synthetic "unknown" bucket and keeping it sorted
     /// (#951 — DORA's project picker; #750's broader multi-dimension
@@ -570,9 +667,13 @@ struct HistoryView: View {
         // Activity's range/chart aren't meaningful (granularity replaces
         // range entirely) — name the file after granularity instead rather
         // than embedding a stale range/chart pair.
-        panel.nameFieldStringValue = tab == .activity
-            ? "irrlicht-history-activity-\(stateGranularity.rawValue).\(ext)"
-            : "irrlicht-history-\(range.rawValue)-\(chart.rawValue).\(ext)"
+        if tab == .activity {
+            panel.nameFieldStringValue = "irrlicht-history-activity-\(stateGranularity.rawValue).\(ext)"
+        } else if tab == .autonomy {
+            panel.nameFieldStringValue = "irrlicht-history-autonomy-\(autonomyRange.rawValue).\(ext)"
+        } else {
+            panel.nameFieldStringValue = "irrlicht-history-\(range.rawValue)-\(chart.rawValue).\(ext)"
+        }
         panel.begin { resp in
             guard resp == .OK, let url = panel.url else { return }
             try? text.write(to: url, atomically: true, encoding: .utf8)

--- a/platforms/macos/Tests/HistoryAutonomyTests.swift
+++ b/platforms/macos/Tests/HistoryAutonomyTests.swift
@@ -200,6 +200,43 @@ final class HistoryAutonomyTests: XCTestCase {
         XCTAssertEqual(Set(HistoryAutonomyRange.allCases.map(\.rawValue)), ["30d", "1y"])
     }
 
+    // MARK: The chart's key, and the strip's bounds
+
+    /// The chart's colour scale is what Swift Charts builds its legend from, so
+    /// a line with no colour is a line the key cannot name. The web twin of
+    /// this check is `the three line colours are distinct`.
+    func testSeriesColorsCoverEveryLineAndAreDistinct() {
+        XCTAssertEqual(AutonomyPalette.seriesOrder, ["p95", "p50", "p5"])
+        for key in AutonomyPalette.seriesOrder {
+            XCTAssertNotNil(AutonomyPalette.seriesColors[key],
+                            "\(key) is drawn but has no colour, so the legend cannot name it")
+        }
+        let range = AutonomyPalette.seriesRange
+        XCTAssertEqual(range.count, AutonomyPalette.seriesOrder.count)
+        XCTAssertEqual(Set(range.map { String(describing: $0) }).count, range.count,
+                       "two of the three lines share a colour — the key would be ambiguous")
+    }
+
+    /// The strip's bounds coarsen with the window, so an 8h strip reads as a
+    /// time of day and a 12mo strip as a month.
+    func testAxisBoundCoarsensWithTheWindow() {
+        let utc = TimeZone(identifier: "UTC")!
+        // 2026-01-02T15:30:00Z
+        let d = Date(timeIntervalSince1970: 1_767_367_800)
+        XCTAssertEqual(AutonomyFormat.axisBound(d, windowSeconds: 8 * 3600, timeZone: utc), "15:30")
+        XCTAssertEqual(AutonomyFormat.axisBound(d, windowSeconds: 7 * 86400, timeZone: utc), "Jan 2")
+        XCTAssertEqual(AutonomyFormat.axisBound(d, windowSeconds: 365 * 86400, timeZone: utc), "Jan 2026")
+    }
+
+    /// #1659: every date this section renders takes its zone as an input.
+    func testAxisBoundHonorsTheCallersZone() {
+        let d = Date(timeIntervalSince1970: 1_767_367_800)
+        let utc = AutonomyFormat.axisBound(d, windowSeconds: 8 * 3600, timeZone: TimeZone(identifier: "UTC")!)
+        let tokyo = AutonomyFormat.axisBound(d, windowSeconds: 8 * 3600,
+                                             timeZone: TimeZone(identifier: "Asia/Tokyo")!)
+        XCTAssertNotEqual(utc, tokyo, "the bound must follow the zone it is given, never the machine's")
+    }
+
     // MARK: Formatting + provenance
 
     func testDurationFormatting() {

--- a/platforms/macos/Tests/HistoryAutonomyTests.swift
+++ b/platforms/macos/Tests/HistoryAutonomyTests.swift
@@ -18,7 +18,8 @@ final class HistoryAutonomyTests: XCTestCase {
         let manager = SessionManager()
         let ordered = AutonomyEndReason.allCases.sorted { $0.priority > $1.priority }
         for i in 1..<ordered.count {
-            let higher = ordered[i - 1], lower = ordered[i]
+            let higher = ordered[i - 1]
+            let lower = ordered[i]
             XCTAssertGreaterThan(
                 manager.historyPriorityForState(higher.rawValue),
                 manager.historyPriorityForState(lower.rawValue),
@@ -40,9 +41,16 @@ final class HistoryAutonomyTests: XCTestCase {
         """)
     }
 
-    private func decodeRow(_ json: String) -> HistoryAutonomySpanRow {
-        // swiftlint:disable:next force_try
-        try! JSONDecoder().decode(HistoryAutonomySpanRow.self, from: Data(json.utf8))
+    /// Decoding a literal fixture cannot fail; a malformed one is a bug in the
+    /// test, so it reports as a test failure with the offending JSON rather
+    /// than as a crash (`try!`) with no context.
+    private func decodeRow(_ json: String, file: StaticString = #filePath, line: UInt = #line) -> HistoryAutonomySpanRow {
+        do {
+            return try JSONDecoder().decode(HistoryAutonomySpanRow.self, from: Data(json.utf8))
+        } catch {
+            XCTFail("fixture is not a decodable span row: \(error)\n\(json)", file: file, line: line)
+            return HistoryAutonomySpanRow(start: 0, end: 0, project: "", session: "", reason: nil)
+        }
     }
 
     /// Every span draws at a minimum of one column. At 12 months a 40-second

--- a/platforms/macos/Tests/HistoryAutonomyTests.swift
+++ b/platforms/macos/Tests/HistoryAutonomyTests.swift
@@ -1,0 +1,218 @@
+import XCTest
+@testable import Irrlicht
+
+/// Autonomy section (#1905): the decode contract, the strip's pixel-collapse
+/// rule, and the two ladders that must not drift apart.
+final class HistoryAutonomyTests: XCTestCase {
+
+    // MARK: The collapse ladder
+
+    /// The strip's ladder and the session-history bar's ladder are two
+    /// hand-written copies of one ORDER — not of one numbering: the bar also
+    /// ranks `working`, which is never a span's end reason, so the absolute
+    /// values differ by construction and only the order can be compared. This
+    /// is what stops the two drifting, the same job
+    /// `TestAutonomyReasonLadderMatchesHistoryBar` does on the daemon side.
+    @MainActor
+    func testCollapseLadderMatchesTheHistoryBar() {
+        let manager = SessionManager()
+        let ordered = AutonomyEndReason.allCases.sorted { $0.priority > $1.priority }
+        for i in 1..<ordered.count {
+            let higher = ordered[i - 1], lower = ordered[i]
+            XCTAssertGreaterThan(
+                manager.historyPriorityForState(higher.rawValue),
+                manager.historyPriorityForState(lower.rawValue),
+                "the autonomy strip ranks \(higher.rawValue) above \(lower.rawValue), but the " +
+                "session-history bar does not — the two ladders have drifted")
+        }
+        // Asserted one rung per line: a single line naming three of the four
+        // canonical states is what tools/state-vocabulary-lint.sh refuses.
+        XCTAssertEqual(ordered[0].rawValue, "error")
+        XCTAssertEqual(ordered[1].rawValue, "waiting")
+        XCTAssertEqual(ordered[2].rawValue, "ready")
+    }
+
+    // MARK: The pixel-collapse rule
+
+    private func row(_ start: Int64, _ end: Int64, _ reason: String, project: String = "p") -> HistoryAutonomySpanRow {
+        decodeRow("""
+        {"start":\(start),"end":\(end),"project":"\(project)","session":"s\(start)","reason":"\(reason)"}
+        """)
+    }
+
+    private func decodeRow(_ json: String) -> HistoryAutonomySpanRow {
+        // swiftlint:disable:next force_try
+        try! JSONDecoder().decode(HistoryAutonomySpanRow.self, from: Data(json.utf8))
+    }
+
+    /// Every span draws at a minimum of one column. At 12 months a 40-second
+    /// run is far under one pixel; rounding it away would erase exactly the
+    /// short runs the p5 line is about.
+    func testSubPixelSpanStillDrawsOneColumn() {
+        // A 1-second run inside a 100,000-second window drawn 10 columns wide:
+        // its true width is 0.0001 columns.
+        let cells = AutonomyStripLayout.collapse(
+            spans: [row(50_000, 50_001, "ready")],
+            start: 0, end: 100_000, columns: 10)
+        XCTAssertEqual(cells.count, 10)
+        let occupied = cells.filter(\.occupied)
+        XCTAssertEqual(occupied.count, 1, "a sub-pixel run must still occupy exactly one column, never zero")
+        XCTAssertEqual(occupied.first?.reason, .ready)
+    }
+
+    /// When one column holds several spans, the column takes the
+    /// highest-priority end reason — error over waiting over ready.
+    func testSharedColumnTakesTheHighestPriorityReason() {
+        // Three runs inside the same 1/10th of the window.
+        let spans = [
+            row(1_000, 1_100, "ready"),
+            row(1_200, 1_300, "error"),
+            row(1_400, 1_500, "waiting"),
+        ]
+        let cells = AutonomyStripLayout.collapse(spans: spans, start: 0, end: 100_000, columns: 10)
+        XCTAssertEqual(cells[0].reason, .error,
+                       "a column holding several runs must paint the highest-priority reason — one error " +
+                       "in a column paints the whole column")
+
+        // Order must not matter: the ladder decides, not arrival.
+        let reversed = AutonomyStripLayout.collapse(spans: spans.reversed(), start: 0, end: 100_000, columns: 10)
+        XCTAssertEqual(reversed[0].reason, .error)
+
+        // And without the error, waiting beats ready.
+        let noError = AutonomyStripLayout.collapse(
+            spans: [row(1_000, 1_100, "ready"), row(1_400, 1_500, "waiting")],
+            start: 0, end: 100_000, columns: 10)
+        XCTAssertEqual(noError[0].reason, .waiting)
+    }
+
+    /// A long run spans every column it covers, so the strip still reads as a
+    /// length and not just a marker.
+    func testLongSpanCoversItsColumns() {
+        let cells = AutonomyStripLayout.collapse(
+            spans: [row(0, 50_000, "waiting")],
+            start: 0, end: 100_000, columns: 10)
+        XCTAssertEqual(cells.filter(\.occupied).count, 6,
+                       "half the window plus the column its end falls in")
+    }
+
+    func testSpansOutsideTheWindowAreClippedNotDrawn() {
+        let before = AutonomyStripLayout.collapse(
+            spans: [row(-5_000, -1_000, "ready")], start: 0, end: 100_000, columns: 10)
+        XCTAssertTrue(before.allSatisfy { !$0.occupied })
+
+        let straddling = AutonomyStripLayout.collapse(
+            spans: [row(-5_000, 10_000, "ready")], start: 0, end: 100_000, columns: 10)
+        XCTAssertTrue(straddling[0].occupied, "the visible part of a straddling run must still draw")
+        XCTAssertFalse(straddling[5].occupied)
+    }
+
+    /// A run whose reason this build cannot name still HAPPENED: it occupies
+    /// its column (drawn neutral) rather than reading as idle.
+    func testUnnamedReasonStillOccupiesItsColumn() {
+        let unknown = decodeRow(#"{"start":10,"end":20,"project":"p","session":"s","reason":"martian"}"#)
+        let cells = AutonomyStripLayout.collapse(spans: [unknown], start: 0, end: 100, columns: 10)
+        XCTAssertTrue(cells[1].occupied, "an unrecognized reason must not erase the run")
+        XCTAssertNil(cells[1].reason)
+
+        // …and it must never outrank a real reason in a shared column.
+        let mixed = AutonomyStripLayout.collapse(
+            spans: [unknown, row(11, 19, "error")], start: 0, end: 100, columns: 10)
+        XCTAssertEqual(mixed[1].reason, .error)
+    }
+
+    func testDegenerateInputsProduceNoColumns() {
+        XCTAssertTrue(AutonomyStripLayout.collapse(spans: [], start: 0, end: 0, columns: 10).isEmpty)
+        XCTAssertTrue(AutonomyStripLayout.collapse(spans: [], start: 0, end: 100, columns: 0).isEmpty)
+    }
+
+    // MARK: Decoding
+
+    func testDurationResponseDecodesIncludingOmittedThin() throws {
+        let json = """
+        {"window":"30d","chart":"autonomy_duration","start":1,"end":2,"bucket_seconds":86400,
+         "bucket_starts":[1,2],
+         "buckets":[{"ts":1,"p95":100,"p50":50,"p5":10,"min":10,"max":100,"count":30},
+                    {"ts":2,"p95":9,"p50":5,"p5":1,"min":1,"max":9,"count":3,"thin":true}],
+         "summary":{"p95":100,"p50":40,"p5":5,"min":1,"max":100,"count":33},
+         "sample_floor":20,"earliest_span":1700000000,"total_recorded":33}
+        """
+        let r = try JSONDecoder().decode(HistoryAutonomyDurationResponse.self, from: Data(json.utf8))
+        XCTAssertEqual(r.buckets.count, 2)
+        XCTAssertFalse(r.buckets[0].thin, "`thin` is omitempty on the wire — absent must decode as false")
+        XCTAssertTrue(r.buckets[1].thin)
+        XCTAssertEqual(r.sampleFloor, 20)
+        XCTAssertEqual(r.earliestSpan, 1_700_000_000)
+        XCTAssertEqual(r.totalRecorded, 33)
+        XCTAssertTrue(r.hasData)
+    }
+
+    func testEmptyBucketListIsNoData() throws {
+        let json = """
+        {"window":"1y","chart":"autonomy_duration","start":1,"end":2,"bucket_seconds":604800,
+         "bucket_starts":[1,2,3],"buckets":[],
+         "summary":{"p95":0,"p50":0,"p5":0,"min":0,"max":0,"count":0},
+         "sample_floor":20,"earliest_span":0,"total_recorded":0}
+        """
+        let r = try JSONDecoder().decode(HistoryAutonomyDurationResponse.self, from: Data(json.utf8))
+        XCTAssertFalse(r.hasData, "a fully-drawn axis with no buckets is still \"no data\"")
+        XCTAssertFalse(r.bucketStarts.isEmpty, "the axis is still sent, so the chart can say what window it is")
+    }
+
+    func testSpansResponseDecodesAndGroups() throws {
+        let json = """
+        {"window":"24h","chart":"autonomy_spans","start":0,"end":100,
+         "spans":[{"start":1,"end":9,"project":"a","session":"s1","reason":"ready"},
+                  {"start":2,"end":8,"project":"b","session":"s2","reason":"error"}],
+         "projects":["b","a"],"earliest_span":1,"total_recorded":2,"truncated":false}
+        """
+        let r = try JSONDecoder().decode(HistoryAutonomySpansResponse.self, from: Data(json.utf8))
+        XCTAssertEqual(r.projects, ["b", "a"], "row order is the daemon's, not re-derived here")
+        XCTAssertEqual(r.spans(for: "a").count, 1)
+        XCTAssertEqual(r.spans(for: "a").first?.endReason, .ready)
+        XCTAssertEqual(r.spans(for: "a").first?.duration, 8)
+    }
+
+    // MARK: The two window vocabularies stay distinct
+
+    /// The macOS twin of the daemon's window-vocabulary tripwire: the Autonomy
+    /// pickers send window LENGTHS, while `HistoryGranularity`'s same-looking
+    /// keys are bucket widths. Nothing may quietly reuse one for the other.
+    func testAutonomyWindowsAreNotGranularities() {
+        let autonomyKeys = Set(HistoryAutonomySpanWindow.allCases.map(\.rawValue))
+        XCTAssertTrue(autonomyKeys.contains("12mo"),
+                      "12mo is the strip's own key and has no granularity twin — if it is gone, the two " +
+                      "vocabularies may have been merged")
+        XCTAssertFalse(Set(HistoryGranularity.allCases.map(\.rawValue)).contains("12mo"))
+        // The overlapping keys must not be sourced from the granularity enum.
+        for key in ["8h", "24h", "7d"] {
+            XCTAssertNotNil(HistoryAutonomySpanWindow(rawValue: key))
+            XCTAssertNotNil(HistoryGranularity(rawValue: key),
+                            "the overlap this check guards is gone; re-check whether it still covers the trap")
+        }
+        XCTAssertEqual(Set(HistoryAutonomyRange.allCases.map(\.rawValue)), ["30d", "1y"])
+    }
+
+    // MARK: Formatting + provenance
+
+    func testDurationFormatting() {
+        XCTAssertEqual(AutonomyFormat.duration(41), "41s")
+        XCTAssertEqual(AutonomyFormat.duration(660), "11m")
+        XCTAssertEqual(AutonomyFormat.duration(7080), "1h58m")
+        XCTAssertEqual(AutonomyFormat.duration(86_400), "1d")
+    }
+
+    /// "No data" must never read as "you did nothing": with nothing recorded
+    /// the line says so in words, and with something recorded it names the
+    /// date collection started.
+    func testProvenanceLineSaysWhenCollectionStarted() {
+        let utc = TimeZone(identifier: "UTC")!
+        let empty = AutonomyFormat.provenance(earliest: 0, total: 0, timeZone: utc)
+        XCTAssertTrue(empty.contains("began measuring"),
+                      "an empty section must explain that collection starts with this update, not imply idleness")
+
+        // 1700000000 = 2023-11-14T22:13:20Z
+        let seeded = AutonomyFormat.provenance(earliest: 1_700_000_000, total: 312, timeZone: utc)
+        XCTAssertTrue(seeded.contains("Nov 14, 2023"), "got: \(seeded)")
+        XCTAssertTrue(seeded.contains("312 runs"), "got: \(seeded)")
+    }
+}

--- a/platforms/macos/Tests/HistoryTabVisibilityTests.swift
+++ b/platforms/macos/Tests/HistoryTabVisibilityTests.swift
@@ -7,11 +7,11 @@ import XCTest
 /// developer's real UserDefaults.
 final class HistoryTabVisibilityTests: XCTestCase {
     func testActivityIsHiddenByDefault() {
-        XCTAssertEqual(HistoryTab.visible(activityEnabled: false), [.usage, .metrics, .quota])
+        XCTAssertEqual(HistoryTab.visible(activityEnabled: false), [.usage, .metrics, .quota, .autonomy])
     }
 
     func testActivityAppearsWhenEnabled() {
-        XCTAssertEqual(HistoryTab.visible(activityEnabled: true), [.usage, .activity, .metrics, .quota])
+        XCTAssertEqual(HistoryTab.visible(activityEnabled: true), [.usage, .activity, .metrics, .quota, .autonomy])
     }
 
     func testGatingOnlyAffectsActivity() {

--- a/platforms/web/historyTab.js
+++ b/platforms/web/historyTab.js
@@ -840,11 +840,40 @@ export function autonomyChartPoints(duration) {
   return starts.map(ts => byTs.get(ts) || null);
 }
 
-const AUTONOMY_SERIES = [
+// The three drawn lines, in draw order: series key, the CSS custom property
+// that colours it, and the fallback for a stylesheet that has not loaded.
+//
+// EXPORTED, and read by both the canvas painter and the side panel's key
+// swatches. The web shipped its first round with three unlabelled curves and a
+// panel that explicitly blanked its dots, so a reader had to infer which line
+// was which from vertical order. A key drawn from a SECOND colour table would
+// be worse than none — it can disagree with the chart — so there is one table
+// and one resolver.
+export const AUTONOMY_SERIES = [
   ['p95', '--ready', '#34C759'],
   ['p50', '--working', '#8B5CF6'],
   ['p5', '--waiting', '#FF9500'],
 ];
+
+// Panel labels for the three lines. Split from the colour table only because
+// the canvas has no use for them.
+const AUTONOMY_SERIES_LABELS = {
+  p95: 'p95 · how long the good runs go',
+  p50: 'p50 · the typical run',
+  p5: 'p5 · how short the bad runs are',
+};
+
+// autonomySeriesColor resolves one line's colour against the live theme,
+// falling back to the literal when the custom property is unset (an
+// unstyled document, or a test's stub). Returns '' for a key that is not a
+// drawn line, so a caller cannot silently paint a swatch for something the
+// chart never drew.
+export function autonomySeriesColor(key, cs) {
+  const row = AUTONOMY_SERIES.find(([k]) => k === key);
+  if (!row) return '';
+  const [, cssVar, fallback] = row;
+  return ((cs && cs.getPropertyValue(cssVar)) || fallback).trim();
+}
 
 function paintAutonomyChart() {
   const canvas = document.getElementById('history-chart');
@@ -879,9 +908,8 @@ function paintAutonomyChart() {
   };
 
   drawAutonomyGridlines(ctx, { lo, hi, yAt, padL, padR, w, muted, gridColor });
-  for (const [key, cssVar, fallback] of AUTONOMY_SERIES) {
-    const color = (cs.getPropertyValue(cssVar) || fallback).trim();
-    drawAutonomySeries(ctx, { points, key, color, xAt, yAt });
+  for (const [key] of AUTONOMY_SERIES) {
+    drawAutonomySeries(ctx, { points, key, color: autonomySeriesColor(key, cs), xAt, yAt });
   }
   drawAutonomyXLabels(ctx, { duration, xAt, muted, h, padB });
 }
@@ -979,9 +1007,17 @@ function renderAutonomyStrip() {
   }
 
   const cs = getComputedStyle(document.documentElement);
+  // A header over the value column: the figure at the end of each row was a
+  // bare duration with nothing saying what it measured.
+  rowsEl.appendChild(buildAutonomyStripHeader());
   for (const project of projects) {
     rowsEl.appendChild(buildAutonomyStripRow(project, spans, cs));
   }
+  // …and the window's bounds under it, so a mark can be placed in time. Two
+  // labels, not a tick axis: at 12mo a full axis is more furniture than the
+  // strip is worth, but "from when to when" is the difference between a
+  // timeline and a texture.
+  rowsEl.appendChild(buildAutonomyStripAxis(spans));
   if (legendEl) fillAutonomyLegend(legendEl, cs);
   if (noteEl && spans.truncated) {
     noteEl.textContent = 'This window holds more runs than one request returns; the strip shows the oldest part of it. '
@@ -1014,6 +1050,57 @@ function fillAutonomyLegend(legendEl, cs) {
     item.appendChild(document.createTextNode(glyph + ' ' + label));
     legendEl.appendChild(item);
   }
+}
+
+// buildAutonomyStripHeader labels the value column. It reuses the row grid so
+// the header sits exactly over the values it names.
+export function buildAutonomyStripHeader() {
+  const head = document.createElement('div');
+  head.className = 'history-autonomy-row history-autonomy-head';
+  head.setAttribute('aria-hidden', 'true'); // each row's aria-label already says "longest"
+  const label = document.createElement('span');
+  label.className = 'history-autonomy-label';
+  label.textContent = 'project';
+  const spacer = document.createElement('span');
+  const val = document.createElement('span');
+  val.className = 'history-autonomy-val';
+  val.textContent = 'longest';
+  head.appendChild(label);
+  head.appendChild(spacer);
+  head.appendChild(val);
+  return head;
+}
+
+// buildAutonomyStripAxis puts the window's start on the left and "now" on the
+// right, under the strip, on the same grid so both land under the canvas
+// column rather than under the labels.
+export function buildAutonomyStripAxis(spans) {
+  const axis = document.createElement('div');
+  axis.className = 'history-autonomy-row history-autonomy-axis';
+  const label = document.createElement('span');
+  const bounds = document.createElement('span');
+  bounds.className = 'history-autonomy-axis-bounds';
+  const from = document.createElement('i');
+  from.textContent = autonomyAxisLabel(spans.start, (spans.end || 0) - (spans.start || 0));
+  const to = document.createElement('i');
+  to.textContent = 'now';
+  bounds.appendChild(from);
+  bounds.appendChild(to);
+  const tail = document.createElement('span');
+  axis.appendChild(label);
+  axis.appendChild(bounds);
+  axis.appendChild(tail);
+  return axis;
+}
+
+// autonomyAxisLabel formats the strip's left bound, coarsening with the window
+// the way stateBucketLabel does for the activity matrix: an 8h strip needs a
+// time of day, a 12mo strip needs a month.
+export function autonomyAxisLabel(ts, windowSeconds) {
+  const d = new Date((Number(ts) || 0) * 1000);
+  if (windowSeconds <= 36 * 3600) return d.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' });
+  if (windowSeconds <= 60 * 86400) return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+  return d.toLocaleDateString(undefined, { month: 'short', year: 'numeric' });
 }
 
 function buildAutonomyStripRow(project, spans, cs) {
@@ -1064,6 +1151,40 @@ function paintAutonomyStripRow(canvas, mine, spans, cs) {
   }
 }
 
+// autonomyPanelRows builds the side panel's rows, INCLUDING each row's swatch
+// colour, as a pure function.
+//
+// The swatch belongs here rather than at the DOM call site because that is
+// exactly where the defect was: the panel used to build the p95/p50/p5 rows and
+// then blank every dot, leaving three unlabelled curves on the canvas with no
+// key at all. As a value it is testable; as a `style.background =` buried in a
+// render loop it was not.
+//
+// The first three rows ARE the chart's lines, so they carry the chart's own
+// colours (from AUTONOMY_SERIES, the same table the canvas strokes from) and
+// double as its key — the macOS surface says the same thing through Swift
+// Charts' legend. longest/shortest/runs are FIGURES, not lines, and stay
+// unswatched on purpose: a swatch would claim a curve the chart deliberately
+// does not draw.
+export function autonomyPanelRows(summary, cs) {
+  const s = summary || {};
+  const line = (key, value) => ({
+    series: key,
+    label: AUTONOMY_SERIES_LABELS[key],
+    value,
+    swatch: autonomySeriesColor(key, cs),
+  });
+  const figure = (label, value) => ({ series: null, label, value, swatch: 'transparent' });
+  return [
+    line('p95', autonomyDuration(s.p95)),
+    line('p50', autonomyDuration(s.p50)),
+    line('p5', autonomyDuration(s.p5)),
+    figure('longest', autonomyDuration(s.max)),
+    figure('shortest', autonomyDuration(s.min)),
+    figure('runs', String(s.count || 0)),
+  ];
+}
+
 // renderAutonomyPanel fills the shared side panel with element 1's figures.
 // The true extremes are FIGURES here and deliberately not lines on the chart:
 // one overnight run would otherwise redraw the whole Y scale.
@@ -1084,25 +1205,17 @@ function renderAutonomyPanel() {
       ? 'no runs in this range'
       : 'nothing recorded yet');
   } else {
-    const rows = [
-      ['p95 (good runs)', autonomyDuration(s.p95)],
-      ['p50 (typical run)', autonomyDuration(s.p50)],
-      ['p5 (bad runs)', autonomyDuration(s.p5)],
-      ['longest', autonomyDuration(s.max)],
-      ['shortest', autonomyDuration(s.min)],
-      ['runs', String(s.count)],
-    ];
-    for (const [label, value] of rows) {
+    for (const row of autonomyPanelRows(s, getComputedStyle(document.documentElement))) {
       const li = document.createElement('li');
       const dot = document.createElement('span');
       dot.className = 'dot';
-      dot.style.background = 'transparent';
+      dot.style.background = row.swatch;
       const lbl = document.createElement('span');
       lbl.className = 'label';
-      lbl.textContent = label;
+      lbl.textContent = row.label;
       const val = document.createElement('span');
       val.className = 'val';
-      val.textContent = value;
+      val.textContent = row.value;
       li.appendChild(dot);
       li.appendChild(lbl);
       li.appendChild(val);

--- a/platforms/web/historyTab.js
+++ b/platforms/web/historyTab.js
@@ -788,26 +788,32 @@ export function autonomyProvenanceLine(duration) {
 // because a run whose reason this build cannot name still HAPPENED: it holds
 // its column (drawn neutral) rather than reading as idle.
 export function collapseAutonomyStrip(spans, start, end, columns) {
-  if (!(columns > 0) || !(end > start)) return [];
+  if (columns <= 0 || end <= start) return [];
   const out = [];
   for (let i = 0; i < columns; i++) out.push({ occupied: false, reason: null });
-  const width = end - start;
-  for (const sp of (spans || [])) {
-    let first = Math.floor((sp.start - start) / width * columns);
-    let last = Math.floor((sp.end - start) / width * columns);
-    if (last < 0 || first > columns - 1) continue; // wholly outside the window
-    first = Math.max(0, first);
-    last = Math.min(columns - 1, last);
-    if (last < first) last = first; // the minimum-one-column rule
-    const rank = AUTONOMY_REASON_PRIORITY[sp.reason] || 0;
-    for (let i = first; i <= last; i++) {
-      // -1 for an untouched column, so even an unnamed reason (rank 0) claims it.
-      const existingRank = out[i].occupied ? (AUTONOMY_REASON_PRIORITY[out[i].reason] || 0) : -1;
-      out[i].occupied = true;
-      if (rank > existingRank) out[i].reason = AUTONOMY_REASON_PRIORITY[sp.reason] ? sp.reason : null;
-    }
-  }
+  for (const sp of (spans || [])) paintSpanColumns(out, sp, start, end, columns);
   return out;
+}
+
+// paintSpanColumns writes one span into the column array, applying both halves
+// of the rule: the span's column range (never empty — the minimum-one-column
+// rule) and the ladder that decides a shared column's color.
+function paintSpanColumns(out, sp, start, end, columns) {
+  const width = end - start;
+  let first = Math.floor((sp.start - start) / width * columns);
+  let last = Math.floor((sp.end - start) / width * columns);
+  if (last < 0 || first > columns - 1) return; // wholly outside the window
+  first = Math.max(0, first);
+  last = Math.min(columns - 1, last);
+  if (last < first) last = first; // the minimum-one-column rule
+  const reason = AUTONOMY_REASON_PRIORITY[sp.reason] ? sp.reason : null;
+  const rank = AUTONOMY_REASON_PRIORITY[sp.reason] || 0;
+  for (let i = first; i <= last; i++) {
+    // -1 for an untouched column, so even an unnamed reason (rank 0) claims it.
+    const existingRank = out[i].occupied ? (AUTONOMY_REASON_PRIORITY[out[i].reason] || 0) : -1;
+    out[i].occupied = true;
+    if (rank > existingRank) out[i].reason = reason;
+  }
 }
 
 // autonomyReasonColor maps an end reason onto the shared state palette. An
@@ -872,7 +878,18 @@ function paintAutonomyChart() {
     return padT + plotH * (1 - t);
   };
 
-  // Gridlines, labelled in the same duration units the summary uses.
+  drawAutonomyGridlines(ctx, { lo, hi, yAt, padL, padR, w, muted, gridColor });
+  for (const [key, cssVar, fallback] of AUTONOMY_SERIES) {
+    const color = (cs.getPropertyValue(cssVar) || fallback).trim();
+    drawAutonomySeries(ctx, { points, key, color, xAt, yAt });
+  }
+  drawAutonomyXLabels(ctx, { duration, xAt, muted, h, padB });
+}
+
+// drawAutonomyGridlines draws the log-scale Y gridlines, labelled in the same
+// duration units the summary row uses, so an axis tick and a headline figure
+// can never be read in different units.
+function drawAutonomyGridlines(ctx, { lo, hi, yAt, padL, padR, w, muted, gridColor }) {
   ctx.strokeStyle = gridColor;
   ctx.fillStyle = muted;
   ctx.font = '10px ui-monospace, monospace';
@@ -888,13 +905,9 @@ function paintAutonomyChart() {
     ctx.stroke();
     ctx.fillText(autonomyDuration(v), padL - 6, y);
   }
+}
 
-  for (const [key, cssVar, fallback] of AUTONOMY_SERIES) {
-    const color = (cs.getPropertyValue(cssVar) || fallback).trim();
-    drawAutonomySeries(ctx, { points, key, color, xAt, yAt });
-  }
-
-  // X labels.
+function drawAutonomyXLabels(ctx, { duration, xAt, muted, h, padB }) {
   ctx.fillStyle = muted;
   ctx.textAlign = 'center';
   ctx.textBaseline = 'top';
@@ -961,13 +974,7 @@ function renderAutonomyStrip() {
 
   const projects = spans?.projects || [];
   if (!projects.length) {
-    const empty = document.createElement('div');
-    empty.className = 'history-autonomy-empty';
-    empty.textContent = autonomyEverRecorded()
-      ? 'No runs in the last ' + (AUTONOMY_SPAN_LABELS[historyState.autonomySpan] || historyState.autonomySpan)
-        + '. ' + (spans?.total_recorded || 0) + ' runs are on record over a longer period.'
-      : 'No runs recorded yet — this strip fills in as sessions run.';
-    rowsEl.appendChild(empty);
+    rowsEl.appendChild(buildAutonomyStripEmpty(spans));
     return;
   }
 
@@ -975,20 +982,37 @@ function renderAutonomyStrip() {
   for (const project of projects) {
     rowsEl.appendChild(buildAutonomyStripRow(project, spans, cs));
   }
-  if (legendEl) {
-    for (const [reason, glyph, label] of AUTONOMY_REASON_LEGEND) {
-      const item = document.createElement('span');
-      item.className = 'history-autonomy-legend-item';
-      const swatch = document.createElement('i');
-      swatch.style.background = autonomyReasonColor(reason, cs);
-      item.appendChild(swatch);
-      item.appendChild(document.createTextNode(glyph + ' ' + label));
-      legendEl.appendChild(item);
-    }
-  }
+  if (legendEl) fillAutonomyLegend(legendEl, cs);
   if (noteEl && spans.truncated) {
     noteEl.textContent = 'This window holds more runs than one request returns; the strip shows the oldest part of it. '
       + 'Pick a shorter span for a complete picture.';
+  }
+}
+
+// buildAutonomyStripEmpty renders the strip's empty state. Two wordings, and
+// the distinction is the honesty rule: "no runs in this window" and "nothing
+// has ever been recorded" are different claims, and only the second one is
+// about the feature rather than about the user.
+function buildAutonomyStripEmpty(spans) {
+  const empty = document.createElement('div');
+  empty.className = 'history-autonomy-empty';
+  const label = AUTONOMY_SPAN_LABELS[historyState.autonomySpan] || historyState.autonomySpan;
+  empty.textContent = autonomyEverRecorded()
+    ? 'No runs in the last ' + label + '. ' + (spans?.total_recorded || 0)
+      + ' runs are on record over a longer period.'
+    : 'No runs recorded yet — this strip fills in as sessions run.';
+  return empty;
+}
+
+function fillAutonomyLegend(legendEl, cs) {
+  for (const [reason, glyph, label] of AUTONOMY_REASON_LEGEND) {
+    const item = document.createElement('span');
+    item.className = 'history-autonomy-legend-item';
+    const swatch = document.createElement('i');
+    swatch.style.background = autonomyReasonColor(reason, cs);
+    item.appendChild(swatch);
+    item.appendChild(document.createTextNode(glyph + ' ' + label));
+    legendEl.appendChild(item);
   }
 }
 

--- a/platforms/web/historyTab.js
+++ b/platforms/web/historyTab.js
@@ -11,7 +11,35 @@ const HISTORY_COLORS = [
   '#5E5CE6', '#FFD60A', '#30D158', '#BF5AF2', '#64D2FF',
 ];
 const RANGE_LABELS = { day: 'Day', week: 'Week', month: 'Month', year: 'Year', 'this-month': 'This Month', custom: 'Custom' };
-export const CHART_LABELS = { cost: 'Cost', tokens: 'Tokens', co2: 'CO2', models: 'Models', providers: 'Providers', agents: 'Agents', state: 'Activity', yield: 'Yield', dora: 'DORA' };
+export const CHART_LABELS = { cost: 'Cost', tokens: 'Tokens', co2: 'CO2', models: 'Models', providers: 'Providers', agents: 'Agents', state: 'Activity', yield: 'Yield', dora: 'DORA', autonomy: 'Autonomy' };
+// Autonomy (#1905). `autonomy` is a CLIENT-SIDE pseudo-chart: selecting it
+// fans out into the daemon's two real charts, chart=autonomy_duration (the
+// percentile lines) and chart=autonomy_spans (the run strip), because the
+// section shows both elements at once.
+//
+// WINDOW LENGTHS, not bucket widths. These keys overlap GRANULARITY_LABELS'
+// textually and mean something else entirely: there a key names a bucket width
+// that is multiplied by a count (so '24h' resolves to a THIRTY-DAY window),
+// here a key IS the window. The two tables must never be merged — see
+// autonomy window vocabularies in irrlicht.history.autonomy.test.js.
+export const AUTONOMY_RANGE_LABELS = { '30d': '30 days', '1y': 'Year' };
+export const AUTONOMY_SPAN_LABELS = { '8h': '8h', '24h': '24h', '7d': '7d', '30d': '30d', '12mo': '12mo' };
+// The strip's pixel-collapse ladder: when one device-pixel column holds
+// several runs, the column paints the highest-ranked reason in it. Same order
+// as the session-history strip's ladder (#1805) — one error in a column paints
+// the whole column. One state per line, because a single line naming three of
+// the four canonical states is what tools/state-vocabulary-lint.sh refuses.
+export const AUTONOMY_REASON_PRIORITY = {
+  error: 3,
+  waiting: 2,
+  ready: 1,
+};
+// Legend glyphs + wording, matching the issue's sketch and the macOS legend.
+export const AUTONOMY_REASON_LEGEND = [
+  ['error', '\u2717', 'error'],
+  ['waiting', '?', 'it asked'],
+  ['ready', '\u2713', 'turn finished'],
+];
 // Granularity steps for chart=state's activity matrix (issue #981) — each
 // picks both the server's bucket width and the matrix's visible column
 // count at once (see historyGranularitySpecs on the daemon side).
@@ -50,6 +78,11 @@ const historyState = {
   // granularity is chart=state's own zoom-level axis (#981) — independent of
   // range, which every other chart uses instead.
   granularity: '24h',
+  // Autonomy (#1905): one window per element, neither of them `range`.
+  // autonomyData holds BOTH responses, since the section renders both at once.
+  autonomyRange: '30d',
+  autonomySpan: '24h',
+  autonomyData: null,
   filters: { provider: [], token_type: [], project: [] },
   known: { provider: [], project: [] },
   // DORA (#951) is inherently repo-scoped — needs exactly one project,
@@ -230,6 +263,21 @@ function setHistoryFilterParams(p, state) {
   }
 }
 
+// autonomyQuery builds one of the two Autonomy requests. `element` picks
+// which daemon chart and therefore which window vocabulary applies — they are
+// different sets, and neither endpoint accepts the other's keys.
+export function autonomyQuery(element, state = historyState) {
+  const p = new URLSearchParams();
+  if (element === 'spans') {
+    p.set('chart', 'autonomy_spans');
+    p.set('window', state.autonomySpan);
+  } else {
+    p.set('chart', 'autonomy_duration');
+    p.set('window', state.autonomyRange);
+  }
+  return p.toString();
+}
+
 export function historyQuery(state = historyState) {
   const p = new URLSearchParams();
   p.set('chart', state.chart);
@@ -244,7 +292,24 @@ export function historyQuery(state = historyState) {
   return p.toString();
 }
 
+// fetchAutonomy fetches BOTH Autonomy elements. Either failing marks the whole
+// section unavailable rather than leaving one element beside a spinner that
+// never resolves.
+function fetchAutonomy() {
+  const seq = ++historyFetchSeq;
+  const get = (element) => fetch('/api/v1/history?' + autonomyQuery(element))
+    .then(r => (r.ok ? r.json() : null))
+    .catch(() => null);
+  return Promise.all([get('duration'), get('spans')]).then(([duration, spans]) => {
+    if (seq !== historyFetchSeq) return; // superseded by a newer request
+    historyState.autonomyData = (duration && spans) ? { duration, spans } : null;
+    historyState.data = historyState.autonomyData ? duration : null;
+    renderHistory();
+  });
+}
+
 function fetchHistory() {
+  if (historyState.chart === 'autonomy') return fetchAutonomy();
   // DORA needs exactly one project — with none selected, there's nothing
   // to fetch at all (a distinct empty state, not a load failure or a
   // spinner; see renderDoraPanel).
@@ -292,6 +357,11 @@ function historyEmptyCaption() {
     case 'agents':
     case 'state':
       return 'no recordings in this range yet';
+    case 'autonomy':
+      // Never "no runs": this feature collects from the day it ships, so an
+      // empty view has to say which of the two it is (#1905). The full
+      // sentence lives in the side panel; this is the canvas overlay.
+      return autonomyEverRecorded() ? 'no runs in this range' : 'not collecting yet — runs appear as sessions run';
     default:
       return 'no cost data in this range yet';
   }
@@ -320,6 +390,11 @@ function paintActiveHistoryChart() {
       renderStateMatrix();
       renderStatePanel();
       break;
+    case 'autonomy':
+      paintAutonomyChart();
+      renderAutonomyStrip();
+      renderAutonomyPanel();
+      break;
     default:
       paintHistoryChart();
       renderHistoryPanel();
@@ -336,6 +411,7 @@ function renderHistory() {
   // The activity matrix is a grid, not a time-series line — it replaces the
   // shared canvas with its own scrollable DOM grid (see history-matrix-scroll).
   syncHistoryMatrixVisibility(historyState.chart === 'state');
+  syncAutonomyRows(historyState.chart === 'autonomy');
   const emptyEl = document.getElementById('history-chart-empty');
   if (emptyEl) emptyEl.textContent = historyEmptyCaption();
   if (!historyState.data) {
@@ -361,7 +437,24 @@ function syncHistoryMatrixVisibility(isState) {
 // instead, so the range buttons would be visible but silently inert.
 function syncHistoryRangeRow() {
   const row = document.getElementById('history-range-row');
-  if (row) row.hidden = historyState.chart === 'state';
+  // Autonomy joins chart=state here: it resolves both its windows from
+  // ?window=, so the Day/Week/Month buttons would be visible but inert.
+  if (row) row.hidden = historyState.chart === 'state' || historyState.chart === 'autonomy';
+}
+
+// syncAutonomyRows shows the Autonomy pickers and the run strip only while the
+// section is active, mirroring syncGranularityRow's per-chart row toggle.
+function syncAutonomyRows(isAutonomy) {
+  const ctl = document.getElementById('history-autonomy-row');
+  if (ctl) ctl.hidden = !isAutonomy;
+  const strip = document.getElementById('history-autonomy-strip');
+  if (strip) strip.hidden = !isAutonomy;
+  const groupRow = document.getElementById('history-group-sel')?.closest('.history-ctl-row');
+  // Group and the cross-filters do not apply to spans — the section has no
+  // stacking axis at all.
+  if (groupRow) groupRow.hidden = isAutonomy;
+  const filterRow = document.getElementById('history-filter-row');
+  if (filterRow) filterRow.hidden = isAutonomy;
 }
 
 // syncGranularityRow shows the granularity zoom-level control only while
@@ -627,6 +720,380 @@ function paintHistoryChart() {
 
   // X axis time labels.
   drawHistoryXAxisLabels(geo, { buckets, B, bucketSeconds: data.bucket_seconds, muted, h, padB });
+}
+
+// --- Autonomy (#1905) ---
+//
+// Two elements over the always-on span log: a percentile line chart of
+// autonomous run duration over time (drawn on the shared canvas, like every
+// other time series here), and a per-project run strip (its own DOM section,
+// one canvas per project row).
+//
+// An autonomy span is one unbroken stretch of `working`; the state the session
+// left `working` FOR is the signal both elements carry.
+
+// autonomyEverRecorded reports whether the span log holds anything at all,
+// anywhere — the fact that separates "no runs in this range" from "this
+// feature has not collected anything yet". Both are empty views; only one of
+// them means the user did nothing.
+export function autonomyEverRecorded(state = historyState) {
+  const d = state.autonomyData;
+  if (!d) return false;
+  return (d.duration?.total_recorded || 0) > 0 || (d.spans?.total_recorded || 0) > 0;
+}
+
+// autonomyDuration formats a run length: "41s", "11m", "1h58m", "2d3h".
+export function autonomyDuration(seconds) {
+  const s = Math.round(Number(seconds) || 0);
+  if (s < 60) return s + 's';
+  if (s < 3600) {
+    const m = Math.floor(s / 60), rem = s % 60;
+    return rem === 0 ? m + 'm' : m + 'm' + rem + 's';
+  }
+  if (s < 86400) {
+    const h = Math.floor(s / 3600), m = Math.floor((s % 3600) / 60);
+    return m === 0 ? h + 'h' : h + 'h' + m + 'm';
+  }
+  const d = Math.floor(s / 86400), h = Math.floor((s % 86400) / 3600);
+  return h === 0 ? d + 'd' : d + 'd' + h + 'h';
+}
+
+// autonomyProvenanceLine states when collection started, so an empty or short
+// history is never read as "you did nothing" (#1905). This sentence is part of
+// the feature, not decoration.
+export function autonomyProvenanceLine(duration) {
+  const earliest = Number(duration?.earliest_span) || 0;
+  const total = Number(duration?.total_recorded) || 0;
+  if (!earliest) {
+    return 'No autonomous runs recorded yet. Irrlicht began measuring them with this update — '
+      + 'an empty chart means "nothing recorded", not "nothing happened".';
+  }
+  const since = new Date(earliest * 1000).toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' });
+  return 'Collecting since ' + since + ' · ' + total + ' runs recorded.';
+}
+
+// collapseAutonomyStrip is the strip's pixel-collapse rule (#1905 design
+// decision 4), as a pure function so it can be tested without a canvas — and
+// so this and the macOS AutonomyStripLayout draw the same strip.
+//
+// TWO HALVES, both load-bearing:
+//   - Every span draws at a minimum of ONE column. At 12mo a 40-second run is
+//     far under one device pixel; rounding it away would erase exactly the
+//     short runs the p5 line is about.
+//   - A column holding several spans takes the HIGHEST-priority end reason
+//     (AUTONOMY_REASON_PRIORITY). One error in a column paints the whole
+//     column, because what is worth seeing at a glance is that something broke.
+//
+// Returns one {occupied, reason} per column. occupied and reason are separate
+// because a run whose reason this build cannot name still HAPPENED: it holds
+// its column (drawn neutral) rather than reading as idle.
+export function collapseAutonomyStrip(spans, start, end, columns) {
+  if (!(columns > 0) || !(end > start)) return [];
+  const out = [];
+  for (let i = 0; i < columns; i++) out.push({ occupied: false, reason: null });
+  const width = end - start;
+  for (const sp of (spans || [])) {
+    let first = Math.floor((sp.start - start) / width * columns);
+    let last = Math.floor((sp.end - start) / width * columns);
+    if (last < 0 || first > columns - 1) continue; // wholly outside the window
+    first = Math.max(0, first);
+    last = Math.min(columns - 1, last);
+    if (last < first) last = first; // the minimum-one-column rule
+    const rank = AUTONOMY_REASON_PRIORITY[sp.reason] || 0;
+    for (let i = first; i <= last; i++) {
+      // -1 for an untouched column, so even an unnamed reason (rank 0) claims it.
+      const existingRank = out[i].occupied ? (AUTONOMY_REASON_PRIORITY[out[i].reason] || 0) : -1;
+      out[i].occupied = true;
+      if (rank > existingRank) out[i].reason = AUTONOMY_REASON_PRIORITY[sp.reason] ? sp.reason : null;
+    }
+  }
+  return out;
+}
+
+// autonomyReasonColor maps an end reason onto the shared state palette. An
+// unnamed reason draws neutral — the run happened, this build just cannot say
+// how it ended.
+function autonomyReasonColor(reason, cs) {
+  const pick = (name, fallback) => (cs.getPropertyValue(name) || fallback).trim();
+  if (reason === 'error') return pick('--pressure-high', '#FF3B30');
+  if (reason === 'waiting') return pick('--waiting', '#FF9500');
+  if (reason === 'ready') return pick('--ready', '#34C759');
+  return pick('--muted', '#888');
+}
+
+// autonomyChartPoints turns the sparse bucket list into per-series point lists
+// aligned to bucket_starts, with a null for every bucket the daemon OMITTED.
+//
+// The null is the honesty rule, not a convenience: an empty bucket is a GAP,
+// and a day with no runs must not pull the line down to the axis. The painter
+// below breaks the stroke at a null instead of interpolating through it.
+export function autonomyChartPoints(duration) {
+  const starts = duration?.bucket_starts || [];
+  const byTs = new Map();
+  for (const b of (duration?.buckets || [])) byTs.set(b.ts, b);
+  return starts.map(ts => byTs.get(ts) || null);
+}
+
+const AUTONOMY_SERIES = [
+  ['p95', '--ready', '#34C759'],
+  ['p50', '--working', '#8B5CF6'],
+  ['p5', '--waiting', '#FF9500'],
+];
+
+function paintAutonomyChart() {
+  const canvas = document.getElementById('history-chart');
+  const wrap = document.getElementById('history-chart-wrap');
+  if (!canvas || !wrap) return;
+  const duration = historyState.autonomyData?.duration;
+  const { ctx, w, h } = setupHistoryCanvas(canvas, wrap);
+  const points = autonomyChartPoints(duration);
+  const drawn = points.filter(Boolean);
+  const hasData = drawn.length > 0;
+  wrap.classList.toggle('empty', !hasData);
+  if (!hasData) return;
+
+  const cs = getComputedStyle(document.documentElement);
+  const muted = (cs.getPropertyValue('--muted') || '#888').trim();
+  const gridColor = 'rgba(128,140,170,0.18)';
+
+  // Log Y: the interesting range is seconds to hours, so a linear axis spends
+  // its whole height on the longest run. Floored at 1s — a log scale cannot
+  // plot 0, and a sub-second span is not a run.
+  const lo = Math.max(1, Math.min(...drawn.map(b => Math.max(1, b.p5))) * 0.8);
+  const hi = Math.max(lo * 2, Math.max(...drawn.map(b => Math.max(1, b.p95))) * 1.25);
+  const padL = 52, padR = 12, padT = 12, padB = 22;
+  const plotW = Math.max(1, w - padL - padR);
+  const plotH = Math.max(1, h - padT - padB);
+  const n = Math.max(1, points.length);
+  const xAt = (i) => (n <= 1 ? padL : padL + plotW * (i / (n - 1)));
+  const yAt = (v) => {
+    const clamped = Math.min(hi, Math.max(lo, Math.max(1, v)));
+    const t = (Math.log(clamped) - Math.log(lo)) / (Math.log(hi) - Math.log(lo));
+    return padT + plotH * (1 - t);
+  };
+
+  // Gridlines, labelled in the same duration units the summary uses.
+  ctx.strokeStyle = gridColor;
+  ctx.fillStyle = muted;
+  ctx.font = '10px ui-monospace, monospace';
+  ctx.textAlign = 'right';
+  ctx.textBaseline = 'middle';
+  const decades = 4;
+  for (let i = 0; i <= decades; i++) {
+    const v = Math.exp(Math.log(lo) + (Math.log(hi) - Math.log(lo)) * (i / decades));
+    const y = yAt(v);
+    ctx.beginPath();
+    ctx.moveTo(padL, y);
+    ctx.lineTo(w - padR, y);
+    ctx.stroke();
+    ctx.fillText(autonomyDuration(v), padL - 6, y);
+  }
+
+  for (const [key, cssVar, fallback] of AUTONOMY_SERIES) {
+    const color = (cs.getPropertyValue(cssVar) || fallback).trim();
+    drawAutonomySeries(ctx, { points, key, color, xAt, yAt });
+  }
+
+  // X labels.
+  ctx.fillStyle = muted;
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'top';
+  const starts = duration.bucket_starts || [];
+  const labels = Math.min(5, starts.length);
+  for (let i = 0; i < labels; i++) {
+    const c = Math.round(i * (starts.length - 1) / Math.max(1, labels - 1));
+    ctx.fillText(histAxisLabel(starts[c], duration.bucket_seconds), xAt(c), h - padB + 5);
+  }
+}
+
+// drawAutonomySeries strokes one percentile line, breaking at every omitted
+// bucket and DASHING any segment that touches a thin bucket — so a bucket
+// under the sample floor is visibly different rather than hidden or smoothed.
+function drawAutonomySeries(ctx, { points, key, color, xAt, yAt }) {
+  ctx.strokeStyle = color;
+  ctx.lineWidth = 1.6;
+  for (let i = 1; i < points.length; i++) {
+    const a = points[i - 1], b = points[i];
+    if (!a || !b) continue; // a gap is a gap: never interpolate across it
+    ctx.save();
+    ctx.setLineDash(a.thin || b.thin ? [3, 3] : []);
+    ctx.globalAlpha = (a.thin || b.thin) ? 0.55 : 1;
+    ctx.beginPath();
+    ctx.moveTo(xAt(i - 1), yAt(a[key]));
+    ctx.lineTo(xAt(i), yAt(b[key]));
+    ctx.stroke();
+    ctx.restore();
+  }
+  // Hollow markers on thin buckets, and a solid dot on an isolated bucket that
+  // has no neighbour to draw a segment to (which would otherwise vanish).
+  for (let i = 0; i < points.length; i++) {
+    const b = points[i];
+    if (!b) continue;
+    const isolated = !points[i - 1] && !points[i + 1];
+    if (!b.thin && !isolated) continue;
+    ctx.beginPath();
+    ctx.arc(xAt(i), yAt(b[key]), 2.5, 0, Math.PI * 2);
+    if (b.thin) {
+      ctx.strokeStyle = color;
+      ctx.globalAlpha = 0.7;
+      ctx.stroke();
+      ctx.globalAlpha = 1;
+    } else {
+      ctx.fillStyle = color;
+      ctx.fill();
+    }
+  }
+}
+
+// renderAutonomyStrip draws element 2: one row per project, ordered by the
+// daemon (busiest first), each a canvas of collapsed columns.
+function renderAutonomyStrip() {
+  const rowsEl = document.getElementById('history-autonomy-rows');
+  const titleEl = document.getElementById('history-autonomy-strip-title');
+  const legendEl = document.getElementById('history-autonomy-legend');
+  const noteEl = document.getElementById('history-autonomy-note');
+  const spans = historyState.autonomyData?.spans;
+  if (titleEl) titleEl.textContent = 'Runs · last ' + (AUTONOMY_SPAN_LABELS[historyState.autonomySpan] || historyState.autonomySpan);
+  if (!rowsEl) return;
+  rowsEl.innerHTML = '';
+  if (legendEl) legendEl.innerHTML = '';
+  if (noteEl) noteEl.textContent = '';
+
+  const projects = spans?.projects || [];
+  if (!projects.length) {
+    const empty = document.createElement('div');
+    empty.className = 'history-autonomy-empty';
+    empty.textContent = autonomyEverRecorded()
+      ? 'No runs in the last ' + (AUTONOMY_SPAN_LABELS[historyState.autonomySpan] || historyState.autonomySpan)
+        + '. ' + (spans?.total_recorded || 0) + ' runs are on record over a longer period.'
+      : 'No runs recorded yet — this strip fills in as sessions run.';
+    rowsEl.appendChild(empty);
+    return;
+  }
+
+  const cs = getComputedStyle(document.documentElement);
+  for (const project of projects) {
+    rowsEl.appendChild(buildAutonomyStripRow(project, spans, cs));
+  }
+  if (legendEl) {
+    for (const [reason, glyph, label] of AUTONOMY_REASON_LEGEND) {
+      const item = document.createElement('span');
+      item.className = 'history-autonomy-legend-item';
+      const swatch = document.createElement('i');
+      swatch.style.background = autonomyReasonColor(reason, cs);
+      item.appendChild(swatch);
+      item.appendChild(document.createTextNode(glyph + ' ' + label));
+      legendEl.appendChild(item);
+    }
+  }
+  if (noteEl && spans.truncated) {
+    noteEl.textContent = 'This window holds more runs than one request returns; the strip shows the oldest part of it. '
+      + 'Pick a shorter span for a complete picture.';
+  }
+}
+
+function buildAutonomyStripRow(project, spans, cs) {
+  const row = document.createElement('div');
+  row.className = 'history-autonomy-row';
+
+  const label = document.createElement('span');
+  label.className = 'history-autonomy-label';
+  label.textContent = project;
+  row.appendChild(label);
+
+  const mine = (spans.spans || []).filter(sp => sp.project === project);
+  const longest = mine.reduce((m, sp) => Math.max(m, (sp.end || 0) - (sp.start || 0)), 0);
+
+  const canvas = document.createElement('canvas');
+  canvas.className = 'history-autonomy-canvas';
+  canvas.setAttribute('role', 'img');
+  canvas.setAttribute('aria-label', project + ': ' + mine.length + ' runs, longest ' + autonomyDuration(longest));
+  row.appendChild(canvas);
+
+  const val = document.createElement('span');
+  val.className = 'history-autonomy-val';
+  val.textContent = autonomyDuration(longest);
+  row.appendChild(val);
+
+  // Painted on the next frame: the canvas has no layout width until it is in
+  // the document, and a zero-width canvas would collapse every span into
+  // nothing — the exact failure the minimum-one-column rule exists to prevent.
+  requestAnimationFrame(() => paintAutonomyStripRow(canvas, mine, spans, cs));
+  return row;
+}
+
+function paintAutonomyStripRow(canvas, mine, spans, cs) {
+  const dpr = window.devicePixelRatio || 1;
+  const w = canvas.offsetWidth || 300;
+  const h = canvas.offsetHeight || 14;
+  const pxW = Math.max(1, Math.round(w * dpr)), pxH = Math.max(1, Math.round(h * dpr));
+  if (canvas.width !== pxW || canvas.height !== pxH) { canvas.width = pxW; canvas.height = pxH; }
+  const ctx = canvas.getContext('2d');
+  if (!ctx) return;
+  ctx.setTransform(1, 0, 0, 1, 0, 0); // draw in DEVICE pixels: one column = one pixel
+  ctx.clearRect(0, 0, pxW, pxH);
+  const cells = collapseAutonomyStrip(mine, spans.start, spans.end, pxW);
+  for (let i = 0; i < cells.length; i++) {
+    if (!cells[i].occupied) continue;
+    ctx.fillStyle = autonomyReasonColor(cells[i].reason, cs);
+    ctx.fillRect(i, 0, 1, pxH);
+  }
+}
+
+// renderAutonomyPanel fills the shared side panel with element 1's figures.
+// The true extremes are FIGURES here and deliberately not lines on the chart:
+// one overnight run would otherwise redraw the whole Y scale.
+function renderAutonomyPanel() {
+  const titleEl = document.getElementById('history-panel-title');
+  const totalEl = document.getElementById('history-total');
+  const fcEl = document.getElementById('history-forecast-line');
+  const listEl = document.getElementById('history-contrib');
+  const duration = historyState.autonomyData?.duration;
+  if (titleEl) titleEl.textContent = 'Autonomy · ' + (AUTONOMY_RANGE_LABELS[historyState.autonomyRange] || historyState.autonomyRange);
+  const s = duration?.summary || {};
+  if (totalEl) totalEl.textContent = (s.count || 0) > 0 ? autonomyDuration(s.p50) : '—';
+  if (fcEl) fcEl.textContent = (s.count || 0) > 0 ? 'median run · ' + s.count + ' runs' : '';
+  if (!listEl) return;
+  listEl.innerHTML = '';
+  if (!(s.count > 0)) {
+    appendHistoryEmpty(listEl, autonomyEverRecorded()
+      ? 'no runs in this range'
+      : 'nothing recorded yet');
+  } else {
+    const rows = [
+      ['p95 (good runs)', autonomyDuration(s.p95)],
+      ['p50 (typical run)', autonomyDuration(s.p50)],
+      ['p5 (bad runs)', autonomyDuration(s.p5)],
+      ['longest', autonomyDuration(s.max)],
+      ['shortest', autonomyDuration(s.min)],
+      ['runs', String(s.count)],
+    ];
+    for (const [label, value] of rows) {
+      const li = document.createElement('li');
+      const dot = document.createElement('span');
+      dot.className = 'dot';
+      dot.style.background = 'transparent';
+      const lbl = document.createElement('span');
+      lbl.className = 'label';
+      lbl.textContent = label;
+      const val = document.createElement('span');
+      val.className = 'val';
+      val.textContent = value;
+      li.appendChild(dot);
+      li.appendChild(lbl);
+      li.appendChild(val);
+      listEl.appendChild(li);
+    }
+    const thin = (duration.buckets || []).filter(b => b.thin).length;
+    if (thin > 0) {
+      appendHistoryEmpty(listEl, thin + ' of ' + duration.buckets.length + ' buckets hold fewer than '
+        + duration.sample_floor + ' runs (dashed, hollow): there p95 is that bucket’s longest run '
+        + 'and p5 its shortest — not percentiles.');
+    }
+  }
+  // The provenance line is part of the feature: "no data" must never read as
+  // "you did nothing".
+  appendHistoryEmpty(listEl, autonomyProvenanceLine(duration));
 }
 
 // --- Activity matrix (chart=state, issue #981) ---
@@ -1115,6 +1582,8 @@ function syncHistorySelectors() {
   if (chartSeg) for (const b of chartSeg.querySelectorAll('button')) b.classList.toggle('active', b.dataset.chart === historyState.chart);
   const metricsSeg = document.getElementById('history-metrics-sel');
   if (metricsSeg) for (const b of metricsSeg.querySelectorAll('button')) b.classList.toggle('active', b.dataset.chart === historyState.chart);
+  const autonomySeg = document.getElementById('history-autonomy-sel');
+  if (autonomySeg) for (const b of autonomySeg.querySelectorAll('button')) b.classList.toggle('active', b.dataset.chart === historyState.chart);
   const groupSeg = document.getElementById('history-group-sel');
   if (groupSeg) for (const b of groupSeg.querySelectorAll('button')) b.classList.toggle('active', b.dataset.group === historyState.group);
 }
@@ -1376,10 +1845,27 @@ function seriesCsvLines(d) {
   return lines;
 }
 
+// autonomyCsvLines exports the spans themselves — the raw rows both elements
+// are derived from, so a spreadsheet can re-derive either.
+function autonomyCsvLines() {
+  const spans = historyState.autonomyData?.spans?.spans || [];
+  const lines = ['start,end,duration_seconds,project,session,reason'];
+  for (const sp of spans) {
+    lines.push([
+      new Date(sp.start * 1000).toISOString(), new Date(sp.end * 1000).toISOString(),
+      String(Math.max(0, (sp.end || 0) - (sp.start || 0))),
+      historyCsvCell(sp.project || ''), historyCsvCell(sp.session || ''),
+      historyCsvCell(sp.reason || ''),
+    ].join(','));
+  }
+  return lines;
+}
+
 const HISTORY_CSV_BUILDERS = {
   yield: yieldCsvLines,
   state: stateCsvLines,
   dora: doraCsvLines,
+  autonomy: autonomyCsvLines,
 };
 
 function exportHistoryCSV() {
@@ -1389,7 +1875,8 @@ function exportHistoryCSV() {
   historyDownload('irrlicht-history-' + historyState.range + '-' + historyState.chart + '.csv', 'text/csv;charset=utf-8', build(d).join('\n') + '\n');
 }
 function exportHistoryJSON() {
-  const d = historyState.data;
+  // Autonomy exports BOTH payloads: either alone is a partial answer.
+  const d = historyState.chart === 'autonomy' ? historyState.autonomyData : historyState.data;
   if (!d) return;
   historyDownload('irrlicht-history-' + historyState.range + '-' + historyState.chart + '.json', 'application/json', JSON.stringify(d, null, 2));
 }
@@ -1444,6 +1931,7 @@ export function initHistoryTab() {
     if (c === 'models') historyState.group = 'model';
     else if (c === 'providers') historyState.group = 'provider';
     else if (c === 'agents' || c === 'state') historyState.group = 'project'; // recordings carry no other axis
+    else if (c === 'autonomy') historyState.group = 'project'; // spans carry no other axis
     else if (c !== 'tokens' && historyState.group === 'token_type') historyState.group = 'project'; // token_type needs the tokens metric
     historyState.scope = null; // a new metric resets any drilldown
     syncHistorySelectors();
@@ -1453,6 +1941,24 @@ export function initHistoryTab() {
   if (histChartSeg) histChartSeg.addEventListener('click', handleChartClick);
   const histMetricsSeg = document.getElementById('history-metrics-sel');
   if (histMetricsSeg) histMetricsSeg.addEventListener('click', handleChartClick);
+  const histAutonomySeg = document.getElementById('history-autonomy-sel');
+  if (histAutonomySeg) histAutonomySeg.addEventListener('click', handleChartClick);
+
+  // The two Autonomy pickers. Each re-fetches only because the section shows
+  // both elements together; the daemon serves them as two independent charts.
+  const wireAutonomyPicker = (id, attr, key) => {
+    const seg = document.getElementById(id);
+    if (!seg) return;
+    seg.addEventListener('click', (e) => {
+      const b = e.target.closest('button[data-' + attr + ']');
+      if (!b) return;
+      for (const x of seg.querySelectorAll('button')) x.classList.toggle('active', x === b);
+      historyState[key] = b.dataset[attr === 'autonomy-range' ? 'autonomyRange' : 'autonomySpan'];
+      fetchHistory();
+    });
+  };
+  wireAutonomyPicker('history-autonomy-range-sel', 'autonomy-range', 'autonomyRange');
+  wireAutonomyPicker('history-autonomy-span-sel', 'autonomy-span', 'autonomySpan');
 
   const histDoraProjectSel = document.getElementById('history-dora-project');
   if (histDoraProjectSel) histDoraProjectSel.addEventListener('change', () => {

--- a/platforms/web/index.html
+++ b/platforms/web/index.html
@@ -265,12 +265,35 @@
             <button type="button" data-chart="yield" title="Metrics: productive vs reverted spend per project">Yield</button>
             <button type="button" data-chart="dora" title="Metrics: DORA deployment metrics per project">DORA</button>
           </fieldset>
+          <!-- Autonomy (#1905) is its own top-level section, not another chart
+               type: it holds TWO elements over the span log and uses neither
+               Range, Group, nor the drilldown filters. On macOS it is a fifth
+               HistoryTab; here, where there is no tab strip, a third segmented
+               group is the equivalent. -->
+          <fieldset class="history-seg" id="history-autonomy-sel" aria-label="Autonomy">
+            <button type="button" data-chart="autonomy" title="How long sessions ran without needing a human">Autonomy</button>
+          </fieldset>
         </div>
         <div class="history-ctl-row" id="history-dora-row" hidden>
           <span class="history-ctl-label">Project</span>
           <select id="history-dora-project" aria-label="DORA project">
             <option value="">Select a project…</option>
           </select>
+        </div>
+        <div class="history-ctl-row" id="history-autonomy-row" hidden>
+          <span class="history-ctl-label">Range</span>
+          <fieldset class="history-seg" id="history-autonomy-range-sel" aria-label="Autonomy chart range">
+            <button type="button" data-autonomy-range="30d" class="active">30 days</button>
+            <button type="button" data-autonomy-range="1y">Year</button>
+          </fieldset>
+          <span class="history-ctl-label">Span</span>
+          <fieldset class="history-seg" id="history-autonomy-span-sel" aria-label="Autonomy strip span">
+            <button type="button" data-autonomy-span="8h">8h</button>
+            <button type="button" data-autonomy-span="24h" class="active">24h</button>
+            <button type="button" data-autonomy-span="7d">7d</button>
+            <button type="button" data-autonomy-span="30d">30d</button>
+            <button type="button" data-autonomy-span="12mo">12mo</button>
+          </fieldset>
         </div>
         <div class="history-ctl-row" id="history-granularity-row" hidden>
           <span class="history-ctl-label">Granularity</span>
@@ -336,6 +359,17 @@
           </div>
         </aside>
       </div>
+
+      <!-- Element 2 of the Autonomy section (#1905): one row per project,
+           each span drawn at its true length and colored by what ended it.
+           Full width under the chart because it is a SECOND element, not
+           another rendering of the first. -->
+      <section class="history-autonomy" id="history-autonomy-strip" hidden aria-label="Autonomous runs">
+        <div class="history-autonomy-title" id="history-autonomy-strip-title">Runs</div>
+        <div class="history-autonomy-rows" id="history-autonomy-rows"></div>
+        <div class="history-autonomy-legend" id="history-autonomy-legend"></div>
+        <div class="history-autonomy-note" id="history-autonomy-note"></div>
+      </section>
     </section>
   </main>
 

--- a/platforms/web/irrlicht.css
+++ b/platforms/web/irrlicht.css
@@ -1755,6 +1755,44 @@
     .history-co2-info:hover { color: var(--text-bright); background: var(--working); }
     .history-co2-info[hidden] { display: none; }
 
+    /* Autonomy run strip (#1905), element 2 of the Autonomy section. A
+       full-width block UNDER the chart card rather than inside it: it is a
+       second element, not another rendering of the first, and it grows a row
+       per project instead of living in a fixed-height card. */
+    .history-autonomy { margin-top: 18px; }
+    .history-autonomy[hidden] { display: none; }
+    .history-autonomy-title {
+      font-family: var(--font-mono); font-size: 11px; letter-spacing: 0.08em;
+      text-transform: uppercase; color: var(--muted); margin-bottom: 8px;
+    }
+    .history-autonomy-row {
+      display: grid; grid-template-columns: 140px 1fr 56px;
+      align-items: center; gap: 10px; margin-bottom: 6px;
+    }
+    .history-autonomy-label {
+      font-size: 12px; color: var(--text); overflow: hidden;
+      text-overflow: ellipsis; white-space: nowrap;
+    }
+    .history-autonomy-canvas {
+      width: 100%; height: 14px; display: block;
+      background: var(--surface); border: 1px solid var(--border); border-radius: 3px;
+    }
+    .history-autonomy-val {
+      font-family: var(--font-mono); font-size: 11px; color: var(--muted); text-align: right;
+    }
+    .history-autonomy-empty, .history-autonomy-note {
+      font-size: 12px; color: var(--muted); padding: 8px 0; line-height: 1.5;
+    }
+    .history-autonomy-note { color: var(--waiting); }
+    .history-autonomy-legend {
+      display: flex; flex-wrap: wrap; gap: 14px; margin-top: 8px;
+      font-size: 11px; color: var(--muted);
+    }
+    .history-autonomy-legend-item { display: inline-flex; align-items: center; gap: 5px; }
+    .history-autonomy-legend-item i {
+      display: inline-block; width: 10px; height: 8px; border-radius: 1px;
+    }
+
     /* Activity matrix (chart=state, issue #981): projects × time buckets,
        each cell a stacked working/waiting/ready mini bar. Replaces the
        canvas inside the same .history-chart-wrap card (see

--- a/platforms/web/irrlicht.css
+++ b/platforms/web/irrlicht.css
@@ -1780,6 +1780,20 @@
     .history-autonomy-val {
       font-family: var(--font-mono); font-size: 11px; color: var(--muted); text-align: right;
     }
+    /* Column header over the per-row "longest" figure, and the window's own
+       bounds under the strip — both reuse .history-autonomy-row's grid so they
+       line up with the column they describe. */
+    .history-autonomy-head .history-autonomy-label,
+    .history-autonomy-head .history-autonomy-val {
+      font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.06em;
+      text-transform: uppercase; color: var(--muted);
+    }
+    .history-autonomy-axis { margin-top: 2px; }
+    .history-autonomy-axis-bounds {
+      display: flex; justify-content: space-between;
+      font-family: var(--font-mono); font-size: 10px; color: var(--muted);
+    }
+    .history-autonomy-axis-bounds i { font-style: normal; }
     .history-autonomy-empty, .history-autonomy-note {
       font-size: 12px; color: var(--muted); padding: 8px 0; line-height: 1.5;
     }

--- a/platforms/web/irrlicht.history.autonomy.test.js
+++ b/platforms/web/irrlicht.history.autonomy.test.js
@@ -4,10 +4,16 @@ import {
   AUTONOMY_RANGE_LABELS,
   AUTONOMY_SPAN_LABELS,
   AUTONOMY_REASON_PRIORITY,
+  AUTONOMY_SERIES,
   autonomyQuery,
   autonomyChartPoints,
   autonomyDuration,
   autonomyProvenanceLine,
+  autonomyAxisLabel,
+  autonomySeriesColor,
+  autonomyPanelRows,
+  buildAutonomyStripHeader,
+  buildAutonomyStripAxis,
   collapseAutonomyStrip,
 } from './historyTab.js'
 import { historyPriorityForState } from './irrlicht.js'
@@ -168,6 +174,128 @@ describe('“no data” never reads as “you did nothing”', () => {
     const line = autonomyProvenanceLine({ earliest_span: 1_700_000_000, total_recorded: 312 })
     expect(line).toMatch(/Collecting since/)
     expect(line).toMatch(/312 runs recorded/)
+  })
+})
+
+describe('the chart names its three lines', () => {
+  // QA found three unlabelled curves on the web: the panel built p95/p50/p5
+  // rows and then blanked every swatch (`background = 'transparent'`), so the
+  // only way to tell the lines apart was vertical order. These pin the key.
+  //
+  // `cs` here returns '' for every custom property, which is what an unstyled
+  // document (and jsdom) gives — so this exercises the fallback branch, the
+  // one a stylesheet-less render actually takes.
+  const unstyled = { getPropertyValue: () => '' }
+
+  test('every drawn line resolves to a non-empty colour', () => {
+    for (const [key] of AUTONOMY_SERIES) {
+      expect(autonomySeriesColor(key, unstyled)).toBeTruthy()
+    }
+  })
+
+  test('the three line colours are distinct', () => {
+    const colors = AUTONOMY_SERIES.map(([key]) => autonomySeriesColor(key, unstyled))
+    expect(new Set(colors).size).toBe(AUTONOMY_SERIES.length)
+  })
+
+  test('the series table covers exactly the three drawn lines', () => {
+    expect(AUTONOMY_SERIES.map(([key]) => key)).toEqual(['p95', 'p50', 'p5'])
+  })
+
+  test('a key that is not a drawn line gets no colour', () => {
+    // longest/shortest/runs are FIGURES, not lines. A swatch for one of them
+    // would claim a curve the chart deliberately does not draw.
+    expect(autonomySeriesColor('longest', unstyled)).toBe('')
+    expect(autonomySeriesColor('p90', unstyled)).toBe('')
+  })
+
+  test('a themed document wins over the fallback', () => {
+    const themed = { getPropertyValue: (name) => (name === '--ready' ? ' #123456 ' : '') }
+    expect(autonomySeriesColor('p95', themed)).toBe('#123456')
+    expect(autonomySeriesColor('p50', themed)).toBe('#8B5CF6')
+  })
+
+  // THE DEFECT ITSELF. The panel used to build these rows and then set every
+  // dot to `transparent`, so the key existed in the markup and said nothing.
+  // Asserting on the resolver alone would not have caught that; these assert
+  // on the rows the panel actually renders.
+  const summary = { p95: 3600, p50: 600, p5: 30, min: 8, max: 7200, count: 312 }
+  const unstyledCS = { getPropertyValue: () => '' }
+
+  test('the three line rows carry non-empty, distinct swatches', () => {
+    const rows = autonomyPanelRows(summary, unstyledCS)
+    const lines = rows.filter(r => r.series)
+    expect(lines.map(r => r.series)).toEqual(['p95', 'p50', 'p5'])
+    for (const row of lines) {
+      expect(row.swatch).toBeTruthy()
+      expect(row.swatch).not.toBe('transparent')
+    }
+    expect(new Set(lines.map(r => r.swatch)).size).toBe(3)
+  })
+
+  test('the figures stay unswatched — they are not lines', () => {
+    const figures = autonomyPanelRows(summary, unstyledCS).filter(r => !r.series)
+    expect(figures.map(r => r.label)).toEqual(['longest', 'shortest', 'runs'])
+    for (const row of figures) expect(row.swatch).toBe('transparent')
+  })
+
+  test('every line row names its percentile in words', () => {
+    for (const row of autonomyPanelRows(summary, unstyledCS).filter(r => r.series)) {
+      expect(row.label).toContain(row.series)
+      expect(row.label.length).toBeGreaterThan(row.series.length)
+    }
+  })
+
+  test('an empty summary still produces the full key', () => {
+    const rows = autonomyPanelRows(undefined, unstyledCS)
+    expect(rows).toHaveLength(6)
+    expect(rows[5].value).toBe('0')
+  })
+})
+
+describe('the strip labels its value column and its window', () => {
+  test('the header names the value column', () => {
+    const head = buildAutonomyStripHeader()
+    expect(head.textContent).toContain('longest')
+    // Same grid as a data row, so the header lands over the column it names.
+    expect(head.className).toContain('history-autonomy-row')
+    expect(head.children).toHaveLength(3)
+  })
+
+  test('the axis states where the window starts and that it ends now', () => {
+    const now = Math.floor(Date.UTC(2026, 0, 9) / 1000)
+    const start = now - 7 * 86400
+    const axis = buildAutonomyStripAxis({ start, end: now })
+    const bounds = axis.querySelector('.history-autonomy-axis-bounds')
+    expect(bounds).toBeTruthy()
+    expect(bounds.children).toHaveLength(2)
+    expect(bounds.children[1].textContent).toBe('now')
+    // The left bound must be a HUMAN label, not the raw epoch seconds — the
+    // whole point is that a mark can be placed in time by reading it.
+    expect(bounds.children[0].textContent).toBe(autonomyAxisLabel(start, now - start))
+    expect(bounds.children[0].textContent).not.toContain(String(start))
+  })
+})
+
+describe('the strip states its own time bounds', () => {
+  // Without them the strip is texture: at 30d and 12mo a mark cannot be
+  // placed in time at all.
+  const jan2 = Date.UTC(2026, 0, 2, 15, 30) / 1000
+
+  test('a short window labels a time of day, a long one a date', () => {
+    expect(autonomyAxisLabel(jan2, 8 * 3600)).toMatch(/\d/)
+    expect(autonomyAxisLabel(jan2, 8 * 3600)).not.toMatch(/Jan/)
+    expect(autonomyAxisLabel(jan2, 7 * 86400)).toMatch(/Jan/)
+  })
+
+  test('a year-long window coarsens to a month, not a day', () => {
+    const label = autonomyAxisLabel(jan2, 365 * 86400)
+    expect(label).toMatch(/Jan/)
+    expect(label).toMatch(/2026/)
+  })
+
+  test('a missing timestamp still renders something', () => {
+    expect(autonomyAxisLabel(undefined, 86400)).toBeTruthy()
   })
 })
 

--- a/platforms/web/irrlicht.history.autonomy.test.js
+++ b/platforms/web/irrlicht.history.autonomy.test.js
@@ -1,0 +1,182 @@
+import { describe, test, expect } from 'vitest'
+
+import {
+  AUTONOMY_RANGE_LABELS,
+  AUTONOMY_SPAN_LABELS,
+  AUTONOMY_REASON_PRIORITY,
+  autonomyQuery,
+  autonomyChartPoints,
+  autonomyDuration,
+  autonomyProvenanceLine,
+  collapseAutonomyStrip,
+} from './historyTab.js'
+import { historyPriorityForState } from './irrlicht.js'
+
+// The Autonomy section (#1905): the strip's pixel-collapse rule, the
+// gap-not-zero rule, the two window vocabularies staying distinct, and the
+// wording that keeps an empty view from reading as "you did nothing".
+
+const span = (start, end, reason, project = 'p') => ({ start, end, reason, project, session: 's' + start })
+
+describe('collapseAutonomyStrip — the pixel-collapse rule', () => {
+  // Every span draws at a minimum of one column. At 12mo a 40-second run is
+  // far under one device pixel; rounding it away would erase exactly the short
+  // runs the p5 line is about.
+  test('a sub-pixel run still occupies exactly one column', () => {
+    const cells = collapseAutonomyStrip([span(50_000, 50_001, 'ready')], 0, 100_000, 10)
+    expect(cells).toHaveLength(10)
+    const occupied = cells.filter(c => c.occupied)
+    expect(occupied).toHaveLength(1)
+    expect(occupied[0].reason).toBe('ready')
+  })
+
+  test('a shared column takes the highest-priority reason, whatever the order', () => {
+    // One state per line: a line naming three of the four canonical states is
+    // what tools/state-vocabulary-lint.sh refuses, and rightly — such a list is
+    // complete when written and silently stale one state later.
+    const spans = [
+      span(1_000, 1_100, 'ready'),
+      span(1_200, 1_300, 'error'),
+      span(1_400, 1_500, 'waiting'),
+    ]
+    expect(collapseAutonomyStrip(spans, 0, 100_000, 10)[0].reason).toBe('error')
+    expect(collapseAutonomyStrip([...spans].reverse(), 0, 100_000, 10)[0].reason).toBe('error')
+    // …and without the error, waiting beats ready.
+    const noError = [span(1_000, 1_100, 'ready'), span(1_400, 1_500, 'waiting')]
+    expect(collapseAutonomyStrip(noError, 0, 100_000, 10)[0].reason).toBe('waiting')
+  })
+
+  test('the ladder matches the session-history strip’s', () => {
+    // Two hand-written copies of one ORDER (the bar also ranks `working`,
+    // which is never an end reason, so only the order can be compared).
+    const ordered = Object.keys(AUTONOMY_REASON_PRIORITY)
+      .sort((a, b) => AUTONOMY_REASON_PRIORITY[b] - AUTONOMY_REASON_PRIORITY[a])
+    expect(ordered[0]).toBe('error')
+    expect(ordered[1]).toBe('waiting')
+    expect(ordered[2]).toBe('ready')
+    expect(ordered).toHaveLength(3)
+    for (let i = 1; i < ordered.length; i++) {
+      expect(historyPriorityForState(ordered[i - 1]))
+        .toBeGreaterThan(historyPriorityForState(ordered[i]))
+    }
+  })
+
+  test('a long run covers every column it spans', () => {
+    const cells = collapseAutonomyStrip([span(0, 50_000, 'waiting')], 0, 100_000, 10)
+    expect(cells.filter(c => c.occupied)).toHaveLength(6)
+  })
+
+  test('runs outside the window are clipped, not drawn', () => {
+    const before = collapseAutonomyStrip([span(-5_000, -1_000, 'ready')], 0, 100_000, 10)
+    expect(before.some(c => c.occupied)).toBe(false)
+    const straddling = collapseAutonomyStrip([span(-5_000, 10_000, 'ready')], 0, 100_000, 10)
+    expect(straddling[0].occupied).toBe(true)
+    expect(straddling[5].occupied).toBe(false)
+  })
+
+  test('an unnamed reason still occupies its column and never outranks a real one', () => {
+    const unknown = span(10, 20, 'martian')
+    const cells = collapseAutonomyStrip([unknown], 0, 100, 10)
+    expect(cells[1].occupied).toBe(true)
+    expect(cells[1].reason).toBe(null)
+    expect(collapseAutonomyStrip([unknown, span(11, 19, 'error')], 0, 100, 10)[1].reason).toBe('error')
+  })
+
+  test('degenerate inputs produce no columns', () => {
+    expect(collapseAutonomyStrip([], 0, 0, 10)).toEqual([])
+    expect(collapseAutonomyStrip([], 0, 100, 0)).toEqual([])
+  })
+})
+
+describe('autonomyChartPoints — an empty bucket is a gap, not a zero', () => {
+  // The daemon omits empty buckets; the client must keep them absent so the
+  // stroke BREAKS there. Interpolating (or substituting a zero) would pull the
+  // line to the axis on a day with no runs, which reads as "runs got shorter".
+  test('omitted buckets come back as nulls aligned to the axis', () => {
+    const points = autonomyChartPoints({
+      bucket_starts: [100, 200, 300, 400],
+      buckets: [
+        { ts: 100, p95: 90, p50: 50, p5: 10, min: 10, max: 90, count: 30 },
+        { ts: 400, p95: 80, p50: 40, p5: 8, min: 8, max: 80, count: 25 },
+      ],
+    })
+    expect(points).toHaveLength(4)
+    expect(points[0]).not.toBeNull()
+    expect(points[1]).toBeNull()
+    expect(points[2]).toBeNull()
+    expect(points[3]).not.toBeNull()
+
+    // THE COMMITTED MUTATION: the "just densify with zeros" build. If
+    // production ever did this, a quiet day would draw a point at the floor
+    // instead of a break in the line — and this expectation is what fails.
+    const densified = points.map(b => b || { ts: 0, p95: 0, p50: 0, p5: 0, min: 0, max: 0, count: 0 })
+    expect(densified.filter(b => b.count === 0)).toHaveLength(2)
+    expect(points.filter(b => b === null)).toHaveLength(2)
+  })
+
+  test('a fully populated range has no gaps', () => {
+    const points = autonomyChartPoints({
+      bucket_starts: [1, 2],
+      buckets: [{ ts: 1, p50: 5 }, { ts: 2, p50: 6 }],
+    })
+    expect(points.every(Boolean)).toBe(true)
+  })
+
+  test('a missing payload is an empty axis, not a crash', () => {
+    expect(autonomyChartPoints(null)).toEqual([])
+    expect(autonomyChartPoints({})).toEqual([])
+  })
+})
+
+describe('the two window vocabularies stay distinct', () => {
+  // The trap #1905 calls out by name: chart=state's granularity keys and the
+  // Autonomy windows OVERLAP textually and mean different things — a
+  // granularity is a bucket width times a count ('24h' → a 30-DAY window),
+  // an autonomy window IS the window.
+  test('each element sends its own ?window=, and neither is a granularity', () => {
+    const state = { autonomyRange: '1y', autonomySpan: '12mo' }
+    expect(autonomyQuery('duration', state)).toBe('chart=autonomy_duration&window=1y')
+    expect(autonomyQuery('spans', state)).toBe('chart=autonomy_spans&window=12mo')
+  })
+
+  test('the two pickers offer different sets, and neither is the granularity set', () => {
+    expect(Object.keys(AUTONOMY_RANGE_LABELS)).toEqual(['30d', '1y'])
+    expect(Object.keys(AUTONOMY_SPAN_LABELS)).toEqual(['8h', '24h', '7d', '30d', '12mo'])
+    // 12mo is the strip's own key and has no granularity twin; if it ever
+    // disappears, the vocabularies may have been merged.
+    expect(AUTONOMY_SPAN_LABELS['12mo']).toBeTruthy()
+    // The chart's range vocabulary must not silently gain the strip's keys.
+    expect(AUTONOMY_RANGE_LABELS['24h']).toBeUndefined()
+  })
+
+  test('a strip key is never sent to the duration chart', () => {
+    // The daemon 400s this pairing; the client must not be the thing that
+    // constructs it in the first place.
+    expect(autonomyQuery('duration', { autonomyRange: '30d', autonomySpan: '8h' }))
+      .toBe('chart=autonomy_duration&window=30d')
+  })
+})
+
+describe('“no data” never reads as “you did nothing”', () => {
+  test('an empty log says collection just started', () => {
+    const line = autonomyProvenanceLine({ earliest_span: 0, total_recorded: 0 })
+    expect(line).toMatch(/began measuring/)
+    expect(line).not.toMatch(/^0 runs$/)
+  })
+
+  test('a seeded log names the date collection started and the total', () => {
+    const line = autonomyProvenanceLine({ earliest_span: 1_700_000_000, total_recorded: 312 })
+    expect(line).toMatch(/Collecting since/)
+    expect(line).toMatch(/312 runs recorded/)
+  })
+})
+
+describe('autonomyDuration', () => {
+  test('formats seconds through days', () => {
+    expect(autonomyDuration(41)).toBe('41s')
+    expect(autonomyDuration(660)).toBe('11m')
+    expect(autonomyDuration(7080)).toBe('1h58m')
+    expect(autonomyDuration(86_400)).toBe('1d')
+    expect(autonomyDuration(0)).toBe('0s')
+  })
+})

--- a/tools/preflight.sh
+++ b/tools/preflight.sh
@@ -644,6 +644,12 @@ if want go; then
   # is the one moment it must work (docs/elfdans-device-test.md Phase 5).
   run_gate_scoped '^tools/elfdans-drive/|^core/adapters/outbound/relay/|^core/domain/session/' \
                   "elfdans-drive builds"      go build ./tools/elfdans-drive/...
+  # seed-autonomy-spans (#1905) writes a synthetic span log for QA. Its guard —
+  # refuse a span directory this tool did not create — has no "before the fix"
+  # to run red, so the mutation fixture in its own tests is the only thing that
+  # proves it works, and a test nothing runs proves nothing.
+  run_gate_scoped '^tools/seed-autonomy-spans/|^core/adapters/outbound/filesystem/autonomy_tracker\.go$' \
+                  "seed-autonomy-spans tests" go test ./tools/seed-autonomy-spans/... -count=1
   run_gate_scoped '^tools/onboarding-factory/desktop-helper/' \
                   "Claude Desktop helper tests" tools/onboarding-factory/desktop-helper/test.sh
   run_gate_scoped '^replaydata/|^tools/onboarding-factory/' \

--- a/tools/seed-autonomy-spans/go.mod
+++ b/tools/seed-autonomy-spans/go.mod
@@ -1,0 +1,7 @@
+module irrlicht/tools/seed-autonomy-spans
+
+go 1.25.12
+
+require irrlicht/core v0.0.0
+
+replace irrlicht/core => ../../core

--- a/tools/seed-autonomy-spans/main.go
+++ b/tools/seed-autonomy-spans/main.go
@@ -1,0 +1,284 @@
+// seed-autonomy-spans writes a synthetic autonomy span log (#1905) into a
+// given Irrlicht data dir, so the History view's Autonomy section can be
+// screenshotted with realistic data on a machine that has none.
+//
+// A fresh install has no spans — the log starts collecting the day the feature
+// ships — so every QA pass of this section would otherwise look at the empty
+// state and nothing else.
+//
+// It writes through the daemon's own AutonomySpanTracker rather than
+// hand-rolling JSONL, so the seeded rows cannot drift from the format the
+// daemon reads. That also means it obeys the same "one file per project"
+// layout and the same 400-day retention.
+//
+// Usage:
+//
+//	go run ./tools/seed-autonomy-spans <data-dir> [--overwrite] [--seed N] [--days N]
+//
+// where <data-dir> is the daemon's data directory: $IRRLICHT_HOME for an
+// isolated daemon, or ~/Library/Application Support/Irrlicht for the packaged
+// app. Spans land in <data-dir>/autonomy/<project>.jsonl.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"irrlicht/core/adapters/outbound/filesystem"
+	"irrlicht/core/domain/session"
+	"irrlicht/core/ports/outbound"
+)
+
+// autonomyDirName must match the daemon's own subdirectory (see
+// initAutonomySpanStore in core/cmd/irrlichd/startup.go). Stated here rather
+// than imported because it is unexported there; seedMarker below is what makes
+// a mismatch loud instead of silent — a wrong directory produces a marker in a
+// place the daemon never reads, and the section stays empty.
+const autonomyDirName = "autonomy"
+
+// seedMarker records that THIS tool created the span directory. Its absence in
+// an existing directory means the directory is someone else's — a real
+// daemon's, most likely — and seeding into it would silently mix synthetic
+// runs into a user's real history.
+const seedMarker = ".seeded-by-seed-autonomy-spans"
+
+// The synthetic corpus' shape. Tuned so that every window both elements offer
+// renders populated:
+//
+//   - the strip's 8h window needs runs in the last eight hours (recentBurst);
+//   - the duration chart's 30d range needs DAILY buckets on both sides of the
+//     20-span floor, so QA sees the thin rendering AND the normal one;
+//   - its 1y range needs WEEKLY buckets that also straddle that floor, which
+//     is why the older days are sparse-but-not-empty rather than empty: at
+//     1-6 runs a day a week lands around 25, on both sides of 20.
+const (
+	recentDays        = 30
+	recentSpansMin    = 6
+	recentSpansMax    = 34
+	olderSpansMin     = 1
+	olderSpansMax     = 6
+	recentBurst       = 6 // runs forced into the last eight hours
+	defaultTotalDays  = 400
+	medianDurationSec = 480.0 // p50 ≈ 8 minutes
+	durationSigma     = 1.25  // log-normal spread: a long tail into hours
+	maxDurationSec    = 6 * 3600
+)
+
+// seedProject is one synthetic project's identity. Four of them, because the
+// strip draws one row per project and a single-row strip proves nothing about
+// row ordering or the busiest-first rule.
+type seedProject struct {
+	name    string
+	adapter string
+	model   string
+	weight  int // relative share of runs
+}
+
+var seedProjects = []seedProject{
+	{"irrlicht", "claude-code", "claude-opus-4", 5},
+	{"articles", "codex", "gpt-5", 3},
+	{"irrlicht-1719", "claude-code", "claude-sonnet-4", 2},
+	{"dotfiles", "opencode", "qwen3-coder", 1},
+}
+
+// reasonWeights is the end-reason mix. Deliberately not uniform: most runs
+// finish their turn, a good share stop to ask, and errors are the minority —
+// a strip where a third of the columns are red would misrepresent what the
+// colors mean.
+var reasonWeights = []struct {
+	reason string
+	weight int
+}{
+	{session.StateReady, 55},
+	{session.StateWaiting, 35},
+	{session.StateError, 10},
+}
+
+func main() {
+	overwrite := flag.Bool("overwrite", false, "replace an existing span log (refused by default)")
+	seed := flag.Int64("seed", 1905, "PRNG seed; the same seed produces the same corpus")
+	days := flag.Int("days", defaultTotalDays, "how far back to spread runs, in days")
+	flag.Usage = usage
+	flag.Parse()
+
+	if flag.NArg() != 1 {
+		usage()
+		os.Exit(2)
+	}
+	dataDir := flag.Arg(0)
+	spanDir := filepath.Join(dataDir, autonomyDirName)
+
+	if err := guardSpanDir(spanDir, *overwrite); err != nil {
+		fmt.Fprintln(os.Stderr, "refusing to seed:", err)
+		os.Exit(1)
+	}
+	if err := os.MkdirAll(spanDir, 0700); err != nil {
+		fmt.Fprintln(os.Stderr, "cannot create", spanDir+":", err)
+		os.Exit(1)
+	}
+	if err := os.WriteFile(filepath.Join(spanDir, seedMarker),
+		[]byte(time.Now().Format(time.RFC3339)+"\n"), 0600); err != nil {
+		fmt.Fprintln(os.Stderr, "cannot write the seed marker:", err)
+		os.Exit(1)
+	}
+
+	tracker := filesystem.NewAutonomySpanTrackerWithDir(spanDir)
+	spans := generateSpans(rand.New(rand.NewSource(*seed)), time.Now(), *days)
+	for _, s := range spans {
+		if err := tracker.RecordSpan(s); err != nil {
+			fmt.Fprintln(os.Stderr, "write failed:", err)
+			os.Exit(1)
+		}
+	}
+	fmt.Printf("seeded %d autonomy spans across %d projects into %s\n",
+		len(spans), len(seedProjects), spanDir)
+	fmt.Println("restart the daemon (or just reload the dashboard) and open History → Autonomy")
+}
+
+func usage() {
+	fmt.Fprintln(os.Stderr,
+		"seed-autonomy-spans <data-dir> [--overwrite] [--seed N] [--days N] — fill <data-dir>/autonomy "+
+			"with a few hundred synthetic runs so History → Autonomy renders populated in every range and span.")
+	flag.PrintDefaults()
+}
+
+// guardSpanDir refuses to write into a span directory this tool did not create
+// or that already holds spans, unless the caller asked for it explicitly.
+//
+// The point is not tidiness: <data-dir> is normally a live daemon's, and
+// synthetic runs mixed into a real span log are indistinguishable from real
+// ones afterwards — there is no undo, and the charts would be quietly wrong
+// from then on.
+func guardSpanDir(spanDir string, overwrite bool) error {
+	entries, err := os.ReadDir(spanDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil // we will create it
+		}
+		return err
+	}
+	var spanFiles []string
+	seeded := false
+	for _, e := range entries {
+		if e.Name() == seedMarker {
+			seeded = true
+			continue
+		}
+		if !e.IsDir() && strings.HasSuffix(e.Name(), ".jsonl") {
+			spanFiles = append(spanFiles, e.Name())
+		}
+	}
+	if overwrite {
+		for _, name := range spanFiles {
+			if err := os.Remove(filepath.Join(spanDir, name)); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	if !seeded {
+		return fmt.Errorf("%s exists and was not created by this tool — it looks like a real span log; "+
+			"pass --overwrite only if you are sure you want to replace it", spanDir)
+	}
+	if len(spanFiles) > 0 {
+		return fmt.Errorf("%s already holds %d span file(s); pass --overwrite to replace them",
+			spanDir, len(spanFiles))
+	}
+	return nil
+}
+
+// generateSpans builds the synthetic corpus, newest day first, using rng so a
+// given --seed always produces the same picture (a screenshot that changes
+// every run is not evidence of anything).
+func generateSpans(rng *rand.Rand, now time.Time, days int) []outbound.AutonomySpan {
+	var out []outbound.AutonomySpan
+	for day := 0; day < days; day++ {
+		n := spansForDay(rng, day)
+		dayEnd := now.Add(-time.Duration(day) * 24 * time.Hour)
+		for i := 0; i < n; i++ {
+			// Spread across the day, biased towards working hours only in the
+			// crude sense that runs cluster rather than tile evenly.
+			offset := time.Duration(rng.Float64()*24*3600) * time.Second
+			out = append(out, spanEndingAt(rng, dayEnd.Add(-offset)))
+		}
+	}
+	// The strip's shortest window is 8 hours; without runs inside it, the
+	// default view of element 2 is the empty state, which is precisely the
+	// thing a seeded screenshot is supposed to get past.
+	for i := 0; i < recentBurst; i++ {
+		end := now.Add(-time.Duration(rng.Intn(7*3600+1)) * time.Second)
+		out = append(out, spanEndingAt(rng, end))
+	}
+	return out
+}
+
+// spansForDay picks how many runs a given day back from now holds: dense over
+// the last month (straddling the 20-span sample floor, so both the thin and
+// the normal bucket rendering appear), sparse before it.
+func spansForDay(rng *rand.Rand, dayBack int) int {
+	if dayBack < recentDays {
+		return recentSpansMin + rng.Intn(recentSpansMax-recentSpansMin+1)
+	}
+	return olderSpansMin + rng.Intn(olderSpansMax-olderSpansMin+1)
+}
+
+// spanEndingAt builds one run ending at end, with a log-normal duration — the
+// long-tailed shape real runs have, where the median is minutes and the top
+// few per cent are hours. A uniform duration would make p95, p50 and p5 sit
+// evenly apart and hide exactly what the three lines exist to show.
+func spanEndingAt(rng *rand.Rand, end time.Time) outbound.AutonomySpan {
+	d := math.Exp(math.Log(medianDurationSec) + rng.NormFloat64()*durationSigma)
+	if d < 5 {
+		d = 5
+	}
+	if d > maxDurationSec {
+		d = maxDurationSec
+	}
+	seconds := int64(d)
+	p := pickProject(rng)
+	return outbound.AutonomySpan{
+		Start:   end.Unix() - seconds,
+		End:     end.Unix(),
+		Project: p.name,
+		Session: fmt.Sprintf("seed-%d", rng.Int63n(1_000_000)),
+		Adapter: p.adapter,
+		Model:   p.model,
+		Reason:  pickReason(rng),
+	}
+}
+
+func pickProject(rng *rand.Rand) seedProject {
+	total := 0
+	for _, p := range seedProjects {
+		total += p.weight
+	}
+	n := rng.Intn(total)
+	for _, p := range seedProjects {
+		if n < p.weight {
+			return p
+		}
+		n -= p.weight
+	}
+	return seedProjects[0]
+}
+
+func pickReason(rng *rand.Rand) string {
+	total := 0
+	for _, r := range reasonWeights {
+		total += r.weight
+	}
+	n := rng.Intn(total)
+	for _, r := range reasonWeights {
+		if n < r.weight {
+			return r.reason
+		}
+		n -= r.weight
+	}
+	return session.StateReady
+}

--- a/tools/seed-autonomy-spans/main_test.go
+++ b/tools/seed-autonomy-spans/main_test.go
@@ -1,0 +1,206 @@
+package main
+
+import (
+	"math/rand"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"irrlicht/core/adapters/outbound/filesystem"
+	"irrlicht/core/domain/session"
+	"irrlicht/core/ports/outbound"
+)
+
+// TestGuardRefusesAForeignSpanDir is the mutation fixture for the guard: it
+// mutates the state the guard protects (a span directory this tool did not
+// create) and confirms the guard refuses. Without it, a QA run would mix
+// synthetic runs into a real span log with no way to tell them apart
+// afterwards.
+func TestGuardRefusesAForeignSpanDir(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), autonomyDirName)
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	// A real daemon's log: a span file, and no marker of ours.
+	if err := os.WriteFile(filepath.Join(dir, "irrlicht.jsonl"), []byte("{}\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := guardSpanDir(dir, false); err == nil {
+		t.Fatal("the guard accepted a span directory it did not create — synthetic runs would be " +
+			"mixed into a real log with no way to separate them again")
+	}
+	if err := guardSpanDir(dir, true); err != nil {
+		t.Fatalf("--overwrite must be honored: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "irrlicht.jsonl")); !os.IsNotExist(err) {
+		t.Error("--overwrite left the old span file in place")
+	}
+}
+
+func TestGuardRefusesItsOwnPreviousSeed(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), autonomyDirName)
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, seedMarker), []byte("x\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := guardSpanDir(dir, false); err != nil {
+		t.Fatalf("an empty seeded directory is safe to reuse: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "irrlicht.jsonl"), []byte("{}\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := guardSpanDir(dir, false); err == nil {
+		t.Error("the guard accepted a directory that already holds spans without --overwrite")
+	}
+}
+
+func TestGuardAllowsAMissingDir(t *testing.T) {
+	if err := guardSpanDir(filepath.Join(t.TempDir(), "nothing-here"), false); err != nil {
+		t.Errorf("a directory that does not exist yet is the normal case: %v", err)
+	}
+}
+
+// TestGeneratedCorpusPopulatesEveryWindow is the tool's reason for existing: a
+// seeded machine must render populated in EVERY range and span the section
+// offers, not just the default pair.
+func TestGeneratedCorpusPopulatesEveryWindow(t *testing.T) {
+	now := time.Now()
+	spans := generateSpans(rand.New(rand.NewSource(1905)), now, defaultTotalDays)
+	if len(spans) < 300 {
+		t.Fatalf("generated %d spans, want at least a few hundred", len(spans))
+	}
+	windows := map[string]time.Duration{
+		"8h":   8 * time.Hour,
+		"24h":  24 * time.Hour,
+		"7d":   7 * 24 * time.Hour,
+		"30d":  30 * 24 * time.Hour,
+		"12mo": 365 * 24 * time.Hour,
+	}
+	for name, w := range windows {
+		cutoff := now.Add(-w).Unix()
+		count := 0
+		for _, s := range spans {
+			if s.End >= cutoff {
+				count++
+			}
+		}
+		if count == 0 {
+			t.Errorf("no runs inside the %s window — that view would render its empty state", name)
+		}
+	}
+}
+
+// TestGeneratedCorpusStraddlesTheSampleFloor keeps the seeded picture useful
+// for reviewing the honesty rules: with every daily bucket on one side of the
+// floor, a screenshot shows only one of the two renderings.
+func TestGeneratedCorpusStraddlesTheSampleFloor(t *testing.T) {
+	const sampleFloor = 20 // mirrors autonomySampleFloor in the daemon's handler
+	now := time.Now()
+	spans := generateSpans(rand.New(rand.NewSource(1905)), now, defaultTotalDays)
+	perDay := map[int64]int{}
+	for _, s := range spans {
+		perDay[(now.Unix()-s.End)/86400]++
+	}
+	thin, thick := 0, 0
+	for day, n := range perDay {
+		if day >= recentDays {
+			continue
+		}
+		if n < sampleFloor {
+			thin++
+		} else {
+			thick++
+		}
+	}
+	if thin == 0 || thick == 0 {
+		t.Errorf("the last %d days are %d thin / %d full buckets — a seeded screenshot must show BOTH "+
+			"the under-floor rendering and the normal one", recentDays, thin, thick)
+	}
+
+	// The Year range buckets by WEEK, so it needs its own straddle: the older
+	// days' density is chosen for exactly this (see the const block's comment),
+	// and without the check that choice is an unverified claim.
+	perWeek := map[int64]int{}
+	for _, s := range spans {
+		perWeek[(now.Unix()-s.End)/(7*86400)]++
+	}
+	weeklyThin, weeklyThick := 0, 0
+	for week, n := range perWeek {
+		if week >= 52 {
+			continue
+		}
+		if n < sampleFloor {
+			weeklyThin++
+		} else {
+			weeklyThick++
+		}
+	}
+	if weeklyThin == 0 || weeklyThick == 0 {
+		t.Errorf("the last 52 weeks are %d thin / %d full buckets — the Year range must show both too",
+			weeklyThin, weeklyThick)
+	}
+}
+
+func TestGeneratedCorpusCoversEveryEndReason(t *testing.T) {
+	spans := generateSpans(rand.New(rand.NewSource(1905)), time.Now(), 60)
+	seen := map[string]int{}
+	for _, s := range spans {
+		seen[s.Reason]++
+	}
+	for _, reason := range session.AutonomyEndReasons() {
+		if seen[reason] == 0 {
+			t.Errorf("no seeded run ends in %q — the strip's legend would have an unused color", reason)
+		}
+	}
+	if len(seen) != len(session.AutonomyEndReasons()) {
+		t.Errorf("seeded reasons %v do not match the domain vocabulary %v", seen, session.AutonomyEndReasons())
+	}
+}
+
+func TestGeneratedDurationsHaveALongTail(t *testing.T) {
+	spans := generateSpans(rand.New(rand.NewSource(1905)), time.Now(), defaultTotalDays)
+	var short, long int
+	for _, s := range spans {
+		d := s.Duration()
+		if d < 60 {
+			short++
+		}
+		if d > 3600 {
+			long++
+		}
+	}
+	if short == 0 || long == 0 {
+		t.Errorf("durations span %d sub-minute and %d over-an-hour runs — a flat distribution would make "+
+			"p95/p50/p5 sit evenly apart and hide what the three lines exist to show", short, long)
+	}
+}
+
+// TestSeededRowsReadBackThroughTheDaemonsOwnReader is the format-agreement
+// check: the tool writes through the daemon's tracker, so a seeded log must
+// come back out of the daemon's reader unchanged.
+func TestSeededRowsReadBackThroughTheDaemonsOwnReader(t *testing.T) {
+	dir := t.TempDir()
+	tracker := filesystem.NewAutonomySpanTrackerWithDir(dir)
+	now := time.Now()
+	spans := generateSpans(rand.New(rand.NewSource(7)), now, 40)
+	for _, s := range spans {
+		if err := tracker.RecordSpan(s); err != nil {
+			t.Fatalf("RecordSpan: %v", err)
+		}
+	}
+	res, err := tracker.SpansInWindow(outbound.AutonomySpanQuery{Start: 0, End: now.Unix() + 1})
+	if err != nil {
+		t.Fatalf("SpansInWindow: %v", err)
+	}
+	if res.TotalRecorded != len(spans) {
+		t.Errorf("wrote %d spans, read back %d", len(spans), res.TotalRecorded)
+	}
+	for _, s := range res.Spans {
+		if s.Project == "" || s.Reason == "" || s.Duration() <= 0 {
+			t.Fatalf("a seeded row came back incomplete: %+v", s)
+		}
+	}
+}


### PR DESCRIPTION
Closes #1905.

A new top-level **Autonomy** section in the History view, on both surfaces,
holding two elements over one always-on data source — plus the daemon-side
capture and storage that feeds them.

An **autonomy span** is one unbroken stretch of `working` before the session
left that state. The **end reason** — which state it left *for* — is the signal
the feature is about: `waiting` means it needed you, `ready` means the turn
finished on its own, `error` means it broke.

## Storage — the part that had to not be got wrong

Capture happens live, in `applyStateTransition`
(`core/application/services/session_detector_activity.go`), the single site where
a transition and its per-state side effects are applied. The open span's start
lives on the session (`AutonomySpanStart *int64`, following `WaitingStartTime`);
the **closed** span is appended to `<dataDir>/autonomy/<project>.jsonl`.

That log follows the **cost log**, not the lifecycle recordings. Recordings are
opt-in (`--record` / `IRRLICHT_RECORD=1`) and the packaged app runs without
them, so a recordings-derived chart would show a normal user nothing while
looking exactly like "you did nothing". The span log is written unconditionally,
pruned to the same 400 days, at the same startup call site
(`initAutonomySpanStore` beside `initCostTracker`), and reuses the cost log's
atomic read-transform-rename prune idiom — extracted to `pruneJSONLFile` and now
shared by both rather than copied.

## The five open questions, answered

Each answer is recorded as a comment at the site that implements it.

1. **Grace period.** `working → ready → working` within **10 s** is tool-call
   flicker and does **not** close the span. `working → waiting` and
   `working → error` close it immediately with **no grace** — one there would
   merge *"it asked me a question and I answered in 4 s"* into a single
   fabricated long run, which is the exact failure the issue calls worse than no
   number. (`services.AutonomySpanGrace`)
2. **Per session or per project.** A span row carries **both**. The strip groups
   by project; the chart aggregates over everything. No choice at the data layer.
3. **`error` ends a span** (reason `error`); a run resumed after a usage limit is
   a **new** span. Trade-off recorded on `closeAutonomySpan`: this under-reports
   an interrupted-then-resumed run, but treating `error` as a pause would record
   an agent that broke at 09:00 and was restarted by hand at 17:00 as one
   eight-hour "autonomous run".
4. **Strip density.** Every span draws at a minimum of **one device pixel**; a
   pixel column holding several spans takes the **highest-priority** end reason,
   `error > waiting > ready` — the same ladder as the session-history strip
   (`history_tracker.go`'s `statePriority*`). Implemented as a pure function on
   each client (`AutonomyStripLayout.collapse`, `collapseAutonomyStrip`) so it is
   testable without a view.
5. **Percentiles are computed daemon-side**, once, with **R-7 / `PERCENTILE.INC`**
   (linear interpolation between closest ranks). Named in `stats.Percentile`'s
   doc comment and pinned by a hand-computed fixture.

## API

`GET /api/v1/history` gains two charts, each with its **own window vocabulary**
(the `chart=state` precedent, where a chart brings its own window params instead
of reusing `?range=`):

| chart | `?window=` | payload |
|---|---|---|
| `autonomy_duration` | `30d` \| `1y` | one entry per non-empty bucket: p95, p50, p5, min, max, count, `thin` |
| `autonomy_spans` | `8h` \| `24h` \| `7d` \| `30d` \| `12mo` | the spans in the window, with project, session, start, end, reason |

**These are window LENGTHS.** `historyGranularitySpecs`' keys look identical and
mean a bucket width × a count — `24h` there resolves to a **30-day** window.
The two tables are deliberately separate and a tripwire pins them apart.

## Honesty rules (acceptance criteria, each with a test)

- **An empty bucket is a gap, not a zero.** The daemon omits empty buckets; both
  clients break the stroke there rather than interpolating or drawing a zero.
- **Sample floor = 20 spans.** Below it a bucket's p95 *is* its max and its p5
  *is* its min, so it is marked `thin` on the wire and rendered dashed + hollow
  on both surfaces — never hidden, never smoothed — with a sentence saying what
  the marking means.
- **"No data" never reads as "you did nothing."** Both elements say so in words,
  and the panel states the date of the earliest recorded span
  (`earliest_span` / `total_recorded`, computed over the whole log rather than
  the window). An empty chart with axes drawn is not shipped.

## Mutation fixtures — which one proves which check

AGENTS.md: a check a change *adds* has no "before the fix" to run red, so the
thing it protects gets mutated instead. Every row below was run: production was
mutated, the named test was observed **red**, and the mutation reverted.

| Check | Test | Mutation that turns it red |
|---|---|---|
| R-7 percentile convention | `TestPercentile_UsesR7NotNearestRank` (`core/pkg/stats`) | `nearestRankPercentile`, committed *in the test file*, asserted to disagree with production on the 12-sample fixture; also verified by switching `h = (n-1)p` to `h = np` in production |
| Sample floor | `TestAutonomyDuration_SampleFloorMarksThinBuckets`, `…ThinBucketsOuterLinesAreItsExtremes` | `Thin: false` in `autonomyBucketFrom` |
| Gap, not zero (daemon) | `TestAutonomyDuration_EmptyBucketIsAGapNotAZero` | emitting a zero-count bucket instead of skipping it |
| Gap, not zero (web) | `autonomyChartPoints — omitted buckets come back as nulls` | densifying with zero-filled buckets |
| Two window vocabularies stay distinct | `TestAutonomyWindows_AreNotHistoryGranularities` (Go), `the two pickers offer different sets` (web), `testAutonomyWindowsAreNotGranularities` (Swift) | `mergedResolver` — committed *in the Go test* — plus sourcing `autonomySpanWindowSeconds` from `historyGranularitySpecs` |
| Grace period: flicker resumes a span | `TestAutonomySpan_ReadyFlickerInsideGraceDoesNotBreakTheSpan` | `if false` in place of the resume check in `openOrResumeAutonomySpan` |
| Grace period: `waiting`/`error` are exempt | `TestAutonomySpan_WaitingGetsNoGrace`, `TestAutonomySpan_ErrorEndsTheSpan` | granting the pending-close grace to every leave |
| Grace window is 10 s | `TestAutonomySpanGrace_IsTenSeconds` — a **lock**, passes by construction | widening the constant to 10 minutes |
| Minimum one column per span | `testSubPixelSpanStillDrawsOneColumn` (Swift), `a sub-pixel run still occupies exactly one column` (web) | skipping spans narrower than one column |
| Highest-priority reason wins a column | `testSharedColumnTakesTheHighestPriorityReason` (Swift + web) | last-write-wins instead of the ladder |
| Seeder never clobbers a real log | `TestGuardRefusesAForeignSpanDir` | a span directory with a `.jsonl` and no seed marker |

The two priority ladders (daemon-side domain, and one per client) are pinned
against the session-history strip's by
`TestAutonomyReasonLadderMatchesHistoryBar`, `testCollapseLadderMatchesTheHistoryBar`
and `the ladder matches the session-history strip's` — order only, since the bar
also ranks `working`, which is never an end reason.

## Clients

- **macOS**: a fifth `HistoryTab` case, `.autonomy`, with its own control bar
  (Range `30 days | Year`, Span `8h … 12mo`). Swift Charts for the three lines on
  a log Y scale; a `Canvas` per project row for the strip.
- **Web**: a third segmented fieldset (`#history-autonomy-sel`) beside
  `#history-chart-sel` and `#history-metrics-sel`, its own control row, the lines
  hand-drawn on the shared canvas, and the strip as a full-width DOM section with
  one device-pixel-accurate canvas per project. No Quota group was added — the
  web History bar has none, and that gap is out of scope.

## QA seeding tool

```
go run ./tools/seed-autonomy-spans <data-dir> [--overwrite] [--seed N] [--days N]
```

`<data-dir>` is the daemon's data dir — `$IRRLICHT_HOME` for an isolated daemon,
`~/Library/Application Support/Irrlicht` for the packaged app. It writes through
the daemon's own `AutonomySpanTracker`, so the seeded rows cannot drift from the
format the daemon reads, and it **refuses** a span directory it did not create or
that already holds spans unless given `--overwrite`.

Verified end to end against a real daemon (`IRRLICHT_HOME=/tmp/irr-seed-qa`,
`IRRLICHT_BIND_ADDR=127.0.0.1:7899`), from the default seed:

```
seeded 1932 autonomy spans across 4 projects
duration 30d: 30 buckets, 12 thin; p50 428s p95 3275s; 661 runs
duration  1y: 52 buckets,  5 thin
spans  8h: 9 · 24h: 12 · 7d: 152 · 30d: 661 · 12mo: 1830   (4 projects each)
chart=autonomy_duration&window=8h → 400 (the strip's vocabulary is refused)
```

Both chart ranges and every strip window render populated, and both buckets
straddle the 20-span floor so the thin rendering *and* the normal one are
visible in one screenshot. (1932, not "a few hundred": the density needed to put
daily *and* weekly buckets on both sides of the floor is what sets the count.
`--days` and `--seed` adjust it.)

## Gates

`tools/preflight.sh` run chunked, each `--only <group>` as its own foreground
invocation: `go` PASS · `web` PASS · `swift` PASS · `arch` PASS (composite
7.9290 → 7.9330, no category regression) · `tools` PASS · `skills` PASS ·
`posix` PASS · `bash` PASS · `security` PASS. `--only linux` was not run
(opt-in, needs Docker).

Every CI check on the PR passes, including SonarCloud. The one exception is
**CodeScene, which is advisory** (AGENTS.md: *"Code health (advisory)"*). What
it flags, and why it is being left:

- Two *hotspot decline* entries, both one line each and both unavoidable where
  they are: `refreshStaleSessions` gains the pending-span flush (7.61 → 7.55)
  — that ticker is the only thing that revisits a session which finished its
  turn and then did nothing — and `runDaemon` gains the store's construction
  (8.37 → 8.36), beside `initCostTracker`, which is where the issue says to put
  it.
- The rest are *Bumpy Road Ahead* / *Complex Method* on new **test** functions
  (nested `for`/`if` inside table assertions) and on
  `buildAutonomyDurationResponse` / `SpansInWindow` / the two collapse
  functions. The first round of these was already addressed — see the second
  commit, which is why `cost_tracker.go` and `handlers.go` show as *improved* —
  and what remains would trade a named, commented loop for indirection that
  makes the rule harder to read, not easier.

The SonarCloud gate failed on the first push for one reason, now fixed: the new
module had no `go.sum`.

## QA round — three legibility fixes

QA on the real stack (dev daemon on 7838, seeded isolated `IRRLICHT_HOME`, web
dashboard in both themes plus the macOS popover) confirmed capture, storage, the
API and both renderers — including a **real** 54-second span ending in `waiting`,
captured live from a claude-code session by the daemon rather than the seeder,
and both clients agreeing exactly with the API (656 runs / 13 thin / 1933 total).
It found three presentation defects, all now fixed:

1. **The web chart had no key.** It drew p95/p50/p5 and the side panel built a
   row per line, then blanked every swatch (`dot.style.background =
   'transparent'`) — so the only way to tell three curves apart was vertical
   order. `AUTONOMY_SERIES` is now the single exported colour table and
   `autonomySeriesColor` resolves from it, read by both the canvas stroke and
   the panel's swatch; the swatch decision moved into `autonomyPanelRows`, a
   pure exported function, because that is exactly where the defect lived and
   nothing could see it there. macOS gained `AutonomyPalette.seriesOrder` /
   `seriesColors` so its scale — and the legend Swift Charts derives from it —
   comes from one table too. longest/shortest/runs stay unswatched on purpose:
   they are figures, not lines.
2. **The strip's right-hand figure was unlabelled** — a bare duration with
   nothing saying what it measured (the aria-label said "longest"; sighted
   users got nothing). Both surfaces now carry a column header over it.
3. **The strip had no time axis**, so at `30d` and `12mo` it read as texture.
   Both surfaces now print the window's start on the left and "now" on the
   right, under the strip; the label coarsens with the window (time of day at
   8h, month at 12mo), the way the activity matrix's column headers do. Two
   labels, not a tick axis.

Each fix carries a check that was seen red against the defect it describes:

| Check | Mutation that turns it red |
|---|---|
| `the three line rows carry non-empty, distinct swatches` | the original `swatch: 'transparent'`; also one colour for all three lines |
| `the three line colours are distinct` | one colour for all three lines |
| `the header names the value column` | blanking the header text |
| `the axis states where the window starts and that it ends now` | printing raw epoch seconds instead of a label |
| `testSeriesColorsCoverEveryLineAndAreDistinct` (Swift) | two of the three lines sharing a colour |
| `testAxisBoundCoarsensWithTheWindow` (Swift) | one date format for every window |

`--only web` and `--only swift` re-run after the fixes: both PASS.

## Findings, not filed as issues

- **A new Go module has three registration points, and only one of them is
  obvious.** Adding `tools/seed-autonomy-spans` needed `go.work`,
  `.github/dependabot.yml` (enforced by `tools/lib/module-list_test.sh`) and a
  CI/preflight gate. The first two are caught mechanically; the third is not —
  `tools/seed-demo-sessions` has a `main_test.go` that no gate runs. This PR adds
  a `test.yml` step and a scoped preflight gate for the new module, but the
  general hole is still there.
- **A pending span can be lost in one narrow window.** A span held by the flicker
  grace is written by whichever comes first: the 5 s refresh ticker, the next
  transition, or session teardown (`cacheDeletedSnapshot`). A daemon killed
  within ~10 s of a turn finishing loses that one span. Teardown paths that do
  not go through `cacheDeletedSnapshot` (`/clear`, the dedup/supersession
  reconciliation) rely on the ticker instead — verified by reading
  `forgetSessionScopedState`'s own comment naming the two teardown paths, not by
  instrumenting them.
- **`chart=autonomy_spans` returns raw spans, capped at 20 000** with a
  `truncated` flag the clients surface. The alternative — collapsing server-side
  — needs the client's pixel width on the wire, which felt like the wrong trade
  for v1. At 12 months of heavy use the payload is a few MB.
- **One unrelated flake observed**: `kirocli TestHooksPermission_IsGated` failed
  once under a full-suite `-race` run (`signal: killed` on a 5 s shell-out to the
  real `kiro-cli`) and passed in isolation immediately afterwards. Not touched by
  this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rw2jkcKiLcYdGavEWDeRRB
