### PR TITLE
feat(history): one hue, three weights for the Autonomy duration chart (#1905)

### DIFF
--- a/platforms/macos/Irrlicht/Models/HistoryAutonomyData.swift
+++ b/platforms/macos/Irrlicht/Models/HistoryAutonomyData.swift
@@ -300,6 +300,115 @@ struct HistoryAutonomyDurationResponse: Codable {
         guard let first = bucketStarts.first, let last = bucketStarts.last, last > first else { return [] }
         return provenanceOrNone.boundaryList.filter { $0.ts > first && $0.ts < last }
     }
+
+    /// Where in the DRAWN domain a boundary sits, 0…1 — the macOS twin of the
+    /// web's `autonomyVisibleBoundaries().fraction`. 0 for a boundary that is
+    /// not in view, which `visibleBoundaries` has already excluded.
+    func domainFraction(of boundary: HistoryAutonomyBoundary) -> Double {
+        guard let first = bucketStarts.first, let last = bucketStarts.last, last > first else { return 0 }
+        return Double(boundary.ts - first) / Double(last - first)
+    }
+
+    /// The buckets aligned to `bucket_starts`, with `nil` for every bucket the
+    /// daemon OMITTED — the macOS twin of the web's `autonomyChartPoints`.
+    ///
+    /// The null is the honesty rule, not a convenience: an empty bucket is a
+    /// GAP, and a day with no runs must not pull a line down to the axis or
+    /// let a filled band close over it. Reading `buckets` directly — which is
+    /// what this section did before the band existed — hands Swift Charts a
+    /// dense list in which the gap is simply not there, and it connects
+    /// straight across.
+    var alignedBuckets: [HistoryAutonomyBucket?] {
+        var byTS: [Int64: HistoryAutonomyBucket] = [:]
+        for b in buckets { byTS[b.ts] = b }
+        return bucketStarts.map { byTS[$0] }
+    }
+}
+
+/// Where a source-boundary caption sits relative to the rule it describes.
+///
+/// The caption is a fixed string ("← cost log · 60s resolution") that can be
+/// most of the plot wide at 9 pt, and it used to be pinned to the rule's LEFT
+/// unconditionally. A rule in the left third of the chart therefore had less
+/// room than the caption needed, SwiftUI clamped the annotation to the chart's
+/// leading edge, and the caption ended up detached from the rule with its
+/// arrow pointing off-chart at nothing — which is worse than no caption, since
+/// it reads as a rendering fault rather than as an annotation.
+///
+/// Putting it on whichever side of the rule has more room cannot be clamped
+/// unless the caption is wider than HALF the plot, and the arrow keeps its
+/// meaning either way: it points across the rule, at the era to its left.
+enum AutonomyBoundaryCaption {
+    enum Side: Equatable { case left, right }
+
+    static func side(fraction: Double) -> Side { fraction >= 0.5 ? .left : .right }
+}
+
+/// The p5–p95 band's geometry (#1905 redesign), as a pure function so both the
+/// gap rule and the thin-bucket rule are testable without a chart — and so
+/// this and the web's `autonomyBandSegments` fill the same shape.
+///
+/// TWO RULES, both of them honesty rules a smooth fill would otherwise erase:
+///
+///   - **A filled area wants to close across a gap.** The daemon omits empty
+///     buckets; a polygon spanning one paints a plane over days that hold no
+///     runs at all, a stronger false claim than the interpolated line #1905
+///     already refuses. A segment never crosses a `nil`.
+///   - **A thin bucket is not a percentile.** Under `sample_floor`, p95 is
+///     that bucket's longest run and p5 its shortest. The stroke already
+///     dashes across such a bucket; the fill splits at the same place so the
+///     thin stretch can be painted in its own fainter plane.
+enum AutonomyBandLayout {
+    /// One fillable stretch: inclusive indices into the aligned point list,
+    /// and whether it is thin. Adjacent segments SHARE their boundary index,
+    /// so a thin→solid handover leaves no seam. `from == to` is an isolated
+    /// bucket — it has no neighbour to make an area with, and the chart draws
+    /// its spread as a whisker rather than leaving it the one bucket with no
+    /// visible range at all.
+    struct Segment: Equatable, Identifiable {
+        let from: Int
+        let to: Int
+        let thin: Bool
+
+        var id: String { "\(from)-\(to)-\(thin)" }
+        var isIsolated: Bool { from == to }
+    }
+
+    static func segments(points: [HistoryAutonomyBucket?]) -> [Segment] {
+        var out: [Segment] = []
+        var i = 0
+        while i < points.count {
+            guard points[i] != nil else { i += 1; continue }
+            var last = i
+            while last + 1 < points.count, points[last + 1] != nil { last += 1 }
+            if last == i {
+                out.append(Segment(from: i, to: i, thin: points[i]?.thin ?? false))
+                i = last + 1
+                continue
+            }
+            // Thinness belongs to the INTERVAL, not the bucket — matching the
+            // stroke, which dashes a segment either of whose ends is thin.
+            var start = i
+            var thin = isThin(points, i) || isThin(points, i + 1)
+            var j = i + 1
+            while j < last {
+                let next = isThin(points, j) || isThin(points, j + 1)
+                if next != thin {
+                    out.append(Segment(from: start, to: j, thin: thin))
+                    start = j
+                    thin = next
+                }
+                j += 1
+            }
+            out.append(Segment(from: start, to: last, thin: thin))
+            i = last + 1
+        }
+        return out
+    }
+
+    private static func isThin(_ points: [HistoryAutonomyBucket?], _ i: Int) -> Bool {
+        points[i]?.thin ?? false
+    }
 }
 
 struct HistoryAutonomySpanRow: Codable, Identifiable {

--- a/platforms/macos/Irrlicht/Theme/Tokens.swift
+++ b/platforms/macos/Irrlicht/Theme/Tokens.swift
@@ -67,6 +67,25 @@ enum IrrColors {
     static let readyDim   = ready.opacity(0.12)
     static let errorDim   = error.opacity(0.12)
 
+    // Autonomy chart (#1905) — ONE hue, three weights. The p50 line is
+    // `working` at full strength; the p5–p95 band is the same hue as a
+    // translucent plane, and its two edges the same hue again, quiet enough to
+    // bound the plane without competing with the line inside it.
+    //
+    // `adaptive` rather than `working.opacity(…)` because the alpha itself has
+    // to differ per appearance, and a single opacity cannot have two values:
+    // on a dark window a violet wash has to LIGHTEN the surface to register at
+    // all, while on a light one the same alpha reads as a solid lavender slab
+    // louder than the line it sits behind. Hex is `#AARRGGBB`, so the alpha
+    // rides in the token. Web twin: --autonomy-band / --autonomy-band-thin /
+    // --autonomy-edge in platforms/web/irrlicht.css, same alphas.
+    static let autonomyBand     = Color.adaptive(light: "#1C8B5CF6", dark: "#338B5CF6")
+    // Buckets under `sample_floor` keep their own, fainter plane: there p95 IS
+    // the maximum and p5 IS the minimum, so the area is a range rather than a
+    // percentile spread and must not read as one.
+    static let autonomyBandThin = Color.adaptive(light: "#0D8B5CF6", dark: "#148B5CF6")
+    static let autonomyEdge     = Color.adaptive(light: "#618B5CF6", dark: "#738B5CF6")
+
     // Glow halos (--working-glow 0.25, --waiting-glow / --ready-glow 0.20).
     static let workingGlow = working.opacity(0.25)
     static let waitingGlow = waiting.opacity(0.20)

--- a/platforms/macos/Irrlicht/Views/HistoryAutonomyView.swift
+++ b/platforms/macos/Irrlicht/Views/HistoryAutonomyView.swift
@@ -656,12 +656,20 @@ enum AutonomyPalette {
     ///
     /// Named for a reader who has never seen a percentile — the register the
     /// section already used ("the typical run") — with the p-labels kept in
-    /// front for a reader who has. Same two strings as the web's panel key.
+    /// front for a reader who has. Two noun phrases that read as a pair: the
+    /// chart draws one line and one plane, and these name them as one thing
+    /// and its spread rather than as two measurements.
+    ///
+    /// SAME TWO STRINGS AS THE WEB's panel key (AUTONOMY_KEY in
+    /// platforms/web/historyTab.js), and pinned against it by `the two
+    /// surfaces name the key the same way` — two clients must not explain one
+    /// chart differently. This popover has room the web's 260 pt side panel
+    /// does not, so the length that fits THERE is the length both carry.
     static var keyEntries: [AutonomyKeyEntry] {
         [
             AutonomyKeyEntry(kind: .line, from: "p50", label: "p50 · the typical run",
                              color: seriesColors["p50"] ?? .gray, fill: nil),
-            AutonomyKeyEntry(kind: .band, from: "p95", label: "p5–p95 · where most runs land",
+            AutonomyKeyEntry(kind: .band, from: "p95", label: "p5–p95 · the usual spread",
                              color: edge, fill: band),
         ]
     }

--- a/platforms/macos/Irrlicht/Views/HistoryAutonomyView.swift
+++ b/platforms/macos/Irrlicht/Views/HistoryAutonomyView.swift
@@ -15,7 +15,14 @@ struct HistoryAutonomyContentView: View {
     let duration: HistoryAutonomyDurationResponse
     let spans: HistoryAutonomySpansResponse
     let range: HistoryAutonomyRange
-    let spanWindow: HistoryAutonomySpanWindow
+    /// A BINDING, unlike `range`: the Span picker lives in this view now,
+    /// in the strip's own section header. Range still belongs to the tab's
+    /// control row because the chart is the first thing under it; Span sat up
+    /// there too, one row of controls above two elements, with nothing saying
+    /// which control moved which — and the two vocabularies overlap textually
+    /// (`30d` is a Range value AND a Span value), so the row read as one zoom
+    /// control with an odd set of steps.
+    @Binding var spanWindow: HistoryAutonomySpanWindow
 
     /// #1659 — every date this view renders takes its zone as an INPUT rather
     /// than reading `NSTimeZone.default`.
@@ -49,6 +56,7 @@ struct HistoryAutonomyContentView: View {
             if duration.hasData {
                 AutonomyDurationChart(data: duration, timeZone: formatTimeZone)
                     .frame(height: 190)
+                AutonomyKeyView()
                 summaryRow
                 if thinCount > 0 { thinNote }
             } else {
@@ -76,12 +84,13 @@ struct HistoryAutonomyContentView: View {
     private var thinCount: Int { duration.buckets.filter(\.thin).count }
 
     /// Thin buckets are MARKED, never hidden and never smoothed — and the
-    /// marking is explained in words, because a hollow dot means nothing on
-    /// its own.
+    /// marking is explained in words, because a fainter plane means nothing on
+    /// its own. Three signals, since a distinction is easy to lose inside a
+    /// smooth band: the plane itself, the edges bounding it, and the points.
     private var thinNote: some View {
         Text("\(thinCount) of \(duration.buckets.count) buckets hold fewer than \(duration.sampleFloor) runs "
-             + "(hollow points, dashed): there, p95 is that bucket's longest run and p5 its shortest — "
-             + "not percentiles.")
+             + "(fainter band, dashed edges, hollow points): there, p95 is that bucket's longest run and "
+             + "p5 its shortest — not percentiles.")
             .font(.caption2)
             .foregroundColor(.secondary)
             .fixedSize(horizontal: false, vertical: true)
@@ -104,9 +113,22 @@ struct HistoryAutonomyContentView: View {
 
     @ViewBuilder private var stripSection: some View {
         VStack(alignment: .leading, spacing: IrrSpacing.sp2) {
-            Text("Runs · last \(spanWindow.label)")
+            // The strip's own header: its title and the picker that changes
+            // it, together — the whole point of moving Span down here.
+            HStack(spacing: IrrSpacing.sp2) {
+                Text("Runs · last \(spanWindow.label)")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                Spacer(minLength: IrrSpacing.sp2)
+                Picker("Span", selection: $spanWindow) {
+                    ForEach(HistoryAutonomySpanWindow.allCases) { Text($0.label).tag($0) }
+                }
+                .labelsHidden()
+                .fixedSize()
+                .pickerStyle(.menu)
+                .controlSize(.small)
                 .font(.caption)
-                .foregroundColor(.secondary)
+            }
             if spans.hasData {
                 // A header over the value column: the figure at the end of
                 // each row was a bare duration with nothing saying what it
@@ -240,12 +262,31 @@ private struct AutonomyDurationChart: View {
     let data: HistoryAutonomyDurationResponse
     let timeZone: TimeZone
 
-    /// One drawn point. `series` names which of the three lines it belongs to.
+    /// One drawn point.
+    ///
+    /// `series` names which of the three lines it belongs to and is what the
+    /// colour scale reads. `run` is a different key on purpose: it names the
+    /// CONTIGUOUS STRETCH the point belongs to, and Swift Charts connects
+    /// points that share it. Without that second key a line is drawn through
+    /// every bucket the daemon sent — which silently bridges the omitted ones,
+    /// exactly the interpolation `alignedBuckets` exists to refuse.
     private struct Datum: Identifiable {
         let id: String
         let date: Date
         let series: String
+        let run: String
         let value: Double
+        let thin: Bool
+    }
+
+    /// One stretch of the band: the plane between p5 and p95 over a run of
+    /// consecutive buckets, or (when `isolated`) a single bucket's spread.
+    private struct BandDatum: Identifiable {
+        let id: String
+        let date: Date
+        let run: String
+        let low: Double
+        let high: Double
         let thin: Bool
     }
 
@@ -253,15 +294,67 @@ private struct AutonomyDurationChart: View {
     /// run — clamp to one second so a degenerate value cannot blank the chart.
     private func plottable(_ v: Double) -> Double { Swift.max(1, v) }
 
-    private var data3: [Datum] {
+    private func date(at index: Int) -> Date {
+        Date(timeIntervalSince1970: TimeInterval(data.bucketStarts[index]))
+    }
+
+    private var points: [HistoryAutonomyBucket?] { data.alignedBuckets }
+    private var segments: [AutonomyBandLayout.Segment] {
+        AutonomyBandLayout.segments(points: points)
+    }
+
+    /// The three lines, split into one series per contiguous stretch so the
+    /// stroke BREAKS at every omitted bucket instead of being drawn through it.
+    private func lineData(_ segments: [AutonomyBandLayout.Segment]) -> [Datum] {
         var out: [Datum] = []
-        for b in data.buckets {
-            let date = Date(timeIntervalSince1970: TimeInterval(b.ts))
-            out.append(Datum(id: "p95-\(b.ts)", date: date, series: "p95", value: plottable(b.p95), thin: b.thin))
-            out.append(Datum(id: "p50-\(b.ts)", date: date, series: "p50", value: plottable(b.p50), thin: b.thin))
-            out.append(Datum(id: "p5-\(b.ts)", date: date, series: "p5", value: plottable(b.p5), thin: b.thin))
+        for segment in segments where !segment.isIsolated {
+            for i in segment.from...segment.to {
+                guard let b = points[i] else { continue }
+                for key in AutonomyPalette.seriesOrder {
+                    let v: Double
+                    switch key {
+                    case "p95": v = b.p95
+                    case "p5": v = b.p5
+                    default: v = b.p50
+                    }
+                    out.append(Datum(id: "\(key)-\(segment.id)-\(b.ts)",
+                                     date: date(at: i),
+                                     series: key,
+                                     run: "\(key)#\(segment.id)",
+                                     value: plottable(v),
+                                     thin: segment.thin))
+                }
+            }
         }
         return out
+    }
+
+    private func bandData(_ segments: [AutonomyBandLayout.Segment]) -> [BandDatum] {
+        var out: [BandDatum] = []
+        for segment in segments where !segment.isIsolated {
+            for i in segment.from...segment.to {
+                guard let b = points[i] else { continue }
+                out.append(BandDatum(id: "band-\(segment.id)-\(b.ts)",
+                                     date: date(at: i),
+                                     run: segment.id,
+                                     low: plottable(b.p5),
+                                     high: plottable(b.p95),
+                                     thin: segment.thin))
+            }
+        }
+        return out
+    }
+
+    /// Buckets with no neighbour to make an area with. Drawn as a whisker
+    /// rather than dropped: a lone bucket is exactly where a reader most needs
+    /// to see how wide the range was, and it would otherwise be the only one
+    /// whose spread is invisible.
+    private func whiskerData(_ segments: [AutonomyBandLayout.Segment]) -> [BandDatum] {
+        segments.filter(\.isIsolated).compactMap { segment in
+            guard let b = points[segment.from] else { return nil }
+            return BandDatum(id: "whisker-\(segment.id)", date: date(at: segment.from), run: segment.id,
+                             low: plottable(b.p5), high: plottable(b.p95), thin: segment.thin)
+        }
     }
 
     /// Y domain with a little headroom, floored so a single short run still
@@ -274,39 +367,70 @@ private struct AutonomyDurationChart: View {
     }
 
     var body: some View {
-        let points = data3
+        let segments = self.segments
+        let lines = lineData(segments)
         Chart {
-            // FIRST in the builder, so the rules sit UNDER the lines: the
-            // marker explains the data, it is not part of it, and a rule drawn
-            // over a curve competes with the thing it annotates.
+            // FIRST in the builder, so the plane and the rules sit UNDER the
+            // lines. The band is context; the p50 line is the headline, and it
+            // is the last ink down so nothing crosses over it.
+            ForEach(bandData(segments)) { d in
+                AreaMark(
+                    x: .value("Date", d.date),
+                    yStart: .value("p5", d.low),
+                    yEnd: .value("p95", d.high),
+                    series: .value("Band", d.run)
+                )
+                .foregroundStyle(d.thin ? AutonomyPalette.bandThin : AutonomyPalette.band)
+                .interpolationMethod(.monotone)
+            }
+            ForEach(whiskerData(segments)) { d in
+                RuleMark(
+                    x: .value("Date", d.date),
+                    yStart: .value("p5", d.low),
+                    yEnd: .value("p95", d.high)
+                )
+                .lineStyle(StrokeStyle(lineWidth: 1, dash: d.thin ? [3, 3] : []))
+                .foregroundStyle(AutonomyPalette.edge)
+            }
+            // The source-change markers: the marker explains the data, it is
+            // not part of it, so it sits under the curves too.
             //
-            // A hairline at low opacity, in `.secondary` so both themes resolve
-            // it themselves — findable when looked for, invisible when not.
+            // A LONG-DASHED 1.5 pt rule, deliberately unlike the axis
+            // gridlines below (solid hairlines): before, both were thin dashes
+            // in a muted colour and the one line on the chart that carries an
+            // explanation was indistinguishable from furniture.
             ForEach(data.visibleBoundaries) { boundary in
                 RuleMark(x: .value("Source change", boundary.date))
-                    .lineStyle(StrokeStyle(lineWidth: 1, dash: [2, 3]))
-                    .foregroundStyle(Color.secondary.opacity(0.45))
-                    .annotation(position: .top, alignment: .trailing, spacing: 1) {
+                    .lineStyle(StrokeStyle(lineWidth: 1.5, dash: [6, 3]))
+                    .foregroundStyle(Color.secondary.opacity(0.75))
+                    .annotation(position: .top,
+                                alignment: captionAlignment(for: boundary),
+                                spacing: 2) {
                         Text(boundary.label)
                             .font(.system(size: 9))
                             .foregroundColor(.secondary)
-                            .opacity(0.8)
+                            .opacity(0.9)
                             .fixedSize()
                     }
             }
-            ForEach(points) { d in
+            ForEach(lines) { d in
                 LineMark(
                     x: .value("Date", d.date),
                     y: .value("Duration", d.value),
-                    series: .value("Series", d.series)
+                    series: .value("Run", d.run)
                 )
                 .foregroundStyle(by: .value("Series", d.series))
                 .interpolationMethod(.monotone)
+                .lineStyle(StrokeStyle(lineWidth: AutonomyPalette.lineWidth(AutonomyPalette.role(of: d.series)),
+                                       dash: d.thin ? [3, 3] : []))
+                .opacity(AutonomyPalette.opacity(AutonomyPalette.role(of: d.series), thin: d.thin))
             }
             // Thin buckets are marked rather than hidden: a hollow point on
             // every line at that bucket, so a low-sample day is visibly
-            // different from a well-sampled one without being dropped.
-            ForEach(points.filter(\.thin)) { d in
+            // different from a well-sampled one without being dropped. Inside
+            // a smooth band this is the third signal, alongside the fainter
+            // plane and the dashed edges.
+            ForEach(lines.filter(\.thin)) { d in
                 PointMark(
                     x: .value("Date", d.date),
                     y: .value("Duration", d.value)
@@ -317,15 +441,20 @@ private struct AutonomyDurationChart: View {
                 .opacity(0.45)
             }
         }
-        // One table for the three lines, read by the scale AND by the legend
-        // Swift Charts derives from it — the web's twin of this is
+        // One table for the three lines, read by the scale AND by
+        // AutonomyPalette.keyEntries — the web's twin of this is
         // AUTONOMY_SERIES, and both surfaces must name the lines the same way.
         .chartForegroundStyleScale(domain: AutonomyPalette.seriesOrder,
                                    range: AutonomyPalette.seriesRange)
+        // …and the legend Swift Charts derives from that scale is hidden,
+        // because with one hue it would be three identical swatches naming
+        // three percentiles. AutonomyKeyView draws the two entries that
+        // actually correspond to marks on the chart.
+        .chartLegend(.hidden)
         .chartYScale(domain: yDomain, type: .log)
         .chartYAxis {
             AxisMarks { value in
-                AxisGridLine()
+                AxisGridLine(stroke: StrokeStyle(lineWidth: 0.5))
                 AxisValueLabel {
                     if let v = value.as(Double.self) {
                         Text(AutonomyFormat.duration(v))
@@ -335,7 +464,9 @@ private struct AutonomyDurationChart: View {
         }
         .chartXAxis {
             AxisMarks(values: .automatic(desiredCount: 4)) { value in
-                AxisGridLine()
+                // Solid hairlines. Dashed x gridlines read as several source
+                // markers and made the real one impossible to find.
+                AxisGridLine(stroke: StrokeStyle(lineWidth: 0.5))
                 AxisValueLabel {
                     if let d = value.as(Date.self) {
                         Text(AutonomyFormat.axisDate(d, timeZone: timeZone))
@@ -343,7 +474,52 @@ private struct AutonomyDurationChart: View {
                 }
             }
         }
-        .chartLegend(position: .bottom, spacing: 4)
+    }
+
+    /// Which side of its rule a boundary caption hangs off — see
+    /// `AutonomyBoundaryCaption`. `.trailing` puts the caption's trailing edge
+    /// on the rule (text extends left), `.leading` its leading edge (text
+    /// extends right).
+    private func captionAlignment(for boundary: HistoryAutonomyBoundary) -> Alignment {
+        AutonomyBoundaryCaption.side(fraction: data.domainFraction(of: boundary)) == .left
+            ? .trailing
+            : .leading
+    }
+}
+
+// MARK: - The chart's key
+
+/// Two entries, because the chart draws two things: a line and a plane. Each
+/// swatch takes the SHAPE of what it stands for — a pair of identically
+/// coloured dots would be a key that says the same thing twice.
+private struct AutonomyKeyView: View {
+    var body: some View {
+        HStack(spacing: IrrSpacing.sp3) {
+            ForEach(AutonomyPalette.keyEntries) { entry in
+                HStack(spacing: IrrSpacing.sp1) {
+                    swatch(entry)
+                    Text(entry.label)
+                }
+            }
+            Spacer(minLength: 0)
+        }
+        .font(.caption2)
+        .foregroundColor(.secondary)
+    }
+
+    @ViewBuilder private func swatch(_ entry: AutonomyKeyEntry) -> some View {
+        switch entry.kind {
+        case .line:
+            Capsule()
+                .fill(entry.color)
+                .frame(width: 16, height: 2)
+        case .band:
+            (entry.fill ?? Color.clear)
+                .frame(width: 16, height: 9)
+                .overlay(alignment: .top) { entry.color.frame(height: 1) }
+                .overlay(alignment: .bottom) { entry.color.frame(height: 1) }
+                .clipShape(RoundedRectangle(cornerRadius: 1))
+        }
     }
 }
 
@@ -400,18 +576,95 @@ private struct AutonomyStripRow: View {
 
 // MARK: - Palette + formatting
 
+/// One entry of the chart's key. `from` names the `AutonomyPalette.seriesOrder`
+/// row the entry takes its colour from, so a key entry cannot be given a
+/// colour the chart does not draw.
+struct AutonomyKeyEntry: Identifiable, Equatable {
+    enum Kind: String { case line, band }
+
+    let kind: Kind
+    let from: String
+    let label: String
+    let color: Color
+    /// The plane's fill. `nil` for the line entry — a line has no area, and a
+    /// swatch with a fill would claim one.
+    let fill: Color?
+
+    var id: String { kind.rawValue }
+}
+
 enum AutonomyPalette {
     /// The three drawn lines, in draw order, and their colours — ONE table,
-    /// read by the chart's style scale and therefore by the legend Swift
-    /// Charts derives from it, so the key and the curves cannot disagree.
-    /// Mirrors the web's AUTONOMY_SERIES, which had to gain the same property
-    /// when QA found three unlabelled curves there.
+    /// read by the chart's style scale AND by the two key entries below, so
+    /// the key and the curves cannot disagree. Mirrors the web's
+    /// AUTONOMY_SERIES, which carries the same property.
+    ///
+    /// ONE HUE, THREE WEIGHTS. The first round drew p95 green, p50 purple and
+    /// p5 orange — three equally loud curves and a legend that had to be
+    /// decoded before the chart said anything. It says one thing now: here is
+    /// the typical run (the solid `line`), and here is the spread around it
+    /// (the plane between the two quiet `edge`s). A hue per percentile made
+    /// p95 and p5 read as two independent measurements rather than as the
+    /// boundary of one range.
     static let seriesOrder = ["p95", "p50", "p5"]
     static let seriesColors: [String: Color] = [
-        "p95": IrrColors.ready,
+        "p95": IrrColors.working,
         "p50": IrrColors.working,
-        "p5": IrrColors.waiting,
+        "p5": IrrColors.working,
     ]
+
+    /// What each line is FOR. The colours no longer separate them, so the
+    /// roles do — and the chart reads its stroke weights from here rather than
+    /// from a literal beside each mark.
+    enum Role { case line, edge }
+    static let seriesRoles: [String: Role] = [
+        "p95": .edge,
+        "p50": .line,
+        "p5": .edge,
+    ]
+
+    static func role(of key: String) -> Role { seriesRoles[key] ?? .line }
+
+    /// The headline line's colour: the one every reader is meant to follow.
+    static var lineColor: Color { seriesColors["p50"] ?? .gray }
+
+    /// The band's own three weights — the plane, the fainter plane a thin
+    /// stretch gets, and the weight its two edges are stroked at. A second
+    /// TABLE, not a second palette: every one of them is the `working` hue at
+    /// a lower alpha (`bandIsTheLineHue` in the tests pins that), and both the
+    /// chart and the key read these same entries.
+    static var band: Color { IrrColors.autonomyBand }
+    static var bandThin: Color { IrrColors.autonomyBandThin }
+    static var edge: Color { IrrColors.autonomyEdge }
+
+    /// Stroke weight per role. The line carries the chart; the edges are
+    /// present enough to bound the plane and quiet enough not to compete.
+    static func lineWidth(_ role: Role) -> CGFloat { role == .line ? 1.8 : 1 }
+    static func opacity(_ role: Role, thin: Bool) -> Double {
+        switch (role, thin) {
+        case (.line, false): return 1
+        case (.line, true): return 0.6
+        case (.edge, false): return 0.5
+        case (.edge, true): return 0.32
+        }
+    }
+
+    /// The chart's key: exactly two entries, because the chart draws exactly
+    /// two things. Three percentile swatches in one hue would promise a
+    /// distinction the chart stopped making — which is why the Swift Charts
+    /// legend derived from `seriesOrder` is hidden and this is drawn instead.
+    ///
+    /// Named for a reader who has never seen a percentile — the register the
+    /// section already used ("the typical run") — with the p-labels kept in
+    /// front for a reader who has. Same two strings as the web's panel key.
+    static var keyEntries: [AutonomyKeyEntry] {
+        [
+            AutonomyKeyEntry(kind: .line, from: "p50", label: "p50 · the typical run",
+                             color: seriesColors["p50"] ?? .gray, fill: nil),
+            AutonomyKeyEntry(kind: .band, from: "p95", label: "p5–p95 · where most runs land",
+                             color: edge, fill: band),
+        ]
+    }
 
     /// The scale's range in `seriesOrder`. A key with no colour would be a
     /// line drawn in the fallback grey rather than silently undrawn, which is

--- a/platforms/macos/Irrlicht/Views/HistoryView.swift
+++ b/platforms/macos/Irrlicht/Views/HistoryView.swift
@@ -318,21 +318,24 @@ struct HistoryView: View {
         .font(.caption)
     }
 
-    /// Autonomy tab (#1905): one picker per element — Range for the duration
-    /// chart, Span for the run strip. Neither is the shared `range`: the two
-    /// elements answer different questions over different windows, and the
-    /// section uses no Group or drilldown at all.
+    /// Autonomy tab (#1905): Range, and only Range. It governs the duration
+    /// chart, which is the first thing under this row.
+    ///
+    /// Span — the run strip's window — used to sit here beside it, one control
+    /// row above BOTH elements, with nothing on screen saying which control
+    /// moved which; the two vocabularies even overlap textually (`30d` is a
+    /// Range value AND a Span value), so the row read as a single zoom control
+    /// with an odd set of steps. Span now lives in the strip's own section
+    /// header, in HistoryAutonomyContentView.
+    ///
+    /// Neither is the shared `range`: the two elements answer different
+    /// questions over different windows, and the section uses no Group or
+    /// drilldown at all.
     @ViewBuilder private var autonomyControls: some View {
         HStack(spacing: IrrSpacing.sp3) {
             Text("Range").foregroundColor(.secondary)
             Picker("Range", selection: $autonomyRange) {
                 ForEach(HistoryAutonomyRange.allCases) { Text($0.label).tag($0) }
-            }
-            .labelsHidden()
-            .fixedSize()
-            Text("Span").foregroundColor(.secondary)
-            Picker("Span", selection: $autonomySpanWindow) {
-                ForEach(HistoryAutonomySpanWindow.allCases) { Text($0.label).tag($0) }
             }
             .labelsHidden()
             .fixedSize()
@@ -476,7 +479,7 @@ struct HistoryView: View {
     @ViewBuilder private var autonomyContent: some View {
         if let d = autonomyDuration, let s = autonomySpans {
             HistoryAutonomyContentView(duration: d, spans: s,
-                                       range: autonomyRange, spanWindow: autonomySpanWindow)
+                                       range: autonomyRange, spanWindow: $autonomySpanWindow)
         } else if loadFailed {
             loadFailedText
         } else {

--- a/platforms/macos/Tests/HistoryAutonomyTests.swift
+++ b/platforms/macos/Tests/HistoryAutonomyTests.swift
@@ -1,3 +1,5 @@
+import AppKit
+import SwiftUI
 import XCTest
 @testable import Irrlicht
 
@@ -202,19 +204,293 @@ final class HistoryAutonomyTests: XCTestCase {
 
     // MARK: The chart's key, and the strip's bounds
 
-    /// The chart's colour scale is what Swift Charts builds its legend from, so
-    /// a line with no colour is a line the key cannot name. The web twin of
-    /// this check is `the three line colours are distinct`.
-    func testSeriesColorsCoverEveryLineAndAreDistinct() {
+    /// The chart's colour scale still has to cover every drawn line: a line
+    /// with no colour is a line drawn in fallback grey.
+    func testSeriesColorsCoverEveryLine() {
         XCTAssertEqual(AutonomyPalette.seriesOrder, ["p95", "p50", "p5"])
         for key in AutonomyPalette.seriesOrder {
             XCTAssertNotNil(AutonomyPalette.seriesColors[key],
-                            "\(key) is drawn but has no colour, so the legend cannot name it")
+                            "\(key) is drawn but has no colour, so the key cannot name it")
+            XCTAssertNotNil(AutonomyPalette.seriesRoles[key],
+                            "\(key) is drawn but has no role, so nothing decides its weight")
         }
-        let range = AutonomyPalette.seriesRange
-        XCTAssertEqual(range.count, AutonomyPalette.seriesOrder.count)
-        XCTAssertEqual(Set(range.map { String(describing: $0) }).count, range.count,
-                       "two of the three lines share a colour — the key would be ambiguous")
+        XCTAssertEqual(AutonomyPalette.seriesRange.count, AutonomyPalette.seriesOrder.count)
+    }
+
+    /// The INVERSION of the old `…AndAreDistinct`. Distinct hues are what the
+    /// redesign removed: p95 and p5 are the two EDGES of one range, and a hue
+    /// each made them read as two independent measurements. The web twin is
+    /// `the three lines share one colour, and roles carry the difference`.
+    func testTheThreeLinesShareOneColourAndRolesCarryTheDifference() {
+        let colours = Set(AutonomyPalette.seriesRange.map { String(describing: $0) })
+        XCTAssertEqual(colours.count, 1, "the three lines must be one hue — weight is what separates them")
+        XCTAssertEqual(AutonomyPalette.seriesOrder.map { AutonomyPalette.role(of: $0) },
+                       [.edge, .line, .edge])
+        XCTAssertEqual(AutonomyPalette.seriesRoles.values.filter { $0 == .line }.count, 1,
+                       "more than one headline line makes \"the typical run\" ambiguous")
+        // The line carries the weight; the edges stay out of its way.
+        XCTAssertGreaterThan(AutonomyPalette.lineWidth(.line), AutonomyPalette.lineWidth(.edge))
+        XCTAssertGreaterThan(AutonomyPalette.opacity(.line, thin: false),
+                             AutonomyPalette.opacity(.edge, thin: false))
+        // …and a thin bucket is quieter than a measured one on both roles.
+        XCTAssertLessThan(AutonomyPalette.opacity(.line, thin: true),
+                          AutonomyPalette.opacity(.line, thin: false))
+        XCTAssertLessThan(AutonomyPalette.opacity(.edge, thin: true),
+                          AutonomyPalette.opacity(.edge, thin: false))
+    }
+
+    /// The key is two entries, because the chart draws two things — a line and
+    /// a plane. Three percentile swatches in one hue would promise a
+    /// distinction the chart stopped making, which is why the Swift Charts
+    /// legend derived from `seriesOrder` is hidden and this is drawn instead.
+    func testTheKeyHasTwoEntriesBothFromTheOneTable() {
+        let entries = AutonomyPalette.keyEntries
+        XCTAssertEqual(entries.count, 2)
+        XCTAssertEqual(entries.map(\.kind), [.line, .band])
+        for entry in entries {
+            // `from` names a row of the one table, not a label someone invented.
+            XCTAssertTrue(AutonomyPalette.seriesOrder.contains(entry.from),
+                          "\(entry.from) is not a line the chart draws")
+        }
+        XCTAssertEqual(String(describing: entries[0].color),
+                       String(describing: AutonomyPalette.seriesColors["p50"]!),
+                       "the line swatch must be the very colour the p50 line is stroked in")
+        XCTAssertEqual(String(describing: entries[1].fill), String(describing: Optional(AutonomyPalette.band)))
+        XCTAssertEqual(String(describing: entries[1].color), String(describing: AutonomyPalette.edge))
+        XCTAssertNil(entries[0].fill, "a line has no area; a fill would claim one")
+    }
+
+    /// Both labels name their percentiles AND say what they mean in words:
+    /// "p5–p95" is not something a reader who has never seen a percentile can
+    /// read. Same two strings as the web panel's key.
+    func testTheKeyExplainsItselfInWords() {
+        let entries = AutonomyPalette.keyEntries
+        XCTAssertEqual(entries[0].label, "p50 · the typical run")
+        XCTAssertEqual(entries[1].label, "p5–p95 · where most runs land")
+    }
+
+    /// The band is a WEIGHT of the line's hue, not a fourth colour. Were it an
+    /// independent value, "one hue" would hold for the three strokes and
+    /// quietly fail for the largest area of ink on the chart. Checked in BOTH
+    /// appearances, because the band's alpha differs per appearance and a
+    /// hand-typed hex is exactly where a wrong triple would hide.
+    @MainActor
+    func testBandIsTheLineHueInBothAppearances() {
+        for appearance in [NSAppearance.Name.aqua, .darkAqua] {
+            let line = srgb(AutonomyPalette.lineColor, in: appearance)
+            for (name, colour) in [("band", AutonomyPalette.band),
+                                   ("bandThin", AutonomyPalette.bandThin),
+                                   ("edge", AutonomyPalette.edge)] {
+                let got = srgb(colour, in: appearance)
+                XCTAssertEqual(got.r, line.r, accuracy: 0.004, "\(name) is a different hue in \(appearance.rawValue)")
+                XCTAssertEqual(got.g, line.g, accuracy: 0.004, "\(name) is a different hue in \(appearance.rawValue)")
+                XCTAssertEqual(got.b, line.b, accuracy: 0.004, "\(name) is a different hue in \(appearance.rawValue)")
+            }
+        }
+    }
+
+    /// …and the band is genuinely translucent, in both appearances and with a
+    /// fainter plane for thin buckets. An opaque plane would bury the line it
+    /// is supposed to sit behind.
+    @MainActor
+    func testBandIsTranslucentAndThinIsFainter() {
+        for appearance in [NSAppearance.Name.aqua, .darkAqua] {
+            let band = alpha(AutonomyPalette.band, in: appearance)
+            let thin = alpha(AutonomyPalette.bandThin, in: appearance)
+            let edge = alpha(AutonomyPalette.edge, in: appearance)
+            XCTAssertGreaterThan(band, 0, "an invisible band draws nothing at all")
+            XCTAssertLessThan(band, 0.5, "a plane this solid competes with the line inside it")
+            XCTAssertLessThan(thin, band, "a thin bucket's plane must be fainter than a measured one's")
+            XCTAssertGreaterThan(edge, band, "the edges must read as the band's boundary")
+            XCTAssertLessThan(edge, 1, "a full-strength edge is a fourth curve, not a boundary")
+        }
+    }
+
+    /// Resolved sRGB of a possibly-appearance-dependent colour. Same technique
+    /// `TokenContrastTests.srgb` uses; force-unwraps on purpose, since a colour
+    /// this cannot resolve must fail the test rather than compare as equal.
+    @MainActor
+    private func srgb(_ color: Color, in appearance: NSAppearance.Name) -> (r: Double, g: Double, b: Double) {
+        var out = (r: 0.0, g: 0.0, b: 0.0)
+        NSAppearance(named: appearance)!.performAsCurrentDrawingAppearance {
+            let ns = NSColor(color).usingColorSpace(.sRGB)!
+            out = (Double(ns.redComponent), Double(ns.greenComponent), Double(ns.blueComponent))
+        }
+        return out
+    }
+
+    @MainActor
+    private func alpha(_ color: Color, in appearance: NSAppearance.Name) -> Double {
+        var out = 0.0
+        NSAppearance(named: appearance)!.performAsCurrentDrawingAppearance {
+            out = Double(NSColor(color).usingColorSpace(.sRGB)!.alphaComponent)
+        }
+        return out
+    }
+
+    // MARK: The band's geometry
+
+    private func bucket(_ ts: Int64, thin: Bool = false) -> HistoryAutonomyBucket {
+        decodeBucket("""
+        {"ts":\(ts),"p95":90,"p50":50,"p5":10,"min":10,"max":90,"count":\(thin ? 3 : 30),"thin":\(thin)}
+        """)
+    }
+
+    private func decodeBucket(_ json: String, file: StaticString = #filePath, line: UInt = #line) -> HistoryAutonomyBucket {
+        do {
+            return try JSONDecoder().decode(HistoryAutonomyBucket.self, from: Data(json.utf8))
+        } catch {
+            XCTFail("fixture is not a decodable bucket: \(error)\n\(json)", file: file, line: line)
+            return decodeBucket("""
+            {"ts":0,"p95":1,"p50":1,"p5":1,"min":1,"max":1,"count":1}
+            """)
+        }
+    }
+
+    /// The daemon OMITS empty buckets, and reading `buckets` directly hands
+    /// Swift Charts a dense list in which the gap simply is not there — so it
+    /// connects straight across. `alignedBuckets` is what puts the hole back.
+    func testAlignedBucketsPutTheGapBack() throws {
+        let d = try durationWithBuckets(starts: [100, 200, 300, 400], present: [100, 400])
+        let aligned = d.alignedBuckets
+        XCTAssertEqual(aligned.count, 4)
+        XCTAssertNotNil(aligned[0])
+        XCTAssertNil(aligned[1], "an omitted bucket is a GAP, not a zero")
+        XCTAssertNil(aligned[2])
+        XCTAssertNotNil(aligned[3])
+    }
+
+    /// A LINE drawn across a gap interpolates; a FILLED AREA drawn across one
+    /// paints a whole plane over days that hold no runs at all.
+    func testABandSegmentNeverSpansAnEmptyBucket() throws {
+        let d = try durationWithBuckets(starts: [100, 200, 300, 400, 500], present: [100, 200, 400, 500])
+        let points = d.alignedBuckets
+        let segments = AutonomyBandLayout.segments(points: points)
+        XCTAssertEqual(segments.map { [$0.from, $0.to] }, [[0, 1], [3, 4]])
+        // Stated as the property, not just the shape.
+        for segment in segments {
+            for i in segment.from...segment.to {
+                XCTAssertNotNil(points[i], "segment \(segment.id) covers an omitted bucket")
+            }
+        }
+    }
+
+    /// THE COMMITTED MUTATION: the "one polygon over everything present"
+    /// build — the shape a fill takes by default, and the shape that silently
+    /// claims the gap. It answers identically for a gapped range and an
+    /// unbroken one; production must not.
+    func testProductionTellsAGappedRangeFromAnUnbrokenOne() throws {
+        let gapped = try durationWithBuckets(starts: [1, 2, 3], present: [1, 3]).alignedBuckets
+        let whole = try durationWithBuckets(starts: [1, 2, 3], present: [1, 2, 3]).alignedBuckets
+
+        let bridging: ([HistoryAutonomyBucket?]) -> [AutonomyBandLayout.Segment] = {
+            [AutonomyBandLayout.Segment(from: 0, to: $0.count - 1, thin: false)]
+        }
+        XCTAssertEqual(bridging(gapped), bridging(whole))
+
+        XCTAssertEqual(AutonomyBandLayout.segments(points: whole),
+                       [AutonomyBandLayout.Segment(from: 0, to: 2, thin: false)])
+        XCTAssertNotEqual(AutonomyBandLayout.segments(points: gapped),
+                          AutonomyBandLayout.segments(points: whole))
+        // Two isolated buckets — a bridging build would have drawn one plane
+        // straight over the empty day between them.
+        XCTAssertEqual(AutonomyBandLayout.segments(points: gapped),
+                       [AutonomyBandLayout.Segment(from: 0, to: 0, thin: false),
+                        AutonomyBandLayout.Segment(from: 2, to: 2, thin: false)])
+    }
+
+    /// A thin bucket's p95 IS its maximum and its p5 IS its minimum. Inside
+    /// one smooth plane that distinction disappears, so the plane splits there
+    /// and the thin stretch is filled from its own fainter token.
+    func testAThinStretchIsItsOwnSegmentAndTheSeamIsShared() {
+        let points: [HistoryAutonomyBucket?] = [
+            bucket(1), bucket(2), bucket(3, thin: true), bucket(4), bucket(5),
+        ]
+        let segments = AutonomyBandLayout.segments(points: points)
+        XCTAssertEqual(segments, [
+            AutonomyBandLayout.Segment(from: 0, to: 1, thin: false),
+            AutonomyBandLayout.Segment(from: 1, to: 3, thin: true),
+            AutonomyBandLayout.Segment(from: 3, to: 4, thin: false),
+        ])
+        // Adjacent segments SHARE their boundary index — a seam would show as
+        // a hairline crack down the band.
+        for i in 1..<segments.count {
+            XCTAssertEqual(segments[i].from, segments[i - 1].to)
+        }
+    }
+
+    /// The stroke dashes a segment either of whose ends is thin; the fill has
+    /// to split on the same rule, or the dashes and the plane disagree about
+    /// where the thin stretch is.
+    func testThinnessBelongsToTheIntervalNotTheBucket() {
+        let segments = AutonomyBandLayout.segments(points: [bucket(1), bucket(2, thin: true), bucket(3)])
+        XCTAssertEqual(segments, [AutonomyBandLayout.Segment(from: 0, to: 2, thin: true)])
+    }
+
+    /// A lone bucket has no neighbour to make an area with. Reported as a
+    /// zero-width segment so the chart can draw its spread as a whisker rather
+    /// than leaving the one bucket that most needs a range with none.
+    func testAnIsolatedBucketIsAZeroWidthSegment() throws {
+        let points = try durationWithBuckets(starts: [1, 2, 3], present: [2]).alignedBuckets
+        let segments = AutonomyBandLayout.segments(points: points)
+        XCTAssertEqual(segments, [AutonomyBandLayout.Segment(from: 1, to: 1, thin: false)])
+        XCTAssertTrue(segments[0].isIsolated)
+    }
+
+    func testAnEmptyAxisProducesNoSegments() {
+        XCTAssertTrue(AutonomyBandLayout.segments(points: []).isEmpty)
+        XCTAssertTrue(AutonomyBandLayout.segments(points: [nil, nil]).isEmpty)
+    }
+
+    // MARK: The boundary caption
+
+    /// The caption used to hang off its rule's LEFT unconditionally. It is a
+    /// fixed string most of the plot wide at 9 pt, so a rule in the left third
+    /// had less room than the caption needed, SwiftUI clamped the annotation
+    /// to the chart's leading edge, and the caption ended up detached from the
+    /// rule it describes with its arrow pointing off-chart at nothing.
+    func testTheCaptionHangsOffWhicheverSideOfTheRuleHasRoom() {
+        XCTAssertEqual(AutonomyBoundaryCaption.side(fraction: 0.0), .right)
+        XCTAssertEqual(AutonomyBoundaryCaption.side(fraction: 0.36), .right,
+                       "the measured case: a rule at 36% has more room to its right")
+        XCTAssertEqual(AutonomyBoundaryCaption.side(fraction: 0.5), .left)
+        XCTAssertEqual(AutonomyBoundaryCaption.side(fraction: 0.9), .left)
+    }
+
+    /// THE COMMITTED MUTATION for it: the always-left build. It answers
+    /// identically for a rule near the left edge and one near the right;
+    /// production must not, or "it is placed where there is room" could pass
+    /// against a build that never looked at where the rule is.
+    func testProductionTellsALeftRuleFromARightOne() {
+        let alwaysLeft: (Double) -> AutonomyBoundaryCaption.Side = { _ in .left }
+        XCTAssertEqual(alwaysLeft(0.1), alwaysLeft(0.9))
+        XCTAssertNotEqual(AutonomyBoundaryCaption.side(fraction: 0.1),
+                          AutonomyBoundaryCaption.side(fraction: 0.9))
+    }
+
+    /// The fraction the side is chosen from is the rule's real position in the
+    /// drawn domain — the macOS twin of the web's `fraction`.
+    func testBoundaryFractionIsItsPositionInTheDrawnDomain() throws {
+        let d = try durationWithBuckets(starts: [0, 100, 200, 300, 400], present: [0])
+        let boundary = HistoryAutonomyBoundary(ts: 100, from: "cost", to: "log")
+        XCTAssertEqual(d.domainFraction(of: boundary), 0.25, accuracy: 0.0001)
+    }
+
+    /// Decodes a duration payload whose `bucket_starts` is `starts` and whose
+    /// `buckets` holds only `present` — the omission the daemon really makes,
+    /// exercised through the real decode path rather than a hand-built struct.
+    private func durationWithBuckets(starts: [Int64], present: [Int64]) throws -> HistoryAutonomyDurationResponse {
+        let startList = starts.map(String.init).joined(separator: ",")
+        let bucketList = present
+            .map { "{\"ts\":\($0),\"p95\":90,\"p50\":50,\"p5\":10,\"min\":10,\"max\":90,\"count\":30}" }
+            .joined(separator: ",")
+        let json = """
+        {"window":"30d","chart":"autonomy_duration","start":1,"end":2,"bucket_seconds":86400,
+         "bucket_starts":[\(startList)],"buckets":[\(bucketList)],
+         "summary":{"p95":90,"p50":50,"p5":10,"min":10,"max":90,"count":\(present.count)},
+         "sample_floor":20,"earliest_span":1,"total_recorded":\(present.count)}
+        """
+        return try JSONDecoder().decode(HistoryAutonomyDurationResponse.self, from: Data(json.utf8))
     }
 
     /// The strip's bounds coarsen with the window, so an 8h strip reads as a

--- a/platforms/macos/Tests/HistoryAutonomyTests.swift
+++ b/platforms/macos/Tests/HistoryAutonomyTests.swift
@@ -266,7 +266,7 @@ final class HistoryAutonomyTests: XCTestCase {
     func testTheKeyExplainsItselfInWords() {
         let entries = AutonomyPalette.keyEntries
         XCTAssertEqual(entries[0].label, "p50 · the typical run")
-        XCTAssertEqual(entries[1].label, "p5–p95 · where most runs land")
+        XCTAssertEqual(entries[1].label, "p5–p95 · the usual spread")
     }
 
     /// The band is a WEIGHT of the line's hue, not a fourth colour. Were it an

--- a/platforms/web/autonomyLayout.test.js
+++ b/platforms/web/autonomyLayout.test.js
@@ -1,0 +1,154 @@
+// Autonomy control-placement contract (#1905 redesign).
+//
+// The defect this pins: Range (which changes the duration chart) and Span
+// (which changes the run strip) shipped on ONE control row above BOTH
+// elements. Nothing on screen said which control moved which, and the two
+// vocabularies overlap textually — `30d` is a Range value AND a Span value —
+// so the row read as one zoom control with an odd set of steps. Each control
+// now sits directly above the element it changes: Range in its own row above
+// the chart card, Span in the strip's own header.
+//
+// jsdom has no layout engine, so this cannot assert geometry — every
+// getBoundingClientRect here would be zeroes. It asserts the two things that
+// CAUSE the geometry instead: the DOM puts each picker inside the block it
+// governs, and the picker precedes the element it labels in document order.
+// The same technique headerLayout.test.js uses, for the same reason.
+//
+// Fail-loud (house rule: a verifier that cannot run must never read as a
+// pass): an unreadable or empty file, an index.html with no Autonomy section,
+// and a stylesheet with no matching rule each THROW rather than vacuously
+// satisfying the assertions below.
+
+import { describe, expect, test } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { JSDOM } from 'jsdom';
+import { WEB_DIR } from './shippedFiles.testutil.js';
+
+function read(name) {
+  const body = readFileSync(join(WEB_DIR, name), 'utf8');
+  if (body.trim().length === 0) {
+    throw new Error(`fail-loud: ${name} is empty — nothing below can be trusted`);
+  }
+  return body;
+}
+
+const html = read('index.html');
+const css = read('irrlicht.css');
+const js = read('historyTab.js');
+
+function doc() {
+  const d = new JSDOM(html).window.document;
+  if (!d.querySelector('#history-autonomy-strip')) {
+    throw new Error('fail-loud: index.html has no #history-autonomy-strip — the parse found no Autonomy section');
+  }
+  return d;
+}
+
+// The declaration block of the first CSS rule whose selector list is exactly
+// `selector`. Throws rather than returning '' so a renamed selector fails
+// loudly instead of satisfying every assertion.
+function ruleBody(selector) {
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const m = new RegExp('(?:^|\\n)[ \\t]*' + escaped + '\\s*\\{([^}]*)\\}').exec(css);
+  if (!m) {
+    throw new Error(`fail-loud: irrlicht.css has no \`${selector} { … }\` rule — the parse found nothing to assert on`);
+  }
+  return m[1];
+}
+
+// Node.DOCUMENT_POSITION_FOLLOWING === 4
+const follows = (a, b) => Boolean(a.compareDocumentPosition(b) & 4);
+
+// The property under test, as a predicate over any document, so it can be run
+// against the mutation fixture below as well as against the shipped markup.
+function pickersAreSeparated(d) {
+  const range = d.querySelector('#history-autonomy-range-sel');
+  const span = d.querySelector('#history-autonomy-span-sel');
+  if (!range || !span) {
+    throw new Error('fail-loud: a document under test is missing one of the two Autonomy pickers');
+  }
+  const sharedRow = range.closest('.history-ctl-row');
+  return Boolean(sharedRow) && sharedRow !== span.closest('.history-ctl-row');
+}
+
+describe('each Autonomy control sits with the element it changes', () => {
+  test('Range has a control row of its own, and Span is not on it', () => {
+    const d = doc();
+    const range = d.querySelector('#history-autonomy-range-sel');
+    expect(range, 'the Range picker must exist').not.toBeNull();
+    const row = range.closest('.history-ctl-row');
+    expect(row, 'Range belongs in a .history-ctl-row above the chart').not.toBeNull();
+    expect(row.querySelector('#history-autonomy-span-sel'),
+      'Span must not share Range’s row — that is the confusion this fixes').toBeNull();
+    expect(pickersAreSeparated(d)).toBe(true);
+  });
+
+  test('Range’s row comes before the chart it changes', () => {
+    const d = doc();
+    const row = d.querySelector('#history-autonomy-range-row');
+    expect(row, 'index.html must hold #history-autonomy-range-row').not.toBeNull();
+    const chart = d.querySelector('.history-layout');
+    expect(chart, 'index.html must hold the chart layout').not.toBeNull();
+    expect(follows(row, chart), 'the chart must follow its Range picker').toBe(true);
+  });
+
+  test('Span lives inside the run strip, above the rows it changes', () => {
+    const d = doc();
+    const span = d.querySelector('#history-autonomy-span-sel');
+    const strip = d.querySelector('#history-autonomy-strip');
+    expect(strip.contains(span), 'Span must live inside the strip section it governs').toBe(true);
+    // …and not in the control block at the top of the tab, which is what
+    // "above both elements" meant.
+    expect(span.closest('.history-ctl-row'), 'Span must not be in a top-of-tab control row').toBeNull();
+    const rows = d.querySelector('#history-autonomy-rows');
+    expect(rows, 'the strip must hold its rows container').not.toBeNull();
+    expect(follows(span, rows), 'the strip’s rows must follow the Span picker').toBe(true);
+  });
+
+  test('the strip’s header keeps the title and the picker on one row', () => {
+    const d = doc();
+    const header = d.querySelector('.history-autonomy-header');
+    expect(header, 'the strip needs a header row for its title + picker').not.toBeNull();
+    expect(header.querySelector('#history-autonomy-strip-title')).not.toBeNull();
+    expect(header.querySelector('#history-autonomy-span-sel')).not.toBeNull();
+    expect(ruleBody('.history-autonomy-header')).toMatch(/display:\s*flex/);
+    // It wraps rather than compressing: five segmented buttons plus a title
+    // do not fit a narrow window on one line, and squeezing them is worse
+    // than stacking them.
+    expect(ruleBody('.history-autonomy-header')).toMatch(/flex-wrap:\s*wrap/);
+  });
+
+  // The markup and the code that shows/hides it are two files, and a rename in
+  // one is invisible to the other until the row silently stops toggling. The
+  // shared row's old id is gone from BOTH, and the new one is in both.
+  test('the row toggle and the markup name the same row', () => {
+    expect(html).toContain('id="history-autonomy-range-row"');
+    expect(js).toContain("getElementById('history-autonomy-range-row')");
+    expect(html).not.toContain('id="history-autonomy-row"');
+    expect(js).not.toContain("getElementById('history-autonomy-row')");
+  });
+
+  // THE COMMITTED MUTATION: the shipped-before layout, both pickers on one
+  // row. A check that could not tell it from the split layout would pass
+  // against the very arrangement this change exists to remove.
+  test('the check goes red against the one-row layout it replaced', () => {
+    const merged = new JSDOM(`
+      <div class="history-ctl-row" id="history-autonomy-row">
+        <span class="history-ctl-label">Range</span>
+        <fieldset id="history-autonomy-range-sel"></fieldset>
+        <span class="history-ctl-label">Span</span>
+        <fieldset id="history-autonomy-span-sel"></fieldset>
+      </div>
+    `).window.document;
+    expect(pickersAreSeparated(merged)).toBe(false);
+    expect(pickersAreSeparated(doc())).toBe(true);
+  });
+
+  // …and the fail-loud half: a document with no pickers at all must throw,
+  // never quietly report "separated".
+  test('a document missing a picker fails loudly instead of passing', () => {
+    const empty = new JSDOM('<div></div>').window.document;
+    expect(() => pickersAreSeparated(empty)).toThrow(/fail-loud/);
+  });
+});

--- a/platforms/web/autonomyLayout.test.js
+++ b/platforms/web/autonomyLayout.test.js
@@ -24,6 +24,7 @@ import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { JSDOM } from 'jsdom';
 import { WEB_DIR } from './shippedFiles.testutil.js';
+import { autonomyPanelRows, autonomyDuration } from './historyTab.js';
 
 function read(name) {
   const body = readFileSync(join(WEB_DIR, name), 'utf8');
@@ -150,5 +151,170 @@ describe('each Autonomy control sits with the element it changes', () => {
   test('a document missing a picker fails loudly instead of passing', () => {
     const empty = new JSDOM('<div></div>').window.document;
     expect(() => pickersAreSeparated(empty)).toThrow(/fail-loud/);
+  });
+});
+
+// The one px value in this file, and it is an ESTIMATE, stated as one: the
+// advance of a monospace glyph as a fraction of its font-size. 0.6em is the
+// figure for SF Mono, Menlo, Consolas and Cascadia Code — every family in
+// --font-mono — and jsdom cannot measure text, so nothing here can produce a
+// real metric. It is used only to show a label CLEARS its column with room to
+// spare, so a face a few percent wider than the estimate still fits.
+const MONO_ADVANCE_EM = 0.6;
+
+// One declaration out of a rule body, as a number of px. Throws rather than
+// returning a default: a property this cannot find is one whose value nothing
+// below can be trusted to have computed.
+function px(body, property, selector) {
+  const m = new RegExp('(?:^|[;{\\s])' + property + '\\s*:\\s*([^;]+)').exec(body);
+  if (!m) {
+    throw new Error(`fail-loud: \`${selector}\` declares no ${property} — the width budget cannot be computed`);
+  }
+  const value = /(-?\d+(?:\.\d+)?)px/.exec(m[1]);
+  if (!value) {
+    throw new Error(`fail-loud: \`${selector}\`'s ${property} is "${m[1].trim()}", which is not a px length`);
+  }
+  return Number(value[1]);
+}
+
+// The panel's geometry, read from the stylesheet rather than typed here — so
+// narrowing the panel, fattening the swatch or widening the gap fails this
+// test instead of silently re-truncating the label.
+function panelGeometry() {
+  const panel = ruleBody('.history-panel');
+  const flex = /flex:\s*\d+\s+\d+\s+(\d+(?:\.\d+)?)px/.exec(panel);
+  if (!flex) {
+    throw new Error('fail-loud: .history-panel has no fixed px flex-basis — the width budget cannot be computed');
+  }
+  const content = Number(flex[1]) - 2 * px(panel, 'padding', '.history-panel');
+  const row = ruleBody('.history-contrib li');
+  const swatch = px(ruleBody('.history-contrib .dot.autonomy-band'), 'width', '.history-contrib .dot.autonomy-band');
+  const gap = px(row, 'gap', '.history-contrib li');
+  return {
+    content,
+    fontSize: px(row, 'font-size', '.history-contrib li'),
+    // A key row's label shares its line with the swatch and one gap; its
+    // value has a line to itself, so the value gets the whole content width.
+    labelLine: content - swatch - gap,
+  };
+}
+
+describe('the key rows fit the panel they are rendered in', () => {
+  // THE DEFECT: at the shipped width the band row rendered as
+  // `p5–p95 · where most runs…` with an ellipsis, and its value broke across
+  // two lines as `6s –` / `23m46s`. So the one row whose whole job is to
+  // explain the band cut off its own explanation, and a single span read as
+  // two numbers. jsdom has no layout engine, so this asserts the two things
+  // that CAUSE that geometry — the width budget, and the CSS that decides
+  // what happens when something exceeds it.
+  const geometry = panelGeometry();
+  const width = (text) => text.length * geometry.fontSize * MONO_ADVANCE_EM;
+  const unstyled = { getPropertyValue: () => '' };
+  const keyRows = () => autonomyPanelRows(
+    { p95: 1426, p50: 210, p5: 6, min: 4, max: 8040, count: 312 }, unstyled,
+  ).filter((r) => r.kind);
+
+  test('the panel is wide enough for every key label on one line', () => {
+    expect(keyRows()).toHaveLength(2);
+    for (const row of keyRows()) {
+      expect(width(row.label), `"${row.label}" (${row.label.length} chars) overruns the `
+        + `${geometry.labelLine}px a key row's label gets`).toBeLessThan(geometry.labelLine);
+    }
+  });
+
+  // The QA case verbatim: p5 6s, p95 23m46s. It is the value that broke, and
+  // it breaks again the moment a label is allowed to crowd it.
+  test('the reported row fits: label and value each clear their line', () => {
+    const band = keyRows()[1];
+    expect(band.value).toBe('6s – 23m46s');
+    expect(width(band.label)).toBeLessThan(geometry.labelLine);
+    expect(width(band.value)).toBeLessThan(geometry.content);
+  });
+
+  // …and the widest figure this formatter can ever produce, so the check is
+  // not pinned to one lucky data set. autonomyDuration's longest output is a
+  // six-character `NNdNNh`, twice, with the separator between.
+  test('even the widest range this formatter can emit fits its line', () => {
+    const widest = autonomyDuration(12 * 86400 + 23 * 3600) + ' – ' + autonomyDuration(12 * 86400 + 23 * 3600);
+    expect(widest).toBe('12d23h – 12d23h');
+    expect(width(widest)).toBeLessThan(geometry.content);
+  });
+
+  // THE COMMITTED MUTATION: the label as it shipped. It is one character over
+  // the column, which is exactly why nobody caught it by eye — and it is the
+  // string the check has to reject, or the check is decoration.
+  test('the check rejects the label that shipped truncated', () => {
+    expect(width('p5–p95 · where most runs land')).toBeGreaterThan(geometry.labelLine);
+    // …while the one that replaced it clears the column with room to spare,
+    // so a mono face a little wider than the estimate still fits.
+    expect(width('p5–p95 · the usual spread')).toBeLessThan(geometry.labelLine * 0.95);
+  });
+
+  test('a stylesheet the budget cannot be read from fails loudly', () => {
+    expect(() => px('color: red;', 'width', '.nope')).toThrow(/fail-loud/);
+    expect(() => px('width: 50%;', 'width', '.nope')).toThrow(/fail-loud/);
+    expect(() => ruleBody('.history-contrib li.no-such-key')).toThrow(/fail-loud/);
+  });
+});
+
+describe('nothing in the panel truncates a key label or splits a figure', () => {
+  // The width budget above says the label FITS. These say what happens if it
+  // ever stops fitting — it wraps, and the reader still gets the whole
+  // sentence. A truncated explanation is unreadable; a wrapped one is merely
+  // taller, and this row explains the largest area of ink on the chart.
+  test('a key row’s label wraps rather than ellipsising', () => {
+    const body = ruleBody('.history-contrib li.autonomy-key .label');
+    expect(body).toMatch(/white-space:\s*normal/);
+    expect(body).toMatch(/overflow:\s*visible/);
+    expect(body).not.toMatch(/text-overflow:\s*ellipsis/);
+  });
+
+  test('no figure in the panel is ever split across lines', () => {
+    expect(ruleBody('.history-contrib .val')).toMatch(/white-space:\s*nowrap/);
+  });
+
+  // The value gets a line of its own — which is what makes the label's line
+  // 204px rather than the 196px it would have to share.
+  test('a key row’s value takes a line of its own, right-aligned', () => {
+    expect(ruleBody('.history-contrib li.autonomy-key')).toMatch(/flex-wrap:\s*wrap/);
+    const val = ruleBody('.history-contrib li.autonomy-key .val');
+    expect(val).toMatch(/flex:\s*0\s+0\s+100%/);
+    expect(val).toMatch(/text-align:\s*right/);
+  });
+
+  // The rows have to CARRY the class the rules above are written against, or
+  // every one of them is asserting about markup nothing renders.
+  test('the panel actually marks its key rows', () => {
+    const list = new JSDOM('<ul id="l"></ul>').window.document.getElementById('l');
+    for (const row of autonomyPanelRows({ p95: 60, p50: 30, p5: 10, min: 1, max: 99, count: 5 },
+      { getPropertyValue: () => '' })) {
+      const li = list.ownerDocument.createElement('li');
+      if (row.kind) li.className = 'autonomy-key';
+      list.appendChild(li);
+    }
+    // Two key rows, three unswatched figures — the same split renderAutonomyPanel makes.
+    expect(list.querySelectorAll('li.autonomy-key')).toHaveLength(2);
+    expect(js).toMatch(/li\.className\s*=\s*'autonomy-key'/);
+  });
+});
+
+describe('the two surfaces name the key the same way', () => {
+  // Two clients must not explain one chart differently. Reads the Swift
+  // source rather than comparing against a hand-typed literal — the same
+  // technique sessionError.test.js uses for Tokens.swift, and the twin of
+  // macOS's own testBoundaryLabelsMatchTheWebs.
+  const swift = readFileSync(
+    join(WEB_DIR, '..', 'macos', 'Irrlicht', 'Views', 'HistoryAutonomyView.swift'), 'utf8',
+  );
+
+  test('AutonomyPalette.keyEntries carries the web’s two labels verbatim', () => {
+    const entries = /static var keyEntries: \[AutonomyKeyEntry\] \{([\s\S]*?)\n    \}/.exec(swift);
+    expect(entries, 'fail-loud: no AutonomyPalette.keyEntries found in HistoryAutonomyView.swift').not.toBeNull();
+    const labels = [...entries[1].matchAll(/label: "([^"]+)"/g)].map((m) => m[1]);
+    expect(labels, 'fail-loud: parsed no labels out of keyEntries').toHaveLength(2);
+    const web = autonomyPanelRows(undefined, { getPropertyValue: () => '' })
+      .filter((r) => r.kind)
+      .map((r) => r.label);
+    expect(labels).toEqual(web);
   });
 });

--- a/platforms/web/historyTab.js
+++ b/platforms/web/historyTab.js
@@ -1034,10 +1034,24 @@ const AUTONOMY_ROLE_STYLE = {
 //
 // Named for a reader who has never seen a percentile — the register the panel
 // already used ("the typical run") — with the p-labels kept in front for a
-// reader who has.
+// reader who has. Two noun phrases that read as a pair, which is the point:
+// the chart draws one line and one plane, and these name them as one thing
+// and its spread rather than as two measurements.
+//
+// LENGTH IS A CONSTRAINT HERE, not a style preference. This panel is
+// `flex: 0 0 260px` with 16px padding, so a key row's label gets 204px once
+// its swatch and gap are taken out — about 28 monospace characters at 12px.
+// The band row first shipped as "p5–p95 · where most runs land" (29), which
+// ellipsised in the real panel: the one row whose job is to explain the band
+// cut off its own explanation. `autonomyLayout.test.js` computes that budget
+// from the stylesheet and fails a label that will not fit.
+//
+// Both strings are duplicated in AutonomyPalette.keyEntries on macOS, and
+// `the two surfaces name the key the same way` reads this table against that
+// one — two clients must not explain one chart differently.
 const AUTONOMY_KEY = [
   ['line', 'p50', 'p50 · the typical run'],
-  ['band', 'p95', 'p5–p95 · where most runs land'],
+  ['band', 'p95', 'p5–p95 · the usual spread'],
 ];
 
 // autonomySeriesColor resolves one line's colour against the live theme,
@@ -1594,6 +1608,10 @@ function renderAutonomyPanel() {
   } else {
     for (const row of autonomyPanelRows(s, getComputedStyle(document.documentElement))) {
       const li = document.createElement('li');
+      // The key rows lay out differently from the figure rows below them:
+      // they carry a sentence AND a two-ended figure, which do not fit one
+      // 228px line together. See .history-contrib li.autonomy-key.
+      if (row.kind) li.className = 'autonomy-key';
       const dot = document.createElement('span');
       // The two key swatches take the SHAPE of what they stand for — a rule
       // for the line, a bounded plane for the band. A pair of identical dots

--- a/platforms/web/historyTab.js
+++ b/platforms/web/historyTab.js
@@ -451,10 +451,14 @@ function syncHistoryRangeRow() {
   if (row) row.hidden = historyState.chart === 'state' || historyState.chart === 'autonomy';
 }
 
-// syncAutonomyRows shows the Autonomy pickers and the run strip only while the
-// section is active, mirroring syncGranularityRow's per-chart row toggle.
+// syncAutonomyRows shows the Autonomy controls and the run strip only while
+// the section is active, mirroring syncGranularityRow's per-chart row toggle.
+//
+// One row, not two: Range is the only Autonomy control up here now, because
+// Span moved into the strip's own header (which this same function shows and
+// hides, so the picker cannot outlive the element it drives).
 function syncAutonomyRows(isAutonomy) {
-  const ctl = document.getElementById('history-autonomy-row');
+  const ctl = document.getElementById('history-autonomy-range-row');
   if (ctl) ctl.hidden = !isAutonomy;
   const strip = document.getElementById('history-autonomy-strip');
   if (strip) strip.hidden = !isAutonomy;
@@ -980,28 +984,61 @@ export function autonomyChartPoints(duration) {
   return starts.map(ts => byTs.get(ts) || null);
 }
 
-// The three drawn lines, in draw order: series key, the CSS custom property
-// that colours it, and the fallback for a stylesheet that has not loaded.
+// The three drawn lines, in draw order: series key, the ROLE it plays in the
+// chart, the CSS custom property that colours it, and the fallback for a
+// stylesheet that has not loaded.
 //
-// EXPORTED, and read by both the canvas painter and the side panel's key
-// swatches. The web shipped its first round with three unlabelled curves and a
-// panel that explicitly blanked its dots, so a reader had to infer which line
-// was which from vertical order. A key drawn from a SECOND colour table would
-// be worse than none — it can disagree with the chart — so there is one table
-// and one resolver.
+// ONE HUE, THREE WEIGHTS. The first round drew p95 green, p50 purple and p5
+// orange — three equally loud curves that a reader had to decode before the
+// chart said anything. It says one thing now: here is the typical run (the
+// solid `line`), and here is the spread around it (the translucent plane
+// between the two quiet `edge`s). Three hues cannot say that; a hue per
+// percentile makes p95 and p5 read as two independent measurements rather
+// than as the boundary of one range.
+//
+// EXPORTED, and read by both the canvas painter and the side panel's key. The
+// web also shipped a panel that explicitly blanked its dots, so a reader had
+// to infer which line was which from vertical order. A key drawn from a SECOND
+// colour table would be worse than none — it can disagree with the chart — so
+// there is one table and one resolver.
 export const AUTONOMY_SERIES = [
-  ['p95', '--ready', '#34C759'],
-  ['p50', '--working', '#8B5CF6'],
-  ['p5', '--waiting', '#FF9500'],
+  ['p95', 'edge', '--working', '#8B5CF6'],
+  ['p50', 'line', '--working', '#8B5CF6'],
+  ['p5', 'edge', '--working', '#8B5CF6'],
 ];
 
-// Panel labels for the three lines. Split from the colour table only because
-// the canvas has no use for them.
-const AUTONOMY_SERIES_LABELS = {
-  p95: 'p95 · how long the good runs go',
-  p50: 'p50 · the typical run',
-  p5: 'p5 · how short the bad runs are',
+// The band's own colours — the fill between p5 and p95, the fainter fill a
+// thin bucket gets, and the weight its two edge lines are stroked at.
+//
+// A SECOND TABLE, not a second PALETTE: every entry is the --working hue at a
+// lower alpha (`the band is the p50 hue, not a fourth colour` pins that), and
+// both the canvas and the panel's band swatch read these same three entries,
+// so the key cannot show a plane the chart does not draw.
+export const AUTONOMY_BAND_TOKENS = {
+  fill: ['--autonomy-band', 'rgba(139, 92, 246, 0.20)'],
+  fillThin: ['--autonomy-band-thin', 'rgba(139, 92, 246, 0.08)'],
+  edge: ['--autonomy-edge', 'rgba(139, 92, 246, 0.45)'],
 };
+
+// Per-role stroke weights. The p50 line carries the chart: full alpha, the
+// heavier stroke. The two edges are present enough to bound the plane and
+// quiet enough not to compete with it.
+const AUTONOMY_ROLE_STYLE = {
+  line: { width: 1.8, alpha: 1, thinAlpha: 0.6, marker: 2.6 },
+  edge: { width: 1, alpha: 0.5, thinAlpha: 0.32, marker: 2 },
+};
+
+// The two key entries, in panel order. `from` names the AUTONOMY_SERIES row
+// each one takes its colour from, so neither can be given a colour the chart
+// does not stroke.
+//
+// Named for a reader who has never seen a percentile — the register the panel
+// already used ("the typical run") — with the p-labels kept in front for a
+// reader who has.
+const AUTONOMY_KEY = [
+  ['line', 'p50', 'p50 · the typical run'],
+  ['band', 'p95', 'p5–p95 · where most runs land'],
+];
 
 // autonomySeriesColor resolves one line's colour against the live theme,
 // falling back to the literal when the custom property is unset (an
@@ -1011,8 +1048,92 @@ const AUTONOMY_SERIES_LABELS = {
 export function autonomySeriesColor(key, cs) {
   const row = AUTONOMY_SERIES.find(([k]) => k === key);
   if (!row) return '';
-  const [, cssVar, fallback] = row;
+  const [, , cssVar, fallback] = row;
   return ((cs && cs.getPropertyValue(cssVar)) || fallback).trim();
+}
+
+// autonomySeriesRole reports whether a key is the headline `line` or one of
+// the band's `edge`s. '' for anything the chart does not draw.
+export function autonomySeriesRole(key) {
+  const row = AUTONOMY_SERIES.find(([k]) => k === key);
+  return row ? row[1] : '';
+}
+
+// autonomyBandColor resolves one of the band's three tokens, same fallback
+// rule as autonomySeriesColor. '' for a name the band has no token for.
+export function autonomyBandColor(name, cs) {
+  const token = AUTONOMY_BAND_TOKENS[name];
+  if (!token) return '';
+  const [cssVar, fallback] = token;
+  return ((cs && cs.getPropertyValue(cssVar)) || fallback).trim();
+}
+
+// autonomyKeyEntries is the chart's key: exactly two entries, because the
+// chart draws exactly two things — a line and a plane.
+//
+// Every colour here is resolved through autonomySeriesColor / autonomyBandColor
+// — the same calls the canvas makes — so a swatch cannot disagree with the ink
+// beside it. `fill` is '' for the line entry: a line has no area.
+export function autonomyKeyEntries(cs) {
+  return AUTONOMY_KEY.map(([kind, from, label]) => ({
+    kind,
+    from,
+    label,
+    color: kind === 'band' ? autonomyBandColor('edge', cs) : autonomySeriesColor(from, cs),
+    fill: kind === 'band' ? autonomyBandColor('fill', cs) : '',
+  }));
+}
+
+// autonomyBandSegments splits the gap-aligned point list into the areas the
+// band may actually be filled over.
+//
+// TWO RULES, both of them honesty rules the smooth shape would otherwise
+// erase, and both of them the reason this is a pure function rather than a
+// loop inside the painter:
+//
+//   - A FILLED AREA WANTS TO CLOSE ACROSS A GAP. The daemon omits empty
+//     buckets and the line breaks there (autonomyChartPoints); a polygon
+//     spanning the gap would draw a plane over days that hold no runs at all,
+//     which is a stronger false claim than the interpolated line #1905 already
+//     refuses. A segment therefore never crosses a null.
+//   - A THIN BUCKET IS NOT A PERCENTILE. Under sample_floor, p95 is that
+//     bucket's longest run and p5 its shortest. The stroke already dashes
+//     across such a bucket; the fill splits at the same place so the thin
+//     stretch can be painted in its own fainter plane.
+//
+// Returns index ranges into `points`, inclusive at both ends. Adjacent
+// segments SHARE their boundary index, so a thin→solid handover has no seam.
+// `from === to` is an isolated bucket: it has no neighbour to make an area
+// with, and the painter draws its spread as a whisker instead.
+export function autonomyBandSegments(points) {
+  const out = [];
+  const n = (points || []).length;
+  let i = 0;
+  while (i < n) {
+    if (!points[i]) { i++; continue; }
+    let last = i;
+    while (last + 1 < n && points[last + 1]) last++;
+    if (last === i) {
+      out.push({ from: i, to: i, thin: !!points[i].thin });
+      i = last + 1;
+      continue;
+    }
+    // Thinness belongs to the INTERVAL, not the bucket — matching
+    // drawAutonomySeries, which dashes a segment either of whose ends is thin.
+    let start = i;
+    let thin = !!(points[i].thin || points[i + 1].thin);
+    for (let j = i + 1; j < last; j++) {
+      const next = !!(points[j].thin || points[j + 1].thin);
+      if (next !== thin) {
+        out.push({ from: start, to: j, thin });
+        start = j;
+        thin = next;
+      }
+    }
+    out.push({ from: start, to: last, thin });
+    i = last + 1;
+  }
+  return out;
 }
 
 function paintAutonomyChart() {
@@ -1047,15 +1168,77 @@ function paintAutonomyChart() {
     return padT + plotH * (1 - t);
   };
 
+  // Draw order IS the visual hierarchy, cheapest thing first:
+  //
+  //   gridlines → band → boundary rules → edges → p50 → axis labels
+  //
+  // The band goes over the gridlines rather than under them. A gridline is
+  // furniture; drawn on top of the plane it would cut the band into slices
+  // that read as structure in the data, which is the one thing a soft fill
+  // must never do. Over it, the fill's own translucency dims each gridline
+  // where it crosses — the line stays legible, and stays furniture.
   drawAutonomyGridlines(ctx, { lo, hi, yAt, padL, padR, w, muted, gridColor });
+  drawAutonomyBand(ctx, {
+    points,
+    segments: autonomyBandSegments(points),
+    xAt,
+    yAt,
+    fill: autonomyBandColor('fill', cs),
+    fillThin: autonomyBandColor('fillThin', cs),
+    edge: autonomyBandColor('edge', cs),
+  });
   // Under the lines, deliberately: the marker explains the data, it is not
   // part of it, and a rule drawn over a curve competes with the thing it is
   // annotating.
   drawAutonomyBoundaries(ctx, { duration, padL, plotW, padT, plotH, muted });
-  for (const [key] of AUTONOMY_SERIES) {
-    drawAutonomySeries(ctx, { points, key, color: autonomySeriesColor(key, cs), xAt, yAt });
+  // Edges before the line, whatever order the table lists them in: the
+  // headline curve is the last ink down, so nothing crosses over it.
+  for (const role of ['edge', 'line']) {
+    for (const [key, seriesRole] of AUTONOMY_SERIES) {
+      if (seriesRole !== role) continue;
+      drawAutonomySeries(ctx, { points, key, role, color: autonomySeriesColor(key, cs), xAt, yAt });
+    }
   }
   drawAutonomyXLabels(ctx, { duration, xAt, muted, h, padB });
+}
+
+// drawAutonomyBand fills the plane between p5 and p95 — the spread around the
+// typical run — one polygon per autonomyBandSegments entry.
+//
+// It fills SEGMENT BY SEGMENT rather than as one path so the two rules that
+// function encodes survive the paint: a gap leaves real empty canvas (no
+// plane over days with no runs), and a thin stretch is filled from the
+// fainter token, so a range that is not a percentile spread does not look
+// like one.
+function drawAutonomyBand(ctx, { points, segments, xAt, yAt, fill, fillThin, edge }) {
+  ctx.save();
+  for (const seg of segments) {
+    if (seg.from === seg.to) {
+      // An isolated bucket has no neighbour to make an area with. Drawn as a
+      // whisker rather than dropped, or it would be the one bucket whose
+      // spread is invisible — and a lone bucket is exactly where the reader
+      // most needs to see how wide the range was.
+      const only = points[seg.from];
+      ctx.setLineDash(seg.thin ? [3, 3] : []);
+      ctx.strokeStyle = edge;
+      ctx.lineWidth = 1;
+      ctx.beginPath();
+      ctx.moveTo(xAt(seg.from), yAt(only.p95));
+      ctx.lineTo(xAt(seg.from), yAt(only.p5));
+      ctx.stroke();
+      continue;
+    }
+    ctx.beginPath();
+    for (let i = seg.from; i <= seg.to; i++) {
+      const x = xAt(i), y = yAt(points[i].p95);
+      if (i === seg.from) ctx.moveTo(x, y); else ctx.lineTo(x, y);
+    }
+    for (let i = seg.to; i >= seg.from; i--) ctx.lineTo(xAt(i), yAt(points[i].p5));
+    ctx.closePath();
+    ctx.fillStyle = seg.thin ? fillThin : fill;
+    ctx.fill();
+  }
+  ctx.restore();
 }
 
 // drawAutonomyBoundaries marks each instant where the data's source changes: a
@@ -1131,15 +1314,21 @@ function drawAutonomyXLabels(ctx, { duration, xAt, muted, h, padB }) {
 // drawAutonomySeries strokes one percentile line, breaking at every omitted
 // bucket and DASHING any segment that touches a thin bucket — so a bucket
 // under the sample floor is visibly different rather than hidden or smoothed.
-function drawAutonomySeries(ctx, { points, key, color, xAt, yAt }) {
+//
+// `role` decides the weight, not the colour: all three lines are one hue, and
+// what separates the headline p50 from the band's two edges is stroke width
+// and alpha (AUTONOMY_ROLE_STYLE).
+function drawAutonomySeries(ctx, { points, key, role, color, xAt, yAt }) {
+  const style = AUTONOMY_ROLE_STYLE[role] || AUTONOMY_ROLE_STYLE.line;
   ctx.strokeStyle = color;
-  ctx.lineWidth = 1.6;
+  ctx.lineWidth = style.width;
   for (let i = 1; i < points.length; i++) {
     const a = points[i - 1], b = points[i];
     if (!a || !b) continue; // a gap is a gap: never interpolate across it
+    const thin = a.thin || b.thin;
     ctx.save();
-    ctx.setLineDash(a.thin || b.thin ? [3, 3] : []);
-    ctx.globalAlpha = (a.thin || b.thin) ? 0.55 : 1;
+    ctx.setLineDash(thin ? [3, 3] : []);
+    ctx.globalAlpha = thin ? style.thinAlpha : style.alpha;
     ctx.beginPath();
     ctx.moveTo(xAt(i - 1), yAt(a[key]));
     ctx.lineTo(xAt(i), yAt(b[key]));
@@ -1153,17 +1342,19 @@ function drawAutonomySeries(ctx, { points, key, color, xAt, yAt }) {
     if (!b) continue;
     const isolated = !points[i - 1] && !points[i + 1];
     if (!b.thin && !isolated) continue;
+    ctx.save();
     ctx.beginPath();
-    ctx.arc(xAt(i), yAt(b[key]), 2.5, 0, Math.PI * 2);
+    ctx.arc(xAt(i), yAt(b[key]), style.marker, 0, Math.PI * 2);
     if (b.thin) {
       ctx.strokeStyle = color;
-      ctx.globalAlpha = 0.7;
+      ctx.globalAlpha = style.alpha * 0.8;
       ctx.stroke();
-      ctx.globalAlpha = 1;
     } else {
       ctx.fillStyle = color;
+      ctx.globalAlpha = style.alpha;
       ctx.fill();
     }
+    ctx.restore();
   }
 }
 
@@ -1351,25 +1542,30 @@ function paintAutonomyStripRow(canvas, mine, spans, cs) {
 // key at all. As a value it is testable; as a `style.background =` buried in a
 // render loop it was not.
 //
-// The first three rows ARE the chart's lines, so they carry the chart's own
-// colours (from AUTONOMY_SERIES, the same table the canvas strokes from) and
-// double as its key — the macOS surface says the same thing through Swift
-// Charts' legend. longest/shortest/runs are FIGURES, not lines, and stay
-// unswatched on purpose: a swatch would claim a curve the chart deliberately
-// does not draw.
+// The first TWO rows are the key, and they are the key because they are what
+// the chart draws: one line and one plane. Three swatches for three
+// percentiles distinguished nothing once the three curves became one hue —
+// worse, they promised a distinction the chart had stopped making. The
+// numbers did not collapse with the colours: p50 is the line row's value and
+// p5/p95 are the band row's, so all three figures are still on screen.
+//
+// longest/shortest/runs are FIGURES, not marks, and stay unswatched on
+// purpose: a swatch would claim ink the chart deliberately does not lay down.
 export function autonomyPanelRows(summary, cs) {
   const s = summary || {};
-  const line = (key, value) => ({
-    series: key,
-    label: AUTONOMY_SERIES_LABELS[key],
-    value,
-    swatch: autonomySeriesColor(key, cs),
-  });
-  const figure = (label, value) => ({ series: null, label, value, swatch: 'transparent' });
+  const [lineKey, bandKey] = autonomyKeyEntries(cs);
+  const figure = (label, value) => ({ kind: null, label, value, swatch: 'transparent', fill: '' });
   return [
-    line('p95', autonomyDuration(s.p95)),
-    line('p50', autonomyDuration(s.p50)),
-    line('p5', autonomyDuration(s.p5)),
+    { kind: lineKey.kind, label: lineKey.label, value: autonomyDuration(s.p50), swatch: lineKey.color, fill: lineKey.fill },
+    {
+      kind: bandKey.kind,
+      label: bandKey.label,
+      // Both ends of the band, in the order they read on the chart: bottom
+      // edge to top edge. One row, three figures still visible.
+      value: autonomyDuration(s.p5) + ' – ' + autonomyDuration(s.p95),
+      swatch: bandKey.color,
+      fill: bandKey.fill,
+    },
     figure('longest', autonomyDuration(s.max)),
     figure('shortest', autonomyDuration(s.min)),
     figure('runs', String(s.count || 0)),
@@ -1399,8 +1595,18 @@ function renderAutonomyPanel() {
     for (const row of autonomyPanelRows(s, getComputedStyle(document.documentElement))) {
       const li = document.createElement('li');
       const dot = document.createElement('span');
-      dot.className = 'dot';
-      dot.style.background = row.swatch;
+      // The two key swatches take the SHAPE of what they stand for — a rule
+      // for the line, a bounded plane for the band. A pair of identical dots
+      // in one hue would be a key that says nothing twice.
+      dot.className = row.kind ? 'dot autonomy-' + row.kind : 'dot';
+      if (row.kind === 'band') {
+        dot.style.background = row.fill;
+        dot.style.borderColor = row.swatch;
+      } else if (row.kind === 'line') {
+        dot.style.borderColor = row.swatch;
+      } else {
+        dot.style.background = row.swatch;
+      }
       const lbl = document.createElement('span');
       lbl.className = 'label';
       lbl.textContent = row.label;
@@ -1415,8 +1621,8 @@ function renderAutonomyPanel() {
     const thin = (duration.buckets || []).filter(b => b.thin).length;
     if (thin > 0) {
       appendHistoryEmpty(listEl, thin + ' of ' + duration.buckets.length + ' buckets hold fewer than '
-        + duration.sample_floor + ' runs (dashed, hollow): there p95 is that bucket’s longest run '
-        + 'and p5 its shortest — not percentiles.');
+        + duration.sample_floor + ' runs (fainter band, dashed edges, hollow points): there p95 is '
+        + 'that bucket’s longest run and p5 its shortest — not percentiles.');
     }
   }
   // The provenance line is part of the feature: "no data" must never read as

--- a/platforms/web/index.html
+++ b/platforms/web/index.html
@@ -280,19 +280,16 @@
             <option value="">Select a project…</option>
           </select>
         </div>
-        <div class="history-ctl-row" id="history-autonomy-row" hidden>
+        <!-- Range governs the duration chart below and nothing else. Span,
+             which governs the run strip, used to sit on this same row — one
+             row of controls above two elements, with nothing saying which
+             control moved which. Each now sits directly above the thing it
+             changes; Span lives in the strip's own header. -->
+        <div class="history-ctl-row" id="history-autonomy-range-row" hidden>
           <span class="history-ctl-label">Range</span>
           <fieldset class="history-seg" id="history-autonomy-range-sel" aria-label="Autonomy chart range">
             <button type="button" data-autonomy-range="30d" class="active">30 days</button>
             <button type="button" data-autonomy-range="1y">Year</button>
-          </fieldset>
-          <span class="history-ctl-label">Span</span>
-          <fieldset class="history-seg" id="history-autonomy-span-sel" aria-label="Autonomy strip span">
-            <button type="button" data-autonomy-span="8h">8h</button>
-            <button type="button" data-autonomy-span="24h" class="active">24h</button>
-            <button type="button" data-autonomy-span="7d">7d</button>
-            <button type="button" data-autonomy-span="30d">30d</button>
-            <button type="button" data-autonomy-span="12mo">12mo</button>
           </fieldset>
         </div>
         <div class="history-ctl-row" id="history-granularity-row" hidden>
@@ -365,7 +362,21 @@
            Full width under the chart because it is a SECOND element, not
            another rendering of the first. -->
       <section class="history-autonomy" id="history-autonomy-strip" hidden aria-label="Autonomous runs">
-        <div class="history-autonomy-title" id="history-autonomy-strip-title">Runs</div>
+        <!-- The strip's own header row: its title and the Span picker that
+             changes it, together. Span is NOT the chart's Range — the two
+             elements answer different questions over different windows, and
+             a shared control row above both said otherwise. -->
+        <div class="history-autonomy-header">
+          <div class="history-autonomy-title" id="history-autonomy-strip-title">Runs</div>
+          <span class="history-ctl-label">Span</span>
+          <fieldset class="history-seg" id="history-autonomy-span-sel" aria-label="Autonomy strip span">
+            <button type="button" data-autonomy-span="8h">8h</button>
+            <button type="button" data-autonomy-span="24h" class="active">24h</button>
+            <button type="button" data-autonomy-span="7d">7d</button>
+            <button type="button" data-autonomy-span="30d">30d</button>
+            <button type="button" data-autonomy-span="12mo">12mo</button>
+          </fieldset>
+        </div>
         <div class="history-autonomy-rows" id="history-autonomy-rows"></div>
         <div class="history-autonomy-legend" id="history-autonomy-legend"></div>
         <div class="history-autonomy-note" id="history-autonomy-note"></div>

--- a/platforms/web/irrlicht.css
+++ b/platforms/web/irrlicht.css
@@ -46,6 +46,24 @@
          differs per theme AND from the macOS side). Like --cancelled, it is
          defined once: a mid-grey that reads on both light and dark surfaces. */
       --unknown: #8E8E93;
+      /* Autonomy chart (#1905) — ONE hue, three weights. The p50 line is
+         --working at full strength; the p5–p95 band is the same hue as a
+         translucent plane, and its two edges the same hue again, quiet enough
+         to read as the band's boundary rather than as two more curves.
+         Tokens rather than an rgba typed into the canvas painter, because the
+         two grounds need different alphas and a literal cannot have two
+         values: on #0f1628 a violet wash has to LIGHTEN the surface to show
+         at all, while on #ffffff the same alpha reads as a solid lavender
+         block that shouts louder than the line it surrounds. Measured by eye
+         against .history-chart-wrap's --surface in both themes.
+         All three are the --working RGB triple; `the band is the p50 hue, not
+         a fourth colour` in irrlicht.history.autonomy.test.js pins that. */
+      --autonomy-band: rgba(139, 92, 246, 0.20);
+      /* Thin buckets (under sample_floor) keep their own, fainter plane: there
+         p95 IS the maximum and p5 IS the minimum, so the area is a range, not
+         a percentile spread, and must not read as one. */
+      --autonomy-band-thin: rgba(139, 92, 246, 0.08);
+      --autonomy-edge: rgba(139, 92, 246, 0.45);
       /* Pressure-bar colors — mirror overlay's ContextBarColor / pressure_level mapping:
          safe → low, caution → medium, warning → high, critical → critical. */
       --pressure-low: #34C759;
@@ -90,6 +108,15 @@
         --waiting-dim: rgba(136, 79, 0, 0.12);
         --ready: #207936;
         --ready-dim: rgba(32, 121, 54, 0.12);
+        /* Autonomy band, re-tuned for the light ground (see the dark block).
+           Two things change at once and both push the alpha DOWN: the hue is
+           the darker light-theme --working (#6526F3), and the surface under it
+           is #ffffff rather than #0f1628, so the same 0.20 that reads as a
+           faint haze on the dark card reads as a solid lavender slab here —
+           louder than the p50 line it is supposed to sit behind. */
+        --autonomy-band: rgba(101, 38, 243, 0.11);
+        --autonomy-band-thin: rgba(101, 38, 243, 0.05);
+        --autonomy-edge: rgba(101, 38, 243, 0.38);
         /* #1801, same rule as the three above and measured the same way. The
            dark --error (#FF3B30) reads 3.01:1 against its own 12% wash on
            --surface #ffffff — under the 4.5:1 minimum, and the worst possible
@@ -126,6 +153,10 @@
       --waiting-dim: rgba(136, 79, 0, 0.12);
       --ready: #207936;
       --ready-dim: rgba(32, 121, 54, 0.12);
+      /* See the matching comment in the media-query block above. */
+      --autonomy-band: rgba(101, 38, 243, 0.11);
+      --autonomy-band-thin: rgba(101, 38, 243, 0.05);
+      --autonomy-edge: rgba(101, 38, 243, 0.38);
       --error: #CC0C00;
       --error-dim: rgba(204, 12, 0, 0.12);
     }
@@ -1765,6 +1796,15 @@
       font-family: var(--font-mono); font-size: 11px; letter-spacing: 0.08em;
       text-transform: uppercase; color: var(--muted); margin-bottom: 8px;
     }
+    /* The strip's header: its title and the Span picker that changes it, on
+       one row. Span used to sit above BOTH elements next to the chart's
+       Range, which said the two controls governed the same thing. Wraps
+       rather than compressing, so a narrow window stacks the picker under the
+       title instead of squeezing the segmented buttons. */
+    .history-autonomy-header {
+      display: flex; align-items: center; flex-wrap: wrap; gap: 8px 10px; margin-bottom: 8px;
+    }
+    .history-autonomy-header .history-autonomy-title { margin-bottom: 0; margin-right: auto; }
     .history-autonomy-row {
       display: grid; grid-template-columns: 140px 1fr 56px;
       align-items: center; gap: 10px; margin-bottom: 6px;
@@ -1907,6 +1947,19 @@
     }
     .history-contrib li { display: flex; align-items: center; gap: 8px; font-family: var(--font-mono); font-size: 12px; }
     .history-contrib .dot { width: 9px; height: 9px; border-radius: 2px; flex-shrink: 0; }
+    /* The Autonomy key's two swatches (#1905 redesign). The chart draws one
+       line and one plane in a single hue, so the key has to distinguish them
+       by SHAPE — two identically-coloured dots would be a key that says the
+       same thing twice. Colours come from the JS resolvers (the same calls the
+       canvas painter makes), never from here. */
+    .history-contrib .dot.autonomy-line {
+      width: 16px; height: 0; border-radius: 0; background: none;
+      border-top: 2px solid currentColor;
+    }
+    .history-contrib .dot.autonomy-band {
+      width: 16px; height: 10px; border-radius: 1px;
+      border-top: 1px solid currentColor; border-bottom: 1px solid currentColor;
+    }
     .history-contrib .label { color: var(--text); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
     .history-contrib .val { margin-left: auto; color: var(--text-bright); }
     /* Drilldown affordance: contributors you can click to scope into. */

--- a/platforms/web/irrlicht.css
+++ b/platforms/web/irrlicht.css
@@ -1961,7 +1961,29 @@
       border-top: 1px solid currentColor; border-bottom: 1px solid currentColor;
     }
     .history-contrib .label { color: var(--text); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-    .history-contrib .val { margin-left: auto; color: var(--text-bright); }
+    /* A figure is never split across two lines: "6s – 23m46s" broken after
+       the dash reads as two separate numbers rather than as one span. The
+       label shrinks and ellipsises instead, which is the right priority —
+       the figure is the thing being reported. */
+    .history-contrib .val { margin-left: auto; color: var(--text-bright); white-space: nowrap; }
+    /* The two Autonomy key rows are the only rows here carrying BOTH a
+       sentence and a two-ended figure, and one 228px line cannot hold them:
+       the label wants 180px and the value another 79px against a 196px
+       budget once the swatch and gaps are out (the arithmetic is in
+       autonomyLayout.test.js, computed from this stylesheet). Shipped as one
+       flex line it ellipsised the very label whose job is to explain the
+       band, and wrapped the range mid-figure.
+       So the value takes a line of its own, right-aligned in the same column
+       the figures below use, and the label is allowed to WRAP rather than
+       ellipsise: a truncated explanation is unreadable, a wrapped one is
+       merely taller. Both key rows lay out the same way even though `p50`
+       alone would fit — they are a matched pair and must read as one. */
+    .history-contrib li.autonomy-key { flex-wrap: wrap; }
+    .history-contrib li.autonomy-key .label {
+      white-space: normal; overflow: visible; text-overflow: clip;
+      flex: 1 1 auto; min-width: 0;
+    }
+    .history-contrib li.autonomy-key .val { flex: 0 0 100%; margin-left: 0; text-align: right; }
     /* Drilldown affordance: contributors you can click to scope into. */
     .history-contrib li.drillable { cursor: pointer; border-radius: 4px; margin: 0 -6px; padding: 2px 6px; }
     .history-contrib li.drillable:hover { background: var(--surface-hover); }

--- a/platforms/web/irrlicht.history.autonomy.test.js
+++ b/platforms/web/irrlicht.history.autonomy.test.js
@@ -5,12 +5,17 @@ import {
   AUTONOMY_SPAN_LABELS,
   AUTONOMY_REASON_PRIORITY,
   AUTONOMY_SERIES,
+  AUTONOMY_BAND_TOKENS,
   autonomyQuery,
   autonomyChartPoints,
+  autonomyBandSegments,
   autonomyDuration,
   autonomyProvenanceLine,
   autonomyAxisLabel,
   autonomySeriesColor,
+  autonomySeriesRole,
+  autonomyBandColor,
+  autonomyKeyEntries,
   autonomyPanelRows,
   buildAutonomyStripHeader,
   buildAutonomyStripAxis,
@@ -177,15 +182,28 @@ describe('“no data” never reads as “you did nothing”', () => {
   })
 })
 
-describe('the chart names its three lines', () => {
-  // QA found three unlabelled curves on the web: the panel built p95/p50/p5
-  // rows and then blanked every swatch (`background = 'transparent'`), so the
-  // only way to tell the lines apart was vertical order. These pin the key.
+describe('the chart is one hue in three weights', () => {
+  // The first round drew p95 green, p50 purple and p5 orange — three equally
+  // loud curves, and a key that had to be decoded before the chart said
+  // anything. It says one thing now: here is the typical run, and here is the
+  // spread around it. These pin that the collapse actually happened, in the
+  // one table both the canvas and the panel read.
   //
   // `cs` here returns '' for every custom property, which is what an unstyled
   // document (and jsdom) gives — so this exercises the fallback branch, the
   // one a stylesheet-less render actually takes.
   const unstyled = { getPropertyValue: () => '' }
+
+  // rgb triple of a '#rrggbb' or 'rgba(r, g, b, a)' literal, as a string.
+  // Throws on anything else rather than returning a value nothing can trust:
+  // a colour this cannot parse is the last place to drop the comparison.
+  const rgbOf = (color) => {
+    const hex = /^#([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})$/i.exec(color)
+    if (hex) return hex.slice(1).map(h => parseInt(h, 16)).join(',')
+    const fn = /^rgba?\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)/i.exec(color)
+    if (fn) return fn.slice(1, 4).join(',')
+    throw new Error(`fail-loud: cannot read an rgb triple out of "${color}"`)
+  }
 
   test('every drawn line resolves to a non-empty colour', () => {
     for (const [key] of AUTONOMY_SERIES) {
@@ -193,63 +211,236 @@ describe('the chart names its three lines', () => {
     }
   })
 
-  test('the three line colours are distinct', () => {
+  // The inversion of the old `the three line colours are distinct`. Distinct
+  // hues are what the redesign removed: p95 and p5 are the two EDGES of one
+  // range, and a hue each made them read as two independent measurements.
+  test('the three lines share one colour, and roles carry the difference', () => {
     const colors = AUTONOMY_SERIES.map(([key]) => autonomySeriesColor(key, unstyled))
-    expect(new Set(colors).size).toBe(AUTONOMY_SERIES.length)
+    expect(new Set(colors).size).toBe(1)
+    expect(AUTONOMY_SERIES.map(([key]) => autonomySeriesRole(key))).toEqual(['edge', 'line', 'edge'])
+    // Exactly one headline line, or "the typical run" is ambiguous.
+    expect(AUTONOMY_SERIES.filter(([, role]) => role === 'line')).toHaveLength(1)
   })
 
   test('the series table covers exactly the three drawn lines', () => {
     expect(AUTONOMY_SERIES.map(([key]) => key)).toEqual(['p95', 'p50', 'p5'])
   })
 
-  test('a key that is not a drawn line gets no colour', () => {
+  test('a key that is not a drawn line gets no colour and no role', () => {
     // longest/shortest/runs are FIGURES, not lines. A swatch for one of them
     // would claim a curve the chart deliberately does not draw.
     expect(autonomySeriesColor('longest', unstyled)).toBe('')
     expect(autonomySeriesColor('p90', unstyled)).toBe('')
+    expect(autonomySeriesRole('p90')).toBe('')
   })
 
   test('a themed document wins over the fallback', () => {
-    const themed = { getPropertyValue: (name) => (name === '--ready' ? ' #123456 ' : '') }
+    const themed = { getPropertyValue: (name) => (name === '--working' ? ' #123456 ' : '') }
+    expect(autonomySeriesColor('p50', themed)).toBe('#123456')
     expect(autonomySeriesColor('p95', themed)).toBe('#123456')
-    expect(autonomySeriesColor('p50', themed)).toBe('#8B5CF6')
   })
 
-  // THE DEFECT ITSELF. The panel used to build these rows and then set every
-  // dot to `transparent`, so the key existed in the markup and said nothing.
-  // Asserting on the resolver alone would not have caught that; these assert
-  // on the rows the panel actually renders.
+  // The band is a WEIGHT of the line's hue, not a fourth colour. Were it an
+  // independent value, "one hue" would hold for the three strokes and quietly
+  // fail for the largest area of ink on the chart.
+  test('the band is the p50 hue, not a fourth colour', () => {
+    const line = rgbOf(autonomySeriesColor('p50', unstyled))
+    for (const name of Object.keys(AUTONOMY_BAND_TOKENS)) {
+      expect(rgbOf(autonomyBandColor(name, unstyled)), `${name} is a different hue from the p50 line`)
+        .toBe(line)
+    }
+  })
+
+  test('a band token that does not exist resolves to nothing', () => {
+    expect(autonomyBandColor('nope', unstyled)).toBe('')
+  })
+
+  test('a themed document wins over the band fallback too', () => {
+    const themed = { getPropertyValue: (name) => (name === '--autonomy-band' ? ' rgba(1, 2, 3, 0.5) ' : '') }
+    expect(autonomyBandColor('fill', themed)).toBe('rgba(1, 2, 3, 0.5)')
+  })
+})
+
+describe('the key has two entries, and both come from the chart’s own tables', () => {
+  const unstyled = { getPropertyValue: () => '' }
+
+  // Two entries because the chart draws two things. Three percentile swatches
+  // in one hue would promise a distinction the chart stopped making.
+  test('exactly two entries: a line and a band', () => {
+    const entries = autonomyKeyEntries(unstyled)
+    expect(entries).toHaveLength(2)
+    expect(entries.map(e => e.kind)).toEqual(['line', 'band'])
+  })
+
+  test('both entries resolve from the one colour table, never a second one', () => {
+    const drawn = new Set(AUTONOMY_SERIES.map(([key]) => autonomySeriesColor(key, unstyled)))
+    const band = new Set(Object.keys(AUTONOMY_BAND_TOKENS).map(n => autonomyBandColor(n, unstyled)))
+    for (const entry of autonomyKeyEntries(unstyled)) {
+      // `from` names a row of AUTONOMY_SERIES — not a label a caller invented.
+      expect(AUTONOMY_SERIES.some(([key]) => key === entry.from)).toBe(true)
+      expect(drawn.has(entry.color) || band.has(entry.color)).toBe(true)
+    }
+    const [line, area] = autonomyKeyEntries(unstyled)
+    expect(line.color).toBe(autonomySeriesColor('p50', unstyled))
+    expect(area.fill).toBe(autonomyBandColor('fill', unstyled))
+    expect(area.color).toBe(autonomyBandColor('edge', unstyled))
+    // A line has no area; a swatch with a fill would claim one.
+    expect(line.fill).toBe('')
+  })
+
+  test('a themed document moves the key with the chart', () => {
+    const themed = { getPropertyValue: (name) => (name === '--working' ? '#abcdef' : '') }
+    expect(autonomyKeyEntries(themed)[0].color).toBe('#abcdef')
+    expect(autonomyKeyEntries(themed)[0].color).toBe(autonomySeriesColor('p50', themed))
+  })
+
+  // Both labels name the percentile AND say what it means in words, because
+  // "p5–p95" is not a thing a reader who has never seen a percentile can read.
+  test('each entry names its percentiles and explains them in words', () => {
+    const [line, area] = autonomyKeyEntries(unstyled)
+    expect(line.label).toContain('p50')
+    expect(line.label).toContain('the typical run')
+    expect(area.label).toContain('p5')
+    expect(area.label).toContain('p95')
+    expect(area.label.replace(/p5|p95/g, '').trim().length).toBeGreaterThan(6)
+  })
+})
+
+describe('the panel keeps every figure the key stopped colouring', () => {
+  // THE ORIGINAL DEFECT still stands guard here: the panel used to build these
+  // rows and then set every dot to `transparent`, so the key existed in the
+  // markup and said nothing. Asserting on the resolver alone would not have
+  // caught that; these assert on the rows the panel actually renders.
   const summary = { p95: 3600, p50: 600, p5: 30, min: 8, max: 7200, count: 312 }
   const unstyledCS = { getPropertyValue: () => '' }
 
-  test('the three line rows carry non-empty, distinct swatches', () => {
+  test('the two key rows carry a real swatch, and the band row carries a fill', () => {
     const rows = autonomyPanelRows(summary, unstyledCS)
-    const lines = rows.filter(r => r.series)
-    expect(lines.map(r => r.series)).toEqual(['p95', 'p50', 'p5'])
-    for (const row of lines) {
+    const keyed = rows.filter(r => r.kind)
+    expect(keyed.map(r => r.kind)).toEqual(['line', 'band'])
+    for (const row of keyed) {
       expect(row.swatch).toBeTruthy()
       expect(row.swatch).not.toBe('transparent')
     }
-    expect(new Set(lines.map(r => r.swatch)).size).toBe(3)
+    expect(keyed[1].fill).toBeTruthy()
+    expect(keyed[0].fill).toBe('')
   })
 
-  test('the figures stay unswatched — they are not lines', () => {
-    const figures = autonomyPanelRows(summary, unstyledCS).filter(r => !r.series)
+  // The colours collapsed; the NUMBERS did not. All three percentiles are
+  // still on screen — p50 as the line row's value, p5 and p95 as the band's.
+  test('p50, p5 and p95 all still show their figures', () => {
+    const rows = autonomyPanelRows(summary, unstyledCS)
+    expect(rows[0].value).toBe(autonomyDuration(600))
+    expect(rows[1].value).toContain(autonomyDuration(30))
+    expect(rows[1].value).toContain(autonomyDuration(3600))
+  })
+
+  test('the figures stay unswatched — they are not marks', () => {
+    const figures = autonomyPanelRows(summary, unstyledCS).filter(r => !r.kind)
     expect(figures.map(r => r.label)).toEqual(['longest', 'shortest', 'runs'])
     for (const row of figures) expect(row.swatch).toBe('transparent')
   })
 
-  test('every line row names its percentile in words', () => {
-    for (const row of autonomyPanelRows(summary, unstyledCS).filter(r => r.series)) {
-      expect(row.label).toContain(row.series)
-      expect(row.label.length).toBeGreaterThan(row.series.length)
+  test('an empty summary still produces the full panel', () => {
+    const rows = autonomyPanelRows(undefined, unstyledCS)
+    expect(rows).toHaveLength(5)
+    expect(rows[4].value).toBe('0')
+  })
+})
+
+describe('autonomyBandSegments — the plane breaks where the line breaks', () => {
+  const bucket = (ts, thin = false) => ({ ts, p95: 90, p50: 50, p5: 10, min: 10, max: 90, count: thin ? 3 : 30, thin })
+
+  // THE RULE A FILL WANTS TO BREAK. A line drawn across a gap interpolates; a
+  // polygon drawn across one paints a whole plane over days that hold no runs.
+  test('a segment never spans an empty bucket', () => {
+    const points = autonomyChartPoints({
+      bucket_starts: [100, 200, 300, 400, 500],
+      buckets: [{ ts: 100, p95: 90, p50: 50, p5: 10 }, { ts: 200, p95: 80, p50: 40, p5: 8 },
+                { ts: 400, p95: 70, p50: 30, p5: 6 }, { ts: 500, p95: 60, p50: 20, p5: 4 }],
+    })
+    const segments = autonomyBandSegments(points)
+    expect(segments.map(s => [s.from, s.to])).toEqual([[0, 1], [3, 4]])
+    // Stated as the property, not just the shape: no segment may contain the
+    // index of a bucket the daemon omitted.
+    for (const seg of segments) {
+      for (let i = seg.from; i <= seg.to; i++) expect(points[i]).not.toBeNull()
     }
   })
 
-  test('an empty summary still produces the full key', () => {
-    const rows = autonomyPanelRows(undefined, unstyledCS)
-    expect(rows).toHaveLength(6)
-    expect(rows[5].value).toBe('0')
+  // THE COMMITTED MUTATION: the "one polygon over everything present" build —
+  // the shape a fill takes by default, and the shape that silently claims the
+  // gap. It answers identically for a gapped range and an unbroken one;
+  // production must not.
+  test('production tells a gapped range from an unbroken one', () => {
+    const gapped = autonomyChartPoints({
+      bucket_starts: [1, 2, 3],
+      buckets: [{ ts: 1, p95: 9, p50: 5, p5: 1 }, { ts: 3, p95: 9, p50: 5, p5: 1 }],
+    })
+    const whole = autonomyChartPoints({
+      bucket_starts: [1, 2, 3],
+      buckets: [{ ts: 1, p95: 9, p50: 5, p5: 1 }, { ts: 2, p95: 9, p50: 5, p5: 1 },
+                { ts: 3, p95: 9, p50: 5, p5: 1 }],
+    })
+
+    const bridging = (pts) => [{ from: 0, to: pts.length - 1, thin: false }]
+    expect(bridging(gapped)).toEqual(bridging(whole))
+
+    expect(autonomyBandSegments(whole)).toEqual([{ from: 0, to: 2, thin: false }])
+    expect(autonomyBandSegments(gapped)).not.toEqual(autonomyBandSegments(whole))
+    // The gapped range is TWO isolated buckets, and a bridging build would
+    // have drawn one plane straight over the empty day between them.
+    expect(autonomyBandSegments(gapped)).toEqual([
+      { from: 0, to: 0, thin: false },
+      { from: 2, to: 2, thin: false },
+    ])
+  })
+
+  // A thin bucket's p95 IS its maximum and its p5 IS its minimum. Inside one
+  // smooth plane that distinction disappears, so the plane splits there and
+  // the thin stretch is filled from its own fainter token.
+  test('a thin stretch is its own segment, and the seam is shared', () => {
+    const points = [bucket(1), bucket(2), bucket(3, true), bucket(4), bucket(5)]
+    const segments = autonomyBandSegments(points)
+    expect(segments.map(s => [s.from, s.to, s.thin])).toEqual([
+      [0, 1, false],
+      [1, 3, true],
+      [3, 4, false],
+    ])
+    // Adjacent segments SHARE their boundary index — a seam would show as a
+    // hairline crack down the band.
+    for (let i = 1; i < segments.length; i++) {
+      expect(segments[i].from).toBe(segments[i - 1].to)
+    }
+  })
+
+  test('a thin bucket makes both of its intervals thin, matching the dashed stroke', () => {
+    // The stroke dashes a segment either of whose ends is thin; the fill must
+    // split on the same rule or the dashes and the plane disagree.
+    const segments = autonomyBandSegments([bucket(1), bucket(2, true), bucket(3)])
+    expect(segments).toEqual([{ from: 0, to: 2, thin: true }])
+  })
+
+  test('an all-thin range is one faint segment, never mistaken for a measured one', () => {
+    const segments = autonomyBandSegments([bucket(1, true), bucket(2, true), bucket(3, true)])
+    expect(segments).toEqual([{ from: 0, to: 2, thin: true }])
+  })
+
+  // A lone bucket has no neighbour to make an area with. It is reported as a
+  // zero-width segment so the painter can draw its spread as a whisker rather
+  // than leaving the one bucket that most needs a range with none.
+  test('an isolated bucket is a zero-width segment, not a dropped one', () => {
+    const points = autonomyChartPoints({
+      bucket_starts: [1, 2, 3],
+      buckets: [{ ts: 2, p95: 9, p50: 5, p5: 1 }],
+    })
+    expect(autonomyBandSegments(points)).toEqual([{ from: 1, to: 1, thin: false }])
+  })
+
+  test('an empty or absent axis produces no segments at all', () => {
+    expect(autonomyBandSegments([])).toEqual([])
+    expect(autonomyBandSegments(null)).toEqual([])
+    expect(autonomyBandSegments([null, null])).toEqual([])
   })
 })
 


### PR DESCRIPTION
Redesigns the Autonomy duration chart on both surfaces (#1905, following #1912 and #1914). Presentation only — no back-fill tool, span store, API or strip-colour changes.

## 1. One hue, three weights

The chart drew p95 green, p50 purple and p5 orange: three equally loud curves that had to be decoded before the chart said anything. A hue per percentile also made p95 and p5 read as two independent measurements rather than as the two edges of one range.

Now the p5–p95 area is a translucent plane in the p50 hue, the two edges are the same hue at low weight, and the p50 line carries the ink. `AUTONOMY_SERIES` / `AutonomyPalette.seriesColors` stay the one colour table, gaining a **role** (`line` / `edge`) that decides stroke weight and alpha in place of the colour that used to.

The fill is a **token**, never a literal: `--autonomy-band`, `--autonomy-band-thin`, `--autonomy-edge` on the web, `IrrColors.autonomyBand/…Thin/…Edge` on macOS. Alphas differ per ground because one literal cannot serve both — a violet wash has to *lighten* the dark card (`--surface` `#0f1628`) to register at all, and the same alpha reads as a solid lavender slab on white. Dark 0.20 / 0.08 / 0.45, light 0.11 / 0.05 / 0.38, and a test pins every one of them to the `--working` RGB triple in both appearances, so the band cannot quietly become a fourth colour.

Draw order: gridlines → band → boundary rules → edges → p50. The band goes **over** the gridlines; drawn on top of the plane a gridline slices it into structure that is not in the data. Under it, the fill's own translucency dims each crossing, so the gridline stays legible and stays furniture.

## 2. The key changed rather than disappeared

Two entries, because the chart draws two things:

- **line** — `p50 · the typical run`
- **band** — `p5–p95 · the usual spread`

Each swatch takes the shape of what it stands for (a rule; a bounded plane) — two identical dots in one hue would be a key that says the same thing twice. Both resolve through the same calls the painter makes, so a swatch cannot disagree with the ink beside it; on macOS the Swift Charts legend derived from `seriesOrder` is hidden and `AutonomyKeyView` draws these two instead. **The p95/p50/p5 figures stay**: p50 is the line row's value, p5 and p95 are the band row's (`41s – 1h58m`).

## 3. Both honesty rules survive the smoother shape

- **The band breaks at a gap.** `autonomyBandSegments` / `AutonomyBandLayout.segments` split the aligned point list at every omitted bucket, so a filled area cannot close over a day with no runs. Adjacent segments share their boundary index (no seam); an isolated bucket comes back as a zero-width segment and is drawn as a p5–p95 whisker rather than left as the one bucket with no visible range.
  - **macOS also had this defect for its *lines*** — `data3` iterated `buckets` (which omits empties), so Swift Charts connected straight across. Fixed with `alignedBuckets` plus one line *series* per contiguous stretch.
- **Thin buckets stay visibly different** inside the band: their own fainter plane, dashed edges, hollow points. Thinness belongs to the *interval*, matching the stroke rule, so the dashes and the plane cannot disagree about where the thin stretch is. Both panel sentences name all three signals.

## 4. Controls moved to what they control

Range governs the chart; Span governs the strip. They shared one row above both, and the vocabularies overlap textually (`30d` is a Range value *and* a Span value), so the row read as one zoom control with an odd set of steps. Range now sits in its own row above the chart; Span moved into the run strip's own section header — a flex header row on the web, an `HStack` beside "Runs · last …" on macOS (`spanWindow` became a `@Binding`).

## 5. The macOS boundary-caption defect

`← cost log · 60s resolution` was pinned to its rule's **left** unconditionally. It is a fixed string most of the plot wide at 9 pt, so a rule in the left third had less room than the caption needed, SwiftUI clamped the annotation to the chart's leading edge, and the caption ended up detached with its arrow pointing off-chart. It now hangs off whichever side of the rule has more room (`AutonomyBoundaryCaption.side`), which cannot be clamped unless the caption is wider than half the plot; the arrow keeps its meaning either way, pointing across the rule at the era to its left.

**Confirmed in QA** on the running app: the caption now sits directly above its rule at ~36% across, and the rule reads as a marker rather than as a gridline.

While there: the boundary rule is now a long-dashed 1.5 pt line and both axes' gridlines are explicit solid 0.5 pt hairlines, so the one line on the chart that carries an explanation no longer looks like the ones that carry nothing.

## Testing

Every added check was **seen red against a mutated production build**, then green:

| mutation applied to production | goes red |
|---|---|
| band segments bridge gaps (one polygon over everything present) | 5 web + 4 macOS |
| caption always hangs left | 2 macOS |
| `p95` back to a second hue (`--ready` / `IrrColors.ready`) | 3 web + 1 macOS |
| band token given a different hue | 1 web + 1 macOS |
| a third key entry from a second colour table | 2 web |
| both pickers back on one control row | committed JSDOM fixture |

The mutations are committed as fixtures inside the tests (`bridging`, `alwaysLeft`, the one-row JSDOM document), in the idiom the sibling suites already use.

Preflight, each `--only` group its own foreground run: **`web` PASS** — `npm test` in `platforms/web` reports 28 files / 586 tests, and the onboarding-factory viewer 8 / 120, **`swift` PASS**. The pre-push hook's scoped run reported both PASS and every Go/replay gate SKIP.

## QA-1 (fixed in 4c6ab0d6)

QA found the band row truncating in the web side panel: `p5–p95 · where most runs…` with an ellipsis, and its value split across two lines as `6s –` / `23m46s`. The panel is `flex: 0 0 260px` with 16px padding — 228px of content, 196px for label + value once the swatch and gaps are out. At 12px monospace the row wanted 208.8 + 79.2 = **288px, 47% over**, so no single-line layout holds it. Both levers moved:

- **Layout.** The key rows wrap: the value takes its own line, right-aligned in the figures' column, which gives the label 204px. The label now *wraps* rather than ellipsises, and `.history-contrib .val` is `white-space: nowrap` panel-wide so no figure is ever split mid-range. Both key rows lay out identically even though `p50` alone fits — they are a matched pair.
- **Words.** 204px is still 4.8px short of the 29-character label, so it would have wrapped raggedly at the shipped width. It becomes `p5–p95 · the usual spread` (25 chars, 180px — 24px of slack), which keeps the percentile pair and the plain-English register, and pairs with `the typical run` as noun phrases. **macOS carries the identical string**; `the usual range` and `the common span` were rejected because Range and Span are the names of the two controls directly above these elements.

The width budget is computed *from the stylesheet* (panel basis, padding, swatch, gap, font-size all parsed), so narrowing the panel fails the test instead of silently re-truncating; the 0.6em monospace advance is the single estimate and is labelled as one. A cross-surface pin reads `AutonomyPalette.keyEntries` out of `HistoryAutonomyView.swift` and compares it to the web's rows — the `sessionError.test.js`/`testBoundaryLabelsMatchTheWebs` technique. Six more mutations seen red: the shipped 29-char label, a 200px panel, `.val` without `nowrap`, rows that stop carrying the `autonomy-key` class, and a macOS-only wording change in both directions.

## Judgement calls not covered by the brief

- **The band row's value is a range** (`p5 – p95`), which is how all three figures stayed on screen with only two key entries.
- **An isolated bucket gets a whisker.** A zero-width polygon draws nothing, and dropping it would leave the one bucket with the least context as the only one showing no spread.
- **The web key swatch's edges use the full `--autonomy-edge` token**, so the swatch reads slightly heavier than the chart's edges at 16 px. Intentional — a swatch at that size needs the extra weight to read as bounded at all.
- **Both key rows are two-line, not just the one that needs it.** Letting `p50` stay on one line while `p5–p95` wrapped would break the matched pair the wording works to establish.
- **macOS keeps `#8B5CF6` in both appearances** (the web light theme retunes `--working` to `#6526F3`). Pre-existing divergence; not touched here.

Not merged — for QA on the running app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rw2jkcKiLcYdGavEWDeRRB
